### PR TITLE
Don't copy skybox textures

### DIFF
--- a/libultraship/libultraship/Lib/Fast3D/U64/PR/ultra64/gbi.h
+++ b/libultraship/libultraship/Lib/Fast3D/U64/PR/ultra64/gbi.h
@@ -4223,6 +4223,17 @@ _DW({                                   \
     gDPPipeSync(pkt);                       \
 })
 
+#define gDPLoadTLUT_pal128(pkt, pal, dram)              \
+_DW({                                   \
+    gDPSetTextureImage(pkt, G_IM_FMT_RGBA, G_IM_SIZ_16b, 1, dram);  \
+    gDPTileSync(pkt);                       \
+    gDPSetTile(pkt, 0, 0, 0, 256 + ((pal)&1)*128,   \
+        G_TX_LOADTILE, 0 , 0, 0, 0, 0, 0, 0);           \
+    gDPLoadSync(pkt);                       \
+    gDPLoadTLUTCmd(pkt, G_TX_LOADTILE, 127);            \
+    gDPPipeSync(pkt);                       \
+})
+
 #else /* **** WORKAROUND hardware 1 load_tlut bug ****** */
 
 #define gDPLoadTLUT_pal256(pkt, dram)                                   \

--- a/libultraship/libultraship/Lib/Fast3D/gfx_pc.cpp
+++ b/libultraship/libultraship/Lib/Fast3D/gfx_pc.cpp
@@ -490,8 +490,8 @@ void gfx_texture_cache_clear()
     gfx_texture_cache.lru.clear();
 }
 
