### PR TITLE
Don't close controller after SDL has quit

### DIFF
--- a/libultraship/libultraship/SDLController.cpp
+++ b/libultraship/libultraship/SDLController.cpp
@@ -101,13 +101,11 @@ namespace Ship {
     }
 
     bool SDLController::Close() {
-        if (SDL_WasInit(SDL_INIT_GAMECONTROLLER)) {
+        if (Cont != nullptr && SDL_WasInit(SDL_INIT_GAMECONTROLLER)) {
             if (CanRumble()) {
                 SDL_GameControllerRumble(Cont, 0, 0, 0);
             }
-            if (Cont != nullptr) {
-                SDL_GameControllerClose(Cont);
-            }
+            SDL_GameControllerClose(Cont);
         }
         Cont = nullptr;
         guid = "";

--- a/libultraship/libultraship/SDLController.cpp
+++ b/libultraship/libultraship/SDLController.cpp
@@ -101,11 +101,13 @@ namespace Ship {
     }
 
     bool SDLController::Close() {
-        if (CanRumble()) {
-            SDL_GameControllerRumble(Cont, 0, 0, 0);
-        }
-        if (Cont != nullptr) {
-            SDL_GameControllerClose(Cont);
+        if (SDL_WasInit(SDL_INIT_GAMECONTROLLER)) {
+            if (CanRumble()) {
+                SDL_GameControllerRumble(Cont, 0, 0, 0);
+            }
+            if (Cont != nullptr) {
+                SDL_GameControllerClose(Cont);
+            }
         }
         Cont = nullptr;
         guid = "";


### PR DESCRIPTION
Fixes SoH segfaulting while closing due to calling SDL functions on the controller after SDL has been deinitialized. Not the biggest deal but can be annoying when debugging.