### PR TITLE
Move item-related enhancements to new submenu

### DIFF
--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -654,8 +654,6 @@ namespace GameMenuBar {
                 UIWidgets::Tooltip("Allows the D-pad to be used as extra C buttons");
                 UIWidgets::PaddedEnhancementCheckbox("Allow the cursor to be on any slot", "gPauseAnyCursor", true, false);
                 UIWidgets::Tooltip("Allows the cursor on the pause menu to be over any slot\nSimilar to Rando and Spaceworld 97");
-                UIWidgets::PaddedEnhancementCheckbox("Prevent Dropped Ocarina Inputs", "gDpadNoDropOcarinaInput", true, false);
-                UIWidgets::Tooltip("Prevent dropping inputs when playing the ocarina quickly");
                 UIWidgets::PaddedEnhancementCheckbox("Answer Navi Prompt with L Button", "gNaviOnL", true, false);
                 UIWidgets::Tooltip("Speak to Navi with L but enter first-person camera with C-Up");
                 ImGui::EndMenu();
@@ -679,8 +677,6 @@ namespace GameMenuBar {
                     UIWidgets::Tooltip("Prevent forced Navi conversations");
                     UIWidgets::PaddedEnhancementCheckbox("No Skulltula Freeze", "gSkulltulaFreeze", true, false);
                     UIWidgets::Tooltip("Stops the game from freezing the player when picking up Gold Skulltulas");
-                    UIWidgets::PaddedEnhancementCheckbox("MM Bunny Hood", "gMMBunnyHood", true, false);
-                    UIWidgets::Tooltip("Wearing the Bunny Hood grants a speed increase like in Majora's Mask");
                     UIWidgets::PaddedEnhancementCheckbox("Fast Chests", "gFastChests", true, false);
                     UIWidgets::Tooltip("Kick open every chest");
                     UIWidgets::PaddedEnhancementCheckbox("Skip Pickup Messages", "gFastDrops", true, false);
@@ -691,15 +687,26 @@ namespace GameMenuBar {
                     UIWidgets::Tooltip("Skip the part where the Ocarina playback is called when you play a song");
                     UIWidgets::PaddedEnhancementCheckbox("Skip Scarecrow Song", "gSkipScarecrow", true, false);
                     UIWidgets::Tooltip("Pierre appears when Ocarina is pulled out. Requires learning scarecrow song.");
+                    UIWidgets::PaddedEnhancementCheckbox("Remember Save Location", "gRememberSaveLocation", true, false);
+                    UIWidgets::Tooltip("When loading a save, places Link at the last entrance he went through.\n"
+                            "This doesn't work if the save was made in a grotto.");
+                    ImGui::EndMenu();
+                }
+
+                UIWidgets::Spacer(0);
+
+                if (ImGui::BeginMenu("Items"))
+                {
                     UIWidgets::PaddedEnhancementCheckbox("Instant Putaway", "gInstantPutaway", true, false);
                     UIWidgets::Tooltip("Allow Link to put items away without having to wait around");
                     UIWidgets::PaddedEnhancementCheckbox("Instant Boomerang Recall", "gFastBoomerang", true, false);
                     UIWidgets::Tooltip("Instantly return the boomerang to Link by pressing its item button while it's in the air");
+                    UIWidgets::PaddedEnhancementCheckbox("Prevent Dropped Ocarina Inputs", "gDpadNoDropOcarinaInput", true, false);
+                    UIWidgets::Tooltip("Prevent dropping inputs when playing the ocarina quickly");
+                    UIWidgets::PaddedEnhancementCheckbox("MM Bunny Hood", "gMMBunnyHood", true, false);
+                    UIWidgets::Tooltip("Wearing the Bunny Hood grants a speed increase like in Majora's Mask");
                     UIWidgets::PaddedEnhancementCheckbox("Mask Select in Inventory", "gMaskSelect", true, false);
                     UIWidgets::Tooltip("After completing the mask trading sub-quest, press A and any direction on the mask slot to change masks");
-                    UIWidgets::PaddedEnhancementCheckbox("Remember Save Location", "gRememberSaveLocation", true, false);
-                    UIWidgets::Tooltip("When loading a save, places Link at the last entrance he went through.\n"
-                            "This doesn't work if the save was made in a grotto.");
                     ImGui::EndMenu();
                 }
 


### PR DESCRIPTION
This adds an Items flyout under Enhancements > Gameplay and moves the following enhancements to it:
 - Instant Putaway
 - Instant Boomerang Recall
 - Prevent Dropped Ocarina Inputs
 - MM Bunny Hood
 - Mask Select in Inventory
Four of these were originally under Time Savers, so that menu is now a little less huge and more focused.