### PR TITLE
add pkgconfig to the list of dependencies for mac

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -48,7 +48,7 @@ make -j $(nproc) OPTFLAGS=-O2 DEBUG=0
 
 ## macOS
 
-1. Requires Xcode (or xcode-tools) && `sdl2, libpng, glew, dylibbundler` (can be installed via brew, etc)
+1. Requires Xcode (or xcode-tools) && `sdl2, libpng, glew, pkgconfig, dylibbundler` (can be installed via homebrew, macports, etc)
 ```bash
 # Clone the repo
 git clone https://github.com/HarbourMasters/Shipwright.git

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -48,7 +48,7 @@ make -j $(nproc) OPTFLAGS=-O2 DEBUG=0
 
 ## macOS
 
-1. Requires Xcode (or xcode-tools) && `sdl2, libpng, glew, pkgconfig, dylibbundler` (can be installed via homebrew, macports, etc)
+1. Requires Xcode (or xcode-tools) && `sdl2, libpng, glew, cmake, pkgconfig, dylibbundler` (can be installed via homebrew, macports, etc)
 ```bash
 # Clone the repo
 git clone https://github.com/HarbourMasters/Shipwright.git


### PR DESCRIPTION
lots of people are trying to build and they don't have pkg-config in
their paths. hopefully this removes some confusion.