### PR TITLE
Clear cvars that lock up randomizer menu on boot

### DIFF
--- a/soh/soh/Enhancements/bootcommands.c
+++ b/soh/soh/Enhancements/bootcommands.c
@@ -24,7 +24,9 @@ void BootCommands_Init()
     CVarRegisterInteger("gLanguages", LANGUAGE_ENG);
     CVarRegisterInteger("gDebugWarpScreenTranslation", 1);
     CVarRegisterInteger("gInvertYAxis", 1);
+    // Clears vars to prevent randomizer menu from being disabled
     CVarSetInteger("gRandoGenerating", 0); // Clear when a crash happened during rando seed generation
+    CVarSetInteger("gOnFileSelectNameEntry", 0); // Clear when soh is killed on the file name entry page
 #if defined(__SWITCH__) || defined(__WIIU__)
     CVarRegisterInteger("gControlNav", 1); // always enable controller nav on switch/wii u
 #endif


### PR DESCRIPTION
We were already clearing the `gRandoGenerating` cvar on boot, but `gOnFileSelectNameEntry` is also used to disable the randomizer menu. This cvar can get stuck if you quit SoH while on the file create name entry menu, and don't go back to the file select screen (e.g. trying to generate a seed from the title screen)

This just clears that cvar on launch as well.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/528857994.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/528857995.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/528857996.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/528857997.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/528857998.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/528857999.zip)
<!--- section:artifacts:end -->