### PR TITLE
update soh to support LUS post liblibultraship

### DIFF
--- a/OTRExporter/CMakeLists.txt
+++ b/OTRExporter/CMakeLists.txt
@@ -81,7 +81,14 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 ################################################################################
 # Sub-projects
 ################################################################################
-if (NOT TARGET libultraship)
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    set(LUS libultraship)
+else()
+    set(LUS ultraship)
+endif()
+
+
+if (NOT TARGET "${LUS}")
     add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../libultraship ${CMAKE_BINARY_DIR}/libultraship)
 endif()
 

--- a/OTRExporter/OTRExporter/CMakeLists.txt
+++ b/OTRExporter/OTRExporter/CMakeLists.txt
@@ -236,8 +236,14 @@ endif()
 ################################################################################
 # Dependencies
 ################################################################################
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    set(LUS libultraship)
+else()
+    set(LUS ultraship)
+endif()
+
 add_dependencies(${PROJECT_NAME}
-    libultraship
+    "${LUS}"
 )
 
 # Link with other targets.

--- a/OTRGui/CMakeLists.txt
+++ b/OTRGui/CMakeLists.txt
@@ -18,7 +18,14 @@ include_directories(src)
 include_directories(src/game)
 include_directories(include)
 
-if (NOT TARGET libultraship)
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    set(LUS libultraship)
+else()
+    set(LUS ultraship)
+endif()
+
+
+if (NOT TARGET "${LUS}")
     add_subdirectory(../libultraship ${CMAKE_BINARY_DIR}/libultraship)
 endif()
 if (NOT TARGET ZAPD)

--- a/ZAPDTR/ZAPD/CMakeLists.txt
+++ b/ZAPDTR/ZAPD/CMakeLists.txt
@@ -432,10 +432,16 @@ endif()
 ################################################################################
 # Dependencies
 ################################################################################
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    set(LUS libultraship)
+else()
+    set(LUS ultraship)
+endif()
+
 add_dependencies(${PROJECT_NAME}
     OTRExporter
     ZAPDUtils
-    libultraship
+    "${LUS}"
 )
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
@@ -482,7 +488,7 @@ else()
 	set(ADDITIONAL_LIBRARY_DEPENDENCIES
 		"ZAPDUtils;"
 		-Wl,--whole-archive $<TARGET_LINKER_FILE_DIR:OTRExporter>/$<TARGET_LINKER_FILE_NAME:OTRExporter> -Wl,--no-whole-archive
-		"libultraship;"
+		"${LUS};"
 		PNG::PNG
 		${CMAKE_DL_LIBS}
 		Threads::Threads

--- a/soh/CMakeLists.txt
+++ b/soh/CMakeLists.txt
@@ -82,7 +82,14 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 ################################################################################
 # Sub-projects
 ################################################################################
-if (NOT TARGET libultraship)
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    set(LUS libultraship)
+else()
+    set(LUS ultraship)
+endif()
+
+
+if (NOT TARGET "${LUS}")
     add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../libultraship ${CMAKE_BINARY_DIR}/libultraship)
 endif()
 
@@ -2199,9 +2206,15 @@ endif()
 ################################################################################
 # Dependencies
 ################################################################################
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    set(LUS libultraship)
+else()
+    set(LUS ultraship)
+endif()
+
 add_dependencies(${PROJECT_NAME}
     ZAPDUtils
-    libultraship
+    "${LUS}"
 )
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Windows")


### PR DESCRIPTION
LUS used to build libs on linux as `liblibultraship.a`, as of https://github.com/Kenix3/libultraship/pull/92 this is no longer the case, but this causes SoH to no longer build.

This PR updates the submodule to use LUS with that change, and updates SoH to accommodate those changes

TODO:
- [ ] get this working everywhere

<!--- section:artifacts:start -->
### Build Artifacts
<!--- section:artifacts:end -->