### PR TITLE
extract_assets.py allow drag & drop and downgrade match to elif

### DIFF
--- a/OTRExporter/extract_assets.py
+++ b/OTRExporter/extract_assets.py
@@ -4,7 +4,7 @@
 #   Place a rom in this directory then run the script.
 #   If you are using multiple roms, the script will let you choose one.
 #   To choose with a commandline argument:
-#      Python3 extract_assets.py <number>
+#      Python3 extract_assets.py <rom_name>
 #      Invalid input results in the first rom being selected
 
 import json, os, signal, time, sys, shutil, glob
@@ -93,16 +93,9 @@ def main():
         # If commandline args exist
         if (len(sys.argv) > 1):
             try:
-                if ((int(sys.argv[1]) - 1) < 1):
-                    romToUse = roms[0]
-                    
-                elif ((int(sys.argv[1]) - 1) > len(roms)):
-                    romToUse = roms[len(roms) - 1]
-                
-                else:
-                    romToUse = roms[int(sys.argv[1]) - 1]
+                romToUse = sys.argv[1]
             except:
-                romToUse = roms[0]
+                print("Error with rom inputted via argument")
             
         # No commandline args, select rom using user input
         else:
@@ -132,13 +125,12 @@ def main():
     else:
         romToUse = roms[0]
     
-    match checkChecksum(romToUse):
-        case Checksums.OOT_PAL_GC:
-            xmlVer = "GC_NMQ_PAL_F"
-        case Checksums.OOT_PAL_GC_DBG1:
-            xmlVer = "GC_NMQ_D"
-        case _: # default case
-            xmlVer = "GC_MQ_D"
+    if checkChecksum(romToUse) == Checksums.OOT_PAL_GC:
+        xmlVer = "GC_NMQ_PAL_F"
+    elif checkChecksum(romToUse) == Checksums.OOT_PAL_GC_DBG1:
+        xmlVer = "GC_NMQ_D"
+    else: # default selection
+        xmlVer = "GC_MQ_D"
 
     if (os.path.exists("Extract")):
         shutil.rmtree("Extract")


### PR DESCRIPTION
This PR changes the functionality of extract_assets.py.

The command argument now uses rom name (don't forget the extension):
`./extract_assets.py <rom>`

This allows dragging and dropping a rom straight into the python file

The match/switch statement has been downgraded to elif for those using python3 from the wood era.

Note: In Windows rather than submitting "rom_name.z64" it submits the entire path: `C:/Users/%USERNAME%/etc/OTRExporter/rom_name.z64`
I recommend testing this change in Linux to make sure it's functional. Otherwise I'll add more logic to parse out the directory.