### PR TITLE
Feature - Bonk damage under difficulty options

### DIFF
--- a/soh/soh/Enhancements/game-interactor/GameInteractor.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor.h
@@ -89,6 +89,7 @@ public:
     DEFINE_HOOK(OnReceiveItem, void(uint8_t item));
     DEFINE_HOOK(OnSceneInit, void(int16_t sceneNum));
     DEFINE_HOOK(OnPlayerUpdate, void());
+    DEFINE_HOOK(OnPlayerBonk, void());
     
     DEFINE_HOOK(OnSaveFile, void(int32_t fileNum));
     DEFINE_HOOK(OnLoadFile, void(int32_t fileNum));

--- a/soh/soh/Enhancements/game-interactor/GameInteractor_Hooks.cpp
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor_Hooks.cpp
@@ -26,6 +26,10 @@ void GameInteractor_ExecuteOnPlayerUpdate() {
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnPlayerUpdate>();
 }
 
+void GameInteractor_ExecuteOnPlayerBonk() {
+    GameInteractor::Instance->ExecuteHooks<GameInteractor::OnPlayerBonk>();
+}
+
 // MARK: -  Save Files
 
 void GameInteractor_ExecuteOnSaveFile(int32_t fileNum) {

--- a/soh/soh/Enhancements/game-interactor/GameInteractor_Hooks.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor_Hooks.h
@@ -7,6 +7,7 @@ extern "C" void GameInteractor_ExecuteOnGameFrameUpdate();
 extern "C" void GameInteractor_ExecuteOnReceiveItemHooks(uint8_t item);
 extern "C" void GameInteractor_ExecuteOnSceneInit(int16_t sceneNum);
 extern "C" void GameInteractor_ExecuteOnPlayerUpdate();
+extern "C" void GameInteractor_ExecuteOnPlayerBonk();
 
 // MARK: -  Save Files
 extern "C" void GameInteractor_ExecuteOnSaveFile(int32_t fileNum);

--- a/soh/soh/Enhancements/presets.h
+++ b/soh/soh/Enhancements/presets.h
@@ -82,6 +82,7 @@ const std::vector<const char*> enhancementsCvars = {
     "gDamageMul",
     "gFallDamageMul",
     "gVoidDamageMul",
+    "gBonkDamageMul",
     "gNoRandomDrops",
     "gNoHeartDrops",
     "gBombchuDrops",

--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -73,6 +73,17 @@ namespace GameMenuBar {
         "Hexaquinquagintiducentuple (256x)"
     };
 
+    const char* bonkDamageValues[8] = {
+        "No Damage",
+        "0.25 Heart",
+        "0.5 Heart",
+        "1 Heart",
+        "2 Hearts",
+        "4 Hearts",
+        "8 Hearts",
+        "OHKO"
+    };
+
     // MARK: - Helpers
 
     std::string GetWindowButtonText(const char* text, bool menuOpen) {
@@ -477,6 +488,9 @@ namespace GameMenuBar {
                         32x: Can survive void damage with max health and double defense\n\
                         64x: Cannot survive void damage"
                     );
+                    UIWidgets::PaddedText("Bonk Damage Multiplier", true, false);
+                    UIWidgets::EnhancementCombobox("gBonkDamageMul", bonkDamageValues, 8, 0);
+                    UIWidgets::Tooltip("Modifies damage taken after bonking.");
                     UIWidgets::PaddedEnhancementCheckbox("Spawn with full health", "gFullHealthSpawn", true, false);
                     UIWidgets::Tooltip("Respawn with full health instead of 3 Hearts");
                     UIWidgets::PaddedEnhancementCheckbox("No Random Drops", "gNoRandomDrops", true, false);

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -8678,6 +8678,7 @@ void func_80844708(Player* this, PlayState* play) {
                     func_80832698(this, NA_SE_VO_LI_CLIMB_END);
                     this->unk_850 = 1;
                     gSaveContext.sohStats.count[COUNT_BONKS]++;
+                    GameInteractor_ExecuteOnPlayerBonk();
                     return;
                 }
             }


### PR DESCRIPTION
Probably pretty self-explanatory, damages Link when bonking.

In action: https://cdn.discordapp.com/attachments/937200399239237724/1082227203871346708/2023-03-06_10-03-26.mp4

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/584268155.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/584268156.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/584268157.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/584268158.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/584268159.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/584268160.zip)
<!--- section:artifacts:end -->