### PR TITLE
Disable concurrent builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,7 @@ pipeline {
     options {
         timestamps() 
         skipDefaultCheckout(true)
+        disableConcurrentBuilds(abortPrevious: true)
     }
     
     stages {


### PR DESCRIPTION
Running job will be aborted if a new run is started on branch.