### PR TITLE
Randomizer: Fixes LACS and Prelude checks under certain conditions

### DIFF
--- a/soh/include/z64player.h
+++ b/soh/include/z64player.h
@@ -359,12 +359,12 @@ typedef struct {
 } WeaponInfo; // size = 0x1C\
 
 typedef enum {
-    SCENE_FLAG_NONE,
-    SCENE_FLAG_SWITCH,
-    SCENE_FLAG_TREASURE,
-    SCENE_FLAG_CLEAR,
-    SCENE_FLAG_COLLECTIBLE,
-} SceneFlagType;
+    FLAG_NONE,
+    FLAG_SCENE_SWITCH,
+    FLAG_SCENE_TREASURE,
+    FLAG_SCENE_CLEAR,
+    FLAG_SCENE_COLLECTIBLE,
+} FlagType;
 
 #define PLAYER_STATE1_0 (1 << 0)
 #define PLAYER_STATE1_1 (1 << 1)
@@ -620,8 +620,8 @@ typedef struct Player {
     /* 0x0A86 */ s8         unk_A86;
     /* 0x0A87 */ u8         unk_A87;
     /* 0x0A88 */ Vec3f      unk_A88; // previous body part 0 position
-    /* 0x0A94 */ SceneFlagType sceneFlagType;
-    /* 0x0A96 */ s32        sceneFlagID;
+    /* 0x0A94 */ FlagType   pendingFlagType; // type of flag to set when Player_SetPendingFlag is called
+    /* 0x0A96 */ s32        pendingFlag; // which flag to set when Player_SetPendingFlag is called
 } Player; // size = 0xAA0
 
 #endif

--- a/soh/include/z64player.h
+++ b/soh/include/z64player.h
@@ -356,7 +356,15 @@ typedef struct {
     /* 0x00 */ s32 active;
     /* 0x04 */ Vec3f tip;
     /* 0x10 */ Vec3f base;
-} WeaponInfo; // size = 0x1C
+} WeaponInfo; // size = 0x1C\
+
+typedef enum {
+    SCENE_FLAG_NONE,
+    SCENE_FLAG_SWITCH,
+    SCENE_FLAG_TREASURE,
+    SCENE_FLAG_CLEAR,
+    SCENE_FLAG_COLLECTIBLE,
+} SceneFlagType;
 
 #define PLAYER_STATE1_0 (1 << 0)
 #define PLAYER_STATE1_1 (1 << 1)
@@ -612,6 +620,8 @@ typedef struct Player {
     /* 0x0A86 */ s8         unk_A86;
     /* 0x0A87 */ u8         unk_A87;
     /* 0x0A88 */ Vec3f      unk_A88; // previous body part 0 position
-} Player; // size = 0xA94
+    /* 0x0A94 */ SceneFlagType sceneFlagType;
+    /* 0x0A96 */ s32        sceneFlagID;
+} Player; // size = 0xAA0
 
 #endif

--- a/soh/include/z64player.h
+++ b/soh/include/z64player.h
@@ -366,6 +366,11 @@ typedef enum {
     FLAG_SCENE_COLLECTIBLE,
 } FlagType;
 
+typedef struct {
+    /* 0x00 */ s32 flagID;     // which flag to set when Player_SetPendingFlag is called
+    /* 0x04 */ FlagType flagType;  // type of flag to set when Player_SetPendingFlag is called
+} PendingFlag; // size = 0x06
+
 #define PLAYER_STATE1_0 (1 << 0)
 #define PLAYER_STATE1_1 (1 << 1)
 #define PLAYER_STATE1_2 (1 << 2)
@@ -620,8 +625,7 @@ typedef struct Player {
     /* 0x0A86 */ s8         unk_A86;
     /* 0x0A87 */ u8         unk_A87;
     /* 0x0A88 */ Vec3f      unk_A88; // previous body part 0 position
-    /* 0x0A94 */ FlagType   pendingFlagType; // type of flag to set when Player_SetPendingFlag is called
-    /* 0x0A96 */ s32        pendingFlag; // which flag to set when Player_SetPendingFlag is called
+    /* 0x0A94 */ PendingFlag pendingFlag;
 } Player; // size = 0xAA0
 
 #endif

