### PR TITLE
Fix: Restore Desert flags wind speed

### DIFF
--- a/soh/soh/resource/importer/scenecommand/SetWindSettingsFactory.cpp
+++ b/soh/soh/resource/importer/scenecommand/SetWindSettingsFactory.cpp
@@ -37,7 +37,7 @@ void Ship::SetWindSettingsFactoryV0::ParseFileBinary(std::shared_ptr<BinaryReade
 	setWind->settings.windWest = reader->ReadInt8();
     setWind->settings.windVertical = reader->ReadInt8();
     setWind->settings.windSouth = reader->ReadInt8();
-    setWind->settings.windSpeed = reader->ReadInt8();
+    setWind->settings.windSpeed = reader->ReadUByte();
 }
 
 } // namespace Ship

--- a/soh/soh/resource/type/scenecommand/SetWindSettings.h
+++ b/soh/soh/resource/type/scenecommand/SetWindSettings.h
@@ -12,7 +12,7 @@ typedef struct {
   int8_t windWest;
   int8_t windVertical;
   int8_t windSouth;
-  int8_t windSpeed;
+  uint8_t windSpeed;
 } WindSettings;
 
 class SetWindSettings : public SceneCommand {


### PR DESCRIPTION
After the resource changes, the flags in Desert Colossus and Haunted Wasteland would briefly appear to move, and then would stop moving entirely.

Looking into, the wind speed value was negative, and the flags have a check for when wind speed is negative they overwrite it to 0.

Comparing to the old resource type this is because the wind speed was original a `uint8_t` but with the new resource changes it was turned into a `int8_t`, causing the wind value to be negative.

This PR switches the wind speed type back to a `unit8_t` which fixes the flags again.

I compared the values returned from 5.1.4 to this PR and they are identical for all the wind values now.

Fixes #2447

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/589497359.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/589497360.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/589497364.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/589497365.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/589497366.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/589497369.zip)
<!--- section:artifacts:end -->