### PR TITLE
Randomzier: Fix starting rupee item collection

### DIFF
--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -3084,10 +3084,11 @@ s32 Health_ChangeBy(PlayState* play, s16 healthChange) {
 }
 
 void Rupees_ChangeBy(s16 rupeeChange) {
-    if (gPlayState == NULL)
+    if (gPlayState == NULL) {
         gSaveContext.rupees += rupeeChange;
-    else
+    } else {
         gSaveContext.rupeeAccumulator += rupeeChange;
+    }
 
     if (rupeeChange > 0) {
         gSaveContext.sohStats.count[COUNT_RUPEES_COLLECTED] += rupeeChange;

--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -3084,7 +3084,10 @@ s32 Health_ChangeBy(PlayState* play, s16 healthChange) {
 }
 
 void Rupees_ChangeBy(s16 rupeeChange) {
-    gSaveContext.rupeeAccumulator += rupeeChange;
+    if (gPlayState == NULL)
+        gSaveContext.rupees += rupeeChange;
+    else
+        gSaveContext.rupeeAccumulator += rupeeChange;
 
     if (rupeeChange > 0) {
         gSaveContext.sohStats.count[COUNT_RUPEES_COLLECTED] += rupeeChange;


### PR DESCRIPTION
When rupees are given as starting items, they still modify `gSaveContext.rupeeAccumulator`, which is never saved, which means that if you make a new file, start it, and reload without saving, or exit SoH before starting the new file, those rupees are lost. This adds a check in `Rupees_ChangeBy` for `gPlayState` being NULL, and if it is, adds those initial rupees to the rupee count directly.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/612017200.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/612017201.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/612017202.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/612017203.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/612017204.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/612017205.zip)
<!--- section:artifacts:end -->