### PR TITLE
FIX: Set back default behaviour of some Views

### DIFF
--- a/soh/soh/Enhancements/controls/GameControlEditor.cpp
+++ b/soh/soh/Enhancements/controls/GameControlEditor.cpp
@@ -238,7 +238,7 @@ namespace GameControlEditor {
         UIWidgets::PaddedEnhancementCheckbox("Right Stick Aiming", "gRightStickAiming");
         UIWidgets::Tooltip("Allows for aiming with the rights stick when:\n-Aiming in the C-Up view\n-Aiming with weapons");
 		ImGui::SetCursorPosX(ImGui::GetCursorPosX() + 5);
-        UIWidgets::PaddedEnhancementCheckbox("Auto-Center First Person View", "gAutoCenterView");
+        UIWidgets::PaddedEnhancementCheckbox("Disable Auto-Centering in First Person View", "gAutoCenterView");
         UIWidgets::Tooltip("Prevents the C-Up view from auto-centering, allowing for Gyro Aiming");
 	}
 	

--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -114,7 +114,7 @@ namespace GameMenuBar {
         // Invert Camera X Axis
         CVar_SetS32("gInvertXAxis", 0);
         // Invert Camera Y Axis
-        CVar_SetS32("gInvertYAxis", 0);
+        CVar_SetS32("gInvertYAxis", 1);
         // Right Stick Aiming
         CVar_SetS32("gRightStickAiming", 0);
         // Auto-Center First Person View

--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -114,7 +114,7 @@ namespace GameMenuBar {
         // Invert Camera X Axis
         CVar_SetS32("gInvertXAxis", 0);
         // Invert Camera Y Axis
-        CVar_SetS32("gInvertYAxis", 1);
+        CVar_SetS32("gInvertYAxis", 0);
         // Right Stick Aiming
         CVar_SetS32("gRightStickAiming", 0);
         // Auto-Center First Person View

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -11122,7 +11122,7 @@ s16 func_8084ABD8(GlobalContext* globalCtx, Player* this, s32 arg2, s16 arg3) {
     s16 temp3;
 
     if (!func_8002DD78(this) && !func_808334B4(this) && (arg2 == 0)) {
-        if (CVar_GetS32("gAutoCenterView", 0) != 0) {
+        if (CVar_GetS32("gAutoCenterView", 0)) {
             temp2 = sControlInput->rel.stick_y * 240.0f * (CVar_GetS32("gInvertYAxis", 1) ? -1 : 1);
             Math_SmoothStepToS(&this->actor.focus.rot.x, temp2, 14, 4000, 30);
 


### PR DESCRIPTION
- Renamed Auto-Center First Person View to Disable Auto-Centering in First Person View and make it necessary to be checked to take effect and not being active by default