### PR TITLE
Add Controller Navigation

### DIFF
--- a/libultraship/libultraship/SohImGuiImpl.cpp
+++ b/libultraship/libultraship/SohImGuiImpl.cpp
@@ -730,16 +730,18 @@ namespace SohImGui {
 
 		ImGui::Separator();
 
-                EnhancementCheckbox("Dpad Support on Pause and File Select", "gDpadPauseName");
-                EnhancementCheckbox("DPad Support in Ocarina and Text Choice", "gDpadOcarinaText");
-                EnhancementCheckbox("DPad Support for Browsing Shop Items", "gDpadShop");
+                EnhancementCheckbox("D-pad Support on Pause and File Select", "gDpadPauseName");
+                EnhancementCheckbox("D-pad Support in Ocarina and Text Choice", "gDpadOcarinaText");
+                EnhancementCheckbox("D-pad Support for Browsing Shop Items", "gDpadShop");
 		    
 		ImGui::Separator();
 
                 EnhancementCheckbox("Show Inputs", "gInputEnabled");
+                Tooltip("Shows currently pressed inputs on the bottom right of the screen");
                 EnhancementCheckbox("Rumble Enabled", "gRumbleEnabled");
 
-                EnhancementSliderFloat("Input Scale: %.1f", "##Input", "gInputScale", 1.0f, 3.0f, "", 1.0f, false);  
+                EnhancementSliderFloat("Input Scale: %.1f", "##Input", "gInputScale", 1.0f, 3.0f, "", 1.0f, false);
+                Tooltip("Sets the on screen size of the displayed inputs from Show Inputs");  
 
 		ImGui::Separator();  
 		    

--- a/libultraship/libultraship/SohImGuiImpl.cpp
+++ b/libultraship/libultraship/SohImGuiImpl.cpp
@@ -727,13 +727,14 @@ namespace SohImGui {
 	    {
 		ImGuiIO& io = ImGui::GetIO();
 		ImGui::CheckboxFlags("Use Controller Navigation",     &io.ConfigFlags, ImGuiConfigFlags_NavEnableGamepad);      
-
+		Tooltip("Allows controller navigation of the menu bar\nD-pad to move between items, A to select, and X to grab focus on the menu bar");
+ 
 		ImGui::Separator();
 
                 EnhancementCheckbox("D-pad Support on Pause and File Select", "gDpadPauseName");
                 EnhancementCheckbox("D-pad Support in Ocarina and Text Choice", "gDpadOcarinaText");
                 EnhancementCheckbox("D-pad Support for Browsing Shop Items", "gDpadShop");
-		    
+
 		ImGui::Separator();
 
                 EnhancementCheckbox("Show Inputs", "gInputEnabled");

--- a/libultraship/libultraship/SohImGuiImpl.cpp
+++ b/libultraship/libultraship/SohImGuiImpl.cpp
@@ -726,9 +726,14 @@ namespace SohImGui {
             if (ImGui::BeginMenu("Controller"))
 	    {
 		ImGuiIO& io = ImGui::GetIO();
-		ImGui::CheckboxFlags("Use Controller Navigation",     &io.ConfigFlags, ImGuiConfigFlags_NavEnableGamepad);      
+		EnhancementCheckbox("Use Controller Navigation", "gControllerNav");
 		Tooltip("Allows controller navigation of the menu bar\nD-pad to move between items, A to select, and X to grab focus on the menu bar");
- 
+		
+		if (CVar_GetS32("gControllerNav", 0) == 1) 
+		{
+        		io.ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad;
+        	}
+
 		ImGui::Separator();
 
                 EnhancementCheckbox("D-pad Support on Pause and File Select", "gDpadPauseName");

--- a/libultraship/libultraship/SohImGuiImpl.cpp
+++ b/libultraship/libultraship/SohImGuiImpl.cpp
@@ -50,6 +50,7 @@ bool oldCursorState = true;
     ImGui::PopStyleColor(); \
     ImGui::Separator();
 #define TOGGLE_BTN ImGuiKey_F1
+#define TOGGLE_PAD_BTN ImGuiKey_GamepadBack
 #define HOOK(b) if(b) needs_save = true;
 OSContPad* pads;
 
@@ -259,7 +260,8 @@ namespace SohImGui {
     }
 
     void LoadRainbowColor() {
-        for (uint16_t s=0; s <= sizeof(RainbowColorCvarList); s++) {
+        u8 arrayLength = sizeof(RainbowColorCvarList) / sizeof(*RainbowColorCvarList);
+        for (u8 s = 0; s < arrayLength; s++) {
             std::string cvarName = RainbowColorCvarList[s];
             std::string Cvar_Red = cvarName;
             Cvar_Red += "R";
@@ -692,7 +694,7 @@ namespace SohImGui {
 
         ImGui::DockSpace(dockId, ImVec2(0.0f, 0.0f), ImGuiDockNodeFlags_None);
 
-        if (ImGui::IsKeyPressed(TOGGLE_BTN)) {
+        if ((ImGui::IsKeyPressed(TOGGLE_BTN)) || (ImGui::IsKeyPressed(TOGGLE_PAD_BTN))) {
             bool menu_bar = CVar_GetS32("gOpenMenuBar", 0);
             CVar_SetS32("gOpenMenuBar", !menu_bar);
             needs_save = true;
@@ -722,7 +724,25 @@ namespace SohImGui {
             }
 
             if (ImGui::BeginMenu("Controller"))
-            {
+	    {
+		ImGuiIO& io = ImGui::GetIO();
+		ImGui::CheckboxFlags("Use Controller Navigation",     &io.ConfigFlags, ImGuiConfigFlags_NavEnableGamepad);      
+
+		ImGui::Separator();
+
+                EnhancementCheckbox("Dpad Support on Pause and File Select", "gDpadPauseName");
+                EnhancementCheckbox("DPad Support in Ocarina and Text Choice", "gDpadOcarinaText");
+                EnhancementCheckbox("DPad Support for Browsing Shop Items", "gDpadShop");
+		    
+		ImGui::Separator();
+
+                EnhancementCheckbox("Show Inputs", "gInputEnabled");
+                EnhancementCheckbox("Rumble Enabled", "gRumbleEnabled");
+
+                EnhancementSliderFloat("Input Scale: %.1f", "##Input", "gInputScale", 1.0f, 3.0f, "", 1.0f, false);  
+
+		ImGui::Separator();  
+		    
                 for (const auto& [i, controllers] : Ship::Window::Controllers)
                 {
                     bool hasPad = std::find_if(controllers.begin(), controllers.end(), [](const auto& c) {
@@ -751,19 +771,6 @@ namespace SohImGui {
                         }
                         ImGui::Separator();
                 }
-
-                EnhancementCheckbox("Show Inputs", "gInputEnabled");
-                Tooltip("Shows currently pressed inputs on the bottom right of the screen");
-                EnhancementCheckbox("Rumble Enabled", "gRumbleEnabled");
-
-                EnhancementSliderFloat("Input Scale: %.1f", "##Input", "gInputScale", 1.0f, 3.0f, "", 1.0f, false);
-                Tooltip("Sets the on screen size of the displayed inputs from Show Inputs");
-
-                ImGui::Separator();
-
-                EnhancementCheckbox("D-pad Support on Pause and File Select", "gDpadPauseName");
-                EnhancementCheckbox("D-pad Support in Ocarina and Text Choice", "gDpadOcarinaText");
-                EnhancementCheckbox("D-pad Support for Browsing Shop Items", "gDpadShop");
 
                 ImGui::EndMenu();
             }

--- a/libultraship/libultraship/SohImGuiImpl.cpp
+++ b/libultraship/libultraship/SohImGuiImpl.cpp
@@ -666,7 +666,7 @@ namespace SohImGui {
         const std::shared_ptr<Window> wnd = GlobalCtx2::GetInstance()->GetWindow();
         ImGuiWindowFlags window_flags = ImGuiWindowFlags_NoDocking | ImGuiWindowFlags_NoBackground |
             ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoMove |
-            ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoNavFocus | ImGuiWindowFlags_NoResize;
+            ImGuiWindowFlags_NoResize;
         if (CVar_GetS32("gOpenMenuBar", 0)) window_flags |= ImGuiWindowFlags_MenuBar;
 
         const ImGuiViewport* viewport = ImGui::GetMainViewport();
@@ -694,7 +694,9 @@ namespace SohImGui {
 
         ImGui::DockSpace(dockId, ImVec2(0.0f, 0.0f), ImGuiDockNodeFlags_None);
 
-        if ((ImGui::IsKeyPressed(TOGGLE_BTN)) || (ImGui::IsKeyPressed(TOGGLE_PAD_BTN))) {
+        ImGuiIO& io = ImGui::GetIO();
+	io.ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad; 
+        if ((ImGui::IsKeyPressed(TOGGLE_BTN)) || (ImGui::IsKeyDown(TOGGLE_PAD_BTN))) {
             bool menu_bar = CVar_GetS32("gOpenMenuBar", 0);
             CVar_SetS32("gOpenMenuBar", !menu_bar);
             needs_save = true;
@@ -725,17 +727,6 @@ namespace SohImGui {
 
             if (ImGui::BeginMenu("Controller"))
 	    {
-		ImGuiIO& io = ImGui::GetIO();
-		EnhancementCheckbox("Use Controller Navigation", "gControllerNav");
-		Tooltip("Allows controller navigation of the menu bar\nD-pad to move between items, A to select, and X to grab focus on the menu bar");
-		
-		if (CVar_GetS32("gControllerNav", 0) == 1) 
-		{
-        		io.ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad;
-        	}
-
-		ImGui::Separator();
-
                 EnhancementCheckbox("D-pad Support on Pause and File Select", "gDpadPauseName");
                 EnhancementCheckbox("D-pad Support in Ocarina and Text Choice", "gDpadOcarinaText");
                 EnhancementCheckbox("D-pad Support for Browsing Shop Items", "gDpadShop");


### PR DESCRIPTION
- Apply Rainbow patch
- Add Controller Navigation
- Controller "Back" button opens F1 Menu
- Controller Rumble/Gyro settings at the bottom of the controller menu

![controller_navigation](https://user-images.githubusercontent.com/62252937/171067221-e244b69c-bd52-4dd4-af02-ca2f211d68d6.png)

https://user-images.githubusercontent.com/62252937/171067287-cde79dbd-46dd-423c-aabb-c7fca75cb642.mp4


