### PR TITLE
Fix: Lake Hylia sun granting multiple fire arrows in vanilla

### DIFF
--- a/soh/src/overlays/actors/ovl_Shot_Sun/z_shot_sun.c
+++ b/soh/src/overlays/actors/ovl_Shot_Sun/z_shot_sun.c
@@ -163,7 +163,7 @@ void ShotSun_UpdateHyliaSun(ShotSun* this, PlayState* play) {
         func_80078884(NA_SE_SY_CORRECT_CHIME);
         osSyncPrintf(VT_FGCOL(CYAN) "SHOT_SUN HIT!!!!!!!\n" VT_RST);
         if ((INV_CONTENT(ITEM_ARROW_FIRE) == ITEM_NONE && !gSaveContext.n64ddFlag) ||
-            !Flags_GetTreasure(play, 0x1F)) {
+            (!Flags_GetTreasure(play, 0x1F) && gSaveContext.n64ddFlag)) {
             Actor_Spawn(&play->actorCtx, play, ACTOR_ITEM_ETCETERA, 700.0f, -800.0f, 7261.0f, 0, 0, 0, 7, true);
             play->csCtx.segment = SEGMENTED_TO_VIRTUAL(gLakeHyliaFireArrowsCS);
             gSaveContext.cutsceneTrigger = 1;


### PR DESCRIPTION
The check against the scene treasure flag in rando was not exclusive to rando saves, cause the sun in vanilla to grant multiple fire arrows even though fire arrows were already in inventory.

This adds an rando save check to the other half of the expression.

Fixes #2703

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/647956199.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/647956200.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/647956201.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/647956202.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/647956204.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/647956205.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/647956206.zip)
<!--- section:artifacts:end -->