### PR TITLE
Check Tracker - Color initialization

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -901,8 +901,8 @@ void ImGuiDrawTwoColorPickerSection(const char* text, const char* cvarMainName, 
             ImGui::TableNextColumn();
             ImGui::PushItemWidth(ImGui::GetContentRegionAvail().x);
             if (UIWidgets::EnhancementColor("Check", cvarMainName,
-                ImVec4(main_color.r / 255.0f, main_color.g / 255.0f, main_color.b / 255.0f, main_color.a / 255.0f),
-                ImVec4(main_default_color.r / 255.0f, main_default_color.g / 255.0f, main_default_color.b / 255.0f, main_default_color.a / 255.0f)))
+                ImVec4(main_color.r, main_color.g, main_color.b, main_color.a),
+                ImVec4(main_default_color.r, main_default_color.g, main_default_color.b, main_default_color.a)))
             {
                 main_color = CVar_GetRGBA(cvarMainName, main_default_color);
             };
@@ -912,8 +912,8 @@ void ImGuiDrawTwoColorPickerSection(const char* text, const char* cvarMainName, 
             ImGui::AlignTextToFramePadding();
             ImGui::PushItemWidth(ImGui::GetContentRegionAvail().x);
             if (UIWidgets::EnhancementColor("Details", cvarExtraName,
-                ImVec4(extra_color.r / 255.0f, extra_color.g / 255.0f, extra_color.b / 255.0f, extra_color.a / 255.0f),
-                ImVec4(extra_default_color.r / 255.0f, extra_default_color.g / 255.0f, extra_default_color.b / 255.0f, extra_default_color.a / 255.0f)))
+                ImVec4(extra_color.r, extra_color.g, extra_color.b, extra_color.a),
+                ImVec4(extra_default_color.r, extra_default_color.g, extra_default_color.b, extra_default_color.a)))
             {
                 extra_color = CVar_GetRGBA(cvarExtraName, extra_default_color);
             }
@@ -952,8 +952,8 @@ void DrawCheckTrackerOptions(bool& open) {
     ImGui::TableNextColumn();
     ImGui::PushItemWidth(ImGui::GetContentRegionAvail().x);
     if (UIWidgets::EnhancementColor("BG Color", "gCheckTrackerBgColor",
-        ImVec4(Color_Background.r / 255.0f, Color_Background.g / 255.0f, Color_Background.b / 255.0f, Color_Background.a / 255.0f),
-        ImVec4(Color_Bg_Default.r / 255.0f, Color_Bg_Default.g / 255.0f, Color_Bg_Default.b / 255.0f, Color_Bg_Default.a / 255.0f),
+        ImVec4(Color_Background.r, Color_Background.g, Color_Background.b, Color_Background.a),
+        ImVec4(Color_Bg_Default.r, Color_Bg_Default.g, Color_Bg_Default.b, Color_Bg_Default.a),
         false, true))
     {
         Color_Background = CVar_GetRGBA("gCheckTrackerBgColor", Color_Bg_Default);


### PR DESCRIPTION
Fixes colours not initializing correctly in Check Tracker settings

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/471411987.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/471411988.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/471411989.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/471411990.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/471411991.zip)
<!--- section:artifacts:end -->