### PR TITLE
Fixes grey screen issue + tooltip for 2 handed shield

### DIFF
--- a/libultraship/libultraship/ImGuiImpl.cpp
+++ b/libultraship/libultraship/ImGuiImpl.cpp
@@ -1218,7 +1218,7 @@ namespace SohImGui {
                 EnhancementCheckbox("Fireproof Deku Shield", "gFireproofDekuShield");
                 Tooltip("Prevents the Deku Shield from burning on contact with fire");
                 EnhancementCheckbox("Shield with Two-Handed Weapons", "gShieldTwoHanded");
-                Tooltip("This allows you to put up your shield with any two-handed weapon in hand");
+                Tooltip("This allows you to put up your shield with any two-handed weapon in hand\nexcept for Deku Sticks");
 
                 ImGui::EndMenu();
             }
@@ -1293,7 +1293,7 @@ namespace SohImGui {
         ImGui::PushStyleVar(ImGuiStyleVar_ChildBorderSize, 0.0f);
         ImGui::PushStyleColor(ImGuiCol_ChildBg, ImVec4(0.0f, 0.0f, 0.0f, 0.0f));
         ImGuiWindowFlags flags = ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoBackground;
-        ImGui::Begin("OoT Master Quest", nullptr, flags);
+        ImGui::Begin("Main Game", nullptr, flags);
         ImGui::PopStyleVar(3);
         ImGui::PopStyleColor();
 


### PR DESCRIPTION
Forgot to change both names for the main game, so one was still called OoT Master Quest, and it was trying to dock a window that didn't exist, causing a grey screen with a small window for the game.

Also added a change @vaguerant suggested after the last PR had been merged