### PR TITLE
Fixes skulltula messages for custom items.

### DIFF
--- a/soh/src/overlays/actors/ovl_En_Si/z_en_si.c
+++ b/soh/src/overlays/actors/ovl_En_Si/z_en_si.c
@@ -108,13 +108,13 @@ void func_80AFB768(EnSi* this, GlobalContext* globalCtx) {
                         giveItemId = sGetItemTable[getItemId - 1].itemId;
                         Item_Give(globalCtx, giveItemId);
                     }
+                    player->getItemId = getItemId;
                 } else {
                     Item_Give(globalCtx, giveItemId);
                 }
                 if ((CVar_GetS32("gSkulltulaFreeze", 0) != 1 || giveItemId != ITEM_SKULL_TOKEN) && getItemId != GI_ICE_TRAP) {
                     player->actor.freezeTimer = 20;
                 }
-                player->getItemId = getItemId;
                 Message_StartTextbox(globalCtx, textId, NULL);
 
                 if (gSaveContext.n64ddFlag) {

--- a/soh/src/overlays/actors/ovl_En_Si/z_en_si.c
+++ b/soh/src/overlays/actors/ovl_En_Si/z_en_si.c
@@ -151,10 +151,10 @@ void func_80AFB89C(EnSi* this, GlobalContext* globalCtx) {
                 giveItemId = sGetItemTable[getItemId - 1].itemId;
                 Item_Give(globalCtx, giveItemId);
             }
+            player->getItemId = getItemId;
         } else {
             Item_Give(globalCtx, giveItemId);
         }
-        player->getItemId = getItemId;
         Message_StartTextbox(globalCtx, textId, NULL);
         if (gSaveContext.n64ddFlag) {
             Audio_PlayFanfare_Rando(getItemId);

--- a/soh/src/overlays/actors/ovl_En_Si/z_en_si.c
+++ b/soh/src/overlays/actors/ovl_En_Si/z_en_si.c
@@ -114,6 +114,7 @@ void func_80AFB768(EnSi* this, GlobalContext* globalCtx) {
                 if ((CVar_GetS32("gSkulltulaFreeze", 0) != 1 || giveItemId != ITEM_SKULL_TOKEN) && getItemId != GI_ICE_TRAP) {
                     player->actor.freezeTimer = 20;
                 }
+                player->getItemId = getItemId;
                 Message_StartTextbox(globalCtx, textId, NULL);
 
                 if (gSaveContext.n64ddFlag) {

--- a/soh/src/overlays/actors/ovl_En_Si/z_en_si.c
+++ b/soh/src/overlays/actors/ovl_En_Si/z_en_si.c
@@ -154,6 +154,7 @@ void func_80AFB89C(EnSi* this, GlobalContext* globalCtx) {
         } else {
             Item_Give(globalCtx, giveItemId);
         }
+        player->getItemId = getItemId;
         Message_StartTextbox(globalCtx, textId, NULL);
         if (gSaveContext.n64ddFlag) {
             Audio_PlayFanfare_Rando(getItemId);


### PR DESCRIPTION
The Skulltula code for tokensanity wasn't setting player->getItemId, so custom items weren't using randomizer's message table. This fixes that and has not caused any issues in testing so far.