### PR TITLE
Fix grayscale Biggoron's Sword

### DIFF
--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_equipment.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_equipment.c
@@ -635,7 +635,8 @@ void KaleidoScope_DrawEquipment(GlobalContext* globalCtx) {
                 KaleidoScope_DrawQuadTextureRGBA32(globalCtx->state.gfxCtx, gBiggoronSwordIconTex, 32, 32, point);
             } else if ((i == 0) && (k == 2) && (gBitFlags[bit + 1] & gSaveContext.inventory.equipment)) {
                 KaleidoScope_DrawQuadTextureRGBA32(globalCtx->state.gfxCtx, gBrokenGiantsKnifeIconTex, 32, 32, point);
-            } else if (gBitFlags[bit] & gSaveContext.inventory.equipment) {
+            }
+            if (gBitFlags[bit] & gSaveContext.inventory.equipment) {
                 int itemId = ITEM_SWORD_KOKIRI + temp;
                 bool not_acquired = (gItemAgeReqs[itemId] != 9) && (gItemAgeReqs[itemId] != gSaveContext.linkAge);
                 if (not_acquired) {


### PR DESCRIPTION
Currently in SoH, the Biggoron's Sword doesn't get grayscaled in the Kaleido Equipment page when playing as Child Link, unlike other age-specific items/equipment. This fix for the issue was noted last week in the Discord, but I figured I'd PR it before it's forgotten. In short, the equipment code currently looks like:
```c
if (bgs) {
    bgs things;
} else if (equipOwned) {
    perform grayscale check;
}
```
This tiny PR breaks off that `else` into a standalone `if` statement.