### PR TITLE
[macOS] Fix launcher code in case with empty 'sysctl.proc_translated'

### DIFF
--- a/soh/macosx/soh-macos.sh
+++ b/soh/macosx/soh-macos.sh
@@ -67,7 +67,7 @@ done
 
 arch_name="$(uname -m)"
 launch_arch="arm64"
-if [ "${arch_name}" = "x86_64" ] && [ "$(sysctl -in sysctl.proc_translated)" = "0" ]; then
+if [ "${arch_name}" = "x86_64" ] && [ "$(sysctl -in sysctl.proc_translated)" != "1" ]; then
 	launch_arch="x86_64"
 fi
 


### PR DESCRIPTION
Just in case with `sysctl -in sysctl.proc_translated` returning nothing (empty) or `-1 (error)` in some macOS installs,
It'd be safe to cover any values other than `1`, not just `0` .