### PR TITLE
reset var for shadow boss key room spike walls

### DIFF
--- a/soh/src/overlays/actors/ovl_Bg_Haka_Trap/z_bg_haka_trap.c
+++ b/soh/src/overlays/actors/ovl_Bg_Haka_Trap/z_bg_haka_trap.c
@@ -228,8 +228,8 @@ void func_8087FFC0(BgHakaTrap* this, GlobalContext* globalCtx) {
     this->colliderCylinder.dim.pos.z = this->dyna.actor.world.pos.z + sp28.x * sine + sp28.z * cosine;
 }
 
+static UNK_TYPE D_80881018 = 0;
 void func_808801B8(BgHakaTrap* this, GlobalContext* globalCtx) {
-    static UNK_TYPE D_80881018 = 0;
     Player* player = GET_PLAYER(globalCtx);
 
     if ((D_80880F30 == 0) && (!Player_InCsMode(globalCtx))) {
@@ -553,4 +553,5 @@ void BgHakaTrap_Draw(Actor* thisx, GlobalContext* globalCtx) {
 void BgHakaTrap_Reset(void) {
     D_80880F30 = 0;
     D_80881014 = 0;
+    D_80881018 = 0;
 }


### PR DESCRIPTION
fixes https://github.com/HarbourMasters/Shipwright/issues/571

`D_80881018` wasn't being reset, so when

https://github.com/HarbourMasters/Shipwright/blob/235cef6abffea3fff1ec28fa4a7856464ec886bd/soh/src/overlays/actors/ovl_Bg_Haka_Trap/z_bg_haka_trap.c#L238-L242

was being called after

https://github.com/HarbourMasters/Shipwright/blob/235cef6abffea3fff1ec28fa4a7856464ec886bd/soh/src/overlays/actors/ovl_Bg_Haka_Trap/z_bg_haka_trap.c#L251-L252

had already run, `D_80881018` was getting stuck at `7` and 

https://github.com/HarbourMasters/Shipwright/blob/235cef6abffea3fff1ec28fa4a7856464ec886bd/soh/src/overlays/actors/ovl_Bg_Haka_Trap/z_bg_haka_trap.c#L253

was never getting called.

this was all in `func_808801B8` in `z_bg_haka_trap.c`
https://github.com/HarbourMasters/Shipwright/blob/235cef6abffea3fff1ec28fa4a7856464ec886bd/soh/src/overlays/actors/ovl_Bg_Haka_Trap/z_bg_haka_trap.c#L231-L255

this PR adds `D_80881018` to the vars being reset in `BgHakaTrap_Reset`
