### PR TITLE
Add quotes around the romfile to capture spaces and other characters.

### DIFF
--- a/scripts/linux/appimage/soh.sh
+++ b/scripts/linux/appimage/soh.sh
@@ -18,7 +18,7 @@ while [[ (! -e "$SHIP_HOME"/oot.otr) || (! -e "$SHIP_HOME"/oot-mq.otr) ]]; do
                 export OLDPWD="$PWD"
                 mkdir -p "$ASSETDIR"/tmp
 	            mkdir -p "$ASSETDIR"/Extract
-                ln -s $romfile "$ASSETDIR"/tmp/rom.z64
+                ln -s "$romfile" "$ASSETDIR"/tmp/rom.z64
                 cd "$ASSETDIR"
                 ROMHASH=$(sha1sum -b "$ASSETDIR"/tmp/rom.z64 | awk '{ print $1 }')
                 case "$ROMHASH" in


### PR DESCRIPTION
This is intended to fix an issue where if you have spaces in the Rom file name, it will fail on the symbolic link to the temporary file.

The `soh.sh` script doesn't escape spaces properly, so if the `.z64` file has a space in it, the `ln -s $romfile "$ASSETDIR"/tmp/rom.z64` fails.

It looks like this worked before because the bash script simply did `ln -s "$SHIP_HOME"/*.*64 "$ASSETDIR"/tmp/rom.z64`, which I think triggers bash's globbing mechanism and so it knows to escape the spaces properly for the command.

This fixed it on my bench, but I'm not a bash expert, so I'm not sure if there are other bash issues that need to be taken care of.