### PR TITLE
Added DPad support to ocarina and text prompts

### DIFF
--- a/libultraship/libultraship/GameSettings.cpp
+++ b/libultraship/libultraship/GameSettings.cpp
@@ -59,7 +59,7 @@ namespace Game {
         CVar_SetS32("gPauseLiveLink", Settings.enhancements.animated_pause_menu);
 
         Settings.enhancements.minimal_ui = stob(Conf[EnhancementSection]["minimal_ui"]);
-        CVar_SetS32(const_cast<char*>("gMinimalUI"), Settings.enhancements.minimal_ui);
+        CVar_SetS32("gMinimalUI", Settings.enhancements.minimal_ui);
 
         // Audio
         Settings.audio.master = Ship::stof(Conf[AudioSection]["master"]);
@@ -89,6 +89,9 @@ namespace Game {
 
         Settings.controller.input_enabled = stob(Conf[ControllerSection]["input_enabled"]);
         CVar_SetS32("gInputEnabled", Settings.controller.input_enabled);
+
+        Settings.controller.dpad_pause_name = stob(Conf[ControllerSection]["dpad_pause_name"]);
+        CVar_SetS32("gDpadPauseName", Settings.controller.dpad_pause_name);
         
         // Cheats
         Settings.cheats.debug_mode = stob(Conf[CheatSection]["debug_mode"]);
@@ -149,6 +152,7 @@ namespace Game {
         Conf[ControllerSection]["rumble_strength"]  = std::to_string(Settings.controller.rumble_strength);
         Conf[ControllerSection]["input_scale"]   = std::to_string(Settings.controller.input_scale);
         Conf[ControllerSection]["input_enabled"] = std::to_string(Settings.controller.input_enabled);
+        Conf[ControllerSection]["dpad_pause_name"] = std::to_string(Settings.controller.dpad_pause_name);
 
         // Cheats
         Conf[CheatSection]["debug_mode"] = std::to_string(Settings.cheats.debug_mode);

--- a/libultraship/libultraship/GameSettings.cpp
+++ b/libultraship/libultraship/GameSettings.cpp
@@ -92,6 +92,9 @@ namespace Game {
 
         Settings.controller.dpad_pause_name = stob(Conf[ControllerSection]["dpad_pause_name"]);
         CVar_SetS32("gDpadPauseName", Settings.controller.dpad_pause_name);
+
+        Settings.controller.dpad_ocarina_text = stob(Conf[ControllerSection]["dpad_ocarina_text"]);
+        CVar_SetS32("gDpadOcarinaText", Settings.controller.dpad_ocarina_text);
         
         // Cheats
         Settings.cheats.debug_mode = stob(Conf[CheatSection]["debug_mode"]);
@@ -153,6 +156,7 @@ namespace Game {
         Conf[ControllerSection]["input_scale"]   = std::to_string(Settings.controller.input_scale);
         Conf[ControllerSection]["input_enabled"] = std::to_string(Settings.controller.input_enabled);
         Conf[ControllerSection]["dpad_pause_name"] = std::to_string(Settings.controller.dpad_pause_name);
+        Conf[ControllerSection]["dpad_ocarina_text"] = std::to_string(Settings.controller.dpad_ocarina_text);
 
         // Cheats
         Conf[CheatSection]["debug_mode"] = std::to_string(Settings.cheats.debug_mode);

--- a/libultraship/libultraship/GameSettings.h
+++ b/libultraship/libultraship/GameSettings.h
@@ -35,6 +35,7 @@ struct SoHConfigType {
         float gyroDriftY = 0.0f;
         bool input_enabled = false;
         bool dpad_pause_name = false;
+        bool dpad_ocarina_text = false;
     } controller;
 
     // Cheats

--- a/libultraship/libultraship/GameSettings.h
+++ b/libultraship/libultraship/GameSettings.h
@@ -34,6 +34,7 @@ struct SoHConfigType {
         float gyroDriftX = 0.0f;
         float gyroDriftY = 0.0f;
         bool input_enabled = false;
+        bool dpad_pause_name = false;
     } controller;
 
     // Cheats

--- a/libultraship/libultraship/Lib/Fast3D/gfx_direct3d11.cpp
+++ b/libultraship/libultraship/Lib/Fast3D/gfx_direct3d11.cpp
@@ -531,8 +531,8 @@ static struct ShaderProgram *gfx_d3d11_create_and_load_new_shader(uint64_t shade
         blend_desc.RenderTarget[0].SrcBlend = D3D11_BLEND_SRC_ALPHA;
         blend_desc.RenderTarget[0].DestBlend = D3D11_BLEND_INV_SRC_ALPHA;
         blend_desc.RenderTarget[0].BlendOp = D3D11_BLEND_OP_ADD;
-        blend_desc.RenderTarget[0].SrcBlendAlpha = D3D11_BLEND_ONE;
-        blend_desc.RenderTarget[0].DestBlendAlpha = D3D11_BLEND_ZERO;
+        blend_desc.RenderTarget[0].SrcBlendAlpha = D3D11_BLEND_SRC_ALPHA;
+        blend_desc.RenderTarget[0].DestBlendAlpha = D3D11_BLEND_INV_SRC_ALPHA;
         blend_desc.RenderTarget[0].BlendOpAlpha = D3D11_BLEND_OP_ADD;
         blend_desc.RenderTarget[0].RenderTargetWriteMask = D3D11_COLOR_WRITE_ENABLE_ALL;
     } else {

--- a/libultraship/libultraship/Lib/Fast3D/gfx_direct3d11.cpp
+++ b/libultraship/libultraship/Lib/Fast3D/gfx_direct3d11.cpp
@@ -977,8 +977,8 @@ uint16_t gfx_d3d11_get_pixel_depth_old(float x, float y) {
 
 } // namespace
 
-void* SohImGui::GetTextureByID(int id) {
-    return d3d.textures[id].resource_view.Get();
+ImTextureID SohImGui::GetTextureByID(int id) {
+    return impl.backend == Backend::DX11 ? d3d.textures[id].resource_view.Get() : reinterpret_cast<ImTextureID>(id);
 }
 
 struct GfxRenderingAPI gfx_direct3d11_api = {

--- a/libultraship/libultraship/SohImGuiImpl.cpp
+++ b/libultraship/libultraship/SohImGuiImpl.cpp
@@ -353,6 +353,13 @@ namespace SohImGui {
                     needs_save = true;
                 }
 
+                ImGui::Separator();
+
+                if (ImGui::Checkbox("Dpad Support on Pause and File Select", &Game::Settings.controller.dpad_pause_name)) {
+                    CVar_SetS32("gDpadPauseName", Game::Settings.controller.dpad_pause_name);
+                    needs_save = true;
+                }
+
                 ImGui::EndMenu();
             }
 
@@ -367,7 +374,7 @@ namespace SohImGui {
                 }
 
                 if (ImGui::Checkbox("Minimal UI", &Game::Settings.enhancements.minimal_ui)) {
-                    CVar_SetS32(const_cast<char*>("gMinimalUI"), Game::Settings.enhancements.minimal_ui);
+                    CVar_SetS32("gMinimalUI", Game::Settings.enhancements.minimal_ui);
                     needs_save = true;
                 }
 

--- a/libultraship/libultraship/SohImGuiImpl.cpp
+++ b/libultraship/libultraship/SohImGuiImpl.cpp
@@ -360,6 +360,11 @@ namespace SohImGui {
                     needs_save = true;
                 }
 
+                if (ImGui::Checkbox("DPad Support in Ocarina and Text Choice", &Game::Settings.controller.dpad_ocarina_text)) {
+                    CVar_SetS32("gDpadOcarinaText", Game::Settings.controller.dpad_ocarina_text);
+                    needs_save = true;
+                }
+
                 ImGui::EndMenu();
             }
 

--- a/libultraship/libultraship/SohImGuiImpl.h
+++ b/libultraship/libultraship/SohImGuiImpl.h
@@ -47,11 +47,23 @@ namespace SohImGui {
         } sdl;
     } EventImpl;
 
+    extern WindowImpl impl;
+
+    using WindowDrawFunc = void(*)(bool& enabled);
+
+    typedef struct {
+        bool enabled;
+        WindowDrawFunc drawFunc;
+    } CustomWindow;
+
     extern Console* console;
     void Init(WindowImpl window_impl);
     void Update(EventImpl event);
     void Draw(void);
     void ShowCursor(bool hide, Dialogues w);
     void BindCmd(const std::string& cmd, CommandEntry entry);
-    void* GetTextureByID(int id);
+    void AddWindow(const std::string& category, const std::string& name, WindowDrawFunc drawFunc);
+    void LoadResource(const std::string& name, const std::string& path);
+    ImTextureID GetTextureByID(int id);
+    ImTextureID GetTextureByName(const std::string& name);
 }

--- a/soh/soh.vcxproj
+++ b/soh/soh.vcxproj
@@ -178,6 +178,8 @@
   <ItemGroup>
     <ClCompile Include="soh\Enhancements\bootcommands.c" />
     <ClCompile Include="soh\Enhancements\debugconsole.cpp" />
+    <ClCompile Include="soh\Enhancements\debugger\debugger.cpp" />
+    <ClCompile Include="soh\Enhancements\debugger\debugSaveEditor.cpp" />
     <ClCompile Include="soh\Enhancements\gameconsole.c" />
     <ClCompile Include="soh\GbiWrap.cpp" />
     <ClCompile Include="soh\gu_pc.c" />
@@ -922,6 +924,8 @@
     <ClInclude Include="soh\Enhancements\bootcommands.h" />
     <ClInclude Include="soh\Enhancements\cvar.h" />
     <ClInclude Include="soh\Enhancements\debugconsole.h" />
+    <ClInclude Include="soh\Enhancements\debugger\debugger.h" />
+    <ClInclude Include="soh\Enhancements\debugger\debugSaveEditor.h" />
     <ClInclude Include="soh\gameconsole.h" />
     <ClInclude Include="soh\OTRGlobals.h" />
     <ClInclude Include="src\overlays\actors\ovl_Arms_Hook\z_arms_hook.h" />

--- a/soh/soh.vcxproj.filters
+++ b/soh/soh.vcxproj.filters
@@ -76,6 +76,12 @@
     <Filter Include="Source Files\src\overlays\actors">
       <UniqueIdentifier>{18b9727f-30de-4ab8-a317-916090d4a110}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Header Files\soh\Enhancements\debugger">
+      <UniqueIdentifier>{9a4378ec-e30f-47b6-9ad6-5ce738b4cf99}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\soh\Enhancements\debugger">
+      <UniqueIdentifier>{04fc1c52-49ff-48e2-ae23-2c00867374f8}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\boot\assert.c">
@@ -2169,6 +2175,12 @@
     <ClCompile Include="src\overlays\actors\ovl_Shot_Sun\z_shot_sun.c">
       <Filter>Source Files\src\overlays\actors</Filter>
     </ClCompile>
+    <ClCompile Include="soh\Enhancements\debugger\debugger.cpp">
+      <Filter>Source Files\soh\Enhancements\debugger</Filter>
+    </ClCompile>
+    <ClCompile Include="soh\Enhancements\debugger\debugSaveEditor.cpp">
+      <Filter>Source Files\soh\Enhancements\debugger</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\overlays\actors\ovl_kaleido_scope\z_kaleido_scope.h">
@@ -3709,6 +3721,12 @@
     </ClInclude>
     <ClInclude Include="resource.h">
       <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="soh\Enhancements\debugger\debugger.h">
+      <Filter>Header Files\soh\Enhancements\debugger</Filter>
+    </ClInclude>
+    <ClInclude Include="soh\Enhancements\debugger\debugSaveEditor.h">
+      <Filter>Header Files\soh\Enhancements\debugger</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
+++ b/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
@@ -1,0 +1,527 @@
+#include "debugSaveEditor.h"
+#include "../libultraship/SohImGuiImpl.h"
+
+#include <bit>
+#include <map>
+#include <string>
+
+extern "C" {
+#include <z64.h>
+#include "variables.h"
+#include "functions.h"
+#include "macros.h"
+extern GlobalContext* gGlobalCtx;
+
+#include "textures/icon_item_static/icon_item_static.h"
+}
+
+typedef struct {
+    uint32_t id;
+    std::string name;
+    std::string texturePath;
+} ItemMapEntry;
+
+#define ITEM_MAP_ENTRY(id)                              \
+    {                                                   \
+        id, {                                           \
+            id, #id, static_cast<char*>(gItemIcons[id]) \
+        }                                               \
+    }
+
+// Maps items ids to info for use in ImGui
+std::map<uint32_t, ItemMapEntry> itemMapping = {
+    ITEM_MAP_ENTRY(ITEM_STICK),
+    ITEM_MAP_ENTRY(ITEM_NUT),
+    ITEM_MAP_ENTRY(ITEM_BOMB),
+    ITEM_MAP_ENTRY(ITEM_BOW),
+    ITEM_MAP_ENTRY(ITEM_ARROW_FIRE),
+    ITEM_MAP_ENTRY(ITEM_DINS_FIRE),
+    ITEM_MAP_ENTRY(ITEM_SLINGSHOT),
+    ITEM_MAP_ENTRY(ITEM_OCARINA_FAIRY),
+    ITEM_MAP_ENTRY(ITEM_OCARINA_TIME),
+    ITEM_MAP_ENTRY(ITEM_BOMBCHU),
+    ITEM_MAP_ENTRY(ITEM_HOOKSHOT),
+    ITEM_MAP_ENTRY(ITEM_LONGSHOT),
+    ITEM_MAP_ENTRY(ITEM_ARROW_ICE),
+    ITEM_MAP_ENTRY(ITEM_FARORES_WIND),
+    ITEM_MAP_ENTRY(ITEM_BOOMERANG),
+    ITEM_MAP_ENTRY(ITEM_LENS),
+    ITEM_MAP_ENTRY(ITEM_BEAN),
+    ITEM_MAP_ENTRY(ITEM_HAMMER),
+    ITEM_MAP_ENTRY(ITEM_ARROW_LIGHT),
+    ITEM_MAP_ENTRY(ITEM_NAYRUS_LOVE),
+    ITEM_MAP_ENTRY(ITEM_BOTTLE),
+    ITEM_MAP_ENTRY(ITEM_POTION_RED),
+    ITEM_MAP_ENTRY(ITEM_POTION_GREEN),
+    ITEM_MAP_ENTRY(ITEM_POTION_BLUE),
+    ITEM_MAP_ENTRY(ITEM_FAIRY),
+    ITEM_MAP_ENTRY(ITEM_FISH),
+    ITEM_MAP_ENTRY(ITEM_MILK_BOTTLE),
+    ITEM_MAP_ENTRY(ITEM_LETTER_RUTO),
+    ITEM_MAP_ENTRY(ITEM_BLUE_FIRE),
+    ITEM_MAP_ENTRY(ITEM_BUG),
+    ITEM_MAP_ENTRY(ITEM_BIG_POE),
+    ITEM_MAP_ENTRY(ITEM_MILK_HALF),
+    ITEM_MAP_ENTRY(ITEM_POE),
+    ITEM_MAP_ENTRY(ITEM_WEIRD_EGG),
+    ITEM_MAP_ENTRY(ITEM_CHICKEN),
+    ITEM_MAP_ENTRY(ITEM_LETTER_ZELDA),
+    ITEM_MAP_ENTRY(ITEM_MASK_KEATON),
+    ITEM_MAP_ENTRY(ITEM_MASK_SKULL),
+    ITEM_MAP_ENTRY(ITEM_MASK_SPOOKY),
+    ITEM_MAP_ENTRY(ITEM_MASK_BUNNY),
+    ITEM_MAP_ENTRY(ITEM_MASK_GORON),
+    ITEM_MAP_ENTRY(ITEM_MASK_ZORA),
+    ITEM_MAP_ENTRY(ITEM_MASK_GERUDO),
+    ITEM_MAP_ENTRY(ITEM_MASK_TRUTH),
+    ITEM_MAP_ENTRY(ITEM_SOLD_OUT),
+    ITEM_MAP_ENTRY(ITEM_POCKET_EGG),
+    ITEM_MAP_ENTRY(ITEM_POCKET_CUCCO),
+    ITEM_MAP_ENTRY(ITEM_COJIRO),
+    ITEM_MAP_ENTRY(ITEM_ODD_MUSHROOM),
+    ITEM_MAP_ENTRY(ITEM_ODD_POTION),
+    ITEM_MAP_ENTRY(ITEM_SAW),
+    ITEM_MAP_ENTRY(ITEM_SWORD_BROKEN),
+    ITEM_MAP_ENTRY(ITEM_PRESCRIPTION),
+    ITEM_MAP_ENTRY(ITEM_FROG),
+    ITEM_MAP_ENTRY(ITEM_EYEDROPS),
+    ITEM_MAP_ENTRY(ITEM_CLAIM_CHECK),
+    ITEM_MAP_ENTRY(ITEM_BOW_ARROW_FIRE),
+    ITEM_MAP_ENTRY(ITEM_BOW_ARROW_ICE),
+    ITEM_MAP_ENTRY(ITEM_BOW_ARROW_LIGHT),
+    ITEM_MAP_ENTRY(ITEM_SWORD_KOKIRI),
+    ITEM_MAP_ENTRY(ITEM_SWORD_MASTER),
+    ITEM_MAP_ENTRY(ITEM_SWORD_BGS),
+    ITEM_MAP_ENTRY(ITEM_SHIELD_DEKU),
+    ITEM_MAP_ENTRY(ITEM_SHIELD_HYLIAN),
+    ITEM_MAP_ENTRY(ITEM_SHIELD_MIRROR),
+    ITEM_MAP_ENTRY(ITEM_TUNIC_KOKIRI),
+    ITEM_MAP_ENTRY(ITEM_TUNIC_GORON),
+    ITEM_MAP_ENTRY(ITEM_TUNIC_ZORA),
+    ITEM_MAP_ENTRY(ITEM_BOOTS_KOKIRI),
+    ITEM_MAP_ENTRY(ITEM_BOOTS_IRON),
+    ITEM_MAP_ENTRY(ITEM_BOOTS_HOVER),
+    ITEM_MAP_ENTRY(ITEM_BULLET_BAG_30),
+    ITEM_MAP_ENTRY(ITEM_BULLET_BAG_40),
+    ITEM_MAP_ENTRY(ITEM_BULLET_BAG_50),
+    ITEM_MAP_ENTRY(ITEM_QUIVER_30),
+    ITEM_MAP_ENTRY(ITEM_QUIVER_40),
+    ITEM_MAP_ENTRY(ITEM_QUIVER_50),
+    ITEM_MAP_ENTRY(ITEM_BOMB_BAG_20),
+    ITEM_MAP_ENTRY(ITEM_BOMB_BAG_30),
+    ITEM_MAP_ENTRY(ITEM_BOMB_BAG_40),
+    ITEM_MAP_ENTRY(ITEM_BRACELET),
+    ITEM_MAP_ENTRY(ITEM_GAUNTLETS_SILVER),
+    ITEM_MAP_ENTRY(ITEM_GAUNTLETS_GOLD),
+    ITEM_MAP_ENTRY(ITEM_SCALE_SILVER),
+    ITEM_MAP_ENTRY(ITEM_SCALE_GOLDEN),
+    ITEM_MAP_ENTRY(ITEM_SWORD_KNIFE),
+    ITEM_MAP_ENTRY(ITEM_WALLET_ADULT),
+    ITEM_MAP_ENTRY(ITEM_WALLET_GIANT),
+    ITEM_MAP_ENTRY(ITEM_SEEDS),
+    ITEM_MAP_ENTRY(ITEM_FISHING_POLE),
+};
+
+// Maps entries in the GS flag array to the area name it represents
+std::vector<std::string> gsMapping = {
+    "Deku Tree",
+    "Dodongo's Cavern",
+    "Inside Jabu-Jabu's Belly",
+    "Forest Temple",
+    "Fire Temple",
+    "Water Temple",
+    "Spirit Temple",
+    "Shadow Temple",
+    "Bottom of the Well",
+    "Ice Cavern",
+    "Hyrule Field",
+    "Lon Lon Ranch",
+    "Kokiri Forest",
+    "Lost Woods, Sacred Forest Meadow",
+    "Castle Town and Ganon's Castle",
+    "Death Mountain Trail, Goron City",
+    "Kakariko Village",
+    "Zora Fountain, River",
+    "Lake Hylia",
+    "Gerudo Valley",
+    "Gerudo Fortress",
+    "Desert Colossus, Haunted Wasteland",
+};
+extern "C" u8 gAreaGsFlags[];
+
+extern "C" u8 gAmmoItems[];
+
+// Modification of gAmmoItems that replaces ITEM_NONE with the item in inventory slot it represents
+u8 gAllAmmoItems[] = {
+    ITEM_STICK,     ITEM_NUT,          ITEM_BOMB,    ITEM_BOW,      ITEM_ARROW_FIRE, ITEM_DINS_FIRE,
+    ITEM_SLINGSHOT, ITEM_OCARINA_TIME, ITEM_BOMBCHU, ITEM_LONGSHOT, ITEM_ARROW_ICE,  ITEM_FARORES_WIND,
+    ITEM_BOOMERANG, ITEM_LENS,         ITEM_BEAN,    ITEM_HAMMER,
+};
+
+// Adds a text tooltip for the previous ImGui item
+void SetLastItemHoverText(const std::string& text) {
+    if (ImGui::IsItemHovered()) {
+        ImGui::BeginTooltip();
+        ImGui::Text(text.c_str());
+        ImGui::EndTooltip();
+    }
+}
+
+// Adds a "?" next to the previous ImGui item with a custom tooltip
+void InsertHelpHoverText(const std::string& text) {
+    ImGui::SameLine();
+    ImGui::TextColored(ImVec4(0.7f, 0.7f, 0.7f, 1.0f), "?");
+    if (ImGui::IsItemHovered()) {
+        ImGui::BeginTooltip();
+        ImGui::Text(text.c_str());
+        ImGui::EndTooltip();
+    }
+}
+
+void DrawSaveEditor(bool& open) {
+    if (!open) {
+        return;
+    }
+
+    ImGui::SetNextWindowSize(ImVec2(520, 600), ImGuiCond_FirstUseEver);
+    if (!ImGui::Begin("Save Editor", &open)) {
+        ImGui::End();
+        return;
+    }
+
+    // TODO This is the bare minimum to get the player name showing
+    // There will need to be more effort to get it robust and editable
+    std::string name;
+    for (int i = 0; i < 8; i++) {
+        char letter = gSaveContext.playerName[i] + 0x3D;
+        if (letter == '{') {
+            letter = '\0';
+        }
+        name += letter;
+    }
+    name += '\0';
+
+    if (ImGui::BeginTabBar("SaveContextTabBar", ImGuiTabBarFlags_NoCloseWithMiddleMouseButton)) {
+        if (ImGui::BeginTabItem("Info")) {
+            ImGui::PushItemWidth(ImGui::GetFontSize() * 6);
+
+            ImGui::Text("Name: %s", name.c_str());
+            InsertHelpHoverText("Player Name");
+
+            // Use an intermediary to keep the health from updating (and potentially killing the player)
+            // until it is done being edited
+            int16_t healthIntermediary = gSaveContext.healthCapacity;
+            ImGui::InputScalar("Max Health", ImGuiDataType_S16, &healthIntermediary);
+            if (ImGui::IsItemDeactivated()) {
+                gSaveContext.healthCapacity = healthIntermediary;
+            }
+            InsertHelpHoverText("Maximum health. 16 units per full heart");
+            if (gSaveContext.health > gSaveContext.healthCapacity) {
+                gSaveContext.health = gSaveContext.healthCapacity; // Clamp health to new max
+            }
+
+            const uint16_t healthMin = 0;
+            const uint16_t healthMax = gSaveContext.healthCapacity;
+            ImGui::SetNextItemWidth(ImGui::GetFontSize() * 15);
+            ImGui::SliderScalar("Health", ImGuiDataType_S16, &gSaveContext.health, &healthMin, &healthMax);
+            InsertHelpHoverText("Current health. 16 units per full heart");
+
+            bool doubleDefense = gSaveContext.doubleDefense != 0;
+            if (ImGui::Checkbox("Double Defense", &doubleDefense)) {
+                gSaveContext.doubleDefense = doubleDefense;
+                gSaveContext.inventory.defenseHearts =
+                    gSaveContext.doubleDefense ? 20 : 0; // Set to get the border drawn in the UI
+            }
+            InsertHelpHoverText("Is double defense unlocked?");
+
+            std::string magicName;
+            if (gSaveContext.magicLevel == 2) {
+                magicName = "Double";
+            } else if (gSaveContext.magicLevel == 1) {
+                magicName = "Single";
+            } else {
+                magicName = "None";
+            }
+            ImGui::SetNextItemWidth(ImGui::GetFontSize() * 6);
+            if (ImGui::BeginCombo("Magic Level", magicName.c_str())) {
+                if (ImGui::Selectable("Double")) {
+                    gSaveContext.magicLevel = 2;
+                    gSaveContext.magicAcquired = true;
+                    gSaveContext.doubleMagic = true;
+                }
+                if (ImGui::Selectable("Single")) {
+                    gSaveContext.magicLevel = 1;
+                    gSaveContext.magicAcquired = true;
+                    gSaveContext.doubleMagic = false;
+                }
+                if (ImGui::Selectable("None")) {
+                    gSaveContext.magicLevel = 0;
+                    gSaveContext.magicAcquired = false;
+                    gSaveContext.doubleMagic = false;
+                }
+
+                ImGui::EndCombo();
+            }
+            InsertHelpHoverText("Current magic level");
+            gSaveContext.unk_13F4 = gSaveContext.magicLevel * 0x30; // Set to get the bar drawn in the UI
+            if (gSaveContext.magic > gSaveContext.unk_13F4) {
+                gSaveContext.magic = gSaveContext.unk_13F4; // Clamp magic to new max
+            }
+
+            const uint8_t magicMin = 0;
+            const uint8_t magicMax = gSaveContext.unk_13F4;
+            ImGui::SetNextItemWidth(ImGui::GetFontSize() * 15);
+            ImGui::SliderScalar("Magic", ImGuiDataType_S8, &gSaveContext.magic, &magicMin, &magicMax);
+            InsertHelpHoverText("Current magic. 48 units per magic level");
+
+            ImGui::InputScalar("Rupees", ImGuiDataType_S16, &gSaveContext.rupees);
+            InsertHelpHoverText("Current rupees");
+
+            const uint16_t dayTimeMin = 0;
+            const uint16_t dayTimeMax = 0xFFFF;
+            ImGui::SetNextItemWidth(ImGui::GetFontSize() * 15);
+            ImGui::SliderScalar("Time", ImGuiDataType_U16, &gSaveContext.dayTime, &dayTimeMin, &dayTimeMax);
+            InsertHelpHoverText("Time of day");
+            if (ImGui::Button("Dawn")) {
+                gSaveContext.dayTime = 0x4000;
+            }
+            ImGui::SameLine();
+            if (ImGui::Button("Noon")) {
+                gSaveContext.dayTime = 0x8000;
+            }
+            ImGui::SameLine();
+            if (ImGui::Button("Sunset")) {
+                gSaveContext.dayTime = 0xC000;
+            }
+            ImGui::SameLine();
+            if (ImGui::Button("Midnight")) {
+                gSaveContext.dayTime = 0;
+            }
+
+            ImGui::InputScalar("Total Days", ImGuiDataType_S32, &gSaveContext.totalDays);
+            InsertHelpHoverText("Total number of days elapsed since the start of the game");
+
+            ImGui::InputScalar("Deaths", ImGuiDataType_U16, &gSaveContext.deaths);
+            InsertHelpHoverText("Total number of deaths");
+
+            // TODO Move to quest status screen once the page is created
+            ImGui::InputScalar("GS Count", ImGuiDataType_S16, &gSaveContext.inventory.gsTokens);
+            InsertHelpHoverText("Number of gold skulltula tokens aquired");
+
+            bool bgsFlag = gSaveContext.bgsFlag != 0;
+            if (ImGui::Checkbox("Has BGS", &bgsFlag)) {
+                gSaveContext.bgsFlag = bgsFlag;
+            }
+            InsertHelpHoverText("Is Biggoron sword unlocked? Replaces Giant's knife");
+
+            ImGui::InputScalar("Sword Health", ImGuiDataType_U16, &gSaveContext.swordHealth);
+            InsertHelpHoverText("Giant's knife health. Default is 8. Must be >0 for Biggoron sword to work");
+
+            ImGui::InputScalar("Bgs Day Count", ImGuiDataType_S32, &gSaveContext.bgsDayCount);
+            InsertHelpHoverText("Total number of days elapsed since giving Biggoron the claim check");
+
+            // TODO Changing Link's age is more involved than just setting gSaveContext.linkAge
+            // It might not fit here and instead should be only changable when changing scenes
+            /*
+            if (ImGui::BeginCombo("Link Age", LINK_IS_ADULT ? "Adult" : "Child")) {
+                if (ImGui::Selectable("Adult")) {
+                    gSaveContext.linkAge = 0;
+                }
+                if (ImGui::Selectable("Child")) {
+                    gSaveContext.linkAge = 1;
+                }
+
+                ImGui::EndCombo();
+            }
+            */
+
+            ImGui::PopItemWidth();
+            ImGui::EndTabItem();
+        }
+
+        if (ImGui::BeginTabItem("Inventory")) {
+            static bool restrictToValid = true;
+
+            ImGui::Checkbox("Restrict to valid items", &restrictToValid);
+            InsertHelpHoverText("Restricts items and ammo to only what is possible to legally acquire in-game");
+
+            for (int32_t y = 0; y < 4; y++) {
+                for (int32_t x = 0; x < 6; x++) {
+                    int32_t index = x + y * 6;
+                    static int32_t selectedIndex = -1;
+                    static const char* itemPopupPicker = "itemPopupPicker";
+
+                    ImGui::PushID(index);
+
+                    if (x != 0) {
+                        ImGui::SameLine();
+                    }
+
+                    ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(1, 1, 1, 0));
+                    ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize, 1.0f);
+                    uint8_t item = gSaveContext.inventory.items[index];
+                    if (item != ITEM_NONE) {
+                        const ItemMapEntry& slotEntry = itemMapping.find(item)->second;
+                        if (ImGui::ImageButton(SohImGui::GetTextureByName(slotEntry.name), ImVec2(32.0f, 32.0f),
+                                               ImVec2(0, 0), ImVec2(1, 1), 0)) {
+                            selectedIndex = index;
+                            ImGui::OpenPopup(itemPopupPicker);
+                        }
+                    } else {
+                        if (ImGui::Button("##itemNone", ImVec2(32.0f, 32.0f))) {
+                            selectedIndex = index;
+                            ImGui::OpenPopup(itemPopupPicker);
+                        }
+                    }
+                    ImGui::PopStyleVar();
+                    ImGui::PopStyleColor();
+
+                    ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0, 0));
+                    if (ImGui::BeginPopup(itemPopupPicker)) {
+                        if (ImGui::Button("##itemNonePicker", ImVec2(32.0f, 32.0f))) {
+                            gSaveContext.inventory.items[selectedIndex] = ITEM_NONE;
+                            ImGui::CloseCurrentPopup();
+                        }
+                        SetLastItemHoverText("ITEM_NONE");
+
+                        std::vector<ItemMapEntry> possibleItems;
+                        if (restrictToValid) {
+                            // Scan gItemSlots to find legal items for this slot. Bottles are a special case
+                            for (int slotIndex = 0; slotIndex < 56; slotIndex++) {
+                                int testIndex = (selectedIndex == SLOT_BOTTLE_1 || selectedIndex == SLOT_BOTTLE_2 ||
+                                                 selectedIndex == SLOT_BOTTLE_3 || selectedIndex == SLOT_BOTTLE_4)
+                                                    ? SLOT_BOTTLE_1
+                                                    : selectedIndex;
+                                if (gItemSlots[slotIndex] == testIndex) {
+                                    possibleItems.push_back(itemMapping[slotIndex]);
+                                }
+                            }
+                        } else {
+                            for (const auto& entry : itemMapping) {
+                                possibleItems.push_back(entry.second);
+                            }
+                        }
+
+                        for (int32_t pickerIndex = 0; pickerIndex < possibleItems.size(); pickerIndex++) {
+                            if (((pickerIndex + 1) % 8) != 0) {
+                                ImGui::SameLine();
+                            }
+                            const ItemMapEntry& slotEntry = possibleItems[pickerIndex];
+                            if (ImGui::ImageButton(SohImGui::GetTextureByName(slotEntry.name), ImVec2(32.0f, 32.0f),
+                                                   ImVec2(0, 0), ImVec2(1, 1), 0)) {
+                                gSaveContext.inventory.items[selectedIndex] = slotEntry.id;
+                                ImGui::CloseCurrentPopup();
+                            }
+                            SetLastItemHoverText(slotEntry.name);
+                        }
+
+                        ImGui::EndPopup();
+                    }
+                    ImGui::PopStyleVar();
+
+                    ImGui::PopID();
+                }
+            }
+
+            ImGui::Text("Ammo");
+            for (uint32_t ammoIndex = 0, drawnAmmoItems = 0; ammoIndex < 16; ammoIndex++) {
+                uint8_t item = (restrictToValid) ? gAmmoItems[ammoIndex] : gAllAmmoItems[ammoIndex];
+                if (item != ITEM_NONE) {
+                    // For legal items, display as 1 row of 7. For unrestricted items, display rows of 6 to match
+                    // inventory
+                    if ((restrictToValid && (drawnAmmoItems != 0)) || ((drawnAmmoItems % 6) != 0)) {
+                        ImGui::SameLine();
+                    }
+                    drawnAmmoItems++;
+
+                    ImGui::PushID(ammoIndex);
+                    ImGui::PushItemWidth(32.0f);
+                    ImGui::BeginGroup();
+
+                    ImGui::Image(SohImGui::GetTextureByName(itemMapping[item].name), ImVec2(32.0f, 32.0f));
+                    ImGui::InputScalar("##ammoInput", ImGuiDataType_S8, &AMMO(item));
+
+                    ImGui::EndGroup();
+                    ImGui::PopItemWidth();
+                    ImGui::PopID();
+                }
+            }
+
+            ImGui::EndTabItem();
+        }
+
+        if (ImGui::BeginTabItem("Flags")) {
+            static uint32_t selectedGsMap = 0;
+            ImGui::Text("Gold Skulltulas");
+            ImGui::Text("Map");
+            ImGui::SameLine();
+            if (ImGui::BeginCombo("##Gold Skulltula Map", gsMapping[selectedGsMap].c_str())) {
+                for (int32_t gsIndex = 0; gsIndex < gsMapping.size(); gsIndex++) {
+                    if (ImGui::Selectable(gsMapping[gsIndex].c_str())) {
+                        selectedGsMap = gsIndex;
+                    }
+                }
+
+                ImGui::EndCombo();
+            }
+
+            // TODO We should write out descriptions for each one... ugh
+            ImGui::Text("Flags");
+            uint32_t currentFlags = GET_GS_FLAGS(selectedGsMap);
+            uint32_t allFlags = gAreaGsFlags[selectedGsMap];
+            uint32_t setMask = 1;
+            // Iterate over bitfield and create a checkbox for each skulltula
+            while (allFlags != 0) {
+                bool isThisSet = (currentFlags & 0x1) == 0x1;
+
+                ImGui::SameLine();
+                ImGui::PushID(allFlags);
+                if (ImGui::Checkbox("##gs", &isThisSet)) {
+                    if (isThisSet) {
+                        SET_GS_FLAGS(selectedGsMap, setMask);
+                    } else {
+                        // Have to do this roundabout method as the macro does not support clearing flags
+                        uint32_t currentFlagsBase = GET_GS_FLAGS(selectedGsMap);
+                        gSaveContext.gsFlags[selectedGsMap >> 2] &= ~gGsFlagsMasks[selectedGsMap & 3];
+                        SET_GS_FLAGS(selectedGsMap, currentFlagsBase & ~setMask);
+                    }
+                }
+
+                ImGui::PopID();
+
+                allFlags >>= 1;
+                currentFlags >>= 1;
+                setMask <<= 1;
+            }
+
+            static bool keepGsCountUpdated = true;
+            ImGui::Checkbox("Keep GS Count Updated", &keepGsCountUpdated);
+            InsertHelpHoverText("Automatically adjust the number of gold skulltula tokens acquired based on set flags");
+            int32_t gsCount = 0;
+            if (keepGsCountUpdated) {
+                for (int32_t gsFlagIndex = 0; gsFlagIndex < 6; gsFlagIndex++) {
+                    gsCount += std::popcount(static_cast<uint32_t>(gSaveContext.gsFlags[gsFlagIndex]));
+                }
+                gSaveContext.inventory.gsTokens = gsCount;
+            }
+
+            // TODO other flag types, like switch, clear, etc.
+            // These flags interact with the actor context, so it's a bit more complicated
+
+            ImGui::EndTabItem();
+        }
+
+        ImGui::EndTabBar();
+    }
+
+    ImGui::End();
+}
+
+void InitSaveEditor() {
+    SohImGui::AddWindow("Debug", "Save Editor", DrawSaveEditor);
+
+    // Load item icons into ImGui
+    for (const auto& entry : itemMapping) {
+        SohImGui::LoadResource(entry.second.name, entry.second.texturePath);
+    }
+}

