### PR TITLE
don't use signed ints for epochs

### DIFF
--- a/soh/include/z64effect.h
+++ b/soh/include/z64effect.h
@@ -25,7 +25,7 @@ typedef struct {
     /* 0x0C */ Vec3f position;
     /* 0x18 */ Vec3s unkVelocity;
     /* 0x1E */ Vec3s unkPosition;
-    /* 0x24 */ s32 epoch;
+    /* 0x24 */ u32 epoch;
 } EffectSparkElement; // size = 0x28
 
 typedef struct {
@@ -118,7 +118,7 @@ typedef struct {
     /* 0x10 */ f32 startX;
     /* 0x14 */ s16 yaw;
     /* 0x16 */ s16 pitch;
-    /* 0x18 */ s32 epoch;
+    /* 0x18 */ u32 epoch;
 } EffectShieldParticleElement; // size = 0x1C
 
 typedef struct {

--- a/soh/src/code/z_actor.c
+++ b/soh/src/code/z_actor.c
@@ -3973,7 +3973,7 @@ void Actor_DrawDoorLock(GlobalContext* globalCtx, s32 frame, s32 type) {
     f32 chainsTranslateX;
     f32 chainsTranslateY;
     f32 rotZStep;
-    static s32 epoch = 0;
+    static u32 epoch = 0;
     epoch++;
 
     entry = &sDoorLocksInfo[type];

--- a/soh/src/code/z_kankyo.c
+++ b/soh/src/code/z_kankyo.c
@@ -1459,7 +1459,7 @@ void Environment_DrawLensFlare(GlobalContext* globalCtx, EnvironmentContext* env
         LENS_FLARE_RING,    LENS_FLARE_CIRCLE1, LENS_FLARE_CIRCLE1, LENS_FLARE_CIRCLE1, LENS_FLARE_CIRCLE1,
         LENS_FLARE_CIRCLE1, LENS_FLARE_CIRCLE1, LENS_FLARE_CIRCLE1, LENS_FLARE_CIRCLE1, LENS_FLARE_CIRCLE1,
     };
-    static s32 epoch = 0;
+    static u32 epoch = 0;
     epoch++;
 
     OPEN_DISPS(gfxCtx);
@@ -1642,7 +1642,7 @@ void Environment_DrawRain(GlobalContext* globalCtx, View* view, GraphicsContext*
     Vec3f unused = { 0.0f, 0.0f, 0.0f };
     Vec3f windDirection = { 0.0f, 0.0f, 0.0f };
     Player* player = GET_PLAYER(globalCtx);
-    static s32 epoch = 0;
+    static u32 epoch = 0;
     epoch++;
 
     if (!(globalCtx->cameraPtrs[0]->unk_14C & 0x100) && (globalCtx->envCtx.unk_EE[2] == 0)) {
@@ -1925,7 +1925,7 @@ void Environment_DrawLightning(GlobalContext* globalCtx, s32 unused) {
     s32 pad[2];
     Vec3f unused1 = { 0.0f, 0.0f, 0.0f };
     Vec3f unused2 = { 0.0f, 0.0f, 0.0f };
-    static s32 epoch = 0;
+    static u32 epoch = 0;
     epoch++;
 
     OPEN_DISPS(globalCtx->state.gfxCtx);

--- a/soh/src/code/z_lifemeter.c
+++ b/soh/src/code/z_lifemeter.c
@@ -413,7 +413,7 @@ void HealthMeter_Draw(GlobalContext* globalCtx) {
     s32 curCombineModeSet = 0;
     u8* curBgImgLoaded = NULL;
     s32 ddHeartCountMinusOne = gSaveContext.inventory.defenseHearts - 1;
-    static s32 epoch = 0;
+    static u32 epoch = 0;
     epoch++;
 
     OPEN_DISPS(gfxCtx);

--- a/soh/src/overlays/actors/ovl_Bg_Dy_Yoseizo/z_bg_dy_yoseizo.h
+++ b/soh/src/overlays/actors/ovl_Bg_Dy_Yoseizo/z_bg_dy_yoseizo.h
@@ -24,7 +24,7 @@ typedef struct {
     /* 0x36 */ f32 pitch;
     /* 0x36 */ f32 yaw;
     /* 0x40 */ f32 roll;
-    /* 0x44 */ s32 epoch;
+    /* 0x44 */ u32 epoch;
 } BgDyYoseizoParticle; // size = 0x48
 
 typedef struct BgDyYoseizo {

--- a/soh/src/overlays/actors/ovl_Bg_Jya_Megami/z_bg_jya_megami.h
+++ b/soh/src/overlays/actors/ovl_Bg_Jya_Megami/z_bg_jya_megami.h
@@ -13,7 +13,7 @@ typedef struct {
     /* 0x0C */ Vec3f vel;
     /* 0x18 */ s16 rotVelX;
     /* 0x1A */ s16 rotVelY;
-    /* 0x1C */ s32 epoch;
+    /* 0x1C */ u32 epoch;
 } BgJyaMegamiPiece; // size = 0x20
 
 typedef struct BgJyaMegami {

--- a/soh/src/overlays/actors/ovl_Bg_Spot00_Hanebasi/z_bg_spot00_hanebasi.c
+++ b/soh/src/overlays/actors/ovl_Bg_Spot00_Hanebasi/z_bg_spot00_hanebasi.c
@@ -261,7 +261,7 @@ void BgSpot00Hanebasi_DrawTorches(Actor* thisx, GlobalContext* globalCtx2) {
     GlobalContext* globalCtx = globalCtx2;
     f32 angle;
     s32 i;
-    static s32 epoch = 0;
+    static u32 epoch = 0;
     epoch++;
 
     OPEN_DISPS(globalCtx->state.gfxCtx);

--- a/soh/src/overlays/actors/ovl_Boss_Dodongo/z_boss_dodongo.h
+++ b/soh/src/overlays/actors/ovl_Boss_Dodongo/z_boss_dodongo.h
@@ -17,7 +17,7 @@ typedef struct {
     /* 0x26 */ Color_RGB8 color;
     /* 0x2A */ s16 alpha;
     /* 0x2C */ f32 unk_2C;
-    /* 0x30 */ s32 epoch;
+    /* 0x30 */ u32 epoch;
 } BossDodongoEffect; // Size = 0x34
 
 typedef struct BossDodongo {

--- a/soh/src/overlays/actors/ovl_Boss_Fd/z_boss_fd.c
+++ b/soh/src/overlays/actors/ovl_Boss_Fd/z_boss_fd.c
@@ -1835,7 +1835,7 @@ void BossFd_DrawBody(GlobalContext* globalCtx, BossFd* this) {
     s16 i;
     f32 temp_float;
     Mtx* tempMat = Graph_Alloc(globalCtx->state.gfxCtx, 18 * sizeof(Mtx));
-    static s32 epoch = 0;
+    static u32 epoch = 0;
     epoch++;
 
     OPEN_DISPS(globalCtx->state.gfxCtx);

--- a/soh/src/overlays/actors/ovl_Boss_Fd2/z_boss_fd2.h
+++ b/soh/src/overlays/actors/ovl_Boss_Fd2/z_boss_fd2.h
@@ -87,7 +87,7 @@ typedef struct BossFd2 {
     /* 0x1394 */ BossFd2Cam camData;
     /* 0x141C */ ColliderJntSph collider;
     /* 0x143C */ ColliderJntSphElement elements[9];
-    /* 0x167C */ s32 epoch;
+    /* 0x167C */ u32 epoch;
 } BossFd2; // size = 0x1680
 
 #endif

--- a/soh/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.c
+++ b/soh/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.c
@@ -3356,7 +3356,7 @@ void BossGanon_DrawShock(BossGanon* this, GlobalContext* globalCtx) {
     s32 pad;
     GraphicsContext* gfxCtx = globalCtx->state.gfxCtx;
     s16 i;
-    static s32 epoch = 0;
+    static u32 epoch = 0;
     epoch++;
 
     OPEN_DISPS(gfxCtx);
@@ -3463,7 +3463,7 @@ void BossGanon_DrawBigMagicCharge(BossGanon* this, GlobalContext* globalCtx) {
     f32 yRot;
     GraphicsContext* gfxCtx = globalCtx->state.gfxCtx;
     s16 i;
-    static s32 epoch = 0;
+    static u32 epoch = 0;
     epoch++;
 
     OPEN_DISPS(gfxCtx);
@@ -4158,7 +4158,7 @@ void BossGanon_LightBall_Draw(Actor* thisx, GlobalContext* globalCtx) {
     s16 i;
     f32 alpha;
     s32 pad;
-    static s32 epoch = 0;
+    static u32 epoch = 0;
     epoch++;
 
     OPEN_DISPS(globalCtx->state.gfxCtx);

--- a/soh/src/overlays/actors/ovl_Boss_Ganon2/z_boss_ganon2.c
+++ b/soh/src/overlays/actors/ovl_Boss_Ganon2/z_boss_ganon2.c
@@ -2464,7 +2464,7 @@ void func_80904340(BossGanon2* this, GlobalContext* globalCtx) {
     f32 angle;
     f32 sin;
     f32 cos;
-    static s32 epoch = 0;
+    static u32 epoch = 0;
     epoch++;
 
     OPEN_DISPS(globalCtx->state.gfxCtx);
@@ -2637,7 +2637,7 @@ void BossGanon2_PostLimbDraw(GlobalContext* globalCtx, s32 limbIndex, Gfx** dLis
 void func_80904D88(BossGanon2* this, GlobalContext* globalCtx) {
     s32 pad;
     s16 i;
-    static s32 epoch = 0;
+    static u32 epoch = 0;
     epoch++;
 
     OPEN_DISPS(globalCtx->state.gfxCtx);
@@ -2701,7 +2701,7 @@ void func_80904FC8(BossGanon2* this, GlobalContext* globalCtx) {
 void func_8090523C(BossGanon2* this, GlobalContext* globalCtx) {
     Player* player;
     f32 phi_f20;
-    static s32 epoch = 0;
+    static u32 epoch = 0;
     epoch++;
 
     OPEN_DISPS(globalCtx->state.gfxCtx);
@@ -2933,7 +2933,7 @@ void func_809060E8(GlobalContext* globalCtx) {
     BossGanon2Effect* effect;
     s16 i;
     BossGanon2Effect* effects;
-    static s32 epoch = 0;
+    static u32 epoch = 0;
     epoch++;
 
     effects = effect = globalCtx->specialEffects;

--- a/soh/src/overlays/actors/ovl_Boss_Mo/z_boss_mo.c
+++ b/soh/src/overlays/actors/ovl_Boss_Mo/z_boss_mo.c
@@ -2443,7 +2443,7 @@ void BossMo_DrawTentacle(BossMo* this, GlobalContext* globalCtx) {
     f32 phi_f20;
     f32 phi_f22;
     Vec3f sp110;
-    static s32 epoch = 0;
+    static u32 epoch = 0;
     epoch++;
 
     OPEN_DISPS(globalCtx->state.gfxCtx);

--- a/soh/src/overlays/actors/ovl_Boss_Sst/z_boss_sst.c
+++ b/soh/src/overlays/actors/ovl_Boss_Sst/z_boss_sst.c
@@ -2706,7 +2706,7 @@ s32 BossSst_OverrideHandTrailDraw(GlobalContext* globalCtx, s32 limbIndex, Gfx**
 
 void BossSst_DrawHand(Actor* thisx, GlobalContext* globalCtx) {
     BossSst* this = (BossSst*)thisx;
-    static s32 epoch = 0;
+    static u32 epoch = 0;
     epoch++;
 
     OPEN_DISPS(globalCtx->state.gfxCtx);

--- a/soh/src/overlays/actors/ovl_Boss_Sst/z_boss_sst.h
+++ b/soh/src/overlays/actors/ovl_Boss_Sst/z_boss_sst.h
@@ -17,7 +17,7 @@ typedef struct {
     /* 0x0020 */ s16 move;
     /* 0x0022 */ s16 status;
     /* 0x0024 */ u8 alpha;
-    /* 0x0028 */ s32 epoch;
+    /* 0x0028 */ u32 epoch;
 } BossSstEffect; // size = 0x2C
 
 typedef struct {

--- a/soh/src/overlays/actors/ovl_Boss_Tw/z_boss_tw.c
+++ b/soh/src/overlays/actors/ovl_Boss_Tw/z_boss_tw.c
@@ -3329,7 +3329,7 @@ void func_80942180(BossTw* this, GlobalContext* globalCtx) {
 void func_809426F0(BossTw* this, GlobalContext* globalCtx) {
     s32 pad;
     s16 i;
-    static s32 epoch = 0;
+    static u32 epoch = 0;
     epoch++;
 
     OPEN_DISPS(globalCtx->state.gfxCtx);
@@ -4418,7 +4418,7 @@ void BossTw_BlastDraw(Actor* thisx, GlobalContext* globalCtx2) {
     f32 scaleFactor;
     s16 tailIdx;
     s16 i;
-    static s32 epoch = 0;
+    static u32 epoch = 0;
     epoch++;
 
     OPEN_DISPS(globalCtx->state.gfxCtx);
@@ -4492,7 +4492,7 @@ void BossTw_DrawDeathBall(Actor* thisx, GlobalContext* globalCtx2) {
     f32 scaleFactor;
     s16 tailIdx;
     s16 i;
-    static s32 epoch = 0;
+    static u32 epoch = 0;
     epoch++;
 
     OPEN_DISPS(globalCtx->state.gfxCtx);

--- a/soh/src/overlays/actors/ovl_Boss_Tw/z_boss_tw.h
+++ b/soh/src/overlays/actors/ovl_Boss_Tw/z_boss_tw.h
@@ -43,7 +43,7 @@ typedef struct {
     /* 0x002E */ s16 work[EFF_WORK_MAX];
     /* 0x0034 */ f32 workf[EFF_FWORK_MAX];
     /* 0x0044 */ Actor* target;
-                 s32 epoch;
+                 u32 epoch;
 } BossTwEffect;
 
 typedef enum {

--- a/soh/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
+++ b/soh/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
@@ -4006,7 +4006,7 @@ void BossVa_DrawDoor(GlobalContext* globalCtx, s16 scale) {
     f32 yScale;
     f32 segAngle = 0.0f;
     s32 i;
-    static s32 epoch = 0;
+    static u32 epoch = 0;
     epoch++;
 
     OPEN_DISPS(globalCtx->state.gfxCtx);

--- a/soh/src/overlays/actors/ovl_Demo_6K/z_demo_6k.c
+++ b/soh/src/overlays/actors/ovl_Demo_6K/z_demo_6k.c
@@ -564,7 +564,7 @@ void func_80967FFC(Actor* thisx, GlobalContext* globalCtx) {
     Demo6K* this = (Demo6K*)thisx;
     s32 pad;
     u16 timer1 = this->timer1;
-    static s32 epoch = 0;
+    static u32 epoch = 0;
     epoch++;
 
     OPEN_DISPS(globalCtx->state.gfxCtx);
@@ -695,7 +695,7 @@ void func_809688C4(Actor* thisx, GlobalContext* globalCtx2) {
     GlobalContext* globalCtx = globalCtx2;
     u32 frames = globalCtx->state.frames;
     s32 i;
-    static s32 epoch = 0;
+    static u32 epoch = 0;
     epoch++;
 
     if ((i = (globalCtx->csCtx.state != CS_STATE_IDLE) && (globalCtx->csCtx.npcActions[1] != NULL)) &&

--- a/soh/src/overlays/actors/ovl_Demo_Kankyo/z_demo_kankyo.c
+++ b/soh/src/overlays/actors/ovl_Demo_Kankyo/z_demo_kankyo.c
@@ -522,7 +522,7 @@ void DemoKankyo_DrawRain(Actor* thisx, GlobalContext* globalCtx) {
     f32 translateY;
     f32 translateZ;
     s16 j;
-    static s32 epoch = 0;
+    static u32 epoch = 0;
     epoch++;
 
     OPEN_DISPS(globalCtx->state.gfxCtx);
@@ -663,7 +663,7 @@ void DemoKankyo_DrawClouds(Actor* thisx, GlobalContext* globalCtx) {
     f32 dx;
     f32 dy;
     f32 dz;
-    static s32 epoch = 0;
+    static u32 epoch = 0;
     epoch++;
 
     OPEN_DISPS(globalCtx->state.gfxCtx);
@@ -784,7 +784,7 @@ void DemoKankyo_DrawWarpSparkles(Actor* thisx, GlobalContext* globalCtx) {
     f32 translateZ;
     PosRot posRot;
     u8 linkAge = gSaveContext.linkAge;
-    static s32 epoch = 0;
+    static u32 epoch = 0;
     epoch++;
 
     OPEN_DISPS(globalCtx->state.gfxCtx);
@@ -933,7 +933,7 @@ void DemoKankyo_DrawSparkles(Actor* thisx, GlobalContext* globalCtx) {
     f32 scale;
     s16 i;
     PosRot posRot;
-    static s32 epoch = 0;
+    static u32 epoch = 0;
     epoch++;
 
     OPEN_DISPS(globalCtx->state.gfxCtx);

--- a/soh/src/overlays/actors/ovl_Efc_Erupc/z_efc_erupc.h
+++ b/soh/src/overlays/actors/ovl_Efc_Erupc/z_efc_erupc.h
@@ -19,7 +19,7 @@ typedef struct {
     /* 0x30 */ char unk_2C[4];
     /* 0x34 */ f32 scale;
     /* 0x38 */ char unk_34[8];
-    /* 0x3C */ s32 epoch;
+    /* 0x3C */ u32 epoch;
 } EfcErupcParticles; // size 0x40
 
 #define EFC_ERUPC_NUM_PARTICLES 100

--- a/soh/src/overlays/actors/ovl_Eff_Dust/z_eff_dust.c
+++ b/soh/src/overlays/actors/ovl_Eff_Dust/z_eff_dust.c
@@ -269,7 +269,7 @@ void EffDust_DrawFunc_8099E4F4(Actor* thisx, GlobalContext* globalCtx2) {
     f32* distanceTraveled;
     s32 i;
     f32 aux;
-    static s32 epoch = 0;
+    static u32 epoch = 0;
     epoch++;
 
     OPEN_DISPS(gfxCtx);
@@ -321,7 +321,7 @@ void EffDust_DrawFunc_8099E784(Actor* thisx, GlobalContext* globalCtx2) {
     s32 i;
     f32 aux;
     Player* player = GET_PLAYER(globalCtx);
-    static s32 epoch = 0;
+    static u32 epoch = 0;
     epoch++;
 
     OPEN_DISPS(gfxCtx);

--- a/soh/src/overlays/actors/ovl_En_Anubice_Fire/z_en_anubice_fire.h
+++ b/soh/src/overlays/actors/ovl_En_Anubice_Fire/z_en_anubice_fire.h
@@ -19,7 +19,7 @@ typedef struct EnAnubiceFire {
     /* 0x015E */ s16 unk_15E;
     /* 0x0178 */ Vec3f unk_160[6];
     /* 0x01A8 */ ColliderCylinder cylinder;
-    /* 0x01F4 */ s32 epoch;
+    /* 0x01F4 */ u32 epoch;
 } EnAnubiceFire; // size = 0x01F8
 
 #endif

--- a/soh/src/overlays/actors/ovl_En_Ba/z_en_ba.h
+++ b/soh/src/overlays/actors/ovl_En_Ba/z_en_ba.h
@@ -32,7 +32,7 @@ typedef struct EnBa {
     /* 0x031C */ s16 unk31C;
     /* 0x0320 */ ColliderJntSph collider;
     /* 0x0340 */ ColliderJntSphElement colliderItems[2];
-    /* 0x03C0 */ s32 epoch;
+    /* 0x03C0 */ u32 epoch;
 } EnBa; // size = 0x03C4
 
 #endif

--- a/soh/src/overlays/actors/ovl_En_Bx/z_en_bx.h
+++ b/soh/src/overlays/actors/ovl_En_Bx/z_en_bx.h
@@ -16,7 +16,7 @@ typedef struct EnBx {
     /* 0x01B4 */ Vec3s unk_1B4[4];
     /* 0x01CC */ ColliderCylinder collider;
     /* 0x0218 */ ColliderQuad colliderQuad;
-    /* 0x0298 */ s32 epoch;
+    /* 0x0298 */ u32 epoch;
 } EnBx; // size = 0x029C
 
 #endif

--- a/soh/src/overlays/actors/ovl_En_Clear_Tag/z_en_clear_tag.h
+++ b/soh/src/overlays/actors/ovl_En_Clear_Tag/z_en_clear_tag.h
@@ -88,7 +88,7 @@ typedef struct EnClearTagEffect {
     /* 0x0058 */ f32 rotationX;
     /* 0x005C */ f32 floorHeight;
     /* 0x0060 */ Vec3f floorTangent;
-    /* 0x006C */ s32 epoch;
+    /* 0x006C */ u32 epoch;
 } EnClearTagEffect; // size = 0x70
 
 #define CLEAR_TAG_EFFECT_MAX_COUNT 100

--- a/soh/src/overlays/actors/ovl_En_Encount2/z_en_encount2.h
+++ b/soh/src/overlays/actors/ovl_En_Encount2/z_en_encount2.h
@@ -14,7 +14,7 @@ typedef struct {
     /* 0x0010 */ u8 isAlive;
     /* 0x0014 */ Vec3f moveDirection;
     /* 0x0020 */ Vec3f rot;
-    /* 0x002C */ s32 epoch;
+    /* 0x002C */ u32 epoch;
 } EnEncount2Particle; // size = 0x30
 
 typedef struct EnEncount2 {

--- a/soh/src/overlays/actors/ovl_En_Fd/z_en_fd.h
+++ b/soh/src/overlays/actors/ovl_En_Fd/z_en_fd.h
@@ -25,7 +25,7 @@ typedef struct {
     /* 0x0014 */ Vec3f pos;
     /* 0x0020 */ Vec3f velocity;
     /* 0x002C */ Vec3f accel;
-                 s32 epoch;
+                 u32 epoch;
 } EnFdEffect; // size = 0x38
 
 typedef struct EnFd {

--- a/soh/src/overlays/actors/ovl_En_Fw/z_en_fw.h
+++ b/soh/src/overlays/actors/ovl_En_Fw/z_en_fw.h
@@ -19,7 +19,7 @@ typedef struct {
     /* 0x0014 */ Vec3f pos;
     /* 0x0020 */ Vec3f velocity;
     /* 0x002C */ Vec3f accel;
-                 s32 epoch;
+                 u32 epoch;
 } EnFwEffect;
 
 typedef struct EnFw {

--- a/soh/src/overlays/actors/ovl_En_Fz/z_en_fz.h
+++ b/soh/src/overlays/actors/ovl_En_Fz/z_en_fz.h
@@ -21,7 +21,7 @@ typedef struct {
     /* 0x0030 */ f32 xyScale; // 
     /* 0x0034 */ f32 xyScaleTarget; 
     /* 0x0038 */ u8 isTimerMod8; // conditional, used to run CollisionCheck_SetAT 
-                 s32 epoch;
+                 u32 epoch;
 } EnFzEffectSsIceSmoke; // size = 0x3C
 
 typedef struct EnFz {

--- a/soh/src/overlays/actors/ovl_En_G_Switch/z_en_g_switch.h
+++ b/soh/src/overlays/actors/ovl_En_G_Switch/z_en_g_switch.h
@@ -32,7 +32,7 @@ typedef struct {
     /* 0x12 */ u8 flag;
     /* 0x14 */ Vec3f velocity;
     /* 0x20 */ Vec3f rot;
-    s32 epoch;
+    u32 epoch;
 } EnGSwitchEffect; // size = 0x2C
 
 typedef struct EnGSwitch {

--- a/soh/src/overlays/actors/ovl_En_Gb/z_en_gb.h
+++ b/soh/src/overlays/actors/ovl_En_Gb/z_en_gb.h
@@ -27,7 +27,7 @@ typedef struct {
     /* 0x20 */ f32   unk_20;
     /* 0x24 */ f32   unk_24;
     /* 0x28 */ f32   unk_28;
-    s32 epoch;
+    u32 epoch;
 } EnGbCagedSoul; // size = 0x2C
 
 typedef struct EnGb {

--- a/soh/src/overlays/actors/ovl_En_Go/z_en_go.h
+++ b/soh/src/overlays/actors/ovl_En_Go/z_en_go.h
@@ -34,7 +34,7 @@ typedef struct {
     /* 0x0014 */ Vec3f pos;
     /* 0x0020 */ Vec3f velocity;
     /* 0x002C */ Vec3f accel;
-    s32 epoch;
+    u32 epoch;
 } EnGoEffect; // size = 0x38
 
 typedef struct EnGo {

--- a/soh/src/overlays/actors/ovl_En_Niw/z_en_niw.h
+++ b/soh/src/overlays/actors/ovl_En_Niw/z_en_niw.h
@@ -18,7 +18,7 @@ typedef struct {
     /* 0x002C */ f32 scale;
     /* 0x0030 */ f32 unk_30;
     /* 0x0034 */ u8 timer;
-    s32 epoch;
+    u32 epoch;
 } EnNiwFeather; // size = 0x0038
 
 typedef struct EnNiw {

--- a/soh/src/overlays/actors/ovl_En_Nwc/z_en_nwc.h
+++ b/soh/src/overlays/actors/ovl_En_Nwc/z_en_nwc.h
@@ -23,7 +23,7 @@ typedef struct EnNwcChick {
     /* 0x36 */ u16 height;
     /* 0x38 */ CollisionPoly* floorPoly;
     /* 0x44 */ char unk_3C[0x20]; 
-    s32 epoch;
+    u32 epoch;
 } EnNwcChick; // size = 0x5C
 
 typedef struct EnNwc {

--- a/soh/src/overlays/actors/ovl_En_Ny/z_en_ny.h
+++ b/soh/src/overlays/actors/ovl_En_Ny/z_en_ny.h
@@ -30,7 +30,7 @@ typedef struct EnNy {
     /* 0x01F0 */ f32 unk_1F0;
     /* 0x01F4 */ f32 unk_1F4;
     /* 0x01F8 */ Vec3f unk_1F8[16];
-    s32 epoch;
+    u32 epoch;
 } EnNy; // size = 0x02B8
 
 #endif

--- a/soh/src/overlays/actors/ovl_En_Po_Sisters/z_en_po_sisters.h
+++ b/soh/src/overlays/actors/ovl_En_Po_Sisters/z_en_po_sisters.h
@@ -29,7 +29,7 @@ typedef struct EnPoSisters {
     /* 0x029C */ LightInfo lightInfo;
     /* 0x02AC */ ColliderCylinder collider;
     /* 0x02F8 */ MtxF unk_2F8;
-    s32 epoch;
+    u32 epoch;
 } EnPoSisters; // size = 0x0338
 
 #endif

--- a/soh/src/overlays/actors/ovl_En_Syateki_Niw/z_en_syateki_niw.h
+++ b/soh/src/overlays/actors/ovl_En_Syateki_Niw/z_en_syateki_niw.h
@@ -18,7 +18,7 @@ typedef struct {
     /* 0x2C */ f32   unk_2C;
     /* 0x30 */ f32   unk_30;
     /* 0x34 */ u8    unk_34;
-    s32 epoch;
+    u32 epoch;
 } EnSyatekiNiw_1; // size = 0x38
 
 typedef struct EnSyatekiNiw {

--- a/soh/src/overlays/actors/ovl_En_Tk/z_en_tk.h
+++ b/soh/src/overlays/actors/ovl_En_Tk/z_en_tk.h
@@ -17,7 +17,7 @@ typedef struct EnTkEff {
     /* 0x0014 */ Vec3f      pos;
     /* 0x0020 */ Vec3f      speed;
     /* 0x002C */ Vec3f      accel;
-    s32 epoch;
+    u32 epoch;
 } EnTkEff; // size = 0x0038
 
 struct EnTk;

--- a/soh/src/overlays/actors/ovl_En_Viewer/z_en_viewer.h
+++ b/soh/src/overlays/actors/ovl_En_Viewer/z_en_viewer.h
@@ -56,7 +56,7 @@ typedef struct {
     /* 0x28 */ f32 scale;
     /* 0x2C */ f32 lerpFactor;
     /* 0x30 */ u8 state;
-    s32 epoch;
+    u32 epoch;
 } EnViewerFireEffect; // size = 0x34
 
 typedef struct EnViewer {

--- a/soh/src/overlays/actors/ovl_Fishing/z_fishing.c
+++ b/soh/src/overlays/actors/ovl_Fishing/z_fishing.c
@@ -90,7 +90,7 @@ typedef struct {
     /* 0x32 */ s16 timer;
     /* 0x34 */ u8 shouldDraw;
     /* 0x38 */ f32 drawDistance;
-    s32 epoch;
+    u32 epoch;
 } FishingProp; // size = 0x3C
 
 typedef enum {
@@ -116,7 +116,7 @@ typedef struct {
     /* 0x40 */ s16 unk_40;
     /* 0x42 */ s16 unk_42;
     /* 0x44 */ u8 shouldDraw;
-    s32 epoch;
+    u32 epoch;
 } FishingGroupFish; // size = 0x48
 
 #define LINE_SEG_COUNT 200
@@ -1766,7 +1766,7 @@ static f32 sSinkingLureSizes[] = {
 void Fishing_DrawSinkingLure(GlobalContext* globalCtx) {
     s16 i;
     f32 scale;
-    static s32 epoch = 0;
+    static u32 epoch = 0;
     epoch++;
 
     OPEN_DISPS(globalCtx->state.gfxCtx);

--- a/soh/src/overlays/actors/ovl_Mir_Ray/z_mir_ray.c
+++ b/soh/src/overlays/actors/ovl_Mir_Ray/z_mir_ray.c
@@ -482,7 +482,7 @@ void MirRay_Draw(Actor* thisx, GlobalContext* globalCtx) {
     s32 i;
     MirRayShieldReflection reflection[6];
     s32 temp;
-    static s32 epoch = 0;
+    static u32 epoch = 0;
     epoch++;
 
     this->reflectIntensity = 0.0f;

--- a/soh/src/overlays/effects/ovl_Effect_Ss_Bomb2/z_eff_ss_bomb2.h
+++ b/soh/src/overlays/effects/ovl_Effect_Ss_Bomb2/z_eff_ss_bomb2.h
@@ -11,7 +11,7 @@ typedef struct {
     /* 0x24 */ s16 scale;
     /* 0x26 */ s16 scaleStep;
     /* 0x28 */ u8 drawMode;
-    /* 0x29 */ s32 epoch;
+    /* 0x29 */ u32 epoch;
 } EffectSsBomb2InitParams; // size = 0x30
 
 #endif


### PR DESCRIPTION
switch all epochs from `s32` to `u32`

this addresses the
> In any case, use u32 rather than s32 when the number can wrap around since it's UB when an s32 overflows.

half of https://github.com/HarbourMasters/Shipwright/pull/938#discussion_r933823936 which i forgot to do before https://github.com/HarbourMasters/Shipwright/pull/938 got merged