### PR TITLE
Bosses title cards fixes

### DIFF
--- a/soh/include/functions.h
+++ b/soh/include/functions.h
@@ -381,7 +381,7 @@ void Flags_UnsetTempClear(GlobalContext* globalCtx, s32 flag);
 s32 Flags_GetCollectible(GlobalContext* globalCtx, s32 flag);
 void Flags_SetCollectible(GlobalContext* globalCtx, s32 flag);
 void TitleCard_InitBossName(GlobalContext* globalCtx, TitleCardContext* titleCtx, void* texture, s16 x, s16 y, u8 width,
-                            u8 height, bool hastranslation);
+                            u8 height, s16 hastranslation);
 void TitleCard_InitPlaceName(GlobalContext* globalCtx, TitleCardContext* titleCtx, void* texture, s32 x, s32 y,
                              s32 width, s32 height, s32 delay);
 s32 func_8002D53C(GlobalContext* globalCtx, TitleCardContext* titleCtx);

--- a/soh/include/functions.h
+++ b/soh/include/functions.h
@@ -381,7 +381,7 @@ void Flags_UnsetTempClear(GlobalContext* globalCtx, s32 flag);
 s32 Flags_GetCollectible(GlobalContext* globalCtx, s32 flag);
 void Flags_SetCollectible(GlobalContext* globalCtx, s32 flag);
 void TitleCard_InitBossName(GlobalContext* globalCtx, TitleCardContext* titleCtx, void* texture, s16 x, s16 y, u8 width,
-                            u8 height);
+                            u8 height, bool hastranslation);
 void TitleCard_InitPlaceName(GlobalContext* globalCtx, TitleCardContext* titleCtx, void* texture, s32 x, s32 y,
                              s32 width, s32 height, s32 delay);
 s32 func_8002D53C(GlobalContext* globalCtx, TitleCardContext* titleCtx);

