### PR TITLE
chore: move asset header generation to new ExtractAssetsHeaders target

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -45,6 +45,9 @@ cd Shipwright
 
 # If you need to clean the project you can run
 & 'C:\Program Files\CMake\bin\cmake.exe' --build .\build\x64 --target clean
+
+# If you need to regenerate the asset headers to check them into source
+& 'C:\Program Files\CMake\bin\cmake.exe' --build .\build\x64 --target ExtractAssetsHeaders
 ```
 
 ### Developing SoH
@@ -104,6 +107,9 @@ cmake --build build-cmake # --config Release (if you're packaging)
 
 # If you need to clean the project you can run
 cmake --build build-cmake --target clean
+
+# If you need to regenerate the asset headers to check them into source
+cmake --build build-cmake --target ExtractAssetsHeaders
 ```
 
 ### Generating a distributable
@@ -148,6 +154,9 @@ cp build-cmake/soh/oot.otr ~/Library/Application\ Support/com.shipofharkinian.so
 
 # If you need to clean the project you can run
 cmake --build build-cmake --target clean
+
+# If you need to regenerate the asset headers to check them into source
+cmake --build build-cmake --target ExtractAssetsHeaders
 ```
 
 ### Generating a distributable

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -47,7 +47,7 @@ cd Shipwright
 & 'C:\Program Files\CMake\bin\cmake.exe' --build .\build\x64 --target clean
 
 # If you need to regenerate the asset headers to check them into source
-& 'C:\Program Files\CMake\bin\cmake.exe' --build .\build\x64 --target ExtractAssetsHeaders
+& 'C:\Program Files\CMake\bin\cmake.exe' --build .\build\x64 --target ExtractAssetHeaders
 ```
 
 ### Developing SoH
@@ -109,7 +109,7 @@ cmake --build build-cmake # --config Release (if you're packaging)
 cmake --build build-cmake --target clean
 
 # If you need to regenerate the asset headers to check them into source
-cmake --build build-cmake --target ExtractAssetsHeaders
+cmake --build build-cmake --target ExtractAssetHeaders
 ```
 
 ### Generating a distributable
@@ -156,7 +156,7 @@ cp build-cmake/soh/oot.otr ~/Library/Application\ Support/com.shipofharkinian.so
 cmake --build build-cmake --target clean
 
 # If you need to regenerate the asset headers to check them into source
-cmake --build build-cmake --target ExtractAssetsHeaders
+cmake --build build-cmake --target ExtractAssetHeaders
 ```
 
 ### Generating a distributable

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,17 +105,21 @@ endif()
 
 find_package(Python3 COMPONENTS Interpreter)
 
-add_custom_target(
-    ExtractAssets
-    # CMake versions prior to 3.17 do not have the rm command, use remove instead for older versions
-    COMMAND ${CMAKE_COMMAND} -E $<IF:$<VERSION_LESS:${CMAKE_VERSION},3.17>,remove,rm> -f oot.otr oot-mq.otr soh.otr
-    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/OTRExporter/extract_assets.py -z "$<TARGET_FILE:ZAPD>" --non-interactive
-    COMMAND ${CMAKE_COMMAND} -DSOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR} -DBINARY_DIR=${CMAKE_BINARY_DIR} -P ${CMAKE_CURRENT_SOURCE_DIR}/copy-existing-otrs.cmake
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/OTRExporter
-    COMMENT "Running asset extraction..."
-    DEPENDS ZAPD
-    BYPRODUCTS oot.otr ${CMAKE_SOURCE_DIR}/oot.otr oot-mq.otr ${CMAKE_SOURCE_DIR}/oot-mq.otr ${CMAKE_SOURCE_DIR}/soh.otr
-)
+# Generate two extraction targets
+foreach(ExtractTarget "ExtractAssets" "ExtractAssetsHeaders")
+    add_custom_target(
+        ${ExtractTarget}
+        # CMake versions prior to 3.17 do not have the rm command, use remove instead for older versions
+        COMMAND ${CMAKE_COMMAND} -E $<IF:$<VERSION_LESS:${CMAKE_VERSION},3.17>,remove,rm> -f oot.otr oot-mq.otr soh.otr
+        # Only generate headers for the ExtractAssetsHeaders target
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/OTRExporter/extract_assets.py -z "$<TARGET_FILE:ZAPD>" --non-interactive $<$<STREQUAL:"${ExtractTarget}","ExtractAssetsHeaders">:--gen-headers>
+        COMMAND ${CMAKE_COMMAND} -DSOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR} -DBINARY_DIR=${CMAKE_BINARY_DIR} -P ${CMAKE_CURRENT_SOURCE_DIR}/copy-existing-otrs.cmake
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/OTRExporter
+        COMMENT "Running asset extraction..."
+        DEPENDS ZAPD
+        BYPRODUCTS oot.otr ${CMAKE_SOURCE_DIR}/oot.otr oot-mq.otr ${CMAKE_SOURCE_DIR}/oot-mq.otr ${CMAKE_SOURCE_DIR}/soh.otr
+    )
+endforeach()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Linux")
     find_package(ImageMagick COMPONENTS convert)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,21 +105,27 @@ endif()
 
 find_package(Python3 COMPONENTS Interpreter)
 
