### PR TITLE
Fix: Chest Sizes Match Contents makes some chests unreachable

### DIFF
--- a/soh/src/overlays/actors/ovl_En_Box/z_en_box.c
+++ b/soh/src/overlays/actors/ovl_En_Box/z_en_box.c
@@ -717,6 +717,36 @@ void EnBox_UpdateSizeAndTexture(EnBox* this, PlayState* play) {
             this->boxLidDL = gChristmasGreenTreasureChestChestSideAndLidDL;
         }
     }
+
+    // Chest Sizes Match Contents can make certain chests unreachable, so nudge
+    // the ones that cause problems.
+    // https://github.com/gamestabled/OoT3D_Randomizer/blob/68cf3f190d319e554bdeebc7f16e67578430dbc3/code/src/actors/chest.c#L57
+    s16 params = this->dyna.actor.params;
+    s16 sceneNum = play->sceneNum;
+    s16 room = this->dyna.actor.room;
+    s16 isLarge = this->dyna.actor.scale.x == 0.01f;
+
+    // Make Ganon's Castle Zelda's Lullaby chest reachable when large.
+    if ((params & 0xF000) == 0x8000 && sceneNum == SCENE_GANONTIKA && room == 9) {
+        this->dyna.actor.world.pos.z = isLarge ? -962.0f : -952.0f;
+    }
+
+    // Make MQ Deku Tree Song of Time chest reachable when large.
+    if (params == 0x5AA0 && sceneNum == SCENE_YDAN && room == 5) {
+        this->dyna.actor.world.pos.x = isLarge ? -1380.0f : -1376.0f;
+    }
+
+    // Make Ganon's Castle Gold Gauntlets chest reachable with hookshot from the
+    // switch platform when small.
+    if (params == 0x36C5 && sceneNum == SCENE_GANONTIKA && room == 12) {
+        this->dyna.actor.world.pos.x = isLarge ? 1757.0f : 1777.0f;
+        this->dyna.actor.world.pos.z = isLarge ? -3595.0f : -3626.0f;
+    }
+
+    // Make Spirit Temple Compass Chest reachable with hookshot when small.
+    if (params == 0x3804 && sceneNum == SCENE_JYASINZOU && room == 14) {
+        this->dyna.actor.world.pos.x = isLarge ? 358.0f : 400.0f;
+    }
 }
 
 void EnBox_CreateExtraChestTextures() {


### PR DESCRIPTION
Same fixes that OoT3D rando employs for the following chests:
- Ganon's Castle Light Trial Lullaby chest (#1800)
- Deku Tree MQ Song of Time block chest
- Ganon's Castle vanilla Gold Gauntlets chest
- Spirit Temple vanilla Compass chest (#2313)

Namely, the this makes the former two openable when large and the latter two reachable with a Hookshot when small.

Left is without CSMC; center is current CSMC, right is this PR

Light Trial Lullaby chest:
![lightttrial](https://user-images.githubusercontent.com/20016345/215029739-4c0f3ee4-e356-406b-b389-3c0d7b824fc5.png)

Deku Tree MQ Song of Time block chest:
![dekutree](https://user-images.githubusercontent.com/20016345/215029866-5e9366f3-a903-4cf9-a964-5b9bf2661d29.png)

Shadow Trial Gaunts chest:
![shadowtrial-a](https://user-images.githubusercontent.com/20016345/215029917-fa46ea84-3046-4d67-8141-2e71a0911719.png)
![shadowtrial-b](https://user-images.githubusercontent.com/20016345/215029925-07c86594-70ae-4c65-b146-82a710b35531.png)
~~(The comment in 3Drando (and by extension this PR) says this one's reachable with "hookshot," but as far as I can tell, normal Hookshot doesn't have enough range. Can anyone confirm?)~~

Spirit Temple Compass chest:
![spirittemple-a](https://user-images.githubusercontent.com/20016345/215029948-ead5dadd-a70a-47fe-9365-ae2d3a13d4bb.png)
![spirittemple-b](https://user-images.githubusercontent.com/20016345/215029966-e8f890d9-f772-4260-ab11-6451c595df28.png)

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/529950165.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/529950166.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/529950167.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/529950168.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/529950169.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/529950170.zip)
<!--- section:artifacts:end -->