### PR TITLE
Makes sequenceMap and seqLoadStatus a dynamic size - Khan Version

### DIFF
--- a/soh/include/z64audio.h
+++ b/soh/include/z64audio.h
@@ -22,7 +22,8 @@
 
 #define CALC_RESAMPLE_FREQ(sampleRate) ((float)sampleRate / (s32)gAudioContext.audioBufferParameters.frequency)
 
-#define MAX_SEQUENCES 0x400
+//#define MAX_SEQUENCES 0x800
+extern size_t sequenceMapSize;
 
 extern char* fontMap[256];
 
@@ -917,7 +918,7 @@ typedef struct {
     /* 0x342C */ AudioPoolSplit3 temporaryCommonPoolSplit;
     /* 0x3438 */ u8 sampleFontLoadStatus[0x30];
     /* 0x3468 */ u8 fontLoadStatus[0x30];
-    /* 0x3498 */ u8 seqLoadStatus[MAX_SEQUENCES];
+    /* 0x3498 */ u8* seqLoadStatus;
     /* 0x3518 */ volatile u8 resetStatus;
     /* 0x3519 */ u8 audioResetSpecIdToLoad;
     /* 0x351C */ s32 audioResetFadeOutFramesLeft;

--- a/soh/src/code/audio_heap.c
+++ b/soh/src/code/audio_heap.c
@@ -53,7 +53,7 @@ void AudioHeap_ResetLoadStatus(void) {
         }
     }
 
-    for (i = 0; i < MAX_SEQUENCES; i++) {
+    for (i = 0; i < sequenceMapSize; i++) {
         if (gAudioContext.seqLoadStatus[i] != 5) {
             gAudioContext.seqLoadStatus[i] = 0;
         }

--- a/soh/src/code/audio_seqplayer.c
+++ b/soh/src/code/audio_seqplayer.c
@@ -3,7 +3,7 @@
 #include <libultraship/libultra.h>
 #include "global.h"
 
-extern char* sequenceMap[MAX_SEQUENCES];
+extern char** sequenceMap;
 
 #define PORTAMENTO_IS_SPECIAL(x) ((x).mode & 0x80)
 #define PORTAMENTO_MODE(x) ((x).mode & ~0x80)


### PR DESCRIPTION
Refactors to allow the above two arrays to be a dynamic size when the game launches, size is set during the AudioLoad_Init function. I have already confirmed that AudioLoad_Init only gets called once per launch, and on soft-reset, AudioLoad_Init does not get called again, so these memory allocations do not cause any memory leaks.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/593366119.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/593366120.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/593366121.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/593366122.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/593366123.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/593366124.zip)
<!--- section:artifacts:end -->