### PR TITLE
[Interpolation] Allow Matching & Limit Max FPS

### DIFF
--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -890,15 +890,10 @@ namespace GameMenuBar {
 
             const char* fps_cvar = "gInterpolationFPS";
             {
-            #if defined(__SWITCH__) || defined(__WIIU__)
                 int minFps = 20;
-                int maxFps = 60;
-            #else
-                int minFps = 20;
-                int maxFps = 360;
-            #endif
+                int maxFps = Ship::Window::GetInstance()->GetCurrentRefreshRate();
 
-                int val = CVarGetInteger(fps_cvar, minFps);
+                int val = OTRGlobals::Instance->GetInterpolationFPS();
                 val = fmax(fmin(val, maxFps), 20);
 
             #ifdef __WIIU__
@@ -915,6 +910,11 @@ namespace GameMenuBar {
                 else
                 {
                     ImGui::Text("Frame interpolation: %d FPS", fps);
+                }
+                
+                if (CVarGetInteger("gMatchRefreshRate", 0)) {
+                    ImGui::PushItemFlag(ImGuiItemFlags_Disabled, true);
+                    ImGui::PushStyleVar(ImGuiStyleVar_Alpha, ImGui::GetStyle().Alpha * 0.5f);
                 }
 
                 std::string MinusBTNFPSI = " - ##FPSInterpolation";
@@ -976,24 +976,18 @@ namespace GameMenuBar {
                     CVarSetInteger(fps_cvar, val);
                     SohImGui::RequestCvarSaveOnNextTick();
                 }
-            }
-
-            if (SohImGui::WindowBackend() == SohImGui::Backend::DX11)
-            {
-                UIWidgets::Spacer(0);
-                ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(6.0f, 4.0f));
-                if (ImGui::Button("Match Refresh Rate"))
-                {
-                    int hz = Ship::Window::GetInstance()->GetCurrentRefreshRate();
-                    if (hz >= 20 && hz <= 360)
-                    {
-                        CVarSetInteger(fps_cvar, hz);
-                        SohImGui::RequestCvarSaveOnNextTick();
-                    }
+                
+                if (CVarGetInteger("gMatchRefreshRate", 0)) {
+                    ImGui::PopItemFlag();
+                    ImGui::PopStyleVar(1);
                 }
-                ImGui::PopStyleVar(1);
-                UIWidgets::Spacer(0);
             }
+            
+            UIWidgets::Spacer(0);
+            UIWidgets::EnhancementCheckbox("Match Refresh Rate", "gMatchRefreshRate");
+            UIWidgets::Tooltip("Matches interpolation value to the current game's window refresh rate");
+            UIWidgets::Spacer(0);
+
             UIWidgets::EnhancementCheckbox("Disable LOD", "gDisableLOD");
             UIWidgets::Tooltip("Turns off the Level of Detail setting, making models use their higher-poly variants at any distance");
             if (UIWidgets::PaddedEnhancementCheckbox("Disable Draw Distance", "gDisableDrawDistance", true, false)) {

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -313,6 +313,14 @@ bool OTRGlobals::HasOriginal() {
     return hasOriginal;
 }
 
+uint32_t OTRGlobals::GetInterpolationFPS() {
+    if (CVarGetInteger("gMatchRefreshRate", 0)) {
+        return Ship::Window::GetInstance()->GetCurrentRefreshRate();
+    }
+
+    return std::min<uint32_t>(Ship::Window::GetInstance()->GetCurrentRefreshRate(), CVarGetInteger("gInterpolationFPS", 20));
+}
+
 std::shared_ptr<std::vector<std::string>> OTRGlobals::ListFiles(std::string path) {
     return context->GetResourceManager()->ListFiles(path);
 }
@@ -731,7 +739,7 @@ extern "C" void Graph_ProcessGfxCommands(Gfx* commands) {
 
     audio.cv_to_thread.notify_one();
     std::vector<std::unordered_map<Mtx*, MtxF>> mtx_replacements;
-    int target_fps = CVarGetInteger("gInterpolationFPS", 20);
+    int target_fps = OTRGlobals::Instance->GetInterpolationFPS();
     static int last_fps;
     static int last_update_rate;
     static int time;

--- a/soh/soh/OTRGlobals.h
+++ b/soh/soh/OTRGlobals.h
@@ -28,6 +28,7 @@ public:
 
     bool HasMasterQuest();
     bool HasOriginal();
+    uint32_t GetInterpolationFPS();
     std::shared_ptr<std::vector<std::string>> ListFiles(std::string path);
 
 private:


### PR DESCRIPTION
Adds an option to match monitor FPS - plus limits max to the max supported by the game display.
This will now also handle the case where you move screens to a lower FPS supported

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/578257352.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/578257354.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/578257355.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/578257357.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/578257359.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/578257360.zip)
<!--- section:artifacts:end -->