### PR TITLE
Dodongo's Cavern blue warp crash fix

### DIFF
--- a/soh/include/z64bgcheck.h
+++ b/soh/include/z64bgcheck.h
@@ -89,6 +89,7 @@ typedef struct {
     /* 0x20 */ CamData* cameraDataList;
     /* 0x24 */ u16 numWaterBoxes;
     /* 0x28 */ WaterBox* waterBoxes;
+    size_t cameraDataListLen; // OTRTODO: Added to allow for bounds checking the cameraDataList.
 } CollisionHeader; // original name: BGDataInfo
 
 typedef struct {

--- a/soh/soh/z_scene_otr.cpp
+++ b/soh/soh/z_scene_otr.cpp
@@ -158,6 +158,7 @@ bool func_80098674(GlobalContext* globalCtx, Ship::SceneCommand* cmd)
         }
 
         colHeader->cameraDataList = (CamData*)malloc(sizeof(CamData) * colRes->camData->entries.size());
+        colHeader->cameraDataListLen = colRes->camData->entries.size();
 
         for (int i = 0; i < colRes->camData->entries.size(); i++)
         {

--- a/soh/src/code/z_play.c
+++ b/soh/src/code/z_play.c
@@ -388,9 +388,8 @@ void Gameplay_Init(GameState* thisx) {
     // CollisionHeader struct to save the length of cameraDataList.
     // Fixes Dodongo's Cavern blue warp crash.
     {
-        CollisionHeader* colHeader;
+        CollisionHeader* colHeader = BgCheck_GetCollisionHeader(&globalCtx->colCtx, BGCHECK_SCENE);
 
-        colHeader = BgCheck_GetCollisionHeader(&globalCtx->colCtx, BGCHECK_SCENE);
         // If the player's start cam is out of bounds, set it to 0xFF so it isn't used.
         if (colHeader != NULL && ((player->actor.params & 0xFF) >= colHeader->cameraDataListLen)) {
             player->actor.params |= 0xFF;

--- a/soh/src/code/z_play.c
+++ b/soh/src/code/z_play.c
@@ -383,6 +383,20 @@ void Gameplay_Init(GameState* thisx) {
     Camera_InitPlayerSettings(&globalCtx->mainCamera, player);
     Camera_ChangeMode(&globalCtx->mainCamera, CAM_MODE_NORMAL);
 
+    // OTRTODO: Bounds check cameraDataList to guard against scenes spawning the player with
+    // an out of bounds background camera index. This requires adding an extra field to the
+    // CollisionHeader struct to save the length of cameraDataList.
+    // Fixes Dodongo's Cavern blue warp crash.
+    {
+        CollisionHeader* colHeader;
+
+        colHeader = BgCheck_GetCollisionHeader(&globalCtx->colCtx, BGCHECK_SCENE);
+        // If the player's start cam is out of bounds, set it to 0xFF so it isn't used.
+        if (colHeader != NULL && ((player->actor.params & 0xFF) > colHeader->cameraDataListLen)) {
+            player->actor.params |= 0xFF;
+        }
+    }
+
     playerStartCamId = player->actor.params & 0xFF;
     if (playerStartCamId != 0xFF) {
         osSyncPrintf("player has start camera ID (" VT_FGCOL(BLUE) "%d" VT_RST ")\n", playerStartCamId);

--- a/soh/src/code/z_play.c
+++ b/soh/src/code/z_play.c
@@ -392,7 +392,7 @@ void Gameplay_Init(GameState* thisx) {
 
         colHeader = BgCheck_GetCollisionHeader(&globalCtx->colCtx, BGCHECK_SCENE);
         // If the player's start cam is out of bounds, set it to 0xFF so it isn't used.
-        if (colHeader != NULL && ((player->actor.params & 0xFF) > colHeader->cameraDataListLen)) {
+        if (colHeader != NULL && ((player->actor.params & 0xFF) >= colHeader->cameraDataListLen)) {
             player->actor.params |= 0xFF;
         }
     }


### PR DESCRIPTION
Fixes #119. In the base game there are scenes that give the player actor parameters that will cause an out of bounds access into the scene's camera list which happens to not crash on N64 due to the garbage data being close enough to camera data to function properly. On SoH, this can crash if the garbage data causes another OoB access later down the line.

This PR fixes the issue by saving the length of the camera data list to the scene's `CollisionHeader` struct. When the player's actor parameters are being accessed, it is compared with the saved length and if it's out of bounds of the array then it isn't used by setting the camera index to `0xFF` which means it is ignored.