### PR TITLE
Checkered room crash workaround

### DIFF
--- a/soh/src/code/z_bgcheck.c
+++ b/soh/src/code/z_bgcheck.c
@@ -1593,8 +1593,10 @@ void BgCheck_Allocate(CollisionContext* colCtx, GlobalContext* globalCtx, Collis
     //
     // OTRTODO: This is a workaround. The proper solution to fix this crash is to manage object loading / unloading
     // the same as N64.
-    colCtx->dyna.polyListMax *= 2;
-    colCtx->dyna.vtxListMax *= 2;
+    if (globalCtx->sceneNum == SCENE_BMORI1) {
+        colCtx->dyna.polyListMax *= 2;
+        colCtx->dyna.vtxListMax *= 2;
+    }
 
     memSize = colCtx->subdivAmount.x * sizeof(StaticLookup) * colCtx->subdivAmount.y * colCtx->subdivAmount.z +
               colCtx->colHeader->numPolygons * sizeof(u8) + colCtx->dyna.polyNodesMax * sizeof(SSNode) +

--- a/soh/src/code/z_bgcheck.c
+++ b/soh/src/code/z_bgcheck.c
@@ -1590,6 +1590,9 @@ void BgCheck_Allocate(CollisionContext* colCtx, GlobalContext* globalCtx, Collis
 
     // BGCheck needs a higher polygon and vertex count due to removed object dependencies.
     // Otherwise Forest Temple checkered room will crash due to the hallway actor being killed a frame late.
+    //
+    // OTRTODO: This is a workaround. The proper solution to fix this crash is to manage object loading / unloading
+    // the same as N64.
     colCtx->dyna.polyListMax *= 2;
     colCtx->dyna.vtxListMax *= 2;
 

--- a/soh/src/code/z_bgcheck.c
+++ b/soh/src/code/z_bgcheck.c
@@ -1588,6 +1588,11 @@ void BgCheck_Allocate(CollisionContext* colCtx, GlobalContext* globalCtx, Collis
     colCtx->memSize *= 2;
 #endif
 
+    // BGCheck needs a higher polygon and vertex count due to removed object dependencies.
+    // Otherwise Forest Temple checkered room will crash due to the hallway actor being killed a frame late.
+    colCtx->dyna.polyListMax *= 2;
+    colCtx->dyna.vtxListMax *= 2;
+
     memSize = colCtx->subdivAmount.x * sizeof(StaticLookup) * colCtx->subdivAmount.y * colCtx->subdivAmount.z +
               colCtx->colHeader->numPolygons * sizeof(u8) + colCtx->dyna.polyNodesMax * sizeof(SSNode) +
               colCtx->dyna.polyListMax * sizeof(CollisionPoly) + colCtx->dyna.vtxListMax * sizeof(Vec3s) +

--- a/soh/src/code/z_bgcheck.c
+++ b/soh/src/code/z_bgcheck.c
@@ -1584,19 +1584,19 @@ void BgCheck_Allocate(CollisionContext* colCtx, GlobalContext* globalCtx, Collis
     BgCheck_SetSubdivisionDimension(colCtx->minBounds.z, colCtx->subdivAmount.z, &colCtx->maxBounds.z,
                                     &colCtx->subdivLength.z, &colCtx->subdivLengthInv.z);
 
-#ifdef _SOH64 // BGCheck needs more memory on 64 bits because it crashes on some areas
-    colCtx->memSize *= 2;
-#endif
+// OTRTODO: Re-enable when the below DynaPoly workaround is removed.
+// #ifdef _SOH64 // BGCheck needs more memory on 64 bits because it crashes on some areas
+//     colCtx->memSize *= 2;
+// #endif
 
     // BGCheck needs a higher polygon and vertex count due to removed object dependencies.
     // Otherwise Forest Temple checkered room will crash due to the hallway actor being killed a frame late.
     //
     // OTRTODO: This is a workaround. The proper solution to fix this crash is to manage object loading / unloading
     // the same as N64.
-    if (globalCtx->sceneNum == SCENE_BMORI1) {
-        colCtx->dyna.polyListMax *= 2;
-        colCtx->dyna.vtxListMax *= 2;
-    }
+    colCtx->memSize *= 2;
+    colCtx->dyna.polyListMax *= 2;
+    colCtx->dyna.vtxListMax *= 2;
 
     memSize = colCtx->subdivAmount.x * sizeof(StaticLookup) * colCtx->subdivAmount.y * colCtx->subdivAmount.z +
               colCtx->colHeader->numPolygons * sizeof(u8) + colCtx->dyna.polyNodesMax * sizeof(SSNode) +


### PR DESCRIPTION
Closes #403. The Forest Temple hallway actor depends on its object unloading for it to be killed, but, due to object dependency differences between PC and N64 the hallway object isn't unloaded when transitioning to the checkered room. Due to this, the hallway actor isn't killed on the correct frame causing a crash. This is a workaround though, the correct solution is to manage object dependencies the same as N64. (CC @NEstelami)