### PR TITLE
Add support for OpenGLES

### DIFF
--- a/libultraship/libultraship/CMakeLists.txt
+++ b/libultraship/libultraship/CMakeLists.txt
@@ -664,7 +664,20 @@ endif()
 ################################################################################
 # Link with other targets.
 
-find_package(OpenGL QUIET)
+cmake_dependent_option(USE_OPENGLES "Build targetting OpenGLESv2 instead of full OpenGL" OFF "CMAKE_SYSTEM_NAME STREQUAL Linux" OFF)
+
+if (USE_OPENGLES)
+    add_compile_definitions(USE_OPENGLES IMGUI_IMPL_OPENGL_ES3)
+    find_library(OPENGL-LIB GLESv2)
+    if (NOT OPENGL-LIB)
+        message(FATAL_ERROR "USE_OPENGLES=ON, but libGLESv2 could not be found")
+    endif()
+    message(STATUS "Building with GLESv2")
+
+else()
+    find_package(OpenGL QUIET)
+    set(OPENGL-LIB ${OPENGL_opengl_LIBRARY})
+endif()
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
     find_package(X11)
@@ -730,7 +743,7 @@ else()
         ${PULSEAUDIO_LIBRARY}
         ${GLEW-LIB}
         ${OPENGL_glx_LIBRARY}
-        ${OPENGL_opengl_LIBRARY}
+        ${OPENGL-LIB}
         ${X11_LIBRARIES}
         storm
     )

