### PR TITLE
Fix: restrict Ask to Equip enhancement to only vanilla equipment items

### DIFF
--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -12604,7 +12604,8 @@ s32 func_8084DFF4(PlayState* play, Player* this) {
         }
         this->unk_84F = 1;
         equipItem = giEntry.itemId;
-        equipNow = CVarGetInteger("gAskToEquip", 0) && equipItem >= ITEM_SWORD_KOKIRI && equipItem <= ITEM_TUNIC_ZORA &&
+        equipNow = CVarGetInteger("gAskToEquip", 0) && giEntry.modIndex == MOD_NONE &&
+                    equipItem >= ITEM_SWORD_KOKIRI && equipItem <= ITEM_TUNIC_ZORA &&
                    ((gItemAgeReqs[equipItem] == 9 || gItemAgeReqs[equipItem] == gSaveContext.linkAge) ||
                     CVarGetInteger("gTimelessEquipment", 0));
 


### PR DESCRIPTION
The "Ask to Equip" enhancement was checking for "Yes/No" prompts for items in the range of all equipment (kokiri sword to zora tunic), but was not accounting for the vanilla mod index.

This meant any randomizer items that collided with the same item ID for kokoiri sword <-> zora tunic would equip their respective vanilla item when the randomizer item was purchased from a shop, and the shop owner prompts for "would you like to keep shopping".

This PR adds a simple check against the mod index value to ensure we are only performing the check against vanilla getItems

The following items were impacted:
* RG_BOTTLE_WITH_FISH: equips Kokiri Sword
* RG_BOTTLE_WITH_BLUE_FIRE: equips Master Sword
* RG_BOTTLE_WITH_BUGS: equips Big Gorron Sword
* RG_BOTTLE_WITH_POE: equips Deku Shield
* RG_RUTOS_LETTER: would equip Hylian Shield (but doesn't as the `itemId` isn't the RG_ value)
* RG_BOTTLE_WITH_BIG_POE: equips Mirror Shield
* RG_ZELDAS_LULLABY: would equip Kokiri Tunic (but doesn't as the `itemId` isn't the RG_ value)
* RG_EPONAS_SONG: would equip Goron Tunic (but doesn't as the `itemId` isn't the RG_ value)
* RG_SARIAS_SONG: would equip Zora Tunic  (but doesn't as the `itemId` isn't the RG_ value)

Fixes: #2589 

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/586419552.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/586419553.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/586419554.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/586419555.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/586419556.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/586419557.zip)
<!--- section:artifacts:end -->