### PR TITLE
Ensure itemTrackerNotes vector is not fully empty in InitItemTracker

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
@@ -511,9 +511,6 @@ void DrawNotes(bool resizeable = false) {
                                                 (void*)itemTrackerNotes);
         }
     };
-    if (itemTrackerNotes.empty()) {
-        itemTrackerNotes.push_back(0);
-    }
     ImVec2 size = resizeable ? ImVec2(-FLT_MIN, ImGui::GetContentRegionAvail().y) : ImVec2(((iconSize + iconSpacing) * 6) - 8, 200);
     ItemTrackerNotes::TrackerNotesInputTextMultiline("##ItemTrackerNotes", &itemTrackerNotes, size, ImGuiInputTextFlags_AllowTabInput);
     if (ImGui::IsItemDeactivatedAfterEdit() && IsValidSaveFile()) {
@@ -926,6 +923,10 @@ void InitItemTracker() {
         trackerBgB,
         trackerBgA
     }; // Float value, 1 = 255 in rgb value.
+    // Crashes when the itemTrackerNotes is empty, so add an empty character to it
+    if (itemTrackerNotes.empty()) {
+        itemTrackerNotes.push_back(0);
+    }
     Ship::RegisterHook<Ship::ControllerRead>([](OSContPad* cont_pad) {
         buttonsPressed = cont_pad;
     });


### PR DESCRIPTION
I won't pretend to fully understand what's going on here, but this fixes it.

This block was added to the `DrawNotes` method in a previous implementation by someone else so I'm not sure of the details of why it is necessary, but this PR moves this into the `InitItemTracker` method so it always happens, regardless of if the item tracker/notes portion is open.
```c++
    if (itemTrackerNotes.empty()) {
        itemTrackerNotes.push_back(0);
    }
```

resolves #1406 