### PR TITLE
Fix Anubis fireballs

### DIFF
--- a/libultraship/libultraship/SohImGuiImpl.cpp
+++ b/libultraship/libultraship/SohImGuiImpl.cpp
@@ -980,6 +980,8 @@ namespace SohImGui {
                     Tooltip("Prevents the Forest Stage Deku Nut upgrade from becoming unobtainable after receiving the Poacher's Saw");
                     EnhancementCheckbox("Fix Navi text HUD position", "gNaviTextFix");
                     Tooltip("Correctly centers the Navi text prompt on the HUD's C-Up button");
+                    EnhancementCheckbox("Fix Anubis fireballs", "gAnubisFix");
+                    Tooltip("Make Anubis fireballs do fire damage when reflected back at them with the Mirror Shield");
 
                     ImGui::EndMenu();
                 }

--- a/soh/src/overlays/actors/ovl_En_Anubice_Fire/z_en_anubice_fire.c
+++ b/soh/src/overlays/actors/ovl_En_Anubice_Fire/z_en_anubice_fire.c
@@ -114,7 +114,7 @@ void func_809B27D8(EnAnubiceFire* this, GlobalContext* globalCtx) {
             Audio_PlayActorSound2(&this->actor, NA_SE_IT_SHIELD_REFLECT_SW);
             this->cylinder.base.atFlags &= 0xFFE9;
             this->cylinder.base.atFlags |= 8;
-            this->cylinder.info.toucher.dmgFlags = 2;
+            this->cylinder.info.toucher.dmgFlags = CVar_GetS32("gAnubisFix", 0) ? 0x800 : 2;
             this->unk_15A = 30;
             this->actor.params = 1;
             this->actor.velocity.x *= -1.0f;


### PR DESCRIPTION
Anubis is this thing from the Spirit Temple:

![Anubis enemy](https://static.wikia.nocookie.net/zelda_gamepedia_en/images/e/e8/OoT_Anubis_Model.png/revision/latest?cb=20101009031408)

One of Anubis's behaviors is that if you swing your sword (don't need to hit the Anubis, just swing), it will shoot a fireball at you. If Link has the Mirror Shield, he can reflect this fireball--you don't even need to aim, the fireball returns directly to the Anubis no matter how the shield is angled.

![Link reflecting a fireball at an Anubis](https://media.discordapp.net/attachments/935186300032667658/987996685932322836/unknown.png)

In the base game, these reflected fireballs do Deku Stick damage instead of ... any kind of fire damage. Anubis is completely immune to Deku Stick damage. Incidentally, this is the same way reflected shots from Deku Scrubs and Deku Salesmen work, so I suspect this is a copy paste error on Nintendo's part, with the reflected fireball behavior being copied from Dekus and not updated to do fire damage.

```c
        if (Player_HasMirrorShieldEquipped(play)) {
            Audio_PlayActorSound2(&this->actor, NA_SE_IT_SHIELD_REFLECT_SW);
            this->cylinder.base.atFlags &= ~(AT_HIT | AT_BOUNCED | AT_TYPE_ENEMY);
            this->cylinder.base.atFlags |= AT_TYPE_PLAYER;
            this->cylinder.info.toucher.dmgFlags = DMG_DEKU_STICK;
            this->unk_15A = 30;
            this->actor.params = 1;
            this->actor.velocity.x *= -1.0f;
            this->actor.velocity.y *= -0.5f;
            this->actor.velocity.z *= -1.0f;
        } else {
            this->unk_15A = 0;
            EffectSsBomb2_SpawnLayered(play, &this->actor.world.pos, &sp78, &sp84, 10, 5);
            this->actor.velocity.x = this->actor.velocity.y = this->actor.velocity.z = 0.0f;
            Audio_PlayActorSound2(&this->actor, NA_SE_EN_ANUBIS_FIREBOMB);
            this->actionFunc = func_809B2B48;
        }
```
https://github.com/zeldaret/oot/blob/849fdbf9ea37a69ad6af3bbdc55c07903135dccd/src/overlays/actors/ovl_En_Anubice_Fire/z_en_anubice_fire.c#L112-L128

This PR adds a CVar to switch the reflected fireballs to doing Fire Arrow damage instead, making this a viable method of killing Anubises (plural?) and giving the Mirror Shield some brief reason for existence. The way the fireball returns to the Anubis, Navi insistently telling you it's vulnerable to fire, etc., overwhelmingly suggests to me that this was the intended behavior, so I'm considering this a bug fix rather than a mod, cheat or other enhancement.

**EDIT:** Something I hadn't realized that @stratomaster64 pointed out is that there are only four Anubises in the original game. In normal gameplay, you have to kill all of them *before* you obtain the Mirror Shield, and they do not respawn, so this behavior can really only be seen by cheating or glitching to obtain the Mirror Shield earlier than the game intends. I don't know if this is true in Master Quest as well. I'm not sure if the Harbour Masters want bug fixes for things that players don't even encounter in normal gameplay. I still think this would be a good fix for the future when there's mods/a randomizer/hard mode with respawning enemies/etc., but it does seem at least a little weird to have a checkbox to fix a bug that can't be encountered in normal play.