### PR TITLE
Pretty fps counter

### DIFF
--- a/libultraship/libultraship/SohImGuiImpl.cpp
+++ b/libultraship/libultraship/SohImGuiImpl.cpp
@@ -812,6 +812,24 @@ namespace SohImGui {
                 ImGui::EndMenu();
             }
 
+            bool FPSCounter_isOpen = CVar_GetS32("gDebugFPSCounterEnabled", 0);
+            if (FPSCounter_isOpen) {
+                if (!FPSCounter_isOpen) {
+                    return;
+                }
+                ImGuiWindowFlags window_flags = ImGuiWindowFlags_NoDocking | ImGuiWindowFlags_NoBackground |
+                ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_AlwaysAutoResize |
+                ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoScrollbar |
+                ImGuiWindowFlags_NoFocusOnAppearing;
+                ImGui::Begin("FPSCounter", nullptr, window_flags);
+                const float framerate = ImGui::GetIO().Framerate;
+                float PosX = CVar_GetS32("gFPSCounterPosX", 0);
+                float PosY = CVar_GetS32("gFPSCounterPosY", 0);
+                ImGui::SetWindowPos(ImVec2{PosX,PosY},0);
+                SohImGui::overlay->TextDraw(0,0,true,ImVec4{FPSCounter[0],FPSCounter[1],FPSCounter[2],FPSCounter[3]}," %.1f FPS", framerate);
+                ImGui::End();
+            }
+
             for (const auto& category : windowCategories) {
                 if (ImGui::BeginMenu(category.first.c_str())) {
                     for (const std::string& name : category.second) {

--- a/libultraship/libultraship/SohImGuiImpl.cpp
+++ b/libultraship/libultraship/SohImGuiImpl.cpp
@@ -505,6 +505,22 @@ namespace SohImGui {
         }
     }
 
+    void EnhancementColor4(std::string text, std::string cvarName, float ColorRGBA[4], bool TitleSameLine) {
+        //If you do not need Alpha channel use 3 Variant !
+        ImGuiColorEditFlags flags = ImGuiColorEditFlags_None;
+        if (!TitleSameLine){
+            ImGui::Text("%s", text.c_str());
+            flags = ImGuiColorEditFlags_NoLabel;
+        }
+        if (ImGui::ColorEdit4(text.c_str(), ColorRGBA, flags)) {
+            CVar_SetS32((cvarName+"R").c_str(), ClampFloatToInt(ColorRGBA[0]*255,0,255));
+            CVar_SetS32((cvarName+"G").c_str(), ClampFloatToInt(ColorRGBA[1]*255,0,255));
+            CVar_SetS32((cvarName+"B").c_str(), ClampFloatToInt(ColorRGBA[2]*255,0,255));
+            CVar_SetS32((cvarName+"A").c_str(), ClampFloatToInt(ColorRGBA[3]*255,0,255));
+            needs_save = true;
+        }
+    }
+
     void Tooltip(std::string text) {
         if (ImGui::IsItemHovered())
             ImGui::SetTooltip("%s", text.c_str());
@@ -774,6 +790,16 @@ namespace SohImGui {
 
             if (ImGui::BeginMenu("Developer Tools"))
             {
+                if (ImGui::BeginMenu("FPS Counter")) {
+                    EnhancementCheckbox("Show FPS counter", "gDebugFPSCounterEnabled");
+                    Tooltip("FPS Counter for PC Master Race users.");
+                    EnhancementColor4("FPS Counter color", "gFPSCounter", FPSCounter, false);
+                    ImGui::Separator();
+                    ImGui::Text("Position");
+                    EnhancementSliderInt("Top | Bottom : %d", "##FPSCounterPosY", "gFPSCounterPosY", 0, gfx_current_game_window_viewport.height, "");
+                    EnhancementSliderInt("Left | Right : %d", "##FPSCounterPosX", "gFPSCounterPosX", -5, gfx_current_game_window_viewport.width, "");
+                    ImGui::EndMenu();
+                }
                 EnhancementCheckbox("OoT Debug Mode", "gDebugEnabled");
                 Tooltip("Enables Debug Mode, allowing you to select maps with L + R + Z, noclip with L + D-pad Right,\nand open the debug menu with L on the pause screen");
                 ImGui::Separator();

--- a/libultraship/libultraship/SohImGuiImpl.h
+++ b/libultraship/libultraship/SohImGuiImpl.h
@@ -68,7 +68,8 @@ namespace SohImGui {
     void EnhancementCheckbox(std::string text, std::string cvarName);
     void EnhancementSliderInt(std::string text, std::string id, std::string cvarName, int min, int max, std::string format);
     void EnhancementSliderFloat(std::string text, std::string id, std::string cvarName, float min, float max, std::string format, float defaultValue);
-
+    void EnhancementColor4(std::string text, std::string cvarName, float ColorRGBA[4], bool TitleSameLine);
+    
     void DrawMainMenuAndCalculateGameSize(void);
     
     void DrawFramebufferAndGameInput(void);


### PR DESCRIPTION
Do you want to have these fancy FPS showing now that we have 60fps ?!
Say no more.

This add an option in DEV tab to show an FPS counter with the color and position you wish.
Since the game do not save your window size that not saving correctly if you put it on the right side etc. but once SOH save your window size this mod will also save it's position properly.

If you want to edit the transparency right click on the color selector and tick Alpha bar :) 
I use this mods to ensure my mods do not bring lags that why it is in dev menu.

![HelpMyImageHasNoName](https://baoulettes.fr/Uploads/1w7pu33v5ewjimbbvdnjqa4uw.png)

Require : #202 