### PR TITLE
L-button cheats disable minimap toggle

### DIFF
--- a/soh/src/code/z_map_exp.c
+++ b/soh/src/code/z_map_exp.c
@@ -651,7 +651,7 @@ void Minimap_Draw(GlobalContext* globalCtx) {
 
     // If any of these CVars are enabled, disable toggling the minimap with L, unless gEnableMapToggle is set
     bool enableMapToggle =
-        !(CVar_GetS32("gMoonJumpOnL", 0) || CVar_GetS32("gTurboOnL", 0)) ||
+        !(CVar_GetS32("gDebugEnabled", 0) || CVar_GetS32("gMoonJumpOnL", 0) || CVar_GetS32("gTurboOnL", 0)) ||
         CVar_GetS32("gEnableMapToggle", 0);
 
     if (globalCtx->pauseCtx.state < 4) {

--- a/soh/src/code/z_map_exp.c
+++ b/soh/src/code/z_map_exp.c
@@ -649,6 +649,11 @@ void Minimap_Draw(GlobalContext* globalCtx) {
 
     OPEN_DISPS(globalCtx->state.gfxCtx, "../z_map_exp.c", 626);
 
+    // If any of these CVars are enabled, disable toggling the minimap with L, unless gEnableMapToggle is set
+    bool enableMapToggle =
+        !(CVar_GetS32("gMoonJumpOnL", 0) || CVar_GetS32("gTurboOnL", 0)) ||
+        CVar_GetS32("gEnableMapToggle", 0);
+
     if (globalCtx->pauseCtx.state < 4) {
         switch (globalCtx->sceneNum) {
             case SCENE_YDAN:
@@ -693,7 +698,7 @@ void Minimap_Draw(GlobalContext* globalCtx) {
                     }
                 }
 
-                if (CHECK_BTN_ALL(globalCtx->state.input[0].press.button, BTN_L) && !Gameplay_InCsMode(globalCtx)) {
+                if (CHECK_BTN_ALL(globalCtx->state.input[0].press.button, BTN_L) && !Gameplay_InCsMode(globalCtx) && enableMapToggle) {
                     osSyncPrintf("Game_play_demo_mode_check=%d\n", Gameplay_InCsMode(globalCtx));
                     // clang-format off
                     if (!R_MINIMAP_DISABLED) { Audio_PlaySoundGeneral(NA_SE_SY_CAMERA_ZOOM_UP, &D_801333D4, 4,
@@ -805,7 +810,7 @@ void Minimap_Draw(GlobalContext* globalCtx) {
                     Minimap_DrawCompassIcons(globalCtx); // Draw icons for the player spawn and current position
                 }
 
-                if (CHECK_BTN_ALL(globalCtx->state.input[0].press.button, BTN_L) && !Gameplay_InCsMode(globalCtx)) {
+                if (CHECK_BTN_ALL(globalCtx->state.input[0].press.button, BTN_L) && !Gameplay_InCsMode(globalCtx) && enableMapToggle) {
                     // clang-format off
                     if (!R_MINIMAP_DISABLED) { Audio_PlaySoundGeneral(NA_SE_SY_CAMERA_ZOOM_UP, &D_801333D4, 4,
                                                                       &D_801333E0, &D_801333E0, &D_801333E8); }


### PR DESCRIPTION
For the three people.

There's a trend for cheats to use the L button to trigger their behavior (Moon Jump, #379's Turbo speed, Baoulettes uses the L button for testing during development, etc.), which in the base game already has a function of toggling the minimap overlay. Current SoH behavior when using L-button cheats just has both actions occurring: e.g. moon jumping also toggles the minimap. This PR adds a check against a bool, `enableMapToggle` which defaults to `false` while L-button cheats are active.

Base game behavior is not visibly changed: the minimap toggles as normal when cheats are disabled. Once the player **enables** an L-button cheat, the L button will now **only** perform cheat functionality and not minimap toggles. Rather than being specific to these two cheats, the intention here is to make it easy for any new L-button based cheats to be added to the `bool`.

If this is desirable for some reason, players can restore the current (pre-PR) behavior by manually setting `gEnableMapToggle` to `true` in their `cvars.cfg`. This will make the minimap toggle work regardless of enabled cheats, as it does now. Even setting this CVar won't change base game behavior, it will **only** change behavior while cheats are enabled. I haven't added this toggle to the UI at all as I feel the case for people who **want** cheats to also toggle the minimap endlessly is a vanishingly small audience.