### PR TITLE
fix: make fisherman rumble text work

### DIFF
--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -1757,12 +1757,13 @@ extern "C" void AudioPlayer_Play(const uint8_t* buf, uint32_t len) {
     }
 }
 
-extern "C" int Controller_ShouldRumble(size_t i) {
+extern "C" int Controller_ShouldRumble(size_t slot) {
     auto controlDeck = Ship::Window::GetInstance()->GetControlDeck();
-
-    for (int i = 0; i < controlDeck->GetNumVirtualDevices(); ++i) {
-        auto physicalDevice = controlDeck->GetPhysicalDeviceFromVirtualSlot(i);
-        if (physicalDevice->CanRumble()) {
+    
+    if (slot < controlDeck->GetNumVirtualDevices()) {
+        auto physicalDevice = controlDeck->GetPhysicalDeviceFromVirtualSlot(slot);
+        
+        if (physicalDevice->getProfile(slot)->UseRumble && physicalDevice->CanRumble()) {
             return 1;
         }
     }

--- a/soh/soh/OTRGlobals.h
+++ b/soh/soh/OTRGlobals.h
@@ -104,7 +104,7 @@ int AudioPlayer_Buffered(void);
 int AudioPlayer_GetDesiredBuffered(void);
 void AudioPlayer_Play(const uint8_t* buf, uint32_t len);
 void AudioMgr_CreateNextAudioBuffer(s16* samples, u32 num_samples);
-int Controller_ShouldRumble(size_t i);
+int Controller_ShouldRumble(size_t slot);
 void Controller_BlockGameInput();
 void Controller_UnblockGameInput();
 void Hooks_ExecuteAudioInit();

--- a/soh/src/code/padmgr.c
+++ b/soh/src/code/padmgr.c
@@ -331,7 +331,7 @@ void PadMgr_HandleRetraceMsg(PadMgr* padMgr) {
     osContGetReadData(padMgr->pads);
 
     for (i = 0; i < __osMaxControllers; i++) {
-        padMgr->padStatus[i].status = CVar_GetS32("gRumbleEnabled", 0) && Controller_ShouldRumble(i);
+        padMgr->padStatus[i].status = Controller_ShouldRumble(i);
     }
 
     if (padMgr->preNMIShutdown) {


### PR DESCRIPTION
we weren't correctly setting the pakType in padMgr because the depreciated `gRumbleEnabled` cvar was being checked

fixes https://github.com/HarbourMasters/Shipwright/issues/170

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/489542946.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/489542947.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/489542949.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/489542951.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/489542952.zip)
<!--- section:artifacts:end -->