### PR TITLE
Fixes minor ice trap issue

### DIFF
--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -6283,8 +6283,8 @@ s32 func_8083E5A8(Player* this, GlobalContext* globalCtx) {
                 if (gSaveContext.n64ddFlag && this->getItemId == GI_ICE_TRAP) {
                     this->stateFlags1 &= ~(PLAYER_STATE1_10 | PLAYER_STATE1_11);
                     this->actor.colChkInfo.damage = 0;
-                    func_80837C0C(globalCtx, this, 3, 0.0f, 0.0f, 0, 20);
                     Player_SetPendingFlag(this, globalCtx);
+                    func_80837C0C(globalCtx, this, 3, 0.0f, 0.0f, 0, 20);
                     return;
                 }
 


### PR DESCRIPTION
Fixes a minor Ice Trap issue introduced by #961. In certain situations, link would either not be frozen by the ice trap, or would slide forward while frozen. It is fixed by moving the `Player_SetPendingFlag` function call in `z_player.c` line 6287 exactly one line up (swap it with the line above). I have no idea why calling the functions in the order I had them in causes Ice Traps to break in these situations. I might have a better idea if `func_808370C` was in any way readable, but what can you do...