### PR TITLE
Rando - Fix ice trap particles

### DIFF
--- a/soh/soh/Enhancements/item-tables/ItemTableManager.cpp
+++ b/soh/soh/Enhancements/item-tables/ItemTableManager.cpp
@@ -23,7 +23,10 @@ bool ItemTableManager::AddItemEntry(uint16_t tableID, uint16_t getItemID, GetIte
 GetItemEntry ItemTableManager::RetrieveItemEntry(uint16_t tableID, uint16_t itemID) {
     try {
         ItemTable* itemTable = RetrieveItemTable(tableID);
-        return itemTable->at(itemID);
+        GetItemEntry getItemEntry = itemTable->at(itemID);
+        getItemEntry.drawItemId = getItemEntry.itemId;
+        getItemEntry.drawModIndex = getItemEntry.modIndex;
+        return getItemEntry;
     } catch (std::out_of_range& oor) { return GET_ITEM_NONE; }
 }
 

--- a/soh/soh/Enhancements/item-tables/ItemTableTypes.h
+++ b/soh/soh/Enhancements/item-tables/ItemTableTypes.h
@@ -52,5 +52,7 @@ typedef struct GetItemEntry {
     /* 0x0C */ uint16_t collectable; // determines whether the item can be collected on the overworld. Will be true in most cases.
     /* 0x0E */ GetItemFrom getItemFrom;
     /* 0x0F */ GetItemCategory getItemCategory; // Primarily made and used for chest size/texture matches contents
+    /* 0x10 */ uint16_t drawItemId; // Will be a copy of itemId unless the item is an ice trap. Needed for particles to function on ice traps.
+    /* 0x11 */ uint16_t drawModIndex; // Will be a copy of modIndex unless the item is an ice trap. Needed for particles to function on ice traps.
     CustomDrawFunc drawFunc;
-};                   // size = 0x0F
+}; // size = 0x11

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -2608,6 +2608,8 @@ GetItemEntry Randomizer::GetItemEntryFromRGData(RandomizerGetData rgData, GetIte
         GetItemEntry fakeGiEntry = ItemTableManager::Instance->RetrieveItemEntry(modIndex, GetItemIdFromRandomizerGet(rgData.fakeRgID, ogItemId));
         giEntry.gid = fakeGiEntry.gid;
         giEntry.gi = fakeGiEntry.gi;
+        giEntry.drawItemId = fakeGiEntry.drawItemId;
+        giEntry.drawModIndex = fakeGiEntry.drawModIndex;
         giEntry.drawFunc = fakeGiEntry.drawFunc;
     }
     return giEntry;

--- a/soh/src/code/z_en_item00.c
+++ b/soh/src/code/z_en_item00.c
@@ -1264,9 +1264,9 @@ void EnItem00_Draw(Actor* thisx, PlayState* play) {
 
 void EnItem00_CustomItemsParticles(Actor* Parent, PlayState* play, GetItemEntry giEntry) {
     s16 color_slot;
-    switch (giEntry.modIndex) {
+    switch (giEntry.drawModIndex) {
         case MOD_NONE:
-            switch (giEntry.itemId) {
+            switch (giEntry.drawItemId) {
                 case ITEM_SONG_MINUET:
                     color_slot = 0;
                     break;
@@ -1298,7 +1298,7 @@ void EnItem00_CustomItemsParticles(Actor* Parent, PlayState* play, GetItemEntry 
             }
             break;
         case MOD_RANDOMIZER:
-            switch (giEntry.itemId) {
+            switch (giEntry.drawItemId) {
                 case RG_MAGIC_SINGLE:
                 case RG_MAGIC_DOUBLE:
                 case RG_MAGIC_BEAN_PACK:
@@ -1355,7 +1355,6 @@ void EnItem00_CustomItemsParticles(Actor* Parent, PlayState* play, GetItemEntry 
         pos.y = (Rand_ZeroOne() * 10.0f) + Parent->world.pos.y + 25;
     }
     pos.z = Rand_CenteredFloat(15.0f) + Parent->world.pos.z;
-
 
     EffectSsKiraKira_SpawnFocused(play, &pos, &velocity, &accel, &primColor, &envColor, 1000, 30);
 }


### PR DESCRIPTION
Resolves https://github.com/HarbourMasters/Shipwright/issues/2037

The custom particles function uses the item ID to decide what particles to show. The problem is, when something is an ice trap, the item ID also corresponds to that ID (139).

Since the item ID is the only thing that's truly unique for each item (GI and GID is sometimes the same across multiple items), and the itemID itself is used to decide what item to grant, the only good way I could think of to achieve this was to introduce 2 more properties in GetItemEntry. I'm not super happy about introducing these 2 new properties, but I can't think of a cleaner solution.

These 2 new properties will be duplicates of the original item ID and modIndex when they aren't ice traps, and reflect the fake item's ID and modindex when it is one. This way the particles spawned will correctly be based on the fake item instead of the ice trap.

The biggest issue with the particles not showing up before is that shops can have ice traps disguised as songs, and some fake names are basically the warp song variant of the normal song or the other way around. Example: Ice trap is named Saria's Song, but is supposed to show the Minuet model, which is nearly impossible to tell apart without the particles.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/485094639.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/485094640.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/485094641.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/485094642.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/485094643.zip)
<!--- section:artifacts:end -->