### PR TITLE
move fixup to main CMakeLists to cover ZAPD.out as well (MacOS)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,6 +195,11 @@ install(DIRECTORY ${CMAKE_BINARY_DIR}/assets
         PERMISSIONS ${PROGRAM_PERMISSIONS_EXECUTE}
         )
 
+install(CODE "
+    include(BundleUtilities)
+    fixup_bundle(\"\${CMAKE_INSTALL_PREFIX}/soh-macos\" \"\" \"${dirs}\")
+    ")
+
 endif()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Windows|NintendoSwitch|CafeOS")

--- a/soh/CMakeLists.txt
+++ b/soh/CMakeLists.txt
@@ -1983,14 +1983,6 @@ elseif(NOT "${CMAKE_SYSTEM_NAME}" MATCHES "NintendoSwitch|CafeOS")
 INSTALL(FILES ${CMAKE_BINARY_DIR}/gamecontrollerdb.txt DESTINATION . COMPONENT ship)
 endif()
 
-if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
-install(CODE "
-    include(InstallRequiredSystemLibraries)
-    include(BundleUtilities)
-    fixup_bundle(\"\${CMAKE_INSTALL_PREFIX}/soh-macos\" \"\" \"${dirs}\")
-    ")
-endif()
-
 if(CMAKE_SYSTEM_NAME MATCHES "NintendoSwitch|CafeOS")
     if (NOT TARGET pathconf)
         add_library(pathconf OBJECT platform/pathconf.c)


### PR DESCRIPTION
With the current sequence ZAPD.out is installed after fixup_bundle is run. This will omit the libpng. Moving fixup_bundle to the end of CMakeLists.txt solves this. Now ZAPD.out is installed before fixup_bundle is run and will therefore also be fixed. 