### PR TITLE
Implement patches for authentic texture overflows

### DIFF
--- a/soh/assets/objects/gameplay_keep/gameplay_keep.h
+++ b/soh/assets/objects/gameplay_keep/gameplay_keep.h
@@ -2375,6 +2375,9 @@ static const ALIGN_ASSET(2) char gEffUnknown11Tex[] = dgEffUnknown11Tex;
 #define dgEffUnknown12Tex "__OTR__objects/gameplay_keep/gEffUnknown12Tex"
 static const ALIGN_ASSET(2) char gEffUnknown12Tex[] = dgEffUnknown12Tex;
 
+#define dgEffUnknown12OverflowTex "__OTR__objects/gameplay_keep/gEffUnknown12OverflowTex"
+static const ALIGN_ASSET(2) char gEffUnknown12OverflowTex[] = dgEffUnknown12OverflowTex;
+
 #define dgUnknownWoodBoardTex "__OTR__objects/gameplay_keep/gUnknownWoodBoardTex"
 static const ALIGN_ASSET(2) char gUnknownWoodBoardTex[] = dgUnknownWoodBoardTex;
 

--- a/soh/assets/objects/gameplay_keep/gameplay_keep.h
+++ b/soh/assets/objects/gameplay_keep/gameplay_keep.h
@@ -20,6 +20,9 @@ static const ALIGN_ASSET(2) char gBottleGlassTex[] = dgBottleGlassTex;
 #define dgDekuStickTex "__OTR__objects/gameplay_keep/gDekuStickTex"
 static const ALIGN_ASSET(2) char gDekuStickTex[] = dgDekuStickTex;
 
+#define dgDekuStickOverflowTex "__OTR__objects/gameplay_keep/gDekuStickOverflowTex"
+static const ALIGN_ASSET(2) char gDekuStickOverflowTex[] = dgDekuStickOverflowTex;
+
 #define dgLinkHairTex "__OTR__objects/gameplay_keep/gLinkHairTex"
 static const ALIGN_ASSET(2) char gLinkHairTex[] = dgLinkHairTex;
 

--- a/soh/assets/objects/object_ik/object_ik.h
+++ b/soh/assets/objects/object_ik/object_ik.h
@@ -101,6 +101,9 @@ static const ALIGN_ASSET(2) char object_ik_Tlut_00F630[] = dobject_ik_Tlut_00F63
 #define dobject_ik_Tex_00F7A0 "__OTR__objects/object_ik/object_ik_Tex_00F7A0"
 static const ALIGN_ASSET(2) char object_ik_Tex_00F7A0[] = dobject_ik_Tex_00F7A0;
 
+#define dgIronKnuckleMetalOverflowTex "__OTR__objects/object_ik/gIronKnuckleMetalOverflowTex"
+static const ALIGN_ASSET(2) char gIronKnuckleMetalOverflowTex[] = dgIronKnuckleMetalOverflowTex;
+
 #define dobject_ik_Tex_00FBA0 "__OTR__objects/object_ik/object_ik_Tex_00FBA0"
 static const ALIGN_ASSET(2) char object_ik_Tex_00FBA0[] = dobject_ik_Tex_00FBA0;
 

--- a/soh/assets/xml/GC_MQ_D/objects/gameplay_keep.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/gameplay_keep.xml
@@ -809,6 +809,10 @@
         <Texture Name="gEffUnknown10Tex" OutName="eff_unknown_10" Format="i8" Width="32" Height="32" Offset="0x32490"/>
         <Texture Name="gEffUnknown11Tex" OutName="eff_unknown_11" Format="i8" Width="32" Height="32" Offset="0x32890"/>
         <Texture Name="gEffUnknown12Tex" OutName="eff_unknown_12" Format="i8" Width="32" Height="32" Offset="0x32C90"/>
+        <!-- This is a duplicate texture to accound for authentic texture overflowing -->
+        <!-- ZAPDTODO: It is set to an offset position -2 of the actual value as ZAPD does not permit
+             duplicate offset values -->
+        <Texture Name="gEffUnknown12OverflowTex" OutName="eff_unknown_12_overflow" Format="ia16" Width="32" Height="32" Offset="0x32C8E"/>
         <Texture Name="gUnknownWoodBoardTex" OutName="unknown_wood_board" Format="i8" Width="32" Height="32" Offset="0x33090"/>
         <DList Name="gEffIceFragment1DL" Offset="0x33720"/>
         <DList Name="gEffIceFragment2DL" Offset="0x33818"/>

