### PR TITLE
[LINUX] Add compiler flags to fix floating-point precision error

### DIFF
--- a/soh/Makefile
+++ b/soh/Makefile
@@ -18,8 +18,8 @@ WARN := \
 	-funsigned-char \
 	-m32 -mhard-float -fno-stack-protector -fno-common -fno-zero-initialized-in-bss -fno-strict-aliasing -fno-inline-functions -fno-inline-small-functions -fno-toplevel-reorder -ffreestanding -fwrapv \
 
-CXXFLAGS := $(WARN) -std=c++20 -D_GNU_SOURCE -fpermissive -no-pie -nostdlib -march=i386
-CFLAGS := $(WARN) -std=c99 -D_GNU_SOURCE -no-pie -nostdlib -march=i386
+CXXFLAGS := $(WARN) -std=c++20 -D_GNU_SOURCE -fpermissive -no-pie -nostdlib -march=i386 -msse2 -mfpmath=sse
+CFLAGS := $(WARN) -std=c99 -D_GNU_SOURCE -no-pie -nostdlib -march=i386 -msse2 -mfpmath=sse
 LDFLAGS := -m32
 CPPFLAGS := -MMD
 


### PR DESCRIPTION
These flags are known to fix one known issue exclusive to Linux: the Volvagia boss battle sequence. The softlock that occurs points towards a possible floating point precision error, possibly tied to the camera/Volvagia movement. This does not occur for the Windows build. It's possible that there are more issues that gets fixed by these flags. These flags will ensure that the compiler follows the IEEE 754 standard for floating-point arithmetic, which so happens to be the same behavior that Windows uses. For more details, read this informative stackoverflow post: https://stackoverflow.com/a/16395650