### PR TITLE
Change gPauseAnyCursor into combobox

### DIFF
--- a/soh/include/z64.h
+++ b/soh/include/z64.h
@@ -2222,6 +2222,13 @@ typedef struct {
     const char** palettes;
 } SkyboxTableEntry;
 
+typedef enum {
+    /* 0x00 */ PAUSE_ANY_CURSOR_RANDO_ONLY,
+    /* 0x01 */ PAUSE_ANY_CURSOR_ALWAYS_ON,
+    /* 0x02 */ PAUSE_ANY_CURSOR_ALWAYS_OFF,
+    /* 0x03 */ PAUSE_ANY_CURSOR_MAX
+} PauseCursorAnySlotOptions;
+
 #define ROM_FILE(name) \
     { 0, 0, #name }
 

--- a/soh/soh/Enhancements/controls/GameControlEditor.cpp
+++ b/soh/soh/Enhancements/controls/GameControlEditor.cpp
@@ -298,7 +298,7 @@ namespace GameControlEditor {
         ImGui::SetCursorPos(ImVec2(cursor.x + 5, cursor.y + 5));
         SohImGui::BeginGroupPanel("Misc Controls", ImGui::GetContentRegionAvail());
         UIWidgets::PaddedText("Allow the cursor to be on any slot");
-        static const char* cursorOnAnySlot[3] = { "Only in Rando", "Always On", "Always Off" };
+        static const char* cursorOnAnySlot[3] = { "Only in Rando", "Always", "Never" };
         UIWidgets::EnhancementCombobox("gPauseAnyCursor", cursorOnAnySlot, PAUSE_ANY_CURSOR_MAX, PAUSE_ANY_CURSOR_RANDO_ONLY);
         DrawHelpIcon("Allows the cursor on the pause menu to be over any slot. Sometimes required in rando to select "
                      "certain items.");

--- a/soh/soh/Enhancements/controls/GameControlEditor.cpp
+++ b/soh/soh/Enhancements/controls/GameControlEditor.cpp
@@ -5,6 +5,7 @@
 #include <unordered_map>
 #include <utility>
 #include <iterator>
+#include <variables.h>
 
 #include <ImGui/imgui.h>
 #include <ImGui/imgui_internal.h>
@@ -298,7 +299,7 @@ namespace GameControlEditor {
         SohImGui::BeginGroupPanel("Misc Controls", ImGui::GetContentRegionAvail());
         UIWidgets::PaddedText("Allow the cursor to be on any slot");
         static const char* cursorOnAnySlot[3] = { "Only in Rando", "Always On", "Always Off" };
-        UIWidgets::EnhancementCombobox("gPauseAnyCursor", cursorOnAnySlot, 3, 0);
+        UIWidgets::EnhancementCombobox("gPauseAnyCursor", cursorOnAnySlot, PAUSE_ANY_CURSOR_MAX, PAUSE_ANY_CURSOR_RANDO_ONLY);
         DrawHelpIcon("Allows the cursor on the pause menu to be over any slot. Sometimes required in rando to select "
                      "certain items.");
         UIWidgets::Spacer(0);

--- a/soh/soh/Enhancements/controls/GameControlEditor.cpp
+++ b/soh/soh/Enhancements/controls/GameControlEditor.cpp
@@ -296,6 +296,12 @@ namespace GameControlEditor {
         ImVec2 cursor = ImGui::GetCursorPos();
         ImGui::SetCursorPos(ImVec2(cursor.x + 5, cursor.y + 5));
         SohImGui::BeginGroupPanel("Misc Controls", ImGui::GetContentRegionAvail());
+        UIWidgets::PaddedText("Allow the cursor to be on any slot");
+        static const char* cursorOnAnySlot[3] = { "Only in Rando", "Always On", "Always Off" };
+        UIWidgets::EnhancementCombobox("gPauseAnyCursor", cursorOnAnySlot, 3, 0);
+        DrawHelpIcon("Allows the cursor on the pause menu to be over any slot. Sometimes required in rando to select "
+                     "certain items.");
+        UIWidgets::Spacer(0);
         UIWidgets::PaddedEnhancementCheckbox("Enable walk speed modifiers", "gEnableWalkModify", true, false);
         DrawHelpIcon("Hold the assigned button to change the maximum walking speed\nTo change the assigned button, go into the Ports tabs above");
          if (CVarGetInteger("gEnableWalkModify", 0)) {
@@ -307,8 +313,6 @@ namespace GameControlEditor {
             SohImGui::EndGroupPanel();
         }
         UIWidgets::Spacer(0);
-        UIWidgets::PaddedEnhancementCheckbox("Allow the cursor to be on any slot", "gPauseAnyCursor");
-        DrawHelpIcon("Allows the cursor on the pause menu to be over any slot\nSimilar to Rando and Spaceworld 97");
         UIWidgets::PaddedEnhancementCheckbox("Answer Navi Prompt with L Button", "gNaviOnL");
         DrawHelpIcon("Speak to Navi with L but enter first-person camera with C-Up");
         SohImGui::EndGroupPanel();

--- a/soh/soh/Enhancements/presets.h
+++ b/soh/soh/Enhancements/presets.h
@@ -592,8 +592,6 @@ const std::vector<PresetEntry> randomizerPresetEntries = {
 
     // Autosave
     PRESET_ENTRY_S32("gAutosave", 1),
-    // Allow the cursor to be on any slot
-    PRESET_ENTRY_S32("gPauseAnyCursor", 1),
 
     // Customize Fishing Behaviour
     PRESET_ENTRY_S32("gCustomizeFishing", 1),

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_equipment.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_equipment.c
@@ -177,8 +177,8 @@ void KaleidoScope_DrawEquipment(PlayState* play) {
     s16 cursorY;
     s16 oldCursorPoint;
     bool dpad = (CVarGetInteger("gDpadPause", 0) && !CHECK_BTN_ALL(input->cur.button, BTN_CUP));
-    bool pauseAnyCursor = (CVarGetInteger("gPauseAnyCursor", 0) == 0 && gSaveContext.n64ddFlag) ||
-                          (CVarGetInteger("gPauseAnyCursor", 0) == 1);
+    bool pauseAnyCursor = (CVarGetInteger("gPauseAnyCursor", 0) == PAUSE_ANY_CURSOR_RANDO_ONLY && gSaveContext.n64ddFlag) ||
+                          (CVarGetInteger("gPauseAnyCursor", 0) == PAUSE_ANY_CURSOR_ALWAYS_ON);
 
     OPEN_DISPS(play->state.gfxCtx);
 

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_equipment.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_equipment.c
@@ -177,6 +177,8 @@ void KaleidoScope_DrawEquipment(PlayState* play) {
     s16 cursorY;
     s16 oldCursorPoint;
     bool dpad = (CVarGetInteger("gDpadPause", 0) && !CHECK_BTN_ALL(input->cur.button, BTN_CUP));
+    bool pauseAnyCursor = (CVarGetInteger("gPauseAnyCursor", 0) == 0 && gSaveContext.n64ddFlag) ||
+                          (CVarGetInteger("gPauseAnyCursor", 0) == 1);
 
     OPEN_DISPS(play->state.gfxCtx);
 
@@ -226,7 +228,7 @@ void KaleidoScope_DrawEquipment(PlayState* play) {
                                     cursorMoveResult = 1;
                                 }
                             }
-                        } else if ((gBitFlags[pauseCtx->cursorPoint[PAUSE_EQUIP] - 1] & gSaveContext.inventory.equipment) || CVarGetInteger("gPauseAnyCursor", 0)) {
+                        } else if ((gBitFlags[pauseCtx->cursorPoint[PAUSE_EQUIP] - 1] & gSaveContext.inventory.equipment) || pauseAnyCursor) {
                             cursorMoveResult = 2;
                         }
                     } else {
@@ -260,7 +262,7 @@ void KaleidoScope_DrawEquipment(PlayState* play) {
                             if (CUR_UPG_VALUE(pauseCtx->cursorY[PAUSE_EQUIP]) != 0) {
                                 cursorMoveResult = 1;
                             }
-                        } else if ((gBitFlags[pauseCtx->cursorPoint[PAUSE_EQUIP] - 1] & gSaveContext.inventory.equipment) || CVarGetInteger("gPauseAnyCursor", 0)) {
+                        } else if ((gBitFlags[pauseCtx->cursorPoint[PAUSE_EQUIP] - 1] & gSaveContext.inventory.equipment) || pauseAnyCursor) {
                                 cursorMoveResult = 2;
                         }
                     } else {
@@ -311,7 +313,7 @@ void KaleidoScope_DrawEquipment(PlayState* play) {
                                 cursorMoveResult = 1;
                             }
                         } else if ((gBitFlags[pauseCtx->cursorPoint[PAUSE_EQUIP] - 1] &
-                                   gSaveContext.inventory.equipment) || CVarGetInteger("gPauseAnyCursor", 0)) {
+                                   gSaveContext.inventory.equipment) || pauseAnyCursor) {
                             cursorMoveResult = 2;
                         }
                     } else {
@@ -329,7 +331,7 @@ void KaleidoScope_DrawEquipment(PlayState* play) {
                                 cursorMoveResult = 1;
                             }
                         } else if ((gBitFlags[pauseCtx->cursorPoint[PAUSE_EQUIP] - 1] &
-                                   gSaveContext.inventory.equipment) || CVarGetInteger("gPauseAnyCursor", 0)) {
+                                   gSaveContext.inventory.equipment) || pauseAnyCursor) {
                             cursorMoveResult = 2;
                         }
                     } else {

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_item.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_item.c
@@ -101,8 +101,8 @@ void KaleidoScope_DrawItemSelect(PlayState* play) {
     s16 oldCursorPoint;
     s16 moveCursorResult;
     bool dpad = (CVarGetInteger("gDpadPause", 0) && !CHECK_BTN_ALL(input->cur.button, BTN_CUP));
-    bool pauseAnyCursor = (CVarGetInteger("gPauseAnyCursor", 0) == 0 && gSaveContext.n64ddFlag) ||
-                          (CVarGetInteger("gPauseAnyCursor", 0) == 1);
+    bool pauseAnyCursor = (CVarGetInteger("gPauseAnyCursor", 0) == PAUSE_ANY_CURSOR_RANDO_ONLY && gSaveContext.n64ddFlag) ||
+                          (CVarGetInteger("gPauseAnyCursor", 0) == PAUSE_ANY_CURSOR_ALWAYS_ON);
 
     OPEN_DISPS(play->state.gfxCtx);
 

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_item.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_item.c
@@ -101,6 +101,8 @@ void KaleidoScope_DrawItemSelect(PlayState* play) {
     s16 oldCursorPoint;
     s16 moveCursorResult;
     bool dpad = (CVarGetInteger("gDpadPause", 0) && !CHECK_BTN_ALL(input->cur.button, BTN_CUP));
+    bool pauseAnyCursor = (CVarGetInteger("gPauseAnyCursor", 0) == 0 && gSaveContext.n64ddFlag) ||
+                          (CVarGetInteger("gPauseAnyCursor", 0) == 1);
 
     OPEN_DISPS(play->state.gfxCtx);
 
@@ -142,7 +144,7 @@ void KaleidoScope_DrawItemSelect(PlayState* play) {
                             pauseCtx->cursorX[PAUSE_ITEM] -= 1;
                             pauseCtx->cursorPoint[PAUSE_ITEM] -= 1;
                             if ((gSaveContext.inventory.items[pauseCtx->cursorPoint[PAUSE_ITEM]] != ITEM_NONE) ||
-                                CVarGetInteger("gPauseAnyCursor", 0)) {
+                                pauseAnyCursor) {
                                 moveCursorResult = 1;
                             }
                         } else {
@@ -174,7 +176,7 @@ void KaleidoScope_DrawItemSelect(PlayState* play) {
                             pauseCtx->cursorX[PAUSE_ITEM] += 1;
                             pauseCtx->cursorPoint[PAUSE_ITEM] += 1;
                             if ((gSaveContext.inventory.items[pauseCtx->cursorPoint[PAUSE_ITEM]] != ITEM_NONE) ||
-                                CVarGetInteger("gPauseAnyCursor", 0)) {
+                                pauseAnyCursor) {
                                 moveCursorResult = 1;
                             }
                         } else {
@@ -296,7 +298,7 @@ void KaleidoScope_DrawItemSelect(PlayState* play) {
                                 pauseCtx->cursorY[PAUSE_ITEM] -= 1;
                                 pauseCtx->cursorPoint[PAUSE_ITEM] -= 6;
                                 if ((gSaveContext.inventory.items[pauseCtx->cursorPoint[PAUSE_ITEM]] != ITEM_NONE) ||
-                                    CVarGetInteger("gPauseAnyCursor", 0)) {
+                                    pauseAnyCursor) {
                                     moveCursorResult = 1;
                                 }
                             } else {
@@ -310,7 +312,7 @@ void KaleidoScope_DrawItemSelect(PlayState* play) {
                                 pauseCtx->cursorY[PAUSE_ITEM] += 1;
                                 pauseCtx->cursorPoint[PAUSE_ITEM] += 6;
                                 if ((gSaveContext.inventory.items[pauseCtx->cursorPoint[PAUSE_ITEM]] != ITEM_NONE) ||
-                                    CVarGetInteger("gPauseAnyCursor", 0)) {
+                                    pauseAnyCursor) {
                                     moveCursorResult = 1;
                                 }
                             } else {

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
@@ -1912,7 +1912,9 @@ void KaleidoScope_DrawInfoPanel(PlayState* play) {
                 }
             }
         } else {
-            if (!pauseCtx->pageIndex && (!CVarGetInteger("gPauseAnyCursor", 0) || (gSaveContext.inventory.items[pauseCtx->cursorPoint[PAUSE_ITEM]] != ITEM_NONE))) { // pageIndex == PAUSE_ITEM
+            bool pauseAnyCursor = (CVarGetInteger("gPauseAnyCursor", 0) == 0 && gSaveContext.n64ddFlag) ||
+                                  (CVarGetInteger("gPauseAnyCursor", 0) == 1);
+            if (!pauseCtx->pageIndex && (!pauseAnyCursor || (gSaveContext.inventory.items[pauseCtx->cursorPoint[PAUSE_ITEM]] != ITEM_NONE))) { // pageIndex == PAUSE_ITEM
                 pauseCtx->infoPanelVtx[16].v.ob[0] = pauseCtx->infoPanelVtx[18].v.ob[0] =
                     WREG(49 + gSaveContext.language);
 
@@ -2048,6 +2050,8 @@ void KaleidoScope_DrawInfoPanel(PlayState* play) {
 void KaleidoScope_UpdateNamePanel(PlayState* play) {
     PauseContext* pauseCtx = &play->pauseCtx;
     u16 sp2A;
+    bool pauseAnyCursor = (CVarGetInteger("gPauseAnyCursor", 0) == 0 && gSaveContext.n64ddFlag) ||
+                          (CVarGetInteger("gPauseAnyCursor", 0) == 1);
 
     if ((pauseCtx->namedItem != pauseCtx->cursorItem[pauseCtx->pageIndex]) ||
         ((pauseCtx->pageIndex == PAUSE_MAP) && (pauseCtx->cursorSpecialPos != 0))) {
@@ -2057,7 +2061,7 @@ void KaleidoScope_UpdateNamePanel(PlayState* play) {
 
         osCreateMesgQueue(&pauseCtx->loadQueue, &pauseCtx->loadMsg, 1);
 
-        if (CVarGetInteger("gPauseAnyCursor", 0) &&
+        if (pauseAnyCursor &&
         ((pauseCtx->pageIndex == PAUSE_EQUIP && pauseCtx->cursorX[PAUSE_EQUIP] != 0 && !CHECK_OWNED_EQUIP(pauseCtx->cursorY[PAUSE_EQUIP], pauseCtx->cursorX[PAUSE_EQUIP] - 1)) ||
         (pauseCtx->pageIndex == PAUSE_ITEM && gSaveContext.inventory.items[pauseCtx->cursorPoint[PAUSE_ITEM]] == ITEM_NONE))) {
             pauseCtx->namedItem = PAUSE_ITEM_NONE;

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
@@ -1912,8 +1912,9 @@ void KaleidoScope_DrawInfoPanel(PlayState* play) {
                 }
             }
         } else {
-            bool pauseAnyCursor = (CVarGetInteger("gPauseAnyCursor", 0) == 0 && gSaveContext.n64ddFlag) ||
-                                  (CVarGetInteger("gPauseAnyCursor", 0) == 1);
+            bool pauseAnyCursor =
+                (CVarGetInteger("gPauseAnyCursor", 0) == PAUSE_ANY_CURSOR_RANDO_ONLY && gSaveContext.n64ddFlag) ||
+                (CVarGetInteger("gPauseAnyCursor", 0) == PAUSE_ANY_CURSOR_ALWAYS_ON);
             if (!pauseCtx->pageIndex && (!pauseAnyCursor || (gSaveContext.inventory.items[pauseCtx->cursorPoint[PAUSE_ITEM]] != ITEM_NONE))) { // pageIndex == PAUSE_ITEM
                 pauseCtx->infoPanelVtx[16].v.ob[0] = pauseCtx->infoPanelVtx[18].v.ob[0] =
                     WREG(49 + gSaveContext.language);
@@ -2050,8 +2051,8 @@ void KaleidoScope_DrawInfoPanel(PlayState* play) {
 void KaleidoScope_UpdateNamePanel(PlayState* play) {
     PauseContext* pauseCtx = &play->pauseCtx;
     u16 sp2A;
-    bool pauseAnyCursor = (CVarGetInteger("gPauseAnyCursor", 0) == 0 && gSaveContext.n64ddFlag) ||
-                          (CVarGetInteger("gPauseAnyCursor", 0) == 1);
+    bool pauseAnyCursor = (CVarGetInteger("gPauseAnyCursor", 0) == PAUSE_ANY_CURSOR_RANDO_ONLY && gSaveContext.n64ddFlag) ||
+                          (CVarGetInteger("gPauseAnyCursor", 0) == PAUSE_ANY_CURSOR_ALWAYS_ON);
 
     if ((pauseCtx->namedItem != pauseCtx->cursorItem[pauseCtx->pageIndex]) ||
         ((pauseCtx->pageIndex == PAUSE_MAP) && (pauseCtx->cursorSpecialPos != 0))) {


### PR DESCRIPTION
Previously this enhancement was a checkbox which toggled it on and off. We kept it optional even in rando because it has applications for equip swapping which we didn't want to lose. But there's many players that don't see this option when playing rando, making them feel stuck because they can't select and equip certain items (even though it was included in the randomizer preset before).

This PR changes the checkbox into a combobox, where the new default is "Only in Rando", while keeping the option to entirely disable it or always enable it.

![image](https://user-images.githubusercontent.com/4244591/215487423-21cdf09f-f629-4f16-af48-3c86cdc4226b.png)
![image](https://user-images.githubusercontent.com/4244591/215487484-359bc62a-49e8-4817-8b77-395c5cb34545.png)


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/534533811.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/534533812.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/534533813.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/534533814.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/534533816.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/534533817.zip)
<!--- section:artifacts:end -->