### PR TITLE
change sunset time in save editor so dampe is out

### DIFF
--- a/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
+++ b/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
@@ -377,7 +377,7 @@ void DrawInfoTab() {
     }
     ImGui::SameLine();
     if (ImGui::Button("Sunset")) {
-        gSaveContext.dayTime = 0xC000;
+        gSaveContext.dayTime = 0xC001;
     }
     ImGui::SameLine();
     if (ImGui::Button("Midnight")) {


### PR DESCRIPTION
by setting the time to `0xC000` any checks for it being after sunset return false (including dampe being out), this leads to 
![image](https://user-images.githubusercontent.com/70942617/176701794-da75489b-3ded-486b-9661-08f57e1c4cd0.png)

where as having it set to `0xC001` will also show the time as **18:00** but dampe will be out

![image](https://user-images.githubusercontent.com/70942617/176702689-2c592dab-ac7b-4452-ab3d-b347c681e590.png)
