### PR TITLE
Adult trade shuffle bugfixes

### DIFF
--- a/soh/include/functions.h
+++ b/soh/include/functions.h
@@ -1055,6 +1055,7 @@ s32 Inventory_HasEmptyBottle(void);
 s32 Inventory_HasSpecificBottle(u8 bottleItem);
 void Inventory_UpdateBottleItem(GlobalContext* globalCtx, u8 item, u8 cButton);
 s32 Inventory_ConsumeFairy(GlobalContext* globalCtx);
+bool Inventory_HatchPocketCucco(GlobalContext* globalCtx);
 void Interface_SetDoAction(GlobalContext* globalCtx, u16 action);
 void Interface_SetNaviCall(GlobalContext* globalCtx, u16 naviCallState);
 void Interface_LoadActionLabelB(GlobalContext* globalCtx, u16 action);

--- a/soh/soh/Enhancements/randomizer/adult_trade_shuffle.h
+++ b/soh/soh/Enhancements/randomizer/adult_trade_shuffle.h
@@ -4,6 +4,7 @@
 #include <z64.h>
 
 #define ADULT_TRADE_FLAG(itemId) (1 << (itemId - ITEM_POCKET_EGG))
+#define PLAYER_HAS_SHUFFLED_ADULT_TRADE_ITEM(itemID) (gSaveContext.adultTradeItems & ADULT_TRADE_FLAG(itemID))
 
 void Randomizer_ConsumeAdultTradeItem(GlobalContext* globalCtx, u8 itemId);
 u8 Randomizer_GetNextAdultTradeItem();

--- a/soh/src/code/z_kankyo.c
+++ b/soh/src/code/z_kankyo.c
@@ -4,7 +4,6 @@
 #include "objects/gameplay_keep/gameplay_keep.h"
 #include "objects/gameplay_field_keep/gameplay_field_keep.h"
 #include "soh/frame_interpolation.h"
