### PR TITLE
Experimental Feature: Allow using CSPRNG for better RNG

### DIFF
--- a/libultraship/libultraship/ImGuiImpl.cpp
+++ b/libultraship/libultraship/ImGuiImpl.cpp
@@ -1357,6 +1357,9 @@ namespace SohImGui {
                 EnhancementCheckbox("Free Camera", "gFreeCamera");
                 Tooltip("Enables camera control\nNote: You must remap C buttons off of the right stick in the controller config menu, and map the camera stick to the right stick.");
 
+                EnhancementCheckbox("Use CSPRNG random", "gCryptoRandom");
+                Tooltip("Uses secure RNG for better randomness and non-manipulable RNG (Requires restart)");
+
              #ifdef __SWITCH__
                 int slot = CVar_GetS32("gSwitchPerfMode", (int)SwitchProfiles::STOCK);
                 ImGui::Text("Switch performance mode");

--- a/soh/soh.vcxproj
+++ b/soh/soh.vcxproj
@@ -325,6 +325,7 @@
     <ClCompile Include="src\code\padutils.c" />
     <ClCompile Include="src\code\PreRender.c" />
     <ClCompile Include="src\code\printutils.c" />
+    <ClCompile Include="src\code\random_experiment.cpp" />
     <ClCompile Include="src\code\relocation.c" />
     <ClCompile Include="src\code\sched.c" />
     <ClCompile Include="src\code\shrink_window.c" />
@@ -1042,6 +1043,7 @@
     <ClInclude Include="soh\OTRGlobals.h" />
     <ClInclude Include="soh\SaveManager.h" />
     <ClInclude Include="soh\util.h" />
+    <ClInclude Include="src\code\random_experiment.h" />
     <ClInclude Include="src\overlays\actors\ovl_Arms_Hook\z_arms_hook.h" />
     <ClInclude Include="src\overlays\actors\ovl_Arrow_Fire\z_arrow_fire.h" />
     <ClInclude Include="src\overlays\actors\ovl_Arrow_Ice\z_arrow_ice.h" />

--- a/soh/src/code/code_800FD970.c
+++ b/soh/src/code/code_800FD970.c
@@ -1,4 +1,6 @@
 #include "global.h"
+#include "random_experiment.h"
+
 
 // The latest generated random number, used to generate the next number in the sequence.
 static u32 sRandInt = 1;
@@ -10,14 +12,18 @@ static u32 sRandFloat;
  * Gets the next integer in the sequence of pseudo-random numbers.
  */
 u32 Rand_Next(void) {
-    return sRandInt = (sRandInt * 1664525) + 1013904223;
+    return sRandInt = randomUint32(sRandInt);
 }
 
 /**
  * Seeds the pseudo-random number generator by providing a starting value.
  */
 void Rand_Seed(u32 seed) {
-    sRandInt = seed;
+    if (gCsprngInitialized) {
+        sRandInt = randomUint32(seed);
+    } else {
+        sRandInt = seed;
+    }
 }
 
 /**
@@ -26,7 +32,7 @@ void Rand_Seed(u32 seed) {
  * between 1.0f and 2.0f, returning the result subtract 1.0f.
  */
 f32 Rand_ZeroOne(void) {
-    sRandInt = (sRandInt * 1664525) + 1013904223;
+    sRandInt = randomUint32(sRandInt);
     sRandFloat = ((sRandInt >> 9) | 0x3F800000);
     return *((f32*)&sRandFloat) - 1.0f;
 }
@@ -36,7 +42,7 @@ f32 Rand_ZeroOne(void) {
  * manner in which Rand_ZeroOne generates its result.
  */
 f32 Rand_Centered(void) {
-    sRandInt = (sRandInt * 1664525) + 1013904223;
+    sRandInt = randomUint32(sRandInt);
     sRandFloat = ((sRandInt >> 9) | 0x3F800000);
     return *((f32*)&sRandFloat) - 1.5f;
 }
@@ -45,14 +51,18 @@ f32 Rand_Centered(void) {
  * Seeds a pseudo-random number at rndNum with a provided seed.
  */
 void Rand_Seed_Variable(u32* rndNum, u32 seed) {
-    *rndNum = seed;
+    if (gCsprngInitialized) {
+        *rndNum = randomUint32(seed);
+    } else {
+        *rndNum = seed;
+    }
 }
 
 /**
  * Generates the next pseudo-random integer from the provided rndNum.
  */
 u32 Rand_Next_Variable(u32* rndNum) {
-    return *rndNum = (*rndNum * 1664525) + 1013904223;
+    return *rndNum = randomUint32(*rndNum);
 }
 
 /**
@@ -60,7 +70,7 @@ u32 Rand_Next_Variable(u32* rndNum) {
  * 1.0f from the provided rndNum.
  */
 f32 Rand_ZeroOne_Variable(u32* rndNum) {
-    u32 next = (*rndNum * 1664525) + 1013904223;
+    u32 next = randomUint32(*rndNum);
 
     // clang-format off
     *rndNum = next; sRandFloat = (next >> 9) | 0x3F800000;
@@ -73,7 +83,7 @@ f32 Rand_ZeroOne_Variable(u32* rndNum) {
  * 0.5f from the provided rndNum.
  */
 f32 Rand_Centered_Variable(u32* rndNum) {
-    u32 next = (*rndNum * 1664525) + 1013904223;
+    u32 next = randomUint32(*rndNum);
 
     // clang-format off
     *rndNum = next; sRandFloat = (next >> 9) | 0x3F800000;

--- a/soh/src/code/main.c
+++ b/soh/src/code/main.c
@@ -2,7 +2,7 @@
 #include "vt.h"
 #include <soh/Enhancements/bootcommands.h>
 #include "soh/OTRGlobals.h"
-
+#include "random_experiment.h"
 
 s32 gScreenWidth = SCREEN_WIDTH;
 s32 gScreenHeight = SCREEN_HEIGHT;
@@ -53,6 +53,11 @@ void Main(void* arg) {
     void* debugHeap;
     size_t debugHeapSize;
     s16* msg;
+
+    if (CVar_GetS32("gCryptoRandom", 0)) {
+        cryptoRandomInit();
+        osSyncPrintf("CSPRNG initialized.");
+    }
 
     osSyncPrintf("mainproc 実行開始\n"); // "Start running"
     gScreenWidth = SCREEN_WIDTH;

--- a/soh/src/code/random_experiment.cpp
+++ b/soh/src/code/random_experiment.cpp
@@ -1,0 +1,30 @@
+#include "random_experiment.h"
+#include <random>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+unsigned long (*randomUint32)(unsigned long) = &standardRandomUint32;
+bool gCsprngInitialized = false;
+std::random_device cryptProvider;
+
+void cryptoRandomInit() {
+    randomUint32 = &cryptoRandomUint32;
+    gCsprngInitialized = true;
+}
+
+unsigned long cryptoRandomUint32(unsigned long seed) {
+    (void)seed;
+    unsigned long randomBits = 0;
+    randomBits = cryptProvider();
+    return randomBits;
+}
+
+unsigned long standardRandomUint32(unsigned long seed) {
+    return (seed * 1664525) + 1013904223;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/soh/src/code/random_experiment.h
+++ b/soh/src/code/random_experiment.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void cryptoRandomInit(void);
+unsigned long cryptoRandomUint32(unsigned long);
+
+extern bool gCsprngInitialized;
+extern unsigned long (*randomUint32)(unsigned long);
+unsigned long standardRandomUint32(unsigned long);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Add an option to use a cryptographic random generator to achieve a less predictable, more varied RNG than the base game's manipulable RNG.
Currently only implemented for Windows platforms, using the `CryptGenRandom` API.