### PR TITLE
Removed d-pad support for pause in preset

### DIFF
--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -315,8 +315,6 @@ namespace GameMenuBar {
     }
 
     void applyEnhancementPresetVanillaPlus(void) {
-        // D-pad Support on Pause
-        CVar_SetS32("gDpadPause", 1);
         // D-pad Support in text and file select
         CVar_SetS32("gDpadText", 1);
         // Play Ocarina with D-pad


### PR DESCRIPTION
When both dpad support for the pause menu and dpad support for equiping items is enabled, you need to press C-up to equip items to the dpad. This isn't very intuitive without reading the description for the option. So in my opinion, it's better to remove dpad support in the pause menu from the preset altogether, because I believe intuitive dpad items is more important than having dpad support in the pause menu in a preset.

![image](https://user-images.githubusercontent.com/4244591/192167123-c7f93546-7f62-4517-aa62-760cda90376a.png)