### PR TITLE
Fix rando save creation crash due to corrupted hint text

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -987,19 +987,19 @@ void Randomizer::ParseHintLocationsFile(const char* spoilerFileName) {
 
         std::string childAltarJsonText = spoilerFileJson["childAltarText"].get<std::string>();
         std::string formattedChildAltarText = FormatJsonHintText(childAltarJsonText);
-        memcpy(gSaveContext.childAltarText, formattedChildAltarText.c_str(), formattedChildAltarText.length());
+        memcpy(gSaveContext.childAltarText, formattedChildAltarText.c_str(), formattedChildAltarText.length() + 1);
 
         std::string adultAltarJsonText = spoilerFileJson["adultAltarText"].get<std::string>();
         std::string formattedAdultAltarText = FormatJsonHintText(adultAltarJsonText);
-        memcpy(gSaveContext.adultAltarText, formattedAdultAltarText.c_str(), formattedAdultAltarText.length());
+        memcpy(gSaveContext.adultAltarText, formattedAdultAltarText.c_str(), formattedAdultAltarText.length() + 1);
 
         std::string ganonHintJsonText = spoilerFileJson["ganonHintText"].get<std::string>();
         std::string formattedGanonHintJsonText = FormatJsonHintText(ganonHintJsonText);
-        memcpy(gSaveContext.ganonHintText, formattedGanonHintJsonText.c_str(), formattedGanonHintJsonText.length());
+        memcpy(gSaveContext.ganonHintText, formattedGanonHintJsonText.c_str(), formattedGanonHintJsonText.length() + 1);
 
         std::string ganonJsonText = spoilerFileJson["ganonText"].get<std::string>();
         std::string formattedGanonJsonText = FormatJsonHintText(ganonJsonText);
-        memcpy(gSaveContext.ganonText, formattedGanonJsonText.c_str(), formattedGanonJsonText.length());
+        memcpy(gSaveContext.ganonText, formattedGanonJsonText.c_str(), formattedGanonJsonText.length() + 1);
 
         json hintsJson = spoilerFileJson["hints"];
         int index = 0;
@@ -1007,7 +1007,7 @@ void Randomizer::ParseHintLocationsFile(const char* spoilerFileName) {
             gSaveContext.hintLocations[index].check = SpoilerfileCheckNameToEnum[it.key()];
 
             std::string hintMessage = FormatJsonHintText(it.value());
-            memcpy(gSaveContext.hintLocations[index].hintText, hintMessage.c_str(), hintMessage.length());
+            memcpy(gSaveContext.hintLocations[index].hintText, hintMessage.c_str(), hintMessage.length() + 1);
 
             index++;
         }

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -981,8 +981,8 @@ void Randomizer::ParseHintLocationsFile(const char* spoilerFileName) {
 
     bool success = false;
 
-    // Have all these use strncpy so that the nul terminator is copied 
-    // and also set the last index to nul for safety
+    // Have all these use strncpy so that the null terminator is copied 
+    // and also set the last index to null for safety
     try {
         json spoilerFileJson;
         spoilerFileStream >> spoilerFileJson;

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -981,26 +981,31 @@ void Randomizer::ParseHintLocationsFile(const char* spoilerFileName) {
 
     bool success = false;
 
-    // Have all these use strcpy so that the nul terminator is copied as well
+    // Have all these use strncpy so that the nul terminator is copied 
+    // and also set the last index to nul for safety
     try {
         json spoilerFileJson;
         spoilerFileStream >> spoilerFileJson;
 
         std::string childAltarJsonText = spoilerFileJson["childAltarText"].get<std::string>();
         std::string formattedChildAltarText = FormatJsonHintText(childAltarJsonText);
-        strcpy(gSaveContext.childAltarText, formattedChildAltarText.c_str());
+        strncpy(gSaveContext.childAltarText, formattedChildAltarText.c_str(), sizeof(gSaveContext.childAltarText) - 1);
+        gSaveContext.childAltarText[sizeof(gSaveContext.childAltarText) - 1] = 0;
 
         std::string adultAltarJsonText = spoilerFileJson["adultAltarText"].get<std::string>();
         std::string formattedAdultAltarText = FormatJsonHintText(adultAltarJsonText);
-        strcpy(gSaveContext.adultAltarText, formattedAdultAltarText.c_str());
+        strncpy(gSaveContext.adultAltarText, formattedAdultAltarText.c_str(), sizeof(gSaveContext.adultAltarText) - 1);
+        gSaveContext.adultAltarText[sizeof(gSaveContext.adultAltarText) - 1] = 0;
 
         std::string ganonHintJsonText = spoilerFileJson["ganonHintText"].get<std::string>();
         std::string formattedGanonHintJsonText = FormatJsonHintText(ganonHintJsonText);
-        strcpy(gSaveContext.ganonHintText, formattedGanonHintJsonText.c_str());
+        strncpy(gSaveContext.ganonHintText, formattedGanonHintJsonText.c_str(), sizeof(gSaveContext.ganonHintText) - 1);
+        gSaveContext.ganonHintText[sizeof(gSaveContext.ganonHintText) - 1] = 0;
 
         std::string ganonJsonText = spoilerFileJson["ganonText"].get<std::string>();
         std::string formattedGanonJsonText = FormatJsonHintText(ganonJsonText);
-        strcpy(gSaveContext.ganonText, formattedGanonJsonText.c_str());
+        strncpy(gSaveContext.ganonText, formattedGanonJsonText.c_str(), sizeof(gSaveContext.ganonText) - 1);
+        gSaveContext.ganonText[sizeof(gSaveContext.ganonText) - 1] = 0;
 
         json hintsJson = spoilerFileJson["hints"];
         int index = 0;
@@ -1008,7 +1013,9 @@ void Randomizer::ParseHintLocationsFile(const char* spoilerFileName) {
             gSaveContext.hintLocations[index].check = SpoilerfileCheckNameToEnum[it.key()];
 
             std::string hintMessage = FormatJsonHintText(it.value());
-            strcpy(gSaveContext.hintLocations[index].hintText, hintMessage.c_str());
+            size_t maxHintTextSize = sizeof(gSaveContext.hintLocations[index].hintText);
+            strncpy(gSaveContext.hintLocations[index].hintText, hintMessage.c_str(), maxHintTextSize - 1);
+            gSaveContext.hintLocations[index].hintText[maxHintTextSize - 1] = 0;
 
             index++;
         }

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -981,25 +981,26 @@ void Randomizer::ParseHintLocationsFile(const char* spoilerFileName) {
 
     bool success = false;
 
+    // Have all these use strcpy so that the nul terminator is copied as well
     try {
         json spoilerFileJson;
         spoilerFileStream >> spoilerFileJson;
 
         std::string childAltarJsonText = spoilerFileJson["childAltarText"].get<std::string>();
         std::string formattedChildAltarText = FormatJsonHintText(childAltarJsonText);
-        memcpy(gSaveContext.childAltarText, formattedChildAltarText.c_str(), formattedChildAltarText.length() + 1);
+        strcpy(gSaveContext.childAltarText, formattedChildAltarText.c_str());
 
         std::string adultAltarJsonText = spoilerFileJson["adultAltarText"].get<std::string>();
         std::string formattedAdultAltarText = FormatJsonHintText(adultAltarJsonText);
-        memcpy(gSaveContext.adultAltarText, formattedAdultAltarText.c_str(), formattedAdultAltarText.length() + 1);
+        strcpy(gSaveContext.adultAltarText, formattedAdultAltarText.c_str());
 
         std::string ganonHintJsonText = spoilerFileJson["ganonHintText"].get<std::string>();
         std::string formattedGanonHintJsonText = FormatJsonHintText(ganonHintJsonText);
-        memcpy(gSaveContext.ganonHintText, formattedGanonHintJsonText.c_str(), formattedGanonHintJsonText.length() + 1);
+        strcpy(gSaveContext.ganonHintText, formattedGanonHintJsonText.c_str());
 
         std::string ganonJsonText = spoilerFileJson["ganonText"].get<std::string>();
         std::string formattedGanonJsonText = FormatJsonHintText(ganonJsonText);
-        memcpy(gSaveContext.ganonText, formattedGanonJsonText.c_str(), formattedGanonJsonText.length() + 1);
+        strcpy(gSaveContext.ganonText, formattedGanonJsonText.c_str());
 
         json hintsJson = spoilerFileJson["hints"];
         int index = 0;
@@ -1007,7 +1008,7 @@ void Randomizer::ParseHintLocationsFile(const char* spoilerFileName) {
             gSaveContext.hintLocations[index].check = SpoilerfileCheckNameToEnum[it.key()];
 
             std::string hintMessage = FormatJsonHintText(it.value());
-            memcpy(gSaveContext.hintLocations[index].hintText, hintMessage.c_str(), hintMessage.length() + 1);
+            strcpy(gSaveContext.hintLocations[index].hintText, hintMessage.c_str());
 
             index++;
         }


### PR DESCRIPTION
In testing #1845 I found a crash that would occur when creating a rando save.
The crash seemed to happen when first generating a rando seed with French, and then a second seed with English, then create a new save.

I found the memcpy's for all the hint text parsing from the spoiler log was not including the nul terminator, which would cause a crash when the gSaveContext gets saved to file due to a corrupt unicode character. This leaves a incomplete save file that will crash on load until the user deletes the save file manually.

I debated between either adding `+1` to the `memcpy` length or to just switch to `strcpy`. If we prefer `strcpy`, I can switch to that instead.

Notice the garbage at the end of each string for saves from before this change.

#### Before:
```json
"ganonHintText": "Ha ha ha... You'll never beat me&by reflecting my lightning bolts&and unleashing the arrows from&Inside Ganon's Castle!\u0002u de Ganon!\u0002",
"ganonText": "What about Zelda makes you think&she'd be a better ruler than I?^I saved Lon Lon Ranch,&fed the hungry,&and my castle floats.\u0002ins sont clairement&plus puissants que jamais!\u0002",
"hintLocations": [
    {
        "check": 703,
        "hintText": "They say good tidings to you^my traitorous @\u0002a Place du Marché.\u0002.\u0002ods.\u0002 Small Key.\u0002ken.\u0002"
    },
    {
        "check": 704,
        "hintText": "They say that Inside Ganon's&Castle hoards a Bow.\u0002faute à Purple Hato!&J'vous jure!\u0002"
    },
```

#### After:
```json
"ganonHintText": "Ha ha ha... You'll never beat me&by reflecting my lightning bolts&and unleashing the arrows from&Inside Ganon's Castle!\u0002",
"ganonText": "What about Zelda makes you think&she'd be a better ruler than I?^I saved Lon Lon Ranch,&fed the hungry,&and my castle floats.\u0002",
"hintLocations": [
    {
        "check": 703,
        "hintText": "They say good tidings to you^my traitorous @\u0002"
    },
    {
        "check": 704,
        "hintText": "They say that Inside Ganon's&Castle hoards a Bow.\u0002"
    },
```
Here is a zip that contains a French and English spoiler that are guaranteed to repro the issue when dragging the French seed first, then the English, then creating a save
[spoilers.zip](https://github.com/HarbourMasters/Shipwright/files/9857471/spoilers.zip)

Separately, I don't understand why we are appending `0x02` to the end of all the hints? It seems hints work even without it. Previously, I guess the `0x02` would prevent the garbage characters from being read in game, but does a nul terminator do the same thing?

https://github.com/HarbourMasters/Shipwright/blob/73da5a173534c99f2d7eece4a16689cb6b5adc0c/soh/soh/Enhancements/randomizer/randomizer.cpp#L972