### PR TITLE
Small improvement to sfx randomize button.

### DIFF
--- a/soh/soh/Enhancements/sfx-editor/SfxEditor.cpp
+++ b/soh/soh/Enhancements/sfx-editor/SfxEditor.cpp
@@ -297,10 +297,9 @@ void Draw_SfxTab(const std::string& tabId, const std::map<u16, std::tuple<std::s
         ImGui::SameLine();
         ImGui::PushItemWidth(-FLT_MIN);
         if (ImGui::Button(randomizeButton.c_str())) {
+            auto it = map.begin();
             while (true) {
-                auto it = map.begin();
-                std::advance(it, rand() % map.size());
-                const auto& [value, seqData] = *it;
+                const auto& [value, seqData] = *std::next(it, rand() % map.size());
                 const auto& [name, sfxKey, seqType] = seqData;
                 if (seqType & type) {
                     CVar_SetS32(cvarKey.c_str(), value);


### PR DESCRIPTION
Should result in less allocations.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/483468779.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/483468780.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/483468781.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/483468782.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/483468783.zip)
<!--- section:artifacts:end -->