### PR TITLE
Fix blocks not being pushed all the way

### DIFF
--- a/soh/src/overlays/actors/ovl_Bg_Hidan_Rock/z_bg_hidan_rock.c
+++ b/soh/src/overlays/actors/ovl_Bg_Hidan_Rock/z_bg_hidan_rock.c
@@ -138,7 +138,7 @@ void func_8088B268(BgHidanRock* this, GlobalContext* globalCtx) {
             }
 
             this->dyna.actor.speedXZ = this->dyna.actor.speedXZ + (CVar_GetS32("gFasterBlockPush", 0) * 0.3) + 0.5f;
-            this->dyna.actor.speedXZ = CLAMP_MAX(this->dyna.actor.speedXZ, 3.0f);
+            this->dyna.actor.speedXZ = CLAMP_MAX(this->dyna.actor.speedXZ, 2.0f);
 
             if (D_8088BFC0 > 0.0f) {
                 temp_v1 = Math_StepToF(&D_8088BFC0, 20.0f, this->dyna.actor.speedXZ);

--- a/soh/src/overlays/actors/ovl_Bg_Po_Event/z_bg_po_event.c
+++ b/soh/src/overlays/actors/ovl_Bg_Po_Event/z_bg_po_event.c
@@ -388,7 +388,7 @@ void BgPoEvent_BlockPush(BgPoEvent* this, GlobalContext* globalCtx) {
     Player* player = GET_PLAYER(globalCtx);
 
     this->dyna.actor.speedXZ = this->dyna.actor.speedXZ + (CVar_GetS32("gFasterBlockPush", 0) * 0.3) + 0.5f;
-    this->dyna.actor.speedXZ = CLAMP_MAX(this->dyna.actor.speedXZ, 3.0f);
+    this->dyna.actor.speedXZ = CLAMP_MAX(this->dyna.actor.speedXZ, 2.0f);
     blockStop = Math_StepToF(&sBgPoEventblockPushDist, 20.0f, this->dyna.actor.speedXZ);
     displacement = this->direction * sBgPoEventblockPushDist;
     this->dyna.actor.world.pos.x = (Math_SinS(this->dyna.unk_158) * displacement) + this->dyna.actor.home.pos.x;

--- a/soh/src/overlays/actors/ovl_Bg_Spot15_Rrbox/z_bg_spot15_rrbox.c
+++ b/soh/src/overlays/actors/ovl_Bg_Spot15_Rrbox/z_bg_spot15_rrbox.c
@@ -260,9 +260,9 @@ void func_808B4194(BgSpot15Rrbox* this, GlobalContext* globalCtx) {
     s32 approxFResult;
     Actor* actor = &this->dyna.actor;
 
-    this->unk_174 = this->unk_174 + (CVar_GetS32("gFasterBlockPush", 0) * 0.3) + 0.5f;
+    this->unk_174 = this->unk_174 + ((CVar_GetS32("gFasterBlockPush", 0) / 2) * 0.5) + 0.5f;
 
-    this->unk_174 = CLAMP_MAX(this->unk_174, 3.0f);
+    this->unk_174 = CLAMP_MAX(this->unk_174, 2.0f);
 
     approxFResult = Math_StepToF(&this->unk_178, 20.0f, this->unk_174);
 

--- a/soh/src/overlays/actors/ovl_Obj_Oshihiki/z_obj_oshihiki.c
+++ b/soh/src/overlays/actors/ovl_Obj_Oshihiki/z_obj_oshihiki.c
@@ -558,9 +558,9 @@ void ObjOshihiki_Push(ObjOshihiki* this, GlobalContext* globalCtx) {
     f32 pushDistSigned;
     s32 stopFlag;
 
-    this->pushSpeed = this->pushSpeed + (CVar_GetS32("gFasterBlockPush", 0) * 0.3) + 0.5f;
+    this->pushSpeed = this->pushSpeed + ((CVar_GetS32("gFasterBlockPush", 0) / 2) * 0.5) + 0.5f;
     this->stateFlags |= PUSHBLOCK_PUSH;
-    this->pushSpeed = CLAMP_MAX(this->pushSpeed, 3.0f);
+    this->pushSpeed = CLAMP_MAX(this->pushSpeed, 2.0f);
     stopFlag = Math_StepToF(&this->pushDist, 20.0f, this->pushSpeed);
     pushDistSigned = ((this->direction >= 0.0f) ? 1.0f : -1.0f) * this->pushDist;
     thisx->world.pos.x = thisx->home.pos.x + (pushDistSigned * this->yawSin);


### PR DESCRIPTION
Specifically, the fire temple one, as well as potentially others, except Deku, which is vanilla.  Closes #1316, which also mentions that block behavior was altered even with the setting turned off.  That was fixed with this PR as well.  