### PR TITLE
wiiu: package SoH as a homebrew bundle

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -186,9 +186,9 @@ cmake --build build-cmake --target ExtractAssets
 # Setup cmake project for building for Wii U
 cmake -H. -Bbuild-wiiu -GNinja -DCMAKE_TOOLCHAIN_FILE=/opt/devkitpro/cmake/WiiU.cmake # -DCMAKE_BUILD_TYPE:STRING=Release (if you're packaging)
 # Build project and generate rpx
-cmake --build build-wiiu --target soh
+cmake --build build-wiiu --target soh # --target soh_wuhb (for building .wuhb) 
 
-# Now you can run the executable in ./build-wiiu/soh/soh.rpx
+# Now you can run the executable in ./build-wiiu/soh/soh.rpx or the Wii U Homebrew Bundle in ./build-wiiu/soh/soh.wuhb
 # To develop the project open the repository in VSCode (or your preferred editor)
 ```
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -206,9 +206,10 @@ pipeline {
                             docker exec sohwiiucont scripts/wiiu/build.sh
                             
                             mv build-wiiu/soh/*.rpx soh.rpx
+                            mv build-wiiu/soh/*.wuhb soh.wuhb
                             mv README.md readme.txt
                             
-                            7z a soh-wiiu.7z soh.rpx readme.txt
+                            7z a soh-wiiu.7z soh.rpx soh.wuhb readme.txt
                             
                             '''
                         }

--- a/scripts/wiiu/build.sh
+++ b/scripts/wiiu/build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 cmake -H. -Bbuild-wiiu -GNinja -DCMAKE_TOOLCHAIN_FILE=/opt/devkitpro/cmake/WiiU.cmake -DCMAKE_BUILD_TYPE:STRING=Release
-cmake --build build-wiiu --target soh --config Release
+cmake --build build-wiiu --target soh_wuhb --config Release

--- a/soh/CMakeLists.txt
+++ b/soh/CMakeLists.txt
@@ -2029,6 +2029,13 @@ elseif(CMAKE_SYSTEM_NAME MATCHES "CafeOS")
 
 wut_create_rpx(${PROJECT_NAME})
 
-INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/soh.rpx DESTINATION . COMPONENT ship)
+wut_create_wuhb(${PROJECT_NAME}
+	NAME       "Ship of Harkinian"
+	SHORTNAME  "SoH"
+	AUTHOR     "Harbour Masters"
+	ICON       ${CMAKE_CURRENT_SOURCE_DIR}/icon.jpg
+)
+
+INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/soh.rpx ${CMAKE_CURRENT_BINARY_DIR}/soh.wuhb DESTINATION . COMPONENT ship)
 
 endif()


### PR DESCRIPTION
Now that Aroma is released a new format called .wuhb for bundling Wii U homebrew can be used.
![image](https://user-images.githubusercontent.com/12049776/188604836-ad7895bc-8ba8-49cf-af0a-ea52c3a9e3d5.png)
![image](https://user-images.githubusercontent.com/12049776/188604899-4a42a593-1a1a-4251-ba1e-4d34ec994157.png)
