### PR TITLE
Fix: Hyrule Field bridge entrance and sun song placing link out of bounds in Entrance Rando

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer_entrance.c
+++ b/soh/soh/Enhancements/randomizer/randomizer_entrance.c
@@ -271,7 +271,8 @@ s16 Entrance_OverrideNextIndex(s16 nextEntranceIndex) {
 
     // Exiting through the crawl space from Hyrule Castle courtyard is the same exit as leaving Ganon's castle
     // Don't override the entrance if we came from the Castle courtyard (day and night scenes)
-    if (gPlayState != NULL && (gPlayState->sceneNum == 69 || gPlayState->sceneNum == 70) && nextEntranceIndex == 0x023D) {
+    if (gPlayState != NULL && (gPlayState->sceneNum == SCENE_HAIRAL_NIWA || gPlayState->sceneNum == SCENE_HAIRAL_NIWA_N) &&
+        nextEntranceIndex == 0x023D) {
         return nextEntranceIndex;
     }
 
@@ -289,7 +290,7 @@ s16 Entrance_OverrideDynamicExit(s16 dynamicExitIndex) {
 u32 Entrance_SceneAndSpawnAre(u8 scene, u8 spawn) {
     s16 computedEntranceIndex;
 
-    // Adjust the entrance to acount for the exact scene/spawn combination for child/adult and day/night
+    // Adjust the entrance to account for the exact scene/spawn combination for child/adult and day/night
     if (!IS_DAY) {
         if (!LINK_IS_ADULT) {
             computedEntranceIndex = gSaveContext.entranceIndex + 1;
@@ -680,7 +681,7 @@ void Entrance_OverrideSpawnScene(s32 sceneNum, s32 spawn) {
 
     if (Randomizer_GetSettingValue(RSK_SHUFFLE_DUNGEON_ENTRANCES) == RO_DUNGEON_ENTRANCE_SHUFFLE_ON_PLUS_GANON) {
         // Move Hyrule's Castle Courtyard exit spawn to be before the crates so players don't skip Talon
-        if (sceneNum == 95 && spawn == 1) {
+        if (sceneNum == SCENE_SPOT15 && spawn == 1) {
             modifiedLinkActorEntry.pos.x = 0x033A;
             modifiedLinkActorEntry.pos.y = 0x0623;
             modifiedLinkActorEntry.pos.z = 0xFF22;
@@ -689,7 +690,7 @@ void Entrance_OverrideSpawnScene(s32 sceneNum, s32 spawn) {
 
         // Move Ganon's Castle exit spawn to be on the small ledge near the castle and not over the void
         // to prevent Link from falling if the bridge isn't spawned
-        if (sceneNum == 100 && spawn == 1) {
+        if (sceneNum == SCENE_GANON_TOU && spawn == 1) {
             modifiedLinkActorEntry.pos.x = 0xFEA8;
             modifiedLinkActorEntry.pos.y = 0x065C;
             modifiedLinkActorEntry.pos.z = 0x0290;

--- a/soh/soh/Enhancements/randomizer/randomizer_entrance.c
+++ b/soh/soh/Enhancements/randomizer/randomizer_entrance.c
@@ -718,6 +718,15 @@ void Entrance_OverrideSpawnScene(s32 sceneNum, s32 spawn) {
             gPlayState->linkActorEntry = &modifiedLinkActorEntry;
         }
     }
+
+    if (Randomizer_GetSettingValue(RSK_SHUFFLE_OVERWORLD_ENTRANCES) == RO_GENERIC_ON) {
+        // Move Hyrule Field bridge spawn for child link at night to be beyond the moat so he doesn't fell in the water
+        if (sceneNum == SCENE_SPOT00 && spawn == 7 && LINK_IS_CHILD && IS_NIGHT) {
+            modifiedLinkActorEntry.pos.x = 0x0001;
+            modifiedLinkActorEntry.pos.z = 0x049E;
+            gPlayState->linkActorEntry = &modifiedLinkActorEntry;
+        }
+    }
 }
 
 s32 Entrance_OverrideSpawnSceneRoom(s32 sceneNum, s32 spawn, s32 roomNum) {

--- a/soh/soh/Enhancements/randomizer/randomizer_entrance.c
+++ b/soh/soh/Enhancements/randomizer/randomizer_entrance.c
@@ -721,7 +721,7 @@ void Entrance_OverrideSpawnScene(s32 sceneNum, s32 spawn) {
     }
 
     if (Randomizer_GetSettingValue(RSK_SHUFFLE_OVERWORLD_ENTRANCES) == RO_GENERIC_ON) {
-        // Move Hyrule Field bridge spawn for child link at night to be beyond the moat so he doesn't fell in the water
+        // Move Hyrule Field bridge spawn for child link at night to be beyond the moat so he doesn't fall in the water
         if (sceneNum == SCENE_SPOT00 && spawn == 7 && LINK_IS_CHILD && IS_NIGHT) {
             modifiedLinkActorEntry.pos.x = 0x0001;
             modifiedLinkActorEntry.pos.z = 0x049E;

--- a/soh/src/overlays/actors/ovl_Demo_Kankyo/z_demo_kankyo.c
+++ b/soh/src/overlays/actors/ovl_Demo_Kankyo/z_demo_kankyo.c
@@ -426,7 +426,8 @@ void DemoKankyo_Update(Actor* thisx, PlayState* play) {
     DemoKankyo* this = (DemoKankyo*)thisx;
     this->actionFunc(this, play);
 
-    if (gSaveContext.n64ddFlag && Randomizer_GetSettingValue(RSK_SHUFFLE_WARP_SONGS) &&
+    // In ER, override the warp song locations. Also removes the warp song cutscene
+    if (gSaveContext.n64ddFlag && Randomizer_GetSettingValue(RSK_SHUFFLE_ENTRANCES) &&
         thisx->params == 0x000F) { // Warp Song particles
         Entrance_SetWarpSongEntrance();
     }

--- a/soh/src/overlays/actors/ovl_En_Heishi4/z_en_heishi4.c
+++ b/soh/src/overlays/actors/ovl_En_Heishi4/z_en_heishi4.c
@@ -350,10 +350,10 @@ void EnHeishi4_MarketSneak(EnHeishi4* this, PlayState* play) {
     if (Message_GetState(&play->msgCtx) == TEXT_STATE_CHOICE && Message_ShouldAdvance(play)) {
         switch (play->msgCtx.choiceIndex) {
             case 0: //yes
-                if (gSaveContext.n64ddFlag){
-                    play->nextEntranceIndex = Entrance_OverrideNextIndex(0xCD);
+                if (gSaveContext.n64ddFlag && Randomizer_GetSettingValue(RSK_SHUFFLE_OVERWORLD_ENTRANCES) != RO_GENERIC_OFF){
+                    play->nextEntranceIndex = Entrance_OverrideNextIndex(0x01FD); // Market Entrance -> HF
                 } else {
-                    play->nextEntranceIndex = 0xCD;
+                    play->nextEntranceIndex = 0x00CD; // HF Near bridge (OoT cutscene entrance) to not fall in the water
                 } 
                 play->sceneLoadFlag = 0x14;
                 play->fadeTransition = 0x2E;

--- a/soh/src/overlays/actors/ovl_En_Syateki_Man/z_en_syateki_man.c
+++ b/soh/src/overlays/actors/ovl_En_Syateki_Man/z_en_syateki_man.c
@@ -157,8 +157,8 @@ void EnSyatekiMan_Init(Actor* thisx, PlayState* play) {
 
     if (gSaveContext.n64ddFlag && Randomizer_GetSettingValue(RSK_SHUFFLE_INTERIOR_ENTRANCES)) {
         // If child is in the adult shooting gallery or adult in the child shooting gallery, then despawn the shooting gallery man
-        if ((LINK_IS_CHILD && Entrance_SceneAndSpawnAre(0x42, 0x00)) || //Kakariko Village -> Adult Shooting Gallery, index 003B in the entrance table
-            (LINK_IS_ADULT && Entrance_SceneAndSpawnAre(0x42, 0x01))) { //Market -> Child Shooting Gallery,           index 016D in the entrance table
+        if ((LINK_IS_CHILD && Entrance_SceneAndSpawnAre(SCENE_SYATEKIJYOU, 0x00)) || //Kakariko Village -> Adult Shooting Gallery, index 003B in the entrance table
+            (LINK_IS_ADULT && Entrance_SceneAndSpawnAre(SCENE_SYATEKIJYOU, 0x01))) { //Market -> Child Shooting Gallery,           index 016D in the entrance table
             Actor_Kill(thisx);
             return;
         }


### PR DESCRIPTION
The "castle guard exit market" enhancement places link at the "Near Drawbridge" entrance instead of the "From Drawbridge" entrance. This is so link does not fall into the water at night as a convenience.

In Overworld shuffle, the "Near Drawbridge" entrance was passed into the override entrance logic instead of "From Drawbridge" resulting in the the vanilla entrance being used. This fixes that to use the proper entrance to get the override value.

I also adjusted the spawn position for "From Drawbridge" for child at night in overworld shuffle to place link just past the bridge so that you also dont fall into the water when going through the normal entrance

It was also reported that if grotto shuffle is on, but warp song shuffle is off, if you leave a grotto -> play a warp song -> then play sun's song, the grotto's coordinates are used as links respawn value. I adjusted the warp song override logic to happen when ER is on in general, rather than only when warp song shuffle is on. This makes it so the ER state is aware that a warpsong was used and so sun song ignores the grotto respawn location.

---

I also update some scene magic numbers to use proper enums.

Fixes #2443 

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/553002372.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/553002373.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/553002374.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/553002375.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/553002376.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/553002377.zip)
<!--- section:artifacts:end -->