### PR TITLE
Adds Slingshot and Bow ammo use fix

### DIFF
--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -316,6 +316,8 @@ namespace GameMenuBar {
         CVar_SetS32("gCrouchStabFix", 0);
         // Fix Gerudo Warrior's clothing colors
         CVar_SetS32("gGerudoWarriorClothingFix", 0);
+        // Fix Bow and Slingshot Ammo use
+        CVar_SetS32("gSlingshotBowAmmoFix", 0);
 
         // Red Ganon blood
         CVar_SetS32("gRedGanonBlood", 0);
@@ -1168,6 +1170,8 @@ namespace GameMenuBar {
                 }
                 UIWidgets::PaddedEnhancementCheckbox("Fix Gerudo Warrior's clothing colors", "gGerudoWarriorClothingFix", true, false);
                 UIWidgets::Tooltip("Prevent the Gerudo Warrior's clothes changing color when changing Link's tunic or using bombs in front of her");
+                UIWidgets::PaddedEnhancementCheckbox("Fix Slingshot and Bow ammo use", "gSlingshotBowAmmoFix", true, false);
+                UIWidgets::Tooltip("Make slingshot and bow use correct ammo for equip swap glitch or Timeless Equipment cheat");
 
                 ImGui::EndMenu();
             }

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -2170,7 +2170,7 @@ void func_80834298(Player* this, PlayState* play) {
 
 // Determine projectile type for bow or slingshot
 s32 func_80834380(PlayState* play, Player* this, s32* itemPtr, s32* typePtr) {
-    if (LINK_IS_ADULT) {
+    if ((CVar_GetS32("gSlingshotBowAmmoFix", 0) && this->heldItemActionParam != PLAYER_AP_SLINGSHOT) || !CVar_GetS32("gSlingshotBowAmmoFix", 0) && LINK_IS_ADULT) {
         *itemPtr = ITEM_BOW;
         if (this->stateFlags1 & PLAYER_STATE1_23) {
             *typePtr = ARROW_NORMAL_HORSE;
@@ -4900,7 +4900,7 @@ s32 func_8083AD4C(PlayState* play, Player* this) {
 
     if (this->unk_6AD == 2) {
         if (func_8002DD6C(this)) {
-            if (LINK_IS_ADULT) {
+            if ((CVar_GetS32("gSlingshotBowAmmoFix", 0) && this->heldItemActionParam != PLAYER_AP_SLINGSHOT) || !CVar_GetS32("gSlingshotBowAmmoFix", 0) && LINK_IS_ADULT) {
                 cameraMode = CAM_MODE_BOWARROW;
             } else {
                 cameraMode = CAM_MODE_SLINGSHOT;
@@ -11468,7 +11468,12 @@ s32 func_8084B3CC(PlayState* play, Player* this) {
         func_80835C58(play, this, func_8084FA54, 0);
 
         if (!func_8002DD6C(this) || Player_HoldsHookshot(this)) {
-            func_80835F44(play, this, 3);
+            if (CVar_GetS32("gSlingshotBowAmmoFix", 0)) {
+                s32 itemToUse = LINK_IS_ADULT ? ITEM_BOW : ITEM_SLINGSHOT;
+                func_80835F44(play, this, itemToUse);
+            }
+            else if (!CVar_GetS32("gSlingshotBowAmmoFix", 0))
+                func_80835F44(play, this, 3);
         }
 
         this->stateFlags1 |= PLAYER_STATE1_20;


### PR DESCRIPTION
Adds a "fix" that allows the slingshot and bow to use the correct ammo when using the equip swap glitch or timeless equipment cheat