### PR TITLE
Switch age fix

### DIFF
--- a/soh/soh/Enhancements/mods.cpp
+++ b/soh/soh/Enhancements/mods.cpp
@@ -161,18 +161,20 @@ void RegisterFreezeTime() {
 void RegisterSwitchAge() {
     GameInteractor::Instance->RegisterGameHook<GameInteractor::OnGameFrameUpdate>([]() {
         static bool warped = false;
+        static bool switchLock = true;
         static Vec3f playerPos;
         static int16_t playerYaw;
 
         if (!gPlayState) return;
 
-        if (CVarGetInteger("gSwitchAge", 0) != 0) {
-            CVarSetInteger("gSwitchAge", 0);
+        if (CVarGetInteger("gSwitchAge", 0) && switchLock) {
+            switchLock = false;
             playerPos = GET_PLAYER(gPlayState)->actor.world.pos;
             playerYaw = GET_PLAYER(gPlayState)->actor.shape.rot.y;
 
             ReloadSceneTogglingLinkAge();
-
+            CVarSetInteger("gSwitchAge", 0);
+            switchLock = true;
             warped = true;
         }
 

--- a/soh/soh/Enhancements/mods.cpp
+++ b/soh/soh/Enhancements/mods.cpp
@@ -181,9 +181,9 @@ void RegisterSwitchAge() {
             gSaveContext.nextTransitionType == 255) {
             GET_PLAYER(gPlayState)->actor.shape.rot.y = playerYaw;
             GET_PLAYER(gPlayState)->actor.world.pos = playerPos;
-            func_800973FC(gPlayState, &gPlayState->roomCtx); //unload start room 
             func_8009728C(gPlayState, roomCtx, roomNum); //load original room
-            func_80097534(gPlayState, roomCtx);  // load map into correct room (finishes unloading of previous room)
+            //func_800973FC(gPlayState, &gPlayState->roomCtx); // commit to room load?
+            func_80097534(gPlayState, roomCtx);  // load map for new room (unloading the previous room)
             warped = false;      
         }
     });

--- a/soh/soh/Enhancements/mods.cpp
+++ b/soh/soh/Enhancements/mods.cpp
@@ -173,15 +173,14 @@ void RegisterSwitchAge() {
             playerYaw = GET_PLAYER(gPlayState)->actor.shape.rot.y;
 
             ReloadSceneTogglingLinkAge();
-            CVarSetInteger("gSwitchAge", 0);
-            switchLock = true;
             warped = true;
         }
 
-        if (warped && gPlayState->sceneLoadFlag != 0x0014 && gSaveContext.nextTransitionType == 255) {
+        if (!switchLock && warped && gPlayState->sceneLoadFlag != 0x0014 && gSaveContext.nextTransitionType == 255) {
             GET_PLAYER(gPlayState)->actor.shape.rot.y = playerYaw;
             GET_PLAYER(gPlayState)->actor.world.pos = playerPos;
             warped = false;
+            switchLock = true;
         }
     });
 }

--- a/soh/soh/Enhancements/mods.cpp
+++ b/soh/soh/Enhancements/mods.cpp
@@ -184,7 +184,8 @@ void RegisterSwitchAge() {
             func_8009728C(gPlayState, roomCtx, roomNum); //load original room
             //func_800973FC(gPlayState, &gPlayState->roomCtx); // commit to room load?
             func_80097534(gPlayState, roomCtx);  // load map for new room (unloading the previous room)
-            warped = false;      
+            warped = false;
+            CVarSetInteger("gSwitchAge", 0);
         }
     });
 }

