### PR TITLE
[#1434] Renders non-warp songs more consistently with warp songs

### DIFF
--- a/soh/src/code/z_draw.c
+++ b/soh/src/code/z_draw.c
@@ -827,12 +827,12 @@ void GetItem_DrawGenericMusicNote(GlobalContext* globalCtx, s16 drawId) {
 
     OPEN_DISPS(globalCtx->state.gfxCtx);
 
-    gSPMatrix(POLY_OPA_DISP++, Matrix_NewMtx(globalCtx->state.gfxCtx,  __FILE__, __LINE__), G_MTX_MODELVIEW | G_MTX_LOAD);
-    gsDPSetGrayscaleColor(POLY_OPA_DISP++, colors[color_slot][0], colors[color_slot][1], colors[color_slot][2], 255);
-    gsSPGrayscale(POLY_OPA_DISP++, true);
+    gSPMatrix(POLY_XLU_DISP++, Matrix_NewMtx(globalCtx->state.gfxCtx,  __FILE__, __LINE__), G_MTX_MODELVIEW | G_MTX_LOAD);
+    gsDPSetGrayscaleColor(POLY_XLU_DISP++, colors[color_slot][0], colors[color_slot][1], colors[color_slot][2], 255);
+    gsSPGrayscale(POLY_XLU_DISP++, true);
     func_80093D18(globalCtx->state.gfxCtx);
-    gSPDisplayList(POLY_OPA_DISP++, sDrawItemTable[drawId].dlists[0]);
-    gsSPGrayscale(POLY_OPA_DISP++, false);
+    gSPDisplayList(POLY_XLU_DISP++, sDrawItemTable[drawId].dlists[0]);
+    gsSPGrayscale(POLY_XLU_DISP++, false);
 
     CLOSE_DISPS(globalCtx->state.gfxCtx);
 }


### PR DESCRIPTION
This change makes non-warp songs behave more like warp songs and other freestanding items like PoH. This is not perfect because warp songs and PoH have their own graphical issues even in vanilla[1]. So while not perfect it's better in basically every way to have the non-warp songs behave like warp songs, rather than them behave different and have different sets of issues.

Resolves #1434 

[1]
<img width="269" alt="Screen_Shot_2022-09-07_at_11 49 05_AM" src="https://user-images.githubusercontent.com/7316699/190656979-ae77ff01-d371-4a5e-b2a6-65133c323bad.png">

## Before Change:
<img width="297" alt="Screen_Shot_2022-09-07_at_11 28 26_AM" src="https://user-images.githubusercontent.com/7316699/190657407-fe785116-77e9-4ae5-83a1-8984fb733b34.png">
<img width="529" alt="Screen Shot 2022-09-16 at 9 06 22 AM" src="https://user-images.githubusercontent.com/7316699/190658243-744b94ed-90b0-441e-b1e2-c1da39647d8f.png">
<img width="206" alt="Screen_Shot_2022-09-07_at_11 27 06_AM" src="https://user-images.githubusercontent.com/7316699/190658272-7560f500-4cf8-4007-81b6-db72ac137e53.png">

## After Change:
<img width="416" alt="Screen_Shot_2022-09-07_at_11 22 50_AM" src="https://user-images.githubusercontent.com/7316699/190658374-0f7d37f7-58a7-4941-bde1-b00ab1b4e8e6.png">
<img width="857" alt="Screen Shot 2022-09-16 at 9 06 02 AM" src="https://user-images.githubusercontent.com/7316699/190658415-d733d0b5-f3a8-4d5c-958a-923c7d75bb2a.png">
<img width="192" alt="Screen_Shot_2022-09-07_at_11 21 16_AM" src="https://user-images.githubusercontent.com/7316699/190658533-143ed6a6-c5fc-440f-957d-21fa8ec82a48.png">
