### PR TITLE
Re-enables OTR patches from mods folder

### DIFF
--- a/libultraship/libultraship/Archive.cpp
+++ b/libultraship/libultraship/Archive.cpp
@@ -493,8 +493,7 @@ namespace Ship {
             // i.e. Ocarina of Time along with Master Quest.
             if (validateVersion) {
                 if (!PushGameVersion(patchHandle)) {
-                    SPDLOG_WARN("({}) Invalid MQP file.", path.c_str());
-                    return false;
+                    SPDLOG_INFO("({}) Missing version file. Attempting to apply patch anyway.", path.c_str());
                 }
             }
         }

--- a/libultraship/libultraship/Archive.cpp
+++ b/libultraship/libultraship/Archive.cpp
@@ -448,12 +448,12 @@ namespace Ship {
         }
         for (int j = i; j < OTRFiles.size(); j++) {
 #ifdef _WIN32
-            std::wstring wfullPath = std::filesystem::absolute(OTRFiles[i]).wstring();
+            std::wstring wfullPath = std::filesystem::absolute(OTRFiles[j]).wstring();
 #endif
 #if defined(__SWITCH__)
             std::string fullPath = OTRFiles[i];
 #else
-            std::string fullPath = std::filesystem::absolute(OTRFiles[i]).string();
+            std::string fullPath = std::filesystem::absolute(OTRFiles[j]).string();
 #endif
             if (LoadPatchMPQ(fullPath, true))
             {

--- a/libultraship/libultraship/WiiUImpl.cpp
+++ b/libultraship/libultraship/WiiUImpl.cpp
@@ -77,6 +77,10 @@ void ThrowMissingOTR(const char* otrPath) {
     OSFatal("Main OTR file not found!");
 }
 
+void ThrowInvalidOTR() {
+    OSFatal("Invalid OTR files! Try regenerating them!");
+}
+
 void Update() {
     bool rescan = false;
 

--- a/libultraship/libultraship/WiiUImpl.h
+++ b/libultraship/libultraship/WiiUImpl.h
@@ -12,6 +12,8 @@ void Exit();
 
 void ThrowMissingOTR(const char* otrPath);
 
+void ThrowInvalidOTR();
+
 void Update();
 
 VPADStatus *GetVPADStatus(VPADReadError *error);

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -87,11 +87,11 @@ OTRGlobals::OTRGlobals() {
         OTRFiles.push_back(ootPath);
     }
     std::string patchesPath = Ship::Window::GetPathRelativeToAppDirectory("mods");
-    if (patchesPath.length() > 0) {
+    if (patchesPath.length() > 0 && std::filesystem::exists(patchesPath)) {
         if (std::filesystem::is_directory(patchesPath)) {
             for (const auto& p : std::filesystem::recursive_directory_iterator(patchesPath)) {
                 if (StringHelper::IEquals(p.path().extension().string(), ".otr")) {
-                    OTRFiles.push_back(p.path().string());
+                    OTRFiles.push_back(p.path().generic_string());
                 }
             }
         }


### PR DESCRIPTION
- Sidestep libultraship validation by passing an empty vector as `ValidHashes`, which still puts version hashes in the `GetGameVersions()` list for later checking.
- libultraship no longer fails on a missing version file, simply info-logs and proceeds with patching.
- SoH now passes any OTRs in the mods folder as part of the list of OTRs to patch in.