### PR TITLE
workaround for vanilla save check tracker crash

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/item_list.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/item_list.cpp
@@ -286,6 +286,11 @@ Item& ItemFromGIID(const int giid) {
         }
         index++;
     }
+
+    // there are vanilla items that don't exist in the item table we're reading from here
+    // if we made it this far, it means we didn't find an item in the table
+    // if we don't return anything, the game will crash, so, as a workaround, return greg
+    return itemTable[GREEN_RUPEE];
 }
 
 //This function should only be used to place items containing hint text


### PR DESCRIPTION
fixes https://github.com/HarbourMasters/Shipwright/issues/2336

the true solution would be updating the tracker to fully support tracking vanilla saves, but that's way out of scope for this fix. this fixes the crash, nothing less, nothing more.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/515622097.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/515622098.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/515622099.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/515622100.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/515622101.zip)
<!--- section:artifacts:end -->