### PR TITLE
Implement todo in extract_assets.py

### DIFF
--- a/OTRExporter/extract_assets.py
+++ b/OTRExporter/extract_assets.py
@@ -7,7 +7,6 @@ import shutil
 
 romVer = "..\\soh\\baserom_non_mq.z64"
 roms = [];
-checksums = ["", "", ""];
 
 class Checksums(Enum):
     OOT_NTSC_10 = "EC7011B7"

--- a/OTRExporter/extract_assets.py
+++ b/OTRExporter/extract_assets.py
@@ -64,9 +64,11 @@ def checkChecksum(rom):
             print("Compatible roms:")
             for compat in CompatibleChecksums:
                 print(compat.name+" | 0x"+compat.value)
+            input("Press Enter to quit the program")
             sys.exit(1)
             
     print("Wrong rom! No valid checksum found")
+    input("Press Enter to quit the program")
     sys.exit(1)
 
 def main():
@@ -81,6 +83,7 @@ def main():
         
     if not (roms):
         print("Error: No roms located, place one in the OTRExporter directory", file=os.sys.stderr)
+        input("Press Enter to quit the program")
         sys.exit(1)
         
     if (len(roms) > 1):

--- a/OTRExporter/extract_assets.py
+++ b/OTRExporter/extract_assets.py
@@ -32,7 +32,7 @@ def main():
         xmlVer = "GC_NMQ_PAL_F"
     elif (args.version == "dbg_mq"):
         xmlVer = "GC_MQ_D"
-        romVer = "..\\soh\\baserom_mq.z64"
+        romPath = "..\\soh\\baserom_mq.z64"
 
     if (os.path.exists("Extract")):
         shutil.rmtree("Extract")

--- a/OTRExporter/extract_assets.py
+++ b/OTRExporter/extract_assets.py
@@ -4,11 +4,13 @@ import argparse, json, os, signal, time, sys, shutil
 from multiprocessing import Pool, cpu_count, Event, Manager, ProcessError
 import shutil
 
+romPath = "..\\soh\\baserom_non_mq.z64"
+
 def BuildOTR(xmlPath):
     shutil.copytree("assets", "Extract/assets")
 
     execStr = "x64\\Release\\ZAPD.exe" if sys.platform == "win32" else "../ZAPD/ZAPD.out"
-    execStr += " ed -i %s -b baserom.z64 -fl CFG\\filelists -o placeholder -osf placeholder -gsf 1 -rconf CFG/Config.xml -se OTR" % (xmlPath)
+    execStr += " ed -i %s -b %s -fl CFG\\filelists -o placeholder -osf placeholder -gsf 1 -rconf CFG/Config.xml -se OTR" % (xmlPath, romPath)
 
     print(execStr)
     exitValue = os.system(execStr)
@@ -30,6 +32,7 @@ def main():
         xmlVer = "GC_NMQ_PAL_F"
     elif (args.version == "dbg_mq"):
         xmlVer = "GC_MQ_D"
+        romVer = "..\\soh\\baserom_mq.z64"
 
     if (os.path.exists("Extract")):
         shutil.rmtree("Extract")

--- a/OTRExporter/extract_assets.py
+++ b/OTRExporter/extract_assets.py
@@ -1,16 +1,44 @@
 #!/usr/bin/env python3
 
-import argparse, json, os, signal, time, sys, shutil
+import argparse, json, os, signal, time, sys, shutil, glob
 from multiprocessing import Pool, cpu_count, Event, Manager, ProcessError
+from enum import Enum
 import shutil
 
-romPath = "..\\soh\\baserom_non_mq.z64"
+romVer = "..\\soh\\baserom_non_mq.z64"
+roms = [];
+checksums = ["", "", ""];
 
