### PR TITLE
Enemy Rando - Hotfix for Jabu Jabu Shabom room

### DIFF
--- a/soh/src/overlays/actors/ovl_Obj_Roomtimer/z_obj_roomtimer.c
+++ b/soh/src/overlays/actors/ovl_Obj_Roomtimer/z_obj_roomtimer.c
@@ -32,7 +32,13 @@ void ObjRoomtimer_Init(Actor* thisx, PlayState* play) {
     ObjRoomtimer* this = (ObjRoomtimer*)thisx;
     s16 params = this->actor.params;
 
-    this->switchFlag = (params >> 10) & 0x3F;
+    // Shabom room in Jabu Jabu has a lengthened timer in Enemy Randomizer. Flag doesn't match what the game
+    // expects. Instead set it back to the same flag as what it would be in vanilla.
+    if (CVar_GetS32("gRandomizedEnemies", 0) && play->sceneNum == SCENE_BDAN && play->roomCtx.curRoom.num == 12) {
+        this->switchFlag = 30;
+    } else {
+        this->switchFlag = (params >> 10) & 0x3F;
+    }
     this->actor.params = params & 0x3FF;
     params = this->actor.params;
 


### PR DESCRIPTION
Guess I'm not out of the woods yet.. :)

As the comment states, the timer wasn't setting the right switch flag because of a lengthened timer in this room. This led to the chest not appearing and the door not opening. This is the only timer that's been changed for enemy rando.

I thought I tested this but I guess I only checked if the timer changed after my changes and wrongly assumed it would work out of the box.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/465973016.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/465973017.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/465973018.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/465973019.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/465973020.zip)
<!--- section:artifacts:end -->