### PR TITLE
Excludes the master sword in the Ganon Battle from triggering autosave.

### DIFF
--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -2607,6 +2607,10 @@ void PerformAutosave(GlobalContext* globalCtx, u8 item) {
                 case ITEM_ARROWS_LARGE:
                 case ITEM_SEEDS_30:
                     break;
+                case ITEM_SWORD_MASTER:
+                    if (globalCtx->sceneNum == SCENE_GANON_DEMO) {
+                        break;
+                    }
                 default:
                     Gameplay_PerformSave(globalCtx);
                     break;


### PR DESCRIPTION
Beforehand it would trigger every frame while the cutsene of Link brandishing the master sword was playing.