### PR TITLE
Tweak: Unique GetItemEntry for Progressive Bombchus with particle effects

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -2002,14 +2002,6 @@ GetItemID Randomizer::GetItemIdFromRandomizerGet(RandomizerGet randoGet, GetItem
                 case ITEM_OCARINA_TIME:
                     return GI_OCARINA_OOT;
             }
-        case RG_PROGRESSIVE_BOMBCHUS:
-            if (INV_CONTENT(ITEM_BOMBCHU) == ITEM_NONE) {
-                return GI_BOMBCHUS_20;
-            }
-            if (AMMO(ITEM_BOMBCHU) < 5) {
-                return GI_BOMBCHUS_10;
-            }
-            return GI_BOMBCHUS_5;
         case RG_BOMBCHU_5:
         case RG_BOMBCHU_DROP:
             return GI_BOMBCHUS_5;
@@ -2318,7 +2310,6 @@ bool Randomizer::IsItemVanilla(RandomizerGet randoGet) {
         case RG_PROGRESSIVE_SCALE:
         case RG_PROGRESSIVE_NUT_UPGRADE:
         case RG_PROGRESSIVE_STICK_UPGRADE:
-        case RG_PROGRESSIVE_BOMBCHUS:
         case RG_PROGRESSIVE_OCARINA:
         case RG_PROGRESSIVE_GORONSWORD:
         case RG_EMPTY_BOTTLE:
@@ -5429,6 +5420,7 @@ void InitRandoItemTable() {
         GET_ITEM(RG_ICE_CAVERN_COMPASS,                OBJECT_GI_COMPASS,  GID_COMPASS,          TEXT_RANDOMIZER_CUSTOM_ITEM, 0x80, CHEST_ANIM_LONG,  ITEM_CATEGORY_LESSER,    MOD_RANDOMIZER, RG_ICE_CAVERN_COMPASS),
         GET_ITEM(RG_MAGIC_BEAN_PACK,                   OBJECT_GI_BEAN,     GID_BEAN,             TEXT_RANDOMIZER_CUSTOM_ITEM, 0x80, CHEST_ANIM_LONG,  ITEM_CATEGORY_MAJOR,     MOD_RANDOMIZER, RG_MAGIC_BEAN_PACK),
         GET_ITEM(RG_TYCOON_WALLET,                     OBJECT_GI_PURSE,    GID_WALLET_GIANT,     TEXT_RANDOMIZER_CUSTOM_ITEM, 0x80, CHEST_ANIM_LONG,  ITEM_CATEGORY_LESSER,    MOD_RANDOMIZER, RG_TYCOON_WALLET),
+        GET_ITEM(RG_PROGRESSIVE_BOMBCHUS,              OBJECT_GI_BOMB_2,   GID_BOMBCHU,          0x33,                        0x80, CHEST_ANIM_LONG,  ITEM_CATEGORY_MAJOR,     MOD_RANDOMIZER, RG_PROGRESSIVE_BOMBCHUS),
     };
     ItemTableManager::Instance->AddItemTable(MOD_RANDOMIZER);
     for (int i = 0; i < ARRAY_COUNT(extendedVanillaGetItemTable); i++) {

--- a/soh/src/code/z_en_item00.c
+++ b/soh/src/code/z_en_item00.c
@@ -1307,6 +1307,9 @@ void EnItem00_CustomItemsParticles(Actor* Parent, PlayState* play, GetItemEntry 
                 case RG_DOUBLE_DEFENSE:
                     color_slot = 8;
                     break;
+                case RG_PROGRESSIVE_BOMBCHUS:
+                    color_slot = 9;
+                    break;
                 default:
                     return;
             }
@@ -1315,34 +1318,40 @@ void EnItem00_CustomItemsParticles(Actor* Parent, PlayState* play, GetItemEntry 
             return;
     }
 
-    s16* colors[9][3] = {
-        { 34, 255, 76 },   // Minuet and Magic Upgrades Colors
-        { 177, 35, 35 },   // Bolero Colors
-        { 115, 251, 253 }, // Serenade Color
-        { 177, 122, 35 },  // Requiem Color
-        { 177, 28, 212 },  // Nocturne Color
-        { 255, 255, 92 },  // Prelude Color
-        { 31, 152, 49 },   // Stick Upgrade Color
-        { 222, 182, 20 },  // Nut Upgrade Color
-        { 255, 255, 255 }  // Double Defense Color
+    // Color of the circle for the particles
+    static Color_RGBA8 mainColors[10][3] = {
+        { 34, 255, 76 },   // Minuet, Bean Pack, and Magic Upgrades
+        { 177, 35, 35 },   // Bolero
+        { 115, 251, 253 }, // Serenade
+        { 177, 122, 35 },  // Requiem
+        { 177, 28, 212 },  // Nocturne
+        { 255, 255, 92 },  // Prelude
+        { 31, 152, 49 },   // Stick Upgrade
+        { 222, 182, 20 },  // Nut Upgrade
+        { 255, 255, 255 }, // Double Defense
+        { 19, 120, 182 }   // Progressive Bombchu
     };
 
-    s16* colorsEnv[9][3] = {
-        { 30, 110, 30 },  // Minuet and Magic Upgrades Colors
-        { 90, 10, 10 },   // Bolero and Double Defense Colors
-        { 35, 35, 177 },  // Serenade Color
-        { 70, 20, 10 },   // Requiem Color
-        { 100, 20, 140 }, // Nocturne Color
-        { 100, 100, 10 }, // Prelude Color
-        { 5, 50, 10 },    // Stick Upgrade Color
-        { 150, 100, 5 },  // Nut Upgrade Color
-        { 154, 154, 154 } // White Color placeholder
+    // Color of the faded flares stretching off the particles
+    static Color_RGBA8 flareColors[10][3] = {
+        { 30, 110, 30 },   // Minuet, Bean Pack, and Magic Upgrades
+        { 90, 10, 10 },    // Bolero
+        { 35, 35, 177 },   // Serenade
+        { 70, 20, 10 },    // Requiem
+        { 100, 20, 140 },  // Nocturne
+        { 100, 100, 10 },  // Prelude
+        { 5, 50, 10 },     // Stick Upgrade
+        { 150, 100, 5 },   // Nut Upgrade
+        { 154, 154, 154 }, // Double Defense
+        { 204, 102, 0 }    // Progressive Bombchu
     };
 
     static Vec3f velocity = { 0.0f, 0.0f, 0.0f };
     static Vec3f accel = { 0.0f, 0.0f, 0.0f };
-    Color_RGBA8 primColor = { colors[color_slot][0], colors[color_slot][1], colors[color_slot][2], 0 };
-    Color_RGBA8 envColor = { colors[color_slot][0], colors[color_slot][1], colors[color_slot][2], 0 };
+    Color_RGBA8 primColor;
+    Color_RGBA8 envColor;
+    Color_RGBA8_Copy(&primColor, &mainColors[color_slot]);
+    Color_RGBA8_Copy(&envColor, &flareColors[color_slot]);
     Vec3f pos;
 
     // Make particles more compact for shop items and use a different height offset for them.

--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -1703,7 +1703,7 @@ void Randomizer_GameplayStats_SetTimestamp(uint16_t item) {
         return;
     }
     // Count any bombchu pack as bombchus
-    if ((item >= RG_BOMBCHU_5 && item <= RG_BOMBCHU_DROP) || RG_PROGRESSIVE_BOMBCHUS) {
+    if ((item >= RG_BOMBCHU_5 && item <= RG_BOMBCHU_DROP) || item == RG_PROGRESSIVE_BOMBCHUS) {
         if (gSaveContext.sohStats.itemTimestamp[ITEM_BOMBCHU] = 0) {
             gSaveContext.sohStats.itemTimestamp[ITEM_BOMBCHU] = time;
         }

--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -1703,7 +1703,7 @@ void Randomizer_GameplayStats_SetTimestamp(uint16_t item) {
         return;
     }
     // Count any bombchu pack as bombchus
-    if (item >= RG_BOMBCHU_5 && item <= RG_BOMBCHU_DROP) {
+    if ((item >= RG_BOMBCHU_5 && item <= RG_BOMBCHU_DROP) || RG_PROGRESSIVE_BOMBCHUS) {
         if (gSaveContext.sohStats.itemTimestamp[ITEM_BOMBCHU] = 0) {
             gSaveContext.sohStats.itemTimestamp[ITEM_BOMBCHU] = time;
         }
@@ -2545,6 +2545,19 @@ u16 Randomizer_Item_Give(PlayState* play, GetItemEntry giEntry) {
         Rupees_ChangeBy(1);
         Flags_SetRandomizerInf(RAND_INF_GREG_FOUND);
         gSaveContext.sohStats.itemTimestamp[TIMESTAMP_FOUND_GREG] = GAMEPLAYSTAT_TOTAL_TIME;
+        return Return_Item_Entry(giEntry, RG_NONE);
+    }
+
+    if (item == RG_PROGRESSIVE_BOMBCHUS) {
+        if (INV_CONTENT(ITEM_BOMBCHU) == ITEM_NONE) {
+            INV_CONTENT(ITEM_BOMBCHU) = ITEM_BOMBCHU;
+            AMMO(ITEM_BOMBCHU) = 20;
+        } else {
+            AMMO(ITEM_BOMBCHU) += AMMO(ITEM_BOMBCHU) < 5 ? 10 : 5;
+            if (AMMO(ITEM_BOMBCHU) > 50) {
+                AMMO(ITEM_BOMBCHU) = 50;
+            }
+        }
         return Return_Item_Entry(giEntry, RG_NONE);
     }
 


### PR DESCRIPTION
Players often would overlook "Progressive Bombchus" in shop sanity, not realizing they are different than bombchu refills.
In an effort to help distinguish them against regular refill items, Progressive Bombchus have been given a particle effect similar to nut/stick upgrades.

To achieve this, `RG_PROGRESSIVE_BOMCHUS` is no longer treated like a vanilla item, and instead has it's own unique GetItemEntry record. This record uses the same GID as regular bombchus, and the same textID, but having the mod randomizer index allows us to strictly apply particles to the Progressive Bombchus item.

To replicate the behavior of how many bombchus are given to the player, the logic has been moved to `Randomizer_Item_give()` where if the player doesn't have bombchus yet, they will get 20. If they have bombchus, but current ammo is less than 5, they will get 10. Otherwise they get 5.

---

In setting up the particles, I noticed we were maintaining a secondary color for the items (envColor), but we weren't actually passing them in. This secondary color allows us to give the particle flares a separate color if desired. I have updated the names and left comments to clarify their usage.
I'm using this to give the bombchu particles a slight orange color to the flares while the particle is blue, to match the item.

I verified that all the other items (songs/upgrades) secondary colors thematically still fit and look good with this change.

![image](https://user-images.githubusercontent.com/13861068/233729945-adaa2a67-9cc7-4f28-b409-2089951444f3.png)
![image](https://user-images.githubusercontent.com/13861068/233734469-3c79610e-c371-40ac-a285-ce401273506e.png)



<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/659710594.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/659710595.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/659710596.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/659710597.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/659710598.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/659710599.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/659710600.zip)
<!--- section:artifacts:end -->