--- a/soh/assets/xml/GC_MQ_D/objects/gameplay_keep.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/gameplay_keep.xml
@@ -7,6 +7,10 @@
         <Texture Name="gOcarinaofTimeDesignTex" OutName="ocarina_of_time_design" Format="rgba16" Width="32" Height="16" Offset="0x1400"/>
         <Texture Name="gBottleGlassTex" OutName="bottle_glass" Format="rgba16" Width="16" Height="16" Offset="0x1800"/>
         <Texture Name="gDekuStickTex" OutName="deku_stick" Format="i8" Width="16" Height="16" Offset="0x1A00"/>
+        <!-- This is a duplicate texture to accound for authentic texture overflowing -->
+        <!-- ZAPDTODO: It is set to an offset position -1 of the actual value as ZAPD does not permit
+             duplicate offset values -->
+        <Texture Name="gDekuStickOverflowTex" OutName="deku_stick_overflow" Format="i8" Width="16" Height="16" Offset="0x19FF"/>
         <Texture Name="gLinkHairTex" OutName="link_hair" Format="rgba16" Width="16" Height="16" Offset="0x1A40"/>
         <Texture Name="gLinkTunic1Tex" OutName="link_tunic_1" Format="i8" Width="16" Height="16" Offset="0x1C40"/>
         <Texture Name="gLinkTunic2Tex" OutName="link_tunic_2" Format="i8" Width="16" Height="32" Offset="0x1D40"/>

--- a/soh/assets/xml/GC_MQ_D/objects/object_ik.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_ik.xml
@@ -38,6 +38,10 @@
 
         <Texture Name="object_ik_Tlut_00F630" OutName="tlut_00F630" Format="rgba16" Width="23" Height="8" Offset="0xf630"/>
         <Texture Name="object_ik_Tex_00F7A0" OutName="tex_00F7A0" Format="i4" Width="32" Height="64" Offset="0xF7A0"/>
+        <!-- This is a duplicate texture to accound for authentic texture overflowing -->
+        <!-- ZAPDTODO: It is set to an offset position -1 of the actual value as ZAPD does not permit
+             duplicate offset values -->
+        <Texture Name="gIronKnuckleMetalOverflowTex" OutName="iron_knuckle_metal_overflow_tex" Format="i8" Width="32" Height="64" Offset="0xF79F"/>
         <Texture Name="object_ik_Tex_00FBA0" OutName="tex_00FBA0" Format="ia8" Width="32" Height="32" Offset="0xFBA0"/>
         <Texture Name="object_ik_Tex_00FFA0" OutName="tex_00FFA0" Format="rgba16" Width="16" Height="16" Offset="0xFFA0"/>
         <Texture Name="object_ik_Tex_0101A0" OutName="tex_0101A0" Format="rgba16" Width="16" Height="16" Offset="0x101A0"/>

--- a/soh/assets/xml/GC_NMQ_D/objects/gameplay_keep.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/gameplay_keep.xml
@@ -806,6 +806,10 @@
         <Texture Name="gEffUnknown10Tex" OutName="eff_unknown_10" Format="i8" Width="32" Height="32" Offset="0x32490"/>
         <Texture Name="gEffUnknown11Tex" OutName="eff_unknown_11" Format="i8" Width="32" Height="32" Offset="0x32890"/>
         <Texture Name="gEffUnknown12Tex" OutName="eff_unknown_12" Format="i8" Width="32" Height="32" Offset="0x32C90"/>
+        <!-- This is a duplicate texture to accound for authentic texture overflowing -->
+        <!-- ZAPDTODO: It is set to an offset position -2 of the actual value as ZAPD does not permit
+             duplicate offset values -->
+        <Texture Name="gEffUnknown12OverflowTex" OutName="eff_unknown_12_overflow" Format="ia16" Width="32" Height="32" Offset="0x32C8E"/>
         <Texture Name="gUnknownWoodBoardTex" OutName="unknown_wood_board" Format="i8" Width="32" Height="32" Offset="0x33090"/>
         <DList Name="gEffIceFragment1DL" Offset="0x33720"/>
         <DList Name="gEffIceFragment2DL" Offset="0x33818"/>

--- a/soh/assets/xml/GC_NMQ_D/objects/gameplay_keep.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/gameplay_keep.xml
@@ -7,6 +7,10 @@
         <Texture Name="gOcarinaofTimeDesignTex" OutName="ocarina_of_time_design" Format="rgba16" Width="32" Height="16" Offset="0x1400"/>
         <Texture Name="gBottleGlassTex" OutName="bottle_glass" Format="rgba16" Width="16" Height="16" Offset="0x1800"/>
         <Texture Name="gDekuStickTex" OutName="deku_stick" Format="i8" Width="16" Height="16" Offset="0x1A00"/>
