### PR TITLE
Fixes Biggoron forge time being 0 days by default

### DIFF
--- a/soh/soh/Enhancements/bootcommands.c
+++ b/soh/soh/Enhancements/bootcommands.c
@@ -25,6 +25,7 @@ void BootCommands_Init()
     CVar_RegisterS32("gDebugEnabled", 0);
     CVar_RegisterS32("gLanguages", 0); //0 = English / 1 = German / 2 = French
     CVar_RegisterS32("gHudColors", 1); //0 = N64 / 1 = NGC / 2 = Custom
+	CVar_RegisterS32("gForgeTime", 3);
 }
 
 //void BootCommands_ParseBootArgs(char* str)


### PR DESCRIPTION
When the bootcommands file was cleaned up, this one was accidentally left out, this adds it back, as the default should be 3 days.