### PR TITLE
Update randomizer save format

### DIFF
--- a/soh/include/z64save.h
+++ b/soh/include/z64save.h
@@ -175,7 +175,7 @@ typedef struct {
     /* 0x1420 */ s16 worldMapArea;
     /* 0x1422 */ s16 sunsSongState; // controls the effects of suns song
     /* 0x1424 */ s16 healthAccumulator;
-    RandoSetting randoSettings[300];
+    RandoSetting randoSettings[RSK_MAX];
     ItemLocationRando itemLocations[RC_MAX];
     HintLocationRando hintLocations[50];
     char childAltarText[250];

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -643,7 +643,6 @@ void Randomizer::LoadRandomizerSettings(const char* spoilerFileName) {
     }
 
     for(auto randoSetting : gSaveContext.randoSettings) {
-        if(randoSetting.key == RSK_NONE) break;
         this->randoSettings[randoSetting.key] = randoSetting.value;
     }
 }
@@ -713,8 +712,7 @@ void Randomizer::ParseRandomizerSettingsFile(const char* spoilerFileName) {
 
     try {
         // clear out existing settings
-        // RANDOTODO don't use magic number for settings array size
-        for(size_t i = 0; i < 300; i++) {
+        for(size_t i = 0; i < RSK_MAX; i++) {
             gSaveContext.randoSettings[i].key = RSK_NONE;
             gSaveContext.randoSettings[i].value = 0;
         }
@@ -723,13 +721,12 @@ void Randomizer::ParseRandomizerSettingsFile(const char* spoilerFileName) {
         spoilerFileStream >> spoilerFileJson;
         json settingsJson = spoilerFileJson["settings"];
 
-        int index = 0;
-
         for (auto it = settingsJson.begin(); it != settingsJson.end(); ++it) {
             // todo load into cvars for UI
             
             std::string numericValueString;
             if(SpoilerfileSettingNameToEnum.count(it.key())) {
+                RandomizerSettingKey index = SpoilerfileSettingNameToEnum[it.key()];
                 gSaveContext.randoSettings[index].key = SpoilerfileSettingNameToEnum[it.key()];
                 // this is annoying but the same strings are used in different orders
                 // and i don't want the spoilerfile to just have numbers instead of
@@ -996,7 +993,6 @@ void Randomizer::ParseRandomizerSettingsFile(const char* spoilerFileName) {
                         }
                         break;
                 }
-                index++;
             }
         }
 

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -1195,25 +1195,23 @@ void Randomizer::ParseItemLocationsFile(const char* spoilerFileName, bool silent
             index++;
         }
 
-        index = 0;
         for (auto it = locationsJson.begin(); it != locationsJson.end(); ++it) {
+            RandomizerCheck randomizerCheck = SpoilerfileCheckNameToEnum[it.key()];
             if (it->is_structured()) {
                 json itemJson = *it;
                 for (auto itemit = itemJson.begin(); itemit != itemJson.end(); ++itemit) {
                     // todo handle prices
                     if (itemit.key() == "item") {
-                        gSaveContext.itemLocations[index].check = SpoilerfileCheckNameToEnum[it.key()];
-                        gSaveContext.itemLocations[index].get = SpoilerfileGetNameToEnum[itemit.value()];
+                        gSaveContext.itemLocations[randomizerCheck].check = randomizerCheck;
+                        gSaveContext.itemLocations[randomizerCheck].get = SpoilerfileGetNameToEnum[itemit.value()];
                     } else if (itemit.key() == "price") {
-                        randomizerMerchantPrices[gSaveContext.itemLocations[index].check] = itemit.value();
+                        randomizerMerchantPrices[gSaveContext.itemLocations[randomizerCheck].check] = itemit.value();
                     }
                 }
             } else {
-                gSaveContext.itemLocations[index].check = SpoilerfileCheckNameToEnum[it.key()];
-                gSaveContext.itemLocations[index].get = SpoilerfileGetNameToEnum[it.value()];
+                gSaveContext.itemLocations[randomizerCheck].check = randomizerCheck;
+                gSaveContext.itemLocations[randomizerCheck].get = SpoilerfileGetNameToEnum[it.value()];
             }
-
-            index++;
         }
 
         if(!silent) {

--- a/soh/soh/Enhancements/randomizer/randomizerTypes.h
+++ b/soh/soh/Enhancements/randomizer/randomizerTypes.h
@@ -1021,7 +1021,8 @@ typedef enum {
     RSK_SHUFFLE_MAGIC_BEANS,
     RSK_ENABLE_BOMBCHU_DROPS,
     RSK_BOMBCHUS_IN_LOGIC,
-    RSK_LINKS_POCKET
+    RSK_LINKS_POCKET,
+    RSK_MAX
 } RandomizerSettingKey;
 
 typedef enum {

--- a/soh/soh/SaveManager.cpp
+++ b/soh/soh/SaveManager.cpp
@@ -53,42 +53,41 @@ SaveManager::SaveManager() {
 void SaveManager::LoadRandomizerVersion1() {
     if(!CVar_GetS32("gRandomizer", 0)) return;
 
-    for (int i = 0; i < ARRAY_COUNT(gSaveContext.itemLocations); i++) {
-        SaveManager::Instance->LoadData("get" + std::to_string(i), gSaveContext.itemLocations[i].get);
-        SaveManager::Instance->LoadData("check" + std::to_string(i), gSaveContext.itemLocations[i].check);
-    }
+    SaveManager::Instance->LoadArray("itemLocations", RC_MAX, [&](size_t i) {
+        gSaveContext.itemLocations[i].check = RandomizerCheck(i);
+        SaveManager::Instance->LoadData("", gSaveContext.itemLocations[i].get);
+    });
 
-    for (int i = 0; i < ARRAY_COUNT(gSaveContext.seedIcons); i++) {
-        SaveManager::Instance->LoadData("seed" + std::to_string(i), gSaveContext.seedIcons[i]);
-    }
+    SaveManager::Instance->LoadArray("seed", ARRAY_COUNT(gSaveContext.seedIcons), [&](size_t i) {
+        SaveManager::Instance->LoadData("", gSaveContext.seedIcons[i]);
+    });
 
-    for (int i = 0; i < ARRAY_COUNT(gSaveContext.randoSettings); i++) {
-        SaveManager::Instance->LoadData("sk" + std::to_string(i), gSaveContext.randoSettings[i].key);
-        SaveManager::Instance->LoadData("sv" + std::to_string(i), gSaveContext.randoSettings[i].value);
-    }
+    SaveManager::Instance->LoadArray("randoSettings", RSK_MAX, [&](size_t i) {
+        gSaveContext.randoSettings[i].key = RandomizerSettingKey(i);
+        SaveManager::Instance->LoadData("", gSaveContext.randoSettings[i].value);
+    });
 
-    for (int i = 0; i < ARRAY_COUNT(gSaveContext.hintLocations); i++) {
-        SaveManager::Instance->LoadData("hc" + std::to_string(i), gSaveContext.hintLocations[i].check);
-        for (int j = 0; j < ARRAY_COUNT(gSaveContext.hintLocations[i].hintText); j++) {
-            SaveManager::Instance->LoadData("ht" + std::to_string(i) + "-" + std::to_string(j), gSaveContext.hintLocations[i].hintText[j]);
-        }
-    }
+    SaveManager::Instance->LoadArray("hintLocations", ARRAY_COUNT(gSaveContext.hintLocations), [&](size_t i) {
+        SaveManager::Instance->LoadStruct("", [&]() {
+            SaveManager::Instance->LoadData("check", gSaveContext.hintLocations[i].check);
+            std::string hintText;
+            SaveManager::Instance->LoadData("hintText", hintText);
+            memcpy(gSaveContext.hintLocations[i].hintText, hintText.c_str(), hintText.length());
+        });
+    });
 
-    for (int i = 0; i < ARRAY_COUNT(gSaveContext.childAltarText); i++) {
-        SaveManager::Instance->LoadData("cat" + std::to_string(i), gSaveContext.childAltarText[i]);
-    }
-
-    for (int i = 0; i < ARRAY_COUNT(gSaveContext.adultAltarText); i++) {
-        SaveManager::Instance->LoadData("aat" + std::to_string(i), gSaveContext.adultAltarText[i]);
-    }
-
-    for (int i = 0; i < ARRAY_COUNT(gSaveContext.ganonHintText); i++) {
-        SaveManager::Instance->LoadData("ght" + std::to_string(i), gSaveContext.ganonHintText[i]);
-    }
-
-    for (int i = 0; i < ARRAY_COUNT(gSaveContext.ganonText); i++) {
-        SaveManager::Instance->LoadData("gt" + std::to_string(i), gSaveContext.ganonText[i]);
-    }
+    std::string childAltarText;
+    SaveManager::Instance->LoadData("childAltarText", childAltarText);
+    memcpy(gSaveContext.childAltarText, childAltarText.c_str(), childAltarText.length());
+    std::string adultAltarText;
+    SaveManager::Instance->LoadData("adultAltarText", adultAltarText);
+    memcpy(gSaveContext.adultAltarText, adultAltarText.c_str(), adultAltarText.length());
+    std::string ganonHintText;
+    SaveManager::Instance->LoadData("ganonHintText", ganonHintText);
+    memcpy(gSaveContext.ganonHintText, ganonHintText.c_str(), ganonHintText.length());
+    std::string ganonText;
+    SaveManager::Instance->LoadData("ganonText", ganonText);
+    memcpy(gSaveContext.ganonText, ganonText.c_str(), ganonText.length());
 
     SaveManager::Instance->LoadData("adultTradeItems", gSaveContext.adultTradeItems);
 }
@@ -97,42 +96,29 @@ void SaveManager::SaveRandomizer() {
 
     if(!gSaveContext.n64ddFlag) return;
 
-    for (int i = 0; i < ARRAY_COUNT(gSaveContext.itemLocations); i++) {
-        SaveManager::Instance->SaveData("get" + std::to_string(i), gSaveContext.itemLocations[i].get);
-        SaveManager::Instance->SaveData("check" + std::to_string(i), gSaveContext.itemLocations[i].check);
-    }
+    SaveManager::Instance->SaveArray("itemLocations", RC_MAX, [&](size_t i) {
+        SaveManager::Instance->SaveData("", gSaveContext.itemLocations[i].get);
+    });
 
-    for (int i = 0; i < ARRAY_COUNT(gSaveContext.seedIcons); i++) {
-        SaveManager::Instance->SaveData("seed" + std::to_string(i), gSaveContext.seedIcons[i]);
-    }
+    SaveManager::Instance->SaveArray("seed", ARRAY_COUNT(gSaveContext.seedIcons), [&](size_t i) {
+        SaveManager::Instance->SaveData("", gSaveContext.seedIcons[i]);
+    });
 
-    for (int i = 0; i < ARRAY_COUNT(gSaveContext.randoSettings); i++) {
-        SaveManager::Instance->SaveData("sk" + std::to_string(i), gSaveContext.randoSettings[i].key);
-        SaveManager::Instance->SaveData("sv" + std::to_string(i), gSaveContext.randoSettings[i].value);
-    }
+    SaveManager::Instance->SaveArray("randoSettings", RSK_MAX, [&](size_t i) {
+        SaveManager::Instance->SaveData("", gSaveContext.randoSettings[i].value);
+    });
 
-    for (int i = 0; i < ARRAY_COUNT(gSaveContext.hintLocations); i++) {
-        SaveManager::Instance->SaveData("hc" + std::to_string(i), gSaveContext.hintLocations[i].check);
-        for (int j = 0; j < ARRAY_COUNT(gSaveContext.hintLocations[i].hintText); j++) {
-            SaveManager::Instance->SaveData("ht" + std::to_string(i) + "-" + std::to_string(j), gSaveContext.hintLocations[i].hintText[j]);
-        }
-    }
+    SaveManager::Instance->SaveArray("hintLocations", ARRAY_COUNT(gSaveContext.hintLocations), [&](size_t i) {
+        SaveManager::Instance->SaveStruct("", [&]() {
+            SaveManager::Instance->SaveData("check", gSaveContext.hintLocations[i].check);
+            SaveManager::Instance->SaveData("hintText", gSaveContext.hintLocations[i].hintText);
+        });
+    });
 
-    for (int i = 0; i < ARRAY_COUNT(gSaveContext.childAltarText); i++) {
-        SaveManager::Instance->SaveData("cat" + std::to_string(i), gSaveContext.childAltarText[i]);
-    }
-
-    for (int i = 0; i < ARRAY_COUNT(gSaveContext.adultAltarText); i++) {
-        SaveManager::Instance->SaveData("aat" + std::to_string(i), gSaveContext.adultAltarText[i]);
-    }
-
-    for (int i = 0; i < ARRAY_COUNT(gSaveContext.ganonHintText); i++) {
-        SaveManager::Instance->SaveData("ght" + std::to_string(i), gSaveContext.ganonHintText[i]);
-    }
-
-    for (int i = 0; i < ARRAY_COUNT(gSaveContext.ganonText); i++) {
-        SaveManager::Instance->SaveData("gt" + std::to_string(i), gSaveContext.ganonText[i]);
-    }
+    SaveManager::Instance->SaveData("childAltarText", gSaveContext.childAltarText);
+    SaveManager::Instance->SaveData("adultAltarText", gSaveContext.adultAltarText);
+    SaveManager::Instance->SaveData("ganonHintText", gSaveContext.ganonHintText);
+    SaveManager::Instance->SaveData("ganonText", gSaveContext.ganonText);
 
     SaveManager::Instance->SaveData("adultTradeItems", gSaveContext.adultTradeItems);
 }


### PR DESCRIPTION
While messing with the SaveManager for merchant prices I realized there is some real low hanging fruit here with updating how randomizer data is saved. 

Benefits include:
- More readable save file
- Smaller save file (495KB -> 113KB) (16094 lines -> 3569 lines)
- More consistent with the base save data
- Strings are actually readable

The main thing I'm not super sure of is the switch from `randoSettings[300];` to `randoSettings[RSK_MAX];` which RSK_MAX is `57`, does anyone know why we had 300 spots for randoSettings?

Things to double test:
- [x] itemLocations
- [x] seedIcons
- [x] randoSettings
- [x] hintLocations
- [x] childAltarText
- [x] adultAltarText
- [x] ganonHintText
- [x] ganonText

Preview of what a save file looks like now
<img width="619" alt="Screen Shot 2022-09-05 at 1 09 10 PM" src="https://user-images.githubusercontent.com/7316699/188500589-cf207c50-57b1-47a8-990b-a7b98346f09f.png">

What it looked like before

<img width="399" alt="Screen Shot 2022-09-05 at 1 33 51 PM" src="https://user-images.githubusercontent.com/7316699/188500903-bcb10fad-04d1-46de-a02e-c951b3e9adfb.png">
