### PR TITLE
Fixes crash due to OOB soundfont access.

### DIFF
--- a/soh/src/code/audio_playback.c
+++ b/soh/src/code/audio_playback.c
@@ -376,7 +376,7 @@ Drum* Audio_GetDrum(s32 fontId, s32 drumId) {
 }
 
 SoundFontSound* Audio_GetSfx(s32 fontId, s32 sfxId) {
-    SoundFontSound* sfx;
+    SoundFontSound* sfx = NULL;
 
     if (fontId == 0xFF) {
         return NULL;
@@ -388,13 +388,15 @@ SoundFontSound* Audio_GetSfx(s32 fontId, s32 sfxId) {
     }
 
     SoundFont* sf = ResourceMgr_LoadAudioSoundFont(fontMap[fontId]);
-    sfx = &sf->soundEffects[sfxId];
+    if (sfxId < sf->numSfx) {
+        sfx = &sf->soundEffects[sfxId];
+    }
 
     if (sfx == NULL) {
         gAudioContext.audioErrorFlags = ((fontId << 8) + sfxId) + 0x5000000;
     }
 
-    if (sfx->sample == NULL) {
+    if (sfx != NULL && sfx->sample == NULL) {
         return NULL;
     }
 


### PR DESCRIPTION
Definitely not impossible that there is something wrong with this sequence causing it not to sound correct, but this at least prevents crashes that were occuring on this sequence.\

Fixes #2136 

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/472719202.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/472719204.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/472719205.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/472719206.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/472719207.zip)
<!--- section:artifacts:end -->