### PR TITLE
Increase build pipeline timeout

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ pipeline {
     
     options {
         timestamps() 
-        timeout(time: 30, unit: 'MINUTES')
+        timeout(time: 60, unit: 'MINUTES')
         skipDefaultCheckout(true)
     }
     


### PR DESCRIPTION
30min could possibly be too low in some instances