### PR TITLE
[Bugfix + Enhancement] Sword Trail fixes and enhancements

### DIFF
--- a/soh/include/functions.h
+++ b/soh/include/functions.h
@@ -185,6 +185,7 @@ void __osSetWatchLo(u32);
 EnItem00* Item_DropCollectible(GlobalContext* globalCtx, Vec3f* spawnPos, s16 params);
 EnItem00* Item_DropCollectible2(GlobalContext* globalCtx, Vec3f* spawnPos, s16 params);
 void Item_DropCollectibleRandom(GlobalContext* globalCtx, Actor* fromActor, Vec3f* spawnPos, s16 params);
+void EffectBlure_ChangeType(EffectBlure* this, int type);
 void EffectBlure_AddVertex(EffectBlure* this, Vec3f* p1, Vec3f* p2);
 void EffectBlure_AddSpace(EffectBlure* this);
 void EffectBlure_Init1(void* thisx, void* initParamsx);

--- a/soh/include/z64effect.h
+++ b/soh/include/z64effect.h
@@ -73,6 +73,7 @@ typedef struct {
     /* 0x194 */ s32 elemDuration;
     /* 0x198 */ s32 unkFlag;
     /* 0x19C */ s32 calcMode;
+    /* 0x1A0 */ u8 trailType; // 1 is swords, 2 is boomerang, 3 is bombchu, 0 is rest
 } EffectBlureInit1; // size = 0x1A0
 
 typedef struct {
@@ -89,6 +90,7 @@ typedef struct {
     /* 0x1B */ u8 mode4Param;
     /* 0x1C */ Color_RGBA8 altPrimColor; // used with drawMode 1
     /* 0x20 */ Color_RGBA8 altEnvColor; // used with drawMode 1
+    /* 0x1A0 */ u8 trailType; // 1 is swords, 2 is boomerang, 3 is bombchu, 4 is arrows, 0 is rest
 } EffectBlureInit2; // size = 0x24
 
 typedef struct {
@@ -108,6 +110,7 @@ typedef struct {
     /* 0x1A1 */ u8 drawMode; // 0: simple; 1: simple with alt colors; 2+: smooth
     /* 0x1A2 */ Color_RGBA8 altPrimColor; // used with drawMode 1
     /* 0x1A6 */ Color_RGBA8 altEnvColor; // used with drawMode 1
+    /* 0x1A0 */ u8 trailType; // 1 is swords, 2 is boomerang, 3 is bombchu, 4 is arrows, 0 is rest
 } EffectBlure; // size = 0x1AC
 
 typedef struct {

--- a/soh/include/z64effect.h
+++ b/soh/include/z64effect.h
@@ -90,7 +90,7 @@ typedef struct {
     /* 0x1B */ u8 mode4Param;
     /* 0x1C */ Color_RGBA8 altPrimColor; // used with drawMode 1
     /* 0x20 */ Color_RGBA8 altEnvColor; // used with drawMode 1
-    /* 0x1A0 */ u8 trailType; // 1 is swords, 2 is boomerang, 3 is bombchu, 4 is arrows, 0 is rest
+    /* 0x1A0 */ u8 trailType; // 1 is swords, 2 is boomerang, 3 is bombchu, 4 is stick, 0 is rest
 } EffectBlureInit2; // size = 0x24
 
 typedef struct {
@@ -110,7 +110,7 @@ typedef struct {
     /* 0x1A1 */ u8 drawMode; // 0: simple; 1: simple with alt colors; 2+: smooth
     /* 0x1A2 */ Color_RGBA8 altPrimColor; // used with drawMode 1
     /* 0x1A6 */ Color_RGBA8 altEnvColor; // used with drawMode 1
-    /* 0x1A0 */ u8 trailType; // 1 is swords, 2 is boomerang, 3 is bombchu, 4 is arrows, 0 is rest
+    /* 0x1A0 */ u8 trailType; // 1 is default swords, 2 is boomerang, 3 is bombchu, 0 is rest. 4 is Kokiri, 5 is Master, 6 is BGS, 7 is Stick, 8 is Hammer.
 } EffectBlure; // size = 0x1AC
 
 typedef struct {

--- a/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
+++ b/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
@@ -25,6 +25,8 @@ const char* RainbowColorCvarList[] = {
     "gDF_Col", "gDF_Env", 
     "gNL_Diamond_Col", "gNL_Diamond_Env", "gNL_Orb_Col", "gNL_Orb_Env",
     "gSwordTrailTopCol", "gSwordTrailBottomCol", "gBoomTrailStartCol", "gBoomTrailEndCol", "gBombTrailCol",
+    "gKSwordTrailTopCol", "gKSwordTrailBottomCol","gMSwordTrailTopCol", "gMSwordTrailBottomCol","gBSwordTrailTopCol", "gBSwordTrailBottomCol",
+    "gStickTrailTopCol", "gStickTrailBottomCol","gHammerTrailTopCol", "gHammerTrailBottomCol",
     "gCharged1Col", "gCharged1ColEnv", "gCharged2Col", "gCharged2ColEnv",
     "gCCFileChoosePrim", "gCCFileChooseTextPrim", "gCCEquipmentsPrim", "gCCItemsPrim",
     "gCCMapsPrim", "gCCQuestsPrim", "gCCSavePrim", "gCCGameoverPrim"
@@ -440,18 +442,31 @@ void Draw_ItemsSkills(){
     }
     UIWidgets::EnhancementCheckbox("Custom trails", "gUseTrailsCol");
     if (CVar_GetS32("gUseTrailsCol", 0)) {
-        DrawRandomizeResetButton("trails", Trail_section, SECTION_SIZE(Trail_section));
+        DrawRandomizeResetButton("trails", AllTrail_section, SECTION_SIZE(AllTrail_section));
     }
     if (CVar_GetS32("gUseTrailsCol", 0) && ImGui::BeginTable("tabletrails", 3, FlagsTable)) {
-        ImGui::TableSetupColumn("Sword Trails", FlagsCell, TablesCellsWidth / 3);
-        ImGui::TableSetupColumn("Boomerang Trails", FlagsCell, TablesCellsWidth / 3);
-        ImGui::TableSetupColumn("Bomb Trails", FlagsCell, TablesCellsWidth / 3);
+        ImGui::TableSetupColumn("Sword Trails", FlagsCell, TablesCellsWidth);
+        ImGui::TableSetupColumn("Boomerang Trails", FlagsCell, TablesCellsWidth);
+        ImGui::TableSetupColumn("Bomb Trails", FlagsCell, TablesCellsWidth);
         Table_InitHeader();
         DrawColorSection(Trail_section, SECTION_SIZE(Trail_section));
         ImGui::EndTable();
         UIWidgets::EnhancementSliderInt("Sword Trail Length: %d", "##TrailsMul", "gTrailDuration", 1, 16, "", 4, true);
         UIWidgets::Tooltip("Determines length of Link's sword trails.");
         ResetTrailLength("gTrailDuration", 4);
+        UIWidgets::EnhancementCheckbox("Swords use separate colors", "gSeperateSwords");
+        if (CVar_GetS32("gSeperateSwords", 0) && ImGui::CollapsingHeader("Individual Sword Colors")) {
+            if (ImGui::BeginTable("tabletrailswords", 2, FlagsTable)) {
+                ImGui::TableSetupColumn("Kokiri Sword", FlagsCell, TablesCellsWidth / 2);
+                ImGui::TableSetupColumn("Master Sword", FlagsCell, TablesCellsWidth / 2);
+                ImGui::TableSetupColumn("Biggoron Sword", FlagsCell, TablesCellsWidth / 2);
+                ImGui::TableSetupColumn("Deku Stick", FlagsCell, TablesCellsWidth / 2);
+                ImGui::TableSetupColumn("Megaton Hammer", FlagsCell, TablesCellsWidth);
+                Table_InitHeader();
+                DrawColorSection(SwordTrail_section, SECTION_SIZE(SwordTrail_section));
+                ImGui::EndTable();
+            }
+        }
         ImGui::NewLine();
     }
 }

--- a/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
+++ b/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
@@ -13,6 +13,7 @@ const char* RainbowColorCvarList[] = {
     //This is the list of possible CVars that has rainbow effect.
     "gTunic_Kokiri", "gTunic_Goron", "gTunic_Zora",
     "gFireArrowCol", "gIceArrowCol",
+    "gNormalArrowCol", "gNormalArrowColEnv",
     "gFireArrowColEnv", "gIceArrowColEnv", "gLightArrowColEnv",
     "gCCHeartsPrim", "gDDCCHeartsPrim", "gLightArrowCol", "gCCDDHeartsPrim",
     "gCCABtnPrim", "gCCBBtnPrim", "gCCCBtnPrim", "gCCStartBtnPrim",
@@ -23,7 +24,8 @@ const char* RainbowColorCvarList[] = {
     "gKeese1_Ef_Prim","gKeese2_Ef_Prim","gKeese1_Ef_Env","gKeese2_Ef_Env",
     "gDF_Col", "gDF_Env", 
     "gNL_Diamond_Col", "gNL_Diamond_Env", "gNL_Orb_Col", "gNL_Orb_Env",
-    "gTrailCol", "gCharged1Col", "gCharged1ColEnv", "gCharged2Col", "gCharged2ColEnv",
+    "gSwordTrailTopCol", "gSwordTrailBottomCol", "gBoomTrailStartCol", "gBoomTrailEndCol", "gBombTrailCol",
+    "gCharged1Col", "gCharged1ColEnv", "gCharged2Col", "gCharged2ColEnv",
     "gCCFileChoosePrim", "gCCFileChooseTextPrim", "gCCEquipmentsPrim", "gCCItemsPrim",
     "gCCMapsPrim", "gCCQuestsPrim", "gCCSavePrim", "gCCGameoverPrim"
 };
@@ -121,6 +123,13 @@ void ResetPositionAll() {
         }
     }
 }
+
+void ResetTrailLength(const char* variable, int value) {
+    if (ImGui::Button("Reset")) {
+        CVar_SetS32(variable, value);
+        }
+    }
+
 void LoadRainbowColor(bool& open) {
     u8 arrayLength = sizeof(RainbowColorCvarList) / sizeof(*RainbowColorCvarList);
     for (u8 s = 0; s < arrayLength; s++) {
@@ -429,15 +438,21 @@ void Draw_ItemsSkills(){
         DrawColorSection(SpinAtk_section, SECTION_SIZE(SpinAtk_section));
         ImGui::EndTable();
     }
-    UIWidgets::EnhancementCheckbox("Custom trails color", "gUseTrailsCol");
-    if (CVar_GetS32("gUseTrailsCol",0) && ImGui::BeginTable("tabletrails", 1, FlagsTable)) {
-        ImGui::TableSetupColumn("Custom Trails", FlagsCell, TablesCellsWidth);
+    UIWidgets::EnhancementCheckbox("Custom trails", "gUseTrailsCol");
+    if (CVar_GetS32("gUseTrailsCol", 0)) {
+        DrawRandomizeResetButton("trails", Trail_section, SECTION_SIZE(Trail_section));
+    }
+    if (CVar_GetS32("gUseTrailsCol", 0) && ImGui::BeginTable("tabletrails", 3, FlagsTable)) {
+        ImGui::TableSetupColumn("Sword Trails", FlagsCell, TablesCellsWidth / 3);
+        ImGui::TableSetupColumn("Boomerang Trails", FlagsCell, TablesCellsWidth / 3);
+        ImGui::TableSetupColumn("Bomb Trails", FlagsCell, TablesCellsWidth / 3);
         Table_InitHeader();
-        DrawColorSection(Trails_section, SECTION_SIZE(Trails_section));
-        UIWidgets::EnhancementSliderInt("Trails duration: %dx", "##TrailsMul", "gTrailDurantion", 1, 5, "");
-        UIWidgets::Tooltip("The longer the trails the weirder it become");
-        ImGui::NewLine();
+        DrawColorSection(Trail_section, SECTION_SIZE(Trail_section));
         ImGui::EndTable();
+        UIWidgets::EnhancementSliderInt("Sword Trail Length: %d", "##TrailsMul", "gTrailDuration", 1, 16, "", 4, true);
+        UIWidgets::Tooltip("Determines length of Link's sword trails.");
+        ResetTrailLength("gTrailDuration", 4);
+        ImGui::NewLine();
     }
 }
 void Draw_Menus(){

--- a/soh/soh/Enhancements/cosmetics/CosmeticsEditor.h
+++ b/soh/soh/Enhancements/cosmetics/CosmeticsEditor.h
@@ -41,10 +41,12 @@ static ImVec4 navi_idle_i_col;     static ImVec4 navi_idle_o_col;
 static ImVec4 navi_npc_i_col;      static ImVec4 navi_npc_o_col;
 static ImVec4 navi_enemy_i_col;    static ImVec4 navi_enemy_o_col;
 static ImVec4 navi_prop_i_col;     static ImVec4 navi_prop_o_col;
-static ImVec4 trailscol;
+static ImVec4 swordtrailtop_col;   static ImVec4 swordtrailbottom_col;
+static ImVec4 boomtrailstart_col;  static ImVec4 boomtrailend_col;
+static ImVec4 bombtrail_col;           
 static ImVec4 crtfilter;
-static ImVec4 firearrow_col;       static ImVec4 icearrow_col;            static ImVec4 lightarrow_col;
-static ImVec4 firearrow_colenv;    static ImVec4 icearrow_colenv;         static ImVec4 lightarrow_colenv;
+static ImVec4 normalarrow_col;     static ImVec4 firearrow_col;           static ImVec4 icearrow_col;            static ImVec4 lightarrow_col;
+static ImVec4 normalarrow_colenv;  static ImVec4 firearrow_colenv;        static ImVec4 icearrow_colenv;         static ImVec4 lightarrow_colenv;
 static ImVec4 charged1_col;        static ImVec4 charged2_col;
 static ImVec4 charged1_colenv;     static ImVec4 charged2_colenv;
 static ImVec4 Keese1_primcol;      static ImVec4 Keese2_primcol;
@@ -90,6 +92,8 @@ static CosmeticsColorIndividual GoronTunic = { "Goron Tunic", "Affects Goron Tun
 static CosmeticsColorIndividual ZoraTunic = { "Zora Tunic", "Affects Zora Tunic color", "gTunic_Zora", zora_col, ImVec4(0, 60, 100, 255), true, false, true };
 
 //Arrows (Fire -> Ice -> Light)
+static CosmeticsColorIndividual Normal_Arrow_Prim = { "Normal Arrows (primary)", "Affects Primary color", "gNormalArrowCol", normalarrow_col, ImVec4(255, 255, 170, 255), true, false, false };
+static CosmeticsColorIndividual Normal_Arrow_Env = { "Normal Arrows (Secondary)", "Affects Secondary color", "gNormalArrowColEnv", normalarrow_colenv, ImVec4(0, 150, 0, 0), true, false, false };
 static CosmeticsColorIndividual Fire_Arrow_Prim = { "Fire Arrows (primary)", "Affects Primary color", "gFireArrowCol", firearrow_col, ImVec4(255,200,0,255), true, false, false };
 static CosmeticsColorIndividual Fire_Arrow_Env = { "Fire Arrows (Secondary)", "Affects Secondary color", "gFireArrowColEnv", firearrow_colenv, ImVec4(255,0,0,255), true, false, false };
 static CosmeticsColorIndividual Ice_Arrow_Prim = { "Ice Arrows (Primary)", "Affects Primary color", "gIceArrowCol", icearrow_col, ImVec4(170,255,255,255), true, false, false };
@@ -112,7 +116,11 @@ static CosmeticsColorIndividual Spin_Lv2_Prim = { "Level 2 (primary)", "Affects 
 static CosmeticsColorIndividual Spin_Lv2_Env = { "Level 2 (Secondary)", "Affects Secondary color", "gCharged2ColEnv", charged2_colenv, ImVec4(255,100,0,255), true, false, false };
 
 //Trails
-static CosmeticsColorIndividual Trails_col = { "Trails color", "Affects Swords slash, boomerang and Bombchu trails color", "gTrailCol", trailscol, ImVec4(255,255,255,255), true, false, false };
+static CosmeticsColorIndividual Sword_Trails_Top_col = { "Sword Trail Top Color", "Affects top of sword slash", "gSwordTrailTopCol", swordtrailtop_col, ImVec4(255,255,255,255), true, false, false };
+static CosmeticsColorIndividual Sword_Trails_Bottom_col = { "Sword Trail End Color", "Affects bottom of sword slash", "gSwordTrailBottomCol", swordtrailbottom_col, ImVec4(255,255,255,255), true, false, false };
+static CosmeticsColorIndividual Boom_Trails_Start_col = { "Boomerang Trail Start Color", "Affects start of boomerang trail", "gBoomTrailStartCol", boomtrailstart_col, ImVec4(255,255,100,255), true, false, false };
+static CosmeticsColorIndividual Boom_Trails_End_col = { "Boomerang Trail End Color", "Affects end of boomerang trail", "gBoomTrailEndCol", boomtrailend_col, ImVec4(255,255,100,255), true, false, false };
+static CosmeticsColorIndividual Bomb_Trails_col = { "Bombchu Trail Color", "Affects Bomchus", "gBombTrailCol", bombtrail_col, ImVec4(250,0,0,255), true, false, false };
 
 //Menus - File Choose
 static CosmeticsColorIndividual FileChoose_Background = { "Main menu color", "Affects the File Select menu background.", "gCCFileChoosePrim", fileselect_colors, ImVec4(100, 150, 255, 255), true, false, false };
@@ -131,7 +139,7 @@ static CosmeticsColorIndividual DPad_Items = { "DPad background", "DPad backgrou
 
 //Hearts colors
 static CosmeticsColorIndividual Hearts_NInner = { "Inner (Normal)", "Affects the inner color", "gCCHeartsPrim", hearts_colors, ImVec4(255,70,50,255), true, false, false };
-static CosmeticsColorIndividual Hearts_DDInner = { "Inner (Double defense)", "Affects the inner color", "gCCDDHeartsPrim", hearts_ddi_colors, ImVec4(255,70,50,255), true, false, false };
+static CosmeticsColorIndividual Hearts_DDInner = { "Inner (Double defense)", "Affects the inner color", "gCCDDHeartsPrim", hearts_ddi_colors, ImVec4(200,0,0,255), true, false, false };
 static CosmeticsColorIndividual Hearts_DDOutline = { "Outline (Double defense)", "Affects the outline color of hearts when you have Double Defense\nWhite is the default value", "gDDCCHeartsPrim", hearts_dd_colors, ImVec4(255,255,255,255), true, false, false };
 
 //Magic Meter colors
@@ -189,7 +197,9 @@ static CosmeticsColorSection Tunics_Section[] = {
     { &ZoraTunic, true, false }
 };
 static CosmeticsColorSection Arrows_section[] = {
-    { &Fire_Arrow_Prim, false, false },
+    { &Normal_Arrow_Prim, false, false },
+    { &Normal_Arrow_Env, true, false },
+    { &Fire_Arrow_Prim, false, true },
     { &Fire_Arrow_Env, true, false },
     { &Ice_Arrow_Prim, false, true },
     { &Ice_Arrow_Env, true, false },
@@ -208,10 +218,13 @@ static CosmeticsColorSection SpinAtk_section[] = {
     { &Spin_Lv1_Prim, false, false },
     { &Spin_Lv1_Env, true, false },
     { &Spin_Lv2_Prim, false, true },
-    { &Spin_Lv2_Env, true, false }
-};
-static CosmeticsColorSection Trails_section[] = {
-    { &Trails_col, false, false }
+    { &Spin_Lv2_Env, true, false } };
+static CosmeticsColorSection Trail_section[] = {
+    { &Sword_Trails_Top_col, false, false },
+    { &Sword_Trails_Bottom_col, false, false },
+    { &Boom_Trails_Start_col, true, false },
+    { &Boom_Trails_End_col, false, false },
+    { &Bomb_Trails_col, true, false }
 };
 static CosmeticsColorSection FileChoose_section[] = {
     { &FileChoose_Background, false, false },
@@ -288,7 +301,9 @@ static CosmeticsColorSection Everything_Section[] = {
     { &KokiriTunic, false, false },
     { &GoronTunic, true, false },
     { &ZoraTunic, true, false },
-    { &Fire_Arrow_Prim, false, false },
+    { &Normal_Arrow_Prim, false, false },
+    { &Normal_Arrow_Env, true, false },
+    { &Fire_Arrow_Prim, false, true },
     { &Fire_Arrow_Env, true, false },
     { &Ice_Arrow_Prim, false, true },
     { &Ice_Arrow_Env, true, false },
@@ -304,7 +319,11 @@ static CosmeticsColorSection Everything_Section[] = {
     { &Spin_Lv1_Env, true, false },
     { &Spin_Lv2_Prim, false, true },
     { &Spin_Lv2_Env, true, false },
-    { &Trails_col, false, false },
+    { &Sword_Trails_Top_col, false, false },
+    { &Sword_Trails_Bottom_col, false, false },
+    { &Boom_Trails_Start_col, true, false },
+    { &Boom_Trails_End_col, false, false },
+    { &Bomb_Trails_col, true, false },
     { &FileChoose_Background, false, false },
     { &FileChoose_BottomText, true, false },
     { &A_Btn, false, false },
@@ -384,7 +403,9 @@ static CosmeticsColorSection AllItemsSkills_section[]{
     { &KokiriTunic, false, false },
     { &GoronTunic, true, false },
     { &ZoraTunic, true, false },
-    { &Fire_Arrow_Prim, false, false },
+    { &Normal_Arrow_Prim, false, false },
+    { &Normal_Arrow_Env, true, false },
+    { &Fire_Arrow_Prim, false, true },
     { &Fire_Arrow_Env, true, false },
     { &Ice_Arrow_Prim, false, true },
     { &Ice_Arrow_Env, true, false },
@@ -400,7 +421,12 @@ static CosmeticsColorSection AllItemsSkills_section[]{
     { &Spin_Lv1_Env, true, false },
     { &Spin_Lv2_Prim, false, true },
     { &Spin_Lv2_Env, true, false },
-    { &Trails_col, false, false }
+    { &Sword_Trails_Top_col, false, false},
+    { &Sword_Trails_Bottom_col, false, false},
+    { &Boom_Trails_Start_col, true, false },
+    { &Boom_Trails_Start_col, true, false },
+    { &Boom_Trails_End_col, false, false },
+    { &Bomb_Trails_col, true, false }
 };
 
 void InitCosmeticsEditor();//Init the menu itself

--- a/soh/soh/Enhancements/cosmetics/CosmeticsEditor.h
+++ b/soh/soh/Enhancements/cosmetics/CosmeticsEditor.h
@@ -122,6 +122,18 @@ static CosmeticsColorIndividual Boom_Trails_Start_col = { "Boomerang Trail Start
 static CosmeticsColorIndividual Boom_Trails_End_col = { "Boomerang Trail End Color", "Affects end of boomerang trail", "gBoomTrailEndCol", boomtrailend_col, ImVec4(255,255,100,255), true, false, false };
 static CosmeticsColorIndividual Bomb_Trails_col = { "Bombchu Trail Color", "Affects Bomchus", "gBombTrailCol", bombtrail_col, ImVec4(250,0,0,255), true, false, false };
 
+
+static CosmeticsColorIndividual KSword_Trails_Top_col = { "Kokiri Sword Top Color", "Affects top of sword slash", "gKSwordTrailTopCol", swordtrailtop_col, ImVec4(255,255,255,255), true, false, false };
+static CosmeticsColorIndividual KSword_Trails_Bottom_col = { "Kokiri Sword End Color", "Affects bottom of sword slash", "gKSwordTrailBottomCol", swordtrailbottom_col, ImVec4(255,255,255,255), true, false, false };
+static CosmeticsColorIndividual MSword_Trails_Top_col = { "Master Sword Top Color", "Affects top of sword slash", "gMSwordTrailTopCol", swordtrailtop_col, ImVec4(255,255,255,255), true, false, false };
+static CosmeticsColorIndividual MSword_Trails_Bottom_col = { "Master Sword End Color", "Affects bottom of sword slash", "gMSwordTrailBottomCol", swordtrailbottom_col, ImVec4(255,255,255,255), true, false, false };
+static CosmeticsColorIndividual BSword_Trails_Top_col = { "BG Sword Top Color", "Affects top of sword slash", "gBSwordTrailTopCol", swordtrailtop_col, ImVec4(255,255,255,255), true, false, false };
+static CosmeticsColorIndividual BSword_Trails_Bottom_col = { "BG Sword End Color", "Affects bottom of sword slash", "gBSwordTrailBottomCol", swordtrailbottom_col, ImVec4(255,255,255,255), true, false, false };
+static CosmeticsColorIndividual Stick_Trails_Top_col = { "Stick Top Color", "Affects top of stick swing", "gStickTrailTopCol", swordtrailtop_col, ImVec4(255,255,255,255), true, false, false };
+static CosmeticsColorIndividual Stick_Trails_Bottom_col = { "Stick End Color", "Affects bottom of stick swing", "gStickTrailBottomCol", swordtrailbottom_col, ImVec4(255,255,255,255), true, false, false };
+static CosmeticsColorIndividual Hammer_Trails_Top_col = { "Hammer Top Color", "Affects top of hammer swing", "gHammerTrailTopCol", swordtrailtop_col, ImVec4(255,255,255,255), true, false, false };
+static CosmeticsColorIndividual Hammer_Trails_Bottom_col = { "Hammer End Color", "Affects bottom of hammer swing", "gHammerTrailBottomCol", swordtrailbottom_col, ImVec4(255,255,255,255), true, false, false };
+
 //Menus - File Choose
 static CosmeticsColorIndividual FileChoose_Background = { "Main menu color", "Affects the File Select menu background.", "gCCFileChoosePrim", fileselect_colors, ImVec4(100, 150, 255, 255), true, false, false };
 static CosmeticsColorIndividual FileChoose_BottomText = { "Bottom texts color", "Affects the File Select texts.", "gCCFileChooseTextPrim", fileselect_text_colors, ImVec4(100, 255, 255, 255), true, false, false };
@@ -219,12 +231,42 @@ static CosmeticsColorSection SpinAtk_section[] = {
     { &Spin_Lv1_Env, true, false },
     { &Spin_Lv2_Prim, false, true },
     { &Spin_Lv2_Env, true, false } };
+
 static CosmeticsColorSection Trail_section[] = {
     { &Sword_Trails_Top_col, false, false },
     { &Sword_Trails_Bottom_col, false, false },
     { &Boom_Trails_Start_col, true, false },
     { &Boom_Trails_End_col, false, false },
     { &Bomb_Trails_col, true, false }
+};
+static CosmeticsColorSection SwordTrail_section[] = {
+    { &KSword_Trails_Top_col, false, false },
+    { &KSword_Trails_Bottom_col, false, false },
+    { &MSword_Trails_Top_col, true, false },
+    { &MSword_Trails_Bottom_col, false, false },
+    { &BSword_Trails_Top_col, true, false },
+    { &BSword_Trails_Bottom_col, false, false },
+    { &Stick_Trails_Top_col, true, false },
+    { &Stick_Trails_Bottom_col, false, false },
+    { &Hammer_Trails_Top_col, true, false },
+    { &Hammer_Trails_Bottom_col, false, false },
+};
+static CosmeticsColorSection AllTrail_section[] = {
+    { &Sword_Trails_Top_col, false, false },
+    { &Sword_Trails_Bottom_col, false, false },
+    { &Boom_Trails_Start_col, true, false },
+    { &Boom_Trails_End_col, false, false },
+    { &Bomb_Trails_col, true, false },
+    { &KSword_Trails_Top_col, false, false },
+    { &KSword_Trails_Bottom_col, false, false },
+    { &MSword_Trails_Top_col, true, false },
+    { &MSword_Trails_Bottom_col, false, false },
+    { &BSword_Trails_Top_col, true, false },
+    { &BSword_Trails_Bottom_col, false, false },
+    { &Stick_Trails_Top_col, true, false },
+    { &Stick_Trails_Bottom_col, false, false },
+    { &Hammer_Trails_Top_col, true, false },
+    { &Hammer_Trails_Bottom_col, false, false },
 };
 static CosmeticsColorSection FileChoose_section[] = {
     { &FileChoose_Background, false, false },
@@ -324,6 +366,16 @@ static CosmeticsColorSection Everything_Section[] = {
     { &Boom_Trails_Start_col, true, false },
     { &Boom_Trails_End_col, false, false },
     { &Bomb_Trails_col, true, false },
+    { &KSword_Trails_Top_col, false, false },
+    { &KSword_Trails_Bottom_col, false, false },
+    { &MSword_Trails_Top_col, true, false },
+    { &MSword_Trails_Bottom_col, false, false },
+    { &BSword_Trails_Top_col, true, false },
+    { &BSword_Trails_Bottom_col, false, false },
+    { &Stick_Trails_Top_col, true, false },
+    { &Stick_Trails_Bottom_col, false, false },
+    { &Hammer_Trails_Top_col, true, false },
+    { &Hammer_Trails_Bottom_col, false, false },
     { &FileChoose_Background, false, false },
     { &FileChoose_BottomText, true, false },
     { &A_Btn, false, false },
@@ -426,7 +478,17 @@ static CosmeticsColorSection AllItemsSkills_section[]{
     { &Boom_Trails_Start_col, true, false },
     { &Boom_Trails_Start_col, true, false },
     { &Boom_Trails_End_col, false, false },
-    { &Bomb_Trails_col, true, false }
+    { &Bomb_Trails_col, true, false },
+    { &KSword_Trails_Top_col, false, false },
+    { &KSword_Trails_Bottom_col, false, false },
+    { &MSword_Trails_Top_col, true, false },
+    { &MSword_Trails_Bottom_col, false, false },
+    { &BSword_Trails_Top_col, true, false },
+    { &BSword_Trails_Bottom_col, false, false },
+    { &Stick_Trails_Top_col, true, false },
+    { &Stick_Trails_Bottom_col, false, false },
+    { &Hammer_Trails_Top_col, true, false },
+    { &Hammer_Trails_Bottom_col, false, false }
 };
 
 void InitCosmeticsEditor();//Init the menu itself

--- a/soh/soh/Enhancements/cosmetics/CosmeticsEditor.h
+++ b/soh/soh/Enhancements/cosmetics/CosmeticsEditor.h
@@ -151,7 +151,7 @@ static CosmeticsColorIndividual DPad_Items = { "DPad background", "DPad backgrou
 
 //Hearts colors
 static CosmeticsColorIndividual Hearts_NInner = { "Inner (Normal)", "Affects the inner color", "gCCHeartsPrim", hearts_colors, ImVec4(255,70,50,255), true, false, false };
-static CosmeticsColorIndividual Hearts_DDInner = { "Inner (Double defense)", "Affects the inner color", "gCCDDHeartsPrim", hearts_ddi_colors, ImVec4(200,0,0,255), true, false, false };
+static CosmeticsColorIndividual Hearts_DDInner = { "Inner (Double defense)", "Affects the inner color", "gCCDDHeartsPrim", hearts_ddi_colors, ImVec4(255,70,50,255), true, false, false };
 static CosmeticsColorIndividual Hearts_DDOutline = { "Outline (Double defense)", "Affects the outline color of hearts when you have Double Defense\nWhite is the default value", "gDDCCHeartsPrim", hearts_dd_colors, ImVec4(255,255,255,255), true, false, false };
 
 //Magic Meter colors

--- a/soh/soh/UIWidgets.cpp
+++ b/soh/soh/UIWidgets.cpp
@@ -427,7 +427,7 @@ namespace UIWidgets {
     }
 
     void RandomizeColor(const char* cvarName, ImVec4* colors) {
-        Color_RGBA8 NewColors = {0,0,0,255};
+        Color_RGBA8 NewColors = {128,0,0,255};
         std::string Cvar_RBM = cvarName;
         Cvar_RBM += "RBM";
         std::string MakeInvisible = "##";
@@ -436,12 +436,9 @@ namespace UIWidgets {
         std::string FullName = "Random";
         FullName += MakeInvisible;
         if (ImGui::Button(FullName.c_str())) {
-            s16 RND_R = rand() % (255 - 0);
-            s16 RND_G = rand() % (255 - 0);
-            s16 RND_B = rand() % (255 - 0);
-            colors->x = (float)RND_R / 255;
-            colors->y = (float)RND_G / 255;
-            colors->z = (float)RND_B / 255;
+            colors->x = rand() % (255 - 0);
+            colors->y = rand() % (255 - 0);
+            colors->z = rand() % (255 - 0);
             NewColors.r = fmin(fmax(colors->x, 0), 255);
             NewColors.g = fmin(fmax(colors->y, 0), 255);
             NewColors.b = fmin(fmax(colors->z, 0), 255);

--- a/soh/soh/UIWidgets.cpp
+++ b/soh/soh/UIWidgets.cpp
@@ -427,7 +427,7 @@ namespace UIWidgets {
     }
 
     void RandomizeColor(const char* cvarName, ImVec4* colors) {
-        Color_RGBA8 NewColors = {128,0,0,255};
+        Color_RGBA8 NewColors = {0,0,0,255};
         std::string Cvar_RBM = cvarName;
         Cvar_RBM += "RBM";
         std::string MakeInvisible = "##";
@@ -436,9 +436,12 @@ namespace UIWidgets {
         std::string FullName = "Random";
         FullName += MakeInvisible;
         if (ImGui::Button(FullName.c_str())) {
-            colors->x = rand() % (255 - 0);
-            colors->y = rand() % (255 - 0);
-            colors->z = rand() % (255 - 0);
+            s16 RND_R = rand() % (255 - 0);
+            s16 RND_G = rand() % (255 - 0);
+            s16 RND_B = rand() % (255 - 0);
+            colors->x = (float)RND_R / 255;
+            colors->y = (float)RND_G / 255;
+            colors->z = (float)RND_B / 255;
             NewColors.r = fmin(fmax(colors->x, 0), 255);
             NewColors.g = fmin(fmax(colors->y, 0), 255);
             NewColors.b = fmin(fmax(colors->z, 0), 255);

--- a/soh/src/code/z_eff_blure.c
+++ b/soh/src/code/z_eff_blure.c
@@ -3,7 +3,9 @@
 
 #include "soh/frame_interpolation.h"
 
-const Color_RGB8 Trails_Color_ori = {255,255,255};
+const Color_RGB8 TrailsColorOriginal = { 255, 255, 255 };
+const Color_RGB8 BoomColorOriginal = { 255, 255, 100 };
+const Color_RGB8 BombColorOriginal = { 200, 0, 0 };
 
 void EffectBlure_AddVertex(EffectBlure* this, Vec3f* p1, Vec3f* p2) {
     EffectBlureElement* elem;
@@ -139,6 +141,7 @@ void EffectBlure_Init1(void* thisx, void* initParamsx) {
         this->elemDuration = initParams->elemDuration;
         this->unkFlag = initParams->unkFlag;
         this->calcMode = initParams->calcMode;
+        this->trailType = initParams->trailType;
         this->flags = 0;
         this->addAngleChange = 0;
         this->addAngle = 0;
@@ -187,6 +190,7 @@ void EffectBlure_Init2(void* thisx, void* initParamsx) {
         this->mode4Param = initParams->mode4Param;
         this->altPrimColor = initParams->altPrimColor;
         this->altEnvColor = initParams->altEnvColor;
+        this->trailType = initParams->trailType;
     }
 }
 
@@ -196,11 +200,113 @@ void EffectBlure_Destroy(void* thisx) {
 s32 EffectBlure_Update(void* thisx) {
     EffectBlure* this = (EffectBlure*)thisx;
     s32 i;
-    s16 RedColor;
-    s16 GreenColor;
-    s16 BlueColor;
-    s16 TrailDuration;
-    Color_RGB8 Trails_col = CVar_GetRGB("gTrailCol", Trails_Color_ori);
+
+    Color_RGB8 SwordTopCol = CVar_GetRGB("gSwordTrailTopCol", TrailsColorOriginal);
+    Color_RGB8 SwordBottomCol = CVar_GetRGB("gSwordTrailBottomCol", TrailsColorOriginal);
+    Color_RGB8 BoomStartCol = CVar_GetRGB("gBoomTrailStartCol", BoomColorOriginal);
+    Color_RGB8 BoomEndCol = CVar_GetRGB("gBoomTrailEndCol", BoomColorOriginal);
+    Color_RGB8 BombchuCol = CVar_GetRGB("gBombTrailCol", BombColorOriginal);
+
+    if ((CVar_GetS32("gUseTrailsCol", 0) != 0) && (this->trailType != 0)) {
+        switch (this->trailType) {
+            case 1: //sword
+                this->p1StartColor.r = SwordTopCol.r;
+                this->p2StartColor.r = SwordBottomCol.r;
+                this->p1EndColor.r = SwordTopCol.r;
+                this->p2EndColor.r = SwordBottomCol.r;
+                this->p1StartColor.g = SwordTopCol.g;
+                this->p2StartColor.g = SwordBottomCol.g;
+                this->p1EndColor.g = SwordTopCol.g;
+                this->p2EndColor.g = SwordBottomCol.g;
+                this->p1StartColor.b = SwordTopCol.b;
+                this->p2StartColor.b = SwordBottomCol.b;
+                this->p1EndColor.b = SwordTopCol.b;
+                this->p2EndColor.b = SwordBottomCol.b;
+                this->elemDuration = CVar_GetS32("gTrailDuration", 1);
+                break;
+            case 2: //boomerang
+                this->p1StartColor.r = BoomStartCol.r;
+                this->p2StartColor.r = BoomStartCol.r;
+                this->p1EndColor.r = BoomEndCol.r;
+                this->p2EndColor.r = BoomEndCol.r;
+                this->p1StartColor.g = BoomStartCol.g;
+                this->p2StartColor.g = BoomStartCol.g;
+                this->p1EndColor.g = BoomEndCol.g;
+                this->p2EndColor.g = BoomEndCol.g;
+                this->p1StartColor.b = BoomStartCol.b;
+                this->p2StartColor.b = BoomStartCol.b;
+                this->p1EndColor.b = BoomEndCol.b;
+                this->p2EndColor.b = BoomEndCol.b;
+                break;
+            case 3: //bombchu
+                this->p1StartColor.r = BombchuCol.r;
+                this->p2StartColor.r = BombchuCol.r * 0.8f;
+                this->p1EndColor.r = BombchuCol.r * 0.6f;
+                this->p2EndColor.r = BombchuCol.r * 0.4f;
+                this->p1StartColor.g = BombchuCol.g;
+                this->p2StartColor.g = BombchuCol.g * 0.8f;
+                this->p1EndColor.g = BombchuCol.g * 0.6f;
+                this->p2EndColor.g = BombchuCol.g * 0.4f;
+                this->p1StartColor.b = BombchuCol.b;
+                this->p2StartColor.b = BombchuCol.b * 0.8f;
+                this->p1EndColor.b = BombchuCol.b * 0.6f;
+                this->p2EndColor.b = BombchuCol.b * 0.4f;
+                break;
+            case 0:
+            default: // don't do anything
+                break;
+        }
+    } else
+        switch (this->trailType) { 
+            case 1: //swords
+                this->p1StartColor.r = 255;
+                this->p2StartColor.r = 255;
+                this->p1EndColor.r = 255;
+                this->p2EndColor.r = 255;
+                this->p1StartColor.g = 255;
+                this->p2StartColor.g = 255;
+                this->p1EndColor.g = 255;
+                this->p2EndColor.g = 255;
+                this->p1StartColor.b = 255;
+                this->p2StartColor.b = 255;
+                this->p1EndColor.b = 255;
+                this->p2EndColor.b = 255;
+                this->elemDuration = 4;
+                break;
+            case 2: //boomerang
+                this->p1StartColor.r = 255;
+                this->p2StartColor.r = 255;
+                this->p1EndColor.r = 255;
+                this->p2EndColor.r = 255;
+                this->p1StartColor.g = 255;
+                this->p2StartColor.g = 255;
+                this->p1EndColor.g = 255;
+                this->p2EndColor.g = 255;
+                this->p1StartColor.b = 100;
+                this->p2StartColor.b = 100;
+                this->p1EndColor.b = 100;
+                this->p2EndColor.b = 100;
+                this->elemDuration = 8;
+                break;
+            case 3: //bombchu
+                this->p1StartColor.r = 250;
+                this->p2StartColor.r = 200;
+                this->p1EndColor.r = 150;
+                this->p2EndColor.r = 100;
+                this->p1StartColor.g = 0;
+                this->p2StartColor.g = 0;
+                this->p1EndColor.g = 0;
+                this->p2EndColor.g = 0;
+                this->p1StartColor.b = 0;
+                this->p2StartColor.b = 0;
+                this->p1EndColor.b = 0;
+                this->p2EndColor.b = 0;
+                this->elemDuration = 16;
+                break;
+            case 0:
+            default: //don't do anything
+                break;
+        }
 
     if (this == NULL) {
         return 0;
@@ -209,32 +315,6 @@ s32 EffectBlure_Update(void* thisx) {
     if (this->numElements == 0) {
         return 0;
     }
-
-    if (CVar_GetS32("gUseTrailsCol", 0) !=0) {
-        RedColor = Trails_col.r;
-        GreenColor = Trails_col.g;
-        BlueColor = Trails_col.b;
-        TrailDuration = 4.0f * CVar_GetS32("gTrailDurantion",1);
-    } else {
-        RedColor = Trails_Color_ori.r;
-        GreenColor = Trails_Color_ori.g;
-        BlueColor = Trails_Color_ori.b;
-        TrailDuration=4.0f;
-    }
-
-    this->p1StartColor.r = RedColor;
-    this->p2StartColor.r = RedColor;
-    this->p1EndColor.r = RedColor;
-    this->p2EndColor.r = RedColor;
-    this->p1StartColor.g = GreenColor;
-    this->p2StartColor.g = GreenColor;
-    this->p1EndColor.g = GreenColor;
-    this->p2EndColor.g = GreenColor;
-    this->p1StartColor.b = BlueColor;
-    this->p2StartColor.b = BlueColor;
-    this->p1EndColor.b = BlueColor;
-    this->p2EndColor.b = BlueColor;
-    this->elemDuration = TrailDuration;
 
     while (true) {
         if (this->elements[0].state == 0) {
@@ -394,7 +474,7 @@ void EffectBlure_GetComputedValues(EffectBlure* this, s32 index, f32 ratio, Vec3
             break;
     }
 
-    //sp30 = sp30; // Optimized out but seems necessary to match stack usage
+    sp30 = sp30; // Optimized out but seems necessary to match stack usage
 
     if (this->flags & 0x10) {
         color1->r = color1->g = color1->b = color1->a = 255;
@@ -693,6 +773,8 @@ void EffectBlure_DrawSmooth(EffectBlure* this2, GraphicsContext* gfxCtx) {
     MtxF sp9C;
     MtxF sp5C;
     Mtx* mtx;
+    static s32 epoch = 0;
+    epoch++;
 
     OPEN_DISPS(gfxCtx);
 
@@ -710,6 +792,7 @@ void EffectBlure_DrawSmooth(EffectBlure* this2, GraphicsContext* gfxCtx) {
     this->elements[this->numElements - 1].flags &= ~3;
     this->elements[this->numElements - 1].flags |= 2;
 
+    FrameInterpolation_RecordOpenChild(this, epoch);
     EffectBlure_SetupSmooth(this, gfxCtx);
     SkinMatrix_SetTranslate(&spDC, this->elements[0].p2.x, this->elements[0].p2.y, this->elements[0].p2.z);
     SkinMatrix_SetScale(&sp9C, 0.1f, 0.1f, 0.1f);
@@ -726,15 +809,11 @@ void EffectBlure_DrawSmooth(EffectBlure* this2, GraphicsContext* gfxCtx) {
         if ((elem->state == 0) || ((elem + 1)->state == 0)) {
             continue;
         }
-        if ((((elem->flags & 3) == 0) && (((elem + 1)->flags & 3) == 0)) ||
-            (((elem->flags & 3) == 2) && (((elem + 1)->flags & 3) == 0)) ||
-            (((elem->flags & 3) == 0) && (((elem + 1)->flags & 3) == 2)) ||
-            (((elem->flags & 3) == 2) && (((elem + 1)->flags & 3) == 2))) {
-            EffectBlure_DrawElemNoInterpolation(this, elem, i, gfxCtx);
-        } else {
-            EffectBlure_DrawElemHermiteInterpolation(this, elem, i, gfxCtx);
-        }
+        EffectBlure_DrawElemHermiteInterpolation(this, elem, i, gfxCtx);
+        
     }
+
+    FrameInterpolation_RecordCloseChild();
 
     CLOSE_DISPS(gfxCtx);
 }
@@ -971,6 +1050,8 @@ void EffectBlure_Draw(void* thisx, GraphicsContext* gfxCtx) {
     s32 i;
     s32 j;
     s32 phi_t2;
+    static s32 epoch = 0;
+    epoch++;
 
     FrameInterpolation_RecordOpenChild(this, 0);
     OPEN_DISPS(gfxCtx);

--- a/soh/src/code/z_eff_blure.c
+++ b/soh/src/code/z_eff_blure.c
@@ -904,7 +904,14 @@ void EffectBlure_DrawSmooth(EffectBlure* this2, GraphicsContext* gfxCtx) {
         if ((elem->state == 0) || ((elem + 1)->state == 0)) {
             continue;
         }
-        EffectBlure_DrawElemHermiteInterpolation(this, elem, i, gfxCtx);
+        if ((((elem->flags & 3) == 0) && (((elem + 1)->flags & 3) == 0)) ||
+            (((elem->flags & 3) == 2) && (((elem + 1)->flags & 3) == 0)) ||
+            (((elem->flags & 3) == 0) && (((elem + 1)->flags & 3) == 2)) ||
+            (((elem->flags & 3) == 2) && (((elem + 1)->flags & 3) == 2))) {
+            EffectBlure_DrawElemNoInterpolation(this, elem, i, gfxCtx);
+        } else {
+            EffectBlure_DrawElemHermiteInterpolation(this, elem, i, gfxCtx);
+        }
         
     }
 

--- a/soh/src/code/z_eff_blure.c
+++ b/soh/src/code/z_eff_blure.c
@@ -75,6 +75,11 @@ void EffectBlure_AddVertex(EffectBlure* this, Vec3f* p1, Vec3f* p2) {
     }
 }
 
+//dumb doo doo command to change the type of an object's blur on the fly. Link's Swords with unique trail colors.
+void EffectBlure_ChangeType(EffectBlure* this, int type) {
+    this->trailType = type;
+}
+
 void EffectBlure_AddSpace(EffectBlure* this) {
     EffectBlureElement* elem;
     s32 numElements;
@@ -206,9 +211,19 @@ s32 EffectBlure_Update(void* thisx) {
     Color_RGB8 BoomStartCol = CVar_GetRGB("gBoomTrailStartCol", BoomColorOriginal);
     Color_RGB8 BoomEndCol = CVar_GetRGB("gBoomTrailEndCol", BoomColorOriginal);
     Color_RGB8 BombchuCol = CVar_GetRGB("gBombTrailCol", BombColorOriginal);
+    Color_RGB8 KSwordTopCol = CVar_GetRGB("gKSwordTrailTopCol", TrailsColorOriginal);
+    Color_RGB8 KSwordBottomCol = CVar_GetRGB("gKSwordTrailBottomCol", TrailsColorOriginal);
+    Color_RGB8 MSwordTopCol = CVar_GetRGB("gMSwordTrailTopCol", TrailsColorOriginal);
+    Color_RGB8 MSwordBottomCol = CVar_GetRGB("gMSwordTrailBottomCol", TrailsColorOriginal);
+    Color_RGB8 BSwordTopCol = CVar_GetRGB("gBSwordTrailTopCol", TrailsColorOriginal);
+    Color_RGB8 BSwordBottomCol = CVar_GetRGB("gBSwordTrailBottomCol", TrailsColorOriginal);
+    Color_RGB8 StickTopCol = CVar_GetRGB("gStickTrailTopCol", TrailsColorOriginal);
+    Color_RGB8 StickBottomCol = CVar_GetRGB("gStickTrailBottomCol", TrailsColorOriginal);
+    Color_RGB8 HammerTopCol = CVar_GetRGB("gHammerTrailTopCol", TrailsColorOriginal);
+    Color_RGB8 HammerBottomCol = CVar_GetRGB("gHammerTrailBottomCol", TrailsColorOriginal);
 
     if ((CVar_GetS32("gUseTrailsCol", 0) != 0) && (this->trailType != 0)) {
-        switch (this->trailType) {
+        switch (this->trailType) { //there HAS to be a better way to do this.
             case 1: //sword
                 this->p1StartColor.r = SwordTopCol.r;
                 this->p2StartColor.r = SwordBottomCol.r;
@@ -238,7 +253,7 @@ s32 EffectBlure_Update(void* thisx) {
                 this->p1EndColor.b = BoomEndCol.b;
                 this->p2EndColor.b = BoomEndCol.b;
                 break;
-            case 3: //bombchu
+            case 3: // bombchu
                 this->p1StartColor.r = BombchuCol.r;
                 this->p2StartColor.r = BombchuCol.r * 0.8f;
                 this->p1EndColor.r = BombchuCol.r * 0.6f;
@@ -252,6 +267,81 @@ s32 EffectBlure_Update(void* thisx) {
                 this->p1EndColor.b = BombchuCol.b * 0.6f;
                 this->p2EndColor.b = BombchuCol.b * 0.4f;
                 break;
+            case 4: // kokiri sword
+                this->p1StartColor.r = KSwordTopCol.r;
+                this->p2StartColor.r = KSwordBottomCol.r;
+                this->p1EndColor.r = KSwordTopCol.r;
+                this->p2EndColor.r = KSwordBottomCol.r;
+                this->p1StartColor.g = KSwordTopCol.g;
+                this->p2StartColor.g = KSwordBottomCol.g;
+                this->p1EndColor.g = KSwordTopCol.g;
+                this->p2EndColor.g = KSwordBottomCol.g;
+                this->p1StartColor.b = KSwordTopCol.b;
+                this->p2StartColor.b = KSwordBottomCol.b;
+                this->p1EndColor.b = KSwordTopCol.b;
+                this->p2EndColor.b = KSwordBottomCol.b;
+                this->elemDuration = CVar_GetS32("gTrailDuration", 1);
+                break;
+            case 5: // master sword
+                this->p1StartColor.r = MSwordTopCol.r;
+                this->p2StartColor.r = MSwordBottomCol.r;
+                this->p1EndColor.r = MSwordTopCol.r;
+                this->p2EndColor.r = MSwordBottomCol.r;
+                this->p1StartColor.g = MSwordTopCol.g;
+                this->p2StartColor.g = MSwordBottomCol.g;
+                this->p1EndColor.g = MSwordTopCol.g;
+                this->p2EndColor.g = MSwordBottomCol.g;
+                this->p1StartColor.b = MSwordTopCol.b;
+                this->p2StartColor.b = MSwordBottomCol.b;
+                this->p1EndColor.b = MSwordTopCol.b;
+                this->p2EndColor.b = MSwordBottomCol.b;
+                this->elemDuration = CVar_GetS32("gTrailDuration", 1);
+                break;
+            case 6: // biggoron sword
+                this->p1StartColor.r = BSwordTopCol.r;
+                this->p2StartColor.r = BSwordBottomCol.r;
+                this->p1EndColor.r = BSwordTopCol.r;
+                this->p2EndColor.r = BSwordBottomCol.r;
+                this->p1StartColor.g = BSwordTopCol.g;
+                this->p2StartColor.g = BSwordBottomCol.g;
+                this->p1EndColor.g = BSwordTopCol.g;
+                this->p2EndColor.g = BSwordBottomCol.g;
+                this->p1StartColor.b = BSwordTopCol.b;
+                this->p2StartColor.b = BSwordBottomCol.b;
+                this->p1EndColor.b = BSwordTopCol.b;
+                this->p2EndColor.b = BSwordBottomCol.b;
+                this->elemDuration = CVar_GetS32("gTrailDuration", 1);
+                break;
+            case 7: // stick
+                this->p1StartColor.r = StickTopCol.r;
+                this->p2StartColor.r = StickBottomCol.r;
+                this->p1EndColor.r = StickTopCol.r;
+                this->p2EndColor.r = StickBottomCol.r;
+                this->p1StartColor.g = StickTopCol.g;
+                this->p2StartColor.g = StickBottomCol.g;
+                this->p1EndColor.g = StickTopCol.g;
+                this->p2EndColor.g = StickBottomCol.g;
+                this->p1StartColor.b = StickTopCol.b;
+                this->p2StartColor.b = StickBottomCol.b;
+                this->p1EndColor.b = StickTopCol.b;
+                this->p2EndColor.b = StickBottomCol.b;
+                this->elemDuration = CVar_GetS32("gTrailDuration", 1);
+                break;
+            case 8: // hammer
+                this->p1StartColor.r = HammerTopCol.r;
+                this->p2StartColor.r = HammerBottomCol.r;
+                this->p1EndColor.r = HammerTopCol.r;
+                this->p2EndColor.r = HammerBottomCol.r;
+                this->p1StartColor.g = HammerTopCol.g;
+                this->p2StartColor.g = HammerBottomCol.g;
+                this->p1EndColor.g = HammerTopCol.g;
+                this->p2EndColor.g = HammerBottomCol.g;
+                this->p1StartColor.b = HammerTopCol.b;
+                this->p2StartColor.b = HammerBottomCol.b;
+                this->p1EndColor.b = HammerTopCol.b;
+                this->p2EndColor.b = HammerBottomCol.b;
+                this->elemDuration = CVar_GetS32("gTrailDuration", 1);
+                break;
             case 0:
             default: // don't do anything
                 break;
@@ -259,6 +349,11 @@ s32 EffectBlure_Update(void* thisx) {
     } else
         switch (this->trailType) { 
             case 1: //swords
+            case 4:
+            case 5:
+            case 6:
+            case 7:
+            case 8:
                 this->p1StartColor.r = 255;
                 this->p2StartColor.r = 255;
                 this->p1EndColor.r = 255;

--- a/soh/src/code/z_player_lib.c
+++ b/soh/src/code/z_player_lib.c
@@ -1242,6 +1242,10 @@ f32 sSwordLengths[] = {
     0.0f, 4000.0f, 3000.0f, 5500.0f, 0.0f, 2500.0f,
 };
 
+f32 sSwordTypes[] = {
+    0, 5, 4, 6, 0, 8,
+};
+
 Gfx* sBottleDLists[] = { gLinkAdultBottleDL, gLinkChildBottleDL };
 
 Color_RGB8 sBottleColors[] = {
@@ -1304,6 +1308,7 @@ void func_80090D20(GlobalContext* globalCtx, s32 limbIndex, Gfx** dList, Vec3s* 
                 D_80126080.x = this->unk_85C * 5000.0f;
                 func_80090A28(this, sp124);
                 if (this->swordState != 0) {
+                    EffectBlure_ChangeType(Effect_GetByIndex(this->swordEffectIndex), 7); // default sword type
                     func_800906D4(globalCtx, this, sp124);
                 } else {
                     Math_Vec3f_Copy(&this->swordInfo[0].tip, &sp124[0]);
@@ -1326,6 +1331,10 @@ void func_80090D20(GlobalContext* globalCtx, s32 limbIndex, Gfx** dList, Vec3s* 
                 D_80126080.x = 1500.0f;
             } else {
                 D_80126080.x = sSwordLengths[Player_GetSwordHeld(this)];
+                if (CVar_GetS32("gSeperateSwords", 0) != 0)
+                    EffectBlure_ChangeType(Effect_GetByIndex(this->swordEffectIndex), sSwordTypes[Player_GetSwordHeld(this)]);
+                else
+                    EffectBlure_ChangeType(Effect_GetByIndex(this->swordEffectIndex),1); //default sword type
             }
 
             func_80090A28(this, spE4);

--- a/soh/src/overlays/actors/ovl_En_Arrow/z_en_arrow.c
+++ b/soh/src/overlays/actors/ovl_En_Arrow/z_en_arrow.c
@@ -6,6 +6,7 @@
 
 #include "z_en_arrow.h"
 #include "objects/gameplay_keep/gameplay_keep.h"
+#include "objects/object_gi_nuts/object_gi_nuts.h"
 
 #define FLAGS (ACTOR_FLAG_4 | ACTOR_FLAG_5)
 
@@ -505,18 +506,30 @@ void EnArrow_Draw(Actor* thisx, GlobalContext* globalCtx) {
             scale = 150.0f;
         }
 
-        Matrix_Push();
-        Matrix_Mult(&globalCtx->billboardMtxF, MTXMODE_APPLY);
-        // redundant check because this is contained in an if block for non-zero speed
-        Matrix_RotateZ((this->actor.speedXZ == 0.0f) ? 0.0f
-                                                     : ((globalCtx->gameplayFrames & 0xFF) * 4000) * (M_PI / 0x8000),
-                       MTXMODE_APPLY);
-        Matrix_Scale(scale, scale, scale, MTXMODE_APPLY);
-        gSPMatrix(POLY_XLU_DISP++, MATRIX_NEWMTX(globalCtx->state.gfxCtx),
-                  G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
-        gSPDisplayList(POLY_XLU_DISP++, gEffSparklesDL);
-        Matrix_Pop();
-        Matrix_RotateY(this->actor.world.rot.y * (M_PI / 0x8000), MTXMODE_APPLY);
+        if (CVar_GetS32("gNewDrops", 0) != 0) {
+            gSPSegment(POLY_OPA_DISP++, 0x08,
+                       Gfx_TwoTexScroll(globalCtx->state.gfxCtx, 0, 1 * (globalCtx->state.frames * 6),
+                                        1 * (globalCtx->state.frames * 6), 32, 32, 1, 1 * (globalCtx->state.frames * 6),
+                                        1 * (globalCtx->state.frames * 6), 32, 32));
+            scale = scale / 10;
+            Matrix_Scale(scale, scale, scale, MTXMODE_APPLY);
+            Matrix_RotateY(this->actor.world.rot.y * (M_PI / 0x4000), MTXMODE_APPLY);
+            gSPMatrix(POLY_OPA_DISP++, MATRIX_NEWMTX(globalCtx->state.gfxCtx), G_MTX_MODELVIEW | G_MTX_LOAD);
+            gSPDisplayList(POLY_OPA_DISP++, gGiNutDL);
+        } else {
+            Matrix_Push();
+            Matrix_Mult(&globalCtx->billboardMtxF, MTXMODE_APPLY);
+            // redundant check because this is contained in an if block for non-zero speed
+            Matrix_RotateZ(
+                (this->actor.speedXZ == 0.0f) ? 0.0f : ((globalCtx->gameplayFrames & 0xFF) * 4000) * (M_PI / 0x8000),
+                MTXMODE_APPLY);
+            Matrix_Scale(scale, scale, scale, MTXMODE_APPLY);
+            gSPMatrix(POLY_XLU_DISP++, MATRIX_NEWMTX(globalCtx->state.gfxCtx),
+                      G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+            gSPDisplayList(POLY_XLU_DISP++, gEffSparklesDL);
+            Matrix_Pop();
+            Matrix_RotateY(this->actor.world.rot.y * (M_PI / 0x8000), MTXMODE_APPLY);
+        }
 
         CLOSE_DISPS(globalCtx->state.gfxCtx);
     }

--- a/soh/src/overlays/actors/ovl_En_Arrow/z_en_arrow.c
+++ b/soh/src/overlays/actors/ovl_En_Arrow/z_en_arrow.c
@@ -506,7 +506,7 @@ void EnArrow_Draw(Actor* thisx, GlobalContext* globalCtx) {
             scale = 150.0f;
         }
 
-        if (CVar_GetS32("gNewDrops", 0) != 0) {
+        /*if (CVar_GetS32("gNewDrops", 0) != 0) {
             gSPSegment(POLY_OPA_DISP++, 0x08,
                        Gfx_TwoTexScroll(globalCtx->state.gfxCtx, 0, 1 * (globalCtx->state.frames * 6),
                                         1 * (globalCtx->state.frames * 6), 32, 32, 1, 1 * (globalCtx->state.frames * 6),
@@ -516,7 +516,7 @@ void EnArrow_Draw(Actor* thisx, GlobalContext* globalCtx) {
             Matrix_RotateY(this->actor.world.rot.y * (M_PI / 0x4000), MTXMODE_APPLY);
             gSPMatrix(POLY_OPA_DISP++, MATRIX_NEWMTX(globalCtx->state.gfxCtx), G_MTX_MODELVIEW | G_MTX_LOAD);
             gSPDisplayList(POLY_OPA_DISP++, gGiNutDL);
-        } else {
+        } else {*/
             Matrix_Push();
             Matrix_Mult(&globalCtx->billboardMtxF, MTXMODE_APPLY);
             // redundant check because this is contained in an if block for non-zero speed
@@ -529,7 +529,7 @@ void EnArrow_Draw(Actor* thisx, GlobalContext* globalCtx) {
             gSPDisplayList(POLY_XLU_DISP++, gEffSparklesDL);
             Matrix_Pop();
             Matrix_RotateY(this->actor.world.rot.y * (M_PI / 0x8000), MTXMODE_APPLY);
-        }
+        //}
 
         CLOSE_DISPS(globalCtx->state.gfxCtx);
     }

--- a/soh/src/overlays/actors/ovl_En_Arrow/z_en_arrow.c
+++ b/soh/src/overlays/actors/ovl_En_Arrow/z_en_arrow.c
@@ -63,25 +63,55 @@ void EnArrow_SetupAction(EnArrow* this, EnArrowActionFunc actionFunc) {
 void EnArrow_Init(Actor* thisx, GlobalContext* globalCtx) {
     static EffectBlureInit2 blureNormal = {
         0, 4, 0, { 0, 255, 200, 255 },   { 0, 255, 255, 255 }, { 0, 255, 200, 0 }, { 0, 255, 255, 0 }, 16,
-        0, 1, 0, { 255, 255, 170, 255 }, { 0, 150, 0, 0 },
+        0, 1, 0, { 255, 255, 170, 255 }, { 0, 150, 0, 0 }, 0,
     };
     static EffectBlureInit2 blureFire = {
         0, 4, 0, { 0, 255, 200, 255 }, { 0, 255, 255, 255 }, { 0, 255, 200, 0 }, { 0, 255, 255, 0 }, 16,
-        0, 1, 0, { 255, 200, 0, 255 }, { 255, 0, 0, 0 },
+        0, 1, 0, { 255, 200, 0, 255 }, { 255, 0, 0, 0 }, 0,
     };
     static EffectBlureInit2 blureIce = {
         0, 4, 0, { 0, 255, 200, 255 },   { 0, 255, 255, 255 }, { 0, 255, 200, 0 }, { 0, 255, 255, 0 }, 16,
-        0, 1, 0, { 170, 255, 255, 255 }, { 0, 100, 255, 0 },
+        0, 1, 0, { 170, 255, 255, 255 }, { 0, 100, 255, 0 }, 0,
     };
     static EffectBlureInit2 blureLight = {
         0, 4, 0, { 0, 255, 200, 255 },   { 0, 255, 255, 255 }, { 0, 255, 200, 0 }, { 0, 255, 255, 0 }, 16,
-        0, 1, 0, { 255, 255, 170, 255 }, { 255, 255, 0, 0 },
+        0, 1, 0, { 255, 255, 170, 255 }, { 255, 255, 0, 0 }, 0,
     };
     static u32 dmgFlags[] = {
         0x00000800, 0x00000020, 0x00000020, 0x00000800, 0x00001000,
         0x00002000, 0x00010000, 0x00004000, 0x00008000, 0x00000004,
     };
     EnArrow* this = (EnArrow*)thisx;
+
+    Color_RGBA8 Arrow_env_ori = { 0, 150, 0, 0 };
+    Color_RGBA8 Arrow_col_ori = { 255, 255, 170, 255 };
+    Color_RGBA8 Light_env_ori = { 255, 255, 0, 255 };
+    Color_RGBA8 Light_col_ori = { 255, 255, 170, 0 };
+    Color_RGBA8 Fire_env_ori = { 255, 0, 0, 255 };
+    Color_RGBA8 Fire_col_ori = { 255, 200, 0, 0 };
+    Color_RGBA8 Ice_env_ori = { 0, 0, 255, 255 };
+    Color_RGBA8 Ice_col_ori = { 170, 255, 255, 0 };
+
+    if (CVar_GetS32("gUseArrowsCol", 0) != 0) {
+        blureNormal.altPrimColor = CVar_GetRGBA("gNormalArrowCol", Arrow_col_ori);
+        blureNormal.altEnvColor = CVar_GetRGBA("gNormalArrowColEnv", Arrow_env_ori);
+        blureFire.altPrimColor = CVar_GetRGBA("gFireArrowCol", Fire_col_ori);
+        blureFire.altEnvColor = CVar_GetRGBA("gFireArrowColEnv", Fire_env_ori);
+        blureIce.altPrimColor = CVar_GetRGBA("gIceArrowCol", Ice_col_ori);
+        blureIce.altEnvColor = CVar_GetRGBA("gIceArrowColEnv", Ice_env_ori);
+        blureLight.altPrimColor = CVar_GetRGBA("gLightArrowCol", Light_col_ori);
+        blureLight.altEnvColor = CVar_GetRGBA("gLightArrowColEnv", Light_env_ori);
+
+        //make sure the alpha values are correct.
+        blureNormal.altPrimColor.a = 255;
+        blureNormal.altEnvColor.a = 0;
+        blureFire.altPrimColor.a = 255;
+        blureFire.altEnvColor.a = 0;
+        blureIce.altPrimColor.a = 255;
+        blureIce.altEnvColor.a = 0;
+        blureLight.altPrimColor.a = 255;
+        blureLight.altEnvColor.a = 0;
+    }
 
     Actor_ProcessInitChain(&this->actor, sInitChain);
 

--- a/soh/src/overlays/actors/ovl_En_Arrow/z_en_arrow.c
+++ b/soh/src/overlays/actors/ovl_En_Arrow/z_en_arrow.c
@@ -506,31 +506,18 @@ void EnArrow_Draw(Actor* thisx, GlobalContext* globalCtx) {
             scale = 150.0f;
         }
 
-        /*if (CVar_GetS32("gNewDrops", 0) != 0) {
-            gSPSegment(POLY_OPA_DISP++, 0x08,
-                       Gfx_TwoTexScroll(globalCtx->state.gfxCtx, 0, 1 * (globalCtx->state.frames * 6),
-                                        1 * (globalCtx->state.frames * 6), 32, 32, 1, 1 * (globalCtx->state.frames * 6),
-                                        1 * (globalCtx->state.frames * 6), 32, 32));
-            scale = scale / 10;
-            Matrix_Scale(scale, scale, scale, MTXMODE_APPLY);
-            Matrix_RotateY(this->actor.world.rot.y * (M_PI / 0x4000), MTXMODE_APPLY);
-            gSPMatrix(POLY_OPA_DISP++, MATRIX_NEWMTX(globalCtx->state.gfxCtx), G_MTX_MODELVIEW | G_MTX_LOAD);
-            gSPDisplayList(POLY_OPA_DISP++, gGiNutDL);
-        } else {*/
-            Matrix_Push();
-            Matrix_Mult(&globalCtx->billboardMtxF, MTXMODE_APPLY);
-            // redundant check because this is contained in an if block for non-zero speed
-            Matrix_RotateZ(
-                (this->actor.speedXZ == 0.0f) ? 0.0f : ((globalCtx->gameplayFrames & 0xFF) * 4000) * (M_PI / 0x8000),
-                MTXMODE_APPLY);
-            Matrix_Scale(scale, scale, scale, MTXMODE_APPLY);
-            gSPMatrix(POLY_XLU_DISP++, MATRIX_NEWMTX(globalCtx->state.gfxCtx),
-                      G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
-            gSPDisplayList(POLY_XLU_DISP++, gEffSparklesDL);
-            Matrix_Pop();
-            Matrix_RotateY(this->actor.world.rot.y * (M_PI / 0x8000), MTXMODE_APPLY);
-        //}
-
+        Matrix_Push();
+        Matrix_Mult(&globalCtx->billboardMtxF, MTXMODE_APPLY);
+        // redundant check because this is contained in an if block for non-zero speed
+        Matrix_RotateZ(
+            (this->actor.speedXZ == 0.0f) ? 0.0f : ((globalCtx->gameplayFrames & 0xFF) * 4000) * (M_PI / 0x8000),
+            MTXMODE_APPLY);
+        Matrix_Scale(scale, scale, scale, MTXMODE_APPLY);
+        gSPMatrix(POLY_XLU_DISP++, MATRIX_NEWMTX(globalCtx->state.gfxCtx),
+                    G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+        gSPDisplayList(POLY_XLU_DISP++, gEffSparklesDL);
+        Matrix_Pop();
+        Matrix_RotateY(this->actor.world.rot.y * (M_PI / 0x8000), MTXMODE_APPLY);
         CLOSE_DISPS(globalCtx->state.gfxCtx);
     }
 

--- a/soh/src/overlays/actors/ovl_En_Bom/z_en_bom.c
+++ b/soh/src/overlays/actors/ovl_En_Bom/z_en_bom.c
@@ -7,6 +7,7 @@
 #include "z_en_bom.h"
 #include "overlays/effects/ovl_Effect_Ss_Dead_Sound/z_eff_ss_dead_sound.h"
 #include "objects/gameplay_keep/gameplay_keep.h"
+#include "objects/gameplay_field_keep/gameplay_field_keep.h"
 
 #define FLAGS (ACTOR_FLAG_4 | ACTOR_FLAG_5)
 
@@ -363,21 +364,34 @@ void EnBom_Draw(Actor* thisx, GlobalContext* globalCtx) {
     OPEN_DISPS(globalCtx->state.gfxCtx);
 
     if (thisx->params == BOMB_BODY) {
-        func_80093D18(globalCtx->state.gfxCtx);
-        Matrix_ReplaceRotation(&globalCtx->billboardMtxF);
-        func_8002EBCC(thisx, globalCtx, 0);
+        if (CVar_GetS32("gNewDrops", 0) != 0) {
+            func_80093D18(globalCtx->state.gfxCtx);
+            func_8002EBCC(thisx, globalCtx, 0);
 
-        gSPMatrix(POLY_OPA_DISP++, MATRIX_NEWMTX(globalCtx->state.gfxCtx),
-                  G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
-        gSPDisplayList(POLY_OPA_DISP++, gBombCapDL);
-        Matrix_RotateZYX(0x4000, 0, 0, MTXMODE_APPLY);
-        gSPMatrix(POLY_OPA_DISP++, MATRIX_NEWMTX(globalCtx->state.gfxCtx),
-                  G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
-        gDPPipeSync(POLY_OPA_DISP++);
-        gDPSetEnvColor(POLY_OPA_DISP++, (s16)this->flashIntensity, 0, 40, 255);
-        gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, (s16)this->flashIntensity, 0, 40, 255);
-        gSPDisplayList(POLY_OPA_DISP++, gBombBodyDL);
-        Collider_UpdateSpheres(0, &this->explosionCollider);
+            gSPMatrix(POLY_OPA_DISP++, MATRIX_NEWMTX(globalCtx->state.gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+            gSPDisplayList(POLY_OPA_DISP++, gBombCapDL);
+            Matrix_RotateZYX(0x4000, 0, 0, MTXMODE_APPLY);
+            Matrix_Scale(7.0f, 7.0f, 7.0f, MTXMODE_APPLY);
+            gSPMatrix(POLY_OPA_DISP++, MATRIX_NEWMTX(globalCtx->state.gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+            gDPPipeSync(POLY_OPA_DISP++);
+            gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, (s16)this->flashIntensity, 32, 200, 255);
+            gSPDisplayList(POLY_OPA_DISP++, gSilverRockDL);
+            Collider_UpdateSpheres(0, &this->explosionCollider);
+        } else {
+            func_80093D18(globalCtx->state.gfxCtx);
+            Matrix_ReplaceRotation(&globalCtx->billboardMtxF);
+            func_8002EBCC(thisx, globalCtx, 0);
+
+            gSPMatrix(POLY_OPA_DISP++, MATRIX_NEWMTX(globalCtx->state.gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+            gSPDisplayList(POLY_OPA_DISP++, gBombCapDL);
+            Matrix_RotateZYX(0x4000, 0, 0, MTXMODE_APPLY);
+            gSPMatrix(POLY_OPA_DISP++, MATRIX_NEWMTX(globalCtx->state.gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+            gDPPipeSync(POLY_OPA_DISP++);
+            gDPSetEnvColor(POLY_OPA_DISP++, (s16)this->flashIntensity, 0, 40, 255);
+            gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, (s16)this->flashIntensity, 0, 40, 255);
+            gSPDisplayList(POLY_OPA_DISP++, gBombBodyDL);
+            Collider_UpdateSpheres(0, &this->explosionCollider);
+        }
     }
 
     CLOSE_DISPS(globalCtx->state.gfxCtx);

--- a/soh/src/overlays/actors/ovl_En_Bom/z_en_bom.c
+++ b/soh/src/overlays/actors/ovl_En_Bom/z_en_bom.c
@@ -7,7 +7,6 @@
 #include "z_en_bom.h"
 #include "overlays/effects/ovl_Effect_Ss_Dead_Sound/z_eff_ss_dead_sound.h"
 #include "objects/gameplay_keep/gameplay_keep.h"
-#include "objects/gameplay_field_keep/gameplay_field_keep.h"
 
 #define FLAGS (ACTOR_FLAG_4 | ACTOR_FLAG_5)
 
@@ -364,34 +363,19 @@ void EnBom_Draw(Actor* thisx, GlobalContext* globalCtx) {
     OPEN_DISPS(globalCtx->state.gfxCtx);
 
     if (thisx->params == BOMB_BODY) {
-        if (CVar_GetS32("gNewDrops", 0) != 0) {
-            func_80093D18(globalCtx->state.gfxCtx);
-            func_8002EBCC(thisx, globalCtx, 0);
+        func_80093D18(globalCtx->state.gfxCtx);
+        Matrix_ReplaceRotation(&globalCtx->billboardMtxF);
+        func_8002EBCC(thisx, globalCtx, 0);
 
-            gSPMatrix(POLY_OPA_DISP++, MATRIX_NEWMTX(globalCtx->state.gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
-            gSPDisplayList(POLY_OPA_DISP++, gBombCapDL);
-            Matrix_RotateZYX(0x4000, 0, 0, MTXMODE_APPLY);
-            Matrix_Scale(7.0f, 7.0f, 7.0f, MTXMODE_APPLY);
-            gSPMatrix(POLY_OPA_DISP++, MATRIX_NEWMTX(globalCtx->state.gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
-            gDPPipeSync(POLY_OPA_DISP++);
-            gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, (s16)this->flashIntensity, 32, 200, 255);
-            gSPDisplayList(POLY_OPA_DISP++, gSilverRockDL);
-            Collider_UpdateSpheres(0, &this->explosionCollider);
-        } else {
-            func_80093D18(globalCtx->state.gfxCtx);
-            Matrix_ReplaceRotation(&globalCtx->billboardMtxF);
-            func_8002EBCC(thisx, globalCtx, 0);
-
-            gSPMatrix(POLY_OPA_DISP++, MATRIX_NEWMTX(globalCtx->state.gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
-            gSPDisplayList(POLY_OPA_DISP++, gBombCapDL);
-            Matrix_RotateZYX(0x4000, 0, 0, MTXMODE_APPLY);
-            gSPMatrix(POLY_OPA_DISP++, MATRIX_NEWMTX(globalCtx->state.gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
-            gDPPipeSync(POLY_OPA_DISP++);
-            gDPSetEnvColor(POLY_OPA_DISP++, (s16)this->flashIntensity, 0, 40, 255);
-            gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, (s16)this->flashIntensity, 0, 40, 255);
-            gSPDisplayList(POLY_OPA_DISP++, gBombBodyDL);
-            Collider_UpdateSpheres(0, &this->explosionCollider);
-        }
+        gSPMatrix(POLY_OPA_DISP++, MATRIX_NEWMTX(globalCtx->state.gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+        gSPDisplayList(POLY_OPA_DISP++, gBombCapDL);
+        Matrix_RotateZYX(0x4000, 0, 0, MTXMODE_APPLY);
+        gSPMatrix(POLY_OPA_DISP++, MATRIX_NEWMTX(globalCtx->state.gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+        gDPPipeSync(POLY_OPA_DISP++);
+        gDPSetEnvColor(POLY_OPA_DISP++, (s16)this->flashIntensity, 0, 40, 255);
+        gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, (s16)this->flashIntensity, 0, 40, 255);
+        gSPDisplayList(POLY_OPA_DISP++, gBombBodyDL);
+        Collider_UpdateSpheres(0, &this->explosionCollider);
     }
 
     CLOSE_DISPS(globalCtx->state.gfxCtx);

--- a/soh/src/overlays/actors/ovl_En_Bom_Chu/z_en_bom_chu.c
+++ b/soh/src/overlays/actors/ovl_En_Bom_Chu/z_en_bom_chu.c
@@ -482,12 +482,16 @@ void EnBomChu_Update(Actor* thisx, GlobalContext* globalCtx2) {
     }
 }
 
+
+const Color_RGB8 BombchuColorOriginal = { 209, 34, -35 };
+
 void EnBomChu_Draw(Actor* thisx, GlobalContext* globalCtx) {
     s32 pad;
     EnBomChu* this = (EnBomChu*)thisx;
     f32 colorIntensity;
     s32 blinkHalfPeriod;
     s32 blinkTime;
+    Color_RGB8 BombchuCol = CVar_GetRGB("gBombTrailCol", BombchuColorOriginal);
 
     OPEN_DISPS(globalCtx->state.gfxCtx);
 
@@ -511,8 +515,11 @@ void EnBomChu_Draw(Actor* thisx, GlobalContext* globalCtx) {
 
     colorIntensity = blinkTime / (f32)blinkHalfPeriod;
 
-    gDPSetEnvColor(POLY_OPA_DISP++, 9.0f + (colorIntensity * 209.0f), 9.0f + (colorIntensity * 34.0f),
-                   35.0f + (colorIntensity * -35.0f), 255);
+    if (CVar_GetS32("gUseTrailsCol", 0) != 0)
+        gDPSetEnvColor(POLY_OPA_DISP++, (colorIntensity * BombchuCol.r), (colorIntensity * BombchuCol.g),
+                       (colorIntensity * BombchuCol.b), 255);
+    else gDPSetEnvColor(POLY_OPA_DISP++, 9.0f + (colorIntensity * 209.0f), 9.0f + (colorIntensity * 34.0f),
+                        35.0f + (colorIntensity * -35.0f), 255);
     Matrix_Translate(this->visualJitter * (1.0f / BOMBCHU_SCALE), 0.0f, 0.0f, MTXMODE_APPLY);
     gSPMatrix(POLY_OPA_DISP++, MATRIX_NEWMTX(globalCtx->state.gfxCtx),
               G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);

--- a/soh/src/overlays/actors/ovl_En_Bom_Chu/z_en_bom_chu.c
+++ b/soh/src/overlays/actors/ovl_En_Bom_Chu/z_en_bom_chu.c
@@ -85,6 +85,7 @@ void EnBomChu_Init(Actor* thisx, GlobalContext* globalCtx) {
     blureInit.elemDuration = 16;
     blureInit.unkFlag = 0;
     blureInit.calcMode = 0;
+    blureInit.trailType = 3;
 
     Effect_Add(globalCtx, &this->blure1Index, EFFECT_BLURE1, 0, 0, &blureInit);
     Effect_Add(globalCtx, &this->blure2Index, EFFECT_BLURE1, 0, 0, &blureInit);

--- a/soh/src/overlays/actors/ovl_En_Boom/z_en_boom.c
+++ b/soh/src/overlays/actors/ovl_En_Boom/z_en_boom.c
@@ -89,6 +89,7 @@ void EnBoom_Init(Actor* thisx, GlobalContext* globalCtx) {
     blure.elemDuration = 8;
     blure.unkFlag = 0;
     blure.calcMode = 0;
+    blure.trailType = 2;
 
     Effect_Add(globalCtx, &this->effectIndex, EFFECT_BLURE1, 0, 0, &blure);
 

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -9422,9 +9422,9 @@ static InitChainEntry sInitChain[] = {
     ICHAIN_F32(targetArrowOffset, 500, ICHAIN_STOP),
 };
 
-static EffectBlureInit2 D_8085470C = {
+static EffectBlureInit2 blureSword = {
     0, 8, 0, { 255, 255, 255, 255 }, { 255, 255, 255, 64 }, { 255, 255, 255, 0 }, { 255, 255, 255, 0 }, 4,
-    0, 2, 0, { 0, 0, 0, 0 },         { 0, 0, 0, 0 },
+    0, 2, 0, { 255, 255, 255, 255 }, { 255, 255, 255, 64 }, 1,
 };
 
 static Vec3s D_80854730 = { -57, 3377, 0 };
@@ -9443,7 +9443,7 @@ void Player_InitCommon(Player* this, GlobalContext* globalCtx, FlexSkeletonHeade
         this->morphTable2, PLAYER_LIMB_MAX);
     this->skelAnime2.baseTransl = D_80854730;
 
-    Effect_Add(globalCtx, &this->swordEffectIndex, EFFECT_BLURE2, 0, 0, &D_8085470C);
+    Effect_Add(globalCtx, &this->swordEffectIndex, EFFECT_BLURE2, 0, 0, &blureSword);
     ActorShape_Init(&this->actor.shape, 0.0f, ActorShadow_DrawFeet, this->ageProperties->unk_04);
     this->unk_46C = SUBCAM_NONE;
     Collider_InitCylinder(globalCtx, &this->cylinder);


### PR DESCRIPTION
After Noting some issues with trails in SoH, this should take care of most bugs/inaccuracies relating to them, as well as adding & fixing customization options.

### FIXES

- Fixes all trails having the properties of Link's sword trails when Custom trails are disabled, now having their proper colors and lengths
- Fixed buggy interpolation on Link's Sword trails

### ENHANCEMENTS

- Better Trail colorization allowing for separate colors for Swords, the Boomerang, and Bombchus
- Bombchus will now glow the color of their trail.
- Added customization for Normal Arrow trails. Elemental arrow trails match the colors of their effects unless specified.
- Added option for each sword to have its own trail color. Includes Deku Sticks and Megaton Hammer.

### TODO

- [ ] Clean and optimize handling of trail types
- [ ] Clean up GUI of the Cosmetic Editor
- [ ] Separate Arrow Trail Colors
