### PR TITLE
Disable bunny hood NPC interactions with MM bunny hood on

### DIFF
--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -382,7 +382,10 @@ namespace GameMenuBar {
                     UIWidgets::PaddedText("Bunny Hood Effect", true, false);
                     const char* bunnyHoodOptions[3] = { "Disabled", "Faster Run & Longer Jump", "Faster Run"};
                     UIWidgets::EnhancementCombobox("gMMBunnyHood", bunnyHoodOptions, 3, 0);
-                    UIWidgets::Tooltip("Wearing the Bunny Hood grants a speed increase like in Majora's Mask. The longer jump option is not accounted for in randomizer logic.");
+                    UIWidgets::Tooltip(
+                        "Wearing the Bunny Hood grants a speed increase like in Majora's Mask. The longer jump option is not accounted for in randomizer logic.\n\n"
+                        "Also disables NPC's reactions to wearing the Bunny Hood."
+                    );
                     UIWidgets::PaddedEnhancementCheckbox("Mask Select in Inventory", "gMaskSelect", true, false);
                     UIWidgets::Tooltip("After completing the mask trading sub-quest, press A and any direction on the mask slot to change masks");
                     UIWidgets::PaddedEnhancementCheckbox("Nuts explode bombs", "gNutsExplodeBombs", true, false);

--- a/soh/src/code/z_face_reaction.c
+++ b/soh/src/code/z_face_reaction.c
@@ -66,7 +66,7 @@ u16 sReactionTextIds[][PLAYER_MASK_MAX] = {
 u16 Text_GetFaceReaction(PlayState* play, u32 reactionSet) {
     u8 currentMask = Player_GetMask(play);
 
-    if (CVar_GetS32("gMMBunnyHood", 0) && currentMask == 4) {
+    if (CVar_GetS32("gMMBunnyHood", 0) && currentMask == PLAYER_MASK_BUNNY) {
         return 0;
     } else {
         return sReactionTextIds[reactionSet][currentMask];

--- a/soh/src/code/z_face_reaction.c
+++ b/soh/src/code/z_face_reaction.c
@@ -66,5 +66,10 @@ u16 sReactionTextIds[][PLAYER_MASK_MAX] = {
 u16 Text_GetFaceReaction(PlayState* play, u32 reactionSet) {
     u8 currentMask = Player_GetMask(play);
 
-    return sReactionTextIds[reactionSet][currentMask];
+    if (CVar_GetS32("gMMBunnyHood", 0) && currentMask == 4) {
+        return 0;
+    } else {
+        return sReactionTextIds[reactionSet][currentMask];
+    }
+
 }


### PR DESCRIPTION
Resolves https://github.com/HarbourMasters/Shipwright/issues/981
Arguably resolves https://github.com/HarbourMasters/Shipwright/issues/699

Turns out this wasn't as complicated as we may have thought.

Does what the title says. The game checks for if a mask is worn by checking if the returning text ID is 0 or not, pulling it from the table of reaction text IDs. By simply setting it to 0 when wearing the bunny hood and with MM bunny hood on, it acts like no mask is worn when talking to NPCs.

Running man has a seperate check from this and is confirmed to still be working. Same goes for the happy mask shop.

Also confirmed to be working when wearing bunny hood:
- Talking to zora after diving minigame
- Turning in Ruto's Letter
- Turning in Claim Check
- Talked to a random selection of NPC's like Link the goron, other gorons and NPCs in Kokiri Forest.

I've done searches for `PLAYER_MASK_BUNNY` and it looks like none of the NPC's outside of shops and the running man actually use it, so I'm pretty confident in saying this should cover all NPC's we want to exclude bunny hood text for.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/456857358.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/456857362.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/456857364.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/456857365.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/456857366.zip)
<!--- section:artifacts:end -->