### PR TITLE
Support for Windows runners + update docs

### DIFF
--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -12,7 +12,15 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: true
-    - name: Extract assets
+    - name: Extract assets (Windows)
+      if: runner.os == 'Windows'
+      run: |
+        cp ../../../ZELOOTD.z64 OTRExporter/baserom_non_mq.z64
+        cmake --no-warn-unused-cli -S . -B build-cmake -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE:STRING=Release
+        cmake --build build-cmake --target ExtractAssets --config Release
+        7z a assets.zip soh/assets
+    - name: Extract assets (Unix)
+      if: runner.os != 'Windows'
       run: |
         cp ../../../ZELOOTD.z64 OTRExporter/baserom_non_mq.z64
         cmake --no-warn-unused-cli -H. -Bbuild-cmake -GNinja -DCMAKE_BUILD_TYPE:STRING=Release

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -215,3 +215,15 @@ Use the `extract_assets.py` script file to run the exporter using any of the fol
 4) In a terminal run `python3 extract_assets.py <path_to_rom>`
 
 If the script finds multiple roms the user is prompted which to use. Selection is done using the number keys and then pressing the carriage return key.
+
+## Getting CI to work on your fork
+
+The CI works via [Github Actions](https://github.com/features/actions) where we mostly make use of machines hosted by Github; except for the very first step of the CI process called "Extract assets". This steps extracts assets from the game file and generates an "assets" folder in `soh/`.
+
+To get this step working on your fork, you'll need to add a machine to your own repository as a self-hosted runner via "Settings > Actions > Runners" in your repository settings. Make sure to add the 'asset-builder' tag to your newly added runner to assign it to run this step. To setup your runner as a service read the docs [here](https://docs.github.com/en/actions/hosting-your-own-runners/configuring-the-self-hosted-runner-application-as-a-service?platform=linux).
+
+### Runner on Windows
+You'll have to enable the ability to run unsigned scripts through PowerShell. To do this, open Powershell as administrator and run `set-executionpolicy remotesigned`. Most dependencies get installed as part of the CI process. You will also need to seperately install 7z and add it to the PATH so `7z` can be run as a command. [Chocolatey](https://chocolatey.org/) or other package managers can be used to install it easily.
+
+### Runner on UNIX systems
+If you're on macOS or Linux take a look at `macports-deps.txt` or `apt-deps.txt` to see the dependencies expected to be on your machine.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ A PC port of OoT allowing you to enjoy the game with modern controls, widescreen
 
 The Ship does not include assets and as such requires a prior copy of the game to play.
 
+## Discord
+
+Official Discord: https://discord.com/invite/BtBmd55HVH
+
 ## Quick Start (Windows)
 
 1) Download The Ship of Harkinian from [Discord](https://discord.com/invite/BtBmd55HVH).
@@ -128,32 +132,16 @@ Once you have prepared your sequences folder:
 
 Assuming you have done everything correctly, boot up SoH and open up the SFX Editor (In the Enhancements dropdown). You should now be able to swap out any of the in game sequences/fanfares for the sequences added in your newly generated OTR file. If you have any trouble with this process please reach out in the support section of the Discord
 
-## Take The Survey
-Want to use cartridge readers in tandem with the OTRGui?
-Take [this survey](https://retroarchopenhardware.com/survey.php) to increase chances of this becoming reality.
-
-## Discord
-
-Official Discord: https://discord.com/invite/BtBmd55HVH
-
 ## Building The Ship of Harkinian
 
 Refer to the [building instructions](BUILDING.md) to compile SoH.
 
-## Getting CI to work on your fork
-
-The CI works via [Github Actions](https://github.com/features/actions) where we mostly make use of machines hosted by Github; except for the very first step of the CI process called "Extract assets". This steps extracts assets from the game file and generates an "assets" folder in `soh/`.
-
-To get this step working on your fork, you'll need to add a machine to your own repository as a self-hosted runner via "Settings > Actions > Runners" in your repository settings. If you're on macOS or Linux take a look at `macports-deps.txt` or `apt-deps.txt` to see the dependencies expected to be on your machine. For Windows, deps get installed as part of the CI process. To setup your runner as a service read the docs [here](https://docs.github.com/en/actions/hosting-your-own-runners/configuring-the-self-hosted-runner-application-as-a-service?platform=linux).
-
-
-## Troubleshooting The Exporter
-- Confirm that you have an `/assets` folder filled with XMLs in the same directory as OTRGui.exe
-- Confirm that `zapd.exe` exists in the `/assets/extractor` folder
-
 ## Nightly Builds
 Nightly builds of Ship of Harkinian are available here: [Windows](https://nightly.link/HarbourMasters/Shipwright/workflows/generate-builds/develop/soh-windows.zip), [macOS](https://nightly.link/HarbourMasters/Shipwright/workflows/generate-builds/develop/soh-mac.zip), [Linux](https://nightly.link/HarbourMasters/Shipwright/workflows/generate-builds/develop/soh-linux.zip), [Switch](https://nightly.link/HarbourMasters/Shipwright/workflows/generate-builds/develop/soh-switch.zip), [Wii U](https://nightly.link/HarbourMasters/Shipwright/workflows/generate-builds/develop/soh-wiiu.zip)
 
+## Take The Survey
+Want to use cartridge readers in tandem with the OTRGui?
+Take [this survey](https://retroarchopenhardware.com/survey.php) to increase chances of this becoming reality.
 
 ## The Harbour Masters Are...
 


### PR DESCRIPTION
As title says. Exception for Windows because the previous version used UNIX commands. 

Updated building.md and readme.md slightly to accomodate for Windows users and moved some stuff around that made more sense in my eyes.

See my own branch for it in action since it's using my own Windows based self-hosted runner. If the build succeeds both on this repo's end and my end, that should confirm it's working on all platforms now (Shipwright uses a UNIX based runner).

CC @dcvz 

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/476557452.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/476557453.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/476557454.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/476557455.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/476557456.zip)
<!--- section:artifacts:end -->