### PR TITLE
Rando: Add pendingFlag to Nocturne and Requiem checks

### DIFF
--- a/soh/src/code/z_play.c
+++ b/soh/src/code/z_play.c
@@ -218,7 +218,8 @@ void GivePlayerRandoRewardNocturne(GlobalContext* globalCtx, RandomizerCheck che
         !Player_InBlockingCsMode(globalCtx, player) && !Flags_GetEventChkInf(0xAA)) {
         GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(check, RG_NOCTURNE_OF_SHADOW);
         GiveItemEntryWithoutActor(globalCtx, getItemEntry);
-        Flags_SetEventChkInf(0xAA);
+        player->pendingFlag.flagID = 0xAA;
+        player->pendingFlag.flagType = FLAG_EVENT_CHECK_INF;
     }
 }
 
@@ -230,7 +231,8 @@ void GivePlayerRandoRewardRequiem(GlobalContext* globalCtx, RandomizerCheck chec
             !Player_InBlockingCsMode(globalCtx, player)) {
             GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(check, RG_SONG_OF_TIME);
             GiveItemEntryWithoutActor(globalCtx, getItemEntry);
-            Flags_SetEventChkInf(0xAC);
+            player->pendingFlag.flagID = 0xAC;
+            player->pendingFlag.flagType = FLAG_EVENT_CHECK_INF;
         }
     }
 }


### PR DESCRIPTION
Resolves https://github.com/HarbourMasters/Shipwright/issues/1397

These checks didn't have it yet, so shielding when entering the areas where they're normally granted could skip the item but set the flag, making the check unobtainable.

Tested in game, both work even when shielding now.

I wanted to point this to Rachael, but that didn't have the enum required `FLAG_EVENT_CHECK_INF`, and quite a bit of code changed in this file in general in Zhora. So it didn't feel worth it backporting all that to Rachael just for this.