### PR TITLE
Ensures MQ and Vanilla title Logos are saved with different names.

### DIFF
--- a/OTRExporter/OTRExporter/Main.cpp
+++ b/OTRExporter/OTRExporter/Main.cpp
@@ -91,8 +91,17 @@ static void ExporterProgramEnd()
 		otrArchive = Ship::Archive::CreateArchive(otrFileName, 40000);
 
 		for (auto item : files) {
+			std::string fName = item.first;
+			if (fName.find("gTitleZeldaShieldLogoMQTex") != std::string::npos && !ZRom(romPath).IsMQ())
+			{
+				size_t pos = 0;
+				if ((pos = fName.find("gTitleZeldaShieldLogoMQTex", 0)) != std::string::npos)
+				{
+					fName.replace(pos, 27, "gTitleZeldaShieldLogoTex");
+				}
+			}
 			auto fileData = item.second;
-			otrArchive->AddFile(item.first, (uintptr_t)fileData.data(),
+			otrArchive->AddFile(fName, (uintptr_t)fileData.data(),
 		                      fileData.size());
 		}
 

--- a/ZAPDTR/ZAPD/ZResource.cpp
+++ b/ZAPDTR/ZAPD/ZResource.cpp
@@ -362,6 +362,28 @@ static const char %s[] __attribute__((aligned (2))) = d%s;
 			}
 		}
 
+		if (name == "gTitleZeldaShieldLogoMQTex")
+		{
+			std::string addName = "gTitleZeldaShieldLogoTex";
+			nameStr = StringHelper::Strip(StringHelper::Strip(addName, "\n"), "\r");
+			str += StringHelper::Sprintf("\n#define d%s \"__OTR__%s/%s/%s\"", addName.c_str(), prefix.c_str(), outName.c_str(), nameStr.c_str());
+			if (nameSet && nameSet->find(addName) == nameSet->end())
+			{
+				str += StringHelper::Sprintf(R"(
+#ifdef _WIN32
+static const __declspec(align(2)) char %s[] = d%s;
+#else
+static const char %s[] __attribute__((aligned (2))) = d%s;
+#endif
+			)", addName.c_str(), addName.c_str(), addName.c_str(), addName.c_str());
+
+				if (nameSet)
+				{
+					nameSet->insert(addName);
+				}
+			}
+		}
+
 		return str;
 	}
 	else

--- a/soh/src/overlays/actors/ovl_En_Mag/z_en_mag.c
+++ b/soh/src/overlays/actors/ovl_En_Mag/z_en_mag.c
@@ -913,7 +913,7 @@ void EnMag_DrawInnerVanilla(Actor* thisx, GlobalContext* globalCtx, Gfx** gfxp) 
     gDPSetPrimColor(gfx++, 0, 0, 255, 255, 255, (s16)this->mainAlpha);
 
     if ((s16)this->mainAlpha != 0) {
-        EnMag_DrawImageRGBA32(&gfx, 160, 100, (u8*)gTitleZeldaShieldLogoMQTex, 160, 160);
+        EnMag_DrawImageRGBA32(&gfx, 160, 100, (u8*)gTitleZeldaShieldLogoTex, 160, 160);
     }
 
     func_8009457C(&gfx);


### PR DESCRIPTION
This way either one can be loaded according to which OTR/whether or not MQ is enabled.

Fixes issue #1786 