--- a/soh/soh/Enhancements/debugger/debugSaveEditor.h
+++ b/soh/soh/Enhancements/debugger/debugSaveEditor.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void InitSaveEditor();

--- a/soh/soh/Enhancements/debugger/debugger.cpp
+++ b/soh/soh/Enhancements/debugger/debugger.cpp
@@ -1,0 +1,6 @@
+#include "debugger.h"
+#include "debugSaveEditor.h"
+
+void Debug_Init(void) {
+    InitSaveEditor();
+}

--- a/soh/soh/Enhancements/debugger/debugger.h
+++ b/soh/soh/Enhancements/debugger/debugger.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void Debug_Init(void);

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -22,6 +22,7 @@
 #include "Lib/stb/stb_image.h"
 #include "AudioPlayer.h"
 #include "../soh/Enhancements/debugconsole.h"
+#include "../soh/Enhancements/debugger/debugger.h"
 #include "Utils/BitConverter.h"
 
 OTRGlobals* OTRGlobals::Instance;
@@ -54,6 +55,7 @@ extern "C" void InitOTR() {
     clearMtx = (uintptr_t)&gMtxClear;
     OTRMessage_Init();
     DebugConsole_Init();
+    Debug_Init();
 }
 
 extern "C" uint64_t GetFrequency() {

--- a/soh/src/code/code_800EC960.c
+++ b/soh/src/code/code_800EC960.c
@@ -824,13 +824,12 @@ NatureAmbienceDataIO sNatureAmbienceDataIO[20] = {
     },
 };
 
