### PR TITLE
[Dev] Add Support for Github Codespaces

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,27 @@
+FROM mcr.microsoft.com/devcontainers/cpp:ubuntu-22.04
+
+RUN apt-get update && apt-get install -y libsdl2-dev libsdl2-net-dev libpng-dev libglew-dev ninja-build
+
+# Install latest SDL2
+RUN wget https://www.libsdl.org/release/SDL2-2.26.1.tar.gz && \
+   tar -xzf SDL2-2.26.1.tar.gz && \
+    cd SDL2-2.26.1 && \
+    ./configure && \
+    make && \
+    make install && \
+    cd .. && \
+    rm -rf SDL2-2.26.1 && \
+    rm SDL2-2.26.1.tar.gz && \
+    cp -av /usr/local/lib/libSDL* /lib/x86_64-linux-gnu/
+
+# Install latest SDL2_net
+RUN wget https://www.libsdl.org/projects/SDL_net/release/SDL2_net-2.2.0.tar.gz && \
+   tar -xzf SDL2_net-2.2.0.tar.gz && \
+    cd SDL2_net-2.2.0 && \
+    ./configure && \
+    make && \
+    make install && \
+    cd .. && \
+    rm -rf SDL2_net-2.2.0 && \
+    rm SDL2_net-2.2.0.tar.gz && \
+    cp -av /usr/local/lib/libSDL* /lib/x86_64-linux-gnu/

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,8 @@
+{
+	"image": "mcr.microsoft.com/devcontainers/universal:2",
+	"features": {
+		"ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
+			"packages": "libsdl2-dev libsdl2-net-dev libpng-dev libglew-dev ninja-build"
+		}
+	}
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,8 +1,29 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/cpp
 {
-	"image": "mcr.microsoft.com/devcontainers/universal:2",
-	"features": {
-		"ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
-			"packages": "libsdl2-dev libsdl2-net-dev libpng-dev libglew-dev ninja-build"
+	"name": "SoH",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Configure tool-specific properties.
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			"settings": {},
+			"extensions": []
 		}
 	}
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "gcc -v",
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
 }


### PR DESCRIPTION
Adds configuration to allow devs to build SoH using codespaces. Minimum required is 8GB RAM machine (4 core).

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/575522886.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/575522887.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/575522888.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/575522889.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/575522890.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/575522891.zip)
<!--- section:artifacts:end -->