### PR TITLE
fix: update xml resolution for FireTempleBigVerticalFlame to match dlist resolution

### DIFF
--- a/soh/assets/xml/GC_MQ_D/objects/object_hidan_objects.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_hidan_objects.xml
@@ -35,14 +35,14 @@
 
         <DList Name="gFireTempleBigVerticalFlameDL" Offset="0xCA10"/>
 
-        <Texture Name="gFireTempleBigVerticalFlame0Tex" OutName="big_vertical_flame_0" Format="ia8" Width="8" Height="240" Offset="0x12120"/>
-        <Texture Name="gFireTempleBigVerticalFlame1Tex" OutName="big_vertical_flame_1" Format="ia8" Width="8" Height="240" Offset="0x128A0"/>
-        <Texture Name="gFireTempleBigVerticalFlame2Tex" OutName="big_vertical_flame_2" Format="ia8" Width="8" Height="240" Offset="0x13020"/>
-        <Texture Name="gFireTempleBigVerticalFlame3Tex" OutName="big_vertical_flame_3" Format="ia8" Width="8" Height="240" Offset="0x137A0"/>
-        <Texture Name="gFireTempleBigVerticalFlame4Tex" OutName="big_vertical_flame_4" Format="ia8" Width="8" Height="240" Offset="0x13F20"/>
-        <Texture Name="gFireTempleBigVerticalFlame5Tex" OutName="big_vertical_flame_5" Format="ia8" Width="8" Height="240" Offset="0x146A0"/>
-        <Texture Name="gFireTempleBigVerticalFlame6Tex" OutName="big_vertical_flame_6" Format="ia8" Width="8" Height="240" Offset="0x14E20"/>
-        <Texture Name="gFireTempleBigVerticalFlame7Tex" OutName="big_vertical_flame_7" Format="ia8" Width="8" Height="240" Offset="0x155A0"/>
+        <Texture Name="gFireTempleBigVerticalFlame0Tex" OutName="big_vertical_flame_0" Format="ia8" Width="24" Height="80" Offset="0x12120"/>
+        <Texture Name="gFireTempleBigVerticalFlame1Tex" OutName="big_vertical_flame_1" Format="ia8" Width="24" Height="80" Offset="0x128A0"/>
+        <Texture Name="gFireTempleBigVerticalFlame2Tex" OutName="big_vertical_flame_2" Format="ia8" Width="24" Height="80" Offset="0x13020"/>
+        <Texture Name="gFireTempleBigVerticalFlame3Tex" OutName="big_vertical_flame_3" Format="ia8" Width="24" Height="80" Offset="0x137A0"/>
+        <Texture Name="gFireTempleBigVerticalFlame4Tex" OutName="big_vertical_flame_4" Format="ia8" Width="24" Height="80" Offset="0x13F20"/>
+        <Texture Name="gFireTempleBigVerticalFlame5Tex" OutName="big_vertical_flame_5" Format="ia8" Width="24" Height="80" Offset="0x146A0"/>
+        <Texture Name="gFireTempleBigVerticalFlame6Tex" OutName="big_vertical_flame_6" Format="ia8" Width="24" Height="80" Offset="0x14E20"/>
+        <Texture Name="gFireTempleBigVerticalFlame7Tex" OutName="big_vertical_flame_7" Format="ia8" Width="24" Height="80" Offset="0x155A0"/>
 
         <DList Name="gFireTempleFireballDL" Offset="0xDC30"/>
         <DList Name="gFireTempleFireballUpperHalfDL" Offset="0xDA80"/>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_hidan_objects.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_hidan_objects.xml
@@ -35,14 +35,14 @@
 
         <DList Name="gFireTempleBigVerticalFlameDL" Offset="0xCA10"/>
 
