### PR TITLE
fix: match auto center option text to behavior

### DIFF
--- a/soh/soh/Enhancements/controls/GameControlEditor.cpp
+++ b/soh/soh/Enhancements/controls/GameControlEditor.cpp
@@ -238,7 +238,7 @@ namespace GameControlEditor {
         UIWidgets::PaddedEnhancementCheckbox("Right Stick Aiming", "gRightStickAiming");
         UIWidgets::Tooltip("Allows for aiming with the rights stick when:\n-Aiming in the C-Up view\n-Aiming with weapons");
 		ImGui::SetCursorPosX(ImGui::GetCursorPosX() + 5);
-        UIWidgets::PaddedEnhancementCheckbox("Disable Auto-Centering in First Person View", "gAutoCenterView");
+        UIWidgets::PaddedEnhancementCheckbox("Disable Auto-Centering in First Person View", "gDisableAutoCenterView");
         UIWidgets::Tooltip("Prevents the C-Up view from auto-centering, allowing for Gyro Aiming");
 	}
 	

--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -117,8 +117,8 @@ namespace GameMenuBar {
         CVar_SetS32("gInvertYAxis", 1);
         // Right Stick Aiming
         CVar_SetS32("gRightStickAiming", 0);
-        // Auto-Center First Person View
-        CVar_SetS32("gAutoCenterView", 0);
+        // Disable Auto-Center First Person View
+        CVar_SetS32("gDisableAutoCenterView", 0);
 
         // Text Speed (1 to 5)
         CVar_SetS32("gTextSpeed", 1);

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -11175,7 +11175,7 @@ s16 func_8084ABD8(GlobalContext* globalCtx, Player* this, s32 arg2, s16 arg3) {
     s16 temp3;
 
     if (!func_8002DD78(this) && !func_808334B4(this) && (arg2 == 0)) {
-        if (CVar_GetS32("gAutoCenterView", 0)) {
+        if (!CVar_GetS32("gDisableAutoCenterView", 0)) {
             temp2 = sControlInput->rel.stick_y * 240.0f * (CVar_GetS32("gInvertYAxis", 1) ? -1 : 1);
             Math_SmoothStepToS(&this->actor.focus.rot.x, temp2, 14, 4000, 30);
 


### PR DESCRIPTION
in https://github.com/HarbourMasters/Shipwright/pull/1615 the name of the option was changed but the actual logic was not. this means the text in the imgui option no longer matches behavior. this renames the cvar to match the behavior, and corrects the inverted check.