### PR TITLE
When testing if an animation is new, make sure we are using the loaded file pointers (partially fixes #161)

### DIFF
--- a/soh/src/code/z_skelanime.c
+++ b/soh/src/code/z_skelanime.c
@@ -1242,8 +1242,12 @@ void LinkAnimation_Change(GlobalContext* globalCtx, SkelAnime* skelAnime, LinkAn
     if (ResourceMgr_OTRSigCheck(animation) != 0)
         animation = ResourceMgr_LoadAnimByName(animation);
 
+    AnimationHeader* currentAnimation = (AnimationHeader*)skelAnime->animation;
+    if (ResourceMgr_OTRSigCheck(currentAnimation) != 0)
+        currentAnimation = ResourceMgr_LoadAnimByName(currentAnimation);
+
     skelAnime->mode = mode;
-    if ((morphFrames != 0.0f) && ((animation != skelAnime->animation) || (startFrame != skelAnime->curFrame))) {
+    if ((morphFrames != 0.0f) && ((animation != currentAnimation) || (startFrame != skelAnime->curFrame))) {
         if (morphFrames < 0) {
             LinkAnimation_SetUpdateFunction(skelAnime);
             SkelAnime_CopyFrameTable(skelAnime, skelAnime->morphTable, skelAnime->jointTable);
@@ -1687,8 +1691,17 @@ s32 SkelAnime_Once(SkelAnime* skelAnime) {
  */
 void Animation_ChangeImpl(SkelAnime* skelAnime, AnimationHeader* animation, f32 playSpeed, f32 startFrame, f32 endFrame,
                           u8 mode, f32 morphFrames, s8 taper) {
+    LinkAnimationHeader* ogAnim = animation;
+
+    if (ResourceMgr_OTRSigCheck(animation) != 0)
+        animation = ResourceMgr_LoadAnimByName(animation);
+
+    AnimationHeader* currentAnimation = (AnimationHeader*)skelAnime->animation;
+    if (ResourceMgr_OTRSigCheck(currentAnimation) != 0)
+        currentAnimation = ResourceMgr_LoadAnimByName(currentAnimation);
+
     skelAnime->mode = mode;
-    if ((morphFrames != 0.0f) && ((animation != skelAnime->animation) || (startFrame != skelAnime->curFrame))) {
+    if ((morphFrames != 0.0f) && ((animation != currentAnimation) || (startFrame != skelAnime->curFrame))) {
         if (morphFrames < 0) {
             SkelAnime_SetUpdate(skelAnime);
             SkelAnime_CopyFrameTable(skelAnime, skelAnime->morphTable, skelAnime->jointTable);
@@ -1710,7 +1723,7 @@ void Animation_ChangeImpl(SkelAnime* skelAnime, AnimationHeader* animation, f32 
         skelAnime->morphWeight = 0.0f;
     }
 
-    skelAnime->animation = animation;
+    skelAnime->animation = ogAnim;
     skelAnime->startFrame = startFrame;
     skelAnime->endFrame = endFrame;
     skelAnime->animLength = Animation_GetLength(animation);

--- a/soh/src/overlays/actors/ovl_En_Go2/z_en_go2.c
+++ b/soh/src/overlays/actors/ovl_En_Go2/z_en_go2.c
@@ -142,7 +142,6 @@ typedef enum {
     /* 10 */ ENGO2_ANIM_10,
     /* 11 */ ENGO2_ANIM_11,
     /* 12 */ ENGO2_ANIM_12,
-    /* 13 */ ENGO2_ANIM_13, // Added to fix spinning goron issue for biggoron
 } EnGo2Animation;
 
 static AnimationInfo sAnimationInfo[] = {
@@ -152,7 +151,7 @@ static AnimationInfo sAnimationInfo[] = {
     { &gGoronAnim_002D80, 1.0f, 0.0f, -1.0f, 0x02, -8.0f }, { &gGoronAnim_00161C, 1.0f, 0.0f, -1.0f, 0x00, -8.0f },
     { &gGoronAnim_001A00, 1.0f, 0.0f, -1.0f, 0x00, -8.0f }, { &gGoronAnim_0021D0, 1.0f, 0.0f, -1.0f, 0x00, -8.0f },
     { &gGoronAnim_004930, 0.0f, 0.0f, -1.0f, 0x01, -8.0f }, { &gGoronAnim_000750, 1.0f, 0.0f, -1.0f, 0x00, -8.0f },
-    { &gGoronAnim_000D5C, 1.0f, 0.0f, -1.0f, 0x00, -8.0f }, { &gGoronAnim_004930, 0.0f, 1.0f, -1.0f, 0x01,  0.0f },
+    { &gGoronAnim_000D5C, 1.0f, 0.0f, -1.0f, 0x00, -8.0f },
 };
 
 static EnGo2DustEffectData sDustEffectData[2][4] = {
@@ -1349,6 +1348,11 @@ void EnGo2_RollingAnimation(EnGo2* this, GlobalContext* globalCtx) {
 }
 
 void EnGo2_WakeUp(EnGo2* this, GlobalContext* globalCtx) {
+    if (CVar_GetS32("gUnfixGoronSpin", 0)) {
+        // Trick SkelAnime into thinking the current animation is changing so that it morphs between the same position,
+        // making the goron do a spin
+        this->skelAnime.animation = NULL;
+    }
     if (this->skelAnime.playSpeed == 0.0f) {
         if ((this->actor.params & 0x1F) != GORON_DMT_BIGGORON) {
             Audio_PlayActorSound2(&this->actor, NA_SE_EN_GOLON_WAKE_UP);
@@ -1358,25 +1362,10 @@ void EnGo2_WakeUp(EnGo2* this, GlobalContext* globalCtx) {
     }
     if ((this->actor.params & 0x1F) == GORON_DMT_BIGGORON) {
         OnePointCutscene_Init(globalCtx, 4200, -99, &this->actor, MAIN_CAM);
-        // There is an issue interpolating between ENGO2_ANIM_0 and ENGO2_ANIM_1/10, the goron
-        // is technically in the same position at the end of ANIM_0 and beginning of ANIM_1/10
-        // but something isn't getting translated correctly causing the 360 degree spin before
-        // then continuing the wake up animation like normal. One solution is to use ANIM_0
-        // which uses the same frame data as ANIM_1/10 but no morph frames, but only when the
-        // current animation frame is at 0, meaning no morphing is necessary anyway.
-        // ANIM_13 is ANIM_0 but with the startFrame and mode adjusted for biggoron.
-        if (this->skelAnime.curFrame == 0.0f && !CVar_GetS32("gUnfixGoronSpin", 0)) {
-            Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENGO2_ANIM_13);
-        } else {
-            Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENGO2_ANIM_10);
-        }
+        Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENGO2_ANIM_10);
         this->skelAnime.playSpeed = 0.5f;
     } else {
-        if (this->skelAnime.curFrame == 0.0f && !CVar_GetS32("gUnfixGoronSpin", 0)) {
-            Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENGO2_ANIM_0);
-        } else {
-            Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENGO2_ANIM_1);
-        }
+        Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENGO2_ANIM_1);
         this->skelAnime.playSpeed = 1.0f;
     }
     this->actionFunc = func_80A46B40;


### PR DESCRIPTION
#161
The `SkelAnime` struct contains a pointer to the animation it is currently playing. This is used to check if the animation it is asked to play next is new or not. We are intentionally keeping it a pointer to the OTR filepath, but the check sometimes has the new animation be a pointer to the loaded file. This means that it thinks the animation is new and morphs between them. This PR fixes it by making sure both files are loaded and comparing those pointers.

This fixes the scrubs visibly hiding. They are still visible for a frame beforehand, but this error is present in the base game as well. The other half of #161, the scrubs not going down into the ground after showing the skull mask, still happens, but I am not sure if that is vanilla behavior or not.

This PR also fixes the root cause of goron spin. I removed the previous fix and have a new implementation of `gUnfixGoronSpin`. Spinners rejoice!

...but will this fix Ganon crash? 👀