### PR TITLE
Fix: Wrong entrances in Epona state handler for ER

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer_entrance.c
+++ b/soh/soh/Enhancements/randomizer/randomizer_entrance.c
@@ -433,6 +433,10 @@ void Entrance_HandleEponaState(void) {
     //If Link is riding Epona but he's about to go through an entrance where she can't spawn,
     //unset the Epona flag to avoid Master glitch, and restore temp B.
     if (Randomizer_GetSettingValue(RSK_SHUFFLE_OVERWORLD_ENTRANCES) && (player->stateFlags1 & PLAYER_STATE1_23)) {
+        // Allow Master glitch to be performed on the Thieves Hideout entrance
+        if (entrance == Entrance_GetOverride(0x0496)) { // Gerudo Fortress -> Theives Hideout
+            return;
+        }
 
         static const s16 validEponaEntrances[] = {
             0x0102, // Hyrule Field -> Lake Hylia
@@ -444,12 +448,11 @@ void Entrance_HandleEponaState(void) {
             0x0157, // Hyrule Field -> Lon Lon Ranch
             0x01F9, // Lon Lon Ranch -> Hyrule Field
             0x01FD, // Market Entrance -> Hyrule Field
-            0x00EA, // ZR Front -> Hyrule Field
-            0x0181, // LW Bridge -> Hyrule Field
+            0x0181, // ZR Front -> Hyrule Field
+            0x0185, // LW Bridge -> Hyrule Field
             0x0129, // GV Fortress Side -> Gerudo Fortress
             0x022D, // Gerudo Fortress -> GV Fortress Side
             0x03D0, // GV Carpenter Tent -> GV Fortress Side
-            0x0496, // Gerudo Fortress -> Thieves Hideout
             0x042F, // LLR Stables -> Lon Lon Ranch
             0x05D4, // LLR Tower -> Lon Lon Ranch
             0x0378, // LLR Talons House -> Lon Lon Ranch


### PR DESCRIPTION
These entrances were the wrong value:
* ZR -> HF was actually HF -> ZR
* LW -> HF was actually ZR -> HF

(more reason entrance enums need to be on my todo list 😞)

The Thieves Hideout one was pulled up higher and compares against the entrance override of that entrance. This is so the "Master glitch" can still be performed and is automatically handled if thieves hideout ever gets an entrance rando option.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/515169214.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/515169215.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/515169216.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/515169217.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/515169219.zip)
<!--- section:artifacts:end -->