### PR TITLE
Fix: Showing pocket cucco in rando gives first Anju reward instead

### DIFF
--- a/soh/src/overlays/actors/ovl_En_Niw_Lady/z_en_niw_lady.c
+++ b/soh/src/overlays/actors/ovl_En_Niw_Lady/z_en_niw_lady.c
@@ -401,7 +401,7 @@ void func_80ABA9B8(EnNiwLady* this, GlobalContext* globalCtx) {
                 } else {
                     // TODO: get-item-rework Adult trade sequence
                     this->getItemEntry = Randomizer_GetItemFromKnownCheck(RC_KAK_ANJU_AS_ADULT, GI_POCKET_EGG);
-                    GiveItemEntryFromActor(&this->actor, globalCtx, this->getItemEntry, 200.0f, 100.0f);
+                    gSaveContext.itemGetInf[2] |= 0x1000;
                 }
 
                 this->actionFunc = func_80ABAC00;
@@ -431,7 +431,14 @@ void func_80ABAB08(EnNiwLady* this, GlobalContext* globalCtx) {
             case 0:
                 Message_CloseTextbox(globalCtx);
                 this->actor.parent = NULL;
-                func_8002F434(&this->actor, globalCtx, GI_COJIRO, 200.0f, 100.0f);
+                if (!gSaveContext.n64ddFlag) {
+                    func_8002F434(&this->actor, globalCtx, GI_COJIRO, 200.0f, 100.0f);
+                } else {
+                    // TODO: get-item-rework Adult trade sequence
+                    this->getItemEntry = Randomizer_GetItemFromKnownCheck(RC_KAK_TRADE_POCKET_CUCCO, GI_COJIRO);
+                    Randomizer_ConsumeAdultTradeItem(globalCtx, ITEM_POCKET_CUCCO);
+                    gSaveContext.itemGetInf[2] |= 0x4000;
+                }
                 this->actionFunc = func_80ABAC00;
                 break;
             case 1:
@@ -455,18 +462,14 @@ void func_80ABAC00(EnNiwLady* this, GlobalContext* globalCtx) {
     } else {
         getItemId = this->getItemId;
         if (LINK_IS_ADULT) {
-            getItemId = !(gSaveContext.itemGetInf[2] & 0x1000) ? GI_POCKET_EGG : GI_COJIRO;
-
-            if (gSaveContext.n64ddFlag) {
-                if (getItemId == GI_POCKET_EGG) {
-                    // TODO: get-item-rework Adult trade sequence
-                    this->getItemEntry = Randomizer_GetItemFromKnownCheck(RC_KAK_ANJU_AS_ADULT, GI_POCKET_EGG);
-                    GiveItemEntryFromActor(&this->actor, globalCtx, this->getItemEntry, 200.0f, 100.0f);
-                } else {
-                    this->getItemEntry = Randomizer_GetItemFromKnownCheck(RC_KAK_TRADE_POCKET_CUCCO, GI_COJIRO);
-                    Randomizer_ConsumeAdultTradeItem(globalCtx, ITEM_POCKET_CUCCO);
-                    GiveItemEntryFromActor(&this->actor, globalCtx, this->getItemEntry, 200.0f, 100.0f);
-                }
+            if (!gSaveContext.n64ddFlag) {
+                getItemId = !(gSaveContext.itemGetInf[2] & 0x1000) ? GI_POCKET_EGG : GI_COJIRO;
+            } else {
+                // TODO: get-item-rework Adult trade sequence
+                getItemId = this->getItemEntry.getItemId;
+                GiveItemEntryFromActor(&this->actor, globalCtx, this->getItemEntry, 200.0f, 100.0f);
+                // Skip setting item flags because that was done earlier
+                this->actionFunc = func_80ABA778;
             }
         }
         if (this->getItemEntry.getItemId == GI_NONE) {


### PR DESCRIPTION
Fixes #1415.

In vanilla, the flags `gSaveContext.itemGetInf[2] & 0x1000` and `gSaveContext.itemGetInf[2] & 0x4000` are used to determine what Anju says when spoken to, and the former is also used to determine whether she gives you the pocket cucco or Cojiro.

This fix makes it so that in randomizer, the item given is independent of `gSaveContext.itemGetInf[2] & 0x1000`. Additionally, whereas before they were set after Link was given the item, rando now sets them at the same time the item Link gets is determined so that the correct flag is set for the location checked.