### PR TITLE
Fix navi colors in cosmetics editor

### DIFF
--- a/soh/soh/Enhancements/cosmetics/CosmeticsEditor.h
+++ b/soh/soh/Enhancements/cosmetics/CosmeticsEditor.h
@@ -73,8 +73,8 @@ static CosmeticsColorIndividual Navi_Npc_Inner = { "Navi NPC (Primary)", "Inner 
 static CosmeticsColorIndividual Navi_Npc_Outer = { "Navi NPC (Secondary)", "Outer color for Navi (when Navi fly around NPCs)", "gNavi_NPC_Outer", navi_npc_o_col, ImVec4(150, 150, 255, 255), false, false, false };
 static CosmeticsColorIndividual Navi_Enemy_Inner = { "Navi Enemy (Primary)", "Inner color for Navi (when Navi fly around Enemies or Bosses)", "gNavi_Enemy_Inner", navi_enemy_i_col, ImVec4(255, 255, 0, 255), false, false, false };
 static CosmeticsColorIndividual Navi_Enemy_Outer = { "Navi Enemy (Secondary)", "Outer color for Navi (when Navi fly around Enemies or Bosses)", "gNavi_Enemy_Outer", navi_enemy_o_col, ImVec4(220, 155, 0, 255), false, false, false };
-static CosmeticsColorIndividual Navi_Prop_Inner = { "Navi Enemy (Primary)", "Inner color for Navi (when Navi fly around props (signs etc))", "gNavi_Prop_Inner", navi_prop_i_col, ImVec4(0, 255, 0, 255), false, false, false };
-static CosmeticsColorIndividual Navi_Prop_Outer = { "Navi Enemy (Secondary)", "Outer color for Navi (when Navi fly around props (signs etc))", "gNavi_Prop_Outer", navi_prop_o_col, ImVec4(0, 255, 0, 255), false, false, false };
+static CosmeticsColorIndividual Navi_Prop_Inner = { "Navi Props (Primary)", "Inner color for Navi (when Navi fly around props (signs etc))", "gNavi_Prop_Inner", navi_prop_i_col, ImVec4(0, 255, 0, 255), false, false, false };
+static CosmeticsColorIndividual Navi_Prop_Outer = { "Navi Props (Secondary)", "Outer color for Navi (when Navi fly around props (signs etc))", "gNavi_Prop_Outer", navi_prop_o_col, ImVec4(0, 255, 0, 255), false, false, false };
 
 //Keese
 static CosmeticsColorIndividual Keese1_prim = { "Fire Primary color", "Affects the primary color of the Fire itself of the Keese", "gKeese1_Ef_Prim", Keese1_primcol, ImVec4(255, 255, 100, 255), true, false, false };

--- a/soh/src/code/z_actor.c
+++ b/soh/src/code/z_actor.c
@@ -335,8 +335,10 @@ void func_8002BE98(TargetContext* targetCtx, s32 actorCategory, GlobalContext* g
 
 void func_8002BF60(TargetContext* targetCtx, Actor* actor, s32 actorCategory, GlobalContext* globalCtx) {
     NaviColor* naviColor = &sNaviColorList[actorCategory];
+    Color_RGB8 customInnerNaviColor;
+    Color_RGB8 customOuterNaviColor;
 
-    if (CVar_GetS32("gUseNaviCol",0) != 1 ) {
+    if (!CVar_GetS32("gUseNaviCol",0)) {
         if (actorCategory == ACTORCAT_PLAYER) {
             naviColor->inner.r = 255; naviColor->inner.g = 255; naviColor->inner.b = 255;
             naviColor->outer.r = 0; naviColor->outer.g = 0; naviColor->outer.b = 255;
@@ -355,21 +357,27 @@ void func_8002BF60(TargetContext* targetCtx, Actor* actor, s32 actorCategory, Gl
         }
     } else {
         if (actorCategory == ACTORCAT_PLAYER) {
-            naviColor->inner = CVar_GetRGBA("gNavi_Idle_Inner", naviColor->inner);
-            naviColor->outer = CVar_GetRGBA("gNavi_Idle_Outer", naviColor->outer);
+            customInnerNaviColor = CVar_GetRGB("gNavi_Idle_Inner", (Color_RGB8){ 0, 0, 0 });
+            customOuterNaviColor = CVar_GetRGB("gNavi_Idle_Outer", (Color_RGB8){ 0, 0, 0 });
         }
         if (actorCategory == ACTORCAT_NPC) {
-            naviColor->inner = CVar_GetRGBA("gNavi_NPC_Inner", naviColor->inner);
-            naviColor->outer = CVar_GetRGBA("gNavi_NPC_Outer", naviColor->outer);
+            customInnerNaviColor = CVar_GetRGB("gNavi_NPC_Inner", (Color_RGB8){ 0, 0, 0 });
+            customOuterNaviColor = CVar_GetRGB("gNavi_NPC_Outer", (Color_RGB8){ 0, 0, 0 });
         }
         if (actorCategory == ACTORCAT_BOSS || actorCategory == ACTORCAT_ENEMY) {
-            naviColor->inner = CVar_GetRGBA("gNavi_Enemy_Inner", naviColor->inner);
-            naviColor->outer = CVar_GetRGBA("gNavi_Enemy_Outer", naviColor->outer);
+            customInnerNaviColor = CVar_GetRGB("gNavi_Enemy_Inner", (Color_RGB8){ 0, 0, 0 });
+            customOuterNaviColor = CVar_GetRGB("gNavi_Enemy_Outer", (Color_RGB8){ 0, 0, 0 });
         }
         if (actorCategory == ACTORCAT_PROP) {
-            naviColor->inner = CVar_GetRGBA("gNavi_Prop_Inner", naviColor->inner);
-            naviColor->outer = CVar_GetRGBA("gNavi_Prop_Outer", naviColor->outer);
+            customInnerNaviColor = CVar_GetRGB("gNavi_Prop_Inner", (Color_RGB8){ 0, 0, 0 });
+            customOuterNaviColor = CVar_GetRGB("gNavi_Prop_Outer", (Color_RGB8){ 0, 0, 0 });
         }
+        naviColor->inner.r = customInnerNaviColor.r;
+        naviColor->inner.g = customInnerNaviColor.g;
+        naviColor->inner.b = customInnerNaviColor.b;
+        naviColor->outer.r = customOuterNaviColor.r;
+        naviColor->outer.g = customOuterNaviColor.g;
+        naviColor->outer.b = customOuterNaviColor.b;
     }
     
     targetCtx->naviRefPos.x = actor->focus.pos.x;


### PR DESCRIPTION
Resolves https://github.com/HarbourMasters/Shipwright/issues/1642, https://github.com/HarbourMasters/Shipwright/issues/1643

It was overwriting the alpha channel while it didn't have any information about that in the CVar, so it set it to 0. 

Now it's setting just the RGB values and leaving the alpha channel alone.

Also fixes slight error in description for Navi's color when targeting props.