### PR TITLE
Rando: Correctly set swordless flag when time traveling

### DIFF
--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -1363,6 +1363,12 @@ void Inventory_SwapAgeEquipment(void) {
     u16 temp;
 
     if (LINK_AGE_IN_YEARS == YEARS_CHILD) {
+        // When becoming adult, remove swordless flag since we'll get master sword
+        // Only in rando to keep swordless link bugs in vanilla
+        if (gSaveContext.n64ddFlag) {
+            gSaveContext.infTable[29] &= ~1;
+        }
+
         for (i = 0; i < ARRAY_COUNT(gSaveContext.equips.buttonItems); i++) {
             if (i != 0) {
                 gSaveContext.childEquips.buttonItems[i] = gSaveContext.equips.buttonItems[i];
@@ -1423,6 +1429,12 @@ void Inventory_SwapAgeEquipment(void) {
             gSaveContext.equips.equipment = gSaveContext.adultEquips.equipment;
         }
     } else {
+        // When becoming child, set swordless flag if player doesn't have kokiri sword
+        // Only in rando to keep swordless link bugs in vanilla
+        if (gSaveContext.n64ddFlag && (1 << 0 & gSaveContext.inventory.equipment) == 0) {
+            gSaveContext.infTable[29] |= 1;
+        }
+
         for (i = 0; i < ARRAY_COUNT(gSaveContext.equips.buttonItems); i++) {
             gSaveContext.adultEquips.buttonItems[i] = gSaveContext.equips.buttonItems[i];
 


### PR DESCRIPTION
Resolves https://github.com/HarbourMasters/Shipwright/issues/697, resolves https://github.com/HarbourMasters/Shipwright/issues/702

As the code comments say, I'm only fixing this when rando'd because swordless link has quite a few applications in the vanilla game.

See: https://cdn.discordapp.com/attachments/988962246585634856/1002302888518889472/2022-07-28_21-44-30.mp4