### PR TITLE
Fixes Dungeon Rewards from Impa on save init with Skip Child Zelda on.

### DIFF
--- a/soh/src/code/z_sram.c
+++ b/soh/src/code/z_sram.c
@@ -701,7 +701,9 @@ void Sram_InitSave(FileChooseContext* fileChooseCtx) {
             s32 giid = getItem.getItemId;
 
             if (getItem.modIndex == MOD_NONE) {
-                if (giid == GI_RUPEE_GREEN || giid == GI_RUPEE_BLUE || giid == GI_RUPEE_RED ||
+                if (getItem.itemId >= ITEM_MEDALLION_FOREST && getItem.itemId <= ITEM_ZORA_SAPPHIRE) {
+                    GiveLinkDungeonReward(getItem.getItemId);
+                } else if (giid == GI_RUPEE_GREEN || giid == GI_RUPEE_BLUE || giid == GI_RUPEE_RED ||
                         giid == GI_RUPEE_PURPLE || giid == GI_RUPEE_GOLD) {
                     GiveLinkRupeesByGetItemId(giid);
                 } else if (giid == GI_BOMBCHUS_10 || giid == GI_BOMBCHUS_5 || giid == GI_BOMBCHUS_20) {


### PR DESCRIPTION
Fixes Dungeon Rewards from Impa with Skip Child Zelda enabled.