+        <!-- This is a duplicate texture to accound for authentic texture overflowing -->
+        <!-- ZAPDTODO: It is set to an offset position -1 of the actual value as ZAPD does not permit
+             duplicate offset values -->
+        <Texture Name="gDekuStickOverflowTex" OutName="deku_stick_overflow" Format="i8" Width="16" Height="16" Offset="0x19FF"/>
         <Texture Name="gLinkHairTex" OutName="link_hair" Format="rgba16" Width="16" Height="16" Offset="0x1A40"/>
         <Texture Name="gLinkTunic1Tex" OutName="link_tunic_1" Format="i8" Width="16" Height="16" Offset="0x1C40"/>
         <Texture Name="gLinkTunic2Tex" OutName="link_tunic_2" Format="i8" Width="16" Height="32" Offset="0x1D40"/>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_ik.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_ik.xml
@@ -38,6 +38,10 @@
 
         <Texture Name="object_ik_Tlut_00F630" OutName="tlut_00F630" Format="rgba16" Width="23" Height="8" Offset="0xf630"/>
         <Texture Name="object_ik_Tex_00F7A0" OutName="tex_00F7A0" Format="i4" Width="32" Height="64" Offset="0xF7A0"/>
+        <!-- This is a duplicate texture to accound for authentic texture overflowing -->
+        <!-- ZAPDTODO: It is set to an offset position -1 of the actual value as ZAPD does not permit
+             duplicate offset values -->
+        <Texture Name="gIronKnuckleMetalOverflowTex" OutName="iron_knuckle_metal_overflow_tex" Format="i8" Width="32" Height="64" Offset="0xF79F"/>
         <Texture Name="object_ik_Tex_00FBA0" OutName="tex_00FBA0" Format="ia8" Width="32" Height="32" Offset="0xFBA0"/>
         <Texture Name="object_ik_Tex_00FFA0" OutName="tex_00FFA0" Format="rgba16" Width="16" Height="16" Offset="0xFFA0"/>
         <Texture Name="object_ik_Tex_0101A0" OutName="tex_0101A0" Format="rgba16" Width="16" Height="16" Offset="0x101A0"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/gameplay_keep.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/gameplay_keep.xml
@@ -806,6 +806,10 @@
         <Texture Name="gEffUnknown10Tex" OutName="eff_unknown_10" Format="i8" Width="32" Height="32" Offset="0x32490"/>
         <Texture Name="gEffUnknown11Tex" OutName="eff_unknown_11" Format="i8" Width="32" Height="32" Offset="0x32890"/>
         <Texture Name="gEffUnknown12Tex" OutName="eff_unknown_12" Format="i8" Width="32" Height="32" Offset="0x32C90"/>
+        <!-- This is a duplicate texture to accound for authentic texture overflowing -->
+        <!-- ZAPDTODO: It is set to an offset position -2 of the actual value as ZAPD does not permit
+             duplicate offset values -->
+        <Texture Name="gEffUnknown12OverflowTex" OutName="eff_unknown_12_overflow" Format="ia16" Width="32" Height="32" Offset="0x32C8E"/>
         <Texture Name="gUnknownWoodBoardTex" OutName="unknown_wood_board" Format="i8" Width="32" Height="32" Offset="0x33090"/>
         <DList Name="gEffIceFragment1DL" Offset="0x33720"/>
         <DList Name="gEffIceFragment2DL" Offset="0x33818"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/gameplay_keep.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/gameplay_keep.xml
@@ -7,6 +7,10 @@
         <Texture Name="gOcarinaofTimeDesignTex" OutName="ocarina_of_time_design" Format="rgba16" Width="32" Height="16" Offset="0x1400"/>
         <Texture Name="gBottleGlassTex" OutName="bottle_glass" Format="rgba16" Width="16" Height="16" Offset="0x1800"/>
         <Texture Name="gDekuStickTex" OutName="deku_stick" Format="i8" Width="16" Height="16" Offset="0x1A00"/>