-def BuildOTR(xmlPath):
+class Checksums(Enum):
+    OOT_NTSC_10 = "EC7011B7"
+    OOT_NTSC_11 = "D43DA81F"
+    OOT_NTSC_12 = "693BA2AE"
+    OOT_PAL_10 = "B044B569"
+    OOT_PAL_11 = "B2055FBD"
+    OOT_NTSC_JP_GC_CE = "F7F52DB8"
+    OOT_NTSC_JP_GC = "F611F4BA"
+    OOT_NTSC_US_GC = "F3DD35BA"
+    OOT_PAL_GC = "09465AC3"
+    OOT_NTSC_JP_MQ = "F43B45BA"
+    OOT_NTSC_US_MQ = "F034001A"
+    OOT_PAL_MQ = "1D4136F3"
+    OOT_PAL_GC_DBG1 = "871E1C92"
+    OOT_PAL_GC_DBG2 = "87121EFE"
+    OOT_PAL_GC_MQ_DBG = "917D18F6"
+    OOT_IQUE_TW = "3D81FB3E"
+    OOT_IQUE_CN = "B1E1E07B"
+    OOT_UNKNOWN = "FFFFFFFF"
+    
+CompatibleChecksums = [
+    Checksums.OOT_PAL_GC,
+    Checksums.OOT_PAL_GC_DBG1
+]
+
+def BuildOTR(xmlPath, rom):
     shutil.copytree("assets", "Extract/assets")
 
-    execStr = "x64\\Release\\ZAPD.exe" if sys.platform == "win32" else "../ZAPD/ZAPD.out"
-    execStr += " ed -i %s -b %s -fl CFG\\filelists -o placeholder -osf placeholder -gsf 1 -rconf CFG/Config.xml -se OTR" % (xmlPath, romPath)
+    execStr = "x64\\Release\\ZAPD.exe" if sys.platform == "win32" else "../ZAPD/ZAPD.out"    
+    execStr += " ed -i %s -b %s -fl CFG\\filelists -o placeholder -osf placeholder -gsf 1 -rconf CFG/Config.xml -se OTR" % (xmlPath, rom)
 
     print(execStr)
     exitValue = os.system(execStr)
@@ -20,24 +48,81 @@ def BuildOTR(xmlPath):
         print("Aborting...", file=os.sys.stderr)
         print("\n")
 
+def checkChecksum(rom):
+    r = open(rom, "rb")
+    r.seek(16)
+    bytes = r.read(4).hex().upper()
+    r.close()
+    
+    for checksum in Checksums:
+        if (checksum.value == bytes):
+            
+            for compat in CompatibleChecksums:
+                if (checksum.name == compat.name):
+                    print("Compatible rom found!")   
+                    return checksum
+            print("Valid oot rom found. However, not compatible with SoH.")
+            print("Compatible roms:")
+            for compat in CompatibleChecksums:
+                print(compat.name+" | 0x"+compat.value)
+            sys.exit(1)
+            
+    print("Wrong rom! No valid checksum found")
+    sys.exit(1)
+
 def main():
     parser = argparse.ArgumentParser(description="baserom asset extractor")
     parser.add_argument("-v", "--version", help="Sets game version.")
     args = parser.parse_args()
     
-    # TODO: Read from makerom file to automatically determine game version
-    xmlVer = "GC_NMQ_D"
-
-    if (args.version == "gc_pal_nmpq"):
-        xmlVer = "GC_NMQ_PAL_F"
-    elif (args.version == "dbg_mq"):
-        xmlVer = "GC_MQ_D"
-        romPath = "..\\soh\\baserom_mq.z64"
+    romToUse = "";
+    
+    for file in glob.glob("*.z64"):
+        roms.append(file)
+        
+    if not (roms):
+        print("Error: No roms located, place one in the OTRExporter directory", file=os.sys.stderr)
+        sys.exit(1)
+        
+    if (len(roms) > 1):
+    
+        print(str(len(roms))+" roms found, please select one by pressing 1-"+str(len(roms)))
+        
+        for list in range(len(roms)):
+            print(roms[list])
+            
+        while(1):
+            try:
+                selection = int(input())
+            except:
+                print("Bad input. Try again with the number keys.")
+                continue
+                
+            if (selection < 1 or selection > len(roms)):
+                print("Bad input. Try again.")
+                continue
+            
+            else: break
+            
+        romToUse = roms[selection - 1]
+        
+    else:
+        romToUse = roms[0]
+        
+    validRom = checkChecksum(romToUse)
+    
+    match validRom.name:
+        case Checksums.OOT_PAL_GC:
+            xmlVer = "GC_NMQ_PAL_F"
+        case Checksums.OOT_PAL_GC_DBG1:
+            xmlVer = "GC_MQ_D"
+        case _: # default case
+            xmlVer = "GC_NMQ_D"
 
     if (os.path.exists("Extract")):
         shutil.rmtree("Extract")
     
