### PR TITLE
Use DX11 by default, if available

### DIFF
--- a/libultraship/libultraship/ConfigFile.cpp
+++ b/libultraship/libultraship/ConfigFile.cpp
@@ -72,7 +72,7 @@ namespace Ship {
 		(*this)["WINDOW"]["FULLSCREEN WIDTH"] = std::to_string(1920);
 		(*this)["WINDOW"]["FULLSCREEN HEIGHT"] = std::to_string(1080);
 		(*this)["WINDOW"]["FULLSCREEN"] = std::to_string(false);
-		(*this)["WINDOW"]["GFX BACKEND"] = "sdl";
+		(*this)["WINDOW"]["GFX BACKEND"] = "";
 
 		(*this)["KEYBOARD CONTROLLER BINDING 1"][STR(BTN_CRIGHT)] = std::to_string(0x14D);
 		(*this)["KEYBOARD CONTROLLER BINDING 1"][STR(BTN_CLEFT)] = std::to_string(0x14B);


### PR DESCRIPTION
This changes the default backend to an empty string, which means dx11 on Windows.

Why (compared to SDL+OpenGL)?

- Imgui can create windows outside the main window.
- Better performance, i.e. less CPU% and GPU% usage. At least on my laptop with Intel / Nvidia optimus.
- Less and consistent input lag (up to 16.6 ms less on a 60 Hz monitor). This is due to DXGI gives better vsync capabilities to actually wait until the previous frame has been processed by the DWM or has been flipped if full screen. With OpenGL we can only guess when the vsync happens, which could be totally off (or we can push frames in a queue and let the video driver block at an arbitrary point, which usually leads to high input lag).

Other than that, the DXGI/DX11 backend should by now have the same features as SDL2/OpenGL.