### PR TITLE
Fixed transparent texture making framebuffers also transparent in D3D11.

### DIFF
--- a/libultraship/libultraship/Lib/Fast3D/gfx_direct3d11.cpp
+++ b/libultraship/libultraship/Lib/Fast3D/gfx_direct3d11.cpp
@@ -531,8 +531,8 @@ static struct ShaderProgram *gfx_d3d11_create_and_load_new_shader(uint64_t shade
         blend_desc.RenderTarget[0].SrcBlend = D3D11_BLEND_SRC_ALPHA;
         blend_desc.RenderTarget[0].DestBlend = D3D11_BLEND_INV_SRC_ALPHA;
         blend_desc.RenderTarget[0].BlendOp = D3D11_BLEND_OP_ADD;
-        blend_desc.RenderTarget[0].SrcBlendAlpha = D3D11_BLEND_ONE;
-        blend_desc.RenderTarget[0].DestBlendAlpha = D3D11_BLEND_ONE;
+        blend_desc.RenderTarget[0].SrcBlendAlpha = D3D11_BLEND_SRC_ALPHA;
+        blend_desc.RenderTarget[0].DestBlendAlpha = D3D11_BLEND_INV_SRC_ALPHA;
         blend_desc.RenderTarget[0].BlendOpAlpha = D3D11_BLEND_OP_ADD;
         blend_desc.RenderTarget[0].RenderTargetWriteMask = D3D11_COLOR_WRITE_ENABLE_ALL;
     } else {

--- a/libultraship/libultraship/Lib/Fast3D/gfx_direct3d11.cpp
+++ b/libultraship/libultraship/Lib/Fast3D/gfx_direct3d11.cpp
@@ -532,7 +532,7 @@ static struct ShaderProgram *gfx_d3d11_create_and_load_new_shader(uint64_t shade
         blend_desc.RenderTarget[0].DestBlend = D3D11_BLEND_INV_SRC_ALPHA;
         blend_desc.RenderTarget[0].BlendOp = D3D11_BLEND_OP_ADD;
         blend_desc.RenderTarget[0].SrcBlendAlpha = D3D11_BLEND_ONE;
-        blend_desc.RenderTarget[0].DestBlendAlpha = D3D11_BLEND_ZERO;
+        blend_desc.RenderTarget[0].DestBlendAlpha = D3D11_BLEND_ONE;
         blend_desc.RenderTarget[0].BlendOpAlpha = D3D11_BLEND_OP_ADD;
         blend_desc.RenderTarget[0].RenderTargetWriteMask = D3D11_COLOR_WRITE_ENABLE_ALL;
     } else {

--- a/libultraship/libultraship/Lib/Fast3D/gfx_opengl.cpp
+++ b/libultraship/libultraship/Lib/Fast3D/gfx_opengl.cpp
@@ -582,7 +582,7 @@ static void gfx_opengl_init(void) {
 
     SohUtils::saveEnvironmentVar("framebuffer", std::to_string(textureColorbuffer));
     glDepthFunc(GL_LEQUAL);
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE);
 }
 
 static void gfx_opengl_on_resize(void) {

--- a/libultraship/libultraship/Lib/Fast3D/gfx_opengl.cpp
+++ b/libultraship/libultraship/Lib/Fast3D/gfx_opengl.cpp
@@ -582,7 +582,7 @@ static void gfx_opengl_init(void) {
 
     SohUtils::saveEnvironmentVar("framebuffer", std::to_string(textureColorbuffer));
     glDepthFunc(GL_LEQUAL);
-    glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 }
 
 static void gfx_opengl_on_resize(void) {


### PR DESCRIPTION
This fixes issue: [https://github.com/HarbourMasters/Shipwright/issues/67](https://github.com/HarbourMasters/Shipwright/issues/67)

This happened with the Mirror Shield in the inventory screen preview. Also configured the blend function in OpenGL so it matches in both APIs.

![Shield](https://user-images.githubusercontent.com/7031754/160035507-b14a5c5c-ea23-4fa9-ab83-f83093ab06f5.png)

