### PR TITLE
Rando - Fix ice traps & get item logic

### DIFF
--- a/soh/include/variables.h
+++ b/soh/include/variables.h
@@ -168,6 +168,7 @@ extern "C"
 	extern s32 __osPfsLastChannel;
 	extern u8 gWalkSpeedToggle1;
 	extern u8 gWalkSpeedToggle2;
+	extern f32 iceTrapScale;
 
 	extern const s16 D_8014A6C0[];
 #define gTatumsPerBeat (D_8014A6C0[1])

--- a/soh/soh/Enhancements/randomizer/draw.cpp
+++ b/soh/soh/Enhancements/randomizer/draw.cpp
@@ -12,7 +12,7 @@
 
 extern "C" void Randomizer_DrawSmallKey(PlayState* play, GetItemEntry* getItemEntry) {
     s32 pad;
-
+    s8 isColoredKeysEnabled = CVar_GetS32("gRandoMatchKeyColors", 0);
     s16 color_slot = getItemEntry->getItemId - RG_FOREST_TEMPLE_SMALL_KEY;
     s16 colors[9][3] = {
         { 4, 195, 46 },    // Forest Temple
@@ -33,18 +33,23 @@ extern "C" void Randomizer_DrawSmallKey(PlayState* play, GetItemEntry* getItemEn
     gSPMatrix(POLY_OPA_DISP++, Matrix_NewMtx(play->state.gfxCtx, (char*)__FILE__, __LINE__),
               G_MTX_MODELVIEW | G_MTX_LOAD);
 
-    gDPSetGrayscaleColor(POLY_OPA_DISP++, colors[color_slot][0], colors[color_slot][1], colors[color_slot][2], 255);
-    gSPGrayscale(POLY_OPA_DISP++, true);
+    if (isColoredKeysEnabled) {
+        gDPSetGrayscaleColor(POLY_OPA_DISP++, colors[color_slot][0], colors[color_slot][1], colors[color_slot][2], 255);
+        gSPGrayscale(POLY_OPA_DISP++, true);
+    }
 
     gSPDisplayList(POLY_OPA_DISP++, (Gfx*)gGiSmallKeyDL);
 
-    gSPGrayscale(POLY_OPA_DISP++, false);
+    if (isColoredKeysEnabled) {
+        gSPGrayscale(POLY_OPA_DISP++, false);
+    }
 
     CLOSE_DISPS(play->state.gfxCtx);
 }
 
 extern "C" void Randomizer_DrawBossKey(PlayState* play, GetItemEntry* getItemEntry) {
     s32 pad;
+    s8 isColoredKeysEnabled = CVar_GetS32("gRandoMatchKeyColors", 0);
     s16 color_slot;
     color_slot = getItemEntry->getItemId - RG_FOREST_TEMPLE_BOSS_KEY;
     s16 colors[6][3] = {
@@ -63,14 +68,14 @@ extern "C" void Randomizer_DrawBossKey(PlayState* play, GetItemEntry* getItemEnt
     gSPMatrix(POLY_OPA_DISP++, Matrix_NewMtx(play->state.gfxCtx, (char*)__FILE__, __LINE__),
               G_MTX_MODELVIEW | G_MTX_LOAD);
 
-    if (color_slot == 5) { // Ganon's Boss Key
+    if (color_slot == 5 && isColoredKeysEnabled) { // Ganon's Boss Key
         gDPSetGrayscaleColor(POLY_OPA_DISP++, 80, 80, 80, 255);
         gSPGrayscale(POLY_OPA_DISP++, true);
     }
 
     gSPDisplayList(POLY_OPA_DISP++, (Gfx*)gGiBossKeyDL);
 
-    if (color_slot == 5) { // Ganon's Boss Key
+    if (color_slot == 5 && isColoredKeysEnabled) { // Ganon's Boss Key
         gSPGrayscale(POLY_OPA_DISP++, false);
     }
 
@@ -79,13 +84,16 @@ extern "C" void Randomizer_DrawBossKey(PlayState* play, GetItemEntry* getItemEnt
     gSPMatrix(POLY_XLU_DISP++, Matrix_NewMtx(play->state.gfxCtx, (char*)__FILE__, __LINE__),
               G_MTX_MODELVIEW | G_MTX_LOAD);
 
-    gDPSetGrayscaleColor(POLY_XLU_DISP++, colors[color_slot][0], colors[color_slot][1], colors[color_slot][2],
-                            255);
-    gSPGrayscale(POLY_XLU_DISP++, true);
+    if (isColoredKeysEnabled) {
+        gDPSetGrayscaleColor(POLY_XLU_DISP++, colors[color_slot][0], colors[color_slot][1], colors[color_slot][2], 255);
+        gSPGrayscale(POLY_XLU_DISP++, true);
+    }
 
     gSPDisplayList(POLY_XLU_DISP++, (Gfx*)gGiBossKeyGemDL);
 
-    gSPGrayscale(POLY_XLU_DISP++, false);
+    if (isColoredKeysEnabled) {
+        gSPGrayscale(POLY_XLU_DISP++, false);
+    }
 
     CLOSE_DISPS(play->state.gfxCtx);
 }
@@ -154,28 +162,6 @@ extern "C" void Randomizer_DrawDoubleDefense(PlayState* play, GetItemEntry getIt
     gSPGrayscale(POLY_XLU_DISP++, false);
 
     gSPDisplayList(POLY_XLU_DISP++, (Gfx*)gGiHeartContainerDL);
-
-    CLOSE_DISPS(play->state.gfxCtx);
-}
-
-
-extern "C" void Randomizer_DrawIceTrap(PlayState* play, GetItemEntry getItemEntry) {
-    s32 pad;
-    OPEN_DISPS(play->state.gfxCtx);
-
-    if (CVar_GetS32("gLetItSnow", 0)) {
-        Gfx_SetupDL_25Opa(play->state.gfxCtx);
-
-        Matrix_Scale(0.2f, 0.2f, 0.2f, MTXMODE_APPLY);
-        gSPMatrix(POLY_OPA_DISP++, Matrix_NewMtx(play->state.gfxCtx, (char*)__FILE__, __LINE__), G_MTX_MODELVIEW | G_MTX_LOAD);
-
-        gDPSetGrayscaleColor(POLY_OPA_DISP++, 100, 100, 100, 255);
-        gSPGrayscale(POLY_OPA_DISP++, true);
-
-        gSPDisplayList(POLY_OPA_DISP++, (Gfx*)gSilverRockDL);
-
-        gSPGrayscale(POLY_OPA_DISP++, false);
-    }
 
     CLOSE_DISPS(play->state.gfxCtx);
 }

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -30,6 +30,9 @@
 extern "C" uint32_t ResourceMgr_IsGameMasterQuest();
 extern "C" uint32_t ResourceMgr_IsSceneMasterQuest(s16 sceneNum);
 
+// Used for animating the ice trap on the "Get Item" model.
+f32 iceTrapScale;
+
 using json = nlohmann::json;
 using namespace std::literals::string_literals;
 
@@ -2605,6 +2608,7 @@ GetItemEntry Randomizer::GetItemEntryFromRGData(RandomizerGetData rgData, GetIte
         } else {
             modIndex = MOD_RANDOMIZER;
         }
+        iceTrapScale = 0.0f;
         GetItemEntry fakeGiEntry = ItemTableManager::Instance->RetrieveItemEntry(modIndex, GetItemIdFromRandomizerGet(rgData.fakeRgID, ogItemId));
         giEntry.gid = fakeGiEntry.gid;
         giEntry.gi = fakeGiEntry.gi;
@@ -4568,8 +4572,8 @@ void CreateIceTrapRandoMessages() {
     // We only use this ice trap message for christmas, so we don't want it in the normal ice trap messages rotation
     customMessageManager->CreateMessage(Randomizer::IceTrapRandoMessageTableID, NUM_ICE_TRAP_MESSAGES + 1,
                                             { TEXTBOX_TYPE_BLACK, TEXTBOX_POS_BOTTOM,
-                                              "This year for Christmas, all&you get is %BCOAL",
-                                              "This year for Christmas, all&you get is %BCOAL",
+                                              "This year for Christmas, all&you get is %BCOAL%w!",
+                                              "This year for Christmas, all&you get is %BCOAL%w!",
                                               "Pour Noël, cette année, tu&n'auras que du %BCHARBON!&%rJoyeux Noël%w!" });
 }
 
@@ -4928,8 +4932,6 @@ void InitRandoItemTable() {
             randoGetItemTable[i].drawFunc = (CustomDrawFunc)Randomizer_DrawBossKey;
         } else if (randoGetItemTable[i].itemId == RG_DOUBLE_DEFENSE) {
             randoGetItemTable[i].drawFunc = (CustomDrawFunc)Randomizer_DrawDoubleDefense;
-        } else if (randoGetItemTable[i].itemId == RG_ICE_TRAP) {
-            randoGetItemTable[i].drawFunc = (CustomDrawFunc)Randomizer_DrawIceTrap;
         }
         ItemTableManager::Instance->AddItemEntry(MOD_RANDOMIZER, randoGetItemTable[i].itemId, randoGetItemTable[i]);
     }

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -30,9 +30,6 @@
 extern "C" uint32_t ResourceMgr_IsGameMasterQuest();
 extern "C" uint32_t ResourceMgr_IsSceneMasterQuest(s16 sceneNum);
 
-// Used for animating the ice trap on the "Get Item" model.
-f32 iceTrapScale;
-
 using json = nlohmann::json;
 using namespace std::literals::string_literals;
 
@@ -2608,7 +2605,6 @@ GetItemEntry Randomizer::GetItemEntryFromRGData(RandomizerGetData rgData, GetIte
         } else {
             modIndex = MOD_RANDOMIZER;
         }
-        iceTrapScale = 0.0f;
         GetItemEntry fakeGiEntry = ItemTableManager::Instance->RetrieveItemEntry(modIndex, GetItemIdFromRandomizerGet(rgData.fakeRgID, ogItemId));
         giEntry.gid = fakeGiEntry.gid;
         giEntry.gi = fakeGiEntry.gi;

--- a/soh/src/code/z_actor.c
+++ b/soh/src/code/z_actor.c
@@ -78,6 +78,9 @@
 static CollisionPoly* sCurCeilingPoly;
 static s32 sCurCeilingBgId;
 
+// Used for animating the ice trap on the "Get Item" model.
+f32 iceTrapScale;
+
 void ActorShape_Init(ActorShape* shape, f32 yOffset, ActorShadowFunc shadowDraw, f32 shadowScale) {
     shape->yOffset = yOffset;
     shape->shadowDraw = shadowDraw;
@@ -2030,6 +2033,7 @@ s32 GiveItemEntryFromActor(Actor* actor, PlayState* play, GetItemEntry getItemEn
                 s32 absYawDiff = ABS(yawDiff);
 
                 if ((getItemEntry.getItemId != GI_NONE) || (player->getItemDirection < absYawDiff)) {
+                    iceTrapScale = 0.0f;
                     player->getItemEntry = getItemEntry;
                     player->getItemId = getItemEntry.getItemId;
                     player->interactRangeActor = actor;

--- a/soh/src/code/z_draw.c
+++ b/soh/src/code/z_draw.c
@@ -400,9 +400,7 @@ void GetItem_Draw(PlayState* play, s16 drawId) {
  * Uses the Custom Draw Function if it exists, or just calls `GetItem_Draw`
  */
 void GetItemEntry_Draw(PlayState* play, GetItemEntry getItemEntry) {
-    // RANDOTODO: Make this more flexible for easier toggling of individual item recolors in the future.
-    if (getItemEntry.drawFunc != NULL && 
-        (CVar_GetS32("gRandoMatchKeyColors", 0) || getItemEntry.getItemId == RG_DOUBLE_DEFENSE)) {
+    if (getItemEntry.drawFunc != NULL) {
         getItemEntry.drawFunc(play, &getItemEntry);
     } else {
         GetItem_Draw(play, getItemEntry.gid);

--- a/soh/src/overlays/gamestates/ovl_title/z_title.c
+++ b/soh/src/overlays/gamestates/ovl_title/z_title.c
@@ -9,6 +9,7 @@
 #include "global.h"
 #include "alloca.h"
 #include "textures/nintendo_rogo_static/nintendo_rogo_static.h"
+#include "assets/objects/gameplay_keep/gameplay_keep.h"
 #include <soh/Enhancements/bootcommands.h>
 #include <GameVersions.h>
 #include <soh/SaveManager.h>
@@ -232,6 +233,22 @@ void Title_Draw(TitleContext* this) {
 
         gDPSetTileSize(POLY_OPA_DISP++, 1, this->uls, (this->ult & 0x7F) - idx * 4, 0, 0);
         gSPTextureRectangle(POLY_OPA_DISP++, 388, y << 2, 1156, (y + 2) << 2, G_TX_RENDERTILE, 0, 0, 1 << 10, 1 << 10);
+    }
+
+    // Draw ice cube around N64 logo.
+    if (CVar_GetS32("gLetItSnow", 0)) {
+        f32 scale = 0.4f;
+
+        gSPSegment(POLY_OPA_DISP++, 0x08,
+                    Gfx_TwoTexScroll(this->state.gfxCtx, 0, 0, (0 - 1) % 128, 32, 32, 1,
+                                    0, (1 * -2) % 128, 32, 32));
+
+        Matrix_Translate(0.0f, -10.0f, 0.0f, MTXMODE_APPLY);
+        Matrix_Scale(scale, scale, scale, MTXMODE_APPLY);
+        gSPMatrix(POLY_OPA_DISP++, MATRIX_NEWMTX(this->state.gfxCtx),
+                    G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+        gDPSetEnvColor(POLY_OPA_DISP++, 0, 50, 100, 255);
+        gSPDisplayList(POLY_OPA_DISP++, gEffIceFragment3DL);
     }
 
     Environment_FillScreen(this->state.gfxCtx, 0, 0, 0, (s16)this->coverAlpha, FILL_SCREEN_XLU);


### PR DESCRIPTION
Fixes and cleans up the logic for grabbing custom draw functions for rando-specific items. This includes moving the check for colored keys inside its custom draw functions instead of the preceding logic grabbing said custom draw functions.

Also fixes ice traps after they showed the fake item model unintentionally after a previous PR. They now show an ice model around the "get item model" to make it clearer the player has received an ice trap instead of an actual item.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/483160608.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/483160609.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/483160610.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/483160611.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/483160612.zip)
<!--- section:artifacts:end -->