### PR TITLE
Fix develop

### DIFF
--- a/soh/include/functions.h
+++ b/soh/include/functions.h
@@ -2397,6 +2397,8 @@ char* SetQuote();
 void Heaps_Alloc(void);
 void Heaps_Free(void);
 
+CollisionHeader* BgCheck_GetCollisionHeader(CollisionContext* colCtx, s32 bgId);
+
 #ifdef __cplusplus
 #undef this
 };


### PR DESCRIPTION
In #622 `BgCheck_GetCollisionHeader` wasn't added to `functions.h` so the returned pointer is truncated on 64-bit causing a segfault.