### PR TITLE
Removes duplicated rando option enum for merchant

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizerTypes.h
+++ b/soh/soh/Enhancements/randomizer/randomizerTypes.h
@@ -1129,11 +1129,6 @@ typedef enum RandoOption {
   RO_SCRUBS_EXPENSIVE,
   RO_SCRUBS_RANDOM,
 
-  //Shuffle Merchants settings (off, on w/o hints, on w/hints)
-  RO_MERCHANTS_OFF = 0,
-  RO_MERCHANTS_ON_NO_HINTS,
-  RO_MERCHANTS_ON_WITH_HINTS,
-
   //Ammo drop settings (on, "on+bombchu", off)
   RO_AMMO_DROPS_ON = 0,
   RO_AMMO_DROPS_ON_PLUS_BOMBCHU,


### PR DESCRIPTION
Simply removes the unused second set of enum options for shuffling merchants. 
`RO_SHUFFLE_MERCHANTS_*` is used by other code, but `RO_MERCHANTS_*` is not