### PR TITLE
Fix #1417

### DIFF
--- a/soh/src/overlays/actors/ovl_En_Syateki_Man/z_en_syateki_man.c
+++ b/soh/src/overlays/actors/ovl_En_Syateki_Man/z_en_syateki_man.c
@@ -349,6 +349,7 @@ void EnSyatekiMan_EndGame(EnSyatekiMan* this, GlobalContext* globalCtx) {
                                 this->getItemId = GI_BULLET_BAG_50;
                             }
                         } else {
+                            this->getItemEntry = (GetItemEntry)GET_ITEM_NONE;
                             this->getItemId = GI_RUPEE_PURPLE;
                         }
                     } else {
@@ -371,6 +372,7 @@ void EnSyatekiMan_EndGame(EnSyatekiMan* this, GlobalContext* globalCtx) {
                                     break;
                             }
                         } else {
+                            this->getItemEntry = (GetItemEntry)GET_ITEM_NONE;
                             this->getItemId = GI_RUPEE_PURPLE;
                         }
                     }


### PR DESCRIPTION
Resolves #1417 Introduced with the get-item-rework 

The following condition for the randomizer check was evaluating to true because we forgot to also clear the `this->getItemEntry` on subsequent runs, where the `this->getItemId` is set to a purple rupee. 
```
if (!gSaveContext.n64ddFlag || this->getItemEntry.getItemId == GI_NONE) {
```
