### PR TITLE
Fix same name controllers entry being un-selectable

### DIFF
--- a/libultraship/libultraship/InputEditor.cpp
+++ b/libultraship/libultraship/InputEditor.cpp
@@ -95,7 +95,11 @@ namespace Ship {
 
 		if (ControllerName != nullptr && ImGui::BeginCombo("##ControllerEntries", ControllerName)) {
 			for (uint8_t i = 0; i < devices.size(); i++) {
-				if (ImGui::Selectable(devices[i]->GetControllerName(), i == vDevices[CurrentPort])) {
+				std::string DeviceName = devices[i]->GetControllerName();
+				if (DeviceName != "Keyboard" && DeviceName != "Auto") {
+					DeviceName+="##"+std::to_string(i);
+				}
+				if (ImGui::Selectable(DeviceName.c_str(), i == vDevices[CurrentPort])) {
 					Window::ControllerApi->SetPhysicalDevice(CurrentPort, i);
 				}
 			}


### PR DESCRIPTION
This fix being unable to select both entry of controller that has same ID and Name 
for example myself, with Mayflash mf103 in my tests got two port both ports has same name and ID rendering the first port unusable without unique name.

This may fix Mayflash GameCube adapter that has 4 port too, you will be able to use port 1 to 4 and map them correctly this way.
if anyone with such adapter could confirm :)