-u32 sOcarinaAllowedBtnMask =
-    (BTN_A | BTN_CUP | BTN_CDOWN | BTN_CLEFT | BTN_CRIGHT | BTN_DUP | BTN_DDOWN | BTN_DLEFT | BTN_DRIGHT);
+u32 sOcarinaAllowedBtnMask = (BTN_A | BTN_CUP | BTN_CDOWN | BTN_CLEFT | BTN_CRIGHT);
 s32 sOcarinaABtnMap = BTN_A;
-s32 sOcarinaCUPBtnMap = BTN_CUP | BTN_DUP;
-s32 sOcarinaCDownBtnMap = BTN_CDOWN | BTN_DDOWN;
-s32 sOcarinaCLeftBtnMap = BTN_CLEFT | BTN_DLEFT;
-s32 sOcarinaCRightBtnMap = BTN_CRIGHT | BTN_DRIGHT;
+s32 sOcarinaCUPBtnMap = BTN_CUP;
+s32 sOcarinaCDownBtnMap = BTN_CDOWN;
+s32 sOcarinaCLeftBtnMap = BTN_CLEFT;
+s32 sOcarinaCRightBtnMap = BTN_CRIGHT;
 u8 sOcarinaInpEnabled = 0;
 s8 D_80130F10 = 0; // "OCA", ocarina active?
 u8 sCurOcarinaBtnVal = 0xFF;
