### PR TITLE
Zelda64: Fix memory curruptions

### DIFF
--- a/ZAPDTR/Makefile
+++ b/ZAPDTR/Makefile
@@ -45,7 +45,7 @@ endif
 # CXXFLAGS += -DTEXTURE_DEBUG
 
 LDFLAGS := -lm -ldl -lpng \
-  -L../external -L../libultraship -lz -lbz2 -pthread -lpulse -lultraship -lstorm -lSDL2 -lGLEW -lGL -lX11
+  -L../StormLib/build -L../libultraship -lz -lbz2 -pthread -lpulse -lultraship -lstorm -lSDL2 -lGLEW -lGL -lX11
 
 # Use LLD if available. Set LLD=0 to not use it
 ifeq ($(shell command -v ld.lld >/dev/null 2>&1; echo $$?),0)

--- a/ZAPDTR/ZAPD/ZAudioDecode.cpp
+++ b/ZAPDTR/ZAPD/ZAudioDecode.cpp
@@ -461,8 +461,8 @@ char* OldMain(char* infilename)
 			else
 			{
 				char comprType[5] = {
-					CommChunk.compressionTypeH >> 8, CommChunk.compressionTypeH & 0xFF,
-					CommChunk.compressionTypeL >> 8, CommChunk.compressionTypeL & 0xFF, 0};
+					static_cast<char>(CommChunk.compressionTypeH >> 8), static_cast<char>(CommChunk.compressionTypeH & 0xFF),
+					static_cast<char>(CommChunk.compressionTypeL >> 8), static_cast<char>(CommChunk.compressionTypeL & 0xFF), 0};
 				fail_parse("file is of the wrong compression type [got %s (%08x)]", &comprType,
 				           cType);
 			}
