### PR TITLE
Enhancement to make Link's cow appear in both time periods

### DIFF
--- a/libultraship/libultraship/SohImGuiImpl.cpp
+++ b/libultraship/libultraship/SohImGuiImpl.cpp
@@ -856,6 +856,8 @@ namespace SohImGui {
                     Tooltip("The default response to Kaepora Gaebora is always that you understood what he said");
                     EnhancementCheckbox("Disable Navi Call Audio", "gDisableNaviCallAudio");
                     Tooltip("Disables the voice audio when Navi calls you");
+                    EnhancementCheckbox("Link's Cow in Both Time Periods", "gCowOfTime");
+                    Tooltip("Allows the Lon Lon Ranch obstacle course reward to be shared across time periods");
                     ImGui::EndMenu();
                 }
 

--- a/soh/src/overlays/actors/ovl_En_Cow/z_en_cow.c
+++ b/soh/src/overlays/actors/ovl_En_Cow/z_en_cow.c
@@ -118,7 +118,7 @@ void EnCow_Init(Actor* thisx, GlobalContext* globalCtx) {
             func_809DEE9C(this);
             this->actionFunc = func_809DF96C;
             if (globalCtx->sceneNum == SCENE_LINK_HOME) {
-                if (!LINK_IS_ADULT) {
+                if (!LINK_IS_ADULT && !CVar_GetS32("gCowOfTime", 0)) {
                     Actor_Kill(&this->actor);
                     return;
                 }


### PR DESCRIPTION
In the base game, Adult Link can win a cow from Lon Lon Ranch any time after obtaining Epona by completing Malon's obstacle course. The cow is delivered to Link's House in Kokiri Forest ("Everybody, Stalfos"?) and can be visited by Adult Link.

This is mostly just a funny novelty, as there's no reason to ever visit Link's House as an adult. This enhancement makes the cow appear in both time periods, so that Child Link can load into a save with the cow immediately accessible, so it can *potentially* serve some purpose.

**tl;dr:** Cow of Time.

**Note:** In this PR, I haven't bothered adding the enhancement to `bootcommands.c`. I picked that up from others doing the same thing, but especially now that it's been decided all enhancements and fixes should be off by default, it seems redundant to specifically add them as disabled when they already are disabled by default. I'll make another commit to add it if anybody asks.