### PR TITLE
Fix: Show correct Gold Skulltula count in textbox on vanilla saves

### DIFF
--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -1678,7 +1678,7 @@ extern "C" int CustomMessage_RetrieveIfExists(PlayState* play) {
                 textId = TEXT_GS_FREEZE;
             }
             messageEntry = CustomMessageManager::Instance->RetrieveMessage(customMessageTableID, textId);
-            CustomMessageManager::ReplaceStringInMessage(messageEntry, "{{gsCount}}", std::to_string(gSaveContext.inventory.gsTokens + 1));
+            CustomMessageManager::ReplaceStringInMessage(messageEntry, "{{gsCount}}", std::to_string(gSaveContext.inventory.gsTokens));
         }
     }
     if (textId == TEXT_HEART_CONTAINER && CVarGetInteger("gInjectItemCounts", 0)) {

--- a/soh/src/overlays/actors/ovl_En_Si/z_en_si.c
+++ b/soh/src/overlays/actors/ovl_En_Si/z_en_si.c
@@ -103,6 +103,11 @@ void func_80AFB768(EnSi* this, PlayState* play) {
 
                 if (gSaveContext.n64ddFlag) {
                     Randomizer_UpdateSkullReward(this, play);
+                    if (getItemId != RG_ICE_TRAP) {
+                        Randomizer_GiveSkullReward(this, play);
+                    } else {
+                        gSaveContext.pendingIceTrapCount++;
+                    }
                 } else {
                     Item_Give(play, giveItemId);
                 }
@@ -117,14 +122,8 @@ void func_80AFB768(EnSi* this, PlayState* play) {
 
                 Message_StartTextbox(play, textId, NULL);
 
-                if (gSaveContext.n64ddFlag) {
-                    if (getItemId != RG_ICE_TRAP) {
-                        Randomizer_GiveSkullReward(this, play);
-                        Audio_PlayFanfare_Rando(getItem);
-                    } else {
-                        gSaveContext.pendingIceTrapCount++;
-                        Audio_PlayFanfare(NA_BGM_SMALL_ITEM_GET);
-                    }
+                if (gSaveContext.n64ddFlag && getItemId != RG_ICE_TRAP) {
+                    Audio_PlayFanfare_Rando(getItem);
                 } else {
                     Audio_PlayFanfare(NA_BGM_SMALL_ITEM_GET);
                 }
@@ -149,20 +148,19 @@ void func_80AFB89C(EnSi* this, PlayState* play) {
     if (!CHECK_FLAG_ALL(this->actor.flags, ACTOR_FLAG_13)) {
         if (gSaveContext.n64ddFlag) {
             Randomizer_UpdateSkullReward(this, play);
+            if (getItemId != RG_ICE_TRAP) {
+                Randomizer_GiveSkullReward(this, play);
+            } else {
+                gSaveContext.pendingIceTrapCount++;
+            }
         } else {
             Item_Give(play, giveItemId);
         }
 
         Message_StartTextbox(play, textId, NULL);
 
-        if (gSaveContext.n64ddFlag) {
-            if (getItemId != RG_ICE_TRAP) {
-                Randomizer_GiveSkullReward(this, play);
-                Audio_PlayFanfare_Rando(getItem);
-            } else {
-                gSaveContext.pendingIceTrapCount++;
-                Audio_PlayFanfare(NA_BGM_SMALL_ITEM_GET);
-            }
+        if (gSaveContext.n64ddFlag && getItemId != RG_ICE_TRAP) {
+            Audio_PlayFanfare_Rando(getItem);
         } else {
             Audio_PlayFanfare(NA_BGM_SMALL_ITEM_GET);
         }


### PR DESCRIPTION
When using the "inject message counts" enhancement and collecting a Gold Skulltua in a vanilla save, the count displayed was always one higher than the actual collected amount. In randomizer saves, the count was displayed correctly.

In looking, `gsTokens` is incremented during `Item_Give()` and randomizer saves were performing the `Item_Give()` after the textbox is started. We were accounting for the wrong number in vanilla saves by adding a `+1` in the message injection. However, vanilla saves perform the `Item_Give()` before the textbox gets started, so the `gsTokens` count on the save was already incremented.

To address I've removed the `+1` from the text display and I've rearranged the logic when collecting a Gold Skulltula token to match the vanilla behavior:
* First, the `Item_Give()` is performed
* Then the textbox is displayed
* Then the audio fanfare is played

Confirmed message counts work as expected for both vanilla and randomizer saves.

Fixes #2516, Fixes #2075


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/588279038.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/588279039.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/588279040.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/588279042.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/588279043.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/588279045.zip)
<!--- section:artifacts:end -->