### PR TITLE
Link's models reflect the projectile weapon he's holding (Bow/Slingshot)

### DIFF
--- a/soh/include/functions.h
+++ b/soh/include/functions.h
@@ -1120,6 +1120,8 @@ s32 Player_HasMirrorShieldEquipped(PlayState* play);
 s32 Player_HasMirrorShieldSetToDraw(PlayState* play);
 s32 Player_ActionToMagicSpell(Player* player, s32 actionParam);
 s32 Player_HoldsHookshot(Player* player);
+s32 Player_HoldsBow(Player* player);
+s32 Player_HoldsSlingshot(Player* player);
 s32 func_8008F128(Player* player);
 s32 Player_ActionToSword(s32 actionParam);
 s32 Player_GetSwordHeld(Player* player);

--- a/soh/src/code/z_player_lib.c
+++ b/soh/src/code/z_player_lib.c
@@ -1093,31 +1093,26 @@ s32 func_800902F0(PlayState* play, s32 limbIndex, Gfx** dList, Vec3f* pos, Vec3s
         } else if (limbIndex == PLAYER_LIMB_L_FOREARM) {
             *dList = sArmOutDLs[gSaveContext.linkAge];
         } else if (limbIndex == PLAYER_LIMB_L_HAND) {
-            *dList = sHandOutDLs[gSaveContext.linkAge];
-
-            if(CVarGetInteger("gBowSlingShotAmmoFix", 0)){
-                if (Player_HoldsSlingshot(this)) {
-                    *dList = NULL;
-                } else if (LINK_IS_ADULT && (Player_HoldsBow(this) || Player_HoldsSlingshot(this))) {
-                    *dList = gLinkAdultRightHandOutNearDL;
-                }
+            s32 handOutDlIndex = gSaveContext.linkAge;
+            if (CVarGetInteger("gBowSlingShotAmmoFix", 0) && LINK_IS_ADULT && Player_HoldsSlingshot(this)) {
+                handOutDlIndex = 1;
             }
+            *dList = sHandOutDLs[handOutDlIndex];
         } else if (limbIndex == PLAYER_LIMB_R_SHOULDER) {
             *dList = sRightShoulderNearDLs[gSaveContext.linkAge];
         } else if (limbIndex == PLAYER_LIMB_R_FOREARM) {
             *dList = D_80125F30[gSaveContext.linkAge];
         } else if (limbIndex == PLAYER_LIMB_R_HAND) {
-            *dList = sHoldingFirstPersonWeaponDLs[gSaveContext.linkAge];
-
-            if (Player_HoldsHookshot(this)) {
-                *dList = gLinkAdultRightHandHoldingHookshotFarDL;
-            } else if (CVarGetInteger("gBowSlingShotAmmoFix", 0)) {
-                if(Player_HoldsBow(this)) {
-                    *dList = gLinkAdultRightHandHoldingBowFirstPersonDL;
+            s32 firstPersonWeaponIndex = gSaveContext.linkAge;
+            if (CVarGetInteger("gBowSlingShotAmmoFix", 0)) {
+                if (Player_HoldsBow(this)) {
+                    firstPersonWeaponIndex = 0;
                 } else if (Player_HoldsSlingshot(this)) {
-                    *dList = gLinkChildRightArmStretchedSlingshotDL;
+                    firstPersonWeaponIndex = 1;
                 }
             }
+            *dList = Player_HoldsHookshot(this) ? gLinkAdultRightHandHoldingHookshotFarDL
+                                                                       : sHoldingFirstPersonWeaponDLs[firstPersonWeaponIndex];
         } else {
             *dList = NULL;
         }

--- a/soh/src/code/z_player_lib.c
+++ b/soh/src/code/z_player_lib.c
@@ -1112,7 +1112,7 @@ s32 func_800902F0(PlayState* play, s32 limbIndex, Gfx** dList, Vec3f* pos, Vec3s
                 }
             }
             *dList = Player_HoldsHookshot(this) ? gLinkAdultRightHandHoldingHookshotFarDL
-                                                                       : sHoldingFirstPersonWeaponDLs[firstPersonWeaponIndex];
+                                                : sHoldingFirstPersonWeaponDLs[firstPersonWeaponIndex];
         } else {
             *dList = NULL;
         }

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -4916,9 +4916,13 @@ s32 func_8083AD4C(PlayState* play, Player* this) {
 
     if (this->unk_6AD == 2) {
         if (func_8002DD6C(this)) {
-            cameraMode = this->heldItemAction == PLAYER_IA_SLINGSHOT 
-                ? CAM_MODE_SLINGSHOT
-                : CAM_MODE_BOWARROW;
+            bool shouldUseBowCamera = LINK_IS_ADULT;
+
+            if(CVarGetInteger("gBowSlingShotAmmoFix", 0)){
+                shouldUseBowCamera = this->heldItemAction != PLAYER_IA_SLINGSHOT;
+            }
+            
+            cameraMode = shouldUseBowCamera ? CAM_MODE_BOWARROW : CAM_MODE_SLINGSHOT;
         } else {
             cameraMode = CAM_MODE_BOOMERANG;
         }

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -4916,11 +4916,9 @@ s32 func_8083AD4C(PlayState* play, Player* this) {
 
     if (this->unk_6AD == 2) {
         if (func_8002DD6C(this)) {
-            if (LINK_IS_ADULT) {
-                cameraMode = CAM_MODE_BOWARROW;
-            } else {
-                cameraMode = CAM_MODE_SLINGSHOT;
-            }
+            cameraMode = this->heldItemAction == PLAYER_IA_SLINGSHOT 
+                ? CAM_MODE_SLINGSHOT
+                : CAM_MODE_BOWARROW;
         } else {
             cameraMode = CAM_MODE_BOOMERANG;
         }


### PR DESCRIPTION
_*Part of an old PR I posted months ago. Figured a smaller PR per each 'feature' would be better for code review._

This makes Link hold the correct item in 1st & 3rd-person views.

While this works fine standalone, probably doesn't make sense to merge without [fixing the ammo type first (Link to PR)](https://github.com/HarbourMasters/Shipwright/pull/2453)

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/556658338.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/556658339.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/556658340.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/556658341.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/556658342.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/556658343.zip)
<!--- section:artifacts:end -->