### PR TITLE
[SteamDeck] Start fullscreen when in gamemode

### DIFF
--- a/libultraship/libultraship/Lib/Fast3D/gfx_sdl2.cpp
+++ b/libultraship/libultraship/Lib/Fast3D/gfx_sdl2.cpp
@@ -176,8 +176,7 @@ static void gfx_sdl_init(const char *game_name, bool start_in_fullscreen, uint32
 #ifndef __SWITCH__
     SDL_GL_GetDrawableSize(wnd, &window_width, &window_height);
 
-    bool steamDeckGameMode = (std::getenv("XDG_CURRENT_DESKTOP") != nullptr && std::string(std::getenv("XDG_CURRENT_DESKTOP")) == "gamescope");
-    if (start_in_fullscreen || steamDeckGameMode) {
+    if (start_in_fullscreen) {
         set_fullscreen(true, false);
     }
 #endif

--- a/libultraship/libultraship/Lib/Fast3D/gfx_sdl2.cpp
+++ b/libultraship/libultraship/Lib/Fast3D/gfx_sdl2.cpp
@@ -176,7 +176,8 @@ static void gfx_sdl_init(const char *game_name, bool start_in_fullscreen, uint32
 #ifndef __SWITCH__
     SDL_GL_GetDrawableSize(wnd, &window_width, &window_height);
 
-    if (start_in_fullscreen) {
+    bool steamDeckGameMode = (std::getenv("XDG_CURRENT_DESKTOP") != nullptr && std::string(std::getenv("XDG_CURRENT_DESKTOP")) == "gamescope");
+    if (start_in_fullscreen || steamDeckGameMode) {
         set_fullscreen(true, false);
     }
 #endif

--- a/libultraship/libultraship/Window.cpp
+++ b/libultraship/libultraship/Window.cpp
@@ -38,6 +38,8 @@
 #include "SwitchImpl.h"
 #elif defined(__WIIU__)
 #include "WiiUImpl.h"
+#elif defined(__linux__)
+#include <sys/utsname.h>
 #endif
 
 
@@ -286,7 +288,18 @@ namespace Ship {
         CreateDefaults();
         InitializeControlDeck();
 
-        bool steamDeckGameMode = std::getenv("XDG_CURRENT_DESKTOP") != nullptr && std::string(std::getenv("XDG_CURRENT_DESKTOP")) == "gamescope";
+        bool steamDeckGameMode = false;
+    #ifdef __linux__
+        struct utsname uts;
+        int err = uname(&uts);
+        if (err == 0) {
+            SPDLOG_TRACE("OS: {} {} {} {}", uts.sysname, uts.release, uts.version, uts.machine);
+            if (strcmp(uts.version, "SteamOS") == 0) {
+                steamDeckGameMode = std::getenv("XDG_CURRENT_DESKTOP") != nullptr && std::string(std::getenv("XDG_CURRENT_DESKTOP")) == "gamescope";
+            }
+        }
+    #endif
+
         bIsFullscreen = GetConfig()->getBool("Window.Fullscreen.Enabled", false) || steamDeckGameMode;
 
         if (bIsFullscreen) {

--- a/libultraship/libultraship/Window.cpp
+++ b/libultraship/libultraship/Window.cpp
@@ -38,10 +38,7 @@
 #include "SwitchImpl.h"
 #elif defined(__WIIU__)
 #include "WiiUImpl.h"
-#elif defined(__linux__)
-#include <sys/utsname.h>
 #endif
-
 
 #define LOAD_TEX(texPath) static_cast<Ship::Texture*>(Ship::Window::GetInstance()->GetResourceManager()->LoadResource(texPath).get());
 
@@ -290,12 +287,16 @@ namespace Ship {
 
         bool steamDeckGameMode = false;
     #ifdef __linux__
-        struct utsname uts;
-        int err = uname(&uts);
-        if (err == 0) {
-            SPDLOG_TRACE("OS: {} {} {} {}", uts.sysname, uts.release, uts.version, uts.machine);
-            if (strcmp(uts.version, "SteamOS") == 0) {
-                steamDeckGameMode = std::getenv("XDG_CURRENT_DESKTOP") != nullptr && std::string(std::getenv("XDG_CURRENT_DESKTOP")) == "gamescope";
+        std::ifstream osReleaseFile("/etc/os-release");
+        if (osReleaseFile.is_open()) {
+            std::string line;
+            while (std::getline(osReleaseFile, line)) {
+                if (line.find("VARIANT_ID") != std::string::npos) {
+                    if (line.find("steamdeck") != std::string::npos) {
+                        steamDeckGameMode = std::getenv("XDG_CURRENT_DESKTOP") != nullptr && std::string(std::getenv("XDG_CURRENT_DESKTOP")) == "gamescope";
+                    }
+                    break;
+                }
             }
         }
     #endif

--- a/libultraship/libultraship/Window.cpp
+++ b/libultraship/libultraship/Window.cpp
@@ -286,11 +286,12 @@ namespace Ship {
         CreateDefaults();
         InitializeControlDeck();
 
-        bIsFullscreen = GetConfig()->getBool("Window.Fullscreen.Enabled", false);
+        bool steamDeckGameMode = std::getenv("XDG_CURRENT_DESKTOP") != nullptr && std::string(std::getenv("XDG_CURRENT_DESKTOP")) == "gamescope";
+        bIsFullscreen = GetConfig()->getBool("Window.Fullscreen.Enabled", false) || steamDeckGameMode;
 
         if (bIsFullscreen) {
-            dwWidth = GetConfig()->getInt("Window.Fullscreen.Width", 1920);
-            dwHeight = GetConfig()->getInt("Window.Fullscreen.Height", 1080);
+            dwWidth = GetConfig()->getInt("Window.Fullscreen.Width", steamDeckGameMode ? 1280 : 1920);
+            dwHeight = GetConfig()->getInt("Window.Fullscreen.Height", steamDeckGameMode ? 800 : 1080);
         } else {
             dwWidth = GetConfig()->getInt("Window.Width", 640);
             dwHeight = GetConfig()->getInt("Window.Height", 480);


### PR DESCRIPTION
This makes sure to start the game in fullscreen mode when console is set to game mode. Currently we have a workaround that people must do for the game to start correctly

Verified on two Steam Decks