### PR TITLE
Change precision of float sliders

### DIFF
--- a/soh/soh/UIWidgets.cpp
+++ b/soh/soh/UIWidgets.cpp
@@ -333,7 +333,10 @@ namespace UIWidgets {
         }
         if (ImGui::SliderFloat(id, &val, min, max, format))
         {
-            CVar_SetFloat(cvarName, val);
+            if (isPercentage)
+                CVar_SetFloat(cvarName, roundf(val * 100) / 100);
+            else
+                CVar_SetFloat(cvarName, roundf(val * 10) / 10);
             SohImGui::RequestCvarSaveOnNextTick();
         }
         if (PlusMinusButton) {

--- a/soh/soh/UIWidgets.cpp
+++ b/soh/soh/UIWidgets.cpp
@@ -337,7 +337,7 @@ namespace UIWidgets {
             if (isPercentage) {
                 CVar_SetFloat(cvarName, roundf(val * 100) / 100);
             } else {
-                CVar_SetFloat(cvarName, roundf(val * 10) / 10);
+                CVar_SetFloat(cvarName, val);
             }
             SohImGui::RequestCvarSaveOnNextTick();
         }

--- a/soh/soh/UIWidgets.cpp
+++ b/soh/soh/UIWidgets.cpp
@@ -301,10 +301,11 @@ namespace UIWidgets {
     void EnhancementSliderFloat(const char* text, const char* id, const char* cvarName, float min, float max, const char* format, float defaultValue, bool isPercentage, bool PlusMinusButton) {
         float val = CVar_GetFloat(cvarName, defaultValue);
 
-        if (!isPercentage)
+        if (!isPercentage) {
             ImGui::Text(text, val);
-        else
+        } else {
             ImGui::Text(text, static_cast<int>(100 * val));
+        }
 
         Spacer(0);
 
@@ -312,10 +313,11 @@ namespace UIWidgets {
             std::string MinusBTNName = " - ##";
             MinusBTNName += cvarName;
             if (ImGui::Button(MinusBTNName.c_str())) {
-                if (!isPercentage)
+                if (!isPercentage) {
                     val -= 0.1f;
-                else
+                } else {
                     val -= 0.01f;
+                }
                 CVar_SetFloat(cvarName, val);
                 SohImGui::RequestCvarSaveOnNextTick();
             }
@@ -331,12 +333,12 @@ namespace UIWidgets {
             ImGui::PushItemWidth(ImGui::GetWindowSize().x - 79.0f);
         #endif
         }
-        if (ImGui::SliderFloat(id, &val, min, max, format))
-        {
-            if (isPercentage)
+        if (ImGui::SliderFloat(id, &val, min, max, format)) {
+            if (isPercentage) {
                 CVar_SetFloat(cvarName, roundf(val * 100) / 100);
-            else
+            } else {
                 CVar_SetFloat(cvarName, roundf(val * 10) / 10);
+            }
             SohImGui::RequestCvarSaveOnNextTick();
         }
         if (PlusMinusButton) {
@@ -348,24 +350,23 @@ namespace UIWidgets {
             ImGui::SameLine();
             ImGui::SetCursorPosX(ImGui::GetCursorPosX() - 7.0f);
             if (ImGui::Button(PlusBTNName.c_str())) {
-                if (!isPercentage)
+                if (!isPercentage) {
                     val += 0.1f;
-                else
+                } else {
                     val += 0.01f;
+                }
                 CVar_SetFloat(cvarName, val);
                 SohImGui::RequestCvarSaveOnNextTick();
             }
         }
 
-        if (val < min)
-        {
+        if (val < min) {
             val = min;
             CVar_SetFloat(cvarName, val);
             SohImGui::RequestCvarSaveOnNextTick();
         }
 
-        if (val > max)
-        {
+        if (val > max) {
             val = max;
             CVar_SetFloat(cvarName, val);
             SohImGui::RequestCvarSaveOnNextTick();


### PR DESCRIPTION
This rounds the values of sliders to `.1` and `.01` to match the values being displayed.
Otherwise the UI shows values as for example `100%` even though the actual value stored is `1.0043902397155762`.