### PR TITLE
sdl windowed fullscreen

### DIFF
--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -271,7 +271,7 @@ namespace GameMenuBar {
                     ImGui::PopStyleVar(1);
                 }
 
-                if (currentRenderingBackend.first == "sdl") {
+                if (SohImGui::supportsWindowedFullscreen()) {
                     UIWidgets::PaddedEnhancementCheckbox("Windowed fullscreen", "gSdlWindowedFullscreen", true, false);
                 }
 

--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -271,6 +271,10 @@ namespace GameMenuBar {
                     ImGui::PopStyleVar(1);
                 }
 
+                if (currentRenderingBackend.first == "sdl") {
+                    UIWidgets::PaddedEnhancementCheckbox("Windowed fullscreen", "gSdlWindowedFullscreen", true, false);
+                }
+
                 if (SohImGui::supportsViewports()) {
                     UIWidgets::PaddedEnhancementCheckbox("Allow multi-windows", "gEnableMultiViewports", true, false);
                     UIWidgets::Tooltip("Allows windows to be able to be dragged off of the main game window. Requires a reload to take effect.");


### PR DESCRIPTION
the latest version of LUS stable supports setting windowed fullscreen mode on the SDL gfx backend <https://github.com/Kenix3/libultraship/pull/73>

this PR updates the submodule to use the latest version of LUS stable and adds a checkbox for windowed fullscreen when the SDL gfx backed is being used

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/515771236.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/515771237.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/515771238.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/515771239.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/515771241.zip)
<!--- section:artifacts:end -->