### PR TITLE
Rando: Small ganon hint text fix

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/hint_list.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/hint_list.cpp
@@ -2102,7 +2102,7 @@ void HintTable_Init() {
 
     hintTable[GANON_LINE07] = HintText::GanonLine({
                      //obscure text
-                     Text{"What about Zelda makes you think she'd be a better ruler than I?^I saved Lon Lon Ranch,&fed the hungry,&and my castle floats.",
+                     Text{"What about Zelda makes you think&she'd be a better ruler than I?^I saved Lon Lon Ranch,&fed the hungry,&and my castle floats.",
                 /*french*/"Zelda ne sera jamais un meilleur monarque que moi!^J'ai un château volant, mes sujets sont des belles amazones... et mes Moblins sont clairement plus puissants que jamais!",
                /*spanish*/"¿Qué te hace pensar que Zelda gobierna mejor que yo?^Yo he salvado el Rancho Lon Lon,&he alimentado a los hambrientos&y hasta hago que mi castillo flote."},
     });

--- a/soh/soh/Enhancements/randomizer/3drando/spoiler_log.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/spoiler_log.cpp
@@ -579,7 +579,7 @@ std::string AutoFormatHintTextString(std::string unformattedHintTextString) {
   bool needsAutomaicNewlines = true;
   if (textStr == "Erreur 0x69a504:&Traduction manquante^C'est de la faute à Purple Hato!&J'vous jure!" ||
       textStr == "Mon très cher @:&Viens vite au château, je t'ai préparé&un délicieux gâteau...^À bientôt, Princesse Zelda" ||
-      textStr == "What about Zelda makes you think she'd be a better ruler than I?^I saved Lon Lon Ranch,&fed the hungry,&and my castle floats." ||
+      textStr == "What about Zelda makes you think&she'd be a better ruler than I?^I saved Lon Lon Ranch,&fed the hungry,&and my castle floats." ||
       textStr == "Many tricks are up my sleeve,&to save yourself&you'd better leave!" ||
       textStr == "I've learned this spell,&it's really neat,&I'll keep it later&for your treat!" ||
       textStr == "Sale petit garnement,&tu fais erreur!&C'est maintenant que marque&ta dernière heure!" ||


### PR DESCRIPTION
Was missing a line break.

Old:
![image](https://user-images.githubusercontent.com/4244591/181384366-25f6ba56-275f-4825-90e5-de373bd1c6e5.png)

New:
![image](https://user-images.githubusercontent.com/4244591/181384330-c3e42f27-c7b9-46e6-a197-d8590e0f1ab7.png)