-static bool gfx_texture_cache_lookup(int i, TextureCacheNode **n, const uint8_t *orig_addr, uint32_t fmt, uint32_t siz, uint32_t palette_index) {
-    TextureCacheKey key = { orig_addr, fmt, siz, palette_index };
+static bool gfx_texture_cache_lookup(int i, TextureCacheNode **n, const uint8_t *orig_addr, const uint8_t *palette_addr, uint32_t fmt, uint32_t siz, uint32_t palette_index) {
+    TextureCacheKey key = { orig_addr, palette_addr, fmt, siz, palette_index };
     auto it = gfx_texture_cache.map.find(key);
 
     if (it != gfx_texture_cache.map.end()) {
@@ -815,7 +815,7 @@ static void import_texture(int i, int tile) {
     // if (ModInternal::callBindHook(0))
     //     return;
 
-    if (gfx_texture_cache_lookup(i, &rendering_state.textures[i], rdp.loaded_texture[tmem_index].addr, fmt, siz, rdp.texture_tile[tile].palette))
+    if (gfx_texture_cache_lookup(i, &rendering_state.textures[i], rdp.loaded_texture[tmem_index].addr, fmt == G_IM_FMT_CI ? rdp.palette : nullptr, fmt, siz, rdp.texture_tile[tile].palette))
     {
         return;
     }

--- a/libultraship/libultraship/Lib/Fast3D/gfx_pc.cpp
+++ b/libultraship/libultraship/Lib/Fast3D/gfx_pc.cpp
@@ -125,7 +125,7 @@ static struct RSP {
 } rsp;
 
 static struct RDP {
-    const uint8_t *palette;
+    const uint8_t *palettes[2];
     struct {
         const uint8_t *addr;
         uint8_t siz;
@@ -145,6 +145,7 @@ static struct RDP {
         uint8_t cms, cmt;
         uint8_t shifts, shiftt;
         uint16_t uls, ult, lrs, lrt; // U10.2
+        uint16_t tmem; // 0-511, in 64-bit word units
         uint32_t line_size_bytes;
         uint8_t palette;
         uint8_t tmem_index; // 0 or 1 for offset 0 kB or offset 2 kB, respectively
@@ -490,8 +491,22 @@ void gfx_texture_cache_clear()
     gfx_texture_cache.lru.clear();
 }
 
-static bool gfx_texture_cache_lookup(int i, TextureCacheNode **n, const uint8_t *orig_addr, const uint8_t *palette_addr, uint32_t fmt, uint32_t siz, uint32_t palette_index) {
-    TextureCacheKey key = { orig_addr, palette_addr, fmt, siz, palette_index };
+static bool gfx_texture_cache_lookup(int i, int tile) {
+    uint8_t fmt = rdp.texture_tile[tile].fmt;
+    uint8_t siz = rdp.texture_tile[tile].siz;
+    uint32_t tmem_index = rdp.texture_tile[tile].tmem_index;
+
+    TextureCacheNode** n = &rendering_state.textures[i];
+    const uint8_t* orig_addr = rdp.loaded_texture[tmem_index].addr;
+    uint8_t palette_index = rdp.texture_tile[tile].palette;
+
+    TextureCacheKey key;
+    if (fmt == G_IM_FMT_CI) {
+        key = { orig_addr, { rdp.palettes[0], rdp.palettes[1] }, fmt, siz, palette_index };
+    } else {
+        key = { orig_addr, { }, fmt, siz, palette_index };
+    }
+
     auto it = gfx_texture_cache.map.find(key);
 
     if (it != gfx_texture_cache.map.end()) {
@@ -735,7 +750,8 @@ static void import_texture_ci4(int tile) {
     uint32_t size_bytes = rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].size_bytes;
     uint32_t full_image_line_size_bytes = rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].full_image_line_size_bytes;
     uint32_t line_size_bytes = rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].line_size_bytes;
-    const uint8_t *palette = rdp.palette + rdp.texture_tile[tile].palette * 16 * 2; // 16 pixel entries, 16 bits each
+    uint32_t pal_idx = rdp.texture_tile[tile].palette; // 0-15
+    const uint8_t *palette = rdp.palettes[pal_idx / 8] + (pal_idx % 8) * 16 * 2; // 16 pixel entries, 16 bits each
     SUPPORT_CHECK(full_image_line_size_bytes == line_size_bytes);
 
     for (uint32_t i = 0; i < size_bytes * 2; i++) {
@@ -770,7 +786,7 @@ static void import_texture_ci8(int tile) {
     {
         for (uint32_t k = 0; k < line_size_bytes; i++, k++, j++) {
             uint8_t idx = addr[j];
-            uint16_t col16 = (rdp.palette[idx * 2] << 8) | rdp.palette[idx * 2 + 1]; // Big endian load
+            uint16_t col16 = (rdp.palettes[idx / 128][(idx % 128) * 2] << 8) | rdp.palettes[idx / 128][(idx % 128) * 2 + 1]; // Big endian load
             uint8_t a = col16 & 1;
             uint8_t r = col16 >> 11;
             uint8_t g = (col16 >> 6) & 0x1f;
@@ -815,7 +831,7 @@ static void import_texture(int i, int tile) {
     // if (ModInternal::callBindHook(0))
     //     return;
 
-    if (gfx_texture_cache_lookup(i, &rendering_state.textures[i], rdp.loaded_texture[tmem_index].addr, fmt == G_IM_FMT_CI ? rdp.palette : nullptr, fmt, siz, rdp.texture_tile[tile].palette))
+    if (gfx_texture_cache_lookup(i, tile))
     {
         return;
     }
@@ -1638,6 +1654,7 @@ static void gfx_dp_set_tile(uint8_t fmt, uint32_t siz, uint32_t line, uint32_t t
         int bp = 0;
     }
 
+    rdp.texture_tile[tile].tmem = tmem;
     //rdp.texture_tile[tile].tmem_index = tmem / 256; // tmem is the 64-bit word offset, so 256 words means 2 kB
     rdp.texture_tile[tile].tmem_index = tmem != 0; // assume one texture is loaded at address 0 and another texture at any other address
     rdp.textures_changed[0] = true;
@@ -1654,10 +1671,19 @@ static void gfx_dp_set_tile_size(uint8_t tile, uint16_t uls, uint16_t ult, uint1
 }
 
 static void gfx_dp_load_tlut(uint8_t tile, uint32_t high_index) {
-    //SUPPORT_CHECK(tile == G_TX_LOADTILE);
-    //SUPPORT_CHECK(rdp.texture_to_load.siz == G_IM_SIZ_16b);
+    SUPPORT_CHECK(tile == G_TX_LOADTILE);
+    SUPPORT_CHECK(rdp.texture_to_load.siz == G_IM_SIZ_16b);
 
-    rdp.palette = rdp.texture_to_load.addr;
+    SUPPORT_CHECK((rdp.texture_tile[tile].tmem == 256 && (high_index <= 127 || high_index == 255)) || (rdp.texture_tile[tile].tmem == 384 && high_index == 127));
+
+    if (rdp.texture_tile[tile].tmem == 256) {
+        rdp.palettes[0] = rdp.texture_to_load.addr;
+        if (high_index == 255) {
+            rdp.palettes[1] = rdp.texture_to_load.addr + 2 * 128;
+        }
+    } else {
+        rdp.palettes[1] = rdp.texture_to_load.addr;
+    }
 }
 
 static void gfx_dp_load_block(uint8_t tile, uint32_t uls, uint32_t ult, uint32_t lrs, uint32_t dxt) {

--- a/libultraship/libultraship/Lib/Fast3D/gfx_pc.h
+++ b/libultraship/libultraship/Lib/Fast3D/gfx_pc.h
@@ -17,7 +17,7 @@ struct GfxDimensions
 
 struct TextureCacheKey {
     const uint8_t* texture_addr;
-    const uint8_t* palette_addr;
+    const uint8_t* palette_addrs[2];
     uint8_t fmt, siz;
     uint8_t palette_index;
 

--- a/libultraship/libultraship/Lib/Fast3D/gfx_pc.h
+++ b/libultraship/libultraship/Lib/Fast3D/gfx_pc.h
@@ -17,6 +17,7 @@ struct GfxDimensions
 
 struct TextureCacheKey {
     const uint8_t* texture_addr;
+    const uint8_t* palette_addr;
     uint8_t fmt, siz;
     uint8_t palette_index;
 

--- a/libultraship/libultraship/TextureMod.cpp
+++ b/libultraship/libultraship/TextureMod.cpp
@@ -80,7 +80,7 @@ namespace Ship {
 
 		if (!this->TextureCache.contains(path)) this->TextureCache[path].resize(10);
 
-		TextureCacheKey key = { orig_addr, static_cast<uint8_t>(fmt), static_cast<uint8_t>(siz), static_cast<uint8_t>(palette) };
+		TextureCacheKey key = { orig_addr, nullptr, static_cast<uint8_t>(fmt), static_cast<uint8_t>(siz), static_cast<uint8_t>(palette) };
 		TextureCacheValue value = { api->new_texture(), 0, 0, false };
 		const auto entry = new TextureCacheNode(key, value);
 		api->select_texture(tile, entry->second.texture_id);

--- a/libultraship/libultraship/TextureMod.cpp
+++ b/libultraship/libultraship/TextureMod.cpp
@@ -80,7 +80,7 @@ namespace Ship {
 
 		if (!this->TextureCache.contains(path)) this->TextureCache[path].resize(10);
 
-		TextureCacheKey key = { orig_addr, nullptr, static_cast<uint8_t>(fmt), static_cast<uint8_t>(siz), static_cast<uint8_t>(palette) };
+		TextureCacheKey key = { orig_addr, { }, static_cast<uint8_t>(fmt), static_cast<uint8_t>(siz), static_cast<uint8_t>(palette) };
 		TextureCacheValue value = { api->new_texture(), 0, 0, false };
 		const auto entry = new TextureCacheNode(key, value);
 		api->select_texture(tile, entry->second.texture_id);

--- a/soh/include/z64.h
+++ b/soh/include/z64.h
@@ -340,6 +340,7 @@ typedef struct {
     s16 skyboxId;
     void* textures[2][6];
     void* palettes[6];
+    u16 palette_size;
     Gfx (*dListBuf)[150];
     Gfx* unk_138;
     Vtx* roomVtx;

--- a/soh/include/z64.h
+++ b/soh/include/z64.h
@@ -337,8 +337,8 @@ typedef enum {
 
 typedef struct {
     /* 0x000 */ char unk_00[0x128];
-    /* 0x128 */ void* staticSegments[2];
-    /* 0x130 */ u16 (*palettes)[256];
+    /* 0x128 */ void* textures[2][6];
+    /* 0x130 */ void* palettes[6];
     /* 0x134 */ Gfx (*dListBuf)[150];
     /* 0x138 */ Gfx* unk_138;
     /* 0x13C */ Vtx* roomVtx;

--- a/soh/include/z64.h
+++ b/soh/include/z64.h
@@ -336,16 +336,17 @@ typedef enum {
 } SkyboxId;
 
 typedef struct {
-    /* 0x000 */ char unk_00[0x128];
-    /* 0x128 */ void* textures[2][6];
-    /* 0x130 */ void* palettes[6];
-    /* 0x134 */ Gfx (*dListBuf)[150];
-    /* 0x138 */ Gfx* unk_138;
-    /* 0x13C */ Vtx* roomVtx;
-    /* 0x140 */ s16  unk_140;
-    /* 0x144 */ Vec3f rot;
-    /* 0x150 */ char unk_150[0x10];
-} SkyboxContext; // size = 0x160
+    char unk_00[0x128];
+    s16 skyboxId;
+    void* textures[2][6];
+    void* palettes[6];
+    Gfx (*dListBuf)[150];
+    Gfx* unk_138;
+    Vtx* roomVtx;
+    s16  unk_140;
+    Vec3f rot;
+    char unk_150[0x10];
+} SkyboxContext;
 
 typedef enum {
     /*  0 */ OCARINA_SONG_MINUET,

--- a/soh/src/code/z_kankyo.c
+++ b/soh/src/code/z_kankyo.c
@@ -677,7 +677,7 @@ void Environment_UpdateSkybox(GlobalContext* globalCtx, u8 skyboxId, Environment
             SkyboxTableEntry entryA = sSkyboxTable[newSkybox1Index];
 
             for (int i = 0; i < 5; i++)
-                LoadSkyboxTex(globalCtx, skyboxCtx, 0, i, entryA.textures[i], 128, i == 4 ? 128 : 64, 128, 64);
+                LoadSkyboxTex(skyboxCtx, 0, i, entryA.textures[i], 128, i == 4 ? 128 : 64, 128, 64);
 
             envCtx->skybox1Index = newSkybox1Index;
 
@@ -695,7 +695,7 @@ void Environment_UpdateSkybox(GlobalContext* globalCtx, u8 skyboxId, Environment
             SkyboxTableEntry entryA = sSkyboxTable[newSkybox2Index];
 
             for (int i = 0; i < 5; i++)
-                LoadSkyboxTex(globalCtx, skyboxCtx, 1, i, entryA.textures[i], 128, i == 4 ? 128 : 64, 128, 64);
+                LoadSkyboxTex(skyboxCtx, 1, i, entryA.textures[i], 128, i == 4 ? 128 : 64, 128, 64);
 
             envCtx->skybox2Index = newSkybox2Index;
 

--- a/soh/src/code/z_kankyo.c
+++ b/soh/src/code/z_kankyo.c
@@ -679,6 +679,8 @@ void Environment_UpdateSkybox(GlobalContext* globalCtx, u8 skyboxId, Environment
             for (int i = 0; i < 5; i++)
                 LoadSkyboxTex(skyboxCtx, 0, i, entryA.textures[i], 128, i == 4 ? 128 : 64, 128, 64);
 
+            Skybox_Update(skyboxCtx);
+
             envCtx->skybox1Index = newSkybox1Index;
 
             //size = gSkyboxFiles[newSkybox1Index].file.vromEnd - gSkyboxFiles[newSkybox1Index].file.vromStart;
@@ -697,6 +699,8 @@ void Environment_UpdateSkybox(GlobalContext* globalCtx, u8 skyboxId, Environment
             for (int i = 0; i < 5; i++)
                 LoadSkyboxTex(skyboxCtx, 1, i, entryA.textures[i], 128, i == 4 ? 128 : 64, 128, 64);
 
+            Skybox_Update(skyboxCtx);
+
             envCtx->skybox2Index = newSkybox2Index;
 
             //size = gSkyboxFiles[newSkybox2Index].file.vromEnd - gSkyboxFiles[newSkybox2Index].file.vromStart;
@@ -712,7 +716,7 @@ void Environment_UpdateSkybox(GlobalContext* globalCtx, u8 skyboxId, Environment
             if ((newSkybox1Index & 1) ^ ((newSkybox1Index & 4) >> 2)) {
 
                 SkyboxTableEntry entryA = sSkyboxTable[newSkybox1Index];
-                LoadSkyboxPalette(globalCtx, skyboxCtx, 0, entryA.palettes[0], 16, 8);
+                LoadSkyboxPalette(skyboxCtx, 0, entryA.palettes[0], 16, 8);
 
                 //size = gSkyboxFiles[newSkybox1Index].palette.vromEnd - gSkyboxFiles[newSkybox1Index].palette.vromStart;
                 //osCreateMesgQueue(&envCtx->loadQueue, &envCtx->loadMsg, 1);
@@ -721,7 +725,7 @@ void Environment_UpdateSkybox(GlobalContext* globalCtx, u8 skyboxId, Environment
                                     //"../z_kankyo.c", 1307);
             } else {
                 SkyboxTableEntry entryA = sSkyboxTable[newSkybox1Index];
-                LoadSkyboxPalette(globalCtx, skyboxCtx, 1, entryA.palettes[0], 16, 8);
+                LoadSkyboxPalette(skyboxCtx, 1, entryA.palettes[0], 16, 8);
 
                 //size = gSkyboxFiles[newSkybox1Index].palette.vromEnd - gSkyboxFiles[newSkybox1Index].palette.vromStart;
                 //osCreateMesgQueue(&envCtx->loadQueue, &envCtx->loadMsg, 1);
@@ -729,6 +733,8 @@ void Environment_UpdateSkybox(GlobalContext* globalCtx, u8 skyboxId, Environment
                                     //gSkyboxFiles[newSkybox1Index].palette.vromStart, size, 0, &envCtx->loadQueue, NULL,
                                     //"../z_kankyo.c", 1320);
             }
+
+            Skybox_Update(skyboxCtx);
         }
 
         if (envCtx->skyboxDmaState == SKYBOX_DMA_FILE2_DONE) {
@@ -737,7 +743,7 @@ void Environment_UpdateSkybox(GlobalContext* globalCtx, u8 skyboxId, Environment
             if ((newSkybox2Index & 1) ^ ((newSkybox2Index & 4) >> 2)) 
             {
                 SkyboxTableEntry entryA = sSkyboxTable[newSkybox2Index];
-                LoadSkyboxPalette(globalCtx, skyboxCtx, 0, entryA.palettes[0], 16, 8);
+                LoadSkyboxPalette(skyboxCtx, 0, entryA.palettes[0], 16, 8);
 
                 /*size = gSkyboxFiles[newSkybox2Index].palette.vromEnd - gSkyboxFiles[newSkybox2Index].palette.vromStart;
                 osCreateMesgQueue(&envCtx->loadQueue, &envCtx->loadMsg, 1);
@@ -747,7 +753,7 @@ void Environment_UpdateSkybox(GlobalContext* globalCtx, u8 skyboxId, Environment
             } else 
             {
                 SkyboxTableEntry entryA = sSkyboxTable[newSkybox2Index];
-                LoadSkyboxPalette(globalCtx, skyboxCtx, 1, entryA.palettes[0], 16, 8);
+                LoadSkyboxPalette(skyboxCtx, 1, entryA.palettes[0], 16, 8);
 
                 /*size = gSkyboxFiles[newSkybox2Index].palette.vromEnd - gSkyboxFiles[newSkybox2Index].palette.vromStart;
                 osCreateMesgQueue(&envCtx->loadQueue, &envCtx->loadMsg, 1);
@@ -755,6 +761,8 @@ void Environment_UpdateSkybox(GlobalContext* globalCtx, u8 skyboxId, Environment
                                     gSkyboxFiles[newSkybox2Index].palette.vromStart, size, 0, &envCtx->loadQueue, NULL,
                                     "../z_kankyo.c", 1355);*/
             }
+
+            Skybox_Update(skyboxCtx);
         }
 
         if ((envCtx->skyboxDmaState == SKYBOX_DMA_FILE1_START) || (envCtx->skyboxDmaState == SKYBOX_DMA_FILE2_START)) {

--- a/soh/src/code/z_vr_box.c
+++ b/soh/src/code/z_vr_box.c
@@ -248,7 +248,7 @@ s32 func_800ADBB0(SkyboxContext* skyboxCtx, Vtx* roomVtx, s32 arg2, s32 arg3, s3
 
         for (phi_t2_4 = 0, phi_ra = 0; phi_ra < 4; phi_ra++, phi_a2_4 += 0x1F) {
             for (phi_a0_4 = 0, phi_t1 = 0; phi_t1 < 4; phi_t1++, phi_a0_4 += 0x3F, phi_t2_4 += 4) {
-                gDPLoadTextureTile(skyboxCtx->unk_138++, (uintptr_t)skyboxCtx->staticSegments[0] + D_8012AC90[arg8],
+                gDPLoadTextureTile(skyboxCtx->unk_138++, skyboxCtx->textures[0][arg8],
                                    G_IM_FMT_CI, G_IM_SIZ_8b, 256, 0, phi_a0_4, phi_a2_4, phi_a0_4 + 0x3F,
                                    phi_a2_4 + 0x1F, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOLOD,
                                    G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOLOD);
@@ -360,11 +360,11 @@ s32 func_800AE2C0(SkyboxContext* skyboxCtx, Vtx* roomVtx, s32 arg2, s32 arg3, s3
         phi_a2_4 = 0;
         for (phi_t2_4 = 0, phi_ra = 0; phi_ra < 4; phi_ra++, phi_a2_4 += 0x1F) {
             for (phi_a0_4 = 0, phi_t1 = 0; phi_t1 < 4; phi_t1++, phi_a0_4 += 0x1F, phi_t2_4 += 4) {
-                gDPLoadMultiTile(skyboxCtx->unk_138++, (uintptr_t)skyboxCtx->staticSegments[0] + D_8012ADC0[arg8], 0,
+                gDPLoadMultiTile(skyboxCtx->unk_138++, skyboxCtx->textures[0][arg8], 0,
                                  G_TX_RENDERTILE, G_IM_FMT_CI, G_IM_SIZ_8b, 128, 0, phi_a0_4, phi_a2_4, phi_a0_4 + 0x1F,
                                  phi_a2_4 + 0x1F, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOLOD,
                                  G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOLOD);
-                gDPLoadMultiTile(skyboxCtx->unk_138++, (uintptr_t)skyboxCtx->staticSegments[1] + D_8012ADC0[arg8], 0x80, 1,
+                gDPLoadMultiTile(skyboxCtx->unk_138++, skyboxCtx->textures[1][arg8], 0x80, 1,
                                  G_IM_FMT_CI, G_IM_SIZ_8b, 128, 0, phi_a0_4, phi_a2_4, phi_a0_4 + 0x1F, phi_a2_4 + 0x1F,
                                  0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOMIRROR | G_TX_WRAP,
                                  G_TX_NOMASK, G_TX_NOLOD);
@@ -379,11 +379,11 @@ s32 func_800AE2C0(SkyboxContext* skyboxCtx, Vtx* roomVtx, s32 arg2, s32 arg3, s3
         phi_a2_4 = 0;
         for (phi_t2_4 = 0, phi_ra = 0; phi_ra < 2; phi_ra++, phi_a2_4 += 0x1F) {
             for (phi_a0_4 = 0, phi_t1 = 0; phi_t1 < 4; phi_t1++, phi_a0_4 += 0x1F, phi_t2_4 += 4) {
-                gDPLoadMultiTile(skyboxCtx->unk_138++, (uintptr_t)skyboxCtx->staticSegments[0] + D_8012ADC0[arg8], 0,
+                gDPLoadMultiTile(skyboxCtx->unk_138++, skyboxCtx->textures[0][arg8], 0,
                                  G_TX_RENDERTILE, G_IM_FMT_CI, G_IM_SIZ_8b, 128, 0, phi_a0_4, phi_a2_4, phi_a0_4 + 0x1F,
                                  phi_a2_4 + 0x1F, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOLOD,
                                  G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOLOD);
-                gDPLoadMultiTile(skyboxCtx->unk_138++, (uintptr_t)skyboxCtx->staticSegments[1] + D_8012ADC0[arg8], 0x80, 1,
+                gDPLoadMultiTile(skyboxCtx->unk_138++, skyboxCtx->textures[1][arg8], 0x80, 1,
                                  G_IM_FMT_CI, G_IM_SIZ_8b, 128, 0, phi_a0_4, phi_a2_4, phi_a0_4 + 0x1F, phi_a2_4 + 0x1F,
                                  0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOMIRROR | G_TX_WRAP,
                                  G_TX_NOMASK, G_TX_NOLOD);
@@ -394,11 +394,11 @@ s32 func_800AE2C0(SkyboxContext* skyboxCtx, Vtx* roomVtx, s32 arg2, s32 arg3, s3
         phi_a2_4 -= 0x1F;
         for (phi_ra = 0; phi_ra < 2; phi_ra++, phi_a2_4 -= 0x1F) {
             for (phi_a0_4 = 0, phi_t1 = 0; phi_t1 < 4; phi_t1++, phi_a0_4 += 0x1F, phi_t2_4 += 4) {
-                gDPLoadMultiTile(skyboxCtx->unk_138++, (uintptr_t)skyboxCtx->staticSegments[0] + D_8012ADC0[arg8], 0,
+                gDPLoadMultiTile(skyboxCtx->unk_138++, skyboxCtx->textures[0][arg8], 0,
                                  G_TX_RENDERTILE, G_IM_FMT_CI, G_IM_SIZ_8b, 128, 0, phi_a0_4, phi_a2_4, phi_a0_4 + 0x1F,
                                  phi_a2_4 + 0x1F, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOLOD,
                                  G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOLOD);
-                gDPLoadMultiTile(skyboxCtx->unk_138++, (uintptr_t)skyboxCtx->staticSegments[1] + D_8012ADC0[arg8], 0x80, 1,
+                gDPLoadMultiTile(skyboxCtx->unk_138++, skyboxCtx->textures[1][arg8], 0x80, 1,
                                  G_IM_FMT_CI, G_IM_SIZ_8b, 128, 0, phi_a0_4, phi_a2_4, phi_a0_4 + 0x1F, phi_a2_4 + 0x1F,
                                  0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOMIRROR | G_TX_WRAP,
                                  G_TX_NOMASK, G_TX_NOLOD);
@@ -446,23 +446,17 @@ void func_800AF178(SkyboxContext* skyboxCtx, s32 arg1) {
 
 void LoadSkyboxTex(GlobalContext* globalCtx, SkyboxContext* skyboxCtx, int segmentIndex, int imageIndex, char* tex, int width, int height, int offsetW, int offsetH)
 {
-    if (globalCtx != NULL && globalCtx->state.gfxCtx != NULL && globalCtx->state.gfxCtx != 0xABABABAB)
-        gSPInvalidateTexCache(globalCtx->state.gfxCtx->polyOpa.p++, ((uintptr_t)skyboxCtx->staticSegments[segmentIndex] + (imageIndex * (offsetW * offsetH))));
-    
-    memcpy((uintptr_t)skyboxCtx->staticSegments[segmentIndex] + (imageIndex * (offsetW * offsetH)), ResourceMgr_LoadTexByName(tex), width * height);
+    skyboxCtx->textures[segmentIndex][imageIndex] = tex;
 }
 
-void LoadSkyboxTexAtOffset(SkyboxContext* skyboxCtx, int segmentIndex, char* tex, int width, int height, int offset)
+void LoadSkyboxTexAtOffset(SkyboxContext* skyboxCtx, int segmentIndex, int imageIndex, char* tex, int width, int height, int offset)
 {
-    memcpy((uintptr_t)skyboxCtx->staticSegments[segmentIndex] + offset, ResourceMgr_LoadTexByName(tex), width * height);
+    skyboxCtx->textures[segmentIndex][imageIndex] = tex;
 }
 
 void LoadSkyboxPalette(GlobalContext* globalCtx, SkyboxContext* skyboxCtx, int paletteIndex, char* palTex, int width,
                        int height) {
-    if (globalCtx != NULL && globalCtx->state.gfxCtx != NULL && globalCtx->state.gfxCtx != 0xABABABAB)
-        gSPInvalidateTexCache(globalCtx->state.gfxCtx->polyOpa.p++, (uintptr_t)skyboxCtx->palettes + (paletteIndex * (width * height * 2)));
-
-    memcpy((uintptr_t)skyboxCtx->palettes + (paletteIndex * (width * height * 2)), ResourceMgr_LoadTexByName(palTex), width * height * 2);
+    skyboxCtx->palettes[paletteIndex] = palTex;
 }
 
 static const char* sSBVRFine0Tex[] =
@@ -634,8 +628,6 @@ void Skybox_Setup(GlobalContext* globalCtx, SkyboxContext* skyboxCtx, s16 skybox
         }
 
 
-        skyboxCtx->staticSegments[0] = GameState_Alloc(&globalCtx->state, (128 * 64 * 4) + (128 * 128), "../z_vr_box.c", 1054);
-
         SkyboxTableEntry entryA = sSkyboxTable[sp41];
 
       for (int i = 0; i < 5; i++)
@@ -643,20 +635,16 @@ void Skybox_Setup(GlobalContext* globalCtx, SkyboxContext* skyboxCtx, s16 skybox
 
         SkyboxTableEntry entryB = sSkyboxTable[sp40];
 
-        skyboxCtx->staticSegments[1] = GameState_Alloc(&globalCtx->state, (128 * 64 * 4) + (128 * 128), "../z_vr_box.c", 1060);
-
         for (int i = 0; i < 5; i++)
             LoadSkyboxTex(globalCtx, skyboxCtx, 1, i, entryB.textures[i], 128, i == 4 ? 128 : 64, 128, 64);
         
         if ((sp41 & 1) ^ ((sp41 & 4) >> 2)) 
         {
-            skyboxCtx->palettes = GameState_Alloc(&globalCtx->state, 256 * 2, "../z_vr_box.c", 1072);
             LoadSkyboxPalette(globalCtx, skyboxCtx, 0, entryA.palettes[0], 16, 8);
             LoadSkyboxPalette(globalCtx, skyboxCtx, 1, entryB.palettes[0], 16, 8);
         }
         else 
         {
-            skyboxCtx->palettes = GameState_Alloc(&globalCtx->state, 256 * 2, "../z_vr_box.c", 1085);
             LoadSkyboxPalette(globalCtx, skyboxCtx, 0, entryB.palettes[0], 16, 8);
             LoadSkyboxPalette(globalCtx, skyboxCtx, 1, entryA.palettes[0], 16, 8);
         }
@@ -664,12 +652,8 @@ void Skybox_Setup(GlobalContext* globalCtx, SkyboxContext* skyboxCtx, s16 skybox
     case SKYBOX_BAZAAR:
         skyboxCtx->unk_140 = 1;
 
-        skyboxCtx->staticSegments[0] = GameState_Alloc(&globalCtx->state, 0x10000 * 2, "../z_vr_box.c", 1226);
-
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 0, gBazaarBgTex, 256, 256, 256, 256);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 1, gBazaar2BgTex, 256, 256, 256, 256);
-
-        skyboxCtx->palettes = GameState_Alloc(&globalCtx->state, 0x200 * 2, "../z_vr_box.c", 1231);
 
         LoadSkyboxPalette(globalCtx, skyboxCtx, 0, gBazaarBgTlut, 16, 16);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 1, gBazaarBg2Tlut, 16, 16);
@@ -678,63 +662,54 @@ void Skybox_Setup(GlobalContext* globalCtx, SkyboxContext* skyboxCtx, s16 skybox
     case SKYBOX_HOUSE_LINK:
         skyboxCtx->unk_140 = 1;
 
-        skyboxCtx->staticSegments[0] = GameState_Alloc(&globalCtx->state, 0x10000 * 4, "../z_vr_box.c", 1226);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 0, gLinksHouseBgTex, 256, 256, 256, 256);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 1, gLinksHouse2BgTex, 256, 256, 256, 256);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 2, gLinksHouse3BgTex, 256, 256, 256, 256);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 3, gLinksHouse4BgTex, 256, 256, 256, 256);
 
-        skyboxCtx->palettes = GameState_Alloc(&globalCtx->state, 0x200 * 4, "../z_vr_box.c", 1231);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 0, gLinksHouseBgTlut, 16, 16);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 1, gLinksHouseBg2Tlut, 16, 16);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 2, gLinksHouseBg3Tlut, 16, 16);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 3, gLinksHouseBg4Tlut, 16, 16);
         break;
     case SKYBOX_OVERCAST_SUNSET:
-        skyboxCtx->staticSegments[0] = GameState_Alloc(&globalCtx->state, 0xC000, "../z_vr_box.c", 1226);
-        LoadSkyboxTexAtOffset(skyboxCtx, 0, gSunsetOvercastSkybox1Tex, 128, 64, 0x0);
-        LoadSkyboxTexAtOffset(skyboxCtx, 0, gSunsetOvercastSkybox2Tex, 128, 64, 0x2000);
-        LoadSkyboxTexAtOffset(skyboxCtx, 0, gSunsetOvercastSkybox3Tex, 128, 64, 0x4000);
-        LoadSkyboxTexAtOffset(skyboxCtx, 0, gSunsetOvercastSkybox4Tex, 128, 64, 0x6000);
-        LoadSkyboxTexAtOffset(skyboxCtx, 0, gSunsetOvercastSkybox5Tex, 128, 128, 0x8000);
+        LoadSkyboxTexAtOffset(skyboxCtx, 0, 0, gSunsetOvercastSkybox1Tex, 128, 64, 0x0);
+        LoadSkyboxTexAtOffset(skyboxCtx, 0, 1, gSunsetOvercastSkybox2Tex, 128, 64, 0x2000);
+        LoadSkyboxTexAtOffset(skyboxCtx, 0, 2, gSunsetOvercastSkybox3Tex, 128, 64, 0x4000);
+        LoadSkyboxTexAtOffset(skyboxCtx, 0, 3, gSunsetOvercastSkybox4Tex, 128, 64, 0x6000);
+        LoadSkyboxTexAtOffset(skyboxCtx, 0, 4, gSunsetOvercastSkybox5Tex, 128, 128, 0x8000);
 
-        skyboxCtx->palettes = GameState_Alloc(&globalCtx->state, 0x100, "../z_vr_box.c", 1231);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 0, gSunsetOvercastSkyboxTlut, 16, 8);
         break;
     case SKYBOX_MARKET_ADULT:
         skyboxCtx->unk_140 = 1;
 
-        skyboxCtx->staticSegments[0] = GameState_Alloc(&globalCtx->state, 0x10000 * 4, "../z_vr_box.c", 1226);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 0, gMarketRuinsBgTex, 256, 256, 256, 256);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 1, gMarketRuins2BgTex, 256, 256, 256, 256);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 2, gMarketRuins3BgTex, 256, 256, 256, 256);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 3, gMarketRuins4BgTex, 256, 256, 256, 256);
 
-        skyboxCtx->palettes = GameState_Alloc(&globalCtx->state, 0x200 * 4, "../z_vr_box.c", 1231);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 0, gMarketRuinsBgTlut, 16, 16);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 1, gMarketRuinsBg2Tlut, 16, 16);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 2, gMarketRuinsBg3Tlut, 16, 16);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 3, gMarketRuinsBg4Tlut, 16, 16);
         break;
     case SKYBOX_CUTSCENE_MAP:
-        skyboxCtx->staticSegments[0] = GameState_Alloc(&globalCtx->state, 0x10000, "../z_vr_box.c", 1226);
-        LoadSkyboxTexAtOffset(skyboxCtx, 0, gHoly0Skybox1Tex, 128, 64, 0x0);
-        LoadSkyboxTexAtOffset(skyboxCtx, 0, gHoly0Skybox2Tex, 128, 64, 0x2000);
-        LoadSkyboxTexAtOffset(skyboxCtx, 0, gHoly0Skybox3Tex, 128, 64, 0x4000);
-        LoadSkyboxTexAtOffset(skyboxCtx, 0, gHoly0Skybox4Tex, 128, 64, 0x6000);
-        LoadSkyboxTexAtOffset(skyboxCtx, 0, gHoly0Skybox5Tex, 128, 128, 0x8000);
-        LoadSkyboxTexAtOffset(skyboxCtx, 0, gHoly0Skybox6Tex, 128, 128, 0xC000);
+        LoadSkyboxTexAtOffset(skyboxCtx, 0, 0, gHoly0Skybox1Tex, 128, 64, 0x0);
+        LoadSkyboxTexAtOffset(skyboxCtx, 0, 1, gHoly0Skybox2Tex, 128, 64, 0x2000);
+        LoadSkyboxTexAtOffset(skyboxCtx, 0, 2, gHoly0Skybox3Tex, 128, 64, 0x4000);
+        LoadSkyboxTexAtOffset(skyboxCtx, 0, 3, gHoly0Skybox4Tex, 128, 64, 0x6000);
+        LoadSkyboxTexAtOffset(skyboxCtx, 0, 4, gHoly0Skybox5Tex, 128, 128, 0x8000);
+        LoadSkyboxTexAtOffset(skyboxCtx, 0, 5, gHoly0Skybox6Tex, 128, 128, 0xC000);
 
-        skyboxCtx->palettes = GameState_Alloc(&globalCtx->state, 0x100 * 2, "../z_vr_box.c", 1231);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 0, gHoly0SkyboxTlut, 16, 8);
 
-        skyboxCtx->staticSegments[1] = GameState_Alloc(&globalCtx->state, 0x10000, "../z_vr_box.c", 1226);
-        LoadSkyboxTexAtOffset(skyboxCtx, 1, gHoly1Skybox1Tex, 128, 64, 0x0);
-        LoadSkyboxTexAtOffset(skyboxCtx, 1, gHoly1Skybox2Tex, 128, 64, 0x2000);
-        LoadSkyboxTexAtOffset(skyboxCtx, 1, gHoly1Skybox3Tex, 128, 64, 0x4000);
-        LoadSkyboxTexAtOffset(skyboxCtx, 1, gHoly1Skybox4Tex, 128, 64, 0x6000);
-        LoadSkyboxTexAtOffset(skyboxCtx, 1, gHoly1Skybox5Tex, 128, 128, 0x8000);
-        LoadSkyboxTexAtOffset(skyboxCtx, 1, gHoly1Skybox6Tex, 128, 128, 0xC000);
+        LoadSkyboxTexAtOffset(skyboxCtx, 1, 0, gHoly1Skybox1Tex, 128, 64, 0x0);
+        LoadSkyboxTexAtOffset(skyboxCtx, 1, 1, gHoly1Skybox2Tex, 128, 64, 0x2000);
+        LoadSkyboxTexAtOffset(skyboxCtx, 1, 2, gHoly1Skybox3Tex, 128, 64, 0x4000);
+        LoadSkyboxTexAtOffset(skyboxCtx, 1, 3, gHoly1Skybox4Tex, 128, 64, 0x6000);
+        LoadSkyboxTexAtOffset(skyboxCtx, 1, 4, gHoly1Skybox5Tex, 128, 128, 0x8000);
+        LoadSkyboxTexAtOffset(skyboxCtx, 1, 5, gHoly1Skybox6Tex, 128, 128, 0xC000);
 
 
         LoadSkyboxPalette(globalCtx, skyboxCtx, 1, gHoly1SkyboxTlut, 16, 8);
@@ -742,13 +717,11 @@ void Skybox_Setup(GlobalContext* globalCtx, SkyboxContext* skyboxCtx, s16 skybox
     case SKYBOX_MARKET_CHILD_DAY:
         skyboxCtx->unk_140 = 1;
 
-        skyboxCtx->staticSegments[0] = GameState_Alloc(&globalCtx->state, 0x10000 * 4, "../z_vr_box.c", 1226);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 0, gMarketDayBgTex, 256, 256, 256, 256);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 1, gMarketDay2BgTex, 256, 256, 256, 256);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 2, gMarketDay3BgTex, 256, 256, 256, 256);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 3, gMarketDay4BgTex, 256, 256, 256, 256);
 
-        skyboxCtx->palettes = GameState_Alloc(&globalCtx->state, 0x200 * 4, "../z_vr_box.c", 1231);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 0, gMarketDayBgTlut, 16, 16);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 1, gMarketDayBg2Tlut, 16, 16);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 2, gMarketDayBg3Tlut, 16, 16);
@@ -757,13 +730,11 @@ void Skybox_Setup(GlobalContext* globalCtx, SkyboxContext* skyboxCtx, s16 skybox
     case SKYBOX_MARKET_CHILD_NIGHT:
         skyboxCtx->unk_140 = 1;
 
-        skyboxCtx->staticSegments[0] = GameState_Alloc(&globalCtx->state, 0x10000 * 4, "../z_vr_box.c", 1226);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 0, gMarketNightBgTex, 256, 256, 256, 256);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 1, gMarketNight2BgTex, 256, 256, 256, 256);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 2, gMarketNight3BgTex, 256, 256, 256, 256);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 3, gMarketNight4BgTex, 256, 256, 256, 256);
 
-        skyboxCtx->palettes = GameState_Alloc(&globalCtx->state, 0x200 * 4, "../z_vr_box.c", 1231);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 0, gMarketNightBgTlut, 16, 16);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 1, gMarketNightBg2Tlut, 16, 16);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 2, gMarketNightBg3Tlut, 16, 16);
@@ -772,11 +743,9 @@ void Skybox_Setup(GlobalContext* globalCtx, SkyboxContext* skyboxCtx, s16 skybox
     case SKYBOX_HAPPY_MASK_SHOP:
         skyboxCtx->unk_140 = 1;
 
-        skyboxCtx->staticSegments[0] = GameState_Alloc(&globalCtx->state, 0x10000 * 2, "../z_vr_box.c", 1226);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 0, gMaskShopBgTex, 256, 256, 256, 256);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 1, gMaskShop2BgTex, 256, 256, 256, 256);
 
-        skyboxCtx->palettes = GameState_Alloc(&globalCtx->state, 0x200 * 2, "../z_vr_box.c", 1231);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 0, gMaskShopBgTlut, 16, 16);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 1, gMaskShopBg2Tlut, 16, 16);
 
@@ -785,13 +754,11 @@ void Skybox_Setup(GlobalContext* globalCtx, SkyboxContext* skyboxCtx, s16 skybox
     case SKYBOX_HOUSE_KNOW_IT_ALL_BROTHERS:
         skyboxCtx->unk_140 = 1;
 
-        skyboxCtx->staticSegments[0] = GameState_Alloc(&globalCtx->state, 0x10000 * 4, "../z_vr_box.c", 1226);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 0, gKnowItAllBrosHouseBgTex, 256, 256, 256, 256);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 1, gKnowItAllBrosHouse2BgTex, 256, 256, 256, 256);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 2, gKnowItAllBrosHouse3BgTex, 256, 256, 256, 256);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 3, gKnowItAllBrosHouse4BgTex, 256, 256, 256, 256);
 
-        skyboxCtx->palettes = GameState_Alloc(&globalCtx->state, 0x200 * 4, "../z_vr_box.c", 1231);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 0, gKnowItAllBrosHouseBgTlut, 16, 16);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 1, gKnowItAllBrosHouseBg2Tlut, 16, 16);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 2, gKnowItAllBrosHouseBg3Tlut, 16, 16);
@@ -800,12 +767,10 @@ void Skybox_Setup(GlobalContext* globalCtx, SkyboxContext* skyboxCtx, s16 skybox
     case SKYBOX_HOUSE_OF_TWINS:
         skyboxCtx->unk_140 = 2;
 
-        skyboxCtx->staticSegments[0] = GameState_Alloc(&globalCtx->state, 0x10000 * 3, "../z_vr_box.c", 1226);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 0, gHouseOfTwinsBgTex, 256, 256, 256, 256);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 1, gHouseOfTwins2BgTex, 256, 256, 256, 256);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 2, gHouseOfTwins3BgTex, 256, 256, 256, 256);
 
-        skyboxCtx->palettes = GameState_Alloc(&globalCtx->state, 0x200 * 3, "../z_vr_box.c", 1231);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 0, gHouseOfTwinsBgTlut, 16, 16);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 1, gHouseOfTwinsBg2Tlut, 16, 16);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 2, gHouseOfTwinsBg3Tlut, 16, 16);
@@ -813,13 +778,11 @@ void Skybox_Setup(GlobalContext* globalCtx, SkyboxContext* skyboxCtx, s16 skybox
     case SKYBOX_STABLES:
         skyboxCtx->unk_140 = 1;
 
-        skyboxCtx->staticSegments[0] = GameState_Alloc(&globalCtx->state, 0x10000 * 4, "../z_vr_box.c", 1226);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 0, gStableBgTex, 256, 256, 256, 256);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 1, gStable2BgTex, 256, 256, 256, 256);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 2, gStable3BgTex, 256, 256, 256, 256);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 3, gStable4BgTex, 256, 256, 256, 256);
 
-        skyboxCtx->palettes = GameState_Alloc(&globalCtx->state, 0x200 * 4, "../z_vr_box.c", 1231);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 0, gStableBgTlut, 16, 16);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 1, gStableBg2Tlut, 16, 16);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 2, gStableBg3Tlut, 16, 16);
@@ -828,13 +791,11 @@ void Skybox_Setup(GlobalContext* globalCtx, SkyboxContext* skyboxCtx, s16 skybox
     case SKYBOX_HOUSE_KAKARIKO:
         skyboxCtx->unk_140 = 1;
 
-        skyboxCtx->staticSegments[0] = GameState_Alloc(&globalCtx->state, 0x10000 * 4, "../z_vr_box.c", 1226);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 0, gCarpentersHouseBgTex, 256, 256, 256, 256);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 1, gCarpentersHouse2BgTex, 256, 256, 256, 256);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 2, gCarpentersHouse3BgTex, 256, 256, 256, 256);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 3, gCarpentersHouse4BgTex, 256, 256, 256, 256);
 
