### PR TITLE
Fix hardcoded keySegment address

### DIFF
--- a/soh/src/overlays/actors/ovl_En_Ex_Item/z_en_ex_item.c
+++ b/soh/src/overlays/actors/ovl_En_Ex_Item/z_en_ex_item.c
@@ -496,7 +496,7 @@ void EnExItem_DrawMagic(EnExItem* this, GlobalContext* globalCtx, s16 magicIndex
 }
 
 void EnExItem_DrawKey(EnExItem* this, GlobalContext* globalCtx, s32 index) {
-    static s32 keySegments[] = { 0x0403F140 };
+    static void* keySegments[] = { gDropKeySmallTex };
 
     OPEN_DISPS(globalCtx->state.gfxCtx, "../z_en_ex_item.c", 880);
 


### PR DESCRIPTION
Fixes crash reported on the Wii U port: https://github.com/GaryOderNichts/Shipwright/issues/9