### PR TITLE
Randomizer: Fix Biggoron checks

### DIFF
--- a/soh/src/overlays/actors/ovl_En_Go/z_en_go.c
+++ b/soh/src/overlays/actors/ovl_En_Go/z_en_go.c
@@ -95,7 +95,7 @@ u16 EnGo_GetTextID(GlobalContext* globalCtx, Actor* thisx) {
 
     switch (thisx->params & 0xF0) {
         case 0x90:
-            if (gSaveContext.bgsFlag) {
+            if (gSaveContext.bgsFlag && !gSaveContext.n64ddFlag) {
                 return 0x305E;
             } else if (INV_CONTENT(ITEM_TRADE_ADULT) >= ITEM_CLAIM_CHECK) {
                 if (Environment_GetBgsDayCount() >= CVar_GetS32("gForgeTime", 3)) {
@@ -859,7 +859,7 @@ void func_80A405CC(EnGo* this, GlobalContext* globalCtx) {
 
 void EnGo_BiggoronActionFunc(EnGo* this, GlobalContext* globalCtx) {
     if (((this->actor.params & 0xF0) == 0x90) && (this->unk_1E0.unk_00 == 2)) {
-        if (gSaveContext.bgsFlag) {
+        if (gSaveContext.bgsFlag && !gSaveContext.n64ddFlag) {
             this->unk_1E0.unk_00 = 0;
         } else {
             if (INV_CONTENT(ITEM_TRADE_ADULT) == ITEM_EYEDROPS) {

--- a/soh/src/overlays/actors/ovl_En_Go/z_en_go.c
+++ b/soh/src/overlays/actors/ovl_En_Go/z_en_go.c
@@ -95,7 +95,7 @@ u16 EnGo_GetTextID(GlobalContext* globalCtx, Actor* thisx) {
 
     switch (thisx->params & 0xF0) {
         case 0x90:
-            if (gSaveContext.bgsFlag && !gSaveContext.n64ddFlag) {
+            if (!gSaveContext.n64ddFlag && gSaveContext.bgsFlag) {
                 return 0x305E;
             } else if (INV_CONTENT(ITEM_TRADE_ADULT) >= ITEM_CLAIM_CHECK) {
                 if (Environment_GetBgsDayCount() >= CVar_GetS32("gForgeTime", 3)) {
@@ -859,7 +859,7 @@ void func_80A405CC(EnGo* this, GlobalContext* globalCtx) {
 
 void EnGo_BiggoronActionFunc(EnGo* this, GlobalContext* globalCtx) {
     if (((this->actor.params & 0xF0) == 0x90) && (this->unk_1E0.unk_00 == 2)) {
-        if (gSaveContext.bgsFlag && !gSaveContext.n64ddFlag) {
+        if (!gSaveContext.n64ddFlag && gSaveContext.bgsFlag) {
             this->unk_1E0.unk_00 = 0;
         } else {
             if (INV_CONTENT(ITEM_TRADE_ADULT) == ITEM_EYEDROPS) {

--- a/soh/src/overlays/actors/ovl_En_Go2/z_en_go2.c
+++ b/soh/src/overlays/actors/ovl_En_Go2/z_en_go2.c
@@ -595,7 +595,7 @@ s16 EnGo2_GetStateGoronCityLink(GlobalContext* globalCtx, EnGo2* this) {
 u16 EnGo2_GetTextIdGoronDmtBiggoron(GlobalContext* globalCtx, EnGo2* this) {
     Player* player = GET_PLAYER(globalCtx);
 
-    if (gSaveContext.bgsFlag && !gSaveContext.n64ddFlag) {
+    if (!gSaveContext.n64ddFlag && gSaveContext.bgsFlag) {
         player->exchangeItemId = EXCH_ITEM_CLAIM_CHECK;
         return 0x305E;
     } else if (INV_CONTENT(ITEM_TRADE_ADULT) >= ITEM_CLAIM_CHECK) {

--- a/soh/src/overlays/actors/ovl_En_Go2/z_en_go2.c
+++ b/soh/src/overlays/actors/ovl_En_Go2/z_en_go2.c
@@ -595,7 +595,7 @@ s16 EnGo2_GetStateGoronCityLink(GlobalContext* globalCtx, EnGo2* this) {
 u16 EnGo2_GetTextIdGoronDmtBiggoron(GlobalContext* globalCtx, EnGo2* this) {
     Player* player = GET_PLAYER(globalCtx);
 
-    if (gSaveContext.bgsFlag) {
+    if (gSaveContext.bgsFlag && !gSaveContext.n64ddFlag) {
         player->exchangeItemId = EXCH_ITEM_CLAIM_CHECK;
         return 0x305E;
     } else if (INV_CONTENT(ITEM_TRADE_ADULT) >= ITEM_CLAIM_CHECK) {
@@ -622,10 +622,6 @@ s16 EnGo2_GetStateGoronDmtBiggoron(GlobalContext* globalCtx, EnGo2* this) {
                 }
                 
                 if(gSaveContext.n64ddFlag) {
-                    if (INV_CONTENT(ITEM_CLAIM_CHECK) != ITEM_CLAIM_CHECK) {
-                        return 0;
-                    }
-
                     EnGo2_GetItemEntry(this, globalCtx, Randomizer_GetItemFromKnownCheck(RC_DMT_TRADE_CLAIM_CHECK, GI_SWORD_BGS));
                     Flags_SetTreasure(globalCtx, 0x1F);
                 } else {
@@ -1063,7 +1059,7 @@ void EnGo2_BiggoronSetTextId(EnGo2* this, GlobalContext* globalCtx, Player* play
     u16 textId;
 
     if ((this->actor.params & 0x1F) == GORON_DMT_BIGGORON) {
-        if (gSaveContext.bgsFlag) {
+        if ((!gSaveContext.n64ddFlag && gSaveContext.bgsFlag)) {
             if (func_8002F368(globalCtx) == EXCH_ITEM_CLAIM_CHECK) {
                 this->actor.textId = 0x3003;
             } else {
@@ -1071,16 +1067,20 @@ void EnGo2_BiggoronSetTextId(EnGo2* this, GlobalContext* globalCtx, Player* play
             }
             player->actor.textId = this->actor.textId;
 
-        } else if (!gSaveContext.bgsFlag && (INV_CONTENT(ITEM_TRADE_ADULT) == ITEM_CLAIM_CHECK)) {
+        } else if (INV_CONTENT(ITEM_TRADE_ADULT) == ITEM_CLAIM_CHECK) {
             if (func_8002F368(globalCtx) == EXCH_ITEM_CLAIM_CHECK) {
-                if (Environment_GetBgsDayCount() >= CVar_GetS32("gForgeTime", 3)) {
+                if (gSaveContext.n64ddFlag && Flags_GetTreasure(globalCtx, 0x1F)) {
+                    textId = 0x3003;
+                } else if (Environment_GetBgsDayCount() >= CVar_GetS32("gForgeTime", 3)) {
                     textId = 0x305E;
                 } else {
                     textId = 0x305D;
                 }
                 this->actor.textId = textId;
             } else {
-                if (Environment_GetBgsDayCount() >= CVar_GetS32("gForgeTime", 3)) {
+                if (gSaveContext.n64ddFlag && Flags_GetTreasure(globalCtx, 0x1F)) {
+                    textId = 0x305E;
+                } else if (Environment_GetBgsDayCount() >= CVar_GetS32("gForgeTime", 3)) {
                     textId = 0x3002;
                 } else {
                     textId = 0x305D;


### PR DESCRIPTION
This fixes Biggoron's text being dependent on the BGS flag in rando. This fixes the follwing issues:
 - #1305
 - #739
 - https://github.com/HarbourMasters/rando-issue-tracker/issues/136 was already fixed, but now the textbox that gives you the sword doesn't appear until after you trade the Claim Check, rendering the original fix redundant.