### PR TITLE
Prevents optimizations for debug configuration on Windows.

### DIFF
--- a/libultraship/libultraship/CMakeLists.txt
+++ b/libultraship/libultraship/CMakeLists.txt
@@ -569,6 +569,10 @@ target_include_directories(${PROJECT_NAME} PRIVATE
 if(MSVC)
     if("${CMAKE_VS_PLATFORM_NAME}" STREQUAL "x64")
         target_compile_options(${PROJECT_NAME} PRIVATE
+            $<$<CONFIG:Debug>:
+                /Od;
+                /Oi-
+            >
             $<$<CONFIG:Release>:
                 /std:c++latest;
                 /Oi;

--- a/soh/CMakeLists.txt
+++ b/soh/CMakeLists.txt
@@ -1739,7 +1739,8 @@ if(MSVC)
         target_compile_options(${PROJECT_NAME} PRIVATE
             $<$<CONFIG:Debug>:
                 /sdl-;
-                /w
+                /w;
+                /Od
             >
             $<$<CONFIG:Release>:
                 /Oi;

--- a/soh/CMakeLists.txt
+++ b/soh/CMakeLists.txt
@@ -1738,16 +1738,15 @@ if(MSVC)
     if("${CMAKE_VS_PLATFORM_NAME}" STREQUAL "x64")
         target_compile_options(${PROJECT_NAME} PRIVATE
             $<$<CONFIG:Debug>:
-                /sdl-;
                 /w;
                 /Od
             >
             $<$<CONFIG:Release>:
                 /Oi;
-                /sdl-;
                 /Gy;
                 /W3
             >
+            /sdl-;
             /permissive-;
             /MP;
             ${DEFAULT_CXX_DEBUG_INFORMATION_FORMAT};


### PR DESCRIPTION
I was noticing while debugging in VSCode on Windows that some variables were still getting optimized away, despite my CMake configuration being set to Debug. After doing a little bit of digging I found this: https://docs.microsoft.com/en-us/cpp/build/reference/o-options-optimize-code?view=msvc-170. Specifically:

> /Ot (a default setting) tells the compiler to favor optimizations for speed over optimizations for size.

The Debug configurations of `soh` and `libultraship` in their respective CMakeLists.txt were not overriding this default value, at least on `x64`. So I added the `/Od` flag to `soh`'s Debug config in `target_compile_options`, and in `libultraship`'s case I had to add the entire Debug configurations section to `target_compile_options`. After that I had no further issues with variables being optimized away in either project.