### PR TITLE
Switch: suspend application when not focused

### DIFF
--- a/libultraship/libultraship/SwitchImpl.cpp
+++ b/libultraship/libultraship/SwitchImpl.cpp
@@ -160,8 +160,13 @@ static void on_applet_hook(AppletHookType hook, void *param) {
                     clkrstSetClockRate(&session, SWITCH_CPU_SPEEDS_VALUES[ Ship::STOCK ]);
                     clkrstCloseSession(&session);
                 }
-            } else
+                /* Lost focus, enable suspension */
+                appletSetFocusHandlingMode(AppletFocusHandlingMode_SuspendHomeSleep);
+            } else {
+                /* Regained focus, disable suspension */
+                appletSetFocusHandlingMode(AppletFocusHandlingMode_NoSuspend);
                 Ship::Switch::ApplyOverclock();
+            }
             break;
 
          /* Performance mode */


### PR DESCRIPTION
This fixes the issue on where the game doesn't pause and actually continues in the background when you press the Home button. (Suspending is the default behavior of libnx, but this was overridden in the initial implementation. Not sure why.)