### PR TITLE
Corrected inf entry label for Fado

### DIFF
--- a/soh/soh/Enhancements/debugger/debugSaveEditor.h
+++ b/soh/soh/Enhancements/debugger/debugSaveEditor.h
@@ -241,7 +241,7 @@ const std::vector<FlagTable> flagTables = {
         { 0xB7, "Spoke to Fado in Kokiri Forest as Child" },
         { 0xB8, "Spoke to Malon After Saving Ranch" },
         { 0xB9, "Spoke to Malon on Horseback" },
-        { 0xBC, "Spoke to Carpenter Boss by Tent" },
+        { 0xBC, "Fado requested Odd Potion" },
         { 0xC0, "Spoke to Fat Woman by Market Potion Shop" },
         { 0xC1, "Spoke to Fat Woman After Zelda's Escape" },
         { 0xC2, "Spoke to Burly Man About Talon Search" },


### PR DESCRIPTION
(infTable[11] & 0x1000) is used by Fado in z_en_ko.c and flagged when she requests to be given the Odd Potion after you present it to her. It has nothing to do with the Carpenter's Boss. This corrects that info in the save editor for Inf Flag 0xBC

![Fado1](https://user-images.githubusercontent.com/14804203/194689689-1cf44260-13e0-4be5-af4c-cc7dff945c11.png)
![Fado2](https://user-images.githubusercontent.com/14804203/194689699-d644239f-ac7e-4e80-8636-91897b27083f.png)
![Fado3](https://user-images.githubusercontent.com/14804203/194689702-460016e4-c8fc-4112-a0da-b13ed7bba003.png)
