### PR TITLE
Spot fix so autosave dropdown will save immediately

### DIFF
--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -834,18 +834,9 @@ namespace GameMenuBar {
             UIWidgets::PaddedSeparator(false, true);
 
             // Autosave enum value of 1 is the default in presets and the old checkbox "on" state for backwards compatibility
-            const uint16_t selectedAutosaveId = CVarGetInteger("gAutosave", 0);
-            std::string autosaveLabels[] = { "Off", "New Location + Major Item", "New Location + Any Item", "New Location", "Major Item", "Any Item" };
             UIWidgets::PaddedText("Autosave", false, true);
-            if (ImGui::BeginCombo("##AutosaveComboBox", autosaveLabels[selectedAutosaveId].c_str())) {
-                for (int index = 0; index < sizeof(autosaveLabels) / sizeof(autosaveLabels[0]); index++) {
-                    if (ImGui::Selectable(autosaveLabels[index].c_str(), index == selectedAutosaveId)) {
-                        CVarSetInteger("gAutosave", index);
-                    }
-                }
-
-                ImGui::EndCombo();
-            }
+            const char* autosaveLabels[] = { "Off", "New Location + Major Item", "New Location + Any Item", "New Location", "Major Item", "Any Item" };
+            UIWidgets::EnhancementCombobox("gAutosave", autosaveLabels, (sizeof(autosaveLabels) / sizeof(autosaveLabels[0])), CVarGetInteger("gAutosave", 0));
             UIWidgets::Tooltip("Automatically save the game every time a new area is entered and/or item is obtained\n"
                 "Major items exclude rupees and health/magic/ammo refills (but include bombchus unless bombchu drops are enabled)");
 


### PR DESCRIPTION
Closes #2567.  I didn't realize we already had an Enhancement version of the combobox, so use it instead.  This PR points to Khan so it can be sent out sooner, but a full PR will be coming soon to update all other non-Enhancement comboboxes that can benefit from the Enhancement version to use it.  That PR will also include this fix so folks on `develop` get it sooner.  

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/581000094.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/581000095.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/581000096.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/581000097.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/581000098.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/581000099.zip)
<!--- section:artifacts:end -->