### PR TITLE
Add toggle for multi viewport setting

### DIFF
--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -686,6 +686,11 @@ namespace GameMenuBar {
                     ImGui::PopStyleVar(1);
                 }
 
+                if (SohImGui::supportsViewports()) {
+                    UIWidgets::PaddedEnhancementCheckbox("Allow multi-windows", "gEnableMultiViewports", true, false);
+                    UIWidgets::Tooltip("Allows windows to be able to be dragged off of the main game window. Requires a reload to take effect.");
+                }
+
                 EXPERIMENTAL();
 
                 ImGui::Text("Texture Filter (Needs reload)");


### PR DESCRIPTION
This adds a toggle in the graphics settings to enable/disable multi viewport/window support. Resolves #1825.

I initially tried to have this toggle work without needing to reopen the game, but it would break if you launched the game with the toggle off and then toggled it on (due to some init logic not being setup for multi viewport support). There is probably a way to do it without a reload, but I didn't want to get too messy in LUS.

I'm sure the toggle name/tooltip could be worded better, and probably be disabled/hidden on systems that can't support multi viewport.

When we figure out a good way to detect Steam Deck/Gamescope systems (#1698), then we should have this CVar default to off for Steam Deck so users don't experience issues with dragging windows in Game mode.

I understand LUS is having some behind the scenes plans going on, so if we wanna approach this differently/later let me know.

![image](https://user-images.githubusercontent.com/13861068/199642587-09c70200-7d45-4aa8-a666-2710862e23c9.png)