### PR TITLE
Fix title cards for market potion shop and bombchu shop (fixes #508)

### DIFF
--- a/soh/src/code/z_actor.c
+++ b/soh/src/code/z_actor.c
@@ -869,11 +869,12 @@ void TitleCard_InitPlaceName(GlobalContext* globalCtx, TitleCardContext* titleCt
         case SCENE_ZOORA:
             texture = gZoraShopTitleCardENGTex;
             break;
-        case SCENE_ALLEY_SHOP:
+        case SCENE_NIGHT_SHOP:
             texture = gBombchuShopTitleCardENGTex;
             break;
         case SCENE_DRAG:
         case SCENE_MAHOUYA:
+        case SCENE_ALLEY_SHOP:
             texture = gPotionShopTitleCardENGTex;
             break;
         case SCENE_FACE_SHOP:


### PR DESCRIPTION
`SCENE_ALLEY_SHOP` is, despite it's name, the Market potion shop, NOT the bombchu shop, which is the only shop in the alley. The bombchu shop is only open at night though, so it's name makes some sense.