### PR TITLE
Add hack to load bss texture in ovl_En_Jsjutan (fixes #69)

### DIFF
--- a/OTRExporter/OTRExporter/DisplayListExporter.cpp
+++ b/OTRExporter/OTRExporter/DisplayListExporter.cpp
@@ -653,8 +653,13 @@ void OTRExporter_DisplayList::Save(ZResource* res, const fs::path& outPath, Bina
 			uint32_t seg = data & 0xFFFFFFFF;
 			int32_t texAddress = Seg2Filespace(data, dList->parent->baseAddress);
 
-			if (!Globals::Instance->HasSegment(GETSEGNUM(seg), res->parent->workerID))
+			if (!Globals::Instance->HasSegment(GETSEGNUM(seg), res->parent->workerID) || (res->GetName() == "sShadowMaterialDL"))
 			{
+				if (res->GetName() == "sShadowMaterialDL") {
+					// sShadowMaterialDL (In ovl_En_Jsjutan) has a texture in bss. This is a hack to override the reference to one
+					// to segment C. The actor has been modified to load the texture into segment C.
+					seg = 0x0C000000;
+				}
 				int32_t __ = (data & 0x00FF000000000000) >> 48;
 				int32_t www = (data & 0x00000FFF00000000) >> 32;
 

--- a/libultraship/libultraship/Lib/Fast3D/gfx_pc.cpp
+++ b/libultraship/libultraship/Lib/Fast3D/gfx_pc.cpp
@@ -2110,11 +2110,6 @@ unsigned int dListBP;
 int matrixBP;
 uintptr_t clearMtx;
 
-extern "C"
-{
-    uintptr_t jsjutanShadowTex = 0;
-};
-
 static void gfx_run_dl(Gfx* cmd) {
     //puts("dl");
     int dummy = 0;

--- a/soh/src/overlays/actors/ovl_En_Jsjutan/z_en_jsjutan.c
+++ b/soh/src/overlays/actors/ovl_En_Jsjutan/z_en_jsjutan.c
@@ -402,7 +402,7 @@ void EnJsjutan_Draw(Actor* thisx, GlobalContext* globalCtx2) {
         this->unk_164 = false;
         u8* carpTex = ResourceMgr_LoadTexByName(sCarpetTex);
         u8* shadTex = sShadowTex;
-        for (i = 0; i < ARRAY_COUNT(shadTex); i++) {
+        for (i = 0; i < ARRAY_COUNT(sShadowTex); i++) {
             if (((u16*)carpTex)[i] != 0) { // Hack to bypass ZAPD exporting textures as u64.
                 shadTex[i] = 0xFF;
             } else {
@@ -421,6 +421,7 @@ void EnJsjutan_Draw(Actor* thisx, GlobalContext* globalCtx2) {
               G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
 
     // Draws the carpet's shadow texture.
+    gSPSegment(POLY_OPA_DISP++, 0x0C, sShadowTex);
     gSPDisplayList(POLY_OPA_DISP++, sShadowMaterialDL);
     gDPPipeSync(POLY_OPA_DISP++);
 

--- a/soh/src/overlays/actors/ovl_En_Jsjutan/z_en_jsjutan.c
+++ b/soh/src/overlays/actors/ovl_En_Jsjutan/z_en_jsjutan.c
@@ -367,8 +367,6 @@ void EnJsjutan_Update(Actor* thisx, GlobalContext* globalCtx2) {
     thisx->shape.rot.z = Math_CosS(globalCtx->gameplayFrames * 3500) * 300.0f;
 }
 
-extern uintptr_t jsjutanShadowTex;
-
 void EnJsjutan_Draw(Actor* thisx, GlobalContext* globalCtx2) {
     EnJsjutan* this = (EnJsjutan*)thisx;
     GlobalContext* globalCtx = globalCtx2;
@@ -396,7 +394,6 @@ void EnJsjutan_Draw(Actor* thisx, GlobalContext* globalCtx2) {
     }
 
     func_80A89A6C(this, globalCtx);
-    jsjutanShadowTex = sShadowTex;
 
     if (this->unk_164) {
         this->unk_164 = false;


### PR DESCRIPTION
#69 
The carpet shadow texture is (I think) the only texture that sources from an overlay's bss. This means it does does occupy any space in the ROM and therefore does not have a name in the OTR. This causes an issue when extracting it, since a proper reference can not be placed in the DL.

This PR adds a hack that replaces the reference in the DL to a texture in segment `0C`, and modifies the actor to load the texture into segment `0C`. This is a scratch segment that actors can use (indeed, see that later on this actor uses it to load vertices into), so this is safe.

There is a potential issue further down the road. Because this is a dynamically generated texture based on the carpet texture, if the carpet texture were to change (say, from a texture mod), the shadow would not be calculated correctly. Therefore, I think the long term solution would be to render the shadow with a shader based on the carpet texture. This is out-of-scope of this PR, however.

This will require a regen of the OTR. Do we have a process for this yet? Is there anything this PR should do accordingly?