### PR TITLE
fix: support building for switch on selfhosted runners

### DIFF
--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -197,10 +197,12 @@ jobs:
       image: devkitpro/devkita64:latest
     steps:
     - name: Install dependencies
-      if: ${{ !vars.LINUX_RUNNER }}
       run: |
         sudo apt-get update
         sudo apt-get install -y ninja-build
+    - name: Fix dubious ownership error
+      if: ${{ vars.LINUX_RUNNER }}
+      run: git config --global --add safe.directory '*'
     - uses: actions/checkout@v3
       with:
         submodules: true


### PR DESCRIPTION
null

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/665431544.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/665431545.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/665431546.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/665431547.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/665431548.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/665431549.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/665431550.zip)
<!--- section:artifacts:end -->