### PR TITLE
Add toggle option for walk speed modifiers

### DIFF
--- a/soh/include/variables.h
+++ b/soh/include/variables.h
@@ -166,6 +166,8 @@ extern "C"
 	extern s32 gSystemArenaLogSeverity;
 	extern u8 __osPfsInodeCacheBank;
 	extern s32 __osPfsLastChannel;
+	extern u8 sSpeedToggle1;
+	extern u8 sSpeedToggle2;
 
 	extern const s16 D_8014A6C0[];
 #define gTatumsPerBeat (D_8014A6C0[1])
@@ -211,16 +213,16 @@ extern "C"
 	extern volatile OSTime gRDPTotalTime;
 	extern FaultThreadStruct gFaultStruct;
 
-extern ActiveSound gActiveSounds[7][MAX_CHANNELS_PER_BANK]; // total size = 0xA8
-extern u8 gSoundBankMuted[];
-extern u8 D_801333F0;
-extern u8 gAudioSfxSwapOff;
-extern u16 gAudioSfxSwapSource[10];
-extern u16 gAudioSfxSwapTarget[10];
-extern u8 gAudioSfxSwapMode[10];
-extern unk_D_8016E750 D_8016E750[4];
-extern AudioContext gAudioContext;
-extern void(*D_801755D0)(void);
+	extern ActiveSound gActiveSounds[7][MAX_CHANNELS_PER_BANK]; // total size = 0xA8
+	extern u8 gSoundBankMuted[];
+	extern u8 D_801333F0;
+	extern u8 gAudioSfxSwapOff;
+	extern u16 gAudioSfxSwapSource[10];
+	extern u16 gAudioSfxSwapTarget[10];
+	extern u8 gAudioSfxSwapMode[10];
+	extern unk_D_8016E750 D_8016E750[4];
+	extern AudioContext gAudioContext;
+	extern void(*D_801755D0)(void);
 
 	extern u32 __osMalloc_FreeBlockTest_Enable;
 	extern Arena gSystemArena;

--- a/soh/include/variables.h
+++ b/soh/include/variables.h
@@ -166,8 +166,8 @@ extern "C"
 	extern s32 gSystemArenaLogSeverity;
 	extern u8 __osPfsInodeCacheBank;
 	extern s32 __osPfsLastChannel;
-	extern u8 sSpeedToggle1;
-	extern u8 sSpeedToggle2;
+	extern u8 gSpeedToggle1;
+	extern u8 gSpeedToggle2;
 
 	extern const s16 D_8014A6C0[];
 #define gTatumsPerBeat (D_8014A6C0[1])

--- a/soh/include/variables.h
+++ b/soh/include/variables.h
@@ -166,8 +166,8 @@ extern "C"
 	extern s32 gSystemArenaLogSeverity;
 	extern u8 __osPfsInodeCacheBank;
 	extern s32 __osPfsLastChannel;
-	extern u8 gSpeedToggle1;
-	extern u8 gSpeedToggle2;
+	extern u8 gWalkSpeedToggle1;
+	extern u8 gWalkSpeedToggle2;
 
 	extern const s16 D_8014A6C0[];
 #define gTatumsPerBeat (D_8014A6C0[1])

