### PR TITLE
Item tracker v3

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
@@ -165,7 +165,7 @@ std::vector<uint32_t> buttonMap = {
     BTN_DUP,
     BTN_DDOWN,
     BTN_DLEFT,
-    BTN_DRIGHT,
+    BTN_DRIGHT
 };
 
 ImVec2 GetItemCurrentAndMax(ItemTrackerItem item) {

--- a/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
@@ -16,6 +16,9 @@ extern "C" {
 #include "functions.h"
 #include "macros.h"
 extern GlobalContext* gGlobalCtx;
+
+#include "textures/icon_item_static/icon_item_static.h"
+#include "textures/icon_item_24_static/icon_item_24_static.h"
 }
 
 void DrawEquip(ItemTrackerItem item);
@@ -68,19 +71,35 @@ std::vector<ItemTrackerItem> songItems = {
 };
 
 std::vector<ItemTrackerDungeon> itemTrackerDungeons = {
-    ITEM_TRACKER_DUNGEON(SCENE_BMORI1, "FRST", true, true, true, true),
-    ITEM_TRACKER_DUNGEON(SCENE_HIDAN, "FIRE", true, true, true, true),
-    ITEM_TRACKER_DUNGEON(SCENE_MIZUSIN, "WATR", true, true, true, true),
-    ITEM_TRACKER_DUNGEON(SCENE_JYASINZOU, "SPRT", true, true, true, true),
-    ITEM_TRACKER_DUNGEON(SCENE_HAKADAN, "SHDW", true, true, true, true),
-    ITEM_TRACKER_DUNGEON(SCENE_HAKADANCH, "BOTW", true, true, false, true),
-    ITEM_TRACKER_DUNGEON(SCENE_YDAN, "DEKU", true, true, false, false),
-    ITEM_TRACKER_DUNGEON(SCENE_DDAN, "DCVN", true, true, false, false),
-    ITEM_TRACKER_DUNGEON(SCENE_BDAN, "JABU", true, true, false, false),
-    ITEM_TRACKER_DUNGEON(SCENE_ICE_DOUKUTO, "ICE", true, true, false, false),
-    ITEM_TRACKER_DUNGEON(SCENE_GANON, "GANON", false, false, true, true),
-    ITEM_TRACKER_DUNGEON(SCENE_MEN, "GTG", false, false, false, true),
-    ITEM_TRACKER_DUNGEON(SCENE_GERUDOWAY, "HIDE", false, false, false, true),
+    { SCENE_BMORI1, { ITEM_KEY_SMALL, ITEM_KEY_BOSS, ITEM_DUNGEON_MAP, ITEM_COMPASS } },
+    { SCENE_HIDAN, { ITEM_KEY_SMALL, ITEM_KEY_BOSS, ITEM_DUNGEON_MAP, ITEM_COMPASS } },
+    { SCENE_MIZUSIN, { ITEM_KEY_SMALL, ITEM_KEY_BOSS, ITEM_DUNGEON_MAP, ITEM_COMPASS } },
+    { SCENE_JYASINZOU, { ITEM_KEY_SMALL, ITEM_KEY_BOSS, ITEM_DUNGEON_MAP, ITEM_COMPASS } },
+    { SCENE_HAKADAN, { ITEM_KEY_SMALL, ITEM_KEY_BOSS, ITEM_DUNGEON_MAP, ITEM_COMPASS } },
+    { SCENE_HAKADANCH, { ITEM_KEY_SMALL, ITEM_DUNGEON_MAP, ITEM_COMPASS } },
+    { SCENE_YDAN, { ITEM_DUNGEON_MAP, ITEM_COMPASS } },
+    { SCENE_DDAN, { ITEM_DUNGEON_MAP, ITEM_COMPASS } },
+    { SCENE_BDAN, { ITEM_DUNGEON_MAP, ITEM_COMPASS } },
+    { SCENE_ICE_DOUKUTO, { ITEM_DUNGEON_MAP, ITEM_COMPASS } },
+    { SCENE_GANON, { ITEM_KEY_SMALL, ITEM_KEY_BOSS } },
+    { SCENE_MEN, { ITEM_KEY_SMALL } },
+    // { SCENE_GERUDOWAY, { ITEM_KEY_SMALL } }, // We're adding this manually for space
+};
+
+std::map<uint16_t, std::string> itemTrackerDungeonShortNames = {
+    { SCENE_BMORI1, "FRST" },
+    { SCENE_HIDAN, "FIRE" },
+    { SCENE_MIZUSIN, "WATR" },
+    { SCENE_JYASINZOU, "SPRT" },
+    { SCENE_HAKADAN, "SHDW" },
+    { SCENE_HAKADANCH, "BOTW" },
+    { SCENE_YDAN, "DEKU" },
+    { SCENE_DDAN, "DCVN" },
+    { SCENE_BDAN, "JABU" },
+    { SCENE_ICE_DOUKUTO, "ICE" },
+    { SCENE_GANON, "GANON" },
+    { SCENE_MEN, "GTG" },
+    { SCENE_GERUDOWAY, "HIDE" },
 };
 
 std::unordered_map<uint32_t, ItemTrackerItem> actualItemTrackerItemMap = {
@@ -245,7 +264,7 @@ ImVec2 GetItemCurrentAndMax(ItemTrackerItem item) {
 }
 
 void DrawItemCount(ItemTrackerItem item) {
-    int iconSize = CVar_GetS32("gItemTrackerIconSize", 32);
+    int iconSize = CVar_GetS32("gItemTrackerIconSize", 36);
     ImVec2 currentAndMax = GetItemCurrentAndMax(item);
     ImVec2 p = ImGui::GetCursorScreenPos();
 
@@ -253,7 +272,7 @@ void DrawItemCount(ItemTrackerItem item) {
         if (currentAndMax.x >= currentAndMax.y) {
             std::string currentString = std::to_string((int)currentAndMax.x);
 
-            ImGui::SetCursorScreenPos(ImVec2(p.x + (iconSize / 2) - (ImGui::CalcTextSize(currentString.c_str()).x / 2), p.y - 10));
+            ImGui::SetCursorScreenPos(ImVec2(p.x + (iconSize / 2) - (ImGui::CalcTextSize(currentString.c_str()).x / 2), p.y - 14));
             ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(0, 255, 0, 255));
             ImGui::Text("%d", (int)currentAndMax.x);
             ImGui::PopStyleColor();
@@ -261,7 +280,7 @@ void DrawItemCount(ItemTrackerItem item) {
             if (CVar_GetS32("gItemTrackerDisplayCurrentMax", 0) == 1) {
                 std::string currentAndMaxString = std::to_string((int)currentAndMax.x) + "/" + std::to_string((int)currentAndMax.y);
 
-                ImGui::SetCursorScreenPos(ImVec2(p.x + (iconSize / 2) - (ImGui::CalcTextSize(currentAndMaxString.c_str()).x / 2), p.y - 10));
+                ImGui::SetCursorScreenPos(ImVec2(p.x + (iconSize / 2) - (ImGui::CalcTextSize(currentAndMaxString.c_str()).x / 2), p.y - 14));
                 ImGui::Text("%d/", (int)currentAndMax.x);
                 ImGui::SameLine(0, 0.0f);
                 ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(0, 255, 0, 255));
@@ -270,7 +289,7 @@ void DrawItemCount(ItemTrackerItem item) {
             } else {
                 std::string currentString = std::to_string((int)currentAndMax.x);
 
-                ImGui::SetCursorScreenPos(ImVec2(p.x + (iconSize / 2) - (ImGui::CalcTextSize(currentString.c_str()).x / 2), p.y - 10));
+                ImGui::SetCursorScreenPos(ImVec2(p.x + (iconSize / 2) - (ImGui::CalcTextSize(currentString.c_str()).x / 2), p.y - 14));
                 ImGui::Text("%d", (int)currentAndMax.x);
             }
         }
@@ -279,7 +298,7 @@ void DrawItemCount(ItemTrackerItem item) {
 
 void DrawEquip(ItemTrackerItem item) {
     bool hasEquip = (item.data & gSaveContext.inventory.equipment) != 0;
-    int iconSize = CVar_GetS32("gItemTrackerIconSize", 32);
+    int iconSize = CVar_GetS32("gItemTrackerIconSize", 36);
     ImGui::Image(SohImGui::GetTextureByName(hasEquip ? item.name : item.nameFaded),
                  ImVec2(iconSize, iconSize), ImVec2(0, 0), ImVec2(1, 1));
 
@@ -288,7 +307,7 @@ void DrawEquip(ItemTrackerItem item) {
 
 void DrawQuest(ItemTrackerItem item) {
     bool hasQuestItem = (item.data & gSaveContext.inventory.questItems) != 0;
-    int iconSize = CVar_GetS32("gItemTrackerIconSize", 32);
+    int iconSize = CVar_GetS32("gItemTrackerIconSize", 36);
     ImGui::BeginGroup();
     ImGui::Image(SohImGui::GetTextureByName(hasQuestItem ? item.name : item.nameFaded),
                  ImVec2(iconSize, iconSize), ImVec2(0, 0), ImVec2(1, 1));
@@ -304,14 +323,10 @@ void DrawQuest(ItemTrackerItem item) {
 
 void DrawItem(ItemTrackerItem item) {
     uint32_t actualItemId = INV_CONTENT(item.id);
-    int iconSize = CVar_GetS32("gItemTrackerIconSize", 32);
+    int iconSize = CVar_GetS32("gItemTrackerIconSize", 36);
     bool hasItem = actualItemId != ITEM_NONE;
 
     if (item.id == ITEM_NONE) {
-        ImGui::BeginGroup();
-        ImVec2 p = ImGui::GetCursorScreenPos();
-        ImGui::SetCursorScreenPos(ImVec2(p.x - 5 + (iconSize / 2) - 10, p.y - 10));
-        ImGui::EndGroup();
         return;
     }
 
@@ -362,7 +377,7 @@ void DrawBottle(ItemTrackerItem item) {
     bool hasItem = actualItemId != ITEM_NONE;
 
     const ItemTrackerItem& actualItem = actualItemTrackerItemMap[hasItem ? actualItemId : item.id];
-    int iconSize = CVar_GetS32("gItemTrackerIconSize", 32);
+    int iconSize = CVar_GetS32("gItemTrackerIconSize", 36);
     ImGui::Image(SohImGui::GetTextureByName(hasItem ? actualItem.name : actualItem.nameFaded),
                  ImVec2(iconSize, iconSize), ImVec2(0, 0), ImVec2(1, 1));
 
@@ -372,7 +387,7 @@ void DrawBottle(ItemTrackerItem item) {
 void DrawDungeonItem(ItemTrackerItem item) {
     uint32_t itemId = item.id;
     uint32_t bitMask = 1 << (item.id - ITEM_KEY_BOSS); // Bitset starts at ITEM_KEY_BOSS == 0. the rest are sequential
-    int iconSize = CVar_GetS32("gItemTrackerIconSize", 32);
+    int iconSize = CVar_GetS32("gItemTrackerIconSize", 36);
     bool hasItem = (bitMask & gSaveContext.inventory.dungeonItems[item.data]) != 0;
     bool hasSmallKey = (gSaveContext.inventory.dungeonKeys[item.data]) >= 0;
     ImGui::BeginGroup();
@@ -387,6 +402,20 @@ void DrawDungeonItem(ItemTrackerItem item) {
 
     if (itemId == ITEM_KEY_SMALL) {
         DrawItemCount(item);
+
+        ImVec2 p = ImGui::GetCursorScreenPos();
+        std::string dungeonName = itemTrackerDungeonShortNames[item.data];
+        ImGui::SetCursorScreenPos(ImVec2(p.x + (iconSize / 2) - (ImGui::CalcTextSize(dungeonName.c_str()).x / 2), p.y - (iconSize + 16)));
+        ImGui::Text(dungeonName.c_str());
+    }
+
+    if (itemId == ITEM_DUNGEON_MAP && 
+        (item.data == SCENE_YDAN || item.data == SCENE_DDAN || item.data == SCENE_BDAN || item.data == SCENE_ICE_DOUKUTO)
+    ) {
+        ImVec2 p = ImGui::GetCursorScreenPos();
+        std::string dungeonName = itemTrackerDungeonShortNames[item.data];
+        ImGui::SetCursorScreenPos(ImVec2(p.x + (iconSize / 2) - (ImGui::CalcTextSize(dungeonName.c_str()).x / 2), p.y - (iconSize + 13)));
+        ImGui::Text(dungeonName.c_str());
     }
     ImGui::EndGroup();
 
@@ -394,16 +423,21 @@ void DrawDungeonItem(ItemTrackerItem item) {
 }
 
 void DrawSong(ItemTrackerItem item) {
-    int iconSize = CVar_GetS32("gItemTrackerIconSize", 32);
+    int iconSize = CVar_GetS32("gItemTrackerIconSize", 36);
     uint32_t bitMask = 1 << item.id;
     bool hasSong = (bitMask & gSaveContext.inventory.questItems) != 0;
+    ImVec2 p = ImGui::GetCursorScreenPos();
+    ImGui::SetCursorScreenPos(ImVec2(p.x + 6, p.y));
     ImGui::Image(SohImGui::GetTextureByName(hasSong ? item.name : item.nameFaded),
                  ImVec2(iconSize / 1.5, iconSize), ImVec2(0, 0), ImVec2(1, 1));
     SetLastItemHoverText(SohUtils::GetQuestItemName(item.id));
 }
 
-void DrawNotes() {
+void DrawNotes(bool resizeable = false) {
     ImGui::BeginGroup();
+    int iconSize = CVar_GetS32("gItemTrackerIconSize", 36);
+    int iconSpacing = CVar_GetS32("gItemTrackerIconSpacing", 12);
+
     struct ItemTrackerNotes {
         static int TrackerNotesResizeCallback(ImGuiInputTextCallbackData* data) {
             if (data->EventFlag == ImGuiInputTextFlags_CallbackResize) {
@@ -428,9 +462,8 @@ void DrawNotes() {
     if (itemTrackerNotes.empty()) {
         itemTrackerNotes.push_back(0);
     }
-    // ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(0, 0, 0, 0));
-    ItemTrackerNotes::TrackerNotesInputTextMultiline("##ItemTrackerNotes", &itemTrackerNotes, ImVec2(-FLT_MIN, ImGui::GetContentRegionAvail().y), ImGuiInputTextFlags_AllowTabInput);
-    // ImGui::PopStyleColor();
+    ImVec2 size = resizeable ? ImVec2(-FLT_MIN, ImGui::GetContentRegionAvail().y) : ImVec2(((iconSize + iconSpacing) * 6) - 8, 200);
+    ItemTrackerNotes::TrackerNotesInputTextMultiline("##ItemTrackerNotes", &itemTrackerNotes, size, ImGuiInputTextFlags_AllowTabInput);
     ImGui::EndGroup();
 }
 
@@ -452,9 +485,11 @@ void BeginFloatingWindows(std::string UniqueName, ImGuiWindowFlags flags = 0) {
     }
     ImGui::PushStyleColor(ImGuiCol_WindowBg, ChromaKeyBackground);
     ImGui::PushStyleColor(ImGuiCol_Border, ImVec4(0, 0, 0, 0));
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 4.0f);
     ImGui::Begin(UniqueName.c_str(), nullptr, windowFlags);
 }
 void EndFloatingWindows() {
+    ImGui::PopStyleVar();
     ImGui::PopStyleColor();
     ImGui::PopStyleColor();
     ImGui::End();
@@ -465,87 +500,82 @@ void EndFloatingWindows() {
  * Takes in a vector of ItemTrackerItem and draws them in rows of N items
  */
 void DrawItemsInRows(std::vector<ItemTrackerItem> items, int columns = 6) {
-    int iconSize = CVar_GetS32("gItemTrackerIconSize", 32);
-    int iconSpacing = CVar_GetS32("gItemTrackerIconSpacing", 7);
+    int iconSize = CVar_GetS32("gItemTrackerIconSize", 36);
+    int iconSpacing = CVar_GetS32("gItemTrackerIconSpacing", 12);
+
     for (int i = 0; i < items.size(); i++) {
-        if (i % columns == 0) {
-            ImGui::BeginGroup();
-        } else {
-            ImGui::SameLine(iconSize * (i % columns));
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + iconSpacing * (i % columns));
-        }
+        int row = i / columns;
+        int column = i % columns;
+        ImGui::SetCursorPos(ImVec2((column * (iconSize + iconSpacing) + 8), (row * (iconSize + iconSpacing)) + 8));
         items[i].drawFunc(items[i]);
-        if (i % columns == columns - 1) {
-            ImGui::EndGroup();
-            ImGui::SetCursorPosY(ImGui::GetCursorPosY() + iconSpacing);
-        }
-    }
-    if (items.size() % columns != 0) {
-        ImGui::EndGroup();
     }
 }
 
 /**
- * DrawDungeons
+ * DrawItemsInACircle
+ * Takes in a vector of ItemTrackerItem and draws them evenly spread across a circle
+ */
+void DrawItemsInACircle(std::vector<ItemTrackerItem> items) {
+    int iconSize = CVar_GetS32("gItemTrackerIconSize", 36);
+    int iconSpacing = CVar_GetS32("gItemTrackerIconSpacing", 12);
+
+    ImVec2 max = ImGui::GetWindowContentRegionMax();
+    float radius = (iconSize + iconSpacing) * 2;
+
+    for (int i = 0; i < items.size(); i++) {
+        float angle = (float)i / items.size() * 2.0f * M_PI;
+        float x = (radius / 2.0f) * cos(angle) + max.x / 2.0f;
+        float y = (radius / 2.0f) * sin(angle) + max.y / 2.0f;
+        ImGui::SetCursorPos(ImVec2(x - 14, y + 4));
+        items[i].drawFunc(items[i]);
+    }
+}
+
+/**
+ * GetDungeonItemsVector
  * Loops over dungeons and creates vectors of items in the correct order 
  * to then call DrawItemsInRows
  */
-void DrawDungeons(std::vector<ItemTrackerDungeon> dungeons, int columns = 6) {
-    int iconSize = CVar_GetS32("gItemTrackerIconSize", 32);
-    int iconSpacing = CVar_GetS32("gItemTrackerIconSpacing", 7);
+std::vector<ItemTrackerItem> GetDungeonItemsVector(std::vector<ItemTrackerDungeon> dungeons, int columns = 6) {
+    int iconSize = CVar_GetS32("gItemTrackerIconSize", 36);
+    int iconSpacing = CVar_GetS32("gItemTrackerIconSpacing", 12);
     std::vector<ItemTrackerItem> dungeonItems = {};
 
-    if (!CVar_GetS32("gItemTrackerDisplayDungeonItemsMaps", 1)) {
-        dungeons.erase(std::remove_if(dungeons.begin(), dungeons.end(), [](ItemTrackerDungeon d) { return !d.hasBossKey && !d.hasSmallKey; }), dungeons.end());
-    }
+    // if (!CVar_GetS32("gItemTrackerDisplayDungeonItemsMaps", 1)) {
+    //     dungeons.erase(std::remove_if(dungeons.begin(), dungeons.end(), [](ItemTrackerDungeon d) {
+    //         return (d.id == SCENE_YDAN || d.id == SCENE_DDAN || d.id == SCENE_BDAN || d.id == SCENE_ICE_DOUKUTO);
+    //     }), dungeons.end());
+    // }
 
-    ImGui::BeginGroup();
-    ImGui::NewLine();
-    for (int i = 0; i < MIN(dungeons.size(), columns); i++) {
-        ImGui::SameLine(iconSize * i);
-        ImGui::SetCursorPosX(ImGui::GetCursorPosX() + iconSpacing * i);
-        ImVec2 p = ImGui::GetCursorScreenPos();
-        std::string dungeonName = dungeons[i].shortName;
-
-        ImGui::SetCursorScreenPos(ImVec2(p.x + (iconSize / 2) - (ImGui::CalcTextSize(dungeonName.c_str()).x / 2), p.y - 4));
-        ImGui::Text(dungeonName.c_str());
-    }
-    ImGui::EndGroup();
-    for (int i = 0; i < MIN(dungeons.size(), columns); i++) {
-        if (dungeons[i].hasSmallKey) {
-            dungeonItems.push_back(ITEM_TRACKER_ITEM(ITEM_KEY_SMALL, dungeons[i].id, DrawDungeonItem));
-        } else {
-            dungeonItems.push_back(ITEM_TRACKER_ITEM(ITEM_NONE, 0, DrawItem));
-        }
-    }
-    for (int i = 0; i < MIN(dungeons.size(), columns); i++) {
-        if (dungeons[i].hasBossKey) {
-            dungeonItems.push_back(ITEM_TRACKER_ITEM(ITEM_KEY_BOSS, dungeons[i].id, DrawDungeonItem));
-        } else {
-            dungeonItems.push_back(ITEM_TRACKER_ITEM(ITEM_NONE, 0, DrawItem));
-        }
-    }
-    if (CVar_GetS32("gItemTrackerDisplayDungeonItemsMaps", 1)) {
-        for (int i = 0; i < MIN(dungeons.size(), columns); i++) {
-            if (dungeons[i].hasMap) {
-                dungeonItems.push_back(ITEM_TRACKER_ITEM(ITEM_DUNGEON_MAP, dungeons[i].id, DrawDungeonItem));
-            } else {
-                dungeonItems.push_back(ITEM_TRACKER_ITEM(ITEM_NONE, 0, DrawItem));
-            }
-        }
-        for (int i = 0; i < MIN(dungeons.size(), columns); i++) {
-            if (dungeons[i].hasCompass) {
-                dungeonItems.push_back(ITEM_TRACKER_ITEM(ITEM_COMPASS, dungeons[i].id, DrawDungeonItem));
+    for (int i = 0; i < dungeons[i].items.size(); i++) {
+        for (int j = 0; j < MIN(dungeons.size(), columns); j++) {
+            if (dungeons[j].items.size() > i) {
+                switch (dungeons[j].items[i]) {
+                    case ITEM_KEY_SMALL:
+                        dungeonItems.push_back(ITEM_TRACKER_ITEM(ITEM_KEY_SMALL, dungeons[j].id, DrawDungeonItem));
+                        break;
+                    case ITEM_KEY_BOSS:
+                        dungeonItems.push_back(ITEM_TRACKER_ITEM(ITEM_KEY_BOSS, dungeons[j].id, DrawDungeonItem));
+                        break;
+                    case ITEM_DUNGEON_MAP:
+                        dungeonItems.push_back(ITEM_TRACKER_ITEM(ITEM_DUNGEON_MAP, dungeons[j].id, DrawDungeonItem));
+                        break;
+                    case ITEM_COMPASS:
+                        dungeonItems.push_back(ITEM_TRACKER_ITEM(ITEM_COMPASS, dungeons[j].id, DrawDungeonItem));
+                        break;
+                }
             } else {
                 dungeonItems.push_back(ITEM_TRACKER_ITEM(ITEM_NONE, 0, DrawItem));
             }
         }
     }
-    DrawItemsInRows(dungeonItems, MIN(dungeons.size(), columns));
 
     if (dungeons.size() > columns) {
-        DrawDungeons(std::vector<ItemTrackerDungeon>(dungeons.begin() + columns, dungeons.end()), columns);
+        std::vector<ItemTrackerItem> nextDungeonItems = GetDungeonItemsVector(std::vector<ItemTrackerDungeon>(dungeons.begin() + columns, dungeons.end()), columns);
+        dungeonItems.insert(dungeonItems.end(), nextDungeonItems.begin(), nextDungeonItems.end());
     }
+
+    return dungeonItems;
 }
 
 /* TODO: These need to be moved to a common imgui file */
@@ -588,8 +618,8 @@ void DrawItemTracker(bool& open) {
         CVar_SetS32("gItemTrackerEnabled", 0);
         return;
     }
-    int iconSize = CVar_GetS32("gItemTrackerIconSize", 32);
-    int iconSpacing = CVar_GetS32("gItemTrackerIconSpacing", 7);
+    int iconSize = CVar_GetS32("gItemTrackerIconSize", 36);
+    int iconSpacing = CVar_GetS32("gItemTrackerIconSpacing", 12);
     int comboButton1Mask = buttonMap[CVar_GetS32("gItemTrackerComboButton1", 6)];
     int comboButton2Mask = buttonMap[CVar_GetS32("gItemTrackerComboButton2", 8)];
     bool comboButtonsHeld = buttonsPressed != nullptr && buttonsPressed[0].button & comboButton1Mask && buttonsPressed[0].button & comboButton2Mask;
@@ -604,30 +634,41 @@ void DrawItemTracker(bool& open) {
             (CVar_GetS32("gItemTrackerSongsDisplayType", 1) == 1) ||
             (CVar_GetS32("gItemTrackerDungeonItemsDisplayType", 1) == 1)
         ) {
-            BeginFloatingWindows("Item Tracker##main window");
+            std::vector<ItemTrackerItem> mainWindowItems = {};
             if (CVar_GetS32("gItemTrackerInventoryItemsDisplayType", 1) == 1) {
-                DrawItemsInRows(inventoryItems);
+                mainWindowItems.insert(mainWindowItems.end(), inventoryItems.begin(), inventoryItems.end());
             }
             if (CVar_GetS32("gItemTrackerEquipmentItemsDisplayType", 1) == 1) {
-                DrawItemsInRows(equipmentItems);
+                mainWindowItems.insert(mainWindowItems.end(), equipmentItems.begin(), equipmentItems.end());
             }
             if (CVar_GetS32("gItemTrackerMiscItemsDisplayType", 1) == 1) {
-                DrawItemsInRows(miscItems);
+                mainWindowItems.insert(mainWindowItems.end(), miscItems.begin(), miscItems.end());
             }
             if (CVar_GetS32("gItemTrackerDungeonRewardsDisplayType", 1) == 1) {
                 if (CVar_GetS32("gItemTrackerMiscItemsDisplayType", 1) == 1) {
-                    ImGui::SameLine(iconSize * 3);
-                    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + iconSpacing * 3);
+                    mainWindowItems.push_back(ITEM_TRACKER_ITEM(ITEM_NONE, 0, DrawItem));
                 }
-                DrawItemsInRows(dungeonRewardStones);
-                DrawItemsInRows(dungeonRewardMedallions);
+                mainWindowItems.insert(mainWindowItems.end(), dungeonRewardStones.begin(), dungeonRewardStones.end());
+                mainWindowItems.insert(mainWindowItems.end(), dungeonRewardMedallions.begin(), dungeonRewardMedallions.end());
             }
             if (CVar_GetS32("gItemTrackerSongsDisplayType", 1) == 1) {
-                DrawItemsInRows(songItems);
+                if (CVar_GetS32("gItemTrackerMiscItemsDisplayType", 1) == 1 && CVar_GetS32("gItemTrackerDungeonRewardsDisplayType", 1) != 1) {
+                    mainWindowItems.push_back(ITEM_TRACKER_ITEM(ITEM_NONE, 0, DrawItem));
+                    mainWindowItems.push_back(ITEM_TRACKER_ITEM(ITEM_NONE, 0, DrawItem));
+                    mainWindowItems.push_back(ITEM_TRACKER_ITEM(ITEM_NONE, 0, DrawItem));
+                    mainWindowItems.push_back(ITEM_TRACKER_ITEM(ITEM_NONE, 0, DrawItem));
+                }
+                mainWindowItems.insert(mainWindowItems.end(), songItems.begin(), songItems.end());
             }
             if (CVar_GetS32("gItemTrackerDungeonItemsDisplayType", 2) == 1) {
-                DrawDungeons(itemTrackerDungeons);
+                std::vector<ItemTrackerItem> dungeonItemsTemp = GetDungeonItemsVector(itemTrackerDungeons);
+                dungeonItemsTemp[35] = ITEM_TRACKER_ITEM(ITEM_KEY_SMALL, SCENE_GERUDOWAY, DrawDungeonItem);
+                mainWindowItems.insert(mainWindowItems.end(), dungeonItemsTemp.begin(), dungeonItemsTemp.end());
             }
+
+            BeginFloatingWindows("Item Tracker##main window");
+            DrawItemsInRows(mainWindowItems, 6);
+
             if (CVar_GetS32("gItemTrackerNotesDisplayType", 2) == 1 && CVar_GetS32("gItemTrackerDisplayType", 0) == 0) {
                 DrawNotes();
             }
@@ -642,20 +683,31 @@ void DrawItemTracker(bool& open) {
 
         if (CVar_GetS32("gItemTrackerEquipmentItemsDisplayType", 1) == 2) {
             BeginFloatingWindows("Equipment Items Tracker");
-            DrawItemsInRows(equipmentItems);
+            DrawItemsInRows(equipmentItems, 3);
             EndFloatingWindows();
         }
 
         if (CVar_GetS32("gItemTrackerMiscItemsDisplayType", 1) == 2) {
             BeginFloatingWindows("Misc Items Tracker");
-            DrawItemsInRows(miscItems);
+            DrawItemsInRows(miscItems, 4);
             EndFloatingWindows();
         }
 
         if (CVar_GetS32("gItemTrackerDungeonRewardsDisplayType", 1) == 2) {
             BeginFloatingWindows("Dungeon Rewards Tracker");
-            DrawItemsInRows(dungeonRewardStones);
-            DrawItemsInRows(dungeonRewardMedallions);
+            if (CVar_GetS32("gItemTrackerDungeonRewardsCircle", 0) == 1) {
+                ImGui::BeginGroup();
+                DrawItemsInACircle(dungeonRewardMedallions);
+                ImGui::EndGroup();
+                ImGui::BeginGroup();
+                DrawItemsInRows(dungeonRewardStones);
+                ImGui::EndGroup();
+            } else {
+                std::vector<ItemTrackerItem> dungeonRewardItems = {};
+                dungeonRewardItems.insert(dungeonRewardItems.end(), dungeonRewardMedallions.begin(), dungeonRewardMedallions.end());
+                dungeonRewardItems.insert(dungeonRewardItems.end(), dungeonRewardStones.begin(), dungeonRewardStones.end());
+                DrawItemsInRows(dungeonRewardItems, 3);
+            }
             EndFloatingWindows();
         }
 
@@ -668,16 +720,21 @@ void DrawItemTracker(bool& open) {
         if (CVar_GetS32("gItemTrackerDungeonItemsDisplayType", 2) == 2) {
             BeginFloatingWindows("Dungeon Items Tracker");
             if (CVar_GetS32("gItemTrackerDisplayDungeonItemsHorizontal", 1)) {
-                DrawDungeons(itemTrackerDungeons, 13);
+                std::vector<ItemTrackerItem> dungeonItemsTemp = GetDungeonItemsVector(itemTrackerDungeons, 12);
+                dungeonItemsTemp[23] = ITEM_TRACKER_ITEM(ITEM_KEY_SMALL, SCENE_GERUDOWAY, DrawDungeonItem);
+                DrawItemsInRows(dungeonItemsTemp, 12);
             } else {
-                DrawDungeons(itemTrackerDungeons);
+                std::vector<ItemTrackerItem> dungeonItemsTemp = GetDungeonItemsVector(itemTrackerDungeons);
+                dungeonItemsTemp[35] = ITEM_TRACKER_ITEM(ITEM_KEY_SMALL, SCENE_GERUDOWAY, DrawDungeonItem);
+                DrawItemsInRows(dungeonItemsTemp);
             }
             EndFloatingWindows();
         }
 
         if (CVar_GetS32("gItemTrackerNotesDisplayType", 2) == 2 && CVar_GetS32("gItemTrackerDisplayType", 0) == 0) {
+            ImGui::SetNextWindowSize(ImVec2(400,300), ImGuiCond_FirstUseEver);
             BeginFloatingWindows("Personal Notes", ImGuiWindowFlags_NoFocusOnAppearing);
-            DrawNotes();
+            DrawNotes(true);
             EndFloatingWindows();
         }
     }
@@ -729,8 +786,8 @@ void DrawItemTrackerOptions(bool& open) {
         PaddedEnhancementCheckbox("Enable Dragging", "gItemTrackerHudEditMode", 0);
     }
     PaddedSeparator();
-    SohImGui::EnhancementSliderInt("Icon size : %dpx", "##ITEMTRACKERICONSIZE", "gItemTrackerIconSize", 25, 128, "", 32, true);
-    SohImGui::EnhancementSliderInt("Icon margins : %dpx", "##ITEMTRACKERSPACING", "gItemTrackerIconSpacing", -5, 50, "", 7, true);
+    SohImGui::EnhancementSliderInt("Icon size : %dpx", "##ITEMTRACKERICONSIZE", "gItemTrackerIconSize", 25, 128, "", 36, true);
+    SohImGui::EnhancementSliderInt("Icon margins : %dpx", "##ITEMTRACKERSPACING", "gItemTrackerIconSpacing", -5, 50, "", 12, true);
     PaddedEnhancementCheckbox("Display \"Current/Max\" values", "gItemTrackerDisplayCurrentMax", 0);
 
     ImGui::TableNextColumn();
@@ -739,13 +796,17 @@ void DrawItemTrackerOptions(bool& open) {
     LabeledComboBoxRightAligned("Equipment", "gItemTrackerEquipmentItemsDisplayType", { "Hidden", "Main Window", "Seperate" }, 1);
     LabeledComboBoxRightAligned("Misc", "gItemTrackerMiscItemsDisplayType", { "Hidden", "Main Window", "Seperate" }, 1);
     LabeledComboBoxRightAligned("Dungeon Rewards", "gItemTrackerDungeonRewardsDisplayType", { "Hidden", "Main Window", "Seperate" }, 1);
+    if (CVar_GetS32("gItemTrackerDungeonRewardsDisplayType", 1) == 2) {
+        PaddedEnhancementCheckbox("Circle display", "gItemTrackerDungeonRewardsCircle", 1);
+    }
     LabeledComboBoxRightAligned("Songs", "gItemTrackerSongsDisplayType", { "Hidden", "Main Window", "Seperate" }, 1);
     LabeledComboBoxRightAligned("Dungeon Items", "gItemTrackerDungeonItemsDisplayType", { "Hidden", "Main Window", "Seperate" }, 2);
     if (CVar_GetS32("gItemTrackerDungeonItemsDisplayType", 2) != 0) {
         if (CVar_GetS32("gItemTrackerDungeonItemsDisplayType", 2) == 2) {
             PaddedEnhancementCheckbox("Horizontal display", "gItemTrackerDisplayDungeonItemsHorizontal", 1);
         }
-        PaddedEnhancementCheckbox("Maps and compasses", "gItemTrackerDisplayDungeonItemsMaps", 1);
+        // TODO: Re-add this, kinda complicated
+        // PaddedEnhancementCheckbox("Maps and compasses", "gItemTrackerDisplayDungeonItemsMaps", 1);
     }
 
     if (CVar_GetS32("gItemTrackerDisplayType", 0) != 1) {

--- a/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
@@ -28,7 +28,6 @@ void DrawItem(ItemTrackerItem item);
 void DrawDungeonItem(ItemTrackerItem item);
 void DrawBottle(ItemTrackerItem item);
 void DrawQuest(ItemTrackerItem item);
-void DrawUpgrade(ItemTrackerItem item);
 void DrawSong(ItemTrackerItem item);
 
 OSContPad* buttonsPressed;
@@ -52,7 +51,7 @@ std::vector<ItemTrackerItem> equipmentItems = {
 };
 
 std::vector<ItemTrackerItem> miscItems = {
-    ITEM_TRACKER_ITEM(UPG_STRENGTH, 0, DrawUpgrade),          ITEM_TRACKER_ITEM(UPG_SCALE, 0, DrawUpgrade),             ITEM_TRACKER_ITEM(ITEM_WALLET_ADULT, 0, DrawItem),
+    ITEM_TRACKER_ITEM(ITEM_BRACELET, 0, DrawItem),            ITEM_TRACKER_ITEM(ITEM_SCALE_SILVER, 0, DrawItem),        ITEM_TRACKER_ITEM(ITEM_WALLET_ADULT, 0, DrawItem),
     ITEM_TRACKER_ITEM(ITEM_HEART_CONTAINER, 0, DrawItem),     ITEM_TRACKER_ITEM(ITEM_MAGIC_SMALL, 0, DrawItem),         ITEM_TRACKER_ITEM(QUEST_STONE_OF_AGONY, 1 << 21, DrawQuest),
     ITEM_TRACKER_ITEM(QUEST_GERUDO_CARD, 1 << 22, DrawQuest), ITEM_TRACKER_ITEM(QUEST_SKULL_TOKEN, 1 << 23, DrawQuest),
 };
@@ -89,29 +88,187 @@ std::vector<ItemTrackerDungeon> itemTrackerDungeons = {
     ITEM_TRACKER_DUNGEON(SCENE_GERUDOWAY, "HIDE", false, false, false, true),
 };
 
-typedef struct {
-    uint32_t id;
-    std::string name;
-    std::string nameFaded;
-    uint32_t bitMask;
-} ItemTrackerMapEntry;
+std::unordered_map<uint32_t, ItemTrackerItem> actualItemTrackerItemMap = {
+    { ITEM_BOTTLE, ITEM_TRACKER_ITEM(ITEM_BOTTLE, 0, DrawItem) },
+    { ITEM_BIG_POE, ITEM_TRACKER_ITEM(ITEM_BIG_POE, 0, DrawItem) },
+    { ITEM_BOTTLE_WITH_BIG_POE, ITEM_TRACKER_ITEM(ITEM_BOTTLE_WITH_BIG_POE, 0, DrawItem) },
+    { ITEM_BLUE_FIRE, ITEM_TRACKER_ITEM(ITEM_BLUE_FIRE, 0, DrawItem) },
+    { ITEM_BOTTLE_WITH_BLUE_FIRE, ITEM_TRACKER_ITEM(ITEM_BOTTLE_WITH_BLUE_FIRE, 0, DrawItem) },
+    { ITEM_BUG, ITEM_TRACKER_ITEM(ITEM_BUG, 0, DrawItem) },
+    { ITEM_BOTTLE_WITH_BUGS, ITEM_TRACKER_ITEM(ITEM_BOTTLE_WITH_BUGS, 0, DrawItem) },
+    { ITEM_FAIRY, ITEM_TRACKER_ITEM(ITEM_FAIRY, 0, DrawItem) },
+    { ITEM_BOTTLE_WITH_FAIRY, ITEM_TRACKER_ITEM(ITEM_BOTTLE_WITH_FAIRY, 0, DrawItem) },
+    { ITEM_FISH, ITEM_TRACKER_ITEM(ITEM_FISH, 0, DrawItem) },
+    { ITEM_BOTTLE_WITH_FISH, ITEM_TRACKER_ITEM(ITEM_BOTTLE_WITH_FISH, 0, DrawItem) },
+    { ITEM_POTION_GREEN, ITEM_TRACKER_ITEM(ITEM_POTION_GREEN, 0, DrawItem) },
+    { ITEM_BOTTLE_WITH_GREEN_POTION, ITEM_TRACKER_ITEM(ITEM_BOTTLE_WITH_GREEN_POTION, 0, DrawItem) },
+    { ITEM_POE, ITEM_TRACKER_ITEM(ITEM_POE, 0, DrawItem) },
+    { ITEM_BOTTLE_WITH_POE, ITEM_TRACKER_ITEM(ITEM_BOTTLE_WITH_POE, 0, DrawItem) },
+    { ITEM_POTION_RED, ITEM_TRACKER_ITEM(ITEM_POTION_RED, 0, DrawItem) },
+    { ITEM_BOTTLE_WITH_RED_POTION, ITEM_TRACKER_ITEM(ITEM_BOTTLE_WITH_RED_POTION, 0, DrawItem) },
+    { ITEM_POTION_BLUE, ITEM_TRACKER_ITEM(ITEM_POTION_BLUE, 0, DrawItem) },
+    { ITEM_BOTTLE_WITH_BLUE_POTION, ITEM_TRACKER_ITEM(ITEM_BOTTLE_WITH_BLUE_POTION, 0, DrawItem) },
+    { ITEM_MILK, ITEM_TRACKER_ITEM(ITEM_MILK, 0, DrawItem) },
+    { ITEM_MILK_BOTTLE, ITEM_TRACKER_ITEM(ITEM_MILK_BOTTLE, 0, DrawItem) },
+    { ITEM_MILK_HALF, ITEM_TRACKER_ITEM(ITEM_MILK_HALF, 0, DrawItem) },
+    { ITEM_LETTER_RUTO, ITEM_TRACKER_ITEM(ITEM_LETTER_RUTO, 0, DrawItem) },
 
-#define ITEM_TRACKER_MAP_ENTRY(id, maskShift)     \
-    {                                             \
-        id, {                                     \
-            id, #id, #id "_Faded", 1 << maskShift \
-        }                                         \
+    { ITEM_HOOKSHOT, ITEM_TRACKER_ITEM(ITEM_HOOKSHOT, 0, DrawItem) },
+    { ITEM_LONGSHOT, ITEM_TRACKER_ITEM(ITEM_LONGSHOT, 0, DrawItem) },
+
+    { ITEM_OCARINA_FAIRY, ITEM_TRACKER_ITEM(ITEM_OCARINA_FAIRY, 0, DrawItem) },
+    { ITEM_OCARINA_TIME, ITEM_TRACKER_ITEM(ITEM_OCARINA_TIME, 0, DrawItem) },
+
+    { ITEM_MAGIC_SMALL, ITEM_TRACKER_ITEM(ITEM_MAGIC_SMALL, 0, DrawItem) },
+    { ITEM_MAGIC_LARGE, ITEM_TRACKER_ITEM(ITEM_MAGIC_LARGE, 0, DrawItem) },
+
+    { ITEM_WALLET_ADULT, ITEM_TRACKER_ITEM(ITEM_WALLET_ADULT, 0, DrawItem) },
+    { ITEM_WALLET_GIANT, ITEM_TRACKER_ITEM(ITEM_WALLET_GIANT, 0, DrawItem) },
+
+    { ITEM_BRACELET, ITEM_TRACKER_ITEM(ITEM_BRACELET, 0, DrawItem) },
+    { ITEM_GAUNTLETS_SILVER, ITEM_TRACKER_ITEM(ITEM_GAUNTLETS_SILVER, 0, DrawItem) },
+    { ITEM_GAUNTLETS_GOLD, ITEM_TRACKER_ITEM(ITEM_GAUNTLETS_GOLD, 0, DrawItem) },
+
+    { ITEM_SCALE_SILVER, ITEM_TRACKER_ITEM(ITEM_SCALE_SILVER, 0, DrawItem) },
+    { ITEM_SCALE_GOLDEN, ITEM_TRACKER_ITEM(ITEM_SCALE_GOLDEN, 0, DrawItem) },
+
+    { ITEM_WEIRD_EGG, ITEM_TRACKER_ITEM(ITEM_WEIRD_EGG, 0, DrawItem) },
+    { ITEM_CHICKEN, ITEM_TRACKER_ITEM(ITEM_CHICKEN, 0, DrawItem) },
+    { ITEM_LETTER_ZELDA, ITEM_TRACKER_ITEM(ITEM_LETTER_ZELDA, 0, DrawItem) },
+    { ITEM_MASK_KEATON, ITEM_TRACKER_ITEM(ITEM_MASK_KEATON, 0, DrawItem) },
+    { ITEM_MASK_SKULL, ITEM_TRACKER_ITEM(ITEM_MASK_SKULL, 0, DrawItem) },
+    { ITEM_MASK_SPOOKY, ITEM_TRACKER_ITEM(ITEM_MASK_SPOOKY, 0, DrawItem) },
+    { ITEM_MASK_BUNNY, ITEM_TRACKER_ITEM(ITEM_MASK_BUNNY, 0, DrawItem) },
+    { ITEM_MASK_GORON, ITEM_TRACKER_ITEM(ITEM_MASK_GORON, 0, DrawItem) },
+    { ITEM_MASK_ZORA, ITEM_TRACKER_ITEM(ITEM_MASK_ZORA, 0, DrawItem) },
+    { ITEM_MASK_GERUDO, ITEM_TRACKER_ITEM(ITEM_MASK_GERUDO, 0, DrawItem) },
+    { ITEM_MASK_TRUTH, ITEM_TRACKER_ITEM(ITEM_MASK_TRUTH, 0, DrawItem) },
+    { ITEM_SOLD_OUT, ITEM_TRACKER_ITEM(ITEM_SOLD_OUT, 0, DrawItem) },
+
+    { ITEM_POCKET_EGG, ITEM_TRACKER_ITEM(ITEM_POCKET_EGG, 0, DrawItem) },
+    { ITEM_POCKET_CUCCO, ITEM_TRACKER_ITEM(ITEM_POCKET_CUCCO, 0, DrawItem) },
+    { ITEM_COJIRO, ITEM_TRACKER_ITEM(ITEM_COJIRO, 0, DrawItem) },
+    { ITEM_ODD_MUSHROOM, ITEM_TRACKER_ITEM(ITEM_ODD_MUSHROOM, 0, DrawItem) },
+    { ITEM_ODD_POTION, ITEM_TRACKER_ITEM(ITEM_ODD_POTION, 0, DrawItem) },
+    { ITEM_SAW, ITEM_TRACKER_ITEM(ITEM_SAW, 0, DrawItem) },
+    { ITEM_SWORD_BROKEN, ITEM_TRACKER_ITEM(ITEM_SWORD_BROKEN, 0, DrawItem) },
+    { ITEM_PRESCRIPTION, ITEM_TRACKER_ITEM(ITEM_PRESCRIPTION, 0, DrawItem) },
+    { ITEM_FROG, ITEM_TRACKER_ITEM(ITEM_FROG, 0, DrawItem) },
+    { ITEM_EYEDROPS, ITEM_TRACKER_ITEM(ITEM_EYEDROPS, 0, DrawItem) },
+    { ITEM_CLAIM_CHECK, ITEM_TRACKER_ITEM(ITEM_CLAIM_CHECK, 0, DrawItem) },
+};
+
+ImVec2 GetItemCurrentAndMax(ItemTrackerItem item) {
+    ImVec2 result = { 0, 0 };
+
+    switch (item.id) {
+        case ITEM_STICK:
+            result.x = CUR_CAPACITY(UPG_STICKS);
+            result.y = 30;
+            break;
+        case ITEM_NUT:
+            result.x = CUR_CAPACITY(UPG_NUTS);
+            result.y = 40;
+            break;
+        case ITEM_BOMB:
+            result.x = CUR_CAPACITY(UPG_BOMB_BAG);
+            result.y = 40;
+            break;
+        case ITEM_BOW:
+            result.x = CUR_CAPACITY(UPG_QUIVER);
+            result.y = 50;
+            break;
+        case ITEM_SLINGSHOT:
+            result.x = CUR_CAPACITY(UPG_BULLET_BAG);
+            result.y = 50;
+            break;
+        case ITEM_WALLET_ADULT:
+        case ITEM_WALLET_GIANT:
+            result.x = CUR_CAPACITY(UPG_WALLET);
+            result.y = 500;
+            break;
+        case ITEM_BEAN:
+            result.x = AMMO(ITEM_BEAN);
+            result.y = 10;
+            break;
+        case QUEST_SKULL_TOKEN:
+            result.x = gSaveContext.inventory.gsTokens;
+            result.y = 100;
+            break;
+        case ITEM_KEY_SMALL:
+            result.x = gSaveContext.inventory.dungeonKeys[item.data];
+            switch (item.data) {
+                case SCENE_BMORI1:
+                    result.y = 5;
+                    break;
+                case SCENE_HIDAN:
+                    result.y = 8;
+                    break;
+                case SCENE_MIZUSIN:
+                    result.y = 6;
+                    break;
+                case SCENE_JYASINZOU:
+                    result.y = 5;
+                    break;
+                case SCENE_HAKADAN:
+                    result.y = 5;
+                    break;
+                case SCENE_HAKADANCH:
+                    result.y = 3;
+                    break;
+                case SCENE_GANON:
+                    result.y = 2;
+                    break;
+                case SCENE_MEN:
+                    result.y = 9;
+                    break;
+                case SCENE_GERUDOWAY:
+                    result.y = 4;
+                    break;
+            }
+            break;
     }
 
-bool IsValidSaveFile() {
-    bool validSave = gSaveContext.fileNum >= 0 && gSaveContext.fileNum <= 2;
-    return validSave;
+    return result;
+}
+
+void DrawItemCount(ItemTrackerItem item) {
+    int iconSize = CVar_GetS32("gItemTrackerIconSize", 32);
+    ImVec2 currentAndMax = GetItemCurrentAndMax(item);
+    ImVec2 p = ImGui::GetCursorScreenPos();
+
+    if (currentAndMax.x > 0) {
+        if (currentAndMax.x >= currentAndMax.y) {
+            std::string currentString = std::to_string((int)currentAndMax.x);
+
+            ImGui::SetCursorScreenPos(ImVec2(p.x + (iconSize / 2) - (ImGui::CalcTextSize(currentString.c_str()).x / 2), p.y - 10));
+            ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(0, 255, 0, 255));
+            ImGui::Text("%d", (int)currentAndMax.x);
+            ImGui::PopStyleColor();
+        } else {
+            if (CVar_GetS32("gItemTrackerDisplayCurrentMax", 0) == 1) {
+                std::string currentAndMaxString = std::to_string((int)currentAndMax.x) + "/" + std::to_string((int)currentAndMax.y);
+
+                ImGui::SetCursorScreenPos(ImVec2(p.x + (iconSize / 2) - (ImGui::CalcTextSize(currentAndMaxString.c_str()).x / 2), p.y - 10));
+                ImGui::Text("%d/", (int)currentAndMax.x);
+                ImGui::SameLine(0, 0.0f);
+                ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(0, 255, 0, 255));
+                ImGui::Text("%d", (int)currentAndMax.y);
+                ImGui::PopStyleColor();
+            } else {
+                std::string currentString = std::to_string((int)currentAndMax.x);
+
+                ImGui::SetCursorScreenPos(ImVec2(p.x + (iconSize / 2) - (ImGui::CalcTextSize(currentString.c_str()).x / 2), p.y - 10));
+                ImGui::Text("%d", (int)currentAndMax.x);
+            }
+        }
+    }
 }
 
 void DrawEquip(ItemTrackerItem item) {
     bool hasEquip = (item.data & gSaveContext.inventory.equipment) != 0;
     int iconSize = CVar_GetS32("gItemTrackerIconSize", 32);
-    ImGui::Image(SohImGui::GetTextureByName(hasEquip && IsValidSaveFile() ? item.name : item.nameFaded),
+    ImGui::Image(SohImGui::GetTextureByName(hasEquip ? item.name : item.nameFaded),
                  ImVec2(iconSize, iconSize), ImVec2(0, 0), ImVec2(1, 1));
 
     SetLastItemHoverText(SohUtils::GetItemName(item.id));
@@ -121,26 +278,11 @@ void DrawQuest(ItemTrackerItem item) {
     bool hasQuestItem = (item.data & gSaveContext.inventory.questItems) != 0;
     int iconSize = CVar_GetS32("gItemTrackerIconSize", 32);
     ImGui::BeginGroup();
-    ImGui::Image(SohImGui::GetTextureByName(hasQuestItem && IsValidSaveFile() ? item.name : item.nameFaded),
+    ImGui::Image(SohImGui::GetTextureByName(hasQuestItem ? item.name : item.nameFaded),
                  ImVec2(iconSize, iconSize), ImVec2(0, 0), ImVec2(1, 1));
 
-    ImVec2 p = ImGui::GetCursorScreenPos();
-    int estimatedTextWidth = 10;
-    int estimatedTextHeight = 10;
-    ImGui::SetCursorScreenPos(ImVec2(p.x + (iconSize / 2) - estimatedTextWidth, p.y - estimatedTextHeight));
-
-    if (item.name == "QUEST_SKULL_TOKEN") {
-        if (gSaveContext.inventory.gsTokens == 0) {
-            ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(155, 155, 155, 255));
-            ImGui::Text("%i", gSaveContext.inventory.gsTokens);
-            ImGui::PopStyleColor();
-        } else if (gSaveContext.inventory.gsTokens >= 1 && gSaveContext.inventory.gsTokens <= 99) {
-            ImGui::Text("%i", gSaveContext.inventory.gsTokens);
-        } else if (gSaveContext.inventory.gsTokens >= 100) {
-            ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(255, 0, 0, 255));
-            ImGui::Text("%i", gSaveContext.inventory.gsTokens);
-            ImGui::PopStyleColor();
-        }
+    if (item.id == QUEST_SKULL_TOKEN) {
+        DrawItemCount(item);
     }
 
     ImGui::EndGroup();
@@ -148,119 +290,12 @@ void DrawQuest(ItemTrackerItem item) {
     SetLastItemHoverText(SohUtils::GetQuestItemName(item.id));
 };
 
-std::unordered_map<uint32_t, ItemTrackerMapEntry> itemTrackerMap = {
-    ITEM_TRACKER_MAP_ENTRY(ITEM_STICK, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_NUT, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_BOMB, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_BOW, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_ARROW_FIRE, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_DINS_FIRE, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_SLINGSHOT, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_OCARINA_FAIRY, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_OCARINA_TIME, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_BOMBCHU, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_HOOKSHOT, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_LONGSHOT, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_ARROW_ICE, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_FARORES_WIND, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_BOOMERANG, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_LENS, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_BEAN, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_HAMMER, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_ARROW_LIGHT, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_NAYRUS_LOVE, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_BOTTLE, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_POTION_RED, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_POTION_GREEN, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_POTION_BLUE, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_FAIRY, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_FISH, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_MILK_BOTTLE, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_LETTER_RUTO, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_BLUE_FIRE, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_BUG, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_BIG_POE, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_MILK_HALF, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_POE, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_WEIRD_EGG, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_CHICKEN, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_LETTER_ZELDA, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_MASK_KEATON, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_MASK_SKULL, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_MASK_SPOOKY, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_MASK_BUNNY, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_MASK_GORON, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_MASK_ZORA, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_MASK_GERUDO, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_MASK_TRUTH, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_SOLD_OUT, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_POCKET_EGG, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_POCKET_CUCCO, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_COJIRO, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_ODD_MUSHROOM, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_ODD_POTION, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_SAW, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_SWORD_BROKEN, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_PRESCRIPTION, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_FROG, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_EYEDROPS, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_CLAIM_CHECK, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_BOW_ARROW_FIRE, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_BOW_ARROW_ICE, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_BOW_ARROW_LIGHT, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_BOTTLE, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_POTION_RED, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_POTION_GREEN, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_POTION_BLUE, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_FAIRY, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_FISH, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_MILK_BOTTLE, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_LETTER_RUTO, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_BLUE_FIRE, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_BUG, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_BIG_POE, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_MILK_HALF, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_POE, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_WEIRD_EGG, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_CHICKEN, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_LETTER_ZELDA, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_MASK_KEATON, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_MASK_SKULL, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_MASK_SPOOKY, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_MASK_BUNNY, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_MASK_GORON, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_MASK_ZORA, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_MASK_GERUDO, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_MASK_TRUTH, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_SOLD_OUT, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_POCKET_EGG, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_POCKET_CUCCO, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_COJIRO, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_ODD_MUSHROOM, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_ODD_POTION, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_SAW, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_SWORD_BROKEN, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_PRESCRIPTION, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_FROG, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_EYEDROPS, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_CLAIM_CHECK, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_HEART_CONTAINER, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_MAGIC_SMALL, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_MAGIC_LARGE, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_WALLET_ADULT, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_WALLET_GIANT, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_DUNGEON_MAP, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_COMPASS, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_KEY_SMALL, 0),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_KEY_BOSS, 0)
-};
-
 void DrawItem(ItemTrackerItem item) {
-    uint32_t itemId = item.id;
-    uint32_t actualItemId = INV_CONTENT(itemId);
+    uint32_t actualItemId = INV_CONTENT(item.id);
     int iconSize = CVar_GetS32("gItemTrackerIconSize", 32);
+    bool hasItem = actualItemId != ITEM_NONE;
 
-    if (itemId == ITEM_NONE) {
+    if (item.id == ITEM_NONE) {
         ImGui::BeginGroup();
         ImVec2 p = ImGui::GetCursorScreenPos();
         ImGui::SetCursorScreenPos(ImVec2(p.x - 5 + (iconSize / 2) - 10, p.y - 10));
@@ -268,293 +303,58 @@ void DrawItem(ItemTrackerItem item) {
         return;
     }
 
-    if (itemId == ITEM_HEART_CONTAINER) {
-        actualItemId = itemId;
-    }
-
-    if (itemId == ITEM_WALLET_ADULT || itemId == ITEM_WALLET_GIANT) {
-        if (CUR_UPG_VALUE(UPG_WALLET) == 2) {
-            actualItemId = ITEM_WALLET_GIANT;
-        } else if (CUR_UPG_VALUE(UPG_WALLET) < 2) {
-            actualItemId = ITEM_WALLET_ADULT;
-        }
-    }
-
-    if (itemId == ITEM_MAGIC_SMALL || itemId == ITEM_MAGIC_LARGE) {
-        if (gSaveContext.magicLevel == 2) {
-            actualItemId = ITEM_MAGIC_LARGE;
-        } else {
-            actualItemId = ITEM_MAGIC_SMALL;
-        }
-    }
-
-    bool hasItem = actualItemId != ITEM_NONE;
-
-    if (itemId == ITEM_HEART_CONTAINER) {
-        if (gSaveContext.doubleDefense) {
-            hasItem = true;
-        } else {
-            hasItem = false;
-        }
-    }
-
-    if (itemId == ITEM_WALLET_ADULT || itemId == ITEM_WALLET_GIANT) {
-        if (CUR_UPG_VALUE(UPG_WALLET) == 0) {
-            hasItem = false;
-        } else {
-            hasItem = true;
-        }
-    }
-
-    if (itemId == ITEM_MAGIC_SMALL || itemId == ITEM_MAGIC_LARGE) {
-        if (gSaveContext.magicLevel == 0) {
-            hasItem = false;
-        } else {
-            hasItem = true;
-        }
-    }
-
-    const ItemTrackerMapEntry& entry = itemTrackerMap[hasItem && IsValidSaveFile() ? actualItemId : itemId];
-
-    ImGui::BeginGroup();
-    ImGui::Image(SohImGui::GetTextureByName(hasItem && IsValidSaveFile() ? entry.name : entry.nameFaded),
-                 ImVec2(iconSize, iconSize), ImVec2(0, 0), ImVec2(1, 1));
-    ImVec2 p = ImGui::GetCursorScreenPos();
-    int estimatedTextWidth = 10;
-    int estimatedTextHeight = 10;
-    ImGui::SetCursorScreenPos(ImVec2(p.x - 5 + (iconSize / 2) - estimatedTextWidth, p.y - estimatedTextHeight));
-
-    if (IsValidSaveFile()) {
-        DrawItemAmmo(actualItemId);
-    } else {
-        ImGui::Text(" ");
-    }
-    ImGui::EndGroup();
-
-    SetLastItemHoverText(SohUtils::GetItemName(entry.id));
-}
-
-void DrawItemAmmo(int itemId) {
-    switch (itemId) {
-        case ITEM_STICK:
-            if (CVar_GetS32("gItemTrackerAmmoDisplay", 0) == 1) {
-                if (AMMO(ITEM_STICK) == CUR_CAPACITY(UPG_STICKS)) {
-                    ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(0, 255, 0, 255));
-                    ImGui::Text("%i", AMMO(ITEM_STICK));
-                    ImGui::SameLine(0, 0.0f);
-                    ImGui::Text("/");
-                    ImGui::PopStyleColor();
-                } else if (AMMO(ITEM_STICK) != 0 || AMMO(ITEM_STICK) == CUR_CAPACITY(UPG_STICKS) - 1) {
-                    ImGui::Text("%i", AMMO(ITEM_STICK));
-                    ImGui::SameLine(0, 0.0f);
-                    ImGui::Text("/");
-                } else if (AMMO(ITEM_STICK) == 0) {
-                    ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(155, 155, 155, 255));
-                    ImGui::Text("%i", AMMO(ITEM_STICK));
-                    ImGui::PopStyleColor();
-                    ImGui::SameLine(0, 0.0f);
-                    ImGui::Text("/");
-                }
-                ImGui::SameLine(0, 0.0f);
-            }
-            ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(0, 255, 0, 255));
-            ImGui::Text("%i", CUR_CAPACITY(UPG_STICKS));
-            ImGui::PopStyleColor();
+    switch (item.id) {
+        case ITEM_HEART_CONTAINER:
+            actualItemId = item.id;
+            hasItem = !!gSaveContext.doubleDefense;
             break;
-        case ITEM_NUT:
-            if (CVar_GetS32("gItemTrackerAmmoDisplay", 0) == 1) {
-                if (AMMO(ITEM_NUT) == CUR_CAPACITY(UPG_NUTS)) {
-                    ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(0, 255, 0, 255));
-                    ImGui::Text("%i", AMMO(ITEM_NUT));
-                    ImGui::SameLine(0, 0.0f);
-                    ImGui::Text("/");
-                    ImGui::PopStyleColor();
-                } else if (AMMO(ITEM_NUT) != 0 || AMMO(ITEM_NUT) == CUR_CAPACITY(UPG_NUTS) - 1) {
-                    ImGui::Text("%i", AMMO(ITEM_NUT));
-                    ImGui::SameLine(0, 0.0f);
-                    ImGui::Text("/");
-                } else if (AMMO(ITEM_NUT) == 0) {
-                    ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(155, 155, 155, 255));
-                    ImGui::Text("%i", AMMO(ITEM_NUT));
-                    ImGui::PopStyleColor();
-                    ImGui::SameLine(0, 0.0f);
-                    ImGui::Text("/");
-                }
-                ImGui::SameLine(0, 0.0f);
-            }
-            ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(0, 255, 0, 255));
-            ImGui::Text("%i", CUR_CAPACITY(UPG_NUTS));
-            ImGui::PopStyleColor();
-            break;
-        case ITEM_BOMB:
-            if (CVar_GetS32("gItemTrackerAmmoDisplay", 0) == 1) {
-                if (AMMO(ITEM_BOMB) == CUR_CAPACITY(UPG_BOMB_BAG)) {
-                    ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(0, 255, 0, 255));
-                    ImGui::Text("%i", AMMO(ITEM_BOMB));
-                    ImGui::SameLine(0, 0.0f);
-                    ImGui::Text("/");
-                    ImGui::PopStyleColor();
-                } else if (AMMO(ITEM_BOMB) != 0 || AMMO(ITEM_BOMB) == CUR_CAPACITY(UPG_BOMB_BAG) - 1) {
-                    ImGui::Text("%i", AMMO(ITEM_BOMB));
-                    ImGui::SameLine(0, 0.0f);
-                    ImGui::Text("/");
-                } else if (AMMO(ITEM_BOMB) == 0) {
-                    ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(155, 155, 155, 255));
-                    ImGui::Text("%i", AMMO(ITEM_BOMB));
-                    ImGui::PopStyleColor();
-                    ImGui::SameLine(0, 0.0f);
-                    ImGui::Text("/");
-                }
-                ImGui::SameLine(0, 0.0f);
-            }
-            ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(0, 255, 0, 255));
-            ImGui::Text("%i", CUR_CAPACITY(UPG_BOMB_BAG));
-            ImGui::PopStyleColor();
-            break;
-
-        case ITEM_BOW:
-            if (CVar_GetS32("gItemTrackerAmmoDisplay", 0) == 1) {
-                if (AMMO(ITEM_BOW) == CUR_CAPACITY(UPG_QUIVER)) {
-                    ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(0, 255, 0, 255));
-                    ImGui::Text("%i", AMMO(ITEM_BOW));
-                    ImGui::SameLine(0, 0.0f);
-                    ImGui::Text("/");
-                    ImGui::PopStyleColor();
-                } else if (AMMO(ITEM_BOW) != 0 || AMMO(ITEM_BOW) == CUR_CAPACITY(UPG_QUIVER) - 1) {
-                    ImGui::Text("%i", AMMO(ITEM_BOW));
-                    ImGui::SameLine(0, 0.0f);
-                    ImGui::Text("/");
-                } else if (AMMO(ITEM_BOW) == 0) {
-                    ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(155, 155, 155, 255));
-                    ImGui::Text("%i", AMMO(ITEM_BOW));
-                    ImGui::PopStyleColor();
-                    ImGui::SameLine(0, 0.0f);
-                    ImGui::Text("/");
-                }
-                ImGui::SameLine(0, 0.0f);
-            }
-            ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(0, 255, 0, 255));
-            ImGui::Text("%i", CUR_CAPACITY(UPG_QUIVER));
-            ImGui::PopStyleColor();
-            break;
-        case ITEM_SLINGSHOT:
-            if (CVar_GetS32("gItemTrackerAmmoDisplay", 0) == 1) {
-                if (AMMO(ITEM_SLINGSHOT) == CUR_CAPACITY(UPG_BULLET_BAG)) {
-                    ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(0, 255, 0, 255));
-                    ImGui::Text("%i", AMMO(ITEM_SLINGSHOT));
-                    ImGui::SameLine(0, 0.0f);
-                    ImGui::Text("/");
-                    ImGui::PopStyleColor();
-                } else if (AMMO(ITEM_SLINGSHOT) != 0 || AMMO(ITEM_SLINGSHOT) == CUR_CAPACITY(UPG_BULLET_BAG) - 1) {
-                    ImGui::Text("%i", AMMO(ITEM_SLINGSHOT));
-                    ImGui::SameLine(0, 0.0f);
-                    ImGui::Text("/");
-                } else if (AMMO(ITEM_SLINGSHOT) == 0) {
-                    ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(155, 155, 155, 255));
-                    ImGui::Text("%i", AMMO(ITEM_SLINGSHOT));
-                    ImGui::PopStyleColor();
-                    ImGui::SameLine(0, 0.0f);
-                    ImGui::Text("/");
-                }
-                ImGui::SameLine(0, 0.0f);
-            }
-            ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(0, 255, 0, 255));
-            ImGui::Text("%i", CUR_CAPACITY(UPG_BULLET_BAG));
-            ImGui::PopStyleColor();
-            break;
-        case ITEM_BOMBCHU:
-            if (AMMO(ITEM_BOMBCHU) == 50) {
-                ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(0, 255, 0, 255));
-                ImGui::Text("%i", AMMO(ITEM_BOMBCHU));
-                if (CVar_GetS32("gItemTrackerAmmoDisplay", 0) == 1) {
-                    ImGui::SameLine(0, 0.0f);
-                    ImGui::Text("/");
-                }
-                ImGui::PopStyleColor();
-            } else if (AMMO(ITEM_BOMBCHU) != 0 || AMMO(ITEM_BOMBCHU) < 50) {
-                ImGui::Text("%i", AMMO(ITEM_BOMBCHU));
-                if (CVar_GetS32("gItemTrackerAmmoDisplay", 0) == 1) {
-                    ImGui::SameLine(0, 0.0f);
-                    ImGui::Text("/");
-                }
-            } else if (AMMO(ITEM_BOMBCHU) == 0) {
-                ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(155, 155, 155, 255));
-                ImGui::Text("%i", AMMO(ITEM_BOMBCHU));
-                ImGui::PopStyleColor();
-                if (CVar_GetS32("gItemTrackerAmmoDisplay", 0) == 1) {
-                    ImGui::SameLine(0, 0.0f);
-                    ImGui::Text("/");
-                }
-            }
-            if (CVar_GetS32("gItemTrackerAmmoDisplay", 0) == 1) {
-                ImGui::SameLine(0, 0.0f);
-                ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(0, 255, 0, 255));
-                ImGui::Text("50");
-                ImGui::PopStyleColor();
-            }
-            break;
-        case ITEM_BEAN:
-            if (AMMO(ITEM_BEAN) == 10) {
-                ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(0, 255, 0, 255));
-                ImGui::Text("%i", AMMO(ITEM_BEAN));
-                if (CVar_GetS32("gItemTrackerAmmoDisplay", 0) == 1) {
-                    ImGui::SameLine(0, 0.0f);
-                    ImGui::Text("/");
-                }
-                ImGui::PopStyleColor();
-            } else if (AMMO(ITEM_BEAN) != 0 || AMMO(ITEM_BEAN) < 10) {
-                ImGui::Text("%i", AMMO(ITEM_BEAN));
-                if (CVar_GetS32("gItemTrackerAmmoDisplay", 0) == 1) {
-                    ImGui::SameLine(0, 0.0f);
-                    ImGui::Text("/");
-                }
-            } else if (AMMO(ITEM_BEAN) == 0) {
-                ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(155, 155, 155, 255));
-                ImGui::Text("%i", AMMO(ITEM_BEAN));
-                ImGui::PopStyleColor();
-                if (CVar_GetS32("gItemTrackerAmmoDisplay", 0) == 1) {
-                    ImGui::SameLine(0, 0.0f);
-                    ImGui::Text("/");
-                }
-            }
-            if (CVar_GetS32("gItemTrackerAmmoDisplay", 0) == 1) {
-                ImGui::SameLine(0, 0.0f);
-                ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(0, 255, 0, 255));
-                ImGui::Text("10");
-                ImGui::PopStyleColor();
-            }
+        case ITEM_MAGIC_SMALL:
+        case ITEM_MAGIC_LARGE:
+            actualItemId = gSaveContext.magicLevel == 2 ? ITEM_MAGIC_LARGE : ITEM_MAGIC_SMALL;
+            hasItem = gSaveContext.magicLevel > 0;
             break;
         case ITEM_WALLET_ADULT:
         case ITEM_WALLET_GIANT:
-            if (CUR_UPG_VALUE(UPG_WALLET) == 0) {
-                ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(0, 255, 0, 255));
-                ImGui::Text("99");
-                ImGui::PopStyleColor();
-            } else if (CUR_UPG_VALUE(UPG_WALLET) == 1) {
-                ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(0, 255, 0, 255));
-                ImGui::Text("200");
-                ImGui::PopStyleColor();
-            } else if (CUR_UPG_VALUE(UPG_WALLET) == 2) {
-                ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(0, 255, 0, 255));
-                ImGui::Text("500");
-                ImGui::PopStyleColor();
-            }
+            actualItemId = CUR_UPG_VALUE(UPG_WALLET) == 2 ? ITEM_WALLET_GIANT : ITEM_WALLET_ADULT;
+            hasItem = true;
             break;
-        default:
-            ImGui::Text(" ");
+        case ITEM_BRACELET:
+        case ITEM_GAUNTLETS_SILVER:
+        case ITEM_GAUNTLETS_GOLD:
+            actualItemId = CUR_UPG_VALUE(UPG_STRENGTH) == 3 ? ITEM_GAUNTLETS_GOLD : CUR_UPG_VALUE(UPG_STRENGTH) == 2 ? ITEM_GAUNTLETS_SILVER : ITEM_BRACELET;
+            hasItem = CUR_UPG_VALUE(UPG_STRENGTH) > 0;
+            break;
+        case ITEM_SCALE_SILVER:
+        case ITEM_SCALE_GOLDEN:
+            actualItemId = CUR_UPG_VALUE(UPG_SCALE) == 2 ? ITEM_SCALE_GOLDEN : ITEM_SCALE_SILVER;
+            hasItem = CUR_UPG_VALUE(UPG_SCALE) > 0;
             break;
     }
+
+    if (hasItem && item.id != actualItemId && actualItemTrackerItemMap.find(actualItemId) != actualItemTrackerItemMap.end()) {
+        item = actualItemTrackerItemMap[actualItemId];
+    }
+    
+    ImGui::BeginGroup();
+    ImGui::Image(SohImGui::GetTextureByName(hasItem ? item.name : item.nameFaded),
+                 ImVec2(iconSize, iconSize), ImVec2(0, 0), ImVec2(1, 1));
+
+    DrawItemCount(item);
+    ImGui::EndGroup();
+
+    SetLastItemHoverText(SohUtils::GetItemName(item.id));
 }
 
 void DrawBottle(ItemTrackerItem item) {
     uint32_t actualItemId = gSaveContext.inventory.items[SLOT(item.id) + item.data];
     bool hasItem = actualItemId != ITEM_NONE;
-    const ItemTrackerMapEntry& entry = itemTrackerMap[hasItem && IsValidSaveFile() ? actualItemId : item.id];
+
+    const ItemTrackerItem& actualItem = actualItemTrackerItemMap[hasItem ? actualItemId : item.id];
     int iconSize = CVar_GetS32("gItemTrackerIconSize", 32);
-    ImGui::Image(SohImGui::GetTextureByName(hasItem && IsValidSaveFile() ? entry.name : entry.nameFaded),
+    ImGui::Image(SohImGui::GetTextureByName(hasItem ? actualItem.name : actualItem.nameFaded),
                  ImVec2(iconSize, iconSize), ImVec2(0, 0), ImVec2(1, 1));
 
-    SetLastItemHoverText(SohUtils::GetItemName(entry.id));
+    SetLastItemHoverText(SohUtils::GetItemName(actualItem.id));
 };
 
 void DrawDungeonItem(ItemTrackerItem item) {
@@ -565,101 +365,32 @@ void DrawDungeonItem(ItemTrackerItem item) {
     bool hasSmallKey = (gSaveContext.inventory.dungeonKeys[item.data]) >= 0;
     ImGui::BeginGroup();
     if (itemId == ITEM_KEY_SMALL) {
-        ImGui::Image(SohImGui::GetTextureByName(hasSmallKey && IsValidSaveFile() ? item.name : item.nameFaded),
+        ImGui::Image(SohImGui::GetTextureByName(hasSmallKey ? item.name : item.nameFaded),
                      ImVec2(iconSize, iconSize), ImVec2(0, 0), ImVec2(1, 1));
     }
     else {
-        ImGui::Image(SohImGui::GetTextureByName(hasItem && IsValidSaveFile() ? item.name : item.nameFaded),
+        ImGui::Image(SohImGui::GetTextureByName(hasItem ? item.name : item.nameFaded),
                      ImVec2(iconSize, iconSize), ImVec2(0, 0), ImVec2(1, 1));
     }
 
-    ImVec2 p = ImGui::GetCursorScreenPos();
-    int estimatedTextWidth = 10;
-    int estimatedTextHeight = 10;
-    ImGui::SetCursorScreenPos(ImVec2(p.x - 5 + (iconSize / 2) - estimatedTextWidth, p.y - estimatedTextHeight));
-
-    if (itemId == ITEM_KEY_SMALL) { // This check there for small key is necessary to get the text position properly and can't be on the same ITEM_KEY chack from the top
-        if (gSaveContext.inventory.dungeonKeys[item.data] <= 0 || !IsValidSaveFile()) {
-            ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(155, 155, 155, 255));
-            ImGui::Text("0");
-            ImGui::PopStyleColor();
-         }
-         else {
-            ImGui::Text("%i", gSaveContext.inventory.dungeonKeys[item.data]);
-         }  
+    if (itemId == ITEM_KEY_SMALL) {
+        DrawItemCount(item);
     }
     ImGui::EndGroup();
 
     SetLastItemHoverText(SohUtils::GetItemName(item.id));
 }
 
-typedef struct {
-    uint8_t id;
-    std::string name;
-    std::string nameFaded;
-} ItemTrackerUpgradeEntry;
-
-#define ITEM_TRACKER_UPGRADE_ENTRY(id) \
-    { id, #id, #id "_Faded" }
-
-std::unordered_map<int32_t, std::vector<ItemTrackerUpgradeEntry>> upgradeTrackerMap = {
-    { UPG_STRENGTH,
-      {
-          ITEM_TRACKER_UPGRADE_ENTRY(ITEM_BRACELET),
-          ITEM_TRACKER_UPGRADE_ENTRY(ITEM_GAUNTLETS_SILVER),
-          ITEM_TRACKER_UPGRADE_ENTRY(ITEM_GAUNTLETS_GOLD),
-      } },
-    { UPG_SCALE,
-      {
-          ITEM_TRACKER_UPGRADE_ENTRY(ITEM_SCALE_SILVER),
-          ITEM_TRACKER_UPGRADE_ENTRY(ITEM_SCALE_GOLDEN),
-      } },
-    { UPG_QUIVER,
-      {
-          ITEM_TRACKER_UPGRADE_ENTRY(ITEM_QUIVER_30),
-          ITEM_TRACKER_UPGRADE_ENTRY(ITEM_QUIVER_40),
-          ITEM_TRACKER_UPGRADE_ENTRY(ITEM_QUIVER_50),
-      } },
-    { UPG_BULLET_BAG,
-      {
-          ITEM_TRACKER_UPGRADE_ENTRY(ITEM_BULLET_BAG_30),
-          ITEM_TRACKER_UPGRADE_ENTRY(ITEM_BULLET_BAG_40),
-          ITEM_TRACKER_UPGRADE_ENTRY(ITEM_BULLET_BAG_50),
-      } },
-    { UPG_BOMB_BAG,
-      {
-          ITEM_TRACKER_UPGRADE_ENTRY(ITEM_BOMB_BAG_20),
-          ITEM_TRACKER_UPGRADE_ENTRY(ITEM_BOMB_BAG_30),
-          ITEM_TRACKER_UPGRADE_ENTRY(ITEM_BOMB_BAG_40),
-      } },
-
-};
-
-void DrawUpgrade(ItemTrackerItem item) {
-    uint32_t categoryId = item.id;
-    int iconSize = CVar_GetS32("gItemTrackerIconSize", 32);
-    if (CUR_UPG_VALUE(categoryId) == 0 || !IsValidSaveFile()) {
-        const ItemTrackerUpgradeEntry& entry = upgradeTrackerMap[categoryId][0];
-        ImGui::Image(SohImGui::GetTextureByName(entry.nameFaded), ImVec2(iconSize, iconSize), ImVec2(0, 0),
-                     ImVec2(1, 1));
-        SetLastItemHoverText(SohUtils::GetItemName(entry.id));
-    } else {
-        const ItemTrackerUpgradeEntry& entry = upgradeTrackerMap[categoryId][CUR_UPG_VALUE(categoryId) - 1];
-        ImGui::Image(SohImGui::GetTextureByName(entry.name), ImVec2(iconSize, iconSize), ImVec2(0, 0), ImVec2(1, 1));
-        SetLastItemHoverText(SohUtils::GetItemName(entry.id));
-    }
-}
-
 void DrawSong(ItemTrackerItem item) {
     int iconSize = CVar_GetS32("gItemTrackerIconSize", 32);
     uint32_t bitMask = 1 << item.id;
     bool hasSong = (bitMask & gSaveContext.inventory.questItems) != 0;
-    ImGui::Image(SohImGui::GetTextureByName(hasSong && IsValidSaveFile() ? item.name : item.nameFaded),
+    ImGui::Image(SohImGui::GetTextureByName(hasSong ? item.name : item.nameFaded),
                  ImVec2(iconSize / 1.5, iconSize), ImVec2(0, 0), ImVec2(1, 1));
     SetLastItemHoverText(SohUtils::GetQuestItemName(item.id));
 }
 
-void DrawFloatingNotes(int Icon_Cells_Size, int Icon_Spacing) {
+void DrawFloatingNotes(int iconSize, int iconSpacing) {
     if (CVar_GetS32("gItemTrackerNotes", 0)) {
         ImGui::BeginGroup();
             struct ItemTrackerNotes {
@@ -718,19 +449,19 @@ void EndFloatingWindows() {
  * Takes in a vector of ItemTrackerItem and draws them in rows of N items
  */
 void DrawItemsInRows(std::vector<ItemTrackerItem> items, int columns = 6) {
-    int Icon_Cells_Size = CVar_GetS32("gItemTrackerIconSize", 32);
-    int Icon_Spacing = CVar_GetS32("gItemTrackerIconSpacing", 0);
+    int iconSize = CVar_GetS32("gItemTrackerIconSize", 32);
+    int iconSpacing = CVar_GetS32("gItemTrackerIconSpacing", 0);
     for (int i = 0; i < items.size(); i++) {
         if (i % columns == 0) {
             ImGui::BeginGroup();
         } else {
-            ImGui::SameLine(Icon_Cells_Size * (i % columns));
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * (i % columns));
+            ImGui::SameLine(iconSize * (i % columns));
+            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + iconSpacing * (i % columns));
         }
         items[i].drawFunc(items[i]);
         if (i % columns == columns - 1) {
             ImGui::EndGroup();
-            ImGui::SetCursorPosY(ImGui::GetCursorPosY() + Icon_Spacing);
+            ImGui::SetCursorPosY(ImGui::GetCursorPosY() + iconSpacing);
         }
     }
     if (items.size() % columns != 0) {
@@ -744,8 +475,8 @@ void DrawItemsInRows(std::vector<ItemTrackerItem> items, int columns = 6) {
  * to then call DrawItemsInRows
  */
 void DrawDungeons(std::vector<ItemTrackerDungeon> dungeons, int columns = 6) {
-    int Icon_Cells_Size = CVar_GetS32("gItemTrackerIconSize", 32);
-    int Icon_Spacing = CVar_GetS32("gItemTrackerIconSpacing", 0);
+    int iconSize = CVar_GetS32("gItemTrackerIconSize", 32);
+    int iconSpacing = CVar_GetS32("gItemTrackerIconSpacing", 0);
     std::vector<ItemTrackerItem> dungeonItems = {};
 
     if (!CVar_GetS32("gItemTrackerDisplayDungeonItemsMaps", 0)) {
@@ -755,10 +486,10 @@ void DrawDungeons(std::vector<ItemTrackerDungeon> dungeons, int columns = 6) {
     ImGui::BeginGroup();
     ImGui::NewLine();
     for (int i = 0; i < MIN(dungeons.size(), columns); i++) {
-        ImGui::SameLine(Icon_Cells_Size * i);
-        ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * i);
+        ImGui::SameLine(iconSize * i);
+        ImGui::SetCursorPosX(ImGui::GetCursorPosX() + iconSpacing * i);
         ImVec2 p = ImGui::GetCursorScreenPos();
-        ImGui::SetCursorScreenPos(ImVec2(p.x - 5 + (Icon_Cells_Size / 2) - 10, p.y - 4));
+        ImGui::SetCursorScreenPos(ImVec2(p.x - 5 + (iconSize / 2) - 10, p.y - 4));
         ImGui::Text(dungeons[i].shortName.c_str());
     }
     ImGui::EndGroup();
@@ -799,74 +530,107 @@ void DrawDungeons(std::vector<ItemTrackerDungeon> dungeons, int columns = 6) {
     }
 }
 
+void LabeledComboBoxRightAligned(const char* label, const char* cvar, std::vector<std::string> options, s32 defaultValue) {
+    s32 currentValue = CVar_GetS32(cvar, defaultValue);
+    std::string hiddenLabel = "##" + std::string(cvar);
+    ImGui::Text(label);
+    ImGui::SameLine(ImGui::GetContentRegionAvail().x - (ImGui::CalcTextSize(options[currentValue].c_str()).x * 2.0f) + 8.0f);
+    ImGui::PushItemWidth(ImGui::CalcTextSize(options[currentValue].c_str()).x * 2.0f);
+    if (ImGui::BeginCombo(hiddenLabel.c_str(), options[currentValue].c_str())) {
+        for (int i = 0; i < options.size(); i++) {
+            if (ImGui::Selectable(options[i].c_str())) {
+                CVar_SetS32(cvar, i);
+                SohImGui::needs_save = true;
+            }
+        }
+
+        ImGui::EndCombo();
+    }
+    ImGui::PopItemWidth();
+}
+
+bool IsValidSaveFile() {
+    bool validSave = gSaveContext.fileNum >= 0 && gSaveContext.fileNum <= 2;
+    return validSave;
+}
+
 void DrawItemTracker(bool& open) {
     if (!open) {
         return;
     }
-    int Icon_Cells_Size = CVar_GetS32("gItemTrackerIconSize", 32);
-    int Icon_Spacing = CVar_GetS32("gItemTrackerIconSpacing", 0);
+    int iconSize = CVar_GetS32("gItemTrackerIconSize", 32);
+    int iconSpacing = CVar_GetS32("gItemTrackerIconSpacing", 0);
 
-    if (CVar_GetS32("gItemTrackerHotKeyShow", 0) == 0 ? CVar_GetS32("gItemTrackerEnabled", 0) : buttonsPressed[0].button & BTN_L) {
-        BeginFloatingWindows("Item Tracker#window");
-        if (CVar_GetS32("gItemTrackerDisplayInventory", 0) && !CVar_GetS32("gItemTrackerDisplayInventorySeparate", 0)) {
-            DrawItemsInRows(inventoryItems);
-        }
-        if (CVar_GetS32("gItemTrackerDisplayEquipment", 0) && !CVar_GetS32("gItemTrackerDisplayEquipmentSeparate", 0)) {
-            DrawItemsInRows(equipmentItems);
-        }
-        if (CVar_GetS32("gItemTrackerDisplayMisc", 0) && !CVar_GetS32("gItemTrackerDisplayMiscSeparate", 0)) {
-            DrawItemsInRows(miscItems);
-        }
-        if (CVar_GetS32("gItemTrackerDisplayDungeonRewards", 0) && !CVar_GetS32("gItemTrackerDisplayDungeonRewardsSeparate", 0)) {
-            if (CVar_GetS32("gItemTrackerDisplayMisc", 0) && !CVar_GetS32("gItemTrackerDisplayMiscSeparate", 0)) {
-                ImGui::SameLine(Icon_Cells_Size * 3);
-                ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 3);
+    if (IsValidSaveFile() && CVar_GetS32("gItemTrackerHotKeyShow", 0) == 0 ? CVar_GetS32("gItemTrackerEnabled", 0) : buttonsPressed[0].button & BTN_L) {
+        if (
+            (CVar_GetS32("gItemTrackerInventoryItemsDisplayType", 1) == 1) ||
+            (CVar_GetS32("gItemTrackerEquipmentItemsDisplayType", 1) == 1) ||
+            (CVar_GetS32("gItemTrackerMiscItemsDisplayType", 1) == 1) ||
+            (CVar_GetS32("gItemTrackerDungeonRewardsDisplayType", 1) == 1) ||
+            (CVar_GetS32("gItemTrackerSongsDisplayType", 1) == 1) ||
+            (CVar_GetS32("gItemTrackerDungeonItemsDisplayType", 1) == 1)
+        ) {
+            BeginFloatingWindows("Item Tracker##main window");
+            if (CVar_GetS32("gItemTrackerInventoryItemsDisplayType", 1) == 1) {
+                DrawItemsInRows(inventoryItems);
             }
-            DrawItemsInRows(dungeonRewardStones);
-            DrawItemsInRows(dungeonRewardMedallions);
+            if (CVar_GetS32("gItemTrackerEquipmentItemsDisplayType", 1) == 1) {
+                DrawItemsInRows(equipmentItems);
+            }
+            if (CVar_GetS32("gItemTrackerMiscItemsDisplayType", 1) == 1) {
+                DrawItemsInRows(miscItems);
+            }
+            if (CVar_GetS32("gItemTrackerDungeonRewardsDisplayType", 1) == 1) {
+                if (CVar_GetS32("gItemTrackerMiscItemsDisplayType", 1) == 1) {
+                    ImGui::SameLine(iconSize * 3);
+                    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + iconSpacing * 3);
+                }
+                DrawItemsInRows(dungeonRewardStones);
+                DrawItemsInRows(dungeonRewardMedallions);
+            }
+            if (CVar_GetS32("gItemTrackerSongsDisplayType", 1) == 1) {
+                DrawItemsInRows(songItems);
+            }
+            if (CVar_GetS32("gItemTrackerDungeonItemsDisplayType", 2) == 1) {
+                DrawDungeons(itemTrackerDungeons);
+            }
+            EndFloatingWindows();
         }
-        if (CVar_GetS32("gItemTrackerDisplaySongs", 0) && !CVar_GetS32("gItemTrackerDisplaySongsSeparate", 0)) {
-            DrawItemsInRows(songItems);
-        }
-        if (CVar_GetS32("gItemTrackerDisplayDungeonItems", 0) && !CVar_GetS32("gItemTrackerDisplayDungeonItemsSeparate", 0)) {
-            DrawDungeons(itemTrackerDungeons);
-        }
-        EndFloatingWindows();
 
-        if (CVar_GetS32("gItemTrackerDisplayInventory", 0) && CVar_GetS32("gItemTrackerDisplayInventorySeparate", 0)) {
+        if (CVar_GetS32("gItemTrackerInventoryItemsDisplayType", 1) == 2) {
             BeginFloatingWindows("Inventory Items Tracker");
             DrawItemsInRows(inventoryItems);
             EndFloatingWindows();
         }
 
-        if (CVar_GetS32("gItemTrackerDisplayEquipment", 0) && CVar_GetS32("gItemTrackerDisplayEquipmentSeparate", 0)) {
+        if (CVar_GetS32("gItemTrackerEquipmentItemsDisplayType", 1) == 2) {
             BeginFloatingWindows("Equipment Items Tracker");
             DrawItemsInRows(equipmentItems);
             EndFloatingWindows();
         }
 
-        if (CVar_GetS32("gItemTrackerDisplayMisc", 0) && CVar_GetS32("gItemTrackerDisplayMiscSeparate", 0)) {
+        if (CVar_GetS32("gItemTrackerMiscItemsDisplayType", 1) == 2) {
             BeginFloatingWindows("Misc Items Tracker");
             DrawItemsInRows(miscItems);
             EndFloatingWindows();
         }
 
-        if (CVar_GetS32("gItemTrackerDisplayDungeonRewards", 0) && CVar_GetS32("gItemTrackerDisplayDungeonRewardsSeparate", 0)) {
+        if (CVar_GetS32("gItemTrackerDungeonRewardsDisplayType", 1) == 2) {
             BeginFloatingWindows("Dungeon Rewards Tracker");
             DrawItemsInRows(dungeonRewardStones);
             DrawItemsInRows(dungeonRewardMedallions);
             EndFloatingWindows();
         }
 
-        if (CVar_GetS32("gItemTrackerDisplaySongs", 0) && CVar_GetS32("gItemTrackerDisplaySongsSeparate", 0)) {
+        if (CVar_GetS32("gItemTrackerSongsDisplayType", 1) == 2) {
             BeginFloatingWindows("Songs Tracker");
             DrawItemsInRows(songItems);
             EndFloatingWindows();
         }
 
-        if (CVar_GetS32("gItemTrackerDisplayDungeonItems", 0) && CVar_GetS32("gItemTrackerDisplayDungeonItemsSeparate", 0)) {
+        if (CVar_GetS32("gItemTrackerDungeonItemsDisplayType", 2) == 2) {
             BeginFloatingWindows("Dungeon Items Tracker");
-            if (CVar_GetS32("gItemTrackerDisplayDungeonItemsHorizontal", 0)) {
+            if (CVar_GetS32("gItemTrackerDisplayDungeonItemsHorizontal", 1)) {
                 DrawDungeons(itemTrackerDungeons, 13);
             } else {
                 DrawDungeons(itemTrackerDungeons);
@@ -882,97 +646,65 @@ void DrawItemTrackerOptions(bool& open) {
         return;
     }
 
-    ImGui::SetNextWindowSize(ImVec2(240, 285), ImGuiCond_FirstUseEver);
+    ImGui::SetNextWindowSize(ImVec2(600,360), ImGuiCond_FirstUseEver);
 
     if (!ImGui::Begin("Item Tracker Settings", &open, ImGuiWindowFlags_NoFocusOnAppearing)) {
         ImGui::End();
         return;
     }
 
-    SohImGui::PaddedText("Hotkey");
+    ImGui::PushStyleVar(ImGuiStyleVar_CellPadding, { 8.0f, 8.0f });
+    ImGui::BeginTable("itemTrackerSettingsTable", 2, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV);
+    ImGui::TableSetupColumn("General settings", ImGuiTableColumnFlags_WidthStretch, 200.0f);
+    ImGui::TableSetupColumn("Section settings", ImGuiTableColumnFlags_WidthStretch, 200.0f);
+    ImGui::TableHeadersRow();
+    ImGui::TableNextRow();
+
+    ImGui::TableNextColumn();
     SohImGui::PaddedEnhancementCheckbox("L Button to show Item Tracker", "gItemTrackerHotKeyShow", 0);
     if (CVar_GetS32("gItemTrackerHotKeyShow", 0)) {
-        if (ImGui::BeginCombo("Button Type", CVar_GetS32("gItemTrackerHotKeyShowType", 0) == 0 ? "Hold" : "Toggle")) {
-            if (ImGui::Selectable("Hold")) {
-                CVar_SetS32("gItemTrackerHotKeyShowType", 0);
-            }
-            if (ImGui::Selectable("Toggle")) {
-                CVar_SetS32("gItemTrackerHotKeyShowType", 1);
-            }
-
-            ImGui::EndCombo();
-        }
         SohImGui::PaddedEnhancementCheckbox("Only enable while paused", "gItemTrackerHotKeyShowOnlyPaused", 0);
     }
-
-    SohImGui::PaddedText("Window");
+    PaddedSeparator();
+    ImGui::Text("BG Color");
+    ImGui::SameLine();
     ImGui::PushItemWidth(ImGui::GetContentRegionAvail().x);
-    if (ImGui::ColorEdit4("Background Color", (float*)&ChromaKeyBackground, ImGuiColorEditFlags_AlphaPreview | ImGuiColorEditFlags_AlphaBar | ImGuiColorEditFlags_NoLabel)) {
+    if (ImGui::ColorEdit4("BG Color##gItemTrackerBgColor", (float*)&ChromaKeyBackground, ImGuiColorEditFlags_AlphaPreview | ImGuiColorEditFlags_AlphaBar | ImGuiColorEditFlags_NoLabel)) {
         CVar_SetFloat("gItemTrackerBgColorR", ChromaKeyBackground.x);
         CVar_SetFloat("gItemTrackerBgColorG", ChromaKeyBackground.y);
         CVar_SetFloat("gItemTrackerBgColorB", ChromaKeyBackground.z);
         CVar_SetFloat("gItemTrackerBgColorA", ChromaKeyBackground.w);
+        SohImGui::needs_save = true;
     }
-    ImGui::PushItemWidth(0);
-    if (ImGui::BeginCombo("Window Type", CVar_GetS32("gItemTrackerWindowType", 0) == 0 ? "Floating" : "Window")) {
-        if (ImGui::Selectable("Floating")) {
-            CVar_SetS32("gItemTrackerWindowType", 0);
-        }
-        if (ImGui::Selectable("Window")) {
-            CVar_SetS32("gItemTrackerWindowType", 1);
-        }
+    ImGui::PopItemWidth();
 
-        ImGui::EndCombo();
-    }
+    LabeledComboBoxRightAligned("Window Type", "gItemTrackerWindowType", { "Floating", "Window" }, 0);
+
     if (CVar_GetS32("gItemTrackerWindowType", 0) == 0) {
         SohImGui::PaddedEnhancementCheckbox("Enable Dragging", "gItemTrackerHudEditMode", 0);
     }
-
-    SohImGui::PaddedText("Icons");
+    PaddedSeparator();
     SohImGui::EnhancementSliderInt("Icon size : %dpx", "##ITEMTRACKERICONSIZE", "gItemTrackerIconSize", 25, 128, "", 32, true);
     SohImGui::EnhancementSliderInt("Icon margins : %dpx", "##ITEMTRACKERSPACING", "gItemTrackerIconSpacing", -5, 50, "", 0, true);
-    SohImGui::PaddedEnhancementCheckbox("Display \"Current/Max\" values on items", "gItemTrackerDisplayCurrentMax", 0);
+    SohImGui::PaddedEnhancementCheckbox("Display \"Current/Max\" values", "gItemTrackerDisplayCurrentMax", 0);
 
-    SohImGui::PaddedText("Items");
-    SohImGui::PaddedEnhancementCheckbox("Display general items in tracker", "gItemTrackerDisplayInventory", 0);
-    if (CVar_GetS32("gItemTrackerDisplayInventory", 0)) {
-        SohImGui::PaddedEnhancementCheckbox("Display general items in separate window", "gItemTrackerDisplayInventorySeparate", 0);
-    }
+    ImGui::TableNextColumn();
 
-    SohImGui::PaddedText("Equipment");
-    SohImGui::PaddedEnhancementCheckbox("Display equipment in tracker", "gItemTrackerDisplayEquipment", 0);
-    if (CVar_GetS32("gItemTrackerDisplayEquipment", 0)) {
-        SohImGui::PaddedEnhancementCheckbox("Display equipment in separate window", "gItemTrackerDisplayEquipmentSeparate", 0);
-    }
-
-    SohImGui::PaddedText("Misc Items");
-    SohImGui::PaddedEnhancementCheckbox("Display misc items in tracker", "gItemTrackerDisplayMisc", 0);
-    if (CVar_GetS32("gItemTrackerDisplayMisc", 0)) {
-        SohImGui::PaddedEnhancementCheckbox("Display misc items in separate window", "gItemTrackerDisplayMiscSeparate", 0);
-    }
-
-    SohImGui::PaddedText("Dungeon Rewards");
-    SohImGui::PaddedEnhancementCheckbox("Display dungeon rewards in tracker", "gItemTrackerDisplayDungeonRewards", 0);
-    if (CVar_GetS32("gItemTrackerDisplayDungeonRewards", 0)) {
-        SohImGui::PaddedEnhancementCheckbox("Display dungeon rewards in separate window", "gItemTrackerDisplayDungeonRewardsSeparate", 0);
-    }
-
-    SohImGui::PaddedText("Songs");
-    SohImGui::PaddedEnhancementCheckbox("Display songs in tracker", "gItemTrackerDisplaySongs", 0);
-    if (CVar_GetS32("gItemTrackerDisplaySongs", 0)) {
-        SohImGui::PaddedEnhancementCheckbox("Display songs in separate window", "gItemTrackerDisplaySongsSeparate", 0);
-        SohImGui::PaddedEnhancementCheckbox("Use randomizer colors", "gItemTrackerDisplaySongsRandom", 0);
-    }
-
-    SohImGui::PaddedText("Dungeon Items");
-    SohImGui::PaddedEnhancementCheckbox("Display dungeon items in tracker", "gItemTrackerDisplayDungeonItems", 0);
-    if (CVar_GetS32("gItemTrackerDisplayDungeonItems", 0)) {
-        SohImGui::PaddedEnhancementCheckbox("Display dungeon items in separate window", "gItemTrackerDisplayDungeonItemsSeparate", 0);
-        if (CVar_GetS32("gItemTrackerDisplayDungeonItemsSeparate", 0)) {
-            SohImGui::PaddedEnhancementCheckbox("Horizontal dungeon items display", "gItemTrackerDisplayDungeonItemsHorizontal", 0);
+    LabeledComboBoxRightAligned("Inventory", "gItemTrackerInventoryItemsDisplayType", { "Hidden", "Main Window", "Seperate" }, 1);
+    LabeledComboBoxRightAligned("Equipment", "gItemTrackerEquipmentItemsDisplayType", { "Hidden", "Main Window", "Seperate" }, 1);
+    LabeledComboBoxRightAligned("Misc", "gItemTrackerMiscItemsDisplayType", { "Hidden", "Main Window", "Seperate" }, 1);
+    LabeledComboBoxRightAligned("Dungeon Rewards", "gItemTrackerDungeonRewardsDisplayType", { "Hidden", "Main Window", "Seperate" }, 1);
+    LabeledComboBoxRightAligned("Songs", "gItemTrackerSongsDisplayType", { "Hidden", "Main Window", "Seperate" }, 1);
+    LabeledComboBoxRightAligned("Dungeon Items", "gItemTrackerDungeonItemsDisplayType", { "Hidden", "Main Window", "Seperate" }, 2);
+    if (CVar_GetS32("gItemTrackerDungeonItemsDisplayType", 2) != 0) {
+        if (CVar_GetS32("gItemTrackerDungeonItemsDisplayType", 2) == 2) {
+            SohImGui::PaddedEnhancementCheckbox("Horizontal display", "gItemTrackerDisplayDungeonItemsHorizontal", 1);
         }
-        SohImGui::PaddedEnhancementCheckbox("Maps and compasses", "gItemTrackerDisplayDungeonItemsMaps", 0);
+        SohImGui::PaddedEnhancementCheckbox("Maps and compasses", "gItemTrackerDisplayDungeonItemsMaps", 1);
     }
+
+    ImGui::PopStyleVar(1);
+    ImGui::EndTable();
 
     // SohImGui::EnhancementCheckbox("Personal notes space", "gItemTrackerNotes");
     // SohImGui::Tooltip("Adds a textbox under the item tracker to keep your own notes in");

--- a/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
@@ -10,11 +10,13 @@
 #include <vector>
 #include <Cvar.h>
 
+extern "C" {
 #include <z64.h>
 #include "variables.h"
 #include "functions.h"
 #include "macros.h"
 extern GlobalContext* gGlobalCtx;
+}
 
 void DrawEquip(ItemTrackerItem item);
 void DrawItem(ItemTrackerItem item);

--- a/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
@@ -1,12 +1,15 @@
 #include "randomizer_item_tracker.h"
 #include "../../util.h"
 #include "../libultraship/ImGuiImpl.h"
+#include "../libultraship/Hooks.h"
+#include "../libultraship/UltraController.h"
 #include <soh/Enhancements/debugger/ImGuiHelpers.h>
 
 #include <array>
 #include <bit>
 #include <map>
 #include <string>
+#include <vector>
 #include <Cvar.h>
 
 extern "C" {
@@ -20,200 +23,71 @@ extern GlobalContext* gGlobalCtx;
 #include "textures/icon_item_24_static/icon_item_24_static.h"
 }
 
-typedef struct {
-    uint32_t id;
-    std::string name;
-    std::string nameFaded;
-    std::string texturePath;
-} ItemMapEntry;
+void DrawEquip(ItemTrackerItem item);
+void DrawItem(ItemTrackerItem item);
+void DrawDungeonItem(ItemTrackerItem item);
+void DrawBottle(ItemTrackerItem item);
+void DrawQuest(ItemTrackerItem item);
+void DrawUpgrade(ItemTrackerItem item);
+void DrawSong(ItemTrackerItem item);
 
-#define ITEM_MAP_ENTRY(id)                                            \
-    {                                                                 \
-        id, {                                                         \
-            id, #id, #id "_Faded", static_cast<char*>(gItemIcons[id]) \
-        }                                                             \
-    }
+OSContPad* buttonsPressed;
 
-// Maps items ids to info for use in ImGui
-std::map<uint32_t, ItemMapEntry> itemMappingSSS = {
-    ITEM_MAP_ENTRY(ITEM_STICK),
-    ITEM_MAP_ENTRY(ITEM_NUT),
-    ITEM_MAP_ENTRY(ITEM_BOMB),
-    ITEM_MAP_ENTRY(ITEM_BOW),
-    ITEM_MAP_ENTRY(ITEM_ARROW_FIRE),
-    ITEM_MAP_ENTRY(ITEM_DINS_FIRE),
-    ITEM_MAP_ENTRY(ITEM_SLINGSHOT),
-    ITEM_MAP_ENTRY(ITEM_OCARINA_FAIRY),
-    ITEM_MAP_ENTRY(ITEM_OCARINA_TIME),
-    ITEM_MAP_ENTRY(ITEM_BOMBCHU),
-    ITEM_MAP_ENTRY(ITEM_HOOKSHOT),
-    ITEM_MAP_ENTRY(ITEM_LONGSHOT),
-    ITEM_MAP_ENTRY(ITEM_ARROW_ICE),
-    ITEM_MAP_ENTRY(ITEM_FARORES_WIND),
-    ITEM_MAP_ENTRY(ITEM_BOOMERANG),
-    ITEM_MAP_ENTRY(ITEM_LENS),
-    ITEM_MAP_ENTRY(ITEM_BEAN),
-    ITEM_MAP_ENTRY(ITEM_HAMMER),
-    ITEM_MAP_ENTRY(ITEM_ARROW_LIGHT),
-    ITEM_MAP_ENTRY(ITEM_NAYRUS_LOVE),
-    ITEM_MAP_ENTRY(ITEM_BOTTLE),
-    ITEM_MAP_ENTRY(ITEM_POTION_RED),
-    ITEM_MAP_ENTRY(ITEM_POTION_GREEN),
-    ITEM_MAP_ENTRY(ITEM_POTION_BLUE),
-    ITEM_MAP_ENTRY(ITEM_FAIRY),
-    ITEM_MAP_ENTRY(ITEM_FISH),
-    ITEM_MAP_ENTRY(ITEM_MILK_BOTTLE),
-    ITEM_MAP_ENTRY(ITEM_LETTER_RUTO),
-    ITEM_MAP_ENTRY(ITEM_BLUE_FIRE),
-    ITEM_MAP_ENTRY(ITEM_BUG),
-    ITEM_MAP_ENTRY(ITEM_BIG_POE),
-    ITEM_MAP_ENTRY(ITEM_MILK_HALF),
-    ITEM_MAP_ENTRY(ITEM_POE),
-    ITEM_MAP_ENTRY(ITEM_WEIRD_EGG),
-    ITEM_MAP_ENTRY(ITEM_CHICKEN),
-    ITEM_MAP_ENTRY(ITEM_LETTER_ZELDA),
-    ITEM_MAP_ENTRY(ITEM_MASK_KEATON),
-    ITEM_MAP_ENTRY(ITEM_MASK_SKULL),
-    ITEM_MAP_ENTRY(ITEM_MASK_SPOOKY),
-    ITEM_MAP_ENTRY(ITEM_MASK_BUNNY),
-    ITEM_MAP_ENTRY(ITEM_MASK_GORON),
-    ITEM_MAP_ENTRY(ITEM_MASK_ZORA),
-    ITEM_MAP_ENTRY(ITEM_MASK_GERUDO),
-    ITEM_MAP_ENTRY(ITEM_MASK_TRUTH),
-    ITEM_MAP_ENTRY(ITEM_SOLD_OUT),
-    ITEM_MAP_ENTRY(ITEM_POCKET_EGG),
-    ITEM_MAP_ENTRY(ITEM_POCKET_CUCCO),
-    ITEM_MAP_ENTRY(ITEM_COJIRO),
-    ITEM_MAP_ENTRY(ITEM_ODD_MUSHROOM),
-    ITEM_MAP_ENTRY(ITEM_ODD_POTION),
-    ITEM_MAP_ENTRY(ITEM_SAW),
-    ITEM_MAP_ENTRY(ITEM_SWORD_BROKEN),
-    ITEM_MAP_ENTRY(ITEM_PRESCRIPTION),
-    ITEM_MAP_ENTRY(ITEM_FROG),
-    ITEM_MAP_ENTRY(ITEM_EYEDROPS),
-    ITEM_MAP_ENTRY(ITEM_CLAIM_CHECK),
-    ITEM_MAP_ENTRY(ITEM_BOW_ARROW_FIRE),
-    ITEM_MAP_ENTRY(ITEM_BOW_ARROW_ICE),
-    ITEM_MAP_ENTRY(ITEM_BOW_ARROW_LIGHT),
-    ITEM_MAP_ENTRY(ITEM_SWORD_KOKIRI),
-    ITEM_MAP_ENTRY(ITEM_SWORD_MASTER),
-    ITEM_MAP_ENTRY(ITEM_SWORD_BGS),
-    ITEM_MAP_ENTRY(ITEM_SHIELD_DEKU),
-    ITEM_MAP_ENTRY(ITEM_SHIELD_HYLIAN),
-    ITEM_MAP_ENTRY(ITEM_SHIELD_MIRROR),
-    ITEM_MAP_ENTRY(ITEM_TUNIC_KOKIRI),
-    ITEM_MAP_ENTRY(ITEM_TUNIC_GORON),
-    ITEM_MAP_ENTRY(ITEM_TUNIC_ZORA),
-    ITEM_MAP_ENTRY(ITEM_BOOTS_KOKIRI),
-    ITEM_MAP_ENTRY(ITEM_BOOTS_IRON),
-    ITEM_MAP_ENTRY(ITEM_BOOTS_HOVER),
-    ITEM_MAP_ENTRY(ITEM_BULLET_BAG_30),
-    ITEM_MAP_ENTRY(ITEM_BULLET_BAG_40),
-    ITEM_MAP_ENTRY(ITEM_BULLET_BAG_50),
-    ITEM_MAP_ENTRY(ITEM_QUIVER_30),
-    ITEM_MAP_ENTRY(ITEM_QUIVER_40),
-    ITEM_MAP_ENTRY(ITEM_QUIVER_50),
-    ITEM_MAP_ENTRY(ITEM_BOMB_BAG_20),
-    ITEM_MAP_ENTRY(ITEM_BOMB_BAG_30),
-    ITEM_MAP_ENTRY(ITEM_BOMB_BAG_40),
-    ITEM_MAP_ENTRY(ITEM_BRACELET),
-    ITEM_MAP_ENTRY(ITEM_GAUNTLETS_SILVER),
-    ITEM_MAP_ENTRY(ITEM_GAUNTLETS_GOLD),
-    ITEM_MAP_ENTRY(ITEM_SCALE_SILVER),
-    ITEM_MAP_ENTRY(ITEM_SCALE_GOLDEN),
-    ITEM_MAP_ENTRY(ITEM_SWORD_KNIFE),
-    ITEM_MAP_ENTRY(ITEM_WALLET_ADULT),
-    ITEM_MAP_ENTRY(ITEM_WALLET_GIANT),
-    ITEM_MAP_ENTRY(ITEM_SEEDS),
-    ITEM_MAP_ENTRY(ITEM_FISHING_POLE),
-    ITEM_MAP_ENTRY(ITEM_KEY_BOSS),
-    ITEM_MAP_ENTRY(ITEM_COMPASS),
-    ITEM_MAP_ENTRY(ITEM_DUNGEON_MAP),
-    ITEM_MAP_ENTRY(ITEM_KEY_SMALL),
-
+std::vector<ItemTrackerItem> inventoryItems = {
+    ITEM_TRACKER_ITEM(ITEM_STICK, 0, DrawItem),     ITEM_TRACKER_ITEM(ITEM_NUT, 0, DrawItem),           ITEM_TRACKER_ITEM(ITEM_BOMB, 0, DrawItem),
+    ITEM_TRACKER_ITEM(ITEM_BOW, 0, DrawItem),       ITEM_TRACKER_ITEM(ITEM_ARROW_FIRE, 0, DrawItem),    ITEM_TRACKER_ITEM(ITEM_DINS_FIRE, 0, DrawItem),
+    ITEM_TRACKER_ITEM(ITEM_SLINGSHOT, 0, DrawItem), ITEM_TRACKER_ITEM(ITEM_OCARINA_FAIRY, 0, DrawItem), ITEM_TRACKER_ITEM(ITEM_BOMBCHU, 0, DrawItem),
+    ITEM_TRACKER_ITEM(ITEM_HOOKSHOT, 0, DrawItem),  ITEM_TRACKER_ITEM(ITEM_ARROW_ICE, 0, DrawItem),     ITEM_TRACKER_ITEM(ITEM_FARORES_WIND, 0, DrawItem),
+    ITEM_TRACKER_ITEM(ITEM_BOOMERANG, 0, DrawItem), ITEM_TRACKER_ITEM(ITEM_LENS, 0, DrawItem),          ITEM_TRACKER_ITEM(ITEM_BEAN, 0, DrawItem),
+    ITEM_TRACKER_ITEM(ITEM_HAMMER, 0, DrawItem),    ITEM_TRACKER_ITEM(ITEM_ARROW_LIGHT, 0, DrawItem),   ITEM_TRACKER_ITEM(ITEM_NAYRUS_LOVE, 0, DrawItem),
+    ITEM_TRACKER_ITEM(ITEM_BOTTLE, 0, DrawBottle),  ITEM_TRACKER_ITEM(ITEM_BOTTLE, 1, DrawBottle),      ITEM_TRACKER_ITEM(ITEM_BOTTLE, 2, DrawBottle),
+    ITEM_TRACKER_ITEM(ITEM_BOTTLE, 3, DrawBottle),  ITEM_TRACKER_ITEM(ITEM_POCKET_EGG, 0, DrawItem),    ITEM_TRACKER_ITEM(ITEM_MASK_KEATON, 0, DrawItem),
 };
 
-// Maps entries in the GS flag array to the area name it represents
-
-std::vector<std::string> gsMappingSSS = {
-    "Deku Tree",
-    "Dodongo's Cavern",
-    "Inside Jabu-Jabu's Belly",
-    "Forest Temple",
-    "Fire Temple",
-    "Water Temple",
-    "Spirit Temple",
-    "Shadow Temple",
-    "Bottom of the Well",
-    "Ice Cavern",
-    "Hyrule Field",
-    "Lon Lon Ranch",
-    "Kokiri Forest",
-    "Lost Woods, Sacred Forest Meadow",
-    "Castle Town and Ganon's Castle",
-    "Death Mountain Trail, Goron City",
-    "Kakariko Village",
-    "Zora Fountain, River",
-    "Lake Hylia",
-    "Gerudo Valley",
-    "Gerudo Fortress",
-    "Desert Colossus, Haunted Wasteland",
+std::vector<ItemTrackerItem> equipmentItems = {
+    ITEM_TRACKER_ITEM(ITEM_SWORD_KOKIRI, 1 << 0, DrawEquip),  ITEM_TRACKER_ITEM(ITEM_SWORD_MASTER, 1 << 1, DrawEquip),  ITEM_TRACKER_ITEM(ITEM_SWORD_BGS, 1 << 2, DrawEquip),
+    ITEM_TRACKER_ITEM(ITEM_TUNIC_KOKIRI, 1 << 8, DrawEquip),  ITEM_TRACKER_ITEM(ITEM_TUNIC_GORON, 1 << 9, DrawEquip),   ITEM_TRACKER_ITEM(ITEM_TUNIC_ZORA, 1 << 10, DrawEquip),
+    ITEM_TRACKER_ITEM(ITEM_SHIELD_DEKU, 1 << 4, DrawEquip),   ITEM_TRACKER_ITEM(ITEM_SHIELD_HYLIAN, 1 << 5, DrawEquip), ITEM_TRACKER_ITEM(ITEM_SHIELD_MIRROR, 1 << 6, DrawEquip),
+    ITEM_TRACKER_ITEM(ITEM_BOOTS_KOKIRI, 1 << 12, DrawEquip), ITEM_TRACKER_ITEM(ITEM_BOOTS_IRON, 1 << 13, DrawEquip),   ITEM_TRACKER_ITEM(ITEM_BOOTS_HOVER, 1 << 14, DrawEquip),
 };
 
-extern "C" u8 gAreaGsFlags[];
-
-extern "C" u8 gAmmoItems[];
-
-// Modification of gAmmoItems that replaces ITEM_NONE with the item in inventory slot it represents
-u8 gAllAmmoItemsSSS[] = {
-    ITEM_STICK,     ITEM_NUT,          ITEM_BOMB,    ITEM_BOW,      ITEM_ARROW_FIRE, ITEM_DINS_FIRE,
-    ITEM_SLINGSHOT, ITEM_OCARINA_TIME, ITEM_BOMBCHU, ITEM_LONGSHOT, ITEM_ARROW_ICE,  ITEM_FARORES_WIND,
-    ITEM_BOOMERANG, ITEM_LENS,         ITEM_BEAN,    ITEM_HAMMER,
+std::vector<ItemTrackerItem> miscItems = {
+    ITEM_TRACKER_ITEM(UPG_STRENGTH, 0, DrawUpgrade),          ITEM_TRACKER_ITEM(UPG_SCALE, 0, DrawUpgrade),             ITEM_TRACKER_ITEM(ITEM_WALLET_ADULT, 0, DrawItem),
+    ITEM_TRACKER_ITEM(ITEM_HEART_CONTAINER, 0, DrawItem),     ITEM_TRACKER_ITEM(ITEM_MAGIC_SMALL, 0, DrawItem),         ITEM_TRACKER_ITEM(QUEST_STONE_OF_AGONY, 1 << 21, DrawQuest),
+    ITEM_TRACKER_ITEM(QUEST_GERUDO_CARD, 1 << 22, DrawQuest), ITEM_TRACKER_ITEM(QUEST_SKULL_TOKEN, 1 << 23, DrawQuest),
 };
 
-// Encapsulates what is drawn by the passed-in function within a border
-template <typename T> void DrawGroupWithBorder(T&& drawFunc) {
-    // First group encapsulates the inner portion and border
-    ImGui::BeginGroup();
+std::vector<ItemTrackerItem> dungeonRewardStones = {
+    ITEM_TRACKER_ITEM(QUEST_KOKIRI_EMERALD, 1 << 18, DrawQuest), ITEM_TRACKER_ITEM(QUEST_GORON_RUBY, 1 << 19, DrawQuest), ITEM_TRACKER_ITEM(QUEST_ZORA_SAPPHIRE, 1 << 20, DrawQuest),
+};
 
-    ImVec2 padding = ImGui::GetStyle().FramePadding;
-    ImVec2 p0 = ImGui::GetCursorScreenPos();
-    ImGui::SetCursorScreenPos(ImVec2(p0.x + padding.x, p0.y + padding.y));
+std::vector<ItemTrackerItem> dungeonRewardMedallions = {
+    ITEM_TRACKER_ITEM(QUEST_MEDALLION_FOREST, 1 << 0, DrawQuest), ITEM_TRACKER_ITEM(QUEST_MEDALLION_FIRE, 1 << 1, DrawQuest),   ITEM_TRACKER_ITEM(QUEST_MEDALLION_WATER, 1 << 2, DrawQuest),
+    ITEM_TRACKER_ITEM(QUEST_MEDALLION_SPIRIT, 1 << 3, DrawQuest), ITEM_TRACKER_ITEM(QUEST_MEDALLION_SHADOW, 1 << 4, DrawQuest), ITEM_TRACKER_ITEM(QUEST_MEDALLION_LIGHT, 1 << 5, DrawQuest),
+};
 
-    // Second group encapsulates just the inner portion
-    ImGui::BeginGroup();
+std::vector<ItemTrackerItem> songItems = {
+    ITEM_TRACKER_ITEM(QUEST_SONG_LULLABY, 0, DrawSong), ITEM_TRACKER_ITEM(QUEST_SONG_EPONA, 0, DrawSong),    ITEM_TRACKER_ITEM(QUEST_SONG_SARIA, 0, DrawSong),
+    ITEM_TRACKER_ITEM(QUEST_SONG_SUN, 0, DrawSong),     ITEM_TRACKER_ITEM(QUEST_SONG_TIME, 0, DrawSong),     ITEM_TRACKER_ITEM(QUEST_SONG_STORMS, 0, DrawSong),
+    ITEM_TRACKER_ITEM(QUEST_SONG_MINUET, 0, DrawSong),  ITEM_TRACKER_ITEM(QUEST_SONG_BOLERO, 0, DrawSong),   ITEM_TRACKER_ITEM(QUEST_SONG_SERENADE, 0, DrawSong),
+    ITEM_TRACKER_ITEM(QUEST_SONG_REQUIEM, 0, DrawSong), ITEM_TRACKER_ITEM(QUEST_SONG_NOCTURNE, 0, DrawSong), ITEM_TRACKER_ITEM(QUEST_SONG_PRELUDE, 0, DrawSong),
+};
 
-    drawFunc();
-
-    ImGui::Dummy(padding);
-    ImGui::EndGroup();
-
-    ImVec2 p1 = ImGui::GetItemRectMax();
-    p1.x += padding.x;
-    ImVec4 borderCol = ImGui::GetStyle().Colors[ImGuiCol_Border];
-    ImGui::GetWindowDrawList()->AddRect(
-        p0, p1, IM_COL32(borderCol.x * 255, borderCol.y * 255, borderCol.z * 255, borderCol.w * 255));
-
-    ImGui::EndGroup();
-}
-
-char z2ASCIISSS(int code) {
-    int ret;
-    if (code < 10) { // Digits
-        ret = code + 0x30;
-    } else if (code >= 10 && code < 36) { // Uppercase letters
-        ret = code + 0x37;
-    } else if (code >= 36 && code < 62) { // Lowercase letters
-        ret = code + 0x3D;
-    } else if (code == 62) { // Space
-        ret = code - 0x1E;
-    } else if (code == 63 || code == 64) { // _ and .
-        ret = code - 0x12;
-    } else {
-        ret = code;
-    }
-    return char(ret);
-}
+std::vector<ItemTrackerDungeon> itemTrackerDungeons = {
+    ITEM_TRACKER_DUNGEON(SCENE_BMORI1, "FRST", true, true, true, true),
+    ITEM_TRACKER_DUNGEON(SCENE_HIDAN, "FIRE", true, true, true, true),
+    ITEM_TRACKER_DUNGEON(SCENE_MIZUSIN, "WATR", true, true, true, true),
+    ITEM_TRACKER_DUNGEON(SCENE_JYASINZOU, "SPIR", true, true, true, true),
+    ITEM_TRACKER_DUNGEON(SCENE_HAKADAN, "SHAD", true, true, true, true),
+    ITEM_TRACKER_DUNGEON(SCENE_HAKADANCH, "BOTW", true, true, false, true),
+    ITEM_TRACKER_DUNGEON(SCENE_YDAN, "DEKU", true, true, false, false),
+    ITEM_TRACKER_DUNGEON(SCENE_DDAN, "DODO", true, true, false, false),
+    ITEM_TRACKER_DUNGEON(SCENE_BDAN, "JABU", true, true, false, false),
+    ITEM_TRACKER_DUNGEON(SCENE_ICE_DOUKUTO, "ICE", true, true, false, false),
+    ITEM_TRACKER_DUNGEON(SCENE_GANON, "GAN", false, false, true, true),
+    ITEM_TRACKER_DUNGEON(SCENE_MEN, "GTG", false, false, false, true),
+    ITEM_TRACKER_DUNGEON(SCENE_GERUDOWAY, "HIDE", false, false, false, true),
+};
 
 typedef struct {
     uint32_t id;
@@ -229,47 +103,25 @@ typedef struct {
         }                                         \
     }
 
-std::unordered_map<uint32_t, ItemTrackerMapEntry> equipTrackerMap = {
-    ITEM_TRACKER_MAP_ENTRY(ITEM_SWORD_KOKIRI, 0),  ITEM_TRACKER_MAP_ENTRY(ITEM_SWORD_MASTER, 1),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_SWORD_BGS, 2),     ITEM_TRACKER_MAP_ENTRY(ITEM_SWORD_BROKEN, 3),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_SHIELD_DEKU, 4),   ITEM_TRACKER_MAP_ENTRY(ITEM_SHIELD_HYLIAN, 5),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_SHIELD_MIRROR, 6), ITEM_TRACKER_MAP_ENTRY(ITEM_TUNIC_KOKIRI, 8),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_TUNIC_GORON, 9),   ITEM_TRACKER_MAP_ENTRY(ITEM_TUNIC_ZORA, 10),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_BOOTS_KOKIRI, 12), ITEM_TRACKER_MAP_ENTRY(ITEM_BOOTS_IRON, 13),
-    ITEM_TRACKER_MAP_ENTRY(ITEM_BOOTS_HOVER, 14),
-};
-
 bool IsValidSaveFile() {
     bool validSave = gSaveContext.fileNum >= 0 && gSaveContext.fileNum <= 2;
     return validSave;
 }
 
-void DrawEquip(uint32_t itemId) {
-    const ItemTrackerMapEntry& entry = equipTrackerMap[itemId];
-    bool hasEquip = (entry.bitMask & gSaveContext.inventory.equipment) != 0;
-    int iconSize = CVar_GetS32("gRandoTrackIconSize", 0);
-    ImGui::Image(SohImGui::GetTextureByName(hasEquip && IsValidSaveFile() ? entry.name : entry.nameFaded),
+void DrawEquip(ItemTrackerItem item) {
+    bool hasEquip = (item.data & gSaveContext.inventory.equipment) != 0;
+    int iconSize = CVar_GetS32("gItemTrackerIconSize", 32);
+    ImGui::Image(SohImGui::GetTextureByName(hasEquip && IsValidSaveFile() ? item.name : item.nameFaded),
                  ImVec2(iconSize, iconSize), ImVec2(0, 0), ImVec2(1, 1));
 
-    SetLastItemHoverText(SohUtils::GetItemName(entry.id));
+    SetLastItemHoverText(SohUtils::GetItemName(item.id));
 }
 
-std::unordered_map<uint32_t, ItemTrackerMapEntry> questTrackerMap = {
-    ITEM_TRACKER_MAP_ENTRY(QUEST_MEDALLION_FOREST, 0), ITEM_TRACKER_MAP_ENTRY(QUEST_MEDALLION_FIRE, 1),
-    ITEM_TRACKER_MAP_ENTRY(QUEST_MEDALLION_WATER, 2),  ITEM_TRACKER_MAP_ENTRY(QUEST_MEDALLION_SPIRIT, 3),
-    ITEM_TRACKER_MAP_ENTRY(QUEST_MEDALLION_SHADOW, 4), ITEM_TRACKER_MAP_ENTRY(QUEST_MEDALLION_LIGHT, 5),
-    ITEM_TRACKER_MAP_ENTRY(QUEST_KOKIRI_EMERALD, 18),  ITEM_TRACKER_MAP_ENTRY(QUEST_GORON_RUBY, 19),
-    ITEM_TRACKER_MAP_ENTRY(QUEST_ZORA_SAPPHIRE, 20),   ITEM_TRACKER_MAP_ENTRY(QUEST_STONE_OF_AGONY, 21),
-    ITEM_TRACKER_MAP_ENTRY(QUEST_GERUDO_CARD, 22),     ITEM_TRACKER_MAP_ENTRY(QUEST_SKULL_TOKEN, 23),
-
-};
-
-void DrawQuest(uint32_t itemId) {
-    const ItemTrackerMapEntry& entry = questTrackerMap[itemId];
-    bool hasQuestItem = (entry.bitMask & gSaveContext.inventory.questItems) != 0;
-    int iconSize = CVar_GetS32("gRandoTrackIconSize", 0);
+void DrawQuest(ItemTrackerItem item) {
+    bool hasQuestItem = (item.data & gSaveContext.inventory.questItems) != 0;
+    int iconSize = CVar_GetS32("gItemTrackerIconSize", 32);
     ImGui::BeginGroup();
-    ImGui::Image(SohImGui::GetTextureByName(hasQuestItem && IsValidSaveFile() ? entry.name : entry.nameFaded),
+    ImGui::Image(SohImGui::GetTextureByName(hasQuestItem && IsValidSaveFile() ? item.name : item.nameFaded),
                  ImVec2(iconSize, iconSize), ImVec2(0, 0), ImVec2(1, 1));
 
     ImVec2 p = ImGui::GetCursorScreenPos();
@@ -277,7 +129,7 @@ void DrawQuest(uint32_t itemId) {
     int estimatedTextHeight = 10;
     ImGui::SetCursorScreenPos(ImVec2(p.x + (iconSize / 2) - estimatedTextWidth, p.y - estimatedTextHeight));
 
-    if (entry.name == "QUEST_SKULL_TOKEN") {
+    if (item.name == "QUEST_SKULL_TOKEN") {
         if (gSaveContext.inventory.gsTokens == 0) {
             ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(155, 155, 155, 255));
             ImGui::Text("%i", gSaveContext.inventory.gsTokens);
@@ -293,7 +145,7 @@ void DrawQuest(uint32_t itemId) {
 
     ImGui::EndGroup();
 
-    SetLastItemHoverText(SohUtils::GetQuestItemName(entry.id));
+    SetLastItemHoverText(SohUtils::GetQuestItemName(item.id));
 };
 
 std::unordered_map<uint32_t, ItemTrackerMapEntry> itemTrackerMap = {
@@ -403,8 +255,18 @@ std::unordered_map<uint32_t, ItemTrackerMapEntry> itemTrackerMap = {
     ITEM_TRACKER_MAP_ENTRY(ITEM_KEY_BOSS, 0)
 };
 
-void DrawItem(uint32_t itemId) {
+void DrawItem(ItemTrackerItem item) {
+    uint32_t itemId = item.id;
     uint32_t actualItemId = INV_CONTENT(itemId);
+    int iconSize = CVar_GetS32("gItemTrackerIconSize", 32);
+
+    if (itemId == ITEM_NONE) {
+        ImGui::BeginGroup();
+        ImVec2 p = ImGui::GetCursorScreenPos();
+        ImGui::SetCursorScreenPos(ImVec2(p.x - 5 + (iconSize / 2) - 10, p.y - 10));
+        ImGui::EndGroup();
+        return;
+    }
 
     if (itemId == ITEM_HEART_CONTAINER) {
         actualItemId = itemId;
@@ -453,7 +315,6 @@ void DrawItem(uint32_t itemId) {
     }
 
     const ItemTrackerMapEntry& entry = itemTrackerMap[hasItem && IsValidSaveFile() ? actualItemId : itemId];
-    int iconSize = CVar_GetS32("gRandoTrackIconSize", 0);
 
     ImGui::BeginGroup();
     ImGui::Image(SohImGui::GetTextureByName(hasItem && IsValidSaveFile() ? entry.name : entry.nameFaded),
@@ -685,30 +546,30 @@ void DrawItemAmmo(int itemId) {
     }
 }
 
-void DrawBottle(uint32_t itemId, uint32_t bottleSlot) {
-    uint32_t actualItemId = gSaveContext.inventory.items[SLOT(itemId) + bottleSlot];
+void DrawBottle(ItemTrackerItem item) {
+    uint32_t actualItemId = gSaveContext.inventory.items[SLOT(item.id) + item.data];
     bool hasItem = actualItemId != ITEM_NONE;
-    const ItemTrackerMapEntry& entry = itemTrackerMap[hasItem && IsValidSaveFile() ? actualItemId : itemId];
-    int iconSize = CVar_GetS32("gRandoTrackIconSize", 0);
+    const ItemTrackerMapEntry& entry = itemTrackerMap[hasItem && IsValidSaveFile() ? actualItemId : item.id];
+    int iconSize = CVar_GetS32("gItemTrackerIconSize", 32);
     ImGui::Image(SohImGui::GetTextureByName(hasItem && IsValidSaveFile() ? entry.name : entry.nameFaded),
                  ImVec2(iconSize, iconSize), ImVec2(0, 0), ImVec2(1, 1));
 
     SetLastItemHoverText(SohUtils::GetItemName(entry.id));
 };
 
-void DrawDungeonItem(uint32_t itemId, uint32_t scene) {
-    const ItemTrackerMapEntry& entry = itemTrackerMap[itemId];
-    uint32_t bitMask = 1 << (entry.id - ITEM_KEY_BOSS); // Bitset starts at ITEM_KEY_BOSS == 0. the rest are sequential
-    int iconSize = CVar_GetS32("gRandoTrackIconSize", 0);
-    bool hasItem = (bitMask & gSaveContext.inventory.dungeonItems[scene]) != 0;
-    bool hasSmallKey = (gSaveContext.inventory.dungeonKeys[scene]) >= 0;
+void DrawDungeonItem(ItemTrackerItem item) {
+    uint32_t itemId = item.id;
+    uint32_t bitMask = 1 << (item.id - ITEM_KEY_BOSS); // Bitset starts at ITEM_KEY_BOSS == 0. the rest are sequential
+    int iconSize = CVar_GetS32("gItemTrackerIconSize", 32);
+    bool hasItem = (bitMask & gSaveContext.inventory.dungeonItems[item.data]) != 0;
+    bool hasSmallKey = (gSaveContext.inventory.dungeonKeys[item.data]) >= 0;
     ImGui::BeginGroup();
     if (itemId == ITEM_KEY_SMALL) {
-        ImGui::Image(SohImGui::GetTextureByName(hasSmallKey && IsValidSaveFile() ? entry.name : entry.nameFaded),
+        ImGui::Image(SohImGui::GetTextureByName(hasSmallKey && IsValidSaveFile() ? item.name : item.nameFaded),
                      ImVec2(iconSize, iconSize), ImVec2(0, 0), ImVec2(1, 1));
     }
     else {
-        ImGui::Image(SohImGui::GetTextureByName(hasItem && IsValidSaveFile() ? entry.name : entry.nameFaded),
+        ImGui::Image(SohImGui::GetTextureByName(hasItem && IsValidSaveFile() ? item.name : item.nameFaded),
                      ImVec2(iconSize, iconSize), ImVec2(0, 0), ImVec2(1, 1));
     }
 
@@ -718,18 +579,18 @@ void DrawDungeonItem(uint32_t itemId, uint32_t scene) {
     ImGui::SetCursorScreenPos(ImVec2(p.x - 5 + (iconSize / 2) - estimatedTextWidth, p.y - estimatedTextHeight));
 
     if (itemId == ITEM_KEY_SMALL) { // This check there for small key is necessary to get the text position properly and can't be on the same ITEM_KEY chack from the top
-        if (gSaveContext.inventory.dungeonKeys[scene] <= 0 || !IsValidSaveFile()) {
+        if (gSaveContext.inventory.dungeonKeys[item.data] <= 0 || !IsValidSaveFile()) {
             ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(155, 155, 155, 255));
             ImGui::Text("0");
             ImGui::PopStyleColor();
          }
          else {
-            ImGui::Text("%i", gSaveContext.inventory.dungeonKeys[scene]);
+            ImGui::Text("%i", gSaveContext.inventory.dungeonKeys[item.data]);
          }  
     }
     ImGui::EndGroup();
 
-    SetLastItemHoverText(SohUtils::GetItemName(entry.id));
+    SetLastItemHoverText(SohUtils::GetItemName(item.id));
 }
 
 typedef struct {
@@ -774,8 +635,9 @@ std::unordered_map<int32_t, std::vector<ItemTrackerUpgradeEntry>> upgradeTracker
 
 };
 
-void DrawUpgrade(int32_t categoryId) {
-    int iconSize = CVar_GetS32("gRandoTrackIconSize", 0);
+void DrawUpgrade(ItemTrackerItem item) {
+    uint32_t categoryId = item.id;
+    int iconSize = CVar_GetS32("gItemTrackerIconSize", 32);
     if (CUR_UPG_VALUE(categoryId) == 0 || !IsValidSaveFile()) {
         const ItemTrackerUpgradeEntry& entry = upgradeTrackerMap[categoryId][0];
         ImGui::Image(SohImGui::GetTextureByName(entry.nameFaded), ImVec2(iconSize, iconSize), ImVec2(0, 0),
@@ -788,622 +650,13 @@ void DrawUpgrade(int32_t categoryId) {
     }
 }
 
-typedef struct {
-    uint32_t id;
-    std::string name;
-    std::string nameFaded;
-    ImVec4 color;
-} ItemTrackerSongEntry;
-
-#define ITEM_TRACKER_SONG_ENTRY(id) \
-    {                               \
-        id, {                       \
-            id, #id, #id "_Faded"   \
-        }                           \
-    }
-
-// Maps song ids to info for use in ImGui
-std::unordered_map<int32_t, ItemTrackerSongEntry> songTrackerMap = {
-    ITEM_TRACKER_SONG_ENTRY(QUEST_SONG_LULLABY),  ITEM_TRACKER_SONG_ENTRY(QUEST_SONG_EPONA),
-    ITEM_TRACKER_SONG_ENTRY(QUEST_SONG_SARIA),    ITEM_TRACKER_SONG_ENTRY(QUEST_SONG_SUN),
-    ITEM_TRACKER_SONG_ENTRY(QUEST_SONG_TIME),     ITEM_TRACKER_SONG_ENTRY(QUEST_SONG_STORMS),
-    ITEM_TRACKER_SONG_ENTRY(QUEST_SONG_MINUET),   ITEM_TRACKER_SONG_ENTRY(QUEST_SONG_BOLERO),
-    ITEM_TRACKER_SONG_ENTRY(QUEST_SONG_SERENADE), ITEM_TRACKER_SONG_ENTRY(QUEST_SONG_REQUIEM),
-    ITEM_TRACKER_SONG_ENTRY(QUEST_SONG_NOCTURNE), ITEM_TRACKER_SONG_ENTRY(QUEST_SONG_PRELUDE),
-};
-
-#define VANILLA_ITEM_TRACKER_SONG_ENTRY(id)          \
-    {                                                \
-        id, {                                        \
-            id, #id "_Vanilla", #id "_Vanilla_Faded" \
-        }                                            \
-    }
-
-// Maps song ids to info for use in ImGui
-std::unordered_map<int32_t, ItemTrackerSongEntry> vanillaSongTrackerMap = {
-    VANILLA_ITEM_TRACKER_SONG_ENTRY(QUEST_SONG_LULLABY),  VANILLA_ITEM_TRACKER_SONG_ENTRY(QUEST_SONG_EPONA),
-    VANILLA_ITEM_TRACKER_SONG_ENTRY(QUEST_SONG_SARIA),    VANILLA_ITEM_TRACKER_SONG_ENTRY(QUEST_SONG_SUN),
-    VANILLA_ITEM_TRACKER_SONG_ENTRY(QUEST_SONG_TIME),     VANILLA_ITEM_TRACKER_SONG_ENTRY(QUEST_SONG_STORMS),
-    VANILLA_ITEM_TRACKER_SONG_ENTRY(QUEST_SONG_MINUET),   VANILLA_ITEM_TRACKER_SONG_ENTRY(QUEST_SONG_BOLERO),
-    VANILLA_ITEM_TRACKER_SONG_ENTRY(QUEST_SONG_SERENADE), VANILLA_ITEM_TRACKER_SONG_ENTRY(QUEST_SONG_REQUIEM),
-    VANILLA_ITEM_TRACKER_SONG_ENTRY(QUEST_SONG_NOCTURNE), VANILLA_ITEM_TRACKER_SONG_ENTRY(QUEST_SONG_PRELUDE),
-};
-
-void DrawSong(int32_t songId) {
-    int iconSize = CVar_GetS32("gRandoTrackIconSize", 0);
-    const ItemTrackerSongEntry& entry =
-        CVar_GetS32("gItemTrackeSongColor", 0) ? songTrackerMap[songId] : vanillaSongTrackerMap[songId];
-    uint32_t bitMask = 1 << entry.id;
+void DrawSong(ItemTrackerItem item) {
+    int iconSize = CVar_GetS32("gItemTrackerIconSize", 32);
+    uint32_t bitMask = 1 << item.id;
     bool hasSong = (bitMask & gSaveContext.inventory.questItems) != 0;
-    ImGui::Image(SohImGui::GetTextureByName(hasSong && IsValidSaveFile() ? entry.name : entry.nameFaded),
+    ImGui::Image(SohImGui::GetTextureByName(hasSong && IsValidSaveFile() ? item.name : item.nameFaded),
                  ImVec2(iconSize / 1.5, iconSize), ImVec2(0, 0), ImVec2(1, 1));
-    SetLastItemHoverText(SohUtils::GetQuestItemName(entry.id));
-}
-
-// Theme 1 Original Tracker style
-void DrawFloatingInventory(int Icon_Cells_Size, int Icon_Spacing) {
-    ImGui::BeginGroup();
-    DrawItem(ITEM_STICK);
-    ImGui::SameLine(Icon_Cells_Size);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing);
-    DrawItem(ITEM_NUT);
-    ImGui::SameLine(Icon_Cells_Size * 2);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 2);
-    DrawItem(ITEM_BOMB);
-    ImGui::SameLine(Icon_Cells_Size * 3);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 3);
-    DrawItem(ITEM_BOW);
-    ImGui::SameLine(Icon_Cells_Size * 4);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 4);
-    DrawItem(ITEM_ARROW_FIRE);
-    ImGui::SameLine(Icon_Cells_Size * 5);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 5);
-    DrawItem(ITEM_DINS_FIRE);
-    ImGui::EndGroup();
-    ImGui::SetCursorPosY(ImGui::GetCursorPosY() + Icon_Spacing);
-    ImGui::BeginGroup();
-    DrawItem(ITEM_SLINGSHOT);
-    ImGui::SameLine(Icon_Cells_Size);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing);
-    DrawItem(ITEM_OCARINA_FAIRY);
-    ImGui::SameLine(Icon_Cells_Size * 2);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 2);
-    DrawItem(ITEM_BOMBCHU);
-    ImGui::SameLine(Icon_Cells_Size * 3);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 3);
-    DrawItem(ITEM_HOOKSHOT);
-    ImGui::SameLine(Icon_Cells_Size * 4);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 4);
-    DrawItem(ITEM_ARROW_ICE);
-    ImGui::SameLine(Icon_Cells_Size * 5);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 5);
-    DrawItem(ITEM_FARORES_WIND);
-    ImGui::EndGroup();
-    ImGui::SetCursorPosY(ImGui::GetCursorPosY() + Icon_Spacing);
-    ImGui::BeginGroup();
-    DrawItem(ITEM_BOOMERANG);
-    ImGui::SameLine(Icon_Cells_Size);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing);
-    DrawItem(ITEM_LENS);
-    ImGui::SameLine(Icon_Cells_Size * 2);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 2);
-    DrawItem(ITEM_BEAN);
-    ImGui::SameLine(Icon_Cells_Size * 3);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 3);
-    DrawItem(ITEM_HAMMER);
-    ImGui::SameLine(Icon_Cells_Size * 4);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 4);
-    DrawItem(ITEM_ARROW_LIGHT);
-    ImGui::SameLine(Icon_Cells_Size * 5);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 5);
-    DrawItem(ITEM_NAYRUS_LOVE);
-    ImGui::EndGroup();
-    ImGui::SetCursorPosY(ImGui::GetCursorPosY() + Icon_Spacing);
-    ImGui::BeginGroup();
-    DrawBottle(ITEM_BOTTLE, 0);
-    ImGui::SameLine(Icon_Cells_Size);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing);
-    DrawBottle(ITEM_BOTTLE, 1);
-    ImGui::SameLine(Icon_Cells_Size * 2);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 2);
-    DrawBottle(ITEM_BOTTLE, 2);
-    ImGui::SameLine(Icon_Cells_Size * 3);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 3);
-    DrawBottle(ITEM_BOTTLE, 3);
-    ImGui::SameLine(Icon_Cells_Size * 4);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 4);
-    DrawItem(ITEM_POCKET_EGG); // ADULT TRADE
-    ImGui::SameLine(Icon_Cells_Size * 5);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 5);
-    DrawItem(ITEM_MASK_KEATON); // CHILD TRADE
-    ImGui::EndGroup();
-}
-void DrawFloatingEquipsQuestUpgradeStones(int Icon_Cells_Size, int Icon_Spacing) {
-    ImGui::BeginGroup();
-    DrawEquip(ITEM_SWORD_KOKIRI);
-    ImGui::SameLine(Icon_Cells_Size);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing);
-    DrawEquip(ITEM_SWORD_MASTER);
-    ImGui::SameLine(Icon_Cells_Size * 2);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 2);
-    DrawEquip(ITEM_SWORD_BGS); // PURPLE TODO: CHECK IF BGS OR BROKEN SWORD TO DISPLAY
-    ImGui::SameLine(Icon_Cells_Size * 3);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 3);
-    DrawQuest(QUEST_STONE_OF_AGONY);
-    ImGui::SameLine(Icon_Cells_Size * 4);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 4);
-    DrawQuest(QUEST_GERUDO_CARD);
-    ImGui::SameLine(Icon_Cells_Size * 5);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 5);
-    DrawQuest(QUEST_SKULL_TOKEN);
-    ImGui::EndGroup();
-    ImGui::SetCursorPosY(ImGui::GetCursorPosY() + Icon_Spacing);
-    ImGui::BeginGroup();
-    DrawEquip(ITEM_SHIELD_DEKU);
-    ImGui::SameLine(Icon_Cells_Size);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing);
-    DrawEquip(ITEM_SHIELD_HYLIAN);
-    ImGui::SameLine(Icon_Cells_Size * 2);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 2);
-    DrawEquip(ITEM_SHIELD_MIRROR);
-    ImGui::SameLine(Icon_Cells_Size * 3);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 3);
-    DrawUpgrade(UPG_STRENGTH);
-    ImGui::SameLine(Icon_Cells_Size * 4);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 4);
-    DrawUpgrade(UPG_SCALE);
-    ImGui::SameLine(Icon_Cells_Size * 5);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 5);
-    DrawItem(ITEM_WALLET_ADULT);
-    ImGui::EndGroup();
-    ImGui::SetCursorPosY(ImGui::GetCursorPosY() + Icon_Spacing);
-    ImGui::BeginGroup();
-    DrawEquip(ITEM_TUNIC_KOKIRI);
-    ImGui::SameLine(Icon_Cells_Size);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing);
-    DrawEquip(ITEM_TUNIC_GORON);
-    ImGui::SameLine(Icon_Cells_Size * 2);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 2);
-    DrawEquip(ITEM_TUNIC_ZORA);
-    ImGui::SameLine(Icon_Cells_Size * 3);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 3);
-    DrawItem(ITEM_HEART_CONTAINER);
-    ImGui::SameLine(Icon_Cells_Size * 4);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 4);
-    DrawItem(ITEM_MAGIC_SMALL);
-    ImGui::SameLine(Icon_Cells_Size * 5);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 5);
-    ImGui::EndGroup();
-    ImGui::SetCursorPosY(ImGui::GetCursorPosY() + Icon_Spacing);
-    ImGui::BeginGroup();
-    DrawEquip(ITEM_BOOTS_KOKIRI);
-    ImGui::SameLine(Icon_Cells_Size);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing);
-    DrawEquip(ITEM_BOOTS_IRON);
-    ImGui::SameLine(Icon_Cells_Size * 2);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 2);
-    DrawEquip(ITEM_BOOTS_HOVER);
-    ImGui::SameLine(Icon_Cells_Size * 3);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 3);
-    DrawQuest(QUEST_KOKIRI_EMERALD);
-    ImGui::SameLine(Icon_Cells_Size * 4);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 4);
-    DrawQuest(QUEST_GORON_RUBY);
-    ImGui::SameLine(Icon_Cells_Size * 5);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 5);
-    DrawQuest(QUEST_ZORA_SAPPHIRE);
-    ImGui::EndGroup();
-}
-void DrawFloatingTokens(int Icon_Cells_Size, int Icon_Spacing) {
-    ImGui::BeginGroup();
-    if (CVar_GetS32("gItemTrackerTheme", 0) == 0 || !CVar_GetS32("gItemTrackerMedallionsPlacement", 0)) {
-        DrawQuest(QUEST_MEDALLION_FOREST);
-        ImGui::SameLine(Icon_Cells_Size);
-        ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing);
-        DrawQuest(QUEST_MEDALLION_FIRE);
-        ImGui::SameLine(Icon_Cells_Size * 2);
-        ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 2);
-        DrawQuest(QUEST_MEDALLION_WATER);
-        ImGui::SameLine(Icon_Cells_Size * 3);
-        ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 3);
-        DrawQuest(QUEST_MEDALLION_SPIRIT);
-        ImGui::SameLine(Icon_Cells_Size * 4);
-        ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 4);
-        DrawQuest(QUEST_MEDALLION_SHADOW);
-        ImGui::SameLine(Icon_Cells_Size * 5);
-        ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 5);
-        DrawQuest(QUEST_MEDALLION_LIGHT);
-    } else if (CVar_GetS32("gItemTrackerTheme", 0) != 0 && CVar_GetS32("gItemTrackerMedallionsPlacement", 0)) {
-        ImGui::BeginGroup();
-        ImGui::SameLine(Icon_Cells_Size);
-        ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 1);
-        DrawQuest(QUEST_MEDALLION_LIGHT);
-        ImGui::EndGroup();
-        ImGui::BeginGroup();
-        DrawQuest(QUEST_MEDALLION_SHADOW);
-        ImGui::SameLine(Icon_Cells_Size * 2);
-        ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 2);
-        DrawQuest(QUEST_MEDALLION_FOREST);
-        ImGui::SetCursorPosY(ImGui::GetCursorPosY() + Icon_Spacing);
-        ImGui::EndGroup();
-        ImGui::BeginGroup();
-        DrawQuest(QUEST_MEDALLION_SPIRIT);
-        ImGui::SameLine(Icon_Cells_Size * 2);
-        ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 2);
-        DrawQuest(QUEST_MEDALLION_FIRE);
-        ImGui::EndGroup();
-        ImGui::BeginGroup();
-        ImGui::NewLine();
-        ImGui::SameLine(Icon_Cells_Size);
-        ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 1);
-        DrawQuest(QUEST_MEDALLION_WATER);
-        ImGui::EndGroup();
-    }
-    ImGui::EndGroup();
-}
-
-void DrawFloatingSongs(int Icon_Cells_Size, int Icon_Spacing) {
-    ImGui::BeginGroup();
-    DrawSong(QUEST_SONG_LULLABY);
-    ImGui::SameLine(Icon_Cells_Size);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing);
-    DrawSong(QUEST_SONG_EPONA);
-    ImGui::SameLine(Icon_Cells_Size * 2);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 2);
-    DrawSong(QUEST_SONG_SARIA);
-    ImGui::SameLine(Icon_Cells_Size * 3);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 3);
-    DrawSong(QUEST_SONG_SUN);
-    ImGui::SameLine(Icon_Cells_Size * 4);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 4);
-    DrawSong(QUEST_SONG_TIME);
-    ImGui::SameLine(Icon_Cells_Size * 5);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 5);
-    DrawSong(QUEST_SONG_STORMS);
-    ImGui::EndGroup();
-    ImGui::SetCursorPosY(ImGui::GetCursorPosY() + Icon_Spacing);
-    ImGui::BeginGroup();
-    DrawSong(QUEST_SONG_MINUET);
-    ImGui::SameLine(Icon_Cells_Size);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing);
-    DrawSong(QUEST_SONG_BOLERO);
-    ImGui::SameLine(Icon_Cells_Size * 2);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 2);
-    DrawSong(QUEST_SONG_SERENADE);
-    ImGui::SameLine(Icon_Cells_Size * 3);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 3);
-    DrawSong(QUEST_SONG_REQUIEM);
-    ImGui::SameLine(Icon_Cells_Size * 4);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 4);
-    DrawSong(QUEST_SONG_NOCTURNE);
-    ImGui::SameLine(Icon_Cells_Size * 5);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 5);
-    DrawSong(QUEST_SONG_PRELUDE);
-    ImGui::EndGroup();
-}
-
-// Theme 2 per cells elements
-void DrawFloatingEquipments(int Icon_Cells_Size, int Icon_Spacing) {
-    ImGui::BeginGroup();
-    DrawEquip(ITEM_SWORD_KOKIRI);
-    ImGui::SameLine(Icon_Cells_Size);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing);
-    DrawEquip(ITEM_SWORD_MASTER);
-    ImGui::SameLine(Icon_Cells_Size * 2);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 2);
-    DrawEquip(ITEM_SWORD_BGS); // PURPLE TODO: CHECK IF BGS OR BROKEN SWORD TO DISPLAY
-    ImGui::EndGroup();
-    ImGui::SetCursorPosY(ImGui::GetCursorPosY() + Icon_Spacing);
-    ImGui::BeginGroup();
-    DrawEquip(ITEM_SHIELD_DEKU);
-    ImGui::SameLine(Icon_Cells_Size);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing);
-    DrawEquip(ITEM_SHIELD_HYLIAN);
-    ImGui::SameLine(Icon_Cells_Size * 2);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 2);
-    DrawEquip(ITEM_SHIELD_MIRROR);
-    ImGui::EndGroup();
-    ImGui::SetCursorPosY(ImGui::GetCursorPosY() + Icon_Spacing);
-    ImGui::BeginGroup();
-    DrawEquip(ITEM_TUNIC_KOKIRI);
-    ImGui::SameLine(Icon_Cells_Size);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing);
-    DrawEquip(ITEM_TUNIC_GORON);
-    ImGui::SameLine(Icon_Cells_Size * 2);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 2);
-    DrawEquip(ITEM_TUNIC_ZORA);
-    ImGui::SameLine(Icon_Cells_Size * 3);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 3);
-    ImGui::EndGroup();
-    ImGui::SetCursorPosY(ImGui::GetCursorPosY() + Icon_Spacing);
-    ImGui::BeginGroup();
-    DrawEquip(ITEM_BOOTS_KOKIRI);
-    ImGui::SameLine(Icon_Cells_Size);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing);
-    DrawEquip(ITEM_BOOTS_IRON);
-    ImGui::SameLine(Icon_Cells_Size * 2);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 2);
-    DrawEquip(ITEM_BOOTS_HOVER);
-    ImGui::EndGroup();
-}
-
-void DrawFloatingUpgrades(int Icon_Cells_Size, int Icon_Spacing) {
-    ImGui::BeginGroup();
-    DrawUpgrade(UPG_STRENGTH);
-    ImGui::SameLine(Icon_Cells_Size);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing);
-    DrawUpgrade(UPG_SCALE);
-    ImGui::SameLine(Icon_Cells_Size * 2);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 2);
-    DrawItem(ITEM_WALLET_ADULT);
-    ImGui::EndGroup();
-    ImGui::SetCursorPosY(ImGui::GetCursorPosY() + Icon_Spacing);
-    ImGui::BeginGroup();
-    DrawItem(ITEM_HEART_CONTAINER);
-    ImGui::SameLine(Icon_Cells_Size);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing);
-    DrawItem(ITEM_MAGIC_SMALL);
-    ImGui::SameLine(Icon_Cells_Size * 2);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 2);
-    ImGui::EndGroup();
-}
-
-void DrawFloatingQuest(int Icon_Cells_Size, int Icon_Spacing) {
-    ImGui::BeginGroup();
-    DrawQuest(QUEST_STONE_OF_AGONY);
-    ImGui::SameLine(Icon_Cells_Size);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing);
-    DrawQuest(QUEST_GERUDO_CARD);
-    ImGui::SameLine(Icon_Cells_Size * 2);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 2);
-    DrawQuest(QUEST_SKULL_TOKEN);
-    ImGui::EndGroup();
-}
-
-void DrawFloatingStones(int Icon_Cells_Size, int Icon_Spacing) {
-    ImGui::BeginGroup();
-    DrawQuest(QUEST_KOKIRI_EMERALD);
-    ImGui::SameLine(Icon_Cells_Size);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing);
-    DrawQuest(QUEST_GORON_RUBY);
-    ImGui::SameLine(Icon_Cells_Size * 2);
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 2);
-    DrawQuest(QUEST_ZORA_SAPPHIRE);
-    ImGui::EndGroup();
-}
-
-void DrawFloatingDungeons(int Icon_Cells_Size, int Icon_Spacing) {
-    if (CVar_GetS32("gItemTrackerDisplayDungeonItems", 0)) {
-        ImGui::BeginGroup();
-        if (CVar_GetS32("gItemTrackerDisplayMapsAndCompasses", 0)) {
-            ImGui::Text("DEKU");
-            ImGui::SameLine(Icon_Cells_Size);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing);
-            ImGui::Text("DCVN");
-            ImGui::SameLine(Icon_Cells_Size * 2);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 2);
-            ImGui::Text("JABU");
-            ImGui::SameLine(Icon_Cells_Size * 3);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 3);
-            ImGui::Text("FRST");
-            ImGui::SameLine(Icon_Cells_Size * 4);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 4);
-            ImGui::Text("FIRE");
-            ImGui::SameLine(Icon_Cells_Size * 5);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 5);
-            ImGui::Text("WATR"); 
-        }
-        else {
-            ImGui::Text("FRST");
-            ImGui::SameLine(Icon_Cells_Size);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing);
-            ImGui::Text("FIRE");
-            ImGui::SameLine(Icon_Cells_Size * 2);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 2);
-            ImGui::Text("WATR");
-            ImGui::SameLine(Icon_Cells_Size * 3);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 3);
-            ImGui::Text("SPRT");
-            ImGui::SameLine(Icon_Cells_Size * 4);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 4);
-            ImGui::Text("SHDW");
-            ImGui::SameLine(Icon_Cells_Size * 5);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 5);
-            ImGui::Text("GANON"); 
-        }
-        ImGui::EndGroup();
-        if (CVar_GetS32("gItemTrackerDisplayMapsAndCompasses", 0)) {
-            ImGui::BeginGroup();
-            DrawDungeonItem(ITEM_DUNGEON_MAP, SCENE_YDAN);
-            ImGui::SameLine(Icon_Cells_Size);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing);
-            DrawDungeonItem(ITEM_DUNGEON_MAP, SCENE_DDAN);
-            ImGui::SameLine(Icon_Cells_Size * 2);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 2);
-            DrawDungeonItem(ITEM_DUNGEON_MAP, SCENE_BDAN);
-            ImGui::SameLine(Icon_Cells_Size * 3);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 3);
-            DrawDungeonItem(ITEM_DUNGEON_MAP, SCENE_BMORI1);
-            ImGui::SameLine(Icon_Cells_Size * 4);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 4);
-            DrawDungeonItem(ITEM_DUNGEON_MAP, SCENE_HIDAN);
-            ImGui::SameLine(Icon_Cells_Size * 5);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 5);
-            DrawDungeonItem(ITEM_DUNGEON_MAP, SCENE_MIZUSIN);
-            ImGui::EndGroup();
-            ImGui::BeginGroup();
-            DrawDungeonItem(ITEM_COMPASS, SCENE_YDAN);
-            ImGui::SameLine(Icon_Cells_Size);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing);
-            DrawDungeonItem(ITEM_COMPASS, SCENE_DDAN);
-            ImGui::SameLine(Icon_Cells_Size * 2);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 2);
-            DrawDungeonItem(ITEM_COMPASS, SCENE_BDAN);
-            ImGui::SameLine(Icon_Cells_Size * 3);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 3);
-            DrawDungeonItem(ITEM_COMPASS, SCENE_BMORI1);
-            ImGui::SameLine(Icon_Cells_Size * 4);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 4);
-            DrawDungeonItem(ITEM_COMPASS, SCENE_HIDAN);
-            ImGui::SameLine(Icon_Cells_Size * 5);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 5);
-            DrawDungeonItem(ITEM_COMPASS, SCENE_MIZUSIN);
-            ImGui::EndGroup();
-        }
-        // SMALL KEYS FOR DEKU TREE TO WATER TEMPLE
-        ImGui::BeginGroup();
-        if (CVar_GetS32("gItemTrackerDisplayMapsAndCompasses", 0)) {
-            ImGui::NewLine();
-            ImGui::SameLine(Icon_Cells_Size * 3);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 3);
-            
-            DrawDungeonItem(ITEM_KEY_SMALL, SCENE_BMORI1);
-            ImGui::SameLine(Icon_Cells_Size * 4);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 4);
-            DrawDungeonItem(ITEM_KEY_SMALL, SCENE_HIDAN);
-            ImGui::SameLine(Icon_Cells_Size * 5);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 5);
-            DrawDungeonItem(ITEM_KEY_SMALL, SCENE_MIZUSIN);
-            ImGui::EndGroup();
-            // BOSS KEYS FOR DEKU TREE TO WATER TEMPLE
-            ImGui::BeginGroup();
-            ImGui::NewLine();
-            ImGui::SameLine(Icon_Cells_Size * 3);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 3);
-            DrawDungeonItem(ITEM_KEY_BOSS, SCENE_BMORI1);
-            ImGui::SameLine(Icon_Cells_Size * 4);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 4);
-            DrawDungeonItem(ITEM_KEY_BOSS, SCENE_HIDAN);
-            ImGui::SameLine(Icon_Cells_Size * 5);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 5);
-            DrawDungeonItem(ITEM_KEY_BOSS, SCENE_MIZUSIN);
-        } else {
-            DrawDungeonItem(ITEM_KEY_SMALL, SCENE_BMORI1);
-            ImGui::SameLine(Icon_Cells_Size);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing );
-            DrawDungeonItem(ITEM_KEY_SMALL, SCENE_HIDAN);
-            ImGui::SameLine(Icon_Cells_Size * 2);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 2);
-            DrawDungeonItem(ITEM_KEY_SMALL, SCENE_MIZUSIN);
-            ImGui::SameLine(Icon_Cells_Size * 3);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 3);
-            DrawDungeonItem(ITEM_KEY_SMALL, SCENE_JYASINZOU);
-            ImGui::SameLine(Icon_Cells_Size *4);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 4);
-            DrawDungeonItem(ITEM_KEY_SMALL, SCENE_HAKADAN);
-            ImGui::SameLine(Icon_Cells_Size * 5);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 5);
-            DrawDungeonItem(ITEM_KEY_SMALL, SCENE_GANONTIKA);
-            ImGui::EndGroup();
-            // BOSS KEYS FOR FOREST TO GANON
-            ImGui::BeginGroup();
-            DrawDungeonItem(ITEM_KEY_BOSS, SCENE_BMORI1);
-            ImGui::SameLine(Icon_Cells_Size);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing);
-            DrawDungeonItem(ITEM_KEY_BOSS, SCENE_HIDAN);
-            ImGui::SameLine(Icon_Cells_Size * 2);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 2);
-            DrawDungeonItem(ITEM_KEY_BOSS, SCENE_MIZUSIN);
-            ImGui::SameLine(Icon_Cells_Size * 3);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 3);
-            DrawDungeonItem(ITEM_KEY_BOSS, SCENE_JYASINZOU);
-            ImGui::SameLine(Icon_Cells_Size *4);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 4);
-            DrawDungeonItem(ITEM_KEY_BOSS, SCENE_HAKADAN);
-            ImGui::SameLine(Icon_Cells_Size * 5);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 5);
-            DrawDungeonItem(ITEM_KEY_BOSS, SCENE_GANON);
-        }
-        ImGui::EndGroup();
-        ImGui::BeginGroup();
-        if (CVar_GetS32("gItemTrackerDisplayMapsAndCompasses", 0)) {
-            ImGui::Text("SPRT");
-            ImGui::SameLine(Icon_Cells_Size);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing);
-            ImGui::Text("SHDW");
-            ImGui::SameLine(Icon_Cells_Size * 2);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 2);
-            ImGui::Text("BOTW");
-            ImGui::SameLine(Icon_Cells_Size * 3);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 3);
-            ImGui::Text("ICE");
-            ImGui::SameLine(Icon_Cells_Size * 4);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 4);
-            ImGui::Text("GTG");
-            ImGui::SameLine(Icon_Cells_Size * 5);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 5);
-            ImGui::Text("GANON");
-        } else {
-            ImGui::Text("BOTW");
-            ImGui::SameLine(Icon_Cells_Size);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing);
-            ImGui::Text("HIDE");
-            ImGui::SameLine(Icon_Cells_Size * 2);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 2);
-            ImGui::Text("GTG");
-        }
-        ImGui::EndGroup();
-        if (CVar_GetS32("gItemTrackerDisplayMapsAndCompasses", 0)) {
-            ImGui::BeginGroup();
-            DrawDungeonItem(ITEM_DUNGEON_MAP, SCENE_JYASINZOU);
-            ImGui::SameLine(Icon_Cells_Size);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing);
-            DrawDungeonItem(ITEM_DUNGEON_MAP, SCENE_HAKADAN);
-            ImGui::SameLine(Icon_Cells_Size * 2);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 2);
-            DrawDungeonItem(ITEM_DUNGEON_MAP, SCENE_HAKADANCH);
-            ImGui::SameLine(Icon_Cells_Size * 3);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 3);
-            DrawDungeonItem(ITEM_DUNGEON_MAP, SCENE_ICE_DOUKUTO);
-            ImGui::SameLine(Icon_Cells_Size * 4);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 4);
-            DrawDungeonItem(ITEM_KEY_SMALL, SCENE_MEN);
-            ImGui::SameLine(Icon_Cells_Size * 5);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 5);
-            DrawDungeonItem(ITEM_KEY_SMALL, SCENE_GANONTIKA);
-            ImGui::EndGroup();
-            ImGui::BeginGroup();
-            DrawDungeonItem(ITEM_COMPASS, SCENE_JYASINZOU);
-            ImGui::SameLine(Icon_Cells_Size);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing);
-            DrawDungeonItem(ITEM_COMPASS, SCENE_HAKADAN);
-            ImGui::SameLine(Icon_Cells_Size * 2);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 2);
-            DrawDungeonItem(ITEM_COMPASS, SCENE_HAKADANCH);
-            ImGui::SameLine(Icon_Cells_Size * 3);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 3);
-            DrawDungeonItem(ITEM_COMPASS, SCENE_ICE_DOUKUTO);
-            ImGui::SameLine(Icon_Cells_Size * 5);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 5);
-            DrawDungeonItem(ITEM_KEY_BOSS, SCENE_GANON);
-            ImGui::EndGroup();
-        }
-        ImGui::BeginGroup();
-        if (CVar_GetS32("gItemTrackerDisplayMapsAndCompasses", 0)) {
-            DrawDungeonItem(ITEM_KEY_SMALL, SCENE_JYASINZOU);
-            ImGui::SameLine(Icon_Cells_Size);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing);
-            DrawDungeonItem(ITEM_KEY_SMALL, SCENE_HAKADAN);
-            ImGui::SameLine(Icon_Cells_Size * 2);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 2);
-            DrawDungeonItem(ITEM_KEY_SMALL, SCENE_HAKADANCH);
-            ImGui::EndGroup();
-            ImGui::BeginGroup();
-            DrawDungeonItem(ITEM_KEY_BOSS, SCENE_JYASINZOU);
-            ImGui::SameLine(Icon_Cells_Size);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing);
-            DrawDungeonItem(ITEM_KEY_BOSS, SCENE_HAKADAN);
-        } else {
-            DrawDungeonItem(ITEM_KEY_SMALL, SCENE_HAKADANCH);
-            ImGui::SameLine(Icon_Cells_Size);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing);
-            DrawDungeonItem(ITEM_KEY_SMALL, SCENE_GERUDOWAY);
-            ImGui::SameLine(Icon_Cells_Size * 2);
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 2);
-            DrawDungeonItem(ITEM_KEY_SMALL, SCENE_MEN);
-        }
-        ImGui::EndGroup();
-    }
+    SetLastItemHoverText(SohUtils::GetQuestItemName(item.id));
 }
 
 void DrawFloatingNotes(int Icon_Cells_Size, int Icon_Spacing) {
@@ -1439,17 +692,16 @@ void DrawFloatingNotes(int Icon_Cells_Size, int Icon_Spacing) {
 }
 
 // Windowing stuff
-ImVec4 ChromaKeyBackground = { 0, 0, 0, 1 }; // Float value, 1 = 255 in rgb value.
+ImVec4 ChromaKeyBackground = { 0, 0, 0, 0 }; // Float value, 1 = 255 in rgb value.
 void BeginFloatingWindows(std::string UniqueName) {
-    ImGuiWindowFlags FloatingWndFlags = ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoFocusOnAppearing |
-                                        ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoDocking |
-                                        ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoScrollWithMouse |
-                                        ImGuiWindowFlags_NoScrollbar;
-    if (!CVar_GetS32("gItemTrackerHudEditMode", 0)) {
-        FloatingWndFlags = ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoFocusOnAppearing |
-                           ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoDecoration |
-                           ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoTitleBar |
-                           ImGuiWindowFlags_NoScrollWithMouse | ImGuiWindowFlags_NoScrollbar;
+    ImGuiWindowFlags FloatingWndFlags = ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoFocusOnAppearing | ImGuiWindowFlags_NoResize;
+
+    if (!CVar_GetS32("gItemTrackerWindowType", 0)) {
+        FloatingWndFlags |= ImGuiWindowFlags_NoDocking | ImGuiWindowFlags_NoNav | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoScrollWithMouse | ImGuiWindowFlags_NoScrollbar;
+
+        if (!CVar_GetS32("gItemTrackerHudEditMode", 0)) {
+            FloatingWndFlags |= ImGuiWindowFlags_NoInputs | ImGuiWindowFlags_NoMove;
+        }
     }
     ImGui::PushStyleColor(ImGuiCol_WindowBg, ChromaKeyBackground);
     ImGui::PushStyleColor(ImGuiCol_Border, ImVec4(0, 0, 0, 0));
@@ -1461,102 +713,165 @@ void EndFloatingWindows() {
     ImGui::End();
 }
 
+/**
+ * DrawItemsInRows
+ * Takes in a vector of ItemTrackerItem and draws them in rows of N items
+ */
+void DrawItemsInRows(std::vector<ItemTrackerItem> items, int columns = 6) {
+    int Icon_Cells_Size = CVar_GetS32("gItemTrackerIconSize", 32);
+    int Icon_Spacing = CVar_GetS32("gItemTrackerIconSpacing", 0);
+    for (int i = 0; i < items.size(); i++) {
+        if (i % columns == 0) {
+            ImGui::BeginGroup();
+        } else {
+            ImGui::SameLine(Icon_Cells_Size * (i % columns));
+            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * (i % columns));
+        }
+        items[i].drawFunc(items[i]);
+        if (i % columns == columns - 1) {
+            ImGui::EndGroup();
+            ImGui::SetCursorPosY(ImGui::GetCursorPosY() + Icon_Spacing);
+        }
+    }
+    if (items.size() % columns != 0) {
+        ImGui::EndGroup();
+    }
+}
+
+/**
+ * DrawDungeons
+ * Loops over dungeons and creates vectors of items in the correct order 
+ * to then call DrawItemsInRows
+ */
+void DrawDungeons(std::vector<ItemTrackerDungeon> dungeons, int columns = 6) {
+    int Icon_Cells_Size = CVar_GetS32("gItemTrackerIconSize", 32);
+    int Icon_Spacing = CVar_GetS32("gItemTrackerIconSpacing", 0);
+    std::vector<ItemTrackerItem> dungeonItems = {};
+
+    if (!CVar_GetS32("gItemTrackerDisplayDungeonItemsMaps", 0)) {
+        dungeons.erase(std::remove_if(dungeons.begin(), dungeons.end(), [](ItemTrackerDungeon d) { return !d.hasBossKey && !d.hasSmallKey; }), dungeons.end());
+    }
+
+    ImGui::BeginGroup();
+    ImGui::NewLine();
+    for (int i = 0; i < MIN(dungeons.size(), columns); i++) {
+        ImGui::SameLine(Icon_Cells_Size * i);
+        ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * i);
+        ImVec2 p = ImGui::GetCursorScreenPos();
+        ImGui::SetCursorScreenPos(ImVec2(p.x - 5 + (Icon_Cells_Size / 2) - 10, p.y - 4));
+        ImGui::Text(dungeons[i].shortName.c_str());
+    }
+    ImGui::EndGroup();
+    for (int i = 0; i < MIN(dungeons.size(), columns); i++) {
+        if (dungeons[i].hasSmallKey) {
+            dungeonItems.push_back(ITEM_TRACKER_ITEM(ITEM_KEY_SMALL, dungeons[i].id, DrawDungeonItem));
+        } else {
+            dungeonItems.push_back(ITEM_TRACKER_ITEM(ITEM_NONE, 0, DrawItem));
+        }
+    }
+    for (int i = 0; i < MIN(dungeons.size(), columns); i++) {
+        if (dungeons[i].hasBossKey) {
+            dungeonItems.push_back(ITEM_TRACKER_ITEM(ITEM_KEY_BOSS, dungeons[i].id, DrawDungeonItem));
+        } else {
+            dungeonItems.push_back(ITEM_TRACKER_ITEM(ITEM_NONE, 0, DrawItem));
+        }
+    }
+    if (CVar_GetS32("gItemTrackerDisplayDungeonItemsMaps", 0)) {
+        for (int i = 0; i < MIN(dungeons.size(), columns); i++) {
+            if (dungeons[i].hasMap) {
+                dungeonItems.push_back(ITEM_TRACKER_ITEM(ITEM_DUNGEON_MAP, dungeons[i].id, DrawDungeonItem));
+            } else {
+                dungeonItems.push_back(ITEM_TRACKER_ITEM(ITEM_NONE, 0, DrawItem));
+            }
+        }
+        for (int i = 0; i < MIN(dungeons.size(), columns); i++) {
+            if (dungeons[i].hasCompass) {
+                dungeonItems.push_back(ITEM_TRACKER_ITEM(ITEM_COMPASS, dungeons[i].id, DrawDungeonItem));
+            } else {
+                dungeonItems.push_back(ITEM_TRACKER_ITEM(ITEM_NONE, 0, DrawItem));
+            }
+        }
+    }
+    DrawItemsInRows(dungeonItems, MIN(dungeons.size(), columns));
+
+    if (dungeons.size() > columns) {
+        DrawDungeons(std::vector<ItemTrackerDungeon>(dungeons.begin() + columns, dungeons.end()), columns);
+    }
+}
+
 void DrawItemTracker(bool& open) {
     if (!open) {
-        CVar_SetS32("gItemTrackerEnabled", 0);
         return;
     }
-    int Icon_Cells_Size = CVar_GetS32("gRandoTrackIconSize", 0);
-    int Icon_Spacing = CVar_GetS32("gRandoTrackIconSpacing", 0);
+    int Icon_Cells_Size = CVar_GetS32("gItemTrackerIconSize", 32);
+    int Icon_Spacing = CVar_GetS32("gItemTrackerIconSpacing", 0);
 
-    if (CVar_GetS32("gItemTrackerEnabled", 0)) {
-        int ImGui_DefaultMargin = 0;
-        if (CVar_GetS32("gItemTrackerTheme", 0) == 0) { // One block tracker, original tracker style
-            BeginFloatingWindows("ItemTracker_Theme_0_Grouped");
-            DrawFloatingInventory(Icon_Cells_Size, Icon_Spacing);
-            DrawFloatingEquipsQuestUpgradeStones(Icon_Cells_Size, Icon_Spacing);
-            DrawFloatingTokens(Icon_Cells_Size, Icon_Spacing);
-            DrawFloatingSongs(Icon_Cells_Size, Icon_Spacing);
-            EndFloatingWindows();
-            if (CVar_GetS32("gItemTrackerDisplayDungeonItems", 0)) {
-                BeginFloatingWindows("ItemTracker_Theme_0_Dungeons");
-                DrawFloatingDungeons(Icon_Cells_Size, Icon_Spacing);
-                EndFloatingWindows();
+    if (CVar_GetS32("gItemTrackerHotKeyShow", 0) == 0 ? CVar_GetS32("gItemTrackerEnabled", 0) : buttonsPressed[0].button & BTN_L) {
+        BeginFloatingWindows("Item Tracker#window");
+        if (CVar_GetS32("gItemTrackerDisplayInventory", 0) && !CVar_GetS32("gItemTrackerDisplayInventorySeparate", 0)) {
+            DrawItemsInRows(inventoryItems);
+        }
+        if (CVar_GetS32("gItemTrackerDisplayEquipment", 0) && !CVar_GetS32("gItemTrackerDisplayEquipmentSeparate", 0)) {
+            DrawItemsInRows(equipmentItems);
+        }
+        if (CVar_GetS32("gItemTrackerDisplayMisc", 0) && !CVar_GetS32("gItemTrackerDisplayMiscSeparate", 0)) {
+            DrawItemsInRows(miscItems);
+        }
+        if (CVar_GetS32("gItemTrackerDisplayDungeonRewards", 0) && !CVar_GetS32("gItemTrackerDisplayDungeonRewardsSeparate", 0)) {
+            if (CVar_GetS32("gItemTrackerDisplayMisc", 0) && !CVar_GetS32("gItemTrackerDisplayMiscSeparate", 0)) {
+                ImGui::SameLine(Icon_Cells_Size * 3);
+                ImGui::SetCursorPosX(ImGui::GetCursorPosX() + Icon_Spacing * 3);
             }
-            /*
-            if (CVar_GetS32("gItemTrackerNotes", 0)) {
-                BeginFloatingWindows("ItemTracker_Theme_0_Notes");
-                DrawFloatingNotes(Icon_Cells_Size, Icon_Spacing);
-                EndFloatingWindows();
-            }*/
-        } else if (CVar_GetS32("gItemTrackerTheme", 0) == 1) { // Per groups elements N.1
-            BeginFloatingWindows("ItemTracker_Theme_1_Inventory");
-            DrawFloatingInventory(Icon_Cells_Size, Icon_Spacing);
-            EndFloatingWindows();
+            DrawItemsInRows(dungeonRewardStones);
+            DrawItemsInRows(dungeonRewardMedallions);
+        }
+        if (CVar_GetS32("gItemTrackerDisplaySongs", 0) && !CVar_GetS32("gItemTrackerDisplaySongsSeparate", 0)) {
+            DrawItemsInRows(songItems);
+        }
+        if (CVar_GetS32("gItemTrackerDisplayDungeonItems", 0) && !CVar_GetS32("gItemTrackerDisplayDungeonItemsSeparate", 0)) {
+            DrawDungeons(itemTrackerDungeons);
+        }
+        EndFloatingWindows();
 
-            BeginFloatingWindows("ItemTracker_Theme_1_Stuffs");
-            DrawFloatingEquipsQuestUpgradeStones(Icon_Cells_Size, Icon_Spacing);
+        if (CVar_GetS32("gItemTrackerDisplayInventory", 0) && CVar_GetS32("gItemTrackerDisplayInventorySeparate", 0)) {
+            BeginFloatingWindows("Inventory Items Tracker");
+            DrawItemsInRows(inventoryItems);
             EndFloatingWindows();
+        }
 
-            BeginFloatingWindows("ItemTracker_Theme_1_Tokens");
-            DrawFloatingTokens(Icon_Cells_Size, Icon_Spacing);
+        if (CVar_GetS32("gItemTrackerDisplayEquipment", 0) && CVar_GetS32("gItemTrackerDisplayEquipmentSeparate", 0)) {
+            BeginFloatingWindows("Equipment Items Tracker");
+            DrawItemsInRows(equipmentItems);
             EndFloatingWindows();
+        }
 
-            BeginFloatingWindows("ItemTracker_Theme_1_Songs");
-            DrawFloatingSongs(Icon_Cells_Size, Icon_Spacing);
+        if (CVar_GetS32("gItemTrackerDisplayMisc", 0) && CVar_GetS32("gItemTrackerDisplayMiscSeparate", 0)) {
+            BeginFloatingWindows("Misc Items Tracker");
+            DrawItemsInRows(miscItems);
             EndFloatingWindows();
+        }
 
-            if (CVar_GetS32("gItemTrackerDisplayDungeonItems", 0)) {
-                BeginFloatingWindows("ItemTracker_Theme_1_Dungeons");
-                DrawFloatingDungeons(Icon_Cells_Size, Icon_Spacing);
-                EndFloatingWindows();
+        if (CVar_GetS32("gItemTrackerDisplayDungeonRewards", 0) && CVar_GetS32("gItemTrackerDisplayDungeonRewardsSeparate", 0)) {
+            BeginFloatingWindows("Dungeon Rewards Tracker");
+            DrawItemsInRows(dungeonRewardStones);
+            DrawItemsInRows(dungeonRewardMedallions);
+            EndFloatingWindows();
+        }
+
+        if (CVar_GetS32("gItemTrackerDisplaySongs", 0) && CVar_GetS32("gItemTrackerDisplaySongsSeparate", 0)) {
+            BeginFloatingWindows("Songs Tracker");
+            DrawItemsInRows(songItems);
+            EndFloatingWindows();
+        }
+
+        if (CVar_GetS32("gItemTrackerDisplayDungeonItems", 0) && CVar_GetS32("gItemTrackerDisplayDungeonItemsSeparate", 0)) {
+            BeginFloatingWindows("Dungeon Items Tracker");
+            if (CVar_GetS32("gItemTrackerDisplayDungeonItemsHorizontal", 0)) {
+                DrawDungeons(itemTrackerDungeons, 13);
+            } else {
+                DrawDungeons(itemTrackerDungeons);
             }
-            /*
-            if (CVar_GetS32("gItemTrackerNotes", 0)) {
-                BeginFloatingWindows("ItemTracker_Theme_1_Notes");
-                DrawFloatingNotes(Icon_Cells_Size, Icon_Spacing);
-                EndFloatingWindows();
-            }*/
-        } else if (CVar_GetS32("gItemTrackerTheme", 0) == 2) { // Per groups elements N.2
-            BeginFloatingWindows("ItemTracker_Theme_2_Inventory");
-            DrawFloatingInventory(Icon_Cells_Size, Icon_Spacing);
             EndFloatingWindows();
-
-            BeginFloatingWindows("ItemTracker_Theme_2_Equips");
-            DrawFloatingEquipments(Icon_Cells_Size, Icon_Spacing);
-            EndFloatingWindows();
-
-            BeginFloatingWindows("ItemTracker_Theme_2_Upgrade");
-            DrawFloatingUpgrades(Icon_Cells_Size, Icon_Spacing);
-            EndFloatingWindows();
-
-            BeginFloatingWindows("ItemTracker_Theme_2_Quest");
-            DrawFloatingQuest(Icon_Cells_Size, Icon_Spacing);
-            EndFloatingWindows();
-
-            BeginFloatingWindows("ItemTracker_Theme_2_Stones");
-            DrawFloatingStones(Icon_Cells_Size, Icon_Spacing);
-            EndFloatingWindows();
-
-            BeginFloatingWindows("ItemTracker_Theme_2_Tokens");
-            DrawFloatingTokens(Icon_Cells_Size, Icon_Spacing);
-            EndFloatingWindows();
-
-            BeginFloatingWindows("ItemTracker_Theme_2_Song");
-            DrawFloatingSongs(Icon_Cells_Size, Icon_Spacing);
-            EndFloatingWindows();
-
-            if (CVar_GetS32("gItemTrackerDisplayDungeonItems", 0)) {
-                BeginFloatingWindows("ItemTracker_Theme_2_Dungeons");
-                DrawFloatingDungeons(Icon_Cells_Size, Icon_Spacing);
-                EndFloatingWindows();
-            }
-            /*
-            if (CVar_GetS32("gItemTrackerNotes", 0)) {
-                BeginFloatingWindows("ItemTracker_Theme_2_Notes");
-                DrawFloatingNotes(Icon_Cells_Size, Icon_Spacing);
-                EndFloatingWindows();
-            }*/
         }
     }
 }
@@ -1574,89 +889,89 @@ void DrawItemTrackerOptions(bool& open) {
         return;
     }
 
-    SohImGui::EnhancementCheckbox("Display \"Ammo/MaxAmo\"", "gItemTrackerAmmoDisplay");
-    SohImGui::EnhancementCheckbox("Randomizer colors for Songs", "gItemTrackeSongColor");
-    SohImGui::Tooltip("Will display non-warp songs with randomizer colors instead of pure white");
+    SohImGui::PaddedText("Hotkey");
+    SohImGui::PaddedEnhancementCheckbox("L Button to show Item Tracker", "gItemTrackerHotKeyShow", 0);
+    if (CVar_GetS32("gItemTrackerHotKeyShow", 0)) {
+        if (ImGui::BeginCombo("Button Type", CVar_GetS32("gItemTrackerHotKeyShowType", 0) == 0 ? "Hold" : "Toggle")) {
+            if (ImGui::Selectable("Hold")) {
+                CVar_SetS32("gItemTrackerHotKeyShowType", 0);
+            }
+            if (ImGui::Selectable("Toggle")) {
+                CVar_SetS32("gItemTrackerHotKeyShowType", 1);
+            }
 
-    SohImGui::EnhancementSliderInt("Icon size : %dpx", "##ITEMTRACKERICONSIZE", "gRandoTrackIconSize", 25, 128, "", 32,
-                                   true);
-    SohImGui::EnhancementSliderInt("Icon margins : %dpx", "##ITEMTRACKERSPACING", "gRandoTrackIconSpacing", -5, 50, "",
-                                   0, true);
-    // SohImGui::EnhancementSliderInt("X spacing : %dpx", "##ITEMTRACKERSPACINGX", "gRandoTrackIconSpacingX", 0, 256,
-    // ""); SohImGui::EnhancementSliderInt("Y Spacing : %dpx", "##ITEMTRACKERSPACINGY", "gRandoTrackIconSpacingY", 0,
-    // 255, "");
-
-    ImGui::PushItemWidth(ImGui::GetContentRegionAvail().x);
-    ImGui::Text("Chroma Key");
-    auto flags = ImGuiColorEditFlags_AlphaPreview | ImGuiColorEditFlags_AlphaBar | ImGuiColorEditFlags_NoLabel;
-    ImGui::ColorEdit4("Chroma Key Selection", (float*)&ChromaKeyBackground, flags);
-    CVar_SetFloat("gItemTrackerBgColorR", ChromaKeyBackground.x);
-    CVar_SetFloat("gItemTrackerBgColorG", ChromaKeyBackground.y);
-    CVar_SetFloat("gItemTrackerBgColorB", ChromaKeyBackground.z);
-    CVar_SetFloat("gItemTrackerBgColorA", ChromaKeyBackground.w);
-
-    const char* ItemsTrackerTheme[3] = { "One Block", "Grouped style n.1", "Grouped style n.2" };
-    ImGui::Text("Using theme :");
-    SohImGui::EnhancementCombobox("gItemTrackerTheme", ItemsTrackerTheme, 3, 0);
-    SohImGui::EnhancementCheckbox("Edit mode HUD", "gItemTrackerHudEditMode");
-    std::string ResetButtonName = "Reset \"";
-    ResetButtonName += ItemsTrackerTheme[CVar_GetS32("gItemTrackerTheme", 0)];
-    ResetButtonName += "\" theme";
-    if (ImGui::Button(ResetButtonName.c_str())) {
-        ImVec2 OriginPosition = {
-            ImGui::GetMainViewport()->GetWorkCenter().x - 100,
-            ImGui::GetMainViewport()->GetWorkCenter().y - 220,
-        };
-        CVar_SetS32("gRandoTrackIconSize", 32);
-        CVar_SetS32("gRandoTrackIconSpacing", 0);
-        if (CVar_GetS32("gItemTrackerTheme", 0) == 0) { // One block tracker, original tracker style
-            ImVec2 Default_Pos_Wnd_0 = { OriginPosition.x, OriginPosition.y };
-            ImGui::SetWindowPos("ItemTracker_Theme_0_Grouped", Default_Pos_Wnd_0);
-            ImVec2 Default_Pos_Wnd_1 = { OriginPosition.x, OriginPosition.y + 175};
-            ImGui::SetWindowPos("ItemTracker_Theme_0_Dungeons", Default_Pos_Wnd_1);
-            //ImVec2 Default_Pos_Wnd_2 = { OriginPosition.x + 100, OriginPosition.y};
-            //ImGui::SetWindowPos("ItemTracker_Theme_0_Notes", Default_Pos_Wnd_2);
-        } else if (CVar_GetS32("gItemTrackerTheme", 0) == 1) { // Per groups elements N.1
-            ImVec2 Default_Pos_Wnd_0 = { OriginPosition.x, OriginPosition.y };
-            ImGui::SetWindowPos("ItemTracker_Theme_1_Inventory", Default_Pos_Wnd_0);
-            ImVec2 Default_Pos_Wnd_1 = { OriginPosition.x, OriginPosition.y + 175 };
-            ImGui::SetWindowPos("ItemTracker_Theme_1_Stuffs", Default_Pos_Wnd_1);
-            ImVec2 Default_Pos_Wnd_2 = { OriginPosition.x, OriginPosition.y + 340 };
-            ImGui::SetWindowPos("ItemTracker_Theme_1_Tokens", Default_Pos_Wnd_2);
-            ImVec2 Default_Pos_Wnd_3 = { OriginPosition.x + 5, OriginPosition.y + 380 };
-            ImGui::SetWindowPos("ItemTracker_Theme_1_Songs", Default_Pos_Wnd_3);
-            ImVec2 Default_Pos_Wnd_4 = { OriginPosition.x + 100, OriginPosition.y + 175};
-            ImGui::SetWindowPos("ItemTracker_Theme_1_Dungeons", Default_Pos_Wnd_4);
-            //ImVec2 Default_Pos_Wnd_5 = { OriginPosition.x - 100, OriginPosition.y};
-            //ImGui::SetWindowPos("ItemTracker_Theme_1_Notes", Default_Pos_Wnd_5);
-        } else if (CVar_GetS32("gItemTrackerTheme", 0) == 2) { // Per groups elements N.2
-            ImVec2 Default_Pos_Wnd_0 = { OriginPosition.x, OriginPosition.y };
-            ImGui::SetWindowPos("ItemTracker_Theme_2_Inventory", Default_Pos_Wnd_0);
-            ImVec2 Default_Pos_Wnd_1 = { OriginPosition.x, OriginPosition.y + 175 };
-            ImGui::SetWindowPos("ItemTracker_Theme_2_Equips", Default_Pos_Wnd_1);
-            ImVec2 Default_Pos_Wnd_2 = { OriginPosition.x + 100, OriginPosition.y + 170 };
-            ImGui::SetWindowPos("ItemTracker_Theme_2_Upgrade", Default_Pos_Wnd_2);
-            ImVec2 Default_Pos_Wnd_3 = { OriginPosition.x + 100, OriginPosition.y + 250 };
-            ImGui::SetWindowPos("ItemTracker_Theme_2_Quest", Default_Pos_Wnd_3);
-            ImVec2 Default_Pos_Wnd_4 = { OriginPosition.x + 100, OriginPosition.y + 290 };
-            ImGui::SetWindowPos("ItemTracker_Theme_2_Stones", Default_Pos_Wnd_4);
-            ImVec2 Default_Pos_Wnd_5 = { OriginPosition.x, OriginPosition.y + 330 };
-            ImGui::SetWindowPos("ItemTracker_Theme_2_Tokens", Default_Pos_Wnd_5);
-            ImVec2 Default_Pos_Wnd_6 = { OriginPosition.x, OriginPosition.y + 368 };
-            ImGui::SetWindowPos("ItemTracker_Theme_2_Song", Default_Pos_Wnd_6);
-            ImVec2 Default_Pos_Wnd_7 = { OriginPosition.x - 100, OriginPosition.y};
-            ImGui::SetWindowPos("ItemTracker_Theme_2_Dungeons", Default_Pos_Wnd_7);
-            //ImVec2 Default_Pos_Wnd_8 = { OriginPosition.x - 100, OriginPosition.y + 170};
-            //ImGui::SetWindowPos("ItemTracker_Theme_2_Notes", Default_Pos_Wnd_8);
+            ImGui::EndCombo();
         }
+        SohImGui::PaddedEnhancementCheckbox("Only enable while paused", "gItemTrackerHotKeyShowOnlyPaused", 0);
     }
-    SohImGui::EnhancementCheckbox("Alternative medallions display", "gItemTrackerMedallionsPlacement");
-    SohImGui::Tooltip("Will display medallions into a placement that will be from the Quest Menu");
-    
-    SohImGui::EnhancementCheckbox("Key Tracker", "gItemTrackerDisplayDungeonItems");
 
+    SohImGui::PaddedText("Window");
+    ImGui::PushItemWidth(ImGui::GetContentRegionAvail().x);
+    if (ImGui::ColorEdit4("Background Color", (float*)&ChromaKeyBackground, ImGuiColorEditFlags_AlphaPreview | ImGuiColorEditFlags_AlphaBar | ImGuiColorEditFlags_NoLabel)) {
+        CVar_SetFloat("gItemTrackerBgColorR", ChromaKeyBackground.x);
+        CVar_SetFloat("gItemTrackerBgColorG", ChromaKeyBackground.y);
+        CVar_SetFloat("gItemTrackerBgColorB", ChromaKeyBackground.z);
+        CVar_SetFloat("gItemTrackerBgColorA", ChromaKeyBackground.w);
+    }
+    ImGui::PushItemWidth(0);
+    if (ImGui::BeginCombo("Window Type", CVar_GetS32("gItemTrackerWindowType", 0) == 0 ? "Floating" : "Window")) {
+        if (ImGui::Selectable("Floating")) {
+            CVar_SetS32("gItemTrackerWindowType", 0);
+        }
+        if (ImGui::Selectable("Window")) {
+            CVar_SetS32("gItemTrackerWindowType", 1);
+        }
+
+        ImGui::EndCombo();
+    }
+    if (CVar_GetS32("gItemTrackerWindowType", 0) == 0) {
+        SohImGui::PaddedEnhancementCheckbox("Enable Dragging", "gItemTrackerHudEditMode", 0);
+    }
+
+    SohImGui::PaddedText("Icons");
+    SohImGui::EnhancementSliderInt("Icon size : %dpx", "##ITEMTRACKERICONSIZE", "gItemTrackerIconSize", 25, 128, "", 32, true);
+    SohImGui::EnhancementSliderInt("Icon margins : %dpx", "##ITEMTRACKERSPACING", "gItemTrackerIconSpacing", -5, 50, "", 0, true);
+    SohImGui::PaddedEnhancementCheckbox("Display \"Current/Max\" values on items", "gItemTrackerDisplayCurrentMax", 0);
+
+    SohImGui::PaddedText("Items");
+    SohImGui::PaddedEnhancementCheckbox("Display general items in tracker", "gItemTrackerDisplayInventory", 0);
+    if (CVar_GetS32("gItemTrackerDisplayInventory", 0)) {
+        SohImGui::PaddedEnhancementCheckbox("Display general items in separate window", "gItemTrackerDisplayInventorySeparate", 0);
+    }
+
+    SohImGui::PaddedText("Equipment");
+    SohImGui::PaddedEnhancementCheckbox("Display equipment in tracker", "gItemTrackerDisplayEquipment", 0);
+    if (CVar_GetS32("gItemTrackerDisplayEquipment", 0)) {
+        SohImGui::PaddedEnhancementCheckbox("Display equipment in separate window", "gItemTrackerDisplayEquipmentSeparate", 0);
+    }
+
+    SohImGui::PaddedText("Misc Items");
+    SohImGui::PaddedEnhancementCheckbox("Display misc items in tracker", "gItemTrackerDisplayMisc", 0);
+    if (CVar_GetS32("gItemTrackerDisplayMisc", 0)) {
+        SohImGui::PaddedEnhancementCheckbox("Display misc items in separate window", "gItemTrackerDisplayMiscSeparate", 0);
+    }
+
+    SohImGui::PaddedText("Dungeon Rewards");
+    SohImGui::PaddedEnhancementCheckbox("Display dungeon rewards in tracker", "gItemTrackerDisplayDungeonRewards", 0);
+    if (CVar_GetS32("gItemTrackerDisplayDungeonRewards", 0)) {
+        SohImGui::PaddedEnhancementCheckbox("Display dungeon rewards in separate window", "gItemTrackerDisplayDungeonRewardsSeparate", 0);
+    }
+
+    SohImGui::PaddedText("Songs");
+    SohImGui::PaddedEnhancementCheckbox("Display songs in tracker", "gItemTrackerDisplaySongs", 0);
+    if (CVar_GetS32("gItemTrackerDisplaySongs", 0)) {
+        SohImGui::PaddedEnhancementCheckbox("Display songs in separate window", "gItemTrackerDisplaySongsSeparate", 0);
+        SohImGui::PaddedEnhancementCheckbox("Use randomizer colors", "gItemTrackerDisplaySongsRandom", 0);
+    }
+
+    SohImGui::PaddedText("Dungeon Items");
+    SohImGui::PaddedEnhancementCheckbox("Display dungeon items in tracker", "gItemTrackerDisplayDungeonItems", 0);
     if (CVar_GetS32("gItemTrackerDisplayDungeonItems", 0)) {
-    SohImGui::EnhancementCheckbox("Map and Compass Tracker", "gItemTrackerDisplayMapsAndCompasses");
+        SohImGui::PaddedEnhancementCheckbox("Display dungeon items in separate window", "gItemTrackerDisplayDungeonItemsSeparate", 0);
+        if (CVar_GetS32("gItemTrackerDisplayDungeonItemsSeparate", 0)) {
+            SohImGui::PaddedEnhancementCheckbox("Horizontal dungeon items display", "gItemTrackerDisplayDungeonItemsHorizontal", 0);
+        }
+        SohImGui::PaddedEnhancementCheckbox("Maps and compasses", "gItemTrackerDisplayDungeonItemsMaps", 0);
     }
 
     // SohImGui::EnhancementCheckbox("Personal notes space", "gItemTrackerNotes");
@@ -1667,7 +982,6 @@ void DrawItemTrackerOptions(bool& open) {
 }
 
 void InitItemTracker() {
-    CVar_RegisterS32("gRandoTrackIconSize", 32);
     SohImGui::AddWindow("Randomizer", "Item Tracker", DrawItemTracker);
     SohImGui::AddWindow("Randomizer", "Item Tracker Settings", DrawItemTrackerOptions);
     float trackerBgR = CVar_GetFloat("gItemTrackerBgColorR", 0);
@@ -1680,4 +994,7 @@ void InitItemTracker() {
         trackerBgB,
         trackerBgA
     }; // Float value, 1 = 255 in rgb value.
+    Ship::RegisterHook<Ship::ControllerRead>([](OSContPad* cont_pad) {
+        buttonsPressed = cont_pad;
+    });
 }

--- a/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
@@ -14,6 +14,7 @@
 #include "variables.h"
 #include "functions.h"
 #include "macros.h"
+extern GlobalContext* gGlobalCtx;
 
 void DrawEquip(ItemTrackerItem item);
 void DrawItem(ItemTrackerItem item);
@@ -165,7 +166,6 @@ std::vector<uint32_t> buttonMap = {
     BTN_DDOWN,
     BTN_DLEFT,
     BTN_DRIGHT,
-    0
 };
 
 ImVec2 GetItemCurrentAndMax(ItemTrackerItem item) {
@@ -503,8 +503,10 @@ void DrawDungeons(std::vector<ItemTrackerDungeon> dungeons, int columns = 6) {
         ImGui::SameLine(iconSize * i);
         ImGui::SetCursorPosX(ImGui::GetCursorPosX() + iconSpacing * i);
         ImVec2 p = ImGui::GetCursorScreenPos();
-        ImGui::SetCursorScreenPos(ImVec2(p.x - 5 + (iconSize / 2) - 10, p.y - 4));
-        ImGui::Text(dungeons[i].shortName.c_str());
+        std::string dungeonName = dungeons[i].shortName;
+
+        ImGui::SetCursorScreenPos(ImVec2(p.x + (iconSize / 2) - (ImGui::CalcTextSize(dungeonName.c_str()).x / 2), p.y - 4));
+        ImGui::Text(dungeonName.c_str());
     }
     ImGui::EndGroup();
     for (int i = 0; i < MIN(dungeons.size(), columns); i++) {
@@ -589,8 +591,9 @@ void DrawItemTracker(bool& open) {
     int comboButton1Mask = buttonMap[CVar_GetS32("gItemTrackerComboButton1", 6)];
     int comboButton2Mask = buttonMap[CVar_GetS32("gItemTrackerComboButton2", 8)];
     bool comboButtonsHeld = buttonsPressed != nullptr && buttonsPressed[0].button & comboButton1Mask && buttonsPressed[0].button & comboButton2Mask;
+    bool isPaused = CVar_GetS32("gItemTrackerShowOnlyPaused", 0) == 0 || gGlobalCtx != nullptr && gGlobalCtx->pauseCtx.state > 0;
 
-    if (CVar_GetS32("gItemTrackerDisplayType", 0) == 0 ? CVar_GetS32("gItemTrackerEnabled", 0) : comboButtonsHeld) {
+    if (isPaused && (CVar_GetS32("gItemTrackerDisplayType", 0) == 0 ? CVar_GetS32("gItemTrackerEnabled", 0) : comboButtonsHeld)) {
         if (
             (CVar_GetS32("gItemTrackerInventoryItemsDisplayType", 1) == 1) ||
             (CVar_GetS32("gItemTrackerEquipmentItemsDisplayType", 1) == 1) ||
@@ -701,10 +704,10 @@ void DrawItemTrackerOptions(bool& open) {
     ImGui::TableNextColumn();
     LabeledComboBoxRightAligned("Display Mode", "gItemTrackerDisplayType", { "Always", "Combo Button Hold" }, 0);
     if (CVar_GetS32("gItemTrackerDisplayType", 0) > 0) {
-        LabeledComboBoxRightAligned("Combo Button 1", "gItemTrackerComboButton1", { "A", "B", "C-Up", "C-Down", "C-Left", "C-Right", "L", "Z", "R", "Start", "D-Up", "D-Down", "D-Left", "D-Right", "None" }, 6);
-        LabeledComboBoxRightAligned("Combo Button 2", "gItemTrackerComboButton2", { "A", "B", "C-Up", "C-Down", "C-Left", "C-Right", "L", "Z", "R", "Start", "D-Up", "D-Down", "D-Left", "D-Right", "None" }, 8);
-        PaddedEnhancementCheckbox("Only enable while paused", "gItemTrackerHotKeyShowOnlyPaused", 0);
+        LabeledComboBoxRightAligned("Combo Button 1", "gItemTrackerComboButton1", { "A", "B", "C-Up", "C-Down", "C-Left", "C-Right", "L", "Z", "R", "Start", "D-Up", "D-Down", "D-Left", "D-Right" }, 6);
+        LabeledComboBoxRightAligned("Combo Button 2", "gItemTrackerComboButton2", { "A", "B", "C-Up", "C-Down", "C-Left", "C-Right", "L", "Z", "R", "Start", "D-Up", "D-Down", "D-Left", "D-Right" }, 8);
     }
+    PaddedEnhancementCheckbox("Only enable while paused", "gItemTrackerShowOnlyPaused", 0);
     PaddedSeparator();
     ImGui::Text("BG Color");
     ImGui::SameLine();

--- a/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
@@ -271,8 +271,9 @@ void DrawItemCount(ItemTrackerItem item) {
     if (currentAndMax.x > 0) {
         if (currentAndMax.x >= currentAndMax.y) {
             std::string currentString = std::to_string((int)currentAndMax.x);
+            float x = CVar_GetS32("gItemTrackerCurrentOnLeft", 0) ? p.x : p.x + (iconSize / 2) - (ImGui::CalcTextSize(currentString.c_str()).x / 2);
 
-            ImGui::SetCursorScreenPos(ImVec2(p.x + (iconSize / 2) - (ImGui::CalcTextSize(currentString.c_str()).x / 2), p.y - 14));
+            ImGui::SetCursorScreenPos(ImVec2(x, p.y - 14));
             ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(0, 255, 0, 255));
             ImGui::Text("%d", (int)currentAndMax.x);
             ImGui::PopStyleColor();
@@ -288,8 +289,9 @@ void DrawItemCount(ItemTrackerItem item) {
                 ImGui::PopStyleColor();
             } else {
                 std::string currentString = std::to_string((int)currentAndMax.x);
+                float x = CVar_GetS32("gItemTrackerCurrentOnLeft", 0) ? p.x : p.x + (iconSize / 2) - (ImGui::CalcTextSize(currentString.c_str()).x / 2);
 
-                ImGui::SetCursorScreenPos(ImVec2(p.x + (iconSize / 2) - (ImGui::CalcTextSize(currentString.c_str()).x / 2), p.y - 14));
+                ImGui::SetCursorScreenPos(ImVec2(x, p.y - 14));
                 ImGui::Text("%d", (int)currentAndMax.x);
             }
         }
@@ -789,6 +791,9 @@ void DrawItemTrackerOptions(bool& open) {
     SohImGui::EnhancementSliderInt("Icon size : %dpx", "##ITEMTRACKERICONSIZE", "gItemTrackerIconSize", 25, 128, "", 36, true);
     SohImGui::EnhancementSliderInt("Icon margins : %dpx", "##ITEMTRACKERSPACING", "gItemTrackerIconSpacing", -5, 50, "", 12, true);
     PaddedEnhancementCheckbox("Display \"Current/Max\" values", "gItemTrackerDisplayCurrentMax", 0);
+    if (CVar_GetS32("gItemTrackerDisplayCurrentMax", 0) == 0) {
+        PaddedEnhancementCheckbox("Align count to left side", "gItemTrackerCurrentOnLeft", 0);
+    }
 
     ImGui::TableNextColumn();
 

--- a/soh/soh/Enhancements/randomizer/randomizer_item_tracker.h
+++ b/soh/soh/Enhancements/randomizer/randomizer_item_tracker.h
@@ -22,14 +22,5 @@ typedef struct ItemTrackerItem {
 
 typedef struct ItemTrackerDungeon {
     uint32_t id;
-    std::string shortName;
-    bool hasMap;
-    bool hasCompass;
-    bool hasBossKey;
-    bool hasSmallKey;
+    std::vector<uint32_t> items;
 } ItemTrackerDungeon;
-
-#define ITEM_TRACKER_DUNGEON(id, shortName, hasMap, hasCompass, hasBossKey, hasSmallKey)  \
-    {                                                                                     \
-        id, shortName, hasMap, hasCompass, hasBossKey, hasSmallKey                        \
-    }

--- a/soh/soh/Enhancements/randomizer/randomizer_item_tracker.h
+++ b/soh/soh/Enhancements/randomizer/randomizer_item_tracker.h
@@ -1,5 +1,35 @@
 #pragma once
 
+#include <string>
+#include <vector>
+
 void InitItemTracker();
 void DrawItemTracker(bool& open);
 void DrawItemAmmo(int itemId);
+
+typedef struct ItemTrackerItem {
+    uint32_t id;
+    std::string name;
+    std::string nameFaded;
+    uint32_t data;
+    void (*drawFunc)(ItemTrackerItem);
+} ItemTrackerItem;
+
+#define ITEM_TRACKER_ITEM(id, data, drawFunc)     \
+    {                                             \
+        id, #id, #id "_Faded", data, drawFunc     \
+    }
+
+typedef struct ItemTrackerDungeon {
+    uint32_t id;
+    std::string shortName;
+    bool hasMap;
+    bool hasCompass;
+    bool hasBossKey;
+    bool hasSmallKey;
+} ItemTrackerDungeon;
+
+#define ITEM_TRACKER_DUNGEON(id, shortName, hasMap, hasCompass, hasBossKey, hasSmallKey)  \
+    {                                                                                     \
+        id, shortName, hasMap, hasCompass, hasBossKey, hasSmallKey                        \
+    }


### PR DESCRIPTION
### What
Basically a complete re-write of the Item Tracker file, more DRY, and a few more features. 
- Re-added Notes
- Replaced manual placement of each individual item with vectors and a `drawItemsInRows(numColumns)` method
- Added button combo to display the tracker when held
- Reorganized/Redone settings panel
- Refactored item counts to work on more items and more inline with other trackers
- Add ability to toggle or separate each section individually
- Background no longer based on dragging mode, just use the alpha channel in the color to make it transparent

### TODO:
- [x] Items disabled unless valid save file
- [x] Persist display state through restarts
- [x] Crashing when you "restart"
- [x] Better align dungeon reward stones
- [x] Currently notes "separate" option starts it as a tiny box
- [x] Button combo on pause not respected
- [x] Align dungeon names better for key tracker (Done except for the first item per row, not sure what's causing it to be padded, will revisit later)

<img width="2032" alt="Screen Shot 2022-08-23 at 12 30 47 AM" src="https://user-images.githubusercontent.com/7316699/186077571-12d0a84f-a0e8-4c40-aba0-7d4b1c00bba8.png">
<img width="2032" alt="Screen Shot 2022-08-23 at 12 30 32 AM" src="https://user-images.githubusercontent.com/7316699/186077594-99ae8f8c-579a-4155-b332-a48cddeb1076.png">


Overview of the vectors/methods, also probably more helpful to look at the new file than the diff, as so much as changed
https://github.com/HarbourMasters/Shipwright/blob/20737a20451bab8e586d195c2687abea4ffac520/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
<img width="328" alt="Screen Shot 2022-08-19 at 2 46 16 PM" src="https://user-images.githubusercontent.com/7316699/185696005-778d4b4e-6846-466a-a6eb-cdf48c2af1be.png">