### PR TITLE
Rando: More UX Changes

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -3714,16 +3714,11 @@ void DrawRandoEditor(bool& open) {
             return;
         }
 
-        bool disableEditingRandoSettings = CVar_GetS32("gRandoGenerating", 0) ||
-                                           CVar_GetS32("gOnFileSelectNameEntry", 0);
-        bool disableZeldaRelatedOptions = CVar_GetS32("gRandomizeSkipChildZelda", 0);
-        if (disableEditingRandoSettings) {
-            disableZeldaRelatedOptions = true;
-        }
+        bool disableEditingRandoSettings = CVar_GetS32("gRandoGenerating", 0) || CVar_GetS32("gOnFileSelectNameEntry", 0);
+        bool disableZeldaRelatedOptions = CVar_GetS32("gRandomizeSkipChildZelda", 0) || disableEditingRandoSettings;
         ImGui::PushItemFlag(ImGuiItemFlags_Disabled, disableEditingRandoSettings);
         ImGui::PushStyleVar(ImGuiStyleVar_Alpha,
-                            ImGui::GetStyle().Alpha * disableEditingRandoSettings ? 0.5f : 1.0f);
-
+                            ImGui::GetStyle().Alpha * (disableEditingRandoSettings ? 0.5f : 1.0f));
         SohImGui::EnhancementCheckbox("Enable Randomizer", "gRandomizer");
 
         if (CVar_GetS32("gRandomizer", 0) == 1) {
@@ -3975,7 +3970,7 @@ void DrawRandoEditor(bool& open) {
                         }
                         ImGui::PushItemFlag(ImGuiItemFlags_Disabled, disableZeldaRelatedOptions);
                         ImGui::PushStyleVar(ImGuiStyleVar_Alpha,
-                                            ImGui::GetStyle().Alpha * disableZeldaRelatedOptions ? 0.5f : 1.0f);
+                                            ImGui::GetStyle().Alpha * (disableZeldaRelatedOptions ? 0.5f : 1.0f));
                         SohImGui::EnhancementCheckbox(Settings::ShuffleWeirdEgg.GetName().c_str(), "gRandomizeShuffleWeirdEgg");
                         ImGui::PopStyleVar();
                         if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && disableZeldaRelatedOptions) {
@@ -4092,7 +4087,7 @@ void DrawRandoEditor(bool& open) {
                     }
                     ImGui::PushItemFlag(ImGuiItemFlags_Disabled, disableZeldaRelatedOptions);
                     ImGui::PushStyleVar(ImGuiStyleVar_Alpha,
-                                        ImGui::GetStyle().Alpha * disableZeldaRelatedOptions ? 0.5f : 1.0f);
+                                        ImGui::GetStyle().Alpha * (disableZeldaRelatedOptions ? 0.5f : 1.0f));
                     SohImGui::EnhancementCheckbox(Settings::SkipChildStealth.GetName().c_str(),
                                                   "gRandomizeSkipChildStealth");
                     ImGui::PopStyleVar();

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -3966,22 +3966,28 @@ void DrawRandoEditor(bool& open) {
                             ImGui::Separator();
                         }
 
-                        // hide this option if we're skipping child zelda
-                        if(CVar_GetS32("gRandomizeSkipChildZelda", 0) == 0) {
-                            // Shuffle Weird Egg
-                            SohImGui::EnhancementCheckbox(Settings::ShuffleWeirdEgg.GetName().c_str(), "gRandomizeShuffleWeirdEgg");
-                            InsertHelpHoverText(
-                                "Shuffles the Weird Egg from Malon in to the item pool.\n"
-                                "\n"
-                                "The Weird Egg is required to unlock several events:\n"
-                                "  - Zelda's Lullaby from Impa\n"
-                                "  - Saria's song in Sacred Forest Meadow\n"
-                                "  - Epona's song and chicken minigame at Lon Lon Ranch\n"
-                                "  - Zelda's letter for Kakariko gate (if set to closed)\n"
-                                "  - Happy Mask Shop sidequest\n"
-                            );
-                            ImGui::Separator();
+                        // Shuffle Weird Egg
+                        // Disabled when Skip Child Zelda is active
+                        if (CVar_GetS32("gRandomizeSkipChildZelda", 0) != 0) {
+                            ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(130, 130, 130, 255));
+                            CVar_SetS32("gRandomizeShuffleWeirdEgg", 0);
+                        } else {
+                            ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(255, 255, 255, 255));
                         }
