### PR TITLE
add SHIP_HOME (Linux)

### DIFF
--- a/libultraship/libultraship/Window.cpp
+++ b/libultraship/libultraship/Window.cpp
@@ -316,6 +316,12 @@ namespace Ship {
         return fpath;
 #endif
 
+#ifdef __linux__
+        char* fpath = std::getenv("SHIP_HOME");
+        if (fpath != NULL)
+            return std::string(fpath);
+#endif
+
         return ".";
     }
 

--- a/scripts/linux/appimage/soh.sh
+++ b/scripts/linux/appimage/soh.sh
@@ -5,14 +5,18 @@ export PATH="$HERE"/bin:"$HERE"/usr/bin:"$PATH"
 export LD_LIBRARY_PATH="$HERE"/usr/lib:"$LD_LIBRARY_PATH"
 export ZENITY=$(command -v zenity)
 
-while [[ ! -e "$PWD"/oot.otr ]]; do
+if [ -z ${SHIP_HOME+x} ]; then
+export SHIP_HOME=.
+fi
+
+while [[ ! -e "$SHIP_HOME"/oot.otr ]]; do
 	export ASSETDIR="$(mktemp -d /tmp/assets-XXXXX)"
 	ln -s "$HERE"/usr/bin/{assets,soh.elf,OTRGui} "$ASSETDIR"
 	export OLDPWD="$PWD"
 	mkdir -p "$ASSETDIR"/tmp
 	mkdir -p "$ASSETDIR"/Extract/assets
-	if [ -e "$PWD"/*.*64 ]; then
-		ln -s "$OLDPWD"/*.*64 "$ASSETDIR"/tmp/rom.z64
+	if [ -e "$SHIP_HOME"/*.*64 ]; then
+		ln -s "$SHIP_HOME"/*.*64 "$ASSETDIR"/tmp/rom.z64
 		cp -r "$ASSETDIR"/assets/game/ship_of_harkinian "$ASSETDIR"/Extract/assets/
 		cd "$ASSETDIR"
 		ROMHASH=$(sha1sum -b "$ASSETDIR"/tmp/rom.z64 | awk '{ print $1 }')
@@ -36,22 +40,19 @@ while [[ ! -e "$PWD"/oot.otr ]]; do
 			echo "Processing..."
 		fi
 		assets/extractor/ZAPD.out ed -eh -i assets/extractor/xmls/"${ROM}" -b tmp/rom.z64 -fl assets/extractor/filelists -o placeholder -osf placeholder -gsf 1 -rconf assets/extractor/Config_"${ROM}".xml -se OTR > /dev/null 2>&1
-		cp "$ASSETDIR"/oot.otr "$OLDPWD"
+		cp "$ASSETDIR"/oot.otr "$SHIP_HOME"
 		echo "Restart $APPIMAGE to play!" 
 		sleep 3
 		rm -r "$ASSETDIR"
 		break
 	else
 		if [ -n "$ZENITY" ]; then
-			zenity --error --timeout=5 --text="Place ROM in $OWD" --title="Missing ROM file" --width=500 --width=200
+			zenity --error --timeout=5 --text="Place ROM in $SHIP_HOME" --title="Missing ROM file" --width=500 --width=200
 		else
 			echo -e "\nPlace ROM in this folder\n"
 		fi	
 		exit
 	fi
 done	
-	cd "$OWD"
-	ln -s "$HERE"/usr/bin/gamecontrollerdb.txt "$PWD"
-	"$HERE"/usr/bin/soh.elf
-	unlink "$PWD"/gamecontrollerdb.txt
+	(cd "$HERE/usr/bin"; ./soh.elf)
 exit

--- a/scripts/linux/appimage/soh.sh
+++ b/scripts/linux/appimage/soh.sh
@@ -6,7 +6,7 @@ export LD_LIBRARY_PATH="$HERE"/usr/lib:"$LD_LIBRARY_PATH"
 export ZENITY=$(command -v zenity)
 
 if [ -z ${SHIP_HOME+x} ]; then
-export SHIP_HOME=.
+export SHIP_HOME=$PWD
 fi
 
 while [[ ! -e "$SHIP_HOME"/oot.otr ]]; do


### PR DESCRIPTION
Add a SHIP_HOME environment variable on Linux to separate the appimage from the other files like it's done on MacOS.
Set the SHIP_HOME in soh.sh to ".", if not already set. ROM, oot.otr, logs etc. all will be in SHIP_HOME.
This eases the integration of the appimage with appimagelauncher, which copies the appimage to a different locationa and renames the appimage.