### PR TITLE
Rando: Fix bomb/bombchu shops

### DIFF
--- a/soh/src/overlays/actors/ovl_En_GirlA/z_en_girla.c
+++ b/soh/src/overlays/actors/ovl_En_GirlA/z_en_girla.c
@@ -634,8 +634,7 @@ s32 EnGirlA_CanBuy_Unk20(GlobalContext* globalCtx, EnGirlA* this) {
 
 s32 EnGirlA_CanBuy_Bombchus(GlobalContext* globalCtx, EnGirlA* this) {
     // When in rando, don't allow buying bombchus when the player doesn't have a bomb bag
-    if ((!gSaveContext.n64ddFlag && AMMO(ITEM_BOMBCHU) >= 50) ||
-        (gSaveContext.n64ddFlag && (AMMO(ITEM_BOMBCHU) >= 50 || CUR_CAPACITY(UPG_BOMB_BAG) == 0))) {
+    if (AMMO(ITEM_BOMBCHU) >= 50 || (gSaveContext.n64ddFlag && CUR_CAPACITY(UPG_BOMB_BAG) == 0)) {
         return CANBUY_RESULT_CANT_GET_NOW;
     }
     if (gSaveContext.rupees < this->basePrice) {

--- a/soh/src/overlays/actors/ovl_En_GirlA/z_en_girla.c
+++ b/soh/src/overlays/actors/ovl_En_GirlA/z_en_girla.c
@@ -633,7 +633,9 @@ s32 EnGirlA_CanBuy_Unk20(GlobalContext* globalCtx, EnGirlA* this) {
 }
 
 s32 EnGirlA_CanBuy_Bombchus(GlobalContext* globalCtx, EnGirlA* this) {
-    if (AMMO(ITEM_BOMBCHU) >= 50) {
+    // When in rando, don't allow buying bombchus when the player doesn't have a bomb bag
+    if ((!gSaveContext.n64ddFlag && AMMO(ITEM_BOMBCHU) >= 50) ||
+        (gSaveContext.n64ddFlag && (AMMO(ITEM_BOMBCHU) >= 50 || CUR_CAPACITY(UPG_BOMB_BAG) == 0))) {
         return CANBUY_RESULT_CANT_GET_NOW;
     }
     if (gSaveContext.rupees < this->basePrice) {

--- a/soh/src/overlays/actors/ovl_En_Ossan/z_en_ossan.c
+++ b/soh/src/overlays/actors/ovl_En_Ossan/z_en_ossan.c
@@ -601,8 +601,9 @@ void EnOssan_Init(Actor* thisx, GlobalContext* globalCtx) {
         return;
     }
 
-    // Completed Dodongo's Cavern
-    if (this->actor.params == OSSAN_TYPE_BOMBCHUS && !(gSaveContext.eventChkInf[2] & 0x20)) {
+    // gSaveContext.eventChkInf[2] & 0x20 - Completed Dodongo's Cavern
+    // Don't kill bombchu shop actor in rando, making it so the shop is immediately open
+    if (this->actor.params == OSSAN_TYPE_BOMBCHUS && !(gSaveContext.eventChkInf[2] & 0x20) && !gSaveContext.n64ddFlag) {
         Actor_Kill(&this->actor);
         return;
     }
@@ -1469,7 +1470,10 @@ void EnOssan_HandleCanBuyBombs(GlobalContext* globalCtx, EnOssan* this) {
 
 void EnOssan_BuyGoronCityBombs(GlobalContext* globalCtx, EnOssan* this) {
     if (LINK_AGE_IN_YEARS == YEARS_CHILD) {
-        if (!(gSaveContext.eventChkInf[2] & 0x20)) {
+        // gSaveContext.eventChkInf[2] & 0x20 - Completed Dodongo's Cavern
+        // Let players buy the right side of the goron shop in rando regardless of DC completion
+        // Players will still need a bomb bag to buy bombs (handled by vanilla behaviour)
+        if (!gSaveContext.n64ddFlag && !(gSaveContext.eventChkInf[2] & 0x20)) {
             if (gSaveContext.infTable[15] & 0x1000) {
                 EnOssan_SetStateCantGetItem(globalCtx, this, 0x302E);
             } else {

--- a/soh/src/overlays/actors/ovl_En_Ossan/z_en_ossan.c
+++ b/soh/src/overlays/actors/ovl_En_Ossan/z_en_ossan.c
@@ -601,8 +601,8 @@ void EnOssan_Init(Actor* thisx, GlobalContext* globalCtx) {
         return;
     }
 
-    // gSaveContext.eventChkInf[2] & 0x20 - Completed Dodongo's Cavern
     // Don't kill bombchu shop actor in rando, making it so the shop is immediately open
+    // gSaveContext.eventChkInf[2] & 0x20 - Completed Dodongo's Cavern
     if (this->actor.params == OSSAN_TYPE_BOMBCHUS && !(gSaveContext.eventChkInf[2] & 0x20) && !gSaveContext.n64ddFlag) {
         Actor_Kill(&this->actor);
         return;
@@ -1470,9 +1470,9 @@ void EnOssan_HandleCanBuyBombs(GlobalContext* globalCtx, EnOssan* this) {
 
 void EnOssan_BuyGoronCityBombs(GlobalContext* globalCtx, EnOssan* this) {
     if (LINK_AGE_IN_YEARS == YEARS_CHILD) {
-        // gSaveContext.eventChkInf[2] & 0x20 - Completed Dodongo's Cavern
         // Let players buy the right side of the goron shop in rando regardless of DC completion
         // Players will still need a bomb bag to buy bombs (handled by vanilla behaviour)
+        // gSaveContext.eventChkInf[2] & 0x20 - Completed Dodongo's Cavern
         if (!gSaveContext.n64ddFlag && !(gSaveContext.eventChkInf[2] & 0x20)) {
             if (gSaveContext.infTable[15] & 0x1000) {
                 EnOssan_SetStateCantGetItem(globalCtx, this, 0x302E);


### PR DESCRIPTION
Resolves https://github.com/HarbourMasters/Shipwright/issues/689

In vanilla, the right side of the Goron's City shop is locked until you beat Dodongo's Cavern. In rando, this should be open from the start, and only allow buying bombs when a player has a bomb bag.

The bombchu shop opening was also tied to completing Dodongo's Cavern. In rando, this should've been opened from the start, and bombchus should only be allowed to be bought when a player has a bomb bag.

This PR fixes both of the above.

Tested and confirmed that vanilla works as before, and that the 2 shops are working in rando as outlined above.