### PR TITLE
fix for 1-core cpu machines in OTR generation tool

### DIFF
--- a/ZAPDTR/ZAPD/Main.cpp
+++ b/ZAPDTR/ZAPD/Main.cpp
@@ -328,7 +328,7 @@ int main(int argc, char* argv[])
 					Directory::ListFiles(Globals::Instance->inputPath.string());
 
 				const int num_threads = std::thread::hardware_concurrency();
-				ctpl::thread_pool pool(num_threads / 2);
+				ctpl::thread_pool pool(num_threads > 1 ? num_threads / 2 : 1);
 
 				bool parseSuccessful;
 


### PR DESCRIPTION
A small minor patch for single core virtual machines *including small cheap servers out there*.  During preparation it spawns processing threads with a half of the CPU core count, and the problem was if any case some machines have only one core, nothing is spawned (`num_threads = 1`, `num_threads / 2` results to **0**) and will always continue infinitely without any work done unless stopped. This PR will just cap it to only one thread for them.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/470538208.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/470538209.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/470538210.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/470538211.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/470538212.zip)
<!--- section:artifacts:end -->