### PR TITLE
Fix killer door textures

### DIFF
--- a/soh/src/overlays/actors/ovl_Door_Killer/z_door_killer.c
+++ b/soh/src/overlays/actors/ovl_Door_Killer/z_door_killer.c
@@ -103,12 +103,34 @@ void DoorKiller_Init(Actor* thisx, GlobalContext* globalCtx2) {
     s32 bankIndex;
     s32 i;
 
+    /*
     // Look in the object bank for one of the four objects containing door textures
     bankIndex = -1;
     for (i = 0; bankIndex < 0; i++) {
         bankIndex = Object_GetIndex(&globalCtx->objectCtx, sDoorTextures[i].objectId);
         this->textureEntryIndex = i;
     }
+    */
+
+    // For SoH where all objects are loaded, hardcode the index to match the current map.
+    // OTRTODO: This is a workaround. The proper solution to fix the textures is to manage
+    // object loading / unloading the same as N64.
+    switch (globalCtx->sceneNum) {
+        case SCENE_HIDAN:
+            this->textureEntryIndex = 0;
+            break;
+        case SCENE_MIZUSIN:
+            this->textureEntryIndex = 1;
+            break;
+        case SCENE_HAKADAN:
+        case SCENE_HAKADANCH:
+            this->textureEntryIndex = 2;
+            break;
+        default:
+            this->textureEntryIndex = 3;
+    }
+    bankIndex = Object_GetIndex(&globalCtx->objectCtx, sDoorTextures[this->textureEntryIndex].objectId);
+
     osSyncPrintf("bank_ID = %d\n", bankIndex);
     osSyncPrintf("status = %d\n", this->textureEntryIndex);
     this->doorObjBankIndex = bankIndex;

--- a/soh/src/overlays/actors/ovl_Door_Killer/z_door_killer.c
+++ b/soh/src/overlays/actors/ovl_Door_Killer/z_door_killer.c
@@ -113,8 +113,6 @@ void DoorKiller_Init(Actor* thisx, GlobalContext* globalCtx2) {
     */
 
     // For SoH where all objects are loaded, hardcode the index to match the current map.
-    // OTRTODO: This is a workaround. The proper solution to fix the textures is to manage
-    // object loading / unloading the same as N64.
     switch (globalCtx->sceneNum) {
         case SCENE_HIDAN:
             this->textureEntryIndex = 0;


### PR DESCRIPTION
Workaround to fix #263.

This may not be the ideal solution. #616 proposes reinstating the original N64 object dependency, but that has its own drawbacks, like crashes when using wrong-age equipment.

I think no matter what the solution ends up being, it will probably involve making hotfixes to various behaviors. It's either workarounds for issues caused by the current behavior, or undo object dependency changes and make workarounds for the issues caused by that instead.

Left a comment noting the workaround, ala the similar #615.

**EDIT:** Additional note:

As far as I know, fake doors only appear in the Fire Temple (where they use the `HIDAN` [Fire Temple] metal door texture), Spirit Temple and Gerudo Training Ground (where they use the default `GAMEPLAY_KEEP` wooden door texture).

The killer door object is also set up to handle using the `MIZU` (Water Temple) and `HAKA` (Shadow Temple) textures even though they don't seem to occur in those areas. Maybe they do appear in Master Quest, or maybe they were removed from those areas during development, or maybe they were just covering their bases in case they ever did want to use them.

This workaround replicates that original behavior, so fake doors should display with dungeon-appropriate textures if forcibly spawned in those locations.