### PR TITLE
Small Crowd Control fixes

### DIFF
--- a/soh/soh/Enhancements/crowd-control/CrowdControl.cpp
+++ b/soh/soh/Enhancements/crowd-control/CrowdControl.cpp
@@ -485,8 +485,9 @@ bool CrowdControl::SpawnEnemy(std::string effectId) {
         // Don't allow Arwings in certain areas because they cause issues.
         // Locations: King dodongo room, Morpha room, Twinrova room, Ganondorf room, Fishing pond, Ganon's room
         // TODO: Swap this to disabling the option in CC options menu instead.
-        if (gPlayState->sceneNum == 18 || gPlayState->sceneNum == 22 || gPlayState->sceneNum == 23 ||
-            gPlayState->sceneNum == 25 || gPlayState->sceneNum == 73 || gPlayState->sceneNum == 79) {
+        if (gPlayState->sceneNum == SCENE_DDAN_BOSS || gPlayState->sceneNum == SCENE_MIZUSIN_BS ||
+            gPlayState->sceneNum == SCENE_JYASINBOSS || gPlayState->sceneNum == SCENE_GANON_BOSS ||
+            gPlayState->sceneNum == SCENE_TURIBORI || gPlayState->sceneNum == SCENE_GANON_DEMO) {
             return 0;
         }
         enemyId = 315;

--- a/soh/soh/Enhancements/crowd-control/CrowdControl.cpp
+++ b/soh/soh/Enhancements/crowd-control/CrowdControl.cpp
@@ -458,7 +458,7 @@ CrowdControl::EffectResult CrowdControl::ExecuteEffect(std::string effectId, uin
             if (dryRun == 0) CMD_EXECUTE(fmt::format("defense_modifier {}", value));
             return EffectResult::Success;
         } else if (effectId == EFFECT_DAMAGE) {
-            if ((gSaveContext.healthCapacity - 0x10) <= 0) {
+            if ((gSaveContext.health - (16 * value)) <= 0) {
                 return EffectResult::Failure;
             }
             
@@ -482,6 +482,13 @@ bool CrowdControl::SpawnEnemy(std::string effectId) {
     if (effectId == EFFECT_SPAWN_WALLMASTER) {
         enemyId = 17;
     } else if (effectId == EFFECT_SPAWN_ARWING) {
+        // Don't allow Arwings in certain areas because they cause issues.
+        // Locations: King dodongo room, Morpha room, Twinrova room, Ganondorf room, Fishing pond, Ganon's room
+        // TODO: Swap this to disabling the option in CC options menu instead.
+        if (gPlayState->sceneNum == 18 || gPlayState->sceneNum == 22 || gPlayState->sceneNum == 23 ||
+            gPlayState->sceneNum == 25 || gPlayState->sceneNum == 73 || gPlayState->sceneNum == 79) {
+            return 0;
+        }
         enemyId = 315;
         enemyParams = 1;
         posYOffset = 100;

--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -1631,7 +1631,7 @@ namespace GameMenuBar {
             ImGui::PopStyleColor(1);
 #ifdef ENABLE_CROWD_CONTROL
             UIWidgets::PaddedEnhancementCheckbox("Crowd Control", "gCrowdControl", true, false);
-            UIWidgets::Tooltip("Requires a full SoH restart to take effect!\n\nEnables CrowdControl. Will attempt to connect to the local Crowd Control server.");
+            UIWidgets::Tooltip("Will attempt to connect to the Crowd Control server. Check out crowdcontrol.live for more information.");
 
             if (CVar_GetS32("gCrowdControl", 0)) {
                 CrowdControl::Instance->Enable();


### PR DESCRIPTION
Resolves 2 issues from https://github.com/HarbourMasters/Shipwright/issues/1599

- Disables arwing spawns in problematic areas. This needs to be excluded from the Crowd Control options menu when they're not available instead, but this would need to handle a new type of packet so I figured it was good to atleast get this in for the time being.
- Improves the handling for emptying hearts, making it unable to straight up kill the player with this option (as it was often a much cheaper alternative to "Kill player").

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/456739298.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/456739299.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/456739300.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/456739301.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/456739303.zip)
<!--- section:artifacts:end -->