### PR TITLE
fix: no longer leak memory, invalidate textures properly

### DIFF
--- a/soh/soh/GbiWrap.cpp
+++ b/soh/soh/GbiWrap.cpp
@@ -85,7 +85,9 @@ extern "C" void gSPInvalidateTexCache(Gfx* pkt, uintptr_t texAddr)
     char* imgData = (char*)texAddr;
 
     if (texAddr != 0 && ResourceMgr_OTRSigCheck(imgData))
-        texAddr = (uintptr_t)ResourceMgr_LoadTexByName(imgData);
+        // Temporary solution to the mq/nonmq issue, this will be
+        // handled better with LUS 1.0 
+        texAddr = (uintptr_t)ResourceMgr_LoadTexOrDListByName(imgData);
 
     __gSPInvalidateTexCache(pkt, texAddr);
  }

--- a/soh/soh/GbiWrap.cpp
+++ b/soh/soh/GbiWrap.cpp
@@ -83,11 +83,12 @@ extern "C" void gSPVertex(Gfx* pkt, uintptr_t v, int n, int v0) {
 extern "C" void gSPInvalidateTexCache(Gfx* pkt, uintptr_t texAddr)
 {
     char* imgData = (char*)texAddr;
-
-    if (texAddr != 0 && ResourceMgr_OTRSigCheck(imgData))
+    
+    if (texAddr != 0 && ResourceMgr_OTRSigCheck(imgData)) {
         // Temporary solution to the mq/nonmq issue, this will be
-        // handled better with LUS 1.0 
-        texAddr = (uintptr_t)ResourceMgr_LoadTexOrDListByName(imgData);
+        // handled better with LUS 1.0
+        texAddr = (uintptr_t)ResourceMgr_LoadTexOrDListByName(imgData); 
+    }
 
     __gSPInvalidateTexCache(pkt, texAddr);
  }

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -724,29 +724,19 @@ extern "C" char** ResourceMgr_ListFiles(const char* searchMask, int* resultSize)
     return result;
 }
 
-std::string GetName(const char* path) {
-    std::string Path = path;
-    if (IsGameMasterQuest()) {
-        size_t pos = 0;
-        if ((pos = Path.find("/nonmq/", 0)) != std::string::npos) {
-            Path.replace(pos, 7, "/mq/");
-        }
-    }
-    return Path;
-}
-
-extern "C" const char* ResourceMgr_GetName(const char* path) {
-    auto s = new std::string(GetName(path));
-    const char* name = s->c_str();
-    return name;
-}
-
 extern "C" void ResourceMgr_LoadFile(const char* resName) {
     OTRGlobals::Instance->context->GetResourceManager()->LoadResource(resName);
 }
 
 std::shared_ptr<Ship::Resource> ResourceMgr_LoadResource(const char* path) {
-    return OTRGlobals::Instance->context->GetResourceManager()->LoadResource(ResourceMgr_GetName(path));
+    std::string Path = path;
+    if (ResourceMgr_IsGameMasterQuest()) {
+        size_t pos = 0;
+        if ((pos = Path.find("/nonmq/", 0)) != std::string::npos) {
+            Path.replace(pos, 7, "/mq/");
+        }
+    }
+    return OTRGlobals::Instance->context->GetResourceManager()->LoadResource(Path.c_str());
 }
 
 extern "C" char* ResourceMgr_LoadFileRaw(const char* resName) {
@@ -821,7 +811,14 @@ extern "C" char* ResourceMgr_LoadTexOrDListByName(const char* filePath) {
     else if (res->ResType == Ship::ResourceType::Array)
         return (char*)(std::static_pointer_cast<Ship::Array>(res))->vertices.data();
     else {
-        return ResourceMgr_LoadTexByName(ResourceMgr_GetName(filePath));
+        std::string Path = filePath;
+        if (ResourceMgr_IsGameMasterQuest()) {
+            size_t pos = 0;
+            if ((pos = Path.find("/nonmq/", 0)) != std::string::npos) {
+                Path.replace(pos, 7, "/mq/");
+            }
+        }
+        return ResourceMgr_LoadTexByName(Path.c_str());
     }
 }
 

--- a/soh/soh/OTRGlobals.h
+++ b/soh/soh/OTRGlobals.h
@@ -37,7 +37,6 @@ private:
 };
 
 uint32_t IsGameMasterQuest();
