### PR TITLE
Fix animation in Ganon that is causing an OOB access during animation

### DIFF
--- a/soh/src/overlays/actors/ovl_Boss_Ganon2/z_boss_ganon2.c
+++ b/soh/src/overlays/actors/ovl_Boss_Ganon2/z_boss_ganon2.c
@@ -577,6 +577,14 @@ void func_808FD5F4(BossGanon2* this, GlobalContext* globalCtx) {
                 BossGanon2_SetObjectSegment(this, globalCtx, OBJECT_GANON_ANIME3, false);
                 func_8002DF54(globalCtx, &this->actor, 0x54);
                 this->unk_314 = 3;
+
+                // At this point, the actor has Ganon's skeleton but is still playing an animation for Ganondorf. This
+                // causes issues when trying to access the limb posotions as Ganon has more limbs than Ganondorf. When
+                // animating, data from past the end of the animation data is accessed. This is a hack solution so
+                // that we are at least playing an animation meant for Ganon. There is no visible change since Ganon is
+                // off-screen. There is actually 1 frame where he is visible, and in the vanilla game he is an
+                // explosion of limbs since half of them are in random positions from the junk data accessed.
+                Animation_PlayOnce(&this->skelAnime, &gGanonUncurlAndFlailAnim, 0.0f);
             }
             // fake, tricks the compiler into using stack the way we need it to
             if (zero) {

--- a/soh/src/overlays/actors/ovl_Boss_Ganon2/z_boss_ganon2.c
+++ b/soh/src/overlays/actors/ovl_Boss_Ganon2/z_boss_ganon2.c
@@ -584,7 +584,7 @@ void func_808FD5F4(BossGanon2* this, GlobalContext* globalCtx) {
                 // that we are at least playing an animation meant for Ganon. There is no visible change since Ganon is
                 // off-screen. There is actually 1 frame where he is visible, and in the vanilla game he is an
                 // explosion of limbs since half of them are in random positions from the junk data accessed.
-                Animation_PlayOnce(&this->skelAnime, &gGanonUncurlAndFlailAnim, 0.0f);
+                Animation_PlayOnce(&this->skelAnime, &gGanonUncurlAndFlailAnim);
             }
             // fake, tricks the compiler into using stack the way we need it to
             if (zero) {


### PR DESCRIPTION
Comment says it all. This is a possible fix for Ganon crash (#682), but since we don't have a consistent repro case it's hard to be sure. It does seem to line up with the symptoms though. The skeleton swap happens right where people seem to crash -- after Ganondorf is glowing blue and the camera swaps to Link.