### PR TITLE
FIX: Equip now message

### DIFF
--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -1796,11 +1796,11 @@ extern "C" int GetEquipNowMessage(char* buffer, char* src, const int maxBufferSi
     std::string postfix;
 
     if (gSaveContext.language == LANGUAGE_FRA) {
-        postfix = "\x04\x1A\x08" "Désirez-vous l'équiper maintenant?" "\x09&&"
+        postfix = "\x04\x1A\x08" "D\x96sirez-vous l'\x96quiper maintenant?" "\x09&&"
                   "\x1B%g" "Oui" "&"
                            "Non" "%w\x02";
     } else if (gSaveContext.language == LANGUAGE_GER) {
-        postfix = "\x04\x1A\x08" "Möchtest Du es jetzt ausrüsten?" "\x09&&"
+        postfix = "\x04\x1A\x08" "M""\x9A""chtest Du es jetzt ausr\x9Esten?" "\x09&&"
                   "\x1B%g" "Ja!" "&"
                            "Nein!" "%w\x02";
     } else {


### PR DESCRIPTION
Equip now message were not tested in both German and French leading them having disaply issue since the parsing of special character weren't handled on that specific function

Before:
![image](https://user-images.githubusercontent.com/47987542/209467006-01c7dbb4-04b4-48a0-ada3-db2bc4b2d862.png)
After:
![image](https://user-images.githubusercontent.com/47987542/209467008-113d88d7-3ba0-4311-af48-76cb9de4a464.png)

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/490391601.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/490391602.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/490391603.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/490391604.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/490391606.zip)
<!--- section:artifacts:end -->