### PR TITLE
Fix: Clear Bongo-Bongo dead static effect on actor reset

### DIFF
--- a/soh/src/overlays/actors/ovl_Boss_Sst/z_boss_sst.c
+++ b/soh/src/overlays/actors/ovl_Boss_Sst/z_boss_sst.c
@@ -247,7 +247,7 @@ const ActorInit Boss_Sst_InitVars = {
     (ActorFunc)BossSst_Destroy,
     (ActorFunc)BossSst_UpdateHand,
     (ActorFunc)BossSst_DrawHand,
-    NULL,
+    (ActorResetFunc)BossSst_Reset,
 };
 
 #include "z_boss_sst_colchk.c"
@@ -3268,4 +3268,13 @@ void BossSst_Reset(void) {
 
     sCutsceneCamera= 0;
     sBodyStatic = false;
+    // Reset death colors
+    sBodyColor.a = 255;
+    sBodyColor.r = 255;
+    sBodyColor.g = 255;
+    sBodyColor.b = 255;
+    sStaticColor.a = 255;
+    sStaticColor.r = 0;
+    sStaticColor.g = 0;
+    sStaticColor.b = 0;
 }


### PR DESCRIPTION
When Bongo-Bongo dies, his body color is darkened and then a static noise effect is applied. However, on subsequent re-fights in the same SoH instance, the darkened and static effects are still applied.

This is because these effects are stored as _static_ variables and were not being reset properly.

This PR wires up the existing `Reset` method to the bongo actor, and adds additional property resets to completely remove the darkened and static effects.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/590431438.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/590431439.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/590431440.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/590431441.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/590431442.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/590431443.zip)
<!--- section:artifacts:end -->