### PR TITLE
Rando Regression: Fixes Link getting Song as pocket item

### DIFF
--- a/soh/src/code/z_sram.c
+++ b/soh/src/code/z_sram.c
@@ -703,6 +703,8 @@ void Sram_InitSave(FileChooseContext* fileChooseCtx) {
             if (getItem.modIndex == MOD_NONE) {
                 if (getItem.itemId >= ITEM_MEDALLION_FOREST && getItem.itemId <= ITEM_ZORA_SAPPHIRE) {
                     GiveLinkDungeonReward(getItem.getItemId);
+                } else if (getItem.itemId >= ITEM_SONG_MINUET && getItem.itemId <= ITEM_SONG_STORMS) {
+                    GiveLinkSong(getItem.getItemId);
                 } else if (giid == GI_RUPEE_GREEN || giid == GI_RUPEE_BLUE || giid == GI_RUPEE_RED ||
                         giid == GI_RUPEE_PURPLE || giid == GI_RUPEE_GOLD) {
                     GiveLinkRupeesByGetItemId(giid);


### PR DESCRIPTION
Fixes regression for Link receiving a song from Impa with Skip Child Zelda turned on.