### PR TITLE
[ZAPD] fix text extraction overflowing messages

### DIFF
--- a/ZAPDTR/ZAPD/ZText.cpp
+++ b/ZAPDTR/ZAPD/ZText.cpp
@@ -63,18 +63,26 @@ void ZText::ParseRawData()
 		unsigned int extra = 0;
 		bool stop = false;
 
+		// Continue parsing until we are told to stop and all extra bytes are read
 		while ((c != '\0' && !stop) || extra > 0)
 		{
 			msgEntry.msg += c;
 			msgPtr++;
 
+			// Some control codes require reading extra bytes
 			if (extra == 0)
 			{
-				if (c == 0x05 || c == 0x13 || c == 0x0E || c == 0x0C || c == 0x1E || c == 0x06 ||
+				// End marker, so stop this message and do not read anything else
+				if (c == 0x02)
+				{
+					stop = true;
+				}
+				else if (c == 0x05 || c == 0x13 || c == 0x0E || c == 0x0C || c == 0x1E || c == 0x06 ||
 				    c == 0x14)
 				{
 					extra = 1;
 				}
+				// "Continue to new text ID", so stop this message and read two more bytes for the text ID
 				else if (c == 0x07)
 				{
 					extra = 2;


### PR DESCRIPTION
In investigating #2064 I discovered that the offending text ID had a message length larger than the supported buffer size, meaning the memcpy into the buffer would overflow and cause the crash. Inspecting the message itself revealed that the next message ID's text was also appended to the original text. This just happened to only crash on German and French due to the buffer size over flow (these languages how longer text on average).

Digging some more I found that many message IDs do a similar text overflow of the next message, but non of them exceed the max buffer size, so there was no crashing and in game, proper control codes would be reached making is to the overflowed text was ignored.

My check indicates that there are 442 duplicated/overflowed English messages (493 for French, 474 for German).

The overflowed/duplicated text was coming straight from the OTR resources. I dug some more into the ZAPD text extraction process. Here we were already doing things like checking for control codes that consume extra bytes and adding stop conditions. There is a stop condition when the control code for "continue to the next message ID" was in place. The one that stood out as missing to me was a stop condition when the control code for "end marker" (`0x02`) is reached.

This PR adds this extra stop condition in and has resolved the duplicated/overflowed message issues.

I don't have an easy way of showing before and after, but the text IDs in the mask shop was a short and clear example. On the left is the old (bad) OTR resource for the static text, and on the right is the new (good) OTR resource:
![image](https://user-images.githubusercontent.com/13861068/232329195-aefdf5ec-dc5d-4bba-8935-b0e47227f669.png)
Notice that the Bunny Hood message on the left contains a duplicated copy of the Skull Mask text underneath it. And similarly the second Keaton Mask text contains a copy of the second bunny hood text.

Additionally, the size of the English text before and after this change has gone from 295kb to 238kb, so a considerable amount of duplicated text was happening.

Confirmed this fixes #2064

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/652099098.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/652099099.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/652099100.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/652099101.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/652099102.zip)
<!--- section:artifacts:end -->