### PR TITLE
Enemy Rando - Arwing range check (Khan Edition)

### DIFF
--- a/soh/src/overlays/actors/ovl_En_Clear_Tag/z_en_clear_tag.c
+++ b/soh/src/overlays/actors/ovl_En_Clear_Tag/z_en_clear_tag.c
@@ -475,9 +475,15 @@ void EnClearTag_Update(Actor* thisx, PlayState* play2) {
                     Math_ApproachS(&this->actor.world.rot.z, 0, 15, this->targetDirection.z);
                     Math_ApproachF(&this->targetDirection.z, 0x500, 1.0f, 0x100);
 
+                    // Introduce a range requirement in Enemy Rando so Arwings don't shoot the player from
+                    // across the map. Especially noticeable in big maps like Lake Hylia and Hyrule Field.
+                    uint8_t enemyRandoShootLaser =
+                        !CVarGetInteger("gRandomizedEnemies", 0) ||
+                        (CVarGetInteger("gRandomizedEnemies", 0) && this->actor.xzDistToPlayer < 1000.0f);
+
                     // Check if the Arwing should fire its laser.
                     if ((this->frameCounter % 4) == 0 && (Rand_ZeroOne() < 0.75f) &&
-                        (this->state == CLEAR_TAG_STATE_TARGET_LOCKED)) {
+                            (this->state == CLEAR_TAG_STATE_TARGET_LOCKED) && enemyRandoShootLaser) {
                         this->shouldShootLaser = true;
                     }
                 } else {

--- a/soh/src/overlays/actors/ovl_En_Clear_Tag/z_en_clear_tag.c
+++ b/soh/src/overlays/actors/ovl_En_Clear_Tag/z_en_clear_tag.c
@@ -477,9 +477,7 @@ void EnClearTag_Update(Actor* thisx, PlayState* play2) {
 
                     // Introduce a range requirement in Enemy Rando so Arwings don't shoot the player from
                     // across the map. Especially noticeable in big maps like Lake Hylia and Hyrule Field.
-                    uint8_t enemyRandoShootLaser =
-                        !CVarGetInteger("gRandomizedEnemies", 0) ||
-                        (CVarGetInteger("gRandomizedEnemies", 0) && this->actor.xzDistToPlayer < 1000.0f);
+                    uint8_t enemyRandoShootLaser = !CVarGetInteger("gRandomizedEnemies", 0) || this->actor.xzDistToPlayer < 1000.0f;
 
                     // Check if the Arwing should fire its laser.
                     if ((this->frameCounter % 4) == 0 && (Rand_ZeroOne() < 0.75f) &&


### PR DESCRIPTION
Continuation of https://github.com/HarbourMasters/Shipwright/pull/2604

It was incredibly annoying that Arwings could shoot players from across the map, with the player basically having no way to retaliate or avoid it. This range check is still considerable but close enough where the player can walk towards the Arwing to begin the nuttage.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/594014162.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/594014163.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/594014164.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/594014165.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/594014166.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/594014167.zip)
<!--- section:artifacts:end -->