### PR TITLE
Add failsafe in case of hang

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,6 +8,9 @@ pipeline {
     
     stages {
         stage ('Build Windows') {
+            options {
+                timeout(time: 20)
+            }
             environment {
                 MSBUILD='C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\Msbuild\\Current\\Bin\\msbuild.exe'
                 CONFIG='Release'
@@ -71,6 +74,9 @@ pipeline {
             }
         }
         stage ('Build Linux') {
+            options {
+                timeout(time: 20)
+            }
             agent {
                 label "SoH-Linux-Builders"
             }


### PR DESCRIPTION
Aborts stage if hung, which extract_assets.py seems to do on rare occasion