+        <!-- This is a duplicate texture to accound for authentic texture overflowing -->
+        <!-- ZAPDTODO: It is set to an offset position -1 of the actual value as ZAPD does not permit
+             duplicate offset values -->
+        <Texture Name="gDekuStickOverflowTex" OutName="deku_stick_overflow" Format="i8" Width="16" Height="16" Offset="0x19FF"/>
         <Texture Name="gLinkHairTex" OutName="link_hair" Format="rgba16" Width="16" Height="16" Offset="0x1A40"/>
         <Texture Name="gLinkTunic1Tex" OutName="link_tunic_1" Format="i8" Width="16" Height="16" Offset="0x1C40"/>
         <Texture Name="gLinkTunic2Tex" OutName="link_tunic_2" Format="i8" Width="16" Height="32" Offset="0x1D40"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_ik.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_ik.xml
@@ -38,6 +38,10 @@
 
         <Texture Name="object_ik_Tlut_00F630" OutName="tlut_00F630" Format="rgba16" Width="23" Height="8" Offset="0xf630"/>
         <Texture Name="object_ik_Tex_00F7A0" OutName="tex_00F7A0" Format="i4" Width="32" Height="64" Offset="0xF7A0"/>
+        <!-- This is a duplicate texture to accound for authentic texture overflowing -->
+        <!-- ZAPDTODO: It is set to an offset position -1 of the actual value as ZAPD does not permit
+             duplicate offset values -->
+        <Texture Name="gIronKnuckleMetalOverflowTex" OutName="iron_knuckle_metal_overflow_tex" Format="i8" Width="32" Height="64" Offset="0xF79F"/>
         <Texture Name="object_ik_Tex_00FBA0" OutName="tex_00FBA0" Format="ia8" Width="32" Height="32" Offset="0xFBA0"/>
         <Texture Name="object_ik_Tex_00FFA0" OutName="tex_00FFA0" Format="rgba16" Width="16" Height="16" Offset="0xFFA0"/>
         <Texture Name="object_ik_Tex_0101A0" OutName="tex_0101A0" Format="rgba16" Width="16" Height="16" Offset="0x101A0"/>

--- a/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
+++ b/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
@@ -1,4 +1,5 @@
 #include "CosmeticsEditor.h"
+#include "authenticGfxPatches.h"
 #include <ImGuiImpl.h>
 #include "soh/Enhancements/game-interactor/GameInteractor.h"
 
@@ -1817,6 +1818,7 @@ void InitCosmeticsEditor() {
     }
     SohImGui::RequestCvarSaveOnNextTick();
     ApplyOrResetCustomGfxPatches();
+    ApplyAuthenticGfxPatches();
 
     RegisterOnLoadGameHook();
 }

