### PR TITLE
TWEAK: Rupee dash duplication

### DIFF
--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -952,12 +952,14 @@ namespace GameMenuBar {
 
                 UIWidgets::PaddedEnhancementCheckbox("Rupee Dash Mode", "gRupeeDash", true, false);
 
-                UIWidgets::Tooltip("Rupees reduced over time, Link suffers damage when the count hits 0.");
-                UIWidgets::PaddedEnhancementSliderInt(
-                    "Rupee Dash Interval: %d", "##DashInterval", "gDashInterval", 3, 5, "", 5, true, true, false,
-                    !CVarGetInteger("gRupeeDash", 0),
-                    "This option is disabled because \"Rupee Dash Mode\" is turned off");
-                UIWidgets::Tooltip("Interval between Rupee reduction in Rupee Dash Mode");
+                if (CVarGetInteger("gRupeeDash", 0)) {
+                    UIWidgets::Tooltip("Rupees reduced over time, Link suffers damage when the count hits 0.");
+                    UIWidgets::PaddedEnhancementSliderInt(
+                        "Rupee Dash Interval: %d", "##DashInterval", "gDashInterval", 3, 5, "", 5, true, true, false,
+                        !CVarGetInteger("gRupeeDash", 0),
+                        "This option is disabled because \"Rupee Dash Mode\" is turned off");
+                    UIWidgets::Tooltip("Interval between Rupee reduction in Rupee Dash Mode");
+                }
 
                 ImGui::EndMenu();
             }

--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -718,14 +718,6 @@ namespace GameMenuBar {
                         ImGui::EndMenu();
                     }
 
-                    UIWidgets::Spacer(0);
-
-                    UIWidgets::PaddedEnhancementCheckbox("Rupee Dash Mode", "gRupeeDash", true, false);
-                    UIWidgets::Tooltip("Rupees reduced over time, Link suffers damage when the count hits 0.");
-                    UIWidgets::PaddedEnhancementSliderInt("Rupee Dash Interval: %d", "##DashInterval", "gDashInterval", 3, 5, "", 5, true, true, false,
-                        !CVarGetInteger("gRupeeDash", 0), "This option is disabled because \"Rupee Dash Mode\" is turned off");
-                    UIWidgets::Tooltip("Interval between Rupee reduction in Rupee Dash Mode");
-
                     ImGui::EndMenu();
                 }
 
@@ -960,14 +952,12 @@ namespace GameMenuBar {
 
                 UIWidgets::PaddedEnhancementCheckbox("Rupee Dash Mode", "gRupeeDash", true, false);
 
-                if (CVarGetInteger("gRupeeDash", 0)) {
-                    UIWidgets::Tooltip("Rupees reduced over time, Link suffers damage when the count hits 0.");
-                    UIWidgets::PaddedEnhancementSliderInt(
-                        "Rupee Dash Interval: %d", "##DashInterval", "gDashInterval", 3, 5, "", 5, true, true, false,
-                        !CVarGetInteger("gRupeeDash", 0),
-                        "This option is disabled because \"Rupee Dash Mode\" is turned off");
-                    UIWidgets::Tooltip("Interval between Rupee reduction in Rupee Dash Mode");
-                }
+                UIWidgets::Tooltip("Rupees reduced over time, Link suffers damage when the count hits 0.");
+                UIWidgets::PaddedEnhancementSliderInt(
+                    "Rupee Dash Interval: %d", "##DashInterval", "gDashInterval", 3, 5, "", 5, true, true, false,
+                    !CVarGetInteger("gRupeeDash", 0),
+                    "This option is disabled because \"Rupee Dash Mode\" is turned off");
+                UIWidgets::Tooltip("Interval between Rupee reduction in Rupee Dash Mode");
 
                 ImGui::EndMenu();
             }


### PR DESCRIPTION
Rupee dash was duplicated while being moved over the EXTRA MODES, so this fixes the duplication and put it only there

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/674334347.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/674334349.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/674334350.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/674334351.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/674334352.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/674334353.zip)
<!--- section:artifacts:end -->