### PR TITLE
[Time Saver Enhancement] Dampe Appears All Night

### DIFF
--- a/soh/soh/Enhancements/presets.h
+++ b/soh/soh/Enhancements/presets.h
@@ -128,6 +128,7 @@ const std::vector<const char*> enhancementsCvars = {
     "gTimeFlowFileSelect",
     "gInjectItemCounts",
     "gDayGravePull",
+    "gDampeAllNight",
     "gSkipScarecrow",
     "gBlueFireArrows",
     "gSunlightArrows",

--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -400,6 +400,8 @@ namespace GameMenuBar {
                     "to the guard next to the gate.");
                     UIWidgets::PaddedEnhancementCheckbox("Faster Farore's Wind", "gFastFarores", true, false);
                     UIWidgets::Tooltip("Greatly decreases cast time of Farore's Wind magic spell.");
+                    UIWidgets::PaddedEnhancementCheckbox("Dampe Appears All Night", "gDampeAllNight", true, false);
+                    UIWidgets::Tooltip("Makes Dampe appear anytime during it's night, not just his usual working hours.");
                     ImGui::EndMenu();
                 }
 

--- a/soh/src/overlays/actors/ovl_En_Tk/z_en_tk.c
+++ b/soh/src/overlays/actors/ovl_En_Tk/z_en_tk.c
@@ -502,8 +502,12 @@ void EnTk_Init(Actor* thisx, PlayState* play) {
 
     CollisionCheck_SetInfo2(&this->actor.colChkInfo, NULL, &sColChkInfoInit);
 
-    if (gSaveContext.dayTime <= 0xC000 || gSaveContext.dayTime >= 0xE000 || !!LINK_IS_ADULT ||
-        play->sceneNum != SCENE_SPOT02) {
+    if (CVarGetInteger("gDampeAllNight", 0)) {
+        if (gSaveContext.dayTime <= (int)-1 || !!LINK_IS_ADULT || play->sceneNum != SCENE_SPOT02) {
+            Actor_Kill(&this->actor);
+            return;
+        }
+    } else if (gSaveContext.dayTime <= 0xC000 || gSaveContext.dayTime >= 0xE000 || !!LINK_IS_ADULT || play->sceneNum != SCENE_SPOT02) {
         Actor_Kill(&this->actor);
         return;
     }

--- a/soh/src/overlays/actors/ovl_En_Tk/z_en_tk.c
+++ b/soh/src/overlays/actors/ovl_En_Tk/z_en_tk.c
@@ -503,7 +503,7 @@ void EnTk_Init(Actor* thisx, PlayState* play) {
     CollisionCheck_SetInfo2(&this->actor.colChkInfo, NULL, &sColChkInfoInit);
 
     if (CVarGetInteger("gDampeAllNight", 0)) {
-        if (gSaveContext.dayTime <= (int)-1 || !!LINK_IS_ADULT || play->sceneNum != SCENE_SPOT02) {
+        if (!!LINK_IS_ADULT || play->sceneNum != SCENE_SPOT02) {
             Actor_Kill(&this->actor);
             return;
         }


### PR DESCRIPTION
When turned on, Dampe will appear at all hours of the night, not just his current, laughably short, working hours. 

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/595060462.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/595060463.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/595060464.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/595060465.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/595060466.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/595060467.zip)
<!--- section:artifacts:end -->