### PR TITLE
Rando: Skip time travel cutscene

### DIFF
--- a/soh/src/code/z_demo.c
+++ b/soh/src/code/z_demo.c
@@ -493,7 +493,8 @@ void Cutscene_Command_Terminator(GlobalContext* globalCtx, CutsceneContext* csCt
 
     // Automatically skip certain cutscenes when in rando
     // cmd->base == 33: Zelda escaping with impa cutscene
-    bool randoCsSkip = (gSaveContext.n64ddFlag && cmd->base == 33);
+    // cmd->base == 8: Traveling back/forward in time cutscene
+    bool randoCsSkip = (gSaveContext.n64ddFlag && (cmd->base == 33 || cmd->base == 8));
     bool debugCsSkip = (CHECK_BTN_ALL(globalCtx->state.input[0].press.button, BTN_START) &&
                         (gSaveContext.fileNum != 0xFEDC) && CVar_GetS32("gDebugEnabled", 0));
 


### PR DESCRIPTION
Same idea as the zelda escape cutscene skip. Makes use of the debug cutscene skip feature.

I've extensively tested different inventory setups to make sure nothing broke on that side. You can also see that in the video below: 
https://cdn.discordapp.com/attachments/988962246585634856/1001947269161041941/2022-07-27_22-19-50.mp4