### PR TITLE
EnhancementColor3 tweak SohImGui Clean

### DIFF
--- a/libultraship/libultraship/SohImGuiImpl.cpp
+++ b/libultraship/libultraship/SohImGuiImpl.cpp
@@ -66,29 +66,29 @@ namespace SohImGui {
     std::vector<const char*> CustomTexts;
     int SelectedLanguage = CVar_GetS32("gLanguages", 0); //Default Language to 0=English 1=German 2=French
     int SelectedHUD = CVar_GetS32("gHudColors", 1);      //Default colors to Gamecube.
-    float hearts_colors[3] = {0,0,0};
-    float hearts_dd_colors[3] = {0,0,0};
-    float a_btn_colors[3] = {0,0,0};
-    float b_btn_colors[3] = {0,0,0};
-    float c_btn_colors[3] = {0,0,0};
-    float start_btn_colors[3] = {0,0,0};
-    float magic_border_colors[3] = {0,0,0};
-    float magic_remaining_colors[3] = {0,0,0};
-    float magic_use_colors[3] = {0,0,0};
-    float minimap_colors[3] = {0,0,0};
-    float rupee_colors[3] = {0,0,0};
-    float smolekey_colors[3] = {0,0,0};
-    float kokiri_col[3] = { 0.118f, 0.41f, 0.106f };
-    float goron_col[3] = { 0.392f, 0.078f, 0.0f };
-    float zora_col[3] = { 0.0f, 0.235f, 0.392f };
-    float navi_idle_i_col[3] = { 0.0f, 0.0f, 0.0f };
-    float navi_idle_o_col[3] = { 0.0f, 0.0f, 0.0f };
-    float navi_npc_i_col[3] = { 0.0f, 0.0f, 0.0f };
-    float navi_npc_o_col[3] = { 0.0f, 0.0f, 0.0f };
-    float navi_enemy_i_col[3] = { 0.0f, 0.0f, 0.0f };
-    float navi_enemy_o_col[3] = { 0.0f, 0.0f, 0.0f };
-    float navi_prop_i_col[3] = { 0.0f, 0.0f, 0.0f };
-    float navi_prop_o_col[3] = { 0.0f, 0.0f, 0.0f };
+    ImVec4 hearts_colors;
+    ImVec4 hearts_dd_colors;
+    ImVec4 a_btn_colors;
+    ImVec4 b_btn_colors;
+    ImVec4 c_btn_colors;
+    ImVec4 start_btn_colors;
+    ImVec4 magic_border_colors;
+    ImVec4 magic_remaining_colors;
+    ImVec4 magic_use_colors;
+    ImVec4 minimap_colors;
+    ImVec4 rupee_colors;
+    ImVec4 smolekey_colors;
+    ImVec4 kokiri_col;
+    ImVec4 goron_col;
+    ImVec4 zora_col;
+    ImVec4 navi_idle_i_col;
+    ImVec4 navi_idle_o_col;
+    ImVec4 navi_npc_i_col;
+    ImVec4 navi_npc_o_col;
+    ImVec4 navi_enemy_i_col;
+    ImVec4 navi_enemy_o_col;
+    ImVec4 navi_prop_i_col;
+    ImVec4 navi_prop_o_col;
 
     const char* filters[3] = {
         "Three-Point",
@@ -240,82 +240,21 @@ namespace SohImGui {
         stbi_image_free(img_data);
     }
 
-    void LoadInterfaceEditor(){//This function is necessary as without it IMGui wont load the updated float array.
-        hearts_colors[0] = (float)CVar_GetS32("gCCHeartsPrimR", 255)/255;
-        hearts_colors[1] = (float)CVar_GetS32("gCCHeartsPrimG", 70)/255;
-        hearts_colors[2] = (float)CVar_GetS32("gCCHeartsPrimB", 50)/255;
-        hearts_dd_colors[0] = (float)CVar_GetS32("gDDCCHeartsPrimR", 255)/255;
-        hearts_dd_colors[1] = (float)CVar_GetS32("gDDCCHeartsPrimG", 255)/255;
-        hearts_dd_colors[2] = (float)CVar_GetS32("gDDCCHeartsPrimB", 255)/255;
-        a_btn_colors[0] = (float)CVar_GetS32("gCCABtnPrimR", 90)/255;
-        a_btn_colors[1] = (float)CVar_GetS32("gCCABtnPrimG", 90)/255;
-        a_btn_colors[2] = (float)CVar_GetS32("gCCABtnPrimB", 255)/255;
-        b_btn_colors[0] = (float)CVar_GetS32("gCCBBtnPrimR", 0)/255;
-        b_btn_colors[1] = (float)CVar_GetS32("gCCBBtnPrimG", 150)/255;
-        b_btn_colors[2] = (float)CVar_GetS32("gCCBBtnPrimB", 0)/255;
-        c_btn_colors[0] = (float)CVar_GetS32("gCCCBtnPrimR", 255)/255;
-        c_btn_colors[1] = (float)CVar_GetS32("gCCCBtnPrimG", 160)/255;
-        c_btn_colors[2] = (float)CVar_GetS32("gCCCBtnPrimB", 0)/255;
-        start_btn_colors[0] = (float)CVar_GetS32("gCCStartBtnPrimR", 120)/255;
-        start_btn_colors[1] = (float)CVar_GetS32("gCCStartBtnPrimG", 120)/255;
-        start_btn_colors[2] = (float)CVar_GetS32("gCCStartBtnPrimB", 120)/255;
-        magic_border_colors[0] = (float)CVar_GetS32("gCCMagicBorderPrimR", 255)/255;
-        magic_border_colors[1] = (float)CVar_GetS32("gCCMagicBorderPrimG", 255)/255;
-        magic_border_colors[2] = (float)CVar_GetS32("gCCMagicBorderPrimB", 255)/255;
-        magic_use_colors[0] = (float)CVar_GetS32("gCCMagicPrimR", 250)/255;
-        magic_use_colors[1] = (float)CVar_GetS32("gCCMagicPrimG", 250)/255;
-        magic_use_colors[2] = (float)CVar_GetS32("gCCMagicPrimB", 0)/255;
-        magic_remaining_colors[0] = (float)CVar_GetS32("gCCMagicUsePrimR", 0)/255;
-        magic_remaining_colors[1] = (float)CVar_GetS32("gCCMagicUsePrimG", 200)/255;
-        magic_remaining_colors[2] = (float)CVar_GetS32("gCCMagicUsePrimB", 0)/255;
-        minimap_colors[0] = (float)CVar_GetS32("gCCMinimapPrimR", 0)/255;
-        minimap_colors[1] = (float)CVar_GetS32("gCCMinimapPrimG", 255)/255;
-        minimap_colors[2] = (float)CVar_GetS32("gCCMinimapPrimB", 255)/255;
-        rupee_colors[0] = (float)CVar_GetS32("gCCRupeePrimR", 200)/255;
-        rupee_colors[1] = (float)CVar_GetS32("gCCRupeePrimG", 255)/255;
-        rupee_colors[2] = (float)CVar_GetS32("gCCRupeePrimB", 100)/255;
-        smolekey_colors[0] = (float)CVar_GetS32("gCCKeysPrimR", 200)/255;
-        smolekey_colors[1] = (float)CVar_GetS32("gCCKeysPrimG", 230)/255;
-        smolekey_colors[2] = (float)CVar_GetS32("gCCKeysPrimB", 255)/255;
-        kokiri_col[0] = (float)CVar_GetS32("gTunic_Kokiri_R", 30)/255;
-        kokiri_col[1] = (float)CVar_GetS32("gTunic_Kokiri_G", 105)/255;
-        kokiri_col[2] = (float)CVar_GetS32("gTunic_Kokiri_B", 27)/255;
-        goron_col[0] = (float)CVar_GetS32("gTunic_Goron_R", 100)/255;
-        goron_col[1] = (float)CVar_GetS32("gTunic_Goron_G", 20)/255;
-        goron_col[2] = (float)CVar_GetS32("gTunic_Goron_B", 0)/255;
-        zora_col[0] = (float)CVar_GetS32("gTunic_Zora_R", 0)/255;
-        zora_col[1] = (float)CVar_GetS32("gTunic_Zora_G", 60)/255;
-        zora_col[2] = (float)CVar_GetS32("gTunic_Zora_B", 100)/255;
-        navi_idle_i_col[0] = (float)CVar_GetS32("gNavi_Idle_Inner_R", 255)/255;
-        navi_idle_i_col[1] = (float)CVar_GetS32("gNavi_Idle_Inner_G", 255)/255;
-        navi_idle_i_col[2] = (float)CVar_GetS32("gNavi_Idle_Inner_B", 255)/255;
-        navi_idle_o_col[0] = (float)CVar_GetS32("gNavi_Idle_Outer_R", 115)/255;
-        navi_idle_o_col[1] = (float)CVar_GetS32("gNavi_Idle_Outer_G", 230)/255;
-        navi_idle_o_col[2] = (float)CVar_GetS32("gNavi_Idle_Outer_B", 255)/255;
-        navi_npc_i_col[0] = (float)CVar_GetS32("gNavi_NPC_Inner_R", 100)/255;
-        navi_npc_i_col[1] = (float)CVar_GetS32("gNavi_NPC_Inner_G", 100)/255;
-        navi_npc_i_col[2] = (float)CVar_GetS32("gNavi_NPC_Inner_B", 255)/255;
-        navi_npc_o_col[0] = (float)CVar_GetS32("gNavi_NPC_Outer_R", 90)/255;
-        navi_npc_o_col[1] = (float)CVar_GetS32("gNavi_NPC_Outer_G", 90)/255;
-        navi_npc_o_col[2] = (float)CVar_GetS32("gNavi_NPC_Outer_B", 255)/255;
-        navi_enemy_i_col[0] = (float)CVar_GetS32("gNavi_Enemy_Inner_R", 255)/255;
-        navi_enemy_i_col[1] = (float)CVar_GetS32("gNavi_Enemy_Inner_G", 255)/255;
-        navi_enemy_i_col[2] = (float)CVar_GetS32("gNavi_Enemy_Inner_B", 0)/255;
-        navi_enemy_o_col[0] = (float)CVar_GetS32("gNavi_Enemy_Outer_R", 220)/255;
-        navi_enemy_o_col[1] = (float)CVar_GetS32("gNavi_Enemy_Outer_G", 220)/255;
-        navi_enemy_o_col[2] = (float)CVar_GetS32("gNavi_Enemy_Outer_B", 0)/255;
-        navi_prop_i_col[0] = (float)CVar_GetS32("gNavi_Prop_Inner_R", 0)/255;
-        navi_prop_i_col[1] = (float)CVar_GetS32("gNavi_Prop_Inner_G", 255)/255;
-        navi_prop_i_col[2] = (float)CVar_GetS32("gNavi_Prop_Inner_B", 0)/255;
-        navi_prop_o_col[0] = (float)CVar_GetS32("gNavi_Prop_Outer_R", 0)/255;
-        navi_prop_o_col[1] = (float)CVar_GetS32("gNavi_Prop_Outer_G", 220)/255;
-        navi_prop_o_col[2] = (float)CVar_GetS32("gNavi_Prop_Outer_B", 0)/255;
-        if (CVar_GetS32("gHudColors", 1) ==0) {
-            SelectedHUD = 0;
-        } else if (CVar_GetS32("gHudColors", 1) == 1) {
-            SelectedHUD = 1;
-        } else if (CVar_GetS32("gHudColors", 1) == 2) {
-            SelectedHUD = 2;
+    void LoadPickersColors(ImVec4& ColorArray, const char* cvarname, const ImVec4& default_colors, bool has_alpha = false) {
+        std::string Cvar_Red = cvarname;
+        Cvar_Red += "R";
+        std::string Cvar_Green = cvarname;
+        Cvar_Green += "G";
+        std::string Cvar_Blue = cvarname;
+        Cvar_Blue += "B";
+        std::string Cvar_Alpha = cvarname;
+        Cvar_Alpha += "A";
+
+        ColorArray.x = (float)CVar_GetS32(Cvar_Red.c_str(), default_colors.x)/255;
+        ColorArray.y = (float)CVar_GetS32(Cvar_Green.c_str(), default_colors.y)/255;
+        ColorArray.z = (float)CVar_GetS32(Cvar_Blue.c_str(), default_colors.z)/255;
+        if (has_alpha) {
+            ColorArray.w = (float)CVar_GetS32(Cvar_Alpha.c_str(), default_colors.w)/255;
         }
     }
 
@@ -533,18 +472,37 @@ namespace SohImGui {
         return fmin(fmax(value,min),max);
     }
 
-    void EnhancementColor3(std::string text, std::string cvarName, float ColorRGB[3], bool TitleSameLine) {
-        //Simplified.
+    void EnhancementColor(const char* text, const char* cvarName, ImVec4 ColorRGBA, ImVec4 default_colors, bool has_alpha = false, bool TitleSameLine = false) {
+        std::string Cvar_Red = cvarName;
+        Cvar_Red += "R";
+        std::string Cvar_Green = cvarName;
+        Cvar_Green += "G";
+        std::string Cvar_Blue = cvarName;
+        Cvar_Blue += "B";
+        std::string Cvar_Alpha = cvarName;
+        Cvar_Alpha += "A";
+        LoadPickersColors(ColorRGBA, cvarName, default_colors, has_alpha);
+
         ImGuiColorEditFlags flags = ImGuiColorEditFlags_None;
         if (!TitleSameLine){
-            ImGui::Text("%s", text.c_str());
+            ImGui::Text("%s", text);
             flags = ImGuiColorEditFlags_NoLabel;
         }
-        if (ImGui::ColorEdit3(text.c_str(), ColorRGB, flags)) {
-            CVar_SetS32((cvarName+"R").c_str(), ClampFloatToInt(ColorRGB[0]*255,0,255));
-            CVar_SetS32((cvarName+"G").c_str(), ClampFloatToInt(ColorRGB[1]*255,0,255));
-            CVar_SetS32((cvarName+"B").c_str(), ClampFloatToInt(ColorRGB[2]*255,0,255));
-            needs_save = true;
+        if (has_alpha) {
+            if (ImGui::ColorEdit3(text, (float *)&ColorRGBA, flags)) {
+                CVar_SetS32(Cvar_Red.c_str(), ClampFloatToInt(ColorRGBA.x*255,0,255));
+                CVar_SetS32(Cvar_Green.c_str(), ClampFloatToInt(ColorRGBA.y*255,0,255));
+                CVar_SetS32(Cvar_Blue.c_str(), ClampFloatToInt(ColorRGBA.z*255,0,255));
+                needs_save = true;
+            }
+        } else {
+            if (ImGui::ColorEdit4(text, (float *)&ColorRGBA, flags)) {
+                CVar_SetS32(Cvar_Red.c_str(), ClampFloatToInt(ColorRGBA.x*255,0,255));
+                CVar_SetS32(Cvar_Green.c_str(), ClampFloatToInt(ColorRGBA.y*255,0,255));
+                CVar_SetS32(Cvar_Blue.c_str(), ClampFloatToInt(ColorRGBA.z*255,0,255));
+                CVar_SetS32(Cvar_Alpha.c_str(), ClampFloatToInt(ColorRGBA.w*255,0,255));
+                needs_save = true;
+            }
         }
     }
 
@@ -558,7 +516,6 @@ namespace SohImGui {
         ImGuiBackendNewFrame();
         ImGuiWMNewFrame();
         ImGui::NewFrame();
-        LoadInterfaceEditor();
 
         const std::shared_ptr<Window> wnd = GlobalCtx2::GetInstance()->GetWindow();
         ImGuiWindowFlags window_flags = ImGuiWindowFlags_NoDocking | ImGuiWindowFlags_NoBackground |
@@ -866,36 +823,36 @@ namespace SohImGui {
                 if (ImGui::BeginTabBar("Cosmetics Editor", ImGuiTabBarFlags_NoCloseWithMiddleMouseButton)) {
                     if (ImGui::BeginTabItem("Navi")) {
                         EnhancementCheckbox("Custom colors for Navi", "gUseNaviCol");
-                        Tooltip("Enable/Disable custom Navi's colors. \nIf disabled you will have original colors for Navi.\nColors are refreshed when Navi goes back in your pockets");
-                        EnhancementColor3("Navi Idle Inner", "gNavi_Idle_Inner_", navi_idle_i_col, false);
+                        Tooltip("Enable/Disable custom Navi's colors. \nIf disabled you will have original colors for Navi.\nColors are refreshed when Navi goes back in your pockets.");
+                        EnhancementColor("Navi Idle Inner", "gNavi_Idle_Inner_", navi_idle_i_col, ImVec4(255,255,255,255));
                         Tooltip("Inner color for Navi (idle flying around)");
-                        EnhancementColor3("Navi Idle Outer", "gNavi_Idle_Outer_", navi_idle_o_col, false);
+                        EnhancementColor("Navi Idle Outer", "gNavi_Idle_Outer_", navi_idle_o_col, ImVec4(115,230,255,255));
                         Tooltip("Outer color for Navi (idle flying around)");
                         ImGui::Separator();
-                        EnhancementColor3("Navi NPC Inner", "gNavi_NPC_Inner_", navi_npc_i_col, false);
+                        EnhancementColor("Navi NPC Inner", "gNavi_NPC_Inner_", navi_npc_i_col, ImVec4(100,100,255,255));
                         Tooltip("Inner color for Navi (when Navi fly around NPCs)");
-                        EnhancementColor3("Navi NPC Outer", "gNavi_NPC_Outer_", navi_npc_o_col, false);
+                        EnhancementColor("Navi NPC Outer", "gNavi_NPC_Outer_", navi_npc_o_col, ImVec4(90,90,255,255));
                         Tooltip("Outer color for Navi (when Navi fly around NPCs)");
                         ImGui::Separator();
-                        EnhancementColor3("Navi Enemy Inner", "gNavi_Enemy_Inner_", navi_enemy_i_col, false);
+                        EnhancementColor("Navi Enemy Inner", "gNavi_Enemy_Inner_", navi_enemy_i_col, ImVec4(255,255,0,255));
                         Tooltip("Inner color for Navi (when Navi fly around Enemies or Bosses)");
-                        EnhancementColor3("Navi Enemy Outer", "gNavi_Enemy_Outer_", navi_enemy_o_col, false);
+                        EnhancementColor("Navi Enemy Outer", "gNavi_Enemy_Outer_", navi_enemy_o_col, ImVec4(220,220,0,255));
                         Tooltip("Outer color for Navi (when Navi fly around Enemies or Bosses)");
                         ImGui::Separator();
-                        EnhancementColor3("Navi Prop Inner", "gNavi_Prop_Inner_", navi_prop_i_col, false);
+                        EnhancementColor("Navi Prop Inner", "gNavi_Prop_Inner_", navi_prop_i_col, ImVec4(0,255,0,255));
                         Tooltip("Inner color for Navi (when Navi fly around props (signs etc))");
-                        EnhancementColor3("Navi Prop Outer", "gNavi_Prop_Outer_", navi_prop_o_col, false);
+                        EnhancementColor("Navi Prop Outer", "gNavi_Prop_Outer_", navi_prop_o_col, ImVec4(0,220,0,255));
                         Tooltip("Outer color for Navi (when Navi fly around props (signs etc))");
                         ImGui::EndTabItem();
                     }
                     if (ImGui::BeginTabItem("Tunics")) {
                         EnhancementCheckbox("Custom colors on tunics", "gUseTunicsCol");
-                        Tooltip("Enable/Disable custom Link's tunics colors. \nIf disabled you will have original colors for Link's tunics");
-                        EnhancementColor3("Kokiri Tunic", "gTunic_Kokiri_", kokiri_col, false);
+                        Tooltip("Enable/Disable custom Link's tunics colors. \nIf disabled you will have original colors for Link's tunics.");
+                        EnhancementColor("Kokiri Tunic", "gTunic_Kokiri_", kokiri_col, ImVec4(30,105,27,255));
                         ImGui::Separator();
-                        EnhancementColor3("Goron Tunic", "gTunic_Goron_", goron_col, false);
+                        EnhancementColor("Goron Tunic", "gTunic_Goron_", goron_col, ImVec4(100,20,0,255));
                         ImGui::Separator();
-                        EnhancementColor3("Zora Tunic", "gTunic_Zora_", zora_col, false);
+                        EnhancementColor("Zora Tunic", "gTunic_Zora_", zora_col, ImVec4(0,60,100,255));
                         ImGui::EndTabItem();
                     }
                     ImGui::EndTabBar();
@@ -911,39 +868,39 @@ namespace SohImGui {
                 ImGui::Begin("Interface Editor", nullptr, ImGuiWindowFlags_NoFocusOnAppearing);
                 if (ImGui::BeginTabBar("Interface Editor", ImGuiTabBarFlags_NoCloseWithMiddleMouseButton)) {
                     if (ImGui::BeginTabItem("Hearts")) {
-                        EnhancementColor3("Hearts inner", "gCCHeartsPrim", hearts_colors, false);
+                        EnhancementColor("Hearts inner", "gCCHeartsPrim", hearts_colors, ImVec4(255,70,50,255));
                         Tooltip("Hearts inner color (red in original)\nAffect both Normal Hearts and the ones in Double Defense");
-                        EnhancementColor3("Hearts double def", "gDDCCHeartsPrim", hearts_dd_colors, false);
-                        Tooltip("Hearts outline color (white in original)\nAffect Double Defense outline only");
+                        EnhancementColor("Hearts double def", "gDDCCHeartsPrim", hearts_dd_colors, ImVec4(255,255,255,255));
+                        Tooltip("Hearts outline color (white in original)\nAffect Double Defense outline only.");
                         ImGui::EndTabItem();
                     }
                     if (ImGui::BeginTabItem("Buttons")) {
-                        EnhancementColor3("A Buttons", "gCCABtnPrim", a_btn_colors, false);
-                        Tooltip("A Buttons colors (Green in original Gamecube)\nAffect A buttons colors on interface, in shops, messages boxes, ocarina notes and inventory cursors");
-                        EnhancementColor3("B Buttons", "gCCBBtnPrim", b_btn_colors, false);
+                        EnhancementColor("A Buttons", "gCCABtnPrim", a_btn_colors, ImVec4(90,90,255,255));
+                        Tooltip("A Buttons colors (Green in original Gamecube)\nAffect A buttons colors on interface, in shops, messages boxes, ocarina notes and inventory cursors.");
+                        EnhancementColor("B Buttons", "gCCBBtnPrim", b_btn_colors, ImVec4(0,150,0,255));
                         Tooltip("B Button colors (Red in original Gamecube)\nAffect B button colors on interface");
-                        EnhancementColor3("C Buttons", "gCCCBtnPrim", c_btn_colors, false);
+                        EnhancementColor("C Buttons", "gCCCBtnPrim", c_btn_colors, ImVec4(255,160,0,255));
                         Tooltip("C Buttons colors (Yellowish / Oranges in originals)\nAffect C buttons colors on interface, in inventory and ocarina notes");
-                        EnhancementColor3("Start Buttons", "gCCStartBtnPrim", start_btn_colors, false);
+                        EnhancementColor("Start Buttons", "gCCStartBtnPrim", start_btn_colors, ImVec4(120,120,120,255));
                         Tooltip("Start Button colors (gray in Gamecube)\nAffect Start button colors in inventory");
                         ImGui::EndTabItem();
                     }
                     if (ImGui::BeginTabItem("Magic Bar")) {
-                        EnhancementColor3("Magic bar borders", "gCCMagicBorderPrim", magic_border_colors, false);
-                        Tooltip("Affect the border of the magic bar when being used\nWhite flash in original game");
-                        EnhancementColor3("Magic bar main color", "gCCMagicPrim", magic_remaining_colors, false);
-                        Tooltip("Affect the magic bar color\nGreen in original game");
-                        EnhancementColor3("Magic bar being used", "gCCMagicUsePrim", magic_use_colors, false);
-                        Tooltip("Affect the magic bar when being used\nYellow in original game");
+                        EnhancementColor("Magic bar borders", "gCCMagicBorderPrim", magic_border_colors, ImVec4(255,255,255,255));
+                        Tooltip("Affect the border of the magic bar when being used\nWhite flash in original game.");
+                        EnhancementColor("Magic bar main color", "gCCMagicPrim", magic_remaining_colors, ImVec4(250,250,0,255));
+                        Tooltip("Affect the magic bar color\nGreen in original game.");
+                        EnhancementColor("Magic bar being used", "gCCMagicUsePrim", magic_use_colors, ImVec4(0,200,0,255));
+                        Tooltip("Affect the magic bar when being used\nYellow in original game.");
                         ImGui::EndTabItem();
                     }
                     if (ImGui::BeginTabItem("Misc")) {
-                        EnhancementColor3("Minimap color", "gCCMinimapPrim", minimap_colors, false);
-                        Tooltip("Affect the Dungeon and Overworld minimaps");
-                        EnhancementColor3("Rupee icon color", "gCCRupeePrim", rupee_colors, false);
-                        Tooltip("Affect the Rupee icon on interface\nGreen by default");
-                        EnhancementColor3("Small Keys icon color", "gCCKeysPrim", smolekey_colors, false);
-                        Tooltip("Affect the Small keys icon on interface\nGray by default");
+                        EnhancementColor("Minimap color", "gCCMinimapPrim", minimap_colors, ImVec4(0,255,255,255));
+                        Tooltip("Affect the Dungeon and Overworld minimaps.");
+                        EnhancementColor("Rupee icon color", "gCCRupeePrim", rupee_colors, ImVec4(120,120,120,255));
+                        Tooltip("Affect the Rupee icon on interface\nGreen by default.");
+                        EnhancementColor("Small Keys icon color", "gCCKeysPrim", smolekey_colors, ImVec4(200,230,255,255));
+                        Tooltip("Affect the Small keys icon on interface\nGray by default.");
                         ImGui::EndTabItem();
                     }
                     ImGui::EndTabBar();

--- a/libultraship/libultraship/SohImGuiImpl.cpp
+++ b/libultraship/libultraship/SohImGuiImpl.cpp
@@ -240,7 +240,7 @@ namespace SohImGui {
         stbi_image_free(img_data);
     }
 
-    void LoadPickersColors(ImVec4& ColorArray, const char* cvarname, const ImVec4& default_colors, bool has_alpha = false) {
+    void LoadPickersColors(ImVec4& ColorArray, const char* cvarname, const ImVec4& default_colors, bool has_alpha) {
         std::string Cvar_Red = cvarname;
         Cvar_Red += "R";
         std::string Cvar_Green = cvarname;
@@ -472,7 +472,7 @@ namespace SohImGui {
         return fmin(fmax(value,min),max);
     }
 
-    void EnhancementColor(const char* text, const char* cvarName, ImVec4 ColorRGBA, ImVec4 default_colors, bool has_alpha = false, bool TitleSameLine = false) {
+    void EnhancementColor(const char* text, const char* cvarName, ImVec4 ColorRGBA, ImVec4 default_colors, bool has_alpha, bool TitleSameLine) {
         std::string Cvar_Red = cvarName;
         Cvar_Red += "R";
         std::string Cvar_Green = cvarName;
@@ -488,7 +488,7 @@ namespace SohImGui {
             ImGui::Text("%s", text);
             flags = ImGuiColorEditFlags_NoLabel;
         }
-        if (has_alpha) {
+        if (!has_alpha) {
             if (ImGui::ColorEdit3(text, (float *)&ColorRGBA, flags)) {
                 CVar_SetS32(Cvar_Red.c_str(), ClampFloatToInt(ColorRGBA.x*255,0,255));
                 CVar_SetS32(Cvar_Green.c_str(), ClampFloatToInt(ColorRGBA.y*255,0,255));

--- a/libultraship/libultraship/SohImGuiImpl.cpp
+++ b/libultraship/libultraship/SohImGuiImpl.cpp
@@ -888,9 +888,9 @@ namespace SohImGui {
                     if (ImGui::BeginTabItem("Magic Bar")) {
                         EnhancementColor("Magic bar borders", "gCCMagicBorderPrim", magic_border_colors, ImVec4(255,255,255,255));
                         Tooltip("Affect the border of the magic bar when being used\nWhite flash in original game.");
-                        EnhancementColor("Magic bar main color", "gCCMagicPrim", magic_remaining_colors, ImVec4(250,250,0,255));
+                        EnhancementColor("Magic bar main color", "gCCMagicPrim", magic_remaining_colors, ImVec4(0,200,0,255));
                         Tooltip("Affect the magic bar color\nGreen in original game.");
-                        EnhancementColor("Magic bar being used", "gCCMagicUsePrim", magic_use_colors, ImVec4(0,200,0,255));
+                        EnhancementColor("Magic bar being used", "gCCMagicUsePrim", magic_use_colors, ImVec4(250,250,0,255));
                         Tooltip("Affect the magic bar when being used\nYellow in original game.");
                         ImGui::EndTabItem();
                     }

--- a/libultraship/libultraship/SohImGuiImpl.cpp
+++ b/libultraship/libultraship/SohImGuiImpl.cpp
@@ -112,9 +112,9 @@ namespace SohImGui {
         return fmin(fmax(value,min),max);
     }
 
-    void Tooltip(std::string text) {
+    void Tooltip(const char* text) {
         if (ImGui::IsItemHovered())
-            ImGui::SetTooltip("%s", text.c_str());
+            ImGui::SetTooltip("%s", text);
     }
 
     void ImGuiWMInit() {

--- a/libultraship/libultraship/SohImGuiImpl.h
+++ b/libultraship/libultraship/SohImGuiImpl.h
@@ -68,7 +68,7 @@ namespace SohImGui {
     void EnhancementCheckbox(std::string text, std::string cvarName);
     void EnhancementSliderInt(std::string text, std::string id, std::string cvarName, int min, int max, std::string format);
     void EnhancementSliderFloat(std::string text, std::string id, std::string cvarName, float min, float max, std::string format, float defaultValue);
-    void EnhancementColor(const char* text, const char* cvarName, ImVec4 ColorRGBA, ImVec4 default_colors, bool has_alpha=false, bool TitleSameLine=false);
+    void EnhancementColor(const char* text, const char* cvarName, ImVec4 ColorRGBA, ImVec4 default_colors, bool allow_rainbow = true, bool has_alpha=false, bool TitleSameLine=false);
 
     void DrawMainMenuAndCalculateGameSize(void);
     
@@ -80,6 +80,9 @@ namespace SohImGui {
     void AddWindow(const std::string& category, const std::string& name, WindowDrawFunc drawFunc);
     void LoadResource(const std::string& name, const std::string& path, const ImVec4& tint = ImVec4(1, 1, 1, 1));
     void LoadPickersColors(ImVec4& ColorArray, const char* cvarname, const ImVec4& default_colors, bool has_alpha=false);
+    void RandomizeColor(const char* cvarName, ImVec4* colors);
+    void RainbowColor(const char* cvarName, ImVec4* colors);
+    void ResetColor(const char* cvarName, ImVec4* colors, ImVec4 defaultcolors, bool has_alpha);
     ImTextureID GetTextureByID(int id);
     ImTextureID GetTextureByName(const std::string& name);
 }

--- a/libultraship/libultraship/SohImGuiImpl.h
+++ b/libultraship/libultraship/SohImGuiImpl.h
@@ -68,7 +68,7 @@ namespace SohImGui {
     void EnhancementCheckbox(std::string text, std::string cvarName);
     void EnhancementSliderInt(std::string text, std::string id, std::string cvarName, int min, int max, std::string format);
     void EnhancementSliderFloat(std::string text, std::string id, std::string cvarName, float min, float max, std::string format, float defaultValue);
-    void EnhancementColor(const char* text, const char* cvarName, ImVec4 ColorRGBA, ImVec4 default_colors, bool has_alpha, bool TitleSameLine);
+    void EnhancementColor(const char* text, const char* cvarName, ImVec4 ColorRGBA, ImVec4 default_colors, bool has_alpha=false, bool TitleSameLine=false);
 
     void DrawMainMenuAndCalculateGameSize(void);
     
@@ -79,7 +79,7 @@ namespace SohImGui {
     void BindCmd(const std::string& cmd, CommandEntry entry);
     void AddWindow(const std::string& category, const std::string& name, WindowDrawFunc drawFunc);
     void LoadResource(const std::string& name, const std::string& path, const ImVec4& tint = ImVec4(1, 1, 1, 1));
-    void LoadPickersColors(ImVec4& ColorArray, const char* cvarname, const ImVec4& default_colors, bool has_alpha);
+    void LoadPickersColors(ImVec4& ColorArray, const char* cvarname, const ImVec4& default_colors, bool has_alpha=false);
     ImTextureID GetTextureByID(int id);
     ImTextureID GetTextureByName(const std::string& name);
 }

--- a/libultraship/libultraship/SohImGuiImpl.h
+++ b/libultraship/libultraship/SohImGuiImpl.h
@@ -68,7 +68,7 @@ namespace SohImGui {
     void EnhancementCheckbox(std::string text, std::string cvarName);
     void EnhancementSliderInt(std::string text, std::string id, std::string cvarName, int min, int max, std::string format);
     void EnhancementSliderFloat(std::string text, std::string id, std::string cvarName, float min, float max, std::string format, float defaultValue);
-    void EnhancementColor3(std::string text, std::string cvarName, float ColorRGB[3], bool TitleSameLine);
+    void EnhancementColor(const char* text, const char* cvarName, ImVec4 ColorRGBA, ImVec4 default_colors, bool has_alpha, bool TitleSameLine);
 
     void DrawMainMenuAndCalculateGameSize(void);
     
@@ -79,7 +79,7 @@ namespace SohImGui {
     void BindCmd(const std::string& cmd, CommandEntry entry);
     void AddWindow(const std::string& category, const std::string& name, WindowDrawFunc drawFunc);
     void LoadResource(const std::string& name, const std::string& path, const ImVec4& tint = ImVec4(1, 1, 1, 1));
-    void LoadInterfaceEditor();
+    void LoadPickersColors(ImVec4& ColorArray, const char* cvarname, const ImVec4& default_colors, bool has_alpha);
     ImTextureID GetTextureByID(int id);
     ImTextureID GetTextureByName(const std::string& name);
 }

--- a/libultraship/libultraship/SohImGuiImpl.h
+++ b/libultraship/libultraship/SohImGuiImpl.h
@@ -63,14 +63,14 @@ namespace SohImGui {
     extern bool needs_save;
     void Init(WindowImpl window_impl);
     void Update(EventImpl event);
-
+    void Tooltip(const char* text);
+    
     void EnhancementRadioButton(const char* text, const char* cvarName, int id);
     void EnhancementCheckbox(const char* text, const char* cvarName);
     void EnhancementButton(const char* text, const char* cvarName);
     void EnhancementSliderInt(const char* text, const char* id, const char* cvarName, int min, int max, const char* format);
     void EnhancementSliderFloat(const char* text, const char* id, const char* cvarName, float min, float max, const char* format, float defaultValue, bool isPercentage);
     void EnhancementColor(const char* text, const char* cvarName, ImVec4 ColorRGBA, ImVec4 default_colors, bool allow_rainbow = true, bool has_alpha=false, bool TitleSameLine=false);
-    void Tooltip(const char* text);
 
     void DrawMainMenuAndCalculateGameSize(void);
     

--- a/soh/src/code/z_lifemeter.c
+++ b/soh/src/code/z_lifemeter.c
@@ -128,6 +128,13 @@ void HealthMeter_Init(GlobalContext* globalCtx) {
         HeartDDOutline[0] = CVar_GetS32("gDDCCHeartsPrimR", 90);
         HeartDDOutline[1] = CVar_GetS32("gDDCCHeartsPrimG", 90);
         HeartDDOutline[2] = CVar_GetS32("gDDCCHeartsPrimB", 90);
+    } else {
+        HeartInner[0] = HEARTS_PRIM_R;
+        HeartInner[1] = HEARTS_PRIM_G;
+        HeartInner[2] = HEARTS_PRIM_B;
+        HeartDDOutline[0] = HEARTS_DD_PRIM_R;
+        HeartDDOutline[1] = HEARTS_DD_PRIM_G;
+        HeartDDOutline[2] = HEARTS_DD_PRIM_B;
     }
     
     interfaceCtx->unk_228 = 0x140;
@@ -194,12 +201,12 @@ void HealthMeter_Update(GlobalContext* globalCtx) {
         HeartDDOutline[1] = CVar_GetS32("gDDCCHeartsPrimG", sHeartsDDPrim[0][1]);
         HeartDDOutline[2] = CVar_GetS32("gDDCCHeartsPrimB", sHeartsDDPrim[0][2]);
     } else {
-        HeartInner[0] = sHeartsPrimColors[0][0];
-        HeartInner[1] = sHeartsPrimColors[0][1];
-        HeartInner[2] = sHeartsPrimColors[0][2];
-        HeartDDOutline[0] = sHeartsDDPrim[0][0];
-        HeartDDOutline[1] = sHeartsDDPrim[0][1];
-        HeartDDOutline[2] = sHeartsDDPrim[0][2];
+        HeartInner[0] = HEARTS_PRIM_R;
+        HeartInner[1] = HEARTS_PRIM_G;
+        HeartInner[2] = HEARTS_PRIM_B;
+        HeartDDOutline[0] = HEARTS_DD_PRIM_R;
+        HeartDDOutline[1] = HEARTS_DD_PRIM_G;
+        HeartDDOutline[2] = HEARTS_DD_PRIM_B;
     }
 
     if (interfaceCtx->unk_200 != 0) {
@@ -299,33 +306,33 @@ void HealthMeter_Update(GlobalContext* globalCtx) {
         sBeatingHeartsDDEnv[1] = (u8)(gFactor + HeartDDInner[1]) & 0xFF;
         sBeatingHeartsDDEnv[2] = (u8)(bFactor + HeartDDInner[2]) & 0xFF;
     } else {
-        sHeartsDDPrim[2][0] = HeartInner[0]; 
-        sHeartsDDPrim[2][1] = HeartInner[1];
-        sHeartsDDPrim[2][2] = HeartInner[2];
+        sHeartsDDPrim[2][0] = HEARTS_PRIM_R; 
+        sHeartsDDPrim[2][1] = HEARTS_PRIM_G;
+        sHeartsDDPrim[2][2] = HEARTS_PRIM_B;
 
-        sHeartsDDPrim[1][0] = sHeartsDDPrimColors[ddType][0];
-        sHeartsDDPrim[1][1] = sHeartsDDPrimColors[ddType][1];
-        sHeartsDDPrim[1][2] = sHeartsDDPrimColors[ddType][2];
+        sHeartsDDPrim[1][0] = HEARTS_DD_PRIM_R;
+        sHeartsDDPrim[1][1] = HEARTS_DD_PRIM_G;
+        sHeartsDDPrim[1][2] = HEARTS_DD_PRIM_B;
 
-        sHeartsDDEnv[1][0] = sHeartsDDEnvColors[ddType][0];
-        sHeartsDDEnv[1][1] = sHeartsDDEnvColors[ddType][1];
-        sHeartsDDEnv[1][2] = sHeartsDDEnvColors[ddType][2];
+        sHeartsDDEnv[1][0] = HEARTS_PRIM_R;
+        sHeartsDDEnv[1][1] = HEARTS_PRIM_G;
+        sHeartsDDEnv[1][2] = HEARTS_PRIM_B;
 
         rFactor = sHeartsDDPrimFactors[ddType][0] * ddFactor;
         gFactor = sHeartsDDPrimFactors[ddType][1] * ddFactor;
         bFactor = sHeartsDDPrimFactors[ddType][2] * ddFactor;
 
-        sBeatingHeartsDDPrim[0] = (u8)(rFactor + HeartDDOutline[0]) & 0xFF;
-        sBeatingHeartsDDPrim[1] = (u8)(gFactor + HeartDDOutline[1]) & 0xFF;
-        sBeatingHeartsDDPrim[2] = (u8)(bFactor + HeartDDOutline[2]) & 0xFF;
+        sBeatingHeartsDDPrim[0] = (u8)(rFactor + HEARTS_DD_PRIM_R) & 0xFF;
+        sBeatingHeartsDDPrim[1] = (u8)(gFactor + HEARTS_DD_PRIM_G) & 0xFF;
+        sBeatingHeartsDDPrim[2] = (u8)(bFactor + HEARTS_DD_PRIM_B) & 0xFF;
 
         rFactor = sHeartsDDEnvFactors[ddType][0] * ddFactor;
         gFactor = sHeartsDDEnvFactors[ddType][1] * ddFactor;
         bFactor = sHeartsDDEnvFactors[ddType][2] * ddFactor;
 
-        sBeatingHeartsDDEnv[0] = (u8)(rFactor + HeartDDInner[0]) & 0xFF;
-        sBeatingHeartsDDEnv[1] = (u8)(gFactor + HeartDDInner[1]) & 0xFF;
-        sBeatingHeartsDDEnv[2] = (u8)(bFactor + HeartDDInner[2]) & 0xFF;
+        sBeatingHeartsDDEnv[0] = (u8)(rFactor + HEARTS_PRIM_R) & 0xFF;
+        sBeatingHeartsDDEnv[1] = (u8)(gFactor + HEARTS_PRIM_G) & 0xFF;
+        sBeatingHeartsDDEnv[2] = (u8)(bFactor + HEARTS_PRIM_B) & 0xFF;
     }
 
 }

--- a/soh/src/code/z_player_lib.c
+++ b/soh/src/code/z_player_lib.c
@@ -746,23 +746,34 @@ void func_8008F470(GlobalContext* globalCtx, void** skeleton, Vec3s* jointTable,
 #endif
 
     Color_RGB8 sTemp;
+    Color_RGB8 sOriginalTunicColors[] = {
+        { 30, 105, 27 },
+        { 100, 20, 0 },
+        { 0, 60, 100 },
+    };
     color = &sTemp;
-    if (tunic == PLAYER_TUNIC_KOKIRI) {
+    if (tunic == PLAYER_TUNIC_KOKIRI && CVar_GetS32("gUseTunicsCol",0)) {
         color->r = CVar_GetS32("gTunic_Kokiri_R", sTunicColors[PLAYER_TUNIC_KOKIRI].r);
         color->g = CVar_GetS32("gTunic_Kokiri_G", sTunicColors[PLAYER_TUNIC_KOKIRI].g);
         color->b = CVar_GetS32("gTunic_Kokiri_B", sTunicColors[PLAYER_TUNIC_KOKIRI].b);
-    } else if (tunic == PLAYER_TUNIC_GORON) {
+    } else if (tunic == PLAYER_TUNIC_GORON && CVar_GetS32("gUseTunicsCol",0)) {
         color->r = CVar_GetS32("gTunic_Goron_R", sTunicColors[PLAYER_TUNIC_GORON].r);
         color->g = CVar_GetS32("gTunic_Goron_G", sTunicColors[PLAYER_TUNIC_GORON].g);
         color->b = CVar_GetS32("gTunic_Goron_B", sTunicColors[PLAYER_TUNIC_GORON].b);
-    } else if (tunic == PLAYER_TUNIC_ZORA) {
+    } else if (tunic == PLAYER_TUNIC_ZORA && CVar_GetS32("gUseTunicsCol",0)) {
         color->r = CVar_GetS32("gTunic_Zora_R", sTunicColors[PLAYER_TUNIC_ZORA].r);
         color->g = CVar_GetS32("gTunic_Zora_G", sTunicColors[PLAYER_TUNIC_ZORA].g);
         color->b = CVar_GetS32("gTunic_Zora_B", sTunicColors[PLAYER_TUNIC_ZORA].b);
-    } else {
-        color->r = CVar_GetS32("gTunic_Kokiri_R", sTunicColors[PLAYER_TUNIC_KOKIRI].r);
-        color->g = CVar_GetS32("gTunic_Kokiri_G", sTunicColors[PLAYER_TUNIC_KOKIRI].g);
-        color->b = CVar_GetS32("gTunic_Kokiri_B", sTunicColors[PLAYER_TUNIC_KOKIRI].b);
+    } else if (!CVar_GetS32("gUseTunicsCol",0)){
+        if (tunic >= 3) {
+            color->r = sOriginalTunicColors[0].r;
+            color->g = sOriginalTunicColors[0].g;
+            color->b = sOriginalTunicColors[0].b;
+        } else {
+            color->r = sOriginalTunicColors[tunic].r;
+            color->g = sOriginalTunicColors[tunic].g;
+            color->b = sOriginalTunicColors[tunic].b;   
+        }
     }
 
     gDPSetEnvColor(POLY_OPA_DISP++, color->r, color->g, color->b, 0);

--- a/soh/src/code/z_player_lib.c
+++ b/soh/src/code/z_player_lib.c
@@ -744,26 +744,27 @@ void func_8008F470(GlobalContext* globalCtx, void** skeleton, Vec3s* jointTable,
 #else
     gSPSegment(POLY_OPA_DISP++, 0x09, SEGMENTED_TO_VIRTUAL(sMouthTextures[eyeIndex]));
 #endif
-    Color_RGB8 NewColor[3];
-    color = &sTunicColors[tunic];
-    if (CVar_GetS32("gUseTunicsCol",0) == 1) {
-        if (tunic == PLAYER_TUNIC_KOKIRI || tunic == PLAYER_TUNIC_GORON || tunic == PLAYER_TUNIC_ZORA) {
-            NewColor[PLAYER_TUNIC_KOKIRI].r = CVar_GetS32("gTunic_Kokiri_R", sTunicColors[PLAYER_TUNIC_KOKIRI].r);
-            NewColor[PLAYER_TUNIC_KOKIRI].g = CVar_GetS32("gTunic_Kokiri_G", sTunicColors[PLAYER_TUNIC_KOKIRI].g);
-            NewColor[PLAYER_TUNIC_KOKIRI].b = CVar_GetS32("gTunic_Kokiri_B", sTunicColors[PLAYER_TUNIC_KOKIRI].b);
-            NewColor[PLAYER_TUNIC_GORON].r = CVar_GetS32("gTunic_Goron_R", sTunicColors[PLAYER_TUNIC_GORON].r);
-            NewColor[PLAYER_TUNIC_GORON].g = CVar_GetS32("gTunic_Goron_G", sTunicColors[PLAYER_TUNIC_GORON].g);
-            NewColor[PLAYER_TUNIC_GORON].b = CVar_GetS32("gTunic_Goron_B", sTunicColors[PLAYER_TUNIC_GORON].b);
-            NewColor[PLAYER_TUNIC_ZORA].r = CVar_GetS32("gTunic_Zora_R", sTunicColors[PLAYER_TUNIC_ZORA].r);
-            NewColor[PLAYER_TUNIC_ZORA].g = CVar_GetS32("gTunic_Zora_G", sTunicColors[PLAYER_TUNIC_ZORA].g);
-            NewColor[PLAYER_TUNIC_ZORA].b = CVar_GetS32("gTunic_Zora_B", sTunicColors[PLAYER_TUNIC_ZORA].b);
-        } else {
-            NewColor[PLAYER_TUNIC_KOKIRI].r = CVar_GetS32("gTunic_Kokiri_R", sTunicColors[PLAYER_TUNIC_KOKIRI].r);
-            NewColor[PLAYER_TUNIC_KOKIRI].g = CVar_GetS32("gTunic_Kokiri_G", sTunicColors[PLAYER_TUNIC_KOKIRI].g);
-            NewColor[PLAYER_TUNIC_KOKIRI].b = CVar_GetS32("gTunic_Kokiri_B", sTunicColors[PLAYER_TUNIC_KOKIRI].b);
-        }
-        color = NewColor;
+
+    Color_RGB8 sTemp;
+    color = &sTemp;
+    if (tunic == PLAYER_TUNIC_KOKIRI) {
+        color->r = CVar_GetS32("gTunic_Kokiri_R", sTunicColors[PLAYER_TUNIC_KOKIRI].r);
+        color->g = CVar_GetS32("gTunic_Kokiri_G", sTunicColors[PLAYER_TUNIC_KOKIRI].g);
+        color->b = CVar_GetS32("gTunic_Kokiri_B", sTunicColors[PLAYER_TUNIC_KOKIRI].b);
+    } else if (tunic == PLAYER_TUNIC_GORON) {
+        color->r = CVar_GetS32("gTunic_Goron_R", sTunicColors[PLAYER_TUNIC_GORON].r);
+        color->g = CVar_GetS32("gTunic_Goron_G", sTunicColors[PLAYER_TUNIC_GORON].g);
+        color->b = CVar_GetS32("gTunic_Goron_B", sTunicColors[PLAYER_TUNIC_GORON].b);
+    } else if (tunic == PLAYER_TUNIC_ZORA) {
+        color->r = CVar_GetS32("gTunic_Zora_R", sTunicColors[PLAYER_TUNIC_ZORA].r);
+        color->g = CVar_GetS32("gTunic_Zora_G", sTunicColors[PLAYER_TUNIC_ZORA].g);
+        color->b = CVar_GetS32("gTunic_Zora_B", sTunicColors[PLAYER_TUNIC_ZORA].b);
+    } else {
+        color->r = CVar_GetS32("gTunic_Kokiri_R", sTunicColors[PLAYER_TUNIC_KOKIRI].r);
+        color->g = CVar_GetS32("gTunic_Kokiri_G", sTunicColors[PLAYER_TUNIC_KOKIRI].g);
+        color->b = CVar_GetS32("gTunic_Kokiri_B", sTunicColors[PLAYER_TUNIC_KOKIRI].b);
     }
+
     gDPSetEnvColor(POLY_OPA_DISP++, color->r, color->g, color->b, 0);
 
     sDListsLodOffset = lod * 2;

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
@@ -976,14 +976,23 @@ void KaleidoScope_DrawCursor(GlobalContext* globalCtx, u16 pageIndex) {
     temp = pauseCtx->unk_1E4;
 
     if (CVar_GetS32("gHudColors", 1) == 0) {
+        sCursorColors[1][0] = 255;
+        sCursorColors[1][1] = 255;
+        sCursorColors[1][2] = 0;
         sCursorColors[2][0] = 0;
         sCursorColors[2][1] = 50;
         sCursorColors[2][2] = 255;
     } else if (CVar_GetS32("gHudColors", 1) == 1) {
+        sCursorColors[1][0] = 255;
+        sCursorColors[1][1] = 255;
+        sCursorColors[1][2] = 0;
         sCursorColors[2][0] = 0;
         sCursorColors[2][1] = 255;
         sCursorColors[2][2] = 50;
     } else if (CVar_GetS32("gHudColors", 1) == 2) {
+        sCursorColors[1][0] = CVar_GetS32("gCCCBtnPrimR", 255);
+        sCursorColors[1][1] = CVar_GetS32("gCCCBtnPrimG", 255);
+        sCursorColors[1][2] = CVar_GetS32("gCCCBtnPrimB", 0);
         sCursorColors[2][0] = CVar_GetS32("gCCABtnPrimR", 0);
         sCursorColors[2][1] = CVar_GetS32("gCCABtnPrimG", 255);
         sCursorColors[2][2] = CVar_GetS32("gCCABtnPrimB", 50);
@@ -1056,10 +1065,22 @@ Gfx* KaleidoScope_DrawPageSections(Gfx* gfx, Vtx* vertices, void** textures) {
 
 void KaleidoScope_DrawPages(GlobalContext* globalCtx, GraphicsContext* gfxCtx) {
     static s16 D_8082ACF4[][3] = {
-        { 0, 0, 0 }, { 0, 0, 0 },     { 0, 0, 0 },    { 0, 0, 0 }, { 255, 255, 0 }, { 0, 0, 0 },
-        { 0, 0, 0 }, { 255, 255, 0 }, { 0, 255, 50 }, { 0, 0, 0 }, { 0, 0, 0 },     { 0, 255, 50 },
+        { 0, 0, 0 }, 
+        { 0, 0, 0 },     
+        { 0, 0, 0 },    
+        { 0, 0, 0 }, 
+        { 255, 255, 0 }, 
+        { 0, 0, 0 },
+        { 0, 0, 0 }, 
+        { 255, 255, 0 }, { 0, 255, 50 }, { 0, 0, 0 }, { 0, 0, 0 },     { 0, 255, 50 },
     };
     if (CVar_GetS32("gHudColors", 1) == 0) {
+        D_8082ACF4[4][0] = 255;
+        D_8082ACF4[4][1] = 255;
+        D_8082ACF4[4][2] = 0;
+        D_8082ACF4[7][0] = 255;
+        D_8082ACF4[7][1] = 255;
+        D_8082ACF4[7][2] = 0;
         D_8082ACF4[8][0] = 0;
         D_8082ACF4[8][1] = 50;
         D_8082ACF4[8][2] = 255;
@@ -1067,6 +1088,12 @@ void KaleidoScope_DrawPages(GlobalContext* globalCtx, GraphicsContext* gfxCtx) {
         D_8082ACF4[11][1] = 50;
         D_8082ACF4[11][2] = 255;
     } else if (CVar_GetS32("gHudColors", 1) == 1) {
+        D_8082ACF4[4][0] = 255;
+        D_8082ACF4[4][1] = 255;
+        D_8082ACF4[4][2] = 0;
+        D_8082ACF4[7][0] = 255;
+        D_8082ACF4[7][1] = 255;
+        D_8082ACF4[7][2] = 0;
         D_8082ACF4[8][0] = 0;
         D_8082ACF4[8][1] = 255;
         D_8082ACF4[8][2] = 50;
@@ -1074,6 +1101,12 @@ void KaleidoScope_DrawPages(GlobalContext* globalCtx, GraphicsContext* gfxCtx) {
         D_8082ACF4[11][1] = 255;
         D_8082ACF4[11][2] = 50;
     } else if (CVar_GetS32("gHudColors", 1) == 2) {
+        D_8082ACF4[4][0] = CVar_GetS32("gCCCBtnPrimR", 255);
+        D_8082ACF4[4][1] = CVar_GetS32("gCCCBtnPrimG", 255);
+        D_8082ACF4[4][2] = CVar_GetS32("gCCCBtnPrimB", 0);
+        D_8082ACF4[7][0] = CVar_GetS32("gCCCBtnPrimR", 255);
+        D_8082ACF4[7][1] = CVar_GetS32("gCCCBtnPrimG", 255);
+        D_8082ACF4[7][2] = CVar_GetS32("gCCCBtnPrimB", 0);
         D_8082ACF4[8][0] = CVar_GetS32("gCCABtnPrimR", 0);
         D_8082ACF4[8][1] = CVar_GetS32("gCCABtnPrimG", 255);
         D_8082ACF4[8][2] = CVar_GetS32("gCCABtnPrimB", 50);

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
@@ -1065,14 +1065,8 @@ Gfx* KaleidoScope_DrawPageSections(Gfx* gfx, Vtx* vertices, void** textures) {
 
 void KaleidoScope_DrawPages(GlobalContext* globalCtx, GraphicsContext* gfxCtx) {
     static s16 D_8082ACF4[][3] = {
-        { 0, 0, 0 }, 
-        { 0, 0, 0 },     
-        { 0, 0, 0 },    
-        { 0, 0, 0 }, 
-        { 255, 255, 0 }, 
-        { 0, 0, 0 },
-        { 0, 0, 0 }, 
-        { 255, 255, 0 }, { 0, 255, 50 }, { 0, 0, 0 }, { 0, 0, 0 },     { 0, 255, 50 },
+        { 0, 0, 0 }, { 0, 0, 0 },     { 0, 0, 0 },    { 0, 0, 0 }, { 255, 255, 0 }, { 0, 0, 0 },
+        { 0, 0, 0 }, { 255, 255, 0 }, { 0, 255, 50 }, { 0, 0, 0 }, { 0, 0, 0 },     { 0, 255, 50 },
     };
     if (CVar_GetS32("gHudColors", 1) == 0) {
         D_8082ACF4[4][0] = 255;


### PR DESCRIPTION
This is a PR that do 2, 3 things (all of them related!)

#202 had a logic bug with it's EnhancementColor3, while fixing it I realized how dirty it was made 
So I removed EnhancementColor3 and made a generic one that do both Alpha channel on demand and load on GUI it's color.
It clean a bit whole mess it allowed me to remove the function that was doing the color fetch and gain quite a lot of space and clarity.
Added the possibility to have Rainbow effect with it.
Also now EnhancementColor Add both Randomize and Reset button.


Fixes for Cosmetic mods I recently made :
Doing it fix both the logic bug with arrays, and SohImGuiImpl mess I had made.

Also I have been reported and been able to track one bug in #202 Hearts with Double Defense were not reverting to there proper colors so this one has also been fixed 

And the C button cursor (the yellow one on Item menu) now properly follow C button colors.

Tunics colors were made improperly