### PR TITLE
Fixes Barinade's set whenever boss fight is reloaded

### DIFF
--- a/soh/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
+++ b/soh/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
@@ -121,6 +121,7 @@ void BossVa_Init(Actor* thisx, GlobalContext* globalCtx);
 void BossVa_Destroy(Actor* thisx, GlobalContext* globalCtx);
 void BossVa_Update(Actor* thisx, GlobalContext* globalCtx);
 void BossVa_Draw(Actor* thisx, GlobalContext* globalCtx);
+void BossVa_Reset(void);
 
 void BossVa_UpdateEffects(GlobalContext* globalCtx);
 void BossVa_DrawEffects(BossVaEffect* effect, GlobalContext* globalCtx);
@@ -204,7 +205,7 @@ const ActorInit Boss_Va_InitVars = {
     (ActorFunc)BossVa_Destroy,
     (ActorFunc)BossVa_Update,
     (ActorFunc)BossVa_Draw,
-    NULL,
+    (ActorResetFunc)BossVa_Reset,
 };
 
 static ColliderCylinderInit sCylinderInit = {
@@ -593,6 +594,8 @@ void BossVa_Init(Actor* thisx, GlobalContext* globalCtx2) {
 
     switch (this->actor.params) {
         case BOSSVA_BODY:
+            //sFightPhase = 0;
+            //sBodyState = 1;
             SkelAnime_Init(globalCtx, &this->skelAnime, &gBarinadeBodySkel, &gBarinadeBodyAnim, NULL, NULL, 0);
             this->actor.flags |= ACTOR_FLAG_24;
             break;

--- a/soh/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
+++ b/soh/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
@@ -4035,6 +4035,8 @@ void BossVa_DrawDoor(GlobalContext* globalCtx, s16 scale) {
     CLOSE_DISPS(globalCtx->state.gfxCtx);
 }
 
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
+
 void BossVa_Reset(void) {
     sKillBari = 0;
     sCsCamera = 0;
@@ -4049,4 +4051,7 @@ void BossVa_Reset(void) {
     sZapperRot.z = 0;    
     sPhase2Timer = 0;
     sPhase4HP = 0;
+    for (u8 i = 0; i < ARRAY_SIZE(sBodyBari); i++) {
+        sBodyBari[i] = 0;
+    }
 }


### PR DESCRIPTION
It seems that Barinade has an unused Reset function for his actor, and NULL provided as the reset function for his ActorInit struct. This caused his boss fight to become glitchy if the player somehow left the boss fight in the middle, such as with the Debug menu or when playing rando without Kokiri sword, running out of Deku Sticks, and saving and reloading then coming back. This PR implements the unused `BossVa_Reset` function, which already did functionally reset the boss, and adds a for loop to reset the `sBodyBari` array, which removes the Jellyfish from his body so that the intro cutscene doesn't look weird.

Fixes #636, which was originally reported on the rando issue tracker: https://github.com/briaguya-ai/rando-issue-tracker/issues/145