### PR TITLE
Randomizer: Ocarina of Time Ice Trap Fix

### DIFF
--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -1501,3 +1501,8 @@ extern "C" s32 Randomizer_GetRandomizedItemId(GetItemID ogId, s16 actorId, s16 a
 extern "C" s32 Randomizer_GetItemIdFromKnownCheck(RandomizerCheck randomizerCheck, GetItemID ogId) {
     return OTRGlobals::Instance->gRandomizer->GetRandomizedItemIdFromKnownCheck(randomizerCheck, ogId);
 }
+
+extern "C" bool Randomizer_ObtainedFreestandingIceTrap(GlobalContext* globalCtx, RandomizerCheck randomizerCheck, GetItemID ogId, Actor* actor) {
+    return gSaveContext.n64ddFlag && (actor->parent != NULL) &&
+         Randomizer_GetItemIdFromKnownCheck(randomizerCheck, ogId) == GI_ICE_TRAP;
+}

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -1502,7 +1502,7 @@ extern "C" s32 Randomizer_GetItemIdFromKnownCheck(RandomizerCheck randomizerChec
     return OTRGlobals::Instance->gRandomizer->GetRandomizedItemIdFromKnownCheck(randomizerCheck, ogId);
 }
 
-extern "C" bool Randomizer_ObtainedFreestandingIceTrap(GlobalContext* globalCtx, RandomizerCheck randomizerCheck, GetItemID ogId, Actor* actor) {
+extern "C" bool Randomizer_ObtainedFreestandingIceTrap(RandomizerCheck randomizerCheck, GetItemID ogId, Actor* actor) {
     return gSaveContext.n64ddFlag && (actor->parent != NULL) &&
          Randomizer_GetItemIdFromKnownCheck(randomizerCheck, ogId) == GI_ICE_TRAP;
 }

--- a/soh/soh/OTRGlobals.h
+++ b/soh/soh/OTRGlobals.h
@@ -97,6 +97,7 @@ s16 Randomizer_GetItemModelFromId(s16 itemId);
 s32 Randomizer_GetItemIDFromGetItemID(s32 getItemId);
 s32 Randomizer_GetRandomizedItemId(GetItemID ogId, s16 actorId, s16 actorParams, s16 sceneNum);
 s32 Randomizer_GetItemIdFromKnownCheck(RandomizerCheck randomizerCheck, GetItemID ogId);
+bool Randomizer_ObtainedFreestandingIceTrap(GlobalContext* globalCtx, RandomizerCheck randomizerCheck, GetItemID ogId, Actor* actor);
 #endif
 
 #endif

--- a/soh/soh/OTRGlobals.h
+++ b/soh/soh/OTRGlobals.h
@@ -97,7 +97,7 @@ s16 Randomizer_GetItemModelFromId(s16 itemId);
 s32 Randomizer_GetItemIDFromGetItemID(s32 getItemId);
 s32 Randomizer_GetRandomizedItemId(GetItemID ogId, s16 actorId, s16 actorParams, s16 sceneNum);
 s32 Randomizer_GetItemIdFromKnownCheck(RandomizerCheck randomizerCheck, GetItemID ogId);
-bool Randomizer_ObtainedFreestandingIceTrap(GlobalContext* globalCtx, RandomizerCheck randomizerCheck, GetItemID ogId, Actor* actor);
+bool Randomizer_ObtainedFreestandingIceTrap(RandomizerCheck randomizerCheck, GetItemID ogId, Actor* actor);
 #endif
 
 #endif

--- a/soh/src/overlays/actors/ovl_Item_Ocarina/z_item_ocarina.c
+++ b/soh/src/overlays/actors/ovl_Item_Ocarina/z_item_ocarina.c
@@ -168,7 +168,8 @@ void ItemOcarina_DoNothing(ItemOcarina* this, GlobalContext* globalCtx) {
 }
 
 void ItemOcarina_StartSoTCutscene(ItemOcarina* this, GlobalContext* globalCtx) {
-    if (Actor_TextboxIsClosing(&this->actor, globalCtx)) {
+    if (Actor_TextboxIsClosing(&this->actor, globalCtx) ||
+        Randomizer_ObtainedFreestandingIceTrap(globalCtx, RC_HF_OCARINA_OF_TIME_ITEM, GI_OCARINA_OOT, &this->actor)) {
         if (!gSaveContext.n64ddFlag) {
             globalCtx->csCtx.segment = SEGMENTED_TO_VIRTUAL(gHyruleFieldZeldaSongOfTimeCs);
             gSaveContext.cutsceneTrigger = 1;

--- a/soh/src/overlays/actors/ovl_Item_Ocarina/z_item_ocarina.c
+++ b/soh/src/overlays/actors/ovl_Item_Ocarina/z_item_ocarina.c
@@ -169,7 +169,7 @@ void ItemOcarina_DoNothing(ItemOcarina* this, GlobalContext* globalCtx) {
 
 void ItemOcarina_StartSoTCutscene(ItemOcarina* this, GlobalContext* globalCtx) {
     if (Actor_TextboxIsClosing(&this->actor, globalCtx) ||
-        Randomizer_ObtainedFreestandingIceTrap(globalCtx, RC_HF_OCARINA_OF_TIME_ITEM, GI_OCARINA_OOT, &this->actor)) {
+        Randomizer_ObtainedFreestandingIceTrap(RC_HF_OCARINA_OF_TIME_ITEM, GI_OCARINA_OOT, &this->actor)) {
         if (!gSaveContext.n64ddFlag) {
             globalCtx->csCtx.segment = SEGMENTED_TO_VIRTUAL(gHyruleFieldZeldaSongOfTimeCs);
             gSaveContext.cutsceneTrigger = 1;


### PR DESCRIPTION
Fixes #922 

Similar to #963, the OoT only triggered the Song of Time cutscene when a textbox was closing, and the Ice Trap does not have a text box. The fix here is subtly different from the linked PR though, because in addition to checking if the particular check has an Ice Trap, we also need to check that the player has picked it up (i.e. the freestanding item actor's parent is not null). 