### PR TITLE
Fix: Correctly handle Vanilla/MQ dungeon location exclusions

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer_check_objects.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_objects.cpp
@@ -925,8 +925,11 @@ void RandomizerCheckObjects::UpdateImGuiVisibility() {
             (locationIt.rc != RC_UNKNOWN_CHECK) &&
             (!RandomizerCheckObjects::AreaIsDungeon(locationIt.rcArea) ||
                 locationIt.vOrMQ == RCVORMQ_BOTH ||
-                locationIt.vOrMQ == RCVORMQ_MQ && CVarGetInteger("gRandomizeMqDungeons", RO_MQ_DUNGEONS_NONE) != RO_MQ_DUNGEONS_NONE && CVarGetInteger("gRandomizeMqDungeonCount", 0) > 0 || // at least one MQ dungeon
-                locationIt.vOrMQ == RCVORMQ_VANILLA && (CVarGetInteger("gRandomizeMqDungeons", RO_MQ_DUNGEONS_NONE) == RO_MQ_DUNGEONS_NONE || CVarGetInteger("gRandomizeMqDungeonCount", 0) < 12) // at least one vanilla dungeon
+                locationIt.vOrMQ == RCVORMQ_MQ &&
+                    ((CVarGetInteger("gRandomizeMqDungeons", RO_MQ_DUNGEONS_NONE) == RO_MQ_DUNGEONS_SET_NUMBER && (CVarGetInteger("gRandomizeMqDungeonCount", 12) > 0) || // at least one MQ dungeon
+                      CVarGetInteger("gRandomizeMqDungeons", RO_MQ_DUNGEONS_NONE) == RO_MQ_DUNGEONS_RANDOM_NUMBER)) ||
+                locationIt.vOrMQ == RCVORMQ_VANILLA &&
+                    (CVarGetInteger("gRandomizeMqDungeons", RO_MQ_DUNGEONS_NONE) != RO_MQ_DUNGEONS_SET_NUMBER || CVarGetInteger("gRandomizeMqDungeonCount", 12) < 12) // at least one vanilla dungeon
             ) &&
             (locationIt.rcType != RCTYPE_SHOP || CVarGetInteger("gRandomizeShopsanity", RO_SHOPSANITY_OFF) > RO_SHOPSANITY_ZERO_ITEMS) &&
             (locationIt.rcType != RCTYPE_SCRUB || CVarGetInteger("gRandomizeShuffleScrubs", RO_SCRUBS_OFF) != RO_SCRUBS_OFF ||


### PR DESCRIPTION
The logic for showing/hiding Vanilla/MQ dungeon locations in the exclusion tab was not accounting for the case if MQ dungeons is set to "Random".

This rewrites the logic check to account for all 3 cases, and only looks at the count value when set to "Set Number".
Also the CVar get for MQ count needs to default to 12 instead 0, to match the declared default behavior everywhere else.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/657472273.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/657472274.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/657472276.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/657472277.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/657472278.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/657472279.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/657472280.zip)
<!--- section:artifacts:end -->