### PR TITLE
Fixes Goron Wakeup animations

### DIFF
--- a/soh/soh/Enhancements/bootcommands.c
+++ b/soh/soh/Enhancements/bootcommands.c
@@ -44,7 +44,6 @@ void BootCommands_Init()
     CVar_RegisterS32("gUseTunicsCol", 0);
     CVar_RegisterS32("gGuardVision", 0);
     CVar_RegisterS32("gTimeFlowFileSelect", 0);
-    CVar_RegisterS32("gGoronSpeen", 0);
 }
 
 //void BootCommands_ParseBootArgs(char* str)

--- a/soh/soh/Enhancements/bootcommands.c
+++ b/soh/soh/Enhancements/bootcommands.c
@@ -44,6 +44,7 @@ void BootCommands_Init()
     CVar_RegisterS32("gUseTunicsCol", 0);
     CVar_RegisterS32("gGuardVision", 0);
     CVar_RegisterS32("gTimeFlowFileSelect", 0);
+    CVar_RegisterS32("gGoronSpeen", 0);
 }
 
 //void BootCommands_ParseBootArgs(char* str)

--- a/soh/src/overlays/actors/ovl_En_Go2/z_en_go2.c
+++ b/soh/src/overlays/actors/ovl_En_Go2/z_en_go2.c
@@ -141,7 +141,7 @@ typedef enum {
     /* 11 */ ENGO2_ANIM_11,
     /* 12 */ ENGO2_ANIM_12,
     /* 13 */ ENGO2_ANIM_13, // Fixed Goron Wakeup Animation
-    /* 14 */ ENGO2_ANIM_14 //Fixed Biggoron Wakeup Animation
+    /* 14 */ ENGO2_ANIM_14 // Fixed Biggoron Wakeup Animation
 } EnGo2Animation;
 
 static AnimationInfo sAnimationInfo[] = {

--- a/soh/src/overlays/actors/ovl_En_Go2/z_en_go2.c
+++ b/soh/src/overlays/actors/ovl_En_Go2/z_en_go2.c
@@ -139,7 +139,9 @@ typedef enum {
     /*  9 */ ENGO2_ANIM_9,
     /* 10 */ ENGO2_ANIM_10,
     /* 11 */ ENGO2_ANIM_11,
-    /* 12 */ ENGO2_ANIM_12
+    /* 12 */ ENGO2_ANIM_12,
+    /* 13 */ ENGO2_ANIM_13, // Fixed Goron Wakeup Animation
+    /* 14 */ ENGO2_ANIM_14 //Fixed Biggoron Wakeup Animation
 } EnGo2Animation;
 
 static AnimationInfo sAnimationInfo[] = {
@@ -149,7 +151,8 @@ static AnimationInfo sAnimationInfo[] = {
     { &gGoronAnim_002D80, 1.0f, 0.0f, -1.0f, 0x02, -8.0f }, { &gGoronAnim_00161C, 1.0f, 0.0f, -1.0f, 0x00, -8.0f },
     { &gGoronAnim_001A00, 1.0f, 0.0f, -1.0f, 0x00, -8.0f }, { &gGoronAnim_0021D0, 1.0f, 0.0f, -1.0f, 0x00, -8.0f },
     { &gGoronAnim_004930, 0.0f, 0.0f, -1.0f, 0x01, -8.0f }, { &gGoronAnim_000750, 1.0f, 0.0f, -1.0f, 0x00, -8.0f },
-    { &gGoronAnim_000D5C, 1.0f, 0.0f, -1.0f, 0x00, -8.0f },
+    { &gGoronAnim_000D5C, 1.0f, 0.0f, -1.0f, 0x00, -8.0f }, { &gGoronAnim_004930, 0.0f, 0.0f, -1.0f, 0x00, 0.0f },
+    { &gGoronAnim_004930, 0.0f, 1.0f, -1.0f, 0x01, 0.0f },
 };
 
 static EnGo2DustEffectData sDustEffectData[2][4] = {
@@ -1341,10 +1344,10 @@ void EnGo2_WakeUp(EnGo2* this, GlobalContext* globalCtx) {
     }
     if ((this->actor.params & 0x1F) == GORON_DMT_BIGGORON) {
         OnePointCutscene_Init(globalCtx, 4200, -99, &this->actor, MAIN_CAM);
-        Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENGO2_ANIM_10);
+        Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, (CVar_GetS32("gGoronSpeen", 0) == 1) ? ENGO2_ANIM_14 : ENGO2_ANIM_10);
         this->skelAnime.playSpeed = 0.5f;
     } else {
-        Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENGO2_ANIM_1);
+        Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, (CVar_GetS32("gGoronSpeen", 0) == 1) ? ENGO2_ANIM_13 : ENGO2_ANIM_1);
         this->skelAnime.playSpeed = 1.0f;
     }
     this->actionFunc = func_80A46B40;
