### PR TITLE
Remove unnecessary warnings

### DIFF
--- a/ZAPDTR/ZAPD/Main.cpp
+++ b/ZAPDTR/ZAPD/Main.cpp
@@ -188,14 +188,7 @@ int main(int argc, char* argv[])
 		}
 		else if (arg == "-eh")  // Enable Error Handler
 		{
-#if !defined(_MSC_VER) && !defined(__CYGWIN__)
-			signal(SIGSEGV, ErrorHandler);
-			signal(SIGABRT, ErrorHandler);
-#else
-			HANDLE_WARNING(WarningType::Always,
-			               "tried to set error handler, but this ZAPD build lacks support for one",
-			               "");
-#endif
+			
 		}
 		else if (arg == "-v")  // Verbose
 		{

--- a/ZAPDTR/ZAPD/Main.cpp
+++ b/ZAPDTR/ZAPD/Main.cpp
@@ -188,7 +188,16 @@ int main(int argc, char* argv[])
 		}
 		else if (arg == "-eh")  // Enable Error Handler
 		{
-			
+	#if !defined(_MSC_VER) && !defined(__CYGWIN__)
+			signal(SIGSEGV, ErrorHandler);
+			signal(SIGABRT, ErrorHandler);
+#else
+			// HANDLE_WARNING(WarningType::Always,
+			//                "tried to set error handler, but this ZAPD build lacks support for one",
+			//                "");
+#endif
+
+
 		}
 		else if (arg == "-v")  // Verbose
 		{


### PR DESCRIPTION
This removes all those warnings that were cluttering up the OTR builder's console output. I could also remove the `-eh` flag, but I figured it might have some other use and this seemed like the simplest way to do it.