### PR TITLE
Fix non-cutscene related title cards

### DIFF
--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -9434,7 +9434,7 @@ void Player_Init(Actor* thisx, GlobalContext* globalCtx2) {
 
     if ((sp50 == 0) || (sp50 < -1)) {
         titleFileSize = scene->titleFile.vromEnd - scene->titleFile.vromStart;
-        if ((titleFileSize != 0) && gSaveContext.showTitleCard) {
+        if (gSaveContext.showTitleCard) {
             if ((gSaveContext.sceneSetupIndex < 4) &&
                 (gEntranceTable[((void)0, gSaveContext.entranceIndex) + ((void)0, gSaveContext.sceneSetupIndex)].field &
                     0x4000) &&


### PR DESCRIPTION
Currently location title cards that are rendered as part of a cutscene function correctly, however, title cards that are displayed as you enter a location without a cutscene fail to appear. It seems the player file tries to ensure the vrom span of the title card isn't zero before rendering it but on SoH the addresses are zero so it fails to render even though the title card is perfectly fine.

Before:
![image](https://user-images.githubusercontent.com/10891979/161452909-4bd753df-e1a2-400e-9f34-cd6686397ab4.png)

After:
![image](https://user-images.githubusercontent.com/10891979/161452916-be818175-315e-42cf-b672-c65491eca7e6.png)
