### PR TITLE
Improve OTRExporter asset extraction script, Lower required CMake to 3.16

### DIFF
--- a/CMake/genscript.cmake
+++ b/CMake/genscript.cmake
@@ -1,5 +1,0 @@
-file(READ ${CMAKE_CURRENT_SOURCE_DIR}/extract_assets.py filedata)
-string(REGEX REPLACE "zapd_exe = .*exec_cmd =" "zapd_exe = \"${program}\"\n    exec_cmd =" filedata "${filedata}")
-file(WRITE "${CMAKE_CURRENT_SOURCE_DIR}/extract_assets_cmake2.py" "${filedata}")
-file(CHMOD "${CMAKE_CURRENT_SOURCE_DIR}/extract_assets_cmake2.py" PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_WRITE GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.16.0 FATAL_ERROR)
 
 set(CMAKE_SYSTEM_VERSION 10.0 CACHE STRING "" FORCE)
 set(CMAKE_CXX_STANDARD 20 CACHE STRING "The C++ standard to use")
@@ -138,15 +138,15 @@ find_package(Python3 COMPONENTS Interpreter)
 
 add_custom_target(
     ExtractAssets
-    COMMAND ${CMAKE_COMMAND} -Dprogram=$<TARGET_FILE:ZAPD> -P ${CMAKE_SOURCE_DIR}/CMake/genscript.cmake
-    COMMAND ${CMAKE_COMMAND} -E rm -f oot.otr
-    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/OTRExporter/extract_assets_cmake2.py
+    # CMake versions prior to 3.17 do not have the rm command, use remove instead for older versions
+    COMMAND ${CMAKE_COMMAND} -E $<IF:$<VERSION_LESS:${CMAKE_VERSION},3.17>,remove,rm> -f oot.otr
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/OTRExporter/extract_assets.py -z "$<TARGET_FILE:ZAPD>"
     COMMAND ${CMAKE_COMMAND} -E copy oot.otr ${CMAKE_SOURCE_DIR}
     COMMAND ${CMAKE_COMMAND} -E copy oot.otr ${CMAKE_BINARY_DIR}/soh
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/OTRExporter
     COMMENT "Running asset extraction..."
     DEPENDS ZAPD
-    BYPRODUCTS oot.otr ${CMAKE_SOURCE_DIR}/oot.otr ${CMAKE_CURRENT_SOURCE_DIR}/OTRExporter/extract_assets_cmake2.py
+    BYPRODUCTS oot.otr ${CMAKE_SOURCE_DIR}/oot.otr
 )
 
 if(CMAKE_SYSTEM_NAME MATCHES "Linux")

--- a/OTRExporter/CMakeLists.txt
+++ b/OTRExporter/CMakeLists.txt
@@ -94,9 +94,3 @@ if (NOT TARGET ZAPDUtils)
 endif()
 
 add_subdirectory(OTRExporter)
