### PR TITLE
Fix: Deku Theater mask randomizer checks not always granting items

### DIFF
--- a/soh/src/overlays/actors/ovl_En_Dnt_Demo/z_en_dnt_demo.c
+++ b/soh/src/overlays/actors/ovl_En_Dnt_Demo/z_en_dnt_demo.c
@@ -136,19 +136,22 @@ void EnDntDemo_Judge(EnDntDemo* this, PlayState* play) {
         }
     } else {
         if (gSaveContext.n64ddFlag) {
+            Player* player = GET_PLAYER(play);
             switch (Player_GetMask(play)) {
                 case PLAYER_MASK_SKULL:
-                    if (!Flags_GetTreasure(play, 0x1F)) {
+                    if (!Flags_GetTreasure(play, 0x1F) && !Player_InBlockingCsMode(play, player)) {
                         GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(RC_DEKU_THEATER_SKULL_MASK, GI_STICK_UPGRADE_30);
                         GiveItemEntryWithoutActor(play, getItemEntry);
-                        Flags_SetTreasure(play, 0x1F);
+                        player->pendingFlag.flagID = 0x1F;
+                        player->pendingFlag.flagType = FLAG_SCENE_TREASURE;
                     }
                     break;
                 case PLAYER_MASK_TRUTH:
-                    if (!Flags_GetTreasure(play, 0x1E)) {
+                    if (!Flags_GetTreasure(play, 0x1E) && !Player_InBlockingCsMode(play, player)) {
                         GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(RC_DEKU_THEATER_MASK_OF_TRUTH, GI_NUT_UPGRADE_40);
                         GiveItemEntryWithoutActor(play, getItemEntry);
-                        Flags_SetTreasure(play, 0x1E);
+                        player->pendingFlag.flagID = 0x1E;
+                        player->pendingFlag.flagType = FLAG_SCENE_TREASURE;
                     }
                     break;
             }


### PR DESCRIPTION
The Deku Theater mask checks were instantly setting the scene flags for the check being received, so if anything interrupted the item give process (like jumping, first person mode, etc), the item would not be given but the flag is still set. This would soft lock the check.

This PR switches the scene flag setting to use the `pendingFlag` system so the flag is only set after a successful item give.
I also added the safety check for `Player_InBlockingCsMode()` that is used normally used with `GiveItemEntryWithoutActor()` everywhere else.

Fixes #1709 and #2442

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/618973650.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/618973654.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/618973656.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/618973658.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/618973661.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/618973663.zip)
<!--- section:artifacts:end -->