### PR TITLE
Don't require input for credits textboxes

### DIFF
--- a/soh/soh/Enhancements/presets.h
+++ b/soh/soh/Enhancements/presets.h
@@ -175,7 +175,8 @@ const std::vector<const char*> enhancementsCvars = {
     "gBombchuBowlingAmmunition",
     "gCreditsFix",
     "gSilverRupeeJingleExtend",
-    "gStaticExplosionRadius"
+    "gStaticExplosionRadius",
+    "gNoInputForCredits",
 };
 
 const std::vector<const char*> randomizerCvars = {
@@ -617,6 +618,8 @@ const std::vector<PresetEntry> randomizerPresetEntries = {
     PRESET_ENTRY_S32("gPauseLiveLink", 16),
     // Frames to wait
     PRESET_ENTRY_S32("gMinFrameCount", 200),
+
+    PRESET_ENTRY_S32("gNoInputForCredits", 1),
 };
 
 const std::vector<PresetEntry> s6PresetEntries = {

--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -641,6 +641,8 @@ namespace GameMenuBar {
                 UIWidgets::Tooltip("Allows graves to be pulled when child during the day");
                 UIWidgets::PaddedEnhancementCheckbox("Dogs follow you everywhere", "gDogFollowsEverywhere", true, false);
                 UIWidgets::Tooltip("Allows dogs to follow you anywhere you go, even if you leave the market");
+                UIWidgets::PaddedEnhancementCheckbox("Don't require input for Credits sequence", "gNoInputForCredits", true, false);
+                UIWidgets::Tooltip("Removes the input requirement on textboxes after defeating Ganon, allowing Credits sequence to continue to progress");
 
                 // Blue Fire Arrows
                 bool forceEnableBlueFireArrows = gSaveContext.n64ddFlag &&

--- a/soh/src/code/z_message_PAL.c
+++ b/soh/src/code/z_message_PAL.c
@@ -1181,7 +1181,7 @@ void Message_Decode(PlayState* play) {
         phi_s1 = temp_s2 = msgCtx->msgBufDecoded[decodedBufPos] = font->msgBuf[msgCtx->msgBufPos];
 
         // Don't require input for credits textboxes in randomizer
-        if (gSaveContext.n64ddFlag && (
+        if (CVarGetInteger("gNoInputForCredits", 0) && (
             msgCtx->textId == 0x706F ||
             msgCtx->textId == 0x7091 ||
             msgCtx->textId == 0x7092 ||

--- a/soh/src/code/z_message_PAL.c
+++ b/soh/src/code/z_message_PAL.c
@@ -1180,6 +1180,23 @@ void Message_Decode(PlayState* play) {
     while (true) {
         phi_s1 = temp_s2 = msgCtx->msgBufDecoded[decodedBufPos] = font->msgBuf[msgCtx->msgBufPos];
 
+        // Don't require input for credits textboxes in randomizer
+        if (gSaveContext.n64ddFlag && (
+            msgCtx->textId == 0x706F ||
+            msgCtx->textId == 0x7091 ||
+            msgCtx->textId == 0x7092 ||
+            msgCtx->textId == 0x7093 ||
+            msgCtx->textId == 0x7094 ||
+            msgCtx->textId == 0x7095
+        )) {
+            if (temp_s2 == MESSAGE_BOX_BREAK) {
+                phi_s1 = temp_s2 = msgCtx->msgBufDecoded[decodedBufPos] = font->msgBuf[msgCtx->msgBufPos] = MESSAGE_BOX_BREAK_DELAYED;
+            } else if (temp_s2 == MESSAGE_END) {
+                phi_s1 = temp_s2 = msgCtx->msgBufDecoded[decodedBufPos] = font->msgBuf[msgCtx->msgBufPos] = MESSAGE_FADE2;
+                phi_s1 = temp_s2 = msgCtx->msgBufDecoded[++decodedBufPos] = font->msgBuf[++msgCtx->msgBufPos] = MESSAGE_END;
+            }
+        }
+
         if (temp_s2 == MESSAGE_BOX_BREAK || temp_s2 == MESSAGE_TEXTID || temp_s2 == MESSAGE_BOX_BREAK_DELAYED ||
             temp_s2 == MESSAGE_EVENT || temp_s2 == MESSAGE_END) {
             // Textbox decoding ends with any of the above text control characters


### PR DESCRIPTION
Can't upload a video cause its too large, and can't be bothered to use youtube or something.

Tested by using old debug warp screen, hyrule field with stage 07

<img width="629" alt="Screen Shot 2022-12-14 at 9 56 54 PM" src="https://user-images.githubusercontent.com/7316699/207769082-37d2aca4-1bc8-4b61-bdd1-b39dfb3ef8cf.png">
<img width="631" alt="Screen Shot 2022-12-14 at 9 57 03 PM" src="https://user-images.githubusercontent.com/7316699/207769088-fdb3caf1-dea2-4f9b-a9c5-5b6361526be9.png">


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/523866766.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/523866768.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/523866769.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/523866770.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/523866771.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/523866773.zip)
<!--- section:artifacts:end -->