### PR TITLE
Kaleidoscope: Fix C buttons when closing the menu

### DIFF
--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
@@ -1980,7 +1980,7 @@ void KaleidoScope_DrawInfoPanel(PlayState* play) {
                 } else {//baguettes
                     PosX = 98;
                 }
-                s16 PosY = 200; //General Pos of C button icon
+                s16 PosY = 200 - pauseCtx->infoPanelOffsetY; //General Pos of C button icon
                 s16 icon_w = 46; // Original texture size
                 s16 icon_h = 16;
                 s32 icon_x_offset;


### PR DESCRIPTION
Fixes a bug where the C buttons on the panel at the bottom of the kaleidoscope menu wouldn't move down with said panel, pictured below.
<img alt="Screenshot of the pause menu closing with the item menu shown. The info panel at the bottom, but not the C-buttons normally displayed on it, is moving offscreen." src="https://user-images.githubusercontent.com/20016345/205957718-9c07ac05-73f0-4a90-a4a0-330e44d9721e.png">

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/464839963.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/464839964.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/464839965.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/464839966.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/464839967.zip)
<!--- section:artifacts:end -->