### PR TITLE
Adds extra entry to obj_lift FallTimerDurations.

### DIFF
--- a/soh/src/overlays/actors/ovl_Obj_Lift/z_obj_lift.c
+++ b/soh/src/overlays/actors/ovl_Obj_Lift/z_obj_lift.c
@@ -36,7 +36,7 @@ const ActorInit Obj_Lift_InitVars = {
     NULL,
 };
 
-static s16 sFallTimerDurations[] = { 0, 10, 20, 30, 40, 50, 60 };
+static s16 sFallTimerDurations[] = { 0, 10, 20, 30, 40, 50, 60, 0 };
 
 typedef struct {
     /* 0x00 */ s16 x;


### PR DESCRIPTION
Prevents an OOB access that, as far as I know, was only causing issues
on the Switch, but it was UB everywhere. 

Basically the `z_obj_lift` instances in the Water Temple Basement had params of `-4`, which caused the calculation for which `sFallTimerDurations` index to use to return `7`, which is out of bounds for that array. On Windows, this resulted in a `timer` value of `0`. I don't know what it was on Switch, but based on the logic I believe it was some random positive number, since if it was negative we would end up eventually executing the correct function for dropping the platform anyway.

The fix is adding a 0 at the end of that array, to prevent OOB and end up with the value PC was ending up with already.