### PR TITLE
Fix known Enemy Randomizer crashes

### DIFF
--- a/soh/src/code/z_actor.c
+++ b/soh/src/code/z_actor.c
@@ -3326,6 +3326,15 @@ Actor* Actor_SpawnAsChild(ActorContext* actorCtx, Actor* parent, PlayState* play
         return NULL;
     }
 
+    // The following enemies break when the parent actor isn't the same as what would happen in authentic gameplay.
+    // As such, don't assign a parent to them at all when spawned with Enemy Randomizer.
+    // Gohma (z_boss_goma.c), the Stalchildren spawner (z_en_encount1.c) and the falling platform spawning Stalfos in
+    // Forest Temple (z_bg_mori_bigst.c) that normally rely on this behaviour are changed when
+    // Enemy Rando is on so they still work properly even without assigning a parent.
+    if (CVar_GetS32("gRandomizedEnemies", 0) && (spawnedActor->id == ACTOR_EN_FLOORMAS || spawnedActor->id == ACTOR_EN_PEEHAT)) {
+        return spawnedActor;
+    }
+
     parent->child = spawnedActor;
     spawnedActor->parent = parent;
 


### PR DESCRIPTION
The comment in the code should explain what this does pretty well. 

The peahat tries to set a property of its parent which is normally a big peahat, but when spawned from anywhere else, that parent won't have that property to begin with, which leads to a crash when it dies. It only sets this property when it has a parent in the first place, so removing the parent is fine.

The floormaster tries to set its parent and child to another copy of itself when it dies and splits, which also crashes when the parent actor is already assigned/populated.

I've searched through every single instance of Actor_SpawnAsChild, and the only 3 times where it's used to spawn an enemy (that is eligible for randomization) is already handled through earlier changes I've made for Enemy Randomizer (see code comment). 

I've also tested every single enemy in-game just to make sure I didn't miss any, and it's only the small peahats and floormasters that cause a crash when spawned as a child actor.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/486321857.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/486321858.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/486321860.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/486321861.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/486321862.zip)
<!--- section:artifacts:end -->