### PR TITLE
Fix: Shopsanity not always spawning objects for items on the shelf

### DIFF
--- a/soh/src/overlays/actors/ovl_En_GirlA/z_en_girla.c
+++ b/soh/src/overlays/actors/ovl_En_GirlA/z_en_girla.c
@@ -422,10 +422,10 @@ void EnGirlA_InitItem(EnGirlA* this, PlayState* play) {
             objectId = getItemEntry.objectId;
         }
 
-        // Weird edge case here, sold out object reports as loaded for Kokiri shop but doesn't render so we force it to load here
-        if (Object_IsLoaded(&play->objectCtx, objectId) && (params != SI_SOLD_OUT && play->sceneNum == SCENE_KOKIRI_SHOP)) {
-            this->objBankIndex = Object_GetIndex(&play->objectCtx, objectId);
-        } else {
+        this->objBankIndex = Object_GetIndex(&play->objectCtx, objectId);
+
+        // If the object isn't normally spawned by the shop scene, then spawn it now
+        if (this->objBankIndex < 0) {
             this->objBankIndex = Object_Spawn(&play->objectCtx, objectId);
         }
     }


### PR DESCRIPTION
Previously a fix was added to solve the "sold out" object not spawning in the kokiri shop, meaning the `girla` actor would get killed and its item on the shelf was empty. This fix was attempting to solve an issue where the "sold out" object was reporting as "loaded" even though it wasn't. A new issue for bugs in a bottle in the kokiri shop was displaying the same object issue.

The problem was due to improper use of `Object_IsLoaded()`. We were checking if the object was loaded, and if so grabbing it's index, otherwise spawning the object. We were passing in the `objectId` into `Object_IsLoaded()`, but what should actually be passed in is an `objectBankIdx`. Most of the `objectId`'s were performing an OOB access and coincidentally reporting false (aside from sold out, and now bugs in a bottle).

Instead, I've updated the logic to fetch the object bank index based on the objectId with `Object_GetIndex()` and if its `-1` then we know we need to spawn it with `Object_Spawn()`.

Confirmed this fixes #2243 and also still loads the "sold out" object.

![image](https://user-images.githubusercontent.com/13861068/209283804-534a3001-0a48-43ff-88b4-33d58ba6e038.png)

Repro spoiler: 
[27-61-94-50-20.txt](https://github.com/HarbourMasters/Shipwright/files/10292563/27-61-94-50-20.txt)


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/487303102.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/487303103.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/487303104.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/487303105.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/487303106.zip)
<!--- section:artifacts:end -->