### PR TITLE
Adding CVar for z-fighting fix

### DIFF
--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -738,6 +738,17 @@ namespace GameMenuBar {
                 UIWidgets::Tooltip("Changes the rupee in the wallet icon to match the wallet size you currently have");
                 UIWidgets::PaddedEnhancementCheckbox("Always show dungeon entrances", "gAlwaysShowDungeonMinimapIcon", true, false);
                 UIWidgets::Tooltip("Always shows dungeon entrance icons on the minimap");
+                UIWidgets::PaddedText("Fix Vanishing Paths", true, false);
+                const char* zFightingOptions[3] = { "Disabled", "Consistent Vanish", "No Vanish" };
+                UIWidgets::EnhancementCombobox("gDirtPathFix", zFightingOptions, 3, 0);
+                UIWidgets::Tooltip("Disabled: Paths vanish more the higher the resolution (Z-fighting is based on resolution)\n"
+                                   "Consistent: Certain paths vanish the same way in all resolutions\n"
+                                   "No Vanish: Paths do not vanish, Link seems to sink in to some paths\n"
+                                   "This might affect other decal effects\n");
+                /* 
+                UIWidgets::PaddedEnhancementCheckbox("Fix Vanishing Paths", "gDirtPathFix", true, false);
+                UIWidgets::Tooltip("Fixes paths vanishing in the ground, but let's link sink a bit in others paths");
+                */
 
                 ImGui::EndMenu();
             }


### PR DESCRIPTION
Adding a CVar to select z-fighting behaviour (current, like N64 mode, no vanish)
Corresponding changes in D3D and OGL

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/570797329.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/570797330.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/570797332.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/570797333.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/570797334.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/570797335.zip)
<!--- section:artifacts:end -->