### PR TITLE
Cheat: Infinite Epona Boost

### DIFF
--- a/libultraship/libultraship/ImGuiImpl.cpp
+++ b/libultraship/libultraship/ImGuiImpl.cpp
@@ -1098,6 +1098,7 @@ namespace SohImGui {
                     EnhancementCheckbox("Ammo", "gInfiniteAmmo");
                     EnhancementCheckbox("Magic", "gInfiniteMagic");
                     EnhancementCheckbox("Nayru's Love", "gInfiniteNayru");
+                    EnhancementCheckbox("Epona Boost", "gInfiniteEpona");
 
                     ImGui::EndMenu();
                 }

--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -3869,7 +3869,7 @@ void Interface_Draw(GlobalContext* globalCtx) {
         if ((globalCtx->pauseCtx.state == 0) && (globalCtx->pauseCtx.debugState == 0)) {
             if (gSaveContext.minigameState != 1) {
                 // Carrots rendering if the action corresponds to riding a horse
-                if (interfaceCtx->unk_1EE == 8) {
+                if (interfaceCtx->unk_1EE == 8 && !CVar_GetS32("gInfiniteEpona", 0)) {
                     // Load Carrot Icon
                     gDPLoadTextureBlock(OVERLAY_DISP++, gCarrotIconTex, G_IM_FMT_RGBA, G_IM_SIZ_32b, 16, 16, 0,
                                         G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK,

--- a/soh/src/overlays/actors/ovl_En_Horse/z_en_horse.c
+++ b/soh/src/overlays/actors/ovl_En_Horse/z_en_horse.c
@@ -3311,7 +3311,7 @@ void EnHorse_CheckBoost(EnHorse* thisx, GlobalContext* globalCtx2) {
                     this->stateFlags |= ENHORSE_BOOST;
                     this->stateFlags |= ENHORSE_FIRST_BOOST_REGEN;
                     this->stateFlags |= ENHORSE_FLAG_8;
-                    this->numBoosts--;
+                    this->numBoosts -= !CVar_GetS32("gInfiniteEpona", 0);
                     this->boostTimer = 0;
                     if (this->numBoosts == 0) {
                         this->boostRegenTime = 140;

--- a/soh/src/overlays/actors/ovl_En_Horse/z_en_horse.c
+++ b/soh/src/overlays/actors/ovl_En_Horse/z_en_horse.c
@@ -3311,7 +3311,7 @@ void EnHorse_CheckBoost(EnHorse* thisx, GlobalContext* globalCtx2) {
                     this->stateFlags |= ENHORSE_BOOST;
                     this->stateFlags |= ENHORSE_FIRST_BOOST_REGEN;
                     this->stateFlags |= ENHORSE_FLAG_8;
-                    this->numBoosts -= !CVar_GetS32("gInfiniteEpona", 0);
+                    if (!CVar_GetS32("gInfiniteEpona", 0)) { this->numBoosts--; }
                     this->boostTimer = 0;
                     if (this->numBoosts == 0) {
                         this->boostRegenTime = 140;


### PR DESCRIPTION
This isn't strictly the same thing as "infinite carrots" because of the way Epona works. The boost timer only starts if you have <6 carrots, so while the only change I make here is preventing the carrot being subtracted, the actual result is that Epona is able to run at full gallop indefinitely.

To stop galloping, just ease off the analog stick.