### PR TITLE
Skip first-time pickup messages for consumable items

### DIFF
--- a/libultraship/libultraship/SohImGuiImpl.cpp
+++ b/libultraship/libultraship/SohImGuiImpl.cpp
@@ -889,6 +889,8 @@ namespace SohImGui {
                     Tooltip("Disables the voice audio when Navi calls you");
                     EnhancementCheckbox("Fast Chests", "gFastChests");
                     Tooltip("Kick open every chest");
+                    EnhancementCheckbox("Fast Drops", "gFastDrops");
+                    Tooltip("Skip first-time pickup messages for consumable items");
                     EnhancementCheckbox("Better Owl", "gBetterOwl");
                     Tooltip("The default response to Kaepora Gaebora is always that you understood what he said");
                     EnhancementCheckbox("Link's Cow in Both Time Periods", "gCowOfTime");

--- a/soh/src/overlays/actors/ovl_En_GirlA/z_en_girla.c
+++ b/soh/src/overlays/actors/ovl_En_GirlA/z_en_girla.c
@@ -452,7 +452,7 @@ s32 EnGirlA_CanBuy_DekuNuts(GlobalContext* globalCtx, EnGirlA* this) {
     if (gSaveContext.rupees < this->basePrice) {
         return CANBUY_RESULT_NEED_RUPEES;
     }
-    if (Item_CheckObtainability(ITEM_NUT) == ITEM_NONE) {
+    if ((Item_CheckObtainability(ITEM_NUT) == ITEM_NONE) && !CVar_GetS32("gFastDrops", 0)) {
         return CANBUY_RESULT_SUCCESS_FANFARE;
     }
     return CANBUY_RESULT_SUCCESS;
@@ -465,7 +465,7 @@ s32 EnGirlA_CanBuy_DekuSticks(GlobalContext* globalCtx, EnGirlA* this) {
     if (gSaveContext.rupees < this->basePrice) {
         return CANBUY_RESULT_NEED_RUPEES;
     }
-    if (Item_CheckObtainability(ITEM_STICK) == ITEM_NONE) {
+    if ((Item_CheckObtainability(ITEM_STICK) == ITEM_NONE) && !CVar_GetS32("gFastDrops", 0)) {
         return CANBUY_RESULT_SUCCESS_FANFARE;
     }
     return CANBUY_RESULT_SUCCESS;
@@ -652,7 +652,7 @@ s32 EnGirlA_CanBuy_DekuSeeds(GlobalContext* globalCtx, EnGirlA* this) {
     if (gSaveContext.rupees < this->basePrice) {
         return CANBUY_RESULT_NEED_RUPEES;
     }
-    if (Item_CheckObtainability(ITEM_SEEDS) == ITEM_NONE) {
+    if ((Item_CheckObtainability(ITEM_SEEDS) == ITEM_NONE) && !CVar_GetS32("gFastDrops", 0)) {
         return CANBUY_RESULT_SUCCESS_FANFARE;
     }
     return CANBUY_RESULT_SUCCESS;

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -6157,7 +6157,12 @@ s32 func_8083E5A8(Player* this, GlobalContext* globalCtx) {
 
                 iREG(67) = false;
 
-                if ((Item_CheckObtainability(giEntry->itemId) == ITEM_NONE) || (globalCtx->sceneNum == SCENE_BOWLING)) {
+                s32 drop = giEntry->objectId;
+
+                if ((globalCtx->sceneNum == SCENE_BOWLING) || !(CVar_GetS32("gFastDrops", 0) &&
+                    ((drop == OBJECT_GI_BOMB_1) || (drop == OBJECT_GI_NUTS) || (drop == OBJECT_GI_STICK) ||
+                    (drop == OBJECT_GI_SEED) || (drop == OBJECT_GI_MAGICPOT) || (drop == OBJECT_GI_ARROW))) &&
+                    (Item_CheckObtainability(giEntry->itemId) == ITEM_NONE)) {
                     func_808323B4(globalCtx, this);
                     func_8083AE40(this, giEntry->objectId);
 


### PR DESCRIPTION
Arguably fixes #58. The original author wanted to skip both item pickups and songs, but @MegaMech disagreed with songs and changed the title to have it only concern pickups. This PR only addresses pickups, so dealer's choice.

This skips the whole fanfare/pose/animation for the following consumable item families when picked up for the first time:
- `OBJECT_GI_BOMB_1` (Bombs but **not** Bombchus)
- `OBJECT_GI_NUTS` (Deku Nuts)
- `OBJECT_GI_STICK` (Deku Sticks)
- `OBJECT_GI_SEED` (Deku Seeds)
- `OBJECT_GI_MAGICPOT` (Magic Jars)
- `OBJECT_GI_ARROW` (Arrows)

I'm identifying the item types by `objectId` rather than `itemId` because the `objectId` covers all quantities of each item, e.g. both Magic Bottles have the same `objectId`, but their `itemId`s are `ITEM_MAGIC_SMALL` and `ITEM_MAGIC_LARGE`.

Some of this is arguably a bit of overkill: e.g., I don't think it's possible to get the Bomb fanfare in normal gameplay because you can't pick up Bombs *off the ground* as your first time finding them. On the other hand, I left Bombchus out of this because they're much rarer than any of the other consumables--indeed, while they are supported, they don't appear as normal drops *at all* in the base game.

Still, future mods could change which items it's possible to grab off the ground, so I figured I'd include all of the consumables (besides Bombchus) just for future-proofing. If people want Bombchus included here, they can be easily added, but I think even in mods, a first-time random Bombchu pickup on the ground is probably big enough news to be worth notifying the player.

In addition to ground drops, the same fanfare occurs if the player has never had Deku Nuts, Sticks or Seeds before and buys them from the Kokiri Shop or Deku Salesmen; these are likewise disabled.