### PR TITLE
Reimplement progressive Bombchus + fix bowling Bombchu prize

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -1323,15 +1323,15 @@ ItemObtainability Randomizer::GetItemObtainabilityFromRandomizerGet(RandomizerGe
         case RG_BUY_BOMBCHU_10:
         case RG_BUY_BOMBCHU_20:
         case RG_BUY_BOMBCHU_5:
+        case RG_BOMBCHU_DROP:
             // If Bombchus aren't in logic, you need a bomb bag to purchase them
             // If they are in logic, you need to have already obtained them somewhere else
+            // Bombchu Drop is only used as a bowling reward, so it needs the same logic
             if (GetRandoSettingValue(RSK_BOMBCHUS_IN_LOGIC)) {
                 return INV_CONTENT(ITEM_BOMBCHU) == ITEM_BOMBCHU ? CAN_OBTAIN : CANT_OBTAIN_NEED_UPGRADE;
             } else {
                 return CUR_UPG_VALUE(UPG_BOMB_BAG) ? CAN_OBTAIN : CANT_OBTAIN_NEED_UPGRADE;
             }
-        case RG_BOMBCHU_DROP:
-            return INV_CONTENT(ITEM_BOMBCHU) == ITEM_BOMBCHU ? CAN_OBTAIN : CANT_OBTAIN_NEED_UPGRADE;
         case RG_PROGRESSIVE_HOOKSHOT:
             switch (INV_CONTENT(ITEM_HOOKSHOT)) {
                 case ITEM_NONE:
@@ -1690,7 +1690,13 @@ GetItemID Randomizer::GetItemIdFromRandomizerGet(RandomizerGet randoGet, GetItem
                     return GI_OCARINA_OOT;
             }
         case RG_PROGRESSIVE_BOMBCHUS:
-            return GI_BOMBCHUS_20;
+            if (INV_CONTENT(ITEM_BOMBCHU) == ITEM_NONE) {
+                return GI_BOMBCHUS_20;
+            }
+            if (AMMO(ITEM_BOMBCHU) < 5) {
+                return GI_BOMBCHUS_10;
+            }
+            return GI_BOMBCHUS_5;
         case RG_BOMBCHU_5:
         case RG_BUY_BOMBCHU_5:
         case RG_BOMBCHU_DROP:


### PR DESCRIPTION
Rereading #1379, I noticed that it reverted `RG_PROGRESSIVE_BOMBCHUS` to always giving 20. This PR re-adds the variable bombchu size to Progressive Bombchus so that Bombchus in Logic works as intended.

Also, `RG_BOMBCHU_DROP`, only used for the Bombchu prize in the bowling alley, was set to require the player to already have chus, which is inconsistent with the requirement to play when chus aren't in logic. This PR fixes that by giving `RG_BOMBCHU_DROP` the same requirement as Bombchu bowling.