### PR TITLE
Rando: Fix Water Temple Softlock

### DIFF
--- a/soh/src/code/z_sram.c
+++ b/soh/src/code/z_sram.c
@@ -826,6 +826,11 @@ void Sram_InitSave(FileChooseContext* fileChooseCtx) {
         // Go away ruto (water temple first cutscene)
         gSaveContext.sceneFlags[05].swch |= (1 << 0x10);
 
+        // Opens locked Water Temple door to prevent softlocks
+        // West door on the middle level that leads to the water raising thing
+        // Happens in 3DS rando and N64 rando as well
+        gSaveContext.sceneFlags[05].swch |= (1 << 0x15);
+
         // Skip intro cutscene when bombing mud wall in Dodongo's cavern
         // this also makes the lower jaw render, and the eyes react to explosives
         Flags_SetEventChkInf(0xB0);


### PR DESCRIPTION
We use 3DS logic to generate item placement, but didn't have this specific door in Water Temple unlocked from the beginning like 3DS does.

This meant that if people took specific paths through the temple, they could softlock themselves by missing a key.

This simply unlocks that door from the beginning when generating a rando save.

![image](https://user-images.githubusercontent.com/4244591/178491023-84a055e2-5039-4f23-81f8-d15281e26244.png)

fixes https://github.com/HarbourMasters/Shipwright/issues/666