### PR TITLE
Fixes Switch/Wii U crashes with Wonder Rupees and Bottleable Entities

### DIFF
--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -1613,7 +1613,7 @@ extern "C" CustomMessageEntry Randomizer_GetHintFromCheck(RandomizerCheck check)
 }
 
 extern "C" GetItemEntry ItemTable_Retrieve(int16_t getItemID) {
-    GetItemEntry giEntry = ItemTableManager::Instance->RetrieveItemEntry(OTRGlobals::Instance->getItemModIndex, getItemID);
+    GetItemEntry giEntry = ItemTableManager::Instance->RetrieveItemEntry(MOD_NONE, getItemID);
     return giEntry;
 }
 

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -289,7 +289,7 @@ extern "C" void VanillaItemTable_Init() {
         GET_ITEM(ITEM_BULLET_BAG_50, OBJECT_GI_DEKUPOUCH, GID_BULLET_BAG_50, 0x6C, 0x80, CHEST_ANIM_LONG, MOD_NONE, GI_BULLET_BAG_50),
         GET_ITEM_NONE,
         GET_ITEM_NONE,
-        GET_ITEM_NONE,
+        GET_ITEM_NONE // GI_MAX - if you need to add to this table insert it before this entry.
     };
     ItemTableManager::Instance->AddItemTable(MOD_NONE);
     for (uint8_t i = 0; i < ARRAY_COUNT(getItemTable); i++) {

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -289,6 +289,7 @@ extern "C" void VanillaItemTable_Init() {
         GET_ITEM(ITEM_BULLET_BAG_50, OBJECT_GI_DEKUPOUCH, GID_BULLET_BAG_50, 0x6C, 0x80, CHEST_ANIM_LONG, MOD_NONE, GI_BULLET_BAG_50),
         GET_ITEM_NONE,
         GET_ITEM_NONE,
+        GET_ITEM_NONE,
     };
     ItemTableManager::Instance->AddItemTable(MOD_NONE);
     for (uint8_t i = 0; i < ARRAY_COUNT(getItemTable); i++) {

--- a/soh/soh/OTRGlobals.h
+++ b/soh/soh/OTRGlobals.h
@@ -21,7 +21,6 @@ public:
     std::shared_ptr<Ship::Window> context;
     std::shared_ptr<SaveStateMgr> gSaveStateMgr;
     std::shared_ptr<Randomizer> gRandomizer;
-    uint16_t getItemModIndex;
 
     OTRGlobals();
     ~OTRGlobals();

--- a/soh/soh/z_play_otr.cpp
+++ b/soh/soh/z_play_otr.cpp
@@ -60,7 +60,6 @@ void OTRGameplay_InitScene(GlobalContext* globalCtx, s32 spawn) {
     globalCtx->cUpElfMsgs = nullptr;
     globalCtx->setupPathList = nullptr;
     globalCtx->numSetupActors = 0;
-    OTRGlobals::Instance->getItemModIndex = MOD_NONE;
     Object_InitBank(globalCtx, &globalCtx->objectCtx);
     LightContext_Init(globalCtx, &globalCtx->lightCtx);
     TransitionActor_InitContext(&globalCtx->state, &globalCtx->transiActorCtx);

--- a/soh/src/code/z_en_item00.c
+++ b/soh/src/code/z_en_item00.c
@@ -515,13 +515,13 @@ void EnItem00_Init(Actor* thisx, GlobalContext* globalCtx) {
     }
 
     if (!Actor_HasParent(&this->actor, globalCtx)) {
-        if (!gSaveContext.n64ddFlag) {
-            if (getItemId != GI_NONE) {
+        if (getItemId != GI_NONE) {
+            if (!gSaveContext.n64ddFlag) {
                 func_8002F554(&this->actor, globalCtx, getItemId);
+            } else {
+                getItem = Randomizer_GetRandomizedItem(getItemId, this->actor.id, this->ogParams, globalCtx->sceneNum);
+                GiveItemEntryFromActorWithFixedRange(&this->actor, globalCtx, getItem);
             }
-        } else {
-            getItem = Randomizer_GetRandomizedItem(getItemId, this->actor.id, this->ogParams, globalCtx->sceneNum);
-            GiveItemEntryFromActorWithFixedRange(&this->actor, globalCtx, getItem);
         }
     }
 


### PR DESCRIPTION
In Item00, when a Wonder Item actor spawns one, a malformed if statement causes a Get Item Entry to be set on the player. Normally the GetItemEntry having an ID of 0 would prevent it from actually going through, but for some reason it seems to be causing a crash on Switch and Wii U. I don't have one to test, so I need someone to test there before this can be merged (maybe it should be merged anyway, but still want to have Switch/Wii U players test it).