### PR TITLE
Fixes some XML texture size and offeset errors.

### DIFF
--- a/soh/assets/xml/GC_MQ_D/objects/object_mori_tex.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_mori_tex.xml
@@ -11,10 +11,9 @@
         <Texture Name="gMoriStalfosPlatformSideTex" OutName="stalfos_platform_side" Format="rgba16" Height="32" Width="64" Offset="0x3200"/>
         <Texture Name="gMoriStalfosPlatformTopTex" OutName="stalfos_platform_top" Format="rgba16" Height="32" Width="32" Offset="0x4200"/>
 
-        <Texture Name="gMoriHashiraPlatformsTex" OutName="hashira_platform" Format="rgba16" Height="32" Width="32" Offset="0x4A00"/>
+        <Texture Name="gMoriHashiraPlatformsTex" OutName="hashira_platform" Format="rgba16" Height="16" Width="16" Offset="0x4A00"/>
 
-        <!-- This is just a guess since its unused -->
-        <Texture Name="gMoriWaterTex" OutName="water_tex" Format="rgba16" Height="8" Width="32" Offset="0x5200"/> 
+        <Texture Name="gMoriWaterTex" OutName="water_tex" Format="rgba16" Height="32" Width="32" Offset="0x4C00"/> 
 
         <Texture Name="gMoriHashigoLadderTex" OutName="ladder" Format="rgba16" Height="32" Width="32" Offset="0x5400"/>
 

--- a/soh/assets/xml/GC_NMQ_D/objects/object_mori_tex.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_mori_tex.xml
@@ -11,10 +11,9 @@
         <Texture Name="gMoriStalfosPlatformSideTex" OutName="stalfos_platform_side" Format="rgba16" Height="32" Width="64" Offset="0x3200"/>
         <Texture Name="gMoriStalfosPlatformTopTex" OutName="stalfos_platform_top" Format="rgba16" Height="32" Width="32" Offset="0x4200"/>
 
-        <Texture Name="gMoriHashiraPlatformsTex" OutName="hashira_platform" Format="rgba16" Height="32" Width="32" Offset="0x4A00"/>
+        <Texture Name="gMoriHashiraPlatformsTex" OutName="hashira_platform" Format="rgba16" Height="16" Width="16" Offset="0x4A00"/>
 
-        <!-- This is just a guess since its unused -->
-        <Texture Name="gMoriWaterTex" OutName="water_tex" Format="rgba16" Height="8" Width="32" Offset="0x5200"/> 
+        <Texture Name="gMoriWaterTex" OutName="water_tex" Format="rgba16" Height="32" Width="32" Offset="0x4C00"/> 
 
         <Texture Name="gMoriHashigoLadderTex" OutName="ladder" Format="rgba16" Height="32" Width="32" Offset="0x5400"/>
 

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_mori_tex.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_mori_tex.xml
@@ -11,10 +11,9 @@
         <Texture Name="gMoriStalfosPlatformSideTex" OutName="stalfos_platform_side" Format="rgba16" Height="32" Width="64" Offset="0x3200"/>
         <Texture Name="gMoriStalfosPlatformTopTex" OutName="stalfos_platform_top" Format="rgba16" Height="32" Width="32" Offset="0x4200"/>
 
-        <Texture Name="gMoriHashiraPlatformsTex" OutName="hashira_platform" Format="rgba16" Height="32" Width="32" Offset="0x4A00"/>
+        <Texture Name="gMoriHashiraPlatformsTex" OutName="hashira_platform" Format="rgba16" Height="16" Width="16" Offset="0x4A00"/>
 
-        <!-- This is just a guess since its unused -->
-        <Texture Name="gMoriWaterTex" OutName="water_tex" Format="rgba16" Height="8" Width="32" Offset="0x5200"/> 
+        <Texture Name="gMoriWaterTex" OutName="water_tex" Format="rgba16" Height="32" Width="32" Offset="0x4C00"/> 
 
         <Texture Name="gMoriHashigoLadderTex" OutName="ladder" Format="rgba16" Height="32" Width="32" Offset="0x5400"/>
 


### PR DESCRIPTION
These fix a crash/texture error in the Forest Temple outdoor areas. The texture bug is technically in Khan but does not crash there and requires an OTR regen to fix, so it will have to go in to develop.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/596113648.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/596113649.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/596113650.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/596113651.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/596113652.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/596113654.zip)
<!--- section:artifacts:end -->