### PR TITLE
Changed Text for Debug Warp Screen

### DIFF
--- a/soh/src/overlays/gamestates/ovl_select/z_select.c
+++ b/soh/src/overlays/gamestates/ovl_select/z_select.c
@@ -528,7 +528,7 @@ static BetterSceneSelectEntry sBetterScenes[] = {
     }},
     { "37:Water Temple", Select_LoadGame, 2, { 
         { "Entrance", 0x0010 },
-        { "Barinade", 0x0417 },
+        { "Morpha", 0x0417 },
     }},
     { "38:Shadow Temple", Select_LoadGame, 3, {
         { "Entrance", 0x0037 },

--- a/soh/src/overlays/gamestates/ovl_select/z_select.c
+++ b/soh/src/overlays/gamestates/ovl_select/z_select.c
@@ -540,7 +540,7 @@ static BetterSceneSelectEntry sBetterScenes[] = {
         { "From Left Hand", 0x03F0 },
         { "From Right Hand", 0x03F4 },
         { "Before Twinrova", 0x02F5 },
-        { "Naboora Fight", 0x008D },
+        { "Nabooru Fight", 0x008D },
         { "Twinrova", 0x05EC },
     }},
     { "40:Ganons Castle", Select_LoadGame, 9, {


### PR DESCRIPTION
Morpha's warp was incorrectly labeled as Barinade. This fixes that