--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -1421,7 +1421,9 @@ void Inventory_SwapAgeEquipment(void) {
             if (i != 0) {
                 gSaveContext.childEquips.buttonItems[i] = gSaveContext.equips.buttonItems[i];
             } else {
-                if (CVarGetInteger("gSwitchAge",0) && (gSaveContext.inventory.equipment & PLAYER_SWORD_KOKIRI == PLAYER_SWORD_KOKIRI)) {
+                if (CVarGetInteger("gSwitchAge", 0) && 
+                    gSaveContext.infTable[29] && 
+                    !gSaveContext.n64ddFlag) {
                     gSaveContext.childEquips.buttonItems[i] = ITEM_NONE;
                 } else {
                     gSaveContext.childEquips.buttonItems[i] = ITEM_SWORD_KOKIRI;
@@ -1497,7 +1499,8 @@ void Inventory_SwapAgeEquipment(void) {
 
         gSaveContext.adultEquips.equipment = gSaveContext.equips.equipment;
 
-        if (gSaveContext.childEquips.buttonItems[0] != ITEM_NONE || (!gSaveContext.n64ddFlag && CVarGetInteger("gSwitchAge",0))) {
+        if (gSaveContext.childEquips.buttonItems[0] != ITEM_NONE ||
+            (CVarGetInteger("gSwitchAge", 0) && !gSaveContext.n64ddFlag)) {
             for (i = 0; i < ARRAY_COUNT(gSaveContext.equips.buttonItems); i++) {
                 gSaveContext.equips.buttonItems[i] = gSaveContext.childEquips.buttonItems[i];
 
@@ -1538,11 +1541,16 @@ void Inventory_SwapAgeEquipment(void) {
             gSaveContext.equips.equipment = 0x1111;
         }
 
-        if (!gSaveContext.n64ddFlag && CVarGetInteger("gSwitchAge",0) && (gSaveContext.inventory.equipment & PLAYER_SWORD_KOKIRI == PLAYER_SWORD_KOKIRI)) {
+        if (CVarGetInteger("gSwitchAge", 0) && !gSaveContext.n64ddFlag && (gSaveContext.equips.buttonItems[0] == ITEM_NONE)) {
             gSaveContext.infTable[29] |= 1;
+            if (gSaveContext.childEquips.equipment == 0) {
+                // force equip kokiri tunic and boots in scenario gSaveContext.childEquips.equipment is uninitialized
+                gSaveContext.equips.equipment &= 0xFFF0;
+                gSaveContext.equips.equipment |= 0x1100;
+            }
         }
     }
-
+    CVarSetInteger("gSwitchAge", 0);
     temp = gEquipMasks[EQUIP_SHIELD] & gSaveContext.equips.equipment;
     if (temp != 0) {
         temp >>= gEquipShifts[EQUIP_SHIELD];

--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -1421,7 +1421,11 @@ void Inventory_SwapAgeEquipment(void) {
             if (i != 0) {
                 gSaveContext.childEquips.buttonItems[i] = gSaveContext.equips.buttonItems[i];
             } else {
-                gSaveContext.childEquips.buttonItems[i] = ITEM_SWORD_KOKIRI;
+                if (CVarGetInteger("gSwitchAge",0) && (gSaveContext.inventory.equipment & PLAYER_SWORD_KOKIRI == PLAYER_SWORD_KOKIRI)) {
+                    gSaveContext.childEquips.buttonItems[i] = ITEM_NONE;
+                } else {
+                    gSaveContext.childEquips.buttonItems[i] = ITEM_SWORD_KOKIRI;
+                }
             }
 
             if (i != 0) {
@@ -1493,7 +1497,7 @@ void Inventory_SwapAgeEquipment(void) {
 
         gSaveContext.adultEquips.equipment = gSaveContext.equips.equipment;
 
-        if (gSaveContext.childEquips.buttonItems[0] != ITEM_NONE) {
+        if (gSaveContext.childEquips.buttonItems[0] != ITEM_NONE || (!gSaveContext.n64ddFlag && CVarGetInteger("gSwitchAge",0))) {
             for (i = 0; i < ARRAY_COUNT(gSaveContext.equips.buttonItems); i++) {
                 gSaveContext.equips.buttonItems[i] = gSaveContext.childEquips.buttonItems[i];
 
@@ -1532,6 +1536,10 @@ void Inventory_SwapAgeEquipment(void) {
                 }
             }
             gSaveContext.equips.equipment = 0x1111;
+        }
+
+        if (!gSaveContext.n64ddFlag && CVarGetInteger("gSwitchAge",0) && (gSaveContext.inventory.equipment & PLAYER_SWORD_KOKIRI == PLAYER_SWORD_KOKIRI)) {
+            gSaveContext.infTable[29] |= 1;
         }
     }
 

--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -1418,7 +1418,7 @@ void Inventory_SwapAgeEquipment(void) {
                 gSaveContext.childEquips.buttonItems[i] = gSaveContext.equips.buttonItems[i];
             } else {
                 if (CVarGetInteger("gSwitchAge", 0) && 
-                    gSaveContext.infTable[29]) {
+                    (gSaveContext.infTable[29] & 1)) {
                     gSaveContext.childEquips.buttonItems[i] = ITEM_NONE;
                 } else {
                     gSaveContext.childEquips.buttonItems[i] = ITEM_SWORD_KOKIRI;
@@ -1552,7 +1552,7 @@ void Inventory_SwapAgeEquipment(void) {
             }
         }
     }
-    CVarSetInteger("gSwitchAge", 0);
+
     temp = gEquipMasks[EQUIP_SHIELD] & gSaveContext.equips.equipment;
     if (temp != 0) {
         temp >>= gEquipShifts[EQUIP_SHIELD];

--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -1411,19 +1411,14 @@ void Inventory_SwapAgeEquipment(void) {
     u16 temp;
 
     if (LINK_AGE_IN_YEARS == YEARS_CHILD) {
-        // When becoming adult, remove swordless flag since we'll get master sword
-        // Only in rando to keep swordless link bugs in vanilla
-        if (gSaveContext.n64ddFlag) {
-            gSaveContext.infTable[29] &= ~1;
-        }
+        
 
         for (i = 0; i < ARRAY_COUNT(gSaveContext.equips.buttonItems); i++) {
             if (i != 0) {
                 gSaveContext.childEquips.buttonItems[i] = gSaveContext.equips.buttonItems[i];
             } else {
                 if (CVarGetInteger("gSwitchAge", 0) && 
-                    gSaveContext.infTable[29] && 
-                    !gSaveContext.n64ddFlag) {
+                    gSaveContext.infTable[29]) {
                     gSaveContext.childEquips.buttonItems[i] = ITEM_NONE;
                 } else {
                     gSaveContext.childEquips.buttonItems[i] = ITEM_SWORD_KOKIRI;
@@ -1433,6 +1428,12 @@ void Inventory_SwapAgeEquipment(void) {
             if (i != 0) {
                 gSaveContext.childEquips.cButtonSlots[i - 1] = gSaveContext.equips.cButtonSlots[i - 1];
             }
+        }
+
+        // When becoming adult, remove swordless flag since we'll get master sword
+        // Only in rando to keep swordless link bugs in vanilla
+        if (gSaveContext.n64ddFlag) {
+            gSaveContext.infTable[29] &= ~1;
         }
 
         gSaveContext.childEquips.equipment = gSaveContext.equips.equipment;
@@ -1500,7 +1501,7 @@ void Inventory_SwapAgeEquipment(void) {
         gSaveContext.adultEquips.equipment = gSaveContext.equips.equipment;
 
         if (gSaveContext.childEquips.buttonItems[0] != ITEM_NONE ||
-            (CVarGetInteger("gSwitchAge", 0) && !gSaveContext.n64ddFlag)) {
+            CVarGetInteger("gSwitchAge", 0)) {
             for (i = 0; i < ARRAY_COUNT(gSaveContext.equips.buttonItems); i++) {
                 gSaveContext.equips.buttonItems[i] = gSaveContext.childEquips.buttonItems[i];
 
@@ -1541,7 +1542,8 @@ void Inventory_SwapAgeEquipment(void) {
             gSaveContext.equips.equipment = 0x1111;
         }
 
-        if (CVarGetInteger("gSwitchAge", 0) && !gSaveContext.n64ddFlag && (gSaveContext.equips.buttonItems[0] == ITEM_NONE)) {
+        if (CVarGetInteger("gSwitchAge", 0) &&
+            (gSaveContext.equips.buttonItems[0] == ITEM_NONE)) {
             gSaveContext.infTable[29] |= 1;
             if (gSaveContext.childEquips.equipment == 0) {
                 // force equip kokiri tunic and boots in scenario gSaveContext.childEquips.equipment is uninitialized


### PR DESCRIPTION
This PR addresses the bugs for the switch age cheat, noted in issues #2562 and #2013. The latter's solution can be used for save states too but I thought it would be best to fix those in a separate PR.


https://user-images.githubusercontent.com/78732756/230623938-ec992892-65ac-4929-b580-61b9ddee59db.mp4


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/637377145.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/637377147.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/637377148.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/637377149.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/637377150.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/637377151.zip)
<!--- section:artifacts:end -->