### PR TITLE
Corrects tooltip on OTRGui

### DIFF
--- a/OTRGui/src/game/game.cpp
+++ b/OTRGui/src/game/game.cpp
@@ -188,7 +188,7 @@ void OTRGame::draw() {
 		sohFolder = path;
 	}
 
-	if (UIUtils::GuiIconButton("Cartridge", "Open\nOoT Rom", 32, 50, currentStep != NULLSTR, "Select an Ocarina of Time\nMaster Quest or Vanilla Debug Rom\n\nYou can dump it or lend one from Nintendo")) {
+	if (UIUtils::GuiIconButton("Cartridge", "Open\nOoT Rom", 32, 50, currentStep != NULLSTR, "Select an Ocarina of Time\nGameCube PAL or Vanilla Debug Rom\n\nYou can dump it or lend one from Nintendo")) {
 		const std::string path = NativeFS->LaunchFileExplorer(LaunchType::FILE);
 		if (path != NULLSTR) {
 			const std::string patched_n64 = std::string(patched_rom);


### PR DESCRIPTION
Previously said Master Quest rom would work, this removes that and replaces it with GameCube PAL.

Before:
![image](https://user-images.githubusercontent.com/60364512/168147374-a422caf3-af5e-4b7f-809a-0b00918df25d.png)

After:
![image](https://user-images.githubusercontent.com/60364512/168147352-717a7362-5cbb-4374-84eb-6204a81a747e.png)
