### PR TITLE
ADD: SaveEditor Edit current D-Pad Item

### DIFF
--- a/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
+++ b/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
@@ -1563,12 +1563,13 @@ void DrawPlayerTab() {
             ImGui::InputScalar("C Right", ImGuiDataType_U8, &gSaveContext.equips.buttonItems[3], &one, NULL);
             ImGui::NewLine();
             ImGui::Text("Current Dpad Equips");
-            ImGui::InputScalar("Dpad Up", ImGuiDataType_U8, &gSaveContext.equips.buttonItems[4], &one, NULL);
+            ImGui::InputScalar("D-pad Up", ImGuiDataType_U8, &gSaveContext.equips.buttonItems[4], &one, NULL);
             ImGui::SameLine();
-            ImGui::InputScalar("Dpad Down", ImGuiDataType_U8, &gSaveContext.equips.buttonItems[5], &one, NULL);
-            ImGui::InputScalar("Dpad Left", ImGuiDataType_U8, &gSaveContext.equips.buttonItems[6], &one, NULL);
+            ImGui::InputScalar("D-pad Down", ImGuiDataType_U8, &gSaveContext.equips.buttonItems[5], &one, NULL);
+            // Intentionnal to not put everything on the same line, else it's taking too much for lower resolution.
+            ImGui::InputScalar("D-pad Left", ImGuiDataType_U8, &gSaveContext.equips.buttonItems[6], &one, NULL);
             ImGui::SameLine();
-            ImGui::InputScalar("Dpad Right", ImGuiDataType_U8, &gSaveContext.equips.buttonItems[7], &one, NULL);
+            ImGui::InputScalar("D-pad Right", ImGuiDataType_U8, &gSaveContext.equips.buttonItems[7], &one, NULL);
         });
 
     } else {

--- a/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
+++ b/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
@@ -1561,6 +1561,14 @@ void DrawPlayerTab() {
             ImGui::InputScalar("C Down", ImGuiDataType_U8, &gSaveContext.equips.buttonItems[2], &one, NULL);
             ImGui::SameLine();
             ImGui::InputScalar("C Right", ImGuiDataType_U8, &gSaveContext.equips.buttonItems[3], &one, NULL);
+            ImGui::NewLine();
+            ImGui::Text("Current Dpad Equips");
+            ImGui::InputScalar("Dpad Up", ImGuiDataType_U8, &gSaveContext.equips.buttonItems[4], &one, NULL);
+            ImGui::SameLine();
+            ImGui::InputScalar("Dpad Down", ImGuiDataType_U8, &gSaveContext.equips.buttonItems[5], &one, NULL);
+            ImGui::InputScalar("Dpad Left", ImGuiDataType_U8, &gSaveContext.equips.buttonItems[6], &one, NULL);
+            ImGui::SameLine();
+            ImGui::InputScalar("Dpad Right", ImGuiDataType_U8, &gSaveContext.equips.buttonItems[7], &one, NULL);
         });
 
     } else {

--- a/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
+++ b/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
@@ -1564,7 +1564,7 @@ void DrawPlayerTab() {
 
             if (CVar_GetS32("gDpadEquips", 0)) {
                 ImGui::NewLine();
-                ImGui::Text("Current Dpad Equips");
+                ImGui::Text("Current D-pad Equips");
                 ImGui::InputScalar("D-pad Up", ImGuiDataType_U8, &gSaveContext.equips.buttonItems[4], &one, NULL);
                 ImGui::SameLine();
                 ImGui::InputScalar("D-pad Down", ImGuiDataType_U8, &gSaveContext.equips.buttonItems[5], &one, NULL);

--- a/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
+++ b/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
@@ -1561,15 +1561,18 @@ void DrawPlayerTab() {
             ImGui::InputScalar("C Down", ImGuiDataType_U8, &gSaveContext.equips.buttonItems[2], &one, NULL);
             ImGui::SameLine();
             ImGui::InputScalar("C Right", ImGuiDataType_U8, &gSaveContext.equips.buttonItems[3], &one, NULL);
-            ImGui::NewLine();
-            ImGui::Text("Current Dpad Equips");
-            ImGui::InputScalar("D-pad Up", ImGuiDataType_U8, &gSaveContext.equips.buttonItems[4], &one, NULL);
-            ImGui::SameLine();
-            ImGui::InputScalar("D-pad Down", ImGuiDataType_U8, &gSaveContext.equips.buttonItems[5], &one, NULL);
-            // Intentionnal to not put everything on the same line, else it's taking too much for lower resolution.
-            ImGui::InputScalar("D-pad Left", ImGuiDataType_U8, &gSaveContext.equips.buttonItems[6], &one, NULL);
-            ImGui::SameLine();
-            ImGui::InputScalar("D-pad Right", ImGuiDataType_U8, &gSaveContext.equips.buttonItems[7], &one, NULL);
+
+            if (CVar_GetS32("gDpadEquips", 0)) {
+                ImGui::NewLine();
+                ImGui::Text("Current Dpad Equips");
+                ImGui::InputScalar("D-pad Up", ImGuiDataType_U8, &gSaveContext.equips.buttonItems[4], &one, NULL);
+                ImGui::SameLine();
+                ImGui::InputScalar("D-pad Down", ImGuiDataType_U8, &gSaveContext.equips.buttonItems[5], &one, NULL);
+                // Intentionnal to not put everything on the same line, else it's taking too much for lower resolution.
+                ImGui::InputScalar("D-pad Left", ImGuiDataType_U8, &gSaveContext.equips.buttonItems[6], &one, NULL);
+                ImGui::SameLine();
+                ImGui::InputScalar("D-pad Right", ImGuiDataType_U8, &gSaveContext.equips.buttonItems[7], &one, NULL);
+            }
         });
 
     } else {

--- a/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
+++ b/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
@@ -1565,7 +1565,7 @@ void DrawPlayerTab() {
             if (CVar_GetS32("gDpadEquips", 0)) {
                 ImGui::NewLine();
                 ImGui::Text("Current D-pad Equips");
-                ImGui::InputScalar("D-pad Up", ImGuiDataType_U8, &gSaveContext.equips.buttonItems[4], &one, NULL);
+                ImGui::InputScalar("D-pad Up  ", ImGuiDataType_U8, &gSaveContext.equips.buttonItems[4], &one, NULL); // Two spaces at the end for aligning, not elegant but it's working
                 ImGui::SameLine();
                 ImGui::InputScalar("D-pad Down", ImGuiDataType_U8, &gSaveContext.equips.buttonItems[5], &one, NULL);
                 // Intentionnal to not put everything on the same line, else it's taking too much for lower resolution.


### PR DESCRIPTION
Allow the edit of the current D-Pad item with the save editor like it's C Button counter part if the Dpad as item is enabled

![image](https://user-images.githubusercontent.com/47987542/179294136-7e56f7b4-18c3-4e55-ad54-ef9ed2eb2e64.png)
![image](https://user-images.githubusercontent.com/47987542/179294155-417f21f3-df9f-4e2a-81ab-4fd0f05f77f9.png)
