### PR TITLE
New cheat: remove age limits on items

### DIFF
--- a/libultraship/libultraship/SohImGuiImpl.cpp
+++ b/libultraship/libultraship/SohImGuiImpl.cpp
@@ -1016,6 +1016,8 @@ namespace SohImGui {
                 Tooltip("Automatically activates the Infinite Sword glitch, making you constantly swing your sword");
                 EnhancementCheckbox("Unrestricted Items", "gNoRestrictItems");
                 Tooltip("Allows you to use any item at any location");
+                EnhancementCheckbox("No Item Age Limits", "gNoItemAgeLimits");
+                Tooltip("Allows you to use any item at any age");
                 EnhancementCheckbox("Freeze Time", "gFreezeTime");
                 Tooltip("Freezes the time of day");
 

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
@@ -727,18 +727,24 @@ static u16 D_8082ABEC[] = {
     PAUSE_MAP, PAUSE_EQUIP, PAUSE_QUEST, PAUSE_ITEM, PAUSE_EQUIP, PAUSE_MAP, PAUSE_ITEM, PAUSE_QUEST,
 };
 
-u8 gSlotAgeReqs[] = {
+u8 gSlotAgeReqs[24];
+
+u8 gSlotAgeReqsClean[] = {
     1, 9, 9, 0, 0, 9, 1, 9, 9, 0, 0, 9, 1, 9, 1, 0, 0, 9, 9, 9, 9, 9, 0, 1,
 };
 
-u8 gEquipAgeReqs[][4] = {
+u8 gEquipAgeReqs[4][4];
+
+u8 gEquipAgeReqsClean[][4] = {
     { 0, 1, 0, 0 },
     { 9, 1, 9, 0 },
     { 0, 9, 0, 0 },
     { 9, 9, 0, 0 },
 };
 
-u8 gItemAgeReqs[] = {
+u8 gItemAgeReqs[86];
+
+u8 gItemAgeReqsClean[] = {
     1, 9, 9, 0, 0, 9, 1, 9, 9, 9, 0, 0, 0, 9, 1, 9, 1, 0, 0, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9,
     9, 9, 9, 9, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 1, 0, 0, 1, 9, 0, 9, 0, 0, 9, 0, 0, 1, 1, 1, 0, 0, 0, 9, 9, 9, 1, 0, 0, 9, 9, 0,
@@ -1027,6 +1033,16 @@ void KaleidoScope_DrawCursor(GlobalContext* globalCtx, u16 pageIndex) {
     }
 
     CLOSE_DISPS(globalCtx->state.gfxCtx, "../z_kaleido_scope_PAL.c", 985);
+
+    if(CVar_GetS32("gNoItemAgeLimits", 0) == 1) {
+        memset(gSlotAgeReqs, 9, sizeof(gSlotAgeReqs));
+        memset(gEquipAgeReqs, 9, sizeof(gEquipAgeReqs));
+        memset(gItemAgeReqs, 9, sizeof(gItemAgeReqs));
+    } else {
+        memcpy(gSlotAgeReqs, gSlotAgeReqsClean, sizeof(gSlotAgeReqs));
+        memcpy(gEquipAgeReqs, gEquipAgeReqsClean, sizeof(gEquipAgeReqs));
+        memcpy(gItemAgeReqs, gItemAgeReqsClean, sizeof(gItemAgeReqs));
+    }
 }
 
 Gfx* KaleidoScope_DrawPageSections(Gfx* gfx, Vtx* vertices, void** textures) {


### PR DESCRIPTION
This works perfectly from my testing, but I'm not sure whether the approach is profoundly ugly.

The base game has arrays `gSlotAgeReqs`, `gEquipAgeReqs` and `gItemAgeReqs`. I **renamed** these to add `Clean` on the end, then I populate all of the original named arrays by either `memset`ing `9`s (age-agnostic) across the board (cheat enabled) or `memcpy`ing the `Clean` arrays over the originals (cheat disabled).

This behavior occurs within the `KaleidoScope_DrawCursor()` function. That *also* might be controversial, as there's no obvious connection between the function name and what I'm using it for, so here's my justifications:
- it allows the CVar to be checked in real-time to have item usability switch while the menu is up--including toggling the grayscale filter, etc.
- the "Assignable Tunics and Boots" enhancement does something similar, putting its logic in `KaleidoScope_SwitchPage()`