-# Generate two extraction targets
-foreach(ExtractTarget "ExtractAssets" "ExtractAssetsHeaders")
-    add_custom_target(
-        ${ExtractTarget}
-        # CMake versions prior to 3.17 do not have the rm command, use remove instead for older versions
-        COMMAND ${CMAKE_COMMAND} -E $<IF:$<VERSION_LESS:${CMAKE_VERSION},3.17>,remove,rm> -f oot.otr oot-mq.otr soh.otr
-        # Only generate headers for the ExtractAssetsHeaders target
-        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/OTRExporter/extract_assets.py -z "$<TARGET_FILE:ZAPD>" --non-interactive $<$<STREQUAL:"${ExtractTarget}","ExtractAssetsHeaders">:--gen-headers>
-        COMMAND ${CMAKE_COMMAND} -DSOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR} -DBINARY_DIR=${CMAKE_BINARY_DIR} -P ${CMAKE_CURRENT_SOURCE_DIR}/copy-existing-otrs.cmake
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/OTRExporter
-        COMMENT "Running asset extraction..."
-        DEPENDS ZAPD
-        BYPRODUCTS oot.otr ${CMAKE_SOURCE_DIR}/oot.otr oot-mq.otr ${CMAKE_SOURCE_DIR}/oot-mq.otr ${CMAKE_SOURCE_DIR}/soh.otr
-    )
-endforeach()
+# Target to generate OTRs
+add_custom_target(
+    ExtractAssets
+    # CMake versions prior to 3.17 do not have the rm command, use remove instead for older versions
+    COMMAND ${CMAKE_COMMAND} -E $<IF:$<VERSION_LESS:${CMAKE_VERSION},3.17>,remove,rm> -f oot.otr oot-mq.otr soh.otr
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/OTRExporter/extract_assets.py -z "$<TARGET_FILE:ZAPD>" --non-interactive
+    COMMAND ${CMAKE_COMMAND} -DSOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR} -DBINARY_DIR=${CMAKE_BINARY_DIR} -P ${CMAKE_CURRENT_SOURCE_DIR}/copy-existing-otrs.cmake
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/OTRExporter
+    COMMENT "Running asset extraction..."
+    DEPENDS ZAPD
+    BYPRODUCTS oot.otr ${CMAKE_SOURCE_DIR}/oot.otr oot-mq.otr ${CMAKE_SOURCE_DIR}/oot-mq.otr ${CMAKE_SOURCE_DIR}/soh.otr
+)
+
+# Target to generate headers
+add_custom_target(
+    ExtractAssetHeaders
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/OTRExporter/extract_assets.py -z "$<TARGET_FILE:ZAPD>" --non-interactive --gen-headers
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/OTRExporter
+    COMMENT "Generating asset headers..."
+    DEPENDS ZAPD
+)
 
 if(CMAKE_SYSTEM_NAME MATCHES "Linux")
     find_package(ImageMagick COMPONENTS convert)

--- a/OTRExporter/extract_assets.py
+++ b/OTRExporter/extract_assets.py
@@ -8,15 +8,20 @@ import struct
 import subprocess
 import argparse
 
-def BuildOTR(xmlPath, rom, zapd_exe=None):
+def BuildOTR(xmlPath, rom, zapd_exe=None, genHeaders=None):
     shutil.copytree("assets", "Extract/assets")
 
     if not zapd_exe:
         zapd_exe = "x64\\Release\\ZAPD.exe" if sys.platform == "win32" else "../ZAPDTR/ZAPD.out"
 
+    if genHeaders:
+        genHeaders = "1"
+    else:
+        genHeaders = "0"
+
     exec_cmd = [zapd_exe, "ed", "-i", xmlPath, "-b", rom, "-fl", "CFG/filelists",
-            "-o", "placeholder", "-osf", "placeholder", "-gsf", "1",
-            "-rconf", "CFG/Config.xml", "-se", "OTR", "--otrfile", 
+            "-o", "placeholder", "-osf", "placeholder", "-gsf", genHeaders,
+            "-rconf", "CFG/Config.xml", "-se", "OTR", "--otrfile",
             "oot-mq.otr" if Z64Rom.isMqRom(rom) else "oot.otr"]
 
     print(exec_cmd)
@@ -33,6 +38,7 @@ def main():
     parser.add_argument("rom", help="Path to the rom", type=str, nargs="?")
     parser.add_argument("--non-interactive", help="Runs the script non-interactively for use in build scripts.", dest="non_interactive", action="store_true")
     parser.add_argument("-v", "--verbose", help="Display rom's header checksums and their corresponding xml folder", dest="verbose", action="store_true")
