### PR TITLE
Fix Shadow Temple title card

### DIFF
--- a/soh/src/code/z_actor.c
+++ b/soh/src/code/z_actor.c
@@ -766,9 +766,9 @@ void TitleCard_InitPlaceName(GlobalContext* globalCtx, TitleCardContext* titleCt
             break;
         case SCENE_JYASINZOU:
             texture = gSpiritTempleTitleCardENGTex;
-            break; 
+            break;
         case SCENE_HAKADAN:
-            texture = gSpiritTempleTitleCardENGTex;
+            texture = gShadowTempleTitleCardENGTex;
             break;
         case SCENE_HAKADANCH:
             texture = gBottomOfTheWellTitleCardENGTex;


### PR DESCRIPTION
Oops, seems like I opened the other PR a bit too soon. The title card for the Shadow Temple isn't quite right (it displayed Spirit Temple), so this fixes it. As far as I know the other ones seem correct.

I would also like to mention though that while the title cards do work now, it seems like they render over the pause screen which seems like incorrect behavior. I suspect this may have something to do with the pause screen not using a framebuffer. I'm not sure if this PR should attempt to fix that, but I thought it was worth pointing out. I think this might also affect things other than the title cards as well.
![image](https://user-images.githubusercontent.com/10891979/161454587-44f85345-80b5-4d84-b55d-cfd9c97177f4.png)
