### PR TITLE
[Game Interactor] Add LoadGame and ExitGame hooks

### DIFF
--- a/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
+++ b/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
@@ -1791,8 +1791,8 @@ void DrawCosmeticsEditor(bool& open) {
     ImGui::End();
 }
 
-void RegisterOnLoadFileHook() {
-    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnLoadFile>([](int32_t fileNum) {
+void RegisterOnLoadGameHook() {
+    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnLoadGame>([](int32_t fileNum) {
         ApplyOrResetCustomGfxPatches();
     });
 }
@@ -1817,7 +1817,7 @@ void InitCosmeticsEditor() {
     SohImGui::RequestCvarSaveOnNextTick();
     ApplyOrResetCustomGfxPatches();
 
-    RegisterOnLoadFileHook();
+    RegisterOnLoadGameHook();
 }
 
 void CosmeticsEditor_RandomizeAll() {

--- a/soh/soh/Enhancements/debugconsole.cpp
+++ b/soh/soh/Enhancements/debugconsole.cpp
@@ -206,6 +206,7 @@ static bool ResetHandler(std::shared_ptr<Ship::Console> Console, std::vector<std
 
     SET_NEXT_GAMESTATE(&gPlayState->state, TitleSetup_Init, GameState);
     gPlayState->state.running = false;
+    GameInteractor::Instance->ExecuteHooks<GameInteractor::OnExitGame>(gSaveContext.fileNum);
     return CMD_SUCCESS;
 }
 

--- a/soh/soh/Enhancements/game-interactor/GameInteractor.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor.h
@@ -84,13 +84,15 @@ public:
         }
     }
 
+    DEFINE_HOOK(OnLoadGame, void(int32_t fileNum));
+    DEFINE_HOOK(OnExitGame, void(int32_t fileNum));
     DEFINE_HOOK(OnReceiveItem, void(u8 item));
     DEFINE_HOOK(OnSceneInit, void(s16 sceneNum));
     
     
-    DEFINE_HOOK(OnSaveFile, void(int fileNum));
-    DEFINE_HOOK(OnLoadFile, void(int fileNum));
-    DEFINE_HOOK(OnDeleteFile, void(int fileNum));
+    DEFINE_HOOK(OnSaveFile, void(int32_t fileNum));
+    DEFINE_HOOK(OnLoadFile, void(int32_t fileNum));
+    DEFINE_HOOK(OnDeleteFile, void(int32_t fileNum));
 
     // Helpers
     static bool IsSaveLoaded();

--- a/soh/soh/Enhancements/game-interactor/GameInteractor_Hooks.cpp
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor_Hooks.cpp
@@ -6,6 +6,14 @@ extern PlayState* gPlayState;
 
 // MARK: - Gameplay
 
+void GameInteractor_ExecuteOnLoadGame(int32_t fileNum) {
+    GameInteractor::Instance->ExecuteHooks<GameInteractor::OnLoadGame>(fileNum);
+}
+
+void GameInteractor_ExecuteOnExitGame(int32_t fileNum) {
+    GameInteractor::Instance->ExecuteHooks<GameInteractor::OnExitGame>(fileNum);
+}
+
 void GameInteractor_ExecuteOnReceiveItemHooks(u8 item) {
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnReceiveItem>(item);
 }
@@ -16,14 +24,14 @@ void GameInteractor_ExecuteOnSceneInitHooks(s16 sceneNum) {
 
 // MARK: -  Save Files
 
-void GameInteractor_ExecuteOnSaveFile(int fileNum) {
+void GameInteractor_ExecuteOnSaveFile(int32_t fileNum) {
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnSaveFile>(fileNum);
 }
 
-void GameInteractor_ExecuteOnLoadFile(int fileNum) {
+void GameInteractor_ExecuteOnLoadFile(int32_t fileNum) {
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnLoadFile>(fileNum);
 }
 
-void GameInteractor_ExecuteOnDeleteFile(int fileNum) {
+void GameInteractor_ExecuteOnDeleteFile(int32_t fileNum) {
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnDeleteFile>(fileNum);
 }

--- a/soh/soh/Enhancements/game-interactor/GameInteractor_Hooks.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor_Hooks.h
@@ -1,10 +1,12 @@
 #include "GameInteractor.h"
 
 // MARK: - Gameplay
+extern "C" void GameInteractor_ExecuteOnLoadGame(int32_t fileNum);
+extern "C" void GameInteractor_ExecuteOnExitGame(int32_t fileNum);
 extern "C" void GameInteractor_ExecuteOnReceiveItemHooks(u8 item);
 extern "C" void GameInteractor_ExecuteOnSceneInit(s16 sceneNum);
 
 // MARK: -  Save Files
-extern "C" void GameInteractor_ExecuteOnSaveFile(int fileNum);
-extern "C" void GameInteractor_ExecuteOnLoadFile(int fileNum);
-extern "C" void GameInteractor_ExecuteOnDeleteFile(int fileNum);
+extern "C" void GameInteractor_ExecuteOnSaveFile(int32_t fileNum);
+extern "C" void GameInteractor_ExecuteOnLoadFile(int32_t fileNum);
+extern "C" void GameInteractor_ExecuteOnDeleteFile(int32_t fileNum);

--- a/soh/soh/Enhancements/randomizer/randomizer_entrance_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_entrance_tracker.cpp
@@ -1,9 +1,7 @@
 #include "randomizer_entrance_tracker.h"
-#include "../../util.h"
-#include "../../OTRGlobals.h"
+#include "soh/OTRGlobals.h"
 #include <ImGuiImpl.h>
-#include "../../UIWidgets.hpp"
-
+#include "soh/UIWidgets.hpp"
 
 #include <map>
 #include <string>
@@ -18,9 +16,11 @@ extern "C" {
 #include "macros.h"
 extern PlayState* gPlayState;
 
-#include "randomizer_entrance.h"
-#include "randomizer_grotto.h"
+#include "soh/Enhancements/randomizer/randomizer_entrance.h"
+#include "soh/Enhancements/randomizer/randomizer_grotto.h"
 }
+
+#include "soh/Enhancements/game-interactor/GameInteractor.h"
 
 #define COLOR_ORANGE IM_COL32(230, 159, 0, 255)
 #define COLOR_GREEN IM_COL32(0, 158, 115, 255)
@@ -920,4 +920,12 @@ void DrawEntranceTracker(bool& open) {
 
 void InitEntranceTracker() {
     SohImGui::AddWindow("Randomizer", "Entrance Tracker", DrawEntranceTracker, CVarGetInteger("gEntranceTrackerEnabled", 0) == 1);
+
+    // Setup hooks for loading and clearing the entrance tracker data
+    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnLoadGame>([](int32_t fileNum) {
+        InitEntranceTrackingData();
+    });
+    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnExitGame>([](int32_t fileNum) {
+        ClearEntranceTrackingData();
+    });
 }

--- a/soh/src/code/z_play.c
+++ b/soh/src/code/z_play.c
@@ -7,6 +7,7 @@
 #include <ImGuiImpl.h>
 #include "soh/frame_interpolation.h"
 #include "soh/Enhancements/debugconsole.h"
+#include "soh/Enhancements/game-interactor/GameInteractor.h"
 #include "soh/Enhancements/randomizer/randomizer_entrance.h"
 #include <overlays/actors/ovl_En_Niw/z_en_niw.h>
 
@@ -427,10 +428,12 @@ void Play_Init(GameState* thisx) {
         }
     }
 
+    // Invalid entrance, so immediately exit the game to opening title
     if (gSaveContext.entranceIndex == -1) {
         gSaveContext.entranceIndex = 0;
         play->state.running = false;
         SET_NEXT_GAMESTATE(&play->state, Opening_Init, OpeningContext);
+        GameInteractor_ExecuteOnExitGame(gSaveContext.fileNum);
         return;
     }
 

--- a/soh/src/code/z_sram.c
+++ b/soh/src/code/z_sram.c
@@ -611,6 +611,4 @@ void Sram_InitSram(GameState* gameState) {
     // When going from a rando save to a vanilla save within the same game instance
     // we need to reset the entrance table back to its vanilla state
     Entrance_ResetEntranceTable();
-    // Clear out the entrance tracker
-    Entrance_ClearEntranceTrackingData();
 }

--- a/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -9,6 +9,7 @@
 #include <GameVersions.h>
 #include "objects/object_mag/object_mag.h"
 #include "objects/gameplay_keep/gameplay_keep.h"
+#include "soh/Enhancements/game-interactor/GameInteractor.h"
 
 #define NORMAL_QUEST 0
 #define MASTER_QUEST 1
@@ -2159,6 +2160,8 @@ void FileChoose_LoadGame(GameState* thisx) {
             Entrance_SetSavewarpEntrance();
         }
     }
+
+    GameInteractor_ExecuteOnLoadGame(gSaveContext.fileNum);
 }
 
 static void (*gSelectModeUpdateFuncs[])(GameState*) = {

--- a/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -2149,7 +2149,6 @@ void FileChoose_LoadGame(GameState* thisx) {
     if (gSaveContext.n64ddFlag) {
         // Setup the modified entrance table and entrance shuffle table for rando
         Entrance_Init();
-        Entrance_InitEntranceTrackingData();
 
         // Handle randomized spawn positions after the save context has been setup from load
         // When remeber save location is on, set save warp if the save was in an a grotto, or

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
@@ -14,6 +14,7 @@
 #include "vt.h"
 
 #include "soh/frame_interpolation.h"
+#include "soh/Enhancements/game-interactor/GameInteractor.h"
 #include "soh/Enhancements/randomizer/randomizer_entrance.h"
 
 static void* sEquipmentFRATexs[] = {
@@ -4180,6 +4181,7 @@ void KaleidoScope_Update(PlayState* play)
                     } else {
                         play->state.running = 0;
                         SET_NEXT_GAMESTATE(&play->state, Opening_Init, OpeningContext);
+                        GameInteractor_ExecuteOnExitGame(gSaveContext.fileNum);
                     }
                 }
             }


### PR DESCRIPTION
This adds `LoadGame` and `ExitGame` hooks which can be used to run actions when entering/exiting the game. The hooks will have the file number passed in if needed by the consumer.

As an example, I have moved the entrance tracker data setup/teardown methods to use these hooks.

The hooks run in the following scenarios:

`LoadGame`
* When loading a file from the file select menu
* When using fast file select to automatically load into a save

`ExitGame`
* Choosing not to continue the game from the game over screen
* Using the reset command (Ctrl+R/selecting reset from the menu bar/using `reset` in the console)
* An invalid entrance was provided, causing the game to reset to the title opening

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/573583098.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/573583099.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/573583100.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/573583101.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/573583102.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/573583103.zip)
<!--- section:artifacts:end -->