--- a/soh/src/code/z_play.c
+++ b/soh/src/code/z_play.c
@@ -240,7 +240,8 @@ void GivePlayerRandoRewardZeldaLightArrowsGift(GlobalContext* globalCtx, Randomi
         globalCtx->sceneLoadFlag == 0 && player->getItemId == GI_NONE) {
         GetItemID getItemId = Randomizer_GetItemIdFromKnownCheck(check, GI_ARROW_LIGHT);
         GiveItemWithoutActor(globalCtx, getItemId);
-        Flags_SetTreasure(globalCtx, 0x1E);
+        player->sceneFlagID = 0x1E;
+        player->sceneFlagType = SCENE_FLAG_TREASURE;
     }
 }
 

--- a/soh/src/code/z_play.c
+++ b/soh/src/code/z_play.c
@@ -240,8 +240,8 @@ void GivePlayerRandoRewardZeldaLightArrowsGift(GlobalContext* globalCtx, Randomi
         globalCtx->sceneLoadFlag == 0) {
         GetItemID getItemId = Randomizer_GetItemIdFromKnownCheck(check, GI_ARROW_LIGHT);
         GiveItemWithoutActor(globalCtx, getItemId);
-        player->pendingFlag = 0x1E;
-        player->pendingFlagType = FLAG_SCENE_TREASURE;
+        player->pendingFlag.flagID = 0x1E;
+        player->pendingFlag.flagType = FLAG_SCENE_TREASURE;
     }
 }
 

--- a/soh/src/code/z_play.c
+++ b/soh/src/code/z_play.c
@@ -240,8 +240,8 @@ void GivePlayerRandoRewardZeldaLightArrowsGift(GlobalContext* globalCtx, Randomi
         globalCtx->sceneLoadFlag == 0) {
         GetItemID getItemId = Randomizer_GetItemIdFromKnownCheck(check, GI_ARROW_LIGHT);
         GiveItemWithoutActor(globalCtx, getItemId);
-        player->sceneFlagID = 0x1E;
-        player->sceneFlagType = SCENE_FLAG_TREASURE;
+        player->pendingFlag = 0x1E;
+        player->pendingFlagType = FLAG_SCENE_TREASURE;
     }
 }
 