-
-file(READ ${CMAKE_CURRENT_SOURCE_DIR}/extract_assets.py filedata)
-string(REGEX REPLACE "../ZAPDTR/ZAPD.out" "${CMAKE_BINARY_DIR}/ZAPD/ZAPD.out" filedata "${filedata}")
-file(WRITE "${CMAKE_CURRENT_SOURCE_DIR}/extract_assets_cmake.py" "${filedata}")
-file(CHMOD "${CMAKE_CURRENT_SOURCE_DIR}/extract_assets_cmake.py" PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_WRITE GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
-

--- a/OTRExporter/extract_assets.py
+++ b/OTRExporter/extract_assets.py
@@ -33,10 +33,11 @@ def BuildOTR(xmlPath, rom, zapd_exe=None):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("-z", "--zapd", help="Path to ZAPD executable", dest="zapd_exe", type=str)
+    parser.add_argument("rom", help="Path to the rom", type=str, nargs="?")
 
     args = parser.parse_args()
 
-    rom_path = rom_chooser.chooseROM()
+    rom_path = args.rom if args.rom else rom_chooser.chooseROM()
     rom = Z64Rom(rom_path)
 
     if (os.path.exists("Extract")):

--- a/OTRExporter/extract_assets.py
+++ b/OTRExporter/extract_assets.py
@@ -6,15 +6,18 @@ from rom_info import Z64Rom
 import rom_chooser
 import struct
 import subprocess
+import argparse
 
-def BuildOTR(xmlPath, rom):
+def BuildOTR(xmlPath, rom, zapd_exe=None):
     shutil.copytree("assets", "Extract/assets")
 
     checksum = int(Z64Rom(rom).checksum.value, 16)
     with open("Extract/version", "wb") as f:
         f.write(struct.pack('<L', checksum))
 
-    zapd_exe = "x64\\Release\\ZAPD.exe" if sys.platform == "win32" else "../ZAPDTR/ZAPD.out"
+    if not zapd_exe:
+        zapd_exe = "x64\\Release\\ZAPD.exe" if sys.platform == "win32" else "../ZAPDTR/ZAPD.out"
+
     exec_cmd = [zapd_exe, "ed", "-i", xmlPath, "-b", rom, "-fl", "CFG/filelists",
             "-o", "placeholder", "-osf", "placeholder", "-gsf", "1",
             "-rconf", "CFG/Config.xml", "-se", "OTR"]
@@ -28,13 +31,18 @@ def BuildOTR(xmlPath, rom):
         print("\n")
 
 def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-z", "--zapd", help="Path to ZAPD executable", dest="zapd_exe", type=str)
+
+    args = parser.parse_args()
+
     rom_path = rom_chooser.chooseROM()
     rom = Z64Rom(rom_path)
 
     if (os.path.exists("Extract")):
         shutil.rmtree("Extract")
 
-    BuildOTR("../soh/assets/xml/" + rom.version.xml_ver + "/", rom_path)
+    BuildOTR("../soh/assets/xml/" + rom.version.xml_ver + "/", rom_path, zapd_exe=args.zapd_exe)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
In an effort to reduce to the CMake version to be able to build on older distros (relevant to Pi builds as discussed in #1013 , there were two conflicting points in the CMakeLists:
 - `file(CHMOD ...)` was [added in 3.19](https://cmake.org/cmake/help/latest/command/file.html#chmod)
 - `cmake -E rm` was [added in 3.17](https://cmake.org/cmake/help/latest/manual/cmake.1.html#run-a-command-line-tool), to replace the [deprecated remove command](https://cmake.org/cmake/help/latest/release/3.17.html#deprecated-and-removed-features)

Note: I targetted 3.16 to match the current highest requirement, which is set as 3.16 in `OTRExporter/CMakeLists.txt`. The actual minimum requirement might be still be lower.

Currently, the `ExtractAssets` target generates a new `extract_assets_cmake*py` script to replace a hardcoded string, and marks that as executable, hence the `CHMOD`. Instead, this PR adds the ability to supply the original script a path to the ZAPD executable with the optional `-z` argument.

`OTRExporter/CMakeLists.txt` also reported a minimum version of `3.16`, but also included a similar script regeneration logic + `CHMOD` that goes seemingly unused. This has been removed.


As a bonus: I noticed that [`BUILDING.md`](https://github.com/HarbourMasters/Shipwright/blob/develop-zhora/BUILDING.md#otrexporter-usage) states:
- In a terminal run `python3 extract_assets.py <path_to_rom>`

This doesn't seem to be implemented, so the second commit adds this functionality.

---
## Testing

I have tested building the `ExtractAssets` target on the following configurations:
 - Windows, with cmake 3.24
 - Linux, with cmake 3.23
 - Linux, with cmake 3.16
 - Linux (RPi), with cmake 3.18  ~(currently still building, will update when done)~ completed ok