### PR TITLE
Fix adult wallet having its own max capacity on tracker

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
@@ -276,10 +276,6 @@ ItemTrackerNumbers GetItemCurrentAndMax(ItemTrackerItem item) {
             result.currentAmmo = AMMO(ITEM_SLINGSHOT);
             break;
         case ITEM_WALLET_ADULT:
-            result.currentCapacity = CUR_CAPACITY(UPG_WALLET);
-            result.maxCapacity = 200;
-            result.currentAmmo = gSaveContext.rupees;
-            break;
         case ITEM_WALLET_GIANT:
             result.currentCapacity = CUR_CAPACITY(UPG_WALLET);
             result.maxCapacity = 500;


### PR DESCRIPTION
This was causing child and adult wallet to show `200` as max capacity, when it should have been `500`