### PR TITLE
Add platform specific OTR instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ If you get any errors, then you might have selected the wrong rom. Make sure to 
 * Run `soh.app`, and when prompted, select one of the supported roms listed above.
 * You should see a notification saying `Processing OTR`, then, once the process is complete, you should get a notification saying `OTR Successfully Generated`, then the game should start.
 
-The packing process can take up to **5 minutes**
+The packing process can take up to **5 minutes**.
 
 If you get an error saying `Incompatible ROM hash`, you have selected the wrong rom, make sure the checksum matches one of the ones listed above.
 

--- a/README.md
+++ b/README.md
@@ -31,16 +31,47 @@ Congratulations, you are now sailing with the Ship of Harkinian! Have fun!
 
 The Ship of Harkinian uses a proprietary versioning system consisting of a sci-fi film character followed by a phonetic alphabet code word. The film character represents a major release version which increments with the addition of many new features and bug fixes. The code word represents a minor release version which increments with small updates mainly comprised of bug fixes. For example, `DECKARD ALFA`.
 
-### The Extraction Tool
+### Windows Rom Extraction
 
-* Open a rom to initiate generating the `oot.otr` archive file.
-* If a second button exists then `oot.otr` already exists. To prevent overwriting the old `oot.otr` use this button to choose a new game directory. The new directory must not already contain an `oot.otr` to prevent an error.
+* Open OTRGui.exe, and select one of the supported roms listed above, to generate the `oot.otr` archive file.
+* If a second button already exits then `oot.otr` already exists. To prevent overwriting the old `oot.otr` use this button to choose a new game directory. The new directory must not already contain an `oot.otr` to prevent an error.
 * When the process completes, place `oot.otr` beside `soh.exe` if it is not already.
 
 This packaging process can take up to **5 minutes**.
 
 Close the OTRGui when the `Done!` message appears.
 If you get another message, then you might have selected the wrong rom. Make sure to use a rom consistent with the above checksum.
+
+### Linux Rom Extraction
+
+* Place one of the supported roms in the same folder as the appimage.
+* When you run the soh appimage, it should begin generating the `oot.otr` archive file.
+* When the process completes, place `oot.otr` in the same folder as the appimage, if it is not already, then run the appimage.
+
+The packaging process can take up to **5 minutes**.
+
+If you get any errors, then you might have selected the wrong rom. Make sure to use a rom consistent with the above checksum.
+
+### MacOS Rom Extraction
+
+* Run `soh.app`, and when prompted, select one of the supported roms listed above.
+* You should see a notification saying `Processing OTR`, then, once the process is complete, you should get a notification saying `OTR Successfully Generated`, then the game should start.
+
+The packing process can take up to **5 minutes**
+
+If you get an error saying `Incompatible ROM hash`, you have selected the wrong rom, make sure the checksum matches one of the ones listed above.
+
+### Nintendo Switch Rom Extraction
+
+* Download the latest PC release of the Ship of Harkinian, and follow the instructions above for generating the `oot.otr` archive on that platform.
+* Place the `.nro` and the `oot.otr` archive into a folder called `soh` in your Switch folder on your Switch
+
+### Nintendo Wii U Rom Extraction
+
+* Download the latest PC release of the Ship of Harkinian, and follow hte instructions above for generating the `oot.otr` archive on that platform.
+* Copy the `.rpx` and the `oot.otr` archive to `wiiu/apps/soh`
+
+---
 
 If you still cannot get the tool to work, join our [Discord Server](https://discord.com/invite/BtBmd55HVH) and ask for help in the `#support` text channel. Keep-in-mind that we do not condone piracy in any way.
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ If you get an error saying `Incompatible ROM hash`, you have selected the wrong 
 
 ### Nintendo Wii U Rom Extraction
 
-* Download the latest PC release of the Ship of Harkinian, and follow hte instructions above for generating the `oot.otr` archive on that platform.
+* Download the latest PC release of the Ship of Harkinian, and follow the instructions above for generating the `oot.otr` archive on that platform.
 * Copy the `.rpx` and the `oot.otr` archive to `wiiu/apps/soh`
 
 ---


### PR DESCRIPTION
We get quite a few people in the Discord server coming into the port channels asking how to generate OTR files on these platforms, as it isn't explained in the readme for anything apart from Windows, and given all these platforms are officially supported now, it makes sense to have instructions for all of them, since OTRGui only applies to Windows.