### PR TITLE
Add rainbow options for tunics

### DIFF
--- a/libultraship/libultraship/SohImGuiImpl.cpp
+++ b/libultraship/libultraship/SohImGuiImpl.cpp
@@ -724,8 +724,15 @@ namespace SohImGui {
                 ImGui::Separator();
 
                 EnhancementColor3("Kokiri Tunic", "gTunic_Kokiri", kokiri_col);
+                ImGui::SameLine();
+                EnhancementCheckbox("Rainbow##Kokiri", "gTunic_KokiriRainbow");
                 EnhancementColor3("Goron Tunic", "gTunic_Goron", goron_col);
+                ImGui::SameLine();
+                EnhancementCheckbox("Rainbow##Goron", "gTunic_GoronRainbow");
                 EnhancementColor3("Zora Tunic", "gTunic_Zora", zora_col);
+                ImGui::SameLine();
+                EnhancementCheckbox("Rainbow##Zora", "gTunic_ZoraRainbow");
+                EnhancementSliderInt("Rainbow Speed: %dx", "##RainbowTunicSpeed", "gTunic_RainbowSpeed", 1, 6, "");
 
                 ImGui::Text("Navi");
                 ImGui::Separator();

--- a/libultraship/libultraship/SohImGuiImpl.cpp
+++ b/libultraship/libultraship/SohImGuiImpl.cpp
@@ -828,6 +828,15 @@ namespace SohImGui {
             ImGui::PopStyleColor();
         }
 
+        if ((CVar_GetS32("gTunic_KokiriRainbow", 0) | CVar_GetS32("gTunic_GoronRainbow", 0) |CVar_GetS32("gTunic_ZoraRainbow", 0)) != 0) {
+            const f32 deltaTime = 1.0f / ImGui::GetIO().Framerate;
+            f32 hue = CVar_GetFloat("gTunic_RainbowHue", 0.0f);
+            f32 newHue = hue + CVar_GetS32("gTunic_RainbowSpeed", 1) * 36.0f * deltaTime;
+            if (newHue >= 360)
+                newHue = 0;
+            CVar_SetFloat("gTunic_RainbowHue", newHue);
+        }
+
         console->Draw();
 
         for (auto& windowIter : customWindows) {

--- a/soh/src/code/z_player_lib.c
+++ b/soh/src/code/z_player_lib.c
@@ -753,30 +753,17 @@ void func_8008F470(GlobalContext* globalCtx, void** skeleton, Vec3s* jointTable,
         u16 hueDelta = CVar_GetS32("gTunic_RainbowSpeed", 1) * 36.0f / 20.0f; 
         CVar_SetS32("gTunic_RainbowHue", (hue + hueDelta) % 360);
 
-        if (hue < 60) {
-            color->r = 255;
-            color->g = (hue / 60.0f) * 255;
-            color->b = 0;
-        } else if (hue < 120) {
-            color->r = (-hue / 60.0f + 2.0f) * 255;
-            color->g = 255;
-            color->b = 0;
-        } else if (hue < 180) {
-            color->r = 0;
-            color->g = 255;
-            color->b = (hue / 60.0f - 2.0f) * 255;
-        } else if (hue < 240) {
-            color->r = 0;
-            color->g = (-hue / 60.0f + 4.0f) * 255;
-            color->b = 255;
-        } else if (hue < 300) {
-            color->r = (hue / 60.0f - 4.0f) * 255;
-            color->g = 0;
-            color->b = 255;
-        } else {
-            color->r = 255;
-            color->g = 0;
-            color->b = (-hue / 60.0f + 6.0f) * 255;
+        u8 i = hue / 60 + 1;
+        u8 a = (-hue / 60.0f + i) * 255;
+        u8 b = (hue / 60.0f + (1 - i)) * 255;
+
+        switch (i) {
+            case 1: color->r = 255; color->g = b; color->b = 0; break;
+            case 2: color->r = a; color->g = 255; color->b = 0; break;
+            case 3: color->r = 0; color->g = 255; color->b = b; break;
+            case 4: color->r = 0; color->g = a; color->b = 255; break;
+            case 5: color->r = b; color->g = 0; color->b = 255; break;
+            case 6: color->r = 255; color->g = 0; color->b = a; break;
         }
     }
     else if (tunic == PLAYER_TUNIC_KOKIRI) {

--- a/soh/src/code/z_player_lib.c
+++ b/soh/src/code/z_player_lib.c
@@ -749,10 +749,7 @@ void func_8008F470(GlobalContext* globalCtx, void** skeleton, Vec3s* jointTable,
     if (tunic == PLAYER_TUNIC_KOKIRI && CVar_GetS32("gTunic_KokiriRainbow", 0) != 0 || 
         tunic == PLAYER_TUNIC_GORON && CVar_GetS32("gTunic_GoronRainbow", 0) != 0 ||
         tunic == PLAYER_TUNIC_ZORA && CVar_GetS32("gTunic_ZoraRainbow", 0) != 0) {
-        u16 hue = CVar_GetS32("gTunic_RainbowHue", 0);
-        u16 hueDelta = CVar_GetS32("gTunic_RainbowSpeed", 1) * 36.0f / 20.0f; 
-        CVar_SetS32("gTunic_RainbowHue", (hue + hueDelta) % 360);
-
+        f32 hue = CVar_GetFloat("gTunic_RainbowHue", 0);
         u8 i = hue / 60 + 1;
         u8 a = (-hue / 60.0f + i) * 255;
         u8 b = (hue / 60.0f + (1 - i)) * 255;

--- a/soh/src/code/z_player_lib.c
+++ b/soh/src/code/z_player_lib.c
@@ -746,7 +746,40 @@ void func_8008F470(GlobalContext* globalCtx, void** skeleton, Vec3s* jointTable,
 #endif
     Color_RGB8 sTemp;
     color = &sTemp;
-    if (tunic == PLAYER_TUNIC_KOKIRI) {
+    if (tunic == PLAYER_TUNIC_KOKIRI && CVar_GetS32("gTunic_KokiriRainbow", 0) != 0 || 
+        tunic == PLAYER_TUNIC_GORON && CVar_GetS32("gTunic_GoronRainbow", 0) != 0 ||
+        tunic == PLAYER_TUNIC_ZORA && CVar_GetS32("gTunic_ZoraRainbow", 0) != 0) {
+        u16 hue = CVar_GetS32("gTunic_RainbowHue", 0);
+        u16 hueDelta = CVar_GetS32("gTunic_RainbowSpeed", 1) * 36.0f / 20.0f; 
+        CVar_SetS32("gTunic_RainbowHue", (hue + hueDelta) % 360);
+
+        if (hue < 60) {
+            color->r = 255;
+            color->g = (hue / 60.0f) * 255;
+            color->b = 0;
+        } else if (hue < 120) {
+            color->r = (-hue / 60.0f + 2.0f) * 255;
+            color->g = 255;
+            color->b = 0;
+        } else if (hue < 180) {
+            color->r = 0;
+            color->g = 255;
+            color->b = (hue / 60.0f - 2.0f) * 255;
+        } else if (hue < 240) {
+            color->r = 0;
+            color->g = (-hue / 60.0f + 4.0f) * 255;
+            color->b = 255;
+        } else if (hue < 300) {
+            color->r = (hue / 60.0f - 4.0f) * 255;
+            color->g = 0;
+            color->b = 255;
+        } else {
+            color->r = 255;
+            color->g = 0;
+            color->b = (-hue / 60.0f + 6.0f) * 255;
+        }
+    }
+    else if (tunic == PLAYER_TUNIC_KOKIRI) {
         color->r = CVar_GetS32("gTunic_Kokiri_Red", sTunicColors[PLAYER_TUNIC_KOKIRI].r);
         color->g = CVar_GetS32("gTunic_Kokiri_Green", sTunicColors[PLAYER_TUNIC_KOKIRI].g);
         color->b = CVar_GetS32("gTunic_Kokiri_Blue", sTunicColors[PLAYER_TUNIC_KOKIRI].b);


### PR DESCRIPTION
This adds a rainbow option for Link's tunics. The option can be toggled for all tunics, none, or some. The speed of the color cycle can be set from 1 to 6 times the base speed, which is around 1 cycle per 10 seconds (unless paused).
![rainbow-tunic-menu](https://user-images.githubusercontent.com/30988624/169421168-cbb2bb37-f5d8-4384-9d86-2939c6750b01.png)
![rainbow-tunic-showcase](https://user-images.githubusercontent.com/30988624/169421185-2df041d9-4d38-4845-84ac-63517c5e6615.gif)

