### PR TITLE
Fix: Allow turning in ruto's letter after rescuing her

### DIFF
--- a/soh/src/overlays/actors/ovl_En_Kz/z_en_kz.c
+++ b/soh/src/overlays/actors/ovl_En_Kz/z_en_kz.c
@@ -75,6 +75,10 @@ u16 EnKz_GetTextNoMaskChild(PlayState* play, EnKz* this) {
 
     if ((gSaveContext.n64ddFlag && Flags_GetRandomizerInf(RAND_INF_DUNGEONS_DONE_JABU_JABUS_BELLY)) ||
         (!gSaveContext.n64ddFlag && CHECK_QUEST_ITEM(QUEST_ZORA_SAPPHIRE))) {
+        // Allow turning in Ruto's letter even if you have already rescued her
+        if (gSaveContext.n64ddFlag && !(gSaveContext.eventChkInf[3] & 8)) {
+            player->exchangeItemId = EXCH_ITEM_LETTER_RUTO;
+        }
         return 0x402B;
     } else if (gSaveContext.eventChkInf[3] & 8) {
         return 0x401C;


### PR DESCRIPTION
It was reported the other day that in randomizer, if you beat JabuJabu and Ruto is rescued, you can not turn in Ruto's letter to King Zora anymore. This is most likely to happen with dungeon entrance shuffle, but can also happen in a glitched run.

This just ensures that you can still turn in the letter when JabuJabu is completed.