### PR TITLE
fix linux release mode crash

### DIFF
--- a/soh/soh/Enhancements/custom-message/CustomMessageManager.cpp
+++ b/soh/soh/Enhancements/custom-message/CustomMessageManager.cpp
@@ -118,6 +118,7 @@ bool CustomMessageManager::ClearMessageTable(std::string tableID) {
     }
     auto& messageTable = foundMessageTable->second;
     messageTable.clear();
+    return true;
 }
 
 bool CustomMessageManager::AddCustomMessageTable(std::string tableID) { 


### PR DESCRIPTION
fixes https://github.com/HarbourMasters/Shipwright/issues/1121

saw a warning
```
[build] /home/briaguya/code/Shipwright/soh/soh/Enhancements/custom-message/CustomMessageManager.cpp:120:23: warning: control reaches end of non-void function [-Wreturn-type]
[build]   120 |     messageTable.clear();
[build]       |     ~~~~~~~~~~~~~~~~~~^~
```
addressed the warning