### PR TITLE
Added return statement in IsVanillaItem before keys

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -1707,6 +1707,7 @@ bool Randomizer::IsItemVanilla(RandomizerGet randoGet) {
         case RG_BUY_BOMBS_535:
         case RG_BUY_RED_POTION_40:
         case RG_BUY_RED_POTION_50:
+            return true;
         case RG_FOREST_TEMPLE_SMALL_KEY:
         case RG_FIRE_TEMPLE_SMALL_KEY:
         case RG_WATER_TEMPLE_SMALL_KEY:


### PR DESCRIPTION
In Keysanity mode, the case statements for the keys were returning false if Keysanity was on, since there was no return before them all the case statements above the keys were also corresponding to that value. Added a return true above RG_FOREST_TEMPLE_SMALL_KEY, since every item listed before that will always come from the vanilla item table.