### PR TITLE
fix: default cvar values before applying presets

### DIFF
--- a/soh/soh/Enhancements/presets.cpp
+++ b/soh/soh/Enhancements/presets.cpp
@@ -55,9 +55,8 @@ void DrawPresetSelector(PresetType presetTypeId) {
 
     ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(6.0f, 4.0f));
     if (ImGui::Button(("Apply Preset##" + presetTypeCvar).c_str())) {
-        if (selectedPresetId == 0) {
-            clearCvars(presetTypeDef.cvarsToClear);
-        } else {
+        clearCvars(presetTypeDef.cvarsToClear);
+        if (selectedPresetId != 0) {
             applyPreset(selectedPresetDef.entries);
         }
         SohImGui::RequestCvarSaveOnNextTick();


### PR DESCRIPTION
null

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/515539995.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/515539996.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/515539997.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/515539998.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/515540000.zip)
<!--- section:artifacts:end -->