### PR TITLE
Restore save confirmation screen when saving and in game over (N64)

### DIFF
--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -312,8 +312,8 @@ namespace GameMenuBar {
 
         // Restore old Gold Skulltula cutscene
         CVar_SetS32("gGsCutscene", 0);
-        // Restore save confirmation
-        CVar_SetS32("gSaveConfirmation", 0);
+        // Skip save confirmation
+        CVar_SetS32("gSkipSaveConfirmation", 0);
         // Autosave
         CVar_SetS32("gAutosave", 0);
 
@@ -380,8 +380,8 @@ namespace GameMenuBar {
         CVar_SetS32("gN64WeirdFrames", 1);
         // Bombchus out of bounds
         CVar_SetS32("gBombchusOOB", 1);
-        // Restore save confirmation
-        CVar_SetS32("gSaveConfirmation", 1);
+        // Skip save confirmation
+        CVar_SetS32("gSkipSaveConfirmation", 1);
     }
 
     void applyEnhancementPresetEnhanced(void) {
@@ -770,6 +770,8 @@ namespace GameMenuBar {
                     UIWidgets::PaddedEnhancementCheckbox("Remember Save Location", "gRememberSaveLocation", true, false);
                     UIWidgets::Tooltip("When loading a save, places Link at the last entrance he went through.\n"
                             "This doesn't work if the save was made in a grotto.");
+                    UIWidgets::PaddedEnhancementCheckbox("Skip save confirmation", "gSkipSaveConfirmation");
+                    UIWidgets::Tooltip("Skip the \"Game saved.\" confirmation screen");
                     ImGui::EndMenu();
                 }
 
@@ -1103,8 +1105,6 @@ namespace GameMenuBar {
                 UIWidgets::PaddedEnhancementCheckbox("Bombchus out of bounds", "gBombchusOOB", true, false);
                 UIWidgets::Tooltip("Allows bombchus to explode out of bounds\nSimilar to GameCube and Wii VC");
                 UIWidgets::PaddedEnhancementCheckbox("Restore old Gold Skulltula cutscene", "gGsCutscene", true, false);
-                UIWidgets::EnhancementCheckbox("Restore save confirmation", "gSaveConfirmation");
-                UIWidgets::Tooltip("Restores the N64 save confirmation screen");
 
                 ImGui::EndMenu();
             }

--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -312,6 +312,8 @@ namespace GameMenuBar {
 
         // Restore old Gold Skulltula cutscene
         CVar_SetS32("gGsCutscene", 0);
+        // Restore save confirmation
+        CVar_SetS32("gSaveConfirmation", 0);
         // Autosave
         CVar_SetS32("gAutosave", 0);
 
@@ -378,6 +380,8 @@ namespace GameMenuBar {
         CVar_SetS32("gN64WeirdFrames", 1);
         // Bombchus out of bounds
         CVar_SetS32("gBombchusOOB", 1);
+        // Restore save confirmation
+        CVar_SetS32("gSaveConfirmation", 1);
     }
 
     void applyEnhancementPresetEnhanced(void) {
@@ -1099,6 +1103,8 @@ namespace GameMenuBar {
                 UIWidgets::PaddedEnhancementCheckbox("Bombchus out of bounds", "gBombchusOOB", true, false);
                 UIWidgets::Tooltip("Allows bombchus to explode out of bounds\nSimilar to GameCube and Wii VC");
                 UIWidgets::PaddedEnhancementCheckbox("Restore old Gold Skulltula cutscene", "gGsCutscene", true, false);
+                UIWidgets::EnhancementCheckbox("Restore save confirmation", "gSaveConfirmation");
+                UIWidgets::Tooltip("Restores the N64 save confirmation screen");
 
                 ImGui::EndMenu();
             }

--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -770,7 +770,7 @@ namespace GameMenuBar {
                     UIWidgets::PaddedEnhancementCheckbox("Remember Save Location", "gRememberSaveLocation", true, false);
                     UIWidgets::Tooltip("When loading a save, places Link at the last entrance he went through.\n"
                             "This doesn't work if the save was made in a grotto.");
-                    UIWidgets::PaddedEnhancementCheckbox("Skip save confirmation", "gSkipSaveConfirmation");
+                    UIWidgets::PaddedEnhancementCheckbox("Skip save confirmation", "gSkipSaveConfirmation", true, false);
                     UIWidgets::Tooltip("Skip the \"Game saved.\" confirmation screen");
                     ImGui::EndMenu();
                 }

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
@@ -1528,7 +1528,7 @@ void KaleidoScope_DrawPages(GlobalContext* globalCtx, GraphicsContext* gfxCtx) {
             POLY_KAL_DISP =
                 KaleidoScope_QuadTextureIA8(POLY_KAL_DISP, sPromptChoiceTexs[gSaveContext.language][1], 48, 16, 16);
         } else if (((pauseCtx->state == 7 && pauseCtx->unk_1EC >= 4) || pauseCtx->state == 0xF) &&
-                   CVar_GetS32("gSaveConfirmation", 0)) {
+                   !CVar_GetS32("gSkipSaveConfirmation", 0)) {
             POLY_KAL_DISP =
                 KaleidoScope_QuadTextureIA8(POLY_KAL_DISP, sSaveConfirmationTexs[gSaveContext.language], 152, 16, 0);
         } else if ((pauseCtx->state != 7) || (pauseCtx->unk_1EC < 4)) {
@@ -3878,11 +3878,7 @@ void KaleidoScope_Update(GlobalContext* globalCtx)
                                                    &D_801333E8);
                             Gameplay_PerformSave(globalCtx);
                             pauseCtx->unk_1EC = 4;
-                            if (CVar_GetS32("gSaveConfirmation", 0)) {
-                                D_8082B25C = 90; // 3 secs
-                            } else {
-                                D_8082B25C = 3;
-                            }
+                            D_8082B25C = CVar_GetS32("gSkipSaveConfirmation", 0) ? 3 /* 0.1 sec */ : 90 /* 3 secs */;
                         }
                     } else if (CHECK_BTN_ALL(input->press.button, BTN_START) ||
                                CHECK_BTN_ALL(input->press.button, BTN_B)) {
@@ -4126,11 +4122,7 @@ void KaleidoScope_Update(GlobalContext* globalCtx)
                     gSaveContext.savedSceneNum = globalCtx->sceneNum;
                     Save_SaveFile();
                     pauseCtx->state = 0xF;
-                    if (CVar_GetS32("gSaveConfirmation", 0)) {
-                        D_8082B25C = 90; // 3 secs
-                    } else {
-                        D_8082B25C = 3;
-                    }
+                    D_8082B25C = CVar_GetS32("gSkipSaveConfirmation", 0) ? 3 /* 0.1 sec */ : 90 /* 3 secs */;
                 }
             }
             break;

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
@@ -3879,7 +3879,7 @@ void KaleidoScope_Update(GlobalContext* globalCtx)
                             Gameplay_PerformSave(globalCtx);
                             pauseCtx->unk_1EC = 4;
                             if (CVar_GetS32("gSaveConfirmation", 0)) {
-                                D_8082B25C = 80; // 3 secs
+                                D_8082B25C = 90; // 3 secs
                             } else {
                                 D_8082B25C = 3;
                             }
@@ -4127,7 +4127,7 @@ void KaleidoScope_Update(GlobalContext* globalCtx)
                     Save_SaveFile();
                     pauseCtx->state = 0xF;
                     if (CVar_GetS32("gSaveConfirmation", 0)) {
-                        D_8082B25C = 80; // 3 secs
+                        D_8082B25C = 90; // 3 secs
                     } else {
                         D_8082B25C = 3;
                     }

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
@@ -1527,6 +1527,10 @@ void KaleidoScope_DrawPages(GlobalContext* globalCtx, GraphicsContext* gfxCtx) {
 
             POLY_KAL_DISP =
                 KaleidoScope_QuadTextureIA8(POLY_KAL_DISP, sPromptChoiceTexs[gSaveContext.language][1], 48, 16, 16);
+        } else if (((pauseCtx->state == 7 && pauseCtx->unk_1EC >= 4) || pauseCtx->state == 0xF) &&
+                   CVar_GetS32("gSaveConfirmation", 0)) {
+            POLY_KAL_DISP =
+                KaleidoScope_QuadTextureIA8(POLY_KAL_DISP, sSaveConfirmationTexs[gSaveContext.language], 152, 16, 0);
         } else if ((pauseCtx->state != 7) || (pauseCtx->unk_1EC < 4)) {
             if ((pauseCtx->state != 0xF) && ((pauseCtx->state == 0x10) || (pauseCtx->state == 0x11))) {
                 POLY_KAL_DISP =
@@ -3874,7 +3878,11 @@ void KaleidoScope_Update(GlobalContext* globalCtx)
                                                    &D_801333E8);
                             Gameplay_PerformSave(globalCtx);
                             pauseCtx->unk_1EC = 4;
-                            D_8082B25C = 3;
+                            if (CVar_GetS32("gSaveConfirmation", 0)) {
+                                D_8082B25C = 80; // 3 secs
+                            } else {
+                                D_8082B25C = 3;
+                            }
                         }
                     } else if (CHECK_BTN_ALL(input->press.button, BTN_START) ||
                                CHECK_BTN_ALL(input->press.button, BTN_B)) {
@@ -4118,7 +4126,11 @@ void KaleidoScope_Update(GlobalContext* globalCtx)
                     gSaveContext.savedSceneNum = globalCtx->sceneNum;
                     Save_SaveFile();
                     pauseCtx->state = 0xF;
-                    D_8082B25C = 3;
+                    if (CVar_GetS32("gSaveConfirmation", 0)) {
+                        D_8082B25C = 80; // 3 secs
+                    } else {
+                        D_8082B25C = 3;
+                    }
                 }
             }
             break;


### PR DESCRIPTION
~~This should be the default behavior and should not be behind a CVar.~~

The texture used exists in all supported versions.