### PR TITLE
Support for patching DLists outside of OTR

### DIFF
--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -706,7 +706,7 @@ typedef struct {
     Gfx instruction;
 } GfxPatch;
 
-std::map<std::string, std::map<std::string, GfxPatch>> originalGfx;
+std::unordered_map<std::string, std::unordered_map<std::string, GfxPatch>> originalGfx;
 
 // Attention! This is primarily for cosmetics & bug fixes. For things like mods and model replacement you should be using OTRs
 // instead (When that is available). Index can be found using the commented out section below.

--- a/soh/soh/OTRGlobals.h
+++ b/soh/soh/OTRGlobals.h
@@ -60,7 +60,8 @@ AnimationHeaderCommon* ResourceMgr_LoadAnimByName(const char* path);
 char* ResourceMgr_GetNameByCRC(uint64_t crc, char* alloc);
 Gfx* ResourceMgr_LoadGfxByCRC(uint64_t crc);
 Gfx* ResourceMgr_LoadGfxByName(const char* path);
-Gfx* ResourceMgr_PatchGfxByName(const char* path, int size);
+void ResourceMgr_PatchGfxByName(const char* path, const char* patchName, int index, Gfx instruction);
+void ResourceMgr_UnpatchGfxByName(const char* path, const char* patchName);
 char* ResourceMgr_LoadArrayByNameAsVec3s(const char* path);
 Vtx* ResourceMgr_LoadVtxByCRC(uint64_t crc);
 

--- a/soh/src/code/z_kankyo.c
+++ b/soh/src/code/z_kankyo.c
@@ -2290,10 +2290,10 @@ Color_RGB8 sSandstormEnvColors[] = {
     { 50, 40, 0 },
 };
 
-u16 hasPatchedSandstormRect = 0;
+u16 previousPatchedSandstormScreenSize = 0;
 
 void Environment_PatchSandstorm(GlobalContext* globalCtx) {
-    if (hasPatchedSandstormRect == ABS(OTRGetRectDimensionFromLeftEdge(0)) + ABS(OTRGetRectDimensionFromRightEdge(SCREEN_WIDTH))) {
+    if (previousPatchedSandstormScreenSize == ABS(OTRGetRectDimensionFromLeftEdge(0)) + ABS(OTRGetRectDimensionFromRightEdge(SCREEN_WIDTH))) {
         return;
     }
 
@@ -2305,7 +2305,7 @@ void Environment_PatchSandstorm(GlobalContext* globalCtx) {
     ResourceMgr_PatchGfxByName(gFieldSandstormDL, "gfxPatchSandstormRect1", 50, gfxPatchSandstormRect[1]);
     ResourceMgr_PatchGfxByName(gFieldSandstormDL, "gfxPatchSandstormRect2", 52, gfxPatchSandstormRect[2]);
 
-    hasPatchedSandstormRect = ABS(OTRGetRectDimensionFromLeftEdge(0)) + ABS(OTRGetRectDimensionFromRightEdge(SCREEN_WIDTH));
+    previousPatchedSandstormScreenSize = ABS(OTRGetRectDimensionFromLeftEdge(0)) + ABS(OTRGetRectDimensionFromRightEdge(SCREEN_WIDTH));
 }
 
 void Environment_DrawSandstorm(GlobalContext* globalCtx, u8 sandstormState) {

--- a/soh/src/code/z_kankyo.c
+++ b/soh/src/code/z_kankyo.c
@@ -2290,27 +2290,22 @@ Color_RGB8 sSandstormEnvColors[] = {
     { 50, 40, 0 },
 };
 
-Gfx* gFieldSandstormDL_Custom = NULL;
+u16 hasPatchedSandstormRect = 0;
 
 void Environment_PatchSandstorm(GlobalContext* globalCtx) {
-    if (gFieldSandstormDL_Custom) return;
-
-    gFieldSandstormDL_Custom = ResourceMgr_PatchGfxByName(gFieldSandstormDL, -3);
-
-    const Gfx gFSPatchDL[2] = { gsSPEndDisplayList() };
-    bool patched = false;
-    Gfx* cmd = gFieldSandstormDL_Custom;
-    int id = 0;
-
-    while (!patched) {
-        const uint32_t opcode = cmd->words.w0 >> 24;
-        if (opcode == G_TEXRECT) {
-            gFieldSandstormDL_Custom[id] = gFSPatchDL[0];
-            patched = true;
-        }
-        ++cmd;
-        id++;
+    if (hasPatchedSandstormRect == ABS(OTRGetRectDimensionFromLeftEdge(0)) + ABS(OTRGetRectDimensionFromRightEdge(SCREEN_WIDTH))) {
+        return;
     }
+
+    Gfx gfxPatchSandstormRect[] = {
+        gsSPWideTextureRectangle(OTRGetRectDimensionFromLeftEdge(0) << 2, 0,
+            OTRGetRectDimensionFromRightEdge(SCREEN_WIDTH) << 2, 0x03C0, G_TX_RENDERTILE, 0, 0, 0x008C, -0x008C),
+    };
+    ResourceMgr_PatchGfxByName(gFieldSandstormDL, "gfxPatchSandstormRect0", 48, gfxPatchSandstormRect[0]);
+    ResourceMgr_PatchGfxByName(gFieldSandstormDL, "gfxPatchSandstormRect1", 50, gfxPatchSandstormRect[1]);
+    ResourceMgr_PatchGfxByName(gFieldSandstormDL, "gfxPatchSandstormRect2", 52, gfxPatchSandstormRect[2]);
+
+    hasPatchedSandstormRect = ABS(OTRGetRectDimensionFromLeftEdge(0)) + ABS(OTRGetRectDimensionFromRightEdge(SCREEN_WIDTH));
 }
 
 void Environment_DrawSandstorm(GlobalContext* globalCtx, u8 sandstormState) {
@@ -2435,10 +2430,7 @@ void Environment_DrawSandstorm(GlobalContext* globalCtx, u8 sandstormState) {
                                 0xFFF - ((u32)sp92 % 0x1000), 0x100, 0x40));
     gDPSetTextureLUT(POLY_XLU_DISP++, G_TT_NONE);
 
-    gSPDisplayList(POLY_XLU_DISP++, gFieldSandstormDL_Custom);
-    gSPWideTextureRectangle(POLY_XLU_DISP++, OTRGetRectDimensionFromLeftEdge(0) << 2, 0,
-                            OTRGetRectDimensionFromRightEdge(SCREEN_WIDTH) << 2, 0x03C0, G_TX_RENDERTILE, 0, 0, 0x008C,
-                            -0x008C);
+    gSPDisplayList(POLY_XLU_DISP++, gFieldSandstormDL);
     CLOSE_DISPS(globalCtx->state.gfxCtx);
 
     D_8015FDB0 += (s32)sp98;


### PR DESCRIPTION
As listed in the comment for `ResourceMgr_PatchGfxByName`, this method of patching DList is primarily for bug fixes and cosmetic changes. Full Dlist replacement for mods and custom models will be supported by the OTR system.

Migrated sandstorm bug fix from #254 to use this new pattern.

Example of this being used on the mirror shield here: #1705 