### PR TITLE
Backports a fix for sheik checks from rando-next

### DIFF
--- a/soh/src/overlays/actors/ovl_En_Xc/z_en_xc.c
+++ b/soh/src/overlays/actors/ovl_En_Xc/z_en_xc.c
@@ -298,7 +298,7 @@ void GivePlayerRandoRewardSheikSong(EnXc* sheik, GlobalContext* globalCtx, Rando
             }
         } else if (check != RC_SHEIK_AT_TEMPLE) {
             if (GiveItemEntryFromActor(&sheik->actor, globalCtx, getItemEntry, 10000.0f, 100.0f)) {
-                player->pendingFlag.flagID = 0x55;
+                player->pendingFlag.flagID = (0x5 << 4) | (sheikType & 0xF) >> 1;
                 player->pendingFlag.flagType = FLAG_EVENT_CHECK_INF;
             }
         }

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -6085,6 +6085,9 @@ void Player_SetPendingFlag(Player* this, GlobalContext* globalCtx) {
         case FLAG_EVENT_CHECK_INF:
             Flags_SetEventChkInf(this->pendingFlag.flagID);
             break;
+        case FLAG_EVENT_CHECK_INF:
+            Flags_SetEventChkInf(this->pendingFlag.flagID);
+            break;
         case FLAG_NONE:
         default:
             break;

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -6085,9 +6085,6 @@ void Player_SetPendingFlag(Player* this, GlobalContext* globalCtx) {
         case FLAG_EVENT_CHECK_INF:
             Flags_SetEventChkInf(this->pendingFlag.flagID);
             break;
-        case FLAG_EVENT_CHECK_INF:
-            Flags_SetEventChkInf(this->pendingFlag.flagID);
-            break;
         case FLAG_NONE:
         default:
             break;


### PR DESCRIPTION
I broke sheik checks while developing get-item-rework and fixed it partially, later realized I had only fixed it for one situation and then fixed it for all of them, but only on rando-next, so rando Sheik checks other than Bolero were infinitely giving the item. I cherry picked the commit where I fixed it in rando-next so there shouldn't be merge conflicts after this merge.