### PR TITLE
Fix Navi HUD text regression

### DIFF
--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -3343,8 +3343,8 @@ void Interface_DrawItemButtons(GlobalContext* globalCtx) {
     const s16 C_Right_BTN_Pos_ori[] = { C_RIGHT_BUTTON_X+X_Margins_CR, C_RIGHT_BUTTON_Y+Y_Margins_CR };
     const s16 C_Up_BTN_Pos_ori[]    = { C_UP_BUTTON_X+X_Margins_CU, C_UP_BUTTON_Y+Y_Margins_CU };
     const s16 C_Down_BTN_Pos_ori[]  = { C_DOWN_BUTTON_X+X_Margins_CD, C_DOWN_BUTTON_Y+Y_Margins_CD };
-    s16 LabelX_Navi=8;
-    s16 LabelY_Navi=4 - !!CVar_GetS32("gNaviTextFix", 0);
+    s16 LabelX_Navi=8 - !!CVar_GetS32("gNaviTextFix", 0);
+    s16 LabelY_Navi=4;
     s16 C_Left_BTN_Pos[2]; //(X,Y)
     s16 C_Right_BTN_Pos[2];
     s16 C_Up_BTN_Pos[2];

--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -3343,7 +3343,7 @@ void Interface_DrawItemButtons(GlobalContext* globalCtx) {
     const s16 C_Right_BTN_Pos_ori[] = { C_RIGHT_BUTTON_X+X_Margins_CR, C_RIGHT_BUTTON_Y+Y_Margins_CR };
     const s16 C_Up_BTN_Pos_ori[]    = { C_UP_BUTTON_X+X_Margins_CU, C_UP_BUTTON_Y+Y_Margins_CU };
     const s16 C_Down_BTN_Pos_ori[]  = { C_DOWN_BUTTON_X+X_Margins_CD, C_DOWN_BUTTON_Y+Y_Margins_CD };
-    s16 LabelX_Navi=8 - !!CVar_GetS32("gNaviTextFix", 0);
+    s16 LabelX_Navi=7 + !!CVar_GetS32("gNaviTextFix", 0);
     s16 LabelY_Navi=4;
     s16 C_Left_BTN_Pos[2]; //(X,Y)
     s16 C_Right_BTN_Pos[2];


### PR DESCRIPTION
Looks like this got broken in some HUD refactoring. The fix is moving the text one unit *left* (X-axis) not one unit *up* (Y-axis). Pointed at Rachael because this was previously working correctly.