### PR TITLE
Fixes Happy Mask shop on the Switch.

### DIFF
--- a/soh/src/overlays/actors/ovl_En_Ossan/z_en_ossan.c
+++ b/soh/src/overlays/actors/ovl_En_Ossan/z_en_ossan.c
@@ -1710,13 +1710,12 @@ void EnOssan_State_ItemPurchased(EnOssan* this, GlobalContext* globalCtx, Player
     EnGirlA* item;
     EnGirlA* itemTemp;
     ShopItemIdentity shopItemIdentity = Randomizer_IdentifyShopItem(globalCtx->sceneNum, this->cursorIndex);
-    // Need to make sure the mask shop gets correct ogItemIds
-    // RANDOTODO: return this from shopItemIdentity or avoid running some of this code completely
-    // when not randomized or in mask shop.
-    if (this->actor.params == OSSAN_TYPE_MASK) {
-        shopItemIdentity.ogItemId = this->shelfSlots[this->cursorIndex]->getItemId;
+    GetItemEntry getItemEntry;
+    if (shopItemIdentity.randomizerCheck != RC_UNKNOWN_CHECK) {
+        getItemEntry = Randomizer_GetItemFromKnownCheck(shopItemIdentity.randomizerCheck, shopItemIdentity.ogItemId);
+    } else {
+        getItemEntry = ItemTable_Retrieve(this->shelfSlots[this->cursorIndex]->getItemId);
     }
-    GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(shopItemIdentity.randomizerCheck, shopItemIdentity.ogItemId);
     
 
     if ((Message_GetState(&globalCtx->msgCtx) == TEXT_STATE_DONE) && Message_ShouldAdvance(globalCtx)) {

--- a/soh/src/overlays/actors/ovl_En_Ossan/z_en_ossan.c
+++ b/soh/src/overlays/actors/ovl_En_Ossan/z_en_ossan.c
@@ -1710,7 +1710,14 @@ void EnOssan_State_ItemPurchased(EnOssan* this, GlobalContext* globalCtx, Player
     EnGirlA* item;
     EnGirlA* itemTemp;
     ShopItemIdentity shopItemIdentity = Randomizer_IdentifyShopItem(globalCtx->sceneNum, this->cursorIndex);
+    // Need to make sure the mask shop gets correct ogItemIds
+    // RANDOTODO: return this from shopItemIdentity or avoid running some of this code completely
+    // when not randomized or in mask shop.
+    if (this->actor.params == OSSAN_TYPE_MASK) {
+        shopItemIdentity.ogItemId = this->shelfSlots[this->cursorIndex]->getItemId;
+    }
     GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(shopItemIdentity.randomizerCheck, shopItemIdentity.ogItemId);
+    
 
     if ((Message_GetState(&globalCtx->msgCtx) == TEXT_STATE_DONE) && Message_ShouldAdvance(globalCtx)) {
         if (this->actor.params == OSSAN_TYPE_MASK) {


### PR DESCRIPTION
On the Switch, the Happy Mask Shop was getting an invalid ogItemId in Item_Purchased. I think this code may have been added specifically for handling ice traps, as the getItemEntry obtained via the ogItemId doesn't get used anywhere but checking for Ice Traps. There may be a way to avoid this altogether, I left a todo comment. Until then, this avoids the crash on Switch associated with trying to check against GI_NONE.