### PR TITLE
Redone fast file select

### DIFF
--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -1465,13 +1465,11 @@ namespace GameMenuBar {
                     "File N.1",
                     "File N.2",
                     "File N.3",
+                    "Zelda Map Select (require OoT Debug Mode)",
                     "File select",
-                    "Zelda Map Select (require OoT Debug Mode)"
                 };
                 ImGui::Text("Loading :");
                 UIWidgets::EnhancementCombobox("gSaveFileID", FastFileSelect, 5, 0);
-                UIWidgets::PaddedEnhancementCheckbox("Create a new save if none", "gCreateNewSave", true, false);
-                UIWidgets::Tooltip("Enable the creation of a new save file if none exist in the File number selected\nNo file name will be assigned please do in Save editor once you see the first text else your save file name will be named \"00000000\"\nIf disabled you will fall back in File select menu");
             };
             UIWidgets::PaddedEnhancementCheckbox("Better Debug Warp Screen", "gBetterDebugWarpScreen", true, false);
             UIWidgets::Tooltip("Optimized debug warp screen, with the added ability to chose entrances and time of day");

--- a/soh/soh/SaveManager.cpp
+++ b/soh/soh/SaveManager.cpp
@@ -689,14 +689,13 @@ void SaveManager::LoadFile(int fileNum) {
 }
 
 bool SaveManager::SaveFile_Exist(int fileNum) {
-    
     try {
-        std::filesystem::exists(GetFileName(fileNum));
-        printf("File[%d] - exist \n",fileNum);
-        return true;
+        bool exists = std::filesystem::exists(GetFileName(fileNum));
+        SPDLOG_INFO("File[{}] - {}", fileNum, exists ? "exists" : "does not exist" );
+        return exists;
     }
     catch(std::filesystem::filesystem_error const& ex) {
-        printf("File[%d] - do not exist \n",fileNum);
+        SPDLOG_ERROR("Filesystem error");
         return false;
     }
 }

--- a/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -12,6 +12,7 @@ static s16 sUnused = 106;
 
 static s16 sScreenFillAlpha = 255;
 
