### PR TITLE
Reverts part of PR #2851 that required OTR regen.

### DIFF
--- a/OTRExporter/OTRExporter/CollisionExporter.cpp
+++ b/OTRExporter/OTRExporter/CollisionExporter.cpp
@@ -41,8 +41,8 @@ void OTRExporter_Collision::Save(ZResource* res, const fs::path& outPath, Binary
 	writer->Write((uint32_t)col->PolygonTypes.size());
 
 	for (uint16_t i = 0; i < col->PolygonTypes.size(); i++) {
-		writer->Write(col->PolygonTypes[i].data[0]);
 		writer->Write(col->PolygonTypes[i].data[1]);
+		writer->Write(col->PolygonTypes[i].data[0]);
 	}
 
 	writer->Write((uint32_t)col->camData->entries.size());

--- a/soh/soh/resource/importer/CollisionHeaderFactory.cpp
+++ b/soh/soh/resource/importer/CollisionHeaderFactory.cpp
@@ -77,8 +77,8 @@ void Ship::CollisionHeaderFactoryV0::ParseFileBinary(std::shared_ptr<BinaryReade
     for (uint32_t i = 0; i < collisionHeader->surfaceTypesCount; i++) {
         SurfaceType surfaceType;
 
-        surfaceType.data[0] = reader->ReadUInt32();
         surfaceType.data[1] = reader->ReadUInt32();
+        surfaceType.data[0] = reader->ReadUInt32();
 
         collisionHeader->surfaceTypes.push_back(surfaceType);
     }


### PR DESCRIPTION
PR #2851 accidentally introduced a change that would require OTRs to regen, this fixes that so old OTRs work.

@louist103 pinging so you are aware of this for your future ZAPD work.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/684213336.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/684213339.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/684213342.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/684213345.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/684213346.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/684213348.zip)
<!--- section:artifacts:end -->