+                        SohImGui::EnhancementCheckbox(Settings::ShuffleWeirdEgg.GetName().c_str(), "gRandomizeShuffleWeirdEgg");
+                        ImGui::PopStyleColor();
+                        InsertHelpHoverText(
+                            "Shuffles the Weird Egg from Malon in to the item pool. Enabling Skip\n"
+                            "Child Zelda disables this feature.\n"
+                            "\n"
+                            "The Weird Egg is required to unlock several events:\n"
+                            "  - Zelda's Lullaby from Impa\n"
+                            "  - Saria's song in Sacred Forest Meadow\n"
+                            "  - Epona's song and chicken minigame at Lon Lon Ranch\n"
+                            "  - Zelda's letter for Kakariko gate (if set to closed)\n"
+                            "  - Happy Mask Shop sidequest\n"
+                        );
+                        ImGui::Separator();
 
                         // Shuffle Gerudo Membership Card
                         SohImGui::EnhancementCheckbox(Settings::ShuffleGerudoToken.GetName().c_str(), "gRandomizeShuffleGerudoToken");
@@ -4072,12 +4078,23 @@ void DrawRandoEditor(bool& open) {
                     ImGui::Separator();
 
                     // Skip child stealth
-                    SohImGui::EnhancementCheckbox(Settings::SkipChildStealth.GetName().c_str(), "gRandomizeSkipChildStealth");
-                    InsertHelpHoverText(
-                        "The crawlspace into Hyrule Castle goes straight to Zelda, skipping\n"
-                        "the guards."
-                    );
+                    // Disabled when Skip Child Zelda is active
+                    if (CVar_GetS32("gRandomizeSkipChildZelda", 0) != 0) {
+                        ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(130, 130, 130, 255));
+                        CVar_SetS32("gRandomizeSkipChildStealth", 0);
+                        // Also disable Weird Egg because it's on a different tab and wouldn't be updated otherwise
+                        CVar_SetS32("gRandomizeShuffleWeirdEgg", 0);
+                    } else {
+                        ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(255, 255, 255, 255));
+                    }
+                    SohImGui::EnhancementCheckbox(Settings::SkipChildStealth.GetName().c_str(),
+                                                    "gRandomizeSkipChildStealth");
+                    ImGui::PopStyleColor();
+                    InsertHelpHoverText("The crawlspace into Hyrule Castle goes straight to Zelda, skipping\n"
+                                        "the guards.");
                     ImGui::Separator();
+
+                    // Skip child zelda
                     SohImGui::EnhancementCheckbox("Skip Child Zelda", "gRandomizeSkipChildZelda");
                     InsertHelpHoverText(
                         "Start with Zelda's Letter in your inventory and skip the sequence up\n"

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -3850,6 +3850,7 @@ void DrawRandoEditor(bool& open) {
                             "Tokens - Obtain the specified amount of Skulltula tokens."
                         );
                         SohImGui::EnhancementCombobox("gRandomizeRainbowBridge", randoRainbowBridge, 7, 0);
+                        ImGui::PopItemWidth();
                         switch (CVar_GetS32("gRandomizeRainbowBridge", 0)) {
                             case 0:
                                 break;
@@ -3857,23 +3858,23 @@ void DrawRandoEditor(bool& open) {
                                 break;
                             case 2:
                                 SohImGui::EnhancementSliderInt("Stone Count: %d", "##RandoStoneCount",
-                                                               "gRandomizeStoneCount", 0, 3, "", 3);
+                                                               "gRandomizeStoneCount", 0, 3, "", 3, true);
                                 break;
                             case 3:
                                 SohImGui::EnhancementSliderInt("Medallion Count: %d", "##RandoMedallionCount",
-                                                               "gRandomizeMedallionCount", 0, 6, "", 6);
+                                                               "gRandomizeMedallionCount", 0, 6, "", 6, true);
                                 break;
                             case 4:
                                 SohImGui::EnhancementSliderInt("Reward Count: %d", "##RandoRewardCount",
-                                                               "gRandomizeRewardCount", 0, 9, "", 9);
+                                                               "gRandomizeRewardCount", 0, 9, "", 9, true);
                                 break;
                             case 5:
                                 SohImGui::EnhancementSliderInt("Dungeon Count: %d", "##RandoDungeonCount",
-                                                               "gRandomizeDungeonCount", 0, 8, "", 8);
+                                                               "gRandomizeDungeonCount", 0, 8, "", 8, true);
                                 break;
                             case 6:
                                 SohImGui::EnhancementSliderInt("Token Count: %d", "##RandoTokenCount",
-                                                               "gRandomizeTokenCount", 0, 100, "", 100);
+                                                               "gRandomizeTokenCount", 0, 100, "", 100, true);
                                 break;
                         }
                         ImGui::Separator();
@@ -4065,7 +4066,7 @@ void DrawRandoEditor(bool& open) {
 
                     // Cuccos to return
                     SohImGui::EnhancementSliderInt("Cuccos to return: %d", "##RandoCuccosToReturn",
-                                                    "gRandomizeCuccosToReturn", 0, 7, "", 7);
+                                                    "gRandomizeCuccosToReturn", 0, 7, "", 7, true);
                     InsertHelpHoverText(
                         "The amount of cuccos needed to claim the reward from Anju the cucco lady"
                     );
