### PR TITLE
refactor: separate RandoOption enum, use max

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -2831,7 +2831,7 @@ void DrawRandoEditor(bool& open) {
                     "Open - Mido no longer blocks the path to the Deku Tree. Kokiri "
                     "boy no longer blocks the path out of the forest."
                 );
-                UIWidgets::EnhancementCombobox("gRandomizeForest", randoForest, 3, RO_FOREST_CLOSED);
+                UIWidgets::EnhancementCombobox("gRandomizeForest", randoForest, RO_FOREST_MAX, RO_FOREST_CLOSED);
 
                 UIWidgets::PaddedSeparator();
 
@@ -2844,7 +2844,7 @@ void DrawRandoEditor(bool& open) {
                     "Open - The gate is always open. The happy mask shop "
                     "will open immediately after obtaining Zelda's letter."
                 );
-                UIWidgets::EnhancementCombobox("gRandomizeKakarikoGate", randoKakarikoGate, 2, RO_KAK_GATE_CLOSED);
+                UIWidgets::EnhancementCombobox("gRandomizeKakarikoGate", randoKakarikoGate, RO_KAK_GATE_MAX, RO_KAK_GATE_CLOSED);
 
                 UIWidgets::PaddedSeparator();
 
@@ -2859,7 +2859,7 @@ void DrawRandoEditor(bool& open) {
                     "\n"
                     "Open - The Door of Time is permanently open with no requirements."
                 );
-                UIWidgets::EnhancementCombobox("gRandomizeDoorOfTime", randoDoorOfTime, 3, RO_DOOROFTIME_CLOSED);
+                UIWidgets::EnhancementCombobox("gRandomizeDoorOfTime", randoDoorOfTime, RO_DOOROFTIME_MAX, RO_DOOROFTIME_CLOSED);
 
                 UIWidgets::PaddedSeparator();
 
@@ -2876,7 +2876,7 @@ void DrawRandoEditor(bool& open) {
                     "Open - King Zora has already mweeped out of the way in both "
                     "time periods. Ruto's Letter is removed from the item pool."
                 );
-                UIWidgets::EnhancementCombobox("gRandomizeZorasFountain", randoZorasFountain, 3, RO_ZF_CLOSED);
+                UIWidgets::EnhancementCombobox("gRandomizeZorasFountain", randoZorasFountain, RO_ZF_MAX, RO_ZF_CLOSED);
 
                 UIWidgets::PaddedSeparator();
 
@@ -2907,7 +2907,7 @@ void DrawRandoEditor(bool& open) {
                     ImGui::PushItemFlag(ImGuiItemFlags_Disabled, true);
                     ImGui::PushStyleVar(ImGuiStyleVar_Alpha, ImGui::GetStyle().Alpha * 0.5f);
                 }    
