### PR TITLE
Randomizer: Fixes odd interaction with malon after receiving her check.

### DIFF
--- a/soh/src/overlays/actors/ovl_En_Ma1/z_en_ma1.c
+++ b/soh/src/overlays/actors/ovl_En_Ma1/z_en_ma1.c
@@ -290,7 +290,8 @@ void EnMa1_Init(Actor* thisx, GlobalContext* globalCtx) {
     this->actor.targetMode = 6;
     this->unk_1E8.unk_00 = 0;
 
-    if (!(gSaveContext.eventChkInf[1] & 0x10) || (CHECK_QUEST_ITEM(QUEST_SONG_EPONA) && !gSaveContext.n64ddFlag)) {
+    if (!(gSaveContext.eventChkInf[1] & 0x10) || (CHECK_QUEST_ITEM(QUEST_SONG_EPONA) && !gSaveContext.n64ddFlag) ||
+        (gSaveContext.n64ddFlag && Flags_GetTreasure(globalCtx, 0x1F))) {
         this->actionFunc = func_80AA0D88;
         EnMa1_ChangeAnim(this, ENMA1_ANIM_2);
     } else {


### PR DESCRIPTION
If you get Malon's check, reload the area, and pull out the ocarina, she will react to it but not give you the item, which results in the UI disappearing until you go to a different area. This PR updates her init code so that if you got her rando check already, she enters a state where she will not react to the ocarina or attempt to give you the item when speaking to her (don't think this was an issue before though).

Fixes: #866 