--- a/soh/src/code/z_play.c
+++ b/soh/src/code/z_play.c
@@ -237,7 +237,7 @@ void GivePlayerRandoRewardZeldaLightArrowsGift(GlobalContext* globalCtx, Randomi
     if (CHECK_QUEST_ITEM(QUEST_MEDALLION_SPIRIT) && CHECK_QUEST_ITEM(QUEST_MEDALLION_SHADOW) && LINK_IS_ADULT &&
         (gEntranceTable[((void)0, gSaveContext.entranceIndex)].scene == SCENE_TOKINOMA) &&
         !Flags_GetTreasure(globalCtx, 0x1E) && player != NULL && !Player_InBlockingCsMode(globalCtx, player) &&
-        globalCtx->sceneLoadFlag == 0 && player->getItemId == GI_NONE) {
+        globalCtx->sceneLoadFlag == 0) {
         GetItemID getItemId = Randomizer_GetItemIdFromKnownCheck(check, GI_ARROW_LIGHT);
         GiveItemWithoutActor(globalCtx, getItemId);
         player->sceneFlagID = 0x1E;

--- a/soh/src/overlays/actors/ovl_En_Xc/z_en_xc.c
+++ b/soh/src/overlays/actors/ovl_En_Xc/z_en_xc.c
@@ -296,8 +296,8 @@ void GivePlayerRandoRewardSheikSong(EnXc* sheik, GlobalContext* globalCtx, Rando
         GetItemID getItemId = Randomizer_GetItemIdFromKnownCheck(check, ogSongId);
         if (check == RC_SHEIK_AT_TEMPLE && !Flags_GetTreasure(globalCtx, 0x1F)) {
             if (func_8002F434(&sheik->actor, globalCtx, getItemId, 10000.0f, 100.0f)) {
-                player->sceneFlagID = 0x1F;
-                player->sceneFlagType = SCENE_FLAG_TREASURE;
+                player->pendingFlag = 0x1F;
+                player->pendingFlagType = FLAG_SCENE_TREASURE;
             }
         } else if (check != RC_SHEIK_AT_TEMPLE) {
             func_8002F434(&sheik->actor, globalCtx, getItemId, 10000.0f, 100.0f);

--- a/soh/src/overlays/actors/ovl_En_Xc/z_en_xc.c
+++ b/soh/src/overlays/actors/ovl_En_Xc/z_en_xc.c
@@ -288,14 +288,16 @@ void func_80B3CA38(EnXc* this, GlobalContext* globalCtx) {
 }
 
 void GivePlayerRandoRewardSheikSong(EnXc* sheik, GlobalContext* globalCtx, RandomizerCheck check, int sheikType, GetItemID ogSongId) {
-    if (sheik->actor.parent != NULL && sheik->actor.parent->id == GET_PLAYER(globalCtx)->actor.id &&
+    Player* player = GET_PLAYER(globalCtx);
+    if (sheik->actor.parent != NULL && sheik->actor.parent->id == player->actor.id &&
         !(gSaveContext.eventChkInf[5] & sheikType)) {
         gSaveContext.eventChkInf[5] |= sheikType;
     } else if (!(gSaveContext.eventChkInf[5] & sheikType)) {
         GetItemID getItemId = Randomizer_GetItemIdFromKnownCheck(check, ogSongId);
         if (check == RC_SHEIK_AT_TEMPLE && !Flags_GetTreasure(globalCtx, 0x1F)) {
             if (func_8002F434(&sheik->actor, globalCtx, getItemId, 10000.0f, 100.0f)) {
-                Flags_SetTreasure(globalCtx, 0x1F);
+                player->sceneFlagID = 0x1F;
+                player->sceneFlagType = SCENE_FLAG_TREASURE;
             }
         } else if (check != RC_SHEIK_AT_TEMPLE) {
             func_8002F434(&sheik->actor, globalCtx, getItemId, 10000.0f, 100.0f);

--- a/soh/src/overlays/actors/ovl_En_Xc/z_en_xc.c
+++ b/soh/src/overlays/actors/ovl_En_Xc/z_en_xc.c
@@ -296,8 +296,8 @@ void GivePlayerRandoRewardSheikSong(EnXc* sheik, GlobalContext* globalCtx, Rando
         GetItemID getItemId = Randomizer_GetItemIdFromKnownCheck(check, ogSongId);
         if (check == RC_SHEIK_AT_TEMPLE && !Flags_GetTreasure(globalCtx, 0x1F)) {
             if (func_8002F434(&sheik->actor, globalCtx, getItemId, 10000.0f, 100.0f)) {
-                player->pendingFlag = 0x1F;
-                player->pendingFlagType = FLAG_SCENE_TREASURE;
+                player->pendingFlag.flagID = 0x1F;
+                player->pendingFlag.flagType = FLAG_SCENE_TREASURE;
             }
         } else if (check != RC_SHEIK_AT_TEMPLE) {
             func_8002F434(&sheik->actor, globalCtx, getItemId, 10000.0f, 100.0f);

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -6254,6 +6254,25 @@ s32 func_8083E5A8(Player* this, GlobalContext* globalCtx) {
                     this->stateFlags1 &= ~(PLAYER_STATE1_10 | PLAYER_STATE1_11);
                     this->actor.colChkInfo.damage = 0;
                     func_80837C0C(globalCtx, this, 3, 0.0f, 0.0f, 0, 20);
+                    switch (this->sceneFlagType) {
+                        case SCENE_FLAG_CLEAR:
+                            Flags_SetClear(globalCtx, this->sceneFlagID);
+                            break;
+                        case SCENE_FLAG_COLLECTIBLE:
+                            Flags_SetCollectible(globalCtx, this->sceneFlagID);
+                            break;
+                        case SCENE_FLAG_SWITCH:
+                            Flags_SetSwitch(globalCtx, this->sceneFlagID);
+                            break;
+                        case SCENE_FLAG_TREASURE:
+                            Flags_SetTreasure(globalCtx, this->sceneFlagID);
+                            break;
+                        case SCENE_FLAG_NONE:
+                        default:
+                            break;
+                    }
+                    this->sceneFlagType = SCENE_FLAG_NONE;
+                    this->sceneFlagID = 0;
                     return;
                 }
 

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -12659,6 +12659,27 @@ s32 func_8084DFF4(GlobalContext* globalCtx, Player* this) {
 
         Message_StartTextbox(globalCtx, giEntry->textId, &this->actor);
         Item_Give(globalCtx, giEntry->itemId);
+        
+        switch (this->sceneFlagType) {
+            case SCENE_FLAG_CLEAR:
+                Flags_SetClear(globalCtx, this->sceneFlagID);
+                break;
+            case SCENE_FLAG_COLLECTIBLE:
+                Flags_SetCollectible(globalCtx, this->sceneFlagID);
+                break;
+            case SCENE_FLAG_SWITCH:
+                Flags_SetSwitch(globalCtx, this->sceneFlagID);
+                break;
+            case SCENE_FLAG_TREASURE:
+                Flags_SetTreasure(globalCtx, this->sceneFlagID);
+                break;
+            case SCENE_FLAG_NONE:
+            default:
+                break;
+        }
+        this->sceneFlagType = SCENE_FLAG_NONE;
+        this->sceneFlagID = 0;
+
 
         if (((this->getItemId >= GI_RUPEE_GREEN) && (this->getItemId <= GI_RUPEE_RED)) ||
             ((this->getItemId >= GI_RUPEE_PURPLE) && (this->getItemId <= GI_RUPEE_GOLD)) ||

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -167,6 +167,7 @@ void func_8083CA20(GlobalContext* globalCtx, Player* this);
 void func_8083CA54(GlobalContext* globalCtx, Player* this);
 void func_8083CA9C(GlobalContext* globalCtx, Player* this);
 s32 func_8083E0FC(Player* this, GlobalContext* globalCtx);
+void Player_SetSceneFlag(Player* this, GlobalContext* globalCtx);
 s32 func_8083E5A8(Player* this, GlobalContext* globalCtx);
 s32 func_8083EB44(Player* this, GlobalContext* globalCtx);
 s32 func_8083F7BC(Player* this, GlobalContext* globalCtx);
@@ -6231,6 +6232,28 @@ void func_8083E4C4(GlobalContext* globalCtx, Player* this, GetItemEntry* giEntry
     func_80078884((this->getItemId < 0) ? NA_SE_SY_GET_BOXITEM : NA_SE_SY_GET_ITEM);
 }
 
+void Player_SetSceneFlag(Player* this, GlobalContext* globalCtx) {
+    switch (this->sceneFlagType) {
+        case SCENE_FLAG_CLEAR:
+            Flags_SetClear(globalCtx, this->sceneFlagID);
+            break;
+        case SCENE_FLAG_COLLECTIBLE:
+            Flags_SetCollectible(globalCtx, this->sceneFlagID);
+            break;
+        case SCENE_FLAG_SWITCH:
+            Flags_SetSwitch(globalCtx, this->sceneFlagID);
+            break;
+        case SCENE_FLAG_TREASURE:
+            Flags_SetTreasure(globalCtx, this->sceneFlagID);
+            break;
+        case SCENE_FLAG_NONE:
+        default:
+            break;
+    }
+    this->sceneFlagType = SCENE_FLAG_NONE;
+    this->sceneFlagID = 0;
+}
+
 s32 func_8083E5A8(Player* this, GlobalContext* globalCtx) {
     Actor* interactedActor;
 
@@ -6254,25 +6277,7 @@ s32 func_8083E5A8(Player* this, GlobalContext* globalCtx) {
                     this->stateFlags1 &= ~(PLAYER_STATE1_10 | PLAYER_STATE1_11);
                     this->actor.colChkInfo.damage = 0;
                     func_80837C0C(globalCtx, this, 3, 0.0f, 0.0f, 0, 20);
-                    switch (this->sceneFlagType) {
-                        case SCENE_FLAG_CLEAR:
-                            Flags_SetClear(globalCtx, this->sceneFlagID);
-                            break;
-                        case SCENE_FLAG_COLLECTIBLE:
-                            Flags_SetCollectible(globalCtx, this->sceneFlagID);
-                            break;
-                        case SCENE_FLAG_SWITCH:
-                            Flags_SetSwitch(globalCtx, this->sceneFlagID);
-                            break;
-                        case SCENE_FLAG_TREASURE:
-                            Flags_SetTreasure(globalCtx, this->sceneFlagID);
-                            break;
-                        case SCENE_FLAG_NONE:
-                        default:
-                            break;
-                    }
-                    this->sceneFlagType = SCENE_FLAG_NONE;
-                    this->sceneFlagID = 0;
+                    Player_SetSceneFlag(this, globalCtx);
                     return;
                 }
 
@@ -12679,26 +12684,7 @@ s32 func_8084DFF4(GlobalContext* globalCtx, Player* this) {
         Message_StartTextbox(globalCtx, giEntry->textId, &this->actor);
         Item_Give(globalCtx, giEntry->itemId);
         
-        switch (this->sceneFlagType) {
-            case SCENE_FLAG_CLEAR:
-                Flags_SetClear(globalCtx, this->sceneFlagID);
-                break;
-            case SCENE_FLAG_COLLECTIBLE:
-                Flags_SetCollectible(globalCtx, this->sceneFlagID);
-                break;
-            case SCENE_FLAG_SWITCH:
-                Flags_SetSwitch(globalCtx, this->sceneFlagID);
-                break;
-            case SCENE_FLAG_TREASURE:
-                Flags_SetTreasure(globalCtx, this->sceneFlagID);
-                break;
-            case SCENE_FLAG_NONE:
-            default:
-                break;
-        }
-        this->sceneFlagType = SCENE_FLAG_NONE;
-        this->sceneFlagID = 0;
-
+        Player_SetSceneFlag(this, globalCtx);
 
         if (((this->getItemId >= GI_RUPEE_GREEN) && (this->getItemId <= GI_RUPEE_RED)) ||
             ((this->getItemId >= GI_RUPEE_PURPLE) && (this->getItemId <= GI_RUPEE_GOLD)) ||

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -6232,28 +6232,28 @@ void func_8083E4C4(GlobalContext* globalCtx, Player* this, GetItemEntry* giEntry
     func_80078884((this->getItemId < 0) ? NA_SE_SY_GET_BOXITEM : NA_SE_SY_GET_ITEM);
 }
 
-// Sets a flag according to which type of flag is specified in player->pendingFlagType
-// and which flag is specified in player->pendingFlag.
+// Sets a flag according to which type of flag is specified in player->pendingFlag.flagType
+// and which flag is specified in player->pendingFlag.flagID.
 void Player_SetPendingFlag(Player* this, GlobalContext* globalCtx) {
-    switch (this->pendingFlagType) {
+    switch (this->pendingFlag.flagType) {
         case FLAG_SCENE_CLEAR:
-            Flags_SetClear(globalCtx, this->pendingFlag);
+            Flags_SetClear(globalCtx, this->pendingFlag.flagID);
             break;
         case FLAG_SCENE_COLLECTIBLE:
-            Flags_SetCollectible(globalCtx, this->pendingFlag);
+            Flags_SetCollectible(globalCtx, this->pendingFlag.flagID);
             break;
         case FLAG_SCENE_SWITCH:
-            Flags_SetSwitch(globalCtx, this->pendingFlag);
+            Flags_SetSwitch(globalCtx, this->pendingFlag.flagID);
             break;
         case FLAG_SCENE_TREASURE:
-            Flags_SetTreasure(globalCtx, this->pendingFlag);
+            Flags_SetTreasure(globalCtx, this->pendingFlag.flagID);
             break;
         case FLAG_NONE:
         default:
             break;
     }
-    this->pendingFlagType = FLAG_NONE;
-    this->pendingFlag = 0;
+    this->pendingFlag.flagType = FLAG_NONE;
+    this->pendingFlag.flagID = 0;
 }
 
 s32 func_8083E5A8(Player* this, GlobalContext* globalCtx) {

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -167,7 +167,7 @@ void func_8083CA20(GlobalContext* globalCtx, Player* this);
 void func_8083CA54(GlobalContext* globalCtx, Player* this);
 void func_8083CA9C(GlobalContext* globalCtx, Player* this);
 s32 func_8083E0FC(Player* this, GlobalContext* globalCtx);
-void Player_SetSceneFlag(Player* this, GlobalContext* globalCtx);
+void Player_SetPendingFlag(Player* this, GlobalContext* globalCtx);
 s32 func_8083E5A8(Player* this, GlobalContext* globalCtx);
 s32 func_8083EB44(Player* this, GlobalContext* globalCtx);
 s32 func_8083F7BC(Player* this, GlobalContext* globalCtx);
@@ -6232,26 +6232,28 @@ void func_8083E4C4(GlobalContext* globalCtx, Player* this, GetItemEntry* giEntry
     func_80078884((this->getItemId < 0) ? NA_SE_SY_GET_BOXITEM : NA_SE_SY_GET_ITEM);
 }
 
-void Player_SetSceneFlag(Player* this, GlobalContext* globalCtx) {
-    switch (this->sceneFlagType) {
-        case SCENE_FLAG_CLEAR:
-            Flags_SetClear(globalCtx, this->sceneFlagID);
+// Sets a flag according to which type of flag is specified in player->pendingFlagType
+// and which flag is specified in player->pendingFlag.
+void Player_SetPendingFlag(Player* this, GlobalContext* globalCtx) {
+    switch (this->pendingFlagType) {
+        case FLAG_SCENE_CLEAR:
+            Flags_SetClear(globalCtx, this->pendingFlag);
             break;
-        case SCENE_FLAG_COLLECTIBLE:
-            Flags_SetCollectible(globalCtx, this->sceneFlagID);
+        case FLAG_SCENE_COLLECTIBLE:
+            Flags_SetCollectible(globalCtx, this->pendingFlag);
             break;
-        case SCENE_FLAG_SWITCH:
-            Flags_SetSwitch(globalCtx, this->sceneFlagID);
+        case FLAG_SCENE_SWITCH:
+            Flags_SetSwitch(globalCtx, this->pendingFlag);
             break;
-        case SCENE_FLAG_TREASURE:
-            Flags_SetTreasure(globalCtx, this->sceneFlagID);
+        case FLAG_SCENE_TREASURE:
+            Flags_SetTreasure(globalCtx, this->pendingFlag);
             break;
-        case SCENE_FLAG_NONE:
+        case FLAG_NONE:
         default:
             break;
     }
-    this->sceneFlagType = SCENE_FLAG_NONE;
-    this->sceneFlagID = 0;
+    this->pendingFlagType = FLAG_NONE;
+    this->pendingFlag = 0;
 }
 
 s32 func_8083E5A8(Player* this, GlobalContext* globalCtx) {
@@ -6277,7 +6279,7 @@ s32 func_8083E5A8(Player* this, GlobalContext* globalCtx) {
                     this->stateFlags1 &= ~(PLAYER_STATE1_10 | PLAYER_STATE1_11);
                     this->actor.colChkInfo.damage = 0;
                     func_80837C0C(globalCtx, this, 3, 0.0f, 0.0f, 0, 20);
-                    Player_SetSceneFlag(this, globalCtx);
+                    Player_SetPendingFlag(this, globalCtx);
                     return;
                 }
 
@@ -12684,7 +12686,7 @@ s32 func_8084DFF4(GlobalContext* globalCtx, Player* this) {
         Message_StartTextbox(globalCtx, giEntry->textId, &this->actor);
         Item_Give(globalCtx, giEntry->itemId);
         
-        Player_SetSceneFlag(this, globalCtx);
+        Player_SetPendingFlag(this, globalCtx);
 
         if (((this->getItemId >= GI_RUPEE_GREEN) && (this->getItemId <= GI_RUPEE_RED)) ||
             ((this->getItemId >= GI_RUPEE_PURPLE) && (this->getItemId <= GI_RUPEE_GOLD)) ||


### PR DESCRIPTION
In Randomizer, LACS and Prelude checks would both fail and set their collected flags if the player had

1. Previously Equipped Biggoron's Sword as Adult.
2. Travelled back in time to be a Child, with Biggoron's Sword still equipped.
3.  Got the necessary medallions for the checks as a child.
4. Travelled forward in time to adult link.

The culprit was the put-away animation for the master sword that happens when becoming adult with Biggoron Sword already equipped. It put link in a state where the checks for Prelude and LACS both passed, but Link was unable to hold the item over his head, so he didn't get the item but their flags were set. I have fixed this by adding values to the Player Struct for which sceneFlag to set and what type of Scene Flag to set, which then get set after Item_Give gets called (and after the Ice Trap code runs).

This code could also possibly be re-used for some other problematic checks.

Fixes #906 