### PR TITLE
Fix "Mask Select in Inventory" cycling bottle contents when bottle duping

### DIFF
--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_item.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_item.c
@@ -381,7 +381,8 @@ void KaleidoScope_DrawItemSelect(GlobalContext* globalCtx) {
                             --INV_CONTENT(ITEM_TRADE_CHILD);
                         } else if ((pauseCtx->stickRelX < -30 || pauseCtx->stickRelX > 30 || pauseCtx->stickRelY < -30 || pauseCtx->stickRelY > 30) ||
                                    dpad && CHECK_BTN_ANY(input->press.button, BTN_DUP | BTN_DDOWN | BTN_DLEFT | BTN_DRIGHT)) {
-                            if (INV_CONTENT(ITEM_TRADE_CHILD) == ITEM_LETTER_ZELDA) {
+                            // Change to keaton mask if no mask is in child trade slot. Catches Zelda's letter and bottle duping over this slot.
+                            if (INV_CONTENT(ITEM_TRADE_CHILD) < ITEM_MASK_KEATON || INV_CONTENT(ITEM_TRADE_CHILD) > ITEM_MASK_TRUTH) {
                                 INV_CONTENT(ITEM_TRADE_CHILD) = ITEM_MASK_KEATON;
                             } else {
                                 INV_CONTENT(ITEM_TRADE_CHILD) ^= ITEM_MASK_KEATON ^ ITEM_MASK_TRUTH;


### PR DESCRIPTION
Mask select in inventory is just cycling through item ID's. I added a conditional for Zelda's Letter before so it would still swap to Keaton Mask when swapping away from letter, but that didn't catch any other item in that slot (like bottles when duping a bottle over the child trade item slot). This now just checks for literally any item that's not a mask.