### PR TITLE
Fix: Vanilla Sun's Song tablet attempting to give rando item

### DIFF
--- a/soh/src/overlays/actors/ovl_En_Okarina_Tag/z_en_okarina_tag.c
+++ b/soh/src/overlays/actors/ovl_En_Okarina_Tag/z_en_okarina_tag.c
@@ -337,7 +337,7 @@ void func_80ABF7CC(EnOkarinaTag* this, GlobalContext* globalCtx) {
         if (!gSaveContext.n64ddFlag && !CHECK_QUEST_ITEM(QUEST_SONG_SUN)) {
             globalCtx->csCtx.segment = SEGMENTED_TO_VIRTUAL(&gSunSongGraveSunSongTeachCs);
             gSaveContext.cutsceneTrigger = 1;
-        } else if (!Flags_GetTreasure(globalCtx, 0x1F)) {
+        } else if (gSaveContext.n64ddFlag && !Flags_GetTreasure(globalCtx, 0x1F)) {
             GivePlayerRandoRewardSunSong(this, globalCtx, RC_SONG_FROM_ROYAL_FAMILYS_TOMB);
         }
         this->actionFunc = func_80ABF708;


### PR DESCRIPTION
Wasn't handled properly by: https://github.com/HarbourMasters/Shipwright/pull/1185

When you were in a vanilla save, received sun's song and then talked to the tablet again, it would try and grant a randomizer item.