### PR TITLE
Fix: add header to align soh.otr file assets and fix asset crash for Mac

### DIFF
--- a/soh/assets/soh_assets.h
+++ b/soh/assets/soh_assets.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include "align_asset_macro.h"
+
+// This file is manually made
+// When new assets are added to the soh.otr file
+// We need to add the aligned version of the resource names here and use in code
+// On Mac, not using aligned resource names was causing crashes in release builds
+
+// objects
+#define dgChristmasGreenTreasureChestFrontTex "__OTR__objects/object_box/gChristmasGreenTreasureChestFrontTex"
+static const ALIGN_ASSET(2) char gChristmasGreenTreasureChestFrontTex[] = dgChristmasGreenTreasureChestFrontTex;
+
+#define dgChristmasGreenTreasureChestSideAndTopTex "__OTR__objects/object_box/gChristmasGreenTreasureChestSideAndTopTex"
+static const ALIGN_ASSET(2) char gChristmasGreenTreasureChestSideAndTopTex[] = dgChristmasGreenTreasureChestSideAndTopTex;
+
+#define dgChristmasRedTreasureChestFrontTex "__OTR__objects/object_box/gChristmasRedTreasureChestFrontTex"
+static const ALIGN_ASSET(2) char gChristmasRedTreasureChestFrontTex[] = dgChristmasRedTreasureChestFrontTex;
+
+#define dgChristmasRedTreasureChestSideAndTopTex "__OTR__objects/object_box/gChristmasRedTreasureChestSideAndTopTex"
+static const ALIGN_ASSET(2) char gChristmasRedTreasureChestSideAndTopTex[] = dgChristmasRedTreasureChestSideAndTopTex;
+
+#define dgGoldTreasureChestFrontTex "__OTR__objects/object_box/gGoldTreasureChestFrontTex"
+static const ALIGN_ASSET(2) char gGoldTreasureChestFrontTex[] = dgGoldTreasureChestFrontTex;
+
+#define dgGoldTreasureChestSideAndTopTex "__OTR__objects/object_box/gGoldTreasureChestSideAndTopTex"
+static const ALIGN_ASSET(2) char gGoldTreasureChestSideAndTopTex[] = dgGoldTreasureChestSideAndTopTex;
+
+#define dgKeyTreasureChestFrontTex "__OTR__objects/object_box/gKeyTreasureChestFrontTex"
+static const ALIGN_ASSET(2) char gKeyTreasureChestFrontTex[] = dgKeyTreasureChestFrontTex;
+
+#define dgKeyTreasureChestSideAndTopTex "__OTR__objects/object_box/gKeyTreasureChestSideAndTopTex"
+static const ALIGN_ASSET(2) char gKeyTreasureChestSideAndTopTex[] = dgKeyTreasureChestSideAndTopTex;
+
+#define dgSkullTreasureChestFrontTex "__OTR__objects/object_box/gSkullTreasureChestFrontTex"
+static const ALIGN_ASSET(2) char gSkullTreasureChestFrontTex[] = dgSkullTreasureChestFrontTex;
+
+#define dgSkullTreasureChestSideAndTopTex "__OTR__objects/object_box/gSkullTreasureChestSideAndTopTex"
+static const ALIGN_ASSET(2) char gSkullTreasureChestSideAndTopTex[] = dgSkullTreasureChestSideAndTopTex;
+
+#define dgTitleRandomizerSubtitleTex "__OTR__objects/object_mag/gTitleRandomizerSubtitleTex"
+static const ALIGN_ASSET(2) char gTitleRandomizerSubtitleTex[] = dgTitleRandomizerSubtitleTex;
+
+// textures
+#define dgDPad "__OTR__textures/parameter_static/gDPad"
+static const ALIGN_ASSET(2) char gDPadTex[] = dgDPad;
+
+#define dgFileSelMQButtonTex "__OTR__textures/title_static/gFileSelMQButtonTex"
+static const ALIGN_ASSET(2) char gFileSelMQButtonTex[] = dgFileSelMQButtonTex;
+
+#define dgFileSelPleaseChooseAQuestENGTex "__OTR__textures/title_static/gFileSelPleaseChooseAQuestENGTex"
+static const ALIGN_ASSET(2) char gFileSelPleaseChooseAQuestENGTex[] = dgFileSelPleaseChooseAQuestENGTex;
+
+#define dgFileSelPleaseChooseAQuestFRATex "__OTR__textures/title_static/gFileSelPleaseChooseAQuestFRATex"
+static const ALIGN_ASSET(2) char gFileSelPleaseChooseAQuestFRATex[] = dgFileSelPleaseChooseAQuestFRATex;
+
+#define dgFileSelPleaseChooseAQuestGERTex "__OTR__textures/title_static/gFileSelPleaseChooseAQuestGERTex"
+static const ALIGN_ASSET(2) char gFileSelPleaseChooseAQuestGERTex[] = dgFileSelPleaseChooseAQuestGERTex;
+
+#define dgFileSelRANDButtonTex "__OTR__textures/title_static/gFileSelRANDButtonTex"
+static const ALIGN_ASSET(2) char gFileSelRANDButtonTex[] = dgFileSelRANDButtonTex;
+
+#define dgEmptyTexture "__OTR__textures/virtual/gEmptyTexture"
+static const ALIGN_ASSET(2) char gEmptyTexture[] = dgEmptyTexture;

