### PR TITLE
Fix Title card name for FRA and GER

### DIFF
--- a/soh/src/code/z_actor.c
+++ b/soh/src/code/z_actor.c
@@ -977,7 +977,6 @@ void TitleCard_Draw(GlobalContext* globalCtx, TitleCardContext* titleCtx) {
     s32 doubleWidth;
     s32 titleY;
     s32 titleSecondY;
-    s32 textureLanguageOffset;
 
     if (titleCtx->alpha != 0) {
         width = titleCtx->width;
@@ -988,7 +987,6 @@ void TitleCard_Draw(GlobalContext* globalCtx, TitleCardContext* titleCtx) {
 
         OPEN_DISPS(globalCtx->state.gfxCtx, "../z_actor.c", 2824);
 
-        textureLanguageOffset = width * height * gSaveContext.language;
         height = (width * height > 0x1000) ? 0x1000 / width : height;
         titleSecondY = titleY + (height * 4);
 
@@ -997,7 +995,7 @@ void TitleCard_Draw(GlobalContext* globalCtx, TitleCardContext* titleCtx) {
         gDPSetPrimColor(OVERLAY_DISP++, 0, 0, (u8)titleCtx->intensity, (u8)titleCtx->intensity, (u8)titleCtx->intensity,
                         (u8)titleCtx->alpha);
 
-        gDPLoadTextureBlock(OVERLAY_DISP++, (uintptr_t)titleCtx->texture + textureLanguageOffset, G_IM_FMT_IA,
+        gDPLoadTextureBlock(OVERLAY_DISP++, (uintptr_t)titleCtx->texture, G_IM_FMT_IA,
                             G_IM_SIZ_8b,
                             width, height, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK,
                             G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
@@ -1009,7 +1007,7 @@ void TitleCard_Draw(GlobalContext* globalCtx, TitleCardContext* titleCtx) {
 
         // If texture is bigger than 0x1000, display the rest
         if (height > 0) {
-            gDPLoadTextureBlock(OVERLAY_DISP++, (uintptr_t)titleCtx->texture + textureLanguageOffset + 0x1000,
+            gDPLoadTextureBlock(OVERLAY_DISP++, (uintptr_t)titleCtx->texture + 0x1000,
                                 G_IM_FMT_IA,
                                 G_IM_SIZ_8b, width, height, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP,
                                 G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);


### PR DESCRIPTION
Removing textureLanguageOffset does fix the French and German title card name that was showing as corrupted in game.

There gSaveContext.language will return 0 for English language
``textureLanguageOffset = width * height * gSaveContext.language;``

French & German will return 1 and 2 breaking the offset logic since both German and French need to be on the same offset than English
Since we need it to be zero just removing that offset make it working just fine.

![English preview](https://www.baoulettes.fr/Uploads/v2vcjb7rnei7gz7j9v1yey35f.png)
![German preview](https://www.baoulettes.fr/Uploads/lsn9ubgaib9zy0nbpt4rp5eko.png)
![French preview](https://www.baoulettes.fr/Uploads/szw5k46sky1l5su9vji3hwbe7.png)

My test goes as far as :
Launching game in each language see it work, walk to other scene and see if it change the title to correct one
Changing language without restarting and change scene
all of that work just fine 
Only if you change the language on runtime when the title card is draw it will not refresh. but that definitely normal since the change is made in Draw() function once it is passed it will not refresh except if you change scene :)

So in short it work as intended 