### PR TITLE
Initialize staticSegment in Title_Init to NULL

### DIFF
--- a/soh/src/overlays/gamestates/ovl_title/z_title.c
+++ b/soh/src/overlays/gamestates/ovl_title/z_title.c
@@ -333,6 +333,7 @@ void Title_Init(GameState* thisx) {
     } else {
         quote = SetQuote();
 
+        this->staticSegment = NULL;
         //this->staticSegment = GAMESTATE_ALLOC_MC(&this->state, size);
         osSyncPrintf("z_title.c\n");
         //ASSERT(this->staticSegment != NULL);


### PR DESCRIPTION
Fixes potential crash in `Title_Main` since uninitialized data would be interpreted as a pointer.