### PR TITLE
Fixes save lag on Switch

### DIFF
--- a/soh/soh/SaveManager.cpp
+++ b/soh/soh/SaveManager.cpp
@@ -484,7 +484,7 @@ void SaveManager::SaveFile(int fileNum) {
     FILE* w = fopen(GetFileName(fileNum).c_str(), "w");
     fwrite(json_string, sizeof(char), strlen(json_string), w);
     fclose(w);
-#elif
+#else
 
     std::ofstream output(GetFileName(fileNum));
 

--- a/soh/soh/SaveManager.cpp
+++ b/soh/soh/SaveManager.cpp
@@ -479,14 +479,21 @@ void SaveManager::SaveFile(int fileNum) {
         section.second.second();
     }
 
+#ifdef __SWITCH__
+    const char* json_string = baseBlock.dump(4).c_str();
+    FILE* w = fopen(GetFileName(fileNum).c_str(), "w");
+    fwrite(json_string, sizeof(char), strlen(json_string), w);
+    fclose(w);
+#elif
+
     std::ofstream output(GetFileName(fileNum));
 
 #ifdef __WIIU__
     alignas(0x40) char buffer[8192];
     output.rdbuf()->pubsetbuf(buffer, sizeof(buffer));
 #endif
-
     output << std::setw(4) << baseBlock << std::endl;
+#endif
 
     InitMeta(fileNum);
 }


### PR DESCRIPTION
Turns out file i/o via the C++ Standard Library is just really bad on Switch. This PR uses `#ifdef __SWITCH__` to use a C-based `fopen` and `fwrite` implementation instead of using a `std::ofstream`. The lag is almost imperceptible and I have not been able to cause any save file corruption or anything in my testing. 

@GaryOderNichts it might be worth adapting this to include Wii U as well, not sure how saving currently is on there and I am not able to test any changes. Let me know if you want me to include it!

Please other people test this as well and try to break it!