### PR TITLE
TWEAK: Game controls menu simplification

### DIFF
--- a/soh/soh/Enhancements/controls/GameControlEditor.cpp
+++ b/soh/soh/Enhancements/controls/GameControlEditor.cpp
@@ -264,13 +264,14 @@ namespace GameControlEditor {
         SohImGui::EndGroupPanel();
     }
 
-    void DrawMKBControlPanel() {
-        if (!ImGui::CollapsingHeader("Mouse and Keyboard Controls")) {
+    void DrawMiscControlPanel() {
+        if (!ImGui::CollapsingHeader("Miscellaneous Controls")) {
             return;
         }
 
         ImVec2 cursor = ImGui::GetCursorPos();
         ImGui::SetCursorPos(ImVec2(cursor.x + 5, cursor.y + 5));
+        SohImGui::BeginGroupPanel("Misc Controls", ImGui::GetContentRegionAvail());
         UIWidgets::PaddedEnhancementCheckbox("Enable walk speed modifiers", "gEnableWalkModify", true, false);
         DrawHelpIcon("Hold the assigned button to change the maximum walking speed\nTo change the assigned button, go into the Ports tabs above");
          if (CVar_GetS32("gEnableWalkModify", 0)) {
@@ -281,17 +282,7 @@ namespace GameControlEditor {
             UIWidgets::EnhancementSliderFloat("Modifier 2: %d %%", "##WalkMod2", "gWalkModifierTwo", 0.0f, 5.0f, "", 1.0f, true);
             SohImGui::EndGroupPanel();
         }
-        UIWidgets::Spacer(5);
-    }
-
-    void DrawMiscControlPanel() {
-        if (!ImGui::CollapsingHeader("Miscellaneous Controls")) {
-            return;
-        }
-
-        ImVec2 cursor = ImGui::GetCursorPos();
-        ImGui::SetCursorPos(ImVec2(cursor.x + 5, cursor.y + 5));
-        SohImGui::BeginGroupPanel("Misc Controls", ImGui::GetContentRegionAvail());
+        UIWidgets::Spacer(0);
         UIWidgets::PaddedEnhancementCheckbox("Allow the cursor to be on any slot", "gPauseAnyCursor");
         DrawHelpIcon("Allows the cursor on the pause menu to be over any slot\nSimilar to Rando and Spaceworld 97");
         UIWidgets::PaddedEnhancementCheckbox("Answer Navi Prompt with L Button", "gNaviOnL");
@@ -327,7 +318,6 @@ namespace GameControlEditor {
                 DrawOcarinaControlPanel();
                 DrawCameraControlPanel();
                 DrawDpadControlPanel();
-                DrawMKBControlPanel();
                 DrawMiscControlPanel();
             } else {
                 DrawCustomButtons();

--- a/soh/soh/Enhancements/controls/GameControlEditor.cpp
+++ b/soh/soh/Enhancements/controls/GameControlEditor.cpp
@@ -245,6 +245,61 @@ namespace GameControlEditor {
         UIWidgets::EnhancementSliderFloat("Camera Sensitivity: %d %%", "##Sensitivity", "gCameraSensitivity", 0.01f, 5.0f, "", 1.0f, true, true);
     }
 
+    void DrawDpadControlPanel() {
+        if (!ImGui::CollapsingHeader("D-Pad Controls")) {
+            return;
+        }
+
+        ImVec2 cursor = ImGui::GetCursorPos();
+        ImGui::SetCursorPos(ImVec2(cursor.x + 5, cursor.y + 5));
+        SohImGui::BeginGroupPanel("D-Pad Options", ImGui::GetContentRegionAvail());
+        UIWidgets::PaddedEnhancementCheckbox("D-pad Support on Pause Screen", "gDpadPause");
+        DrawHelpIcon("Navigate Pause with the D-pad\nIf used with D-pad as Equip Items, you must hold C-Up to equip instead of navigate\n"
+                    "To make the cursor only move a single space no matter how long a direction is held, manually set gDpadHoldChange to 0");
+        UIWidgets::PaddedEnhancementCheckbox("D-pad Support in Text Boxes", "gDpadText");
+        DrawHelpIcon("Navigate choices in text boxes, shop item selection, and the file select / name entry screens with the D-pad\n"
+                    "To make the cursor only move a single space during name entry no matter how long a direction is held, manually set gDpadHoldChange to 0");
+        UIWidgets::PaddedEnhancementCheckbox("D-pad as Equip Items", "gDpadEquips");
+        DrawHelpIcon("Equip items and equipment on the D-pad\nIf used with D-pad on Pause Screen, you must hold C-Up to equip instead of navigate");
+        SohImGui::EndGroupPanel();
+    }
+
+    void DrawMKBControlPanel() {
+        if (!ImGui::CollapsingHeader("Mouse and Keyboard Controls")) {
+            return;
+        }
+
+        ImVec2 cursor = ImGui::GetCursorPos();
+        ImGui::SetCursorPos(ImVec2(cursor.x + 5, cursor.y + 5));
+        UIWidgets::PaddedEnhancementCheckbox("Enable walk speed modifiers", "gEnableWalkModify", true, false);
+        DrawHelpIcon("Hold the assigned button to change the maximum walking speed\nTo change the assigned button, go into the Ports tabs above");
+         if (CVar_GetS32("gEnableWalkModify", 0)) {
+            UIWidgets::Spacer(5);
+            SohImGui::BeginGroupPanel("Walk Modifier", ImGui::GetContentRegionAvail());
+            UIWidgets::PaddedEnhancementCheckbox("Toggle modifier instead of holding", "gWalkSpeedToggle", true, false);
+            UIWidgets::EnhancementSliderFloat("Modifier 1: %d %%", "##WalkMod1", "gWalkModifierOne", 0.0f, 5.0f, "", 1.0f, true);
+            UIWidgets::EnhancementSliderFloat("Modifier 2: %d %%", "##WalkMod2", "gWalkModifierTwo", 0.0f, 5.0f, "", 1.0f, true);
+            SohImGui::EndGroupPanel();
+        }
+        UIWidgets::Spacer(5);
+    }
+
+    void DrawMiscControlPanel() {
+        if (!ImGui::CollapsingHeader("Miscellaneous Controls")) {
+            return;
+        }
+
+        ImVec2 cursor = ImGui::GetCursorPos();
+        ImGui::SetCursorPos(ImVec2(cursor.x + 5, cursor.y + 5));
+        SohImGui::BeginGroupPanel("Misc Controls", ImGui::GetContentRegionAvail());
+        UIWidgets::PaddedEnhancementCheckbox("Allow the cursor to be on any slot", "gPauseAnyCursor");
+        DrawHelpIcon("Allows the cursor on the pause menu to be over any slot\nSimilar to Rando and Spaceworld 97");
+        UIWidgets::PaddedEnhancementCheckbox("Answer Navi Prompt with L Button", "gNaviOnL");
+        DrawHelpIcon("Speak to Navi with L but enter first-person camera with C-Up");
+        SohImGui::EndGroupPanel();
+
+    }
+
     void DrawUI(bool& open) {
         if (!open) {
             CVar_SetS32("gGameControlEditorEnabled", false);
@@ -271,6 +326,9 @@ namespace GameControlEditor {
             if (CurrentPort == 0) {
                 DrawOcarinaControlPanel();
                 DrawCameraControlPanel();
+                DrawDpadControlPanel();
+                DrawMKBControlPanel();
+                DrawMiscControlPanel();
             } else {
                 DrawCustomButtons();
             }

--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -306,49 +306,7 @@ namespace GameMenuBar {
             DrawPresetSelector(PRESET_TYPE_ENHANCEMENTS);
 
             UIWidgets::Spacer(0);
-
-            if (ImGui::BeginMenu("Controls")) {
-                ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(12.0f, 6.0f));
-                ImGui::PushStyleVar(ImGuiStyleVar_ButtonTextAlign, ImVec2(0, 0));
-                ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize, 1.0f);
-                ImGui::PushStyleColor(ImGuiCol_Border, ImVec4(0.22f, 0.38f, 0.56f, 1.0f));
-                float availableWidth = ImGui::GetContentRegionAvail().x;
-                if (ImGui::Button(
-                    GetWindowButtonText("Customize Game Controls", CVar_GetS32("gGameControlEditorEnabled", 0)).c_str(),
-                    ImVec2(availableWidth, 0)
-                )) {
-                    bool currentValue = CVar_GetS32("gGameControlEditorEnabled", 0);
-                    CVar_SetS32("gGameControlEditorEnabled", !currentValue);
-                    SohImGui::RequestCvarSaveOnNextTick();
-                    SohImGui::EnableWindow("Game Control Editor", CVar_GetS32("gGameControlEditorEnabled", 0));
-                }
-                ImGui::PopStyleVar(3);
-                ImGui::PopStyleColor(1);
-
-                UIWidgets::PaddedEnhancementCheckbox("D-pad Support on Pause Screen", "gDpadPause", true, false);
-                UIWidgets::Tooltip("Navigate Pause with the D-pad\nIf used with D-pad as Equip Items, you must hold C-Up to equip instead of navigate\n"
-                    "To make the cursor only move a single space no matter how long a direction is held, manually set gDpadHoldChange to 0");
-                UIWidgets::PaddedEnhancementCheckbox("D-pad Support in Text Boxes", "gDpadText", true, false);
-                UIWidgets::Tooltip("Navigate choices in text boxes, shop item selection, and the file select / name entry screens with the D-pad\n"
-                    "To make the cursor only move a single space during name entry no matter how long a direction is held, manually set gDpadHoldChange to 0");
-                UIWidgets::PaddedEnhancementCheckbox("D-pad as Equip Items", "gDpadEquips", true, false);
-                UIWidgets::Tooltip("Equip items and equipment on the D-pad\nIf used with D-pad on Pause Screen, you must hold C-Up to equip instead of navigate");
-                UIWidgets::PaddedEnhancementCheckbox("Allow the cursor to be on any slot", "gPauseAnyCursor", true, false);
-                UIWidgets::Tooltip("Allows the cursor on the pause menu to be over any slot\nSimilar to Rando and Spaceworld 97");
-                UIWidgets::PaddedEnhancementCheckbox("Answer Navi Prompt with L Button", "gNaviOnL", true, false);
-                UIWidgets::Tooltip("Speak to Navi with L but enter first-person camera with C-Up");
-                UIWidgets::PaddedEnhancementCheckbox("Enable walk speed modifiers", "gEnableWalkModify", true, false);
-                UIWidgets::Tooltip("Hold the assigned button to change the maximum walking speed\nTo change the assigned button, click Customize Game Controls");
-                if (CVar_GetS32("gEnableWalkModify", 0)) {
-                    UIWidgets::PaddedEnhancementCheckbox("Toggle modifier instead of holding", "gWalkSpeedToggle", true, false);
-                    UIWidgets::EnhancementSliderFloat("Modifier 1: %d %%", "##WalkMod1", "gWalkModifierOne", 0.0f, 5.0f, "", 1.0f, true);
-                    UIWidgets::EnhancementSliderFloat("Modifier 2: %d %%", "##WalkMod2", "gWalkModifierTwo", 0.0f, 5.0f, "", 1.0f, true);
-                }
-                ImGui::EndMenu();
-            }
-
-            UIWidgets::Spacer(0);
-
+            
             if (ImGui::BeginMenu("Gameplay"))
             {
                 if (ImGui::BeginMenu("Time Savers"))
@@ -792,6 +750,16 @@ namespace GameMenuBar {
             ImGui::PushStyleVar(ImGuiStyleVar_ButtonTextAlign, ImVec2(0, 0));
             ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize, 1.0f);
             ImGui::PushStyleColor(ImGuiCol_Border, ImVec4(0.22f, 0.38f, 0.56f, 1.0f));
+            float availableWidth = ImGui::GetContentRegionAvail().x;
+            if (ImGui::Button(
+                GetWindowButtonText("Customize Game Controls", CVar_GetS32("gGameControlEditorEnabled", 0)).c_str(),
+                ImVec2(availableWidth, 0)
+            )) {
+                bool currentValue = CVar_GetS32("gGameControlEditorEnabled", 0);
+                CVar_SetS32("gGameControlEditorEnabled", !currentValue);
+                SohImGui::RequestCvarSaveOnNextTick();
+                SohImGui::EnableWindow("Game Control Editor", CVar_GetS32("gGameControlEditorEnabled", 0));
+            }
             if (ImGui::Button(GetWindowButtonText("Cosmetics Editor", CVar_GetS32("gCosmeticsEditorEnabled", 0)).c_str(), ImVec2(-1.0f, 0.0f)))
             {
                 bool currentValue = CVar_GetS32("gCosmeticsEditorEnabled", 0);

--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -306,7 +306,7 @@ namespace GameMenuBar {
             DrawPresetSelector(PRESET_TYPE_ENHANCEMENTS);
 
             UIWidgets::Spacer(0);
-            
+
             if (ImGui::BeginMenu("Gameplay"))
             {
                 if (ImGui::BeginMenu("Time Savers"))
@@ -750,11 +750,9 @@ namespace GameMenuBar {
             ImGui::PushStyleVar(ImGuiStyleVar_ButtonTextAlign, ImVec2(0, 0));
             ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize, 1.0f);
             ImGui::PushStyleColor(ImGuiCol_Border, ImVec4(0.22f, 0.38f, 0.56f, 1.0f));
-            float availableWidth = ImGui::GetContentRegionAvail().x;
-            if (ImGui::Button(
-                GetWindowButtonText("Customize Game Controls", CVar_GetS32("gGameControlEditorEnabled", 0)).c_str(),
-                ImVec2(availableWidth, 0)
-            )) {
+
+            if (ImGui::Button(GetWindowButtonText("Customize Game Controls", CVar_GetS32("gGameControlEditorEnabled", 0)).c_str(), ImVec2(-1.0f, 0.0f)))
+            {
                 bool currentValue = CVar_GetS32("gGameControlEditorEnabled", 0);
                 CVar_SetS32("gGameControlEditorEnabled", !currentValue);
                 SohImGui::RequestCvarSaveOnNextTick();


### PR DESCRIPTION
Moves the "customize game controls" button out of the controls submenu, and into the main enhancements section, alongside the other buttons for additional window menus. Also moves all of the options previously in the controls submenu into the game controls menu.

<img width="270" alt="image" src="https://user-images.githubusercontent.com/60364512/203569929-d8cafdfb-ac0c-4c11-bda5-241534c7aea2.png">
<img width="595" alt="image" src="https://user-images.githubusercontent.com/60364512/203586418-a0c61bb1-9326-4308-9f65-88d315edbdde.png">
