### PR TITLE
Init desired languages CVar on InitSram

### DIFF
--- a/soh/src/code/z_sram.c
+++ b/soh/src/code/z_sram.c
@@ -836,7 +836,7 @@ void Sram_InitSram(GameState* gameState, SramContext* sramCtx) {
     for (i = 0; i < ARRAY_COUNTU(sZeldaMagic) - 3; i++) {
         if (sZeldaMagic[i + SRAM_HEADER_MAGIC] != sramCtx->readBuff[i + SRAM_HEADER_MAGIC]) {
             osSyncPrintf("ＳＲＡＭ破壊！！！！！！\n"); // "SRAM destruction! ! ! ! ! !"
-            gSaveContext.language = sramCtx->readBuff[SRAM_HEADER_LANGUAGE];
+            gSaveContext.language = = CVar_GetS32("gLanguages", 0);
             memcpy(sramCtx->readBuff, sZeldaMagic, sizeof(sZeldaMagic));
             sramCtx->readBuff[SRAM_HEADER_LANGUAGE] = gSaveContext.language;
             Sram_WriteSramHeader(sramCtx);
@@ -845,7 +845,7 @@ void Sram_InitSram(GameState* gameState, SramContext* sramCtx) {
 
     gSaveContext.audioSetting = sramCtx->readBuff[SRAM_HEADER_SOUND] & 3;
     gSaveContext.zTargetSetting = sramCtx->readBuff[SRAM_HEADER_ZTARGET] & 1;
-    gSaveContext.language = sramCtx->readBuff[SRAM_HEADER_LANGUAGE];
+    gSaveContext.language = = CVar_GetS32("gLanguages", 0);
 
     if (gSaveContext.language >= LANGUAGE_MAX) {
         gSaveContext.language = LANGUAGE_ENG;

--- a/soh/src/code/z_sram.c
+++ b/soh/src/code/z_sram.c
@@ -836,7 +836,7 @@ void Sram_InitSram(GameState* gameState, SramContext* sramCtx) {
     for (i = 0; i < ARRAY_COUNTU(sZeldaMagic) - 3; i++) {
         if (sZeldaMagic[i + SRAM_HEADER_MAGIC] != sramCtx->readBuff[i + SRAM_HEADER_MAGIC]) {
             osSyncPrintf("ＳＲＡＭ破壊！！！！！！\n"); // "SRAM destruction! ! ! ! ! !"
-            gSaveContext.language = = CVar_GetS32("gLanguages", 0);
+            gSaveContext.language = CVar_GetS32("gLanguages", 0);
             memcpy(sramCtx->readBuff, sZeldaMagic, sizeof(sZeldaMagic));
             sramCtx->readBuff[SRAM_HEADER_LANGUAGE] = gSaveContext.language;
             Sram_WriteSramHeader(sramCtx);
@@ -845,7 +845,7 @@ void Sram_InitSram(GameState* gameState, SramContext* sramCtx) {
 
     gSaveContext.audioSetting = sramCtx->readBuff[SRAM_HEADER_SOUND] & 3;
     gSaveContext.zTargetSetting = sramCtx->readBuff[SRAM_HEADER_ZTARGET] & 1;
-    gSaveContext.language = = CVar_GetS32("gLanguages", 0);
+    gSaveContext.language = CVar_GetS32("gLanguages", 0);
 
     if (gSaveContext.language >= LANGUAGE_MAX) {
         gSaveContext.language = LANGUAGE_ENG;


### PR DESCRIPTION
with my pr #369 
I noticed that if you play in French or German and instantly load your save file while having #380 activated 
TitleCard remain in English, tracking it down a bit seem like it was not Init properly.

This should be pretty safe since it make a check with LANGUAGE_MAX this would not try to load a language we do not have :)
Here a PR that fix it or lead to was wrong but with it in this specific configuration or normal player with these two PR it work fine