### PR TITLE
Remove -Werror from Makefile

### DIFF
--- a/libultraship/Makefile
+++ b/libultraship/Makefile
@@ -10,7 +10,7 @@ DEBUG ?= 1
 OPTFLAGS ?= -O0
 LTO ?= 0
 
-WARN := -Wall -Wextra -Werror \
+WARN := -Wall -Wextra \
 	-Wno-unused-variable \
 	-Wno-unused-parameter \
 	-Wno-unused-function \


### PR DESCRIPTION
All warnings should not be treated as errors. 

`libultraship/Lib/ImGui/imgui_widgets.cpp: In function ‘bool ImGui::TempInputScalar(const ImRect&, ImGuiID, const char*, ImGuiDataType, void*, const char*, const void*, const void*)’:
libultraship/Lib/ImGui/imgui_widgets.cpp:3350:67: error: bitwise operation between different enumeration types ‘ImGuiInputTextFlags_’ and ‘ImGuiInputTextFlagsPrivate_’ is deprecated [-Werror=deprecated-enum-enum-conversion]
 3350 |     ImGuiInputTextFlags flags = ImGuiInputTextFlags_AutoSelectAll | ImGuiInputTextFlags_NoMarkEdited;
      |                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
libultraship/Lib/ImGui/imgui_widgets.cpp: In function ‘bool ImGui::CollapsingHeader(const char*, bool*, ImGuiTreeNodeFlags)’:
libultraship/Lib/ImGui/imgui_widgets.cpp:6116:54: error: bitwise operation between different enumeration types ‘ImGuiTreeNodeFlags_’ and ‘ImGuiTreeNodeFlagsPrivate_’ is deprecated [-Werror=deprecated-enum-enum-conversion]
 6116 |         flags |= ImGuiTreeNodeFlags_AllowItemOverlap | ImGuiTreeNodeFlags_ClipLabelForTrailingButton;
      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
make[2]: *** [Makefile:88: build/libultraship/Lib/ImGui/imgui_widgets.o] Error 1`