### PR TITLE
Rando & Vanilla: Skip Scarecrow Song fix

### DIFF
--- a/soh/src/overlays/actors/ovl_En_Kakasi2/z_en_kakasi2.c
+++ b/soh/src/overlays/actors/ovl_En_Kakasi2/z_en_kakasi2.c
@@ -117,10 +117,10 @@ void func_80A90264(EnKakasi2* this, GlobalContext* globalCtx) {
     Player* player = GET_PLAYER(globalCtx);
 
     this->unk_194++;
-
-    bool skipScarecrow = globalCtx->msgCtx.ocarinaAction == OCARINA_ACTION_FREE_PLAY &&
-                         ((CVar_GetS32("gSkipScarecrow", 0) && gSaveContext.scarecrowSpawnSongSet) ||
-                          (gSaveContext.n64ddFlag && Randomizer_GetSettingValue(RSK_SKIP_SCARECROWS_SONG)));
+    
+    bool skipScarecrow = globalCtx->msgCtx.msgMode == MSGMODE_OCARINA_PLAYING &&
+                            ((CVar_GetS32("gSkipScarecrow", 0) && gSaveContext.scarecrowSpawnSongSet) ||
+                            (gSaveContext.n64ddFlag && Randomizer_GetSettingValue(RSK_SKIP_SCARECROWS_SONG)));
 
     if ((BREG(1) != 0) || skipScarecrow && (this->actor.xzDistToPlayer < this->maxSpawnDistance.x) &&
         (fabsf(player->actor.world.pos.y - this->actor.world.pos.y) < this->maxSpawnDistance.y)) {


### PR DESCRIPTION
Resolves: https://github.com/HarbourMasters/Shipwright/issues/1453

This enhancement is in vanilla as well, but because it's already incorporated (and thus different) in rando as well, I figured I should just point the fix towards rando-next instead.

It was checking for something before that didn't actually change when you left ocarina freeplay. I now changed to something that's actually only true when you have the ocarina out. Tested this in Lake Hylia by summoning Pierre on the lab, then moved towards the fishing hole. Pierre did not automatically appear until I pulled out my ocarina again.

This still doesn't put away the ocarina automatically when summoning Pierre with this, but I made an issue for that so we can look into it in the future. I couldn't find a fix after looking for it for a decent while, so I'd rather move on and focus on more pressing bugs right now. Issue here: https://github.com/HarbourMasters/Shipwright/issues/1517