### PR TITLE
Fix L&Z Kaleido pages switch

### DIFF
--- a/libultraship/libultraship/SohImGuiImpl.cpp
+++ b/libultraship/libultraship/SohImGuiImpl.cpp
@@ -701,6 +701,8 @@ namespace SohImGui {
                 {
                     EnhancementCheckbox("Fix L&R Pause menu", "gUniformLR");
                     Tooltip("Makes the L and R buttons in the pause menu the same color");
+                    EnhancementCheckbox("Fix L&Z Page switch in Pause menu", "gNGCKaleidoSwitcher");
+                    Tooltip("Enabling it make L and R be your page switch like on Gamecube\nZ become the button to open Debug Menu");
                     EnhancementCheckbox("Fix Dungeon entrances", "gFixDungeonMinimapIcon");
                     Tooltip("Show dungeon entrances icon only when it should be");
                     EnhancementCheckbox("Fix Two Handed idle animations", "gTwoHandedIdle");

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_debug.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_debug.c
@@ -640,9 +640,13 @@ void KaleidoScope_DrawDebugEditor(GlobalContext* globalCtx) {
 
     // Handles exiting the inventory editor with the L button
     // The editor is opened with `debugState` set to 1, and becomes closable after a frame once `debugState` is set to 2
+    s16 Debug_BTN = BTN_L;
+    if (CVar_GetS32("gNGCKaleidoSwitcher", 0) != 1) {
+        Debug_BTN = BTN_Z;
+    }
     if (pauseCtx->debugState == 1) {
         pauseCtx->debugState = 2;
-    } else if ((pauseCtx->debugState == 2) && CHECK_BTN_ALL(input->press.button, BTN_L)) {
+    } else if ((pauseCtx->debugState == 2) && CHECK_BTN_ALL(input->press.button, Debug_BTN)) {
         pauseCtx->debugState = 0;
     }
 

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_debug.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_debug.c
@@ -641,7 +641,7 @@ void KaleidoScope_DrawDebugEditor(GlobalContext* globalCtx) {
     // Handles exiting the inventory editor with the L button
     // The editor is opened with `debugState` set to 1, and becomes closable after a frame once `debugState` is set to 2
     s16 Debug_BTN = BTN_L;
-    if (CVar_GetS32("gNGCKaleidoSwitcher", 0) != 1) {
+    if (CVar_GetS32("gNGCKaleidoSwitcher", 0) != 0) {
         Debug_BTN = BTN_Z;
     }
     if (pauseCtx->debugState == 1) {

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
@@ -930,7 +930,14 @@ void KaleidoScope_SwitchPage(PauseContext* pauseCtx, u8 pt) {
 }
 
 void KaleidoScope_HandlePageToggles(PauseContext* pauseCtx, Input* input) {
-    if (CVar_GetS32("gDebugEnabled", 0) && (pauseCtx->debugState == 0) && CHECK_BTN_ALL(input->press.button, BTN_L)) {
+    s16 Debug_BTN = BTN_L;
+    s16 PageLeft_BTN = BTN_Z;
+    if (CVar_GetS32("gNGCKaleidoSwitcher", 0) != 1) {
+        Debug_BTN = BTN_Z;
+        PageLeft_BTN = BTN_L;
+    }
+
+    if (CVar_GetS32("gDebugEnabled", 0) && (pauseCtx->debugState == 0) && CHECK_BTN_ALL(input->press.button, Debug_BTN)) {
         pauseCtx->debugState = 1;
         return;
     }
@@ -940,7 +947,7 @@ void KaleidoScope_HandlePageToggles(PauseContext* pauseCtx, Input* input) {
         return;
     }
 
-    if (CHECK_BTN_ALL(input->press.button, BTN_Z)) {
+    if (CHECK_BTN_ALL(input->press.button, PageLeft_BTN)) {
         KaleidoScope_SwitchPage(pauseCtx, 0);
         return;
     }

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
@@ -932,7 +932,7 @@ void KaleidoScope_SwitchPage(PauseContext* pauseCtx, u8 pt) {
 void KaleidoScope_HandlePageToggles(PauseContext* pauseCtx, Input* input) {
     s16 Debug_BTN = BTN_L;
     s16 PageLeft_BTN = BTN_Z;
-    if (CVar_GetS32("gNGCKaleidoSwitcher", 0) != 1) {
+    if (CVar_GetS32("gNGCKaleidoSwitcher", 0) != 0) {
         Debug_BTN = BTN_Z;
         PageLeft_BTN = BTN_L;
     }


### PR DESCRIPTION
It trigger me since the beginning.
We use N64 style to switch page and open debug menu 
Z to swipe left and L to open debug menu, while it was really logic for an N64 Controller (Z was pressed by left hand finger) that feel weird on modern controllers.
yet we use Gamecube visual.

This add a toggle (default off) to make the button the one used on Gamecube
L to swipe left and Z to open close the debug menu.
Enabling it will match the visual that is why I placed it on Fixes else that just a matter of preferences

It do not change the visual so no screenshots is needed :)