@@ -4073,7 +4074,7 @@ void DrawRandoEditor(bool& open) {
 
                     // Big Poe Target Count
                     SohImGui::EnhancementSliderInt("Big Poe Target Count: %d", "##RandoBigPoeTargetCount",
-                                                    "gRandomizeBigPoeTargetCount", 1, 10, "", 10);
+                                                    "gRandomizeBigPoeTargetCount", 1, 10, "", 10, true);
                     InsertHelpHoverText(
                         "The Poe collector will give a reward for turning in this many Big Poes."
                     );

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -3710,7 +3710,6 @@ void DrawRandoEditor(bool& open) {
                                      "Timer",
                                      "Zelda Gasp (Adult)" };
 
-
         ImGui::SetNextWindowSize(ImVec2(750, 530), ImGuiCond_FirstUseEver);
         if (!ImGui::Begin("Randomizer Editor", &open, ImGuiWindowFlags_NoFocusOnAppearing)) {
             ImGui::End();

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -3414,17 +3414,17 @@ void GenerateRandomizerImgui() {
     Game::SaveSettings();
     
     std::unordered_map<RandomizerSettingKey, u8> cvarSettings;
-    cvarSettings[RSK_FOREST] = CVar_GetS32("gRandomizeForest", 1);
-    cvarSettings[RSK_KAK_GATE] = CVar_GetS32("gRandomizeKakarikoGate", 1);
+    cvarSettings[RSK_FOREST] = CVar_GetS32("gRandomizeForest", 0);
+    cvarSettings[RSK_KAK_GATE] = CVar_GetS32("gRandomizeKakarikoGate", 0);
     cvarSettings[RSK_DOOR_OF_TIME] = CVar_GetS32("gRandomizeDoorOfTime", 0);
     cvarSettings[RSK_ZORAS_FOUNTAIN] = CVar_GetS32("gRandomizeZorasFountain", 0);
-    cvarSettings[RSK_GERUDO_FORTRESS] = CVar_GetS32("gRandomizeGerudoFortress", 1);
-    cvarSettings[RSK_RAINBOW_BRIDGE] = CVar_GetS32("gRandomizeRainbowBridge", 3);
-    cvarSettings[RSK_RAINBOW_BRIDGE_STONE_COUNT] = CVar_GetS32("gRandomizeStoneCount", 1);
-    cvarSettings[RSK_RAINBOW_BRIDGE_MEDALLION_COUNT] = CVar_GetS32("gRandomizeMedallionCount", 6);
-    cvarSettings[RSK_RAINBOW_BRIDGE_REWARD_COUNT] = CVar_GetS32("gRandomizeRewardCount", 1);
-    cvarSettings[RSK_RAINBOW_BRIDGE_DUNGEON_COUNT] = CVar_GetS32("gRandomizeDungeonCount", 1);
-    cvarSettings[RSK_RAINBOW_BRIDGE_TOKEN_COUNT] = CVar_GetS32("gRandomizeTokenCount", 1);
+    cvarSettings[RSK_GERUDO_FORTRESS] = CVar_GetS32("gRandomizeGerudoFortress", 0);
+    cvarSettings[RSK_RAINBOW_BRIDGE] = CVar_GetS32("gRandomizeRainbowBridge", 0);
+    cvarSettings[RSK_RAINBOW_BRIDGE_STONE_COUNT] = CVar_GetS32("gRandomizeStoneCount", 0);
+    cvarSettings[RSK_RAINBOW_BRIDGE_MEDALLION_COUNT] = CVar_GetS32("gRandomizeMedallionCount", 0);
+    cvarSettings[RSK_RAINBOW_BRIDGE_REWARD_COUNT] = CVar_GetS32("gRandomizeRewardCount", 0);
+    cvarSettings[RSK_RAINBOW_BRIDGE_DUNGEON_COUNT] = CVar_GetS32("gRandomizeDungeonCount", 0);
+    cvarSettings[RSK_RAINBOW_BRIDGE_TOKEN_COUNT] = CVar_GetS32("gRandomizeTokenCount", 0);
     cvarSettings[RSK_RANDOM_TRIALS] = CVar_GetS32("gRandomizeGanonTrial", 0);
     cvarSettings[RSK_TRIAL_COUNT] = CVar_GetS32("gRandomizeGanonTrialCount", 0);
     cvarSettings[RSK_STARTING_OCARINA] = CVar_GetS32("gRandomizeStartingOcarina", 0);
@@ -3858,23 +3858,23 @@ void DrawRandoEditor(bool& open) {
                                 break;
                             case 2:
                                 SohImGui::EnhancementSliderInt("Stone Count: %d", "##RandoStoneCount",
-                                                               "gRandomizeStoneCount", 0, 3, "", 3, true);
+                                                               "gRandomizeStoneCount", 1, 3, "", 3, true);
                                 break;
                             case 3:
                                 SohImGui::EnhancementSliderInt("Medallion Count: %d", "##RandoMedallionCount",
-                                                               "gRandomizeMedallionCount", 0, 6, "", 6, true);
+                                                               "gRandomizeMedallionCount", 1, 6, "", 6, true);
                                 break;
                             case 4:
                                 SohImGui::EnhancementSliderInt("Reward Count: %d", "##RandoRewardCount",
-                                                               "gRandomizeRewardCount", 0, 9, "", 9, true);
+                                                               "gRandomizeRewardCount", 1, 9, "", 9, true);
                                 break;
                             case 5:
                                 SohImGui::EnhancementSliderInt("Dungeon Count: %d", "##RandoDungeonCount",
-                                                               "gRandomizeDungeonCount", 0, 8, "", 8, true);
+                                                               "gRandomizeDungeonCount", 1, 8, "", 8, true);
                                 break;
                             case 6:
                                 SohImGui::EnhancementSliderInt("Token Count: %d", "##RandoTokenCount",
-                                                               "gRandomizeTokenCount", 0, 100, "", 100, true);
+                                                               "gRandomizeTokenCount", 1, 100, "", 100, true);
                                 break;
                         }
                         ImGui::Separator();

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -3711,6 +3711,8 @@ void DrawRandoEditor(bool& open) {
                                      "Timer",
                                      "Zelda Gasp (Adult)" };
 
