### PR TITLE
Fixes Ice Trap as starting item.

### DIFF
--- a/soh/src/code/z_sram.c
+++ b/soh/src/code/z_sram.c
@@ -104,7 +104,7 @@ void GiveLinksPocketItem() {
                 gSaveContext.bgsFlag = true;
             }
             Item_Give(NULL, getItemEntry.itemId);
-        } else if (getItemEntry.modIndex == MOD_RANDOMIZER) {
+        } else if (getItemEntry.modIndex == MOD_RANDOMIZER && getItemEntry.getItemId != RG_ICE_TRAP) {
             Randomizer_Item_Give(NULL, getItemEntry);
         }
     }

--- a/soh/src/code/z_sram.c
+++ b/soh/src/code/z_sram.c
@@ -406,7 +406,7 @@ void Sram_InitSave(FileChooseContext* fileChooseCtx) {
                     gSaveContext.bgsFlag = true;
                 }
                 Item_Give(NULL, getItem.itemId);
-            } else if (getItem.modIndex == MOD_RANDOMIZER) {
+            } else if (getItem.modIndex == MOD_RANDOMIZER && getItem.getItemId != RG_ICE_TRAP) {
                 Randomizer_Item_Give(NULL, getItem);
             }
 


### PR DESCRIPTION
Fixes #1437

If Link's Starting item, from either Link's Pocket or Song from Impa, was an Ice Trap, it would crash when pausing, _but only_ on Jenkins builds for some reason. We couldn't reproduce the crash with local builds, either in Release or Debug mode. But it makes sense, the OTRSigCheck was failing because it couldn't find an icon for the Ice Trap, since one doesn't exist.