### PR TITLE
Get rid of erroneous int casts (fixes #513)

### DIFF
--- a/libultraship/libultraship/SohImGuiImpl.cpp
+++ b/libultraship/libultraship/SohImGuiImpl.cpp
@@ -354,10 +354,10 @@ namespace SohImGui {
         }
 
         for (size_t pixel = 0; pixel < texBuffer.size() / 4; pixel++) {
-            texBuffer[pixel * 4 + 0] *= (uint8_t)tint.x;
-            texBuffer[pixel * 4 + 1] *= (uint8_t)tint.y;
-            texBuffer[pixel * 4 + 2] *= (uint8_t)tint.z;
-            texBuffer[pixel * 4 + 3] *= (uint8_t)tint.w;
+            texBuffer[pixel * 4 + 0] *= tint.x;
+            texBuffer[pixel * 4 + 1] *= tint.y;
+            texBuffer[pixel * 4 + 2] *= tint.z;
+            texBuffer[pixel * 4 + 3] *= tint.w;
         }
 
         const auto asset = new GameAsset{ api->new_texture() };


### PR DESCRIPTION
These values are floats that vary from 0-1, so these casts converted them to either 0 or 1, allowing for no partial transparency (which is what this tint is currently used for)