### PR TITLE
Changes Malon's behavior to so she won't leave Hyrule Castle until you've obtained her item.

### DIFF
--- a/soh/src/overlays/actors/ovl_En_Ma1/z_en_ma1.c
+++ b/soh/src/overlays/actors/ovl_En_Ma1/z_en_ma1.c
@@ -205,16 +205,15 @@ s32 func_80AA08C4(EnMa1* this, GlobalContext* globalCtx) {
         !(gSaveContext.eventChkInf[1] & 0x10) && !(gSaveContext.infTable[8] & 0x800)) {
         return 1;
     }
-    // Causes Malon to appear at Hyrule Castle if you've met her already and either we're vanilla and Talon hasn't
-    // left Hyrule Castle, or if we're randomized and haven't obtained her check. If we haven't met Malon yet, this
-    // sets the flag for meeting her.
-    if ((globalCtx->sceneNum == SCENE_SPOT15) && (!(gSaveContext.eventChkInf[1] & 0x10) || 
-        (gSaveContext.n64ddFlag && !Randomizer_ObtainedMalonHCReward()))) {
-        if (gSaveContext.infTable[8] & 0x800) {
-            return 1;
-        } else {
-            gSaveContext.infTable[8] |= 0x800;
-            return 0;
+    if ((globalCtx->sceneNum == SCENE_SPOT15) &&  // if we're at hyrule castle
+        (!(gSaveContext.eventChkInf[1] & 0x10) || // and talon hasn't left
+         (gSaveContext.n64ddFlag &&
+          !Randomizer_ObtainedMalonHCReward()))) { // or we're rando'd and haven't gotten malon's HC check
+        if (gSaveContext.infTable[8] & 0x800) {    // if we've met malon
+            return 1;                              // make her appear at the castle
+        } else {                                   // if we haven't met malon
+            gSaveContext.infTable[8] |= 0x800;     // set the flag for meeting malon
+            return 0;                              // don't make her appear at the castle
         }
     }
     // Malon asleep in her bed if Talon has left Hyrule Castle and it is nighttime.

--- a/soh/src/overlays/actors/ovl_En_Ma1/z_en_ma1.c
+++ b/soh/src/overlays/actors/ovl_En_Ma1/z_en_ma1.c
@@ -309,9 +309,11 @@ void EnMa1_Init(Actor* thisx, GlobalContext* globalCtx) {
     this->actor.targetMode = 6;
     this->unk_1E8.unk_00 = 0;
 
-    // If Talon has not left Hyrule Castle, we are randomized and ahve not obtained Malon's HC Check, we are not randomized
-    // and have Epona's Song, or we are randomized and have obtained Malon's Epona's Song Check. This sets Malon's idle
-    // singing animation in such a way that she has dialog but does not give items or respond to the Ocarina.
+   // To avoid missing a check, we want Malon to have the actionFunc for singing, but not reacting to Ocarina, if any of
+   // the following are true.
+   // 1. Talon has not left Hyrule Castle.
+   // 2. We are Randomized and have not obtained Malon's Weird Egg Check.
+   // 3. We are not Randomized and have obtained Epona's Song
     if (!(gSaveContext.eventChkInf[1] & 0x10) || (gSaveContext.n64ddFlag && !Randomizer_ObtainedMalonHCReward()) || (CHECK_QUEST_ITEM(QUEST_SONG_EPONA) && !gSaveContext.n64ddFlag) ||
         (gSaveContext.n64ddFlag && Flags_GetTreasure(globalCtx, 0x1F))) {
         this->actionFunc = func_80AA0D88;
@@ -345,15 +347,15 @@ void func_80AA0D88(EnMa1* this, GlobalContext* globalCtx) {
         }
     }
 
-    // If we're at Hyrule Castle, and either Talon has left or we're randomized and have obtained Malon's HC Check
-    if ((globalCtx->sceneNum == SCENE_SPOT15) && ((!gSaveContext.n64ddFlag && gSaveContext.eventChkInf[1] & 0x10) || (gSaveContext.n64ddFlag && Randomizer_ObtainedMalonHCReward()))) {
-        // Only kill Malon's Actor here in vanilla. If we're in rando and speak to her we don't want her to pop
-        // out of existence immediately. The init function will properly kill her actor on the next scene load.
-        if (!gSaveContext.n64ddFlag) {
-            Actor_Kill(&this->actor);
-        }
-    // If Talon has not run away, or we're randomized and have not received Malon's HC Check, or we're
-    // not randomized and have obtained Epona's Song, put Malon in the state to give Link the HC reward.
+    // We want to Kill Malon's Actor outside of randomizer when Talon is freed. In Randomizer we don't kill Malon's
+    // Actor here, otherwise if we wake up Talon first and then get her check she will spontaneously
+    // disappear.
+    if ((globalCtx->sceneNum == SCENE_SPOT15) && (!gSaveContext.n64ddFlag && gSaveContext.eventChkInf[1] & 0x10)) {
+        Actor_Kill(&this->actor);
+    // We want Malon to give the Weird Egg Check (see function below) in the following situations:
+    // 1. Talon as not left Hyrule Castle (Vanilla) OR
+    // 2. We haven't obtained Malon's Weird Egg Check (Randomizer only) OR
+    // 3. We have Epona's Song? (Vanilla only, not sure why it's here but I didn't write that one)
     } else if ((!(gSaveContext.eventChkInf[1] & 0x10) || (gSaveContext.n64ddFlag && !Randomizer_ObtainedMalonHCReward())) || (CHECK_QUEST_ITEM(QUEST_SONG_EPONA) && !gSaveContext.n64ddFlag)) {
         if (this->unk_1E8.unk_00 == 2) {
             this->actionFunc = func_80AA0EA0;


### PR DESCRIPTION
Changes Malon's behavior so that she will not leave Hyrule Castle until after you have received her check. Currently it is possible to miss Malon's Weird Egg check completely if you skip talking to her and go wake up Talon, as she would no longer appear at Hyrule Castle and only appear at the ranch to give her Epona's Song Check.  Now she has the following behavior in randomizer (vanilla behavior is unchanged, I checked).

- Talking to Malon will give you her item, as always
- Skipping HC Malon and waking up Talon will cause Malon to stay at Hyrule Castle until you get her item.
- Malon will remain at HC until you leave the area (specifying it here because I had to specifically code her not to pop out of existence after receiving her check if Talon had already been woken up).
- If Malon is at Hyrule Castle, she will not appear at Lon Lon Ranch, even if Talon has left Hyrule Castle.