### PR TITLE
Fast Save Loader crashes fixes

### DIFF
--- a/libultraship/libultraship/ImGuiImpl.cpp
+++ b/libultraship/libultraship/ImGuiImpl.cpp
@@ -1335,10 +1335,20 @@ namespace SohImGui {
                 EnhancementCheckbox("OoT Debug Mode", "gDebugEnabled");
                 Tooltip("Enables Debug Mode, allowing you to select maps with L + R + Z, noclip with L + D-pad Right,\nand open the debug menu with L on the pause screen");
                 EnhancementCheckbox("Fast File Select", "gSkipLogoTitle");
-                Tooltip("Load the game to the selected slot below upon launch\nUse slot number 4 to load directly into the game's internal Map Select\n(Does not require the Debug Menu, but you will be unable to save there\nYou can also load the Map Select with OoT Debug Mode + slot 0)\nWith slot 0 you can directly go to the File Select menu\nAttention: loading an empty save file will result in a crash");
+                Tooltip("Bootup the game to selected menu or file\n\"Zelda Map Select\" require debug mode else you will fallback to File choose menu\nUsing a file number that don't have save will create a save file only\nif you toggle on \"Create a new save if none ?\" else it will bring you to the\nFile choose menu");
                 if (CVar_GetS32("gSkipLogoTitle", 0)) {
-                    EnhancementSliderInt("Loading %d", "##SaveFileID", "gSaveFileID", 0, 4, "");
-                }
+                    const char* FastFileSelect[5] = {
+                        "File N.1",
+                        "File N.2",
+                        "File N.3",
+                        "File select",
+                        "Zelda Map Select (require OoT Debug Mode)"
+                    };
+                    ImGui::Text("Loading :");
+                    EnhancementCombobox("gSaveFileID", FastFileSelect, 5, 0);
+                    EnhancementCheckbox("Create a new save if none ?", "gCreateNewSave");
+                    Tooltip("Enable the creation of a new save file\nif none exist in the File number selected\nNo file name will be assigned please do in Save editor once you see the first text\nelse your save file name will be named \"00000000\"\nIf disabled you will fall back in File select menu");
+                };
                 ImGui::Separator();
                 EnhancementCheckbox("Stats", "gStatsEnabled");
                 Tooltip("Shows the stats window, with your FPS and frametimes,\nand the OS you're playing on");

