### PR TITLE
Add window to customize specific controls

### DIFF
--- a/libultraship/libultraship/ImGuiImpl.cpp
+++ b/libultraship/libultraship/ImGuiImpl.cpp
@@ -1067,10 +1067,27 @@ namespace SohImGui {
                 PaddedSeparator();
 
                 if (ImGui::BeginMenu("Controls")) {
+                    ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(12.0f, 6.0f));
+                    ImGui::PushStyleVar(ImGuiStyleVar_ButtonTextAlign, ImVec2(0, 0));
+                    ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize, 1.0f);
+                    ImGui::PushStyleColor(ImGuiCol_Border, ImVec4(0.22f, 0.38f, 0.56f, 1.0f));
+                    float availableWidth = ImGui::GetContentRegionAvail().x;
+                    if (ImGui::Button(
+                        GetWindowButtonText("Customize Game Controls", CVar_GetS32("gGameControlEditorEnabled", 0)).c_str(),
+                        ImVec2(availableWidth, 0)
+                    )) {
+                        bool currentValue = CVar_GetS32("gGameControlEditorEnabled", 0);
+                        CVar_SetS32("gGameControlEditorEnabled", !currentValue);
+                        needs_save = true;
+                        customWindows["Game Control Editor"].enabled = CVar_GetS32("gGameControlEditorEnabled", 0);
+                    }
+                    ImGui::PopStyleVar(3);
+                    ImGui::PopStyleColor(1);
+
                     // TODO mutual exclusions -- There should be some system to prevent conclifting enhancements from being selected
-                    EnhancementCheckbox("D-pad Support on Pause and File Select", "gDpadPauseName");
+                    PaddedEnhancementCheckbox("D-pad Support on Pause and File Select", "gDpadPauseName");
                     Tooltip("Enables Pause and File Select screen navigation with the D-pad\nIf used with D-pad as Equip Items, you must hold C-Up to equip instead of navigate");
-                    PaddedEnhancementCheckbox("D-pad Support in Ocarina and Text Choice", "gDpadOcarinaText", true, false);
+                    PaddedEnhancementCheckbox("D-pad Support in Text Choice", "gDpadText", true, false);
                     PaddedEnhancementCheckbox("D-pad Support for Browsing Shop Items", "gDpadShop", true, false);
                     PaddedEnhancementCheckbox("D-pad as Equip Items", "gDpadEquips", true, false);
                     Tooltip("Allows the D-pad to be used as extra C buttons");

--- a/soh/CMakeLists.txt
+++ b/soh/CMakeLists.txt
@@ -157,6 +157,11 @@ set(Header_Files__soh__Enhancements
 )
 source_group("Header Files\\soh\\Enhancements" FILES ${Header_Files__soh__Enhancements})
 
+set(Header_Files__soh__Enhancements__controls
+    "soh/Enhancements/controls/GameControlEditor.h"
+)
+source_group("Header Files\\soh\\Enhancements\\controls" FILES ${Header_Files__soh__Enhancements__controls})
+
 set(Header_Files__soh__Enhancements__cosmetics
     "soh/Enhancements/cosmetics/CosmeticsEditor.h"
 )
@@ -248,6 +253,11 @@ set(Source_Files__soh__Enhancements
     "soh/Enhancements/savestates.cpp"
 )
 source_group("Source Files\\soh\\Enhancements" FILES ${Source_Files__soh__Enhancements})
