### PR TITLE
Fixed window not properly disposing raylib and OpenGL when closing.

### DIFF
--- a/OTRGui/src/game/game.cpp
+++ b/OTRGui/src/game/game.cpp
@@ -116,7 +116,7 @@ void OTRGame::draw() {
 		DrawTexture(titleTex, windowSize.x / 2 - titleTex.width / 2, titlebar.height / 2 - titleTex.height / 2, WHITE);
 
 		if (UIUtils::GuiIcon("Exit", windowSize.x - 36, titlebar.height / 2 - 10) && (extracting && currentStep.find("Done") != std::string::npos || !extracting)) {
-			CloseWindow();
+			closeRequested = true;
 		}
 
 		BeginMode3D(camera);
@@ -157,7 +157,7 @@ void OTRGame::draw() {
 			UIUtils::GuiShadowText(currentStep.c_str(), 0, windowSize.y / 2, 10, WHITE, BLACK, windowSize.x, true);
 		}
 
-    EndDrawing();
+	EndDrawing();
 }
 
 void setCurrentStep(const std::string& step) {

--- a/OTRGui/src/game/game.h
+++ b/OTRGui/src/game/game.h
@@ -19,6 +19,8 @@ public:
     void update();
     void draw();
     void exit();
+
+    inline bool CloseRequested() { return closeRequested; }
 protected:
     void LoadTexture(const std::string& name, const std::string& path) {
         const Image tmp = LoadImage(path.c_str());
@@ -32,6 +34,9 @@ protected:
         SetTextureFilter(font.texture, TEXTURE_FILTER_POINT);
         Fonts[name] = font;
     }
+
+private:
+    bool closeRequested = false;
 };
 
 extern OTRGame* Game;

--- a/OTRGui/src/main.cpp
+++ b/OTRGui/src/main.cpp
@@ -17,7 +17,7 @@ void UpdateDrawFrame(void) {
 }
 
 int main() {
-	constexpr Vector2 windowSize = Vector2(400, 200);
+    constexpr Vector2 windowSize = Vector2(400, 200);
     SetTargetFPS(144);
     SetConfigFlags(FLAG_WINDOW_HIGHDPI);
     SetConfigFlags(FLAG_WINDOW_UNDECORATED);
@@ -32,7 +32,7 @@ int main() {
     Game = new OTRGame();
     Game->preload();
     Game->init();
-    while(!WindowShouldClose()) {
+    while(!WindowShouldClose() && !Game->CloseRequested()) {
         UpdateDrawFrame();
     }
     CloseWindow();


### PR DESCRIPTION
Closing the window with the X button will not close it immediately during the rendering of a frame, causing it to actually crash, but will set the engine in a pending state until it finishes the current frame.