-        skyboxCtx->palettes = GameState_Alloc(&globalCtx->state, 0x200 * 4, "../z_vr_box.c", 1231);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 0, gCarpentersHouseBgTlut, 16, 16);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 1, gCarpentersHouseBg2Tlut, 16, 16);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 2, gCarpentersHouseBg3Tlut, 16, 16);
@@ -843,11 +804,9 @@ void Skybox_Setup(GlobalContext* globalCtx, SkyboxContext* skyboxCtx, s16 skybox
     case SKYBOX_KOKIRI_SHOP:
         skyboxCtx->unk_140 = 1;
 
-        skyboxCtx->staticSegments[0] = GameState_Alloc(&globalCtx->state, 0x10000 * 2, "../z_vr_box.c", 1226);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 0, gKokiriShopBgTex, 256, 256, 256, 256);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 1, gKokiriShop2BgTex, 256, 256, 256, 256);
 
-        skyboxCtx->palettes = GameState_Alloc(&globalCtx->state, 0x200 * 2, "../z_vr_box.c", 1231);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 0, gKokiriShopBgTlut, 16, 16);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 1, gKokiriShopBg2Tlut, 16, 16);
 
@@ -856,11 +815,9 @@ void Skybox_Setup(GlobalContext* globalCtx, SkyboxContext* skyboxCtx, s16 skybox
     case SKYBOX_GORON_SHOP:
         skyboxCtx->unk_140 = 1;
 
-        skyboxCtx->staticSegments[0] = GameState_Alloc(&globalCtx->state, 0x10000 * 2, "../z_vr_box.c", 1226);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 0, gGoronShopBgTex, 256, 256, 256, 256);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 1, gGoronShop2BgTex, 256, 256, 256, 256);
 
