### PR TITLE
Fixes laggy text boxes in Switch

### DIFF
--- a/soh/src/code/z_message_PAL.c
+++ b/soh/src/code/z_message_PAL.c
@@ -1281,7 +1281,6 @@ void Message_Decode(GlobalContext* globalCtx) {
     MessageContext* msgCtx = &globalCtx->msgCtx;
     Font* font = &globalCtx->msgCtx.font;
 
-    //gSPInvalidateTexCache(globalCtx->state.gfxCtx->polyOpa.p++, font->fontBuf);
     for (u32 i = 0; i < FONT_CHAR_TEX_SIZE * 120; i += FONT_CHAR_TEX_SIZE) {
         gSPInvalidateTexCache(globalCtx->state.gfxCtx->polyOpa.p++, &font->charTexBuf[i]);
     }
@@ -1681,7 +1680,6 @@ void Message_OpenText(GlobalContext* globalCtx, u16 textId) {
     }
 
     sMessageHasSetSfx = D_8014B2F4 = sTextboxSkipped = sTextIsCredits = 0;
-    //gSPInvalidateTexCache(globalCtx->state.gfxCtx->polyOpa.p++, font->fontBuf);
 
     if (textId >= 0x0500 && textId < 0x0600) { // text ids 0500 to 0600 are reserved for credits
         sTextIsCredits = true;

--- a/soh/src/code/z_message_PAL.c
+++ b/soh/src/code/z_message_PAL.c
@@ -1281,7 +1281,10 @@ void Message_Decode(GlobalContext* globalCtx) {
     MessageContext* msgCtx = &globalCtx->msgCtx;
     Font* font = &globalCtx->msgCtx.font;
 
-    gSPInvalidateTexCache(globalCtx->state.gfxCtx->polyOpa.p++, NULL);
+    //gSPInvalidateTexCache(globalCtx->state.gfxCtx->polyOpa.p++, font->fontBuf);
+    for (u32 i = 0; i < FONT_CHAR_TEX_SIZE * 120; i += FONT_CHAR_TEX_SIZE) {
+        gSPInvalidateTexCache(globalCtx->state.gfxCtx->polyOpa.p++, &font->charTexBuf[i]);
+    }
 
     globalCtx->msgCtx.textDelayTimer = 0;
     globalCtx->msgCtx.textUnskippable = globalCtx->msgCtx.textDelay = globalCtx->msgCtx.textDelayTimer = 0;
@@ -1678,7 +1681,7 @@ void Message_OpenText(GlobalContext* globalCtx, u16 textId) {
     }
 
     sMessageHasSetSfx = D_8014B2F4 = sTextboxSkipped = sTextIsCredits = 0;
-    gSPInvalidateTexCache(globalCtx->state.gfxCtx->polyOpa.p++, NULL);
+    //gSPInvalidateTexCache(globalCtx->state.gfxCtx->polyOpa.p++, font->fontBuf);
 
     if (textId >= 0x0500 && textId < 0x0600) { // text ids 0500 to 0600 are reserved for credits
         sTextIsCredits = true;


### PR DESCRIPTION
The switch really doesn't like calling `gSPInvalidateTexCache` with a `texaddr` of `NULL`. This moves the invalidation to an area where we can reference the `font->charTexBuf` indices and invalidate them. This change caused my switch to have no perceptible lag, and did not cause any issues with loading the wrong characters or Get Item Icons on my Switch or my PC.