### PR TITLE
Fix: Remove MQ Spirit Temple silver block for child to guarantee access to the chest

### DIFF
--- a/soh/src/overlays/actors/ovl_Obj_Oshihiki/z_obj_oshihiki.c
+++ b/soh/src/overlays/actors/ovl_Obj_Oshihiki/z_obj_oshihiki.c
@@ -275,7 +275,7 @@ void ObjOshihiki_Init(Actor* thisx, PlayState* play2) {
     // In MQ Spirit, remove the large silver block in the hole as child so the chest in the silver block hallway
     // can be guaranteed accessible
     if (gSaveContext.n64ddFlag && LINK_IS_CHILD && ResourceMgr_IsGameMasterQuest() &&
-        play->sceneNum == 6 && thisx->room == 6 && // Spirit Temple silver block hallway
+        play->sceneNum == SCENE_JYASINZOU && thisx->room == 6 && // Spirit Temple silver block hallway
         thisx->params == 0x9C7) { // Silver block that is marked as in the hole
         Actor_Kill(thisx);
         return;

--- a/soh/src/overlays/actors/ovl_Obj_Oshihiki/z_obj_oshihiki.c
+++ b/soh/src/overlays/actors/ovl_Obj_Oshihiki/z_obj_oshihiki.c
@@ -274,7 +274,8 @@ void ObjOshihiki_Init(Actor* thisx, PlayState* play2) {
 
     // In MQ Spirit, remove the large silver block in the hole as child so the chest in the silver block hallway
     // can be guaranteed accessible
-    if (gSaveContext.n64ddFlag && LINK_IS_CHILD && play->sceneNum == 6 && ResourceMgr_IsGameMasterQuest() &&
+    if (gSaveContext.n64ddFlag && LINK_IS_CHILD && ResourceMgr_IsGameMasterQuest() &&
+        play->sceneNum == 6 && thisx->room == 6 && // Spirit Temple silver block hallway
         thisx->params == 0x9C7) { // Silver block that is marked as in the hole
         Actor_Kill(thisx);
         return;

--- a/soh/src/overlays/actors/ovl_Obj_Oshihiki/z_obj_oshihiki.c
+++ b/soh/src/overlays/actors/ovl_Obj_Oshihiki/z_obj_oshihiki.c
@@ -272,6 +272,14 @@ void ObjOshihiki_Init(Actor* thisx, PlayState* play2) {
     PlayState* play = play2;
     ObjOshihiki* this = (ObjOshihiki*)thisx;
 
+    // In MQ Spirit, remove the large silver block in the hole as child so the chest in the silver block hallway
+    // can be guaranteed accessible
+    if (gSaveContext.n64ddFlag && LINK_IS_CHILD && play->sceneNum == 6 && ResourceMgr_IsGameMasterQuest() &&
+        thisx->params == 0x9C7) { // Silver block that is marked as in the hole
+        Actor_Kill(thisx);
+        return;
+    }
+
     ObjOshihiki_CheckType(this, play);
 
     if ((((this->dyna.actor.params >> 8) & 0xFF) >= 0) && (((this->dyna.actor.params >> 8) & 0xFF) <= 0x3F)) {


### PR DESCRIPTION
Normally in MQ Spirit Temple, the chest in the silver block hallway is required to be activated and opened as child prior to doing adult Spirit. The silver block in the hallway when pushed as adult will cover the hole for both ages, blocking access to the eye switch.

In rando, if someone pushes the block first as adult, they lose the ability to check that chest as the eye switch is permanently covered.

This change checks for rando/MQ Spirit/as child and will remove the silver block when its in the hole so that child always as access to this switch/chest, preventing softlocks.

Silver blocks are in pairs of two actors: one for their original starting location, and one for the "switched" or final pushed location. Only the final pushed block is removed here.

This matches the behavior in N64 rando.

Tested both rando vanilla and MQ Spirit.

### Before (with silver block covering eye in hole):
![image](https://user-images.githubusercontent.com/13861068/211417283-8fc600e4-e2b0-4b1f-8100-7c83a884e548.png)

### After (no one silver block):
![image](https://user-images.githubusercontent.com/13861068/211417301-9b65aa57-43e1-4113-94f0-7e727a240e77.png)


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/504532245.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/504532246.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/504532247.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/504532248.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/504532249.zip)
<!--- section:artifacts:end -->