### PR TITLE
Fix: Rando Lake Hylia water texture

### DIFF
--- a/soh/src/overlays/actors/ovl_Door_Warp1/z_door_warp1.c
+++ b/soh/src/overlays/actors/ovl_Door_Warp1/z_door_warp1.c
@@ -843,6 +843,8 @@ void DoorWarp1_AdultWarpOut(DoorWarp1* this, PlayState* play) {
                 if (gSaveContext.n64ddFlag) {
                     play->nextEntranceIndex = 0x60C;
                     gSaveContext.nextCutsceneIndex = 0;
+                    // Set "raised lake hylia water" since we aren't warping to the cutscene
+                    gSaveContext.eventChkInf[6] |= 0x200;
                 } else {
                     Item_Give(play, ITEM_MEDALLION_WATER);
                     play->nextEntranceIndex = 0x6B;


### PR DESCRIPTION
The way we were handling the Lake Hylia water level in rando missed setting the flag for "raised lake hylia water level". This flag is needed so the appropriate "under water moving" texture is applied to the ground of Lake Hylia.

The flag controls the following effect for the Lake Hylia scene. https://github.com/HarbourMasters/Shipwright/blob/6c2a3542be5724e400972d62c77e458b109084d2/soh/src/code/z_scene_table.c#L2014-L2016

### Before:
![image](https://user-images.githubusercontent.com/13861068/206050068-b9d9810b-5a7d-4899-87e8-31412f14b386.png)
![image](https://user-images.githubusercontent.com/13861068/206050127-f5ce14b0-9d08-4e04-86c4-65ff90a8110b.png)

### After:
![image](https://user-images.githubusercontent.com/13861068/206050103-d9d22385-50e4-4748-99fd-50825097c916.png)
![image](https://user-images.githubusercontent.com/13861068/206050140-3aed37a1-015f-43c3-8873-6ff711115b98.png)


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/465459623.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/465459624.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/465459625.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/465459626.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/465459627.zip)
<!--- section:artifacts:end -->