### PR TITLE
set morpha reset function in initvars

### DIFF
--- a/soh/src/overlays/actors/ovl_Boss_Mo/z_boss_mo.c
+++ b/soh/src/overlays/actors/ovl_Boss_Mo/z_boss_mo.c
@@ -53,6 +53,7 @@ void BossMo_UpdateCore(Actor* thisx, GlobalContext* globalCtx);
 void BossMo_UpdateTent(Actor* thisx, GlobalContext* globalCtx);
 void BossMo_DrawCore(Actor* thisx, GlobalContext* globalCtx);
 void BossMo_DrawTent(Actor* thisx, GlobalContext* globalCtx);
+void BossMo_Reset(void);
 
 void BossMo_UpdateEffects(BossMo* this, GlobalContext* globalCtx);
 void BossMo_DrawEffects(BossMoEffect* effect, GlobalContext* globalCtx);
@@ -131,7 +132,7 @@ const ActorInit Boss_Mo_InitVars = {
     (ActorFunc)BossMo_Destroy,
     (ActorFunc)BossMo_UpdateTent,
     (ActorFunc)BossMo_DrawTent,
-    NULL,
+    (ActorResetFunc)BossMo_Reset,
 };
 
 static BossMo* sMorphaCore = NULL;


### PR DESCRIPTION
fixes https://github.com/HarbourMasters/Shipwright/issues/650

it seems we already had a reset function for morpha 

https://github.com/HarbourMasters/Shipwright/blob/84236e7ac334c992e78920af0dfa1d6354413b51/soh/src/overlays/actors/ovl_Boss_Mo/z_boss_mo.c#L3599-L3607

 but it wasn't being set in initvars
 
https://github.com/HarbourMasters/Shipwright/blob/84236e7ac334c992e78920af0dfa1d6354413b51/soh/src/overlays/actors/ovl_Boss_Mo/z_boss_mo.c#L124-L135

this pr just sets the existing reset function in initvars

from my testing, this fixes the water level issue and doesn't cause any new problems