### PR TITLE
assert __THROW fix for Linux

### DIFF
--- a/soh/include/functions.h
+++ b/soh/include/functions.h
@@ -64,8 +64,10 @@ u32 func_80001F8C(void);
 u32 Locale_IsRegionNative(void);
 #ifdef __WIIU__
 void _assert(const char* exp, const char* file, s32 line);
-#elif !defined(__APPLE__) && !defined(__SWITCH__)
+#elif defined(__linux__)
 void __assert(const char* exp, const char* file, s32 line) __THROW;
+#elif !defined(__APPLE__) && !defined(__SWITCH__)
+void __assert(const char* exp, const char* file, s32 line);
 #endif
 #if defined(__APPLE__) && defined(NDEBUG)
 void __assert(const char* exp, const char* file, s32 line);

--- a/soh/include/functions.h
+++ b/soh/include/functions.h
@@ -65,7 +65,7 @@ u32 Locale_IsRegionNative(void);
 #ifdef __WIIU__
 void _assert(const char* exp, const char* file, s32 line);
 #elif !defined(__APPLE__) && !defined(__SWITCH__)
-void __assert(const char* exp, const char* file, s32 line);
+void __assert(const char* exp, const char* file, s32 line) __THROW;
 #endif
 #if defined(__APPLE__) && defined(NDEBUG)
 void __assert(const char* exp, const char* file, s32 line);


### PR DESCRIPTION
Fixes the mismatched `__assert` definition compilation error in certain Linux build environments. Probably related to versions of `gcc` that are more recent than the one used by the CI.