### PR TITLE
Fixes visual bug in shops when above 2x text speed

### DIFF
--- a/soh/src/code/z_message_PAL.c
+++ b/soh/src/code/z_message_PAL.c
@@ -1144,7 +1144,7 @@ void Message_DrawText(GlobalContext* globalCtx, Gfx** gfxP) {
         }
     }
     if (msgCtx->textDelayTimer == 0) {
-        msgCtx->textDrawPos = i + CVar_GetS32("gTextSpeed", 1);
+        msgCtx->textDrawPos = i + 1;
         msgCtx->textDelayTimer = msgCtx->textDelay;
     } else {
         msgCtx->textDelayTimer--;


### PR DESCRIPTION
Fixes #210 

Second `textdrawpos` wasn't necessary, as whenever it's called, text appears instantly anyway, however when it's called in shops caused a visual bug where the arrow would be a square rather than an arrow.

Before fix:
![image](https://user-images.githubusercontent.com/60364512/164976117-207b806f-ffe0-4c68-996d-b046874fde44.png)
After fix:
![image](https://user-images.githubusercontent.com/60364512/164976124-1a5dc27a-3dc9-44c0-a89c-4d88e1f653d3.png)
