### PR TITLE
Fix: Add missing Medigoron hint text

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/hint_list/hint_list_exclude_overworld.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/hint_list/hint_list_exclude_overworld.cpp
@@ -418,6 +418,10 @@ void HintTable_Init_Exclude_Overworld() {
                        Text{"a #carpet guru# sells", /*french*/"#un marchand du désert# vend", /*spanish*/"el #genio de una alfombra# vende"},
   });
 
+    hintTable[GC_MEDIGORON] = HintText::Exclude({
+                       //obscure text
+                       Text{"#Medigoron# sells", /*french*/"#Medigoron# vend", /*spanish*/"#Medigoron# vende"},
+  });
 
     hintTable[KAK_IMPAS_HOUSE_FREESTANDING_POH] = HintText::Exclude({
                        //obscure text


### PR DESCRIPTION
Medigoron was missing a hint text, which would cause a crash during seed generation if the medigoron item location was selected to be hinted.

This adds the missing hint. N64 rando uses "Medigoron sells", so I copied that here as well. I borrowed the translated version of "sells" from the other hints with the same format.

3ds rando fix for reference: https://github.com/gamestabled/OoT3D_Randomizer/pull/631

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/502309379.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/502309380.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/502309381.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/502309382.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/502309383.zip)
<!--- section:artifacts:end -->