### PR TITLE
ACTOR_EN_FLOORMAS splitting fix

### DIFF
--- a/soh/src/overlays/actors/ovl_En_Floormas/z_en_floormas.c
+++ b/soh/src/overlays/actors/ovl_En_Floormas/z_en_floormas.c
@@ -427,9 +427,8 @@ void EnFloormas_SetupFreeze(EnFloormas* this) {
 }
 
 void EnFloormas_Die(EnFloormas* this, GlobalContext* globalCtx) {
-    //Originally was doing > 0.004f that is not correct since apparently 
-    //that not 0.004f precisly therefore making a bit of size margin help.
-    if (this->actor.scale.x > 0.005f) {
+    //Originally was doing > 0.004f, better fix thanks Gary :D
+    if (this->actor.scale.x > (f32)0.004f) {
         // split
         this->actor.shape.rot.y = this->actor.yawTowardsPlayer + 0x8000;
         EnFloormas_SetupSplit((EnFloormas*)this->actor.child);

--- a/soh/src/overlays/actors/ovl_En_Floormas/z_en_floormas.c
+++ b/soh/src/overlays/actors/ovl_En_Floormas/z_en_floormas.c
@@ -427,7 +427,9 @@ void EnFloormas_SetupFreeze(EnFloormas* this) {
 }
 
 void EnFloormas_Die(EnFloormas* this, GlobalContext* globalCtx) {
-    if (this->actor.scale.x > 0.004f) {
+    //Originally was doing > 0.004f that is not correct since apparently 
+    //that not 0.004f precisly therefore making a bit of size margin help.
+    if (this->actor.scale.x > 0.005f) {
         // split
         this->actor.shape.rot.y = this->actor.yawTowardsPlayer + 0x8000;
         EnFloormas_SetupSplit((EnFloormas*)this->actor.child);


### PR DESCRIPTION
This fix the issues that the Hands enemies keep splitting preventing a chest to spawn a door to open and so be softlocked.
here the fix in action :

[Direct link(I'd prefer Zelda but okay) to webm](https://baoulettes.fr/Uploads/uz5phmudo7dcs5en0tl4ojqo4.webm)