### PR TITLE
improve cvar usage in AudioEditor

### DIFF
--- a/soh/soh/Enhancements/audio/AudioCollection.cpp
+++ b/soh/soh/Enhancements/audio/AudioCollection.cpp
@@ -196,7 +196,7 @@ void AudioCollection::AddToCollection(char* otrPath, uint16_t seqNum) {
     }
     SequenceInfo info = {seqNum,
                          sequenceName,
-                         StringHelper::Replace(StringHelper::Replace(sequenceName, " ", "_"), "~", "-"),
+                         StringHelper::Replace(StringHelper::Replace(StringHelper::Replace(sequenceName, " ", "_"), "~", "-"),".", ""),
                          type};
     sequenceMap.emplace(seqNum, info);
 }
@@ -206,7 +206,7 @@ uint16_t AudioCollection::GetReplacementSequence(uint16_t seqId) {
     // for Hyrule Field instead. Otherwise, leave it alone, so that without any sfx editor modifications we will
     // play the normal track as usual.
     if (seqId == NA_BGM_FIELD_MORNING) {
-        if (CVarGetInteger("gSfxEditor_NA_BGM_FIELD_LOGIC", NA_BGM_FIELD_LOGIC) != NA_BGM_FIELD_LOGIC) {
+        if (CVarGetInteger("gAudioEditor.ReplacedSequences.NA_BGM_FIELD_LOGIC", NA_BGM_FIELD_LOGIC) != NA_BGM_FIELD_LOGIC) {
             seqId = NA_BGM_FIELD_LOGIC;
         }
     }
@@ -216,7 +216,7 @@ uint16_t AudioCollection::GetReplacementSequence(uint16_t seqId) {
     }
 
     const auto& sequenceInfo = sequenceMap.at(seqId);
-    const std::string cvarKey = "gSfxEditor_" + sequenceInfo.sfxKey;
+    const std::string cvarKey = "gAudioEditor.ReplacedSequences." + sequenceInfo.sfxKey;
     int replacementSeq = CVarGetInteger(cvarKey.c_str(), seqId);
     if (!sequenceMap.contains(replacementSeq)) {
         replacementSeq = seqId;
@@ -225,7 +225,7 @@ uint16_t AudioCollection::GetReplacementSequence(uint16_t seqId) {
 }
 
 void AudioCollection::RemoveFromShufflePool(SequenceInfo* seqInfo) {
-    const std::string cvarKey = "gExcludeSfx_" + seqInfo->sfxKey;
+    const std::string cvarKey = "gAudioEditor.Excluded." + seqInfo->sfxKey;
     excludedSequences.insert(seqInfo);
     includedSequences.erase(seqInfo);
     CVarSetInteger(cvarKey.c_str(), 1);
@@ -233,7 +233,7 @@ void AudioCollection::RemoveFromShufflePool(SequenceInfo* seqInfo) {
 }
 
 void AudioCollection::AddToShufflePool(SequenceInfo* seqInfo) {
-    const std::string cvarKey = "gExcludeSfx_" + seqInfo->sfxKey;
+    const std::string cvarKey = "gAudioEditor.Excluded." + seqInfo->sfxKey;
     includedSequences.insert(seqInfo);
     excludedSequences.erase(seqInfo);
     CVarClear(cvarKey.c_str());
@@ -244,7 +244,7 @@ void AudioCollection::InitializeShufflePool() {
     if (shufflePoolInitialized) return;
     
     for (auto& [seqId, seqInfo] : sequenceMap) {
-        const std::string cvarKey = "gExcludeSfx_" + seqInfo.sfxKey;
+        const std::string cvarKey = "gAudioEditor.Excluded." + seqInfo.sfxKey;
         if (CVarGetInteger(cvarKey.c_str(), 0)) {
             excludedSequences.insert(&seqInfo);
         } else {

--- a/soh/soh/Enhancements/audio/AudioEditor.cpp
+++ b/soh/soh/Enhancements/audio/AudioEditor.cpp
@@ -92,7 +92,7 @@ void RandomizeGroup(SeqType type) {
     }
     Shuffle(values);
     for (const auto& [seqId, seqData] : AudioCollection::Instance->GetAllSequences()) {
-        const std::string cvarKey = "gSfxEditor_" + seqData.sfxKey;
+        const std::string cvarKey = "gAudioEditor.ReplacedSequences." + seqData.sfxKey;
         if (seqData.category & type) {
             // Only save authentic sequence CVars
             if (((seqData.category & SEQ_BGM_CUSTOM) || seqData.category == SEQ_FANFARE) && seqData.sequenceId >= MAX_AUTHENTIC_SEQID) {
@@ -112,28 +112,28 @@ void ResetGroup(const std::map<u16, SequenceInfo>& map, SeqType type) {
             if (seqData.category == SEQ_FANFARE && defaultValue >= MAX_AUTHENTIC_SEQID) {
                 continue;
             }
-            const std::string cvarKey = "gSfxEditor_" + seqData.sfxKey;
+            const std::string cvarKey = "gAudioEditor.ReplacedSequences." + seqData.sfxKey;
             CVarSetInteger(cvarKey.c_str(), defaultValue);
         }
     }
 }
 
 void DrawPreviewButton(uint16_t sequenceId, std::string sfxKey, SeqType sequenceType) {
-    const std::string cvarKey = "gSfxEditor_" + sfxKey;
+    const std::string cvarKey = "gAudioEditor.ReplacedSequences." + sfxKey;
     const std::string hiddenKey = "##" + cvarKey;
     const std::string stopButton = " Stop  " + hiddenKey;
     const std::string previewButton = "Preview" + hiddenKey;
 
-    if (CVarGetInteger("gSfxEditor_playing", 0) == sequenceId) {
+    if (CVarGetInteger("gAudioEditor.Playing", 0) == sequenceId) {
         if (ImGui::Button(stopButton.c_str())) {
             func_800F5C2C();
-            CVarSetInteger("gSfxEditor_playing", 0);
+            CVarSetInteger("gAudioEditor.Playing", 0);
         }
     } else {
         if (ImGui::Button(previewButton.c_str())) {
-            if  (CVarGetInteger("gSfxEditor_playing", 0) != 0) {
+            if  (CVarGetInteger("gAudioEditor.Playing", 0) != 0) {
                 func_800F5C2C();
-                CVarSetInteger("gSfxEditor_playing", 0);
+                CVarSetInteger("gAudioEditor.Playing", 0);
             } else {
                 if (sequenceType == SEQ_SFX) {
                     Audio_PlaySoundGeneral(sequenceId, &pos, 4, &freqScale, &freqScale, &reverbAdd);
@@ -143,7 +143,7 @@ void DrawPreviewButton(uint16_t sequenceId, std::string sfxKey, SeqType sequence
                 } else {
                     // TODO: Cant do both here, so have to click preview button twice
                     PreviewSequence(sequenceId);
-                    CVarSetInteger("gSfxEditor_playing", sequenceId);
+                    CVarSetInteger("gAudioEditor.Playing", sequenceId);
                 }
             }
         }
@@ -185,7 +185,7 @@ void Draw_SfxTab(const std::string& tabId, SeqType type) {
             continue;
         }
 
-        const std::string cvarKey = "gSfxEditor_" + seqData.sfxKey;
+        const std::string cvarKey = "gAudioEditor.ReplacedSequences." + seqData.sfxKey;
         const std::string hiddenKey = "##" + cvarKey;
         const std::string resetButton = "Reset" + hiddenKey;
         const std::string randomizeButton = "Randomize" + hiddenKey;
@@ -308,7 +308,7 @@ void DrawTypeChip(SeqType type) {
 
 void DrawSfxEditor(bool& open) {
     if (!open) {
-        CVarSetInteger("gSfxEditor", 0);
+        CVarSetInteger("gAudioEditor.WindowOpen", 0);
         return;
     }
 
@@ -538,7 +538,7 @@ void DrawSfxEditor(bool& open) {
 
 void InitAudioEditor() {
     //Draw the bar in the menu.
-    SohImGui::AddWindow("Enhancements", "SFX Editor", DrawSfxEditor);
+    SohImGui::AddWindow("Enhancements", "Audio Editor", DrawSfxEditor);
 }
 
 std::vector<SeqType> allTypes = { SEQ_BGM_WORLD, SEQ_BGM_EVENT, SEQ_BGM_BATTLE, SEQ_OCARINA, SEQ_FANFARE, SEQ_INSTRUMENT, SEQ_SFX };

--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -835,12 +835,12 @@ namespace GameMenuBar {
                 SohImGui::RequestCvarSaveOnNextTick();
                 SohImGui::EnableWindow("Cosmetics Editor", CVarGetInteger("gCosmeticsEditorEnabled", 0));
             }
-            if (ImGui::Button(GetWindowButtonText("Audio Editor", CVarGetInteger("gSfxEditor", 0)).c_str(), ImVec2(-1.0f, 0.0f)))
+            if (ImGui::Button(GetWindowButtonText("Audio Editor", CVarGetInteger("gAudioEditor.WindowOpen", 0)).c_str(), ImVec2(-1.0f, 0.0f)))
             {
-                bool currentValue = CVarGetInteger("gSfxEditor", 0);
-                CVarSetInteger("gSfxEditor", !currentValue);
+                bool currentValue = CVarGetInteger("gAudioEditor.WindowOpen", 0);
+                CVarSetInteger("gAudioEditor.WindowOpen", !currentValue);
                 SohImGui::RequestCvarSaveOnNextTick();
-                SohImGui::EnableWindow("SFX Editor", CVarGetInteger("gSfxEditor", 0));
+                SohImGui::EnableWindow("Audio Editor", CVarGetInteger("gAudioEditor.WindowOpen", 0));
             }
             if (ImGui::Button(GetWindowButtonText("Gameplay Stats", CVarGetInteger("gGameplayStatsEnabled", 0)).c_str(), ImVec2(-1.0f, 0.0f))) {
                 bool currentValue = CVarGetInteger("gGameplayStatsEnabled", 0);


### PR DESCRIPTION
* fixes excluding sequences with a `.` in their names (removes `.` when generating `sfxKey`)
* moves from using flat `gSfxEditor_` and `gExcludeSfx_` prefixed cvars to using `.` to nest all audio editor related cvars under `gAudioEditor`

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/569296854.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/569296857.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/569296858.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/569296860.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/569296861.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/569296862.zip)
<!--- section:artifacts:end -->