### PR TITLE
Fixed 2 incorrect needs_save instances

### DIFF
--- a/libultraship/libultraship/ImGuiImpl.cpp
+++ b/libultraship/libultraship/ImGuiImpl.cpp
@@ -1061,6 +1061,7 @@ namespace SohImGui {
                 ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(6.0f, 4.0f));
                 if (ImGui::Button("Apply Preset")) {
                     applyEnhancementPresets();
+                    needs_save = true;
                 }
                 ImGui::PopStyleVar(1);
 
@@ -1628,7 +1629,6 @@ namespace SohImGui {
                     else {
                         lastBetaQuestWorld = betaQuestWorld = 0xFFEF;
                         CVar_SetS32("gBetaQuestWorld", betaQuestWorld);
-                        needs_save = true;
                     }
                     if (betaQuestEnabled != lastBetaQuestEnabled || betaQuestWorld != lastBetaQuestWorld)
                     {


### PR DESCRIPTION
Applying presets didn't actually save the changes to the JSON file, now it does.

Beta Quest was saving the JSON every time the cheats window was being drawn. Since there was already another needs_save a bit further down that triggers when the option is changed, this first one can be safely removed.