-        <Texture Name="gFireTempleBigVerticalFlame0Tex" OutName="big_vertical_flame_0" Format="ia8" Width="8" Height="240" Offset="0x12120"/>
-        <Texture Name="gFireTempleBigVerticalFlame1Tex" OutName="big_vertical_flame_1" Format="ia8" Width="8" Height="240" Offset="0x128A0"/>
-        <Texture Name="gFireTempleBigVerticalFlame2Tex" OutName="big_vertical_flame_2" Format="ia8" Width="8" Height="240" Offset="0x13020"/>
-        <Texture Name="gFireTempleBigVerticalFlame3Tex" OutName="big_vertical_flame_3" Format="ia8" Width="8" Height="240" Offset="0x137A0"/>
-        <Texture Name="gFireTempleBigVerticalFlame4Tex" OutName="big_vertical_flame_4" Format="ia8" Width="8" Height="240" Offset="0x13F20"/>
-        <Texture Name="gFireTempleBigVerticalFlame5Tex" OutName="big_vertical_flame_5" Format="ia8" Width="8" Height="240" Offset="0x146A0"/>
-        <Texture Name="gFireTempleBigVerticalFlame6Tex" OutName="big_vertical_flame_6" Format="ia8" Width="8" Height="240" Offset="0x14E20"/>
-        <Texture Name="gFireTempleBigVerticalFlame7Tex" OutName="big_vertical_flame_7" Format="ia8" Width="8" Height="240" Offset="0x155A0"/>
+        <Texture Name="gFireTempleBigVerticalFlame0Tex" OutName="big_vertical_flame_0" Format="ia8" Width="24" Height="80" Offset="0x12120"/>
+        <Texture Name="gFireTempleBigVerticalFlame1Tex" OutName="big_vertical_flame_1" Format="ia8" Width="24" Height="80" Offset="0x128A0"/>
+        <Texture Name="gFireTempleBigVerticalFlame2Tex" OutName="big_vertical_flame_2" Format="ia8" Width="24" Height="80" Offset="0x13020"/>
+        <Texture Name="gFireTempleBigVerticalFlame3Tex" OutName="big_vertical_flame_3" Format="ia8" Width="24" Height="80" Offset="0x137A0"/>
+        <Texture Name="gFireTempleBigVerticalFlame4Tex" OutName="big_vertical_flame_4" Format="ia8" Width="24" Height="80" Offset="0x13F20"/>
+        <Texture Name="gFireTempleBigVerticalFlame5Tex" OutName="big_vertical_flame_5" Format="ia8" Width="24" Height="80" Offset="0x146A0"/>
+        <Texture Name="gFireTempleBigVerticalFlame6Tex" OutName="big_vertical_flame_6" Format="ia8" Width="24" Height="80" Offset="0x14E20"/>
+        <Texture Name="gFireTempleBigVerticalFlame7Tex" OutName="big_vertical_flame_7" Format="ia8" Width="24" Height="80" Offset="0x155A0"/>
 
         <DList Name="gFireTempleFireballDL" Offset="0xDC30"/>
         <DList Name="gFireTempleFireballUpperHalfDL" Offset="0xDA80"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_hidan_objects.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_hidan_objects.xml
@@ -35,14 +35,14 @@
 
         <DList Name="gFireTempleBigVerticalFlameDL" Offset="0xCA10"/>
 
-        <Texture Name="gFireTempleBigVerticalFlame0Tex" OutName="big_vertical_flame_0" Format="ia8" Width="8" Height="240" Offset="0x12120"/>
-        <Texture Name="gFireTempleBigVerticalFlame1Tex" OutName="big_vertical_flame_1" Format="ia8" Width="8" Height="240" Offset="0x128A0"/>
-        <Texture Name="gFireTempleBigVerticalFlame2Tex" OutName="big_vertical_flame_2" Format="ia8" Width="8" Height="240" Offset="0x13020"/>
-        <Texture Name="gFireTempleBigVerticalFlame3Tex" OutName="big_vertical_flame_3" Format="ia8" Width="8" Height="240" Offset="0x137A0"/>
-        <Texture Name="gFireTempleBigVerticalFlame4Tex" OutName="big_vertical_flame_4" Format="ia8" Width="8" Height="240" Offset="0x13F20"/>
-        <Texture Name="gFireTempleBigVerticalFlame5Tex" OutName="big_vertical_flame_5" Format="ia8" Width="8" Height="240" Offset="0x146A0"/>
-        <Texture Name="gFireTempleBigVerticalFlame6Tex" OutName="big_vertical_flame_6" Format="ia8" Width="8" Height="240" Offset="0x14E20"/>
-        <Texture Name="gFireTempleBigVerticalFlame7Tex" OutName="big_vertical_flame_7" Format="ia8" Width="8" Height="240" Offset="0x155A0"/>
+        <Texture Name="gFireTempleBigVerticalFlame0Tex" OutName="big_vertical_flame_0" Format="ia8" Width="24" Height="80" Offset="0x12120"/>
+        <Texture Name="gFireTempleBigVerticalFlame1Tex" OutName="big_vertical_flame_1" Format="ia8" Width="24" Height="80" Offset="0x128A0"/>
+        <Texture Name="gFireTempleBigVerticalFlame2Tex" OutName="big_vertical_flame_2" Format="ia8" Width="24" Height="80" Offset="0x13020"/>
+        <Texture Name="gFireTempleBigVerticalFlame3Tex" OutName="big_vertical_flame_3" Format="ia8" Width="24" Height="80" Offset="0x137A0"/>
+        <Texture Name="gFireTempleBigVerticalFlame4Tex" OutName="big_vertical_flame_4" Format="ia8" Width="24" Height="80" Offset="0x13F20"/>
+        <Texture Name="gFireTempleBigVerticalFlame5Tex" OutName="big_vertical_flame_5" Format="ia8" Width="24" Height="80" Offset="0x146A0"/>
+        <Texture Name="gFireTempleBigVerticalFlame6Tex" OutName="big_vertical_flame_6" Format="ia8" Width="24" Height="80" Offset="0x14E20"/>
+        <Texture Name="gFireTempleBigVerticalFlame7Tex" OutName="big_vertical_flame_7" Format="ia8" Width="24" Height="80" Offset="0x155A0"/>
 
         <DList Name="gFireTempleFireballDL" Offset="0xDC30"/>
         <DList Name="gFireTempleFireballUpperHalfDL" Offset="0xDA80"/>


### PR DESCRIPTION
Looks like it still works

![Screenshot from 2023-04-24 14-20-01](https://user-images.githubusercontent.com/70942617/234082872-21690fe2-6da5-421e-ae6c-023ced6f3541.png)


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/662899471.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/662899472.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/662899473.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/662899476.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/662899478.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/662899479.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/662899480.zip)
<!--- section:artifacts:end -->