### PR TITLE
Shopsanity - fix regression from removing BUY_BOMBCHU_5

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/shops.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/shops.cpp
@@ -50,6 +50,7 @@ std::vector<uint32_t> GetMinVanillaShopItems(int total_replaced) {
     BUY_ARROWS_50,
     BUY_BOMBCHU_10,
     BUY_BOMBCHU_10,
+    BUY_BOMBCHU_10,
     BUY_BOMBCHU_20,
     BUY_BOMBS_525,
     BUY_BOMBS_535,


### PR DESCRIPTION
There are assumptions made about the size of this vector, and an item was removed in #1605 

This restores the original length of that vector with a 10 pack of bombchus instead of 5. This matches the vanilla bombchu shop with 4 10 packs and 4 20 packs