### PR TITLE
Fix: Remove rando allowing grave pulling during day regardless of grave pulling enhancement

### DIFF
--- a/soh/src/overlays/actors/ovl_Bg_Haka/z_bg_haka.c
+++ b/soh/src/overlays/actors/ovl_Bg_Haka/z_bg_haka.c
@@ -69,7 +69,7 @@ void func_8087B7E8(BgHaka* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
 
     if (this->dyna.unk_150 != 0.0f) {
-        if (play->sceneNum == SCENE_SPOT02 && !LINK_IS_ADULT && IS_DAY && !gSaveContext.n64ddFlag && !CVarGetInteger("gDayGravePull", 0)) {
+        if (play->sceneNum == SCENE_SPOT02 && !LINK_IS_ADULT && IS_DAY && !CVarGetInteger("gDayGravePull", 0)) {
             this->dyna.unk_150 = 0.0f;
             player->stateFlags2 &= ~0x10;
             if (!Play_InCsMode(play)) {


### PR DESCRIPTION
There is an enhancement for allowing pulling graves as child during the day, but when playing a rando save the graves are always allowed to be pulled regardless of the enhancement being on or off.

Rando logic does not assume this behavior should exist this way. Looking at the commit history it seems the rando check and the enhancement were made one day apart from each other and then merged together without rando being dropped in favor of the enhancement.

This PR just removes the rando check.
Fixes #1952 

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/628323263.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/628323264.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/628323265.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/628323266.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/628323267.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/628323268.zip)
<!--- section:artifacts:end -->