-                UIWidgets::EnhancementCombobox("gRandomizeStartingAge", randoStartingAge, 3, RO_AGE_CHILD);
+                UIWidgets::EnhancementCombobox("gRandomizeStartingAge", randoStartingAge, RO_AGE_MAX, RO_AGE_CHILD);
                 if (disableRandoStartingAge) {
                     if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
                        ImGui::SetTooltip("%s", disableRandoStartingAgeText);
@@ -2931,7 +2931,7 @@ void DrawRandoEditor(bool& open) {
                     "\n"
                     "Open - The bridge is repaired from the start."
                 );
-                UIWidgets::EnhancementCombobox("gRandomizeGerudoFortress", randoGerudoFortress, 3, RO_GF_NORMAL);
+                UIWidgets::EnhancementCombobox("gRandomizeGerudoFortress", randoGerudoFortress, RO_GF_MAX, RO_GF_NORMAL);
 
                 UIWidgets::PaddedSeparator();
 
@@ -2958,7 +2958,7 @@ void DrawRandoEditor(bool& open) {
                     "Tokens - Obtain the specified amount of Skulltula tokens."
                 );
 
-                UIWidgets::EnhancementCombobox("gRandomizeRainbowBridge", randoRainbowBridge, 7, RO_BRIDGE_VANILLA);
+                UIWidgets::EnhancementCombobox("gRandomizeRainbowBridge", randoRainbowBridge, RO_BRIDGE_MAX, RO_BRIDGE_VANILLA);
                 ImGui::PopItemWidth();
                 switch (CVar_GetS32("gRandomizeRainbowBridge", RO_BRIDGE_VANILLA)) {
                     case RO_BRIDGE_ALWAYS_OPEN:
@@ -3007,7 +3007,7 @@ void DrawRandoEditor(bool& open) {
                     "\n"
                     "Random Number - A Random number and set of trials will be required."
                 );
-                UIWidgets::EnhancementCombobox("gRandomizeGanonTrial", randoGanonsTrial, 3, RO_GANONS_TRIALS_SET_NUMBER);
+                UIWidgets::EnhancementCombobox("gRandomizeGanonTrial", randoGanonsTrial, RO_GANONS_TRIALS_MAX, RO_GANONS_TRIALS_SET_NUMBER);
                 ImGui::PopItemWidth();
                 if (CVar_GetS32("gRandomizeGanonTrial", RO_GANONS_TRIALS_SET_NUMBER) == RO_GANONS_TRIALS_SET_NUMBER) {
                     ImGui::Dummy(ImVec2(0.0f, 0.0f));

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -3139,7 +3139,7 @@ void DrawRandoEditor(bool& open) {
                     "\n"
                     "Anywhere - Songs can appear at any location."
                 );
-                UIWidgets::EnhancementCombobox("gRandomizeShuffleSongs", randoShuffleSongs, 3, RO_SONG_SHUFFLE_SONG_LOCATIONS);
+                UIWidgets::EnhancementCombobox("gRandomizeShuffleSongs", randoShuffleSongs, RO_SONG_SHUFFLE_MAX, RO_SONG_SHUFFLE_SONG_LOCATIONS);
 
                 UIWidgets::PaddedSeparator();
 
@@ -3157,7 +3157,7 @@ void DrawRandoEditor(bool& open) {
                     "\n"
                     "All Tokens - Shuffle all 100 GS tokens."
                 );
-                UIWidgets::EnhancementCombobox("gRandomizeShuffleTokens", randoTokensanity, 4, RO_TOKENSANITY_OFF);
+                UIWidgets::EnhancementCombobox("gRandomizeShuffleTokens", randoTokensanity, RO_TOKENSANITY_MAX, RO_TOKENSANITY_OFF);
 
                 ImGui::Dummy(ImVec2(0,0));
 
@@ -3249,7 +3249,7 @@ void DrawRandoEditor(bool& open) {
                     "\n"
                     "Random - Vanilla shop items will be shuffled among different shops, and each shop will contain a random number(1-4) of non-vanilla shop items.\n"
                 );
-                UIWidgets::EnhancementCombobox("gRandomizeShopsanity", randoShopsanity, 7, RO_SHOPSANITY_OFF);
+                UIWidgets::EnhancementCombobox("gRandomizeShopsanity", randoShopsanity, RO_SHOPSANITY_MAX, RO_SHOPSANITY_OFF);
 
                 UIWidgets::PaddedSeparator();
 
@@ -3264,7 +3264,7 @@ void DrawRandoEditor(bool& open) {
                     "Expensive - Scrubs will be shuffled and their item will cost the vanilla price.\n"
                     "\n"
                     "Random - Scrubs will be shuffled and their item will cost will be between 0-95 rupees.\n");
-                UIWidgets::EnhancementCombobox("gRandomizeShuffleScrubs", randoShuffleScrubs, 4, RO_SCRUBS_OFF);
+                UIWidgets::EnhancementCombobox("gRandomizeShuffleScrubs", randoShuffleScrubs, RO_SCRUBS_MAX, RO_SCRUBS_OFF);
 
                 UIWidgets::PaddedSeparator();
 
@@ -3291,7 +3291,7 @@ void DrawRandoEditor(bool& open) {
                     "On (no hints) - Salesmen will be included but won't tell you what you'll get.\n"
                     "On (with hints) - Salesmen will be included and you'll know what you're buying."
                 );
-                UIWidgets::EnhancementCombobox("gRandomizeShuffleMerchants", randoShuffleMerchants, 3, RO_SHUFFLE_MERCHANTS_OFF);
+                UIWidgets::EnhancementCombobox("gRandomizeShuffleMerchants", randoShuffleMerchants, RO_SHUFFLE_MERCHANTS_MAX, RO_SHUFFLE_MERCHANTS_OFF);
 
                 UIWidgets::PaddedSeparator();
 
@@ -3346,7 +3346,7 @@ void DrawRandoEditor(bool& open) {
                     "\n"
                     "Anywhere - Spiritual stones and medallions can appear anywhere."
                 );
-                UIWidgets::EnhancementCombobox("gRandomizeShuffleDungeonReward", randoShuffleDungeonRewards, 4, RO_DUNGEON_REWARDS_END_OF_DUNGEON);
+                UIWidgets::EnhancementCombobox("gRandomizeShuffleDungeonReward", randoShuffleDungeonRewards, RO_DUNGEON_REWARDS_MAX, RO_DUNGEON_REWARDS_END_OF_DUNGEON);
 
                 UIWidgets::PaddedSeparator();
 
@@ -3365,7 +3365,7 @@ void DrawRandoEditor(bool& open) {
                     "\n"
                     "Anywhere - Maps & Compasses can appear anywhere in the world."
                 );
-                UIWidgets::EnhancementCombobox("gRandomizeStartingMapsCompasses", randoShuffleMapsAndCompasses, 6, RO_DUNGEON_ITEM_LOC_OWN_DUNGEON);
+                UIWidgets::EnhancementCombobox("gRandomizeStartingMapsCompasses", randoShuffleMapsAndCompasses, RO_DUNGEON_ITEM_LOC_MAX, RO_DUNGEON_ITEM_LOC_OWN_DUNGEON);
 
                 UIWidgets::PaddedSeparator();
 
@@ -3384,7 +3384,7 @@ void DrawRandoEditor(bool& open) {
                     "\n"
                     "Anywhere - Small Keys can appear anywhere in the world."
                 );
-                UIWidgets::EnhancementCombobox("gRandomizeKeysanity", randoShuffleSmallKeys, 6, RO_DUNGEON_ITEM_LOC_OWN_DUNGEON);
+                UIWidgets::EnhancementCombobox("gRandomizeKeysanity", randoShuffleSmallKeys, RO_DUNGEON_ITEM_LOC_MAX, RO_DUNGEON_ITEM_LOC_OWN_DUNGEON);
 
                 UIWidgets::PaddedSeparator();
 
@@ -3401,7 +3401,7 @@ void DrawRandoEditor(bool& open) {
                     "\n"
                     "Selection - Hand select which dungeons will have their keys replaced with keyrings."
                 );
-                UIWidgets::EnhancementCombobox("gRandomizeShuffleKeyRings", randoShuffleKeyRings, 4, RO_KEYRINGS_OFF);
+                UIWidgets::EnhancementCombobox("gRandomizeShuffleKeyRings", randoShuffleKeyRings, RO_KEYRINGS_MAX, RO_KEYRINGS_OFF);
                 ImGui::PopItemWidth();
                 switch (CVar_GetS32("gRandomizeShuffleKeyRings", RO_KEYRINGS_OFF)) {
                     case RO_KEYRINGS_COUNT:
@@ -3437,7 +3437,7 @@ void DrawRandoEditor(bool& open) {
                     "\n"
                     "Anywhere - Thieve's Hideout Keys can appear anywhere in the world."
                 );
-                UIWidgets::EnhancementCombobox("gRandomizeGerudoKeys", randoShuffleGerudoFortressKeys, 4, RO_GERUDO_KEYS_VANILLA);
+                UIWidgets::EnhancementCombobox("gRandomizeGerudoKeys", randoShuffleGerudoFortressKeys, RO_GERUDO_KEYS_MAX, RO_GERUDO_KEYS_VANILLA);
 
                 UIWidgets::PaddedSeparator();
 
@@ -3456,7 +3456,7 @@ void DrawRandoEditor(bool& open) {
                     "\n"
                     "Anywhere - Boss Keys can appear anywhere in the world."
                 );
-                UIWidgets::EnhancementCombobox("gRandomizeBossKeysanity", randoShuffleBossKeys, 6, RO_DUNGEON_ITEM_LOC_OWN_DUNGEON);
+                UIWidgets::EnhancementCombobox("gRandomizeBossKeysanity", randoShuffleBossKeys, RO_DUNGEON_ITEM_LOC_MAX, RO_DUNGEON_ITEM_LOC_OWN_DUNGEON);
 
                 UIWidgets::PaddedSeparator();
 
@@ -3483,7 +3483,7 @@ void DrawRandoEditor(bool& open) {
                     "- Dungeons: Complete the specified amount of dungeons. Dungeons are considered complete after stepping in to the blue warp after the boss.\n"
                     "- Tokens: Obtain the specified amount of Skulltula tokens."
                 );
-                UIWidgets::EnhancementCombobox("gRandomizeShuffleGanonBossKey", randoShuffleGanonsBossKey, 12, RO_GANON_BOSS_KEY_VANILLA);
+                UIWidgets::EnhancementCombobox("gRandomizeShuffleGanonBossKey", randoShuffleGanonsBossKey, RO_GANON_BOSS_KEY_MAX, RO_GANON_BOSS_KEY_VANILLA);
                 ImGui::PopItemWidth();
                 switch (CVar_GetS32("gRandomizeShuffleGanonBossKey", RO_GANON_BOSS_KEY_VANILLA)) {
                     case RO_GANON_BOSS_KEY_LACS_MEDALLIONS:
@@ -3621,7 +3621,7 @@ void DrawRandoEditor(bool& open) {
                     "\n"
                     "Minimal - Most excess items are removed."
                 );
-                UIWidgets::EnhancementCombobox("gRandomizeItemPool", randoItemPool, 4, RO_ITEM_POOL_BALANCED);
+                UIWidgets::EnhancementCombobox("gRandomizeItemPool", randoItemPool, RO_ITEM_POOL_MAX, RO_ITEM_POOL_BALANCED);
                 UIWidgets::PaddedSeparator();
 
                 // Ice Traps
@@ -3640,7 +3640,7 @@ void DrawRandoEditor(bool& open) {
                     "Onslaught - All junk items will be replaced by Ice Traps, even those "
                     "in the base pool."
                 );
-                UIWidgets::EnhancementCombobox("gRandomizeIceTraps", randoIceTraps, 5, RO_ICE_TRAPS_NORMAL);
+                UIWidgets::EnhancementCombobox("gRandomizeIceTraps", randoIceTraps, RO_ICE_TRAPS_MAX, RO_ICE_TRAPS_NORMAL);
 
                 UIWidgets::PaddedSeparator();
 
@@ -3658,7 +3658,7 @@ void DrawRandoEditor(bool& open) {
                     "Need Stone of Agony - Hints are only available after obtaining the Stone of Agony.\n"
                     "\n"
                     "Need Mask of Truth - Hints are only available whilst wearing the Mask of Truth.\n");
-                UIWidgets::EnhancementCombobox("gRandomizeGossipStoneHints", randoGossipStoneHints, 4, RO_GOSSIP_STONES_NEED_NOTHING);
+                UIWidgets::EnhancementCombobox("gRandomizeGossipStoneHints", randoGossipStoneHints, RO_GOSSIP_STONES_MAX, RO_GOSSIP_STONES_NEED_NOTHING);
                 if (CVar_GetS32("gRandomizeGossipStoneHints", 1) != 0) {
                     // Hint Clarity
                     ImGui::Dummy(ImVec2(0.0f, 0.0f));
@@ -3676,7 +3676,7 @@ void DrawRandoEditor(bool& open) {
                         "Clear - Hints are clearly written and are unique for each item.\n"
                         "Ex: Kokiri Sword > the Kokiri Sword"
                     );
-                    UIWidgets::EnhancementCombobox("gRandomizeHintClarity", randoHintClarity, 3, RO_HINT_CLARITY_CLEAR);
+                    UIWidgets::EnhancementCombobox("gRandomizeHintClarity", randoHintClarity, RO_HINT_CLARITY_MAX, RO_HINT_CLARITY_CLEAR);
 
                     // Hint Distribution
                     ImGui::Dummy(ImVec2(0.0f, 0.0f));
@@ -3692,7 +3692,7 @@ void DrawRandoEditor(bool& open) {
                         "\n"
                         "Very Strong - Many powerful hints."
                     );
-                    UIWidgets::EnhancementCombobox("gRandomizeHintDistribution", randoHintDistribution, 4, RO_HINT_DIST_BALANCED);
+                    UIWidgets::EnhancementCombobox("gRandomizeHintDistribution", randoHintDistribution, RO_HINT_DIST_MAX, RO_HINT_DIST_BALANCED);
                     ImGui::Unindent();
                 }
 
@@ -3890,7 +3890,7 @@ void DrawRandoEditor(bool& open) {
                     "\n"
                     "No logic - Item placement is completely random. MAY BE IMPOSSIBLE TO BEAT."
                 );
-                UIWidgets::EnhancementCombobox("gRandomizeLogicRules", randoLogicRules, 2, RO_GENERIC_OFF);
+                UIWidgets::EnhancementCombobox("gRandomizeLogicRules", randoLogicRules, RO_LOGIC_MAX, RO_LOGIC_GLITCHLESS);
 
                 UIWidgets::PaddedSeparator();
 
@@ -3955,7 +3955,7 @@ void DrawRandoEditor(bool& open) {
                 // TODO: Show this but disabled when we have options for disabled Comboboxes.
                 if (CVar_GetS32("gRandomizeShuffleDungeonReward", RO_DUNGEON_REWARDS_END_OF_DUNGEON) != RO_DUNGEON_REWARDS_END_OF_DUNGEON) {
                     ImGui::Text(Settings::LinksPocketItem.GetName().c_str());
-                    UIWidgets::EnhancementCombobox("gRandomizeLinksPocket", randoLinksPocket, 4, RO_LINKS_POCKET_DUNGEON_REWARD);
+                    UIWidgets::EnhancementCombobox("gRandomizeLinksPocket", randoLinksPocket, RO_LINKS_POCKET_MAX, RO_LINKS_POCKET_DUNGEON_REWARD);
                     UIWidgets::PaddedSeparator();
                 }
 

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -3061,7 +3061,7 @@ void DrawRandoEditor(bool& open) {
                     "- Bottom of the Well will be open for adult after playing Song of Storms to the Windmill guy as child.\n"
                     "- Gerudo Training Ground will be open for child after adult has paid to open the gate once."
                 );
-                UIWidgets::EnhancementCombobox("gRandomizeShuffleDungeonsEntrances", randoShuffleDungeonsEntrances, 3, RO_DUNGEON_ENTRANCE_SHUFFLE_OFF);
+                UIWidgets::EnhancementCombobox("gRandomizeShuffleDungeonsEntrances", randoShuffleDungeonsEntrances, RO_DUNGEON_ENTRANCE_SHUFFLE_MAX, RO_DUNGEON_ENTRANCE_SHUFFLE_OFF);
 
                 UIWidgets::PaddedSeparator();
 
@@ -3089,7 +3089,7 @@ void DrawRandoEditor(bool& open) {
                     "- Temple of Time\n"
                     "- Kakariko Potion Shop"
                 );
-                UIWidgets::EnhancementCombobox("gRandomizeShuffleInteriorsEntrances", randoShuffleInteriorsEntrances, 3, RO_INTERIOR_ENTRANCE_SHUFFLE_OFF);
+                UIWidgets::EnhancementCombobox("gRandomizeShuffleInteriorsEntrances", randoShuffleInteriorsEntrances, RO_INTERIOR_ENTRANCE_SHUFFLE_MAX, RO_INTERIOR_ENTRANCE_SHUFFLE_OFF);
 
                 UIWidgets::PaddedSeparator();
 

--- a/soh/soh/Enhancements/randomizer/randomizerTypes.h
+++ b/soh/soh/Enhancements/randomizer/randomizerTypes.h
@@ -1070,193 +1070,291 @@ typedef enum {
     RSK_MAX
 } RandomizerSettingKey;
 
-typedef enum RandoOption {
-  //Generic Settings (any binary option can use this)
-  //(off/on, no/yes, don't skip/skip)
-  RO_GENERIC_OFF,
-  RO_GENERIC_ON,
-  RO_GENERIC_NO = 0,
-  RO_GENERIC_YES,
-  RO_GENERIC_DONT_SKIP = 0,
-  RO_GENERIC_SKIP,
+//Generic Settings (any binary option can use this)
+// off/on
+typedef enum {
+    RO_GENERIC_OFF,
+    RO_GENERIC_ON,
+    RO_GENERIC_ON_OFF_MAX,
+} RandoOptionGenericOffOn;
 
-  //Forest settings (closed, closed deku, open)
-  RO_FOREST_CLOSED = 0,
-  RO_FOREST_CLOSED_DEKU,
-  RO_FOREST_OPEN,
+// no/yes
+typedef enum {
+    RO_GENERIC_NO,
+    RO_GENERIC_YES,
+    RO_GENERIC_NO_YES_MAX,
+} RandoOptionGenericNoYes;
 
-  //Door of Time settings (closed, song only, open)
-  RO_DOOROFTIME_CLOSED = 0,
-  RO_DOOROFTIME_SONGONLY,
-  RO_DOOROFTIME_OPEN,
-  
-  //Zora's Fountain settings (closed, closed as child, open)
-  RO_ZF_CLOSED = 0,
-  RO_ZF_CLOSED_CHILD,
-  RO_ZF_OPEN,
+// don't skip/skip
+typedef enum {
+    RO_GENERIC_DONT_SKIP,
+    RO_GENERIC_SKIP,
+    RO_GENERIC_SKIP_MAX,
+} RandoOptionGenericSkip;
 
-  //Starting Age settings (child, adult, random)
-  RO_AGE_CHILD = 0,
-  RO_AGE_ADULT,
-  RO_AGE_RANDOM,
+//Forest settings (closed, closed deku, open)
+typedef enum {
+    RO_FOREST_CLOSED,
+    RO_FOREST_CLOSED_DEKU,
+    RO_FOREST_OPEN,
+    RO_FOREST_MAX,
+} RandoOptionForest;
 
-  //Gerudo Fortress settings (normal, fast, open)
-  RO_GF_NORMAL = 0,
-  RO_GF_FAST,
-  RO_GF_OPEN,
+//Door of Time settings (closed, song only, open)
+typedef enum {
+    RO_DOOROFTIME_CLOSED,
+    RO_DOOROFTIME_SONGONLY,
+    RO_DOOROFTIME_OPEN,
+    RO_DOOROFTIME_MAX,
+} RandoOptionDoorOfTime;
 
-  //Kakariko Gate settings (closed/open)
-  RO_KAK_GATE_CLOSED = 0,
-  RO_KAK_GATE_OPEN,
+//Zora's Fountain settings (closed, closed as child, open)
+typedef enum {
+    RO_ZF_CLOSED,
+    RO_ZF_CLOSED_CHILD,
+    RO_ZF_OPEN,
+    RO_ZF_MAX,
+} RandoOptionZorasFountain;
 
-  //Rainbow Bridge settings (vanilla, always open, stones, medallions, dungeon rewards, dungeons, tokens)
-  RO_BRIDGE_VANILLA = 0,
-  RO_BRIDGE_ALWAYS_OPEN,
-  RO_BRIDGE_STONES,
-  RO_BRIDGE_MEDALLIONS,
-  RO_BRIDGE_DUNGEON_REWARDS,
-  RO_BRIDGE_DUNGEONS,
-  RO_BRIDGE_TOKENS,
+//Starting Age settings (child, adult, random)
+typedef enum {
+    RO_AGE_CHILD,
+    RO_AGE_ADULT,
+    RO_AGE_RANDOM,
+    RO_AGE_MAX,
+} RandoOptionStartingAge;
 
-  //Shopsanity settings (off, 0-4 items, random)
-  RO_SHOPSANITY_OFF = 0,
-  RO_SHOPSANITY_ZERO_ITEMS,
-  RO_SHOPSANITY_ONE_ITEM,
-  RO_SHOPSANITY_TWO_ITEMS,
-  RO_SHOPSANITY_THREE_ITEMS,
-  RO_SHOPSANITY_FOUR_ITEMS,
-  RO_SHOPSANITY_RANDOM,
+//Gerudo Fortress settings (normal, fast, open)
+typedef enum {
+    RO_GF_NORMAL,
+    RO_GF_FAST,
+    RO_GF_OPEN,
+    RO_GF_MAX,
+} RandoOptionGerudoFortress;
 
-  //Scrubsanity settings (off, affordable, expensive, random)
-  RO_SCRUBS_OFF = 0,
-  RO_SCRUBS_AFFORDABLE,
-  RO_SCRUBS_EXPENSIVE,
-  RO_SCRUBS_RANDOM,
+//Kakariko Gate settings (closed/open)
+typedef enum {
+    RO_KAK_GATE_CLOSED,
+    RO_KAK_GATE_OPEN,
+    RO_KAK_GATE_MAX,
+} RandoOptionKakarikoGate;
 
-  //Ammo drop settings (on, "on+bombchu", off)
-  RO_AMMO_DROPS_ON = 0,
-  RO_AMMO_DROPS_ON_PLUS_BOMBCHU,
-  RO_AMMO_DROPS_OFF,
+//Rainbow Bridge settings (vanilla, always open, stones, medallions, dungeon rewards, dungeons, tokens)
+typedef enum {
+    RO_BRIDGE_VANILLA = 0,
+    RO_BRIDGE_ALWAYS_OPEN,
+    RO_BRIDGE_STONES,
+    RO_BRIDGE_MEDALLIONS,
+    RO_BRIDGE_DUNGEON_REWARDS,
+    RO_BRIDGE_DUNGEONS,
+    RO_BRIDGE_TOKENS,
+    RO_BRIDGE_MAX,
+} RandoOptionRainbowBridge;
 
-  //Any Dungeon Item (start with, vanilla, own dungeon, any dungeon,
-  //overworld, anywhere)
-  RO_DUNGEON_ITEM_LOC_STARTWITH = 0,
-  RO_DUNGEON_ITEM_LOC_VANILLA,
-  RO_DUNGEON_ITEM_LOC_OWN_DUNGEON,
-  RO_DUNGEON_ITEM_LOC_ANY_DUNGEON,
-  RO_DUNGEON_ITEM_LOC_OVERWORLD,
-  RO_DUNGEON_ITEM_LOC_ANYWHERE,
+//Shopsanity settings (off, 0-4 items, random)
+typedef enum {
+    RO_SHOPSANITY_OFF,
+    RO_SHOPSANITY_ZERO_ITEMS,
+    RO_SHOPSANITY_ONE_ITEM,
+    RO_SHOPSANITY_TWO_ITEMS,
+    RO_SHOPSANITY_THREE_ITEMS,
+    RO_SHOPSANITY_FOUR_ITEMS,
+    RO_SHOPSANITY_RANDOM,
+    RO_SHOPSANITY_MAX,
+} RandoOptionShopsanity;
 
-  //Dungeon reward settings
-  RO_DUNGEON_REWARDS_END_OF_DUNGEON = 0,
-  RO_DUNGEON_REWARDS_ANY_DUNGEON,
-  RO_DUNGEON_REWARDS_OVERWORLD,
-  RO_DUNGEON_REWARDS_ANYWHERE,
+//Scrubsanity settings (off, affordable, expensive, random)
+typedef enum {
+    RO_SCRUBS_OFF,
+    RO_SCRUBS_AFFORDABLE,
+    RO_SCRUBS_EXPENSIVE,
+    RO_SCRUBS_RANDOM,
+    RO_SCRUBS_MAX,
+} RandoOptionScrubsanity;
 
-  //Keyring Settings
-  RO_KEYRINGS_OFF = 0,
-  RO_KEYRINGS_RANDOM,
-  RO_KEYRINGS_COUNT,
-  RO_KEYRINGS_SELECTION,
+//Ammo drop settings (on, "on+bombchu", off)
+typedef enum {
+    RO_AMMO_DROPS_ON,
+    RO_AMMO_DROPS_ON_PLUS_BOMBCHU,
+    RO_AMMO_DROPS_OFF,
+    RO_AMMO_DROPS_MAX,
+} RandoOptionAmmoDrops;
 
-  //Ganon Boss Key Settings (vanilla, own dungeon, start with,
-  //overworld, anywhere)
-  RO_GANON_BOSS_KEY_VANILLA = 0,
-  RO_GANON_BOSS_KEY_OWN_DUNGEON,
-  RO_GANON_BOSS_KEY_STARTWITH,
-  RO_GANON_BOSS_KEY_ANY_DUNGEON,
-  RO_GANON_BOSS_KEY_OVERWORLD,
-  RO_GANON_BOSS_KEY_ANYWHERE,
-  RO_GANON_BOSS_KEY_LACS_VANILLA,
-  RO_GANON_BOSS_KEY_LACS_MEDALLIONS,
-  RO_GANON_BOSS_KEY_LACS_STONES,
-  RO_GANON_BOSS_KEY_LACS_REWARDS,
-  RO_GANON_BOSS_KEY_LACS_DUNGEONS,
-  RO_GANON_BOSS_KEY_LACS_TOKENS,
+//Any Dungeon Item (start with, vanilla, own dungeon, any dungeon,
+//overworld, anywhere)
+typedef enum {
+    RO_DUNGEON_ITEM_LOC_STARTWITH,
+    RO_DUNGEON_ITEM_LOC_VANILLA,
+    RO_DUNGEON_ITEM_LOC_OWN_DUNGEON,
+    RO_DUNGEON_ITEM_LOC_ANY_DUNGEON,
+    RO_DUNGEON_ITEM_LOC_OVERWORLD,
+    RO_DUNGEON_ITEM_LOC_ANYWHERE,
+    RO_DUNGEON_ITEM_LOC_MAX,
+} RandoOptionDungeonItemLocation;
 
-  //Ganon's Trials
-  RO_GANONS_TRIALS_SKIP = 0,
-  RO_GANONS_TRIALS_SET_NUMBER,
-  RO_GANONS_TRIALS_RANDOM_NUMBER,
+//Dungeon reward settings
+typedef enum {
+    RO_DUNGEON_REWARDS_END_OF_DUNGEON,
+    RO_DUNGEON_REWARDS_ANY_DUNGEON,
+    RO_DUNGEON_REWARDS_OVERWORLD,
+    RO_DUNGEON_REWARDS_ANYWHERE,
+    RO_DUNGEON_REWARDS_MAX,
+} RandoOptionDungeonRewards;
 
-  //Shuffle Dungeon Entrance Settings (Off, on, plus ganon)
-  RO_DUNGEON_ENTRANCE_SHUFFLE_OFF = 0,
-  RO_DUNGEON_ENTRANCE_SHUFFLE_ON,
-  RO_DUNGEON_ENTRANCE_SHUFFLE_ON_PLUS_GANON,
+//Keyring Settings
+typedef enum {
+    RO_KEYRINGS_OFF,
+    RO_KEYRINGS_RANDOM,
+    RO_KEYRINGS_COUNT,
+    RO_KEYRINGS_SELECTION,
+    RO_KEYRINGS_MAX,
+} RandoOptionKeyrings;
 
-  //Shuffle Interior Entrance Settings (Off, simple, all)
-  RO_INTERIOR_ENTRANCE_SHUFFLE_OFF = 0,
-  RO_INTERIOR_ENTRANCE_SHUFFLE_SIMPLE,
-  RO_INTERIOR_ENTRANCE_SHUFFLE_ALL,
+//Ganon's Boss Key Settings (vanilla, own dungeon, start with,
+//overworld, anywhere)
+typedef enum {
+    RO_GANON_BOSS_KEY_VANILLA,
+    RO_GANON_BOSS_KEY_OWN_DUNGEON,
+    RO_GANON_BOSS_KEY_STARTWITH,
+    RO_GANON_BOSS_KEY_ANY_DUNGEON,
+    RO_GANON_BOSS_KEY_OVERWORLD,
+    RO_GANON_BOSS_KEY_ANYWHERE,
+    RO_GANON_BOSS_KEY_LACS_VANILLA,
+    RO_GANON_BOSS_KEY_LACS_MEDALLIONS,
+    RO_GANON_BOSS_KEY_LACS_STONES,
+    RO_GANON_BOSS_KEY_LACS_REWARDS,
+    RO_GANON_BOSS_KEY_LACS_DUNGEONS,
+    RO_GANON_BOSS_KEY_LACS_TOKENS,
+    RO_GANON_BOSS_KEY_MAX,
+} RandoOptionGanonsBossKey;
 
-  //Song shuffle Settings (Song locations, Dungeon rewards, anywhere)
-  RO_SONG_SHUFFLE_SONG_LOCATIONS = 0,
-  RO_SONG_SHUFFLE_DUNGEON_REWARDS,
-  RO_SONG_SHUFFLE_ANYWHERE,
+//Ganon's Trials
+typedef enum {
+    RO_GANONS_TRIALS_SKIP,
+    RO_GANONS_TRIALS_SET_NUMBER,
+    RO_GANONS_TRIALS_RANDOM_NUMBER,
+    RO_GANONS_TRIALS_MAX,
+} RandoOptionGanonsTrials;
 
-  //Shuffle Merchants Settings (Off, On no hint, on with wint)
-  RO_SHUFFLE_MERCHANTS_OFF = 0,
-  RO_SHUFFLE_MERCHANTS_ON_NO_HINT,
-  RO_SHUFFLE_MERCHANTS_ON_HINT,
+//Shuffle Dungeon Entrance Settings (Off, on, plus ganon)
+typedef enum {
+    RO_DUNGEON_ENTRANCE_SHUFFLE_OFF,
+    RO_DUNGEON_ENTRANCE_SHUFFLE_ON,
+    RO_DUNGEON_ENTRANCE_SHUFFLE_ON_PLUS_GANON,
+    RO_DUNGEON_ENTRANCE_SHUFFLE_MAX,
+} RandoOptionDungeonEntranceShuffle;
 
-  //Starting Ocarina Settings (off, fairy)
-  RO_STARTING_OCARINA_OFF = 0,
-  RO_STARTING_OCARINA_FAIRY,
+//Shuffle Interior Entrance Settings (Off, simple, all)
+typedef enum {
+    RO_INTERIOR_ENTRANCE_SHUFFLE_OFF,
+    RO_INTERIOR_ENTRANCE_SHUFFLE_SIMPLE,
+    RO_INTERIOR_ENTRANCE_SHUFFLE_ALL,
+    RO_INTERIOR_ENTRANCE_SHUFFLE_MAX,
+} RandoOptionInteriorEntranceShuffle;
 
-  //Item Pool Settings
-  RO_ITEM_POOL_PLENTIFUL = 0,
-  RO_ITEM_POOL_BALANCED,
-  RO_ITEM_POOL_SCARCE,
-  RO_ITEM_POOL_MINIMAL,
+//Song shuffle Settings (Song locations, Dungeon rewards, anywhere)
+typedef enum {
+    RO_SONG_SHUFFLE_SONG_LOCATIONS,
+    RO_SONG_SHUFFLE_DUNGEON_REWARDS,
+    RO_SONG_SHUFFLE_ANYWHERE,
+    RO_SONG_SHUFFLE_MAX,
+} RandoOptionSongShuffle;
 
-  //Ice Trap Settings
-  RO_ICE_TRAPS_OFF = 0,
-  RO_ICE_TRAPS_NORMAL,
-  RO_ICE_TRAPS_EXTRA,
-  RO_ICE_TRAPS_MAYHEM,
-  RO_ICE_TRAPS_ONSLAUGHT,
-  
-  //Gossip Stone Hint Settings (no hints, needs nothing,
-  //needs mask of truth, needs stone of agony)
-  RO_GOSSIP_STONES_NONE = 0,
-  RO_GOSSIP_STONES_NEED_NOTHING,
-  RO_GOSSIP_STONES_NEED_TRUTH,
-  RO_GOSSIP_STONES_NEED_STONE,
-  
-  //Hint Clarity Settings (obscure, ambiguous, clear)
-  RO_HINT_CLARITY_OBSCURE = 0,
-  RO_HINT_CLARITY_AMBIGUOUS,
-  RO_HINT_CLARITY_CLEAR,
+//Shuffle Merchants Settings (Off, On no hint, on with wint)
+typedef enum {
+    RO_SHUFFLE_MERCHANTS_OFF,
+    RO_SHUFFLE_MERCHANTS_ON_NO_HINT,
+    RO_SHUFFLE_MERCHANTS_ON_HINT,
+    RO_SHUFFLE_MERCHANTS_MAX,
+} RandoOptionShuffleMerchants;
 
-  //Hint Distribution Settings (useless, balanced, strong, very strong)
-  RO_HINT_DIST_USELESS = 0,
-  RO_HINT_DIST_BALANCED,
-  RO_HINT_DIST_STRONG,
-  RO_HINT_DIST_VERY_STRONG,
+//Starting Ocarina Settings (off, fairy)
+typedef enum {
+    RO_STARTING_OCARINA_OFF,
+    RO_STARTING_OCARINA_FAIRY,
+    RO_STARTING_OCARINA_MAX,
+} RandoOptionStartingOcarina;
 
-  //Gerudo Fortress Key Settings (vanilla, any dungeon, overworld,
-  //anywhere)
-  RO_GERUDO_KEYS_VANILLA = 0,
-  RO_GERUDO_KEYS_ANY_DUNGEON,
-  RO_GERUDO_KEYS_OVERWORLD,
-  RO_GERUDO_KEYS_ANYWHERE,
+//Item Pool Settings
+typedef enum {
+    RO_ITEM_POOL_PLENTIFUL,
+    RO_ITEM_POOL_BALANCED,
+    RO_ITEM_POOL_SCARCE,
+    RO_ITEM_POOL_MINIMAL,
+    RO_ITEM_POOL_MAX,
+} RandoOptionItemPool;
 
-  //Tokensanity settings (off, dungeons, overworld, all)
-  RO_TOKENSANITY_OFF = 0,
-  RO_TOKENSANITY_DUNGEONS,
-  RO_TOKENSANITY_OVERWORLD,
-  RO_TOKENSANITY_ALL,
+//Ice Trap Settings
+typedef enum {
+    RO_ICE_TRAPS_OFF,
+    RO_ICE_TRAPS_NORMAL,
+    RO_ICE_TRAPS_EXTRA,
+    RO_ICE_TRAPS_MAYHEM,
+    RO_ICE_TRAPS_ONSLAUGHT,
+    RO_ICE_TRAPS_MAX,
+} RandoOptionIceTraps;
 
-  //Link's Pocket Settings (dungeon reward, advancement, anything, nothing)
-  RO_LINKS_POCKET_DUNGEON_REWARD = 0,
-  RO_LINKS_POCKET_ADVANCEMENT,
-  RO_LINKS_POCKET_ANYTHING,
-  RO_LINKS_POCKET_NOTHING,
+//Gossip Stone Hint Settings (no hints, needs nothing,
+//needs mask of truth, needs stone of agony)
+typedef enum {
+    RO_GOSSIP_STONES_NONE,
+    RO_GOSSIP_STONES_NEED_NOTHING,
+    RO_GOSSIP_STONES_NEED_TRUTH,
+    RO_GOSSIP_STONES_NEED_STONE,
+    RO_GOSSIP_STONES_MAX,
+} RandoOptionGossipStones;
 
-  //If you're going to add to this enum, please list the default option first
-  //with a value of zero.
+//Hint Clarity Settings (obscure, ambiguous, clear)
+typedef enum {
+    RO_HINT_CLARITY_OBSCURE,
+    RO_HINT_CLARITY_AMBIGUOUS,
+    RO_HINT_CLARITY_CLEAR,
+    RO_HINT_CLARITY_MAX,
+} RandoOptionHintClarity;
 
-} RandoOption;
+//Hint Distribution Settings (useless, balanced, strong, very strong)
+typedef enum {
+    RO_HINT_DIST_USELESS,
+    RO_HINT_DIST_BALANCED,
+    RO_HINT_DIST_STRONG,
+    RO_HINT_DIST_VERY_STRONG,
+    RO_HINT_DIST_MAX,
+} RandoOptionHintDistribution;
+
+//Gerudo Fortress Key Settings (vanilla, any dungeon, overworld,
+//anywhere)
+typedef enum {
+    RO_GERUDO_KEYS_VANILLA,
+    RO_GERUDO_KEYS_ANY_DUNGEON,
+    RO_GERUDO_KEYS_OVERWORLD,
+    RO_GERUDO_KEYS_ANYWHERE,
+    RO_GERUDO_KEYS_MAX,
+} RandoOptionGerudoKeys;
+
+//Tokensanity settings (off, dungeons, overworld, all)
+typedef enum {
+    RO_TOKENSANITY_OFF,
+    RO_TOKENSANITY_DUNGEONS,
+    RO_TOKENSANITY_OVERWORLD,
+    RO_TOKENSANITY_ALL,
+    RO_TOKENSANITY_MAX,
+} RandoOptionTokensanity;
+
+//Link's Pocket Settings (dungeon reward, advancement, anything, nothing)
+typedef enum {
+    RO_LINKS_POCKET_DUNGEON_REWARD,
+    RO_LINKS_POCKET_ADVANCEMENT,
+    RO_LINKS_POCKET_ANYTHING,
+    RO_LINKS_POCKET_NOTHING,
+    RO_LINKS_POCKET_MAX,
+} RandoOptionLinksPocket;
+
+// Logic (glitchless/no logic)
+typedef enum {
+    RO_LOGIC_GLITCHLESS,
+    RO_LOGIC_NO_LOGIC,
+    RO_LOGIC_MAX,
+} RandoOptionLogic;
 
 typedef enum {
     CAN_OBTAIN,


### PR DESCRIPTION
resolves https://github.com/HarbourMasters/Shipwright/issues/2053

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/456384242.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/456384243.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/456384244.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/456384245.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/456384246.zip)
<!--- section:artifacts:end -->