### PR TITLE
Graphics backend enhancements etc.

### DIFF
--- a/libultraship/libultraship/GameSettings.h
+++ b/libultraship/libultraship/GameSettings.h
@@ -50,6 +50,11 @@ struct SoHConfigType {
         bool moon_jump_on_l = false;
         bool super_tunic = false;
     } cheats;
+
+    // Graphics
+    struct {
+        bool show = false;
+    } graphics;
 };
 
 enum SeqPlayers {

--- a/libultraship/libultraship/Lib/Fast3D/gfx_opengl.cpp
+++ b/libultraship/libultraship/Lib/Fast3D/gfx_opengl.cpp
@@ -52,19 +52,33 @@ struct ShaderProgram {
     uint8_t num_attribs;
     bool used_noise;
     GLint frame_count_location;
-    GLint window_height_location;
+    GLint noise_scale_location;
+};
+
+struct Framebuffer {
+    uint32_t width, height;
+    bool has_depth_buffer;
+    uint32_t msaa_level;
+    bool invert_y;
+
+    GLuint fbo, clrbuf, clrbuf_msaa, rbo;
 };
 
 static map<pair<uint64_t, uint32_t>, struct ShaderProgram> shader_program_pool;
 static GLuint opengl_vbo;
-
-static uint32_t frame_count;
-static uint32_t current_height;
-static map<int, pair<GLuint, GLuint>> fb2tex;
 static bool current_depth_mask;
 
-static bool gfx_opengl_z_is_from_0_to_1(void) {
-    return false;
+static uint32_t frame_count;
+
+static vector<Framebuffer> framebuffers;
+static size_t current_framebuffer;
+static float current_noise_scale;
+
+GLuint pixel_depth_rb, pixel_depth_fb;
+size_t pixel_depth_rb_size;
+
+static struct GfxClipParameters gfx_opengl_get_clip_parameters(void) {
+    return { false, framebuffers[current_framebuffer].invert_y };
 }
 
 static void gfx_opengl_vertex_array_set_attribs(struct ShaderProgram *prg) {
@@ -81,7 +95,7 @@ static void gfx_opengl_vertex_array_set_attribs(struct ShaderProgram *prg) {
 static void gfx_opengl_set_uniforms(struct ShaderProgram *prg) {
     if (prg->used_noise) {
         glUniform1i(prg->frame_count_location, frame_count);
-        glUniform1i(prg->window_height_location, current_height);
+        glUniform1f(prg->noise_scale_location, current_noise_scale);
     }
 }
 
@@ -277,7 +291,7 @@ static struct ShaderProgram* gfx_opengl_create_and_load_new_shader(uint64_t shad
 
     if (cc_features.opt_alpha && cc_features.opt_noise) {
         append_line(fs_buf, &fs_len, "uniform int frame_count;");
-        append_line(fs_buf, &fs_len, "uniform int window_height;");
+        append_line(fs_buf, &fs_len, "uniform float noise_scale;");
 
         append_line(fs_buf, &fs_len, "float random(in vec3 value) {");
         append_line(fs_buf, &fs_len, "    float random = dot(sin(value), vec3(12.9898, 78.233, 37.719));");
@@ -338,7 +352,7 @@ static struct ShaderProgram* gfx_opengl_create_and_load_new_shader(uint64_t shad
     }
 
     if (cc_features.opt_alpha && cc_features.opt_noise) {
-        append_line(fs_buf, &fs_len, "texel.a *= floor(clamp(random(vec3(floor(gl_FragCoord.xy * (240.0 / float(window_height))), float(frame_count))) + texel.a, 0.0, 1.0));");
+        append_line(fs_buf, &fs_len, "texel.a *= floor(clamp(random(vec3(floor(gl_FragCoord.xy * noise_scale), float(frame_count))) + texel.a, 0.0, 1.0));");
     }
 
     if (cc_features.opt_alpha) {
@@ -460,7 +474,7 @@ static struct ShaderProgram* gfx_opengl_create_and_load_new_shader(uint64_t shad
 
     if (cc_features.opt_alpha && cc_features.opt_noise) {
         prg->frame_count_location = glGetUniformLocation(shader_program, "frame_count");
-        prg->window_height_location = glGetUniformLocation(shader_program, "window_height");
+        prg->noise_scale_location = glGetUniformLocation(shader_program, "noise_scale");
         prg->used_noise = true;
     } else {
         prg->used_noise = false;
@@ -496,7 +510,7 @@ static void gfx_opengl_select_texture(int tile, GLuint texture_id) {
 }
 
 static void gfx_opengl_upload_texture(const uint8_t *rgba32_buf, uint32_t width, uint32_t height) {
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, rgba32_buf);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, rgba32_buf);
 }
 
 static uint32_t gfx_cm_to_opengl(uint32_t val) {
@@ -543,7 +557,6 @@ static void gfx_opengl_set_zmode_decal(bool zmode_decal) {
 
 static void gfx_opengl_set_viewport(int x, int y, int width, int height) {
     glViewport(x, y, width, height);
-    current_height = height;
 }
 
 static void gfx_opengl_set_scissor(int x, int y, int width, int height) {
@@ -564,10 +577,6 @@ static void gfx_opengl_draw_triangles(float buf_vbo[], size_t buf_vbo_len, size_
     glDrawArrays(GL_TRIANGLES, 0, 3 * buf_vbo_num_tris);
 }
 
-static unsigned int framebuffer;
-static unsigned int textureColorbuffer;
-static unsigned int rbo;
-
 static void gfx_opengl_init(void) {
 //#if FOR_WINDOWS
     glewInit();
@@ -576,143 +585,214 @@ static void gfx_opengl_init(void) {
     glGenBuffers(1, &opengl_vbo);
     glBindBuffer(GL_ARRAY_BUFFER, opengl_vbo);
 
-    glGenFramebuffers(1, &framebuffer);
-    glGenTextures(1, &textureColorbuffer);
-    glGenRenderbuffers(1, &rbo);
-
-    SohUtils::saveEnvironmentVar("framebuffer", std::to_string(textureColorbuffer));
     glDepthFunc(GL_LEQUAL);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+
+    framebuffers.resize(1); // for the default screen buffer
+
+    glGenRenderbuffers(1, &pixel_depth_rb);
+    glBindRenderbuffer(GL_RENDERBUFFER, pixel_depth_rb);
+    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, 1, 1);
+    glBindRenderbuffer(GL_RENDERBUFFER, 0);
+
+    glGenFramebuffers(1, &pixel_depth_fb);
+    glBindFramebuffer(GL_FRAMEBUFFER, pixel_depth_fb);
+    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_RENDERBUFFER, pixel_depth_rb);
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+
+    pixel_depth_rb_size = 1;
 }
 
 static void gfx_opengl_on_resize(void) {
 }
 
 static void gfx_opengl_start_frame(void) {
-    GLsizei framebuffer_width  = gfx_current_dimensions.width;
-    GLsizei framebuffer_height = gfx_current_dimensions.height;
-    glBindFramebuffer(GL_FRAMEBUFFER, framebuffer);
-    std::shared_ptr<Ship::Window> wnd = Ship::GlobalCtx2::GetInstance()->GetWindow();
-    glBindTexture(GL_TEXTURE_2D, textureColorbuffer);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, framebuffer_width, framebuffer_height, 0, GL_RGB, GL_UNSIGNED_BYTE, NULL);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, textureColorbuffer, 0);
-    glBindRenderbuffer(GL_RENDERBUFFER, rbo);
-    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, framebuffer_width, framebuffer_height); // use a single renderbuffer object for both a depth AND stencil buffer.
-    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_RENDERBUFFER, rbo); // now actually attach it
-    glBindFramebuffer(GL_FRAMEBUFFER, framebuffer);
-
     frame_count++;
-
-    glDisable(GL_SCISSOR_TEST);
-    glDepthMask(GL_TRUE);
-    glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
-    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-    glEnable(GL_SCISSOR_TEST);
-    glEnable(GL_DEPTH_CLAMP);
-    current_depth_mask = true;
 }
 
 static void gfx_opengl_end_frame(void) {
-
-    glBindFramebuffer(GL_FRAMEBUFFER, 0);
-    glClearColor(1.0f, 1.0f, 1.0f, 1.0f);
-    glClear(GL_COLOR_BUFFER_BIT);
-
-    GLint last_program;
-    glGetIntegerv(GL_CURRENT_PROGRAM, &last_program);
-    glUseProgram(0);
-    SohImGui::Draw();
-    glUseProgram(last_program);
+    glFlush();
 }
 
 static void gfx_opengl_finish_render(void) {
 }
 
-static int gfx_opengl_create_framebuffer(uint32_t width, uint32_t height) {
-    GLuint textureColorbuffer;
-
-    glGenTextures(1, &textureColorbuffer);
-    glBindTexture(GL_TEXTURE_2D, textureColorbuffer);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_RGB, GL_UNSIGNED_BYTE, NULL);
+static int gfx_opengl_create_framebuffer() {
+    GLuint clrbuf;
+    glGenTextures(1, &clrbuf);
+    glBindTexture(GL_TEXTURE_2D, clrbuf);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB8, 1, 1, 0, GL_RGB, GL_UNSIGNED_BYTE, NULL);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     glBindTexture(GL_TEXTURE_2D, 0);
 
+    GLuint clrbuf_msaa;
+    glGenRenderbuffers(1, &clrbuf_msaa);
+
     GLuint rbo;
     glGenRenderbuffers(1, &rbo);
     glBindRenderbuffer(GL_RENDERBUFFER, rbo);
-    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, width, height);
+    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, 1, 1);
     glBindRenderbuffer(GL_RENDERBUFFER, 0);
 
     GLuint fbo;
     glGenFramebuffers(1, &fbo);
-    glBindFramebuffer(GL_FRAMEBUFFER, fbo);
 
-    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, textureColorbuffer, 0);
-    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_RENDERBUFFER, rbo);
-    glBindFramebuffer(GL_FRAMEBUFFER, fbo);
+    size_t i = framebuffers.size();
+    framebuffers.resize(i + 1);
 
-    fb2tex[fbo] = make_pair(textureColorbuffer, rbo);
-
-    //glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    framebuffers[i].fbo = fbo;
+    framebuffers[i].clrbuf = clrbuf;
+    framebuffers[i].clrbuf_msaa = clrbuf_msaa;
+    framebuffers[i].rbo = rbo;
 
     return fbo;
 }
 
