### PR TITLE
GameplayStats: replace hack in displaying time and numbers

### DIFF
--- a/soh/soh/Enhancements/gameplaystats.cpp
+++ b/soh/soh/Enhancements/gameplaystats.cpp
@@ -49,22 +49,7 @@ void DisplayTimeHHMMSS(uint32_t timeInTenthsOfSeconds, const char* text, ImVec4 
 
     ImGui::Text(text);
     ImGui::SameLine();
-
-    // Hack to keep the timers aligned and prevent them from shifting around
-    // Put a leading zero in front of the seconds or minutes if they're less than 10
-    if (mm < 10 && ss < 10) {
-        ImGui::Text("%u:0%u:0%u.%u", hh, mm, ss, ds);
-    }
-    if (mm < 10 && ss >= 10) {
-        ImGui::Text("%u:0%u:%u.%u", hh, mm, ss, ds);
-    }
-    if (mm >= 10 && ss < 10) {
-        ImGui::Text("%u:%u:0%u.%u", hh, mm, ss, ds);
-    }
-    if (mm >= 10 && ss >= 10) {
-        ImGui::Text("%u:%u:%u.%u", hh, mm, ss, ds);
-    }
-
+    ImGui::Text("%2u:%02u:%02u.%u", hh, mm, ss, ds);
     ImGui::PopStyleColor();
 }
 
@@ -85,20 +70,7 @@ void DisplayStat(const char* text, uint32_t value) {
 
     ImGui::Text(text);
     ImGui::SameLine();
-    // Hack to keep the digits properly aligned in the column
-           if (value < 10) {
-        ImGui::Text("     %u", value);
-    } else if (value < 100) {
-        ImGui::Text("    %u", value);
-    } else if (value < 1000) {
-        ImGui::Text("   %u", value);
-    } else if (value < 10000) {
-        ImGui::Text("  %u", value);
-    } else if (value < 100000) {
-        ImGui::Text(" %u", value);
-    } else {
-        ImGui::Text("%u", value);
-    }
+    ImGui::Text("%7u", value);
 }
 
 void DisplayStatIfNonZero(const char* text, uint32_t value) {


### PR DESCRIPTION
Use anything else possible other than just `%u` as `ImGui::Text` supports any capabilities within the printf format string. Might be related to #2437

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/559412506.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/559412507.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/559412508.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/559412509.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/559412510.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/559412511.zip)
<!--- section:artifacts:end -->