### PR TITLE
set menubar to open by default

### DIFF
--- a/libultraship/libultraship/SohImGuiImpl.cpp
+++ b/libultraship/libultraship/SohImGuiImpl.cpp
@@ -520,7 +520,7 @@ namespace SohImGui {
         ImGuiWindowFlags window_flags = ImGuiWindowFlags_NoDocking | ImGuiWindowFlags_NoBackground |
             ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoMove |
             ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoNavFocus | ImGuiWindowFlags_NoResize;
-        if (CVar_GetS32("gOpenMenuBar", 0)) window_flags |= ImGuiWindowFlags_MenuBar;
+        if (CVar_GetS32("gOpenMenuBar", 1)) window_flags |= ImGuiWindowFlags_MenuBar;
 
         const ImGuiViewport* viewport = ImGui::GetMainViewport();
         ImGui::SetNextWindowPos(viewport->WorkPos);


### PR DESCRIPTION
based on https://github.com/HarbourMasters/Shipwright/pull/351#issuecomment-1127069011

when there is no `cvars.cfg`, default to having the menubar open.