### PR TITLE
Restoration Item Sliders

### DIFF
--- a/libultraship/libultraship/ImGuiImpl.cpp
+++ b/libultraship/libultraship/ImGuiImpl.cpp
@@ -926,7 +926,6 @@ namespace SohImGui {
             {
                 if (ImGui::BeginMenu("Gameplay"))
                 {
-<<<<<<< HEAD:libultraship/libultraship/ImGuiImpl.cpp
                     if (ImGui::BeginMenu("Time Savers"))
                     {
                         EnhancementSliderInt("Text Speed: %dx", "##TEXTSPEED", "gTextSpeed", 1, 5, "");
@@ -970,14 +969,14 @@ namespace SohImGui {
                         {
                             EnhancementCheckbox("Change Red Potion Effect", "gRedPotionEffect");
                             Tooltip("Enable the following changes to the amount of health restored by Red Potions");
-                            EnhancementSliderInt("Red Potion: %d", "##REDPOTION", "gRedPotion", 1, 100, "");
+                            EnhancementSliderInt("Red Potion Health: %d", "##REDPOTIONHEALTH", "gRedPotionHealth", 1, 100, "");
                             Tooltip("Changes the amount of health restored by Red Potions");
                             EnhancementCheckbox("Red Potion Percent Restore", "gRedPercentRestore");
                             Tooltip("Toggles from Red Potions restoring a fixed amount of health to a percent of the player's current max health");
                             
                             EnhancementCheckbox("Change Green Potion Effect", "gGreenPotionEffect");
                             Tooltip("Enable the following changes to the amount of mana restored by Green Potions");
-                            EnhancementSliderInt("Green Potion: %d", "##GREENPOTION", "gGreenPotion", 1, 100, "");
+                            EnhancementSliderInt("Green Potion Mana: %d", "##GREENPOTIONMANA", "gGreenPotionMana", 1, 100, "");
                             Tooltip("Changes the amount of mana restored by Green Potions, base max mana is 48, max upgraded mana is 96");
                             EnhancementCheckbox("Green Potion Percent Restore", "gGreenPercentRestore");
                             Tooltip("Toggles from Green Potions restoring a fixed amount of mana to a percent of the player's current max mana");
@@ -996,17 +995,32 @@ namespace SohImGui {
 
                             EnhancementCheckbox("Change Milk Effect", "gMilkEffect");
                             Tooltip("Enable the following changes to the amount of health restored by Milk");
-                            EnhancementSliderInt("Milk: %d", "##MILK", "gMilk", 1, 100, "");
+                            EnhancementSliderInt("Milk Health: %d", "##MILKHEALTH", "gMilkHealth", 1, 100, "");
                             Tooltip("Changes the amount of health restored by Milk");
                             EnhancementCheckbox("Milk Percent Restore", "gMilkPercentRestore");
                             Tooltip("Toggles from Milk restoring a fixed amount of health to a percent of the player's current max health");
 
                             EnhancementCheckbox("Separate Half Milk Effect", "gSeparateHalfMilkEffect");
                             Tooltip("Enable the following changes to the amount of health restored by Half Milk.\nIf this is disabled, Half Milk will behave the same as Full Milk.");
-                            EnhancementSliderInt("Half Milk: %d", "##HALFMILK", "gHalfMilk", 1, 100, "");
+                            EnhancementSliderInt("Half Milk Health: %d", "##HALFMILKHEALTH", "gHalfMilkHealth", 1, 100, "");
                             Tooltip("Changes the amount of health restored by Half Milk");
                             EnhancementCheckbox("Half Milk Percent Restore", "gHalfMilkPercentRestore");
                             Tooltip("Toggles from Half Milk restoring a fixed amount of health to a percent of the player's current max health");
+
+                            EnhancementCheckbox("Change Fairy Effect", "gFairyEffect");
+                            Tooltip("Enable the following changes to the amount of health restored by Fairies");
+                            EnhancementSliderInt("Fairy: %d", "##FAIRYHEALTH", "gFairyHealth", 1, 100, "");
+                            Tooltip("Changes the amount of health restored by Fairies");
+                            EnhancementCheckbox("Fairy Percent Restore", "gFairyPercentRestore");
+                            Tooltip("Toggles from Fairies restoring a fixed amount of health to a percent of the player's current max health");
+
+                            EnhancementCheckbox("Change Fairy Revive Effect", "gFairyReviveEffect");
+                            Tooltip("Enable the following changes to the amount of health restored by Fairy Revivals");
+                            EnhancementSliderInt("Fairy Revival: %d", "##FAIRYREVIVEHEALTH", "gFairyReviveHealth", 1, 100, "");
+                            Tooltip("Changes the amount of health restored by Fairy Revivals");
+                            EnhancementCheckbox("Fairy Revive Percent Restore", "gFairyRevivePercentRestore");
+                            Tooltip("Toggles from Fairy Revivals restoring a fixed amount of health to a percent of the player's current max health");
+
                             ImGui::EndMenu();
                         }
                         

--- a/libultraship/libultraship/SohImGuiImpl.cpp
+++ b/libultraship/libultraship/SohImGuiImpl.cpp
@@ -911,7 +911,7 @@ namespace SohImGui {
                         EnhancementCheckbox("Milk Percent Restore", "gMilkPercentRestore");
                         Tooltip("Toggles from Milk restoring a fixed amount of health to a percent of the player's current max health");
 
-                        EnhancementCheckbox("gSeparateHalfMilkEffect", "gMilkEffect");
+                        EnhancementCheckbox("Separate Half Milk Effect", "gSeparateHalfMilkEffect");
                         Tooltip("Enable the following changes to the amount of health restored by Half Milk.\nIf this is disabled, Half Milk will behave the same as Full Milk.");
                         EnhancementSliderInt("Half Milk: %d", "##HALFMILK", "gHalfMilk", 1, 100, "");
                         Tooltip("Changes the amount of health restored by Half Milk");

--- a/libultraship/libultraship/SohImGuiImpl.cpp
+++ b/libultraship/libultraship/SohImGuiImpl.cpp
@@ -876,6 +876,50 @@ namespace SohImGui {
             {
                 if (ImGui::BeginMenu("Gameplay"))
                 {
+                    if (ImGui::BeginMenu("Potion Values"))
+                    {
+                        EnhancementCheckbox("Change Red Potion Effect", "gRedPotionEffect");
+                        Tooltip("Enable the following changes to the amount of health restored by Red Potions");
+                        EnhancementSliderInt("Red Potion: %d", "##REDPOTION", "gRedPotion", 1, 100, "");
+                        Tooltip("Changes the amount of health restored by Red Potions");
+                        EnhancementCheckbox("Red Potion Percent Restore", "gRedPercentRestore");
+                        Tooltip("Toggles from Red Potions restoring a fixed amount of health to a percent of the player's current max health");
+                        
+                        EnhancementCheckbox("Change Green Potion Effect", "gGreenPotionEffect");
+                        Tooltip("Enable the following changes to the amount of mana restored by Green Potions");
+                        EnhancementSliderInt("Green Potion: %d", "##GREENPOTION", "gGreenPotion", 1, 100, "");
+                        Tooltip("Changes the amount of mana restored by Green Potions, base max mana is 48, max upgraded mana is 96");
+                        EnhancementCheckbox("Green Potion Percent Restore", "gGreenPercentRestore");
+                        Tooltip("Toggles from Green Potions restoring a fixed amount of mana to a percent of the player's current max mana");
+
+                        EnhancementCheckbox("Change Blue Potion Effects", "gBluePotionEffects");
+                        Tooltip("Enable the following changes to the amount of health and mana restored by Blue Potions");
+                        EnhancementSliderInt("Blue Potion Health: %d", "##BLUEPOTIONHEALTH", "gBluePotionHealth", 1, 100, "");
+                        Tooltip("Changes the amount of health restored by Blue Potions");
+                        EnhancementCheckbox("Blue Potion Health Percent Restore", "gBlueHealthPercentRestore");
+                        Tooltip("Toggles from Blue Potions restoring a fixed amount of health to a percent of the player's current max health");
+                        
+                        EnhancementSliderInt("Blue Potion Mana: %d", "##BLUEPOTIONMANA", "gBluePotionMana", 1, 100, "");
+                        Tooltip("Changes the amount of mana restored by Blue Potions, base max mana is 48, max upgraded mana is 96");
+                        EnhancementCheckbox("Blue Potion Mana Percent Restore", "gBlueManaPercentRestore");
+                        Tooltip("Toggles from Blue Potions restoring a fixed amount of mana to a percent of the player's current max mana");
+
+                        EnhancementCheckbox("Change Milk Effect", "gMilkEffect");
+                        Tooltip("Enable the following changes to the amount of health restored by Milk");
+                        EnhancementSliderInt("Milk: %d", "##MILK", "gMilk", 1, 100, "");
+                        Tooltip("Changes the amount of health restored by Milk");
+                        EnhancementCheckbox("Milk Percent Restore", "gMilkPercentRestore");
+                        Tooltip("Toggles from Milk restoring a fixed amount of health to a percent of the player's current max health");
+
+                        EnhancementCheckbox("gSeparateHalfMilkEffect", "gMilkEffect");
+                        Tooltip("Enable the following changes to the amount of health restored by Half Milk.\nIf this is disabled, Half Milk will behave the same as Full Milk.");
+                        EnhancementSliderInt("Half Milk: %d", "##HALFMILK", "gHalfMilk", 1, 100, "");
+                        Tooltip("Changes the amount of health restored by Half Milk");
+                        EnhancementCheckbox("Half Milk Percent Restore", "gHalfMilkPercentRestore");
+                        Tooltip("Toggles from Half Milk restoring a fixed amount of health to a percent of the player's current max health");
+                        ImGui::EndMenu();
+                    }
+
                     EnhancementSliderInt("Text Speed: %dx", "##TEXTSPEED", "gTextSpeed", 1, 5, "");
                     EnhancementSliderInt("King Zora Speed: %dx", "##WEEPSPEED", "gMweepSpeed", 1, 5, "");
                     EnhancementSliderInt("Biggoron Forge Time: %d days", "##FORGETIME", "gForgeTime", 0, 3, "");

--- a/soh/src/overlays/actors/ovl_En_Elf/z_en_elf.c
+++ b/soh/src/overlays/actors/ovl_En_Elf/z_en_elf.c
@@ -628,7 +628,21 @@ void func_80A0329C(EnElf* this, GlobalContext* globalCtx) {
 
         if ((heightDiff > 0.0f) && (heightDiff < 60.0f)) {
             if (!func_80A01F90(&this->actor.world.pos, &refActor->actor.world.pos, 10.0f)) {
-                Health_ChangeBy(globalCtx, 128);
+                if (CVar_GetS32("gFairyEffect", 0) && !(this->fairyFlags & FAIRY_FLAG_BIG))
+                {
+                    if (CVar_GetS32("gFairyPercentRestore", 0))
+                    {
+                        Health_ChangeBy(globalCtx, (gSaveContext.healthCapacity * CVar_GetS32("gFairyHealth", 100) / 100 + 15) / 16 * 16);
+                    }
+                    else
+                    {
+                        Health_ChangeBy(globalCtx, CVar_GetS32("gFairyHealth", 8) * 16);
+                    }
+                }
+                else
+                {
+                    Health_ChangeBy(globalCtx, 128);
+                }
                 if (this->fairyFlags & FAIRY_FLAG_BIG) {
                     Magic_Fill(globalCtx);
                 }

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -12789,17 +12789,100 @@ void func_8084EAC0(Player* this, GlobalContext* globalCtx) {
             }
             else {
                 s32 sp28 = D_808549FC[this->itemActionParam - PLAYER_AP_BOTTLE_POTION_RED];
-
-                if (sp28 & 1) {
-                    gSaveContext.healthAccumulator = 0x140;
+                
+                if (CVar_GetS32("gRedPotionEffect", 0) && this->itemActionParam == PLAYER_AP_BOTTLE_POTION_RED)
+                {
+                    if (CVar_GetS32("gRedPercentRestore", 0))
+                    {
+                        gSaveContext.healthAccumulator = (gSaveContext.healthCapacity * CVar_GetS32("gRedPotion", 100) / 100 + 15) / 16 * 16;
+                    }
+                    else
+                    {
+                        gSaveContext.healthAccumulator = CVar_GetS32("gRedPotion", 20) * 16;
+                    }
                 }
+                else if (CVar_GetS32("gBluePotionEffects", 0) && this->itemActionParam == PLAYER_AP_BOTTLE_POTION_BLUE)
+                {
+                    if (CVar_GetS32("gBlueHealthPercentRestore", 0))
+                    {
+                        gSaveContext.healthAccumulator = (gSaveContext.healthCapacity * CVar_GetS32("gBluePotionHealth", 100) / 100 + 15) / 16 * 16;
+                    }
+                    else
+                    {
+                        gSaveContext.healthAccumulator = CVar_GetS32("gBluePotionHealth", 20) * 16;
+                    }
 
-                if (sp28 & 2) {
-                    Magic_Fill(globalCtx);
+                    if (CVar_GetS32("gBlueManaPercentRestore", 0))
+                    {
+                        if (gSaveContext.unk_13F0 != 10) {
+                            Magic_Fill(globalCtx);
+                        }
+
+                        func_80087708(globalCtx, (gSaveContext.magicLevel * 48 * CVar_GetS32("gBluePotionMana", 100) / 100 + 15) / 16 * 16, 5);
+                    }
+                    else
+                    {
+                        if (gSaveContext.unk_13F0 != 10) {
+                            Magic_Fill(globalCtx);
+                        }
+
+                        func_80087708(globalCtx, CVar_GetS32("gBluePotionMana", 100), 5);;
+                    }
                 }
+                else if (CVar_GetS32("gGreenPotionEffect", 0) && this->itemActionParam == PLAYER_AP_BOTTLE_POTION_GREEN)
+                {
+                    if (CVar_GetS32("gGreenPercentRestore", 0))
+                    {
+                        if (gSaveContext.unk_13F0 != 10) {
+                            Magic_Fill(globalCtx);
+                        }
 
-                if (sp28 & 4) {
-                    gSaveContext.healthAccumulator = 0x50;
+                        func_80087708(globalCtx, (gSaveContext.magicLevel * 48 * CVar_GetS32("gGreenPotion", 100) / 100 + 15) / 16 * 16, 5);
+                    }
+                    else
+                    {
+                        if (gSaveContext.unk_13F0 != 10) {
+                            Magic_Fill(globalCtx);
+                        }
+
+                        func_80087708(globalCtx, CVar_GetS32("gGreenPotion", 100), 5);;
+                    }
+                }
+                else if (CVar_GetS32("gMilkEffect", 0) && (this->itemActionParam == PLAYER_AP_BOTTLE_MILK || this->itemActionParam == PLAYER_AP_BOTTLE_MILK_HALF))
+                {
+                    if (CVar_GetS32("gMilkPercentRestore", 0))
+                    {
+                        gSaveContext.healthAccumulator = (gSaveContext.healthCapacity * CVar_GetS32("gMilk", 100) / 100 + 15) / 16 * 16;
+                    }
+                    else
+                    {
+                        gSaveContext.healthAccumulator = CVar_GetS32("gMilk", 5) * 16;
+                    }
+                    if  (CVar_GetS32("gSeparateHalfMilkEffect", 0) && this->itemActionParam == PLAYER_AP_BOTTLE_MILK_HALF)
+                    {
+                        if (CVar_GetS32("gHalfMilkPercentRestore", 0))
+                        {
+                            gSaveContext.healthAccumulator = (gSaveContext.healthCapacity * CVar_GetS32("gHalfMilk", 100) / 100 + 15) / 16 * 16;
+                        }
+                        else
+                        {
+                            gSaveContext.healthAccumulator = CVar_GetS32("gHalfMilk", 5) * 16;
+                        }
+                    }
+                }
+                else
+                {
+                    if (sp28 & 1) {
+                        gSaveContext.healthAccumulator = 0x140;
+                    }
+
+                    if (sp28 & 2) {
+                        Magic_Fill(globalCtx);
+                    }
+
+                    if (sp28 & 4) {
+                        gSaveContext.healthAccumulator = 0x50;
+                    }
                 }
             }
 

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -8232,7 +8232,21 @@ void func_80843AE8(GlobalContext* globalCtx, Player* this) {
                     LinkAnimation_Change(globalCtx, &this->skelAnime, &gPlayerAnim_002878, 1.0f, 99.0f,
                         Animation_GetLastFrame(&gPlayerAnim_002878), ANIMMODE_ONCE, 0.0f);
                 }
-                gSaveContext.healthAccumulator = 0x140;
+                if (CVar_GetS32("gFairyReviveEffect", 0))
+                {
+                    if (CVar_GetS32("gFairyRevivePercentRestore", 0))
+                    {
+                        gSaveContext.healthAccumulator = (gSaveContext.healthCapacity * CVar_GetS32("gFairyReviveHealth", 100) / 100 + 15) / 16 * 16;
+                    }
+                    else
+                    {
+                        gSaveContext.healthAccumulator = CVar_GetS32("gFairyReviveHealth", 20) * 16;
+                    }
+                }
+                else
+                {
+                    gSaveContext.healthAccumulator = 0x140;
+                }
                 this->unk_850 = -1;
             }
         }
@@ -12839,11 +12853,11 @@ void func_8084EAC0(Player* this, GlobalContext* globalCtx) {
                 {
                     if (CVar_GetS32("gRedPercentRestore", 0))
                     {
-                        gSaveContext.healthAccumulator = (gSaveContext.healthCapacity * CVar_GetS32("gRedPotion", 100) / 100 + 15) / 16 * 16;
+                        gSaveContext.healthAccumulator = (gSaveContext.healthCapacity * CVar_GetS32("gRedPotionHealth", 100) / 100 + 15) / 16 * 16;
                     }
                     else
                     {
-                        gSaveContext.healthAccumulator = CVar_GetS32("gRedPotion", 20) * 16;
+                        gSaveContext.healthAccumulator = CVar_GetS32("gRedPotionHealth", 20) * 16;
                     }
                 }
                 else if (CVar_GetS32("gBluePotionEffects", 0) && this->itemActionParam == PLAYER_AP_BOTTLE_POTION_BLUE)
@@ -12882,7 +12896,7 @@ void func_8084EAC0(Player* this, GlobalContext* globalCtx) {
                             Magic_Fill(globalCtx);
                         }
 
-                        func_80087708(globalCtx, (gSaveContext.magicLevel * 48 * CVar_GetS32("gGreenPotion", 100) / 100 + 15) / 16 * 16, 5);
+                        func_80087708(globalCtx, (gSaveContext.magicLevel * 48 * CVar_GetS32("gGreenPotionMana", 100) / 100 + 15) / 16 * 16, 5);
                     }
                     else
                     {
@@ -12890,28 +12904,28 @@ void func_8084EAC0(Player* this, GlobalContext* globalCtx) {
                             Magic_Fill(globalCtx);
                         }
 
-                        func_80087708(globalCtx, CVar_GetS32("gGreenPotion", 100), 5);;
+                        func_80087708(globalCtx, CVar_GetS32("gGreenPotionMana", 100), 5);;
                     }
                 }
                 else if (CVar_GetS32("gMilkEffect", 0) && (this->itemActionParam == PLAYER_AP_BOTTLE_MILK || this->itemActionParam == PLAYER_AP_BOTTLE_MILK_HALF))
                 {
                     if (CVar_GetS32("gMilkPercentRestore", 0))
                     {
-                        gSaveContext.healthAccumulator = (gSaveContext.healthCapacity * CVar_GetS32("gMilk", 100) / 100 + 15) / 16 * 16;
+                        gSaveContext.healthAccumulator = (gSaveContext.healthCapacity * CVar_GetS32("gMilkHealth", 100) / 100 + 15) / 16 * 16;
                     }
                     else
                     {
-                        gSaveContext.healthAccumulator = CVar_GetS32("gMilk", 5) * 16;
+                        gSaveContext.healthAccumulator = CVar_GetS32("gMilkHealth", 5) * 16;
                     }
                     if  (CVar_GetS32("gSeparateHalfMilkEffect", 0) && this->itemActionParam == PLAYER_AP_BOTTLE_MILK_HALF)
                     {
                         if (CVar_GetS32("gHalfMilkPercentRestore", 0))
                         {
-                            gSaveContext.healthAccumulator = (gSaveContext.healthCapacity * CVar_GetS32("gHalfMilk", 100) / 100 + 15) / 16 * 16;
+                            gSaveContext.healthAccumulator = (gSaveContext.healthCapacity * CVar_GetS32("gHalfMilkHealth", 100) / 100 + 15) / 16 * 16;
                         }
                         else
                         {
-                            gSaveContext.healthAccumulator = CVar_GetS32("gHalfMilk", 5) * 16;
+                            gSaveContext.healthAccumulator = CVar_GetS32("gHalfMilkHealth", 5) * 16;
                         }
                     }
                 }
@@ -13040,7 +13054,21 @@ void func_8084EED8(Player* this, GlobalContext* globalCtx) {
         func_8002F7DC(&this->actor, NA_SE_EV_FIATY_HEAL - SFX_FLAG);
     }
     else if (LinkAnimation_OnFrame(&this->skelAnime, 47.0f)) {
-        gSaveContext.healthAccumulator = 0x140;
+        if (CVar_GetS32("gFairyEffect", 0))
+        {
+            if (CVar_GetS32("gFairyPercentRestore", 0))
+            {
+                gSaveContext.healthAccumulator = (gSaveContext.healthCapacity * CVar_GetS32("gFairyHealth", 100) / 100 + 15) / 16 * 16;
+            }
+            else
+            {
+                gSaveContext.healthAccumulator = CVar_GetS32("gFairyHealth", 8) * 16;
+            }
+        }
+        else
+        {
+            gSaveContext.healthAccumulator = 0x140;
+        }
     }
 }
 


### PR DESCRIPTION
Adds sliders for changing how much health/mana potions, milk and fairies (except big fairies) restore. Changes can be percent based or integer based, though will always be in multiples of 16 health, aka 1 heart increments.