### PR TITLE
disable ImGUI cursor visibility control

### DIFF
--- a/libultraship/libultraship/ImGuiImpl.cpp
+++ b/libultraship/libultraship/ImGuiImpl.cpp
@@ -346,7 +346,7 @@ namespace SohImGui {
         ImGuiContext* ctx = ImGui::CreateContext();
         ImGui::SetCurrentContext(ctx);
         io = &ImGui::GetIO();
-        io->ConfigFlags |= ImGuiConfigFlags_DockingEnable;
+        io->ConfigFlags |= ImGuiConfigFlags_DockingEnable | ImGuiConfigFlags_NoMouseCursorChange;
         io->Fonts->AddFontDefault();
         statsWindowOpen = CVar_GetS32("gStatsEnabled", 0);
         CVar_RegisterS32("gRandomizeRupeeNames", 1);


### PR DESCRIPTION
This tells ImGUI to not call `SDL_ShowCursor` every time in SDL2/OpenGL video api, causing the mouse cursor at fullscreen to be always visible at all times, in this case.

Note at `imgui_impl_sdl.cpp` for clarity:
https://github.com/HarbourMasters/Shipwright/blob/763f3a5760cf2b54c5deb9540e5085ca3bf83c32/libultraship/libultraship/Lib/ImGui/backends/imgui_impl_sdl.cpp#L10

and its only use:
https://github.com/HarbourMasters/Shipwright/blob/763f3a5760cf2b54c5deb9540e5085ca3bf83c32/libultraship/libultraship/Lib/ImGui/backends/imgui_impl_sdl.cpp#L583-L602

Fixes #1889 - *Issue also persists on Windows too!*