### PR TITLE
Galaxy

### DIFF
--- a/.github/workflows/apt-deps.txt
+++ b/.github/workflows/apt-deps.txt
@@ -1,0 +1,1 @@
+libsdl2-dev libsdl2-net-dev libpng-dev libglew-dev ninja-build 

--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -1,0 +1,246 @@
+name: generate-builds
+on:
+  push:
+  pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  extract-assets:
+    runs-on: [ self-hosted, asset-builder ]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Extract assets
+      run: |
+        cp ../../../ZELOOTD.z64 OTRExporter/baserom_non_mq.z64
+        cmake --no-warn-unused-cli -H. -Bbuild-cmake -GNinja -DCMAKE_BUILD_TYPE:STRING=Release
+        cmake --build build-cmake --target ExtractAssets --config Release
+        zip -r assets.zip soh/assets
+    - uses: actions/upload-artifact@v3
+      with:
+        name: assets
+        path: assets.zip
+        retention-days: 1
+  build-macos:
+    needs: extract-assets
+    runs-on: macos-12
+    steps:
+    - uses: actions/checkout@v2
+    - name: ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: ${{ runner.os }}-ccache
+    - name: Install gtar wrapper
+      run: |
+        sudo mv /usr/local/bin/gtar /usr/local/bin/gtar.orig
+        sudo cp .github/workflows//gtar /usr/local/bin/gtar
+        sudo chmod +x /usr/local/bin/gtar
+    - name: Cache MacPorts
+      id: cache-macports
+      uses: actions/cache@v2
+      with:
+        path: /opt/local/
+        key: ${{ runner.os }}-macports-${{ hashFiles('.github/workflows/macports-deps.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-macports-
+    - name: Install MacPorts (if necessary)
+      run: |
+        if [ -d /opt/local/ ]; then
+          echo "MacPorts already installed"
+        else
+          wget https://github.com/macports/macports-base/releases/download/v2.7.2/MacPorts-2.7.2-12-Monterey.pkg
+          sudo installer -pkg ./MacPorts-2.7.2-12-Monterey.pkg -target /
+        fi
+        echo "/opt/local/bin:/opt/local/sbin" >> $GITHUB_PATH
+    - name: Install dependencies
+      run: |
+        brew uninstall --ignore-dependencies libpng
+        sudo port install $(cat .github/workflows/macports-deps.txt)
+        brew install ninja
+    - name: Restore assets
+      uses: actions/download-artifact@v3
+      with:
+        name: assets
+    - name: Build SoH
+      run: |
+        unzip -o assets.zip
+
+        export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+        cmake --no-warn-unused-cli -H. -Bbuild-cmake -GNinja -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64"
+        cmake --build build-cmake --config Release --parallel 10
+        (cd build-cmake && cpack)
+
+        mv _packages/*.dmg SoH.dmg
+        mv README.md readme.txt
+    - name: Upload build
+      uses: actions/upload-artifact@v3
+      with:
+        name: soh-mac
+        path: |
+          SoH.dmg
+          readme.txt
+  build-linux:
+    needs: extract-assets
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y $(cat .github/workflows/apt-deps.txt)
+    - name: ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: ${{ runner.os }}-ccache
+    - name: Install latest SDL
+      run: |
+        export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+        wget https://www.libsdl.org/release/SDL2-2.24.1.tar.gz
+        tar -xzf SDL2-2.24.1.tar.gz
+        cd SDL2-2.24.1
+        ./configure
+        make -j 10
+        sudo make install
+    - name: Install latest SDL_net
+      run: |
+        export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+        wget https://www.libsdl.org/projects/SDL_net/release/SDL2_net-2.2.0.tar.gz
+        tar -xzf SDL2_net-2.2.0.tar.gz
+        cd SDL2_net-2.2.0
+        ./configure
+        make -j 10
+        sudo make install
+    - name: Restore assets
+      uses: actions/download-artifact@v3
+      with:
+        name: assets
+    - name: Build SoH
+      run: |
+        unzip -o assets.zip
+
+        export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+        cmake --no-warn-unused-cli -H. -Bbuild-cmake -GNinja -DCMAKE_BUILD_TYPE:STRING=Release
+        cmake --build build-cmake --target OTRGui -j3
+        cmake --build build-cmake --config Release -j3
+        (cd build-cmake && cpack -G External)
+
+        mv README.md readme.txt
+        mv build-cmake/*.appimage soh.appimage
+      env:
+        CC: gcc-10
+        CXX: g++-10
+    - name: Upload build
+      uses: actions/upload-artifact@v3
+      with:
+        name: soh-linux
+        path: |
+          soh.appimage
+          readme.txt
+  build-switch:
+    needs: extract-assets
+    runs-on: ubuntu-latest
+    container:
+      image: devkitpro/devkita64:latest
+    steps:
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y ninja-build
+    - uses: actions/checkout@v2
+    - name: ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: ${{ runner.os }}-switch-ccache
+    - name: Restore assets
+      uses: actions/download-artifact@v3
+      with:
+        name: assets
+    - name: Build SoH
+      run: |
+        unzip -o assets.zip
+
+        cmake -H. -Bbuild-switch -GNinja -DCMAKE_TOOLCHAIN_FILE=/opt/devkitpro/cmake/Switch.cmake -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache
+        cmake --build build-switch --target soh_nro -j3
+
+        mv build-switch/soh/*.nro soh.nro
+        mv README.md readme.txt
+    - name: Upload build
+      uses: actions/upload-artifact@v3
+      with:
+        name: soh-switch
+        path: |
+          soh.nro
+          readme.txt
+  build-wiiu:
+    needs: extract-assets
+    runs-on: ubuntu-latest
+    container:
+      image: devkitpro/devkitppc:latest
+    steps:
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y ninja-build
+    - uses: actions/checkout@v2
+    - name: ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: ${{ runner.os }}-wiiu-ccache
+    - name: Restore assets
+      uses: actions/download-artifact@v3
+      with:
+        name: assets
+    - name: Build SoH
+      run: |
+        unzip -o assets.zip
+
+        cmake -H. -Bbuild-wiiu -GNinja -DCMAKE_TOOLCHAIN_FILE=/opt/devkitpro/cmake/WiiU.cmake -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache
+        cmake --build build-wiiu --target soh_wuhb --config Release -j3
+
+        mv build-wiiu/soh/*.rpx soh.rpx
+        mv build-wiiu/soh/*.wuhb soh.wuhb
+        mv README.md readme.txt
+      env:
+        DEVKITPRO: /opt/devkitpro
+        DEVKITPPC: /opt/devkitpro/devkitPPC
+    - name: Upload build
+      uses: actions/upload-artifact@v3
+      with:
+        name: soh-wiiu
+        path: |
+          soh.rpx
+          soh.wuhb
+          readme.txt
+  build-windows:
+    needs: extract-assets
+    runs-on: windows-latest
+    steps:
+    - name: Install dependencies
+      run: |
+        choco install ninja
+        Remove-Item -Path "C:\ProgramData\Chocolatey\bin\ccache.exe" -Force
+    - uses: actions/checkout@v2
+    - name: ccache
+      uses: dcvz/ccache-action@27b9f33213c0079872f064f6b6ba0233dfa16ba2
+      with:
+        key: ${{ runner.os }}-ccache
+    - name: Restore assets
+      uses: actions/download-artifact@v3
+      with:
+        name: assets
+    - uses: ilammy/msvc-dev-cmd@v1
+    - name: Build SoH
+      run: |
+        7z x assets.zip -aoa
+
+        set $env:PATH="$env:USERPROFILE/.cargo/bin;$env:PATH"
+        cmake -S . -B build-windows -G Ninja -DCMAKE_MAKE_PROGRAM=ninja -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+        cmake --build build-windows --target OTRGui --config Release --parallel 10
+        cmake --build build-windows --config Release --parallel 10
+        cd build-windows
+        cpack -G ZIP
+    - name: Upload build
+      uses: actions/upload-artifact@v3
+      with:
+        name: soh-windows
+        path: _packages/*.zip

--- a/.github/workflows/gtar
+++ b/.github/workflows/gtar
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec sudo /usr/local/bin/gtar.orig "$@"

--- a/.github/workflows/macports-deps.txt
+++ b/.github/workflows/macports-deps.txt
@@ -1,0 +1,1 @@
+libsdl2 +universal libpng +universal glew +universal

--- a/README.md
+++ b/README.md
@@ -116,6 +116,13 @@ Official Discord: https://discord.com/invite/BtBmd55HVH
 
 Refer to the [building instructions](BUILDING.md) to compile SoH.
 
+## Getting CI to work on your fork
+
+The CI works via [Github Actions](https://github.com/features/actions) where we mostly make use of machines hosted by Github; except for the very first step of the CI process called "Extract assets". This steps extracts assets from the game file and generates an "assets" folder in `soh/`.
+
+To get this step working on your fork, you'll need to add a machine to your own repository as a self-hosted runner via "Settings > Actions > Runners" in your repository settings. If you're on macOS or Linux take a look at `macports-deps.txt` or `apt-deps.txt` to see the dependencies expected to be on your machine. For Windows, deps get installed as part of the CI process. To setup your runner as a service read the docs [here](https://docs.github.com/en/actions/hosting-your-own-runners/configuring-the-self-hosted-runner-application-as-a-service?platform=linux).
+
+
 ## Troubleshooting The Exporter
 - Confirm that you have an `/assets` folder filled with XMLs in the same directory as OTRGui.exe
 - Confirm that `zapd.exe` exists in the `/assets/extractor` folder


### PR DESCRIPTION
This PR moves our CI system to use Github Actions.

## Why
The main motivation driving this is being able to further scale. Leveraging Github Actions allows us to make use of their "free to open source" resources. This means we might be able to support more platforms or make use of matrices to perhaps build with different compilers for different platforms, or build and support variants.

### Other Benefits
- One eventual benefit might be to not have to pay for our current Jenkins master node.
- Integrated into the platform we're already using, making it easy to see CI runs
- Also, when more ports are supported, ports also won't have to compete for building time.

_Potential: If we find a better way to do assets, in theory any public fork of this repo will automatically have CI. Otherwise individual devs can add a machine to their forks to act as asset builders._

## Limits
What limits do we have when using Github Actions? Well, in theory it is free to use for any open source project (meaning the repository is public). But there are a few limits to know about:

- The number of concurrent builds is 20 and 5 concurrent macOS builds. _Better than we can currently do, but still good to know about_
- Artefacts can only be stored up to 90 days. _Again better than what we currently have, but a good to know_

## Machine Specs?
Are Github machines fast? No. They are actually quite weak compared to the top notch machines we have in Jenkins so builds take longer.. around 12-25 minutes (macOS and Windows take the longest).

However, as part of this effort I have added in a compiler cache (ccache) that makes builds 65%+ faster. The slowest builds taking up to 4 min or so, when healthy cache is available. Given the bandwidth this project gets, cache should usually be available for builds.

## Generating Assets
How does generating assets work? The workflow first generates assets (similar to what we currently do) and for that step and only that step, it uses our self hosted machines. Generating assets takes around 1 minute, making it pretty fast and unlikely to be a bottleneck. When this ships we will have three macOS machines acting as asset builders.

## Possible Migration Plan
The moment this is merged in it will begin to work and run on branches that contain these changes. Before this gets merged we should make sure we have at least 3 asset building machines in the organization. We can keep Jenkins running for branches that are not yet updated and for private forks (Ghostship).

## Cons
- Makes it harder to move away from Github (if we ever want to)
- Machines are technically slower (but mitigated with ccache)
- Tricker to do private repos (since its only free for open source)

