### PR TITLE
prevent losing adult trade item

### DIFF
--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_item.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_item.c
@@ -398,11 +398,15 @@ void KaleidoScope_DrawItemSelect(GlobalContext* globalCtx) {
                         if (((pauseCtx->stickRelX > 30 || pauseCtx->stickRelY > 30) ||
                              dpad && CHECK_BTN_ANY(input->press.button, BTN_DRIGHT | BTN_DUP))) {
                             Audio_PlaySoundGeneral(NA_SE_SY_CURSOR, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
-                            Inventory_ReplaceItem(globalCtx, INV_CONTENT(ITEM_TRADE_ADULT), Randomizer_GetNextAdultTradeItem());
+                            if (Randomizer_GetNextAdultTradeItem() != ITEM_NONE) {
+                                Inventory_ReplaceItem(globalCtx, INV_CONTENT(ITEM_TRADE_ADULT), Randomizer_GetNextAdultTradeItem());
+                            }
                         } else if (((pauseCtx->stickRelX < -30 || pauseCtx->stickRelY < -30) ||
                             dpad && CHECK_BTN_ANY(input->press.button, BTN_DLEFT | BTN_DDOWN))) {
                             Audio_PlaySoundGeneral(NA_SE_SY_CURSOR, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
-                            Inventory_ReplaceItem(globalCtx, INV_CONTENT(ITEM_TRADE_ADULT), Randomizer_GetPrevAdultTradeItem());
+                            if (Randomizer_GetPrevAdultTradeItem() != ITEM_NONE) {
+                                Inventory_ReplaceItem(globalCtx, INV_CONTENT(ITEM_TRADE_ADULT), Randomizer_GetPrevAdultTradeItem());
+                            }
                         }
                         gSelectingAdultTrade = cursorSlot == SLOT_TRADE_ADULT;
                     }


### PR DESCRIPTION
before adding this, if you go into adult trade item select mode in the kaleidoscope menu when you only have one trade item, pressing any direction would cause the item to be replaced with nothing, with no way of getting it back

@lilDavid i'm not sure if this was just an issue with how i was testing it (using the save editor to give myself an adult trade item) or not, but it'd be good to ensure this behavior is rock solid

also, on discord @vaguerant mentioned

> **vr:** Does the selecting adult trade inventory option handle all the weird things players might do? e.g. If you start selecting mode then unpause, pause again, is selecting mode still active? Or, start selecting mode then page over and back again, is selecting mode still active?
> **me:** the code looks really similar to your mask code
> **vr:** Yeah. But without the changes in z_kaleido_scope_PAL.c where I handled things like page changes.

in my testing, switching between pages seems to be fine, but adult trade item select mode is still enabled when unpausing and reopening the menu

more testing/definition around exactly how this should behave would be good