### PR TITLE
fix greg hint (and an RSK parsing issue)

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -853,6 +853,13 @@ void Randomizer::ParseRandomizerSettingsFile(const char* spoilerFileName) {
                     case RSK_MIX_GROTTO_ENTRANCES:
                     case RSK_DECOUPLED_ENTRANCES:
                     case RSK_SHOPSANITY_PRICES_AFFORDABLE:
+                    case RSK_ALL_LOCATIONS_REACHABLE:
+                        if(it.value() == "Off") {
+                            gSaveContext.randoSettings[index].value = RO_GENERIC_OFF;
+                        } else if(it.value() == "On") {
+                            gSaveContext.randoSettings[index].value = RO_GENERIC_ON;
+                        }
+                        break;
                     case RSK_KEYRINGS:
                         if (it.value() == "Off") {
                             gSaveContext.randoSettings[index].value = RO_KEYRINGS_OFF;
@@ -862,13 +869,6 @@ void Randomizer::ParseRandomizerSettingsFile(const char* spoilerFileName) {
                             gSaveContext.randoSettings[index].value = RO_KEYRINGS_COUNT;
                         } else if (it.value() == "Selection") {
                             gSaveContext.randoSettings[index].value = RO_KEYRINGS_SELECTION;
-                        }
-                        break;
-                    case RSK_ALL_LOCATIONS_REACHABLE:
-                        if(it.value() == "Off") {
-                            gSaveContext.randoSettings[index].value = RO_GENERIC_OFF;
-                        } else if(it.value() == "On") {
-                            gSaveContext.randoSettings[index].value = RO_GENERIC_ON;
                         }
                         break;
                     case RSK_SHUFFLE_MERCHANTS:
@@ -888,21 +888,6 @@ void Randomizer::ParseRandomizerSettingsFile(const char* spoilerFileName) {
                             gSaveContext.randoSettings[index].value = RO_AMMO_DROPS_ON_PLUS_BOMBCHU;
                         } else if (it.value() == "Off") {
                             gSaveContext.randoSettings[index].value = RO_AMMO_DROPS_OFF;
-                        }
-                        break;
-                    case RSK_STARTING_MAPS_COMPASSES:
-                        if(it.value() == "Start With") {
-                            gSaveContext.randoSettings[index].value = RO_DUNGEON_ITEM_LOC_STARTWITH;
-                        } else if(it.value() == "Vanilla") {
-                            gSaveContext.randoSettings[index].value = RO_DUNGEON_ITEM_LOC_VANILLA;
-                        } else if(it.value() == "Own Dungeon") {
-                            gSaveContext.randoSettings[index].value = RO_DUNGEON_ITEM_LOC_OWN_DUNGEON;
-                        } else if(it.value() == "Any Dungeon") {
-                            gSaveContext.randoSettings[index].value = RO_DUNGEON_ITEM_LOC_ANY_DUNGEON;
-                        } else if(it.value() == "Overworld") {
-                            gSaveContext.randoSettings[index].value = RO_DUNGEON_ITEM_LOC_OVERWORLD;
-                        } else if(it.value() == "Anywhere") {
-                            gSaveContext.randoSettings[index].value = RO_DUNGEON_ITEM_LOC_ANYWHERE;
                         }
                         break;
                     case RSK_STARTING_OCARINA:
@@ -977,21 +962,8 @@ void Randomizer::ParseRandomizerSettingsFile(const char* spoilerFileName) {
                         }
                         break;
                     case RSK_KEYSANITY:
-                        if(it.value() == "Start With") {
-                            gSaveContext.randoSettings[index].value = RO_DUNGEON_ITEM_LOC_STARTWITH;
-                        } else if(it.value() == "Vanilla") {
-                            gSaveContext.randoSettings[index].value = RO_DUNGEON_ITEM_LOC_VANILLA;
-                        } else if(it.value() == "Own Dungeon") {
-                            gSaveContext.randoSettings[index].value = RO_DUNGEON_ITEM_LOC_OWN_DUNGEON;
-                        } else if(it.value() == "Any Dungeon") {
-                            gSaveContext.randoSettings[index].value = RO_DUNGEON_ITEM_LOC_ANY_DUNGEON;
-                        } else if(it.value() == "Overworld") {
-                            gSaveContext.randoSettings[index].value = RO_DUNGEON_ITEM_LOC_OVERWORLD;
-                        } else if(it.value() == "Anywhere") {
-                            gSaveContext.randoSettings[index].value = RO_DUNGEON_ITEM_LOC_ANYWHERE;
-                        }
-                        break;
                     case RSK_BOSS_KEYSANITY:
+                    case RSK_STARTING_MAPS_COMPASSES:
                         if(it.value() == "Start With") {
                             gSaveContext.randoSettings[index].value = RO_DUNGEON_ITEM_LOC_STARTWITH;
                         } else if(it.value() == "Vanilla") {

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -1648,7 +1648,7 @@ extern "C" int CustomMessage_RetrieveIfExists(PlayState* play) {
             }
         } else if (Randomizer_GetSettingValue(RSK_DAMPES_DIARY_HINT) && textId == TEXT_DAMPES_DIARY) {
             messageEntry = CustomMessageManager::Instance->RetrieveMessage(Randomizer::randoMiscHintsTableID, TEXT_DAMPES_DIARY);
-        } else if (Randomizer_GetSettingValue(RSK_GREG_HINT) && (textId == 0x704C || textId == 0x6E || textId == 0x84)) {
+        } else if (Randomizer_GetSettingValue(RSK_GREG_HINT) && (textId == 0x704C || textId == 0x6E)) {
             messageEntry = CustomMessageManager::Instance->RetrieveMessage(Randomizer::randoMiscHintsTableID, TEXT_CHEST_GAME_PROCEED);
         } else if (Randomizer_GetSettingValue(RSK_SHUFFLE_WARP_SONGS) &&
                    (textId >= TEXT_WARP_MINUET_OF_FOREST && textId <= TEXT_WARP_PRELUDE_OF_LIGHT)) {

--- a/soh/src/overlays/actors/ovl_En_Takara_Man/z_en_takara_man.c
+++ b/soh/src/overlays/actors/ovl_En_Takara_Man/z_en_takara_man.c
@@ -104,7 +104,14 @@ void func_80B1778C(EnTakaraMan* this, PlayState* play) {
 
         if (!this->unk_21A && this->unk_214) {
             if (Flags_GetSwitch(play, 0x32)) {
-                this->actor.textId = 0x84; //Thanks a lot! (Lost)
+                // text id 0x84 is used in places other than the treasure chest game.
+                // in order to provide a  unique text id that can be replaced for the custom
+                // greg hint, we set it to 0x6E instead
+                if (gSaveContext.n64ddFlag && Randomizer_GetSettingValue(RSK_GREG_HINT)) {
+                    this->actor.textId = 0x6E;
+                } else {
+                    this->actor.textId = 0x84; //Thanks a lot! (Lost)
+                }
                 this->dialogState = TEXT_STATE_EVENT;
             } else {
                 this->actor.textId = 0x704C; //Proceed


### PR DESCRIPTION
* make it so greg hint doesn't show up when shopkeepers say "Thanks a lot!" (buying refills after already having the item)
* fix RSK parsing so we don't try to parse all off/on options as keyrings
* remove a little copypasta in RSK parsing

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/574062997.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/574062998.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/574063000.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/574063001.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/574063002.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/574063003.zip)
<!--- section:artifacts:end -->