### PR TITLE
Fix: Switch Age No Longer Reloads Start Room

### DIFF
--- a/soh/soh/Enhancements/mods.cpp
+++ b/soh/soh/Enhancements/mods.cpp
@@ -181,9 +181,11 @@ void RegisterSwitchAge() {
             gSaveContext.nextTransitionType == 255) {
             GET_PLAYER(gPlayState)->actor.shape.rot.y = playerYaw;
             GET_PLAYER(gPlayState)->actor.world.pos = playerPos;
-            func_8009728C(gPlayState, roomCtx, roomNum); //load original room
-            //func_800973FC(gPlayState, &gPlayState->roomCtx); // commit to room load?
-            func_80097534(gPlayState, roomCtx);  // load map for new room (unloading the previous room)
+            if (roomNum != roomCtx->curRoom.num) {
+                func_8009728C(gPlayState, roomCtx, roomNum); //load original room
+                //func_800973FC(gPlayState, &gPlayState->roomCtx); // commit to room load?
+                func_80097534(gPlayState, roomCtx);  // load map for new room (unloading the previous room)
+            }
             warped = false;
             CVarSetInteger("gSwitchAge", 0);
         }


### PR DESCRIPTION
Forgot to add a check to make sure the room load only occurs when not in the start room; otherwise actors were being loaded in twice.

Only other potential issue I have found is that using the cheat during the start of door transition will cause the room link was going into to be the one loaded, while link remains on the unloaded room side of the door. Not sure if this is really a big deal. 

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/637478742.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/637478743.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/637478744.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/637478745.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/637478746.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/637478747.zip)
<!--- section:artifacts:end -->