+static u8 isFastFileIdIncompatible = 0;
 
 static Gfx sScreenFillSetupDL[] = {
     gsDPPipeSync(),
@@ -1791,13 +1792,13 @@ void FileChoose_Main(GameState* thisx) {
         gSaveContext.skyboxTime += 0x10;
     }
 
-    if (CVar_GetS32("gSkipLogoTitle", 0) && CVar_GetS32("gSaveFileID", 0) < 3) {
+    if (CVar_GetS32("gSkipLogoTitle", 0) && CVar_GetS32("gSaveFileID", 0) < 3 && !isFastFileIdIncompatible) {
         if (Save_Exist(CVar_GetS32("gSaveFileID", 0)) && FileChoose_IsSaveCompatible(Save_GetSaveMetaInfo(CVar_GetS32("gSaveFileID", 0)))) {
             this->buttonIndex = CVar_GetS32("gSaveFileID", 0);
             this->menuMode = FS_MENU_MODE_SELECT;
             this->selectMode = SM_LOAD_GAME;
         } else {
-            CVar_SetS32("gSaveFileID", 4);
+            isFastFileIdIncompatible = 1;
         }
     } else if (CVar_GetS32("gSkipLogoTitle", 0) && CVar_GetS32("gSaveFileID", 0) == 3) {
         this->buttonIndex = 0xFF;
@@ -2119,6 +2120,7 @@ void FileChoose_Init(GameState* thisx) {
     size_t size = (u32)_title_staticSegmentRomEnd - (u32)_title_staticSegmentRomStart;
     s32 pad;
     fileSelectSpoilerFileLoaded = false;
+    isFastFileIdIncompatible = 0;
     CVar_SetS32("gOnFileSelectNameEntry", 0);
 
     SREG(30) = 1;

--- a/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -1608,10 +1608,14 @@ void FileChoose_LoadGame(GameState* thisx) {
     u16 swordEquipMask;
     s32 pad;
 
-    if (this->buttonIndex == FS_BTN_SELECT_FILE_1 && CVar_GetS32("gDebugEnabled", 0)) {
+    if ((this->buttonIndex == FS_BTN_SELECT_FILE_1 && CVar_GetS32("gDebugEnabled", 0)) || this->buttonIndex == 0xFF) {
         Audio_PlaySoundGeneral(NA_SE_SY_FSEL_DECIDE_L, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
         gSaveContext.fileNum = this->buttonIndex;
-        Sram_OpenSave();
+        if (this->buttonIndex == 0xFF) {
+            Sram_InitDebugSave();
+        } else {
+            Sram_OpenSave();
+        }
         gSaveContext.gameMode = 0;
         SET_NEXT_GAMESTATE(&this->state, Select_Init, SelectContext);
         this->state.running = false;
@@ -1627,7 +1631,9 @@ void FileChoose_LoadGame(GameState* thisx) {
     Randomizer_LoadSettings("");
     Randomizer_LoadHintLocations("");
     Randomizer_LoadItemLocations("", true);
+    Randomizer_LoadRequiredTrials("");
     Randomizer_LoadMerchantMessages("");
+    Randomizer_LoadMasterQuestDungeons("");
 
     gSaveContext.respawn[0].entranceIndex = -1;
     gSaveContext.respawnFlag = 0;
@@ -1783,6 +1789,20 @@ void FileChoose_Main(GameState* thisx) {
 
     if (CVar_GetS32("gTimeFlowFileSelect", 0) != 0) {
         gSaveContext.skyboxTime += 0x10;
+    }
+
+    if (CVar_GetS32("gSkipLogoTitle", 0) && CVar_GetS32("gSaveFileID", 0) < 3) {
+        if (Save_Exist(CVar_GetS32("gSaveFileID", 0))) {
+            this->buttonIndex = CVar_GetS32("gSaveFileID", 0);
+            this->menuMode = FS_MENU_MODE_SELECT;
+            this->selectMode = SM_LOAD_GAME;
+        } else {
+            CVar_SetS32("gSaveFileID", 4);
+        }
+    } else if (CVar_GetS32("gSkipLogoTitle", 0) && CVar_GetS32("gSaveFileID", 0) == 3) {
+        this->buttonIndex = 0xFF;
+        this->menuMode = FS_MENU_MODE_SELECT;
+        this->selectMode = SM_LOAD_GAME;
     }
 
     OPEN_DISPS(this->state.gfxCtx);

--- a/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -1792,7 +1792,7 @@ void FileChoose_Main(GameState* thisx) {
     }
 
     if (CVar_GetS32("gSkipLogoTitle", 0) && CVar_GetS32("gSaveFileID", 0) < 3) {
-        if (Save_Exist(CVar_GetS32("gSaveFileID", 0))) {
+        if (Save_Exist(CVar_GetS32("gSaveFileID", 0)) && FileChoose_IsSaveCompatible(Save_GetSaveMetaInfo(CVar_GetS32("gSaveFileID", 0)))) {
             this->buttonIndex = CVar_GetS32("gSaveFileID", 0);
             this->menuMode = FS_MENU_MODE_SELECT;
             this->selectMode = SM_LOAD_GAME;

--- a/soh/src/overlays/gamestates/ovl_title/z_title.c
+++ b/soh/src/overlays/gamestates/ovl_title/z_title.c
@@ -12,6 +12,7 @@
 #include <soh/Enhancements/bootcommands.h>
 #include <libultraship/GameVersions.h>
 #include <soh/SaveManager.h>
+#include "overlays/gamestates/ovl_file_choose/file_choose.h"
 
 #include "time.h"
 
@@ -243,13 +244,13 @@ void Title_Main(GameState* thisx) {
         POLY_OPA_DISP = gfx;
     }
 
-    if (this->exit) {
+    if (this->exit || CVar_GetS32("gSkipLogoTitle", 0)) {
         gSaveContext.seqId = (u8)NA_BGM_DISABLED;
         gSaveContext.natureAmbienceId = 0xFF;
         gSaveContext.gameMode = 1;
         this->state.running = false;
 
-        if (gLoadFileSelect)
+        if (gLoadFileSelect || CVar_GetS32("gSkipLogoTitle", 0))
             SET_NEXT_GAMESTATE(&this->state, FileChoose_Init, FileChooseContext);
         else
             SET_NEXT_GAMESTATE(&this->state, Opening_Init, OpeningContext);
@@ -267,99 +268,28 @@ void Title_Destroy(GameState* thisx) {
 void Title_Init(GameState* thisx) {
     //u32 size = 0;
     TitleContext* this = (TitleContext*)thisx;
-    FileChooseContext* FileChooseCtx = (FileChooseContext*)thisx;
 
-    if (CVar_GetS32("gSkipLogoTitle",0)) {
-        bool saveloading = false;
-        Sram_InitSram(&this->state.init);
-        gSaveContext.language = CVar_GetS32("gLanguages", 0);
-        s32 selectedfile = CVar_GetS32("gSaveFileID", 0);
-        if (selectedfile == 4) {
-            if (CVar_GetS32("gDebugEnabled",0)) {
-                selectedfile = 0xFF;
-            } else {
-                selectedfile = 3;
-            }
-        }
-        if (selectedfile < 0) {
-            selectedfile = 3; //If somehow the save file number under 0 revert back to 3 to prevent boot error
-        }
-        if(selectedfile == 3){
-            saveloading = true;
-            gSaveContext.seqId = (u8)NA_BGM_DISABLED;
-            gSaveContext.natureAmbienceId = 0xFF;
-            gSaveContext.gameMode = 1;
-            SET_NEXT_GAMESTATE(&this->state, FileChoose_Init, FileChooseContext);
-            this->state.running = false;
-            return;
-        } else if (selectedfile == 0xFF || selectedfile > 3) {
-            saveloading = true;
-            Sram_InitDebugSave();
-            gSaveContext.fileNum = selectedfile;
-            SET_NEXT_GAMESTATE(&this->state, Select_Init, SelectContext);
-            this->state.running = false;
-            return;
-        } else if (selectedfile >= 0 && selectedfile <= 2) {
-            if (Save_Exist(selectedfile) == true) { //The file exist load it
-                saveloading = true;
-                gSaveContext.fileNum = selectedfile;
-                Sram_OpenSave();
-                Randomizer_LoadSettings("");
-                Randomizer_LoadHintLocations("");
-                Randomizer_LoadItemLocations("", true);
-                Randomizer_LoadMerchantMessages("");
-                gSaveContext.gameMode = 0;
-                gSaveContext.magic = gSaveContext.magic;
-                SET_NEXT_GAMESTATE(&this->state, Gameplay_Init, GlobalContext);
-                this->state.running = false;
-                return;
-            } else { 
-                if (CVar_GetS32("gCreateNewSave",0)) {
-                    //File do not exist create a new save file
-                    saveloading = true;
-                    Sram_InitSram(&FileChooseCtx->state.init);
-                    gSaveContext.fileNum = selectedfile;
-                    Sram_InitSave(FileChooseCtx);
-                    Sram_OpenSave();      
-                    gSaveContext.gameMode = 0;
-                    SET_NEXT_GAMESTATE(&this->state, Gameplay_Init, GlobalContext);
-                    this->state.running = false;
-                    return;
-                } else {
-                    //File do not exist but user do not wish to auto create a save file with blank name
-                    saveloading = true;
-                    gSaveContext.seqId = (u8)NA_BGM_DISABLED;
-                    gSaveContext.natureAmbienceId = 0xFF;
-                    gSaveContext.gameMode = 1;
-                    SET_NEXT_GAMESTATE(&this->state, FileChoose_Init, FileChooseContext);
-                    this->state.running = false;
-                    return;
-                }
-            }
-        }
-    } else {
-        quote = SetQuote();
+    quote = SetQuote();
 
-        this->staticSegment = NULL;
-        //this->staticSegment = GAMESTATE_ALLOC_MC(&this->state, size);
-        osSyncPrintf("z_title.c\n");
-        //ASSERT(this->staticSegment != NULL);
+    this->staticSegment = NULL;
+    //this->staticSegment = GAMESTATE_ALLOC_MC(&this->state, size);
+    osSyncPrintf("z_title.c\n");
+    //ASSERT(this->staticSegment != NULL);
 
-        //ResourceMgr_CacheDirectory("nintendo_rogo_static*");
+    //ResourceMgr_CacheDirectory("nintendo_rogo_static*");
 
-        // Disable vismono
-        D_801614B0.a = 0;
-        R_UPDATE_RATE = 1;
-        Matrix_Init(&this->state);
-        View_Init(&this->view, this->state.gfxCtx);
-        this->state.main = Title_Main;
-        this->state.destroy = Title_Destroy;
-        this->exit = false;
-        gSaveContext.fileNum = 0xFF;
-        this->ult = 0;
-        this->unk_1D4 = 0x14;
-        this->coverAlpha = 255;
-        this->addAlpha = -3;
-        this->visibleDuration = 0x3C;
-    }
+    // Disable vismono
+    D_801614B0.a = 0;
+    R_UPDATE_RATE = 1;
+    Matrix_Init(&this->state);
+    View_Init(&this->view, this->state.gfxCtx);
+    this->state.main = Title_Main;
+    this->state.destroy = Title_Destroy;
+    this->exit = false;
+    gSaveContext.fileNum = 0xFF;
+    this->ult = 0;
+    this->unk_1D4 = 0x14;
+    this->coverAlpha = 255;
+    this->addAlpha = -3;
+    this->visibleDuration = 0x3C;
 }

--- a/soh/src/overlays/gamestates/ovl_title/z_title.c
+++ b/soh/src/overlays/gamestates/ovl_title/z_title.c
@@ -12,7 +12,6 @@
 #include <soh/Enhancements/bootcommands.h>
 #include <libultraship/GameVersions.h>
 #include <soh/SaveManager.h>
-#include "overlays/gamestates/ovl_file_choose/file_choose.h"
 
 #include "time.h"
 


### PR DESCRIPTION
Should resolve #1850 and prevent much further inconsistencies when loading from fast file select vs from the file select screen.

Effectively this is just using the file choose screen and manually setting state to load the file, so that fast file select acts exactly as loading a file from the file choose screen should.