### PR TITLE
Add 240p and 480p widescreen modes

### DIFF
--- a/soh/soh/Enhancements/presets.h
+++ b/soh/soh/Enhancements/presets.h
@@ -133,7 +133,7 @@ const std::vector<const char*> enhancementsCvars = {
     "gPauseLiveLinkRotation",
     "gPauseLiveLink",
     "gMinFrameCount",
-    "gN64Mode",
+    "gLowResMode",
     "gNewDrops",
     "gDisableBlackBars",
     "gDynamicWalletIcon",

--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -623,6 +623,17 @@ namespace GameMenuBar {
 
             if (ImGui::BeginMenu("Graphics"))
             {
+                if (ImGui::BeginMenu("Low-res Mode")) {
+                    UIWidgets::EnhancementRadioButton("Disabled", "gLowResMode", 0);
+                    UIWidgets::EnhancementRadioButton("N64 Mode", "gLowResMode", 1);
+                    UIWidgets::Tooltip("Sets aspect ratio to 4:3 and lowers resolution to 240p, the N64's native resolution");
+                    UIWidgets::EnhancementRadioButton("240p Widescreen", "gLowResMode", 2);
+                    UIWidgets::Tooltip("Lowers vertical resolution to the N64's 240p, while retaining a widescreen aspect ratio.");
+                    UIWidgets::EnhancementRadioButton("480p Widescreen", "gLowResMode", 3);
+                    UIWidgets::Tooltip("Lowers vertical resolution to the Gamecube's 480p, while retaining a widescreen aspect ratio.");
+                    ImGui::EndMenu();
+                }
+
                 if (ImGui::BeginMenu("Animated Link in Pause Menu")) {
                     ImGui::Text("Rotation");
                     UIWidgets::EnhancementRadioButton("Disabled", "gPauseLiveLinkRotation", 0);
@@ -666,8 +677,6 @@ namespace GameMenuBar {
 
                     ImGui::EndMenu();
                 }
-                UIWidgets::PaddedEnhancementCheckbox("N64 Mode", "gN64Mode", true, false);
-                UIWidgets::Tooltip("Sets aspect ratio to 4:3 and lowers resolution to 240p, the N64's native resolution");
                 UIWidgets::PaddedEnhancementCheckbox("Glitch line-up tick", "gDrawLineupTick", true, false);
                 UIWidgets::Tooltip("Displays a tick in the top center of the screen to help with glitch line-ups in SoH, as traditional UI based line-ups do not work outside of 4:3");
                 UIWidgets::PaddedEnhancementCheckbox("Enable 3D Dropped items/projectiles", "gNewDrops", true, false);


### PR DESCRIPTION
Requires libultraship PR https://github.com/Kenix3/libultraship/pull/61

This adds Crispy Doom-style widescreen low res modes for people who prefer the look of N64's 240p, or Gamecube's 480p, but still want to take advantage of their widescreen monitors https://github.com/HarbourMasters/Shipwright/issues/349.

Renamed `gN64Mode` to `gLowResMode` and created a radio menu to choose different modes from.

![ws240p](https://user-images.githubusercontent.com/116680301/205495238-e4330486-e7f8-41f1-85ad-4077538fe5c2.gif)


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/465576113.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/465576115.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/465576116.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/465576117.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/465576118.zip)
<!--- section:artifacts:end -->