### PR TITLE
Include Minigame Ammo in Infinite Ammo Cheat

### DIFF
--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -1373,7 +1373,6 @@ namespace GameMenuBar {
                 UIWidgets::EnhancementCheckbox("Money", "gInfiniteMoney");
                 UIWidgets::PaddedEnhancementCheckbox("Health", "gInfiniteHealth", true, false);
                 UIWidgets::PaddedEnhancementCheckbox("Ammo", "gInfiniteAmmo", true, false);
-                UIWidgets::PaddedEnhancementCheckbox("Minigame Ammo", "gInfiniteMinigame", true, false);
                 UIWidgets::PaddedEnhancementCheckbox("Magic", "gInfiniteMagic", true, false);
                 UIWidgets::PaddedEnhancementCheckbox("Nayru's Love", "gInfiniteNayru", true, false);
                 UIWidgets::PaddedEnhancementCheckbox("Epona Boost", "gInfiniteEpona", true, false);

--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -1373,6 +1373,7 @@ namespace GameMenuBar {
                 UIWidgets::EnhancementCheckbox("Money", "gInfiniteMoney");
                 UIWidgets::PaddedEnhancementCheckbox("Health", "gInfiniteHealth", true, false);
                 UIWidgets::PaddedEnhancementCheckbox("Ammo", "gInfiniteAmmo", true, false);
+                UIWidgets::PaddedEnhancementCheckbox("Minigame Ammo", "gInfiniteMinigame", true, false);
                 UIWidgets::PaddedEnhancementCheckbox("Magic", "gInfiniteMagic", true, false);
                 UIWidgets::PaddedEnhancementCheckbox("Nayru's Love", "gInfiniteNayru", true, false);
                 UIWidgets::PaddedEnhancementCheckbox("Epona Boost", "gInfiniteEpona", true, false);

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -1874,7 +1874,7 @@ void func_808337D4(PlayState* play, Player* this) {
                                       this->actor.shape.rot.y, 0, 0);
     if (spawnedActor != NULL) {
         if ((explosiveType != 0) && (play->bombchuBowlingStatus != 0)) {
-            if (!CVar_GetS32("gInfiniteMinigame", 0))
+            if (!CVar_GetS32("gInfiniteAmmo", 0))
                 play->bombchuBowlingStatus--;
             if (play->bombchuBowlingStatus == 0) {
                 play->bombchuBowlingStatus = -1;
@@ -2516,10 +2516,10 @@ s32 func_808350A4(PlayState* play, Player* this) {
             func_80834380(play, this, &item, &arrowType);
 
             if (gSaveContext.minigameState == 1) {
-                if (!CVar_GetS32("gInfiniteMinigame", 0))
+                if (!CVar_GetS32("gInfiniteAmmo", 0))
                     play->interfaceCtx.hbaAmmo--;
             } else if (play->shootingGalleryStatus != 0) {
-                if (!CVar_GetS32("gInfiniteMinigame", 0))
+                if (!CVar_GetS32("gInfiniteAmmo", 0))
                     play->shootingGalleryStatus--;
             } else {
                 Inventory_ChangeAmmo(item, -1);

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -1874,7 +1874,8 @@ void func_808337D4(PlayState* play, Player* this) {
                                       this->actor.shape.rot.y, 0, 0);
     if (spawnedActor != NULL) {
         if ((explosiveType != 0) && (play->bombchuBowlingStatus != 0)) {
-            play->bombchuBowlingStatus--;
+            if (!CVar_GetS32("gInfiniteMinigame", 0))
+                play->bombchuBowlingStatus--;
             if (play->bombchuBowlingStatus == 0) {
                 play->bombchuBowlingStatus = -1;
             }
@@ -2515,9 +2516,11 @@ s32 func_808350A4(PlayState* play, Player* this) {
             func_80834380(play, this, &item, &arrowType);
 
             if (gSaveContext.minigameState == 1) {
-                play->interfaceCtx.hbaAmmo--;
+                if (!CVar_GetS32("gInfiniteMinigame", 0))
+                    play->interfaceCtx.hbaAmmo--;
             } else if (play->shootingGalleryStatus != 0) {
-                play->shootingGalleryStatus--;
+                if (!CVar_GetS32("gInfiniteMinigame", 0))
+                    play->shootingGalleryStatus--;
             } else {
                 Inventory_ChangeAmmo(item, -1);
             }


### PR DESCRIPTION
Adds a new cheat to the infinite.. cheat sub-menu called "Minigame Ammo" which prevents your minigame ammo from depleting while playing a minigame that uses ammo (shooting gallery, bombchu bowling, horseback archery)