+
+set(Source_Files__soh__Enhancements__controls
+    "soh/Enhancements/controls/GameControlEditor.cpp"
+)
+source_group("Source Files\\soh\\Enhancements\\controls" FILES ${Source_Files__soh__Enhancements__controls})
 
 set(Source_Files__soh__Enhancements__cosmetics
     "soh/Enhancements/cosmetics/CosmeticsEditor.cpp"
@@ -1543,6 +1553,7 @@ set(ALL_FILES
     ${Header_Files}
     ${Header_Files__include}
     ${Header_Files__soh__Enhancements}
+    ${Header_Files__soh__Enhancements__controls}
     ${Header_Files__soh__Enhancements__cosmetics}
     ${Header_Files__soh__Enhancements__debugger}
     ${Header_Files__soh__Enhancements__randomizer}
@@ -1550,6 +1561,7 @@ set(ALL_FILES
     ${Header_Files__soh__Enhancements__custom_message}
     ${Source_Files__soh}
     ${Source_Files__soh__Enhancements}
+    ${Source_Files__soh__Enhancements__controls}
     ${Source_Files__soh__Enhancements__cosmetics}
     ${Source_Files__soh__Enhancements__debugger}
     ${Source_Files__soh__Enhancements__randomizer}

--- a/soh/include/z64audio.h
+++ b/soh/include/z64audio.h
@@ -1094,11 +1094,11 @@ typedef struct {
 } OcarinaStaff;
 
 typedef enum {
-    /*  0 */ OCARINA_NOTE_A,
-    /*  1 */ OCARINA_NOTE_C_DOWN,
-    /*  2 */ OCARINA_NOTE_C_RIGHT,
-    /*  3 */ OCARINA_NOTE_C_LEFT,
-    /*  4 */ OCARINA_NOTE_C_UP,
+    /*  0 */ OCARINA_NOTE_D4,
+    /*  1 */ OCARINA_NOTE_F4,
+    /*  2 */ OCARINA_NOTE_A4,
+    /*  3 */ OCARINA_NOTE_B4,
+    /*  4 */ OCARINA_NOTE_D5,
     /* -1 */ OCARINA_NOTE_INVALID = 0xFF
 } OcarinaNoteIdx;
 

--- a/soh/soh/Enhancements/controls/GameControlEditor.cpp
+++ b/soh/soh/Enhancements/controls/GameControlEditor.cpp
@@ -1,4 +1,11 @@
 #include "GameControlEditor.h"
+
+#include <string>
+#include <list>
+#include <unordered_map>
+#include <utility>
+#include <iterator>
+
 #include "Lib/ImGui/imgui.h"
 #include "Lib/ImGui/imgui_internal.h"
 #include "Cvar.h"

--- a/soh/soh/Enhancements/controls/GameControlEditor.cpp
+++ b/soh/soh/Enhancements/controls/GameControlEditor.cpp
@@ -1,0 +1,224 @@
+#include "GameControlEditor.h"
+#include "Lib/ImGui/imgui.h"
+#include "Lib/ImGui/imgui_internal.h"
+#include "Cvar.h"
+#include "UltraController.h"
+#include "Utils/StringHelper.h"
+#include "../libultraship/ImGuiImpl.h"
+
+namespace GameControlEditor {
+    const ImGuiTableFlags PANEL_TABLE_FLAGS =
+        ImGuiTableFlags_BordersH |
+        ImGuiTableFlags_BordersV;
+    const ImGuiTableColumnFlags PANEL_TABLE_COLUMN_FLAGS =
+        ImGuiTableColumnFlags_IndentEnable |
+        ImGuiTableColumnFlags_NoSort;
+
+    namespace TableHelper {
+        void InitHeader(bool has_header = true) {
+            if (has_header) {
+                ImGui::TableHeadersRow();
+            }
+            ImGui::TableNextRow();
+            ImGui::TableNextColumn();
+            ImGui::AlignTextToFramePadding(); //This is to adjust Vertical pos of item in a cell to be normlized.
+            ImGui::PushItemWidth(ImGui::GetContentRegionAvail().x);
+        }
+
+        void NextCol() {
+            ImGui::TableNextColumn();
+            ImGui::AlignTextToFramePadding();
+            ImGui::PushItemWidth(ImGui::GetContentRegionAvail().x);
+        }
+
+        void NextLine() {
+            ImGui::TableNextRow();
+            ImGui::TableNextColumn();
+            ImGui::AlignTextToFramePadding();
+            ImGui::PushItemWidth(ImGui::GetContentRegionAvail().x);
+        }
+    }
+
+    void DrawHelpIcon(const std::string& helptext, bool sameline = true, int Pos = 0) {
+        // place the ? button to the most of the right side of the cell it is using.
+        ImGui::SetCursorPosX(ImGui::GetCursorPosX() + ImGui::GetContentRegionAvail().x - 15);
+        ImGui::SmallButton("?");
+        SohImGui::Tooltip(helptext.c_str());
+        if (sameline) {
+            //I do not use ImGui::SameLine(); because it make some element vanish.
+            ImGui::SetCursorPosY(ImGui::GetCursorPosY() - 22);
+        }
+    }
+
+    typedef uint32_t N64ButtonMask;
+
+    // Used together for an incomplete linked hash map implementation in order to
+    // map button masks to their names and original mapping on N64
+    static std::list<std::pair<N64ButtonMask, const char*>> buttons;
+    static std::unordered_map<N64ButtonMask, decltype(buttons)::iterator> buttonNames;
+
+    void addButtonName(N64ButtonMask mask, const char* name) {
+        buttons.push_back(std::make_pair(mask, name));
+        buttonNames[mask] = std::prev(buttons.end());
+    }
+
+    typedef struct {
+        const char* label;
+        const char* cVarName;
+        N64ButtonMask defaultBtn;
+    } CustomButtonMap;
+
+    // Ocarina button maps
+    static CustomButtonMap ocarinaD5 = {"D5", "gOcarinaD5BtnMap", BTN_CUP};
+    static CustomButtonMap ocarinaB4 = {"B4", "gOcarinaB4BtnMap", BTN_CLEFT};
+    static CustomButtonMap ocarinaA4 = {"A4", "gOcarinaA4BtnMap", BTN_CRIGHT};
+    static CustomButtonMap ocarinaF4 = {"F4", "gOcarinaF4BtnMap", BTN_CDOWN};
+    static CustomButtonMap ocarinaD4 = {"D4", "gOcarinaD4BtnMap", BTN_A};
+    static CustomButtonMap ocarinaSongDisable = {"Disable songs", "gOcarinaDisableBtnMap", BTN_L};
+    static CustomButtonMap ocarinaSharp = {"Pitch up", "gOcarinaSharpBtnMap", BTN_R};
+    static CustomButtonMap ocarinaFlat = {"Pitch down", "gOcarinaFlatBtnMap", BTN_Z};
+
+    void DrawUI(bool&);
+
+    void Init() {
+        SohImGui::AddWindow("Enhancements", "Game Control Editor", DrawUI);
+
+        addButtonName(BTN_A,		"A");
+        addButtonName(BTN_B,		"B");
+        addButtonName(BTN_CUP,		"C Up");
+        addButtonName(BTN_CDOWN,	"C Down");
+        addButtonName(BTN_CLEFT,	"C Left");
+        addButtonName(BTN_CRIGHT,	"C Right");
+        addButtonName(BTN_L,		"L");
+        addButtonName(BTN_Z,		"Z");
+        addButtonName(BTN_R,		"R");
+        addButtonName(BTN_START,	"Start");
+        addButtonName(BTN_DUP,		"D-pad up");
+        addButtonName(BTN_DDOWN,	"D-pad down");
+        addButtonName(BTN_DLEFT,	"D-pad left");
+        addButtonName(BTN_DRIGHT,	"D-pad right");
+        addButtonName(0,			"None");
+    }
+
+    // Draw a button mapping setting consisting of a padded label and button dropdown.
+    // excludedButtons indicates which buttons are unavailable to choose from.
+    void DrawMapping(CustomButtonMap& mapping, float labelWidth, N64ButtonMask excludedButtons) {
+        N64ButtonMask currentButton = CVar_GetS32(mapping.cVarName, mapping.defaultBtn);
+
+        const char* preview;
+        if (buttonNames.contains(currentButton)) {
+            preview = buttonNames[currentButton]->second;
+        } else {
+            preview = "Unknown";
+        }
+
+        SohImGui::InsertPadding();
+        ImVec2 cursorPos = ImGui::GetCursorPos();
+        ImVec2 textSize = ImGui::CalcTextSize(mapping.label);
+        ImGui::SetCursorPosY(cursorPos.y + textSize.y / 4);
+        ImGui::SetCursorPosX(cursorPos.x + abs(textSize.x - labelWidth));
+        ImGui::Text("%s", mapping.label);
+        ImGui::SameLine();
+        ImGui::SetCursorPosY(cursorPos.y);
+
+        ImGui::SetNextItemWidth(ImGui::GetFontSize() * 8);
+            if (ImGui::BeginCombo(StringHelper::Sprintf("##%s", mapping.cVarName).c_str(), preview)) {
+            for (auto i = buttons.begin(); i != buttons.end(); i++) {
+                if ((i->first & excludedButtons) != 0) {
+                    continue;
+                }
+                if (ImGui::Selectable(i->second, i->first == currentButton)) {
+                    CVar_SetS32(mapping.cVarName, i->first);
+                }
+            }
+            ImGui::EndCombo();
+        }
+        SohImGui::InsertPadding();
+    }
+
+    void DrawOcarinaControlPanel() {
+        if (!ImGui::CollapsingHeader("Ocarina Controls")) {
+            return;
+        }
+
+        if (!ImGui::BeginTable("tableCustomOcarinaControls", 1, PANEL_TABLE_FLAGS)) {
+            return;
+        }
+
+        ImGui::TableSetupColumn("Custom Ocarina Controls", PANEL_TABLE_COLUMN_FLAGS | ImGuiTableColumnFlags_WidthStretch);
+        TableHelper::InitHeader(false);
+        
+        ImVec2 cursor = ImGui::GetCursorPos();
+        ImGui::SetCursorPos(ImVec2(cursor.x + 5, cursor.y + 5));
+        SohImGui::EnhancementCheckbox("Customize Ocarina Controls", "gCustomOcarinaControls");
+
+        if (CVar_GetS32("gCustomOcarinaControls", 0) == 1) {
+            if (ImGui::BeginTable("tableCustomMainOcarinaControls", 2, ImGuiTableFlags_SizingStretchProp)) {
+                float labelWidth;
+                N64ButtonMask disableMask = BTN_B;
+                if (CVar_GetS32("gDpadOcarina", 0)) {
+                    disableMask |= BTN_DUP | BTN_DDOWN | BTN_DLEFT | BTN_DRIGHT;
+                }
+
+                ImGui::TableSetupColumn("Notes##CustomOcarinaNotes", PANEL_TABLE_COLUMN_FLAGS);
+                ImGui::TableSetupColumn("Modifiers##CustomOcaranaModifiers", PANEL_TABLE_COLUMN_FLAGS);
+                TableHelper::InitHeader(false);
+
+                SohImGui::BeginGroupPanel("Notes", ImGui::GetContentRegionAvail());
+                labelWidth = ImGui::CalcTextSize("D5").x + 10;
+                DrawMapping(ocarinaD5, labelWidth, disableMask);
+                DrawMapping(ocarinaB4, labelWidth, disableMask);
+                DrawMapping(ocarinaA4, labelWidth, disableMask);
+                DrawMapping(ocarinaF4, labelWidth, disableMask);
+                DrawMapping(ocarinaD4, labelWidth, disableMask);
+                ImGui::Dummy(ImVec2(0, 5));
+                float cursorY = ImGui::GetCursorPosY();
+                SohImGui::EndGroupPanel();
+
+                TableHelper::NextCol();
+
+                SohImGui::BeginGroupPanel("Modifiers", ImGui::GetContentRegionAvail());
+                labelWidth = ImGui::CalcTextSize(ocarinaSongDisable.label).x + 10;
+                DrawMapping(ocarinaSongDisable, labelWidth, disableMask);
+                DrawMapping(ocarinaSharp, labelWidth, disableMask);
+                DrawMapping(ocarinaFlat, labelWidth, disableMask);
+                SohImGui::EndGroupPanel(cursorY - ImGui::GetCursorPosY() + 2);
+
+                ImGui::EndTable();
+            }
+        } else {
+            SohImGui::InsertPadding();
+            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + 5);
+            ImGui::TextWrapped("To modify the main ocarina controls, select the \"Customize Ocarina Controls\" checkbox.");
+            SohImGui::InsertPadding();
+        }
+
+        SohImGui::BeginGroupPanel("Alternate controls", ImGui::GetContentRegionAvail());
+        if (ImGui::BeginTable("tableOcarinaAlternateControls", 2, ImGuiTableFlags_SizingFixedSame)) {
+            ImGui::TableSetupColumn("D-pad", PANEL_TABLE_COLUMN_FLAGS);
+            ImGui::TableSetupColumn("Right stick", PANEL_TABLE_COLUMN_FLAGS);
+            TableHelper::InitHeader(false);
+            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + 5);
+            SohImGui::EnhancementCheckbox("Play with D-pad", "gDpadOcarina");
+            TableHelper::NextCol();
+            SohImGui::EnhancementCheckbox("Play with camera stick", "gRStickOcarina");
+            ImGui::EndTable();
+        }
+        SohImGui::EndGroupPanel();
+
+        ImGui::EndTable();
+    }
+
+    void DrawUI(bool& open) {
+        if (!open) {
+            CVar_SetS32("gGameControlEditorEnabled", false);
+            return;
+        }
+
+        ImGui::SetNextWindowSize(ImVec2(465, 430), ImGuiCond_FirstUseEver);
+        if (ImGui::Begin("Game Controls Configuration", &open)) {
+            DrawOcarinaControlPanel();
+        }
+        ImGui::End();
+    }
+}

--- a/soh/soh/Enhancements/controls/GameControlEditor.h
+++ b/soh/soh/Enhancements/controls/GameControlEditor.h
@@ -1,0 +1,5 @@
+#pragma once
+
+namespace GameControlEditor {
+    void Init();
+}

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -29,6 +29,7 @@
 #define DRWAV_IMPLEMENTATION
 #include "Lib/dr_libs/wav.h"
 #include "AudioPlayer.h"
+#include "Enhancements/controls/GameControlEditor.h"
 #include "Enhancements/cosmetics/CosmeticsEditor.h"
 #include "Enhancements/debugconsole.h"
 #include "Enhancements/debugger/debugger.h"
@@ -187,6 +188,7 @@ extern "C" void InitOTR() {
     OTRMessage_Init();
     OTRAudio_Init();
     InitCosmeticsEditor();
+    GameControlEditor::Init();
     DebugConsole_Init();
     Debug_Init();
     Rando_Init();

--- a/soh/src/code/code_800EC960.c
+++ b/soh/src/code/code_800EC960.c
@@ -825,11 +825,11 @@ NatureAmbienceDataIO sNatureAmbienceDataIO[20] = {
 };
 
 u32 sOcarinaAllowedBtnMask = (BTN_A | BTN_CUP | BTN_CDOWN | BTN_CLEFT | BTN_CRIGHT);
-s32 sOcarinaABtnMap = BTN_A;
-s32 sOcarinaCUPBtnMap = BTN_CUP;
-s32 sOcarinaCDownBtnMap = BTN_CDOWN;
-s32 sOcarinaCLeftBtnMap = BTN_CLEFT;
-s32 sOcarinaCRightBtnMap = BTN_CRIGHT;
+s32 sOcarinaD5BtnMap = BTN_CUP;
+s32 sOcarinaB4BtnMap = BTN_CLEFT;
+s32 sOcarinaA4BtnMap = BTN_CRIGHT;
+s32 sOcarinaF4BtnMap = BTN_CDOWN;
+s32 sOcarinaD4BtnMap = BTN_A;
 u8 sOcarinaInpEnabled = 0;
 s8 D_80130F10 = 0; // "OCA", ocarina active?
 u8 sCurOcarinaBtnVal = 0xFF;
@@ -1013,9 +1013,9 @@ OcarinaNote sOcarinaSongs[OCARINA_SONG_MAX][20] = {
 
 OcarinaNote* sPlaybackSong = sOcarinaSongs[0];
 u8 sFrogsSongNotes[14] = {
-    OCARINA_NOTE_A,       OCARINA_NOTE_C_LEFT,  OCARINA_NOTE_C_RIGHT, OCARINA_NOTE_C_DOWN, OCARINA_NOTE_C_LEFT,
-    OCARINA_NOTE_C_RIGHT, OCARINA_NOTE_C_DOWN,  OCARINA_NOTE_A,       OCARINA_NOTE_C_DOWN, OCARINA_NOTE_A,
-    OCARINA_NOTE_C_DOWN,  OCARINA_NOTE_C_RIGHT, OCARINA_NOTE_C_LEFT,  OCARINA_NOTE_A,
+    OCARINA_NOTE_D4, OCARINA_NOTE_B4, OCARINA_NOTE_A4, OCARINA_NOTE_F4, OCARINA_NOTE_B4,
+    OCARINA_NOTE_A4, OCARINA_NOTE_F4, OCARINA_NOTE_D4, OCARINA_NOTE_F4, OCARINA_NOTE_D4,
+    OCARINA_NOTE_F4, OCARINA_NOTE_A4, OCARINA_NOTE_B4, OCARINA_NOTE_D4,
 };
 u8* gFrogsSongPtr = sFrogsSongNotes;
 u8 sRecordingState = 0;
@@ -1044,124 +1044,124 @@ OcarinaSongInfo gOcarinaSongNotes[OCARINA_SONG_MAX] = {
     // Minuet
     { 6,
       {
-          OCARINA_NOTE_A,
-          OCARINA_NOTE_C_UP,
-          OCARINA_NOTE_C_LEFT,
-          OCARINA_NOTE_C_RIGHT,
-          OCARINA_NOTE_C_LEFT,
-          OCARINA_NOTE_C_RIGHT,
+          OCARINA_NOTE_D4,
+          OCARINA_NOTE_D5,
+          OCARINA_NOTE_B4,
+          OCARINA_NOTE_A4,
+          OCARINA_NOTE_B4,
+          OCARINA_NOTE_A4,
       } },
     // Bolero
     { 8,
       {
-          OCARINA_NOTE_C_DOWN,
-          OCARINA_NOTE_A,
-          OCARINA_NOTE_C_DOWN,
-          OCARINA_NOTE_A,
-          OCARINA_NOTE_C_RIGHT,
-          OCARINA_NOTE_C_DOWN,
-          OCARINA_NOTE_C_RIGHT,
-          OCARINA_NOTE_C_DOWN,
+          OCARINA_NOTE_F4,
+          OCARINA_NOTE_D4,
+          OCARINA_NOTE_F4,
+          OCARINA_NOTE_D4,
+          OCARINA_NOTE_A4,
+          OCARINA_NOTE_F4,
+          OCARINA_NOTE_A4,
+          OCARINA_NOTE_F4,
       } },
     // Serenade
     { 5,
       {
-          OCARINA_NOTE_A,
-          OCARINA_NOTE_C_DOWN,
-          OCARINA_NOTE_C_RIGHT,
-          OCARINA_NOTE_C_RIGHT,
-          OCARINA_NOTE_C_LEFT,
+          OCARINA_NOTE_D4,
+          OCARINA_NOTE_F4,
+          OCARINA_NOTE_A4,
+          OCARINA_NOTE_A4,
+          OCARINA_NOTE_B4,
       } },
     // Requiem
     { 6,
       {
-          OCARINA_NOTE_A,
-          OCARINA_NOTE_C_DOWN,
-          OCARINA_NOTE_A,
-          OCARINA_NOTE_C_RIGHT,
-          OCARINA_NOTE_C_DOWN,
-          OCARINA_NOTE_A,
+          OCARINA_NOTE_D4,
+          OCARINA_NOTE_F4,
+          OCARINA_NOTE_D4,
+          OCARINA_NOTE_A4,
+          OCARINA_NOTE_F4,
+          OCARINA_NOTE_D4,
       } },
     // Nocturne
     { 7,
       {
-          OCARINA_NOTE_C_LEFT,
-          OCARINA_NOTE_C_RIGHT,
-          OCARINA_NOTE_C_RIGHT,
-          OCARINA_NOTE_A,
-          OCARINA_NOTE_C_LEFT,
-          OCARINA_NOTE_C_RIGHT,
-          OCARINA_NOTE_C_DOWN,
+          OCARINA_NOTE_B4,
+          OCARINA_NOTE_A4,
+          OCARINA_NOTE_A4,
+          OCARINA_NOTE_D4,
+          OCARINA_NOTE_B4,
+          OCARINA_NOTE_A4,
+          OCARINA_NOTE_F4,
       } },
     // Prelude
     { 6,
       {
-          OCARINA_NOTE_C_UP,
-          OCARINA_NOTE_C_RIGHT,
-          OCARINA_NOTE_C_UP,
-          OCARINA_NOTE_C_RIGHT,
-          OCARINA_NOTE_C_LEFT,
-          OCARINA_NOTE_C_UP,
+          OCARINA_NOTE_D5,
+          OCARINA_NOTE_A4,
+          OCARINA_NOTE_D5,
+          OCARINA_NOTE_A4,
+          OCARINA_NOTE_B4,
+          OCARINA_NOTE_D5,
       } },
     // Sarias
     { 6,
       {
-          OCARINA_NOTE_C_DOWN,
-          OCARINA_NOTE_C_RIGHT,
-          OCARINA_NOTE_C_LEFT,
-          OCARINA_NOTE_C_DOWN,
-          OCARINA_NOTE_C_RIGHT,
-          OCARINA_NOTE_C_LEFT,
+          OCARINA_NOTE_F4,
+          OCARINA_NOTE_A4,
+          OCARINA_NOTE_B4,
+          OCARINA_NOTE_F4,
+          OCARINA_NOTE_A4,
+          OCARINA_NOTE_B4,
       } },
     // Epona
     { 6,
       {
-          OCARINA_NOTE_C_UP,
-          OCARINA_NOTE_C_LEFT,
-          OCARINA_NOTE_C_RIGHT,
-          OCARINA_NOTE_C_UP,
-          OCARINA_NOTE_C_LEFT,
-          OCARINA_NOTE_C_RIGHT,
+          OCARINA_NOTE_D5,
+          OCARINA_NOTE_B4,
+          OCARINA_NOTE_A4,
+          OCARINA_NOTE_D5,
+          OCARINA_NOTE_B4,
+          OCARINA_NOTE_A4,
       } },
     // Lullaby
     { 6,
       {
-          OCARINA_NOTE_C_LEFT,
-          OCARINA_NOTE_C_UP,
-          OCARINA_NOTE_C_RIGHT,
-          OCARINA_NOTE_C_LEFT,
-          OCARINA_NOTE_C_UP,
-          OCARINA_NOTE_C_RIGHT,
+          OCARINA_NOTE_B4,
+          OCARINA_NOTE_D5,
+          OCARINA_NOTE_A4,
+          OCARINA_NOTE_B4,
+          OCARINA_NOTE_D5,
+          OCARINA_NOTE_A4,
       } },
     // Suns
     { 6,
       {
-          OCARINA_NOTE_C_RIGHT,
-          OCARINA_NOTE_C_DOWN,
-          OCARINA_NOTE_C_UP,
-          OCARINA_NOTE_C_RIGHT,
-          OCARINA_NOTE_C_DOWN,
-          OCARINA_NOTE_C_UP,
+          OCARINA_NOTE_A4,
+          OCARINA_NOTE_F4,
+          OCARINA_NOTE_D5,
+          OCARINA_NOTE_A4,
+          OCARINA_NOTE_F4,
+          OCARINA_NOTE_D5,
       } },
     // Song of Time
     { 6,
       {
-          OCARINA_NOTE_C_RIGHT,
-          OCARINA_NOTE_A,
-          OCARINA_NOTE_C_DOWN,
-          OCARINA_NOTE_C_RIGHT,
-          OCARINA_NOTE_A,
-          OCARINA_NOTE_C_DOWN,
+          OCARINA_NOTE_A4,
+          OCARINA_NOTE_D4,
+          OCARINA_NOTE_F4,
+          OCARINA_NOTE_A4,
+          OCARINA_NOTE_D4,
+          OCARINA_NOTE_F4,
       } },
     // Storms
     { 6,
       {
-          OCARINA_NOTE_A,
-          OCARINA_NOTE_C_DOWN,
-          OCARINA_NOTE_C_UP,
-          OCARINA_NOTE_A,
-          OCARINA_NOTE_C_DOWN,
-          OCARINA_NOTE_C_UP,
+          OCARINA_NOTE_D4,
+          OCARINA_NOTE_F4,
+          OCARINA_NOTE_D5,
+          OCARINA_NOTE_D4,
+          OCARINA_NOTE_F4,
+          OCARINA_NOTE_D5,
       } },
     // Scarecrow
     { 8, { 0, 0, 0, 0, 0, 0, 0, 0 } },
@@ -1247,24 +1247,49 @@ void func_800F56A8(void);
 void Audio_PlayNatureAmbienceSequence(u8 natureAmbienceId);
 s32 Audio_SetGanonDistVol(u8 targetVol);
 
-// Function originally not called, so repurposing for DPad input
-void func_800EC960(u8 dpad) {
-    if (dpad) {
-        sOcarinaAllowedBtnMask =
-            (BTN_A | BTN_CUP | BTN_CDOWN | BTN_CLEFT | BTN_CRIGHT | BTN_DUP | BTN_DDOWN | BTN_DLEFT | BTN_DRIGHT);
-        sOcarinaABtnMap = BTN_A;
-        sOcarinaCUPBtnMap = BTN_CUP | BTN_DUP;
-        sOcarinaCDownBtnMap = BTN_CDOWN | BTN_DDOWN;
-        sOcarinaCLeftBtnMap = BTN_CLEFT | BTN_DLEFT;
-        sOcarinaCRightBtnMap = BTN_CRIGHT | BTN_DRIGHT;
+// Right stick as virtual C buttons
+#define RSTICK_UP    0x100000
+#define RSTICK_DOWN  0x200000
+#define RSTICK_LEFT  0x400000
+#define RSTICK_RIGHT 0x800000
+
+// Function originally not called, so repurposing for control mapping
+void Audio_OcaUpdateBtnMap(bool customControls, bool dpad, bool rStick) {
+    if (customControls) {
+        sOcarinaD5BtnMap = CVar_GetS32("gOcarinaD5BtnMap", BTN_CUP);
+        sOcarinaB4BtnMap = CVar_GetS32("gOcarinaB4BtnMap", BTN_CLEFT);
+        sOcarinaA4BtnMap = CVar_GetS32("gOcarinaA4BtnMap", BTN_CRIGHT);
+        sOcarinaF4BtnMap = CVar_GetS32("gOcarinaF4BtnMap", BTN_CDOWN);
+        sOcarinaD4BtnMap = CVar_GetS32("gOcarinaD4BtnMap", BTN_A);
     } else {
-        sOcarinaAllowedBtnMask = (BTN_A | BTN_CUP | BTN_CDOWN | BTN_CLEFT | BTN_CRIGHT);
-        sOcarinaABtnMap = BTN_A;
-        sOcarinaCUPBtnMap = BTN_CUP;
-        sOcarinaCDownBtnMap = BTN_CDOWN;
-        sOcarinaCLeftBtnMap = BTN_CLEFT;
-        sOcarinaCRightBtnMap = BTN_CRIGHT;
+        sOcarinaD5BtnMap = BTN_CUP;
+        sOcarinaB4BtnMap = BTN_CLEFT;
+        sOcarinaA4BtnMap = BTN_CRIGHT;
+        sOcarinaF4BtnMap = BTN_CDOWN;
+        sOcarinaD4BtnMap = BTN_A;
     }
+
+    if (dpad) {
+        sOcarinaD5BtnMap |= BTN_DUP;
+        sOcarinaB4BtnMap |= BTN_DLEFT;
+        sOcarinaA4BtnMap |= BTN_DRIGHT;
+        sOcarinaF4BtnMap |= BTN_DDOWN;
+    }
+
+    if (rStick) {
+        sOcarinaD5BtnMap |= RSTICK_UP;
+        sOcarinaB4BtnMap |= RSTICK_LEFT;
+        sOcarinaA4BtnMap |= RSTICK_RIGHT;
+        sOcarinaF4BtnMap |= RSTICK_DOWN;
+    }
+
+    sOcarinaAllowedBtnMask = (
+        sOcarinaD5BtnMap |
+        sOcarinaB4BtnMap |
+        sOcarinaA4BtnMap |
+        sOcarinaF4BtnMap |
+        sOcarinaD4BtnMap
+    );
 }
 
 void Audio_GetOcaInput(void) {
@@ -1278,6 +1303,23 @@ void Audio_GetOcaInput(void) {
     sPrevOcarinaBtnPress = sp18;
     sCurOcaStick.x = input->rel.stick_x;
     sCurOcaStick.y = input->rel.stick_y;
+
+    f32 rstick_x = input->cur.cam_x;
+    f32 rstick_y = input->cur.cam_y;
+    printf("%f %f\n", rstick_x, rstick_y);
+    const f32 sensitivity = 500;
+    if (rstick_x > sensitivity) {
+        sCurOcarinaBtnPress |= RSTICK_RIGHT;
+    }
+    if (rstick_x < -sensitivity) {
+        sCurOcarinaBtnPress |= RSTICK_LEFT;
+    }
+    if (rstick_y > sensitivity) {
+        sCurOcarinaBtnPress |= RSTICK_UP;
+    }
+    if (rstick_y < -sensitivity) {
+        sCurOcarinaBtnPress |= RSTICK_DOWN;
+    }
 }
 
 f32 Audio_OcaAdjStick(s8 inp) {
@@ -1495,7 +1537,17 @@ void func_800ED200(void) {
     u8 j;
     u8 k;
 
-    if (CHECK_BTN_ANY(sCurOcarinaBtnPress, BTN_L) && CHECK_BTN_ANY(sCurOcarinaBtnPress, sOcarinaAllowedBtnMask)) {
+    u32 disableSongBtnMap;
+    if (CVar_GetS32("gCustomOcarinaControls", 0)) {
+        disableSongBtnMap = CVar_GetS32("gOcarinaDisableBtnMap", BTN_L);
+    } else {
+        disableSongBtnMap = BTN_L;
+    }
+
+    if (
+        CHECK_BTN_ANY(sCurOcarinaBtnPress, disableSongBtnMap)
+        && CHECK_BTN_ANY(sCurOcarinaBtnPress, sOcarinaAllowedBtnMask)
+    ) {
         func_800ECC04((u16)D_80130F3C);
         return;
     }
@@ -1548,7 +1600,9 @@ void func_800ED200(void) {
 
 void func_800ED458(s32 arg0) {
     u32 phi_v1_2;
-    bool dpad = CVar_GetS32("gDpadOcarinaText", 0);
+    bool customControls = CVar_GetS32("gCustomOcarinaControls", 0);
+    bool dpad = CVar_GetS32("gDpadOcarina", 0);
+    bool rStick = CVar_GetS32("gRStickOcarina", 0);
 
     if (D_80130F3C != 0 && sOcarinaDropInputTimer != 0) {
         sOcarinaDropInputTimer--;
@@ -1569,35 +1623,47 @@ void func_800ED458(s32 arg0) {
             D_8016BA18 &= phi_v1_2;
         }
 
-        func_800EC960(dpad);
-        if (D_8016BA18 & sOcarinaABtnMap) {
-            osSyncPrintf("Presss NA_KEY_D4 %08x\n", sOcarinaABtnMap);
+        Audio_OcaUpdateBtnMap(customControls, dpad, rStick);
+        if (D_8016BA18 & sOcarinaD4BtnMap) {
+            osSyncPrintf("Presss NA_KEY_D4 %08x\n", sOcarinaD4BtnMap);
             sCurOcarinaBtnVal = 2;
             sCurOcarinaBtnIdx = 0;
-        } else if (D_8016BA18 & sOcarinaCDownBtnMap) {
-            osSyncPrintf("Presss NA_KEY_F4 %08x\n", sOcarinaCDownBtnMap);
+        } else if (D_8016BA18 & sOcarinaF4BtnMap) {
+            osSyncPrintf("Presss NA_KEY_F4 %08x\n", sOcarinaF4BtnMap);
             sCurOcarinaBtnVal = 5;
             sCurOcarinaBtnIdx = 1;
-        } else if (D_8016BA18 & sOcarinaCRightBtnMap) {
-            osSyncPrintf("Presss NA_KEY_A4 %08x\n", sOcarinaCRightBtnMap);
+        } else if (D_8016BA18 & sOcarinaA4BtnMap) {
+            osSyncPrintf("Presss NA_KEY_A4 %08x\n", sOcarinaA4BtnMap);
             sCurOcarinaBtnVal = 9;
             sCurOcarinaBtnIdx = 2;
-        } else if (D_8016BA18 & sOcarinaCLeftBtnMap) {
-            osSyncPrintf("Presss NA_KEY_B4 %08x\n", sOcarinaCRightBtnMap);
+        } else if (D_8016BA18 & sOcarinaB4BtnMap) {
+            osSyncPrintf("Presss NA_KEY_B4 %08x\n", sOcarinaA4BtnMap);
             sCurOcarinaBtnVal = 0xB;
             sCurOcarinaBtnIdx = 3;
-        } else if (D_8016BA18 & sOcarinaCUPBtnMap) {
-            osSyncPrintf("Presss NA_KEY_D5 %08x\n", sOcarinaCUPBtnMap);
+        } else if (D_8016BA18 & sOcarinaD5BtnMap) {
+            osSyncPrintf("Presss NA_KEY_D5 %08x\n", sOcarinaD5BtnMap);
             sCurOcarinaBtnVal = 0xE;
             sCurOcarinaBtnIdx = 4;
         }
 
-        if (sCurOcarinaBtnVal != 0xFF && sCurOcarinaBtnPress & 0x10 && sRecordingState != 2) {
+        u32 noteSharpBtnMap;
+        if (customControls) {
+            noteSharpBtnMap = CVar_GetS32("gOcarinaSharpBtnMap", BTN_R);
+        } else {
+            noteSharpBtnMap = BTN_R;
+        }
+        if ((sCurOcarinaBtnVal != 0xFF) && (sCurOcarinaBtnPress & noteSharpBtnMap) && (sRecordingState != 2)) {
             sCurOcarinaBtnIdx += 0x80;
             sCurOcarinaBtnVal++;
         }
 
-        if ((sCurOcarinaBtnVal != 0xFF) && (sCurOcarinaBtnPress & 0x2000) && (sRecordingState != 2)) {
+        u32 noteFlatBtnMap;
+        if (customControls) {
+            noteFlatBtnMap = CVar_GetS32("gOcarinaFlatBtnMap", BTN_Z);
+        } else {
+            noteFlatBtnMap = BTN_Z;
+        }
+        if ((sCurOcarinaBtnVal != 0xFF) && (sCurOcarinaBtnPress & noteFlatBtnMap) && (sRecordingState != 2)) {
             sCurOcarinaBtnIdx += 0x40;
             sCurOcarinaBtnVal--;
         }

--- a/soh/src/code/z_message_PAL.c
+++ b/soh/src/code/z_message_PAL.c
@@ -70,30 +70,93 @@ s16 gOcarinaSongItemMap[] = {
 
 s32 sCharTexSize;
 s32 sCharTexScale;
-s16 sOcarinaNoteAPrimR;
-s16 sOcarinaNoteAPrimB;
-s16 sOcarinaNoteAPrimG;
-s16 sOcarinaNoteAEnvR;
-s16 sOcarinaNoteAEnvB;
-s16 sOcarinaNoteAEnvG;
-s16 sOcarinaNoteCPrimR;
-s16 sOcarinaNoteCPrimB;
-s16 sOcarinaNoteCPrimG;
-s16 sOcarinaNoteCEnvR;
-s16 sOcarinaNoteCEnvB;
-s16 sOcarinaNoteCEnvG;
-s16 sOcarinaNoteCUpPrimR;
-s16 sOcarinaNoteCUpPrimB;
-s16 sOcarinaNoteCUpPrimG;
-s16 sOcarinaNoteCLeftPrimR;
-s16 sOcarinaNoteCLeftPrimB;
-s16 sOcarinaNoteCLeftPrimG;
-s16 sOcarinaNoteCDownPrimR;
-s16 sOcarinaNoteCDownPrimB;
-s16 sOcarinaNoteCDownPrimG;
-s16 sOcarinaNoteCRightPrimR;
-s16 sOcarinaNoteCRightPrimB;
-s16 sOcarinaNoteCRightPrimG;
+
+Color_RGB8 sOcarinaNoteABtnEnv;
+Color_RGB8 sOcarinaNoteCBtnEnv;
+Color_RGB8 sOcarinaNoteCBtnPrim;
+
+Color_RGB8 sOcarinaNoteD5Prim;
+Color_RGB8 sOcarinaNoteB4Prim;
+Color_RGB8 sOcarinaNoteA4Prim;
+Color_RGB8 sOcarinaNoteF4Prim;
+Color_RGB8 sOcarinaNoteD4Prim;
+
+// If the "separate" bool is set, use the "gCCC<cDirection>BtnPrim<R/G/B> CVars
+// to set the button color. Otherwise, use sOcarinaNoteCBtnPrim.
+void Message_SetCustomOrGeneralCColor(Color_RGB8* color, bool separate, char cDirection) {
+    if (!separate) {
+        *color = sOcarinaNoteCBtnPrim;
+        return;
+    }
+
+    // C direction is '*' @ idx 4
+    // Color component is '*' @ idx 12
+    char cVar[] = "gCCC*BtnPrim*";
+    cVar[4] = cDirection;
+    cVar[12] = 'R';
+    color->r = CVar_GetS32(cVar, 255);
+    cVar[12] = 'G';
+    color->g = CVar_GetS32(cVar, 255);
+    cVar[12] = 'B';
+    color->b = CVar_GetS32(cVar, 50);
+}
+
+typedef struct {
+    bool separateC;
+    bool dpad;
+    bool rightStick;
+} CustomNoteOptions;
+
+// Set the non-null button color corresponding to the button map
+//
+// If the assigned button is A, a C button, Start, or the D-pad, then it'll be
+// colored to the corresponding CVar. Otherwise, its color will be equal to
+// sOcarinaNoteCBtnPrim.
+void Message_SetCustomOcarinaNoteColor(Color_RGB8* color, s32 btnMap, CustomNoteOptions* flags) {
+    switch (btnMap) {
+        case BTN_A:
+            color->r = CVar_GetS32("gCCABtnPrimR", 80);
+            color->g = CVar_GetS32("gCCABtnPrimG", 255);
+            color->b = CVar_GetS32("gCCABtnPrimB", 150);
+            break;
+        case BTN_CUP:
+            Message_SetCustomOrGeneralCColor(color, flags->separateC, 'U');
+            break;
+        case BTN_CDOWN:
+            Message_SetCustomOrGeneralCColor(color, flags->separateC, 'D');
+            break;
+        case BTN_CLEFT:
+            Message_SetCustomOrGeneralCColor(color, flags->separateC, 'L');
+            break;
+        case BTN_CRIGHT:
+            Message_SetCustomOrGeneralCColor(color, flags->separateC, 'R');
+            break;
+        case BTN_START:
+            color->r = CVar_GetS32("gCCStartBtnPrimR", 200);
+            color->g = CVar_GetS32("gCCStartBtnPrimG", 0);
+            color->b = CVar_GetS32("gCCStartBtnPrimB", 0);
+            break;
+        case BTN_DUP:
+        case BTN_DDOWN:
+        case BTN_DLEFT:
+        case BTN_DRIGHT:
+            color->r = CVar_GetS32("gCCDpadPrimR", 255) * 103 / 255;
+            color->g = CVar_GetS32("gCCDpadPrimG", 255) * 103 / 255;
+            color->b = CVar_GetS32("gCCDpadPrimB", 255) * 103 / 255;
+            break;
+        case 0:
+            if (flags->dpad && !flags->rightStick) {
+                // D pad is dark gray even when set to white, so emulate that.
+                color->r = CVar_GetS32("gCCDpadPrimR", 255) * 103 / 255;
+                color->g = CVar_GetS32("gCCDpadPrimG", 255) * 103 / 255;
+                color->b = CVar_GetS32("gCCDpadPrimB", 255) * 103 / 255;
+                break;
+            }  // else fall through
+        default:
+            *color = sOcarinaNoteCBtnPrim;
+            break;
+    }
+}
 
 void Message_ResetOcarinaNoteState(void) {
     R_OCARINA_NOTES_YPOS(0) = 189;
@@ -105,45 +168,47 @@ void Message_ResetOcarinaNoteState(void) {
     sOcarinaNotesAlphaValues[0] = sOcarinaNotesAlphaValues[1] = sOcarinaNotesAlphaValues[2] =
         sOcarinaNotesAlphaValues[3] = sOcarinaNotesAlphaValues[4] = sOcarinaNotesAlphaValues[5] =
             sOcarinaNotesAlphaValues[6] = sOcarinaNotesAlphaValues[7] = sOcarinaNotesAlphaValues[8] = 0;
-    sOcarinaNoteAEnvR = 10;
-    sOcarinaNoteAEnvG = 10;
-    sOcarinaNoteAEnvB = 10;
-    sOcarinaNoteCEnvR = 10;
-    sOcarinaNoteCEnvG = 10;
-    sOcarinaNoteCEnvB = 10;
-    if (CVar_GetS32("gHudColors", 1) == 0) {
-        sOcarinaNoteAPrimR = 80;
-        sOcarinaNoteAPrimG = 150;
-        sOcarinaNoteAPrimB = 255;
-        sOcarinaNoteCPrimR = 255;
-        sOcarinaNoteCPrimG = 255;
-        sOcarinaNoteCPrimB = 50;
-    } else if (CVar_GetS32("gHudColors", 1) == 1) {
-        sOcarinaNoteAPrimR = 80;
-        sOcarinaNoteAPrimG = 255;
-        sOcarinaNoteAPrimB = 150;
-        sOcarinaNoteCPrimR = 255;
-        sOcarinaNoteCPrimG = 255;
-        sOcarinaNoteCPrimB = 50;
-    } else if (CVar_GetS32("gHudColors", 1) == 2) {
-        sOcarinaNoteAPrimR = CVar_GetS32("gCCABtnPrimR", 80);
-        sOcarinaNoteAPrimG = CVar_GetS32("gCCABtnPrimR", 255);
-        sOcarinaNoteAPrimB = CVar_GetS32("gCCABtnPrimR", 150);
-        sOcarinaNoteCPrimR = CVar_GetS32("gCCCBtnPrimR", 255);
-        sOcarinaNoteCPrimG = CVar_GetS32("gCCCBtnPrimG", 255);
-        sOcarinaNoteCPrimB = CVar_GetS32("gCCCBtnPrimB", 50);
-        sOcarinaNoteCUpPrimR = CVar_GetS32("gCCCUBtnPrimR", 255);
-        sOcarinaNoteCUpPrimG = CVar_GetS32("gCCCUBtnPrimG", 255);
-        sOcarinaNoteCUpPrimB = CVar_GetS32("gCCCUBtnPrimB", 50);
-        sOcarinaNoteCLeftPrimR = CVar_GetS32("gCCCLBtnPrimR", 255);
-        sOcarinaNoteCLeftPrimG = CVar_GetS32("gCCCLBtnPrimG", 255);
-        sOcarinaNoteCLeftPrimB = CVar_GetS32("gCCCLBtnPrimB", 50);
-        sOcarinaNoteCDownPrimR = CVar_GetS32("gCCCDBtnPrimR", 255);
-        sOcarinaNoteCDownPrimG = CVar_GetS32("gCCCDBtnPrimG", 255);
-        sOcarinaNoteCDownPrimB = CVar_GetS32("gCCCDBtnPrimB", 50);
-        sOcarinaNoteCRightPrimR = CVar_GetS32("gCCCRBtnPrimR", 255);
-        sOcarinaNoteCRightPrimG = CVar_GetS32("gCCCRBtnPrimG", 255);
-        sOcarinaNoteCRightPrimB = CVar_GetS32("gCCCRBtnPrimB", 50);
+    sOcarinaNoteABtnEnv = (Color_RGB8){ .r = 10, .g = 10, .b = 10 };
+    sOcarinaNoteCBtnEnv = (Color_RGB8){ .r = 10, .g = 10, .b = 10 };
+
+    if (CVar_GetS32("gHudColors", 1) != 2) {  // N64/GameCube
+        if (CVar_GetS32("gHudColors", 1) == 0) {
+            sOcarinaNoteD4Prim = (Color_RGB8){ .r = 80, .g = 150, .b = 255 };
+        } else if (CVar_GetS32("gHudColors", 1) == 1) {
+            sOcarinaNoteD4Prim = (Color_RGB8){ .r = 80, .g = 255, .b = 150 };
+        }
+
+        sOcarinaNoteCBtnPrim = (Color_RGB8){ .r = 255, .g = 255, .b = 50 };
+        sOcarinaNoteD5Prim = sOcarinaNoteCBtnPrim;
+        sOcarinaNoteB4Prim = sOcarinaNoteCBtnPrim;
+        sOcarinaNoteA4Prim = sOcarinaNoteCBtnPrim;
+        sOcarinaNoteF4Prim = sOcarinaNoteCBtnPrim;
+    } else {  // Custom
+        sOcarinaNoteCBtnPrim.r = CVar_GetS32("gCCCBtnPrimR", 255);
+        sOcarinaNoteCBtnPrim.g = CVar_GetS32("gCCCBtnPrimG", 255);
+        sOcarinaNoteCBtnPrim.b = CVar_GetS32("gCCCBtnPrimB", 50);
+
+        CustomNoteOptions options = (CustomNoteOptions){
+            .separateC = CVar_GetS32("gCCparated", 0),
+            .dpad = CVar_GetS32("gDpadOcarina", 0),
+            .rightStick = CVar_GetS32("gDpadRStick", 0),
+        };
+
+        if (CVar_GetS32("gCustomOcarinaControls", 0)) {
+            Message_SetCustomOcarinaNoteColor(&sOcarinaNoteD5Prim, CVar_GetS32("gOcarinaD5BtnMap", BTN_CUP), &options);
+            Message_SetCustomOcarinaNoteColor(&sOcarinaNoteB4Prim, CVar_GetS32("gOcarinaB4BtnMap", BTN_CLEFT), &options);
+            Message_SetCustomOcarinaNoteColor(&sOcarinaNoteA4Prim, CVar_GetS32("gOcarinaA4BtnMap", BTN_CRIGHT), &options);
+            Message_SetCustomOcarinaNoteColor(&sOcarinaNoteF4Prim, CVar_GetS32("gOcarinaF4BtnMap", BTN_CDOWN), &options);
+            Message_SetCustomOcarinaNoteColor(&sOcarinaNoteD4Prim, CVar_GetS32("gOcarinaD4BtnMap", BTN_A), &options);
+        } else {
+            Message_SetCustomOrGeneralCColor(&sOcarinaNoteD5Prim, options.separateC, 'U');
+            Message_SetCustomOrGeneralCColor(&sOcarinaNoteB4Prim, options.separateC, 'L');
+            Message_SetCustomOrGeneralCColor(&sOcarinaNoteA4Prim, options.separateC, 'R');
+            Message_SetCustomOrGeneralCColor(&sOcarinaNoteF4Prim, options.separateC, 'D');
+            sOcarinaNoteD4Prim.r = CVar_GetS32("gCCABtnPrimR", 80);
+            sOcarinaNoteD4Prim.g = CVar_GetS32("gCCABtnPrimG", 255);
+            sOcarinaNoteD4Prim.b = CVar_GetS32("gCCABtnPrimB", 150);
+        }
     }
 }
 
@@ -208,7 +273,7 @@ void Message_HandleChoiceSelection(GlobalContext* globalCtx, u8 numChoices) {
     static s16 sAnalogStickHeld = false;
     MessageContext* msgCtx = &globalCtx->msgCtx;
     Input* input = &globalCtx->state.input[0];
-    bool dpad = CVar_GetS32("gDpadOcarinaText", 0);
+    bool dpad = CVar_GetS32("gDpadText", 0);
 
     if ((input->rel.stick_y >= 30 && !sAnalogStickHeld) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DUP))) {
         sAnalogStickHeld = true;
@@ -2290,213 +2355,213 @@ void Message_DrawMain(GlobalContext* globalCtx, Gfx** p) {
             case MSGMODE_OCARINA_CORRECT_PLAYBACK:
             case MSGMODE_SONG_PLAYBACK_SUCCESS:
             case MSGMODE_SCARECROW_RECORDING_DONE:
-                r = ABS(sOcarinaNoteAPrimR - sOcarinaNoteAPrimColors[sOcarinaNoteFlashColorIdx][0]) /
+                r = ABS(sOcarinaNoteD4Prim.r - sOcarinaNoteAPrimColors[sOcarinaNoteFlashColorIdx][0]) /
                     sOcarinaNoteFlashTimer;
-                g = ABS(sOcarinaNoteAPrimG - sOcarinaNoteAPrimColors[sOcarinaNoteFlashColorIdx][1]) /
+                g = ABS(sOcarinaNoteD4Prim.g - sOcarinaNoteAPrimColors[sOcarinaNoteFlashColorIdx][1]) /
                     sOcarinaNoteFlashTimer;
-                b = ABS(sOcarinaNoteAPrimB - sOcarinaNoteAPrimColors[sOcarinaNoteFlashColorIdx][2]) /
-                    sOcarinaNoteFlashTimer;
-
-                if (sOcarinaNoteAPrimR >= sOcarinaNoteAPrimColors[sOcarinaNoteFlashColorIdx][0]) {
-                    sOcarinaNoteAPrimR -= r;
-                } else {
-                    sOcarinaNoteAPrimR += r;
-                }
-                if (sOcarinaNoteAPrimG >= sOcarinaNoteAPrimColors[sOcarinaNoteFlashColorIdx][1]) {
-                    sOcarinaNoteAPrimG -= g;
-                } else {
-                    sOcarinaNoteAPrimG += g;
-                }
-                if (sOcarinaNoteAPrimB >= sOcarinaNoteAPrimColors[sOcarinaNoteFlashColorIdx][2]) {
-                    sOcarinaNoteAPrimB -= b;
-                } else {
-                    sOcarinaNoteAPrimB += b;
-                }
-
-                r = ABS(sOcarinaNoteAEnvR - sOcarinaNoteAEnvColors[sOcarinaNoteFlashColorIdx][0]) /
-                    sOcarinaNoteFlashTimer;
-                g = ABS(sOcarinaNoteAEnvG - sOcarinaNoteAEnvColors[sOcarinaNoteFlashColorIdx][1]) /
-                    sOcarinaNoteFlashTimer;
-                b = ABS(sOcarinaNoteAEnvB - sOcarinaNoteAEnvColors[sOcarinaNoteFlashColorIdx][2]) /
+                b = ABS(sOcarinaNoteD4Prim.b - sOcarinaNoteAPrimColors[sOcarinaNoteFlashColorIdx][2]) /
                     sOcarinaNoteFlashTimer;
 
-                if (sOcarinaNoteCEnvR >= sOcarinaNoteAEnvColors[sOcarinaNoteFlashColorIdx][0]) {
-                    sOcarinaNoteAEnvR -= r;
+                if (sOcarinaNoteD4Prim.r >= sOcarinaNoteAPrimColors[sOcarinaNoteFlashColorIdx][0]) {
+                    sOcarinaNoteD4Prim.r -= r;
                 } else {
-                    sOcarinaNoteAEnvR += r;
+                    sOcarinaNoteD4Prim.r += r;
                 }
-                if (sOcarinaNoteCEnvG >= sOcarinaNoteAEnvColors[sOcarinaNoteFlashColorIdx][1]) {
-                    sOcarinaNoteAEnvG -= g;
+                if (sOcarinaNoteD4Prim.g >= sOcarinaNoteAPrimColors[sOcarinaNoteFlashColorIdx][1]) {
+                    sOcarinaNoteD4Prim.g -= g;
                 } else {
-                    sOcarinaNoteAEnvG += g;
+                    sOcarinaNoteD4Prim.g += g;
                 }
-                if (sOcarinaNoteCEnvB >= sOcarinaNoteAEnvColors[sOcarinaNoteFlashColorIdx][2]) {
-                    sOcarinaNoteAEnvB -= b;
+                if (sOcarinaNoteD4Prim.b >= sOcarinaNoteAPrimColors[sOcarinaNoteFlashColorIdx][2]) {
+                    sOcarinaNoteD4Prim.b -= b;
                 } else {
-                    sOcarinaNoteAEnvB += b;
-                }
-
-                r = ABS(sOcarinaNoteCPrimR - sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx][0]) /
-                    sOcarinaNoteFlashTimer;
-                g = ABS(sOcarinaNoteCPrimG - sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx][1]) /
-                    sOcarinaNoteFlashTimer;
-                b = ABS(sOcarinaNoteCPrimB - sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx][2]) /
-                    sOcarinaNoteFlashTimer;
-
-                ru = ABS(sOcarinaNoteCUpPrimR - sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+5][0]) /
-                    sOcarinaNoteFlashTimer;
-                gu = ABS(sOcarinaNoteCUpPrimG - sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+5][1]) /
-                    sOcarinaNoteFlashTimer;
-                bu = ABS(sOcarinaNoteCUpPrimB - sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+5][2]) /
-                    sOcarinaNoteFlashTimer;
-                rl = ABS(sOcarinaNoteCLeftPrimR - sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+2][0]) /
-                    sOcarinaNoteFlashTimer;
-                gl = ABS(sOcarinaNoteCLeftPrimG - sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+2][1]) /
-                    sOcarinaNoteFlashTimer;
-                bl = ABS(sOcarinaNoteCLeftPrimB - sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+2][2]) /
-                    sOcarinaNoteFlashTimer;
-                rd = ABS(sOcarinaNoteCDownPrimR - sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+3][0]) /
-                    sOcarinaNoteFlashTimer;
-                gd = ABS(sOcarinaNoteCDownPrimG - sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+3][1]) /
-                    sOcarinaNoteFlashTimer;
-                bd = ABS(sOcarinaNoteCDownPrimB - sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+3][2]) /
-                    sOcarinaNoteFlashTimer;
-                rr = ABS(sOcarinaNoteCRightPrimR - sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+4][0]) /
-                    sOcarinaNoteFlashTimer;
-                gr = ABS(sOcarinaNoteCRightPrimG - sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+4][1]) /
-                    sOcarinaNoteFlashTimer;
-                br = ABS(sOcarinaNoteCRightPrimB - sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+4][2]) /
-                    sOcarinaNoteFlashTimer;
-
-                if (sOcarinaNoteCPrimR >= sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx][0]) {
-                    sOcarinaNoteCPrimR -= r;
-                } else {
-                    sOcarinaNoteCPrimR += r;
-                }
-                if (sOcarinaNoteCPrimG >= sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx][1]) {
-                    sOcarinaNoteCPrimG -= g;
-                } else {
-                    sOcarinaNoteCPrimG += g;
-                }
-                if (sOcarinaNoteCPrimB >= sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx][2]) {
-                    sOcarinaNoteCPrimB -= b;
-                } else {
-                    sOcarinaNoteCPrimB += b;
+                    sOcarinaNoteD4Prim.b += b;
                 }
 
-                if (sOcarinaNoteCUpPrimR >= sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+5][0]) {
-                    sOcarinaNoteCUpPrimR -= ru;
-                } else {
-                    sOcarinaNoteCUpPrimR += ru;
-                }
-                if (sOcarinaNoteCUpPrimG >= sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+5][1]) {
-                    sOcarinaNoteCUpPrimG -= gu;
-                } else {
-                    sOcarinaNoteCUpPrimG += gu;
-                }
-                if (sOcarinaNoteCUpPrimB >= sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+5][2]) {
-                    sOcarinaNoteCUpPrimB -= bu;
-                } else {
-                    sOcarinaNoteCUpPrimB += bu;
-                }
-
-                if (sOcarinaNoteCLeftPrimR >= sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+2][0]) {
-                    sOcarinaNoteCLeftPrimR -= rl;
-                } else {
-                    sOcarinaNoteCLeftPrimR += rl;
-                }
-                if (sOcarinaNoteCLeftPrimG >= sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+2][1]) {
-                    sOcarinaNoteCLeftPrimG -= gl;
-                } else {
-                    sOcarinaNoteCLeftPrimG += gl;
-                }
-                if (sOcarinaNoteCLeftPrimB >= sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+2][2]) {
-                    sOcarinaNoteCLeftPrimB -= bl;
-                } else {
-                    sOcarinaNoteCLeftPrimB += bl;
-                }
-
-                if (sOcarinaNoteCDownPrimR >= sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+3][0]) {
-                    sOcarinaNoteCDownPrimR -= rd;
-                } else {
-                    sOcarinaNoteCDownPrimR += rd;
-                }
-                if (sOcarinaNoteCDownPrimG >= sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+3][1]) {
-                    sOcarinaNoteCDownPrimG -= gd;
-                } else {
-                    sOcarinaNoteCDownPrimG += gd;
-                }
-                if (sOcarinaNoteCDownPrimB >= sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+3][2]) {
-                    sOcarinaNoteCDownPrimB -= bd;
-                } else {
-                    sOcarinaNoteCDownPrimB += bd;
-                }
-
-                if (sOcarinaNoteCRightPrimR >= sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+4][0]) {
-                    sOcarinaNoteCRightPrimR -= rr;
-                } else {
-                    sOcarinaNoteCRightPrimR += rr;
-                }
-                if (sOcarinaNoteCRightPrimG >= sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+4][1]) {
-                    sOcarinaNoteCRightPrimG -= gr;
-                } else {
-                    sOcarinaNoteCRightPrimG += gr;
-                }
-                if (sOcarinaNoteCRightPrimB >= sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+4][2]) {
-                    sOcarinaNoteCRightPrimB -= br;
-                } else {
-                    sOcarinaNoteCRightPrimB += br;
-                }
-
-                r = ABS(sOcarinaNoteCEnvR - sOcarinaNoteCEnvColors[sOcarinaNoteFlashColorIdx][0]) /
+                r = ABS(sOcarinaNoteABtnEnv.r - sOcarinaNoteAEnvColors[sOcarinaNoteFlashColorIdx][0]) /
                     sOcarinaNoteFlashTimer;
