### PR TITLE
Tweak: Fix "Static Explosion Radius"

### DIFF
--- a/soh/src/overlays/actors/ovl_En_Bom/z_en_bom.c
+++ b/soh/src/overlays/actors/ovl_En_Bom/z_en_bom.c
@@ -178,7 +178,8 @@ void EnBom_Explode(EnBom* this, PlayState* play) {
     }
 
     if (CVarGetInteger("gStaticExplosionRadius", 0)) {
-        this->explosionCollider.elements[0].dim.worldSphere.radius = 40;
+        //72 is the maximum radius of an OoT bomb explosion
+        this->explosionCollider.elements[0].dim.worldSphere.radius = 72;
     } else {
         this->explosionCollider.elements[0].dim.worldSphere.radius += this->actor.shape.rot.z + 8;
     }


### PR DESCRIPTION
Currently, `Static Explosion Radius` sets the explosion radius of a bomb (and bombchu by extension) to a constant 40 units, rather than have the radius grow by 8 every frame until the bomb timer ran out. This gave the bombs a more "Majora's Mask feel" since the explosion being constant is a trait found with MM bombs, and allows easier bomb hovering for more advanced players.
However, 40 is not enough to solve some bomb puzzles, such as the staircase in Dodongo's Cavern. The explosion radius, under normal conditions, grows to about 72 before the bomb actor is killed. This sets the constant to that number to a) preserve the MM-like bombs and b) still allow completion of bomb puzzles.
There can be an argument made to increase the radius further to 100, as this is the actual value from MM's `z_en_bom` [as seen in this snippet](https://github.com/zeldaret/mm/blob/master/src/overlays/actors/ovl_En_Bom/z_en_bom.c#L322-L345), but this could interfere with normal bomb puzzles in my opinion.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/565204202.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/565204203.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/565204204.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/565204205.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/565204206.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/565204207.zip)
<!--- section:artifacts:end -->