### PR TITLE
Fix skipping "get item" cutscene logic

### DIFF
--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -6246,23 +6246,21 @@ s32 func_8083E5A8(Player* this, GlobalContext* globalCtx) {
                     }
                 }
 
-                s32 drop = giEntry.objectId;
+                // Skip cutscenes from picking up items when they come from bushes/rocks/etc, but nowhere else.
+                uint8_t skipItemCutscene = CVar_GetS32("gFastDrops", 0) && interactedActor->id == ACTOR_EN_ITEM00 &&
+                                     interactedActor->params != 6 && interactedActor->params != 17;
 
-                if (gSaveContext.n64ddFlag || (globalCtx->sceneNum == SCENE_BOWLING) ||
-                    !(CVar_GetS32("gFastDrops", 0) &&
-                      ((drop == OBJECT_GI_BOMB_1) || (drop == OBJECT_GI_NUTS) || (drop == OBJECT_GI_STICK) ||
-                       (drop == OBJECT_GI_SEED) || (drop == OBJECT_GI_MAGICPOT) || (drop == OBJECT_GI_ARROW))) &&
-                        (Item_CheckObtainability(giEntry.itemId) == ITEM_NONE)) {
+                // Same as above but for rando. We need this specifically for rando because we need to be enable the cutscenes everywhere else in the game
+                // because the items are randomized and thus it's important to show the get item animation.
+                uint8_t skipItemCutsceneRando = gSaveContext.n64ddFlag &&
+                                                Item_CheckObtainability(giEntry.itemId) != ITEM_NONE &&
+                                                interactedActor->id == ACTOR_EN_ITEM00 &&
+                                                interactedActor->params != 6 && interactedActor->params != 17;
 
-                    if (gSaveContext.n64ddFlag &&
-                        ((interactedActor->id == ACTOR_EN_ITEM00 &&
-                          (interactedActor->params != 6 && interactedActor->params != 17)) ||
-                         (interactedActor->id == ACTOR_EN_KAREBABA || interactedActor->id == ACTOR_EN_DEKUBABA))) {
-                        func_8083E4C4(globalCtx, this, &giEntry);
-                        this->getItemId = GI_NONE;
-                        this->getItemEntry = (GetItemEntry)GET_ITEM_NONE;
-                        return 0;
-                    }
+                // Show cutscene when picking up a item that the player doesn't own yet.
+                // We want to ALWAYS show "get item animations" for items when they're randomized to account for
+                // randomized freestanding items etc, but we still don't want to show it every time you pick up a consumable from a pot/bush etc.
+                if ((globalCtx->sceneNum == SCENE_BOWLING || Item_CheckObtainability(giEntry.itemId) == ITEM_NONE || gSaveContext.n64ddFlag) && !skipItemCutscene && !skipItemCutsceneRando) {
 
                     func_808323B4(globalCtx, this);
                     func_8083AE40(this, giEntry.objectId);
@@ -6278,6 +6276,7 @@ s32 func_8083E5A8(Player* this, GlobalContext* globalCtx) {
                     return 1;
                 }
 
+                // Don't show cutscene when picking up an item
                 func_8083E4C4(globalCtx, this, &giEntry);
                 this->getItemId = GI_NONE;
                 this->getItemEntry = (GetItemEntry)GET_ITEM_NONE;


### PR DESCRIPTION
Resolves https://github.com/HarbourMasters/Shipwright/issues/1530

The logic for if the game should show the animation for getting an item was wrong on several counts. First of all, it skipped the cutscenes of drops from scrub merchants and the deku mask theatre when "Skip Pickup Messages" was enabled, causing either softlocks or generally strange behaviour.

Consumable drops were also skipped in rando regardless if the "Skip Pickup Messages" was on or off. 

This fixes all of that logic. That said, I've been staring at this for over an hour and I can't possible think of a cleaner way of writing these statements, so if someone wants to do a look-over it'd be greatly appreciated. It does atleast do what it's supposed to do now according to my testing.