### PR TITLE
Enhancement: Adds Slider for Duration of Sequence Names on the Overlay

### DIFF
--- a/soh/soh/Enhancements/sfx-editor/SfxEditor.cpp
+++ b/soh/soh/Enhancements/sfx-editor/SfxEditor.cpp
@@ -448,6 +448,10 @@ void DrawSfxEditor(bool& open) {
                     "Displays the name of the current sequence in the corner of the screen whenever a new sequence "
                     "is loaded to the main sequence player (does not apply to fanfares or enemy BGM)."
                 );
+                ImGui::SameLine();
+                UIWidgets::EnhancementSliderInt("Overlay Duration: %d seconds", "##SeqNameOverlayDuration",
+                                                "gSeqNameOverlayDuration", 1, 10, "", 5, true);
+                ImGui::NewLine();
                 UIWidgets::PaddedSeparator();
                 UIWidgets::PaddedText("The following options are experimental and may cause music\nto sound odd or have other undesireable effects.");
                 UIWidgets::EnhancementCheckbox("Lower Octaves of Unplayable High Notes", "gExperimentalOctaveDrop");

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -1598,6 +1598,11 @@ extern "C" void Overlay_DisplayText(float duration, const char* text) {
     SohImGui::GetGameOverlay()->TextDrawNotification(duration, true, text);
 }
 
+extern "C" void Overlay_DisplayText_Seconds(int seconds, const char* text) {
+    float duration = seconds * CVarGetInteger("gInterpolationFPS", 20) * 0.05;
+    SohImGui::GetGameOverlay()->TextDrawNotification(duration, true, text);
+}
+
 extern "C" void Entrance_ClearEntranceTrackingData(void) {
     ClearEntranceTrackingData();
 }

--- a/soh/soh/OTRGlobals.h
+++ b/soh/soh/OTRGlobals.h
@@ -130,6 +130,7 @@ GetItemEntry Randomizer_GetItemFromKnownCheckWithoutObtainabilityCheck(Randomize
 ItemObtainability Randomizer_GetItemObtainabilityFromRandomizerCheck(RandomizerCheck randomizerCheck);
 int CustomMessage_RetrieveIfExists(PlayState* play);
 void Overlay_DisplayText(float duration, const char* text);
+void Overlay_DisplayText_Seconds(int seconds, const char* text);
 GetItemEntry ItemTable_Retrieve(int16_t getItemID);
 GetItemEntry ItemTable_RetrieveEntry(s16 modIndex, s16 getItemID);
 void Entrance_ClearEntranceTrackingData(void);

--- a/soh/src/code/audio_load.c
+++ b/soh/src/code/audio_load.c
@@ -615,7 +615,7 @@ s32 AudioLoad_SyncInitSeqPlayerInternal(s32 playerIdx, s32 seqId, s32 arg2) {
     if (CVarGetInteger("gSeqNameOverlay", 0) && playerIdx == SEQ_PLAYER_BGM_MAIN) {
         const char* sequenceName = SfxEditor_GetSequenceName(seqId);
         if (sequenceName != NULL) {
-            Overlay_DisplayText(5.0f, sequenceName);
+            Overlay_DisplayText_Seconds(CVarGetInteger("gSeqNameOverlayDuration", 5), sequenceName);
         }
     }
 }


### PR DESCRIPTION
Adds a Slider to the SfxEditor menu for users to configure how long they want the Sequence Name text to stay on screen. Also adds a function for displaying the text on the screen for a given number of seconds. For context, `Overlay_DisplayText` takes an obscure "duration" float, which has no clear meaning and ends up longer or shorter depending on the user's interpolated frame rate. I added `Overlay_DisplayText_Seconds` which instead takes an integer representing seconds and calculates the "duration" based on the frame rate.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/520827075.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/520827076.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/520827077.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/520827078.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/520827079.zip)
<!--- section:artifacts:end -->