### PR TITLE
Fix: Bottle filling action updating all empty bottles

### DIFF
--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -2270,6 +2270,7 @@ u8 Item_Give(PlayState* play, u8 item) {
                     }
 
                     gSaveContext.inventory.items[temp + i] = item;
+                    break;
                 }
             }
         } else {


### PR DESCRIPTION
After the GetItem hook rework, the early returns for bottle filling were removed accidentally. A previous bug in dev testing exposed one of these cases and a break was re-added back. The other case was still missing and causing it so when filling a bottle, all empty bottles were replaced, rather than just one bottle only.

This just adds back a break statement to replicate the early return from before the hook rework.

Original code change for reference: 
![image](https://user-images.githubusercontent.com/13861068/235573117-0082a107-d279-4025-912d-9d16c05c2554.png)


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/674683521.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/674683522.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/674683523.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/674683524.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/674683525.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/674683526.zip)
<!--- section:artifacts:end -->