### PR TITLE
Don't autosave after obtaining bombchus if bombchu drops are enabled

### DIFF
--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -2673,6 +2673,13 @@ void PerformAutosave(PlayState* play, u8 item) {
                     if (play->sceneNum == SCENE_GANON_DEMO) {
                         break;
                     }
+                case ITEM_BOMBCHU:
+                case ITEM_BOMBCHUS_5:
+                case ITEM_BOMBCHUS_20:
+                    if (!CVar_GetS32("gBombchuDrops", 0)) {
+                        Play_PerformSave(play);
+                    }
+                    break;
                 default:
                     Play_PerformSave(play);
                     break;


### PR DESCRIPTION
Note that this only applies to default autosave CVar settings, which only save after obtaining major items.  The intent behind this is to avoid autosaving after every single item drop.  When bombchu drops are enabled, they should no longer be considered a major item, and therefore shouldn't trigger autosave under these settings.  Closes #1945 

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/461654804.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/461654805.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/461654806.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/461654807.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/461654808.zip)
<!--- section:artifacts:end -->