### PR TITLE
Fix: add missing rando settings values that weren't being parsed on save creation

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/settings.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/settings.cpp
@@ -193,7 +193,7 @@ namespace Settings {
   Option ShuffleFrogSongRupees  = Option::Bool("Shuffle Frog Song Rupees",{"Off", "On"},                                                    {frogSongRupeesDesc});
   Option ShuffleAdultTradeQuest = Option::Bool("Shuffle Adult Trade",    {"Off", "On"},                                                     {adultTradeDesc});
   Option ShuffleChestMinigame   = Option::U8  ("Shuffle Chest Minigame", {"Off", "On (Separate)", "On (Pack)"},                             {chestMinigameDesc});
-  Option Shuffle100GSReward     = Option::Bool("Shuffle 100 GS Reward",  {"No", "Yes"},                                                     {shuffle100GsDesc},                                                                                                    OptionCategory::Toggle);
+  Option Shuffle100GSReward     = Option::Bool("Shuffle 100 GS Reward",  {"Off", "On"},                                                     {shuffle100GsDesc});
   std::vector<Option *> shuffleOptions = {
     &RandomizeShuffle,
     &ShuffleRewards,

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -207,24 +207,34 @@ std::unordered_map<s16, s16>
                           { GI_CLAIM_CHECK, ITEM_CLAIM_CHECK } };
 
 std::unordered_map<std::string, RandomizerSettingKey> SpoilerfileSettingNameToEnum = {
+    { "Detailed Logic Settings:Logic", RSK_LOGIC_RULES },
+    { "Detailed Logic Settings:Night GSs Expect Sun's", RSK_SKULLS_SUNS_SONG },
+    { "Detailed Logic Settings:All Locations Reachable", RSK_ALL_LOCATIONS_REACHABLE },
+    { "Item Pool Settings:Item Pool", RSK_ITEM_POOL },
+    { "Item Pool Settings:Ice Traps", RSK_ICE_TRAPS },
     { "Open Settings:Forest", RSK_FOREST },
     { "Open Settings:Kakariko Gate", RSK_KAK_GATE },
     { "Open Settings:Door of Time", RSK_DOOR_OF_TIME },
     { "Open Settings:Zora's Fountain", RSK_ZORAS_FOUNTAIN },
     { "Open Settings:Gerudo Fortress", RSK_GERUDO_FORTRESS },
     { "Open Settings:Rainbow Bridge", RSK_RAINBOW_BRIDGE },
+    { "Open Settings:Trial Count", RSK_TRIAL_COUNT },
     { "Open Settings:Stone Count", RSK_RAINBOW_BRIDGE_STONE_COUNT },
     { "Open Settings:Medallion Count", RSK_RAINBOW_BRIDGE_MEDALLION_COUNT },
     { "Open Settings:Reward Count", RSK_RAINBOW_BRIDGE_REWARD_COUNT },
     { "Open Settings:Dungeon Count", RSK_RAINBOW_BRIDGE_DUNGEON_COUNT },
     { "Open Settings:Token Count", RSK_RAINBOW_BRIDGE_TOKEN_COUNT },
+    { "Shuffle Settings:Shuffle Dungeon Rewards", RSK_SHUFFLE_DUNGEON_REWARDS },
     { "Shuffle Settings:Link's Pocket", RSK_LINKS_POCKET},
+    { "Shuffle Settings:Shuffle Songs", RSK_SHUFFLE_SONGS },
     { "Shuffle Settings:Shuffle Gerudo Card", RSK_SHUFFLE_GERUDO_MEMBERSHIP_CARD },
     { "Shuffle Settings:Shopsanity", RSK_SHOPSANITY },
     { "Shuffle Settings:Shopsanity Prices", RSK_SHOPSANITY_PRICES },
+    { "Shuffle Settings:Affordable Prices", RSK_SHOPSANITY_PRICES_AFFORDABLE },
     { "Shuffle Settings:Scrub Shuffle", RSK_SHUFFLE_SCRUBS },
     { "Shuffle Settings:Shuffle Cows", RSK_SHUFFLE_COWS },
     { "Shuffle Settings:Tokensanity", RSK_SHUFFLE_TOKENS },
+    { "Shuffle Settings:Shuffle Ocarinas", RSK_SHUFFLE_OCARINA },
     { "Shuffle Settings:Shuffle Adult Trade", RSK_SHUFFLE_ADULT_TRADE },
     { "Shuffle Settings:Shuffle Magic Beans", RSK_SHUFFLE_MAGIC_BEANS },
     { "Shuffle Settings:Shuffle Kokiri Sword", RSK_SHUFFLE_KOKIRI_SWORD },
@@ -257,6 +267,16 @@ std::unordered_map<std::string, RandomizerSettingKey> SpoilerfileSettingNameToEn
     { "Shuffle Dungeon Items:Reward Count", RSK_LACS_REWARD_COUNT },
     { "Shuffle Dungeon Items:Dungeon Count", RSK_LACS_DUNGEON_COUNT },
     { "Shuffle Dungeon Items:Token Count", RSK_LACS_TOKEN_COUNT },
+    { "Shuffle Dungeon Items:Key Rings", RSK_KEYRINGS },
+    { "Shuffle Dungeon Items:Keyring Dungeon Count", RSK_KEYRINGS_RANDOM_COUNT },
+    { "Shuffle Dungeon Items:Forest Temple", RSK_KEYRINGS_FOREST_TEMPLE },
+    { "Shuffle Dungeon Items:Fire Temple", RSK_KEYRINGS_FIRE_TEMPLE },
+    { "Shuffle Dungeon Items:Water Temple", RSK_KEYRINGS_WATER_TEMPLE },
+    { "Shuffle Dungeon Items:Spirit Temple", RSK_KEYRINGS_SPIRIT_TEMPLE },
+    { "Shuffle Dungeon Items:Shadow Temple", RSK_KEYRINGS_SHADOW_TEMPLE },
+    { "Shuffle Dungeon Items:Bottom of the Well", RSK_KEYRINGS_BOTTOM_OF_THE_WELL },
+    { "Shuffle Dungeon Items:GTG", RSK_KEYRINGS_GTG },
+    { "Shuffle Dungeon Items:Ganon's Castle", RSK_KEYRINGS_GANONS_CASTLE },
     { "World Settings:Starting Age", RSK_STARTING_AGE },
     { "World Settings:Ammo Drops", RSK_ENABLE_BOMBCHU_DROPS },
     { "World Settings:Bombchus in Logic", RSK_BOMBCHUS_IN_LOGIC },
@@ -637,9 +657,16 @@ void Randomizer::ParseRandomizerSettingsFile(const char* spoilerFileName) {
                 // and i don't want the spoilerfile to just have numbers instead of
                 // human readable settings values so it'll have to do for now
                 switch(gSaveContext.randoSettings[index].key) {
+                    case RSK_LOGIC_RULES:
+                        if (it.value() == "Glitchless") {
+                            gSaveContext.randoSettings[index].value = RO_LOGIC_GLITCHLESS;
+                        } else if (it.value() == "No Logic") {
+                            gSaveContext.randoSettings[index].value = RO_LOGIC_NO_LOGIC;
+                        }
+                        break;
                     case RSK_FOREST:
                         if(it.value() == "Closed") {
-                            gSaveContext.randoSettings[index].value = RO_FOREST_CLOSED;            
+                            gSaveContext.randoSettings[index].value = RO_FOREST_CLOSED;
                         } else if(it.value() == "Open") {
                             gSaveContext.randoSettings[index].value = RO_FOREST_OPEN;
                         } else if(it.value() == "Closed Deku") {
@@ -648,14 +675,14 @@ void Randomizer::ParseRandomizerSettingsFile(const char* spoilerFileName) {
                         break;
                     case RSK_KAK_GATE:
                         if(it.value() == "Closed") {
-                            gSaveContext.randoSettings[index].value = RO_KAK_GATE_CLOSED;            
+                            gSaveContext.randoSettings[index].value = RO_KAK_GATE_CLOSED;
                         } else if(it.value() == "Open") {
                             gSaveContext.randoSettings[index].value = RO_KAK_GATE_OPEN;
                         }
                         break;
                     case RSK_DOOR_OF_TIME:
                         if(it.value() == "Open") {
-                            gSaveContext.randoSettings[index].value = RO_DOOROFTIME_OPEN;            
+                            gSaveContext.randoSettings[index].value = RO_DOOROFTIME_OPEN;
                         } else if(it.value() == "Song only") {
                             gSaveContext.randoSettings[index].value = RO_DOOROFTIME_SONGONLY;
                         } else if(it.value() == "Closed") {
@@ -664,7 +691,7 @@ void Randomizer::ParseRandomizerSettingsFile(const char* spoilerFileName) {
                         break;
                     case RSK_ZORAS_FOUNTAIN:
                         if(it.value() == "Closed") {
-                            gSaveContext.randoSettings[index].value = RO_ZF_CLOSED;            
+                            gSaveContext.randoSettings[index].value = RO_ZF_CLOSED;
                         } else if(it.value() == "Closed as child") {
                             gSaveContext.randoSettings[index].value = RO_ZF_CLOSED_CHILD;
                         } else if(it.value() == "Open") {
@@ -680,7 +707,7 @@ void Randomizer::ParseRandomizerSettingsFile(const char* spoilerFileName) {
                         break;
                     case RSK_GERUDO_FORTRESS:
                         if(it.value() == "Normal") {
-                            gSaveContext.randoSettings[index].value = RO_GF_NORMAL;            
+                            gSaveContext.randoSettings[index].value = RO_GF_NORMAL;
                         } else if(it.value() == "Fast") {
                             gSaveContext.randoSettings[index].value = RO_GF_FAST;
                         } else if(it.value() == "Open") {
@@ -691,7 +718,7 @@ void Randomizer::ParseRandomizerSettingsFile(const char* spoilerFileName) {
                         if(it.value() == "Vanilla") {
                             gSaveContext.randoSettings[index].value = RO_BRIDGE_VANILLA;
                         } else if(it.value() == "Always open") {
-                            gSaveContext.randoSettings[index].value = RO_BRIDGE_ALWAYS_OPEN;            
+                            gSaveContext.randoSettings[index].value = RO_BRIDGE_ALWAYS_OPEN;
                         } else if(it.value() == "Stones") {
                             gSaveContext.randoSettings[index].value = RO_BRIDGE_STONES;
                         } else if(it.value() == "Medallions") {
@@ -711,11 +738,13 @@ void Randomizer::ParseRandomizerSettingsFile(const char* spoilerFileName) {
                     case RSK_RAINBOW_BRIDGE_REWARD_COUNT:
                     case RSK_RAINBOW_BRIDGE_DUNGEON_COUNT:
                     case RSK_RAINBOW_BRIDGE_TOKEN_COUNT:
+                    case RSK_TRIAL_COUNT:
                     case RSK_LACS_STONE_COUNT:
                     case RSK_LACS_MEDALLION_COUNT:
                     case RSK_LACS_REWARD_COUNT:
                     case RSK_LACS_DUNGEON_COUNT:
                     case RSK_LACS_TOKEN_COUNT:
+                    case RSK_KEYRINGS_RANDOM_COUNT:
                     case RSK_BIG_POE_COUNT:
                     case RSK_CUCCO_COUNT:
                     case RSK_STARTING_SKULLTULA_TOKEN:
@@ -724,7 +753,7 @@ void Randomizer::ParseRandomizerSettingsFile(const char* spoilerFileName) {
                         break;
                     case RSK_SHOPSANITY:
                         if(it.value() == "Off") {
-                            gSaveContext.randoSettings[index].value = RO_SHOPSANITY_OFF;         
+                            gSaveContext.randoSettings[index].value = RO_SHOPSANITY_OFF;
                         } else if(it.value() == "0 Items") {
                             gSaveContext.randoSettings[index].value = RO_SHOPSANITY_ZERO_ITEMS;
                         } else if(it.value() == "1 Item") {
@@ -753,7 +782,7 @@ void Randomizer::ParseRandomizerSettingsFile(const char* spoilerFileName) {
                         }
                     case RSK_SHUFFLE_SCRUBS:
                         if(it.value() == "Off") {
-                            gSaveContext.randoSettings[index].value = RO_SCRUBS_OFF;            
+                            gSaveContext.randoSettings[index].value = RO_SCRUBS_OFF;
                         } else if(it.value() == "Affordable") {
                             gSaveContext.randoSettings[index].value = RO_SCRUBS_AFFORDABLE;
                         } else if(it.value() == "Expensive") {
@@ -770,7 +799,7 @@ void Randomizer::ParseRandomizerSettingsFile(const char* spoilerFileName) {
                     case RSK_SHUFFLE_WEIRD_EGG:
                     case RSK_SHUFFLE_FROG_SONG_RUPEES:
                     case RSK_SHUFFLE_100_GS_REWARD:
-                    case RSK_RANDOM_MQ_DUNGEONS:
+                    case RSK_SHUFFLE_OCARINA:
                     case RSK_STARTING_DEKU_SHIELD:
                     case RSK_STARTING_KOKIRI_SWORD:
                     case RSK_STARTING_ZELDAS_LULLABY:
@@ -788,6 +817,7 @@ void Randomizer::ParseRandomizerSettingsFile(const char* spoilerFileName) {
                     case RSK_COMPLETE_MASK_QUEST:
                     case RSK_SKIP_SCARECROWS_SONG:
                     case RSK_ENABLE_GLITCH_CUTSCENES:
+                    case RSK_SKULLS_SUNS_SONG:
                     case RSK_BLUE_FIRE_ARROWS:
                     case RSK_SUNLIGHT_ARROWS:
                     case RSK_BOMBCHUS_IN_LOGIC:
@@ -802,6 +832,14 @@ void Randomizer::ParseRandomizerSettingsFile(const char* spoilerFileName) {
                     case RSK_KAK_50_SKULLS_HINT:
                     case RSK_WARP_SONG_HINTS:
                     case RSK_SCRUB_TEXT_HINT:
+                    case RSK_KEYRINGS_FOREST_TEMPLE:
+                    case RSK_KEYRINGS_FIRE_TEMPLE:
+                    case RSK_KEYRINGS_WATER_TEMPLE:
+                    case RSK_KEYRINGS_SHADOW_TEMPLE:
+                    case RSK_KEYRINGS_SPIRIT_TEMPLE:
+                    case RSK_KEYRINGS_BOTTOM_OF_THE_WELL:
+                    case RSK_KEYRINGS_GTG:
+                    case RSK_KEYRINGS_GANONS_CASTLE:
                     case RSK_SHUFFLE_ENTRANCES:
                     case RSK_SHUFFLE_OVERWORLD_ENTRANCES:
                     case RSK_SHUFFLE_GROTTO_ENTRANCES:
@@ -815,8 +853,20 @@ void Randomizer::ParseRandomizerSettingsFile(const char* spoilerFileName) {
                     case RSK_MIX_GROTTO_ENTRANCES:
                     case RSK_DECOUPLED_ENTRANCES:
                     case RSK_SHOPSANITY_PRICES_AFFORDABLE:
+                    case RSK_KEYRINGS:
+                        if (it.value() == "Off") {
+                            gSaveContext.randoSettings[index].value = RO_KEYRINGS_OFF;
+                        } else if (it.value() == "Random") {
+                            gSaveContext.randoSettings[index].value = RO_KEYRINGS_RANDOM;
+                        } else if (it.value() == "Count") {
+                            gSaveContext.randoSettings[index].value = RO_KEYRINGS_COUNT;
+                        } else if (it.value() == "Selection") {
+                            gSaveContext.randoSettings[index].value = RO_KEYRINGS_SELECTION;
+                        }
+                        break;
+                    case RSK_ALL_LOCATIONS_REACHABLE:
                         if(it.value() == "Off") {
-                            gSaveContext.randoSettings[index].value = RO_GENERIC_OFF;            
+                            gSaveContext.randoSettings[index].value = RO_GENERIC_OFF;
                         } else if(it.value() == "On") {
                             gSaveContext.randoSettings[index].value = RO_GENERIC_ON;
                         }
@@ -842,7 +892,7 @@ void Randomizer::ParseRandomizerSettingsFile(const char* spoilerFileName) {
                         break;
                     case RSK_STARTING_MAPS_COMPASSES:
                         if(it.value() == "Start With") {
-                            gSaveContext.randoSettings[index].value = RO_DUNGEON_ITEM_LOC_STARTWITH;            
+                            gSaveContext.randoSettings[index].value = RO_DUNGEON_ITEM_LOC_STARTWITH;
                         } else if(it.value() == "Vanilla") {
                             gSaveContext.randoSettings[index].value = RO_DUNGEON_ITEM_LOC_VANILLA;
                         } else if(it.value() == "Own Dungeon") {
@@ -857,7 +907,7 @@ void Randomizer::ParseRandomizerSettingsFile(const char* spoilerFileName) {
                         break;
                     case RSK_STARTING_OCARINA:
                         if(it.value() == "Off") {
-                            gSaveContext.randoSettings[index].value = RO_STARTING_OCARINA_OFF;            
+                            gSaveContext.randoSettings[index].value = RO_STARTING_OCARINA_OFF;
                         } else if(it.value() == "Fairy Ocarina") {
                             gSaveContext.randoSettings[index].value = RO_STARTING_OCARINA_FAIRY;
                         }
@@ -866,7 +916,7 @@ void Randomizer::ParseRandomizerSettingsFile(const char* spoilerFileName) {
                         if(it.value() == "Plentiful") {
                             gSaveContext.randoSettings[index].value = RO_ITEM_POOL_PLENTIFUL;
                         } else if(it.value() == "Balanced") {
-                            gSaveContext.randoSettings[index].value = RO_ITEM_POOL_BALANCED;            
+                            gSaveContext.randoSettings[index].value = RO_ITEM_POOL_BALANCED;
                         } else if(it.value() == "Scarce") {
                             gSaveContext.randoSettings[index].value = RO_ITEM_POOL_SCARCE;
                         } else if(it.value() == "Minimal") {
@@ -876,7 +926,7 @@ void Randomizer::ParseRandomizerSettingsFile(const char* spoilerFileName) {
                         if(it.value() == "Off") {
                             gSaveContext.randoSettings[index].value = RO_ICE_TRAPS_OFF;
                         } else if(it.value() == "Normal") {
-                            gSaveContext.randoSettings[index].value = RO_ICE_TRAPS_NORMAL;            
+                            gSaveContext.randoSettings[index].value = RO_ICE_TRAPS_NORMAL;
                         } else if(it.value() == "Extra") {
                             gSaveContext.randoSettings[index].value = RO_ICE_TRAPS_EXTRA;
                         } else if(it.value() == "Mayhem") {
@@ -886,7 +936,7 @@ void Randomizer::ParseRandomizerSettingsFile(const char* spoilerFileName) {
                         }
                     case RSK_GOSSIP_STONE_HINTS:
                         if(it.value() == "No Hints") {
-                            gSaveContext.randoSettings[index].value = RO_GOSSIP_STONES_NONE;            
+                            gSaveContext.randoSettings[index].value = RO_GOSSIP_STONES_NONE;
                         } else if(it.value() == "Need Nothing") {
                             gSaveContext.randoSettings[index].value = RO_GOSSIP_STONES_NEED_NOTHING;
                         } else if(it.value() == "Mask of Truth") {
@@ -897,7 +947,7 @@ void Randomizer::ParseRandomizerSettingsFile(const char* spoilerFileName) {
                         break;
                     case RSK_HINT_CLARITY:
                         if(it.value() == "Obscure") {
-                            gSaveContext.randoSettings[index].value = RO_HINT_CLARITY_OBSCURE;            
+                            gSaveContext.randoSettings[index].value = RO_HINT_CLARITY_OBSCURE;
                         } else if(it.value() == "Ambiguous") {
                             gSaveContext.randoSettings[index].value = RO_HINT_CLARITY_AMBIGUOUS;
                         } else if(it.value() == "Clear") {
@@ -906,7 +956,7 @@ void Randomizer::ParseRandomizerSettingsFile(const char* spoilerFileName) {
                         break;
                     case RSK_HINT_DISTRIBUTION:
                         if(it.value() == "Useless") {
-                            gSaveContext.randoSettings[index].value = RO_HINT_DIST_USELESS;            
+                            gSaveContext.randoSettings[index].value = RO_HINT_DIST_USELESS;
                         } else if(it.value() == "Balanced") {
                             gSaveContext.randoSettings[index].value = RO_HINT_DIST_BALANCED;
                         } else if(it.value() == "Strong") {
@@ -928,7 +978,7 @@ void Randomizer::ParseRandomizerSettingsFile(const char* spoilerFileName) {
                         break;
                     case RSK_KEYSANITY:
                         if(it.value() == "Start With") {
-                            gSaveContext.randoSettings[index].value = RO_DUNGEON_ITEM_LOC_STARTWITH;            
+                            gSaveContext.randoSettings[index].value = RO_DUNGEON_ITEM_LOC_STARTWITH;
                         } else if(it.value() == "Vanilla") {
                             gSaveContext.randoSettings[index].value = RO_DUNGEON_ITEM_LOC_VANILLA;
                         } else if(it.value() == "Own Dungeon") {
@@ -943,7 +993,7 @@ void Randomizer::ParseRandomizerSettingsFile(const char* spoilerFileName) {
                         break;
                     case RSK_BOSS_KEYSANITY:
                         if(it.value() == "Start With") {
-                            gSaveContext.randoSettings[index].value = RO_DUNGEON_ITEM_LOC_STARTWITH;            
+                            gSaveContext.randoSettings[index].value = RO_DUNGEON_ITEM_LOC_STARTWITH;
                         } else if(it.value() == "Vanilla") {
                             gSaveContext.randoSettings[index].value = RO_DUNGEON_ITEM_LOC_VANILLA;
                         } else if(it.value() == "Own Dungeon") {
@@ -991,7 +1041,7 @@ void Randomizer::ParseRandomizerSettingsFile(const char* spoilerFileName) {
                     case RSK_STARTING_CONSUMABLES:
                     case RSK_FULL_WALLETS:
                         if(it.value() == "No") {
-                            gSaveContext.randoSettings[index].value = RO_GENERIC_NO;            
+                            gSaveContext.randoSettings[index].value = RO_GENERIC_NO;
                         } else if(it.value() == "Yes") {
                             gSaveContext.randoSettings[index].value = RO_GENERIC_YES;
                         }
@@ -1003,6 +1053,26 @@ void Randomizer::ParseRandomizerSettingsFile(const char* spoilerFileName) {
                             gSaveContext.randoSettings[index].value = RO_GENERIC_DONT_SKIP;
                         } else if (it.value() == "Skip") {
                             gSaveContext.randoSettings[index].value = RO_GENERIC_SKIP;
+                        }
+                        break;
+                    case RSK_SHUFFLE_DUNGEON_REWARDS:
+                        if (it.value() == "End of dungeons") {
+                            gSaveContext.randoSettings[index].value = RO_DUNGEON_REWARDS_END_OF_DUNGEON;
+                        } else if (it.value() == "Any dungeon") {
+                            gSaveContext.randoSettings[index].value = RO_DUNGEON_REWARDS_ANY_DUNGEON;
+                        } else if (it.value() == "Overworld") {
+                            gSaveContext.randoSettings[index].value = RO_DUNGEON_REWARDS_OVERWORLD;
+                        } else if (it.value() == "Anywhere") {
+                            gSaveContext.randoSettings[index].value = RO_DUNGEON_REWARDS_ANYWHERE;
+                        }
+                        break;
+                    case RSK_SHUFFLE_SONGS:
+                        if (it.value() == "Song locations") {
+                            gSaveContext.randoSettings[index].value = RO_SONG_SHUFFLE_SONG_LOCATIONS;
+                        } else if (it.value() == "Dungeon rewards") {
+                            gSaveContext.randoSettings[index].value = RO_SONG_SHUFFLE_DUNGEON_REWARDS;
+                        } else if (it.value() == "Anywhere") {
+                            gSaveContext.randoSettings[index].value = RO_SONG_SHUFFLE_ANYWHERE;
                         }
                         break;
                     case RSK_SHUFFLE_TOKENS:


### PR DESCRIPTION
Not all rando settings were being parsed from the spoiler log as they weren't being used in game. But now with the check tracker, sometimes we need to know settings values to display/hide checks.

This adds all missing settings values that could be parsed.

The 100GS token in 3ds settings was marked as a toggle and using no/yes instead of off/on, updated so it parses correctly

The only ones I didn't touch were ganon trial setting and mq dungeon since thats not being saved into the spoiler log (skip/random/count). This is fine since the actual parts that matter are stored elsewhere in the save context.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/573073638.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/573073639.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/573073640.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/573073641.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/573073642.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/573073643.zip)
<!--- section:artifacts:end -->