### PR TITLE
Fix: Boss clear logic and add projectile-less Bongo logic trick

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_jabujabus_belly.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_jabujabus_belly.cpp
@@ -244,7 +244,8 @@ void AreaTable_Init_JabuJabusBelly() {
         Area("Jabu Jabus Belly Boss Room", "Jabu Jabus Belly", NONE, NO_DAY_NIGHT_CYCLE,
              {
                  // Events
-                 EventAccess(&JabuJabusBellyClear, { [] { return JabuJabusBellyClear || CanUse(BOOMERANG); } }),
+                 EventAccess(&JabuJabusBellyClear,
+                             { [] { return JabuJabusBellyClear || (CanUse(BOOMERANG) && CanJumpslash); } }),
              },
              {
                  // Locations

--- a/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_shadow_temple.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_shadow_temple.cpp
@@ -193,24 +193,25 @@ void AreaTable_Init_ShadowTemple() {
                  Entrance(SHADOW_TEMPLE_BOSS_ROOM, { [] { return true; } }),
              });
 
-    areaTable[SHADOW_TEMPLE_BOSS_ROOM] =
-        Area("Shadow Temple Boss Room", "Shadow Temple", NONE, NO_DAY_NIGHT_CYCLE,
-             {
-                 // Events
-                 EventAccess(&ShadowTempleClear, { [] {
-                     return ShadowTempleClear ||
-                            ((CanUse(LENS_OF_TRUTH) || ((Dungeon::ShadowTemple.IsVanilla() && LogicLensShadowBack) ||
-                                                        (Dungeon::ShadowTemple.IsMQ() && LogicLensShadowMQBack))) &&
-                             (CanUse(KOKIRI_SWORD) || CanUse(MASTER_SWORD) || CanUse(BIGGORON_SWORD)));
-                 } }),
-             },
-             {
-                 // Locations
-                 LocationAccess(SHADOW_TEMPLE_BONGO_BONGO_HEART, { [] { return ShadowTempleClear; } }),
-                 LocationAccess(BONGO_BONGO, { [] { return ShadowTempleClear; } }),
-             },
-             {
-                 // Exits
-                 Entrance(SHADOW_TEMPLE_BOSS_ENTRYWAY, { [] { return false; } }),
-             });
+    areaTable[SHADOW_TEMPLE_BOSS_ROOM] = Area(
+        "Shadow Temple Boss Room", "Shadow Temple", NONE, NO_DAY_NIGHT_CYCLE,
+        {
+            // Events
+            EventAccess(&ShadowTempleClear, { [] {
+                return ShadowTempleClear ||
+                       ((CanUse(LENS_OF_TRUTH) || ((Dungeon::ShadowTemple.IsVanilla() && LogicLensShadowBack) ||
+                                                   (Dungeon::ShadowTemple.IsMQ() && LogicLensShadowMQBack))) &&
+                        (CanUse(KOKIRI_SWORD) || CanUse(MASTER_SWORD) || CanUse(BIGGORON_SWORD) || LogicShadowBongo) &&
+                        (CanUse(HOOKSHOT) || CanUse(BOW) || CanUse(SLINGSHOT)));
+            } }),
+        },
+        {
+            // Locations
+            LocationAccess(SHADOW_TEMPLE_BONGO_BONGO_HEART, { [] { return ShadowTempleClear; } }),
+            LocationAccess(BONGO_BONGO, { [] { return ShadowTempleClear; } }),
+        },
+        {
+            // Exits
+            Entrance(SHADOW_TEMPLE_BOSS_ENTRYWAY, { [] { return false; } }),
+        });
 }

--- a/soh/soh/Enhancements/randomizer/3drando/setting_descriptions.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/setting_descriptions.cpp
@@ -1435,6 +1435,12 @@ string_view LogicShadowStatueDesc                     = "Difficulty: Novice\n"  
                                                         "By sending a Bombchu around the edge of the gorge,"
                                                         "you can knock down the statue without needing a\n"//
                                                         "Bow. Applies in both vanilla and MQ Shadow.";     //
+string_view LogicShadowBongoDesc                      = "Difficulty Expert\n"                              //
+                                                        "Using precise sword slashes, Bongo Bongo can be\n"//
+                                                        "defeated without using projectiles.\n"            //
+                                                        "This trick is much more difficult when done with\n"
+                                                        "Kokiri Sword vs Master Sword or Biggorron Sword.\n"
+                                                        "Useful for Boss Entrance Randomizer.";            //
 string_view LogicChildDeadhandDesc                    = "Difficulty: Novice\n"                             //
                                                         "Requires 9 sticks or 5 jump slashes.";            //
 string_view LogicGtgWithoutHookshotDesc               = "Difficulty: Expert\n"                             //

--- a/soh/soh/Enhancements/randomizer/3drando/setting_descriptions.hpp
+++ b/soh/soh/Enhancements/randomizer/3drando/setting_descriptions.hpp
@@ -431,6 +431,7 @@ extern string_view LogicShadowFireArrowEntryDesc;
 extern string_view LogicShadowUmbrellaDesc;
 extern string_view LogicShadowFreestandingKeyDesc;
 extern string_view LogicShadowStatueDesc;
+extern string_view LogicShadowBongoDesc;
 extern string_view LogicChildDeadhandDesc;
 extern string_view LogicGtgWithoutHookshotDesc;
 extern string_view LogicGtgFakeWallDesc;

--- a/soh/soh/Enhancements/randomizer/3drando/settings.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/settings.cpp
@@ -726,6 +726,7 @@ namespace Settings {
   Option LogicShadowUmbrella              = LogicTrick(" ShT Stone Umbrella\n   w/ Hover Boots",      LogicShadowUmbrellaDesc);
   Option LogicShadowFreestandingKey       = LogicTrick(" ShT Skull Vase Key\n   w/ Bombchu",          LogicShadowFreestandingKeyDesc);
   Option LogicShadowStatue                = LogicTrick(" ShT River Statue\n   w/ Bombchu",            LogicShadowStatueDesc);
+  Option LogicShadowBongo                 = LogicTrick("ShT Bongo\n w/o Projectiles",                 LogicShadowBongoDesc);
   Option LogicChildDeadhand               = LogicTrick(" BotW Deadhand\n   w/o Sword",                LogicChildDeadhandDesc);
   Option LogicGtgWithoutHookshot          = LogicTrick(" GTG West Silver Rupee\n   w/o Hookshot",     LogicGtgWithoutHookshotDesc);
   Option LogicGtgFakeWall                 = LogicTrick(" GTG Invisible Wall\n   w/ Hover Boots",      LogicGtgFakeWallDesc);
@@ -816,6 +817,7 @@ namespace Settings {
     &LogicShadowUmbrella,
     &LogicShadowFreestandingKey,
     &LogicShadowStatue,
+    &LogicShadowBongo,
     &LogicChildDeadhand,
     &LogicGtgWithoutHookshot,
     &LogicGtgFakeWall,
@@ -2287,6 +2289,7 @@ namespace Settings {
           LogicSpiritSunChest.SetSelectedIndex(1);
           //LogicShadowFireArrowEntry.SetSelectedIndex(1);
           LogicShadowUmbrella.SetSelectedIndex(1);
+          LogicShadowBongo.SetSelectedIndex(1);
           LogicGtgWithoutHookshot.SetSelectedIndex(1);
         }
       }

--- a/soh/soh/Enhancements/randomizer/3drando/settings.hpp
+++ b/soh/soh/Enhancements/randomizer/3drando/settings.hpp
@@ -1186,6 +1186,7 @@ void UpdateSettings(std::unordered_map<RandomizerSettingKey, uint8_t> cvarSettin
   extern Option LogicShadowUmbrella;
   extern Option LogicShadowFreestandingKey;
   extern Option LogicShadowStatue;
+  extern Option LogicShadowBongo;
   extern Option LogicChildDeadhand;
   extern Option LogicGtgWithoutHookshot;
   extern Option LogicGtgFakeWall;


### PR DESCRIPTION
Looking at the logic for boss clears, Barinade was missing a sword/stick check, and Bongo was missing a projectile weapon check. I looked over the rest of the bosses and they seemed fine (ignoring that adult bosses did not have a stick check, but I think that is intended given how much health adult bosses have).

These probably were never a problem in that past for glitchless settings, but with Boss room shuffle, its possible that a previous exit check did not require something needed for the bosses.

The Bongo check in N64 rando has an accompanying logic option to bypass the need for projectiles (using precise sword slashes). This logic option has been added on the 3ds side for posterity and will be available once logic tricks are implemented on our end.

This is a porting of what I did on the 3ds repo here https://github.com/gamestabled/OoT3D_Randomizer/pull/664

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/637296833.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/637296834.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/637296835.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/637296836.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/637296837.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/637296838.zip)
<!--- section:artifacts:end -->