### PR TITLE
Rando: Fix Complete Mask Quest & Mask Select interaction bugs

### DIFF
--- a/soh/src/code/z_sram.c
+++ b/soh/src/code/z_sram.c
@@ -521,6 +521,7 @@ void Sram_InitSave(FileChooseContext* fileChooseCtx) {
 
         // complete mask quest
         if (Randomizer_GetSettingValue(RSK_COMPLETE_MASK_QUEST)) {
+            gSaveContext.infTable[7] |= 0x80;      // Soldier Wears Keaton Mask
             gSaveContext.itemGetInf[3] |= 0x100;   // Sold Keaton Mask
             gSaveContext.itemGetInf[3] |= 0x200;   // Sold Skull Mask
             gSaveContext.itemGetInf[3] |= 0x400;   // Sold Spooky Mask

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_item.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_item.c
@@ -381,7 +381,11 @@ void KaleidoScope_DrawItemSelect(GlobalContext* globalCtx) {
                             --INV_CONTENT(ITEM_TRADE_CHILD);
                         } else if ((pauseCtx->stickRelX < -30 || pauseCtx->stickRelX > 30 || pauseCtx->stickRelY < -30 || pauseCtx->stickRelY > 30) ||
                                    dpad && CHECK_BTN_ANY(input->press.button, BTN_DUP | BTN_DDOWN | BTN_DLEFT | BTN_DRIGHT)) {
-                            INV_CONTENT(ITEM_TRADE_CHILD) ^= ITEM_MASK_KEATON ^ ITEM_MASK_TRUTH;
+                            if (INV_CONTENT(ITEM_TRADE_CHILD) == ITEM_LETTER_ZELDA) {
+                                INV_CONTENT(ITEM_TRADE_CHILD) = ITEM_MASK_KEATON;
+                            } else {
+                                INV_CONTENT(ITEM_TRADE_CHILD) ^= ITEM_MASK_KEATON ^ ITEM_MASK_TRUTH;
+                            }
                             Audio_PlaySoundGeneral(NA_SE_SY_CURSOR, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
                         }
                         for (uint16_t cSlotIndex = 0; cSlotIndex < ARRAY_COUNT(gSaveContext.equips.cButtonSlots); cSlotIndex++) {


### PR DESCRIPTION
You could sell the Keaton Mask to the guard at the kakariko gate even though the mask shop was technically completed already, leading to other issues like the "Mask Select in Inventory" breaking.

I couldn't find anything else this flag is used for. Flag is tested ingame, seems to fix the issue. Can still open the kakariko gate with zelda's letter just fine.