### PR TITLE
Fixes CMake to explicity launch python interpreter on Windows.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,7 +136,7 @@ string(REGEX REPLACE "Release" "${CMAKE_BUILD_TYPE}" filedata "${filedata}")
 file(WRITE "${CMAKE_CURRENT_SOURCE_DIR}/OTRExporter/extract_assets_cmake2.py" "${filedata}")
 file(CHMOD "${CMAKE_CURRENT_SOURCE_DIR}/OTRExporter/extract_assets_cmake2.py" PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_WRITE GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
 
-find_package(Python3 COMPONENTS Interpreter)
+find_package(Python COMPONENTS Interpreter)
 
 add_custom_target(
     ExtractAssets

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,12 +136,12 @@ string(REGEX REPLACE "Release" "${CMAKE_BUILD_TYPE}" filedata "${filedata}")
 file(WRITE "${CMAKE_CURRENT_SOURCE_DIR}/OTRExporter/extract_assets_cmake2.py" "${filedata}")
 file(CHMOD "${CMAKE_CURRENT_SOURCE_DIR}/OTRExporter/extract_assets_cmake2.py" PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_WRITE GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
 
-find_package(Python COMPONENTS Interpreter)
+find_package(Python3 COMPONENTS Interpreter)
 
 add_custom_target(
     ExtractAssets
     COMMAND ${CMAKE_COMMAND} -E rm -f oot.otr
-    COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/OTRExporter/extract_assets_cmake2.py
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/OTRExporter/extract_assets_cmake2.py
     COMMAND ${CMAKE_COMMAND} -E copy oot.otr ${CMAKE_SOURCE_DIR}
     COMMAND ${CMAKE_COMMAND} -E copy oot.otr ${CMAKE_BINARY_DIR}/soh
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/OTRExporter

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,7 +38,7 @@ pipeline {
 
                             xcopy "..\\..\\ZELOOTD.z64" "OTRExporter\\"
                             
-                            "${env.CMAKE}" -S . -B "build\\${env.PLATFORM}" -G "Visual Studio 17 2022" -T ${env.TOOLSET} -A ${env.PLATFORM} -D Python_EXECUTABLE=${env.PYTHON} -D CMAKE_BUILD_TYPE:STRING=Release
+                            "${env.CMAKE}" -S . -B "build\\${env.PLATFORM}" -G "Visual Studio 17 2022" -T ${env.TOOLSET} -A ${env.PLATFORM} -D Python3_EXECUTABLE=${env.PYTHON} -D CMAKE_BUILD_TYPE:STRING=Release
                             "${env.CMAKE}" --build ".\\build\\${env.PLATFORM}" --target ExtractAssets --config Release
                             "${env.CMAKE}" --build ".\\build\\${env.PLATFORM}" --config Release
                             cd  ".\\build\\${env.PLATFORM}"


### PR DESCRIPTION
It seems that, at least on most Windows systems, CMake was failing to find the Python Interpreter when the find_package command searched for Python3 instead of Python. This causes CMake to fall back to the Windows file handler. For all of us who tested earlier it seems that our default handler on Windows for .py files was the Python Interpreter, so nothing seemed to be amiss. However, it was discovered that if someone had their default program for opening Python files in Windows was set to, say, VSCode, CMake would just open `extract_assets_cmake2.py` in VSCode instead of running it. If this change doesn't work for other platforms then we may need to add an if statment specifically for Windows here. 

Source: https://cmake.org/cmake/help/latest/module/FindPython.html