### PR TITLE
Re-implements Ninja and CCache for Windows Builds

### DIFF
--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -225,11 +225,19 @@ jobs:
           readme.txt
   build-windows:
     needs: extract-assets
-    runs-on: [self-hosted, Windows, x64]
+    runs-on: windows-latest
     steps:
+    - name: Install dependencies
+      run: |
+        choco install ninja
+        Remove-Item -Path "C:\ProgramData\Chocolatey\bin\ccache.exe" -Force
     - uses: actions/checkout@v3
       with:
         submodules: true
+    - name: ccache
+      uses: dcvz/ccache-action@27b9f33213c0079872f064f6b6ba0233dfa16ba2
+      with:
+        key: ${{ runner.os }}-ccache
     - name: Restore assets
       uses: actions/download-artifact@v3
       with:
@@ -241,7 +249,8 @@ jobs:
       run: |
         7z x assets.zip -aoa
 
-        cmake -S . -B build-windows -G "Visual Studio 17 2022" -T v142 -A x64 -DCMAKE_BUILD_TYPE:STRING=Release
+        set $env:PATH="$env:USERPROFILE/.cargo/bin;$env:PATH"
+        cmake -S . -B build-windows -G Ninja -DCMAKE_MAKE_PROGRAM=ninja -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         cmake --build build-windows --target OTRGui --config Release --parallel 10
         cmake --build build-windows --config Release --parallel 10
         cd build-windows

--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -242,6 +242,7 @@ jobs:
       uses: actions/download-artifact@v3
       with:
         name: assets
+    - uses: ilammy/msvc-dev-cmd@v1
     - name: Setup 7-Zip
       run: |
         "C:\Program Files\7-Zip" >> $env:GITHUB_PATH

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,34 +66,34 @@ endif()
 ################################################################################
 # Global compiler options
 ################################################################################
-if(MSVC)
-    # remove default flags provided with CMake for MSVC
-    set(CMAKE_C_FLAGS "")
-    set(CMAKE_C_FLAGS_DEBUG "")
-    set(CMAKE_C_FLAGS_RELEASE "")
-    set(CMAKE_CXX_FLAGS "")
-    set(CMAKE_CXX_FLAGS_DEBUG "")
-    set(CMAKE_CXX_FLAGS_RELEASE "")
-endif()
+# if(MSVC)
+#     # remove default flags provided with CMake for MSVC
+#     set(CMAKE_C_FLAGS "")
+#     set(CMAKE_C_FLAGS_DEBUG "")
+#     set(CMAKE_C_FLAGS_RELEASE "")
+#     set(CMAKE_CXX_FLAGS "")
+#     set(CMAKE_CXX_FLAGS_DEBUG "")
+#     set(CMAKE_CXX_FLAGS_RELEASE "")
+# endif()
 
 ################################################################################
 # Global linker options
 ################################################################################
-if(MSVC)
-    # remove default flags provided with CMake for MSVC
-    set(CMAKE_EXE_LINKER_FLAGS "")
-    set(CMAKE_MODULE_LINKER_FLAGS "")
-    set(CMAKE_SHARED_LINKER_FLAGS "")
-    set(CMAKE_STATIC_LINKER_FLAGS "")
-    set(CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_EXE_LINKER_FLAGS}")
-    set(CMAKE_MODULE_LINKER_FLAGS_DEBUG "${CMAKE_MODULE_LINKER_FLAGS}")
-    set(CMAKE_SHARED_LINKER_FLAGS_DEBUG "${CMAKE_SHARED_LINKER_FLAGS}")
-    set(CMAKE_STATIC_LINKER_FLAGS_DEBUG "${CMAKE_STATIC_LINKER_FLAGS}")
-    set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS}")
-    set(CMAKE_MODULE_LINKER_FLAGS_RELEASE "${CMAKE_MODULE_LINKER_FLAGS}")
-    set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS}")
-    set(CMAKE_STATIC_LINKER_FLAGS_RELEASE "${CMAKE_STATIC_LINKER_FLAGS}")
-endif()
+# if(MSVC)
+#     # remove default flags provided with CMake for MSVC
+#     set(CMAKE_EXE_LINKER_FLAGS "")
+#     set(CMAKE_MODULE_LINKER_FLAGS "")
+#     set(CMAKE_SHARED_LINKER_FLAGS "")
+#     set(CMAKE_STATIC_LINKER_FLAGS "")
+#     set(CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_EXE_LINKER_FLAGS}")
+#     set(CMAKE_MODULE_LINKER_FLAGS_DEBUG "${CMAKE_MODULE_LINKER_FLAGS}")
+#     set(CMAKE_SHARED_LINKER_FLAGS_DEBUG "${CMAKE_SHARED_LINKER_FLAGS}")
+#     set(CMAKE_STATIC_LINKER_FLAGS_DEBUG "${CMAKE_STATIC_LINKER_FLAGS}")
+#     set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS}")
+#     set(CMAKE_MODULE_LINKER_FLAGS_RELEASE "${CMAKE_MODULE_LINKER_FLAGS}")
+#     set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS}")
+#     set(CMAKE_STATIC_LINKER_FLAGS_RELEASE "${CMAKE_STATIC_LINKER_FLAGS}")
+# endif()
 
 ################################################################################
 # Common utils

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,38 +64,6 @@ if(NOT CMAKE_BUILD_TYPE )
 endif()
 
 ################################################################################
-# Global compiler options
-################################################################################
-# if(MSVC)
-#     # remove default flags provided with CMake for MSVC
-#     set(CMAKE_C_FLAGS "")
-#     set(CMAKE_C_FLAGS_DEBUG "")
-#     set(CMAKE_C_FLAGS_RELEASE "")
-#     set(CMAKE_CXX_FLAGS "")
-#     set(CMAKE_CXX_FLAGS_DEBUG "")
-#     set(CMAKE_CXX_FLAGS_RELEASE "")
-# endif()
-
-################################################################################
-# Global linker options
-################################################################################
-# if(MSVC)
-#     # remove default flags provided with CMake for MSVC
-#     set(CMAKE_EXE_LINKER_FLAGS "")
-#     set(CMAKE_MODULE_LINKER_FLAGS "")
-#     set(CMAKE_SHARED_LINKER_FLAGS "")
-#     set(CMAKE_STATIC_LINKER_FLAGS "")
-#     set(CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_EXE_LINKER_FLAGS}")
-#     set(CMAKE_MODULE_LINKER_FLAGS_DEBUG "${CMAKE_MODULE_LINKER_FLAGS}")
-#     set(CMAKE_SHARED_LINKER_FLAGS_DEBUG "${CMAKE_SHARED_LINKER_FLAGS}")
-#     set(CMAKE_STATIC_LINKER_FLAGS_DEBUG "${CMAKE_STATIC_LINKER_FLAGS}")
-#     set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS}")
-#     set(CMAKE_MODULE_LINKER_FLAGS_RELEASE "${CMAKE_MODULE_LINKER_FLAGS}")
-#     set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS}")
-#     set(CMAKE_STATIC_LINKER_FLAGS_RELEASE "${CMAKE_STATIC_LINKER_FLAGS}")
-# endif()
-
-################################################################################
 # Common utils
 ################################################################################
 include(CMake/Utils.cmake)


### PR DESCRIPTION
I think I found out why the ninja built soh.exe's were starting slower. I fixed that and updated the GitHub actions to use Ninja and GitHub actions. Need to test these builds but if they are back to loading faster then we can use this in github actions.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/456158878.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/456158879.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/456158880.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/456158881.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/456158882.zip)
<!--- section:artifacts:end -->