### PR TITLE
hintless altar text

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/fill.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/fill.cpp
@@ -1079,9 +1079,7 @@ int Fill() {
       }
       //Always execute ganon hint generation for the funny line  
       CreateGanonText();
-      if (AltarHintText) {
-        CreateAltarText();
-      }
+      CreateAltarText(AltarHintText);
       if (DampeHintText) {
         CreateDampesDiaryText();
       }

--- a/soh/soh/Enhancements/randomizer/3drando/hints.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/hints.cpp
@@ -678,37 +678,45 @@ static Text BuildGanonBossKeyText() {
   return Text()+"$b"+ganonBossKeyText+"^";
 }
 
-void CreateAltarText() {
+void CreateAltarText(Option withHints) {
 
   //Child Altar Text
-  childAltarText = Hint(SPIRITUAL_STONE_TEXT_START).GetText()+"^"+
-  //Spiritual Stones
-      (StartingKokiriEmerald.Value<uint8_t>() ? Text{ "##", "##", "##" }
-                                              : BuildDungeonRewardText(KOKIRI_EMERALD)) +
-      (StartingGoronRuby.Value<uint8_t>() ? Text{ "##", "##", "##" }
-                                          : BuildDungeonRewardText(GORON_RUBY)) +
-      (StartingZoraSapphire.Value<uint8_t>() ? Text{ "##", "##", "##" }
-                                             : BuildDungeonRewardText(ZORA_SAPPHIRE)) +
-  //How to open Door of Time, the event trigger is necessary to read the altar multiple times
-  BuildDoorOfTimeText();
+  if (withHints) {
+    childAltarText = Hint(SPIRITUAL_STONE_TEXT_START).GetText()+"^"+
+    //Spiritual Stones
+        (StartingKokiriEmerald.Value<uint8_t>() ? Text{ "##", "##", "##" }
+                                                : BuildDungeonRewardText(KOKIRI_EMERALD)) +
+        (StartingGoronRuby.Value<uint8_t>() ? Text{ "##", "##", "##" }
+                                            : BuildDungeonRewardText(GORON_RUBY)) +
+        (StartingZoraSapphire.Value<uint8_t>() ? Text{ "##", "##", "##" }
+                                              : BuildDungeonRewardText(ZORA_SAPPHIRE)) +
+    //How to open Door of Time, the event trigger is necessary to read the altar multiple times
+    BuildDoorOfTimeText();
+  } else {
+    childAltarText = BuildDoorOfTimeText();
+  }
+
   CreateMessageFromTextObject(0x7040, 0, 2, 3, AddColorsAndFormat(childAltarText, {QM_GREEN, QM_RED, QM_BLUE}));
 
   //Adult Altar Text
-  adultAltarText = Hint(ADULT_ALTAR_TEXT_START).GetText()+"^"+
-  //Medallion Areas
-      (StartingLightMedallion.Value<uint8_t>() ? Text{ "##", "##", "##" }
-                                               : BuildDungeonRewardText(LIGHT_MEDALLION)) +
-      (StartingForestMedallion.Value<uint8_t>() ? Text{ "##", "##", "##" }
-                                                : BuildDungeonRewardText(FOREST_MEDALLION)) +
-      (StartingFireMedallion.Value<uint8_t>() ? Text{ "##", "##", "##" }
-                                              : BuildDungeonRewardText(FIRE_MEDALLION)) +
-      (StartingWaterMedallion.Value<uint8_t>() ? Text{ "##", "##", "##" }
-                                               : BuildDungeonRewardText(WATER_MEDALLION)) +
-      (StartingSpiritMedallion.Value<uint8_t>() ? Text{ "##", "##", "##" }
-                                                : BuildDungeonRewardText(SPIRIT_MEDALLION)) +
-      (StartingShadowMedallion.Value<uint8_t>() ? Text{ "##", "##", "##" }
-                                                : BuildDungeonRewardText(SHADOW_MEDALLION)) +
-
+  adultAltarText = Hint(ADULT_ALTAR_TEXT_START).GetText() + "^";
+  if (withHints) {
+    adultAltarText = adultAltarText +
+    //Medallion Areas
+        (StartingLightMedallion.Value<uint8_t>() ? Text{ "##", "##", "##" }
+                                                : BuildDungeonRewardText(LIGHT_MEDALLION)) +
+        (StartingForestMedallion.Value<uint8_t>() ? Text{ "##", "##", "##" }
+                                                  : BuildDungeonRewardText(FOREST_MEDALLION)) +
+        (StartingFireMedallion.Value<uint8_t>() ? Text{ "##", "##", "##" }
+                                                : BuildDungeonRewardText(FIRE_MEDALLION)) +
+        (StartingWaterMedallion.Value<uint8_t>() ? Text{ "##", "##", "##" }
+                                                : BuildDungeonRewardText(WATER_MEDALLION)) +
+        (StartingSpiritMedallion.Value<uint8_t>() ? Text{ "##", "##", "##" }
+                                                  : BuildDungeonRewardText(SPIRIT_MEDALLION)) +
+        (StartingShadowMedallion.Value<uint8_t>() ? Text{ "##", "##", "##" }
+                                                  : BuildDungeonRewardText(SHADOW_MEDALLION));
+  }
+  adultAltarText = adultAltarText + 
   //Bridge requirement
   BuildBridgeReqsText()+
 

--- a/soh/soh/Enhancements/randomizer/3drando/hints.hpp
+++ b/soh/soh/Enhancements/randomizer/3drando/hints.hpp
@@ -223,7 +223,7 @@ extern void CreateMerchantsHints();
 extern void CreateWarpSongTexts();
 extern void CreateDampesDiaryText();
 extern void CreateGanonText();
-extern void CreateAltarText();
+extern void CreateAltarText(Option withHints);
 
 Text& GetChildAltarText();
 Text& GetAdultAltarText();

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -1570,7 +1570,7 @@ extern "C" int CustomMessage_RetrieveIfExists(PlayState* play) {
                 Randomizer_GetCheckFromActor(stone->id, play->sceneNum, actorParams);
 
             messageEntry = CustomMessageManager::Instance->RetrieveMessage(Randomizer::hintMessageTableID, hintCheck);
-        } else if ((textId == TEXT_ALTAR_CHILD || textId == TEXT_ALTAR_ADULT) && Randomizer_GetSettingValue(RSK_TOT_ALTAR_HINT)) {
+        } else if ((textId == TEXT_ALTAR_CHILD || textId == TEXT_ALTAR_ADULT)) {
             // rando hints at altar
             messageEntry = (LINK_IS_ADULT)
                ? CustomMessageManager::Instance->RetrieveMessage(Randomizer::hintMessageTableID, TEXT_ALTAR_ADULT)


### PR DESCRIPTION
The old logic for turning off altar text hints would just try using the vanilla altar text in rando when that setting was enabled. This was causing a softlock when reading the altar as child https://github.com/HarbourMasters/Shipwright/issues/2451

When investigating this, I decided the ideal solution would be to *always* show custom altar text, but not show the hints when the hint setting is off.

This means that even with altar hints off, checking the altar as child will still display the door of time requirements, and checking the altar as adult will still show the rainbow bridge and ganon's boss key requirements

I implemented this by updating the `CreateAltarText` method to take in a `withHints` param.

technical note: I would have liked to do some nicer looking string manip stuff here, but the 3drando `Text`/`HintText` objects are a little fussy (they don't like `+=`)

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/552957150.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/552957152.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/552957153.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/552957154.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/552957155.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/552957156.zip)
<!--- section:artifacts:end -->