--- a/libultraship/libultraship/ImGuiImpl.cpp
+++ b/libultraship/libultraship/ImGuiImpl.cpp
@@ -200,6 +200,9 @@ namespace SohImGui {
         case Backend::SDL:
         #if defined(__APPLE__)
             ImGui_ImplOpenGL3_Init("#version 410 core");
+        #elif defined(USE_OPENGLES)
+            // Let ImGui try to figure this out. Should be something like #version 320 es
+            ImGui_ImplOpenGL3_Init(NULL);
         #else
             ImGui_ImplOpenGL3_Init("#version 120");
         #endif

--- a/libultraship/libultraship/Lib/Fast3D/gfx_opengl.cpp
+++ b/libultraship/libultraship/Lib/Fast3D/gfx_opengl.cpp
@@ -47,6 +47,10 @@
 #include "../../Window.h"
 #include "gfx_pc.h"
 
+#if defined(__APPLE__) || defined(USE_OPENGLES)
+#define USE_NEWER_GLSL 1
+#endif
+
 using namespace std;
 
 struct ShaderProgram {
@@ -237,13 +241,16 @@ static struct ShaderProgram* gfx_opengl_create_and_load_new_shader(uint64_t shad
 #ifdef __APPLE__
     append_line(vs_buf, &vs_len, "#version 410 core");
     append_line(vs_buf, &vs_len, "in vec4 aVtxPos;");
+#elif USE_OPENGLES
+    append_line(vs_buf, &vs_len, "#version 300 es");
+    append_line(vs_buf, &vs_len, "in vec4 aVtxPos;");
 #else
     append_line(vs_buf, &vs_len, "#version 110");
     append_line(vs_buf, &vs_len, "attribute vec4 aVtxPos;");
 #endif
     for (int i = 0; i < 2; i++) {
         if (cc_features.used_textures[i]) {
-        #ifdef __APPLE__
+        #ifdef USE_NEWER_GLSL
             vs_len += sprintf(vs_buf + vs_len, "in vec2 aTexCoord%d;\n", i);
             vs_len += sprintf(vs_buf + vs_len, "out vec2 vTexCoord%d;\n", i);
         #else
@@ -253,7 +260,7 @@ static struct ShaderProgram* gfx_opengl_create_and_load_new_shader(uint64_t shad
             num_floats += 2;
             for (int j = 0; j < 2; j++) {
                 if (cc_features.clamp[i][j]) {
-                #ifdef __APPLE__
+                #ifdef USE_NEWER_GLSL
                     vs_len += sprintf(vs_buf + vs_len, "in float aTexClamp%s%d;\n", j == 0 ? "S" : "T", i);
                     vs_len += sprintf(vs_buf + vs_len, "out float vTexClamp%s%d;\n", j == 0 ? "S" : "T", i);
                 #else
@@ -266,7 +273,7 @@ static struct ShaderProgram* gfx_opengl_create_and_load_new_shader(uint64_t shad
         }
     }
     if (cc_features.opt_fog) {
-    #ifdef __APPLE__
+    #ifdef USE_NEWER_GLSL
         append_line(vs_buf, &vs_len, "in vec4 aFog;");
         append_line(vs_buf, &vs_len, "out vec4 vFog;");
     #else
@@ -277,7 +284,7 @@ static struct ShaderProgram* gfx_opengl_create_and_load_new_shader(uint64_t shad
     }
 
     if (cc_features.opt_grayscale) {
-    #ifdef __APPLE__
+    #ifdef USE_NEWER_GLSL
         append_line(vs_buf, &vs_len, "in vec4 aGrayscaleColor;");
         append_line(vs_buf, &vs_len, "out vec4 vGrayscaleColor;");
     #else
@@ -288,7 +295,7 @@ static struct ShaderProgram* gfx_opengl_create_and_load_new_shader(uint64_t shad
     }
 
     for (int i = 0; i < cc_features.num_inputs; i++) {
-    #ifdef __APPLE__
+    #ifdef USE_NEWER_GLSL
         vs_len += sprintf(vs_buf + vs_len, "in vec%d aInput%d;\n", cc_features.opt_alpha ? 4 : 3, i + 1);
         vs_len += sprintf(vs_buf + vs_len, "out vec%d vInput%d;\n", cc_features.opt_alpha ? 4 : 3, i + 1);
     #else
@@ -323,20 +330,23 @@ static struct ShaderProgram* gfx_opengl_create_and_load_new_shader(uint64_t shad
     // Fragment shader
 #ifdef __APPLE__
     append_line(fs_buf, &fs_len, "#version 410 core");
+#elif USE_OPENGLES
+    append_line(fs_buf, &fs_len, "#version 300 es");
+    append_line(fs_buf, &fs_len, "precision mediump float;");
 #else
     append_line(fs_buf, &fs_len, "#version 130");
 #endif
     //append_line(fs_buf, &fs_len, "precision mediump float;");
     for (int i = 0; i < 2; i++) {
         if (cc_features.used_textures[i]) {
-        #ifdef __APPLE__
+        #ifdef USE_NEWER_GLSL
             fs_len += sprintf(fs_buf + fs_len, "in vec2 vTexCoord%d;\n", i);
         #else
             fs_len += sprintf(fs_buf + fs_len, "varying vec2 vTexCoord%d;\n", i);
         #endif
             for (int j = 0; j < 2; j++) {
                 if (cc_features.clamp[i][j]) {
-                #ifdef __APPLE__
+                #ifdef USE_NEWER_GLSL
                     fs_len += sprintf(fs_buf + fs_len, "in float vTexClamp%s%d;\n", j == 0 ? "S" : "T", i);
                 #else
                     fs_len += sprintf(fs_buf + fs_len, "varying float vTexClamp%s%d;\n", j == 0 ? "S" : "T", i);
@@ -346,21 +356,21 @@ static struct ShaderProgram* gfx_opengl_create_and_load_new_shader(uint64_t shad
         }
     }
     if (cc_features.opt_fog) {
-    #ifdef __APPLE__
+    #ifdef USE_NEWER_GLSL
         append_line(fs_buf, &fs_len, "in vec4 vFog;");
     #else
         append_line(fs_buf, &fs_len, "varying vec4 vFog;");
     #endif
     }
     if (cc_features.opt_grayscale) {
-    #ifdef __APPLE__
+    #ifdef USE_NEWER_GLSL
         append_line(fs_buf, &fs_len, "in vec4 vGrayscaleColor;");
     #else
         append_line(fs_buf, &fs_len, "varying vec4 vGrayscaleColor;");
     #endif
     }
     for (int i = 0; i < cc_features.num_inputs; i++) {
-    #ifdef __APPLE__
+    #ifdef USE_NEWER_GLSL
         fs_len += sprintf(fs_buf + fs_len, "in vec%d vInput%d;\n", cc_features.opt_alpha ? 4 : 3, i + 1);
     #else
         fs_len += sprintf(fs_buf + fs_len, "varying vec%d vInput%d;\n", cc_features.opt_alpha ? 4 : 3, i + 1);
@@ -382,7 +392,7 @@ static struct ShaderProgram* gfx_opengl_create_and_load_new_shader(uint64_t shad
     append_line(fs_buf, &fs_len, "}");
 
     if (current_filter_mode == FILTER_THREE_POINT) {
-    #if __APPLE__
+    #if USE_NEWER_GLSL
         append_line(fs_buf, &fs_len, "#define TEX_OFFSET(off) texture(tex, texCoord - (off)/texSize)");
     #else
         append_line(fs_buf, &fs_len, "#define TEX_OFFSET(off) texture2D(tex, texCoord - (off)/texSize)");
@@ -400,7 +410,7 @@ static struct ShaderProgram* gfx_opengl_create_and_load_new_shader(uint64_t shad
         append_line(fs_buf, &fs_len, "}");
     } else {
         append_line(fs_buf, &fs_len, "vec4 hookTexture2D(in sampler2D tex, in vec2 uv, in vec2 texSize) {");
-    #if __APPLE__
+    #if USE_NEWER_GLSL
         append_line(fs_buf, &fs_len, "    return texture(tex, uv);");
     #else
         append_line(fs_buf, &fs_len, "    return texture2D(tex, uv);");
@@ -408,7 +418,7 @@ static struct ShaderProgram* gfx_opengl_create_and_load_new_shader(uint64_t shad
         append_line(fs_buf, &fs_len, "}");
     }
 
-#if __APPLE__
+#if USE_NEWER_GLSL
     append_line(fs_buf, &fs_len, "out vec4 outColor;");
 #endif
 
@@ -422,7 +432,13 @@ static struct ShaderProgram* gfx_opengl_create_and_load_new_shader(uint64_t shad
         if (cc_features.used_textures[i]) {
             bool s = cc_features.clamp[i][0], t = cc_features.clamp[i][1];
 
+        #ifdef USE_OPENGLES
+            // ES glsl can't implicitly convert ivec2 -> vec2
+            fs_len += sprintf(fs_buf + fs_len, "ivec2 itexSize%d = textureSize(uTex%d, 0);\n", i, i);
+            fs_len += sprintf(fs_buf + fs_len, "vec2 texSize%d = vec2(itexSize%d.x, itexSize%d.y);\n", i, i, i);
+        #else
             fs_len += sprintf(fs_buf + fs_len, "vec2 texSize%d = textureSize(uTex%d, 0);\n", i, i);
+        #endif
 
             if (!s && !t) {
                 fs_len += sprintf(fs_buf + fs_len, "vec4 texVal%d = hookTexture2D(uTex%d, vTexCoord%d, texSize%d);\n", i, i, i, i);
@@ -494,13 +510,13 @@ static struct ShaderProgram* gfx_opengl_create_and_load_new_shader(uint64_t shad
         if (cc_features.opt_invisible) {
             append_line(fs_buf, &fs_len, "texel.a = 0.0;");
         }
-    #if __APPLE__
+    #if USE_NEWER_GLSL
         append_line(fs_buf, &fs_len, "outColor = texel;");
     #else
         append_line(fs_buf, &fs_len, "gl_FragColor = texel;");
     #endif
     } else {
-    #if __APPLE__
+    #if USE_NEWER_GLSL
         append_line(fs_buf, &fs_len, "outColor = vec4(texel, 1.0);");
     #else
         append_line(fs_buf, &fs_len, "gl_FragColor = vec4(texel, 1.0);");


### PR DESCRIPTION
This is split out from a larger group of changes. For full context please see #1013 .

---

Allow the Ship to run on platforms that may not support the full desktop OpenGL.

Only a few small changes were needed to support OpenGLES:
 - Use glsl #version 300 es
 - Change the #if guards on glsl generation to USE_NEWER_OPENGL
   - use this for both `USE_OPENGLES` and `__APPLE__` build targets
 - Tweak glsl for ES-specific issue with implicit `ivec` -> `vec` conversion
 - Have ImGui figure out its own glsl version
---
### Building

To build, add `-DUSE_OPENGLES=1` to the initial cmake command like so:
```
cmake -H. -Bbuild-cmake -GNinja -DUSE_OPENGLES=1
```
---
### Additional Notes

Currently, GLEW and GLX will probably still pull in libGL as a dependency, so this PR alone will not completely remove the need for libGL.

