### PR TITLE
Quick Putaway restoration enhancement

### DIFF
--- a/soh/soh/Enhancements/presets.h
+++ b/soh/soh/Enhancements/presets.h
@@ -157,6 +157,7 @@ const std::vector<const char*> enhancementsCvars = {
     "gHoverFishing",
     "gN64WeirdFrames",
     "gBombchusOOB",
+    "gQuickPutaway",
     "gGsCutscene",
     "gSkipSaveConfirmation",
     "gAutosave",
@@ -359,6 +360,8 @@ const std::vector<PresetEntry> vanillaPlusPresetEntries = {
     PRESET_ENTRY_S32("gN64WeirdFrames", 1),
     // Bombchus out of bounds
     PRESET_ENTRY_S32("gBombchusOOB", 1),
+    // Quick Putaway
+    PRESET_ENTRY_S32("gQuickPutaway", 1),
     // Skip save confirmation
     PRESET_ENTRY_S32("gSkipSaveConfirmation", 1),
 };
@@ -424,6 +427,8 @@ const std::vector<PresetEntry> enhancedPresetEntries = {
     PRESET_ENTRY_S32("gN64WeirdFrames", 1),
     // Bombchus out of bounds
     PRESET_ENTRY_S32("gBombchusOOB", 1),
+    // Quick Putaway
+    PRESET_ENTRY_S32("gQuickPutaway", 1),
     // Skip save confirmation
     PRESET_ENTRY_S32("gSkipSaveConfirmation", 1),
     // Biggoron Forge Time (0 to 3)
@@ -538,6 +543,8 @@ const std::vector<PresetEntry> randomizerPresetEntries = {
     PRESET_ENTRY_S32("gN64WeirdFrames", 1),
     // Bombchus out of bounds
     PRESET_ENTRY_S32("gBombchusOOB", 1),
+    // Quick Putaway
+    PRESET_ENTRY_S32("gQuickPutaway", 1),
     // Skip save confirmation
     PRESET_ENTRY_S32("gSkipSaveConfirmation", 1),
     // Biggoron Forge Time (0 to 3)

--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -794,6 +794,8 @@ namespace GameMenuBar {
                 UIWidgets::Tooltip("Restores N64 Weird Frames allowing weirdshots to behave the same as N64");
                 UIWidgets::PaddedEnhancementCheckbox("Bombchus out of bounds", "gBombchusOOB", true, false);
                 UIWidgets::Tooltip("Allows bombchus to explode out of bounds\nSimilar to GameCube and Wii VC");
+                UIWidgets::PaddedEnhancementCheckbox("Quick Putaway", "gQuickPutaway", true, false);
+                UIWidgets::Tooltip("Restore a bug from NTSC 1.0 that allows putting away an item without an animation and performing Putaway Ocarina Items");
                 UIWidgets::PaddedEnhancementCheckbox("Restore old Gold Skulltula cutscene", "gGsCutscene", true, false);
 
                 ImGui::EndMenu();

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -2167,7 +2167,7 @@ void func_808340DC(Player* this, PlayState* play) {
 }
 
 void func_80834298(Player* this, PlayState* play) {
-    if ((this->actor.category == ACTORCAT_PLAYER) && !(this->stateFlags1 & PLAYER_STATE1_8) &&
+    if ((this->actor.category == ACTORCAT_PLAYER) && (CVarGetInteger("gQuickPutaway", 0) || !(this->stateFlags1 & PLAYER_STATE1_8)) &&
         ((this->heldItemAction == this->itemAction) || (this->stateFlags1 & PLAYER_STATE1_22)) &&
         (gSaveContext.health != 0) && (play->csCtx.state == CS_STATE_IDLE) && (this->csMode == 0) &&
         (play->shootingGalleryStatus == 0) && (play->activeCamera == MAIN_CAM) &&


### PR DESCRIPTION
Restores the [Quick Putaway](https://www.zeldaspeedruns.com/oot/tech/quick-putaway-glitched-damage-value) glitch from OoT 1.0 as part of an enhancement. Since this can be useful for people who use glitches in the Randomizer and etc, it is enabled in  presets that enable other glitch restoration enhancements.

Edit: I've compared this to the code for OoT 1.0 and can confirm that this enhancement behaves the same way.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/532619508.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/532619509.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/532619510.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/532619511.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/532619512.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/532619513.zip)
<!--- section:artifacts:end -->