### PR TITLE
Rando: Zelda sequence fixes

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -3253,7 +3253,7 @@ void GenerateRandomizerImgui() {
 
     // If we skip child zelda, skip child stealth is pointless, so this needs to be reflected in the spoiler log
     cvarSettings[RSK_SKIP_CHILD_STEALTH] =
-        !(CVar_GetS32("gRandomizeSkipChildZelda", 0)) && CVar_GetS32("gRandomizeSkipChildStealth", 0);
+        !CVar_GetS32("gRandomizeSkipChildZelda", 0) && CVar_GetS32("gRandomizeSkipChildStealth", 0);
 
     cvarSettings[RSK_SKIP_EPONA_RACE] = CVar_GetS32("gRandomizeSkipEponaRace", 0);
     cvarSettings[RSK_SKIP_TOWER_ESCAPE] = CVar_GetS32("gRandomizeSkipTowerEscape", 0);

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -3253,7 +3253,7 @@ void GenerateRandomizerImgui() {
 
     // If we skip child zelda, skip child stealth is pointless, so this needs to be reflected in the spoiler log
     cvarSettings[RSK_SKIP_CHILD_STEALTH] =
-        ((CVar_GetS32("gRandomizeSkipChildZelda", 0) == 0) && CVar_GetS32("gRandomizeSkipChildStealth", 0));
+        !(CVar_GetS32("gRandomizeSkipChildZelda", 0)) && CVar_GetS32("gRandomizeSkipChildStealth", 0);
 
     cvarSettings[RSK_SKIP_EPONA_RACE] = CVar_GetS32("gRandomizeSkipEponaRace", 0);
     cvarSettings[RSK_SKIP_TOWER_ESCAPE] = CVar_GetS32("gRandomizeSkipTowerEscape", 0);

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -3251,7 +3251,10 @@ void GenerateRandomizerImgui() {
     cvarSettings[RSK_CUCCO_COUNT] = CVar_GetS32("gRandomizeCuccosToReturn", 7);
     cvarSettings[RSK_BIG_POE_COUNT] = CVar_GetS32("gRandomizeBigPoeTargetCount", 10);
 
-    cvarSettings[RSK_SKIP_CHILD_STEALTH] = CVar_GetS32("gRandomizeSkipChildStealth", 0);
+    // If we skip child zelda, skip child stealth is pointless, so this needs to be reflected in the spoiler log
+    cvarSettings[RSK_SKIP_CHILD_STEALTH] =
+        ((CVar_GetS32("gRandomizeSkipChildZelda", 0) == 0) && CVar_GetS32("gRandomizeSkipChildStealth", 0));
+
     cvarSettings[RSK_SKIP_EPONA_RACE] = CVar_GetS32("gRandomizeSkipEponaRace", 0);
     cvarSettings[RSK_SKIP_TOWER_ESCAPE] = CVar_GetS32("gRandomizeSkipTowerEscape", 0);
 

--- a/soh/src/code/z_play.c
+++ b/soh/src/code/z_play.c
@@ -276,7 +276,7 @@ void Gameplay_Init(GameState* thisx) {
     // Skip Child Stealth when option is enabled, Zelda's Letter isn't obtained and Impa's reward hasn't been received
     // eventChkInf[4] & 1 = Got Zelda's Letter
     // eventChkInf[5] & 0x200 = Got Impa's reward
-    // entranceIndex 0x7A, Castle Courtyard - Day
+    // entranceIndex 0x7A, Castle Courtyard - Day from crawlspace
     // entranceIndex 0x400, Zelda's Courtyard
     if (gSaveContext.n64ddFlag && Randomizer_GetSettingValue(RSK_SKIP_CHILD_STEALTH) &&
         !(gSaveContext.eventChkInf[4] & 1) && !(gSaveContext.eventChkInf[5] & 0x200)) {

--- a/soh/src/code/z_play.c
+++ b/soh/src/code/z_play.c
@@ -276,12 +276,12 @@ void Gameplay_Init(GameState* thisx) {
     // Skip Child Stealth when option is enabled, Zelda's Letter isn't obtained and Impa's reward hasn't been received
     // eventChkInf[4] & 1 = Got Zelda's Letter
     // eventChkInf[5] & 0x200 = Got Impa's reward
+    // entranceIndex 0x7A, Castle Courtyard - Day
+    // entranceIndex 0x400, Zelda's Courtyard
     if (gSaveContext.n64ddFlag && Randomizer_GetSettingValue(RSK_SKIP_CHILD_STEALTH) &&
         !(gSaveContext.eventChkInf[4] & 1) && !(gSaveContext.eventChkInf[5] & 0x200)) {
         if (gSaveContext.entranceIndex == 0x7A) {
             gSaveContext.entranceIndex = 0x400;
-        } else if (gSaveContext.entranceIndex == 0x296) {
-            gSaveContext.entranceIndex = 0x23D;
         }
     }
 

--- a/soh/src/code/z_play.c
+++ b/soh/src/code/z_play.c
@@ -273,7 +273,11 @@ void Gameplay_Init(GameState* thisx) {
     u8 tempSetupIndex;
     s32 pad[2];
 
-    if (gSaveContext.n64ddFlag && Randomizer_GetSettingValue(RSK_SKIP_CHILD_STEALTH)) {
+    // Skip Child Stealth when option is enabled, Zelda's Letter isn't obtained and Impa's reward hasn't been received
+    // eventChkInf[4] & 0x01 = Got Zelda's Letter
+    // eventChkInf[5] & 0x200 = Got Impa's reward
+    if (gSaveContext.n64ddFlag && Randomizer_GetSettingValue(RSK_SKIP_CHILD_STEALTH) &&
+        !(gSaveContext.eventChkInf[4] & 0x01) && !(gSaveContext.eventChkInf[5] & 0x200)) {
         if (gSaveContext.entranceIndex == 0x7A) {
             gSaveContext.entranceIndex = 0x400;
         } else if (gSaveContext.entranceIndex == 0x296) {

--- a/soh/src/code/z_play.c
+++ b/soh/src/code/z_play.c
@@ -274,10 +274,10 @@ void Gameplay_Init(GameState* thisx) {
     s32 pad[2];
 
     // Skip Child Stealth when option is enabled, Zelda's Letter isn't obtained and Impa's reward hasn't been received
-    // eventChkInf[4] & 0x01 = Got Zelda's Letter
+    // eventChkInf[4] & 1 = Got Zelda's Letter
     // eventChkInf[5] & 0x200 = Got Impa's reward
     if (gSaveContext.n64ddFlag && Randomizer_GetSettingValue(RSK_SKIP_CHILD_STEALTH) &&
-        !(gSaveContext.eventChkInf[4] & 0x01) && !(gSaveContext.eventChkInf[5] & 0x200)) {
+        !(gSaveContext.eventChkInf[4] & 1) && !(gSaveContext.eventChkInf[5] & 0x200)) {
         if (gSaveContext.entranceIndex == 0x7A) {
             gSaveContext.entranceIndex = 0x400;
         } else if (gSaveContext.entranceIndex == 0x296) {

--- a/soh/src/code/z_sram.c
+++ b/soh/src/code/z_sram.c
@@ -790,6 +790,9 @@ void Sram_InitSave(FileChooseContext* fileChooseCtx) {
             gSaveContext.eventChkInf[1] |= (1 << 3);
             gSaveContext.eventChkInf[1] |= (1 << 4);
 
+            // Got Zelda's Letter
+            gSaveContext.eventChkInf[4] |= 1;
+
             // Got item from impa
             gSaveContext.eventChkInf[5] |= 0x200;
 

--- a/soh/src/code/z_sram.c
+++ b/soh/src/code/z_sram.c
@@ -790,14 +790,11 @@ void Sram_InitSave(FileChooseContext* fileChooseCtx) {
             gSaveContext.eventChkInf[1] |= (1 << 3);
             gSaveContext.eventChkInf[1] |= (1 << 4);
 
-            // Got Zelda's Letter
+            // Set "Got Zelda's Letter" flag. Also ensures Saria is back at SFM. TODO: Is this flag used for anything else?
             gSaveContext.eventChkInf[4] |= 1;
 
             // Got item from impa
             gSaveContext.eventChkInf[5] |= 0x200;
-
-            // make sure saria is at SFM
-            gSaveContext.eventChkInf[4] |= (1 << 0);
 
             // set this at the end to ensure we always start with the letter
             // this is for the off chance we got the weird egg from impa (which should never happen)

--- a/soh/src/overlays/actors/ovl_En_Heishi1/z_en_heishi1.c
+++ b/soh/src/overlays/actors/ovl_En_Heishi1/z_en_heishi1.c
@@ -115,22 +115,17 @@ void EnHeishi1_Init(Actor* thisx, GlobalContext* globalCtx) {
     // eventChkInf[4] & 1 = Got Zelda's Letter
     // eventChkInf[5] & 0x200 = Got item from impa
     // eventChkInf[8] & 1 = Ocarina thrown in moat
-    
-    // Rando'd but not met Zelda yet
-    bool randoNotMetZelda =
-        (gSaveContext.n64ddFlag) && !(gSaveContext.eventChkInf[5] & 0x200) && !(gSaveContext.eventChkInf[4] & 1);
-    // Rando'd and already met Zelda
-    bool randoMetZelda = (gSaveContext.n64ddFlag) && (gSaveContext.eventChkInf[5] & 0x200) && (gSaveContext.eventChkInf[4] & 1);
+    bool rando = gSaveContext.n64ddFlag;
+    bool metZelda = (gSaveContext.eventChkInf[4] & 1) && (gSaveContext.eventChkInf[5] & 0x200);
 
     if (this->type != 5) {
-        if ((gSaveContext.dayTime < 0xB888 || IS_DAY) && ((!(gSaveContext.eventChkInf[8] & 1) && !gSaveContext.n64ddFlag) || randoNotMetZelda)) {
+        if ((gSaveContext.dayTime < 0xB888 || IS_DAY) && ((!rando && !(gSaveContext.eventChkInf[8] & 1)) || (rando && !metZelda))) {
             this->actionFunc = EnHeishi1_SetupWalk;
         } else {
             Actor_Kill(&this->actor);
         }
     } else {
-        if ((gSaveContext.dayTime >= 0xB889) || !IS_DAY ||
-            (gSaveContext.eventChkInf[8] & 1 && !gSaveContext.n64ddFlag) || randoMetZelda) {
+        if ((gSaveContext.dayTime >= 0xB889) || !IS_DAY || (!rando && gSaveContext.eventChkInf[8] & 1) || (rando && metZelda)) {
             this->actionFunc = EnHeishi1_SetupWaitNight;
         } else {
             Actor_Kill(&this->actor);

--- a/soh/src/overlays/actors/ovl_En_Heishi1/z_en_heishi1.c
+++ b/soh/src/overlays/actors/ovl_En_Heishi1/z_en_heishi1.c
@@ -115,17 +115,20 @@ void EnHeishi1_Init(Actor* thisx, GlobalContext* globalCtx) {
     // eventChkInf[4] & 1 = Got Zelda's Letter
     // eventChkInf[5] & 0x200 = Got item from impa
     // eventChkInf[8] & 1 = Ocarina thrown in moat
-    bool rando = gSaveContext.n64ddFlag;
     bool metZelda = (gSaveContext.eventChkInf[4] & 1) && (gSaveContext.eventChkInf[5] & 0x200);
 
     if (this->type != 5) {
-        if ((gSaveContext.dayTime < 0xB888 || IS_DAY) && ((!rando && !(gSaveContext.eventChkInf[8] & 1)) || (rando && !metZelda))) {
+        if ((gSaveContext.dayTime < 0xB888 || IS_DAY) &&
+            ((!gSaveContext.n64ddFlag && !(gSaveContext.eventChkInf[8] & 1)) ||
+             (gSaveContext.n64ddFlag && !metZelda))) {
             this->actionFunc = EnHeishi1_SetupWalk;
         } else {
             Actor_Kill(&this->actor);
         }
     } else {
-        if ((gSaveContext.dayTime >= 0xB889) || !IS_DAY || (!rando && gSaveContext.eventChkInf[8] & 1) || (rando && metZelda)) {
+        if ((gSaveContext.dayTime >= 0xB889) || !IS_DAY ||
+            (!gSaveContext.n64ddFlag && gSaveContext.eventChkInf[8] & 1) || 
+            (gSaveContext.n64ddFlag && metZelda)) {
             this->actionFunc = EnHeishi1_SetupWaitNight;
         } else {
             Actor_Kill(&this->actor);

--- a/soh/src/overlays/actors/ovl_En_Heishi1/z_en_heishi1.c
+++ b/soh/src/overlays/actors/ovl_En_Heishi1/z_en_heishi1.c
@@ -112,14 +112,25 @@ void EnHeishi1_Init(Actor* thisx, GlobalContext* globalCtx) {
         }
     }
 
+    // eventChkInf[4] & 1 = Got Zelda's Letter
+    // eventChkInf[5] & 0x200 = Got item from impa
+    // eventChkInf[8] & 1 = Ocarina thrown in moat
+    
+    // Rando'd but not met Zelda yet
+    bool randoNotMetZelda =
+        (gSaveContext.n64ddFlag) && !(gSaveContext.eventChkInf[5] & 0x200) && !(gSaveContext.eventChkInf[4] & 1);
+    // Rando'd and already met Zelda
+    bool randoMetZelda = (gSaveContext.n64ddFlag) && (gSaveContext.eventChkInf[5] & 0x200) && (gSaveContext.eventChkInf[4] & 1);
+
     if (this->type != 5) {
-        if (((gSaveContext.dayTime < 0xB888) || IS_DAY) && (gSaveContext.n64ddFlag || !(gSaveContext.eventChkInf[8] & 1))) {
+        if ((gSaveContext.dayTime < 0xB888 || IS_DAY) && ((!(gSaveContext.eventChkInf[8] & 1) && !gSaveContext.n64ddFlag) || randoNotMetZelda)) {
             this->actionFunc = EnHeishi1_SetupWalk;
         } else {
             Actor_Kill(&this->actor);
         }
     } else {
-        if ((gSaveContext.dayTime >= 0xB889) || !IS_DAY || (!gSaveContext.n64ddFlag && (gSaveContext.eventChkInf[8] & 1))) {
+        if ((gSaveContext.dayTime >= 0xB889) || !IS_DAY ||
+            (gSaveContext.eventChkInf[8] & 1 && !gSaveContext.n64ddFlag) || randoMetZelda) {
             this->actionFunc = EnHeishi1_SetupWaitNight;
         } else {
             Actor_Kill(&this->actor);


### PR DESCRIPTION
Resolves https://github.com/HarbourMasters/Shipwright/issues/749

Changes made in this PR:
- `Skip Child Stealth` is set to false when `Skip Child Zelda` is on, making `Skip Child Stealth` appear as off in the spoiler log when `Skip Child Zelda` is on.
- Changed `Child Stealth Skip` to only trigger when Zelda has not been met yet.
- Changed conditionals used for deciding wether the guards should block Link's path after the crawlspace or not.
- Removed a entranceIndex change when going back to Courtyard - Day that was only neccesary when the player could still meet Zelda for a second time (they can't now).


As a summary, this is the behaviour after these changes:

- Vanilla game: Guards do not block the way even after meeting zelda, and will only block the way after the "Ocarina thrown into moat" cutscene has played. This didn't change and is vanilla behaviour.
- Rando, only `Skip Child Stealth` enabled: Player will be placed at Zelda's Courtyard after going through the crawlspace. Trying this again when Zelda has already been met doesn't skip to Zelda's courtyard and Link is stopped by the guards instead. Guards will not stop Link when only the Ocarina in moat cutscene has been triggered, but Zelda hasn't been met.
- Rando, only `Skip Child Zelda` is selected: Guards will immediately stop the player after going through the crawlspace.
- Rando, both `Skip Child Zelda` and `Skip Child Stealth` are enabled: Player is immediately stopped by the guards, `Skip Child Stealth` shows up in spoiler log as not enabled.

All these scenarios have been tested ingame and confirmed working as stated above.

I hope it's not too confusing for someone else to review this. If anyone has any questions, please ask  them.