### PR TITLE
Rando: Adjust closed forest and starting age settings for edge cases

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/settings.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/settings.cpp
@@ -2965,6 +2965,13 @@ namespace Settings {
       trials[i]->SetAsRequired();
     }
 
+    // If any ER option is on that would allow you to escape forest, then we should set closed forest to closed deku
+    if (OpenForest.Is(OPENFOREST_CLOSED) &&
+        (ShuffleInteriorEntrances.Is(SHUFFLEINTERIORS_ALL) || ShuffleOverworldEntrances || ShuffleOverworldSpawns ||
+         DecoupleEntrances || MixedEntrancePools)) {
+        OpenForest.SetSelectedIndex(OPENFOREST_CLOSED_DEKU);
+    }
+
     if (StartingAge.Is(AGE_RANDOM)) {
       int choice = Random(0, 2); //50% chance of each
       if (choice == 0) {

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -3168,33 +3168,19 @@ void DrawRandoEditor(bool& open) {
 
                 //Starting Age
                 //Disabled when Forest is set to Closed or under very specific conditions
-                //RANDOTODO: Replace magic number checks with enums
-                bool disableRandoStartingAge =  (CVarGetInteger("gRandomizeLogicRules", RO_LOGIC_GLITCHLESS) == RO_LOGIC_GLITCHLESS) &&
-                ((CVarGetInteger("gRandomizeForest", RO_FOREST_CLOSED) == RO_FOREST_CLOSED) ||
-                 ((CVarGetInteger("gRandomizeDoorOfTime", RO_DOOROFTIME_CLOSED) == RO_DOOROFTIME_CLOSED) &&
-                 (CVarGetInteger("gRandomizeShuffleOcarinas", 0) == 0)));  // ocarinas not shuffled
-                    
+                bool disableRandoStartingAge = CVarGetInteger("gRandomizeForest", RO_FOREST_CLOSED) == RO_FOREST_CLOSED || 
+                    ((CVarGetInteger("gRandomizeDoorOfTime", RO_DOOROFTIME_CLOSED) == RO_DOOROFTIME_CLOSED) &&
+                    (CVarGetInteger("gRandomizeShuffleOcarinas", RO_GENERIC_OFF) == RO_GENERIC_OFF)); // closed door of time with ocarina shuffle off
+
                 static const char* disableRandoStartingAgeText = "This option is disabled due to other options making the game unbeatable.";
                 ImGui::Text(Settings::StartingAge.GetName().c_str());
                 UIWidgets::InsertHelpHoverText(
                     "Choose which age Link will start as.\n\n"
                     "Starting as adult means you start with the Master Sword in your inventory.\n"
-                    "The child option is forcefully set if it would conflict with other options."    
+                    "The child option is forcefully set if it would conflict with other options."
                 );
-               if (disableRandoStartingAge) {
-                    ImGui::PushItemFlag(ImGuiItemFlags_Disabled, true);
-                    ImGui::PushStyleVar(ImGuiStyleVar_Alpha, ImGui::GetStyle().Alpha * 0.5f);
-                }    
-                UIWidgets::EnhancementCombobox("gRandomizeStartingAge", randoStartingAge, RO_AGE_MAX, RO_AGE_CHILD);
-                if (disableRandoStartingAge) {
-                    if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
-                       ImGui::SetTooltip("%s", disableRandoStartingAgeText);
-                    }
-                    CVarSetInteger("gRandomizeStartingAge", RO_AGE_CHILD);
-                    ImGui::PopStyleVar(1);
-                    ImGui::PopItemFlag();
-                }                
-                
+                UIWidgets::EnhancementCombobox("gRandomizeStartingAge", randoStartingAge, RO_AGE_MAX, RO_AGE_CHILD, disableRandoStartingAge, disableRandoStartingAgeText, RO_AGE_CHILD);
+
                 UIWidgets::PaddedSeparator();
 
                 // Gerudo Fortress

--- a/soh/soh/UIWidgets.cpp
+++ b/soh/soh/UIWidgets.cpp
@@ -245,11 +245,17 @@ namespace UIWidgets {
         }
     }
 
-    bool EnhancementCombobox(const char* name, const char* ComboArray[], size_t arraySize, uint8_t FirstTimeValue) {
+    bool EnhancementCombobox(const char* name, const char* ComboArray[], size_t arraySize, uint8_t FirstTimeValue, bool disabled, const char* disabledTooltipText, uint8_t disabledValue) {
         bool changed = false;
         if (FirstTimeValue <= 0) {
             FirstTimeValue = 0;
         }
+
+        if (disabled) {
+            ImGui::PushItemFlag(ImGuiItemFlags_Disabled, true);
+            ImGui::PushStyleVar(ImGuiStyleVar_Alpha, ImGui::GetStyle().Alpha * 0.5f);
+        }
+
         uint8_t selected = CVarGetInteger(name, FirstTimeValue);
         uint8_t DefaultValue = selected;
         std::string comboName = std::string("##") + std::string(name);
@@ -266,6 +272,21 @@ namespace UIWidgets {
             }
             ImGui::EndCombo();
         }
+
+        if (disabled) {
+            ImGui::PopStyleVar(1);
+            if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && strcmp(disabledTooltipText, "") != 0) {
+                ImGui::SetTooltip("%s", disabledTooltipText);
+            }
+            ImGui::PopItemFlag();
+
+            if (disabledValue >= 0 && selected != disabledValue) {
+                CVarSetInteger(name, disabledValue);
+                changed = true;
+                SohImGui::RequestCvarSaveOnNextTick();
+            }
+        }
+
         return changed;
     }
 