-    BuildOTR("..\\soh\\assets\\xml\\" + xmlVer + "\\")
+    BuildOTR("..\\soh\\assets\\xml\\" + xmlVer + "\\", romToUse)
 
 if __name__ == "__main__":
     main()

--- a/README.md
+++ b/README.md
@@ -55,20 +55,22 @@ Official Discord: https://discord.com/invite/BtBmd55HVH
  2. Install [Visual Studio 2022 Community Edition](https://visualstudio.microsoft.com/vs/community/)
  2b. In the Visual Studio Installer, install `MSVC v142 - VS 2019 C++`.
  4. Clone the Ship of Harkinian repository.
- 5. Place `oot debug` rom (not Master Quest) in the `soh` folder named `baserom_original_non_mq`.
- 6. Launch `soh/fixbaserom.py`.
- 7. Launch `soh/extract_baserom.py`.
- 8. Copy the `baserom` folder from the `soh` folder into the `OTRExporter` folder.
- 9. Run `OTRExporter/OTRExporter.sln`.
- 10. Switch the solution to `Release x64`.
- 11. Build the solution. 
- 12. Launching `OTRExporter/extract_assets.py` will generate an `oot.otr` archive file in `OTRExporter/oot.otr`.
- 13. Run `soh/soh.sln`
- 14. Switch the solution to `Release x86`.
- 15. Build the solution.
- 16. Copy the `OTRExporter/oot.otr` archive file to `soh/Release`.
- 17. Launch `soh.exe`.
+ 5. Place one or more [compatible](#compatible-roms) roms in the `OTRExporter` directory with namings of your choice.
+ 6. Run `OTRExporter/OTRExporter.sln`.
+ 7. Switch the solution to `Release x64`.
+ 8. Build the solution. 
+ 9. Launching `OTRExporter/extract_assets.py` will generate an `oot.otr` archive file in `OTRExporter/oot.otr`.
+ 10. Run `soh/soh.sln`
+ 11. Switch the solution to `Release x86`.
+ 12. Build the solution.
+ 13. Copy the `OTRExporter/oot.otr` archive file to `soh/Release`.
+ 14. Launch `soh.exe`.
 
+## Compatible Roms
+```
+OOT_PAL_GC      checksum 0x09465AC3
+OOT_PAL_GC_DBG1 checksum 0x871E1C92 (debug non-master quest)
+```
 ## Troubleshooting The Exporter
 - Affirm that you have an `/assets` folder filled with XMLs in the same directory as OTRGui.exe
 - Affirm that `zapd.exe` exists in the `/assets/extractor` folder


### PR DESCRIPTION
These changes may be somewhat controversial. However, I think from a normal user perspective it could be helpful.

How to use:
Place a baserom of any name in the `OTRExporter/` directory.

It should validate your checksum. If validation fails the program exits.

If you place multiple baseroms in the directory, it will let you choose which rom to use.

If you want to use commandline args instead of in-process user-input. Do the following:
`python3 extract_assets.py <number>` to select which rom to use. Note that if only one rom exists, the program just runs without needing any user input nor commandline argument.
I suppose this could be expanded to: \<version\>...

Also, please squash and merge this PR  to prevent extra commits. #githubIsMyEditor