### PR TITLE
Fixes copying save files on the switch

### DIFF
--- a/soh/soh/SaveManager.cpp
+++ b/soh/soh/SaveManager.cpp
@@ -1181,6 +1181,13 @@ void SaveManager::CopyZeldaFile(int from, int to) {
     DeleteZeldaFile(to);
 #ifdef __WIIU__
     assert(copy_file(GetFileName(from).c_str(), GetFileName(to).c_str()) == 0);
+#elif __SWITCH__
+// std::filesystem::copy_file seems to crash the switch, but this works well.
+    std::ifstream source(GetFileName(from));
+    std::ofstream dest(GetFileName(to));
+    nlohmann::json saveBlock;
+    source >> saveBlock;
+    dest << std::setw(4) << saveBlock << std::endl; 
 #else
     std::filesystem::copy_file(GetFileName(from), GetFileName(to));
 #endif

--- a/soh/soh/SaveManager.cpp
+++ b/soh/soh/SaveManager.cpp
@@ -1149,7 +1149,7 @@ void SaveManager::LoadStruct(const std::string& name, LoadStructFunc func) {
     }
 }
 
-#ifdef __WIIU__
+#if defined(__WIIU__) || defined(__SWITCH__)
 // std::filesystem::copy_file doesn't work properly with the Wii U's toolchain atm
 int copy_file(const char* src, const char* dst)
 {
@@ -1179,15 +1179,8 @@ int copy_file(const char* src, const char* dst)
 void SaveManager::CopyZeldaFile(int from, int to) {
     assert(std::filesystem::exists(GetFileName(from)));
     DeleteZeldaFile(to);
-#ifdef __WIIU__
-    assert(copy_file(GetFileName(from).c_str(), GetFileName(to).c_str()) == 0);
-#elif __SWITCH__
-// std::filesystem::copy_file seems to crash the switch, but this works well.
-    std::ifstream source(GetFileName(from));
-    std::ofstream dest(GetFileName(to));
-    nlohmann::json saveBlock;
-    source >> saveBlock;
-    dest << std::setw(4) << saveBlock << std::endl; 
+#if defined(__WIIU__) || defined(__SWITCH__)
+    copy_file(GetFileName(from).c_str(), GetFileName(to).c_str());
 #else
     std::filesystem::copy_file(GetFileName(from), GetFileName(to));
 #endif


### PR DESCRIPTION
Copying save files on the switch would result in a crash. I saw the fix for a similar issue for Wii U, but the same fix didn't seem to do anything on Switch. So I coded a new solution using an ifstream and ofstream to copy the data instead of std::filesystem::copy_file. From my testing, this successfully copies the file and the copied file will boot up and play correctly.