### PR TITLE
fix: use trick names for scrub and house of skulltula hints

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/spoiler_log.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/spoiler_log.cpp
@@ -726,43 +726,29 @@ static void WriteAllLocations(int language) {
             break;
         }
 
-        // Eventually check for other things here like fake name
+        jsonData["locations"][location->GetName()] = placedItemName;
+
         if (location->HasScrubsanityPrice() || location->HasShopsanityPrice()) {
-            jsonData["locations"][location->GetName()]["item"] = placedItemName;
-            if (location->GetPlacedItemKey() == ICE_TRAP && location->IsCategory(Category::cShop)) {
-                switch (language) {
-                    case 0:
-                    default:
-                        jsonData["locations"][location->GetName()]["model"] =
-                            ItemFromGIID(iceTrapModels[location->GetRandomizerCheck()]).GetName().english;
-                        jsonData["locations"][location->GetName()]["trickName"] = 
-                            NonShopItems[TransformShopIndex(GetShopIndex(key))].Name.english;
-                        break;
-                    case 2:
-                        jsonData["locations"][location->GetName()]["model"] =
-                            ItemFromGIID(iceTrapModels[location->GetRandomizerCheck()]).GetName().french;
-                        jsonData["locations"][location->GetName()]["trickName"] =
-                            NonShopItems[TransformShopIndex(GetShopIndex(key))].Name.french;
-                        break;
-                }
-            }
-            jsonData["locations"][location->GetName()]["price"] = location->GetPrice();
-        } else if (location->GetPlacedItemKey() == ICE_TRAP && iceTrapModels.contains(location->GetRandomizerCheck())) {
-            jsonData["locations"][location->GetName()]["item"] = placedItemName;
-            switch (language) {
-                case 0:
-                default:
-                    jsonData["locations"][location->GetName()]["model"] =
-                        ItemFromGIID(iceTrapModels[location->GetRandomizerCheck()]).GetName().english;
-                    break;
-                case 2:
-                    jsonData["locations"][location->GetName()]["model"] =
-                        ItemFromGIID(iceTrapModels[location->GetRandomizerCheck()]).GetName().french;
-                    break;
-            }
-        } else {
-          jsonData["locations"][location->GetName()] = placedItemName;
+          jsonData["locations"][location->GetName()]["price"] = location->GetPrice();
         }
+
+        if (location->GetPlacedItemKey() == ICE_TRAP) {
+          switch (language) {
+              case 0:
+              default:
+                  jsonData["locations"][location->GetName()]["model"] =
+                      ItemFromGIID(iceTrapModels[location->GetRandomizerCheck()]).GetName().english;
+                  jsonData["locations"][location->GetName()]["trickName"] = 
+                      NonShopItems[TransformShopIndex(GetShopIndex(key))].Name.english;
+                  break;
+              case 2:
+                  jsonData["locations"][location->GetName()]["model"] =
+                      ItemFromGIID(iceTrapModels[location->GetRandomizerCheck()]).GetName().french;
+                  jsonData["locations"][location->GetName()]["trickName"] =
+                      NonShopItems[TransformShopIndex(GetShopIndex(key))].Name.french;
+                  break;
+          }
+      }
     }
 }
 

--- a/soh/soh/Enhancements/randomizer/3drando/spoiler_log.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/spoiler_log.cpp
@@ -750,13 +750,13 @@ static void WriteAllLocations(int language) {
                   jsonData["locations"][location->GetName()]["model"] =
                       ItemFromGIID(iceTrapModels[location->GetRandomizerCheck()]).GetName().english;
                   jsonData["locations"][location->GetName()]["trickName"] = 
-                      NonShopItems[TransformShopIndex(GetShopIndex(key))].Name.english;
+                      GetIceTrapName(iceTrapModels[location->GetRandomizerCheck()]).english;
                   break;
               case 2:
                   jsonData["locations"][location->GetName()]["model"] =
                       ItemFromGIID(iceTrapModels[location->GetRandomizerCheck()]).GetName().french;
                   jsonData["locations"][location->GetName()]["trickName"] =
-                      NonShopItems[TransformShopIndex(GetShopIndex(key))].Name.french;
+                      GetIceTrapName(iceTrapModels[location->GetRandomizerCheck()]).french;
                   break;
           }
       }

--- a/soh/soh/Enhancements/randomizer/3drando/spoiler_log.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/spoiler_log.cpp
@@ -726,7 +726,18 @@ static void WriteAllLocations(int language) {
             break;
         }
 
-        jsonData["locations"][location->GetName()] = placedItemName;
+        // If it's a simple item (not an ice trap, doesn't have a price)
+        // just add the name of the item and move on
+        if (!location->HasScrubsanityPrice() &&
+            !location->HasShopsanityPrice() &&
+            location->GetPlacedItemKey() != ICE_TRAP) {
+            
+            jsonData["locations"][location->GetName()] = placedItemName;
+            continue;
+        }
+
+        // We're dealing with a complex item, build out the json object for it
+        jsonData["locations"][location->GetName()]["item"] = placedItemName;
 
         if (location->HasScrubsanityPrice() || location->HasShopsanityPrice()) {
           jsonData["locations"][location->GetName()]["price"] = location->GetPrice();


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/70942617/221093832-7ce6f8b0-55e3-4711-b8e7-200b0f37eeb9.png)
![image](https://user-images.githubusercontent.com/70942617/221094056-5872bf55-5be0-4914-8e49-cb308aab5482.png)


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/570892329.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/570892331.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/570892332.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/570892333.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/570892334.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/570892336.zip)
<!--- section:artifacts:end -->