### PR TITLE
Fix: remove TTS hotkey for Linux and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ You can verify you have a supported copy of the game by checking the `sha1` hash
 | - | - |
 | PAL GC | `0227d7c0074f2d0ac935631990da8ec5914597b4` |
 | PAL GC (Debug) | `cee6bc3c2a634b41728f2af8da54d9bf8cc14099` |
-| PAL MQ | `079b855b943d6ad8bd1eb026c0ed169ecbdac7da` |
-| PAL MQ | `50bebedad9e0f10746a52b07239e47fa6c284d03` | 
+| PAL MQ (Debug) | `079b855b943d6ad8bd1eb026c0ed169ecbdac7da` |
+| PAL MQ (Debug) | `50bebedad9e0f10746a52b07239e47fa6c284d03` | 
 
 ### 2. Download The Ship of Harkinian from [Discord](https://discord.com/invite/shipofharkinian)
 The latest release is available in the most recent post in the `#downloads` channel.
@@ -73,7 +73,9 @@ Congratulations, you are now sailing with the Ship of Harkinian! Have fun!
 | F5 | Save state |
 | F6 | Change state |
 | F7 | Load state |
+| F9 | Toggle Text-to-Speech (Windows and Mac only) |
 | F10 | Fullscreen (OpenGL) |
+| Tab | Toggle Alternate assets |
 | Alt+Enter | Fullscreen (DirectX) |
 | Ctrl+R | Reset |
 

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -894,11 +894,13 @@ extern "C" void Graph_StartFrame() {
 
             break;
         }
+#if defined(_WIN32) || defined(__APPLE__)
         case KbScancode::LUS_KB_F9: {
             // Toggle TTS
             CVarSetInteger("gA11yTTS", !CVarGetInteger("gA11yTTS", 0));
             break;
         }
+#endif
         case KbScancode::LUS_KB_TAB: {
             // Toggle HD Assets
             CVarSetInteger("gAltAssets", !CVarGetInteger("gAltAssets", 0));


### PR DESCRIPTION
TTS is only supported for Windows and Mac, but the hotkey would allow turning it on for Linux. Once on, this would cause a crash on Linux.
Added the same if def from the menu bar toggle to the TTS hotkey switch case

Also updated the README to include the new hotkeys and re-add (Debug) to the MQ rom names.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/680730628.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/680730629.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/680730630.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/680730631.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/680730632.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/680730633.zip)
<!--- section:artifacts:end -->