### PR TITLE
Fix dungeon entrance icon + feature

### DIFF
--- a/libultraship/libultraship/SohImGuiImpl.cpp
+++ b/libultraship/libultraship/SohImGuiImpl.cpp
@@ -559,6 +559,8 @@ namespace SohImGui {
                 EnhancementCheckbox("Disable LOD", "gDisableLOD");
                 EnhancementCheckbox("Enable 3D Dropped items", "gNewDrops");
                 EnhancementCheckbox("Dynamic Wallet Icon", "gDynamicWalletIcon");
+                //EnhancementCheckbox("Fix Dungeon entrances", "gFixDungeonMinimapIcon"); //This is just to show that we can toggle it on/off with that cvar 
+                EnhancementCheckbox("Always show dungeon entrances", "gAlwaysShowDungeonMinimapIcon");
 
                 ImGui::EndMenu();
             }

--- a/libultraship/libultraship/SohImGuiImpl.cpp
+++ b/libultraship/libultraship/SohImGuiImpl.cpp
@@ -559,9 +559,13 @@ namespace SohImGui {
                 EnhancementCheckbox("Disable LOD", "gDisableLOD");
                 EnhancementCheckbox("Enable 3D Dropped items", "gNewDrops");
                 EnhancementCheckbox("Dynamic Wallet Icon", "gDynamicWalletIcon");
-                //EnhancementCheckbox("Fix Dungeon entrances", "gFixDungeonMinimapIcon"); //This is just to show that we can toggle it on/off with that cvar 
                 EnhancementCheckbox("Always show dungeon entrances", "gAlwaysShowDungeonMinimapIcon");
-
+                
+                if (ImGui::BeginMenu("Fixes")) {
+                    EnhancementCheckbox("Fix L&R Pause menu", "gUniformLR");
+                    EnhancementCheckbox("Fix Dungeon entrances", "gFixDungeonMinimapIcon");
+                    ImGui::EndMenu();
+                }
                 ImGui::EndMenu();
             }
 

--- a/soh/src/code/z_map_exp.c
+++ b/soh/src/code/z_map_exp.c
@@ -737,21 +737,33 @@ void Minimap_Draw(GlobalContext* globalCtx) {
                     if (((globalCtx->sceneNum != SCENE_SPOT01) && (globalCtx->sceneNum != SCENE_SPOT04) &&
                          (globalCtx->sceneNum != SCENE_SPOT08)) ||
                         (LINK_AGE_IN_YEARS != YEARS_ADULT)) {
+                        s16 IconSize = 8;
+                        s16 PosX = gMapData->owEntranceIconPosX[sEntranceIconMapIndex];
+                        s16 PosY = gMapData->owEntranceIconPosY[sEntranceIconMapIndex];
+                        //gFixDungeonMinimapIcon fix both Y position of visible icon and hide these non needed.
+                        if (CVar_GetS32("gFixDungeonMinimapIcon", 1) != 0){
+                            //No idea why and how Original value work but this does actually fix them all.
+                            PosY = PosY+1024;
+                        }
+                        s16 TopLeftX = OTRGetRectDimensionFromRightEdge(PosX) << 2;
+                        s16 TopLeftY = PosY << 2;
+                        s16 TopLeftW = OTRGetRectDimensionFromRightEdge(PosX + IconSize) << 2;
+                        s16 TopLeftH = (PosY + IconSize) << 2;
                         if ((gMapData->owEntranceFlag[sEntranceIconMapIndex] == 0xFFFF) ||
                             ((gMapData->owEntranceFlag[sEntranceIconMapIndex] != 0xFFFF) &&
                              (gSaveContext.infTable[26] & gBitFlags[gMapData->owEntranceFlag[mapIndex]]))) {
-
+                            if (gMapData->owEntranceIconPosY[sEntranceIconMapIndex] << 2 != 0 && CVar_GetS32("gFixDungeonMinimapIcon", 1) != 0){
+                                gDPLoadTextureBlock(OVERLAY_DISP++, gMapDungeonEntranceIconTex, G_IM_FMT_RGBA, G_IM_SIZ_16b,
+                                                    IconSize, IconSize, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP,
+                                                    G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
+                                gSPWideTextureRectangle(OVERLAY_DISP++, TopLeftX, TopLeftY, TopLeftW, TopLeftH, G_TX_RENDERTILE, 0, 0, 1 << 10, 1 << 10);
+                            }
+                        } else if (CVar_GetS32("gAlwaysShowDungeonMinimapIcon", 0) != 0){ //Ability to show entrance Before beating the dungeon itself
                             gDPLoadTextureBlock(OVERLAY_DISP++, gMapDungeonEntranceIconTex, G_IM_FMT_RGBA, G_IM_SIZ_16b,
-                                                8, 8, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP,
+                                                IconSize, IconSize, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP,
                                                 G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
-
-                            gSPWideTextureRectangle(OVERLAY_DISP++,
-                                                OTRGetRectDimensionFromLeftEdge(gMapData->owEntranceIconPosX[sEntranceIconMapIndex]) << 2,
-                                                gMapData->owEntranceIconPosY[sEntranceIconMapIndex] << 2,
-                                                OTRGetRectDimensionFromLeftEdge(gMapData->owEntranceIconPosX[sEntranceIconMapIndex] + 8) << 2,
-                                                (gMapData->owEntranceIconPosY[sEntranceIconMapIndex] + 8) << 2,
-                                                G_TX_RENDERTILE, 0, 0, 1 << 10, 1 << 10);
-                        }
+                            gSPWideTextureRectangle(OVERLAY_DISP++, TopLeftX, TopLeftY, TopLeftW, TopLeftH, G_TX_RENDERTILE, 0, 0, 1 << 10, 1 << 10);
+                        } 
                     }
 
                     if ((globalCtx->sceneNum == SCENE_SPOT08) && (gSaveContext.infTable[26] & gBitFlags[9])) {


### PR DESCRIPTION
This PR add Fixes submenu to include L&R Kaleido button color and this Dungeon icon on minimap. (under Enhancements menu)
It fixes the Dungeon Entrance icon that was not visible when it should be and was present when it should not.
Also it add the ability to show the dungeon entrance before finishing a dungeon.

This code also rework a bit the icon draw to make it a bit more readable.

Screen before fixes:
![what an ugly top left icon](https://baoulettes.fr/Uploads/gz7hwtm9w68hpqhxbntxo6c5o.png)

Screenshots after fixes:
![no more icon](https://baoulettes.fr/Uploads/6syki6mvltbs6e69zqpjn1k44.png)
![Nice head there](https://baoulettes.fr/Uploads/cjal7ertbewo4ut1pwcx19cjo.png)

Here what the fix look next to GCN version 
![Compare](https://baoulettes.fr/Uploads/4y3bj6msv62eh1bkv4c966dra.png)