### PR TITLE
changes to the asset extraction script 

### DIFF
--- a/OTRExporter/extract_assets.py
+++ b/OTRExporter/extract_assets.py
@@ -32,17 +32,16 @@ def main():
     parser.add_argument("-z", "--zapd", help="Path to ZAPD executable", dest="zapd_exe", type=str)
     parser.add_argument("rom", help="Path to the rom", type=str, nargs="?")
     parser.add_argument("--non-interactive", help="Runs the script non-interactively for use in build scripts.", dest="non_interactive", action="store_true")
+    parser.add_argument("-v", "--verbose", help="Display rom's header checksums and their corresponding xml folder", dest="verbose", action="store_true")
 
     args = parser.parse_args()
 
-    rom_paths = [ args.rom ] if args.rom else rom_chooser.chooseROM(args.non_interactive)
-    for rom_path in rom_paths:
-        rom = Z64Rom(rom_path)
-
+    roms = [ Z64Rom(args.rom) ] if args.rom else rom_chooser.chooseROM(args.verbose, args.non_interactive)
+    for rom in roms:
         if (os.path.exists("Extract")):
             shutil.rmtree("Extract")
 
-        BuildOTR("../soh/assets/xml/" + rom.version.xml_ver + "/", rom_path, zapd_exe=args.zapd_exe)
+        BuildOTR("../soh/assets/xml/" + rom.version.xml_ver + "/", rom.file_path, zapd_exe=args.zapd_exe)
 
 if __name__ == "__main__":
     main()

--- a/OTRExporter/rom_chooser.py
+++ b/OTRExporter/rom_chooser.py
@@ -2,12 +2,13 @@ import os, sys, glob
 
 from rom_info import Z64Rom
 
-def chooseROM(non_interactive=False):
+def chooseROM(verbose=False, non_interactive=False):
     roms = []
 
     for file in glob.glob("*.z64"):
-        if Z64Rom.isValidRom(file):
-            roms.append(file)
+        rom = Z64Rom(file)
+        if rom.is_valid:
+            roms.append(rom)
 
     if not (roms):
         print("Error: No roms located, place one in the OTRExporter directory", file=os.sys.stderr)
@@ -21,23 +22,28 @@ def chooseROM(non_interactive=False):
         foundMq = False
         foundOot = False
         for rom in roms:
-            isMq = Z64Rom.isMqRom(rom)
-            if isMq and not foundMq:
+            if rom.isMq and not foundMq:
                 romsToExtract.append(rom)
                 foundMq = True
-            elif not isMq and not foundOot:
+            elif not rom.isMq and not foundOot:
                 romsToExtract.append(rom)
                 foundOot = True
         return romsToExtract
 
-    print(str(len(roms))+ " roms found, please select one by pressing 1-"+str(len(roms)))
+    print(f"{len(roms)} roms found, please select one by pressing 1-{len(roms)}")
+    print()
 
     for i in range(len(roms)):
-        print(str(i+1)+ ". " + roms[i])
+        print(f"[{i+1:>2d}] {roms[i].file_path}")
+        if verbose:
+            print(f"     Checksum: {roms[i].checksum.value}, Version XML: {roms[i].version.xml_ver}")
+            print()
 
     while(1):
         try:
             selection = int(input())
+        except KeyboardInterrupt:
+            sys.exit(1)
         except:
             print("Bad input. Try again with the number keys.")
             continue


### PR DESCRIPTION
- fixes exiting with Ctrl+C on linux. *You can't quit this script with normal ^C in interactive. You'll have to kill its process!*
- chooseROM returns Z64Rom object *in addition to speed, so we don't have to execute Z64Rom() or its static methods like isValidRom every time to read the rom file's headers, and that makes it a slight slow on some computers.*
- adds simple verbosity for inspecting roms, *just to make sure if the version of your rom file you wanted to extract is correct*

Any suggestions or issues are welcome...

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/458435867.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/458435868.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/458435870.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/458435871.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/458435872.zip)
<!--- section:artifacts:end -->