### PR TITLE
Fixes Rando Ice Traps on Windows and Mac.

### DIFF
--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -6280,7 +6280,7 @@ s32 func_8083E5A8(Player* this, GlobalContext* globalCtx) {
                     this->actor.colChkInfo.damage = 0;
                     func_80837C0C(globalCtx, this, 3, 0.0f, 0.0f, 0, 20);
                     Player_SetPendingFlag(this, globalCtx);
-                    return;
+                    return 1;
                 }
 
                 s32 drop = giEntry->objectId;


### PR DESCRIPTION
Sets NPC Ice Traps to return a value instead of returning nothing. I'm guessing this is UB and explains why Windows, Linux, and Mac systems behaved differently, since they all use different compilers.

Specifically returning 1 properly stops the players movement and freezes them when near an NPC.