### PR TITLE
[#1712] Reset fileNum on title screen and prevent save when fileNum == 0xFF

### DIFF
--- a/soh/src/code/z_play.c
+++ b/soh/src/code/z_play.c
@@ -2006,7 +2006,7 @@ s32 func_800C0DB4(GlobalContext* globalCtx, Vec3f* pos) {
 }
 
 void Gameplay_PerformSave(GlobalContext* globalCtx) {
-    if (globalCtx != NULL) {
+    if (globalCtx != NULL && gSaveContext.fileNum != 0xFF) {
         Gameplay_SaveSceneFlags(globalCtx);
         gSaveContext.savedSceneNum = globalCtx->sceneNum;
         if (gSaveContext.temporaryWeapon) {

--- a/soh/src/overlays/gamestates/ovl_opening/z_opening.c
+++ b/soh/src/overlays/gamestates/ovl_opening/z_opening.c
@@ -10,6 +10,7 @@ void Opening_SetupTitleScreen(OpeningContext* this) {
     gSaveContext.gameMode = 1;
     this->state.running = false;
     gSaveContext.linkAge = 0;
+    gSaveContext.fileNum = 0xFF;
     Sram_InitDebugSave();
     gSaveContext.cutsceneIndex = 0xFFF3;
     gSaveContext.sceneSetupIndex = 7;


### PR DESCRIPTION
Resolves #1712

The following line was already on the startup screen (with the nintendo logo) but that screen isn't revisited after dying
```cpp
gSaveContext.fileNum = 0xFF;
```

This also adds a condition to prevent attempting to save if the fileNum == `0xFF`, the SaveManager already checks for this, but checking higher up the chain to also prevent the `autosave` "Game Saved" overlay text