--- a/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
+++ b/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
@@ -21,6 +21,7 @@ extern PlayState* gPlayState;
 
 #include "textures/icon_item_static/icon_item_static.h"
 #include "textures/icon_item_24_static/icon_item_24_static.h"
+#include "textures/parameter_static/parameter_static.h"
 }
 
 typedef struct {
@@ -140,7 +141,7 @@ std::map<uint32_t, ItemMapEntry> itemMapping = {
 };
 
 std::map<uint32_t, ItemMapEntry> gregMapping = {
-    {ITEM_RUPEE_GREEN, {ITEM_RUPEE_GREEN, "ITEM_RUPEE_GREEN", "ITEM_RUPEE_GREEN_Faded", "__OTR__textures/parameter_static/gRupeeCounterIconTex"}}
+    {ITEM_RUPEE_GREEN, {ITEM_RUPEE_GREEN, "ITEM_RUPEE_GREEN", "ITEM_RUPEE_GREEN_Faded", gRupeeCounterIconTex}}
 };
 
 // Maps entries in the GS flag array to the area name it represents

--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -3,6 +3,7 @@
 #include "textures/parameter_static/parameter_static.h"
 #include "textures/do_action_static/do_action_static.h"
 #include "textures/icon_item_static/icon_item_static.h"
+#include "soh_assets.h"
 #include "soh/Enhancements/randomizer/adult_trade_shuffle.h"
 #include "soh/Enhancements/randomizer/randomizer_entrance.h"
 #include "libultraship/bridge.h"
@@ -5219,7 +5220,7 @@ void Interface_Draw(PlayState* play) {
 
             gDPSetPrimColor(OVERLAY_DISP++, 0, 0, dPadColor.r, dPadColor.g, dPadColor.b, dpadAlpha);
             if (fullUi) {
-                gDPLoadTextureBlock(OVERLAY_DISP++, "__OTR__textures/parameter_static/gDPad",
+                gDPLoadTextureBlock(OVERLAY_DISP++, gDPadTex,
                                     G_IM_FMT_IA, G_IM_SIZ_16b, 32, 32, 0, G_TX_NOMIRROR | G_TX_WRAP,
                                     G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
                 gSPWideTextureRectangle(OVERLAY_DISP++, DpadPosX << 2, DpadPosY << 2,

--- a/soh/src/overlays/actors/ovl_En_Box/z_en_box.c
+++ b/soh/src/overlays/actors/ovl_En_Box/z_en_box.c
@@ -1,5 +1,6 @@
 #include "z_en_box.h"
 #include "objects/object_box/object_box.h"
+#include "soh_assets.h"
 
 #define FLAGS 0
 
@@ -756,16 +757,16 @@ void EnBox_UpdateSizeAndTexture(EnBox* this, PlayState* play) {
 void EnBox_CreateExtraChestTextures() {
     if (hasCreatedRandoChestTextures) return;
     Gfx gTreasureChestChestTextures[] = {
-        gsDPSetTextureImage(G_IM_FMT_RGBA, G_IM_SIZ_16b, 1, "__OTR__objects/object_box/gSkullTreasureChestFrontTex"),
-        gsDPSetTextureImage(G_IM_FMT_RGBA, G_IM_SIZ_16b, 1, "__OTR__objects/object_box/gSkullTreasureChestSideAndTopTex"),
-        gsDPSetTextureImage(G_IM_FMT_RGBA, G_IM_SIZ_16b, 1, "__OTR__objects/object_box/gGoldTreasureChestFrontTex"),
-        gsDPSetTextureImage(G_IM_FMT_RGBA, G_IM_SIZ_16b, 1, "__OTR__objects/object_box/gGoldTreasureChestSideAndTopTex"),
-        gsDPSetTextureImage(G_IM_FMT_RGBA, G_IM_SIZ_16b, 1, "__OTR__objects/object_box/gKeyTreasureChestFrontTex"),
-        gsDPSetTextureImage(G_IM_FMT_RGBA, G_IM_SIZ_16b, 1, "__OTR__objects/object_box/gKeyTreasureChestSideAndTopTex"),
-        gsDPSetTextureImage(G_IM_FMT_RGBA, G_IM_SIZ_16b, 1, "__OTR__objects/object_box/gChristmasRedTreasureChestFrontTex"),
-        gsDPSetTextureImage(G_IM_FMT_RGBA, G_IM_SIZ_16b, 1, "__OTR__objects/object_box/gChristmasRedTreasureChestSideAndTopTex"),
-        gsDPSetTextureImage(G_IM_FMT_RGBA, G_IM_SIZ_16b, 1, "__OTR__objects/object_box/gChristmasGreenTreasureChestFrontTex"),
-        gsDPSetTextureImage(G_IM_FMT_RGBA, G_IM_SIZ_16b, 1, "__OTR__objects/object_box/gChristmasGreenTreasureChestSideAndTopTex"),
+        gsDPSetTextureImage(G_IM_FMT_RGBA, G_IM_SIZ_16b, 1, gSkullTreasureChestFrontTex),
+        gsDPSetTextureImage(G_IM_FMT_RGBA, G_IM_SIZ_16b, 1, gSkullTreasureChestSideAndTopTex),
+        gsDPSetTextureImage(G_IM_FMT_RGBA, G_IM_SIZ_16b, 1, gGoldTreasureChestFrontTex),
+        gsDPSetTextureImage(G_IM_FMT_RGBA, G_IM_SIZ_16b, 1, gGoldTreasureChestSideAndTopTex),
+        gsDPSetTextureImage(G_IM_FMT_RGBA, G_IM_SIZ_16b, 1, gKeyTreasureChestFrontTex),
+        gsDPSetTextureImage(G_IM_FMT_RGBA, G_IM_SIZ_16b, 1, gKeyTreasureChestSideAndTopTex),
+        gsDPSetTextureImage(G_IM_FMT_RGBA, G_IM_SIZ_16b, 1, gChristmasRedTreasureChestFrontTex),
+        gsDPSetTextureImage(G_IM_FMT_RGBA, G_IM_SIZ_16b, 1, gChristmasRedTreasureChestSideAndTopTex),
+        gsDPSetTextureImage(G_IM_FMT_RGBA, G_IM_SIZ_16b, 1, gChristmasGreenTreasureChestFrontTex),
+        gsDPSetTextureImage(G_IM_FMT_RGBA, G_IM_SIZ_16b, 1, gChristmasGreenTreasureChestSideAndTopTex),
     };
 
     Gfx* frontCmd = ResourceMgr_LoadGfxByName(gTreasureChestChestFrontDL);

--- a/soh/src/overlays/actors/ovl_En_Mag/z_en_mag.c
+++ b/soh/src/overlays/actors/ovl_En_Mag/z_en_mag.c
@@ -701,7 +701,7 @@ void EnMag_DrawInnerMq(Actor* thisx, PlayState* play, Gfx** gfxp) {
 
         gDPPipeSync(gfx++);
         gDPSetPrimColor(gfx++, 0, 0, 255, 255, 255, (s16)this->subAlpha);
-        EnMag_DrawImageRGBA32(&gfx, 174, 145, "__OTR__objects/object_mag/gTitleMasterQuestSubtitleTex", 128, 32);
+        EnMag_DrawImageRGBA32(&gfx, 174, 145, gTitleMasterQuestSubtitleTex, 128, 32);
     }
 
     Gfx_SetupDL_39Ptr(&gfx);

--- a/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -1452,7 +1452,7 @@ void FileChoose_DrawWindowContents(GameState* thisx) {
                 FileChoose_DrawTextureI8(this->state.gfxCtx, gTitleTheLegendOfTextTex, 72, 8, 156, 108, 72, 8, 1024, 1024);
                 FileChoose_DrawTextureI8(this->state.gfxCtx, gTitleOcarinaOfTimeTMTextTex, 96, 8, 154, 163, 96, 8, 1024, 1024);
                 FileChoose_DrawImageRGBA32(this->state.gfxCtx, 160, 135, gTitleZeldaShieldLogoMQTex, 160, 160);
-                FileChoose_DrawImageRGBA32(this->state.gfxCtx, 182, 180, "__OTR__objects/object_mag/gTitleMasterQuestSubtitleTex", 128, 32);
+                FileChoose_DrawImageRGBA32(this->state.gfxCtx, 182, 180, gTitleMasterQuestSubtitleTex, 128, 32);
                 break;
             
             case RANDOMIZER_QUEST:

--- a/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -688,8 +688,6 @@ void FileChoose_RotateToNameEntry(GameState* thisx) {
     FileChooseContext* this = (FileChooseContext*)thisx;
 
     this->windowRot += VREG(16);
-    lusprintf(__FILE__, __LINE__, 2, "Hello World");
-    lusprintf(__FILE__, __LINE__, 2, "Hello World %d", 1);
 
     if (MIN_QUEST == MAX_QUEST && this->windowRot >= 314.0f) {
         this->windowRot = 314.0f;

--- a/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -9,6 +9,7 @@
 #include <GameVersions.h>
 #include "objects/object_mag/object_mag.h"
 #include "objects/gameplay_keep/gameplay_keep.h"
+#include "soh_assets.h"
 #include "soh/Enhancements/game-interactor/GameInteractor.h"
 
 #include "soh/Enhancements/custom-message/CustomMessageTypes.h"
@@ -687,6 +688,8 @@ void FileChoose_RotateToNameEntry(GameState* thisx) {
     FileChooseContext* this = (FileChooseContext*)thisx;
 
     this->windowRot += VREG(16);
+    lusprintf(__FILE__, __LINE__, 2, "Hello World");
+    lusprintf(__FILE__, __LINE__, 2, "Hello World %d", 1);
 
     if (MIN_QUEST == MAX_QUEST && this->windowRot >= 314.0f) {
         this->windowRot = 314.0f;
@@ -1367,11 +1370,11 @@ const char* FileChoose_GetQuestChooseTitleTexName(Language lang) {
     switch (lang) {
         case LANGUAGE_ENG:
         default:
-            return "__OTR__textures/title_static/gFileSelPleaseChooseAQuestENGTex";
+            return gFileSelPleaseChooseAQuestENGTex;
         case LANGUAGE_FRA:
-            return "__OTR__textures/title_static/gFileSelPleaseChooseAQuestFRATex";
+            return gFileSelPleaseChooseAQuestFRATex;
         case LANGUAGE_GER:
-            return "__OTR__textures/title_static/gFileSelPleaseChooseAQuestGERTex";
+            return gFileSelPleaseChooseAQuestGERTex;
     }
 }
 
@@ -1460,7 +1463,7 @@ void FileChoose_DrawWindowContents(GameState* thisx) {
                 FileChoose_DrawTextureI8(this->state.gfxCtx, gTitleTheLegendOfTextTex, 72, 8, 156, 108, 72, 8, 1024, 1024);
                 FileChoose_DrawTextureI8(this->state.gfxCtx, gTitleOcarinaOfTimeTMTextTex, 96, 8, 154, 163, 96, 8, 1024, 1024);
                 FileChoose_DrawImageRGBA32(this->state.gfxCtx, 160, 135, ResourceMgr_GameHasOriginal() ? gTitleZeldaShieldLogoTex : gTitleZeldaShieldLogoMQTex, 160, 160);
-                FileChoose_DrawImageRGBA32(this->state.gfxCtx, 182, 180, "__OTR__objects/object_mag/gTitleRandomizerSubtitleTex", 128, 32);
+                FileChoose_DrawImageRGBA32(this->state.gfxCtx, 182, 180, gTitleRandomizerSubtitleTex, 128, 32);
                 break;
         }
     } else if (this->configMode != CM_ROTATE_TO_NAME_ENTRY) {
@@ -1536,7 +1539,7 @@ void FileChoose_DrawWindowContents(GameState* thisx) {
                                     this->nameAlpha[i]);
                 }
                 gDPLoadTextureBlock(POLY_OPA_DISP++,
-                                    "__OTR__textures/title_static/gFileSelRANDButtonTex",
+                                    gFileSelRANDButtonTex,
                                     G_IM_FMT_IA, G_IM_SIZ_16b, 44, 16, 0, G_TX_NOMIRROR | G_TX_WRAP,
                                     G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
                 gSP1Quadrangle(POLY_OPA_DISP++, 8, 10, 11, 9, 0);
@@ -1553,7 +1556,7 @@ void FileChoose_DrawWindowContents(GameState* thisx) {
                                     this->nameAlpha[i]);
                 }
                 gDPLoadTextureBlock(POLY_OPA_DISP++,
-                                    "__OTR__textures/title_static/gFileSelMQButtonTex",
+                                    gFileSelMQButtonTex,
                                     G_IM_FMT_IA, G_IM_SIZ_16b, 44, 16, 0, G_TX_NOMIRROR | G_TX_WRAP,
                                     G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
                 gSP1Quadrangle(POLY_OPA_DISP++, 8, 10, 11, 9, 0);


### PR DESCRIPTION
For some reason on mac release builds, our custom assets in the `soh.otr` file were causing crashes when read. An Investigation was done here #2766 and showed that by aligning the custom asset names similar to the original game asset headers, the issue would go away.

I've created an `soh_assets.h` header file that contains exports for aligned assets that needed to be fixed to prevent crashing on mac. This file will need to be maintained in the future as we add new assets.

Also updated other references to stringed assets like the MQ title sub title and greg green rupee for item tracker to use the aligned vars.

Not included in this PR is assets used by LUS directly, e.g. the input viewer button icons. Not sure if this is the same problem, but I found the input viewer just doesn't display anything for Mac. If a similar solution works for that, it would need to be applied in LUS directly.

Should fix #2766

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/676182608.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/676182609.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/676182611.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/676182614.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/676182617.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/676182620.zip)
<!--- section:artifacts:end -->