### PR TITLE
[Cheat] No ReDead/Gibdo freeze

### DIFF
--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -1088,6 +1088,8 @@ namespace GameMenuBar {
             UIWidgets::Tooltip("This allows you to put up your shield with any two-handed weapon in hand except for Deku Sticks");
             UIWidgets::PaddedEnhancementCheckbox("Time Sync", "gTimeSync", true, false);
             UIWidgets::Tooltip("This syncs the ingame time with the real world time");
+            UIWidgets::PaddedEnhancementCheckbox("No ReDead/Gibdo Freeze", "gNoRedeadFreeze", true, false);
+            UIWidgets::Tooltip("Prevents ReDeads and Gibdos from being able to freeze you with their scream");
 
             {
                 static int32_t betaQuestEnabled = CVarGetInteger("gEnableBetaQuest", 0);

--- a/soh/src/overlays/actors/ovl_En_Rd/z_en_rd.c
+++ b/soh/src/overlays/actors/ovl_En_Rd/z_en_rd.c
@@ -329,28 +329,13 @@ void func_80AE2C1C(EnRd* this, PlayState* play) {
         func_80AE2F50(this, play);
     }
     
-    if (CVarGetInteger("gNoRedeadFreeze", 0) && (ABS(sp32) < 0x1554) && (Actor_WorldDistXYZToActor(&this->actor, &player->actor) <= 150.0f)) {
+    if ((ABS(sp32) < 0x1554) && (Actor_WorldDistXYZToActor(&this->actor, &player->actor) <= 150.0f)) {
         if (!(player->stateFlags1 & 0x2C6080) && !(player->stateFlags2 & 0x80)) {
             if (this->unk_306 == 0) {
-                if (!(this->unk_312 & 0x80)) {
-                    player->actor.freezeTimer = 0;
-                }
-                this->unk_306 = 0x3C;
-                Audio_PlayActorSound2(&this->actor, NA_SE_EN_REDEAD_AIM);
-            }
-        } else {
-            func_80AE2F50(this, play);
-        }
-    
-
-
-    } else if ((ABS(sp32) < 0x1554) && (Actor_WorldDistXYZToActor(&this->actor, &player->actor) <= 150.0f)) {
-        if (!(player->stateFlags1 & 0x2C6080) && !(player->stateFlags2 & 0x80)) {
-            if (this->unk_306 == 0) {
-                if (!(this->unk_312 & 0x80)) {
+                if (!(this->unk_312 & 0x80) && !(CVarGetInteger("gNoRedeadFreeze", 0))) {
                     player->actor.freezeTimer = 40;
                     func_8008EEAC(play, &this->actor);
-                    GET_PLAYER(play)->unk_684 = &this->actor;
+                    GET_PLAYER(play)->unk_684 = &this->actor; 
                     func_800AA000(this->actor.xzDistToPlayer, 0xFF, 0x14, 0x96);
                 }
                 this->unk_306 = 0x3C;
@@ -575,15 +560,8 @@ void func_80AE3834(EnRd* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
     s16 temp_v0 = this->actor.yawTowardsPlayer - this->actor.shape.rot.y - this->unk_30E - this->unk_310;
     
-    if (CVarGetInteger("gNoRedeadFreeze", 0)) {
-        if (!(this->unk_312 & 0x80)) {
-            player->actor.freezeTimer = 0;
-        }
-        Audio_PlayActorSound2(&this->actor, NA_SE_EN_REDEAD_AIM);
-        func_80AE2B90(this, play);
-
-    } else if (ABS(temp_v0) < 0x2008) {
-        if (!(this->unk_312 & 0x80)) {
+    if (ABS(temp_v0) < 0x2008) {
+        if (!(this->unk_312 & 0x80) && !(CVarGetInteger("gNoRedeadFreeze", 0))) {
             player->actor.freezeTimer = 60;
             func_800AA000(this->actor.xzDistToPlayer, 0xFF, 0x14, 0x96);
             func_8008EEAC(play, &this->actor);

--- a/soh/src/overlays/actors/ovl_En_Rd/z_en_rd.c
+++ b/soh/src/overlays/actors/ovl_En_Rd/z_en_rd.c
@@ -328,14 +328,14 @@ void func_80AE2C1C(EnRd* this, PlayState* play) {
     if (Actor_WorldDistXYZToPoint(&player->actor, &this->actor.home.pos) >= 150.0f) {
         func_80AE2F50(this, play);
     }
-    
+
     if ((ABS(sp32) < 0x1554) && (Actor_WorldDistXYZToActor(&this->actor, &player->actor) <= 150.0f)) {
         if (!(player->stateFlags1 & 0x2C6080) && !(player->stateFlags2 & 0x80)) {
             if (this->unk_306 == 0) {
                 if (!(this->unk_312 & 0x80) && !(CVarGetInteger("gNoRedeadFreeze", 0))) {
                     player->actor.freezeTimer = 40;
                     func_8008EEAC(play, &this->actor);
-                    GET_PLAYER(play)->unk_684 = &this->actor; 
+                    GET_PLAYER(play)->unk_684 = &this->actor;
                     func_800AA000(this->actor.xzDistToPlayer, 0xFF, 0x14, 0x96);
                 }
                 this->unk_306 = 0x3C;
@@ -559,7 +559,7 @@ void func_80AE3834(EnRd* this, PlayState* play) {
     Color_RGBA8 sp2C = D_80AE493C;
     Player* player = GET_PLAYER(play);
     s16 temp_v0 = this->actor.yawTowardsPlayer - this->actor.shape.rot.y - this->unk_30E - this->unk_310;
-    
+
     if (ABS(temp_v0) < 0x2008) {
         if (!(this->unk_312 & 0x80) && !(CVarGetInteger("gNoRedeadFreeze", 0))) {
             player->actor.freezeTimer = 60;

--- a/soh/src/overlays/actors/ovl_En_Rd/z_en_rd.c
+++ b/soh/src/overlays/actors/ovl_En_Rd/z_en_rd.c
@@ -332,7 +332,7 @@ void func_80AE2C1C(EnRd* this, PlayState* play) {
     if ((ABS(sp32) < 0x1554) && (Actor_WorldDistXYZToActor(&this->actor, &player->actor) <= 150.0f)) {
         if (!(player->stateFlags1 & 0x2C6080) && !(player->stateFlags2 & 0x80)) {
             if (this->unk_306 == 0) {
-                if (!(this->unk_312 & 0x80) && !(CVarGetInteger("gNoRedeadFreeze", 0))) {
+                if (!(this->unk_312 & 0x80) && !CVarGetInteger("gNoRedeadFreeze", 0)) {
                     player->actor.freezeTimer = 40;
                     func_8008EEAC(play, &this->actor);
                     GET_PLAYER(play)->unk_684 = &this->actor;
@@ -561,7 +561,7 @@ void func_80AE3834(EnRd* this, PlayState* play) {
     s16 temp_v0 = this->actor.yawTowardsPlayer - this->actor.shape.rot.y - this->unk_30E - this->unk_310;
 
     if (ABS(temp_v0) < 0x2008) {
-        if (!(this->unk_312 & 0x80) && !(CVarGetInteger("gNoRedeadFreeze", 0))) {
+        if (!(this->unk_312 & 0x80) && !CVarGetInteger("gNoRedeadFreeze", 0)) {
             player->actor.freezeTimer = 60;
             func_800AA000(this->actor.xzDistToPlayer, 0xFF, 0x14, 0x96);
             func_8008EEAC(play, &this->actor);

--- a/soh/src/overlays/actors/ovl_En_Rd/z_en_rd.c
+++ b/soh/src/overlays/actors/ovl_En_Rd/z_en_rd.c
@@ -328,8 +328,23 @@ void func_80AE2C1C(EnRd* this, PlayState* play) {
     if (Actor_WorldDistXYZToPoint(&player->actor, &this->actor.home.pos) >= 150.0f) {
         func_80AE2F50(this, play);
     }
+    
+    if (CVarGetInteger("gNoRedeadFreeze", 0) && (ABS(sp32) < 0x1554) && (Actor_WorldDistXYZToActor(&this->actor, &player->actor) <= 150.0f)) {
+        if (!(player->stateFlags1 & 0x2C6080) && !(player->stateFlags2 & 0x80)) {
+            if (this->unk_306 == 0) {
+                if (!(this->unk_312 & 0x80)) {
+                    player->actor.freezeTimer = 0;
+                }
+                this->unk_306 = 0x3C;
+                Audio_PlayActorSound2(&this->actor, NA_SE_EN_REDEAD_AIM);
+            }
+        } else {
+            func_80AE2F50(this, play);
+        }
+    
 
-    if ((ABS(sp32) < 0x1554) && (Actor_WorldDistXYZToActor(&this->actor, &player->actor) <= 150.0f)) {
+
+    } else if ((ABS(sp32) < 0x1554) && (Actor_WorldDistXYZToActor(&this->actor, &player->actor) <= 150.0f)) {
         if (!(player->stateFlags1 & 0x2C6080) && !(player->stateFlags2 & 0x80)) {
             if (this->unk_306 == 0) {
                 if (!(this->unk_312 & 0x80)) {
@@ -559,8 +574,15 @@ void func_80AE3834(EnRd* this, PlayState* play) {
     Color_RGBA8 sp2C = D_80AE493C;
     Player* player = GET_PLAYER(play);
     s16 temp_v0 = this->actor.yawTowardsPlayer - this->actor.shape.rot.y - this->unk_30E - this->unk_310;
+    
+    if (CVarGetInteger("gNoRedeadFreeze", 0)) {
+        if (!(this->unk_312 & 0x80)) {
+            player->actor.freezeTimer = 0;
+        }
+        Audio_PlayActorSound2(&this->actor, NA_SE_EN_REDEAD_AIM);
+        func_80AE2B90(this, play);
 
-    if (ABS(temp_v0) < 0x2008) {
+    } else if (ABS(temp_v0) < 0x2008) {
         if (!(this->unk_312 & 0x80)) {
             player->actor.freezeTimer = 60;
             func_800AA000(this->actor.xzDistToPlayer, 0xFF, 0x14, 0x96);


### PR DESCRIPTION
Not sure if this was best suited for a cheat or enhancement, but I leaned more towards cheat. I can change it though if that's preferred. But this gets rid of the annoying freeze that normally happens when the redeads/gibdos scream at you, allowing you to walk right past them or kill them with ease.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/611720868.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/611720869.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/611720870.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/611720871.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/611720872.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/611720873.zip)
<!--- section:artifacts:end -->