### PR TITLE
Restore 1.0 quick Bongo kill glitch

### DIFF
--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -853,6 +853,8 @@ namespace GameMenuBar {
                 UIWidgets::PaddedEnhancementCheckbox("Quick Putaway", "gQuickPutaway", true, false);
                 UIWidgets::Tooltip("Restore a bug from NTSC 1.0 that allows putting away an item without an animation and performing Putaway Ocarina Items");
                 UIWidgets::PaddedEnhancementCheckbox("Restore old Gold Skulltula cutscene", "gGsCutscene", true, false);
+                UIWidgets::PaddedEnhancementCheckbox("Quick Bongo Kill", "gQuickBongoKill", true, false);
+                UIWidgets::Tooltip("Restore a bug from NTSC 1.0 that allows bypassing Bongo Bongo's intro cutscene to quickly kill him");
 
                 ImGui::EndMenu();
             }

--- a/soh/src/overlays/actors/ovl_Boss_Sst/z_boss_sst.c
+++ b/soh/src/overlays/actors/ovl_Boss_Sst/z_boss_sst.c
@@ -356,12 +356,17 @@ void BossSst_HeadSetupLurk(BossSst* this) {
 }
 
 void BossSst_HeadLurk(BossSst* this, PlayState* play) {
+    if (CVarGetInteger("gQuickBongoKill", 0))
+        this->colliderCyl.base.acFlags |= AC_ON;
     if (this->actor.yDistToPlayer < 1000.0f) {
         BossSst_HeadSetupIntro(this, play);
     }
 }
 
 void BossSst_HeadSetupIntro(BossSst* this, PlayState* play) {
+    //Make sure to restore original behavior if the quick kill didn't happen
+    if (CVarGetInteger("gQuickBongoKill", 0))
+        this->colliderCyl.base.acFlags &= ~AC_ON;
     Player* player = GET_PLAYER(play);
 
     this->timer = 611;
@@ -2649,7 +2654,7 @@ void BossSst_UpdateHead(Actor* thisx, PlayState* play) {
         CollisionCheck_SetAT(play, &play->colChkCtx, &this->colliderJntSph.base);
     }
 
-    if ((this->actionFunc != BossSst_HeadLurk) && (this->actionFunc != BossSst_HeadIntro)) {
+    if ((this->actionFunc != BossSst_HeadLurk || CVarGetInteger("gQuickBongoKill", 0)) && (this->actionFunc != BossSst_HeadIntro)) {
         if (this->colliderCyl.base.acFlags & AC_ON) {
             CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderCyl.base);
         }

--- a/soh/src/overlays/actors/ovl_Boss_Sst/z_boss_sst.c
+++ b/soh/src/overlays/actors/ovl_Boss_Sst/z_boss_sst.c
@@ -356,8 +356,10 @@ void BossSst_HeadSetupLurk(BossSst* this) {
 }
 
 void BossSst_HeadLurk(BossSst* this, PlayState* play) {
-    if (CVarGetInteger("gQuickBongoKill", 0))
+    if (CVarGetInteger("gQuickBongoKill", 0)) {
         this->colliderCyl.base.acFlags |= AC_ON;
+    }
+
     if (this->actor.yDistToPlayer < 1000.0f) {
         BossSst_HeadSetupIntro(this, play);
     }
@@ -365,8 +367,10 @@ void BossSst_HeadLurk(BossSst* this, PlayState* play) {
 
 void BossSst_HeadSetupIntro(BossSst* this, PlayState* play) {
     //Make sure to restore original behavior if the quick kill didn't happen
-    if (CVarGetInteger("gQuickBongoKill", 0))
+    if (CVarGetInteger("gQuickBongoKill", 0)) {
         this->colliderCyl.base.acFlags &= ~AC_ON;
+    }
+
     Player* player = GET_PLAYER(play);
 
     this->timer = 611;


### PR DESCRIPTION
Don't have the decompiled 1.0 code to compare to, but looks good as far as I tested.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/609922902.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/609922903.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/609922904.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/609922905.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/609922906.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/609922907.zip)
<!--- section:artifacts:end -->