### PR TITLE
clean up build info on logo screen

### DIFF
--- a/OTRGui/src/impl/baserom_extractor/baserom_extractor.cpp
+++ b/OTRGui/src/impl/baserom_extractor/baserom_extractor.cpp
@@ -56,19 +56,19 @@ RomVersion GetVersion(FILE* rom) {
 
     version.crc = __bswap_32(version.crc);
     switch (version.crc) {
-    case OOT_NTSC_10:
+    case OOT_NTSC_US_10:
         version.version = "N64 NTSC 1.0";
         version.listPath = "ntsc_oot.txt";
         version.offset = OOT_OFF_NTSC_10;
         version.isMQ = false;
         break;
-    case OOT_NTSC_11:
+    case OOT_NTSC_US_11:
         version.version = "N64 NTSC 1.1";
         version.listPath = "ntsc_oot.txt";
         version.offset = OOT_OFF_NTSC_11;
         version.isMQ = false;
         break;
-    case OOT_NTSC_12:
+    case OOT_NTSC_US_12:
         version.version = "N64 NTSC 1.2";
         version.listPath = "ntsc_oot.txt";
         version.offset = OOT_OFF_NTSC_12;

--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -917,6 +917,8 @@ namespace GameMenuBar {
 
             if (ImGui::BeginMenu("Restoration"))
             {
+                UIWidgets::PaddedEnhancementCheckbox("Hide Build Info", "gHideBuildInfo", true, false);
+                UIWidgets::Tooltip("Hides the game version and build details in the boot logo start screen");
                 UIWidgets::EnhancementCheckbox("Red Ganon blood", "gRedGanonBlood");
                 UIWidgets::Tooltip("Restore the original red blood from NTSC 1.0/1.1. Disable for green blood");
                 UIWidgets::PaddedEnhancementCheckbox("Fish while hovering", "gHoverFishing", true, false);
@@ -1127,8 +1129,6 @@ namespace GameMenuBar {
                 ImGui::Text("Loading :");
                 UIWidgets::EnhancementCombobox("gSaveFileID", FastFileSelect, 0);
             };
-            UIWidgets::PaddedEnhancementCheckbox("Hide Build Info", "gHideBuildInfo", true, false);
-            UIWidgets::Tooltip("Hides the game version and build details in the boot logo start screen");
             UIWidgets::PaddedEnhancementCheckbox("Better Debug Warp Screen", "gBetterDebugWarpScreen", true, false);
             UIWidgets::Tooltip("Optimized debug warp screen, with the added ability to chose entrances and time of day");
             UIWidgets::PaddedEnhancementCheckbox("Debug Warp Screen Translation", "gDebugWarpScreenTranslation", true, false);

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -224,9 +224,9 @@ OTRGlobals::OTRGlobals() {
         OOT_NTSC_JP_MQ,
         OOT_NTSC_US_MQ,
         OOT_PAL_GC_MQ_DBG,
-        OOT_NTSC_10,
-        OOT_NTSC_11,
-        OOT_NTSC_12,
+        OOT_NTSC_US_10,
+        OOT_NTSC_US_11,
+        OOT_NTSC_US_12,
         OOT_PAL_10,
         OOT_PAL_11,
         OOT_NTSC_JP_GC_CE,
@@ -289,9 +289,9 @@ OTRGlobals::OTRGlobals() {
             case OOT_PAL_GC_MQ_DBG:
                 hasMasterQuest = true;
                 break;
-            case OOT_NTSC_10:
-            case OOT_NTSC_11:
-            case OOT_NTSC_12:
+            case OOT_NTSC_US_10:
+            case OOT_NTSC_US_11:
+            case OOT_NTSC_US_12:
             case OOT_PAL_10:
             case OOT_PAL_11:
             case OOT_NTSC_JP_GC_CE:

--- a/soh/src/overlays/gamestates/ovl_title/z_title.c
+++ b/soh/src/overlays/gamestates/ovl_title/z_title.c
@@ -279,6 +279,5 @@ void Title_Init(GameState* thisx) {
     this->unk_1D4 = 0x14;
     this->coverAlpha = 255;
     this->addAlpha = -3;
-    // this->visibleDuration = 0x3C;
-    this->visibleDuration = 0xFFF;
+    this->visibleDuration = 0x3C;
 }

--- a/soh/src/overlays/gamestates/ovl_title/z_title.c
+++ b/soh/src/overlays/gamestates/ovl_title/z_title.c
@@ -21,97 +21,54 @@ char* quote;
 
 void Title_PrintBuildInfo(Gfx** gfxp) {
     Gfx* g;
-    //GfxPrint* printer;
     GfxPrint printer;
 
     g = *gfxp;
     g = Gfx_SetupDL_28(g);
-    //printer = alloca(sizeof(GfxPrint));
+
     GfxPrint_Init(&printer);
     GfxPrint_Open(&printer, g);
-    GfxPrint_SetColor(&printer, 255, 155, 255, 255);
-    GfxPrint_SetPos(&printer, 12, 20);
+    GfxPrint_SetColor(&printer, 131, 154, 255, 255);
 
-#ifdef _MSC_VER
-    GfxPrint_Printf(&printer, "MSVC SHIP");
-#elif __clang__
-    GfxPrint_Printf(&printer, "CLANG SHIP");
-#else
-    GfxPrint_Printf(&printer, "GCC SHIP");
-#endif
-
-    s32 pos = 4;
-    GfxPrint_SetPos(&printer, 1, pos);
-    GfxPrint_Printf(&printer, "Game Versions:");
+    GfxPrint_SetPos(&printer, 1, 25);
+    GfxPrint_Printf(&printer, "%s", gBuildVersion);
+    GfxPrint_SetPos(&printer, 1, 26);
+    GfxPrint_Printf(&printer, "%s", gBuildDate);
 
     u32 numVersions = ResourceMgr_GetNumGameVersions();
-    if (!numVersions) {
-        GfxPrint_SetPos(&printer, 16, pos++);
-        GfxPrint_Printf(&printer, "Unknown");
-    } else {
-        for (u32 i = 0; i < numVersions; i++) {
-            GfxPrint_SetPos(&printer, 16, pos++);
-            GfxPrint_Printf(&printer, "%s", GetGameVersionString(i));
-        }
+    s32 pos = 27 - numVersions;
+    for (u32 i = 0; i < numVersions; i++) {
+        GfxPrint_SetPos(&printer, 29, pos++);
+        GfxPrint_Printf(&printer, "%s", GetGameVersionString(i));
     }
 
-    GfxPrint_SetPos(&printer, 1, pos);
-    GfxPrint_Printf(&printer, "Release Version: %s", gBuildVersion);
-
-    GfxPrint_SetColor(&printer, 255, 255, 255, 255);
-    GfxPrint_SetPos(&printer, 2, 22);
-    GfxPrint_Printf(&printer, quote);
-    GfxPrint_SetPos(&printer, 1, 25);
-    GfxPrint_Printf(&printer, "Build Date:%s", gBuildDate);
-    GfxPrint_SetPos(&printer, 3, 26);
-    GfxPrint_Printf(&printer, "%s", gBuildTeam);
     g = GfxPrint_Close(&printer);
     GfxPrint_Destroy(&printer);
     *gfxp = g;
 }
 
-const char* quotes[11] = {
-    "My boy! This peace is what all true warriors strive for!",
-    "Hmm. How can we help?",
-    "Zelda! Duke Onkled is under attack by the evil forces of Ganon!",
-    "I'm going to Gamelon to aid him.",
-    "I'll take the Triforce of Courage to protect me.",
-    "If you don't hear from me in a month, send Link.",
-    "Enough! My ship sails in the morning.",
-    "I wonder what's for dinner.",
-    "You've saved me!",
-    "After you've scrubbed all the floors in Hyrule, then we can talk about mercy! Take him away!",
-    "Waaaahahahohohahahahahahaha"
-};
-
-const char* SetQuote() {
-    srand(time(NULL));
-    int randomQuote = rand() % 11;
-    return quotes[randomQuote];
-}
-
 const char* GetGameVersionString(s32 index) {
     uint32_t gameVersion = ResourceMgr_GetGameVersion(index);
     switch (gameVersion) {
-        case OOT_NTSC_10:
-            return "N64 NTSC 1.0";
-        case OOT_NTSC_11:
-            return "N64 NTSC 1.1";
-        case OOT_NTSC_12:
-            return "N64 NTSC 1.2";
+        case OOT_NTSC_US_10:
+            return "NTSC-U 1.0";
+        case OOT_NTSC_US_11:
+            return "NTSC-U 1.1";
+        case OOT_NTSC_US_12:
+            return "NTSC-U 1.2";
         case OOT_PAL_10:
-            return "N64 PAL 1.0";
+            return "PAL 1.0";
         case OOT_PAL_11:
-            return "N64 PAL 1.1";
+            return "PAL 1.1";
         case OOT_PAL_GC:
-            return "GC PAL";
+            return "PAL GC";
         case OOT_PAL_MQ:
-            return "GC PAL MQ";
+            return "PAL MQ";
         case OOT_PAL_GC_DBG1:
         case OOT_PAL_GC_DBG2:
-            return "GC PAL DEBUG";
+            return "PAL GC-D";
         case OOT_PAL_GC_MQ_DBG:
-            return "GC PAL DEBUG MQ";
+            return "PAL MQ-D";
         case OOT_IQUE_CN:
             return "IQUE CN";
         case OOT_IQUE_TW:
@@ -302,8 +259,6 @@ void Title_Init(GameState* thisx) {
     //u32 size = 0;
     TitleContext* this = (TitleContext*)thisx;
 
-    quote = SetQuote();
-
     this->staticSegment = NULL;
     //this->staticSegment = GAMESTATE_ALLOC_MC(&this->state, size);
     osSyncPrintf("z_title.c\n");
@@ -324,5 +279,6 @@ void Title_Init(GameState* thisx) {
     this->unk_1D4 = 0x14;
     this->coverAlpha = 255;
     this->addAlpha = -3;
-    this->visibleDuration = 0x3C;
+    // this->visibleDuration = 0x3C;
+    this->visibleDuration = 0xFFF;
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/70942617/233867228-1bf9833a-7e12-431b-9b6d-09f086bbb038.png)

depends on <https://github.com/Kenix3/libultraship/pull/176>

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/661253958.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/661253959.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/661253960.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/661253961.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/661253962.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/661253963.zip)
<!--- section:artifacts:end -->