### PR TITLE
Fix adult trade shuffle in save editor

### DIFF
--- a/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
+++ b/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
@@ -15,6 +15,7 @@ extern "C" {
 #include "variables.h"
 #include "functions.h"
 #include "macros.h"
+#include "soh/Enhancements/randomizer/adult_trade_shuffle.h"
 extern GlobalContext* gGlobalCtx;
 
 #include "textures/icon_item_static/icon_item_static.h"
@@ -535,8 +536,12 @@ void DrawBGSItemFlag(uint8_t itemID) {
     ImGui::Checkbox(("##adultTradeFlag" + std::to_string(itemID)).c_str(), &hasItem);
     if (hasItem) {
         gSaveContext.adultTradeItems |= (1 << tradeIndex);
+        if (INV_CONTENT(ITEM_TRADE_ADULT) == ITEM_NONE) {
+            INV_CONTENT(ITEM_TRADE_ADULT) = ITEM_POCKET_EGG + tradeIndex;
+        }
     } else {
         gSaveContext.adultTradeItems &= ~(1 << tradeIndex);
+        Inventory_ReplaceItem(gGlobalCtx, INV_CONTENT(ITEM_TRADE_ADULT), Randomizer_GetNextAdultTradeItem());
     }
 }
 
@@ -611,6 +616,17 @@ void DrawInventoryTab() {
                     if (ImGui::ImageButton(SohImGui::GetTextureByName(slotEntry.name), ImVec2(32.0f, 32.0f),
                                            ImVec2(0, 0), ImVec2(1, 1), 0)) {
                         gSaveContext.inventory.items[selectedIndex] = slotEntry.id;
+                        // Set adult trade item flag if you're playing adult trade shuffle in rando
+                        if (gSaveContext.n64ddFlag &&
+                            OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_SHUFFLE_ADULT_TRADE) &&
+                            selectedIndex == SLOT_TRADE_ADULT) {
+                                if (slotEntry.id == ITEM_NONE) {
+                                    gSaveContext.adultTradeItems = 0;
+                                } else if (slotEntry.id >= ITEM_POCKET_EGG && slotEntry.id <= ITEM_CLAIM_CHECK) {
+                                    uint32_t tradeID = slotEntry.id - ITEM_POCKET_EGG;
+                                    gSaveContext.adultTradeItems |= tradeID;
+                                }
+                            }
                         ImGui::CloseCurrentPopup();
                     }
                     SetLastItemHoverText(SohUtils::GetItemName(slotEntry.id));

--- a/soh/src/code/z_kankyo.c
+++ b/soh/src/code/z_kankyo.c
@@ -2058,8 +2058,8 @@ bool HatchPocketEgg(GlobalContext* globalCtx) {
          return 0;
     }
 
-    // Swap the flags, then replace the item if it's selected
-    gSaveContext.adultTradeItems ^= ADULT_TRADE_FLAG(ITEM_POCKET_EGG) | ADULT_TRADE_FLAG(ITEM_POCKET_CUCCO);
+    gSaveContext.adultTradeItems &= ~ADULT_TRADE_FLAG(ITEM_POCKET_EGG);
+    gSaveContext.adultTradeItems |= ADULT_TRADE_FLAG(ITEM_POCKET_CUCCO);
     Inventory_ReplaceItem(globalCtx, ITEM_POCKET_EGG, ITEM_POCKET_CUCCO);
     return 1;
 }


### PR DESCRIPTION
This better integrates the adult trade slot in the save editor with the adult trade item flags.

Before, as mentioned in #1128, you could set the adult trade item without affecting the flags, which could cause the item to disappear when swapped. That was intended behavior, but it revealed that the two not affecting each other was a design flaw on my part, as it's not clear that you need to change both in order for the adult trade to be in a valid state.

Now, setting the adult trade item slot in the inventory to empty will clear all adult trade flags, and setting it to an item you don't have will set its flag. Conversely, checking an item's box in the Adult Trade Items dropdown will fill the adult trade slot, and removing the item you have set will update the adult trade slot accordingly, either advancing or clearing it. This should prevent the issue mentioned above from being able to happen.

Also, the code to hatch the Pocket Cucco no longer assumes that you only have one or the other. It will now clear the Pocket Egg and set the Pocket Cucco instead of flipping both.