### PR TITLE
[Mod]Max health modifier

### DIFF
--- a/libultraship/libultraship/SohImGuiImpl.cpp
+++ b/libultraship/libultraship/SohImGuiImpl.cpp
@@ -663,6 +663,10 @@ namespace SohImGui {
             {
                 if (ImGui::BeginMenu("Gameplay"))
                 {
+                    EnhancementCheckbox("Force Max heart", "gForceMaxHeartCount");
+                    if(CVar_GetS32("gForceMaxHeartCount",0)){
+                        EnhancementSliderInt("Link maximum hearts %dx", "##HEARTSCOUNT", "gMaxHeartCount", 0, 20, "");
+                    }
                     EnhancementSliderInt("Text Speed: %dx", "##TEXTSPEED", "gTextSpeed", 1, 5, "");
                     EnhancementSliderInt("King Zora Speed: %dx", "##WEEPSPEED", "gMweepSpeed", 1, 5, "");
 

--- a/soh/src/code/z_lifemeter.c
+++ b/soh/src/code/z_lifemeter.c
@@ -305,10 +305,12 @@ void HealthMeter_Draw(GlobalContext* globalCtx) {
     f32 temp4;
     InterfaceContext* interfaceCtx = &globalCtx->interfaceCtx;
     GraphicsContext* gfxCtx = globalCtx->state.gfxCtx;
+    s16 MaxHeartsCount = gSaveContext.healthCapacity;
+    s16 HealthNow = gSaveContext.health;
     Vtx* sp154 = interfaceCtx->beatingHeartVtx;
-    s32 curHeartFraction = gSaveContext.health % 0x10;
-    s16 totalHeartCount = gSaveContext.healthCapacity / 0x10;
-    s16 fullHeartCount = gSaveContext.health / 0x10;
+    s32 curHeartFraction = HealthNow % 0x10;
+    s16 totalHeartCount = MaxHeartsCount / 0x10;
+    s16 fullHeartCount = HealthNow / 0x10;
     s32 pad2;
     f32 sp144 = interfaceCtx->unk_22A * 0.1f;
     s32 curCombineModeSet = 0;

--- a/soh/src/code/z_lifemeter.c
+++ b/soh/src/code/z_lifemeter.c
@@ -317,6 +317,32 @@ void HealthMeter_Draw(GlobalContext* globalCtx) {
 
     OPEN_DISPS(gfxCtx, "../z_lifemeter.c", 353);
 
+    if (CVar_GetS32("gForceMaxHeartCount", 0)) {
+        MaxHeartsCount = CVar_GetS32("gMaxHeartCount", gSaveContext.healthCapacity)*16; //16 is what a full heart is
+        if (MaxHeartsCount < 4) { //1/4 of an heart.
+            MaxHeartsCount = 16; //prevent some glitch like infinite breath.
+            HealthNow = 4;
+        }
+        if (MaxHeartsCount > gSaveContext.healthCapacity) {
+            MaxHeartsCount = gSaveContext.healthCapacity;
+        }   
+        if (HealthNow > MaxHeartsCount) {
+            HealthNow = MaxHeartsCount;
+            gSaveContext.health = HealthNow;
+        }
+        curHeartFraction = HealthNow % 0x10;
+        totalHeartCount = MaxHeartsCount / 0x10;
+        fullHeartCount = HealthNow / 0x10;
+    } else {
+        MaxHeartsCount = gSaveContext.healthCapacity;
+        if (HealthNow > MaxHeartsCount) {
+            HealthNow = MaxHeartsCount;
+        }
+        curHeartFraction = HealthNow % 0x10;
+        totalHeartCount = MaxHeartsCount / 0x10;
+        fullHeartCount = HealthNow / 0x10;
+    }
+
     if (!(gSaveContext.health % 0x10)) {
         fullHeartCount--;
     }
@@ -514,15 +540,53 @@ void HealthMeter_HandleCriticalAlarm(GlobalContext* globalCtx) {
 
 u32 HealthMeter_IsCritical(void) {
     s32 var;
+    s16 MaxHeartsCount = gSaveContext.healthCapacity;
+    s16 HealthNow = gSaveContext.health;
 
-    if (gSaveContext.healthCapacity <= 0x50) {
-        var = 0x10;
-    } else if (gSaveContext.healthCapacity <= 0xA0) {
-        var = 0x18;
-    } else if (gSaveContext.healthCapacity <= 0xF0) {
-        var = 0x20;
+    if (CVar_GetS32("gForceMaxHeartCount", 0)) {
+        MaxHeartsCount = CVar_GetS32("gMaxHeartCount", gSaveContext.healthCapacity)*16; //16 is what a full heart is
+        if (MaxHeartsCount < 4) { //1/4 of an heart.
+            MaxHeartsCount = 16; //prevent some glitch like infinite breath.
+            HealthNow = 4;
+        }
+        if (MaxHeartsCount > gSaveContext.healthCapacity) {
+            MaxHeartsCount = gSaveContext.healthCapacity;
+        }   
+        if (HealthNow > MaxHeartsCount) {
+            HealthNow = MaxHeartsCount;
+            gSaveContext.health = HealthNow;
+        }
     } else {
-        var = 0x2C;
+        MaxHeartsCount = gSaveContext.healthCapacity;
+        if (HealthNow > MaxHeartsCount) {
+            HealthNow = MaxHeartsCount;
+        }
+    }
+
+    if (MaxHeartsCount <= 0x50) {
+        if (CVar_GetS32("gForceMaxHeartCount", 0)) {
+            var = 0;
+        } else {
+            var = 0x10;
+        }
+    } else if (MaxHeartsCount <= 0xA0) {
+        if (CVar_GetS32("gForceMaxHeartCount", 0)) {
+            var = 0;
+        } else {
+            var = 0x18;
+        }
+    } else if (MaxHeartsCount <= 0xF0) {
+        if (CVar_GetS32("gForceMaxHeartCount", 0)) {
+            var = 0;
+        } else {
+            var = 0x20;
+        }
+    } else {
+        if (CVar_GetS32("gForceMaxHeartCount", 0)) {
+            var = 0;
+        } else {
+            var = 0x2C;
+        }
     }
 
     if ((var >= gSaveContext.health) && (gSaveContext.health > 0)) {


### PR DESCRIPTION
As title say, this will allow to edit your maximum hearts count.
Not in the cheats method, this one allow to temporary lower your heart count, you can go higher than what you originally have.

What you can do :
Make your maximum heart count from 1/4 to your available save count (if you have 7 heart then your maximum is 7 even if you go higher)
It disable Link being tired when he is low life but keep the camera style ( I thought that playing with 1 heart make sense to have that)
With this you can make a one or 3 hearts challenge without having to toy around with save editor or avoid hearts, you can even use them to heal you how wonderful ?

How it work :
It edit value on memory and not save, this mean if you play with restricted hearts count and pickup hearts or heart pieces, it is properly saved in your save in case you want to disable the mods you will have your proper count.
Making it at one heart and going back to your original count will not heal you, in contrary it will put you at 1 heart (except if you interrupt it fast enough that the animation is not done.)
Make it at 0 will put you at 1/4 heart going back to 1 will heal you that heart cause that hard as it to have one heart (this is a fail safe there in case you slide too fast.)
Double defense work as intended.

Here some screen :
![Menu style](https://baoulettes.fr/Uploads/m8bh15oi0wx0z15fgbbyfcro6.png)
![One heart challenge](https://baoulettes.fr/Uploads/hu0x5sr8fjezdn80qsc35skly.png)