--- a/soh/soh/UIWidgets.hpp
+++ b/soh/soh/UIWidgets.hpp
@@ -48,7 +48,7 @@ namespace UIWidgets {
     bool EnhancementCheckbox(const char* text, const char* cvarName, bool disabled = false, const char* disabledTooltipText = "", CheckboxGraphics disabledGraphic = CheckboxGraphics::Cross, bool defaultValue = false);
     bool PaddedEnhancementCheckbox(const char* text, const char* cvarName, bool padTop = true, bool padBottom = true, bool disabled = false, const char* disabledTooltipText = "", CheckboxGraphics disabledGraphic = CheckboxGraphics::Cross, bool defaultValue = false);
     void EnhancementCombo(const std::string& name, const char* cvarName, const std::vector<std::string>& items, int defaultValue = 0);
-    bool EnhancementCombobox(const char* name, const char* ComboArray[], size_t arraySize, uint8_t FirstTimeValue);
+    bool EnhancementCombobox(const char* name, const char* ComboArray[], size_t arraySize, uint8_t FirstTimeValue, bool disabled = false, const char* disabledTooltipText = "", uint8_t disabledValue = -1);
     void PaddedText(const char* text, bool padTop = true, bool padBottom = true);
     bool EnhancementSliderInt(const char* text, const char* id, const char* cvarName, int min, int max, const char* format, int defaultValue = 0, bool PlusMinusButton = false, bool disabled = false, const char* disabledTooltipText = "");
     void PaddedEnhancementSliderInt(const char* text, const char* id, const char* cvarName, int min, int max, const char* format, int defaultValue = 0, bool PlusMinusButton = false, bool padTop = true, bool padBottom = true, bool disabled = false, const char* disabledTooltipText = "");


### PR DESCRIPTION
The edge cases where starting age would get disabled was only being handled for glitchless logic. Since these settings and soft lock scenarios regard world settings, not item placement, the disabled check should happen regardless of logic setting. This was already happening on the 3ds rando side, just not in the UI for the randomizer menu.

While adjusting this, I tweaked the `EnhancementCombobox` to support being disabled directly, and allowed disabling to override the selected value.

There is also an edge case where if any entrance rando option is on that allows Link to escape the forest, then closed forest should just be set to closed deku. This happens on N64 rando. I opted to not have this be reflected in the UI. If we feel otherwise, then let me know. As it stands right now, I don't think we have a way to disable only a single option within a combo box.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/532373977.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/532373978.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/532373980.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/532373981.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/532373982.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/532373983.zip)
<!--- section:artifacts:end -->