### PR TITLE
Equip dupe fix

### DIFF
--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_item.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_item.c
@@ -902,7 +902,17 @@ void KaleidoScope_UpdateItemEquip(PlayState* play) {
                         gSaveContext.equips.buttonItems[otherButtonIndex] = ITEM_NONE;
                         gSaveContext.equips.cButtonSlots[otherSlotIndex] = SLOT_NONE;
                     }
-                    break; // Assume there is only one possible pre-existing equip
+                    //break; // 'Assume there is only one possible pre-existing equip'
+                }
+
+                //Fix for Equip Dupe
+                if (pauseCtx->equipTargetItem == ITEM_BOW) {
+                    if ((gSaveContext.equips.buttonItems[otherButtonIndex] >= ITEM_BOW_ARROW_FIRE) &&
+                        (gSaveContext.equips.buttonItems[otherButtonIndex] <= ITEM_BOW_ARROW_LIGHT)) {
+                            gSaveContext.equips.buttonItems[otherButtonIndex] = gSaveContext.equips.buttonItems[targetButtonIndex];
+                            gSaveContext.equips.cButtonSlots[otherSlotIndex] = gSaveContext.equips.cButtonSlots[pauseCtx->equipTargetCBtn];
+                            Interface_LoadItemIcon2(play, otherButtonIndex);
+                        }
                 }
             }
 


### PR DESCRIPTION
This PR reintroduces equip duping which was removed in [https://github.com/HarbourMasters/Shipwright/pull/525](url) which introduced dpad equips.

In the original game elemental arrows temporarily use different addresses (0xBF to 0xC1) for the equipTargetItem index. The code later checks for these values to correct them while it also does checks to swap items in cases where the equipTargetSlot is the same as items on the cButtonSlots. These extra steps were removed with the introduction of dpad equips. Instead the elemental arrows' equipTargetItem indexes were corrected before these checks. I believe this is what lead to the removal of unnecessary checks that the original would do, including a check that would swap the equips when the equipTargetItem is bow and an elemental arrow is equipped to a different buttonItems slot than the equipTargetCBtn. It is this check which is triggered only when performing equip dupe and as the current swapping only looks for the equipTargetSlots and not the removed bow case. This PR readds this case into the buttonItems swap loop.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/628106688.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/628106689.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/628106690.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/628106691.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/628106692.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/628106693.zip)
<!--- section:artifacts:end -->