### PR TITLE
Invalidate text box icon before drawing

### DIFF
--- a/soh/src/code/z_message_PAL.c
+++ b/soh/src/code/z_message_PAL.c
@@ -543,6 +543,7 @@ void Message_DrawTextboxIcon(GlobalContext* globalCtx, Gfx** p, s16 x, s16 y) {
     s16 envG;
     s16 envB;
     u8* iconTexture = font->iconBuf;
+    gSPInvalidateTexCache(gfx++, iconTexture);
 
     if (sTextIsCredits) {
         return;


### PR DESCRIPTION
The text box icon is the triangle/square/arrow prompting the player for interaction. The cache is currently not invalidated before drawing, so the last one loaded will keep displaying regardless of whether it's the correct icon for the current interaction.

Fixes #581 