### PR TITLE
Fix: MQ only cutscene crashes

### DIFF
--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -1186,7 +1186,14 @@ extern "C" SkeletonHeader* ResourceMgr_LoadSkeletonByName(const char* path) {
 }
 
 extern "C" s32* ResourceMgr_LoadCSByName(const char* path) {
-    return (s32*)GetResourceDataByName(path, false);
+    // Handle mq vs nonmq for cutscenes due to scene/ paths
+    auto res = ResourceMgr_LoadResource(path);
+
+    if (res == nullptr) {
+        return nullptr;
+    }
+
+    return (s32*)res->GetPointer();
 }
 
 std::filesystem::path GetSaveFile(std::shared_ptr<Mercury> Conf) {


### PR DESCRIPTION
After the resource refactor we were no longer accounting from swapping `/nonmq/` to `/mq/` for cutscene resources, and fetching the cutscene with only a MQ rom loaded would lead to crashes.

This updates the load CS resource function to use the method that handles converting nonmq -> mq paths.

Confirmed fixes #2452, fixes #2473

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/573759974.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/573759975.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/573759976.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/573759977.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/573759978.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/573759979.zip)
<!--- section:artifacts:end -->