+    bool disableZeldaRelatedOptions = CVar_GetS32("gRandomizeSkipChildZelda", 0);
+
         ImGui::SetNextWindowSize(ImVec2(750, 530), ImGuiCond_FirstUseEver);
         if (!ImGui::Begin("Randomizer Editor", &open, ImGuiWindowFlags_NoFocusOnAppearing)) {
             ImGui::End();
@@ -3968,17 +3970,21 @@ void DrawRandoEditor(bool& open) {
 
                         // Shuffle Weird Egg
                         // Disabled when Skip Child Zelda is active
-                        if (CVar_GetS32("gRandomizeSkipChildZelda", 0) != 0) {
-                            ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(130, 130, 130, 255));
+                        if (disableZeldaRelatedOptions) {
                             CVar_SetS32("gRandomizeShuffleWeirdEgg", 0);
-                        } else {
-                            ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(255, 255, 255, 255));
                         }
+                        ImGui::PushItemFlag(ImGuiItemFlags_Disabled, disableZeldaRelatedOptions);
+                        ImGui::PushStyleVar(ImGuiStyleVar_Alpha,
+                                            ImGui::GetStyle().Alpha * disableZeldaRelatedOptions ? 0.5f : 1.0f);
                         SohImGui::EnhancementCheckbox(Settings::ShuffleWeirdEgg.GetName().c_str(), "gRandomizeShuffleWeirdEgg");
-                        ImGui::PopStyleColor();
+                        ImGui::PopStyleVar();
+                        if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && disableZeldaRelatedOptions) {
+                            ImGui::SetTooltip("%s", "This option is disabled because \"Skip Child Zelda\" is enabled");
+                        }
+                        ImGui::PopItemFlag();
                         InsertHelpHoverText(
-                            "Shuffles the Weird Egg from Malon in to the item pool. Enabling Skip\n"
-                            "Child Zelda disables this feature.\n"
+                            "Shuffles the Weird Egg from Malon in to the item pool. Enabling\n"
+                            "\"Skip Child Zelda\" disables this feature.\n"
                             "\n"
                             "The Weird Egg is required to unlock several events:\n"
                             "  - Zelda's Lullaby from Impa\n"
@@ -4079,17 +4085,21 @@ void DrawRandoEditor(bool& open) {
 
                     // Skip child stealth
                     // Disabled when Skip Child Zelda is active
-                    if (CVar_GetS32("gRandomizeSkipChildZelda", 0) != 0) {
-                        ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(130, 130, 130, 255));
+                    if (disableZeldaRelatedOptions) {
                         CVar_SetS32("gRandomizeSkipChildStealth", 0);
                         // Also disable Weird Egg because it's on a different tab and wouldn't be updated otherwise
                         CVar_SetS32("gRandomizeShuffleWeirdEgg", 0);
-                    } else {
-                        ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(255, 255, 255, 255));
                     }
+                    ImGui::PushItemFlag(ImGuiItemFlags_Disabled, disableZeldaRelatedOptions);
+                    ImGui::PushStyleVar(ImGuiStyleVar_Alpha,
+                                        ImGui::GetStyle().Alpha * disableZeldaRelatedOptions ? 0.5f : 1.0f);
                     SohImGui::EnhancementCheckbox(Settings::SkipChildStealth.GetName().c_str(),
-                                                    "gRandomizeSkipChildStealth");
-                    ImGui::PopStyleColor();
+                                                  "gRandomizeSkipChildStealth");
+                    ImGui::PopStyleVar();
+                    if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && disableZeldaRelatedOptions) {
+                        ImGui::SetTooltip("%s", "This option is disabled because \"Skip Child Zelda\" is enabled");
+                    }
+                    ImGui::PopItemFlag();
                     InsertHelpHoverText("The crawlspace into Hyrule Castle goes straight to Zelda, skipping\n"
                                         "the guards.");
                     ImGui::Separator();

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -3768,7 +3768,7 @@ void DrawRandoEditor(bool& open) {
                             "\n"
                             "Open - Mido no longer blocks the path to the Deku Tree. Kokiri\n"
                             "boy no longer blocks the path out of the forest.");
