### PR TITLE
Another fix for getting items near critters

### DIFF
--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -6104,7 +6104,7 @@ s32 func_8083E5A8(Player* this, GlobalContext* globalCtx) {
             }
 
             GetItemEntry giEntry;
-            if (this->getItemEntry.objectId == OBJECT_INVALID) {
+            if (this->getItemEntry.objectId == OBJECT_INVALID || (this->getItemId != this->getItemEntry.getItemId)) {
                 giEntry = ItemTable_Retrieve(this->getItemId);
             } else {
                 giEntry = this->getItemEntry;
@@ -9430,6 +9430,7 @@ static EffectBlureInit2 D_8085470C = {
 static Vec3s D_80854730 = { -57, 3377, 0 };
 
 void Player_InitCommon(Player* this, GlobalContext* globalCtx, FlexSkeletonHeader* skelHeader) {
+    this->getItemEntry = (GetItemEntry)GET_ITEM_NONE;
     this->ageProperties = &sAgeProperties[gSaveContext.linkAge];
     Actor_ProcessInitChain(&this->actor, sInitChain);
     this->swordEffectIndex = TOTAL_EFFECT_COUNT;


### PR DESCRIPTION
This time it was being near a chest in rando and either releasing bugs or releasing them from nearby grass causing collection of the chest item. This was due to having the chest's getItemEntry and a positive getItemId from the proximity to the bugs. Added a safeguard against that in z_player.c.