### PR TITLE
BUILDING.md update - https for cloning repo

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -21,7 +21,7 @@
 
 ```bash
 # Clone the repo
-git clone git@github.com:HarbourMasters/ShipWright.git
+git clone https://github.com/HarbourMasters/Shipwright.git
 cd ShipWright
 # Copy the baserom to the OTRExporter folder
 cp <path to your ROM> OTRExporter


### PR DESCRIPTION
 if users don't have ssh keys set up `git clone git@github.com:HarbourMasters/ShipWright.git` fails. this makes it so copy/pasting the instructions should work for more users.