### PR TITLE
Fix: Rando quest selection falling back to vanilla saves

### DIFF
--- a/soh/soh/SaveManager.cpp
+++ b/soh/soh/SaveManager.cpp
@@ -1726,6 +1726,8 @@ void SaveManager::DeleteZeldaFile(int fileNum) {
     }
     fileMetaInfo[fileNum].valid = false;
     fileMetaInfo[fileNum].randoSave = false;
+    fileMetaInfo[fileNum].requiresMasterQuest = false;
+    fileMetaInfo[fileNum].requiresOriginal = false;
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnDeleteFile>(fileNum);
 }
 

--- a/soh/src/code/z_sram.c
+++ b/soh/src/code/z_sram.c
@@ -298,9 +298,7 @@ void Sram_InitSave(FileChooseContext* fileChooseCtx) {
         gSaveContext.playerName[offset] = Save_GetSaveMetaInfo(fileChooseCtx->buttonIndex)->playerName[offset];
     }
 
-    if (fileChooseCtx->questType[fileChooseCtx->buttonIndex] == 2 && strnlen(CVarGetString("gSpoilerLog", ""), 1) != 0 &&
-        !((Save_GetSaveMetaInfo(fileChooseCtx->buttonIndex)->requiresMasterQuest && !ResourceMgr_GameHasMasterQuest()) ||
-          (Save_GetSaveMetaInfo(fileChooseCtx->buttonIndex)->requiresMasterQuest && !ResourceMgr_GameHasOriginal()))) {
+    if (fileChooseCtx->questType[fileChooseCtx->buttonIndex] == 2 && strnlen(CVarGetString("gSpoilerLog", ""), 1) != 0) {
         // Set N64DD Flags for save file
         fileChooseCtx->n64ddFlags[fileChooseCtx->buttonIndex] = 1;
         fileChooseCtx->n64ddFlag = 1;


### PR DESCRIPTION
When only an MQ rom is provided and a MQ save or rando save is created, then deleted, If you try to create a new rando save on top of the same deleted file slot, it will fail to be a rando save and fall back to a vanilla savefile.

This is due to a broken check during file creation that first checks for the quest mode to be rando, and then checks the filemetainfo to see if it relies on master quest. The check is broken as it compares `requiresMasterQuest` against both `ResourceMgr_GameHasMasterQuest()` and `ResourceMgr_GameHasOriginal()`. I think the intent of this check was to not allow a rando save be created if the spoiler log depended on a rom that isn't available.

The issue with this check is that the fileMetaInfo is not considered valid until _**after**_ the save is created. So checking during save init is wrong as the values will not be correct. The reason why it _**seemed**_ to work today is because on SoH launch, the fileMetaInfo is 0, and the check is broken so everything succeeds. And if a vanilla rom is provided, then again because of the broken check everything succeeds. Only when deleting a save and creating ontop with only a MQ rom does the issue arise, as deleting a save does not fully clear the fileMetaInfo.

This PR removes the broken check entirely as since fileMetaInfo is not valid until after the save is created, it can't be relied on. I updated the file delete method to at least clear out the `requiresX` properties of the fileMetaInfo just to reduce future headaches.

In my opinion, it is ok to remove this check. If someone loads a spoiler log that requires a rom they dont have, I think it makes more sense to allow the file to be created as expected and then grey it out, rather than turning it into a vanilla save unexpectedly.

Fixes #2595 

For context, the broken check is the following
```c++
!((Save_GetSaveMetaInfo(fileChooseCtx->buttonIndex)->requiresMasterQuest && !ResourceMgr_GameHasMasterQuest()) ||
(Save_GetSaveMetaInfo(fileChooseCtx->buttonIndex)->requiresMasterQuest && !ResourceMgr_GameHasOriginal()))
```
VS what I think it was intended to be
```c++
!((Save_GetSaveMetaInfo(fileChooseCtx->buttonIndex)->requiresMasterQuest && !ResourceMgr_GameHasMasterQuest()) ||
(Save_GetSaveMetaInfo(fileChooseCtx->buttonIndex)->requiresOriginal && !ResourceMgr_GameHasOriginal()))
```
But as I said, we can't rely on the fileMetaInfo here anyways

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/588519555.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/588519556.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/588519557.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/588519558.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/588519559.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/588519560.zip)
<!--- section:artifacts:end -->