### PR TITLE
Use all 3 axes for gyro aim

### DIFF
--- a/libultraship/libultraship/Controller.cpp
+++ b/libultraship/libultraship/Controller.cpp
@@ -76,6 +76,10 @@ namespace Ship {
 		// Gyro
 		padToBuffer.gyro_x = getGyroX(virtualSlot);
 		padToBuffer.gyro_y = getGyroY(virtualSlot);
+		padToBuffer.gyro_z = getGyroZ(virtualSlot);
+
+		// Accel
+		padToBuffer.accel_pitch = getAccelPitch(virtualSlot);
 
 		padBuffer.push_front(padToBuffer);
 		if (pad != nullptr) {
@@ -85,8 +89,10 @@ namespace Ship {
 			if (pad->stick_y == 0) pad->stick_y = padFromBuffer.stick_y;
 			if (pad->gyro_x == 0) pad->gyro_x = padFromBuffer.gyro_x;
 			if (pad->gyro_y == 0) pad->gyro_y = padFromBuffer.gyro_y;
+			if (pad->gyro_z == 0) pad->gyro_z = padFromBuffer.gyro_z;
 			if (pad->right_stick_x == 0) pad->right_stick_x = padFromBuffer.right_stick_x;
 			if (pad->right_stick_y == 0) pad->right_stick_y = padFromBuffer.right_stick_y;
+			if (pad->accel_pitch == 0) pad->accel_pitch = padFromBuffer.accel_pitch;
 		}
 
 		while (padBuffer.size() > 6) {
@@ -126,6 +132,14 @@ namespace Ship {
 
 	float& Controller::getGyroY(int32_t virtualSlot) {
 		return ButtonData[virtualSlot]->gyroY;
+	}
+
+	float& Controller::getGyroZ(int32_t virtualSlot) {
+		return ButtonData[virtualSlot]->gyroZ;
+	}
+
+	float& Controller::getAccelPitch(int32_t virtualSlot) {
+		return ButtonData[virtualSlot]->accelPitch;
 	}
 
 	std::shared_ptr<DeviceProfile> Controller::getProfile(int32_t virtualSlot) {

--- a/libultraship/libultraship/Controller.h
+++ b/libultraship/libultraship/Controller.h
@@ -16,7 +16,14 @@ namespace Ship {
 	enum GyroData {
 		DRIFT_X,
 		DRIFT_Y,
-		GYRO_SENSITIVITY
+		GYRO_SENSITIVITY,
+		DRIFT_Z // After sensitivity for backwards compatibility
+	};
+
+	enum AccelData {
+		ACCEL_X,
+		ACCEL_Y,
+		ACCEL_Z
 	};
 
 	enum DeviceProfileVersion {
@@ -34,6 +41,7 @@ namespace Ship {
 		std::unordered_map<int32_t, float> AxisDeadzones;
 		std::unordered_map<int32_t, float> AxisMinimumPress;
 		std::unordered_map<int32_t, float> GyroData;
+		std::unordered_map<int32_t, float> AccelData;
 		std::map<int32_t, int32_t> Mappings;
 	};
 
@@ -46,6 +54,7 @@ namespace Ship {
 		virtual bool Connected() const = 0;
 		virtual bool CanRumble() const = 0;
 		virtual bool CanGyro() const = 0;
+		virtual bool CanAccel() const = 0;
 		virtual void CreateDefaultBinding(int32_t virtualSlot) = 0;
 		virtual void ClearRawPress() = 0;
 		virtual int32_t ReadRawPress() = 0;
@@ -62,6 +71,8 @@ namespace Ship {
 		int32_t& getPressedButtons(int32_t virtualSlot);
 		float& getGyroX(int32_t virtualSlot);
 		float& getGyroY(int32_t virtualSlot);
+		float& getGyroZ(int32_t virtualSlot);
+		float& getAccelPitch(int32_t virtualSlot);
 		bool IsRumbling();
 		std::string GetGuid();
 
@@ -81,6 +92,8 @@ namespace Ship {
 				int8_t rightStickY = 0;
 				float gyroX = 0.0f;
 				float gyroY = 0.0f;
+				float gyroZ = 0.0f;
+				float accelPitch = 0.0f;
 			};
 
 			std::unordered_map<int32_t, std::shared_ptr<DeviceProfile>> profiles;

--- a/libultraship/libultraship/DummyController.cpp
+++ b/libultraship/libultraship/DummyController.cpp
@@ -35,6 +35,10 @@ namespace Ship {
 		return false;
 	}
 
+	bool DummyController::CanAccel() const {
+		return false;
+	}
+
 	void DummyController::CreateDefaultBinding(int32_t slot) {
 		
 	}

--- a/libultraship/libultraship/DummyController.h
+++ b/libultraship/libultraship/DummyController.h
@@ -16,6 +16,7 @@ namespace Ship {
 		bool Connected() const override;
 		bool CanRumble() const override;
 		bool CanGyro() const override;
+		bool CanAccel()  const override;
 		void ClearRawPress() override;
 		int32_t ReadRawPress() override;
 		bool HasPadConf() const;

--- a/libultraship/libultraship/InputEditor.cpp
+++ b/libultraship/libultraship/InputEditor.cpp
@@ -124,9 +124,13 @@ namespace Ship {
 			DrawButton("START", BTN_START, CurrentPort, &BtnReading);
 			SEPARATION();
 	#ifdef __SWITCH__
-		SohImGui::EndGroupPanel(IsKeyboard ? 7.0f : 56.0f);
+		SohImGui::EndGroupPanel(IsKeyboard ? 7.0f :
+								Backend->CanGyro() ? 90.0f :
+								56.0f);
 	#else
-		SohImGui::EndGroupPanel(IsKeyboard ? 7.0f : 48.0f);
+		SohImGui::EndGroupPanel(IsKeyboard ? 7.0f :
+								Backend->CanGyro() ? 82.0f :
+								48.0f);
 	#endif
 		ImGui::SameLine();
 		SohImGui::BeginGroupPanel("Digital Pad", ImVec2(150, 20));
@@ -136,9 +140,13 @@ namespace Ship {
 			DrawButton("Right", BTN_DRIGHT, CurrentPort, &BtnReading);
 			SEPARATION();
 	#ifdef __SWITCH__
-		SohImGui::EndGroupPanel(IsKeyboard ? 53.0f : 122.0f);
+		SohImGui::EndGroupPanel(IsKeyboard ? 53.0f :
+								Backend->CanGyro() ? 156.0f :
+								122.0f);
 	#else
-		SohImGui::EndGroupPanel(IsKeyboard ? 53.0f : 94.0f);
+		SohImGui::EndGroupPanel(IsKeyboard ? 53.0f :
+								Backend->CanGyro() ? 128.0f :
+								94.0f);
 	#endif
 		ImGui::SameLine();
 		SohImGui::BeginGroupPanel("Analog Stick", ImVec2(150, 20));
@@ -177,9 +185,13 @@ namespace Ship {
 				ImGui::Dummy(ImVec2(0, 6));
 			}
 		#ifdef __SWITCH__
-			SohImGui::EndGroupPanel(IsKeyboard ? 52.0f : 52.0f);
+			SohImGui::EndGroupPanel(IsKeyboard ? 52.0f :
+									Backend->CanGyro() ? 86.0f :
+									52.0f);
 		#else
-			SohImGui::EndGroupPanel(IsKeyboard ? 52.0f : 24.0f);
+			SohImGui::EndGroupPanel(IsKeyboard ? 52.0f :
+									Backend->CanGyro() ? 58.0f :
+									24.0f);
 		#endif
 		ImGui::SameLine();
 
@@ -218,9 +230,9 @@ namespace Ship {
 					ImGui::PopItemWidth();
 				ImGui::EndChild();
 		#ifdef __SWITCH__
-			SohImGui::EndGroupPanel(43.0f);
+			SohImGui::EndGroupPanel(Backend->CanGyro() ? 77.0f : 43.0f);
 		#else
-			SohImGui::EndGroupPanel(14.0f);
+			SohImGui::EndGroupPanel(Backend->CanGyro() ? 48.0f : 14.0f);
 		#endif
 		}
 
@@ -247,6 +259,10 @@ namespace Ship {
 				if (ImGui::Button("Recalibrate Gyro##RGyro")) {
 					profile->GyroData[DRIFT_X] = 0.0f;
 					profile->GyroData[DRIFT_Y] = 0.0f;
+					profile->GyroData[DRIFT_Z] = 0.0f;
+					profile->AccelData[ACCEL_X] = 0.0f;
+					profile->AccelData[ACCEL_Y] = 0.0f;
+					profile->AccelData[ACCEL_Z] = 0.0f;
 				}
 				ImGui::SetCursorPosX(cursorX);
 				DrawVirtualStick("##GyroPreview", ImVec2(-10.0f * Backend->getGyroY(CurrentPort), 10.0f * Backend->getGyroX(CurrentPort)));
@@ -254,9 +270,9 @@ namespace Ship {
 				ImGui::SameLine();
 				ImGui::SetCursorPosX(ImGui::GetCursorPosX() + 5);
 			#ifdef __WIIU__
-				ImGui::BeginChild("##GyInput", ImVec2(90 * 2, 85 * 2), false);
+				ImGui::BeginChild("##GyInput", ImVec2(90 * 2, 120 * 2), false);
 			#else
-				ImGui::BeginChild("##GyInput", ImVec2(90, 85), false);
+				ImGui::BeginChild("##GyInput", ImVec2(90, 120), false);
 			#endif
 				ImGui::Text("Drift X");
 			#ifdef __WIIU__
@@ -273,6 +289,14 @@ namespace Ship {
 				ImGui::PushItemWidth(80);
 			#endif
 				ImGui::InputFloat("##GDriftY", &profile->GyroData[DRIFT_Y], 1.0f, 0.0f, "%.1f");
+				ImGui::PopItemWidth();
+				ImGui::Text("Drift Z");
+			#ifdef __WIIU__
+				ImGui::PushItemWidth(80 * 2);
+			#else
+				ImGui::PushItemWidth(80);
+			#endif
+				ImGui::InputFloat("##GDriftZ", &profile->GyroData[DRIFT_Z], 1.0f, 0.0f, "%.1f");
 				ImGui::PopItemWidth();
 				ImGui::EndChild();
 		#ifdef __SWITCH__
@@ -319,7 +343,9 @@ namespace Ship {
 				ImGui::PopItemWidth();
 			}
 			ImGui::Dummy(ImVec2(0, 5));
-		SohImGui::EndGroupPanel(IsKeyboard ? 0.0f : 2.0f);
+		SohImGui::EndGroupPanel(IsKeyboard ? 0.0f :
+								Backend->CanGyro() ? 37.0f :
+								2.0f);
 	}
 
 	void InputEditor::DrawHud() {
@@ -331,13 +357,13 @@ namespace Ship {
 
 #ifdef __SWITCH__
 		ImVec2 minSize = ImVec2(641, 250);
-		ImVec2 maxSize = ImVec2(2200, 505);
+		ImVec2 maxSize = ImVec2(2200, 540);
 #elif defined(__WIIU__)
 		ImVec2 minSize = ImVec2(641 * 2, 250 * 2);
-		ImVec2 maxSize = ImVec2(1200 * 2, 290 * 2);
+		ImVec2 maxSize = ImVec2(1200 * 2, 325 * 2);
 #else
 		ImVec2 minSize = ImVec2(641, 250);
-		ImVec2 maxSize = ImVec2(1200, 290);
+		ImVec2 maxSize = ImVec2(1200, 325);
 #endif
 
 		ImGui::SetNextWindowSizeConstraints(minSize, maxSize);

--- a/libultraship/libultraship/KeyboardController.cpp
+++ b/libultraship/libultraship/KeyboardController.cpp
@@ -114,6 +114,10 @@ namespace Ship {
 		return false;
 	}
 
+	bool KeyboardController::CanAccel() const {
+		return false;
+	}
+
 	void KeyboardController::ClearRawPress() {
 		lastKey = -1;
 	}

--- a/libultraship/libultraship/KeyboardController.h
+++ b/libultraship/libultraship/KeyboardController.h
@@ -16,6 +16,7 @@ namespace Ship {
 			bool Connected() const override;
 			bool CanRumble() const override;
 			bool CanGyro() const override;
+			bool CanAccel() const override;
 			void ClearRawPress() override;
 			int32_t ReadRawPress() override;
 			void ReleaseAllButtons();

--- a/libultraship/libultraship/Lib/Fast3D/U64/PR/ultra64/controller.h
+++ b/libultraship/libultraship/Lib/Fast3D/U64/PR/ultra64/controller.h
@@ -116,9 +116,11 @@ typedef struct {
     /* 0x04 */ uint8_t err_no;
     /* 0x05 */ float gyro_x;
     /* 0x09 */ float gyro_y;
-    /* 0x1C */ int8_t right_stick_x;
-    /* 0x20 */ int8_t right_stick_y;
-} OSContPad; // size = 0x22
+    /* 0x1C */ float gyro_z;
+    /* 0x20 */ int8_t right_stick_x;
+    /* 0x21 */ int8_t right_stick_y;
+    /* 0x22 */ float accel_pitch;
+} OSContPad; // size = 0x26
 
 typedef struct {
     /* 0x00 */ u8 rumble;

--- a/libultraship/libultraship/SDLController.h
+++ b/libultraship/libultraship/SDLController.h
@@ -12,6 +12,7 @@ namespace Ship {
 			void WriteToSource(int32_t virtualSlot, ControllerCallback* controller) override;
 			bool Connected() const override;
 			bool CanGyro() const override;
+			bool CanAccel() const override;
 			bool CanRumble() const override;
 			bool Open();
 			void ClearRawPress() override;
@@ -35,6 +36,7 @@ namespace Ship {
 			SDL_GameController* Cont;
 			int32_t physicalSlot;
 			bool supportsGyro;
+			bool supportsAccel;
 			void NormalizeStickAxis(SDL_GameControllerAxis axisX, SDL_GameControllerAxis axisY, int16_t axisThreshold, int32_t virtualSlot);
 			bool Close();
 	};

--- a/libultraship/libultraship/UltraController.h
+++ b/libultraship/libultraship/UltraController.h
@@ -126,9 +126,11 @@ typedef struct {
     /* 0x04 */ uint8_t err_no;
     /* 0x05 */ float gyro_x;
     /* 0x09 */ float gyro_y;
-    /* 0x1C */ int8_t right_stick_x;
-    /* 0x20 */ int8_t right_stick_y;
-} OSContPad; // size = 0x24
+    /* 0x1C */ float gyro_z;
+    /* 0x20 */ int8_t right_stick_x;
+    /* 0x21 */ int8_t right_stick_y;
+    /* 0x22 */ float accel_pitch;
+} OSContPad; // size = 0x26
 
 typedef struct {
     /* 0x00 */ uint8_t rumble;

--- a/libultraship/libultraship/WiiUController.cpp
+++ b/libultraship/libultraship/WiiUController.cpp
@@ -43,6 +43,8 @@ namespace Ship {
             getRightStickY(i) = 0;
             getGyroX(i) = 0;
             getGyroY(i) = 0;
+            getGyroZ(i) = 0;
+            getAccelPitch(i) = 0;
         }
     }
 
@@ -69,6 +71,8 @@ namespace Ship {
         getRightStickY(virtualSlot) = 0;
         getGyroX(virtualSlot) = 0;
         getGyroY(virtualSlot) = 0;
+        getGyroZ(virtualSlot) = 0;
+        getAccelPitch(virtualSlot) = 0;
 
         if (error != KPAD_ERROR_OK) {
             return;

--- a/libultraship/libultraship/WiiUController.h
+++ b/libultraship/libultraship/WiiUController.h
@@ -15,6 +15,7 @@ namespace Ship {
             void WriteToSource(int32_t virtualSlot, ControllerCallback* controller) override;
             bool Connected() const override { return connected; };
             bool CanGyro() const override { return false; }
+            bool CanAccel() const override { return false; }
             bool CanRumble() const override { return true; };
 
             void ClearRawPress() override;

--- a/libultraship/libultraship/WiiUGamepad.h
+++ b/libultraship/libultraship/WiiUGamepad.h
@@ -14,6 +14,7 @@ namespace Ship {
             void WriteToSource(int32_t virtualSlot, ControllerCallback* controller) override;
             bool Connected() const override { return connected; };
             bool CanGyro() const override { return true; }
+            bool CanAccel() const override { return true; }
             bool CanRumble() const override { return true; };
 
             void ClearRawPress() override;

--- a/soh/soh/Enhancements/bootcommands.c
+++ b/soh/soh/Enhancements/bootcommands.c
@@ -30,6 +30,9 @@ void BootCommands_Init()
 #if defined(__SWITCH__) || defined(__WIIU__)
     CVar_RegisterS32("gControlNav", 1); // always enable controller nav on switch/wii u
 #endif
+#ifdef __WIIU__
+    CVar_RegisterS32("gGyroAxis", 1); // default to Z-axis instead of Y because of how the gamepad is held
+#endif
 }
 
 //void BootCommands_ParseBootArgs(char* str)

--- a/soh/soh/Enhancements/controls/GameControlEditor.cpp
+++ b/soh/soh/Enhancements/controls/GameControlEditor.cpp
@@ -243,6 +243,13 @@ namespace GameControlEditor {
         UIWidgets::PaddedEnhancementCheckbox("Disable Auto-Centering in First Person View", "gDisableAutoCenterView");
         DrawHelpIcon("Prevents the C-Up view from auto-centering, allowing for Gyro Aiming");
         UIWidgets::EnhancementSliderFloat("Camera Sensitivity: %d %%", "##Sensitivity", "gCameraSensitivity", 0.01f, 5.0f, "", 1.0f, true, true);
+		ImGui::SetCursorPosX(ImGui::GetCursorPosX() + 5);
+        ImGui::BeginChild("##GyInput", ImVec2(0, 0), false);
+            UIWidgets::PaddedText("Gyro Aiming Axis");
+            UIWidgets::EnhancementRadioButton("Y-axis", "gGyroAxis", 0);
+            UIWidgets::EnhancementRadioButton("Z-axis", "gGyroAxis", 1);
+            UIWidgets::EnhancementRadioButton("Automatic", "gGyroAxis", 2);
+        ImGui::EndChild();
     }
 
     void DrawUI(bool& open) {

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -11228,6 +11228,24 @@ s16 func_8084ABD8(PlayState* play, Player* this, s32 arg2, s16 arg3) {
     s16 temp2;
     s16 temp3;
 
+    // Determine gyro axis (or mix) for vertical aim
+    float yGyroAim, yAxisAmt, zAxisAmt, effectiveY, effectiveZ;
+    switch (CVar_GetS32("gGyroAxis", 0)) {
+        case 0:
+            yGyroAim = sControlInput->cur.gyro_y;
+            break;
+        case 1:
+            yGyroAim = sControlInput->cur.gyro_z;
+            break;
+        case 2:
+            yAxisAmt = cosf(sControlInput->cur.accel_pitch);
+            zAxisAmt = sinf(sControlInput->cur.accel_pitch);
+            effectiveY = sControlInput->cur.gyro_y * yAxisAmt;
+            effectiveZ = sControlInput->cur.gyro_z * zAxisAmt;
+            yGyroAim = effectiveY - effectiveZ;
+            break;
+    }
+
     if (!func_8002DD78(this) && !func_808334B4(this) && (arg2 == 0)) {
         if (!CVar_GetS32("gDisableAutoCenterView", 0)) {
             temp2 = sControlInput->rel.stick_y * 240.0f * (CVar_GetS32("gInvertYAxis", 1) ? 1 : -1); // Sensitivity not applied here because higher than default sensitivies will allow the camera to escape the autocentering, and glitch out massively
@@ -11263,8 +11281,8 @@ s16 func_8084ABD8(PlayState* play, Player* this, s32 arg2, s16 arg3) {
 
             this->actor.focus.rot.y = CLAMP(temp2, -temp1, temp1) + this->actor.shape.rot.y;
 
-            if (fabsf(sControlInput->cur.gyro_y) > 0.01f) {
-                this->actor.focus.rot.y += (sControlInput->cur.gyro_y) * 750.0f;
+            if (fabsf(yGyroAim) > 0.01f) {
+                this->actor.focus.rot.y += (yGyroAim) * 750.0f;
             }
 
             if (fabsf(sControlInput->cur.right_stick_x) > 15.0f && CVar_GetS32("gRightStickAiming", 0) != 0) {
@@ -11299,8 +11317,8 @@ s16 func_8084ABD8(PlayState* play, Player* this, s32 arg2, s16 arg3) {
 
         this->actor.focus.rot.y = CLAMP(temp2, -temp1, temp1) + this->actor.shape.rot.y;
 
-        if (fabsf(sControlInput->cur.gyro_y) > 0.01f) {
-            this->actor.focus.rot.y += (sControlInput->cur.gyro_y) * 750.0f;
+        if (fabsf(yGyroAim) > 0.01f) {
+            this->actor.focus.rot.y += (yGyroAim) * 750.0f;
         }
 
         if (fabsf(sControlInput->cur.right_stick_x) > 15.0f && CVar_GetS32("gRightStickAiming", 0) != 0) {


### PR DESCRIPTION
The goal of this PR is to make gyro aiming work more like it does in Nintendo's games. As it is now, the horizontal aiming only uses the controller's Y axis, which works fine if the controller is level, but isn't as intuitive if the controller is pointed up or down.

By comparison, in Nintendo games, you can also aim by pointing the controller up and moving it like a viewfinder (the Wii U port does this by changing the axis used to Z instead of Y). If it's between level and straight up, aiming uses a combination of the two.

All I've done at the moment is add the gyro Z axis and accelerometer in order to allow the implementation of such a system. But as the details of how to implement this are TBD, nothing is actually done with that data yet.