### PR TITLE
Rando: Fix being able to get Sun's Song check multiple times

### DIFF
--- a/soh/src/overlays/actors/ovl_En_Okarina_Tag/z_en_okarina_tag.c
+++ b/soh/src/overlays/actors/ovl_En_Okarina_Tag/z_en_okarina_tag.c
@@ -323,13 +323,9 @@ void func_80ABF708(EnOkarinaTag* this, GlobalContext* globalCtx) {
 }
 
 void GivePlayerRandoRewardSunSong(EnOkarinaTag* song, GlobalContext* globalCtx, RandomizerCheck check) {
-    if (song->actor.parent != NULL && song->actor.parent->id == GET_PLAYER(globalCtx)->actor.id &&
-        !Flags_GetTreasure(globalCtx, 0x1F)) {
-        Flags_SetTreasure(globalCtx, 0x1F);
-    } else if (!Flags_GetTreasure(globalCtx, 0x1F)) {
-        GetItemID getItemId = Randomizer_GetItemIdFromKnownCheck(check, GI_LETTER_ZELDA);
-        func_8002F434(&song->actor, globalCtx, getItemId, 10000.0f, 100.0f);
-    }
+    Flags_SetTreasure(globalCtx, 0x1F);
+    GetItemID getItemId = Randomizer_GetItemIdFromKnownCheck(check, GI_LETTER_ZELDA);
+    func_8002F434(&song->actor, globalCtx, getItemId, 10000.0f, 100.0f);
 }
 
 void func_80ABF7CC(EnOkarinaTag* this, GlobalContext* globalCtx) {
@@ -343,10 +339,8 @@ void func_80ABF7CC(EnOkarinaTag* this, GlobalContext* globalCtx) {
                 globalCtx->csCtx.segment = SEGMENTED_TO_VIRTUAL(&gSunSongGraveSunSongTeachCs);
                 gSaveContext.cutsceneTrigger = 1;
             }
-        } else {
-            if (!Flags_GetTreasure(globalCtx, 0x1F)) {
-                GivePlayerRandoRewardSunSong(this, globalCtx, RC_SONG_FROM_ROYAL_FAMILYS_TOMB);
-            }
+        } else if (!Flags_GetTreasure(globalCtx, 0x1F)) {
+            GivePlayerRandoRewardSunSong(this, globalCtx, RC_SONG_FROM_ROYAL_FAMILYS_TOMB);
         }
         this->actionFunc = func_80ABF708;
     }

--- a/soh/src/overlays/actors/ovl_En_Okarina_Tag/z_en_okarina_tag.c
+++ b/soh/src/overlays/actors/ovl_En_Okarina_Tag/z_en_okarina_tag.c
@@ -334,11 +334,9 @@ void func_80ABF7CC(EnOkarinaTag* this, GlobalContext* globalCtx) {
 
     if ((Message_GetState(&globalCtx->msgCtx) == TEXT_STATE_EVENT) && Message_ShouldAdvance(globalCtx)) {
         Message_CloseTextbox(globalCtx);
-        if (!gSaveContext.n64ddFlag) {
-            if (!CHECK_QUEST_ITEM(QUEST_SONG_SUN)) {
-                globalCtx->csCtx.segment = SEGMENTED_TO_VIRTUAL(&gSunSongGraveSunSongTeachCs);
-                gSaveContext.cutsceneTrigger = 1;
-            }
+        if (!gSaveContext.n64ddFlag && !CHECK_QUEST_ITEM(QUEST_SONG_SUN)) {
+            globalCtx->csCtx.segment = SEGMENTED_TO_VIRTUAL(&gSunSongGraveSunSongTeachCs);
+            gSaveContext.cutsceneTrigger = 1;
         } else if (!Flags_GetTreasure(globalCtx, 0x1F)) {
             GivePlayerRandoRewardSunSong(this, globalCtx, RC_SONG_FROM_ROYAL_FAMILYS_TOMB);
         }


### PR DESCRIPTION
The code was checking for something that was only temporarily set to an object. Only when you talked to the music tablet a second time would it set the treasure flag. So if you only got the item, left the area and come back, you could claim it a second time (and a third time if you did it again etc).

This cleans up the code a bit and it sets the flag whenever you get the item, and only check for that flag instead to decide wether or not the player should get the randomized item.