### PR TITLE
[#1584] Undo the special rotation done for spiritual stones after they are purchased

### DIFF
--- a/soh/src/overlays/actors/ovl_En_GirlA/z_en_girla.c
+++ b/soh/src/overlays/actors/ovl_En_GirlA/z_en_girla.c
@@ -381,6 +381,12 @@ s32 EnGirlA_TryChangeShopItem(EnGirlA* this, GlobalContext* globalCtx) {
             ShopItemIdentity shopItemIdentity = Randomizer_IdentifyShopItem(globalCtx->sceneNum, this->randoSlotIndex);
             if (Flags_GetRandomizerInf(shopItemIdentity.randomizerInf)) {
                 this->actor.params = SI_SOLD_OUT;
+                GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheckWithoutObtainabilityCheck(shopItemIdentity.randomizerCheck, shopItemIdentity.ogItemId);
+
+                // Undo the rotation for spiritual stones
+                if (getItemEntry.getItemId >= RG_KOKIRI_EMERALD && getItemEntry.getItemId <= RG_ZORA_SAPPHIRE) {
+                    this->actor.shape.rot.y = this->actor.shape.rot.y - 20000;
+                }
                 return true;
             }
             break;


### PR DESCRIPTION
Without undoing the rotation the sold out sign was appearing sideways after buying the spiritual stones. This fixes that.

Resolves #1584 