-static void gfx_opengl_resize_framebuffer(int fb, uint32_t width, uint32_t height) {
-    glBindTexture(GL_TEXTURE_2D, fb2tex[fb].first);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_RGB, GL_UNSIGNED_BYTE, NULL);
-    glBindTexture(GL_TEXTURE_2D, 0);
+static void gfx_opengl_update_framebuffer_parameters(int fb_id, uint32_t width, uint32_t height, uint32_t msaa_level, bool opengl_invert_y, bool render_target, bool has_depth_buffer, bool can_extract_depth) {
+    Framebuffer& fb = framebuffers[fb_id];
 
-    glBindRenderbuffer(GL_RENDERBUFFER, fb2tex[fb].second);
-    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, width, height);
-    glBindRenderbuffer(GL_RENDERBUFFER, 0);
+    width = max(width, 1U);
+    height = max(height, 1U);
+
+    glBindFramebuffer(GL_FRAMEBUFFER, fb.fbo);
+
+    if (fb_id != 0) {
+        if (fb.width != width || fb.height != height || fb.msaa_level != msaa_level) {
+            if (msaa_level <= 1) {
+                glBindTexture(GL_TEXTURE_2D, fb.clrbuf);
+                glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB8, width, height, 0, GL_RGB, GL_UNSIGNED_BYTE, NULL);
+                glBindTexture(GL_TEXTURE_2D, 0);
+                glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, fb.clrbuf, 0);
+            } else {
+                glBindRenderbuffer(GL_RENDERBUFFER, fb.clrbuf_msaa);
+                glRenderbufferStorageMultisample(GL_RENDERBUFFER, msaa_level, GL_RGB8, width, height);
+                glBindRenderbuffer(GL_RENDERBUFFER, 0);
+                glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, fb.clrbuf_msaa);
+            }
+        }
+
+        if (has_depth_buffer && (fb.width != width || fb.height != height || fb.msaa_level != msaa_level || !fb.has_depth_buffer)) {
+            glBindRenderbuffer(GL_RENDERBUFFER, fb.rbo);
+            if (msaa_level <= 1) {
+                glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, width, height);
+            } else {
+                glRenderbufferStorageMultisample(GL_RENDERBUFFER, msaa_level, GL_DEPTH24_STENCIL8, width, height);
+            }
+            glBindRenderbuffer(GL_RENDERBUFFER, 0);
+        }
+
+        if (!fb.has_depth_buffer && has_depth_buffer) {
+            glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_RENDERBUFFER, fb.rbo);
+        } else if (fb.has_depth_buffer && !has_depth_buffer) {
+            glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_RENDERBUFFER, 0);
+        }
+    }
+
+    fb.width = width;
+    fb.height = height;
+    fb.has_depth_buffer = has_depth_buffer;
+    fb.msaa_level = msaa_level;
+    fb.invert_y = opengl_invert_y;
 }
 
