### PR TITLE
Dynamic Wallet Rupee Icon Color

### DIFF
--- a/libultraship/libultraship/GameSettings.cpp
+++ b/libultraship/libultraship/GameSettings.cpp
@@ -58,6 +58,9 @@ namespace Game {
         Settings.enhancements.animated_pause_menu = stob(Conf[EnhancementSection]["animated_pause_menu"]);
         CVar_SetS32(const_cast<char*>("gPauseLiveLink"), Settings.enhancements.animated_pause_menu);
 
+        Settings.enhancements.dynamic_wallet_icon = stob(Conf[EnhancementSection]["dynamic_wallet_icon"]);
+        CVar_SetS32(const_cast<char*>("gDynamicWalletIcon"), Settings.enhancements.dynamic_wallet_icon);
+
         // Audio
         Settings.audio.master = Ship::stof(Conf[AudioSection]["master"]);
         CVar_SetFloat(const_cast<char*>("gGameMasterVolume"), Settings.audio.master);
@@ -139,6 +142,7 @@ namespace Game {
         Conf[EnhancementSection]["fast_text"] = std::to_string(Settings.enhancements.fast_text);
         Conf[EnhancementSection]["disable_lod"] = std::to_string(Settings.enhancements.disable_lod);
         Conf[EnhancementSection]["animated_pause_menu"] = std::to_string(Settings.enhancements.animated_pause_menu);
+        Conf[EnhancementSection]["dynamic_wallet_icon"] = std::to_string(Settings.enhancements.dynamic_wallet_icon);
         
 
         // Controllers

--- a/libultraship/libultraship/GameSettings.h
+++ b/libultraship/libultraship/GameSettings.h
@@ -23,6 +23,7 @@ struct SoHConfigType {
         bool fast_text = false;
         bool disable_lod = false;
         bool animated_pause_menu = false;
+        bool dynamic_wallet_icon = false;
     } enhancements;
 
     // Controller

--- a/libultraship/libultraship/SohImGuiImpl.cpp
+++ b/libultraship/libultraship/SohImGuiImpl.cpp
@@ -358,6 +358,11 @@ namespace SohImGui {
                     needs_save = true;
                 }
 
+                if (ImGui::Checkbox("Dynamic Wallet Icon", &Game::Settings.enhancements.dynamic_wallet_icon)) {
+                    CVar_SetS32(const_cast<char*>("gDynamicWalletIcon"), Game::Settings.enhancements.dynamic_wallet_icon);
+                    needs_save = true;
+                }
+
                 ImGui::EndMenu();
             }
 

--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -3125,6 +3125,9 @@ void Interface_Draw(GlobalContext* globalCtx) {
     };
     static s16 rupeeDigitsFirst[] = { 1, 0, 0 };
     static s16 rupeeDigitsCount[] = { 2, 3, 3 };
+    static s16 rupeeIconGreen[] = { 200, 255, 100 };
+    static s16 rupeeIconBlue[] = { 100, 200, 255 };
+    static s16 rupeeIconRed[] = { 255, 100, 100 };
     static s16 spoilingItemEntrances[] = { 0x01AD, 0x0153, 0x0153 };
     static f32 D_80125B54[] = { -40.0f, -35.0f }; // unused
     static s16 D_80125B5C[] = { 91, 91 };         // unused
@@ -3163,7 +3166,30 @@ void Interface_Draw(GlobalContext* globalCtx) {
         func_80094520(globalCtx->state.gfxCtx);
 
         // Rupee Icon
-        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 200, 255, 100, interfaceCtx->magicAlpha);
+        s16 rupeeR;
+        s16 rupeeG;
+        s16 rupeeB;
+        switch (CUR_UPG_VALUE(UPG_WALLET)) {
+            case 0:
+                rupeeR = rupeeIconGreen[0];
+                rupeeG = rupeeIconGreen[1];
+                rupeeB = rupeeIconGreen[2];
+                break;
+            case 1:
+                rupeeR = rupeeIconBlue[0];
+                rupeeG = rupeeIconBlue[1];
+                rupeeB = rupeeIconBlue[2];
+                break;
+            case 2:
+                rupeeR = rupeeIconRed[0];
+                rupeeG = rupeeIconRed[1];
+                rupeeB = rupeeIconRed[2];
+                break;
+            default:
+                break;
+        }
+
+        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, rupeeR, rupeeG, rupeeB, interfaceCtx->magicAlpha);
         gDPSetEnvColor(OVERLAY_DISP++, 0, 80, 0, 255);
         OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, gRupeeCounterIconTex, 16, 16, OTRGetRectDimensionFromLeftEdge(26),
                                       206, 16, 16, 1 << 10, 1 << 10);