--- a/soh/soh/Enhancements/cosmetics/authenticGfxPatches.cpp
+++ b/soh/soh/Enhancements/cosmetics/authenticGfxPatches.cpp
@@ -1,0 +1,153 @@
+#include <libultraship/bridge.h>
+#include <string>
+
+extern "C" {
+#include <libultraship/libultra.h>
+#include "objects/object_ik/object_ik.h"
+#include "objects/object_fz/object_fz.h"
+#include "objects/gameplay_keep/gameplay_keep.h"
+
+void ResourceMgr_PatchGfxByName(const char* path, const char* patchName, int index, Gfx instruction);
+void ResourceMgr_UnpatchGfxByName(const char* path, const char* patchName);
+}
+
+typedef struct {
+    const char* dlist;
+    int startInstruction;
+} DListPatchInfo;
+
+static DListPatchInfo freezardEffectDListPatchInfos[] = {
+    { gFreezardIntactDL, 5 },
+    { gFreezardTopRightHornChippedDL, 5 },
+    { gFreezardHeadChippedDL, 5 },
+    { gFreezardIceTriangleDL, 5 },
+    { gFreezardIceRockDL, 5 },
+};
+
+static DListPatchInfo ironKnuckleDListPatchInfos[] = {
+    { object_ik_DL_01BE98, 39 },
+    { object_ik_DL_01BE98, 59 },
+
+    { object_ik_DL_01C130, 38 },
+
+    { object_ik_DL_01C2B8, 39 },
+    { object_ik_DL_01C2B8, 59 },
+
+    { object_ik_DL_01C550, 38 },
+
+    { object_ik_DL_01C7B8, 8 },
+    { object_ik_DL_01C7B8, 28 },
+
+    { object_ik_DL_01CB58, 8 },
+    { object_ik_DL_01CB58, 31 },
+
+    { object_ik_DL_01CCA0, 15 },
+    { object_ik_DL_01CCA0, 37 },
+    { object_ik_DL_01CCA0, 52 },
+    { object_ik_DL_01CCA0, 68 },
+
+    { object_ik_DL_01CEE0, 27 },
+    { object_ik_DL_01CEE0, 46 },
+    { object_ik_DL_01CEE0, 125 },
+
+    { object_ik_DL_01D2B0, 8 },
+    { object_ik_DL_01D2B0, 32 },
+    
+    { object_ik_DL_01D3F8, 15 },
+    { object_ik_DL_01D3F8, 37 },
+    { object_ik_DL_01D3F8, 52 },
+    { object_ik_DL_01D3F8, 68 },
+
+    { object_ik_DL_01D638, 23 },
+    { object_ik_DL_01D638, 42 },
+    { object_ik_DL_01D638, 110 },
+};
+
+void PatchFreezardTextureOverflow() {
+    // Custom texture for Freezard effect that accounts for overflow texture reading
+    Gfx gEffUnknown12OverflowTextFix = gsDPSetTextureImage(G_IM_FMT_IA, G_IM_SIZ_16b, 1, gEffUnknown12OverflowTex);
+
+    // Gfx instructions to fix authentic vanilla bug where the Freezard effect texture is read as the wrong size
+    Gfx gEffUnknown12TexFix[] = {
+        gsDPLoadTextureBlock(gEffUnknown12Tex, G_IM_FMT_I, G_IM_SIZ_8b, 32, 32, 0, G_TX_NOMIRROR |
+                             G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, 5, 5, G_TX_NOLOD, G_TX_NOLOD)
+    };
+
+    for (const auto& patchInfo : freezardEffectDListPatchInfos) {
+        const char* dlist = patchInfo.dlist;
+        int start = patchInfo.startInstruction;
+
+        char patchNameBuf[24];
+
+        // Patch using custom overflowed texture
+        if (!CVarGetInteger("gFixTexturesOOB", 0)) {
+            // Unpatch the other texture fix
+            for (size_t i = 0; i < 7; i++) {
+                int instruction = start + (i == 0 ? 0 : i + 1);
+                std::string unpatchName = "gEffUnknown12" + std::to_string(instruction);
+                ResourceMgr_UnpatchGfxByName(dlist, unpatchName.c_str());
+            }
+
+            std::string patchName = "gEffUnknown12Overflow" + std::to_string(start);
+            ResourceMgr_PatchGfxByName(dlist, patchName.c_str(), start, gEffUnknown12OverflowTextFix);
+        } else { // Patch texture to use correct image size
+            // Unpatch the other texture fix
+            std::string unpatchName = "gEffUnknown12Overflow" + std::to_string(start);
+            ResourceMgr_UnpatchGfxByName(dlist, unpatchName.c_str());
+
+            for (size_t i = 0; i < 7; i++) {
+                int instruction = start + (i == 0 ? 0 : i + 1);
+                std::string patchName = "gEffUnknown12" + std::to_string(instruction);
+                ResourceMgr_PatchGfxByName(dlist, patchName.c_str(), instruction, gEffUnknown12TexFix[i]);
+            }
+        }
+    }
+}
+
+void PatchIronKnuckleTextureOverflow() {
+    // Custom texture for iron knuckles that accounts for overflow texture reading
+    Gfx gIronKnuckleMetalOverflowTexFix = gsDPSetTextureImage(G_IM_FMT_I, G_IM_SIZ_8b, 1, gIronKnuckleMetalOverflowTex);
+
+    // Gfx instructions to fix authentic vanilla bug where the iron knuckle texture is read as the wrong size
+    Gfx gIronKnuckleMetalTexFix[] = {
+        gsDPLoadTextureBlock(object_ik_Tex_00F7A0, G_IM_FMT_I, G_IM_SIZ_4b, 32, 64, 0, G_TX_MIRROR | G_TX_WRAP,
+                            G_TX_MIRROR | G_TX_WRAP, 5, 6, G_TX_NOLOD, G_TX_NOLOD)
+    };
+
+    for (const auto& patchInfo : ironKnuckleDListPatchInfos) {
+        const char* dlist = patchInfo.dlist;
+        int start = patchInfo.startInstruction;
+
+        // OTRTODO: Patching to use the correct size format for Iron Knuckles causes a tile size failure
+        // Until this is solved, Iron Knuckles will be hardcoded to always display with the "authentic" texture fix
+
+        // Patch using custom overflowed texture
+        // if (!CVarGetInteger("gFixTexturesOOB", 0)) {
+            // Unpatch the other texture fix
+            for (size_t i = 0; i < 7; i++) {
+                int instruction = start + (i == 0 ? 0 : i + 1);
+                std::string unpatchName = "MetalTexFix" + std::to_string(instruction);
+                ResourceMgr_UnpatchGfxByName(dlist, unpatchName.c_str());
+            }
+
+            std::string patchName = "MetalTexOverflow" + std::to_string(start);
+            ResourceMgr_PatchGfxByName(dlist, patchName.c_str(), start, gIronKnuckleMetalOverflowTexFix);
+        // } else { // Patch texture to use correct image size
+        //     // Unpatch the other texture fix
+        //     std::string unpatchName = "MetalTexOverflow" + std::to_string(start);
+        //     ResourceMgr_UnpatchGfxByName(dlist, unpatchName.c_str());
+
+        //     // Patch texture to use correct image size
+        //     for (size_t i = 0; i < 7; i++) {
+        //         int instruction = start + (i == 0 ? 0 : i + 1);
+        //         std::string patchName = "MetalTexFix" + std::to_string(instruction);
+        //         ResourceMgr_PatchGfxByName(dlist, patchName.c_str(), instruction, gIronKnuckleMetalTexFix[i]);
+        //     }
+        // }
+    }
+}
+
+void ApplyAuthenticGfxPatches() {
+    PatchFreezardTextureOverflow();
+    PatchIronKnuckleTextureOverflow();
+}

