### PR TITLE
Fixes: Fix text issues

### DIFF
--- a/libultraship/libultraship/ImGuiImpl.cpp
+++ b/libultraship/libultraship/ImGuiImpl.cpp
@@ -1105,6 +1105,8 @@ namespace SohImGui {
                     Tooltip("Correctly centers the Navi text prompt on the HUD's C-Up button");
                     EnhancementCheckbox("Fix Anubis fireballs", "gAnubisFix");
                     Tooltip("Make Anubis fireballs do fire damage when reflected back at them with the Mirror Shield");
+                    EnhancementCheckbox("Fix text issues", "gTypoFixes");
+                    Tooltip("Fixes minor errors in the original dialogue");
 
                     ImGui::EndMenu();
                 }

--- a/soh/src/code/z_message_PAL.c
+++ b/soh/src/code/z_message_PAL.c
@@ -1670,6 +1670,96 @@ void Message_OpenText(GlobalContext* globalCtx, u16 textId) {
         // OTRTODO
         //DmaMgr_SendRequest1(font->msgBuf, (uintptr_t)(_staff_message_data_staticSegmentRomStart + 4 + font->msgOffset),
                             //font->msgLength, __FILE__, __LINE__);
+    }
+
+    if (CVar_GetS32("gTypoFixes", 0)) {
+        Message_FindMessage(globalCtx, textId);
+        char* src = (uintptr_t)font->msgOffset;
+        // Bombchu Get!
+        if (textId == 0x33 && gSaveContext.language != LANGUAGE_GER) {
+            if (gSaveContext.language == LANGUAGE_ENG) {
+                msgCtx->msgLength = font->msgLength + 2;
+                memcpy(font->msgBuf, src, 0x66);
+                memcpy(font->msgBuf + 0x66, src + 0x67, 0x2E);
+                memcpy(font->msgBuf + 0x97, src + 0x95, font->msgLength - 0x93);
+                memcpy(font->msgBuf + 0x94, " of", 3);
+                font->msgBuf[0x9C] = 0x01;
+                font->msgBuf[0xA1] = 0x20;
+            } else { // French
+                msgCtx->msgLength = font->msgLength - 1;
+                memcpy(font->msgBuf, src, 0x61);
+                memcpy(font->msgBuf + 0x61, src + 0x62, font->msgLength - 0x62);
+            }
+        // Potion Shop at night
+        } else if (textId == 0x020E && gSaveContext.language == LANGUAGE_ENG) {
+            msgCtx->msgLength = font->msgLength - 2;
+            strcpy(font->msgBuf, "\x05\x44Potion");
+            memcpy(font->msgBuf + 0x8, src + 0xA, font->msgLength - 0xA);
+        // Shabom Navi hint
+        } else if (textId == 0x0616 && gSaveContext.language == LANGUAGE_ENG) {
+            msgCtx->msgLength = font->msgLength - 1;
+            memcpy(font->msgBuf, src, 0x29);
+            strcpy(font->msgBuf + 0x29, "low up\x01in your face!\x05\x40\x09\x02");
+        // Freezard
+        } else if (textId == 0x063B && gSaveContext.language != LANGUAGE_GER) {
+            if (gSaveContext.language == LANGUAGE_ENG) {
+                msgCtx->msgLength = font->msgLength - 1;
+                memcpy(font->msgBuf, src, 0x05);
+                memcpy(font->msgBuf + 0x05, src + 0x06, font->msgLength - 0x06);
+            } else { // French
+                msgCtx->msgLength = font->msgLength - 1;
+                memcpy(font->msgBuf, src, 0x09);
+                memcpy(font->msgBuf + 0x09, src + 0x0A, font->msgLength - 0x0A);
+            }
+        // Nocturne of Shadow
+        } else if (textId == 0x0897 && gSaveContext.language == LANGUAGE_ENG) {
+            msgCtx->msgLength = font->msgLength + 2;
+            strcpy(font->msgBuf, "\x08You p");
+            memcpy(font->msgBuf + 6, src + 4, font->msgLength - 4);
+        // Friendly Saria
+        } else if (textId == 0x106B && gSaveContext.language != LANGUAGE_GER) {
+            if (gSaveContext.language == LANGUAGE_ENG) {
+                msgCtx->msgLength = font->msgLength - 4;
+                strcpy(font->msgBuf, "\x1A\x06\x2EI");
+                memcpy(font->msgBuf + 0x04, src + 0x08, font->msgLength - 0x08);
+            } else { // French
+                msgCtx->msgLength = font->msgLength - 2;
+                strcpy(font->msgBuf, "\x1A\x06\x2CJe serai");
+                memcpy(font->msgBuf + 0x0B, src + 0x0D, font->msgLength - 0x0D);
+            }
+        // Running Man's dream
+        } else if (textId == 0x202D && gSaveContext.language == LANGUAGE_ENG) {
+            msgCtx->msgLength = font->msgLength;
+            memcpy(font->msgBuf, src, font->msgLength);
+            font->msgBuf[0x07] = '-';
+        // Malon incubation tip
+        } else if (textId == 0x2044 && gSaveContext.language == LANGUAGE_ENG) {
+            msgCtx->msgLength = font->msgLength + 3;
+            strcpy(font->msgBuf, "Incubate the egg, then set it to \x05\x46\xA1\x05\x40");
+            memcpy(font->msgBuf + 0x26, src + 0x23, font->msgLength - 0x23);
+        // Talon's plums
+        } else if (textId == 0x2084 && gSaveContext.language == LANGUAGE_ENG) {
+            msgCtx->msgLength = font->msgLength + 1;
+            memcpy(font->msgBuf, src, 0x20);
+            font->msgBuf[0x20] = 'b';
+            memcpy(font->msgBuf + 0x21, src + 0x20, font->msgLength - 0x20);
+        // Running Man's head-start
+        } else if (textId == 0x607F && gSaveContext.language == LANGUAGE_ENG) {
+            msgCtx->msgLength = font->msgLength + 1;
+            memcpy(font->msgBuf, src, 0x35);
+            font->msgBuf[0x35] = '-';
+            memcpy(font->msgBuf + 0x36, src + 0x35, font->msgLength - 0x35);
+        // It's an illusion, Michael (buff guy in alley)
+        } else if (textId == 0x7114 && gSaveContext.language == LANGUAGE_ENG) {
+            msgCtx->msgLength = font->msgLength - 1;
+            memcpy(font->msgBuf, src, 0x17);
+            strcpy(font->msgBuf + 0x17, " mask...\x02");
+        } else {
+            Message_FindMessage(globalCtx, textId);
+            msgCtx->msgLength = font->msgLength;
+            char* src = (uintptr_t)font->msgOffset;
+            memcpy(font->msgBuf, src, font->msgLength);
+        }
     } else {
         Message_FindMessage(globalCtx, textId);
         msgCtx->msgLength = font->msgLength;

--- a/soh/src/code/z_message_PAL.c
+++ b/soh/src/code/z_message_PAL.c
@@ -1670,9 +1670,7 @@ void Message_OpenText(GlobalContext* globalCtx, u16 textId) {
         // OTRTODO
         //DmaMgr_SendRequest1(font->msgBuf, (uintptr_t)(_staff_message_data_staticSegmentRomStart + 4 + font->msgOffset),
                             //font->msgLength, __FILE__, __LINE__);
-    }
-
-    if (CVar_GetS32("gTypoFixes", 0)) {
+    } else if (CVar_GetS32("gTypoFixes", 0)) {
         Message_FindMessage(globalCtx, textId);
         char* src = (uintptr_t)font->msgOffset;
         // Bombchu Get!

--- a/soh/src/code/z_message_PAL.c
+++ b/soh/src/code/z_message_PAL.c
@@ -1717,6 +1717,18 @@ void Message_OpenText(GlobalContext* globalCtx, u16 textId) {
             strcpy(font->msgBuf, "\x08You p");
             memcpy(font->msgBuf + 0x06, src + 0x04, font->msgLength - 0x04);
         // Friendly Saria
+        } else if (textId == 0x1048 && gSaveContext.language != LANGUAGE_GER) {
+            if (gSaveContext.language == LANGUAGE_ENG) {
+                msgCtx->msgLength = font->msgLength - 4;
+                strcpy(font->msgBuf, "\x0F, you and I");
+                memcpy(font->msgBuf + 0x0C, src + 0x0B, font->msgLength - 0x0B);
+            } else { // French
+                msgCtx->msgLength = font->msgLength - 2;
+                strcpy(font->msgBuf, "\x0F, toi et moi");
+                memcpy(font->msgBuf + 0x0D, src + 0x0A, font->msgLength - 0x0A);
+                font->msgBuf[0x13] = 's';
+            }
+        // Friendly Saria again
         } else if (textId == 0x106B && gSaveContext.language != LANGUAGE_GER) {
             if (gSaveContext.language == LANGUAGE_ENG) {
                 msgCtx->msgLength = font->msgLength - 4;

--- a/soh/src/code/z_message_PAL.c
+++ b/soh/src/code/z_message_PAL.c
@@ -1726,7 +1726,6 @@ void Message_OpenText(GlobalContext* globalCtx, u16 textId) {
                 msgCtx->msgLength = font->msgLength - 2;
                 strcpy(font->msgBuf, "\x0F, toi et moi");
                 memcpy(font->msgBuf + 0x0D, src + 0x0A, font->msgLength - 0x0A);
-                font->msgBuf[0x13] = 's';
             }
         // Friendly Saria again
         } else if (textId == 0x106B && gSaveContext.language != LANGUAGE_GER) {

--- a/soh/src/code/z_message_PAL.c
+++ b/soh/src/code/z_message_PAL.c
@@ -1729,9 +1729,9 @@ void Message_OpenText(GlobalContext* globalCtx, u16 textId) {
             }
         // Running Man's dream
         } else if (textId == 0x202D && gSaveContext.language == LANGUAGE_ENG) {
-            msgCtx->msgLength = font->msgLength;
-            memcpy(font->msgBuf, src, font->msgLength);
-            font->msgBuf[0x07] = '-';
+            msgCtx->msgLength = font->msgLength - 1;
+            memcpy(font->msgBuf, src, 0x07);
+            memcpy(font->msgBuf + 0x07, src + 0x08, font->msgLength - 0x08);
         // Malon incubation tip
         } else if (textId == 0x2044 && gSaveContext.language == LANGUAGE_ENG) {
             msgCtx->msgLength = font->msgLength + 3;
@@ -1743,11 +1743,11 @@ void Message_OpenText(GlobalContext* globalCtx, u16 textId) {
             memcpy(font->msgBuf, src, 0x20);
             font->msgBuf[0x20] = 'b';
             memcpy(font->msgBuf + 0x21, src + 0x20, font->msgLength - 0x20);
-        // Running Man's head-start
+        // Running Man's head start
         } else if (textId == 0x607F && gSaveContext.language == LANGUAGE_ENG) {
             msgCtx->msgLength = font->msgLength + 1;
             memcpy(font->msgBuf, src, 0x35);
-            font->msgBuf[0x35] = '-';
+            font->msgBuf[0x35] = ' ';
             memcpy(font->msgBuf + 0x36, src + 0x35, font->msgLength - 0x35);
         // It's an illusion, Michael (buff guy in alley)
         } else if (textId == 0x7114 && gSaveContext.language == LANGUAGE_ENG) {

--- a/soh/src/code/z_message_PAL.c
+++ b/soh/src/code/z_message_PAL.c
@@ -1684,7 +1684,7 @@ void Message_OpenText(GlobalContext* globalCtx, u16 textId) {
                 memcpy(font->msgBuf + 0x97, src + 0x95, font->msgLength - 0x93);
                 memcpy(font->msgBuf + 0x94, " of", 3);
                 font->msgBuf[0x9C] = 0x01;
-                font->msgBuf[0xA1] = 0x20;
+                font->msgBuf[0xA1] = ' ';
             } else { // French
                 msgCtx->msgLength = font->msgLength - 1;
                 memcpy(font->msgBuf, src, 0x61);

--- a/soh/src/code/z_message_PAL.c
+++ b/soh/src/code/z_message_PAL.c
@@ -1681,8 +1681,8 @@ void Message_OpenText(GlobalContext* globalCtx, u16 textId) {
                 msgCtx->msgLength = font->msgLength + 2;
                 memcpy(font->msgBuf, src, 0x66);
                 memcpy(font->msgBuf + 0x66, src + 0x67, 0x2E);
-                memcpy(font->msgBuf + 0x97, src + 0x95, font->msgLength - 0x93);
-                memcpy(font->msgBuf + 0x94, " of", 3);
+                memcpy(font->msgBuf + 0x97, src + 0x95, font->msgLength - 0x95);
+                memcpy(font->msgBuf + 0x94, " of", 0x03);
                 font->msgBuf[0x9C] = 0x01;
                 font->msgBuf[0xA1] = ' ';
             } else { // French
@@ -1694,7 +1694,7 @@ void Message_OpenText(GlobalContext* globalCtx, u16 textId) {
         } else if (textId == 0x020E && gSaveContext.language == LANGUAGE_ENG) {
             msgCtx->msgLength = font->msgLength - 2;
             strcpy(font->msgBuf, "\x05\x44Potion");
-            memcpy(font->msgBuf + 0x8, src + 0xA, font->msgLength - 0xA);
+            memcpy(font->msgBuf + 0x08, src + 0x0A, font->msgLength - 0x0A);
         // Shabom Navi hint
         } else if (textId == 0x0616 && gSaveContext.language == LANGUAGE_ENG) {
             msgCtx->msgLength = font->msgLength - 1;
@@ -1715,7 +1715,7 @@ void Message_OpenText(GlobalContext* globalCtx, u16 textId) {
         } else if (textId == 0x0897 && gSaveContext.language == LANGUAGE_ENG) {
             msgCtx->msgLength = font->msgLength + 2;
             strcpy(font->msgBuf, "\x08You p");
-            memcpy(font->msgBuf + 6, src + 4, font->msgLength - 4);
+            memcpy(font->msgBuf + 0x06, src + 0x04, font->msgLength - 0x04);
         // Friendly Saria
         } else if (textId == 0x106B && gSaveContext.language != LANGUAGE_GER) {
             if (gSaveContext.language == LANGUAGE_ENG) {


### PR DESCRIPTION
Adds a checkbox (yeah, yeah) in ImGui's Fixes section for fixing typos. Right now, this CVar is only checked in one place: when reading `textId 0x33`, the "You got Bombchu!" message. Somebody must have been tired that day, because there's two typos in the English message, plus one in the French message. Specifically, I'm removing an accidental space and adding the word "of" to "new type **of** bomb". These fixes were also made in the 3DS port.

I made the ImGui explanation a bit vague so that this same CVar can cover any potential text fixes in future.

**Before**:
![A new type bomb?](https://cdn.discordapp.com/attachments/935186300032667658/993514843443298304/unknown.png)

**After**:
![New Bomb XL](https://user-images.githubusercontent.com/5259025/177197696-6dc306cc-7a53-4f27-86fe-bef457cfe2b8.png)

---

If anyone is aware of more typos, I'd be happy to add them to this PR so it's a bit beefier than it is currently. The only other issue that I'm aware of is that Navi's Shabom (bubble enemy in Jabu-Jabu) help text is mistranslated, but that might be tough to fix without infringing on the original text, either by retranslating it or using the corrected GameCube final/3DS version.

**EDIT:** Just added a bunch more corrections. I'll list them here:
| Original | Fixed | Notes |
| --- | --- | --- |
| _Carry and place with (C).<br />This is a new type bomb [...] | Carry and place with (C).<br />This is a new type **of** bomb [...] | Typos
| **Medicine** Shop<br />Closed until morning | **Potion** Shop<br />Closed until morning | Mistranslation
| Shabom<br>If you try to cut it, it will b**ounce<br />off your blade**! | Shabom<br>If you try to cut it, it will b**low up<br />in your face**! | Mistranslation
| Freez**z**ard | Freezard | Typo
| **P**layed the Nocturne of Shadow. | **You p**layed the Nocturne of Shadow. | All other songs use "You played". |
| **Saria** will always be...<br />your friend... | **I** will always be...<br />your friend... | This is Saria speaking. In Japanese, sentences like this are expressed in the third-person, so this is just a mistranslation likely caused by seeing the line without the context that Saria is the one saying it. |
| My **long time** dream! | My **longtime** dream! | Longtime is the correct word and is used elsewhere in the script. |
| **Set the egg to (C) to incubate it.** | **Incubate the egg, then set it to (C).** | Mistranslation
| It's plum incredible! | It's plum**b** incredible! | Spelling error
| I'll give you a **headstart**. | I'll give you a **head start**. | Spelling error
| Ohhhh...I see...<br />It's a**n illusion**... | Ohhhh...I see...<br />It's a **mask**... | Mistranslation

All of these lines were fixed in later releases, either the GameCube final or the 3DS port, however I will stress that I **haven't** copied the text from those later releases. With an excess of caution, I've written new lines from scratch where necessary, e.g. Navi's mistranslated Shabom text. The new line is neither copied from later releases, nor a new translation (which would also be infringing), it is my personal description of what Shaboms do based on experience.

As much as possible, the dialogue fixes were made by shuffling around the original messages rather than including them in the code. As an example, the fixed Shabom text looks like this in the code:
```c
            memcpy(font->msgBuf, src, 0x29);
            strcpy(font->msgBuf + 0x29, "low up\x01in your face!\x05\x40\x09\x02");
```
i.e. The first `0x29` bytes are just reading directly from the message file, and the part that gets included in code is original, non-N dialogue. For another example that's more at the extreme end, this is how the fixed Bombchu text is generated:
```c
                memcpy(font->msgBuf, src, 0x66);
                memcpy(font->msgBuf + 0x66, src + 0x67, 0x2E);
                memcpy(font->msgBuf + 0x97, src + 0x95, font->msgLength - 0x95);
                memcpy(font->msgBuf + 0x94, " of", 3);
                font->msgBuf[0x9C] = 0x01;
                font->msgBuf[0xA1] = ' ';
```
I know that's hard to follow, but it's reading the first `0x66` bytes straight from the message file, then skipping one byte (a typo in the original message), reading the next `0x2E` bytes, then leaving a three byte space (we'll come back to this), then reading the rest of the message from the message file. Lastly, we make our patches: inserting the string `" of"` into the three byte space we left earlier, then inserting a line break `0x01` and a space to re-arrange how the new message fits the text box.

I'll be the first to acknowledge that some of these (long time->longtime, headstart -> head start) are ridiculously minor fixes. To find things that looked like they might be worth fixing, I did use the 3DS script as a reference solely to identify *where changes were made*. There are actually hundreds of minor changes all throughout the 3DS port, but I limited myself to things that seemed *obviously* wrong. Long time and headstart were definitely on the low end of that scale. Further down that scale were changes like making sure ellipses are always made of three dots and that commas are placed correctly.