### PR TITLE
RANDO: Disable Shuffle Ocarina for S6 preset

### DIFF
--- a/soh/soh/Enhancements/presets.h
+++ b/soh/soh/Enhancements/presets.h
@@ -625,6 +625,7 @@ const std::vector<PresetEntry> s6PresetEntries = {
     PRESET_ENTRY_S32("gRandomizeStartingMapsCompasses", RO_DUNGEON_ITEM_LOC_STARTWITH),
     PRESET_ENTRY_S32("gRandomizeStartingOcarina", 1),
     PRESET_ENTRY_S32("gRandomizeZorasFountain", 0),
+    PRESET_ENTRY_S32("gRandomizeShuffleOcarinas", 0),
 };
 
 const std::vector<PresetEntry> hellModePresetEntries = {


### PR DESCRIPTION
S6 don't shuffle Ocarina and the preset settings wasn't forcing that, which may result some incoherence if someone generate a run while they had the Shuffle enable before hand

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/491562802.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/491562804.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/491562806.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/491562807.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/491562809.zip)
<!--- section:artifacts:end -->