### PR TITLE
Rando: UX debug config crash fix

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -3896,7 +3896,6 @@ void DrawRandoEditor(bool& open) {
                             "Sets whether or not Ganon's Castle Trials are required to enter Ganon's Tower.");
                         ImGui::Separator();
                     }
-                    ImGui::PopItemWidth();
                     
                     // COLUMN 2 - Shuffle Settings
                     ImGui::TableNextColumn();


### PR DESCRIPTION
Previous UX PR added another instance of `ImGui::PopItemWidth();` just before the rainbow bridge option to make the sliders fit correctly, but it left another instance of it near the end of the column. This made ImGui crash when built in the Debug configuration.

This removes that now duplicate instance of `ImGui::PopItemWidth();`.

Woops.