### PR TITLE
ADD: Rando Spiritual Stones Power

### DIFF
--- a/soh/src/overlays/actors/ovl_Demo_Effect/z_demo_effect.c
+++ b/soh/src/overlays/actors/ovl_Demo_Effect/z_demo_effect.c
@@ -1659,6 +1659,7 @@ void DemoEffect_UpdateJewelChild(DemoEffect* this, GlobalContext* globalCtx) {
     } else {
         // Contrary to it's adult conterpart Authenthic doesn't use DemoEffect_SetJewelColor(this, 1.0f); here
     }
+}
 
 /**
  * Update Function for the Dust Actor.

--- a/soh/src/overlays/actors/ovl_Demo_Effect/z_demo_effect.c
+++ b/soh/src/overlays/actors/ovl_Demo_Effect/z_demo_effect.c
@@ -1544,18 +1544,26 @@ void DemoEffect_UpdateJewelAdult(DemoEffect* this, GlobalContext* globalCtx) {
     if (gSaveContext.n64ddFlag) {
         switch (this->jewel.type) {
             case DEMO_EFFECT_JEWEL_KOKIRI:
-                if (gSaveContext.inventory.questItems == QUEST_KOKIRI_EMERALD) {
+                if (CHECK_QUEST_ITEM(QUEST_KOKIRI_EMERALD)) {
                     DemoEffect_SetJewelColor(this, 1.0f);
-                } else if (gSaveContext.inventory.questItems == !QUEST_KOKIRI_EMERALD) {
+                } else {
                     DemoEffect_SetJewelColor(this, 0.0f);
                 }
-                break;
+            break;
             case DEMO_EFFECT_JEWEL_GORON:
-                DemoEffect_SetJewelColor(this, 0.5f);
-                break;
+                if (CHECK_QUEST_ITEM(QUEST_GORON_RUBY)) {
+                    DemoEffect_SetJewelColor(this, 1.0f);
+                } else {
+                    DemoEffect_SetJewelColor(this, 0.0f);
+                }
+            break;
             case DEMO_EFFECT_JEWEL_ZORA:
-                DemoEffect_SetJewelColor(this, 1.0f);
-                break;
+                if (CHECK_QUEST_ITEM(QUEST_ZORA_SAPPHIRE)) {
+                    DemoEffect_SetJewelColor(this, 1.0f);
+                } else {
+                    DemoEffect_SetJewelColor(this, 0.0f);
+                }
+            break;
         }
     } else {
     DemoEffect_SetJewelColor(this, 1.0f);
@@ -1623,6 +1631,32 @@ void DemoEffect_UpdateJewelChild(DemoEffect* this, GlobalContext* globalCtx) {
     thisx->shape.rot.y += 0x0400;
     DemoEffect_PlayJewelSfx(this, globalCtx);
     this->effectFlags &= ~1;
+
+    if (gSaveContext.n64ddFlag) {
+        switch (this->jewel.type) {
+            case DEMO_EFFECT_JEWEL_KOKIRI:
+                if (CHECK_QUEST_ITEM(QUEST_KOKIRI_EMERALD)) {
+                    DemoEffect_SetJewelColor(this, 1.0f);
+                } else {
+                    DemoEffect_SetJewelColor(this, 0.0f);
+                }
+                break;
+            case DEMO_EFFECT_JEWEL_GORON:
+                if (CHECK_QUEST_ITEM(QUEST_GORON_RUBY)) {
+                    DemoEffect_SetJewelColor(this, 1.0f);
+                } else {
+                    DemoEffect_SetJewelColor(this, 0.0f);
+                }
+                break;
+            case DEMO_EFFECT_JEWEL_ZORA:
+                if (CHECK_QUEST_ITEM(QUEST_ZORA_SAPPHIRE)) {
+                    DemoEffect_SetJewelColor(this, 1.0f);
+                } else {
+                    DemoEffect_SetJewelColor(this, 0.0f);
+                }
+                break;
+        }
+    }
 }
 
 /**

--- a/soh/src/overlays/actors/ovl_Demo_Effect/z_demo_effect.c
+++ b/soh/src/overlays/actors/ovl_Demo_Effect/z_demo_effect.c
@@ -1656,8 +1656,9 @@ void DemoEffect_UpdateJewelChild(DemoEffect* this, GlobalContext* globalCtx) {
                 }
                 break;
         }
+    } else {
+        // Contrary to it's adult conterpart Authenthic doesn't use DemoEffect_SetJewelColor(this, 1.0f); here
     }
-}
 
 /**
  * Update Function for the Dust Actor.

--- a/soh/src/overlays/actors/ovl_Demo_Effect/z_demo_effect.c
+++ b/soh/src/overlays/actors/ovl_Demo_Effect/z_demo_effect.c
@@ -1540,7 +1540,26 @@ void DemoEffect_UpdateJewelAdult(DemoEffect* this, GlobalContext* globalCtx) {
     this->jewel.timer++;
     this->actor.shape.rot.y += 0x0400;
     DemoEffect_PlayJewelSfx(this, globalCtx);
+
+    if (gSaveContext.n64ddFlag) {
+        switch (this->jewel.type) {
+            case DEMO_EFFECT_JEWEL_KOKIRI:
+                if (gSaveContext.inventory.questItems == QUEST_KOKIRI_EMERALD) {
+                    DemoEffect_SetJewelColor(this, 1.0f);
+                } else if (gSaveContext.inventory.questItems == !QUEST_KOKIRI_EMERALD) {
+                    DemoEffect_SetJewelColor(this, 0.0f);
+                }
+                break;
+            case DEMO_EFFECT_JEWEL_GORON:
+                DemoEffect_SetJewelColor(this, 0.5f);
+                break;
+            case DEMO_EFFECT_JEWEL_ZORA:
+                DemoEffect_SetJewelColor(this, 1.0f);
+                break;
+        }
+    } else {
     DemoEffect_SetJewelColor(this, 1.0f);
+    }
 }
 
 /**


### PR DESCRIPTION
Usage of the famous unused function of the old concept of OOT where the spiritual stone lose their power and needed to be refilled, this case is now used in rando to show if the player got the stone or not

Will also close issue https://github.com/HarbourMasters/Shipwright/issues/683

https://user-images.githubusercontent.com/47987542/180628774-5e4a5aad-9389-4b75-950c-6711f46548ec.mp4

