### PR TITLE
Fixes Spirit Temple Crash

### DIFF
--- a/soh/src/overlays/actors/ovl_Bg_Jya_Cobra/z_bg_jya_cobra.c
+++ b/soh/src/overlays/actors/ovl_Bg_Jya_Cobra/z_bg_jya_cobra.c
@@ -596,7 +596,7 @@ void BgJyaCobra_DrawShadow(BgJyaCobra* this, GlobalContext* globalCtx) {
     gSPMatrix(POLY_XLU_DISP++, Matrix_NewMtx(globalCtx->state.gfxCtx, "../z_bg_jya_cobra.c", 994),
               G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
 
-    gDPLoadTextureBlock(POLY_XLU_DISP++, ALIGN16((s32)(&this->shadowTexture)), G_IM_FMT_I, G_IM_SIZ_8b, 0x40, 0x40, 0,
+    gDPLoadTextureBlock(POLY_XLU_DISP++, ALIGN16((uintptr_t)(&this->shadowTexture)), G_IM_FMT_I, G_IM_SIZ_8b, 0x40, 0x40, 0,
                         G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD,
                         G_TX_NOLOD);
 


### PR DESCRIPTION
The conversion to 64-bit introduced a crash in the spirit temple. The cause ended up being the jya_cobra (spinning mirror in spirit temple) shadow texture pointer was being cast to an s32 instead of a uintptr_t. It was causing there to be some implicit conversion resulting in attempting to access memory that was not allocated to the soh process.

Closes #524 