### PR TITLE
Fix Ruto softlock with fast text (fixes #96)

### DIFF
--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -1252,7 +1252,7 @@ namespace GameMenuBar {
                 UIWidgets::Tooltip("The Kokiri are mystical beings that fade into view when approached\nEnabling this will remove their draw distance");
             }
             UIWidgets::PaddedEnhancementCheckbox("Skip Text", "gSkipText", true, false);
-            UIWidgets::Tooltip("Holding down B skips text\nKnown to cause a cutscene softlock in Water Temple\nSoftlock can be fixed by pressing D-Right in Debug mode");
+            UIWidgets::Tooltip("Holding down B skips text");
             UIWidgets::PaddedEnhancementCheckbox("Free Camera", "gFreeCamera", true, false);
             UIWidgets::Tooltip("Enables camera control\nNote: You must remap C buttons off of the right stick in the controller config menu, and map the camera stick to the right stick.");
 

--- a/soh/src/overlays/actors/ovl_En_Ru2/z_en_ru2.c
+++ b/soh/src/overlays/actors/ovl_En_Ru2/z_en_ru2.c
@@ -634,13 +634,13 @@ s32 func_80AF383C(EnRu2* this, GlobalContext* globalCtx) {
 void func_80AF3878(EnRu2* this, GlobalContext* globalCtx) {
     if (func_80AF383C(this, globalCtx) && !Gameplay_InCsMode(globalCtx)) {
         this->action = 16;
-        OnePointCutscene_Init(globalCtx, 3130, -99, &this->actor, MAIN_CAM);
+        this->subCamId = OnePointCutscene_Init(globalCtx, 3130, -99, &this->actor, MAIN_CAM);
     }
 }
 
 void func_80AF38D0(EnRu2* this, GlobalContext* globalCtx) {
     this->action = 16;
-    OnePointCutscene_Init(globalCtx, 3130, -99, &this->actor, MAIN_CAM);
+    this->subCamId = OnePointCutscene_Init(globalCtx, 3130, -99, &this->actor, MAIN_CAM);
 }
 
 void func_80AF390C(EnRu2* this, GlobalContext* globalCtx) {
@@ -703,6 +703,7 @@ void func_80AF3ADC(EnRu2* this, GlobalContext* globalCtx) {
 void func_80AF3B74(EnRu2* this, GlobalContext* globalCtx) {
     if (this->unk_2C0 > ((((u16)(kREG(3) + 0x28)) + ((u16)(kREG(2) + 0x96))) & 0xFFFF)) {
         Actor_Kill(&this->actor);
+        OnePointCutscene_EndCutscene(globalCtx, this->subCamId);
     }
 }
 
@@ -789,6 +790,7 @@ void EnRu2_Init(Actor* thisx, GlobalContext* globalCtx) {
 
     this->unk_2C2 = 0;
     this->unk_2C3 = TEXT_STATE_DONE_FADING;
+    this->subCamId = 0;
 }
 
 void func_80AF3F14(EnRu2* this, GlobalContext* globalCtx) {

--- a/soh/src/overlays/actors/ovl_En_Ru2/z_en_ru2.h
+++ b/soh/src/overlays/actors/ovl_En_Ru2/z_en_ru2.h
@@ -27,6 +27,7 @@ typedef struct EnRu2 {
     /* 0x02C3 */ u8 unk_2C3;
     /* 0x02C4 */ f32 unk_2C4;
     /* 0x02C8 */ ColliderCylinder collider;
+    /* 0x02C8 */ s16 subCamId;
 } EnRu2; // size = 0x0314
 
 #endif


### PR DESCRIPTION
#96 
The softlock is caused by how Ruto controls the cutscene. She watched for the ends of the textboxes and trigger the cutscene to advance after specific ones. However, Ruto can not see these ends because the state of the textbox is updating too frequently. Even when it's slowed down enough, however, the cutscene has waits in the middle. Ruto ends up sending multiple trigger during the wait and they get dropped, leading the cutscene to be eternally waiting.

The fix I choose is to explicitly end the cutscene when Ruto is deleted. This should be safe, as nothing happens if it is already over and there has not been time for another to start.