-        skyboxCtx->palettes = GameState_Alloc(&globalCtx->state, 0x200 * 2, "../z_vr_box.c", 1231);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 0, gGoronShopBgTlut, 16, 16);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 1, gGoronShopBg2Tlut, 16, 16);
 
@@ -869,11 +826,9 @@ void Skybox_Setup(GlobalContext* globalCtx, SkyboxContext* skyboxCtx, s16 skybox
     case SKYBOX_ZORA_SHOP:
         skyboxCtx->unk_140 = 1;
 
-        skyboxCtx->staticSegments[0] = GameState_Alloc(&globalCtx->state, 0x10000 * 2, "../z_vr_box.c", 1226);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 0, gZoraShopBgTex, 256, 256, 256, 256);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 1, gZoraShop2BgTex, 256, 256, 256, 256);
 
-        skyboxCtx->palettes = GameState_Alloc(&globalCtx->state, 0x200 * 2, "../z_vr_box.c", 1231);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 0, gZoraShopBgTlut, 16, 16);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 1, gZoraShopBg2Tlut, 16, 16);
 
@@ -882,11 +837,9 @@ void Skybox_Setup(GlobalContext* globalCtx, SkyboxContext* skyboxCtx, s16 skybox
     case SKYBOX_POTION_SHOP_KAKARIKO:
         skyboxCtx->unk_140 = 1;
 
-        skyboxCtx->staticSegments[0] = GameState_Alloc(&globalCtx->state, 0x10000 * 2, "../z_vr_box.c", 1226);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 0, gKakPotionShopBgTex, 256, 256, 256, 256);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 1, gKakPotionShop2BgTex, 256, 256, 256, 256);
 
