### PR TITLE
Add glitch line-up tick option

### DIFF
--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -1105,6 +1105,8 @@ namespace GameMenuBar {
                 }
                 UIWidgets::PaddedEnhancementCheckbox("N64 Mode", "gN64Mode", true, false);
                 UIWidgets::Tooltip("Sets aspect ratio to 4:3 and lowers resolution to 240p, the N64's native resolution");
+                UIWidgets::PaddedEnhancementCheckbox("Glitch line-up tick", "gDrawLineupTick", true, false);
+                UIWidgets::Tooltip("Displays a tick in the top center of the screen to help with glitch line-ups in SoH, as traditional UI based line-ups do not work outside of 4:3");
                 UIWidgets::PaddedEnhancementCheckbox("Enable 3D Dropped items/projectiles", "gNewDrops", true, false);
                 UIWidgets::Tooltip("Change most 2D items and projectiles on the overworld to their 3D versions");
                 UIWidgets::PaddedEnhancementCheckbox("Disable Black Bar Letterboxes", "gDisableBlackBars", true, false);

--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -3404,6 +3404,28 @@ void Interface_UpdateMagicBar(GlobalContext* globalCtx) {
     }
 }
 
+void Interface_DrawLineupTick(GlobalContext* globalCtx) {
+    InterfaceContext* interfaceCtx = &globalCtx->interfaceCtx;
+
+    OPEN_DISPS(globalCtx->state.gfxCtx);
+
+    func_80094520(globalCtx->state.gfxCtx);
+
+    gDPSetEnvColor(OVERLAY_DISP++, 255, 255, 255, 255);
+    gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 255, 255, 255);
+
+    s16 width = 32;
+    s16 height = 32;
+    s16 x = -8 + (SCREEN_WIDTH / 2);
+    s16 y = CVar_GetS32("gOpenMenuBar", 0) ? -4 : -6;
+
+    OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, gEmptyCDownArrowTex, width, height, x, y, width, height, 2 << 10, 2 << 10);
+
+    gDPPipeSync(OVERLAY_DISP++);
+
+    CLOSE_DISPS(globalCtx->state.gfxCtx);
+}
+
 void Interface_DrawMagicBar(GlobalContext* globalCtx) {
     InterfaceContext* interfaceCtx = &globalCtx->interfaceCtx;
     s16 magicDrop = R_MAGIC_BAR_LARGE_Y-R_MAGIC_BAR_SMALL_Y+2;
@@ -5018,6 +5040,10 @@ void Interface_Draw(GlobalContext* globalCtx) {
             // Make sure item counts have black backgrounds
             gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 0, 0, 0, interfaceCtx->magicAlpha);
             gDPSetEnvColor(OVERLAY_DISP++, 0, 0, 0, 0);
+        }
+
+        if (CVar_GetS32("gDrawLineupTick", 1)) {
+            Interface_DrawLineupTick(globalCtx);
         }
 
         if (fullUi || gSaveContext.unk_13F0 > 0) {


### PR DESCRIPTION
Should aid UI based lineups in SoH, as the traditional ones usually rely on a 4:3 aspect ratio.

<img width="752" alt="Screen Shot 2022-10-29 at 8 56 54 PM" src="https://user-images.githubusercontent.com/7316699/198859149-1b9dba3e-dd6f-4b42-86f7-a91e2e6a6813.png">
<img width="521" alt="Screen Shot 2022-10-29 at 8 56 59 PM" src="https://user-images.githubusercontent.com/7316699/198859171-9c446ff4-96ff-410e-ad58-ac8cc65f3086.png">
<img width="1639" alt="Screen Shot 2022-10-29 at 8 57 11 PM" src="https://user-images.githubusercontent.com/7316699/198859174-aa15ae59-38f7-449d-97df-bbdc97c02392.png">

