### PR TITLE
Hide debug overlay behind gDebugEnabled

### DIFF
--- a/soh/src/code/z_message_PAL.c
+++ b/soh/src/code/z_message_PAL.c
@@ -3228,6 +3228,8 @@ void Message_DrawMain(GlobalContext* globalCtx, Gfx** p) {
  * the last value being saved in a static variable.
  */
 void Message_DrawDebugVariableChanged(s16* var, GraphicsContext* gfxCtx) {
+    if (!CVar_GetS32("gDebugEnabled", 0)) { return; }
+
     static s16 sVarLastValue = 0;
     static s16 sFillTimer = 0;
     s32 pad;


### PR DESCRIPTION
This thing:

![Debug overlay example](https://user-images.githubusercontent.com/35378213/160254993-61eab4f3-3cca-491e-8c18-97bd4a7e3035.png)

This is unguarded debug behavior which is used to track a variable changing and give visual feedback. In the debug ROM we have (and thus the decomp), this is set up to track the state of `gSaveContext.scarecrowCustomSongSet`, which itself tracks whether you have taught a custom song to Pierre, the upper scarecrow. Note that this is **not** the Scarecrow's Song, which you teach to Bonooru, the lower scarecrow.

Fixes #100 (and its dupe #356).

#100 was just closed a few hours ago as completed, but I'm pretty sure that was done in error, as this issue continues to occur in current `develop`.