-                g = ABS(sOcarinaNoteCEnvG - sOcarinaNoteCEnvColors[sOcarinaNoteFlashColorIdx][1]) /
+                g = ABS(sOcarinaNoteABtnEnv.g - sOcarinaNoteAEnvColors[sOcarinaNoteFlashColorIdx][1]) /
                     sOcarinaNoteFlashTimer;
-                b = ABS(sOcarinaNoteCEnvB - sOcarinaNoteCEnvColors[sOcarinaNoteFlashColorIdx][2]) /
+                b = ABS(sOcarinaNoteABtnEnv.b - sOcarinaNoteAEnvColors[sOcarinaNoteFlashColorIdx][2]) /
                     sOcarinaNoteFlashTimer;
 
-                if (sOcarinaNoteCEnvR >= sOcarinaNoteCEnvColors[sOcarinaNoteFlashColorIdx][0]) {
-                    sOcarinaNoteCEnvR -= r;
+                if (sOcarinaNoteCBtnEnv.r >= sOcarinaNoteAEnvColors[sOcarinaNoteFlashColorIdx][0]) {
+                    sOcarinaNoteABtnEnv.r -= r;
                 } else {
-                    sOcarinaNoteCEnvR += r;
+                    sOcarinaNoteABtnEnv.r += r;
                 }
-                if (sOcarinaNoteCEnvG >= sOcarinaNoteCEnvColors[sOcarinaNoteFlashColorIdx][1]) {
-                    sOcarinaNoteCEnvG -= g;
+                if (sOcarinaNoteCBtnEnv.g >= sOcarinaNoteAEnvColors[sOcarinaNoteFlashColorIdx][1]) {
+                    sOcarinaNoteABtnEnv.g -= g;
                 } else {
-                    sOcarinaNoteCEnvG += g;
+                    sOcarinaNoteABtnEnv.g += g;
                 }
-                if (sOcarinaNoteCEnvB >= sOcarinaNoteCEnvColors[sOcarinaNoteFlashColorIdx][2]) {
-                    sOcarinaNoteCEnvB -= b;
+                if (sOcarinaNoteCBtnEnv.b >= sOcarinaNoteAEnvColors[sOcarinaNoteFlashColorIdx][2]) {
+                    sOcarinaNoteABtnEnv.b -= b;
                 } else {
-                    sOcarinaNoteCEnvB += b;
+                    sOcarinaNoteABtnEnv.b += b;
+                }
+
+                r = ABS(sOcarinaNoteCBtnPrim.r - sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx][0]) /
+                    sOcarinaNoteFlashTimer;
+                g = ABS(sOcarinaNoteCBtnPrim.g - sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx][1]) /
+                    sOcarinaNoteFlashTimer;
+                b = ABS(sOcarinaNoteCBtnPrim.b - sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx][2]) /
+                    sOcarinaNoteFlashTimer;
+
+                ru = ABS(sOcarinaNoteD5Prim.r - sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+5][0]) /
+                    sOcarinaNoteFlashTimer;
+                gu = ABS(sOcarinaNoteD5Prim.g - sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+5][1]) /
+                    sOcarinaNoteFlashTimer;
+                bu = ABS(sOcarinaNoteD5Prim.b - sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+5][2]) /
+                    sOcarinaNoteFlashTimer;
+                rl = ABS(sOcarinaNoteB4Prim.r - sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+2][0]) /
+                    sOcarinaNoteFlashTimer;
+                gl = ABS(sOcarinaNoteB4Prim.g - sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+2][1]) /
+                    sOcarinaNoteFlashTimer;
+                bl = ABS(sOcarinaNoteB4Prim.b - sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+2][2]) /
+                    sOcarinaNoteFlashTimer;
+                rd = ABS(sOcarinaNoteF4Prim.r - sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+3][0]) /
+                    sOcarinaNoteFlashTimer;
+                gd = ABS(sOcarinaNoteF4Prim.g - sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+3][1]) /
+                    sOcarinaNoteFlashTimer;
+                bd = ABS(sOcarinaNoteF4Prim.b - sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+3][2]) /
+                    sOcarinaNoteFlashTimer;
+                rr = ABS(sOcarinaNoteA4Prim.r - sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+4][0]) /
+                    sOcarinaNoteFlashTimer;
+                gr = ABS(sOcarinaNoteA4Prim.g - sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+4][1]) /
+                    sOcarinaNoteFlashTimer;
+                br = ABS(sOcarinaNoteA4Prim.b - sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+4][2]) /
+                    sOcarinaNoteFlashTimer;
+
+                if (sOcarinaNoteCBtnPrim.r >= sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx][0]) {
+                    sOcarinaNoteCBtnPrim.r -= r;
+                } else {
+                    sOcarinaNoteCBtnPrim.r += r;
+                }
+                if (sOcarinaNoteCBtnPrim.g >= sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx][1]) {
+                    sOcarinaNoteCBtnPrim.g -= g;
+                } else {
+                    sOcarinaNoteCBtnPrim.g += g;
+                }
+                if (sOcarinaNoteCBtnPrim.b >= sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx][2]) {
+                    sOcarinaNoteCBtnPrim.b -= b;
+                } else {
+                    sOcarinaNoteCBtnPrim.b += b;
+                }
+
+                if (sOcarinaNoteD5Prim.r >= sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+5][0]) {
+                    sOcarinaNoteD5Prim.r -= ru;
+                } else {
+                    sOcarinaNoteD5Prim.r += ru;
+                }
+                if (sOcarinaNoteD5Prim.g >= sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+5][1]) {
+                    sOcarinaNoteD5Prim.g -= gu;
+                } else {
+                    sOcarinaNoteD5Prim.g += gu;
+                }
+                if (sOcarinaNoteD5Prim.b >= sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+5][2]) {
+                    sOcarinaNoteD5Prim.b -= bu;
+                } else {
+                    sOcarinaNoteD5Prim.b += bu;
+                }
+
+                if (sOcarinaNoteB4Prim.r >= sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+2][0]) {
+                    sOcarinaNoteB4Prim.r -= rl;
+                } else {
+                    sOcarinaNoteB4Prim.r += rl;
+                }
+                if (sOcarinaNoteB4Prim.g >= sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+2][1]) {
+                    sOcarinaNoteB4Prim.g -= gl;
+                } else {
+                    sOcarinaNoteB4Prim.g += gl;
+                }
+                if (sOcarinaNoteB4Prim.b >= sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+2][2]) {
+                    sOcarinaNoteB4Prim.b -= bl;
+                } else {
+                    sOcarinaNoteB4Prim.b += bl;
+                }
+
+                if (sOcarinaNoteF4Prim.r >= sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+3][0]) {
+                    sOcarinaNoteF4Prim.r -= rd;
+                } else {
+                    sOcarinaNoteF4Prim.r += rd;
+                }
+                if (sOcarinaNoteF4Prim.g >= sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+3][1]) {
+                    sOcarinaNoteF4Prim.g -= gd;
+                } else {
+                    sOcarinaNoteF4Prim.g += gd;
+                }
+                if (sOcarinaNoteF4Prim.b >= sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+3][2]) {
+                    sOcarinaNoteF4Prim.b -= bd;
+                } else {
+                    sOcarinaNoteF4Prim.b += bd;
+                }
+
+                if (sOcarinaNoteA4Prim.r >= sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+4][0]) {
+                    sOcarinaNoteA4Prim.r -= rr;
+                } else {
+                    sOcarinaNoteA4Prim.r += rr;
+                }
+                if (sOcarinaNoteA4Prim.g >= sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+4][1]) {
+                    sOcarinaNoteA4Prim.g -= gr;
+                } else {
+                    sOcarinaNoteA4Prim.g += gr;
+                }
+                if (sOcarinaNoteA4Prim.b >= sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+4][2]) {
+                    sOcarinaNoteA4Prim.b -= br;
+                } else {
+                    sOcarinaNoteA4Prim.b += br;
+                }
+
+                r = ABS(sOcarinaNoteCBtnEnv.r - sOcarinaNoteCEnvColors[sOcarinaNoteFlashColorIdx][0]) /
+                    sOcarinaNoteFlashTimer;
+                g = ABS(sOcarinaNoteCBtnEnv.g - sOcarinaNoteCEnvColors[sOcarinaNoteFlashColorIdx][1]) /
+                    sOcarinaNoteFlashTimer;
+                b = ABS(sOcarinaNoteCBtnEnv.b - sOcarinaNoteCEnvColors[sOcarinaNoteFlashColorIdx][2]) /
+                    sOcarinaNoteFlashTimer;
+
+                if (sOcarinaNoteCBtnEnv.r >= sOcarinaNoteCEnvColors[sOcarinaNoteFlashColorIdx][0]) {
+                    sOcarinaNoteCBtnEnv.r -= r;
+                } else {
+                    sOcarinaNoteCBtnEnv.r += r;
+                }
+                if (sOcarinaNoteCBtnEnv.g >= sOcarinaNoteCEnvColors[sOcarinaNoteFlashColorIdx][1]) {
+                    sOcarinaNoteCBtnEnv.g -= g;
+                } else {
+                    sOcarinaNoteCBtnEnv.g += g;
+                }
+                if (sOcarinaNoteCBtnEnv.b >= sOcarinaNoteCEnvColors[sOcarinaNoteFlashColorIdx][2]) {
+                    sOcarinaNoteCBtnEnv.b -= b;
+                } else {
+                    sOcarinaNoteCBtnEnv.b += b;
                 }
 
                 sOcarinaNoteFlashTimer--;
                 if (sOcarinaNoteFlashTimer == 0) {
-                    sOcarinaNoteAPrimR = sOcarinaNoteAPrimColors[sOcarinaNoteFlashColorIdx][0];
-                    sOcarinaNoteAPrimG = sOcarinaNoteAPrimColors[sOcarinaNoteFlashColorIdx][1];
-                    sOcarinaNoteAPrimB = sOcarinaNoteAPrimColors[sOcarinaNoteFlashColorIdx][2];
-                    sOcarinaNoteAEnvR = sOcarinaNoteAEnvColors[sOcarinaNoteFlashColorIdx][0];
-                    sOcarinaNoteAEnvG = sOcarinaNoteAEnvColors[sOcarinaNoteFlashColorIdx][1];
-                    sOcarinaNoteAEnvB = sOcarinaNoteAEnvColors[sOcarinaNoteFlashColorIdx][2];
-                    sOcarinaNoteCPrimR = sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx][0];
-                    sOcarinaNoteCPrimG = sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx][1];
-                    sOcarinaNoteCPrimB = sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx][2];
-                    sOcarinaNoteCUpPrimR = sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+5][0];
-                    sOcarinaNoteCUpPrimG = sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+5][1];
-                    sOcarinaNoteCUpPrimB = sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+5][2];
-                    sOcarinaNoteCLeftPrimR = sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+2][0];
-                    sOcarinaNoteCLeftPrimG = sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+2][1];
-                    sOcarinaNoteCLeftPrimB = sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+2][2];
-                    sOcarinaNoteCDownPrimR = sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+3][0];
-                    sOcarinaNoteCDownPrimG = sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+3][1];
-                    sOcarinaNoteCDownPrimB = sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+3][2];
-                    sOcarinaNoteCRightPrimR = sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+4][0];
-                    sOcarinaNoteCRightPrimG = sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+4][1];
-                    sOcarinaNoteCRightPrimB = sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+4][2];
-                    sOcarinaNoteCEnvR = sOcarinaNoteCEnvColors[sOcarinaNoteFlashColorIdx][0];
-                    sOcarinaNoteCEnvG = sOcarinaNoteCEnvColors[sOcarinaNoteFlashColorIdx][1];
-                    sOcarinaNoteCEnvB = sOcarinaNoteCEnvColors[sOcarinaNoteFlashColorIdx][2];
+                    sOcarinaNoteD4Prim.r = sOcarinaNoteAPrimColors[sOcarinaNoteFlashColorIdx][0];
+                    sOcarinaNoteD4Prim.g = sOcarinaNoteAPrimColors[sOcarinaNoteFlashColorIdx][1];
+                    sOcarinaNoteD4Prim.b = sOcarinaNoteAPrimColors[sOcarinaNoteFlashColorIdx][2];
+                    sOcarinaNoteABtnEnv.r = sOcarinaNoteAEnvColors[sOcarinaNoteFlashColorIdx][0];
+                    sOcarinaNoteABtnEnv.g = sOcarinaNoteAEnvColors[sOcarinaNoteFlashColorIdx][1];
+                    sOcarinaNoteABtnEnv.b = sOcarinaNoteAEnvColors[sOcarinaNoteFlashColorIdx][2];
+                    sOcarinaNoteCBtnPrim.r = sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx][0];
+                    sOcarinaNoteCBtnPrim.g = sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx][1];
+                    sOcarinaNoteCBtnPrim.b = sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx][2];
+                    sOcarinaNoteD5Prim.r = sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+5][0];
+                    sOcarinaNoteD5Prim.g = sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+5][1];
+                    sOcarinaNoteD5Prim.b = sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+5][2];
+                    sOcarinaNoteB4Prim.r = sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+2][0];
+                    sOcarinaNoteB4Prim.g = sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+2][1];
+                    sOcarinaNoteB4Prim.b = sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+2][2];
+                    sOcarinaNoteF4Prim.r = sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+3][0];
+                    sOcarinaNoteF4Prim.g = sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+3][1];
+                    sOcarinaNoteF4Prim.b = sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+3][2];
+                    sOcarinaNoteA4Prim.r = sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+4][0];
+                    sOcarinaNoteA4Prim.g = sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+4][1];
+                    sOcarinaNoteA4Prim.b = sOcarinaNoteCPrimColors[sOcarinaNoteFlashColorIdx+4][2];
+                    sOcarinaNoteCBtnEnv.r = sOcarinaNoteCEnvColors[sOcarinaNoteFlashColorIdx][0];
+                    sOcarinaNoteCBtnEnv.g = sOcarinaNoteCEnvColors[sOcarinaNoteFlashColorIdx][1];
+                    sOcarinaNoteCBtnEnv.b = sOcarinaNoteCEnvColors[sOcarinaNoteFlashColorIdx][2];
                     sOcarinaNoteFlashTimer = 3;
                     sOcarinaNoteFlashColorIdx ^= 1;
                 }
