### PR TITLE
Fixes Ganon's Boss Key setting discrepancy

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -1471,8 +1471,13 @@ s16 Randomizer::GetItemFromGet(RandomizerGet randoGet, GetItemID ogItemId) {
         case RG_WATER_TEMPLE_BOSS_KEY:
         case RG_SPIRIT_TEMPLE_BOSS_KEY:
         case RG_SHADOW_TEMPLE_BOSS_KEY:
-        case RG_GANONS_CASTLE_BOSS_KEY:
             if (GetRandoSettingValue(RSK_BOSS_KEYSANITY) < 3) {
+                return GI_KEY_BOSS;
+            } else {
+                return randoGet;
+            }
+        case RG_GANONS_CASTLE_BOSS_KEY:
+            if (GetRandoSettingValue(RSK_GANONS_BOSS_KEY) < 3) {
                 return GI_KEY_BOSS;
             } else {
                 return randoGet;


### PR DESCRIPTION
If regular Boss Keys were set to Own Dungeon or below, but Ganon's Boss Key was set to outside of his own dungeon, then `GetItemFromGet` would return the vanilla boss key, but `IsItemVanilla` would return false, resulting in `GetItemNone`. This is because `IsItemVanilla` was correctly handling Ganon's Boss Key separately from the other boss keys, while `GetItemFromGet` did not, it lumped it in with the other Boss Key setting. This PR correctly separates it.