### PR TITLE
[Time Saver Enhancement] Skip breath animation when Link surfaces from water

### DIFF
--- a/soh/soh/Enhancements/presets.h
+++ b/soh/soh/Enhancements/presets.h
@@ -130,6 +130,7 @@ const std::vector<const char*> enhancementsCvars = {
     "gInjectItemCounts",
     "gDayGravePull",
     "gDampeAllNight",
+    "gSkipSwimDeepEndAnim",
     "gSkipScarecrow",
     "gBlueFireArrows",
     "gSunlightArrows",

--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -356,6 +356,8 @@ namespace GameMenuBar {
                     UIWidgets::Tooltip("Greatly decreases cast time of Farore's Wind magic spell.");
                     UIWidgets::PaddedEnhancementCheckbox("Dampe Appears All Night", "gDampeAllNight", true, false);
                     UIWidgets::Tooltip("Makes Dampe appear anytime during it's night, not just his usual working hours.");
+                    UIWidgets::PaddedEnhancementCheckbox("No water take breath animation", "gNoSwimDeepEndAnim", true, false);
+                    UIWidgets::Tooltip("Skips Link's taking breath animation after coming up from water. This setting does not interfere with getting items from underwater.");
                     ImGui::EndMenu();
                 }
 

--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -365,7 +365,7 @@ namespace GameMenuBar {
                         "- Obtained the Master Sword\n"
                         "- Not within range of Time Block\n"
                         "- Not within range of Ocarina playing spots");
-                    UIWidgets::PaddedEnhancementCheckbox("No water take breath animation", "gNoSwimDeepEndAnim", true, false);
+                    UIWidgets::PaddedEnhancementCheckbox("Skip water take breath animation", "gSkipSwimDeepEndAnim", true, false);
                     UIWidgets::Tooltip("Skips Link's taking breath animation after coming up from water. This setting does not interfere with getting items from underwater.");
                     ImGui::EndMenu();
                 }

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -5819,9 +5819,20 @@ s32 func_8083D12C(PlayState* play, Player* this, Input* arg2) {
                 }
 
                 func_80832340(play, this);
-                func_80832B0C(play, this,
+                
+                /* Skip water take breath animation if the player didn't get an item and the setting is enabled */
+                if (CVarGetInteger("gNoSwimDeepEndAnim", 0) && !(this->stateFlags1 & PLAYER_STATE1_11))
+                {
+                    LinkAnimation_Change(play, &this->skelAnime, &gPlayerAnim_link_swimer_swim_deep_end, 1.0f,
+                        Animation_GetLastFrame(&gPlayerAnim_link_swimer_swim_deep_end),
+                        Animation_GetLastFrame(&gPlayerAnim_link_swimer_swim_deep_end), ANIMMODE_ONCE, -6.0f);
+                }
+                else
+                {
+                    func_80832B0C(play, this,
                               (this->stateFlags1 & PLAYER_STATE1_11) ? &gPlayerAnim_link_swimer_swim_get
                                                                      : &gPlayerAnim_link_swimer_swim_deep_end);
+                }
 
                 if (func_8083CFA8(play, this, this->actor.velocity.y, 500)) {
                     func_8002F7DC(&this->actor, NA_SE_PL_FACE_UP);

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -5821,7 +5821,7 @@ s32 func_8083D12C(PlayState* play, Player* this, Input* arg2) {
                 func_80832340(play, this);
                 
                 /* Skip water take breath animation if the player didn't get an item and the setting is enabled */
-                if (CVarGetInteger("gNoSwimDeepEndAnim", 0) && !(this->stateFlags1 & PLAYER_STATE1_11))
+                if (CVarGetInteger("gSkipSwimDeepEndAnim", 0) && !(this->stateFlags1 & PLAYER_STATE1_11))
                 {
                     LinkAnimation_Change(play, &this->skelAnime, &gPlayerAnim_link_swimer_swim_deep_end, 1.0f,
                         Animation_GetLastFrame(&gPlayerAnim_link_swimer_swim_deep_end),

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -5820,12 +5820,12 @@ s32 func_8083D12C(PlayState* play, Player* this, Input* arg2) {
 
                 func_80832340(play, this);
                 
-                /* Skip water take breath animation if the player didn't get an item and the setting is enabled */
+                // Skip take breath animation on surface if Link didn't grab an item while underwater and the setting is enabled
                 if (CVarGetInteger("gSkipSwimDeepEndAnim", 0) && !(this->stateFlags1 & PLAYER_STATE1_11))
                 {
+                    auto lastAnimFrame = Animation_GetLastFrame(&gPlayerAnim_link_swimer_swim_deep_end);
                     LinkAnimation_Change(play, &this->skelAnime, &gPlayerAnim_link_swimer_swim_deep_end, 1.0f,
-                        Animation_GetLastFrame(&gPlayerAnim_link_swimer_swim_deep_end),
-                        Animation_GetLastFrame(&gPlayerAnim_link_swimer_swim_deep_end), ANIMMODE_ONCE, -6.0f);
+                        lastAnimFrame, lastAnimFrame, ANIMMODE_ONCE, -6.0f);
                 }
                 else
                 {


### PR DESCRIPTION
This PR adds a time saver enhancement to skip the breath animation when Link surfaces from water. It does not interfere with grabbing items underwater - those will still play the in-water "item get" animation.

The entry is in the menu under `Enhancements > Gameplay > Time Savers > Skip water take breath animation`.

Video:
https://user-images.githubusercontent.com/1388037/229373251-9ca4d72d-fccf-4839-973b-9616ab2a0644.mp4



<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/641358498.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/641358500.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/641358502.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/641358503.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/641358504.zip)
<!--- section:artifacts:end -->