### PR TITLE
Add instant boomerang recall

### DIFF
--- a/libultraship/libultraship/ImGuiImpl.cpp
+++ b/libultraship/libultraship/ImGuiImpl.cpp
@@ -1037,6 +1037,8 @@ namespace SohImGui {
                         Tooltip("Skip the part where the Ocarina playback is called when you play a song");
                         EnhancementCheckbox("Prevent Dropped Ocarina Inputs", "gDpadNoDropOcarinaInput");
                         Tooltip("Prevent dropping inputs when playing the ocarina quickly");
+                        EnhancementCheckbox("Instant Boomerang Recall", "gFastBoomerang");
+                        Tooltip("Instantly return the boomerang to Link by pressing its item button while it's in the air");
                         EnhancementCheckbox("Instant Putaway", "gInstantPutaway");
                         Tooltip("Allow Link to put items away without having to wait around");
                         EnhancementCheckbox("Mask Select in Inventory", "gMaskSelect");

--- a/soh/include/z64player.h
+++ b/soh/include/z64player.h
@@ -626,6 +626,7 @@ typedef struct Player {
     /* 0x0A87 */ u8         unk_A87;
     /* 0x0A88 */ Vec3f      unk_A88; // previous body part 0 position
     /* 0x0A94 */ PendingFlag pendingFlag;
-} Player; // size = 0xAA0
+    /* 0x0AA0 */ u8         boomerangQuickRecall; // Has the player pressed the boomerang button while it's in the air still?
+} Player; // size = 0xAA1
 
 #endif

--- a/soh/src/overlays/actors/ovl_En_Boom/z_en_boom.c
+++ b/soh/src/overlays/actors/ovl_En_Boom/z_en_boom.c
@@ -167,12 +167,12 @@ void EnBoom_Fly(EnBoom* this, GlobalContext* globalCtx) {
 
     // Decrement the return timer and check if it's 0. If it is, check if Link can catch it and handle accordingly.
     // Otherwise handle grabbing and colliding.
-    if (DECR(this->returnTimer) == 0) {
+    if (DECR(this->returnTimer) == 0 || player->boomerangQuickRecall) {
         distFromLink = Math_Vec3f_DistXYZ(&this->actor.world.pos, &player->actor.focus.pos);
         this->moveTo = &player->actor;
 
         // If the boomerang is less than 40 units away from Link, he can catch it.
-        if (distFromLink < 40.0f) {
+        if (distFromLink < 40.0f || player->boomerangQuickRecall) {
             target = this->grabbed;
             if (target != NULL) {
                 Math_Vec3f_Copy(&target->world.pos, &player->actor.world.pos);
@@ -187,7 +187,8 @@ void EnBoom_Fly(EnBoom* this, GlobalContext* globalCtx) {
                 }
             }
             // Set player flags and kill the boomerang beacause Link caught it.
-            player->stateFlags1 &= ~0x02000000;
+            player->stateFlags1 &= ~PLAYER_STATE1_25;
+            player->boomerangQuickRecall = false;
             Actor_Kill(&this->actor);
         }
     } else {

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -146,10 +146,10 @@ s32 func_808353D8(Player* this, GlobalContext* globalCtx);
 s32 func_80835588(Player* this, GlobalContext* globalCtx);
 s32 func_808356E8(Player* this, GlobalContext* globalCtx);
 s32 func_80835800(Player* this, GlobalContext* globalCtx);
-s32 func_80835884(Player* this, GlobalContext* globalCtx);
-s32 func_808358F0(Player* this, GlobalContext* globalCtx);
-s32 func_808359FC(Player* this, GlobalContext* globalCtx);
-s32 func_80835B60(Player* this, GlobalContext* globalCtx);
+s32 func_80835884(Player* this, GlobalContext* globalCtx); // Start aiming boomerang
+s32 func_808358F0(Player* this, GlobalContext* globalCtx); // Aim boomerang
+s32 func_808359FC(Player* this, GlobalContext* globalCtx); // Throw boomerang
+s32 func_80835B60(Player* this, GlobalContext* globalCtx); // Boomerang active
 s32 func_80835C08(Player* this, GlobalContext* globalCtx);
 void func_80835F44(GlobalContext* globalCtx, Player* this, s32 item);
 void func_80839F90(Player* this, GlobalContext* globalCtx);
@@ -487,8 +487,8 @@ static s32 D_80853604 = 0;
 static s32 D_80853608 = 0;
 static s32 D_8085360C = 0;
 static s16 D_80853610 = 0;
-static s32 D_80853614 = 0;
-static s32 D_80853618 = 0;
+static s32 D_80853614 = 0; // Held item button just pressed?
+static s32 D_80853618 = 0; // Held item button currently down?
 
 static u16 D_8085361C[] = {
     NA_SE_VO_LI_SWEAT,
@@ -955,6 +955,7 @@ static s8 sItemActionParams[] = {
 
 static u8 sMaskMemory;
 
+// Used to map action params to update functions
 static s32(*D_80853EDC[])(Player* this, GlobalContext* globalCtx) = {
     func_8083485C, func_8083485C, func_8083485C, func_808349DC, func_808349DC, func_808349DC, func_8083485C,
     func_8083485C, func_8083501C, func_8083501C, func_8083501C, func_8083501C, func_8083501C, func_8083501C,
@@ -2727,6 +2728,10 @@ s32 func_80835B60(Player* this, GlobalContext* globalCtx) {
         func_8002F7DC(&this->actor, NA_SE_PL_CATCH_BOOMERANG);
         func_80832698(this, NA_SE_VO_LI_SWORD_N);
         return 1;
+    }
+
+    if (D_80853614 && CVar_GetS32("gFastBoomerang", 0)) {
+        this->boomerangQuickRecall = true;
     }
 
     return 0;


### PR DESCRIPTION
Adds an enhancement to the Time Savers menu to allow the player to instantly return the boomerang to Link. Like in _Ocarina of Time 3D_, if the boomerang picked up a Gold Skulltula Token, he'll collect the token; otherwise, the item will be dropped on the ground.

A note on the implementation: this uses a new field in the Player struct, but it may make more sense to expand `stateFlags3` and use that instead.