### PR TITLE
Update BUILDING.md

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -22,7 +22,7 @@ You can also find the v142 toolset by searching through the individual component
 While you're there, you can also install Python 3 and Git if needed.
 
 1. Clone the Ship of Harkinian repository
-(NOTE: Be sure to either clone with the ``--recursive`` flag or do ``git submodule init`` after cloning to pull in the libultraship submodule!)
+_NOTE: Be sure to either clone with the ``--recursive`` flag or do ``git submodule init`` after cloning to pull in the libultraship submodule!_
 2. Place one or more [compatible](#compatible-roms) roms in the `OTRExporter` directory with namings of your choice
 
 _Note: Instructions assume using powershell_

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -22,6 +22,7 @@ You can also find the v142 toolset by searching through the individual component
 While you're there, you can also install Python 3 and Git if needed.
 
 1. Clone the Ship of Harkinian repository
+(NOTE: Be sure to either clone with the ``--recursive`` flag or do ``git submodule init`` after cloning to pull in the libultraship submodule!)
 2. Place one or more [compatible](#compatible-roms) roms in the `OTRExporter` directory with namings of your choice
 
 _Note: Instructions assume using powershell_

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -22,7 +22,9 @@ You can also find the v142 toolset by searching through the individual component
 While you're there, you can also install Python 3 and Git if needed.
 
 1. Clone the Ship of Harkinian repository
-_NOTE: Be sure to either clone with the ``--recursive`` flag or do ``git submodule init`` after cloning to pull in the libultraship submodule!_
+
+_Note: Be sure to either clone with the ``--recursive`` flag or do ``git submodule init`` after cloning to pull in the libultraship submodule!_
+
 2. Place one or more [compatible](#compatible-roms) roms in the `OTRExporter` directory with namings of your choice
 
 _Note: Instructions assume using powershell_


### PR DESCRIPTION
Noticed that the Linux instructions for building mention pulling in LUS, but the Windows instructions do not. Added a note to pull in LUS when building for Windows.

Obviously, if it needs worded better, feel free to suggest something.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/502622160.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/502622161.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/502622162.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/502622163.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/502622164.zip)
<!--- section:artifacts:end -->