### PR TITLE
Fixed idle animations for Two Handed Items

### DIFF
--- a/libultraship/libultraship/SohImGuiImpl.cpp
+++ b/libultraship/libultraship/SohImGuiImpl.cpp
@@ -668,6 +668,7 @@ namespace SohImGui {
                 ImGui::Separator();
                 EnhancementCheckbox("Fix L&R Pause menu", "gUniformLR");
                 EnhancementCheckbox("Fix Dungeon entrances", "gFixDungeonMinimapIcon");
+                EnhancementCheckbox("Fix Two Handed idle animations", "gTwoHandedIdle");
 
                 EXPERIMENTAL();
 

--- a/soh/soh/Enhancements/bootcommands.c
+++ b/soh/soh/Enhancements/bootcommands.c
@@ -27,7 +27,7 @@ void BootCommands_Init()
     CVar_RegisterS32("gMinimalUI", 0);
     CVar_RegisterS32("gRumbleEnabled", 0);
     CVar_RegisterS32("gUniformLR", 1);
-    CVar_RegisterS32("gTwoHandedIdle", 1);
+    CVar_RegisterS32("gTwoHandedIdle", 0);
     CVar_RegisterS32("gNewDrops", 0);
     CVar_RegisterS32("gVisualAgony", 0);
     CVar_RegisterS32("gLanguages", 0); //0 = English / 1 = German / 2 = French

--- a/soh/soh/Enhancements/bootcommands.c
+++ b/soh/soh/Enhancements/bootcommands.c
@@ -27,6 +27,7 @@ void BootCommands_Init()
     CVar_RegisterS32("gMinimalUI", 0);
     CVar_RegisterS32("gRumbleEnabled", 0);
     CVar_RegisterS32("gUniformLR", 1);
+    CVar_RegisterS32("gTwoHandedIdle", 1);
     CVar_RegisterS32("gNewDrops", 0);
     CVar_RegisterS32("gVisualAgony", 0);
     CVar_RegisterS32("gLanguages", 0); //0 = English / 1 = German / 2 = French

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -6981,7 +6981,7 @@ void func_808409CC(GlobalContext* globalCtx, Player* this) {
                 if (sp34 < 4) {
                     if (((sp34 != 0) && (sp34 != 3)) || ((this->rightHandType == PLAYER_MODELTYPE_RH_SHIELD) &&
                         ((sp34 == 3) || Player_GetSwordHeld(this)))) {
-                        if ((sp34 == 1) && Player_HoldsTwoHandedWeapon(this)) {
+                        if ((sp34 == 1) && Player_HoldsTwoHandedWeapon(this) && CVar_GetS32("gTwoHandedIdle", 1) == 1) {
                             sp34 = 4;
                         }
                         sp38 = sp34 + 9;

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -6981,7 +6981,7 @@ void func_808409CC(GlobalContext* globalCtx, Player* this) {
                 if (sp34 < 4) {
                     if (((sp34 != 0) && (sp34 != 3)) || ((this->rightHandType == PLAYER_MODELTYPE_RH_SHIELD) &&
                         ((sp34 == 3) || Player_GetSwordHeld(this)))) {
-                        if ((sp34 == 0) && Player_HoldsTwoHandedWeapon(this)) {
+                        if ((sp34 == 1) && Player_HoldsTwoHandedWeapon(this)) {
                             sp34 = 4;
                         }
                         sp38 = sp34 + 9;


### PR DESCRIPTION
Nintendo messed up and used a 0 instead of a 1 which basically pulled the wrong animation to load while holding two handed items

https://user-images.githubusercontent.com/47987542/168158698-e1f1705a-7661-4f34-aaba-11620dcda502.mp4

https://user-images.githubusercontent.com/47987542/168159728-91543a81-aa89-4c2a-960e-d2f21d0b4e89.mp4


