### PR TITLE
Fix: Unbreak Wii U sliders

### DIFF
--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -547,7 +547,7 @@ namespace GameMenuBar {
                     ImGui::SetCursorPosX(ImGui::GetCursorPosX() - 7.0f);
                 #ifdef __SWITCH__
                     ImGui::PushItemWidth(ImGui::GetWindowSize().x - 110.0f);
-                #elseif __WIIU__
+                #elif __WIIU__
                     ImGui::PushItemWidth(ImGui::GetWindowSize().x - 79.0f * 2);
                 #else
                     ImGui::PushItemWidth(ImGui::GetWindowSize().x - 79.0f);
@@ -1077,7 +1077,7 @@ namespace GameMenuBar {
                 ImGui::SetCursorPosX(ImGui::GetCursorPosX() - 7.0f);
             #ifdef __SWITCH__
                 ImGui::PushItemWidth(ImGui::GetWindowSize().x - 110.0f);
-            #elseif __WIIU__
+            #elif __WIIU__
                 ImGui::PushItemWidth(ImGui::GetWindowSize().x - 79.0f * 2);
             #else
                 ImGui::PushItemWidth(ImGui::GetWindowSize().x - 79.0f);

--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -545,8 +545,10 @@ namespace GameMenuBar {
                     }
                     ImGui::SameLine();
                     ImGui::SetCursorPosX(ImGui::GetCursorPosX() - 7.0f);
-                #if defined(__SWITCH__) || defined(__WIIU__)
+                #ifdef __SWITCH__
                     ImGui::PushItemWidth(ImGui::GetWindowSize().x - 110.0f);
+                #elseif __WIIU__
+                    ImGui::PushItemWidth(ImGui::GetWindowSize().x - 79.0f * 2);
                 #else
                     ImGui::PushItemWidth(ImGui::GetWindowSize().x - 79.0f);
                 #endif
@@ -1073,8 +1075,10 @@ namespace GameMenuBar {
                 }
                 ImGui::SameLine();
                 ImGui::SetCursorPosX(ImGui::GetCursorPosX() - 7.0f);
-            #if defined(__SWITCH__) || defined(__WIIU__)
+            #ifdef __SWITCH__
                 ImGui::PushItemWidth(ImGui::GetWindowSize().x - 110.0f);
+            #elseif __WIIU__
+                ImGui::PushItemWidth(ImGui::GetWindowSize().x - 79.0f * 2);
             #else
                 ImGui::PushItemWidth(ImGui::GetWindowSize().x - 79.0f);
             #endif

--- a/soh/soh/UIWidgets.cpp
+++ b/soh/soh/UIWidgets.cpp
@@ -324,7 +324,7 @@ namespace UIWidgets {
         if (PlusMinusButton) {
         #ifdef __SWITCH__
             ImGui::PushItemWidth(ImGui::GetWindowSize().x - 110.0f);
-        #elseif __WIIU__
+        #elif __WIIU__
             ImGui::PushItemWidth(ImGui::GetWindowSize().x - 79.0f * 2);
         #else
             ImGui::PushItemWidth(ImGui::GetWindowSize().x - 79.0f);

--- a/soh/soh/UIWidgets.cpp
+++ b/soh/soh/UIWidgets.cpp
@@ -322,8 +322,10 @@ namespace UIWidgets {
             ImGui::SetCursorPosX(ImGui::GetCursorPosX() - 7.0f);
         }
         if (PlusMinusButton) {
-        #if defined(__SWITCH__) || defined(__WIIU__)
+        #ifdef __SWITCH__
             ImGui::PushItemWidth(ImGui::GetWindowSize().x - 110.0f);
+        #elseif __WIIU__
+            ImGui::PushItemWidth(ImGui::GetWindowSize().x - 79.0f * 2);
         #else
             ImGui::PushItemWidth(ImGui::GetWindowSize().x - 79.0f);
         #endif


### PR DESCRIPTION
Last time I changed the sliders to fix them on the Switch builds, I assumed it would work the same on Wii U. Turns out Switch isn't doubling font size, only the rest of the menu, while Wii U is doubling everything.

Reverted the sliders to be the same as before on Wii U.

For completeness sake, this is the previous PR that changed the sliders: https://github.com/HarbourMasters/Shipwright/pull/1371