### PR TITLE
Rando - Fix particle regression

### DIFF
--- a/soh/src/code/z_en_item00.c
+++ b/soh/src/code/z_en_item00.c
@@ -1339,25 +1339,26 @@ void EnItem00_CustomItemsParticles(Actor* Parent, PlayState* play, GetItemEntry 
         { 154, 154, 154 } // White Color placeholder
     };
 
-    static Vec3f velocity = { 0.0f, 0.2f, 0.0f };
-    static Vec3f accel = { 0.0f, 0.05f, 0.0f };
+    static Vec3f velocity = { 0.0f, 0.0f, 0.0f };
+    static Vec3f accel = { 0.0f, 0.0f, 0.0f };
     Color_RGBA8 primColor = { colors[color_slot][0], colors[color_slot][1], colors[color_slot][2], 0 };
     Color_RGBA8 envColor = { colors[color_slot][0], colors[color_slot][1], colors[color_slot][2], 0 };
     Vec3f pos;
 
-    velocity.y = -0.00f;
-    accel.y = -0.0f;
-    pos.x = Rand_CenteredFloat(15.0f) + Parent->world.pos.x;
-    // Shop items are rendered at a different height than the rest, so a different y offset is required
+    // Make particles more compact for shop items and use a different height offset for them.
     if (Parent->id == ACTOR_EN_GIRLA) {
+        pos.x = Rand_CenteredFloat(15.0f) + Parent->world.pos.x;
         pos.y = (Rand_ZeroOne() * 10.0f) + Parent->world.pos.y + 3;
+        pos.z = Rand_CenteredFloat(15.0f) + Parent->world.pos.z;
+        EffectSsKiraKira_SpawnFocused(play, &pos, &velocity, &accel, &primColor, &envColor, 1000, 30);
     } else {
-        pos.y = (Rand_ZeroOne() * 10.0f) + Parent->world.pos.y + 25;
+        pos.x = Rand_CenteredFloat(32.0f) + Parent->world.pos.x;
+        pos.y = (Rand_ZeroOne() * 6.0f) + Parent->world.pos.y + 25;
+        pos.z = Rand_CenteredFloat(32.0f) + Parent->world.pos.z;
+        velocity.y = -0.05f;
+        accel.y = -0.025f;
+        EffectSsKiraKira_SpawnDispersed(play, &pos, &velocity, &accel, &primColor, &envColor, 1000, 30);
     }
-    pos.z = Rand_CenteredFloat(15.0f) + Parent->world.pos.z;
-
-
-    EffectSsKiraKira_SpawnFocused(play, &pos, &velocity, &accel, &primColor, &envColor, 1000, 30);
 }
 
 /**


### PR DESCRIPTION
Sometime after Shopsanity was merged in, the particles for warp songs etc were changed to make them more compact in shops. But this change was applied to every item with particles, not just the shops.

This properly brings back the particles like they were before. One additional change to those particles was made where we shortened the lifespan from 50 to 30 to make them a little less visually agressive.

See this clip for the difference in lifespan: https://cdn.discordapp.com/attachments/982811550467387392/1054901377131876393/2022-12-21_00-20-28.mp4

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/484792362.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/484792363.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/484792365.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/484792366.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/484792367.zip)
<!--- section:artifacts:end -->