### PR TITLE
Rando: Fix "Scrubsanity Off" using mysterious text

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizerTypes.h
+++ b/soh/soh/Enhancements/randomizer/randomizerTypes.h
@@ -1040,7 +1040,7 @@ typedef struct ScrubIdentity {
     RandomizerCheck randomizerCheck;
     GetItemID getItemId;
     int32_t itemPrice;
-    uint32_t isShuffled;
+    uint8_t isShuffled;
 } ScrubIdentity;
 
 typedef struct ShopItemIdentity {

--- a/soh/soh/Enhancements/randomizer/randomizerTypes.h
+++ b/soh/soh/Enhancements/randomizer/randomizerTypes.h
@@ -1040,7 +1040,7 @@ typedef struct ScrubIdentity {
     RandomizerCheck randomizerCheck;
     GetItemID getItemId;
     int32_t itemPrice;
-    bool isShuffled;
+    uint32_t isShuffled;
 } ScrubIdentity;
 
 typedef struct ShopItemIdentity {


### PR DESCRIPTION
Resolves https://github.com/HarbourMasters/Shipwright/issues/1664

It was using a bool for the property "isShuffled" which is used in C code but C code doesn't support bools. So it resolved as true even though it was supposed to be false.

Tested both shuffled and non shuffled scrubs when shuffling scrubs is set to off and tested scrubs that are normally not randomized with scrubshuffle set to on. Both scenarios work as expected now.