### PR TITLE
Rando: Fix lost woods leading music

### DIFF
--- a/soh/src/overlays/actors/ovl_En_River_Sound/z_en_river_sound.c
+++ b/soh/src/overlays/actors/ovl_En_River_Sound/z_en_river_sound.c
@@ -40,9 +40,8 @@ void EnRiverSound_Init(Actor* thisx, GlobalContext* globalCtx) {
         Audio_PlayNatureAmbienceSequence(NATURE_ID_KOKIRI_REGION);
         Actor_Kill(&this->actor);
     } else if (this->actor.params == RS_SARIAS_SONG) {
-        if (!CHECK_QUEST_ITEM(QUEST_SONG_LULLABY) ||
-             CHECK_QUEST_ITEM(QUEST_SONG_SARIA) ||
-             gSaveContext.n64ddFlag) {
+        // Always have leading music in rando
+        if ((!CHECK_QUEST_ITEM(QUEST_SONG_LULLABY) || CHECK_QUEST_ITEM(QUEST_SONG_SARIA)) && !gSaveContext.n64ddFlag) {
             Actor_Kill(&this->actor);
         }
     }


### PR DESCRIPTION
Resolves https://github.com/HarbourMasters/Shipwright/issues/738

We initially thought rando never had the leading music, but turns out N64 **always** has leading music, so we had it backwards.

This PR fixes that.