### PR TITLE
Easy Twinrova enhancement

### DIFF
--- a/libultraship/libultraship/ImGuiImpl.cpp
+++ b/libultraship/libultraship/ImGuiImpl.cpp
@@ -964,6 +964,8 @@ namespace SohImGui {
                         Tooltip("Disables random drops, except from the Goron Pot, Dampe, and bosses");
                         EnhancementCheckbox("No Heart Drops", "gNoHeartDrops");
                         Tooltip("Disables heart drops, but not heart placements, like from a Deku Scrub running off. This simulates Hero Mode from other games in the series.");
+                        EnhancementCheckbox("Easy Twinrova", "gEasyTwinrova");
+                        Tooltip("First phase goes down after a single reflected beam. Shield fully charges after absorbing one attack in the second phase.");
                         
                         ImGui::EndMenu();
                     }

--- a/soh/src/overlays/actors/ovl_Boss_Tw/z_boss_tw.c
+++ b/soh/src/overlays/actors/ovl_Boss_Tw/z_boss_tw.c
@@ -1275,7 +1275,12 @@ void BossTw_ShootBeam(BossTw* this, GlobalContext* globalCtx) {
             BossTw_SetupHitByBeam(otherTw, globalCtx);
             Audio_PlayActorSound2(&otherTw->actor, NA_SE_EN_TWINROBA_DAMAGE_VOICE);
             globalCtx->envCtx.unk_D8 = 1.0f;
-            otherTw->actor.colChkInfo.health++;
+            if (!(CVar_GetS32("gEasyTwinrova", 0))) {
+                otherTw->actor.colChkInfo.health++;
+            }
+            else {
+                otherTw->actor.colChkInfo.health = otherTw->actor.colChkInfo.health + 4;
+            }
         }
     }
 }
@@ -4307,7 +4312,11 @@ s32 BossTw_BlastShieldCheck(BossTw* this, GlobalContext* globalCtx) {
                             BossTw_AddShieldDeflectEffect(globalCtx, 10.0f, 1);
                         } else {
                             BossTw_AddShieldHitEffect(globalCtx, 10.0f, 1);
-                            sShieldFireCharge++;
+                            if (!(CVar_GetS32("gEasyTwinrova", 0))) {
+                                sShieldFireCharge++;
+                            } else {
+                                sShieldFireCharge = 3;
+                            }
                             D_8094C86F = (sShieldFireCharge * 2) + 8;
                             D_8094C872 = -7;
                         }
@@ -4318,7 +4327,11 @@ s32 BossTw_BlastShieldCheck(BossTw* this, GlobalContext* globalCtx) {
                             BossTw_AddShieldDeflectEffect(globalCtx, 10.0f, 0);
                         } else {
                             BossTw_AddShieldHitEffect(globalCtx, 10.0f, 0);
-                            sShieldIceCharge++;
+                            if (!(CVar_GetS32("gEasyTwinrova", 0))) {
+                                sShieldIceCharge++;
+                            } else {
+                                sShieldIceCharge = 3;
+                            }
                             D_8094C86F = (sShieldIceCharge * 2) + 8;
                             D_8094C872 = -7;
                         }

--- a/soh/src/overlays/actors/ovl_Boss_Tw/z_boss_tw.c
+++ b/soh/src/overlays/actors/ovl_Boss_Tw/z_boss_tw.c
@@ -1275,6 +1275,7 @@ void BossTw_ShootBeam(BossTw* this, GlobalContext* globalCtx) {
             BossTw_SetupHitByBeam(otherTw, globalCtx);
             Audio_PlayActorSound2(&otherTw->actor, NA_SE_EN_TWINROBA_DAMAGE_VOICE);
             globalCtx->envCtx.unk_D8 = 1.0f;
+            // Immediately set the hp of twinrova to 4 to go into phase 2 after one beam hit
             if (!(CVar_GetS32("gEasyTwinrova", 0))) {
                 otherTw->actor.colChkInfo.health++;
             }
@@ -4312,6 +4313,7 @@ s32 BossTw_BlastShieldCheck(BossTw* this, GlobalContext* globalCtx) {
                             BossTw_AddShieldDeflectEffect(globalCtx, 10.0f, 1);
                         } else {
                             BossTw_AddShieldHitEffect(globalCtx, 10.0f, 1);
+                            // Set the shield value to fully charged immediately when enhancement is enabled
                             if (!(CVar_GetS32("gEasyTwinrova", 0))) {
                                 sShieldFireCharge++;
                             } else {
@@ -4327,6 +4329,7 @@ s32 BossTw_BlastShieldCheck(BossTw* this, GlobalContext* globalCtx) {
                             BossTw_AddShieldDeflectEffect(globalCtx, 10.0f, 0);
                         } else {
                             BossTw_AddShieldHitEffect(globalCtx, 10.0f, 0);
+                            // Set the shield value to fully charged immediately when enhancement is enabled
                             if (!(CVar_GetS32("gEasyTwinrova", 0))) {
                                 sShieldIceCharge++;
                             } else {


### PR DESCRIPTION
Adds enhancement to SoH for easier/faster twinrova fight. First phase only requires one beam hit to continue to phase 2. In phase 2, shield immediately charges to full when hit.