### PR TITLE
Fixes ice trap gidata not getting cleared after randomized ice trap is sprung.

### DIFF
--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -6121,6 +6121,8 @@ s32 func_8083E5A8(Player* this, GlobalContext* globalCtx) {
                     this->actor.colChkInfo.damage = 0;
                     func_80837C0C(globalCtx, this, 3, 0.0f, 0.0f, 0, 20);
                     Player_SetPendingFlag(this, globalCtx);
+                    this->getItemId == GI_NONE;
+                    this->getItemEntry = (GetItemEntry)GET_ITEM_NONE;
                     return 1;
                 }
 
@@ -12866,6 +12868,8 @@ void func_8084E6D4(Player* this, GlobalContext* globalCtx) {
                 } else {
                     this->actor.colChkInfo.damage = 0;
                     func_80837C0C(globalCtx, this, 3, 0.0f, 0.0f, 0, 20);
+                    this->getItemId == GI_NONE;
+                    this->getItemEntry = (GetItemEntry)GET_ITEM_NONE;
                 }
                 return;
             }


### PR DESCRIPTION
Getting a randomized ice trap and interacting with bottleable items caused the player to receive items. In rando-next this resulted in more ice traps, but in develop-zhora this crashed the game. This PR ensures the getItemEntry for the Ice Trap is cleared from the player struct after the trap has been sprung, since approaching these critters sets a getItemId on the player that then triggers the item get code because there's a getItemEntry present.