### PR TITLE
Fixes glitchy dungeon maps.

### DIFF
--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
@@ -3228,10 +3228,9 @@ void KaleidoScope_LoadDungeonMap(GlobalContext* globalCtx) {
 
     char* firstTextureName = sDungeonMapTexs[R_MAP_TEX_INDEX];
     char* secondTextureName = sDungeonMapTexs[R_MAP_TEX_INDEX + 1];
-    uint32_t firstTextureSize = ResourceMgr_LoadTexSizeByName(firstTextureName);
 
     memcpy(interfaceCtx->mapSegment, ResourceMgr_LoadTexByName(firstTextureName), ResourceMgr_LoadTexSizeByName(firstTextureName));
-    memcpy(interfaceCtx->mapSegment + (firstTextureSize / 2), ResourceMgr_LoadTexByName(secondTextureName), ResourceMgr_LoadTexSizeByName(secondTextureName));
+    memcpy(interfaceCtx->mapSegment + 0x800, ResourceMgr_LoadTexByName(secondTextureName), ResourceMgr_LoadTexSizeByName(secondTextureName));
 }
 
 void KaleidoScope_UpdateDungeonMap(GlobalContext* globalCtx) {


### PR DESCRIPTION
#610 seems to have caused an issue with the dungeon map textures not being aligned correctly. The maps are drawn by loading two textures and putting them into two different `mapSegments`, the second one offset by the first one by 0x800. #610 changed this to instead change this hardcoded 0x800 offset to the size of the first texture divided by 2. This causes the maps to glitch out on the pause menu. See #1029 for some picture examples. Using `ResourceMgr_LoadTexSizeByName` for the amount of data to memcpy into the segments seems to cause no issues, it's just the `mapSegment offset that seems to cause a problem.

This fix simply reverts this offset to its hardcoded 0x800.