### PR TITLE
Rando: Clear seed generation cvar on launch

### DIFF
--- a/soh/soh/Enhancements/bootcommands.c
+++ b/soh/soh/Enhancements/bootcommands.c
@@ -25,8 +25,9 @@ void BootCommands_Init()
     CVar_RegisterS32("gDebugEnabled", 0);
     CVar_RegisterS32("gLanguages", LANGUAGE_ENG);
     CVar_RegisterS32("gHudColors", 0); //0 = N64 / 1 = NGC / 2 = Custom
-	CVar_RegisterS32("gInvertYAxis", 1);
+    CVar_RegisterS32("gInvertYAxis", 1);
     CVar_RegisterS32("gTrailDuration", 4); // 4 = Default trail duration
+    CVar_SetS32("gRandoGenerating", 0); // Clear when a crash happened during rando seed generation
 #if defined(__SWITCH__) || defined(__WIIU__)
     CVar_RegisterS32("gControlNav", 1); // always enable controller nav on switch/wii u
 #endif


### PR DESCRIPTION
Many people have reported being soft locked on generating a new seed when a crash happens during a rando generation.

This sets the cvar off on launch since it shouldn't be useful anymore and should enable generating a new seed without user intervention.

I figured this was an ok spot for this, unless there is a better spot that only runs during launch.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/465817570.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/465817571.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/465817572.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/465817573.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/465817574.zip)
<!--- section:artifacts:end -->