### PR TITLE
Bugfix/version file creation

### DIFF
--- a/OTRExporter/OTRExporter/Main.cpp
+++ b/OTRExporter/OTRExporter/Main.cpp
@@ -63,13 +63,28 @@ static void ExporterProgramEnd()
 {
 	if (Globals::Instance->fileMode == ZFileMode::ExtractDirectory)
 	{
-		printf("Generating OTR Archive...\n");
-		otrArchive = Ship::Archive::CreateArchive(otrFileName, 40000);
+    printf("Creating version file...\n");
 
-		for (auto item : files)
-		{
-			auto fileData = item.second;
-			otrArchive->AddFile(item.first, (uintptr_t)fileData.data(), fileData.size());
+    // Get crc from rom
+    std::string romPath = Globals::Instance->baseRomPath.string();
+    std::vector<uint8_t> romData = File::ReadAllBytes(romPath);
+    uint32_t crc = BitConverter::ToUInt32BE(romData, 0x10);
+
+    // Write crc to version file
+    std::ofstream versionFile("Extract/version", std::ios::out | std::ios::binary);
+    versionFile.write((char*)&crc, sizeof(crc));
+    versionFile.flush();
+    versionFile.close();
+
+    printf("Created version file.\n");
+
+    printf("Generating OTR Archive...\n");
+    otrArchive = Ship::Archive::CreateArchive(otrFileName, 40000);
+
+    for (auto item : files) {
+      auto fileData = item.second;
+      otrArchive->AddFile(item.first, (uintptr_t)fileData.data(),
+                          fileData.size());
 		}
 
 		// Add any additional files that need to be manually copied...

--- a/OTRExporter/OTRExporter/Main.cpp
+++ b/OTRExporter/OTRExporter/Main.cpp
@@ -63,29 +63,29 @@ static void ExporterProgramEnd()
 {
 	if (Globals::Instance->fileMode == ZFileMode::ExtractDirectory)
 	{
-    printf("Creating version file...\n");
+		printf("Creating version file...\n");
 
-    // Get crc from rom
-    std::string romPath = Globals::Instance->baseRomPath.string();
-    std::vector<uint8_t> romData = File::ReadAllBytes(romPath);
-    uint32_t crc = BitConverter::ToUInt32BE(romData, 0x10);
+		// Get crc from rom
+		std::string romPath = Globals::Instance->baseRomPath.string();
+		std::vector<uint8_t> romData = File::ReadAllBytes(romPath);
+		uint32_t crc = BitConverter::ToUInt32BE(romData, 0x10);
 
-    // Write crc to version file
-    fs::path versionPath("Extract/version");
-    std::ofstream versionFile(versionPath.c_str(), std::ios::out | std::ios::binary);
-    versionFile.write((char*)&crc, sizeof(crc));
-    versionFile.flush();
-    versionFile.close();
+		// Write crc to version file
+		fs::path versionPath("Extract/version");
+		std::ofstream versionFile(versionPath.c_str(), std::ios::out | std::ios::binary);
+		versionFile.write((char*)&crc, sizeof(crc));
+		versionFile.flush();
+		versionFile.close();
 
-    printf("Created version file.\n");
+		printf("Created version file.\n");
 
-    printf("Generating OTR Archive...\n");
-    otrArchive = Ship::Archive::CreateArchive(otrFileName, 40000);
+		printf("Generating OTR Archive...\n");
+		otrArchive = Ship::Archive::CreateArchive(otrFileName, 40000);
 
-    for (auto item : files) {
-      auto fileData = item.second;
-      otrArchive->AddFile(item.first, (uintptr_t)fileData.data(),
-                          fileData.size());
+		for (auto item : files) {
+			auto fileData = item.second;
+			otrArchive->AddFile(item.first, (uintptr_t)fileData.data(),
+		                      fileData.size());
 		}
 
 		// Add any additional files that need to be manually copied...

--- a/OTRExporter/OTRExporter/Main.cpp
+++ b/OTRExporter/OTRExporter/Main.cpp
@@ -71,7 +71,8 @@ static void ExporterProgramEnd()
     uint32_t crc = BitConverter::ToUInt32BE(romData, 0x10);
 
     // Write crc to version file
-    std::ofstream versionFile("Extract/version", std::ios::out | std::ios::binary);
+    fs::path versionPath("Extract/version");
+    std::ofstream versionFile(versionPath.c_str(), std::ios::out | std::ios::binary);
     versionFile.write((char*)&crc, sizeof(crc));
     versionFile.flush();
     versionFile.close();

--- a/OTRExporter/extract_assets.py
+++ b/OTRExporter/extract_assets.py
@@ -11,10 +11,6 @@ import argparse
 def BuildOTR(xmlPath, rom, zapd_exe=None):
     shutil.copytree("assets", "Extract/assets")
 
-    checksum = int(Z64Rom(rom).checksum.value, 16)
-    with open("Extract/version", "wb") as f:
-        f.write(struct.pack('<L', checksum))
-
     if not zapd_exe:
         zapd_exe = "x64\\Release\\ZAPD.exe" if sys.platform == "win32" else "../ZAPDTR/ZAPD.out"
 

--- a/OTRGui/src/game/game.cpp
+++ b/OTRGui/src/game/game.cpp
@@ -91,7 +91,6 @@ void ExtractRom()
 		//MoonUtils::copy("tmp/baserom/Audioseq", "Extract/Audioseq");
 		//MoonUtils::copy("tmp/baserom/Audiotable", "Extract/Audiotable");
 		//MoonUtils::copy("tmp/baserom/version", "Extract/version");
-		MoonUtils::write("Extract/version", (char*)&version.crc, sizeof(version.crc));
 
 		MoonUtils::copy("assets/game/", "Extract/assets/");
 

--- a/OTRGui/src/impl/extractor/extractor.cpp
+++ b/OTRGui/src/impl/extractor/extractor.cpp
@@ -81,7 +81,7 @@ void startWorker(RomVersion version) {
 
 	path += GetXMLVersion(version);
 
-	Util::write("tmp/baserom/version", (char*)&version.crc, sizeof(version.crc));
+	// Util::write("tmp/baserom/version", (char*)&version.crc, sizeof(version.crc));
 
 	if (oldExtractMode)
 	{


### PR DESCRIPTION
Fixes #1459 

Adds creation of the `Extract/version` file to `OTRExporter/Main.cpp` and removes it from `OTRExporter/extract_assets.py` and OTRGui. This fixes the lack of version file creation in the `soh.sh` script and the AppImage without adding any additional dependencies by having it done by `ZAPD.out` while also slightly improving maintainability by reducing the amount of places in the code where version files are created.

Note: I only commented out the version file creation in `OTRGui/src/impl/extractor/extractor.cpp` since this seemed to only be related to `oldExtractMode` and there was another piece of commented out code depending on the `tmp/baserom/version` file.