### PR TITLE
Return button translation for GER/FRA

### DIFF
--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -2804,7 +2804,26 @@ void Interface_DrawItemButtons(GlobalContext* globalCtx) {
             gDPSetEnvColor(OVERLAY_DISP++, 0, 0, 0, 0);
             gDPSetCombineLERP(OVERLAY_DISP++, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0,
                               PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0);
-
+            
+            //There is probably a more elegant way to do it.
+            char* doAction = actionsTbl[3];
+            char newName[512];
+            if (gSaveContext.language != LANGUAGE_ENG) {
+                size_t length = strlen(doAction);
+                strcpy(newName, doAction);
+                if (gSaveContext.language == LANGUAGE_FRA) {
+                    newName[length - 6] = 'F';
+                    newName[length - 5] = 'R';
+                    newName[length - 4] = 'A';
+                } else if (gSaveContext.language == LANGUAGE_GER) {
+                    newName[length - 6] = 'G';
+                    newName[length - 5] = 'E';
+                    newName[length - 4] = 'R';
+                }
+                doAction = newName;
+            }
+            memcpy(interfaceCtx->doActionSegment + DO_ACTION_TEX_SIZE * 2, ResourceMgr_LoadTexByName(doAction), DO_ACTION_TEX_SIZE);
+            
             gDPLoadTextureBlock_4b(OVERLAY_DISP++, interfaceCtx->doActionSegment + DO_ACTION_TEX_SIZE * 2, G_IM_FMT_IA,
                                    DO_ACTION_TEX_WIDTH, DO_ACTION_TEX_HEIGHT, 0, G_TX_NOMIRROR | G_TX_WRAP,
                                    G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);


### PR DESCRIPTION
Fix the button "Return" (Start) not being translated in Kaleido menu.
This is probably not the best way to do it but I had no any ideas how to make it more simple.
Incorrect: 
![Bye bye english button in french language](https://baoulettes.fr/Uploads/sdj1p7cpn9u5g2irsxlq256mb.png)
how it is (notice that Quitter?):
![Fixed](https://baoulettes.fr/Uploads/tomehh9iu68l1n645jaudi85t.png)