### PR TITLE
Swap gNoRestrictAge to gTimelessEquipment

### DIFF
--- a/soh/src/code/z_message_PAL.c
+++ b/soh/src/code/z_message_PAL.c
@@ -1750,11 +1750,11 @@ void Message_OpenText(GlobalContext* globalCtx, u16 textId) {
                             //font->msgLength, __FILE__, __LINE__);
 
     } else if (CVar_GetS32("gAskToEquip", 0) &&
-               (((LINK_IS_ADULT || CVar_GetS32("gNoRestrictAge", 0)) &&
+               (((LINK_IS_ADULT || CVar_GetS32("gTimelessEquipment", 0)) &&
                  // 0C = Biggoron, 4B = Giant's, 4E = Mirror Shield, 50-51 = Tunics
                  (textId == 0x0C || textId == 0x4B || textId == 0x4E ||
                   textId == 0x50 || textId == 0x51)) ||
-                ((!LINK_IS_ADULT || CVar_GetS32("gNoRestrictAge", 0)) &&
+                ((!LINK_IS_ADULT || CVar_GetS32("gTimelessEquipment", 0)) &&
                 // 4C = Deku Shield, A4 = Kokiri Sword
                  (textId == 0x4C || textId == 0xA4)) ||
                 // 4D == Hylian Shield

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -9573,7 +9573,7 @@ void Player_Init(Actor* thisx, GlobalContext* globalCtx2) {
         for (uint16_t cSlotIndex = 0; cSlotIndex < ARRAY_COUNT(gSaveContext.equips.cButtonSlots); cSlotIndex++) {
             if (gSaveContext.equips.cButtonSlots[cSlotIndex] == SLOT_TRADE_CHILD &&
                 (gItemAgeReqs[gSaveContext.equips.buttonItems[cSlotIndex + 1]] != 9 && LINK_IS_ADULT &&
-                 !CVar_GetS32("gNoRestrictAge", 0))) {
+                 !CVar_GetS32("gTimelessEquipment", 0))) {
                 gSaveContext.equips.cButtonSlots[cSlotIndex] = SLOT_NONE;
                 gSaveContext.equips.buttonItems[cSlotIndex + 1] = ITEM_NONE;
             }
@@ -12587,7 +12587,7 @@ s32 func_8084DFF4(GlobalContext* globalCtx, Player* this) {
         equipItem = giEntry.itemId;
         equipNow = CVar_GetS32("gAskToEquip", 0) && equipItem >= ITEM_SWORD_KOKIRI && equipItem <= ITEM_TUNIC_ZORA &&
                    ((gItemAgeReqs[equipItem] == 9 || gItemAgeReqs[equipItem] == gSaveContext.linkAge) ||
-                    CVar_GetS32("gNoRestrictAge", 0));
+                    CVar_GetS32("gTimelessEquipment", 0));
 
         Message_StartTextbox(globalCtx, giEntry.textId, &this->actor);
         // RANDOTODO: Macro this boolean check.

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_item.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_item.c
@@ -394,7 +394,7 @@ void KaleidoScope_DrawItemSelect(GlobalContext* globalCtx) {
                         }
                         for (uint16_t cSlotIndex = 0; cSlotIndex < ARRAY_COUNT(gSaveContext.equips.cButtonSlots); cSlotIndex++) {
                             if (gSaveContext.equips.cButtonSlots[cSlotIndex] == SLOT_TRADE_CHILD) {
-                                if (!LINK_IS_ADULT || CVar_GetS32("gNoRestrictAge", 0)) {
+                                if (!LINK_IS_ADULT || CVar_GetS32("gTimelessEquipment", 0)) {
                                     gSaveContext.equips.buttonItems[cSlotIndex+1] = INV_CONTENT(ITEM_TRADE_CHILD);
                                 } else if (INV_CONTENT(ITEM_TRADE_CHILD) != gSaveContext.equips.buttonItems[cSlotIndex+1]) {
                                     gSaveContext.equips.cButtonSlots[cSlotIndex] = SLOT_NONE;


### PR DESCRIPTION
There was an old approved-but-unmerged PR #379 which included unrestricting items by age as a feature, behind the CVar `gNoRestrictAge`. Since that PR was approved, I proactively made certain PRs that accounted for that CVar so that they would be ready for it once merged.

Ultimately, the author closed that PR and #1644 was later merged, which included the same feature behind the CVar `gTimelessEquipment`. This updates the handful of dead-end `gNoRestrictAge` checks to use the new CVar.