### PR TITLE
Tweak: Shopsanity Heart Pieces and Containers now refill Link's health

### DIFF
--- a/soh/src/overlays/actors/ovl_En_GirlA/z_en_girla.c
+++ b/soh/src/overlays/actors/ovl_En_GirlA/z_en_girla.c
@@ -1071,6 +1071,14 @@ void EnGirlA_BuyEvent_Randomizer(PlayState* play, EnGirlA* this) {
     gSaveContext.pendingSaleMod = getItemEntry.modIndex;
     Flags_SetRandomizerInf(shopItemIdentity.randomizerInf);
     Rupees_ChangeBy(-this->basePrice);
+
+    // Heart Pieces and Heart Containers refill Links health when the text box is closed on their text IDs.
+    // In Shopsanity the textbox does not close, as the shop keeper continues the text bos asking to buy more.
+    // So here we detect when a Heart Piece/Container is granted to refil Links health manually
+    if (getItemEntry.itemId == ITEM_HEART_PIECE || getItemEntry.itemId == ITEM_HEART_PIECE_2 ||
+        getItemEntry.itemId == ITEM_HEART_CONTAINER) {
+        gSaveContext.healthAccumulator = 0x140; // Refill 20 hearts
+    }
 }
 
 void EnGirlA_Noop(EnGirlA* this, PlayState* play) {


### PR DESCRIPTION
Heart Pieces and Heart Containers normally refill Links health when the text box with their respective textID is closed.
However, with shops and shopsanity, after receiving the heart piece, the textbox isn't actually closed. The shop keeper keeps it open to prompt the player if they want to continue shopping. This prevents the health refill logic from running.

This PR adds a check for these items in the BuyEvent for randomizer items and manually refills Links health.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/656284015.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/656284017.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/656284018.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/656284019.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/656284021.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/656284022.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/656284023.zip)
<!--- section:artifacts:end -->