### PR TITLE
Fix: Gerudo Fortress chest as child to give correct randomizer check item

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -2587,6 +2587,13 @@ RandomizerCheckObject Randomizer::GetCheckObjectFromActor(s16 actorId, s16 scene
                     break;
             }
             break;
+        case SCENE_SPOT12:
+            // GF chest as child has different params and gives odd mushroom
+            // set it to the GF chest check for both ages
+            if (actorId == ACTOR_EN_BOX) {
+                specialRc = RC_GF_CHEST;
+            }
+            break;
         case SCENE_DDAN:
             // special case for MQ DC Gossip Stone
             if (actorId == ACTOR_EN_GS && actorParams == 15892 && ResourceMgr_IsGameMasterQuest()) {


### PR DESCRIPTION
The Gerudo Fortress chest as child has different params and would not load the correct RC_ value.
This PR adds a specialty case for the GF scene to set the chest as `RC_GF_CHEST` regardless of age. This specialty check should be fine as there is only the one chest in the GF scene.

Fixes #1070 

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/568356811.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/568356812.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/568356813.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/568356814.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/568356815.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/568356816.zip)
<!--- section:artifacts:end -->