### PR TITLE
Fix LACS ganon's key hint text coloring and new lines

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/hint_list.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/hint_list.cpp
@@ -2767,7 +2767,7 @@ void HintTable_Init() {
 
     hintTable[LACS_REWARDS_HINT] = HintText::LACS({
         // obscure text                                                     singular                         plural
-        Text{ "And the %revil oneRw's key will be&provided by Zelda once %r%d&|Spiritual Stone or Medallion%w&"
+        Text{ "And the %revil one%w's key will be&provided by Zelda once %r%d&|Spiritual Stone or Medallion%w&"
               "is|Spiritual Stones and Medallions%w&are| retrieved.",
               /*french*/
               "Aussi, Zelda crééra la clé du&%rMalin%w avec %r%d |Pierre Ancestrale&et des médaillon|Pierres "

--- a/soh/soh/Enhancements/randomizer/3drando/hint_list.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/hint_list.cpp
@@ -2685,49 +2685,49 @@ void HintTable_Init() {
     hintTable[GANON_BK_START_WITH_HINT] = HintText::GanonsBossKey({
         // obscure text
         Text{ "And the %revil one%w's key will&be given %rfrom the start%w.",
-              /*french*/ "Aussi, la clé du %rMalin%w sera&possession %rmême du héros%w.",
+              /*french*/ "Aussi, la %rclé du Malin%w sera&possession %rmême du héros%w.",
               /*spanish*/ "Y obtendrás la llave del #señor del mal# desde el #inicio#." },
     });
 
     hintTable[GANON_BK_VANILLA_HINT] = HintText::GanonsBossKey({
         // obscure text
         Text{ "And the %revil one%w's key will&be kept in a big chest&%rinside its tower%w.",
-              /*french*/ "Aussi, la clé du %rMalin%w sera&encoffrée %rdans sa tour%w.",
+              /*french*/ "Aussi, la %rclé du Malin%w sera&encoffrée %rdans sa tour%w.",
               /*spanish*/ "Y la llave del #señor del mal# aguardará en un gran cofre de #su torre#." },
     });
 
     hintTable[GANON_BK_OWN_DUNGEON_HINT] = HintText::GanonsBossKey({
         // obscure text
         Text{ "And the %revil one%w's key will&be hidden somewhere %rinside&its castle%w.",
-              /*french*/ "Aussi, la clé du %rMalin%w sera&cachée %rdans son vaste château%w.",
+              /*french*/ "Aussi, la %rclé du Malin%w sera&cachée %rdans son vaste château%w.",
               /*spanish*/ "Y la llave del #señor del mal# aguardará en #algún lugar de su castillo#." },
     });
 
     hintTable[GANON_BK_OVERWORLD_HINT] = HintText::GanonsBossKey({
         // obscure text
         Text{ "And the %revil one%w's key will&be hidden %routside of&dungeons%w in Hyrule.",
-              /*french*/ "Aussi, la clé du %rMalin%w se&trouve %rhors des donjons%w d'Hyrule.",
+              /*french*/ "Aussi, la %rclé du Malin%w se&trouve %rhors des donjons%w d'Hyrule.",
               /*spanish*/ "Y la llave del #señor del mal# aguardará #fuera de las mazmorras# de Hyrule." },
     });
 
     hintTable[GANON_BK_ANY_DUNGEON_HINT] = HintText::GanonsBossKey({
         // obscure text
         Text{ "And the %revil one%w's key will&be hidden %rinside a&dungeon%w in Hyrule.",
-              /*french*/ "Aussi, la clé du %rMalin%w se&trouve %rdans un donjon%w d'Hyrule.",
+              /*french*/ "Aussi, la %rclé du Malin%w se&trouve %rdans un donjon%w d'Hyrule.",
               /*spanish*/ "Y la llave del #señor del mal# aguardará #en una mazmorra# de Hyrule." },
     });
 
     hintTable[GANON_BK_ANYWHERE_HINT] = HintText::GanonsBossKey({
         // obscure text
         Text{ "And the %revil one%w's key will&be hidden somewhere&%rin Hyrule%w.",
-              /*french*/ "Aussi, la clé du %rMalin%w se&trouve quelque part %rdans Hyrule%w.",
+              /*french*/ "Aussi, la %rclé du Malin%w se&trouve quelque part %rdans Hyrule%w.",
               /*spanish*/ "Y la llave del #señor del mal# aguardará en #cualquier lugar de Hyrule#." },
     });
 
     hintTable[GANON_BK_TRIFORCE_HINT] = HintText::GanonsBossKey({
         // obscure text
         Text{ "And the %revil one%w's key will&be given to the Hero once&the %rTriforce%w is completed.",
-              /*french*/ "Aussi, la clé du %rMalin%w se&révèlera une fois la %rTriforce%w&assemblée.",
+              /*french*/ "Aussi, la %rclé du Malin%w se&révèlera une fois la %rTriforce%w&assemblée.",
               /*spanish*/ "Y el héroe recibirá la llave del #señor del mal# cuando haya completado la #Trifuerza#." },
     });
 
@@ -2768,7 +2768,7 @@ void HintTable_Init() {
         Text{ "And the %revil one%w's key will be&provided by Zelda once %r%d&|Spiritual Stone or Medallion%w&"
               "is|Spiritual Stones and Medallions%w&are| retrieved.",
               /*french*/
-              "Aussi, la %rclé du Malin%w sera&fournie par Zelda une fois |qu'&%r%d Pierre Ancestrale ou %d&Médaillon%w sera récupéré|que&%r%d Pierres Ancestrales&et&Médaillons%w seront récupérés|.",
+              "Aussi, la %rclé du Malin%w sera&fournie par Zelda une fois |qu'&%r%d Pierre Ancestrale ou %d&Médaillon%w sera récupéré|que&%r%d Pierres Ancestrales et&Médaillons%w seront récupérés|.",
               /*spanish*/
               "Y Zelda entregará la llave&del #señor del mal# tras obtener&#%d |piedra espiritual o medallón|piedras "
               "espirituales o medallones|#." },

--- a/soh/soh/Enhancements/randomizer/3drando/hint_list.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/hint_list.cpp
@@ -2740,8 +2740,8 @@ void HintTable_Init() {
     hintTable[LACS_VANILLA_HINT] = HintText::LACS({
         // obscure text
         Text{
-            "And the #evil one#'s key will be&provided by Zelda once the #Shadow&and Spirit Medallions# are retrieved.",
-            /*french*/ "Aussi, Zelda crééra la clé du&#Malin# avec les #médaillons de&l'ombre et de l'esprit#.",
+            "And the %revil one%w's key will be&provided by Zelda once the&%rShadow and Spirit Medallions%w&are retrieved.",
+            /*french*/ "Aussi, Zelda crééra la clé du&%rMalin%w avec les %rmédaillons de&l'ombre et de l'esprit%w.",
             /*spanish*/
             "Y Zelda entregará la llave&del #señor del mal# tras obtener&#el medallón de las sombras y del "
             "espíritu#." },
@@ -2749,17 +2749,17 @@ void HintTable_Init() {
 
     hintTable[LACS_MEDALLIONS_HINT] = HintText::LACS({
         // obscure text                                                     singular      plural
-        Text{ "And the #evil one#'s key will be&provided by Zelda once #%d&|Medallion# is|Medallions# are| retrieved.",
-              /*french*/ "Aussi, Zelda crééra la clé du&#Malin# avec #%d |médaillon|médaillons|#.",
+        Text{ "And the %revil one%w's key will be&provided by Zelda once %r%d&|Medallion%w is|Medallions%w are| retrieved.",
+              /*french*/ "Aussi, Zelda crééra la clé du&%rMalin%w avec %r%d |médaillon|médaillons|%w.",
               /*spanish*/ "Y Zelda entregará la llave&del #señor del mal# tras obtener&#%d |medallón|medallones|#." },
     });
 
     hintTable[LACS_STONES_HINT] = HintText::LACS({
         // obscure text                                                     singular            plural
         Text{
-            "And the #evil one#'s key will be&provided by Zelda once #%d |Spiritual&Stone# is|Spiritual&Stones# are| "
+            "And the %revil one%w's key will be&provided by Zelda once %r%d&|Spiritual Stone%w is|Spiritual Stones%w are| "
             "retrieved.",
-            /*french*/ "Aussi, Zelda crééra la clé du&#Malin# avec #%d des |pierre&spirituelle|pierres&spirituelles|#.",
+            /*french*/ "Aussi, Zelda crééra la clé du&%rMalin%w avec %r%d des |pierre&spirituelle|pierres&spirituelles|%w.",
             /*spanish*/
             "Y Zelda entregará la llave&del #señor del mal# tras obtener&#%d |piedra espiritual|piedras "
             "espirituales|#." },
@@ -2767,11 +2767,11 @@ void HintTable_Init() {
 
     hintTable[LACS_REWARDS_HINT] = HintText::LACS({
         // obscure text                                                     singular                         plural
-        Text{ "And the #evil one#'s key will be&provided by Zelda once #%d |Spiritual&Stone or Medallion# "
-              "is|Spiritual&Stones and Medallions# are| retrieved.",
+        Text{ "And the %revil oneRw's key will be&provided by Zelda once %r%d&|Spiritual Stone or Medallion%w "
+              "is|Spiritual Stones and Medallions%w&are| retrieved.",
               /*french*/
-              "Aussi, Zelda crééra la clé du&#Malin# avec #%d |Pierre Ancestrale&et des médaillon|Pierres "
-              "Ancestrales&et des médaillons|#.",
+              "Aussi, Zelda crééra la clé du&%rMalin%w avec %r%d |Pierre Ancestrale&et des médaillon|Pierres "
+              "Ancestrales&et des médaillons|%w.",
               /*spanish*/
               "Y Zelda entregará la llave&del #señor del mal# tras obtener&#%d |piedra espiritual o medallón|piedras "
               "espirituales o medallones|#." },
@@ -2779,16 +2779,16 @@ void HintTable_Init() {
 
     hintTable[LACS_DUNGEONS_HINT] = HintText::LACS({
         // obscure text                                                     singular    plural
-        Text{ "And the #evil one#'s key will be&provided by Zelda once #%d |Dungeon#&is|Dungeons#&are| conquered.",
-              /*french*/ "Aussi, Zelda crééra la clé du&#Malin# une fois #%d |donjon conquéri|donjons conquéris|#.",
+        Text{ "And the %revil one%w's key will be&provided by Zelda once %r%d&|Dungeon%w is|Dungeons%w are| conquered.",
+              /*french*/ "Aussi, Zelda crééra la clé du&%rMalin%w une fois %r%d |donjon&conquéri|donjons&conquéris|%w.",
               /*spanish*/ "Y Zelda entregará la llave&del #señor del mal# tras completar&#%d |mazmorra|mazmorras|#." },
     });
 
     hintTable[LACS_TOKENS_HINT] = HintText::LACS({
         // obscure text                                                     singular                 plural
-        Text{ "And the #evil one#'s key will be&provided by Zelda once #%d |Gold&Skulltula Token# is|Gold&Skulltula "
-              "Tokens# are| retrieved.",
-              /*french*/ "Aussi, Zelda crééra la clé du&#Malin# avec #%d |symbole|symboles| de&Skulltula d'or#.",
+        Text{ "And the %revil one%w's key will be&provided by Zelda once %r%d |Gold&Skulltula Token%w is|Gold&Skulltula "
+              "Tokens%w are| retrieved.",
+              /*french*/ "Aussi, Zelda crééra la clé du&%rMalin%w avec %r%d |symbole|symboles| de&Skulltula d'or%w.",
               /*spanish*/
               "Y Zelda entregará la llave&del #señor del mal# tras obtener&#%d |símbolo|símbolos| de&skulltula "
               "dorada#." },

--- a/soh/soh/Enhancements/randomizer/3drando/hint_list.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/hint_list.cpp
@@ -2767,7 +2767,7 @@ void HintTable_Init() {
 
     hintTable[LACS_REWARDS_HINT] = HintText::LACS({
         // obscure text                                                     singular                         plural
-        Text{ "And the %revil oneRw's key will be&provided by Zelda once %r%d&|Spiritual Stone or Medallion%w "
+        Text{ "And the %revil oneRw's key will be&provided by Zelda once %r%d&|Spiritual Stone or Medallion%w&"
               "is|Spiritual Stones and Medallions%w&are| retrieved.",
               /*french*/
               "Aussi, Zelda crééra la clé du&%rMalin%w avec %r%d |Pierre Ancestrale&et des médaillon|Pierres "

--- a/soh/soh/Enhancements/randomizer/3drando/hint_list.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/hint_list.cpp
@@ -2632,8 +2632,7 @@ void HintTable_Init() {
         // obscure text
         Text{ "The awakened ones require&the Shadow and Spirit Medallions&as well as the Light Arrows.",
               /*french*/
-              "Les êtres de sagesse attendront&le héros muni des #Médaillons de&l'Ombre et l'Esprit# et des&#Flèches "
-              "de Lumière#.",
+              "Les êtres de sagesse attendront&le héros muni des %rMédaillons de&l'Ombre et l'Esprit%w et des&%yFlèches de Lumière%w.",
               /*spanish*/
               "Los sabios aguardarán a que el héroe&obtenga tanto el #Medallón de las&Sombras y el del Espíritu# junto "
               "a la #flecha de luz#." },
@@ -2643,14 +2642,14 @@ void HintTable_Init() {
         // obscure text                                                  singular        plural
         Text{
             "The awakened ones will&await for the Hero to collect&%d |Spiritual Stone|Spiritual Stones|.",
-            /*french*/ "Les êtres de sagesse attendront&le héros muni de #%d |Pierre&Ancestrale|Pierres&Ancestrales|#.",
+            /*french*/ "Les êtres de sagesse attendront&le héros muni de %r%d |Pierre&Ancestrale|Pierres&Ancestrales|%w.",
             /*spanish*/ "Los sabios aguardarán a que el héroe&obtenga #%d |piedra espiritual|piedras espirituales|#." },
     });
 
     hintTable[BRIDGE_MEDALLIONS_HINT] = HintText::Bridge({
         // obscure text                                                  singular  plural
         Text{ "The awakened ones will await&for the Hero to collect&%d |Medallion|Medallions|.",
-              /*french*/ "Les êtres de sagesse attendront&le héros muni de #%d |médaillon|médaillons|#.",
+              /*french*/ "Les êtres de sagesse attendront&le héros muni de %r#%d |Médaillon|Médaillons|%w.",
               /*spanish*/ "Los sabios aguardarán a que el héroe&obtenga #%d |medallón|medallones|#." },
     });
 
@@ -2659,8 +2658,7 @@ void HintTable_Init() {
         Text{ "The awakened ones will await&for the Hero to collect&%d |Spiritual Stone or Medallion|Spiritual Stones "
               "and Medallions|.",
               /*french*/
-              "Les êtres de sagesse attendront&le héros muni de #%d |Pierre&Ancestrale ou "
-              "Médaillon|Pierres&Ancestrales ou Médaillons|#.",
+              "Les êtres de sagesse attendront&le héros muni de %r%d |Pierre&Ancestrale ou Médaillon|Pierres&Ancestrales ou Médaillons|%w.",
               /*spanish*/
               "Los sabios aguardarán a que el héroe&obtenga #%d |piedra espiritual o medallón|piedras espirtuales y "
               "medallones|#." },
@@ -2669,14 +2667,14 @@ void HintTable_Init() {
     hintTable[BRIDGE_DUNGEONS_HINT] = HintText::Bridge({
         // obscure text                                                  singular plural
         Text{ "The awakened ones will await&for the Hero to conquer&%d |Dungeon|Dungeons|.",
-              /*french*/ "Les êtres de sagesse attendront&la conquête de #%d |Donjon|Donjons|#.",
+              /*french*/ "Les êtres de sagesse attendront&la conquête de %r%d |Donjon|Donjons|%w.",
               /*spanish*/ "Los sabios aguardarán a que el héroe& complete #%d |mazmorra|mazmorras|#." },
     });
 
     hintTable[BRIDGE_TOKENS_HINT] = HintText::Bridge({
         // obscure text
         Text{ "The awakened ones will await&for the Hero to collect&%d |Gold Skulltula Token|Gold Skulltula Tokens|.",
-              /*french*/ "Les êtres de sagesse attendront&le héros muni de #%d |Symbole|Symboles| &de Skulltula d'or#.",
+              /*french*/ "Les êtres de sagesse attendront&le héros muni de %r%d |Symbole|Symboles| &de Skulltula d'or%w.",
               /*spanish*/ "Los sabios aguardarán a que el héroe&obtenga #%d |símbolo|símbolos| de&skulltula dorada#." },
     });
 
@@ -2741,7 +2739,7 @@ void HintTable_Init() {
         // obscure text
         Text{
             "And the %revil one%w's key will be&provided by Zelda once the&%rShadow and Spirit Medallions%w&are retrieved.",
-            /*french*/ "Aussi, Zelda crééra la clé du&%rMalin%w avec les %rmédaillons de&l'ombre et de l'esprit%w.",
+            /*french*/ "Aussi, la %rclé du Malin%w sera&fournie par Zelda une fois que &les %rMédaillons de l'Ombre et de&l'Esprit%w seront récupérés.",
             /*spanish*/
             "Y Zelda entregará la llave&del #señor del mal# tras obtener&#el medallón de las sombras y del "
             "espíritu#." },
@@ -2750,7 +2748,7 @@ void HintTable_Init() {
     hintTable[LACS_MEDALLIONS_HINT] = HintText::LACS({
         // obscure text                                                     singular      plural
         Text{ "And the %revil one%w's key will be&provided by Zelda once %r%d&|Medallion%w is|Medallions%w are| retrieved.",
-              /*french*/ "Aussi, Zelda crééra la clé du&%rMalin%w avec %r%d |médaillon|médaillons|%w.",
+              /*french*/ "Aussi, la %rclé du Malin%w sera&fournie par Zelda une fois |qu'&%r%d Médaillon%w aura été&récupéré|que&%r%d Médaillons%w auront été&récupérés|.",
               /*spanish*/ "Y Zelda entregará la llave&del #señor del mal# tras obtener&#%d |medallón|medallones|#." },
     });
 
@@ -2759,7 +2757,7 @@ void HintTable_Init() {
         Text{
             "And the %revil one%w's key will be&provided by Zelda once %r%d&|Spiritual Stone%w is|Spiritual Stones%w are| "
             "retrieved.",
-            /*french*/ "Aussi, Zelda crééra la clé du&%rMalin%w avec %r%d des |pierre&spirituelle|pierres&spirituelles|%w.",
+            /*french*/ "Aussi, la %rclé du Malin%w sera&fournie par Zelda une fois |qu'&%r%d Pierre Ancestrale%w aura été&récupérée|que&%r%d Pierres Ancestrales%w auront été&récupérées|.",
             /*spanish*/
             "Y Zelda entregará la llave&del #señor del mal# tras obtener&#%d |piedra espiritual|piedras "
             "espirituales|#." },
@@ -2770,8 +2768,7 @@ void HintTable_Init() {
         Text{ "And the %revil one%w's key will be&provided by Zelda once %r%d&|Spiritual Stone or Medallion%w&"
               "is|Spiritual Stones and Medallions%w&are| retrieved.",
               /*french*/
-              "Aussi, Zelda crééra la clé du&%rMalin%w avec %r%d |Pierre Ancestrale&et des médaillon|Pierres "
-              "Ancestrales&et des médaillons|%w.",
+              "Aussi, la %rclé du Malin%w sera&fournie par Zelda une fois |qu'&%r%d Pierre Ancestrale ou %d&Médaillon%w sera récupéré|que&%r%d Pierres Ancestrales&et&Médaillons%w seront récupérés|.",
               /*spanish*/
               "Y Zelda entregará la llave&del #señor del mal# tras obtener&#%d |piedra espiritual o medallón|piedras "
               "espirituales o medallones|#." },
@@ -2780,7 +2777,7 @@ void HintTable_Init() {
     hintTable[LACS_DUNGEONS_HINT] = HintText::LACS({
         // obscure text                                                     singular    plural
         Text{ "And the %revil one%w's key will be&provided by Zelda once %r%d&|Dungeon%w is|Dungeons%w are| conquered.",
-              /*french*/ "Aussi, Zelda crééra la clé du&%rMalin%w une fois %r%d |donjon&conquéri|donjons&conquéris|%w.",
+              /*french*/ "Aussi, la %rclé du Malin%w sera&fournie par Zelda une fois |qu'&%r%d donjon %wsera conquis|que&%r%d donjons%w seront conquis|.",
               /*spanish*/ "Y Zelda entregará la llave&del #señor del mal# tras completar&#%d |mazmorra|mazmorras|#." },
     });
 
@@ -2788,7 +2785,7 @@ void HintTable_Init() {
         // obscure text                                                     singular                 plural
         Text{ "And the %revil one%w's key will be&provided by Zelda once %r%d |Gold&Skulltula Token%w is|Gold&Skulltula "
               "Tokens%w are| retrieved.",
-              /*french*/ "Aussi, Zelda crééra la clé du&%rMalin%w avec %r%d |symbole|symboles| de&Skulltula d'or%w.",
+              /*french*/ "Aussi, la %rclé du Malin%w sera&fournie par Zelda une fois |qu'&%r%d symbole de Skulltula d'or&%wsera récupuéré|que &%r%d symboles de Skulltula d'or&%wseront recupérés|.",
               /*spanish*/
               "Y Zelda entregará la llave&del #señor del mal# tras obtener&#%d |símbolo|símbolos| de&skulltula "
               "dorada#." },


### PR DESCRIPTION
The hints for the LACS hint needed to be updated for our text coloring and the new lines re-positioned. Some hints required 4 lines of text for English, but still look ok.

Fixes #1844

### Vanilla
![english_vanilla](https://user-images.githubusercontent.com/13861068/197656079-2fc770cd-4848-4ced-b155-02a19d4aa545.png)
![new_french_vanilla](https://user-images.githubusercontent.com/13861068/197806797-0f7f0917-8359-4abf-8257-80a671a9cdf1.png)


### Medallions
![english_medallions](https://user-images.githubusercontent.com/13861068/197656138-31ebc144-7531-4ca0-9350-5b82acb70bbd.png)
![new_french_medallions](https://user-images.githubusercontent.com/13861068/197806849-50a16683-10c1-4a57-904f-5b0c506f8ca7.png)

### Stones
![english_stones](https://user-images.githubusercontent.com/13861068/197656173-daef5af8-83cf-4c29-a9b5-b9af2aafae83.png)
![new_french_stones](https://user-images.githubusercontent.com/13861068/197806887-5aae3ca7-232d-477e-9c85-c256fcd0b028.png)

### Dungeon Rewards
![english_rewards](https://user-images.githubusercontent.com/13861068/197656295-04a428b6-ad9a-405b-9575-187e834a8c14.png)
![new_french_rewards](https://user-images.githubusercontent.com/13861068/197806916-537f45e2-d5f5-4409-b624-1c0ab7677fcd.png)

### Dungeons Completed
![english_dungeons](https://user-images.githubusercontent.com/13861068/197656416-8cbf14fa-e41c-4a37-85eb-e16292f11e2f.png)
![new_french_dungeons](https://user-images.githubusercontent.com/13861068/197806964-aed912a9-0823-4a2e-843e-abb38b49b71f.png)

### Skull Tokens
![english_tokens](https://user-images.githubusercontent.com/13861068/197656460-b9398dee-2c2b-4e22-8543-eda56a68e044.png)
![new_french_tokens](https://user-images.githubusercontent.com/13861068/197806986-f7a65dad-8be3-4966-bc34-6874aa790754.png)
