### PR TITLE
Fix: TTS crash on pause menu with any cursor position

### DIFF
--- a/OTRExporter/assets/accessibility/texts/kaleidoscope_eng.json
+++ b/OTRExporter/assets/accessibility/texts/kaleidoscope_eng.json
@@ -158,6 +158,7 @@
     "153": "STICK UPGRADE 30",
     "154": "NUT UPGRADE 30",
     "155": "NUT UPGRADE 40",
+    "255": "",
     "256": "Haunted Wasteland",
     "257": "Gerudos Fortress",
     "258": "Gerudo Valley",

--- a/OTRExporter/assets/accessibility/texts/kaleidoscope_fra.json
+++ b/OTRExporter/assets/accessibility/texts/kaleidoscope_fra.json
@@ -158,6 +158,7 @@
     "153": "AMÉLIORATION BÂTON MOJO 30",
     "154": "AMÉLIORATION NOIX MOJO 30",
     "155": "AMÉLIORATION NOIX MOJO 40",
+    "255": "",
     "256": "Désert Hanté",
     "257": "Forteresse Gerudo",
     "258": "Vallée Gerudo",

--- a/OTRExporter/assets/accessibility/texts/kaleidoscope_ger.json
+++ b/OTRExporter/assets/accessibility/texts/kaleidoscope_ger.json
@@ -158,6 +158,7 @@
     "153": "STAB UPGRADE 30",
     "154": "NUß UPGRADE 30",
     "155": "NUß UPGRADE 40",
+    "255": "",
     "256": "Gespensterwüste",
     "257": "Gerudo-Festung",
     "258": "Gerudotal",


### PR DESCRIPTION
TTS would crash with a failed lookup on the pause menu item screen when using the cursor on empty slots enhancement.
Adding an empty string condition for the key value reported for the empty slots addresses the crash.

Fixes #2688

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/650062617.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/650062619.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/650062620.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/650062622.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/650062623.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/650062624.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/650062625.zip)
<!--- section:artifacts:end -->