--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -3127,7 +3127,7 @@ void Interface_Draw(GlobalContext* globalCtx) {
     static s16 rupeeDigitsCount[] = { 2, 3, 3 };
 
     // courtesy of https://github.com/TestRunnerSRL/OoT-Randomizer/blob/Dev/ASM/c/hud_colors.c
-    static s16 rupeeWalletColors[4][3] = {
+    static s16 rupeeWalletColors[3][3] = {
         { 0xC8, 0xFF, 0x64 }, // Base Wallet (Green)
         { 0x82, 0x82, 0xFF }, // Adult's Wallet (Blue)
         { 0xFF, 0x64, 0x64 }, // Giant's Wallet (Red)

--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -3131,7 +3131,6 @@ void Interface_Draw(GlobalContext* globalCtx) {
         { 0xC8, 0xFF, 0x64 }, // Base Wallet (Green)
         { 0x82, 0x82, 0xFF }, // Adult's Wallet (Blue)
         { 0xFF, 0x64, 0x64 }, // Giant's Wallet (Red)
-        { 0xFF, 0x5A, 0xFF }, // Tycoon's Wallet (Purple)
     };
 
     static s16 spoilingItemEntrances[] = { 0x01AD, 0x0153, 0x0153 };
@@ -3176,7 +3175,7 @@ void Interface_Draw(GlobalContext* globalCtx) {
 
         if (fullUi) {
             // Rupee Icon
-            s16 *rColor;
+            s16* rColor;
 
             if (CVar_GetS32("gDynamicWalletIcon", 0)) {
                 rColor = &rupeeWalletColors[CUR_UPG_VALUE(UPG_WALLET)];

--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -3126,7 +3126,7 @@ void Interface_Draw(GlobalContext* globalCtx) {
     static s16 rupeeDigitsFirst[] = { 1, 0, 0 };
     static s16 rupeeDigitsCount[] = { 2, 3, 3 };
     static s16 rupeeIconGreen[] = { 200, 255, 100 };
-    static s16 rupeeIconBlue[] = { 100, 100, 255 };
+    static s16 rupeeIconBlue[] = { 130, 130, 255 };
     static s16 rupeeIconRed[] = { 255, 100, 100 };
     static s16 spoilingItemEntrances[] = { 0x01AD, 0x0153, 0x0153 };
     static f32 D_80125B54[] = { -40.0f, -35.0f }; // unused

--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -3169,24 +3169,33 @@ void Interface_Draw(GlobalContext* globalCtx) {
         s16 rupeeR;
         s16 rupeeG;
         s16 rupeeB;
-        switch (CUR_UPG_VALUE(UPG_WALLET)) {
-            case 0:
-                rupeeR = rupeeIconGreen[0];
-                rupeeG = rupeeIconGreen[1];
-                rupeeB = rupeeIconGreen[2];
-                break;
-            case 1:
-                rupeeR = rupeeIconBlue[0];
-                rupeeG = rupeeIconBlue[1];
-                rupeeB = rupeeIconBlue[2];
-                break;
-            case 2:
-                rupeeR = rupeeIconRed[0];
-                rupeeG = rupeeIconRed[1];
-                rupeeB = rupeeIconRed[2];
-                break;
-            default:
-                break;
+
+        if (CVar_GetS32("gDynamicWalletIcon", 0)) {
+            switch (CUR_UPG_VALUE(UPG_WALLET)) {
+                case 0:
+                    rupeeR = rupeeIconGreen[0];
+                    rupeeG = rupeeIconGreen[1];
+                    rupeeB = rupeeIconGreen[2];
+                    break;
+                case 1:
+                    rupeeR = rupeeIconBlue[0];
+                    rupeeG = rupeeIconBlue[1];
+                    rupeeB = rupeeIconBlue[2];
+                    break;
+                case 2:
+                    rupeeR = rupeeIconRed[0];
+                    rupeeG = rupeeIconRed[1];
+                    rupeeB = rupeeIconRed[2];
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        else {
+            rupeeR = rupeeIconGreen[0];
+            rupeeG = rupeeIconGreen[1];
+            rupeeB = rupeeIconGreen[2];
         }
 
         gDPSetPrimColor(OVERLAY_DISP++, 0, 0, rupeeR, rupeeG, rupeeB, interfaceCtx->magicAlpha);

--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -3126,7 +3126,7 @@ void Interface_Draw(GlobalContext* globalCtx) {
     static s16 rupeeDigitsFirst[] = { 1, 0, 0 };
     static s16 rupeeDigitsCount[] = { 2, 3, 3 };
     static s16 rupeeIconGreen[] = { 200, 255, 100 };
-    static s16 rupeeIconBlue[] = { 100, 200, 255 };
+    static s16 rupeeIconBlue[] = { 100, 100, 255 };
     static s16 rupeeIconRed[] = { 255, 100, 100 };
     static s16 spoilingItemEntrances[] = { 0x01AD, 0x0153, 0x0153 };
     static f32 D_80125B54[] = { -40.0f, -35.0f }; // unused

--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -3125,9 +3125,15 @@ void Interface_Draw(GlobalContext* globalCtx) {
     };
     static s16 rupeeDigitsFirst[] = { 1, 0, 0 };
     static s16 rupeeDigitsCount[] = { 2, 3, 3 };
-    static s16 rupeeIconGreen[] = { 200, 255, 100 };
-    static s16 rupeeIconBlue[] = { 130, 130, 255 };
-    static s16 rupeeIconRed[] = { 255, 100, 100 };
+
+    // courtesy of https://github.com/TestRunnerSRL/OoT-Randomizer/blob/Dev/ASM/c/hud_colors.c
+    static s16 rupeeWalletColors[4][3] = {
+        { 0xC8, 0xFF, 0x64 }, // Base Wallet (Green)
+        { 0x82, 0x82, 0xFF }, // Adult's Wallet (Blue)
+        { 0xFF, 0x64, 0x64 }, // Giant's Wallet (Red)
+        { 0xFF, 0x5A, 0xFF }, // Tycoon's Wallet (Purple)
+    };
+
     static s16 spoilingItemEntrances[] = { 0x01AD, 0x0153, 0x0153 };
     static f32 D_80125B54[] = { -40.0f, -35.0f }; // unused
     static s16 D_80125B5C[] = { 91, 91 };         // unused
@@ -3165,40 +3171,15 @@ void Interface_Draw(GlobalContext* globalCtx) {
 
         func_80094520(globalCtx->state.gfxCtx);
 
-        // Rupee Icon
-        s16 rupeeR;
-        s16 rupeeG;
-        s16 rupeeB;
+        s16 *rColor;
 
         if (CVar_GetS32("gDynamicWalletIcon", 0)) {
-            switch (CUR_UPG_VALUE(UPG_WALLET)) {
-                case 0:
-                    rupeeR = rupeeIconGreen[0];
-                    rupeeG = rupeeIconGreen[1];
-                    rupeeB = rupeeIconGreen[2];
-                    break;
-                case 1:
-                    rupeeR = rupeeIconBlue[0];
-                    rupeeG = rupeeIconBlue[1];
-                    rupeeB = rupeeIconBlue[2];
-                    break;
-                case 2:
-                    rupeeR = rupeeIconRed[0];
-                    rupeeG = rupeeIconRed[1];
-                    rupeeB = rupeeIconRed[2];
-                    break;
-                default:
-                    break;
-            }
+            rColor = &rupeeWalletColors[CUR_UPG_VALUE(UPG_WALLET)];
+        } else {
+          rColor = &rupeeWalletColors[0];
         }
 
-        else {
-            rupeeR = rupeeIconGreen[0];
-            rupeeG = rupeeIconGreen[1];
-            rupeeB = rupeeIconGreen[2];
-        }
-
-        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, rupeeR, rupeeG, rupeeB, interfaceCtx->magicAlpha);
+        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, rColor[0], rColor[1], rColor[2], interfaceCtx->magicAlpha);
         gDPSetEnvColor(OVERLAY_DISP++, 0, 80, 0, 255);
         OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, gRupeeCounterIconTex, 16, 16, OTRGetRectDimensionFromLeftEdge(26),
                                       206, 16, 16, 1 << 10, 1 << 10);


### PR DESCRIPTION
***Let me preface this with the fact that I am absolutely not at all fluent in c/c++. I just look at examples and imitate. I have no idea what's considered good or bad practices, but what I did here works and that's all that I'm really able to evaluate.***

Recolors the bottom left rupee icon according to what wallet you currently have:
![green](https://user-images.githubusercontent.com/30968528/160961229-482eedc7-6e10-4f4c-9564-9d4ee82fba42.PNG)
![blue](https://user-images.githubusercontent.com/30968528/160961237-4f02da2b-296d-4c35-ab14-e336a3ceb8d7.PNG)
![red](https://user-images.githubusercontent.com/30968528/160961241-33bbc388-95ef-4b33-9120-542093e7953c.PNG)

Green RGB: 200, 255, 100 (what was there by default)
Blue RGB: 100, 100, 255
Red RGB: 255, 100, 100

I know Ocarina of Time Randomizer implemented this as well as (I think) Majora's Mask, but I couldn't really figure out what RGB values that they were using for the colors. But I think for now, this is good enough. It can easily be changed later.

This can be turned on and off through the "Dynamic Wallet Icon" cvar option within `Enhancements` > `Graphics`