### PR TITLE
[Rando Enhancement] Get GBK as soon as requirement is met

### DIFF
--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -1280,6 +1280,8 @@ namespace GameMenuBar {
                     "Play unique fanfares when obtaining quest items "
                     "(medallions/stones/songs). Note that these fanfares are longer than usual."
                 );
+                UIWidgets::PaddedEnhancementCheckbox("Get GBK When Requirement is Met", "gGetGBKImmediately", true, false);
+                UIWidgets::Tooltip("Get Ganon's Boss Key as soon as you meet the set requirement instead of going to the Temple of Time for it.");
                 ImGui::EndMenu();
             }
 

--- a/soh/src/code/z_play.c
+++ b/soh/src/code/z_play.c
@@ -376,7 +376,14 @@ void GivePlayerRandoRewardZeldaLightArrowsGift(PlayState* play, RandomizerCheck 
             break;
     }
 
-    if (meetsRequirements && LINK_IS_ADULT &&
+    if (meetsRequirements && CVarGetInteger("gGetGBKImmediately", 0) && !Flags_GetTreasure(play, 0x1E)) {
+        GetItemEntry getItem = Randomizer_GetItemFromKnownCheck(check, GI_ARROW_LIGHT);
+        if (GiveItemEntryWithoutActor(play, getItem)) {
+            player->pendingFlag.flagID = 0x1E;
+            player->pendingFlag.flagType = FLAG_SCENE_TREASURE;
+        }
+            
+    } else if (meetsRequirements && LINK_IS_ADULT &&
         (gEntranceTable[((void)0, gSaveContext.entranceIndex)].scene == SCENE_TOKINOMA) &&
         !Flags_GetTreasure(play, 0x1E) && player != NULL && !Player_InBlockingCsMode(play, player) &&
         play->sceneLoadFlag == 0) {


### PR DESCRIPTION
WIP to add an option for GBK to be given to you as soon as you meet the requirements, instead of having to go to the Temple of Time for the LACS.

- [ ] Add Check Box for selecting which behavior you want
- [ ] Implement new option while keeping the LACS option
- [ ] Make sure logic is correct for each option
- [ ] Testing
<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/642686239.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/642686240.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/642686241.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/642686242.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/642686243.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/642686244.zip)
<!--- section:artifacts:end -->