### PR TITLE
fix non-rando non-3d-drops small key crash

### DIFF
--- a/soh/src/code/z_en_item00.c
+++ b/soh/src/code/z_en_item00.c
@@ -1297,7 +1297,7 @@ void EnItem00_DrawRupee(EnItem00* this, GlobalContext* globalCtx) {
  * Draw Function used for most collectible types of En_Item00 (ammo, bombs, sticks, nuts, magic...).
  */
 void EnItem00_DrawCollectible(EnItem00* this, GlobalContext* globalCtx) {
-    if ((gSaveContext.n64ddFlag && this->getItemId != GI_NONE) || this->actor.params == ITEM00_SMALL_KEY) {
+    if (gSaveContext.n64ddFlag && (this->getItemId != GI_NONE || this->actor.params == ITEM00_SMALL_KEY)) {
         f32 mtxScale = 16.0f;
         Matrix_Scale(mtxScale, mtxScale, mtxScale, MTXMODE_APPLY);
         s32 randoGetItemId = GetRandomizedItemId(this->getItemId, this->actor.id, this->ogParams, globalCtx->sceneNum);


### PR DESCRIPTION
IceMan on discord reported fighting the gerudo guards in GF causing a crash for them in `#support`

I was able to reproduce the issue, and found the crash was happening in logic that should be rando specific (parens in the wrong spot in an if statement)

This isn't an issue with 3d drops enabled, as the DrawCollectable code is skipped entirely in that case, so i was able to suggest enabling that as a workaround

this PR fixes the parens

fixes #821 