### PR TITLE
Fix: Entrance Rando one-way entrances preventing certain entrances from being overridden

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/fill.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/fill.cpp
@@ -295,8 +295,8 @@ std::vector<uint32_t> GetAccessibleLocations(const std::vector<uint32_t>& allowe
         if (mode == SearchMode::GeneratePlaythrough && exit.IsShuffled() && !exit.IsAddedToPool() && !noRandomEntrances) {
           entranceSphere.push_back(&exit);
           exit.AddToPool();
-          // Don't list a coupled entrance from both directions
-          if (exit.GetReplacement()->GetReverse() != nullptr && !Settings::DecoupleEntrances) {
+          // Don't list a two-way coupled entrance from both directions
+          if (exit.GetReverse() != nullptr && exit.GetReplacement()->GetReverse() != nullptr && !Settings::DecoupleEntrances) {
             exit.GetReplacement()->GetReverse()->AddToPool();
           }
         }


### PR DESCRIPTION
A bug was preventing certain entrances from being overridden and missing from the spoiler log file when decoupled was off.

This would occur when a one-way entrance was early in the entrance sphere play through order (usually child/adult spawn). When decoupled is set to off, we avoid putting in the "coupled" entrance in the sphere order. This check was not accounting for one-way entrances, so if child spawn was set to a grotto exit, then the grotto itself would be missing from the entrance override list.

This fix makes it so we exclude one-way entrances from the coupled check.

As an aside, I think it may be best to modify the spoiler log for the actual entrance override IDs to not be derived from the play through sphere, that way if there is an error with the sphere itself in the log, it doesn't break the game. I'll reference this in #2308.

Prior to this fix I had 10+ bad seeds after generating 200 seeds. With this fix I confirmed after generating 500 seeds, that everything looks as expected.

Fixes #2275

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/494175318.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/494175319.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/494175320.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/494175321.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/494175322.zip)
<!--- section:artifacts:end -->