### PR TITLE
Don't autosave in the Chamber of Sages

### DIFF
--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -2704,7 +2704,7 @@ u8 Item_CheckObtainability(u8 item) {
 }
 
 void PerformAutosave(PlayState* play, u8 item) {
-    if (CVar_GetS32("gAutosave", 0)) {
+    if (CVar_GetS32("gAutosave", 0) && (play->sceneNum != SCENE_KENJYANOMA)) {
         if (CVar_GetS32("gAutosaveAllItems", 0)) {
             Play_PerformSave(play);
         } else if (CVar_GetS32("gAutosaveMajorItems", 1)) {

--- a/soh/src/code/z_play.c
+++ b/soh/src/code/z_play.c
@@ -870,7 +870,7 @@ void Play_Update(PlayState* play) {
                             // Don't autosave in grottos or cutscenes
                             // Also don't save when you first load a file
                             if (CVar_GetS32("gAutosave", 0) && (gSaveContext.cutsceneIndex == 0) && (play->gameplayFrames > 60) &&
-                                (play->sceneNum != SCENE_YOUSEI_IZUMI_TATE) && (play->sceneNum != SCENE_KAKUSIANA)) {
+                                (play->sceneNum != SCENE_YOUSEI_IZUMI_TATE) && (play->sceneNum != SCENE_KAKUSIANA) && (play->sceneNum != SCENE_KENJYANOMA)) {
                                 Play_PerformSave(play);
                             }
                         }


### PR DESCRIPTION
The game was never designed to save there, so doing so and then returning to that location results in the wrong cutscene playing and the wrong item being awarded.  Closes #2025 

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/457850092.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/457850094.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/457850096.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/457850098.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/457850099.zip)
<!--- section:artifacts:end -->