### PR TITLE
Enemy Rando - Attempt at limiting Hyrule Field crashes

### DIFF
--- a/soh/src/overlays/actors/ovl_En_Encount1/z_en_encount1.c
+++ b/soh/src/overlays/actors/ovl_En_Encount1/z_en_encount1.c
@@ -239,10 +239,14 @@ void EnEncount1_SpawnStalchildOrWolfos(EnEncount1* this, PlayState* play) {
     spawnPos = this->actor.world.pos;
     // In authentic gameplay, the game checks how many Stalchildren were spawned and only spawns new ones
     // when the old ones are despawned and a timer is reached.
-    // With Enemy Randomizer on, this will keep spawning enemies solely on the timer because it's much
-    // more difficult tracking how many enemies have been spawned/killed. It's also fun. :)
-    if ((this->curNumSpawn < this->maxCurSpawns && this->totalNumSpawn < this->maxTotalSpawns) || CVar_GetS32("gRandomizedEnemies", 0)) {
-        while ((this->curNumSpawn < this->maxCurSpawns && this->totalNumSpawn < this->maxTotalSpawns) || CVar_GetS32("gRandomizedEnemies", 0)) {
+    // With Enemy Randomizer on, this will keep spawning enemies based on the timer and the total amount of existing
+    // enemies because it's much more difficult tracking how many enemies specifically spawned by this spawner have
+    // been spawned and/or killed.
+    int8_t enemyCount = play->actorCtx.actorLists[ACTORCAT_ENEMY].length;
+    if ((this->curNumSpawn < this->maxCurSpawns && this->totalNumSpawn < this->maxTotalSpawns) || 
+            (CVar_GetS32("gRandomizedEnemies", 0) && enemyCount < 15)) {
+        while ((this->curNumSpawn < this->maxCurSpawns && this->totalNumSpawn < this->maxTotalSpawns) || 
+                (CVar_GetS32("gRandomizedEnemies", 0) && enemyCount < 15)) {
             if (play->sceneNum == SCENE_SPOT00) {
                 if ((player->unk_89E == 0) || (player->actor.floorBgId != BGCHECK_SCENE) ||
                     !(player->actor.bgCheckFlags & 1) || (player->stateFlags1 & 0x08000000)) {


### PR DESCRIPTION
There's a crash that happens in Hyrule Field sometimes, and it seems to happen when there's a lot of enemies spawned in Hyrule Field. While this does not solve the root cause (which I still haven't figured out), it should make the crash much less likely to happen.

It basically limits the amount of enemies that can be in Hyrule field at once to 15 (specifically when spawned by the stalchildren spawner).

I still want to figure out the root cause and fix that eventually too, but I think it's a good idea to limit the enemy spawns in Hyrule Field this way regardless. It could get a little too ridiculous without the limit.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/484033670.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/484033671.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/484033672.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/484033673.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/484033674.zip)
<!--- section:artifacts:end -->