### PR TITLE
FIX: Sword Trail not appearing when using custom color

### DIFF
--- a/soh/soh/Enhancements/bootcommands.c
+++ b/soh/soh/Enhancements/bootcommands.c
@@ -26,6 +26,7 @@ void BootCommands_Init()
     CVar_RegisterS32("gLanguages", 0); //0 = English / 1 = German / 2 = French
     CVar_RegisterS32("gHudColors", 1); //0 = N64 / 1 = NGC / 2 = Custom
 	CVar_RegisterS32("gInvertYAxis", 1);
+    CVar_RegisterS32("gTrailDuration", 4); // 4 = Default trail duration
 #if defined(__SWITCH__) || defined(__WIIU__)
     CVar_RegisterS32("gControlNav", 1); // always enable controller nav on switch/wii u
 #endif

--- a/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
+++ b/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
@@ -467,8 +467,8 @@ void Draw_ItemsSkills(){
         Table_InitHeader();
         DrawColorSection(Trail_section, SECTION_SIZE(Trail_section));
         ImGui::EndTable();
-        UIWidgets::EnhancementSliderInt("Sword Trail Length: %d", "##TrailsMul", "gTrailDuration", 1, 16, "", 4, true);
-        UIWidgets::Tooltip("Determines length of Link's sword trails.");
+        UIWidgets::EnhancementSliderInt("Sword Trail Duration: %d", "##TrailsMul", "gTrailDuration", 1, 16, "", 4, true);
+        UIWidgets::Tooltip("Determines the duration of Link's sword trails.");
         ResetTrailLength("gTrailDuration", 4);
         UIWidgets::EnhancementCheckbox("Swords use separate colors", "gSeperateSwords");
         if (CVar_GetS32("gSeperateSwords", 0) && ImGui::CollapsingHeader("Individual Sword Colors")) {


### PR DESCRIPTION
This was caused by the trail duration cvar not being init properly until we change the duration manually.

cf this video: https://streamable.com/a9u4fm

- Also changed Lengh to Duration for clarity