### PR TITLE
Rando: Skip warp song cutscenes

### DIFF
--- a/soh/src/overlays/actors/ovl_Demo_Kankyo/z_demo_kankyo.c
+++ b/soh/src/overlays/actors/ovl_Demo_Kankyo/z_demo_kankyo.c
@@ -788,7 +788,14 @@ void DemoKankyo_DrawWarpSparkles(Actor* thisx, GlobalContext* globalCtx) {
                 this->unk_150[i].unk_0.y = (s16)((Rand_ZeroOne() - 0.5f) * 16.0f * temp_f22);
                 this->unk_150[i].unk_0.z = (s16)((Rand_ZeroOne() - 0.5f) * 16.0f * temp_f22);
                 this->unk_150[i].unk_23 = 0;
-                this->unk_150[i].unk_22++;
+
+                // Skip the first part of warp song cutscenes in rando
+                if (gSaveContext.n64ddFlag && this->actor.params == DEMOKANKYO_WARP_OUT) {
+                    this->unk_150[i].unk_22 = 2;
+                } else {
+                    this->unk_150[i].unk_22++;
+                }
+
             case 1:
                 if (this->actor.params == DEMOKANKYO_WARP_OUT) {
                     if (func_800BB2B4(&camPos, &sWarpRoll, &sWarpFoV, sWarpOutCameraPoints, &this->unk_150[i].unk_20,


### PR DESCRIPTION
Skips the first half of the cutscene for using a warp song.

Does it by skipping to the last part of the cutscene data. Tested on all songs, both adult and child. This function is used for spawning the warp song particles, so I can safely say that this does not break anything outside of warp songs.

resolves https://github.com/HarbourMasters/Shipwright/issues/669

https://user-images.githubusercontent.com/70942617/178514628-b37abe10-b2e9-458d-acd2-1f7a13ee5564.mp4


