### PR TITLE
Add option to build using SDL extensions instead of GLEW

### DIFF
--- a/libultraship/libultraship/CMakeLists.txt
+++ b/libultraship/libultraship/CMakeLists.txt
@@ -671,12 +671,17 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
     find_package(PulseAudio)
 endif()
 
-if (NOT GLEW_FOUND)
-    set(GLEW-LIB glew_s)
+if (NOT NO_GLEW)
+    if (NOT GLEW_FOUND)
+        set(GLEW-LIB glew_s)
+    else()
+        set(GLEW-LIB  GLEW::GLEW)
+    endif()
 else()
-    set(GLEW-LIB  GLEW::GLEW)
+    message(STATUS "Disabling GLEW")
+    add_compile_definitions(NO_GLEW)
 endif()
- 
+
 if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
     if("${CMAKE_VS_PLATFORM_NAME}" STREQUAL "x64")
         target_link_libraries(${PROJECT_NAME}

--- a/libultraship/libultraship/Lib/Fast3D/gfx_opengl.cpp
+++ b/libultraship/libultraship/Lib/Fast3D/gfx_opengl.cpp
@@ -34,6 +34,11 @@
 #elif __SWITCH__
 #include <SDL2/SDL.h>
 #include <glad/glad.h>
+#elif NO_GLEW
+ #define GL_GLEXT_PROTOTYPES 1
+ #include <SDL2/SDL_opengles2.h>
+ #include <GL/gl.h>
+ #include <GL/glext.h>
 #else
 #include <SDL2/SDL.h>
 #include <GL/glew.h>
@@ -725,7 +730,7 @@ static void gfx_opengl_draw_triangles(float buf_vbo[], size_t buf_vbo_len, size_
 }
 
 static void gfx_opengl_init(void) {
-#ifndef __SWITCH__
+#if !(defined(__SWITCH__) || defined(NO_GLEW))
     glewInit();
 #endif
 


### PR DESCRIPTION
This is split out from a larger group of changes. For full context please see #1013 .

---

The use of GLEW adds extra dependencies that are extraneous, particularly for builds targetting smaller embedded environments. SDL includes references to the same extensions that GLEW provides, without needing to install or compile an additional library.

---
### Building

To build, add `-DNO_GLEW=1` to the initial cmake command like so:
```
cmake -H. -Bbuild-cmake -GNinja -DNO_GLEW=1
```

---
### Additional Notes

GLX may still pull in GLEW as a dependency, so this PR may depend on a future PR that adds an option to also disable building against GLX.

This PR is relatively tangled with the PR enabling OpenGLES support #1924 , as different headers can be used when building with OpenGLES. See the full context from the previous PR containing all the changes [here](https://github.com/HarbourMasters/Shipwright/blob/858df98e7547d937c75271a4c8c110045137c716/libultraship/libultraship/Lib/Fast3D/gfx_opengl.cpp#L37).

