### PR TITLE
Map Select: Disable warning sound (BEL) sound by default

### DIFF
--- a/soh/include/vt.h
+++ b/soh/include/vt.h
@@ -32,4 +32,11 @@
 #define VT_RST VT_SGR("")
 #define VT_CLS VT_ED(2)
 
+#ifdef USE_BELL
+// ASCII BEL character, plays an alert tone
+#define BEL '\a'
+#else
+#define BEL '\0'
+#endif
+
 #endif

--- a/soh/src/boot/z_std_dma.c
+++ b/soh/src/boot/z_std_dma.c
@@ -168,7 +168,7 @@ void DmaMgr_Error(DmaRequest* req, const char* file, const char* errorName, cons
     char buff1[80];
     char buff2[80];
 
-    osSyncPrintf("%c", 7);
+    osSyncPrintf("%c", BEL);
     osSyncPrintf(VT_FGCOL(RED));
     osSyncPrintf("DMA致命的エラー(%s)\nROM:%X RAM:%X SIZE:%X %s\n",
                  errorDesc != NULL ? errorDesc : (errorName != NULL ? errorName : "???"), vrom, ram, size,
@@ -348,7 +348,7 @@ s32 DmaMgr_SendRequestImpl(DmaRequest* req, uintptr_t ram, uintptr_t vrom, size_
     if (1) {
         if ((sDmaMgrQueueFullLogged == 0) && (sDmaMgrMsgQueue.validCount >= sDmaMgrMsgQueue.msgCount)) {
             sDmaMgrQueueFullLogged++;
-            osSyncPrintf("%c", 7);
+            osSyncPrintf("%c", BEL);
             osSyncPrintf(VT_FGCOL(RED));
             osSyncPrintf("dmaEntryMsgQが一杯です。キューサイズの再検討をおすすめします。");
             LOG_NUM("(sizeof(dmaEntryMsgBufs) / sizeof(dmaEntryMsgBufs[0]))", ARRAY_COUNT(sDmaMgrMsgs));

--- a/soh/src/code/game.c
+++ b/soh/src/code/game.c
@@ -491,7 +491,7 @@ void GameState_Realloc(GameState* gameState, size_t size) {
     osSyncPrintf("ハイラル一時解放!!\n"); // "Hyrule temporarily released!!"
     SystemArena_GetSizes(&systemMaxFree, &systemFree, &systemAlloc);
     if ((systemMaxFree - 0x10) < size) {
-        osSyncPrintf("%c", 7);
+        osSyncPrintf("%c", BEL);
         osSyncPrintf(VT_FGCOL(RED));
 
         // "Not enough memory. Change the hyral size to the largest possible value"

--- a/soh/src/code/graph.c
+++ b/soh/src/code/graph.c
@@ -337,14 +337,14 @@ void Graph_Update(GraphicsContext* gfxCtx, GameState* gameState) {
 
         if (pool->headMagic != GFXPOOL_HEAD_MAGIC) {
             //! @bug (?) : "problem = true;" may be missing
-            osSyncPrintf("%c", 7);
+            osSyncPrintf("%c", BEL);
             // "Dynamic area head is destroyed"
             osSyncPrintf(VT_COL(RED, WHITE) "ダイナミック領域先頭が破壊されています\n" VT_RST);
             Fault_AddHungupAndCrash(__FILE__, __LINE__);
         }
         if (pool->tailMagic != GFXPOOL_TAIL_MAGIC) {
             problem = true;
-            osSyncPrintf("%c", 7);
+            osSyncPrintf("%c", BEL);
             // "Dynamic region tail is destroyed"
             osSyncPrintf(VT_COL(RED, WHITE) "ダイナミック領域末尾が破壊されています\n" VT_RST);
             Fault_AddHungupAndCrash(__FILE__, __LINE__);
@@ -353,19 +353,19 @@ void Graph_Update(GraphicsContext* gfxCtx, GameState* gameState) {
 
     if (THGA_IsCrash(&gfxCtx->polyOpa)) {
         problem = true;
-        osSyncPrintf("%c", 7);
+        osSyncPrintf("%c", BEL);
         // "Zelda 0 is dead"
         osSyncPrintf(VT_COL(RED, WHITE) "ゼルダ0は死んでしまった(graph_alloc is empty)\n" VT_RST);
     }
     if (THGA_IsCrash(&gfxCtx->polyXlu)) {
         problem = true;
-        osSyncPrintf("%c", 7);
+        osSyncPrintf("%c", BEL);
         // "Zelda 1 is dead"
         osSyncPrintf(VT_COL(RED, WHITE) "ゼルダ1は死んでしまった(graph_alloc is empty)\n" VT_RST);
     }
     if (THGA_IsCrash(&gfxCtx->overlay)) {
         problem = true;
-        osSyncPrintf("%c", 7);
+        osSyncPrintf("%c", BEL);
         // "Zelda 4 is dead"
         osSyncPrintf(VT_COL(RED, WHITE) "ゼルダ4は死んでしまった(graph_alloc is empty)\n" VT_RST);
     }

--- a/soh/src/code/irqmgr.c
+++ b/soh/src/code/irqmgr.c
@@ -116,7 +116,7 @@ void IrqMgr_CheckStack() {
     if (StackCheck_Check(NULL) == 0) {
         osSyncPrintf("スタックは大丈夫みたいです\n"); // "The stack looks ok"
     } else {
-        osSyncPrintf("%c", 7);
+        osSyncPrintf("%c", BEL);
         osSyncPrintf(VT_FGCOL(RED));
         // "Stack overflow or dangerous"
         osSyncPrintf("スタックがオーバーフローしたか危険な状態です\n");

--- a/soh/src/overlays/gamestates/ovl_select/z_select.c
+++ b/soh/src/overlays/gamestates/ovl_select/z_select.c
@@ -1295,7 +1295,7 @@ void Select_Main(GameState* thisx) {
 }
 
 void Select_Destroy(GameState* thisx) {
-    osSyncPrintf("%c", '\a'); // ASCII BEL character, plays an alert tone
+    osSyncPrintf("%c", BEL);
     // "view_cleanup will hang, so it won't be called"
     osSyncPrintf("*** view_cleanupはハングアップするので、呼ばない ***\n");
 }


### PR DESCRIPTION
Disabled by default the warning sound (BEL) in Map Select and others.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/502881046.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/502881047.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/502881048.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/502881049.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/502881050.zip)
<!--- section:artifacts:end -->