### PR TITLE
Fix: Remove incorrect child spawn hint key

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/location_access.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/location_access.cpp
@@ -286,7 +286,7 @@ void AreaTable_Init() {
                                                                  ((Bugs || Fish) && CanShield && CanDoGlitch(GlitchType::QPA, GlitchDifficulty::ADVANCED)) || ((Bugs || Fish) && (IsAdult || KokiriSword || Sticks || Bombs || HasBombchus || Boomerang || Slingshot || CanUse(MEGATON_HAMMER)) && CanShield && CanDoGlitch(GlitchType::ActionSwap, GlitchDifficulty::NOVICE)))) && PreludeOfLight   && CanLeaveForest;}}),
   });
 
-  areaTable[CHILD_SPAWN] = Area("Child Spawn", "", TEMPLE_OF_TIME, NO_DAY_NIGHT_CYCLE, {}, {}, {
+  areaTable[CHILD_SPAWN] = Area("Child Spawn", "", NONE, NO_DAY_NIGHT_CYCLE, {}, {}, {
                   //Exits
                   Entrance(KF_LINKS_HOUSE, {[]{return true;}}),
   });


### PR DESCRIPTION
A hint key was assigned to CHILD_SPAWN location, when it should be NONE so that the proper connected parent region hint is used instead (when overworld spawn is in an interrior/grotto, the connected region should be hinted if a item in that spawn location is hinted).

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/563441228.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/563441229.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/563441230.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/563441231.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/563441232.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/563441233.zip)
<!--- section:artifacts:end -->