### PR TITLE
Add options to modify/disable certain dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,13 +117,16 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 ################################################################################
 # Sub-projects
 ################################################################################
+option(BUILD_OTR_GUI "Build the OTRGui tool" ON)
+
 add_subdirectory(libultraship/libultraship ${CMAKE_BINARY_DIR}/libultraship)
 add_subdirectory(ZAPDTR/ZAPD ${CMAKE_BINARY_DIR}/ZAPD)
 add_subdirectory(ZAPDTR/ZAPDUtils ${CMAKE_BINARY_DIR}/ZAPDUtils)
 add_subdirectory(OTRExporter)
 add_subdirectory(soh)
-if(NOT CMAKE_SYSTEM_NAME MATCHES "Darwin|NintendoSwitch|CafeOS")
-add_subdirectory(OTRGui)
+if(BUILD_OTR_GUI AND NOT CMAKE_SYSTEM_NAME MATCHES "Darwin|NintendoSwitch|CafeOS")
+    message(STATUS "Building OTRGui")
+    add_subdirectory(OTRGui)
 endif()
 
 set_property(TARGET soh PROPERTY APPIMAGE_DESKTOP_FILE_TERMINAL YES)

--- a/libultraship/libultraship/AudioPlayer.h
+++ b/libultraship/libultraship/AudioPlayer.h
@@ -17,7 +17,7 @@ namespace Ship {
 
 #ifdef _WIN32
 #include "WasapiAudioPlayer.h"
-#elif defined(__linux)
+#elif defined(__linux) && !defined(NO_PULSE)
 #include "PulseAudioPlayer.h"
 #else
 #include "SDLAudioPlayer.h"

--- a/libultraship/libultraship/CMakeLists.txt
+++ b/libultraship/libultraship/CMakeLists.txt
@@ -525,18 +525,23 @@ endif()
 ################################################################################
 if (NOT CMAKE_SYSTEM_NAME MATCHES "Windows|NintendoSwitch|CafeOS")
     find_package(SDL2)
-    find_package(GLEW)
-    find_package(X11)
-    if (NOT GLEW_FOUND)
-        if (NOT CMAKE_SYSTEM_NAME MATCHES "Windows|Darwin")
-            include (FetchContent)
-            FetchContent_Declare(
-                glew
-                GIT_REPOSITORY https://github.com/Perlmint/glew-cmake.git
-                SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../external/glew
-            )
-            FetchContent_MakeAvailable(glew)
-            add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../../external/glew/build/cmake ${CMAKE_BINARY_DIR}/glew EXCLUDE_FROM_ALL)
+    if (USE_X11)
+        find_package(X11)
+    endif()
+    if (NOT NO_GLEW)
+        find_package(GLEW)
+
+        if (NOT GLEW_FOUND)
+            if (NOT CMAKE_SYSTEM_NAME MATCHES "Windows|Darwin")
+                include (FetchContent)
+                FetchContent_Declare(
+                    glew
+                    GIT_REPOSITORY https://github.com/Perlmint/glew-cmake.git
+                    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../external/glew
+                )
+                FetchContent_MakeAvailable(glew)
+                add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../../external/glew/build/cmake ${CMAKE_BINARY_DIR}/glew EXCLUDE_FROM_ALL)
+            endif()
         endif()
     endif()
 
@@ -639,19 +644,54 @@ endif()
 ################################################################################
 # Link with other targets.
 
