### PR TITLE
Restore hover fishing bug from 1.0

### DIFF
--- a/libultraship/libultraship/SohImGuiImpl.cpp
+++ b/libultraship/libultraship/SohImGuiImpl.cpp
@@ -946,6 +946,8 @@ namespace SohImGui {
                 {
                     EnhancementCheckbox("Red Ganon blood", "gRedGanonBlood");
                     Tooltip("Restore the original red blood from NTSC 1.0/1.1. Disable for green blood");
+                    EnhancementCheckbox("Fish while hovering", "gHoverFishing");
+                    Tooltip("Restore a bug from NTSC 1.0 that allows casting the Fishing Rod while using the Hover Boots");
 
                     ImGui::EndMenu();
                 }

--- a/soh/soh/Enhancements/bootcommands.c
+++ b/soh/soh/Enhancements/bootcommands.c
@@ -26,6 +26,7 @@ void BootCommands_Init()
     CVar_RegisterS32("gPauseLiveLink", 0);
     CVar_RegisterS32("gMinimalUI", 0);
     CVar_RegisterS32("gRedGanonBlood", 0);
+    CVar_RegisterS32("gHoverFishing", 0);
     CVar_RegisterS32("gRumbleEnabled", 0);
     CVar_RegisterS32("gUniformLR", 0);
     CVar_RegisterS32("gTwoHandedIdle", 0);

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -5470,8 +5470,8 @@ s32 func_8083C6B8(GlobalContext* globalCtx, Player* this) {
             sp24 = this->actor.world.pos;
             sp24.y += 50.0f;
 
-            if (!(this->actor.bgCheckFlags & 1) || (this->actor.world.pos.z > 1300.0f) ||
-                BgCheck_SphVsFirstPoly(&globalCtx->colCtx, &sp24, 20.0f)) {
+            if (CVar_GetS32("gHoverFishing", 0) ? 0 : !(this->actor.bgCheckFlags & 1) ||
+                (this->actor.world.pos.z > 1300.0f) || BgCheck_SphVsFirstPoly(&globalCtx->colCtx, &sp24, 20.0f)) {
                 func_80078884(NA_SE_SY_ERROR);
                 return 0;
             }


### PR DESCRIPTION
First off, this PR "depends" on #411.  If it turns out this PR is wanted but the other isn't, it can easily be reworked, but this one seems more controversial, so if anything it's more likely 411 gets merged and this one gets refused.

This restores a classic bug from the NTSC 1.0 release of Ocarina of Time. You can find it documented various places around the web, e.g. [ZeldaSpeedRuns](https://www.zeldaspeedruns.com/oot/ba/steal-the-fishing-rod) and [ZeldaChaos](http://www.jaytheham.com/zcw/Ocarina_of_Time_Miscellaneous_Glitches_-_Steal_the_Rod).

In short, the 1.0 release allowed Link to cast the Fishing Rod while hovering with the Hover Boots. When the hover timer runs out with the Rod cast, Link falls, exits the fishing state and is able to move freely. This allows the player to exit the Fishing Pond without returning the Rod, which in turn allows them to trigger further bugs, e.g. Swordless Link, Deku Sticks on B, Bottle Adventure and Reverse Bottle Adventure.

The bug was fixed in 1.1 and all later OoT versions by checking that Link was in contact with the ground before allowing him to cast. Here, a CVar is checked before the ground check so it can be skipped if players choose to enable it.

There is actually a [second, unpatched bug](http://www.jaytheham.com/zcw/Ocarina_of_Time_Miscellaneous_Glitches_-_Steal_the_Rod_II) which allows the player to steal the Fishing Rod, so it's already possible to steal the Fishing Rod in current SoH using that method. However, I think there's some merit in having the classic 1.0 method available, not least because it's easier to perform.

I don't know if *adding* bugs is something the Harbour Masters are interested in, so consider this PR a test case, For clarity, I'm not advocating that all bugs should be restored, but adding back minor, enjoyable and optional bugs seems as harmless as any other enhancement to me.