### PR TITLE
Add option for Linux builds to avoid linking against PulseAudio

### DIFF
--- a/libultraship/libultraship/AudioPlayer.h
+++ b/libultraship/libultraship/AudioPlayer.h
@@ -17,7 +17,7 @@ namespace Ship {
 
 #ifdef _WIN32
 #include "WasapiAudioPlayer.h"
-#elif defined(__linux)
+#elif defined(__linux) && !defined(NO_PULSE)
 #include "PulseAudioPlayer.h"
 #endif
 

--- a/libultraship/libultraship/CMakeLists.txt
+++ b/libultraship/libultraship/CMakeLists.txt
@@ -664,11 +664,21 @@ endif()
 ################################################################################
 # Link with other targets.
 
+cmake_dependent_option(NO_PULSE "Build without PulseAudio, using only SDLAudio" OFF "CMAKE_SYSTEM_NAME STREQUAL Linux" OFF)
+
 find_package(OpenGL QUIET)
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
     find_package(X11)
     find_package(PulseAudio)
+
+    if (NOT NO_PULSE)
+        find_package(PulseAudio)
+        set(PULSE-LIB ${PULSEAUDIO_LIBRARY})
+    else()
+        add_compile_definitions(NO_PULSE)
+        message(STATUS "Disabling Pulse")
+    endif()
 endif()
 
 if (NOT GLEW_FOUND)
@@ -727,7 +737,7 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "CafeOS")
 else()
     target_link_libraries(${PROJECT_NAME}
         SDL2::SDL2
-        ${PULSEAUDIO_LIBRARY}
+        ${PULSE-LIB}
         ${GLEW-LIB}
         ${OPENGL_glx_LIBRARY}
         ${OPENGL_opengl_LIBRARY}

--- a/libultraship/libultraship/ImGuiImpl.cpp
+++ b/libultraship/libultraship/ImGuiImpl.cpp
@@ -113,7 +113,7 @@ namespace SohImGui {
 #ifdef _WIN32
         { "wasapi", "Windows Audio Session API" },
 #endif
-#if defined(__linux)
+#if defined(__linux) && !defined(NO_PULSE)
         { "pulse", "PulseAudio" },
 #endif
         { "sdl", "SDL Audio" }

--- a/libultraship/libultraship/PulseAudioPlayer.cpp
+++ b/libultraship/libultraship/PulseAudioPlayer.cpp
@@ -1,4 +1,4 @@
-#if defined(__linux__) || defined(__BSD__)
+#if !defined(NO_PULSE) && defined(__linux__) || defined(__BSD__)
 
 #include "PulseAudioPlayer.h"
 #include <spdlog/spdlog.h>

--- a/libultraship/libultraship/PulseAudioPlayer.h
+++ b/libultraship/libultraship/PulseAudioPlayer.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(__linux__) || defined(__BSD__)
+#if !defined(NO_PULSE) && defined(__linux__) || defined(__BSD__)
 
 #include "AudioPlayer.h"
 #include <pulse/pulseaudio.h>

--- a/libultraship/libultraship/Window.cpp
+++ b/libultraship/libultraship/Window.cpp
@@ -439,7 +439,7 @@ namespace Ship {
     void Window::InitializeAudioPlayer() {
 #ifdef _WIN32
         APlayer = std::make_shared<WasapiAudioPlayer>();
-#elif defined(__linux)
+#elif defined(__linux) && !defined(NO_PULSE)
         APlayer = std::make_shared<PulseAudioPlayer>();
 #else
         APlayer = std::make_shared<SDLAudioPlayer>();
@@ -451,7 +451,7 @@ namespace Ship {
             APlayer = std::make_shared<WasapiAudioPlayer>();
         }
 #endif
-#if defined(__linux)
+#if defined(__linux) && !defined(NO_PULSE)
         if (audioBackend == "pulse") {
             APlayer = std::make_shared<PulseAudioPlayer>();
         }


### PR DESCRIPTION
This is split out from a larger group of changes. For full context please see #1013 .

---

Allow the Ship to run in Linux environments that may not use PulseAudio (e.g. ALSA-only embedded Linux).

SDL already abstracts audio backends, so rather than directly linking against PulseAudio, utilize the abstraction so that the final resulting binary can run on a wider range of Linux environments.

This has been implemented as a compile-time option, so that the current behavior that allows switching the backend at runtime between Pulse and SDL remains the default.

---
### Building

To build, add `-DNO_PULSE=1` to the initial cmake command like so:
```
cmake -H. -Bbuild-cmake -GNinja -DNO_PULSE=1
```