+cmake_dependent_option(NO_GLEW "Build without using libGLEW" OFF "CMAKE_SYSTEM_NAME STREQUAL Linux" OFF)
+cmake_dependent_option(NO_GLEW "Build without PulseAudio, using only SDLAudio" OFF "CMAKE_SYSTEM_NAME STREQUAL Linux" OFF)
+cmake_dependent_option(USE_OPENGLES "Build targetting OpenGLESv2 instead of full OpenGL" OFF "CMAKE_SYSTEM_NAME STREQUAL Linux" OFF)
+cmake_dependent_option(USE_X11 "Build with X11/GLX support" ON "CMAKE_SYSTEM_NAME STREQUAL Linux" OFF)
+
 find_package(OpenGL QUIET)
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    find_package(X11)
-    find_package(PulseAudio)
+    if (USE_X11)
+        find_package(X11)
+        add_compile_definitions(X11_SUPPORTED)
+        set(GLX-LIB ${OPENGL_glx_LIBRARY})
+        set(X11-LIBS ${X11_LIBRARIES})
+    else()
+        message(STATUS "Disabling X11/GLX")
+    endif()
+
+    if (NOT NO_PULSE)
+        find_package(PulseAudio)
+        set(PULSE-LIB ${PULSEAUDIO_LIBRARY})
+    else()
+        add_compile_definitions(NO_PULSE)
+        message(STATUS "Disabling Pulse")
+    endif()
 endif()
 
-if (NOT GLEW_FOUND)
-    set(GLEW-LIB glew_s)
+if (NOT NO_GLEW)
+    if (NOT GLEW_FOUND)
+        set(GLEW-LIB glew_s)
+    else()
+        set(GLEW-LIB  GLEW::GLEW)
+    endif()
 else()
-    set(GLEW-LIB  GLEW::GLEW)
+    message(STATUS "Disabling GLEW")
+    add_compile_definitions(NO_GLEW)
 endif()
- 
+
+if (USE_OPENGLES)
+    add_compile_definitions(USE_OPENGLES IMGUI_IMPL_OPENGL_ES3)
+    find_library(OPENGL-LIB GLESv2)
+    if (NOT OPENGL-LIB)
+        message(FATAL_ERROR "USE_OPENGLES=ON, but libGLESv2 could not be found")
+    endif()
+    message(STATUS "Building with OpenGLESv2")
+else()
+    set(OPENGL-LIB ${OPENGL_opengl_LIBRARY})
+endif()
+
 if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
     if("${CMAKE_VS_PLATFORM_NAME}" STREQUAL "x64")
         target_link_libraries(${PROJECT_NAME}
@@ -702,11 +742,11 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "CafeOS")
 else()
     target_link_libraries(${PROJECT_NAME}
         SDL2::SDL2
-        ${PULSEAUDIO_LIBRARY}
+        ${PULSE-LIB}
         ${GLEW-LIB}
-        ${OPENGL_glx_LIBRARY}
-        ${OPENGL_opengl_LIBRARY}
-        ${X11_LIBRARIES}
+        ${GLX-LIB}
+        ${OPENGL-LIB}
+        ${X11-LIBS}
         storm
     )
 endif()

--- a/libultraship/libultraship/CMakeLists.txt
+++ b/libultraship/libultraship/CMakeLists.txt
@@ -645,7 +645,7 @@ endif()
 # Link with other targets.
 
 cmake_dependent_option(NO_GLEW "Build without using libGLEW" OFF "CMAKE_SYSTEM_NAME STREQUAL Linux" OFF)
-cmake_dependent_option(NO_GLEW "Build without PulseAudio, using only SDLAudio" OFF "CMAKE_SYSTEM_NAME STREQUAL Linux" OFF)
+cmake_dependent_option(NO_PULSE "Build without PulseAudio, using only SDLAudio" OFF "CMAKE_SYSTEM_NAME STREQUAL Linux" OFF)
 cmake_dependent_option(USE_OPENGLES "Build targetting OpenGLESv2 instead of full OpenGL" OFF "CMAKE_SYSTEM_NAME STREQUAL Linux" OFF)
 cmake_dependent_option(USE_X11 "Build with X11/GLX support" ON "CMAKE_SYSTEM_NAME STREQUAL Linux" OFF)
 

