### PR TITLE
Balanced Shopsanity Bugfix

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/shops.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/shops.cpp
@@ -136,7 +136,7 @@ int GetPriceFromMax(int max) {
 // Get random price out of available "affordable prices", or just return 10 if Starter wallet is selected (no need to randomly select
 // from a single element)
 int GetPriceAffordable() {
-    if (Settings::ShopsanityPrices.Is(RO_SHOPSANITY_PRICE_STARTER)) {
+    if (Settings::ShopsanityPrices.Is(RO_SHOPSANITY_PRICE_STARTER) && !Settings::ShopsanityPrices.Is(RO_SHOPSANITY_PRICE_BALANCED)) {
         return 10;
     }
 

--- a/soh/soh/Enhancements/randomizer/3drando/shops.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/shops.cpp
@@ -136,7 +136,7 @@ int GetPriceFromMax(int max) {
 // Get random price out of available "affordable prices", or just return 10 if Starter wallet is selected (no need to randomly select
 // from a single element)
 int GetPriceAffordable() {
-    if (Settings::ShopsanityPrices.Is(RO_SHOPSANITY_PRICE_STARTER) && !Settings::ShopsanityPrices.Is(RO_SHOPSANITY_PRICE_BALANCED)) {
+    if (Settings::ShopsanityPrices.Is(RO_SHOPSANITY_PRICE_STARTER)) {
         return 10;
     }
 
@@ -151,7 +151,7 @@ int GetPriceAffordable() {
 
 int GetRandomShopPrice() {
     // If Affordable is enabled, no need to set randomizer max price
-    if (Settings::ShopsanityPricesAffordable.Is(true)) {
+    if (Settings::ShopsanityPricesAffordable.Is(true) && Settings::ShopsanityPrices.IsNot(RO_SHOPSANITY_PRICE_BALANCED)) {
         return GetPriceAffordable();
     }
 

--- a/soh/soh/Enhancements/randomizer/3drando/shops.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/shops.cpp
@@ -150,7 +150,7 @@ int GetPriceAffordable() {
 }
 
 int GetRandomShopPrice() {
-    // If Affordable is enabled, no need to set randomizer max price
+    // If Shopsanity prices aren't Balanced, but Affordable is on, don't GetPriceFromMax
     if (Settings::ShopsanityPricesAffordable.Is(true) && Settings::ShopsanityPrices.IsNot(RO_SHOPSANITY_PRICE_BALANCED)) {
         return GetPriceAffordable();
     }


### PR DESCRIPTION
As an unintended consequence of the changes briaguya suggested, and I implemented, in the affordable shopsanity update, it didn't register that the Affordable checkbox in Randomizer Settings retains its enabled or disabled status, so if someone selects Affordable and then changes the price range to Balanced, Affordable is still on, and thus GetPriceAffordable is called even without a wallet range, executing an out of range error. This fixes that.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/600996275.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/600996277.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/600996278.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/600996280.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/600996282.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/600996283.zip)
<!--- section:artifacts:end -->