### PR TITLE
Fix Ganon's Castle title cards

### DIFF
--- a/soh/src/code/z_actor.c
+++ b/soh/src/code/z_actor.c
@@ -843,8 +843,11 @@ void TitleCard_InitPlaceName(GlobalContext* globalCtx, TitleCardContext* titleCt
         case SCENE_GERUDOWAY:
             texture = gThievesHideoutTitleCardENGTex;
             break;
-        case SCENE_GANONTIKA:
+        case SCENE_GANON_TOU:
             texture = gGanonsCastleTitleCardENGTex;
+            break;
+        case SCENE_GANONTIKA:
+            texture = gInsideGanonsCastleTitleCardENGTex;
             break;
         case SCENE_TAKARAYA:
             texture = gTreasureBoxShopTitleCardENGTex;


### PR DESCRIPTION
Title cards were wrong in SoH for the outside/inside Ganon's Castle scenes.

Fixes #573