### PR TITLE
Add option to allow the ocarina to be played faster

### DIFF
--- a/libultraship/libultraship/ImGuiImpl.cpp
+++ b/libultraship/libultraship/ImGuiImpl.cpp
@@ -975,6 +975,8 @@ namespace SohImGui {
                         Tooltip("The default response to Kaepora Gaebora is\nalways that you understood what he said");
                         EnhancementCheckbox("Fast Ocarina Playback", "gFastOcarinaPlayback");
                         Tooltip("Skip the part where the Ocarina playback is called when you play\na song");
+                        EnhancementCheckbox("Unlimited Ocarina Speed", "gDpadNoDropOcarinaInput");
+                        Tooltip("Prevent dropping inputs when playing the ocarina quickly");
                         EnhancementCheckbox("Instant Putaway", "gInstantPutaway");
                         Tooltip("Allow Link to put items away without having to wait around");
                         ImGui::EndMenu();

--- a/libultraship/libultraship/ImGuiImpl.cpp
+++ b/libultraship/libultraship/ImGuiImpl.cpp
@@ -975,7 +975,7 @@ namespace SohImGui {
                         Tooltip("The default response to Kaepora Gaebora is\nalways that you understood what he said");
                         EnhancementCheckbox("Fast Ocarina Playback", "gFastOcarinaPlayback");
                         Tooltip("Skip the part where the Ocarina playback is called when you play\na song");
-                        EnhancementCheckbox("Unlimited Ocarina Speed", "gDpadNoDropOcarinaInput");
+                        EnhancementCheckbox("Prevent Dropped Ocarina Inputs", "gDpadNoDropOcarinaInput");
                         Tooltip("Prevent dropping inputs when playing the ocarina quickly");
                         EnhancementCheckbox("Instant Putaway", "gInstantPutaway");
                         Tooltip("Allow Link to put items away without having to wait around");

--- a/soh/src/code/code_800EC960.c
+++ b/soh/src/code/code_800EC960.c
@@ -1552,7 +1552,7 @@ void func_800ED458(s32 arg0) {
 
     if (D_80130F3C != 0 && sOcarinaDropInputTimer != 0) {
         sOcarinaDropInputTimer--;
-        if (CVar_GetS32 ("gDpadNoDropOcarinaInput", 0) == 0) {
+        if (!CVar_GetS32("gDpadNoDropOcarinaInput", 0)) {
             return;
         }
     }

--- a/soh/src/code/code_800EC960.c
+++ b/soh/src/code/code_800EC960.c
@@ -1028,7 +1028,7 @@ s8 D_80131870 = 0;
 u8 D_80131874 = 0;
 u8 D_80131878 = 0;
 u8 D_8013187C = 0;
-u8 D_80131880 = 0;
+u8 sOcarinaDropInputTimer = 0;
 
 OcarinaNote sPierresSong[108] = {
     { 0xFF, 0, 0, 0, 0, 0, 0 },
@@ -1550,9 +1550,11 @@ void func_800ED458(s32 arg0) {
     u32 phi_v1_2;
     bool dpad = CVar_GetS32("gDpadOcarinaText", 0);
 
-    if (D_80130F3C != 0 && D_80131880 != 0) {
-        D_80131880--;
-        return;
+    if (D_80130F3C != 0 && sOcarinaDropInputTimer != 0) {
+        sOcarinaDropInputTimer--;
+        if (CVar_GetS32 ("gDpadNoDropOcarinaInput", 0) == 0) {
+            return;
+        }
     }
 
     if ((D_8016BA10 == 0) ||
@@ -2057,7 +2059,7 @@ void func_800EE6F4(void) {
         }
 
         if ((D_80130F3C != 0) && (sPrevOcarinaNoteVal != sCurOcarinaBtnVal)) {
-            D_80131880 = 1;
+            sOcarinaDropInputTimer = 1;
         }
 
         sPrevOcarinaNoteVal = sCurOcarinaBtnVal;
@@ -2110,7 +2112,7 @@ void func_800EE930(void) {
     sRecordingStaff.noteIdx = OCARINA_NOTE_INVALID;
     sRecordingStaff.state = 0xFF;
     sRecordingStaff.pos = 0;
-    D_80131880 = 0;
+    sOcarinaDropInputTimer = 0;
 }
 
 f32 D_80131C8C = 0.0f;


### PR DESCRIPTION
_Majora's Mask 3D_ made it so that you can play the ocarina really fast without dropping inputs, and this adds the option to make this game do the same. Specifically, this allows the player to input notes faster and doesn't involve playback of the song.

The name and tooltip for the option are open to any suggestion that makes it clearer what it does. It's also been suggested that this be merged with the Fast Ocarina Playback enhancement, but I decided to make them separate, at least for now, as one could also make the case that the two enhancements do two different, not-entirely-related things.