### PR TITLE
Fixes default text speed

### DIFF
--- a/libultraship/libultraship/ConfigFile.cpp
+++ b/libultraship/libultraship/ConfigFile.cpp
@@ -2,6 +2,7 @@
 #include "spdlog/spdlog.h"
 #include "GlobalCtx2.h"
 #include "Window.h"
+#include "GameSettings.h"
 
 namespace Ship {
 	ConfigFile::ConfigFile(std::shared_ptr<GlobalCtx2> Context, const std::string& Path) : Context(Context), Path(Path), File(Path.c_str()) {
@@ -148,6 +149,8 @@ namespace Ship {
 		(*this)["KEYBOARD CONTROLLER BINDING 4"][STR(BTN_STICKLEFT)] = std::to_string(0x01E);
 		(*this)["KEYBOARD CONTROLLER BINDING 4"][STR(BTN_STICKDOWN)] = std::to_string(0x01F);
 		(*this)["KEYBOARD CONTROLLER BINDING 4"][STR(BTN_STICKUP)] = std::to_string(0x011);
+
+		(*this)["ENHANCEMENT SETTINGS"]["TEXT_SPEED"] = "1";
 
 		(*this)["SDL CONTROLLER 1"]["GUID"] = "";
 		(*this)["SDL CONTROLLER 2"]["GUID"] = "";

--- a/soh/src/code/z_message_PAL.c
+++ b/soh/src/code/z_message_PAL.c
@@ -951,7 +951,10 @@ void Message_DrawText(GlobalContext* globalCtx, Gfx** gfxP) {
                         }
                     }
                     i = j - 1;
-                    msgCtx->textDrawPos = i + CVar_GetS32("gTextSpeed", 1);
+                    if (CVar_GetS32("gTextSpeed", 1) > 0)
+                        msgCtx->textDrawPos = i + CVar_GetS32("gTextSpeed", 1);
+                    else
+                        CVar_SetS32("gTextSpeed", 1);
 
                     if (character) {}
                 }
@@ -1144,7 +1147,10 @@ void Message_DrawText(GlobalContext* globalCtx, Gfx** gfxP) {
         }
     }
     if (msgCtx->textDelayTimer == 0) {
-        msgCtx->textDrawPos = i + CVar_GetS32("gTextSpeed", 1);
+        if (CVar_GetS32("gTextSpeed", 1) > 0)
+            msgCtx->textDrawPos = i + CVar_GetS32("gTextSpeed", 1);
+        else
+            CVar_SetS32("gTextSpeed", 1);
         msgCtx->textDelayTimer = msgCtx->textDelay;
     } else {
         msgCtx->textDelayTimer--;

--- a/soh/src/code/z_message_PAL.c
+++ b/soh/src/code/z_message_PAL.c
@@ -951,10 +951,7 @@ void Message_DrawText(GlobalContext* globalCtx, Gfx** gfxP) {
                         }
                     }
                     i = j - 1;
-                    if (CVar_GetS32("gTextSpeed", 1) > 0)
-                        msgCtx->textDrawPos = i + CVar_GetS32("gTextSpeed", 1);
-                    else
-                        CVar_SetS32("gTextSpeed", 1);
+                    msgCtx->textDrawPos = i + CVar_GetS32("gTextSpeed", 1);
 
                     if (character) {}
                 }
@@ -1147,10 +1144,7 @@ void Message_DrawText(GlobalContext* globalCtx, Gfx** gfxP) {
         }
     }
     if (msgCtx->textDelayTimer == 0) {
-        if (CVar_GetS32("gTextSpeed", 1) > 0)
-            msgCtx->textDrawPos = i + CVar_GetS32("gTextSpeed", 1);
-        else
-            CVar_SetS32("gTextSpeed", 1);
+        msgCtx->textDrawPos = i + CVar_GetS32("gTextSpeed", 1);
         msgCtx->textDelayTimer = msgCtx->textDelay;
     } else {
         msgCtx->textDelayTimer--;


### PR DESCRIPTION
Adds default setting for `text_speed` in config file, fixing a bug where if you didn't manually change it in the enhancements menu, text wouldn't progress ingame.