### PR TITLE
[WIP] CVar rework

### DIFF
--- a/soh/CMakeLists.txt
+++ b/soh/CMakeLists.txt
@@ -148,6 +148,7 @@ set(Header_Files__include
     "include/z64player.h"
     "include/z64save.h"
     "include/z64scene.h"
+    "include/z64settings.h"
     "include/z64transition.h"
 )
 source_group("Header Files\\include" FILES ${Header_Files__include})
@@ -301,6 +302,8 @@ set(Source_Files__soh
     "soh/UIWidgets.hpp"
     "soh/UIWidgets.cpp"
     "soh/CrashHandlerExt.cpp"
+    "soh/GlobalSettings.h"
+    "soh/GlobalSettings.cpp"
 )
 source_group("Source Files\\soh" FILES ${Source_Files__soh})
 

--- a/soh/include/variables.h
+++ b/soh/include/variables.h
@@ -180,6 +180,7 @@ extern "C"
 	extern u64 gJpegUCodeData[];
 
 	extern SaveContext gSaveContext;
+	extern GlobalSettingsStruct gGlobalSettings;
 	extern GameInfo* gGameInfo;
 	extern u16 D_8015FCC0;
 	extern u16 D_8015FCC2;

--- a/soh/include/z64.h
+++ b/soh/include/z64.h
@@ -24,6 +24,7 @@
 #include "z64skin.h"
 #include "z64transition.h"
 #include "z64interface.h"
+#include "z64settings.h"
 #include "alignment.h"
 #include "sequence.h"
 #include "sfx.h"