-#include "soh/Enhancements/randomizer/adult_trade_shuffle.h"
 
 typedef enum {
     /* 0 */ LENS_FLARE_CIRCLE0,
@@ -2049,21 +2048,6 @@ void Environment_PlaySceneSequence(GlobalContext* globalCtx) {
     Audio_SetEnvReverb(globalCtx->roomCtx.curRoom.echo);
 }
 
-bool HatchPocketEgg(GlobalContext* globalCtx) {
-    if (!gSaveContext.n64ddFlag) {
-        return Inventory_ReplaceItem(globalCtx, ITEM_POCKET_EGG, ITEM_POCKET_CUCCO);
-    }
-
-    if (!(gSaveContext.adultTradeItems & ADULT_TRADE_FLAG(ITEM_POCKET_EGG))) { 
-         return 0;
-    }
-
-    gSaveContext.adultTradeItems &= ~ADULT_TRADE_FLAG(ITEM_POCKET_EGG);
-    gSaveContext.adultTradeItems |= ADULT_TRADE_FLAG(ITEM_POCKET_CUCCO);
-    Inventory_ReplaceItem(globalCtx, ITEM_POCKET_EGG, ITEM_POCKET_CUCCO);
-    return 1;
-}
-
 // updates bgm/sfx and other things as the day progresses
 void func_80075B44(GlobalContext* globalCtx) {
     switch (globalCtx->envCtx.unk_E0) {
@@ -2117,7 +2101,7 @@ void func_80075B44(GlobalContext* globalCtx) {
                 gSaveContext.dogIsLost = true;
                 func_80078884(NA_SE_EV_CHICKEN_CRY_M);
                 if ((Inventory_ReplaceItem(globalCtx, ITEM_WEIRD_EGG, ITEM_CHICKEN) ||
-                     HatchPocketEgg(globalCtx)) &&
+                     Inventory_HatchPocketCucco(globalCtx)) &&
                     globalCtx->csCtx.state == 0 && !Player_InCsMode(globalCtx)) {
                     Message_StartTextbox(globalCtx, 0x3066, NULL);
                 }

--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -2578,7 +2578,7 @@ bool Inventory_HatchPocketCucco(GlobalContext* globalCtx) {
         return Inventory_ReplaceItem(globalCtx, ITEM_POCKET_EGG, ITEM_POCKET_CUCCO);
     }
 
-    if (!(gSaveContext.adultTradeItems & ADULT_TRADE_FLAG(ITEM_POCKET_EGG))) { 
+    if (!PLAYER_HAS_SHUFFLED_ADULT_TRADE_ITEM(ITEM_POCKET_EGG)) { 
          return 0;
     }
 

--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -2573,6 +2573,21 @@ s32 Inventory_ConsumeFairy(GlobalContext* globalCtx) {
     return 0;
 }
 
+bool Inventory_HatchPocketCucco(GlobalContext* globalCtx) {
+    if (!gSaveContext.n64ddFlag) {
+        return Inventory_ReplaceItem(globalCtx, ITEM_POCKET_EGG, ITEM_POCKET_CUCCO);
+    }
+
+    if (!(gSaveContext.adultTradeItems & ADULT_TRADE_FLAG(ITEM_POCKET_EGG))) { 
+         return 0;
+    }
+
+    gSaveContext.adultTradeItems &= ~ADULT_TRADE_FLAG(ITEM_POCKET_EGG);
+    gSaveContext.adultTradeItems |= ADULT_TRADE_FLAG(ITEM_POCKET_CUCCO);
+    Inventory_ReplaceItem(globalCtx, ITEM_POCKET_EGG, ITEM_POCKET_CUCCO);
+    return 1;
+}
+
 void func_80086D5C(s32* buf, u16 size) {
     u16 i;
 

--- a/soh/src/code/z_play.c
+++ b/soh/src/code/z_play.c
@@ -398,7 +398,7 @@ void Gameplay_Init(GameState* thisx) {
             gSaveContext.bgsDayCount++;
             gSaveContext.dogIsLost = true;
             if (Inventory_ReplaceItem(globalCtx, ITEM_WEIRD_EGG, ITEM_CHICKEN) ||
-                Inventory_ReplaceItem(globalCtx, ITEM_POCKET_EGG, ITEM_POCKET_CUCCO)) {
+                Inventory_HatchPocketCucco(globalCtx)) {
                 Message_StartTextbox(globalCtx, 0x3066, NULL);
             }
             gSaveContext.nextDayTime = 0xFFFE;

--- a/soh/src/code/z_scene_table.c
+++ b/soh/src/code/z_scene_table.c
@@ -23,6 +23,8 @@
 
 #include "overlays/actors/ovl_Bg_Dodoago/z_bg_dodoago.h"
 
+#include "soh/Enhancements/randomizer/adult_trade_shuffle.h"
+
 #define ENTRANCE(scene, spawn, continueBgm, displayTitleCard, fadeIn, fadeOut)                                     \
     {                                                                                                              \
         scene, spawn,                                                                                              \
@@ -2136,7 +2138,11 @@ void func_8009EE44(GlobalContext* globalCtx) {
     gDPPipeSync(POLY_OPA_DISP++);
     gDPSetEnvColor(POLY_OPA_DISP++, 128, 128, 128, 128);
 
-    if ((globalCtx->roomCtx.unk_74[0] == 0) && (INV_CONTENT(ITEM_COJIRO) == ITEM_COJIRO)) {
+	bool playerHasCojiro = INV_CONTENT(ITEM_COJIRO) == ITEM_COJIRO;
+    if (gSaveContext.n64ddFlag && Randomizer_GetSettingValue(RSK_SHUFFLE_ADULT_TRADE)) {
+        playerHasCojiro = PLAYER_HAS_SHUFFLED_ADULT_TRADE_ITEM(ITEM_COJIRO);
+    }
+    if ((globalCtx->roomCtx.unk_74[0] == 0) && playerHasCojiro) {
         if (globalCtx->roomCtx.unk_74[1] == 50) {
             func_8002F7DC(&GET_PLAYER(globalCtx)->actor, NA_SE_EV_CHICKEN_CRY_M);
             globalCtx->roomCtx.unk_74[0] = 1;

--- a/soh/src/overlays/actors/ovl_En_Hs/z_en_hs.c
+++ b/soh/src/overlays/actors/ovl_En_Hs/z_en_hs.c
@@ -79,14 +79,25 @@ void EnHs_Init(Actor* thisx, GlobalContext* globalCtx) {
         // "chicken shop (adult era)"
         osSyncPrintf(VT_FGCOL(CYAN) " ヒヨコの店(大人の時) \n" VT_RST);
         func_80A6E3A0(this, func_80A6E9AC);
-        bool shouldDespawn;
+        bool shouldSpawn;
         bool tradedMushroom = gSaveContext.itemGetInf[3] & 1;
-        if (gSaveContext.n64ddFlag) {
-            shouldDespawn = tradedMushroom && !(gSaveContext.adultTradeItems & ADULT_TRADE_FLAG(ITEM_COJIRO));
+        if (gSaveContext.n64ddFlag && Randomizer_GetSettingValue(RSK_SHUFFLE_ADULT_TRADE)) {
+            // To explain the logic because Fado and Grog are linked:
+            // - If you have Cojiro, then spawn Grog and not Fado.
+            // - If you don't have Cojiro but do have Odd Potion, spawn Fado and not Grog.
+            // - If you don't have either, spawn Grog if you haven't traded the Odd Mushroom.
+            // - If you don't have either but have traded the mushroom, don't spawn either.
+            if (PLAYER_HAS_SHUFFLED_ADULT_TRADE_ITEM(ITEM_COJIRO)) {
+                shouldSpawn = true;
+            } else if (PLAYER_HAS_SHUFFLED_ADULT_TRADE_ITEM(ITEM_ODD_POTION)) {
+                shouldSpawn = false;
+            } else {
+                shouldSpawn = !tradedMushroom;
+            }
         } else {
-            shouldDespawn = tradedMushroom;
+            shouldSpawn = !tradedMushroom;
         }
-        if (shouldDespawn) {
+        if (!shouldSpawn) {
             // "chicken shop closed"
             osSyncPrintf(VT_FGCOL(CYAN) " ヒヨコ屋閉店 \n" VT_RST);
             Actor_Kill(&this->actor);

--- a/soh/src/overlays/actors/ovl_En_Ko/z_en_ko.c
+++ b/soh/src/overlays/actors/ovl_En_Ko/z_en_ko.c
@@ -1026,7 +1026,20 @@ s32 EnKo_CanSpawn(EnKo* this, GlobalContext* globalCtx) {
             }
 
         case SCENE_SPOT10:
-            return (INV_CONTENT(ITEM_TRADE_ADULT) == ITEM_ODD_POTION) ? true : false;
+            if (gSaveContext.n64ddFlag && Randomizer_GetSettingValue(RSK_SHUFFLE_ADULT_TRADE)) {
+                // To explain the logic because Fado and Grog are linked:
+                // - If you have Cojiro, then spawn Grog and not Fado.
+                // - If you don't have Cojiro but do have Odd Potion, spawn Fado and not Grog.
+                // - If you don't have either, spawn Grog if you haven't traded the Odd Mushroom.
+                // - If you don't have either but have traded the mushroom, don't spawn either.
+                if (PLAYER_HAS_SHUFFLED_ADULT_TRADE_ITEM(ITEM_COJIRO)) {
+                    return false;
+                } else {
+                    return PLAYER_HAS_SHUFFLED_ADULT_TRADE_ITEM(ITEM_ODD_POTION);
+                }
+            } else {
+                return (INV_CONTENT(ITEM_TRADE_ADULT) == ITEM_ODD_POTION) ? true : false;
+            }
         default:
             return false;
     }


### PR DESCRIPTION
Fixes for #1151 and a few other bugs related to the shuffled adult trade sequence.
In all, this fixes the following bugs:
 - Grog and Fado can spawn at the same time
 - When hatching the Pocket Egg by using the Sun's Song in an area, your trade quest status is not properly updated
 - Setting the adult trade slot in the Save Editor doesn't set the flags properly (both setting and emptying the slot were broken lol)
 - Opening the trade item menu in the Save Editor rapidly cycles between the items you have
 - Removing a trade item cycles your trade slot when it isn't necessary