### PR TITLE
Fix: Handle "angry" happy mask salesman throwing link out in entrance rando

### DIFF
--- a/soh/src/overlays/actors/ovl_En_Ossan/z_en_ossan.c
+++ b/soh/src/overlays/actors/ovl_En_Ossan/z_en_ossan.c
@@ -13,6 +13,7 @@
 #include "objects/object_mastergolon/object_mastergolon.h"
 #include "objects/object_masterzoora/object_masterzoora.h"
 #include "objects/object_masterkokirihead/object_masterkokirihead.h"
+#include "soh/Enhancements/randomizer/randomizer_entrance.h"
 
 #define FLAGS (ACTOR_FLAG_0 | ACTOR_FLAG_3 | ACTOR_FLAG_4)
 
@@ -934,7 +935,12 @@ void EnOssan_State_StartConversation(EnOssan* this, PlayState* play, Player* pla
                 EnOssan_TryPaybackMask(this, play);
                 return;
             case OSSAN_HAPPY_STATE_ANGRY:
-                play->nextEntranceIndex = 0x1D1;
+                // In ER, handle happy mask throwing link out with not enough rupees
+                if (gSaveContext.n64ddFlag && Randomizer_GetSettingValue(RSK_SHUFFLE_ENTRANCES)) {
+                    play->nextEntranceIndex = Entrance_OverrideNextIndex(0x1D1);
+                } else {
+                    play->nextEntranceIndex = 0x1D1;
+                }
                 play->sceneLoadFlag = 0x14;
                 play->fadeTransition = 0x2E;
                 return;


### PR DESCRIPTION
When Link doesn't have enough rupees to pay back the mask salesman, he gets angry and throws link out of the shop. This handles overriding the entrance when entrance randomizer is on.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/583031725.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/583031726.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/583031727.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/583031728.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/583031729.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/583031730.zip)
<!--- section:artifacts:end -->