--- a/soh/include/z64save.h
+++ b/soh/include/z64save.h
@@ -226,10 +226,7 @@ typedef struct {
     /* 0x1404 */ u16 minigameState;
     /* 0x1406 */ u16 minigameScore; // "yabusame_total"
     /* 0x1408 */ char unk_1408[0x0001];
-    /* 0x1409 */ u8 language; // NTSC 0: Japanese; 1: English | PAL 0: English; 1: German; 2: French
-    /* 0x140A */ u8 audioSetting;
     /* 0x140B */ char unk_140B[0x0001];
-    /* 0x140C */ u8 zTargetSetting; // 0: Switch; 1: Hold
     /* 0x140E */ u16 forcedSeqId; // immediately start playing the sequence if set
     /* 0x1410 */ u8 cutsceneTransitionControl; // context dependent usage: can either trigger a delayed fade or control fill alpha
     /* 0x1411 */ char unk_1411[0x0001];

--- a/soh/include/z64settings.h
+++ b/soh/include/z64settings.h
@@ -1,0 +1,12 @@
+#ifndef Z64SETTINGS_H
+#define Z64SETTINGS_H
+
+#include <libultraship/libultra.h>
+
+typedef struct {
+    s32 language; // NTSC 0: Japanese; 1: English | PAL 0: English; 1: German; 2: French
+    s32 zTargetSetting;
+    s32 audioSetting;
+} GlobalSettingsStruct;
+
+#endif

--- a/soh/include/z64settings.h
+++ b/soh/include/z64settings.h
@@ -4,9 +4,14 @@
 #include <libultraship/libultra.h>
 
 typedef struct {
+    s32 matchKeyColor;
+} RandomizerSettings;
+
+typedef struct {
     s32 language; // NTSC 0: Japanese; 1: English | PAL 0: English; 1: German; 2: French
     s32 zTargetSetting;
     s32 audioSetting;
+    RandomizerSettings rando;
 } GlobalSettingsStruct;
 
 #endif

--- a/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
+++ b/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
@@ -457,7 +457,7 @@ void DrawInfoTab() {
     UIWidgets::InsertHelpHoverText("Time, in seconds");
      
     const char* audioName;
-    switch (gSaveContext.audioSetting) { 
+    switch (gGlobalSettings.audioSetting) { 
         case 0:
             audioName = "Stereo";
             break;
@@ -475,16 +475,16 @@ void DrawInfoTab() {
     }
     if (ImGui::BeginCombo("Audio", audioName)) {
         if (ImGui::Selectable("Stereo")) {
-            gSaveContext.audioSetting = 0;
+            gGlobalSettings.audioSetting = 0;
         }
         if (ImGui::Selectable("Mono")) {
-            gSaveContext.audioSetting = 1;
+            gGlobalSettings.audioSetting = 1;
         }
         if (ImGui::Selectable("Headset")) {
-            gSaveContext.audioSetting = 2;
+            gGlobalSettings.audioSetting = 2;
         }
         if (ImGui::Selectable("Surround")) {
-            gSaveContext.audioSetting = 3;
+            gGlobalSettings.audioSetting = 3;
         }
 
         ImGui::EndCombo();
@@ -497,12 +497,12 @@ void DrawInfoTab() {
     }
     UIWidgets::InsertHelpHoverText("WARNING! If you save, your file may be locked! Use caution!");
     
-    if (ImGui::BeginCombo("Z Target Mode", gSaveContext.zTargetSetting ? "Hold" : "Switch")) {
+    if (ImGui::BeginCombo("Z Target Mode", gGlobalSettings.zTargetSetting ? "Hold" : "Switch")) {
         if (ImGui::Selectable("Switch")) {
-            gSaveContext.zTargetSetting = 0;
+            gGlobalSettings.zTargetSetting = 0;
         }
         if (ImGui::Selectable("Hold")) {
-            gSaveContext.zTargetSetting = 1;
+            gGlobalSettings.zTargetSetting = 1;
         }
         ImGui::EndCombo();
     }

--- a/soh/soh/Enhancements/randomizer/3drando/spoiler_log.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/spoiler_log.cpp
@@ -255,7 +255,7 @@ static void WriteLocation(
   ItemLocation* location = Location(locationKey);
 
   // auto node = parentNode->InsertNewChildElement("location");
-  switch (gSaveContext.language) {
+  switch (gGlobalSettings.language) {
         case LANGUAGE_ENG:
         default:
             jsonData["playthrough"][sphere][location->GetName()] = location->GetPlacedItemName().GetEnglish();
@@ -335,7 +335,7 @@ static void WriteShuffledEntrance(std::string sphereString, Entrance* entrance) 
     jsonData["entrances"].push_back(reverseEntranceJson);
   }
 
-  switch (gSaveContext.language) {
+  switch (gGlobalSettings.language) {
         case LANGUAGE_ENG:
         case LANGUAGE_FRA:
         default:
@@ -538,7 +538,7 @@ static void WriteRequiredTrials() {
     for (const auto& trial : Trial::trialList) {
         if (trial->IsRequired()) {
             std::string trialName;
-            switch (gSaveContext.language) {
+            switch (gGlobalSettings.language) {
                 case LANGUAGE_FRA:
                     trialName = trial->GetName().GetFrench();
                     break;

--- a/soh/soh/Enhancements/randomizer/draw.cpp
+++ b/soh/soh/Enhancements/randomizer/draw.cpp
@@ -3,6 +3,7 @@
 #include "z64.h"
 #include "macros.h"
 #include "functions.h"
+#include "variables.h"
 #include "randomizerTypes.h"
 #include <array>
 #include "objects/object_gi_key/object_gi_key.h"
@@ -12,7 +13,6 @@
 
 extern "C" void Randomizer_DrawSmallKey(PlayState* play, GetItemEntry* getItemEntry) {
     s32 pad;
-    s8 isColoredKeysEnabled = CVarGetInteger("gRandoMatchKeyColors", 0);
     s16 color_slot = getItemEntry->getItemId - RG_FOREST_TEMPLE_SMALL_KEY;
     s16 colors[9][3] = {
         { 4, 195, 46 },    // Forest Temple
@@ -33,14 +33,14 @@ extern "C" void Randomizer_DrawSmallKey(PlayState* play, GetItemEntry* getItemEn
     gSPMatrix(POLY_OPA_DISP++, Matrix_NewMtx(play->state.gfxCtx, (char*)__FILE__, __LINE__),
               G_MTX_MODELVIEW | G_MTX_LOAD);
 
-    if (isColoredKeysEnabled) {
+    if (gGlobalSettings.rando.matchKeyColor) {
         gDPSetGrayscaleColor(POLY_OPA_DISP++, colors[color_slot][0], colors[color_slot][1], colors[color_slot][2], 255);
         gSPGrayscale(POLY_OPA_DISP++, true);
     }
 
     gSPDisplayList(POLY_OPA_DISP++, (Gfx*)gGiSmallKeyDL);
 
-    if (isColoredKeysEnabled) {
+    if (gGlobalSettings.rando.matchKeyColor) {
         gSPGrayscale(POLY_OPA_DISP++, false);
     }
 
@@ -49,7 +49,6 @@ extern "C" void Randomizer_DrawSmallKey(PlayState* play, GetItemEntry* getItemEn
 
 extern "C" void Randomizer_DrawBossKey(PlayState* play, GetItemEntry* getItemEntry) {
     s32 pad;
-    s8 isColoredKeysEnabled = CVarGetInteger("gRandoMatchKeyColors", 0);
     s16 color_slot;
     color_slot = getItemEntry->getItemId - RG_FOREST_TEMPLE_BOSS_KEY;
     s16 colors[6][3] = {
@@ -68,14 +67,14 @@ extern "C" void Randomizer_DrawBossKey(PlayState* play, GetItemEntry* getItemEnt
     gSPMatrix(POLY_OPA_DISP++, Matrix_NewMtx(play->state.gfxCtx, (char*)__FILE__, __LINE__),
               G_MTX_MODELVIEW | G_MTX_LOAD);
 
-    if (color_slot == 5 && isColoredKeysEnabled) { // Ganon's Boss Key
+    if (color_slot == 5 && gGlobalSettings.rando.matchKeyColor) { // Ganon's Boss Key
         gDPSetGrayscaleColor(POLY_OPA_DISP++, 80, 80, 80, 255);
         gSPGrayscale(POLY_OPA_DISP++, true);
     }
 
     gSPDisplayList(POLY_OPA_DISP++, (Gfx*)gGiBossKeyDL);
 
-    if (color_slot == 5 && isColoredKeysEnabled) { // Ganon's Boss Key
+    if (color_slot == 5 && gGlobalSettings.rando.matchKeyColor) { // Ganon's Boss Key
         gSPGrayscale(POLY_OPA_DISP++, false);
     }
 
@@ -84,14 +83,14 @@ extern "C" void Randomizer_DrawBossKey(PlayState* play, GetItemEntry* getItemEnt
     gSPMatrix(POLY_XLU_DISP++, Matrix_NewMtx(play->state.gfxCtx, (char*)__FILE__, __LINE__),
               G_MTX_MODELVIEW | G_MTX_LOAD);
 
-    if (isColoredKeysEnabled) {
+    if (gGlobalSettings.rando.matchKeyColor) {
         gDPSetGrayscaleColor(POLY_XLU_DISP++, colors[color_slot][0], colors[color_slot][1], colors[color_slot][2], 255);
         gSPGrayscale(POLY_XLU_DISP++, true);
     }
 
     gSPDisplayList(POLY_XLU_DISP++, (Gfx*)gGiBossKeyGemDL);
 
-    if (isColoredKeysEnabled) {
+    if (gGlobalSettings.rando.matchKeyColor) {
         gSPGrayscale(POLY_XLU_DISP++, false);
     }
 

--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -845,10 +845,11 @@ void DrawLocation(RandomizerCheckObject rcObj, RandomizerCheckShow* thisCheckSta
             case RCSHOW_SCUMMED:
                 if (gSaveContext.n64ddFlag)
                     txt = OTRGlobals::Instance->gRandomizer
-                        ->EnumToSpoilerfileGetName[gSaveContext.itemLocations[rcObj.rc].get.rgID][gSaveContext.language];
-                else if (gSaveContext.language == LANGUAGE_ENG)
+                              ->EnumToSpoilerfileGetName[gSaveContext.itemLocations[rcObj.rc].get.rgID]
+                                                        [gGlobalSettings.language];
+                else if (gGlobalSettings.language == LANGUAGE_ENG)
                     txt = ItemFromGIID(rcObj.ogItemId).GetName().english;
-                else if (gSaveContext.language == LANGUAGE_FRA)
+                else if (gGlobalSettings.language == LANGUAGE_FRA)
                     txt = ItemFromGIID(rcObj.ogItemId).GetName().french;
                 break;
             case RCSHOW_SKIPPED:
@@ -857,10 +858,11 @@ void DrawLocation(RandomizerCheckObject rcObj, RandomizerCheckShow* thisCheckSta
             case RCSHOW_SEEN:
                 if (gSaveContext.n64ddFlag)
                     txt = OTRGlobals::Instance->gRandomizer
-                        ->EnumToSpoilerfileGetName[gSaveContext.itemLocations[rcObj.rc].get.fakeRgID][gSaveContext.language];
-                else if (gSaveContext.language == LANGUAGE_ENG)
+                              ->EnumToSpoilerfileGetName[gSaveContext.itemLocations[rcObj.rc].get.fakeRgID]
+                                                        [gGlobalSettings.language];
+                else if (gGlobalSettings.language == LANGUAGE_ENG)
                     txt = ItemFromGIID(rcObj.ogItemId).GetName().english;
-                else if (gSaveContext.language == LANGUAGE_FRA)
+                else if (gGlobalSettings.language == LANGUAGE_FRA)
                     txt = ItemFromGIID(rcObj.ogItemId).GetName().french;
                 break;
             case RCSHOW_HINTED:

--- a/soh/soh/GlobalSettings.cpp
+++ b/soh/soh/GlobalSettings.cpp
@@ -1,0 +1,25 @@
+#include "GlobalSettings.h"
+#include "z64.h"
+#include "variables.h"
+#include "core/bridge/consolevariablebridge.h"
+#include "core/Window.h"
+
+extern "C" GlobalSettingsStruct gGlobalSettings;
+
+namespace GlobalSettings {
+
+void Init() {
+    gGlobalSettings.language = LANGUAGE_ENG;
+    gGlobalSettings.zTargetSetting = 0;
+    gGlobalSettings.audioSetting = 0;
+}
+
+void RegisterCVars() {
+    std::shared_ptr<Ship::ConsoleVariable> cvar = Ship::Window::GetInstance()->GetConsoleVariables();
+
+    cvar->RegisterManaged("gLanguages", gGlobalSettings.language);
+    cvar->RegisterManaged("gZTargetSetting", gGlobalSettings.zTargetSetting);
+    cvar->RegisterManaged("gAudioSetting", gGlobalSettings.audioSetting);
+}
+
+} // namespace GlobalSettings

--- a/soh/soh/GlobalSettings.cpp
+++ b/soh/soh/GlobalSettings.cpp
@@ -12,6 +12,7 @@ void Init() {
     gGlobalSettings.language = LANGUAGE_ENG;
     gGlobalSettings.zTargetSetting = 0;
     gGlobalSettings.audioSetting = 0;
+    gGlobalSettings.rando.matchKeyColor = 0;
 }
 
 void RegisterCVars() {
@@ -20,6 +21,7 @@ void RegisterCVars() {
     cvar->RegisterManaged("gLanguages", gGlobalSettings.language);
     cvar->RegisterManaged("gZTargetSetting", gGlobalSettings.zTargetSetting);
     cvar->RegisterManaged("gAudioSetting", gGlobalSettings.audioSetting);
+    cvar->RegisterManaged("gRandoMatchKeyColors", gGlobalSettings.rando.matchKeyColor);
 }
 
 } // namespace GlobalSettings

--- a/soh/soh/GlobalSettings.h
+++ b/soh/soh/GlobalSettings.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "z64settings.h"
+
+namespace GlobalSettings {
+
+void Init();
+
+void RegisterCVars();
+
+}

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -47,6 +47,7 @@
 #include <Utils/StringHelper.h>
 #include <Hooks.h>
 #include "Enhancements/custom-message/CustomMessageManager.h"
+#include "GlobalSettings.h"
 
 #include <Fast3D/gfx_pc.h>
 #include <Fast3D/gfx_rendering_api.h>
@@ -230,6 +231,10 @@ OTRGlobals::OTRGlobals() {
         OOT_PAL_GC_DBG1,
         OOT_PAL_GC_DBG2
     };
+
+    GlobalSettings::Init();
+    Ship::RegisterHook<Ship::CVarInit>(GlobalSettings::RegisterCVars);
+
     context = Ship::Window::CreateInstance("Ship of Harkinian", OTRFiles);
 
     context->GetResourceManager()->GetResourceLoader()->RegisterResourceFactory(Ship::ResourceType::SOH_Animation, std::make_shared<Ship::AnimationFactory>());
@@ -564,6 +569,8 @@ extern "C" void InitOTR() {
 #endif
     SohImGui::AddSetupHooksDelegate(GameMenuBar::SetupHooks);
     SohImGui::RegisterMenuDrawMethod(GameMenuBar::Draw);
+
+    //GlobalSettings_Init();
 
     OTRGlobals::Instance = new OTRGlobals();
     SaveManager::Instance = new SaveManager();
@@ -1414,11 +1421,11 @@ extern "C" void* getN64WeirdFrame(s32 i) {
 extern "C" int GetEquipNowMessage(char* buffer, char* src, const int maxBufferSize) {
     std::string postfix;
 
-    if (gSaveContext.language == LANGUAGE_FRA) {
+    if (gGlobalSettings.language == LANGUAGE_FRA) {
         postfix = "\x04\x1A\x08" "D\x96sirez-vous l'\x96quiper maintenant?" "\x09&&"
                   "\x1B%g" "Oui" "&"
                            "Non" "%w\x02";
-    } else if (gSaveContext.language == LANGUAGE_GER) {
+    } else if (gGlobalSettings.language == LANGUAGE_GER) {
         postfix = "\x04\x1A\x08" "M""\x9A""chtest Du es jetzt ausr\x9Esten?" "\x09&&"
                   "\x1B%g" "Ja!" "&"
                            "Nein!" "%w\x02";
@@ -1687,7 +1694,7 @@ extern "C" int CustomMessage_RetrieveIfExists(PlayState* play) {
     }
     if (messageEntry.textBoxType != -1) {
         font->charTexBuf[0] = (messageEntry.textBoxType << 4) | messageEntry.textBoxPos;
-        switch (gSaveContext.language) {
+        switch (gGlobalSettings.language) {
             case LANGUAGE_FRA:
                 return msgCtx->msgLength = font->msgLength =
                            CopyStringToCharBuffer(messageEntry.french, buffer, maxBufferSize);

--- a/soh/soh/SaveManager.h
+++ b/soh/soh/SaveManager.h
@@ -109,7 +109,6 @@ public:
     std::filesystem::path GetFileName(int fileNum);
 
     void ConvertFromUnversioned();
-    void CreateDefaultGlobal();
 
     void InitMeta(int slotNum);
     static void InitFileImpl(bool isDebug);

--- a/soh/src/code/game.c
+++ b/soh/src/code/game.c
@@ -458,8 +458,6 @@ void GameState_Update(GameState* gameState) {
         }
     }
 
-    gSaveContext.language = CVarGetInteger("gLanguages", LANGUAGE_ENG);
-
     gameState->frames++;
 }
 

--- a/soh/src/code/z_actor.c
+++ b/soh/src/code/z_actor.c
@@ -1003,15 +1003,14 @@ void TitleCard_InitPlaceName(PlayState* play, TitleCardContext* titleCtx, void* 
 
     char newName[512];
 
-    if (gSaveContext.language != LANGUAGE_ENG) {
+    if (gGlobalSettings.language != LANGUAGE_ENG) {
         size_t length = strlen(texture);
         strcpy(newName, texture);
-        if (gSaveContext.language == LANGUAGE_FRA) {
+        if (gGlobalSettings.language == LANGUAGE_FRA) {
             newName[length - 6] = 'F';
             newName[length - 5] = 'R';
             newName[length - 4] = 'A';
-        }
-        else if (gSaveContext.language == LANGUAGE_GER) {
+        } else if (gGlobalSettings.language == LANGUAGE_GER) {
             newName[length - 6] = 'G';
             newName[length - 5] = 'E';
             newName[length - 4] = 'R';
@@ -1109,12 +1108,12 @@ void TitleCard_Draw(PlayState* play, TitleCardContext* titleCtx) {
         shiftBottomY = 0x1000;
 
         //if this card is bosses cards, has translation and that is not using English language.
-        if (titleCtx->isBossCard && titleCtx->hasTranslation && gSaveContext.language != LANGUAGE_ENG) {
-            textureLanguageOffset = (width * height * gSaveContext.language);
-            if (gSaveContext.language == LANGUAGE_GER) {
+        if (titleCtx->isBossCard && titleCtx->hasTranslation && gGlobalSettings.language != LANGUAGE_ENG) {
+            textureLanguageOffset = (width * height * gGlobalSettings.language);
+            if (gGlobalSettings.language == LANGUAGE_GER) {
                 shiftTopY = 0x400;
                 shiftBottomY = 0x1400;
-            } else if (gSaveContext.language == LANGUAGE_FRA) {
+            } else if (gGlobalSettings.language == LANGUAGE_FRA) {
                 shiftTopY = 0x800;
                 shiftBottomY = 0x1800;
             }

--- a/soh/src/code/z_common_data.c
+++ b/soh/src/code/z_common_data.c
@@ -2,6 +2,7 @@
 #include <string.h>
 
 SaveContext gSaveContext;
+GlobalSettingsStruct gGlobalSettings;
 
 void SaveContext_Init(void) {
     memset(&gSaveContext, 0, sizeof(gSaveContext));

--- a/soh/src/code/z_message_PAL.c
+++ b/soh/src/code/z_message_PAL.c
@@ -293,9 +293,9 @@ void Message_FindMessage(PlayState* play, u16 textId) {
         bufferId = 0x71B3;
     }
 
-    if (gSaveContext.language == LANGUAGE_GER)
+    if (gGlobalSettings.language == LANGUAGE_GER)
         messageTableEntry = sGerMessageEntryTablePtr;
-    else if (gSaveContext.language == LANGUAGE_FRA)
+    else if (gGlobalSettings.language == LANGUAGE_FRA)
         messageTableEntry = sFraMessageEntryTablePtr;
 
     // If PAL languages are not present in the OTR file, default to English
@@ -1127,7 +1127,7 @@ void Message_LoadItemIcon(PlayState* play, u16 itemId, s16 y) {
         interfaceCtx->mapPalette[31] = 0xFF;
     }
     if (itemId < ITEM_MEDALLION_FOREST) {
-        R_TEXTBOX_ICON_XPOS = R_TEXT_INIT_XPOS - sIconItem32XOffsets[gSaveContext.language];
+        R_TEXTBOX_ICON_XPOS = R_TEXT_INIT_XPOS - sIconItem32XOffsets[gGlobalSettings.language];
         R_TEXTBOX_ICON_YPOS = y + 6;
         R_TEXTBOX_ICON_SIZE = 32;
         memcpy((uintptr_t)msgCtx->textboxSegment + MESSAGE_STATIC_TEX_SIZE,
@@ -1135,7 +1135,7 @@ void Message_LoadItemIcon(PlayState* play, u16 itemId, s16 y) {
         // "Item 32-0"
         osSyncPrintf("アイテム32-0\n");
     } else {
-        R_TEXTBOX_ICON_XPOS = R_TEXT_INIT_XPOS - sIconItem24XOffsets[gSaveContext.language];
+        R_TEXTBOX_ICON_XPOS = R_TEXT_INIT_XPOS - sIconItem24XOffsets[gGlobalSettings.language];
         R_TEXTBOX_ICON_YPOS = y + 10;
         R_TEXTBOX_ICON_SIZE = 24;
         memcpy((uintptr_t)msgCtx->textboxSegment + MESSAGE_STATIC_TEX_SIZE,

--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -2889,14 +2889,14 @@ void Interface_LoadActionLabel(InterfaceContext* interfaceCtx, u16 action, s16 l
     char* doAction = actionsTbl[action];
 
     char newName[512];
-    if (gSaveContext.language != LANGUAGE_ENG) {
+    if (gGlobalSettings.language != LANGUAGE_ENG) {
         size_t length = strlen(doAction);
         strcpy(newName, doAction);
-        if (gSaveContext.language == LANGUAGE_FRA) {
+        if (gGlobalSettings.language == LANGUAGE_FRA) {
             newName[length - 6] = 'F';
             newName[length - 5] = 'R';
             newName[length - 4] = 'A';
-        } else if (gSaveContext.language == LANGUAGE_GER) {
+        } else if (gGlobalSettings.language == LANGUAGE_GER) {
             newName[length - 6] = 'G';
             newName[length - 5] = 'E';
             newName[length - 4] = 'R';
@@ -2975,14 +2975,14 @@ void Interface_LoadActionLabelB(PlayState* play, u16 action) {
     char* doAction = actionsTbl[action];
     char newName[512];
 
-    if (gSaveContext.language != LANGUAGE_ENG) {
+    if (gGlobalSettings.language != LANGUAGE_ENG) {
         size_t length = strlen(doAction);
         strcpy(newName, doAction);
-        if (gSaveContext.language == LANGUAGE_FRA) {
+        if (gGlobalSettings.language == LANGUAGE_FRA) {
             newName[length - 6] = 'F';
             newName[length - 5] = 'R';
             newName[length - 4] = 'A';
-        } else if (gSaveContext.language == LANGUAGE_GER) {
+        } else if (gGlobalSettings.language == LANGUAGE_GER) {
             newName[length - 6] = 'G';
             newName[length - 5] = 'E';
             newName[length - 4] = 'R';
@@ -3836,7 +3836,8 @@ void Interface_DrawItemButtons(PlayState* play) {
     int StartBTN_W_Scaled = StartBtn_Icon_W * Start_BTN_Scale;
     int StartBTN_W_factor = (1 << 10) * StartBtn_Icon_W / StartBTN_W_Scaled;
     int StartBTN_H_factor = (1 << 10) * StartBtn_Icon_H / StartBTN_H_Scaled;
-    const s16 PosX_StartBtn_ori = OTRGetRectDimensionFromRightEdge(startButtonLeftPos[gSaveContext.language]+X_Margins_StartBtn);
+    const s16 PosX_StartBtn_ori =
+        OTRGetRectDimensionFromRightEdge(startButtonLeftPos[gGlobalSettings.language] + X_Margins_StartBtn);
     const s16 PosY_StartBtn_ori = 16+Y_Margins_StartBtn;
     s16 StartBTN_Label_W = DO_ACTION_TEX_WIDTH();
     s16 StartBTN_Label_H = DO_ACTION_TEX_HEIGHT();
@@ -4063,14 +4064,14 @@ void Interface_DrawItemButtons(PlayState* play) {
             //There is probably a more elegant way to do it.
             char* doAction = actionsTbl[3];
             char newName[512];
-            if (gSaveContext.language != LANGUAGE_ENG) {
+            if (gGlobalSettings.language != LANGUAGE_ENG) {
                 size_t length = strlen(doAction);
                 strcpy(newName, doAction);
-                if (gSaveContext.language == LANGUAGE_FRA) {
+                if (gGlobalSettings.language == LANGUAGE_FRA) {
                     newName[length - 6] = 'F';
                     newName[length - 5] = 'R';
                     newName[length - 4] = 'A';
-                } else if (gSaveContext.language == LANGUAGE_GER) {
+                } else if (gGlobalSettings.language == LANGUAGE_GER) {
                     newName[length - 6] = 'G';
                     newName[length - 5] = 'E';
                     newName[length - 4] = 'R';
@@ -4125,7 +4126,7 @@ void Interface_DrawItemButtons(PlayState* play) {
             gDPSetCombineLERP(OVERLAY_DISP++, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0,
                               PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0);
 
-            gDPLoadTextureBlock_4b(OVERLAY_DISP++, cUpLabelTextures[gSaveContext.language], G_IM_FMT_IA, 32, 8, 0,
+            gDPLoadTextureBlock_4b(OVERLAY_DISP++, cUpLabelTextures[gGlobalSettings.language], G_IM_FMT_IA, 32, 8, 0,
                                    G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK,
                                    G_TX_NOLOD, G_TX_NOLOD);
 
@@ -4971,7 +4972,7 @@ void Interface_Draw(PlayState* play) {
                         break;
                 }
             } else {
-                if (CVarGetInteger("gCosmetics.Consumable_GreenRupee.Changed", rupeeWalletColors)) {
+                if (CVarGetInteger("gCosmetics.Consumable_GreenRupee.Changed", 0)) {
                      rColor = CVarGetColor24("gCosmetics.Consumable_GreenRupee.Value", rupeeWalletColors[0]);
                 } else {
                      rColor = rupeeWalletColors[0];
@@ -5186,10 +5187,10 @@ void Interface_Draw(PlayState* play) {
             // B Button Do Action Label
             s16 PosX_adjust;
             s16 PosY_adjust;
-            if (gSaveContext.language == 2) {
+            if (gGlobalSettings.language == 2) {
                 PosX_adjust = -12;
                 PosY_adjust = 5;
-            } else if (gSaveContext.language == 1) { //ger
+            } else if (gGlobalSettings.language == 1) { // ger
                 PosY_adjust = 6;
                 PosX_adjust = -9;
             } else {
@@ -5222,8 +5223,9 @@ void Interface_Draw(PlayState* play) {
                     BbtnPosX = -9999;
                 }
             } else {
-                BbtnPosX = OTRGetRectDimensionFromRightEdge(R_B_LABEL_X(gSaveContext.language)+X_Margins_BtnB_label);
-                BbtnPosY = R_B_LABEL_Y(gSaveContext.language)+Y_Margins_BtnB_label;
+                BbtnPosX =
+                    OTRGetRectDimensionFromRightEdge(R_B_LABEL_X(gGlobalSettings.language) + X_Margins_BtnB_label);
+                BbtnPosY = R_B_LABEL_Y(gGlobalSettings.language) + Y_Margins_BtnB_label;
             }
             gDPPipeSync(OVERLAY_DISP++);
             gDPSetCombineLERP(OVERLAY_DISP++, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0,
@@ -5234,7 +5236,7 @@ void Interface_Draw(PlayState* play) {
                                    DO_ACTION_TEX_WIDTH(), DO_ACTION_TEX_HEIGHT(), 0, G_TX_NOMIRROR | G_TX_WRAP,
                                    G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
 
-            R_B_LABEL_DD = (1 << 10) / (WREG(37 + gSaveContext.language) / 100.0f);
+            R_B_LABEL_DD = (1 << 10) / (WREG(37 + gGlobalSettings.language) / 100.0f);
             gSPWideTextureRectangle(OVERLAY_DISP++, BbtnPosX << 2, BbtnPosY << 2,
                                 (BbtnPosX + DO_ACTION_TEX_WIDTH()) << 2,
                                 (BbtnPosY + DO_ACTION_TEX_HEIGHT()) << 2, G_TX_RENDERTILE, 0, 0,
@@ -5428,7 +5430,7 @@ void Interface_Draw(PlayState* play) {
                           PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0);
         gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 255, 255, interfaceCtx->aAlpha);
         gDPSetEnvColor(OVERLAY_DISP++, 0, 0, 0, 0);
-        Matrix_Translate(-138.0f + rAIconX, rAIconY, WREG(46 + gSaveContext.language) / 10.0f, MTXMODE_NEW);
+        Matrix_Translate(-138.0f + rAIconX, rAIconY, WREG(46 + gGlobalSettings.language) / 10.0f, MTXMODE_NEW);
         Matrix_Scale(1.0f, 1.0f, 1.0f, MTXMODE_APPLY);
         Matrix_RotateX(interfaceCtx->unk_1F4 / 10000.0f, MTXMODE_APPLY);
         gSPMatrix(OVERLAY_DISP++, MATRIX_NEWMTX(play->state.gfxCtx),
@@ -6065,14 +6067,14 @@ void Interface_Update(PlayState* play) {
     Bottom_HUD_Margin = CVarGetInteger("gHUDMargin_B", 0);
 
     if (CHECK_BTN_ALL(debugInput->press.button, BTN_DLEFT)) {
-        gSaveContext.language = LANGUAGE_ENG;
-        osSyncPrintf("J_N=%x J_N=%x\n", gSaveContext.language, &gSaveContext.language);
+        gGlobalSettings.language = LANGUAGE_ENG;
+        osSyncPrintf("J_N=%x J_N=%x\n", gGlobalSettings.language, &gGlobalSettings.language);
     } else if (CHECK_BTN_ALL(debugInput->press.button, BTN_DUP)) {
-        gSaveContext.language = LANGUAGE_GER;
-        osSyncPrintf("J_N=%x J_N=%x\n", gSaveContext.language, &gSaveContext.language);
+        gGlobalSettings.language = LANGUAGE_GER;
+        osSyncPrintf("J_N=%x J_N=%x\n", gGlobalSettings.language, &gGlobalSettings.language);
     } else if (CHECK_BTN_ALL(debugInput->press.button, BTN_DRIGHT)) {
-        gSaveContext.language = LANGUAGE_FRA;
-        osSyncPrintf("J_N=%x J_N=%x\n", gSaveContext.language, &gSaveContext.language);
+        gGlobalSettings.language = LANGUAGE_FRA;
+        osSyncPrintf("J_N=%x J_N=%x\n", gGlobalSettings.language, &gGlobalSettings.language);
     }
 
     if ((play->pauseCtx.state == 0) && (play->pauseCtx.debugState == 0)) {

--- a/soh/src/code/z_sram.c
+++ b/soh/src/code/z_sram.c
@@ -606,7 +606,7 @@ void Sram_InitSave(FileChooseContext* fileChooseCtx) {
 void Sram_InitSram(GameState* gameState) {
     Save_Init();
 
-    func_800F6700(gSaveContext.audioSetting);
+    func_800F6700(gGlobalSettings.audioSetting);
 
     // When going from a rando save to a vanilla save within the same game instance
     // we need to reset the entrance table back to its vanilla state

--- a/soh/src/overlays/actors/ovl_En_Mag/z_en_mag.c
+++ b/soh/src/overlays/actors/ovl_En_Mag/z_en_mag.c
@@ -667,7 +667,7 @@ void EnMag_DrawInnerMq(Actor* thisx, PlayState* play, Gfx** gfxp) {
     u16 length;
     int lang = LANGUAGE_ENG;
     if (CVarGetInteger("gTitleScreenTranslation", 0)) {
-        lang = gSaveContext.language;
+        lang = gGlobalSettings.language;
     }
 
     gSPSegment(gfx++, 0x06, play->objectCtx.status[this->actor.objBankIndex].segment);
@@ -862,7 +862,7 @@ void EnMag_DrawInnerVanilla(Actor* thisx, PlayState* play, Gfx** gfxp) {
     u16 length;
     int lang = LANGUAGE_ENG;
     if (CVarGetInteger("gTitleScreenTranslation", 0)) {
-        lang = gSaveContext.language;
+        lang = gGlobalSettings.language;
     }
 
     gSPSegment(gfx++, 0x06, play->objectCtx.status[this->actor.objBankIndex].segment);

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -3258,7 +3258,7 @@ void func_80836BEC(Player* this, PlayState* play) {
                     actorToTarget = &GET_PLAYER(play)->actor;
                 }
 
-                holdTarget = (gSaveContext.zTargetSetting != 0) || (this->actor.category != ACTORCAT_PLAYER);
+                holdTarget = (gGlobalSettings.zTargetSetting != 0) || (this->actor.category != ACTORCAT_PLAYER);
                 this->stateFlags1 |= PLAYER_STATE1_15;
 
                 if ((actorToTarget != NULL) && !(actorToTarget->flags & ACTOR_FLAG_27)) {

--- a/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -1415,8 +1415,8 @@ void FileChoose_DrawWindowContents(GameState* thisx) {
     char* tex = (this->configMode == CM_QUEST_MENU || this->configMode == CM_ROTATE_TO_NAME_ENTRY || 
         this->configMode == CM_START_QUEST_MENU || this->configMode == CM_QUEST_TO_MAIN ||
         this->configMode == CM_NAME_ENTRY_TO_QUEST_MENU)
-                  ? ResourceMgr_LoadFileRaw(FileChoose_GetQuestChooseTitleTexName(gSaveContext.language))
-                  : sTitleLabels[gSaveContext.language][this->titleLabel];
+                    ? ResourceMgr_LoadFileRaw(FileChoose_GetQuestChooseTitleTexName(gGlobalSettings.language))
+                    : sTitleLabels[gGlobalSettings.language][this->titleLabel];
 
     OPEN_DISPS(this->state.gfxCtx);
 
@@ -1491,7 +1491,7 @@ void FileChoose_DrawWindowContents(GameState* thisx) {
     } else if (this->configMode != CM_ROTATE_TO_NAME_ENTRY) {
         gDPPipeSync(POLY_OPA_DISP++);
         gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 255, 255, 255, this->titleAlpha[1]);
-        gDPLoadTextureBlock(POLY_OPA_DISP++, sTitleLabels[gSaveContext.language][this->nextTitleLabel], G_IM_FMT_IA,
+        gDPLoadTextureBlock(POLY_OPA_DISP++, sTitleLabels[gGlobalSettings.language][this->nextTitleLabel], G_IM_FMT_IA,
                             G_IM_SIZ_8b, 128, 16, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK,
                             G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
         gSP1Quadrangle(POLY_OPA_DISP++, 0, 2, 3, 1, 0);
@@ -1530,7 +1530,7 @@ void FileChoose_DrawWindowContents(GameState* thisx) {
                                 this->fileButtonAlpha[i]);
             }
 
-            gDPLoadTextureBlock(POLY_OPA_DISP++, sFileButtonTextures[gSaveContext.language][i], G_IM_FMT_IA,
+            gDPLoadTextureBlock(POLY_OPA_DISP++, sFileButtonTextures[gGlobalSettings.language][i], G_IM_FMT_IA,
                                 G_IM_SIZ_16b, 64, 16, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP,
                                 G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
             gSP1Quadrangle(POLY_OPA_DISP++, 0, 2, 3, 1, 0);
@@ -1620,7 +1620,7 @@ void FileChoose_DrawWindowContents(GameState* thisx) {
             gDPPipeSync(POLY_OPA_DISP++);
             gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, this->windowColor[0], this->windowColor[1], this->windowColor[2],
                             this->actionButtonAlpha[i]);
-            gDPLoadTextureBlock(POLY_OPA_DISP++, sActionButtonTextures[gSaveContext.language][i], G_IM_FMT_IA,
+            gDPLoadTextureBlock(POLY_OPA_DISP++, sActionButtonTextures[gGlobalSettings.language][i], G_IM_FMT_IA,
                                 G_IM_SIZ_16b, 64, 16, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP,
                                 G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
             gSP1Quadrangle(POLY_OPA_DISP++, quadVtxIndex, quadVtxIndex + 2, quadVtxIndex + 3, quadVtxIndex + 1, 0);
@@ -1634,7 +1634,7 @@ void FileChoose_DrawWindowContents(GameState* thisx) {
 
             gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, this->windowColor[0], this->windowColor[1], this->windowColor[2],
                             this->confirmButtonAlpha[i]);
-            gDPLoadTextureBlock(POLY_OPA_DISP++, sActionButtonTextures[gSaveContext.language][temp], G_IM_FMT_IA,
+            gDPLoadTextureBlock(POLY_OPA_DISP++, sActionButtonTextures[gGlobalSettings.language][temp], G_IM_FMT_IA,
                                 G_IM_SIZ_16b, 64, 16, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP,
                                 G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
             gSP1Quadrangle(POLY_OPA_DISP++, quadVtxIndex, quadVtxIndex + 2, quadVtxIndex + 3, quadVtxIndex + 1, 0);
@@ -1644,7 +1644,8 @@ void FileChoose_DrawWindowContents(GameState* thisx) {
         gDPPipeSync(POLY_OPA_DISP++);
         gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, this->windowColor[0], this->windowColor[1], this->windowColor[2],
                         this->optionButtonAlpha);
-        gDPLoadTextureBlock(POLY_OPA_DISP++, sOptionsButtonTextures[gSaveContext.language], G_IM_FMT_IA, G_IM_SIZ_16b,
+        gDPLoadTextureBlock(POLY_OPA_DISP++, sOptionsButtonTextures[gGlobalSettings.language], G_IM_FMT_IA,
+                            G_IM_SIZ_16b,
                             64, 16, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK,
                             G_TX_NOLOD, G_TX_NOLOD);
         gSP1Quadrangle(POLY_OPA_DISP++, 8, 10, 11, 9, 0);
@@ -1673,7 +1674,8 @@ void FileChoose_DrawWindowContents(GameState* thisx) {
                               PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0);
             gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 255, 255, 255, this->emptyFileTextAlpha);
             gDPSetEnvColor(POLY_OPA_DISP++, 0, 0, 0, 0);
-            gDPLoadTextureBlock(POLY_OPA_DISP++, sWarningLabels[gSaveContext.language][this->warningLabel], G_IM_FMT_IA,
+            gDPLoadTextureBlock(POLY_OPA_DISP++, sWarningLabels[gGlobalSettings.language][this->warningLabel],
+                                G_IM_FMT_IA,
                                 G_IM_SIZ_8b, 128, 16, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP,
                                 G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
             gSP1Quadrangle(POLY_OPA_DISP++, 16, 18, 19, 17, 0);
@@ -2421,7 +2423,8 @@ void FileChoose_Main(GameState* thisx) {
                           PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0);
         gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, helpTextColor.r, helpTextColor.g, helpTextColor.b, this->controlsAlpha);
         gDPSetEnvColor(POLY_OPA_DISP++, 0, 0, 0, 0);
-        gDPLoadTextureBlock(POLY_OPA_DISP++, controlsTextures[gSaveContext.language], G_IM_FMT_IA, G_IM_SIZ_8b, 144, 16,
+        gDPLoadTextureBlock(POLY_OPA_DISP++, controlsTextures[gGlobalSettings.language], G_IM_FMT_IA, G_IM_SIZ_8b, 144,
+                            16,
                             0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK,
                             G_TX_NOLOD, G_TX_NOLOD);
         gSPTextureRectangle(POLY_OPA_DISP++, 0x0168, 0x0330, 0x03A8, 0x0370, G_TX_RENDERTILE, 0, 0, 0x0400, 0x0400);

--- a/soh/src/overlays/gamestates/ovl_file_choose/z_file_nameset_PAL.c
+++ b/soh/src/overlays/gamestates/ovl_file_choose/z_file_nameset_PAL.c
@@ -124,7 +124,8 @@ void FileChoose_SetNameEntryVtx(GameState* thisx) {
     gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 255, 255, 255, this->titleAlpha[0]);
     gDPSetEnvColor(POLY_OPA_DISP++, 0, 0, 0, 0);
     gSPVertex(POLY_OPA_DISP++, D_80811BB0, 24, 0);
-    gDPLoadTextureBlock(POLY_OPA_DISP++, sNameLabelTextures[gSaveContext.language], G_IM_FMT_IA, G_IM_SIZ_8b, 56, 16, 0,
+    gDPLoadTextureBlock(POLY_OPA_DISP++, sNameLabelTextures[gGlobalSettings.language], G_IM_FMT_IA, G_IM_SIZ_8b, 56, 16,
+                        0,
                         G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD,
                         G_TX_NOLOD);
     gSP1Quadrangle(POLY_OPA_DISP++, 0, 2, 3, 1, 0);
@@ -135,7 +136,7 @@ void FileChoose_SetNameEntryVtx(GameState* thisx) {
         gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, this->windowColor[0], this->windowColor[1], this->windowColor[2],
                         255);
         gDPSetEnvColor(POLY_OPA_DISP++, 0, 0, 0, 0);
-        gDPLoadTextureBlock(POLY_OPA_DISP++, sBackspaceEndTextures[gSaveContext.language][phi_t1], G_IM_FMT_IA,
+        gDPLoadTextureBlock(POLY_OPA_DISP++, sBackspaceEndTextures[gGlobalSettings.language][phi_t1], G_IM_FMT_IA,
                             G_IM_SIZ_16b, sBackspaceEndWidths[phi_t1], 16, 0, G_TX_NOMIRROR | G_TX_WRAP,
                             G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
         gSP1Quadrangle(POLY_OPA_DISP++, phi_s0, phi_s0 + 2, phi_s0 + 3, phi_s0 + 1, 0);
@@ -675,11 +676,11 @@ void FileChoose_UpdateOptionsMenu(GameState* thisx) {
         osSyncPrintf("ＳＡＶＥ");
         Save_SaveGlobal();
         osSyncPrintf(VT_FGCOL(YELLOW));
-        osSyncPrintf("Na_SetSoundOutputMode = %d\n", gSaveContext.audioSetting);
-        osSyncPrintf("Na_SetSoundOutputMode = %d\n", gSaveContext.audioSetting);
-        osSyncPrintf("Na_SetSoundOutputMode = %d\n", gSaveContext.audioSetting);
+        osSyncPrintf("Na_SetSoundOutputMode = %d\n", gGlobalSettings.audioSetting);
+        osSyncPrintf("Na_SetSoundOutputMode = %d\n", gGlobalSettings.audioSetting);
+        osSyncPrintf("Na_SetSoundOutputMode = %d\n", gGlobalSettings.audioSetting);
         osSyncPrintf(VT_RST);
-        func_800F6700(gSaveContext.audioSetting);
+        func_800F6700(gGlobalSettings.audioSetting);
         osSyncPrintf("終了\n");
         return;
     }
@@ -688,26 +689,26 @@ void FileChoose_UpdateOptionsMenu(GameState* thisx) {
         Audio_PlaySoundGeneral(NA_SE_SY_FSEL_CURSOR, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
 
         if (sSelectedSetting == FS_SETTING_AUDIO) {
-            gSaveContext.audioSetting--;
+            gGlobalSettings.audioSetting--;
 
             // because audio setting is unsigned, can't check for < 0
-            if (gSaveContext.audioSetting > 0xF0) {
-                gSaveContext.audioSetting = FS_AUDIO_SURROUND;
+            if (gGlobalSettings.audioSetting > 0xF0) {
+                gGlobalSettings.audioSetting = FS_AUDIO_SURROUND;
             }
         } else {
-            gSaveContext.zTargetSetting ^= 1;
+            gGlobalSettings.zTargetSetting ^= 1;
         }
     } else if ((this->stickRelX > 30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DRIGHT))) {
         Audio_PlaySoundGeneral(NA_SE_SY_FSEL_CURSOR, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
 
         if (sSelectedSetting == FS_SETTING_AUDIO) {
-            gSaveContext.audioSetting++;
+            gGlobalSettings.audioSetting++;
 
-            if (gSaveContext.audioSetting > FS_AUDIO_SURROUND) {
-                gSaveContext.audioSetting = FS_AUDIO_STEREO;
+            if (gGlobalSettings.audioSetting > FS_AUDIO_SURROUND) {
+                gGlobalSettings.audioSetting = FS_AUDIO_STEREO;
             }
         } else {
-            gSaveContext.zTargetSetting ^= 1;
+            gGlobalSettings.zTargetSetting ^= 1;
         }
     }
 
@@ -880,7 +881,7 @@ void FileChoose_DrawOptionsImpl(GameState* thisx) {
         }
     }
 
-    if (gSaveContext.language == LANGUAGE_GER) {
+    if (gGlobalSettings.language == LANGUAGE_GER) {
         gSPVertex(POLY_OPA_DISP++, D_80811E30, 32, 0);
     } else {
         gSPVertex(POLY_OPA_DISP++, D_80811D30, 32, 0);
@@ -893,14 +894,14 @@ void FileChoose_DrawOptionsImpl(GameState* thisx) {
     gDPSetEnvColor(POLY_OPA_DISP++, 0, 0, 0, 255);
 
     for (i = 0, vtx = 0; i < 4; i++, vtx += 4) {
-        gDPLoadTextureBlock(POLY_OPA_DISP++, gOptionsMenuHeaders[i].texture[gSaveContext.language], G_IM_FMT_IA,
-                            G_IM_SIZ_8b, gOptionsMenuHeaders[i].width[gSaveContext.language],
+        gDPLoadTextureBlock(POLY_OPA_DISP++, gOptionsMenuHeaders[i].texture[gGlobalSettings.language], G_IM_FMT_IA,
+                            G_IM_SIZ_8b, gOptionsMenuHeaders[i].width[gGlobalSettings.language],
                             gOptionsMenuHeaders[i].height, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP,
                             G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
         gSP1Quadrangle(POLY_OPA_DISP++, vtx, vtx + 2, vtx + 3, vtx + 1, 0);
     }
 
-    if (gSaveContext.language == LANGUAGE_GER) {
+    if (gGlobalSettings.language == LANGUAGE_GER) {
         gSPVertex(POLY_OPA_DISP++, D_80812130, 32, 0);
     } else {
         gSPVertex(POLY_OPA_DISP++, D_80811F30, 32, 0);
@@ -908,7 +909,7 @@ void FileChoose_DrawOptionsImpl(GameState* thisx) {
 
     for (i = 0, vtx = 0; i < 4; i++, vtx += 4) {
         gDPPipeSync(POLY_OPA_DISP++);
-        if (i == gSaveContext.audioSetting) {
+        if (i == gGlobalSettings.audioSetting) {
             if (sSelectedSetting == FS_SETTING_AUDIO) {
                 gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, cursorPrimRed, cursorPrimGreen, cursorPrimBlue,
                                 this->titleAlpha[0]);
@@ -922,8 +923,8 @@ void FileChoose_DrawOptionsImpl(GameState* thisx) {
             gDPSetEnvColor(POLY_OPA_DISP++, 0, 0, 0, 255);
         }
 
-        gDPLoadTextureBlock(POLY_OPA_DISP++, gOptionsMenuSettings[i].texture[gSaveContext.language], G_IM_FMT_IA,
-                            G_IM_SIZ_8b, gOptionsMenuSettings[i].width[gSaveContext.language],
+        gDPLoadTextureBlock(POLY_OPA_DISP++, gOptionsMenuSettings[i].texture[gGlobalSettings.language], G_IM_FMT_IA,
+                            G_IM_SIZ_8b, gOptionsMenuSettings[i].width[gGlobalSettings.language],
                             gOptionsMenuSettings[i].height, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP,
                             G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
         gSP1Quadrangle(POLY_OPA_DISP++, vtx, vtx + 2, vtx + 3, vtx + 1, 0);
@@ -932,7 +933,7 @@ void FileChoose_DrawOptionsImpl(GameState* thisx) {
     for (; i < 6; i++, vtx += 4) {
         gDPPipeSync(POLY_OPA_DISP++);
 
-        if (i == (gSaveContext.zTargetSetting + 4)) {
+        if (i == (gGlobalSettings.zTargetSetting + 4)) {
             if (sSelectedSetting != FS_SETTING_AUDIO) {
                 gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, cursorPrimRed, cursorPrimGreen, cursorPrimBlue,
                                 this->titleAlpha[0]);
@@ -946,8 +947,8 @@ void FileChoose_DrawOptionsImpl(GameState* thisx) {
             gDPSetEnvColor(POLY_OPA_DISP++, 0, 0, 0, 255);
         }
 
-        gDPLoadTextureBlock(POLY_OPA_DISP++, gOptionsMenuSettings[i].texture[gSaveContext.language], G_IM_FMT_IA,
-                            G_IM_SIZ_8b, gOptionsMenuSettings[i].width[gSaveContext.language],
+        gDPLoadTextureBlock(POLY_OPA_DISP++, gOptionsMenuSettings[i].texture[gGlobalSettings.language], G_IM_FMT_IA,
+                            G_IM_SIZ_8b, gOptionsMenuSettings[i].width[gGlobalSettings.language],
                             gOptionsMenuSettings[i].height, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP,
                             G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
         gSP1Quadrangle(POLY_OPA_DISP++, vtx, vtx + 2, vtx + 3, vtx + 1, 0);

--- a/soh/src/overlays/gamestates/ovl_select/z_select.c
+++ b/soh/src/overlays/gamestates/ovl_select/z_select.c
@@ -1036,7 +1036,7 @@ void Select_PrintMenu(SelectContext* this, GfxPrint* printer) {
         }
 
         if (CVarGetInteger("gDebugWarpScreenTranslation", 0)) {
-            switch (gSaveContext.language) {
+            switch (gGlobalSettings.language) {
                 case LANGUAGE_ENG:
                 default:
                     name = this->scenes[scene].englishName;
@@ -1062,7 +1062,7 @@ void Select_PrintMenu(SelectContext* this, GfxPrint* printer) {
     GfxPrint_SetColor(printer, 155, 55, 150, 255);
 
     // Small position hack of the OPT=X text since german Link's Age overlap if translated
-    if (CVarGetInteger("gDebugWarpScreenTranslation", 0) && gSaveContext.language == LANGUAGE_GER) {
+    if (CVarGetInteger("gDebugWarpScreenTranslation", 0) && gGlobalSettings.language == LANGUAGE_GER) {
         GfxPrint_SetPos(printer, 26, 26);
     } else {
         GfxPrint_SetPos(printer, 20, 26);
@@ -1092,7 +1092,7 @@ void Better_Select_PrintMenu(SelectContext* this, GfxPrint* printer) {
         }
         
         if (CVarGetInteger("gDebugWarpScreenTranslation", 0)) {
-            switch (gSaveContext.language) {
+            switch (gGlobalSettings.language) {
                 case LANGUAGE_ENG:
                 default:
                     name = this->betterScenes[scene].englishName;
@@ -1118,7 +1118,7 @@ void Better_Select_PrintMenu(SelectContext* this, GfxPrint* printer) {
     GfxPrint_SetPos(printer, 3, 26);
 
     if (CVarGetInteger("gDebugWarpScreenTranslation", 0)) {
-        switch (gSaveContext.language) {
+        switch (gGlobalSettings.language) {
             case LANGUAGE_ENG:
             default:
                 GfxPrint_Printf(printer, "%s", this->betterScenes[this->currentScene].entrancePairs[this->pageDownIndex].englishName);
@@ -1158,7 +1158,7 @@ void Select_PrintLoadingMessage(SelectContext* this, GfxPrint* printer) {
     GfxPrint_SetColor(printer, 255, 255, 255, 255);
     randomMsg = Rand_ZeroOne() * ARRAY_COUNT(sLoadingMessages);
     if (CVarGetInteger("gDebugWarpScreenTranslation", 0)) {
-        switch (gSaveContext.language) {
+        switch (gGlobalSettings.language) {
             case LANGUAGE_ENG:
             default:
                 GfxPrint_Printf(printer, "%s", sLoadingMessages[randomMsg].englishMessage);
@@ -1189,7 +1189,7 @@ void Select_PrintAgeSetting(SelectContext* this, GfxPrint* printer, s32 age) {
     GfxPrint_SetPos(printer, 4, 26);
     GfxPrint_SetColor(printer, 255, 255, 55, 255);
     if (CVarGetInteger("gDebugWarpScreenTranslation", 0)) {
-        switch (gSaveContext.language) {
+        switch (gGlobalSettings.language) {
             case LANGUAGE_ENG:
             default:
                 GfxPrint_Printf(printer, "Age:%s", sAgeLabels[age].englishAge);
@@ -1210,7 +1210,7 @@ void Better_Select_PrintAgeSetting(SelectContext* this, GfxPrint* printer, s32 a
     GfxPrint_SetPos(printer, 25, 25);
     GfxPrint_SetColor(printer, 100, 100, 100, 255);
     if (CVarGetInteger("gDebugWarpScreenTranslation", 0)) {
-        switch (gSaveContext.language) {
+        switch (gGlobalSettings.language) {
             case LANGUAGE_ENG:
             case LANGUAGE_FRA:
             default:
@@ -1226,7 +1226,7 @@ void Better_Select_PrintAgeSetting(SelectContext* this, GfxPrint* printer, s32 a
     
     GfxPrint_SetColor(printer, 55, 200, 50, 255);
     if (CVarGetInteger("gDebugWarpScreenTranslation", 0)) {
-        switch (gSaveContext.language) {
+        switch (gGlobalSettings.language) {
             case LANGUAGE_ENG:
             default:
                 GfxPrint_Printf(printer, "%s", sBetterAgeLabels[age].englishAge);
@@ -1261,7 +1261,7 @@ void Select_PrintCutsceneSetting(SelectContext* this, GfxPrint* printer, u16 csI
     };
     
     char* label;
-    int lang = CVarGetInteger("gDebugWarpScreenTranslation", 0) ? gSaveContext.language + 1 : 0;
+    int lang = CVarGetInteger("gDebugWarpScreenTranslation", 0) ? gGlobalSettings.language + 1 : 0;
 
     GfxPrint_SetPos(printer, 4, 25);
     GfxPrint_SetColor(printer, 255, 255, 55, 255);
@@ -1325,7 +1325,7 @@ void Better_Select_PrintTimeSetting(SelectContext* this, GfxPrint* printer) {
 
     if (gSaveContext.dayTime > 0xC000 || gSaveContext.dayTime < 0x4555) {
         if (CVarGetInteger("gDebugWarpScreenTranslation", 0)) {
-            switch (gSaveContext.language) {
+            switch (gGlobalSettings.language) {
                 case LANGUAGE_ENG:
                 default:
                     label = "Night";
@@ -1342,7 +1342,7 @@ void Better_Select_PrintTimeSetting(SelectContext* this, GfxPrint* printer) {
         }
     } else {
         if (CVarGetInteger("gDebugWarpScreenTranslation", 0)) {
-            switch (gSaveContext.language) {
+            switch (gGlobalSettings.language) {
                 case LANGUAGE_ENG:
                 default:
                     label = "Day";
@@ -1359,7 +1359,7 @@ void Better_Select_PrintTimeSetting(SelectContext* this, GfxPrint* printer) {
         }
     }
     if (CVarGetInteger("gDebugWarpScreenTranslation", 0)) {
-        switch (gSaveContext.language) {
+        switch (gGlobalSettings.language) {
             case LANGUAGE_ENG:
             default:
                 GfxPrint_Printf(printer, "(Z/R)Time:");

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_map_PAL.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_map_PAL.c
@@ -224,7 +224,8 @@ void KaleidoScope_DrawDungeonMap(PlayState* play, GraphicsContext* gfxCtx) {
 
     gSPVertex(POLY_KAL_DISP++, &pauseCtx->mapPageVtx[68], 16, 0);
 
-    gDPLoadTextureBlock(POLY_KAL_DISP++, dungeonTitleTexs[gSaveContext.mapIndex+(10*gSaveContext.language)], G_IM_FMT_IA, G_IM_SIZ_8b, 96, 16, 0,
+    gDPLoadTextureBlock(POLY_KAL_DISP++, dungeonTitleTexs[gSaveContext.mapIndex + (10 * gGlobalSettings.language)],
+                        G_IM_FMT_IA, G_IM_SIZ_8b, 96, 16, 0,
                         G_TX_WRAP | G_TX_NOMIRROR, G_TX_WRAP | G_TX_NOMIRROR, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD,
                         G_TX_NOLOD);
 
@@ -733,7 +734,7 @@ void KaleidoScope_DrawWorldMap(PlayState* play, GraphicsContext* gfxCtx) {
                       PRIMITIVE, 0);
     gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 0, 0, 0, pauseCtx->alpha);
 
-    gDPLoadTextureBlock_4b(POLY_KAL_DISP++, currentPosTitleTexs[gSaveContext.language], G_IM_FMT_I, 64, 8, 0,
+    gDPLoadTextureBlock_4b(POLY_KAL_DISP++, currentPosTitleTexs[gGlobalSettings.language], G_IM_FMT_I, 64, 8, 0,
                            G_TX_WRAP | G_TX_NOMIRROR, G_TX_WRAP | G_TX_NOMIRROR, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD,
                            G_TX_NOLOD);
 

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
@@ -1249,7 +1249,7 @@ void KaleidoScope_DrawPages(PlayState* play, GraphicsContext* gfxCtx) {
                       G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
 
             POLY_KAL_DISP = KaleidoScope_DrawPageSections(POLY_KAL_DISP, pauseCtx->itemPageVtx,
-                                                          sSelectItemTexs[gSaveContext.language]);
+                                                          sSelectItemTexs[gGlobalSettings.language]);
 
             KaleidoScope_DrawItemSelect(play);
         }
@@ -1267,7 +1267,7 @@ void KaleidoScope_DrawPages(PlayState* play, GraphicsContext* gfxCtx) {
                       G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
 
             POLY_KAL_DISP = KaleidoScope_DrawPageSections(POLY_KAL_DISP, pauseCtx->equipPageVtx,
-                                                          sEquipmentTexs[gSaveContext.language]);
+                                                          sEquipmentTexs[gGlobalSettings.language]);
 
             KaleidoScope_DrawEquipment(play);
         }
@@ -1286,7 +1286,7 @@ void KaleidoScope_DrawPages(PlayState* play, GraphicsContext* gfxCtx) {
                       G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
 
             POLY_KAL_DISP = KaleidoScope_DrawPageSections(POLY_KAL_DISP, pauseCtx->questPageVtx,
-                                                          sQuestStatusTexs[gSaveContext.language]);
+                                                          sQuestStatusTexs[gGlobalSettings.language]);
 
             KaleidoScope_DrawQuestStatus(play, gfxCtx);
         }
@@ -1305,7 +1305,7 @@ void KaleidoScope_DrawPages(PlayState* play, GraphicsContext* gfxCtx) {
                       G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
 
             POLY_KAL_DISP =
-                KaleidoScope_DrawPageSections(POLY_KAL_DISP, pauseCtx->mapPageVtx, sMapTexs[gSaveContext.language]);
+                KaleidoScope_DrawPageSections(POLY_KAL_DISP, pauseCtx->mapPageVtx, sMapTexs[gGlobalSettings.language]);
 
             if (sInDungeonScene) {
                 KaleidoScope_DrawDungeonMap(play, gfxCtx);
@@ -1334,7 +1334,7 @@ void KaleidoScope_DrawPages(PlayState* play, GraphicsContext* gfxCtx) {
                           G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
 
                 POLY_KAL_DISP = KaleidoScope_DrawPageSections(POLY_KAL_DISP, pauseCtx->itemPageVtx,
-                                                              sSelectItemTexs[gSaveContext.language]);
+                                                              sSelectItemTexs[gGlobalSettings.language]);
 
                 KaleidoScope_DrawItemSelect(play);
                 break;
@@ -1348,8 +1348,8 @@ void KaleidoScope_DrawPages(PlayState* play, GraphicsContext* gfxCtx) {
                 gSPMatrix(POLY_KAL_DISP++, MATRIX_NEWMTX(gfxCtx),
                           G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
 
-                POLY_KAL_DISP =
-                    KaleidoScope_DrawPageSections(POLY_KAL_DISP, pauseCtx->mapPageVtx, sMapTexs[gSaveContext.language]);
+                POLY_KAL_DISP = KaleidoScope_DrawPageSections(POLY_KAL_DISP, pauseCtx->mapPageVtx,
+                                                              sMapTexs[gGlobalSettings.language]);
 
                 if (sInDungeonScene) {
                     KaleidoScope_DrawDungeonMap(play, gfxCtx);
@@ -1381,7 +1381,7 @@ void KaleidoScope_DrawPages(PlayState* play, GraphicsContext* gfxCtx) {
                           G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
 
                 POLY_KAL_DISP = KaleidoScope_DrawPageSections(POLY_KAL_DISP, pauseCtx->questPageVtx,
-                                                              sQuestStatusTexs[gSaveContext.language]);
+                                                              sQuestStatusTexs[gGlobalSettings.language]);
 
                 KaleidoScope_DrawQuestStatus(play, gfxCtx);
 
@@ -1400,7 +1400,7 @@ void KaleidoScope_DrawPages(PlayState* play, GraphicsContext* gfxCtx) {
                           G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
 
                 POLY_KAL_DISP = KaleidoScope_DrawPageSections(POLY_KAL_DISP, pauseCtx->equipPageVtx,
-                                                              sEquipmentTexs[gSaveContext.language]);
+                                                              sEquipmentTexs[gGlobalSettings.language]);
 
                 KaleidoScope_DrawEquipment(play);
 
@@ -1454,14 +1454,14 @@ void KaleidoScope_DrawPages(PlayState* play, GraphicsContext* gfxCtx) {
             POLY_KAL_DISP = KaleidoScope_DrawPageSections(POLY_KAL_DISP, pauseCtx->saveVtx, sGameOverTexs);
         } else {
             POLY_KAL_DISP =
-                KaleidoScope_DrawPageSections(POLY_KAL_DISP, pauseCtx->saveVtx, sSaveTexs[gSaveContext.language]);
+                KaleidoScope_DrawPageSections(POLY_KAL_DISP, pauseCtx->saveVtx, sSaveTexs[gGlobalSettings.language]);
         }
 
         gSPVertex(POLY_KAL_DISP++, &pauseCtx->saveVtx[60], 32, 0);
 
         if (((pauseCtx->state == 7) && (pauseCtx->unk_1EC < 4)) || (pauseCtx->state == 0xE)) {
             POLY_KAL_DISP =
-                KaleidoScope_QuadTextureIA8(POLY_KAL_DISP, sSavePromptTexs[gSaveContext.language], 152, 16, 0);
+                KaleidoScope_QuadTextureIA8(POLY_KAL_DISP, sSavePromptTexs[gGlobalSettings.language], 152, 16, 0);
 
             gDPSetCombineLERP(POLY_KAL_DISP++, 1, 0, PRIMITIVE, 0, TEXEL0, 0, PRIMITIVE, 0, 1, 0, PRIMITIVE, 0, TEXEL0,
                               0, PRIMITIVE, 0);
@@ -1478,18 +1478,18 @@ void KaleidoScope_DrawPages(PlayState* play, GraphicsContext* gfxCtx) {
             gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 255, 255, 255, pauseCtx->alpha);
 
             POLY_KAL_DISP =
-                KaleidoScope_QuadTextureIA8(POLY_KAL_DISP, sPromptChoiceTexs[gSaveContext.language][0], 48, 16, 12);
+                KaleidoScope_QuadTextureIA8(POLY_KAL_DISP, sPromptChoiceTexs[gGlobalSettings.language][0], 48, 16, 12);
 
             POLY_KAL_DISP =
-                KaleidoScope_QuadTextureIA8(POLY_KAL_DISP, sPromptChoiceTexs[gSaveContext.language][1], 48, 16, 16);
+                KaleidoScope_QuadTextureIA8(POLY_KAL_DISP, sPromptChoiceTexs[gGlobalSettings.language][1], 48, 16, 16);
         } else if (((pauseCtx->state == 7 && pauseCtx->unk_1EC >= 4) || pauseCtx->state == 0xF) &&
                    !CVarGetInteger("gSkipSaveConfirmation", 0)) {
             POLY_KAL_DISP =
-                KaleidoScope_QuadTextureIA8(POLY_KAL_DISP, sSaveConfirmationTexs[gSaveContext.language], 152, 16, 0);
+                KaleidoScope_QuadTextureIA8(POLY_KAL_DISP, sSaveConfirmationTexs[gGlobalSettings.language], 152, 16, 0);
         } else if ((pauseCtx->state != 7) || (pauseCtx->unk_1EC < 4)) {
             if ((pauseCtx->state != 0xF) && ((pauseCtx->state == 0x10) || (pauseCtx->state == 0x11))) {
-                POLY_KAL_DISP =
-                    KaleidoScope_QuadTextureIA8(POLY_KAL_DISP, sContinuePromptTexs[gSaveContext.language], 152, 16, 0);
+                POLY_KAL_DISP = KaleidoScope_QuadTextureIA8(POLY_KAL_DISP,
+                                                            sContinuePromptTexs[gGlobalSettings.language], 152, 16, 0);
 
                 gDPSetCombineLERP(POLY_KAL_DISP++, 1, 0, PRIMITIVE, 0, TEXEL0, 0, PRIMITIVE, 0, 1, 0, PRIMITIVE, 0,
                                   TEXEL0, 0, PRIMITIVE, 0);
@@ -1505,11 +1505,11 @@ void KaleidoScope_DrawPages(PlayState* play, GraphicsContext* gfxCtx) {
                 gDPSetCombineMode(POLY_KAL_DISP++, G_CC_MODULATEIA, G_CC_MODULATEIA);
                 gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 255, 255, 255, pauseCtx->alpha);
 
-                POLY_KAL_DISP =
-                    KaleidoScope_QuadTextureIA8(POLY_KAL_DISP, sPromptChoiceTexs[gSaveContext.language][0], 48, 16, 12);
+                POLY_KAL_DISP = KaleidoScope_QuadTextureIA8(POLY_KAL_DISP,
+                                                            sPromptChoiceTexs[gGlobalSettings.language][0], 48, 16, 12);
 
-                POLY_KAL_DISP =
-                    KaleidoScope_QuadTextureIA8(POLY_KAL_DISP, sPromptChoiceTexs[gSaveContext.language][1], 48, 16, 16);
+                POLY_KAL_DISP = KaleidoScope_QuadTextureIA8(POLY_KAL_DISP,
+                                                            sPromptChoiceTexs[gGlobalSettings.language][1], 48, 16, 16);
             }
         }
 
@@ -1866,20 +1866,22 @@ void KaleidoScope_DrawInfoPanel(PlayState* play) {
         gSPVertex(POLY_KAL_DISP++, &pauseCtx->infoPanelVtx[16], 8, 0);
 
         if (pauseCtx->state == 7) {
-            pauseCtx->infoPanelVtx[16].v.ob[0] = pauseCtx->infoPanelVtx[18].v.ob[0] = WREG(61 + gSaveContext.language);
+            pauseCtx->infoPanelVtx[16].v.ob[0] = pauseCtx->infoPanelVtx[18].v.ob[0] =
+                WREG(61 + gGlobalSettings.language);
 
             pauseCtx->infoPanelVtx[17].v.ob[0] = pauseCtx->infoPanelVtx[19].v.ob[0] =
                 pauseCtx->infoPanelVtx[16].v.ob[0] + 24;
 
             pauseCtx->infoPanelVtx[20].v.ob[0] = pauseCtx->infoPanelVtx[22].v.ob[0] =
-                pauseCtx->infoPanelVtx[16].v.ob[0] + WREG(52 + gSaveContext.language);
+                pauseCtx->infoPanelVtx[16].v.ob[0] + WREG(52 + gGlobalSettings.language);
 
             pauseCtx->infoPanelVtx[21].v.ob[0] = pauseCtx->infoPanelVtx[23].v.ob[0] =
-                pauseCtx->infoPanelVtx[20].v.ob[0] + D_8082ADE0[gSaveContext.language];
+                pauseCtx->infoPanelVtx[20].v.ob[0] + D_8082ADE0[gGlobalSettings.language];
 
             pauseCtx->infoPanelVtx[17].v.tc[0] = pauseCtx->infoPanelVtx[19].v.tc[0] = 0x300;
 
-            pauseCtx->infoPanelVtx[21].v.tc[0] = pauseCtx->infoPanelVtx[23].v.tc[0] = D_8082ADE0[gSaveContext.language]
+            pauseCtx->infoPanelVtx[21].v.tc[0] = pauseCtx->infoPanelVtx[23].v.tc[0] =
+                D_8082ADE0[gGlobalSettings.language]
                                                                                       << 5;
             gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, aButtonColor.r, aButtonColor.g, aButtonColor.b, 255);
             //gSPDisplayList(POLY_KAL_DISP++, gAButtonIconDL);//This is changed to load the texture only so we can prim color it.
@@ -1889,8 +1891,8 @@ void KaleidoScope_DrawInfoPanel(PlayState* play) {
             gDPPipeSync(POLY_KAL_DISP++);
             gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 255, 255, 255, 255);
 
-            POLY_KAL_DISP = KaleidoScope_QuadTextureIA8(POLY_KAL_DISP, sToDecideTextures[gSaveContext.language],
-                                                        D_8082ADE0[gSaveContext.language], 16, 4);
+            POLY_KAL_DISP = KaleidoScope_QuadTextureIA8(POLY_KAL_DISP, sToDecideTextures[gGlobalSettings.language],
+                                                        D_8082ADE0[gGlobalSettings.language], 16, 4);
         } else if (pauseCtx->cursorSpecialPos != 0) {
             if ((pauseCtx->state == 6) && (pauseCtx->unk_1E4 == 0)) {
                 pauseCtx->infoPanelVtx[16].v.ob[0] = pauseCtx->infoPanelVtx[18].v.ob[0] = -63;
@@ -1905,10 +1907,10 @@ void KaleidoScope_DrawInfoPanel(PlayState* play) {
 
                 if (pauseCtx->cursorSpecialPos == PAUSE_CURSOR_PAGE_LEFT) {
                     POLY_KAL_DISP = KaleidoScope_QuadTextureIA8(
-                        POLY_KAL_DISP, D_8082AD78[pauseCtx->pageIndex][gSaveContext.language], 128, 16, 0);
+                        POLY_KAL_DISP, D_8082AD78[pauseCtx->pageIndex][gGlobalSettings.language], 128, 16, 0);
                 } else {
                     POLY_KAL_DISP = KaleidoScope_QuadTextureIA8(
-                        POLY_KAL_DISP, D_8082ADA8[pauseCtx->pageIndex][gSaveContext.language], 128, 16, 0);
+                        POLY_KAL_DISP, D_8082ADA8[pauseCtx->pageIndex][gGlobalSettings.language], 128, 16, 0);
                 }
             }
         } else {
@@ -1917,26 +1919,26 @@ void KaleidoScope_DrawInfoPanel(PlayState* play) {
                 (CVarGetInteger("gPauseAnyCursor", 0) == PAUSE_ANY_CURSOR_ALWAYS_ON);
             if (!pauseCtx->pageIndex && (!pauseAnyCursor || (gSaveContext.inventory.items[pauseCtx->cursorPoint[PAUSE_ITEM]] != ITEM_NONE))) { // pageIndex == PAUSE_ITEM
                 pauseCtx->infoPanelVtx[16].v.ob[0] = pauseCtx->infoPanelVtx[18].v.ob[0] =
-                    WREG(49 + gSaveContext.language);
+                    WREG(49 + gGlobalSettings.language);
 
                 pauseCtx->infoPanelVtx[17].v.ob[0] = pauseCtx->infoPanelVtx[19].v.ob[0] =
                     pauseCtx->infoPanelVtx[16].v.ob[0] + 48;
 
                 pauseCtx->infoPanelVtx[20].v.ob[0] = pauseCtx->infoPanelVtx[22].v.ob[0] =
-                    pauseCtx->infoPanelVtx[16].v.ob[0] + WREG(58 + gSaveContext.language);
+                    pauseCtx->infoPanelVtx[16].v.ob[0] + WREG(58 + gGlobalSettings.language);
 
                 pauseCtx->infoPanelVtx[21].v.ob[0] = pauseCtx->infoPanelVtx[23].v.ob[0] =
-                    pauseCtx->infoPanelVtx[20].v.ob[0] + D_8082ADD8[gSaveContext.language];
+                    pauseCtx->infoPanelVtx[20].v.ob[0] + D_8082ADD8[gGlobalSettings.language];
 
                 pauseCtx->infoPanelVtx[17].v.tc[0] = pauseCtx->infoPanelVtx[19].v.tc[0] = 0x600;
 
                 pauseCtx->infoPanelVtx[21].v.tc[0] = pauseCtx->infoPanelVtx[23].v.tc[0] =
-                    D_8082ADD8[gSaveContext.language] << 5;
+                    D_8082ADD8[gGlobalSettings.language] << 5;
 
                 s16 PosX; //General Pos of C button icon
-                if (gSaveContext.language == 0) { //eng
+                if (gGlobalSettings.language == 0) { // eng
                     PosX = 112;
-                } else if (gSaveContext.language == 1) { //ger
+                } else if (gGlobalSettings.language == 1) { // ger
                     PosX = 175;
                 } else {//baguettes
                     PosX = 98;
@@ -1969,34 +1971,34 @@ void KaleidoScope_DrawInfoPanel(PlayState* play) {
                 }
                 gDPPipeSync(POLY_KAL_DISP++);
                 gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 255, 255, 255, 255);
-                POLY_KAL_DISP = KaleidoScope_QuadTextureIA8(POLY_KAL_DISP, sToEquipTextures[gSaveContext.language],
-                                                            D_8082ADD8[gSaveContext.language], 16, 4);
+                POLY_KAL_DISP = KaleidoScope_QuadTextureIA8(POLY_KAL_DISP, sToEquipTextures[gGlobalSettings.language],
+                                                            D_8082ADD8[gGlobalSettings.language], 16, 4);
             } else if ((pauseCtx->pageIndex == PAUSE_MAP) && sInDungeonScene) {
 
             } else if ((pauseCtx->pageIndex == PAUSE_QUEST) && (pauseCtx->cursorSlot[PAUSE_QUEST] >= 6) &&
                        (pauseCtx->cursorSlot[PAUSE_QUEST] <= 0x11)) {
                 if (pauseCtx->namedItem != PAUSE_ITEM_NONE) {
                     pauseCtx->infoPanelVtx[16].v.ob[0] = pauseCtx->infoPanelVtx[18].v.ob[0] =
-                        WREG(55 + gSaveContext.language);
+                        WREG(55 + gGlobalSettings.language);
 
                     pauseCtx->infoPanelVtx[17].v.ob[0] = pauseCtx->infoPanelVtx[19].v.ob[0] =
                         pauseCtx->infoPanelVtx[16].v.ob[0] + 24;
 
                     pauseCtx->infoPanelVtx[20].v.ob[0] = pauseCtx->infoPanelVtx[22].v.ob[0] =
-                        pauseCtx->infoPanelVtx[16].v.ob[0] + WREG(52 + gSaveContext.language);
+                        pauseCtx->infoPanelVtx[16].v.ob[0] + WREG(52 + gGlobalSettings.language);
 
-                    if (gSaveContext.language == LANGUAGE_GER) {
+                    if (gGlobalSettings.language == LANGUAGE_GER) {
                         pauseCtx->infoPanelVtx[20].v.ob[0] = pauseCtx->infoPanelVtx[22].v.ob[0] =
                             pauseCtx->infoPanelVtx[16].v.ob[0] - 99;
                     }
 
                     pauseCtx->infoPanelVtx[21].v.ob[0] = pauseCtx->infoPanelVtx[23].v.ob[0] =
-                        pauseCtx->infoPanelVtx[20].v.ob[0] + D_8082ADE8[gSaveContext.language];
+                        pauseCtx->infoPanelVtx[20].v.ob[0] + D_8082ADE8[gGlobalSettings.language];
 
                     pauseCtx->infoPanelVtx[17].v.tc[0] = pauseCtx->infoPanelVtx[19].v.tc[0] = 0x300;
 
                     pauseCtx->infoPanelVtx[21].v.tc[0] = pauseCtx->infoPanelVtx[23].v.tc[0] =
-                        D_8082ADE8[gSaveContext.language] << 5;
+                        D_8082ADE8[gGlobalSettings.language] << 5;
 
                     gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, aButtonColor.r, aButtonColor.g, aButtonColor.b, 255);
                     //gSPDisplayList(POLY_KAL_DISP++, gAButtonIconDL);
@@ -2006,26 +2008,27 @@ void KaleidoScope_DrawInfoPanel(PlayState* play) {
                     gDPPipeSync(POLY_KAL_DISP++);
                     gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 255, 255, 255, 255);
 
-                    POLY_KAL_DISP = KaleidoScope_QuadTextureIA8(POLY_KAL_DISP, sPlayMelodyTextures[gSaveContext.language],
-                                                                D_8082ADE8[gSaveContext.language], 16, 4);
+                    POLY_KAL_DISP =
+                        KaleidoScope_QuadTextureIA8(POLY_KAL_DISP, sPlayMelodyTextures[gGlobalSettings.language],
+                                                    D_8082ADE8[gGlobalSettings.language], 16, 4);
                 }
             } else if (pauseCtx->pageIndex == PAUSE_EQUIP) {
                 pauseCtx->infoPanelVtx[16].v.ob[0] = pauseCtx->infoPanelVtx[18].v.ob[0] =
-                    WREG(64 + gSaveContext.language);
+                    WREG(64 + gGlobalSettings.language);
 
                 pauseCtx->infoPanelVtx[17].v.ob[0] = pauseCtx->infoPanelVtx[19].v.ob[0] =
                     pauseCtx->infoPanelVtx[16].v.ob[0] + 24;
 
                 pauseCtx->infoPanelVtx[20].v.ob[0] = pauseCtx->infoPanelVtx[22].v.ob[0] =
-                    pauseCtx->infoPanelVtx[16].v.ob[0] + WREG(52 + gSaveContext.language);
+                    pauseCtx->infoPanelVtx[16].v.ob[0] + WREG(52 + gGlobalSettings.language);
 
                 pauseCtx->infoPanelVtx[21].v.ob[0] = pauseCtx->infoPanelVtx[23].v.ob[0] =
-                    pauseCtx->infoPanelVtx[20].v.ob[0] + D_8082ADD8[gSaveContext.language];
+                    pauseCtx->infoPanelVtx[20].v.ob[0] + D_8082ADD8[gGlobalSettings.language];
 
                 pauseCtx->infoPanelVtx[17].v.tc[0] = pauseCtx->infoPanelVtx[19].v.tc[0] = 0x300;
 
                 pauseCtx->infoPanelVtx[21].v.tc[0] = pauseCtx->infoPanelVtx[23].v.tc[0] =
-                    D_8082ADD8[gSaveContext.language] << 5;
+                    D_8082ADD8[gGlobalSettings.language] << 5;
 
                  if (!(CHECK_OWNED_EQUIP(pauseCtx->cursorY[PAUSE_EQUIP], pauseCtx->cursorX[PAUSE_EQUIP] - 1)) && (pauseCtx->pageIndex == PAUSE_EQUIP) && (pauseCtx->cursorX[PAUSE_EQUIP] != 0)) {
                     return;
@@ -2039,8 +2042,8 @@ void KaleidoScope_DrawInfoPanel(PlayState* play) {
                 gDPPipeSync(POLY_KAL_DISP++);
                 gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 255, 255, 255, 255);
 
-                POLY_KAL_DISP = KaleidoScope_QuadTextureIA8(POLY_KAL_DISP, sToEquipTextures[gSaveContext.language],
-                                                            D_8082ADD8[gSaveContext.language], 16, 4);
+                POLY_KAL_DISP = KaleidoScope_QuadTextureIA8(POLY_KAL_DISP, sToEquipTextures[gGlobalSettings.language],
+                                                            D_8082ADD8[gGlobalSettings.language], 16, 4);
             }
         }
     }
@@ -2070,10 +2073,10 @@ void KaleidoScope_UpdateNamePanel(PlayState* play) {
 
         if (pauseCtx->namedItem != PAUSE_ITEM_NONE) {
             if ((pauseCtx->pageIndex == PAUSE_MAP) && !sInDungeonScene) {
-                if (gSaveContext.language) {
+                if (gGlobalSettings.language) {
                     sp2A += 12;
                 }
-                if (gSaveContext.language == LANGUAGE_FRA) {
+                if (gGlobalSettings.language == LANGUAGE_FRA) {
                     sp2A += 12;
                 }
 
@@ -2082,14 +2085,14 @@ void KaleidoScope_UpdateNamePanel(PlayState* play) {
             } else {
                 osSyncPrintf("zoom_name=%d\n", pauseCtx->namedItem);
 
-                if (gSaveContext.language) {
+                if (gGlobalSettings.language) {
                     sp2A += 123;
                 }
-                if (gSaveContext.language == LANGUAGE_FRA) {
+                if (gGlobalSettings.language == LANGUAGE_FRA) {
                     sp2A += 123;
                 }
 
-                osSyncPrintf("J_N=%d  point=%d\n", gSaveContext.language, sp2A);
+                osSyncPrintf("J_N=%d  point=%d\n", gGlobalSettings.language, sp2A);
 
                 const char* textureName = iconNameTextures[sp2A];
                 memcpy(pauseCtx->nameSegment, GetResourceDataByName(textureName, false), GetResourceTexSizeByName(textureName, false));
@@ -3347,12 +3350,12 @@ void KaleidoScope_Update(PlayState* play)
 #if 1
             //pauseCtx->iconItemLangSegment = (void*)(((uintptr_t)pauseCtx->iconItemAltSegment + size2 + 0xF) & ~0xF);
 
-            if (gSaveContext.language == LANGUAGE_ENG) {
+            if (gGlobalSettings.language == LANGUAGE_ENG) {
                 //size = (uintptr_t)_icon_item_nes_staticSegmentRomEnd - (uintptr_t)_icon_item_nes_staticSegmentRomStart;
                 //osSyncPrintf("icon_item_dungeon dungeon-size=%x\n", size);
                 //DmaMgr_SendRequest1(pauseCtx->iconItemLangSegment, _icon_item_nes_staticSegmentRomStart, size,
                                     //__FILE__, __LINE__);
-            } else if (gSaveContext.language == LANGUAGE_GER) {
+            } else if (gGlobalSettings.language == LANGUAGE_GER) {
                 //size = (uintptr_t)_icon_item_ger_staticSegmentRomEnd - (uintptr_t)_icon_item_ger_staticSegmentRomStart;
                 //osSyncPrintf("icon_item_dungeon dungeon-size=%x\n", size);
                 //DmaMgr_SendRequest1(pauseCtx->iconItemLangSegment, (uintptr_t)_icon_item_ger_staticSegmentRomStart, size,
@@ -3374,10 +3377,10 @@ void KaleidoScope_Update(PlayState* play)
             osSyncPrintf("サイズ＝%x\n", size2 + size1 + size0 + size + 0x800);
 
             if (((void)0, gSaveContext.worldMapArea) < 22) {
-                if (gSaveContext.language == LANGUAGE_ENG) {
+                if (gGlobalSettings.language == LANGUAGE_ENG) {
                     const char* textureName = mapNameTextures[36 + gSaveContext.worldMapArea];
                     memcpy(pauseCtx->nameSegment + 0x400, GetResourceDataByName(textureName, false), GetResourceTexSizeByName(textureName, false));
-                } else if (gSaveContext.language == LANGUAGE_GER) {
+                } else if (gGlobalSettings.language == LANGUAGE_GER) {
                     const char* textureName = mapNameTextures[58 + gSaveContext.worldMapArea];
                     memcpy(pauseCtx->nameSegment + 0x400, GetResourceDataByName(textureName, false), GetResourceTexSizeByName(textureName, false));
                 } else {


### PR DESCRIPTION
This is a WIP example of reworking CVars to solve several issues with them. This is the SoH side of things, for the LUS PR, see https://github.com/Kenix3/libultraship/pull/137.

The issues I am trying to fix:

- CVar lookup is expensive since it involves a map lookup. It is one of the most expensive things that occurs in the game update loop (so outside of graphics/rendering)
- CVar usage is error-prone. Since they are identified with strings, and defaulted if they don't exist (a common occurrence since they don't exist until they are changed), there is potential for misspellings to result in bugs that go undetected.

The changes needed in SoH are less structural, and more just needed as a client of the new interface. They do present an example of the intended interface. This PR reworks the values previously held in `global.sav` to be the new version of CVars. As such, they no longer need to be saved, since they will be saved with the CVars. Let's see what was needed to convert them.

- There are new files, `GlobalSettings.h`/`.cpp` and `z64settings.h`
- `z64settings.h` contains a global struct of settings that exist outside of any file-specific data. Data was moved out from `gSaveContext` accordingly.
- `GlobalSettings` is the C++ side of things and manages defaulting and associating the data with CVars.

So, to add a new setting and associated CVar you:

- Add data to the struct in `z64settings.h`
- Add the default in `GlobalSettings.cpp`
- Add the CVar also in `GlobalSettings.cpp`

That's it! Now you can use it just like a regular C variable and it'll get saved along with all the other CVars.

Update: made a second commit to show how to convert the existing usage into the new usage.