### PR TITLE
update mac launch script to set SHIP_HOME

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -444,6 +444,7 @@ install_manifest.txt
 compile_commands.json
 CTestTestfile.cmake
 _deps
+_packages
 */extract_assets_cmake*
 /build*
 

--- a/soh/macosx/soh-macos.sh
+++ b/soh/macosx/soh-macos.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
 
 SNAME="$(dirname $0)"
-export DATA_SHARE="$HOME/Library/Application Support/com.shipofharkinian.soh"
+export SHIP_HOME="$HOME/Library/Application Support/com.shipofharkinian.soh"
 export SNAME
 export RESPATH="${SNAME%/MacOS*}/Resources"
 export LIBPATH="${SNAME%/MacOS*}/Frameworks"
 export DYLD_FALLBACK_LIBRARY_PATH="$LIBPATH"
 
-if [ ! -e "$DATA_SHARE" ]; then	mkdir "$DATA_SHARE"; fi
+if [ ! -e "$SHIP_HOME" ]; then	mkdir "$SHIP_HOME"; fi
 
 # If either OTR doesn't exist kick off the OTR gen process
-if [ ! -e "$DATA_SHARE"/oot.otr ] || [ ! -e "$DATA_SHARE"/oot-mq.otr ]; then
+if [ ! -e "$SHIP_HOME"/oot.otr ] || [ ! -e "$SHIP_HOME"/oot-mq.otr ]; then
 
 	# If no ROMs exist kick off the file selection prompts
-	while [ ! -e "$DATA_SHARE"/*.*64 ] && [ ! -e "$DATA_SHARE"/oot*.otr ]; do
+	while [ ! -e "$SHIP_HOME"/*.*64 ] && [ ! -e "$SHIP_HOME"/oot*.otr ]; do
 
 		SHOULD_PROMPT_FOR_ROM=1
 		while [ $SHOULD_PROMPT_FOR_ROM -eq 1 ]; do
@@ -63,7 +63,7 @@ if [ ! -e "$DATA_SHARE"/oot.otr ] || [ ! -e "$DATA_SHARE"/oot-mq.otr ]; then
 					fi
 			esac
 
-			cp "$DROPROM" "$DATA_SHARE"
+			cp "$DROPROM" "$SHIP_HOME"
 
 			# Ask user if they would also like to select the other variant (MQ/Vanilla)
 			if [ $ROM_TYPE -eq 0 ] && [[ -z "$UPLOAD_ANOTHER_RESULT" ]]; then
@@ -93,10 +93,10 @@ if [ ! -e "$DATA_SHARE"/oot.otr ] || [ ! -e "$DATA_SHARE"/oot-mq.otr ]; then
 		done
 	done
 
-	# At this point we should now have 1 or more valid roms in $DATA_SHARE directory
+	# At this point we should now have 1 or more valid roms in $SHIP_HOME directory
 
 	# Prepare tmp dir
-	for ROMPATH in "$DATA_SHARE"/*.*64
+	for ROMPATH in "$SHIP_HOME"/*.*64
 	do
 		ASSETDIR="$(mktemp -d /tmp/assets-XXXXX)"
 		export ASSETDIR
@@ -132,7 +132,7 @@ if [ ! -e "$DATA_SHARE"/oot.otr ] || [ ! -e "$DATA_SHARE"/oot-mq.otr ]; then
 		esac
 
 		# Only generate OTR if we don't have on of this type yet
-		if [ -e "$DATA_SHARE"/"$OTRNAME" ]; then
+		if [ -e "$SHIP_HOME"/"$OTRNAME" ]; then
 			rm -r "$ASSETDIR"
 			continue;
 		fi
@@ -141,12 +141,12 @@ if [ ! -e "$DATA_SHARE"/oot.otr ] || [ ! -e "$DATA_SHARE"/oot-mq.otr ]; then
 		assets/extractor/ZAPD.out ed -i assets/extractor/xmls/"${ROM}" -b tmp/rom.z64 -fl assets/extractor/filelists -o placeholder -osf placeholder -gsf 1 -rconf assets/extractor/Config_"${ROM}".xml -se OTR
 		if [ -e "$ASSETDIR"/oot.otr ]; then
 			osascript -e 'display notification "OTR successfully generated" with title "Ship Of Harkinian"'
-			cp "$ASSETDIR"/oot.otr "$DATA_SHARE"/"$OTRNAME"
+			cp "$ASSETDIR"/oot.otr "$SHIP_HOME"/"$OTRNAME"
 			rm -r "$ASSETDIR"
 		fi
 	done
 
-	if [ ! -e "$DATA_SHARE"/oot*.otr ]; then
+	if [ ! -e "$SHIP_HOME"/oot*.otr ]; then
 		osascript -e 'display notification "OTR failed to generate" with title "Ship Of Harkinian"'
 		exit 1;
 	fi


### PR DESCRIPTION
Update the mac launch script to rename `DATA_SHARE` to `SHIP_HOME` so the the env var can be read by LUS when trying to get the app dir path.
Requires LUS PR: https://github.com/Kenix3/libultraship/pull/192

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/680627659.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/680627660.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/680627661.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/680627662.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/680627663.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/680627664.zip)
<!--- section:artifacts:end -->