@@ -3120,32 +3185,24 @@ void Message_DrawMain(GlobalContext* globalCtx, Gfx** p) {
                     }
 
                     gDPPipeSync(gfx++);
-                    if (sOcarinaNoteBuf[i] == OCARINA_NOTE_A) {
-                        if (CVar_GetS32("gHudColors", 1) == 0) { //A buttons :)
-                            gDPSetPrimColor(gfx++, 0, 0, 80, 150, 255, sOcarinaNotesAlphaValues[i]);
-                        } else if (CVar_GetS32("gHudColors", 1) == 1) {
-                            gDPSetPrimColor(gfx++, 0, 0, sOcarinaNoteAPrimR, sOcarinaNoteAPrimG, sOcarinaNoteAPrimB, sOcarinaNotesAlphaValues[i]);
-                        } else if (CVar_GetS32("gHudColors", 1) == 2) {
-                            gDPSetPrimColor(gfx++, 0, 0, CVar_GetS32("gCCABtnPrimR", 80), CVar_GetS32("gCCABtnPrimG", 255), CVar_GetS32("gCCABtnPrimB", 150), sOcarinaNotesAlphaValues[i]);
-                        }
-                        gDPSetEnvColor(gfx++, sOcarinaNoteAEnvR, sOcarinaNoteAEnvG, sOcarinaNoteAEnvB, 0);
+
+                    // Since I don't know what exactly these Env vars are used for, I elected keep their usage
+                    // consistent with the note played, rather than having AEnv be used for whatever note A happens to
+                    // play at the moment and CEnv for everything else, even with custom controls enabled.
+                    if (sOcarinaNoteBuf[i] == OCARINA_NOTE_D4) {
+                        gDPSetPrimColor(gfx++, 0, 0, sOcarinaNoteD4Prim.r, sOcarinaNoteD4Prim.g, sOcarinaNoteD4Prim.b, sOcarinaNotesAlphaValues[i]);
+                        gDPSetEnvColor(gfx++, sOcarinaNoteABtnEnv.r, sOcarinaNoteABtnEnv.g, sOcarinaNoteABtnEnv.b, 0);
                     } else {
-                        if (CVar_GetS32("gHudColors", 1) == 0) { //C buttons :)
-                            gDPSetPrimColor(gfx++, 0, 0, sOcarinaNoteCPrimR, sOcarinaNoteCPrimG, sOcarinaNoteCPrimB, sOcarinaNotesAlphaValues[i]);
-                        } else if (CVar_GetS32("gHudColors", 1) == 1) {
-                            gDPSetPrimColor(gfx++, 0, 0, sOcarinaNoteCPrimR, sOcarinaNoteCPrimG, sOcarinaNoteCPrimB, sOcarinaNotesAlphaValues[i]);
-                        } else if (CVar_GetS32("gHudColors", 1) == 2 && !CVar_GetS32("gCCparated", 0)) {
-                            gDPSetPrimColor(gfx++, 0, 0, CVar_GetS32("gCCCBtnPrimR", 255), CVar_GetS32("gCCCBtnPrimG", 255), CVar_GetS32("gCCCBtnPrimB", 180), sOcarinaNotesAlphaValues[i]);
-                        } else if (sOcarinaNoteBuf[i] == OCARINA_NOTE_C_UP && CVar_GetS32("gHudColors", 1) == 2 && CVar_GetS32("gCCparated", 0)) {
-                            gDPSetPrimColor(gfx++, 0, 0, sOcarinaNoteCUpPrimR, sOcarinaNoteCUpPrimG, sOcarinaNoteCUpPrimB, sOcarinaNotesAlphaValues[i]);
-                        } else if (sOcarinaNoteBuf[i] == OCARINA_NOTE_C_LEFT && CVar_GetS32("gHudColors", 1) == 2 && CVar_GetS32("gCCparated", 0)) {
-                            gDPSetPrimColor(gfx++, 0, 0, sOcarinaNoteCLeftPrimR, sOcarinaNoteCLeftPrimG, sOcarinaNoteCLeftPrimB, sOcarinaNotesAlphaValues[i]);
-                        } else if (sOcarinaNoteBuf[i] == OCARINA_NOTE_C_RIGHT && CVar_GetS32("gHudColors", 1) == 2 && CVar_GetS32("gCCparated", 0)) {
-                            gDPSetPrimColor(gfx++, 0, 0, sOcarinaNoteCRightPrimR, sOcarinaNoteCRightPrimG, sOcarinaNoteCRightPrimB, sOcarinaNotesAlphaValues[i]);
-                        } else if (sOcarinaNoteBuf[i] == OCARINA_NOTE_C_DOWN && CVar_GetS32("gHudColors", 1) == 2 && CVar_GetS32("gCCparated", 0)) {
-                            gDPSetPrimColor(gfx++, 0, 0, sOcarinaNoteCDownPrimR, sOcarinaNoteCDownPrimG, sOcarinaNoteCDownPrimB, sOcarinaNotesAlphaValues[i]);
+                        if (sOcarinaNoteBuf[i] == OCARINA_NOTE_D5) {
+                            gDPSetPrimColor(gfx++, 0, 0, sOcarinaNoteD5Prim.r, sOcarinaNoteD5Prim.g, sOcarinaNoteD5Prim.b, sOcarinaNotesAlphaValues[i]);
+                        } else if (sOcarinaNoteBuf[i] == OCARINA_NOTE_B4) {
+                            gDPSetPrimColor(gfx++, 0, 0, sOcarinaNoteB4Prim.r, sOcarinaNoteB4Prim.g, sOcarinaNoteB4Prim.b, sOcarinaNotesAlphaValues[i]);
+                        } else if (sOcarinaNoteBuf[i] == OCARINA_NOTE_A4) {
+                            gDPSetPrimColor(gfx++, 0, 0, sOcarinaNoteA4Prim.r, sOcarinaNoteA4Prim.g, sOcarinaNoteA4Prim.b, sOcarinaNotesAlphaValues[i]);
+                        } else if (sOcarinaNoteBuf[i] == OCARINA_NOTE_F4) {
+                            gDPSetPrimColor(gfx++, 0, 0, sOcarinaNoteF4Prim.r, sOcarinaNoteF4Prim.g, sOcarinaNoteF4Prim.b, sOcarinaNotesAlphaValues[i]);
                         }
-                        gDPSetEnvColor(gfx++, sOcarinaNoteCEnvR, sOcarinaNoteCEnvG, sOcarinaNoteCEnvB, 0);
+                        gDPSetEnvColor(gfx++, sOcarinaNoteCBtnEnv.r, sOcarinaNoteCBtnEnv.g, sOcarinaNoteCBtnEnv.b, 0);
                     }
 
                     gDPLoadTextureBlock(gfx++, sOcarinaNoteTextures[sOcarinaNoteBuf[i]], G_IM_FMT_IA, G_IM_SIZ_8b, 16,

--- a/soh/src/overlays/actors/ovl_En_Fr/z_en_fr.c
+++ b/soh/src/overlays/actors/ovl_En_Fr/z_en_fr.c
@@ -187,7 +187,7 @@ static u8 sJumpOrder[] = {
 };
 
 static u8 sOcarinaNotes[] = {
-    OCARINA_NOTE_A, OCARINA_NOTE_C_DOWN, OCARINA_NOTE_C_RIGHT, OCARINA_NOTE_C_LEFT, OCARINA_NOTE_C_UP,
+    OCARINA_NOTE_D4, OCARINA_NOTE_F4, OCARINA_NOTE_A4, OCARINA_NOTE_B4, OCARINA_NOTE_D5,
 };
 
 void EnFr_OrientUnderwater(EnFr* this) {
@@ -680,19 +680,19 @@ void EnFr_ListeningToOcarinaNotes(EnFr* this, GlobalContext* globalCtx) {
             break;
         case OCARINA_MODE_01:                           // Ocarina note played, but no song played
             switch (globalCtx->msgCtx.lastOcaNoteIdx) { // Jumping frogs in open ocarina based on ocarina note played
-                case OCARINA_NOTE_A:
+                case OCARINA_NOTE_D4:
                     EnFr_SetupJumpingUp(this, FROG_BLUE);
                     break;
-                case OCARINA_NOTE_C_DOWN:
+                case OCARINA_NOTE_F4:
                     EnFr_SetupJumpingUp(this, FROG_YELLOW);
                     break;
-                case OCARINA_NOTE_C_RIGHT:
+                case OCARINA_NOTE_A4:
                     EnFr_SetupJumpingUp(this, FROG_RED);
                     break;
-                case OCARINA_NOTE_C_LEFT:
+                case OCARINA_NOTE_B4:
                     EnFr_SetupJumpingUp(this, FROG_PURPLE);
                     break;
-                case OCARINA_NOTE_C_UP:
+                case OCARINA_NOTE_D5:
                     EnFr_SetupJumpingUp(this, FROG_WHITE);
                     break;
             }
@@ -871,19 +871,19 @@ void EnFr_ContinueFrogSong(EnFr* this, GlobalContext* globalCtx) {
         if (globalCtx->msgCtx.msgMode == MSGMODE_FROGS_WAITING) {
             globalCtx->msgCtx.msgMode = MSGMODE_FROGS_START;
             switch (globalCtx->msgCtx.lastOcaNoteIdx) {
-                case OCARINA_NOTE_A:
+                case OCARINA_NOTE_D4:
                     EnFr_SetupJumpingUp(this, FROG_BLUE);
                     break;
-                case OCARINA_NOTE_C_DOWN:
+                case OCARINA_NOTE_F4:
                     EnFr_SetupJumpingUp(this, FROG_YELLOW);
                     break;
-                case OCARINA_NOTE_C_RIGHT:
+                case OCARINA_NOTE_A4:
                     EnFr_SetupJumpingUp(this, FROG_RED);
                     break;
-                case OCARINA_NOTE_C_LEFT:
+                case OCARINA_NOTE_B4:
                     EnFr_SetupJumpingUp(this, FROG_PURPLE);
                     break;
-                case OCARINA_NOTE_C_UP:
+                case OCARINA_NOTE_D5:
                     EnFr_SetupJumpingUp(this, FROG_WHITE);
             }
             if (EnFr_IsFrogSongComplete(this, globalCtx)) {

--- a/soh/src/overlays/actors/ovl_En_Kakasi/z_en_kakasi.c
+++ b/soh/src/overlays/actors/ovl_En_Kakasi/z_en_kakasi.c
@@ -107,30 +107,30 @@ void func_80A8F320(EnKakasi* this, GlobalContext* globalCtx, s16 arg) {
         ocarinaNote = this->unk_1A6;
     }
     switch (ocarinaNote) {
-        case OCARINA_NOTE_A:
+        case OCARINA_NOTE_D4:
             this->unk_19A++;
             if (this->unk_1A4 == 0) {
                 this->unk_1A4 = 1;
                 Audio_PlayActorSound2(&this->actor, NA_SE_EV_KAKASHI_ROLL);
             }
             break;
-        case OCARINA_NOTE_C_DOWN:
+        case OCARINA_NOTE_F4:
             this->unk_19A++;
             this->unk_1B8 = 1.0f;
             break;
-        case OCARINA_NOTE_C_RIGHT:
+        case OCARINA_NOTE_A4:
             this->unk_19A++;
             if (this->unk_1AC == 0) {
                 this->unk_1AC = 0x1388;
             }
             break;
-        case OCARINA_NOTE_C_LEFT:
+        case OCARINA_NOTE_B4:
             this->unk_19A++;
             if (this->unk_1A8 == 0) {
                 this->unk_1A8 = 0x1388;
             }
             break;
-        case OCARINA_NOTE_C_UP:
+        case OCARINA_NOTE_D5:
             this->unk_19A++;
             this->unk_1B8 = 2.0f;
             break;

--- a/soh/src/overlays/actors/ovl_En_Kakasi3/z_en_kakasi3.c
+++ b/soh/src/overlays/actors/ovl_En_Kakasi3/z_en_kakasi3.c
@@ -110,30 +110,30 @@ void func_80A90EBC(EnKakasi3* this, GlobalContext* globalCtx, s32 arg) {
         ocarinaNote = this->unk_1A6;
     }
     switch (ocarinaNote) {
-        case OCARINA_NOTE_A:
+        case OCARINA_NOTE_D4:
             this->unk_19A++;
             if (this->unk_1A4 == 0) {
                 this->unk_1A4 = 1;
                 Audio_PlayActorSound2(&this->actor, NA_SE_EV_KAKASHI_ROLL);
             }
             break;
-        case OCARINA_NOTE_C_DOWN:
+        case OCARINA_NOTE_F4:
             this->unk_19A++;
             this->unk_1B8 = 1.0f;
             break;
-        case OCARINA_NOTE_C_RIGHT:
+        case OCARINA_NOTE_A4:
             this->unk_19A++;
             if (this->unk_1AE == 0x0) {
                 this->unk_1AE = 0x1388;
             }
             break;
-        case OCARINA_NOTE_C_LEFT:
+        case OCARINA_NOTE_B4:
             this->unk_19A++;
             if (this->unk_1AA == 0x0) {
                 this->unk_1AA = 0x1388;
             }
             break;
-        case OCARINA_NOTE_C_UP:
+        case OCARINA_NOTE_D5:
             this->unk_19A++;
             this->unk_1B8 = 2.0f;
             break;

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_collect.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_collect.c
@@ -508,13 +508,13 @@ void KaleidoScope_DrawQuestStatus(GlobalContext* globalCtx, GraphicsContext* gfx
                             gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 255, 255, 50, D_8082A150[sp218]);
                         } else if (CVar_GetS32("gHudColors", 1) == 2 && !CVar_GetS32("gCCparated", 0)) {
                             gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, CVar_GetS32("gCCCBtnPrimR", 255), CVar_GetS32("gCCCBtnPrimG", 160), CVar_GetS32("gCCCBtnPrimB", 0), D_8082A150[sp218]);
-                        } else if (D_8082A124[sp218] == OCARINA_NOTE_C_UP && CVar_GetS32("gHudColors", 1) == 2 && CVar_GetS32("gCCparated", 0)) {
+                        } else if (D_8082A124[sp218] == OCARINA_NOTE_D5 && CVar_GetS32("gHudColors", 1) == 2 && CVar_GetS32("gCCparated", 0)) {
                             gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, CVar_GetS32("gCCCUBtnPrimR", 255), CVar_GetS32("gCCCUBtnPrimG", 160), CVar_GetS32("gCCCUBtnPrimB", 0), D_8082A150[sp218]);
-                        } else if (D_8082A124[sp218] == OCARINA_NOTE_C_LEFT && CVar_GetS32("gHudColors", 1) == 2 && CVar_GetS32("gCCparated", 0)) {
+                        } else if (D_8082A124[sp218] == OCARINA_NOTE_B4 && CVar_GetS32("gHudColors", 1) == 2 && CVar_GetS32("gCCparated", 0)) {
                             gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, CVar_GetS32("gCCCLBtnPrimR", 255), CVar_GetS32("gCCCLBtnPrimG", 160), CVar_GetS32("gCCCLBtnPrimB", 0), D_8082A150[sp218]);
-                        } else if (D_8082A124[sp218] == OCARINA_NOTE_C_RIGHT && CVar_GetS32("gHudColors", 1) == 2 && CVar_GetS32("gCCparated", 0)) {
+                        } else if (D_8082A124[sp218] == OCARINA_NOTE_A4 && CVar_GetS32("gHudColors", 1) == 2 && CVar_GetS32("gCCparated", 0)) {
                             gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, CVar_GetS32("gCCCRBtnPrimR", 255), CVar_GetS32("gCCCRBtnPrimG", 160), CVar_GetS32("gCCCRBtnPrimB", 0), D_8082A150[sp218]);
-                        } else if (D_8082A124[sp218] == OCARINA_NOTE_C_DOWN && CVar_GetS32("gHudColors", 1) == 2 && CVar_GetS32("gCCparated", 0)) {
+                        } else if (D_8082A124[sp218] == OCARINA_NOTE_F4 && CVar_GetS32("gHudColors", 1) == 2 && CVar_GetS32("gCCparated", 0)) {
                             gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, CVar_GetS32("gCCCDBtnPrimR", 255), CVar_GetS32("gCCCDBtnPrimG", 160), CVar_GetS32("gCCCDBtnPrimB", 0), D_8082A150[sp218]);
                         }
                     }
@@ -558,13 +558,13 @@ void KaleidoScope_DrawQuestStatus(GlobalContext* globalCtx, GraphicsContext* gfx
                             gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 255, 255, 50, 200);
                         } else if (CVar_GetS32("gHudColors", 1) == 2 && !CVar_GetS32("gCCparated", 0)) {
                             gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, CVar_GetS32("gCCCBtnPrimR", 255), CVar_GetS32("gCCCBtnPrimG", 160), CVar_GetS32("gCCCBtnPrimB", 0), 200);
-                        } else if (gOcarinaSongNotes[sp224].notesIdx[phi_s3] == OCARINA_NOTE_C_UP && CVar_GetS32("gHudColors", 1) == 2 && CVar_GetS32("gCCparated", 0)) {
+                        } else if (gOcarinaSongNotes[sp224].notesIdx[phi_s3] == OCARINA_NOTE_D5 && CVar_GetS32("gHudColors", 1) == 2 && CVar_GetS32("gCCparated", 0)) {
                             gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, CVar_GetS32("gCCCUBtnPrimR", 255), CVar_GetS32("gCCCUBtnPrimG", 160), CVar_GetS32("gCCCUBtnPrimB", 0), 200);
-                        } else if (gOcarinaSongNotes[sp224].notesIdx[phi_s3] == OCARINA_NOTE_C_LEFT && CVar_GetS32("gHudColors", 1) == 2 && CVar_GetS32("gCCparated", 0)) {
+                        } else if (gOcarinaSongNotes[sp224].notesIdx[phi_s3] == OCARINA_NOTE_B4 && CVar_GetS32("gHudColors", 1) == 2 && CVar_GetS32("gCCparated", 0)) {
                             gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, CVar_GetS32("gCCCLBtnPrimR", 255), CVar_GetS32("gCCCLBtnPrimG", 160), CVar_GetS32("gCCCLBtnPrimB", 0), 200);
