### PR TITLE
Modify cutsceneIndex in scene transition autosave to include use-cases outside of normal play.

### DIFF
--- a/soh/src/code/z_play.c
+++ b/soh/src/code/z_play.c
@@ -874,7 +874,7 @@ void Play_Update(PlayState* play) {
                             // Also don't save when you first load a file to prevent consumables like magic from being lost
                             // Also don't save if there's a pending shop sale to prevent getting the item for a discount!
                             if ((CVarGetInteger("gAutosave", 0) >= 1) && (CVarGetInteger("gAutosave", 0) <= 3) &&
-                                (gSaveContext.cutsceneIndex == 0) && (play->gameplayFrames > 60) && (gSaveContext.pendingSale == ITEM_NONE) &&
+                                (gSaveContext.cutsceneIndex < 0xFFF0) && (play->gameplayFrames > 60) && (gSaveContext.pendingSale == ITEM_NONE) &&
                                 (play->sceneNum != SCENE_YOUSEI_IZUMI_TATE) && (play->sceneNum != SCENE_KAKUSIANA) && (play->sceneNum != SCENE_KENJYANOMA)) {
                                 Play_PerformSave(play);
                             }


### PR DESCRIPTION
Encountered this when playing after having used the debug menu, thought something was seriously broken. Turns out only non-standard use was broken XD.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/585748184.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/585748185.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/585748186.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/585748187.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/585748188.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/585748190.zip)
<!--- section:artifacts:end -->