### PR TITLE
Add merchantPrices to save file instead of loading from active spoiler log

### DIFF
--- a/soh/include/macros.h
+++ b/soh/include/macros.h
@@ -261,5 +261,6 @@ extern GraphicsContext* __gfxCtx;
 #define SEG_ADDR(seg, addr) (addr | (seg << 24) | 1)
 
 #define NUM_TRIALS 6
+#define NUM_SCRUBS 35
 
 #endif

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -110,7 +110,7 @@ Sprite* Randomizer::GetSeedTexture(uint8_t index) {
 Randomizer::~Randomizer() { 
     this->randoSettings.clear();
     this->itemLocations.clear();
-    this->randomizerMerchantPrices.clear();
+    this->merchantPrices.clear();
 }
 
 std::unordered_map<std::string, RandomizerInf> spoilerFileTrialToEnum = {
@@ -1205,7 +1205,7 @@ void Randomizer::ParseItemLocationsFile(const char* spoilerFileName, bool silent
                         gSaveContext.itemLocations[index].check = SpoilerfileCheckNameToEnum[it.key()];
                         gSaveContext.itemLocations[index].get = SpoilerfileGetNameToEnum[itemit.value()];
                     } else if (itemit.key() == "price") {
-                        randomizerMerchantPrices[gSaveContext.itemLocations[index].check] = itemit.value();
+                        merchantPrices[gSaveContext.itemLocations[index].check] = itemit.value();
                     }
                 }
             } else {
@@ -2416,8 +2416,8 @@ ScrubIdentity Randomizer::IdentifyScrub(s32 sceneNum, s32 actorParams, s32 respa
             break;
     }
     
-    if (randomizerMerchantPrices.find(scrubIdentity.randomizerCheck) != randomizerMerchantPrices.end()) {
-        scrubIdentity.itemPrice = randomizerMerchantPrices[scrubIdentity.randomizerCheck];
+    if (merchantPrices.find(scrubIdentity.randomizerCheck) != merchantPrices.end()) {
+        scrubIdentity.itemPrice = merchantPrices[scrubIdentity.randomizerCheck];
     }
 
     return scrubIdentity;

--- a/soh/soh/Enhancements/randomizer/randomizer.h
+++ b/soh/soh/Enhancements/randomizer/randomizer.h
@@ -14,13 +14,11 @@ class Randomizer {
   private:
     std::unordered_map<RandomizerCheck, RandomizerGet> itemLocations;
     std::unordered_map<RandomizerCheck, std::string> hintLocations;
-    std::unordered_map<RandomizerInf, bool> trialsRequired;
     std::string childAltarText;
     std::string adultAltarText;
     std::string ganonHintText;
     std::string ganonText;
     std::unordered_map<RandomizerSettingKey, u8> randoSettings;
-    std::unordered_map<RandomizerCheck, u16> randomizerMerchantPrices;
     void ParseRandomizerSettingsFile(const char* spoilerFileName);
     void ParseHintLocationsFile(const char* spoilerFileName);
     void ParseRequiredTrialsFile(const char* spoilerFileName);
@@ -37,6 +35,10 @@ class Randomizer {
     static const std::string merchantMessageTableID;
     static const std::string rupeeMessageTableID;
     static const std::string NaviRandoMessageTableID;
+
+    // Public for now to be accessed by SaveManager, will be made private again soon :tm:
+    std::unordered_map<RandomizerInf, bool> trialsRequired;
+    std::unordered_map<RandomizerCheck, u16> merchantPrices;
 
     static Sprite* GetSeedTexture(uint8_t index);
     s16 GetItemModelFromId(s16 itemId);

--- a/soh/soh/SaveManager.cpp
+++ b/soh/soh/SaveManager.cpp
@@ -91,6 +91,28 @@ void SaveManager::LoadRandomizerVersion1() {
     }
 
     SaveManager::Instance->LoadData("adultTradeItems", gSaveContext.adultTradeItems);
+
+    std::shared_ptr<Randomizer> randomizer = OTRGlobals::Instance->gRandomizer;
+
+    SaveManager::Instance->LoadArray("merchantPrices", NUM_SCRUBS, [&](size_t i) {
+        SaveManager::Instance->LoadStruct("", [&]() {
+            RandomizerCheck rc;
+            SaveManager::Instance->LoadData("check", rc);
+            uint32_t price;
+            SaveManager::Instance->LoadData("price", price);
+            randomizer->merchantPrices[rc] = price;
+        });
+    });
+
+    SaveManager::Instance->LoadArray("trialsRequired", NUM_TRIALS, [&](size_t i) {
+        SaveManager::Instance->LoadStruct("", [&]() {
+            RandomizerInf inf;
+            SaveManager::Instance->LoadData("inf", inf);
+            bool required;
+            SaveManager::Instance->LoadData("price", required);
+            randomizer->trialsRequired[inf] = required;
+        });
+    });
 }
 
 void SaveManager::SaveRandomizer() {
@@ -135,6 +157,28 @@ void SaveManager::SaveRandomizer() {
     }
 
     SaveManager::Instance->SaveData("adultTradeItems", gSaveContext.adultTradeItems);
+
+    std::shared_ptr<Randomizer> randomizer = OTRGlobals::Instance->gRandomizer;
+
+    std::vector<std::pair<RandomizerCheck, u16>> merchantPrices;
+    for (const auto & [ check, price ] : randomizer->merchantPrices) {
+        merchantPrices.push_back(std::make_pair(check, price));
+    }
+
+    SaveManager::Instance->SaveArray("merchantPrices", NUM_SCRUBS, [&](size_t i) {
+        SaveManager::Instance->SaveStruct("", [&]() {
+            SaveManager::Instance->SaveData("check", merchantPrices[i].first);
+            SaveManager::Instance->SaveData("price", merchantPrices[i].second);
+        });
+    });
+
+    SaveManager::Instance->SaveArray("trialsRequired", NUM_TRIALS, [&](size_t i) {
+        SaveManager::Instance->SaveStruct("", [&]() {
+            RandomizerInf inf = RandomizerInf(RAND_INF_TRIALS_DONE_LIGHT_TRIAL - i);
+            SaveManager::Instance->SaveData("inf", inf);
+            SaveManager::Instance->SaveData("required", randomizer->trialsRequired[inf]);
+        });
+    });
 }
 
 void SaveManager::Init() {

--- a/soh/soh/SaveManager.cpp
+++ b/soh/soh/SaveManager.cpp
@@ -103,16 +103,6 @@ void SaveManager::LoadRandomizerVersion1() {
             randomizer->merchantPrices[rc] = price;
         });
     });
-
-    SaveManager::Instance->LoadArray("trialsRequired", NUM_TRIALS, [&](size_t i) {
-        SaveManager::Instance->LoadStruct("", [&]() {
-            RandomizerInf inf;
-            SaveManager::Instance->LoadData("inf", inf);
-            bool required;
-            SaveManager::Instance->LoadData("price", required);
-            randomizer->trialsRequired[inf] = required;
-        });
-    });
 }
 
 void SaveManager::SaveRandomizer() {
@@ -169,14 +159,6 @@ void SaveManager::SaveRandomizer() {
         SaveManager::Instance->SaveStruct("", [&]() {
             SaveManager::Instance->SaveData("check", merchantPrices[i].first);
             SaveManager::Instance->SaveData("price", merchantPrices[i].second);
-        });
-    });
-
-    SaveManager::Instance->SaveArray("trialsRequired", NUM_TRIALS, [&](size_t i) {
-        SaveManager::Instance->SaveStruct("", [&]() {
-            RandomizerInf inf = RandomizerInf(RAND_INF_TRIALS_DONE_LIGHT_TRIAL - i);
-            SaveManager::Instance->SaveData("inf", inf);
-            SaveManager::Instance->SaveData("required", randomizer->trialsRequired[inf]);
         });
     });
 }

--- a/soh/src/code/z_sram.c
+++ b/soh/src/code/z_sram.c
@@ -8,7 +8,6 @@
 
 #define NUM_DUNGEONS 8
 #define NUM_COWS 10
-#define NUM_SCRUBS 35
 
 /**
  *  Initialize new save.


### PR DESCRIPTION
This resolves an issue that slipped in with Scrubsanity, mostly due to my lack of knowledge. Currently scrubs prices are loaded from your active spoiler log (CVar `gSpoilerLog`). This isn't a huge deal for scrubs because it falls back nicely to the vanilla prices. This PR persists/loads scrub prices in/from the save files