### PR TITLE
Fix texture width for G_SETTIMG

### DIFF
--- a/OTRExporter/OTRExporter/DisplayListExporter.cpp
+++ b/OTRExporter/OTRExporter/DisplayListExporter.cpp
@@ -689,7 +689,7 @@ void OTRExporter_DisplayList::Save(ZResource* res, const fs::path& outPath, Bina
 				uint32_t fmt = (__ & 0xE0) >> 5;
 				uint32_t siz = (__ & 0x18) >> 3;
 
-				Gfx value = gsDPSetTextureImage(fmt, siz, www - 1, (seg & 0x0FFFFFFF) + 0xF0000000);
+				Gfx value = gsDPSetTextureImage(fmt, siz, www + 1, (seg & 0x0FFFFFFF) + 0xF0000000);
 				word0 = value.words.w0;
 				word1 = value.words.w1;
 
@@ -707,7 +707,7 @@ void OTRExporter_DisplayList::Save(ZResource* res, const fs::path& outPath, Bina
 				uint32_t fmt = (__ & 0xE0) >> 5;
 				uint32_t siz = (__ & 0x18) >> 3;
 
-				Gfx value = gsDPSetTextureImage(fmt, siz, www - 1, __);
+				Gfx value = gsDPSetTextureImage(fmt, siz, www + 1, __);
 				word0 = value.words.w0 & 0x00FFFFFF;
 				word0 += (G_SETTIMG_OTR << 24);
 				//word1 = value.words.w1;


### PR DESCRIPTION
`gsDPSetTextureImage` does `(width)-1`, so this should be `width + 1` to maintain the correct width.
Fixes triggering the following assert when building without `NDEBUG`: https://github.com/HarbourMasters/Shipwright/blob/ceef4a94537a9b6fd14b5ff1b58f4605fd4c64fd/libultraship/libultraship/Lib/Fast3D/gfx_pc.cpp#L652