### PR TITLE
Stops syncing GS Flags with GS Token Count with Skullsanity on

### DIFF
--- a/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
+++ b/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
@@ -911,15 +911,19 @@ void DrawFlagsTab() {
             setMask <<= 1;
         }
 
-        static bool keepGsCountUpdated = true;
-        ImGui::Checkbox("Keep GS Count Updated", &keepGsCountUpdated);
-        InsertHelpHoverText("Automatically adjust the number of gold skulltula tokens acquired based on set flags");
-        int32_t gsCount = 0;
-        if (keepGsCountUpdated) {
-            for (int32_t gsFlagIndex = 0; gsFlagIndex < 6; gsFlagIndex++) {
-                gsCount += std::popcount(static_cast<uint32_t>(gSaveContext.gsFlags[gsFlagIndex]));
+        // If playing a Randomizer Save with Shuffle Skull Tokens on anything other than "Off" we don't want to keep
+        // GS Token Count updated, since Gold Skulltulas killed will not correlate to GS Tokens Collected.
+        if (!(gSaveContext.n64ddFlag && OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_SHUFFLE_TOKENS))) {
+            static bool keepGsCountUpdated = true;
+            ImGui::Checkbox("Keep GS Count Updated", &keepGsCountUpdated);
+            InsertHelpHoverText("Automatically adjust the number of gold skulltula tokens acquired based on set flags.");
+            int32_t gsCount = 0;
+            if (keepGsCountUpdated) {
+                for (int32_t gsFlagIndex = 0; gsFlagIndex < 6; gsFlagIndex++) {
+                    gsCount += std::popcount(static_cast<uint32_t>(gSaveContext.gsFlags[gsFlagIndex]));
+                }
+                gSaveContext.inventory.gsTokens = gsCount;
             }
-            gSaveContext.inventory.gsTokens = gsCount;
         }
     });
 


### PR DESCRIPTION
Removes the checkbox and syncing functionality from the save editor while in a Randomized Save File with Skullsanity on. Skulltula flags set will not necessarily correlate to the amount of tokens the player has in this state, so the automatic sync should not occur. When in a vanilla save file, or a randomized one with Skullsanity turned off, the checkbox is rendered and syncing the token count is allowed as normal.