### PR TITLE
fix: lowercase package names for vcpkg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ set(VCPKG_TRIPLET x64-windows-static)
 set(VCPKG_TARGET_TRIPLET x64-windows-static)
 
 vcpkg_bootstrap()
-vcpkg_install_packages(zlib bzip2 libpng SDL2 SDL2-net GLEW glfw3)
+vcpkg_install_packages(zlib bzip2 libpng sdl2 sdl2-net glew glfw3)
 endif()
 
 ################################################################################

--- a/README.md
+++ b/README.md
@@ -196,4 +196,3 @@ Take [this survey](https://retroarchopenhardware.com/survey.php) to increase cha
     MicTheMicrophone | Gwonam / The King
     Amphibibro | Link
     AceHeart | Zelda
-

--- a/README.md
+++ b/README.md
@@ -196,3 +196,4 @@ Take [this survey](https://retroarchopenhardware.com/survey.php) to increase cha
     MicTheMicrophone | Gwonam / The King
     Amphibibro | Link
     AceHeart | Zelda
+


### PR DESCRIPTION
vcpkg was throwing an error `error: invalid character in package name (must be lowercase, digits, '-')`
this updates our calls to `vcpkg_install_packages` to use lowercase package names instead of uppercase

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/641329089.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/641329091.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/641329092.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/641329094.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/641329095.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/641329096.zip)
<!--- section:artifacts:end -->