### PR TITLE
Rando: Small fixes for "Maps/Compasses"

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/settings.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/settings.cpp
@@ -191,7 +191,7 @@ namespace Settings {
 
   //Shuffle Dungeon Items
   Option RandomizeDungeon    = Option::Bool("Randomize Settings",        {"No","Yes"},                                                           {dungeonRandomize},                                                                                                    OptionCategory::Toggle);
-  Option MapsAndCompasses    = Option::U8  ("Start with Maps/Compasses",            {"Start With", "Vanilla", "Own Dungeon", "Any Dungeon", "Overworld", "Anywhere"},
+  Option MapsAndCompasses    = Option::U8  ("Maps/Compasses",            {"Start With", "Vanilla", "Own Dungeon", "Any Dungeon", "Overworld", "Anywhere"},
                                                                          {mapCompassStartWith, mapCompassVanilla, mapCompassOwnDungeon, mapCompassAnyDungeon, mapCompassOverworld, mapCompassAnywhere},                                                            OptionCategory::Setting,    MAPSANDCOMPASSES_OWN_DUNGEON);
   Option Keysanity           = Option::U8  ("Small Keys",                {"Start With", "Vanilla", "Own Dungeon", "Any Dungeon", "Overworld", "Anywhere"},
                                                                          {smallKeyStartWith, smallKeyVanilla, smallKeyOwnDungeon, smallKeyAnyDungeon, smallKeyOverworld, smallKeyAnywhere},                                                                        OptionCategory::Setting,    KEYSANITY_OWN_DUNGEON);

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -1447,7 +1447,7 @@ std::unordered_map<std::string, RandomizerSettingKey> SpoilerfileSettingNameToEn
     { "Start with Deku Shield", RSK_STARTING_DEKU_SHIELD },
     { "Start with Kokiri Sword", RSK_STARTING_KOKIRI_SWORD },
     { "Start with Fairy Ocarina", RSK_STARTING_OCARINA },
-    { "Shuffle Dungeon Items:Start with Maps/Compasses", RSK_STARTING_MAPS_COMPASSES },
+    { "Shuffle Dungeon Items:Maps/Compasses", RSK_STARTING_MAPS_COMPASSES },
     { "Shuffle Dungeon Items:Small Keys", RSK_KEYSANITY },
     { "Shuffle Dungeon Items:Gerudo Fortress Keys", RSK_GERUDO_KEYS },
     { "Shuffle Dungeon Items:Boss Keys", RSK_BOSS_KEYSANITY },

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -4180,6 +4180,24 @@ void DrawRandoEditor(bool& open) {
                     SohImGui::EnhancementCombobox("gRandomizeShuffleDungeonReward", randoShuffleDungeonRewards, 4, 0);
                     PaddedSeparator();
 
+                    // Start with Maps & Compasses
+                    ImGui::Text(Settings::MapsAndCompasses.GetName().c_str());
+                    InsertHelpHoverText(
+                        "Start with - You will start with Maps & Compasses from all dungeons.\n"
+                            "\n"
+                            "Vanilla - Maps & Compasses will appear in their vanilla locations.\n"
+                            "\n"
+                            "Own dungeon - Maps & Compasses can only appear in their respective dungeon.\n"
+                            "\n"
+                            "Any dungeon - Maps & Compasses can only appear inside of any dungon.\n"
+                            "\n"
+                            "Overworld - Maps & Compasses can only appear outside of dungeons.\n"
+                            "\n"
+                            "Anywhere - Maps & Compasses can appear anywhere in the world."
+                    );
+                    SohImGui::EnhancementCombobox("gRandomizeStartingMapsCompasses", randoShuffleMapsAndCompasses, 6, 2);
+                    PaddedSeparator();
+
                     // Keysanity
                     ImGui::Text(Settings::Keysanity.GetName().c_str());
                     InsertHelpHoverText(
@@ -4246,24 +4264,6 @@ void DrawRandoEditor(bool& open) {
                         "Anywhere - Ganon's Boss Key Key can appear anywhere in the world."
                     );
                     SohImGui::EnhancementCombobox("gRandomizeShuffleGanonBossKey", randoShuffleGanonsBossKey, 6, 1);
-                    PaddedSeparator();
-
-                    // Start with Maps & Compasses
-                    ImGui::Text(Settings::MapsAndCompasses.GetName().c_str());
-                    InsertHelpHoverText(
-                        "Start with - You will start with Maps & Compasses from all dungeons.\n"
-                        "\n"
-                        "Vanilla - Maps & Compasses will appear in their vanilla locations.\n"
-                        "\n"
-                        "Own dungeon - Maps & Compasses can only appear in their respective dungeon.\n"
-                        "\n"
-                        "Any dungeon - Maps & Compasses can only appear inside of any dungon.\n"
-                        "\n"
-                        "Overworld - Maps & Compasses can only appear outside of dungeons.\n"
-                        "\n"
-                        "Anywhere - Maps & Compasses can appear anywhere in the world."
-                    );  
-                    SohImGui::EnhancementCombobox("gRandomizeStartingMapsCompasses", randoShuffleMapsAndCompasses, 6, 2);
 
                     ImGui::PopItemWidth();
                     ImGui::EndTable();

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -4180,7 +4180,7 @@ void DrawRandoEditor(bool& open) {
                     SohImGui::EnhancementCombobox("gRandomizeShuffleDungeonReward", randoShuffleDungeonRewards, 4, 0);
                     PaddedSeparator();
 
-                    // Start with Maps & Compasses
+                    // Maps & Compasses
                     ImGui::Text(Settings::MapsAndCompasses.GetName().c_str());
                     InsertHelpHoverText(
                         "Start with - You will start with Maps & Compasses from all dungeons.\n"


### PR DESCRIPTION
With the new options for maps and compasses, name should be reverted from "Start with Maps/Compasses" to "Maps/Compasses" again.

Tested ingame (gives maps/compasses correctly with "Start with") and logic still seems to work correctly looking at some generated spoiler logs.

Also changed the location of the option in the UI to line it up with 3DS/N64.