@@ -603,8 +603,8 @@ char* OldMain(char* infilename)
 	{
 		s32 startPos = aloops[0].start, endPos = aloops[0].end;
 		const char* markerNames[2] = {"start", "end"};
-		Marker markers[2] = {{1, startPos >> 16, startPos & 0xffff},
-		                     {2, endPos >> 16, endPos & 0xffff}};
+		Marker markers[2] = {{1, static_cast<u16>(startPos >> 16), static_cast<u16>(startPos & 0xffff)},
+		                     {2, static_cast<u16>(endPos >> 16), static_cast<u16>(endPos & 0xffff)}};
 		write_header(ofile, "MARK", 2 + 2 * sizeof(Marker) + 1 + 5 + 1 + 3);
 		s16 numMarkers = bswap16(2);
 		fwrite(&numMarkers, sizeof(s16), 1, ofile);

--- a/libultraship/Makefile
+++ b/libultraship/Makefile
@@ -18,8 +18,11 @@ WARN := -Wall -Wextra -Werror \
 	-Wno-narrowing \
 	-Wno-missing-field-initializers
 
-CXXFLAGS := $(WARN) -std=c++20 -D_GNU_SOURCE -DENABLE_OPENGL -DSPDLOG_ACTIVE_LEVEL=0 -m32
-CFLAGS := $(WARN) -std=c99 -D_GNU_SOURCE -DENABLE_OPENGL -DSPDLOG_ACTIVE_LEVEL=0 -m32
+CWARN :=
+CXXWARN := -Wno-deprecated-enum-enum-conversion
+
+CXXFLAGS := $(WARN) $(CXXWARN) -std=c++20 -D_GNU_SOURCE -DENABLE_OPENGL -DSPDLOG_ACTIVE_LEVEL=0
+CFLAGS := $(WARN) $(CWARN) -std=c99 -D_GNU_SOURCE -DENABLE_OPENGL -DSPDLOG_ACTIVE_LEVEL=0
 CPPFLAGS := -MMD
 
 ifneq ($(DEBUG),0)
@@ -40,10 +43,10 @@ endif
 SRC_DIRS  := $(shell find -type d -not -path "*build*")
 
 CXX_FILES := \
-	$(shell find libultraship/Factories -name *.cpp) \
-	$(shell find libultraship/Lib/Fast3D -name *.cpp) \
-	$(shell find libultraship -maxdepth 1 -name *.cpp) \
-	$(shell find libultraship/Lib/ImGui -maxdepth 1 -name *.cpp) \
+	$(shell find libultraship/Factories -name "*.cpp") \
+	$(shell find libultraship/Lib/Fast3D -name *.cpp") \
+	$(shell find libultraship -maxdepth 1 -name "*.cpp") \
+	$(shell find libultraship/Lib/ImGui -maxdepth 1 -name "*.cpp") \
 	libultraship/Lib/ImGui/backends/imgui_impl_opengl3.cpp \
 	libultraship/Lib/ImGui/backends/imgui_impl_sdl.cpp \
 	libultraship/Lib/StrHash64.cpp \
@@ -53,7 +56,7 @@ C_FILES := \
 	libultraship/mixer.c \
 	libultraship/Lib/stb/stb_impl.c
 
-FMT_FILES := $(shell find libultraship/ -type f \( -name *.cpp -o -name *.h \) -a -not -path "libultraship/Lib/*")
+FMT_FILES := $(shell find libultraship/ -type f \( -name "*.cpp" -o -name "*.h" \) -a -not -path "libultraship/Lib/*")
 
 O_FILES   := \
 	$(CXX_FILES:%.cpp=build/%.o) \
@@ -69,6 +72,7 @@ INC_DIRS := $(addprefix -I, \
 	libultraship/Lib/spdlog \
 	libultraship/Lib/spdlog/include \
 	libultraship \
+	../StormLib/src \
 )
 
 # create build directories

--- a/libultraship/Makefile
+++ b/libultraship/Makefile
@@ -44,7 +44,7 @@ SRC_DIRS  := $(shell find -type d -not -path "*build*")
 
 CXX_FILES := \
 	$(shell find libultraship/Factories -name "*.cpp") \
-	$(shell find libultraship/Lib/Fast3D -name *.cpp") \
+	$(shell find libultraship/Lib/Fast3D -name "*.cpp") \
 	$(shell find libultraship -maxdepth 1 -name "*.cpp") \
 	$(shell find libultraship/Lib/ImGui -maxdepth 1 -name "*.cpp") \
 	libultraship/Lib/ImGui/backends/imgui_impl_opengl3.cpp \

--- a/libultraship/libultraship/Lib/Fast3D/U64/PR/ultra64/message.h
+++ b/libultraship/libultraship/Lib/Fast3D/U64/PR/ultra64/message.h
@@ -6,7 +6,23 @@
 #define OS_MESG_NOBLOCK         0
 #define OS_MESG_BLOCK           1
 
-typedef void* OSMesg;
+typedef union {
+    u8 data8;
+    u16 data16;
+    u32 data32;
+    void* ptr;
+} OSMesg;
+
+#define OS_MESG_8(x) ((OSMesg) { .data8 = (x) })
+#define OS_MESG_16(x) ((OSMesg) { .data16 = (x) })
+#define OS_MESG_32(x) ((OSMesg) { .data32 = (x) })
+#define OS_MESG_PTR(x) ((OSMesg) { .ptr = (x) })
+
+#define osSendMesg8(queue, msg, flag) osSendMesg(queue, OS_MESG_8(msg), flag)
+#define osSendMesg16(queue, msg, flag) osSendMesg(queue, OS_MESG_16(msg), flag)
+#define osSendMesg32(queue, msg, flag) osSendMesg(queue, OS_MESG_32(msg), flag)
+#define osSendMesgPtr(queue, msg, flag) osSendMesg(queue, OS_MESG_PTR(msg), flag)
+
 typedef u32 OSEvent;
 
 #define OS_NUM_EVENTS           15

--- a/libultraship/libultraship/Lib/Fast3D/gfx_pc.h
+++ b/libultraship/libultraship/Lib/Fast3D/gfx_pc.h
@@ -5,6 +5,7 @@
 #include <stdint.h>
 #include <unordered_map>
 #include <list>
+#include <cstddef>
 
 #include "U64/PR/ultra64/types.h"
 

--- a/libultraship/libultraship/Resource.h
+++ b/libultraship/libultraship/Resource.h
@@ -30,9 +30,9 @@ namespace Ship
         Array            =   0x4F415252,     // OARR
         Text             =   0x4F545854,     // OTXT
         Blob             =   0x4F424C42,     // OBLB
-        Audio            =   'OAUD',
-        AudioSample      =   'OSMP',
-        AudioSoundFont   =   'OSFT',
+        Audio            =   0x4F415544,     // OAUD
+        AudioSample      =   0x4F534D50,     // OSMP
+        AudioSoundFont   =   0x4F534654,     // OSFT
     };
 
     enum class DataType

--- a/soh/Makefile
+++ b/soh/Makefile
@@ -30,11 +30,13 @@ endif
 
 ifneq ($(ASAN),0)
 	CXXFLAGS += -fsanitize=address
+	CFLAGS += -fsanitize=address
 	LDFLAGS += -fsanitize=address
 endif
 
 ifneq ($(LTO),0)
 	CXXFLAGS += -flto
+	CFLAGS += -flto
 	LDFLAGS += -flto
 endif
 

--- a/soh/Makefile
+++ b/soh/Makefile
@@ -16,11 +16,11 @@ LTO ?= 0
 WARN := \
 	-Wno-return-type \
 	-funsigned-char \
-	-m32 -mhard-float -fno-stack-protector -fno-common -fno-zero-initialized-in-bss -fno-strict-aliasing -fno-inline-functions -fno-inline-small-functions -fno-toplevel-reorder -ffreestanding -fwrapv \
+	-mhard-float -fno-stack-protector -fno-common -fno-zero-initialized-in-bss -fno-strict-aliasing -fno-inline-functions -fno-inline-small-functions -fno-toplevel-reorder -ffreestanding -fwrapv \
 
-CXXFLAGS := $(WARN) -std=c++20 -D_GNU_SOURCE -fpermissive -no-pie -nostdlib -march=i386 -msse2 -mfpmath=sse
-CFLAGS := $(WARN) -std=c99 -D_GNU_SOURCE -no-pie -nostdlib -march=i386 -msse2 -mfpmath=sse
-LDFLAGS := -m32
+CXXFLAGS := $(WARN) -std=c++20 -D_GNU_SOURCE -fpermissive -no-pie -nostdlib -msse2 -mfpmath=sse
+CFLAGS := $(WARN) -std=c99 -D_GNU_SOURCE -no-pie -nostdlib -msse2 -mfpmath=sse
+LDFLAGS :=
 CPPFLAGS := -MMD
 
 ifneq ($(DEBUG),0)
@@ -54,7 +54,7 @@ INC_DIRS := $(addprefix -I, \
 )
 
 LDDIRS := $(addprefix -L, \
-	../external \
+	../StormLib/build \
 	../libultraship/ \
 )
 
@@ -87,14 +87,14 @@ TEXTURE_FILES_OUT := $(foreach f,$(TEXTURE_FILES_PNG:.png=.inc.c),build/$f) \
 					 $(foreach f,$(TEXTURE_FILES_JPG:.jpg=.jpg.inc.c),build/$f) \
 
 CXX_FILES := \
-	$(shell find soh -type f -name *.cpp)
+	$(shell find soh -type f -name "*.cpp")
 
 C_FILES := \
-	$(shell find soh -type f -name *.c) \
-	$(shell find src/boot -type f -name *.c) \
-	$(shell find src/buffers -type f -name *.c) \
-	$(shell find src/code -type f -name *.c) \
-	$(shell find src/overlays -type f -name *.c) \
+	$(shell find soh -type f -name "*.c") \
+	$(shell find src/boot -type f -name "*.c") \
+	$(shell find src/buffers -type f -name "*.c") \
+	$(shell find src/code -type f -name "*.c") \
+	$(shell find src/overlays -type f -name "*.c") \
 	src/libultra/gu/coss.c \
 	src/libultra/gu/guLookAt.c \
 	src/libultra/gu/guLookAtHilite.c \
@@ -125,6 +125,8 @@ setup:
 	$(MAKE) mpq
 
 mpq:
+	cmake -B ../StormLib/build -S ../StormLib
+	cmake --build ../StormLib/build
 	$(MAKE) -C ../libultraship
 	$(MAKE) -C ../OTRExporter/OTRExporter
 	$(MAKE) -C ../ZAPDTR
@@ -137,6 +139,7 @@ distclean: clean
 	$(MAKE) clean -C ../libultraship
 	$(MAKE) clean -C ../OTRExporter/OTRExporter
 	$(MAKE) clean -C ../ZAPDTR
+	rm -rf ../StormLib/build
 
 clean:
 	rm -rf build $(TARGET)

--- a/soh/include/z64audio.h
+++ b/soh/include/z64audio.h
@@ -120,7 +120,7 @@ typedef struct {
     /* 0x08 */ s16 book[1]; // size 8 * order * npredictors. 8-byte aligned
 } AdpcmBook; // size >= 0x8
 
-typedef struct 
+typedef struct
 {
     union {
         struct {
@@ -143,7 +143,7 @@ typedef struct {
     /* 0x04 */ union {
         u32 tuningAsU32;
         f32 tuning;// frequency scale factor
-    };            
+    };
 } SoundFontSound; // size = 0x8
 
 typedef struct {
@@ -689,7 +689,7 @@ typedef struct {
         };
     };
     union {
-        void* data;
+        u32 data;
         f32 asFloat;
         s32 asInt;
         struct {

--- a/soh/src/boot/z_std_dma.c
+++ b/soh/src/boot/z_std_dma.c
@@ -312,7 +312,7 @@ void DmaMgr_ThreadEntry(void* arg0) {
     osSyncPrintf("ＤＭＡマネージャスレッド実行開始\n");
     while (true) {
         osRecvMesg(&sDmaMgrMsgQueue, &msg, OS_MESG_BLOCK);
-        req = (DmaRequest*)msg;
+        req = (DmaRequest*)msg.ptr;
         if (req == NULL) {
             break;
         }
@@ -360,7 +360,7 @@ s32 DmaMgr_SendRequestImpl(DmaRequest* req, uintptr_t ram, uintptr_t vrom, size_
         }
     }
 
-    osSendMesg(&sDmaMgrMsgQueue, req, OS_MESG_BLOCK);
+    osSendMesgPtr(&sDmaMgrMsgQueue, req, OS_MESG_BLOCK);
     return 0;
 }
 
@@ -371,7 +371,7 @@ s32 DmaMgr_SendRequest0(uintptr_t ram, uintptr_t vrom, size_t size) {
     s32 ret;
 
     osCreateMesgQueue(&queue, &msg, 1);
-    ret = DmaMgr_SendRequestImpl(&req, ram, vrom, size, 0, &queue, NULL);
+    ret = DmaMgr_SendRequestImpl(&req, ram, vrom, size, 0, &queue, OS_MESG_PTR(NULL));
     if (ret == -1) {
         return ret;
     }
@@ -413,7 +413,7 @@ void DmaMgr_Init(void) {
     }
 
 #if 0
-    if ((uintptr_t)_bootSegmentRomStart != gDmaDataTable[0].vromEnd) 
+    if ((uintptr_t)_bootSegmentRomStart != gDmaDataTable[0].vromEnd)
     {
         osSyncPrintf("_bootSegmentRomStart(%08x) != dma_rom_ad[0].rom_b(%08x)\n", _bootSegmentRomStart,
                      gDmaDataTable[0].vromEnd);

--- a/soh/src/code/__osMalloc.c
+++ b/soh/src/code/__osMalloc.c
@@ -63,7 +63,7 @@ void ArenaImpl_LockInit(Arena* arena) {
 }
 
 void ArenaImpl_Lock(Arena* arena) {
-    osSendMesg(&arena->lock, NULL, OS_MESG_BLOCK);
+    osSendMesgPtr(&arena->lock, NULL, OS_MESG_BLOCK);
 }
 
 void ArenaImpl_Unlock(Arena* arena) {

--- a/soh/src/code/audioMgr.c
+++ b/soh/src/code/audioMgr.c
@@ -7,7 +7,7 @@ void func_800C3C80(AudioMgr* audioMgr) {
 
     task = audioMgr->rspTask;
     if (audioMgr->rspTask->taskQueue != NULL) {
-        osSendMesg(task->taskQueue, NULL, OS_MESG_BLOCK);
+        osSendMesgPtr(task->taskQueue, NULL, OS_MESG_BLOCK);
     }
 }
 
@@ -25,8 +25,8 @@ void AudioMgr_HandleRetrace(AudioMgr* audioMgr) {
         audioMgr->audioTask.list = audioMgr->rspTask->task;
         audioMgr->audioTask.msgQ = &audioMgr->unk_AC;
 
-        audioMgr->audioTask.msg = NULL;
-        osSendMesg(&audioMgr->sched->cmdQ, &audioMgr->audioTask, OS_MESG_BLOCK);
+        audioMgr->audioTask.msg.ptr = NULL;
+        osSendMesgPtr(&audioMgr->sched->cmdQ, &audioMgr->audioTask, OS_MESG_BLOCK);
         Sched_SendEntryMsg(audioMgr->sched);
     }
 
@@ -96,7 +96,7 @@ void AudioMgr_Init(AudioMgr* audioMgr, void* stack, OSPri pri, OSId id, SchedCon
     osCreateMesgQueue(&audioMgr->unk_74, &audioMgr->unk_8C, 8);
     osCreateMesgQueue(&audioMgr->unk_C8, &audioMgr->unk_E0, 1);
 
-    osSendMesg(&audioMgr->unk_AC, NULL, OS_MESG_BLOCK);
+    osSendMesgPtr(&audioMgr->unk_AC, NULL, OS_MESG_BLOCK);
 
         static bool hasInitialized = false;
 
@@ -107,7 +107,7 @@ void AudioMgr_Init(AudioMgr* audioMgr, void* stack, OSPri pri, OSId id, SchedCon
         Audio_Init();
         AudioLoad_SetDmaHandler(DmaMgr_DmaHandler);
         Audio_InitSound();
-        osSendMesg(&audioMgr->unk_C8, NULL, OS_MESG_BLOCK);
+        osSendMesgPtr(&audioMgr->unk_C8, NULL, OS_MESG_BLOCK);
         ModInternal_ExecuteAudioInitHooks();
         // Removed due to crash
         //IrqMgr_AddClient(audioMgr->irqMgr, &irqClient, &audioMgr->unk_74);

--- a/soh/src/code/audio_load.c
+++ b/soh/src/code/audio_load.c
@@ -461,7 +461,7 @@ s32 AudioLoad_SyncLoadInstrument(s32 fontId, s32 instId, s32 drumId) {
 
 void AudioLoad_AsyncLoad(s32 tableType, s32 id, s32 nChunks, s32 retData, OSMesgQueue* retQueue) {
     if (AudioLoad_AsyncLoadInner(tableType, id, nChunks, retData, retQueue) == NULL) {
-        osSendMesg(retQueue, 0xFFFFFFFF, OS_MESG_NOBLOCK);
+        osSendMesg32(retQueue, 0xFFFFFFFF, OS_MESG_NOBLOCK);
     }
 }
 
@@ -1079,7 +1079,7 @@ void* AudioLoad_AsyncLoadInner(s32 tableType, s32 id, s32 nChunks, s32 retData, 
     ret = AudioLoad_SearchCaches(tableType, realId);
     if (ret != NULL) {
         status = 2;
-        osSendMesg(retQueue, MK_ASYNC_MSG(retData, 0, 0, 0), OS_MESG_NOBLOCK);
+        osSendMesg32(retQueue, MK_ASYNC_MSG(retData, 0, 0, 0), OS_MESG_NOBLOCK);
     } else {
         sp50 = AudioLoad_GetLoadTable(tableType);
         size = sp50->entries[realId].size;
@@ -1312,19 +1312,12 @@ void AudioLoad_Init(void* heap, size_t heapSize) {
     void* temp_v0_3;
     s32 i;
     u64* heapP;
-    u8* ctxP;
     s16* u2974p;
 
     D_801755D0 = NULL;
     gAudioContext.resetTimer = 0;
 
-    {
-        s32 i;
-        u8* ctxP = (u8*)&gAudioContext;
-        for (i = sizeof(gAudioContext); i >= 0; i--) {
-            *ctxP++ = 0;
-        }
-    }
+    memset(&gAudioContext, 0, sizeof(gAudioContext));
 
     switch (osTvType) {
         case OS_TV_PAL:
@@ -1421,7 +1414,7 @@ void AudioLoad_Init(void* heap, size_t heapSize) {
 
     AudioHeap_AllocPoolInit(&gAudioContext.permanentPool, temp_v0_3, D_8014A6C4.permanentPoolSize);
     gAudioContextInitalized = true;
-    osSendMesg(gAudioContext.taskStartQueueP, (void*)gAudioContext.totalTaskCnt, OS_MESG_NOBLOCK);
+    osSendMesg32(gAudioContext.taskStartQueueP, gAudioContext.totalTaskCnt, OS_MESG_NOBLOCK);
 }
 
 void AudioLoad_InitSlowLoads(void) {
@@ -1649,7 +1642,7 @@ AudioAsyncLoad* AudioLoad_StartAsyncLoadUnkMedium(s32 unkMediumParam, uintptr_t 
         return NULL;
     }
 
-    osSendMesg(&gAudioContext.asyncLoadUnkMediumQueue, asyncLoad, OS_MESG_NOBLOCK);
+    osSendMesgPtr(&gAudioContext.asyncLoadUnkMediumQueue, asyncLoad, OS_MESG_NOBLOCK);
     asyncLoad->unkMediumParam = unkMediumParam;
     return asyncLoad;
 }
@@ -1765,7 +1758,7 @@ void AudioLoad_FinishAsyncLoad(AudioAsyncLoad* asyncLoad) {
             break;
     }
 
-    doneMsg = asyncLoad->retMsg;
+    doneMsg.data32 = asyncLoad->retMsg;
     if (1) {}
     asyncLoad->status = LOAD_STATUS_WAITING;
     osSendMesg(asyncLoad->retQueue, doneMsg, OS_MESG_NOBLOCK);

--- a/soh/src/code/audio_load.c
+++ b/soh/src/code/audio_load.c
@@ -51,9 +51,9 @@ s32 AudioLoad_Dma(OSIoMesg* mesg, u32 priority, s32 direction, uintptr_t devAddr
                   OSMesgQueue* reqQueue, s32 medium, const char* dmaFuncType);
 void* AudioLoad_AsyncLoadInner(s32 tableType, s32 id, s32 nChunks, s32 retData, OSMesgQueue* retQueue);
 AudioAsyncLoad* AudioLoad_StartAsyncLoadUnkMedium(s32 unkMediumParam, uintptr_t devAddr, uintptr_t ramAddr,
-                                                  ptrdiff_t size, s32 medium,
+                                                  size_t size, s32 medium,
                                                   s32 nChunks, OSMesgQueue* retQueue, s32 retMsg);
-AudioAsyncLoad* AudioLoad_StartAsyncLoad(u32 devAddr, uintptr_t ramAddr, size_t size, s32 medium, s32 nChunks,
+AudioAsyncLoad* AudioLoad_StartAsyncLoad(uintptr_t devAddr, uintptr_t ramAddr, size_t size, s32 medium, s32 nChunks,
                                          OSMesgQueue* retQueue, s32 retMsg);
 void AudioLoad_AsyncDma(AudioAsyncLoad* asyncLoad, size_t size);
 void AudioLoad_AsyncDmaUnkMedium(uintptr_t devAddr, uintptr_t ramAddr, size_t size, s16 arg3);
@@ -1638,7 +1638,7 @@ void AudioLoad_InitAsyncLoads(void) {
     }
 }
 
-AudioAsyncLoad* AudioLoad_StartAsyncLoadUnkMedium(s32 unkMediumParam, u32 devAddr, uintptr_t ramAddr, size_t size,
+AudioAsyncLoad* AudioLoad_StartAsyncLoadUnkMedium(s32 unkMediumParam, uintptr_t devAddr, uintptr_t ramAddr, size_t size,
                                                   s32 medium,
                                                   s32 nChunks, OSMesgQueue* retQueue, s32 retMsg) {
     AudioAsyncLoad* asyncLoad;

--- a/soh/src/code/code_800E4FE0.c
+++ b/soh/src/code/code_800E4FE0.c
@@ -39,7 +39,7 @@ extern u64 rspAspMainDataStart[];
 extern u64 rspAspMainDataEnd[];
 
 void AudioMgr_CreateNextAudioBuffer(s16* samples, u32 num_samples) {
-    u32 sp4C;
+    OSMesg sp4C;
 
     gAudioContext.totalTaskCnt++;
 
@@ -50,7 +50,7 @@ void AudioMgr_CreateNextAudioBuffer(s16* samples, u32 num_samples) {
     if (gAudioContext.resetStatus != 0) {
         if (AudioHeap_ResetStep() == 0) {
             if (gAudioContext.resetStatus == 0) {
-                osSendMesg(gAudioContext.audioResetQueueP, gAudioContext.audioResetSpecIdToLoad, OS_MESG_NOBLOCK);
+                osSendMesg8(gAudioContext.audioResetQueueP, gAudioContext.audioResetSpecIdToLoad, OS_MESG_NOBLOCK);
             }
         }
     }
@@ -58,8 +58,8 @@ void AudioMgr_CreateNextAudioBuffer(s16* samples, u32 num_samples) {
     int j = 0;
     if (gAudioContext.resetStatus == 0) {
         // msg = 0000RREE R = read pos, E = End Pos
-        while (osRecvMesg(gAudioContext.cmdProcQueueP, (OSMesg*)&sp4C, OS_MESG_NOBLOCK) != -1) {
-            Audio_ProcessCmds(sp4C);
+        while (osRecvMesg(gAudioContext.cmdProcQueueP, &sp4C, OS_MESG_NOBLOCK) != -1) {
+            Audio_ProcessCmds(sp4C.data32);
             j++;
         }
         if ((j == 0) && (gAudioContext.cmdQueueFinished)) {
@@ -84,7 +84,7 @@ AudioTask* func_800E5000(void) {
     s16* currAiBuffer;
     OSTask_t* task;
     s32 index;
-    u32 sp4C;
+    OSMesg sp4C;
     s32 sp48;
     s32 i;
 
@@ -102,7 +102,7 @@ AudioTask* func_800E5000(void) {
         }
     }
 
-    osSendMesg(gAudioContext.taskStartQueueP, gAudioContext.totalTaskCnt, OS_MESG_NOBLOCK);
+    osSendMesg32(gAudioContext.taskStartQueueP, gAudioContext.totalTaskCnt, OS_MESG_NOBLOCK);
     gAudioContext.rspTaskIdx ^= 1;
     gAudioContext.curAIBufIdx++;
     gAudioContext.curAIBufIdx %= 3;
@@ -149,7 +149,7 @@ AudioTask* func_800E5000(void) {
     if (gAudioContext.resetStatus != 0) {
         if (AudioHeap_ResetStep() == 0) {
             if (gAudioContext.resetStatus == 0) {
-                osSendMesg(gAudioContext.audioResetQueueP, gAudioContext.audioResetSpecIdToLoad, OS_MESG_NOBLOCK);
+                osSendMesg8(gAudioContext.audioResetQueueP, gAudioContext.audioResetSpecIdToLoad, OS_MESG_NOBLOCK);
             }
 
             sWaitingAudioTask = NULL;
@@ -186,11 +186,11 @@ AudioTask* func_800E5000(void) {
     j = 0;
     if (gAudioContext.resetStatus == 0) {
         // msg = 0000RREE R = read pos, E = End Pos
-        while (osRecvMesg(gAudioContext.cmdProcQueueP, (OSMesg*)&sp4C, OS_MESG_NOBLOCK) != -1) {
+        while (osRecvMesg(gAudioContext.cmdProcQueueP, &sp4C, OS_MESG_NOBLOCK) != -1) {
             if (1) {}
             if (1) {}
             if (1) {}
-            Audio_ProcessCmds(sp4C);
+            Audio_ProcessCmds(sp4C.data32);
             j++;
         }
         if ((j == 0) && (gAudioContext.cmdQueueFinished)) {
@@ -386,11 +386,11 @@ void Audio_InitMesgQueuesInternal(void) {
                       ARRAY_COUNT(gAudioContext.audioResetMesgs));
 }
 
-void Audio_QueueCmd(u32 opArgs, void** data) {
+void Audio_QueueCmd(u32 opArgs, u32 data) {
     AudioCmd* cmd = &gAudioContext.cmdBuf[gAudioContext.cmdWrPos & 0xFF];
 
     cmd->opArgs = opArgs;
-    cmd->data = *data;
+    cmd->data = data;
 
     gAudioContext.cmdWrPos++;
 
@@ -400,23 +400,28 @@ void Audio_QueueCmd(u32 opArgs, void** data) {
 }
 
 void Audio_QueueCmdF32(u32 opArgs, f32 data) {
-    Audio_QueueCmd(opArgs, (void**)&data);
+    union
+    {
+        f32 f;
+        u32 u;
+    } uData = { .f = data };
+    Audio_QueueCmd(opArgs, uData.u);
 }
 
 void Audio_QueueCmdS32(u32 opArgs, s32 data) {
-    Audio_QueueCmd(opArgs, (void**)&data);
+    Audio_QueueCmd(opArgs, data);
 }
 
 void Audio_QueueCmdS8(u32 opArgs, s8 data) {
     u32 uData = data << 0x18;
 
-    Audio_QueueCmd(opArgs, (void**)&uData);
+    Audio_QueueCmd(opArgs, uData);
 }
 
 void Audio_QueueCmdU16(u32 opArgs, u16 data) {
     u32 uData = data << 0x10;
 
-    Audio_QueueCmd(opArgs, (void**)&uData);
+    Audio_QueueCmd(opArgs, uData);
 }
 
 s32 Audio_ScheduleProcessCmds(void) {
@@ -428,8 +433,8 @@ s32 Audio_ScheduleProcessCmds(void) {
     }
 
     ret =
-        osSendMesg(gAudioContext.cmdProcQueueP,
-                   (void*)(((gAudioContext.cmdRdPos & 0xFF) << 8) | (gAudioContext.cmdWrPos & 0xFF)), OS_MESG_NOBLOCK);
+        osSendMesg32(gAudioContext.cmdProcQueueP,
+                   (((gAudioContext.cmdRdPos & 0xFF) << 8) | (gAudioContext.cmdWrPos & 0xFF)), OS_MESG_NOBLOCK);
     if (ret != -1) {
         gAudioContext.cmdRdPos = gAudioContext.cmdWrPos;
         ret = 0;
@@ -531,11 +536,11 @@ void func_800E5EA4(s32 arg0, u32* arg1, u32* arg2) {
 
 s32 func_800E5EDC(void) {
     s32 pad;
-    s32 sp18;
+    OSMesg sp18;
 
-    if (osRecvMesg(gAudioContext.audioResetQueueP, (OSMesg*)&sp18, OS_MESG_NOBLOCK) == -1) {
+    if (osRecvMesg(gAudioContext.audioResetQueueP, &sp18, OS_MESG_NOBLOCK) == -1) {
         return 0;
-    } else if (gAudioContext.audioResetSpecIdToLoad != sp18) {
+    } else if (gAudioContext.audioResetSpecIdToLoad != sp18.data8) {
         return -1;
     } else {
         return 1;
@@ -545,7 +550,7 @@ s32 func_800E5EDC(void) {
 void func_800E5F34(void) {
     // macro?
     // clang-format off
-    s32 chk = -1; s32 sp28; do {} while (osRecvMesg(gAudioContext.audioResetQueueP, (OSMesg*)&sp28, OS_MESG_NOBLOCK) != chk);
+    s32 chk = -1; OSMesg sp28; do {} while (osRecvMesg(gAudioContext.audioResetQueueP, &sp28, OS_MESG_NOBLOCK) != chk);
     // clang-format on
 }
 

--- a/soh/src/code/game.c
+++ b/soh/src/code/game.c
@@ -240,7 +240,7 @@ int fbTest = -1;
 void GameState_Update(GameState* gameState) {
     GraphicsContext* gfxCtx = gameState->gfxCtx;
 
-    if (fbTest == -1) 
+    if (fbTest == -1)
     {
         fbTest = gfx_create_framebuffer(64, 112);
         //fbTest = gfx_create_framebuffer(256, 512);
@@ -323,18 +323,18 @@ void GameState_Update(GameState* gameState) {
         GameState_Draw(gameState, gfxCtx);
         func_800C49F4(gfxCtx);
     }
-    
+
     // -----------------------
     // Cheats hooks
     // -----------------------
-    
+
     // Inf Money
     if (CVar_GetS32("gInfiniteMoney", 0) != 0) {
         if (gSaveContext.rupees < CUR_CAPACITY(UPG_WALLET)) {
             gSaveContext.rupees = CUR_CAPACITY(UPG_WALLET);
         }
     }
-    
+
     // Inf Health
     if (CVar_GetS32("gInfiniteHealth", 0) != 0) {
         if (gSaveContext.health < gSaveContext.healthCapacity) {
@@ -348,33 +348,33 @@ void GameState_Update(GameState* gameState) {
         if (AMMO(ITEM_STICK) < CUR_CAPACITY(UPG_STICKS)) {
             AMMO(ITEM_STICK) = CUR_CAPACITY(UPG_STICKS);
         }
-        
+
         // Deku Nuts
         if (AMMO(ITEM_NUT) < CUR_CAPACITY(UPG_NUTS)) {
             AMMO(ITEM_NUT) = CUR_CAPACITY(UPG_NUTS);
         }
-        
+
         // Bombs
         if (AMMO(ITEM_BOMB) < CUR_CAPACITY(UPG_BOMB_BAG)) {
             AMMO(ITEM_BOMB) = CUR_CAPACITY(UPG_BOMB_BAG);
         }
-        
+
         // Fairy Bow (Ammo)
         if (AMMO(ITEM_BOW) < CUR_CAPACITY(UPG_QUIVER)) {
             AMMO(ITEM_BOW) = CUR_CAPACITY(UPG_QUIVER);
         }
-        
+
         // Fairy Slingshot (Ammo)
         if (AMMO(ITEM_SLINGSHOT) < CUR_CAPACITY(UPG_BULLET_BAG)) {
             AMMO(ITEM_SLINGSHOT) = CUR_CAPACITY(UPG_BULLET_BAG);
         }
-        
+
         // Bombchus (max: 50, no upgrades)
         if (AMMO(ITEM_BOMBCHU) < 50) {
             AMMO(ITEM_BOMBCHU) = 50;
         }
     }
-    
+
     // Inf Magic
     if (CVar_GetS32("gInfiniteMagic", 0) != 0) {
         if (gSaveContext.magicAcquired && gSaveContext.magic != (gSaveContext.doubleMagic + 1) * 0x30) {
@@ -386,7 +386,7 @@ void GameState_Update(GameState* gameState) {
     if (CVar_GetS32("gInfiniteNayru", 0) != 0) {
         gSaveContext.nayrusLoveTimer = 0x44B;
     }
-    
+
     // Moon Jump On L
     if (CVar_GetS32("gMoonJumpOnL", 0) != 0) {
         if (gGlobalCtx) {
@@ -424,7 +424,7 @@ void GameState_Update(GameState* gameState) {
     } else {
         CVar_SetS32("gPrevTime", -1);
     }
-   
+
     //since our CVar is same value and properly default to 0 there is not problems doing this in single line.
     gSaveContext.language = CVar_GetS32("gLanguages", 0);
 
@@ -525,7 +525,7 @@ void GameState_Init(GameState* gameState, GameStateFunc init, GraphicsContext* g
     }
     SpeedMeter_Init(&D_801664D0);
     func_800AA0B4();
-    osSendMesg(&gameState->gfxCtx->queue, NULL, OS_MESG_BLOCK);
+    osSendMesgPtr(&gameState->gfxCtx->queue, NULL, OS_MESG_BLOCK);
 
     endTime = osGetTime();
     // "Other initialization processing time %d us"

--- a/soh/src/code/graph.c
+++ b/soh/src/code/graph.c
@@ -170,12 +170,12 @@ void Graph_TaskSet00(GraphicsContext* gfxCtx) {
 
     D_8016A528 = osGetTime() - sGraphSetTaskTime - D_8016A558;
 
-    osSetTimer(&timer, OS_USEC_TO_CYCLES(3000000), 0, &gfxCtx->queue, (OSMesg)666);
+    osSetTimer(&timer, OS_USEC_TO_CYCLES(3000000), 0, &gfxCtx->queue, OS_MESG_32(666));
 
     osRecvMesg(&gfxCtx->queue, &msg, OS_MESG_BLOCK);
     osStopTimer(&timer);
     //OTRTODO - Proper GFX crash handler
-    #if 0 
+    #if 0
     if (msg == (OSMesg)666) {
         osSyncPrintf(VT_FGCOL(RED));
         osSyncPrintf("RCPが帰ってきませんでした。"); // "RCP did not return."
@@ -194,7 +194,7 @@ void Graph_TaskSet00(GraphicsContext* gfxCtx) {
         }
         Fault_AddHungupAndCrashImpl("RCP is HUNG UP!!", "Oh! MY GOD!!");
     }
-    #endif 
+    #endif
     osRecvMesg(&gfxCtx->queue, &msg, OS_MESG_NOBLOCK);
 
     D_8012D260 = gfxCtx->workBuffer;
@@ -243,7 +243,7 @@ void Graph_TaskSet00(GraphicsContext* gfxCtx) {
     }
 
     scTask->msgQ = &gfxCtx->queue;
-    scTask->msg = NULL;
+    scTask->msg.ptr = NULL;
 
     cfb = &sGraphCfbInfos[sGraphCfbInfoIdx++];
     cfb->fb1 = gfxCtx->curFrameBuffer;
@@ -262,7 +262,7 @@ void Graph_TaskSet00(GraphicsContext* gfxCtx) {
 
     gfxCtx->schedMsgQ = &gSchedContext.cmdQ;
 
-    osSendMesg(&gSchedContext.cmdQ, scTask, OS_MESG_BLOCK);
+    osSendMesgPtr(&gSchedContext.cmdQ, scTask, OS_MESG_BLOCK);
     Sched_SendEntryMsg(&gSchedContext);
 }
 
@@ -399,7 +399,7 @@ void Graph_Update(GraphicsContext* gfxCtx, GameState* gameState) {
         sGraphUpdateTime = time;
     }
 
-    if (CVar_GetS32("gDebugEnabled", 0)) 
+    if (CVar_GetS32("gDebugEnabled", 0))
     {
         if (CHECK_BTN_ALL(gameState->input[0].press.button, BTN_Z) &&
             CHECK_BTN_ALL(gameState->input[0].cur.button, BTN_L | BTN_R)) {
@@ -475,14 +475,14 @@ static void RunFrame()
         {
             uint64_t ticksA, ticksB;
             ticksA = GetPerfCounter();
-            
+
             Graph_StartFrame();
 
             // TODO: Workaround for rumble being too long. Implement os thread functions.
             for (int i = 0; i < 3; i++) {
                 PadMgr_ThreadEntry(&gPadMgr);
             }
-            
+
             Graph_Update(&runFrameContext.gfxCtx, runFrameContext.gameState);
             ticksB = GetPerfCounter();
 

--- a/soh/src/code/main.c
+++ b/soh/src/code/main.c
@@ -87,7 +87,7 @@ void Main(void* arg) {
     R_ENABLE_ARENA_DBG = 0;
 
     osCreateMesgQueue(&sSiIntMsgQ, sSiIntMsgBuf, 1);
-    osSetEventMesg(5, &sSiIntMsgQ, 0);
+    osSetEventMesg(5, &sSiIntMsgQ, OS_MESG_PTR(NULL));
 
     Main_LogSystemHeap();
 
@@ -118,7 +118,7 @@ void Main(void* arg) {
 
     while (true) {
         msg = NULL;
-        osRecvMesg(&irqMgrMsgQ, (OSMesg)&msg, OS_MESG_BLOCK);
+        osRecvMesg(&irqMgrMsgQ, (OSMesg*)&msg, OS_MESG_BLOCK);
         if (msg == NULL) {
             break;
         }

--- a/soh/src/code/padmgr.c
+++ b/soh/src/code/padmgr.c
@@ -20,7 +20,7 @@ OSMesgQueue* PadMgr_LockSerialMesgQueue(PadMgr* padMgr) {
                      padMgr->serialMsgQ.validCount, padMgr, &padMgr->serialMsgQ, &ctrlrQ);
     }
 
-    osRecvMesg(&padMgr->serialMsgQ, (OSMesg)&ctrlrQ, OS_MESG_BLOCK);
+    osRecvMesg(&padMgr->serialMsgQ, (OSMesg*)&ctrlrQ, OS_MESG_BLOCK);
 
     if (D_8012D280 > 2) {
         // "serialMsgQ Locked"
@@ -38,7 +38,7 @@ void PadMgr_UnlockSerialMesgQueue(PadMgr* padMgr, OSMesgQueue* ctrlrQ) {
                      padMgr->serialMsgQ.validCount, padMgr, &padMgr->serialMsgQ, ctrlrQ);
     }
 
-    osSendMesg(&padMgr->serialMsgQ, ctrlrQ, OS_MESG_BLOCK);
+    osSendMesgPtr(&padMgr->serialMsgQ, ctrlrQ, OS_MESG_BLOCK);
 
     if (D_8012D280 > 2) {
         // "serialMsgQ Unlocked"
@@ -52,7 +52,7 @@ void PadMgr_LockPadData(PadMgr* padMgr) {
 }
 
 void PadMgr_UnlockPadData(PadMgr* padMgr) {
-    osSendMesg(&padMgr->lockMsgQ, NULL, OS_MESG_BLOCK);
+    osSendMesgPtr(&padMgr->lockMsgQ, NULL, OS_MESG_BLOCK);
 }
 
 void PadMgr_RumbleControl(PadMgr* padMgr) {
@@ -174,7 +174,7 @@ void PadMgr_RumbleStop(PadMgr* padMgr) {
     for (i = 0; i < 4; i++) {
         if (osMotorInit(ctrlrQ, &padMgr->pfs[i], i) == 0) {
 #if 0
-            if ((gFaultStruct.msgId == 0) && (padMgr->rumbleOnFrames != 0)) 
+            if ((gFaultStruct.msgId == 0) && (padMgr->rumbleOnFrames != 0))
             {
                 osSyncPrintf(VT_FGCOL(YELLOW));
                 // "Stop vibration pack"
@@ -399,7 +399,7 @@ void PadMgr_ThreadEntry(PadMgr* padMgr) {
             osSyncPrintf("コントローラスレッドイベント待ち %lld\n", OS_CYCLES_TO_USEC(osGetTime()));
         }
 
-        osRecvMesg(&padMgr->interruptMsgQ, (OSMesg)&mesg, OS_MESG_BLOCK);
+        osRecvMesg(&padMgr->interruptMsgQ, (OSMesg*)&mesg, OS_MESG_BLOCK);
         //LogUtils_CheckNullPointer("msg", mesg, "../padmgr.c", 563);
 
         PadMgr_HandleRetraceMsg(padMgr);

--- a/soh/src/code/sleep.c
+++ b/soh/src/code/sleep.c
@@ -6,7 +6,7 @@ void Sleep_Cycles(OSTime cycles) {
     OSTimer timer;
 
     osCreateMesgQueue(&mq, &msg, OS_MESG_BLOCK);
-    osSetTimer(&timer, cycles, 0, &mq, NULL);
+    osSetTimer(&timer, cycles, 0, &mq, OS_MESG_PTR(NULL));
     osRecvMesg(&mq, NULL, OS_MESG_BLOCK);
 }
 

--- a/soh/src/code/z_lifemeter.c
+++ b/soh/src/code/z_lifemeter.c
@@ -136,7 +136,7 @@ void HealthMeter_Init(GlobalContext* globalCtx) {
         HeartDDOutline[1] = HEARTS_DD_PRIM_G;
         HeartDDOutline[2] = HEARTS_DD_PRIM_B;
     }
-    
+
     interfaceCtx->unk_228 = 0x140;
     interfaceCtx->unk_226 = gSaveContext.health;
     interfaceCtx->unk_22A = interfaceCtx->unk_1FE = 0;
@@ -162,9 +162,9 @@ void HealthMeter_Init(GlobalContext* globalCtx) {
     sHeartsDDPrim[0][1] = sHeartsDDPrim[1][1] = HeartDDOutline[1];
     sHeartsDDPrim[0][2] = sHeartsDDPrim[1][2] = HeartDDOutline[2];
 
-    sHeartsDDPrim[2][0] = HeartInner[0];
-    sHeartsDDPrim[2][1] = HeartInner[1];
-    sHeartsDDPrim[2][2] = HeartInner[2];
+    // sHeartsDDPrim[2][0] = HeartInner[0];
+    // sHeartsDDPrim[2][1] = HeartInner[1];
+    // sHeartsDDPrim[2][2] = HeartInner[2];
 
     sHeartsDDEnv[0][0] = sHeartsDDEnv[1][0] = HeartDDInner[0];
     sHeartsDDEnv[0][1] = sHeartsDDEnv[1][1] = HeartDDInner[1];
@@ -274,11 +274,11 @@ void HealthMeter_Update(GlobalContext* globalCtx) {
     sHeartsDDEnv[0][2] = HeartDDInner[2];
 
     if (CVar_GetS32("gHudColors", 1) == 2) {
-        sHeartsDDPrim[2][0] = HeartInner[0]; 
+        sHeartsDDPrim[2][0] = HeartInner[0];
         sHeartsDDPrim[2][1] = HeartInner[1];
         sHeartsDDPrim[2][2] = HeartInner[2];
 
-        sHeartsDDPrim[1][0] = HeartDDOutline[0]; 
+        sHeartsDDPrim[1][0] = HeartDDOutline[0];
         sHeartsDDPrim[1][1] = HeartDDOutline[1];
         sHeartsDDPrim[1][2] = HeartDDOutline[2];
 
@@ -286,7 +286,7 @@ void HealthMeter_Update(GlobalContext* globalCtx) {
         sHeartsDDEnv[1][1] = HeartDDInner[1];
         sHeartsDDEnv[1][2] = HeartDDInner[2];
 
-        HeartDDInner[0] = HeartInner[0]; 
+        HeartDDInner[0] = HeartInner[0];
         HeartDDInner[1] = HeartInner[1];
         HeartDDInner[2] = HeartInner[2];
 
@@ -306,9 +306,9 @@ void HealthMeter_Update(GlobalContext* globalCtx) {
         sBeatingHeartsDDEnv[1] = (u8)(gFactor + HeartDDInner[1]) & 0xFF;
         sBeatingHeartsDDEnv[2] = (u8)(bFactor + HeartDDInner[2]) & 0xFF;
     } else {
-        sHeartsDDPrim[2][0] = HEARTS_PRIM_R; 
-        sHeartsDDPrim[2][1] = HEARTS_PRIM_G;
-        sHeartsDDPrim[2][2] = HEARTS_PRIM_B;
+        // sHeartsDDPrim[2][0] = HEARTS_PRIM_R;
+        // sHeartsDDPrim[2][1] = HEARTS_PRIM_G;
+        // sHeartsDDPrim[2][2] = HEARTS_PRIM_B;
 
         sHeartsDDPrim[1][0] = HEARTS_DD_PRIM_R;
         sHeartsDDPrim[1][1] = HEARTS_DD_PRIM_G;

--- a/soh/src/code/z_msgevent.c
+++ b/soh/src/code/z_msgevent.c
@@ -10,11 +10,11 @@ void MsgEvent_SendNullTask(void) {
     task.next = NULL;
     task.flags = OS_SC_RCP_MASK;
     task.msgQ = &queue;
-    task.msg = NULL;
+    task.msg.ptr = NULL;
     task.framebuffer = NULL;
     task.list.t.type = M_NULTASK;
     osCreateMesgQueue(task.msgQ, &msg, 1);
-    osSendMesg(&gSchedContext.cmdQ, &task, OS_MESG_BLOCK);
+    osSendMesgPtr(&gSchedContext.cmdQ, &task, OS_MESG_BLOCK);
     Sched_SendEntryMsg(&gSchedContext);
     osRecvMesg(&queue, NULL, OS_MESG_BLOCK);
 }

--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -1317,7 +1317,7 @@ void Interface_LoadItemIcon1(GlobalContext* globalCtx, u16 button) {
     osCreateMesgQueue(&interfaceCtx->loadQueue, &interfaceCtx->loadMsg, OS_MESG_BLOCK);
     DmaMgr_SendRequest2(&interfaceCtx->dmaRequest_160, interfaceCtx->iconItemSegment + button * 0x1000,
                         (uintptr_t)_icon_item_staticSegmentRomStart + (gSaveContext.equips.buttonItems[button] * 0x1000),
-                        0x1000, 0, &interfaceCtx->loadQueue, NULL, "../z_parameter.c", 1171);
+                        0x1000, 0, &interfaceCtx->loadQueue, OS_MESG_PTR(NULL), "../z_parameter.c", 1171);
     osRecvMesg(&interfaceCtx->loadQueue, NULL, OS_MESG_BLOCK);
 }
 
@@ -1327,7 +1327,7 @@ void Interface_LoadItemIcon2(GlobalContext* globalCtx, u16 button) {
     osCreateMesgQueue(&interfaceCtx->loadQueue, &interfaceCtx->loadMsg, OS_MESG_BLOCK);
     DmaMgr_SendRequest2(&interfaceCtx->dmaRequest_180, interfaceCtx->iconItemSegment + button * 0x1000,
                         (uintptr_t)_icon_item_staticSegmentRomStart + (gSaveContext.equips.buttonItems[button] * 0x1000),
-                        0x1000, 0, &interfaceCtx->loadQueue, NULL, "../z_parameter.c", 1193);
+                        0x1000, 0, &interfaceCtx->loadQueue, OS_MESG_PTR(NULL), "../z_parameter.c", 1193);
     osRecvMesg(&interfaceCtx->loadQueue, NULL, OS_MESG_BLOCK);
 }
 
@@ -2164,7 +2164,7 @@ void Interface_SetNaviCall(GlobalContext* globalCtx, u16 naviCallState) {
 
     if (((naviCallState == 0x1D) || (naviCallState == 0x1E)) && !interfaceCtx->naviCalling &&
         (globalCtx->csCtx.state == CS_STATE_IDLE)) {
-        if (!CVar_GetS32("gDisableNaviCallAudio", 0)) {            
+        if (!CVar_GetS32("gDisableNaviCallAudio", 0)) {
             // clang-format off
             if (naviCallState == 0x1E) { Audio_PlaySoundGeneral(NA_SE_VO_NAVY_CALL, &D_801333D4, 4,
                                                                 &D_801333E0, &D_801333E0, &D_801333E8); }
@@ -2884,7 +2884,7 @@ void Interface_DrawItemButtons(GlobalContext* globalCtx) {
             gDPSetEnvColor(OVERLAY_DISP++, 0, 0, 0, 0);
             gDPSetCombineLERP(OVERLAY_DISP++, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0,
                               PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0);
-            
+
             //There is probably a more elegant way to do it.
             char* doAction = actionsTbl[3];
             char newName[512];
@@ -2903,7 +2903,7 @@ void Interface_DrawItemButtons(GlobalContext* globalCtx) {
                 doAction = newName;
             }
             memcpy(interfaceCtx->doActionSegment + DO_ACTION_TEX_SIZE * 2, ResourceMgr_LoadTexByName(doAction), DO_ACTION_TEX_SIZE);
-            
+
             gDPLoadTextureBlock_4b(OVERLAY_DISP++, interfaceCtx->doActionSegment + DO_ACTION_TEX_SIZE * 2, G_IM_FMT_IA,
                                    DO_ACTION_TEX_WIDTH, DO_ACTION_TEX_HEIGHT, 0, G_TX_NOMIRROR | G_TX_WRAP,
                                    G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
@@ -2987,8 +2987,8 @@ void Interface_DrawItemButtons(GlobalContext* globalCtx) {
                 //This later will feature color per C button right now that it.
                 gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetS32("gCCCBtnPrimR", R_C_BTN_COLOR(0)), CVar_GetS32("gCCCBtnPrimG", R_C_BTN_COLOR(1)), CVar_GetS32("gCCCBtnPrimB", R_C_BTN_COLOR(2)), interfaceCtx->cRightAlpha);
             }
-            
-            OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, ((u8*)gButtonBackgroundTex), 32, 32, 
+
+            OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, ((u8*)gButtonBackgroundTex), 32, 32,
                                           OTRGetRectDimensionFromRightEdge(R_ITEM_BTN_X(temp)+Right_HUD_Margin), R_ITEM_BTN_Y(temp)+(Top_HUD_Margin*-1), R_ITEM_BTN_WIDTH(temp),
                                           R_ITEM_BTN_WIDTH(temp), R_ITEM_BTN_DD(temp) << 1, R_ITEM_BTN_DD(temp) << 1);
 
@@ -3073,7 +3073,7 @@ void Interface_DrawAmmoCount(GlobalContext* globalCtx, s16 button, s16 alpha) {
         }
 
         if (i != 0) {
-            OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, (u8*)_gAmmoDigit0Tex[i], 8, 8, 
+            OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, (u8*)_gAmmoDigit0Tex[i], 8, 8,
                                           OTRGetRectDimensionFromRightEdge(R_ITEM_AMMO_X(button)+Right_HUD_Margin), R_ITEM_AMMO_Y(button)+(Top_HUD_Margin*-1), 8, 8, 1 << 10, 1 << 10);
         }
 
@@ -3444,11 +3444,11 @@ void Interface_Draw(GlobalContext* globalCtx) {
 
                 if ((player->stateFlags1 & 0x00800000) || (globalCtx->shootingGalleryStatus > 1) ||
                     ((globalCtx->sceneNum == SCENE_BOWLING) && Flags_GetSwitch(globalCtx, 0x38))) {
-                    
+
                     if (!fullUi) {
                         Interface_DrawItemIconTexture(globalCtx, gItemIcons[gSaveContext.equips.buttonItems[0]], 0);
                     }
-                    
+
                     gDPPipeSync(OVERLAY_DISP++);
                     gDPSetCombineLERP(OVERLAY_DISP++, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE,
                                       0, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0);
@@ -4070,7 +4070,7 @@ void Interface_Draw(GlobalContext* globalCtx) {
 
                 for (svar1 = 0; svar1 < 5; svar1++) {
                     // clang-format off
-                    svar5 = OTRGetRectDimensionFromLeftEdge(gSaveContext.timerX[svar6]); 
+                    svar5 = OTRGetRectDimensionFromLeftEdge(gSaveContext.timerX[svar6]);
                     OVERLAY_DISP = Gfx_TextureI8(OVERLAY_DISP, digitTextures[timerDigits[svar1]], 8, 16,
                                       svar5 + timerDigitLeftPos[svar1],
                                       svar2 = gSaveContext.timerY[svar6], digitWidth[svar1], VREG(42), VREG(43) << 1,

--- a/soh/src/code/z_room.c
+++ b/soh/src/code/z_room.c
@@ -586,7 +586,7 @@ s32 func_8009728C(GlobalContext* globalCtx, RoomContext* roomCtx, s32 roomNum) {
 
         osCreateMesgQueue(&roomCtx->loadQueue, &roomCtx->loadMsg, 1);
         DmaMgr_SendRequest2(&roomCtx->dmaRequest, roomCtx->unk_34, globalCtx->roomList[roomNum].vromStart, size, 0,
-                            &roomCtx->loadQueue, NULL, "../z_room.c", 1036);
+                            &roomCtx->loadQueue, OS_MESG_PTR(NULL), "../z_room.c", 1036);
         roomCtx->unk_30 ^= 1;
 
         return 1;

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -4855,7 +4855,7 @@ void func_8083AE40(Player* this, s16 objectId) {
         ASSERT(size <= 1024 * 8, "size <= 1024 * 8", "../z_player.c", 9091);
 
         DmaMgr_SendRequest2(&this->giObjectDmaRequest, (uintptr_t)this->giObjectSegment, gObjectTable[objectId].vromStart,
-            size, 0, &this->giObjectLoadQueue, NULL, "../z_player.c", 9099);
+            size, 0, &this->giObjectLoadQueue, OS_MESG_PTR(NULL), "../z_player.c", 9099);
     }
 }
 
@@ -10798,7 +10798,7 @@ void Player_UpdateCommon(Player* this, GlobalContext* globalCtx, Input* input) {
 static Vec3f D_80854838 = { 0.0f, 0.0f, -30.0f };
 
 void Player_Update(Actor* thisx, GlobalContext* globalCtx) {
-    static Vec3f sDogSpawnPos; 
+    static Vec3f sDogSpawnPos;
     Player* this = (Player*)thisx;
     s32 dogParams;
     s32 pad;


### PR DESCRIPTION
This should fix most if not all the memory corruption issues currently present on the `zelda64` branch.
Most of it is changing `OSMesg`'s definition because a lot of code still assumes `sizeof(OSMesg) == 4` with `OSMesg` being a typedef for `void*` (which obviously is wrong for 64-bit platforms).
I also had to change the definition of `AudioCmd.data` which has the exact same problem.