-                        } else if (gOcarinaSongNotes[sp224].notesIdx[phi_s3] == OCARINA_NOTE_C_RIGHT && CVar_GetS32("gHudColors", 1) == 2 && CVar_GetS32("gCCparated", 0)) {
+                        } else if (gOcarinaSongNotes[sp224].notesIdx[phi_s3] == OCARINA_NOTE_A4 && CVar_GetS32("gHudColors", 1) == 2 && CVar_GetS32("gCCparated", 0)) {
                             gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, CVar_GetS32("gCCCRBtnPrimR", 255), CVar_GetS32("gCCCRBtnPrimG", 160), CVar_GetS32("gCCCRBtnPrimB", 0), 200);
-                        } else if (gOcarinaSongNotes[sp224].notesIdx[phi_s3] == OCARINA_NOTE_C_DOWN && CVar_GetS32("gHudColors", 1) == 2 && CVar_GetS32("gCCparated", 0)) {
+                        } else if (gOcarinaSongNotes[sp224].notesIdx[phi_s3] == OCARINA_NOTE_F4 && CVar_GetS32("gHudColors", 1) == 2 && CVar_GetS32("gCCparated", 0)) {
                             gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, CVar_GetS32("gCCCDBtnPrimR", 255), CVar_GetS32("gCCCDBtnPrimG", 160), CVar_GetS32("gCCCDBtnPrimB", 0), 200);
                         }
                     }
