### PR TITLE
Fix shift for G_LOADTILE

### DIFF
--- a/OTRExporter/OTRExporter/DisplayListExporter.cpp
+++ b/OTRExporter/OTRExporter/DisplayListExporter.cpp
@@ -667,7 +667,7 @@ void OTRExporter_DisplayList::Save(ZResource* res, const fs::path& outPath, Bina
 		{
 			int sss =	(data & 0x00FFF00000000000) >> 44;
 			int ttt =	(data & 0x00000FFF00000000) >> 32;
-			int i =		(data & 0x000000000F000000) >> 16;
+			int i =		(data & 0x000000000F000000) >> 24;
 			int uuu =	(data & 0x0000000000FFF000) >> 12;
 			int vvv=	(data & 0x0000000000000FFF);
 


### PR DESCRIPTION
Fixes triggering the following assert when building without `NDEBUG`: https://github.com/HarbourMasters/Shipwright/blob/ceef4a94537a9b6fd14b5ff1b58f4605fd4c64fd/libultraship/libultraship/Lib/Fast3D/gfx_pc.cpp#L1728