### PR TITLE
Update OTRGui to extract MQ roms with the correct name

### DIFF
--- a/OTRGui/src/game/game.cpp
+++ b/OTRGui/src/game/game.cpp
@@ -83,7 +83,8 @@ void ExtractRom()
 		result.error = NULLSTR;
 
 	if (result.error == NULLSTR) {
-		if (MoonUtils::exists("oot.otr")) MoonUtils::rm("oot.otr");
+		if (MoonUtils::exists("oot.otr") && !version.isMQ) MoonUtils::rm("oot.otr");
+		if (MoonUtils::exists("oot-mq.otr") && version.isMQ) MoonUtils::rm("oot-mq.otr");
 		if (MoonUtils::exists("Extract")) MoonUtils::rm("Extract");
 
 		MoonUtils::mkdir("Extract");
@@ -100,7 +101,7 @@ void ExtractRom()
 }
 
 void OTRGame::update(){
-	updateWorker(sohFolder);
+	updateWorker(sohFolder, version);
 	this->ModelRotation += 50 * GetFrameTime();
 	UpdateLightValues(shader, light);
 

--- a/OTRGui/src/game/game.cpp
+++ b/OTRGui/src/game/game.cpp
@@ -67,7 +67,7 @@ void OTRGame::init(){
 		mat.shader = shader;
 	}
 
-	if((fs::exists("soh.exe") || fs::exists("soh.elf")) && !fs::exists("oot.otr")) {
+	if (fs::exists("soh.exe") || fs::exists("soh.elf")) {
 		hide_second_btn = true;
 		sohFolder = ".";
 	}

--- a/OTRGui/src/impl/baserom_extractor/baserom_extractor.cpp
+++ b/OTRGui/src/impl/baserom_extractor/baserom_extractor.cpp
@@ -60,86 +60,103 @@ RomVersion GetVersion(FILE* rom) {
         version.version = "N64 NTSC 1.0";
         version.listPath = "ntsc_oot.txt";
         version.offset = OOT_OFF_NTSC_10;
+        version.isMQ = false;
         break;
     case OOT_NTSC_11:
         version.version = "N64 NTSC 1.1";
         version.listPath = "ntsc_oot.txt";
         version.offset = OOT_OFF_NTSC_11;
+        version.isMQ = false;
         break;
     case OOT_NTSC_12:
         version.version = "N64 NTSC 1.2";
         version.listPath = "ntsc_oot.txt";
         version.offset = OOT_OFF_NTSC_12;
+        version.isMQ = false;
         break;
     case OOT_PAL_10:
         version.version = "N64 PAL 1.0";
         version.listPath = "pal_oot.txt";
         version.offset = OOT_OFF_PAL_10;
+        version.isMQ = false;
         break;
     case OOT_PAL_11:
         version.version = "N64 PAL 1.1";
         version.listPath = "pal_oot.txt";
         version.offset = OOT_OFF_PAL_11;
+        version.isMQ = false;
         break;
     case OOT_NTSC_JP_GC:
         version.version = "JP GameCube (MQ Disk)";
         version.listPath = "gamecube.txt";
         version.offset = OOT_OFF_JP_GC;
+        version.isMQ = true;
         break;
     case OOT_NTSC_JP_GC_CE:
         version.version = "GameCube (Collectors Edition Disk)";
         version.listPath = "gamecube.txt";
         version.offset = OOT_OFF_JP_GC_CE;
+        version.isMQ = false;
         break;
     case OOT_NTSC_JP_MQ:
         version.version = "JP Master Quest";
         version.listPath = "gamecube.txt";
         version.offset = OOT_OFF_JP_MQ;
+        version.isMQ = true;
         break;
     case OOT_NTSC_US_MQ:
         version.version = "NTSC Master Quest";
         version.listPath = "gamecube.txt";
         version.offset = OOT_OFF_JP_MQ;
+        version.isMQ = true;
         break;
     case OOT_NTSC_US_GC:
         version.version = "NTSC GameCube";
         version.listPath = "gamecube.txt";
         version.offset = OOT_OFF_US_MQ;
+        version.isMQ = true;
         break;
     case OOT_PAL_GC:
         version.version = "PAL GameCube";
         version.listPath = "gamecube_pal.txt";
         version.offset = OOT_OFF_PAL_GC;
+        version.isMQ = false;
         break;
     case OOT_PAL_MQ:
         version.version = "PAL Master Quest";
         version.listPath = "gamecube_pal.txt";
         version.offset = OOT_OFF_PAL_MQ;
+        version.isMQ = true;
         break;
     case OOT_PAL_GC_DBG1:
         version.version = "GameCube Debug 1.0";
         version.listPath = "dbg.txt";
         version.offset = OOT_OFF_PAL_GC_DBG1;
+        version.isMQ = false;
         break;
     case OOT_PAL_GC_DBG2:
         version.version = "GameCube Debug 2.0";
         version.listPath = "dbg.txt";
         version.offset = OOT_OFF_PAL_GC_DBG2;
+        version.isMQ = false;
         break;
     case OOT_PAL_GC_MQ_DBG:
         version.version = "GameCube MQ-Debug";
         version.listPath = "dbg.txt";
         version.offset = OOT_OFF_PAL_MQ_DBG;
+        version.isMQ = true;
         break;
     case OOT_IQUE_CN:
         version.version = "OoT IQue";
         version.listPath = "ique.txt";
         version.offset = OOT_OFF_CN_IQUE;
+        version.isMQ = false;
         break;
     case OOT_IQUE_TW:
         version.version = "TW IQue";
         version.listPath = "ique.txt";
         version.offset = OOT_OFF_TW_IQUE;
+        version.isMQ = false;
         break;
     default:
         version.error = MoonUtils::format("Unknown CRC %x given: ", version.crc);

--- a/OTRGui/src/impl/baserom_extractor/baserom_extractor.h
+++ b/OTRGui/src/impl/baserom_extractor/baserom_extractor.h
@@ -9,6 +9,7 @@ struct RomVersion {
 	std::string version = "None";
 	std::string error = "None";
 	std::string listPath = "None";
+	bool isMQ;
 	int offset;
 	uint32_t crc;
 };

--- a/OTRGui/src/impl/extractor/extractor.cpp
+++ b/OTRGui/src/impl/extractor/extractor.cpp
@@ -36,7 +36,7 @@ std::string GetXMLVersion(RomVersion version)
 	return "ERROR";
 }
 
-void BuildOTR(const std::string output) {
+void BuildOTR(const std::string output, RomVersion version) {
 	if (oldExtractMode)
 	{
 		std::string execStr = Util::format("assets/extractor/%s", isWindows() ? "ZAPD.exe" : "ZAPD.out") + " botr -se OTR";
@@ -49,11 +49,17 @@ void BuildOTR(const std::string output) {
 
 	setCurrentStep("Done!");
 
-	if (output == ".") return;
-	const std::string outputPath = MoonUtils::join(output, "oot.otr");
-	if(MoonUtils::exists(outputPath)) MoonUtils::rm(outputPath);
+	if (output == ".") {
+		if (version.isMQ) {
+			MoonUtils::move("oot.otr", "oot-mq.otr");
+		}
+	} else {
+		const std::string otrName = version.isMQ ? "oot-mq.otr" : "oot.otr";
+		const std::string outputPath = MoonUtils::join(output, otrName);
+		if(MoonUtils::exists(outputPath)) MoonUtils::rm(outputPath);
 
-	MoonUtils::copy("oot.otr", outputPath);
+		MoonUtils::copy("oot.otr", outputPath);
+	}
 }
 
 void ExtractFile(std::string xmlPath, std::string outPath, std::string outSrcPath, RomVersion version) {
@@ -127,7 +133,7 @@ void startWorker(RomVersion version) {
 	}
 }
 
-void updateWorker(const std::string& output) {
+void updateWorker(const std::string& output, RomVersion version) {
 	if (maxResources > 0 && !buildingOtr && (extractedResources >= maxResources || !oldExtractMode)) 
 	{
 		setCurrentStep("Building OTR...");
@@ -138,10 +144,10 @@ void updateWorker(const std::string& output) {
 		buildingOtr = true;
 		
 		if (single_thread || !oldExtractMode){
-			BuildOTR(output);
+			BuildOTR(output, version);
 			return;
 		}
-		std::thread otr(BuildOTR, output);
+		std::thread otr(BuildOTR, output, version);
 		otr.detach();
 	}
 }

--- a/OTRGui/src/impl/extractor/extractor.cpp
+++ b/OTRGui/src/impl/extractor/extractor.cpp
@@ -64,8 +64,13 @@ void BuildOTR(const std::string output, RomVersion version) {
 }
 
 void ExtractFile(std::string xmlPath, std::string outPath, std::string outSrcPath, RomVersion version) {
+	std::string otrExporterArgs = Util::format("--otrfile %s", version.isMQ ? "oot-mq.otr" : "oot.otr");
+	if (xmlPath.find("overlays") != std::string::npos) {
+		otrExporterArgs += " --static";
+	}
+
 	std::string execStr = Util::format("assets/extractor/%s", isWindows() ? "ZAPD.exe" : "ZAPD.out");
-	std::string args = Util::format(" e -eh -i %s -b tmp/baserom/ -o %s -osf %s -gsf 1 -rconf assets/extractor/Config_%s.xml -se OTR %s", xmlPath.c_str(), outPath.c_str(), outSrcPath.c_str(), GetXMLVersion(version).c_str(), xmlPath.find("overlays") != std::string::npos ? "--static" : "");
+	std::string args = Util::format(" e -eh -i %s -b tmp/baserom/ -o %s -osf %s -gsf 1 -rconf assets/extractor/Config_%s.xml -se OTR %s", xmlPath.c_str(), outPath.c_str(), outSrcPath.c_str(), GetXMLVersion(version).c_str(), otrExporterArgs);
 	ProcessResult result = NativeFS->LaunchProcess(execStr + args);
 
 	if (result.exitCode != 0) {

--- a/OTRGui/src/impl/extractor/extractor.cpp
+++ b/OTRGui/src/impl/extractor/extractor.cpp
@@ -49,17 +49,18 @@ void BuildOTR(const std::string output, RomVersion version) {
 
 	setCurrentStep("Done!");
 
-	if (output == ".") {
-		if (version.isMQ) {
-			MoonUtils::move("oot.otr", "oot-mq.otr");
-		}
-	} else {
-		const std::string otrName = version.isMQ ? "oot-mq.otr" : "oot.otr";
-		const std::string outputPath = MoonUtils::join(output, otrName);
-		if(MoonUtils::exists(outputPath)) MoonUtils::rm(outputPath);
-
-		MoonUtils::copy("oot.otr", outputPath);
+	// If a custom SoH folder was not selected, or the custom SOH folder is the same location as OTRGui,
+	// then the otr file should already be where it is expected
+	if (output == "." || output == MoonUtils::absolute(".")) {
+		return;
 	}
+
+	// Otherwise an outside SoH folder was selected so we need to copy the exported otr to the correct folder
+	const std::string otrName = version.isMQ ? "oot-mq.otr" : "oot.otr";
+	const std::string outputPath = MoonUtils::join(output, otrName);
+	if (MoonUtils::exists(outputPath)) MoonUtils::rm(outputPath);
+
+	MoonUtils::copy(otrName, outputPath);
 }
 
 void ExtractFile(std::string xmlPath, std::string outPath, std::string outSrcPath, RomVersion version) {
@@ -116,8 +117,9 @@ void startWorker(RomVersion version) {
 	}
 	else
 	{
+		std::string otrExporterArgs = Util::format("--otrfile %s", version.isMQ ? "oot-mq.otr" : "oot.otr");
 		std::string execStr = Util::format("assets/extractor/%s", isWindows() ? "ZAPD.exe" : "ZAPD.out");
-		std::string args = Util::format(" ed -eh -i %s -b tmp/rom.z64 -fl assets/extractor/filelists -o %s -osf %s -gsf 1 -rconf assets/extractor/Config_%s.xml -se OTR %s", path.c_str(), (path + "/../").c_str(), (path + "/../").c_str(), GetXMLVersion(version).c_str(), "");
+		std::string args = Util::format(" ed -eh -i %s -b tmp/rom.z64 -fl assets/extractor/filelists -o %s -osf %s -gsf 1 -rconf assets/extractor/Config_%s.xml -se OTR %s", path.c_str(), (path + "/../").c_str(), (path + "/../").c_str(), GetXMLVersion(version).c_str(), otrExporterArgs.c_str());
 		ProcessResult result = NativeFS->LaunchProcess(execStr + args);
 
 		if (result.exitCode != 0) {

--- a/OTRGui/src/impl/extractor/extractor.h
+++ b/OTRGui/src/impl/extractor/extractor.h
@@ -8,4 +8,4 @@ enum Platforms {
 struct RomVersion;
 
 void startWorker(RomVersion version);
-void updateWorker(const std::string& output);
+void updateWorker(const std::string& output, RomVersion version);

--- a/OTRGui/src/utils/mutils.cpp
+++ b/OTRGui/src/utils/mutils.cpp
@@ -102,6 +102,10 @@ namespace MoonUtils {
         else fs::remove(path);
     }
 
+    string absolute(string path) {
+        return normalize(fs::absolute(path).string());
+    }
+
     string relative(string parent, string child){
         return normalize(fs::relative(child, parent).string());
     }

--- a/OTRGui/src/utils/mutils.h
+++ b/OTRGui/src/utils/mutils.h
@@ -37,6 +37,7 @@ namespace MoonUtils {
     bool exists(std::string path);
     void mkdir(std::string path);
     void rm(std::string path);
+    std::string absolute(std::string path);
     std::string relative(std::string parent, std::string child);
     void move(std::string src, std::string dst);
     void copy(std::string src, std::string dst);


### PR DESCRIPTION
This continues the effort from #1928, thanks @garrettjoecox!

OTRExporter arguments for the otrfile name are passed into ZAPD based on vanilla/mq (similar to how the linux script does it). I also updated the "old export" logic too for completeness (but don't think this is used in release right?)

The "select the SoH folder" button would display if you already had an `oot.otr`, so I removed that check since it didn't really make sense.

When a custom SoH folder is selected, the correct otr is copied to the new location based on vanilla/mq. An extra check was added for if the custom SoH folder matches the current working directory to skip the copy process.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/466914923.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/466914924.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/466914925.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/466914926.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/466914927.zip)
<!--- section:artifacts:end -->