### PR TITLE
Entrance tracker tweaks

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer_entrance_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_entrance_tracker.cpp
@@ -850,7 +850,13 @@ void DrawEntranceTracker(bool& open) {
                     uint32_t color = isDiscovered ? IM_COL32_WHITE : COLOR_GRAY;
 
                     // Handle highlighting and auto scroll
-                    if (LinkIsInArea(original) != -1) {
+                    if (original->index == lastEntranceIndex ||
+                        (override->reverseIndex == lastEntranceIndex && OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_DECOUPLED_ENTRANCES) == RO_GENERIC_OFF) &&
+                            CVarGetInteger("gEntranceTrackerHighlightPrevious", 0)) {
+                                 color = COLOR_ORANGE;
+                    } else if (LinkIsInArea(original) != -1) {
+                        printf("Last: %d; Original: %d,%d; Override: %d,%d", lastEntranceIndex, original->index,
+                               original->reverseIndex, override->index, override->reverseIndex);
                         if (CVarGetInteger("gEntranceTrackerHighlightAvailable", 0)) {
                             color = COLOR_GREEN;
                         }
@@ -860,10 +866,6 @@ void DrawEntranceTracker(bool& open) {
                             if (CVarGetInteger("gEntranceTrackerAutoScroll", 0)) {
                                 ImGui::SetScrollHereY(0.0f);
                             }
-                        }
-                    } else if (original->index == lastEntranceIndex) {
-                        if (CVarGetInteger("gEntranceTrackerHighlightPrevious", 0)) {
-                            color = COLOR_ORANGE;
                         }
                     }
 

--- a/soh/soh/Enhancements/randomizer/randomizer_entrance_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_entrance_tracker.cpp
@@ -855,8 +855,6 @@ void DrawEntranceTracker(bool& open) {
                             CVarGetInteger("gEntranceTrackerHighlightPrevious", 0)) {
                                  color = COLOR_ORANGE;
                     } else if (LinkIsInArea(original) != -1) {
-                        printf("Last: %d; Original: %d,%d; Override: %d,%d", lastEntranceIndex, original->index,
-                               original->reverseIndex, override->index, override->reverseIndex);
                         if (CVarGetInteger("gEntranceTrackerHighlightAvailable", 0)) {
                             color = COLOR_GREEN;
                         }

--- a/soh/soh/Enhancements/randomizer/randomizer_entrance_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_entrance_tracker.cpp
@@ -688,7 +688,11 @@ void DrawEntranceTracker(bool& open) {
                 UIWidgets::PaddedEnhancementCheckbox("Show \"From\"", "gEntranceTrackerShowFrom", true, false);
                 UIWidgets::Tooltip("Reveal the \"From\" entrance for undiscovered entrances");
                 UIWidgets::Spacer(2.0f);
-                UIWidgets::PaddedEnhancementCheckbox("Show redundant entrances", "gEntranceTrackerShowRedundantEntrances", true, false);
+                bool disableHideReverseEntrances = OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_DECOUPLED_ENTRANCES) == RO_GENERIC_ON;
+                static const char* disableHideReverseEntrancesText = "This option is disabled because \"Decouple Entrances\" is enabled.";
+                UIWidgets::EnhancementCheckbox("Hide reverse", "gEntranceTrackerHideReverseEntrances",
+                                              disableHideReverseEntrances, disableHideReverseEntrancesText);                
+                UIWidgets::Tooltip("Hide reverse entrance transitions when Decouple Entrances is off");
 
                 ImGui::EndTable();
             }
@@ -786,7 +790,7 @@ void DrawEntranceTracker(bool& open) {
             // However, if entrances are decoupled, then all transitions need to be displayed, so we proceed with the filtering
             if ((original->type == ENTRANCE_TYPE_DUNGEON || original->type == ENTRANCE_TYPE_GROTTO || original->type == ENTRANCE_TYPE_INTERIOR) &&
                 (original->oneExit != 1 && OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_DECOUPLED_ENTRANCES) == RO_GENERIC_OFF) &&
-                CVarGetInteger("gEntranceTrackerShowRedundantEntrances", 0) == 0) {
+                CVarGetInteger("gEntranceTrackerHideReverseEntrances", 1) == 1) {
                     continue;
             }
 

--- a/soh/soh/Enhancements/randomizer/randomizer_entrance_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_entrance_tracker.cpp
@@ -676,6 +676,7 @@ void DrawEntranceTracker(bool& open) {
                 UIWidgets::PaddedEnhancementCheckbox("Hide reverse", "gEntranceTrackerHideReverseEntrances", true, false,
                                               disableHideReverseEntrances, disableHideReverseEntrancesText, UIWidgets::CheckboxGraphics::Cross, true);
                 UIWidgets::Tooltip("Hide reverse entrance transitions when Decouple Entrances is off");
+                UIWidgets::Spacer(0);
 
                 ImGui::TableNextColumn();
 

--- a/soh/soh/Enhancements/randomizer/randomizer_entrance_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_entrance_tracker.cpp
@@ -831,6 +831,10 @@ void DrawEntranceTracker(bool& open) {
                     const EntranceData* original = GetEntranceData(entrance.index);
                     const EntranceData* override = GetEntranceData(entrance.override);
 
+                    if (original->type == ENTRANCE_TYPE_DUNGEON || original->type == ENTRANCE_TYPE_GROTTO || original->type == ENTRANCE_TYPE_INTERIOR)
+                        if (original->oneExit != 1 && OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_DECOUPLED_ENTRANCES) == RO_GENERIC_OFF)
+                            continue;
+
                     bool isDiscovered = IsEntranceDiscovered(entrance.index);
 
                     bool showOriginal = (!destToggle ? CVarGetInteger("gEntranceTrackerShowTo", 0) : CVarGetInteger("gEntranceTrackerShowFrom", 0)) || isDiscovered;

--- a/soh/soh/Enhancements/randomizer/randomizer_entrance_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_entrance_tracker.cpp
@@ -669,8 +669,13 @@ void DrawEntranceTracker(bool& open) {
                 UIWidgets::Tooltip("Highlight the previous entrance that Link came from");
                 UIWidgets::PaddedEnhancementCheckbox("Highlight available", "gEntranceTrackerHighlightAvailable", true, false);
                 UIWidgets::Tooltip("Highlight available entrances in the current scene");
-                UIWidgets::PaddedEnhancementCheckbox("Hide undiscovered", "gEntranceTrackerCollapseUndiscovered", true, true);
+                UIWidgets::PaddedEnhancementCheckbox("Hide undiscovered", "gEntranceTrackerCollapseUndiscovered", true, false);
                 UIWidgets::Tooltip("Collapse undiscovered entrances towards the bottom of each group");
+                bool disableHideReverseEntrances = OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_DECOUPLED_ENTRANCES) == RO_GENERIC_ON;
+                static const char* disableHideReverseEntrancesText = "This option is disabled because \"Decouple Entrances\" is enabled.";
+                UIWidgets::PaddedEnhancementCheckbox("Hide reverse", "gEntranceTrackerHideReverseEntrances", true, true,
+                                              disableHideReverseEntrances, disableHideReverseEntrancesText, UIWidgets::CheckboxGraphics::Cross, false);                
+                UIWidgets::Tooltip("Hide reverse entrance transitions when Decouple Entrances is off");
 
                 ImGui::TableNextColumn();
 
@@ -687,12 +692,6 @@ void DrawEntranceTracker(bool& open) {
                 UIWidgets::Tooltip("Reveal the \"To\" entrance for undiscovered entrances");
                 UIWidgets::PaddedEnhancementCheckbox("Show \"From\"", "gEntranceTrackerShowFrom", true, false);
                 UIWidgets::Tooltip("Reveal the \"From\" entrance for undiscovered entrances");
-                UIWidgets::Spacer(2.0f);
-                bool disableHideReverseEntrances = OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_DECOUPLED_ENTRANCES) == RO_GENERIC_ON;
-                static const char* disableHideReverseEntrancesText = "This option is disabled because \"Decouple Entrances\" is enabled.";
-                UIWidgets::EnhancementCheckbox("Hide reverse", "gEntranceTrackerHideReverseEntrances",
-                                              disableHideReverseEntrances, disableHideReverseEntrancesText);                
-                UIWidgets::Tooltip("Hide reverse entrance transitions when Decouple Entrances is off");
 
                 ImGui::EndTable();
             }

--- a/soh/soh/Enhancements/randomizer/randomizer_entrance_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_entrance_tracker.cpp
@@ -786,7 +786,8 @@ void DrawEntranceTracker(bool& open) {
             const EntranceData* override = GetEntranceData(entrance.override);
 
             // If entrance is a dungeon, grotto, or interior entrance, the transition into that area has oneExit set, which means we can filter the return transitions as redundant
-            // if entrances are not decoupled, as this is redundant information. Also, allows for If all of these conditions are met, we skip adding this entrance to any lists.
+            // if entrances are not decoupled, as this is redundant information. Also checks a setting, enabled by default, for hiding them.
+            // If all of these conditions are met, we skip adding this entrance to any lists.
             // However, if entrances are decoupled, then all transitions need to be displayed, so we proceed with the filtering
             if ((original->type == ENTRANCE_TYPE_DUNGEON || original->type == ENTRANCE_TYPE_GROTTO || original->type == ENTRANCE_TYPE_INTERIOR) &&
                 (original->oneExit != 1 && OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_DECOUPLED_ENTRANCES) == RO_GENERIC_OFF) &&

--- a/soh/soh/Enhancements/randomizer/randomizer_entrance_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_entrance_tracker.cpp
@@ -673,8 +673,8 @@ void DrawEntranceTracker(bool& open) {
                 UIWidgets::Tooltip("Collapse undiscovered entrances towards the bottom of each group");
                 bool disableHideReverseEntrances = OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_DECOUPLED_ENTRANCES) == RO_GENERIC_ON;
                 static const char* disableHideReverseEntrancesText = "This option is disabled because \"Decouple Entrances\" is enabled.";
-                UIWidgets::PaddedEnhancementCheckbox("Hide reverse", "gEntranceTrackerHideReverseEntrances", true, true,
-                                              disableHideReverseEntrances, disableHideReverseEntrancesText, UIWidgets::CheckboxGraphics::Cross, false);                
+                UIWidgets::PaddedEnhancementCheckbox("Hide reverse", "gEntranceTrackerHideReverseEntrances", true, false,
+                                              disableHideReverseEntrances, disableHideReverseEntrancesText, UIWidgets::CheckboxGraphics::Cross, true);
                 UIWidgets::Tooltip("Hide reverse entrance transitions when Decouple Entrances is off");
 
                 ImGui::TableNextColumn();


### PR DESCRIPTION
Hides return entrance transitions for grotto, interior, and dungeon types when "Decouple entrances" is off.

Also highlights the inverse of the last entrance when checking for "Highlight last entrance" if the actual last entrance is hidden on the tracker due to the first part of this pull request, if Decouple is off, and checks for this first to allow for highlighting "last entrance" in an area Link is currently in.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/561206585.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/561206586.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/561206587.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/561206588.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/561206589.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/561206591.zip)
<!--- section:artifacts:end -->