### PR TITLE
Fix: SFX only save authentic sequence cvars

### DIFF
--- a/soh/soh/Enhancements/sfx-editor/SfxEditor.cpp
+++ b/soh/soh/Enhancements/sfx-editor/SfxEditor.cpp
@@ -189,6 +189,10 @@ void Draw_SfxTab(const std::string& tabId, const std::map<u16, std::tuple<std::s
         for (const auto& [defaultValue, seqData] : map) {
             const auto& [name, sfxKey, seqType] = seqData;
             if (seqType == type) {
+                // Only save authentic sequence CVars
+                if (seqType == SEQ_FANFARE && defaultValue >= MAX_AUTHENTIC_SEQID) {
+                    continue;
+                }
                 const std::string cvarKey = "gSfxEditor_" + sfxKey;
                 CVar_SetS32(cvarKey.c_str(), defaultValue);
             }
@@ -208,7 +212,8 @@ void Draw_SfxTab(const std::string& tabId, const std::map<u16, std::tuple<std::s
             const auto& [name, sfxKey, seqType] = seqData;
             const std::string cvarKey = "gSfxEditor_" + sfxKey;
             if (seqType & type) {
-                if (((seqType & SEQ_BGM_CUSTOM) || seqType == SEQ_FANFARE) && defaultValue > MAX_AUTHENTIC_SEQID) {
+                // Only save authentic sequence CVars
+                if (((seqType & SEQ_BGM_CUSTOM) || seqType == SEQ_FANFARE) && defaultValue >= MAX_AUTHENTIC_SEQID) {
                     continue;
                 }
                 const int randomValue = values.back();
@@ -229,6 +234,7 @@ void Draw_SfxTab(const std::string& tabId, const std::map<u16, std::tuple<std::s
         if (~(seqType) & type) {
             continue;
         }
+        // Do not display custom sequences in the list
         if (((seqType & SEQ_BGM_CUSTOM) || seqType == SEQ_FANFARE) && defaultValue >= MAX_AUTHENTIC_SEQID) {
             continue;
         }


### PR DESCRIPTION
The randomize all/reset all buttons in the SFX editor would save custom sequence names to CVars (specifically the first BGM, and all fanfares). This does not have an immediate impact on the game, but I'm not sure if certain characters in a sequence name could cause the json to get corrupted.

This PR prevents non-authentic sequence names from getting save to the json.

Here is an example of what the shipofharkinian.json would look like:
```json
"gSfxEditor_Super_Mario_Bros_Deluxe_-_Flag_Fanfare": 605,
"gSfxEditor_Super_Smash_Bros": {
    "_Melee_-_Ice_Climbers_Victory_Theme": 632,
    "_Melee_-_Stage_Clear_2": 634
},
"gSfxEditor_TLoZ_A_Link_to_the_Past_-_Ganon_Transform_Fanfare": 644,
"gSfxEditor_TLoZ_A_Link_to_the_Past_-_Ocarina_": 647,
"gSfxEditor_TLoZ_A_Link_to_the_Past_-_Victory_Fanfare": 650,
"gSfxEditor_TLoZ_Majora's_Mask_-_Elegy_of_Emptiness_(SPT)": 659,
"gSfxEditor_TLoZ_Majora's_Mask_-_Goron_Lullaby_(SPT)": 663,
"gSfxEditor_TLoZ_Majora's_Mask_-_Mask_Get_(SPT)": 666,
"gSfxEditor_TLoZ_Majora's_Mask_-_New_Wave_Bossa_Nova_(SPT)": 671,
"gSfxEditor_TLoZ_Majora's_Mask_-_Oath_to_Order_(SPT)": 672,
"gSfxEditor_TLoZ_Majora's_Mask_-_Sonata_of_Awakening_(SPT)": 675,
"gSfxEditor_TLoZ_Majora's_Mask_-_Song_of_Double_Time_(SPT)": 676,
"gSfxEditor_TLoZ_Majora's_Mask_-_Song_of_Healing_(SPT)": 677,
"gSfxEditor_TLoZ_Majora's_Mask_-_Song_of_Inverted_Time_(SPT)": 678,
"gSfxEditor_TLoZ_Majora's_Mask_-_Song_of_Soaring_(SPT)": 679,
"gSfxEditor_The_Legend_of_Zelda_the_Windwaker_-_Wind's_Aria": 736,
"gSfxEditor_The_Lick_(Requiem_of_Spirit_Ver": {
    ")": 738
},
"gSfxEditor_Twilight_Princess_-_Learn_Skill": 749,
```

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/482597497.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/482597500.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/482597501.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/482597503.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/482597512.zip)
<!--- section:artifacts:end -->