### PR TITLE
Rando: Small menu tweaks

### DIFF
--- a/libultraship/libultraship/ImGuiImpl.cpp
+++ b/libultraship/libultraship/ImGuiImpl.cpp
@@ -2001,22 +2001,22 @@ namespace SohImGui {
 
                 if (ImGui::BeginMenu("Rando Enhancements"))
                 {
-                    EnhancementCheckbox("Quest Item Fanfares", "gRandoQuestItemFanfares");
+                    EnhancementCheckbox("Rando-Relevant Navi Hints", "gRandoRelevantNavi");
                     Tooltip(
-                        "Play unique fanfares when obtaining quest items "
-                        "(medallions/stones/songs). Note that these fanfares are longer than usual."
+                        "Replace Navi's overworld quest hints with rando-related gameplay hints."
                     );
                     PaddedEnhancementCheckbox("Random Rupee Names", "gRandomizeRupeeNames", true, false);
                     Tooltip(
                         "When obtaining rupees, randomize what the rupee is called in the textbox."
                     );
-                    PaddedEnhancementCheckbox("Rando-Relevant Navi Hints", "gRandoRelevantNavi", true, false);
-                    Tooltip(
-                        "Replace Navi's overworld quest hints with rando-related gameplay hints."
-                    );
                     PaddedEnhancementCheckbox("Key Colors Match Dungeon", "gRandoMatchKeyColors", true, false);
                     Tooltip(
                         "Matches the color of small keys and boss keys to the dungeon they belong to. This helps identify keys from afar and adds a little bit of flair.");
+                    PaddedEnhancementCheckbox("Quest Item Fanfares", "gRandoQuestItemFanfares", true, false);
+                    Tooltip(
+                        "Play unique fanfares when obtaining quest items "
+                        "(medallions/stones/songs). Note that these fanfares are longer than usual."
+                    );
                     ImGui::EndMenu();
                 }
 

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -3328,7 +3328,7 @@ void DrawRandoEditor(bool& open) {
             if (ImGui::BeginTable("tableRandoOther", 3, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV)) {
                 ImGui::TableSetupColumn("Timesavers", ImGuiTableColumnFlags_WidthStretch, 200.0f);
                 ImGui::TableSetupColumn("World Settings", ImGuiTableColumnFlags_WidthStretch, 200.0f);
-                ImGui::TableSetupColumn("Hint & Item Pool Settings", ImGuiTableColumnFlags_WidthStretch, 200.0f);
+                ImGui::TableSetupColumn("Item Pool & Hint Settings", ImGuiTableColumnFlags_WidthStretch, 200.0f);
                 ImGui::PushItemFlag(ImGuiItemFlags_Disabled, true);
                 ImGui::TableHeadersRow();
                 ImGui::PopItemFlag();
@@ -3408,10 +3408,41 @@ void DrawRandoEditor(bool& open) {
                 
                 ImGui::PopItemWidth();
 
-                // COLUMN 3 - HINT & ITEM POOL SETTINGS
+                // COLUMN 3 - ITEM POOL & HINT SETTINGS
                 ImGui::TableNextColumn();
                 window->DC.CurrLineTextBaseOffset = 0.0f;
                 ImGui::PushItemWidth(-FLT_MIN);
+
+                ImGui::Text(Settings::ItemPoolValue.GetName().c_str());
+                InsertHelpHoverText("Sets how many major items appear in the item pool.\n"
+                                    "\n"
+                                    "Plentiful - Extra major items are added to the pool.\n"
+                                    "\n"
+                                    "Balanced - Original item pool.\n"
+                                    "\n"
+                                    "Scarce - Some excess items are removed, including health upgrades.\n"
+                                    "\n"
+                                    "Minimal - Most excess items are removed.");
+                SohImGui::EnhancementCombobox("gRandomizeItemPool", randoItemPool, 4, 1);
+                PaddedSeparator();
+
+                // Ice Traps
+                ImGui::Text(Settings::IceTrapValue.GetName().c_str());
+                InsertHelpHoverText("Sets how many items are replaced by ice traps.\n"
+                                    "\n"
+                                    "Off - No ice traps.\n"
+                                    "\n"
+                                    "Normal - Only Ice Traps from the base item pool are shuffled in.\n"
+                                    "\n"
+                                    "Extra - Chance to replace added junk items with additional ice traps.\n"
+                                    "\n"
+                                    "Mayhem - All added junk items will be Ice Traps.\n"
+                                    "\n"
+                                    "Onslaught - All junk items will be replaced by Ice Traps, even those "
+                                    "in the base pool.");
+                SohImGui::EnhancementCombobox("gRandomizeIceTraps", randoIceTraps, 5, 1);
+
+                PaddedSeparator();
 
                 // Gossip Stone Hints
                 ImGui::Text(Settings::GossipStoneHints.GetName().c_str());
@@ -3462,36 +3493,6 @@ void DrawRandoEditor(bool& open) {
                     ImGui::Unindent();
                 }
 
-                PaddedSeparator();
-
-                ImGui::Text(Settings::ItemPoolValue.GetName().c_str());
-                InsertHelpHoverText("Sets how many major items appear in the item pool.\n"
-                                    "\n"
-                                    "Plentiful - Extra major items are added to the pool.\n"
-                                    "\n"
-                                    "Balanced - Original item pool.\n"
-                                    "\n"
-                                    "Scarce - Some excess items are removed, including health upgrades.\n"
-                                    "\n"
-                                    "Minimal - Most excess items are removed.");
-                SohImGui::EnhancementCombobox("gRandomizeItemPool", randoItemPool, 4, 1);
-                PaddedSeparator();
-
-                // Ice Traps
-                ImGui::Text(Settings::IceTrapValue.GetName().c_str());
-                InsertHelpHoverText("Sets how many items are replaced by ice traps.\n"
-                                    "\n"
-                                    "Off - No ice traps.\n"
-                                    "\n"
-                                    "Normal - Only Ice Traps from the base item pool are shuffled in.\n"
-                                    "\n"
-                                    "Extra - Chance to replace added junk items with additional ice traps.\n"
-                                    "\n"
-                                    "Mayhem - All added junk items will be Ice Traps.\n"
-                                    "\n"
-                                    "Onslaught - All junk items will be replaced by Ice Traps, even those "
-                                    "in the base pool.");
-                SohImGui::EnhancementCombobox("gRandomizeIceTraps", randoIceTraps, 5, 1);
                 ImGui::PopItemWidth();
                 ImGui::EndTable();
             }

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -3327,8 +3327,8 @@ void DrawRandoEditor(bool& open) {
             ImGui::PushStyleVar(ImGuiStyleVar_CellPadding, cellPadding);
             if (ImGui::BeginTable("tableRandoOther", 3, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV)) {
                 ImGui::TableSetupColumn("Timesavers", ImGuiTableColumnFlags_WidthStretch, 200.0f);
-                ImGui::TableSetupColumn("Hint Settings", ImGuiTableColumnFlags_WidthStretch, 200.0f);
-                ImGui::TableSetupColumn("Item Pool Settings", ImGuiTableColumnFlags_WidthStretch, 200.0f);
+                ImGui::TableSetupColumn("World Settings", ImGuiTableColumnFlags_WidthStretch, 200.0f);
+                ImGui::TableSetupColumn("Hint & Item Pool Settings", ImGuiTableColumnFlags_WidthStretch, 200.0f);
                 ImGui::PushItemFlag(ImGuiItemFlags_Disabled, true);
                 ImGui::TableHeadersRow();
                 ImGui::PopItemFlag();
@@ -3400,7 +3400,15 @@ void DrawRandoEditor(bool& open) {
                     "The cutscenes of the Poes in Forest Temple and Darunia in Fire Temple will not be skipped. "
                     "These cutscenes are only useful for glitched gameplay and can be safely skipped otherwise.");
 
-                // COLUMN 2 - HINT SETTINGS
+                // COLUMN 2 - WORLD SETTINGS
+                ImGui::TableNextColumn();
+                window->DC.CurrLineTextBaseOffset = 0.0f;
+                ImGui::PushItemWidth(-FLT_MIN);
+                ImGui::Text("Coming soon");
+                
+                ImGui::PopItemWidth();
+
+                // COLUMN 3 - HINT & ITEM POOL SETTINGS
                 ImGui::TableNextColumn();
                 window->DC.CurrLineTextBaseOffset = 0.0f;
                 ImGui::PushItemWidth(-FLT_MIN);
@@ -3453,12 +3461,9 @@ void DrawRandoEditor(bool& open) {
                     SohImGui::EnhancementCombobox("gRandomizeHintDistribution", randoHintDistribution, 4, 1);
                     ImGui::Unindent();
                 }
-                ImGui::PopItemWidth();
 
-                // COLUMN 3 - ITEM POOL SETTINGS
-                ImGui::TableNextColumn();
-                window->DC.CurrLineTextBaseOffset = 0.0f;
-                ImGui::PushItemWidth(-FLT_MIN);
+                PaddedSeparator();
+
                 ImGui::Text(Settings::ItemPoolValue.GetName().c_str());
                 InsertHelpHoverText("Sets how many major items appear in the item pool.\n"
                                     "\n"


### PR DESCRIPTION
This is partly a proposal.

I rearranged the settings in the Rando Enhancements menu so the options that are on by default are at the top, and the options are sorted from what I think will be the most used options to the least used options.

Old:
![image](https://user-images.githubusercontent.com/4244591/186626074-76db49a8-129b-4f1d-85c5-92a4c0df2a6e.png)

New:
![image](https://user-images.githubusercontent.com/4244591/186625872-e222d5b8-dbbb-41c5-821f-56a85bb75e37.png)

Also, I moved Hint Settings in the "Other" tab to reserve a spot for entrance rando and bombchu's in logic. Down the line this can also hold "Starting Location" and "Starting Age" for example.

Old:
![image](https://user-images.githubusercontent.com/4244591/186626162-9dfad8bd-70ff-4276-85be-0e30b49d2646.png)

New:
![image](https://user-images.githubusercontent.com/4244591/186693879-2ddd5dc6-ed64-431d-8680-a0d987447c52.png)

