### PR TITLE
fix: use cache on LoadFileRaw

### DIFF
--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -896,11 +896,11 @@ extern "C" char* ResourceMgr_LoadFileRaw(const char* resName) {
     
     auto file = OTRGlobals::Instance->context->GetResourceManager()->LoadFile(resName);
     cachedRawFiles[resName] = file;
-    
+
     if (file == nullptr) {
         return nullptr;
     }
-    
+
     return file->Buffer.data();
 }
 

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -896,9 +896,11 @@ extern "C" char* ResourceMgr_LoadFileRaw(const char* resName) {
     
     auto file = OTRGlobals::Instance->context->GetResourceManager()->LoadFile(resName);
     cachedRawFiles[resName] = file;
+    
     if (file == nullptr) {
         return nullptr;
     }
+    
     return file->Buffer.data();
 }
 

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -888,13 +888,14 @@ extern "C" char* ResourceMgr_LoadFileRaw(const char* resName) {
     // TODO: This should not exist. Anywhere we are loading textures with this function should be Resources instead.
     // We are not currently packing our otr archive with certain textures as resources with otr headers.
     static std::unordered_map<std::string, std::shared_ptr<Ship::OtrFile>> cachedRawFiles;
+
+    auto cacheFind = cachedRawFiles.find(resName);
+    if (cacheFind != cachedRawFiles.end()) {
+        return cacheFind->second->Buffer.data();
+    }
+    
     auto file = OTRGlobals::Instance->context->GetResourceManager()->LoadFile(resName);
     cachedRawFiles[resName] = file;
-
-    if (file == nullptr) {
-        return nullptr;
-    }
-
     return file->Buffer.data();
 }
 

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -896,6 +896,9 @@ extern "C" char* ResourceMgr_LoadFileRaw(const char* resName) {
     
     auto file = OTRGlobals::Instance->context->GetResourceManager()->LoadFile(resName);
     cachedRawFiles[resName] = file;
+    if (file == nullptr) {
+        return nullptr;
+    }
     return file->Buffer.data();
 }
 


### PR DESCRIPTION
this makes it so explosions don't use the dpad texture

fixes https://github.com/HarbourMasters/Shipwright/issues/2484

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/559894041.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/559894042.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/559894043.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/559894044.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/559894045.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/559894046.zip)
<!--- section:artifacts:end -->