### PR TITLE
Fix issue when merchantPrices is empty

### DIFF
--- a/soh/soh/SaveManager.cpp
+++ b/soh/soh/SaveManager.cpp
@@ -94,7 +94,13 @@ void SaveManager::LoadRandomizerVersion1() {
 
     std::shared_ptr<Randomizer> randomizer = OTRGlobals::Instance->gRandomizer;
 
-    SaveManager::Instance->LoadArray("merchantPrices", NUM_SCRUBS, [&](size_t i) {
+    size_t merchantPricesSize = 0;
+    if (randomizer->GetRandoSettingValue(RSK_SHUFFLE_SCRUBS) > 0) {
+        merchantPricesSize += NUM_SCRUBS;
+    }
+    // TODO: Add shop item count when shopsanity is enabled
+
+    SaveManager::Instance->LoadArray("merchantPrices", merchantPricesSize, [&](size_t i) {
         SaveManager::Instance->LoadStruct("", [&]() {
             RandomizerCheck rc;
             SaveManager::Instance->LoadData("check", rc);

--- a/soh/soh/SaveManager.cpp
+++ b/soh/soh/SaveManager.cpp
@@ -155,7 +155,7 @@ void SaveManager::SaveRandomizer() {
         merchantPrices.push_back(std::make_pair(check, price));
     }
 
-    SaveManager::Instance->SaveArray("merchantPrices", NUM_SCRUBS, [&](size_t i) {
+    SaveManager::Instance->SaveArray("merchantPrices", merchantPrices.size(), [&](size_t i) {
         SaveManager::Instance->SaveStruct("", [&]() {
             SaveManager::Instance->SaveData("check", merchantPrices[i].first);
             SaveManager::Instance->SaveData("price", merchantPrices[i].second);


### PR DESCRIPTION
This should fix the main issue, ~the oddity left over is that when there are no prices on a save a single entry gets created~
```json
               "merchantPrices": [],
```