-        skyboxCtx->palettes = GameState_Alloc(&globalCtx->state, 0x200 * 2, "../z_vr_box.c", 1231);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 0, gKakPotionShopBgTlut, 16, 16);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 1, gKakPotionShopBg2Tlut, 16, 16);
 
@@ -895,11 +848,9 @@ void Skybox_Setup(GlobalContext* globalCtx, SkyboxContext* skyboxCtx, s16 skybox
     case SKYBOX_POTION_SHOP_MARKET:
         skyboxCtx->unk_140 = 1;
 
-        skyboxCtx->staticSegments[0] = GameState_Alloc(&globalCtx->state, 0x10000 * 2, "../z_vr_box.c", 1226);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 0, gMarketPotionShopBgTex, 256, 256, 256, 256);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 1, gMarketPotionShop2BgTex, 256, 256, 256, 256);
 
-        skyboxCtx->palettes = GameState_Alloc(&globalCtx->state, 0x200 * 2, "../z_vr_box.c", 1231);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 0, gMarketPotionShopBgTlut, 16, 16);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 1, gMarketPotionShopBg2Tlut, 16, 16);
 
@@ -908,11 +859,9 @@ void Skybox_Setup(GlobalContext* globalCtx, SkyboxContext* skyboxCtx, s16 skybox
     case SKYBOX_BOMBCHU_SHOP:
         skyboxCtx->unk_140 = 1;
 
-        skyboxCtx->staticSegments[0] = GameState_Alloc(&globalCtx->state, 0x10000 * 2, "../z_vr_box.c", 1226);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 0, gBombchuShopBgTex, 256, 256, 256, 256);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 1, gBombchuShop2BgTex, 256, 256, 256, 256);
 
-        skyboxCtx->palettes = GameState_Alloc(&globalCtx->state, 0x200 * 2, "../z_vr_box.c", 1231);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 0, gBombchuShopBgTlut, 16, 16);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 1, gBombchuShopBg2Tlut, 16, 16);
 
@@ -921,13 +870,11 @@ void Skybox_Setup(GlobalContext* globalCtx, SkyboxContext* skyboxCtx, s16 skybox
     case SKYBOX_HOUSE_RICHARD:
         skyboxCtx->unk_140 = 1;
 
-        skyboxCtx->staticSegments[0] = GameState_Alloc(&globalCtx->state, 0x10000 * 4, "../z_vr_box.c", 1226);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 0, gRichardsHouseBgTex, 256, 256, 256, 256);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 1, gRichardsHouse2BgTex, 256, 256, 256, 256);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 2, gRichardsHouse3BgTex, 256, 256, 256, 256);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 3, gRichardsHouse4BgTex, 256, 256, 256, 256);
 
-        skyboxCtx->palettes = GameState_Alloc(&globalCtx->state, 0x200 * 4, "../z_vr_box.c", 1231);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 0, gRichardsHouseBgTlut, 16, 16);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 1, gRichardsHouseBg2Tlut, 16, 16);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 2, gRichardsHouseBg3Tlut, 16, 16);
@@ -936,13 +883,11 @@ void Skybox_Setup(GlobalContext* globalCtx, SkyboxContext* skyboxCtx, s16 skybox
     case SKYBOX_HOUSE_IMPA:
         skyboxCtx->unk_140 = 1;
 
-        skyboxCtx->staticSegments[0] = GameState_Alloc(&globalCtx->state, 0x10000 * 4, "../z_vr_box.c", 1226);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 0, gCowHouseBgTex, 256, 256, 256, 256);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 1, gCowHouse2BgTex, 256, 256, 256, 256);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 2, gCowHouse3BgTex, 256, 256, 256, 256);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 3, gCowHouse4BgTex, 256, 256, 256, 256);
 
-        skyboxCtx->palettes = GameState_Alloc(&globalCtx->state, 0x200 * 4, "../z_vr_box.c", 1231);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 0, gCowHouseBgTlut, 16, 16);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 1, gCowHouseBg2Tlut, 16, 16);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 2, gCowHouseBg3Tlut, 16, 16);
@@ -951,12 +896,10 @@ void Skybox_Setup(GlobalContext* globalCtx, SkyboxContext* skyboxCtx, s16 skybox
     case SKYBOX_TENT:
         skyboxCtx->unk_140 = 2;
 
-        skyboxCtx->staticSegments[0] = GameState_Alloc(&globalCtx->state, 0x10000 * 3, "../z_vr_box.c", 1226);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 0, gCarpentersTentBgTex, 256, 256, 256, 256);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 1, gCarpentersTent2BgTex, 256, 256, 256, 256);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 2, gCarpentersTent3BgTex, 256, 256, 256, 256);
 
