### PR TITLE
Rando: Added extra flyout for item fanfares

### DIFF
--- a/libultraship/libultraship/ImGuiImpl.cpp
+++ b/libultraship/libultraship/ImGuiImpl.cpp
@@ -1396,8 +1396,8 @@ namespace SohImGui {
                 }
             }
 
+            // Randomizer Menu
             ImGui::SetCursorPosY(0.0f);
-
             if (ImGui::BeginMenu("Randomizer"))
             {
                 EnhancementCheckbox("Randomizer Settings", "gRandomizerSettingsEnabled");
@@ -1414,13 +1414,10 @@ namespace SohImGui {
                         "of item that is obtained. This can make fanfares\n"
                         "longer than usual in some cases."
                     );
-
                     ImGui::EndMenu();
                 }
-
                 ImGui::EndMenu();
             }
-
             ImGui::EndMenuBar();
         }
 

--- a/libultraship/libultraship/ImGuiImpl.cpp
+++ b/libultraship/libultraship/ImGuiImpl.cpp
@@ -1382,6 +1382,19 @@ namespace SohImGui {
             for (const auto& category : windowCategories) {
                 ImGui::SetCursorPosY(0.0f);
                 if (ImGui::BeginMenu(category.first.c_str())) {
+                    if (category.first == "Randomizer") {
+                        if (ImGui::BeginMenu("Rando Enhancements"))
+                        {
+                            EnhancementCheckbox("Dynamic Item Fanfares", "gRandoFanfareByItemType");
+                            Tooltip(
+                                "Change what fanfare is played to match the type of item that is\n"
+                                "obtained. This can make fanfares longer than usual in some cases."
+                            );
+
+                            ImGui::EndMenu();
+                        }
+                        ImGui::Separator();
+                    }
                     for (const std::string& name : category.second) {
                         std::string varName(name);
                         varName.erase(std::remove_if(varName.begin(), varName.end(), [](unsigned char x) { return std::isspace(x); }), varName.end());

--- a/libultraship/libultraship/ImGuiImpl.cpp
+++ b/libultraship/libultraship/ImGuiImpl.cpp
@@ -1408,11 +1408,11 @@ namespace SohImGui {
                 ImGui::Separator();
                 if (ImGui::BeginMenu("Rando Enhancements"))
                 {
-                    EnhancementCheckbox("Dynamic Item Fanfares", "gRandoFanfareByItemType");
+                    EnhancementCheckbox("Quest Item Fanfares", "gRandoQuestItemFanfares");
                     Tooltip(
-                        "Change what fanfare is played to match the type\n"
-                        "of item that is obtained. This can make fanfares\n"
-                        "longer than usual in some cases."
+                        "Play unique fanfares when obtaining quest items\n"
+                        "(medallions/stones/songs). Note that these fanfares\n"
+                        "are longer than usual."
                     );
                     ImGui::EndMenu();
                 }

--- a/libultraship/libultraship/ImGuiImpl.cpp
+++ b/libultraship/libultraship/ImGuiImpl.cpp
@@ -1381,30 +1381,44 @@ namespace SohImGui {
 
             for (const auto& category : windowCategories) {
                 ImGui::SetCursorPosY(0.0f);
-                if (ImGui::BeginMenu(category.first.c_str())) {
-                    if (category.first == "Randomizer") {
-                        if (ImGui::BeginMenu("Rando Enhancements"))
-                        {
-                            EnhancementCheckbox("Dynamic Item Fanfares", "gRandoFanfareByItemType");
-                            Tooltip(
-                                "Change what fanfare is played to match the type of item that is\n"
-                                "obtained. This can make fanfares longer than usual in some cases."
-                            );
+                if (category.first != "Randomizer") {
+                    if (ImGui::BeginMenu(category.first.c_str())) {
+                        for (const std::string& name : category.second) {
+                            std::string varName(name);
+                            varName.erase(std::remove_if(varName.begin(), varName.end(), [](unsigned char x) { return std::isspace(x); }), varName.end());
+                            std::string toggleName = "g" + varName + "Enabled";
 
-                            ImGui::EndMenu();
+                            EnhancementCheckbox(name.c_str(), toggleName.c_str());
+                            customWindows[name].enabled = CVar_GetS32(toggleName.c_str(), 0);
                         }
-                        ImGui::Separator();
+                        ImGui::EndMenu();
                     }
-                    for (const std::string& name : category.second) {
-                        std::string varName(name);
-                        varName.erase(std::remove_if(varName.begin(), varName.end(), [](unsigned char x) { return std::isspace(x); }), varName.end());
-                        std::string toggleName = "g" + varName + "Enabled";
+                }
+            }
 
-                        EnhancementCheckbox(name.c_str(), toggleName.c_str());
-                        customWindows[name].enabled = CVar_GetS32(toggleName.c_str(), 0);
-                    }
+            ImGui::SetCursorPosY(0.0f);
+
+            if (ImGui::BeginMenu("Randomizer"))
+            {
+                EnhancementCheckbox("Randomizer Settings", "gRandomizerSettingsEnabled");
+                customWindows["Randomizer Settings"].enabled = CVar_GetS32("gRandomizerSettingsEnabled", 0);
+                EnhancementCheckbox("Item Tracker", "gItemTrackerEnabled");
+                customWindows["Item Tracker"].enabled = CVar_GetS32("gItemTrackerEnabled", 0);
+
+                ImGui::Separator();
+                if (ImGui::BeginMenu("Rando Enhancements"))
+                {
+                    EnhancementCheckbox("Dynamic Item Fanfares", "gRandoFanfareByItemType");
+                    Tooltip(
+                        "Change what fanfare is played to match the type\n"
+                        "of item that is obtained. This can make fanfares\n"
+                        "longer than usual in some cases."
+                    );
+
                     ImGui::EndMenu();
                 }
+
+                ImGui::EndMenu();
             }
 
             ImGui::EndMenuBar();


### PR DESCRIPTION
Adds an extra menu for future rando specific enhancements that can be toggled on the fly. 

Created for: https://github.com/HarbourMasters/Shipwright/pull/746

![Randomizer enhancement poc](https://user-images.githubusercontent.com/4244591/180642992-9b3044de-1396-45b0-b0f2-8bcd9912008c.gif)

That said, I'd like some input on how to move forward with this. Considering we might need more menus in the future, would it better to completely move away from using the function that autopopulates the "Randomizer" tab with how other parts of the SoH UI are defined? AKA, define the menu manually and integrate the external windows like "Controller Configuration" is handled right now?

As it stands, it's difficult to add more menu items or re-order them easily.

I'd love to hear what others think.