### PR TITLE
Rumble and check tracker fixes

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -115,9 +115,10 @@ void DrawCheckTracker(bool& open) {
 
     ImGui::SetNextWindowSize(ImVec2(400, 540), ImGuiCond_FirstUseEver);
 
-    if (doInitialize)
+    if (doInitialize) {
+        Teardown();
         InitializeChecks();
-    else if (initialized && (gPlayState == nullptr || gSaveContext.fileNum < 0 || gSaveContext.fileNum > 2)) {
+    } else if (initialized && (gPlayState == nullptr || gSaveContext.fileNum < 0 || gSaveContext.fileNum > 2)) {
         Teardown();
         return;
     }

--- a/soh/src/code/code_800A9F30.c
+++ b/soh/src/code/code_800A9F30.c
@@ -3,8 +3,12 @@
 UnkRumbleStruct D_80160FD0;
 
 void func_800A9F30(PadMgr* a, s32 b) {
-    func_800D2E30(&D_80160FD0);
-    PadMgr_RumbleSet(a, D_80160FD0.rumbleEnable);
+    // TODO: Workaround for rumble being too long. Implement os thread functions.
+    // Game logic runs at 20hz but input thread runs at 60 hertz, so we call this 3 times
+    for (int i = 0; i < 3; i++) {
+        func_800D2E30(&D_80160FD0);
+        PadMgr_RumbleSet(a, D_80160FD0.rumbleEnable);
+    }
 }
 
 void func_800A9F6C(f32 a, u8 b, u8 c, u8 d) {

--- a/soh/src/code/padmgr.c
+++ b/soh/src/code/padmgr.c
@@ -357,20 +357,16 @@ void PadMgr_HandleRetraceMsg(PadMgr* padMgr) {
     }
     padMgr->validCtrlrsMask = mask;
 
-    // TODO: Workaround for rumble being too long. Implement os thread functions.
-    // Game logic runs at 20hz but input thread runs at 60 hertz, so we call this 3 times
-    for (i = 0; i < 3; i++) {
-        /* if (gFaultStruct.msgId) {
-            PadMgr_RumbleStop(padMgr);
-        } else */ if (padMgr->rumbleOffFrames > 0) {
-            --padMgr->rumbleOffFrames;
-            PadMgr_RumbleStop(padMgr);
-        } else if (padMgr->rumbleOnFrames == 0) {
-            PadMgr_RumbleStop(padMgr);
-        } else if (!padMgr->preNMIShutdown) {
-            PadMgr_RumbleControl(padMgr);
-            --padMgr->rumbleOnFrames;
-        }
+    /* if (gFaultStruct.msgId) {
+        PadMgr_RumbleStop(padMgr);
+    } else */ if (padMgr->rumbleOffFrames > 0) {
+        --padMgr->rumbleOffFrames;
+        PadMgr_RumbleStop(padMgr);
+    } else if (padMgr->rumbleOnFrames == 0) {
+        PadMgr_RumbleStop(padMgr);
+    } else if (!padMgr->preNMIShutdown) {
+        PadMgr_RumbleControl(padMgr);
+        --padMgr->rumbleOnFrames;
     }
 }
 


### PR DESCRIPTION
Just some fixes for things I encountered when I did a rando the other day.

## Fixes
- It seems my rumble changes in f217b9bb973e334ffc88e37b167cfffa45b4bd3f were unintentionally undone by f712068a1, meaning that rumble is x3 too long again. I'm assuming this was done to only process inputs once per frame, but the rumble loop was not moved to the correct place. This fixes that so rumble length should be normal again.
- The rando check tracker will not clean itself up if you reload the game with the check tracker window closed which means loading the game with the check tracker open, then closing it, and loading the game again will result in check locations being duplicated. Eventually this will crash the game. To fix this I changed the check tracker to clean itself up before initializing which seems to work fine.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/532139958.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/532139959.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/532139960.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/532139961.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/532139962.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/532139963.zip)
<!--- section:artifacts:end -->