-void gfx_opengl_set_framebuffer(int fb) 
-{
-    if (GLEW_ARB_clip_control || GLEW_VERSION_4_5) {
-        // Set origin to upper left corner, to match N64 and DX11
-        // If this function is not supported, the texture will be upside down :(
-        glClipControl(GL_UPPER_LEFT, GL_NEGATIVE_ONE_TO_ONE);
-    }
-    glBindFramebuffer(GL_FRAMEBUFFER_EXT, fb);
+void gfx_opengl_start_draw_to_framebuffer(int fb_id, float noise_scale) {
+    Framebuffer& fb = framebuffers[fb_id];
 
+    if (noise_scale != 0.0f) {
+        current_noise_scale = 1.0f / noise_scale;
+    }
+
+    glBindFramebuffer(GL_FRAMEBUFFER, fb.fbo);
+
+    current_framebuffer = fb_id;
+}
+
+void gfx_opengl_clear_framebuffer() {
+    glDisable(GL_SCISSOR_TEST);
     glDepthMask(GL_TRUE);
     glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
     glDepthMask(current_depth_mask ? GL_TRUE : GL_FALSE);
+    glEnable(GL_SCISSOR_TEST);
 }
 
-void gfx_opengl_reset_framebuffer(void) 
-{
-    glBindFramebuffer(GL_FRAMEBUFFER, 0);
-
-    glBindFramebuffer(GL_FRAMEBUFFER_EXT, framebuffer);
-    if (GLEW_ARB_clip_control || GLEW_VERSION_4_5) {
-        glClipControl(GL_LOWER_LEFT, GL_NEGATIVE_ONE_TO_ONE);
-    }
+void gfx_opengl_resolve_msaa_color_buffer(int fb_id_target, int fb_id_source) {
+    Framebuffer& fb_dst = framebuffers[fb_id_target];
+    Framebuffer& fb_src = framebuffers[fb_id_source];
+    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, fb_dst.fbo);
+    glBindFramebuffer(GL_READ_FRAMEBUFFER, fb_src.fbo);
+    glBlitFramebuffer(0, 0, fb_src.width, fb_src.height, 0, 0, fb_dst.width, fb_dst.height, GL_COLOR_BUFFER_BIT, GL_NEAREST);
+    glBindFramebuffer(GL_FRAMEBUFFER, current_framebuffer);
 }
 
-void gfx_opengl_select_texture_fb(int fbID)
-{
+void *gfx_opengl_get_framebuffer_texture_id(int fb_id) {
+    return (void *)(uintptr_t)framebuffers[fb_id].clrbuf;
+}
+
+void gfx_opengl_select_texture_fb(int fb_id) {
     //glDisable(GL_DEPTH_TEST);
     glActiveTexture(GL_TEXTURE0 + 0);
-    glBindTexture(GL_TEXTURE_2D, fb2tex[fbID].first);
+    glBindTexture(GL_TEXTURE_2D, framebuffers[fb_id].clrbuf);
 }
 
-static uint16_t gfx_opengl_get_pixel_depth(float x, float y) {
-    float depth;
-    glBindFramebuffer(GL_FRAMEBUFFER, framebuffer);
-    glReadPixels(x, y, 1, 1, GL_DEPTH_COMPONENT, GL_FLOAT, &depth);
-    glBindFramebuffer(GL_FRAMEBUFFER, 0);
-    return depth * 65532.0f;
+static std::map<std::pair<float, float>, uint16_t> gfx_opengl_get_pixel_depth(int fb_id, const std::set<std::pair<float, float>>& coordinates) {
+    std::map<std::pair<float, float>, uint16_t> res;
+
+    Framebuffer& fb = framebuffers[fb_id];
+
+    if (coordinates.size() == 1) {
+        uint32_t depth_stencil_value;
+        glBindFramebuffer(GL_FRAMEBUFFER, fb.fbo);
+        int x = coordinates.begin()->first;
+        int y = coordinates.begin()->second;
+        glReadPixels(x, fb.invert_y ? fb.height - y : y, 1, 1, GL_DEPTH_STENCIL, GL_UNSIGNED_INT_24_8, &depth_stencil_value);
+        res.emplace(*coordinates.begin(), (depth_stencil_value >> 18) << 2);
+    } else {
+        if (pixel_depth_rb_size < coordinates.size()) {
+            glBindRenderbuffer(GL_RENDERBUFFER, pixel_depth_rb);
+            glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, coordinates.size(), 1);
+            glBindRenderbuffer(GL_RENDERBUFFER, 0);
+
+            pixel_depth_rb_size = coordinates.size();
+        }
+
+        glBindFramebuffer(GL_READ_FRAMEBUFFER, fb.fbo);
+        glBindFramebuffer(GL_DRAW_FRAMEBUFFER, pixel_depth_fb);
+
+        glDisable(GL_SCISSOR_TEST); // needed for the blit operation
+
+        {
+            size_t i = 0;
+            for (const auto& coord : coordinates) {
+                int x = coord.first;
+                int y = coord.second;
+                if (fb.invert_y) {
+                    y = fb.height - y;
+                }
+                glBlitFramebuffer(x, y, x + 1, y + 1, i, 0, i + 1, 1, GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT, GL_NEAREST);
+                ++i;
+            }
+        }
+
+        glBindFramebuffer(GL_READ_FRAMEBUFFER, pixel_depth_fb);
+        vector<uint32_t> depth_stencil_values(coordinates.size());
+        glReadPixels(0, 0, coordinates.size(), 1, GL_DEPTH_STENCIL, GL_UNSIGNED_INT_24_8, depth_stencil_values.data());
+
+        {
+            size_t i = 0;
+            for (const auto& coord : coordinates) {
+                res.emplace(coord, (depth_stencil_values[i++] >> 18) << 2);
+            }
+        }
+    }
+
+    glBindFramebuffer(GL_FRAMEBUFFER, current_framebuffer);
+    return res;
 }
 
 struct GfxRenderingAPI gfx_opengl_api = {
-    gfx_opengl_z_is_from_0_to_1,
+    gfx_opengl_get_clip_parameters,
     gfx_opengl_unload_shader,
     gfx_opengl_load_shader,
     gfx_opengl_create_and_load_new_shader,
@@ -723,7 +803,6 @@ struct GfxRenderingAPI gfx_opengl_api = {
     gfx_opengl_upload_texture,
     gfx_opengl_set_sampler_parameters,
     gfx_opengl_set_depth_test_and_mask,
-    gfx_opengl_get_pixel_depth,
     gfx_opengl_set_zmode_decal,
     gfx_opengl_set_viewport,
     gfx_opengl_set_scissor,
@@ -735,9 +814,12 @@ struct GfxRenderingAPI gfx_opengl_api = {
     gfx_opengl_end_frame,
     gfx_opengl_finish_render,
     gfx_opengl_create_framebuffer,
-    gfx_opengl_resize_framebuffer,
-    gfx_opengl_set_framebuffer,
-    gfx_opengl_reset_framebuffer,
+    gfx_opengl_update_framebuffer_parameters,
+    gfx_opengl_start_draw_to_framebuffer,
+    gfx_opengl_clear_framebuffer,
+    gfx_opengl_resolve_msaa_color_buffer,
+    gfx_opengl_get_pixel_depth,
+    gfx_opengl_get_framebuffer_texture_id,
     gfx_opengl_select_texture_fb,
     gfx_opengl_delete_texture
 };

--- a/libultraship/libultraship/Lib/Fast3D/gfx_pc.cpp
+++ b/libultraship/libultraship/Lib/Fast3D/gfx_pc.cpp
@@ -2690,7 +2690,7 @@ struct GfxRenderingAPI *gfx_get_current_rendering_api(void) {
 void gfx_start_frame(void) {
     gfx_wapi->handle_events();
     gfx_wapi->get_dimensions(&gfx_current_window_dimensions.width, &gfx_current_window_dimensions.height);
-    SohImGui::Draw1();
+    SohImGui::DrawMainMenuAndCalculateGameSize();
     if (gfx_current_dimensions.height == 0) {
         // Avoid division by zero
         gfx_current_dimensions.height = 1;
@@ -2738,7 +2738,7 @@ void gfx_run(Gfx *commands) {
 
     if (!gfx_wapi->start_frame()) {
         dropped_frame = true;
-        SohImGui::Draw2();
+        SohImGui::DrawFramebufferAndGameInput();
         SohImGui::CancelFrame();
         return;
     }
@@ -2769,7 +2769,7 @@ void gfx_run(Gfx *commands) {
             SohUtils::saveEnvironmentVar("framebuffer", std::to_string((uintptr_t)gfx_rapi->get_framebuffer_texture_id(game_framebuffer)));
         }
     }
-    SohImGui::Draw2();
+    SohImGui::DrawFramebufferAndGameInput();
     SohImGui::Render();
     double t1 = gfx_wapi->get_time();
     //printf("Process %f %f\n", t1, t1 - t0);

--- a/libultraship/libultraship/Lib/Fast3D/gfx_pc.cpp
+++ b/libultraship/libultraship/Lib/Fast3D/gfx_pc.cpp
@@ -7,6 +7,7 @@
 #include <stdio.h>
 
 #include <map>
+#include <set>
 #include <unordered_map>
 #include <vector>
 
@@ -27,6 +28,8 @@
 
 #include "../../luslog.h"
 #include "../StrHash64.h"
+#include "../../SohImGuiImpl.h"
+#include "../../Environment.h"
 
 // OTRTODO: fix header files for these
 extern "C" {
@@ -69,10 +72,6 @@ using namespace std;
 
 struct RGBA {
     uint8_t r, g, b, a;
-};
-
-struct XYWidthHeight {
-    uint16_t x, y, width, height;
 };
 
 struct LoadedVertex {
@@ -174,8 +173,16 @@ static struct RenderingState {
     TextureCacheNode *textures[2];
 } rendering_state;
 
+struct GfxDimensions gfx_current_window_dimensions;
 struct GfxDimensions gfx_current_dimensions;
 static struct GfxDimensions gfx_prev_dimensions;
+struct XYWidthHeight gfx_current_game_window_viewport;
+
+static bool game_renders_to_framebuffer;
+static int game_framebuffer;
+static int game_framebuffer_msaa_resolved;
+
+uint32_t gfx_msaa_level = 1;
 
 static bool dropped_frame;
 
@@ -197,6 +204,9 @@ struct FBInfo {
 static bool fbActive = 0;
 static map<int, FBInfo>::iterator active_fb;
 static map<int, FBInfo> framebuffers;
+
+static set<pair<float, float>> get_pixel_depth_pending;
+static map<pair<float, float>, uint16_t> get_pixel_depth_cached;
 
 #ifdef _MSC_VER
 // TODO: Properly implement for MSVC
@@ -1326,11 +1336,11 @@ static void gfx_sp_tri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx, bo
 
     gfx_rapi->shader_get_info(prg, &num_inputs, used_textures);
 
-    bool z_is_from_0_to_1 = gfx_rapi->z_is_from_0_to_1();
+    struct GfxClipParameters clip_parameters = gfx_rapi->get_clip_parameters();
 
     for (int i = 0; i < 3; i++) {
         float z = v_arr[i]->z, w = v_arr[i]->w;
-        if (z_is_from_0_to_1) {
+        if (clip_parameters.z_is_from_0_to_1) {
             z = (z + w) / 2.0f;
         }
 
@@ -1340,7 +1350,7 @@ static void gfx_sp_tri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx, bo
         }
 
         buf_vbo[buf_vbo_len++] = v_arr[i]->x;
-        buf_vbo[buf_vbo_len++] = v_arr[i]->y;
+        buf_vbo[buf_vbo_len++] = clip_parameters.invert_y ? -v_arr[i]->y : v_arr[i]->y;
         buf_vbo[buf_vbo_len++] = z;
         buf_vbo[buf_vbo_len++] = w;
 
@@ -1491,6 +1501,27 @@ static void gfx_sp_geometry_mode(uint32_t clear, uint32_t set) {
     rsp.geometry_mode |= set;
 }
 
+static void gfx_adjust_viewport_or_scissor(XYWidthHeight *area) {
+    if (!fbActive) {
+        area->width *= RATIO_X;
+        area->height *= RATIO_Y;
+        area->x *= RATIO_X;
+        area->y = SCREEN_HEIGHT - area->y;
+        area->y *= RATIO_Y;
+
+        if (!game_renders_to_framebuffer || (gfx_msaa_level > 1 && gfx_current_dimensions.width == gfx_current_game_window_viewport.width && gfx_current_dimensions.height == gfx_current_game_window_viewport.height)) {
+            area->x += gfx_current_game_window_viewport.x;
+            area->y += gfx_current_window_dimensions.height - (gfx_current_game_window_viewport.y + gfx_current_game_window_viewport.height);
+        }
+    } else {
+        area->width *= RATIO_Y;
+        area->height *= RATIO_Y;
+        area->x *= RATIO_Y;
+        area->y = active_fb->second.orig_height - area->y;
+        area->y *= RATIO_Y;
+    }
+}
+
 static void gfx_calc_and_set_viewport(const Vp_t *viewport) {
     // 2 bits fraction
     float width = 2.0f * viewport->vscale[0] / 4.0f;
@@ -1498,24 +1529,12 @@ static void gfx_calc_and_set_viewport(const Vp_t *viewport) {
     float x = (viewport->vtrans[0] / 4.0f) - width / 2.0f;
     float y = ((viewport->vtrans[1] / 4.0f) + height / 2.0f);
 
-    if (!fbActive) {
-        width *= RATIO_X;
-        height *= RATIO_Y;
-        x *= RATIO_X;
-        y = SCREEN_HEIGHT - y;
-        y *= RATIO_Y;
-    } else {
-        width *= RATIO_Y;
-        height *= RATIO_Y;
-        x *= RATIO_Y;
-        y = active_fb->second.orig_height - y;
-        y *= RATIO_Y;
-    }
-
     rdp.viewport.x = x;
     rdp.viewport.y = y;
     rdp.viewport.width = width;
     rdp.viewport.height = height;
+
+    gfx_adjust_viewport_or_scissor(&rdp.viewport);
 
     rdp.viewport_or_scissor_changed = true;
 }
@@ -1585,11 +1604,6 @@ static void gfx_sp_texture(uint16_t sc, uint16_t tc, uint8_t level, uint8_t tile
         rdp.textures_changed[1] = true;
     }
 
-    if (tile > 8)
-    {
-        int bp = 0;
-    }
-
     rdp.first_tile_index = tile;
 }
 
@@ -1599,24 +1613,12 @@ static void gfx_dp_set_scissor(uint32_t mode, uint32_t ulx, uint32_t uly, uint32
     float width = (lrx - ulx) / 4.0f;
     float height = (lry - uly) / 4.0f;
 
-    if (!fbActive) {
-        x *= RATIO_X;
-        y = SCREEN_HEIGHT - y;
-        y *= RATIO_Y;
-        width *= RATIO_X;
-        height *= RATIO_Y;
-    } else {
-        width *= RATIO_Y;
-        height *= RATIO_Y;
-        x *= RATIO_Y;
-        y = active_fb->second.orig_height - y;
-        y *= RATIO_Y;
-    }
-
     rdp.scissor.x = x;
     rdp.scissor.y = y;
     rdp.scissor.width = width;
     rdp.scissor.height = height;
+
+    gfx_adjust_viewport_or_scissor(&rdp.scissor);
 
     rdp.viewport_or_scissor_changed = true;
 }
@@ -1887,9 +1889,11 @@ static void gfx_draw_rectangle(int32_t ulx, int32_t uly, int32_t lrx, int32_t lr
     ur->w = 1.0f;
 
     // The coordinates for texture rectangle shall bypass the viewport setting
-    struct XYWidthHeight default_viewport = { 0, 0, gfx_current_dimensions.width, gfx_current_dimensions.height };
+    struct XYWidthHeight default_viewport = { 0, SCREEN_HEIGHT, SCREEN_WIDTH, SCREEN_HEIGHT };
     struct XYWidthHeight viewport_saved = rdp.viewport;
     uint32_t geometry_mode_saved = rsp.geometry_mode;
+
+    gfx_adjust_viewport_or_scissor(&default_viewport);
 
     rdp.viewport = default_viewport;
     rdp.viewport_or_scissor_changed = true;
@@ -2456,14 +2460,15 @@ static void gfx_run_dl(Gfx* cmd) {
                 gfx_flush();
                 fbActive = 1;
                 active_fb = framebuffers.find(cmd->words.w1);
-                gfx_rapi->set_framebuffer(active_fb->first);
+                gfx_rapi->start_draw_to_framebuffer(active_fb->first, (float)active_fb->second.applied_height / active_fb->second.orig_height);
+                gfx_rapi->clear_framebuffer();
             }
                 break;
             case G_RESETFB:
             {
                 gfx_flush();
                 fbActive = 0;
-                gfx_rapi->reset_framebuffer();
+                gfx_rapi->start_draw_to_framebuffer(game_renders_to_framebuffer ? game_framebuffer : 0, (float)gfx_current_dimensions.height / SCREEN_HEIGHT);
                 break;
             }
             break;
@@ -2547,7 +2552,7 @@ static void gfx_run_dl(Gfx* cmd) {
                 gfx_dp_texture_rectangle(ulx, uly, lrx, lry, tile, uls, ult, dsdx, dtdy, opcode == G_TEXRECTFLIP);
                 break;
             }
-			case G_TEXRECT_WIDE:
+            case G_TEXRECT_WIDE:
             {
                 int32_t lrx, lry, tile, ulx, uly;
                 uint32_t uls, ult, dsdx, dtdy;
@@ -2630,9 +2635,12 @@ void gfx_init(struct GfxWindowManagerAPI *wapi, struct GfxRenderingAPI *rapi, co
     gfx_rapi = rapi;
     gfx_wapi->init(game_name, start_in_fullscreen);
     gfx_rapi->init();
+    gfx_rapi->update_framebuffer_parameters(0, SCREEN_WIDTH, SCREEN_HEIGHT, 1, false, true, true, true);
     gfx_current_dimensions.internal_mul = 1;
     gfx_current_dimensions.width = SCREEN_WIDTH;
     gfx_current_dimensions.height = SCREEN_HEIGHT;
+    game_framebuffer = gfx_rapi->create_framebuffer();
+    game_framebuffer_msaa_resolved = gfx_rapi->create_framebuffer();
 
     for (int i = 0; i < 16; i++)
         segmentPointers[i] = NULL;
@@ -2681,7 +2689,8 @@ struct GfxRenderingAPI *gfx_get_current_rendering_api(void) {
 
 void gfx_start_frame(void) {
     gfx_wapi->handle_events();
-    // gfx_wapi->get_dimensions(&gfx_current_dimensions.width, &gfx_current_dimensions.height);
+    gfx_wapi->get_dimensions(&gfx_current_window_dimensions.width, &gfx_current_window_dimensions.height);
+    SohImGui::Draw1();
     if (gfx_current_dimensions.height == 0) {
         // Avoid division by zero
         gfx_current_dimensions.height = 1;
@@ -2693,13 +2702,29 @@ void gfx_start_frame(void) {
             uint32_t width = fb.second.orig_width, height = fb.second.orig_height;
             gfx_adjust_width_height_for_scale(width, height);
             if (width != fb.second.applied_width || height != fb.second.applied_height) {
-                gfx_rapi->resize_framebuffer(fb.first, width, height);
+                gfx_rapi->update_framebuffer_parameters(fb.first, width, height, 1, true, true, true, true);
                 fb.second.applied_width = width;
                 fb.second.applied_height = height;
             }
         }
     }
     gfx_prev_dimensions = gfx_current_dimensions;
+
+    bool different_size = gfx_current_dimensions.width != gfx_current_game_window_viewport.width || gfx_current_dimensions.height != gfx_current_game_window_viewport.height;
+    if (different_size || gfx_msaa_level > 1) {
+        game_renders_to_framebuffer = true;
+        if (different_size) {
+            gfx_rapi->update_framebuffer_parameters(game_framebuffer, gfx_current_dimensions.width, gfx_current_dimensions.height, gfx_msaa_level, true, true, true, true);
+        } else {
+            // MSAA framebuffer needs to be resolved to an equally sized target when complete, which must therefore match the window size
+            gfx_rapi->update_framebuffer_parameters(game_framebuffer, gfx_current_window_dimensions.width, gfx_current_window_dimensions.height, gfx_msaa_level, false, true, true, true);
+        }
+        if (gfx_msaa_level > 1 && different_size) {
+            gfx_rapi->update_framebuffer_parameters(game_framebuffer_msaa_resolved, gfx_current_dimensions.width, gfx_current_dimensions.height, 1, false, false, false, false);
+        }
+    } else {
+        game_renders_to_framebuffer = false;
+    }
 
     fbActive = 0;
 }
@@ -2708,17 +2733,44 @@ void gfx_run(Gfx *commands) {
     gfx_sp_reset();
 
     //puts("New frame");
+    get_pixel_depth_pending.clear();
+    get_pixel_depth_cached.clear();
 
     if (!gfx_wapi->start_frame()) {
         dropped_frame = true;
+        SohImGui::Draw2();
+        SohImGui::CancelFrame();
         return;
     }
     dropped_frame = false;
 
     double t0 = gfx_wapi->get_time();
+    gfx_rapi->update_framebuffer_parameters(0, gfx_current_window_dimensions.width, gfx_current_window_dimensions.height, 1, false, true, true, !game_renders_to_framebuffer);
     gfx_rapi->start_frame();
+    gfx_rapi->start_draw_to_framebuffer(game_renders_to_framebuffer ? game_framebuffer : 0, (float)gfx_current_dimensions.height / SCREEN_HEIGHT);
+    gfx_rapi->clear_framebuffer();
     gfx_run_dl(commands);
     gfx_flush();
+    SohUtils::saveEnvironmentVar("framebuffer", string());
+    if (game_renders_to_framebuffer) {
+        gfx_rapi->start_draw_to_framebuffer(0, 1);
+        gfx_rapi->clear_framebuffer();
+
+        if (gfx_msaa_level > 1) {
+            bool different_size = gfx_current_dimensions.width != gfx_current_game_window_viewport.width || gfx_current_dimensions.height != gfx_current_game_window_viewport.height;
+
+            if (different_size) {
+                gfx_rapi->resolve_msaa_color_buffer(game_framebuffer_msaa_resolved, game_framebuffer);
+                SohUtils::saveEnvironmentVar("framebuffer", std::to_string((uintptr_t)gfx_rapi->get_framebuffer_texture_id(game_framebuffer_msaa_resolved)));
+            } else {
+                gfx_rapi->resolve_msaa_color_buffer(0, game_framebuffer);
+            }
+        } else {
+            SohUtils::saveEnvironmentVar("framebuffer", std::to_string((uintptr_t)gfx_rapi->get_framebuffer_texture_id(game_framebuffer)));
+        }
+    }
+    SohImGui::Draw2();
+    SohImGui::Render();
     double t1 = gfx_wapi->get_time();
     //printf("Process %f %f\n", t1, t1 - t0);
     gfx_rapi->end_frame();
@@ -2739,21 +2791,47 @@ void gfx_set_framedivisor(int divisor) {
 int gfx_create_framebuffer(uint32_t width, uint32_t height) {
     uint32_t orig_width = width, orig_height = height;
     gfx_adjust_width_height_for_scale(width, height);
-    int fb = gfx_rapi->create_framebuffer(width, height);
+    int fb = gfx_rapi->create_framebuffer();
+    gfx_rapi->update_framebuffer_parameters(fb, width, height, 1, true, true, true, true);
     framebuffers[fb] = { orig_width, orig_height, width, height };
     return fb;
 }
 
-void gfx_set_framebuffer(int fb)
-{
-    gfx_rapi->set_framebuffer(fb);
+void gfx_set_framebuffer(int fb, float noise_scale) {
+    gfx_rapi->start_draw_to_framebuffer(fb, noise_scale);
+    gfx_rapi->clear_framebuffer();
 }
 
-void gfx_reset_framebuffer()
-{
-    gfx_rapi->reset_framebuffer();
+void gfx_reset_framebuffer() {
+    gfx_rapi->start_draw_to_framebuffer(0, (float)gfx_current_dimensions.height / SCREEN_HEIGHT);
+}
+
+static void adjust_pixel_depth_coordinates(float& x, float& y) {
+    x = x * RATIO_Y - (SCREEN_WIDTH * RATIO_Y - gfx_current_dimensions.width) / 2;
+    y *= RATIO_Y;
+    if (!game_renders_to_framebuffer || (gfx_msaa_level > 1 && gfx_current_dimensions.width == gfx_current_game_window_viewport.width && gfx_current_dimensions.height == gfx_current_game_window_viewport.height)) {
+        x += gfx_current_game_window_viewport.x;
+        y += gfx_current_window_dimensions.height - (gfx_current_game_window_viewport.y + gfx_current_game_window_viewport.height);
+    }
+}
+
+void gfx_get_pixel_depth_prepare(float x, float y) {
+    adjust_pixel_depth_coordinates(x, y);
+    get_pixel_depth_pending.emplace(x, y);
 }
 
 uint16_t gfx_get_pixel_depth(float x, float y) {
-    return gfx_rapi->get_pixel_depth(x * RATIO_Y - (SCREEN_WIDTH * RATIO_Y - gfx_current_dimensions.width) / 2, y * RATIO_Y);
+    adjust_pixel_depth_coordinates(x, y);
+
+    if (auto it = get_pixel_depth_cached.find(make_pair(x, y)); it != get_pixel_depth_cached.end()) {
+        return it->second;
+    }
+
+    get_pixel_depth_pending.emplace(x, y);
+
+    map<pair<float, float>, uint16_t> res = gfx_rapi->get_pixel_depth(game_renders_to_framebuffer ? game_framebuffer : 0, get_pixel_depth_pending);
+    get_pixel_depth_cached.merge(res);
+    get_pixel_depth_pending.clear();
+
+    return get_pixel_depth_cached.find(make_pair(x, y))->second;
 }

--- a/libultraship/libultraship/Lib/Fast3D/gfx_pc.h
+++ b/libultraship/libultraship/Lib/Fast3D/gfx_pc.h
@@ -8,8 +8,11 @@
 struct GfxRenderingAPI;
 struct GfxWindowManagerAPI;
 
-struct GfxDimensions
-{
+struct XYWidthHeight {
+    int16_t x, y, width, height;
+};
+
+struct GfxDimensions {
     uint32_t internal_mul;
     uint32_t width, height;
     float aspect_ratio;
@@ -50,7 +53,10 @@ struct TextureCacheValue {
 #ifdef __cplusplus
 extern "C" {
 #endif
-extern struct GfxDimensions gfx_current_dimensions;
+extern struct GfxDimensions gfx_current_window_dimensions; // The dimensions of the window
+extern struct GfxDimensions gfx_current_dimensions; // The dimensions of the draw area the game draws to, before scaling (if applicable)
+extern struct XYWidthHeight gfx_current_game_window_viewport; // The area of the window the game is drawn to, (0, 0) is top-left corner
+extern uint32_t gfx_msaa_level;
 
 void gfx_init(struct GfxWindowManagerAPI* wapi, struct GfxRenderingAPI* rapi, const char* game_name, bool start_in_fullscreen);
 struct GfxRenderingAPI* gfx_get_current_rendering_api(void);
@@ -60,6 +66,7 @@ void gfx_end_frame(void);
 void gfx_set_framedivisor(int);
 void gfx_texture_cache_clear();
 int gfx_create_framebuffer(uint32_t width, uint32_t height);
+void gfx_get_pixel_depth_prepare(float x, float y);
 uint16_t gfx_get_pixel_depth(float x, float y);
 
 #ifdef __cplusplus

--- a/libultraship/libultraship/Lib/Fast3D/gfx_rendering_api.h
+++ b/libultraship/libultraship/Lib/Fast3D/gfx_rendering_api.h
@@ -5,10 +5,18 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#include <map>
+#include <set>
+
 struct ShaderProgram;
 
+struct GfxClipParameters {
+    bool z_is_from_0_to_1;
+    bool invert_y;
+};
+
 struct GfxRenderingAPI {
-    bool (*z_is_from_0_to_1)(void);
+    struct GfxClipParameters (*get_clip_parameters)(void);
     void (*unload_shader)(struct ShaderProgram *old_prg);
     void (*load_shader)(struct ShaderProgram *new_prg);
     struct ShaderProgram *(*create_and_load_new_shader)(uint64_t shader_id0, uint32_t shader_id1);
@@ -19,7 +27,6 @@ struct GfxRenderingAPI {
     void (*upload_texture)(const uint8_t *rgba32_buf, uint32_t width, uint32_t height);
     void (*set_sampler_parameters)(int sampler, bool linear_filter, uint32_t cms, uint32_t cmt);
     void (*set_depth_test_and_mask)(bool depth_test, bool z_upd);
-    uint16_t (*get_pixel_depth)(float x, float y);
     void (*set_zmode_decal)(bool zmode_decal);
     void (*set_viewport)(int x, int y, int width, int height);
     void (*set_scissor)(int x, int y, int width, int height);
@@ -30,11 +37,14 @@ struct GfxRenderingAPI {
     void (*start_frame)(void);
     void (*end_frame)(void);
     void (*finish_render)(void);
-    int (*create_framebuffer)(uint32_t width, uint32_t height);
-    void (*resize_framebuffer)(int fb, uint32_t width, uint32_t height);
-    void (*set_framebuffer)(int fb);
-    void (*reset_framebuffer)();
-    void (*select_texture_fb)(int fbID);
+    int (*create_framebuffer)();
+    void (*update_framebuffer_parameters)(int fb_id, uint32_t width, uint32_t height, uint32_t msaa_level, bool opengl_invert_y, bool render_target, bool has_depth_buffer, bool can_extract_depth);
+    void (*start_draw_to_framebuffer)(int fb_id, float noise_scale);
+    void (*clear_framebuffer)(void);
+    void (*resolve_msaa_color_buffer)(int fb_id_target, int fb_id_source);
+    std::map<std::pair<float, float>, uint16_t> (*get_pixel_depth)(int fb_id, const std::set<std::pair<float, float>>& coordinates);
+    void *(*get_framebuffer_texture_id)(int fb_id);
+    void (*select_texture_fb)(int fb_id);
     void (*delete_texture)(uint32_t texID);
 };
 

--- a/libultraship/libultraship/Lib/ImGui/imgui.h
+++ b/libultraship/libultraship/Lib/ImGui/imgui.h
@@ -502,7 +502,7 @@ namespace ImGui
     IMGUI_API bool          SmallButton(const char* label);                                 // button with FramePadding=(0,0) to easily embed within text
     IMGUI_API bool          InvisibleButton(const char* str_id, const ImVec2& size, ImGuiButtonFlags flags = 0); // flexible button behavior without the visuals, frequently useful to build custom behaviors using the public api (along with IsItemActive, IsItemHovered, etc.)
     IMGUI_API bool          ArrowButton(const char* str_id, ImGuiDir dir);                  // square button with an arrow shape
-    IMGUI_API void          ImageRotated(ImTextureID tex_id, ImVec2 center, ImVec2 size, float angle);
+    IMGUI_API void          ImageSimple(ImTextureID tex_id, ImVec2 center, ImVec2 size);
     IMGUI_API void          Image(ImTextureID user_texture_id, const ImVec2& size, const ImVec2& uv0 = ImVec2(0, 0), const ImVec2& uv1 = ImVec2(1,1), const ImVec4& tint_col = ImVec4(1,1,1,1), const ImVec4& border_col = ImVec4(0,0,0,0));
     IMGUI_API bool          ImageButton(ImTextureID user_texture_id, const ImVec2& size, const ImVec2& uv0 = ImVec2(0, 0),  const ImVec2& uv1 = ImVec2(1,1), int frame_padding = -1, const ImVec4& bg_col = ImVec4(0,0,0,0), const ImVec4& tint_col = ImVec4(1,1,1,1));    // <0 frame_padding uses default frame padding settings. 0 for no padding
     IMGUI_API bool          Checkbox(const char* label, bool* v);

--- a/libultraship/libultraship/Lib/ImGui/imgui.h
+++ b/libultraship/libultraship/Lib/ImGui/imgui.h
@@ -502,7 +502,6 @@ namespace ImGui
     IMGUI_API bool          SmallButton(const char* label);                                 // button with FramePadding=(0,0) to easily embed within text
     IMGUI_API bool          InvisibleButton(const char* str_id, const ImVec2& size, ImGuiButtonFlags flags = 0); // flexible button behavior without the visuals, frequently useful to build custom behaviors using the public api (along with IsItemActive, IsItemHovered, etc.)
     IMGUI_API bool          ArrowButton(const char* str_id, ImGuiDir dir);                  // square button with an arrow shape
-    IMGUI_API void          ImageSimple(ImTextureID tex_id, ImVec2 center, ImVec2 size);
     IMGUI_API void          Image(ImTextureID user_texture_id, const ImVec2& size, const ImVec2& uv0 = ImVec2(0, 0), const ImVec2& uv1 = ImVec2(1,1), const ImVec4& tint_col = ImVec4(1,1,1,1), const ImVec4& border_col = ImVec4(0,0,0,0));
     IMGUI_API bool          ImageButton(ImTextureID user_texture_id, const ImVec2& size, const ImVec2& uv0 = ImVec2(0, 0),  const ImVec2& uv1 = ImVec2(1,1), int frame_padding = -1, const ImVec4& bg_col = ImVec4(0,0,0,0), const ImVec4& tint_col = ImVec4(1,1,1,1));    // <0 frame_padding uses default frame padding settings. 0 for no padding
     IMGUI_API bool          Checkbox(const char* label, bool* v);

--- a/libultraship/libultraship/Lib/ImGui/imgui_widgets.cpp
+++ b/libultraship/libultraship/Lib/ImGui/imgui_widgets.cpp
@@ -1007,7 +1007,7 @@ bool ImGui::ScrollbarEx(const ImRect& bb_frame, ImGuiID id, ImGuiAxis axis, ImS6
     return held;
 }
 
-void ImGui::ImageRotated(ImTextureID tex_id, ImVec2 center, ImVec2 size, float angle) {
+void ImGui::ImageSimple(ImTextureID tex_id, ImVec2 center, ImVec2 size) {
 
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -1025,10 +1025,10 @@ void ImGui::ImageRotated(ImTextureID tex_id, ImVec2 center, ImVec2 size, float a
     };
     ImVec2 uvs[4] =
     {
-        ImVec2(0.0f, 1.0f),
-        ImVec2(1.0f, 1.0f),
+        ImVec2(0.0f, 0.0f),
         ImVec2(1.0f, 0.0f),
-        ImVec2(0.0f, 0.0f)
+        ImVec2(1.0f, 1.0f),
+        ImVec2(0.0f, 1.0f)
     };
 
     draw_list->AddImageQuad(tex_id, pos[0], pos[1], pos[2], pos[3], uvs[0], uvs[1], uvs[2], uvs[3], IM_COL32_WHITE);

--- a/libultraship/libultraship/Lib/ImGui/imgui_widgets.cpp
+++ b/libultraship/libultraship/Lib/ImGui/imgui_widgets.cpp
@@ -1007,33 +1007,6 @@ bool ImGui::ScrollbarEx(const ImRect& bb_frame, ImGuiID id, ImGuiAxis axis, ImS6
     return held;
 }
 
-void ImGui::ImageSimple(ImTextureID tex_id, ImVec2 center, ImVec2 size) {
-
-    ImGuiWindow* window = GetCurrentWindow();
-    if (window->SkipItems)
-        return;
-
-    ImDrawList* draw_list = ImGui::GetWindowDrawList();
-    ImRect bb(window->DC.CursorPos + ImVec2(size.x / 2, size.y / 2), window->DC.CursorPos + size);
-
-    ImVec2 pos[4] =
-    {
-        center + bb.Min + ImVec2(-size.x * 0.5f, -size.y * 0.5f),
-        center + bb.Min + ImVec2(+size.x * 0.5f, -size.y * 0.5f),
-        center + bb.Min + ImVec2(+size.x * 0.5f, +size.y * 0.5f),
-        center + bb.Min + ImVec2(-size.x * 0.5f, +size.y * 0.5f)
-    };
-    ImVec2 uvs[4] =
-    {
-        ImVec2(0.0f, 0.0f),
-        ImVec2(1.0f, 0.0f),
-        ImVec2(1.0f, 1.0f),
-        ImVec2(0.0f, 1.0f)
-    };
-
-    draw_list->AddImageQuad(tex_id, pos[0], pos[1], pos[2], pos[3], uvs[0], uvs[1], uvs[2], uvs[3], IM_COL32_WHITE);
-}
-
 void ImGui::Image(ImTextureID user_texture_id, const ImVec2& size, const ImVec2& uv0, const ImVec2& uv1, const ImVec4& tint_col, const ImVec4& border_col)
 {
     ImGuiWindow* window = GetCurrentWindow();

--- a/libultraship/libultraship/SohImGuiImpl.cpp
+++ b/libultraship/libultraship/SohImGuiImpl.cpp
@@ -123,14 +123,6 @@ namespace SohImGui {
         }
     }
 
-    bool UseInternalRes() {
-        switch (impl.backend) {
-        case Backend::SDL:
-            return true;
-        }
-        return false;
-    }
-
     bool UseViewports() {
         switch (impl.backend) {
         case Backend::DX11:
@@ -256,20 +248,16 @@ namespace SohImGui {
         }
     }
 
-    void Draw() {
-
+    void Draw1() {
         console->Update();
         ImGuiBackendNewFrame();
         ImGuiWMNewFrame();
         ImGui::NewFrame();
 
         const std::shared_ptr<Window> wnd = GlobalCtx2::GetInstance()->GetWindow();
-        ImGuiWindowFlags window_flags = ImGuiWindowFlags_NoDocking |
+        ImGuiWindowFlags window_flags = ImGuiWindowFlags_NoDocking | ImGuiWindowFlags_NoBackground |
             ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoMove |
             ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoNavFocus | ImGuiWindowFlags_NoResize;
-        if (UseViewports()) {
-            window_flags |= ImGuiWindowFlags_NoBackground;
-        }
         if (Game::Settings.debug.menu_bar) window_flags |= ImGuiWindowFlags_MenuBar;
 
         const ImGuiViewport* viewport = ImGui::GetMainViewport();
@@ -277,8 +265,14 @@ namespace SohImGui {
         ImGui::SetNextWindowSize(ImVec2(wnd->GetCurrentWidth(), wnd->GetCurrentHeight()));
         ImGui::SetNextWindowViewport(viewport->ID);
         ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
+        ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.0f);
+        ImGui::PushStyleVar(ImGuiStyleVar_ChildBorderSize, 0.0f);
         ImGui::Begin("Main - Deck", nullptr, window_flags);
         ImGui::PopStyleVar();
+        ImGui::PopStyleVar();
+        ImGui::PopStyleVar();
+
+        ImVec2 top_left_pos = ImGui::GetWindowPos();
 
         const ImGuiID dockId = ImGui::GetID("main_dock");
 
@@ -386,9 +380,7 @@ namespace SohImGui {
                 ImGui::Text("Graphics");
                 ImGui::Separator();
 
-                if (UseInternalRes()) {
-                    HOOK(ImGui::Checkbox("N64 Mode", &Game::Settings.debug.n64mode));
-                }
+                HOOK(ImGui::Checkbox("N64 Mode", &Game::Settings.debug.n64mode));
 
                 if (ImGui::Checkbox("Animated Link in Pause Menu", &Game::Settings.enhancements.animated_pause_menu)) {
                     CVar_SetS32("gPauseLiveLink", Game::Settings.enhancements.animated_pause_menu);
@@ -406,10 +398,10 @@ namespace SohImGui {
             if (ImGui::BeginMenu("Developer Tools")) {
                 HOOK(ImGui::MenuItem("Stats", nullptr, &Game::Settings.debug.soh));
                 HOOK(ImGui::MenuItem("Console", nullptr, &console->opened));
-                
+
                 ImGui::Text("Debug");
                 ImGui::Separator();
-                
+
                 if (ImGui::Checkbox("Debug Mode", &Game::Settings.cheats.debug_mode)) {
                     CVar_SetS32("gDebugEnabled", Game::Settings.cheats.debug_mode);
                     needs_save = true;
@@ -417,7 +409,7 @@ namespace SohImGui {
 
                 ImGui::EndMenu();
             }
-            
+
             if (ImGui::BeginMenu("Cheats")) {
                 if (ImGui::Checkbox("Infinite Money", &Game::Settings.cheats.infinite_money)) {
                     CVar_SetS32("gInfiniteMoney", Game::Settings.cheats.infinite_money);
@@ -438,22 +430,22 @@ namespace SohImGui {
                     CVar_SetS32("gInfiniteMagic", Game::Settings.cheats.infinite_magic);
                     needs_save = true;
                 }
-                
+
                 if (ImGui::Checkbox("No Clip", &Game::Settings.cheats.no_clip)) {
                     CVar_SetS32("gNoClip", Game::Settings.cheats.no_clip);
                     needs_save = true;
                 }
-                
+
                 if (ImGui::Checkbox("Climb Everything", &Game::Settings.cheats.climb_everything)) {
                     CVar_SetS32("gClimbEverything", Game::Settings.cheats.climb_everything);
                     needs_save = true;
                 }
-                
+
                 if (ImGui::Checkbox("Moon Jump on L", &Game::Settings.cheats.moon_jump_on_l)) {
                     CVar_SetS32("gMoonJumpOnL", Game::Settings.cheats.moon_jump_on_l);
                     needs_save = true;
                 }
-                
+
                 if (ImGui::Checkbox("Super Tunic", &Game::Settings.cheats.super_tunic)) {
                     CVar_SetS32("gSuperTunic", Game::Settings.cheats.super_tunic);
                     needs_save = true;
@@ -476,34 +468,53 @@ namespace SohImGui {
 
         ImGui::End();
         ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0, 0));
+        ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.0f);
+        ImGui::PushStyleVar(ImGuiStyleVar_ChildBorderSize, 0.0f);
         ImGui::PushStyleColor(ImGuiCol_ChildBg, ImVec4(0.0f, 0.0f, 0.0f, 0.0f));
-        ImGuiWindowFlags flags = ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove;
-        if (UseViewports()) {
-            flags |= ImGuiWindowFlags_NoBackground;
-        }
+        ImGuiWindowFlags flags = ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoBackground;
         ImGui::Begin("OoT Master Quest", nullptr, flags);
+        ImGui::PopStyleVar();
+        ImGui::PopStyleVar();
         ImGui::PopStyleVar();
         ImGui::PopStyleColor();
 
         ImVec2 main_pos = ImGui::GetWindowPos();
+        main_pos.x -= top_left_pos.x;
+        main_pos.y -= top_left_pos.y;
         ImVec2 size = ImGui::GetContentRegionAvail();
         ImVec2 pos = ImVec2(0, 0);
         gfx_current_dimensions.width = size.x * gfx_current_dimensions.internal_mul;
         gfx_current_dimensions.height = size.y * gfx_current_dimensions.internal_mul;
-        if (UseInternalRes()) {
-            if (Game::Settings.debug.n64mode) {
-                gfx_current_dimensions.width = 320;
-                gfx_current_dimensions.height = 240;
-                const int sw = size.y * 320 / 240;
-                pos = ImVec2(size.x / 2 - sw / 2, 0);
-                size = ImVec2(sw, size.y);
-            }
+        gfx_current_game_window_viewport.x = main_pos.x;
+        gfx_current_game_window_viewport.y = main_pos.y;
+        gfx_current_game_window_viewport.width = size.x;
+        gfx_current_game_window_viewport.height = size.y;
+        if (Game::Settings.debug.n64mode) {
+            gfx_current_dimensions.width = 320;
+            gfx_current_dimensions.height = 240;
+            const int sw = size.y * 320 / 240;
+            gfx_current_game_window_viewport.x += (size.x - sw) / 2;
+            gfx_current_game_window_viewport.width = sw;
+            pos = ImVec2(size.x / 2 - sw / 2, 0);
+            size = ImVec2(sw, size.y);
+        }
+    }
+
+    void Draw2() {
+        ImVec2 main_pos = ImGui::GetWindowPos();
+        ImVec2 size = ImGui::GetContentRegionAvail();
+        ImVec2 pos = ImVec2(0, 0);
+        if (Game::Settings.debug.n64mode) {
+            const int sw = size.y * 320 / 240;
+            pos = ImVec2(size.x / 2 - sw / 2, 0);
+            size = ImVec2(sw, size.y);
+        }
+        std::string fb_str = SohUtils::getEnvironmentVar("framebuffer");
+        if (!fb_str.empty()) {
+            uintptr_t fbuf = (uintptr_t)std::stoull(fb_str);
+            ImGui::ImageSimple(reinterpret_cast<ImTextureID>(fbuf), pos, size);
         }
 
-        if (UseInternalRes()) {
-            int fbuf = std::stoi(SohUtils::getEnvironmentVar("framebuffer"));
-            ImGui::ImageRotated(reinterpret_cast<ImTextureID>(fbuf), pos, size, 0.0f);
-        }
         ImGui::End();
 
         if (Game::Settings.debug.soh) {
@@ -513,10 +524,10 @@ namespace SohImGui {
 
             ImGui::Text("Platform: Windows");
             ImGui::Text("Status: %.3f ms/frame (%.1f FPS)", 1000.0f / framerate, framerate);
-            if (UseInternalRes()) {
-                ImGui::Text("Internal Resolution:");
-                ImGui::SliderInt("Mul", reinterpret_cast<int*>(&gfx_current_dimensions.internal_mul), 1, 8);
-            }
+            ImGui::Text("Internal Resolution:");
+            ImGui::SliderInt("Mul", reinterpret_cast<int*>(&gfx_current_dimensions.internal_mul), 1, 8);
+            ImGui::Text("MSAA:");
+            ImGui::SliderInt("MSAA", reinterpret_cast<int*>(&gfx_msaa_level), 1, 8);
             ImGui::End();
             ImGui::PopStyleColor();
         }
@@ -524,7 +535,7 @@ namespace SohImGui {
         const float scale = Game::Settings.controller.input_scale;
         ImVec2 BtnPos = ImVec2(160 * scale, 85 * scale);
 
-        if(Game::Settings.controller.input_enabled) {
+        if (Game::Settings.controller.input_enabled) {
             ImGui::SetNextWindowSize(BtnPos);
             ImGui::SetNextWindowPos(ImVec2(main_pos.x + size.x - BtnPos.x - 20, main_pos.y + size.y - BtnPos.y - 20));
 
@@ -579,12 +590,21 @@ namespace SohImGui {
                 window.drawFunc(window.enabled);
             }
         }
+    }
 
+    void Render() {
         ImGui::Render();
         ImGuiRenderDrawData(ImGui::GetDrawData());
         if (UseViewports()) {
             ImGui::UpdatePlatformWindows();
             ImGui::RenderPlatformWindowsDefault();
+        }
+    }
+
+    void CancelFrame() {
+        ImGui::EndFrame();
+        if (UseViewports()) {
+            ImGui::UpdatePlatformWindows();
         }
     }
 

--- a/libultraship/libultraship/SohImGuiImpl.cpp
+++ b/libultraship/libultraship/SohImGuiImpl.cpp
@@ -268,9 +268,7 @@ namespace SohImGui {
         ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.0f);
         ImGui::PushStyleVar(ImGuiStyleVar_ChildBorderSize, 0.0f);
         ImGui::Begin("Main - Deck", nullptr, window_flags);
-        ImGui::PopStyleVar();
-        ImGui::PopStyleVar();
-        ImGui::PopStyleVar();
+        ImGui::PopStyleVar(3);
 
         ImVec2 top_left_pos = ImGui::GetWindowPos();
 
@@ -473,9 +471,7 @@ namespace SohImGui {
         ImGui::PushStyleColor(ImGuiCol_ChildBg, ImVec4(0.0f, 0.0f, 0.0f, 0.0f));
         ImGuiWindowFlags flags = ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoBackground;
         ImGui::Begin("OoT Master Quest", nullptr, flags);
-        ImGui::PopStyleVar();
-        ImGui::PopStyleVar();
-        ImGui::PopStyleVar();
+        ImGui::PopStyleVar(3);
         ImGui::PopStyleColor();
 
         ImVec2 main_pos = ImGui::GetWindowPos();

--- a/libultraship/libultraship/SohImGuiImpl.h
+++ b/libultraship/libultraship/SohImGuiImpl.h
@@ -59,8 +59,8 @@ namespace SohImGui {
     extern Console* console;
     void Init(WindowImpl window_impl);
     void Update(EventImpl event);
-    void Draw1(void);
-    void Draw2(void);
+    void DrawMainMenuAndCalculateGameSize(void);
+    void DrawFramebufferAndGameInput(void);
     void Render(void);
     void CancelFrame(void);
     void ShowCursor(bool hide, Dialogues w);

--- a/libultraship/libultraship/SohImGuiImpl.h
+++ b/libultraship/libultraship/SohImGuiImpl.h
@@ -59,7 +59,10 @@ namespace SohImGui {
     extern Console* console;
     void Init(WindowImpl window_impl);
     void Update(EventImpl event);
-    void Draw(void);
+    void Draw1(void);
+    void Draw2(void);
+    void Render(void);
+    void CancelFrame(void);
     void ShowCursor(bool hide, Dialogues w);
     void BindCmd(const std::string& cmd, CommandEntry entry);
     void AddWindow(const std::string& category, const std::string& name, WindowDrawFunc drawFunc);

--- a/libultraship/libultraship/Window.cpp
+++ b/libultraship/libultraship/Window.cpp
@@ -286,6 +286,10 @@ namespace Ship {
         //gfx_set_framedivisor(0);
     }
 
+    void Window::GetPixelDepthPrepare(float x, float y) {
+        gfx_get_pixel_depth_prepare(x, y);
+    }
+
     uint16_t Window::GetPixelDepth(float x, float y) {
         return gfx_get_pixel_depth(x, y);
     }

--- a/libultraship/libultraship/Window.h
+++ b/libultraship/libultraship/Window.h
@@ -20,6 +20,7 @@ namespace Ship {
 			void Init();
 			void RunCommands(Gfx* Commands);
 			void SetFrameDivisor(int divisor);
+			void GetPixelDepthPrepare(float x, float y);
 			uint16_t GetPixelDepth(float x, float y);
 			void ToggleFullscreen();
 			void SetFullscreen(bool bIsFullscreen);

--- a/soh/include/functions.h
+++ b/soh/include/functions.h
@@ -977,6 +977,7 @@ void LightContext_RemoveLight(GlobalContext* globalCtx, LightContext* lightCtx, 
 Lights* Lights_NewAndDraw(GraphicsContext* gfxCtx, u8 ambientR, u8 ambientG, u8 ambientB, u8 numLights, u8 r, u8 g,
                           u8 b, s8 x, s8 y, s8 z);
 Lights* Lights_New(GraphicsContext* gfxCtx, u8 ambientR, u8 ambientG, u8 ambientB);
+void Lights_GlowCheckPrepare(GlobalContext* globalCtx);
 void Lights_GlowCheck(GlobalContext* globalCtx);
 void Lights_DrawGlow(GlobalContext* globalCtx);
 void ZeldaArena_CheckPointer(void* ptr, size_t size, const char* name, const char* action);

--- a/soh/soh/GbiWrap.cpp
+++ b/soh/soh/GbiWrap.cpp
@@ -9,6 +9,7 @@ void Graph_ProcessGfxCommands(Gfx* commands);
 void OTRLogString(const char* src);
 void OTRGfxPrint(const char* str, void* printer, void (*printImpl)(void*, char));
 void OTRSetFrameDivisor(int divisor);
+void OTRGetPixelDepthPrepare(float x, float y);
 uint16_t OTRGetPixelDepth(float x, float y);
 int32_t OTRGetLastScancode();
 void ResourceMgr_CacheDirectory(const char* resName);

--- a/soh/soh/OTRGlobals.h
+++ b/soh/soh/OTRGlobals.h
@@ -24,7 +24,7 @@ void Graph_ProcessFrame(void (*run_one_game_iter)(void));
 void Graph_ProcessGfxCommands(Gfx* commands);
 void OTRLogString(const char* src);
 void OTRGfxPrint(const char* str, void* printer, void (*printImpl)(void*, char));
-void OTRSetFrameDivisor(int divisor);
+void OTRGetPixelDepthPrepare(float x, float y);
 uint16_t OTRGetPixelDepth(float x, float y);
 int32_t OTRGetLastScancode();
 uint32_t ResourceMgr_GetGameVersion();

--- a/soh/src/code/graph.c
+++ b/soh/src/code/graph.c
@@ -468,35 +468,6 @@ static void RunFrame()
         {
             uint64_t ticksA, ticksB;
             ticksA = GetPerfCounter();
-
-            OTRSetFrameDivisor(R_UPDATE_RATE);
-            //OTRSetFrameDivisor(0);
-
-            
-            //AudioMgr_ThreadEntry(&gAudioMgr);
-            // 528 and 544 relate to 60 fps at 32 kHz 32000/60 = 533.333..
-            // in an ideal world, one third of the calls should use num_samples=544 and two thirds num_samples=528
-            #define SAMPLES_HIGH 560
-            #define SAMPLES_LOW 528
-            // PAL values
-            //#define SAMPLES_HIGH 656
-            //#define SAMPLES_LOW 624
-            #define AUDIO_FRAMES_PER_UPDATE (R_UPDATE_RATE > 0 ? R_UPDATE_RATE : 1 )
-            #define NUM_AUDIO_CHANNELS 2
-            int samples_left = AudioPlayer_Buffered();
-            u32 num_audio_samples = samples_left < AudioPlayer_GetDesiredBuffered() ? SAMPLES_HIGH : SAMPLES_LOW;
-            // printf("Audio samples: %d %u\n", samples_left, num_audio_samples);
-
-            // 3 is the maximum authentic frame divisor.
-            s16 audio_buffer[SAMPLES_HIGH * NUM_AUDIO_CHANNELS * 3];
-            for (int i = 0; i < AUDIO_FRAMES_PER_UPDATE; i++) {
-                AudioMgr_CreateNextAudioBuffer(audio_buffer + i * (num_audio_samples * NUM_AUDIO_CHANNELS), num_audio_samples);
-            }
-            //for (uint32_t i = 0; i < 2 * num_audio_samples; i++) {
-            //    audio_buffer[i] = Rand_Next() & 0xFF;
-            //}
-            // printf("Audio samples before submitting: %d\n", audio_api->buffered());
-            AudioPlayer_Play((u8*)audio_buffer, num_audio_samples * (sizeof(int16_t) * NUM_AUDIO_CHANNELS * AUDIO_FRAMES_PER_UPDATE));
             
 
             PadMgr_ThreadEntry(&gPadMgr);

--- a/soh/src/code/z_kankyo.c
+++ b/soh/src/code/z_kankyo.c
@@ -226,6 +226,9 @@ u16 Environment_GetPixelDepth(s32 x, s32 y) {
 void Environment_GraphCallback(GraphicsContext* gfxCtx, void* param) {
     GlobalContext* globalCtx = (GlobalContext*)param;
 
+    OTRGetPixelDepthPrepare(D_8015FD7E, D_8015FD80);
+    Lights_GlowCheckPrepare(globalCtx);
+
     D_8011FB44 = Environment_GetPixelDepth(D_8015FD7E, D_8015FD80);
     Lights_GlowCheck(globalCtx);
 }

--- a/soh/src/code/z_lights.c
+++ b/soh/src/code/z_lights.c
@@ -323,6 +323,44 @@ Lights* Lights_New(GraphicsContext* gfxCtx, u8 ambientR, u8 ambientG, u8 ambient
     return lights;
 }
 
+void Lights_GlowCheckPrepare(GlobalContext* globalCtx) {
+    LightNode* node;
+    LightPoint* params;
+    Vec3f pos;
+    Vec3f multDest;
+    f32 wDest;
+    f32 wX;
+    f32 wY;
+
+    node = globalCtx->lightCtx.listHead;
+
+    while (node != NULL) {
+        params = &node->info->params.point;
+
+        if (node->info->type == LIGHT_POINT_GLOW) {
+            f32 x, y;
+            u32 shrink;
+            uint32_t height;
+
+            pos.x = params->x;
+            pos.y = params->y;
+            pos.z = params->z;
+            func_8002BE04(globalCtx, &pos, &multDest, &wDest);
+            wX = multDest.x * wDest;
+            wY = multDest.y * wDest;
+
+            x = wX * 160 + 160;
+            y = wY * 120 + 120;
+            shrink = ShrinkWindow_GetCurrentVal();
+
+            if ((multDest.z > 1.0f) && y >= shrink && y <= SCREEN_HEIGHT - shrink) {
+                OTRGetPixelDepthPrepare(x, y);
+            }
+        }
+        node = node->next;
+    }
+}
+
 void Lights_GlowCheck(GlobalContext* globalCtx) {
     LightNode* node;
     LightPoint* params;


### PR DESCRIPTION
This change simplifies and unifies how the framebuffers concept is implemented in the different gfx backends.

This allows SSAA, MSAA and N64 mode to be implemented by both the OpenGL and Direct3D 11 backends in the same way. The ImGUI gui has been updated accordingly.

When rendering for unscaled resolution, the OpenGL renderer now renders directly to the back buffer instead of to a texture which is then rendered to the back buffer, in order to save some performance.

The glClipControl usage is now removed and the y flipping has been moved to software. This should only result in a tiny performance decrease but will allow framebuffers to not be rendered upside-down on old hardware/drivers. It should also remove the need to use GLEW on Linux.

Another huge improvement that drastically reduces CPU% and GPU% in Kokiri forest is the batching of all read depth value calls to a single one, to avoid ping-ponging the GPU for every pixel that should be read (11 in Kokiri Forest and 26 in that grotto outside Shadow Temple). The OpenGL renderer now also avoids a read pixel "slow path" when the Intel driver was used that made it slower at higher resolutions.

I also moved audio to a separate thread, so it can be parallelized with the gfx rendering. It's still synchronized to the game though so the audio thread never does any job while the game logic runs. This also avoids the audio to drift in case the game or graphics would lag, which might be important in cutscenes.