### PR TITLE
Fix 0xabababab crash

### DIFF
--- a/soh/src/code/graph.c
+++ b/soh/src/code/graph.c
@@ -433,6 +433,7 @@ static void RunFrame()
 {
     u32 size;
     char faultMsg[0x50];
+    static bool hasSetupSkybox = false;
 
     switch (runFrameContext.state) {
         case 0:
@@ -464,6 +465,14 @@ static void RunFrame()
             Fault_AddHungupAndCrashImpl("GAME CLASS MALLOC FAILED", faultMsg);
         }
         GameState_Init(runFrameContext.gameState, runFrameContext.ovl->init, &runFrameContext.gfxCtx);
+
+        // Setup the normal skybox once before entering any game states to avoid the 0xabababab crash.
+        // The crash is due to certain skyboxes not loading all the data they need from Skybox_Setup.
+        if (!hasSetupSkybox) {
+            GlobalContext* globalCtx = (GlobalContext*)runFrameContext.gameState;
+            Skybox_Setup(globalCtx, &globalCtx->skyboxCtx, SKYBOX_NORMAL_SKY);
+            hasSetupSkybox = true;
+        }
 
         uint64_t freq = GetFrequency();
 

--- a/soh/src/code/z_vr_box.c
+++ b/soh/src/code/z_vr_box.c
@@ -950,9 +950,6 @@ void Skybox_Init(GameState* state, SkyboxContext* skyboxCtx, s16 skyboxId) {
     skyboxCtx->unk_140 = 0;
     skyboxCtx->rot.x = skyboxCtx->rot.y = skyboxCtx->rot.z = 0.0f;
 
-    // Unconditionally setup the normal skybox as well to avoid the 0xabababab crash.
-    // The crash is due to certain skyboxes not loading all the data they need from Skybox_Setup.
-    Skybox_Setup(globalCtx, skyboxCtx, SKYBOX_NORMAL_SKY);
     Skybox_Setup(globalCtx, skyboxCtx, skyboxId);
     osSyncPrintf("\n\n\n＊＊＊＊＊＊＊＊＊＊＊＊＊＊＊＊＊＊＊＊\n\n\n"
                  "ＴＹＰＥ＝%d"

--- a/soh/src/code/z_vr_box.c
+++ b/soh/src/code/z_vr_box.c
@@ -950,6 +950,9 @@ void Skybox_Init(GameState* state, SkyboxContext* skyboxCtx, s16 skyboxId) {
     skyboxCtx->unk_140 = 0;
     skyboxCtx->rot.x = skyboxCtx->rot.y = skyboxCtx->rot.z = 0.0f;
 
+    // Unconditionally setup the normal skybox as well to avoid the 0xabababab crash.
+    // The crash is due to certain skyboxes not loading all the data they need from Skybox_Setup.
+    Skybox_Setup(globalCtx, skyboxCtx, SKYBOX_NORMAL_SKY);
     Skybox_Setup(globalCtx, skyboxCtx, skyboxId);
     osSyncPrintf("\n\n\n＊＊＊＊＊＊＊＊＊＊＊＊＊＊＊＊＊＊＊＊\n\n\n"
                  "ＴＹＰＥ＝%d"


### PR DESCRIPTION
Fixes the infamous **abab** crash. The crash is caused by loading outside Ganon's Castle (or scenes with a similar skybox presumably) without first loading a scene that has the normal skybox such as Hyrule Field (by using fast file select / warping from N64 logo). This is because the Ganon's Castle skybox requires data loaded by setting up the normal skybox.

This fix works by setting up the normal skybox once before entering any game states to ensure the data is loaded. ~~I'm not sure if this fix has any side effects, so I'm going to draft it for now.~~