-        skyboxCtx->palettes = GameState_Alloc(&globalCtx->state, 0x200 * 3, "../z_vr_box.c", 1231);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 0, gCarpentersTentBgTlut, 16, 16);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 1, gCarpentersTentBg2Tlut, 16, 16);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 2, gCarpentersTentBg3Tlut, 16, 16);
@@ -964,12 +907,10 @@ void Skybox_Setup(GlobalContext* globalCtx, SkyboxContext* skyboxCtx, s16 skybox
     case SKYBOX_HOUSE_MIDO:
         skyboxCtx->unk_140 = 2;
 
-        skyboxCtx->staticSegments[0] = GameState_Alloc(&globalCtx->state, 0x10000 * 3, "../z_vr_box.c", 1226);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 0, gMidosHouseBgTex, 256, 256, 256, 256);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 1, gMidosHouse2BgTex, 256, 256, 256, 256);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 2, gMidosHouse3BgTex, 256, 256, 256, 256);
 
-        skyboxCtx->palettes = GameState_Alloc(&globalCtx->state, 0x200 * 3, "../z_vr_box.c", 1231);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 0, gMidosHouseBgTlut, 16, 16);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 1, gMidosHouseBg2Tlut, 16, 16);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 2, gMidosHouseBg3Tlut, 16, 16);
@@ -977,12 +918,10 @@ void Skybox_Setup(GlobalContext* globalCtx, SkyboxContext* skyboxCtx, s16 skybox
     case SKYBOX_HOUSE_SARIA:
         skyboxCtx->unk_140 = 2;
 
-        skyboxCtx->staticSegments[0] = GameState_Alloc(&globalCtx->state, 0x10000 * 3, "../z_vr_box.c", 1226);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 0, gSariasHouseBgTex, 256, 256, 256, 256);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 1, gSariasHouse2BgTex, 256, 256, 256, 256);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 2, gSariasHouse3BgTex, 256, 256, 256, 256);
 
-        skyboxCtx->palettes = GameState_Alloc(&globalCtx->state, 0x200 * 3, "../z_vr_box.c", 1231);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 0, gSariasHouseBgTlut, 16, 16);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 1, gSariasHouseBg2Tlut, 16, 16);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 2, gSariasHouseBg3Tlut, 16, 16);
@@ -990,20 +929,15 @@ void Skybox_Setup(GlobalContext* globalCtx, SkyboxContext* skyboxCtx, s16 skybox
     case SKYBOX_HOUSE_ALLEY:
         skyboxCtx->unk_140 = 2;
 
-        skyboxCtx->staticSegments[0] = GameState_Alloc(&globalCtx->state, 0x10000 * 3, "../z_vr_box.c", 1226);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 0, gBackAlleyHouseBgTex, 256, 256, 256, 256);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 1, gBackAlleyHouse2BgTex, 256, 256, 256, 256);
         LoadSkyboxTex(globalCtx, skyboxCtx, 0, 2, gBackAlleyHouse3BgTex, 256, 256, 256, 256);
 
-        skyboxCtx->palettes = GameState_Alloc(&globalCtx->state, 0x200 * 3, "../z_vr_box.c", 1231);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 0, gBackAlleyHouseBgTlut, 16, 16);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 1, gBackAlleyHouseBg2Tlut, 16, 16);
         LoadSkyboxPalette(globalCtx, skyboxCtx, 2, gBackAlleyHouseBg3Tlut, 16, 16);
         break;
     default:
-        skyboxCtx->staticSegments[0] = GameState_Alloc(&globalCtx->state, 0x10000 * 4, "../z_vr_box.c", 1226);
-        skyboxCtx->staticSegments[1] = GameState_Alloc(&globalCtx->state, 0x10000 * 4, "../z_vr_box.c", 1226);
-        skyboxCtx->palettes = GameState_Alloc(&globalCtx->state, 0x1000, "../z_vr_box.c", 1226);
         break;
     }
 }

--- a/soh/src/code/z_vr_box.c
+++ b/soh/src/code/z_vr_box.c
@@ -444,7 +444,7 @@ void func_800AF178(SkyboxContext* skyboxCtx, s32 arg1) {
     }
 }
 
-void LoadSkyboxTex(GlobalContext* globalCtx, SkyboxContext* skyboxCtx, int segmentIndex, int imageIndex, char* tex, int width, int height, int offsetW, int offsetH)
+void LoadSkyboxTex(SkyboxContext* skyboxCtx, int segmentIndex, int imageIndex, char* tex, int width, int height, int offsetW, int offsetH)
 {
     skyboxCtx->textures[segmentIndex][imageIndex] = tex;
 }
@@ -454,7 +454,7 @@ void LoadSkyboxTexAtOffset(SkyboxContext* skyboxCtx, int segmentIndex, int image
     skyboxCtx->textures[segmentIndex][imageIndex] = tex;
 }
 
-void LoadSkyboxPalette(GlobalContext* globalCtx, SkyboxContext* skyboxCtx, int paletteIndex, char* palTex, int width,
+void LoadSkyboxPalette(SkyboxContext* skyboxCtx, int paletteIndex, char* palTex, int width,
                        int height) {
     skyboxCtx->palettes[paletteIndex] = palTex;
 }
@@ -631,46 +631,46 @@ void Skybox_Setup(GlobalContext* globalCtx, SkyboxContext* skyboxCtx, s16 skybox
         SkyboxTableEntry entryA = sSkyboxTable[sp41];
 
       for (int i = 0; i < 5; i++)
-            LoadSkyboxTex(globalCtx, skyboxCtx, 0, i, entryA.textures[i], 128, i == 4 ? 128 : 64, 128, 64);
+            LoadSkyboxTex(skyboxCtx, 0, i, entryA.textures[i], 128, i == 4 ? 128 : 64, 128, 64);
 
         SkyboxTableEntry entryB = sSkyboxTable[sp40];
 
         for (int i = 0; i < 5; i++)
-            LoadSkyboxTex(globalCtx, skyboxCtx, 1, i, entryB.textures[i], 128, i == 4 ? 128 : 64, 128, 64);
+            LoadSkyboxTex(skyboxCtx, 1, i, entryB.textures[i], 128, i == 4 ? 128 : 64, 128, 64);
         
         if ((sp41 & 1) ^ ((sp41 & 4) >> 2)) 
         {
-            LoadSkyboxPalette(globalCtx, skyboxCtx, 0, entryA.palettes[0], 16, 8);
-            LoadSkyboxPalette(globalCtx, skyboxCtx, 1, entryB.palettes[0], 16, 8);
+            LoadSkyboxPalette(skyboxCtx, 0, entryA.palettes[0], 16, 8);
+            LoadSkyboxPalette(skyboxCtx, 1, entryB.palettes[0], 16, 8);
         }
         else 
         {
-            LoadSkyboxPalette(globalCtx, skyboxCtx, 0, entryB.palettes[0], 16, 8);
-            LoadSkyboxPalette(globalCtx, skyboxCtx, 1, entryA.palettes[0], 16, 8);
+            LoadSkyboxPalette(skyboxCtx, 0, entryB.palettes[0], 16, 8);
+            LoadSkyboxPalette(skyboxCtx, 1, entryA.palettes[0], 16, 8);
         }
         break;
     case SKYBOX_BAZAAR:
         skyboxCtx->unk_140 = 1;
 
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 0, gBazaarBgTex, 256, 256, 256, 256);
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 1, gBazaar2BgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 0, gBazaarBgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 1, gBazaar2BgTex, 256, 256, 256, 256);
 
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 0, gBazaarBgTlut, 16, 16);
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 1, gBazaarBg2Tlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 0, gBazaarBgTlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 1, gBazaarBg2Tlut, 16, 16);
         skyboxCtx->rot.y = 0.8f;
         break;
     case SKYBOX_HOUSE_LINK:
         skyboxCtx->unk_140 = 1;
 
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 0, gLinksHouseBgTex, 256, 256, 256, 256);
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 1, gLinksHouse2BgTex, 256, 256, 256, 256);
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 2, gLinksHouse3BgTex, 256, 256, 256, 256);
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 3, gLinksHouse4BgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 0, gLinksHouseBgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 1, gLinksHouse2BgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 2, gLinksHouse3BgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 3, gLinksHouse4BgTex, 256, 256, 256, 256);
 
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 0, gLinksHouseBgTlut, 16, 16);
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 1, gLinksHouseBg2Tlut, 16, 16);
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 2, gLinksHouseBg3Tlut, 16, 16);
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 3, gLinksHouseBg4Tlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 0, gLinksHouseBgTlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 1, gLinksHouseBg2Tlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 2, gLinksHouseBg3Tlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 3, gLinksHouseBg4Tlut, 16, 16);
         break;
     case SKYBOX_OVERCAST_SUNSET:
         LoadSkyboxTexAtOffset(skyboxCtx, 0, 0, gSunsetOvercastSkybox1Tex, 128, 64, 0x0);
@@ -679,20 +679,20 @@ void Skybox_Setup(GlobalContext* globalCtx, SkyboxContext* skyboxCtx, s16 skybox
         LoadSkyboxTexAtOffset(skyboxCtx, 0, 3, gSunsetOvercastSkybox4Tex, 128, 64, 0x6000);
         LoadSkyboxTexAtOffset(skyboxCtx, 0, 4, gSunsetOvercastSkybox5Tex, 128, 128, 0x8000);
 
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 0, gSunsetOvercastSkyboxTlut, 16, 8);
+        LoadSkyboxPalette(skyboxCtx, 0, gSunsetOvercastSkyboxTlut, 16, 8);
         break;
     case SKYBOX_MARKET_ADULT:
         skyboxCtx->unk_140 = 1;
 
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 0, gMarketRuinsBgTex, 256, 256, 256, 256);
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 1, gMarketRuins2BgTex, 256, 256, 256, 256);
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 2, gMarketRuins3BgTex, 256, 256, 256, 256);
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 3, gMarketRuins4BgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 0, gMarketRuinsBgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 1, gMarketRuins2BgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 2, gMarketRuins3BgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 3, gMarketRuins4BgTex, 256, 256, 256, 256);
 
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 0, gMarketRuinsBgTlut, 16, 16);
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 1, gMarketRuinsBg2Tlut, 16, 16);
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 2, gMarketRuinsBg3Tlut, 16, 16);
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 3, gMarketRuinsBg4Tlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 0, gMarketRuinsBgTlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 1, gMarketRuinsBg2Tlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 2, gMarketRuinsBg3Tlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 3, gMarketRuinsBg4Tlut, 16, 16);
         break;
     case SKYBOX_CUTSCENE_MAP:
         LoadSkyboxTexAtOffset(skyboxCtx, 0, 0, gHoly0Skybox1Tex, 128, 64, 0x0);
