### PR TITLE
Moves release version text

### DIFF
--- a/soh/src/overlays/gamestates/ovl_title/z_title.c
+++ b/soh/src/overlays/gamestates/ovl_title/z_title.c
@@ -39,8 +39,10 @@ void Title_PrintBuildInfo(Gfx** gfxp) {
     GfxPrint_Printf(&printer, "GCC SHIP");
 #endif
 
-    GfxPrint_SetPos(&printer, 5, 4);
+    GfxPrint_SetPos(&printer, 1, 4);
     GfxPrint_Printf(&printer, "Game Version: %s", gameVersionStr);
+    GfxPrint_SetPos(&printer, 1, 5);
+    GfxPrint_Printf(&printer, "Release Version: %s", gBuildVersion);
 
     GfxPrint_SetColor(&printer, 255, 255, 255, 255);
     GfxPrint_SetPos(&printer, 2, 22);
@@ -49,8 +51,6 @@ void Title_PrintBuildInfo(Gfx** gfxp) {
     GfxPrint_Printf(&printer, "Build Date:%s", gBuildDate);
     GfxPrint_SetPos(&printer, 3, 26);
     GfxPrint_Printf(&printer, "%s", gBuildTeam);
-    GfxPrint_SetPos(&printer, 3, 28);
-    GfxPrint_Printf(&printer, "Release Version: %s", gBuildVersion);
     g = GfxPrint_Close(&printer);
     GfxPrint_Destroy(&printer);
     *gfxp = g;


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/60364512/182709171-7a81a66d-ec72-4329-bb25-1e3a6328e34d.png)

After:
![image](https://user-images.githubusercontent.com/60364512/182709141-9ae2b1dc-3e7a-4cb8-a90a-6bfdeb24d22d.png)

Fixes #409 

Previously, the F1 notification text overlapped the release version text at the default windowed resolution, moving that text up seemed like the simpler solution, and this new position makes more sense next to the game version text, imo