### PR TITLE
Cosmetic editor fixes & mini updates

### DIFF
--- a/libultraship/libultraship/ImGuiImpl.cpp
+++ b/libultraship/libultraship/ImGuiImpl.cpp
@@ -758,12 +758,7 @@ namespace SohImGui {
     }
 
     void RandomizeColor(const char* cvarName, ImVec4* colors) {
-        std::string Cvar_Red = cvarName;
-        Cvar_Red += "R";
-        std::string Cvar_Green = cvarName;
-        Cvar_Green += "G";
-        std::string Cvar_Blue = cvarName;
-        Cvar_Blue += "B";
+        Color_RGBA8 NewColors = {0,0,0,255};
         std::string Cvar_RBM = cvarName;
         Cvar_RBM += "RBM";
         std::string MakeInvisible = "##";
@@ -778,9 +773,10 @@ namespace SohImGui {
             colors->x = (float)RND_R / 255;
             colors->y = (float)RND_G / 255;
             colors->z = (float)RND_B / 255;
-            CVar_SetS32(Cvar_Red.c_str(), ClampFloatToInt(colors->x * 255, 0, 255));
-            CVar_SetS32(Cvar_Green.c_str(), ClampFloatToInt(colors->y * 255, 0, 255));
-            CVar_SetS32(Cvar_Blue.c_str(), ClampFloatToInt(colors->z * 255, 0, 255));
+            NewColors.r = ClampFloatToInt(colors->x * 255, 0, 255);
+            NewColors.g = ClampFloatToInt(colors->y * 255, 0, 255);
+            NewColors.b = ClampFloatToInt(colors->z * 255, 0, 255);
+            CVar_SetRGBA(cvarName, NewColors);
             CVar_SetS32(Cvar_RBM.c_str(), 0); //On click disable rainbow mode.
             needs_save = true;
         }
@@ -807,16 +803,16 @@ namespace SohImGui {
         MakeInvisible += cvarName;
         MakeInvisible += "Reset";
         if (ImGui::Button(MakeInvisible.c_str())) {
-            colors->x = defaultcolors.x / 255;
-            colors->y = defaultcolors.y / 255;
-            colors->z = defaultcolors.z / 255;
-            if (has_alpha) { colors->w = defaultcolors.w / 255; };
+            colors->x = defaultcolors.x;
+            colors->y = defaultcolors.y;
+            colors->z = defaultcolors.z;
+            if (has_alpha) { colors->w = defaultcolors.w; };
 
             Color_RGBA8 colorsRGBA;
-            colorsRGBA.r = defaultcolors.x / 255;
-            colorsRGBA.g = defaultcolors.y / 255;
-            colorsRGBA.b = defaultcolors.z / 255;
-            if (has_alpha) { colorsRGBA.a = defaultcolors.w / 255; };
+            colorsRGBA.r = defaultcolors.x;
+            colorsRGBA.g = defaultcolors.y;
+            colorsRGBA.b = defaultcolors.z;
+            if (has_alpha) { colorsRGBA.a = defaultcolors.w; };
 
             CVar_SetRGBA(cvarName, colorsRGBA);
             CVar_SetS32(Cvar_RBM.c_str(), 0); //On click disable rainbow mode.

--- a/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
+++ b/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
@@ -3,83 +3,14 @@
 
 #include <string>
 #include <Cvar.h>
+#include <random>
+#include <algorithm>
 #include <PR/ultra64/types.h>
 
-/**
- * Colors variables
- */
-float TablesCellsWidth = 300.0f; //1 Col
-ImVec4 hearts_colors;
-ImVec4 hearts_dd_colors;
-ImVec4 hearts_ddi_colors; //DD inner colors
-ImVec4 a_btn_colors;
-ImVec4 b_btn_colors;
-ImVec4 c_btn_colors;
-ImVec4 start_btn_colors;
-ImVec4 magic_border_colors;
-ImVec4 magic_remaining_colors;
-ImVec4 magic_use_colors;
-ImVec4 minimap_colors;
-ImVec4 rupee_colors;
-ImVec4 smolekey_colors;
-ImVec4 fileselect_colors;
-ImVec4 fileselect_text_colors;
-ImVec4 kokiri_col;
-ImVec4 goron_col;
-ImVec4 zora_col;
-ImVec4 navi_idle_i_col;
-ImVec4 navi_idle_o_col;
-ImVec4 navi_npc_i_col;
-ImVec4 navi_npc_o_col;
-ImVec4 navi_enemy_i_col;
-ImVec4 navi_enemy_o_col;
-ImVec4 navi_prop_i_col;
-ImVec4 navi_prop_o_col;
-ImVec4 trailscol;
-ImVec4 c_btn_u_colors;
-ImVec4 c_btn_l_colors;
-ImVec4 c_btn_d_colors;
-ImVec4 c_btn_r_colors;
-ImVec4 magic_bordern_colors;
-ImVec4 firearrow_col;
-ImVec4 icearrow_col;
-ImVec4 lightarrow_col;
-ImVec4 firearrow_colenv;
-ImVec4 icearrow_colenv;
-ImVec4 lightarrow_colenv;
-ImVec4 charged1_col;
-ImVec4 charged2_col;
-ImVec4 charged1_colenv;
-ImVec4 charged2_colenv;
-ImVec4 Keese1_primcol;
-ImVec4 Keese2_primcol;
-ImVec4 Keese1_envcol;
-ImVec4 Keese2_envcol;
-ImVec4 doggo1col;
-ImVec4 doggo2col;
-ImVec4 df_col;
-ImVec4 df_colenv;
-ImVec4 nl_diam_col;
-ImVec4 nl_diam_colenv;
-ImVec4 nl_orb_col;
-ImVec4 nl_orb_colenv;
-ImVec4 dgn_minimap_colors;
-ImVec4 cp_minimap_colors;
-ImVec4 le_minimap_colors;
-ImVec4 tc_ou_colors;
-ImVec4 tc_bu_colors;
-ImVec4 dpad_colors;
-ImVec4 visualagony_colors;
-/*ImVec4 menu_equips_colors;
-ImVec4 menu_items_colors;
-ImVec4 menu_map_colors;
-ImVec4 menu_quest_colors;
-ImVec4 menu_save_colors;
-ImVec4 menu_gameover_colors;*/
 const char* RainbowColorCvarList[] = {
     //This is the list of possible CVars that has rainbow effect.
-    "gTunic_Kokiri_", "gTunic_Goron_", "gTunic_Zora_",
-    "gFireArrowCol", "gIceArrowCol", "gTunic_Zora_",
+    "gTunic_Kokiri", "gTunic_Goron", "gTunic_Zora",
+    "gFireArrowCol", "gIceArrowCol",
     "gFireArrowColEnv", "gIceArrowColEnv", "gLightArrowColEnv",
     "gCCHeartsPrim", "gDDCCHeartsPrim", "gLightArrowCol", "gCCDDHeartsPrim",
     "gCCABtnPrim", "gCCBBtnPrim", "gCCCBtnPrim", "gCCStartBtnPrim",
@@ -88,11 +19,11 @@ const char* RainbowColorCvarList[] = {
     "gCCMinimapPrim", "gCCMinimapDGNPrim", "gCCMinimapCPPrim", "gCCMinimapLEPrim",
     "gCCRupeePrim", "gCCKeysPrim", "gDog1Col", "gDog2Col", "gCCVSOAPrim",
     "gKeese1_Ef_Prim","gKeese2_Ef_Prim","gKeese1_Ef_Env","gKeese2_Ef_Env",
-    "gDF_Col", "gDF_Env",
+    "gDF_Col", "gDF_Env", 
     "gNL_Diamond_Col", "gNL_Diamond_Env", "gNL_Orb_Col", "gNL_Orb_Env",
     "gTrailCol", "gCharged1Col", "gCharged1ColEnv", "gCharged2Col", "gCharged2ColEnv",
     "gCCFileChoosePrim", "gCCFileChooseTextPrim", "gCCEquipmentsPrim", "gCCItemsPrim",
-    "gCCMapsPrim", "gCCQuestsPrim", "gCCSavePrim", "gCCGameoverPrim",
+    "gCCMapsPrim", "gCCQuestsPrim", "gCCSavePrim", "gCCGameoverPrim"
 };
 const char* MarginCvarList[] {
     "gHearts", "gMagicBar", "gVSOA", "gBBtn", "gABtn", "gStartBtn", 
@@ -100,6 +31,57 @@ const char* MarginCvarList[] {
     "gSKC", "gRC", "gCarrots",  "gTimers", "gAS", "gTCM", "gTCB"
 };
 
+ImVec4 GetRandomValue(int MaximumPossible){
+    ImVec4 NewColor;
+    unsigned long range = 255 - 0;
+    std::random_device rd;
+    std::mt19937 rng(rd());
+    std::uniform_int_distribution<int> dist(0, 255 - 1);
+    
+    NewColor.x = (float)(dist(rng)) / 255;
+    NewColor.y = (float)(dist(rng)) / 255;
+    NewColor.z = (float)(dist(rng)) / 255;
+    return NewColor;
+}
+void GetRandomColorRGB(CosmeticsColorSection* ColorSection, int SectionSize){
+    //std::random_shuffle(ColorSection, ColorSection + SectionSize);
+    for (int i = 0; i < SectionSize; i++){
+        CosmeticsColorIndividual* Element = ColorSection[i].Element;
+        ImVec4 colors = Element->ModifiedColor;
+        Color_RGBA8 NewColors = { 0, 0, 0, 255 };
+        std::string cvarName = Element->CvarName;
+        std::string Cvar_RBM = cvarName + "RBM";
+        colors = RANDOMIZE_32(255);
+        NewColors.r = SohImGui::ClampFloatToInt(colors.x * 255, 0, 255);
+        NewColors.g = SohImGui::ClampFloatToInt(colors.y * 255, 0, 255);
+        NewColors.b = SohImGui::ClampFloatToInt(colors.z * 255, 0, 255);
+        Element->ModifiedColor = colors;
+        CVar_SetRGBA(cvarName.c_str(), NewColors);
+        CVar_SetS32(Cvar_RBM.c_str(), 0);
+    }
+}
+void GetDefaultColorRGB(CosmeticsColorSection* ColorSection, int SectionSize){
+    for (int i = 0; i < SectionSize; i++){
+        CosmeticsColorIndividual* Element = ColorSection[i].Element;
+        ImVec4 colors = Element->ModifiedColor;
+        ImVec4 defaultcolors = Element->DefaultColor;
+        std::string cvarName = Element->CvarName;
+        std::string Cvar_RBM = cvarName + "RBM";
+        colors.x = defaultcolors.x;
+        colors.y = defaultcolors.y;
+        colors.z = defaultcolors.z;
+        if (Element->hasAlpha) { colors.w = defaultcolors.w; };
+        Element->ModifiedColor = colors;
+        Color_RGBA8 colorsRGBA;
+        colorsRGBA.r = defaultcolors.x;
+        colorsRGBA.g = defaultcolors.y;
+        colorsRGBA.b = defaultcolors.z;
+        if (Element->hasAlpha) { colorsRGBA.a = defaultcolors.w; };
+        CVar_SetRGBA(cvarName.c_str(), colorsRGBA);
+        CVar_SetS32(Cvar_RBM.c_str(), 0); //On click disable rainbow mode.
+
+    }
+}
 void SetMarginAll(const char* ButtonName, bool SetActivated) {
     if (ImGui::Button(ButtonName)) {
         u8 arrayLength = sizeof(MarginCvarList) / sizeof(*MarginCvarList);
@@ -142,12 +124,6 @@ void LoadRainbowColor(bool& open) {
     u8 arrayLength = sizeof(RainbowColorCvarList) / sizeof(*RainbowColorCvarList);
     for (u8 s = 0; s < arrayLength; s++) {
         std::string cvarName = RainbowColorCvarList[s];
-        std::string Cvar_Red = cvarName;
-        Cvar_Red += "R";
-        std::string Cvar_Green = cvarName;
-        Cvar_Green += "G";
-        std::string Cvar_Blue = cvarName;
-        Cvar_Blue += "B";
         std::string Cvar_RBM = cvarName;
         Cvar_RBM += "RBM";
         std::string RBM_HUE = cvarName;
@@ -173,11 +149,14 @@ void LoadRainbowColor(bool& open) {
         case 5: NewColor.x = b; NewColor.y = 0; NewColor.z = 255; break;
         case 6: NewColor.x = 255; NewColor.y = 0; NewColor.z = a; break;
         }
-
+        Color_RGBA8 NewColorRGB = {
+            SohImGui::ClampFloatToInt(NewColor.x, 0, 255),
+            SohImGui::ClampFloatToInt(NewColor.y, 0, 255),
+            SohImGui::ClampFloatToInt(NewColor.z, 0, 255),
+            255
+        };
         if (CVar_GetS32(Cvar_RBM.c_str(), 0) != 0) {
-            CVar_SetS32(Cvar_Red.c_str(), SohImGui::ClampFloatToInt(NewColor.x, 0, 255));
-            CVar_SetS32(Cvar_Green.c_str(), SohImGui::ClampFloatToInt(NewColor.y, 0, 255));
-            CVar_SetS32(Cvar_Blue.c_str(), SohImGui::ClampFloatToInt(NewColor.z, 0, 255));
+            CVar_SetRGBA(cvarName.c_str(), NewColorRGB);
         }
     }
 }
@@ -190,7 +169,7 @@ void Table_InitHeader(bool has_header = true) {
     ImGui::TableNextColumn();
     ImGui::AlignTextToFramePadding(); //This is to adjust Vertical pos of item in a cell to be normlized.
     ImGui::SetCursorPosX(ImGui::GetCursorPosX() - 2);
-    ImGui::PushItemWidth(ImGui::GetContentRegionAvail().x);
+    ImGui::PushItemWidth(ImGui::GetContentRegionAvail().x-60);
 }
 void Table_NextCol() {
     ImGui::TableNextColumn();
@@ -216,161 +195,244 @@ void Draw_HelpIcon(const std::string& helptext, bool sameline = true, int Pos = 
     }
     ImGui::PushItemWidth(ImGui::GetContentRegionAvail().x);
 }
+void DrawUseMarginsSlider(const std::string ElementName, const std::string CvarName){
+    std::string CvarLabel = CvarName + "UseMargins";
+    std::string Label = ElementName + " use margins";
+    SohImGui::EnhancementCheckbox(Label.c_str(), CvarLabel.c_str());
+    SohImGui::Tooltip("Using this allow you move the element with General margins sliders");
+}
+void DrawPositionsRadioBoxes(const std::string CvarName, bool NoAnchorEnabled = true){
+    std::string CvarLabel = CvarName + "PosType";
+    SohImGui::EnhancementRadioButton("Original position", CvarLabel.c_str(), 0);
+    SohImGui::Tooltip("This will use original intended elements position");
+    SohImGui::EnhancementRadioButton("Anchor to the left", CvarLabel.c_str(), 1);
+    SohImGui::Tooltip("This will make your elements follow the left side of your game window");
+    SohImGui::EnhancementRadioButton("Anchor to the right", CvarLabel.c_str(), 2);
+    SohImGui::Tooltip("This will make your elements follow the right side of your game window");
+    if (NoAnchorEnabled) {
+        SohImGui::EnhancementRadioButton("No anchors", CvarLabel.c_str(), 3);
+        SohImGui::Tooltip("This will make your elements to not follow any side\nBetter used for center elements");
+    }
+    SohImGui::EnhancementRadioButton("Hidden", CvarLabel.c_str(), 4);
+    SohImGui::Tooltip("This will make your elements hidden");
+}
+void DrawTransitions(const std::string CvarName){
+    SohImGui::EnhancementRadioButton("Really slow fade (white)", CvarName.c_str(), 8);
+    Table_NextCol();
+    SohImGui::EnhancementRadioButton("Really slow fade (black)", CvarName.c_str(), 7);
+    Table_NextLine();
+    SohImGui::EnhancementRadioButton("Slow fade (white)", CvarName.c_str(), 10);
+    Table_NextCol();
+    SohImGui::EnhancementRadioButton("Slow fade (black)", CvarName.c_str(), 9);
+    Table_NextLine();
+    SohImGui::EnhancementRadioButton("Normal fade (white)", CvarName.c_str(), 3);
+    Table_NextCol();
+    SohImGui::EnhancementRadioButton("Normal fade (black)", CvarName.c_str(), 2);
+    Table_NextLine();
+    SohImGui::EnhancementRadioButton("Fast fade (white)", CvarName.c_str(), 5);
+    Table_NextCol();
+    SohImGui::EnhancementRadioButton("Fast fade (black)", CvarName.c_str(), 4);
+    Table_NextLine();
+    SohImGui::EnhancementRadioButton("Fast circle (white)", CvarName.c_str(), 40);
+    Table_NextCol();
+    SohImGui::EnhancementRadioButton("Normal circle (black)", CvarName.c_str(), 32);
+    Table_NextLine();
+    SohImGui::EnhancementRadioButton("Slow circle (white)", CvarName.c_str(), 41);
+    Table_NextCol();
+    SohImGui::EnhancementRadioButton("Slow circle (black)", CvarName.c_str(), 33);
+    Table_NextLine();
+    SohImGui::EnhancementRadioButton("Fast noise circle (white)", CvarName.c_str(), 42);
+    Table_NextCol();
+    SohImGui::EnhancementRadioButton("Fast noise circle (black)", CvarName.c_str(), 34);
+    Table_NextLine();
+    SohImGui::EnhancementRadioButton("Slow noise circle (white)", CvarName.c_str(), 43);
+    Table_NextCol();
+    SohImGui::EnhancementRadioButton("Slow noise circle (black)", CvarName.c_str(), 35);
+    Table_NextLine();
+    SohImGui::EnhancementRadioButton("Normal waves circle (white)", CvarName.c_str(), 44);
+    Table_NextCol();
+    SohImGui::EnhancementRadioButton("Normal waves circle (black)", CvarName.c_str(), 36);
+    Table_NextLine();
+    SohImGui::EnhancementRadioButton("Slow waves circle (white)", CvarName.c_str(), 45);
+    Table_NextCol();
+    SohImGui::EnhancementRadioButton("Slow waves circle (black)", CvarName.c_str(), 37);
+    Table_NextLine();
+    SohImGui::EnhancementRadioButton("Normal close circle (white)", CvarName.c_str(), 46);
+    Table_NextCol();
+    SohImGui::EnhancementRadioButton("Normal close circle (black)", CvarName.c_str(), 38);
+    Table_NextLine();
+    SohImGui::EnhancementRadioButton("Slow close circle (white)", CvarName.c_str(), 47);
+    Table_NextCol();
+    SohImGui::EnhancementRadioButton("Slow close circle (black)", CvarName.c_str(), 39);
+    Table_NextLine();
+    SohImGui::EnhancementRadioButton("Super fast circle (white)", CvarName.c_str(), 56);
+    Table_NextCol();
+    SohImGui::EnhancementRadioButton("Super fast circle (black)", CvarName.c_str(), 58);
+    Table_NextLine();
+    SohImGui::EnhancementRadioButton("Super fast noise circle (white)", CvarName.c_str(), 57);
+    Table_NextCol();
+    SohImGui::EnhancementRadioButton("Super fast noise circle (black)", CvarName.c_str(), 59);
+}
+void DrawPositionSlider(const std::string CvarName, int MinY, int MaxY, int MinX, int MaxX){
+    std::string PosXCvar = CvarName+"PosX";
+    std::string PosYCvar = CvarName+"PosY";
+    std::string InvisibleLabelX = "##"+PosXCvar;
+    std::string InvisibleLabelY = "##"+PosYCvar;
+    SohImGui::EnhancementSliderInt("Up <-> Down : %d", InvisibleLabelY.c_str(), PosYCvar.c_str(), MinY, MaxY, "", 0, true);
+    SohImGui::Tooltip("This slider is used to move Up and Down your elements.");
+    SohImGui::EnhancementSliderInt("Left <-> Right : %d", InvisibleLabelX.c_str(), PosXCvar.c_str(), MinX, MaxX, "", 0, true);
+    SohImGui::Tooltip("This slider is used to move Left and Right your elements.");
+}
+void DrawScaleSlider(const std::string CvarName,float DefaultValue){
+    std::string InvisibleLabel = "##"+CvarName;
+    std::string CvarLabel = CvarName+"Scale";
+    //Disabled for now. feature not done and several fixes needed to be merged.
+    //SohImGui::EnhancementSliderFloat("Scale : %dx", InvisibleLabel.c_str(), CvarLabel.c_str(), 0.1f, 3.0f,"",DefaultValue,true,true);
+}
+void DrawColorSection(CosmeticsColorSection* ColorSection, int SectionSize) {
+    for (s16 i = 0; i < SectionSize; i++) {
+        CosmeticsColorIndividual* ThisElement = ColorSection[i].Element;
+        const std::string Tooltip = ThisElement->ToolTip;
+        const std::string Name = ThisElement->Name;
+        const std::string Cvar = ThisElement->CvarName;
+        ImVec4 ModifiedColor = ThisElement->ModifiedColor;
+        ImVec4 DefaultColor = ThisElement->DefaultColor;
+        bool canRainbow = ThisElement->canRainbow;
+        bool hasAlpha = ThisElement->hasAlpha;
+        bool sameLine = ThisElement->sameLine;
+        bool Nextcol = ColorSection[i].Nextcol;
+        bool NextLine = ColorSection[i].NextLine;
+        if (Nextcol){
+            Table_NextCol();
+        }
+        if (NextLine){
+            Table_NextLine();
+        }
+        Draw_HelpIcon(Tooltip.c_str());
+        SohImGui::EnhancementColor(Name.c_str(), Cvar.c_str(), ModifiedColor, DefaultColor, canRainbow, hasAlpha, sameLine);
+    }
+}
+void DrawRandomizeResetButton(const std::string Identifier, CosmeticsColorSection* ColorSection, int SectionSize, bool isAllCosmetics = false){
+    std::string TableName = Identifier+"_Table";
+    std::string Col1Name = Identifier+"_Col1";
+    std::string Col2Name = Identifier+"_Col2";
+    std::string Tooltip_RNG = "Affect "+Identifier+" colors";
+    std::string RNG_BtnText = "Randomize : "+Identifier;
+    std::string Reset_BtnText = "Reset : "+Identifier;
+    if (ImGui::BeginTable(TableName.c_str(), 2, FlagsTable)) {
+        ImGui::TableSetupColumn(Col1Name.c_str(), FlagsCell, TablesCellsWidth/2);
+        ImGui::TableSetupColumn(Col2Name.c_str(), FlagsCell, TablesCellsWidth/2);
+        Table_InitHeader(false);
+        if(ImGui::Button(RNG_BtnText.c_str(), ImVec2( ImGui::GetContentRegionAvail().x, 20.0f))){
+            CVar_SetS32("gHudColors", 2);
+            CVar_SetS32("gUseNaviCol", 1);
+            CVar_SetS32("gUseKeeseCol", 1);
+            CVar_SetS32("gUseDogsCol", 1);
+            CVar_SetS32("gUseTunicsCol", 1);
+            CVar_SetS32("gUseArrowsCol", 1);
+            CVar_SetS32("gUseSpellsCol", 1);
+            CVar_SetS32("gUseChargedCol", 1);
+            CVar_SetS32("gUseTrailsCol", 1);
+            CVar_SetS32("gCCparated", 1);
+            GetRandomColorRGB(ColorSection, SectionSize);
+        }
+        SohImGui::Tooltip(Tooltip_RNG.c_str());
+        Table_NextCol();
+        if(ImGui::Button(Reset_BtnText.c_str(), ImVec2( ImGui::GetContentRegionAvail().x, 20.0f))){
+            GetDefaultColorRGB(ColorSection, SectionSize);
+        }
+        SohImGui::Tooltip("Enable/Disable custom Link's tunics colors\nIf disabled you will have original colors for Link's tunics.");
+        SohImGui::Tooltip(Tooltip_RNG.c_str());
+        ImGui::EndTable();
+    }
+}
+
 void Draw_Npcs(){
+    DrawRandomizeResetButton("all NPCs", NPCs_section, SECTION_SIZE(NPCs_section));
     SohImGui::EnhancementCheckbox("Custom colors for Navi", "gUseNaviCol");
     SohImGui::Tooltip("Enable/Disable custom Navi colors\nIf disabled, default colors will be used\nColors go into effect when Navi goes back into your pockets");
-    if (CVar_GetS32("gUseNaviCol",0) && ImGui::BeginTable("tableNavi", 2, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV)) {
-        ImGui::TableSetupColumn("Inner colors##Navi", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort, TablesCellsWidth/2);
-        ImGui::TableSetupColumn("Outer colors##Navi", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort, TablesCellsWidth/2);
+    if (CVar_GetS32("gUseNaviCol",0)) { 
+        DrawRandomizeResetButton("Navi's", Navi_Section, SECTION_SIZE(Navi_Section)); 
+    };
+    if (CVar_GetS32("gUseNaviCol",0) && ImGui::BeginTable("tableNavi", 2, FlagsTable)) {
+        ImGui::TableSetupColumn("Inner colors##Navi", FlagsCell, TablesCellsWidth/2);
+        ImGui::TableSetupColumn("Outer colors##Navi", FlagsCell, TablesCellsWidth/2);
         Table_InitHeader();
-        Draw_HelpIcon("Inner color for Navi (idle flying around)");
-        SohImGui::EnhancementColor("Navi Idle (Primary)", "gNavi_Idle_Inner", navi_idle_i_col, ImVec4(255, 255, 255, 255), false);
-        Table_NextCol();
-        Draw_HelpIcon("Outer color for Navi (idle flying around)");
-        SohImGui::EnhancementColor("Navi Idle (Secondary)", "gNavi_Idle_Outer", navi_idle_o_col, ImVec4(0, 0, 255, 255), false);
-        Table_NextLine();
-        Draw_HelpIcon("Inner color for Navi (when Navi fly around NPCs)");
-        SohImGui::EnhancementColor("Navi NPC (Primary)", "gNavi_NPC_Inner", navi_npc_i_col, ImVec4(150, 150, 255, 255), false);
-        Table_NextCol();
-        Draw_HelpIcon("Outer color for Navi (when Navi fly around NPCs)");
-        SohImGui::EnhancementColor("Navi NPC (Secondary)", "gNavi_NPC_Outer", navi_npc_o_col, ImVec4(150, 150, 255, 255), false);
-        Table_NextLine();
-        Draw_HelpIcon("Inner color for Navi (when Navi fly around Enemies or Bosses)");
-        SohImGui::EnhancementColor("Navi Enemy", "gNavi_Enemy_Inner", navi_enemy_i_col, ImVec4(255, 255, 0, 255), false);
-        Table_NextCol();
-        Draw_HelpIcon("Outer color for Navi (when Navi fly around Enemies or Bosses)");
-        SohImGui::EnhancementColor("Navi Enemy (Secondary)", "gNavi_Enemy_Outer", navi_enemy_o_col, ImVec4(220, 155, 0, 255), false);
-        Table_NextLine();
-        Draw_HelpIcon("Inner color for Navi (when Navi fly around props (signs etc))");
-        SohImGui::EnhancementColor("Navi Prop (Primary)", "gNavi_Prop_Inner", navi_prop_i_col, ImVec4(0, 255, 0, 255), false);
-        Table_NextCol();
-        Draw_HelpIcon("Outer color for Navi (when Navi fly around props (signs etc))");
-        SohImGui::EnhancementColor("Navi Prop (Secondary)", "gNavi_Prop_Outer", navi_prop_o_col, ImVec4(0, 255, 0, 255), false);
+        DrawColorSection(Navi_Section, SECTION_SIZE(Navi_Section));
         ImGui::EndTable();
     }
     SohImGui::EnhancementCheckbox("Custom colors for Keese", "gUseKeeseCol");
     SohImGui::Tooltip("Enable/Disable custom Keese element colors\nIf disabled, default element colors will be used\nColors go into effect when Keese respawn (or when the room is reloaded)");
-    if (CVar_GetS32("gUseKeeseCol",0) && ImGui::BeginTable("tableKeese", 2, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV)) {
-        ImGui::TableSetupColumn("Fire colors##Keese", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort, TablesCellsWidth/2);
-        ImGui::TableSetupColumn("Ice colors##Keese", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort, TablesCellsWidth/2);
-        Table_InitHeader(false);
-        Draw_HelpIcon("Affects the primary color of the Fire itself of the Keese");
-        SohImGui::EnhancementColor("Fire Primary color", "gKeese1_Ef_Prim", Keese1_primcol, ImVec4(255, 255, 100, 255));
-        Table_NextCol();
-        Draw_HelpIcon("Affects the primary color of the Ice itself of the Keese");
-        SohImGui::EnhancementColor("Ice Primary color", "gKeese2_Ef_Prim", Keese2_primcol, ImVec4(100, 200, 255, 255));
-        Table_NextLine();
-        Draw_HelpIcon("Affects the secondary color of the Fire itself of the Keese");
-        SohImGui::EnhancementColor("Fire Secondary color", "gKeese1_Ef_Env", Keese1_envcol, ImVec4(255, 50, 0, 255));
-        Table_NextCol();
-        Draw_HelpIcon("Affects the secondary color of the Ice itself of the Keese");
-        SohImGui::EnhancementColor("Ice Secondary color", "gKeese2_Ef_Env", Keese2_envcol, ImVec4(0, 0, 255, 255));
+    if (CVar_GetS32("gUseKeeseCol",0) && ImGui::BeginTable("tableKeese", 2, FlagsTable)) {
+        ImGui::TableSetupColumn("Fire colors##Keese", FlagsCell, TablesCellsWidth/2);
+        ImGui::TableSetupColumn("Ice colors##Keese", FlagsCell, TablesCellsWidth/2);
+        Table_InitHeader();
+        DrawColorSection(Keese_Section, SECTION_SIZE(Keese_Section));
         ImGui::EndTable();
     }
     SohImGui::EnhancementCheckbox("Custom colors for Dogs", "gUseDogsCol");
     SohImGui::Tooltip("Enable/Disable custom colors for the two Dog variants\nIf disabled, default colors will be used");
-    if (CVar_GetS32("gUseDogsCol",0) && ImGui::BeginTable("tableDogs", 2, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV)) {
-        ImGui::TableSetupColumn("Dog N.1 color", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort, TablesCellsWidth/2);
-        ImGui::TableSetupColumn("Dog N.2 color", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort, TablesCellsWidth/2);
+    if (CVar_GetS32("gUseDogsCol",0) && ImGui::BeginTable("tableDogs", 2, FlagsTable)) {
+        ImGui::TableSetupColumn("White Dog color", FlagsCell, TablesCellsWidth/2);
+        ImGui::TableSetupColumn("Brown Dog color", FlagsCell, TablesCellsWidth/2);
         Table_InitHeader();
-        Draw_HelpIcon("Affects the colors of the white dog");
-        SohImGui::EnhancementColor("Dog white", "gDog1Col", doggo1col, ImVec4(255,255,200,255), true, false, true);
-        Table_NextCol();
-        Draw_HelpIcon("Affects the colors of the brown dog");
-        SohImGui::EnhancementColor("Dog brown", "gDog2Col", doggo2col, ImVec4(150,100,50,255), true, false, true);
+        DrawColorSection(Dogs_Section, SECTION_SIZE(Dogs_Section));
         ImGui::EndTable();
     }
 }
 void Draw_ItemsSkills(){
+    DrawRandomizeResetButton("all skills and items", AllItemsSkills_section, SECTION_SIZE(AllItemsSkills_section));
     SohImGui::EnhancementCheckbox("Custom tunics color", "gUseTunicsCol");
     SohImGui::Tooltip("Enable/Disable custom Link's tunics colors\nIf disabled you will have original colors for Link's tunics.");
-    if (CVar_GetS32("gUseTunicsCol",0) && ImGui::BeginTable("tableTunics", 3, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV)) {
-        ImGui::TableSetupColumn("Kokiri Tunic", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort, TablesCellsWidth/3);
-        ImGui::TableSetupColumn("Goron Tunic", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort, TablesCellsWidth/3);
-        ImGui::TableSetupColumn("Zora Tunic", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort, TablesCellsWidth/3);
+    if (CVar_GetS32("gUseTunicsCol",0)) {
+        DrawRandomizeResetButton("Link's tunics", Tunics_Section, SECTION_SIZE(Tunics_Section));
+    };
+    if (CVar_GetS32("gUseTunicsCol",0) && ImGui::BeginTable("tableTunics", 3, FlagsTable)) {
+        ImGui::TableSetupColumn("Kokiri Tunic", FlagsCell, TablesCellsWidth/3);
+        ImGui::TableSetupColumn("Goron Tunic", FlagsCell, TablesCellsWidth/3);
+        ImGui::TableSetupColumn("Zora Tunic", FlagsCell, TablesCellsWidth/3);
         Table_InitHeader();
-        Draw_HelpIcon("Affects Kokiri Tunic color", false);
-        SohImGui::EnhancementColor("Kokiri Tunic", "gTunic_Kokiri_", kokiri_col, ImVec4(30, 105, 27, 255), true, false, true);
-        Table_NextCol();
-        Draw_HelpIcon("Affects Goron Tunic color", false);
-        SohImGui::EnhancementColor("Goron Tunic", "gTunic_Goron_", goron_col, ImVec4(100, 20, 0, 255), true, false, true);
-        Table_NextCol();
-        Draw_HelpIcon("Affects Zora Tunic color", false);
-        SohImGui::EnhancementColor("Zora Tunic", "gTunic_Zora_", zora_col, ImVec4(0, 60, 100, 255), true, false, true);
+        DrawColorSection(Tunics_Section, SECTION_SIZE(Tunics_Section));
         ImGui::EndTable();
     }
     SohImGui::EnhancementCheckbox("Custom arrows colors", "gUseArrowsCol");
-    if (CVar_GetS32("gUseArrowsCol",0) && ImGui::BeginTable("tableArrows", 2, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV)) {
-        ImGui::TableSetupColumn("Primary colors##Arrows", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort, TablesCellsWidth/2);
-        ImGui::TableSetupColumn("Env colors##Arrows", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort, TablesCellsWidth/2);
+    if (CVar_GetS32("gUseArrowsCol",0)) {
+        DrawRandomizeResetButton("elemental arrows", Arrows_section, SECTION_SIZE(Arrows_section));
+    }
+    if (CVar_GetS32("gUseArrowsCol",0) && ImGui::BeginTable("tableArrows", 2, FlagsTable)) {
+        ImGui::TableSetupColumn("Primary colors##Arrows", FlagsCell, TablesCellsWidth/2);
+        ImGui::TableSetupColumn("Env colors##Arrows", FlagsCell, TablesCellsWidth/2);
         Table_InitHeader();
-        Draw_HelpIcon("Affects Primary color");
-        SohImGui::EnhancementColor("Fire Arrows (primary)", "gFireArrowCol", firearrow_col, ImVec4(255,200,0,255));
-        Table_NextCol();
-        Draw_HelpIcon("Affects Secondary color");
-        SohImGui::EnhancementColor("Fire Arrows", "gFireArrowColEnv", firearrow_colenv, ImVec4(255,0,0,255));
-        Table_NextLine();
-        Draw_HelpIcon("Affects Primary color");
-        SohImGui::EnhancementColor("Ice Arrows (primary)", "gIceArrowCol", icearrow_col, ImVec4(170,255,255,255));
-        Table_NextCol();
-        Draw_HelpIcon("Affects Secondary color");
-        SohImGui::EnhancementColor("Ice Arrows", "gIceArrowColEnv", icearrow_colenv, ImVec4(0,0,255,255));
-        Table_NextLine();
-        Draw_HelpIcon("Affects Primary color");
-        SohImGui::EnhancementColor("Light Arrows (primary)", "gLightArrowCol", lightarrow_col, ImVec4(255,255,170,255));
-        Table_NextCol();
-        Draw_HelpIcon("Affects Secondary color");
-        SohImGui::EnhancementColor("Light Arrows", "gLightArrowColEnv", lightarrow_colenv, ImVec4(255,255,0,255));
+        DrawColorSection(Arrows_section, SECTION_SIZE(Arrows_section));
         ImGui::EndTable();
     }
     SohImGui::EnhancementCheckbox("Custom spells colors", "gUseSpellsCol");
-    if (CVar_GetS32("gUseSpellsCol",0) && ImGui::BeginTable("tableSpells", 2, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV)) {
-        ImGui::TableSetupColumn("Inner colors##Spells", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort, TablesCellsWidth/2);
-        ImGui::TableSetupColumn("Outer colors##Spells", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort, TablesCellsWidth/2);
+    if (CVar_GetS32("gUseSpellsCol",0)) {
+        DrawRandomizeResetButton("spells", Spells_section, SECTION_SIZE(Spells_section));
+    }
+    if (CVar_GetS32("gUseSpellsCol",0) && ImGui::BeginTable("tableSpells", 2, FlagsTable)) {
+        ImGui::TableSetupColumn("Inner colors##Spells", FlagsCell, TablesCellsWidth/2);
+        ImGui::TableSetupColumn("Outer colors##Spells", FlagsCell, TablesCellsWidth/2);
         Table_InitHeader();
-        Draw_HelpIcon("Affects Primary color");
-        SohImGui::EnhancementColor("Din's Fire (primary)", "gDF_Col", df_col, ImVec4(255,200,0,255));
-        Table_NextCol();
-        Draw_HelpIcon("Affects Secondary color");
-        SohImGui::EnhancementColor("Din's Fire", "gDF_Env", df_colenv, ImVec4(255,0,0,255));
-        Table_NextLine();
-        Draw_HelpIcon("Affects Primary color");
-        SohImGui::EnhancementColor("Nayru's Love Diamond (primary)", "gNL_Diamond_Col", nl_diam_col, ImVec4(170,255,255,255));
-        Table_NextCol();
-        Draw_HelpIcon("Affects Secondary color");
-        SohImGui::EnhancementColor("Nayru's Love Diamond", "gNL_Diamond_Env", nl_diam_colenv, ImVec4(100,255,128,255));
-        Table_NextLine();
-        Draw_HelpIcon("Affects Primary color");
-        SohImGui::EnhancementColor("Nayru's Love Orb (primary)", "gNL_Orb_Col", nl_orb_col, ImVec4(170,255,255,255));
-        Table_NextCol();
-        Draw_HelpIcon("Affects Secondary color");
-        SohImGui::EnhancementColor("Nayru's Love Orb", "gNL_Orb_Env", nl_orb_colenv, ImVec4(150,255,255,255));
+        DrawColorSection(Spells_section, SECTION_SIZE(Spells_section));
         ImGui::EndTable();
     }
     SohImGui::EnhancementCheckbox("Custom spin attack colors", "gUseChargedCol");
-    if (CVar_GetS32("gUseChargedCol",0) && ImGui::BeginTable("tableChargeAtk", 2, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV)) {
-        ImGui::TableSetupColumn("Primary colors##Charge", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort, TablesCellsWidth/2);
-        ImGui::TableSetupColumn("Env colors##Charge", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort, TablesCellsWidth/2);
+    if (CVar_GetS32("gUseChargedCol",0)) {
+        DrawRandomizeResetButton("spins attack", SpinAtk_section, SECTION_SIZE(SpinAtk_section));
+    }
+    if (CVar_GetS32("gUseChargedCol",0) && ImGui::BeginTable("tableChargeAtk", 2, FlagsTable)) {
+        ImGui::TableSetupColumn("Primary colors##Charge", FlagsCell, TablesCellsWidth/2);
+        ImGui::TableSetupColumn("Env colors##Charge", FlagsCell, TablesCellsWidth/2);
         Table_InitHeader();
-        Draw_HelpIcon("Affects Primary color");
-        SohImGui::EnhancementColor("Level 1 color (primary)", "gCharged1Col", charged1_col, ImVec4(170,255,255,255));
-        Table_NextCol();
-        Draw_HelpIcon("Affects Secondary color");
-        SohImGui::EnhancementColor("Level 1 color", "gCharged1ColEnv", charged1_colenv, ImVec4(0,100,255,255));
-        Table_NextLine();
-        Draw_HelpIcon("Affects Primary color");
-        SohImGui::EnhancementColor("Level 2 color (primary)", "gCharged2Col", charged2_col, ImVec4(255,255,170,255));
-        Table_NextCol();
-        Draw_HelpIcon("Affects Secondary color");
-        SohImGui::EnhancementColor("Level 2 color", "gCharged2ColEnv", charged2_colenv, ImVec4(255,100,0,255));
+        DrawColorSection(SpinAtk_section, SECTION_SIZE(SpinAtk_section));
         ImGui::EndTable();
     }
     SohImGui::EnhancementCheckbox("Custom trails color", "gUseTrailsCol");
-    if (CVar_GetS32("gUseTrailsCol",0) && ImGui::BeginTable("tabletrails", 1, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV)) {
-        ImGui::TableSetupColumn("Custom Trails", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort, TablesCellsWidth);
+    if (CVar_GetS32("gUseTrailsCol",0) && ImGui::BeginTable("tabletrails", 1, FlagsTable)) {
+        ImGui::TableSetupColumn("Custom Trails", FlagsCell, TablesCellsWidth);
         Table_InitHeader();
-        Draw_HelpIcon("Affects Swords slash, boomerang and Bombchu trails color");
-        SohImGui::EnhancementColor("Trails color", "gTrailCol", trailscol, ImVec4(255,255,255,255));
+        DrawColorSection(Trails_section, SECTION_SIZE(Trails_section));
         SohImGui::EnhancementSliderInt("Trails duration: %dx", "##TrailsMul", "gTrailDurantion", 1, 5, "");
         SohImGui::Tooltip("The longer the trails the weirder it become");
         ImGui::NewLine();
@@ -379,48 +441,20 @@ void Draw_ItemsSkills(){
 }
 void Draw_Menus(){
     if (CVar_GetS32("gHudColors",0) ==2 ){
-        if (ImGui::BeginTable("tableFileChoose", 2, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV)) {
-            ImGui::TableSetupColumn("File Choose color", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort, TablesCellsWidth/2);
-            ImGui::TableSetupColumn("Bottom text color", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort, TablesCellsWidth/2);
+        if (ImGui::BeginTable("tableFileChoose", 2, FlagsTable)) {
+            ImGui::TableSetupColumn("File Choose color", FlagsCell, TablesCellsWidth/2);
+            ImGui::TableSetupColumn("Bottom text color", FlagsCell, TablesCellsWidth/2);
             Table_InitHeader();
-            Draw_HelpIcon("Affects the File Select menu background.");
-            SohImGui::EnhancementColor("File Choose color", "gCCFileChoosePrim", fileselect_colors, ImVec4(100, 150, 255, 255), true, false, true);
-            Table_NextCol();
-            Draw_HelpIcon("Affects the File Select texts.");
-            SohImGui::EnhancementColor("Bottom text color", "gCCFileChooseTextPrim", fileselect_text_colors, ImVec4(100, 255, 255, 255), true, false, true);
+            DrawColorSection(FileChoose_section, SECTION_SIZE(FileChoose_section));
             ImGui::EndTable();
         }
-        /*
-        if (ImGui::BeginTable("tablePauseMenu", 1, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV)) {
-            ImGui::TableSetupColumn("Kaleido pages (Non working atm)", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort, TablesCellsWidth);
-            Table_InitHeader();
-            Draw_HelpIcon("Affect the Equipments menu background.");
-            SohImGui::EnhancementColor("Equipments", "gCCEquipmentsPrim", menu_equips_colors, ImVec4(0, 100, 255, 255), true, true);
-            Table_NextLine();
-            Draw_HelpIcon("Affect the Select items menu background.");
-            SohImGui::EnhancementColor("Items", "gCCItemsPrim", menu_items_colors, ImVec4(0, 100, 255, 255), true, true);
-            Table_NextLine();
-            Draw_HelpIcon("Affect the Map menu background.");
-            SohImGui::EnhancementColor("Maps", "gCCMapsPrim", menu_map_colors, ImVec4(0, 100, 255, 255), true, true);
-            Table_NextLine();
-            Draw_HelpIcon("Affect the Quests statut menu background.");
-            SohImGui::EnhancementColor("Quests", "gCCQuestsPrim", menu_quest_colors, ImVec4(0, 100, 255, 255), true, true);
-            Table_NextLine();
-            Draw_HelpIcon("Affect the Save menu background.");
-            SohImGui::EnhancementColor("Save", "gCCSavePrim", menu_save_colors, ImVec4(0, 100, 255, 255), true, true);
-            Table_NextLine();
-            Draw_HelpIcon("Affect the Gameover screen background.");
-            SohImGui::EnhancementColor("Gameover", "gCCGameoverPrim", menu_gameover_colors, ImVec4(0, 100, 255, 255), true, true);
-            ImGui::EndTable();
-        }
-        */
     } else {
         ImGui::Text("To modify menus colors you need \"Custom Colors\" scheme\nto be selected in \"General\" tab.\nOnce enabled you will be able to modify the following colors:\nFile Choose color\nBottom text color");
     }
 }
 void Draw_Placements(){
-    if (ImGui::BeginTable("tableMargins", 1, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV)) {
-        ImGui::TableSetupColumn("General margins settings", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort, TablesCellsWidth);
+    if (ImGui::BeginTable("tableMargins", 1, FlagsTable)) {
+        ImGui::TableSetupColumn("General margins settings", FlagsCell, TablesCellsWidth);
         Table_InitHeader();
         SohImGui::EnhancementSliderInt("Top : %dx", "##UIMARGINT", "gHUDMargin_T", (ImGui::GetWindowViewport()->Size.y/2)*-1, 25, "", 0, true);
         SohImGui::EnhancementSliderInt("Left: %dx", "##UIMARGINL", "gHUDMargin_L", -25, ImGui::GetWindowViewport()->Size.x, "", 0, true);
@@ -438,174 +472,90 @@ void Draw_Placements(){
         ImGui::EndTable();
     }
     if (ImGui::CollapsingHeader("Hearts count position")) {
-        if (ImGui::BeginTable("tableHeartsCounts", 1, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV)) {
-            ImGui::TableSetupColumn("Hearts counts settings", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort, TablesCellsWidth);
+        if (ImGui::BeginTable("tableHeartsCounts", 1, FlagsTable)) {
+            ImGui::TableSetupColumn("Hearts counts settings", FlagsCell, TablesCellsWidth);
             Table_InitHeader(false);
-            SohImGui::EnhancementCheckbox("Hearts count use margins", "gHeartsUseMargins");
-            SohImGui::Tooltip("This will use original intended elements position.");
-            SohImGui::EnhancementRadioButton("Original position", "gHeartsCountPosType", 0);
-            SohImGui::Tooltip("This will use original intended elements position.");
-            SohImGui::EnhancementRadioButton("Anchor to the left", "gHeartsCountPosType", 1);
-            SohImGui::Tooltip("This will make your elements follow the left side of your game window.");
-            SohImGui::EnhancementRadioButton("Anchor to the right", "gHeartsCountPosType", 2);
-            SohImGui::Tooltip("This will make your elements follow the right side of your game window.");
-            SohImGui::EnhancementRadioButton("No anchors", "gHeartsCountPosType", 3);
-            SohImGui::Tooltip("This will make your elements to not follow any side\nBetter used for center elements.");
-            SohImGui::EnhancementRadioButton("Hidden", "gHeartsCountPosType", 4);
-            SohImGui::Tooltip("This will make your elements hidden");
-            SohImGui::EnhancementSliderInt("Up <-> Down : %d", "##HeartCountPosY", "gHeartsPosY", -22, ImGui::GetWindowViewport()->Size.y, "", 0, true);
-            SohImGui::Tooltip("This slider is used to move Up and Down your elements.");
-            SohImGui::EnhancementSliderInt("Left <-> Right : %d", "##HeartCountPosX", "gHeartsPosX", -25, ImGui::GetWindowViewport()->Size.x, "", 0, true);
-            SohImGui::Tooltip("This slider is used to move Left and Right your elements.");
+            DrawUseMarginsSlider("Hearts counts", "gHearts");
+            DrawPositionsRadioBoxes("gHeartsCount");
+            DrawPositionSlider("gHeartsCount",-22,ImGui::GetWindowViewport()->Size.y,-25,ImGui::GetWindowViewport()->Size.x);
+            DrawScaleSlider("gHeartsCount",0.7f);
             ImGui::NewLine();
             ImGui::EndTable();
         }
     }
     if (ImGui::CollapsingHeader("Magic Meter position")) {
-        if (ImGui::BeginTable("tablemmpos", 1, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV)) {
-            ImGui::TableSetupColumn("Magic meter settings", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort, TablesCellsWidth);
+        if (ImGui::BeginTable("tablemmpos", 1, FlagsTable)) {
+            ImGui::TableSetupColumn("Magic meter settings", FlagsCell, TablesCellsWidth);
             Table_InitHeader(false);
-            SohImGui::EnhancementCheckbox("Magic meter use margins", "gMagicBarUseMargins");
-            SohImGui::Tooltip("This will use original intended elements position.");
-            SohImGui::EnhancementRadioButton("Original position", "gMagicBarPosType", 0);
-            SohImGui::Tooltip("This will use original intended elements position.");
-            SohImGui::EnhancementRadioButton("Anchor to the left", "gMagicBarPosType", 1);
-            SohImGui::Tooltip("This will make your elements follow the left side of your game window.");
-            SohImGui::EnhancementRadioButton("Anchor to the right", "gMagicBarPosType", 2);
-            SohImGui::Tooltip("This will make your elements follow the right side of your game window.");
-            SohImGui::EnhancementRadioButton("No anchors", "gMagicBarPosType", 3);
-            SohImGui::Tooltip("This will make your elements to not follow any side\nBetter used for center elements.");
-            SohImGui::EnhancementRadioButton("Hidden", "gMagicBarPosType", 4);
-            SohImGui::Tooltip("This will make your elements hidden");
-            SohImGui::EnhancementSliderInt("Up <-> Down : %d", "##MagicBarPosY", "gMagicBarPosY", 0, ImGui::GetWindowViewport()->Size.y/2, "", 0, true);
-            SohImGui::Tooltip("This slider is used to move Up and Down your elements.");
-            SohImGui::EnhancementSliderInt("Left <-> Right : %d", "##MagicBarPosX", "gMagicBarPosX", -5, ImGui::GetWindowViewport()->Size.x/2, "", 0, true);
-            SohImGui::Tooltip("This slider is used to move Left and Right your elements.");
+            DrawUseMarginsSlider("Magic meter", "gMagicBar");
+            DrawPositionsRadioBoxes("gMagicBar");
+            DrawPositionSlider("gMagicBar", 0, ImGui::GetWindowViewport()->Size.y/2, -5, ImGui::GetWindowViewport()->Size.x/2);
+            DrawScaleSlider("gMagicBar",1.0f);
             ImGui::NewLine();
             ImGui::EndTable();
         }
     }
     if (CVar_GetS32("gVisualAgony",0) && ImGui::CollapsingHeader("Visual stone of agony position")) {
-        if (ImGui::BeginTable("tabledvisualstoneofagony", 1, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV)) {
-            ImGui::TableSetupColumn("Visual stone of agony settings", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort, TablesCellsWidth);
+        if (ImGui::BeginTable("tabledvisualstoneofagony", 1, FlagsTable)) {
+            ImGui::TableSetupColumn("Visual stone of agony settings", FlagsCell, TablesCellsWidth);
             Table_InitHeader(false);
-            SohImGui::EnhancementCheckbox("Visual stone of agony use margins", "gVSOAUseMargins");
-            SohImGui::Tooltip("This will use original intended elements position.");
-            SohImGui::EnhancementRadioButton("Original position", "gVSOAPosType", 0);
-            SohImGui::Tooltip("This will use original intended elements position.");
-            SohImGui::EnhancementRadioButton("Anchor to the left", "gVSOAPosType", 1);
-            SohImGui::Tooltip("This will make your elements follow the left side of your game window.");
-            SohImGui::EnhancementRadioButton("Anchor to the right", "gVSOAPosType", 2);
-            SohImGui::Tooltip("This will make your elements follow the right side of your game window.");
-            SohImGui::EnhancementRadioButton("No anchors", "gVSOAPosType", 3);
-            SohImGui::Tooltip("This will make your elements to not follow any side\nBetter used for center elements.");
-            SohImGui::EnhancementRadioButton("Hidden", "gVSOAPosType", 4); //in case you want only SFX
-            SohImGui::Tooltip("This will make your elements hidden");
-            SohImGui::EnhancementSliderInt("Up <-> Down : %d", "##VSOAPosY", "gVSOAPosY", 0, ImGui::GetWindowViewport()->Size.y/2, "", 0, true);
-            SohImGui::Tooltip("This slider is used to move Up and Down your elements.");
-            s16 Min_X_Dpad = 0;
-            s16 Max_X_Dpad = ImGui::GetWindowViewport()->Size.x/2;
+            DrawUseMarginsSlider("Visual stone of agony", "gVSOA");
+            DrawPositionsRadioBoxes("gVSOA");
+            s16 Min_X_VSOA = 0;
+            s16 Max_X_VSOA = ImGui::GetWindowViewport()->Size.x/2;
             if(CVar_GetS32("gVSOAPosType",0) == 2){
-                Max_X_Dpad = 290;
+                Max_X_VSOA = 290;
             } else if(CVar_GetS32("gVSOAPosType",0) == 4){
-                Min_X_Dpad = (ImGui::GetWindowViewport()->Size.x/2)*-1;
+                Min_X_VSOA = (ImGui::GetWindowViewport()->Size.x/2)*-1;
             }
-            SohImGui::EnhancementSliderInt("Left <-> Right : %d", "##VSOAPosX", "gVSOAPosX", Min_X_Dpad, Max_X_Dpad, "", 0, true);
-            SohImGui::Tooltip("This slider is used to move Left and Right your elements.");
+            DrawPositionSlider("gVSOA", 0, ImGui::GetWindowViewport()->Size.y/2, Min_X_VSOA, Max_X_VSOA);
+            DrawScaleSlider("gVSOA",1.0f);
             ImGui::NewLine();
             ImGui::EndTable();
         }
     }
     if (ImGui::CollapsingHeader("B Button position")) {
-        if (ImGui::BeginTable("tablebbtn", 1, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV)) {
-            ImGui::TableSetupColumn("B Button settings", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort, TablesCellsWidth);
+        if (ImGui::BeginTable("tablebbtn", 1, FlagsTable)) {
+            ImGui::TableSetupColumn("B Button settings", FlagsCell, TablesCellsWidth);
             Table_InitHeader(false);
-            SohImGui::EnhancementCheckbox("B Button use margins", "gBBtnUseMargins");
-            SohImGui::Tooltip("This will use original intended elements position.");
-            SohImGui::EnhancementRadioButton("Original position", "gBBtnPosType", 0);
-            SohImGui::Tooltip("This will use original intended elements position.");
-            SohImGui::EnhancementRadioButton("Anchor to the left", "gBBtnPosType", 1);
-            SohImGui::Tooltip("This will make your elements follow the left side of your game window.");
-            SohImGui::EnhancementRadioButton("Anchor to the right", "gBBtnPosType", 2);
-            SohImGui::Tooltip("This will make your elements follow the right side of your game window.");
-            SohImGui::EnhancementRadioButton("No anchors", "gBBtnPosType", 3);
-            SohImGui::Tooltip("This will make your elements to not follow any side\nBetter used for center elements.");
-            SohImGui::EnhancementRadioButton("Hidden", "gBBtnPosType", 4);
-            SohImGui::Tooltip("This will make your elements hidden");
-            SohImGui::EnhancementSliderInt("Up <-> Down : %d", "##BBtnPosY", "gBBtnPosY", 0, ImGui::GetWindowViewport()->Size.y/4+50, "", 0, true);
-            SohImGui::Tooltip("This slider is used to move Up and Down your elements.");
-            SohImGui::EnhancementSliderInt("Left <-> Right : %d", "##BBtnPosX", "gBBtnPosX", -1, ImGui::GetWindowViewport()->Size.x-50, "", 0, true);
-            SohImGui::Tooltip("This slider is used to move Left and Right your elements.");
+            DrawUseMarginsSlider("B Button", "gBBtn");
+            DrawPositionsRadioBoxes("gBBtn");
+            DrawPositionSlider("gBBtn", 0, ImGui::GetWindowViewport()->Size.y/4+50, -1, ImGui::GetWindowViewport()->Size.x-50);
+            DrawScaleSlider("gBBtn",0.95f);
             ImGui::NewLine();
             ImGui::EndTable();
         }
     }
     if (ImGui::CollapsingHeader("A Button position")) {
-        if (ImGui::BeginTable("tableabtn", 1, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV)) {
-            ImGui::TableSetupColumn("A Button settings", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort, TablesCellsWidth);
+        if (ImGui::BeginTable("tableabtn", 1, FlagsTable)) {
+            ImGui::TableSetupColumn("A Button settings", FlagsCell, TablesCellsWidth);
             Table_InitHeader(false);
-            SohImGui::EnhancementCheckbox("A Button use margins", "gABtnUseMargins");
-            SohImGui::Tooltip("This will use original intended elements position.");
-            SohImGui::EnhancementRadioButton("Original position", "gABtnPosType", 0);
-            SohImGui::Tooltip("This will use original intended elements position.");
-            SohImGui::EnhancementRadioButton("Anchor to the left", "gABtnPosType", 1);
-            SohImGui::Tooltip("This will make your elements follow the left side of your game window.");
-            SohImGui::EnhancementRadioButton("Anchor to the right", "gABtnPosType", 2);
-            SohImGui::Tooltip("This will make your elements follow the right side of your game window.");
-            SohImGui::EnhancementRadioButton("No anchors", "gABtnPosType", 3);
-            SohImGui::Tooltip("This will make your elements to not follow any side\nBetter used for center elements.");
-            SohImGui::EnhancementRadioButton("Hidden", "gABtnPosType", 4);
-            SohImGui::Tooltip("This will make your elements hidden");
-            SohImGui::EnhancementSliderInt("Up <-> Down : %d", "##ABtnPosY", "gABtnPosY", -10, ImGui::GetWindowViewport()->Size.y/4+50, "", 0, true);
-            SohImGui::Tooltip("This slider is used to move Up and Down your elements.");
-            SohImGui::EnhancementSliderInt("Left <-> Right : %d", "##ABtnPosX", "gABtnPosX", -20, ImGui::GetWindowViewport()->Size.x-50, "", 0, true);
-            SohImGui::Tooltip("This slider is used to move Left and Right your elements.");
+            DrawUseMarginsSlider("A Button", "gABtn");
+            DrawPositionsRadioBoxes("gABtn");
+            DrawPositionSlider("gABtn", -10, ImGui::GetWindowViewport()->Size.y/4+50, -20, ImGui::GetWindowViewport()->Size.x-50);
+            DrawScaleSlider("gABtn",0.95f);
             ImGui::NewLine();
             ImGui::EndTable();
         }
     }
     if (ImGui::CollapsingHeader("Start Button position")) {
-        if (ImGui::BeginTable("tablestartbtn", 1, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV)) {
-            ImGui::TableSetupColumn("Start Button settings", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort, TablesCellsWidth);
+        if (ImGui::BeginTable("tablestartbtn", 1, FlagsTable)) {
+            ImGui::TableSetupColumn("Start Button settings", FlagsCell, TablesCellsWidth);
             Table_InitHeader(false);
-            SohImGui::EnhancementCheckbox("Start Button use margins", "gStartBtnUseMargins");
-            SohImGui::Tooltip("This will use original intended elements position.");
-            SohImGui::EnhancementRadioButton("Original position", "gStartBtnPosType", 0);
-            SohImGui::Tooltip("This will use original intended elements position.");
-            SohImGui::EnhancementRadioButton("Anchor to the left", "gStartBtnPosType", 1);
-            SohImGui::Tooltip("This will make your elements follow the left side of your game window.");
-            SohImGui::EnhancementRadioButton("Anchor to the right", "gStartBtnPosType", 2);
-            SohImGui::Tooltip("This will make your elements follow the right side of your game window.");
-            SohImGui::EnhancementRadioButton("No anchors", "gStartBtnPosType", 3);
-            SohImGui::Tooltip("This will make your elements to not follow any side\nBetter used for center elements.");
-            SohImGui::EnhancementRadioButton("Hidden", "gStartBtnPosType", 4);
-            SohImGui::Tooltip("This will make your elements hidden");
-            SohImGui::EnhancementSliderInt("Up <-> Down : %d", "##StartBtnPosY", "gStartBtnPosY", 0, ImGui::GetWindowViewport()->Size.y/2, "", 0, true);
-            SohImGui::Tooltip("This slider is used to move Up and Down your elements.");
-            SohImGui::EnhancementSliderInt("Left <-> Right : %d", "##StartBtnPosX", "gStartBtnPosX", 0, ImGui::GetWindowViewport()->Size.x/2+70, "", 0, true);
-            SohImGui::Tooltip("This slider is used to move Left and Right your elements.");
+            DrawUseMarginsSlider("Start Button", "gStartBtn");
+            DrawPositionsRadioBoxes("gStartBtn");
+            DrawPositionSlider("gStartBtn", 0, ImGui::GetWindowViewport()->Size.y/2, 0, ImGui::GetWindowViewport()->Size.x/2+70);
+            DrawScaleSlider("gStartBtn",0.75f);
             ImGui::NewLine();
             ImGui::EndTable();
         }
     }
     if (ImGui::CollapsingHeader("C Button Up position")) {
-        if (ImGui::BeginTable("tablecubtn", 1, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV)) {
-            ImGui::TableSetupColumn("C Button Up settings", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort, TablesCellsWidth);
+        if (ImGui::BeginTable("tablecubtn", 1, FlagsTable)) {
+            ImGui::TableSetupColumn("C Button Up settings", FlagsCell, TablesCellsWidth);
             Table_InitHeader(false);
-            SohImGui::EnhancementCheckbox("C Button Up use margins", "gCBtnUUseMargins");
-            SohImGui::Tooltip("This will use original intended elements position.");
-            SohImGui::EnhancementRadioButton("Original position", "gCBtnUPosType", 0);
-            SohImGui::Tooltip("This will use original intended elements position.");
-            SohImGui::EnhancementRadioButton("Anchor to the left", "gCBtnUPosType", 1);
-            SohImGui::Tooltip("This will make your elements follow the left side of your game window.");
-            SohImGui::EnhancementRadioButton("Anchor to the right", "gCBtnUPosType", 2);
-            SohImGui::Tooltip("This will make your elements follow the right side of your game window.");
-            SohImGui::EnhancementRadioButton("No anchors", "gCBtnUPosType", 3);
-            SohImGui::Tooltip("This will make your elements to not follow any side\nBetter used for center elements.");
-            SohImGui::EnhancementRadioButton("Hidden", "gCBtnUPosType", 4);
-            SohImGui::Tooltip("This will make your elements hidden");
-            SohImGui::EnhancementSliderInt("Up <-> Down : %d", "##CBtnUPosY", "gCBtnUPosY", 0, ImGui::GetWindowViewport()->Size.y/2, "", 0, true);
-            SohImGui::Tooltip("This slider is used to move Up and Down your elements.");
+            DrawUseMarginsSlider("C Button Up", "gCBtnU");
+            DrawPositionsRadioBoxes("gCBtnU");
             s16 Min_X_CU = 0;
             s16 Max_X_CU = ImGui::GetWindowViewport()->Size.x/2;
             if(CVar_GetS32("gCBtnUPosType",0) == 2){
@@ -615,30 +565,18 @@ void Draw_Placements(){
             } else if(CVar_GetS32("gCBtnUPosType",0) == 4){
                 Min_X_CU = (ImGui::GetWindowViewport()->Size.x/2)*-1;
             }
-            SohImGui::EnhancementSliderInt("Left <-> Right : %d", "##CBtnUPosX", "gCBtnUPosX", Min_X_CU, Max_X_CU, "", 0, true);
-            SohImGui::Tooltip("This slider is used to move Left and Right your elements.");
+            DrawPositionSlider("gCBtnU", 0, ImGui::GetWindowViewport()->Size.y/2, Min_X_CU, Max_X_CU);
+            DrawScaleSlider("gCBtnU",0.5f);
             ImGui::NewLine();
             ImGui::EndTable();
         }
     }
     if (ImGui::CollapsingHeader("C Button Down position")) {
-        if (ImGui::BeginTable("tablecdbtn", 1, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV)) {
-            ImGui::TableSetupColumn("C Button Down settings", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort, TablesCellsWidth);
+        if (ImGui::BeginTable("tablecdbtn", 1, FlagsTable)) {
+            ImGui::TableSetupColumn("C Button Down settings", FlagsCell, TablesCellsWidth);
             Table_InitHeader(false);
-            SohImGui::EnhancementCheckbox("C Button Down use margins", "gCBtnDUseMargins");
-            SohImGui::Tooltip("This will use original intended elements position.");
-            SohImGui::EnhancementRadioButton("Original position", "gCBtnDPosType", 0);
-            SohImGui::Tooltip("This will use original intended elements position.");
-            SohImGui::EnhancementRadioButton("Anchor to the left", "gCBtnDPosType", 1);
-            SohImGui::Tooltip("This will make your elements follow the left side of your game window.");
-            SohImGui::EnhancementRadioButton("Anchor to the right", "gCBtnDPosType", 2);
-            SohImGui::Tooltip("This will make your elements follow the right side of your game window.");
-            SohImGui::EnhancementRadioButton("No anchors", "gCBtnDPosType", 3);
-            SohImGui::Tooltip("This will make your elements to not follow any side\nBetter used for center elements.");
-            SohImGui::EnhancementRadioButton("Hidden", "gCBtnDPosType", 4);
-            SohImGui::Tooltip("This will make your elements hidden");
-            SohImGui::EnhancementSliderInt("Up <-> Down : %d", "##CBtnDPosY", "gCBtnDPosY", 0, ImGui::GetWindowViewport()->Size.y/2, "", 0, true);
-            SohImGui::Tooltip("This slider is used to move Up and Down your elements.");
+            DrawUseMarginsSlider("C Button Down", "gCBtnD");
+            DrawPositionsRadioBoxes("gCBtnD");
             s16 Min_X_CD = 0;
             s16 Max_X_CD = ImGui::GetWindowViewport()->Size.x/2;
             if(CVar_GetS32("gCBtnDPosType",0) == 2){
@@ -648,63 +586,39 @@ void Draw_Placements(){
             } else if(CVar_GetS32("gCBtnDPosType",0) == 4){
                 Min_X_CD = (ImGui::GetWindowViewport()->Size.x/2)*-1;
             }
-            SohImGui::EnhancementSliderInt("Left <-> Right : %d", "##CBtnDPosX", "gCBtnDPosX", Min_X_CD, Max_X_CD, "", 0, true);
-            SohImGui::Tooltip("This slider is used to move Left and Right your elements.");
+            DrawPositionSlider("gCBtnD", 0, ImGui::GetWindowViewport()->Size.y/2, Min_X_CD, Max_X_CD);
+            DrawScaleSlider("gCBtnD",0.87f);
             ImGui::NewLine();
             ImGui::EndTable();
         }
     }
     if (ImGui::CollapsingHeader("C Button Left position")) {
-        if (ImGui::BeginTable("tableclbtn", 1, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV)) {
-            ImGui::TableSetupColumn("C Button Left settings", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort, TablesCellsWidth);
+        if (ImGui::BeginTable("tableclbtn", 1, FlagsTable)) {
+            ImGui::TableSetupColumn("C Button Left settings", FlagsCell, TablesCellsWidth);
             Table_InitHeader(false);
-            SohImGui::EnhancementCheckbox("C Button Left use margins", "gCBtnLUseMargins");
-            SohImGui::Tooltip("This will use original intended elements position.");
-            SohImGui::EnhancementRadioButton("Original position", "gCBtnLPosType", 0);
-            SohImGui::Tooltip("This will use original intended elements position.");
-            SohImGui::EnhancementRadioButton("Anchor to the left", "gCBtnLPosType", 1);
-            SohImGui::Tooltip("This will make your elements follow the left side of your game window.");
-            SohImGui::EnhancementRadioButton("Anchor to the right", "gCBtnLPosType", 2);
-            SohImGui::Tooltip("This will make your elements follow the right side of your game window.");
-            SohImGui::EnhancementRadioButton("No anchors", "gCBtnLPosType", 3);
-            SohImGui::Tooltip("This will make your elements to not follow any side\nBetter used for center elements.");
-            SohImGui::EnhancementRadioButton("Hidden", "gCBtnLPosType", 4);
-            SohImGui::Tooltip("This will make your elements hidden");
-            SohImGui::EnhancementSliderInt("Up <-> Down : %d", "##CBtnLPosY", "gCBtnLPosY", 0, ImGui::GetWindowViewport()->Size.y/2, "", 0, true);
-            SohImGui::Tooltip("This slider is used to move Up and Down your elements.");
+            DrawUseMarginsSlider("C Button Left", "gCBtnL");
+            DrawPositionsRadioBoxes("gCBtnL");
             s16 Min_X_CL = 0;
             s16 Max_X_CL = ImGui::GetWindowViewport()->Size.x/2;
-            if(CVar_GetS32("gCBtnDPosType",0) == 2){
+            if(CVar_GetS32("gCBtnLPosType",0) == 2){
                 Max_X_CL = 294;
-            } else if(CVar_GetS32("gCBtnDPosType",0) == 3){
+            } else if(CVar_GetS32("gCBtnLPosType",0) == 3){
                 Max_X_CL = ImGui::GetWindowViewport()->Size.x/2;
-            } else if(CVar_GetS32("gCBtnDPosType",0) == 4){
+            } else if(CVar_GetS32("gCBtnLPosType",0) == 4){
                 Min_X_CL = (ImGui::GetWindowViewport()->Size.x/2)*-1;
             }
-            SohImGui::EnhancementSliderInt("Left <-> Right : %d", "##CBtnLPosX", "gCBtnLPosX", Min_X_CL, Max_X_CL, "", 0, true);
-            SohImGui::Tooltip("This slider is used to move Left and Right your elements.");
+            DrawPositionSlider("gCBtnL", 0, ImGui::GetWindowViewport()->Size.y/2, Min_X_CL, Max_X_CL);
+            DrawScaleSlider("gCBtnL",0.87f);
             ImGui::NewLine();
             ImGui::EndTable();
         }
     }
     if (ImGui::CollapsingHeader("C Button Right position")) {
-        if (ImGui::BeginTable("tablecrnbtn", 1, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV)) {
-            ImGui::TableSetupColumn("C Button Right settings", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort, TablesCellsWidth);
+        if (ImGui::BeginTable("tablecrnbtn", 1, FlagsTable)) {
+            ImGui::TableSetupColumn("C Button Right settings", FlagsCell, TablesCellsWidth);
             Table_InitHeader(false);
-            SohImGui::EnhancementCheckbox("C Button Right use margins", "gCBtnRUseMargins");
-            SohImGui::Tooltip("This will use original intended elements position.");
-            SohImGui::EnhancementRadioButton("Original position", "gCBtnRPosType", 0);
-            SohImGui::Tooltip("This will use original intended elements position.");
-            SohImGui::EnhancementRadioButton("Anchor to the left", "gCBtnRPosType", 1);
-            SohImGui::Tooltip("This will make your elements follow the left side of your game window.");
-            SohImGui::EnhancementRadioButton("Anchor to the right", "gCBtnRPosType", 2);
-            SohImGui::Tooltip("This will make your elements follow the right side of your game window.");
-            SohImGui::EnhancementRadioButton("No anchors", "gCBtnRPosType", 3);
-            SohImGui::Tooltip("This will make your elements to not follow any side\nBetter used for center elements.");
-            SohImGui::EnhancementRadioButton("Hidden", "gCBtnRPosType", 4);
-            SohImGui::Tooltip("This will make your elements hidden");
-            SohImGui::EnhancementSliderInt("Up <-> Down : %d", "##CBtnRPosY", "gCBtnRPosY", 0, ImGui::GetWindowViewport()->Size.y/2, "", 0, true);
-            SohImGui::Tooltip("This slider is used to move Up and Down your elements.");
+            DrawUseMarginsSlider("C Button Right", "gCBtnR");
+            DrawPositionsRadioBoxes("gCBtnR");
             s16 Min_X_CR = 0;
             s16 Max_X_CR = ImGui::GetWindowViewport()->Size.x/2;
             if(CVar_GetS32("gCBtnRPosType",0) == 2){
@@ -714,30 +628,18 @@ void Draw_Placements(){
             } else if(CVar_GetS32("gCBtnRPosType",0) == 4){
                 Min_X_CR = (ImGui::GetWindowViewport()->Size.x/2)*-1;
             }
-            SohImGui::EnhancementSliderInt("Left <-> Right : %d", "##CBtnRPosX", "gCBtnRPosX", Min_X_CR, Max_X_CR, "", 0, true);
-            SohImGui::Tooltip("This slider is used to move Left and Right your elements.");
+            DrawPositionSlider("gCBtnR", 0, ImGui::GetWindowViewport()->Size.y/2, Min_X_CR, Max_X_CR);
+            DrawScaleSlider("gCBtnR",0.87f);
             ImGui::NewLine();
             ImGui::EndTable();
         }
     }
     if (CVar_GetS32("gDpadEquips",0) && ImGui::CollapsingHeader("DPad items position")) {
-        if (ImGui::BeginTable("tabledpaditems", 1, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV)) {
-            ImGui::TableSetupColumn("DPad items settings", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort, TablesCellsWidth);
+        if (ImGui::BeginTable("tabledpaditems", 1, FlagsTable)) {
+            ImGui::TableSetupColumn("DPad items settings", FlagsCell, TablesCellsWidth);
             Table_InitHeader(false);
-            SohImGui::EnhancementCheckbox("DPad items use margins", "gDPadUseMargins");
-            SohImGui::Tooltip("This will use original intended elements position.");
-            SohImGui::EnhancementRadioButton("Original position", "gDPadPosType", 0);
-            SohImGui::Tooltip("This will use original intended elements position.");
-            SohImGui::EnhancementRadioButton("Anchor to the left", "gDPadPosType", 1);
-            SohImGui::Tooltip("This will make your elements follow the left side of your game window.");
-            SohImGui::EnhancementRadioButton("Anchor to the right", "gDPadPosType", 2);
-            SohImGui::Tooltip("This will make your elements follow the right side of your game window.");
-            SohImGui::EnhancementRadioButton("No anchors", "gDPadPosType", 3);
-            SohImGui::Tooltip("This will make your elements to not follow any side\nBetter used for center elements.");
-            SohImGui::EnhancementRadioButton("Hidden", "gDPadPosType", 4);
-            SohImGui::Tooltip("This will make your elements hidden");
-            SohImGui::EnhancementSliderInt("Up <-> Down : %d", "##DPadPosY", "gDPadPosY", 0, ImGui::GetWindowViewport()->Size.y/2, "", 0, true);
-            SohImGui::Tooltip("This slider is used to move Up and Down your elements.");
+            DrawUseMarginsSlider("DPad items", "gDPad");
+            DrawPositionsRadioBoxes("gDPad");
             s16 Min_X_Dpad = 0;
             s16 Max_X_Dpad = ImGui::GetWindowViewport()->Size.x/2;
             if(CVar_GetS32("gDPadPosType",0) == 2){
@@ -745,200 +647,104 @@ void Draw_Placements(){
             } else if(CVar_GetS32("gDPadPosType",0) == 4){
                 Min_X_Dpad = (ImGui::GetWindowViewport()->Size.x/2)*-1;
             }
-            SohImGui::EnhancementSliderInt("Left <-> Right : %d", "##DPadPosX", "gDPadPosX", Min_X_Dpad, Max_X_Dpad, "", 0, true);
-            SohImGui::Tooltip("This slider is used to move Left and Right your elements.");
+            DrawPositionSlider("gDPad", 0, ImGui::GetWindowViewport()->Size.y/2, Min_X_Dpad, Max_X_Dpad);
+            DrawScaleSlider("gDPad",1.0f);
             ImGui::NewLine();
             ImGui::EndTable();
         }
     }
     if (ImGui::CollapsingHeader("Minimaps position")) {
-        if (ImGui::BeginTable("tableminimapspos", 1, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV)) {
-            ImGui::TableSetupColumn("minimaps settings", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort, TablesCellsWidth);
+        if (ImGui::BeginTable("tableminimapspos", 1, FlagsTable)) {
+            ImGui::TableSetupColumn("minimaps settings", FlagsCell, TablesCellsWidth);
             Table_InitHeader(false);
-            SohImGui::EnhancementCheckbox("Minimap Button use margins", "gMinimapUseMargins");
-            SohImGui::Tooltip("This will use original intended elements position.");
-            SohImGui::EnhancementRadioButton("Original position", "gMinimapPosType", 0);
-            SohImGui::Tooltip("This will use original intended elements position.");
-            SohImGui::EnhancementRadioButton("Anchor to the left", "gMinimapPosType", 1);
-            SohImGui::Tooltip("This will make your elements follow the left side of your game window.");
-            SohImGui::EnhancementRadioButton("Anchor to the right", "gMinimapPosType", 2);
-            SohImGui::Tooltip("This will make your elements follow the right side of your game window.");
-            //SohImGui::EnhancementRadioButton("No anchors", "gMinimapPosType", 3); //currently bugged
-            //SohImGui::Tooltip("This will make your elements to not follow any side\nBetter used for center elements.");
-            SohImGui::EnhancementRadioButton("Hidden", "gMinimapPosType", 4);
-            SohImGui::Tooltip("This will make your elements hidden");
-            SohImGui::EnhancementSliderInt("Up <-> Down : %d", "##MinimapPosY", "gMinimapPosY", (ImGui::GetWindowViewport()->Size.y/3)*-1, ImGui::GetWindowViewport()->Size.y/3, "", 0, true);
-            SohImGui::Tooltip("This slider is used to move Up and Down your elements.");
-            SohImGui::EnhancementSliderInt("Left <-> Right : %d", "##MinimapPosX", "gMinimapPosX", ImGui::GetWindowViewport()->Size.x*-1, ImGui::GetWindowViewport()->Size.x/2, "", 0, true);
-            SohImGui::Tooltip("This slider is used to move Left and Right your elements.");
+            DrawUseMarginsSlider("Minimap", "gMinimap");
+            DrawPositionsRadioBoxes("gMinimap", false);
+            DrawPositionSlider("gMinimap", (ImGui::GetWindowViewport()->Size.y/3)*-1, ImGui::GetWindowViewport()->Size.y/3, ImGui::GetWindowViewport()->Size.x*-1, ImGui::GetWindowViewport()->Size.x/2);
+            DrawScaleSlider("gMinimap",1.0f);
             ImGui::NewLine();
             ImGui::EndTable();
         }
     }
     if (ImGui::CollapsingHeader("Small Keys counter position")) {
-        if (ImGui::BeginTable("tablesmolekeys", 1, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV)) {
-            ImGui::TableSetupColumn("Small Keys counter settings", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort, TablesCellsWidth);
+        if (ImGui::BeginTable("tablesmolekeys", 1, FlagsTable)) {
+            ImGui::TableSetupColumn("Small Keys counter settings", FlagsCell, TablesCellsWidth);
             Table_InitHeader(false);
-            SohImGui::EnhancementCheckbox("Small Keys counter use margins", "gSKCUseMargins");
-            SohImGui::Tooltip("This will use original intended elements position.");
-            SohImGui::EnhancementRadioButton("Original position", "gSKCPosType", 0);
-            SohImGui::Tooltip("This will use original intended elements position.");
-            SohImGui::EnhancementRadioButton("Anchor to the left", "gSKCPosType", 1);
-            SohImGui::Tooltip("This will make your elements follow the left side of your game window.");
-            SohImGui::EnhancementRadioButton("Anchor to the right", "gSKCPosType", 2);
-            SohImGui::Tooltip("This will make your elements follow the right side of your game window.");
-            SohImGui::EnhancementRadioButton("No anchors", "gSKCPosType", 3);
-            SohImGui::Tooltip("This will make your elements to not follow any side\nBetter used for center elements.");
-            SohImGui::EnhancementRadioButton("Hidden", "gSKCPosType", 4);
-            SohImGui::Tooltip("This will make your elements hidden");
-            SohImGui::EnhancementSliderInt("Up <-> Down : %d", "##SKCPosY", "gSKCPosY", 0, ImGui::GetWindowViewport()->Size.y/3, "", 0, true);
-            SohImGui::Tooltip("This slider is used to move Up and Down your elements.");
-            SohImGui::EnhancementSliderInt("Left <-> Right : %d", "##SKCPosX", "gSKCPosX", -1, ImGui::GetWindowViewport()->Size.x/2, "", 0, true);
-            SohImGui::Tooltip("This slider is used to move Left and Right your elements.");
+            DrawUseMarginsSlider("Small Keys counter", "gSKC");
+            DrawPositionsRadioBoxes("gSKC");
+            DrawPositionSlider("gSKC", 0, ImGui::GetWindowViewport()->Size.y/3, -1, ImGui::GetWindowViewport()->Size.x/2);
+            DrawScaleSlider("gSKC",1.0f);
             ImGui::NewLine();
             ImGui::EndTable();
         }
     }
     if (ImGui::CollapsingHeader("Rupee counter position")) {
-        if (ImGui::BeginTable("tablerupeecount", 1, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV)) {
-            ImGui::TableSetupColumn("Rupee counter settings", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort, TablesCellsWidth);
+        if (ImGui::BeginTable("tablerupeecount", 1, FlagsTable)) {
+            ImGui::TableSetupColumn("Rupee counter settings", FlagsCell, TablesCellsWidth);
             Table_InitHeader(false);
-            SohImGui::EnhancementCheckbox("Rupee counter use margins", "gRCUseMargins");
-            SohImGui::Tooltip("This will use original intended elements position.");
-            SohImGui::EnhancementRadioButton("Original position", "gRCPosType", 0);
-            SohImGui::Tooltip("This will use original intended elements position.");
-            SohImGui::EnhancementRadioButton("Anchor to the left", "gRCPosType", 1);
-            SohImGui::Tooltip("This will make your elements follow the left side of your game window.");
-            SohImGui::EnhancementRadioButton("Anchor to the right", "gRCPosType", 2);
-            SohImGui::Tooltip("This will make your elements follow the right side of your game window.");
-            SohImGui::EnhancementRadioButton("No anchors", "gRCPosType", 3);
-            SohImGui::Tooltip("This will make your elements to not follow any side\nBetter used for center elements.");
-            SohImGui::EnhancementRadioButton("Hidden", "gRCPosType", 4);
-            SohImGui::Tooltip("This will make your elements hidden");
-            SohImGui::EnhancementSliderInt("Up <-> Down : %d", "##RCPosY", "gRCPosY", -2, ImGui::GetWindowViewport()->Size.y/3, "", 0, true);
-            SohImGui::Tooltip("This slider is used to move Up and Down your elements.");
-            SohImGui::EnhancementSliderInt("Left <-> Right : %d", "##RCPosX", "gRCPosX", -3, ImGui::GetWindowViewport()->Size.x/2, "", 0, true);
-            SohImGui::Tooltip("This slider is used to move Left and Right your elements.");
+            DrawUseMarginsSlider("Rupee counter", "gRC");
+            DrawPositionsRadioBoxes("gRC");
+            DrawPositionSlider("gRC", -2, ImGui::GetWindowViewport()->Size.y/3, -3, ImGui::GetWindowViewport()->Size.x/2);
+            DrawScaleSlider("gRC",1.0f);
             ImGui::NewLine();
             ImGui::EndTable();
         }
     }
     if (ImGui::CollapsingHeader("Carrots position")) {
-        if (ImGui::BeginTable("tableCarrots", 1, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV)) {
-            ImGui::TableSetupColumn("Carrots settings", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort, TablesCellsWidth);
+        if (ImGui::BeginTable("tableCarrots", 1, FlagsTable)) {
+            ImGui::TableSetupColumn("Carrots settings", FlagsCell, TablesCellsWidth);
             Table_InitHeader(false);
-            SohImGui::EnhancementCheckbox("Carrots use margins", "gCarrotsUseMargins");
-            SohImGui::Tooltip("This will use original intended elements position.");
-            SohImGui::EnhancementRadioButton("Original position", "gCarrotsPosType", 0);
-            SohImGui::Tooltip("This will use original intended elements position.");
-            SohImGui::EnhancementRadioButton("Anchor to the left", "gCarrotsPosType", 1);
-            SohImGui::Tooltip("This will make your elements follow the left side of your game window.");
-            SohImGui::EnhancementRadioButton("Anchor to the right", "gCarrotsPosType", 2);
-            SohImGui::Tooltip("This will make your elements follow the right side of your game window.");
-            SohImGui::EnhancementRadioButton("No anchors", "gCarrotsPosType", 3);
-            SohImGui::Tooltip("This will make your elements to not follow any side\nBetter used for center elements.");
-            SohImGui::EnhancementRadioButton("Hidden", "gCarrotsPosType", 4);
-            SohImGui::Tooltip("This will make your elements hidden");
-            SohImGui::EnhancementSliderInt("Up <-> Down : %d", "##CarrotsPosY", "gCarrotsPosY", 0, ImGui::GetWindowViewport()->Size.y/2, "", 0, true);
-            SohImGui::Tooltip("This slider is used to move Up and Down your elements.");
-            SohImGui::EnhancementSliderInt("Left <-> Right : %d", "##CarrotsPosX", "gCarrotsPosX", -50, ImGui::GetWindowViewport()->Size.x/2+25, "", 0, true);
-            SohImGui::Tooltip("This slider is used to move Left and Right your elements.");
+            DrawUseMarginsSlider("Carrots", "gCarrots");
+            DrawPositionsRadioBoxes("gCarrots");
+            DrawPositionSlider("gCarrots", 0, ImGui::GetWindowViewport()->Size.y/2, -50, ImGui::GetWindowViewport()->Size.x/2+25);
+            DrawScaleSlider("gCarrots",1.0f);
             ImGui::NewLine();
             ImGui::EndTable();
         }
     }
     if (ImGui::CollapsingHeader("Timers position")) {
-        if (ImGui::BeginTable("tabletimers", 1, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV)) {
-            ImGui::TableSetupColumn("Timers settings", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort, TablesCellsWidth);
+        if (ImGui::BeginTable("tabletimers", 1, FlagsTable)) {
+            ImGui::TableSetupColumn("Timers settings", FlagsCell, TablesCellsWidth);
             Table_InitHeader(false);
-            SohImGui::EnhancementCheckbox("Timers use margins", "gTimersUseMargins");
-            SohImGui::Tooltip("This will use original intended elements position.");
-            SohImGui::EnhancementRadioButton("Original position", "gTimersPosType", 0);
-            SohImGui::Tooltip("This will use original intended elements position.");
-            SohImGui::EnhancementRadioButton("Anchor to the left", "gTimersPosType", 1);
-            SohImGui::Tooltip("This will make your elements follow the left side of your game window.");
-            SohImGui::EnhancementRadioButton("Anchor to the right", "gTimersPosType", 2);
-            SohImGui::Tooltip("This will make your elements follow the right side of your game window.");
-            SohImGui::EnhancementRadioButton("No anchors", "gTimersPosType", 3);
-            SohImGui::Tooltip("This will make your elements to not follow any side\nBetter used for center elements.");
-            SohImGui::EnhancementRadioButton("Hidden", "gTimersPosType", 4);
-            SohImGui::Tooltip("This will make your elements hidden");
-            SohImGui::EnhancementSliderInt("Up <-> Down : %d", "##TimersPosY", "gTimersPosY", 0, ImGui::GetWindowViewport()->Size.y/2, "", 0, true);
-            SohImGui::Tooltip("This slider is used to move Up and Down your elements.");
-            SohImGui::EnhancementSliderInt("Left <-> Right : %d", "##TimersPosX", "gTimersPosX", -50, ImGui::GetWindowViewport()->Size.x/2-50, "", 0, true);
-            SohImGui::Tooltip("This slider is used to move Left and Right your elements.");
+            DrawUseMarginsSlider("Timers", "gTimers");
+            DrawPositionsRadioBoxes("gTimers");
+            DrawPositionSlider("gTimers", 0, ImGui::GetWindowViewport()->Size.y/2, -50, ImGui::GetWindowViewport()->Size.x/2-50);
+            DrawScaleSlider("gTimers",1.0f);
             ImGui::NewLine();
             ImGui::EndTable();
         }
     }
     if (ImGui::CollapsingHeader("Archery Scores position")) {
-        if (ImGui::BeginTable("tablearchery", 1, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV)) {
-            ImGui::TableSetupColumn("Archery Scores settings", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort, TablesCellsWidth);
+        if (ImGui::BeginTable("tablearchery", 1, FlagsTable)) {
+            ImGui::TableSetupColumn("Archery Scores settings", FlagsCell, TablesCellsWidth);
             Table_InitHeader(false);
-            SohImGui::EnhancementCheckbox("Archery Scores use margins", "gASUseMargins");
-            SohImGui::Tooltip("This will use original intended elements position.");
-            SohImGui::EnhancementRadioButton("Original position", "gASPosType", 0);
-            SohImGui::Tooltip("This will use original intended elements position.");
-            SohImGui::EnhancementRadioButton("Anchor to the left", "gASPosType", 1);
-            SohImGui::Tooltip("This will make your elements follow the left side of your game window.");
-            SohImGui::EnhancementRadioButton("Anchor to the right", "gASPosType", 2);
-            SohImGui::Tooltip("This will make your elements follow the right side of your game window.");
-            //SohImGui::EnhancementRadioButton("No anchors", "gASPosType", 3); //currently bugged
-            //SohImGui::Tooltip("This will make your elements to not follow any side\nBetter used for center elements.");
-            SohImGui::EnhancementRadioButton("Hidden", "gASPosType", 4);
-            SohImGui::Tooltip("This will make your elements hidden");
-            SohImGui::EnhancementSliderInt("Up <-> Down : %d", "##ASPosY", "gASPosY", 0, ImGui::GetWindowViewport()->Size.y/2, "", 0, true);
-            SohImGui::Tooltip("This slider is used to move Up and Down your elements.");
-            SohImGui::EnhancementSliderInt("Left <-> Right : %d", "##ASPosX", "gASPosX", -50, ImGui::GetWindowViewport()->Size.x/2-50, "", 0, true);
-            SohImGui::Tooltip("This slider is used to move Left and Right your elements.");
+            DrawUseMarginsSlider("Archery scores", "gAS");
+            DrawPositionsRadioBoxes("gAS", false);
+            DrawPositionSlider("gAS", 0, ImGui::GetWindowViewport()->Size.y/2, -50, ImGui::GetWindowViewport()->Size.x/2-50);
+            DrawScaleSlider("gAS",1.0f);
             ImGui::NewLine();
             ImGui::EndTable();
         }
     }
     if (ImGui::CollapsingHeader("Title cards (Maps) position")) {
-        if (ImGui::BeginTable("tabletcmaps", 1, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV)) {
-            ImGui::TableSetupColumn("Titlecard maps settings", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort, TablesCellsWidth);
+        if (ImGui::BeginTable("tabletcmaps", 1, FlagsTable)) {
+            ImGui::TableSetupColumn("Titlecard maps settings", FlagsCell, TablesCellsWidth);
             Table_InitHeader(false);
-            SohImGui::EnhancementCheckbox("Title cards (Maps) use margins", "gTCMUseMargins");
-            SohImGui::Tooltip("This will use original intended elements position.");
-            SohImGui::EnhancementRadioButton("Original position", "gTCMPosType", 0);
-            SohImGui::Tooltip("This will use original intended elements position.");
-            SohImGui::EnhancementRadioButton("Anchor to the left", "gTCMPosType", 1);
-            SohImGui::Tooltip("This will make your elements follow the left side of your game window.");
-            SohImGui::EnhancementRadioButton("Anchor to the right", "gTCMPosType", 2);
-            SohImGui::Tooltip("This will make your elements follow the right side of your game window.");
-            SohImGui::EnhancementRadioButton("No anchors", "gTCMPosType", 3);
-            SohImGui::Tooltip("This will make your elements to not follow any side\nBetter used for center elements.");
-            SohImGui::EnhancementRadioButton("Hidden", "gTCMPosType", 4);
-            SohImGui::Tooltip("This will make your elements hidden");
-            SohImGui::EnhancementSliderInt("Up <-> Down : %d", "##TCMPosY", "gTCMPosY", 0, ImGui::GetWindowViewport()->Size.y/2, "", 0, true);
-            SohImGui::Tooltip("This slider is used to move Up and Down your elements.");
-            SohImGui::EnhancementSliderInt("Left <-> Right : %d", "##TCMPosX", "gTCMPosX", -50, ImGui::GetWindowViewport()->Size.x/2+10, ""), true;
-            SohImGui::Tooltip("This slider is used to move Left and Right your elements.");
+            DrawUseMarginsSlider("Title cards (overworld)", "gTCM");
+            DrawPositionsRadioBoxes("gTCM");
+            DrawPositionSlider("gTCM", 0, ImGui::GetWindowViewport()->Size.y/2, -50, ImGui::GetWindowViewport()->Size.x/2+10);
+            DrawScaleSlider("gTCM",1.0f);
             ImGui::NewLine();
             ImGui::EndTable();
         }
     }
     if (ImGui::CollapsingHeader("Title cards (Bosses) position")) {
-        if (ImGui::BeginTable("tabletcbosses", 1, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV)) {
-            ImGui::TableSetupColumn("Title cards (Bosses) settings", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort, TablesCellsWidth);
+        if (ImGui::BeginTable("tabletcbosses", 1, FlagsTable)) {
+            ImGui::TableSetupColumn("Title cards (Bosses) settings", FlagsCell, TablesCellsWidth);
             Table_InitHeader(false);
-            SohImGui::EnhancementCheckbox("Title cards (Bosses) use margins", "gTCBUseMargins");
-            SohImGui::Tooltip("This will use original intended elements position.");
-            SohImGui::EnhancementRadioButton("Original position", "gTCBPosType", 0);
-            SohImGui::Tooltip("This will use original intended elements position.");
-            SohImGui::EnhancementRadioButton("Anchor to the left", "gTCBPosType", 1);
-            SohImGui::Tooltip("This will make your elements follow the left side of your game window.");
-            SohImGui::EnhancementRadioButton("Anchor to the right", "gTCBPosType", 2);
-            SohImGui::Tooltip("This will make your elements follow the right side of your game window.");
-            SohImGui::EnhancementRadioButton("No anchors", "gTCBPosType", 3);
-            SohImGui::Tooltip("This will make your elements to not follow any side\nBetter used for center elements.");
-            SohImGui::EnhancementRadioButton("Hidden", "gTCBPosType", 4);
-            SohImGui::Tooltip("This will make your elements hidden");
-            SohImGui::EnhancementSliderInt("Up <-> Down : %d", "##TCBPosY", "gTCBPosY", 0, ImGui::GetWindowViewport()->Size.y/2, "", 0, true);
-            SohImGui::Tooltip("This slider is used to move Up and Down your elements.");
-            SohImGui::EnhancementSliderInt("Left <-> Right : %d", "##TCBPosX", "gTCBPosX", -50, ImGui::GetWindowViewport()->Size.x/2+10, "", 0, true);
-            SohImGui::Tooltip("This slider is used to move Left and Right your elements.");
+            DrawUseMarginsSlider("Title cards (Bosses)", "gTCB");
+            DrawPositionsRadioBoxes("gTCB");
+            DrawPositionSlider("gTCB", 0, ImGui::GetWindowViewport()->Size.y/2, -50, ImGui::GetWindowViewport()->Size.x/2+10);
+            DrawScaleSlider("gTCB",1.0f);
             ImGui::NewLine();
             ImGui::EndTable();
         }
@@ -946,67 +752,53 @@ void Draw_Placements(){
 }
 void Draw_HUDButtons(){
     if (CVar_GetS32("gHudColors",0) ==2 ){
+        DrawRandomizeResetButton("every buttons", Buttons_section, SECTION_SIZE(Buttons_section));
         if (ImGui::CollapsingHeader("A Button colors & A Cursors")) {
-            if (ImGui::BeginTable("tableBTN_A", 1, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV)) {
-                ImGui::TableSetupColumn("A Button colors", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort, TablesCellsWidth);
+            if (ImGui::BeginTable("tableBTN_A", 1, FlagsTable)) {
+                ImGui::TableSetupColumn("A Button colors", FlagsCell, TablesCellsWidth);
                 Table_InitHeader(false);
-                Draw_HelpIcon("Affects the A button colors (and various cursors that use the same theme)", false);
-                SohImGui::EnhancementColor("A Buttons", "gCCABtnPrim", a_btn_colors, ImVec4(0, 200, 50, 255), true, false, true);
+                DrawColorSection(A_Btn_section, SECTION_SIZE(A_Btn_section));
                 ImGui::EndTable();
             }
         }
         if (ImGui::CollapsingHeader("B Button color")) {
-            if (ImGui::BeginTable("tableBTN_B", 1, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV)) {
-                ImGui::TableSetupColumn("B button color", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort, TablesCellsWidth);
+            if (ImGui::BeginTable("tableBTN_B", 1, FlagsTable)) {
+                ImGui::TableSetupColumn("B button color", FlagsCell, TablesCellsWidth);
                 Table_InitHeader(false);
-                Draw_HelpIcon("Affects the B button color", false);
-                SohImGui::EnhancementColor("B Button", "gCCBBtnPrim", b_btn_colors, ImVec4(255, 30, 30, 255), true, false, true);
+                DrawColorSection(B_Btn_section, SECTION_SIZE(B_Btn_section));
                 ImGui::EndTable();
             }
         }
         if (ImGui::CollapsingHeader("C-Buttons & C Cursor")) {
-            if (ImGui::BeginTable("tableBTN_C", 1, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV)) {
-                ImGui::TableSetupColumn("Button C colors & C Cursor colors", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort, TablesCellsWidth);
+            if (ImGui::BeginTable("tableBTN_C", 1, FlagsTable)) {
+                ImGui::TableSetupColumn("Button C colors & C Cursor colors", FlagsCell, TablesCellsWidth);
                 Table_InitHeader(false);
-                Draw_HelpIcon("Affects the C Buttons' color (if not using separate colors)\nAnd various cursor that use C-Buttons colors", false);
-                SohImGui::EnhancementColor("C-Buttons", "gCCCBtnPrim", c_btn_colors, ImVec4(255, 160, 0, 255), true, false, true);
+                DrawColorSection(C_Btn_Unified_section, SECTION_SIZE(C_Btn_Unified_section));
                 ImGui::EndTable();
             }
             SohImGui::EnhancementCheckbox("C-Buttons use separate colors", "gCCparated");
             if (CVar_GetS32("gCCparated",0) && ImGui::CollapsingHeader("C Button individual colors")) {
-                if (ImGui::BeginTable("tableBTN_CSep", 1, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV)) {
-                    ImGui::TableSetupColumn("C-Buttons individual colors", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort, TablesCellsWidth);
+                if (ImGui::BeginTable("tableBTN_CSep", 1, FlagsTable)) {
+                    ImGui::TableSetupColumn("C-Buttons individual colors", FlagsCell, TablesCellsWidth);
                     Table_InitHeader(false);
-                    Draw_HelpIcon("Affects C-Buttons Up colors, but not C cursor colors\nTo edit C Cursor check C-Buttons color on top");
-                    SohImGui::EnhancementColor("C Buttons Up", "gCCCUBtnPrim", c_btn_u_colors, ImVec4(255,160,0,255));
-                    Table_NextLine();
-                    Draw_HelpIcon("Affects C-Buttons Down colors, but not C cursor colors\nTo edit C Cursor check C-Buttons color on top");
-                    SohImGui::EnhancementColor("C Buttons Down", "gCCCDBtnPrim", c_btn_d_colors, ImVec4(255,160,0,255));
-                    Table_NextLine();
-                    Draw_HelpIcon("Affects C-Buttons Left colors, but not C cursor colors\nTo edit C Cursor check C-Buttons color on top");
-                    SohImGui::EnhancementColor("C Buttons Left", "gCCCLBtnPrim", c_btn_l_colors, ImVec4(255,160,0,255));
-                    Table_NextLine();
-                    Draw_HelpIcon("Affects C-Buttons Right colors, but not C cursor colors\nTo edit C Cursor check C-Buttons color on top");
-                    SohImGui::EnhancementColor("C Buttons Right", "gCCCRBtnPrim", c_btn_r_colors, ImVec4(255,160,0,255));
+                    DrawColorSection(C_Btn_Separated_section, SECTION_SIZE(C_Btn_Separated_section));
                     ImGui::EndTable();
                 }
             }
         }
         if (ImGui::CollapsingHeader("Start button colors")) {
-            if (ImGui::BeginTable("tableBTN_Start", 1, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV)) {
-                ImGui::TableSetupColumn("Start button colors", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort, TablesCellsWidth);
+            if (ImGui::BeginTable("tableBTN_Start", 1, FlagsTable)) {
+                ImGui::TableSetupColumn("Start button colors", FlagsCell, TablesCellsWidth);
                 Table_InitHeader(false);
-                Draw_HelpIcon("Affects the Start button color", false);
-                SohImGui::EnhancementColor("Start Buttons", "gCCStartBtnPrim", start_btn_colors, ImVec4(200, 0, 0, 255), true, false, true);
+                DrawColorSection(Start_Btn_section, SECTION_SIZE(Start_Btn_section));
                 ImGui::EndTable();
             }
         }
         if (CVar_GetS32("gDpadEquips",0) && ImGui::CollapsingHeader("DPad colors")) {
-            if (ImGui::BeginTable("tableDpadHud", 1, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV)) {
-                ImGui::TableSetupColumn("DPad color", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort, TablesCellsWidth);
+            if (ImGui::BeginTable("tableDpadHud", 1, FlagsTable)) {
+                ImGui::TableSetupColumn("DPad color", FlagsCell, TablesCellsWidth);
                 Table_InitHeader(false);
-                Draw_HelpIcon("DPad background color, White is the default value");
-                SohImGui::EnhancementColor("DPad background color", "gCCDpadPrim", dpad_colors, ImVec4(255, 255, 255, 255));
+                DrawColorSection(DPad_section, SECTION_SIZE(DPad_section));
                 ImGui::EndTable();
             }
         }
@@ -1015,10 +807,11 @@ void Draw_HUDButtons(){
     }
 }
 void Draw_General(){
-    if (ImGui::BeginTable("tableScheme", 3, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV | ImGuiTableFlags_Hideable)) {
-        ImGui::TableSetupColumn("N64 Scheme", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort, TablesCellsWidth);
-        ImGui::TableSetupColumn("GameCube Scheme", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort, TablesCellsWidth);
-        ImGui::TableSetupColumn("Custom Schemes", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort, TablesCellsWidth);
+    DrawRandomizeResetButton("all cosmetics", Everything_Section, SECTION_SIZE(Everything_Section), true);
+    if (ImGui::BeginTable("tableScheme", 3, FlagsTable | ImGuiTableFlags_Hideable)) {
+        ImGui::TableSetupColumn("N64 Scheme", FlagsCell, TablesCellsWidth);
+        ImGui::TableSetupColumn("GameCube Scheme", FlagsCell, TablesCellsWidth);
+        ImGui::TableSetupColumn("Custom Schemes", FlagsCell, TablesCellsWidth);
         Table_InitHeader();
         Draw_HelpIcon("Change interface color to N64 style");
         SohImGui::EnhancementRadioButton("N64 Colors", "gHudColors", 0);
@@ -1031,86 +824,83 @@ void Draw_General(){
         ImGui::EndTable();
     }
     if (CVar_GetS32("gHudColors",0) ==2 ){
+        DrawRandomizeResetButton("interface (excluding buttons)", Misc_Interface_section, SECTION_SIZE(Misc_Interface_section));
         if (ImGui::CollapsingHeader("Hearts colors")) {
             SohImGui::Tooltip("Hearts colors in general\nDD stand for Double Defense");
-            if (ImGui::BeginTable("tableHearts", 3, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV | ImGuiTableFlags_Hideable)) {
+            if (ImGui::BeginTable("tableHearts", 3, FlagsTable | ImGuiTableFlags_Hideable)) {
                 ImGui::TableSetupColumn("Hearts (normal)", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable, TablesCellsWidth/3);
                 ImGui::TableSetupColumn("Hearts (DD)", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable, TablesCellsWidth/3);
                 ImGui::TableSetupColumn("Hearts Outline (DD)", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable, TablesCellsWidth/3);
                 Table_InitHeader();
-                Draw_HelpIcon("Affects the inner color", false);
-                SohImGui::EnhancementColor("Inner normal", "gCCHeartsPrim", hearts_colors, ImVec4(255,70,50,255), true, false, true);
-                Table_NextCol();
-                Draw_HelpIcon("Affects the inner color", false);
-                SohImGui::EnhancementColor("Inner DD", "gCCDDHeartsPrim", hearts_ddi_colors, ImVec4(255,70,50,255), true, false, true);
-                Table_NextCol();
-                Draw_HelpIcon("Affects the outline color of hearts when you have Double Defense\nWhite is the default value", false);
-                SohImGui::EnhancementColor("Outline DD", "gDDCCHeartsPrim", hearts_dd_colors, ImVec4(255,255,255,255), true, false, true);
+                DrawColorSection(Hearts_section, SECTION_SIZE(Hearts_section));
                 ImGui::EndTable();
             }
         }
         if (ImGui::CollapsingHeader("Magic Meter colors")) {
-            if (ImGui::BeginTable("tableMagicmeter", 2, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV | ImGuiTableFlags_Hideable)) {
-                ImGui::TableSetupColumn("Magic meter", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort, TablesCellsWidth/2);
-                ImGui::TableSetupColumn("Magic meter in use", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort, TablesCellsWidth/2);
+            if (ImGui::BeginTable("tableMagicmeter", 2, FlagsTable | ImGuiTableFlags_Hideable)) {
+                ImGui::TableSetupColumn("Magic meter", FlagsCell, TablesCellsWidth/2);
+                ImGui::TableSetupColumn("Magic meter in use", FlagsCell, TablesCellsWidth/2);
                 Table_InitHeader();
-                Draw_HelpIcon("Affects the border of the magic meter\nWhite is the default value, color change only when used one time");
-                SohImGui::EnhancementColor("Borders", "gCCMagicBorderNormPrim", magic_bordern_colors, ImVec4(255,255,255,255), false);
-                Table_NextCol();
-                Draw_HelpIcon("Affects the border of the magic meter when being used\nWhite is the default value");
-                SohImGui::EnhancementColor("Borders in use", "gCCMagicBorderPrim", magic_border_colors, ImVec4(255,255,255,255), false);
-                Table_NextLine();
-                Draw_HelpIcon("Affects the magic meter color\nGreen is the default value");
-                SohImGui::EnhancementColor("Main color", "gCCMagicPrim", magic_remaining_colors, ImVec4(0,200,0,255));
-                Table_NextCol();
-                Draw_HelpIcon("Affects the magic meter when being used\nYellow is the default value");
-                SohImGui::EnhancementColor("Main color in use", "gCCMagicUsePrim", magic_use_colors, ImVec4(250,250,0,255));
+                DrawColorSection(Magic_Meter_section, SECTION_SIZE(Magic_Meter_section));
                 ImGui::EndTable();
             }
         }
         if (ImGui::CollapsingHeader("Minimap and compass colors")) {
-            if (ImGui::BeginTable("tableMinimapCol", 1, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV)) {
-                ImGui::TableSetupColumn("Minimap color", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort, TablesCellsWidth);
+            if (ImGui::BeginTable("tableMinimapCol", 1, FlagsTable)) {
+                ImGui::TableSetupColumn("Minimap color", FlagsCell, TablesCellsWidth);
                 Table_InitHeader();
-                Draw_HelpIcon("Affects the Overworld minimaps");
-                SohImGui::EnhancementColor("Overworlds", "gCCMinimapPrim", minimap_colors, ImVec4(0, 255, 255, 255));
-                Table_NextLine();
-                Draw_HelpIcon("Affects the Dungeon minimaps");
-                SohImGui::EnhancementColor("Dungeons", "gCCMinimapDGNPrim", dgn_minimap_colors, ImVec4(100, 255, 255, 255));
-                Table_NextLine();
-                Draw_HelpIcon("Affects the current position arrow on the minimap\nYellow is the default value");
-                SohImGui::EnhancementColor("Current position arrow", "gCCMinimapCPPrim", cp_minimap_colors, ImVec4(200, 255, 0, 255));
-                Table_NextLine();
-                Draw_HelpIcon("Affects the last entrance position arrow on the minimap\nRed is the default value");
-                SohImGui::EnhancementColor("Last entrance arrow", "gCCMinimapLEPrim", le_minimap_colors, ImVec4(200, 0, 0, 255));
+                DrawColorSection(Minimap_section, SECTION_SIZE(Minimap_section));
                 ImGui::EndTable();
             }
         }
         if (ImGui::CollapsingHeader("Title cards colors")) {
-            if (ImGui::BeginTable("tableTitleCards", 2, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV | ImGuiTableFlags_Hideable)) {
-                ImGui::TableSetupColumn("Title cards Overworld", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort, TablesCellsWidth/2);
-                ImGui::TableSetupColumn("Title cards Bosses", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort, TablesCellsWidth/2);
+            if (ImGui::BeginTable("tableTitleCards", 2, FlagsTable | ImGuiTableFlags_Hideable)) {
+                ImGui::TableSetupColumn("Title cards Overworld", FlagsCell, TablesCellsWidth/2);
+                ImGui::TableSetupColumn("Title cards Bosses", FlagsCell, TablesCellsWidth/2);
                 Table_InitHeader();
-                Draw_HelpIcon("Affects all the overworld title cards color, white is the default value");
-                SohImGui::EnhancementColor("Main color", "gCCTC_OW_U_Prim", tc_ou_colors, ImVec4(255, 255, 255, 255), false);
-                Table_NextCol();
-                Draw_HelpIcon("Affects all the bosses title cards color, white is the default value");
-                SohImGui::EnhancementColor("Main color", "gCCTC_B_U_Prim", tc_bu_colors, ImVec4(255, 255, 255, 255), false);
+                DrawColorSection(TitleCards_section, SECTION_SIZE(TitleCards_section));
                 ImGui::EndTable();
             }
         }
         if (ImGui::CollapsingHeader("Misc. interface colors")) {
-            if (ImGui::BeginTable("tableMiscHudCol", 1, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV | ImGuiTableFlags_Hideable)) {
-                ImGui::TableSetupColumn("Misc HUD colors", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort, TablesCellsWidth);
+            if (ImGui::BeginTable("tableMiscHudCol", 1, FlagsTable | ImGuiTableFlags_Hideable)) {
+                ImGui::TableSetupColumn("Misc HUD colors", FlagsCell, TablesCellsWidth);
                 Table_InitHeader();
-                Draw_HelpIcon("Affects the Rupee icon on interface\nGreen is the default value");
-                SohImGui::EnhancementColor("Rupee icon", "gCCRupeePrim", rupee_colors, ImVec4(200, 255, 100, 255));
+                DrawColorSection(Misc_section, SECTION_SIZE(Misc_section));
+                ImGui::EndTable();
+            }
+        }
+        if (ImGui::CollapsingHeader("Scenes transitions")) {
+            if (ImGui::BeginTable("tabletransitionotherCol", 2, FlagsTable | ImGuiTableFlags_Hideable)) {
+                ImGui::TableSetupColumn("transitionother1", FlagsCell, TablesCellsWidth/2);
+                ImGui::TableSetupColumn("transitionother2", FlagsCell, TablesCellsWidth/2);
+                Table_InitHeader(false);
+                SohImGui::EnhancementRadioButton("Originals", "gSceneTransitions", 255);
+                SohImGui::Tooltip("This will make the game use original scenes transitions");
+                Table_NextCol();
+                SohImGui::EnhancementRadioButton("None", "gSceneTransitions", 11);
+                SohImGui::Tooltip("This will make the game use no any scenes transitions");
                 Table_NextLine();
-                Draw_HelpIcon("Affects the Small keys icon on interface\nGray is the default value");
-                SohImGui::EnhancementColor("Small Keys icon", "gCCKeysPrim", smolekey_colors, ImVec4(200, 230, 255, 255));
+                SohImGui::EnhancementRadioButton("Desert mode (persistant)", "gSceneTransitions", 14);
+                SohImGui::Tooltip("This will make the game use the sand storm scenes transitions that will persist in map");
+                Table_NextCol();
+                SohImGui::EnhancementRadioButton("Desert mode (non persistant)", "gSceneTransitions", 15);
+                SohImGui::Tooltip("This will make the game use the sand storm scenes transitions");
                 Table_NextLine();
-                Draw_HelpIcon("Affects the Stone of Agony icon on interface\nWhite is the default value");
-                SohImGui::EnhancementColor("Stone of agony icon", "gCCVSOAPrim", visualagony_colors, ImVec4(255, 255, 255, 255));
+                SohImGui::EnhancementRadioButton("Normal fade (green)", "gSceneTransitions", 18);
+                SohImGui::Tooltip("This will make the game use a greenish fade in/out scenes transitions");
+                Table_NextCol();
+                SohImGui::EnhancementRadioButton("Normal fade (blue)", "gSceneTransitions", 19);
+                SohImGui::Tooltip("This will make the game use a blue fade in/out scenes transitions");
+                Table_NextLine();
+                SohImGui::EnhancementRadioButton("Triforce", "gSceneTransitions", 1);
+                ImGui::EndTable();
+            }
+            if (ImGui::BeginTable("tabletransitionCol", 2, FlagsTable | ImGuiTableFlags_Hideable)) {
+                ImGui::TableSetupColumn("White color", FlagsCell, TablesCellsWidth/2);
+                ImGui::TableSetupColumn("Black color", FlagsCell, TablesCellsWidth/2);
+                Table_InitHeader();
+                DrawTransitions("gSceneTransitions");
                 ImGui::EndTable();
             }
         }
@@ -1123,7 +913,8 @@ void DrawCosmeticsEditor(bool& open) {
         CVar_SetS32("gCosmeticsEditorEnabled", 0);
         return;
     }
-    ImGui::SetNextWindowSize(ImVec2(465, 430), ImGuiCond_FirstUseEver);
+
+    ImGui::SetNextWindowSize(ImVec2(620, 430), ImGuiCond_FirstUseEver);
     if (!ImGui::Begin("Cosmetics Editor", &open)) {
         ImGui::End();
         return;
@@ -1150,7 +941,7 @@ void DrawCosmeticsEditor(bool& open) {
             Draw_Menus();
             ImGui::EndTabItem();
         }
-        if (ImGui::BeginTabItem("Placements")) {
+        if (ImGui::BeginTabItem("Placements & Scale")) {
             Draw_Placements();
             ImGui::EndTabItem();
         }

--- a/soh/soh/Enhancements/cosmetics/CosmeticsEditor.h
+++ b/soh/soh/Enhancements/cosmetics/CosmeticsEditor.h
@@ -1,4 +1,407 @@
 #pragma once
+#include "../libultraship/ImGuiImpl.h"
+#define SECTION_SIZE(arr) (s32)(sizeof(arr) / sizeof(arr[0]))
+#define RANDOMIZE_32(Max) GetRandomValue(Max);
+#define CATEGORY_NPC 0
+#define CATEGORY_ITEMS 1
+#define CATEGORY_MENU 2
+#define CATEGORY_HUD 3
+#define CATEGORY_MISC 4
+
+typedef struct {
+    const std::string Name;
+    const std::string ToolTip;
+    const std::string CvarName;
+    ImVec4 ModifiedColor;
+    ImVec4 DefaultColor;
+    bool canRainbow;
+    bool hasAlpha;
+    bool sameLine;
+} CosmeticsColorIndividual;
+
+typedef struct {
+    CosmeticsColorIndividual* Element;
+    bool Nextcol;
+    bool NextLine;
+} CosmeticsColorSection;
+
+static float TablesCellsWidth = 300.0f;
+static ImGuiTableColumnFlags FlagsTable = ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV;
+static ImGuiTableColumnFlags FlagsCell = ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort;
+static ImVec4 hearts_colors;       static ImVec4 hearts_dd_colors;        static ImVec4 hearts_ddi_colors;
+static ImVec4 a_btn_colors;        static ImVec4 b_btn_colors;            static ImVec4 c_btn_colors;        static ImVec4 start_btn_colors;
+static ImVec4 c_btn_u_colors;      static ImVec4 c_btn_l_colors;          static ImVec4 c_btn_d_colors;      static ImVec4 c_btn_r_colors;
+static ImVec4 magic_border_colors; static ImVec4 magic_remaining_colors;  static ImVec4 magic_use_colors;
+static ImVec4 minimap_colors;      static ImVec4 dgn_minimap_colors;
+static ImVec4 cp_minimap_colors;   static ImVec4 le_minimap_colors;
+static ImVec4 rupee_colors;        static ImVec4 smolekey_colors;         static ImVec4 magic_bordern_colors;
+static ImVec4 fileselect_colors;   static ImVec4 fileselect_text_colors;
+static ImVec4 kokiri_col;          static ImVec4 goron_col;               static ImVec4 zora_col;
+static ImVec4 navi_idle_i_col;     static ImVec4 navi_idle_o_col;
+static ImVec4 navi_npc_i_col;      static ImVec4 navi_npc_o_col;
+static ImVec4 navi_enemy_i_col;    static ImVec4 navi_enemy_o_col;
+static ImVec4 navi_prop_i_col;     static ImVec4 navi_prop_o_col;
+static ImVec4 trailscol;
+static ImVec4 crtfilter;
+static ImVec4 firearrow_col;       static ImVec4 icearrow_col;            static ImVec4 lightarrow_col;
+static ImVec4 firearrow_colenv;    static ImVec4 icearrow_colenv;         static ImVec4 lightarrow_colenv;
+static ImVec4 charged1_col;        static ImVec4 charged2_col;
+static ImVec4 charged1_colenv;     static ImVec4 charged2_colenv;
+static ImVec4 Keese1_primcol;      static ImVec4 Keese2_primcol;
+static ImVec4 Keese1_envcol;       static ImVec4 Keese2_envcol;
+static ImVec4 doggo1col;           static ImVec4 doggo2col;
+static ImVec4 df_col;              static ImVec4 df_colenv;
+static ImVec4 nl_diam_col;         static ImVec4 nl_diam_colenv;
+static ImVec4 nl_orb_col;          static ImVec4 nl_orb_colenv;
+static ImVec4 tc_ou_colors;        static ImVec4 tc_bu_colors;
+static ImVec4 dpad_colors;
+static ImVec4 visualagony_colors;
+static ImVec4 tc_fire_colors;      static ImVec4 tc_fire_colors_env; 
+/*ImVec4 menu_equips_colors;
+ImVec4 menu_items_colors;
+ImVec4 menu_map_colors;
+ImVec4 menu_quest_colors;
+ImVec4 menu_save_colors;
+ImVec4 menu_gameover_colors;*/
+
+//Navi
+static CosmeticsColorIndividual Navi_Idle_Inner = { "Navi Idle (Primary)", "Inner color for Navi (idle flying around)", "gNavi_Idle_Inner_", navi_idle_i_col, ImVec4(255, 255, 255, 255), false, false, false };
+static CosmeticsColorIndividual Navi_Idle_Outer = { "Navi Idle (Secondary)", "Outer color for Navi (idle flying around)", "gNavi_Idle_Outer_", navi_idle_o_col, ImVec4(0, 0, 255, 255), false, false, false };
+static CosmeticsColorIndividual Navi_Npc_Inner = { "Navi NPC (Primary)", "Inner color for Navi (when Navi fly around NPCs)", "gNavi_NPC_Inner_", navi_npc_i_col, ImVec4(150, 150, 255, 255), false, false, false };
+static CosmeticsColorIndividual Navi_Npc_Outer = { "Navi NPC (Secondary)", "Outer color for Navi (when Navi fly around NPCs)", "gNavi_NPC_Outer_", navi_npc_o_col, ImVec4(150, 150, 255, 255), false, false, false };
+static CosmeticsColorIndividual Navi_Enemy_Inner = { "Navi Enemy (Primary)", "Inner color for Navi (when Navi fly around Enemies or Bosses)", "gNavi_Enemy_Inner_", navi_enemy_i_col, ImVec4(255, 255, 0, 255), false, false, false };
+static CosmeticsColorIndividual Navi_Enemy_Outer = { "Navi Enemy (Secondary)", "Outer color for Navi (when Navi fly around Enemies or Bosses)", "gNavi_Enemy_Outer_", navi_enemy_o_col, ImVec4(220, 155, 0, 255), false, false, false };
+static CosmeticsColorIndividual Navi_Prop_Inner = { "Navi Enemy (Primary)", "Inner color for Navi (when Navi fly around props (signs etc))", "gNavi_Prop_Inner_", navi_prop_i_col, ImVec4(0, 255, 0, 255), false, false, false };
+static CosmeticsColorIndividual Navi_Prop_Outer = { "Navi Enemy (Secondary)", "Outer color for Navi (when Navi fly around props (signs etc))", "gNavi_Prop_Outer_", navi_prop_o_col, ImVec4(0, 255, 0, 255), false, false, false };
+
+//Keese
+static CosmeticsColorIndividual Keese1_prim = { "Fire Primary color", "Affects the primary color of the Fire itself of the Keese", "gKeese1_Ef_Prim", Keese1_primcol, ImVec4(255, 255, 100, 255), true, false, false };
+static CosmeticsColorIndividual Keese2_prim = { "Ice Primary color", "Affects the primary color of the Ice itself of the Keese", "gKeese2_Ef_Prim", Keese2_primcol, ImVec4(100, 200, 255, 255), true, false, false };
+static CosmeticsColorIndividual Keese1_env = { "Fire Secondary color", "Affects the secondary color of the Fire itself of the Keese", "gKeese1_Ef_Env", Keese1_envcol, ImVec4(255, 50, 0, 255), true, false, false };
+static CosmeticsColorIndividual Keese2_env = { "Ice Secondary color", "Affects the secondary color of the Ice itself of the Keese", "gKeese2_Ef_Env", Keese2_envcol, ImVec4(0, 0, 255, 255), true, false, false };
+
+//Good old Dogs, we all love them
+static CosmeticsColorIndividual DogN1 = { "Dog white", "Affects the colors of the white dog", "gDog1Col", doggo1col, ImVec4(255,255,200,255), true, false, true };
+static CosmeticsColorIndividual DogN2 = { "Dog brown", "Affects the colors of the brown dog", "gDog2Col", doggo2col, ImVec4(150,100,50,255), true, false, true };
+
+//Tunics colors
+static CosmeticsColorIndividual KokiriTunic = { "Kokiri Tunic", "Affects Kokiri Tunic color", "gTunic_Kokiri", kokiri_col, ImVec4(30, 105, 27, 255), true, false, true };
+static CosmeticsColorIndividual GoronTunic = { "Goron Tunic", "Affects Goron Tunic color", "gTunic_Goron", goron_col, ImVec4(100, 20, 0, 255), true, false, true };
+static CosmeticsColorIndividual ZoraTunic = { "Zora Tunic", "Affects Zora Tunic color", "gTunic_Zora", zora_col, ImVec4(0, 60, 100, 255), true, false, true };
+
+//Arrows (Fire -> Ice -> Light)
+static CosmeticsColorIndividual Fire_Arrow_Prim = { "Fire Arrows (primary)", "Affects Primary color", "gFireArrowCol", firearrow_col, ImVec4(255,200,0,255), true, false, false };
+static CosmeticsColorIndividual Fire_Arrow_Env = { "Fire Arrows (Secondary)", "Affects Secondary color", "gFireArrowColEnv", firearrow_colenv, ImVec4(255,0,0,255), true, false, false };
+static CosmeticsColorIndividual Ice_Arrow_Prim = { "Ice Arrows (Primary)", "Affects Primary color", "gIceArrowCol", icearrow_col, ImVec4(170,255,255,255), true, false, false };
+static CosmeticsColorIndividual Ice_Arrow_Env = { "Ice Arrows (Secondary)", "Affects Secondary color", "gIceArrowColEnv", icearrow_colenv, ImVec4(0,0,255,255), true, false, false };
+static CosmeticsColorIndividual Light_Arrow_Prim = { "Light Arrows (Primary)", "Affects Primary color", "gLightArrowCol", lightarrow_col, ImVec4(255,255,170,255), true, false, false };
+static CosmeticsColorIndividual Light_Arrow_Env = { "Light Arrows (Secondary)", "Affects Secondary color", "gLightArrowColEnv", lightarrow_colenv, ImVec4(255,255,0,255), true, false, false };
+
+//Spells
+static CosmeticsColorIndividual Din_Fire_Prim = { "Din's Fire (primary)", "Affects Primary color", "gDF_Col", df_col, ImVec4(255,200,0,255), true, false, false };
+static CosmeticsColorIndividual Din_Fire_Env = { "Din's Fire (Secondary)", "Affects Secondary color", "gDF_Env", df_colenv, ImVec4(255,0,0,255), true, false, false };
+static CosmeticsColorIndividual Nayru_Diamond_Prim = { "Nayru's Love Diamond (primary)", "Affects Primary color", "gNL_Diamond_Col", nl_diam_col, ImVec4(170,255,255,255), true, false, false };
+static CosmeticsColorIndividual Nayru_Diamond_Env = { "Nayru's Love Diamond (Secondary)", "Affects Secondary color", "gNL_Diamond_Env", nl_diam_colenv, ImVec4(100,255,128,255), true, false, false };
+static CosmeticsColorIndividual Nayru_Orb_Prim = { "Nayru's Love Orb (primary)", "Affects Primary color", "gNL_Orb_Col", nl_orb_col, ImVec4(170,255,255,255), true, false, false };
+static CosmeticsColorIndividual Nayru_Orb_Env = { "Nayru's Love Orb (Secondary)", "Affects Secondary color", "gNL_Orb_Env", nl_orb_colenv, ImVec4(150,255,255,255), true, false, false };
+
+//Spin attacks colors
+static CosmeticsColorIndividual Spin_Lv1_Prim = { "Level 1 (primary)", "Affects Primary color", "gCharged1Col", charged1_col, ImVec4(170,255,255,255), true, false, false };
+static CosmeticsColorIndividual Spin_Lv1_Env = { "Level 1 (Secondary)", "Affects Secondary color", "gCharged1ColEnv", charged1_colenv, ImVec4(0,100,255,255), true, false, false };
+static CosmeticsColorIndividual Spin_Lv2_Prim = { "Level 2 (primary)", "Affects Primary color", "gCharged2Col", charged2_col, ImVec4(255,255,170,255), true, false, false };
+static CosmeticsColorIndividual Spin_Lv2_Env = { "Level 2 (Secondary)", "Affects Secondary color", "gCharged2ColEnv", charged2_colenv, ImVec4(255,100,0,255), true, false, false };
+
+//Trails
+static CosmeticsColorIndividual Trails_col = { "Trails color", "Affects Swords slash, boomerang and Bombchu trails color", "gTrailCol", trailscol, ImVec4(255,255,255,255), true, false, false };
+
+//Menus - File Choose
+static CosmeticsColorIndividual FileChoose_Background = { "Main menu color", "Affects the File Select menu background.", "gCCFileChoosePrim", fileselect_colors, ImVec4(100, 150, 255, 255), true, false, false };
+static CosmeticsColorIndividual FileChoose_BottomText = { "Bottom texts color", "Affects the File Select texts.", "gCCFileChooseTextPrim", fileselect_text_colors, ImVec4(100, 255, 255, 255), true, false, false };
+
+//Hud Stuff (Dpad, Buttons etc)
+static CosmeticsColorIndividual A_Btn = { "A Button", "Affects the A button colors (and various cursors that use the same theme)", "gCCABtnPrim", a_btn_colors, ImVec4(0, 200, 50, 255), true, false, false };
+static CosmeticsColorIndividual B_Btn = { "B Button", "Affects the B button color", "gCCBBtnPrim", b_btn_colors, ImVec4(255, 30, 30, 255), true, false, false };
+static CosmeticsColorIndividual C_Btn = { "C-Buttons", "Affects the C Buttons' color (if not using separate colors)\nAnd various cursor that use C-Buttons colors", "gCCCBtnPrim", c_btn_colors, ImVec4(255, 160, 0, 255), true, false, false };
+static CosmeticsColorIndividual C_Btn_U = { "C-Buttons Up", "Affects C-Buttons Up colors, but not C cursor colors\nTo edit C Cursor check C-Buttons color on top", "gCCCUBtnPrim", c_btn_u_colors, ImVec4(255,160,0,255), true, false, false };
+static CosmeticsColorIndividual C_Btn_D = { "C-Buttons Down", "Affects C-Buttons Down colors, but not C cursor colors\nTo edit C Cursor check C-Buttons color on top", "gCCCDBtnPrim", c_btn_d_colors, ImVec4(255,160,0,255), true, false, false };
+static CosmeticsColorIndividual C_Btn_L = { "C-Buttons Left", "Affects C-Buttons Left colors, but not C cursor colors\nTo edit C Cursor check C-Buttons color on top", "gCCCLBtnPrim", c_btn_l_colors, ImVec4(255,160,0,255), true, false, false };
+static CosmeticsColorIndividual C_Btn_R = { "C-Buttons Right", "Affects C-Buttons Right colors, but not C cursor colors\nTo edit C Cursor check C-Buttons color on top", "gCCCRBtnPrim", c_btn_r_colors, ImVec4(255,160,0,255), true, false, false };
+static CosmeticsColorIndividual Start_btn = { "Start Button", "Affects the Start button color", "gCCStartBtnPrim", start_btn_colors, ImVec4(200, 0, 0, 255), true, false, false };
+static CosmeticsColorIndividual DPad_Items = { "DPad background", "DPad background color, White is the default value", "gCCDpadPrim", dpad_colors, ImVec4(255, 255, 255, 255), true, false, false };
+
+//Hearts colors
+static CosmeticsColorIndividual Hearts_NInner = { "Inner (Normal)", "Affects the inner color", "gCCHeartsPrim", hearts_colors, ImVec4(255,70,50,255), true, false, false };
+static CosmeticsColorIndividual Hearts_DDInner = { "Inner (Double defense)", "Affects the inner color", "gCCDDHeartsPrim", hearts_ddi_colors, ImVec4(255,70,50,255), true, false, false };
+static CosmeticsColorIndividual Hearts_DDOutline = { "Outline (Double defense)", "Affects the outline color of hearts when you have Double Defense\nWhite is the default value", "gDDCCHeartsPrim", hearts_dd_colors, ImVec4(255,255,255,255), true, false, false };
+
+//Magic Meter colors
+static CosmeticsColorIndividual Magic_Borders = { "Borders", "Affects the border of the magic meter\nWhite is the default value, color change only when used one time", "gCCMagicBorderNormPrim", magic_bordern_colors, ImVec4(255,255,255,255), false, false, false };
+static CosmeticsColorIndividual Magic_InUse_Borders = { "Borders in use", "Affects the border of the magic meter when being used\nWhite is the default value", "gCCMagicBorderPrim", magic_border_colors, ImVec4(255,255,255,255), false, false, false };
+static CosmeticsColorIndividual Magic_Meter = { "Main color", "Affects the magic meter color\nGreen is the default value", "gCCMagicPrim", magic_remaining_colors, ImVec4(0,200,0,255), true, false, false };
+static CosmeticsColorIndividual Magic_InUse_Meter = { "Main color in use", "Affects the magic meter when being used\nYellow is the default value", "gCCMagicUsePrim", magic_use_colors, ImVec4(250,250,0,255), true, false, false };
+
+//Minimap and it's arrow colors
+static CosmeticsColorIndividual Minimap_OW = { "Overworlds", "Affects the Overworld minimaps", "gCCMinimapPrim", minimap_colors, ImVec4(0, 255, 255, 255), true, false, false };
+static CosmeticsColorIndividual Minimap_DG = { "Dungeons", "Affects the Dungeon minimaps", "gCCMinimapDGNPrim", dgn_minimap_colors, ImVec4(100, 255, 255, 255), true, false, false };
+static CosmeticsColorIndividual Minimap_CP = { "Current position arrow", "Affects the current position arrow on the minimap\nYellow is the default value", "gCCMinimapCPPrim", cp_minimap_colors, ImVec4(200, 255, 0, 255), true, false, false };
+static CosmeticsColorIndividual Minimap_LE = { "Last entrance arrow", "Affects the last entrance position arrow on the minimap\nRed is the default value", "gCCMinimapLEPrim", le_minimap_colors, ImVec4(200, 0, 0, 255), true, false, false };
+
+//Title Cards colors
+static CosmeticsColorIndividual TitleCards_OW = { "Main color (Overworld)", "Affects all the overworld title cards color, white is the default value", "gCCTC_OW_U_Prim", tc_ou_colors, ImVec4(255, 255, 255, 255), false, false, false };
+static CosmeticsColorIndividual TitleCards_DG = { "Main color (Dungeon)", "Affects all the bosses title cards color, white is the default value", "gCCTC_B_U_Prim", tc_bu_colors, ImVec4(255, 255, 255, 255), false, false, false };
+
+//Misc. colors, the one I have no clue where to put nor that aren't that important
+#ifdef MASTER_QUEST
+static CosmeticsColorIndividual TitleScreen_fire_Prim = { "Opening logo fire (Primary)", "Affects the fire behind the title screen logo", "gCCTCFirePrim", tc_fire_colors, ImVec4(170, 255, 255, 255), false, false, false };
+static CosmeticsColorIndividual TitleScreen_fire_Env = { "Opening logo fire (Secondary)", "Affects the fire behind the title screen logo", "gCCTCFireEnv", tc_fire_colors_env, ImVec4(200, 255, 0, 255), false, false, false };
+#else
+static CosmeticsColorIndividual TitleScreen_fire_Prim = { "Opening logo fire (Primary)", "Affects the fire behind the title screen logo", "gCCTCFirePrim", tc_fire_colors, ImVec4(255, 255, 170, 255), false, false, false };
+static CosmeticsColorIndividual TitleScreen_fire_Env = { "Opening logo fire (Secondary)", "Affects the fire behind the title screen logo", "gCCTCFireEnv", tc_fire_colors_env, ImVec4(255, 100, 0, 255), false, false, false };
+#endif
+static CosmeticsColorIndividual Rupee_Icon = { "Rupee icon", "Affects the Rupee icon on interface\nGreen is the default value", "gCCRupeePrim", rupee_colors, ImVec4(200, 255, 100, 255), true, false, false };
+static CosmeticsColorIndividual SmallKeys_Icon = { "Small Keys icon", "Affects the Small keys icon on interface\nGray is the default value", "gCCKeysPrim", smolekey_colors, ImVec4(200, 230, 255, 255), true, false, false };
+static CosmeticsColorIndividual VSOA_Icon = { "Visual Stone of agony icon", "Affects the Stone of Agony icon on interface\nWhite is the default value\nRequire room reload or activation", "gCCVSOAPrim", visualagony_colors, ImVec4(255, 255, 255, 255), true, false, false };
+
+//Sections creation, here I regroup them in some sort of a Theme, all navi stuff together etc. It will be used to create the menu.
+static CosmeticsColorSection Navi_Section[] = {
+    { &Navi_Idle_Inner, false, false },
+    { &Navi_Idle_Outer, true, false },
+    { &Navi_Npc_Inner, false, true },
+    { &Navi_Npc_Outer, true, false },
+    { &Navi_Enemy_Inner, false, true },
+    { &Navi_Enemy_Outer, true, false },
+    { &Navi_Prop_Inner, false, true },
+    { &Navi_Prop_Outer, true, false }
+};
+static CosmeticsColorSection Keese_Section[] = {
+    { &Keese1_prim, false, false },
+    { &Keese2_prim, true, false },
+    { &Keese1_env, false, true },
+    { &Keese2_env, true, false }
+};
+static CosmeticsColorSection Dogs_Section[] = {
+    { &DogN1, false, false },
+    { &DogN2, true, false }
+};
+static CosmeticsColorSection Tunics_Section[] = {
+    { &KokiriTunic, false, false },
+    { &GoronTunic, true, false },
+    { &ZoraTunic, true, false }
+};
+static CosmeticsColorSection Arrows_section[] = {
+    { &Fire_Arrow_Prim, false, false },
+    { &Fire_Arrow_Env, true, false },
+    { &Ice_Arrow_Prim, false, true },
+    { &Ice_Arrow_Env, true, false },
+    { &Light_Arrow_Prim, false, true },
+    { &Light_Arrow_Env, true, false }
+};
+static CosmeticsColorSection Spells_section[] = {
+    { &Din_Fire_Prim, false, false },
+    { &Din_Fire_Env, true, false },
+    { &Nayru_Diamond_Prim, false, true },
+    { &Nayru_Diamond_Env, true, false },
+    { &Nayru_Orb_Prim, false, true },
+    { &Nayru_Orb_Env, true, false }
+};
+static CosmeticsColorSection SpinAtk_section[] = {
+    { &Spin_Lv1_Prim, false, false },
+    { &Spin_Lv1_Env, true, false },
+    { &Spin_Lv2_Prim, false, true },
+    { &Spin_Lv2_Env, true, false }
+};
+static CosmeticsColorSection Trails_section[] = {
+    { &Trails_col, false, false }
+};
+static CosmeticsColorSection FileChoose_section[] = {
+    { &FileChoose_Background, false, false },
+    { &FileChoose_BottomText, true, false }
+};
+static CosmeticsColorSection A_Btn_section[] = {
+    { &A_Btn, false, false }
+};
+static CosmeticsColorSection B_Btn_section[] = {
+    { &B_Btn, false, false }
+};
+static CosmeticsColorSection C_Btn_Unified_section[] = {
+    { &C_Btn, false, false }
+};
+static CosmeticsColorSection C_Btn_Separated_section[] = {
+    { &C_Btn_U, false, false },
+    { &C_Btn_D, false, true },
+    { &C_Btn_L, false, true },
+    { &C_Btn_R, false, true }
+};
+static CosmeticsColorSection Start_Btn_section[] = {
+    { &Start_btn, false, false }
+};
+static CosmeticsColorSection DPad_section[] = {
+    { &DPad_Items, false, false }
+};
+static CosmeticsColorSection Hearts_section[] = {
+    { &Hearts_NInner, false, false },
+    { &Hearts_DDInner, true, false },
+    { &Hearts_DDOutline, true, false }
+};
+static CosmeticsColorSection Magic_Meter_section[] = {
+    { &Magic_Borders, false, false },
+    { &Magic_InUse_Borders, true, false },
+    { &Magic_Meter, false, true },
+    { &Magic_InUse_Meter, true, false }
+};
+static CosmeticsColorSection Minimap_section[] = {
+    { &Minimap_OW, false, false },
+    { &Minimap_DG, false, true },
+    { &Minimap_CP, false, true },
+    { &Minimap_LE, false, true }
+};
+static CosmeticsColorSection TitleCards_section[] = {
+    { &TitleCards_OW, false, false },
+    { &TitleCards_DG, true, false }
+};
+static CosmeticsColorSection Misc_section[] = {
+    { &Rupee_Icon, false, false },
+    { &SmallKeys_Icon, false, true },
+    { &VSOA_Icon, false, true },
+    { &TitleScreen_fire_Prim, false, true },
+    { &TitleScreen_fire_Env, false, true }
+};
+
+//Randomizer specific stuff (by randomizer I mean within cosmetics, these section are there just for the purpose of randomizing their colors)
+static CosmeticsColorSection Everything_Section[] = {
+    { &TitleScreen_fire_Prim, false, true },
+    { &TitleScreen_fire_Env, false, true },
+    { &Navi_Idle_Inner, false, false },
+    { &Navi_Idle_Outer, true, false },
+    { &Navi_Npc_Inner, false, true },
+    { &Navi_Npc_Outer, true, false },
+    { &Navi_Enemy_Inner, false, true },
+    { &Navi_Enemy_Outer, true, false },
+    { &Navi_Prop_Inner, false, true },
+    { &Navi_Prop_Outer, true, false },
+    { &Keese1_prim, false, false },
+    { &Keese2_prim, true, false },
+    { &Keese1_env, false, true },
+    { &Keese2_env, true, false },
+    { &DogN1, false, false },
+    { &DogN2, true, false },
+    { &KokiriTunic, false, false },
+    { &GoronTunic, true, false },
+    { &ZoraTunic, true, false },
+    { &Fire_Arrow_Prim, false, false },
+    { &Fire_Arrow_Env, true, false },
+    { &Ice_Arrow_Prim, false, true },
+    { &Ice_Arrow_Env, true, false },
+    { &Light_Arrow_Prim, false, true },
+    { &Light_Arrow_Env, true, false },
+    { &Din_Fire_Prim, false, false },
+    { &Din_Fire_Env, true, false },
+    { &Nayru_Diamond_Prim, false, true },
+    { &Nayru_Diamond_Env, true, false },
+    { &Nayru_Orb_Prim, false, true },
+    { &Nayru_Orb_Env, true, false },
+    { &Spin_Lv1_Prim, false, false },
+    { &Spin_Lv1_Env, true, false },
+    { &Spin_Lv2_Prim, false, true },
+    { &Spin_Lv2_Env, true, false },
+    { &Trails_col, false, false },
+    { &FileChoose_Background, false, false },
+    { &FileChoose_BottomText, true, false },
+    { &A_Btn, false, false },
+    { &B_Btn, false, false },
+    { &C_Btn, false, false },
+    { &C_Btn_U, false, false },
+    { &C_Btn_D, false, true },
+    { &C_Btn_L, false, true },
+    { &C_Btn_R, false, true },
+    { &Start_btn, false, false },
+    { &DPad_Items, false, false },
+    { &Hearts_NInner, false, false },
+    { &Hearts_DDInner, true, false },
+    { &Hearts_DDOutline, true, false },
+    { &Magic_Borders, false, false },
+    { &Magic_InUse_Borders, true, false },
+    { &Magic_Meter, false, true },
+    { &Magic_InUse_Meter, true, false },
+    { &Minimap_OW, false, false },
+    { &Minimap_DG, false, true },
+    { &Minimap_CP, false, true },
+    { &Minimap_LE, false, true },
+    { &TitleCards_OW, false, false },
+    { &TitleCards_DG, true, false },
+    { &Rupee_Icon, false, false },
+    { &SmallKeys_Icon, false, true },
+    { &VSOA_Icon, false, true }
+};
+static CosmeticsColorSection Buttons_section[]{
+    { &DPad_Items, false, false },
+    { &C_Btn_U, false, false },
+    { &C_Btn_D, false, true },
+    { &C_Btn_L, false, true },
+    { &C_Btn_R, false, true },
+    { &C_Btn, false, false },
+    { &B_Btn, false, false },
+    { &A_Btn, false, false },
+    { &Start_btn, false, false }
+};
+static CosmeticsColorSection Misc_Interface_section[]{
+    { &Hearts_NInner, false, false },
+    { &Hearts_DDInner, true, false },
+    { &Hearts_DDOutline, true, false },
+    { &Magic_Borders, false, false },
+    { &Magic_InUse_Borders, true, false },
+    { &Magic_Meter, false, true },
+    { &Magic_InUse_Meter, true, false },
+    { &Minimap_OW, false, false },
+    { &Minimap_DG, false, true },
+    { &Minimap_CP, false, true },
+    { &Minimap_LE, false, true },
+    { &TitleCards_OW, false, false },
+    { &TitleCards_DG, true, false },
+    { &Rupee_Icon, false, false },
+    { &SmallKeys_Icon, false, true },
+    { &VSOA_Icon, false, true },
+    { &TitleScreen_fire_Prim, false, true },
+    { &TitleScreen_fire_Env, false, true }
+};
+static CosmeticsColorSection NPCs_section[]{
+    { &Navi_Idle_Inner, false, false },
+    { &Navi_Idle_Outer, true, false },
+    { &Navi_Npc_Inner, false, true },
+    { &Navi_Npc_Outer, true, false },
+    { &Navi_Enemy_Inner, false, true },
+    { &Navi_Enemy_Outer, true, false },
+    { &Navi_Prop_Inner, false, true },
+    { &Navi_Prop_Outer, true, false },
+    { &Keese1_prim, false, false },
+    { &Keese2_prim, true, false },
+    { &Keese1_env, false, true },
+    { &Keese2_env, true, false },
+    { &DogN1, false, false },
+    { &DogN2, true, false }
+};
+static CosmeticsColorSection AllItemsSkills_section[]{
+    { &KokiriTunic, false, false },
+    { &GoronTunic, true, false },
+    { &ZoraTunic, true, false },
+    { &Fire_Arrow_Prim, false, false },
+    { &Fire_Arrow_Env, true, false },
+    { &Ice_Arrow_Prim, false, true },
+    { &Ice_Arrow_Env, true, false },
+    { &Light_Arrow_Prim, false, true },
+    { &Light_Arrow_Env, true, false },
+    { &Din_Fire_Prim, false, false },
+    { &Din_Fire_Env, true, false },
+    { &Nayru_Diamond_Prim, false, true },
+    { &Nayru_Diamond_Env, true, false },
+    { &Nayru_Orb_Prim, false, true },
+    { &Nayru_Orb_Env, true, false },
+    { &Spin_Lv1_Prim, false, false },
+    { &Spin_Lv1_Env, true, false },
+    { &Spin_Lv2_Prim, false, true },
+    { &Spin_Lv2_Env, true, false },
+    { &Trails_col, false, false }
+};
 
 void InitCosmeticsEditor();//Init the menu itself
 void LoadRainbowColor();

--- a/soh/src/code/z_actor.c
+++ b/soh/src/code/z_actor.c
@@ -1009,20 +1009,15 @@ void TitleCard_InitPlaceName(GlobalContext* globalCtx, TitleCardContext* titleCt
 }
 
 void TitleCard_Update(GlobalContext* globalCtx, TitleCardContext* titleCtx) {
-    s16* TitleCard_Colors[3] = {255,255,255};
-        if (titleCtx->isBossCard && CVar_GetS32("gHudColors", 1) == 2) {//Bosses cards.
-            TitleCard_Colors[0] = CVar_GetS32("gCCTC_B_U_PrimR", 255);
-            TitleCard_Colors[1] = CVar_GetS32("gCCTC_B_U_PrimG", 255);
-            TitleCard_Colors[2] = CVar_GetS32("gCCTC_B_U_PrimB", 255);
-        } else if (!titleCtx->isBossCard && CVar_GetS32("gHudColors", 1) == 2) {
-            TitleCard_Colors[0] = CVar_GetS32("gCCTC_OW_U_PrimR", 255);
-            TitleCard_Colors[1] = CVar_GetS32("gCCTC_OW_U_PrimG", 255);
-            TitleCard_Colors[2] = CVar_GetS32("gCCTC_OW_U_PrimB", 255);
-        } else {
-            TitleCard_Colors[0] = 255;
-            TitleCard_Colors[1] = 255;
-            TitleCard_Colors[2] = 255;
-        }
+    const Color_RGB8 TitleCard_Colors_ori = {255,255,255};
+    Color_RGB8 TitleCard_Colors = {255,255,255};
+    if (titleCtx->isBossCard && CVar_GetS32("gHudColors", 1) == 2) {//Bosses cards.
+        TitleCard_Colors = CVar_GetRGB("gCCTC_B_U_Prim", TitleCard_Colors_ori);
+    } else if (!titleCtx->isBossCard && CVar_GetS32("gHudColors", 1) == 2) {
+        TitleCard_Colors = CVar_GetRGB("gCCTC_OW_U_Prim", TitleCard_Colors_ori);
+    } else {
+        TitleCard_Colors = TitleCard_Colors_ori;
+    }
 
     if (DECR(titleCtx->delayTimer) == 0) {
         if (DECR(titleCtx->durationTimer) == 0) {
@@ -1032,9 +1027,9 @@ void TitleCard_Update(GlobalContext* globalCtx, TitleCardContext* titleCtx) {
             Math_StepToS(&titleCtx->intensityB, 0, 70);
         } else {
             Math_StepToS(&titleCtx->alpha, 255, 10);
-            Math_StepToS(&titleCtx->intensityR, TitleCard_Colors[0], 20);
-            Math_StepToS(&titleCtx->intensityG, TitleCard_Colors[1], 20);
-            Math_StepToS(&titleCtx->intensityB, TitleCard_Colors[2], 20);
+            Math_StepToS(&titleCtx->intensityR, TitleCard_Colors.r, 20);
+            Math_StepToS(&titleCtx->intensityG, TitleCard_Colors.g, 20);
+            Math_StepToS(&titleCtx->intensityB, TitleCard_Colors.b, 20);
         }
     }
 }

--- a/soh/src/code/z_eff_blure.c
+++ b/soh/src/code/z_eff_blure.c
@@ -3,6 +3,8 @@
 
 #include "soh/frame_interpolation.h"
 
+const Color_RGB8 Trails_Color_ori = {255,255,255};
+
 void EffectBlure_AddVertex(EffectBlure* this, Vec3f* p1, Vec3f* p2) {
     EffectBlureElement* elem;
     s32 numElements;
@@ -198,6 +200,7 @@ s32 EffectBlure_Update(void* thisx) {
     s16 GreenColor;
     s16 BlueColor;
     s16 TrailDuration;
+    Color_RGB8 Trails_col = CVar_GetRGB("gTrailCol", Trails_Color_ori);
 
     if (this == NULL) {
         return 0;
@@ -208,16 +211,17 @@ s32 EffectBlure_Update(void* thisx) {
     }
 
     if (CVar_GetS32("gUseTrailsCol", 0) !=0) {
-        RedColor = CVar_GetS32("gTrailColR",255);
-        GreenColor = CVar_GetS32("gTrailColG",255);
-        BlueColor = CVar_GetS32("gTrailColB",255);
-        TrailDuration = 4.0f*CVar_GetS32("gTrailDurantion",1);
+        RedColor = Trails_col.r;
+        GreenColor = Trails_col.g;
+        BlueColor = Trails_col.b;
+        TrailDuration = 4.0f * CVar_GetS32("gTrailDurantion",1);
     } else {
-        RedColor = 255;
-        GreenColor = 255;
-        BlueColor = 255;
+        RedColor = Trails_Color_ori.r;
+        GreenColor = Trails_Color_ori.g;
+        BlueColor = Trails_Color_ori.b;
         TrailDuration=4.0f;
     }
+
     this->p1StartColor.r = RedColor;
     this->p2StartColor.r = RedColor;
     this->p1EndColor.r = RedColor;

--- a/soh/src/code/z_lifemeter.c
+++ b/soh/src/code/z_lifemeter.c
@@ -112,9 +112,12 @@ static s16 sHeartsDDEnvFactors[3][3] = {
 };
 
 // Current colors for the double defense hearts
-s16 HeartInner[3] = {HEARTS_PRIM_R,HEARTS_PRIM_G,HEARTS_PRIM_B};
-s16 HeartDDOutline[3] = {HEARTS_DD_PRIM_R,HEARTS_DD_PRIM_G,HEARTS_DD_PRIM_B};
-s16 HeartDDInner[3] = {HEARTS_DD_ENV_R,HEARTS_DD_ENV_G,HEARTS_DD_ENV_B};
+Color_RGB8 HeartInner_ori = {HEARTS_PRIM_R,HEARTS_PRIM_G,HEARTS_PRIM_B};
+Color_RGB8 HeartDDOutline_ori = {HEARTS_DD_PRIM_R,HEARTS_DD_PRIM_G,HEARTS_DD_PRIM_B};
+Color_RGB8 HeartDDInner_ori = {HEARTS_DD_ENV_R,HEARTS_DD_ENV_G,HEARTS_DD_ENV_B};
+Color_RGB8 HeartInner;
+Color_RGB8 HeartDDOutline;
+Color_RGB8 HeartDDInner;
 s16 sBeatingHeartsDDPrim[3];
 s16 sBeatingHeartsDDEnv[3];
 s16 sHeartsDDPrim[2][3];
@@ -123,19 +126,13 @@ s16 sHeartsDDEnv[2][3];
 void HealthMeter_Init(GlobalContext* globalCtx) {
     InterfaceContext* interfaceCtx = &globalCtx->interfaceCtx;
     if (CVar_GetS32("gHudColors", 1) == 2) {
-        HeartInner[0] = CVar_GetS32("gCCHeartsPrimR", 90);
-        HeartInner[1] = CVar_GetS32("gCCHeartsPrimG", 90);
-        HeartInner[2] = CVar_GetS32("gCCHeartsPrimB", 90);
-        HeartDDOutline[0] = CVar_GetS32("gDDCCHeartsPrimR", 90);
-        HeartDDOutline[1] = CVar_GetS32("gDDCCHeartsPrimG", 90);
-        HeartDDOutline[2] = CVar_GetS32("gDDCCHeartsPrimB", 90);
+        HeartInner = CVar_GetRGB("gCCHeartsPrim", HeartInner_ori);
+        HeartDDInner = CVar_GetRGB("gCCDDHeartsPrim", HeartDDInner_ori);
+        HeartDDOutline = CVar_GetRGB("gDDCCHeartsPrim", HeartDDOutline_ori);
     } else {
-        HeartInner[0] = HEARTS_PRIM_R;
-        HeartInner[1] = HEARTS_PRIM_G;
-        HeartInner[2] = HEARTS_PRIM_B;
-        HeartDDOutline[0] = HEARTS_DD_PRIM_R;
-        HeartDDOutline[1] = HEARTS_DD_PRIM_G;
-        HeartDDOutline[2] = HEARTS_DD_PRIM_B;
+        HeartInner = HeartInner_ori;
+        HeartDDInner = HeartDDInner_ori;
+        HeartDDOutline = HeartDDOutline_ori;
     }
 
     interfaceCtx->unk_228 = 0x140;
@@ -143,33 +140,33 @@ void HealthMeter_Init(GlobalContext* globalCtx) {
     interfaceCtx->unk_22A = interfaceCtx->unk_1FE = 0;
     interfaceCtx->unk_22C = interfaceCtx->unk_200 = 0;
 
-    interfaceCtx->heartsPrimR[0] = HeartInner[0];
-    interfaceCtx->heartsPrimG[0] = HeartInner[1];
-    interfaceCtx->heartsPrimB[0] = HeartInner[2];
+    interfaceCtx->heartsPrimR[0] = HeartInner.r;
+    interfaceCtx->heartsPrimG[0] = HeartInner.g;
+    interfaceCtx->heartsPrimB[0] = HeartInner.b;
 
     interfaceCtx->heartsEnvR[0] = HEARTS_ENV_R;
     interfaceCtx->heartsEnvG[0] = HEARTS_ENV_G;
     interfaceCtx->heartsEnvB[0] = HEARTS_ENV_B;
 
-    interfaceCtx->heartsPrimR[1] = HeartInner[0];
-    interfaceCtx->heartsPrimG[1] = HeartInner[1];
-    interfaceCtx->heartsPrimB[1] = HeartInner[2];
+    interfaceCtx->heartsPrimR[1] = HeartInner.r;
+    interfaceCtx->heartsPrimG[1] = HeartInner.g;
+    interfaceCtx->heartsPrimB[1] = HeartInner.b;
 
     interfaceCtx->heartsEnvR[1] = HEARTS_ENV_R;
     interfaceCtx->heartsEnvG[1] = HEARTS_ENV_G;
     interfaceCtx->heartsEnvB[1] = HEARTS_ENV_B;
 
-    sHeartsDDPrim[0][0] = sHeartsDDPrim[1][0] = HeartDDOutline[0];
-    sHeartsDDPrim[0][1] = sHeartsDDPrim[1][1] = HeartDDOutline[1];
-    sHeartsDDPrim[0][2] = sHeartsDDPrim[1][2] = HeartDDOutline[2];
+    sHeartsDDPrim[0][0] = sHeartsDDPrim[1][0] = HeartDDOutline.r;
+    sHeartsDDPrim[0][1] = sHeartsDDPrim[1][1] = HeartDDOutline.b;
+    sHeartsDDPrim[0][2] = sHeartsDDPrim[1][2] = HeartDDOutline.b;
 
     // sHeartsDDPrim[2][0] = HeartInner[0];
     // sHeartsDDPrim[2][1] = HeartInner[1];
     // sHeartsDDPrim[2][2] = HeartInner[2];
 
-    sHeartsDDEnv[0][0] = sHeartsDDEnv[1][0] = HeartDDInner[0];
-    sHeartsDDEnv[0][1] = sHeartsDDEnv[1][1] = HeartDDInner[1];
-    sHeartsDDEnv[0][2] = sHeartsDDEnv[1][2] = HeartDDInner[2];
+    sHeartsDDEnv[0][0] = sHeartsDDEnv[1][0] = HeartDDInner.r;
+    sHeartsDDEnv[0][1] = sHeartsDDEnv[1][1] = HeartDDInner.g;
+    sHeartsDDEnv[0][2] = sHeartsDDEnv[1][2] = HeartDDInner.b;
 }
 
 void HealthMeter_Update(GlobalContext* globalCtx) {
@@ -188,19 +185,13 @@ void HealthMeter_Update(GlobalContext* globalCtx) {
     Bottom_LM_Margin = CVar_GetS32("gHUDMargin_B", 0);
 
     if (CVar_GetS32("gHudColors", 1) == 2) {
-        HeartInner[0] = CVar_GetS32("gCCHeartsPrimR", sHeartsPrimColors[0][0]);
-        HeartInner[1] = CVar_GetS32("gCCHeartsPrimG", sHeartsPrimColors[0][1]);
-        HeartInner[2] = CVar_GetS32("gCCHeartsPrimB", sHeartsPrimColors[0][2]);
-        HeartDDOutline[0] = CVar_GetS32("gDDCCHeartsPrimR", sHeartsDDPrim[0][0]);
-        HeartDDOutline[1] = CVar_GetS32("gDDCCHeartsPrimG", sHeartsDDPrim[0][1]);
-        HeartDDOutline[2] = CVar_GetS32("gDDCCHeartsPrimB", sHeartsDDPrim[0][2]);
+        HeartInner = CVar_GetRGB("gCCHeartsPrim", HeartInner_ori);
+        HeartDDInner = CVar_GetRGB("gCCDDHeartsPrim", HeartDDInner_ori);
+        HeartDDOutline = CVar_GetRGB("gDDCCHeartsPrim", HeartDDOutline_ori);
     } else {
-        HeartInner[0] = HEARTS_PRIM_R;
-        HeartInner[1] = HEARTS_PRIM_G;
-        HeartInner[2] = HEARTS_PRIM_B;
-        HeartDDOutline[0] = HEARTS_DD_PRIM_R;
-        HeartDDOutline[1] = HEARTS_DD_PRIM_G;
-        HeartDDOutline[2] = HEARTS_DD_PRIM_B;
+        HeartInner = HeartInner_ori;
+        HeartDDInner = HeartDDInner_ori;
+        HeartDDOutline = HeartDDOutline_ori;
     }
 
     if (interfaceCtx->unk_200 != 0) {
@@ -219,18 +210,18 @@ void HealthMeter_Update(GlobalContext* globalCtx) {
 
     ddFactor = factor;
 
-    interfaceCtx->heartsPrimR[0] = HeartInner[0];
-    interfaceCtx->heartsPrimG[0] = HeartInner[1];
-    interfaceCtx->heartsPrimB[0] = HeartInner[2];
+    interfaceCtx->heartsPrimR[0] = HeartInner.r;
+    interfaceCtx->heartsPrimG[0] = HeartInner.g;
+    interfaceCtx->heartsPrimB[0] = HeartInner.b;
 
     interfaceCtx->heartsEnvR[0] = HEARTS_ENV_R;
     interfaceCtx->heartsEnvG[0] = HEARTS_ENV_G;
     interfaceCtx->heartsEnvB[0] = HEARTS_ENV_B;
 
     if (CVar_GetS32("gHudColors", 1) == 2) {
-        interfaceCtx->heartsPrimR[1] = HeartInner[0];
-        interfaceCtx->heartsPrimG[1] = HeartInner[1];
-        interfaceCtx->heartsPrimB[1] = HeartInner[2];
+        interfaceCtx->heartsPrimR[1] = HeartInner.r;
+        interfaceCtx->heartsPrimG[1] = HeartInner.g;
+        interfaceCtx->heartsPrimB[1] = HeartInner.b;
     } else {
         interfaceCtx->heartsPrimR[1] = sHeartsPrimColors[type][0];
         interfaceCtx->heartsPrimG[1] = sHeartsPrimColors[type][1];
@@ -245,9 +236,9 @@ void HealthMeter_Update(GlobalContext* globalCtx) {
     gFactor = sHeartsPrimFactors[0][1] * factor;
     bFactor = sHeartsPrimFactors[0][2] * factor;
 
-    interfaceCtx->beatingHeartPrim[0] = (u8)(rFactor + HeartInner[0]) & 0xFF;
-    interfaceCtx->beatingHeartPrim[1] = (u8)(gFactor + HeartInner[1]) & 0xFF;
-    interfaceCtx->beatingHeartPrim[2] = (u8)(bFactor + HeartInner[2]) & 0xFF;
+    interfaceCtx->beatingHeartPrim[0] = (u8)(rFactor + HeartInner.r) & 0xFF;
+    interfaceCtx->beatingHeartPrim[1] = (u8)(gFactor + HeartInner.g) & 0xFF;
+    interfaceCtx->beatingHeartPrim[2] = (u8)(bFactor + HeartInner.b) & 0xFF;
 
     rFactor = sHeartsEnvFactors[0][0] * factor;
     gFactor = sHeartsEnvFactors[0][1] * factor;
@@ -259,50 +250,48 @@ void HealthMeter_Update(GlobalContext* globalCtx) {
 
     ddType = type;
 
-    sHeartsDDPrim[0][0] = HeartDDOutline[0];
-    sHeartsDDPrim[0][1] = HeartDDOutline[1];
-    sHeartsDDPrim[0][2] = HeartDDOutline[2];
+    sHeartsDDPrim[0][0] = HeartDDOutline.r;
+    sHeartsDDPrim[0][1] = HeartDDOutline.g;
+    sHeartsDDPrim[0][2] = HeartDDOutline.b;
 
-    sHeartsDDEnv[0][0] = HeartDDInner[0];
-    sHeartsDDEnv[0][1] = HeartDDInner[1];
-    sHeartsDDEnv[0][2] = HeartDDInner[2];
+    sHeartsDDEnv[0][0] = HeartDDInner.r;
+    sHeartsDDEnv[0][1] = HeartDDInner.g;
+    sHeartsDDEnv[0][2] = HeartDDInner.b;
 
     if (CVar_GetS32("gHudColors", 1) == 2) {
-        sHeartsDDPrim[2][0] = CVar_GetS32("gCCDDHeartsPrimR", 255);
-        sHeartsDDPrim[2][1] = CVar_GetS32("gCCDDHeartsPrimG", 70);
-        sHeartsDDPrim[2][2] = CVar_GetS32("gCCDDHeartsPrimB", 50);
+        sHeartsDDPrim[2][0] = HeartDDInner.r;
+        sHeartsDDPrim[2][1] = HeartDDInner.g;
+        sHeartsDDPrim[2][2] = HeartDDInner.b;
 
-        sHeartsDDPrim[1][0] = HeartDDOutline[0];
-        sHeartsDDPrim[1][1] = HeartDDOutline[1];
-        sHeartsDDPrim[1][2] = HeartDDOutline[2];
+        sHeartsDDPrim[1][0] = HeartDDOutline.r;
+        sHeartsDDPrim[1][1] = HeartDDOutline.g;
+        sHeartsDDPrim[1][2] = HeartDDOutline.b;
 
-        sHeartsDDEnv[1][0] = CVar_GetS32("gCCDDHeartsPrimR", 255);
-        sHeartsDDEnv[1][1] = CVar_GetS32("gCCDDHeartsPrimG", 70);
-        sHeartsDDEnv[1][2] = CVar_GetS32("gCCDDHeartsPrimB", 50);
+        sHeartsDDEnv[1][0] = HeartDDInner.r;
+        sHeartsDDEnv[1][1] = HeartDDInner.g;
+        sHeartsDDEnv[1][2] = HeartDDInner.b;
 
-        HeartDDInner[0] = CVar_GetS32("gCCDDHeartsPrimR", 255);
-        HeartDDInner[1] = CVar_GetS32("gCCDDHeartsPrimG", 70);
-        HeartDDInner[2] = CVar_GetS32("gCCDDHeartsPrimB", 50);
+        HeartDDInner = CVar_GetRGB("gCCDDHeartsPrim", HeartDDInner_ori);
 
-        sHeartsDDEnv[0][0] = CVar_GetS32("gCCDDHeartsPrimR", 255);
-        sHeartsDDEnv[0][1] = CVar_GetS32("gCCDDHeartsPrimG", 70);
-        sHeartsDDEnv[0][2] = CVar_GetS32("gCCDDHeartsPrimB", 0);
+        sHeartsDDEnv[0][0] = HeartDDInner.r;
+        sHeartsDDEnv[0][1] = HeartDDInner.g;
+        sHeartsDDEnv[0][2] = HeartDDInner.b;
 
         rFactor = sHeartsDDPrimFactors[ddType][0] * ddFactor;
         gFactor = sHeartsDDPrimFactors[ddType][1] * ddFactor;
         bFactor = sHeartsDDPrimFactors[ddType][2] * ddFactor;
 
-        sBeatingHeartsDDPrim[0] = (u8)(rFactor + HeartDDOutline[0]) & 0xFF;
-        sBeatingHeartsDDPrim[1] = (u8)(gFactor + HeartDDOutline[1]) & 0xFF;
-        sBeatingHeartsDDPrim[2] = (u8)(bFactor + HeartDDOutline[2]) & 0xFF;
+        sBeatingHeartsDDPrim[0] = (u8)(rFactor + HeartDDOutline.r) & 0xFF;
+        sBeatingHeartsDDPrim[1] = (u8)(gFactor + HeartDDOutline.g) & 0xFF;
+        sBeatingHeartsDDPrim[2] = (u8)(bFactor + HeartDDOutline.b) & 0xFF;
 
         rFactor = sHeartsDDEnvFactors[ddType][0] * ddFactor;
         gFactor = sHeartsDDEnvFactors[ddType][1] * ddFactor;
         bFactor = sHeartsDDEnvFactors[ddType][2] * ddFactor;
 
-        sBeatingHeartsDDEnv[0] = (u8)(rFactor + HeartDDInner[0]) & 0xFF;
-        sBeatingHeartsDDEnv[1] = (u8)(gFactor + HeartDDInner[1]) & 0xFF;
-        sBeatingHeartsDDEnv[2] = (u8)(bFactor + HeartDDInner[2]) & 0xFF;
+        sBeatingHeartsDDEnv[0] = (u8)(rFactor + HeartDDInner.r) & 0xFF;
+        sBeatingHeartsDDEnv[1] = (u8)(gFactor + HeartDDInner.g) & 0xFF;
+        sBeatingHeartsDDEnv[2] = (u8)(bFactor + HeartDDInner.b) & 0xFF;
     } else {    
         sHeartsDDPrim[0][0] = HEARTS_DD_PRIM_R;
         sHeartsDDPrim[0][1] = HEARTS_DD_PRIM_G;
@@ -413,6 +402,12 @@ void HealthMeter_Draw(GlobalContext* globalCtx) {
     s32 curCombineModeSet = 0;
     u8* curBgImgLoaded = NULL;
     s32 ddHeartCountMinusOne = gSaveContext.inventory.defenseHearts - 1;
+    float HeartsScale = 0.7f; 
+    if (CVar_GetS32("gHeartsCountPosType", 0) != 0) {
+        HeartsScale = CVar_GetFloat("gHeartsCountScale", 0.7f);
+    }
+    static u32 epoch = 0;
+    epoch++;
 
     OPEN_DISPS(gfxCtx);
 
@@ -433,14 +428,14 @@ void HealthMeter_Draw(GlobalContext* globalCtx) {
     s16 PosX_original = OTRGetDimensionFromLeftEdge(0.0f)+X_Margins;
     s16 PosY_original = 0.0f+Y_Margins;
     if (CVar_GetS32("gHeartsCountPosType", 0) != 0) {
-        offsetY = CVar_GetS32("gHeartsPosY", 0)+Y_Margins;
+        offsetY = CVar_GetS32("gHeartsCountPosY", 0)+Y_Margins+(HeartsScale*15);
         if (CVar_GetS32("gHeartsCountPosType", 0) == 1) {//Anchor Left
-            offsetX = OTRGetDimensionFromLeftEdge(CVar_GetS32("gHeartsPosX", 0)+X_Margins);
+            offsetX = OTRGetDimensionFromLeftEdge(CVar_GetS32("gHeartsCountPosX", 0)+X_Margins+70.0f);
         } else if (CVar_GetS32("gHeartsCountPosType", 0) == 2) {//Anchor Right
             X_Margins = Right_LM_Margin;
-            offsetX = OTRGetDimensionFromRightEdge(CVar_GetS32("gHeartsPosX", 0)+X_Margins);
+            offsetX = OTRGetDimensionFromRightEdge(CVar_GetS32("gHeartsCountPosX", 0)+X_Margins+70.0f);
         } else if (CVar_GetS32("gHeartsCountPosType", 0) == 3) {//Anchor None
-            offsetX = CVar_GetS32("gHeartsPosX", 0);
+            offsetX = CVar_GetS32("gHeartsCountPosX", 0)+70.0f;
         } else if (CVar_GetS32("gHeartsCountPosType", 0) == 4) {//Hidden
             offsetX = -9999;
         }
@@ -568,16 +563,27 @@ void HealthMeter_Draw(GlobalContext* globalCtx) {
                 }
             }
 
-            temp3 = 26.0f + offsetY;
-            temp2 = 30.0f + offsetX;
-            temp4 = 1.0f;
-            temp4 /= 0.68f;
+            temp3 = offsetY;
+            temp2 = offsetX;
+            temp4 = 1.0f;//Heart texture size
+            temp4 /= 0.68f; //Hearts Scaled size
             temp4 *= 1 << 10;
             temp1 = 8.0f;
             temp1 *= 0.68f;
-            gSPWideTextureRectangle(OVERLAY_DISP++, (s32)((temp2 - temp1) * 4), (s32)((temp3 - temp1) * 4),
+            /*gSPWideTextureRectangle(OVERLAY_DISP++, (s32)((temp2 - temp1) * 4), (s32)((temp3 - temp1) * 4),
                                 (s32)((temp2 + temp1) * 4), (s32)((temp3 + temp1) * 4), G_TX_RENDERTILE, 0, 0,
-                                (s32)temp4, (s32)temp4);
+                                (s32)temp4, (s32)temp4);*/
+            Mtx* matrix = Graph_Alloc(gfxCtx, sizeof(Mtx));
+            Matrix_SetTranslateScaleMtx2(matrix, 
+                HeartsScale, //Scale X
+                HeartsScale, //Scale Y
+                HeartsScale, //Scale Z
+                -130+offsetX, //Pos X
+                (-94+offsetY) *-1, //Pos Y
+                0.0f); //Pos Z
+            gSPMatrix(OVERLAY_DISP++, matrix, G_MTX_MODELVIEW | G_MTX_LOAD);
+            gSPVertex(OVERLAY_DISP++, sp154, 4, 0);
+            gSP1Quadrangle(OVERLAY_DISP++, 0, 2, 3, 1, 0);
         } else {
             if ((ddHeartCountMinusOne < 0) || (i > ddHeartCountMinusOne)) {
                 if (curCombineModeSet != 2) {
@@ -597,28 +603,33 @@ void HealthMeter_Draw(GlobalContext* globalCtx) {
 
             {
                 Mtx* matrix = Graph_Alloc(gfxCtx, sizeof(Mtx));
-                Matrix_SetTranslateScaleMtx2(matrix, 1.0f - (0.32f * sp144), 1.0f - (0.32f * sp144),
-                                             1.0f - (0.32f * sp144), -130.0f + offsetX,
-                                             94.5f - offsetY, 0.0f);
+                Matrix_SetTranslateScaleMtx2(matrix, 
+                HeartsScale+(HeartsScale/3) - ((HeartsScale/3) * sp144), 
+                HeartsScale+(HeartsScale/3) - ((HeartsScale/3) * sp144),
+                HeartsScale+(HeartsScale/3) - ((HeartsScale/3) * sp144), 
+                -130+offsetX, //Pos X
+                (-94+offsetY) *-1, //Pos Y
+                0.0f);
                 gSPMatrix(OVERLAY_DISP++, matrix, G_MTX_MODELVIEW | G_MTX_LOAD);
                 gSPVertex(OVERLAY_DISP++, sp154, 4, 0);
                 gSP1Quadrangle(OVERLAY_DISP++, 0, 2, 3, 1, 0);
             }
         }
 
-        offsetX += 10.0f;
+        //offsetX += 10.0f;
+        offsetX += (HeartsScale*14.5f);
         if (i == 9) {
             PosX_original = OTRGetDimensionFromLeftEdge(0.0f)+X_Margins;
-            PosY_original = 10.0f+Y_Margins;
+            PosY_original = (HeartsScale*15)+Y_Margins;
             if (CVar_GetS32("gHeartsCountPosType", 0) != 0) {
-                offsetY = CVar_GetS32("gHeartsPosY", 0)+Y_Margins+10.0f;
+                offsetY = CVar_GetS32("gHeartsCountPosY", 0)+((HeartsScale*15)*2)+Y_Margins;
                 if (CVar_GetS32("gHeartsCountPosType", 0) == 1) {//Anchor Left
-                    offsetX = OTRGetDimensionFromLeftEdge(CVar_GetS32("gHeartsPosX", 0)+X_Margins);
+                    offsetX = OTRGetDimensionFromLeftEdge(CVar_GetS32("gHeartsCountPosX", 0)+X_Margins+70.0f);
                 } else if (CVar_GetS32("gHeartsCountPosType", 0) == 2) {//Anchor Right
                     X_Margins = Right_LM_Margin;
-                    offsetX = OTRGetDimensionFromRightEdge(CVar_GetS32("gHeartsPosX", 0)+X_Margins);
+                    offsetX = OTRGetDimensionFromRightEdge(CVar_GetS32("gHeartsCountPosX", 0)+X_Margins+70.0f);
                 } else if (CVar_GetS32("gHeartsCountPosType", 0) == 3) {//Anchor None
-                    offsetX = CVar_GetS32("gHeartsPosX", 0);
+                    offsetX = CVar_GetS32("gHeartsCountPosX", 0)+70.0f;
                 } else if (CVar_GetS32("gHeartsCountPosType", 0) == 4) {//Hidden
                     offsetX = -9999;
                 }

--- a/soh/src/code/z_map_exp.c
+++ b/soh/src/code/z_map_exp.c
@@ -601,6 +601,8 @@ void Minimap_DrawCompassIcons(GlobalContext* globalCtx) {
     s32 pad;
     Player* player = GET_PLAYER(globalCtx);
     s16 tempX, tempZ;
+    const Color_RGB8 LastEntrance_arrow = { 200, 0, 0 };
+    const Color_RGB8 CurrentPosition_arrow = { 200, 255, 0 };
     s16 X_Margins_Minimap;
     s16 Y_Margins_Minimap;
     if (CVar_GetS32("gMinimapUseMargins", 0) != 0) {
@@ -658,9 +660,9 @@ void Minimap_DrawCompassIcons(GlobalContext* globalCtx) {
                   G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
 
         if (CVar_GetS32("gHudColors", 1) == 2) {
-            gDPSetPrimColor(OVERLAY_DISP++, 0, 0xFF, CVar_GetS32("gCCMinimapCPPrimR", 200), CVar_GetS32("gCCMinimapCPPrimG", 255), CVar_GetS32("gCCMinimapCPPrimB", 0), 255);
+            gDPSetPrimColor(OVERLAY_DISP++, 0, 0xFF, CVar_GetRGB("gCCMinimapCPPrim", CurrentPosition_arrow).r, CVar_GetRGB("gCCMinimapCPPrim", CurrentPosition_arrow).g, CVar_GetRGB("gCCMinimapCPPrim", CurrentPosition_arrow).b, 255);       
         } else {
-            gDPSetPrimColor(OVERLAY_DISP++, 0, 0xFF, 200, 255, 0, 255);
+            gDPSetPrimColor(OVERLAY_DISP++, 0, 0xFF, CurrentPosition_arrow.r, CurrentPosition_arrow.g, CurrentPosition_arrow.b, 255);
         }
         gSPDisplayList(OVERLAY_DISP++, gCompassArrowDL);
 
@@ -699,9 +701,9 @@ void Minimap_DrawCompassIcons(GlobalContext* globalCtx) {
                   G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
 
         if (CVar_GetS32("gHudColors", 1) == 2) {
-            gDPSetPrimColor(OVERLAY_DISP++, 0, 0xFF, CVar_GetS32("gCCMinimapLEPrimR", 200), CVar_GetS32("gCCMinimapLEPrimG", 0), CVar_GetS32("gCCMinimapLEPrimB", 0), 255);
+            gDPSetPrimColor(OVERLAY_DISP++, 0, 0xFF, CVar_GetRGB("gCCMinimapLEPrim", LastEntrance_arrow).r,CVar_GetRGB("gCCMinimapLEPrim", LastEntrance_arrow).g,CVar_GetRGB("gCCMinimapLEPrim", LastEntrance_arrow).b, 255);
         } else {
-            gDPSetPrimColor(OVERLAY_DISP++, 0, 0xFF, 200, 0, 0, 255);
+            gDPSetPrimColor(OVERLAY_DISP++, 0, 0xFF, LastEntrance_arrow.r, LastEntrance_arrow.g, LastEntrance_arrow.b, 255);
         }
         gSPDisplayList(OVERLAY_DISP++, gCompassArrowDL);
     }
@@ -713,6 +715,8 @@ void Minimap_Draw(GlobalContext* globalCtx) {
     s32 pad[2];
     InterfaceContext* interfaceCtx = &globalCtx->interfaceCtx;
     s32 mapIndex = gSaveContext.mapIndex;
+    const Color_RGB8 Dungeon_minimap = {100, 255, 255};
+    const Color_RGB8 Overworld_minimap = {R_MINIMAP_COLOR(0), R_MINIMAP_COLOR(1), R_MINIMAP_COLOR(2)};
 
     OPEN_DISPS(globalCtx->state.gfxCtx);
 
@@ -751,9 +755,9 @@ void Minimap_Draw(GlobalContext* globalCtx) {
 
                     if (CHECK_DUNGEON_ITEM(DUNGEON_MAP, mapIndex)) {
                         if (CVar_GetS32("gHudColors", 1) == 2) { //Dungeon minimap
-                            gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetS32("gCCMinimapDGNPrimR", R_MINIMAP_COLOR(0)), CVar_GetS32("gCCMinimapDGNPrimG", R_MINIMAP_COLOR(1)), CVar_GetS32("gCCMinimapDGNPrimB", R_MINIMAP_COLOR(2)), interfaceCtx->minimapAlpha);
+                            gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetRGB("gCCMinimapDGNPrim", Dungeon_minimap).r,CVar_GetRGB("gCCMinimapDGNPrim", Dungeon_minimap).g,CVar_GetRGB("gCCMinimapDGNPrim", Dungeon_minimap).b, interfaceCtx->minimapAlpha);
                         } else {
-                            gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 100, 255, 255, interfaceCtx->minimapAlpha);
+                            gDPSetPrimColor(OVERLAY_DISP++, 0, 0, Dungeon_minimap.r, Dungeon_minimap.g, Dungeon_minimap.b, interfaceCtx->minimapAlpha);
                         }
 
                         gSPInvalidateTexCache(OVERLAY_DISP++, interfaceCtx->mapSegment);
@@ -826,9 +830,9 @@ void Minimap_Draw(GlobalContext* globalCtx) {
 
                     gDPSetCombineMode(OVERLAY_DISP++, G_CC_MODULATEIA_PRIM, G_CC_MODULATEIA_PRIM);
                     if (CVar_GetS32("gHudColors", 1) == 2) {//Overworld minimap
-                        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetS32("gCCMinimapPrimR", R_MINIMAP_COLOR(0)), CVar_GetS32("gCCMinimapPrimG", R_MINIMAP_COLOR(1)), CVar_GetS32("gCCMinimapPrimB", R_MINIMAP_COLOR(2)), interfaceCtx->minimapAlpha);
+                        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetRGB("gCCMinimapPrim", Overworld_minimap).r,CVar_GetRGB("gCCMinimapPrim", Overworld_minimap).g,CVar_GetRGB("gCCMinimapPrim", Overworld_minimap).b, interfaceCtx->minimapAlpha);
                     } else {
-                        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_MINIMAP_COLOR(0), R_MINIMAP_COLOR(1), R_MINIMAP_COLOR(2), interfaceCtx->minimapAlpha);
+                        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, Overworld_minimap.r, Overworld_minimap.g, Overworld_minimap.b, interfaceCtx->minimapAlpha);
                     }
 
                     gDPLoadTextureBlock_4b(OVERLAY_DISP++, interfaceCtx->mapSegment, G_IM_FMT_IA,
@@ -858,7 +862,7 @@ void Minimap_Draw(GlobalContext* globalCtx) {
                                             0, 1 << 10, 1 << 10);
 
                     if (CVar_GetS32("gHudColors", 1) != 2) {//This need to be added else it will color dungeon entrance icon too. (it re-init prim color to default color)
-                        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_MINIMAP_COLOR(0), R_MINIMAP_COLOR(1), R_MINIMAP_COLOR(2), interfaceCtx->minimapAlpha);
+                        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, Overworld_minimap.r, Overworld_minimap.g, Overworld_minimap.b, interfaceCtx->minimapAlpha);
                     }
 
                     if (((globalCtx->sceneNum != SCENE_SPOT01) && (globalCtx->sceneNum != SCENE_SPOT04) &&

--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -165,9 +165,8 @@ static u16 sCUpTimer = 0;
 s16 gSpoilingItems[] = { ITEM_ODD_MUSHROOM, ITEM_FROG, ITEM_EYEDROPS };
 s16 gSpoilingItemReverts[] = { ITEM_COJIRO, ITEM_PRESCRIPTION, ITEM_PRESCRIPTION };
 
-static s16 sMagicBorderR = 255;
-static s16 sMagicBorderG = 255;
-static s16 sMagicBorderB = 255;
+static Color_RGB8 sMagicBorder = {255,255,255};
+static Color_RGB8 sMagicBorder_ori = {255,255,255};
 
 static s16 sExtraItemBases[] = {
     ITEM_STICK, ITEM_STICK, ITEM_NUT,   ITEM_NUT,     ITEM_BOMB,    ITEM_BOMB,  ITEM_BOMB,  ITEM_BOMB, ITEM_BOW,
@@ -2854,23 +2853,27 @@ void Interface_UpdateMagicBar(GlobalContext* globalCtx) {
         { 255, 255, 150 },
         { 255, 255, 50 },
     };
+    Color_RGB8 MagicBorder_0 = { 255, 255, 255 };
+    Color_RGB8 MagicBorder_1 = { 150, 150, 150 };
+    Color_RGB8 MagicBorder_2 = { 255, 255, 150 };
+    Color_RGB8 MagicBorder_3 = { 255, 255, 50 };
 
     if (CVar_GetS32("gHudColors", 1) == 2) { //This will make custom color based on users selected colors.
-        sMagicBorderColors[0][0] = CVar_GetS32("gCCMagicBorderPrimR", 255);
-        sMagicBorderColors[0][1] = CVar_GetS32("gCCMagicBorderPrimG", 255);
-        sMagicBorderColors[0][2] = CVar_GetS32("gCCMagicBorderPrimB", 255);
+        sMagicBorderColors[0][0] = CVar_GetRGB("gCCMagicBorderPrim", MagicBorder_0).r;
+        sMagicBorderColors[0][1] = CVar_GetRGB("gCCMagicBorderPrim", MagicBorder_0).g;
+        sMagicBorderColors[0][2] = CVar_GetRGB("gCCMagicBorderPrim", MagicBorder_0).b;
 
-        sMagicBorderColors[1][0] = CVar_GetS32("gCCMagicBorderPrimR", 255)/2;
-        sMagicBorderColors[1][1] = CVar_GetS32("gCCMagicBorderPrimG", 255)/2;
-        sMagicBorderColors[1][2] = CVar_GetS32("gCCMagicBorderPrimB", 255)/2;
+        sMagicBorderColors[1][0] = CVar_GetRGB("gCCMagicBorderPrim", MagicBorder_1).r/2;
+        sMagicBorderColors[1][1] = CVar_GetRGB("gCCMagicBorderPrim", MagicBorder_1).g/2;
+        sMagicBorderColors[1][2] = CVar_GetRGB("gCCMagicBorderPrim", MagicBorder_1).b/2;
 
-        sMagicBorderColors[2][0] = CVar_GetS32("gCCMagicBorderPrimR", 255)/3;
-        sMagicBorderColors[2][1] = CVar_GetS32("gCCMagicBorderPrimG", 255)/3;
-        sMagicBorderColors[2][2] = CVar_GetS32("gCCMagicBorderPrimB", 255)/3;
+        sMagicBorderColors[2][0] = CVar_GetRGB("gCCMagicBorderPrim", MagicBorder_2).r/2.5;
+        sMagicBorderColors[2][1] = CVar_GetRGB("gCCMagicBorderPrim", MagicBorder_2).g/2.5;
+        sMagicBorderColors[2][2] = CVar_GetRGB("gCCMagicBorderPrim", MagicBorder_2).b/2.5;
 
-        sMagicBorderColors[3][0] = CVar_GetS32("gCCMagicBorderPrimR", 255)/2;
-        sMagicBorderColors[3][1] = CVar_GetS32("gCCMagicBorderPrimG", 255)/2;
-        sMagicBorderColors[3][2] = CVar_GetS32("gCCMagicBorderPrimB", 255)/2;
+        sMagicBorderColors[3][0] = CVar_GetRGB("gCCMagicBorderPrim", MagicBorder_3).r/3;
+        sMagicBorderColors[3][1] = CVar_GetRGB("gCCMagicBorderPrim", MagicBorder_3).g/3;
+        sMagicBorderColors[3][2] = CVar_GetRGB("gCCMagicBorderPrim", MagicBorder_3).b/3;
     }
 
     static s16 sMagicBorderIndexes[] = { 0, 1, 1, 0 };
@@ -2931,53 +2934,49 @@ void Interface_UpdateMagicBar(GlobalContext* globalCtx) {
                 gSaveContext.magic = 0;
                 gSaveContext.unk_13F0 = 3;
                 if (CVar_GetS32("gHudColors", 1) == 2) {
-                    sMagicBorderR = CVar_GetS32("gCCMagicBorderNormPrimR", 255);
-                    sMagicBorderG = CVar_GetS32("gCCMagicBorderNormPrimG", 255);
-                    sMagicBorderB = CVar_GetS32("gCCMagicBorderNormPrimB", 255);
+                    sMagicBorder = CVar_GetRGB("gCCMagicBorderNormPrim", sMagicBorder_ori);
                 } else {
-                    sMagicBorderR = sMagicBorderG = sMagicBorderB = 255;
+                    sMagicBorder = sMagicBorder_ori;
                 }
             } else if (gSaveContext.magic == gSaveContext.unk_13F8) {
                 gSaveContext.unk_13F0 = 3;
                 if (CVar_GetS32("gHudColors", 1) == 2) {
-                    sMagicBorderR = CVar_GetS32("gCCMagicBorderNormPrimR", 255);
-                    sMagicBorderG = CVar_GetS32("gCCMagicBorderNormPrimG", 255);
-                    sMagicBorderB = CVar_GetS32("gCCMagicBorderNormPrimB", 255);
+                    sMagicBorder = CVar_GetRGB("gCCMagicBorderNormPrim", sMagicBorder_ori);
                 } else {
-                    sMagicBorderR = sMagicBorderG = sMagicBorderB = 255;
+                    sMagicBorder = sMagicBorder_ori;
                 }
             }
         case 3:
         case 4:
         case 6:
             temp = sMagicBorderIndexes[sMagicBorderStep];
-            borderChangeR = ABS(sMagicBorderR - sMagicBorderColors[temp][0]) / sMagicBorderRatio;
-            borderChangeG = ABS(sMagicBorderG - sMagicBorderColors[temp][1]) / sMagicBorderRatio;
-            borderChangeB = ABS(sMagicBorderB - sMagicBorderColors[temp][2]) / sMagicBorderRatio;
+            borderChangeR = ABS(sMagicBorder.r - sMagicBorderColors[temp][0]) / sMagicBorderRatio;
+            borderChangeG = ABS(sMagicBorder.g - sMagicBorderColors[temp][1]) / sMagicBorderRatio;
+            borderChangeB = ABS(sMagicBorder.b - sMagicBorderColors[temp][2]) / sMagicBorderRatio;
 
-            if (sMagicBorderR >= sMagicBorderColors[temp][0]) {
-                sMagicBorderR -= borderChangeR;
+            if (sMagicBorder.r >= sMagicBorderColors[temp][0]) {
+                sMagicBorder.r -= borderChangeR;
             } else {
-                sMagicBorderR += borderChangeR;
+                sMagicBorder.r += borderChangeR;
             }
 
-            if (sMagicBorderG >= sMagicBorderColors[temp][1]) {
-                sMagicBorderG -= borderChangeG;
+            if (sMagicBorder.g >= sMagicBorderColors[temp][1]) {
+                sMagicBorder.g -= borderChangeG;
             } else {
-                sMagicBorderG += borderChangeG;
+                sMagicBorder.g += borderChangeG;
             }
 
-            if (sMagicBorderB >= sMagicBorderColors[temp][2]) {
-                sMagicBorderB -= borderChangeB;
+            if (sMagicBorder.b >= sMagicBorderColors[temp][2]) {
+                sMagicBorder.b -= borderChangeB;
             } else {
-                sMagicBorderB += borderChangeB;
+                sMagicBorder.b += borderChangeB;
             }
 
             sMagicBorderRatio--;
             if (sMagicBorderRatio == 0) {
-                sMagicBorderR = sMagicBorderColors[temp][0];
-                sMagicBorderG = sMagicBorderColors[temp][1];
-                sMagicBorderB = sMagicBorderColors[temp][2];
+                sMagicBorder.r = sMagicBorderColors[temp][0];
+                sMagicBorder.g = sMagicBorderColors[temp][1];
+                sMagicBorder.b = sMagicBorderColors[temp][2];
                 sMagicBorderRatio = YREG(40 + sMagicBorderStep);
                 sMagicBorderStep++;
                 if (sMagicBorderStep >= 4) {
@@ -2988,11 +2987,9 @@ void Interface_UpdateMagicBar(GlobalContext* globalCtx) {
 
         case 5:
             if (CVar_GetS32("gHudColors", 1) == 2) {
-                sMagicBorderR = CVar_GetS32("gCCMagicBorderNormPrimR", 255);
-                sMagicBorderG = CVar_GetS32("gCCMagicBorderNormPrimG", 255);
-                sMagicBorderB = CVar_GetS32("gCCMagicBorderNormPrimB", 255);
+                sMagicBorder = CVar_GetRGB("gCCMagicBorderNormPrim", sMagicBorder_ori);
             } else {
-                sMagicBorderR = sMagicBorderG = sMagicBorderB = 255;
+                sMagicBorder = sMagicBorder_ori;
             }
             gSaveContext.unk_13F0 = 0;
             break;
@@ -3016,11 +3013,9 @@ void Interface_UpdateMagicBar(GlobalContext* globalCtx) {
                                            &D_801333E8);
                     gSaveContext.unk_13F0 = 0;
                     if (CVar_GetS32("gHudColors", 1) == 2) {
-                        sMagicBorderR = CVar_GetS32("gCCMagicBorderNormPrimR", 255);
-                        sMagicBorderG = CVar_GetS32("gCCMagicBorderNormPrimG", 255);
-                        sMagicBorderB = CVar_GetS32("gCCMagicBorderNormPrimB", 255);
+                        sMagicBorder = CVar_GetRGB("gCCMagicBorderNormPrim", sMagicBorder_ori);
                     } else {
-                        sMagicBorderR = sMagicBorderG = sMagicBorderB = 255;
+                        sMagicBorder = sMagicBorder_ori;
                     }
                     break;
                 }
@@ -3033,33 +3028,33 @@ void Interface_UpdateMagicBar(GlobalContext* globalCtx) {
             }
 
             temp = sMagicBorderIndexes[sMagicBorderStep];
-            borderChangeR = ABS(sMagicBorderR - sMagicBorderColors[temp][0]) / sMagicBorderRatio;
-            borderChangeG = ABS(sMagicBorderG - sMagicBorderColors[temp][1]) / sMagicBorderRatio;
-            borderChangeB = ABS(sMagicBorderB - sMagicBorderColors[temp][2]) / sMagicBorderRatio;
+            borderChangeR = ABS(sMagicBorder.r - sMagicBorderColors[temp][0]) / sMagicBorderRatio;
+            borderChangeG = ABS(sMagicBorder.g - sMagicBorderColors[temp][1]) / sMagicBorderRatio;
+            borderChangeB = ABS(sMagicBorder.b - sMagicBorderColors[temp][2]) / sMagicBorderRatio;
 
-            if (sMagicBorderR >= sMagicBorderColors[temp][0]) {
-                sMagicBorderR -= borderChangeR;
+            if (sMagicBorder.r >= sMagicBorderColors[temp][0]) {
+                sMagicBorder.r -= borderChangeR;
             } else {
-                sMagicBorderR += borderChangeR;
+                sMagicBorder.r += borderChangeR;
             }
 
-            if (sMagicBorderG >= sMagicBorderColors[temp][1]) {
-                sMagicBorderG -= borderChangeG;
+            if (sMagicBorder.g >= sMagicBorderColors[temp][1]) {
+                sMagicBorder.g -= borderChangeG;
             } else {
-                sMagicBorderG += borderChangeG;
+                sMagicBorder.g += borderChangeG;
             }
 
-            if (sMagicBorderB >= sMagicBorderColors[temp][2]) {
-                sMagicBorderB -= borderChangeB;
+            if (sMagicBorder.b >= sMagicBorderColors[temp][2]) {
+                sMagicBorder.b -= borderChangeB;
             } else {
-                sMagicBorderB += borderChangeB;
+                sMagicBorder.b += borderChangeB;
             }
 
             sMagicBorderRatio--;
             if (sMagicBorderRatio == 0) {
-                sMagicBorderR = sMagicBorderColors[temp][0];
-                sMagicBorderG = sMagicBorderColors[temp][1];
-                sMagicBorderB = sMagicBorderColors[temp][2];
+                sMagicBorder.r = sMagicBorderColors[temp][0];
+                sMagicBorder.g = sMagicBorderColors[temp][1];
+                sMagicBorder.b = sMagicBorderColors[temp][2];
                 sMagicBorderRatio = YREG(40 + sMagicBorderStep);
                 sMagicBorderStep++;
                 if (sMagicBorderStep >= 4) {
@@ -3087,6 +3082,8 @@ void Interface_UpdateMagicBar(GlobalContext* globalCtx) {
 void Interface_DrawMagicBar(GlobalContext* globalCtx) {
     InterfaceContext* interfaceCtx = &globalCtx->interfaceCtx;
     s16 magicBarY;
+    Color_RGB8 magicbar_yellow = {250,250,0}; //Magic bar being used
+    Color_RGB8 magicbar_green = {R_MAGIC_FILL_COLOR(0),R_MAGIC_FILL_COLOR(1),R_MAGIC_FILL_COLOR(2)}; //Magic bar fill
 
     OPEN_DISPS(globalCtx->state.gfxCtx);
 
@@ -3155,7 +3152,7 @@ void Interface_DrawMagicBar(GlobalContext* globalCtx) {
         } else {
             gDPSetEnvColor(OVERLAY_DISP++, 100, 50, 50, 255);
         }
-        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, sMagicBorderR, sMagicBorderG, sMagicBorderB, interfaceCtx->magicAlpha);
+        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, sMagicBorder.r, sMagicBorder.g, sMagicBorder.b, interfaceCtx->magicAlpha);
 
         OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, gMagicBarEndTex, 8, 16, PosX_Start, magicBarY, 8, 16, 1 << 10, 1 << 10);
 
@@ -3176,9 +3173,9 @@ void Interface_DrawMagicBar(GlobalContext* globalCtx) {
         if (gSaveContext.unk_13F0 == 4) {
             // Yellow part of the bar indicating the amount of magic to be subtracted
             if (CVar_GetS32("gHudColors", 1) == 2) {
-                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetS32("gCCMagicUsePrimR", 250), CVar_GetS32("gCCMagicUsePrimG", 250), CVar_GetS32("gCCMagicUsePrimB", 0), interfaceCtx->magicAlpha);
+                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetRGB("gCCMagicUsePrim", magicbar_yellow).r, CVar_GetRGB("gCCMagicUsePrim", magicbar_yellow).g, CVar_GetRGB("gCCMagicUsePrim", magicbar_yellow).b, interfaceCtx->magicAlpha);
             } else {
-                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 250, 250, 0, interfaceCtx->magicAlpha);
+                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, magicbar_yellow.r, magicbar_yellow.g, magicbar_yellow.b, interfaceCtx->magicAlpha);
             }
 
             gDPLoadMultiBlock_4b(OVERLAY_DISP++, gMagicBarFillTex, 0, G_TX_RENDERTILE, G_IM_FMT_I, 16, 16, 0,
@@ -3192,9 +3189,9 @@ void Interface_DrawMagicBar(GlobalContext* globalCtx) {
             // Fill the rest of the bar with the normal magic color
             gDPPipeSync(OVERLAY_DISP++);
             if (CVar_GetS32("gHudColors", 1) == 2) {
-                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetS32("gCCMagicPrimR", 0), CVar_GetS32("gCCMagicPrimG", 200), CVar_GetS32("gCCMagicPrimB", 0), interfaceCtx->magicAlpha);
+                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetRGB("gCCMagicPrim", magicbar_green).r, CVar_GetRGB("gCCMagicPrim", magicbar_green).g, CVar_GetRGB("gCCMagicPrim", magicbar_green).b, interfaceCtx->magicAlpha);
             } else {
-                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_MAGIC_FILL_COLOR(0), R_MAGIC_FILL_COLOR(1), R_MAGIC_FILL_COLOR(2), interfaceCtx->magicAlpha);
+                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, magicbar_green.r, magicbar_green.g, magicbar_green.b, interfaceCtx->magicAlpha);
             }
 
             gSPWideTextureRectangle(OVERLAY_DISP++, rMagicFillX << 2, (magicBarY + 3) << 2,
@@ -3203,9 +3200,9 @@ void Interface_DrawMagicBar(GlobalContext* globalCtx) {
         } else {
             // Fill the whole bar with the normal magic color
             if (CVar_GetS32("gHudColors", 1) == 2) {
-                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetS32("gCCMagicPrimR", 0), CVar_GetS32("gCCMagicPrimG", 200), CVar_GetS32("gCCMagicPrimB", 0), interfaceCtx->magicAlpha);
+                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetRGB("gCCMagicPrim", magicbar_green).r, CVar_GetRGB("gCCMagicPrim", magicbar_green).g, CVar_GetRGB("gCCMagicPrim", magicbar_green).b, interfaceCtx->magicAlpha);
             } else {
-                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_MAGIC_FILL_COLOR(0), R_MAGIC_FILL_COLOR(1), R_MAGIC_FILL_COLOR(2), interfaceCtx->magicAlpha);
+                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, magicbar_green.r, magicbar_green.g, magicbar_green.b, interfaceCtx->magicAlpha);
             }
 
             gDPLoadMultiBlock_4b(OVERLAY_DISP++, gMagicBarFillTex, 0, G_TX_RENDERTILE, G_IM_FMT_I, 16, 16, 0,
@@ -3279,10 +3276,28 @@ void Interface_DrawItemButtons(GlobalContext* globalCtx) {
     s16 dxdy;
     s16 width;
     s16 height;
+    Color_RGB8 A_button_ori = {R_A_BTN_COLOR(0), R_A_BTN_COLOR(1), R_A_BTN_COLOR(2)};
+    Color_RGB8 A_button = CVar_GetRGB("gCCABtnPrim", A_button_ori);
+    Color_RGB8 B_button_ori = {R_B_BTN_COLOR(0), R_B_BTN_COLOR(1), R_B_BTN_COLOR(2)};
+    Color_RGB8 B_button = CVar_GetRGB("gCCBBtnPrim", B_button_ori);
+    Color_RGB8 Start_button_ori = {120, 120, 120};
+    Color_RGB8 Start_button = CVar_GetRGB("gCCStartBtnPrim", Start_button_ori);
+    Color_RGB8 C_button_ori = {R_C_BTN_COLOR(0), R_C_BTN_COLOR(1), R_C_BTN_COLOR(2)};
+    Color_RGB8 C_button_uni = CVar_GetRGB("gCCCBtnPrim", C_button_ori);
+    Color_RGB8 C_button_U = CVar_GetRGB("gCCCUBtnPrim", C_button_ori);
+    Color_RGB8 C_button_D = CVar_GetRGB("gCCCDBtnPrim", C_button_ori);
+    Color_RGB8 C_button_L = CVar_GetRGB("gCCCLBtnPrim", C_button_ori);
+    Color_RGB8 C_button_R = CVar_GetRGB("gCCCRBtnPrim", C_button_ori);
 
     //B Button
     s16 X_Margins_BtnB;
     s16 Y_Margins_BtnB;
+    s16 BBtn_Size = 32;
+    int BBtnScaled = BBtn_Size * 0.95f;
+    if (CVar_GetS32("gBBtnPosType", 0) != 0) {
+        BBtnScaled = BBtn_Size * CVar_GetFloat("gBBtnScale", 0.95f);
+    }
+    int BBtn_factor = (1 << 10) * BBtn_Size / BBtnScaled;
     if (CVar_GetS32("gBBtnUseMargins", 0) != 0) {
         if (CVar_GetS32("gBBtnPosType", 0) == 0) {X_Margins_BtnB = Right_HUD_Margin;};
         Y_Margins_BtnB = (Top_HUD_Margin*-1);
@@ -3325,49 +3340,40 @@ void Interface_DrawItemButtons(GlobalContext* globalCtx) {
     }
     s16 StartBtn_Icon_H = 32;
     s16 StartBtn_Icon_W = 32;
-    int StartBTN_H_Scaled = StartBtn_Icon_H * 0.75f;
-    int StartBTN_W_Scaled = StartBtn_Icon_W * 0.75f;
+    float Start_BTN_Scale = 0.75f;
+    if (CVar_GetS32("gStartBtnPosType", 0) != 0) {
+        Start_BTN_Scale = CVar_GetFloat("gStartBtnScale", 0.75f);
+    }
+    int StartBTN_H_Scaled = StartBtn_Icon_H * Start_BTN_Scale;
+    int StartBTN_W_Scaled = StartBtn_Icon_W * Start_BTN_Scale;
     int StartBTN_W_factor = (1 << 10) * StartBtn_Icon_W / StartBTN_W_Scaled;
     int StartBTN_H_factor = (1 << 10) * StartBtn_Icon_H / StartBTN_H_Scaled;
-    const s16 rStartLabelX_ori = OTRGetRectDimensionFromRightEdge(R_START_LABEL_X(gSaveContext.language)+X_Margins_StartBtn);
-    const s16 rStartLabelY_ori = R_START_LABEL_Y(gSaveContext.language)+Y_Margins_StartBtn;
     const s16 PosX_StartBtn_ori = OTRGetRectDimensionFromRightEdge(startButtonLeftPos[gSaveContext.language]+X_Margins_StartBtn);
     const s16 PosY_StartBtn_ori = 16+Y_Margins_StartBtn;
     s16 StartBTN_Label_W = DO_ACTION_TEX_WIDTH();
     s16 StartBTN_Label_H = DO_ACTION_TEX_HEIGHT();
-    int StartBTN_Label_H_Scaled = StartBTN_Label_H * 1.0f;
-    int StartBTN_Label_W_Scaled = StartBTN_Label_W * 1.0f;
-    int StartBTN_Label_W_factor = (1 << 10) * StartBTN_Label_W / StartBTN_Label_W_Scaled;
-    int StartBTN_Label_H_factor = (1 << 10) * StartBTN_Label_H / StartBTN_Label_H_Scaled;
-    const s16 StartBtn_Label_W_ori = StartBTN_Label_W / (R_START_LABEL_DD(gSaveContext.language) / 100.0f);
-    const s16 StartBtn_Label_H_ori = StartBTN_Label_H / (R_START_LABEL_DD(gSaveContext.language) / 100.0f);
     s16 PosX_StartBtn;
     s16 PosY_StartBtn;
-    s16 rStartLabelX;
-    s16 rStartLabelY;
     if (CVar_GetS32("gStartBtnPosType", 0) != 0) {
-        PosY_StartBtn = CVar_GetS32("gStartBtnPosY", 0)+Y_Margins_StartBtn;
-        rStartLabelY = CVar_GetS32("gStartBtnPosY", 0)+Y_Margins_StartBtn+3;
+        PosY_StartBtn = CVar_GetS32("gStartBtnPosY", 0)-(Start_BTN_Scale*13)+Y_Margins_StartBtn;
         if (CVar_GetS32("gStartBtnPosType", 0) == 1) {//Anchor Left
             if (CVar_GetS32("gStartBtnUseMargins", 0) != 0) {X_Margins_StartBtn = Left_HUD_Margin;};
-            PosX_StartBtn = OTRGetDimensionFromLeftEdge(CVar_GetS32("gStartBtnPosX", 0)+X_Margins_StartBtn);
-            rStartLabelX = OTRGetDimensionFromLeftEdge(CVar_GetS32("gStartBtnPosX", 0)+X_Margins_StartBtn-12);
+            PosX_StartBtn = OTRGetDimensionFromLeftEdge(CVar_GetS32("gStartBtnPosX", 0)-(Start_BTN_Scale*13)+X_Margins_StartBtn);
         } else if (CVar_GetS32("gStartBtnPosType", 0) == 2) {//Anchor Right
             if (CVar_GetS32("gStartBtnUseMargins", 0) != 0) {X_Margins_StartBtn = Right_HUD_Margin;};
-            PosX_StartBtn = OTRGetDimensionFromRightEdge(CVar_GetS32("gStartBtnPosX", 0)+X_Margins_StartBtn);
-            rStartLabelX = OTRGetDimensionFromRightEdge(CVar_GetS32("gStartBtnPosX", 0)+X_Margins_StartBtn-12);
+            PosX_StartBtn = OTRGetDimensionFromRightEdge(CVar_GetS32("gStartBtnPosX", 0)-(Start_BTN_Scale*13)+X_Margins_StartBtn);
         } else if (CVar_GetS32("gStartBtnPosType", 0) == 3) {//Anchor None
             PosX_StartBtn = CVar_GetS32("gStartBtnPosX", 0);
-            rStartLabelX = CVar_GetS32("gStartBtnPosX", 0)-12;
         } else if (CVar_GetS32("gStartBtnPosType", 0) == 4) {//Hidden
            PosX_StartBtn = -9999;
-           rStartLabelX = -9999;
         }
     } else {
+        StartBTN_H_Scaled = StartBtn_Icon_H * 0.75f;
+        StartBTN_W_Scaled = StartBtn_Icon_W * 0.75f;
+        StartBTN_W_factor = (1 << 10) * StartBtn_Icon_W / StartBTN_W_Scaled;
+        StartBTN_H_factor = (1 << 10) * StartBtn_Icon_H / StartBTN_H_Scaled;
         PosY_StartBtn = PosY_StartBtn_ori;
         PosX_StartBtn = PosX_StartBtn_ori;
-        rStartLabelY = rStartLabelY_ori;
-        rStartLabelX = rStartLabelX_ori;
     }
     //C Buttons position
     s16 X_Margins_CL;
@@ -3417,6 +3423,13 @@ void Interface_DrawItemButtons(GlobalContext* globalCtx) {
     s16 C_Up_BTN_Pos[2];
     s16 C_Down_BTN_Pos[2];
     //C button Left
+    s16 C_Left_BTN_Size = 32;
+    float CLeftScale = CVar_GetFloat("gCBtnLScale", 0.87f);
+    int CLeftScaled = C_Left_BTN_Size * 0.87f;
+    if (CVar_GetS32("gCBtnLPosType", 0) != 0) {
+        CLeftScaled = C_Left_BTN_Size * CLeftScale;
+    }
+    int CLeft_factor = (1 << 10) * C_Left_BTN_Size / CLeftScaled;
     if (CVar_GetS32("gCBtnLPosType", 0) != 0) {
         C_Left_BTN_Pos[1] = CVar_GetS32("gCBtnLPosY", 0)+Y_Margins_CL;
         if (CVar_GetS32("gCBtnLPosType", 0) == 1) {//Anchor Left
@@ -3435,6 +3448,13 @@ void Interface_DrawItemButtons(GlobalContext* globalCtx) {
         C_Left_BTN_Pos[0] = OTRGetRectDimensionFromRightEdge(C_Left_BTN_Pos_ori[0]);
     }
     //C button Right
+    s16 C_Right_BTN_Size = 32;
+    float CRightScale = CVar_GetFloat("gCBtnRScale", 0.87f);
+    int CRightScaled = C_Right_BTN_Size * 0.87f;
+    if (CVar_GetS32("gCBtnRPosType", 0) != 0) {
+        CRightScaled = C_Right_BTN_Size * CRightScale;
+    }
+    int CRight_factor = (1 << 10) * C_Right_BTN_Size / CRightScaled;
     if (CVar_GetS32("gCBtnRPosType", 0) != 0) {
         C_Right_BTN_Pos[1] = CVar_GetS32("gCBtnRPosY", 0)+Y_Margins_CR;
         if (CVar_GetS32("gCBtnRPosType", 0) == 1) {//Anchor Left
@@ -3453,16 +3473,23 @@ void Interface_DrawItemButtons(GlobalContext* globalCtx) {
         C_Right_BTN_Pos[0] = OTRGetRectDimensionFromRightEdge(C_Right_BTN_Pos_ori[0]);
     }
     //C Button Up
+    s16 C_Up_BTN_Size = 32;
+    int CUpScaled = C_Up_BTN_Size * 0.5f;
+    float CUpScale = CVar_GetFloat("gCBtnUScale", 0.5f);
     if (CVar_GetS32("gCBtnUPosType", 0) != 0) {
-        C_Up_BTN_Pos[1] = CVar_GetS32("gCBtnUPosY", 0)+Y_Margins_CU;
+        CUpScaled = C_Up_BTN_Size * CUpScale;
+    }
+    int CUp_factor = (1 << 10) * C_Up_BTN_Size / CUpScaled;
+    if (CVar_GetS32("gCBtnUPosType", 0) != 0) {
+        C_Up_BTN_Pos[1] = CVar_GetS32("gCBtnUPosY", 0)-(CUpScale*13)+Y_Margins_CU;
         if (CVar_GetS32("gCBtnUPosType", 0) == 1) {//Anchor Left
             if (CVar_GetS32("gCBtnUUseMargins", 0) != 0) {X_Margins_CU = Left_HUD_Margin;};
-            C_Up_BTN_Pos[0] = OTRGetDimensionFromLeftEdge(CVar_GetS32("gCBtnUPosX", 0)+X_Margins_CU);
+            C_Up_BTN_Pos[0] = OTRGetDimensionFromLeftEdge(CVar_GetS32("gCBtnUPosX", 0)-(CUpScale*13)+X_Margins_CU);
         } else if (CVar_GetS32("gCBtnUPosType", 0) == 2) {//Anchor Right
             if (CVar_GetS32("gCBtnUUseMargins", 0) != 0) {X_Margins_CU = Right_HUD_Margin;};
-            C_Up_BTN_Pos[0] = OTRGetDimensionFromRightEdge(CVar_GetS32("gCBtnUPosX", 0)+X_Margins_CU);
+            C_Up_BTN_Pos[0] = OTRGetDimensionFromRightEdge(CVar_GetS32("gCBtnUPosX", 0)-(CUpScale*13)+X_Margins_CU);
         } else if (CVar_GetS32("gCBtnUPosType", 0) == 3) {//Anchor None
-            C_Up_BTN_Pos[0] = CVar_GetS32("gCBtnUPosX", 0);
+            C_Up_BTN_Pos[0] = CVar_GetS32("gCBtnUPosX", 0)-(CUpScale*13);
         } else if (CVar_GetS32("gCBtnUPosType", 0) == 4) {//Hidden
             C_Up_BTN_Pos[0] = -9999;
         }
@@ -3471,16 +3498,24 @@ void Interface_DrawItemButtons(GlobalContext* globalCtx) {
         C_Up_BTN_Pos[0] = OTRGetRectDimensionFromRightEdge(C_Up_BTN_Pos_ori[0]);
     }
     //C Button down
+    s16 C_Down_BTN_Size = 32;
+    float CDownScale = CVar_GetFloat("gCBtnDScale", 0.87f);
+    if (CVar_GetS32("gCBtnDPosType", 0) == 0) {
+        CDownScale = 0.87f;
+    }
+    int CDownScaled = C_Down_BTN_Size * CDownScale;
+    int CDown_factor = (1 << 10) * C_Down_BTN_Size / CDownScaled;
+    int PositionAdjustment = CDownScaled/2;
     if (CVar_GetS32("gCBtnDPosType", 0) != 0) {
-        C_Down_BTN_Pos[1] = CVar_GetS32("gCBtnDPosY", 0)+Y_Margins_CD;
+        C_Down_BTN_Pos[1] = CVar_GetS32("gCBtnDPosY", 0)-PositionAdjustment+Y_Margins_CD;
         if (CVar_GetS32("gCBtnDPosType", 0) == 1) {//Anchor Left
             if (CVar_GetS32("gCBtnDUseMargins", 0) != 0) {X_Margins_CD = Left_HUD_Margin;};
-            C_Down_BTN_Pos[0] = OTRGetDimensionFromLeftEdge(CVar_GetS32("gCBtnDPosX", 0)+X_Margins_CD);
+            C_Down_BTN_Pos[0] = OTRGetDimensionFromLeftEdge(CVar_GetS32("gCBtnDPosX", 0)-PositionAdjustment+X_Margins_CD);
         } else if (CVar_GetS32("gCBtnDPosType", 0) == 2) {//Anchor Right
             if (CVar_GetS32("gCBtnDUseMargins", 0) != 0) {X_Margins_CD = Right_HUD_Margin;};
-            C_Down_BTN_Pos[0] = OTRGetDimensionFromRightEdge(CVar_GetS32("gCBtnDPosX", 0)+X_Margins_CD);
+            C_Down_BTN_Pos[0] = OTRGetDimensionFromRightEdge(CVar_GetS32("gCBtnDPosX", 0)-PositionAdjustment+X_Margins_CD);
         } else if (CVar_GetS32("gCBtnDPosType", 0) == 3) {//Anchor None
-            C_Down_BTN_Pos[0] = CVar_GetS32("gCBtnDPosX", 0);
+            C_Down_BTN_Pos[0] = CVar_GetS32("gCBtnDPosX", 0)-PositionAdjustment;
         } else if (CVar_GetS32("gCBtnDPosType", 0) == 4) {//Hidden
             C_Down_BTN_Pos[0] = -9999;
         }
@@ -3498,59 +3533,59 @@ void Interface_DrawItemButtons(GlobalContext* globalCtx) {
     if (CVar_GetS32("gHudColors", 1) == 0) {
         gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 0, 150, 0, interfaceCtx->bAlpha);
     } else if (CVar_GetS32("gHudColors", 1) == 1) {
-        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_B_BTN_COLOR(0), R_B_BTN_COLOR(1), R_B_BTN_COLOR(2), interfaceCtx->bAlpha);
+        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, B_button_ori.r,B_button_ori.g,B_button_ori.b, interfaceCtx->bAlpha);
     } else if (CVar_GetS32("gHudColors", 1) == 2) {
-        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetS32("gCCBBtnPrimR", R_B_BTN_COLOR(0)), CVar_GetS32("gCCBBtnPrimG", R_B_BTN_COLOR(1)), CVar_GetS32("gCCBBtnPrimB", R_B_BTN_COLOR(2)), interfaceCtx->bAlpha);
+        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, B_button.r,B_button.g,B_button.b, interfaceCtx->bAlpha);
     }
     gDPSetEnvColor(OVERLAY_DISP++, 0, 0, 0, 255);
 
-    OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, gButtonBackgroundTex, 32, 32, PosX_BtnB, PosY_BtnB, R_ITEM_BTN_WIDTH(0), R_ITEM_BTN_WIDTH(0), R_ITEM_BTN_DD(0) << 1, R_ITEM_BTN_DD(0) << 1);
+    OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, gButtonBackgroundTex, BBtn_Size, BBtn_Size, PosX_BtnB, PosY_BtnB, BBtnScaled, BBtnScaled, BBtn_factor, BBtn_factor);
 
     // C-Left Button Color & Texture
     gDPPipeSync(OVERLAY_DISP++);
     if (CVar_GetS32("gHudColors", 1) == 0) {
-        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_C_BTN_COLOR(0), R_C_BTN_COLOR(1), R_C_BTN_COLOR(2), interfaceCtx->cLeftAlpha);
+        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, C_button_ori.r, C_button_ori.g, C_button_ori.b, interfaceCtx->cLeftAlpha);
     } else if (CVar_GetS32("gHudColors", 1) == 1) {
-        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_C_BTN_COLOR(0), R_C_BTN_COLOR(1), R_C_BTN_COLOR(2), interfaceCtx->cLeftAlpha);
+        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, C_button_ori.r, C_button_ori.g, C_button_ori.b, interfaceCtx->cLeftAlpha);
     } else if (CVar_GetS32("gHudColors", 1) == 2 && !CVar_GetS32("gCCparated",0)) {
-        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetS32("gCCCBtnPrimR", R_C_BTN_COLOR(0)), CVar_GetS32("gCCCBtnPrimG", R_C_BTN_COLOR(1)), CVar_GetS32("gCCCBtnPrimB", R_C_BTN_COLOR(2)), interfaceCtx->cLeftAlpha);
+        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, C_button_uni.r, C_button_uni.g, C_button_uni.b, interfaceCtx->cLeftAlpha);
     } else if (CVar_GetS32("gHudColors", 1) == 2 && CVar_GetS32("gCCparated",0)) {
-        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetS32("gCCCLBtnPrimR", R_C_BTN_COLOR(0)), CVar_GetS32("gCCCLBtnPrimG", R_C_BTN_COLOR(1)), CVar_GetS32("gCCCLBtnPrimB", R_C_BTN_COLOR(2)), interfaceCtx->cLeftAlpha);
+        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, C_button_L.r, C_button_L.g, C_button_L.b, interfaceCtx->cLeftAlpha);
     }
     gSPWideTextureRectangle(OVERLAY_DISP++, C_Left_BTN_Pos[0] << 2, C_Left_BTN_Pos[1] << 2,
-                        (C_Left_BTN_Pos[0] + R_ITEM_BTN_WIDTH(1)) << 2,
-                        (C_Left_BTN_Pos[1] + R_ITEM_BTN_WIDTH(1)) << 2,
-                        G_TX_RENDERTILE, 0, 0, R_ITEM_BTN_DD(1) << 1, R_ITEM_BTN_DD(1) << 1);
+                        (C_Left_BTN_Pos[0] + CLeftScaled) << 2,
+                        (C_Left_BTN_Pos[1] + CLeftScaled) << 2,
+                        G_TX_RENDERTILE, 0, 0, CLeft_factor, CLeft_factor);
 
     // C-Down Button Color & Texture
     if (CVar_GetS32("gHudColors", 1) == 0) {
-        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_C_BTN_COLOR(0), R_C_BTN_COLOR(1), R_C_BTN_COLOR(2), interfaceCtx->cDownAlpha);
+        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, C_button_ori.r, C_button_ori.g, C_button_ori.b, interfaceCtx->cDownAlpha);
     } else if (CVar_GetS32("gHudColors", 1) == 1) {
-        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_C_BTN_COLOR(0), R_C_BTN_COLOR(1), R_C_BTN_COLOR(2), interfaceCtx->cDownAlpha);
+        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, C_button_ori.r, C_button_ori.g, C_button_ori.b, interfaceCtx->cDownAlpha);
     } else if (CVar_GetS32("gHudColors", 1) == 2 && !CVar_GetS32("gCCparated",0)) {
-        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetS32("gCCCBtnPrimR", R_C_BTN_COLOR(0)), CVar_GetS32("gCCCBtnPrimG", R_C_BTN_COLOR(1)), CVar_GetS32("gCCCBtnPrimB", R_C_BTN_COLOR(2)), interfaceCtx->cDownAlpha);
+        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, C_button_uni.r, C_button_uni.g, C_button_uni.b, interfaceCtx->cDownAlpha);
     } else if (CVar_GetS32("gHudColors", 1) == 2 && CVar_GetS32("gCCparated",0)) {
-        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetS32("gCCCDBtnPrimR", R_C_BTN_COLOR(0)), CVar_GetS32("gCCCDBtnPrimG", R_C_BTN_COLOR(1)), CVar_GetS32("gCCCDBtnPrimB", R_C_BTN_COLOR(2)), interfaceCtx->cDownAlpha);
+        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, C_button_D.r, C_button_D.g, C_button_D.b, interfaceCtx->cDownAlpha);
     }
     gSPWideTextureRectangle(OVERLAY_DISP++,  C_Down_BTN_Pos[0] << 2, C_Down_BTN_Pos[1] << 2,
-                        (C_Down_BTN_Pos[0] + R_ITEM_BTN_WIDTH(2)) << 2,
-                        (C_Down_BTN_Pos[1] + R_ITEM_BTN_WIDTH(2)) << 2,
-                        G_TX_RENDERTILE, 0, 0, R_ITEM_BTN_DD(2) << 1, R_ITEM_BTN_DD(2) << 1);
+                        (C_Down_BTN_Pos[0] + CDownScaled) << 2,
+                        (C_Down_BTN_Pos[1] + CDownScaled) << 2,
+                        G_TX_RENDERTILE, 0, 0, CDown_factor, CDown_factor);
 
     // C-Right Button Color & Texture
     if (CVar_GetS32("gHudColors", 1) == 0) {
-        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_C_BTN_COLOR(0), R_C_BTN_COLOR(1), R_C_BTN_COLOR(2), interfaceCtx->cRightAlpha);
+        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, C_button_ori.r, C_button_ori.g, C_button_ori.b, interfaceCtx->cRightAlpha);
     } else if (CVar_GetS32("gHudColors", 1) == 1) {
-        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_C_BTN_COLOR(0), R_C_BTN_COLOR(1), R_C_BTN_COLOR(2), interfaceCtx->cRightAlpha);
+        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, C_button_ori.r, C_button_ori.g, C_button_ori.b, interfaceCtx->cRightAlpha);
     } else if (CVar_GetS32("gHudColors", 1) == 2 && !CVar_GetS32("gCCparated",0)) {
-        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetS32("gCCCBtnPrimR", R_C_BTN_COLOR(0)), CVar_GetS32("gCCCBtnPrimG", R_C_BTN_COLOR(1)), CVar_GetS32("gCCCBtnPrimB", R_C_BTN_COLOR(2)), interfaceCtx->cRightAlpha);
+        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, C_button_uni.r, C_button_uni.g, C_button_uni.b, interfaceCtx->cRightAlpha);
     } else if (CVar_GetS32("gHudColors", 1) == 2 && CVar_GetS32("gCCparated",0)) {
-        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetS32("gCCCRBtnPrimR", R_C_BTN_COLOR(0)), CVar_GetS32("gCCCRBtnPrimG", R_C_BTN_COLOR(1)), CVar_GetS32("gCCCRBtnPrimB", R_C_BTN_COLOR(2)), interfaceCtx->cRightAlpha);
+        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, C_button_R.r, C_button_R.g, C_button_R.b, interfaceCtx->cRightAlpha);
     }
     gSPWideTextureRectangle(OVERLAY_DISP++, C_Right_BTN_Pos[0] << 2, C_Right_BTN_Pos[1] << 2,
-                        (C_Right_BTN_Pos[0] + R_ITEM_BTN_WIDTH(3)) << 2,
-                        (C_Right_BTN_Pos[1] + R_ITEM_BTN_WIDTH(3)) << 2,
-                        G_TX_RENDERTILE, 0, 0, R_ITEM_BTN_DD(3) << 1, R_ITEM_BTN_DD(3) << 1);
+                        (C_Right_BTN_Pos[0] + CRightScaled) << 2,
+                        (C_Right_BTN_Pos[1] + CRightScaled) << 2,
+                        G_TX_RENDERTILE, 0, 0, CRight_factor, CRight_factor);
 
     if ((pauseCtx->state < 8) || (pauseCtx->state >= 18)) {
         if ((globalCtx->pauseCtx.state != 0) || (globalCtx->pauseCtx.debugState != 0)) {
@@ -3560,9 +3595,9 @@ void Interface_DrawItemButtons(GlobalContext* globalCtx) {
             if (CVar_GetS32("gHudColors", 1) == 0) {
                 gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 200, 0, 0, interfaceCtx->startAlpha);
             } else if (CVar_GetS32("gHudColors", 1) == 1) {
-                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 120, 120, 120, interfaceCtx->startAlpha);
+                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, Start_button_ori.r, Start_button_ori.g, Start_button_ori.b, interfaceCtx->startAlpha);
             } else if (CVar_GetS32("gHudColors", 1) == 2) {
-                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetS32("gCCStartBtnPrimR", 120), CVar_GetS32("gCCStartBtnPrimG", 120), CVar_GetS32("gCCStartBtnPrimB", 120), interfaceCtx->startAlpha);
+                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, Start_button.r, Start_button.g, Start_button.b, interfaceCtx->startAlpha);
             }
             gSPWideTextureRectangle(OVERLAY_DISP++, PosX_StartBtn << 2, PosY_StartBtn << 2,
                                 (PosX_StartBtn + StartBTN_W_Scaled) << 2, (PosY_StartBtn + StartBTN_H_Scaled) << 2,
@@ -3597,11 +3632,19 @@ void Interface_DrawItemButtons(GlobalContext* globalCtx) {
                                    DO_ACTION_TEX_WIDTH(), DO_ACTION_TEX_HEIGHT(), 0, G_TX_NOMIRROR | G_TX_WRAP,
                                    G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
 
-            //const s16 rStartLabelX = OTRGetRectDimensionFromRightEdge(R_START_LABEL_X(gSaveContext.language)+Right_HUD_Margin);
-            gSPWideTextureRectangle(
-                OVERLAY_DISP++, rStartLabelX << 2, rStartLabelY << 2, 
-                (rStartLabelX + StartBTN_Label_W) << 2,
-                (rStartLabelY + StartBTN_Label_H) << 2, G_TX_RENDERTILE, 0, 0, StartBTN_Label_W_factor, StartBTN_Label_H_factor);
+            gDPPipeSync(OVERLAY_DISP++);
+            gSPSetGeometryMode(OVERLAY_DISP++, G_CULL_BACK);
+            gDPSetCombineLERP(OVERLAY_DISP++, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0,
+                            PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0);
+            gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 255, 255, interfaceCtx->startAlpha);
+            gDPSetEnvColor(OVERLAY_DISP++, 0, 0, 0, 0);
+            Matrix_Translate(PosX_StartBtn-160+((Start_BTN_Scale+Start_BTN_Scale/3)*11.5f), (PosY_StartBtn-120+((Start_BTN_Scale+Start_BTN_Scale/3)*11.5f)) * -1, 1.0f, MTXMODE_NEW);
+            Matrix_Scale(Start_BTN_Scale+(Start_BTN_Scale/3), Start_BTN_Scale+(Start_BTN_Scale/3), Start_BTN_Scale+(Start_BTN_Scale/3), MTXMODE_APPLY);
+            gSPMatrix(OVERLAY_DISP++, MATRIX_NEWMTX(globalCtx->state.gfxCtx),
+                    G_MTX_MODELVIEW | G_MTX_LOAD);
+            gSPVertex(OVERLAY_DISP++, &interfaceCtx->actionVtx[4], 4, 0);
+            Interface_DrawActionLabel(globalCtx->state.gfxCtx, interfaceCtx->doActionSegment + DO_ACTION_TEX_SIZE() * 2);
+            gDPPipeSync(OVERLAY_DISP++);
         }
     }
 
@@ -3621,13 +3664,13 @@ void Interface_DrawItemButtons(GlobalContext* globalCtx) {
             }
 
             if (CVar_GetS32("gHudColors", 1) == 0) {
-                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_C_BTN_COLOR(0), R_C_BTN_COLOR(1), R_C_BTN_COLOR(2), temp);
+                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, C_button_ori.r, C_button_ori.g, C_button_ori.b, temp);
             } else if (CVar_GetS32("gHudColors", 1) == 1) {
-                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_C_BTN_COLOR(0), R_C_BTN_COLOR(1), R_C_BTN_COLOR(2), temp);
+                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, C_button_ori.r, C_button_ori.g, C_button_ori.b, temp);
             } else if (CVar_GetS32("gHudColors", 1) == 2 && !CVar_GetS32("gCCparated",0)) {
-                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetS32("gCCCBtnPrimR", R_C_BTN_COLOR(0)), CVar_GetS32("gCCCBtnPrimG", R_C_BTN_COLOR(1)), CVar_GetS32("gCCCBtnPrimB", R_C_BTN_COLOR(2)), temp);
+                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, C_button_uni.r, C_button_uni.g, C_button_uni.b, temp);
             } else if (CVar_GetS32("gHudColors", 1) == 2 && CVar_GetS32("gCCparated",0)) {
-                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetS32("gCCCUBtnPrimR", R_C_BTN_COLOR(0)), CVar_GetS32("gCCCUBtnPrimG", R_C_BTN_COLOR(1)), CVar_GetS32("gCCCUBtnPrimB", R_C_BTN_COLOR(2)), temp);
+                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, C_button_U.r, C_button_U.g, C_button_U.b, temp);
             }
             gDPSetCombineMode(OVERLAY_DISP++, G_CC_MODULATEIA_PRIM, G_CC_MODULATEIA_PRIM);
             gSPWideTextureRectangle(OVERLAY_DISP++, C_Up_BTN_Pos[0] << 2, C_Up_BTN_Pos[1] << 2, (C_Up_BTN_Pos[0] + 16) << 2,
@@ -3686,6 +3729,11 @@ void Interface_DrawItemButtons(GlobalContext* globalCtx) {
                 X_Margins_CD = 0;
                 Y_Margins_CD = 0;
             }
+            const s16 ItemIconWidthFactor[3][2] = {
+                { CLeftScaled, CLeft_factor },
+                { CDownScaled, CDown_factor },
+                { CRightScaled, CRight_factor },
+            };
             const s16 ItemIconPos_ori[3][2] = {
                 { R_ITEM_ICON_X(1)+X_Margins_CL, R_ITEM_ICON_Y(1)+Y_Margins_CL },
                 { R_ITEM_ICON_X(2)+X_Margins_CD, R_ITEM_ICON_Y(2)+Y_Margins_CD },
@@ -3748,40 +3796,34 @@ void Interface_DrawItemButtons(GlobalContext* globalCtx) {
             }
 
             if (temp == 1) {
-                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_C_BTN_COLOR(0), R_C_BTN_COLOR(1), R_C_BTN_COLOR(2),
-                                interfaceCtx->cLeftAlpha);
+                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, C_button_ori.r, C_button_ori.g, C_button_ori.b, interfaceCtx->cLeftAlpha);
             } else if (temp == 2) {
-                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_C_BTN_COLOR(0), R_C_BTN_COLOR(1), R_C_BTN_COLOR(2),
-                                interfaceCtx->cDownAlpha);
+                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, C_button_ori.r, C_button_ori.g, C_button_ori.b, interfaceCtx->cDownAlpha);
             } else {
-                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_C_BTN_COLOR(0), R_C_BTN_COLOR(1), R_C_BTN_COLOR(2),
-                                interfaceCtx->cRightAlpha);
+                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, C_button_ori.r, C_button_ori.g, C_button_ori.b, interfaceCtx->cRightAlpha);
             }
 
             if (CVar_GetS32("gHudColors", 1) == 2 && !CVar_GetS32("gCCparated", 0)) {
-                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetS32("gCCCBtnPrimR", R_C_BTN_COLOR(0)), CVar_GetS32("gCCCBtnPrimG", R_C_BTN_COLOR(1)), CVar_GetS32("gCCCBtnPrimB", R_C_BTN_COLOR(2)), interfaceCtx->cRightAlpha);
+                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, C_button_uni.r, C_button_uni.g, C_button_uni.b, interfaceCtx->cRightAlpha);
             } else if (temp == 1 && CVar_GetS32("gHudColors", 1) == 2 && CVar_GetS32("gCCparated", 0)) {
-                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetS32("gCCCLBtnPrimR", R_C_BTN_COLOR(0)), CVar_GetS32("gCCCLBtnPrimG", R_C_BTN_COLOR(1)), CVar_GetS32("gCCCLBtnPrimB", R_C_BTN_COLOR(2)),
-                                interfaceCtx->cLeftAlpha);
+                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, C_button_L.r, C_button_L.g, C_button_L.b, interfaceCtx->cLeftAlpha);
             } else if (temp == 2 && CVar_GetS32("gHudColors", 1) == 2 && CVar_GetS32("gCCparated", 0)) {
-                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetS32("gCCCDBtnPrimR", R_C_BTN_COLOR(0)), CVar_GetS32("gCCCDBtnPrimG", R_C_BTN_COLOR(1)), CVar_GetS32("gCCCDBtnPrimB", R_C_BTN_COLOR(2)),
-                                interfaceCtx->cDownAlpha);
+                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, C_button_D.r, C_button_D.g, C_button_D.b, interfaceCtx->cDownAlpha);
             } else if (CVar_GetS32("gHudColors", 1) == 2 && CVar_GetS32("gCCparated", 0)) {
-                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetS32("gCCCRBtnPrimR", R_C_BTN_COLOR(0)), CVar_GetS32("gCCCRBtnPrimG", R_C_BTN_COLOR(1)), CVar_GetS32("gCCCRBtnPrimB", R_C_BTN_COLOR(2)),
-                                interfaceCtx->cRightAlpha);
+                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, C_button_R.r, C_button_R.g, C_button_R.b, interfaceCtx->cRightAlpha);
             }
             
             OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, ((u8*)gButtonBackgroundTex), 32, 32, 
-                                          ItemIconPos[temp-1][0], ItemIconPos[temp-1][1], R_ITEM_BTN_WIDTH(temp),
-                                          R_ITEM_BTN_WIDTH(temp), R_ITEM_BTN_DD(temp) << 1, R_ITEM_BTN_DD(temp) << 1);
+                                          ItemIconPos[temp-1][0], ItemIconPos[temp-1][1], ItemIconWidthFactor[temp-1][0],
+                                          ItemIconWidthFactor[temp-1][0], ItemIconWidthFactor[temp-1][1], ItemIconWidthFactor[temp-1][1]);
 
             const char* cButtonIcons[] = { gButtonBackgroundTex, gEquippedItemOutlineTex, gEmptyCLeftArrowTex,
                                            gEmptyCDownArrowTex, gEmptyCRightArrowTex
             };
 
             OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, cButtonIcons[(temp + 1)], 32, 32,
-                                          ItemIconPos[temp-1][0], ItemIconPos[temp-1][1], R_ITEM_BTN_WIDTH(temp),
-                                          R_ITEM_BTN_WIDTH(temp), R_ITEM_BTN_DD(temp) << 1, R_ITEM_BTN_DD(temp) << 1);
+                                          ItemIconPos[temp-1][0], ItemIconPos[temp-1][1], ItemIconWidthFactor[temp-1][0],
+                                          ItemIconWidthFactor[temp-1][0], ItemIconWidthFactor[temp-1][1], ItemIconWidthFactor[temp-1][1]);
         }
     }
 
@@ -3793,6 +3835,8 @@ int16_t gItemIconDD[] = { 550, 680, 680, 680, 1024, 1024, 1024, 1024 };
 
 void Interface_DrawItemIconTexture(GlobalContext* globalCtx, void* texture, s16 button) {
     OPEN_DISPS(globalCtx->state.gfxCtx);
+    GraphicsContext* gfxCtx = globalCtx->state.gfxCtx;
+    InterfaceContext* interfaceCtx = &globalCtx->interfaceCtx;
     s16 X_Margins_CL;
     s16 X_Margins_CR;
     s16 X_Margins_CD;
@@ -3838,15 +3882,52 @@ void Interface_DrawItemIconTexture(GlobalContext* globalCtx, void* texture, s16 
         X_Margins_DPad_Items = 0;
         Y_Margins_DPad_Items = 0;
     }
+    const float ItemsScale_offset[8][2] = {
+        // Y      X
+        { 104.0f, 144.0f }, //B
+        { 108.0f, 148.0f }, //C L 
+        { 108.0f, 148.0f }, //C D
+        { 108.0f, 148.0f }, //C R
+        { 112.0f, 152.0f }, //Dpad ^
+        { 112.0f, 152.0f }, //Dpad V
+        { 112.0f, 152.0f }, //Dpad <
+        { 112.0f, 152.0f }  //Dpad >
+    };
+    float ItemScale_ori[8] = {
+        1.0f, //B BTN
+        0.87f, 0.87f, 0.87f, //C BTNs L / D / R
+        0.6f, 0.6f, 0.6f, 0.6f //Dpad U/D/L/R
+    };
     const s16 ItemIconPos_ori[8][2] = {
-        { B_BUTTON_X+X_Margins_BtnB, B_BUTTON_Y+Y_Margins_BtnB },
-        { C_LEFT_BUTTON_X+X_Margins_CL, C_LEFT_BUTTON_Y+Y_Margins_CL },
-        { C_DOWN_BUTTON_X+X_Margins_CD, C_DOWN_BUTTON_Y+Y_Margins_CD },
-        { C_RIGHT_BUTTON_X+X_Margins_CR, C_RIGHT_BUTTON_Y+Y_Margins_CR },
-        { DPAD_UP_X+X_Margins_DPad_Items, DPAD_UP_Y+Y_Margins_DPad_Items },
-        { DPAD_DOWN_X+X_Margins_DPad_Items, DPAD_DOWN_Y+Y_Margins_DPad_Items }, 
-        { DPAD_LEFT_X+X_Margins_DPad_Items, DPAD_LEFT_Y+Y_Margins_DPad_Items }, 
-        { DPAD_RIGHT_X+X_Margins_DPad_Items, DPAD_RIGHT_Y+Y_Margins_DPad_Items }
+        { B_BUTTON_X+X_Margins_BtnB-ItemsScale_offset[0][1], B_BUTTON_Y+Y_Margins_BtnB-ItemsScale_offset[0][0] },
+        { C_LEFT_BUTTON_X+X_Margins_CL-ItemsScale_offset[1][1], C_LEFT_BUTTON_Y+Y_Margins_CL-ItemsScale_offset[1][0] },
+        { C_DOWN_BUTTON_X+X_Margins_CD-ItemsScale_offset[2][1], C_DOWN_BUTTON_Y+Y_Margins_CD-ItemsScale_offset[2][0] },
+        { C_RIGHT_BUTTON_X+X_Margins_CR-ItemsScale_offset[3][1], C_RIGHT_BUTTON_Y+Y_Margins_CR-ItemsScale_offset[3][0] },
+        { DPAD_UP_X+X_Margins_DPad_Items-ItemsScale_offset[4][1], DPAD_UP_Y+Y_Margins_DPad_Items-ItemsScale_offset[4][0] },
+        { DPAD_DOWN_X+X_Margins_DPad_Items-ItemsScale_offset[5][1], DPAD_DOWN_Y+Y_Margins_DPad_Items-ItemsScale_offset[5][0] }, 
+        { DPAD_LEFT_X+X_Margins_DPad_Items-ItemsScale_offset[6][1], DPAD_LEFT_Y+Y_Margins_DPad_Items-ItemsScale_offset[6][0] }, 
+        { DPAD_RIGHT_X+X_Margins_DPad_Items-ItemsScale_offset[7][1], DPAD_RIGHT_Y+Y_Margins_DPad_Items-ItemsScale_offset[7][0] }
+    };
+    float ItemScale[8] = {
+        CVar_GetFloat("gBBtnScale", 1.0f),
+        CVar_GetFloat("gCBtnLScale", 0.87f),
+        CVar_GetFloat("gCBtnDScale", 0.87f),
+        CVar_GetFloat("gCBtnRScale", 0.87f),
+        CVar_GetFloat("gDPadScale", 0.425f),
+        CVar_GetFloat("gDPadScale", 0.425f),
+        CVar_GetFloat("gDPadScale", 0.425f),
+        CVar_GetFloat("gDPadScale", 0.425f),
+    };
+    float ItemScaleCurrent[8]; //Hold the array with modified scale
+    u16 ItemsSlotsAlpha[8] = {
+        interfaceCtx->bAlpha,
+        interfaceCtx->cLeftAlpha,
+        interfaceCtx->cRightAlpha,
+        interfaceCtx->cDownAlpha,
+        interfaceCtx->dpadUpAlpha,
+        interfaceCtx->dpadDownAlpha,
+        interfaceCtx->dpadLeftAlpha,
+        interfaceCtx->dpadRightAlpha
     };
     s16 DPad_ItemsOffset[4][2] = {
         { 7,-8},//Up
@@ -3857,6 +3938,10 @@ void Interface_DrawItemIconTexture(GlobalContext* globalCtx, void* texture, s16 
     s16 ItemIconPos[8][2]; //(X,Y)
     //DPadItems
     if (CVar_GetS32("gDPadPosType", 0) != 0) {
+        ItemScaleCurrent[4] = ItemScale[4];
+        ItemScaleCurrent[5] = ItemScale[5];
+        ItemScaleCurrent[6] = ItemScale[6];
+        ItemScaleCurrent[7] = ItemScale[7];
         ItemIconPos[4][1] = CVar_GetS32("gDPadPosY", 0)+Y_Margins_DPad_Items+DPad_ItemsOffset[0][1];//Up
         ItemIconPos[5][1] = CVar_GetS32("gDPadPosY", 0)+Y_Margins_DPad_Items+DPad_ItemsOffset[1][1];//Down
         ItemIconPos[6][1] = CVar_GetS32("gDPadPosY", 0)+Y_Margins_DPad_Items+DPad_ItemsOffset[2][1];//Left
@@ -3885,6 +3970,10 @@ void Interface_DrawItemIconTexture(GlobalContext* globalCtx, void* texture, s16 
             ItemIconPos[7][0] = -9999;
         }
     } else {
+        ItemScaleCurrent[4] = ItemScale_ori[4];
+        ItemScaleCurrent[5] = ItemScale_ori[5];
+        ItemScaleCurrent[6] = ItemScale_ori[6];
+        ItemScaleCurrent[7] = ItemScale_ori[7];
         ItemIconPos[4][0] = OTRGetDimensionFromRightEdge(ItemIconPos_ori[4][0]);
         ItemIconPos[5][0] = OTRGetDimensionFromRightEdge(ItemIconPos_ori[5][0]);
         ItemIconPos[6][0] = OTRGetDimensionFromRightEdge(ItemIconPos_ori[6][0]);
@@ -3896,73 +3985,81 @@ void Interface_DrawItemIconTexture(GlobalContext* globalCtx, void* texture, s16 
     }
     //B Button
     if (CVar_GetS32("gBBtnPosType", 0) != 0) {
-        ItemIconPos[0][1] = CVar_GetS32("gBBtnPosY", 0)+Y_Margins_BtnB;
+        ItemScaleCurrent[0] = ItemScale[0];
+        ItemIconPos[0][1] = CVar_GetS32("gBBtnPosY", 0)+Y_Margins_BtnB-ItemsScale_offset[0][0];
         if (CVar_GetS32("gBBtnPosType", 0) == 1) {//Anchor Left
             if (CVar_GetS32("gBBtnUseMargins", 0) != 0) {X_Margins_BtnB = Left_HUD_Margin;};
-            ItemIconPos[0][0] = OTRGetDimensionFromLeftEdge(CVar_GetS32("gBBtnPosX", 0)+X_Margins_BtnB);
+            ItemIconPos[0][0] = OTRGetDimensionFromLeftEdge(CVar_GetS32("gBBtnPosX", 0)+X_Margins_BtnB-ItemsScale_offset[0][1]);
         } else if (CVar_GetS32("gBBtnPosType", 0) == 2) {//Anchor Right
             if (CVar_GetS32("gBBtnUseMargins", 0) != 0) {X_Margins_BtnB = Right_HUD_Margin;};
-            ItemIconPos[0][0] = OTRGetDimensionFromRightEdge(CVar_GetS32("gBBtnPosX", 0)+X_Margins_BtnB);
+            ItemIconPos[0][0] = OTRGetDimensionFromRightEdge(CVar_GetS32("gBBtnPosX", 0)+X_Margins_BtnB-ItemsScale_offset[0][1]);
         } else if (CVar_GetS32("gBBtnPosType", 0) == 3) {//Anchor None
-            ItemIconPos[0][0] = CVar_GetS32("gBBtnPosX", 0);
+            ItemIconPos[0][0] = CVar_GetS32("gBBtnPosX", 0)-ItemsScale_offset[0][1];
         } else if (CVar_GetS32("gBBtnPosType", 0) == 4) {//Hidden
            ItemIconPos[0][0] = -9999;
         }
     } else {
+        ItemScaleCurrent[0] = ItemScale_ori[0];
         ItemIconPos[0][0] = OTRGetRectDimensionFromRightEdge(ItemIconPos_ori[0][0]);
         ItemIconPos[0][1] = ItemIconPos_ori[0][1];
     }
     //C button Left
     if (CVar_GetS32("gCBtnLPosType", 0) != 0) {
-        ItemIconPos[1][1] = CVar_GetS32("gCBtnLPosY", 0)+Y_Margins_CL;
+        ItemScaleCurrent[1] = ItemScale[1];
+        ItemIconPos[1][1] = CVar_GetS32("gCBtnLPosY", 0)+Y_Margins_CL-ItemsScale_offset[1][0];
         if (CVar_GetS32("gCBtnLPosType", 0) == 1) {//Anchor Left
             if (CVar_GetS32("gCBtnLUseMargins", 0) != 0) {X_Margins_CL = Left_HUD_Margin;};
-            ItemIconPos[1][0] = OTRGetDimensionFromLeftEdge(CVar_GetS32("gCBtnLPosX", 0)+X_Margins_CL);
+            ItemIconPos[1][0] = OTRGetDimensionFromLeftEdge(CVar_GetS32("gCBtnLPosX", 0)+X_Margins_CL-ItemsScale_offset[1][1]);
         } else if (CVar_GetS32("gCBtnLPosType", 0) == 2) {//Anchor Right
             if (CVar_GetS32("gCBtnLUseMargins", 0) != 0) {X_Margins_CL = Right_HUD_Margin;};
-            ItemIconPos[1][0] = OTRGetDimensionFromRightEdge(CVar_GetS32("gCBtnLPosX", 0)+X_Margins_CL);
+            ItemIconPos[1][0] = OTRGetDimensionFromRightEdge(CVar_GetS32("gCBtnLPosX", 0)+X_Margins_CL-ItemsScale_offset[1][1]);
         } else if (CVar_GetS32("gCBtnLPosType", 0) == 3) {//Anchor None
-            ItemIconPos[1][0] = CVar_GetS32("gCBtnLPosX", 0);
+            ItemIconPos[1][0] = CVar_GetS32("gCBtnLPosX", 0)-ItemsScale_offset[1][1];
         } else if (CVar_GetS32("gCBtnLPosType", 0) == 4) {//Hidden
             ItemIconPos[1][0] = -9999;
         }
     } else {
+        ItemScaleCurrent[1] = ItemScale_ori[1];
         ItemIconPos[1][0] = OTRGetRectDimensionFromRightEdge(ItemIconPos_ori[1][0]);
         ItemIconPos[1][1] = ItemIconPos_ori[1][1];
     }
     //C Button down
     if (CVar_GetS32("gCBtnDPosType", 0) != 0) {
-        ItemIconPos[2][1] = CVar_GetS32("gCBtnDPosY", 0)+Y_Margins_CD;
+        ItemScaleCurrent[2] = ItemScale[2];
+        ItemIconPos[2][1] = CVar_GetS32("gCBtnDPosY", 0)+Y_Margins_CD-ItemsScale_offset[2][0];
         if (CVar_GetS32("gCBtnDPosType", 0) == 1) {//Anchor Left
             if (CVar_GetS32("gCBtnDUseMargins", 0) != 0) {X_Margins_CD = Left_HUD_Margin;};
-            ItemIconPos[2][0] = OTRGetDimensionFromLeftEdge(CVar_GetS32("gCBtnDPosX", 0)+X_Margins_CD);
+            ItemIconPos[2][0] = OTRGetDimensionFromLeftEdge(CVar_GetS32("gCBtnDPosX", 0)+X_Margins_CD-ItemsScale_offset[2][1]);
         } else if (CVar_GetS32("gCBtnDPosType", 0) == 2) {//Anchor Right
             if (CVar_GetS32("gCBtnDUseMargins", 0) != 0) {X_Margins_CD = Right_HUD_Margin;};
-            ItemIconPos[2][0] = OTRGetDimensionFromRightEdge(CVar_GetS32("gCBtnDPosX", 0)+X_Margins_CD);
+            ItemIconPos[2][0] = OTRGetDimensionFromRightEdge(CVar_GetS32("gCBtnDPosX", 0)+X_Margins_CD-ItemsScale_offset[2][1]);
         } else if (CVar_GetS32("gCBtnDPosType", 0) == 3) {//Anchor None
-            ItemIconPos[2][0] = CVar_GetS32("gCBtnDPosX", 0);
+            ItemIconPos[2][0] = CVar_GetS32("gCBtnDPosX", 0)-ItemsScale_offset[2][1];
         } else if (CVar_GetS32("gCBtnDPosType", 0) == 4) {//Hidden
             ItemIconPos[2][0] = -9999;
         }
     } else {
+        ItemScaleCurrent[2] = ItemScale_ori[2];
         ItemIconPos[2][0] = OTRGetRectDimensionFromRightEdge(ItemIconPos_ori[2][0]);
         ItemIconPos[2][1] = ItemIconPos_ori[2][1];
     }
     //C button Right
     if (CVar_GetS32("gCBtnRPosType", 0) != 0) {
-        ItemIconPos[3][1] = CVar_GetS32("gCBtnRPosY", 0)+Y_Margins_CR;
+        ItemScaleCurrent[3] = ItemScale[3];
+        ItemIconPos[3][1] = CVar_GetS32("gCBtnRPosY", 0)+Y_Margins_CR-ItemsScale_offset[3][0];
         if (CVar_GetS32("gCBtnRPosType", 0) == 1) {//Anchor Left
             if (CVar_GetS32("gCBtnRUseMargins", 0) != 0) {X_Margins_CR = Left_HUD_Margin;};
-            ItemIconPos[3][0] = OTRGetDimensionFromLeftEdge(CVar_GetS32("gCBtnRPosX", 0)+X_Margins_CR);
+            ItemIconPos[3][0] = OTRGetDimensionFromLeftEdge(CVar_GetS32("gCBtnRPosX", 0)+X_Margins_CR-ItemsScale_offset[3][1]);
         } else if (CVar_GetS32("gCBtnRPosType", 0) == 2) {//Anchor Right
             if (CVar_GetS32("gCBtnRUseMargins", 0) != 0) {X_Margins_CR = Right_HUD_Margin;};
-            ItemIconPos[3][0] = OTRGetDimensionFromRightEdge(CVar_GetS32("gCBtnRPosX", 0)+X_Margins_CR);
+            ItemIconPos[3][0] = OTRGetDimensionFromRightEdge(CVar_GetS32("gCBtnRPosX", 0)+X_Margins_CR-ItemsScale_offset[3][1]);
         } else if (CVar_GetS32("gCBtnRPosType", 0) == 3) {//Anchor None
-            ItemIconPos[3][0] = CVar_GetS32("gCBtnRPosX", 0);
+            ItemIconPos[3][0] = CVar_GetS32("gCBtnRPosX", 0)-ItemsScale_offset[3][1];
         } else if (CVar_GetS32("gCBtnRPosType", 0) == 4) {//Hidden
             ItemIconPos[3][0] = -9999;
         }
     } else {
+        ItemScaleCurrent[3] = ItemScale_ori[3];
         ItemIconPos[3][0] = OTRGetRectDimensionFromRightEdge(ItemIconPos_ori[3][0]);
         ItemIconPos[3][1] = ItemIconPos_ori[3][1];
     }
@@ -3970,10 +4067,23 @@ void Interface_DrawItemIconTexture(GlobalContext* globalCtx, void* texture, s16 
     gDPLoadTextureBlock(OVERLAY_DISP++, texture, G_IM_FMT_RGBA, G_IM_SIZ_32b, 32, 32, 0, G_TX_NOMIRROR | G_TX_WRAP,
                         G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
 
-    gSPWideTextureRectangle(OVERLAY_DISP++, ItemIconPos[button][0] << 2, ItemIconPos[button][1] << 2,
-                        (ItemIconPos[button][0] + gItemIconWidth[button]) << 2,
-                        (ItemIconPos[button][1] + gItemIconWidth[button]) << 2, G_TX_RENDERTILE, 0, 0,
-                        gItemIconDD[button] << 1, gItemIconDD[button] << 1);
+    gDPPipeSync(OVERLAY_DISP++);
+    gSPSetGeometryMode(OVERLAY_DISP++, G_CULL_BACK);
+    gDPSetCombineLERP(OVERLAY_DISP++, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0);
+    gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 255, 255, ItemsSlotsAlpha[button]);
+    gDPSetEnvColor(OVERLAY_DISP++, 0, 0, 0, 0);
+    Matrix_Translate(
+        ItemIconPos[button][0],
+        ItemIconPos[button][1] * -1, 1.0f, MTXMODE_NEW);
+
+    Matrix_Scale(
+        ItemScaleCurrent[button]/1, 
+        ItemScaleCurrent[button]/1, 
+        ItemScaleCurrent[button]/1, MTXMODE_APPLY);
+    gSPMatrix(OVERLAY_DISP++, MATRIX_NEWMTX(globalCtx->state.gfxCtx), G_MTX_MODELVIEW | G_MTX_LOAD);
+    gSPVertex(OVERLAY_DISP++, &interfaceCtx->actionVtx[0], 4, 0);
+    gSP1Quadrangle(OVERLAY_DISP++, 0, 2, 3, 1, 0);
+    gDPPipeSync(OVERLAY_DISP++);
 
     CLOSE_DISPS(globalCtx->state.gfxCtx);
 }
@@ -4385,7 +4495,12 @@ void Interface_Draw(GlobalContext* globalCtx) {
         { 0x82, 0x82, 0xFF }, // Adult's Wallet (Blue)
         { 0xFF, 0x64, 0x64 }, // Giant's Wallet (Red)
     };
-    s16 rColor[3] = { 200, 255, 100 };
+    Color_RGB8 rColor_ori = { 200, 255, 100 };
+    Color_RGB8 rColor;
+    Color_RGB8 keyColor_ori = { 200, 230, 255 };
+    Color_RGB8 keyColor;
+    Color_RGB8 DPad_colors_ori = {255, 255, 255};
+    Color_RGB8 DPad_colors = CVar_GetRGB("gCCDpadPrim", DPad_colors_ori);
     static s16 spoilingItemEntrances[] = { 0x01AD, 0x0153, 0x0153 };
     static f32 D_80125B54[] = { -40.0f, -35.0f }; // unused
     static s16 D_80125B5C[] = { 91, 91 };         // unused
@@ -4432,25 +4547,23 @@ void Interface_Draw(GlobalContext* globalCtx) {
                 //Custom Color is on but check if Dynamic Wallet is on.
                 if (CVar_GetS32("gDynamicWalletIcon", 0) != 0) {
                     //if on let's use Dynamic Colors
-                    rColor[0] = rupeeWalletColors[CUR_UPG_VALUE(UPG_WALLET)][0];
-                    rColor[1] = rupeeWalletColors[CUR_UPG_VALUE(UPG_WALLET)][1];
-                    rColor[2] = rupeeWalletColors[CUR_UPG_VALUE(UPG_WALLET)][2];
+                    rColor.r = rupeeWalletColors[CUR_UPG_VALUE(UPG_WALLET)][0];
+                    rColor.g = rupeeWalletColors[CUR_UPG_VALUE(UPG_WALLET)][1];
+                    rColor.b = rupeeWalletColors[CUR_UPG_VALUE(UPG_WALLET)][2];
                 } else {
                     //else use our custom color
-                    rColor[0] = CVar_GetS32("gCCRupeePrimR", &rupeeWalletColors[0][0]);
-                    rColor[1] = CVar_GetS32("gCCRupeePrimG", &rupeeWalletColors[0][1]);
-                    rColor[2] = CVar_GetS32("gCCRupeePrimB", &rupeeWalletColors[0][2]);
+                    rColor = CVar_GetRGB("gCCRupeePrim", rColor_ori);
                 }
             } else {
                 //Custom colors is off so check if Dynamic Wallet is on.
                 if (CVar_GetS32("gDynamicWalletIcon", 0) != 0) {
-                    rColor[0] = rupeeWalletColors[CUR_UPG_VALUE(UPG_WALLET)][0];
-                    rColor[1] = rupeeWalletColors[CUR_UPG_VALUE(UPG_WALLET)][1];
-                    rColor[2] = rupeeWalletColors[CUR_UPG_VALUE(UPG_WALLET)][2];
+                    rColor.r = rupeeWalletColors[CUR_UPG_VALUE(UPG_WALLET)][0];
+                    rColor.g = rupeeWalletColors[CUR_UPG_VALUE(UPG_WALLET)][1];
+                    rColor.b = rupeeWalletColors[CUR_UPG_VALUE(UPG_WALLET)][2];
                 } else {
-                    rColor[0] = rupeeWalletColors[0][0];
-                    rColor[1] = rupeeWalletColors[0][1];
-                    rColor[2] = rupeeWalletColors[0][2];
+                    rColor.r = rupeeWalletColors[0][0];
+                    rColor.g = rupeeWalletColors[0][1];
+                    rColor.b = rupeeWalletColors[0][2];
                 }
             }
             if (CVar_GetS32("gHudColors", 1) == 2 && CVar_GetS32("gDynamicWalletIcon", 0) != 1) {
@@ -4488,7 +4601,7 @@ void Interface_Draw(GlobalContext* globalCtx) {
                 PosY_RC = PosY_RC_ori;
                 PosX_RC = PosX_RC_ori;
             }
-            gDPSetPrimColor(OVERLAY_DISP++, 0, 0, rColor[0], rColor[1], rColor[2], interfaceCtx->magicAlpha);
+            gDPSetPrimColor(OVERLAY_DISP++, 0, 0, rColor.r, rColor.g, rColor.b, interfaceCtx->magicAlpha);
             OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, gRupeeCounterIconTex, 16, 16, PosX_RC, PosY_RC, 16, 16, 1 << 10, 1 << 10);
 
             switch (globalCtx->sceneNum) {
@@ -4541,10 +4654,10 @@ void Interface_Draw(GlobalContext* globalCtx) {
                         gDPPipeSync(OVERLAY_DISP++);
 
                         if (CVar_GetS32("gHudColors", 1) == 2) {
-                            gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetS32("gCCKeysPrimR", 200), CVar_GetS32("gCCKeysPrimG", 230), CVar_GetS32("gCCKeysPrimB", 255), interfaceCtx->magicAlpha);
+                            gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetRGB("gCCKeysPrim", keyColor_ori).r,CVar_GetRGB("gCCKeysPrim", keyColor_ori).g,CVar_GetRGB("gCCKeysPrim", keyColor_ori).b, interfaceCtx->magicAlpha);
                             gDPSetEnvColor(OVERLAY_DISP++, 0, 0, 0, 255); //We reset this here so it match user color :)
                         } else {
-                            gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 200, 230, 255, interfaceCtx->magicAlpha);
+                            gDPSetPrimColor(OVERLAY_DISP++, 0, 0, keyColor_ori.r, keyColor_ori.g, keyColor_ori.b, interfaceCtx->magicAlpha);
                             gDPSetEnvColor(OVERLAY_DISP++, 0, 0, 20, 255);
                         }
                         OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, gSmallKeyCounterIconTex, 16, 16, PosX_SKC, PosY_SKC, 16, 16,
@@ -4799,9 +4912,9 @@ void Interface_Draw(GlobalContext* globalCtx) {
             gDPSetCombineMode(OVERLAY_DISP++, G_CC_MODULATEIA_PRIM, G_CC_MODULATEIA_PRIM);
 
             if (CVar_GetS32("gHudColors", 1) == 2) {
-                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetS32("gCCDpadPrimR", 255), CVar_GetS32("gCCDpadPrimG", 255), CVar_GetS32("gCCDpadPrimB", 255), dpadAlpha);
+                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, DPad_colors.r,DPad_colors.g,DPad_colors.b, dpadAlpha);
             } else {
-                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 255, 255, dpadAlpha);
+                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, DPad_colors_ori.r,DPad_colors_ori.g,DPad_colors_ori.b, dpadAlpha);
             }
             if (fullUi) {
                 gDPLoadTextureBlock(OVERLAY_DISP++, ResourceMgr_LoadFileRaw("assets/ship_of_harkinian/buttons/dpad.bin"),
@@ -4859,6 +4972,7 @@ void Interface_Draw(GlobalContext* globalCtx) {
 
         // A Button
         func_80094A14(globalCtx->state.gfxCtx);
+        const Color_RGB8 A_Button_Colors = {R_A_BTN_COLOR(0), R_A_BTN_COLOR(1), R_A_BTN_COLOR(2)};
         s16 X_Margins_BtnA;
         s16 Y_Margins_BtnA;
         if (CVar_GetS32("gABtnUseMargins", 0) != 0) {
@@ -4905,9 +5019,9 @@ void Interface_Draw(GlobalContext* globalCtx) {
         if (CVar_GetS32("gHudColors", 1) == 0) {
             gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 90, 90, 255, interfaceCtx->aAlpha);
         } else if (CVar_GetS32("gHudColors", 1) == 1) {
-            gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_A_BTN_COLOR(0), R_A_BTN_COLOR(1), R_A_BTN_COLOR(2), interfaceCtx->aAlpha);
+            gDPSetPrimColor(OVERLAY_DISP++, 0, 0, A_Button_Colors.r, A_Button_Colors.g, A_Button_Colors.b, interfaceCtx->aAlpha);
         } else if (CVar_GetS32("gHudColors", 1) == 2) {
-            gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetS32("gCCABtnPrimR", R_A_BTN_COLOR(0)), CVar_GetS32("gCCABtnPrimG", R_A_BTN_COLOR(1)), CVar_GetS32("gCCABtnPrimB", R_A_BTN_COLOR(2)), interfaceCtx->aAlpha);
+            gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetRGB("gCCABtnPrim", A_Button_Colors).r,CVar_GetRGB("gCCABtnPrim", A_Button_Colors).g,CVar_GetRGB("gCCABtnPrim", A_Button_Colors).b, interfaceCtx->aAlpha);
         }
         if (fullUi) {
             Interface_DrawActionButton(globalCtx, PosX_BtnA, PosY_BtnA);

--- a/soh/src/code/z_play.c
+++ b/soh/src/code/z_play.c
@@ -414,6 +414,13 @@ void Gameplay_Init(GameState* thisx) {
     PreRender_SetValues(&globalCtx->pauseBgPreRender, SCREEN_WIDTH, SCREEN_HEIGHT, 0, 0);
     gTrnsnUnkState = 0;
     globalCtx->transitionMode = 0;
+
+    if (CVar_GetS32("gSceneTransitions", 255)!= 255){
+        globalCtx->transitionMode = CVar_GetS32("gSceneTransitions", 0);
+        gSaveContext.nextTransition = CVar_GetS32("gSceneTransitions", 0);
+        globalCtx->fadeTransition = CVar_GetS32("gSceneTransitions", 0);
+    }
+
     FrameAdvance_Init(&globalCtx->frameAdvCtx);
     Rand_Seed((u32)osGetTime());
     Matrix_Init(&globalCtx->state);

--- a/soh/src/overlays/actors/ovl_Arrow_Fire/z_arrow_fire.c
+++ b/soh/src/overlays/actors/ovl_Arrow_Fire/z_arrow_fire.c
@@ -194,6 +194,10 @@ void ArrowFire_Draw(Actor* thisx, GlobalContext* globalCtx2) {
     u32 stateFrames;
     EnArrow* arrow;
     Actor* tranform;
+    Color_RGB8 Arrow_env_ori = {255,0,0};
+    Color_RGB8 Arrow_col_ori = {255,200,0};
+    Color_RGB8 Arrow_env = CVar_GetRGB("gFireArrowColEnv", Arrow_env_ori);
+    Color_RGB8 Arrow_col = CVar_GetRGB("gFireArrowCol", Arrow_col_ori);
 
     stateFrames = globalCtx->state.frames;
     arrow = (EnArrow*)this->actor.parent;
@@ -214,9 +218,9 @@ void ArrowFire_Draw(Actor* thisx, GlobalContext* globalCtx2) {
             POLY_XLU_DISP = func_800937C0(POLY_XLU_DISP);
             if (CVar_GetS32("gUseArrowsCol", 0)) {
                 gDPSetPrimColor(POLY_XLU_DISP++, 0, 0, 
-                (s32)(CVar_GetS32("gFireArrowColEnvR", 40) * this->unk_15C) & 0xFF,
-                (s32)(CVar_GetS32("gFireArrowColEnvG", 0) * this->unk_15C) & 0xFF, 
-                (s32)(CVar_GetS32("gFireArrowColEnvB", 0) * this->unk_15C) & 0xFF, 
+                (s32)(Arrow_env.r * this->unk_15C) & 0xFF,
+                (s32)(Arrow_env.g * this->unk_15C) & 0xFF, 
+                (s32)(Arrow_env.b * this->unk_15C) & 0xFF,
                 (s32)(30.0f * this->unk_15C) & 0xFF); //Intentionnally made Alpha lower.
             } else {
                 gDPSetPrimColor(POLY_XLU_DISP++, 0, 0, (s32)(40.0f * this->unk_15C) & 0xFF, 0, 0,
@@ -230,11 +234,11 @@ void ArrowFire_Draw(Actor* thisx, GlobalContext* globalCtx2) {
         // Draw fire on the arrow
         func_80093D84(globalCtx->state.gfxCtx);
         if (CVar_GetS32("gUseArrowsCol", 0)) {
-            gDPSetPrimColor(POLY_XLU_DISP++, 0x80, 0x80, CVar_GetS32("gFireArrowColR", 255), CVar_GetS32("gFireArrowColG", 200), CVar_GetS32("gFireArrowColB", 0), this->alpha);
-            gDPSetEnvColor(POLY_XLU_DISP++, CVar_GetS32("gFireArrowColEnvR", 255), CVar_GetS32("gFireArrowColEnvG", 0), CVar_GetS32("gFireArrowColEnvB", 0), 128);
+            gDPSetPrimColor(POLY_XLU_DISP++, 0x80, 0x80, Arrow_col.r, Arrow_col.g, Arrow_col.b, this->alpha);
+            gDPSetEnvColor(POLY_XLU_DISP++, Arrow_env.r, Arrow_env.g, Arrow_env.b, 128);
         } else {
-            gDPSetPrimColor(POLY_XLU_DISP++, 0x80, 0x80, 255, 200, 0, this->alpha);
-            gDPSetEnvColor(POLY_XLU_DISP++, 255, 0, 0, 128);
+            gDPSetPrimColor(POLY_XLU_DISP++, 0x80, 0x80, Arrow_col_ori.r, Arrow_col_ori.g, Arrow_col_ori.b, this->alpha);
+            gDPSetEnvColor(POLY_XLU_DISP++, Arrow_env_ori.r, Arrow_env_ori.g, Arrow_env_ori.b, 128);
         }
         Matrix_RotateZYX(0x4000, 0x0, 0x0, MTXMODE_APPLY);
         if (this->timer != 0) {

--- a/soh/src/overlays/actors/ovl_Arrow_Ice/z_arrow_ice.c
+++ b/soh/src/overlays/actors/ovl_Arrow_Ice/z_arrow_ice.c
@@ -195,6 +195,10 @@ void ArrowIce_Draw(Actor* thisx, GlobalContext* globalCtx) {
     Actor* tranform;
     u32 stateFrames = globalCtx->state.frames;
     EnArrow* arrow = (EnArrow*)this->actor.parent;
+    Color_RGB8 Arrow_env_ori = {0,0,255};
+    Color_RGB8 Arrow_col_ori = {170, 255, 255};
+    Color_RGB8 Arrow_env = CVar_GetRGB("gIceArrowColEnv", Arrow_env_ori);
+    Color_RGB8 Arrow_col = CVar_GetRGB("gIceArrowCol", Arrow_col_ori);
 
     if ((arrow != NULL) && (arrow->actor.update != NULL) && (this->timer < 255)) {
         tranform = (arrow->hitFlags & 2) ? &this->actor : &arrow->actor;
@@ -212,9 +216,9 @@ void ArrowIce_Draw(Actor* thisx, GlobalContext* globalCtx) {
             POLY_XLU_DISP = func_800937C0(POLY_XLU_DISP);
             if (CVar_GetS32("gUseArrowsCol", 0)) {
                 gDPSetPrimColor(POLY_XLU_DISP++, 0, 0, 
-                (s32)(CVar_GetS32("gIceArrowColEnvR", 0) * this->unk_164) & 0xFF,
-                (s32)(CVar_GetS32("gIceArrowColEnvG", 10) * this->unk_164) & 0xFF, 
-                (s32)(CVar_GetS32("gIceArrowColEnvB", 50) * this->unk_164) & 0xFF, 
+                (s32)(Arrow_env.r * this->unk_164) & 0xFF,
+                (s32)(Arrow_env.g * this->unk_164) & 0xFF, 
+                (s32)(Arrow_env.b * this->unk_164) & 0xFF,
                 (s32)(30.0f * this->unk_164) & 0xFF); //Intentionnally made Alpha lower.
             } else {
                 gDPSetPrimColor(POLY_XLU_DISP++, 0, 0, 0, (s32)(10.0f * this->unk_164) & 0xFF,
@@ -228,11 +232,11 @@ void ArrowIce_Draw(Actor* thisx, GlobalContext* globalCtx) {
         // Draw ice on the arrow
         func_80093D84(globalCtx->state.gfxCtx);
         if (CVar_GetS32("gUseArrowsCol", 0)) {
-            gDPSetPrimColor(POLY_XLU_DISP++, 0x80, 0x80, CVar_GetS32("gIceArrowColR", 170), CVar_GetS32("gIceArrowColG", 255), CVar_GetS32("gIceArrowColB", 255), this->alpha);
-            gDPSetEnvColor(POLY_XLU_DISP++, CVar_GetS32("gIceArrowColEnvR", 0), CVar_GetS32("gIceArrowColEnvG", 0), CVar_GetS32("gIceArrowColEnvB", 255), 128);
+            gDPSetPrimColor(POLY_XLU_DISP++, 0x80, 0x80, Arrow_col.r, Arrow_col.g, Arrow_col.b, this->alpha);
+            gDPSetEnvColor(POLY_XLU_DISP++, Arrow_env.r, Arrow_env.g, Arrow_env.b, 128);
         } else {
-            gDPSetPrimColor(POLY_XLU_DISP++, 0x80, 0x80, 170, 255, 255, this->alpha);
-            gDPSetEnvColor(POLY_XLU_DISP++, 0, 0, 255, 128);
+            gDPSetPrimColor(POLY_XLU_DISP++, 0x80, 0x80, Arrow_col_ori.r, Arrow_col_ori.g, Arrow_col_ori.b, this->alpha);
+            gDPSetEnvColor(POLY_XLU_DISP++, Arrow_env_ori.r, Arrow_env_ori.g, Arrow_env_ori.b, 128);
         }
         Matrix_RotateZYX(0x4000, 0x0, 0x0, MTXMODE_APPLY);
         if (this->timer != 0) {

--- a/soh/src/overlays/actors/ovl_Arrow_Light/z_arrow_light.c
+++ b/soh/src/overlays/actors/ovl_Arrow_Light/z_arrow_light.c
@@ -193,6 +193,10 @@ void ArrowLight_Draw(Actor* thisx, GlobalContext* globalCtx) {
     u32 stateFrames = globalCtx->state.frames;
     EnArrow* arrow = (EnArrow*)this->actor.parent;
     Actor* tranform;
+    Color_RGB8 Arrow_env_ori = {255, 255, 0};
+    Color_RGB8 Arrow_col_ori = {255, 255, 170};
+    Color_RGB8 Arrow_env = CVar_GetRGB("gLightArrowColEnv", Arrow_env_ori);
+    Color_RGB8 Arrow_col = CVar_GetRGB("gLightArrowCol", Arrow_col_ori);
 
     if ((arrow != NULL) && (arrow->actor.update != NULL) && (this->timer < 255)) {
         tranform = (arrow->hitFlags & 2) ? &this->actor : &arrow->actor;
@@ -210,9 +214,9 @@ void ArrowLight_Draw(Actor* thisx, GlobalContext* globalCtx) {
             POLY_XLU_DISP = func_800937C0(POLY_XLU_DISP);
             if (CVar_GetS32("gUseArrowsCol", 0)) {
                 gDPSetPrimColor(POLY_XLU_DISP++, 0, 0, 
-                (s32)(CVar_GetS32("gLightArrowColEnvR", 30) * this->unk_164) & 0xFF,
-                (s32)(CVar_GetS32("gLightArrowColEnvG", 40) * this->unk_164) & 0xFF, 
-                (s32)(CVar_GetS32("gLightArrowColEnvB", 0) * this->unk_164) & 0xFF, 
+                (s32)(Arrow_env.r * this->unk_164) & 0xFF,
+                (s32)(Arrow_env.g * this->unk_164) & 0xFF, 
+                (s32)(Arrow_env.b * this->unk_164) & 0xFF, 
                 (s32)(30.0f * this->unk_164) & 0xFF); //Intentionnally made Alpha lower.
             } else {
                 gDPSetPrimColor(POLY_XLU_DISP++, 0, 0, (s32)(30.0f * this->unk_164) & 0xFF,
@@ -226,11 +230,11 @@ void ArrowLight_Draw(Actor* thisx, GlobalContext* globalCtx) {
         // Draw light on the arrow
         func_80093D84(globalCtx->state.gfxCtx);
         if (CVar_GetS32("gUseArrowsCol", 0)) {
-            gDPSetPrimColor(POLY_XLU_DISP++, 0x80, 0x80, CVar_GetS32("gLightArrowColR", 255), CVar_GetS32("gLightArrowColG", 255), CVar_GetS32("gLightArrowColB", 170), this->alpha);
-            gDPSetEnvColor(POLY_XLU_DISP++, CVar_GetS32("gLightArrowColEnvR", 255), CVar_GetS32("gLightArrowColEnvG", 255), CVar_GetS32("gLightArrowColEnvB", 0), 128);
+            gDPSetPrimColor(POLY_XLU_DISP++, 0x80, 0x80, Arrow_col.r, Arrow_col.g, Arrow_col.b, this->alpha);
+            gDPSetEnvColor(POLY_XLU_DISP++, Arrow_env.r, Arrow_env.g, Arrow_env.b, 128);
         } else {
-            gDPSetPrimColor(POLY_XLU_DISP++, 0x80, 0x80, 255, 255, 170, this->alpha);
-            gDPSetEnvColor(POLY_XLU_DISP++, 255, 255, 0, 128);
+            gDPSetPrimColor(POLY_XLU_DISP++, 0x80, 0x80, Arrow_col_ori.r, Arrow_col_ori.g, Arrow_col_ori.b, this->alpha);
+            gDPSetEnvColor(POLY_XLU_DISP++, Arrow_env_ori.r, Arrow_env_ori.g, Arrow_env_ori.b, 128);
         }
         Matrix_RotateZYX(0x4000, 0x0, 0x0, MTXMODE_APPLY);
         if (this->timer != 0) {

--- a/soh/src/overlays/actors/ovl_En_Dog/z_en_dog.c
+++ b/soh/src/overlays/actors/ovl_En_Dog/z_en_dog.c
@@ -472,6 +472,10 @@ void EnDog_PostLimbDraw(GlobalContext* globalCtx, s32 limbIndex, Gfx** dList, Ve
 void EnDog_Draw(Actor* thisx, GlobalContext* globalCtx) {
     EnDog* this = (EnDog*)thisx;
     Color_RGBA8 colors[] = { { 255, 255, 200, 0 }, { 150, 100, 50, 0 } };
+    Color_RGB8 Dog1_ori = {colors[0].r, colors[0].g, colors[0].b};
+    Color_RGB8 Dog2_ori = {colors[1].r, colors[1].g, colors[1].b};
+    Color_RGB8 Dog1 = CVar_GetRGB("gDog1Col", Dog1_ori);
+    Color_RGB8 Dog2 = CVar_GetRGB("gDog2Col", Dog2_ori);
 
     OPEN_DISPS(globalCtx->state.gfxCtx);
 
@@ -479,19 +483,19 @@ void EnDog_Draw(Actor* thisx, GlobalContext* globalCtx) {
 
     gDPPipeSync(POLY_OPA_DISP++);
     if (CVar_GetS32("gUseDogsCol",0)) {
-        colors[0].r = CVar_GetS32("gDog1ColR", 255);
-        colors[0].g = CVar_GetS32("gDog1ColG", 255);
-        colors[0].b = CVar_GetS32("gDog1ColB", 200);
-        colors[1].r = CVar_GetS32("gDog2ColR", 150);
-        colors[1].g = CVar_GetS32("gDog2ColG", 100);
-        colors[1].b = CVar_GetS32("gDog2ColB", 50);
+        colors[0].r = Dog1.r;
+        colors[0].g = Dog1.g;
+        colors[0].b = Dog1.b;
+        colors[1].r = Dog2.r;
+        colors[1].g = Dog2.g;
+        colors[1].b = Dog2.b;
     } else {
-        colors[0].r = 255;
-        colors[0].g = 255;
-        colors[0].b = 200;
-        colors[1].r = 150;
-        colors[1].g = 100;
-        colors[1].b = 50;
+        colors[0].r = Dog1_ori.r;
+        colors[0].g = Dog1_ori.g;
+        colors[0].b = Dog1_ori.b;
+        colors[1].r = Dog2_ori.r;
+        colors[1].g = Dog2_ori.g;
+        colors[1].b = Dog2_ori.b;
     }
     gDPSetEnvColor(POLY_OPA_DISP++, colors[this->actor.params & 0xF].r, colors[this->actor.params & 0xF].g,
                    colors[this->actor.params & 0xF].b, colors[this->actor.params & 0xF].a);

--- a/soh/src/overlays/actors/ovl_En_Firefly/z_en_firefly.c
+++ b/soh/src/overlays/actors/ovl_En_Firefly/z_en_firefly.c
@@ -735,6 +735,11 @@ void EnFirefly_PostLimbDraw(GlobalContext* globalCtx, s32 limbIndex, Gfx** dList
     static Color_RGBA8 fireAuraEnvColor = { 255, 50, 0, 0 };
     static Color_RGBA8 iceAuraPrimColor = { 100, 200, 255, 255 };
     static Color_RGBA8 iceAuraEnvColor = { 0, 0, 255, 0 };
+    static Color_RGB8 fireAuraPrimColor_ori = { 255, 255, 100 };
+    static Color_RGB8 fireAuraEnvColor_ori = { 255, 50, 0 };
+    static Color_RGB8 iceAuraPrimColor_ori = { 100, 200, 255 };
+    static Color_RGB8 iceAuraEnvColor_ori = { 0, 0, 255 };
+
     static Vec3f effVelocity = { 0.0f, 0.5f, 0.0f };
     static Vec3f effAccel = { 0.0f, 0.5f, 0.0f };
     static Vec3f limbSrc = { 0.0f, 0.0f, 0.0f };
@@ -747,20 +752,20 @@ void EnFirefly_PostLimbDraw(GlobalContext* globalCtx, s32 limbIndex, Gfx** dList
     s16 effLife;
     EnFirefly* this = (EnFirefly*)thisx;
     if (CVar_GetS32("gUseKeeseCol", 0)) {
-        Color_RGBA8 fireAuraPrimColor_custom = { CVar_GetS32("gKeese1_Ef_PrimR", 255), CVar_GetS32("gKeese1_Ef_PrimG", 255), CVar_GetS32("gKeese1_Ef_PrimB", 100), 255 };
-        Color_RGBA8 fireAuraEnvColor_custom = { CVar_GetS32("gKeese1_Ef_EnvR", 255), CVar_GetS32("gKeese1_Ef_Env", 50), CVar_GetS32("gKeese1_Ef_EnvB", 0), 0 };
-        Color_RGBA8 iceAuraPrimColor_custom = { CVar_GetS32("gKeese2_Ef_PrimR", 100), CVar_GetS32("gKeese2_Ef_PrimG", 200), CVar_GetS32("gKeese2_Ef_PrimB", 255), 255 };
-        Color_RGBA8 iceAuraEnvColor_custom = { CVar_GetS32("gKeese2_Ef_EnvR", 0), CVar_GetS32("gKeese2_Ef_Env", 0), CVar_GetS32("gKeese2_Ef_EnvB", 255), 0 };
+        Color_RGBA8 fireAuraPrimColor_custom = { CVar_GetRGB("gKeese1_Ef_Prim", fireAuraPrimColor_ori).r,CVar_GetRGB("gKeese1_Ef_Prim", fireAuraPrimColor_ori).g,CVar_GetRGB("gKeese1_Ef_Prim", fireAuraPrimColor_ori).b, 255 };
+        Color_RGBA8 fireAuraEnvColor_custom = { CVar_GetRGB("gKeese1_Ef_Env", fireAuraEnvColor_ori).r,CVar_GetRGB("gKeese1_Ef_Env", fireAuraEnvColor_ori).g,CVar_GetRGB("gKeese1_Ef_Env", fireAuraEnvColor_ori).b, 0 };
+        Color_RGBA8 iceAuraPrimColor_custom = { CVar_GetRGB("gKeese2_Ef_Prim", iceAuraPrimColor_ori).r,CVar_GetRGB("gKeese2_Ef_Prim", iceAuraPrimColor_ori).g,CVar_GetRGB("gKeese2_Ef_Prim", iceAuraPrimColor_ori).b, 255 };
+        Color_RGBA8 iceAuraEnvColor_custom = { CVar_GetRGB("gKeese2_Ef_Env", iceAuraEnvColor_ori).r,CVar_GetRGB("gKeese2_Ef_Env", iceAuraEnvColor_ori).g,CVar_GetRGB("gKeese2_Ef_Env", iceAuraEnvColor_ori).b, 0 };
         fireAuraPrimColor = fireAuraPrimColor_custom;
         fireAuraEnvColor = fireAuraEnvColor_custom;
         iceAuraPrimColor = iceAuraPrimColor_custom;
         iceAuraEnvColor = iceAuraEnvColor_custom;
     } else {
         //Original colors are back there
-        Color_RGBA8 fireAuraPrimColor_custom = { 255, 255, 100, 255 };
-        Color_RGBA8 fireAuraEnvColor_custom = { 255, 50, 0, 0 };
-        Color_RGBA8 iceAuraPrimColor_custom = { 100, 200, 255, 255 };
-        Color_RGBA8 iceAuraEnvColor_custom = { 0, 0, 255, 0 };
+        Color_RGBA8 fireAuraPrimColor_custom = { fireAuraPrimColor_ori.r, fireAuraPrimColor_ori.g, fireAuraPrimColor_ori.b, 255 };
+        Color_RGBA8 fireAuraEnvColor_custom = { fireAuraEnvColor_ori.r, fireAuraEnvColor_ori.g, fireAuraEnvColor_ori.b, 0 };
+        Color_RGBA8 iceAuraPrimColor_custom = { iceAuraPrimColor_ori.r, iceAuraPrimColor_ori.g, iceAuraPrimColor_ori.b, 255 };
+        Color_RGBA8 iceAuraEnvColor_custom = { iceAuraEnvColor_ori.r, iceAuraEnvColor_ori.g, iceAuraEnvColor_ori.b, 0 };
         fireAuraPrimColor = fireAuraPrimColor_custom;
         fireAuraEnvColor = fireAuraEnvColor_custom;
         iceAuraPrimColor = iceAuraPrimColor_custom;

--- a/soh/src/overlays/actors/ovl_En_M_Thunder/z_en_m_thunder.c
+++ b/soh/src/overlays/actors/ovl_En_M_Thunder/z_en_m_thunder.c
@@ -341,7 +341,8 @@ void EnMThunder_Draw(Actor* thisx, GlobalContext* globalCtx2) {
     switch (this->unk_1C6) {
         case 0:
             if (CVar_GetS32("gUseChargedCol",0)) {
-                gDPSetPrimColor(POLY_XLU_DISP++, 0, 0x80, CVar_GetS32("gCharged2ColR",255), CVar_GetS32("gCharged2ColG",255), CVar_GetS32("gCharged2ColB",170), (u8)(this->unk_1B0 * 255));
+                Color_RGB8 SpinColor = {255, 255, 170};
+                gDPSetPrimColor(POLY_XLU_DISP++, 0, 0x80, CVar_GetRGB("gCharged2Col", SpinColor).r, CVar_GetRGB("gCharged2Col", SpinColor).g, CVar_GetRGB("gCharged2Col", SpinColor).b, (u8)(this->unk_1B0 * 255));
             } else {
                 gDPSetPrimColor(POLY_XLU_DISP++, 0, 0x80, 255, 255, 170, (u8)(this->unk_1B0 * 255));
             }
@@ -350,7 +351,8 @@ void EnMThunder_Draw(Actor* thisx, GlobalContext* globalCtx2) {
             break;
         case 1:
             if (CVar_GetS32("gUseChargedCol",0)) {
-                gDPSetPrimColor(POLY_XLU_DISP++, 0, 0x80, CVar_GetS32("gCharged1ColR",170), CVar_GetS32("gCharged1ColG",255), CVar_GetS32("gCharged1ColB",255), (u8)(this->unk_1B0 * 255));
+                Color_RGB8 SpinColor = {255, 255, 170};
+                gDPSetPrimColor(POLY_XLU_DISP++, 0, 0x80, CVar_GetRGB("gCharged1Col", SpinColor).r, CVar_GetRGB("gCharged1Col", SpinColor).g, CVar_GetRGB("gCharged1Col", SpinColor).b, (u8)(this->unk_1B0 * 255));
             } else {
                 gDPSetPrimColor(POLY_XLU_DISP++, 0, 0x80, 170, 255, 255, (u8)(this->unk_1B0 * 255));
             }
@@ -382,8 +384,10 @@ void EnMThunder_Draw(Actor* thisx, GlobalContext* globalCtx2) {
     if (this->unk_1B8 >= 0.85f) {
         phi_f14 = (D_80AA046C[(globalCtx->gameplayFrames & 7)] * 6.0f) + 1.0f;
         if (CVar_GetS32("gUseChargedCol",0)) {
-            gDPSetPrimColor(POLY_XLU_DISP++, 0, 0x80, CVar_GetS32("gCharged2ColR",255), CVar_GetS32("gCharged2ColG",255), CVar_GetS32("gCharged2ColB",170), this->unk_1C8);
-            gDPSetEnvColor(POLY_XLU_DISP++, CVar_GetS32("gCharged2ColEnvR",255), CVar_GetS32("gCharged2ColEnvG",100), CVar_GetS32("gCharged2ColEnvB",0), 128);
+            Color_RGB8 SpinColor1 = {255, 255, 170};
+            Color_RGB8 SpinColor2 = {255, 100, 0};
+            gDPSetPrimColor(POLY_XLU_DISP++, 0, 0x80, CVar_GetRGB("gCharged2Col", SpinColor1).r, CVar_GetRGB("gCharged2Col", SpinColor1).g, CVar_GetRGB("gCharged2Col", SpinColor1).b, this->unk_1C8);
+            gDPSetEnvColor(POLY_XLU_DISP++, CVar_GetRGB("gCharged2ColEnv", SpinColor2).r, CVar_GetRGB("gCharged2ColEnv", SpinColor2).g, CVar_GetRGB("gCharged2ColEnv", SpinColor2).b, 128);
         } else {
             gDPSetPrimColor(POLY_XLU_DISP++, 0, 0x80, 255, 255, 170, this->unk_1C8);
             gDPSetEnvColor(POLY_XLU_DISP++, 255, 100, 0, 128);
@@ -393,8 +397,10 @@ void EnMThunder_Draw(Actor* thisx, GlobalContext* globalCtx2) {
     } else {
         phi_f14 = (D_80AA046C[globalCtx->gameplayFrames & 7] * 2.0f) + 1.0f;
         if (CVar_GetS32("gUseChargedCol",0)) {
-            gDPSetPrimColor(POLY_XLU_DISP++, 0, 0x80, CVar_GetS32("gCharged1ColR",170), CVar_GetS32("gCharged1ColG",255), CVar_GetS32("gCharged1ColB",255), this->unk_1C8);
-            gDPSetEnvColor(POLY_XLU_DISP++, CVar_GetS32("gCharged1ColEnvR",0), CVar_GetS32("gCharged1ColEnvG",100), CVar_GetS32("gCharged1ColEnvB",255), 128);
+            Color_RGB8 SpinColor1 = {170, 255, 255};
+            Color_RGB8 SpinColor2 = {20, 100, 255};
+            gDPSetPrimColor(POLY_XLU_DISP++, 0, 0x80, CVar_GetRGB("gCharged1Col", SpinColor1).r, CVar_GetRGB("gCharged1Col", SpinColor1).g, CVar_GetRGB("gCharged1Col", SpinColor1).b, this->unk_1C8);
+            gDPSetEnvColor(POLY_XLU_DISP++, CVar_GetRGB("gCharged1ColEnv", SpinColor2).r, CVar_GetRGB("gCharged1ColEnv", SpinColor2).g, CVar_GetRGB("gCharged1ColEnv", SpinColor2).b, 128);
         } else {
             gDPSetPrimColor(POLY_XLU_DISP++, 0, 0x80, 170, 255, 255, this->unk_1C8);
             gDPSetEnvColor(POLY_XLU_DISP++, 0, 100, 255, 128);

--- a/soh/src/overlays/actors/ovl_En_Mag/z_en_mag.c
+++ b/soh/src/overlays/actors/ovl_En_Mag/z_en_mag.c
@@ -101,6 +101,8 @@ void EnMag_Init(Actor* thisx, GlobalContext* globalCtx) {
 #else
 void EnMag_Init(Actor* thisx, GlobalContext* globalCtx) {
     EnMag* this = (EnMag*)thisx;
+    Color_RGB8 Original_Prim = { 255, 255, 170 };
+    Color_RGB8 Original_Env = { 255, 100, 0 };
 
     YREG(1) = 63;
     YREG(3) = 80;
@@ -127,12 +129,21 @@ void EnMag_Init(Actor* thisx, GlobalContext* globalCtx) {
     this->effectScroll = 0;
     this->unk_E30C = 0;
 
-    this->effectPrimColor[0] = 0.0f;
-    this->effectPrimColor[1] = 100.0f;
-    this->effectPrimColor[2] = 170.0f;
-    this->effectEnvColor[0] = 0.0f;
-    this->effectEnvColor[1] = 100.0f;
-    this->effectEnvColor[2] = 0.0f;
+    if (CVar_GetS32("gHudColors",0) == 2 ){
+        this->effectPrimColor[0] = (float)CVar_GetRGB("gCCTCFirePrim", Original_Prim).r;
+        this->effectPrimColor[1] = (float)CVar_GetRGB("gCCTCFirePrim", Original_Prim).g;
+        this->effectPrimColor[2] = (float)CVar_GetRGB("gCCTCFirePrim", Original_Prim).b;
+        this->effectEnvColor[0] = (float)CVar_GetRGB("gCCTCFireEnv", Original_Env).r;
+        this->effectEnvColor[1] = (float)CVar_GetRGB("gCCTCFireEnv", Original_Env).g;
+        this->effectEnvColor[2] = (float)CVar_GetRGB("gCCTCFireEnv", Original_Env).b;
+    } else {
+        this->effectPrimColor[0] = 0.0f;
+        this->effectPrimColor[1] = 100.0f;
+        this->effectPrimColor[2] = 170.0f;
+        this->effectEnvColor[0] = 0.0f;
+        this->effectEnvColor[1] = 100.0f;
+        this->effectEnvColor[2] = 0.0f;
+    }
 
     this->effectFadeInTimer = 40;
 
@@ -147,11 +158,21 @@ void EnMag_Init(Actor* thisx, GlobalContext* globalCtx) {
         this->effectPrimLodFrac = 128.0f;
         this->effectAlpha = 255.0f;
 
-        this->effectPrimColor[0] = 255.0f;
-        this->effectPrimColor[1] = 255.0f;
-        this->effectPrimColor[2] = 170;
-        this->effectEnvColor[0] = 255.0f;
-        this->effectEnvColor[1] = 100;
+        if (CVar_GetS32("gHudColors",0) == 2 ){
+            this->effectPrimColor[0] = (float)CVar_GetRGB("gCCTCFirePrim", Original_Prim).r;
+            this->effectPrimColor[1] = (float)CVar_GetRGB("gCCTCFirePrim", Original_Prim).g;
+            this->effectPrimColor[2] = (float)CVar_GetRGB("gCCTCFirePrim", Original_Prim).b;
+            this->effectEnvColor[0] = (float)CVar_GetRGB("gCCTCFireEnv", Original_Env).r;
+            this->effectEnvColor[1] = (float)CVar_GetRGB("gCCTCFireEnv", Original_Env).g;
+            this->effectEnvColor[2] = (float)CVar_GetRGB("gCCTCFireEnv", Original_Env).b;
+        } else {
+            this->effectPrimColor[0] = (float)Original_Prim.r;
+            this->effectPrimColor[1] = (float)Original_Prim.g;
+            this->effectPrimColor[2] = (float)Original_Prim.b;
+            this->effectEnvColor[0] = (float)Original_Env.r;
+            this->effectEnvColor[1] = (float)Original_Env.g;
+            this->effectEnvColor[2] = (float)Original_Env.b;
+        }
 
         gSaveContext.unk_13E7 = 0;
         this->globalState = MAG_STATE_DISPLAY;
@@ -336,6 +357,8 @@ void EnMag_Update(Actor* thisx, GlobalContext* globalCtx) {
 void EnMag_Update(Actor* thisx, GlobalContext* globalCtx) {
     s32 pad[2];
     EnMag* this = (EnMag*)thisx;
+    Color_RGB8 Original_Prim = { 255, 255, 170 };
+    Color_RGB8 Original_Env = { 255, 100, 0 };
 
     if (gSaveContext.fileNum != 0xFEDC) {
         if (this->globalState < MAG_STATE_DISPLAY) {
@@ -352,11 +375,21 @@ void EnMag_Update(Actor* thisx, GlobalContext* globalCtx) {
                 this->effectPrimLodFrac = 128.0f;
                 this->effectAlpha = 255.0f;
 
-                this->effectPrimColor[0] = 255.0f;
-                this->effectPrimColor[1] = 255.0f;
-                this->effectPrimColor[2] = 170;
-                this->effectEnvColor[0] = 255.0f;
-                this->effectEnvColor[1] = 100;
+                if (CVar_GetS32("gHudColors",0) == 2 ){
+                    this->effectPrimColor[0] = (float)CVar_GetRGB("gCCTCFirePrim", Original_Prim).r;
+                    this->effectPrimColor[1] = (float)CVar_GetRGB("gCCTCFirePrim", Original_Prim).g;
+                    this->effectPrimColor[2] = (float)CVar_GetRGB("gCCTCFirePrim", Original_Prim).b;
+                    this->effectEnvColor[0] = (float)CVar_GetRGB("gCCTCFireEnv", Original_Env).r;
+                    this->effectEnvColor[1] = (float)CVar_GetRGB("gCCTCFireEnv", Original_Env).g;
+                    this->effectEnvColor[2] = (float)CVar_GetRGB("gCCTCFireEnv", Original_Env).b;
+                } else {
+                    this->effectPrimColor[0] = (float)Original_Prim.r;
+                    this->effectPrimColor[1] = (float)Original_Prim.g;
+                    this->effectPrimColor[2] = (float)Original_Prim.b;
+                    this->effectEnvColor[0] = (float)Original_Env.r;
+                    this->effectEnvColor[1] = (float)Original_Env.g;
+                    this->effectEnvColor[2] = (float)Original_Env.b;
+                }
 
                 this->globalState = MAG_STATE_DISPLAY;
                 sDelayTimer = 20;
@@ -395,11 +428,13 @@ void EnMag_Update(Actor* thisx, GlobalContext* globalCtx) {
             this->effectAlpha += 6.375f;
             this->effectPrimLodFrac += 0.8f;
 
-            this->effectPrimColor[0] += 6.375f;
-            this->effectPrimColor[1] += 3.875f;
-            this->effectPrimColor[2] += 2.125f;
-            this->effectEnvColor[0] += 6.375f;
-            this->effectEnvColor[1] += 3.875f;
+            if (CVar_GetS32("gHudColors",0) != 2 ){
+                this->effectPrimColor[0] += 6.375f;
+                this->effectPrimColor[1] += 3.875f;
+                this->effectPrimColor[2] += 2.125f;
+                this->effectEnvColor[0] += 6.375f;
+                this->effectEnvColor[1] += 3.875f;
+            }
 
             this->effectFadeInTimer--;
 
@@ -407,18 +442,22 @@ void EnMag_Update(Actor* thisx, GlobalContext* globalCtx) {
                 this->effectPrimLodFrac = 32.0f;
                 this->effectAlpha = 255.0f;
 
-                this->effectPrimColor[0] = 255.0f;
-                this->effectPrimColor[1] = 255.0f;
-                this->effectPrimColor[2] = 255.0f;
-                this->effectEnvColor[0] = 255.0f;
-                this->effectEnvColor[1] = 255.0f;
+                if (CVar_GetS32("gHudColors",0) != 2 ){
+                    this->effectPrimColor[0] = 255.0f;
+                    this->effectPrimColor[1] = 255.0f;
+                    this->effectPrimColor[2] = 255.0f;
+                    this->effectEnvColor[0] = 255.0f;
+                    this->effectEnvColor[1] = 255.0f;
+                }
 
                 this->effectFadeInTimer = 40;
                 this->effectFadeInState = 1;
             }
         } else if (this->effectFadeInState == 1) {
-            this->effectPrimColor[2] += -2.125f;
-            this->effectEnvColor[1] += -3.875f;
+            if (CVar_GetS32("gHudColors",0) != 2 ){
+                this->effectPrimColor[2] += -2.125f;
+                this->effectEnvColor[1] += -3.875f;
+            }
 
             this->effectPrimLodFrac += 2.4f;
 
@@ -427,8 +466,17 @@ void EnMag_Update(Actor* thisx, GlobalContext* globalCtx) {
             if (this->effectFadeInTimer == 0) {
                 this->effectPrimLodFrac = 128.0f;
 
-                this->effectPrimColor[2] = 170.0f;
-                this->effectEnvColor[1] = 100.0f;
+                if (CVar_GetS32("gHudColors",0) == 2 ){
+                    this->effectPrimColor[0] = (float)CVar_GetRGB("gCCTCFirePrim", Original_Prim).r;
+                    this->effectPrimColor[1] = (float)CVar_GetRGB("gCCTCFirePrim", Original_Prim).g;
+                    this->effectPrimColor[2] = (float)CVar_GetRGB("gCCTCFirePrim", Original_Prim).b;
+                    this->effectEnvColor[0] = (float)CVar_GetRGB("gCCTCFireEnv", Original_Env).r;
+                    this->effectEnvColor[1] = (float)CVar_GetRGB("gCCTCFireEnv", Original_Env).g;
+                    this->effectEnvColor[2] = (float)CVar_GetRGB("gCCTCFireEnv", Original_Env).b;
+                } else {
+                    this->effectPrimColor[2] = 170.0f;
+                    this->effectEnvColor[1] = 100.0f;
+                }
 
                 this->effectFadeInTimer = 32;
                 this->effectFadeInState = 2;

--- a/soh/src/overlays/actors/ovl_En_Ossan/z_en_ossan.c
+++ b/soh/src/overlays/actors/ovl_En_Ossan/z_en_ossan.c
@@ -1875,6 +1875,8 @@ void EnOssan_UpdateItemSelectedProperty(EnOssan* this) {
 }
 
 void EnOssan_UpdateCursorAnim(EnOssan* this) {
+    Color_RGB8 A_button_ori = {0,255,80};
+    Color_RGB8 A_button = CVar_GetRGB("gCCABtnPrim", A_button_ori);
     f32 t;
 
     t = this->cursorAnimTween;
@@ -1896,13 +1898,13 @@ void EnOssan_UpdateCursorAnim(EnOssan* this) {
         this->cursorColorG = ColChanMix(80, 80.0f, t);
         this->cursorColorB = ColChanMix(255, 0.0f, t);
     } else if (CVar_GetS32("gHudColors", 1) == 1) {
-        this->cursorColorR = ColChanMix(0, 0.0f, t);
-        this->cursorColorG = ColChanMix(255, 80.0f, t);
-        this->cursorColorB = ColChanMix(80, 0.0f, t);
+        this->cursorColorR = ColChanMix(A_button_ori.r, 0.0f, t);
+        this->cursorColorG = ColChanMix(A_button_ori.b, 80.0f, t);
+        this->cursorColorB = ColChanMix(A_button_ori.r, 0.0f, t);
     } else if (CVar_GetS32("gHudColors", 1) == 2) {
-        this->cursorColorR = ColChanMix(CVar_GetS32("gCCABtnPrimR", 90), ((CVar_GetS32("gCCABtnPrimR", 90)/255)*100), t);
-        this->cursorColorG = ColChanMix(CVar_GetS32("gCCABtnPrimG", 90), ((CVar_GetS32("gCCABtnPrimG", 90)/255)*100), t);
-        this->cursorColorB = ColChanMix(CVar_GetS32("gCCABtnPrimB", 90), ((CVar_GetS32("gCCABtnPrimB", 90)/255)*100), t);
+        this->cursorColorR = ColChanMix(A_button.r, ((A_button.r/255)*100), t);
+        this->cursorColorG = ColChanMix(A_button.g, ((A_button.g/255)*100), t);
+        this->cursorColorB = ColChanMix(A_button.b, ((A_button.b/255)*100), t);
     }
     this->cursorColorA = ColChanMix(255, 0.0f, t);
     this->cursorAnimTween = t;

--- a/soh/src/overlays/actors/ovl_Magic_Dark/z_magic_dark.c
+++ b/soh/src/overlays/actors/ovl_Magic_Dark/z_magic_dark.c
@@ -198,6 +198,10 @@ void MagicDark_DiamondDraw(Actor* thisx, GlobalContext* globalCtx) {
     MagicDark* this = (MagicDark*)thisx;
     s32 pad;
     u16 gameplayFrames = globalCtx->gameplayFrames;
+    Color_RGB8 Spell_env_ori = {0, 100, 255};
+    Color_RGB8 Spell_col_ori = {170, 255, 255};
+    Color_RGB8 Spell_env = CVar_GetRGB("gNL_Diamond_Env", Spell_env_ori);
+    Color_RGB8 Spell_col = CVar_GetRGB("gNL_Diamond_Col", Spell_col_ori);
 
     OPEN_DISPS(globalCtx->state.gfxCtx);
 
@@ -221,8 +225,8 @@ void MagicDark_DiamondDraw(Actor* thisx, GlobalContext* globalCtx) {
         gSPMatrix(POLY_XLU_DISP++, MATRIX_NEWMTX(globalCtx->state.gfxCtx),
                   G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
         if (CVar_GetS32("gUseSpellsCol",0)) {
-            gDPSetPrimColor(POLY_XLU_DISP++, 0, 0x80, CVar_GetS32("gNL_Diamond_ColR",170), CVar_GetS32("gNL_Diamond_ColG",255), CVar_GetS32("gNL_Diamond_ColB",255), (s32)(this->primAlpha * 0.6f) & 0xFF);
-            gDPSetEnvColor(POLY_XLU_DISP++, CVar_GetS32("gNL_Diamond_EnvR",100), CVar_GetS32("gNL_Diamond_EnvG",100), CVar_GetS32("gNL_Diamond_EnvB",255), 128);
+            gDPSetPrimColor(POLY_XLU_DISP++, 0, 0x80, Spell_col.r, Spell_col.g, Spell_col.b, (s32)(this->primAlpha * 0.6f) & 0xFF);
+            gDPSetEnvColor(POLY_XLU_DISP++, Spell_env.r, Spell_env.g, Spell_env.b, 128);
         } else {
             gDPSetPrimColor(POLY_XLU_DISP++, 0, 0, 170, 255, 255, (s32)(this->primAlpha * 0.6f) & 0xFF);
             gDPSetEnvColor(POLY_XLU_DISP++, 0, 100, 255, 128);

--- a/soh/src/overlays/actors/ovl_Magic_Fire/z_magic_fire.c
+++ b/soh/src/overlays/actors/ovl_Magic_Fire/z_magic_fire.c
@@ -216,7 +216,11 @@ void MagicFire_Draw(Actor* thisx, GlobalContext* globalCtx) {
     s32 pad2;
     s32 i;
     u8 alpha;
-    
+    Color_RGB8 Spell_env_ori = {255, 0, 0};
+    Color_RGB8 Spell_col_ori = {255, 200, 0};
+    Color_RGB8 Spell_env = CVar_GetRGB("gDF_Env", Spell_env_ori);
+    Color_RGB8 Spell_col = CVar_GetRGB("gDF_Col", Spell_col_ori);
+
     if (this->action > 0) {
         OPEN_DISPS(globalCtx->state.gfxCtx);
         POLY_XLU_DISP = func_800937C0(POLY_XLU_DISP);
@@ -228,11 +232,11 @@ void MagicFire_Draw(Actor* thisx, GlobalContext* globalCtx) {
         gDPFillRectangle(POLY_XLU_DISP++, 0, 0, 319, 239);
         func_80093D84(globalCtx->state.gfxCtx);
         if (CVar_GetS32("gUseSpellsCol",0)) {
-            gDPSetPrimColor(POLY_XLU_DISP++, 0, 0x80, CVar_GetS32("gDF_ColR",255), CVar_GetS32("gDF_ColG",200), CVar_GetS32("gDF_ColB",0), (u8)(this->alphaMultiplier * 255));
-            gDPSetEnvColor(POLY_XLU_DISP++, CVar_GetS32("gDF_EnvR",255), CVar_GetS32("gDF_EnvG",0), CVar_GetS32("gDF_EnvB",0), (u8)(this->alphaMultiplier * 255));
+            gDPSetPrimColor(POLY_XLU_DISP++, 0, 0x80, Spell_col.r, Spell_col.g, Spell_col.b, (u8)(this->alphaMultiplier * 255));
+            gDPSetEnvColor(POLY_XLU_DISP++, Spell_env.r, Spell_env.g, Spell_env.b, (u8)(this->alphaMultiplier * 255));
         } else {
-            gDPSetPrimColor(POLY_XLU_DISP++, 0, 128, 255, 200, 0, (u8)(this->alphaMultiplier * 255));
-            gDPSetEnvColor(POLY_XLU_DISP++, 255, 0, 0, (u8)(this->alphaMultiplier * 255));
+            gDPSetPrimColor(POLY_XLU_DISP++, 0, 0x80, Spell_col_ori.r, Spell_col_ori.g, Spell_col_ori.b, (u8)(this->alphaMultiplier * 255));
+            gDPSetEnvColor(POLY_XLU_DISP++, Spell_env_ori.r, Spell_env_ori.g, Spell_env_ori.b, (u8)(this->alphaMultiplier * 255));
         }
         Matrix_Scale(0.15f, 0.15f, 0.15f, MTXMODE_APPLY);
         gSPMatrix(POLY_XLU_DISP++, MATRIX_NEWMTX(globalCtx->state.gfxCtx),

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -10531,6 +10531,7 @@ void func_80848EF8(Player* this, GlobalContext* globalCtx) {
 
         /*Prevent it on horse, while jumping and on title screen.
         If you fly around no stone of agony for you! */
+        Color_RGB8 StoneOfAgony_ori = { 255, 255, 255 };
         if (CVar_GetS32("gVisualAgony", 0) !=0 && !this->stateFlags1) {
             s16 Top_Margins = (CVar_GetS32("gHUDMargin_T", 0)*-1);
             s16 Left_Margins = CVar_GetS32("gHUDMargin_L", 0);
@@ -10576,30 +10577,34 @@ void func_80848EF8(Player* this, GlobalContext* globalCtx) {
             gDPPipeSync(OVERLAY_DISP++);
 
             if (CVar_GetS32("gHudColors", 1) == 2) {
-                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetS32("gCCVSOAPrimR", 255), CVar_GetS32("gCCVSOAPrimG", 255), CVar_GetS32("gCCVSOAPrimB", 255), DefaultIconA);
+                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetRGB("gCCVSOAPrim", StoneOfAgony_ori).r,CVar_GetRGB("gCCVSOAPrim", StoneOfAgony_ori).g,CVar_GetRGB("gCCVSOAPrim", StoneOfAgony_ori).b, DefaultIconA);
             } else {
-                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 255, 255, DefaultIconA);
+                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, StoneOfAgony_ori.r, StoneOfAgony_ori.g, StoneOfAgony_ori.b, DefaultIconA);
             }
 
             gDPSetCombineLERP(OVERLAY_DISP++, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0);
             if (this->unk_6A0 > 4000000.0f) {
                 if (CVar_GetS32("gHudColors", 1) == 2) {
-                    gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetS32("gCCVSOAPrimR", 255), CVar_GetS32("gCCVSOAPrimG", 255), CVar_GetS32("gCCVSOAPrimB", 255), 255);
+                    gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetRGB("gCCVSOAPrim", StoneOfAgony_ori).r,CVar_GetRGB("gCCVSOAPrim", StoneOfAgony_ori).g,CVar_GetRGB("gCCVSOAPrim", StoneOfAgony_ori).b, 255);
                 } else {
-                    gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 255, 255, 255);
+                    gDPSetPrimColor(OVERLAY_DISP++, 0, 0, StoneOfAgony_ori.r, StoneOfAgony_ori.g, StoneOfAgony_ori.b, 255);
                 }
             } else {
                 if (CVar_GetS32("gHudColors", 1) == 2) {
-                    gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetS32("gCCVSOAPrimR", 255), CVar_GetS32("gCCVSOAPrimG", 255), CVar_GetS32("gCCVSOAPrimB", 255), DefaultIconA);
+                    gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetRGB("gCCVSOAPrim", StoneOfAgony_ori).r,CVar_GetRGB("gCCVSOAPrim", StoneOfAgony_ori).g,CVar_GetRGB("gCCVSOAPrim", StoneOfAgony_ori).b, DefaultIconA);
                 } else {
-                    gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 255, 255, DefaultIconA);
+                    gDPSetPrimColor(OVERLAY_DISP++, 0, 0, StoneOfAgony_ori.r, StoneOfAgony_ori.g, StoneOfAgony_ori.b, DefaultIconA);
                 }
             }
             if (temp == 0 || temp <= 0.1f) {
-               /*Fail check, it is used to draw off the icon when
-               link is standing out range but do not refresh unk_6A0.
-               Also used to make a default value in my case.*/
-               gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 255, 255, DefaultIconA);
+                /*Fail check, it is used to draw off the icon when
+                link is standing out range but do not refresh unk_6A0.
+                Also used to make a default value in my case.*/
+                if (CVar_GetS32("gHudColors", 1) == 2) {
+                    gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetRGB("gCCVSOAPrim", StoneOfAgony_ori).r,CVar_GetRGB("gCCVSOAPrim", StoneOfAgony_ori).g,CVar_GetRGB("gCCVSOAPrim", StoneOfAgony_ori).b, DefaultIconA);
+                } else {
+                    gDPSetPrimColor(OVERLAY_DISP++, 0, 0, StoneOfAgony_ori.r, StoneOfAgony_ori.g, StoneOfAgony_ori.b, DefaultIconA);
+                }
             }
             gDPSetEnvColor(OVERLAY_DISP++, 0, 0, 0, 255);
             gDPSetOtherMode(OVERLAY_DISP++, G_AD_DISABLE | G_CD_DISABLE | G_CK_NONE | G_TC_FILT | G_TF_POINT | G_TT_IA16 | G_TL_TILE | G_TD_CLAMP | G_TP_NONE | G_CYC_1CYCLE | G_PM_NPRIMITIVE, G_AC_NONE | G_ZS_PRIM | G_RM_XLU_SURF | G_RM_XLU_SURF2);

--- a/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -1155,6 +1155,7 @@ void FileChoose_DrawWindowContents(GameState* thisx) {
     s16 quadVtxIndex;
     s16 isActive;
     s16 pad;
+    Color_RGB8 Background_Color = { this->windowColor[0], this->windowColor[1], this->windowColor[2] };
 
     OPEN_DISPS(this->state.gfxCtx);
 
@@ -1187,11 +1188,9 @@ void FileChoose_DrawWindowContents(GameState* thisx) {
         gDPPipeSync(POLY_OPA_DISP++);
 
         if (CVar_GetS32("gHudColors", 1) == 2) {
-        gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, CVar_GetS32("gCCFileChoosePrimR", 100), CVar_GetS32("gCCFileChoosePrimG", 150),
-                            CVar_GetS32("gCCFileChoosePrimB", 255), this->fileInfoAlpha[fileIndex]);
+            gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, CVar_GetRGB("gCCFileChoosePrim", Background_Color).r, CVar_GetRGB("gCCFileChoosePrim", Background_Color).g, CVar_GetRGB("gCCFileChoosePrim", Background_Color).b, this->fileInfoAlpha[fileIndex]);
         } else {
-        gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, this->windowColor[0], this->windowColor[1], this->windowColor[2],
-                        this->fileInfoAlpha[fileIndex]);
+            gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, Background_Color.r, Background_Color.g, Background_Color.b, this->fileInfoAlpha[fileIndex]);
         }
         gSPVertex(POLY_OPA_DISP++, &this->windowContentVtx[temp], 20, 0);
 
@@ -1210,8 +1209,7 @@ void FileChoose_DrawWindowContents(GameState* thisx) {
         isActive = 0;
 
         if (CVar_GetS32("gHudColors", 1) == 2) {
-            gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, CVar_GetS32("gCCFileChoosePrimR", 100), CVar_GetS32("gCCFileChoosePrimG", 150),
-                            CVar_GetS32("gCCFileChoosePrimB", 255), this->fileButtonAlpha[i]);
+            gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, CVar_GetRGB("gCCFileChoosePrim", Background_Color).r, CVar_GetRGB("gCCFileChoosePrim", Background_Color).g, CVar_GetRGB("gCCFileChoosePrim", Background_Color).b, this->fileButtonAlpha[i]);
         } else {
             gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, sWindowContentColors[isActive][0], sWindowContentColors[isActive][1],
                             sWindowContentColors[isActive][2], this->fileButtonAlpha[i]);
@@ -1224,8 +1222,7 @@ void FileChoose_DrawWindowContents(GameState* thisx) {
 
         // draw file name box
         if (CVar_GetS32("gHudColors", 1) == 2) {
-            gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, CVar_GetS32("gCCFileChoosePrimR", 100), CVar_GetS32("gCCFileChoosePrimG", 150),
-                            CVar_GetS32("gCCFileChoosePrimB", 255), this->nameBoxAlpha[i]);
+            gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, CVar_GetRGB("gCCFileChoosePrim", Background_Color).r, CVar_GetRGB("gCCFileChoosePrim", Background_Color).g, CVar_GetRGB("gCCFileChoosePrim", Background_Color).b, this->nameBoxAlpha[i]);
         } else {
             gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, sWindowContentColors[isActive][0], sWindowContentColors[isActive][1],
                             sWindowContentColors[isActive][2], this->nameBoxAlpha[i]);
@@ -1239,9 +1236,7 @@ void FileChoose_DrawWindowContents(GameState* thisx) {
         // draw disk label for 64DD
         if (Save_GetSaveMetaInfo(i)->randoSave) {
             if (CVar_GetS32("gHudColors", 1) == 2) {
-                gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, CVar_GetS32("gCCFileChoosePrimR", 100),
-                                CVar_GetS32("gCCFileChoosePrimG", 150), CVar_GetS32("gCCFileChoosePrimB", 255),
-                                this->nameAlpha[i]);
+                gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, CVar_GetRGB("gCCFileChoosePrim", Background_Color).r, CVar_GetRGB("gCCFileChoosePrim", Background_Color).g, CVar_GetRGB("gCCFileChoosePrim", Background_Color).b, this->nameAlpha[i]);
             } else {
                 gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, sWindowContentColors[isActive][0],
                                 sWindowContentColors[isActive][1], sWindowContentColors[isActive][2],
@@ -1255,9 +1250,7 @@ void FileChoose_DrawWindowContents(GameState* thisx) {
 
         // draw connectors
         if (CVar_GetS32("gHudColors", 1) == 2) {
-            gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, CVar_GetS32("gCCFileChoosePrimR", 100),
-                            CVar_GetS32("gCCFileChoosePrimG", 150), CVar_GetS32("gCCFileChoosePrimB", 255),
-                            this->connectorAlpha[i]);
+            gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, CVar_GetRGB("gCCFileChoosePrim", Background_Color).r, CVar_GetRGB("gCCFileChoosePrim", Background_Color).g, CVar_GetRGB("gCCFileChoosePrim", Background_Color).b, this->connectorAlpha[i]);
         } else {
             gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, sWindowContentColors[isActive][0], sWindowContentColors[isActive][1],
                             sWindowContentColors[isActive][2], this->connectorAlpha[i]);
@@ -1289,8 +1282,7 @@ void FileChoose_DrawWindowContents(GameState* thisx) {
         gDPPipeSync(POLY_OPA_DISP++);
 
         if (CVar_GetS32("gHudColors", 1) == 2) {
-            gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, CVar_GetS32("gCCFileChoosePrimR", 100), CVar_GetS32("gCCFileChoosePrimG", 150),
-                            CVar_GetS32("gCCFileChoosePrimB", 255), this->actionButtonAlpha[i]);
+            gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, CVar_GetRGB("gCCFileChoosePrim", Background_Color).r, CVar_GetRGB("gCCFileChoosePrim", Background_Color).g, CVar_GetRGB("gCCFileChoosePrim", Background_Color).b, this->actionButtonAlpha[i]);
         } else {
             gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, this->windowColor[0], this->windowColor[1], this->windowColor[2],
                             this->actionButtonAlpha[i]);
@@ -1308,8 +1300,7 @@ void FileChoose_DrawWindowContents(GameState* thisx) {
         temp = this->confirmButtonTexIndices[i];
 
         if (CVar_GetS32("gHudColors", 1) == 2) {
-            gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, CVar_GetS32("gCCFileChoosePrimR", 100), CVar_GetS32("gCCFileChoosePrimG", 150),
-                            CVar_GetS32("gCCFileChoosePrimB", 255), this->confirmButtonAlpha[i]);
+            gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, CVar_GetRGB("gCCFileChoosePrim", Background_Color).r, CVar_GetRGB("gCCFileChoosePrim", Background_Color).g, CVar_GetRGB("gCCFileChoosePrim", Background_Color).b, this->confirmButtonAlpha[i]);
         } else {
             gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, this->windowColor[0], this->windowColor[1], this->windowColor[2],
                             this->confirmButtonAlpha[i]);
@@ -1324,8 +1315,7 @@ void FileChoose_DrawWindowContents(GameState* thisx) {
     gDPPipeSync(POLY_OPA_DISP++);
 
     if (CVar_GetS32("gHudColors", 1) == 2) {
-        gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, CVar_GetS32("gCCFileChoosePrimR", 100), CVar_GetS32("gCCFileChoosePrimG", 150),
-                        CVar_GetS32("gCCFileChoosePrimB", 255), this->optionButtonAlpha);
+        gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, CVar_GetRGB("gCCFileChoosePrim", Background_Color).r, CVar_GetRGB("gCCFileChoosePrim", Background_Color).g, CVar_GetRGB("gCCFileChoosePrim", Background_Color).b, this->optionButtonAlpha);
     } else {
         gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, this->windowColor[0], this->windowColor[1], this->windowColor[2],
                         this->optionButtonAlpha);
@@ -1346,9 +1336,7 @@ void FileChoose_DrawWindowContents(GameState* thisx) {
                           PRIMITIVE, 0);
 
         if (CVar_GetS32("gHudColors", 1) == 2) {
-            gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, CVar_GetS32("gCCFileChoosePrimR", 155),
-                            CVar_GetS32("gCCFileChoosePrimG", 255), CVar_GetS32("gCCFileChoosePrimB", 255),
-                            this->highlightColor[3]);
+            gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, CVar_GetRGB("gCCFileChoosePrim", Background_Color).r, CVar_GetRGB("gCCFileChoosePrim", Background_Color).g, CVar_GetRGB("gCCFileChoosePrim", Background_Color).b, this->highlightColor[3]);
         } else {
             gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, this->highlightColor[0], this->highlightColor[1],
                             this->highlightColor[2], this->highlightColor[3]);
@@ -1383,6 +1371,7 @@ void FileChoose_ConfigModeDraw(GameState* thisx) {
     f32 eyeX;
     f32 eyeY;
     f32 eyeZ;
+    Color_RGB8 Background_Color = {this->windowColor[0], this->windowColor[1], this->windowColor[2]};
 
     OPEN_DISPS(this->state.gfxCtx);
     gDPPipeSync(POLY_OPA_DISP++);
@@ -1409,8 +1398,7 @@ void FileChoose_ConfigModeDraw(GameState* thisx) {
         gDPSetCombineMode(POLY_OPA_DISP++, G_CC_MODULATEIA_PRIM, G_CC_MODULATEIA_PRIM);
 
         if (CVar_GetS32("gHudColors", 1) == 2) {
-            gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, CVar_GetS32("gCCFileChoosePrimR", 100), CVar_GetS32("gCCFileChoosePrimG", 150),
-                            CVar_GetS32("gCCFileChoosePrimB", 255), this->windowAlpha);
+            gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, CVar_GetRGB("gCCFileChoosePrim", Background_Color).r, CVar_GetRGB("gCCFileChoosePrim", Background_Color).g, CVar_GetRGB("gCCFileChoosePrim", Background_Color).b, this->windowAlpha);
         } else {
             gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, this->windowColor[0], this->windowColor[1], this->windowColor[2],
                             this->windowAlpha);
@@ -1447,8 +1435,7 @@ void FileChoose_ConfigModeDraw(GameState* thisx) {
         gDPSetCombineMode(POLY_OPA_DISP++, G_CC_MODULATEIA_PRIM, G_CC_MODULATEIA_PRIM);
 
         if (CVar_GetS32("gHudColors", 1) == 2) {
-            gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, CVar_GetS32("gCCFileChoosePrimR", 100), CVar_GetS32("gCCFileChoosePrimG", 150),
-                            CVar_GetS32("gCCFileChoosePrimB", 255), this->windowAlpha);
+            gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, CVar_GetRGB("gCCFileChoosePrim", Background_Color).r, CVar_GetRGB("gCCFileChoosePrim", Background_Color).g, CVar_GetRGB("gCCFileChoosePrim", Background_Color).b, this->windowAlpha);
         } else {
             gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, this->windowColor[0], this->windowColor[1], this->windowColor[2],
                             this->windowAlpha);
@@ -1481,8 +1468,7 @@ void FileChoose_ConfigModeDraw(GameState* thisx) {
         gDPSetCombineMode(POLY_OPA_DISP++, G_CC_MODULATEIA_PRIM, G_CC_MODULATEIA_PRIM);
 
         if (CVar_GetS32("gHudColors", 1) == 2) {
-            gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, CVar_GetS32("gCCFileChoosePrimR", 100), CVar_GetS32("gCCFileChoosePrimG", 150),
-                            CVar_GetS32("gCCFileChoosePrimB", 255), this->windowAlpha);
+            gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, CVar_GetRGB("gCCFileChoosePrim", Background_Color).r, CVar_GetRGB("gCCFileChoosePrim", Background_Color).g, CVar_GetRGB("gCCFileChoosePrim", Background_Color).b, this->windowAlpha);
         } else {
             gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, this->windowColor[0], this->windowColor[1], this->windowColor[2],
                             this->windowAlpha);
@@ -1819,6 +1805,7 @@ void FileChoose_SelectModeDraw(GameState* thisx) {
     f32 eyeX;
     f32 eyeY;
     f32 eyeZ;
+    Color_RGB8 Background_Color = { this->windowColor[0], this->windowColor[1], this->windowColor[2] };
 
     OPEN_DISPS(this->state.gfxCtx);
 
@@ -1842,8 +1829,7 @@ void FileChoose_SelectModeDraw(GameState* thisx) {
     gDPSetCombineMode(POLY_OPA_DISP++, G_CC_MODULATEIA_PRIM, G_CC_MODULATEIA_PRIM);
 
     if (CVar_GetS32("gHudColors", 1) == 2) {
-        gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, CVar_GetS32("gCCFileChoosePrimR", 100), CVar_GetS32("gCCFileChoosePrimG", 150),
-                        CVar_GetS32("gCCFileChoosePrimB", 255), this->windowAlpha);
+        gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, CVar_GetRGB("gCCFileChoosePrim", Background_Color).r, CVar_GetRGB("gCCFileChoosePrim", Background_Color).g, CVar_GetRGB("gCCFileChoosePrim", Background_Color).b, this->windowAlpha);
     } else {
         gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, this->windowColor[0], this->windowColor[1], this->windowColor[2],
                         this->windowAlpha);
@@ -1892,6 +1878,7 @@ void FileChoose_Main(GameState* thisx) {
         gFileSelControlsGERTex,
         gFileSelControlsFRATex,
     };
+    Color_RGB8 Text_Color = { 100, 255, 255 };
     FileChooseContext* this = (FileChooseContext*)thisx;
     Input* input = &this->state.input[0];
 
@@ -2028,11 +2015,9 @@ void FileChoose_Main(GameState* thisx) {
                           PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0);
 
         if (CVar_GetS32("gHudColors", 1) == 2) {
-            gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, CVar_GetS32("gCCFileChooseTextPrimR", 100),
-                            CVar_GetS32("gCCFileChooseTextPrimG", 255), CVar_GetS32("gCCFileChooseTextPrimB", 255),
-                            this->controlsAlpha);
+            gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, CVar_GetRGB("gCCFileChooseTextPrim", Text_Color).r, CVar_GetRGB("gCCFileChooseTextPrim", Text_Color).g, CVar_GetRGB("gCCFileChooseTextPrim", Text_Color).b, this->controlsAlpha);
         } else {
-            gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 100, 255, 255, this->controlsAlpha);
+            gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, Text_Color.r, Text_Color.g, Text_Color.b, this->controlsAlpha);
         }
         gDPSetEnvColor(POLY_OPA_DISP++, 0, 0, 0, 0);
         gDPLoadTextureBlock(POLY_OPA_DISP++, controlsTextures[gSaveContext.language], G_IM_FMT_IA, G_IM_SIZ_8b, 144, 16,

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_collect.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_collect.c
@@ -5,6 +5,14 @@
 extern const char* digitTextures[];
 
 void KaleidoScope_DrawQuestStatus(GlobalContext* globalCtx, GraphicsContext* gfxCtx) {
+    Color_RGB8 A_button_ori = {80, 255, 150};
+    Color_RGB8 A_button = CVar_GetRGB("gCCABtnPrim", A_button_ori);
+    Color_RGB8 C_button_ori = {255, 255, 50};
+    Color_RGB8 C_button_uni = CVar_GetRGB("gCCCBtnPrim", C_button_ori);
+    Color_RGB8 C_button_U = CVar_GetRGB("gCCCUBtnPrim", C_button_ori);
+    Color_RGB8 C_button_D = CVar_GetRGB("gCCCDBtnPrim", C_button_ori);
+    Color_RGB8 C_button_L = CVar_GetRGB("gCCCLBtnPrim", C_button_ori);
+    Color_RGB8 C_button_R = CVar_GetRGB("gCCCRBtnPrim", C_button_ori);
     static s16 D_8082A070[][4] = {
         { 255, 0, 0, 255 },
         { 255, 70, 0, 150 },
@@ -493,29 +501,30 @@ void KaleidoScope_DrawQuestStatus(GlobalContext* globalCtx, GraphicsContext* gfx
 
                     gDPPipeSync(POLY_KAL_DISP++);
 
+                    s16 Notes_alpha = D_8082A150[sp218];
                     if (D_8082A124[sp218] == 0) {
                         if (CVar_GetS32("gHudColors", 1) == 0) { // A Button notes
-                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 80, 150, 255, D_8082A150[sp218]);
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 80, 150, 255, Notes_alpha);
                         } else if (CVar_GetS32("gHudColors", 1) == 1) {
-                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 80, 255, 150, D_8082A150[sp218]);
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, A_button_ori.r, A_button_ori.g, A_button_ori.b, Notes_alpha);
                         } else if (CVar_GetS32("gHudColors", 1) == 2) {
-                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, CVar_GetS32("gCCABtnPrimR", 80), CVar_GetS32("gCCABtnPrimG", 255), CVar_GetS32("gCCABtnPrimB", 150), D_8082A150[sp218]);
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, A_button.r, A_button.g, A_button.b, Notes_alpha);
                         }
                     } else {
                         if (CVar_GetS32("gHudColors", 1) == 0) { // C Buttons notes
-                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 255, 255, 50, D_8082A150[sp218]);
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, C_button_ori.r, C_button_ori.g, C_button_ori.b, Notes_alpha);
                         } else if (CVar_GetS32("gHudColors", 1) == 1) {
-                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 255, 255, 50, D_8082A150[sp218]);
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, C_button_ori.r, C_button_ori.g, C_button_ori.b, Notes_alpha);
                         } else if (CVar_GetS32("gHudColors", 1) == 2 && !CVar_GetS32("gCCparated", 0)) {
-                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, CVar_GetS32("gCCCBtnPrimR", 255), CVar_GetS32("gCCCBtnPrimG", 160), CVar_GetS32("gCCCBtnPrimB", 0), D_8082A150[sp218]);
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, C_button_uni.r, C_button_uni.g, C_button_uni.b, Notes_alpha);
                         } else if (D_8082A124[sp218] == OCARINA_NOTE_D5 && CVar_GetS32("gHudColors", 1) == 2 && CVar_GetS32("gCCparated", 0)) {
-                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, CVar_GetS32("gCCCUBtnPrimR", 255), CVar_GetS32("gCCCUBtnPrimG", 160), CVar_GetS32("gCCCUBtnPrimB", 0), D_8082A150[sp218]);
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, C_button_U.r, C_button_U.g, C_button_U.b, Notes_alpha);
                         } else if (D_8082A124[sp218] == OCARINA_NOTE_B4 && CVar_GetS32("gHudColors", 1) == 2 && CVar_GetS32("gCCparated", 0)) {
-                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, CVar_GetS32("gCCCLBtnPrimR", 255), CVar_GetS32("gCCCLBtnPrimG", 160), CVar_GetS32("gCCCLBtnPrimB", 0), D_8082A150[sp218]);
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, C_button_L.r, C_button_L.g, C_button_L.b, Notes_alpha);
                         } else if (D_8082A124[sp218] == OCARINA_NOTE_A4 && CVar_GetS32("gHudColors", 1) == 2 && CVar_GetS32("gCCparated", 0)) {
-                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, CVar_GetS32("gCCCRBtnPrimR", 255), CVar_GetS32("gCCCRBtnPrimG", 160), CVar_GetS32("gCCCRBtnPrimB", 0), D_8082A150[sp218]);
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, C_button_R.r, C_button_R.g, C_button_R.b, Notes_alpha);
                         } else if (D_8082A124[sp218] == OCARINA_NOTE_F4 && CVar_GetS32("gHudColors", 1) == 2 && CVar_GetS32("gCCparated", 0)) {
-                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, CVar_GetS32("gCCCDBtnPrimR", 255), CVar_GetS32("gCCCDBtnPrimG", 160), CVar_GetS32("gCCCDBtnPrimB", 0), D_8082A150[sp218]);
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, C_button_D.r, C_button_D.g, C_button_D.b, Notes_alpha);
                         }
                     }
 
@@ -543,29 +552,30 @@ void KaleidoScope_DrawQuestStatus(GlobalContext* globalCtx, GraphicsContext* gfx
                 gDPPipeSync(POLY_KAL_DISP++);
 
                 if (pauseCtx->unk_1E4 == 8) {
+                    s16 Notes_alpha = 200;
                     if (gOcarinaSongNotes[sp224].notesIdx[phi_s3] == 0) {
-                        if (CVar_GetS32("gHudColors", 1) == 0) {
-                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 80, 150, 255, 200);
+                        if (CVar_GetS32("gHudColors", 1) == 0) { // A Button notes
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 80, 150, 255, Notes_alpha);
                         } else if (CVar_GetS32("gHudColors", 1) == 1) {
-                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 80, 255, 150, 200);
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, A_button_ori.r, A_button_ori.g, A_button_ori.b, Notes_alpha);
                         } else if (CVar_GetS32("gHudColors", 1) == 2) {
-                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, CVar_GetS32("gCCABtnPrimR", 80), CVar_GetS32("gCCABtnPrimG", 255), CVar_GetS32("gCCABtnPrimB", 150), 200);
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, A_button.r, A_button.g, A_button.b, Notes_alpha);
                         }
                     } else {
-                        if (CVar_GetS32("gHudColors", 1) == 0) {
-                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 255, 255, 50, 200);
+                        if (CVar_GetS32("gHudColors", 1) == 0) { // C Buttons notes
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, C_button_ori.r, C_button_ori.g, C_button_ori.b, Notes_alpha);
                         } else if (CVar_GetS32("gHudColors", 1) == 1) {
-                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 255, 255, 50, 200);
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, C_button_ori.r, C_button_ori.g, C_button_ori.b, Notes_alpha);
                         } else if (CVar_GetS32("gHudColors", 1) == 2 && !CVar_GetS32("gCCparated", 0)) {
-                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, CVar_GetS32("gCCCBtnPrimR", 255), CVar_GetS32("gCCCBtnPrimG", 160), CVar_GetS32("gCCCBtnPrimB", 0), 200);
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, C_button_uni.r, C_button_uni.g, C_button_uni.b, Notes_alpha);
                         } else if (gOcarinaSongNotes[sp224].notesIdx[phi_s3] == OCARINA_NOTE_D5 && CVar_GetS32("gHudColors", 1) == 2 && CVar_GetS32("gCCparated", 0)) {
-                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, CVar_GetS32("gCCCUBtnPrimR", 255), CVar_GetS32("gCCCUBtnPrimG", 160), CVar_GetS32("gCCCUBtnPrimB", 0), 200);
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, C_button_U.r, C_button_U.g, C_button_U.b, Notes_alpha);
                         } else if (gOcarinaSongNotes[sp224].notesIdx[phi_s3] == OCARINA_NOTE_B4 && CVar_GetS32("gHudColors", 1) == 2 && CVar_GetS32("gCCparated", 0)) {
-                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, CVar_GetS32("gCCCLBtnPrimR", 255), CVar_GetS32("gCCCLBtnPrimG", 160), CVar_GetS32("gCCCLBtnPrimB", 0), 200);
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, C_button_L.r, C_button_L.g, C_button_L.b, Notes_alpha);
                         } else if (gOcarinaSongNotes[sp224].notesIdx[phi_s3] == OCARINA_NOTE_A4 && CVar_GetS32("gHudColors", 1) == 2 && CVar_GetS32("gCCparated", 0)) {
-                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, CVar_GetS32("gCCCRBtnPrimR", 255), CVar_GetS32("gCCCRBtnPrimG", 160), CVar_GetS32("gCCCRBtnPrimB", 0), 200);
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, C_button_R.r, C_button_R.g, C_button_R.b, Notes_alpha);
                         } else if (gOcarinaSongNotes[sp224].notesIdx[phi_s3] == OCARINA_NOTE_F4 && CVar_GetS32("gHudColors", 1) == 2 && CVar_GetS32("gCCparated", 0)) {
-                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, CVar_GetS32("gCCCDBtnPrimR", 255), CVar_GetS32("gCCCDBtnPrimG", 160), CVar_GetS32("gCCCDBtnPrimB", 0), 200);
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, C_button_D.r, C_button_D.g, C_button_D.b, Notes_alpha);
                         }
                     }
                 } else {
@@ -618,27 +628,28 @@ void KaleidoScope_DrawQuestStatus(GlobalContext* globalCtx, GraphicsContext* gfx
 
                     gDPPipeSync(POLY_KAL_DISP++);
 
+                    s16 Notes_alpha = D_8082A150[phi_s3];
                     if (D_8082A124[phi_s3] == 0) {
-                        if (CVar_GetS32("gHudColors", 1) == 0) {
-                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 80, 150, 255, 200);
+                        if (CVar_GetS32("gHudColors", 1) == 0) { // A Button notes
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 80, 150, 255, Notes_alpha);
                         } else if (CVar_GetS32("gHudColors", 1) == 1) {
-                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 80, 255, 150, D_8082A150[phi_s3]);
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, A_button_ori.r, A_button_ori.g, A_button_ori.b, Notes_alpha);
                         } else if (CVar_GetS32("gHudColors", 1) == 2) {
-                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, CVar_GetS32("gCCABtnPrimR", 80), CVar_GetS32("gCCABtnPrimG", 255), CVar_GetS32("gCCABtnPrimB", 150), D_8082A150[phi_s3]);
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, A_button.r, A_button.g, A_button.b, Notes_alpha);
                         }
                     } else {
-                        if (CVar_GetS32("gHudColors", 1) == 0) {
-                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 255, 255, 50, 200);
+                        if (CVar_GetS32("gHudColors", 1) == 0) { // C Buttons notes
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, C_button_ori.r, C_button_ori.g, C_button_ori.b, Notes_alpha);
+                        } else if (CVar_GetS32("gHudColors", 1) == 1) {
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, C_button_ori.r, C_button_ori.g, C_button_ori.b, Notes_alpha);
                         } else if (CVar_GetS32("gHudColors", 1) == 2 && !CVar_GetS32("gCCparated", 0)) {
-                             gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, CVar_GetS32("gCCCBtnPrimR", 255), CVar_GetS32("gCCCBtnPrimG", 255), CVar_GetS32("gCCCBtnPrimB", 0), D_8082A150[phi_s3]);
-                        } else if (gOcarinaSongNotes[sp224].notesIdx[phi_s3] == OCARINA_NOTE_D5 && CVar_GetS32("gHudColors", 1) == 2 && CVar_GetS32("gCCparated", 0)) {
-                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, CVar_GetS32("gCCCUBtnPrimR", 255), CVar_GetS32("gCCCUBtnPrimG", 255), CVar_GetS32("gCCCUBtnPrimB", 0), D_8082A150[phi_s3]);
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, C_button_uni.r, C_button_uni.g, C_button_uni.b, Notes_alpha);
                         } else if (gOcarinaSongNotes[sp224].notesIdx[phi_s3] == OCARINA_NOTE_B4 && CVar_GetS32("gHudColors", 1) == 2 && CVar_GetS32("gCCparated", 0)) {
-                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, CVar_GetS32("gCCCLBtnPrimR", 255), CVar_GetS32("gCCCLBtnPrimG", 255), CVar_GetS32("gCCCLBtnPrimB", 0), D_8082A150[phi_s3]);
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, C_button_L.r, C_button_L.g, C_button_L.b, Notes_alpha);
                         } else if (gOcarinaSongNotes[sp224].notesIdx[phi_s3] == OCARINA_NOTE_A4 && CVar_GetS32("gHudColors", 1) == 2 && CVar_GetS32("gCCparated", 0)) {
-                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, CVar_GetS32("gCCCRBtnPrimR", 255), CVar_GetS32("gCCCRBtnPrimG", 255), CVar_GetS32("gCCCRBtnPrimB", 0), D_8082A150[phi_s3]);
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, C_button_R.r, C_button_R.g, C_button_R.b, Notes_alpha);
                         } else if (gOcarinaSongNotes[sp224].notesIdx[phi_s3] == OCARINA_NOTE_F4 && CVar_GetS32("gHudColors", 1) == 2 && CVar_GetS32("gCCparated", 0)) {
-                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, CVar_GetS32("gCCCDBtnPrimR", 255), CVar_GetS32("gCCCDBtnPrimG", 255), CVar_GetS32("gCCCDBtnPrimB", 0), D_8082A150[phi_s3]);
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, C_button_D.r, C_button_D.g, C_button_D.b, Notes_alpha);
                         }
                     }
 

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
@@ -761,6 +761,13 @@ static s16 sCursorColors[][3] = {
     { 0, 255, 50 },
 };
 
+const Color_RGB8 Cursor_ABTN_ori = {0, 255, 50};
+const Color_RGB8 Cursor_ABTNN64_ori = {0, 50, 255};
+const Color_RGB8 Cursor_CBTN_ori = {255, 255, 0};
+const Color_RGB8 Cursor_StartBTN_ori = {255, 255, 255};
+Color_RGB8 Cursor_ABTN;
+Color_RGB8 Cursor_CBTN;
+
 static void* sSavePromptTexs[] = {
     gPauseSavePromptENGTex,
     gPauseSavePromptGERTex,
@@ -987,26 +994,27 @@ void KaleidoScope_DrawCursor(GlobalContext* globalCtx, u16 pageIndex) {
     temp = pauseCtx->unk_1E4;
 
     if (CVar_GetS32("gHudColors", 1) == 0) {
-        sCursorColors[1][0] = 255;
-        sCursorColors[1][1] = 255;
-        sCursorColors[1][2] = 0;
-        sCursorColors[2][0] = 0;
-        sCursorColors[2][1] = 50;
-        sCursorColors[2][2] = 255;
+        //Will be converted to ColorRGB later.
+        sCursorColors[1][0] = Cursor_CBTN_ori.r;
+        sCursorColors[1][1] = Cursor_CBTN_ori.g;
+        sCursorColors[1][2] = Cursor_CBTN_ori.b;
+        sCursorColors[2][0] = Cursor_ABTNN64_ori.r;
+        sCursorColors[2][1] = Cursor_ABTNN64_ori.g;
+        sCursorColors[2][2] = Cursor_ABTNN64_ori.b;
     } else if (CVar_GetS32("gHudColors", 1) == 1) {
-        sCursorColors[1][0] = 255;
-        sCursorColors[1][1] = 255;
-        sCursorColors[1][2] = 0;
-        sCursorColors[2][0] = 0;
-        sCursorColors[2][1] = 255;
-        sCursorColors[2][2] = 50;
+        sCursorColors[1][0] = Cursor_CBTN_ori.r;
+        sCursorColors[1][1] = Cursor_CBTN_ori.g;
+        sCursorColors[1][2] = Cursor_CBTN_ori.b;
+        sCursorColors[2][0] = Cursor_ABTN_ori.r;
+        sCursorColors[2][1] = Cursor_ABTN_ori.g;
+        sCursorColors[2][2] = Cursor_ABTN_ori.b;
     } else if (CVar_GetS32("gHudColors", 1) == 2) {
-        sCursorColors[1][0] = CVar_GetS32("gCCCBtnPrimR", 255);
-        sCursorColors[1][1] = CVar_GetS32("gCCCBtnPrimG", 255);
-        sCursorColors[1][2] = CVar_GetS32("gCCCBtnPrimB", 0);
-        sCursorColors[2][0] = CVar_GetS32("gCCABtnPrimR", 0);
-        sCursorColors[2][1] = CVar_GetS32("gCCABtnPrimG", 255);
-        sCursorColors[2][2] = CVar_GetS32("gCCABtnPrimB", 50);
+        sCursorColors[1][0] = CVar_GetRGB("gCCCBtnPrim", Cursor_CBTN_ori).r;
+        sCursorColors[1][1] = CVar_GetRGB("gCCCBtnPrim", Cursor_CBTN_ori).g;
+        sCursorColors[1][2] = CVar_GetRGB("gCCCBtnPrim", Cursor_CBTN_ori).b;
+        sCursorColors[2][0] = CVar_GetRGB("gCCABtnPrim", Cursor_ABTN_ori).r;
+        sCursorColors[2][1] = CVar_GetRGB("gCCABtnPrim", Cursor_ABTN_ori).g;
+        sCursorColors[2][2] = CVar_GetRGB("gCCABtnPrim", Cursor_ABTN_ori).b;
     }
 
     if ((((pauseCtx->unk_1E4 == 0) || (temp == 8)) && (pauseCtx->state == 6)) ||
@@ -1079,45 +1087,46 @@ void KaleidoScope_DrawPages(GlobalContext* globalCtx, GraphicsContext* gfxCtx) {
         { 0, 0, 0 }, { 0, 0, 0 },     { 0, 0, 0 },    { 0, 0, 0 }, { 255, 255, 0 }, { 0, 0, 0 },
         { 0, 0, 0 }, { 255, 255, 0 }, { 0, 255, 50 }, { 0, 0, 0 }, { 0, 0, 0 },     { 0, 255, 50 },
     };
+    const Color_RGB8 A_BTN_ori = {100, 255, 100};
     if (CVar_GetS32("gHudColors", 1) == 0) {
-        D_8082ACF4[4][0] = 255;
-        D_8082ACF4[4][1] = 255;
-        D_8082ACF4[4][2] = 0;
-        D_8082ACF4[7][0] = 255;
-        D_8082ACF4[7][1] = 255;
-        D_8082ACF4[7][2] = 0;
-        D_8082ACF4[8][0] = 0;
-        D_8082ACF4[8][1] = 50;
-        D_8082ACF4[8][2] = 255;
-        D_8082ACF4[11][0] = 0;
-        D_8082ACF4[11][1] = 50;
-        D_8082ACF4[11][2] = 255;
+        D_8082ACF4[4][0] = Cursor_CBTN_ori.r;
+        D_8082ACF4[4][1] = Cursor_CBTN_ori.g;
+        D_8082ACF4[4][2] = Cursor_CBTN_ori.b;
+        D_8082ACF4[7][0] = Cursor_CBTN_ori.r;
+        D_8082ACF4[7][1] = Cursor_CBTN_ori.g;
+        D_8082ACF4[7][2] = Cursor_CBTN_ori.b;
+        D_8082ACF4[8][0] = Cursor_ABTNN64_ori.r;
+        D_8082ACF4[8][1] = Cursor_ABTNN64_ori.g;
+        D_8082ACF4[8][2] = Cursor_ABTNN64_ori.b;
+        D_8082ACF4[11][0] = Cursor_ABTNN64_ori.r;
+        D_8082ACF4[11][1] = Cursor_ABTNN64_ori.g;
+        D_8082ACF4[11][2] = Cursor_ABTNN64_ori.b;
     } else if (CVar_GetS32("gHudColors", 1) == 1) {
-        D_8082ACF4[4][0] = 255;
-        D_8082ACF4[4][1] = 255;
-        D_8082ACF4[4][2] = 0;
-        D_8082ACF4[7][0] = 255;
-        D_8082ACF4[7][1] = 255;
-        D_8082ACF4[7][2] = 0;
-        D_8082ACF4[8][0] = 0;
-        D_8082ACF4[8][1] = 255;
-        D_8082ACF4[8][2] = 50;
-        D_8082ACF4[11][0] = 0;
-        D_8082ACF4[11][1] = 255;
-        D_8082ACF4[11][2] = 50;
+        D_8082ACF4[4][0] = Cursor_CBTN_ori.r;
+        D_8082ACF4[4][1] = Cursor_CBTN_ori.g;
+        D_8082ACF4[4][2] = Cursor_CBTN_ori.b;
+        D_8082ACF4[7][0] = Cursor_CBTN_ori.r;
+        D_8082ACF4[7][1] = Cursor_CBTN_ori.g;
+        D_8082ACF4[7][2] = Cursor_CBTN_ori.b;
+        D_8082ACF4[8][0] = Cursor_ABTN_ori.r;
+        D_8082ACF4[8][1] = Cursor_ABTN_ori.g;
+        D_8082ACF4[8][2] = Cursor_ABTN_ori.b;
+        D_8082ACF4[11][0] = Cursor_ABTN_ori.r;
+        D_8082ACF4[11][1] = Cursor_ABTN_ori.g;
+        D_8082ACF4[11][2] = Cursor_ABTN_ori.b;
     } else if (CVar_GetS32("gHudColors", 1) == 2) {
-        D_8082ACF4[4][0] = CVar_GetS32("gCCCBtnPrimR", 255);
-        D_8082ACF4[4][1] = CVar_GetS32("gCCCBtnPrimG", 255);
-        D_8082ACF4[4][2] = CVar_GetS32("gCCCBtnPrimB", 0);
-        D_8082ACF4[7][0] = CVar_GetS32("gCCCBtnPrimR", 255);
-        D_8082ACF4[7][1] = CVar_GetS32("gCCCBtnPrimG", 255);
-        D_8082ACF4[7][2] = CVar_GetS32("gCCCBtnPrimB", 0);
-        D_8082ACF4[8][0] = CVar_GetS32("gCCABtnPrimR", 0);
-        D_8082ACF4[8][1] = CVar_GetS32("gCCABtnPrimG", 255);
-        D_8082ACF4[8][2] = CVar_GetS32("gCCABtnPrimB", 50);
-        D_8082ACF4[11][0] = CVar_GetS32("gCCABtnPrimR", 0);
-        D_8082ACF4[11][1] = CVar_GetS32("gCCABtnPrimG", 255);
-        D_8082ACF4[11][2] = CVar_GetS32("gCCABtnPrimB", 50);
+        D_8082ACF4[4][0] = CVar_GetRGB("gCCCBtnPrim", Cursor_CBTN_ori).r;
+        D_8082ACF4[4][1] = CVar_GetRGB("gCCCBtnPrim", Cursor_CBTN_ori).g;
+        D_8082ACF4[4][2] = CVar_GetRGB("gCCCBtnPrim", Cursor_CBTN_ori).b;
+        D_8082ACF4[7][0] = CVar_GetRGB("gCCCBtnPrim", Cursor_CBTN_ori).r;
+        D_8082ACF4[7][1] = CVar_GetRGB("gCCCBtnPrim", Cursor_CBTN_ori).g;
+        D_8082ACF4[7][2] = CVar_GetRGB("gCCCBtnPrim", Cursor_CBTN_ori).b;
+        D_8082ACF4[8][0] = CVar_GetRGB("gCCABtnPrim", Cursor_ABTN_ori).r;
+        D_8082ACF4[8][1] = CVar_GetRGB("gCCABtnPrim", Cursor_ABTN_ori).g;
+        D_8082ACF4[8][2] = CVar_GetRGB("gCCABtnPrim", Cursor_ABTN_ori).b;
+        D_8082ACF4[11][0] = CVar_GetRGB("gCCABtnPrim", Cursor_ABTN_ori).r;
+        D_8082ACF4[11][1] = CVar_GetRGB("gCCABtnPrim", Cursor_ABTN_ori).g;
+        D_8082ACF4[11][2] = CVar_GetRGB("gCCABtnPrim", Cursor_ABTN_ori).b;
     }
     static s16 D_8082AD3C = 20;
     static s16 D_8082AD40 = 0;
@@ -1499,7 +1508,7 @@ void KaleidoScope_DrawPages(GlobalContext* globalCtx, GraphicsContext* gfxCtx) {
             } else if (CVar_GetS32("gHudColors", 1) == 1) {
                 gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 100, 255, 100, VREG(61)); 
             } else if (CVar_GetS32("gHudColors", 1) == 2) {
-                gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, CVar_GetS32("gCCABtnPrimR", 100), CVar_GetS32("gCCABtnPrimG", 255), CVar_GetS32("gCCABtnPrimB", 100), VREG(61)); //Save prompt cursor colour
+                gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, CVar_GetRGB("gCCABtnPrim", A_BTN_ori).r, CVar_GetRGB("gCCABtnPrim", A_BTN_ori).g, CVar_GetRGB("gCCABtnPrim", A_BTN_ori).b, VREG(61)); //Save prompt cursor colour
             }
 
             if (pauseCtx->promptChoice == 0) {
@@ -1563,6 +1572,14 @@ void KaleidoScope_DrawInfoPanel(GlobalContext* globalCtx) {
         { 0, 255, 100, 255 },//Gamecube
         { 0, 100, 255, 255 },//Original N64
     };
+    Color_RGB8 A_button_ori = {gABtnTexColour[0][0],gABtnTexColour[0][1],gABtnTexColour[0][2]};
+    Color_RGB8 A_button = CVar_GetRGB("gCCABtnPrim", A_button_ori);
+    Color_RGB8 C_button_ori = {R_C_BTN_COLOR(0), R_C_BTN_COLOR(1), R_C_BTN_COLOR(2)};
+    Color_RGB8 C_button_uni = CVar_GetRGB("gCCCBtnPrim", C_button_ori);
+    Color_RGB8 C_button_U = CVar_GetRGB("gCCCUBtnPrim", C_button_ori);
+    Color_RGB8 C_button_D = CVar_GetRGB("gCCCDBtnPrim", C_button_ori);
+    Color_RGB8 C_button_L = CVar_GetRGB("gCCCLBtnPrim", C_button_ori);
+    Color_RGB8 C_button_R = CVar_GetRGB("gCCCRBtnPrim", C_button_ori);
     static const void* sToEquipTextures[3] = {
         gPauseToEquipENGTex,
         gPauseToEquipGERTex,
@@ -1889,11 +1906,11 @@ void KaleidoScope_DrawInfoPanel(GlobalContext* globalCtx) {
             pauseCtx->infoPanelVtx[21].v.tc[0] = pauseCtx->infoPanelVtx[23].v.tc[0] = D_8082ADE0[gSaveContext.language]
                                                                                       << 5;
             if (CVar_GetS32("gHudColors", 1) == 0) {//A icon to decide in save prompt
-              gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, gABtnTexColour[1][0], gABtnTexColour[1][1], gABtnTexColour[1][2], gABtnTexColour[1][3]);
+                gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, gABtnTexColour[1][0], gABtnTexColour[1][1], gABtnTexColour[1][2], gABtnTexColour[1][3]);
             } else if (CVar_GetS32("gHudColors", 1) == 1) {
-              gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, gABtnTexColour[0][0], gABtnTexColour[0][1], gABtnTexColour[0][2], gABtnTexColour[0][3]);
+                gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, gABtnTexColour[0][0], gABtnTexColour[0][1], gABtnTexColour[0][2], gABtnTexColour[0][3]);
             } else if (CVar_GetS32("gHudColors", 1) == 2) {
-              gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, CVar_GetS32("gCCABtnPrimR", gABtnTexColour[0][0]), CVar_GetS32("gCCABtnPrimG", gABtnTexColour[0][1]), CVar_GetS32("gCCABtnPrimB", gABtnTexColour[0][2]), gABtnTexColour[0][3]);
+                gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, A_button.r, A_button.g, A_button.b, gABtnTexColour[0][3]);
             }
             //gSPDisplayList(POLY_KAL_DISP++, gAButtonIconDL);//This is changed to load the texture only so we can prim color it.
             gDPLoadTextureBlock(POLY_KAL_DISP++, gABtnSymbolTex, G_IM_FMT_IA, G_IM_SIZ_8b, 24, 16, 0, G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR | G_TX_CLAMP, 4, 4, G_TX_NOLOD, G_TX_NOLOD);
@@ -1962,17 +1979,17 @@ void KaleidoScope_DrawInfoPanel(GlobalContext* globalCtx) {
                 int height_factor = (1 << 10) * icon_h / height;
                 int width_factor = (1 << 10) * icon_w / width;
                 if (CVar_GetS32("gHudColors", 1) == 2 && CVar_GetS32("gCCparated", 0)) {
-                    gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, CVar_GetS32("gCCCBtnPrimR", R_C_BTN_COLOR(0)), CVar_GetS32("gCCCBtnPrimG", R_C_BTN_COLOR(1)), CVar_GetS32("gCCCBtnPrimB", R_C_BTN_COLOR(2)), 255);
+                    gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, C_button_uni.r, C_button_uni.g, C_button_uni.b, 255);
                     for (s16 i=0; i < 3; i++) {
                         if (i == 0) {
                             icon_x_offset = width_crop*3-3;
-                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, CVar_GetS32("gCCCRBtnPrimR", R_C_BTN_COLOR(0)), CVar_GetS32("gCCCRBtnPrimG", R_C_BTN_COLOR(1)), CVar_GetS32("gCCCRBtnPrimB", R_C_BTN_COLOR(2)), 255);
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, C_button_R.r, C_button_R.g, C_button_R.b, 255);
                         } else if (i == 1) {
                             icon_x_offset = width_crop*2-3;
-                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, CVar_GetS32("gCCCDBtnPrimR", R_C_BTN_COLOR(0)), CVar_GetS32("gCCCDBtnPrimG", R_C_BTN_COLOR(1)), CVar_GetS32("gCCCDBtnPrimB", R_C_BTN_COLOR(2)), 255);
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, C_button_D.r, C_button_D.g, C_button_D.b, 255);
                         } else if (i == 2) {
                             icon_x_offset = width_crop;
-                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, CVar_GetS32("gCCCLBtnPrimR", R_C_BTN_COLOR(0)), CVar_GetS32("gCCCLBtnPrimG", R_C_BTN_COLOR(1)), CVar_GetS32("gCCCLBtnPrimB", R_C_BTN_COLOR(2)), 255);
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, C_button_L.r, C_button_L.g, C_button_L.b, 255);
                         }
                         gDPLoadTextureBlock(POLY_KAL_DISP++, gCBtnSymbolsTex, G_IM_FMT_IA, G_IM_SIZ_8b, icon_w, icon_h, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
                         //gSPScisTextureRectangle(POLY_KAL_DISP++,PosX << 2, PosY << 2, (PosX + icon_x_offset) << 2, (PosY + height) << 2, G_TX_RENDERTILE, 0, 0, width_factor, height_factor);
@@ -1980,11 +1997,11 @@ void KaleidoScope_DrawInfoPanel(GlobalContext* globalCtx) {
                     }
                 } else {
                     if (CVar_GetS32("gHudColors", 1) == 0) {//To equip text C button icon
-                        gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, R_C_BTN_COLOR(0), R_C_BTN_COLOR(1), R_C_BTN_COLOR(2), 255);
+                        gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, C_button_ori.r, C_button_ori.g, C_button_ori.b, 255);
                     } else if (CVar_GetS32("gHudColors", 1) == 1) {
-                        gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, R_C_BTN_COLOR(0), R_C_BTN_COLOR(1), R_C_BTN_COLOR(2), 255);
+                        gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, C_button_ori.r, C_button_ori.g, C_button_ori.b, 255);
                     } else if (CVar_GetS32("gHudColors", 1) == 2 && !CVar_GetS32("gCCparated", 0)) {
-                        gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, CVar_GetS32("gCCCBtnPrimR", R_C_BTN_COLOR(0)), CVar_GetS32("gCCCBtnPrimG", R_C_BTN_COLOR(1)), CVar_GetS32("gCCCBtnPrimB", R_C_BTN_COLOR(2)), 255);
+                        gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, C_button_uni.r, C_button_uni.g, C_button_uni.b, 255);
                     }
                     gDPLoadTextureBlock(POLY_KAL_DISP++, gCBtnSymbolsTex, G_IM_FMT_IA, G_IM_SIZ_8b, icon_w, icon_h, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
                     gSPWideTextureRectangle(POLY_KAL_DISP++, PosX << 2, PosY << 2, (PosX + width) << 2, (PosY + height) << 2, G_TX_RENDERTILE, 0, 0, width_factor, height_factor);
@@ -2025,7 +2042,7 @@ void KaleidoScope_DrawInfoPanel(GlobalContext* globalCtx) {
                     } else if (CVar_GetS32("gHudColors", 1) == 1) {
                         gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, gABtnTexColour[0][0], gABtnTexColour[0][1], gABtnTexColour[0][2], gABtnTexColour[0][3]);
                     } else if (CVar_GetS32("gHudColors", 1) == 2) {
-                        gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, CVar_GetS32("gCCABtnPrimR", gABtnTexColour[0][0]), CVar_GetS32("gCCABtnPrimG", gABtnTexColour[0][1]), CVar_GetS32("gCCABtnPrimB", gABtnTexColour[0][2]), gABtnTexColour[0][3]);
+                        gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, A_button.r, A_button.g, A_button.b, gABtnTexColour[0][3]);
                     }
                     //gSPDisplayList(POLY_KAL_DISP++, gAButtonIconDL);
                     gDPLoadTextureBlock(POLY_KAL_DISP++, gABtnSymbolTex, G_IM_FMT_IA, G_IM_SIZ_8b, 24, 16, 0, G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR | G_TX_CLAMP, 4, 4, G_TX_NOLOD, G_TX_NOLOD);
@@ -2065,7 +2082,7 @@ void KaleidoScope_DrawInfoPanel(GlobalContext* globalCtx) {
                 } else if (CVar_GetS32("gHudColors", 1) == 1) {
                     gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, gABtnTexColour[0][0], gABtnTexColour[0][1], gABtnTexColour[0][2], gABtnTexColour[0][3]);
                 } else if (CVar_GetS32("gHudColors", 1) == 2) {
-                    gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, CVar_GetS32("gCCABtnPrimR", gABtnTexColour[0][0]), CVar_GetS32("gCCABtnPrimG", gABtnTexColour[0][1]), CVar_GetS32("gCCABtnPrimB", gABtnTexColour[0][2]), gABtnTexColour[0][3]);
+                    gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, A_button.r, A_button.g, A_button.b, gABtnTexColour[0][3]);
                 }
                 gDPLoadTextureBlock(POLY_KAL_DISP++, gABtnSymbolTex, G_IM_FMT_IA, G_IM_SIZ_8b, 24, 16, 0, G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR | G_TX_CLAMP, 4, 4, G_TX_NOLOD, G_TX_NOLOD);
                 gSP1Quadrangle(POLY_KAL_DISP++, 0, 2, 3, 1, 0);


### PR DESCRIPTION
Fix some Cvar name issues and Array that was weird for RainbowColor (This function will be drastically reworked)
Add some transition stuff. (presentation not final, Triforce is a bit buggy no idea how to fix.)
Make use of Cvar RGB (If I miss any please feel free to point me)
Fix both ResetColor() and RandomizeColor() has Cvar RGB killed them.

Cosmetics Editor now use a structure system
Fix + & - button position
Fix CVar for Tunics, duplicated and typos in some Cvars
Use RGB Cvar system

Now you will be able to randomize stuffs with a single button !
Remove Disco mode in graveyard.
Title logo's flame colors (require game reboot^^)
Some more that still hidden yet because not done but this same menu support scaling system just disabled as not all are done.
I did not point to Rachael as it add feature and fix bug only present in Zhora (RGBa CVar)
