### PR TITLE
Fix gfx patching on 32-bit platforms

### DIFF
--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -867,6 +867,11 @@ extern "C" void ResourceMgr_PatchGfxByName(const char* path, const char* patchNa
         }
     }*/
 
+    // Index refers to individual gfx words, which are half the size on 32-bit
+    if (sizeof(uintptr_t) < 8) {
+        index /= 2;
+    }
+
     Gfx* gfx = (Gfx*)&res->instructions[index];
 
     if (!originalGfx.contains(path) || !originalGfx[path].contains(patchName)) {


### PR DESCRIPTION
Temporary fix. The index will always need to be halved if SoH integrates the latest lus changes.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/482451634.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/482451635.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/482451636.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/482451637.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/482451638.zip)
<!--- section:artifacts:end -->