### PR TITLE
Add glitch practice cheats

### DIFF
--- a/soh/soh/Enhancements/presets.h
+++ b/soh/soh/Enhancements/presets.h
@@ -262,6 +262,9 @@ const std::vector<const char*> cheatCvars = {
     "gSwitchAge",
     "gSwitchTimeline",
     "gNoRedeadFreeze",
+    "gBombTimerMultiplier",
+    "gNoFishDespawn",
+    "gNoBugsDespawn"
 };
 
 const std::vector<const char*> randomizerCvars = {

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -1192,6 +1192,8 @@ void DrawCheatsMenu() {
         UIWidgets::Tooltip("This syncs the ingame time with the real world time");
         UIWidgets::PaddedEnhancementCheckbox("No ReDead/Gibdo Freeze", "gNoRedeadFreeze", true, false);
         UIWidgets::Tooltip("Prevents ReDeads and Gibdos from being able to freeze you with their scream");
+        UIWidgets::PaddedEnhancementCheckbox("Fish don't despawn", "gNoFishDespawn", true, false);
+        UIWidgets::Tooltip("Prevents fish from automatically despawning after a while when dropped");
 
         {
             static int32_t betaQuestEnabled = CVarGetInteger("gEnableBetaQuest", 0);

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -1194,6 +1194,8 @@ void DrawCheatsMenu() {
         UIWidgets::Tooltip("Prevents ReDeads and Gibdos from being able to freeze you with their scream");
         UIWidgets::PaddedEnhancementCheckbox("Fish don't despawn", "gNoFishDespawn", true, false);
         UIWidgets::Tooltip("Prevents fish from automatically despawning after a while when dropped");
+        UIWidgets::PaddedEnhancementCheckbox("Bugs don't despawn", "gNoBugsDespawn", true, false);
+        UIWidgets::Tooltip("Prevents bugs from automatically despawning after a while when dropped");
 
         {
             static int32_t betaQuestEnabled = CVarGetInteger("gEnableBetaQuest", 0);

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -1165,6 +1165,7 @@ void DrawCheatsMenu() {
         UIWidgets::PaddedEnhancementCheckbox("Hookshot Everything", "gHookshotEverything", true, false);
         UIWidgets::Tooltip("Makes every surface in the game hookshot-able");
         UIWidgets::EnhancementSliderFloat("Hookshot Reach Multiplier: %.1fx", "##gCheatHookshotReachMultiplier", "gCheatHookshotReachMultiplier", 1.0f, 5.0f, "", 1.0f, false);
+        UIWidgets::EnhancementSliderFloat("Bomb Timer Multiplier: %.1fx", "##gBombTimerMultiplier", "gBombTimerMultiplier", 0.1f, 5.0f, "", 1.0f, false);
         UIWidgets::PaddedEnhancementCheckbox("Moon Jump on L", "gMoonJumpOnL", true, false);
         UIWidgets::Tooltip("Holding L makes you float into the air");
         UIWidgets::PaddedEnhancementCheckbox("Super Tunic", "gSuperTunic", true, false);

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -1184,6 +1184,10 @@ void DrawCheatsMenu() {
         UIWidgets::Tooltip("Freezes the time of day");
         UIWidgets::PaddedEnhancementCheckbox("Drops Don't Despawn", "gDropsDontDie", true, false);
         UIWidgets::Tooltip("Drops from enemies, grass, etc. don't disappear after a set amount of time");
+        UIWidgets::PaddedEnhancementCheckbox("Fish Don't despawn", "gNoFishDespawn", true, false);
+        UIWidgets::Tooltip("Prevents fish from automatically despawning after a while when dropped");
+        UIWidgets::PaddedEnhancementCheckbox("Bugs Don't despawn", "gNoBugsDespawn", true, false);
+        UIWidgets::Tooltip("Prevents bugs from automatically despawning after a while when dropped");
         UIWidgets::PaddedEnhancementCheckbox("Fireproof Deku Shield", "gFireproofDekuShield", true, false);
         UIWidgets::Tooltip("Prevents the Deku Shield from burning on contact with fire");
         UIWidgets::PaddedEnhancementCheckbox("Shield with Two-Handed Weapons", "gShieldTwoHanded", true, false);
@@ -1192,10 +1196,6 @@ void DrawCheatsMenu() {
         UIWidgets::Tooltip("This syncs the ingame time with the real world time");
         UIWidgets::PaddedEnhancementCheckbox("No ReDead/Gibdo Freeze", "gNoRedeadFreeze", true, false);
         UIWidgets::Tooltip("Prevents ReDeads and Gibdos from being able to freeze you with their scream");
-        UIWidgets::PaddedEnhancementCheckbox("Fish don't despawn", "gNoFishDespawn", true, false);
-        UIWidgets::Tooltip("Prevents fish from automatically despawning after a while when dropped");
-        UIWidgets::PaddedEnhancementCheckbox("Bugs don't despawn", "gNoBugsDespawn", true, false);
-        UIWidgets::Tooltip("Prevents bugs from automatically despawning after a while when dropped");
 
         {
             static int32_t betaQuestEnabled = CVarGetInteger("gEnableBetaQuest", 0);

--- a/soh/src/overlays/actors/ovl_En_Bom/z_en_bom.c
+++ b/soh/src/overlays/actors/ovl_En_Bom/z_en_bom.c
@@ -281,7 +281,8 @@ void EnBom_Update(Actor* thisx, PlayState* play2) {
     Actor_UpdateBgCheckInfo(play, thisx, 5.0f, 10.0f, 15.0f, 0x1F);
 
     if (thisx->params == BOMB_BODY) {
-        if (this->timer < (s32)(70 * CVarGetFloat("gBombTimerMultiplier", 1.0f) - 7)) {
+        float timerMultiplier = CVarGetFloat("gBombTimerMultiplier", 1.0f);
+        if (this->timer < (timerMultiplier == 1.0f ? 63 : (s32)(70 * timerMultiplier - 7))) {
             dustAccel.y = 0.2f;
 
             // spawn spark effect on even frames

--- a/soh/src/overlays/actors/ovl_En_Bom/z_en_bom.c
+++ b/soh/src/overlays/actors/ovl_En_Bom/z_en_bom.c
@@ -98,6 +98,7 @@ void EnBom_Init(Actor* thisx, PlayState* play) {
     thisx->colChkInfo.mass = 200;
     thisx->colChkInfo.cylRadius = 5;
     thisx->colChkInfo.cylHeight = 10;
+
     if (!GameInteractor_GetRandomBombFuseTimerActive()) {
         this->timer = 70;
     } else {
@@ -108,6 +109,16 @@ void EnBom_Init(Actor* thisx, PlayState* play) {
         Audio_PlayActorSound2(thisx, NA_SE_PL_TAKE_OUT_SHIELD);
         Actor_SetScale(thisx, 0.01f);
     }
+
+    if (CVarGetFloat("gBombTimerMultiplier", 1.0f) != 1.0f) {
+        this->timer = (s32)(70 * CVarGetFloat("gBombTimerMultiplier", 1.0f));
+        // Do the sound and scale immediately if GameInteractor hasn't already.
+        if (!GameInteractor_GetRandomBombFuseTimerActive()) {
+            Audio_PlayActorSound2(thisx, NA_SE_PL_TAKE_OUT_SHIELD);
+            Actor_SetScale(thisx, 0.01f);
+        }
+    }
+
     this->flashSpeedScale = 7;
     Collider_InitCylinder(play, &this->bombCollider);
     Collider_InitJntSph(play, &this->explosionCollider);
@@ -255,8 +266,8 @@ void EnBom_Update(Actor* thisx, PlayState* play2) {
         this->timer--;
     }
 
-    // With random bomb fuse timer, sound effect and scaling is already done on init.
-    if (this->timer == 67 && !GameInteractor_GetRandomBombFuseTimerActive()) {
+    // With random bomb fuse timer or gBombTimerMultiplier, sound effect and scaling is already done on init.
+    if (this->timer == 67 && !GameInteractor_GetRandomBombFuseTimerActive() && CVarGetFloat("gBombTimerMultiplier", 1.0f) != 1.0f) {
         Audio_PlayActorSound2(thisx, NA_SE_PL_TAKE_OUT_SHIELD);
         Actor_SetScale(thisx, 0.01f);
     }
@@ -270,7 +281,7 @@ void EnBom_Update(Actor* thisx, PlayState* play2) {
     Actor_UpdateBgCheckInfo(play, thisx, 5.0f, 10.0f, 15.0f, 0x1F);
 
     if (thisx->params == BOMB_BODY) {
-        if (this->timer < 63) {
+        if (this->timer < (s32)(70 * CVarGetFloat("gBombTimerMultiplier", 1.0f) - 7)) {
             dustAccel.y = 0.2f;
 
             // spawn spark effect on even frames

--- a/soh/src/overlays/actors/ovl_En_Fish/z_en_fish.c
+++ b/soh/src/overlays/actors/ovl_En_Fish/z_en_fish.c
@@ -679,7 +679,7 @@ void EnFish_UpdateCutscene(EnFish* this, PlayState* play) {
 // Update functions and Draw
 
 void EnFish_OrdinaryUpdate(EnFish* this, PlayState* play) {
-    if (this->timer > 0) {
+    if (this->timer > 0 && CVarGetInteger("gNoFishDespawn", 0) == 0) {
         this->timer--;
     }
 

--- a/soh/src/overlays/actors/ovl_En_Insect/z_en_insect.c
+++ b/soh/src/overlays/actors/ovl_En_Insect/z_en_insect.c
@@ -394,6 +394,9 @@ void func_80A7CAD0(EnInsect* this, PlayState* play) {
 }
 
 void func_80A7CBC8(EnInsect* this) {
+    if (CVarGetInteger("gNoBugsDespawn", 0) != 0) {
+        return;
+    }
     this->unk_31A = 60;
     func_80A7BF58(this);
     this->skelAnime.playSpeed = 1.9f;


### PR DESCRIPTION
Adds a cheat to prevent fish from despawning, a cheat to prevent bugs from despawning and a cheat to change the fuse timer of bombs.
Meant to help with practicing glitches.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/850557247.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/850557248.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/850557250.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/850557251.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/850557253.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/850557254.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/850557255.zip)
<!--- section:artifacts:end -->