### PR TITLE
Enable Crowd Control in Linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,9 +36,20 @@ RUN apt-get update && \
 	update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${GCCVER} 10 
 	
 RUN git clone https://github.com/Perlmint/glew-cmake.git && \
-	cmake glew-cmake && \
+	mkdir build-glew && \
+	cd build-glew && \
+	cmake ../glew-cmake && \
 	make -j$(nproc) && \
-	make install
+	make install && \
+	cd ..
+
+RUN git clone https://github.com/libsdl-org/SDL_net && \
+	mkdir build-sdl2_net && \
+	cd build-sdl2_net && \
+	cmake ../SDL_net && \
+	make -j$(nproc) && \
+	make install && \
+	cd ..
 
 ENV SDL2VER=2.0.22
 RUN curl -sLO https://libsdl.org/release/SDL2-${SDL2VER}.tar.gz && \

--- a/soh/CMakeLists.txt
+++ b/soh/CMakeLists.txt
@@ -250,7 +250,7 @@ set(Header_Files__soh__Enhancements__item_tables
 
 source_group("Header Files\\soh\\Enhancements\\item-tables" FILES ${Header_Files__soh__Enhancements__item_tables})
 
-if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
+if (CMAKE_SYSTEM_NAME STREQUAL "Windows" OR CMAKE_SYSTEM_NAME STREQUAL "Linux")
 set(Header_Files__soh__Enhancements__crowd_control
     "soh/Enhancements/crowd-control/CrowdControl.h"
 )
@@ -397,7 +397,7 @@ set(Source_Files__soh__Enhancements__item_tables
 
 source_group("Source Files\\soh\\Enhancements\\item-tables" FILES ${Source_Files__soh__Enhancements__item_tables})
 
-if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
+if (CMAKE_SYSTEM_NAME STREQUAL "Windows" OR CMAKE_SYSTEM_NAME STREQUAL "Linux")
 set(Source_Files__soh__Enhancements__crowd_control
     "soh/Enhancements/crowd-control/CrowdControl.cpp"
 )
@@ -1779,6 +1779,22 @@ elseif (CMAKE_SYSTEM_NAME STREQUAL "CafeOS")
         "SPDLOG_NO_TLS;"
 		"STBI_NO_THREAD_LOCALS;"
 	)
+elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    target_compile_definitions(${PROJECT_NAME} PRIVATE
+		"$<$<CONFIG:Debug>:"
+			"_DEBUG"
+		">"
+		"$<$<CONFIG:Release>:"
+			"NDEBUG"
+		">"
+		"SPDLOG_ACTIVE_LEVEL=0;"
+		"_CONSOLE;"
+		"_CRT_SECURE_NO_WARNINGS;"
+		"ENABLE_OPENGL;"
+        "ENABLE_CROWD_CONTROL;"
+		"UNICODE;"
+		"_UNICODE"
+	)
 elseif ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU|Clang|AppleClang")
 	target_compile_definitions(${PROJECT_NAME} PRIVATE
 		"$<$<CONFIG:Debug>:"
@@ -2028,6 +2044,20 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "CafeOS")
     target_include_directories(${PROJECT_NAME} PRIVATE
         ${DEVKITPRO}/portlibs/wiiu/include/
     )
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    find_package(SDL2)
+    find_package(SDL2_net)
+    set(THREADS_PREFER_PTHREAD_FLAG ON)
+    find_package(Threads REQUIRED)
+ 	set(ADDITIONAL_LIBRARY_DEPENDENCIES
+        "libultraship;"
+        "ZAPDUtils;"
+		"SDL2::SDL2;"
+        "SDL2::SDL2main;"
+        "SDL2_net::SDL2_net-static;"
+		${CMAKE_DL_LIBS}
+		Threads::Threads
+	)
 else()
     find_package(SDL2)
     set(THREADS_PREFER_PTHREAD_FLAG ON)

--- a/soh/soh/Enhancements/crowd-control/CrowdControl.cpp
+++ b/soh/soh/Enhancements/crowd-control/CrowdControl.cpp
@@ -326,14 +326,14 @@ CrowdControl::EffectResult CrowdControl::ExecuteEffect(std::string effectId, uin
             if (dryRun == 0) CMD_EXECUTE("empty_magic");
             return EffectResult::Success;
         } else if (effectId == "add_rupees") {
-            if (dryRun == 0) CMD_EXECUTE(std::format("update_rupees {}", value));
+            if (dryRun == 0) CMD_EXECUTE(fmt::v8::format("update_rupees {}", value));
             return EffectResult::Success;
         } else if (effectId == "remove_rupees") {
             if (gSaveContext.rupees - value < 0) {
                 return EffectResult::Failure;
             }
 
-            if (dryRun == 0) CMD_EXECUTE(std::format("update_rupees -{}", value));
+            if (dryRun == 0) CMD_EXECUTE(fmt::v8::format("update_rupees -{}", value));
             return EffectResult::Success;
         }
     }