-                        SohImGui::EnhancementCombobox("gRandomizeForest", randoForest, 3, 1);
+                        SohImGui::EnhancementCombobox("gRandomizeForest", randoForest, 3, 0);
                         ImGui::Separator();
                         // Kakariko Gate
                         ImGui::Text(Settings::OpenKakariko.GetName().c_str());
@@ -3779,7 +3779,7 @@ void DrawRandoEditor(bool& open) {
                             "Open - The gate is always open. The happy mask shop\n"
                             "will open immediately after obtaining Zelda's letter."
                         );
-                        SohImGui::EnhancementCombobox("gRandomizeKakarikoGate", randoKakarikoGate, 2, 1);
+                        SohImGui::EnhancementCombobox("gRandomizeKakarikoGate", randoKakarikoGate, 2, 0);
                         ImGui::Separator();
 
                         // Door of Time
@@ -3825,7 +3825,7 @@ void DrawRandoEditor(bool& open) {
                             "\n"
                             "Open - The bridge is repaired from the start."
                         );
-                        SohImGui::EnhancementCombobox("gRandomizeGerudoFortress", randoGerudoFortress, 3, 1);
+                        SohImGui::EnhancementCombobox("gRandomizeGerudoFortress", randoGerudoFortress, 3, 0);
                         ImGui::Separator();
 
                         // Rainbow Bridge
@@ -3851,13 +3851,15 @@ void DrawRandoEditor(bool& open) {
                             "\n"
                             "Tokens - Obtain the specified amount of Skulltula tokens."
                         );
