### PR TITLE
Adds some new cheats and fixes

### DIFF
--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -316,6 +316,8 @@ namespace GameMenuBar {
         CVar_SetS32("gCrouchStabFix", 0);
         // Fix Gerudo Warrior's clothing colors
         CVar_SetS32("gGerudoWarriorClothingFix", 0);
+        // Fix Bow and Slingshot Ammo use
+        CVar_SetS32("gSlingshotBowAmmoFix", 0);
 
         // Red Ganon blood
         CVar_SetS32("gRedGanonBlood", 0);
@@ -1168,6 +1170,8 @@ namespace GameMenuBar {
                 }
                 UIWidgets::PaddedEnhancementCheckbox("Fix Gerudo Warrior's clothing colors", "gGerudoWarriorClothingFix", true, false);
                 UIWidgets::Tooltip("Prevent the Gerudo Warrior's clothes changing color when changing Link's tunic or using bombs in front of her");
+                UIWidgets::PaddedEnhancementCheckbox("Fix Slingshot and Bow ammo use", "gSlingshotBowAmmoFix", true, false);
+                UIWidgets::Tooltip("Make slingshot and bow use correct ammo for equip swap glitch or Timeless Equipment cheat");
 
                 ImGui::EndMenu();
             }
@@ -1373,6 +1377,7 @@ namespace GameMenuBar {
                 UIWidgets::EnhancementCheckbox("Money", "gInfiniteMoney");
                 UIWidgets::PaddedEnhancementCheckbox("Health", "gInfiniteHealth", true, false);
                 UIWidgets::PaddedEnhancementCheckbox("Ammo", "gInfiniteAmmo", true, false);
+                UIWidgets::PaddedEnhancementCheckbox("Minigame Ammo", "gInfiniteMinigame", true, false);
                 UIWidgets::PaddedEnhancementCheckbox("Magic", "gInfiniteMagic", true, false);
                 UIWidgets::PaddedEnhancementCheckbox("Nayru's Love", "gInfiniteNayru", true, false);
                 UIWidgets::PaddedEnhancementCheckbox("Epona Boost", "gInfiniteEpona", true, false);
@@ -1392,6 +1397,8 @@ namespace GameMenuBar {
             UIWidgets::Tooltip("Makes every tunic have the effects of every other tunic");
             UIWidgets::PaddedEnhancementCheckbox("Easy ISG", "gEzISG", true, false);
             UIWidgets::Tooltip("Passive Infinite Sword Glitch\nIt makes your sword's swing effect and hitbox stay active indefinitely");
+            UIWidgets::PaddedEnhancementCheckbox("Ultra Deku Stick", "gUltraDekuStick", true, false);
+            UIWidgets::Tooltip("Lights your Deku Stick, keeps it lit and keeps it from breaking.");
             UIWidgets::PaddedEnhancementCheckbox("Timeless Equipment", "gTimelessEquipment", true, false);
             UIWidgets::Tooltip("Allows any item to be equipped, regardless of age\nAlso allows Child to use Adult strength upgrades");
             UIWidgets::PaddedEnhancementCheckbox("Easy Frame Advancing", "gCheatEasyPauseBufferEnabled", true, false);

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -1874,6 +1874,7 @@ void func_808337D4(PlayState* play, Player* this) {
                                       this->actor.shape.rot.y, 0, 0);
     if (spawnedActor != NULL) {
         if ((explosiveType != 0) && (play->bombchuBowlingStatus != 0)) {
+            if (!CVar_GetS32("gInfiniteMinigame", 0))
             play->bombchuBowlingStatus--;
             if (play->bombchuBowlingStatus == 0) {
                 play->bombchuBowlingStatus = -1;
@@ -2170,7 +2171,7 @@ void func_80834298(Player* this, PlayState* play) {
 
 // Determine projectile type for bow or slingshot
 s32 func_80834380(PlayState* play, Player* this, s32* itemPtr, s32* typePtr) {
-    if (LINK_IS_ADULT) {
+    if ((CVar_GetS32("gSlingshotBowAmmoFix", 0) && this->heldItemActionParam != PLAYER_AP_SLINGSHOT) || !CVar_GetS32("gSlingshotBowAmmoFix", 0) && LINK_IS_ADULT) {
         *itemPtr = ITEM_BOW;
         if (this->stateFlags1 & PLAYER_STATE1_23) {
             *typePtr = ARROW_NORMAL_HORSE;
@@ -2515,8 +2516,10 @@ s32 func_808350A4(PlayState* play, Player* this) {
             func_80834380(play, this, &item, &arrowType);
 
             if (gSaveContext.minigameState == 1) {
+                if (!CVar_GetS32("gInfiniteMinigame", 0))
                 play->interfaceCtx.hbaAmmo--;
             } else if (play->shootingGalleryStatus != 0) {
+                if (!CVar_GetS32("gInfiniteMinigame", 0))
                 play->shootingGalleryStatus--;
             } else {
                 Inventory_ChangeAmmo(item, -1);
@@ -4900,7 +4903,7 @@ s32 func_8083AD4C(PlayState* play, Player* this) {
 
     if (this->unk_6AD == 2) {
         if (func_8002DD6C(this)) {
-            if (LINK_IS_ADULT) {
+            if ((CVar_GetS32("gSlingshotBowAmmoFix", 0) && this->heldItemActionParam != PLAYER_AP_SLINGSHOT) || !CVar_GetS32("gSlingshotBowAmmoFix", 0) && LINK_IS_ADULT) {
                 cameraMode = CAM_MODE_BOWARROW;
             } else {
                 cameraMode = CAM_MODE_SLINGSHOT;
@@ -7917,13 +7920,15 @@ void func_80842A28(PlayState* play, Player* this) {
 }
 
 void func_80842A88(PlayState* play, Player* this) {
-    Inventory_ChangeAmmo(ITEM_STICK, -1);
-    func_80835F44(play, this, ITEM_NONE);
+    if (!CVar_GetS32("gUltraDekuStick", 0)) {
+        Inventory_ChangeAmmo(ITEM_STICK, -1);
+        func_80835F44(play, this, ITEM_NONE);
+    }
 }
 
 s32 func_80842AC4(PlayState* play, Player* this) {
     if ((this->heldItemActionParam == PLAYER_AP_STICK) && (this->unk_85C > 0.5f)) {
-        if (AMMO(ITEM_STICK) != 0) {
+        if (AMMO(ITEM_STICK) != 0 && !CVar_GetS32("gUltraDekuStick", 0)) {
             EffectSsStick_Spawn(play, &this->bodyPartsPos[PLAYER_BODYPART_R_HAND],
                                 this->actor.shape.rot.y + 0x8000);
             this->unk_85C = 0.5f;
@@ -10263,27 +10268,34 @@ static Color_RGBA8 D_808547C0 = { 255, 50, 0, 0 };
 
 void func_80848A04(PlayState* play, Player* this) {
     f32 temp;
-
-    if (this->unk_85C == 0.0f) {
+    f32 temp2;
+    if(CVar_GetS32("gUltraDekuStick", 0)){
+        temp2 = 1.0f;
+        this->unk_860 = 200;
+        this->unk_85C = 1.0f;
+        func_8002836C(play, &this->swordInfo[0].tip, &D_808547A4, &D_808547B0, &D_808547BC, &D_808547C0, temp2 * 200.0f,
+                    0, 8);
+    }
+    if (this->unk_85C == 0.0f && !CVar_GetS32("gUltraDekuStick", 0)) {
         func_80835F44(play, this, 0xFF);
         return;
     }
 
     temp = 1.0f;
-    if (DECR(this->unk_860) == 0) {
+    if (DECR(this->unk_860) == 0 && !CVar_GetS32("gUltraDekuStick", 0)) {
         Inventory_ChangeAmmo(ITEM_STICK, -1);
         this->unk_860 = 1;
         temp = 0.0f;
         this->unk_85C = temp;
     } else if (this->unk_860 > 200) {
         temp = (210 - this->unk_860) / 10.0f;
-    } else if (this->unk_860 < 20) {
+    } else if (this->unk_860 < 20 && !CVar_GetS32("gUltraDekuStick", 0)) {
         temp = this->unk_860 / 20.0f;
         this->unk_85C = temp;
     }
 
     func_8002836C(play, &this->swordInfo[0].tip, &D_808547A4, &D_808547B0, &D_808547BC, &D_808547C0, temp * 200.0f,
-                  0, 8);
+                0, 8);
 }
 
 void func_80848B44(PlayState* play, Player* this) {
@@ -10563,8 +10575,7 @@ void Player_UpdateCommon(Player* this, PlayState* play, Input* input) {
 
     func_808473D4(play, this);
     func_80836BEC(this, play);
-
-    if ((this->heldItemActionParam == PLAYER_AP_STICK) && (this->unk_860 != 0)) {
+    if ((this->heldItemActionParam == PLAYER_AP_STICK) && ((this->unk_860 != 0) || CVar_GetS32("gUltraDekuStick", 0))) {
         func_80848A04(play, this);
     } else if ((this->heldItemActionParam == PLAYER_AP_FISHING_POLE) && (this->unk_860 < 0)) {
         this->unk_860++;
@@ -11468,6 +11479,11 @@ s32 func_8084B3CC(PlayState* play, Player* this) {
         func_80835C58(play, this, func_8084FA54, 0);
 
         if (!func_8002DD6C(this) || Player_HoldsHookshot(this)) {
+            if (CVar_GetS32("gSlingshotBowAmmoFix", 0)) {
+                s32 itemToUse = LINK_IS_ADULT ? ITEM_BOW : ITEM_SLINGSHOT;
+                func_80835F44(play, this, itemToUse);
+            }
+            else if (!CVar_GetS32("gSlingshotBowAmmoFix", 0))
             func_80835F44(play, this, 3);
         }
 


### PR DESCRIPTION
- Adds a new cheat called Ultra Deku Stick, which lights your deku stick on fire, keeps it lit and prevents it from breaking.
- Adds a new cheat to the infinite.. menu called "Minigame Ammo" which prevents your minigame ammo from depleting while playing a minigame that uses ammo (shooting gallery, bombchu bowling, horseback archery)
- Adds a "fix" that allows the slingshot and bow to use the correct ammo when using the equip swap glitch or timeless equipment cheat