### PR TITLE
Add checkbox to make holding the D-pad act like holding the joystick on the file and pause screens

### DIFF
--- a/libultraship/libultraship/SohImGuiImpl.cpp
+++ b/libultraship/libultraship/SohImGuiImpl.cpp
@@ -785,9 +785,6 @@ namespace SohImGui {
                 ImGui::Separator();
 
                 EnhancementCheckbox("D-pad Support on Pause and File Select", "gDpadPauseName");
-                if (CVar_GetS32("gDpadPauseName", 0)) {
-                    EnhancementCheckbox("Hold D-pad to continuously change selection", "gDpadHoldChange");
-                }
                 EnhancementCheckbox("D-pad Support in Ocarina and Text Choice", "gDpadOcarinaText");
                 EnhancementCheckbox("D-pad Support for Browsing Shop Items", "gDpadShop");
 

--- a/libultraship/libultraship/SohImGuiImpl.cpp
+++ b/libultraship/libultraship/SohImGuiImpl.cpp
@@ -785,6 +785,9 @@ namespace SohImGui {
                 ImGui::Separator();
 
                 EnhancementCheckbox("D-pad Support on Pause and File Select", "gDpadPauseName");
+                if (CVar_GetS32("gDpadPauseName", 0)) {
+                    EnhancementCheckbox("Hold D-pad to continuously change selection", "gDpadHoldChange");
+                }
                 EnhancementCheckbox("D-pad Support in Ocarina and Text Choice", "gDpadOcarinaText");
                 EnhancementCheckbox("D-pad Support for Browsing Shop Items", "gDpadShop");
 

--- a/soh/src/code/z_camera.c
+++ b/soh/src/code/z_camera.c
@@ -7532,7 +7532,7 @@ Vec3s Camera_Update(Camera* camera) {
                      BINANG_TO_DEGF(camera->camDir.x), camera->camDir.y, BINANG_TO_DEGF(camera->camDir.y));
     }
 
-    if (camera->timer != -1 && CHECK_BTN_ALL(D_8015BD7C->state.input[0].press.button, BTN_DRIGHT)) {
+    if (camera->timer != -1 && CHECK_BTN_ALL(D_8015BD7C->state.input[0].press.button, BTN_DRIGHT) && CVar_GetS32("gDebugEnabled", 0)) {
         camera->timer = 0;
     }
 

--- a/soh/src/code/z_camera.c
+++ b/soh/src/code/z_camera.c
@@ -7532,7 +7532,7 @@ Vec3s Camera_Update(Camera* camera) {
                      BINANG_TO_DEGF(camera->camDir.x), camera->camDir.y, BINANG_TO_DEGF(camera->camDir.y));
     }
 
-    if (camera->timer != -1 && CHECK_BTN_ALL(D_8015BD7C->state.input[0].press.button, BTN_DRIGHT) && CVar_GetS32("gDebugEnabled", 0)) {
+    if (camera->timer != -1 && CHECK_BTN_ALL(D_8015BD7C->state.input[0].press.button, BTN_DRIGHT) && CVar_GetS32("gDebugCamera", 0)) {
         camera->timer = 0;
     }
 

--- a/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -1615,7 +1615,7 @@ void FileChoose_Main(GameState* thisx) {
     this->stickRelX = input->rel.stick_x;
     this->stickRelY = input->rel.stick_y;
 
-    if (CVar_GetS32("gDpadHoldChange", 0)) {
+    if (CVar_GetS32("gDpadHoldChange", 1) && CVar_GetS32("gDpadPauseName", 0)) {
         if (CHECK_BTN_ALL(input->cur.button, BTN_DLEFT)) {
             if (CHECK_BTN_ALL(input->press.button, BTN_DLEFT)) {
                 this->inputTimerX = 10;

--- a/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -1615,6 +1615,52 @@ void FileChoose_Main(GameState* thisx) {
     this->stickRelX = input->rel.stick_x;
     this->stickRelY = input->rel.stick_y;
 
+    if (CVar_GetS32("gDpadHoldChange", 0)) {
+        if (CHECK_BTN_ALL(input->cur.button, BTN_DLEFT)) {
+            if (CHECK_BTN_ALL(input->press.button, BTN_DLEFT)) {
+                this->inputTimerX = 10;
+                this->stickXDir = -1;
+            } else if (--(this->inputTimerX) < 0) {
+                this->inputTimerX = XREG(6);
+                input->press.button |= BTN_DLEFT;
+            }
+        } else if (CHECK_BTN_ALL(input->rel.button, BTN_DLEFT)) {
+            this->stickXDir = 0;
+        } else if (CHECK_BTN_ALL(input->cur.button, BTN_DRIGHT)) {
+            if (CHECK_BTN_ALL(input->press.button, BTN_DRIGHT)) {
+                this->inputTimerX = 10;
+                this->stickXDir = 1;
+            } else if (--(this->inputTimerX) < 0) {
+                this->inputTimerX = XREG(6);
+                input->press.button |= BTN_DRIGHT;
+            }
+        } else if (CHECK_BTN_ALL(input->rel.button, BTN_DRIGHT)) {
+            this->stickXDir = 0;
+        }
+
+        if (CHECK_BTN_ALL(input->cur.button, BTN_DDOWN)) {
+            if (CHECK_BTN_ALL(input->press.button, BTN_DDOWN)) {
+                this->inputTimerY = 10;
+                this->stickYDir = -1;
+            } else if (--(this->inputTimerY) < 0) {
+                this->inputTimerY = XREG(6);
+                input->press.button |= BTN_DDOWN;
+            }
+        } else if (CHECK_BTN_ALL(input->rel.button, BTN_DDOWN)) {
+            this->stickYDir = 0;
+        } else if (CHECK_BTN_ALL(input->cur.button, BTN_DUP)) {
+            if (CHECK_BTN_ALL(input->press.button, BTN_DUP)) {
+                this->inputTimerY = 10;
+                this->stickYDir = -1;
+            } else if (--(this->inputTimerY) < 0) {
+                this->inputTimerY = XREG(6);
+                input->press.button |= BTN_DUP;
+            }
+        } else if (CHECK_BTN_ALL(input->rel.button, BTN_DUP)) {
+            this->stickYDir = 0;
+        }
+    }
+
     if (this->stickRelX < -30) {
         if (this->stickXDir == -1) {
             this->inputTimerX--;
@@ -1645,7 +1691,7 @@ void FileChoose_Main(GameState* thisx) {
 
     if (this->stickRelY < -30) {
         if (this->stickYDir == -1) {
-            this->inputTimerY -= 1;
+            this->inputTimerY--;
             if (this->inputTimerY < 0) {
                 this->inputTimerY = 2;
             } else {
@@ -1657,7 +1703,7 @@ void FileChoose_Main(GameState* thisx) {
         }
     } else if (this->stickRelY > 30) {
         if (this->stickYDir == 1) {
-            this->inputTimerY -= 1;
+            this->inputTimerY--;
             if (this->inputTimerY < 0) {
                 this->inputTimerY = 2;
             } else {

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
@@ -947,7 +947,7 @@ void KaleidoScope_HandlePageToggles(PauseContext* pauseCtx, Input* input) {
 
     bool dpad = CVar_GetS32("gDpadPauseName", 0);
     if (pauseCtx->cursorSpecialPos == PAUSE_CURSOR_PAGE_LEFT) {
-        if ((pauseCtx->stickRelX < -30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DLEFT))) {
+        if ((pauseCtx->stickRelX < -30) || (dpad && CHECK_BTN_ALL(input->cur.button, BTN_DLEFT))) {
             pauseCtx->pageSwitchTimer++;
             if ((pauseCtx->pageSwitchTimer >= 10) || (pauseCtx->pageSwitchTimer == 0)) {
                 KaleidoScope_SwitchPage(pauseCtx, 0);
@@ -956,7 +956,7 @@ void KaleidoScope_HandlePageToggles(PauseContext* pauseCtx, Input* input) {
             pauseCtx->pageSwitchTimer = -1;
         }
     } else if (pauseCtx->cursorSpecialPos == PAUSE_CURSOR_PAGE_RIGHT) {
-        if ((pauseCtx->stickRelX > 30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DRIGHT))) {
+        if ((pauseCtx->stickRelX > 30) || (dpad && CHECK_BTN_ALL(input->cur.button, BTN_DRIGHT))) {
             pauseCtx->pageSwitchTimer++;
             if ((pauseCtx->pageSwitchTimer >= 10) || (pauseCtx->pageSwitchTimer == 0)) {
                 KaleidoScope_SwitchPage(pauseCtx, 2);
@@ -1115,6 +1115,7 @@ void KaleidoScope_DrawPages(GlobalContext* globalCtx, GraphicsContext* gfxCtx) {
     static s16 D_8082AD4C = 0;
     static s16 D_8082AD50 = 0;
     PauseContext* pauseCtx = &globalCtx->pauseCtx;
+    Input* input = &globalCtx->state.input[0];
     s16 stepR;
     s16 stepG;
     s16 stepB;
@@ -1152,6 +1153,52 @@ void KaleidoScope_DrawPages(GlobalContext* globalCtx, GraphicsContext* gfxCtx) {
                 D_8082AD40++;
                 if (D_8082AD40 >= 4) {
                     D_8082AD40 = 0;
+                }
+            }
+
+            if (CVar_GetS32("gDpadHoldChange", 0)) {
+                if (CHECK_BTN_ALL(input->cur.button, BTN_DLEFT)) {
+                    if (CHECK_BTN_ALL(input->press.button, BTN_DLEFT)) {
+                        D_8082AD44 = XREG(8);
+                        D_8082AD4C = -1;
+                    } else if (--D_8082AD44 < 0) {
+                        D_8082AD44 = XREG(6);
+                        input->press.button |= BTN_DLEFT;
+                    }
+                } else if (CHECK_BTN_ALL(input->rel.button, BTN_DLEFT)) {
+                    D_8082AD4C = 0;
+                } else if (CHECK_BTN_ALL(input->cur.button, BTN_DRIGHT)) {
+                    if (CHECK_BTN_ALL(input->press.button, BTN_DRIGHT)) {
+                        D_8082AD44 = XREG(8);
+                        D_8082AD4C = 1;
+                    } else if (--D_8082AD44 < 0) {
+                        D_8082AD44 = XREG(6);
+                        input->press.button |= BTN_DRIGHT;
+                    }
+                } else if (CHECK_BTN_ALL(input->rel.button, BTN_DRIGHT)) {
+                    D_8082AD4C = 0;
+                }
+
+                if (CHECK_BTN_ALL(input->cur.button, BTN_DDOWN)) {
+                    if (CHECK_BTN_ALL(input->press.button, BTN_DDOWN)) {
+                        D_8082AD48 = XREG(8);
+                        D_8082AD50 = -1;
+                    } else if (--D_8082AD48 < 0) {
+                        D_8082AD48 = XREG(6);
+                        input->press.button |= BTN_DDOWN;
+                    }
+                } else if (CHECK_BTN_ALL(input->rel.button, BTN_DDOWN)) {
+                    D_8082AD50 = 0;
+                } else if (CHECK_BTN_ALL(input->cur.button, BTN_DUP)) {
+                    if (CHECK_BTN_ALL(input->press.button, BTN_DUP)) {
+                        D_8082AD48 = XREG(8);
+                        D_8082AD50 = 1;
+                    } else if (--D_8082AD48 < 0) {
+                        D_8082AD48 = XREG(6);
+                        input->press.button |= BTN_DUP;
+                    }
+                } else if (CHECK_BTN_ALL(input->rel.button, BTN_DUP)) {
+                    D_8082AD50 = 0;
                 }
             }
 

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
@@ -1156,7 +1156,7 @@ void KaleidoScope_DrawPages(GlobalContext* globalCtx, GraphicsContext* gfxCtx) {
                 }
             }
 
-            if (CVar_GetS32("gDpadHoldChange", 0)) {
+            if (CVar_GetS32("gDpadHoldChange", 1) && CVar_GetS32("gDpadPauseName", 0)) {
                 if (CHECK_BTN_ALL(input->cur.button, BTN_DLEFT)) {
                     if (CHECK_BTN_ALL(input->press.button, BTN_DLEFT)) {
                         D_8082AD44 = XREG(8);


### PR DESCRIPTION
Before this change, each movement of the cursor with the D-pad required a new press.  Holding the D-pad only ever moved a single cursor position.  This was in contrast with the joystick, which, when held, continuously moves the cursor according to a timer (10 frames to the second position and to change pause screen pages, 2 frames for subsequent positions).  

This change adds an option to make holding the D-pad now behave identically to the joystick, where the cursor continuously moves according to a timer.  Note that there is one small behavior change when this option is disabled:  holding the D-pad for longer than 10 frames on the page switch buttons will automatically trigger a page switch.  This essentially now makes it take a single long press to switch pages instead of two presses (one to move the cursor to the switch button and another to actually switch pages).  

This PR also fixes an unguarded debug camera action.  Specifically, pressing D-pad right will reset the camera to its default position during certain cutscenes.  This appears to be vanilla behavior to the debug ROM that wasn't intended to be unguarded, and was most easily triggered during the singing frogs minigame, so this PR also closes #448. 