### PR TITLE
Add bottle swipes to Fast Drops; rename to Skip Pickup Messages

### DIFF
--- a/libultraship/libultraship/ImGuiImpl.cpp
+++ b/libultraship/libultraship/ImGuiImpl.cpp
@@ -967,8 +967,8 @@ namespace SohImGui {
                         Tooltip("Wearing the Bunny Hood grants a speed\nincrease like in Majora's Mask");
                         EnhancementCheckbox("Fast Chests", "gFastChests");
                         Tooltip("Kick open every chest");
-                        EnhancementCheckbox("Fast Pickups", "gFastDrops");
-                        Tooltip("Skip pickup messages for bottle swipes\nand new consumable items");
+                        EnhancementCheckbox("Skip Pickup Messages", "gFastDrops");
+                        Tooltip("Skip pickup messages for new consumable items and bottle swipes");
                         EnhancementCheckbox("Better Owl", "gBetterOwl");
                         Tooltip("The default response to Kaepora Gaebora is\nalways that you understood what he said");
                         EnhancementCheckbox("Fast Ocarina Playback", "gFastOcarinaPlayback");

--- a/libultraship/libultraship/ImGuiImpl.cpp
+++ b/libultraship/libultraship/ImGuiImpl.cpp
@@ -967,8 +967,8 @@ namespace SohImGui {
                         Tooltip("Wearing the Bunny Hood grants a speed\nincrease like in Majora's Mask");
                         EnhancementCheckbox("Fast Chests", "gFastChests");
                         Tooltip("Kick open every chest");
-                        EnhancementCheckbox("Fast Drops", "gFastDrops");
-                        Tooltip("Skip first-time pickup messages for consumable items");
+                        EnhancementCheckbox("Fast Pickups", "gFastDrops");
+                        Tooltip("Skip pickup messages for bottle swipes\nand new consumable items");
                         EnhancementCheckbox("Better Owl", "gBetterOwl");
                         Tooltip("The default response to Kaepora Gaebora is\nalways that you understood what he said");
                         EnhancementCheckbox("Fast Ocarina Playback", "gFastOcarinaPlayback");

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -13140,10 +13140,10 @@ void func_8084ECA4(Player* this, GlobalContext* globalCtx) {
                         if (i < 4) {
                             this->unk_84F = i + 1;
                             this->unk_850 = 0;
-                            this->stateFlags1 |= PLAYER_STATE1_28 | PLAYER_STATE1_29;
                             this->interactRangeActor->parent = &this->actor;
                             Player_UpdateBottleHeld(globalCtx, this, catchInfo->itemId, ABS(catchInfo->actionParam));
                             if (!CVar_GetS32("gFastDrops", 0)) {
+                                this->stateFlags1 |= PLAYER_STATE1_28 | PLAYER_STATE1_29;
                                 func_808322D0(globalCtx, this, sp24->unk_04);
                                 func_80835EA4(globalCtx, 4);
                             }

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -13101,11 +13101,14 @@ void func_8084ECA4(Player* this, GlobalContext* globalCtx) {
     if (LinkAnimation_Update(globalCtx, &this->skelAnime)) {
         if (this->unk_84F != 0) {
             if (this->unk_850 == 0) {
-                if (!CVar_GetS32("gFastDrops", 0)) { Message_StartTextbox(globalCtx, D_80854A04[this->unk_84F - 1].textId, &this->actor); }
+                if (CVar_GetS32("gFastDrops", 0))
+                    { this->unk_84F = 0; }
+                else
+                    { Message_StartTextbox(globalCtx, D_80854A04[this->unk_84F - 1].textId, &this->actor); }
                 Audio_PlayFanfare(NA_BGM_ITEM_GET | 0x900);
                 this->unk_850 = 1;
             }
-            else if (Message_GetState(&globalCtx->msgCtx) == TEXT_STATE_CLOSING || CVar_GetS32("gFastDrops", 0)) {
+            else if (Message_GetState(&globalCtx->msgCtx) == TEXT_STATE_CLOSING) {
                 this->unk_84F = 0;
                 func_8005B1A4(Gameplay_GetCamera(globalCtx, 0));
             }

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -13101,11 +13101,11 @@ void func_8084ECA4(Player* this, GlobalContext* globalCtx) {
     if (LinkAnimation_Update(globalCtx, &this->skelAnime)) {
         if (this->unk_84F != 0) {
             if (this->unk_850 == 0) {
-                Message_StartTextbox(globalCtx, D_80854A04[this->unk_84F - 1].textId, &this->actor);
+                if (!CVar_GetS32("gFastDrops", 0)) { Message_StartTextbox(globalCtx, D_80854A04[this->unk_84F - 1].textId, &this->actor); }
                 Audio_PlayFanfare(NA_BGM_ITEM_GET | 0x900);
                 this->unk_850 = 1;
             }
-            else if (Message_GetState(&globalCtx->msgCtx) == TEXT_STATE_CLOSING) {
+            else if (Message_GetState(&globalCtx->msgCtx) == TEXT_STATE_CLOSING || CVar_GetS32("gFastDrops", 0)) {
                 this->unk_84F = 0;
                 func_8005B1A4(Gameplay_GetCamera(globalCtx, 0));
             }
@@ -13140,8 +13140,10 @@ void func_8084ECA4(Player* this, GlobalContext* globalCtx) {
                             this->stateFlags1 |= PLAYER_STATE1_28 | PLAYER_STATE1_29;
                             this->interactRangeActor->parent = &this->actor;
                             Player_UpdateBottleHeld(globalCtx, this, catchInfo->itemId, ABS(catchInfo->actionParam));
-                            func_808322D0(globalCtx, this, sp24->unk_04);
-                            func_80835EA4(globalCtx, 4);
+                            if (!CVar_GetS32("gFastDrops", 0)) {
+                                func_808322D0(globalCtx, this, sp24->unk_04);
+                                func_80835EA4(globalCtx, 4);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Skips the cutscene animation when picking up items with bottle swipes, behind the already existing `gFastDrops` CVar. For backward compatibility, the CVar itself was not renamed but its name in ImGui's Time Savers section was changed to "Skip Pickup Messages" to reflect that it now affects more than just dropped items. I think it's sensible for these to share a single checkbox.

Affected items are Bugs, Fairies, Fish and Blue Fire. The pickup fanfare has been left intact to give audible feedback that the pickup was successful.

Fixes #835

**EDIT:** ~~Don't merge this yet, as it has a negative interaction with @MelonSpeedruns's free camera. This works fine with the vanilla camera, but when freecam is active (currently manipulated by the player, **not just enabled**) catching anything in a bottle causes the camera to do an extreme zoom in on Link. I initially thought that the "more freecam friendly" commit had resolved this, but it did not.~~

**EDIT2:** Resolved.