@@ -353,14 +353,14 @@ CrowdControl::EffectResult CrowdControl::ExecuteEffect(std::string effectId, uin
                     || effectId == "cucco_storm"
         ) {
             if (PlayerGrounded(player)) {
-                if (dryRun == 0) CMD_EXECUTE(std::format("{}", effectId));
+                if (dryRun == 0) CMD_EXECUTE(fmt::v8::format("{}", effectId));
                 return EffectResult::Success;
             }
             return EffectResult::Failure;
         } else if (effectId == "heal"
                     || effectId == "knockback"
         ) {
-            if (dryRun == 0) CMD_EXECUTE(std::format("{} {}", effectId, value));
+            if (dryRun == 0) CMD_EXECUTE(fmt::v8::format("{} {}", effectId, value));
             return EffectResult::Success;
         } else if (effectId == "giant_link"
                     || effectId == "minish_link"
@@ -372,7 +372,7 @@ CrowdControl::EffectResult CrowdControl::ExecuteEffect(std::string effectId, uin
                     || effectId == "pacifist"
                     || effectId == "rainstorm"
         ) {
-            if (dryRun == 0) CMD_EXECUTE(std::format("{} 1", effectId));
+            if (dryRun == 0) CMD_EXECUTE(fmt::v8::format("{} 1", effectId));
             return EffectResult::Success;
         } else if (effectId == "reverse") {
             if (dryRun == 0) CMD_EXECUTE("reverse_controls 1"); 
@@ -413,17 +413,17 @@ CrowdControl::EffectResult CrowdControl::ExecuteEffect(std::string effectId, uin
            if (dryRun == 0) CMD_EXECUTE("speed_modifier -2");
             return EffectResult::Success;
         } else if (effectId == "damage_multiplier") {
-            if (dryRun == 0) CMD_EXECUTE(std::format("defense_modifier -{}", value));
+            if (dryRun == 0) CMD_EXECUTE(fmt::v8::format("defense_modifier -{}", value));
             return EffectResult::Success;
         } else if (effectId == "defense_multiplier") {
-            if (dryRun == 0) CMD_EXECUTE(std::format("defense_modifier {}", value));
+            if (dryRun == 0) CMD_EXECUTE(fmt::v8::format("defense_modifier {}", value));
             return EffectResult::Success;
         } else if (effectId == "damage") {
             if ((gSaveContext.healthCapacity - 0x10) <= 0) {
                 return EffectResult::Failure;
             }
             
-            if (dryRun == 0) CMD_EXECUTE(std::format("{} {}", effectId, value));
+            if (dryRun == 0) CMD_EXECUTE(fmt::v8::format("{} {}", effectId, value));
             return EffectResult::Success;
         }
     }
@@ -511,7 +511,7 @@ void CrowdControl::RemoveEffect(std::string effectId) {
                 || effectId == "pacifist"
                 || effectId == "rainstorm"
         ) {
-            CMD_EXECUTE(std::format("{} 0", effectId));
+            CMD_EXECUTE(fmt::v8::format("{} 0", effectId));
             return;
         } else if (effectId == "iron_boots" || effectId == "hover_boots") {
             CMD_EXECUTE("boots kokiri");


### PR DESCRIPTION
Since Crowd Control runs without issue through Wine in Linux and Linux clients are able to communicate with the local Crowd Control server, I thought it would be fun to enable Crowd Control in Linux, too. This has been tested and works without any issue I can see.


https://user-images.githubusercontent.com/20977880/199754936-3ee0efd1-85fb-46a2-9ae1-e7163234ebe1.mp4