### PR TITLE
Rando: Fix rendering of Ruto's Letter and sun check when it's a stick

### DIFF
--- a/soh/src/code/z_actor.c
+++ b/soh/src/code/z_actor.c
@@ -6122,7 +6122,7 @@ GetItemEntry GetChestGameRandoGetItem(s8 room, s16 ogDrawId, GlobalContext* glob
 s16 GetChestGameRandoGiDrawId(s8 room, s16 ogDrawId, GlobalContext* globalCtx) {
     GetItemEntry randoGetItem = GetChestGameRandoGetItem(room, ogDrawId, globalCtx);
 
-    if (randoGetItem.itemId != RG_NONE) {
+    if (randoGetItem.itemId != ITEM_NONE) {
         return randoGetItem.gid;
     }
 

--- a/soh/src/overlays/actors/ovl_Item_Etcetera/z_item_etcetera.c
+++ b/soh/src/overlays/actors/ovl_Item_Etcetera/z_item_etcetera.c
@@ -256,7 +256,7 @@ void ItemEtcetera_Draw(Actor* thisx, GlobalContext* globalCtx) {
 
         EnItem00_CustomItemsParticles(&this->actor, globalCtx, randoGetItem);
 
-        if (randoGetItem.itemId != RG_NONE) {
+        if (randoGetItem.itemId != ITEM_NONE) {
             func_8002EBCC(&this->actor, globalCtx, 0);
             func_8002ED80(&this->actor, globalCtx, 0);
             GetItemEntry_Draw(globalCtx, randoGetItem);


### PR DESCRIPTION
Resolves https://github.com/HarbourMasters/Shipwright/issues/1419

Probably a holdover from when the new GetItemTable stuff was implemented, it was checking for RG_NONE which is 0, but that's the ID for a Deku Stick, so it defaulted to rendering the vanilla item when either of these was a stick.