### PR TITLE
Fix unused dynamic link shadow for possible future enhancement

### DIFF
--- a/soh/src/overlays/actors/ovl_En_Sda/z_en_sda.c
+++ b/soh/src/overlays/actors/ovl_En_Sda/z_en_sda.c
@@ -100,8 +100,6 @@ void EnSda_Update(Actor* thisx, GlobalContext* globalCtx) {
     EnSda* this = (EnSda*)thisx;
     Player* player;
 
-    osSyncPrintf("SDA MOVE\n");
-
     if (this->actor.params == 1) {
         player = (Player*)this->actor.parent;
     } else {
@@ -109,16 +107,12 @@ void EnSda_Update(Actor* thisx, GlobalContext* globalCtx) {
     }
 
     this->actor.world.pos = player->actor.world.pos;
-
-    osSyncPrintf("SDA MOVE END\n");
 }
 
 void EnSda_Draw(Actor* thisx, GlobalContext* globalCtx) {
     EnSda* this = (EnSda*)thisx;
     Player* player;
     u8* shadowTexture = Graph_Alloc(globalCtx->state.gfxCtx, 0x1000);
-
-    osSyncPrintf("SDA DRAW \n");
 
     if (this->actor.params == 1) {
         player = (Player*)this->actor.parent;
@@ -132,8 +126,6 @@ void EnSda_Draw(Actor* thisx, GlobalContext* globalCtx) {
     if (KREG(0) < 5) {
         func_80AF9C70(shadowTexture, player, globalCtx);
     }
-
-    osSyncPrintf("SDA DRAW END\n");
 }
 
 void func_80AF8F60(Player* player, u8* shadowTexture, f32 arg2) {
@@ -252,7 +244,6 @@ void func_80AF95C4(EnSda* this, u8* shadowTexture, Player* player, GlobalContext
     Vec3f sp16C;
     Vec3f sp64[22];
 
-    osSyncPrintf("SDA CONT \n");
     if (BREG(57) != 0) {
         for (shadowTextureTemp = shadowTexture, i = 0; i < 0x1000; i++, shadowTextureTemp++) {
             if ((i >= 0 && i < 0x40) || (i >= 0xFC0 && i < 0x1000) || ((i & 0x3F) == 0) || ((i & 0x3F) == 0x3F)) {
@@ -272,7 +263,6 @@ void func_80AF95C4(EnSda* this, u8* shadowTexture, Player* player, GlobalContext
             D_80AFA660[D_80AFA16C[i]] = player->bodyPartsPos[i];
         }
     }
-    osSyncPrintf("SDA CONT 2\n");
     D_80AFA660[0].y += 3.0f;
     D_80AFA660[15].x = D_80AFA660[0].x + ((D_80AFA660[15].x - D_80AFA660[0].x) * 1.2f);
     D_80AFA660[15].y = D_80AFA660[0].y + ((D_80AFA660[15].y - D_80AFA660[0].y) * -1.2f);
@@ -280,7 +270,6 @@ void func_80AF95C4(EnSda* this, u8* shadowTexture, Player* player, GlobalContext
     for (i = 0; i < 6; i++) {
         func_80AF8F60(player, shadowTexture, i / 5.0f);
     }
-    osSyncPrintf("SDA CONT 3\n");
     if (this->actor.params != 1) {
         Matrix_MtxFToYXZRotS(&player->shieldMf, &sp178, false);
         sp178.y += (KREG(87) << 0xF) + 0x8000;
@@ -329,7 +318,6 @@ void func_80AF95C4(EnSda* this, u8* shadowTexture, Player* player, GlobalContext
             }
         }
     }
-    osSyncPrintf("SDA CONT 4\n");
 }
 
 void func_80AF9C70(u8* shadowTexture, Player* player, GlobalContext* globalCtx) {
@@ -341,7 +329,6 @@ void func_80AF9C70(u8* shadowTexture, Player* player, GlobalContext* globalCtx) 
 
     OPEN_DISPS(gfxCtx);
 
-    osSyncPrintf("SDA D 1\n");
     func_80094044(globalCtx->state.gfxCtx);
     gDPSetPrimColor(POLY_XLU_DISP++, 0x00, 0x00, 0, 0, 0, (BREG(52) + 50));
     gDPSetEnvColor(POLY_XLU_DISP++, 0, 0, 0, 0);
@@ -358,6 +345,7 @@ void func_80AF9C70(u8* shadowTexture, Player* player, GlobalContext* globalCtx) 
     gSPDisplayList(POLY_XLU_DISP++, D_80AFA3D8);
     gDPLoadTextureBlock(POLY_XLU_DISP++, shadowTexture, G_IM_FMT_I, G_IM_SIZ_8b, 0x40, 0x40, 0,
                         G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR | G_TX_CLAMP, 6, 6, G_TX_NOLOD, G_TX_NOLOD);
+    gSPInvalidateTexCache(POLY_XLU_DISP++, (uintptr_t)shadowTexture); // Don't remember this texture, it will only be used this frame.
     gSPDisplayList(POLY_XLU_DISP++, D_80AFA3F8);
 
     for (phi_s1 = 0; phi_s1 < KREG(78); phi_s1++) {
@@ -366,6 +354,5 @@ void func_80AF9C70(u8* shadowTexture, Player* player, GlobalContext* globalCtx) 
                   G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
         gSPDisplayList(POLY_XLU_DISP++, D_80AFA3F8);
     }
-    osSyncPrintf("SDA D 2\n");
     CLOSE_DISPS(gfxCtx);
 }

--- a/soh/src/overlays/actors/ovl_En_Sda/z_en_sda.c
+++ b/soh/src/overlays/actors/ovl_En_Sda/z_en_sda.c
@@ -100,6 +100,8 @@ void EnSda_Update(Actor* thisx, GlobalContext* globalCtx) {
     EnSda* this = (EnSda*)thisx;
     Player* player;
 
+    osSyncPrintf("SDA MOVE\n");
+
     if (this->actor.params == 1) {
         player = (Player*)this->actor.parent;
     } else {
@@ -107,12 +109,16 @@ void EnSda_Update(Actor* thisx, GlobalContext* globalCtx) {
     }
 
     this->actor.world.pos = player->actor.world.pos;
+
+    osSyncPrintf("SDA MOVE END\n");
 }
 
 void EnSda_Draw(Actor* thisx, GlobalContext* globalCtx) {
     EnSda* this = (EnSda*)thisx;
     Player* player;
     u8* shadowTexture = Graph_Alloc(globalCtx->state.gfxCtx, 0x1000);
+
+    osSyncPrintf("SDA DRAW \n");
 
     if (this->actor.params == 1) {
         player = (Player*)this->actor.parent;
@@ -126,6 +132,8 @@ void EnSda_Draw(Actor* thisx, GlobalContext* globalCtx) {
     if (KREG(0) < 5) {
         func_80AF9C70(shadowTexture, player, globalCtx);
     }
+
+    osSyncPrintf("SDA DRAW END\n");
 }
 
 void func_80AF8F60(Player* player, u8* shadowTexture, f32 arg2) {
@@ -244,6 +252,7 @@ void func_80AF95C4(EnSda* this, u8* shadowTexture, Player* player, GlobalContext
     Vec3f sp16C;
     Vec3f sp64[22];
 
+    osSyncPrintf("SDA CONT \n");
     if (BREG(57) != 0) {
         for (shadowTextureTemp = shadowTexture, i = 0; i < 0x1000; i++, shadowTextureTemp++) {
             if ((i >= 0 && i < 0x40) || (i >= 0xFC0 && i < 0x1000) || ((i & 0x3F) == 0) || ((i & 0x3F) == 0x3F)) {
@@ -263,6 +272,7 @@ void func_80AF95C4(EnSda* this, u8* shadowTexture, Player* player, GlobalContext
             D_80AFA660[D_80AFA16C[i]] = player->bodyPartsPos[i];
         }
     }
+    osSyncPrintf("SDA CONT 2\n");
     D_80AFA660[0].y += 3.0f;
     D_80AFA660[15].x = D_80AFA660[0].x + ((D_80AFA660[15].x - D_80AFA660[0].x) * 1.2f);
     D_80AFA660[15].y = D_80AFA660[0].y + ((D_80AFA660[15].y - D_80AFA660[0].y) * -1.2f);
@@ -270,6 +280,7 @@ void func_80AF95C4(EnSda* this, u8* shadowTexture, Player* player, GlobalContext
     for (i = 0; i < 6; i++) {
         func_80AF8F60(player, shadowTexture, i / 5.0f);
     }
+    osSyncPrintf("SDA CONT 3\n");
     if (this->actor.params != 1) {
         Matrix_MtxFToYXZRotS(&player->shieldMf, &sp178, false);
         sp178.y += (KREG(87) << 0xF) + 0x8000;
@@ -318,6 +329,7 @@ void func_80AF95C4(EnSda* this, u8* shadowTexture, Player* player, GlobalContext
             }
         }
     }
+    osSyncPrintf("SDA CONT 4\n");
 }
 
 void func_80AF9C70(u8* shadowTexture, Player* player, GlobalContext* globalCtx) {
@@ -329,6 +341,7 @@ void func_80AF9C70(u8* shadowTexture, Player* player, GlobalContext* globalCtx) 
 
     OPEN_DISPS(gfxCtx);
 
+    osSyncPrintf("SDA D 1\n");
     func_80094044(globalCtx->state.gfxCtx);
     gDPSetPrimColor(POLY_XLU_DISP++, 0x00, 0x00, 0, 0, 0, (BREG(52) + 50));
     gDPSetEnvColor(POLY_XLU_DISP++, 0, 0, 0, 0);
@@ -354,5 +367,6 @@ void func_80AF9C70(u8* shadowTexture, Player* player, GlobalContext* globalCtx) 
                   G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
         gSPDisplayList(POLY_XLU_DISP++, D_80AFA3F8);
     }
+    osSyncPrintf("SDA D 2\n");
     CLOSE_DISPS(gfxCtx);
 }


### PR DESCRIPTION
Since the texture for the shadow is dynamically allocated from Graph's THA, the address it uses can be the same (not uncommon if the same things are being rendered). Therefore, when it tries to draw, it sometimes used the shadow from an old frame.

There is no use caching these textures, so this PR fixes it by always invalidating them.


https://user-images.githubusercontent.com/6820874/190827658-b80a0ec4-c2c1-46f8-8ee9-b2b247457cbd.mp4

