### PR TITLE
Fix Cutscene Lighting (fixes #68, #33, and the goddess cutscene)

### DIFF
--- a/soh/include/z64cutscene.h
+++ b/soh/include/z64cutscene.h
@@ -38,8 +38,7 @@ typedef struct {
 } CsCmdBase; // size = 0x6
 
 typedef struct {
-    /* 0x00 */ u8  unk_00;
-    /* 0x01 */ u8  setting;
+    /* 0x00 */ u16 setting;
     /* 0x02 */ u16 startFrame;
     /* 0x04 */ u16 endFrame;
 } CsCmdEnvLighting; // size = 0x6


### PR DESCRIPTION
#68 #33
The cutscene lighting command has an index into the array of lighting settings. During export, this is treated as a halfword. However, the struct has it as two u8s. This creates an endian issue where the setting in the parsed struct is only the upper half of the exported value. This is fine on the n64, where it's actually the lower half. Indeed, it may actually only be a u8 since I assume the struct is the way it is to match in decomp. Luckily, because the other byte is unused and always 0, it's fine to treat it as a halfword.