### PR TITLE
Fix: Override jail capture for the Gerudo fighter

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer_entrance.c
+++ b/soh/soh/Enhancements/randomizer/randomizer_entrance.c
@@ -659,7 +659,7 @@ void Entrance_OverrideWeatherState() {
 // Child should always be thrown in the stream when caught in the valley, and placed at the fortress entrance from valley when caught in the fortress
 void Entrance_OverrideGeurdoGuardCapture(void) {
     if (LINK_IS_CHILD) {
-        gPlayState->nextEntranceIndex = 0x1A5;
+        gPlayState->nextEntranceIndex = 0x1A5; // Geurdo Valley thrown out
     }
 
     if ((LINK_IS_CHILD || Randomizer_GetSettingValue(RSK_SHUFFLE_OVERWORLD_ENTRANCES)) &&

--- a/soh/src/overlays/actors/ovl_En_GeldB/z_en_geldb.c
+++ b/soh/src/overlays/actors/ovl_En_GeldB/z_en_geldb.c
@@ -1570,6 +1570,11 @@ void EnGeldB_Draw(Actor* thisx, PlayState* play) {
                 } else {
                     play->nextEntranceIndex = 0x3B4;
                 }
+
+                if (gSaveContext.n64ddFlag) {
+                    Entrance_OverrideGeurdoGuardCapture();
+                }
+
                 play->fadeTransition = 0x26;
                 play->sceneLoadFlag = 0x14;
             }

--- a/soh/src/overlays/actors/ovl_En_GeldB/z_en_geldb.c
+++ b/soh/src/overlays/actors/ovl_En_GeldB/z_en_geldb.c
@@ -6,6 +6,7 @@
 
 #include "z_en_geldb.h"
 #include "objects/object_geldb/object_geldb.h"
+#include "soh/Enhancements/randomizer/randomizer_entrance.h"
 
 #define FLAGS (ACTOR_FLAG_0 | ACTOR_FLAG_2 | ACTOR_FLAG_4)
 


### PR DESCRIPTION
We were already handling most of the Gerudo captures that prevents child link getting thrown in jail, but I missed the Gerudo fighter (didn't know there was a fancy spin attack move that would knock you out and throw you in jail).

This adds the same handling to the Gerudo fighter

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/530556548.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/530556549.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/530556551.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/530556552.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/530556553.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/530556554.zip)
<!--- section:artifacts:end -->