### PR TITLE
Credits message order fix by rink

### DIFF
--- a/soh/src/code/z_message_PAL.c
+++ b/soh/src/code/z_message_PAL.c
@@ -390,7 +390,7 @@ void Message_FindCreditsMessage(GlobalContext* globalCtx, u16 textId) {
         if (messageTableEntry->textId == textId) {
             foundSeg = messageTableEntry->segment;
             font->charTexBuf[0] = messageTableEntry->typePos;
-            messageTableEntry++;
+            //messageTableEntry++;
             nextSeg = messageTableEntry->segment;
             font->msgOffset = messageTableEntry->segment;
             font->msgLength = messageTableEntry->msgSize;


### PR DESCRIPTION
Same as #205, but targeting the `develop` branch instead of `master`.

```
rink discovered this fix for https://github.com/HarbourMasters/Shipwright/issues/190 in the Discord a few days ago. I suggested they PR it but haven't had a response, so I figured I'd just do it rather than let the fix languish.

Rather than just removing it, I commented it as the same code is basically duplicated for normal (non-credits) messages, and it's commented out in the other version.
```