### PR TITLE
Rando: Adjust locked door logic for temples and give starting keys for MQ Spirit

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -3555,9 +3555,11 @@ void DrawRandoEditor(bool& open) {
                 UIWidgets::InsertHelpHoverText(
                     "Start with - You will start with all Small Keys from all dungeons.\n"
                     "\n"
-                    "Vanilla - Small Keys will appear in their vanilla locations.\n"
+                    "Vanilla - Small Keys will appear in their vanilla locations. "
+                    "You start with 3 keys in Spirit Temple MQ because the vanilla key layout is not beatable in logic.\n"
                     "\n"
-                    "Own dungeon - Small Keys can only appear in their respective dungeon.\n"
+                    "Own dungeon - Small Keys can only appear in their respective dungeon. "
+                    "If Fire Temple is not a Master Quest dungeon, the door to the Boss Key chest will be unlocked.\n"
                     "\n"
                     "Any dungeon - Small Keys can only appear inside of any dungon.\n"
                     "\n"

--- a/soh/src/code/z_sram.c
+++ b/soh/src/code/z_sram.c
@@ -470,7 +470,7 @@ void Sram_InitSave(FileChooseContext* fileChooseCtx) {
             GiveLinkRupees(9001);
         }
 
-        if(Randomizer_GetSettingValue(RSK_KEYSANITY) == RO_DUNGEON_ITEM_LOC_STARTWITH) {
+        if (Randomizer_GetSettingValue(RSK_KEYSANITY) == RO_DUNGEON_ITEM_LOC_STARTWITH) {
             gSaveContext.inventory.dungeonKeys[SCENE_BMORI1] = FOREST_TEMPLE_SMALL_KEY_MAX; // Forest
             gSaveContext.sohStats.dungeonKeys[SCENE_BMORI1]     = FOREST_TEMPLE_SMALL_KEY_MAX; // Forest
             gSaveContext.inventory.dungeonKeys[SCENE_HIDAN] = FIRE_TEMPLE_SMALL_KEY_MAX; // Fire
@@ -487,6 +487,16 @@ void Sram_InitSave(FileChooseContext* fileChooseCtx) {
             gSaveContext.sohStats.dungeonKeys[SCENE_MEN]     = GERUDO_TRAINING_GROUNDS_SMALL_KEY_MAX; // GTG
             gSaveContext.inventory.dungeonKeys[SCENE_GANONTIKA] = GANONS_CASTLE_SMALL_KEY_MAX; // Ganon
             gSaveContext.sohStats.dungeonKeys[SCENE_GANONTIKA]     = GANONS_CASTLE_SMALL_KEY_MAX; // Ganon
+        } else if (Randomizer_GetSettingValue(RSK_KEYSANITY) == RO_DUNGEON_ITEM_LOC_VANILLA) {
+            // Logic cannot handle vanilla key layout in some dungeons
+            // this is because vanilla expects the dungeon major item to be
+            // locked behind the keys, which is not always true in rando.
+            // We can resolve this by starting with some extra keys
+            if (ResourceMgr_IsSceneMasterQuest(SCENE_JYASINZOU)) {
+                // MQ Spirit needs 3 keys
+                gSaveContext.inventory.dungeonKeys[SCENE_JYASINZOU] = 3;
+                gSaveContext.sohStats.dungeonKeys[SCENE_JYASINZOU] = 3;
+            }
         }
 
         if(Randomizer_GetSettingValue(RSK_BOSS_KEYSANITY) == RO_DUNGEON_ITEM_LOC_STARTWITH) {

--- a/soh/src/code/z_sram.c
+++ b/soh/src/code/z_sram.c
@@ -471,7 +471,6 @@ void Sram_InitSave(FileChooseContext* fileChooseCtx) {
         }
 
         if(Randomizer_GetSettingValue(RSK_KEYSANITY) == RO_DUNGEON_ITEM_LOC_STARTWITH) {
-            // TODO: If master quest there are different key counts
             gSaveContext.inventory.dungeonKeys[SCENE_BMORI1] = FOREST_TEMPLE_SMALL_KEY_MAX; // Forest
             gSaveContext.sohStats.dungeonKeys[SCENE_BMORI1]     = FOREST_TEMPLE_SMALL_KEY_MAX; // Forest
             gSaveContext.inventory.dungeonKeys[SCENE_HIDAN] = FIRE_TEMPLE_SMALL_KEY_MAX; // Fire
@@ -516,12 +515,23 @@ void Sram_InitSave(FileChooseContext* fileChooseCtx) {
         gSaveContext.infTable[20] |= 4;
 
         // Go away ruto (water temple first cutscene)
-        gSaveContext.sceneFlags[05].swch |= (1 << 0x10);
+        gSaveContext.sceneFlags[SCENE_MIZUSIN].swch |= (1 << 0x10);
 
-        // Opens locked Water Temple door to prevent softlocks
+        // Open lowest Vanilla Fire Temple locked door (to prevent key logic lockouts)
+        // Not done on keysanity since this lockout is a non issue when Fire keys can be found outside the temple
+        u8 keysanity = Randomizer_GetSettingValue(RSK_KEYSANITY) == RO_DUNGEON_ITEM_LOC_ANYWHERE ||
+                       Randomizer_GetSettingValue(RSK_KEYSANITY) == RO_DUNGEON_ITEM_LOC_OVERWORLD ||
+                       Randomizer_GetSettingValue(RSK_KEYSANITY) == RO_DUNGEON_ITEM_LOC_ANY_DUNGEON;
+        if (!ResourceMgr_IsSceneMasterQuest(SCENE_HIDAN) && !keysanity) {
+            gSaveContext.sceneFlags[SCENE_HIDAN].swch |= (1 << 0x17);
+        }
+
+        // Opens locked Water Temple door in vanilla to prevent softlocks
         // West door on the middle level that leads to the water raising thing
         // Happens in 3DS rando and N64 rando as well
-        gSaveContext.sceneFlags[05].swch |= (1 << 0x15);
+        if (!ResourceMgr_IsSceneMasterQuest(SCENE_MIZUSIN)) {
+            gSaveContext.sceneFlags[SCENE_MIZUSIN].swch |= (1 << 0x15);
+        }
 
         // Skip intro cutscene when bombing mud wall in Dodongo's cavern
         // this also makes the lower jaw render, and the eyes react to explosives

--- a/soh/src/overlays/actors/ovl_En_Door/z_en_door.c
+++ b/soh/src/overlays/actors/ovl_En_Door/z_en_door.c
@@ -159,13 +159,6 @@ void EnDoor_SetupType(EnDoor* this, PlayState* play) {
         }
         this->actor.world.rot.y = 0x0000;
         if (doorType == DOOR_LOCKED) {
-            // unlock the door behind the hammer blocks
-            // in the fire temple entryway when rando'd
-            if (gSaveContext.n64ddFlag && play->sceneNum == 4) {
-                // RANDOTODO don't do this when keysanity is enabled
-                Flags_SetSwitch(play, 0x17);
-            }
-
             if (!Flags_GetSwitch(play, this->actor.params & 0x3F)) {
                 this->lockTimer = 10;
             }


### PR DESCRIPTION
In rando, we were unlocking the locked down that blocks the boss key chest in Fire temple, however this should only happen when keysanity is not active (vanilla placement/own dungeon). There was a todo to handle this.

I moved the handling of this into rando save init rather than being in the actor file. I also placed this and the water temple locked door change within a vanilla dungeon check as these are only needed for vanilla dungeons.

I also noticed we missed a logic edge case where MQ Spirit with vanilla small keys expects to start with 3 keys as logic can't handle the vanilla key layout.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/515190141.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/515190142.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/515190143.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/515190144.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/515190145.zip)
<!--- section:artifacts:end -->