### PR TITLE
Improve CVars a bit

### DIFF
--- a/libultraship/libultraship/Cvar.cpp
+++ b/libultraship/libultraship/Cvar.cpp
@@ -16,7 +16,7 @@ extern "C" CVar* CVar_Get(const char* name) {
 extern "C" s32 CVar_GetS32(const char* name, s32 defaultValue) {
     CVar* cvar = CVar_Get(name);
 
-    if (cvar != nullptr) {
+    if (cvar) {
         if (cvar->type == CVAR_TYPE_S32)
             return cvar->value.valueS32;
     }
@@ -27,7 +27,7 @@ extern "C" s32 CVar_GetS32(const char* name, s32 defaultValue) {
 extern "C" float CVar_GetFloat(const char* name, float defaultValue) {
     CVar* cvar = CVar_Get(name);
 
-    if (cvar != nullptr) {
+    if (cvar) {
         if (cvar->type == CVAR_TYPE_FLOAT)
             return cvar->value.valueFloat;
     }
@@ -38,7 +38,7 @@ extern "C" float CVar_GetFloat(const char* name, float defaultValue) {
 extern "C" const char* CVar_GetString(const char* name, const char* defaultValue) {
     CVar* cvar = CVar_Get(name);
 
-    if (cvar != nullptr) {
+    if (cvar) {
         if (cvar->type == CVAR_TYPE_STRING)
             return cvar->value.valueStr;
     }
@@ -48,7 +48,7 @@ extern "C" const char* CVar_GetString(const char* name, const char* defaultValue
 
 extern "C" void CVar_SetS32(const char* name, s32 value) {
     auto& cvar = cvars[name];
-    if (cvar == nullptr) {
+    if (!cvar) {
         cvar = std::make_unique<CVar>();
     }
     cvar->type = CVAR_TYPE_S32;
@@ -57,7 +57,7 @@ extern "C" void CVar_SetS32(const char* name, s32 value) {
 
 void CVar_SetFloat(const char* name, float value) {
     auto& cvar = cvars[name];
-    if (cvar == nullptr) {
+    if (!cvar) {
         cvar = std::make_unique<CVar>();
     }
     cvar->type = CVAR_TYPE_FLOAT;
@@ -66,7 +66,7 @@ void CVar_SetFloat(const char* name, float value) {
 
 void CVar_SetString(const char* name, const char* value) {
     auto& cvar = cvars[name];
-    if (cvar == nullptr) {
+    if (!cvar) {
         cvar = std::make_unique<CVar>();
     }
     cvar->type = CVAR_TYPE_STRING;
@@ -74,22 +74,16 @@ void CVar_SetString(const char* name, const char* value) {
 }
 
 extern "C" void CVar_RegisterS32(const char* name, s32 defaultValue) {
-    CVar* cvar = CVar_Get(name);
-
-    if (cvar == nullptr)
+    if (!CVar_Get(name))
         CVar_SetS32(name, defaultValue);
 }
 
 extern "C" void CVar_RegisterFloat(const char* name, float defaultValue) {
-    CVar* cvar = CVar_Get(name);
-
-    if (cvar == nullptr)
+    if (!CVar_Get(name))
         CVar_SetFloat(name, defaultValue);
 }
 
 extern "C" void CVar_RegisterString(const char* name, const char* defaultValue) {
-    CVar* cvar = CVar_Get(name);
-
-    if (cvar == nullptr)
+    if (!CVar_Get(name))
         CVar_SetString(name, defaultValue);
 }

--- a/libultraship/libultraship/Cvar.h
+++ b/libultraship/libultraship/Cvar.h
@@ -6,13 +6,13 @@
 typedef enum CVarType { CVAR_TYPE_S32, CVAR_TYPE_FLOAT, CVAR_TYPE_STRING } CVarType;
 
 typedef struct CVar {
-    char* name;
+    const char* name;
     CVarType type;
 
     union {
         s32 valueS32;
         float valueFloat;
-        char* valueStr;
+        const char* valueStr;
     } value;
 } CVar;
 
@@ -22,16 +22,15 @@ extern "C"
 #endif
 //#include <ultra64.h>
 
-
 CVar* CVar_Get(const char* name);
 s32 CVar_GetS32(const char* name, s32 defaultValue);
 float CVar_GetFloat(const char* name, float defaultValue);
-char* CVar_GetString(const char* name, char* defaultValue);
+const char* CVar_GetString(const char* name, const char* defaultValue);
 void CVar_SetS32(const char* name, s32 value);
 
 void CVar_RegisterS32(const char* name, s32 defaultValue);
 void CVar_RegisterFloat(const char* name, float defaultValue);
-void CVar_RegisterString(const char* name, char* defaultValue);
+void CVar_RegisterString(const char* name, const char* defaultValue);
 
 #ifdef __cplusplus
 };
@@ -40,10 +39,12 @@ void CVar_RegisterString(const char* name, char* defaultValue);
 #ifdef __cplusplus
 #include <map>
 #include <string>
+#include <functional>
+#include <memory>
 
-extern std::map<std::string, CVar*> cvars;
+extern std::map<std::string, std::unique_ptr<CVar>, std::less<>> cvars;
 CVar* CVar_GetVar(const char* name);
 void CVar_SetFloat(const char* name, float value);
-void CVar_SetString(const char* name, char* value);
+void CVar_SetString(const char* name, const char* value);
 #endif
 #endif

--- a/libultraship/libultraship/SohConsole.cpp
+++ b/libultraship/libultraship/SohConsole.cpp
@@ -92,7 +92,7 @@ void Console::Update() {
 	}
 	for (auto [key, var] : BindingToggle) {
 		if (ImGui::IsKeyPressed(key)) {
-			CVar* cvar = CVar_GetVar(var.c_str());
+			CVar* cvar = CVar_Get(var.c_str());
 			Dispatch("set " + var + " " + std::to_string(cvar == nullptr ? 0 : !static_cast<bool>(cvar->value.valueS32)));
 		}
 	}

--- a/soh/soh/Enhancements/debugconsole.cpp
+++ b/soh/soh/Enhancements/debugconsole.cpp
@@ -334,7 +334,7 @@ static bool SetCVarHandler(const std::vector<std::string>& args) {
     int vType = CheckVarType(args[2]);
 
     if (vType == VARTYPE_STRING)
-        CVar_SetString(args[1].c_str(), (char*)args[2].c_str());
+        CVar_SetString(args[1].c_str(), args[2].c_str());
     else if (vType == VARTYPE_FLOAT)
         CVar_SetFloat(args[1].c_str(), std::stof(args[2]));
     else
@@ -351,7 +351,7 @@ static bool GetCVarHandler(const std::vector<std::string>& args) {
     if (args.size() < 2)
         return CMD_FAILED;
 
-    CVar* cvar = CVar_GetVar(args[1].c_str());
+    CVar* cvar = CVar_Get(args[1].c_str());
 
     if (cvar != nullptr)
     {


### PR DESCRIPTION
Avoid constructing a new string every time a `CVar` is accessed, make string values in the `CVar` structure `const`, use `std::unique_ptr` for `CVar` instead of raw pointers with `new`, remove `CVar_GetVar` and just use `CVar_Get` (I didn't see a reason to have both).