### PR TITLE
Add yShift position when displaying the positions of cylinders

### DIFF
--- a/soh/soh/Enhancements/debugger/colViewer.cpp
+++ b/soh/soh/Enhancements/debugger/colViewer.cpp
@@ -529,7 +529,7 @@ void DrawColCheckList(std::vector<Gfx>& dl, Collider** objects, int32_t count) {
 
                 Mtx m;
                 MtxF mt;
-                SkinMatrix_SetTranslate(&mt, cyl->dim.pos.x, cyl->dim.pos.y, cyl->dim.pos.z);
+                SkinMatrix_SetTranslate(&mt, cyl->dim.pos.x, cyl->dim.pos.y + cyl->dim.yShift, cyl->dim.pos.z);
                 MtxF ms;
                 int32_t radius = cyl->dim.radius == 0 ? 1 : cyl->dim.radius;
                 SkinMatrix_SetScale(&ms, radius / 128.0f, cyl->dim.height / 128.0f, radius / 128.0f);


### PR DESCRIPTION
The yShift value of a cylinder is used in every comparison in sys_math3d that references a cylinder's y-position in order to determine the actual position of its base, and is frequently used by actors to dynamically update cylinder positions without modifying their y value.

Adding it to the translation of displayed collision cylinders hence shows the real position of the cylinder as used by the collision system, and accurately shows things like Link's collision bounds actually clearing objects that backflipping lets him jump onto.