### PR TITLE
Fixes Maps, Compasses, and Boss Keys in Vanilla.

### DIFF
--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -1710,6 +1710,8 @@ u8 Item_Give(GlobalContext* globalCtx, u8 item) {
             } else {
                 gSaveContext.inventory.dungeonItems[gSaveContext.mapIndex] |= gBitFlags[item - ITEM_KEY_BOSS];
             }
+        } else {
+            gSaveContext.inventory.dungeonItems[gSaveContext.mapIndex] |= gBitFlags[item - ITEM_KEY_BOSS];
         }
         return ITEM_NONE;
     } else if (item == ITEM_KEY_SMALL) {


### PR DESCRIPTION
Rando seems to have accidentally broken Map, Compass, and Boss Key assigning. This PR fixes the functionality behind them. The large chests seem to have lost their glowing effect as well, but I'm not sure where that code is so that will be a separate PR.