-std::string GetName(const char* path);
 #endif
 
 #ifndef __cplusplus
@@ -60,7 +59,6 @@ uint32_t ResourceMgr_GetNumGameVersions();
 uint32_t ResourceMgr_GetGameVersion(int index);
 void ResourceMgr_CacheDirectory(const char* resName);
 char** ResourceMgr_ListFiles(const char* searchMask, int* resultSize);
-const char* ResourceMgr_GetName(const char* path);
 void ResourceMgr_LoadFile(const char* resName);
 char* ResourceMgr_LoadFileFromDisk(const char* filePath);
 char* ResourceMgr_LoadJPEG(char* data, int dataSize);

--- a/soh/src/overlays/actors/ovl_Boss_Dodongo/z_boss_dodongo.c
+++ b/soh/src/overlays/actors/ovl_Boss_Dodongo/z_boss_dodongo.c
@@ -1703,10 +1703,7 @@ void BossDodongo_DrawEffects(PlayState* play) {
     Gfx_SetupDL_25Xlu(play->state.gfxCtx);
     unkMtx = &play->billboardMtxF;
 
-    // OTRTODO: This call causes the whole texture cache to be cleaned up, which causes an important slowdown on switch so we need to find a way to avoid it.
-// #if !defined(__SWITCH__) && !defined(__WIIU__)
     gSPInvalidateTexCache(POLY_XLU_DISP++, gDodongosCavernBossLavaFloorTex);
-// #endif
 
     for (i = 0; i < 80; i++, eff++) {
         FrameInterpolation_RecordOpenChild(eff, eff->epoch);

--- a/soh/src/overlays/actors/ovl_Boss_Dodongo/z_boss_dodongo.c
+++ b/soh/src/overlays/actors/ovl_Boss_Dodongo/z_boss_dodongo.c
@@ -1704,9 +1704,9 @@ void BossDodongo_DrawEffects(PlayState* play) {
     unkMtx = &play->billboardMtxF;
 
     // OTRTODO: This call causes the whole texture cache to be cleaned up, which causes an important slowdown on switch so we need to find a way to avoid it.
-#if !defined(__SWITCH__) && !defined(__WIIU__)
-    gSPInvalidateTexCache(POLY_XLU_DISP++, 0);
-#endif
+// #if !defined(__SWITCH__) && !defined(__WIIU__)
+    gSPInvalidateTexCache(POLY_XLU_DISP++, gDodongosCavernBossLavaFloorTex);
+// #endif
 
     for (i = 0; i < 80; i++, eff++) {
         FrameInterpolation_RecordOpenChild(eff, eff->epoch);

--- a/soh/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.c
+++ b/soh/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.c
@@ -1197,7 +1197,8 @@ void BossGanon_SetupTowerCutscene(BossGanon* this, PlayState* play) {
 
 void BossGanon_ShatterWindows(u8 windowShatterState) {
     s16 i;
-    // Temporary solution: using LoadTexOrDList to 
+    // Temporary solution: using LoadTexOrDList to ensure we actually have the texture available
+    // based on mq/nonmq. This will be handled properly with LUS 1.0
     u8* tex1 = ResourceMgr_LoadTexOrDListByName(SEGMENTED_TO_VIRTUAL(ganon_boss_sceneTex_006C18));
     u8* tex2 = ResourceMgr_LoadTexOrDListByName(SEGMENTED_TO_VIRTUAL(ganon_boss_sceneTex_007418));
     u8* templateTex = ResourceMgr_LoadTexByName(SEGMENTED_TO_VIRTUAL(gGanondorfWindowShatterTemplateTex));

--- a/soh/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.c
+++ b/soh/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.c
@@ -1197,8 +1197,9 @@ void BossGanon_SetupTowerCutscene(BossGanon* this, PlayState* play) {
 
 void BossGanon_ShatterWindows(u8 windowShatterState) {
     s16 i;
-    u8* tex1 = ResourceMgr_LoadTexByName(SEGMENTED_TO_VIRTUAL(ganon_boss_sceneTex_006C18));
-    u8* tex2 = ResourceMgr_LoadTexByName(SEGMENTED_TO_VIRTUAL(ganon_boss_sceneTex_007418));
+    // Temporary solution: using LoadTexOrDList to 
+    u8* tex1 = ResourceMgr_LoadTexOrDListByName(SEGMENTED_TO_VIRTUAL(ganon_boss_sceneTex_006C18));
+    u8* tex2 = ResourceMgr_LoadTexOrDListByName(SEGMENTED_TO_VIRTUAL(ganon_boss_sceneTex_007418));
     u8* templateTex = ResourceMgr_LoadTexByName(SEGMENTED_TO_VIRTUAL(gGanondorfWindowShatterTemplateTex));
 
     for (i = 0; i < 2048; i++) {

--- a/soh/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.c
+++ b/soh/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.c
@@ -1197,8 +1197,8 @@ void BossGanon_SetupTowerCutscene(BossGanon* this, PlayState* play) {
 
 void BossGanon_ShatterWindows(u8 windowShatterState) {
     s16 i;
-    u8* tex1 = ResourceMgr_LoadTexByName(SEGMENTED_TO_VIRTUAL(ResourceMgr_GetName(ganon_boss_sceneTex_006C18)));
-    u8* tex2 = ResourceMgr_LoadTexByName(SEGMENTED_TO_VIRTUAL(ResourceMgr_GetName(ganon_boss_sceneTex_007418)));
+    u8* tex1 = ResourceMgr_LoadTexByName(SEGMENTED_TO_VIRTUAL(ganon_boss_sceneTex_006C18));
+    u8* tex2 = ResourceMgr_LoadTexByName(SEGMENTED_TO_VIRTUAL(ganon_boss_sceneTex_007418));
     u8* templateTex = ResourceMgr_LoadTexByName(SEGMENTED_TO_VIRTUAL(gGanondorfWindowShatterTemplateTex));
 
     for (i = 0; i < 2048; i++) {
@@ -3820,8 +3820,8 @@ void BossGanon_Draw(Actor* thisx, PlayState* play) {
 
     // Invalidate textures if they have changed
     if (this->windowShatterState != GDF_WINDOW_SHATTER_OFF) {
-        gSPInvalidateTexCache(POLY_OPA_DISP++, ResourceMgr_GetName(ganon_boss_sceneTex_006C18));
-        gSPInvalidateTexCache(POLY_OPA_DISP++, ResourceMgr_GetName(ganon_boss_sceneTex_007418));
+        gSPInvalidateTexCache(POLY_OPA_DISP++, ganon_boss_sceneTex_006C18);
+        gSPInvalidateTexCache(POLY_OPA_DISP++, ganon_boss_sceneTex_007418);
     }
 
     Gfx_SetupDL_25Opa(play->state.gfxCtx);


### PR DESCRIPTION
* reverts https://github.com/HarbourMasters/Shipwright/pull/2072
* updates `gSPInvalidateTexCache` to use `ResourceMgr_LoadTexOrDListByName` to handle mq/nonmq texture logic
* updates ganondorf to use `ResourceMgr_LoadTexOrDListByName` to handle mq/nonmq texture logic
* updates king dodongo to only invalidate `gDodongosCavernBossLavaFloorTex` instead of everything

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/484339470.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/484339473.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/484339475.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/484339477.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/484339479.zip)
<!--- section:artifacts:end -->