### PR TITLE
fix: return enum value so mido moves away properly

### DIFF
--- a/soh/src/overlays/actors/ovl_En_Md/z_en_md.c
+++ b/soh/src/overlays/actors/ovl_En_Md/z_en_md.c
@@ -469,12 +469,12 @@ s16 func_80AAAF04(PlayState* play, Actor* thisx) {
                     break;
                 case 0x1033:
                 case 0x1067:
-                    NPC_TALK_STATE_ACTION;
+                    return NPC_TALK_STATE_ACTION;
             }
             return NPC_TALK_STATE_IDLE;
         case TEXT_STATE_EVENT:
             if (Message_ShouldAdvance(play)) {
-                NPC_TALK_STATE_ACTION;
+                return NPC_TALK_STATE_ACTION;
             }
         default:
             return NPC_TALK_STATE_TALKING;


### PR DESCRIPTION
when pulling in documentation i missed a couple returns
this was causing mido to never stop blocking the path to the deku tree
after searching the codebase, i found two instances of this mistake
this pr fixes them

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/521201146.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/521201147.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/521201148.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/521201149.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/521201150.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/521201151.zip)
<!--- section:artifacts:end -->