### PR TITLE
Fix Navi text HUD position

### DIFF
--- a/libultraship/libultraship/SohImGuiImpl.cpp
+++ b/libultraship/libultraship/SohImGuiImpl.cpp
@@ -753,6 +753,8 @@ namespace SohImGui {
                     Tooltip("Makes two handed idle animation play, a seemingly finished animation that was disabled on accident in the original game");
                     EnhancementCheckbox("Fix Deku Nut upgrade", "gDekuNutUpgradeFix");
                     Tooltip("Prevents the Forest Stage Deku Nut upgrade from becoming unobtainable after receiving the Poacher's Saw");
+                    EnhancementCheckbox("Fix Navi text HUD position", "gNaviTextFix");
+                    Tooltip("Correctly centers the Navi text prompt on the HUD's C-Up button");
 
                     ImGui::EndMenu();
                 }

--- a/soh/soh/Enhancements/bootcommands.c
+++ b/soh/soh/Enhancements/bootcommands.c
@@ -26,10 +26,10 @@ void BootCommands_Init()
     CVar_RegisterS32("gPauseLiveLink", 0);
     CVar_RegisterS32("gMinimalUI", 0);
     CVar_RegisterS32("gRumbleEnabled", 0);
-    CVar_RegisterS32("gUniformLR", 1);
+    CVar_RegisterS32("gUniformLR", 0);
     CVar_RegisterS32("gTwoHandedIdle", 0);
-    CVar_RegisterS32("gDekuNutUpgradeFix", 1);
-    CVar_RegisterS32("gNaviTextFix", 1);
+    CVar_RegisterS32("gDekuNutUpgradeFix", 0);
+    CVar_RegisterS32("gNaviTextFix", 0);
     CVar_RegisterS32("gNewDrops", 0);
     CVar_RegisterS32("gVisualAgony", 0);
     CVar_RegisterS32("gLanguages", 0); //0 = English / 1 = German / 2 = French

--- a/soh/soh/Enhancements/bootcommands.c
+++ b/soh/soh/Enhancements/bootcommands.c
@@ -29,6 +29,7 @@ void BootCommands_Init()
     CVar_RegisterS32("gUniformLR", 1);
     CVar_RegisterS32("gTwoHandedIdle", 0);
     CVar_RegisterS32("gDekuNutUpgradeFix", 1);
+    CVar_RegisterS32("gNaviTextFix", 1);
     CVar_RegisterS32("gNewDrops", 0);
     CVar_RegisterS32("gVisualAgony", 0);
     CVar_RegisterS32("gLanguages", 0); //0 = English / 1 = German / 2 = French

--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -2916,7 +2916,7 @@ void Interface_DrawItemButtons(GlobalContext* globalCtx) {
             }
 
             const s16 rCUpBtnX  = OTRGetRectDimensionFromRightEdge(R_C_UP_BTN_X+Right_HUD_Margin);
-            const s16 rCUPIconX = OTRGetRectDimensionFromRightEdge(R_C_UP_ICON_X+Right_HUD_Margin-CVar_GetS32("gNaviTextFix", 0));
+            const s16 rCUPIconX = OTRGetRectDimensionFromRightEdge(R_C_UP_ICON_X+Right_HUD_Margin-!!CVar_GetS32("gNaviTextFix", 0));
             if (CVar_GetS32("gHudColors", 1) == 0) {
                 gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_C_BTN_COLOR(0), R_C_BTN_COLOR(1), R_C_BTN_COLOR(2), temp);
             } else if (CVar_GetS32("gHudColors", 1) == 1) {

--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -2916,7 +2916,7 @@ void Interface_DrawItemButtons(GlobalContext* globalCtx) {
             }
 
             const s16 rCUpBtnX  = OTRGetRectDimensionFromRightEdge(R_C_UP_BTN_X+Right_HUD_Margin);
-            const s16 rCUPIconX = OTRGetRectDimensionFromRightEdge(R_C_UP_ICON_X+Right_HUD_Margin);
+            const s16 rCUPIconX = OTRGetRectDimensionFromRightEdge(R_C_UP_ICON_X+Right_HUD_Margin-CVar_GetS32("gNaviTextFix", 0));
             if (CVar_GetS32("gHudColors", 1) == 0) {
                 gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_C_BTN_COLOR(0), R_C_BTN_COLOR(1), R_C_BTN_COLOR(2), temp);
             } else if (CVar_GetS32("gHudColors", 1) == 1) {


### PR DESCRIPTION
The Navi text that appears on the C-Up button when Navi wants to say something is slightly off-center in the base game. This fix behind a cvar shifts it 1 unit (I assume these units represent 320\*240 N64 pixels) to the left, centering it correctly. ~~Enabled by default because why not.~~

**EDIT:** 

Before:
![Far-right Navi](https://user-images.githubusercontent.com/5259025/169845234-03ef171e-b301-4059-ba0c-269697c79102.png)

After:
![Enlightened centrist Navi](https://user-images.githubusercontent.com/5259025/169845313-9af0e2db-7c35-4b79-b766-c37464a5706b.png)