### PR TITLE
Unrestricted warping in randomizer

### DIFF
--- a/soh/src/code/z_message_PAL.c
+++ b/soh/src/code/z_message_PAL.c
@@ -2736,7 +2736,7 @@ void Message_DrawMain(GlobalContext* globalCtx, Gfx** p) {
                     if (msgCtx->lastPlayedSong < OCARINA_SONG_SARIAS &&
                         (msgCtx->ocarinaAction < OCARINA_ACTION_PLAYBACK_MINUET ||
                          msgCtx->ocarinaAction >= OCARINA_ACTION_PLAYBACK_SARIA)) {
-                        if (msgCtx->disableWarpSongs || interfaceCtx->restrictions.warpSongs == 3) {
+                        if (msgCtx->disableWarpSongs || (interfaceCtx->restrictions.warpSongs == 3 && !gSaveContext.n64ddFlag)) {
                             Message_StartTextbox(globalCtx, 0x88C, NULL); // "You can't warp here!"
                             globalCtx->msgCtx.ocarinaMode = OCARINA_MODE_04;
                         } else if ((gSaveContext.eventInf[0] & 0xF) != 1) {


### PR DESCRIPTION
Closes #680 

Unsure of what `msgCtx->disableWarpSongs` is, but I verified it is not the reason warps are disabled in GTG & Ganons Castle, the `interfaceCtx->restrictions.warpSongs == 3` is the culprit. 

Manual tested after change:
- Warping within GTG still not allowed in vanilla save
- Warping within Ganon's castle still not allowed in vanilla save
- Warping within GTG allowed in randomizer save
- Warping within Ganon's castle allowed in randomizer save