### PR TITLE
Don't disable keyboard when menuBar is shown and gControlNav is true

### DIFF
--- a/libultraship/libultraship/ImGuiImpl.cpp
+++ b/libultraship/libultraship/ImGuiImpl.cpp
@@ -363,7 +363,7 @@ namespace SohImGui {
         }
 
         if (CVar_GetS32("gControlNav", 0) && CVar_GetS32("gOpenMenuBar", 0)) {
-            io->ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad | ImGuiConfigFlags_NavEnableKeyboard;
+            io->ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad;
         } else {
             io->ConfigFlags &= ~ImGuiConfigFlags_NavEnableGamepad;
         }
@@ -466,7 +466,7 @@ namespace SohImGui {
             ShowCursor(menu_bar, Dialogues::dMenubar);
             Window::GetInstance()->GetControlDeck()->SaveControllerSettings();
             if (CVar_GetS32("gControlNav", 0) && CVar_GetS32("gOpenMenuBar", 0)) {
-                io->ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad | ImGuiConfigFlags_NavEnableKeyboard;
+                io->ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad;
             } else {
                 io->ConfigFlags &= ~ImGuiConfigFlags_NavEnableGamepad;
             }


### PR DESCRIPTION
I don't think we want the `gControlNav`(Use controller for navigation) option to enable/disable keyboard input.

If we do want this, we just need to make sure the `ImGuiConfigFlags_NavEnableKeyboard` is removed along with the `ImGuiConfigFlags_NavEnableGamepad` flag when the menuBar is hidden.