### PR TITLE
Add ability to disable fish randomly escaping

### DIFF
--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -209,6 +209,8 @@ namespace GameMenuBar {
         CVar_SetS32("gInstantFishing", 0);
         // Guarantee Bite
         CVar_SetS32("gGuaranteeFishingBite", 0);
+        // Fish Never Escape
+        CVar_SetS32("gFishNeverEscape", 0);
         // Child Minimum Weight (6 to 10)
         CVar_SetS32("gChildMinimumWeightFish", 10);
         // Adult Minimum Weight (8 to 13)
@@ -397,6 +399,8 @@ namespace GameMenuBar {
         CVar_SetS32("gInstantFishing", 1);
         // Guarantee Bite
         CVar_SetS32("gGuaranteeFishingBite", 1);
+        // Fish Never Escape
+        CVar_SetS32("gFishNeverEscape", 1);
         // Child Minimum Weight (6 to 10)
         CVar_SetS32("gChildMinimumWeightFish", 6);
         // Adult Minimum Weight (8 to 13)
@@ -833,6 +837,8 @@ namespace GameMenuBar {
                         UIWidgets::Tooltip("All fish will be caught instantly");
                         UIWidgets::PaddedEnhancementCheckbox("Guarantee Bite", "gGuaranteeFishingBite", true, false);
                         UIWidgets::Tooltip("When a line is stable, guarantee bite. Otherwise use default logic");
+                        UIWidgets::PaddedEnhancementCheckbox("Fish Never Escape", "gFishNeverEscape", true, false);
+                        UIWidgets::Tooltip("Once a hook has been set, fish will never let go while being reeled in.");
                         UIWidgets::PaddedEnhancementSliderInt("Child Minimum Weight: %d", "##cMinimumWeight", "gChildMinimumWeightFish", 6, 10, "", 10, false, true, false);
                         UIWidgets::Tooltip("The minimum weight for the unique fishing reward as a child");
                         UIWidgets::PaddedEnhancementSliderInt("Adult Minimum Weight: %d", "##aMinimumWeight", "gAdultMinimumWeightFish", 8, 13, "", 13, false, true, false);

--- a/soh/src/overlays/actors/ovl_Fishing/z_fishing.c
+++ b/soh/src/overlays/actors/ovl_Fishing/z_fishing.c
@@ -2926,6 +2926,10 @@ bool getGuaranteeBite() {
     return CVar_GetS32("gGuaranteeFishingBite", 0);
 }
 
+bool getFishNeverEscape() {
+    return CVar_GetS32("gFishNeverEscape", 0);
+}
+
 void Fishing_UpdateFish(Actor* thisx, GlobalContext* globalCtx2) {
     s16 i;
     s16 sp134 = 10;
@@ -3837,7 +3841,7 @@ void Fishing_UpdateFish(Actor* thisx, GlobalContext* globalCtx2) {
 
             if ((D_80B7A694 < 3) || ((D_80B7E074 != 0) && (D_80B7E080 > 50)) || (D_80B7E080 >= 6000) ||
                 ((D_80B7E122 == 0) && (D_80B7E124 == 0)) || (D_80B7E116 == 0) ||
-                (((D_80B7E0AE & 0x7F) == 0) && (Rand_ZeroOne() < 0.05f) && (D_80B7E0B6 != 2) && (KREG(69) == 0))) {
+                (((D_80B7E0AE & 0x7F) == 0) && (Rand_ZeroOne() < 0.05f) && (D_80B7E0B6 != 2) && (KREG(69) == 0) && (getFishNeverEscape() == 0))) {
                 D_80B7A67C = 20;
 
                 if ((D_80B7E122 == 0) && (D_80B7E124 == 0)) {


### PR DESCRIPTION
N64 rando does this, and I never realized how nice it was!  

Ignore the branch name, I was doing some testing for that freecam bug and got really pissed off at not having a fast repro because the fish kept escaping :)