### PR TITLE
Fix: Actually display correct GS token count in message for vanilla and rando

### DIFF
--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -1678,7 +1678,7 @@ extern "C" int CustomMessage_RetrieveIfExists(PlayState* play) {
                 textId = TEXT_GS_FREEZE;
             }
             messageEntry = CustomMessageManager::Instance->RetrieveMessage(customMessageTableID, textId);
-            CustomMessageManager::ReplaceStringInMessage(messageEntry, "{{gsCount}}", std::to_string(gSaveContext.inventory.gsTokens));
+            CustomMessageManager::ReplaceStringInMessage(messageEntry, "{{gsCount}}", std::to_string(gSaveContext.inventory.gsTokens + 1));
         }
     }
     if (textId == TEXT_HEART_CONTAINER && CVarGetInteger("gInjectItemCounts", 0)) {

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -1677,8 +1677,11 @@ extern "C" int CustomMessage_RetrieveIfExists(PlayState* play) {
             } else {
                 textId = TEXT_GS_FREEZE;
             }
+            // In vanilla, GS token count is incremented prior to the text box displaying
+            // In rando we need to bump the token count by one to show the correct count
+            s16 gsCount = gSaveContext.inventory.gsTokens + (gSaveContext.n64ddFlag ? 1 : 0);
             messageEntry = CustomMessageManager::Instance->RetrieveMessage(customMessageTableID, textId);
-            CustomMessageManager::ReplaceStringInMessage(messageEntry, "{{gsCount}}", std::to_string(gSaveContext.inventory.gsTokens + 1));
+            CustomMessageManager::ReplaceStringInMessage(messageEntry, "{{gsCount}}", std::to_string(gsCount));
         }
     }
     if (textId == TEXT_HEART_CONTAINER && CVarGetInteger("gInjectItemCounts", 0)) {

--- a/soh/src/overlays/actors/ovl_En_Si/z_en_si.c
+++ b/soh/src/overlays/actors/ovl_En_Si/z_en_si.c
@@ -103,11 +103,6 @@ void func_80AFB768(EnSi* this, PlayState* play) {
 
                 if (gSaveContext.n64ddFlag) {
                     Randomizer_UpdateSkullReward(this, play);
-                    if (getItemId != RG_ICE_TRAP) {
-                        Randomizer_GiveSkullReward(this, play);
-                    } else {
-                        gSaveContext.pendingIceTrapCount++;
-                    }
                 } else {
                     Item_Give(play, giveItemId);
                 }
@@ -122,8 +117,14 @@ void func_80AFB768(EnSi* this, PlayState* play) {
 
                 Message_StartTextbox(play, textId, NULL);
 
-                if (gSaveContext.n64ddFlag && getItemId != RG_ICE_TRAP) {
-                    Audio_PlayFanfare_Rando(getItem);
+                if (gSaveContext.n64ddFlag) {
+                    if (getItemId != RG_ICE_TRAP) {
+                        Randomizer_GiveSkullReward(this, play);
+                        Audio_PlayFanfare_Rando(getItem);
+                    } else {
+                        gSaveContext.pendingIceTrapCount++;
+                        Audio_PlayFanfare(NA_BGM_SMALL_ITEM_GET);
+                    }
                 } else {
                     Audio_PlayFanfare(NA_BGM_SMALL_ITEM_GET);
                 }
@@ -148,19 +149,20 @@ void func_80AFB89C(EnSi* this, PlayState* play) {
     if (!CHECK_FLAG_ALL(this->actor.flags, ACTOR_FLAG_13)) {
         if (gSaveContext.n64ddFlag) {
             Randomizer_UpdateSkullReward(this, play);
-            if (getItemId != RG_ICE_TRAP) {
-                Randomizer_GiveSkullReward(this, play);
-            } else {
-                gSaveContext.pendingIceTrapCount++;
-            }
         } else {
             Item_Give(play, giveItemId);
         }
 
         Message_StartTextbox(play, textId, NULL);
 
-        if (gSaveContext.n64ddFlag && getItemId != RG_ICE_TRAP) {
-            Audio_PlayFanfare_Rando(getItem);
+        if (gSaveContext.n64ddFlag) {
+            if (getItemId != RG_ICE_TRAP) {
+                Randomizer_GiveSkullReward(this, play);
+                Audio_PlayFanfare_Rando(getItem);
+            } else {
+                gSaveContext.pendingIceTrapCount++;
+                Audio_PlayFanfare(NA_BGM_SMALL_ITEM_GET);
+            }
         } else {
             Audio_PlayFanfare(NA_BGM_SMALL_ITEM_GET);
         }


### PR DESCRIPTION
This PR reverts #2597, as the fix done there although correctly addresses the GS count on vanilla saves being off, it also introduced an issue where rando saves now displayed the wrong count when getting a GS token from a non-GS check.

This was investigated and reported here https://github.com/HarbourMasters/Shipwright/issues/2516#issuecomment-1487435517

The new solution now checks if the save is a rando save to conditionally add the `+1` when displaying the count as randomizer checks present the message box prior to giving the token (which is when the count is actually incremented)

Rando? | From Skulltula? | No Skulltula Freeze? | Working as intended?
-- | -- | -- | --
Vanilla | From Skulltula | No Freeze | ✔
Vanilla | From Skulltula | Freeze | ✔
Rando | From Skulltula | No Freeze | ✔
Rando | From Skulltula | Freeze | ✔
Rando | Not From Skulltula | N/A | ✔

Truly fixes #2516 and #2075

(I'll take my 🥖)

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/620763392.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/620763393.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/620763394.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/620763395.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/620763396.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/620763398.zip)
<!--- section:artifacts:end -->