### PR TITLE
Fixes a crash on Switch and cleans up some rando ui interactions.

### DIFF
--- a/soh/soh/Enhancements/bootcommands.c
+++ b/soh/soh/Enhancements/bootcommands.c
@@ -29,7 +29,6 @@ void BootCommands_Init()
     CVar_RegisterS32("gTrailDuration", 4); // 4 = Default trail duration
     if (ResourceMgr_GameHasMasterQuest() && !ResourceMgr_GameHasOriginal()) {
         CVar_SetS32("gMasterQuest", 1);
-        CVar_SetS32("gRandomizer", 0);
     } else if (!ResourceMgr_GameHasMasterQuest()) {
         CVar_SetS32("gMasterQuest", 0);
     }

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -423,10 +423,6 @@ std::unordered_map<RandomizerGet, EnGirlAShopItem> randomizerGetToEnGirlShopItem
 };
 
 void Randomizer::LoadMerchantMessages(const char* spoilerFileName) {
-    if (strcmp(spoilerFileName, "") != 0) {
-        ParseHintLocationsFile(spoilerFileName);
-    }
-
     CustomMessageManager::Instance->ClearMessageTable(Randomizer::merchantMessageTableID);
     CustomMessageManager::Instance->AddCustomMessageTable(Randomizer::merchantMessageTableID);
 
@@ -857,6 +853,7 @@ void Randomizer::ParseRandomizerSettingsFile(const char* spoilerFileName) {
                     case RSK_MQ_DUNGEON_COUNT:
                         if (it.value() == "Random") {
                             gSaveContext.randoSettings[index].value = 13;
+                            break;
                         }
                         numericValueString = it.value();
                         gSaveContext.randoSettings[index].value = std::stoi(numericValueString);

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -124,7 +124,7 @@ OTRGlobals::OTRGlobals() {
     for (uint32_t version : versions) {
         if (!ValidHashes.contains(version)) {
 #if defined(__SWITCH__)
-            printf("Invalid OTR File!\n");
+            SPDLOG_ERROR("Invalid OTR File!");
 #elif defined(__WIIU__)
             Ship::WiiU::ThrowInvalidOTR();
 #else
@@ -805,7 +805,7 @@ extern "C" char* ResourceMgr_LoadTexOrDListByName(const char* filePath) {
 }
 
 extern "C" Sprite* GetSeedTexture(uint8_t index) {
-    return Randomizer::GetSeedTexture(index);
+    return OTRGlobals::Instance->gRandomizer->GetSeedTexture(index);
 }
 
 extern "C" char* ResourceMgr_LoadPlayerAnimByName(const char* animPath) {
@@ -1796,7 +1796,7 @@ extern "C" bool Randomizer_IsTrialRequired(RandomizerInf trial) {
     return OTRGlobals::Instance->gRandomizer->IsTrialRequired(trial);
 }
 
-extern "C" bool SpoilerFileExists(const char* spoilerFileName) {
+extern "C" u32 SpoilerFileExists(const char* spoilerFileName) {
     return OTRGlobals::Instance->gRandomizer->SpoilerFileExists(spoilerFileName);
 }
 

--- a/soh/soh/OTRGlobals.h
+++ b/soh/soh/OTRGlobals.h
@@ -106,6 +106,7 @@ void Controller_BlockGameInput();
 void Controller_UnblockGameInput();
 void Hooks_ExecuteAudioInit();
 void* getN64WeirdFrame(s32 i);
+u32 SpoilerFileExists(const char* spoilerFileName);
 Sprite* GetSeedTexture(uint8_t index);
 void Randomizer_LoadSettings(const char* spoilerFileName);
 u8 Randomizer_GetSettingValue(RandomizerSettingKey randoSettingKey);

--- a/soh/soh/SaveManager.cpp
+++ b/soh/soh/SaveManager.cpp
@@ -194,7 +194,7 @@ void SaveManager::LoadRandomizerVersion2() {
         });
     });
 
-    SaveManager::Instance->LoadData("masterQuestDungeonCount", gSaveContext.mqDungeonCount);
+    SaveManager::Instance->LoadData("masterQuestDungeonCount", gSaveContext.mqDungeonCount, (uint8_t)0);
 
     OTRGlobals::Instance->gRandomizer->masterQuestDungeons.clear();
     SaveManager::Instance->LoadArray("masterQuestDungeons", randomizer->GetRandoSettingValue(RSK_MQ_DUNGEON_COUNT), [&](size_t i) {

--- a/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -204,6 +204,8 @@ void SpriteDraw(FileChooseContext* this, Sprite* sprite, int left, int top, int 
     CLOSE_DISPS(this->state.gfxCtx);
 }
 
+bool fileSelectSpoilerFileLoaded = false;
+
 void DrawSeedHashSprites(FileChooseContext* this) {
     OPEN_DISPS(this->state.gfxCtx);
     gDPPipeSync(POLY_OPA_DISP++);
@@ -226,9 +228,7 @@ void DrawSeedHashSprites(FileChooseContext* this) {
 
         gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 0xFF, 0xFF, 0xFF, this->fileButtonAlpha[this->buttonIndex]);
 
-        if (CVar_GetS32("gRandomizer", 0) && strnlen(CVar_GetString("gSpoilerLog", ""), 1) != 0 && 
-            !((gSaveContext.mqDungeonCount > 0 && !ResourceMgr_GameHasMasterQuest())
-            || (gSaveContext.mqDungeonCount < 12 && !ResourceMgr_GameHasOriginal()))) {
+        if (CVar_GetS32("gRandomizer", 0) && strnlen(CVar_GetString("gSpoilerLog", ""), 1) != 0 && fileSelectSpoilerFileLoaded) {
             u16 xStart = 64;
             for (unsigned int i = 0; i < 5; i++) {
                 SpriteLoad(this, GetSeedTexture(gSaveContext.seedIcons[i]));
@@ -243,8 +243,6 @@ void DrawSeedHashSprites(FileChooseContext* this) {
 }
 
 u8 generating;
-bool fileSelectSpoilerFileLoaded;
-bool shouldLoadSpoilerFile;
 
 /**
  * Update the cursor and wait for the player to select a button to change menus accordingly.
@@ -280,8 +278,7 @@ void FileChoose_UpdateMainMenu(GameState* thisx) {
 
     if ((CVar_GetS32("gNewFileDropped", 0) != 0) ||
         (CVar_GetS32("gNewSeedGenerated", 0) != 0) ||
-        (!fileSelectSpoilerFileLoaded && shouldLoadSpoilerFile &&
-            SpoilerFileExists(CVar_GetString("gSpoilerLog", "")))) {
+        (!fileSelectSpoilerFileLoaded && SpoilerFileExists(CVar_GetString("gSpoilerLog", "")))) {
         if (CVar_GetS32("gNewFileDropped", 0) != 0) {
             CVar_SetString("gSpoilerLog", CVar_GetString("gDroppedFile", "None"));
         }
@@ -298,9 +295,9 @@ void FileChoose_UpdateMainMenu(GameState* thisx) {
         Randomizer_LoadSettings(fileLoc);
         Randomizer_LoadHintLocations(fileLoc);
         Randomizer_LoadRequiredTrials(fileLoc);
-        Randomizer_LoadMasterQuestDungeons(fileLoc);
         Randomizer_LoadItemLocations(fileLoc, silent);
         Randomizer_LoadMerchantMessages(fileLoc);
+        Randomizer_LoadMasterQuestDungeons(fileLoc);
         fileSelectSpoilerFileLoaded = true;
     }
 
@@ -2102,7 +2099,6 @@ void FileChoose_Init(GameState* thisx) {
     size_t size = (u32)_title_staticSegmentRomEnd - (u32)_title_staticSegmentRomStart;
     s32 pad;
     fileSelectSpoilerFileLoaded = false;
-    shouldLoadSpoilerFile = true;
     CVar_SetS32("gOnFileSelectNameEntry", 0);
 
     SREG(30) = 1;


### PR DESCRIPTION
- Fixes a crash on Switch due to missing break statement from the Switch Case while parsing settings.
- Allows creating a rando seed while only an MQ OTR is loaded (the resulting seed will be locked to 12 MQ Dungeons).
- Prevents an all 0 seed hash from being briefly shown on the file select screen before the spoiler file is loaded.