### PR TITLE
prevent unrestricted items camera crash

### DIFF
--- a/soh/src/code/z_room.c
+++ b/soh/src/code/z_room.c
@@ -402,8 +402,14 @@ BgImage* func_80096A74(PolygonType1* polygon1, GlobalContext* globalCtx) {
 
     camera = GET_ACTIVE_CAM(globalCtx);
     camId = camera->camDataIdx;
+    if (camId == -1 && CVar_GetS32("gNoRestrictItems", 0)) {
+        // This prevents a crash when using items that change the
+        // camera (such as din's fire) on scenes with prerendered backgrounds
+        return NULL;
+    }
+    
     // jfifid
-    camId2 = func_80041C10(&globalCtx->colCtx, camId, BGCHECK_SCENE)[2].y;
+    camId2 = func_80041C10(&globalCtx->colCtx, camId, BGCHECK_SCENE)[2].y;    
     if (camId2 >= 0) {
         camId = camId2;
     }

--- a/soh/src/code/z_room.c
+++ b/soh/src/code/z_room.c
@@ -409,7 +409,7 @@ BgImage* func_80096A74(PolygonType1* polygon1, GlobalContext* globalCtx) {
     }
     
     // jfifid
-    camId2 = func_80041C10(&globalCtx->colCtx, camId, BGCHECK_SCENE)[2].y;    
+    camId2 = func_80041C10(&globalCtx->colCtx, camId, BGCHECK_SCENE)[2].y;
     if (camId2 >= 0) {
         camId = camId2;
     }


### PR DESCRIPTION
fixes https://github.com/HarbourMasters/Shipwright/issues/802 (at least for din's fire, haven't tested other items)

https://user-images.githubusercontent.com/70942617/179850107-9acfce6d-59ca-4247-b43f-40b3a4c70b58.mp4