### PR TITLE
[APPIMAGE] Disable AppImageLauncher integration

### DIFF
--- a/scripts/linux/appimage/soh.desktop
+++ b/scripts/linux/appimage/soh.desktop
@@ -6,4 +6,4 @@ Terminal=false
 Icon=sohIcon
 Type=Application
 Categories=Game;
-Name[en_US]=
+X-AppImage-Integrate=false


### PR DESCRIPTION
Prevents errors associated with running AppImageLauncher, allowing SOH AppImage to execute properly.