### PR TITLE
ImGui Cleanup - Move Experimental entries, clean up presets

### DIFF
--- a/soh/soh/Enhancements/presets.h
+++ b/soh/soh/Enhancements/presets.h
@@ -194,7 +194,7 @@ const std::vector<const char*> enhancementsCvars = {
     "gRupeeDash",
     "gDashInterval",
     "gDogFollowsEverywhere",
-    "gDisableWarningText",
+    "gDisableTunicWarningText",
     "gDisableLOD",
     "gDisableDrawDistance",
     "gDisableKokiriDrawDistance",

--- a/soh/soh/Enhancements/presets.h
+++ b/soh/soh/Enhancements/presets.h
@@ -182,6 +182,25 @@ const std::vector<const char*> enhancementsCvars = {
     "gNoInputForCredits",
     "gFastFarores",
     "gNightGSAlwaysSpawn",
+    "gSkipText",
+    "gLinkDefaultName",
+    "gMarketSneak",
+    "gTimeTravel",
+    "gNutsExplodeBombs",
+    "gBowSlingShotAmmoFix",
+    "gBetterFW",
+    "gDisableFirstPersonChus",
+    "gHyperBosses",
+    "gRupeeDash",
+    "gDashInterval",
+    "gDogFollowsEverywhere",
+    "gDisableWarningText",
+    "gDisableLOD",
+    "gDisableDrawDistance",
+    "gDisableKokiriDrawDistance",
+    "gLowResMode",
+    "gDrawLineupTick",
+    "gQuickBongoKill",
 };
 
 const std::vector<const char*> randomizerCvars = {
@@ -320,6 +339,8 @@ const std::vector<PresetEntry> vanillaPlusPresetEntries = {
 
     // Text Speed (1 to 5)
     PRESET_ENTRY_S32("gTextSpeed", 5),
+    // Skip Text
+    PRESET_ENTRY_S32("gSkipText", 1),
     // King Zora Speed (1 to 5)
     PRESET_ENTRY_S32("gMweepSpeed", 2),
     // Faster Block Push (+0 to +5)
@@ -387,6 +408,8 @@ const std::vector<PresetEntry> enhancedPresetEntries = {
 
     // Text Speed (1 to 5)
     PRESET_ENTRY_S32("gTextSpeed", 5),
+    // Skip Text
+    PRESET_ENTRY_S32("gSkipText", 1),
     // King Zora Speed (1 to 5)
     PRESET_ENTRY_S32("gMweepSpeed", 5),
     // Faster Block Push (+0 to +5)
@@ -458,6 +481,8 @@ const std::vector<PresetEntry> enhancedPresetEntries = {
     PRESET_ENTRY_S32("gInstantPutaway", 1),
     // Instant Boomerang Recall
     PRESET_ENTRY_S32("gFastBoomerang", 1),
+    // Nuts Explode Bombs
+    PRESET_ENTRY_S32("gNutsExplodeBombs", 1),
     // Ask to Equip New Items
     PRESET_ENTRY_S32("gAskToEquip", 1),
     // Mask Select in Inventory
@@ -506,6 +531,8 @@ const std::vector<PresetEntry> randomizerPresetEntries = {
 
     // Text Speed (1 to 5)
     PRESET_ENTRY_S32("gTextSpeed", 5),
+    // Skip Text
+    PRESET_ENTRY_S32("gSkipText", 1),
     // King Zora Speed (1 to 5)
     PRESET_ENTRY_S32("gMweepSpeed", 5),
     // Faster Block Push (+0 to +5)
@@ -574,6 +601,8 @@ const std::vector<PresetEntry> randomizerPresetEntries = {
     PRESET_ENTRY_S32("gInstantPutaway", 1),
     // Instant Boomerang Recall
     PRESET_ENTRY_S32("gFastBoomerang", 1),
+    // Nuts Explode Bombs
+    PRESET_ENTRY_S32("gNutsExplodeBombs", 1),
     // Ask to Equip New Items
     PRESET_ENTRY_S32("gAskToEquip", 1),
     // Mask Select in Inventory

--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -35,13 +35,6 @@
 
 #include "Enhancements/game-interactor/GameInteractor.h"
 
-#define EXPERIMENTAL() \
-    ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(255, 50, 50, 255)); \
-    UIWidgets::Spacer(3.0f); \
-    ImGui::Text("Experimental"); \
-    ImGui::PopStyleColor(); \
-    UIWidgets::PaddedSeparator(false, true);
-
 bool isBetaQuestEnabled = false;
 
 extern "C" {
@@ -284,7 +277,7 @@ namespace GameMenuBar {
                 } // END FPS Slider
 
                 if (SohImGui::WindowBackend() == SohImGui::Backend::DX11) {
-                    ImGui::Dummy(ImVec2(0, 0));
+                    UIWidgets::Spacer(0);
                     if (ImGui::Button("Match Refresh Rate")) {
                         int hz = Ship::Window::GetInstance()->GetCurrentRefreshRate();
                         if (hz >= 20 && hz <= 360) {
@@ -730,7 +723,7 @@ namespace GameMenuBar {
                     UIWidgets::Tooltip("Hides most of the UI when not needed\nNote: Doesn't activate until after loading a new scene");
                     UIWidgets::PaddedEnhancementCheckbox("Disable Navi Call Audio", "gDisableNaviCallAudio", true, false);
                     UIWidgets::Tooltip("Disables the voice audio when Navi calls you");
-                    UIWidgets::PaddedEnhancementCheckbox("Disable Hot/Underwater Warning Text", "gDisableWarningText", true, false);
+                    UIWidgets::PaddedEnhancementCheckbox("Disable Hot/Underwater Warning Text", "gDisableTunicWarningText", true, false);
                     UIWidgets::Tooltip("Disables warning text when you don't have on the Goron/Zora Tunic in Hot/Underwater conditions.");
 
                     ImGui::EndMenu();

--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -211,7 +211,7 @@ namespace GameMenuBar {
                     }
                     int currentFps = fmax(fmin(OTRGlobals::Instance->GetInterpolationFPS(), maxFps), minFps);
                 #ifdef __WIIU__
-                    UIWidgets::Spacer();
+                    UIWidgets::Spacer(0);
                     // only support divisors of 60 on the Wii U
                     if (currentFps > 60) {
                         currentFps = 60;
@@ -240,7 +240,7 @@ namespace GameMenuBar {
                     ImGui::SameLine();
                     ImGui::SetCursorPosX(ImGui::GetCursorPosX() - 7.0f);
 
-                    UIWidgets::Spacer();
+                    UIWidgets::Spacer(0);
 
                     ImGui::SliderInt("##WiiUFPSSlider", &fpsSlider, 1, 3, "", ImGuiSliderFlags_AlwaysClamp);
 

--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -268,12 +268,18 @@ namespace GameMenuBar {
                         (currentFps == 20) ? "FPS: Original (20)" : "FPS: %d",
                         "##FPSInterpolation", "gInterpolationFPS", minFps, maxFps, "", 20, true, true, false, matchingRefreshRate);
                 #endif
-                    UIWidgets::Tooltip(
-                        "Uses Matrix Interpolation to create extra frames, resulting in smoother graphics. This is purely "
-                        "visual and does not impact game logic, execution of glitches etc.\n\n"
-                        "A higher target FPS than your monitor's refresh rate will waste resources, and might give a worse result.\n\n"
-                        "For consistent input lag, set this value and your monitor's refresh rate to a multiple of 20."
-                    );
+                    if (SohImGui::WindowBackend() == SohImGui::Backend::DX11) {
+                        UIWidgets::Tooltip(
+                            "Uses Matrix Interpolation to create extra frames, resulting in smoother graphics. This is purely "
+                            "visual and does not impact game logic, execution of glitches etc.\n\n"
+                            "A higher target FPS than your monitor's refresh rate will waste resources, and might give a worse result."
+                        );
+                    } else {
+                        UIWidgets::Tooltip(
+                            "Uses Matrix Interpolation to create extra frames, resulting in smoother graphics. This is purely "
+                            "visual and does not impact game logic, execution of glitches etc."
+                        );
+                    }
                 } // END FPS Slider
 
                 if (SohImGui::WindowBackend() == SohImGui::Backend::DX11) {

--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -211,6 +211,7 @@ namespace GameMenuBar {
                     }
                     int currentFps = fmax(fmin(OTRGlobals::Instance->GetInterpolationFPS(), maxFps), minFps);
                 #ifdef __WIIU__
+                    UIWidgets::Spacer();
                     // only support divisors of 60 on the Wii U
                     if (currentFps > 60) {
                         currentFps = 60;
@@ -220,9 +221,9 @@ namespace GameMenuBar {
 
                     int fpsSlider = 1;
                     if (currentFps == 20) {
-                        ImGui::Text("Frame interpolation: Off");
+                        ImGui::Text("FPS: Original (20)");
                     } else {
-                        ImGui::Text("Frame interpolation: %d FPS", currentFps);
+                        ImGui::Text("FPS: %d", currentFps);
                         if (currentFps == 30) {
                             fpsSlider = 2;
                         } else { // currentFps == 60
@@ -239,7 +240,9 @@ namespace GameMenuBar {
                     ImGui::SameLine();
                     ImGui::SetCursorPosX(ImGui::GetCursorPosX() - 7.0f);
 
-                    ImGui::PaddedEnhancementSliderInt("##WiiUFPSSlider", &fpsSlider, 1, 3, "", ImGuiSliderFlags_AlwaysClamp, true, true, false);
+                    UIWidgets::Spacer();
+
+                    ImGui::SliderInt("##WiiUFPSSlider", &fpsSlider, 1, 3, "", ImGuiSliderFlags_AlwaysClamp);
 
                     ImGui::SameLine();
                     ImGui::SetCursorPosX(ImGui::GetCursorPosX() - 7.0f);

--- a/soh/soh/UIWidgets.cpp
+++ b/soh/soh/UIWidgets.cpp
@@ -102,9 +102,13 @@ namespace UIWidgets {
     }
 
     void PaddedSeparator(bool padTop, bool padBottom, float extraVerticalTopPadding, float extraVerticalBottomPadding) {
-        if (padTop) Spacer(0);
+        if (padTop) {
+            Spacer(extraVerticalTopPadding);
+        }
         ImGui::Separator();
-        if (padBottom) Spacer(0);
+        if (padBottom) {
+            Spacer(extraVerticalBottomPadding);
+        }
     }
 
     void RenderCross(ImDrawList* draw_list, ImVec2 pos, ImU32 col, float sz) {

--- a/soh/src/code/z_player_lib.c
+++ b/soh/src/code/z_player_lib.c
@@ -660,9 +660,9 @@ s32 func_8008F2F8(PlayState* play) {
         triggerEntry = &sTextTriggers[var];
 
         if ((triggerEntry->flag != 0) && !(gSaveContext.textTriggerFlags & triggerEntry->flag) &&
-            (((var == 0) && (this->currentTunic != PLAYER_TUNIC_GORON && CVarGetInteger("gSuperTunic", 0) == 0 && CVarGetInteger("gDisableWarningText", 0) == 0)) ||
+            (((var == 0) && (this->currentTunic != PLAYER_TUNIC_GORON && CVarGetInteger("gSuperTunic", 0) == 0 && CVarGetInteger("gDisableTunicWarningText", 0) == 0)) ||
              (((var == 1) || (var == 3)) && (this->currentBoots == PLAYER_BOOTS_IRON) &&
-              (this->currentTunic != PLAYER_TUNIC_ZORA && CVarGetInteger("gSuperTunic", 0) == 0 && CVarGetInteger("gDisableWarningText", 0) == 0)))) {
+              (this->currentTunic != PLAYER_TUNIC_ZORA && CVarGetInteger("gSuperTunic", 0) == 0 && CVarGetInteger("gDisableTunicWarningText", 0) == 0)))) {
             Message_StartTextbox(play, triggerEntry->textId, NULL);
             gSaveContext.textTriggerFlags |= triggerEntry->flag;
         }


### PR DESCRIPTION
Moves enhancements that were previously labeled "Experimental" into other submenu's and cleaned up styling and text surrounding them. Frame Interpolation is now called "FPS" and lives in the Settings -> Graphics menu, the others were moved to the Enhancements -> Graphics menu. The tooltip for the now called "FPS" slider was also slighty reworded to clarify what it does.

Noticed a lot of enhancements were not in the presets list, so the default preset didn't reset them, so I cleaned those up as well.

Settings -> Graphics:
![image](https://user-images.githubusercontent.com/4244591/233316138-df685024-7b88-4f21-9db9-c9e90efd7674.png)

Enhancements -> Graphics
![image](https://user-images.githubusercontent.com/4244591/233316072-38945abc-078d-4119-b5f4-af5a6a1ec017.png)



<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/659446002.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/659446003.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/659446004.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/659446005.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/659446006.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/659446007.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/659446008.zip)
<!--- section:artifacts:end -->