--- a/soh/soh/Enhancements/cosmetics/authenticGfxPatches.cpp
+++ b/soh/soh/Enhancements/cosmetics/authenticGfxPatches.cpp
@@ -3,9 +3,10 @@
 
 extern "C" {
 #include <libultraship/libultra.h>
-#include "objects/object_ik/object_ik.h"
-#include "objects/object_fz/object_fz.h"
 #include "objects/gameplay_keep/gameplay_keep.h"
+#include "objects/object_fz/object_fz.h"
+#include "objects/object_ik/object_ik.h"
+#include "objects/object_link_child/object_link_child.h"
 
 void ResourceMgr_PatchGfxByName(const char* path, const char* patchName, int index, Gfx instruction);
 void ResourceMgr_UnpatchGfxByName(const char* path, const char* patchName);
@@ -63,11 +64,47 @@ static DListPatchInfo ironKnuckleDListPatchInfos[] = {
     { object_ik_DL_01D638, 110 },
 };
 
+void PatchDekuStickTextureOverflow() {
+    // Custom texture for holding Deku Stick that accounts for overflow texture reading
+    Gfx gDekuStickOverflowTexFix = gsDPSetTextureImage(G_IM_FMT_I, G_IM_SIZ_8b, 1, gDekuStickOverflowTex);
+
+    // Gfx instructions to fix authentic vanilla bug where the Deku Stick texture is read as the wrong size
+    Gfx gDekuStickTexFix[] = {
+        gsDPLoadTextureBlock(gDekuStickTex, G_IM_FMT_I, G_IM_SIZ_8b, 8, 8, 0, G_TX_NOMIRROR | G_TX_WRAP,
+                             G_TX_NOMIRROR | G_TX_WRAP, 4, 4, G_TX_NOLOD, G_TX_NOLOD)
+    };
+
+    const char* dlist = gLinkChildLinkDekuStickDL;
+    int start = 5;
+
+    if (!CVarGetInteger("gFixTexturesOOB", 0)) {
+        // Unpatch the other texture fix
+        for (size_t i = 0; i < 7; i++) {
+            int instruction = start + (i == 0 ? 0 : i + 1);
+            std::string unpatchName = "DekuStickFix" + std::to_string(instruction);
+            ResourceMgr_UnpatchGfxByName(dlist, unpatchName.c_str());
+        }
+
+        std::string patchName = "DekuStickOverflow" + std::to_string(start);
+        ResourceMgr_PatchGfxByName(dlist, patchName.c_str(), start, gDekuStickOverflowTexFix);
+    } else {
+        // Unpatch the other texture fix
+        std::string unpatchName = "DekuStickOverflow" + std::to_string(start);
+        ResourceMgr_UnpatchGfxByName(dlist, unpatchName.c_str());
+        
+        for (size_t i = 0; i < 7; i++) {
+            int instruction = start + (i == 0 ? 0 : i + 1);
+            std::string patchName = "DekuStickFix" + std::to_string(instruction);
+            ResourceMgr_PatchGfxByName(dlist, patchName.c_str(), instruction, gDekuStickTexFix[i]);
+        }
+    }
+}
+
 void PatchFreezardTextureOverflow() {
     // Custom texture for Freezard effect that accounts for overflow texture reading
     Gfx gEffUnknown12OverflowTextFix = gsDPSetTextureImage(G_IM_FMT_IA, G_IM_SIZ_16b, 1, gEffUnknown12OverflowTex);
 
-    // Gfx instructions to fix authentic vanilla bug where the Freezard effect texture is read as the wrong size
+    // Gfx instructions to fix authentic vanilla bug where the Freezard effect texture is read as the wrong format
     Gfx gEffUnknown12TexFix[] = {
         gsDPLoadTextureBlock(gEffUnknown12Tex, G_IM_FMT_I, G_IM_SIZ_8b, 32, 32, 0, G_TX_NOMIRROR |
                              G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, 5, 5, G_TX_NOLOD, G_TX_NOLOD)
@@ -84,7 +121,7 @@ void PatchFreezardTextureOverflow() {
             // Unpatch the other texture fix
             for (size_t i = 0; i < 7; i++) {
                 int instruction = start + (i == 0 ? 0 : i + 1);
-                std::string unpatchName = "gEffUnknown12" + std::to_string(instruction);
+                std::string unpatchName = "gEffUnknown12Fix" + std::to_string(instruction);
                 ResourceMgr_UnpatchGfxByName(dlist, unpatchName.c_str());
             }
 
@@ -97,7 +134,7 @@ void PatchFreezardTextureOverflow() {
 
             for (size_t i = 0; i < 7; i++) {
                 int instruction = start + (i == 0 ? 0 : i + 1);
-                std::string patchName = "gEffUnknown12" + std::to_string(instruction);
+                std::string patchName = "gEffUnknown12Fix" + std::to_string(instruction);
                 ResourceMgr_PatchGfxByName(dlist, patchName.c_str(), instruction, gEffUnknown12TexFix[i]);
             }
         }
@@ -105,10 +142,10 @@ void PatchFreezardTextureOverflow() {
 }
 
 void PatchIronKnuckleTextureOverflow() {
-    // Custom texture for iron knuckles that accounts for overflow texture reading
+    // Custom texture for Iron Knuckle that accounts for overflow texture reading
     Gfx gIronKnuckleMetalOverflowTexFix = gsDPSetTextureImage(G_IM_FMT_I, G_IM_SIZ_8b, 1, gIronKnuckleMetalOverflowTex);
 
-    // Gfx instructions to fix authentic vanilla bug where the iron knuckle texture is read as the wrong size
+    // Gfx instructions to fix authentic vanilla bug where the Iron Knuckle texture is read as the wrong format
     Gfx gIronKnuckleMetalTexFix[] = {
         gsDPLoadTextureBlock(object_ik_Tex_00F7A0, G_IM_FMT_I, G_IM_SIZ_4b, 32, 64, 0, G_TX_MIRROR | G_TX_WRAP,
                             G_TX_MIRROR | G_TX_WRAP, 5, 6, G_TX_NOLOD, G_TX_NOLOD)
@@ -118,8 +155,8 @@ void PatchIronKnuckleTextureOverflow() {
         const char* dlist = patchInfo.dlist;
         int start = patchInfo.startInstruction;
 
-        // OTRTODO: Patching to use the correct size format for Iron Knuckles causes a tile size failure
-        // Until this is solved, Iron Knuckles will be hardcoded to always display with the "authentic" texture fix
+        // OTRTODO: Patching to use the correct size format for Iron Knuckle causes a tile size failure
+        // Until this is solved, Iron Knuckle will be hardcoded to always display with the "authentic" texture fix
 
         // Patch using custom overflowed texture
         // if (!CVarGetInteger("gFixTexturesOOB", 0)) {
@@ -148,6 +185,7 @@ void PatchIronKnuckleTextureOverflow() {
 }
 
 void ApplyAuthenticGfxPatches() {
+    PatchDekuStickTextureOverflow();
     PatchFreezardTextureOverflow();
     PatchIronKnuckleTextureOverflow();
 }

--- a/soh/soh/Enhancements/cosmetics/authenticGfxPatches.h
+++ b/soh/soh/Enhancements/cosmetics/authenticGfxPatches.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void ApplyAuthenticGfxPatches();

--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -34,6 +34,7 @@
 #endif
 
 #include "Enhancements/game-interactor/GameInteractor.h"
+#include "Enhancements/cosmetics/authenticGfxPatches.h"
 
 bool isBetaQuestEnabled = false;
 
@@ -928,6 +929,10 @@ namespace GameMenuBar {
                 UIWidgets::PaddedEnhancementCheckbox("Restore old Gold Skulltula cutscene", "gGsCutscene", true, false);
                 UIWidgets::PaddedEnhancementCheckbox("Quick Bongo Kill", "gQuickBongoKill", true, false);
                 UIWidgets::Tooltip("Restore a bug from NTSC 1.0 that allows bypassing Bongo Bongo's intro cutscene to quickly kill him");
+                if (UIWidgets::PaddedEnhancementCheckbox("Fix out of bounds textures", "gFixTexturesOOB", true, false)) {
+                    ApplyAuthenticGfxPatches();
+                }
+                UIWidgets::Tooltip("Some textures in the game read out of bounds data (Freezards, etc.)\nThis patches them to instead load the texture with the correct size");
 
                 ImGui::EndMenu();
             }

--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -908,6 +908,10 @@ namespace GameMenuBar {
                 UIWidgets::Tooltip(
                     "Adds 5 higher pitches for the Silver Rupee Jingle for the rooms with more than 5 Silver Rupees. "
                     "Currently only relevant in Master Quest.");
+                if (UIWidgets::PaddedEnhancementCheckbox("Fix out of bounds textures", "gFixTexturesOOB", true, false)) {
+                    ApplyAuthenticGfxPatches();
+                }
+                UIWidgets::Tooltip("Fixes authentic out of bounds texture reads, instead loading textures with the correct size");
 
                 ImGui::EndMenu();
             }
@@ -929,10 +933,6 @@ namespace GameMenuBar {
                 UIWidgets::PaddedEnhancementCheckbox("Restore old Gold Skulltula cutscene", "gGsCutscene", true, false);
                 UIWidgets::PaddedEnhancementCheckbox("Quick Bongo Kill", "gQuickBongoKill", true, false);
                 UIWidgets::Tooltip("Restore a bug from NTSC 1.0 that allows bypassing Bongo Bongo's intro cutscene to quickly kill him");
-                if (UIWidgets::PaddedEnhancementCheckbox("Fix out of bounds textures", "gFixTexturesOOB", true, false)) {
-                    ApplyAuthenticGfxPatches();
-                }
-                UIWidgets::Tooltip("Some textures in the game read out of bounds data (Freezards, etc.)\nThis patches them to instead load the texture with the correct size");
 
                 ImGui::EndMenu();
             }


### PR DESCRIPTION
It was identified that there are some cases where the game authentically loads textures with the wrong size/format. The renderer would overflow when reading the texture. Sometimes this OOB read would cause a crash, otherwise garbage data was read and was not predictable between relaunches (causing the textures to vary slightly every time).

In N64 hardware, the following rom data would be read instead. To replicate this, new texture exports were added to mimic the overflow and produce a new texture output. DList patching is implemented for these situations to point to the new texture which will give the N64 hardware behavior.

For the time being, ZAPD does not permit multiple textures with the same offset value, so these new exports are offset by -1/-2 bytes so that ZAPD would still export, and the texture should be nearly close to the correct value. In the future, when ZAPD is updated to allow duplicate overflows, we can adjust these.

These patches are applied on launch only once (in the Cosmetic editor init flow).

A new toggle is added to the Restorations menu that allows the user to opt-in to patches that correct the original bugged wrong size/format. This sets patches that use the original texture with the correct format. Toggling this value will re-run the patch method (unpatching the opposite effect, and applying the new effect).

Currently there is one instance of this for Freezards. I tried to do the same for Iron Knuckles, but there seems to be something weird that causes a crash, so I left them commented out for now.

This means the new exported textures will need to be remade by texture pack makers intending to replace them.

### Freezard showing "fix" and spliced texture default behavior
https://user-images.githubusercontent.com/13861068/233870940-de0f1142-b2d9-41ca-9877-f0fe9e7e69a1.mp4

### Deku Stick with custom spliced texture
![image](https://user-images.githubusercontent.com/13861068/233870813-775ee9a0-7f51-41ab-8c06-843ba47557c8.png)

### Deku Stick with "fix"
![image](https://user-images.githubusercontent.com/13861068/233870825-c640ba8b-484f-4f66-9879-90a7f6aaed5d.png)

### Iron Knuckle before this PR (random garbage data)
![image](https://user-images.githubusercontent.com/13861068/233871237-34f65f16-fddd-4aa6-b4c7-bb6db04ee480.png)

### Iron Knuckle with custom spliced texture
![image](https://user-images.githubusercontent.com/13861068/233871252-5548bee0-2e62-40bc-bc7c-44eb03c792c7.png)



<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/661288262.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/661288263.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/661288264.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/661288265.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/661288266.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/661288267.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/661288268.zip)
<!--- section:artifacts:end -->