### PR TITLE
Use updated object_ani.xml to fix erroneous TLUT

### DIFF
--- a/soh/assets/xml/GC_NMQ_D/objects/object_ani.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_ani.xml
@@ -37,9 +37,9 @@
         <DList Name="gRoofManRightHandDL" Offset="0x4A68"/>
         <DList Name="gRoofManHeadDL" Offset="0x2CD8"/>  
   
-        <!-- Kakariko Roof Man Palettes --> <!-- There's something weird going on with the TLUTs here... -->
+        <!-- Kakariko Roof Man Palettes -->
         <Texture Name="gRoofMan1TLUT" OutName="roof_man_1_tlut" Format="rgba16" Width="16" Height="16" Offset="0x00108"/>
-        <Texture Name="gRoofMan2TLUT" OutName="roof_man_2_tlut" Format="ci8" Width="16" Height="16" Offset="0x1088"/>
+        <Texture Name="gRoofMan2TLUT" OutName="roof_man_2_tlut" Format="rgba16" Width="21" Height="8" Offset="0x1088"/>
 
         <!-- Roof Man DisplayList Textures -->
         <Texture Name="gRoofManHandBackTex" OutName="roof_man_hand_back" Format="ci8" Width="16" Height="16" Offset="0x00C08" TlutOffset="0x00108"/>
@@ -47,9 +47,9 @@
         <Texture Name="gRoofManThighGradientTex" OutName="roof_man_thigh_gradient" Format="ci8" Width="8" Height="8" Offset="0x00D48" TlutOffset="0x00108"/>
         <Texture Name="gRoofManSandalBuckleTex" OutName="roof_man_sandal_buckle" Format="ci8" Width="16" Height="16" Offset="0x00D88" TlutOffset="0x00108"/>
         <Texture Name="gRoofManTrouserPatternTex" OutName="roof_man_trouser_pattern" Format="rgba16" Width="16" Height="16" Offset="0x00E88"/>
-        <Texture Name="gRoofManSkinGradientTex" OutName="roof_man_skin_gradient" Format="ci8" Width="8" Height="8" Offset="0x012D8"/>
-        <Texture Name="gRoofManEarTex" OutName="roof_man_ear" Format="ci8" Width="16" Height="16" Offset="0x01318"/>
-        <Texture Name="gRoofManHairTex" OutName="roof_man_hair" Format="ci8" Width="16" Height="16" Offset="0x01418"/>
+        <Texture Name="gRoofManSkinGradientTex" OutName="roof_man_skin_gradient" Format="ci8" Width="8" Height="8" Offset="0x012D8" TlutOffset="0x1088"/>
+        <Texture Name="gRoofManEarTex" OutName="roof_man_ear" Format="ci8" Width="16" Height="16" Offset="0x01318" TlutOffset="0x1088"/>
+        <Texture Name="gRoofManHairTex" OutName="roof_man_hair" Format="ci8" Width="16" Height="16" Offset="0x01418" TlutOffset="0x1088"/>
 
 
         <!-- Kakariko Roof Man Eye Textures -->

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_ani.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_ani.xml
@@ -37,9 +37,9 @@
         <DList Name="gRoofManRightHandDL" Offset="0x4A68"/>
         <DList Name="gRoofManHeadDL" Offset="0x2CD8"/>  
   
-        <!-- Kakariko Roof Man Palettes --> <!-- There's something weird going on with the TLUTs here... -->
+        <!-- Kakariko Roof Man Palettes -->
         <Texture Name="gRoofMan1TLUT" OutName="roof_man_1_tlut" Format="rgba16" Width="16" Height="16" Offset="0x00108"/>
-        <Texture Name="gRoofMan2TLUT" OutName="roof_man_2_tlut" Format="ci8" Width="16" Height="16" Offset="0x1088"/>
+        <Texture Name="gRoofMan2TLUT" OutName="roof_man_2_tlut" Format="rgba16" Width="21" Height="8" Offset="0x1088"/>
 
         <!-- Roof Man DisplayList Textures -->
         <Texture Name="gRoofManHandBackTex" OutName="roof_man_hand_back" Format="ci8" Width="16" Height="16" Offset="0x00C08" TlutOffset="0x00108"/>
@@ -47,9 +47,9 @@
         <Texture Name="gRoofManThighGradientTex" OutName="roof_man_thigh_gradient" Format="ci8" Width="8" Height="8" Offset="0x00D48" TlutOffset="0x00108"/>
         <Texture Name="gRoofManSandalBuckleTex" OutName="roof_man_sandal_buckle" Format="ci8" Width="16" Height="16" Offset="0x00D88" TlutOffset="0x00108"/>
         <Texture Name="gRoofManTrouserPatternTex" OutName="roof_man_trouser_pattern" Format="rgba16" Width="16" Height="16" Offset="0x00E88"/>
-        <Texture Name="gRoofManSkinGradientTex" OutName="roof_man_skin_gradient" Format="ci8" Width="8" Height="8" Offset="0x012D8"/>
-        <Texture Name="gRoofManEarTex" OutName="roof_man_ear" Format="ci8" Width="16" Height="16" Offset="0x01318"/>
-        <Texture Name="gRoofManHairTex" OutName="roof_man_hair" Format="ci8" Width="16" Height="16" Offset="0x01418"/>
+        <Texture Name="gRoofManSkinGradientTex" OutName="roof_man_skin_gradient" Format="ci8" Width="8" Height="8" Offset="0x012D8" TlutOffset="0x1088"/>
+        <Texture Name="gRoofManEarTex" OutName="roof_man_ear" Format="ci8" Width="16" Height="16" Offset="0x01318" TlutOffset="0x1088"/>
+        <Texture Name="gRoofManHairTex" OutName="roof_man_hair" Format="ci8" Width="16" Height="16" Offset="0x01418" TlutOffset="0x1088"/>
 
 
         <!-- Kakariko Roof Man Eye Textures -->


### PR DESCRIPTION
This sort of fixes #106. There were problems with the actor's graphics, but they were not what the issue describes. However, if you look at the linked picture in the issue, you can see the black pixels on the man's face. That is what this PR fixes.

All this change is is bringing in the current object_ani xmls from decomp, as the issue was fixed upstream.

These changes will require a regen of the OTR.