### PR TITLE
[macos] Disable buggy resolution scaling

### DIFF
--- a/libultraship/libultraship/ImGuiImpl.cpp
+++ b/libultraship/libultraship/ImGuiImpl.cpp
@@ -859,10 +859,12 @@ namespace SohImGui {
 
             if (ImGui::BeginMenu("Graphics"))
             {
+#ifndef __APPLE__
                 EnhancementSliderFloat("Internal Resolution: %d %%", "##IMul", "gInternalResolution", 0.5f, 2.0f, "", 1.0f, true);
                 Tooltip("Multiplies your output resolution by the value inputted,\nas a more intensive but effective form of anti-aliasing");
                 gfx_current_dimensions.internal_mul = CVar_GetFloat("gInternalResolution", 1);
-                EnhancementSliderInt("MSAA: %d", "##IMSAA", "gMSAAValue", 1, 8, "");
+#endif
+                EnhancementSliderInt("MSAA: %d", "##IMSAA", "gMSAAValue", 1, 8, "", 1, true);
                 Tooltip("Activates multi-sample anti-aliasing when above 1x\nup to 8x for 8 samples for every pixel");
                 gfx_msaa_level = CVar_GetS32("gMSAAValue", 1);
 

--- a/libultraship/libultraship/Lib/Fast3D/gfx_pc.cpp
+++ b/libultraship/libultraship/Lib/Fast3D/gfx_pc.cpp
@@ -2651,7 +2651,11 @@ void gfx_init(struct GfxWindowManagerAPI *wapi, struct GfxRenderingAPI *rapi, co
     gfx_wapi->init(game_name, start_in_fullscreen, width, height);
     gfx_rapi->init();
     gfx_rapi->update_framebuffer_parameters(0, width, height, 1, false, true, true, true);
+#ifdef __APPLE__
+    gfx_current_dimensions.internal_mul = 1;
+#else
     gfx_current_dimensions.internal_mul = CVar_GetFloat("gInternalResolution", 1);
+#endif
     gfx_msaa_level = CVar_GetS32("gMSAAValue", 1);
     gfx_current_dimensions.width = width;
     gfx_current_dimensions.height = height;


### PR DESCRIPTION
Disables bug in resolution scaling on macos. Due to the retina display and high DPI -- there's errors between the size that gfx thinks it should render to (from Imgui content size) vs what the retina display is actually rendering too.

gfx in fast3d could probably be updated to try to take this into account but would take more thinking and planning. In the meantime this prohibits users from being able to get into a broken state and play only at 100% resolution. Which is already pretty good on macos retina displays.