### PR TITLE
Update BUILDING and README text

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -41,9 +41,9 @@ cp /usr/local/lib/libGLEW.a external
 
 cd soh
 # Extract the assets/Compile the exporter/Run the exporter
-make setup -j$(nproc) OPTFLAGS=-O0 DEBUG=0
+make setup -j$(nproc) OPTFLAGS=-O2 DEBUG=0
 # Compile the code
-make -j $(nproc) OPTFLAGS=-O0 DEBUG=0
+make -j $(nproc) OPTFLAGS=-O2 DEBUG=0
 ```
 
 # Compatible Roms

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The Ship does not include assets and as such requires a prior copy of the game t
 2) Requires a supported copy of the game (See supported games below).
 3) Use the OTRGui to generate an `oot.otr` archive file.
 4) Launch `soh.exe`
+5) Press F1 to view the menu bar and access all neat features.
 
 ### Supported Games
 Ocarina of Time Debug (not Master Quest)


### PR DESCRIPTION
Added 5th step mentioning how to view the menu bar by pressing F1, and added -O2 optimization flag in the Linux building instructions after Emil's fix #342