### PR TITLE
Rando: Ice trap cleanup fix

### DIFF
--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -12471,7 +12471,6 @@ s32 func_8084DFF4(GlobalContext* globalCtx, Player* this) {
         this->unk_84F = 1;
 
         Message_StartTextbox(globalCtx, giEntry.textId, &this->actor);
-        //RANDOTODO: Macro this boolean check.
         if (giEntry.modIndex == MOD_NONE) {
             // RANDOTOD: Move this into Item_Give() or some other more central location
             if (giEntry.getItemId == GI_SWORD_BGS) {
@@ -12482,7 +12481,11 @@ s32 func_8084DFF4(GlobalContext* globalCtx, Player* this) {
         } else if (giEntry.itemId != RG_ICE_TRAP) {
             Randomizer_Item_Give(globalCtx, giEntry);
         }
-        Player_SetPendingFlag(this, globalCtx);
+
+        // RANDOTODO: Macro this boolean check.
+        if (giEntry.modIndex != MOD_RANDOMIZER && giEntry.itemId != RG_ICE_TRAP) {
+            Player_SetPendingFlag(this, globalCtx);
+        }
 
         // Use this if we do have a getItemEntry
         if (giEntry.modIndex == MOD_NONE) {

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -12478,7 +12478,7 @@ s32 func_8084DFF4(GlobalContext* globalCtx, Player* this) {
                 gSaveContext.swordHealth = 8;
             }
             Item_Give(globalCtx, giEntry.itemId);
-        } else if (giEntry.itemId != RG_ICE_TRAP) {
+        } else {
             Randomizer_Item_Give(globalCtx, giEntry);
         }
 

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -12472,19 +12472,17 @@ s32 func_8084DFF4(GlobalContext* globalCtx, Player* this) {
 
         Message_StartTextbox(globalCtx, giEntry.textId, &this->actor);
         //RANDOTODO: Macro this boolean check.
-        if (giEntry.modIndex != MOD_RANDOMIZER && giEntry.itemId != RG_ICE_TRAP) {
-            if (giEntry.modIndex == MOD_NONE) {
+        if (giEntry.modIndex == MOD_NONE) {
             // RANDOTOD: Move this into Item_Give() or some other more central location
             if (giEntry.getItemId == GI_SWORD_BGS) {
                 gSaveContext.bgsFlag = true;
                 gSaveContext.swordHealth = 8;
             }
-                Item_Give(globalCtx, giEntry.itemId);
-            } else {
-                Randomizer_Item_Give(globalCtx, giEntry);
-            }
-            Player_SetPendingFlag(this, globalCtx);
+            Item_Give(globalCtx, giEntry.itemId);
+        } else if (giEntry.itemId != RG_ICE_TRAP) {
+            Randomizer_Item_Give(globalCtx, giEntry);
         }
+        Player_SetPendingFlag(this, globalCtx);
 
         // Use this if we do have a getItemEntry
         if (giEntry.modIndex == MOD_NONE) {

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -12471,19 +12471,17 @@ s32 func_8084DFF4(GlobalContext* globalCtx, Player* this) {
         this->unk_84F = 1;
 
         Message_StartTextbox(globalCtx, giEntry.textId, &this->actor);
-        if (giEntry.modIndex == MOD_NONE) {
-            // RANDOTOD: Move this into Item_Give() or some other more central location
-            if (giEntry.getItemId == GI_SWORD_BGS) {
-                gSaveContext.bgsFlag = true;
-                gSaveContext.swordHealth = 8;
+        if (!(giEntry.modIndex == MOD_RANDOMIZER && giEntry.itemId == RG_ICE_TRAP)) {
+            if (giEntry.modIndex == MOD_NONE) {
+                // RANDOTOD: Move this into Item_Give() or some other more central location
+                if (giEntry.getItemId == GI_SWORD_BGS) {
+                    gSaveContext.bgsFlag = true;
+                    gSaveContext.swordHealth = 8;
+                }
+                Item_Give(globalCtx, giEntry.itemId);
+            } else {
+                Randomizer_Item_Give(globalCtx, giEntry);
             }
-            Item_Give(globalCtx, giEntry.itemId);
-        } else {
-            Randomizer_Item_Give(globalCtx, giEntry);
-        }
-
-        // RANDOTODO: Macro this boolean check.
-        if (giEntry.modIndex != MOD_RANDOMIZER && giEntry.itemId != RG_ICE_TRAP) {
             Player_SetPendingFlag(this, globalCtx);
         }
 

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -12471,6 +12471,7 @@ s32 func_8084DFF4(GlobalContext* globalCtx, Player* this) {
         this->unk_84F = 1;
 
         Message_StartTextbox(globalCtx, giEntry.textId, &this->actor);
+        // RANDOTODO: Macro this boolean check.
         if (!(giEntry.modIndex == MOD_RANDOMIZER && giEntry.itemId == RG_ICE_TRAP)) {
             if (giEntry.modIndex == MOD_NONE) {
                 // RANDOTOD: Move this into Item_Give() or some other more central location


### PR DESCRIPTION
The ice trap fix PR from earlier https://github.com/HarbourMasters/Shipwright/pull/1505 made it so randomized items didn't get granted when gotten from chests and other places. This was because the conditional to check for ice traps didn't allow items from the randomizer item table to reach the code to grant the item.

CC: @leggettc18 