--- a/soh/include/z64.h
+++ b/soh/include/z64.h
@@ -251,8 +251,8 @@ typedef struct {
     /* 0x0B */ u8       delayTimer; // how long the title card waits to appear
     /* 0x0C */ s16      alpha;
     /* 0x0E */ s16      intensity;
-    /* ---- */ bool     isBossCard; //To detect if that a Boss name title card.
-    /* ---- */ bool     hasTranslation; // to detect if the current title card has translation (used for bosses only)
+    /* ---- */ s16     isBossCard; //To detect if that a Boss name title card.
+    /* ---- */ s16     hasTranslation; // to detect if the current title card has translation (used for bosses only)
 } TitleCardContext; // size = 0x10
 
 typedef struct {

--- a/soh/include/z64.h
+++ b/soh/include/z64.h
@@ -251,6 +251,8 @@ typedef struct {
     /* 0x0B */ u8       delayTimer; // how long the title card waits to appear
     /* 0x0C */ s16      alpha;
     /* 0x0E */ s16      intensity;
+    /* ---- */ bool     isBossCard; //To detect if that a Boss name title card.
+    /* ---- */ bool     hasTranslation; // to detect if the current title card has translation (used for bosses only)
 } TitleCardContext; // size = 0x10
 
 typedef struct {

--- a/soh/src/code/z_actor.c
+++ b/soh/src/code/z_actor.c
@@ -1009,6 +1009,9 @@ void TitleCard_Draw(GlobalContext* globalCtx, TitleCardContext* titleCtx) {
     s32 doubleWidth;
     s32 titleY;
     s32 titleSecondY;
+    s32 textureLanguageOffset;
+    s32 shiftTopY;
+    s32 shiftBottomY;
 
     if (titleCtx->alpha != 0) {
         width = titleCtx->width;
@@ -1022,31 +1025,49 @@ void TitleCard_Draw(GlobalContext* globalCtx, TitleCardContext* titleCtx) {
         height = (width * height > 0x1000) ? 0x1000 / width : height;
         titleSecondY = titleY + (height * 4);
 
+        /* A more elegant way should be made but this one actually work fine.
+            I tried every single bosses in both English/French and German.
+            Zone name should not be affected by this changes.
+            I do not see any zone name with these dimensions. */
+        if (gSaveContext.language == LANGUAGE_GER && titleCtx->height == 40 && titleCtx->width == 128) {
+            textureLanguageOffset = (width * height * gSaveContext.language);
+            shiftTopY = 0x400;
+            shiftBottomY = 0x1400;
+        } else if (gSaveContext.language == LANGUAGE_FRA && titleCtx->height == 40 && titleCtx->width == 128) {
+            textureLanguageOffset = (width * height * gSaveContext.language);
+            shiftTopY = 0x800;
+            shiftBottomY = 0x1800;
+        } else { //Fall back to English value.
+            textureLanguageOffset = 0;
+            shiftTopY = 0;
+            shiftBottomY = 0x1000;
+        }
+
         // WORLD_OVERLAY_DISP Goes over POLY_XLU_DISP but under POLY_KAL_DISP
         WORLD_OVERLAY_DISP = func_80093808(WORLD_OVERLAY_DISP);
 
         gDPSetPrimColor(WORLD_OVERLAY_DISP++, 0, 0, (u8)titleCtx->intensity, (u8)titleCtx->intensity, (u8)titleCtx->intensity,
                         (u8)titleCtx->alpha);
 
-        gDPLoadTextureBlock(WORLD_OVERLAY_DISP++, (uintptr_t)titleCtx->texture, G_IM_FMT_IA,
+        gDPLoadTextureBlock(WORLD_OVERLAY_DISP++, (uintptr_t)titleCtx->texture + textureLanguageOffset + shiftBottomY, G_IM_FMT_IA,
                             G_IM_SIZ_8b,
                             width, height, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK,
                             G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
-
-        gSPTextureRectangle(WORLD_OVERLAY_DISP++, titleX, titleY, ((doubleWidth * 2) + titleX) - 4, titleY + (height * 4) - 1,
+        //Removing the -1 there remove the gap between top and bottom textures.
+        gSPTextureRectangle(WORLD_OVERLAY_DISP++, titleX, titleY, ((doubleWidth * 2) + titleX) - 4, titleY + (height * 4),
                             G_TX_RENDERTILE, 0, 0, 1 << 10, 1 << 10);
 
         height = titleCtx->height - height;
 
         // If texture is bigger than 0x1000, display the rest
         if (height > 0) {
-            gDPLoadTextureBlock(WORLD_OVERLAY_DISP++, (uintptr_t)titleCtx->texture + 0x1000,
+            gDPLoadTextureBlock(WORLD_OVERLAY_DISP++, (uintptr_t)titleCtx->texture + textureLanguageOffset + shiftBottomY,
                                 G_IM_FMT_IA,
                                 G_IM_SIZ_8b, width, height, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP,
                                 G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
-
+            //Removing the -1 there remove the gap between top and bottom textures.
             gSPTextureRectangle(WORLD_OVERLAY_DISP++, titleX, titleSecondY, ((doubleWidth * 2) + titleX) - 4,
-                                titleSecondY + (height * 4) - 1, G_TX_RENDERTILE, 0, 0, 1 << 10, 1 << 10);
+                                titleSecondY + (height * 4), G_TX_RENDERTILE, 0, 0, 1 << 10, 1 << 10);
         }
 
         CLOSE_DISPS(globalCtx->state.gfxCtx, "../z_actor.c", 2880);

--- a/soh/src/code/z_actor.c
+++ b/soh/src/code/z_actor.c
@@ -1032,6 +1032,9 @@ void TitleCard_Draw(GlobalContext* globalCtx, TitleCardContext* titleCtx) {
             Also Ganondorf do not have French and German title card it seem.
             A dirty method has been applied to actually detect it, once a better 
             method is found this workaround will be reverted.*/
+        textureLanguageOffset = 0x0;
+        shiftTopY = 0x0;
+        shiftBottomY = 0x1000;
         if (gSaveContext.language == LANGUAGE_GER && titleCtx->height == 40 && titleCtx->width == 128) {
             textureLanguageOffset = (width * height * gSaveContext.language);
             shiftTopY = 0x400;
@@ -1040,10 +1043,6 @@ void TitleCard_Draw(GlobalContext* globalCtx, TitleCardContext* titleCtx) {
             textureLanguageOffset = (width * height * gSaveContext.language);
             shiftTopY = 0x800;
             shiftBottomY = 0x1800;
-        } else if (titleCtx->height == 39 && titleCtx->width == 128 || gSaveContext.language == LANGUAGE_ENG) { //Fall back to English value.
-            textureLanguageOffset = 0;
-            shiftTopY = 0;
-            shiftBottomY = 0x1000;
         }
 
         // WORLD_OVERLAY_DISP Goes over POLY_XLU_DISP but under POLY_KAL_DISP

--- a/soh/src/code/z_actor.c
+++ b/soh/src/code/z_actor.c
@@ -758,12 +758,14 @@ void func_8002CDE4(GlobalContext* globalCtx, TitleCardContext* titleCtx) {
 }
 
 void TitleCard_InitBossName(GlobalContext* globalCtx, TitleCardContext* titleCtx, void* texture, s16 x, s16 y, u8 width,
-                            u8 height) {
+                            u8 height, bool hasTranslation) {
 
     if (ResourceMgr_OTRSigCheck(texture))
         texture = ResourceMgr_LoadTexByName(texture);
 
     titleCtx->texture = texture;
+    titleCtx->isBossCard = false;
+    titleCtx->hasTranslation = hasTranslation;   
     titleCtx->x = x;
     titleCtx->y = y;
     titleCtx->width = width;
@@ -981,6 +983,8 @@ void TitleCard_InitPlaceName(GlobalContext* globalCtx, TitleCardContext* titleCt
     titleCtx->texture = ResourceMgr_LoadTexByName(texture);
 
     //titleCtx->texture = texture;
+    titleCtx->isBossCard = false;
+    titleCtx->hasTranslation = false;
     titleCtx->x = x;
     titleCtx->y = y;
     titleCtx->width = width;
@@ -1025,24 +1029,21 @@ void TitleCard_Draw(GlobalContext* globalCtx, TitleCardContext* titleCtx) {
         height = (width * height > 0x1000) ? 0x1000 / width : height;
         titleSecondY = titleY + (height * 4);
 
-        /* A more elegant way should be made but this one actually work fine.
-            I tried every single bosses in both English/French and German.
-            Zone name should not be affected by this changes.
-            I do not see any zone name with these dimensions. 
-            Also Ganondorf do not have French and German title card it seem.
-            A dirty method has been applied to actually detect it, once a better 
-            method is found this workaround will be reverted.*/
         textureLanguageOffset = 0x0;
         shiftTopY = 0x0;
         shiftBottomY = 0x1000;
-        if (gSaveContext.language == LANGUAGE_GER && titleCtx->height == 40 && titleCtx->width == 128) {
-            textureLanguageOffset = (width * height * gSaveContext.language);
-            shiftTopY = 0x400;
-            shiftBottomY = 0x1400;
-        } else if (gSaveContext.language == LANGUAGE_FRA && titleCtx->height == 40 && titleCtx->width == 128) {
-            textureLanguageOffset = (width * height * gSaveContext.language);
-            shiftTopY = 0x800;
-            shiftBottomY = 0x1800;
+
+        //if this card is bosses cards, has translation and that is not using English language.
+        if (titleCtx->isBossCard && titleCtx->hasTranslation && gSaveContext.language != LANGUAGE_ENG) {
+            if (gSaveContext.language == LANGUAGE_GER) {
+                textureLanguageOffset = (width * height * gSaveContext.language);
+                shiftTopY = 0x400;
+                shiftBottomY = 0x1400;
+            } else if (gSaveContext.language == LANGUAGE_FRA) {
+                textureLanguageOffset = (width * height * gSaveContext.language);
+                shiftTopY = 0x800;
+                shiftBottomY = 0x1800;
+            }
         }
 
         // WORLD_OVERLAY_DISP Goes over POLY_XLU_DISP but under POLY_KAL_DISP

--- a/soh/src/code/z_actor.c
+++ b/soh/src/code/z_actor.c
@@ -758,13 +758,13 @@ void func_8002CDE4(GlobalContext* globalCtx, TitleCardContext* titleCtx) {
 }
 
 void TitleCard_InitBossName(GlobalContext* globalCtx, TitleCardContext* titleCtx, void* texture, s16 x, s16 y, u8 width,
-                            u8 height, bool hasTranslation) {
+                            u8 height, s16 hasTranslation) {
 
     if (ResourceMgr_OTRSigCheck(texture))
         texture = ResourceMgr_LoadTexByName(texture);
 
     titleCtx->texture = texture;
-    titleCtx->isBossCard = false;
+    titleCtx->isBossCard = true;
     titleCtx->hasTranslation = hasTranslation;   
     titleCtx->x = x;
     titleCtx->y = y;
@@ -1034,7 +1034,7 @@ void TitleCard_Draw(GlobalContext* globalCtx, TitleCardContext* titleCtx) {
         shiftBottomY = 0x1000;
 
         //if this card is bosses cards, has translation and that is not using English language.
-        if (titleCtx->isBossCard && titleCtx->hasTranslation && gSaveContext.language != LANGUAGE_ENG) {
+        if (titleCtx->isBossCard == 1 && titleCtx->hasTranslation == 1 && gSaveContext.language != LANGUAGE_ENG) {
             if (gSaveContext.language == LANGUAGE_GER) {
                 textureLanguageOffset = (width * height * gSaveContext.language);
                 shiftTopY = 0x400;

--- a/soh/src/code/z_actor.c
+++ b/soh/src/code/z_actor.c
@@ -1028,7 +1028,10 @@ void TitleCard_Draw(GlobalContext* globalCtx, TitleCardContext* titleCtx) {
         /* A more elegant way should be made but this one actually work fine.
             I tried every single bosses in both English/French and German.
             Zone name should not be affected by this changes.
-            I do not see any zone name with these dimensions. */
+            I do not see any zone name with these dimensions. 
+            Also Ganondorf do not have French and German title card it seem.
+            A dirty method has been applied to actually detect it, once a better 
+            method is found this workaround will be reverted.*/
         if (gSaveContext.language == LANGUAGE_GER && titleCtx->height == 40 && titleCtx->width == 128) {
             textureLanguageOffset = (width * height * gSaveContext.language);
             shiftTopY = 0x400;
@@ -1037,7 +1040,7 @@ void TitleCard_Draw(GlobalContext* globalCtx, TitleCardContext* titleCtx) {
             textureLanguageOffset = (width * height * gSaveContext.language);
             shiftTopY = 0x800;
             shiftBottomY = 0x1800;
-        } else { //Fall back to English value.
+        } else if (titleCtx->height == 39 && titleCtx->width == 128 || gSaveContext.language == LANGUAGE_ENG) { //Fall back to English value.
             textureLanguageOffset = 0;
             shiftTopY = 0;
             shiftBottomY = 0x1000;

--- a/soh/src/overlays/actors/ovl_Boss_Dodongo/z_boss_dodongo.c
+++ b/soh/src/overlays/actors/ovl_Boss_Dodongo/z_boss_dodongo.c
@@ -418,7 +418,7 @@ void BossDodongo_IntroCutscene(BossDodongo* this, GlobalContext* globalCtx) {
             if (this->unk_198 == 0x5A) {
                 if (!(gSaveContext.eventChkInf[7] & 2)) {
                     TitleCard_InitBossName(globalCtx, &globalCtx->actorCtx.titleCtx,
-                                           SEGMENTED_TO_VIRTUAL(gKingDodongoTitleCardTex), 160, 180, 128, 40);
+                                           SEGMENTED_TO_VIRTUAL(gKingDodongoTitleCardTex), 160, 180, 128, 40, true);
                 }
                 Audio_QueueSeqCmd(SEQ_PLAYER_BGM_MAIN << 24 | NA_BGM_FIRE_BOSS);
             }

--- a/soh/src/overlays/actors/ovl_Boss_Dodongo/z_boss_dodongo.c
+++ b/soh/src/overlays/actors/ovl_Boss_Dodongo/z_boss_dodongo.c
@@ -418,7 +418,7 @@ void BossDodongo_IntroCutscene(BossDodongo* this, GlobalContext* globalCtx) {
             if (this->unk_198 == 0x5A) {
                 if (!(gSaveContext.eventChkInf[7] & 2)) {
                     TitleCard_InitBossName(globalCtx, &globalCtx->actorCtx.titleCtx,
-                                           SEGMENTED_TO_VIRTUAL(gKingDodongoTitleCardTex), 0xA0, 0xB4, 0x80, 0x28);
+                                           SEGMENTED_TO_VIRTUAL(gKingDodongoTitleCardTex), 160, 180, 128, 40);
                 }
                 Audio_QueueSeqCmd(SEQ_PLAYER_BGM_MAIN << 24 | NA_BGM_FIRE_BOSS);
             }

--- a/soh/src/overlays/actors/ovl_Boss_Fd/z_boss_fd.c
+++ b/soh/src/overlays/actors/ovl_Boss_Fd/z_boss_fd.c
@@ -493,7 +493,7 @@ void BossFd_Fly(BossFd* this, GlobalContext* globalCtx) {
                 }
                 if ((this->timers[3] == 130) && !(gSaveContext.eventChkInf[7] & 8)) {
                     TitleCard_InitBossName(globalCtx, &globalCtx->actorCtx.titleCtx,
-                                           SEGMENTED_TO_VIRTUAL(gVolvagiaBossTitleCardTex), 160, 180, 128, 40);
+                                           SEGMENTED_TO_VIRTUAL(gVolvagiaBossTitleCardTex), 160, 180, 128, 40, true);
                 }
                 if (this->timers[3] <= 100) {
                     this->camData.eyeVel.x = this->camData.eyeVel.y = this->camData.eyeVel.z = 2.0f;

--- a/soh/src/overlays/actors/ovl_Boss_Fd/z_boss_fd.c
+++ b/soh/src/overlays/actors/ovl_Boss_Fd/z_boss_fd.c
@@ -493,7 +493,7 @@ void BossFd_Fly(BossFd* this, GlobalContext* globalCtx) {
                 }
                 if ((this->timers[3] == 130) && !(gSaveContext.eventChkInf[7] & 8)) {
                     TitleCard_InitBossName(globalCtx, &globalCtx->actorCtx.titleCtx,
-                                           SEGMENTED_TO_VIRTUAL(gVolvagiaBossTitleCardTex), 0xA0, 0xB4, 0x80, 0x28);
+                                           SEGMENTED_TO_VIRTUAL(gVolvagiaBossTitleCardTex), 160, 180, 128, 40);
                 }
                 if (this->timers[3] <= 100) {
                     this->camData.eyeVel.x = this->camData.eyeVel.y = this->camData.eyeVel.z = 2.0f;

--- a/soh/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.c
+++ b/soh/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.c
@@ -1088,7 +1088,7 @@ void BossGanon_IntroCutscene(BossGanon* this, GlobalContext* globalCtx) {
 
                 if (!(gSaveContext.eventChkInf[7] & 0x100)) {
                     TitleCard_InitBossName(globalCtx, &globalCtx->actorCtx.titleCtx,
-                                           SEGMENTED_TO_VIRTUAL(gDorfTitleCardTex), 160, 180, 128, 39); //Dirty method to detect if that Ganondoft title card.
+                                           SEGMENTED_TO_VIRTUAL(gDorfTitleCardTex), 160, 180, 128, 40, false);
                 }
 
                 gSaveContext.eventChkInf[7] |= 0x100;

--- a/soh/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.c
+++ b/soh/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.c
@@ -1088,7 +1088,7 @@ void BossGanon_IntroCutscene(BossGanon* this, GlobalContext* globalCtx) {
 
                 if (!(gSaveContext.eventChkInf[7] & 0x100)) {
                     TitleCard_InitBossName(globalCtx, &globalCtx->actorCtx.titleCtx,
-                                           SEGMENTED_TO_VIRTUAL(gDorfTitleCardTex), 160, 180, 128, 40);
+                                           SEGMENTED_TO_VIRTUAL(gDorfTitleCardTex), 160, 180, 128, 39); //Dirty method to detect if that Ganondoft title card.
                 }
 
                 gSaveContext.eventChkInf[7] |= 0x100;

--- a/soh/src/overlays/actors/ovl_Boss_Ganon2/z_boss_ganon2.c
+++ b/soh/src/overlays/actors/ovl_Boss_Ganon2/z_boss_ganon2.c
@@ -671,7 +671,8 @@ void func_808FD5F4(BossGanon2* this, GlobalContext* globalCtx) {
             if (this->unk_398 == 80) {
                 BossGanon2_SetObjectSegment(this, globalCtx, OBJECT_GANON2, false);
                 TitleCard_InitBossName(globalCtx, &globalCtx->actorCtx.titleCtx,
-                                       SEGMENTED_TO_VIRTUAL(object_ganon2_Tex_021A90), 160, 180, 128, 40);
+                                       SEGMENTED_TO_VIRTUAL(object_ganon2_Tex_021A90), 160, 180, 128, 40, true);
+                                       //It has translation but they are all the same. they all say "GANON" only
             }
             this->unk_3A4.x = ((this->actor.world.pos.x + 500.0f) - 350.0f) + 100.0f;
             this->unk_3A4.y = this->actor.world.pos.y;

--- a/soh/src/overlays/actors/ovl_Boss_Goma/z_boss_goma.c
+++ b/soh/src/overlays/actors/ovl_Boss_Goma/z_boss_goma.c
@@ -926,7 +926,7 @@ void BossGoma_Encounter(BossGoma* this, GlobalContext* globalCtx) {
 
                 if (!(gSaveContext.eventChkInf[7] & 1)) {
                     TitleCard_InitBossName(globalCtx, &globalCtx->actorCtx.titleCtx,
-                                           SEGMENTED_TO_VIRTUAL(gGohmaTitleCardTex), 160, 180, 128, 40);
+                                           SEGMENTED_TO_VIRTUAL(gGohmaTitleCardTex), 160, 180, 128, 40, true);
                 }
 
                 Audio_QueueSeqCmd(SEQ_PLAYER_BGM_MAIN << 24 | NA_BGM_BOSS);

--- a/soh/src/overlays/actors/ovl_Boss_Goma/z_boss_goma.c
+++ b/soh/src/overlays/actors/ovl_Boss_Goma/z_boss_goma.c
@@ -926,7 +926,7 @@ void BossGoma_Encounter(BossGoma* this, GlobalContext* globalCtx) {
 
                 if (!(gSaveContext.eventChkInf[7] & 1)) {
                     TitleCard_InitBossName(globalCtx, &globalCtx->actorCtx.titleCtx,
-                                           SEGMENTED_TO_VIRTUAL(gGohmaTitleCardTex), 0xA0, 0xB4, 0x80, 0x28);
+                                           SEGMENTED_TO_VIRTUAL(gGohmaTitleCardTex), 160, 180, 128, 40);
                 }
 
                 Audio_QueueSeqCmd(SEQ_PLAYER_BGM_MAIN << 24 | NA_BGM_BOSS);

--- a/soh/src/overlays/actors/ovl_Boss_Mo/z_boss_mo.c
+++ b/soh/src/overlays/actors/ovl_Boss_Mo/z_boss_mo.c
@@ -1423,7 +1423,7 @@ void BossMo_IntroCs(BossMo* this, GlobalContext* globalCtx) {
             }
             if (this->timers[2] == 130) {
                 TitleCard_InitBossName(globalCtx, &globalCtx->actorCtx.titleCtx,
-                                       SEGMENTED_TO_VIRTUAL(gMorphaTitleCardTex), 160, 180, 128, 40);
+                                       SEGMENTED_TO_VIRTUAL(gMorphaTitleCardTex), 160, 180, 128, 40, true);
                 gSaveContext.eventChkInf[7] |= 0x10;
             }
             break;

--- a/soh/src/overlays/actors/ovl_Boss_Mo/z_boss_mo.c
+++ b/soh/src/overlays/actors/ovl_Boss_Mo/z_boss_mo.c
@@ -1423,7 +1423,7 @@ void BossMo_IntroCs(BossMo* this, GlobalContext* globalCtx) {
             }
             if (this->timers[2] == 130) {
                 TitleCard_InitBossName(globalCtx, &globalCtx->actorCtx.titleCtx,
-                                       SEGMENTED_TO_VIRTUAL(gMorphaTitleCardTex), 0xA0, 0xB4, 0x80, 0x28);
+                                       SEGMENTED_TO_VIRTUAL(gMorphaTitleCardTex), 160, 180, 128, 40);
                 gSaveContext.eventChkInf[7] |= 0x10;
             }
             break;

--- a/soh/src/overlays/actors/ovl_Boss_Sst/z_boss_sst.c
+++ b/soh/src/overlays/actors/ovl_Boss_Sst/z_boss_sst.c
@@ -598,7 +598,7 @@ void BossSst_HeadIntro(BossSst* this, GlobalContext* globalCtx) {
                 } else if (revealStateTimer == 85) {
                     if (!(gSaveContext.eventChkInf[7] & 0x80)) {
                         TitleCard_InitBossName(globalCtx, &globalCtx->actorCtx.titleCtx,
-                                               SEGMENTED_TO_VIRTUAL(gBongoTitleCardTex), 160, 180, 128, 40);
+                                               SEGMENTED_TO_VIRTUAL(gBongoTitleCardTex), 160, 180, 128, 40, true);
                     }
                     Audio_QueueSeqCmd(SEQ_PLAYER_BGM_MAIN << 24 | NA_BGM_BOSS);
                     Animation_MorphToPlayOnce(&this->skelAnime, &gBongoHeadEyeCloseAnim, -5.0f);

--- a/soh/src/overlays/actors/ovl_Boss_Tw/z_boss_tw.c
+++ b/soh/src/overlays/actors/ovl_Boss_Tw/z_boss_tw.c
@@ -2220,7 +2220,7 @@ void BossTw_TwinrovaIntroCS(BossTw* this, GlobalContext* globalCtx) {
                 globalCtx->envCtx.unk_BE = 1;
                 globalCtx->envCtx.unk_BD = 1;
                 globalCtx->envCtx.unk_D8 = 0.0f;
-                TitleCard_InitBossName(globalCtx, &globalCtx->actorCtx.titleCtx, SEGMENTED_TO_VIRTUAL(gTwinrovaTitleCardTex), 160, 180, 128, 40); // OTRTODO
+                TitleCard_InitBossName(globalCtx, &globalCtx->actorCtx.titleCtx, SEGMENTED_TO_VIRTUAL(gTwinrovaTitleCardTex), 160, 180, 128, 40, true);
                 gSaveContext.eventChkInf[7] |= 0x20;
                 Audio_QueueSeqCmd(SEQ_PLAYER_BGM_MAIN << 24 | NA_BGM_BOSS);
             }

--- a/soh/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
+++ b/soh/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
@@ -979,7 +979,7 @@ void BossVa_BodyIntro(BossVa* this, GlobalContext* globalCtx) {
 
                 if (!(gSaveContext.eventChkInf[7] & 0x40)) {
                     TitleCard_InitBossName(globalCtx, &globalCtx->actorCtx.titleCtx,
-                                           SEGMENTED_TO_VIRTUAL(gBarinadeTitleCardTex), 160, 180, 128, 40);
+                                           SEGMENTED_TO_VIRTUAL(gBarinadeTitleCardTex), 160, 180, 128, 40, true);
                 }
 
                 if (Rand_ZeroOne() < 0.1f) {

--- a/soh/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
+++ b/soh/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
@@ -979,7 +979,7 @@ void BossVa_BodyIntro(BossVa* this, GlobalContext* globalCtx) {
 
                 if (!(gSaveContext.eventChkInf[7] & 0x40)) {
                     TitleCard_InitBossName(globalCtx, &globalCtx->actorCtx.titleCtx,
-                                           SEGMENTED_TO_VIRTUAL(gBarinadeTitleCardTex), 0xA0, 0xB4, 0x80, 0x28);
+                                           SEGMENTED_TO_VIRTUAL(gBarinadeTitleCardTex), 160, 180, 128, 40);
                 }
 
                 if (Rand_ZeroOne() < 0.1f) {

--- a/soh/src/overlays/actors/ovl_En_fHG/z_en_fhg.c
+++ b/soh/src/overlays/actors/ovl_En_fHG/z_en_fhg.c
@@ -332,7 +332,7 @@ void EnfHG_Intro(EnfHG* this, GlobalContext* globalCtx) {
             Math_ApproachF(&this->cameraSpeedMod, 1.0f, 1.0f, 0.05f);
             if (this->timers[0] == 75) {
                 TitleCard_InitBossName(globalCtx, &globalCtx->actorCtx.titleCtx,
-                                       SEGMENTED_TO_VIRTUAL(gPhantomGanonTitleCardTex), 160, 180, 128, 40);
+                                       SEGMENTED_TO_VIRTUAL(gPhantomGanonTitleCardTex), 160, 180, 128, 40, true);
             }
             if (this->timers[0] == 0) {
                 this->cutsceneState = INTRO_RETREAT;


### PR DESCRIPTION
First, Ganondorf I hate you why do you have to play bad like that?

This PR is to fix Germand and French title cards translation 
(except Ganondorf, for some reasons this one do not have translation.)

Every bosses has been tested and quite a lot of zone name.
now when you use TitleCard_InitBossName you can tell if there is a translation or not.

This need method I think that a clean one. :)
Btw in TitleCard_InitBossName() in bosses files I use true/false for better readability and in code it translate to 0/1
so that fine :)

![English title card](https://www.baoulettes.fr/Uploads/i10apn2enl4qh4bib7guw8967.png) 
![Germand title card](https://www.baoulettes.fr/Uploads/nle66e2gwm1oyihwe6chx0iic.png) 
![French title card](https://www.baoulettes.fr/Uploads/05k8z666vao6c6gcb8444c2r5.png) 