### PR TITLE
Rando: Starting Age fixes

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/settings.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/settings.cpp
@@ -2739,9 +2739,11 @@ namespace Settings {
       int choice = Random(0, 2); //50% chance of each
       if (choice == 0) {
         ResolvedStartingAge = AGE_CHILD;
+        StartingAge.SetSelectedIndex(AGE_CHILD);
       }
       else {
         ResolvedStartingAge = AGE_ADULT;
+        StartingAge.SetSelectedIndex(AGE_ADULT);
       }
     }
     else {

--- a/soh/soh/Enhancements/randomizer/3drando/settings.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/settings.cpp
@@ -1860,6 +1860,16 @@ namespace Settings {
         StartingAge.Unlock();
       }
 
+      //Adult is also not compatible with the following combination:
+      //DoT:Intended, ShuffleOcarinas:false, Logic:Glitchless
+      if (OpenDoorOfTime.Is(OPENDOOROFTIME_INTENDED) && !ShuffleOcarinas &&
+        Logic.Is(LOGIC_GLITCHLESS)) {
+          StartingAge.SetSelectedIndex(AGE_CHILD);
+          StartingAge.Lock();
+        } else {
+          StartingAge.Unlock();
+        }
+
       //Only show stone count option if Stones is selected
       if (Bridge.Is(RAINBOWBRIDGE_STONES)) {
         BridgeStoneCount.Unhide();

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -3946,10 +3946,11 @@ void DrawRandoEditor(bool& open) {
 
                 //Starting Age
                 //Disabled when Forest is set to Closed or under very specific conditions
-                bool disableRandoStartingAge = !CVar_GetS32("gRandomizeForest", 0) || //If Forest is closed...
-                    !(CVar_GetS32("gRandomizeDoorOfTime", 0)) && //or Door of Time is Intended
-                    !(CVar_GetS32("gRandomizeShuffleOcarinas", 0)) && //and ocarinas are not shuffled
-                    !(CVar_GetS32("gRandomizeLogicRules", 0)); // and logic is glitchless
+                //RANDOTODO: Replace magic number checks with enums
+                bool disableRandoStartingAge = (CVar_GetS32("gRandomizeForest", 0) == 0) || //If Forest is closed...
+                    (CVar_GetS32("gRandomizeDoorOfTime", 0) == 0) && //or Door of Time is Closed
+                    (CVar_GetS32("gRandomizeShuffleOcarinas", 0) == 0) && //and ocarinas are not shuffled
+                    (CVar_GetS32("gRandomizeLogicRules", 0) == 0); // and logic is glitchless
                 const char* disableRandoStartingAgeText = "This option is disabled due to other options making the game unbeatable.";
                 ImGui::Text(Settings::StartingAge.GetName().c_str());
                 UIWidgets::InsertHelpHoverText(

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -3949,7 +3949,7 @@ void DrawRandoEditor(bool& open) {
                 bool disableRandoStartingAge = !CVar_GetS32("gRandomizeForest", 0) || //If Forest is closed...
                     (CVar_GetS32("gRandomizeDoorOfTime", 0) != 2) && //or Door of Time is Intended
                     !(CVar_GetS32("gRandomizeShuffleOcarinas", 0)) && //and ocarinas are shuffled
-                    !(CVar_GetS32("gRandomizeLogicRules", 0));
+                    !(CVar_GetS32("gRandomizeLogicRules", 0)); // and logic is glitchless
                 const char* disableRandoStartingAgeText = "This option is disabled due to other options making the game unbeatable.";
                 ImGui::Text(Settings::StartingAge.GetName().c_str());
                 UIWidgets::InsertHelpHoverText(
@@ -3966,7 +3966,7 @@ void DrawRandoEditor(bool& open) {
                     if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
                        ImGui::SetTooltip("%s", disableRandoStartingAgeText);
                     }
-                    CVar_SetS32("gRandomizeStartingAge", 1);
+                    CVar_SetS32("gRandomizeStartingAge", 0);
                     ImGui::PopStyleVar(1);
                     ImGui::PopItemFlag();
                 }                

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -3947,7 +3947,7 @@ void DrawRandoEditor(bool& open) {
                 //Starting Age
                 //Disabled when Forest is set to Closed or under very specific conditions
                 bool disableRandoStartingAge = !CVar_GetS32("gRandomizeForest", 0) || //If Forest is closed...
-                    (CVar_GetS32("gRandomizeDoorOfTime", 0) != 2) && //or Door of Time is Intended
+                    !(CVar_GetS32("gRandomizeDoorOfTime", 0)) && //or Door of Time is Intended
                     !(CVar_GetS32("gRandomizeShuffleOcarinas", 0)) && //and ocarinas are shuffled
                     !(CVar_GetS32("gRandomizeLogicRules", 0)); // and logic is glitchless
                 const char* disableRandoStartingAgeText = "This option is disabled due to other options making the game unbeatable.";
@@ -3966,7 +3966,7 @@ void DrawRandoEditor(bool& open) {
                     if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
                        ImGui::SetTooltip("%s", disableRandoStartingAgeText);
                     }
-                    CVar_SetS32("gRandomizeStartingAge", 0);
+                    CVar_SetS32("gRandomizeStartingAge", 1);
                     ImGui::PopStyleVar(1);
                     ImGui::PopItemFlag();
                 }                

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -3947,10 +3947,11 @@ void DrawRandoEditor(bool& open) {
                 //Starting Age
                 //Disabled when Forest is set to Closed or under very specific conditions
                 //RANDOTODO: Replace magic number checks with enums
-                bool disableRandoStartingAge = (CVar_GetS32("gRandomizeForest", 0) == 0) || //If Forest is closed...
-                    (CVar_GetS32("gRandomizeDoorOfTime", 0) == 0) && //or Door of Time is Closed
-                    (CVar_GetS32("gRandomizeShuffleOcarinas", 0) == 0) && //and ocarinas are not shuffled
-                    (CVar_GetS32("gRandomizeLogicRules", 0) == 0); // and logic is glitchless
+                bool disableRandoStartingAge =  (CVar_GetS32("gRandomizeLogicRules", 0) == 0) && // glitchless logic
+                ((CVar_GetS32("gRandomizeForest", 0) == 0) || // Closed Forest
+                 ((CVar_GetS32("gRandomizeDoorOfTime", 0) == 0) && // Closed Door of Time 
+                 (CVar_GetS32("gRandomizeShuffleOcarinas", 0) == 0)));  // ocarinas not shuffled
+                    
                 const char* disableRandoStartingAgeText = "This option is disabled due to other options making the game unbeatable.";
                 ImGui::Text(Settings::StartingAge.GetName().c_str());
                 UIWidgets::InsertHelpHoverText(

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -3948,7 +3948,7 @@ void DrawRandoEditor(bool& open) {
                 //Disabled when Forest is set to Closed or under very specific conditions
                 bool disableRandoStartingAge = !CVar_GetS32("gRandomizeForest", 0) || //If Forest is closed...
                     !(CVar_GetS32("gRandomizeDoorOfTime", 0)) && //or Door of Time is Intended
-                    !(CVar_GetS32("gRandomizeShuffleOcarinas", 0)) && //and ocarinas are shuffled
+                    !(CVar_GetS32("gRandomizeShuffleOcarinas", 0)) && //and ocarinas are not shuffled
                     !(CVar_GetS32("gRandomizeLogicRules", 0)); // and logic is glitchless
                 const char* disableRandoStartingAgeText = "This option is disabled due to other options making the game unbeatable.";
                 ImGui::Text(Settings::StartingAge.GetName().c_str());
@@ -3966,7 +3966,7 @@ void DrawRandoEditor(bool& open) {
                     if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
                        ImGui::SetTooltip("%s", disableRandoStartingAgeText);
                     }
-                    CVar_SetS32("gRandomizeStartingAge", 1);
+                    CVar_SetS32("gRandomizeStartingAge", 0);
                     ImGui::PopStyleVar(1);
                     ImGui::PopItemFlag();
                 }                

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -3658,9 +3658,7 @@ void GenerateRandomizerImgui() {
     cvarSettings[RSK_KAK_GATE] = CVar_GetS32("gRandomizeKakarikoGate", 0);
     cvarSettings[RSK_DOOR_OF_TIME] = CVar_GetS32("gRandomizeDoorOfTime", 0);
     cvarSettings[RSK_ZORAS_FOUNTAIN] = CVar_GetS32("gRandomizeZorasFountain", 0);
-    //Starting Age is forced to child if forest setting is set to closed. (0 = Child, 1 = Adult)
-    cvarSettings[RSK_STARTING_AGE] = ((CVar_GetS32("gRandomizeForest", 0)) && 
-                                        (CVar_GetS32("gRandomizeStartingAge", 0)));
+    cvarSettings[RSK_STARTING_AGE] = CVar_GetS32("gRandomizeStartingAge", 0);
     cvarSettings[RSK_GERUDO_FORTRESS] = CVar_GetS32("gRandomizeGerudoFortress", 0);
     cvarSettings[RSK_RAINBOW_BRIDGE] = CVar_GetS32("gRandomizeRainbowBridge", 0);
     cvarSettings[RSK_RAINBOW_BRIDGE_STONE_COUNT] = CVar_GetS32("gRandomizeStoneCount", 3);
@@ -3947,14 +3945,17 @@ void DrawRandoEditor(bool& open) {
                 ImGui::PushItemWidth(-FLT_MIN);
 
                 //Starting Age
-                //Disabled when Forest is set to Closed
-                bool disableRandoStartingAge = !CVar_GetS32("gRandomizeForest", 0);
-                const char* disableRandoStartingAgeText = "This option is disabled because \"Forest\" is set to \"Closed\".";
+                //Disabled when Forest is set to Closed or under very specific conditions
+                bool disableRandoStartingAge = !CVar_GetS32("gRandomizeForest", 0) || //If Forest is closed...
+                    (CVar_GetS32("gRandomizeDoorOfTime", 0) != 2) && //or Door of Time is Intended
+                    !(CVar_GetS32("gRandomizeShuffleOcarinas", 0)) && //and ocarinas are shuffled
+                    !(CVar_GetS32("gRandomizeLogicRules", 0));
+                const char* disableRandoStartingAgeText = "This option is disabled due to other options making the game unbeatable.";
                 ImGui::Text(Settings::StartingAge.GetName().c_str());
                 UIWidgets::InsertHelpHoverText(
                     "Choose which age Link will start as.\n\n"
                     "Starting as adult means you start with the Master Sword in your inventory.\n"
-                    "Only the child option is compatible with Closed Forest."    
+                    "The child option is forcefully set if it would conflict with other options."    
                 );
                if (disableRandoStartingAge) {
                     ImGui::PushItemFlag(ImGuiItemFlags_Disabled, true);
@@ -3965,7 +3966,7 @@ void DrawRandoEditor(bool& open) {
                     if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
                        ImGui::SetTooltip("%s", disableRandoStartingAgeText);
                     }
-                    CVar_SetS32("gRandomizeStartingAge", 0);
+                    CVar_SetS32("gRandomizeStartingAge", 1);
                     ImGui::PopStyleVar(1);
                     ImGui::PopItemFlag();
                 }                

--- a/soh/src/code/z_sram.c
+++ b/soh/src/code/z_sram.c
@@ -375,8 +375,10 @@ void Sram_InitSave(FileChooseContext* fileChooseCtx) {
                 gSaveContext.entranceIndex = 0x5F4;
                 gSaveContext.savedSceneNum = SCENE_SPOT20; //Set scene num manually to ToT
                 break;
-            default: //Child
+            case 0: //Child
                 gSaveContext.linkAge = 1;
+                break;
+            default:
                 break;
         }
 


### PR DESCRIPTION
Resolves #1747, potentially [3D rando #565](https://github.com/gamestabled/OoT3D_Randomizer/issues/565).
This also resolves an issue reported on the Discord, where the "Random" age settings was not properly setting the correct value to have 3d rando randomize the starting age.

Edit: 3D rando has already implemented a similar solution from ours, so all that's left is to fix on our side.