### PR TITLE
macOS: show in Launchpad Games folder

### DIFF
--- a/soh/macosx/Info.plist.in
+++ b/soh/macosx/Info.plist.in
@@ -29,6 +29,8 @@
     <string>@CMAKE_PROJECT_VERSION@</string>
     <key>NSHumanReadableCopyright</key>
     <string>Copyright 2022 HarbourMasters.</string>
+ 	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.games</string>
     <key>LSMinimumSystemVersion</key>
     <string>10.15</string>
 </dict>


### PR DESCRIPTION
https://developer.apple.com/documentation/bundleresources/information_property_list/lsapplicationcategorytype
This makes it show up in the macOS Launchpad Games folder