### PR TITLE
Restore QPA glitched damage

### DIFF
--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -1095,6 +1095,7 @@ namespace GameMenuBar {
                 UIWidgets::PaddedEnhancementCheckbox("Bombchus out of bounds", "gBombchusOOB", true, false);
                 UIWidgets::Tooltip("Allows bombchus to explode out of bounds\nSimilar to GameCube and Wii VC");
                 UIWidgets::PaddedEnhancementCheckbox("Restore old Gold Skulltula cutscene", "gGsCutscene", true, false);
+                UIWidgets::PaddedEnhancementCheckbox("Restore QPA glitched damage value", "gRestoreQPA", true, false);
 
                 ImGui::EndMenu();
             }

--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -1095,7 +1095,6 @@ namespace GameMenuBar {
                 UIWidgets::PaddedEnhancementCheckbox("Bombchus out of bounds", "gBombchusOOB", true, false);
                 UIWidgets::Tooltip("Allows bombchus to explode out of bounds\nSimilar to GameCube and Wii VC");
                 UIWidgets::PaddedEnhancementCheckbox("Restore old Gold Skulltula cutscene", "gGsCutscene", true, false);
-                UIWidgets::PaddedEnhancementCheckbox("Restore QPA glitched damage value", "gRestoreQPA", true, false);
 
                 ImGui::EndMenu();
             }

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -3595,7 +3595,7 @@ void func_80837948(GlobalContext* globalCtx, Player* this, s32 arg2) {
     }
 
     if ((arg2 >= 16) && (arg2 < 20)) {
-        if (CVar_GetS32("gRestoreQPA", 0) && temp == -1) {
+        if (CVar_GetS32("gRestoreQPA", 1) && temp == -1) {
             flags = 0x16171617;
         }
         else {

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -3595,7 +3595,12 @@ void func_80837948(GlobalContext* globalCtx, Player* this, s32 arg2) {
     }
 
     if ((arg2 >= 16) && (arg2 < 20)) {
-        flags = D_80854488[temp][1];
+        if (CVar_GetS32("gRestoreQPA", 0) && temp == -1) {
+            flags = 0x16171617;
+        }
+        else {
+            flags = D_80854488[temp][1];
+        }
     } else {
         flags = D_80854488[temp][0];
     }


### PR DESCRIPTION
Adds an option to restore the original behavior of getting a glitched damage value with multiple flags set when getting a broken deku stick after performing the quick putaway glitch.