### PR TITLE
Adds Ultra Deku Stick Cheat

### DIFF
--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -1408,6 +1408,8 @@ namespace GameMenuBar {
             UIWidgets::Tooltip("This allows you to put up your shield with any two-handed weapon in hand except for Deku Sticks");
             UIWidgets::PaddedEnhancementCheckbox("Time Sync", "gTimeSync", true, false);
             UIWidgets::Tooltip("This syncs the ingame time with the real world time");
+            UIWidgets::PaddedEnhancementCheckbox("Ultra Deku Stick", "gUltraDekuStick", true, false);
+            UIWidgets::Tooltip("Lights your Deku Stick, keeps it lit and keeps it from breaking.");
 
             {
                 static int32_t betaQuestEnabled = CVar_GetS32("gEnableBetaQuest", 0);

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -7917,13 +7917,15 @@ void func_80842A28(PlayState* play, Player* this) {
 }
 
 void func_80842A88(PlayState* play, Player* this) {
-    Inventory_ChangeAmmo(ITEM_STICK, -1);
-    func_80835F44(play, this, ITEM_NONE);
+    if (!CVar_GetS32("gUltraDekuStick", 0)) {
+        Inventory_ChangeAmmo(ITEM_STICK, -1);
+        func_80835F44(play, this, ITEM_NONE);
+    }
 }
 
 s32 func_80842AC4(PlayState* play, Player* this) {
     if ((this->heldItemActionParam == PLAYER_AP_STICK) && (this->unk_85C > 0.5f)) {
-        if (AMMO(ITEM_STICK) != 0) {
+        if (AMMO(ITEM_STICK) != 0 && !CVar_GetS32("gUltraDekuStick", 0)) {
             EffectSsStick_Spawn(play, &this->bodyPartsPos[PLAYER_BODYPART_R_HAND],
                                 this->actor.shape.rot.y + 0x8000);
             this->unk_85C = 0.5f;
@@ -10263,21 +10265,29 @@ static Color_RGBA8 D_808547C0 = { 255, 50, 0, 0 };
 
 void func_80848A04(PlayState* play, Player* this) {
     f32 temp;
-
-    if (this->unk_85C == 0.0f) {
+    f32 temp2;
+    
+    if(CVar_GetS32("gUltraDekuStick", 0)){
+        temp2 = 1.0f;
+        this->unk_860 = 200;
+        this->unk_85C = 1.0f;
+        func_8002836C(play, &this->swordInfo[0].tip, &D_808547A4, &D_808547B0, &D_808547BC, &D_808547C0, temp2 * 200.0f,
+                    0, 8);
+    }
+    if (this->unk_85C == 0.0f && !CVar_GetS32("gUltraDekuStick", 0)) {
         func_80835F44(play, this, 0xFF);
         return;
     }
 
     temp = 1.0f;
-    if (DECR(this->unk_860) == 0) {
+    if (DECR(this->unk_860) == 0 && !CVar_GetS32("gUltraDekuStick", 0)) {
         Inventory_ChangeAmmo(ITEM_STICK, -1);
         this->unk_860 = 1;
         temp = 0.0f;
         this->unk_85C = temp;
     } else if (this->unk_860 > 200) {
         temp = (210 - this->unk_860) / 10.0f;
-    } else if (this->unk_860 < 20) {
+    } else if (this->unk_860 < 20 && !CVar_GetS32("gUltraDekuStick", 0)) {
         temp = this->unk_860 / 20.0f;
         this->unk_85C = temp;
     }
@@ -10564,7 +10574,7 @@ void Player_UpdateCommon(Player* this, PlayState* play, Input* input) {
     func_808473D4(play, this);
     func_80836BEC(this, play);
 
-    if ((this->heldItemActionParam == PLAYER_AP_STICK) && (this->unk_860 != 0)) {
+    if ((this->heldItemActionParam == PLAYER_AP_STICK) && ((this->unk_860 != 0) || CVar_GetS32("gUltraDekuStick", 0))) {
         func_80848A04(play, this);
     } else if ((this->heldItemActionParam == PLAYER_AP_FISHING_POLE) && (this->unk_860 < 0)) {
         this->unk_860++;

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -10268,11 +10268,11 @@ void func_80848A04(PlayState* play, Player* this) {
     f32 temp2;
     
     if(CVar_GetS32("gUltraDekuStick", 0)){
-        temp2 = 1.0f;
-        this->unk_860 = 200;
-        this->unk_85C = 1.0f;
+        temp2 = 1.0f;           // Secondary temporary variable to use with the alleged draw flame function
+        this->unk_860 = 200;    // Keeps the stick's flame lit
+        this->unk_85C = 1.0f;   // Ensures the stick is the proper length
         func_8002836C(play, &this->swordInfo[0].tip, &D_808547A4, &D_808547B0, &D_808547BC, &D_808547C0, temp2 * 200.0f,
-                    0, 8);
+                    0, 8);      // I believe this draws the flame effect
     }
     if (this->unk_85C == 0.0f && !CVar_GetS32("gUltraDekuStick", 0)) {
         func_80835F44(play, this, 0xFF);


### PR DESCRIPTION
Adds a new cheat called Ultra Deku Stick, which lights your deku stick on fire, keeps it lit and prevents it from breaking.