### PR TITLE
Rando: Custom key colors fix

### DIFF
--- a/soh/src/code/z_player_lib.c
+++ b/soh/src/code/z_player_lib.c
@@ -1170,7 +1170,8 @@ void Player_DrawGetItemImpl(GlobalContext* globalCtx, Player* this, Vec3f* refPo
     Matrix_RotateZYX(0, globalCtx->gameplayFrames * 1000, 0, MTXMODE_APPLY);
     Matrix_Scale(0.2f, 0.2f, 0.2f, MTXMODE_APPLY);
 
-    if (this->getItemEntry.drawFunc != NULL && CVar_GetS32("gRandoMatchKeyColors", 0)) {
+    if (this->getItemEntry.drawFunc != NULL &&
+        (CVar_GetS32("gRandoMatchKeyColors", 0) || this->getItemEntry.getItemId == RG_DOUBLE_DEFENSE)) {
         this->getItemEntry.drawFunc(globalCtx, &this->getItemEntry);
     } else {
         GetItem_Draw(globalCtx, drawIdPlusOne - 1);

--- a/soh/src/code/z_player_lib.c
+++ b/soh/src/code/z_player_lib.c
@@ -1170,6 +1170,7 @@ void Player_DrawGetItemImpl(GlobalContext* globalCtx, Player* this, Vec3f* refPo
     Matrix_RotateZYX(0, globalCtx->gameplayFrames * 1000, 0, MTXMODE_APPLY);
     Matrix_Scale(0.2f, 0.2f, 0.2f, MTXMODE_APPLY);
 
+    // RANDOTODO: Make this more flexible for easier toggling of individual item recolors in the future.
     if (this->getItemEntry.drawFunc != NULL &&
         (CVar_GetS32("gRandoMatchKeyColors", 0) || this->getItemEntry.getItemId == RG_DOUBLE_DEFENSE)) {
         this->getItemEntry.drawFunc(globalCtx, &this->getItemEntry);

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -12667,6 +12667,14 @@ s32 func_8084DFF4(GlobalContext* globalCtx, Player* this) {
                 this->stateFlags1 &= ~PLAYER_STATE1_29;
                 func_80852FFC(globalCtx, NULL, 8);
             }
+
+            // Set unk_862 to 0 early to not have the game draw non-custom colored models for a split second.
+            // This unk is what the game normally uses to decide what item to draw when holding up an item above Link's head.
+            // Only do this when the item actually has a custom draw function.
+            if (this->getItemEntry.drawFunc != NULL) {
+                this->unk_862 = 0;
+            }
+
             this->getItemId = GI_NONE;
             this->getItemEntry = (GetItemEntry)GET_ITEM_NONE;
         }


### PR DESCRIPTION
Items with a custom color draw function were showing the "vanilla" colors for a split second when Link held an item above his head and dismissing the textbox.

Double defense was also still showing the vanilla heart container colors when Link was holding it above his head, fixed now.