### PR TITLE
Revert "Credits message order fix"

### DIFF
--- a/soh/src/code/z_message_PAL.c
+++ b/soh/src/code/z_message_PAL.c
@@ -390,7 +390,7 @@ void Message_FindCreditsMessage(GlobalContext* globalCtx, u16 textId) {
         if (messageTableEntry->textId == textId) {
             foundSeg = messageTableEntry->segment;
             font->charTexBuf[0] = messageTableEntry->typePos;
-            //messageTableEntry++;
+            messageTableEntry++;
             nextSeg = messageTableEntry->segment;
             font->msgOffset = messageTableEntry->segment;
             font->msgLength = messageTableEntry->msgSize;


### PR DESCRIPTION
Reverts HarbourMasters/Shipwright#205

These need to be merged into `develop`, not `master`.