### PR TITLE
Add hack for Ruto's earrings

### DIFF
--- a/soh/src/overlays/actors/ovl_En_Ru2/z_en_ru2.c
+++ b/soh/src/overlays/actors/ovl_En_Ru2/z_en_ru2.c
@@ -820,6 +820,7 @@ void func_80AF3F20(EnRu2* this, GlobalContext* globalCtx) {
 void EnRu2_Draw(Actor* thisx, GlobalContext* globalCtx) {
     EnRu2* this = (EnRu2*)thisx;
 
+    // FAST3D: This is a hack for the issue of both TEXEL0 and TEXEL1 using the same texture with different settings.
     // Ruto's earring uses both TEXEL0 and TEXEL1 to render. The issue is that it never loads anything into TEXEL1, so
     // it reuses whatever happens to be there, which is the water temple brick texture. It just so happens that the
     // earring texture loads into the same place in tmem as the brick texture, so when it comes to rendering, TEXEL1

--- a/soh/src/overlays/actors/ovl_En_Ru2/z_en_ru2.c
+++ b/soh/src/overlays/actors/ovl_En_Ru2/z_en_ru2.c
@@ -820,6 +820,18 @@ void func_80AF3F20(EnRu2* this, GlobalContext* globalCtx) {
 void EnRu2_Draw(Actor* thisx, GlobalContext* globalCtx) {
     EnRu2* this = (EnRu2*)thisx;
 
+    // Ruto's earring uses both TEXEL0 and TEXEL1 to render. The issue is that it never loads anything into TEXEL1, so
+    // it reuses whatever happens to be there, which is the water temple brick texture. It just so happens that the
+    // earring texture loads into the same place in tmem as the brick texture, so when it comes to rendering, TEXEL1
+    // uses the earring texture with diffrent clamp settings, and it displays without noticeable error. However, both
+    // texel samplers are not intended to be used for the same texture with different settings, so this misuse confuses
+    // our texture cache, and we load the wrong settings for the earrings texture. This patch is a hack that replaecs
+    // TEXEL1 with TEXEL0, which is most likely the original intention, and all is well.
+    Gfx* gfx = ResourceMgr_LoadGfxByName(gAdultRutoHeadDL);
+    Gfx patch = gsDPSetCombineLERP(TEXEL0, 0, PRIMITIVE, 0, TEXEL0, 0, ENVIRONMENT, 0, 0, 0, 0, COMBINED, TEXEL0, 0,
+                                  PRIM_LOD_FRAC, COMBINED);
+    gfx[0xA2] = patch;
+
     if ((this->drawConfig < 0) || (this->drawConfig >= ARRAY_COUNT(sDrawFuncs)) ||
         (sDrawFuncs[this->drawConfig] == 0)) {
         // "Draw Mode is improper!"

--- a/soh/src/overlays/actors/ovl_En_Ru2/z_en_ru2.c
+++ b/soh/src/overlays/actors/ovl_En_Ru2/z_en_ru2.c
@@ -826,7 +826,7 @@ void EnRu2_Draw(Actor* thisx, GlobalContext* globalCtx) {
     // earring texture loads into the same place in tmem as the brick texture, so when it comes to rendering, TEXEL1
     // uses the earring texture with diffrent clamp settings, and it displays without noticeable error. However, both
     // texel samplers are not intended to be used for the same texture with different settings, so this misuse confuses
-    // our texture cache, and we load the wrong settings for the earrings texture. This patch is a hack that replaecs
+    // our texture cache, and we load the wrong settings for the earrings texture. This patch is a hack that replaces
     // TEXEL1 with TEXEL0, which is most likely the original intention, and all is well.
     Gfx* gfx = ResourceMgr_LoadGfxByName(gAdultRutoHeadDL);
     Gfx patch = gsDPSetCombineLERP(TEXEL0, 0, PRIMITIVE, 0, TEXEL0, 0, ENVIRONMENT, 0, 0, 0, 0, COMBINED, TEXEL0, 0,


### PR DESCRIPTION
The issue is laid out in the comment, but boils down to the fact that we do not have texture settings on a per-texel-sampler basis, but on a per-texture basis. But the same texture could be used for both texel samplers and use different settings. This is really something that you should not do, but you can theoretically do, and is done accidentally with Ruto's earrings.

This is a hack to avoid that issue with no visual change from the intended effect.