### PR TITLE
Add support for the "Vanilla" logic option in Rando

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/settings.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/settings.cpp
@@ -2501,6 +2501,9 @@ namespace Settings {
         case 1:
             Logic.SetSelectedIndex(2);
             break;
+        case 2:
+            Logic.SetSelectedIndex(3);
+            break;
     }
 
     AddExcludedOptions();

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -3131,7 +3131,7 @@ void DrawRandoEditor(bool& open) {
 
     // Randomizer settings
     // Logic Settings
-    const char* randoLogicRules[2] = { "Glitchless", "No logic" };
+    const char* randoLogicRules[3] = { "Glitchless", "No logic", "Vanilla" };
 
     // Open Settings
     const char* randoForest[3] = { "Closed", "Closed Deku", "Open" };
@@ -4103,9 +4103,11 @@ void DrawRandoEditor(bool& open) {
                 UIWidgets::InsertHelpHoverText(
                     "Glitchless - No glitches are required, but may require some minor tricks.\n"
                     "\n"
-                    "No logic - Item placement is completely random. MAY BE IMPOSSIBLE TO BEAT."
+                    "No logic - Item placement is completely random. MAY BE IMPOSSIBLE TO BEAT.\n"
+                    "\n"
+                    "Vanilla - Places all items and dungeon rewards in their vanilla locations"
                 );
-                UIWidgets::EnhancementCombobox("gRandomizeLogicRules", randoLogicRules, 2, 0);
+                UIWidgets::EnhancementCombobox("gRandomizeLogicRules", randoLogicRules, 3, 0);
 
                 UIWidgets::PaddedSeparator();
 


### PR DESCRIPTION
Adds an additional dropdown entry to the Logic Rules dropdown for Vanilla logic which sets item locations and dungeon rewards to their vanilla locations. It doesn't seem to disable rules like the number of Cuccos to return but I think that's probably expected?

From my limited testing this seems to work just fine (and looking at the spoiler log)

Here is the new option in the menu:
![image](https://user-images.githubusercontent.com/9058133/190013256-0bed4793-4265-4a29-9293-fc1ae5ec4152.png)


Pastebin of the generated spoiler log:
https://pastebin.com/R25Prt1X