### PR TITLE
Always use authentic cache policy for replaced seqs

### DIFF
--- a/soh/include/z64audio.h
+++ b/soh/include/z64audio.h
@@ -26,6 +26,8 @@
 
 extern char* fontMap[256];
 
+#define MAX_AUTHENTIC_SEQID 110
+
 typedef enum {
     /* 0 */ ADSR_STATE_DISABLED,
     /* 1 */ ADSR_STATE_INITIAL,

--- a/soh/soh/Enhancements/sfx-editor/SfxEditor.h
+++ b/soh/soh/Enhancements/sfx-editor/SfxEditor.h
@@ -7,7 +7,6 @@ void SfxEditor_AddSequence(char *otrPath, uint16_t seqNum);
 #endif
 
 #define INSTRUMENT_OFFSET 0x81
-#define MAX_AUTHENTIC_SEQID 110
 
 enum SeqType {
     SEQ_NOSHUFFLE  = 0,


### PR DESCRIPTION
Should fix some issues with sequences unloading in specific situations.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/474042234.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/474042235.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/474042236.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/474042237.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/474042238.zip)
<!--- section:artifacts:end -->