### PR TITLE
Fixes Master Quest on Mac and Linux

### DIFF
--- a/scripts/linux/appimage/soh.sh
+++ b/scripts/linux/appimage/soh.sh
@@ -25,6 +25,10 @@ while [[ ! -e "$SHIP_HOME"/oot.otr ]]; do
 			ROM=GC_NMQ_D;;
 		0227d7c0074f2d0ac935631990da8ec5914597b4)
 			ROM=GC_NMQ_PAL_F;;
+		50bebedad9e0f10746a52b07239e47fa6c284d03)
+			ROM=GC_MQ_D;;
+		079b855b943d6ad8bd1eb026c0ed169ecbdac7da)
+			ROM=GC_MQ_D;;	
 		*)
   			if [ -n "$ZENITY" ]; then
 				zenity --error --timeout=10 --text="ROM hash <b>$ROMHASH</b> does not match" --title="Incorrect ROM file" --width=500 --width=200

--- a/soh/macosx/soh-macos.sh
+++ b/soh/macosx/soh-macos.sh
@@ -40,6 +40,10 @@ while [ ! -e "$DATA_SHARE/oot.otr" ]; do
 		export ROM=GC_NMQ_D;;
 	0227d7c0074f2d0ac935631990da8ec5914597b4)
 		export ROM=GC_NMQ_PAL_F;;
+	50bebedad9e0f10746a52b07239e47fa6c284d03)
+		export ROM=GC_MQ_D;;
+	079b855b943d6ad8bd1eb026c0ed169ecbdac7da
+		export ROM=GC_MQ_D;;	
 	*)
 		WRONGHASH="$(osascript -ss - "$ROMHASH" <<-EOF
 		display dialog "Incompatible ROM hash $ROMHASH" \

--- a/soh/macosx/soh-macos.sh
+++ b/soh/macosx/soh-macos.sh
@@ -42,7 +42,7 @@ while [ ! -e "$DATA_SHARE/oot.otr" ]; do
 		export ROM=GC_NMQ_PAL_F;;
 	50bebedad9e0f10746a52b07239e47fa6c284d03)
 		export ROM=GC_MQ_D;;
-	079b855b943d6ad8bd1eb026c0ed169ecbdac7da
+	079b855b943d6ad8bd1eb026c0ed169ecbdac7da)
 		export ROM=GC_MQ_D;;	
 	*)
 		WRONGHASH="$(osascript -ss - "$ROMHASH" <<-EOF


### PR DESCRIPTION
Previously the hash checks didn't include the new hashes for MQ support, so without compiling from source, you couldn't play MQ on Mac or Linux, this fixes this by adding in the new hashes