### PR TITLE
Rando: Temporary Fishing Fixes

### DIFF
--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -397,14 +397,12 @@ namespace GameMenuBar {
         // Allow the cursor to be on any slot
         CVar_SetS32("gPauseAnyCursor", 1);
 
-        // Instant Fishing
-        CVar_SetS32("gInstantFishing", 1);
         // Guarantee Bite
         CVar_SetS32("gGuaranteeFishingBite", 1);
         // Child Minimum Weight (6 to 10)
-        CVar_SetS32("gChildMinimumWeightFish", 6);
+        CVar_SetS32("gChildMinimumWeightFish", 3);
         // Adult Minimum Weight (8 to 13)
-        CVar_SetS32("gAdultMinimumWeightFish", 8);
+        CVar_SetS32("gAdultMinimumWeightFish", 6);
 
         // Visual Stone of Agony
         CVar_SetS32("gVisualAgony", 1);
@@ -850,9 +848,9 @@ namespace GameMenuBar {
                         UIWidgets::Tooltip("All fish will be caught instantly");
                         UIWidgets::PaddedEnhancementCheckbox("Guarantee Bite", "gGuaranteeFishingBite", true, false);
                         UIWidgets::Tooltip("When a line is stable, guarantee bite. Otherwise use default logic");
-                        UIWidgets::PaddedEnhancementSliderInt("Child Minimum Weight: %d", "##cMinimumWeight", "gChildMinimumWeightFish", 6, 10, "", 10, false, true, false);
+                        UIWidgets::PaddedEnhancementSliderInt("Child Minimum Weight: %d", "##cMinimumWeight", "gChildMinimumWeightFish", 3, 10, "", 10, false, true, false);
                         UIWidgets::Tooltip("The minimum weight for the unique fishing reward as a child");
-                        UIWidgets::PaddedEnhancementSliderInt("Adult Minimum Weight: %d", "##aMinimumWeight", "gAdultMinimumWeightFish", 8, 13, "", 13, false, true, false);
+                        UIWidgets::PaddedEnhancementSliderInt("Adult Minimum Weight: %d", "##aMinimumWeight", "gAdultMinimumWeightFish", 6, 13, "", 13, false, true, false);
                         UIWidgets::Tooltip("The minimum weight for the unique fishing reward as an adult");
                         ImGui::EndMenu();
                     }

--- a/soh/src/overlays/actors/ovl_Fishing/z_fishing.c
+++ b/soh/src/overlays/actors/ovl_Fishing/z_fishing.c
@@ -2901,18 +2901,8 @@ f32 Fishing_GetMinimumRequiredScore() {
     // values above rando fish weight values when rando'd
     if(sLinkAge == 1) {
         weight = CVar_GetS32("gChildMinimumWeightFish", 10);
-        if (gSaveContext.n64ddFlag) {
-            if (weight > 8) {
-                weight = 8;
-            }
-        }
     } else {
-        weight = CVar_GetS32("gAdultMinimumWeightFish", 13);
-        if (gSaveContext.n64ddFlag) {
-            if (weight > 10) {
-                weight = 10;
-            }
-        }        
+        weight = CVar_GetS32("gAdultMinimumWeightFish", 13);     
     }
 
     return sqrt(((f32)weight - 0.5f) / 0.0036f);


### PR DESCRIPTION
Resolves https://github.com/HarbourMasters/Shipwright/issues/1503

This is a short term fix for making rando fishing more consistent with N64 rando. It changes the minimum weights for the fishing enhancement to even lower, and adjusts the Randomizer enhancement preset to the new lowest weights. It also removes the "Instant Catch" enhancement from the same preset, as players didn't like how boring fishing was with it on.

We should probably still have a discussion about what to do in the future for this. I do think there's some merit to keep the choice for players to keep fishing as difficult as vanilla.