### PR TITLE
Fixes crash during randomization of individual sound effects.

### DIFF
--- a/soh/soh/Enhancements/sfx-editor/SfxEditor.cpp
+++ b/soh/soh/Enhancements/sfx-editor/SfxEditor.cpp
@@ -181,7 +181,7 @@ std::map<u16, std::tuple<std::string, std::string, SeqType>> sfxEditorSequenceMa
     {NA_SE_EV_CHICKEN_CRY_A,       {"Chicken Cry",                         "NA_SE_EV_CHICKEN_CRY_A",         SEQ_SFX}},
 };
 
-void Draw_SfxTab(const std::string& tabId, std::map<u16, std::tuple<std::string, std::string, SeqType>>& map, SeqType type) {
+void Draw_SfxTab(const std::string& tabId, const std::map<u16, std::tuple<std::string, std::string, SeqType>>& map, SeqType type) {
     const std::string hiddenTabId = "##" + tabId;
     const std::string resetAllButton = "Reset All" + hiddenTabId;
     const std::string randomizeAllButton = "Randomize All" + hiddenTabId;

--- a/soh/soh/Enhancements/sfx-editor/SfxEditor.cpp
+++ b/soh/soh/Enhancements/sfx-editor/SfxEditor.cpp
@@ -353,7 +353,7 @@ void DrawSfxEditor(bool& open) {
         CVar_SetS32("gSfxEditor", 0);
         return;
     }
-    ImGui::SetNextWindowSize(ImVec2(465, 630), ImGuiCond_FirstUseEver);
+    ImGui::SetNextWindowSize(ImVec2(900, 630), ImGuiCond_FirstUseEver);
     if (!ImGui::Begin("SFX Editor", &open)) {
         ImGui::End();
         return;

--- a/soh/soh/Enhancements/sfx-editor/SfxEditor.cpp
+++ b/soh/soh/Enhancements/sfx-editor/SfxEditor.cpp
@@ -297,19 +297,17 @@ void Draw_SfxTab(const std::string& tabId, const std::map<u16, std::tuple<std::s
         ImGui::SameLine();
         ImGui::PushItemWidth(-FLT_MIN);
         if (ImGui::Button(randomizeButton.c_str())) {
-            bool valid = false;
-            uint32_t value;
-            while (!valid) {
-                value = Random(2, map.end()->first);
-                if (map.contains(value)) {
-                    auto [name, sfxKey, seqType] = map.at(value);
-                    if (seqType & type) {
-                        valid = true;
-                    }
+            while (true) {
+                auto it = map.begin();
+                std::advance(it, rand() % map.size());
+                const auto& [value, seqData] = *it;
+                const auto& [name, sfxKey, seqType] = seqData;
+                if (seqType & type) {
+                    CVar_SetS32(cvarKey.c_str(), value);
+                    SohImGui::RequestCvarSaveOnNextTick();
+                    break;
                 }
             }
-            CVar_SetS32(cvarKey.c_str(), value);
-            SohImGui::RequestCvarSaveOnNextTick();
         }
     }
     ImGui::EndTable();

--- a/soh/soh/Enhancements/sfx-editor/SfxEditor.cpp
+++ b/soh/soh/Enhancements/sfx-editor/SfxEditor.cpp
@@ -181,7 +181,7 @@ std::map<u16, std::tuple<std::string, std::string, SeqType>> sfxEditorSequenceMa
     {NA_SE_EV_CHICKEN_CRY_A,       {"Chicken Cry",                         "NA_SE_EV_CHICKEN_CRY_A",         SEQ_SFX}},
 };
 
-void Draw_SfxTab(const std::string& tabId, const std::map<u16, std::tuple<std::string, std::string, SeqType>>& map, SeqType type) {
+void Draw_SfxTab(const std::string& tabId, std::map<u16, std::tuple<std::string, std::string, SeqType>>& map, SeqType type) {
     const std::string hiddenTabId = "##" + tabId;
     const std::string resetAllButton = "Reset All" + hiddenTabId;
     const std::string randomizeAllButton = "Randomize All" + hiddenTabId;
@@ -300,7 +300,7 @@ void Draw_SfxTab(const std::string& tabId, const std::map<u16, std::tuple<std::s
             bool valid = false;
             uint32_t value;
             while (!valid) {
-                value = Random(2, map.size());
+                value = Random(2, map.end()->first);
                 if (map.contains(value)) {
                     auto [name, sfxKey, seqType] = map.at(value);
                     if (seqType & type) {


### PR DESCRIPTION
I was picking a random value between 2 (0 and 1 aren't useable sequences) and the size of the map. However I didn't realize that many of the keys for the sound effects have keys higher than the size of the map. Since it's an ordered map, I now instead grab the key off of the last entry in the map. This seems to work from my testing.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/481420972.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/481420973.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/481420974.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/481420975.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/481420976.zip)
<!--- section:artifacts:end -->