### PR TITLE
Rando: Added no logic option

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/settings.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/settings.cpp
@@ -2463,6 +2463,17 @@ namespace Settings {
   //Function to set flags depending on settings
   void UpdateSettings(std::unordered_map<RandomizerSettingKey, uint8_t> cvarSettings) {
 
+    // RANDTODO: Switch this back once all logic options are implemented
+    // Logic.SetSelectedIndex(cvarSettings[RSK_LOGIC_RULES]);
+    switch (cvarSettings[RSK_LOGIC_RULES]) {
+        case 0:
+            Logic.SetSelectedIndex(0);
+            break;
+        case 1:
+            Logic.SetSelectedIndex(2);
+            break;
+    }
+
     OpenForest.SetSelectedIndex(cvarSettings[RSK_FOREST]);
     OpenKakariko.SetSelectedIndex(cvarSettings[RSK_KAK_GATE]);
     ZorasFountain.SetSelectedIndex(cvarSettings[RSK_ZORAS_FOUNTAIN]);

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -3414,6 +3414,7 @@ void GenerateRandomizerImgui() {
     Game::SaveSettings();
     
     std::unordered_map<RandomizerSettingKey, u8> cvarSettings;
+    cvarSettings[RSK_LOGIC_RULES] = CVar_GetS32("gRandomizeLogicRules", 0);
     cvarSettings[RSK_FOREST] = CVar_GetS32("gRandomizeForest", 0);
     cvarSettings[RSK_KAK_GATE] = CVar_GetS32("gRandomizeKakarikoGate", 0);
     cvarSettings[RSK_DOOR_OF_TIME] = CVar_GetS32("gRandomizeDoorOfTime", 0);
@@ -3497,6 +3498,9 @@ void DrawRandoEditor(bool& open) {
     }
 
 // Randomizer settings
+    // Logic Settings
+    const char* randoLogicRules[2] = { "Glitchless", "No logic"};
+
     // Open Settings
     const char* randoForest[3] = { "Closed", "Closed Deku", "Open" };
     const char* randoKakarikoGate[2] = { "Closed", "Open" };
@@ -3739,6 +3743,20 @@ void DrawRandoEditor(bool& open) {
 
         if (CVar_GetS32("gRandomizer", 0) == 1 && ImGui::BeginTabBar("Randomizer Settings", ImGuiTabBarFlags_NoCloseWithMiddleMouseButton)) {
             if (ImGui::BeginTabItem("Main Rules")) {
+                if (ImGui::BeginTable("tableRandoLogic", 1, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV)) {
+                    ImGui::TableSetupColumn("", ImGuiTableColumnFlags_WidthStretch, 200.0f);
+                    ImGui::TableNextRow();
+                    ImGui::TableNextColumn();
+                    ImGui::PushItemWidth(170.0);
+                    ImGui::Text("Logic Rules");
+                    InsertHelpHoverText("Glitchless - No glitches are required, but may require some minor tricks.\n"
+                        "\n"
+                        "No logic - Item placement is completely random. MAY BE IMPOSSIBLE TO BEAT."
+                    );
+                    SohImGui::EnhancementCombobox("gRandomizeLogicRules", randoLogicRules, 2, 0);
+                    ImGui::PopItemWidth();
+                    ImGui::EndTable();
+                }
                 if (ImGui::BeginTable("tableRandoMainRules", 3, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV)) {
                     ImGui::TableSetupColumn("Open Settings", ImGuiTableColumnFlags_WidthStretch, 200.0f);
                     ImGui::TableSetupColumn("Shuffle Settings", ImGuiTableColumnFlags_WidthStretch, 200.0f);

--- a/soh/soh/Enhancements/randomizer/randomizerTypes.h
+++ b/soh/soh/Enhancements/randomizer/randomizerTypes.h
@@ -952,6 +952,7 @@ typedef enum {
 
 typedef enum {
     RSK_NONE,
+    RSK_LOGIC_RULES,
     RSK_FOREST,
     RSK_KAK_GATE,
     RSK_DOOR_OF_TIME,


### PR DESCRIPTION
Adds an option to switch between glitchless logic and no logic. 

Looks like this in the menu (took the placement from N64 rando interface):
![image](https://user-images.githubusercontent.com/4244591/182015127-502b2cd2-2573-4b8b-baa1-da31b0370ae4.png)
