### PR TITLE
Fix - Enemy Randomizer wrongly set flags

### DIFF
--- a/soh/src/overlays/actors/ovl_En_Ik/z_en_ik.c
+++ b/soh/src/overlays/actors/ovl_En_Ik/z_en_ik.c
@@ -656,7 +656,9 @@ void func_80A75A38(EnIk* this, PlayState* play) {
             }
             if (this->unk_2F9 == 0) {
                 Item_DropCollectibleRandom(play, &this->actor, &this->actor.world.pos, 0xB0);
-                if (this->switchFlags != 0xFF) {
+                // Don't set flag when Iron Knuckle is spawned by Enemy Rando.
+                // Instead Iron Knuckles rely on the "clear room" flag when Enemy Rando is on.
+                if (this->switchFlags != 0xFF && !CVar_GetS32("gRandomizedEnemies",0)) {
                     Flags_SetSwitch(play, this->switchFlags);
                 }
                 Actor_Kill(&this->actor);

--- a/soh/src/overlays/actors/ovl_En_Rd/z_en_rd.c
+++ b/soh/src/overlays/actors/ovl_En_Rd/z_en_rd.c
@@ -663,7 +663,8 @@ void func_80AE3C98(EnRd* this, PlayState* play) {
 
     if (SkelAnime_Update(&this->skelAnime)) {
         if (this->unk_30C == 0) {
-            if (!Flags_GetSwitch(play, this->unk_312 & 0x7F)) {
+            // Don't set this flag in Enemy Rando as it can overlap with other objects using the same flag.
+            if (!Flags_GetSwitch(play, this->unk_312 & 0x7F) && !CVar_GetS32("gRandomizedEnemies", 0)) {
                 Flags_SetSwitch(play, this->unk_312 & 0x7F);
             }
             if (this->unk_314 != 0) {


### PR DESCRIPTION
Both redeads/gibdo's and Iron Knuckles were setting flags that overlapped with the flags already used by other objects in the game.

Notably, the web in Deku Tree would already be lit when killing an Iron Knuckle before, and killing a redead caused the "platforms dropping" cutscene when killing a redead in the central room. Spirit temple torches would be incorrectly lit, Fire Temple cracked floor would already be open before bombing it, all because of similar reasons.

Iron knuckles already were changed to use the "clear room" flag to properly despawn them in Enemy Rando, so removing this flag doesn't break anything.

I honestly couldn't even find anything in the game's code that uses this Redead flag, but they seem to work just fine in clear enemy rooms, so I'm not sure what's up with this one? Regardless, just to be safe, it's only prevented from being set in Enemy Randomizer.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/488056610.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/488056611.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/488056612.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/488056613.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/488056614.zip)
<!--- section:artifacts:end -->