### PR TITLE
OTRGui: extractor run command fix

### DIFF
--- a/OTRGui/src/impl/extractor/extractor.cpp
+++ b/OTRGui/src/impl/extractor/extractor.cpp
@@ -111,7 +111,7 @@ void startWorker(RomVersion version) {
 	else
 	{
 		std::string execStr = Util::format("assets/extractor/%s", isWindows() ? "ZAPD.exe" : "ZAPD.out");
-		std::string args = Util::format(" ed -eh -i %s -b tmp/rom.z64 -fl assets/extractor/filelists -o %s -osf %s -gsf 1 -rconf assets/extractor/Config_%s.xml -se OTR %s", path.c_str(), path + "../", path + "../", GetXMLVersion(version).c_str(), "");
+		std::string args = Util::format(" ed -eh -i %s -b tmp/rom.z64 -fl assets/extractor/filelists -o %s -osf %s -gsf 1 -rconf assets/extractor/Config_%s.xml -se OTR %s", path.c_str(), (path + "../").c_str(), (path + "../").c_str(), GetXMLVersion(version).c_str(), "");
 		ProcessResult result = NativeFS->LaunchProcess(execStr + args);
 
 		if (result.exitCode != 0) {

--- a/OTRGui/src/impl/extractor/extractor.cpp
+++ b/OTRGui/src/impl/extractor/extractor.cpp
@@ -111,7 +111,7 @@ void startWorker(RomVersion version) {
 	else
 	{
 		std::string execStr = Util::format("assets/extractor/%s", isWindows() ? "ZAPD.exe" : "ZAPD.out");
-		std::string args = Util::format(" ed -eh -i %s -b tmp/rom.z64 -fl assets/extractor/filelists -o %s -osf %s -gsf 1 -rconf assets/extractor/Config_%s.xml -se OTR %s", path.c_str(), (path + "../").c_str(), (path + "../").c_str(), GetXMLVersion(version).c_str(), "");
+		std::string args = Util::format(" ed -eh -i %s -b tmp/rom.z64 -fl assets/extractor/filelists -o %s -osf %s -gsf 1 -rconf assets/extractor/Config_%s.xml -se OTR %s", path.c_str(), (path + "/../").c_str(), (path + "/../").c_str(), GetXMLVersion(version).c_str(), "");
 		ProcessResult result = NativeFS->LaunchProcess(execStr + args);
 
 		if (result.exitCode != 0) {


### PR DESCRIPTION
Uh oh some one forgot to add c_str() on this one and it broke some linux systems randomly. Bug caused this parameter in this line parsed as `std::string` *pointer* instead of `char *`. Just some tiny bugfix that i found while testing otrgui to my linux vm.

the result of this bug:
![ProcessHacker_jb4A1jIAc4](https://user-images.githubusercontent.com/56553686/196380870-a85ae841-fccd-4854-9fc1-0757f5d4c6ad.png)
