### PR TITLE
fix: set color picker alpha on reset

### DIFF
--- a/soh/soh/UIWidgets.cpp
+++ b/soh/soh/UIWidgets.cpp
@@ -528,13 +528,15 @@ namespace UIWidgets {
             colors->x = defaultcolors.x;
             colors->y = defaultcolors.y;
             colors->z = defaultcolors.z;
-            if (has_alpha) { colors->w = defaultcolors.w; };
+            if (has_alpha) { colors->w = defaultcolors.w; }
+            else { colors->w = 255.0f; }
 
             Color_RGBA8 colorsRGBA;
             colorsRGBA.r = defaultcolors.x;
             colorsRGBA.g = defaultcolors.y;
             colorsRGBA.b = defaultcolors.z;
-            if (has_alpha) { colorsRGBA.a = defaultcolors.w; };
+            if (has_alpha) { colorsRGBA.a = defaultcolors.w; }
+            else { colorsRGBA.a = 255.0f; }
 
             CVar_SetRGBA(cvarName, colorsRGBA);
             CVar_SetS32(Cvar_RBM.c_str(), 0); //On click disable rainbow mode.
@@ -616,7 +618,7 @@ namespace UIWidgets {
                 colors.r = ColorRGBA.x * 255.0;
                 colors.g = ColorRGBA.y * 255.0;
                 colors.b = ColorRGBA.z * 255.0;
-                colors.a = ColorRGBA.w * 255.0;
+                colors.a = 255.0;
 
                 CVar_SetRGBA(cvarName, colors);
                 SohImGui::RequestCvarSaveOnNextTick();

--- a/soh/soh/UIWidgets.cpp
+++ b/soh/soh/UIWidgets.cpp
@@ -528,15 +528,13 @@ namespace UIWidgets {
             colors->x = defaultcolors.x;
             colors->y = defaultcolors.y;
             colors->z = defaultcolors.z;
-            if (has_alpha) { colors->w = defaultcolors.w; }
-            else { colors->w = 255.0f; }
+            colors->w = has_alpha ? defaultcolors.w : 255.0f;
 
             Color_RGBA8 colorsRGBA;
             colorsRGBA.r = defaultcolors.x;
             colorsRGBA.g = defaultcolors.y;
             colorsRGBA.b = defaultcolors.z;
-            if (has_alpha) { colorsRGBA.a = defaultcolors.w; }
-            else { colorsRGBA.a = 255.0f; }
+            colorsRGBA.a = has_alpha ? defaultcolors.w : 255.0f;
 
             CVar_SetRGBA(cvarName, colorsRGBA);
             CVar_SetS32(Cvar_RBM.c_str(), 0); //On click disable rainbow mode.


### PR DESCRIPTION
Fixes a bug where the colour picker enhancement widget without alpha uses a garbage value for alpha on reset

implements https://github.com/HarbourMasters/Shipwright/pull/2169 with formatting changes, tested and working locally

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/473449894.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/473449895.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/473449896.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/473449897.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/473449898.zip)
<!--- section:artifacts:end -->