### PR TITLE
Heart line length alteration and magic bar tracking

### DIFF
--- a/soh/include/functions.h
+++ b/soh/include/functions.h
@@ -976,6 +976,8 @@ void Color_RGBA8_Copy(Color_RGBA8* dst, Color_RGBA8* src);
 void func_80078884(u16 sfxId);
 void func_800788CC(u16 sfxId);
 void func_80078914(Vec3f* arg0, u16 sfxId);
+s16 getHealthMeterXOffset();
+s16 getHealthMeterYOffset();
 void HealthMeter_Init(GlobalContext* globalCtx);
 void HealthMeter_Update(GlobalContext* globalCtx);
 void HealthMeter_Draw(GlobalContext* globalCtx);

--- a/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
+++ b/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
@@ -526,6 +526,8 @@ void Draw_Placements(){
             DrawPositionsRadioBoxes("gHeartsCount");
             DrawPositionSlider("gHeartsCount",-22,ImGui::GetWindowViewport()->Size.y,-125,ImGui::GetWindowViewport()->Size.x);
             DrawScaleSlider("gHeartsCount",0.7f);
+            UIWidgets::EnhancementSliderInt("Heart line length : %d", "##HeartLineLength", "gHeartsLineLength", 0, 20, "", 10, true);
+            UIWidgets::Tooltip("This will set the length of a row of hearts. Set to 0 for unlimited length.");
             ImGui::NewLine();
             ImGui::EndTable();
         }
