### PR TITLE
Color Picker bug

### DIFF
--- a/soh/soh/UIWidgets.cpp
+++ b/soh/soh/UIWidgets.cpp
@@ -528,13 +528,15 @@ namespace UIWidgets {
             colors->x = defaultcolors.x;
             colors->y = defaultcolors.y;
             colors->z = defaultcolors.z;
-            if (has_alpha) { colors->w = defaultcolors.w; };
+            if (has_alpha) { colors->w = defaultcolors.w; }
+            else { colors->w = 255.0f; }
 
             Color_RGBA8 colorsRGBA;
             colorsRGBA.r = defaultcolors.x;
             colorsRGBA.g = defaultcolors.y;
             colorsRGBA.b = defaultcolors.z;
-            if (has_alpha) { colorsRGBA.a = defaultcolors.w; };
+            if (has_alpha) { colorsRGBA.a = defaultcolors.w; }
+            else { colorsRGBA.a = 255.0f; }
 
             CVar_SetRGBA(cvarName, colorsRGBA);
             CVar_SetS32(Cvar_RBM.c_str(), 0); //On click disable rainbow mode.
@@ -616,7 +618,7 @@ namespace UIWidgets {
                 colors.r = ColorRGBA.x * 255.0;
                 colors.g = ColorRGBA.y * 255.0;
                 colors.b = ColorRGBA.z * 255.0;
-                colors.a = ColorRGBA.w * 255.0;
+                colors.a = 255.0;
 
                 CVar_SetRGBA(cvarName, colors);
                 SohImGui::RequestCvarSaveOnNextTick();


### PR DESCRIPTION
Fixes a bug where the colour picker enhancement widget without alpha uses a garbage value for alpha on reset.

The number of places that the EnhancementColor is used is fairly low right now, only Check Tracker and Collision Viewer. This forces to use full alpha when using `has_alpha` false, instead of leaving the alpha variable as whatever garbage value is in memory. 

Alternative fix could be to force it to be the actual provided value always regardless of has_alpha. Kinda defeats the purpose of the flag IMO. 

Originally found by site#2488. 

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/473355350.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/473355351.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/473355352.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/473355353.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/473355354.zip)
<!--- section:artifacts:end -->