@@ -1248,8 +1247,9 @@ void func_800F56A8(void);
 void Audio_PlayNatureAmbienceSequence(u8 natureAmbienceId);
 s32 Audio_SetGanonDistVol(u8 targetVol);
 
+// Function originally not called, so repurposing for DPad input
 void func_800EC960(u8 custom) {
-    if (!custom) {
+    if (custom) {
         osSyncPrintf("AUDIO : Ocarina Control Assign Normal\n");
         sOcarinaAllowedBtnMask = 
             (BTN_A | BTN_CUP | BTN_CDOWN | BTN_CLEFT | BTN_CRIGHT | BTN_DUP | BTN_DDOWN | BTN_DLEFT | BTN_DRIGHT);
@@ -1258,14 +1258,6 @@ void func_800EC960(u8 custom) {
         sOcarinaCDownBtnMap = BTN_CDOWN | BTN_DDOWN;
         sOcarinaCLeftBtnMap = BTN_CLEFT | BTN_DLEFT;
         sOcarinaCRightBtnMap = BTN_CRIGHT | BTN_DRIGHT;
-    } else {
-        osSyncPrintf("AUDIO : Ocarina Control Assign Custom\n");
-        sOcarinaAllowedBtnMask = (BTN_A | BTN_B | BTN_CDOWN | BTN_CLEFT | BTN_CRIGHT);
-        sOcarinaABtnMap = BTN_B;
-        sOcarinaCUPBtnMap = BTN_CDOWN;
-        sOcarinaCDownBtnMap = BTN_A;
-        sOcarinaCLeftBtnMap = BTN_CLEFT;
-        sOcarinaCRightBtnMap = BTN_CRIGHT;
     }
 }
 
@@ -1550,6 +1542,7 @@ void func_800ED200(void) {
 
 void func_800ED458(s32 arg0) {
     u32 phi_v1_2;
+    bool dpad = CVar_GetS32("gDpadOcarinaText", 0);
 
     if (D_80130F3C != 0 && D_80131880 != 0) {
         D_80131880--;
@@ -1569,6 +1562,7 @@ void func_800ED458(s32 arg0) {
             D_8016BA18 &= phi_v1_2;
         }
 
+        func_800EC960(dpad);
         if (D_8016BA18 & sOcarinaABtnMap) {
             osSyncPrintf("Presss NA_KEY_D4 %08x\n", sOcarinaABtnMap);
             sCurOcarinaBtnVal = 2;

--- a/soh/src/code/code_800EC960.c
+++ b/soh/src/code/code_800EC960.c
@@ -824,10 +824,13 @@ NatureAmbienceDataIO sNatureAmbienceDataIO[20] = {
     },
 };
 
-u32 sOcarinaAllowedBtnMask = 0x800F;
-s32 sOcarinaABtnMap = 0x8000;
-s32 sOcarinaCUPBtnMap = 8;
-s32 sOcarinaCDownBtnMap = 4;
+u32 sOcarinaAllowedBtnMask =
+    (BTN_A | BTN_CUP | BTN_CDOWN | BTN_CLEFT | BTN_CRIGHT | BTN_DUP | BTN_DDOWN | BTN_DLEFT | BTN_DRIGHT);
+s32 sOcarinaABtnMap = BTN_A;
+s32 sOcarinaCUPBtnMap = BTN_CUP | BTN_DUP;
+s32 sOcarinaCDownBtnMap = BTN_CDOWN | BTN_DDOWN;
+s32 sOcarinaCLeftBtnMap = BTN_CLEFT | BTN_DLEFT;
+s32 sOcarinaCRightBtnMap = BTN_CRIGHT | BTN_DRIGHT;
 u8 sOcarinaInpEnabled = 0;
 s8 D_80130F10 = 0; // "OCA", ocarina active?
 u8 sCurOcarinaBtnVal = 0xFF;
@@ -1248,16 +1251,21 @@ s32 Audio_SetGanonDistVol(u8 targetVol);
 void func_800EC960(u8 custom) {
     if (!custom) {
         osSyncPrintf("AUDIO : Ocarina Control Assign Normal\n");
-        sOcarinaAllowedBtnMask = (BTN_A | BTN_CUP | BTN_CDOWN | BTN_CLEFT | BTN_CRIGHT);
+        sOcarinaAllowedBtnMask = 
+            (BTN_A | BTN_CUP | BTN_CDOWN | BTN_CLEFT | BTN_CRIGHT | BTN_DUP | BTN_DDOWN | BTN_DLEFT | BTN_DRIGHT);
         sOcarinaABtnMap = BTN_A;
-        sOcarinaCUPBtnMap = BTN_CUP;
-        sOcarinaCDownBtnMap = BTN_CDOWN;
+        sOcarinaCUPBtnMap = BTN_CUP | BTN_DUP;
+        sOcarinaCDownBtnMap = BTN_CDOWN | BTN_DDOWN;
+        sOcarinaCLeftBtnMap = BTN_CLEFT | BTN_DLEFT;
+        sOcarinaCRightBtnMap = BTN_CRIGHT | BTN_DRIGHT;
     } else {
         osSyncPrintf("AUDIO : Ocarina Control Assign Custom\n");
         sOcarinaAllowedBtnMask = (BTN_A | BTN_B | BTN_CDOWN | BTN_CLEFT | BTN_CRIGHT);
         sOcarinaABtnMap = BTN_B;
         sOcarinaCUPBtnMap = BTN_CDOWN;
         sOcarinaCDownBtnMap = BTN_A;
+        sOcarinaCLeftBtnMap = BTN_CLEFT;
+        sOcarinaCRightBtnMap = BTN_CRIGHT;
     }
 }
 
@@ -1569,12 +1577,12 @@ void func_800ED458(s32 arg0) {
             osSyncPrintf("Presss NA_KEY_F4 %08x\n", sOcarinaCDownBtnMap);
             sCurOcarinaBtnVal = 5;
             sCurOcarinaBtnIdx = 1;
-        } else if (D_8016BA18 & 1) {
-            osSyncPrintf("Presss NA_KEY_A4 %08x\n", 1);
+        } else if (D_8016BA18 & sOcarinaCRightBtnMap) {
+            osSyncPrintf("Presss NA_KEY_A4 %08x\n", sOcarinaCRightBtnMap);
             sCurOcarinaBtnVal = 9;
             sCurOcarinaBtnIdx = 2;
-        } else if (D_8016BA18 & 2) {
-            osSyncPrintf("Presss NA_KEY_B4 %08x\n", 2);
+        } else if (D_8016BA18 & sOcarinaCLeftBtnMap) {
+            osSyncPrintf("Presss NA_KEY_B4 %08x\n", sOcarinaCRightBtnMap);
             sCurOcarinaBtnVal = 0xB;
             sCurOcarinaBtnIdx = 3;
         } else if (D_8016BA18 & sOcarinaCUPBtnMap) {
@@ -1671,7 +1679,7 @@ void Audio_OcaSetSongPlayback(s8 songIdxPlusOne, s8 playbackState) {
 
 void Audio_OcaPlayback(void) {
     u32 noteTimerStep;
-    u32 nextNoteTimerStep;
+    u32 nextNoteTimerStep = 0;
 
     if (sPlaybackState != 0) {
         if (sStaffPlaybackPos == 0) {
@@ -4772,7 +4780,7 @@ void Audio_SetCodeReverb(s8 reverb) {
 }
 
 void func_800F6700(s8 arg0) {
-    s8 sp1F;
+    s8 sp1F = 0;
 
     switch (arg0) {
         case 0:

--- a/soh/src/code/code_800EC960.c
+++ b/soh/src/code/code_800EC960.c
@@ -1248,9 +1248,8 @@ void Audio_PlayNatureAmbienceSequence(u8 natureAmbienceId);
 s32 Audio_SetGanonDistVol(u8 targetVol);
 
 // Function originally not called, so repurposing for DPad input
-void func_800EC960(u8 custom) {
-    if (custom) {
-        osSyncPrintf("AUDIO : Ocarina Control Assign Normal\n");
+void func_800EC960(u8 dpad) {
+    if (dpad) {
         sOcarinaAllowedBtnMask = 
             (BTN_A | BTN_CUP | BTN_CDOWN | BTN_CLEFT | BTN_CRIGHT | BTN_DUP | BTN_DDOWN | BTN_DLEFT | BTN_DRIGHT);
         sOcarinaABtnMap = BTN_A;
@@ -1258,6 +1257,13 @@ void func_800EC960(u8 custom) {
         sOcarinaCDownBtnMap = BTN_CDOWN | BTN_DDOWN;
         sOcarinaCLeftBtnMap = BTN_CLEFT | BTN_DLEFT;
         sOcarinaCRightBtnMap = BTN_CRIGHT | BTN_DRIGHT;
+    } else {
+        sOcarinaAllowedBtnMask = (BTN_A | BTN_CUP | BTN_CDOWN | BTN_CLEFT | BTN_CRIGHT);
+        sOcarinaABtnMap = BTN_A;
+        sOcarinaCUPBtnMap = BTN_CUP;
+        sOcarinaCDownBtnMap = BTN_CDOWN;
+        sOcarinaCLeftBtnMap = BTN_CLEFT;
+        sOcarinaCRightBtnMap = BTN_CRIGHT;
     }
 }
 

--- a/soh/src/code/z_message_PAL.c
+++ b/soh/src/code/z_message_PAL.c
@@ -203,8 +203,9 @@ void Message_HandleChoiceSelection(GlobalContext* globalCtx, u8 numChoices) {
     static s16 sAnalogStickHeld = false;
     MessageContext* msgCtx = &globalCtx->msgCtx;
     Input* input = &globalCtx->state.input[0];
+    bool dpad = CVar_GetS32("gDpadOcarinaText", 0);
 
-    if ((input->rel.stick_y >= 30 && !sAnalogStickHeld) || CHECK_BTN_ALL(input->press.button, BTN_DUP)) {
+    if ((input->rel.stick_y >= 30 && !sAnalogStickHeld) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DUP))) {
         sAnalogStickHeld = true;
         msgCtx->choiceIndex--;
         if (msgCtx->choiceIndex > 128) {
@@ -212,7 +213,7 @@ void Message_HandleChoiceSelection(GlobalContext* globalCtx, u8 numChoices) {
         } else {
             Audio_PlaySoundGeneral(NA_SE_SY_CURSOR, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
         }
-    } else if ((input->rel.stick_y <= -30 && !sAnalogStickHeld) || CHECK_BTN_ALL(input->press.button, BTN_DDOWN)) {
+    } else if ((input->rel.stick_y <= -30 && !sAnalogStickHeld) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DDOWN))) {
         sAnalogStickHeld = true;
         msgCtx->choiceIndex++;
         if (msgCtx->choiceIndex > numChoices) {

--- a/soh/src/code/z_message_PAL.c
+++ b/soh/src/code/z_message_PAL.c
@@ -204,7 +204,7 @@ void Message_HandleChoiceSelection(GlobalContext* globalCtx, u8 numChoices) {
     MessageContext* msgCtx = &globalCtx->msgCtx;
     Input* input = &globalCtx->state.input[0];
 
-    if (input->rel.stick_y >= 30 && !sAnalogStickHeld) {
+    if ((input->rel.stick_y >= 30 && !sAnalogStickHeld) || CHECK_BTN_ALL(input->press.button, BTN_DUP)) {
         sAnalogStickHeld = true;
         msgCtx->choiceIndex--;
         if (msgCtx->choiceIndex > 128) {
@@ -212,7 +212,7 @@ void Message_HandleChoiceSelection(GlobalContext* globalCtx, u8 numChoices) {
         } else {
             Audio_PlaySoundGeneral(NA_SE_SY_CURSOR, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
         }
-    } else if (input->rel.stick_y <= -30 && !sAnalogStickHeld) {
+    } else if ((input->rel.stick_y <= -30 && !sAnalogStickHeld) || CHECK_BTN_ALL(input->press.button, BTN_DDOWN)) {
         sAnalogStickHeld = true;
         msgCtx->choiceIndex++;
         if (msgCtx->choiceIndex > numChoices) {
@@ -3032,7 +3032,7 @@ void Message_Update(GlobalContext* globalCtx) {
     Input* input = &globalCtx->state.input[0];
     s16 var;
     s16 focusScreenPosX;
-    s16 averageY;
+    s16 averageY = 0;
     s16 playerFocusScreenPosY;
     s16 actorFocusScreenPosY;
 

--- a/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -179,6 +179,7 @@ void FileChoose_UpdateMainMenu(GameState* thisx) {
     FileChooseContext* this = (FileChooseContext*)thisx;
     SramContext* sramCtx = &this->sramCtx;
     Input* input = &this->state.input[0];
+    bool dpad = CVar_GetS32("gDpadPauseName", 0);
 
     if (CHECK_BTN_ALL(input->press.button, BTN_START) || CHECK_BTN_ALL(input->press.button, BTN_A)) {
         if (this->buttonIndex <= FS_BTN_MAIN_FILE_3) {
@@ -237,10 +238,10 @@ void FileChoose_UpdateMainMenu(GameState* thisx) {
             }
         }
     } else {
-        if (ABS(this->stickRelY) > 30) {
+        if ((ABS(this->stickRelY) > 30) || (dpad && CHECK_BTN_ANY(input->press.button, BTN_DDOWN | BTN_DUP))) {
             Audio_PlaySoundGeneral(NA_SE_SY_FSEL_CURSOR, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
 
-            if (this->stickRelY > 30) {
+            if ((this->stickRelY > 30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DUP))) {
                 this->buttonIndex--;
                 if (this->buttonIndex < FS_BTN_MAIN_FILE_1) {
                     this->buttonIndex = FS_BTN_MAIN_OPTIONS;
@@ -1318,6 +1319,7 @@ void FileChoose_FadeInFileInfo(GameState* thisx) {
 void FileChoose_ConfirmFile(GameState* thisx) {
     FileChooseContext* this = (FileChooseContext*)thisx;
     Input* input = &this->state.input[0];
+    bool dpad = CVar_GetS32("gDpadPauseName", 0);
 
     if (CHECK_BTN_ALL(input->press.button, BTN_START) || (CHECK_BTN_ALL(input->press.button, BTN_A))) {
         if (this->confirmButtonIndex == FS_BTN_CONFIRM_YES) {
@@ -1332,7 +1334,7 @@ void FileChoose_ConfirmFile(GameState* thisx) {
     } else if (CHECK_BTN_ALL(input->press.button, BTN_B)) {
         Audio_PlaySoundGeneral(NA_SE_SY_FSEL_CLOSE, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
         this->selectMode++;
-    } else if (ABS(this->stickRelY) >= 30) {
+    } else if ((ABS(this->stickRelY) >= 30) || (dpad && CHECK_BTN_ANY(input->press.button, BTN_DDOWN | BTN_DUP))) {
         Audio_PlaySoundGeneral(NA_SE_SY_FSEL_CURSOR, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
         this->confirmButtonIndex ^= 1;
     }

--- a/soh/src/overlays/gamestates/ovl_file_choose/z_file_copy_erase.c
+++ b/soh/src/overlays/gamestates/ovl_file_choose/z_file_copy_erase.c
@@ -62,6 +62,7 @@ void FileChoose_SelectCopySource(GameState* thisx) {
     FileChooseContext* this = (FileChooseContext*)thisx;
     SramContext* sramCtx = &this->sramCtx;
     Input* input = &this->state.input[0];
+    bool dpad = CVar_GetS32("gDpadPauseName", 0);
 
     if (((this->buttonIndex == FS_BTN_COPY_QUIT) && CHECK_BTN_ANY(input->press.button, BTN_A | BTN_START)) ||
         CHECK_BTN_ALL(input->press.button, BTN_B)) {
@@ -82,10 +83,10 @@ void FileChoose_SelectCopySource(GameState* thisx) {
             Audio_PlaySoundGeneral(NA_SE_SY_FSEL_ERROR, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
         }
     } else {
-        if (ABS(this->stickRelY) >= 30) {
+        if ((ABS(this->stickRelY) >= 30) || (dpad && CHECK_BTN_ANY(input->press.button, BTN_DDOWN | BTN_DUP))) {
             Audio_PlaySoundGeneral(NA_SE_SY_FSEL_CURSOR, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
 
-            if (this->stickRelY >= 30) {
+            if ((this->stickRelY >= 30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DUP))) {
                 this->buttonIndex--;
 
                 if (this->buttonIndex < FS_BTN_COPY_FILE_1) {
@@ -174,6 +175,7 @@ void FileChoose_SelectCopyDest(GameState* thisx) {
     FileChooseContext* this = (FileChooseContext*)thisx;
     SramContext* sramCtx = &this->sramCtx;
     Input* input = &this->state.input[0];
+    bool dpad = CVar_GetS32("gDpadPauseName", 0);
 
     if (((this->buttonIndex == FS_BTN_COPY_QUIT) && CHECK_BTN_ANY(input->press.button, BTN_A | BTN_START)) ||
         CHECK_BTN_ALL(input->press.button, BTN_B)) {
@@ -194,10 +196,10 @@ void FileChoose_SelectCopyDest(GameState* thisx) {
         }
     } else {
 
-        if (ABS(this->stickRelY) >= 30) {
+        if ((ABS(this->stickRelY) >= 30) || (dpad && CHECK_BTN_ANY(input->press.button, BTN_DDOWN | BTN_DUP))) {
             Audio_PlaySoundGeneral(NA_SE_SY_FSEL_CURSOR, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
 
-            if (this->stickRelY >= 30) {
+            if ((this->stickRelY >= 30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DUP))) {
                 this->buttonIndex--;
 
                 if ((this->buttonIndex == this->selectedFileIndex)) {
@@ -360,6 +362,7 @@ void FileChoose_CopyConfirm(GameState* thisx) {
     SramContext* sramCtx = &this->sramCtx;
     Input* input = &this->state.input[0];
     u16 dayTime;
+    bool dpad = CVar_GetS32("gDpadPauseName", 0);
 
     if (((this->buttonIndex != FS_BTN_CONFIRM_YES) && CHECK_BTN_ANY(input->press.button, BTN_A | BTN_START)) ||
         CHECK_BTN_ALL(input->press.button, BTN_B)) {
@@ -377,7 +380,7 @@ void FileChoose_CopyConfirm(GameState* thisx) {
         this->configMode = CM_COPY_ANIM_1;
         func_800AA000(300.0f, 0xB4, 0x14, 0x64);
         Audio_PlaySoundGeneral(NA_SE_SY_FSEL_DECIDE_L, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
-    } else if (ABS(this->stickRelY) >= 30) {
+    } else if ((ABS(this->stickRelY) >= 30) || (dpad && CHECK_BTN_ANY(input->press.button, BTN_DDOWN | BTN_DUP))) {
         Audio_PlaySoundGeneral(NA_SE_SY_FSEL_CURSOR, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
         this->buttonIndex ^= 1;
     }
@@ -680,6 +683,7 @@ void FileChoose_EraseSelect(GameState* thisx) {
     FileChooseContext* this = (FileChooseContext*)thisx;
     SramContext* sramCtx = &this->sramCtx;
     Input* input = &this->state.input[0];
+    bool dpad = CVar_GetS32("gDpadPauseName", 0);
 
     if (((this->buttonIndex == FS_BTN_COPY_QUIT) && CHECK_BTN_ANY(input->press.button, BTN_A | BTN_START)) ||
         CHECK_BTN_ALL(input->press.button, BTN_B)) {
@@ -700,10 +704,10 @@ void FileChoose_EraseSelect(GameState* thisx) {
             Audio_PlaySoundGeneral(NA_SE_SY_FSEL_ERROR, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
         }
     } else {
-        if (ABS(this->stickRelY) >= 30) {
+        if ((ABS(this->stickRelY) >= 30) || (dpad && CHECK_BTN_ANY(input->press.button, BTN_DDOWN | BTN_DUP))) {
             Audio_PlaySoundGeneral(NA_SE_SY_FSEL_CURSOR, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
 
-            if (this->stickRelY >= 30) {
+            if ((this->stickRelY >= 30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DUP))) {
                 this->buttonIndex--;
                 if (this->buttonIndex < FS_BTN_ERASE_FILE_1) {
                     this->buttonIndex = FS_BTN_ERASE_QUIT;
@@ -817,6 +821,7 @@ void FileChoose_SetupEraseConfirm2(GameState* thisx) {
 void FileChoose_EraseConfirm(GameState* thisx) {
     FileChooseContext* this = (FileChooseContext*)thisx;
     Input* input = &this->state.input[0];
+    bool dpad = CVar_GetS32("gDpadPauseName", 0);
 
     if (((this->buttonIndex != FS_BTN_CONFIRM_YES) && CHECK_BTN_ANY(input->press.button, BTN_A | BTN_START)) ||
         CHECK_BTN_ALL(input->press.button, BTN_B)) {
@@ -833,7 +838,7 @@ void FileChoose_EraseConfirm(GameState* thisx) {
         this->nextTitleLabel = FS_TITLE_ERASE_COMPLETE;
         func_800AA000(200.0f, 0xFF, 0x14, 0x96);
         sEraseDelayTimer = 15;
-    } else if (ABS(this->stickRelY) >= 30) {
+    } else if ((ABS(this->stickRelY) >= 30) || (dpad && CHECK_BTN_ANY(input->press.button, BTN_DDOWN | BTN_DUP))) {
         Audio_PlaySoundGeneral(NA_SE_SY_FSEL_CURSOR, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
         this->buttonIndex ^= 1;
     }

--- a/soh/src/overlays/gamestates/ovl_file_choose/z_file_nameset_PAL.c
+++ b/soh/src/overlays/gamestates/ovl_file_choose/z_file_nameset_PAL.c
@@ -509,12 +509,14 @@ void FileChoose_StartNameEntry(GameState* thisx) {
  */
 void FileChoose_UpdateKeyboardCursor(GameState* thisx) {
     FileChooseContext* this = (FileChooseContext*)thisx;
+    Input* input = &this->state.input[0];
     s16 prevKbdX;
+    bool dpad = CVar_GetS32("gDpadPauseName", 0);
 
     this->kbdButton = 99;
 
     if (this->kbdY != 5) {
-        if (this->stickRelX < -30) {
+        if ((this->stickRelX < -30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DLEFT))) {
             Audio_PlaySoundGeneral(NA_SE_SY_FSEL_CURSOR, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
             this->charIndex--;
             this->kbdX--;
@@ -522,7 +524,7 @@ void FileChoose_UpdateKeyboardCursor(GameState* thisx) {
                 this->kbdX = 12;
                 this->charIndex = (this->kbdY * 13) + this->kbdX;
             }
-        } else if (this->stickRelX > 30) {
+        } else if ((this->stickRelX > 30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DRIGHT))) {
             Audio_PlaySoundGeneral(NA_SE_SY_FSEL_CURSOR, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
             this->charIndex++;
             this->kbdX++;
@@ -532,13 +534,13 @@ void FileChoose_UpdateKeyboardCursor(GameState* thisx) {
             }
         }
     } else {
-        if (this->stickRelX < -30) {
+        if ((this->stickRelX < -30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DLEFT))) {
             Audio_PlaySoundGeneral(NA_SE_SY_FSEL_CURSOR, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
             this->kbdX--;
             if (this->kbdX < 3) {
                 this->kbdX = 4;
             }
-        } else if (this->stickRelX > 30) {
+        } else if ((this->stickRelX > 30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DRIGHT))) {
             Audio_PlaySoundGeneral(NA_SE_SY_FSEL_CURSOR, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
             this->kbdX++;
             if (this->kbdX > 4) {
@@ -547,7 +549,7 @@ void FileChoose_UpdateKeyboardCursor(GameState* thisx) {
         }
     }
 
-    if (this->stickRelY > 30) {
+    if ((this->stickRelY > 30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DUP))) {
         Audio_PlaySoundGeneral(NA_SE_SY_FSEL_CURSOR, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
         this->kbdY--;
 
@@ -578,7 +580,7 @@ void FileChoose_UpdateKeyboardCursor(GameState* thisx) {
                 this->charIndex += this->kbdX;
             }
         }
-    } else if (this->stickRelY < -30) {
+    } else if ((this->stickRelY < -30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DDOWN))) {
         Audio_PlaySoundGeneral(NA_SE_SY_FSEL_CURSOR, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
         this->kbdY++;
 
@@ -655,6 +657,7 @@ void FileChoose_UpdateOptionsMenu(GameState* thisx) {
     FileChooseContext* this = (FileChooseContext*)thisx;
     SramContext* sramCtx = &this->sramCtx;
     Input* input = &this->state.input[0];
+    bool dpad = CVar_GetS32("gDpadPauseName", 0);
 
     if (CHECK_BTN_ALL(input->press.button, BTN_B)) {
         Audio_PlaySoundGeneral(NA_SE_SY_FSEL_DECIDE_L, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
@@ -675,7 +678,7 @@ void FileChoose_UpdateOptionsMenu(GameState* thisx) {
         return;
     }
 
-    if (this->stickRelX < -30) {
+    if ((this->stickRelX < -30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DLEFT))) {
         Audio_PlaySoundGeneral(NA_SE_SY_FSEL_CURSOR, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
 
         if (sSelectedSetting == FS_SETTING_AUDIO) {
@@ -688,7 +691,7 @@ void FileChoose_UpdateOptionsMenu(GameState* thisx) {
         } else {
             gSaveContext.zTargetSetting ^= 1;
         }
-    } else if (this->stickRelX > 30) {
+    } else if ((this->stickRelX > 30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DRIGHT))) {
         Audio_PlaySoundGeneral(NA_SE_SY_FSEL_CURSOR, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
 
         if (sSelectedSetting == FS_SETTING_AUDIO) {
@@ -702,7 +705,7 @@ void FileChoose_UpdateOptionsMenu(GameState* thisx) {
         }
     }
 
-    if ((this->stickRelY < -30) || (this->stickRelY > 30)) {
+    if ((ABS(this->stickRelY) > 30) || (dpad && CHECK_BTN_ANY(input->press.button, BTN_DDOWN | BTN_DUP))) {
         Audio_PlaySoundGeneral(NA_SE_SY_FSEL_CURSOR, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
         sSelectedSetting ^= 1;
     } else if (CHECK_BTN_ALL(input->press.button, BTN_A)) {

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_collect.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_collect.c
@@ -74,6 +74,7 @@ void KaleidoScope_DrawQuestStatus(GlobalContext* globalCtx, GraphicsContext* gfx
     s16 pad2;
     s16 phi_s0_2;
     s16 sp208[3];
+    bool dpad = CVar_GetS32("gDpadPauseName", 0);
 
     OPEN_DISPS(gfxCtx, "../z_kaleido_collect.c", 248);
 
@@ -83,95 +84,91 @@ void KaleidoScope_DrawQuestStatus(GlobalContext* globalCtx, GraphicsContext* gfx
 
         if (pauseCtx->cursorSpecialPos == 0) {
             pauseCtx->nameColorSet = 0;
+            sp216 = pauseCtx->cursorSlot[PAUSE_QUEST];
+            phi_s3 = pauseCtx->cursorPoint[PAUSE_QUEST];
 
-            if ((pauseCtx->state != 6) || ((pauseCtx->stickRelX == 0) && (pauseCtx->stickRelY == 0))) {
-                sp216 = pauseCtx->cursorSlot[PAUSE_QUEST];
-            } else {
-                phi_s3 = pauseCtx->cursorPoint[PAUSE_QUEST];
-
-                if (pauseCtx->stickRelX < -30) {
-                    phi_s0 = D_8082A1AC[phi_s3][2];
-                    if (phi_s0 == -3) {
-                        KaleidoScope_MoveCursorToSpecialPos(globalCtx, PAUSE_CURSOR_PAGE_LEFT);
-                        pauseCtx->unk_1E4 = 0;
-                    } else {
-                        while (phi_s0 >= 0) {
-                            if ((s16)KaleidoScope_UpdateQuestStatusPoint(pauseCtx, phi_s0) != 0) {
-                                break;
-                            }
-                            phi_s0 = D_8082A1AC[phi_s0][2];
-                        }
-                    }
-                } else if (pauseCtx->stickRelX > 30) {
-                    phi_s0 = D_8082A1AC[phi_s3][3];
-                    if (phi_s0 == -2) {
-                        KaleidoScope_MoveCursorToSpecialPos(globalCtx, PAUSE_CURSOR_PAGE_RIGHT);
-                        pauseCtx->unk_1E4 = 0;
-                    } else {
-                        while (phi_s0 >= 0) {
-                            if ((s16)KaleidoScope_UpdateQuestStatusPoint(pauseCtx, phi_s0) != 0) {
-                                break;
-                            }
-                            phi_s0 = D_8082A1AC[phi_s0][3];
-                        }
-                    }
-                }
-
-                if (pauseCtx->stickRelY < -30) {
-                    phi_s0 = D_8082A1AC[phi_s3][1];
-                    while (phi_s0 >= 0) {
-                        if ((s16)KaleidoScope_UpdateQuestStatusPoint(pauseCtx, phi_s0) != 0) {
-                            break;
-                        }
-                        phi_s0 = D_8082A1AC[phi_s0][1];
-                    }
-                } else if (pauseCtx->stickRelY > 30) {
-                    phi_s0 = D_8082A1AC[phi_s3][0];
-                    while (phi_s0 >= 0) {
-                        if ((s16)KaleidoScope_UpdateQuestStatusPoint(pauseCtx, phi_s0) != 0) {
-                            break;
-                        }
-                        phi_s0 = D_8082A1AC[phi_s0][0];
-                    }
-                }
-
-                if (phi_s3 != pauseCtx->cursorPoint[PAUSE_QUEST]) {
+            if ((pauseCtx->stickRelX < -30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DLEFT))) {
+                phi_s0 = D_8082A1AC[phi_s3][2];
+                if (phi_s0 == -3) {
+                    KaleidoScope_MoveCursorToSpecialPos(globalCtx, PAUSE_CURSOR_PAGE_LEFT);
                     pauseCtx->unk_1E4 = 0;
-                    Audio_PlaySoundGeneral(NA_SE_SY_CURSOR, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
-                }
-
-                if (pauseCtx->cursorPoint[PAUSE_QUEST] != 0x18) {
-                    if (CHECK_QUEST_ITEM(pauseCtx->cursorPoint[PAUSE_QUEST])) {
-                        if (pauseCtx->cursorPoint[PAUSE_QUEST] < 6) {
-                            phi_s0_2 = pauseCtx->cursorPoint[PAUSE_QUEST] + 0x66;
-                            osSyncPrintf("000 ccc=%d\n", phi_s0_2);
-                        } else if (pauseCtx->cursorPoint[PAUSE_QUEST] < 0x12) {
-                            phi_s0_2 = pauseCtx->cursorPoint[PAUSE_QUEST] + 0x54;
-                            osSyncPrintf("111 ccc=%d\n", phi_s0_2);
-                        } else {
-                            phi_s0_2 = pauseCtx->cursorPoint[PAUSE_QUEST] + 0x5A;
-                            osSyncPrintf("222 ccc=%d (%d, %d, %d)\n", phi_s0_2, pauseCtx->cursorPoint[PAUSE_QUEST],
-                                         0x12, 0x6C);
+                } else {
+                    while (phi_s0 >= 0) {
+                        if ((s16)KaleidoScope_UpdateQuestStatusPoint(pauseCtx, phi_s0) != 0) {
+                            break;
                         }
+                        phi_s0 = D_8082A1AC[phi_s0][2];
+                    }
+                }
+            } else if ((pauseCtx->stickRelX > 30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DRIGHT))) {
+                phi_s0 = D_8082A1AC[phi_s3][3];
+                if (phi_s0 == -2) {
+                    KaleidoScope_MoveCursorToSpecialPos(globalCtx, PAUSE_CURSOR_PAGE_RIGHT);
+                    pauseCtx->unk_1E4 = 0;
+                } else {
+                    while (phi_s0 >= 0) {
+                        if ((s16)KaleidoScope_UpdateQuestStatusPoint(pauseCtx, phi_s0) != 0) {
+                            break;
+                        }
+                        phi_s0 = D_8082A1AC[phi_s0][3];
+                    }
+                }
+            }
+
+            if ((pauseCtx->stickRelY < -30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DDOWN))) {
+                phi_s0 = D_8082A1AC[phi_s3][1];
+                while (phi_s0 >= 0) {
+                    if ((s16)KaleidoScope_UpdateQuestStatusPoint(pauseCtx, phi_s0) != 0) {
+                        break;
+                    }
+                    phi_s0 = D_8082A1AC[phi_s0][1];
+                }
+            } else if ((pauseCtx->stickRelY > 30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DUP))) {
+                phi_s0 = D_8082A1AC[phi_s3][0];
+                while (phi_s0 >= 0) {
+                    if ((s16)KaleidoScope_UpdateQuestStatusPoint(pauseCtx, phi_s0) != 0) {
+                        break;
+                    }
+                    phi_s0 = D_8082A1AC[phi_s0][0];
+                }
+            }
+
+            if (phi_s3 != pauseCtx->cursorPoint[PAUSE_QUEST]) {
+                pauseCtx->unk_1E4 = 0;
+                Audio_PlaySoundGeneral(NA_SE_SY_CURSOR, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
+            }
+
+            if (pauseCtx->cursorPoint[PAUSE_QUEST] != 0x18) {
+                if (CHECK_QUEST_ITEM(pauseCtx->cursorPoint[PAUSE_QUEST])) {
+                    if (pauseCtx->cursorPoint[PAUSE_QUEST] < 6) {
+                        phi_s0_2 = pauseCtx->cursorPoint[PAUSE_QUEST] + 0x66;
+                        osSyncPrintf("000 ccc=%d\n", phi_s0_2);
+                    } else if (pauseCtx->cursorPoint[PAUSE_QUEST] < 0x12) {
+                        phi_s0_2 = pauseCtx->cursorPoint[PAUSE_QUEST] + 0x54;
+                        osSyncPrintf("111 ccc=%d\n", phi_s0_2);
                     } else {
-                        phi_s0_2 = PAUSE_ITEM_NONE;
-                        osSyncPrintf("999 ccc=%d (%d,  %d)\n", PAUSE_ITEM_NONE, pauseCtx->cursorPoint[PAUSE_QUEST],
-                                     0x18);
+                        phi_s0_2 = pauseCtx->cursorPoint[PAUSE_QUEST] + 0x5A;
+                        osSyncPrintf("222 ccc=%d (%d, %d, %d)\n", phi_s0_2, pauseCtx->cursorPoint[PAUSE_QUEST],
+                                        0x12, 0x6C);
                     }
                 } else {
-                    if ((gSaveContext.inventory.questItems & 0xF0000000) != 0) {
-                        phi_s0_2 = 0x72;
-                    } else {
-                        phi_s0_2 = PAUSE_ITEM_NONE;
-                    }
-                    osSyncPrintf("888 ccc=%d (%d,  %d,  %x)\n", phi_s0_2, pauseCtx->cursorPoint[PAUSE_QUEST], 0x72,
-                                 gSaveContext.inventory.questItems & 0xF0000000);
+                    phi_s0_2 = PAUSE_ITEM_NONE;
+                    osSyncPrintf("999 ccc=%d (%d,  %d)\n", PAUSE_ITEM_NONE, pauseCtx->cursorPoint[PAUSE_QUEST],
+                                    0x18);
                 }
-
-                sp216 = pauseCtx->cursorPoint[PAUSE_QUEST];
-                pauseCtx->cursorItem[pauseCtx->pageIndex] = phi_s0_2;
-                pauseCtx->cursorSlot[pauseCtx->pageIndex] = sp216;
+            } else {
+                if ((gSaveContext.inventory.questItems & 0xF0000000) != 0) {
+                    phi_s0_2 = 0x72;
+                } else {
+                    phi_s0_2 = PAUSE_ITEM_NONE;
+                }
+                osSyncPrintf("888 ccc=%d (%d,  %d,  %x)\n", phi_s0_2, pauseCtx->cursorPoint[PAUSE_QUEST], 0x72,
+                                gSaveContext.inventory.questItems & 0xF0000000);
             }
+
+            sp216 = pauseCtx->cursorPoint[PAUSE_QUEST];
+            pauseCtx->cursorItem[pauseCtx->pageIndex] = phi_s0_2;
+            pauseCtx->cursorSlot[pauseCtx->pageIndex] = sp216;
 
             KaleidoScope_SetCursorVtx(pauseCtx, sp216 * 4, pauseCtx->questVtx);
 
@@ -215,7 +212,7 @@ void KaleidoScope_DrawQuestStatus(GlobalContext* globalCtx, GraphicsContext* gfx
                 }
             }
         } else if (pauseCtx->cursorSpecialPos == PAUSE_CURSOR_PAGE_LEFT) {
-            if (pauseCtx->stickRelX > 30) {
+            if ((pauseCtx->stickRelX > 30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DRIGHT))) {
                 pauseCtx->cursorPoint[PAUSE_QUEST] = 0x15;
                 pauseCtx->nameDisplayTimer = 0;
                 pauseCtx->cursorSpecialPos = 0;
@@ -232,7 +229,7 @@ void KaleidoScope_DrawQuestStatus(GlobalContext* globalCtx, GraphicsContext* gfx
                 pauseCtx->cursorSlot[pauseCtx->pageIndex] = sp216;
             }
         } else {
-            if (pauseCtx->stickRelX < -30) {
+            if ((pauseCtx->stickRelX < -30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DLEFT))) {
                 pauseCtx->cursorPoint[PAUSE_QUEST] = 0;
                 pauseCtx->nameDisplayTimer = 0;
                 pauseCtx->cursorSpecialPos = 0;

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_equipment.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_equipment.c
@@ -140,6 +140,7 @@ void KaleidoScope_DrawEquipment(GlobalContext* globalCtx) {
     s16 cursorX;
     s16 cursorY;
     volatile s16 oldCursorPoint;
+    bool dpad = CVar_GetS32("gDpadPauseName", 0);
 
     OPEN_DISPS(globalCtx->state.gfxCtx, "../z_kaleido_equipment.c", 219);
 
@@ -174,7 +175,7 @@ void KaleidoScope_DrawEquipment(GlobalContext* globalCtx) {
 
             cursorMoveResult = 0;
             while (cursorMoveResult == 0) {
-                if (pauseCtx->stickRelX < -30) {
+                if ((pauseCtx->stickRelX < -30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DLEFT))) {
                     if (pauseCtx->cursorX[PAUSE_EQUIP] != 0) {
                         pauseCtx->cursorX[PAUSE_EQUIP] -= 1;
                         pauseCtx->cursorPoint[PAUSE_EQUIP] -= 1;
@@ -216,7 +217,7 @@ void KaleidoScope_DrawEquipment(GlobalContext* globalCtx) {
                             cursorMoveResult = 3;
                         }
                     }
-                } else if (pauseCtx->stickRelX > 30) {
+                } else if ((pauseCtx->stickRelX > 30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DRIGHT))) {
                     if (pauseCtx->cursorX[PAUSE_EQUIP] < 3) {
                         pauseCtx->cursorX[PAUSE_EQUIP] += 1;
                         pauseCtx->cursorPoint[PAUSE_EQUIP] += 1;
@@ -264,7 +265,7 @@ void KaleidoScope_DrawEquipment(GlobalContext* globalCtx) {
 
             cursorMoveResult = 0;
             while (cursorMoveResult == 0) {
-                if (pauseCtx->stickRelY > 30) {
+                if ((pauseCtx->stickRelY > 30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DUP))) {
                     if (pauseCtx->cursorY[PAUSE_EQUIP] != 0) {
                         pauseCtx->cursorY[PAUSE_EQUIP] -= 1;
                         pauseCtx->cursorPoint[PAUSE_EQUIP] -= 4;
@@ -286,7 +287,7 @@ void KaleidoScope_DrawEquipment(GlobalContext* globalCtx) {
                         pauseCtx->cursorPoint[PAUSE_EQUIP] = cursorPoint;
                         cursorMoveResult = 3;
                     }
-                } else if (pauseCtx->stickRelY < -30) {
+                } else if ((pauseCtx->stickRelY < -30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DDOWN))) {
                     if (pauseCtx->cursorY[PAUSE_EQUIP] < 3) {
                         pauseCtx->cursorY[PAUSE_EQUIP] += 1;
                         pauseCtx->cursorPoint[PAUSE_EQUIP] += 4;
@@ -309,7 +310,7 @@ void KaleidoScope_DrawEquipment(GlobalContext* globalCtx) {
                 }
             }
         } else if (pauseCtx->cursorSpecialPos == PAUSE_CURSOR_PAGE_LEFT) {
-            if (pauseCtx->stickRelX > 30) {
+            if ((pauseCtx->stickRelX > 30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DRIGHT))) {
                 pauseCtx->nameDisplayTimer = 0;
                 pauseCtx->cursorSpecialPos = 0;
 
@@ -356,7 +357,7 @@ void KaleidoScope_DrawEquipment(GlobalContext* globalCtx) {
                 }
             }
         } else {
-            if (pauseCtx->stickRelX < -30) {
+            if ((pauseCtx->stickRelX < -30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DLEFT))) {
                 pauseCtx->nameDisplayTimer = 0;
                 pauseCtx->cursorSpecialPos = 0;
                 Audio_PlaySoundGeneral(NA_SE_SY_CURSOR, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_item.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_item.c
@@ -96,6 +96,7 @@ void KaleidoScope_DrawItemSelect(GlobalContext* globalCtx) {
     s16 cursorY;
     s16 oldCursorPoint;
     s16 moveCursorResult;
+    bool dpad = CVar_GetS32("gDpadPauseName", 0);
 
     OPEN_DISPS(globalCtx->state.gfxCtx, "../z_kaleido_item.c", 234);
 
@@ -120,7 +121,7 @@ void KaleidoScope_DrawItemSelect(GlobalContext* globalCtx) {
                 pauseCtx->stickRelX = 40;
             }
 
-            if (ABS(pauseCtx->stickRelX) > 30) {
+            if ((ABS(pauseCtx->stickRelX) > 30) || (dpad && CHECK_BTN_ANY(input->press.button, BTN_DLEFT | BTN_DRIGHT))) {
                 cursorPoint = pauseCtx->cursorPoint[PAUSE_ITEM];
                 cursorX = pauseCtx->cursorX[PAUSE_ITEM];
                 cursorY = pauseCtx->cursorY[PAUSE_ITEM];
@@ -132,7 +133,7 @@ void KaleidoScope_DrawItemSelect(GlobalContext* globalCtx) {
                 if (gSaveContext.inventory.items[pauseCtx->cursorPoint[PAUSE_ITEM]]) {}
 
                 while (moveCursorResult == 0) {
-                    if (pauseCtx->stickRelX < -30) {
+                    if ((pauseCtx->stickRelX < -30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DLEFT))) {
                         if (pauseCtx->cursorX[PAUSE_ITEM] != 0) {
                             pauseCtx->cursorX[PAUSE_ITEM] -= 1;
                             pauseCtx->cursorPoint[PAUSE_ITEM] -= 1;
@@ -164,7 +165,7 @@ void KaleidoScope_DrawItemSelect(GlobalContext* globalCtx) {
                                 moveCursorResult = 2;
                             }
                         }
-                    } else if (pauseCtx->stickRelX > 30) {
+                    } else if ((pauseCtx->stickRelX > 30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DRIGHT))) {
                         if (pauseCtx->cursorX[PAUSE_ITEM] < 5) {
                             pauseCtx->cursorX[PAUSE_ITEM] += 1;
                             pauseCtx->cursorPoint[PAUSE_ITEM] += 1;
@@ -208,7 +209,7 @@ void KaleidoScope_DrawItemSelect(GlobalContext* globalCtx) {
                              cursorItem, pauseCtx->cursorSpecialPos);
             }
         } else if (pauseCtx->cursorSpecialPos == PAUSE_CURSOR_PAGE_LEFT) {
-            if (pauseCtx->stickRelX > 30) {
+            if ((pauseCtx->stickRelX > 30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DRIGHT))) {
                 pauseCtx->nameDisplayTimer = 0;
                 pauseCtx->cursorSpecialPos = 0;
 
@@ -242,7 +243,7 @@ void KaleidoScope_DrawItemSelect(GlobalContext* globalCtx) {
                 }
             }
         } else {
-            if (pauseCtx->stickRelX < -30) {
+            if ((pauseCtx->stickRelX < -30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DLEFT))) {
                 pauseCtx->nameDisplayTimer = 0;
                 pauseCtx->cursorSpecialPos = 0;
 
@@ -280,13 +281,13 @@ void KaleidoScope_DrawItemSelect(GlobalContext* globalCtx) {
 
         if (pauseCtx->cursorSpecialPos == 0) {
             if (cursorItem != PAUSE_ITEM_NONE) {
-                if (ABS(pauseCtx->stickRelY) > 30) {
+                if ((ABS(pauseCtx->stickRelY) > 30) || (dpad && CHECK_BTN_ANY(input->press.button, BTN_DDOWN | BTN_DUP))) {
                     moveCursorResult = 0;
 
                     cursorPoint = pauseCtx->cursorPoint[PAUSE_ITEM];
                     cursorY = pauseCtx->cursorY[PAUSE_ITEM];
                     while (moveCursorResult == 0) {
-                        if (pauseCtx->stickRelY > 30) {
+                        if ((pauseCtx->stickRelY > 30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DUP))) {
                             if (pauseCtx->cursorY[PAUSE_ITEM] != 0) {
                                 pauseCtx->cursorY[PAUSE_ITEM] -= 1;
                                 pauseCtx->cursorPoint[PAUSE_ITEM] -= 6;
@@ -300,7 +301,7 @@ void KaleidoScope_DrawItemSelect(GlobalContext* globalCtx) {
 
                                 moveCursorResult = 2;
                             }
-                        } else if (pauseCtx->stickRelY < -30) {
+                        } else if ((pauseCtx->stickRelY < -30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DDOWN))) {
                             if (pauseCtx->cursorY[PAUSE_ITEM] < 3) {
                                 pauseCtx->cursorY[PAUSE_ITEM] += 1;
                                 pauseCtx->cursorPoint[PAUSE_ITEM] += 6;

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_map_PAL.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_map_PAL.c
@@ -36,6 +36,7 @@ void KaleidoScope_DrawDungeonMap(GlobalContext* globalCtx, GraphicsContext* gfxC
     static u16 mapBgPulseStage = 0;
     InterfaceContext* interfaceCtx = &globalCtx->interfaceCtx;
     PauseContext* pauseCtx = &globalCtx->pauseCtx;
+    Input* input = &globalCtx->state.input[0];
     s16 i;
     s16 j;
     s16 oldCursorPoint;
@@ -43,6 +44,7 @@ void KaleidoScope_DrawDungeonMap(GlobalContext* globalCtx, GraphicsContext* gfxC
     s16 stepG;
     s16 stepB;
     u16 rgba16;
+    bool dpad = CVar_GetS32("gDpadPauseName", 0);
 
     OPEN_DISPS(gfxCtx, "../z_kaleido_map_PAL.c", 123);
 
@@ -51,7 +53,7 @@ void KaleidoScope_DrawDungeonMap(GlobalContext* globalCtx, GraphicsContext* gfxC
         oldCursorPoint = pauseCtx->cursorPoint[PAUSE_MAP];
 
         if (pauseCtx->cursorSpecialPos == 0) {
-            if (pauseCtx->stickRelX > 30) {
+            if ((pauseCtx->stickRelX > 30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DRIGHT))) {
                 if (pauseCtx->cursorX[PAUSE_MAP] != 0) {
                     KaleidoScope_MoveCursorToSpecialPos(globalCtx, PAUSE_CURSOR_PAGE_RIGHT);
                 } else {
@@ -67,7 +69,7 @@ void KaleidoScope_DrawDungeonMap(GlobalContext* globalCtx, GraphicsContext* gfxC
                         }
                     }
                 }
-            } else if (pauseCtx->stickRelX < -30) {
+            } else if ((pauseCtx->stickRelX < -30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DLEFT))) {
                 if (pauseCtx->cursorX[PAUSE_MAP] == 0) {
                     KaleidoScope_MoveCursorToSpecialPos(globalCtx, PAUSE_CURSOR_PAGE_LEFT);
                 } else {
@@ -82,7 +84,7 @@ void KaleidoScope_DrawDungeonMap(GlobalContext* globalCtx, GraphicsContext* gfxC
             }
 
             if (pauseCtx->cursorPoint[PAUSE_MAP] < 3) {
-                if (pauseCtx->stickRelY > 30) {
+                if ((pauseCtx->stickRelY > 30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DUP))) {
                     if (pauseCtx->cursorPoint[PAUSE_MAP] != 0) {
                         for (i = pauseCtx->cursorPoint[PAUSE_MAP] - 1; i >= 0; i--) {
                             if (CHECK_DUNGEON_ITEM(i, gSaveContext.mapIndex)) {
@@ -92,7 +94,7 @@ void KaleidoScope_DrawDungeonMap(GlobalContext* globalCtx, GraphicsContext* gfxC
                         }
                     }
                 } else {
-                    if (pauseCtx->stickRelY < -30) {
+                    if ((pauseCtx->stickRelY < -30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DDOWN))) {
                         if (pauseCtx->cursorPoint[PAUSE_MAP] != 2) {
                             for (i = pauseCtx->cursorPoint[PAUSE_MAP] + 1; i < 3; i++) {
                                 if (CHECK_DUNGEON_ITEM(i, gSaveContext.mapIndex)) {
@@ -104,7 +106,7 @@ void KaleidoScope_DrawDungeonMap(GlobalContext* globalCtx, GraphicsContext* gfxC
                     }
                 }
             } else {
-                if (pauseCtx->stickRelY > 30) {
+                if ((pauseCtx->stickRelY > 30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DUP))) {
                     if (pauseCtx->cursorPoint[PAUSE_MAP] >= 4) {
                         for (i = pauseCtx->cursorPoint[PAUSE_MAP] - 3 - 1; i >= 0; i--) {
                             if ((gSaveContext.sceneFlags[gSaveContext.mapIndex].floors & gBitFlags[i]) ||
@@ -115,7 +117,7 @@ void KaleidoScope_DrawDungeonMap(GlobalContext* globalCtx, GraphicsContext* gfxC
                             }
                         }
                     }
-                } else if (pauseCtx->stickRelY < -30) {
+                } else if ((pauseCtx->stickRelY < -30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DDOWN))) {
                     if (pauseCtx->cursorPoint[PAUSE_MAP] != 10) {
                         for (i = pauseCtx->cursorPoint[PAUSE_MAP] - 3 + 1; i < 11; i++) {
                             if ((gSaveContext.sceneFlags[gSaveContext.mapIndex].floors & gBitFlags[i]) ||
@@ -138,7 +140,7 @@ void KaleidoScope_DrawDungeonMap(GlobalContext* globalCtx, GraphicsContext* gfxC
                 }
             }
         } else if (pauseCtx->cursorSpecialPos == PAUSE_CURSOR_PAGE_LEFT) {
-            if (pauseCtx->stickRelX > 30) {
+            if ((pauseCtx->stickRelX > 30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DRIGHT))) {
                 pauseCtx->nameDisplayTimer = 0;
                 pauseCtx->cursorSpecialPos = 0;
                 pauseCtx->cursorSlot[PAUSE_MAP] = pauseCtx->cursorPoint[PAUSE_MAP] = pauseCtx->dungeonMapSlot;
@@ -148,7 +150,7 @@ void KaleidoScope_DrawDungeonMap(GlobalContext* globalCtx, GraphicsContext* gfxC
                 Audio_PlaySoundGeneral(NA_SE_SY_CURSOR, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
             }
         } else {
-            if (pauseCtx->stickRelX < -30) {
+            if ((pauseCtx->stickRelX < -30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DLEFT))) {
                 pauseCtx->nameDisplayTimer = 0;
                 pauseCtx->cursorSpecialPos = 0;
                 pauseCtx->cursorX[PAUSE_MAP] = 1;
@@ -396,6 +398,7 @@ void KaleidoScope_DrawWorldMap(GlobalContext* globalCtx, GraphicsContext* gfxCtx
     };
     static u16 D_8082A6D4 = 0;
     PauseContext* pauseCtx = &globalCtx->pauseCtx;
+    Input* input = &globalCtx->state.input[0];
     s16 i;
     s16 j;
     s16 t;
@@ -404,6 +407,7 @@ void KaleidoScope_DrawWorldMap(GlobalContext* globalCtx, GraphicsContext* gfxCtx
     s16 stepR;
     s16 stepG;
     s16 stepB;
+    bool dpad = CVar_GetS32("gDpadPauseName", 0);
 
     OPEN_DISPS(gfxCtx, "../z_kaleido_map_PAL.c", 556);
 
@@ -412,7 +416,7 @@ void KaleidoScope_DrawWorldMap(GlobalContext* globalCtx, GraphicsContext* gfxCtx
         oldCursorPoint = pauseCtx->cursorPoint[PAUSE_WORLD_MAP];
 
         if (pauseCtx->cursorSpecialPos == 0) {
-            if (pauseCtx->stickRelX > 30) {
+            if ((pauseCtx->stickRelX > 30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DRIGHT))) {
                 D_8082A6D4 = 0;
 
                 do {
@@ -423,7 +427,7 @@ void KaleidoScope_DrawWorldMap(GlobalContext* globalCtx, GraphicsContext* gfxCtx
                         break;
                     }
                 } while (pauseCtx->worldMapPoints[pauseCtx->cursorPoint[PAUSE_WORLD_MAP]] == 0);
-            } else if (pauseCtx->stickRelX < -30) {
+            } else if ((pauseCtx->stickRelX < -30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DLEFT))) {
                 D_8082A6D4 = 0;
 
                 do {
@@ -444,7 +448,7 @@ void KaleidoScope_DrawWorldMap(GlobalContext* globalCtx, GraphicsContext* gfxCtx
         } else {
             pauseCtx->cursorItem[PAUSE_MAP] = gSaveContext.worldMapArea + 0x18;
             if (pauseCtx->cursorSpecialPos == PAUSE_CURSOR_PAGE_LEFT) {
-                if (pauseCtx->stickRelX > 30) {
+                if ((pauseCtx->stickRelX > 30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DRIGHT))) {
                     pauseCtx->cursorPoint[PAUSE_WORLD_MAP] = 0;
                     pauseCtx->cursorSpecialPos = 0;
 
@@ -459,7 +463,7 @@ void KaleidoScope_DrawWorldMap(GlobalContext* globalCtx, GraphicsContext* gfxCtx
                     D_8082A6D4 = 0;
                 }
             } else {
-                if (pauseCtx->stickRelX < -30) {
+                if ((pauseCtx->stickRelX < -30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DLEFT))) {
                     pauseCtx->cursorPoint[PAUSE_WORLD_MAP] = 11;
                     pauseCtx->cursorSpecialPos = 0;
 
@@ -663,7 +667,7 @@ void KaleidoScope_DrawWorldMap(GlobalContext* globalCtx, GraphicsContext* gfxCtx
     gDPLoadTextureBlock(POLY_KAL_DISP++, gWorldMapDotTex, G_IM_FMT_IA, G_IM_SIZ_8b, 8, 8, 0, G_TX_WRAP | G_TX_NOMIRROR,
                         G_TX_WRAP | G_TX_NOMIRROR, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
 
-    for (j = i = 0; i < 12; i++, t++, j += 4) {
+    for (j = t = i = 0; i < 12; i++, t++, j += 4) {
         if (pauseCtx->worldMapPoints[i] != 0) {
             gDPPipeSync(POLY_KAL_DISP++);
 

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_prompt.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_prompt.c
@@ -7,12 +7,13 @@ void KaleidoScope_UpdatePrompt(GlobalContext* globalCtx) {
     Input* input = &globalCtx->state.input[0];
     s8 relStickX = input->rel.stick_x;
     s16 step;
+    bool dpad = CVar_GetS32("gDpadPauseName", 0);
 
     if (((pauseCtx->state == 7) && (pauseCtx->unk_1EC == 1)) || (pauseCtx->state == 0xE) || (pauseCtx->state == 0x10)) {
-        if ((pauseCtx->promptChoice == 0) && (relStickX >= 30)) {
+        if ((pauseCtx->promptChoice == 0) && ((relStickX >= 30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DRIGHT)))) {
             Audio_PlaySoundGeneral(NA_SE_SY_CURSOR, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
             pauseCtx->promptChoice = 4;
-        } else if ((pauseCtx->promptChoice != 0) && (relStickX <= -30)) {
+        } else if ((pauseCtx->promptChoice != 0) && ((relStickX <= -30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DLEFT)))) {
             Audio_PlaySoundGeneral(NA_SE_SY_CURSOR, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
             pauseCtx->promptChoice = 0;
         }

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
@@ -936,8 +936,9 @@ void KaleidoScope_HandlePageToggles(PauseContext* pauseCtx, Input* input) {
         return;
     }
 
+    bool dpad = CVar_GetS32("gDpadPauseName", 0);
     if (pauseCtx->cursorSpecialPos == PAUSE_CURSOR_PAGE_LEFT) {
-        if (pauseCtx->stickRelX < -30) {
+        if ((pauseCtx->stickRelX < -30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DLEFT))) {
             pauseCtx->pageSwitchTimer++;
             if ((pauseCtx->pageSwitchTimer >= 10) || (pauseCtx->pageSwitchTimer == 0)) {
                 KaleidoScope_SwitchPage(pauseCtx, 0);
@@ -946,7 +947,7 @@ void KaleidoScope_HandlePageToggles(PauseContext* pauseCtx, Input* input) {
             pauseCtx->pageSwitchTimer = -1;
         }
     } else if (pauseCtx->cursorSpecialPos == PAUSE_CURSOR_PAGE_RIGHT) {
-        if (pauseCtx->stickRelX > 30) {
+        if ((pauseCtx->stickRelX > 30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DRIGHT))) {
             pauseCtx->pageSwitchTimer++;
             if ((pauseCtx->pageSwitchTimer >= 10) || (pauseCtx->pageSwitchTimer == 0)) {
                 KaleidoScope_SwitchPage(pauseCtx, 2);


### PR DESCRIPTION
The four DPad directions now mirror the four C buttons when playing ocarina notes.  I also added DPad support to all the text prompts that come up when talking to various characters like the owl.  