### PR TITLE
Rando: Allows Malon's Item Check to be obtained by pulling out the Ocarina. [FIXED PR]

### DIFF
--- a/soh/src/overlays/actors/ovl_En_Ma1/z_en_ma1.c
+++ b/soh/src/overlays/actors/ovl_En_Ma1/z_en_ma1.c
@@ -25,6 +25,7 @@ void func_80AA106C(EnMa1* this, GlobalContext* globalCtx);
 void func_80AA10EC(EnMa1* this, GlobalContext* globalCtx);
 void func_80AA1150(EnMa1* this, GlobalContext* globalCtx);
 void EnMa1_DoNothing(EnMa1* this, GlobalContext* globalCtx);
+void EnMa1_WaitForSongGive(EnMa1* this, GlobalContext* globalCtx);
 
 const ActorInit En_Ma1_InitVars = {
     ACTOR_EN_MA1,
@@ -356,7 +357,6 @@ void func_80AA0EFC(EnMa1* this, GlobalContext* globalCtx) {
 
 void GivePlayerRandoRewardMalon(EnMa1* malon, GlobalContext* globalCtx, RandomizerCheck check) {
     GetItemID getItemId = GetRandomizedItemIdFromKnownCheck(check, GI_EPONAS_SONG);
-    malon->actionFunc = func_80AA0D88;
     if (malon->actor.parent != NULL && malon->actor.parent->id == GET_PLAYER(globalCtx)->actor.id &&
         !Flags_GetTreasure(globalCtx, 0x1F)) {
         Flags_SetTreasure(globalCtx, 0x1F);
@@ -364,7 +364,6 @@ void GivePlayerRandoRewardMalon(EnMa1* malon, GlobalContext* globalCtx, Randomiz
     } else if (!Flags_GetTreasure(globalCtx, 0x1F) &&
         (INV_CONTENT(ITEM_OCARINA_FAIRY) != ITEM_NONE || INV_CONTENT(ITEM_OCARINA_TIME) != ITEM_NONE)) {
         func_8002F434(&malon->actor, globalCtx, getItemId, 10000.0f, 100.0f);
-        malon->actionFunc = func_80AA0F44;
     }
     malon->unk_1E8.unk_00 = 0;
     malon->unk_1E0 = 1;
@@ -411,7 +410,7 @@ void func_80AA0F44(EnMa1* this, GlobalContext* globalCtx) {
             player->stateFlags2 |= 0x800000;
         }
         if (gSaveContext.n64ddFlag && Actor_TextboxIsClosing(&this->actor, globalCtx)) {
-            GivePlayerRandoRewardMalon(this, globalCtx, RC_SONG_FROM_MALON);
+            this->actionFunc = EnMa1_WaitForSongGive;
         }
     }
 }

--- a/soh/src/overlays/actors/ovl_En_Ma1/z_en_ma1.c
+++ b/soh/src/overlays/actors/ovl_En_Ma1/z_en_ma1.c
@@ -404,7 +404,7 @@ void func_80AA0F44(EnMa1* this, GlobalContext* globalCtx) {
         }
         // If rando'ed, a textbox is closing, it's malon's 'my mom wrote this song' text, AND we do have an ocarina
         // in our inventory. This allows us to grant the check when talking to malon with the ocarina in our inventory.
-        if (gSaveContext.n64ddFlag && (Actor_TextboxIsClosing(&this->actor, globalCtx) && this->actor.textId == 0x2049) &&
+        if (gSaveContext.n64ddFlag && (Actor_TextboxIsClosing(&this->actor, globalCtx) && globalCtx->msgCtx.textId == 0x2049) &&
             (INV_CONTENT(ITEM_OCARINA_FAIRY) != ITEM_NONE || INV_CONTENT(ITEM_OCARINA_TIME) != ITEM_NONE)) {
             this->actionFunc = EnMa1_WaitForSongGive;
         }

--- a/soh/src/overlays/actors/ovl_En_Ma1/z_en_ma1.c
+++ b/soh/src/overlays/actors/ovl_En_Ma1/z_en_ma1.c
@@ -402,7 +402,9 @@ void func_80AA0F44(EnMa1* this, GlobalContext* globalCtx) {
             // triggers the code above this.
             player->stateFlags2 |= 0x800000;
         }
-        if (gSaveContext.n64ddFlag && Actor_TextboxIsClosing(&this->actor, globalCtx) &&
+        // If rando'ed, a textbox is closing, it's malon's 'my mom wrote this song' text, AND we do have an ocarina
+        // in our inventory. This allows us to grant the check when talking to malon with the ocarina in our inventory.
+        if (gSaveContext.n64ddFlag && (Actor_TextboxIsClosing(&this->actor, globalCtx) && this->actor.textId == 0x2049) &&
             (INV_CONTENT(ITEM_OCARINA_FAIRY) != ITEM_NONE || INV_CONTENT(ITEM_OCARINA_TIME) != ITEM_NONE)) {
             this->actionFunc = EnMa1_WaitForSongGive;
         }

--- a/soh/src/overlays/actors/ovl_En_Ma1/z_en_ma1.c
+++ b/soh/src/overlays/actors/ovl_En_Ma1/z_en_ma1.c
@@ -434,9 +434,9 @@ void EnMa1_WaitForSongGive(EnMa1* this, GlobalContext* globalCtx) {
     GivePlayerRandoRewardMalon(this, globalCtx, RC_SONG_FROM_MALON);
 }
 
+// Sets an Ocarina State necessary to not softlock in rando.
+// This function should only be called in rando.
 void EnMa1_EndTeachSong(EnMa1* this, GlobalContext* globalCtx) {
-    // Sets an Ocarina State necessary to not softlock in rando.
-    // This function should only be called in rando.
     if (globalCtx->csCtx.state == CS_STATE_IDLE) {
         this->actionFunc = func_80AA0F44;
         globalCtx->msgCtx.ocarinaMode = OCARINA_MODE_04;

--- a/soh/src/overlays/actors/ovl_En_Ma1/z_en_ma1.c
+++ b/soh/src/overlays/actors/ovl_En_Ma1/z_en_ma1.c
@@ -365,8 +365,7 @@ void GivePlayerRandoRewardMalon(EnMa1* malon, GlobalContext* globalCtx, Randomiz
         // puts malon in the action that vanilla has her in after learning the song
         // (confirmed via breakpoints in a vanilla save).
         malon->actionFunc = func_80AA0D88;
-    } else if (!Flags_GetTreasure(globalCtx, 0x1F) &&
-        (INV_CONTENT(ITEM_OCARINA_FAIRY) != ITEM_NONE || INV_CONTENT(ITEM_OCARINA_TIME) != ITEM_NONE)) {
+    } else if (!Flags_GetTreasure(globalCtx, 0x1F)) {
         func_8002F434(&malon->actor, globalCtx, getItemId, 10000.0f, 100.0f);
     }
     // make malon sing again after giving the item.
@@ -403,7 +402,8 @@ void func_80AA0F44(EnMa1* this, GlobalContext* globalCtx) {
             // triggers the code above this.
             player->stateFlags2 |= 0x800000;
         }
-        if (gSaveContext.n64ddFlag && Actor_TextboxIsClosing(&this->actor, globalCtx)) {
+        if (gSaveContext.n64ddFlag && Actor_TextboxIsClosing(&this->actor, globalCtx) &&
+            (INV_CONTENT(ITEM_OCARINA_FAIRY) != ITEM_NONE || INV_CONTENT(ITEM_OCARINA_TIME) != ITEM_NONE)) {
             this->actionFunc = EnMa1_WaitForSongGive;
         }
     }


### PR DESCRIPTION
Previously, Malon would only grant her item check if you talked to her. This is in contrast to a similarly behaving song-giving NPC, the Windmill man in Kakariko's Windmill, as well as in contrast to the N64 and 3DS randos. This implements the ability for Malon to grant her item check by either talking to her or pulling out the Ocarina.

resolves #671

This was previously open as PR #659, but I was branched off of the original rando branch and it caused some weirdness with the unsquashed commits from that branch. I've cherry-picked the commits from the previous PR and put them onto a branch off of the main develop branch. The previous PR will be closed.

This is not ready to merge yet, currently using OI without an ocarina in your inventory would not work to receive the check in rando, and in fact would most likely softlock.