### PR TITLE
"Customize behaviour" cleanup

### DIFF
--- a/soh/soh/Enhancements/presets.h
+++ b/soh/soh/Enhancements/presets.h
@@ -526,6 +526,8 @@ const std::vector<PresetEntry> randomizerPresetEntries = {
     // Allow the cursor to be on any slot
     PRESET_ENTRY_S32("gPauseAnyCursor", 1),
 
+    // Customize Fishing Behaviour
+    PRESET_ENTRY_S32("gCustomizeFishing", 1),
     // Guarantee Bite
     PRESET_ENTRY_S32("gGuaranteeFishingBite", 1),
     // Fish Never Escape

--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -551,9 +551,9 @@ namespace GameMenuBar {
                         UIWidgets::Tooltip("Turn on/off changes to the shooting gallery behavior");
                         bool disabled = !CVar_GetS32("gCustomizeShootingGallery", 0);
                         const char* disabledTooltip = "This option is disabled because \"Customize Behavior\" is turned off";
-                        UIWidgets::EnhancementCheckbox("Instant Win", "gInstantShootingGalleryWin", disabled, disabledTooltip);
+                        UIWidgets::PaddedEnhancementCheckbox("Instant Win", "gInstantShootingGalleryWin", true, false, disabled, disabledTooltip);
                         UIWidgets::Tooltip("Skips the shooting gallery minigame");
-                        UIWidgets::EnhancementCheckbox("No Rupee Randomization", "gConstantAdultGallery", disabled, disabledTooltip);
+                        UIWidgets::PaddedEnhancementCheckbox("No Rupee Randomization", "gConstantAdultGallery", true, false, disabled, disabledTooltip);
                         UIWidgets::Tooltip("Forces the rupee order to not be randomized as adult, making it the same as chlid");
                         UIWidgets::PaddedEnhancementSliderInt("Child Starting Ammunition: %d", "##cShootingGalleryAmmunition", "gChildShootingGalleryAmmunition", 10, 30, "", 15, false, true, false, disabled, disabledTooltip);
                         UIWidgets::Tooltip("The ammunition at the start of the shooting gallery minigame as a child");
@@ -569,9 +569,9 @@ namespace GameMenuBar {
                         UIWidgets::Tooltip("Turn on/off changes to the bombchu bowling behavior");
                         bool disabled = CVar_GetS32("gCustomizeBombchuBowling", 0) == 0;
                         const char* disabledTooltip = "This option is disabled because \"Customize Behavior\" is turned off";
-                        UIWidgets::EnhancementCheckbox("Remove Small Cucco", "gBombchuBowlingNoSmallCucco", disabled, disabledTooltip);
+                        UIWidgets::PaddedEnhancementCheckbox("Remove Small Cucco", "gBombchuBowlingNoSmallCucco", true, false, disabled, disabledTooltip);
                         UIWidgets::Tooltip("Prevents the small cucco from appearing in the bombchu bowling minigame");
-                        UIWidgets::EnhancementCheckbox("Remove Big Cucco", "gBombchuBowlingNoBigCucco", disabled, disabledTooltip);
+                        UIWidgets::PaddedEnhancementCheckbox("Remove Big Cucco", "gBombchuBowlingNoBigCucco", true, false, disabled, disabledTooltip);
                         UIWidgets::Tooltip("Prevents the big cucco from appearing in the bombchu bowling minigame");
                         UIWidgets::PaddedEnhancementSliderInt("Bombchu Count: %d", "##cBombchuBowlingAmmunition", "gBombchuBowlingAmmunition", 3, 20, "", 10, false, true, false, disabled, disabledTooltip);
                         UIWidgets::Tooltip("The number of bombchus available at the start of the bombchu bowling minigame");
@@ -585,7 +585,7 @@ namespace GameMenuBar {
                         UIWidgets::Tooltip("Turn on/off changes to the fishing behavior");
                         bool disabled = !CVar_GetS32("gCustomizeFishing", 0);
                         const char* disabledTooltip = "This option is disabled because \"Customize Behavior\" is turned off";
-                        UIWidgets::EnhancementCheckbox("Instant Fishing", "gInstantFishing", disabled, disabledTooltip);
+                        UIWidgets::PaddedEnhancementCheckbox("Instant Fishing", "gInstantFishing", true, false, disabled, disabledTooltip);
                         UIWidgets::Tooltip("All fish will be caught instantly");
                         UIWidgets::PaddedEnhancementCheckbox("Guarantee Bite", "gGuaranteeFishingBite", true, false, disabled, disabledTooltip);
                         UIWidgets::Tooltip("When a line is stable, guarantee bite. Otherwise use default logic");


### PR DESCRIPTION
https://github.com/HarbourMasters/Shipwright/pull/1990 included the "customize fishing behaviour" in the right preset at some point but I'm guessing the preset rework from Proxy happened before it got merged, so it got lost. This adds it back to the randomizer preset so the fishing options for that actually get used correctly.

Noticed some of the new checkboxes for the new "Customize Behaviour" were also missing padding, so I added those too.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/471117196.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/471117197.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/471117198.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/471117199.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/471117200.zip)
<!--- section:artifacts:end -->