### PR TITLE
Rando: Fix lab dive check with eye drops

### DIFF
--- a/soh/src/overlays/actors/ovl_En_Mk/z_en_mk.c
+++ b/soh/src/overlays/actors/ovl_En_Mk/z_en_mk.c
@@ -251,7 +251,9 @@ void EnMk_Wait(EnMk* this, PlayState* play) {
             player->actor.textId = this->actor.textId;
             this->actionFunc = func_80AACA40;
         } else {
-            if (INV_CONTENT(ITEM_ODD_MUSHROOM) == ITEM_EYEDROPS) {
+            // Skip eye drop text on rando if Link went in the water, so you can still receive the dive check
+            if (INV_CONTENT(ITEM_ODD_MUSHROOM) == ITEM_EYEDROPS &&
+                (!gSaveContext.n64ddFlag || this->swimFlag == 0)) {
                 player->actor.textId = 0x4032;
                 this->actionFunc = func_80AACA40;
             } else {


### PR DESCRIPTION
When Link has the eye drops in his inventory, the Lake Hylia lab professor will not reward you if you did the lab dive, instead he says "bring me back a souvenir!".

To address this, a rando check was added that will skip the eye drops text if you went in the water, which will allow the normal dive text to execute, granting the itemget for the dive check.

Fixes #2069

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/468766549.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/468766550.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/468766551.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/468766552.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/468766553.zip)
<!--- section:artifacts:end -->