### PR TITLE
Fixes Link starting with BGS

### DIFF
--- a/soh/src/code/z_sram.c
+++ b/soh/src/code/z_sram.c
@@ -101,6 +101,9 @@ void GiveLinksPocketItem() {
         GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(RC_LINKS_POCKET, RG_NONE);
 
         if (getItemEntry.modIndex == MOD_NONE) {
+            if (getItemEntry.getItemId == GI_SWORD_BGS) {
+                gSaveContext.bgsFlag = true;
+            }
             Item_Give(NULL, getItemEntry.itemId);
         } else if (getItemEntry.modIndex == MOD_RANDOMIZER) {
             Randomizer_Item_Give(NULL, getItemEntry);
@@ -400,6 +403,9 @@ void Sram_InitSave(FileChooseContext* fileChooseCtx) {
             s32 giid = getItem.getItemId;
 
             if (getItem.modIndex == MOD_NONE) {
+                if (getItem.getItemId == GI_SWORD_BGS) {
+                    gSaveContext.bgsFlag = true;
+                }
                 Item_Give(NULL, getItem.itemId);
             } else if (getItem.modIndex == MOD_RANDOMIZER) {
                 Randomizer_Item_Give(NULL, getItem);


### PR DESCRIPTION
After transition `z_sram.c` to `Item_Give` instead of the `GiveLinkItem` functions, I forgot to handle the BGS case appropriately, so starting with BGS would have given Link the Giant's Knife.

Giant's Knife also still works appropriately with not setting the flag once we randomize that in. Tested by making a Spoiler with Link's Pocket set to Giant's Knife, Link correctly had Giant's Knife and _not_ BGS.