-                        SohImGui::EnhancementCombobox("gRandomizeRainbowBridge", randoRainbowBridge, 7, 3);
-                        switch (CVar_GetS32("gRandomizeRainbowBridge", 3)) {
+                        SohImGui::EnhancementCombobox("gRandomizeRainbowBridge", randoRainbowBridge, 7, 0);
+                        switch (CVar_GetS32("gRandomizeRainbowBridge", 0)) {
+                            case 0:
+                                break;
                             case 1:
                                 break;
                             case 2:
                                 SohImGui::EnhancementSliderInt("Stone Count: %d", "##RandoStoneCount",
-                                                               "gRandomizeStoneCount", 0, 3, "");
+                                                               "gRandomizeStoneCount", 0, 3, "", 3);
                                 break;
                             case 3:
                                 SohImGui::EnhancementSliderInt("Medallion Count: %d", "##RandoMedallionCount",
@@ -3865,15 +3867,15 @@ void DrawRandoEditor(bool& open) {
                                 break;
                             case 4:
                                 SohImGui::EnhancementSliderInt("Reward Count: %d", "##RandoRewardCount",
-                                                               "gRandomizeRewardCount", 0, 9, "");
+                                                               "gRandomizeRewardCount", 0, 9, "", 9);
                                 break;
                             case 5:
                                 SohImGui::EnhancementSliderInt("Dungeon Count: %d", "##RandoDungeonCount",
-                                                               "gRandomizeDungeonCount", 0, 8, "");
+                                                               "gRandomizeDungeonCount", 0, 8, "", 8);
                                 break;
                             case 6:
                                 SohImGui::EnhancementSliderInt("Token Count: %d", "##RandoTokenCount",
-                                                               "gRandomizeTokenCount", 0, 100, "");
+                                                               "gRandomizeTokenCount", 0, 100, "", 100);
                                 break;
                         }
                         ImGui::Separator();

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -3439,11 +3439,7 @@ void GenerateRandomizerImgui() {
     cvarSettings[RSK_SHUFFLE_SONGS] = CVar_GetS32("gRandomizeShuffleSongs", 0);
     cvarSettings[RSK_SHUFFLE_TOKENS] = CVar_GetS32("gRandomizeShuffleTokens", 0);
     cvarSettings[RSK_SKIP_CHILD_ZELDA] = CVar_GetS32("gRandomizeSkipChildZelda", 0);
-
-    // if we skip child zelda, we start with zelda's letter, and malon starts
-    // at the ranch, so we should *not* shuffle the weird egg
-    cvarSettings[RSK_SHUFFLE_WEIRD_EGG] = ((CVar_GetS32("gRandomizeSkipChildZelda", 0) == 0) &&
-                                            CVar_GetS32("gRandomizeShuffleWeirdEgg", 0));
+    cvarSettings[RSK_SHUFFLE_WEIRD_EGG] = CVar_GetS32("gRandomizeShuffleWeirdEgg", 0);
     
     cvarSettings[RSK_SHUFFLE_GERUDO_MEMBERSHIP_CARD] = CVar_GetS32("gRandomizeShuffleGerudoToken", 0);
     cvarSettings[RSK_ITEM_POOL] = CVar_GetS32("gRandomizeItemPool", 1);

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -3439,7 +3439,10 @@ void GenerateRandomizerImgui() {
     cvarSettings[RSK_SHUFFLE_SONGS] = CVar_GetS32("gRandomizeShuffleSongs", 0);
     cvarSettings[RSK_SHUFFLE_TOKENS] = CVar_GetS32("gRandomizeShuffleTokens", 0);
     cvarSettings[RSK_SKIP_CHILD_ZELDA] = CVar_GetS32("gRandomizeSkipChildZelda", 0);
-    cvarSettings[RSK_SHUFFLE_WEIRD_EGG] = CVar_GetS32("gRandomizeShuffleWeirdEgg", 0);
+
+    // if we skip child zelda, we start with zelda's letter, and malon starts
+    // at the ranch, so we should *not* shuffle the weird egg
+    cvarSettings[RSK_SHUFFLE_WEIRD_EGG] = ((CVar_GetS32("gRandomizeSkipChildZelda", 0) == 0) && CVar_GetS32("gRandomizeShuffleWeirdEgg", 0));
     
     cvarSettings[RSK_SHUFFLE_GERUDO_MEMBERSHIP_CARD] = CVar_GetS32("gRandomizeShuffleGerudoToken", 0);
     cvarSettings[RSK_ITEM_POOL] = CVar_GetS32("gRandomizeItemPool", 1);
@@ -3965,9 +3968,6 @@ void DrawRandoEditor(bool& open) {
 
                         // Shuffle Weird Egg
                         // Disabled when Skip Child Zelda is active
-                        if (disableZeldaRelatedOptions) {
-                            CVar_SetS32("gRandomizeShuffleWeirdEgg", 0);
-                        }
                         ImGui::PushItemFlag(ImGuiItemFlags_Disabled, disableZeldaRelatedOptions);
                         ImGui::PushStyleVar(ImGuiStyleVar_Alpha,
                                             ImGui::GetStyle().Alpha * (disableZeldaRelatedOptions ? 0.5f : 1.0f));
@@ -4080,11 +4080,6 @@ void DrawRandoEditor(bool& open) {
 
                     // Skip child stealth
                     // Disabled when Skip Child Zelda is active
-                    if (disableZeldaRelatedOptions) {
-                        CVar_SetS32("gRandomizeSkipChildStealth", 0);
-                        // Also disable Weird Egg because it's on a different tab and wouldn't be updated otherwise
-                        CVar_SetS32("gRandomizeShuffleWeirdEgg", 0);
-                    }
                     ImGui::PushItemFlag(ImGuiItemFlags_Disabled, disableZeldaRelatedOptions);
                     ImGui::PushStyleVar(ImGuiStyleVar_Alpha,
                                         ImGui::GetStyle().Alpha * (disableZeldaRelatedOptions ? 0.5f : 1.0f));

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -3717,7 +3717,7 @@ void DrawRandoEditor(bool& open) {
         }
 
         bool disableEditingRandoSettings = CVar_GetS32("gRandoGenerating", 0) || CVar_GetS32("gOnFileSelectNameEntry", 0);
-        bool disableZeldaRelatedOptions = CVar_GetS32("gRandomizeSkipChildZelda", 0) || disableEditingRandoSettings;
+        bool disableZeldaRelatedOptions = CVar_GetS32("gRandomizeSkipChildZelda", 0);
         ImGui::PushItemFlag(ImGuiItemFlags_Disabled, disableEditingRandoSettings);
         ImGui::PushStyleVar(ImGuiStyleVar_Alpha,
                             ImGui::GetStyle().Alpha * (disableEditingRandoSettings ? 0.5f : 1.0f));
@@ -3967,15 +3967,21 @@ void DrawRandoEditor(bool& open) {
 
                         // Shuffle Weird Egg
                         // Disabled when Skip Child Zelda is active
-                        ImGui::PushItemFlag(ImGuiItemFlags_Disabled, disableZeldaRelatedOptions);
-                        ImGui::PushStyleVar(ImGuiStyleVar_Alpha,
-                                            ImGui::GetStyle().Alpha * (disableZeldaRelatedOptions ? 0.5f : 1.0f));
-                        SohImGui::EnhancementCheckbox(Settings::ShuffleWeirdEgg.GetName().c_str(), "gRandomizeShuffleWeirdEgg");
-                        ImGui::PopStyleVar();
-                        if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && disableZeldaRelatedOptions) {
-                            ImGui::SetTooltip("%s", "This option is disabled because \"Skip Child Zelda\" is enabled");
+                        if (!disableEditingRandoSettings) {
+                            ImGui::PushItemFlag(ImGuiItemFlags_Disabled, disableZeldaRelatedOptions);
+                            ImGui::PushStyleVar(ImGuiStyleVar_Alpha,
+                                                ImGui::GetStyle().Alpha * (disableZeldaRelatedOptions ? 0.5f : 1.0f));
                         }
-                        ImGui::PopItemFlag();
+                        SohImGui::EnhancementCheckbox(Settings::ShuffleWeirdEgg.GetName().c_str(), "gRandomizeShuffleWeirdEgg");
+                        if (!disableEditingRandoSettings) {
+                            ImGui::PopStyleVar();
+                            if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) &&
+                                disableZeldaRelatedOptions) {
+                                ImGui::SetTooltip("%s",
+                                                  "This option is disabled because \"Skip Child Zelda\" is enabled");
+                            }
+                            ImGui::PopItemFlag();
+                        }
                         InsertHelpHoverText(
                             "Shuffles the Weird Egg from Malon in to the item pool. Enabling\n"
                             "\"Skip Child Zelda\" disables this feature.\n"
@@ -4079,16 +4085,20 @@ void DrawRandoEditor(bool& open) {
 
                     // Skip child stealth
                     // Disabled when Skip Child Zelda is active
-                    ImGui::PushItemFlag(ImGuiItemFlags_Disabled, disableZeldaRelatedOptions);
-                    ImGui::PushStyleVar(ImGuiStyleVar_Alpha,
-                                        ImGui::GetStyle().Alpha * (disableZeldaRelatedOptions ? 0.5f : 1.0f));
+                    if (!disableEditingRandoSettings) {
+                        ImGui::PushItemFlag(ImGuiItemFlags_Disabled, disableZeldaRelatedOptions);
+                        ImGui::PushStyleVar(ImGuiStyleVar_Alpha,
+                                            ImGui::GetStyle().Alpha * (disableZeldaRelatedOptions ? 0.5f : 1.0f));
+                    }
                     SohImGui::EnhancementCheckbox(Settings::SkipChildStealth.GetName().c_str(),
                                                   "gRandomizeSkipChildStealth");
-                    ImGui::PopStyleVar();
-                    if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && disableZeldaRelatedOptions) {
-                        ImGui::SetTooltip("%s", "This option is disabled because \"Skip Child Zelda\" is enabled");
+                    if (!disableEditingRandoSettings) {
+                        ImGui::PopStyleVar();
+                        if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && disableZeldaRelatedOptions) {
+                            ImGui::SetTooltip("%s", "This option is disabled because \"Skip Child Zelda\" is enabled");
+                        }
+                        ImGui::PopItemFlag();
                     }
-                    ImGui::PopItemFlag();
                     InsertHelpHoverText("The crawlspace into Hyrule Castle goes straight to Zelda, skipping\n"
                                         "the guards.");
                     ImGui::Separator();

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -3707,7 +3707,6 @@ void DrawRandoEditor(bool& open) {
                                      "Timer",
                                      "Zelda Gasp (Adult)" };
 
-    bool disableZeldaRelatedOptions = CVar_GetS32("gRandomizeSkipChildZelda", 0);
 
         ImGui::SetNextWindowSize(ImVec2(750, 530), ImGuiCond_FirstUseEver);
         if (!ImGui::Begin("Randomizer Editor", &open, ImGuiWindowFlags_NoFocusOnAppearing)) {
@@ -3717,6 +3716,10 @@ void DrawRandoEditor(bool& open) {
 
         bool disableEditingRandoSettings = CVar_GetS32("gRandoGenerating", 0) ||
                                            CVar_GetS32("gOnFileSelectNameEntry", 0);
+        bool disableZeldaRelatedOptions = CVar_GetS32("gRandomizeSkipChildZelda", 0);
+        if (disableEditingRandoSettings) {
+            disableZeldaRelatedOptions = true;
+        }
         ImGui::PushItemFlag(ImGuiItemFlags_Disabled, disableEditingRandoSettings);
         ImGui::PushStyleVar(ImGuiStyleVar_Alpha,
                             ImGui::GetStyle().Alpha * disableEditingRandoSettings ? 0.5f : 1.0f);

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -3717,7 +3717,6 @@ void DrawRandoEditor(bool& open) {
         }
 
         bool disableEditingRandoSettings = CVar_GetS32("gRandoGenerating", 0) || CVar_GetS32("gOnFileSelectNameEntry", 0);
-        bool disableZeldaRelatedOptions = CVar_GetS32("gRandomizeSkipChildZelda", 0);
         ImGui::PushItemFlag(ImGuiItemFlags_Disabled, disableEditingRandoSettings);
         ImGui::PushStyleVar(ImGuiStyleVar_Alpha,
                             ImGui::GetStyle().Alpha * (disableEditingRandoSettings ? 0.5f : 1.0f));
@@ -3968,15 +3967,16 @@ void DrawRandoEditor(bool& open) {
                         // Shuffle Weird Egg
                         // Disabled when Skip Child Zelda is active
                         if (!disableEditingRandoSettings) {
-                            ImGui::PushItemFlag(ImGuiItemFlags_Disabled, disableZeldaRelatedOptions);
+                            ImGui::PushItemFlag(ImGuiItemFlags_Disabled, CVar_GetS32("gRandomizeSkipChildZelda", 0));
                             ImGui::PushStyleVar(ImGuiStyleVar_Alpha,
-                                                ImGui::GetStyle().Alpha * (disableZeldaRelatedOptions ? 0.5f : 1.0f));
+                                                ImGui::GetStyle().Alpha *
+                                                    (CVar_GetS32("gRandomizeSkipChildZelda", 0) ? 0.5f : 1.0f));
                         }
                         SohImGui::EnhancementCheckbox(Settings::ShuffleWeirdEgg.GetName().c_str(), "gRandomizeShuffleWeirdEgg");
                         if (!disableEditingRandoSettings) {
                             ImGui::PopStyleVar();
                             if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) &&
-                                disableZeldaRelatedOptions) {
+                                CVar_GetS32("gRandomizeSkipChildZelda", 0)) {
                                 ImGui::SetTooltip("%s",
                                                   "This option is disabled because \"Skip Child Zelda\" is enabled");
                             }
@@ -4086,15 +4086,17 @@ void DrawRandoEditor(bool& open) {
                     // Skip child stealth
                     // Disabled when Skip Child Zelda is active
                     if (!disableEditingRandoSettings) {
-                        ImGui::PushItemFlag(ImGuiItemFlags_Disabled, disableZeldaRelatedOptions);
+                        ImGui::PushItemFlag(ImGuiItemFlags_Disabled, CVar_GetS32("gRandomizeSkipChildZelda", 0));
                         ImGui::PushStyleVar(ImGuiStyleVar_Alpha,
-                                            ImGui::GetStyle().Alpha * (disableZeldaRelatedOptions ? 0.5f : 1.0f));
+                                            ImGui::GetStyle().Alpha *
+                                                (CVar_GetS32("gRandomizeSkipChildZelda", 0) ? 0.5f : 1.0f));
                     }
                     SohImGui::EnhancementCheckbox(Settings::SkipChildStealth.GetName().c_str(),
                                                   "gRandomizeSkipChildStealth");
                     if (!disableEditingRandoSettings) {
                         ImGui::PopStyleVar();
-                        if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && disableZeldaRelatedOptions) {
+                        if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) &&
+                            CVar_GetS32("gRandomizeSkipChildZelda", 0)) {
                             ImGui::SetTooltip("%s", "This option is disabled because \"Skip Child Zelda\" is enabled");
                         }
                         ImGui::PopItemFlag();


### PR DESCRIPTION
This PR aims to solve the last batch of stuff that I couldn't get in V1 of the UX overhaul. Specifically this issue: #676 

It adds default values for the rainbow bridge settings since they would default to "0 stones" for example instead of 3. Changed some other default values so they align with the (new) topmost options which makes them as vanilla as possible. Ice traps and loot options haven't been changed because "standard" options make more sense there.

This also adds a more graceful way of handling settings that conflict with each other. If "Skip Child Zelda" is now checked, "Skip Child Stealth" and "Shuffle Weird Egg" will have their cvar set to 0 and interaction is disabled. A hover text is added to clarify why these options are disabled. As a result, I could remove the additional Weird Egg conditional because it'll always be properly set to 0 on the ImGui side.

All the other things I had open in the above GitHub issue I kind of already picked up in the previous PR or turned out to already be correct, so this should be everything that was on my to-do list for the UX changes (for now). 

That just leaves https://github.com/HarbourMasters/Shipwright/issues/678 for the future.