### PR TITLE
Fix: GI overruling Link's size

### DIFF
--- a/soh/soh/Enhancements/game-interactor/GameInteractionEffect.cpp
+++ b/soh/soh/Enhancements/game-interactor/GameInteractionEffect.cpp
@@ -233,7 +233,7 @@ namespace GameInteractionEffect {
         GameInteractor::State::LinkSize = (GILinkSize)parameter;
     }
     void ModifyLinkSize::_Remove() {
-        GameInteractor::State::LinkSize = GI_LINK_SIZE_NORMAL;
+        GameInteractor::State::LinkSize = GI_LINK_SIZE_RESET;
     }
 
     // MARK: - InvisibleLink

--- a/soh/soh/Enhancements/game-interactor/GameInteractor.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor.h
@@ -10,6 +10,7 @@ typedef enum {
     /* 0x01 */ GI_LINK_SIZE_GIANT,
     /* 0x02 */ GI_LINK_SIZE_MINISH,
     /* 0x03 */ GI_LINK_SIZE_PAPER,
+    /* 0x04 */ GI_LINK_SIZE_RESET
 } GILinkSize;
 
 typedef enum {
@@ -22,9 +23,9 @@ typedef enum {
 extern "C" {
 #endif
 uint8_t GameInteractor_NoUIActive();
-GILinkSize GameInteractor_LinkSize();
+GILinkSize GameInteractor_GetLinkSize();
+void GameInteractor_SetLinkSize(GILinkSize size);
 uint8_t GameInteractor_InvisibleLinkActive();
-uint8_t GameInteractor_ResetLinkScale();
 uint8_t GameInteractor_OneHitKOActive();
 uint8_t GameInteractor_PacifistModeActive();
 uint8_t GameInteractor_DisableZTargetingActive();

--- a/soh/soh/Enhancements/game-interactor/GameInteractor_State.cpp
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor_State.cpp
@@ -27,8 +27,13 @@ uint8_t GameInteractor_NoUIActive() {
 }
 
 // MARK: - GameInteractor::State::LinkSize
-GILinkSize GameInteractor_LinkSize() {
+GILinkSize GameInteractor_GetLinkSize() {
     return GameInteractor::State::LinkSize;
+}
+
+// MARK: - GameInteractor::State::LinkSize
+void GameInteractor_SetLinkSize(GILinkSize size) {
+    GameInteractor::State::LinkSize = size;
 }
 
 // MARK: - GameInteractor::State::InvisibleLinkActive

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -10995,7 +10995,13 @@ void Player_Update(Actor* thisx, PlayState* play) {
     MREG(54) = this->actor.world.pos.z;
     MREG(55) = this->actor.world.rot.y;
 
-    switch (GameInteractor_LinkSize()) {
+    switch (GameInteractor_GetLinkSize()) {
+        case GI_LINK_SIZE_RESET:
+            this->actor.scale.x = 0.01f;
+            this->actor.scale.y = 0.01f;
+            this->actor.scale.z = 0.01f;
+            GameInteractor_SetLinkSize(GI_LINK_SIZE_NORMAL);
+            break;
         case GI_LINK_SIZE_GIANT:
             this->actor.scale.x = 0.02f;
             this->actor.scale.y = 0.02f;
@@ -11013,9 +11019,6 @@ void Player_Update(Actor* thisx, PlayState* play) {
             break;
         case GI_LINK_SIZE_NORMAL:
         default:
-            this->actor.scale.x = 0.01f;
-            this->actor.scale.y = 0.01f;
-            this->actor.scale.z = 0.01f;
             break;
     }
 


### PR DESCRIPTION
Before, Link's size was handled through multiple different variables, where one was specifically used to reset Link's size before unsetting itself.

The GI rework made it so one variable handled all sizes and essentially removed the reset state, but this also meant that if the size was "normal" it would always try and set Link to his regular size. This meant that the body size slider in the Cosmetics Editor no longer did anything, because it would be immediately overruled by the GI code afterwards.

This re-introduces the same concept where the "reset" state is used to set Link's size down to normal only once so other code can still change Link's size when it's supposed to be "normal". 

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/534565981.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/534565982.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/534565983.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/534565984.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/534565985.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/534565988.zip)
<!--- section:artifacts:end -->