### PR TITLE
Load SDL controller db from file

### DIFF
--- a/libultraship/libultraship/Window.cpp
+++ b/libultraship/libultraship/Window.cpp
@@ -39,6 +39,14 @@ extern "C" {
             exit(EXIT_FAILURE);
         }
 
+        const char* controllerDb = "gamecontrollerdb.txt";
+        int mappingsAdded = SDL_GameControllerAddMappingsFromFile(controllerDb);
+        if (mappingsAdded >= 0) {
+            SPDLOG_INFO("Added SDL game controllers from \"{}\" ({})", controllerDb, mappingsAdded);
+        } else {
+            SPDLOG_ERROR("Failed add SDL game controller mappings from \"{}\" ({})", controllerDb, SDL_GetError());
+        }
+
         // TODO: This for loop is debug. Burn it with fire.
         for (size_t i = 0; i < SDL_NumJoysticks(); i++) {
             if (SDL_IsGameController(i)) {


### PR DESCRIPTION
This will allow the use of the `gamecontrollerdb.txt` from [SDL_GameControllerDB](https://github.com/gabomdq/SDL_GameControllerDB) which adds SDL mappings for many more controllers not supported by default, and, it being a text file loaded at runtime means users can add mappings for custom controllers to the text file without having to edit soh's code and rebuild.

This is separate from the button mapping in the `.ini` file and instead allows non-default controllers to be found and work properly in SDL.

However, I do have two questions.
- Should a `gamecontrollerdb.txt` be included in the soh repo and copied to the build folder as part of the build process if it doesn't already exist? (I'm not sure how to do this with a VS solution). Celeste takes this approach, it includes a `gamecontrollerdb.txt` in the game files alongside the executable.
- Should the log entry for failing to read the mappings have error as its log level? It's currently implemented as such, the program will continue even if the file doesn't exist: it will use the default SDL controller db in that case. So, I'm not sure if it should be a warn or not.