### PR TITLE
Always show GTG & Ganons castle MQ status on tracker

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
@@ -556,7 +556,7 @@ void DrawDungeonItem(ItemTrackerItem item) {
                      ImVec2(iconSize, iconSize), ImVec2(0, 0), ImVec2(1, 1));
     }
 
-    if (ResourceMgr_IsSceneMasterQuest(item.data) && CHECK_DUNGEON_ITEM(DUNGEON_MAP, item.data)) {
+    if (ResourceMgr_IsSceneMasterQuest(item.data) && (CHECK_DUNGEON_ITEM(DUNGEON_MAP, item.data) || item.data == SCENE_MEN || item.data == SCENE_GANONTIKA)) {
         dungeonColor = IM_COL_PURPLE;
     }
 


### PR DESCRIPTION
No maps for GTG & Ganon's castle so we always display them.