### PR TITLE
[#1675] Fix for business scrubs crashing on expensive scrub shuffle

### DIFF
--- a/soh/src/overlays/actors/ovl_En_Dns/z_en_dns.c
+++ b/soh/src/overlays/actors/ovl_En_Dns/z_en_dns.c
@@ -172,7 +172,7 @@ void EnDns_Init(Actor* thisx, GlobalContext* globalCtx) {
         s16 respawnData = gSaveContext.respawn[RESPAWN_MODE_RETURN].data & ((1 << 8) - 1);
         this->scrubIdentity = Randomizer_IdentifyScrub(globalCtx->sceneNum, this->actor.params, respawnData);
 
-        if (Randomizer_GetSettingValue(RSK_SHUFFLE_SCRUBS) == 1 || Randomizer_GetSettingValue(RSK_SHUFFLE_SCRUBS) == 3 && this->scrubIdentity.itemPrice != -1) {
+        if ((Randomizer_GetSettingValue(RSK_SHUFFLE_SCRUBS) == 1 || Randomizer_GetSettingValue(RSK_SHUFFLE_SCRUBS) == 3) && this->scrubIdentity.itemPrice != -1) {
             this->dnsItemEntry->itemPrice = this->scrubIdentity.itemPrice;
         }
 


### PR DESCRIPTION
So this did end up due to expensive scrub shuffle, but was not because we don't handle all expensive prices, which we do. It was due to a malformed condition, causing the itemPrice to be set to `-1` when it wasn't supposed to.

Resolves #1675 