### PR TITLE
GCC 13 support

### DIFF
--- a/soh/soh/Enhancements/audio/AudioCollection.h
+++ b/soh/soh/Enhancements/audio/AudioCollection.h
@@ -2,6 +2,7 @@
 #include <map>
 #include <string>
 #include <set>
+#include <cstdint>
 
 enum SeqType {
     SEQ_NOSHUFFLE  = 0,

--- a/soh/soh/Enhancements/custom-message/CustomMessageManager.h
+++ b/soh/soh/Enhancements/custom-message/CustomMessageManager.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <string>
 #include <unordered_map>
+#include <cstdint>
 #include "../../../include/z64item.h"
 #include "../../../include/message_data_textbox_types.h"
 

--- a/soh/soh/Enhancements/debugger/debugSaveEditor.h
+++ b/soh/soh/Enhancements/debugger/debugSaveEditor.h
@@ -4,6 +4,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <cstdint>
 #include <soh/Enhancements/randomizer/randomizer_inf.h>
 
 void InitSaveEditor();

--- a/soh/soh/Enhancements/randomizer/3drando/cosmetics.hpp
+++ b/soh/soh/Enhancements/randomizer/3drando/cosmetics.hpp
@@ -3,6 +3,7 @@
 #include <array>
 #include <string>
 #include <vector>
+#include <cstdint>
 
 namespace Cosmetics {
   constexpr std::string_view RANDOM_CHOICE_STR = "Random Choice";

--- a/soh/soh/Enhancements/randomizer/3drando/custom_messages.hpp
+++ b/soh/soh/Enhancements/randomizer/3drando/custom_messages.hpp
@@ -3,6 +3,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <cstdint>
 
 #include "text.hpp"
 

--- a/soh/soh/Enhancements/randomizer/3drando/spoiler_log.hpp
+++ b/soh/soh/Enhancements/randomizer/3drando/spoiler_log.hpp
@@ -3,6 +3,7 @@
 #include <array>
 #include <string>
 #include <string_view>
+#include <cstdint>
 
 using RandomizerHash = std::array<std::string, 5>;
 

--- a/soh/soh/Enhancements/randomizer/randomizer_entrance_tracker.h
+++ b/soh/soh/Enhancements/randomizer/randomizer_entrance_tracker.h
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <vector>
+#include <cstdint>
 
 typedef enum {
     // ENTRANCE_GROUP_NO_GROUP,

--- a/soh/soh/Enhancements/randomizer/randomizer_item_tracker.h
+++ b/soh/soh/Enhancements/randomizer/randomizer_item_tracker.h
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <vector>
+#include <cstdint>
 
 void InitItemTracker();
 void DrawItemTracker(bool& open);


### PR DESCRIPTION
This fixes builds with GCC 13 due to the changes mentioned in [Porting to GCC 13](https://gcc.gnu.org/gcc-13/porting_to.html).
`<cstdint>` is no longer widely used in libstdc++ and needs to be included explicitly.

Requires https://github.com/Kenix3/libultraship/pull/182 to fully work with GCC 13.


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/671977722.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/671977723.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/671977724.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/671977725.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/671977726.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/671977727.zip)
<!--- section:artifacts:end -->