@@ -1675,6 +1678,11 @@ void EnGo2_CurledUp(EnGo2* this, GlobalContext* globalCtx) {
 void func_80A46B40(EnGo2* this, GlobalContext* globalCtx) {
     u8 index = (this->actor.params & 0x1F);
     f32 height;
+    if (CVar_GetS32("gGoronSpeen", 0) == 1) {
+        // The morphFrames value seems to be what causes the spin.
+        this->skelAnime.morphRate = 0.0f;
+        this->skelAnime.morphWeight = 0.0f;
+    }
 
     if (this->unk_211 == true) {
         EnGo2_BiggoronAnimation(this);

--- a/soh/src/overlays/actors/ovl_En_Go2/z_en_go2.c
+++ b/soh/src/overlays/actors/ovl_En_Go2/z_en_go2.c
@@ -1344,10 +1344,10 @@ void EnGo2_WakeUp(EnGo2* this, GlobalContext* globalCtx) {
     }
     if ((this->actor.params & 0x1F) == GORON_DMT_BIGGORON) {
         OnePointCutscene_Init(globalCtx, 4200, -99, &this->actor, MAIN_CAM);
-        Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, (CVar_GetS32("gGoronSpeen", 0) == 1) ? ENGO2_ANIM_14 : ENGO2_ANIM_10);
+        Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ((CVar_GetS32("gGoronSpeen", 0) == 1) ? ENGO2_ANIM_10 : ENGO2_ANIM_14));
         this->skelAnime.playSpeed = 0.5f;
     } else {
-        Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, (CVar_GetS32("gGoronSpeen", 0) == 1) ? ENGO2_ANIM_13 : ENGO2_ANIM_1);
+        Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ((CVar_GetS32("gGoronSpeen", 0) == 1) ? ENGO2_ANIM_1 : ENGO2_ANIM_13));
         this->skelAnime.playSpeed = 1.0f;
     }
     this->actionFunc = func_80A46B40;
@@ -1678,11 +1678,6 @@ void EnGo2_CurledUp(EnGo2* this, GlobalContext* globalCtx) {
 void func_80A46B40(EnGo2* this, GlobalContext* globalCtx) {
     u8 index = (this->actor.params & 0x1F);
     f32 height;
-    if (CVar_GetS32("gGoronSpeen", 0) == 1) {
-        // The morphFrames value seems to be what causes the spin.
-        this->skelAnime.morphRate = 0.0f;
-        this->skelAnime.morphWeight = 0.0f;
-    }
 
     if (this->unk_211 == true) {
         EnGo2_BiggoronAnimation(this);


### PR DESCRIPTION
Fixes #80 

This fixes the Gorons' Wake Up animations so that they no longer spin when waking up. It seems to be related somehow to the `morphFrames` being set to `-8.0f` on those animations. Changing them to `0.0f` on the relevant animations causes the spin to not happen. Additionally, Biggoron has a glitchy frame at the start of his animation still, so I set the `startFrame` to `1.0f` on his and it looks pretty smooth. In order to preserve the spinny Goron behavior (since people seemed to like it) I added two new animations which are copies of the original ones with the fixes applied, and conditionally switch between them with a CVar named "gGoronSpeen" (can rename to gGoronSpin if the silliness is not appreciated). 0 is the default fixed behavior, while 1 is the old behavior. This CVar is not exposed in the UI, so you would have to edit your `shipofharkinian.json` for it

https://user-images.githubusercontent.com/21345721/180585526-f5c0d16c-46c1-431e-8e79-d595f5126cb1.mp4