### PR TITLE
Fix: Pickup item cutscene logic fix

### DIFF
--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -2484,13 +2484,6 @@ u8 Item_CheckObtainability(u8 item) {
         } else {
             return ITEM_NONE;
         }
-    } else if ( gSaveContext.n64ddFlag &&
-        ((item >= RG_GERUDO_FORTRESS_SMALL_KEY) && (item <= RG_GANONS_CASTLE_SMALL_KEY) ||
-        (item >= RG_FOREST_TEMPLE_BOSS_KEY) && (item <= RG_GANONS_CASTLE_BOSS_KEY) ||
-        (item >= RG_DEKU_TREE_MAP) && (item <= RG_ICE_CAVERN_MAP) ||
-        (item >= RG_DEKU_TREE_COMPASS) && (item <= RG_ICE_CAVERN_COMPASS))
-    ) {
-        return ITEM_NONE;
     } else if ((item == ITEM_KEY_BOSS) || (item == ITEM_COMPASS) || (item == ITEM_DUNGEON_MAP)) {
         return ITEM_NONE;
     } else if (item == ITEM_KEY_SMALL) {

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -6246,21 +6246,19 @@ s32 func_8083E5A8(Player* this, GlobalContext* globalCtx) {
                     }
                 }
 
-                // Skip cutscenes from picking up items when they come from bushes/rocks/etc, but nowhere else.
-                uint8_t skipItemCutscene = CVar_GetS32("gFastDrops", 0) && interactedActor->id == ACTOR_EN_ITEM00 &&
-                                     interactedActor->params != 6 && interactedActor->params != 17;
+                // Only skip cutscenes for drops when they're items/consumables from bushes/rocks/enemies
+                uint8_t isDropToSkip = (interactedActor->id == ACTOR_EN_ITEM00 && interactedActor->params != 6 && interactedActor->params != 17) || 
+                                    interactedActor->id == ACTOR_EN_KAREBABA || 
+                                    interactedActor->id == ACTOR_EN_DEKUBABA;
 
-                // Same as above but for rando. We need this specifically for rando because we need to be enable the cutscenes everywhere else in the game
-                // because the items are randomized and thus it's important to show the get item animation.
-                uint8_t skipItemCutsceneRando = gSaveContext.n64ddFlag &&
-                                                Item_CheckObtainability(giEntry.itemId) != ITEM_NONE &&
-                                                ((interactedActor->id == ACTOR_EN_ITEM00 &&
-                                                interactedActor->params != 6 && interactedActor->params != 17) || 
-                                                interactedActor->id == ACTOR_EN_KAREBABA || interactedActor->id == ACTOR_EN_DEKUBABA);
+                // Skip cutscenes from picking up consumables with "Fast Pickup Text" enabled, even when the player never picked it up before.
+                uint8_t skipItemCutscene = CVar_GetS32("gFastDrops", 0) && isDropToSkip;
 
-                // Show cutscene when picking up a item that the player doesn't own yet.
-                // We want to ALWAYS show "get item animations" for items when they're randomized to account for
-                // randomized freestanding items etc, but we still don't want to show it every time you pick up a consumable from a pot/bush etc.
+                // Same as above but for rando. Rando is different because we want to enable cutscenes for items that the player already has because
+                // those items could be a randomized item coming from scrubs, freestanding PoH's and keys.
+                uint8_t skipItemCutsceneRando = gSaveContext.n64ddFlag && Item_CheckObtainability(giEntry.itemId) != ITEM_NONE && isDropToSkip;
+
+                // Show cutscene when picking up a item that the player doesn't own yet or hasn't picked up before yet.
                 if ((globalCtx->sceneNum == SCENE_BOWLING || Item_CheckObtainability(giEntry.itemId) == ITEM_NONE || gSaveContext.n64ddFlag) && !skipItemCutscene && !skipItemCutsceneRando) {
 
                     func_808323B4(globalCtx, this);

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -6256,7 +6256,7 @@ s32 func_8083E5A8(Player* this, GlobalContext* globalCtx) {
                                                 Item_CheckObtainability(giEntry.itemId) != ITEM_NONE &&
                                                 ((interactedActor->id == ACTOR_EN_ITEM00 &&
                                                 interactedActor->params != 6 && interactedActor->params != 17) || 
-                                                (interactedActor->id == ACTOR_EN_KAREBABA || interactedActor->id == ACTOR_EN_DEKUBABA));
+                                                interactedActor->id == ACTOR_EN_KAREBABA || interactedActor->id == ACTOR_EN_DEKUBABA);
 
                 // Show cutscene when picking up a item that the player doesn't own yet.
                 // We want to ALWAYS show "get item animations" for items when they're randomized to account for

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -6254,8 +6254,9 @@ s32 func_8083E5A8(Player* this, GlobalContext* globalCtx) {
                 // because the items are randomized and thus it's important to show the get item animation.
                 uint8_t skipItemCutsceneRando = gSaveContext.n64ddFlag &&
                                                 Item_CheckObtainability(giEntry.itemId) != ITEM_NONE &&
-                                                interactedActor->id == ACTOR_EN_ITEM00 &&
-                                                interactedActor->params != 6 && interactedActor->params != 17;
+                                                ((interactedActor->id == ACTOR_EN_ITEM00 &&
+                                                interactedActor->params != 6 && interactedActor->params != 17) || 
+                                                (interactedActor->id == ACTOR_EN_KAREBABA || interactedActor->id == ACTOR_EN_DEKUBABA));
 
                 // Show cutscene when picking up a item that the player doesn't own yet.
                 // We want to ALWAYS show "get item animations" for items when they're randomized to account for


### PR DESCRIPTION
Resolves bug introduced by https://github.com/HarbourMasters/Shipwright/pull/1692 and https://github.com/HarbourMasters/Shipwright/issues/1734.

Turns out the sticks from the deku baba's aren't item00, and I missed the check that was there before my own changes. This meant that in rando, picking up sticks from a deku baba was showing the "get item" animation every time you picked up a stick from them. This fixes that.

On top of that, there was a check in `Item_CheckObtainability()` for keys and compasses, but those IDs aligned with slingshot seeds, so it was returning ITEM_NONE even when the player already picked up the seeds before. So that meant the cutscene would always play in rando.

I've looked into if removing these from `Item_CheckObtainability()`, but this function is only used in vanilla functions for scrubs and shops (which don't check for keys/maps/compasses), and some functions in z_player.c. The functions in z_player.c are either for the pick-up item cutscene logic which this PR already addresses, and seemingly some functions that decide if a chest should give out a blue rupee.

That said, I still can't say with 100% certainty I understand what's happening in the other functions in z_player.c or why they are there or if they can cause issues. I'm still looking into that, but initial testing with a rando-specific key in a chest seems to work fine.