### PR TITLE
Fix gyro drift being applied when gyro is disabled

### DIFF
--- a/libultraship/libultraship/SDLController.cpp
+++ b/libultraship/libultraship/SDLController.cpp
@@ -171,6 +171,10 @@ namespace Ship {
             getGyroX(virtualSlot) *= gyro_sensitivity;
             getGyroY(virtualSlot) *= gyro_sensitivity;
         }
+        else {
+            getGyroX(virtualSlot) = 0;
+            getGyroY(virtualSlot) = 0;
+        }
 
         getPressedButtons(virtualSlot) = 0;
 


### PR DESCRIPTION
Resolves #1539

Verified this prevents gyro drift from applying when gyro is disabled.

For WiiU this seems to not have been an issue as it appears that all controller values are reset when the profile is read from source anyways. I don't have a WiiU setup to confirm.

The only thing I wasn't sure of is if the profile data should also be updated to set the drift to 0 so that the next time gyro is turned on it auto re-calibrates. Thoughts?