### PR TITLE
fix extract_assets.py for roms with spaces

### DIFF
--- a/OTRExporter/extract_assets.py
+++ b/OTRExporter/extract_assets.py
@@ -45,7 +45,7 @@ def BuildOTR(xmlPath, rom):
     shutil.copytree("assets", "Extract/assets")
 
     execStr = "x64\\Release\\ZAPD.exe" if sys.platform == "win32" else "../ZAPD/ZAPD.out"    
-    execStr += " ed -i %s -b %s -fl CFG\\filelists -o placeholder -osf placeholder -gsf 1 -rconf CFG/Config.xml -se OTR" % (xmlPath, rom)
+    execStr += " ed -i %s -b \"%s\" -fl CFG\\filelists -o placeholder -osf placeholder -gsf 1 -rconf CFG/Config.xml -se OTR" % (xmlPath, rom)
 
     print(execStr)
     exitValue = os.system(execStr)

--- a/OTRExporter/extract_assets.py
+++ b/OTRExporter/extract_assets.py
@@ -8,9 +8,7 @@
 #      Invalid input results in the first rom being selected
 
 import json, os, signal, time, sys, shutil, glob
-from multiprocessing import Pool, cpu_count, Event, Manager, ProcessError
 from enum import Enum
-import shutil
 
 romVer = "..\\soh\\baserom_non_mq.z64"
 roms = [];


### PR DESCRIPTION
Fixes the ZAPD.exe command in the extract_assets.py for working with .z64 filenames with spaces. Not worrying about a literal quotation mark in the file on Windows as it is illegal to name with it.

Mind if I suggest using subprocess for executing commands instead of os.system?