### PR TITLE
Fix build link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Refer to the [building instructions](BUILDING.md) to compile SoH.
 - Confirm that `zapd.exe` exists in the `/assets/extractor` folder
 
 ## Nightly Builds
-Nightly builds of Ship of Harkinian are available [here](https://builds.shipofharkinian.com/job/SoH_Multibranch/job/develop)
+Nightly builds of Ship of Harkinian are available [here](https://builds.shipofharkinian.com/)
 
 
 ## The Harbour Masters Are...


### PR DESCRIPTION
Currently leads to a 404 page since there's no longer a branch called "develop", I've just sent it to the main page for the builds site