### PR TITLE
fix: build wii u

### DIFF
--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -229,48 +229,48 @@ jobs:
           soh.nro
           soh.otr
           readme.txt
-  # build-wiiu:
-  #   needs: generate-soh-otr
-  #   runs-on: ${{ (vars.LINUX_RUNNER && fromJSON(vars.LINUX_RUNNER)) || 'ubuntu-latest' }}
-  #   container:
-  #     image: devkitpro/devkitppc:latest
-  #   steps:
-  #   - name: Install dependencies
-  #     if: ${{ !vars.LINUX_RUNNER }}
-  #     run: |
-  #       sudo apt-get update
-  #       sudo apt-get install -y ninja-build
-  #   - uses: actions/checkout@v3
-  #     with:
-  #       submodules: true
-  #   - name: ccache
-  #     uses: hendrikmuhs/ccache-action@v1.2
-  #     with:
-  #       key: ${{ runner.os }}-wiiu-ccache
-  #   - name: Build SoH
-  #     run: |
-  #       cmake -H. -Bbuild-wiiu -GNinja -DCMAKE_TOOLCHAIN_FILE=/opt/devkitpro/cmake/WiiU.cmake -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache
-  #       cmake --build build-wiiu --target soh_wuhb --config Release -j3
+  build-wiiu:
+    needs: generate-soh-otr
+    runs-on: ${{ (vars.LINUX_RUNNER && fromJSON(vars.LINUX_RUNNER)) || 'ubuntu-latest' }}
+    container:
+      image: devkitpro/devkitppc:20230110
+    steps:
+    - name: Install dependencies
+      if: ${{ !vars.LINUX_RUNNER }}
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y ninja-build
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - name: ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: ${{ runner.os }}-wiiu-ccache
+    - name: Build SoH
+      run: |
+        cmake -H. -Bbuild-wiiu -GNinja -DCMAKE_TOOLCHAIN_FILE=/opt/devkitpro/cmake/WiiU.cmake -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache
+        cmake --build build-wiiu --target soh_wuhb --config Release -j3
 
-  #       mv build-wiiu/soh/*.rpx soh.rpx
-  #       mv build-wiiu/soh/*.wuhb soh.wuhb
-  #       mv README.md readme.txt
-  #     env:
-  #       DEVKITPRO: /opt/devkitpro
-  #       DEVKITPPC: /opt/devkitpro/devkitPPC
-  #   - name: Download soh.otr
-  #     uses: actions/download-artifact@v3
-  #     with:
-  #       name: soh.otr
-  #   - name: Upload build
-  #     uses: actions/upload-artifact@v3
-  #     with:
-  #       name: soh-wiiu
-  #       path: |
-  #         soh.rpx
-  #         soh.wuhb
-  #         soh.otr
-  #         readme.txt
+        mv build-wiiu/soh/*.rpx soh.rpx
+        mv build-wiiu/soh/*.wuhb soh.wuhb
+        mv README.md readme.txt
+      env:
+        DEVKITPRO: /opt/devkitpro
+        DEVKITPPC: /opt/devkitpro/devkitPPC
+    - name: Download soh.otr
+      uses: actions/download-artifact@v3
+      with:
+        name: soh.otr
+    - name: Upload build
+      uses: actions/upload-artifact@v3
+      with:
+        name: soh-wiiu
+        path: |
+          soh.rpx
+          soh.wuhb
+          soh.otr
+          readme.txt
   build-windows:
     needs: generate-soh-otr
     runs-on: ${{ (vars.WINDOWS_RUNNER && fromJSON(vars.WINDOWS_RUNNER)) || 'windows-latest' }}

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -734,9 +734,9 @@ extern "C" void InitOTR() {
 #ifdef __SWITCH__
     Ship::Switch::Init(Ship::PreInitPhase);
 #elif defined(__WIIU__)
-    static const std::string shortName = "soh";
-    Ship::WiiU::Init(shortName);
+    Ship::WiiU::Init("soh");
 #endif
+
     Ship::AddSetupHooksDelegate(GameMenuBar::SetupHooks);
     Ship::RegisterMenuDrawMethod(GameMenuBar::Draw);
 

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -734,7 +734,7 @@ extern "C" void InitOTR() {
 #ifdef __SWITCH__
     Ship::Switch::Init(Ship::PreInitPhase);
 #elif defined(__WIIU__)
-    Ship::WiiU::Init();
+    Ship::WiiU::Init("soh");
 #endif
     Ship::AddSetupHooksDelegate(GameMenuBar::SetupHooks);
     Ship::RegisterMenuDrawMethod(GameMenuBar::Draw);

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -734,7 +734,8 @@ extern "C" void InitOTR() {
 #ifdef __SWITCH__
     Ship::Switch::Init(Ship::PreInitPhase);
 #elif defined(__WIIU__)
-    Ship::WiiU::Init("soh");
+    static const std::string shortName = "soh";
+    Ship::WiiU::Init(shortName);
 #endif
     Ship::AddSetupHooksDelegate(GameMenuBar::SetupHooks);
     Ship::RegisterMenuDrawMethod(GameMenuBar::Draw);


### PR DESCRIPTION
* use older version of devkitppc docker image that still works with cemu
* pass in shortname to wii u init method

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/682654734.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/682654735.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/682654737.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/682654738.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/682654739.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/682654740.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/682654741.zip)
<!--- section:artifacts:end -->