### PR TITLE
DEV Tool : Fast Save Loading

### DIFF
--- a/libultraship/libultraship/SohImGuiImpl.cpp
+++ b/libultraship/libultraship/SohImGuiImpl.cpp
@@ -777,9 +777,9 @@ namespace SohImGui {
                 EnhancementCheckbox("OoT Debug Mode", "gDebugEnabled");
                 Tooltip("Enables Debug Mode, allowing you to select maps with L + R + Z, noclip with L + D-pad Right,\nand open the debug menu with L on the pause screen");
                 EnhancementCheckbox("Fast File Select", "gSkipLogoTitle");
-                Tooltip("Directly load the game to selected slot bellow\nUse slot number 4 to load directly in Zelda Map Select\n(Do not require debug menu but you will be unable to save there)\n(you can also load Zelda map select with Debug mod + slot 0).");
+                Tooltip("Directly load the game to selected slot bellow\nUse slot number 4 to load directly in Zelda Map Select\n(Do not require debug menu but you will be unable to save there)\n(you can also load Zelda map select with Debug mod + slot 0).\nWith Slot : 0 you can go directly in File Select menu\nAttention, Loading an empty save will result in crash");
                 if (CVar_GetS32("gSkipLogoTitle",0)) {
-                    EnhancementSliderInt("Save file to load: %d", "##SaveFileID", "gSaveFileID", 1, 4, "");
+                    EnhancementSliderInt("Loading %d", "##SaveFileID", "gSaveFileID", 0, 4, "");
                 }
 		ImGui::Separator();
                 EnhancementCheckbox("Stats", "gStatsEnabled");

--- a/libultraship/libultraship/SohImGuiImpl.cpp
+++ b/libultraship/libultraship/SohImGuiImpl.cpp
@@ -776,7 +776,12 @@ namespace SohImGui {
             {
                 EnhancementCheckbox("OoT Debug Mode", "gDebugEnabled");
                 Tooltip("Enables Debug Mode, allowing you to select maps with L + R + Z, noclip with L + D-pad Right,\nand open the debug menu with L on the pause screen");
-                ImGui::Separator();
+                EnhancementCheckbox("Fast File Select", "gSkipLogoTitle");
+                Tooltip("Directly load the game to selected slot bellow\nUse slot number 4 to load directly in Zelda Map Select\n(Do not require debug menu but you will be unable to save there)\n(you can also load Zelda map select with Debug mod + slot 0).");
+                if (CVar_GetS32("gSkipLogoTitle",0)) {
+                    EnhancementSliderInt("Save file to load: %d", "##SaveFileID", "gSaveFileID", 1, 4, "");
+                }
+		ImGui::Separator();
                 EnhancementCheckbox("Stats", "gStatsEnabled");
                 Tooltip("Shows the stats window, with your FPS and frametimes, and the OS you're playing on");
                 EnhancementCheckbox("Console", "gConsoleEnabled");

--- a/soh/src/overlays/gamestates/ovl_title/z_title.c
+++ b/soh/src/overlays/gamestates/ovl_title/z_title.c
@@ -223,17 +223,24 @@ void Title_Main(GameState* thisx) {
     TitleContext* this = (TitleContext*)thisx;
 
     if (CVar_GetS32("gSkipLogoTitle",0)!=0) {
+        gSaveContext.language = CVar_GetS32("gLanguages", 0);
         Sram_InitSram(&this->state, &this->sramCtx);
         s16 selectedfile = CVar_GetS32("gSaveFileID", 0);
         if (selectedfile == 4) {
             selectedfile = 0xFF;
+        } else if(selectedfile == 0){
+            gSaveContext.fileNum = selectedfile;
+            gSaveContext.gameMode = 0;
+            this->state.running = false;
+            SET_NEXT_GAMESTATE(&this->state, FileChoose_Init, SelectContext);
+            return;
         } else {
             selectedfile--;
             if (selectedfile < 0) {
                 selectedfile = 0xFF;
             }
         }
-        if (selectedfile == 0 && CVar_GetS32("gDebugEnabled", 0) || selectedfile == 0xFF) {
+        if (selectedfile == 0xFF) {
             gSaveContext.fileNum = selectedfile;
             Sram_OpenSave(&this->sramCtx);
             gSaveContext.gameMode = 0;
@@ -244,6 +251,7 @@ void Title_Main(GameState* thisx) {
             Sram_OpenSave(&this->sramCtx);
             gSaveContext.gameMode = 0;
             this->state.running = false;
+            //return;
             SET_NEXT_GAMESTATE(&this->state, Gameplay_Init, GlobalContext);
         }
         gSaveContext.respawn[0].entranceIndex = -1;
@@ -277,7 +285,6 @@ void Title_Main(GameState* thisx) {
         gSaveContext.magic = 0;
         gSaveContext.magicLevel = gSaveContext.magic;
         gSaveContext.naviTimer = 0;
-        //Properly exit the function to avoid issues with OPEN_DISP etc.
         return;
     }
 

--- a/soh/src/overlays/gamestates/ovl_title/z_title.c
+++ b/soh/src/overlays/gamestates/ovl_title/z_title.c
@@ -222,6 +222,65 @@ void Title_Draw(TitleContext* this) {
 void Title_Main(GameState* thisx) {
     TitleContext* this = (TitleContext*)thisx;
 
+    if (CVar_GetS32("gSkipLogoTitle",0)!=0) {
+        Sram_InitSram(&this->state, &this->sramCtx);
+        s16 selectedfile = CVar_GetS32("gSaveFileID", 0);
+        if (selectedfile == 4) {
+            selectedfile = 0xFF;
+        } else {
+            selectedfile--;
+            if (selectedfile < 0) {
+                selectedfile = 0xFF;
+            }
+        }
+        if (selectedfile == 0 && CVar_GetS32("gDebugEnabled", 0) || selectedfile == 0xFF) {
+            gSaveContext.fileNum = selectedfile;
+            Sram_OpenSave(&this->sramCtx);
+            gSaveContext.gameMode = 0;
+            this->state.running = false;
+            SET_NEXT_GAMESTATE(&this->state, Select_Init, SelectContext);
+        } else {
+            gSaveContext.fileNum = selectedfile;
+            Sram_OpenSave(&this->sramCtx);
+            gSaveContext.gameMode = 0;
+            this->state.running = false;
+            SET_NEXT_GAMESTATE(&this->state, Gameplay_Init, GlobalContext);
+        }
+        gSaveContext.respawn[0].entranceIndex = -1;
+        gSaveContext.respawnFlag = 0;
+        gSaveContext.seqId = (u8)NA_BGM_DISABLED;
+        gSaveContext.natureAmbienceId = 0xFF;
+        gSaveContext.showTitleCard = true;
+        gSaveContext.dogParams = 0;
+        gSaveContext.timer1State = 0;
+        gSaveContext.timer2State = 0;
+        gSaveContext.eventInf[0] = 0;
+        gSaveContext.eventInf[1] = 0;
+        gSaveContext.eventInf[2] = 0;
+        gSaveContext.eventInf[3] = 0;
+        gSaveContext.unk_13EE = 0x32;
+        gSaveContext.nayrusLoveTimer = 0;
+        gSaveContext.healthAccumulator = 0;
+        gSaveContext.unk_13F0 = 0;
+        gSaveContext.unk_13F2 = 0;
+        gSaveContext.forcedSeqId = NA_BGM_GENERAL_SFX;
+        gSaveContext.skyboxTime = 0;
+        gSaveContext.nextTransition = 0xFF;
+        gSaveContext.nextCutsceneIndex = 0xFFEF;
+        gSaveContext.cutsceneTrigger = 0;
+        gSaveContext.chamberCutsceneNum = 0;
+        gSaveContext.nextDayTime = 0xFFFF;
+        gSaveContext.unk_13C3 = 0;
+        gSaveContext.buttonStatus[0] = gSaveContext.buttonStatus[1] = gSaveContext.buttonStatus[2] = gSaveContext.buttonStatus[3] = gSaveContext.buttonStatus[4] = BTN_ENABLED;
+        gSaveContext.unk_13E7 = gSaveContext.unk_13E8 = gSaveContext.unk_13EA = gSaveContext.unk_13EC = gSaveContext.unk_13F4 = 0;
+        gSaveContext.unk_13F6 = gSaveContext.magic;
+        gSaveContext.magic = 0;
+        gSaveContext.magicLevel = gSaveContext.magic;
+        gSaveContext.naviTimer = 0;
+        //Properly exit the function to avoid issues with OPEN_DISP etc.
+        return;
+    }
+
     OPEN_DISPS(this->state.gfxCtx, "../z_title.c", 494);
 
     gSPSegment(POLY_OPA_DISP++, 0, NULL);


### PR DESCRIPTION
This add an option in dev toolbar, you will be able to skip both N64 logo, Opening Scene and File select scene to directly load a save
This is not a Enhancement, this is made to help DEV to go in ZELDA MAP SELECT faster or load specific slot and test their feature faster.

For a video example : 
[Discord video in message](https://discord.com/channels/808039310850130000/955997420288888902/976177247063007232)

Informations : 
Slod 4 Always mean Zelda Map Select even without Debug mod. 
Slot 4 = 0xFF aka the save used for Debug Mode.
Loading slot 0 with Debug Mode on will bring you Zelda Map Select and load Debug mode on your save (becareful there)
Slot 1 and 2 with debut behave normally
with debug mode these two slot will load normally just with debug mode enabled.

Always backup your saves if you mess with debug mode or slot 4. 

without debug mode and save slot 1 , 2 and 3 it should be as if you loaded your save from file select menu and you should be able to play normally.