### PR TITLE
Show player state flags on the "Player" tab of Save Editor

### DIFF
--- a/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
+++ b/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
@@ -1564,8 +1564,8 @@ void DrawPlayerTab() {
         });
 
         ImGui::Text("Player State");
-        u8 bit[32] = {};
-        u32 flags[3] = { player->stateFlags1, player->stateFlags2, player->stateFlags3 };
+        uint8_t bit[32] = {};
+        uint32_t flags[3] = { player->stateFlags1, player->stateFlags2, player->stateFlags3 };
 
         for (int j = 0; j <= 2; j++) {
             DrawGroupWithBorder([&]() {

--- a/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
+++ b/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
@@ -1563,6 +1563,27 @@ void DrawPlayerTab() {
             }
         });
 
+        ImGui::Text("Player State");
+        u8 bit[32] = {};
+        u32 flags[3] = { player->stateFlags1, player->stateFlags2, player->stateFlags3 };
+
+        for (int j = 0; j <= 2; j++) {
+            DrawGroupWithBorder([&]() {
+                ImGui::Text("State Flags %d", j + 1);
+                for (int i = 0; i <= 31; i++) {
+                    bit[i] = ((flags[j] >> i) & 1);
+                    if (bit[i] != 0) {
+                        ImGui::Text("Flag %d", i);
+                    }
+                }
+            });
+            ImGui::SameLine();
+        }
+        DrawGroupWithBorder([&]() {
+            ImGui::Text("Sword");
+            ImGui::Text("  %d", player->swordState);
+        });
+
     } else {
         ImGui::Text("Global Context needed for player info!");
     }


### PR DESCRIPTION
This would expose the currently active player state flags at the bottom of the "Player" tab in the Save Editor. Inactive flags are not shown. Hopefully this can be used to help with debugging, or just for better understanding of the player actor.

![sign](https://user-images.githubusercontent.com/108380086/197910429-1d06b3e6-237e-4edb-82ea-f352d501f23b.PNG)
![jumpslash](https://user-images.githubusercontent.com/108380086/197910445-e7f99d5d-3c68-40ea-9d52-4b8f21e25b81.PNG)

The "Flags" tab could also be a suitable place for this, but I figured it should go with the other player properties (i.e. position, rotation, velocity).