@@ -536,6 +538,8 @@ void Draw_Placements(){
             Table_InitHeader(false);
             DrawUseMarginsSlider("Magic meter", "gMagicBar");
             DrawPositionsRadioBoxes("gMagicBar");
+            UIWidgets::EnhancementRadioButton("Anchor to life bar", "gMagicBarPosType", 5);
+            UIWidgets::Tooltip("This will make your elements follow the bottom of the life meter");
             DrawPositionSlider("gMagicBar", 0, ImGui::GetWindowViewport()->Size.y/2, -5, ImGui::GetWindowViewport()->Size.x/2);
             DrawScaleSlider("gMagicBar",1.0f);
             ImGui::NewLine();

--- a/soh/src/code/z_lifemeter.c
+++ b/soh/src/code/z_lifemeter.c
@@ -380,10 +380,50 @@ static void* sHeartDDTextures[] = {
     gDefenseHeartThreeQuarterTex,
 };
 
+s16 getHealthMeterXOffset() {
+    s16 X_Margins;
+    if (CVar_GetS32("gHeartsUseMargins", 0) != 0)
+        X_Margins = Left_LM_Margin;
+    else
+        X_Margins = 0;
+
+    if (CVar_GetS32("gHeartsCountPosType", 0) != 0) {
+        if (CVar_GetS32("gHeartsCountPosType", 0) == 1) {//Anchor Left
+            return OTRGetDimensionFromLeftEdge(CVar_GetS32("gHeartsCountPosX", 0)+X_Margins+70.0f);
+        } else if (CVar_GetS32("gHeartsCountPosType", 0) == 2) {//Anchor Right
+            X_Margins = Right_LM_Margin;
+            return OTRGetDimensionFromRightEdge(CVar_GetS32("gHeartsCountPosX", 0)+X_Margins+70.0f);
+        } else if (CVar_GetS32("gHeartsCountPosType", 0) == 3) {//Anchor None
+            return CVar_GetS32("gHeartsCountPosX", 0)+70.0f;;
+        } else if (CVar_GetS32("gHeartsCountPosType", 0) == 4) {//Hidden
+            return -9999;
+        }
+    } else {
+        return OTRGetDimensionFromLeftEdge(0.0f)+X_Margins;
+    }
+}
+
+s16 getHealthMeterYOffset() {
+    s16 Y_Margins;
+    if (CVar_GetS32("gHeartsUseMargins", 0) != 0)
+        Y_Margins = (Top_LM_Margin*-1);
+    else
+        Y_Margins = 0;
+
+    f32 HeartsScale = 0.7f; 
+    if (CVar_GetS32("gHeartsCountPosType", 0) != 0) {
+        HeartsScale = CVar_GetFloat("gHeartsCountScale", 0.7f);
+        return CVar_GetS32("gHeartsCountPosY", 0)+Y_Margins+(HeartsScale*15);
+    } else {
+        return 0.0f+Y_Margins;
+    }
+}
+
 void HealthMeter_Draw(GlobalContext* globalCtx) {
     s32 pad[5];
     void* heartBgImg;
     u32 curColorSet;
+    f32 PosX_anchor;
     f32 offsetX;
     f32 offsetY;
     s32 i;
@@ -402,7 +442,7 @@ void HealthMeter_Draw(GlobalContext* globalCtx) {
     s32 curCombineModeSet = 0;
     u8* curBgImgLoaded = NULL;
     s32 ddHeartCountMinusOne = gSaveContext.inventory.defenseHearts - 1;
-    float HeartsScale = 0.7f; 
+    f32 HeartsScale = 0.7f; 
     if (CVar_GetS32("gHeartsCountPosType", 0) != 0) {
         HeartsScale = CVar_GetFloat("gHeartsCountScale", 0.7f);
     }
@@ -416,6 +456,7 @@ void HealthMeter_Draw(GlobalContext* globalCtx) {
     }
 
     curColorSet = -1;
+/*
     s16 X_Margins;
     s16 Y_Margins;
     if (CVar_GetS32("gHeartsUseMargins", 0) != 0) {
@@ -443,6 +484,9 @@ void HealthMeter_Draw(GlobalContext* globalCtx) {
         offsetY = PosY_original;
         offsetX = PosX_original;
     }
+*/
+    offsetX = PosX_anchor = getHealthMeterXOffset();
+    offsetY = getHealthMeterYOffset();
 
     for (i = 0; i < totalHeartCount; i++) {
         FrameInterpolation_RecordOpenChild("HealthMeter Heart", i);
@@ -616,27 +660,11 @@ void HealthMeter_Draw(GlobalContext* globalCtx) {
             }
         }
 
-        //offsetX += 10.0f;
-        offsetX += (HeartsScale*14.5f);
-        if (i == 9) {
-            PosX_original = OTRGetDimensionFromLeftEdge(0.0f)+X_Margins;
-            PosY_original = (HeartsScale*15)+Y_Margins;
-            if (CVar_GetS32("gHeartsCountPosType", 0) != 0) {
-                offsetY = CVar_GetS32("gHeartsCountPosY", 0)+((HeartsScale*15)*2)+Y_Margins;
-                if (CVar_GetS32("gHeartsCountPosType", 0) == 1) {//Anchor Left
-                    offsetX = OTRGetDimensionFromLeftEdge(CVar_GetS32("gHeartsCountPosX", 0)+X_Margins+70.0f);
-                } else if (CVar_GetS32("gHeartsCountPosType", 0) == 2) {//Anchor Right
-                    X_Margins = Right_LM_Margin;
-                    offsetX = OTRGetDimensionFromRightEdge(CVar_GetS32("gHeartsCountPosX", 0)+X_Margins+70.0f);
-                } else if (CVar_GetS32("gHeartsCountPosType", 0) == 3) {//Anchor None
-                    offsetX = CVar_GetS32("gHeartsCountPosX", 0)+70.0f;
-                } else if (CVar_GetS32("gHeartsCountPosType", 0) == 4) {//Hidden
-                    offsetX = -9999;
-                }
-            } else {
-                offsetY = PosY_original;
-                offsetX = PosX_original;
-            }
+        offsetX += 10.0f;
+        s32 lineLength = CVar_GetS32("gHeartsLineLength", 10);
+        if (lineLength != 0 && (i+1)%lineLength == 0) {
+            offsetX = PosX_anchor;
+            offsetY += 10.0f;
         }
         
         FrameInterpolation_RecordCloseChild();

--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -3381,6 +3381,7 @@ void Interface_UpdateMagicBar(GlobalContext* globalCtx) {
 
 void Interface_DrawMagicBar(GlobalContext* globalCtx) {
     InterfaceContext* interfaceCtx = &globalCtx->interfaceCtx;
+    s16 magicDrop = R_MAGIC_BAR_LARGE_Y-R_MAGIC_BAR_SMALL_Y+2;
     s16 magicBarY;
     Color_RGB8 magicbar_yellow = {250,250,0}; //Magic bar being used
     Color_RGB8 magicbar_green = {R_MAGIC_FILL_COLOR(0),R_MAGIC_FILL_COLOR(1),R_MAGIC_FILL_COLOR(2)}; //Magic bar fill
@@ -3408,6 +3409,7 @@ void Interface_DrawMagicBar(GlobalContext* globalCtx) {
         s16 rMagicBarX;
         s16 PosX_MidEnd;
         s16 rMagicFillX;
+        s32 lineLength = CVar_GetS32("gHeartsLineLength", 10);
         if (CVar_GetS32("gMagicBarPosType", 0) != 0) {
             magicBarY = CVar_GetS32("gMagicBarPosY", 0)+Y_Margins;
             if (CVar_GetS32("gMagicBarPosType", 0) == 1) {//Anchor Left
@@ -3432,10 +3434,20 @@ void Interface_DrawMagicBar(GlobalContext* globalCtx) {
                 rMagicBarX = -9999;
                 PosX_MidEnd = -9999;
                 rMagicFillX = -9999;
+            } else if (CVar_GetS32("gMagicBarPosType", 0) == 5) {//Anchor To life meter
+                magicBarY = R_MAGIC_BAR_SMALL_Y-2 +
+                            magicDrop*(lineLength == 0 ? 0 : (gSaveContext.healthCapacity-1)/(0x10*lineLength)) +
+                            CVar_GetS32("gMagicBarPosY", 0) + getHealthMeterYOffset();
+                s16 xPushover = CVar_GetS32("gMagicBarPosX", 0) + getHealthMeterXOffset() + R_MAGIC_BAR_X-1;
+                PosX_Start = xPushover;
+                rMagicBarX = xPushover;
+                PosX_MidEnd = xPushover+8;
+                rMagicFillX = CVar_GetS32("gMagicBarPosX", 0) + getHealthMeterXOffset() + R_MAGIC_FILL_X-1;
             }
         } else {
-            if (gSaveContext.healthCapacity > 0xA0) {
-                magicBarY = magicBarY_original_l;
+            if ((gSaveContext.healthCapacity-1)/0x10 >= lineLength && lineLength != 0) {
+                magicBarY = magicBarY_original_l +
+                            magicDrop*(lineLength == 0 ? 0 : ((gSaveContext.healthCapacity-1)/(0x10*lineLength) - 1));
             } else {
                 magicBarY = magicBarY_original_s;
             }


### PR DESCRIPTION
This feature adds two things that function in tandem, the ability to alter the length of the life meter's hearts rows (so BotW style extended heart rows are possible and extra heart rows beyond 2 are also enabled, if a greater maximum number of hearts is desired), and the ability to have the magic meter fix its position relative to the final row of hearts unconditionally.

In implementing the first feature, the default behavior of the heart rows when adding more than 20 hearts changes, from having a final line with unlimited length, to having a consistent row length. I feel that this is warranted, as otherwise heart row length inconsistency is introduced when increasing the heart capacity beyond that of the original game, and this acts as a fix for that. However, if an unlimited length heart row is desired by the player, putting the setting to 0 allows this.

By default, the magic meter tracks the heart rows as it does in the original game (with a different offset from the heart rows depending on how many rows there are, being further away from the hearts if there are multiple rows), but an extra option enables the user to select the meter to be set at a specified position relative to the bottom row.