--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -730,6 +730,7 @@ namespace GameMenuBar {
                 UIWidgets::PaddedEnhancementCheckbox("Enable walk speed modifiers", "gEnableWalkModify", true, false);
                 UIWidgets::Tooltip("Hold the assigned button to change the maximum walking speed\nTo change the assigned button, click Customize Game Controls");
                 if (CVar_GetS32("gEnableWalkModify", 0)) {
+                    UIWidgets::PaddedEnhancementCheckbox("Toggle modifier button instead of holding it", "gSpeedToggle", true, false);
                     UIWidgets::EnhancementSliderFloat("Modifier 1: %d %%", "##WalkMod1", "gWalkModifierOne", 0.0f, 5.0f, "", 1.0f, true);
                     UIWidgets::EnhancementSliderFloat("Modifier 2: %d %%", "##WalkMod2", "gWalkModifierTwo", 0.0f, 5.0f, "", 1.0f, true);
                 }

--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -730,7 +730,7 @@ namespace GameMenuBar {
                 UIWidgets::PaddedEnhancementCheckbox("Enable walk speed modifiers", "gEnableWalkModify", true, false);
                 UIWidgets::Tooltip("Hold the assigned button to change the maximum walking speed\nTo change the assigned button, click Customize Game Controls");
                 if (CVar_GetS32("gEnableWalkModify", 0)) {
-                    UIWidgets::PaddedEnhancementCheckbox("Toggle modifier button instead of holding it", "gSpeedToggle", true, false);
+                    UIWidgets::PaddedEnhancementCheckbox("Toggle modifier instead of holding", "gSpeedToggle", true, false);
                     UIWidgets::EnhancementSliderFloat("Modifier 1: %d %%", "##WalkMod1", "gWalkModifierOne", 0.0f, 5.0f, "", 1.0f, true);
                     UIWidgets::EnhancementSliderFloat("Modifier 2: %d %%", "##WalkMod2", "gWalkModifierTwo", 0.0f, 5.0f, "", 1.0f, true);
                 }

--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -730,7 +730,7 @@ namespace GameMenuBar {
                 UIWidgets::PaddedEnhancementCheckbox("Enable walk speed modifiers", "gEnableWalkModify", true, false);
                 UIWidgets::Tooltip("Hold the assigned button to change the maximum walking speed\nTo change the assigned button, click Customize Game Controls");
                 if (CVar_GetS32("gEnableWalkModify", 0)) {
-                    UIWidgets::PaddedEnhancementCheckbox("Toggle modifier instead of holding", "gSpeedToggle", true, false);
+                    UIWidgets::PaddedEnhancementCheckbox("Toggle modifier instead of holding", "gWalkSpeedToggle", true, false);
                     UIWidgets::EnhancementSliderFloat("Modifier 1: %d %%", "##WalkMod1", "gWalkModifierOne", 0.0f, 5.0f, "", 1.0f, true);
                     UIWidgets::EnhancementSliderFloat("Modifier 2: %d %%", "##WalkMod2", "gWalkModifierTwo", 0.0f, 5.0f, "", 1.0f, true);
                 }

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -1053,6 +1053,8 @@ static s8 sItemActionParams[] = {
 };
 
 static u8 sMaskMemory;
+u8 sSpeedToggle1;
+u8 sSpeedToggle2;
 
 // Used to map action params to update functions
 static s32 (*D_80853EDC[])(Player* this, GlobalContext* globalCtx) = {
@@ -6033,10 +6035,22 @@ void func_8083DFE0(Player* this, f32* arg1, s16* arg2) {
 
         if (CVar_GetS32("gMMBunnyHood", 0) && this->currentMask == PLAYER_MASK_BUNNY) {
             maxSpeed *= 1.5f;
-        } else if (CVar_GetS32("gEnableWalkModify", 0) && CHECK_BTN_ALL(sControlInput->cur.button, BTN_MODIFIER1)) {
-            maxSpeed *= CVar_GetFloat("gWalkModifierOne", 1.0f);
-        } else if (CVar_GetS32("gEnableWalkModify", 0) && CHECK_BTN_ALL(sControlInput->cur.button, BTN_MODIFIER2)) {
-            maxSpeed *= CVar_GetFloat("gWalkModifierTwo", 1.0f);
+        } 
+        
+        if (CVar_GetS32("gEnableWalkModify", 0)) {
+            if (CVar_GetS32("gSpeedToggle", 0)) {
+                if (sSpeedToggle1) {
+                    maxSpeed *= CVar_GetFloat("gWalkModifierOne", 1.0f);
+                } else if (sSpeedToggle2) {
+                    maxSpeed *= CVar_GetFloat("gWalkModifierTwo", 1.0f);
+                }
+            } else {
+                if (CHECK_BTN_ALL(sControlInput->cur.button, BTN_MODIFIER1)) {
+                    maxSpeed *= CVar_GetFloat("gWalkModifierOne", 1.0f);
+                } else if (CHECK_BTN_ALL(sControlInput->cur.button, BTN_MODIFIER2)) {
+                    maxSpeed *= CVar_GetFloat("gWalkModifierTwo", 1.0f);
+                }
+            }
         }
 
         this->linearVelocity = CLAMP(this->linearVelocity, -maxSpeed, maxSpeed);
@@ -7662,10 +7676,22 @@ void func_80842180(Player* this, GlobalContext* globalCtx) {
 
             if (CVar_GetS32("gMMBunnyHood", 0) && this->currentMask == PLAYER_MASK_BUNNY) {
                 sp2C *= 1.5f;
-            } else if (CVar_GetS32("gEnableWalkModify", 0) && CHECK_BTN_ALL(sControlInput->cur.button, BTN_MODIFIER1)) {
-                sp2C *= CVar_GetFloat("gWalkModifierOne", 1.0f);
-            } else if (CVar_GetS32("gEnableWalkModify", 0) && CHECK_BTN_ALL(sControlInput->cur.button, BTN_MODIFIER2)) {
-                sp2C *= CVar_GetFloat("gWalkModifierTwo", 1.0f);
+            } 
+            
+            if (CVar_GetS32("gEnableWalkModify", 0)) {
+                if (CVar_GetS32("gSpeedToggle", 0)) {
+                    if (sSpeedToggle1) {
+                        sp2C *= CVar_GetFloat("gWalkModifierOne", 1.0f);
+                    } else if (sSpeedToggle2) {
+                        sp2C *= CVar_GetFloat("gWalkModifierTwo", 1.0f);
+                    }
+                } else {
+                    if (CHECK_BTN_ALL(sControlInput->cur.button, BTN_MODIFIER1)) {
+                        sp2C *= CVar_GetFloat("gWalkModifierOne", 1.0f);
+                    } else if (CHECK_BTN_ALL(sControlInput->cur.button, BTN_MODIFIER2)) {
+                        sp2C *= CVar_GetFloat("gWalkModifierTwo", 1.0f);
+                    }
+                }
             }
 
             func_8083DF68(this, sp2C, sp2A);
@@ -9519,6 +9545,8 @@ void Player_Init(Actor* thisx, GlobalContext* globalCtx2) {
     s32 sp50;
     s32 sp4C;
 
+    sSpeedToggle1 = 0;
+    sSpeedToggle2 = 0;
     globalCtx->shootingGalleryStatus = globalCtx->bombchuBowlingStatus = 0;
 
     globalCtx->playerInit = Player_InitCommon;
@@ -10955,6 +10983,13 @@ void Player_Update(Actor* thisx, GlobalContext* globalCtx) {
 
     if (chaosEffectGravityLevel == GRAVITY_LEVEL_LIGHT) {
         this->actor.gravity = -0.3f;
+    }
+
+    if (CHECK_BTN_ALL(sControlInput->press.button, BTN_MODIFIER1)) {
+        sSpeedToggle1 = !sSpeedToggle1;
+    }
+    if (CHECK_BTN_ALL(sControlInput->press.button, BTN_MODIFIER2)) {
+        sSpeedToggle2 = !sSpeedToggle2;
     }
 }
 

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -1053,8 +1053,8 @@ static s8 sItemActionParams[] = {
 };
 
 static u8 sMaskMemory;
-u8 sSpeedToggle1;
-u8 sSpeedToggle2;
+u8 gSpeedToggle1;
+u8 gSpeedToggle2;
 
 // Used to map action params to update functions
 static s32 (*D_80853EDC[])(Player* this, GlobalContext* globalCtx) = {
@@ -6039,9 +6039,9 @@ void func_8083DFE0(Player* this, f32* arg1, s16* arg2) {
         
         if (CVar_GetS32("gEnableWalkModify", 0)) {
             if (CVar_GetS32("gSpeedToggle", 0)) {
-                if (sSpeedToggle1) {
+                if (gSpeedToggle1) {
                     maxSpeed *= CVar_GetFloat("gWalkModifierOne", 1.0f);
-                } else if (sSpeedToggle2) {
+                } else if (gSpeedToggle2) {
                     maxSpeed *= CVar_GetFloat("gWalkModifierTwo", 1.0f);
                 }
             } else {
@@ -7680,9 +7680,9 @@ void func_80842180(Player* this, GlobalContext* globalCtx) {
             
             if (CVar_GetS32("gEnableWalkModify", 0)) {
                 if (CVar_GetS32("gSpeedToggle", 0)) {
-                    if (sSpeedToggle1) {
+                    if (gSpeedToggle1) {
                         sp2C *= CVar_GetFloat("gWalkModifierOne", 1.0f);
-                    } else if (sSpeedToggle2) {
+                    } else if (gSpeedToggle2) {
                         sp2C *= CVar_GetFloat("gWalkModifierTwo", 1.0f);
                     }
                 } else {
@@ -9545,8 +9545,6 @@ void Player_Init(Actor* thisx, GlobalContext* globalCtx2) {
     s32 sp50;
     s32 sp4C;
 
-    sSpeedToggle1 = 0;
-    sSpeedToggle2 = 0;
     globalCtx->shootingGalleryStatus = globalCtx->bombchuBowlingStatus = 0;
 
     globalCtx->playerInit = Player_InitCommon;
@@ -10985,11 +10983,13 @@ void Player_Update(Actor* thisx, GlobalContext* globalCtx) {
         this->actor.gravity = -0.3f;
     }
 
-    if (CHECK_BTN_ALL(sControlInput->press.button, BTN_MODIFIER1)) {
-        sSpeedToggle1 = !sSpeedToggle1;
-    }
-    if (CHECK_BTN_ALL(sControlInput->press.button, BTN_MODIFIER2)) {
-        sSpeedToggle2 = !sSpeedToggle2;
+    if (CVar_GetS32("gEnableWalkModify", 0) && CVar_GetS32("gSpeedToggle", 0)) {
+        if (CHECK_BTN_ALL(sControlInput->press.button, BTN_MODIFIER1)) {
+            gSpeedToggle1 = !gSpeedToggle1;
+        }
+        if (CHECK_BTN_ALL(sControlInput->press.button, BTN_MODIFIER2)) {
+            gSpeedToggle2 = !gSpeedToggle2;
+        }
     }
 }
 

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -1053,8 +1053,8 @@ static s8 sItemActionParams[] = {
 };
 
 static u8 sMaskMemory;
-u8 gSpeedToggle1;
-u8 gSpeedToggle2;
+u8 gWalkSpeedToggle1;
+u8 gWalkSpeedToggle2;
 
 // Used to map action params to update functions
 static s32 (*D_80853EDC[])(Player* this, GlobalContext* globalCtx) = {
@@ -6038,10 +6038,10 @@ void func_8083DFE0(Player* this, f32* arg1, s16* arg2) {
         } 
         
         if (CVar_GetS32("gEnableWalkModify", 0)) {
-            if (CVar_GetS32("gSpeedToggle", 0)) {
-                if (gSpeedToggle1) {
+            if (CVar_GetS32("gWalkSpeedToggle", 0)) {
+                if (gWalkSpeedToggle1) {
                     maxSpeed *= CVar_GetFloat("gWalkModifierOne", 1.0f);
-                } else if (gSpeedToggle2) {
+                } else if (gWalkSpeedToggle2) {
                     maxSpeed *= CVar_GetFloat("gWalkModifierTwo", 1.0f);
                 }
             } else {
@@ -7679,10 +7679,10 @@ void func_80842180(Player* this, GlobalContext* globalCtx) {
             } 
             
             if (CVar_GetS32("gEnableWalkModify", 0)) {
-                if (CVar_GetS32("gSpeedToggle", 0)) {
-                    if (gSpeedToggle1) {
+                if (CVar_GetS32("gWalkSpeedToggle", 0)) {
+                    if (gWalkSpeedToggle1) {
                         sp2C *= CVar_GetFloat("gWalkModifierOne", 1.0f);
-                    } else if (gSpeedToggle2) {
+                    } else if (gWalkSpeedToggle2) {
                         sp2C *= CVar_GetFloat("gWalkModifierTwo", 1.0f);
                     }
                 } else {
@@ -10983,12 +10983,12 @@ void Player_Update(Actor* thisx, GlobalContext* globalCtx) {
         this->actor.gravity = -0.3f;
     }
 
-    if (CVar_GetS32("gEnableWalkModify", 0) && CVar_GetS32("gSpeedToggle", 0)) {
+    if (CVar_GetS32("gEnableWalkModify", 0) && CVar_GetS32("gWalkSpeedToggle", 0)) {
         if (CHECK_BTN_ALL(sControlInput->press.button, BTN_MODIFIER1)) {
-            gSpeedToggle1 = !gSpeedToggle1;
+            gWalkSpeedToggle1 = !gWalkSpeedToggle1;
         }
         if (CHECK_BTN_ALL(sControlInput->press.button, BTN_MODIFIER2)) {
-            gSpeedToggle2 = !gSpeedToggle2;
+            gWalkSpeedToggle2 = !gWalkSpeedToggle2;
         }
     }
 }

--- a/soh/src/overlays/gamestates/ovl_opening/z_opening.c
+++ b/soh/src/overlays/gamestates/ovl_opening/z_opening.c
@@ -11,8 +11,8 @@ void Opening_SetupTitleScreen(OpeningContext* this) {
     this->state.running = false;
     gSaveContext.linkAge = 0;
     gSaveContext.fileNum = 0xFF;
-    gSpeedToggle1 = 0;
-    gSpeedToggle2 = 0;
+    gWalkSpeedToggle1 = 0;
+    gWalkSpeedToggle2 = 0;
     Sram_InitDebugSave();
     gSaveContext.cutsceneIndex = 0xFFF3;
     gSaveContext.sceneSetupIndex = 7;

--- a/soh/src/overlays/gamestates/ovl_opening/z_opening.c
+++ b/soh/src/overlays/gamestates/ovl_opening/z_opening.c
@@ -11,6 +11,8 @@ void Opening_SetupTitleScreen(OpeningContext* this) {
     this->state.running = false;
     gSaveContext.linkAge = 0;
     gSaveContext.fileNum = 0xFF;
+    gSpeedToggle1 = 0;
+    gSpeedToggle2 = 0;
     Sram_InitDebugSave();
     gSaveContext.cutsceneIndex = 0xFFF3;
     gSaveContext.sceneSetupIndex = 7;


### PR DESCRIPTION
By request, adding a checkbox to toggle instead of hold the walk speed modifier buttons.  Checkbox will only appear if the main walk speed modifier checkbox is enabled.  Closes #1742 

Like with the hold behavior, modifier 1 still trumps modifier 2 if both have been toggled on.  The modifier will also reset if the game returns to the title screen.  

This PR also changes the previous behavior to no longer be overridden by the bunny hood.  Instead, these manual modifiers, bunny hood, and crowd control modifiers all stack.  