@@ -588,8 +588,8 @@ void KaleidoScope_DrawQuestStatus(GlobalContext* globalCtx, GraphicsContext* gfx
 
                 if (pauseCtx->ocarinaStaff->pos != 0) {
                     if (D_8082A11C == (pauseCtx->ocarinaStaff->pos - 1)) {
-                        if ((pauseCtx->ocarinaStaff->noteIdx >= OCARINA_NOTE_A) &&
-                            (pauseCtx->ocarinaStaff->noteIdx <= OCARINA_NOTE_C_UP)) {
+                        if ((pauseCtx->ocarinaStaff->noteIdx >= OCARINA_NOTE_D4) &&
+                            (pauseCtx->ocarinaStaff->noteIdx <= OCARINA_NOTE_D5)) {
                             D_8082A124[pauseCtx->ocarinaStaff->pos - 1] = pauseCtx->ocarinaStaff->noteIdx;
                             D_8082A124[pauseCtx->ocarinaStaff->pos] = 0xFF;
                             D_8082A11C++;
@@ -631,13 +631,13 @@ void KaleidoScope_DrawQuestStatus(GlobalContext* globalCtx, GraphicsContext* gfx
                             gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 255, 255, 50, 200);
                         } else if (CVar_GetS32("gHudColors", 1) == 2 && !CVar_GetS32("gCCparated", 0)) {
                              gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, CVar_GetS32("gCCCBtnPrimR", 255), CVar_GetS32("gCCCBtnPrimG", 255), CVar_GetS32("gCCCBtnPrimB", 0), D_8082A150[phi_s3]);
-                        } else if (gOcarinaSongNotes[sp224].notesIdx[phi_s3] == OCARINA_NOTE_C_UP && CVar_GetS32("gHudColors", 1) == 2 && CVar_GetS32("gCCparated", 0)) {
+                        } else if (gOcarinaSongNotes[sp224].notesIdx[phi_s3] == OCARINA_NOTE_D5 && CVar_GetS32("gHudColors", 1) == 2 && CVar_GetS32("gCCparated", 0)) {
                             gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, CVar_GetS32("gCCCUBtnPrimR", 255), CVar_GetS32("gCCCUBtnPrimG", 255), CVar_GetS32("gCCCUBtnPrimB", 0), D_8082A150[phi_s3]);
-                        } else if (gOcarinaSongNotes[sp224].notesIdx[phi_s3] == OCARINA_NOTE_C_LEFT && CVar_GetS32("gHudColors", 1) == 2 && CVar_GetS32("gCCparated", 0)) {
+                        } else if (gOcarinaSongNotes[sp224].notesIdx[phi_s3] == OCARINA_NOTE_B4 && CVar_GetS32("gHudColors", 1) == 2 && CVar_GetS32("gCCparated", 0)) {
                             gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, CVar_GetS32("gCCCLBtnPrimR", 255), CVar_GetS32("gCCCLBtnPrimG", 255), CVar_GetS32("gCCCLBtnPrimB", 0), D_8082A150[phi_s3]);
-                        } else if (gOcarinaSongNotes[sp224].notesIdx[phi_s3] == OCARINA_NOTE_C_RIGHT && CVar_GetS32("gHudColors", 1) == 2 && CVar_GetS32("gCCparated", 0)) {
+                        } else if (gOcarinaSongNotes[sp224].notesIdx[phi_s3] == OCARINA_NOTE_A4 && CVar_GetS32("gHudColors", 1) == 2 && CVar_GetS32("gCCparated", 0)) {
                             gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, CVar_GetS32("gCCCRBtnPrimR", 255), CVar_GetS32("gCCCRBtnPrimG", 255), CVar_GetS32("gCCCRBtnPrimB", 0), D_8082A150[phi_s3]);
-                        } else if (gOcarinaSongNotes[sp224].notesIdx[phi_s3] == OCARINA_NOTE_C_DOWN && CVar_GetS32("gHudColors", 1) == 2 && CVar_GetS32("gCCparated", 0)) {
+                        } else if (gOcarinaSongNotes[sp224].notesIdx[phi_s3] == OCARINA_NOTE_F4 && CVar_GetS32("gHudColors", 1) == 2 && CVar_GetS32("gCCparated", 0)) {
                             gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, CVar_GetS32("gCCCDBtnPrimR", 255), CVar_GetS32("gCCCDBtnPrimG", 255), CVar_GetS32("gCCCDBtnPrimB", 0), D_8082A150[phi_s3]);
                         }
                     }


### PR DESCRIPTION
Eliminates the merge issues from #851 but otherwise makes the same changes.

This adds a window accessed from the Enhancements > Controls menu that contains options to change the way certain actions are mapped to the N64 controller, sorted using collapsing headers like the cosmetics menu. Some or all of the controls enhancements could be moved into this window, but that's outside the scope of this PR.

As for the ocarina control panel, there are options to change which play which notes as well as which buttons modify the note (originally L, R, and Z). Additionally, the option to use the D-pad for the ocarina and text was split with the latter being moved to the ocarina controls, and there's a new option to play the ocarina using the camera stick.