### PR TITLE
Fix debug building on Windows with new build.c file

### DIFF
--- a/soh/CMakeLists.txt
+++ b/soh/CMakeLists.txt
@@ -1953,7 +1953,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
 		TARGET ${PROJECT_NAME}
 		PRE_BUILD
 		COMMANDS
-		COMMAND   $<CONFIG:Debug> copy /b $<SHELL_PATH:${CMAKE_CURRENT_SOURCE_DIR}/>src\\boot\\build.c +,,
+		COMMAND   $<CONFIG:Debug> copy /b $<SHELL_PATH:${CMAKE_BINARY_DIR}/>build.c +,,
 	)
 endif()
 ################################################################################


### PR DESCRIPTION
The recent PR #1678 that changed the build.c file to be generated missed changing the prebuild command for debug on windows. Just needed to update the path to reference the new generated file now.

Will want this also brought into `develop` to fix building over there too.

~~Edit: Build error seems to be due to a missing CI/CD linux machine~~