### PR TITLE
fix oot ice trap check optimization issues

### DIFF
--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -1652,13 +1652,12 @@ extern "C" GetItemEntry Randomizer_GetItemFromKnownCheck(RandomizerCheck randomi
     return ItemTable_RetrieveEntry(getItemModIndex, itemID);
 }
 
-extern "C" bool Randomizer_ObtainedFreestandingIceTrap(RandomizerCheck randomizerCheck, GetItemID ogId, Actor* actor) {
-    return gSaveContext.n64ddFlag && (actor->parent != NULL) &&
-         Randomizer_GetItemFromKnownCheck(randomizerCheck, ogId).getItemId == RG_ICE_TRAP;
-}
-
 extern "C" bool Randomizer_ItemIsIceTrap(RandomizerCheck randomizerCheck, GetItemID ogId) {
     return gSaveContext.n64ddFlag && Randomizer_GetItemFromKnownCheck(randomizerCheck, ogId).getItemId == RG_ICE_TRAP;
+}
+
+extern "C" bool Randomizer_ObtainedFreestandingIceTrap(RandomizerCheck randomizerCheck, GetItemID ogId, Actor* actor) {
+    return Randomizer_ItemIsIceTrap(randomizerCheck, ogId) && actor->parent != NULL;
 }
 
 extern "C" CustomMessageEntry Randomizer_GetCustomGetItemMessage(Player* player) {


### PR DESCRIPTION
i'm not sure what exactly was causing this to get optimized out, i'm thinking maybe there was an issue with the ordering of the actor parent check, but i'm not sure.

this seems to fix the issue, and reduces copypasta