### PR TITLE
Fix: Entrance Rando Castle courtyard exit

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer_entrance.c
+++ b/soh/soh/Enhancements/randomizer/randomizer_entrance.c
@@ -198,8 +198,8 @@ s16 Entrance_OverrideNextIndex(s16 nextEntranceIndex) {
     }
 
     // Exiting through the crawl space from Hyrule Castle courtyard is the same exit as leaving Ganon's castle
-    // If we came from the Castle courtyard, then don't override the entrance to keep Link in Hyrule Castle area
-    if (gPlayState != NULL && gPlayState->sceneNum == 69 && nextEntranceIndex == 0x023D) {
+    // Don't override the entrance if we came from the Castle courtyard (day and night scenes)
+    if (gPlayState != NULL && (gPlayState->sceneNum == 69 || gPlayState->sceneNum == 70) && nextEntranceIndex == 0x023D) {
         return nextEntranceIndex;
     }
 


### PR DESCRIPTION
There is an entrance edge case where exiting the castle courtyard crawlspace uses the same entrance index as exiting ganon's castle. This would allow child link to "spoil" where ganon's castle is shuffled too.

I had a check if you were in the courtyard scene to prevent overriding that entrance, but turns out being in the courtyard at night is considered a different scene and so this check was missing that.

PR adds the other scene to the check to fix this edge case.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/494103326.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/494103327.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/494103328.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/494103329.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/494103330.zip)
<!--- section:artifacts:end -->