### PR TITLE
Rando: Fix gerudo card incorrectly given to link when bridge is open

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -1440,6 +1440,7 @@ std::unordered_map<std::string, RandomizerSettingKey> SpoilerfileSettingNameToEn
     { "Open Settings:Token Count", RSK_RAINBOW_BRIDGE_TOKEN_COUNT },
     { "Open Settings:Random Ganon's Trials", RSK_RANDOM_TRIALS },
     { "Open Settings:Trial Count", RSK_TRIAL_COUNT },
+    { "Shuffle Settings:Shuffle Gerudo Card", RSK_SHUFFLE_GERUDO_MEMBERSHIP_CARD },
     { "Shuffle Settings:Shuffle Cows", RSK_SHUFFLE_COWS },
     { "Shuffle Settings:Tokensanity", RSK_SHUFFLE_TOKENS },
     { "Shuffle Settings:Shuffle Adult Trade", RSK_SHUFFLE_ADULT_TRADE },
@@ -1677,6 +1678,7 @@ void Randomizer::ParseRandomizerSettingsFile(const char* spoilerFileName) {
                         numericValueString = it.value();
                         gSaveContext.randoSettings[index].value = std::stoi(numericValueString);
                         break;
+                    case RSK_SHUFFLE_GERUDO_MEMBERSHIP_CARD:
                     case RSK_SHUFFLE_COWS:
                     case RSK_SHUFFLE_ADULT_TRADE:
                     case RSK_RANDOM_TRIALS:


### PR DESCRIPTION
Resolves https://github.com/HarbourMasters/Shipwright/issues/1005

The value for shuffling the gerudo card wasn't being read from the spoiler log properly, so the following was always passing the conditional:

```
if (!Randomizer_GetSettingValue(RSK_SHUFFLE_GERUDO_MEMBERSHIP_CARD)) {
      GiveLinkGerudoCard();
}
```
In `z_sram.c`.

I originally was pointing this at Rachael because it's a bugfix, but we changed the option name since then and there would probably be conflicts when we'd merge this into zhora/rando-next afterwards. So instead of having to fix this twice, I figured it'd be easier to just point it to rando-next instead. The bug isn't that severe either, it's just giving someone a free gerudo card with specific settings.