### PR TITLE
Feature: speed modifiers affect inputs

### DIFF
--- a/soh/soh/Enhancements/controls/GameControlEditor.cpp
+++ b/soh/soh/Enhancements/controls/GameControlEditor.cpp
@@ -313,6 +313,9 @@ namespace GameControlEditor {
             UIWidgets::Spacer(5);
             SohImGui::BeginGroupPanel("Walk Modifier", ImGui::GetContentRegionAvail());
             UIWidgets::PaddedEnhancementCheckbox("Toggle modifier instead of holding", "gWalkSpeedToggle", true, false);
+            UIWidgets::PaddedEnhancementCheckbox("Apply walk speed modifier to raw player inputs if less than 100%", "gWalkModifierToInputs", true, false);
+            DrawHelpIcon("If selected, the walk speed modifier will be taken into account for all player controls that relies on stick magnitude.\n"
+                         "This allows, for example, to put away your sword while moving, easily achieving ESS position, or a quick adjustment of aim sensitivity.");
             UIWidgets::EnhancementSliderFloat("Modifier 1: %d %%", "##WalkMod1", "gWalkModifierOne", 0.0f, 5.0f, "", 1.0f, true);
             UIWidgets::EnhancementSliderFloat("Modifier 2: %d %%", "##WalkMod2", "gWalkModifierTwo", 0.0f, 5.0f, "", 1.0f, true);
             SohImGui::EndGroupPanel();

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -6100,18 +6100,23 @@ void func_8083DFE0(Player* this, f32* arg1, s16* arg2) {
         } 
         
         if (CVarGetInteger("gEnableWalkModify", 0)) {
+            f32 modifierValue = 1.0;
             if (CVarGetInteger("gWalkSpeedToggle", 0)) {
                 if (gWalkSpeedToggle1) {
-                    maxSpeed *= CVarGetFloat("gWalkModifierOne", 1.0f);
+                    modifierValue = CVarGetFloat("gWalkModifierOne", 1.0f);
                 } else if (gWalkSpeedToggle2) {
-                    maxSpeed *= CVarGetFloat("gWalkModifierTwo", 1.0f);
+                    modifierValue = CVarGetFloat("gWalkModifierTwo", 1.0f);
                 }
             } else {
                 if (CHECK_BTN_ALL(sControlInput->cur.button, BTN_MODIFIER1)) {
-                    maxSpeed *= CVarGetFloat("gWalkModifierOne", 1.0f);
+                    modifierValue = CVarGetFloat("gWalkModifierOne", 1.0f);
                 } else if (CHECK_BTN_ALL(sControlInput->cur.button, BTN_MODIFIER2)) {
-                    maxSpeed *= CVarGetFloat("gWalkModifierTwo", 1.0f);
+                    modifierValue = CVarGetFloat("gWalkModifierTwo", 1.0f);
                 }
+            }
+
+            if (modifierValue > 1.0 || !CVarGetInteger("gWalkModifierToInputs", 0)) {
+                maxSpeed *= modifierValue;
             }
         }
 
@@ -10549,6 +10554,30 @@ void Player_UpdateCommon(Player* this, PlayState* play, Input* input) {
     s32 pad;
 
     sControlInput = input;
+
+    if (CVarGetInteger("gEnableWalkModify", 0)) {
+        f32 modifierValue = 1.0;
+        if (CVarGetInteger("gWalkSpeedToggle", 0)) {
+            if (gWalkSpeedToggle1) {
+                modifierValue = CVarGetFloat("gWalkModifierOne", 1.0f);
+            } else if (gWalkSpeedToggle2) {
+                modifierValue = CVarGetFloat("gWalkModifierTwo", 1.0f);
+            }
+        } else {
+            if (CHECK_BTN_ALL(sControlInput->cur.button, BTN_MODIFIER1)) {
+                modifierValue = CVarGetFloat("gWalkModifierOne", 1.0f);
+            } else if (CHECK_BTN_ALL(sControlInput->cur.button, BTN_MODIFIER2)) {
+                modifierValue = CVarGetFloat("gWalkModifierTwo", 1.0f);
+            }
+        }
+
+        if (modifierValue < 1.0 && CVarGetInteger("gWalkModifierToInputs", 0)) {
+            s32 old_stick_x = input->rel.stick_x;
+            s32 old_stick_y = input->rel.stick_y;
+            input->rel.stick_x *= modifierValue * ABS(cosf(Math_Atan2F(old_stick_x, old_stick_y)));
+            input->rel.stick_y *= modifierValue * ABS(sinf(Math_Atan2F(old_stick_x, old_stick_y)));
+        }
+    }
 
     if (this->unk_A86 < 0) {
         this->unk_A86++;


### PR DESCRIPTION
Adds an option for the speed modifiers to directly impact player analog inputs.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/614864461.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/614864462.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/614864463.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/614864464.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/614864465.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/614864466.zip)
<!--- section:artifacts:end -->