--- a/libultraship/libultraship/ImGuiImpl.cpp
+++ b/libultraship/libultraship/ImGuiImpl.cpp
@@ -227,6 +227,9 @@ namespace SohImGui {
         case Backend::SDL:
         #if defined(__APPLE__)
             ImGui_ImplOpenGL3_Init("#version 410 core");
+		#elif defined(USE_OPENGLES)
+            // Let ImGui try to figure this out. Should be something like #version 320 es
+            ImGui_ImplOpenGL3_Init(NULL);
         #else
             ImGui_ImplOpenGL3_Init("#version 120");
         #endif

--- a/libultraship/libultraship/Lib/Fast3D/gfx_opengl.cpp
+++ b/libultraship/libultraship/Lib/Fast3D/gfx_opengl.cpp
@@ -34,6 +34,11 @@
 #elif __SWITCH__
 #include <SDL2/SDL.h>
 #include <glad/glad.h>
+#elif NO_GLEW
+ #define GL_GLEXT_PROTOTYPES 1
+ #include <SDL2/SDL_opengles2.h>
+ #include <GL/gl.h>
+ #include <GL/glext.h>
 #else
 #include <SDL2/SDL.h>
 #include <GL/glew.h>
@@ -716,7 +721,7 @@ static void gfx_opengl_draw_triangles(float buf_vbo[], size_t buf_vbo_len, size_
 }
 
 static void gfx_opengl_init(void) {
-#ifndef __SWITCH__
+#if !(defined(__SWITCH__) || defined(NO_GLEW))
     glewInit();
 #endif
 

--- a/libultraship/libultraship/PulseAudioPlayer.cpp
+++ b/libultraship/libultraship/PulseAudioPlayer.cpp
@@ -1,4 +1,4 @@
-#if defined(__linux__) || defined(__BSD__)
+#if !defined(NO_PULSE) && defined(__linux__) || defined(__BSD__)
 
 #include "PulseAudioPlayer.h"
 #include <spdlog/spdlog.h>

--- a/libultraship/libultraship/PulseAudioPlayer.h
+++ b/libultraship/libultraship/PulseAudioPlayer.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(__linux__) || defined(__BSD__)
+#if !defined(NO_PULSE) && defined(__linux__) || defined(__BSD__)
 
 #include "AudioPlayer.h"
 #include <pulse/pulseaudio.h>

--- a/libultraship/libultraship/Window.cpp
+++ b/libultraship/libultraship/Window.cpp
@@ -398,7 +398,7 @@ namespace Ship {
     void Window::InitializeAudioPlayer() {
 #ifdef _WIN32
         APlayer = std::make_shared<WasapiAudioPlayer>();
-#elif defined(__linux)
+#elif defined(__linux) && !defined(NO_PULSE)
         APlayer = std::make_shared<PulseAudioPlayer>();
 #else
         APlayer = std::make_shared<SDLAudioPlayer>();

--- a/soh/CMakeLists.txt
+++ b/soh/CMakeLists.txt
@@ -1961,6 +1961,10 @@ else()
     find_package(SDL2)
     set(THREADS_PREFER_PTHREAD_FLAG ON)
     find_package(Threads REQUIRED)
+    if(NO_PULSE)
+        add_compile_definitions(NO_PULSE)
+    endif()
+
  	set(ADDITIONAL_LIBRARY_DEPENDENCIES
         "libultraship;"
         "ZAPDUtils;"


### PR DESCRIPTION
This PR has been split up into the following components:
 - `NO_PULSE` - #1922
 - `USE_OPENGLES` - #1924
 - `NO_GLEW` - #1925
 - `USE_X11` - TBD
 - `BUILD_OTR_GUI` - No longer needed
---

## Motivation
I would like to see SoH able to be run on small embedded devices, such as a Raspberry Pi, or my goal in particular, retro handhelds such as the Anbernic RG series. This PR is a step in that direction, by allowing certain dependencies to be trimmed/replaced with alternatives that are better suited for embedded Linux environments.

This PR is marked as a draft because there is still some cleaning up that needs to be done, but I want to get feedback first to determine if it is worth spending more time on it.

## Changes
The following options to libultraship's CMake have been added
 - `NO_GLEW` - Set to `ON` to use SDL's extensions instead of GLEW.
 - `USE_OPENGLES` - Set to `ON` to link against `libGLESv2` instead of `libGL`. This requires using the newer glsl that MacOS uses.
 - `NO_PULSE` - Set to `ON` to use SDL Audio instead of the pulseaudio backend.
 - `USE_X11` - When set to `OFF`, do not link against `-lX11`. The default is now `ON` (currently, nothing defines `X11_SUPPORTED`)
 - `BUILD_OTR_GUI` - Set to `ON` to build the `OTRGui` tool. Defaults to `ON`. Will still not build on systems matching `Darwin|NintendoSwitch|CafeOS`. 

## Building
This can be tested by supplying the following options during the CMake generation step:
```bash
$ cmake -H. -Bbuild-cmake -GNinja -DNO_GLEW=ON -DNO_PULSE=ON -DUSE_OPENGLES=ON -DUSE_X11=OFF -DBUILD_OTR_GUI=OFF

# other commands as normal
$ cmake --build build-cmake --target ExtractAssets
$ cmake --build build-cmake
```

## Known Issues / Open Questions / Misc Implementation Details
 - `pkg-config --libs glew` includes `-lX11` as one of the flags, so `X11=0` might also depend on `NO_GLEW=1`
 - It seems the naming convention for Makefile options is the opposite of what I implemented (e.g. `X11=0` vs `NO_X11=1`), will go back and change if needed
 - The fragment shader uses `#version 130`, because it needs `textureSize`. Unfortunately, the earliest ES version that supplies that function is `#version 300 es`, which is based on glsl version 3.30. Since MacOS already has a newer glsl version, this borrows that implementation. I honestly don't know what the implications are of this, I am not terribly experienced with OpenGL.
 -  ~~`ZAPDTR` links against `libultraship.a`, which pulls in a lot of the same linker dependencies as `soh.elf`. I suspect a lot of those can also be wholesale trimmed if the entire archive isn't linked in, and only certain files are included instead. This would also aid cross compilation builds, but that seems out of scope for this PR.~~ This may have been addressed by the CMake overhaul

## Testing
So far, I have only tested these changes on my Linux desktop. Unless I messed up an `#ifdef` somewhere, this should not affect Windows/Mac/Switch, but I will look into personally testing on at least Windows.

I am aware that adding a lot of options introduces a lot of complexity with how many combinations of libraries are used. I have tried to make sure that each current option does not affect others (exception being that building with GLEW implies `-lX11`), and have at least compile tested all default, all enabled, and each individual options.

## Results
The following is the output of `ldd soh.elf` on my system before and after these changes:
```
# Regular make with no options set
$ ldd soh.elf 
	linux-vdso.so.1 (0x00007ffe247ef000)
	libSDL2-2.0.so.0 => /usr/lib/libSDL2-2.0.so.0 (0x00007eff6a24f000)
	libbz2.so.1.0 => /usr/lib/libbz2.so.1.0 (0x00007eff6b37b000)
	libz.so.1 => /usr/lib/libz.so.1 (0x00007eff6b361000)
	libGLEW.so.2.2 => /usr/lib/libGLEW.so.2.2 (0x00007eff6a192000)
	libGL.so.1 => /usr/lib/libGL.so.1 (0x00007eff6b2db000)
	libX11.so.6 => /usr/lib/libX11.so.6 (0x00007eff6a04f000)
	libGLU.so.1 => /usr/lib/libGLU.so.1 (0x00007eff69ff9000)
	libOpenGL.so.0 => /usr/lib/libOpenGL.so.0 (0x00007eff69fcd000)
	libpulse.so.0 => /usr/lib/libpulse.so.0 (0x00007eff69f78000)
	libstdc++.so.6 => /usr/lib/libstdc++.so.6 (0x00007eff69c00000)
	libm.so.6 => /usr/lib/libm.so.6 (0x00007eff69e91000)
	libgcc_s.so.1 => /usr/lib/libgcc_s.so.1 (0x00007eff69e71000)
	libc.so.6 => /usr/lib/libc.so.6 (0x00007eff69800000)
	/lib64/ld-linux-x86-64.so.2 => /usr/lib64/ld-linux-x86-64.so.2 (0x00007eff6b3da000)
	libGLdispatch.so.0 => /usr/lib/libGLdispatch.so.0 (0x00007eff69b48000)
	libGLX.so.0 => /usr/lib/libGLX.so.0 (0x00007eff69e3e000)
	libxcb.so.1 => /usr/lib/libxcb.so.1 (0x00007eff69b1d000)
	libpulsecommon-16.1.so => /usr/lib/pulseaudio/libpulsecommon-16.1.so (0x00007eff69a95000)
	libdbus-1.so.3 => /usr/lib/libdbus-1.so.3 (0x00007eff69a42000)
	libXau.so.6 => /usr/lib/libXau.so.6 (0x00007eff6b2d0000)
	libXdmcp.so.6 => /usr/lib/libXdmcp.so.6 (0x00007eff6b2c8000)
	libsndfile.so.1 => /usr/lib/libsndfile.so.1 (0x00007eff69780000)
	libsystemd.so.0 => /usr/lib/libsystemd.so.0 (0x00007eff696a2000)
	libasyncns.so.0 => /usr/lib/libasyncns.so.0 (0x00007eff69a3a000)
	libvorbisenc.so.2 => /usr/lib/libvorbisenc.so.2 (0x00007eff695f7000)
	libFLAC.so.8 => /usr/lib/libFLAC.so.8 (0x00007eff695b9000)
	libopus.so.0 => /usr/lib/libopus.so.0 (0x00007eff6955f000)
	libvorbis.so.0 => /usr/lib/libvorbis.so.0 (0x00007eff69a0c000)
	libogg.so.0 => /usr/lib/libogg.so.0 (0x00007eff69554000)
	libcap.so.2 => /usr/lib/libcap.so.2 (0x00007eff69548000)
	libgcrypt.so.20 => /usr/lib/libgcrypt.so.20 (0x00007eff693ff000)
	liblzma.so.5 => /usr/lib/liblzma.so.5 (0x00007eff693d5000)
	libzstd.so.1 => /usr/lib/libzstd.so.1 (0x00007eff6932c000)
	liblz4.so.1 => /usr/lib/liblz4.so.1 (0x00007eff69309000)
	libgpg-error.so.0 => /usr/lib/libgpg-error.so.0 (0x00007eff692e3000)
```
```
# make NO_GLEW=1 NO_PULSE=1 USE_OPENGLES=1
$ ldd soh.elf
	linux-vdso.so.1 (0x00007ffcc9d75000)
	libSDL2-2.0.so.0 => /usr/lib/libSDL2-2.0.so.0 (0x00007f211ea4f000)
	libbz2.so.1.0 => /usr/lib/libbz2.so.1.0 (0x00007f211fc4b000)
	libz.so.1 => /usr/lib/libz.so.1 (0x00007f211fc31000)
	libGLESv2.so.2 => /usr/lib/libGLESv2.so.2 (0x00007f211fc1e000)
	libstdc++.so.6 => /usr/lib/libstdc++.so.6 (0x00007f211e800000)
	libm.so.6 => /usr/lib/libm.so.6 (0x00007f211fb37000)
	libgcc_s.so.1 => /usr/lib/libgcc_s.so.1 (0x00007f211fb15000)
	libc.so.6 => /usr/lib/libc.so.6 (0x00007f211e400000)
	/lib64/ld-linux-x86-64.so.2 => /usr/lib64/ld-linux-x86-64.so.2 (0x00007f211fcaa000)
	libGLdispatch.so.0 => /usr/lib/libGLdispatch.so.0 (0x00007f211e748000)
```
