### PR TITLE
Randomizer: Fixes a few bugs related to chests.

### DIFF
--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -6108,7 +6108,7 @@ s32 func_8083E5A8(Player* this, GlobalContext* globalCtx) {
             }
 
             GetItemEntry giEntry;
-            if (this->getItemEntry.objectId == OBJECT_INVALID) {
+            if (this->getItemEntry.objectId == OBJECT_INVALID || (this->getItemId != this->getItemEntry.getItemId)) {
                 giEntry = ItemTable_Retrieve(this->getItemId);
             } else {
                 giEntry = this->getItemEntry;
@@ -6165,7 +6165,7 @@ s32 func_8083E5A8(Player* this, GlobalContext* globalCtx) {
             }
         } else if (CHECK_BTN_ALL(sControlInput->press.button, BTN_A) && !(this->stateFlags1 & PLAYER_STATE1_11) &&
                    !(this->stateFlags2 & PLAYER_STATE2_10)) {
-            if (this->getItemId != GI_NONE && this->getItemEntry.objectId != OBJECT_INVALID) {
+            if (this->getItemId != GI_NONE) {
                 GetItemEntry giEntry;
                 if (this->getItemEntry.objectId == OBJECT_INVALID) {
                     giEntry = ItemTable_Retrieve(-this->getItemId);
@@ -9687,8 +9687,8 @@ void func_808473D4(GlobalContext* globalCtx, Player* this) {
                 else if ((!(this->stateFlags1 & PLAYER_STATE1_11) || (heldActor == NULL)) &&
                     (interactRangeActor != NULL) &&
                     ((!sp1C && (this->getItemId == GI_NONE)) ||
-                        ((this->getItemId < 0 && this->getItemEntry.getItemId < 0) && !(this->stateFlags1 & PLAYER_STATE1_27)))) {
-                    if (this->getItemId < 0 && this->getItemEntry.getItemId < 0) {
+                        (this->getItemId < 0 && !(this->stateFlags1 & PLAYER_STATE1_27)))) {
+                    if (this->getItemId < 0) {
                         doAction = DO_ACTION_OPEN;
                     } else if ((interactRangeActor->id == ACTOR_BG_TOKI_SWD) && LINK_IS_ADULT) {
                         doAction = DO_ACTION_DROP;


### PR DESCRIPTION
1. Vanilla Chests were completely broken, fixed here.
2. In Randomizer, approaching a chest without opening it and then approaching bottleable critters or blue fire in the same scene caused the player to receive the chest item, possibly in a loop. Fixed by the same fix from #1332, which is for zhora but hasn't been merged yet. 
3. Fixed a few oddities with the UI action indicators.