### PR TITLE
fix: show always shuffled scrubs on check tracker

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -478,7 +478,12 @@ bool IsVisibleInCheckTracker(RandomizerCheckObject rcObj) {
             rcObj.vOrMQ == RCVORMQ_VANILLA && !OTRGlobals::Instance->gRandomizer->masterQuestDungeons.contains(rcObj.sceneId)
         ) &&
         (rcObj.rcType != RCTYPE_SHOP                || showShops) &&
-        (rcObj.rcType != RCTYPE_SCRUB               || showScrubs) &&
+        (rcObj.rcType != RCTYPE_SCRUB ||
+         showScrubs || 
+         rcObj.rc == RC_LW_DEKU_SCRUB_NEAR_BRIDGE || // The 3 scrubs that are always randomized
+         rcObj.rc == RC_HF_DEKU_SCRUB_GROTTO ||
+         rcObj.rc == RC_LW_DEKU_SCRUB_GROTTO_FRONT
+        ) &&
         (rcObj.rcType != RCTYPE_MERCHANT            || showMerchants) &&
         (rcObj.rcType != RCTYPE_SKULL_TOKEN ||
             (showOverworldTokens && RandomizerCheckObjects::AreaIsOverworld(rcObj.rcArea)) ||


### PR DESCRIPTION
fix https://github.com/HarbourMasters/Shipwright/issues/2160

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/473279533.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/473279534.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/473279536.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/473279537.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/473279538.zip)
<!--- section:artifacts:end -->