### PR TITLE
Removed redundant parameters in GameSettings.

### DIFF
--- a/libultraship/libultraship/GameSettings.cpp
+++ b/libultraship/libultraship/GameSettings.cpp
@@ -14,6 +14,7 @@
 #include "../../soh/include/z64audio.h"
 #include <string>
 #include "SohHooks.h"
+#include "../../soh/soh/Enhancements/debugconsole.h"
 
 #include "Window.h"
 
@@ -34,14 +35,13 @@ namespace Game {
 
 
     void UpdateAudio() {
-        Audio_SetGameVolume(SEQ_BGM_MAIN, Settings.audio.music_main);
-        Audio_SetGameVolume(SEQ_BGM_SUB, Settings.audio.music_sub);
-        Audio_SetGameVolume(SEQ_FANFARE, Settings.audio.fanfare);
-        Audio_SetGameVolume(SEQ_SFX, Settings.audio.sfx);
+        Audio_SetGameVolume(SEQ_BGM_MAIN, CVar_GetFloat("gMainMusicVolume", 1));
+        Audio_SetGameVolume(SEQ_BGM_SUB, CVar_GetFloat("gSubMusicVolume", 1));
+        Audio_SetGameVolume(SEQ_FANFARE, CVar_GetFloat("gSFXMusicVolume", 1));
+        Audio_SetGameVolume(SEQ_SFX, CVar_GetFloat("gFanfareVolume", 1));
     }
 
     void LoadSettings() {
-
         const std::shared_ptr<ConfigFile> pConf = GlobalCtx2::GetInstance()->GetConfig();
         ConfigFile& Conf = *pConf;
 
@@ -49,196 +49,6 @@ namespace Game {
         SohImGui::console->opened = stob(Conf[ConfSection]["console"]);
         Settings.debug.menu_bar = stob(Conf[ConfSection]["menu_bar"]);
         Settings.debug.soh = stob(Conf[ConfSection]["soh_debug"]);
-
-    	Settings.debug.n64mode = stob(Conf[ConfSection]["n64_mode"]);
-
-        // Enhancements
-        Settings.enhancements.skip_text = stob(Conf[EnhancementSection]["skip_text"]);
-        CVar_SetS32("gSkipText", Settings.enhancements.skip_text);
-
-        Settings.enhancements.text_speed = Ship::stoi(Conf[EnhancementSection]["text_speed"]);
-        CVar_SetS32("gTextSpeed", Settings.enhancements.text_speed);
-
-        Settings.enhancements.disable_lod = stob(Conf[EnhancementSection]["disable_lod"]);
-        CVar_SetS32("gDisableLOD", Settings.enhancements.disable_lod);
-
-        Settings.enhancements.animated_pause_menu = stob(Conf[EnhancementSection]["animated_pause_menu"]);
-        CVar_SetS32("gPauseLiveLink", Settings.enhancements.animated_pause_menu);
-
-        Settings.enhancements.dynamic_wallet_icon = stob(Conf[EnhancementSection]["dynamic_wallet_icon"]);
-        CVar_SetS32("gDynamicWalletIcon", Settings.enhancements.dynamic_wallet_icon);
-
-        Settings.enhancements.minimal_ui = stob(Conf[EnhancementSection]["minimal_ui"]);
-        CVar_SetS32("gMinimalUI", Settings.enhancements.minimal_ui);
-
-        Settings.enhancements.visualagony = stob(Conf[EnhancementSection]["visualagony"]);
-        CVar_SetS32("gVisualAgony", Settings.enhancements.visualagony);
-      
-        Settings.enhancements.mm_bunny_hood = stob(Conf[EnhancementSection]["mm_bunny_hood"]);
-        CVar_SetS32("gMMBunnyHood", Settings.enhancements.mm_bunny_hood);
-	    
-        Settings.enhancements.uniform_lr = stob(Conf[EnhancementSection]["uniform_lr"]);
-        //CVar_SetS32("gUniformLR", Settings.enhancements.uniform_lr);
-        CVar_SetS32("gUniformLR", 1);
-
-        Settings.enhancements.newdrops = stob(Conf[EnhancementSection]["newdrops"]);
-        CVar_SetS32("gNewDrops", Settings.enhancements.newdrops);
-        
-        // Audio
-        Settings.audio.master = Ship::stof(Conf[AudioSection]["master"]);
-        CVar_SetFloat("gGameMasterVolume", Settings.audio.master);
-
-        Settings.audio.music_main = Ship::stof(Conf[AudioSection]["music_main"]);
-        CVar_SetFloat("gMainMusicVolume", Settings.audio.music_main);
-
-        Settings.audio.music_sub = Ship::stof(Conf[AudioSection]["music_sub"]);
-        CVar_SetFloat("gSubMusicVolume", Settings.audio.music_sub);
-
-        Settings.audio.sfx = Ship::stof(Conf[AudioSection]["sfx"]);
-        CVar_SetFloat("gSFXMusicVolume", Settings.audio.sfx);
-
-        Settings.audio.fanfare = Ship::stof(Conf[AudioSection]["fanfare"]);
-        CVar_SetFloat("gFanfareVolume", Settings.audio.fanfare);
-
-        // Controllers
-        Settings.controller.rumble_enabled = Ship::stof(Conf[ControllerSection]["rumble_enabled"]);
-        CVar_SetS32("gRumbleEnabled", Settings.controller.rumble_enabled);
-
-        Settings.controller.input_scale = Ship::stof(Conf[ControllerSection]["input_scale"]);
-        CVar_SetFloat("gInputScale", Settings.controller.input_scale);
-
-        Settings.controller.input_enabled = stob(Conf[ControllerSection]["input_enabled"]);
-
-        CVar_SetS32("gInputEnabled", Settings.controller.input_enabled);
-        //Tunics
-        Settings.cosmetic.tunic_kokiri_red = (Conf[CosmeticsSection]["tunic_kokiri_red"] != "") ? Ship::stoi(Conf[CosmeticsSection]["tunic_kokiri_red"]) : Settings.cosmetic.tunic_kokiri_red;
-        CVar_SetS32("gTunic_Kokiri_Red", Settings.cosmetic.tunic_kokiri_red);
-        Settings.cosmetic.tunic_kokiri_green = (Conf[CosmeticsSection]["tunic_kokiri_green"] != "") ? Ship::stoi(Conf[CosmeticsSection]["tunic_kokiri_green"]) : Settings.cosmetic.tunic_kokiri_green;
-        CVar_SetS32("gTunic_Kokiri_Green", Settings.cosmetic.tunic_kokiri_green);
-        Settings.cosmetic.tunic_kokiri_blue = (Conf[CosmeticsSection]["tunic_kokiri_blue"] != "") ? Ship::stoi(Conf[CosmeticsSection]["tunic_kokiri_blue"]) : Settings.cosmetic.tunic_kokiri_blue;
-        CVar_SetS32("gTunic_Kokiri_Blue", Settings.cosmetic.tunic_kokiri_blue);
-
-        Settings.cosmetic.tunic_goron_red = (Conf[CosmeticsSection]["tunic_goron_red"] != "") ? Ship::stoi(Conf[CosmeticsSection]["tunic_goron_red"]) : Settings.cosmetic.tunic_goron_red;
-        CVar_SetS32("gTunic_Goron_Red", Settings.cosmetic.tunic_goron_red);
-        Settings.cosmetic.tunic_goron_green = (Conf[CosmeticsSection]["tunic_goron_green"] != "") ? Ship::stoi(Conf[CosmeticsSection]["tunic_goron_green"]) : Settings.cosmetic.tunic_goron_green;
-        CVar_SetS32("gTunic_Goron_Green", Settings.cosmetic.tunic_goron_green);
-        Settings.cosmetic.tunic_goron_blue = (Conf[CosmeticsSection]["tunic_goron_blue"] != "") ? Ship::stoi(Conf[CosmeticsSection]["tunic_goron_blue"]) : Settings.cosmetic.tunic_goron_blue;
-        CVar_SetS32("gTunic_Goron_Blue", Settings.cosmetic.tunic_goron_blue);
-
-        Settings.cosmetic.tunic_zora_red = (Conf[CosmeticsSection]["tunic_zora_green"] != "") ? Ship::stoi(Conf[CosmeticsSection]["tunic_zora_red"]) : Settings.cosmetic.tunic_zora_red;
-        CVar_SetS32("gTunic_Zora_Red", Settings.cosmetic.tunic_zora_red);
-        Settings.cosmetic.tunic_zora_green = (Conf[CosmeticsSection]["tunic_zora_green"] != "") ? Ship::stoi(Conf[CosmeticsSection]["tunic_zora_green"]) : Settings.cosmetic.tunic_zora_green;
-        CVar_SetS32("gTunic_Zora_Green", Settings.cosmetic.tunic_zora_green);
-        Settings.cosmetic.tunic_zora_blue = (Conf[CosmeticsSection]["tunic_zora_blue"] != "" ) ? Ship::stoi(Conf[CosmeticsSection]["tunic_zora_blue"]) : Settings.cosmetic.tunic_zora_blue;
-        CVar_SetS32("gTunic_Zora_Blue", Settings.cosmetic.tunic_zora_blue);
-        //Navi
-        Settings.cosmetic.navi_idle_inner_red = (Conf[CosmeticsSection]["navi_idle_inner_red"] != "") ? Ship::stoi(Conf[CosmeticsSection]["navi_idle_inner_red"]) : Settings.cosmetic.navi_idle_inner_red;
-        CVar_SetS32("gNavi_Idle_Inner_Red", Settings.cosmetic.navi_idle_inner_red);
-        Settings.cosmetic.navi_idle_inner_green = (Conf[CosmeticsSection]["navi_idle_inner_green"] != "") ? Ship::stoi(Conf[CosmeticsSection]["navi_idle_inner_green"]) : Settings.cosmetic.navi_idle_inner_green;
-        CVar_SetS32("gNavi_Idle_Inner_Green", Settings.cosmetic.navi_idle_inner_green);
-        Settings.cosmetic.navi_idle_inner_blue = (Conf[CosmeticsSection]["navi_idle_inner_blue"] != "") ? Ship::stoi(Conf[CosmeticsSection]["navi_idle_inner_blue"]) : Settings.cosmetic.navi_idle_inner_blue;
-        CVar_SetS32("gNavi_Idle_Inner_Blue", Settings.cosmetic.navi_idle_inner_blue);
-        Settings.cosmetic.navi_idle_outer_red = (Conf[CosmeticsSection]["navi_idle_outer_red"] != "") ? Ship::stoi(Conf[CosmeticsSection]["navi_idle_outer_red"]) : Settings.cosmetic.navi_idle_outer_red;
-        CVar_SetS32("gNavi_Idle_Outer_Red", Settings.cosmetic.navi_idle_outer_red);
-        Settings.cosmetic.navi_idle_outer_green = (Conf[CosmeticsSection]["navi_idle_outer_green"] != "") ? Ship::stoi(Conf[CosmeticsSection]["navi_idle_outer_green"]) : Settings.cosmetic.navi_idle_outer_green;
-        CVar_SetS32("gNavi_Idle_Outer_Green", Settings.cosmetic.navi_idle_outer_green);
-        Settings.cosmetic.navi_idle_outer_blue = (Conf[CosmeticsSection]["navi_idle_outer_blue"] != "") ? Ship::stoi(Conf[CosmeticsSection]["navi_idle_outer_blue"]) : Settings.cosmetic.navi_idle_outer_blue;
-        CVar_SetS32("gNavi_Idle_Outer_Blue", Settings.cosmetic.navi_idle_outer_blue);
-
-        Settings.cosmetic.navi_npc_inner_red = (Conf[CosmeticsSection]["navi_npc_inner_red"] != "") ? Ship::stoi(Conf[CosmeticsSection]["navi_npc_inner_red"]) : Settings.cosmetic.navi_npc_inner_red;
-        CVar_SetS32("gNavi_NPC_Inner_Red", Settings.cosmetic.navi_npc_inner_red);
-        Settings.cosmetic.navi_npc_inner_green = (Conf[CosmeticsSection]["navi_npc_inner_green"] != "") ? Ship::stoi(Conf[CosmeticsSection]["navi_npc_inner_green"]) : Settings.cosmetic.navi_npc_inner_green;
-        CVar_SetS32("gNavi_NPC_Inner_Green", Settings.cosmetic.navi_npc_inner_green);
-        Settings.cosmetic.navi_npc_inner_blue = (Conf[CosmeticsSection]["navi_npc_inner_blue"] != "") ? Ship::stoi(Conf[CosmeticsSection]["navi_npc_inner_blue"]) : Settings.cosmetic.navi_npc_inner_blue;
-        CVar_SetS32("gNavi_NPC_Inner_Blue", Settings.cosmetic.navi_npc_inner_blue);
-        Settings.cosmetic.navi_npc_outer_red = (Conf[CosmeticsSection]["navi_npc_outer_red"] != "") ? Ship::stoi(Conf[CosmeticsSection]["navi_npc_outer_red"]) : Settings.cosmetic.navi_npc_outer_red;
-        CVar_SetS32("gNavi_NPC_Outer_Red", Settings.cosmetic.navi_npc_outer_red);
-        Settings.cosmetic.navi_npc_outer_green = (Conf[CosmeticsSection]["navi_npc_outer_green"] != "") ? Ship::stoi(Conf[CosmeticsSection]["navi_npc_outer_green"]) : Settings.cosmetic.navi_npc_outer_green;
-        CVar_SetS32("gNavi_NPC_Outer_Green", Settings.cosmetic.navi_npc_outer_green);
-        Settings.cosmetic.navi_npc_outer_blue = (Conf[CosmeticsSection]["navi_npc_outer_blue"] != "") ? Ship::stoi(Conf[CosmeticsSection]["navi_npc_outer_blue"]) : Settings.cosmetic.navi_npc_outer_blue;
-        CVar_SetS32("gNavi_NPC_Outer_Blue", Settings.cosmetic.navi_npc_outer_blue);
-
-        Settings.cosmetic.navi_enemy_inner_red = (Conf[CosmeticsSection]["navi_enemy_inner_red"] != "") ? Ship::stoi(Conf[CosmeticsSection]["navi_enemy_inner_red"]) : Settings.cosmetic.navi_enemy_inner_red;
-        CVar_SetS32("gNavi_Enemy_Inner_Red", Settings.cosmetic.navi_enemy_inner_red);
-        Settings.cosmetic.navi_enemy_inner_green = (Conf[CosmeticsSection]["navi_enemy_inner_green"] != "") ? Ship::stoi(Conf[CosmeticsSection]["navi_enemy_inner_green"]) : Settings.cosmetic.navi_enemy_inner_green;
-        CVar_SetS32("gNavi_Enemy_Inner_Green", Settings.cosmetic.navi_enemy_inner_green);
-        Settings.cosmetic.navi_enemy_inner_blue = (Conf[CosmeticsSection]["navi_enemy_inner_blue"] != "") ? Ship::stoi(Conf[CosmeticsSection]["navi_enemy_inner_blue"]) : Settings.cosmetic.navi_enemy_inner_blue;
-        CVar_SetS32("gNavi_Enemy_Inner_Blue", Settings.cosmetic.navi_enemy_inner_blue);
-        Settings.cosmetic.navi_enemy_outer_red = (Conf[CosmeticsSection]["navi_enemy_outer_red"] != "") ? Ship::stoi(Conf[CosmeticsSection]["navi_enemy_outer_red"]) : Settings.cosmetic.navi_enemy_outer_red;
-        CVar_SetS32("gNavi_Enemy_Outer_Red", Settings.cosmetic.navi_enemy_outer_red);
-        Settings.cosmetic.navi_enemy_outer_green = (Conf[CosmeticsSection]["navi_enemy_outer_green"] != "") ? Ship::stoi(Conf[CosmeticsSection]["navi_enemy_outer_green"]) : Settings.cosmetic.navi_enemy_outer_green;
-        CVar_SetS32("gNavi_Enemy_Outer_Green", Settings.cosmetic.navi_enemy_outer_green);
-        Settings.cosmetic.navi_enemy_outer_blue = (Conf[CosmeticsSection]["navi_enemy_outer_blue"] != "") ? Ship::stoi(Conf[CosmeticsSection]["navi_enemy_outer_blue"]) : Settings.cosmetic.navi_enemy_outer_blue;
-        CVar_SetS32("gNavi_Enemy_Outer_Blue", Settings.cosmetic.navi_enemy_outer_blue);
-
-        Settings.cosmetic.navi_prop_inner_red = (Conf[CosmeticsSection]["navi_prop_inner_red"] != "") ? Ship::stoi(Conf[CosmeticsSection]["navi_prop_inner_red"]) : Settings.cosmetic.navi_prop_inner_red;
-        CVar_SetS32("gNavi_Prop_Inner_Red", Settings.cosmetic.navi_prop_inner_red);
-        Settings.cosmetic.navi_prop_inner_green = (Conf[CosmeticsSection]["navi_prop_inner_green"] != "") ? Ship::stoi(Conf[CosmeticsSection]["navi_prop_inner_green"]) : Settings.cosmetic.navi_prop_inner_green;
-        CVar_SetS32("gNavi_Prop_Inner_Green", Settings.cosmetic.navi_prop_inner_green);
-        Settings.cosmetic.navi_prop_inner_blue = (Conf[CosmeticsSection]["navi_prop_inner_blue"] != "") ? Ship::stoi(Conf[CosmeticsSection]["navi_prop_inner_blue"]) : Settings.cosmetic.navi_prop_inner_blue;
-        CVar_SetS32("gNavi_Prop_Inner_Blue", Settings.cosmetic.navi_prop_inner_blue);
-        Settings.cosmetic.navi_prop_outer_red = (Conf[CosmeticsSection]["navi_prop_outer_red"] != "") ? Ship::stoi(Conf[CosmeticsSection]["navi_prop_outer_red"]) : Settings.cosmetic.navi_prop_outer_red;
-        CVar_SetS32("gNavi_Prop_Outer_Red", Settings.cosmetic.navi_prop_outer_red);
-        Settings.cosmetic.navi_prop_outer_green = (Conf[CosmeticsSection]["navi_prop_outer_green"] != "") ? Ship::stoi(Conf[CosmeticsSection]["navi_prop_outer_green"]) : Settings.cosmetic.navi_prop_outer_green;
-        CVar_SetS32("gNavi_Prop_Outer_Green", Settings.cosmetic.navi_prop_outer_green);
-        Settings.cosmetic.navi_prop_outer_blue = (Conf[CosmeticsSection]["navi_prop_outer_blue"] != "") ? Ship::stoi(Conf[CosmeticsSection]["navi_prop_outer_blue"]) : Settings.cosmetic.navi_prop_outer_blue;
-        CVar_SetS32("gNavi_Prop_Outer_Blue", Settings.cosmetic.navi_prop_outer_blue);
-
-
-
-        CVar_SetS32("gInputEnabled", Settings.controller.input_enabled);
-
-        Settings.controller.dpad_pause_name = stob(Conf[ControllerSection]["dpad_pause_name"]);
-        CVar_SetS32("gDpadPauseName", Settings.controller.dpad_pause_name);
-
-        Settings.controller.dpad_ocarina_text = stob(Conf[ControllerSection]["dpad_ocarina_text"]);
-        CVar_SetS32("gDpadOcarinaText", Settings.controller.dpad_ocarina_text);
-
-        Settings.controller.dpad_shop = stob(Conf[ControllerSection]["dpad_shop"]);
-        CVar_SetS32("gDpadShop", Settings.controller.dpad_shop);
-        
-        // Cheats
-        Settings.cheats.debug_mode = stob(Conf[CheatSection]["debug_mode"]);
-        CVar_SetS32("gDebugEnabled", Settings.cheats.debug_mode);
-
-        Settings.cheats.infinite_money = stob(Conf[CheatSection]["infinite_money"]);
-        CVar_SetS32("gInfiniteMoney", Settings.cheats.infinite_money);
-
-        Settings.cheats.infinite_health = stob(Conf[CheatSection]["infinite_health"]);
-        CVar_SetS32("gInfiniteHealth", Settings.cheats.infinite_health);
-
-        Settings.cheats.infinite_ammo = stob(Conf[CheatSection]["infinite_ammo"]);
-        CVar_SetS32("gInfiniteAmmo", Settings.cheats.infinite_ammo);
-
-        Settings.cheats.infinite_magic = stob(Conf[CheatSection]["infinite_magic"]);
-        CVar_SetS32("gInfiniteMagic", Settings.cheats.infinite_magic);
-
-        Settings.cheats.infinite_nayru = stob(Conf[CheatSection]["infinite_nayru"]);
-        CVar_SetS32("gInfiniteNayru", Settings.cheats.infinite_nayru);
-
-        Settings.cheats.no_clip = stob(Conf[CheatSection]["no_clip"]);
-        CVar_SetS32("gNoClip", Settings.cheats.no_clip);
-
-        Settings.cheats.climb_everything = stob(Conf[CheatSection]["climb_everything"]);
-        CVar_SetS32("gClimbEverything", Settings.cheats.climb_everything);
-
-        Settings.cheats.moon_jump_on_l = stob(Conf[CheatSection]["moon_jump_on_l"]);
-        CVar_SetS32("gMoonJumpOnL", Settings.cheats.moon_jump_on_l);
-
-        Settings.cheats.super_tunic = stob(Conf[CheatSection]["super_tunic"]);
-        CVar_SetS32("gSuperTunic", Settings.cheats.super_tunic);
-
-        Settings.cheats.ez_isg = stob(Conf[CheatSection]["ez_isg"]);
-        CVar_SetS32("gEzISG", Settings.cheats.ez_isg);
-
-        Settings.cheats.no_restrict_item = stob(Conf[CheatSection]["no_restrict_item"]);
-        CVar_SetS32("gNoRestrictItems", Settings.cheats.no_restrict_item);
-
-        Settings.cheats.freeze_time = stob(Conf[CheatSection]["freeze_time"]);
-        CVar_SetS32("gFreezeTime", Settings.cheats.freeze_time);
-
-        // Per-Controller
-        LoadPadSettings();
 
         UpdateAudio();
     }
@@ -267,102 +77,9 @@ namespace Game {
         Conf[ConfSection]["console"] = std::to_string(SohImGui::console->opened);
         Conf[ConfSection]["menu_bar"] = std::to_string(Settings.debug.menu_bar);
         Conf[ConfSection]["soh_debug"] = std::to_string(Settings.debug.soh);
-        Conf[ConfSection]["n64_mode"] = std::to_string(Settings.debug.n64mode);
-
-        // Audio
-        Conf[AudioSection]["master"] = std::to_string(Settings.audio.master);
-        Conf[AudioSection]["music_main"] = std::to_string(Settings.audio.music_main);
-        Conf[AudioSection]["music_sub"] = std::to_string(Settings.audio.music_sub);
-        Conf[AudioSection]["sfx"] = std::to_string(Settings.audio.sfx);
-        Conf[AudioSection]["fanfare"] = std::to_string(Settings.audio.fanfare);
-
-        // Enhancements
-        Conf[EnhancementSection]["skip_text"] = std::to_string(Settings.enhancements.skip_text);
-        Conf[EnhancementSection]["text_speed"] = std::to_string(Settings.enhancements.text_speed);
-        Conf[EnhancementSection]["disable_lod"] = std::to_string(Settings.enhancements.disable_lod);
-        Conf[EnhancementSection]["animated_pause_menu"] = std::to_string(Settings.enhancements.animated_pause_menu);
-        Conf[EnhancementSection]["dynamic_wallet_icon"] = std::to_string(Settings.enhancements.dynamic_wallet_icon);
-        Conf[EnhancementSection]["minimal_ui"] = std::to_string(Settings.enhancements.minimal_ui);
-        Conf[EnhancementSection]["newdrops"] = std::to_string(Settings.enhancements.newdrops);
-        Conf[EnhancementSection]["visualagony"] = std::to_string(Settings.enhancements.visualagony);
-        Conf[EnhancementSection]["mm_bunny_hood"] = std::to_string(Settings.enhancements.mm_bunny_hood);
-        Conf[EnhancementSection]["uniform_lr"] = std::to_string(Settings.enhancements.uniform_lr);
-
-
-        // Controllers
-        Conf[ControllerSection]["rumble_enabled"]  = std::to_string(Settings.controller.rumble_enabled);
-        Conf[ControllerSection]["input_scale"]   = std::to_string(Settings.controller.input_scale);
-        Conf[ControllerSection]["input_enabled"] = std::to_string(Settings.controller.input_enabled);
-        Conf[ControllerSection]["dpad_pause_name"] = std::to_string(Settings.controller.dpad_pause_name);
-        Conf[ControllerSection]["dpad_ocarina_text"] = std::to_string(Settings.controller.dpad_ocarina_text);
-        Conf[ControllerSection]["dpad_shop"] = std::to_string(Settings.controller.dpad_shop);
-
-
-        // Cosmetics 
-        Conf[CosmeticsSection]["tunic_kokiri_red"] = std::to_string(Settings.cosmetic.tunic_kokiri_red);
-        Conf[CosmeticsSection]["tunic_kokiri_green"] = std::to_string(Settings.cosmetic.tunic_kokiri_green);
-        Conf[CosmeticsSection]["tunic_kokiri_blue"] = std::to_string(Settings.cosmetic.tunic_kokiri_blue);
-
-        Conf[CosmeticsSection]["tunic_goron_red"] = std::to_string(Settings.cosmetic.tunic_goron_red);
-        Conf[CosmeticsSection]["tunic_goron_green"] = std::to_string(Settings.cosmetic.tunic_goron_green);
-        Conf[CosmeticsSection]["tunic_goron_blue"] = std::to_string(Settings.cosmetic.tunic_goron_blue);
-
-        Conf[CosmeticsSection]["tunic_zora_red"] = std::to_string(Settings.cosmetic.tunic_zora_red);
-        Conf[CosmeticsSection]["tunic_zora_green"] = std::to_string(Settings.cosmetic.tunic_zora_green);
-        Conf[CosmeticsSection]["tunic_zora_blue"] = std::to_string(Settings.cosmetic.tunic_zora_blue);
-
-        Conf[CosmeticsSection]["navi_idle_inner_red"] = std::to_string(Settings.cosmetic.navi_idle_inner_red);
-        Conf[CosmeticsSection]["navi_idle_inner_green"] = std::to_string(Settings.cosmetic.navi_idle_inner_green);
-        Conf[CosmeticsSection]["navi_idle_inner_blue"] = std::to_string(Settings.cosmetic.navi_idle_inner_blue);
-        Conf[CosmeticsSection]["navi_idle_outer_red"] = std::to_string(Settings.cosmetic.navi_idle_outer_red);
-        Conf[CosmeticsSection]["navi_idle_outer_green"] = std::to_string(Settings.cosmetic.navi_idle_outer_green);
-        Conf[CosmeticsSection]["navi_idle_outer_blue"] = std::to_string(Settings.cosmetic.navi_idle_outer_blue);
-
-        Conf[CosmeticsSection]["navi_npc_inner_red"] = std::to_string(Settings.cosmetic.navi_npc_inner_red);
-        Conf[CosmeticsSection]["navi_npc_inner_green"] = std::to_string(Settings.cosmetic.navi_npc_inner_green);
-        Conf[CosmeticsSection]["navi_npc_inner_blue"] = std::to_string(Settings.cosmetic.navi_npc_inner_blue);
-        Conf[CosmeticsSection]["navi_npc_outer_red"] = std::to_string(Settings.cosmetic.navi_npc_outer_red);
-        Conf[CosmeticsSection]["navi_npc_outer_green"] = std::to_string(Settings.cosmetic.navi_npc_outer_green);
-        Conf[CosmeticsSection]["navi_npc_outer_blue"] = std::to_string(Settings.cosmetic.navi_npc_outer_blue);
-
-        Conf[CosmeticsSection]["navi_enemy_inner_red"] = std::to_string(Settings.cosmetic.navi_enemy_inner_red);
-        Conf[CosmeticsSection]["navi_enemy_inner_green"] = std::to_string(Settings.cosmetic.navi_enemy_inner_green);
-        Conf[CosmeticsSection]["navi_enemy_inner_blue"] = std::to_string(Settings.cosmetic.navi_enemy_inner_blue);
-        Conf[CosmeticsSection]["navi_enemy_outer_red"] = std::to_string(Settings.cosmetic.navi_enemy_outer_red);
-        Conf[CosmeticsSection]["navi_enemy_outer_green"] = std::to_string(Settings.cosmetic.navi_enemy_outer_green);
-        Conf[CosmeticsSection]["navi_enemy_outer_blue"] = std::to_string(Settings.cosmetic.navi_enemy_outer_blue);
-
-        Conf[CosmeticsSection]["navi_prop_inner_red"] = std::to_string(Settings.cosmetic.navi_prop_inner_red);
-        Conf[CosmeticsSection]["navi_prop_inner_green"] = std::to_string(Settings.cosmetic.navi_prop_inner_green);
-        Conf[CosmeticsSection]["navi_prop_inner_blue"] = std::to_string(Settings.cosmetic.navi_prop_inner_blue);
-        Conf[CosmeticsSection]["navi_prop_outer_red"] = std::to_string(Settings.cosmetic.navi_prop_outer_red);
-        Conf[CosmeticsSection]["navi_prop_outer_green"] = std::to_string(Settings.cosmetic.navi_prop_outer_green);
-        Conf[CosmeticsSection]["navi_prop_outer_blue"] = std::to_string(Settings.cosmetic.navi_prop_outer_blue);
-
-        // Cheats
-        Conf[CheatSection]["debug_mode"] = std::to_string(Settings.cheats.debug_mode);
-        Conf[CheatSection]["infinite_money"] = std::to_string(Settings.cheats.infinite_money);
-        Conf[CheatSection]["infinite_health"] = std::to_string(Settings.cheats.infinite_health);
-        Conf[CheatSection]["infinite_ammo"] = std::to_string(Settings.cheats.infinite_ammo);
-        Conf[CheatSection]["infinite_magic"] = std::to_string(Settings.cheats.infinite_magic);
-        Conf[CheatSection]["no_clip"] = std::to_string(Settings.cheats.no_clip);
-        Conf[CheatSection]["climb_everything"] = std::to_string(Settings.cheats.climb_everything);
-        Conf[CheatSection]["moon_jump_on_l"] = std::to_string(Settings.cheats.moon_jump_on_l);
-        Conf[CheatSection]["super_tunic"] = std::to_string(Settings.cheats.super_tunic);
-
-        // Per-Controller
-        for (const auto& [i, controllers] : Ship::Window::Controllers) {
-            for (const auto& controller : controllers) {
-                if (auto padConfSection = controller->GetPadConfSection()) {
-                    Conf[*padConfSection]["gyro_sensitivity"] = std::to_string(Settings.controller.extra[i].gyro_sensitivity);
-                    Conf[*padConfSection]["rumble_strength"]  = std::to_string(Settings.controller.extra[i].rumble_strength);
-                    Conf[*padConfSection]["gyro_drift_x"] = std::to_string(Settings.controller.extra[i].gyro_drift_x);
-                    Conf[*padConfSection]["gyro_drift_y"]  = std::to_string(Settings.controller.extra[i].gyro_drift_y);
-                }
-            }
-        }
 
         Conf.Save();
+        DebugConsole_SaveCVars();
     }
 
     void InitSettings() {

--- a/libultraship/libultraship/GameSettings.cpp
+++ b/libultraship/libultraship/GameSettings.cpp
@@ -60,10 +60,6 @@ namespace Game {
         for (const auto& [i, controllers] : Ship::Window::Controllers) {
             for (const auto& controller : controllers) {
                 if (auto padConfSection = controller->GetPadConfSection()) {
-                    Settings.controller.extra[i].gyro_sensitivity = Ship::stof(Conf[*padConfSection]["gyro_sensitivity"]);
-                    Settings.controller.extra[i].rumble_strength = Ship::stof(Conf[*padConfSection]["rumble_strength"]);
-                    Settings.controller.extra[i].gyro_drift_x = Ship::stof(Conf[*padConfSection]["gyro_drift_x"], 0.0f);
-                    Settings.controller.extra[i].gyro_drift_y = Ship::stof(Conf[*padConfSection]["gyro_drift_y"], 0.0f);
                 }
             }
         }

--- a/libultraship/libultraship/GameSettings.h
+++ b/libultraship/libultraship/GameSettings.h
@@ -8,12 +8,6 @@ struct SoHConfigType {
         bool soh_sink = true;
     } debug;
 
-    // Controller
-    struct {
-        float gyroDriftX = 0.0f;
-        float gyroDriftY = 0.0f;
-    } controller;
-
     // Graphics
     struct {
         bool show = false;

--- a/libultraship/libultraship/GameSettings.h
+++ b/libultraship/libultraship/GameSettings.h
@@ -4,107 +4,15 @@ struct SoHConfigType {
     // Debug
     struct {
         bool soh = false;
-        bool n64mode = false;
         bool menu_bar = false;
         bool soh_sink = true;
     } debug;
 
-    // Audio
-    struct {
-        float master = 1.0f;
-        float music_main = 1.0f;
-        float fanfare = 1.0f;
-        float sfx = 1.0f;
-        float music_sub = 1.0f;
-    } audio;
-
-    // Enhancements
-    struct {
-        int text_speed = 1;
-        bool skip_text = false;
-        bool disable_lod = false;
-        bool animated_pause_menu = false;
-        bool dynamic_wallet_icon = false;
-        bool minimal_ui = false;
-        bool newdrops = false;
-        bool visualagony = false;
-        bool mm_bunny_hood = false;
-        bool uniform_lr = true;
-    } enhancements;
-
     // Controller
     struct {
-        struct {
-            float gyro_sensitivity = 1.0f;
-            float rumble_strength = 1.0f;
-            float gyro_drift_x = 0.0f;
-            float gyro_drift_y = 0.0f;
-        } extra[4];
-        bool rumble_enabled = true;
-        float input_scale = 1.0f;
-        bool input_enabled = false;
-        bool dpad_pause_name = false;
-        bool dpad_ocarina_text = false;
-        bool dpad_shop = false;
+        float gyroDriftX = 0.0f;
+        float gyroDriftY = 0.0f;
     } controller;
-
-    struct {
-        int tunic_kokiri_red = 30;
-        int tunic_kokiri_green = 105;
-        int tunic_kokiri_blue = 27;
-        int tunic_goron_red = 100;
-        int tunic_goron_green = 20;
-        int tunic_goron_blue = 0;
-        int tunic_zora_red = 0;
-        int tunic_zora_green = 60;
-        int tunic_zora_blue = 100;
-        
-        int navi_idle_inner_red = 255;
-        int navi_idle_inner_green = 255;
-        int navi_idle_inner_blue = 255;
-        int navi_idle_outer_red = 0;
-        int navi_idle_outer_green = 0;
-        int navi_idle_outer_blue = 255;
-
-        int navi_enemy_inner_red = 255;
-        int navi_enemy_inner_green = 255;
-        int navi_enemy_inner_blue = 0;
-        int navi_enemy_outer_red = 200;
-        int navi_enemy_outer_green = 155;
-        int navi_enemy_outer_blue = 0;
-
-        int navi_npc_inner_red = 150;
-        int navi_npc_inner_green = 150;
-        int navi_npc_inner_blue = 255;
-        int navi_npc_outer_red = 150;
-        int navi_npc_outer_green = 150;
-        int navi_npc_outer_blue = 255;
-
-        int navi_prop_inner_red = 0;
-        int navi_prop_inner_green = 250;
-        int navi_prop_inner_blue = 0;
-        int navi_prop_outer_red = 0;
-        int navi_prop_outer_green = 250;
-        int navi_prop_outer_blue = 0;
-
-    } cosmetic;
-
-    // Cheats
-    struct {
-        bool debug_mode = false;
-        bool infinite_money = false;
-        bool infinite_health = false;
-        bool infinite_ammo = false;
-        bool infinite_magic = false;
-        bool infinite_nayru = false;
-        bool no_clip = false;
-        bool climb_everything = false;
-        bool moon_jump_on_l = false;
-        bool super_tunic = false;
-        bool ez_isg = false;
-        bool no_restrict_item = false;
-        bool freeze_time = false;
-    } cheats;
 
     // Graphics
     struct {

--- a/libultraship/libultraship/SDLController.cpp
+++ b/libultraship/libultraship/SDLController.cpp
@@ -5,6 +5,7 @@
 #include "spdlog/spdlog.h"
 #include "stox.h"
 #include "Window.h"
+#include "Cvar.h"
 
 extern "C" uint8_t __osMaxControllers;
 
@@ -197,6 +198,7 @@ namespace Ship {
 
             const char* contName = SDL_GameControllerName(Cont);
             const int isSpecialController = !strcmp("PS5 Controller", contName);
+            const float gyroSensitivity = CVar_GetFloat("gGyroSensitivity", 1.0f);
 
             if (gyro_drift_x == 0) {
                 gyro_drift_x = gyroData[0];

--- a/libultraship/libultraship/SohImGuiImpl.cpp
+++ b/libultraship/libultraship/SohImGuiImpl.cpp
@@ -84,49 +84,51 @@ namespace SohImGui {
             ImGui_ImplWin32_Init(impl.dx11.window);
             break;
         }
-        kokiri_col[0] = std::clamp((float) CVar_GetS32("gTunic_Kokiri_Red", 30)/255, 0.0f, 1.0f);
-        kokiri_col[1] = std::clamp((float)CVar_GetS32("gTunic_Kokiri_Green", 105) / 255, 0.0f, 1.0f);
-        kokiri_col[2] = std::clamp((float)CVar_GetS32("gTunic_Kokiri_Blue", 27) / 255, 0.0f, 1.0f);
-
-        goron_col[0] = std::clamp((float)CVar_GetS32("gTunic_Goron_Red", 100) / 255, 0.0f, 1.0f);
-        goron_col[1] = std::clamp((float)CVar_GetS32("gTunic_Goron_Green", 20) / 255, 0.0f, 1.0f);
-        goron_col[2] = std::clamp((float)CVar_GetS32("gTunic_Goron_Blue", 0) / 255, 0.0f, 1.0f);
         
-        zora_col[0] = std::clamp((float)CVar_GetS32("gTunic_Zora_Red", 0) / 255, 0.0f, 1.0f);
-        zora_col[1] = std::clamp((float)CVar_GetS32("gTunic_Zora_Green", 60) / 255, 0.0f, 1.0f);
-        zora_col[2] = std::clamp((float)CVar_GetS32("gTunic_Zora_Blue", 100) / 255, 0.0f, 1.0f);
+        // OTRTODO: This gameplay specific stuff should not be in libultraship. This needs to be moved to soh and use sTunicColors
+        kokiri_col[0] = 30 / 255.0f;
+        kokiri_col[1] = 105 / 255.0f;
+        kokiri_col[2] = 27 / 255.0f;
 
-        navi_idle_i_col[0] = std::clamp((float)CVar_GetS32("gNavi_Idle_Inner_Red", 0) / 255, 0.0f, 1.0f);
-        navi_idle_i_col[1] = std::clamp((float)CVar_GetS32("gNavi_Idle_Inner_Green", 0) / 255, 0.0f, 1.0f);
-        navi_idle_i_col[2] = std::clamp((float)CVar_GetS32("gNavi_Idle_Inner_Blue", 0) / 255, 0.0f, 1.0f);
+        goron_col[0] = 100 / 255.0f;
+        goron_col[1] = 20 / 255.0f;
+        goron_col[2] = 0;
+        
+        zora_col[0] = 0;
+        zora_col[1] = 60 / 255.0f;
+        zora_col[2] = 100 / 255.0f;
 
-        navi_idle_o_col[0] = std::clamp((float)CVar_GetS32("gNavi_Idle_Outer_Red", 0) / 255, 0.0f, 1.0f);
-        navi_idle_o_col[1] = std::clamp((float)CVar_GetS32("gNavi_Idle_Outer_Green", 0) / 255, 0.0f, 1.0f);
-        navi_idle_o_col[2] = std::clamp((float)CVar_GetS32("gNavi_Idle_Outer_Blue", 0) / 255, 0.0f, 1.0f);
+        navi_idle_i_col[0] = 0;
+        navi_idle_i_col[1] = 0;
+        navi_idle_i_col[2] = 0;
 
-        navi_npc_i_col[0] = std::clamp((float)CVar_GetS32("gNavi_NPC_Inner_Red", 0) / 255, 0.0f, 1.0f);
-        navi_npc_i_col[1] = std::clamp((float)CVar_GetS32("gNavi_NPC_Inner_Green", 0) / 255, 0.0f, 1.0f);
-        navi_npc_i_col[2] = std::clamp((float)CVar_GetS32("gNavi_NPC_Inner_Blue", 0) / 255, 0.0f, 1.0f);
+        navi_idle_o_col[0] = 0;
+        navi_idle_o_col[1] = 0;
+        navi_idle_o_col[2] = 0;
 
-        navi_npc_o_col[0] = std::clamp((float)CVar_GetS32("gNavi_NPC_Outer_Red", 0) / 255, 0.0f, 1.0f);
-        navi_npc_o_col[1] = std::clamp((float)CVar_GetS32("gNavi_NPC_Outer_Green", 0) / 255, 0.0f, 1.0f);
-        navi_npc_o_col[2] = std::clamp((float)CVar_GetS32("gNavi_NPC_Outer_Blue", 0) / 255, 0.0f, 1.0f);
+        navi_npc_i_col[0] = 0;
+        navi_npc_i_col[1] = 0;
+        navi_npc_i_col[2] = 0;
 
-        navi_enemy_i_col[0] = std::clamp((float)CVar_GetS32("gNavi_Enemy_Inner_Red", 0) / 255, 0.0f, 1.0f);
-        navi_enemy_i_col[1] = std::clamp((float)CVar_GetS32("gNavi_Enemy_Inner_Green", 0) / 255, 0.0f, 1.0f);
-        navi_enemy_i_col[2] = std::clamp((float)CVar_GetS32("gNavi_Enemy_Inner_Blue", 0) / 255, 0.0f, 1.0f);
+        navi_npc_o_col[0] = 0;
+        navi_npc_o_col[1] = 0;
+        navi_npc_o_col[2] = 0;
 
-        navi_enemy_o_col[0] = std::clamp((float)CVar_GetS32("gNavi_Enemy_Outer_Red", 0) / 255, 0.0f, 1.0f);
-        navi_enemy_o_col[1] = std::clamp((float)CVar_GetS32("gNavi_Enemy_Outer_Green", 0) / 255, 0.0f, 1.0f);
-        navi_enemy_o_col[2] = std::clamp((float)CVar_GetS32("gNavi_Enemy_Outer_Blue", 0) / 255, 0.0f, 1.0f);
+        navi_enemy_i_col[0] = 0;
+        navi_enemy_i_col[1] = 0;
+        navi_enemy_i_col[2] = 0;
 
-        navi_prop_i_col[0] = std::clamp((float)CVar_GetS32("gNavi_Prop_Inner_Red", 0) / 255, 0.0f, 1.0f);
-        navi_prop_i_col[1] = std::clamp((float)CVar_GetS32("gNavi_Prop_Inner_Green", 0) / 255, 0.0f, 1.0f);
-        navi_prop_i_col[2] = std::clamp((float)CVar_GetS32("gNavi_Prop_Inner_Blue", 0) / 255, 0.0f, 1.0f);
+        navi_enemy_o_col[0] = 0;
+        navi_enemy_o_col[1] = 0;
+        navi_enemy_o_col[2] = 0;
 
-        navi_prop_o_col[0] = std::clamp((float)CVar_GetS32("gNavi_Prop_Outer_Red", 0) / 255, 0.0f, 1.0f);
-        navi_prop_o_col[1] = std::clamp((float)CVar_GetS32("gNavi_Prop_Outer_Green", 0) / 255, 0.0f, 1.0f);
-        navi_prop_o_col[2] = std::clamp((float)CVar_GetS32("gNavi_Prop_Outer_Blue", 0) / 255, 0.0f, 1.0f);
+        navi_prop_i_col[0] = 0;
+        navi_prop_i_col[1] = 0;
+        navi_prop_i_col[2] = 0;
+
+        navi_prop_o_col[0] = 0;
+        navi_prop_o_col[1] = 0;
+        navi_prop_o_col[2] = 0;
     }
 
     void ImGuiBackendInit() {
@@ -373,11 +375,14 @@ namespace SohImGui {
         }
     }
 
-    void EnhancementSliderFloat(std::string text, std::string id, std::string cvarName, float min, float max, std::string format, float defaultValue)
+    void EnhancementSliderFloat(std::string text, std::string id, std::string cvarName, float min, float max, std::string format, float defaultValue, bool isPercentage)
     {
         float val = CVar_GetFloat(cvarName.c_str(), defaultValue);
 
-        ImGui::Text(text.c_str(), static_cast<int>(100 * val));
+        if (!isPercentage)
+            ImGui::Text(text.c_str(), val);
+        else
+            ImGui::Text(text.c_str(), static_cast<int>(100 * val));
 
         if (ImGui::SliderFloat(id.c_str(), &val, min, max, format.c_str()))
         {
@@ -397,6 +402,28 @@ namespace SohImGui {
             val = max;
             CVar_SetFloat(cvarName.c_str(), val);
             needs_save = true;
+        }
+    }
+
+    void EnhancementColor3(std::string text, std::string cvarName, float defaultColors[3])
+    {
+        int r = CVar_GetS32((cvarName + "_Red").c_str(), (defaultColors[0] * 255.0f));
+        int g = CVar_GetS32((cvarName + "_Green").c_str(), (defaultColors[1] * 255.0f));
+        int b = CVar_GetS32((cvarName + "_Blue").c_str(), (defaultColors[2] * 255.0f));
+
+        float colors[3];
+        colors[0] = r / 255.0f;
+        colors[1] = g / 255.0f;
+        colors[2] = b / 255.0f;
+
+        {
+            if (ImGui::ColorEdit3(text.c_str(), colors)) 
+            {
+                CVar_SetS32((cvarName + "_Red").c_str(), (int)(colors[0] * 255));
+                CVar_SetS32((cvarName + "_Green").c_str(), (int)(colors[1] * 255));
+                CVar_SetS32((cvarName + "_Blue").c_str(), (int)(colors[2] * 255));
+                needs_save = true;
+            }
         }
     }
 
@@ -455,7 +482,7 @@ namespace SohImGui {
             ImGui::Separator();
 
             if (ImGui::BeginMenu("Audio")) {
-                EnhancementSliderFloat("Master Volume: %d %%", "##Master_Vol", "gGameMasterVolume", 0.0f, 1.0f, "", 1.0f);
+                EnhancementSliderFloat("Master Volume: %d %%", "##Master_Vol", "gGameMasterVolume", 0.0f, 1.0f, "", 1.0f, true);
 
                 BindAudioSlider("Main Music Volume: %d %%", "gMainMusicVolume", 1.0f, SEQ_BGM_MAIN);
                 BindAudioSlider("Sub Music Volume: %d %%", "gSubMusicVolume", 1.0f, SEQ_BGM_SUB);
@@ -465,26 +492,41 @@ namespace SohImGui {
                 ImGui::EndMenu();
             }
 
-            if (ImGui::BeginMenu("Controller")) 
+            if (ImGui::BeginMenu("Controller"))
             {
-                EnhancementSliderFloat("Gyro Sensitivity: %d %%", "##GYROSCOPE", "gGyroSensitivity", 0.0f, 1.0f, "", 1.0f);
-                
-                if (ImGui::Button("Recalibrate Gyro")) {
-                    Game::Settings.controller.gyroDriftX = 0;
-                    Game::Settings.controller.gyroDriftY = 0;
+                for (const auto& [i, controllers] : Ship::Window::Controllers)
+                {
+                    bool hasPad = std::find_if(controllers.begin(), controllers.end(), [](const auto& c) {
+                        return c->HasPadConf() && c->Connected();
+                        }) != controllers.end();
+
+                        if (!hasPad) continue;
+
+                        auto menuLabel = "Controller " + std::to_string(i + 1);
+                        if (ImGui::BeginMenu(menuLabel.c_str()))
+                        {
+                            EnhancementSliderFloat("Gyro Sensitivity: %d %%", "##GYROSCOPE", StringHelper::Sprintf("gCont%i_GyroSensitivity", i), 0.0f, 1.0f, "", 1.0f, true);
+
+                            if (ImGui::Button("Recalibrate Gyro"))
+                            {
+                                CVar_SetFloat(StringHelper::Sprintf("gCont%i_GyroDriftX").c_str(), 0);
+                                CVar_SetFloat(StringHelper::Sprintf("gCont%i_GyroDriftY").c_str(), 0);
+                                needs_save = true;
+                            }
+
+                            ImGui::Separator();
+
+                            EnhancementSliderFloat("Rumble Strength: %d %%", "##RUMBLE", StringHelper::Sprintf("gCont%i_RumbleStrength", i), 0.0f, 1.0f, "", 1.0f, true);
+
+                            ImGui::EndMenu();
+                        }
+                        ImGui::Separator();
                 }
 
-                ImGui::Separator();
-
-                EnhancementSliderFloat("Rumble Strength: %d %%", "##RUMBLE", "gRumbleStrength", 0.0f, 1.0f, "", 1.0f);
-                
                 EnhancementCheckbox("Show Inputs", "gInputEnabled");
-                if (ImGui::Checkbox("Rumble Enabled", &Game::Settings.controller.rumble_enabled)) {
-                    CVar_SetS32("gRumbleEnabled", Game::Settings.controller.rumble_enabled);
-                    needs_save = true;
-                }
+                EnhancementCheckbox("Rumble Enabled", "gRumbleEnabled");
 
-                EnhancementSliderFloat("Input Scale: %.1f", "##Input", "gInputScale", 1.0f, 3.0f, "", 1.0f);
+                EnhancementSliderFloat("Input Scale: %.1f", "##Input", "gInputScale", 1.0f, 3.0f, "", 1.0f, false);
 
                 ImGui::Separator();
 
@@ -495,7 +537,8 @@ namespace SohImGui {
                 ImGui::EndMenu();
             }
 
-            if (ImGui::BeginMenu("Enhancements")) {
+            if (ImGui::BeginMenu("Enhancements"))
+            {
 
                 ImGui::Text("Gameplay");
                 ImGui::Separator();
@@ -520,7 +563,8 @@ namespace SohImGui {
                 ImGui::EndMenu();
             }
 
-            if (ImGui::BeginMenu("Developer Tools")) {
+            if (ImGui::BeginMenu("Developer Tools"))
+            {
                 HOOK(ImGui::MenuItem("Stats", nullptr, &Game::Settings.debug.soh));
                 HOOK(ImGui::MenuItem("Console", nullptr, &console->opened));
 
@@ -532,12 +576,14 @@ namespace SohImGui {
                 ImGui::EndMenu();
             }
 
-            if (ImGui::BeginMenu("Graphics")) {
+            if (ImGui::BeginMenu("Graphics"))
+            {
                 HOOK(ImGui::MenuItem("Anti-aliasing", nullptr, &Game::Settings.graphics.show));
                 ImGui::EndMenu();
             }
 
-            if (ImGui::BeginMenu("Cheats")) {
+            if (ImGui::BeginMenu("Cheats"))
+            {
                 if (ImGui::BeginMenu("Infinite...")) {
                     EnhancementCheckbox("Money", "gInfiniteMoney");
                     EnhancementCheckbox("Health", "gInfiniteHealth");
@@ -559,139 +605,26 @@ namespace SohImGui {
                 ImGui::EndMenu();
             }
 
-            if (ImGui::BeginMenu("Cosmetics")) {
+            if (ImGui::BeginMenu("Cosmetics"))
+            {
                 ImGui::Text("Tunics");
                 ImGui::Separator();
-                if (ImGui::ColorEdit3("Kokiri Tunic", kokiri_col)) {
-                    Game::Settings.cosmetic.tunic_kokiri_red = (int)(kokiri_col[0] * 255);
-                    Game::Settings.cosmetic.tunic_kokiri_green = (int)(kokiri_col[1] * 255);
-                    Game::Settings.cosmetic.tunic_kokiri_blue = (int)(kokiri_col[2] * 255);
-                    CVar_SetS32("gTunic_Kokiri_Red", Game::Settings.cosmetic.tunic_kokiri_red);
-                    CVar_SetS32("gTunic_Kokiri_Green", Game::Settings.cosmetic.tunic_kokiri_green);
-                    CVar_SetS32("gTunic_Kokiri_Blue", Game::Settings.cosmetic.tunic_kokiri_blue);
-                    needs_save = true;
-                }
-                if (ImGui::ColorEdit3("Goron Tunic", goron_col)) {
-                    Game::Settings.cosmetic.tunic_goron_red = (int)(goron_col[0] * 255);
-                    Game::Settings.cosmetic.tunic_goron_green = (int)(goron_col[1] * 255);
-                    Game::Settings.cosmetic.tunic_goron_blue = (int)(goron_col[2] * 255);
-                    CVar_SetS32("gTunic_Goron_Red", Game::Settings.cosmetic.tunic_goron_red);
-                    CVar_SetS32("gTunic_Goron_Green", Game::Settings.cosmetic.tunic_goron_green);
-                    CVar_SetS32("gTunic_Goron_Blue", Game::Settings.cosmetic.tunic_goron_blue);
-                    needs_save = true;
-                }
-                if (ImGui::ColorEdit3("Zora Tunic", zora_col)) {
-                    Game::Settings.cosmetic.tunic_zora_red = (int)(zora_col[0] * 255);
-                    Game::Settings.cosmetic.tunic_zora_green = (int)(zora_col[1] * 255);
-                    Game::Settings.cosmetic.tunic_zora_blue = (int)(zora_col[2] * 255);
-                    CVar_SetS32("gTunic_Zora_Red", Game::Settings.cosmetic.tunic_zora_red);
-                    CVar_SetS32("gTunic_Zora_Green", Game::Settings.cosmetic.tunic_zora_green);
-                    CVar_SetS32("gTunic_Zora_Blue", Game::Settings.cosmetic.tunic_zora_blue);
-                    needs_save = true;
-                }
+
+                EnhancementColor3("Kokiri Tunic", "gTunic_Kokiri", kokiri_col);
+                EnhancementColor3("Goron Tunic", "gTunic_Goron", goron_col);
+                EnhancementColor3("Zora Tunic", "gTunic_Zora", zora_col);
+
                 ImGui::Text("Navi");
                 ImGui::Separator();
-                if (ImGui::ColorEdit3("Navi Idle Inner", navi_idle_i_col)) {
-                    Game::Settings.cosmetic.navi_idle_inner_red = (int)(navi_idle_i_col[0] * 255);
-                    Game::Settings.cosmetic.navi_idle_inner_green = (int)(navi_idle_i_col[1] * 255);
-                    Game::Settings.cosmetic.navi_idle_inner_blue = (int)(navi_idle_i_col[2] * 255);
-                    CVar_SetS32("gNavi_Idle_Inner_Red", Game::Settings.cosmetic.navi_idle_inner_red);
-                    CVar_SetS32("gNavi_Idle_Inner_Green", Game::Settings.cosmetic.navi_idle_inner_green);
-                    CVar_SetS32("gNavi_Idle_Inner_Blue", Game::Settings.cosmetic.navi_idle_inner_blue);
-                    needs_save = true;
-                }
 
-                if (ImGui::ColorEdit3("Navi Idle Outer", navi_idle_o_col)) {
-                    Game::Settings.cosmetic.navi_idle_outer_red = (int)(navi_idle_o_col[0] * 255);
-                    Game::Settings.cosmetic.navi_idle_outer_green = (int)(navi_idle_o_col[1] * 255);
-                    Game::Settings.cosmetic.navi_idle_outer_blue = (int)(navi_idle_o_col[2] * 255);
-                    CVar_SetS32("gNavi_Idle_Outer_Red", Game::Settings.cosmetic.navi_idle_outer_red);
-                    CVar_SetS32("gNavi_Idle_Outer_Green", Game::Settings.cosmetic.navi_idle_outer_green);
-                    CVar_SetS32("gNavi_Idle_Outer_Blue", Game::Settings.cosmetic.navi_idle_outer_blue);
-                    needs_save = true;
-                }
-
-                if (ImGui::ColorEdit3("Navi NPC Inner", navi_npc_i_col)) {
-                    Game::Settings.cosmetic.navi_npc_inner_red = (int)(navi_npc_i_col[0] * 255);
-                    Game::Settings.cosmetic.navi_npc_inner_green = (int)(navi_npc_i_col[1] * 255);
-                    Game::Settings.cosmetic.navi_npc_inner_blue = (int)(navi_npc_i_col[2] * 255);
-                    CVar_SetS32("gNavi_NPC_Inner_Red", Game::Settings.cosmetic.navi_npc_inner_red);
-                    CVar_SetS32("gNavi_NPC_Inner_Green", Game::Settings.cosmetic.navi_npc_inner_green);
-                    CVar_SetS32("gNavi_NPC_Inner_Blue", Game::Settings.cosmetic.navi_npc_inner_blue);
-                    needs_save = true;
-                }
-
-                if (ImGui::ColorEdit3("Navi NPC Outer", navi_npc_o_col)) {
-                    Game::Settings.cosmetic.navi_npc_outer_red = (int)(navi_npc_o_col[0] * 255);
-                    Game::Settings.cosmetic.navi_npc_outer_green = (int)(navi_npc_o_col[1] * 255);
-                    Game::Settings.cosmetic.navi_npc_outer_blue = (int)(navi_npc_o_col[2] * 255);
-                    CVar_SetS32("gNavi_NPC_Outer_Red", Game::Settings.cosmetic.navi_npc_outer_red);
-                    CVar_SetS32("gNavi_NPC_Outer_Green", Game::Settings.cosmetic.navi_npc_outer_green);
-                    CVar_SetS32("gNavi_NPC_Outer_Blue", Game::Settings.cosmetic.navi_npc_outer_blue);
-                    needs_save = true;
-                }
-
-                if (ImGui::ColorEdit3("Navi Enemy Inner", navi_enemy_i_col)) {
-                    Game::Settings.cosmetic.navi_enemy_inner_red = (int)(navi_enemy_i_col[0] * 255);
-                    Game::Settings.cosmetic.navi_enemy_inner_green = (int)(navi_enemy_i_col[1] * 255);
-                    Game::Settings.cosmetic.navi_enemy_inner_blue = (int)(navi_enemy_i_col[2] * 255);
-                    CVar_SetS32("gNavi_Enemy_Inner_Red", Game::Settings.cosmetic.navi_enemy_inner_red);
-                    CVar_SetS32("gNavi_Enemy_Inner_Green", Game::Settings.cosmetic.navi_enemy_inner_green);
-                    CVar_SetS32("gNavi_Enemy_Inner_Blue", Game::Settings.cosmetic.navi_enemy_inner_blue);
-                    needs_save = true;
-                }
-
-                if (ImGui::ColorEdit3("Navi Enemy Outer", navi_enemy_o_col)) {
-                    Game::Settings.cosmetic.navi_enemy_outer_red = (int)(navi_enemy_o_col[0] * 255);
-                    Game::Settings.cosmetic.navi_enemy_outer_green = (int)(navi_enemy_o_col[1] * 255);
-                    Game::Settings.cosmetic.navi_enemy_outer_blue = (int)(navi_enemy_o_col[2] * 255);
-                    CVar_SetS32("gNavi_Enemy_Outer_Red", Game::Settings.cosmetic.navi_enemy_outer_red);
-                    CVar_SetS32("gNavi_Enemy_Outer_Green", Game::Settings.cosmetic.navi_enemy_outer_green);
-                    CVar_SetS32("gNavi_Enemy_Outer_Blue", Game::Settings.cosmetic.navi_enemy_outer_blue);
-                    needs_save = true;
-                }
-
-                if (ImGui::ColorEdit3("Navi Prop Inner", navi_prop_i_col)) {
-                    Game::Settings.cosmetic.navi_prop_inner_red = (int)(navi_prop_i_col[0] * 255);
-                    Game::Settings.cosmetic.navi_prop_inner_green = (int)(navi_prop_i_col[1] * 255);
-                    Game::Settings.cosmetic.navi_prop_inner_blue = (int)(navi_prop_i_col[2] * 255);
-                    CVar_SetS32("gNavi_Prop_Inner_Red", Game::Settings.cosmetic.navi_prop_inner_red);
-                    CVar_SetS32("gNavi_Prop_Inner_Green", Game::Settings.cosmetic.navi_prop_inner_green);
-                    CVar_SetS32("gNavi_Prop_Inner_Blue", Game::Settings.cosmetic.navi_prop_inner_blue);
-                    needs_save = true;
-                }
-
-                if (ImGui::ColorEdit3("Navi Prop Outer", navi_prop_o_col)) {
-                    Game::Settings.cosmetic.navi_prop_outer_red = (int)(navi_prop_o_col[0] * 255);
-                    Game::Settings.cosmetic.navi_prop_outer_green = (int)(navi_prop_o_col[1] * 255);
-                    Game::Settings.cosmetic.navi_prop_outer_blue = (int)(navi_prop_o_col[2] * 255);
-                    CVar_SetS32("gNavi_Prop_Outer_Red", Game::Settings.cosmetic.navi_prop_outer_red);
-                    CVar_SetS32("gNavi_Prop_Outer_Green", Game::Settings.cosmetic.navi_prop_outer_green);
-                    CVar_SetS32("gNavi_Prop_Outer_Blue", Game::Settings.cosmetic.navi_prop_outer_blue);
-                    needs_save = true;
-                }
-
-                ImGui::EndMenu();
-            }
-
-
-            if (ImGui::BeginMenu("Developer Tools")) {
-                HOOK(ImGui::MenuItem("Stats", nullptr, &Game::Settings.debug.soh));
-                HOOK(ImGui::MenuItem("Console", nullptr, &console->opened));
-                if (ImGui::Checkbox("Easy ISG", &Game::Settings.cheats.ez_isg)) {
-                    CVar_SetS32("gEzISG", Game::Settings.cheats.ez_isg);
-                    needs_save = true;
-                }
-
-                if (ImGui::Checkbox("Unrestricted Items", &Game::Settings.cheats.no_restrict_item)) {
-                    CVar_SetS32("gNoRestrictItems", Game::Settings.cheats.no_restrict_item);
-                    needs_save = true;
-                }
-
-                if (ImGui::Checkbox("Freeze Time", &Game::Settings.cheats.freeze_time)) {
-                    CVar_SetS32("gFreezeTime", Game::Settings.cheats.freeze_time);
-                    needs_save = true;
-                }
+                EnhancementColor3("Navi Idle Inner", "gNavi_Idle_Inner", navi_idle_i_col);
+                EnhancementColor3("Navi Idle Outer", "gNavi_Idle_Outer", navi_idle_o_col);
+                EnhancementColor3("Navi NPC Inner", "gNavi_NPC_Inner", navi_npc_i_col);
+                EnhancementColor3("Navi NPC Outer", "gNavi_NPC_Outer", navi_npc_o_col);
+                EnhancementColor3("Navi Enemy Inner", "gNavi_Enemy_Inner", navi_enemy_i_col);
+                EnhancementColor3("Navi Enemy Outer", "gNavi_Enemy_Outer", navi_enemy_o_col);
+                EnhancementColor3("Navi Prop Inner", "gNavi_Prop_Inner", navi_prop_i_col);
+                EnhancementColor3("Navi Prop Outer", "gNavi_Prop_Outer", navi_prop_o_col);
 
                 ImGui::EndMenu();
             }

--- a/libultraship/libultraship/SohImGuiImpl.h
+++ b/libultraship/libultraship/SohImGuiImpl.h
@@ -60,7 +60,13 @@ namespace SohImGui {
     extern Console* console;
     void Init(WindowImpl window_impl);
     void Update(EventImpl event);
+
+
+    void EnhancementCheckbox(std::string text, std::string cvarName);
+    void EnhancementSliderInt(std::string text, std::string id, std::string cvarName, int min, int max, std::string format);
+    void EnhancementSliderFloat(std::string text, std::string id, std::string cvarName, float min, float max, std::string format, float defaultValue);
     void DrawMainMenuAndCalculateGameSize(void);
+    
     void DrawFramebufferAndGameInput(void);
     void Render(void);
     void CancelFrame(void);

--- a/soh/soh/Enhancements/debugconsole.cpp
+++ b/soh/soh/Enhancements/debugconsole.cpp
@@ -327,9 +327,6 @@ static int CheckVarType(const std::string& input)
     return result;
 }
 
-void DebugConsole_LoadCVars();
-void DebugConsole_SaveCVars();
-
 static bool SetCVarHandler(const std::vector<std::string>& args) {
     if (args.size() < 3)
         return CMD_FAILED;

--- a/soh/soh/Enhancements/debugconsole.h
+++ b/soh/soh/Enhancements/debugconsole.h
@@ -1,3 +1,5 @@
 #pragma once
 
 void DebugConsole_Init(void);
+void DebugConsole_LoadCVars();
+void DebugConsole_SaveCVars();

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -26,6 +26,7 @@
 #include "../soh/Enhancements/debugger/debugger.h"
 #include "Utils/BitConverter.h"
 #include "variables.h"
+#include <Utils/StringHelper.h>
 
 OTRGlobals* OTRGlobals::Instance;
 
@@ -888,8 +889,11 @@ extern "C" void AudioPlayer_Play(const uint8_t* buf, uint32_t len) {
 }
 
 extern "C" int Controller_ShouldRumble(size_t i) {
-    for (const auto& controller : Ship::Window::Controllers.at(i)) {
-        if (controller->CanRumble() && Game::Settings.controller.extra[i].rumble_strength > 0.001f) {
+    for (const auto& controller : Ship::Window::Controllers.at(i)) 
+    {
+        float rumble_strength = CVar_GetFloat(StringHelper::Sprintf("gCont%i_RumbleStrength", i).c_str(), 1.0f);
+
+        if (controller->CanRumble() && rumble_strength > 0.001f) {
             return 1;
         }
     }

--- a/soh/src/code/z_player_lib.c
+++ b/soh/src/code/z_player_lib.c
@@ -744,24 +744,24 @@ void func_8008F470(GlobalContext* globalCtx, void** skeleton, Vec3s* jointTable,
     gSPSegment(POLY_OPA_DISP++, 0x09, SEGMENTED_TO_VIRTUAL(sMouthTextures[eyeIndex]));
 #endif
     if (tunic == PLAYER_TUNIC_KOKIRI) {
-        Color_RGB8 sTemp = { CVar_GetS32("gTunic_Kokiri_Red", &sTunicColors[PLAYER_TUNIC_KOKIRI].r),
-                             CVar_GetS32("gTunic_Kokiri_Green", &sTunicColors[PLAYER_TUNIC_KOKIRI].g),
-                             CVar_GetS32("gTunic_Kokiri_Blue", &sTunicColors[PLAYER_TUNIC_KOKIRI].b) };
+        Color_RGB8 sTemp = { CVar_GetS32("gTunic_Kokiri_Red", sTunicColors[PLAYER_TUNIC_KOKIRI].r),
+                             CVar_GetS32("gTunic_Kokiri_Green", sTunicColors[PLAYER_TUNIC_KOKIRI].g),
+                             CVar_GetS32("gTunic_Kokiri_Blue", sTunicColors[PLAYER_TUNIC_KOKIRI].b) };
         color = &sTemp;
     } else if (tunic == PLAYER_TUNIC_GORON) {
-        Color_RGB8 sTemp = { CVar_GetS32("gTunic_Goron_Red", &sTunicColors[PLAYER_TUNIC_GORON].r),
-                             CVar_GetS32("gTunic_Goron_Green", &sTunicColors[PLAYER_TUNIC_GORON].g),
-                             CVar_GetS32("gTunic_Goron_Blue", &sTunicColors[PLAYER_TUNIC_GORON].b) };
+        Color_RGB8 sTemp = { CVar_GetS32("gTunic_Goron_Red", sTunicColors[PLAYER_TUNIC_GORON].r),
+                             CVar_GetS32("gTunic_Goron_Green", sTunicColors[PLAYER_TUNIC_GORON].g),
+                             CVar_GetS32("gTunic_Goron_Blue", sTunicColors[PLAYER_TUNIC_GORON].b) };
         color = &sTemp;
     } else if (tunic == PLAYER_TUNIC_ZORA) {
-        Color_RGB8 sTemp = { CVar_GetS32("gTunic_Zora_Red", &sTunicColors[PLAYER_TUNIC_ZORA].r),
-                             CVar_GetS32("gTunic_Zora_Green", &sTunicColors[PLAYER_TUNIC_ZORA].g),
-                             CVar_GetS32("gTunic_Zora_Blue", &sTunicColors[PLAYER_TUNIC_ZORA].b) };
+        Color_RGB8 sTemp = { CVar_GetS32("gTunic_Zora_Red", sTunicColors[PLAYER_TUNIC_ZORA].r),
+                             CVar_GetS32("gTunic_Zora_Green", sTunicColors[PLAYER_TUNIC_ZORA].g),
+                             CVar_GetS32("gTunic_Zora_Blue", sTunicColors[PLAYER_TUNIC_ZORA].b) };
         color = &sTemp;
     } else {
-        Color_RGB8 sTemp = { CVar_GetS32("gTunic_Kokiri_Red", &sTunicColors[PLAYER_TUNIC_KOKIRI].r),
-                             CVar_GetS32("gTunic_Kokiri_Green", &sTunicColors[PLAYER_TUNIC_KOKIRI].g),
-                             CVar_GetS32("gTunic_Kokiri_Blue", &sTunicColors[PLAYER_TUNIC_KOKIRI].b) };
+        Color_RGB8 sTemp = { CVar_GetS32("gTunic_Kokiri_Red", sTunicColors[PLAYER_TUNIC_KOKIRI].r),
+                             CVar_GetS32("gTunic_Kokiri_Green", sTunicColors[PLAYER_TUNIC_KOKIRI].g),
+                             CVar_GetS32("gTunic_Kokiri_Blue", sTunicColors[PLAYER_TUNIC_KOKIRI].b) };
         color = &sTemp;
     }
     gDPSetEnvColor(POLY_OPA_DISP++, color->r, color->g, color->b, 0);


### PR DESCRIPTION
Most of the parameters in the `GameSettings` class, used for enhancements and cheats, are not needed. Currently we have two parameters stored for each setting - the variable in the `GameSettings` class, and the console variable that the game logic ultimately checks for. We only need the latter. I removed this extra data in the `GameSettings` class and had it directly read/write CVars.

I also simplified the code a bit by creating a new set of functions - `EnhancementCheckbox`, `EnhancementSliderInt`, and `EnhancementSliderFloat`. Most of the items on the menu bar followed an identical pattern, and these three functions reduce what would be 4-5 lines for each menu item to just one.