### PR TITLE
Fix: Prevent Softlocking When Leaving Ganon's Castle Without the Rainbow Bridge

### DIFF
--- a/soh/soh/Enhancements/presets.h
+++ b/soh/soh/Enhancements/presets.h
@@ -173,6 +173,7 @@ const std::vector<const char*> enhancementsCvars = {
     "gBombchuBowlingNoBigCucco",
     "gBombchuBowlingAmmunition",
     "gCreditsFix",
+    "gOGCSoftlockFix",
 };
 
 const std::vector<const char*> randomizerCvars = {

--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -757,7 +757,8 @@ namespace GameMenuBar {
                 UIWidgets::Tooltip("Fixes camera getting stuck on collision when standing still, also fixes slight shift back in camera when stop moving");
                 UIWidgets::PaddedEnhancementCheckbox("Fix Hanging Ledge Swing Rate", "gFixHangingLedgeSwingRate", true, false);
                 UIWidgets::Tooltip("Fixes camera swing rate when player falls of a ledge and camera swings around");
-
+                UIWidgets::PaddedEnhancementCheckbox("Fix OGC Respawn Softlock", "gOGCSoftlockFix", true, false);
+                UIWidgets::Tooltip("Fixes a softlock where exiting Ganon's Castle without the rainbow bridge present repeatedly respawns Link over the lava");
                 ImGui::EndMenu();
             }
 

--- a/soh/src/code/z_play.c
+++ b/soh/src/code/z_play.c
@@ -2091,6 +2091,14 @@ void Play_SetupRespawnPoint(PlayState* play, s32 respawnMode, s32 playerParams) 
     if ((play->sceneNum != SCENE_YOUSEI_IZUMI_TATE) && (play->sceneNum != SCENE_KAKUSIANA)) {
         roomIndex = play->roomCtx.curRoom.num;
         entranceIndex = gSaveContext.entranceIndex;
+
+        // OGC Respawn Softlock Fix
+        if (CVar_GetS32("gOGCSoftlockFix", 0) && !Flags_GetEventChkInf(0x4D)
+            && entranceIndex == 0x023D && LINK_IS_ADULT) {
+            player->actor.world.pos.z = 652.0f;
+            gSaveContext.entranceSpeed = 0.0f;
+        }
+
         Play_SetRespawnData(play, respawnMode, entranceIndex, roomIndex, playerParams,
                                 &player->actor.world.pos, player->actor.shape.rot.y);
     }


### PR DESCRIPTION
If the player somehow exits Ganon's Castle without first summoning the rainbow bridge, Link immediately falls into the lava below and repeatedly does so when respawning at the last entrance.

This PR adds an enhancement that moves Link backwards to spawn on the small patch of ground in front of the castle entrance instead, as well as setting the entrance speed to 0 to prevent Link automatically walking off. Normal entrance behaviour occurs once the rainbow bridge has been summoned.