### PR TITLE
Adds tooltip to free camera

### DIFF
--- a/libultraship/libultraship/ImGuiImpl.cpp
+++ b/libultraship/libultraship/ImGuiImpl.cpp
@@ -1162,6 +1162,7 @@ namespace SohImGui {
                 Tooltip("Holding down B skips text\nKnown to cause a cutscene softlock in Water Temple\nSoftlock can be fixed by pressing D-Right in Debug mode");
 
                 EnhancementCheckbox("Free Camera", "gFreeCamera");
+                Tooltip("Enables camera control\nNote: You must remap C buttons off of\nthe right stick in the controller\nconfig menu, and map the camera stick\nto the right stick.");
 
                 ImGui::EndMenu();
             }


### PR DESCRIPTION
Free camera was missing a tooltip, and given the need for a custom controller config for it, and the fact quite a few people have asked in the support channel why the free camera toggle isn't working, it's probably worth adding.