### PR TITLE
Fix Save Editor Event Check Inf "A" Row flags

### DIFF
--- a/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
+++ b/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
@@ -944,7 +944,7 @@ void DrawFlagsTab() {
         DrawGroupWithBorder([&]() {
             ImGui::Text("A");
             InsertHelpHoverText("First-time overworld entrance cs related");
-            DrawFlagArray16("eci1", gSaveContext.eventChkInf[10]);
+            DrawFlagArray16("eci10", gSaveContext.eventChkInf[10]);
         });
 
         DrawGroupWithBorder([&]() {


### PR DESCRIPTION
Fix Save Editor Event Check Inf Flags "A" Row flags not working. It was set to "eci1" instead of "eci10".
(This time in rachael branch!)