### PR TITLE
update pulseaudio for 44.1khz audio

### DIFF
--- a/libultraship/libultraship/PulseAudioPlayer.cpp
+++ b/libultraship/libultraship/PulseAudioPlayer.cpp
@@ -78,9 +78,9 @@ namespace Ship
         ss.channels = 2;
 
         pa_buffer_attr attr;
-	    attr.maxlength = (uint32_t)-1;
+        attr.maxlength = (uint32_t)-1;
         attr.tlength = (uint32_t)-1;
-	    attr.prebuf = (uint32_t)-1;
+        attr.prebuf = (uint32_t)-1;
         attr.minreq = (uint32_t)-1;
         attr.fragsize = (uint32_t)-1;
 

--- a/libultraship/libultraship/PulseAudioPlayer.cpp
+++ b/libultraship/libultraship/PulseAudioPlayer.cpp
@@ -78,10 +78,10 @@ namespace Ship
         ss.channels = 2;
 
         pa_buffer_attr attr;
-        attr.maxlength = (1600 + 544 + 528 + 1600) * 4;
-        attr.tlength = (528*2 + 544) * 4;
-        attr.prebuf = 1500 * 4;
-        attr.minreq = 161 * 4;
+	    attr.maxlength = (uint32_t)-1;
+        attr.tlength = (uint32_t)-1;
+	    attr.prebuf = (uint32_t)-1;
+        attr.minreq = (uint32_t)-1;
         attr.fragsize = (uint32_t)-1;
 
         m_Stream = pa_stream_new(m_Context, "zelda", &ss, NULL);

--- a/libultraship/libultraship/PulseAudioPlayer.cpp
+++ b/libultraship/libultraship/PulseAudioPlayer.cpp
@@ -87,14 +87,12 @@ namespace Ship
         // n64 audio engine running faster than pulseaudio, all multiplied
         // by 4 because each sample is 4 bytes
         attr.maxlength = (GetDesiredBuffered() + 3 * SAMPLES_HIGH * 2) * 4;
-        
-         // in an ideal world, one third of the calls should use SAMPLES_HIGH and two thirds SAMPLES_LOW
-        attr.tlength = (SAMPLES_LOW * 2 + SAMPLES_HIGH) * 4;
-        
+                
         // slightly more than one double audio update
         attr.prebuf = SAMPLES_HIGH * 3 * 1.5 * 4;
         
         attr.minreq = 222 * 4;
+        attr.tlength = (44100 / 20) * 4;
         
         // initialize to a value that is deemed sensible by the server 
         attr.fragsize = (uint32_t)-1;

--- a/libultraship/libultraship/PulseAudioPlayer.cpp
+++ b/libultraship/libultraship/PulseAudioPlayer.cpp
@@ -92,7 +92,7 @@ namespace Ship
         attr.prebuf = SAMPLES_HIGH * 3 * 1.5 * 4;
         
         attr.minreq = 222 * 4;
-        attr.tlength = (44100 / 20) * 4;
+        attr.tlength = (GetSampleRate() / 20) * 4;
         
         // initialize to a value that is deemed sensible by the server 
         attr.fragsize = (uint32_t)-1;


### PR DESCRIPTION
The old values for pulseaudio were ~magic numbers related to~ tuned to the 32khz n64 audio engine

updated to use values for 44.1khz audio and added documentation

~These values are the pulseaudio defaults, based on what [obs does](https://github.com/obsproject/obs-studio/commit/89591843dcda36da7471df627cb832f58315aa7b)~

this has been tested and fixes https://github.com/HarbourMasters/Shipwright/issues/540