### PR TITLE
Fix: Excluded locations not applying when location tab not viewed once

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -2939,6 +2939,9 @@ void GenerateRandomizerImgui(std::string seed = "") {
         excludedLocations.insert((RandomizerCheck)std::stoi(excludedLocationString));
     }
 
+    // Update the visibilitiy before removing conflicting excludes (in case the locations tab wasn't viewed)
+    RandomizerCheckObjects::UpdateImGuiVisibility();
+
     // Remove excludes for locations that are no longer allowed to be excluded
     for (auto [randomizerCheck, rcObject] : RandomizerCheckObjects::GetAllRCObjects()) {
         auto elfound = excludedLocations.find(rcObject.rc);


### PR DESCRIPTION
With Gibbs I introduced a fix where if a randomizer setting was changed after you set your excluded locations, we filter out any conflicting excludes before generating.

This worked, except for if you never viewed the location tab (which is what would set the visibility of what can be excluded).

With this PR we now also call the `UpdateImGuiVisibility()` one more time right before filtering so we have everything up to date even if you never open/reopen the locations tab.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/568245572.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/568245573.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/568245574.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/568245576.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/568245580.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/568245581.zip)
<!--- section:artifacts:end -->