### PR TITLE
Rando: Enable key colors matching dungeon by default

### DIFF
--- a/libultraship/libultraship/ImGuiImpl.cpp
+++ b/libultraship/libultraship/ImGuiImpl.cpp
@@ -329,6 +329,7 @@ namespace SohImGui {
         statsWindowOpen = CVar_GetS32("gStatsEnabled", 0);
         CVar_RegisterS32("gRandomizeRupeeNames", 1);
         CVar_RegisterS32("gRandoRelevantNavi", 1);
+        CVar_RegisterS32("gRandoMatchKeyColors", 1);
     #ifdef __SWITCH__
         Ship::Switch::SetupFont(io->Fonts);
     #endif

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -907,6 +907,7 @@ void Randomizer::ParseRandomizerSettingsFile(const char* spoilerFileName) {
                         } else if (it.value() == "Anywhere") {
                             gSaveContext.randoSettings[index].value = 3;
                         }
+                        break;
                     case RSK_KEYSANITY:
                         if(it.value() == "Start With") {
                             gSaveContext.randoSettings[index].value = 0;            

--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -1392,7 +1392,22 @@ namespace GameMenuBar {
                 UIWidgets::Tooltip(
                     "When obtaining rupees, randomize what the rupee is called in the textbox."
                 );
-                UIWidgets::PaddedEnhancementCheckbox("Key Colors Match Dungeon", "gRandoMatchKeyColors", true, false);
+
+                // Only disable the key colors checkbox when none of the keysanity settings are set to "Any Dungeon", "Overworld" or "Anywhere"
+                bool disableKeyColors = true;
+
+                if (OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_KEYSANITY) > 2 ||
+                    OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_GERUDO_KEYS) > 0 ||
+                    OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_BOSS_KEYSANITY) > 2 ||
+                    OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_GANONS_BOSS_KEY) > 2 || 
+                    !gSaveContext.n64ddFlag) {
+                    disableKeyColors = false;
+                }
+
+                const char* disableKeyColorsText = "This setting is disabled because a savefile is loaded without any key shuffle settings set to \"Any Dungeon\", \"Overworld\" or \"Anywhere\"";
+
+                UIWidgets::PaddedEnhancementCheckbox("Key Colors Match Dungeon", "gRandoMatchKeyColors", true, false,
+                                                     disableKeyColors, disableKeyColorsText);
                 UIWidgets::Tooltip(
                     "Matches the color of small keys and boss keys to the dungeon they belong to. "
                     "This helps identify keys from afar and adds a little bit of flair.\n\nThis only "

--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -1404,7 +1404,9 @@ namespace GameMenuBar {
                     disableKeyColors = false;
                 }
 
-                const char* disableKeyColorsText = "This setting is disabled because a savefile is loaded without any key shuffle settings set to \"Any Dungeon\", \"Overworld\" or \"Anywhere\"";
+                const char* disableKeyColorsText = 
+                    "This setting is disabled because a savefile is loaded without any key\n"
+                    "shuffle settings set to \"Any Dungeon\", \"Overworld\" or \"Anywhere\"";
 
                 UIWidgets::PaddedEnhancementCheckbox("Key Colors Match Dungeon", "gRandoMatchKeyColors", true, false,
                                                      disableKeyColors, disableKeyColorsText);


### PR DESCRIPTION
Since keys got changed now where they use the vanilla draw functions whenever they're not shuffled outside of their own dungeon, I figured it would be good to have this option on by default now.