### PR TITLE
Fix issue with 'auto' controller setting

### DIFF
--- a/libultraship/libultraship/ControlDeck.cpp
+++ b/libultraship/libultraship/ControlDeck.cpp
@@ -76,13 +76,17 @@ namespace Ship {
 		for (size_t i = 0; i < virtualDevices.size(); i++) {
 			const std::shared_ptr<Controller> backend = physicalDevices[virtualDevices[i]];
 			if (backend->GetGuid() == "Auto") {
-				for (const auto& device : physicalDevices) {
-					if(ShouldBlockGameInput() && device->GetGuid() != "Keyboard") {
-						device->Read(nullptr, i);
-						continue;
+				std::shared_ptr<Controller> device;
+				for (const auto& physicalDevice : physicalDevices) {
+					if (!device && physicalDevice->GetGuid() != "Auto") {
+						device = physicalDevice;
 					}
-					device->Read(&pad[i], i);
 				}
+				if(ShouldBlockGameInput() && device->GetGuid() != "Keyboard") {
+					device->Read(nullptr, i);
+					continue;
+				}
+				device->Read(&pad[i], i);
 				continue;
 			}
 			if(ShouldBlockGameInput() && backend->GetGuid() != "Keyboard") {

--- a/libultraship/libultraship/ControlDeck.cpp
+++ b/libultraship/libultraship/ControlDeck.cpp
@@ -76,17 +76,13 @@ namespace Ship {
 		for (size_t i = 0; i < virtualDevices.size(); i++) {
 			const std::shared_ptr<Controller> backend = physicalDevices[virtualDevices[i]];
 			if (backend->GetGuid() == "Auto") {
-				std::shared_ptr<Controller> device;
-				for (const auto& physicalDevice : physicalDevices) {
-					if (!device && physicalDevice->GetGuid() != "Auto") {
-						device = physicalDevice;
+				for (const auto& device : physicalDevices) {
+					if(ShouldBlockGameInput() && device->GetGuid() != "Keyboard") {
+						device->Read(nullptr, i);
+						continue;
 					}
+					device->Read(&pad[i], i);
 				}
-				if(ShouldBlockGameInput() && device->GetGuid() != "Keyboard") {
-					device->Read(nullptr, i);
-					continue;
-				}
-				device->Read(&pad[i], i);
 				continue;
 			}
 			if(ShouldBlockGameInput() && backend->GetGuid() != "Keyboard") {

--- a/libultraship/libultraship/Controller.cpp
+++ b/libultraship/libultraship/Controller.cpp
@@ -81,12 +81,12 @@ namespace Ship {
 		if (pad != nullptr) {
 			auto &padFromBuffer = padBuffer[std::min(padBuffer.size() - 1, (size_t)CVar_GetS32("gSimulatedInputLag", 0))];
 			pad->button |= padFromBuffer.button;
-			if (padFromBuffer.stick_x != 0) pad->stick_x = padFromBuffer.stick_x;
-			if (padFromBuffer.stick_y != 0) pad->stick_y = padFromBuffer.stick_y;
-			if (padFromBuffer.gyro_x != 0) pad->gyro_x = padFromBuffer.gyro_x;
-			if (padFromBuffer.gyro_y != 0) pad->gyro_y = padFromBuffer.gyro_y;
-			if (padFromBuffer.right_stick_x != 0) pad->right_stick_x = padFromBuffer.right_stick_x;
-			if (padFromBuffer.right_stick_y != 0) pad->right_stick_y = padFromBuffer.right_stick_y;
+			if (pad->stick_x == 0) pad->stick_x = padFromBuffer.stick_x;
+			if (pad->stick_y == 0) pad->stick_y = padFromBuffer.stick_y;
+			if (pad->gyro_x == 0) pad->gyro_x = padFromBuffer.gyro_x;
+			if (pad->gyro_y == 0) pad->gyro_y = padFromBuffer.gyro_y;
+			if (pad->right_stick_x == 0) pad->right_stick_x = padFromBuffer.right_stick_x;
+			if (pad->right_stick_y == 0) pad->right_stick_y = padFromBuffer.right_stick_y;
 		}
 
 		while (padBuffer.size() > 6) {

--- a/libultraship/libultraship/Controller.cpp
+++ b/libultraship/libultraship/Controller.cpp
@@ -79,7 +79,14 @@ namespace Ship {
 
 		padBuffer.push_front(padToBuffer);
 		if (pad != nullptr) {
-			*pad = padBuffer[std::min(padBuffer.size() - 1, (size_t)CVar_GetS32("gSimulatedInputLag", 0))];
+			auto &padFromBuffer = padBuffer[std::min(padBuffer.size() - 1, (size_t)CVar_GetS32("gSimulatedInputLag", 0))];
+			pad->button |= padFromBuffer.button;
+			if (padFromBuffer.stick_x != 0) pad->stick_x = padFromBuffer.stick_x;
+			if (padFromBuffer.stick_y != 0) pad->stick_y = padFromBuffer.stick_y;
+			if (padFromBuffer.gyro_x != 0) pad->gyro_x = padFromBuffer.gyro_x;
+			if (padFromBuffer.gyro_y != 0) pad->gyro_y = padFromBuffer.gyro_y;
+			if (padFromBuffer.right_stick_x != 0) pad->right_stick_x = padFromBuffer.right_stick_x;
+			if (padFromBuffer.right_stick_y != 0) pad->right_stick_y = padFromBuffer.right_stick_y;
 		}
 
 		while (padBuffer.size() > 6) {


### PR DESCRIPTION
Basically the issue was, when it's on the auto setting it loops through all physical devices and reads the inputs. "Disconnected" is the last physical device, and now has 0'd out inputs as of my simulated lag work, so the 0'd inputs get read last.

This PR changes it so that it combines button input and only reads non-zero stick inputs