### PR TITLE
Randomizer: When Shuffled to Own Dungeon or Vanilla, Give Vanilla Keys, Maps and Compasses

### DIFF
--- a/libultraship/libultraship/ImGuiImpl.cpp
+++ b/libultraship/libultraship/ImGuiImpl.cpp
@@ -2011,7 +2011,9 @@ namespace SohImGui {
                     );
                     PaddedEnhancementCheckbox("Key Colors Match Dungeon", "gRandoMatchKeyColors", true, false);
                     Tooltip(
-                        "Matches the color of small keys and boss keys to the dungeon they belong to. This helps identify keys from afar and adds a little bit of flair.");
+                        "Matches the color of small keys and boss keys to the dungeon they belong to. "
+                        "This helps identify keys from afar and adds a little bit of flair.\n\nThis only "
+                        "applies to seeds with keys and boss keys shuffled to Any Dungeon, Overworld, or Anywhere.");
                     PaddedEnhancementCheckbox("Quest Item Fanfares", "gRandoQuestItemFanfares", true, false);
                     Tooltip(
                         "Play unique fanfares when obtaining quest items "

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -875,6 +875,19 @@ void Randomizer::ParseRandomizerSettingsFile(const char* spoilerFileName) {
                             gSaveContext.randoSettings[index].value = 3;
                         }
                         break;
+                    case RSK_GERUDO_KEYS:
+                        if (it.value() == "Vanilla") {
+                            gSaveContext.randoSettings[index].value = 0;
+                        }
+                        if (it.value() == "Any Dungeon") {
+                            gSaveContext.randoSettings[index].value = 1;
+                        }
+                        if (it.value() == "Overworld") {
+                            gSaveContext.randoSettings[index].value = 2;
+                        }
+                        if (it.value() == "Anywhere") {
+                            gSaveContext.randoSettings[index].value = 3;
+                        }
                     case RSK_KEYSANITY:
                         if(it.value() == "Start With") {
                             gSaveContext.randoSettings[index].value = 0;            
@@ -1461,9 +1474,14 @@ s16 Randomizer::GetItemFromGet(RandomizerGet randoGet, GetItemID ogItemId) {
         case RG_SHADOW_TEMPLE_SMALL_KEY:
         case RG_BOTTOM_OF_THE_WELL_SMALL_KEY:
         case RG_GERUDO_TRAINING_GROUNDS_SMALL_KEY:
-        case RG_GERUDO_FORTRESS_SMALL_KEY:
         case RG_GANONS_CASTLE_SMALL_KEY:
             if (GetRandoSettingValue(RSK_KEYSANITY) < 3) {
+                return GI_KEY_SMALL;
+            } else {
+                return randoGet;
+            }
+        case RG_GERUDO_FORTRESS_SMALL_KEY:
+            if (GetRandoSettingValue(RSK_GERUDO_KEYS) == 0) {
                 return GI_KEY_SMALL;
             } else {
                 return randoGet;
@@ -1686,10 +1704,14 @@ bool Randomizer::IsItemVanilla(RandomizerGet randoGet) {
         case RG_SHADOW_TEMPLE_SMALL_KEY:
         case RG_BOTTOM_OF_THE_WELL_SMALL_KEY:
         case RG_GERUDO_TRAINING_GROUNDS_SMALL_KEY:
-        case RG_GERUDO_FORTRESS_SMALL_KEY:
         case RG_GANONS_CASTLE_SMALL_KEY:
             if (GetRandoSettingValue(RSK_KEYSANITY) > 2) {
                 return false;
+            }
+            return true;
+        case RG_GERUDO_FORTRESS_SMALL_KEY:
+            if (GetRandoSettingValue(RSK_GERUDO_KEYS != 0)) {
+                return false
             }
             return true;
         case RG_FOREST_TEMPLE_BOSS_KEY:

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -1619,6 +1619,7 @@ bool Randomizer::IsItemVanilla(RandomizerGet randoGet) {
         case RG_BUY_BOMBS_535:
         case RG_BUY_RED_POTION_40:
         case RG_BUY_RED_POTION_50:
+        //RANDO TODO: Fix this to return false if keysanity is on.
         case RG_FOREST_TEMPLE_SMALL_KEY:
         case RG_FIRE_TEMPLE_SMALL_KEY:
         case RG_WATER_TEMPLE_SMALL_KEY:

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -1409,7 +1409,66 @@ s16 Randomizer::GetItemFromGet(RandomizerGet randoGet, GetItemID ogItemId) {
             return GI_BOTTLE;
         case RG_BOTTLE_WITH_MILK:
             return GI_MILK_BOTTLE;
-            
+
+        case RG_DEKU_TREE_MAP:
+        case RG_DODONGOS_CAVERN_MAP:
+        case RG_JABU_JABUS_BELLY_MAP:
+        case RG_FOREST_TEMPLE_MAP:
+        case RG_FIRE_TEMPLE_MAP:
+        case RG_WATER_TEMPLE_MAP:
+        case RG_SPIRIT_TEMPLE_MAP:
+        case RG_SHADOW_TEMPLE_MAP:
+        case RG_BOTTOM_OF_THE_WELL_MAP:
+        case RG_ICE_CAVERN_MAP:
+            if (GetRandoSettingValue(RSK_STARTING_MAPS_COMPASSES) < 3) {
+                return GI_MAP;
+            } else {
+                return randoGet;
+            }
+
+        case RG_DEKU_TREE_COMPASS:
+        case RG_DODONGOS_CAVERN_COMPASS:
+        case RG_JABU_JABUS_BELLY_COMPASS:
+        case RG_FOREST_TEMPLE_COMPASS:
+        case RG_FIRE_TEMPLE_COMPASS:
+        case RG_WATER_TEMPLE_COMPASS:
+        case RG_SPIRIT_TEMPLE_COMPASS:
+        case RG_SHADOW_TEMPLE_COMPASS:
+        case RG_BOTTOM_OF_THE_WELL_COMPASS:
+        case RG_ICE_CAVERN_COMPASS:
+            if (GetRandoSettingValue(RSK_STARTING_MAPS_COMPASSES) < 3) {
+                return GI_COMPASS;
+            } else {
+                return randoGet;
+            }
+
+        case RG_FOREST_TEMPLE_BOSS_KEY:
+        case RG_FIRE_TEMPLE_BOSS_KEY:
+        case RG_WATER_TEMPLE_BOSS_KEY:
+        case RG_SPIRIT_TEMPLE_BOSS_KEY:
+        case RG_SHADOW_TEMPLE_BOSS_KEY:
+        case RG_GANONS_CASTLE_BOSS_KEY:
+            if (GetRandoSettingValue(RSK_BOSS_KEYSANITY) < 3) {
+                return GI_KEY_BOSS;
+            } else {
+                return randoGet;
+            }
+
+        case RG_FOREST_TEMPLE_SMALL_KEY:
+        case RG_FIRE_TEMPLE_SMALL_KEY:
+        case RG_WATER_TEMPLE_SMALL_KEY:
+        case RG_SPIRIT_TEMPLE_SMALL_KEY:
+        case RG_SHADOW_TEMPLE_SMALL_KEY:
+        case RG_BOTTOM_OF_THE_WELL_SMALL_KEY:
+        case RG_GERUDO_TRAINING_GROUNDS_SMALL_KEY:
+        case RG_GERUDO_FORTRESS_SMALL_KEY:
+        case RG_GANONS_CASTLE_SMALL_KEY:
+            if (GetRandoSettingValue(RSK_KEYSANITY) < 3) {
+                return GI_KEY_SMALL;
+            } else {
+                return randoGet;
+            }
+
         // todo test this with keys in own dungeon
         case RG_TREASURE_GAME_SMALL_KEY:
             return GI_DOOR_KEY;
@@ -1619,7 +1678,7 @@ bool Randomizer::IsItemVanilla(RandomizerGet randoGet) {
         case RG_BUY_BOMBS_535:
         case RG_BUY_RED_POTION_40:
         case RG_BUY_RED_POTION_50:
-        //RANDO TODO: Fix this to return false if keysanity is on.
+            return true;
         case RG_FOREST_TEMPLE_SMALL_KEY:
         case RG_FIRE_TEMPLE_SMALL_KEY:
         case RG_WATER_TEMPLE_SMALL_KEY:
@@ -1629,12 +1688,24 @@ bool Randomizer::IsItemVanilla(RandomizerGet randoGet) {
         case RG_GERUDO_TRAINING_GROUNDS_SMALL_KEY:
         case RG_GERUDO_FORTRESS_SMALL_KEY:
         case RG_GANONS_CASTLE_SMALL_KEY:
+            if (GetRandoSettingValue(RSK_KEYSANITY) > 2) {
+                return false;
+            }
+            return true;
         case RG_FOREST_TEMPLE_BOSS_KEY:
         case RG_FIRE_TEMPLE_BOSS_KEY:
         case RG_WATER_TEMPLE_BOSS_KEY:
         case RG_SPIRIT_TEMPLE_BOSS_KEY:
         case RG_SHADOW_TEMPLE_BOSS_KEY:
+            if (GetRandoSettingValue(RSK_BOSS_KEYSANITY) > 2) {
+                return false;
+            }
+            return true;
         case RG_GANONS_CASTLE_BOSS_KEY:
+            if (GetRandoSettingValue(RSK_GANONS_BOSS_KEY) > 2) {
+                return false;
+            }
+            return true;
         case RG_DEKU_TREE_COMPASS:
         case RG_DODONGOS_CAVERN_COMPASS:
         case RG_JABU_JABUS_BELLY_COMPASS:
@@ -1655,6 +1726,9 @@ bool Randomizer::IsItemVanilla(RandomizerGet randoGet) {
         case RG_SHADOW_TEMPLE_MAP:
         case RG_BOTTOM_OF_THE_WELL_MAP:
         case RG_ICE_CAVERN_MAP:
+            if (GetRandoSettingValue(RSK_STARTING_MAPS_COMPASSES) > 2) {
+                return false;
+            }
             return true;
         default:
             return false;

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -1708,7 +1708,7 @@ bool Randomizer::IsItemVanilla(RandomizerGet randoGet) {
             return true;
         case RG_GERUDO_FORTRESS_SMALL_KEY:
             if (GetRandoSettingValue(RSK_GERUDO_KEYS != 0)) {
-                return false
+                return false;
             }
             return true;
         case RG_FOREST_TEMPLE_BOSS_KEY:

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -1707,7 +1707,7 @@ bool Randomizer::IsItemVanilla(RandomizerGet randoGet) {
             }
             return true;
         case RG_GERUDO_FORTRESS_SMALL_KEY:
-            if (GetRandoSettingValue(RSK_GERUDO_KEYS != 0)) {
+            if (GetRandoSettingValue(RSK_GERUDO_KEYS) != 0) {
                 return false;
             }
             return true;

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -878,14 +878,11 @@ void Randomizer::ParseRandomizerSettingsFile(const char* spoilerFileName) {
                     case RSK_GERUDO_KEYS:
                         if (it.value() == "Vanilla") {
                             gSaveContext.randoSettings[index].value = 0;
-                        }
-                        if (it.value() == "Any Dungeon") {
+                        } else if (it.value() == "Any Dungeon") {
                             gSaveContext.randoSettings[index].value = 1;
-                        }
-                        if (it.value() == "Overworld") {
+                        } else if (it.value() == "Overworld") {
                             gSaveContext.randoSettings[index].value = 2;
-                        }
-                        if (it.value() == "Anywhere") {
+                        } else if (it.value() == "Anywhere") {
                             gSaveContext.randoSettings[index].value = 3;
                         }
                     case RSK_KEYSANITY:

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -1619,6 +1619,41 @@ bool Randomizer::IsItemVanilla(RandomizerGet randoGet) {
         case RG_BUY_BOMBS_535:
         case RG_BUY_RED_POTION_40:
         case RG_BUY_RED_POTION_50:
+        case RG_FOREST_TEMPLE_SMALL_KEY:
+        case RG_FIRE_TEMPLE_SMALL_KEY:
+        case RG_WATER_TEMPLE_SMALL_KEY:
+        case RG_SPIRIT_TEMPLE_SMALL_KEY:
+        case RG_SHADOW_TEMPLE_SMALL_KEY:
+        case RG_BOTTOM_OF_THE_WELL_SMALL_KEY:
+        case RG_GERUDO_TRAINING_GROUNDS_SMALL_KEY:
+        case RG_GERUDO_FORTRESS_SMALL_KEY:
+        case RG_GANONS_CASTLE_SMALL_KEY:
+        case RG_FOREST_TEMPLE_BOSS_KEY:
+        case RG_FIRE_TEMPLE_BOSS_KEY:
+        case RG_WATER_TEMPLE_BOSS_KEY:
+        case RG_SPIRIT_TEMPLE_BOSS_KEY:
+        case RG_SHADOW_TEMPLE_BOSS_KEY:
+        case RG_GANONS_CASTLE_BOSS_KEY:
+        case RG_DEKU_TREE_COMPASS:
+        case RG_DODONGOS_CAVERN_COMPASS:
+        case RG_JABU_JABUS_BELLY_COMPASS:
+        case RG_FOREST_TEMPLE_COMPASS:
+        case RG_FIRE_TEMPLE_COMPASS:
+        case RG_WATER_TEMPLE_COMPASS:
+        case RG_SPIRIT_TEMPLE_COMPASS:
+        case RG_SHADOW_TEMPLE_COMPASS:
+        case RG_BOTTOM_OF_THE_WELL_COMPASS:
+        case RG_ICE_CAVERN_COMPASS:
+        case RG_DEKU_TREE_MAP:
+        case RG_DODONGOS_CAVERN_MAP:
+        case RG_JABU_JABUS_BELLY_MAP:
+        case RG_FOREST_TEMPLE_MAP:
+        case RG_FIRE_TEMPLE_MAP:
+        case RG_WATER_TEMPLE_MAP:
+        case RG_SPIRIT_TEMPLE_MAP:
+        case RG_SHADOW_TEMPLE_MAP:
+        case RG_BOTTOM_OF_THE_WELL_MAP:
+        case RG_ICE_CAVERN_MAP:
             return true;
         default:
             return false;

--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -1690,12 +1690,35 @@ u8 Item_Give(GlobalContext* globalCtx, u8 item) {
         }
         return ITEM_NONE;
     } else if (item == ITEM_KEY_SMALL) {
-        if (gSaveContext.inventory.dungeonKeys[gSaveContext.mapIndex] < 0) {
-            gSaveContext.inventory.dungeonKeys[gSaveContext.mapIndex] = 1;
-            return ITEM_NONE;
+        // Small key exceptions for rando with keysanity off.
+        if (gSaveContext.n64ddFlag) {
+            if (globalCtx->sceneNum == 10) { // ganon's tower -> ganon's castle
+                if (gSaveContext.inventory.dungeonKeys[13] < 0) {
+                    gSaveContext.inventory.dungeonKeys[13] = 1;
+                    return ITEM_NONE;
+                } else {
+                    gSaveContext.inventory.dungeonKeys[13]++;
+                    return ITEM_NONE;
+                }
+            }
+
+            if (globalCtx->sceneNum == 92) { // Desert Colossus -> Spirit Temple.
+                if (gSaveContext.inventory.dungeonKeys[6] < 0) {
+                    gSaveContext.inventory.dungeonKeys[6] = 1;
+                    return ITEM_NONE;
+                } else {
+                    gSaveContext.inventory.dungeonKeys[6]++;
+                    return ITEM_NONE;
+                }
+            }
         } else {
-            gSaveContext.inventory.dungeonKeys[gSaveContext.mapIndex]++;
-            return ITEM_NONE;
+            if (gSaveContext.inventory.dungeonKeys[gSaveContext.mapIndex] < 0) {
+                gSaveContext.inventory.dungeonKeys[gSaveContext.mapIndex] = 1;
+                return ITEM_NONE;
+            } else {
+                gSaveContext.inventory.dungeonKeys[gSaveContext.mapIndex]++;
+                return ITEM_NONE;
+            }
         }
     } else if ((item == ITEM_QUIVER_30) || (item == ITEM_BOW)) {
         if (CUR_UPG_VALUE(UPG_QUIVER) == 0) {


### PR DESCRIPTION
Cherry-Picked commits from https://github.com/HarbourMasters/Shipwright/pull/1338 and added some logic to give the vanilla versions of the items when these items are shuffled to Own Dungeon or Vanilla. Technically it would apply to Start With as well, just that you wouldn't ever collect one to see it in that scenario.

The Cherry Picking of commits here should mean that if this is merged, the next zhora->rando-next merge shouldn't hit any merge conflicts related to those changes.

BONUS FIX: Seems that the Gerudo Fortress Keys shuffle settings was missing a case statement for parsing the spoilerfile into the randoSettings array.