@@ -702,7 +702,7 @@ void Skybox_Setup(GlobalContext* globalCtx, SkyboxContext* skyboxCtx, s16 skybox
         LoadSkyboxTexAtOffset(skyboxCtx, 0, 4, gHoly0Skybox5Tex, 128, 128, 0x8000);
         LoadSkyboxTexAtOffset(skyboxCtx, 0, 5, gHoly0Skybox6Tex, 128, 128, 0xC000);
 
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 0, gHoly0SkyboxTlut, 16, 8);
+        LoadSkyboxPalette(skyboxCtx, 0, gHoly0SkyboxTlut, 16, 8);
 
         LoadSkyboxTexAtOffset(skyboxCtx, 1, 0, gHoly1Skybox1Tex, 128, 64, 0x0);
         LoadSkyboxTexAtOffset(skyboxCtx, 1, 1, gHoly1Skybox2Tex, 128, 64, 0x2000);
@@ -712,230 +712,230 @@ void Skybox_Setup(GlobalContext* globalCtx, SkyboxContext* skyboxCtx, s16 skybox
         LoadSkyboxTexAtOffset(skyboxCtx, 1, 5, gHoly1Skybox6Tex, 128, 128, 0xC000);
 
 
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 1, gHoly1SkyboxTlut, 16, 8);
+        LoadSkyboxPalette(skyboxCtx, 1, gHoly1SkyboxTlut, 16, 8);
         break;
     case SKYBOX_MARKET_CHILD_DAY:
         skyboxCtx->unk_140 = 1;
 
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 0, gMarketDayBgTex, 256, 256, 256, 256);
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 1, gMarketDay2BgTex, 256, 256, 256, 256);
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 2, gMarketDay3BgTex, 256, 256, 256, 256);
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 3, gMarketDay4BgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 0, gMarketDayBgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 1, gMarketDay2BgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 2, gMarketDay3BgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 3, gMarketDay4BgTex, 256, 256, 256, 256);
 
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 0, gMarketDayBgTlut, 16, 16);
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 1, gMarketDayBg2Tlut, 16, 16);
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 2, gMarketDayBg3Tlut, 16, 16);
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 3, gMarketDayBg4Tlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 0, gMarketDayBgTlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 1, gMarketDayBg2Tlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 2, gMarketDayBg3Tlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 3, gMarketDayBg4Tlut, 16, 16);
         break;
     case SKYBOX_MARKET_CHILD_NIGHT:
         skyboxCtx->unk_140 = 1;
 
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 0, gMarketNightBgTex, 256, 256, 256, 256);
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 1, gMarketNight2BgTex, 256, 256, 256, 256);
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 2, gMarketNight3BgTex, 256, 256, 256, 256);
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 3, gMarketNight4BgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 0, gMarketNightBgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 1, gMarketNight2BgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 2, gMarketNight3BgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 3, gMarketNight4BgTex, 256, 256, 256, 256);
 
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 0, gMarketNightBgTlut, 16, 16);
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 1, gMarketNightBg2Tlut, 16, 16);
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 2, gMarketNightBg3Tlut, 16, 16);
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 3, gMarketNightBg4Tlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 0, gMarketNightBgTlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 1, gMarketNightBg2Tlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 2, gMarketNightBg3Tlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 3, gMarketNightBg4Tlut, 16, 16);
         break;
     case SKYBOX_HAPPY_MASK_SHOP:
         skyboxCtx->unk_140 = 1;
 
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 0, gMaskShopBgTex, 256, 256, 256, 256);
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 1, gMaskShop2BgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 0, gMaskShopBgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 1, gMaskShop2BgTex, 256, 256, 256, 256);
 
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 0, gMaskShopBgTlut, 16, 16);
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 1, gMaskShopBg2Tlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 0, gMaskShopBgTlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 1, gMaskShopBg2Tlut, 16, 16);
 
         skyboxCtx->rot.y = 0.8f;
         break;
     case SKYBOX_HOUSE_KNOW_IT_ALL_BROTHERS:
         skyboxCtx->unk_140 = 1;
 
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 0, gKnowItAllBrosHouseBgTex, 256, 256, 256, 256);
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 1, gKnowItAllBrosHouse2BgTex, 256, 256, 256, 256);
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 2, gKnowItAllBrosHouse3BgTex, 256, 256, 256, 256);
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 3, gKnowItAllBrosHouse4BgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 0, gKnowItAllBrosHouseBgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 1, gKnowItAllBrosHouse2BgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 2, gKnowItAllBrosHouse3BgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 3, gKnowItAllBrosHouse4BgTex, 256, 256, 256, 256);
 
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 0, gKnowItAllBrosHouseBgTlut, 16, 16);
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 1, gKnowItAllBrosHouseBg2Tlut, 16, 16);
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 2, gKnowItAllBrosHouseBg3Tlut, 16, 16);
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 3, gKnowItAllBrosHouseBg4Tlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 0, gKnowItAllBrosHouseBgTlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 1, gKnowItAllBrosHouseBg2Tlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 2, gKnowItAllBrosHouseBg3Tlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 3, gKnowItAllBrosHouseBg4Tlut, 16, 16);
         break;
     case SKYBOX_HOUSE_OF_TWINS:
         skyboxCtx->unk_140 = 2;
 
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 0, gHouseOfTwinsBgTex, 256, 256, 256, 256);
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 1, gHouseOfTwins2BgTex, 256, 256, 256, 256);
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 2, gHouseOfTwins3BgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 0, gHouseOfTwinsBgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 1, gHouseOfTwins2BgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 2, gHouseOfTwins3BgTex, 256, 256, 256, 256);
 
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 0, gHouseOfTwinsBgTlut, 16, 16);
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 1, gHouseOfTwinsBg2Tlut, 16, 16);
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 2, gHouseOfTwinsBg3Tlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 0, gHouseOfTwinsBgTlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 1, gHouseOfTwinsBg2Tlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 2, gHouseOfTwinsBg3Tlut, 16, 16);
         break;
     case SKYBOX_STABLES:
         skyboxCtx->unk_140 = 1;
 
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 0, gStableBgTex, 256, 256, 256, 256);
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 1, gStable2BgTex, 256, 256, 256, 256);
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 2, gStable3BgTex, 256, 256, 256, 256);
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 3, gStable4BgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 0, gStableBgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 1, gStable2BgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 2, gStable3BgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 3, gStable4BgTex, 256, 256, 256, 256);
 
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 0, gStableBgTlut, 16, 16);
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 1, gStableBg2Tlut, 16, 16);
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 2, gStableBg3Tlut, 16, 16);
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 3, gStableBg4Tlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 0, gStableBgTlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 1, gStableBg2Tlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 2, gStableBg3Tlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 3, gStableBg4Tlut, 16, 16);
         break;
     case SKYBOX_HOUSE_KAKARIKO:
         skyboxCtx->unk_140 = 1;
 
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 0, gCarpentersHouseBgTex, 256, 256, 256, 256);
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 1, gCarpentersHouse2BgTex, 256, 256, 256, 256);
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 2, gCarpentersHouse3BgTex, 256, 256, 256, 256);
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 3, gCarpentersHouse4BgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 0, gCarpentersHouseBgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 1, gCarpentersHouse2BgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 2, gCarpentersHouse3BgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 3, gCarpentersHouse4BgTex, 256, 256, 256, 256);
 
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 0, gCarpentersHouseBgTlut, 16, 16);
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 1, gCarpentersHouseBg2Tlut, 16, 16);
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 2, gCarpentersHouseBg3Tlut, 16, 16);
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 3, gCarpentersHouseBg4Tlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 0, gCarpentersHouseBgTlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 1, gCarpentersHouseBg2Tlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 2, gCarpentersHouseBg3Tlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 3, gCarpentersHouseBg4Tlut, 16, 16);
         break;
     case SKYBOX_KOKIRI_SHOP:
         skyboxCtx->unk_140 = 1;
 
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 0, gKokiriShopBgTex, 256, 256, 256, 256);
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 1, gKokiriShop2BgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 0, gKokiriShopBgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 1, gKokiriShop2BgTex, 256, 256, 256, 256);
 
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 0, gKokiriShopBgTlut, 16, 16);
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 1, gKokiriShopBg2Tlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 0, gKokiriShopBgTlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 1, gKokiriShopBg2Tlut, 16, 16);
 
         skyboxCtx->rot.y = 0.8f;
         break;
     case SKYBOX_GORON_SHOP:
         skyboxCtx->unk_140 = 1;
 
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 0, gGoronShopBgTex, 256, 256, 256, 256);
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 1, gGoronShop2BgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 0, gGoronShopBgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 1, gGoronShop2BgTex, 256, 256, 256, 256);
 
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 0, gGoronShopBgTlut, 16, 16);
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 1, gGoronShopBg2Tlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 0, gGoronShopBgTlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 1, gGoronShopBg2Tlut, 16, 16);
 
         skyboxCtx->rot.y = 0.8f;
         break;
     case SKYBOX_ZORA_SHOP:
         skyboxCtx->unk_140 = 1;
 
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 0, gZoraShopBgTex, 256, 256, 256, 256);
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 1, gZoraShop2BgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 0, gZoraShopBgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 1, gZoraShop2BgTex, 256, 256, 256, 256);
 
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 0, gZoraShopBgTlut, 16, 16);
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 1, gZoraShopBg2Tlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 0, gZoraShopBgTlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 1, gZoraShopBg2Tlut, 16, 16);
 
         skyboxCtx->rot.y = 0.8f;
         break;
     case SKYBOX_POTION_SHOP_KAKARIKO:
         skyboxCtx->unk_140 = 1;
 
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 0, gKakPotionShopBgTex, 256, 256, 256, 256);
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 1, gKakPotionShop2BgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 0, gKakPotionShopBgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 1, gKakPotionShop2BgTex, 256, 256, 256, 256);
 
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 0, gKakPotionShopBgTlut, 16, 16);
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 1, gKakPotionShopBg2Tlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 0, gKakPotionShopBgTlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 1, gKakPotionShopBg2Tlut, 16, 16);
 
         skyboxCtx->rot.y = 0.8f;
         break;
     case SKYBOX_POTION_SHOP_MARKET:
         skyboxCtx->unk_140 = 1;
 
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 0, gMarketPotionShopBgTex, 256, 256, 256, 256);
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 1, gMarketPotionShop2BgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 0, gMarketPotionShopBgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 1, gMarketPotionShop2BgTex, 256, 256, 256, 256);
 
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 0, gMarketPotionShopBgTlut, 16, 16);
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 1, gMarketPotionShopBg2Tlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 0, gMarketPotionShopBgTlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 1, gMarketPotionShopBg2Tlut, 16, 16);
 
         skyboxCtx->rot.y = 0.8f;
         break;
     case SKYBOX_BOMBCHU_SHOP:
         skyboxCtx->unk_140 = 1;
 
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 0, gBombchuShopBgTex, 256, 256, 256, 256);
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 1, gBombchuShop2BgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 0, gBombchuShopBgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 1, gBombchuShop2BgTex, 256, 256, 256, 256);
 
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 0, gBombchuShopBgTlut, 16, 16);
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 1, gBombchuShopBg2Tlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 0, gBombchuShopBgTlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 1, gBombchuShopBg2Tlut, 16, 16);
 
         skyboxCtx->rot.y = 0.8f;
         break;
     case SKYBOX_HOUSE_RICHARD:
         skyboxCtx->unk_140 = 1;
 
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 0, gRichardsHouseBgTex, 256, 256, 256, 256);
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 1, gRichardsHouse2BgTex, 256, 256, 256, 256);
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 2, gRichardsHouse3BgTex, 256, 256, 256, 256);
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 3, gRichardsHouse4BgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 0, gRichardsHouseBgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 1, gRichardsHouse2BgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 2, gRichardsHouse3BgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 3, gRichardsHouse4BgTex, 256, 256, 256, 256);
 
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 0, gRichardsHouseBgTlut, 16, 16);
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 1, gRichardsHouseBg2Tlut, 16, 16);
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 2, gRichardsHouseBg3Tlut, 16, 16);
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 3, gRichardsHouseBg4Tlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 0, gRichardsHouseBgTlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 1, gRichardsHouseBg2Tlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 2, gRichardsHouseBg3Tlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 3, gRichardsHouseBg4Tlut, 16, 16);
         break;
     case SKYBOX_HOUSE_IMPA:
         skyboxCtx->unk_140 = 1;
 
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 0, gCowHouseBgTex, 256, 256, 256, 256);
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 1, gCowHouse2BgTex, 256, 256, 256, 256);
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 2, gCowHouse3BgTex, 256, 256, 256, 256);
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 3, gCowHouse4BgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 0, gCowHouseBgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 1, gCowHouse2BgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 2, gCowHouse3BgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 3, gCowHouse4BgTex, 256, 256, 256, 256);
 
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 0, gCowHouseBgTlut, 16, 16);
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 1, gCowHouseBg2Tlut, 16, 16);
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 2, gCowHouseBg3Tlut, 16, 16);
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 3, gCowHouseBg4Tlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 0, gCowHouseBgTlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 1, gCowHouseBg2Tlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 2, gCowHouseBg3Tlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 3, gCowHouseBg4Tlut, 16, 16);
         break;
     case SKYBOX_TENT:
         skyboxCtx->unk_140 = 2;
 
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 0, gCarpentersTentBgTex, 256, 256, 256, 256);
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 1, gCarpentersTent2BgTex, 256, 256, 256, 256);
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 2, gCarpentersTent3BgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 0, gCarpentersTentBgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 1, gCarpentersTent2BgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 2, gCarpentersTent3BgTex, 256, 256, 256, 256);
 
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 0, gCarpentersTentBgTlut, 16, 16);
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 1, gCarpentersTentBg2Tlut, 16, 16);
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 2, gCarpentersTentBg3Tlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 0, gCarpentersTentBgTlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 1, gCarpentersTentBg2Tlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 2, gCarpentersTentBg3Tlut, 16, 16);
         break;
     case SKYBOX_HOUSE_MIDO:
         skyboxCtx->unk_140 = 2;
 
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 0, gMidosHouseBgTex, 256, 256, 256, 256);
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 1, gMidosHouse2BgTex, 256, 256, 256, 256);
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 2, gMidosHouse3BgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 0, gMidosHouseBgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 1, gMidosHouse2BgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 2, gMidosHouse3BgTex, 256, 256, 256, 256);
 
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 0, gMidosHouseBgTlut, 16, 16);
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 1, gMidosHouseBg2Tlut, 16, 16);
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 2, gMidosHouseBg3Tlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 0, gMidosHouseBgTlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 1, gMidosHouseBg2Tlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 2, gMidosHouseBg3Tlut, 16, 16);
         break;
     case SKYBOX_HOUSE_SARIA:
         skyboxCtx->unk_140 = 2;
 
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 0, gSariasHouseBgTex, 256, 256, 256, 256);
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 1, gSariasHouse2BgTex, 256, 256, 256, 256);
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 2, gSariasHouse3BgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 0, gSariasHouseBgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 1, gSariasHouse2BgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 2, gSariasHouse3BgTex, 256, 256, 256, 256);
 
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 0, gSariasHouseBgTlut, 16, 16);
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 1, gSariasHouseBg2Tlut, 16, 16);
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 2, gSariasHouseBg3Tlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 0, gSariasHouseBgTlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 1, gSariasHouseBg2Tlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 2, gSariasHouseBg3Tlut, 16, 16);
         break;
     case SKYBOX_HOUSE_ALLEY:
         skyboxCtx->unk_140 = 2;
 
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 0, gBackAlleyHouseBgTex, 256, 256, 256, 256);
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 1, gBackAlleyHouse2BgTex, 256, 256, 256, 256);
-        LoadSkyboxTex(globalCtx, skyboxCtx, 0, 2, gBackAlleyHouse3BgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 0, gBackAlleyHouseBgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 1, gBackAlleyHouse2BgTex, 256, 256, 256, 256);
+        LoadSkyboxTex(skyboxCtx, 0, 2, gBackAlleyHouse3BgTex, 256, 256, 256, 256);
 
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 0, gBackAlleyHouseBgTlut, 16, 16);
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 1, gBackAlleyHouseBg2Tlut, 16, 16);
-        LoadSkyboxPalette(globalCtx, skyboxCtx, 2, gBackAlleyHouseBg3Tlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 0, gBackAlleyHouseBgTlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 1, gBackAlleyHouseBg2Tlut, 16, 16);
+        LoadSkyboxPalette(skyboxCtx, 2, gBackAlleyHouseBg3Tlut, 16, 16);
         break;
     default:
         break;

