### PR TITLE
Handle audio thread properly

### DIFF
--- a/libultraship/libultraship/Lib/Fast3D/gfx_dxgi.cpp
+++ b/libultraship/libultraship/Lib/Fast3D/gfx_dxgi.cpp
@@ -240,8 +240,8 @@ static LRESULT CALLBACK gfx_dxgi_wnd_proc(HWND h_wnd, UINT message, WPARAM w_par
             dxgi.current_height = (uint32_t)(l_param >> 16);
             break;
         case WM_DESTROY:
-            Ship::ExecuteHooks<Ship::ExitGame>();
-            exit(0);
+            PostQuitMessage(0);
+            break;
         case WM_PAINT:
             if (dxgi.in_paint) {
                 dxgi.recursive_paint_detected = true;
@@ -379,6 +379,8 @@ static void gfx_dxgi_main_loop(void (*run_one_game_iter)(void)) {
         TranslateMessage(&msg);
         DispatchMessage(&msg);
     }
+
+    Ship::ExecuteHooks<Ship::ExitGame>();
 }
 
 static void gfx_dxgi_get_dimensions(uint32_t *width, uint32_t *height) {

--- a/libultraship/libultraship/Lib/Fast3D/gfx_sdl2.cpp
+++ b/libultraship/libultraship/Lib/Fast3D/gfx_sdl2.cpp
@@ -240,6 +240,8 @@ static void gfx_sdl_main_loop(void (*run_one_game_iter)(void)) {
     Ship::Switch::Exit();
 #endif
     Ship::ExecuteHooks<Ship::ExitGame>();
+
+    SDL_Quit();
 }
 
 static void gfx_sdl_get_dimensions(uint32_t *width, uint32_t *height) {
@@ -309,9 +311,8 @@ static void gfx_sdl_handle_events(void) {
                 Game::SaveSettings();
                 break;
             case SDL_QUIT:
-                Ship::ExecuteHooks<Ship::ExitGame>();
-                SDL_Quit(); // bandaid fix for linux window closing issue
-                exit(0);
+                is_running = false;
+                break;
         }
     }
 }

--- a/soh/soh/OTRAudio.h
+++ b/soh/soh/OTRAudio.h
@@ -1,8 +1,9 @@
 #pragma once
 
 static struct {
+    std::thread thread;
     std::condition_variable cv_to_thread, cv_from_thread;
     std::mutex mutex;
-    bool initialized;
+    bool running;
     bool processing;
 } audio;

--- a/soh/src/code/graph.c
+++ b/soh/src/code/graph.c
@@ -481,22 +481,6 @@ static void RunFrame()
             uint64_t ticksA, ticksB;
             ticksA = GetPerfCounter();
 
-#ifdef __SWITCH__
-            #define SAMPLES_HIGH 752
-            #define SAMPLES_LOW 720
-
-            #define AUDIO_FRAMES_PER_UPDATE (R_UPDATE_RATE > 0 ? R_UPDATE_RATE : 1 )
-            #define NUM_AUDIO_CHANNELS 2
-            int samples_left = AudioPlayer_Buffered();
-            u32 num_audio_samples = samples_left < AudioPlayer_GetDesiredBuffered() ? SAMPLES_HIGH : SAMPLES_LOW;
-
-            s16 audio_buffer[SAMPLES_HIGH * NUM_AUDIO_CHANNELS * 3];
-            for (int i = 0; i < AUDIO_FRAMES_PER_UPDATE; i++) {
-                AudioMgr_CreateNextAudioBuffer(audio_buffer + i * (num_audio_samples * NUM_AUDIO_CHANNELS), num_audio_samples);
-            }
-
-            AudioPlayer_Play((u8*)audio_buffer, num_audio_samples * (sizeof(int16_t) * NUM_AUDIO_CHANNELS * AUDIO_FRAMES_PER_UPDATE));
-#endif
             Graph_StartFrame();
 
             // TODO: Workaround for rumble being too long. Implement os thread functions.

--- a/soh/src/code/main.c
+++ b/soh/src/code/main.c
@@ -36,12 +36,14 @@ void Main_LogSystemHeap(void) {
     osSyncPrintf(VT_RST);
 }
 
-void main(int argc, char** argv)
+int main(int argc, char** argv)
 {
     GameConsole_Init();
     InitOTR();
     BootCommands_Init();
     Main(0);
+    DeinitOTR();
+    return 0;
 }
 
 void Main(void* arg) {


### PR DESCRIPTION
This PR handles the audio thread properly instead of having a detached thread which never quits.
This will quit the application properly on linux and allows returning from `main` without calling `exit`.

This should also make running the audio thread on switch possible where detached threads are not supported.

**Tested on:**
- [x] Linux
- [x] Windows
- [x] Mac OS
- [x] Switch

(Don't merge before tested everywhere since this might break exiting on other platforms!)