### PR TITLE
[Accessibility] Add ability to disable camera re-centering on idle

### DIFF
--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -302,6 +302,17 @@ namespace GameMenuBar {
                 UIWidgets::EnhancementRadioButton("French", "gLanguages", LANGUAGE_FRA);
                 ImGui::EndMenu();
             }
+            
+#if defined(_WIN32) || defined(__APPLE__)
+            UIWidgets::Spacer(0);
+            
+            if (ImGui::BeginMenu("Accessibility")) {
+                UIWidgets::PaddedEnhancementCheckbox("Disable Idle Camera Re-Centering", "gA11yDisableIdleCam");
+                UIWidgets::Tooltip("Disables the automatic re-centering of the camera when idle.");
+                
+                ImGui::EndMenu();
+            }
+#endif
             ImGui::EndMenu();
         }
 

--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -303,7 +303,6 @@ namespace GameMenuBar {
                 ImGui::EndMenu();
             }
             
-#if defined(_WIN32) || defined(__APPLE__)
             UIWidgets::Spacer(0);
             
             if (ImGui::BeginMenu("Accessibility")) {
@@ -312,7 +311,6 @@ namespace GameMenuBar {
                 
                 ImGui::EndMenu();
             }
-#endif
             ImGui::EndMenu();
         }
 

--- a/soh/src/code/z_camera.c
+++ b/soh/src/code/z_camera.c
@@ -1677,10 +1677,12 @@ s32 Camera_Normal1(Camera* camera) {
         Camera_ClampDist(camera, eyeAdjustment.r, norm1->distMin, norm1->distMax, anim->unk_28);
 
     if (anim->startSwingTimer <= 0) {
+        if (CVarGetInteger("gA11yDisableIdleCam", 0)) return;
         eyeAdjustment.pitch = atEyeNextGeo.pitch;
         eyeAdjustment.yaw =
             Camera_LERPCeilS(anim->swingYawTarget, atEyeNextGeo.yaw, 1.0f / camera->yawUpdateRateInv, 0xA);
     } else if (anim->swing.unk_18 != 0) {
+        if (CVarGetInteger("gA11yDisableIdleCam", 0)) return;
         eyeAdjustment.yaw =
             Camera_LERPCeilS(anim->swing.unk_16, atEyeNextGeo.yaw, 1.0f / camera->yawUpdateRateInv, 0xA);
         eyeAdjustment.pitch =

--- a/soh/src/code/z_camera.c
+++ b/soh/src/code/z_camera.c
@@ -1688,7 +1688,7 @@ s32 Camera_Normal1(Camera* camera) {
         eyeAdjustment.pitch =
             Camera_LERPCeilS(anim->swing.unk_14, atEyeNextGeo.pitch, 1.0f / camera->yawUpdateRateInv, 0xA);
     } else {
-        // rotate yaw to follow player.
+        // rotate yaw to follow player while moving around - to keep player on camera.
         eyeAdjustment.yaw =
             Camera_CalcDefaultYaw(camera, atEyeNextGeo.yaw, camera->playerPosRot.rot.y, norm1->unk_14, sp94);
         eyeAdjustment.pitch =


### PR DESCRIPTION
null

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/576399963.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/576399964.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/576399966.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/576399970.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/576399972.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/576399975.zip)
<!--- section:artifacts:end -->