--- a/soh/src/code/z_vr_box.c
+++ b/soh/src/code/z_vr_box.c
@@ -945,6 +945,7 @@ void Skybox_Setup(GlobalContext* globalCtx, SkyboxContext* skyboxCtx, s16 skybox
 void Skybox_Init(GameState* state, SkyboxContext* skyboxCtx, s16 skyboxId) {
     GlobalContext* globalCtx = (GlobalContext*)state;
 
+    skyboxCtx->skyboxId = skyboxId;
     skyboxCtx->unk_140 = 0;
     skyboxCtx->rot.x = skyboxCtx->rot.y = skyboxCtx->rot.z = 0.0f;
 
@@ -978,6 +979,23 @@ void Skybox_Init(GameState* state, SkyboxContext* skyboxCtx, s16 skyboxId) {
                 skyboxCtx->roomVtx = GameState_Alloc(state, 160 * sizeof(Vtx), "../z_vr_box.c", 1653);
                 ASSERT(skyboxCtx->roomVtx != NULL, "vr_box->roomVtx != NULL", "../z_vr_box.c", 1654);
 
+                func_800AF178(skyboxCtx, 5);
+            }
+        }
+        osSyncPrintf(VT_RST);
+    }
+}
+
+void Skybox_Update(SkyboxContext* skyboxCtx) {
+    if (skyboxCtx->skyboxId != SKYBOX_NONE) {
+        osSyncPrintf(VT_FGCOL(GREEN));
+
+        if (skyboxCtx->unk_140 != 0) {
+            func_800AEFC8(skyboxCtx, skyboxCtx->skyboxId);
+        } else {
+            if (skyboxCtx->skyboxId == SKYBOX_CUTSCENE_MAP) {
+                func_800AF178(skyboxCtx, 6);
+            } else {
                 func_800AF178(skyboxCtx, 5);
             }
         }

--- a/soh/src/code/z_vr_box.c
+++ b/soh/src/code/z_vr_box.c
@@ -457,6 +457,7 @@ void LoadSkyboxTexAtOffset(SkyboxContext* skyboxCtx, int segmentIndex, int image
 void LoadSkyboxPalette(SkyboxContext* skyboxCtx, int paletteIndex, char* palTex, int width,
                        int height) {
     skyboxCtx->palettes[paletteIndex] = palTex;
+    skyboxCtx->palette_size = width * height;
 }
 
 static const char* sSBVRFine0Tex[] =

--- a/soh/src/code/z_vr_box_draw.c
+++ b/soh/src/code/z_vr_box_draw.c
@@ -38,7 +38,12 @@ void SkyboxDraw_Draw(SkyboxContext* skyboxCtx, GraphicsContext* gfxCtx, s16 skyb
     gDPSetColorDither(POLY_OPA_DISP++, G_CD_MAGICSQ);
     gDPSetTextureFilter(POLY_OPA_DISP++, G_TF_BILERP);
 
-    gDPLoadTLUT_pal256(POLY_OPA_DISP++, skyboxCtx->palettes[0]);
+    if (skyboxCtx->palette_size == 256) {
+        gDPLoadTLUT_pal256(POLY_OPA_DISP++, skyboxCtx->palettes[0]);
+    } else {
+        gDPLoadTLUT_pal128(POLY_OPA_DISP++, 0, skyboxCtx->palettes[0]);
+        gDPLoadTLUT_pal128(POLY_OPA_DISP++, 1, skyboxCtx->palettes[1]);
+    }
     gDPSetTextureLUT(POLY_OPA_DISP++, G_TT_RGBA16);
     gDPSetTextureConvert(POLY_OPA_DISP++, G_TC_FILT);
 

--- a/soh/src/code/z_vr_box_draw.c
+++ b/soh/src/code/z_vr_box_draw.c
@@ -17,22 +17,10 @@ void SkyboxDraw_Draw(SkyboxContext* skyboxCtx, GraphicsContext* gfxCtx, s16 skyb
     func_800945A0(gfxCtx);
 
     //gsSPShaderTest(POLY_OPA_DISP++);
-    gSPInvalidateTexCache(POLY_OPA_DISP++, 0);
-    
-    // OTRTODO: Not working...
 
-    /*for (int i = 0; i < 8; i++) 
-    {
-        if (skyboxCtx->staticSegments[0] != NULL)
-            gSPInvalidateTexCache(POLY_OPA_DISP++, (uintptr_t)skyboxCtx->staticSegments[0] + (0x10000 * i));
-        
-        if (skyboxCtx->staticSegments[1] != NULL)
-            gSPInvalidateTexCache(POLY_OPA_DISP++, (uintptr_t)skyboxCtx->staticSegments[1] + (0x10000 * i));
-    }*/
-
-    gSPSegment(POLY_OPA_DISP++, 0x7, skyboxCtx->staticSegments[0]);
+    /*gSPSegment(POLY_OPA_DISP++, 0x7, skyboxCtx->staticSegments[0]);
     gSPSegment(POLY_OPA_DISP++, 0x8, skyboxCtx->staticSegments[1]);
-    gSPSegment(POLY_OPA_DISP++, 0x9, skyboxCtx->palettes);
+    gSPSegment(POLY_OPA_DISP++, 0x9, skyboxCtx->palettes);*/
 
     gDPSetPrimColor(POLY_OPA_DISP++, 0x00, 0x00, 0, 0, 0, blend);
     gSPTexture(POLY_OPA_DISP++, 0x8000, 0x8000, 0, G_TX_RENDERTILE, G_ON);


### PR DESCRIPTION
In particular this removes the texture cache full invalidation instruction which significantly lowers the performance.
Also this should make it easier to replace skyboxes with hd textures.