--- a/libultraship/libultraship/ImGuiImpl.cpp
+++ b/libultraship/libultraship/ImGuiImpl.cpp
@@ -1335,7 +1335,7 @@ namespace SohImGui {
                 EnhancementCheckbox("OoT Debug Mode", "gDebugEnabled");
                 Tooltip("Enables Debug Mode, allowing you to select maps with L + R + Z, noclip with L + D-pad Right,\nand open the debug menu with L on the pause screen");
                 EnhancementCheckbox("Fast File Select", "gSkipLogoTitle");
-                Tooltip("Bootup the game to selected menu or file\n\"Zelda Map Select\" require debug mode else you will fallback to File choose menu\nUsing a file number that don't have save will create a save file only\nif you toggle on \"Create a new save if none ?\" else it will bring you to the\nFile choose menu");
+                Tooltip("Load the game to the selected menu or file\n\"Zelda Map Select\" require debug mode else you will fallback to File choose menu\nUsing a file number that don't have save will create a save file only\nif you toggle on \"Create a new save if none ?\" else it will bring you to the\nFile choose menu");
                 if (CVar_GetS32("gSkipLogoTitle", 0)) {
                     const char* FastFileSelect[5] = {
                         "File N.1",
@@ -1346,7 +1346,7 @@ namespace SohImGui {
                     };
                     ImGui::Text("Loading :");
                     EnhancementCombobox("gSaveFileID", FastFileSelect, 5, 0);
-                    EnhancementCheckbox("Create a new save if none ?", "gCreateNewSave");
+                    EnhancementCheckbox("Create a new save if none", "gCreateNewSave");
                     Tooltip("Enable the creation of a new save file\nif none exist in the File number selected\nNo file name will be assigned please do in Save editor once you see the first text\nelse your save file name will be named \"00000000\"\nIf disabled you will fall back in File select menu");
                 };
                 ImGui::Separator();

--- a/soh/soh/SaveManager.cpp
+++ b/soh/soh/SaveManager.cpp
@@ -517,6 +517,19 @@ void SaveManager::LoadFile(int fileNum) {
     InitMeta(fileNum);
 }
 
+bool SaveManager::SaveFile_Exist(int fileNum) {
+    
+    try {
+        std::filesystem::exists(GetFileName(fileNum));
+        printf("File[%d] - exist \n",fileNum);
+        return true;
+    }
+    catch(std::filesystem::filesystem_error const& ex) {
+        printf("File[%d] - do not exist \n",fileNum);
+        return false;
+    }
+}
+
 void SaveManager::AddInitFunction(InitFunc func) {
     initFuncs.emplace_back(func);
 }
@@ -1331,4 +1344,8 @@ extern "C" void Save_CopyFile(int from, int to) {
 
 extern "C" void Save_DeleteFile(int fileNum) {
     SaveManager::Instance->DeleteZeldaFile(fileNum);
+}
+
+extern "C" bool Save_Exist(int fileNum) {
+    return SaveManager::Instance->SaveFile_Exist(fileNum);
 }

--- a/soh/soh/SaveManager.h
+++ b/soh/soh/SaveManager.h
@@ -41,6 +41,7 @@ public:
     void SaveFile(int fileNum);
     void SaveGlobal();
     void LoadFile(int fileNum);
+    bool SaveFile_Exist(int fileNum);
 
     // Adds a function that is called when we are intializing a save, including when we are loading a save.
     void AddInitFunction(InitFunc func);
@@ -149,5 +150,5 @@ void Save_AddSaveFunction(char* name, int version, Save_SaveFunc func);
 SaveFileMetaInfo* Save_GetSaveMetaInfo(int fileNum);
 void Save_CopyFile(int from, int to);
 void Save_DeleteFile(int fileNum);
-
+bool Save_Exist(int fileNum);
 #endif

--- a/soh/src/overlays/gamestates/ovl_title/z_title.c
+++ b/soh/src/overlays/gamestates/ovl_title/z_title.c
@@ -11,9 +11,9 @@
 #include "textures/nintendo_rogo_static/nintendo_rogo_static.h"
 #include <soh/Enhancements/bootcommands.h>
 #include "GameVersions.h"
+#include <soh/SaveManager.h>
 
 const char* GetGameVersionString();
-
 char* quote;
 
 void Title_PrintBuildInfo(Gfx** gfxp) {
@@ -224,72 +224,6 @@ void Title_Draw(TitleContext* this) {
 void Title_Main(GameState* thisx) {
     TitleContext* this = (TitleContext*)thisx;
 
-    if (CVar_GetS32("gSkipLogoTitle",0)!=0) {
-        gSaveContext.language = CVar_GetS32("gLanguages", 0);
-        Sram_InitSram(&this->state);
-        s16 selectedfile = CVar_GetS32("gSaveFileID", 0);
-        if (selectedfile == 4) {
-            selectedfile = 0xFF;
-        } else if(selectedfile == 0){
-            gSaveContext.fileNum = selectedfile;
-            gSaveContext.gameMode = 0;
-            this->state.running = false;
-            SET_NEXT_GAMESTATE(&this->state, FileChoose_Init, SelectContext);
-            return;
-        } else {
-            selectedfile--;
-            if (selectedfile < 0) {
-                selectedfile = 0xFF;
-            }
-        }
-        if (selectedfile == 0xFF) {
-            gSaveContext.fileNum = selectedfile;
-            Sram_OpenSave();
-            gSaveContext.gameMode = 0;
-            this->state.running = false;
-            SET_NEXT_GAMESTATE(&this->state, Select_Init, SelectContext);
-        } else {
-            gSaveContext.fileNum = selectedfile;
-            Sram_OpenSave();
-            gSaveContext.gameMode = 0;
-            this->state.running = false;
-            //return;
-            SET_NEXT_GAMESTATE(&this->state, Gameplay_Init, GlobalContext);
-        }
-        gSaveContext.respawn[0].entranceIndex = -1;
-        gSaveContext.respawnFlag = 0;
-        gSaveContext.seqId = (u8)NA_BGM_DISABLED;
-        gSaveContext.natureAmbienceId = 0xFF;
-        gSaveContext.showTitleCard = true;
-        gSaveContext.dogParams = 0;
-        gSaveContext.timer1State = 0;
-        gSaveContext.timer2State = 0;
-        gSaveContext.eventInf[0] = 0;
-        gSaveContext.eventInf[1] = 0;
-        gSaveContext.eventInf[2] = 0;
-        gSaveContext.eventInf[3] = 0;
-        gSaveContext.unk_13EE = 0x32;
-        gSaveContext.nayrusLoveTimer = 0;
-        gSaveContext.healthAccumulator = 0;
-        gSaveContext.unk_13F0 = 0;
-        gSaveContext.unk_13F2 = 0;
-        gSaveContext.forcedSeqId = NA_BGM_GENERAL_SFX;
-        gSaveContext.skyboxTime = 0;
-        gSaveContext.nextTransition = 0xFF;
-        gSaveContext.nextCutsceneIndex = 0xFFEF;
-        gSaveContext.cutsceneTrigger = 0;
-        gSaveContext.chamberCutsceneNum = 0;
-        gSaveContext.nextDayTime = 0xFFFF;
-        gSaveContext.unk_13C3 = 0;
-        gSaveContext.buttonStatus[0] = gSaveContext.buttonStatus[1] = gSaveContext.buttonStatus[2] = gSaveContext.buttonStatus[3] = gSaveContext.buttonStatus[4] = BTN_ENABLED;
-        gSaveContext.unk_13E7 = gSaveContext.unk_13E8 = gSaveContext.unk_13EA = gSaveContext.unk_13EC = gSaveContext.unk_13F4 = 0;
-        gSaveContext.unk_13F6 = gSaveContext.magic;
-        gSaveContext.magic = 0;
-        gSaveContext.magicLevel = gSaveContext.magic;
-        gSaveContext.naviTimer = 0;
-        return;
-    }
-
     OPEN_DISPS(this->state.gfxCtx);
 
     gSPSegment(POLY_OPA_DISP++, 0, NULL);
@@ -330,27 +264,94 @@ void Title_Destroy(GameState* thisx) {
 void Title_Init(GameState* thisx) {
     //u32 size = 0;
     TitleContext* this = (TitleContext*)thisx;
+    FileChooseContext* FileChooseCtx = (FileChooseContext*)thisx;
 
-    quote = SetQuote();
+    if (CVar_GetS32("gSkipLogoTitle",0)) {
+        bool saveloading = false;
+        Sram_InitSram(&this->state.init);
+        gSaveContext.language = CVar_GetS32("gLanguages", 0);
+        s32 selectedfile = CVar_GetS32("gSaveFileID", 0);
+        if (selectedfile == 4) {
+            if (CVar_GetS32("gDebugEnabled",0)) {
+                selectedfile = 0xFF;
+            } else {
+                selectedfile = 3;
+            }
+        }
+        if (selectedfile < 0) {
+            selectedfile = 3; //If somehow the save file number under 0 revert back to 3 to prevent boot error
+        }
+        if(selectedfile == 3){
+            saveloading = true;
+            gSaveContext.seqId = (u8)NA_BGM_DISABLED;
+            gSaveContext.natureAmbienceId = 0xFF;
+            gSaveContext.gameMode = 1;
+            SET_NEXT_GAMESTATE(&this->state, FileChoose_Init, FileChooseContext);
+            this->state.running = false;
+            return;
+        } else if (selectedfile == 0xFF || selectedfile > 3) {
+            saveloading = true;
+            Sram_InitDebugSave();
+            gSaveContext.fileNum = selectedfile;
+            SET_NEXT_GAMESTATE(&this->state, Select_Init, SelectContext);
+            this->state.running = false;
+            return;
+        } else if (selectedfile >= 0 && selectedfile <= 2) {
+            if (Save_Exist(selectedfile) == true) { //The file exist load it
+                saveloading = true;
+                gSaveContext.fileNum = selectedfile;
+                Sram_OpenSave();
+                gSaveContext.gameMode = 0;
+                gSaveContext.magic = gSaveContext.magic;
+                SET_NEXT_GAMESTATE(&this->state, Gameplay_Init, GlobalContext);
+                this->state.running = false;
+                return;
+            } else { 
+                if (CVar_GetS32("gCreateNewSave",0)) {
+                    //File do not exist create a new save file
+                    saveloading = true;
+                    Sram_InitSram(&FileChooseCtx->state.init);
+                    gSaveContext.fileNum = selectedfile;
+                    Sram_InitSave(FileChooseCtx);
+                    Sram_OpenSave();      
+                    gSaveContext.gameMode = 0;
+                    SET_NEXT_GAMESTATE(&this->state, Gameplay_Init, GlobalContext);
+                    this->state.running = false;
+                    return;
+                } else {
+                    //File do not exist but user do not wish to auto create a save file with blank name
+                    saveloading = true;
+                    gSaveContext.seqId = (u8)NA_BGM_DISABLED;
+                    gSaveContext.natureAmbienceId = 0xFF;
+                    gSaveContext.gameMode = 1;
+                    SET_NEXT_GAMESTATE(&this->state, FileChoose_Init, FileChooseContext);
+                    this->state.running = false;
+                    return;
+                }
+            }
+        }
+    } else {
+        quote = SetQuote();
 
-    //this->staticSegment = GAMESTATE_ALLOC_MC(&this->state, size);
-    osSyncPrintf("z_title.c\n");
-    //ASSERT(this->staticSegment != NULL);
+        //this->staticSegment = GAMESTATE_ALLOC_MC(&this->state, size);
+        osSyncPrintf("z_title.c\n");
+        //ASSERT(this->staticSegment != NULL);
 
-    //ResourceMgr_CacheDirectory("nintendo_rogo_static*");
+        //ResourceMgr_CacheDirectory("nintendo_rogo_static*");
 
-    // Disable vismono
-    D_801614B0.a = 0;
-    R_UPDATE_RATE = 1;
-    Matrix_Init(&this->state);
-    View_Init(&this->view, this->state.gfxCtx);
-    this->state.main = Title_Main;
-    this->state.destroy = Title_Destroy;
-    this->exit = false;
-    gSaveContext.fileNum = 0xFF;
-    this->ult = 0;
-    this->unk_1D4 = 0x14;
-    this->coverAlpha = 255;
-    this->addAlpha = -3;
-    this->visibleDuration = 0x3C;
+        // Disable vismono
+        D_801614B0.a = 0;
+        R_UPDATE_RATE = 1;
+        Matrix_Init(&this->state);
+        View_Init(&this->view, this->state.gfxCtx);
+        this->state.main = Title_Main;
+        this->state.destroy = Title_Destroy;
+        this->exit = false;
+        gSaveContext.fileNum = 0xFF;
+        this->ult = 0;
+        this->unk_1D4 = 0x14;
+        this->coverAlpha = 255;
+        this->addAlpha = -3;
+        this->visibleDuration = 0x3C;
+    }
 }


### PR DESCRIPTION
Should fix : #815
This PR rework the Fast File Select to match the SaveManager
It fix :
Incorrect save ID load (Issue number 815)
Crash when loading non existent save
Incorrect save structure load

it modify:
Zelda Map Select now require debug mode.

it add:
A bit better menu selection with a combox box.
Better tooltips
Ability to create a save or fall back to file choose if a save file is not present in the slot the user selected.
![Preview picture](https://www.baoulettes.fr/Uploads/5m9otfhtnrj7oczm1yslashc1.png)