### PR TITLE
Makes text speed slider consistent with the rest of the UI

### DIFF
--- a/libultraship/libultraship/SohImGuiImpl.cpp
+++ b/libultraship/libultraship/SohImGuiImpl.cpp
@@ -395,8 +395,8 @@ namespace SohImGui {
                 ImGui::Text("Gameplay");
                 ImGui::Separator();
 
-                ImGui::Text("Text Speed", Game::Settings.enhancements.text_speed);
-                if (ImGui::SliderInt("##TEXTSPEED", &Game::Settings.enhancements.text_speed, 1, 5)) {
+                ImGui::Text("Text Speed: %dx", Game::Settings.enhancements.text_speed);
+                if (ImGui::SliderInt("##TEXTSPEED", &Game::Settings.enhancements.text_speed, 1, 5, "")) {
                     CVar_SetS32("gTextSpeed", Game::Settings.enhancements.text_speed);
                     needs_save = true;
                 }


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/60364512/164942531-2a87ded4-bee5-4a10-99ed-9e4e8351391c.png)
After:
![image](https://user-images.githubusercontent.com/60364512/164942537-55f4bafa-64ea-4007-856c-140d0f4d27bb.png)
