### PR TITLE
Fix: Logic to use fire timer for deku scrub in DMC

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_death_mountain.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_death_mountain.cpp
@@ -230,7 +230,7 @@ void AreaTable_Init_DeathMountain() {
   areaTable[DMC_LOWER_LOCAL] = Area("DMC Lower Local", "Death Mountain Crater", DEATH_MOUNTAIN_CRATER, NO_DAY_NIGHT_CYCLE, {}, {}, {
                   //Exits
                   Entrance(DMC_LOWER_NEARBY,       {[]{return true;}}),
-                  Entrance(DMC_LADDER_AREA_NEARBY, {[]{return true;}}),
+                  Entrance(DMC_LADDER_AREA_NEARBY, {[]{return FireTimer >= 8 || Hearts >= 3;}}),
                   Entrance(DMC_CENTRAL_NEARBY,     {[]{return (CanUse(HOVER_BOOTS) || CanUse(HOOKSHOT)) && (FireTimer >= 8 || Hearts >= 3);},
                                         /*Glitched*/[]{return CanDoGlitch(GlitchType::Megaflip, GlitchDifficulty::NOVICE) && (FireTimer >= 8 || Hearts >= 3);}}),
                   Entrance(DMC_CENTRAL_LOCAL,      {[]{return (CanUse(HOVER_BOOTS) || CanUse(HOOKSHOT)) && FireTimer >= 24;}}),


### PR DESCRIPTION
DMC Lower -> Deku scrub was not accounting for fire timer/heart check

Porting fix from https://github.com/gamestabled/OoT3D_Randomizer/pull/643

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/562065476.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/562065477.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/562065478.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/562065479.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/562065480.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/562065481.zip)
<!--- section:artifacts:end -->