### PR TITLE
[CI] Linux Performance Builds

### DIFF
--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -93,7 +93,17 @@ jobs:
           readme.txt
   build-linux:
     needs: extract-assets
-    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+        - os: ubuntu-20.04
+          gcc: 10
+          archive-suffix: compatibility
+        - os: ubuntu-22.04
+          gcc: 12
+          archive-suffix: performance
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
       with:
@@ -105,7 +115,7 @@ jobs:
     - name: ccache
       uses: hendrikmuhs/ccache-action@v1.2
       with:
-        key: ${{ runner.os }}-ccache
+        key: ${{ matrix.os }}-ccache
     - name: Install latest SDL
       run: |
         export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
@@ -143,12 +153,12 @@ jobs:
         mv README.md readme.txt
         mv build-cmake/*.appimage soh.appimage
       env:
-        CC: gcc-10
-        CXX: g++-10
+        CC: gcc-${{ matrix.gcc }}
+        CXX: g++-${{ matrix.gcc }}
     - name: Upload build
       uses: actions/upload-artifact@v3
       with:
-        name: soh-linux
+        name: soh-linux-${{ matrix.archive-suffix }}
         path: |
           soh.appimage
           readme.txt

--- a/README.md
+++ b/README.md
@@ -137,7 +137,10 @@ Assuming you have done everything correctly, boot up SoH and open up the SFX Edi
 Refer to the [building instructions](BUILDING.md) to compile SoH.
 
 ## Nightly Builds
-Nightly builds of Ship of Harkinian are available here: [Windows](https://nightly.link/HarbourMasters/Shipwright/workflows/generate-builds/develop/soh-windows.zip), [macOS](https://nightly.link/HarbourMasters/Shipwright/workflows/generate-builds/develop/soh-mac.zip), [Linux](https://nightly.link/HarbourMasters/Shipwright/workflows/generate-builds/develop/soh-linux.zip), [Switch](https://nightly.link/HarbourMasters/Shipwright/workflows/generate-builds/develop/soh-switch.zip), [Wii U](https://nightly.link/HarbourMasters/Shipwright/workflows/generate-builds/develop/soh-wiiu.zip)
+Nightly builds of Ship of Harkinian are available here: [Windows](https://nightly.link/HarbourMasters/Shipwright/workflows/generate-builds/develop/soh-windows.zip), [macOS](https://nightly.link/HarbourMasters/Shipwright/workflows/generate-builds/develop/soh-mac.zip), [Linux (compatibility*)](https://nightly.link/HarbourMasters/Shipwright/workflows/generate-builds/develop/soh-linux-compatiblity.zip), [Linux (performance*)](https://nightly.link/HarbourMasters/Shipwright/workflows/generate-builds/develop/soh-linux-performance.zip), [Switch](https://nightly.link/HarbourMasters/Shipwright/workflows/generate-builds/develop/soh-switch.zip), [Wii U](https://nightly.link/HarbourMasters/Shipwright/workflows/generate-builds/develop/soh-wiiu.zip)
+
+_*compatibility: compatible with most Linux distributions, but may not be as performant as the perf build._\
+_*performance: requires glibc 2.35 or newer, but will be more performant than the compat build._
 
 ## Take The Survey
 Want to use cartridge readers in tandem with the OTRGui?


### PR DESCRIPTION
Adds two variants of Linux builds:
- performance: built on 22.04 against a newer gcc and glibc
- compat: built on 20.04 with gcc10 which is compatible with more distros.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/495442104.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/495442105.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/495442106.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/495442107.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/495442109.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/495442110.zip)
<!--- section:artifacts:end -->