### PR TITLE
Workaround for #183

### DIFF
--- a/soh/src/code/graph.c
+++ b/soh/src/code/graph.c
@@ -476,7 +476,10 @@ static void RunFrame()
             
             Graph_StartFrame();
 
-            PadMgr_ThreadEntry(&gPadMgr);
+            // TODO: Workaround for rumble being too long. Implement os thread functions.
+            for (int i = 0; i < 3; i++) {
+                PadMgr_ThreadEntry(&gPadMgr);
+            }
             
             Graph_Update(&runFrameContext.gfxCtx, runFrameContext.gameState);
             ticksB = GetPerfCounter();


### PR DESCRIPTION
Implements a workaround that closes #183 by updating the controllers 3 times as often in its current call site. Eventually the proper fix would be implementing os thread functions as laid out in #189 by Kenix and then allowing controller inputs to be read in a separate thread, but this works well enough for now from what I can see.

Edit: Alternatively I could just implement `osCreateThread` in this PR but I'm not entirely sure the proper way to implement it considering the thread parameters may need to be handled. Also would `osStartThread` and `osStopThread` need to be implemented too in that case?