### PR TITLE
Allocate aligned heaps

### DIFF
--- a/soh/include/functions.h
+++ b/soh/include/functions.h
@@ -2397,6 +2397,9 @@ void FileChoose_Destroy(GameState* thisx);
 
 char* SetQuote();
 
+void Heaps_Alloc(void);
+void Heaps_Free(void);
+
 #ifdef __cplusplus
 };
 #endif

--- a/soh/include/variables.h
+++ b/soh/include/variables.h
@@ -237,8 +237,8 @@ extern void(*D_801755D0)(void);
 	extern u8 gGfxSPTaskYieldBuffer[OS_YIELD_DATA_SIZE]; // 0xC00 bytes
 	extern u8 gGfxSPTaskStack[0x400]; // 0x400 bytes
 	extern GfxPool gGfxPools[2]; // 0x24820 bytes
-	extern u8 gAudioHeap[0x38000]; // 0x38000 bytes
-	extern u8 gSystemHeap[];
+	extern u8* gAudioHeap;
+	extern u8* gSystemHeap;
 
 #ifdef __cplusplus
 };

--- a/soh/src/buffers/heaps.c
+++ b/soh/src/buffers/heaps.c
@@ -1,7 +1,44 @@
 #include "z64.h"
+#include <assert.h>
+#include <malloc.h>
 
-// 0x38000 bytes
-u8 gAudioHeap[0x38000];
+#ifndef _MSC_VER
+#include <unistd.h>
+#endif
 
-//u8 gSystemHeap[UNK_SIZE];
-u8 gSystemHeap[1024 * 1024 * 128];
+#define AUDIO_HEAP_SIZE 0x38000
+#define SYSTEM_HEAP_SIZE (1024 * 1024 * 128)
+
+u8* gAudioHeap;
+
+u8* gSystemHeap;
+
+void Heaps_Alloc(void)
+{
+#ifdef _MSC_VER
+    gAudioHeap = (u8*)_aligned_malloc(AUDIO_HEAP_SIZE, 16);
+    gSystemHeap = (u8*)_aligned_malloc(SYSTEM_HEAP_SIZE, 16);
+#elif defined(_POSIX_VERSION) && (_POSIX_VERSION >= 200112L)
+    if (posix_memalign((void**)&gAudioHeap, 16, AUDIO_HEAP_SIZE) != 0)
+        gAudioHeap = NULL;
+    if (posix_memalign((void**)&gSystemHeap, 16, SYSTEM_HEAP_SIZE) != 0)
+        gSystemHeap = NULL;
+#else
+    gAudioHeap = (u8*)memalign(16, AUDIO_HEAP_SIZE);
+    gSystemHeap = (u8*)memalign(16, SYSTEM_HEAP_SIZE);
+#endif
+
+    assert(gAudioHeap != NULL);
+    assert(gSystemHeap != NULL);
+}
+
+void Heaps_Free(void)
+{
+#ifdef _MSC_VER
+    _aligned_free(gAudioHeap);
+    _aligned_free(gSystemHeap);
+#else
+    free(gAudioHeap);
+    free(gSystemHeap);
+#endif
+}

--- a/soh/src/buffers/heaps.c
+++ b/soh/src/buffers/heaps.c
@@ -10,22 +10,21 @@
 #define SYSTEM_HEAP_SIZE (1024 * 1024 * 128)
 
 u8* gAudioHeap;
-
 u8* gSystemHeap;
 
 void Heaps_Alloc(void)
 {
 #ifdef _MSC_VER
-    gAudioHeap = (u8*)_aligned_malloc(AUDIO_HEAP_SIZE, 16);
-    gSystemHeap = (u8*)_aligned_malloc(SYSTEM_HEAP_SIZE, 16);
+    gAudioHeap = (u8*)_aligned_malloc(AUDIO_HEAP_SIZE, 0x10);
+    gSystemHeap = (u8*)_aligned_malloc(SYSTEM_HEAP_SIZE, 0x10);
 #elif defined(_POSIX_VERSION) && (_POSIX_VERSION >= 200112L)
-    if (posix_memalign((void**)&gAudioHeap, 16, AUDIO_HEAP_SIZE) != 0)
+    if (posix_memalign((void**)&gAudioHeap, 0x10, AUDIO_HEAP_SIZE) != 0)
         gAudioHeap = NULL;
-    if (posix_memalign((void**)&gSystemHeap, 16, SYSTEM_HEAP_SIZE) != 0)
+    if (posix_memalign((void**)&gSystemHeap, 0x10, SYSTEM_HEAP_SIZE) != 0)
         gSystemHeap = NULL;
 #else
-    gAudioHeap = (u8*)memalign(16, AUDIO_HEAP_SIZE);
-    gSystemHeap = (u8*)memalign(16, SYSTEM_HEAP_SIZE);
+    gAudioHeap = (u8*)memalign(0x10, AUDIO_HEAP_SIZE);
+    gSystemHeap = (u8*)memalign(0x10, SYSTEM_HEAP_SIZE);
 #endif
 
     assert(gAudioHeap != NULL);

--- a/soh/src/code/main.c
+++ b/soh/src/code/main.c
@@ -63,6 +63,7 @@ void Main(void* arg) {
     PreNmiBuff_Init(gAppNmiBufferPtr);
     Fault_Init();
     SysCfb_Init(0);
+    Heaps_Alloc();
     sysHeap = gSystemHeap;
     fb = SysCfb_GetFbPtr(0);
     gSystemHeapSize = 1024 * 1024 * 4;
@@ -131,4 +132,6 @@ void Main(void* arg) {
     osDestroyThread(&sGraphThread);
     func_800FBFD8();
     osSyncPrintf("mainproc 実行終了\n"); // "End of execution"
+
+    Heaps_Free();
 }


### PR DESCRIPTION
This PR makes sure the heap buffers are always aligned to 16 bytes which avoids a possible truncation in the heap implementations.
It also allocates the buffers from the heap instead of having large static arrays.

Note: Works fine with GCC, untested on MSVC