### PR TITLE
update cmake to use forked gamecontrollerdb.txt

### DIFF
--- a/soh/CMakeLists.txt
+++ b/soh/CMakeLists.txt
@@ -2036,7 +2036,7 @@ INSTALL(FILES $<TARGET_PDB_FILE:soh> DESTINATION ./debug COMPONENT ship)
 endif()
 
 find_program(CURL NAMES curl DOC "Path to the curl program.  Used to download files.")
-execute_process(COMMAND ${CURL} -sSfL https://raw.githubusercontent.com/gabomdq/SDL_GameControllerDB/master/gamecontrollerdb.txt -o ${CMAKE_BINARY_DIR}/gamecontrollerdb.txt OUTPUT_VARIABLE RESULT)
+execute_process(COMMAND ${CURL} -sSfL https://raw.githubusercontent.com/briaguya-ai/SDL_GameControllerDB/vx-gaming-command-series/gamecontrollerdb.txt -o ${CMAKE_BINARY_DIR}/gamecontrollerdb.txt OUTPUT_VARIABLE RESULT)
 
 if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
 INSTALL(FILES ${CMAKE_BINARY_DIR}/gamecontrollerdb.txt DESTINATION ../MacOS COMPONENT ship)


### PR DESCRIPTION
adding linux controller support via https://github.com/briaguya-ai/SDL_GameControllerDB/commit/284645769a47492fcb09ad7c5ac4e21a5f63b1fa

this is a PR to get a build and test that everything is working

if it is, i will PR the `gamecontrollerdb.txt` from my controllerdb fork to [upstream](https://github.com/gabomdq/SDL_GameControllerDB) and our builds will pick up the change automatically if that gets merged

update: tested and working, PR is out here: https://github.com/gabomdq/SDL_GameControllerDB/pull/616