### PR TITLE
Fix: Gameplay Stats OOB

### DIFF
--- a/soh/soh/Enhancements/gameplaystats.cpp
+++ b/soh/soh/Enhancements/gameplaystats.cpp
@@ -251,10 +251,10 @@ std::string ResolveSceneID(int sceneID, int roomID){
     } else if (sceneID == SCENE_HAKASITARELAY) {
         //Only the last room of Dampe's Grave (rm 6) is considered the windmill
         scene = roomID == 6 ? "Windmill" : "Dampe's Grave";
-    } else if (sceneID < sceneMappings.length()) {
+    } else if (sceneID < sceneMappings.size()) {
         scene = sceneMappings[sceneID];
     } else {
-        scene = "???"
+        scene = "???";
     }
     return scene;
 }

--- a/soh/soh/Enhancements/gameplaystats.cpp
+++ b/soh/soh/Enhancements/gameplaystats.cpp
@@ -251,7 +251,7 @@ std::string ResolveSceneID(int sceneID, int roomID){
     } else if (sceneID == SCENE_HAKASITARELAY) {
         //Only the last room of Dampe's Grave (rm 6) is considered the windmill
         scene = roomID == 6 ? "Windmill" : "Dampe's Grave";
-    } else if (sceneID < sceneMappings.size()) {
+    } else if (sceneID < SCENE_ID_MAX) {
         scene = sceneMappings[sceneID];
     } else {
         scene = "???";

--- a/soh/soh/Enhancements/gameplaystats.cpp
+++ b/soh/soh/Enhancements/gameplaystats.cpp
@@ -251,8 +251,10 @@ std::string ResolveSceneID(int sceneID, int roomID){
     } else if (sceneID == SCENE_HAKASITARELAY) {
         //Only the last room of Dampe's Grave (rm 6) is considered the windmill
         scene = roomID == 6 ? "Windmill" : "Dampe's Grave";
-    } else {
+    } else if (sceneID < sceneMappings.length()) {
         scene = sceneMappings[sceneID];
+    } else {
+        scene = "???"
     }
     return scene;
 }


### PR DESCRIPTION
Saves made before https://github.com/HarbourMasters/Shipwright/commit/44906598e4bd094543eb96a6f2be9fece9c7ece4 didn't support scene timestamps, so the Save Manager would fill them up with a value of 254 when making a new save or converting one. Unfortunately, if the value isn't changed then we fall OOB when indexing `sceneMappings`. This fixes that issue so if `sceneID` is ever outside of the normal range of [0, 109], it'll just display '???'

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/636318446.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/636318447.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/636318448.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/636318449.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/636318450.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/636318451.zip)
<!--- section:artifacts:end -->