### PR TITLE
Add glitch practice cheats

### DIFF
--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -1079,6 +1079,8 @@ namespace GameMenuBar {
             UIWidgets::Tooltip("This syncs the ingame time with the real world time");
             UIWidgets::PaddedEnhancementCheckbox("Fish don't despawn", "gNoFishDespawn", true, false);
             UIWidgets::Tooltip("Prevents fish from automatically despawning after a while when dropped");
+            UIWidgets::PaddedEnhancementCheckbox("Bugs don't despawn", "gNoBugsDespawn", true, false);
+            UIWidgets::Tooltip("Prevents bugs from automatically despawning after a while when dropped");
 
             {
                 static int32_t betaQuestEnabled = CVarGetInteger("gEnableBetaQuest", 0);

--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -1052,6 +1052,7 @@ namespace GameMenuBar {
             UIWidgets::PaddedEnhancementCheckbox("Hookshot Everything", "gHookshotEverything", true, false);
             UIWidgets::Tooltip("Makes every surface in the game hookshot-able");
             UIWidgets::EnhancementSliderFloat("Hookshot Reach Multiplier: %.1fx", "##gCheatHookshotReachMultiplier", "gCheatHookshotReachMultiplier", 1.0f, 5.0f, "", 1.0f, false);
+            UIWidgets::EnhancementSliderFloat("Bomb Timer Multiplier: %.1fx", "##gBombTimerMultiplier", "gBombTimerMultiplier", 0.1f, 5.0f, "", 1.0f, false);
             UIWidgets::PaddedEnhancementCheckbox("Moon Jump on L", "gMoonJumpOnL", true, false);
             UIWidgets::Tooltip("Holding L makes you float into the air");
             UIWidgets::PaddedEnhancementCheckbox("Super Tunic", "gSuperTunic", true, false);

--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -1077,6 +1077,8 @@ namespace GameMenuBar {
             UIWidgets::Tooltip("This allows you to put up your shield with any two-handed weapon in hand except for Deku Sticks");
             UIWidgets::PaddedEnhancementCheckbox("Time Sync", "gTimeSync", true, false);
             UIWidgets::Tooltip("This syncs the ingame time with the real world time");
+            UIWidgets::PaddedEnhancementCheckbox("Fish don't despawn", "gNoFishDespawn", true, false);
+            UIWidgets::Tooltip("Prevents fish from automatically despawning after a while when dropped");
 
             {
                 static int32_t betaQuestEnabled = CVarGetInteger("gEnableBetaQuest", 0);

--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -1072,16 +1072,16 @@ namespace GameMenuBar {
             UIWidgets::Tooltip("Freezes the time of day");
             UIWidgets::PaddedEnhancementCheckbox("Drops Don't Despawn", "gDropsDontDie", true, false);
             UIWidgets::Tooltip("Drops from enemies, grass, etc. don't disappear after a set amount of time");
+            UIWidgets::PaddedEnhancementCheckbox("Fish Don't Despawn", "gNoFishDespawn", true, false);
+            UIWidgets::Tooltip("Prevents fish from automatically despawning after a while when dropped");
+            UIWidgets::PaddedEnhancementCheckbox("Bugs Don't Despawn", "gNoBugsDespawn", true, false);
+            UIWidgets::Tooltip("Prevents bugs from automatically despawning after a while when dropped");
             UIWidgets::PaddedEnhancementCheckbox("Fireproof Deku Shield", "gFireproofDekuShield", true, false);
             UIWidgets::Tooltip("Prevents the Deku Shield from burning on contact with fire");
             UIWidgets::PaddedEnhancementCheckbox("Shield with Two-Handed Weapons", "gShieldTwoHanded", true, false);
             UIWidgets::Tooltip("This allows you to put up your shield with any two-handed weapon in hand except for Deku Sticks");
             UIWidgets::PaddedEnhancementCheckbox("Time Sync", "gTimeSync", true, false);
             UIWidgets::Tooltip("This syncs the ingame time with the real world time");
-            UIWidgets::PaddedEnhancementCheckbox("Fish don't despawn", "gNoFishDespawn", true, false);
-            UIWidgets::Tooltip("Prevents fish from automatically despawning after a while when dropped");
-            UIWidgets::PaddedEnhancementCheckbox("Bugs don't despawn", "gNoBugsDespawn", true, false);
-            UIWidgets::Tooltip("Prevents bugs from automatically despawning after a while when dropped");
 
             {
                 static int32_t betaQuestEnabled = CVarGetInteger("gEnableBetaQuest", 0);

--- a/soh/src/overlays/actors/ovl_En_Bom/z_en_bom.c
+++ b/soh/src/overlays/actors/ovl_En_Bom/z_en_bom.c
@@ -96,7 +96,7 @@ void EnBom_Init(Actor* thisx, PlayState* play) {
     thisx->colChkInfo.mass = 200;
     thisx->colChkInfo.cylRadius = 5;
     thisx->colChkInfo.cylHeight = 10;
-    this->timer = 70;
+    this->timer = (s32)(70 * CVarGetFloat("gBombTimerMultiplier", 1.0f));
     this->flashSpeedScale = 7;
     Collider_InitCylinder(play, &this->bombCollider);
     Collider_InitJntSph(play, &this->explosionCollider);
@@ -244,7 +244,7 @@ void EnBom_Update(Actor* thisx, PlayState* play2) {
         this->timer--;
     }
 
-    if (this->timer == 67) {
+    if (this->timer == (s32)(70 * CVarGetFloat("gBombTimerMultiplier", 1.0f) - 3)) {
         Audio_PlayActorSound2(thisx, NA_SE_PL_TAKE_OUT_SHIELD);
         Actor_SetScale(thisx, 0.01f);
     }
@@ -258,7 +258,7 @@ void EnBom_Update(Actor* thisx, PlayState* play2) {
     Actor_UpdateBgCheckInfo(play, thisx, 5.0f, 10.0f, 15.0f, 0x1F);
 
     if (thisx->params == BOMB_BODY) {
-        if (this->timer < 63) {
+        if (this->timer < (s32)(70 * CVarGetFloat("gBombTimerMultiplier", 1.0f) - 7)) {
             dustAccel.y = 0.2f;
 
             // spawn spark effect on even frames

--- a/soh/src/overlays/actors/ovl_En_Bom/z_en_bom.c
+++ b/soh/src/overlays/actors/ovl_En_Bom/z_en_bom.c
@@ -244,7 +244,9 @@ void EnBom_Update(Actor* thisx, PlayState* play2) {
         this->timer--;
     }
 
-    if (this->timer == (s32)(70 * CVarGetFloat("gBombTimerMultiplier", 1.0f) - 3)) {
+    float timerMultiplier = CVarGetFloat("gBombTimerMultiplier", 1.0f);
+
+    if (this->timer == (timerMultiplier == 1.0f ? 67 : (s32)(70 * timerMultiplier - 3))) {
         Audio_PlayActorSound2(thisx, NA_SE_PL_TAKE_OUT_SHIELD);
         Actor_SetScale(thisx, 0.01f);
     }
@@ -258,7 +260,7 @@ void EnBom_Update(Actor* thisx, PlayState* play2) {
     Actor_UpdateBgCheckInfo(play, thisx, 5.0f, 10.0f, 15.0f, 0x1F);
 
     if (thisx->params == BOMB_BODY) {
-        if (this->timer < (s32)(70 * CVarGetFloat("gBombTimerMultiplier", 1.0f) - 7)) {
+        if (this->timer < (timerMultiplier == 1.0f ? 63 : (s32)(70 * timerMultiplier - 7))) {
             dustAccel.y = 0.2f;
 
             // spawn spark effect on even frames

--- a/soh/src/overlays/actors/ovl_En_Fish/z_en_fish.c
+++ b/soh/src/overlays/actors/ovl_En_Fish/z_en_fish.c
@@ -677,7 +677,7 @@ void EnFish_UpdateCutscene(EnFish* this, PlayState* play) {
 // Update functions and Draw
 
 void EnFish_OrdinaryUpdate(EnFish* this, PlayState* play) {
-    if (this->timer > 0) {
+    if (this->timer > 0 && CVarGetInteger("gNoFishDespawn", 0) == 0) {
         this->timer--;
     }
 

--- a/soh/src/overlays/actors/ovl_En_Insect/z_en_insect.c
+++ b/soh/src/overlays/actors/ovl_En_Insect/z_en_insect.c
@@ -392,6 +392,9 @@ void func_80A7CAD0(EnInsect* this, PlayState* play) {
 }
 
 void func_80A7CBC8(EnInsect* this) {
+    if (CVarGetInteger("gNoBugsDespawn", 0) != 0) {
+        return;
+    }
     this->unk_31A = 60;
     func_80A7BF58(this);
     this->skelAnime.playSpeed = 1.9f;


### PR DESCRIPTION
Adds a cheat to prevent fish from despawning, a cheat to prevent bugs from despawning and a cheat to change the fuse timer of bombs.
Meant to help with practicing glitches.