### PR TITLE
Fix: Rando settings not being initialized in time

### DIFF
--- a/soh/soh/SaveManager.cpp
+++ b/soh/soh/SaveManager.cpp
@@ -204,6 +204,8 @@ void SaveManager::LoadRandomizerVersion2() {
 
     std::shared_ptr<Randomizer> randomizer = OTRGlobals::Instance->gRandomizer;
 
+    randomizer->LoadRandomizerSettings("");
+
     size_t merchantPricesSize = 0;
     SaveManager::Instance->LoadData("merchantPricesSize", merchantPricesSize);
 

--- a/soh/src/code/z_sram.c
+++ b/soh/src/code/z_sram.c
@@ -197,12 +197,6 @@ void Sram_OpenSave() {
         }
     }
 
-    // Setup the modified entrance table and entrance shuffle table for rando
-    if (gSaveContext.n64ddFlag) {
-        Entrance_Init();
-        Entrance_InitEntranceTrackingData();
-    }
-
     osSyncPrintf("scene_no = %d\n", gSaveContext.entranceIndex);
     osSyncPrintf(VT_RST);
 

--- a/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -2143,13 +2143,19 @@ void FileChoose_LoadGame(GameState* thisx) {
         }
     }
 
-    // Handle randomized spawn positions after the save context has been setup from load
-    // When remeber save location is on, set save warp if the save was in an a grotto, or
-    // the entrance index is -1 from shuffle overwarld spawn
-    if (gSaveContext.n64ddFlag && Randomizer_GetSettingValue(RSK_SHUFFLE_ENTRANCES) && ((!CVarGetInteger("gRememberSaveLocation", 0) ||
-        gSaveContext.savedSceneNum == SCENE_YOUSEI_IZUMI_TATE || gSaveContext.savedSceneNum == SCENE_KAKUSIANA) ||
-        (CVarGetInteger("gRememberSaveLocation", 0) && Randomizer_GetSettingValue(RSK_SHUFFLE_OVERWORLD_SPAWNS) && gSaveContext.entranceIndex == -1))) {
-        Entrance_SetSavewarpEntrance();
+    if (gSaveContext.n64ddFlag) {
+        // Setup the modified entrance table and entrance shuffle table for rando
+        Entrance_Init();
+        Entrance_InitEntranceTrackingData();
+
+        // Handle randomized spawn positions after the save context has been setup from load
+        // When remeber save location is on, set save warp if the save was in an a grotto, or
+        // the entrance index is -1 from shuffle overwarld spawn
+        if (Randomizer_GetSettingValue(RSK_SHUFFLE_ENTRANCES) && ((!CVarGetInteger("gRememberSaveLocation", 0) ||
+            gSaveContext.savedSceneNum == SCENE_YOUSEI_IZUMI_TATE || gSaveContext.savedSceneNum == SCENE_KAKUSIANA) ||
+            (CVarGetInteger("gRememberSaveLocation", 0) && Randomizer_GetSettingValue(RSK_SHUFFLE_OVERWORLD_SPAWNS) && gSaveContext.entranceIndex == -1))) {
+            Entrance_SetSavewarpEntrance();
+        }
     }
 }
 


### PR DESCRIPTION
It was reported that the entrance tracker would not populate if you had no spoiler log loaded, or the spoiler log is for a different seed without entrance randomizer enabled. Similarly it was reported that save warping in a randomized boss room would place you in the un-randomized dungeon.

These two issues both stem from the same problem: the entrance init and tracker init were happening before a proper call to `Randomizer_LoadSettings("")`. In this case the entrance methods were in `Sram_OpenSave()` which happens before `Randomizer_LoadSettings("")`. This PR just moves the entrance methods to be later in `FileChoose_LoadGame()` to have the proper rando settings loaded.

While fixing this, I noticed there is also one other RSK_ check happening in `Sram_OpenSave()` to prevent spoiling adult trade items when adult trade is enabled. Not having the right spoiler log loaded means that you could have the incorrect adult trade item in your inventory (e.g. mushroom gets replaced with Cojiro). Digging into it I found that originally in the `LoadRandomizerVersion1()` method, we were calling `randomizer->LoadRandomizerSettings("")`, but in the newer `loadRandomizerVersion2()` this line was missing and is a regression. I've added this line to the V2 load call to prevent the spoiling.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/553286750.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/553286751.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/553286752.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/553286753.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/553286754.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/553286755.zip)
<!--- section:artifacts:end -->