### PR TITLE
Fix: Prevent crash when dying in/reloading fishing pond while rod is cast

### DIFF
--- a/soh/src/overlays/actors/ovl_Fishing/z_fishing.c
+++ b/soh/src/overlays/actors/ovl_Fishing/z_fishing.c
@@ -22,6 +22,7 @@ void Fishing_UpdateFish(Actor* thisx, PlayState* play);
 void Fishing_UpdateOwner(Actor* thisx, PlayState* play);
 void Fishing_DrawFish(Actor* thisx, PlayState* play);
 void Fishing_DrawOwner(Actor* thisx, PlayState* play);
+void Fishing_Reset(void);
 
 typedef struct {
     /* 0x00 */ u8 unk_00;
@@ -132,7 +133,7 @@ const ActorInit Fishing_InitVars = {
     (ActorFunc)Fishing_Destroy,
     (ActorFunc)Fishing_UpdateFish,
     (ActorFunc)Fishing_DrawFish,
-    NULL,
+    (ActorResetFunc)Fishing_Reset,
 };
 
 static f32 D_80B7A650 = 0.0f;
@@ -5887,4 +5888,11 @@ void Fishing_DrawOwner(Actor* thisx, PlayState* play) {
     }
 
     CLOSE_DISPS(play->state.gfxCtx);
+}
+
+void Fishing_Reset(void) {
+    // Reset static variables for fishing camera and cinematic state to prevent crashing when dying
+    // or re-entering the scene while the fishing rod was cast
+    sCameraId = 0;
+    D_80B7A6CC = 0;
 }


### PR DESCRIPTION
When the fishing rod is cast in the fishing pond scene, a couple static variables are set to track the cinematic state and camera. If Link dies and continues the save, or if the player steals the fishing rod and reenters the fishing pond, SoH will crash as the first update for the fishing actor will attempt to move the camera, but the fishing camera is not active.

To address this, a reset function was added for the fishing actor that resets these static variables so reentering the scene will not cause a crash.

Confirmed fixes #2491 and #1640

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/627309571.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/627309572.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/627309573.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/627309574.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/627309576.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/627309578.zip)
<!--- section:artifacts:end -->