### PR TITLE
Fix Missing Custom Sequences

### DIFF
--- a/soh/soh/Enhancements/audio/AudioCollection.cpp
+++ b/soh/soh/Enhancements/audio/AudioCollection.cpp
@@ -261,6 +261,10 @@ extern "C" void AudioCollection_AddToCollection(char *otrPath, uint16_t seqNum) 
     AudioCollection::Instance->AddToCollection(otrPath, seqNum);
 }
 
+bool AudioCollection::HasSequenceNum(uint16_t seqId) {
+    return sequenceMap.contains(seqId);
+}
+
 const char* AudioCollection::GetSequenceName(uint16_t seqId) {
     auto seqIt = sequenceMap.find(seqId);
     if (seqIt != sequenceMap.end()) {
@@ -269,6 +273,18 @@ const char* AudioCollection::GetSequenceName(uint16_t seqId) {
     return nullptr;
 }
 
+size_t AudioCollection::SequenceMapSize() {
+    return sequenceMap.size();
+}
+
 extern "C" const char* AudioCollection_GetSequenceName(uint16_t seqId) {
     return AudioCollection::Instance->GetSequenceName(seqId);
+}
+
+extern "C" bool AudioCollection_HasSequenceNum(uint16_t seqId) {
+    return AudioCollection::Instance->HasSequenceNum(seqId);
+}
+
+extern "C" size_t AudioCollection_SequenceMapSize() {
+    return AudioCollection::Instance->SequenceMapSize();
 }

--- a/soh/soh/Enhancements/audio/AudioCollection.h
+++ b/soh/soh/Enhancements/audio/AudioCollection.h
@@ -58,8 +58,12 @@ class AudioCollection {
         uint16_t GetReplacementSequence(uint16_t seqId);
         void InitializeShufflePool();
         const char* GetSequenceName(uint16_t seqId);
+        bool HasSequenceNum(uint16_t seqId);
+        size_t SequenceMapSize();
 };
 #else
 void AudioCollection_AddToCollection(char *otrPath, uint16_t seqNum);
 const char* AudioCollection_GetSequenceName(uint16_t seqId);
+bool AudioCollection_HasSequenceNum(uint16_t seqId);
+size_t AudioCollection_SequenceMapSize();
 #endif

--- a/soh/src/code/audio_load.c
+++ b/soh/src/code/audio_load.c
@@ -1367,7 +1367,9 @@ void AudioLoad_Init(void* heap, size_t heapSize) {
     qsort(customSeqList, customSeqListSize, sizeof(char*), strcmp_sort);
 
     // Because AudioCollection's sequenceMap actually has more than sequences (including instruments from 130-135 and sfx in the 2000s, 6000s, 10000s, 14000s, 18000s, and 26000s),
-    // it's better here to keep track of the next empty seqNum in AudioCollection instead of just skipping past the instruments at 130 with a higher MAX_AUTHENTIC_SEQID
+    // it's better here to keep track of the next empty seqNum in AudioCollection instead of just skipping past the instruments at 130 with a higher MAX_AUTHENTIC_SEQID,
+    // especially if those others could be added to in the future. However, this really needs to be streamlined with specific ranges in AudioCollection for types, or unifying
+    // AudioCollection and the various maps in here
     int seqNum = startingSeqNum;
 
     for (size_t i = startingSeqNum; i < startingSeqNum + customSeqListSize; i++) {

--- a/soh/src/code/audio_load.c
+++ b/soh/src/code/audio_load.c
@@ -1366,9 +1366,8 @@ void AudioLoad_Init(void* heap, size_t heapSize) {
     int startingSeqNum = MAX_AUTHENTIC_SEQID; // 109 is the highest vanilla sequence
     qsort(customSeqList, customSeqListSize, sizeof(char*), strcmp_sort);
 
-    // Because the additions to AudioCollection's map aren't sequences as this code originally assumed, despite there being other audio assets listed in there,
-    // there's a gap of 20 slots that would be wasted space if we just set MAX_AUTHENTIC_SEQID to 136 to manually skip the audio fonts at 130-135.
-    // This keeps track of the seqNum that should be assigned in audio_load's sequenceMap array to match up with AudioCollection's seqNums after skipping existing assets
+    // Because AudioCollection's sequenceMap actually has more than sequences (including instruments from 130-135 and sfx in the 2000s, 6000s, 10000s, 14000s, 18000s, and 26000s),
+    // it's better here to keep track of the next empty seqNum in AudioCollection instead of just skipping past the instruments at 130 with a higher MAX_AUTHENTIC_SEQID
     int seqNum = startingSeqNum;
 
     for (size_t i = startingSeqNum; i < startingSeqNum + customSeqListSize; i++) {


### PR DESCRIPTION
Turns out there are sounds loaded into `AudioCollection` that aren't sequences, and the custom sequence loading code was assuming this wasn't the case. This modifies the custom sequence loading code to bypass these known vanilla items that are in `AudioCollection` blocking `seqNum` assignment.

Fixes #2566 but will change indexes assigned with Audio Manager while this problem existed.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/627149031.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/627149032.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/627149033.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/627149034.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/627149035.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/627149037.zip)
<!--- section:artifacts:end -->