### PR TITLE
Fix: warp song hints not being set when gossip stones are turned off

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/fill.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/fill.cpp
@@ -909,6 +909,9 @@ void VanillaFill() {
   CreateItemOverrides();
   CreateEntranceOverrides();
   CreateAlwaysIncludedMessages();
+  if (ShuffleWarpSongs) {
+    CreateWarpSongTexts();
+  }
 }
 
 void ClearProgress() {
@@ -1070,6 +1073,9 @@ int Fill() {
       }
       if (ShuffleMerchants.Is(SHUFFLEMERCHANTS_HINTS)) {
         CreateMerchantsHints();
+      }
+      if (ShuffleWarpSongs) {
+        CreateWarpSongTexts();
       }
       return 1;
     }

--- a/soh/soh/Enhancements/randomizer/3drando/hints.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/hints.cpp
@@ -779,7 +779,6 @@ void CreateAllHints() {
 
   CreateGanonText();
   CreateAltarText();
-  CreateWarpSongTexts();
 
   SPDLOG_DEBUG("\nNOW CREATING HINTS\n");
   const HintSetting& hintSetting = hintSettingTable[Settings::HintDistribution.Value<uint8_t>()];

--- a/soh/soh/Enhancements/randomizer/3drando/hints.hpp
+++ b/soh/soh/Enhancements/randomizer/3drando/hints.hpp
@@ -220,6 +220,7 @@ extern std::array<ConditionalAlwaysHint, 9> conditionalAlwaysHints;
 extern uint32_t GetHintRegionHintKey(const uint32_t area);
 extern void CreateAllHints();
 extern void CreateMerchantsHints();
+extern void CreateWarpSongTexts();
 
 Text& GetChildAltarText();
 Text& GetAdultAltarText();


### PR DESCRIPTION
I had placed the warp song hint generation behind `CreateAllHints()`, but that apparently is only called when gossip stone hints are turned on. If gossip stone hints were off, then shuffling warp songs would not display any location.
```
Warp to

    Ok
    No
```

This pulls the warp song text generation out and calls it directly, similar to merchant hints.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/478237627.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/478237628.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/478237629.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/478237630.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/478237631.zip)
<!--- section:artifacts:end -->