+    parser.add_argument("--gen-headers", help="Generate source headers to be checked in", dest="gen_headers", action="store_true")
 
     args = parser.parse_args()
 
@@ -41,7 +47,7 @@ def main():
         if (os.path.exists("Extract")):
             shutil.rmtree("Extract")
 
-        BuildOTR("../soh/assets/xml/" + rom.version.xml_ver + "/", rom.file_path, zapd_exe=args.zapd_exe)
+        BuildOTR("../soh/assets/xml/" + rom.version.xml_ver + "/", rom.file_path, zapd_exe=args.zapd_exe, genHeaders=args.gen_headers)
 
 if __name__ == "__main__":
     main()

--- a/OTRExporter/extract_assets.py
+++ b/OTRExporter/extract_assets.py
@@ -14,17 +14,16 @@ def BuildOTR(xmlPath, rom, zapd_exe=None, genHeaders=None):
     if not zapd_exe:
         zapd_exe = "x64\\Release\\ZAPD.exe" if sys.platform == "win32" else "../ZAPDTR/ZAPD.out"
 
+    exec_cmd = [zapd_exe, "ed", "-i", xmlPath, "-b", rom, "-fl", "CFG/filelists",
+                "-o", "placeholder", "-osf", "placeholder", "-rconf", "CFG/Config.xml"]
+
     # generate headers, but not otrs by excluding the otr exporter
     if genHeaders:
-        exec_cmd = [zapd_exe, "ed", "-i", xmlPath, "-b", rom, "-fl", "CFG/filelists",
-                "-o", "placeholder", "-osf", "placeholder", "-gsf", "1",
-                "-rconf", "CFG/Config.xml"]
+        exec_cmd.extend(["-gsf", "1"])
     else:
         # generate otrs, but not headers
-        exec_cmd = [zapd_exe, "ed", "-i", xmlPath, "-b", rom, "-fl", "CFG/filelists",
-                "-o", "placeholder", "-osf", "placeholder", "-gsf", "0",
-                "-rconf", "CFG/Config.xml", "-se", "OTR", "--otrfile",
-                "oot-mq.otr" if Z64Rom.isMqRom(rom) else "oot.otr"]
+        exec_cmd.extend(["-gsf", "0", "-se", "OTR", "--otrfile",
+                "oot-mq.otr" if Z64Rom.isMqRom(rom) else "oot.otr"])
 
     print(exec_cmd)
     exitValue = subprocess.call(exec_cmd)

--- a/OTRExporter/extract_assets.py
+++ b/OTRExporter/extract_assets.py
@@ -14,15 +14,17 @@ def BuildOTR(xmlPath, rom, zapd_exe=None, genHeaders=None):
     if not zapd_exe:
         zapd_exe = "x64\\Release\\ZAPD.exe" if sys.platform == "win32" else "../ZAPDTR/ZAPD.out"
 
+    # generate headers, but not otrs by excluding the otr exporter
     if genHeaders:
-        genHeaders = "1"
+        exec_cmd = [zapd_exe, "ed", "-i", xmlPath, "-b", rom, "-fl", "CFG/filelists",
+                "-o", "placeholder", "-osf", "placeholder", "-gsf", "1",
+                "-rconf", "CFG/Config.xml"]
     else:
-        genHeaders = "0"
-
-    exec_cmd = [zapd_exe, "ed", "-i", xmlPath, "-b", rom, "-fl", "CFG/filelists",
-            "-o", "placeholder", "-osf", "placeholder", "-gsf", genHeaders,
-            "-rconf", "CFG/Config.xml", "-se", "OTR", "--otrfile",
-            "oot-mq.otr" if Z64Rom.isMqRom(rom) else "oot.otr"]
+        # generate otrs, but not headers
+        exec_cmd = [zapd_exe, "ed", "-i", xmlPath, "-b", rom, "-fl", "CFG/filelists",
+                "-o", "placeholder", "-osf", "placeholder", "-gsf", "0",
+                "-rconf", "CFG/Config.xml", "-se", "OTR", "--otrfile",
+                "oot-mq.otr" if Z64Rom.isMqRom(rom) else "oot.otr"]
 
     print(exec_cmd)
     exitValue = subprocess.call(exec_cmd)


### PR DESCRIPTION
This PR updates the extract-assets.py script to accept a parameter to tell ZAPD if it should generate source headers or not.
The original `ExtractAssets` cmake target will not pass in this flag, making it so the normal behavior is only otrs are generated.

The python script will only generate OTRs when headers are turned off, and will only generate headers (no otrs) when headers are turned on.

A new `ExtractAssetHeaders` cmake target is added that will pass in the flag to generate source headers if we need to check into source updated/new headers. It will not produce OTRs, so the extra commands for deleting/copying OTRs are not needed.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/646802671.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/646802672.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/646802674.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/646802675.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/646802676.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/646802677.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/646802679.zip)
<!--- section:artifacts:end -->