### PR TITLE
Enemy rando - Fix silver rupee room in GtG

### DIFF
--- a/soh/soh/Enhancements/enemyrandomizer.cpp
+++ b/soh/soh/Enhancements/enemyrandomizer.cpp
@@ -259,6 +259,10 @@ bool IsEnemyFoundToRandomize(int16_t sceneNum, int8_t roomNum, int16_t actorId, 
                 // Only randomize the initial deku scrub actor (single and triple attack), not the flower they spawn.
                 case ACTOR_EN_DEKUNUTS:
                     return (params == -256 || params == 768);
+                // Don't randomize the OoB wallmaster in the silver rupee room because it's only there to
+                // not trigger unlocking the door after killing the other wallmaster in authentic gameplay.
+                case ACTOR_EN_WALLMAS:
+                    return (!(!isMQ && sceneNum == SCENE_MEN && roomNum == 2 && posX == -2345));
                 // Only randomize initial floormaster actor (it can split and does some spawning on init).
                 case ACTOR_EN_FLOORMAS:
                     return (params == 0 || params == -32768);


### PR DESCRIPTION
Killing an enemy in the timed silver rupee room in GtG sometimes opened the door without collecting the rupees. Turns out there's an exception in the silver rupee tracker actor that for some reason uses the same flag as killing all enemies only in this room.

The authentic game has an out of bounds wallmaster in this room, which prevents the other wallmaster in this room ever triggering this flag. This PR stops the randomization of the OoB wallmaster, which kinda had to be done anyway because it falsely led to a second enemy in this room sometimes when the second enemy could make its way back in-bounds.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/487995441.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/487995442.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/487995443.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/487995445.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/487995447.zip)
<!--- section:artifacts:end -->