### PR TITLE
Changes fast text option to skip text, and makes text speed adjustable via a slider

### DIFF
--- a/libultraship/libultraship/GameSettings.cpp
+++ b/libultraship/libultraship/GameSettings.cpp
@@ -49,6 +49,9 @@ namespace Game {
     	Settings.debug.n64mode = stob(Conf[ConfSection]["n64_mode"]);
 
         // Enhancements
+        Settings.enhancements.skip_text = stob(Conf[EnhancementSection]["skip_text"]);
+        CVar_SetS32("gSkipText", Settings.enhancements.skip_text);
+
         Settings.enhancements.fast_text = stob(Conf[EnhancementSection]["fast_text"]);
         CVar_SetS32("gFastText", Settings.enhancements.fast_text);
 
@@ -148,6 +151,7 @@ namespace Game {
         Conf[AudioSection]["fanfare"] = std::to_string(Settings.audio.fanfare);
 
         // Enhancements
+        Conf[EnhancementSection]["skip_text"] = std::to_string(Settings.enhancements.skip_text);
         Conf[EnhancementSection]["fast_text"] = std::to_string(Settings.enhancements.fast_text);
         Conf[EnhancementSection]["disable_lod"] = std::to_string(Settings.enhancements.disable_lod);
         Conf[EnhancementSection]["animated_pause_menu"] = std::to_string(Settings.enhancements.animated_pause_menu);

--- a/libultraship/libultraship/GameSettings.cpp
+++ b/libultraship/libultraship/GameSettings.cpp
@@ -52,8 +52,8 @@ namespace Game {
         Settings.enhancements.skip_text = stob(Conf[EnhancementSection]["skip_text"]);
         CVar_SetS32("gSkipText", Settings.enhancements.skip_text);
 
-        Settings.enhancements.fast_text = stob(Conf[EnhancementSection]["fast_text"]);
-        CVar_SetS32("gFastText", Settings.enhancements.fast_text);
+        Settings.enhancements.text_speed = Ship::stoi(Conf[EnhancementSection]["text_speed"]);
+        CVar_SetS32("gTextSpeed", Settings.enhancements.text_speed);
 
         Settings.enhancements.disable_lod = stob(Conf[EnhancementSection]["disable_lod"]);
         CVar_SetS32("gDisableLOD", Settings.enhancements.disable_lod);
@@ -152,7 +152,7 @@ namespace Game {
 
         // Enhancements
         Conf[EnhancementSection]["skip_text"] = std::to_string(Settings.enhancements.skip_text);
-        Conf[EnhancementSection]["fast_text"] = std::to_string(Settings.enhancements.fast_text);
+        Conf[EnhancementSection]["text_speed"] = std::to_string(Settings.enhancements.text_speed);
         Conf[EnhancementSection]["disable_lod"] = std::to_string(Settings.enhancements.disable_lod);
         Conf[EnhancementSection]["animated_pause_menu"] = std::to_string(Settings.enhancements.animated_pause_menu);
         Conf[EnhancementSection]["minimal_ui"] = std::to_string(Settings.enhancements.minimal_ui);

--- a/libultraship/libultraship/GameSettings.h
+++ b/libultraship/libultraship/GameSettings.h
@@ -20,6 +20,7 @@ struct SoHConfigType {
 
     // Enhancements
     struct {
+        bool skip_text = false;
         bool fast_text = false;
         bool disable_lod = false;
         bool animated_pause_menu = false;

--- a/libultraship/libultraship/GameSettings.h
+++ b/libultraship/libultraship/GameSettings.h
@@ -20,8 +20,8 @@ struct SoHConfigType {
 
     // Enhancements
     struct {
+        int text_speed = 1;
         bool skip_text = false;
-        bool fast_text = false;
         bool disable_lod = false;
         bool animated_pause_menu = false;
         bool minimal_ui = false;

--- a/libultraship/libultraship/SohImGuiImpl.cpp
+++ b/libultraship/libultraship/SohImGuiImpl.cpp
@@ -378,6 +378,11 @@ namespace SohImGui {
                 ImGui::Text("Gameplay");
                 ImGui::Separator();
 
+                if (ImGui::Checkbox("Skip Text", &Game::Settings.enhancements.skip_text)) {
+                    CVar_SetS32("gSkipText", Game::Settings.enhancements.skip_text);
+                    needs_save = true;
+                }
+
                 if (ImGui::Checkbox("Fast Text", &Game::Settings.enhancements.fast_text)) {
                     CVar_SetS32("gFastText", Game::Settings.enhancements.fast_text);
                     needs_save = true;

--- a/libultraship/libultraship/SohImGuiImpl.cpp
+++ b/libultraship/libultraship/SohImGuiImpl.cpp
@@ -380,6 +380,7 @@ namespace SohImGui {
 
                 ImGui::Text("Text Speed", Game::Settings.enhancements.text_speed);
                 if (ImGui::SliderInt("##TEXTSPEED", &Game::Settings.enhancements.text_speed, 1, 5)) {
+                    CVar_SetS32("gTextSpeed", Game::Settings.enhancements.text_speed);
                     needs_save = true;
                 }
 

--- a/libultraship/libultraship/SohImGuiImpl.cpp
+++ b/libultraship/libultraship/SohImGuiImpl.cpp
@@ -378,13 +378,13 @@ namespace SohImGui {
                 ImGui::Text("Gameplay");
                 ImGui::Separator();
 
-                if (ImGui::Checkbox("Skip Text", &Game::Settings.enhancements.skip_text)) {
-                    CVar_SetS32("gSkipText", Game::Settings.enhancements.skip_text);
+                ImGui::Text("Text Speed", Game::Settings.enhancements.text_speed);
+                if (ImGui::SliderInt("##TEXTSPEED", &Game::Settings.enhancements.text_speed, 1, 5)) {
                     needs_save = true;
                 }
 
-                if (ImGui::Checkbox("Fast Text", &Game::Settings.enhancements.fast_text)) {
-                    CVar_SetS32("gFastText", Game::Settings.enhancements.fast_text);
+                if (ImGui::Checkbox("Skip Text", &Game::Settings.enhancements.skip_text)) {
+                    CVar_SetS32("gSkipText", Game::Settings.enhancements.skip_text);
                     needs_save = true;
                 }
 

--- a/soh/src/code/z_message_PAL.c
+++ b/soh/src/code/z_message_PAL.c
@@ -37,7 +37,9 @@ MessageTableEntry* sStaffMessageEntryTablePtr;
 
 char* _message_0xFFFC_nes;
 
-
+const int fastText = 5;
+const int slowText = 1;
+bool textSpeed = 1;
 
 //MessageTableEntry sNesMessageEntryTable[] = {
 //#define DEFINE_MESSAGE(textId, type, yPos, nesMessage, gerMessage, fraMessage) \
@@ -956,9 +958,10 @@ void Message_DrawText(GlobalContext* globalCtx, Gfx** gfxP) {
                     }
                     i = j - 1;
                     if (CVar_GetS32("gFastText", 0) !=0)
-                        msgCtx->textDrawPos = i + 5;
+                        textSpeed = fastText;
                     else
-                        msgCtx->textDrawPos = i + 1;
+                        textSpeed = slowText;
+                    msgCtx->textDrawPos = i + textSpeed;
 
                     if (character) {}
                 }
@@ -1152,9 +1155,10 @@ void Message_DrawText(GlobalContext* globalCtx, Gfx** gfxP) {
     }
     if (msgCtx->textDelayTimer == 0) {
         if (CVar_GetS32("gFastText", 0) !=0)
-            msgCtx->textDrawPos = i + 5;
+            textSpeed = fastText;
         else
-            msgCtx->textDrawPos = i + 1;
+            textSpeed = slowText;
+        msgCtx->textDrawPos = i + textSpeed;
         msgCtx->textDelayTimer = msgCtx->textDelay;
     } else {
         msgCtx->textDelayTimer--;

--- a/soh/src/code/z_message_PAL.c
+++ b/soh/src/code/z_message_PAL.c
@@ -37,6 +37,8 @@ MessageTableEntry* sStaffMessageEntryTablePtr;
 
 char* _message_0xFFFC_nes;
 
+
+
 //MessageTableEntry sNesMessageEntryTable[] = {
 //#define DEFINE_MESSAGE(textId, type, yPos, nesMessage, gerMessage, fraMessage) \
 //    { textId, (_SHIFTL(type, 4, 8) | _SHIFTL(yPos, 0, 8)), _message_##textId##_nes },
@@ -118,6 +120,8 @@ s16 sOcarinaNoteCEnvR;
 s16 sOcarinaNoteCEnvB;
 s16 sOcarinaNoteCEnvG;
 
+
+
 void Message_ResetOcarinaNoteState(void) {
     R_OCARINA_NOTES_YPOS(0) = 189;
     R_OCARINA_NOTES_YPOS(1) = 184;
@@ -166,7 +170,7 @@ void Message_UpdateOcarinaGame(GlobalContext* globalCtx) {
 u8 Message_ShouldAdvance(GlobalContext* globalCtx) {
     Input* input = &globalCtx->state.input[0];
 
-    bool isB_Held = CVar_GetS32("gFastText", 0) != 0 ? CHECK_BTN_ALL(input->cur.button, BTN_B)
+    bool isB_Held = CVar_GetS32("gSkipText", 0) != 0 ? CHECK_BTN_ALL(input->cur.button, BTN_B)
                                                      : CHECK_BTN_ALL(input->press.button, BTN_B);
 
     if (CHECK_BTN_ALL(input->press.button, BTN_A) || isB_Held || CHECK_BTN_ALL(input->press.button, BTN_CUP)) {
@@ -178,7 +182,7 @@ u8 Message_ShouldAdvance(GlobalContext* globalCtx) {
 u8 Message_ShouldAdvanceSilent(GlobalContext* globalCtx) {
     Input* input = &globalCtx->state.input[0];
 
-    bool isB_Held = CVar_GetS32("gFastText", 0) != 0 ? CHECK_BTN_ALL(input->cur.button, BTN_B)
+    bool isB_Held = CVar_GetS32("gSkipText", 0) != 0 ? CHECK_BTN_ALL(input->cur.button, BTN_B)
                                                      : CHECK_BTN_ALL(input->press.button, BTN_B);
 
     return CHECK_BTN_ALL(input->press.button, BTN_A) || isB_Held || CHECK_BTN_ALL(input->press.button, BTN_CUP);
@@ -951,7 +955,10 @@ void Message_DrawText(GlobalContext* globalCtx, Gfx** gfxP) {
                         }
                     }
                     i = j - 1;
-                    msgCtx->textDrawPos = i + 1;
+                    if (CVar_GetS32("gFastText", 0) !=0)
+                        msgCtx->textDrawPos = i + 5;
+                    else
+                        msgCtx->textDrawPos = i + 1;
 
                     if (character) {}
                 }
@@ -1061,7 +1068,7 @@ void Message_DrawText(GlobalContext* globalCtx, Gfx** gfxP) {
                 msgCtx->textDelay = msgCtx->msgBufDecoded[++i];
                 break;
             case MESSAGE_UNSKIPPABLE:
-                msgCtx->textUnskippable = CVar_GetS32("gFastText", 0) != 1;
+                msgCtx->textUnskippable = CVar_GetS32("gSkipText", 0) != 1;
                 break;
             case MESSAGE_TWO_CHOICE:
                 msgCtx->textboxEndType = TEXTBOX_ENDTYPE_2_CHOICE;
@@ -1144,7 +1151,10 @@ void Message_DrawText(GlobalContext* globalCtx, Gfx** gfxP) {
         }
     }
     if (msgCtx->textDelayTimer == 0) {
-        msgCtx->textDrawPos = i + 1;
+        if (CVar_GetS32("gFastText", 0) !=0)
+            msgCtx->textDrawPos = i + 5;
+        else
+            msgCtx->textDrawPos = i + 1;
         msgCtx->textDelayTimer = msgCtx->textDelay;
     } else {
         msgCtx->textDelayTimer--;
@@ -2026,7 +2036,7 @@ void Message_DrawMain(GlobalContext* globalCtx, Gfx** p) {
         gDPSetCombineLERP(gfx++, 0, 0, 0, PRIMITIVE, TEXEL0, 0, PRIMITIVE, 0, 0, 0, 0, PRIMITIVE, TEXEL0, 0, PRIMITIVE,
                           0);
 
-            bool isB_Held = CVar_GetS32("gFastText", 0) != 0 ? CHECK_BTN_ALL(globalCtx->state.input[0].cur.button, BTN_B)
+            bool isB_Held = CVar_GetS32("gSkipText", 0) != 0 ? CHECK_BTN_ALL(globalCtx->state.input[0].cur.button, BTN_B)
                                                          : CHECK_BTN_ALL(globalCtx->state.input[0].press.button, BTN_B);
 
         switch (msgCtx->msgMode) {
@@ -3067,7 +3077,7 @@ void Message_Update(GlobalContext* globalCtx) {
         return;
     }
 
-    bool isB_Held = CVar_GetS32("gFastText", 0) != 0 ? CHECK_BTN_ALL(input->cur.button, BTN_B) && !sTextboxSkipped
+    bool isB_Held = CVar_GetS32("gSkipText", 0) != 0 ? CHECK_BTN_ALL(input->cur.button, BTN_B) && !sTextboxSkipped
                                                      : CHECK_BTN_ALL(input->press.button, BTN_B);
 
     switch (msgCtx->msgMode) {

--- a/soh/src/code/z_message_PAL.c
+++ b/soh/src/code/z_message_PAL.c
@@ -37,10 +37,6 @@ MessageTableEntry* sStaffMessageEntryTablePtr;
 
 char* _message_0xFFFC_nes;
 
-const int fastText = 5;
-const int slowText = 1;
-bool textSpeed = 1;
-
 //MessageTableEntry sNesMessageEntryTable[] = {
 //#define DEFINE_MESSAGE(textId, type, yPos, nesMessage, gerMessage, fraMessage) \
 //    { textId, (_SHIFTL(type, 4, 8) | _SHIFTL(yPos, 0, 8)), _message_##textId##_nes },
@@ -957,11 +953,7 @@ void Message_DrawText(GlobalContext* globalCtx, Gfx** gfxP) {
                         }
                     }
                     i = j - 1;
-                    if (CVar_GetS32("gFastText", 0) !=0)
-                        textSpeed = fastText;
-                    else
-                        textSpeed = slowText;
-                    msgCtx->textDrawPos = i + textSpeed;
+                    msgCtx->textDrawPos = i + CVar_GetS32("gTextSpeed", 1);
 
                     if (character) {}
                 }
@@ -1154,11 +1146,7 @@ void Message_DrawText(GlobalContext* globalCtx, Gfx** gfxP) {
         }
     }
     if (msgCtx->textDelayTimer == 0) {
-        if (CVar_GetS32("gFastText", 0) !=0)
-            textSpeed = fastText;
-        else
-            textSpeed = slowText;
-        msgCtx->textDrawPos = i + textSpeed;
+        msgCtx->textDrawPos = i + CVar_GetS32("gTextSpeed", 1);
         msgCtx->textDelayTimer = msgCtx->textDelay;
     } else {
         msgCtx->textDelayTimer--;

--- a/soh/src/code/z_message_PAL.c
+++ b/soh/src/code/z_message_PAL.c
@@ -118,8 +118,6 @@ s16 sOcarinaNoteCEnvR;
 s16 sOcarinaNoteCEnvB;
 s16 sOcarinaNoteCEnvG;
 
-
-
 void Message_ResetOcarinaNoteState(void) {
     R_OCARINA_NOTES_YPOS(0) = 189;
     R_OCARINA_NOTES_YPOS(1) = 184;


### PR DESCRIPTION
Changes previous `Fast Text` option to `Skip Text`, and adds a new `Text Speed` slider, which can adjust the speed from original to 5x. 

![image](https://user-images.githubusercontent.com/60364512/163676481-aa9d9cbc-7061-4501-9908-59eff8daf8f7.png)

https://user-images.githubusercontent.com/60364512/163676461-2bc18e07-2985-4cd5-9404-8c590f5ce869.mp4