### PR TITLE
Rando: Fix Winner PoH on skulltula's

### DIFF
--- a/soh/src/overlays/actors/ovl_En_Si/z_en_si.c
+++ b/soh/src/overlays/actors/ovl_En_Si/z_en_si.c
@@ -17,7 +17,8 @@ s32 func_80AFB748(EnSi* this, GlobalContext* globalCtx);
 void func_80AFB768(EnSi* this, GlobalContext* globalCtx);
 void func_80AFB89C(EnSi* this, GlobalContext* globalCtx);
 void func_80AFB950(EnSi* this, GlobalContext* globalCtx);
-void Randomizer_GrantSkullReward(EnSi* this, GlobalContext* globalCtx);
+void Randomizer_GetSkullReward(EnSi* this, GlobalContext* globalCtx);
+void Randomizer_GiveSkullReward(EnSi* this, GlobalContext* globalCtx);
 
 s32 textId = 0xB4;
 s32 giveItemId = ITEM_SKULL_TOKEN;
@@ -99,21 +100,25 @@ void func_80AFB768(EnSi* this, GlobalContext* globalCtx) {
 
             if (this->collider.base.ocFlags2 & OC2_HIT_PLAYER) {
                 this->collider.base.ocFlags2 &= ~OC2_HIT_PLAYER;
+
                 if (gSaveContext.n64ddFlag) {
-                    Randomizer_GrantSkullReward(this, globalCtx);
+                    Randomizer_GetSkullReward(this, globalCtx);
                 } else {
                     Item_Give(globalCtx, giveItemId);
                 }
                 if ((CVar_GetS32("gSkulltulaFreeze", 0) != 1 || giveItemId != ITEM_SKULL_TOKEN) && getItemId != RG_ICE_TRAP) {
                     player->actor.freezeTimer = 20;
                 }
+
                 Message_StartTextbox(globalCtx, textId, NULL);
 
                 if (gSaveContext.n64ddFlag && getItemId != RG_ICE_TRAP) {
+                    Randomizer_GiveSkullReward(this, globalCtx);
                     Audio_PlayFanfare_Rando(getItem);
                 } else {
                     Audio_PlayFanfare(NA_BGM_SMALL_ITEM_GET);
                 }
+
                 player->getItemEntry = (GetItemEntry)GET_ITEM_NONE;
                 this->actionFunc = func_80AFB950;
             } else {
@@ -133,16 +138,20 @@ void func_80AFB89C(EnSi* this, GlobalContext* globalCtx) {
 
     if (!CHECK_FLAG_ALL(this->actor.flags, ACTOR_FLAG_13)) {
         if (gSaveContext.n64ddFlag) {
-            Randomizer_GrantSkullReward(this, globalCtx);
+            Randomizer_GetSkullReward(this, globalCtx);
         } else {
             Item_Give(globalCtx, giveItemId);
         }
+
         Message_StartTextbox(globalCtx, textId, NULL);
+
         if (gSaveContext.n64ddFlag && getItemId != RG_ICE_TRAP) {
+            Randomizer_GiveSkullReward(this, globalCtx);
             Audio_PlayFanfare_Rando(getItem);
         } else {
             Audio_PlayFanfare(NA_BGM_SMALL_ITEM_GET);
         }
+
         player->getItemEntry = (GetItemEntry)GET_ITEM_NONE;
         this->actionFunc = func_80AFB950;
     }
@@ -190,7 +199,7 @@ void EnSi_Draw(Actor* thisx, GlobalContext* globalCtx) {
     }
 }
 
-void Randomizer_GrantSkullReward(EnSi* this, GlobalContext* globalCtx) {
+void Randomizer_GetSkullReward(EnSi* this, GlobalContext* globalCtx) {
     Player* player = GET_PLAYER(globalCtx);
 
     getItem = Randomizer_GetRandomizedItem(GI_SKULL_TOKEN, this->actor.id, this->actor.params, globalCtx->sceneNum);
@@ -201,12 +210,16 @@ void Randomizer_GrantSkullReward(EnSi* this, GlobalContext* globalCtx) {
     } else {
         textId = getItem.textId;
         giveItemId = getItem.itemId;
-        if (getItem.modIndex == MOD_NONE) {
-            Item_Give(globalCtx, giveItemId);
-        } else if (getItem.modIndex == MOD_RANDOMIZER) {
-            Randomizer_Item_Give(globalCtx, getItem);
-        }
     }
-    // player->getItemId = getItemId;
+}
+
+void Randomizer_GiveSkullReward(EnSi* this, GlobalContext* globalCtx) {
+    Player* player = GET_PLAYER(globalCtx);
+
+    if (getItem.modIndex == MOD_NONE) {
+        Item_Give(globalCtx, giveItemId);
+    } else if (getItem.modIndex == MOD_RANDOMIZER) {
+        Randomizer_Item_Give(globalCtx, getItem);
+    }
     player->getItemEntry = getItem;
 }

--- a/soh/src/overlays/actors/ovl_En_Si/z_en_si.c
+++ b/soh/src/overlays/actors/ovl_En_Si/z_en_si.c
@@ -205,6 +205,7 @@ void Randomizer_GetSkullReward(EnSi* this, GlobalContext* globalCtx) {
     getItem = Randomizer_GetRandomizedItem(GI_SKULL_TOKEN, this->actor.id, this->actor.params, globalCtx->sceneNum);
     getItemId = getItem.getItemId;
     if (getItemId == RG_ICE_TRAP) {
+        player->getItemEntry = getItem;
         player->pendingIceTrap = true;
         textId = 0xF8;
     } else {

--- a/soh/src/overlays/actors/ovl_En_Si/z_en_si.c
+++ b/soh/src/overlays/actors/ovl_En_Si/z_en_si.c
@@ -17,7 +17,7 @@ s32 func_80AFB748(EnSi* this, GlobalContext* globalCtx);
 void func_80AFB768(EnSi* this, GlobalContext* globalCtx);
 void func_80AFB89C(EnSi* this, GlobalContext* globalCtx);
 void func_80AFB950(EnSi* this, GlobalContext* globalCtx);
-void Randomizer_GetSkullReward(EnSi* this, GlobalContext* globalCtx);
+void Randomizer_UpdateSkullReward(EnSi* this, GlobalContext* globalCtx);
 void Randomizer_GiveSkullReward(EnSi* this, GlobalContext* globalCtx);
 
 s32 textId = 0xB4;
@@ -102,7 +102,7 @@ void func_80AFB768(EnSi* this, GlobalContext* globalCtx) {
                 this->collider.base.ocFlags2 &= ~OC2_HIT_PLAYER;
 
                 if (gSaveContext.n64ddFlag) {
-                    Randomizer_GetSkullReward(this, globalCtx);
+                    Randomizer_UpdateSkullReward(this, globalCtx);
                 } else {
                     Item_Give(globalCtx, giveItemId);
                 }
@@ -138,7 +138,7 @@ void func_80AFB89C(EnSi* this, GlobalContext* globalCtx) {
 
     if (!CHECK_FLAG_ALL(this->actor.flags, ACTOR_FLAG_13)) {
         if (gSaveContext.n64ddFlag) {
-            Randomizer_GetSkullReward(this, globalCtx);
+            Randomizer_UpdateSkullReward(this, globalCtx);
         } else {
             Item_Give(globalCtx, giveItemId);
         }
@@ -199,7 +199,7 @@ void EnSi_Draw(Actor* thisx, GlobalContext* globalCtx) {
     }
 }
 
-void Randomizer_GetSkullReward(EnSi* this, GlobalContext* globalCtx) {
+void Randomizer_UpdateSkullReward(EnSi* this, GlobalContext* globalCtx) {
     Player* player = GET_PLAYER(globalCtx);
 
     getItem = Randomizer_GetRandomizedItem(GI_SKULL_TOKEN, this->actor.id, this->actor.params, globalCtx->sceneNum);


### PR DESCRIPTION
Resolves https://github.com/HarbourMasters/Shipwright/issues/932

This is a bit of a weird one. I was granting the item before initiating the text box (as that's what vanilla did before), but the WINNER! text ID gets incremented by the amount of heart pieces collected. Because the piece of heart was granted before the text box was drawn, it already took that PoH into account when showing the text box, resulting in the text ID always being 1 too high.

So instead, I seperated the part where it's getting the randomized item + text ID and the part where it's granting the item. This way I can show the correct textbox before granting the item, fixing the issue.

As a sidenote, this was also happening with regular PoH's, not just the WINNER! ones.