### PR TITLE
Tweak: Reset trade item cycling when pausing or changing pages

### DIFF
--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_item.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_item.c
@@ -922,3 +922,8 @@ void KaleidoScope_UpdateItemEquip(PlayState* play) {
         }
     }
 }
+
+void KaleidoScope_ResetTradeSelect() {
+    gSelectingMask = false;
+    gSelectingAdultTrade = false;
+}

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope.h
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope.h
@@ -37,4 +37,6 @@ void PauseMapMark_Draw(PlayState* play);
 
 void KaleidoScope_UpdateCursorSize(PauseContext* pauseCtx);
 
+void KaleidoScope_ResetTradeSelect();
+
 #endif

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
@@ -940,6 +940,8 @@ void KaleidoScope_SwitchPage(PauseContext* pauseCtx, u8 pt) {
 
     gSaveContext.unk_13EA = 0;
     Interface_ChangeAlpha(50);
+
+    KaleidoScope_ResetTradeSelect();
 }
 
 void KaleidoScope_HandlePageToggles(PauseContext* pauseCtx, Input* input) {
@@ -3587,6 +3589,8 @@ void KaleidoScope_Update(PlayState* play)
                 }
             }
 
+            KaleidoScope_ResetTradeSelect();
+
             pauseCtx->state = 4;
             break;
 
@@ -4192,8 +4196,6 @@ void KaleidoScope_Update(PlayState* play)
 
             func_800981B8(&play->objectCtx);
             func_800418D0(&play->colCtx, play);
-
-            KaleidoScope_ResetTradeSelect();
 
             switch (play->sceneNum) {
                 case SCENE_YDAN:

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
@@ -4193,6 +4193,8 @@ void KaleidoScope_Update(PlayState* play)
             func_800981B8(&play->objectCtx);
             func_800418D0(&play->colCtx, play);
 
+            KaleidoScope_ResetTradeSelect();
+
             switch (play->sceneNum) {
                 case SCENE_YDAN:
                 case SCENE_DDAN:


### PR DESCRIPTION
We have flags that track when the player is in a "trade item cycling" mode for adult/child trade items. This mode is unset if you press A again, or equip the item to a C-button. However, if you press B or Start to unpause while mid-cycling, the next time you pause you are still in the cycling state.

I added a method that is called at beginning of the pause init flow that will manually set these flags back to false to address this. I also call this method when the kelido page is switched left or right.

Fixes #2794 

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/674145089.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/674145092.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/674145094.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/674145095.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/674145096.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/674145097.zip)
<!--- section:artifacts:end -->