### PR TITLE
Fix: Use correct fps value for frame interpolation with match refresh rate

### DIFF
--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -1854,7 +1854,7 @@ extern "C" void Overlay_DisplayText(float duration, const char* text) {
 }
 
 extern "C" void Overlay_DisplayText_Seconds(int seconds, const char* text) {
-    float duration = seconds * CVarGetInteger("gInterpolationFPS", 20) * 0.05;
+    float duration = seconds * OTRGlobals::Instance->GetInterpolationFPS() * 0.05;
     SohImGui::GetGameOverlay()->TextDrawNotification(duration, true, text);
 }
 

--- a/soh/soh/frame_interpolation.cpp
+++ b/soh/soh/frame_interpolation.cpp
@@ -6,6 +6,7 @@
 #include <math.h>
 
 #include "frame_interpolation.h"
+#include "soh/OTRGlobals.h"
 
 /*
 Frame interpolation.
@@ -451,7 +452,7 @@ void FrameInterpolation_StartRecord(void) {
     current_recording = {};
     current_path.clear();
     current_path.push_back(&current_recording.root_path);
-    if (CVarGetInteger("gInterpolationFPS", 20) != 20) {
+    if (OTRGlobals::Instance->GetInterpolationFPS() != 20) {
         is_recording = true;
     }
 }


### PR DESCRIPTION
The incorrect FPS value was being used for frame interpolation recording when the slider is set to any position other than your max fresh rate. The match refresh rate toggle is supposed to override the slider value.

This PR replaces all usage of the `gInterpolationFPS` cvar to instead use the `GetInerpolationFPS()` method.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/641521567.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/641521568.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/641521569.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/641521570.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/641521571.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/641521572.zip)
<!--- section:artifacts:end -->