### PR TITLE
Unfix dungeon map icon when bugfix CVar is off

### DIFF
--- a/soh/src/code/z_map_exp.c
+++ b/soh/src/code/z_map_exp.c
@@ -755,22 +755,23 @@ void Minimap_Draw(GlobalContext* globalCtx) {
                     if (((globalCtx->sceneNum != SCENE_SPOT01) && (globalCtx->sceneNum != SCENE_SPOT04) &&
                          (globalCtx->sceneNum != SCENE_SPOT08)) ||
                         (LINK_AGE_IN_YEARS != YEARS_ADULT)) {
+                        bool Map0 = gMapData->owEntranceIconPosY[sEntranceIconMapIndex] << 2 == 0;
                         s16 IconSize = 8;
-                        s16 PosX = gMapData->owEntranceIconPosX[sEntranceIconMapIndex]+Right_MM_Margin;
-                        s16 PosY = gMapData->owEntranceIconPosY[sEntranceIconMapIndex]+Bottom_MM_Margin;
+                        s16 PosX = gMapData->owEntranceIconPosX[sEntranceIconMapIndex] + (Map0 ? 0 : Right_MM_Margin);
+                        s16 PosY = gMapData->owEntranceIconPosY[sEntranceIconMapIndex] + (Map0 ? 0 : Bottom_MM_Margin);
                         //gFixDungeonMinimapIcon fix both Y position of visible icon and hide these non needed.
-                        if (CVar_GetS32("gFixDungeonMinimapIcon", 1) != 0){
+                        if (CVar_GetS32("gFixDungeonMinimapIcon", 0) != 0){
                             //No idea why and how Original value work but this does actually fix them all.
                             PosY = PosY+1024;
                         }
-                        s16 TopLeftX = OTRGetRectDimensionFromRightEdge(PosX) << 2;
+                        s16 TopLeftX = (Map0 ? OTRGetRectDimensionFromLeftEdge(PosX) : OTRGetRectDimensionFromRightEdge(PosX)) << 2;
                         s16 TopLeftY = PosY << 2;
-                        s16 TopLeftW = OTRGetRectDimensionFromRightEdge(PosX + IconSize) << 2;
+                        s16 TopLeftW = (Map0 ? OTRGetRectDimensionFromLeftEdge(PosX + IconSize) : OTRGetRectDimensionFromRightEdge(PosX + IconSize)) << 2;
                         s16 TopLeftH = (PosY + IconSize) << 2;
                         if ((gMapData->owEntranceFlag[sEntranceIconMapIndex] == 0xFFFF) ||
                             ((gMapData->owEntranceFlag[sEntranceIconMapIndex] != 0xFFFF) &&
                              (gSaveContext.infTable[26] & gBitFlags[gMapData->owEntranceFlag[mapIndex]]))) {
-                            if (gMapData->owEntranceIconPosY[sEntranceIconMapIndex] << 2 != 0 && CVar_GetS32("gFixDungeonMinimapIcon", 1) != 0){
+                            if (CVar_GetS32("gFixDungeonMinimapIcon", 0) != 0 ? !Map0 : 1 ) {
                                 gDPLoadTextureBlock(OVERLAY_DISP++, gMapDungeonEntranceIconTex, G_IM_FMT_RGBA, G_IM_SIZ_16b,
                                                     IconSize, IconSize, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP,
                                                     G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);

--- a/soh/src/code/z_map_exp.c
+++ b/soh/src/code/z_map_exp.c
@@ -771,7 +771,7 @@ void Minimap_Draw(GlobalContext* globalCtx) {
                         if ((gMapData->owEntranceFlag[sEntranceIconMapIndex] == 0xFFFF) ||
                             ((gMapData->owEntranceFlag[sEntranceIconMapIndex] != 0xFFFF) &&
                              (gSaveContext.infTable[26] & gBitFlags[gMapData->owEntranceFlag[mapIndex]]))) {
-                            if (CVar_GetS32("gFixDungeonMinimapIcon", 0) != 0 ? !Map0 : 1 ) {
+                            if (!Map0 || !CVar_GetS32("gFixDungeonMinimapIcon", 0)) {
                                 gDPLoadTextureBlock(OVERLAY_DISP++, gMapDungeonEntranceIconTex, G_IM_FMT_RGBA, G_IM_SIZ_16b,
                                                     IconSize, IconSize, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP,
                                                     G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);


### PR DESCRIPTION
@Baoulettes fixed the dungeon map icon way back in #252. This included two fixes:

- adding `1024` to the icon's Y position
- disabling the icon when it's positioned at `0,0` (top left origin)

The second of these fixes was accidentally not behind the `gFixDungeonMinimapIcon` CVar, so the bugged behavior no longer existed in SoH. For more details, see my comment on the original PR.

This PR puts the `0,0` dungeon icon fix behind the CVar as originally intended, but this required a bit of extra work. Because HUD changes have aligned the dungeon map icon using the **right** screen edge, `0,0` was no longer the top left of screen. To handle this, I added a bool `Map0` which checks whether the current dungeon map icon is at `0,0` to make it easy to switch back to the old left-aligned behavior just for this one case.

All of this means if you disable the `gFixDungeonMinimapIcon` CVar, you get this useless icon back in Hyrule Field:
![Useless dungeon minimap icon](https://media.discordapp.net/attachments/935186300032667658/957380406158704660/unknown.png)

In this PR, I also switch the bug fix from default-on to default-off, like other bug fixes.