### PR TITLE
Rando: GtG and carpenter prompts skip

### DIFF
--- a/soh/src/overlays/actors/ovl_En_Wonder_Talk2/z_en_wonder_talk2.c
+++ b/soh/src/overlays/actors/ovl_En_Wonder_Talk2/z_en_wonder_talk2.c
@@ -267,6 +267,7 @@ void func_80B3A4F8(EnWonderTalk2* this, GlobalContext* globalCtx) {
                             randoSkipText = true;
                             break;
                         default:
+                            break;
                     }
                     // individual textIds that should be skipped, or that should be preserved
                     // in a scene that otherwise has all wonder talk skipped.

--- a/soh/src/overlays/actors/ovl_En_Wonder_Talk2/z_en_wonder_talk2.c
+++ b/soh/src/overlays/actors/ovl_En_Wonder_Talk2/z_en_wonder_talk2.c
@@ -252,16 +252,21 @@ void func_80B3A4F8(EnWonderTalk2* this, GlobalContext* globalCtx) {
             }
             this->unk_158 = 0;
             if (!this->unk_156) {
-                // whether or not to skip the text in rando
+                // Whether or not to skip the text in rando
                 bool randoSkipText = false;
                 if (gSaveContext.n64ddFlag) {
-                    // scenes for which all of this type of wonder talk should be skipped.
-                    switch (globalCtx->sceneNum) { 
-                        case 0x0007: //shadow temple
+                    // Scenes for which all of this type of wonder talk should be skipped.
+                    switch (globalCtx->sceneNum) {
+                        case 0x0007: // Shadow Temple
+                            randoSkipText = true;
+                            break;
+                        case 0x000B: // Gerudo Training Grounds
+                            randoSkipText = true;
+                            break;
+                        case 0x000C: // Inside Gerudo Fortress
                             randoSkipText = true;
                             break;
                         default:
-                            break;
                     }
                     // individual textIds that should be skipped, or that should be preserved
                     // in a scene that otherwise has all wonder talk skipped.


### PR DESCRIPTION
Skips some text boxes that pop up in GtG and before talking to the carpenters inside gerudo fortress.

resolves https://github.com/HarbourMasters/Shipwright/issues/668
resolves https://github.com/HarbourMasters/Shipwright/issues/667