### PR TITLE
Item tracker improvements

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
@@ -1590,10 +1590,10 @@ void DrawItemTrackerOptions(bool& open) {
     ImGui::Text("Chroma Key");
     auto flags = ImGuiColorEditFlags_AlphaPreview | ImGuiColorEditFlags_AlphaBar | ImGuiColorEditFlags_NoLabel;
     ImGui::ColorEdit4("Chroma Key Selection", (float*)&ChromaKeyBackground, flags);
-    CVar_SetFloat("gTrackerBgColorR", ChromaKeyBackground.x);
-    CVar_SetFloat("gTrackerBgColorG", ChromaKeyBackground.y);
-    CVar_SetFloat("gTrackerBgColorB", ChromaKeyBackground.z);
-    CVar_SetFloat("gTrackerBgColorA", ChromaKeyBackground.w);
+    CVar_SetFloat("gItemTrackerBgColorR", ChromaKeyBackground.x);
+    CVar_SetFloat("gItemTrackerBgColorG", ChromaKeyBackground.y);
+    CVar_SetFloat("gItemTrackerBgColorB", ChromaKeyBackground.z);
+    CVar_SetFloat("gItemTrackerBgColorA", ChromaKeyBackground.w);
 
     const char* ItemsTrackerTheme[3] = { "One Block", "Grouped style n.1", "Grouped style n.2" };
     ImGui::Text("Using theme :");
@@ -1670,10 +1670,10 @@ void InitItemTracker() {
     CVar_RegisterS32("gRandoTrackIconSize", 32);
     SohImGui::AddWindow("Randomizer", "Item Tracker", DrawItemTracker);
     SohImGui::AddWindow("Randomizer", "Item Tracker Settings", DrawItemTrackerOptions);
-    float trackerBgR = CVar_GetFloat("gTrackerBgColorR", 0);
-    float trackerBgG = CVar_GetFloat("gTrackerBgColorG", 0);
-    float trackerBgB = CVar_GetFloat("gTrackerBgColorB", 0);
-    float trackerBgA = CVar_GetFloat("gTrackerBgColorA", 1);
+    float trackerBgR = CVar_GetFloat("gItemTrackerBgColorR", 0);
+    float trackerBgG = CVar_GetFloat("gItemTrackerBgColorG", 0);
+    float trackerBgB = CVar_GetFloat("gItemTrackerBgColorB", 0);
+    float trackerBgA = CVar_GetFloat("gItemTrackerBgColorA", 1);
     ChromaKeyBackground = {
         trackerBgR,
         trackerBgG,

--- a/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
@@ -270,8 +270,7 @@ void DrawQuest(uint32_t itemId) {
     int iconSize = CVar_GetS32("gRandoTrackIconSize", 0);
     ImGui::BeginGroup();
     ImGui::Image(SohImGui::GetTextureByName(hasQuestItem && IsValidSaveFile() ? entry.name : entry.nameFaded),
-                 ImVec2(iconSize, iconSize),
-                 ImVec2(0, 0), ImVec2(1, 1));
+                 ImVec2(iconSize, iconSize), ImVec2(0, 0), ImVec2(1, 1));
 
     ImVec2 p = ImGui::GetCursorScreenPos();
     int estimatedTextWidth = 10;

--- a/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
@@ -34,8 +34,6 @@ typedef struct {
         }                                                             \
     }
 
-bool validSaveFile = false;
-
 // Maps items ids to info for use in ImGui
 std::map<uint32_t, ItemMapEntry> itemMappingSSS = {
     ITEM_MAP_ENTRY(ITEM_STICK),
@@ -241,12 +239,17 @@ std::unordered_map<uint32_t, ItemTrackerMapEntry> equipTrackerMap = {
     ITEM_TRACKER_MAP_ENTRY(ITEM_BOOTS_HOVER, 14),
 };
 
+bool IsValidSaveFile() {
+    bool validSave = gSaveContext.fileNum >= 0 && gSaveContext.fileNum <= 3;
+    return validSave;
+}
+
 void DrawEquip(uint32_t itemId) {
     const ItemTrackerMapEntry& entry = equipTrackerMap[itemId];
     bool hasEquip = (entry.bitMask & gSaveContext.inventory.equipment) != 0;
     int iconSize = CVar_GetS32("gRandoTrackIconSize", 0);
-    ImGui::Image(SohImGui::GetTextureByName(hasEquip && validSaveFile ? entry.name : entry.nameFaded), 
-                ImVec2(iconSize, iconSize), ImVec2(0, 0), ImVec2(1, 1));
+    ImGui::Image(SohImGui::GetTextureByName(hasEquip && IsValidSaveFile() ? entry.name : entry.nameFaded),
+                 ImVec2(iconSize, iconSize), ImVec2(0, 0), ImVec2(1, 1));
 
     SetLastItemHoverText(SohUtils::GetItemName(entry.id));
 }
@@ -266,7 +269,8 @@ void DrawQuest(uint32_t itemId) {
     bool hasQuestItem = (entry.bitMask & gSaveContext.inventory.questItems) != 0;
     int iconSize = CVar_GetS32("gRandoTrackIconSize", 0);
     ImGui::BeginGroup();
-    ImGui::Image(SohImGui::GetTextureByName(hasQuestItem ? entry.name : entry.nameFaded), ImVec2(iconSize, iconSize),
+    ImGui::Image(SohImGui::GetTextureByName(hasQuestItem && IsValidSaveFile() ? entry.name : entry.nameFaded),
+                 ImVec2(iconSize, iconSize),
                  ImVec2(0, 0), ImVec2(1, 1));
 
     ImVec2 p = ImGui::GetCursorScreenPos();
@@ -449,18 +453,18 @@ void DrawItem(uint32_t itemId) {
         }
     }
 
-    const ItemTrackerMapEntry& entry = itemTrackerMap[hasItem ? actualItemId : itemId];
+    const ItemTrackerMapEntry& entry = itemTrackerMap[hasItem && IsValidSaveFile() ? actualItemId : itemId];
     int iconSize = CVar_GetS32("gRandoTrackIconSize", 0);
 
     ImGui::BeginGroup();
-    ImGui::Image(SohImGui::GetTextureByName(hasItem && validSaveFile ? entry.name : entry.nameFaded), ImVec2(iconSize, iconSize),
-                 ImVec2(0, 0), ImVec2(1, 1));
+    ImGui::Image(SohImGui::GetTextureByName(hasItem && IsValidSaveFile() ? entry.name : entry.nameFaded),
+                 ImVec2(iconSize, iconSize), ImVec2(0, 0), ImVec2(1, 1));
     ImVec2 p = ImGui::GetCursorScreenPos();
     int estimatedTextWidth = 10;
     int estimatedTextHeight = 10;
     ImGui::SetCursorScreenPos(ImVec2(p.x - 5 + (iconSize / 2) - estimatedTextWidth, p.y - estimatedTextHeight));
 
-    if (validSaveFile) {
+    if (IsValidSaveFile()) {
         DrawItemAmmo(actualItemId);
     } else {
         ImGui::Text(" ");
@@ -685,9 +689,9 @@ void DrawItemAmmo(int itemId) {
 void DrawBottle(uint32_t itemId, uint32_t bottleSlot) {
     uint32_t actualItemId = gSaveContext.inventory.items[SLOT(itemId) + bottleSlot];
     bool hasItem = actualItemId != ITEM_NONE;
-    const ItemTrackerMapEntry& entry = itemTrackerMap[hasItem ? actualItemId : itemId];
+    const ItemTrackerMapEntry& entry = itemTrackerMap[hasItem && IsValidSaveFile() ? actualItemId : itemId];
     int iconSize = CVar_GetS32("gRandoTrackIconSize", 0);
-    ImGui::Image(SohImGui::GetTextureByName(hasItem && validSaveFile ? entry.name : entry.nameFaded),
+    ImGui::Image(SohImGui::GetTextureByName(hasItem && IsValidSaveFile() ? entry.name : entry.nameFaded),
                  ImVec2(iconSize, iconSize), ImVec2(0, 0), ImVec2(1, 1));
 
     SetLastItemHoverText(SohUtils::GetItemName(entry.id));
@@ -701,11 +705,11 @@ void DrawDungeonItem(uint32_t itemId, uint32_t scene) {
     bool hasSmallKey = (gSaveContext.inventory.dungeonKeys[scene]) >= 0;
     ImGui::BeginGroup();
     if (itemId == ITEM_KEY_SMALL) {
-        ImGui::Image(SohImGui::GetTextureByName(hasSmallKey && validSaveFile ? entry.name : entry.nameFaded),
+        ImGui::Image(SohImGui::GetTextureByName(hasSmallKey && IsValidSaveFile() ? entry.name : entry.nameFaded),
                      ImVec2(iconSize, iconSize), ImVec2(0, 0), ImVec2(1, 1));
     }
     else {
-        ImGui::Image(SohImGui::GetTextureByName(hasItem && validSaveFile ? entry.name : entry.nameFaded),
+        ImGui::Image(SohImGui::GetTextureByName(hasItem && IsValidSaveFile() ? entry.name : entry.nameFaded),
                      ImVec2(iconSize, iconSize), ImVec2(0, 0), ImVec2(1, 1));
     }
 
@@ -715,7 +719,7 @@ void DrawDungeonItem(uint32_t itemId, uint32_t scene) {
     ImGui::SetCursorScreenPos(ImVec2(p.x - 5 + (iconSize / 2) - estimatedTextWidth, p.y - estimatedTextHeight));
 
     if (itemId == ITEM_KEY_SMALL) { // This check there for small key is necessary to get the text position properly and can't be on the same ITEM_KEY chack from the top
-         if (gSaveContext.inventory.dungeonKeys[scene] <= 0) {
+        if (gSaveContext.inventory.dungeonKeys[scene] <= 0 || !IsValidSaveFile()) {
             ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(155, 155, 155, 255));
             ImGui::Text("0");
             ImGui::PopStyleColor();
@@ -773,7 +777,7 @@ std::unordered_map<int32_t, std::vector<ItemTrackerUpgradeEntry>> upgradeTracker
 
 void DrawUpgrade(int32_t categoryId) {
     int iconSize = CVar_GetS32("gRandoTrackIconSize", 0);
-    if (CUR_UPG_VALUE(categoryId) == 0 && validSaveFile) {
+    if (CUR_UPG_VALUE(categoryId) == 0 || !IsValidSaveFile()) {
         const ItemTrackerUpgradeEntry& entry = upgradeTrackerMap[categoryId][0];
         ImGui::Image(SohImGui::GetTextureByName(entry.nameFaded), ImVec2(iconSize, iconSize), ImVec2(0, 0),
                      ImVec2(1, 1));
@@ -832,7 +836,7 @@ void DrawSong(int32_t songId) {
         CVar_GetS32("gItemTrackeSongColor", 0) ? songTrackerMap[songId] : vanillaSongTrackerMap[songId];
     uint32_t bitMask = 1 << entry.id;
     bool hasSong = (bitMask & gSaveContext.inventory.questItems) != 0;
-    ImGui::Image(SohImGui::GetTextureByName(hasSong && validSaveFile ? entry.name : entry.nameFaded),
+    ImGui::Image(SohImGui::GetTextureByName(hasSong && IsValidSaveFile() ? entry.name : entry.nameFaded),
                  ImVec2(iconSize / 1.5, iconSize), ImVec2(0, 0), ImVec2(1, 1));
     SetLastItemHoverText(SohUtils::GetQuestItemName(entry.id));
 }
@@ -1290,7 +1294,7 @@ void DrawFloatingDungeons(int Icon_Cells_Size, int Icon_Spacing) {
             DrawDungeonItem(ITEM_KEY_SMALL, SCENE_HAKADAN);
             ImGui::SameLine(Icon_Cells_Size * 5);
             ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 5);
-            DrawDungeonItem(ITEM_KEY_SMALL, SCENE_GANON);
+            DrawDungeonItem(ITEM_KEY_SMALL, SCENE_GANONTIKA);
             ImGui::EndGroup();
             // BOSS KEYS FOR FOREST TO GANON
             ImGui::BeginGroup();
@@ -1357,7 +1361,7 @@ void DrawFloatingDungeons(int Icon_Cells_Size, int Icon_Spacing) {
             DrawDungeonItem(ITEM_KEY_SMALL, SCENE_MEN);
             ImGui::SameLine(Icon_Cells_Size * 5);
             ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 5);
-            DrawDungeonItem(ITEM_KEY_SMALL, SCENE_GANON);
+            DrawDungeonItem(ITEM_KEY_SMALL, SCENE_GANONTIKA);
             ImGui::EndGroup();
             ImGui::BeginGroup();
             DrawDungeonItem(ITEM_COMPASS, SCENE_JYASINZOU);
@@ -1372,7 +1376,7 @@ void DrawFloatingDungeons(int Icon_Cells_Size, int Icon_Spacing) {
             DrawDungeonItem(ITEM_COMPASS, SCENE_ICE_DOUKUTO);
             ImGui::SameLine(Icon_Cells_Size * 5);
             ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 5);
-            DrawDungeonItem(ITEM_KEY_BOSS, SCENE_GANONTIKA);
+            DrawDungeonItem(ITEM_KEY_BOSS, SCENE_GANON);
             ImGui::EndGroup();
         }
         ImGui::BeginGroup();
@@ -1465,7 +1469,6 @@ void DrawItemTracker(bool& open) {
     }
     int Icon_Cells_Size = CVar_GetS32("gRandoTrackIconSize", 0);
     int Icon_Spacing = CVar_GetS32("gRandoTrackIconSpacing", 0);
-    validSaveFile = gSaveContext.fileNum >= 0 && gSaveContext.fileNum <= 3;
 
     if (CVar_GetS32("gItemTrackerEnabled", 0)) {
         int ImGui_DefaultMargin = 0;
@@ -1588,6 +1591,10 @@ void DrawItemTrackerOptions(bool& open) {
     ImGui::Text("Chroma Key");
     auto flags = ImGuiColorEditFlags_AlphaPreview | ImGuiColorEditFlags_AlphaBar | ImGuiColorEditFlags_NoLabel;
     ImGui::ColorEdit4("Chroma Key Selection", (float*)&ChromaKeyBackground, flags);
+    CVar_SetFloat("gTrackerBgColorR", ChromaKeyBackground.x);
+    CVar_SetFloat("gTrackerBgColorG", ChromaKeyBackground.y);
+    CVar_SetFloat("gTrackerBgColorB", ChromaKeyBackground.z);
+    CVar_SetFloat("gTrackerBgColorA", ChromaKeyBackground.w);
 
     const char* ItemsTrackerTheme[3] = { "One Block", "Grouped style n.1", "Grouped style n.2" };
     ImGui::Text("Using theme :");
@@ -1664,4 +1671,14 @@ void InitItemTracker() {
     CVar_RegisterS32("gRandoTrackIconSize", 32);
     SohImGui::AddWindow("Randomizer", "Item Tracker", DrawItemTracker);
     SohImGui::AddWindow("Randomizer", "Item Tracker Settings", DrawItemTrackerOptions);
+    float trackerBgR = CVar_GetFloat("gTrackerBgColorR", 0);
+    float trackerBgG = CVar_GetFloat("gTrackerBgColorG", 0);
+    float trackerBgB = CVar_GetFloat("gTrackerBgColorB", 0);
+    float trackerBgA = CVar_GetFloat("gTrackerBgColorA", 1);
+    ChromaKeyBackground = {
+        trackerBgR,
+        trackerBgG,
+        trackerBgB,
+        trackerBgA
+    }; // Float value, 1 = 255 in rgb value.
 }

--- a/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
@@ -240,7 +240,7 @@ std::unordered_map<uint32_t, ItemTrackerMapEntry> equipTrackerMap = {
 };
 
 bool IsValidSaveFile() {
-    bool validSave = gSaveContext.fileNum >= 0 && gSaveContext.fileNum <= 3;
+    bool validSave = gSaveContext.fileNum >= 0 && gSaveContext.fileNum <= 2;
     return validSave;
 }
 

--- a/soh/soh/Enhancements/randomizer/randomizer_item_tracker.h
+++ b/soh/soh/Enhancements/randomizer/randomizer_item_tracker.h
@@ -2,3 +2,4 @@
 
 void InitItemTracker();
 void DrawItemTracker(bool& open);
+void DrawItemAmmo(int itemId);


### PR DESCRIPTION
Resolves https://github.com/HarbourMasters/Shipwright/issues/694, https://github.com/HarbourMasters/Shipwright/issues/696, https://github.com/HarbourMasters/Shipwright/issues/1159

Sort of resolves https://github.com/HarbourMasters/Shipwright/issues/1131

This PR addresses a few outstanding bugs/issues with the item tracker.

- Chroma key values are now saved and loaded to/from 4 CVars. I wanted to use the new RGBA CVars but they don't take float values, so I opted for 4 seperate float CVars instead.
- Ganon's boss key and small keys are now tracked correctly. Because they're both tied to different scene ID's, it wasn't showing them correctly. Now it is.
- Items are now correctly showing their transparent version unless an actual save file is loaded. This in turn also gets rid of the deku stick issue on the N64 logo screen.
- I couldn't find a way to fix magic loading in delayed. It's because the gSaveContext for it is only set when the scene is actually already loaded in. This is likely because of the magic meter effect where it's expanding after loading the scene. It's a lot less noticable now though with the new save file handling. So for this one I'd like to ask others if this is "good enough" or not. As a side note, this behaviour is also present in the save editor.

Old save file handling:
https://cdn.discordapp.com/attachments/937200974152499210/1007751344850993283/2022-08-12_22-40-54.mp4

New save file handling:
https://cdn.discordapp.com/attachments/937200974152499210/1007751344075063456/2022-08-12_22-36-43.mp4