### PR TITLE
add check for mask shop being open to mask select

### DIFF
--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_item.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_item.c
@@ -355,12 +355,15 @@ void KaleidoScope_DrawItemSelect(GlobalContext* globalCtx) {
 
                 if ((pauseCtx->debugState == 0) && (pauseCtx->state == 6) && (pauseCtx->unk_1E4 == 0)) {
                     // only allow mask select when:
-                    // the shop is open (zelda's letter check): gSaveContext.eventChkInf[4] & 1
+                    // the shop is open:
+                    // * zelda's letter check: gSaveContext.eventChkInf[4] & 1
+                    // * kak gate check: gSaveContext.infTable[7] & 0x40
                     // and the mask quest is complete: gSaveContext.eventChkInf[8] & 0x8000
                     if (CVar_GetS32("gMaskSelect", 0) &&
                         (gSaveContext.eventChkInf[8] & 0x8000) &&
                         cursorSlot == SLOT_TRADE_CHILD && CHECK_BTN_ALL(input->press.button, BTN_A) &&
-                        (gSaveContext.eventChkInf[4] & 1)) {
+                        (gSaveContext.eventChkInf[4] & 1) &&
+                        (gSaveContext.infTable[7] & 0x40)) {
                         Audio_PlaySoundGeneral(NA_SE_SY_DECIDE, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
                         gSelectingMask = !gSelectingMask;
                     }

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_item.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_item.c
@@ -354,8 +354,13 @@ void KaleidoScope_DrawItemSelect(GlobalContext* globalCtx) {
                 KaleidoScope_SetCursorVtx(pauseCtx, index, pauseCtx->itemVtx);
 
                 if ((pauseCtx->debugState == 0) && (pauseCtx->state == 6) && (pauseCtx->unk_1E4 == 0)) {
-                    if (CVar_GetS32("gMaskSelect", 0) && (gSaveContext.eventChkInf[8] & 0x8000) &&
-                        cursorSlot == SLOT_TRADE_CHILD && CHECK_BTN_ALL(input->press.button, BTN_A)) {
+                    // only allow mask select when:
+                    // the shop is open (zelda's letter check): gSaveContext.eventChkInf[4] & 1
+                    // and the mask quest is complete: gSaveContext.eventChkInf[8] & 0x8000
+                    if (CVar_GetS32("gMaskSelect", 0) &&
+                        (gSaveContext.eventChkInf[8] & 0x8000) &&
+                        cursorSlot == SLOT_TRADE_CHILD && CHECK_BTN_ALL(input->press.button, BTN_A) &&
+                        (gSaveContext.eventChkInf[4] & 1)) {
                         Audio_PlaySoundGeneral(NA_SE_SY_DECIDE, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
                         gSelectingMask = !gSelectingMask;
                     }


### PR DESCRIPTION
complete mask quest sets the flag for having sold all the masks, which was the only flag being checked by kaleidoscope mask select.

this pr updates the kaleidoscope mask select to also check for the mask shop being open (got zelda's letter, opened kak gate)

fixes https://github.com/HarbourMasters/Shipwright/issues/1149