### PR TITLE
Makes merchant prices array size not depend on Rando Setting Values

### DIFF
--- a/soh/soh/SaveManager.cpp
+++ b/soh/soh/SaveManager.cpp
@@ -177,12 +177,7 @@ void SaveManager::LoadRandomizerVersion2() {
     std::shared_ptr<Randomizer> randomizer = OTRGlobals::Instance->gRandomizer;
 
     size_t merchantPricesSize = 0;
-    if (randomizer->GetRandoSettingValue(RSK_SHUFFLE_SCRUBS) > 0) {
-        merchantPricesSize += NUM_SCRUBS;
-    }
-    if (randomizer->GetRandoSettingValue(RSK_SHOPSANITY) > 0) {
-        merchantPricesSize += NUM_SHOP_ITEMS;
-    }
+    SaveManager::Instance->LoadData("merchantPricesSize", merchantPricesSize);
 
     SaveManager::Instance->LoadArray("merchantPrices", merchantPricesSize, [&](size_t i) {
         SaveManager::Instance->LoadStruct("", [&]() {
@@ -247,6 +242,7 @@ void SaveManager::SaveRandomizer() {
         merchantPrices.push_back(std::make_pair(check, price));
     }
 
+    SaveManager::Instance->SaveData("merchantPricesSize", merchantPrices.size());
     SaveManager::Instance->SaveArray("merchantPrices", merchantPrices.size(), [&](size_t i) {
         SaveManager::Instance->SaveStruct("", [&]() {
             SaveManager::Instance->SaveData("check", merchantPrices[i].first);


### PR DESCRIPTION
Similar to PR #1859, makes the size of merchantPrices array not dependent on the values of any rando settings, but rather persisted to the save file the first time it is saved. Then subsequent loads will load that value. This works even with the old implementation of fast file select.