### PR TITLE
Formatting of "D-pad" in Controller menu

### DIFF
--- a/libultraship/libultraship/SohImGuiImpl.cpp
+++ b/libultraship/libultraship/SohImGuiImpl.cpp
@@ -609,9 +609,9 @@ namespace SohImGui {
 
                 ImGui::Separator();
 
-                EnhancementCheckbox("Dpad Support on Pause and File Select", "gDpadPauseName");
-                EnhancementCheckbox("DPad Support in Ocarina and Text Choice", "gDpadOcarinaText");
-                EnhancementCheckbox("DPad Support for Browsing Shop Items", "gDpadShop");
+                EnhancementCheckbox("D-pad Support on Pause and File Select", "gDpadPauseName");
+                EnhancementCheckbox("D-pad Support in Ocarina and Text Choice", "gDpadOcarinaText");
+                EnhancementCheckbox("D-pad Support for Browsing Shop Items", "gDpadShop");
 
                 ImGui::EndMenu();
             }


### PR DESCRIPTION
Trash-tier PR, but the standard way to write "D-pad" is with a hyphen, and Shipwright currently uses both "pad" and "Pad" capitalizations. I standardized on "D-pad" based on a Google search for ["d-pad" site:nintendo.com](https://www.google.com/search?q="d-pad"+site%3Anintendo.com).

Even Nintendo's web site uses both, but the "D-pad" capitalization is far more common at Nintendo.com. Most uses of "D-Pad" with an upper-case P seem to come from sources that aren't written by Nintendo (e.g. a few product descriptions for licensed Switch controllers and eShop games), while pages written by Nintendo themselves (e.g. manuals for the NES and SNES Classics, gameplay help pages, etc.) use the lower-case P.

I have no attachment to any specific capitalization, but if nothing else it looks cleaner sticking to the same one throughout.

