### PR TITLE
[cmake] Use -O2 for Release config builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,11 +42,16 @@ endif()
 ################################################################################
 # Global configuration types
 ################################################################################
-set(CMAKE_CONFIGURATION_TYPES
-    "Debug"
-    "Release"
-    CACHE STRING "" FORCE
-)
+if (CMAKE_SYSTEM_NAME STREQUAL "NintendoSwitch")
+set(CMAKE_C_FLAGS_DEBUG "-O3 -ffast-math")
+set(CMAKE_CXX_FLAGS_DEBUG "-O3 -ffast-math")
+set(CMAKE_C_FLAGS_RELEASE "-O3 -ffast-math -DNDEBUG")
+set(CMAKE_CXX_FLAGS_RELEASE "-O3 -ffast-math -DNDEBUG")
+else()
+set(CMAKE_C_FLAGS_RELEASE "-O2 -DNDEBUG")
+set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG")
+set(CMAKE_OBJCXX_FLAGS_RELEASE "-O2 -DNDEBUG")
+endif()
 
 if(NOT CMAKE_BUILD_TYPE )
 	set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Choose the type of build." FORCE)

--- a/soh/CMakeLists.txt
+++ b/soh/CMakeLists.txt
@@ -1805,7 +1805,6 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
             $<$<COMPILE_LANGUAGE:CXX>:-fpermissive>
             $<$<COMPILE_LANGUAGE:CXX>:-Wno-deprecated-enum-enum-conversion>
             -pthread
-	    -O3 -ffast-math
         )
 
         target_link_options(${PROJECT_NAME} PRIVATE


### PR DESCRIPTION
By default cmake was using -O3 which hasn't been tested, reverting to known behaviour