### PR TITLE
SFX: Support replaying the current BGM when changed

### DIFF
--- a/soh/soh/Enhancements/sfx-editor/SfxEditor.cpp
+++ b/soh/soh/Enhancements/sfx-editor/SfxEditor.cpp
@@ -181,6 +181,26 @@ std::map<u16, std::tuple<std::string, std::string, SeqType>> sfxEditorSequenceMa
     {NA_SE_EV_CHICKEN_CRY_A,       {"Chicken Cry",                         "NA_SE_EV_CHICKEN_CRY_A",         SEQ_SFX}},
 };
 
+// Grabs the current BGM sequence ID and replays it
+// which will lookup the proper override, or reset back to vanilla
+void ReplayCurrentBGM() {
+    u16 curSeqId = func_800FA0B4(SEQ_PLAYER_BGM_MAIN);
+    Audio_QueueSeqCmd(0x00000000 | curSeqId); // TODO: replace with Audio_StartSeq when the macro is shared
+}
+
+// Attempt to update the BGM if it matches the current sequence that is being played
+// The seqKey that is passed in should be the vanilla ID, not the override ID
+void UpdateCurrentBGM(u16 seqKey, SeqType seqType) {
+    if (seqType != SEQ_BGM_WORLD) {
+        return;
+    }
+
+    u16 curSeqId = func_800FA0B4(SEQ_PLAYER_BGM_MAIN);
+    if (curSeqId == seqKey) {
+        ReplayCurrentBGM();
+    }
+}
+
 void Draw_SfxTab(const std::string& tabId, const std::map<u16, std::tuple<std::string, std::string, SeqType>>& map, SeqType type) {
     const std::string hiddenTabId = "##" + tabId;
     const std::string resetAllButton = "Reset All" + hiddenTabId;
@@ -198,6 +218,9 @@ void Draw_SfxTab(const std::string& tabId, const std::map<u16, std::tuple<std::s
             }
         }
         SohImGui::RequestCvarSaveOnNextTick();
+        if (type == SEQ_BGM_WORLD) {
+            ReplayCurrentBGM();
+        }
     }
     ImGui::SameLine();
     if (ImGui::Button(randomizeAllButton.c_str())) {
@@ -222,6 +245,9 @@ void Draw_SfxTab(const std::string& tabId, const std::map<u16, std::tuple<std::s
             }
         }
         SohImGui::RequestCvarSaveOnNextTick();
+        if (type == SEQ_BGM_WORLD) {
+            ReplayCurrentBGM();
+        }
     }
 
     ImGui::BeginTable(tabId.c_str(), 3, ImGuiTableFlags_SizingFixedFit);
@@ -263,6 +289,7 @@ void Draw_SfxTab(const std::string& tabId, const std::map<u16, std::tuple<std::s
                 if (ImGui::Selectable(std::get<0>(seqData).c_str())) {
                     CVar_SetS32(cvarKey.c_str(), value);
                     SohImGui::RequestCvarSaveOnNextTick();
+                    UpdateCurrentBGM(defaultValue, seqType);
                 }
             }
 
@@ -299,6 +326,7 @@ void Draw_SfxTab(const std::string& tabId, const std::map<u16, std::tuple<std::s
         if (ImGui::Button(resetButton.c_str())) {
             CVar_SetS32(cvarKey.c_str(), defaultValue);
             SohImGui::RequestCvarSaveOnNextTick();
+            UpdateCurrentBGM(defaultValue, seqType);
         }
         ImGui::SameLine();
         ImGui::PushItemWidth(-FLT_MIN);
@@ -310,6 +338,7 @@ void Draw_SfxTab(const std::string& tabId, const std::map<u16, std::tuple<std::s
                 if (seqType & type) {
                     CVar_SetS32(cvarKey.c_str(), value);
                     SohImGui::RequestCvarSaveOnNextTick();
+                    UpdateCurrentBGM(defaultValue, seqType);
                     break;
                 }
             }

--- a/soh/soh/Enhancements/sfx-editor/SfxEditor.cpp
+++ b/soh/soh/Enhancements/sfx-editor/SfxEditor.cpp
@@ -185,7 +185,9 @@ std::map<u16, std::tuple<std::string, std::string, SeqType>> sfxEditorSequenceMa
 // which will lookup the proper override, or reset back to vanilla
 void ReplayCurrentBGM() {
     u16 curSeqId = func_800FA0B4(SEQ_PLAYER_BGM_MAIN);
-    Audio_QueueSeqCmd(0x00000000 | curSeqId); // TODO: replace with Audio_StartSeq when the macro is shared
+    // TODO: replace with Audio_StartSeq when the macro is shared
+    // The fade time and audio player flags will always be 0 in the case of replaying the BGM, so they are not set here
+    Audio_QueueSeqCmd(0x00000000 | curSeqId);
 }
 
 // Attempt to update the BGM if it matches the current sequence that is being played

--- a/soh/soh/Enhancements/sfx-editor/SfxEditor.cpp
+++ b/soh/soh/Enhancements/sfx-editor/SfxEditor.cpp
@@ -291,7 +291,7 @@ void Draw_SfxTab(const std::string& tabId, const std::map<u16, std::tuple<std::s
                 if (ImGui::Selectable(std::get<0>(seqData).c_str())) {
                     CVar_SetS32(cvarKey.c_str(), value);
                     SohImGui::RequestCvarSaveOnNextTick();
-                    UpdateCurrentBGM(defaultValue, seqType);
+                    UpdateCurrentBGM(defaultValue, type);
                 }
             }
 
@@ -340,7 +340,7 @@ void Draw_SfxTab(const std::string& tabId, const std::map<u16, std::tuple<std::s
                 if (seqType & type) {
                     CVar_SetS32(cvarKey.c_str(), value);
                     SohImGui::RequestCvarSaveOnNextTick();
-                    UpdateCurrentBGM(defaultValue, seqType);
+                    UpdateCurrentBGM(defaultValue, type);
                     break;
                 }
             }


### PR DESCRIPTION
This makes it so that when the sequence for the "current" BGM is updated/reset, the audio player will replay the BGM to force the sfx override to take over.

Two functions where added, one that performs the replay, and one that checks when to execute it. The randomize/reset buttons for the line item and any change to the dropdown will check if that line item is the current sequence being played, and replay it. The randomizer all/reset all for the BGM world group will also do a replay.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/488210380.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/488210381.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/488210382.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/488210383.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/488210384.zip)
<!--- section:artifacts:end -->