### PR TITLE
Shopsanity Affordable Logic Update

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/shops.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/shops.cpp
@@ -133,7 +133,13 @@ int GetPriceFromMax(int max) {
     return Random(1, max) * 5; // random range of 1 - wallet max / 5, where wallet max is the highest it goes as a multiple of 5
 }
 
+// Get random price out of available "affordable prices", or just return 10 if Starter wallet is selected (no need to randomly select
+// from a single element
 int GetPriceAffordable() {
+    if (Settings::ShopsanityPrices.Is(RO_SHOPSANITY_PRICE_STARTER)) {
+        return 10;
+    }
+
     static const std::vector<int> affordablePrices = { 10, 105, 205, 505 };
     std::vector<int> priceList;
     uint8_t maxElements = Settings::ShopsanityPrices.Value<uint8_t>();
@@ -161,13 +167,7 @@ int GetRandomShopPrice() {
         max = 199; // 995/5
     }
     if (max != 0) {
-        if (Settings::ShopsanityPricesAffordable.Is(true)) {
-            if(max == 19) {
-                return 10;
-            }
-            return GetPriceAffordable();
-        }
-        return GetPriceFromMax(max);
+        return Settings::ShopsanityPricesAffordable.Is(true) ? GetPriceAffordable() : GetPriceFromMax(max);
     }
     // Balanced is default, so if all other known cases fail, fall back to Balanced
     int price = 150; // JUST in case something fails with the randomization, return sane price for balanced

--- a/soh/soh/Enhancements/randomizer/3drando/shops.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/shops.cpp
@@ -128,27 +128,28 @@ static constexpr std::array<double, 60> ShopPriceProbability= {
   0.959992180, 0.968187000, 0.975495390, 0.981884488, 0.987344345, 0.991851853, 0.995389113, 0.997937921, 0.999481947, 1.000000000,
 };
 
-std::vector<int> priceCaps = { 10, 105, 205, 505 };
-
 // Generate random number from 5 to wallet max
 int GetPriceFromMax(int max) {
     return Random(1, max) * 5; // random range of 1 - wallet max / 5, where wallet max is the highest it goes as a multiple of 5
 }
 
 int GetPriceAffordable() {
-    std::vector<int> elementCaps;
+    static const std::vector<int> affordablePrices = { 10, 105, 205, 505 };
+    std::vector<int> priceList;
     uint8_t maxElements = Settings::ShopsanityPrices.Value<uint8_t>();
     for (int i = 0; i < maxElements; i++) {
-        elementCaps.push_back(priceCaps.at(i));
+        priceList.push_back(affordablePrices.at(i));
     }
-    return RandomElement(elementCaps);
+    return RandomElement(priceList);
 }
 
 int GetRandomShopPrice() {
     int max = 0;
+    // max 0 means Balanced is selected, and thus shouldn't trigger GetPriceFromMax or GetPriceAffordable
 
-    if(Settings::ShopsanityPrices.Is(RO_SHOPSANITY_PRICE_STARTER)) {// check for xx wallet setting and set max amount as method for
-        max = 19; // 95/5                                                        // setting true randomization
+    // check settings for a wallet tier selection and set max amount as method for setting true randomization or affordability
+    if(Settings::ShopsanityPrices.Is(RO_SHOPSANITY_PRICE_STARTER)) {
+        max = 19; // 95/5
     }
     else if (Settings::ShopsanityPrices.Is(RO_SHOPSANITY_PRICE_ADULT)) {
         max = 40; // 200/5

--- a/soh/soh/Enhancements/randomizer/3drando/shops.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/shops.cpp
@@ -134,7 +134,7 @@ int GetPriceFromMax(int max) {
 }
 
 // Get random price out of available "affordable prices", or just return 10 if Starter wallet is selected (no need to randomly select
-// from a single element
+// from a single element)
 int GetPriceAffordable() {
     if (Settings::ShopsanityPrices.Is(RO_SHOPSANITY_PRICE_STARTER)) {
         return 10;
@@ -150,10 +150,15 @@ int GetPriceAffordable() {
 }
 
 int GetRandomShopPrice() {
-    int max = 0;
-    // max 0 means Balanced is selected, and thus shouldn't trigger GetPriceFromMax or GetPriceAffordable
+    // If Affordable is enabled, no need to set randomizer max price
+    if (Settings::ShopsanityPricesAffordable.Is(true)) {
+        return GetPriceAffordable();
+    }
 
-    // check settings for a wallet tier selection and set max amount as method for setting true randomization or affordability
+    // max 0 means Balanced is selected, and thus shouldn't trigger GetPriceFromMax
+    int max = 0;
+
+    // check settings for a wallet tier selection and set max amount as method for setting true randomization
     if(Settings::ShopsanityPrices.Is(RO_SHOPSANITY_PRICE_STARTER)) {
         max = 19; // 95/5
     }
@@ -167,7 +172,7 @@ int GetRandomShopPrice() {
         max = 199; // 995/5
     }
     if (max != 0) {
-        return Settings::ShopsanityPricesAffordable.Is(true) ? GetPriceAffordable() : GetPriceFromMax(max);
+        return GetPriceFromMax(max);
     }
     // Balanced is default, so if all other known cases fail, fall back to Balanced
     int price = 150; // JUST in case something fails with the randomization, return sane price for balanced

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -3094,7 +3094,7 @@ void DrawRandoEditor(bool& open) {
     static const char* randoLinksPocket[4] = { "Dungeon Reward", "Advancement", "Anything", "Nothing" };
     static const char* randoShuffleSongs[3] = { "Song Locations", "Dungeon Rewards", "Anywhere" };
     static const char* randoShopsanity[7] = { "Off", "0 Items", "1 Item", "2 Items", "3 Items", "4 Items", "Random" };
-    static const char* randoShopsanityPrices[6] = { "Balanced", "Starter Wallet", "Adult Wallet", "Giant's Wallet", "Tycoon's Wallet", "Affordable" };
+    static const char* randoShopsanityPrices[5] = { "Balanced", "Starter Wallet", "Adult Wallet", "Giant's Wallet", "Tycoon's Wallet" };
     static const char* randoTokensanity[4] = { "Off", "Dungeons", "Overworld", "All Tokens" };
     static const char* randoShuffleScrubs[4] = { "Off", "Affordable", "Expensive", "Random Prices" };
     static const char* randoShuffleMerchants[3] = { "Off", "On (no hints)", "On (with hints)" };
@@ -3729,8 +3729,8 @@ void DrawRandoEditor(bool& open) {
                         UIWidgets::EnhancementCheckbox(Settings::ShopsanityPricesAffordable.GetName().c_str(), "gRandomizeShopsanityPricesAffordable",
                             CVarGetInteger("gRandomizeShopsanityPrices", RO_SHOPSANITY_PRICE_BALANCED) == RO_SHOPSANITY_PRICE_BALANCED,
                             "This can only apply to a wallet range.");
-                        UIWidgets::InsertHelpHoverText("Cap item prices to a value just above the previous tier wallet's max value.\n"
-                            "Affordable caps: starter = 10, adult = 105, giant = 205, tycoon = 505\n"
+                        UIWidgets::InsertHelpHoverText("Random selection between the selected wallet tier's affordable price and the affordable prices of the preceding wallet tiers.\n\n"
+                            "Affordable prices per tier: starter = 10, adult = 105, giant = 205, tycoon = 505\n\n"
                             "Use this to enable wallet tier locking, but make shop items not as expensive as they could be.");
                 }
 


### PR DESCRIPTION
This changes the Affordable shopsanity price logic to select from an array of "affordable prices" (one per tier) based on the tier of wallet selected. Given {10, 105, 205, 505}, each progressive tier adds one of those to the selection.

Starter  -> 100% 10 rupees
Adult    -> Selection between [10, 105] (50% chance)
Giant    -> Selection between [10, 105, 205] (33% chance)
Tycoon -> Selection between all four (25% chance)

Also updated the tooltip for the Affordable toggle to reflect this (should be obvious this is what it's doing now, instead of confusing between this and the way I had it before).

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/596813807.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/596813809.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/596813811.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/596813813.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/596813815.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/596813817.zip)
<!--- section:artifacts:end -->