### PR TITLE
Fix: SoT Time Travel B-Button Behaviour

### DIFF
--- a/soh/soh/Enhancements/mods.cpp
+++ b/soh/soh/Enhancements/mods.cpp
@@ -194,26 +194,6 @@ void RegisterSwitchAge() {
 
 /// Switches Link's age and respawns him at the last entrance he entered.
 void RegisterOcarinaTimeTravel() {
-    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnGameFrameUpdate>([]() {
-        if (!gPlayState) return;
-
-        // For the gTimeTravel: Don't give child Link a Kokiri Sword if we don't have one
-        if (LINK_AGE_IN_YEARS == 5 && CVarGetInteger("gTimeTravel", 0)) {
-            uint32_t kokiriSwordBitMask = 1 << 0;
-            if (!(gSaveContext.inventory.equipment & kokiriSwordBitMask)) {
-                Player* player = GET_PLAYER(gPlayState);
-                player->currentSwordItemId = ITEM_NONE;
-                gSaveContext.equips.buttonItems[0] = ITEM_NONE;
-                Inventory_ChangeEquipment(EQUIP_SWORD, PLAYER_SWORD_NONE);
-            }
-        }
-
-        // Switches Link's age and respawns him at the last entrance he entered.
-        if (CVarGetInteger("gTimeTravel", 0) && CVarGetInteger("gSwitchTimeline", 0)) {
-            CVarSetInteger("gSwitchTimeline", 0);
-            ReloadSceneTogglingLinkAge();
-        }
-    });
 
     GameInteractor::Instance->RegisterGameHook<GameInteractor::OnOcarinaSongAction>([]() {
         if (!gPlayState) {
@@ -233,13 +213,9 @@ void RegisterOcarinaTimeTravel() {
         if (CVarGetInteger("gTimeTravel", 0) && hasOcarinaOfTime && hasMasterSword &&
             gPlayState->msgCtx.lastPlayedSong == OCARINA_SONG_TIME && !nearbyTimeBlockEmpty && !nearbyTimeBlock &&
             !nearbyOcarinaSpot && !nearbyFrogs) {
-            if (gSaveContext.n64ddFlag) {
-                CVarSetInteger("gSwitchTimeline", 1);
-            } else if (!gSaveContext.n64ddFlag && !nearbyDoorOfTime) {
-                // This check is made for when Link is learning the Song Of Time in a vanilla save file that load a
-                // Temple of Time scene where the only object present is the Door of Time
-                CVarSetInteger("gSwitchTimeline", 1);
-            }
+
+            CVarSetInteger("gSwitchTimeline", 1);
+            ReloadSceneTogglingLinkAge();
         }
     });
 }

--- a/soh/soh/Enhancements/mods.cpp
+++ b/soh/soh/Enhancements/mods.cpp
@@ -214,7 +214,13 @@ void RegisterOcarinaTimeTravel() {
             gPlayState->msgCtx.lastPlayedSong == OCARINA_SONG_TIME && !nearbyTimeBlockEmpty && !nearbyTimeBlock &&
             !nearbyOcarinaSpot && !nearbyFrogs) {
 
-            CVarSetInteger("gSwitchTimeline", 1);
+            if (gSaveContext.n64ddFlag) {
+                CVarSetInteger("gSwitchTimeline", 1);
+            } else if (!gSaveContext.n64ddFlag && !nearbyDoorOfTime) {
+                // This check is made for when Link is learning the Song Of Time in a vanilla save file that load a
+                // Temple of Time scene where the only object present is the Door of Time
+                CVarSetInteger("gSwitchTimeline", 1);
+            }
             ReloadSceneTogglingLinkAge();
         }
     });

--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -1417,7 +1417,7 @@ void Inventory_SwapAgeEquipment(void) {
             if (i != 0) {
                 gSaveContext.childEquips.buttonItems[i] = gSaveContext.equips.buttonItems[i];
             } else {
-                if (CVarGetInteger("gSwitchAge", 0) && 
+                if ((CVarGetInteger("gSwitchAge", 0) || CVarGetInteger("gSwitchTimeline", 0)) && 
                     (gSaveContext.infTable[29] & 1)) {
                     gSaveContext.childEquips.buttonItems[i] = ITEM_NONE;
                 } else {
@@ -1501,7 +1501,8 @@ void Inventory_SwapAgeEquipment(void) {
         gSaveContext.adultEquips.equipment = gSaveContext.equips.equipment;
 
         if (gSaveContext.childEquips.buttonItems[0] != ITEM_NONE ||
-            CVarGetInteger("gSwitchAge", 0)) {
+            CVarGetInteger("gSwitchAge", 0) ||
+            CVarGetInteger("gSwitchTimeline", 0)) {
             for (i = 0; i < ARRAY_COUNT(gSaveContext.equips.buttonItems); i++) {
                 gSaveContext.equips.buttonItems[i] = gSaveContext.childEquips.buttonItems[i];
 
@@ -1542,7 +1543,7 @@ void Inventory_SwapAgeEquipment(void) {
             gSaveContext.equips.equipment = 0x1111;
         }
 
-        if (CVarGetInteger("gSwitchAge", 0) &&
+        if ((CVarGetInteger("gSwitchAge", 0) || CVarGetInteger("gSwitchTimeline", 0)) &&
             (gSaveContext.equips.buttonItems[0] == ITEM_NONE)) {
             gSaveContext.infTable[29] |= 1;
             if (gSaveContext.childEquips.equipment == 0) {
@@ -1552,7 +1553,7 @@ void Inventory_SwapAgeEquipment(void) {
             }
         }
     }
-
+    CVarSetInteger("gSwitchTimeline", 0);
     temp = gEquipMasks[EQUIP_SHIELD] & gSaveContext.equips.equipment;
     if (temp != 0) {
         temp >>= gEquipShifts[EQUIP_SHIELD];


### PR DESCRIPTION
This PR changes the time travel with SoT feature to now use the same conditions as the switch age cheat.

I could not figure out a way to set the "gSwitchTimeline" CVar back to 0 without it being done within the z_parameter.c file or by using a frameupdate hook to check each frame to reset it back to 0. This opts for the former but I'd appreciate any fix to this as it's not preferable. 

This fixes fishing behaviour to allow child link to use the fishing rod while the cheat is turned on, as well as restoring vanilla ToT behaviour.

For clarification, vanilla ToT behaviour is:

child to adult -> adult w master sword equipped and in inventory
adult to child (with child equipment initialised) -> child w kokiri sword equipped, not in inventory

The behaviour the time travel SoT feature had changed this to was:

child to adult -> adult w master sword equipped and in inventory
adult to child (with child equipment initialised and no sword on b flag) -> child with no sword equipped
adult to child (with child equipment initialised and without no sword on b flag) -> child with sticks on b



<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/651208767.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/651208768.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/651208770.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/651208771.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/651208772.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/651208773.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/651208774.zip)
<!--- section:artifacts:end -->