### PR TITLE
Fix oversight in CrowdControl source file

### DIFF
--- a/soh/soh/Enhancements/crowd-control/ShipOfHarkinian.cs
+++ b/soh/soh/Enhancements/crowd-control/ShipOfHarkinian.cs
@@ -113,7 +113,7 @@ public class ShipOfHarkinian : SimpleTCPPack
         new("No UI", "no_ui") { Category = "Visual Effects", Duration = 60, Price = 20, Description = "No need to see ammo counts. The cinematic experience." },
         new("Rainstorm", "rainstorm") { Category = "Visual Effects", Duration = 30, Price = 5, Description = "Summon a rainstorm for a sad moment." },
         new("Debug Mode", "debug_mode") { Category = "Visual Effects", Duration = 30, Price = 20, Description = "if (debug_mode) { ShowCollision(); }" },
-        new("Randomize Cosmetics", "random_cosmetics") { Category = "Visual Effects", Duration = 30, Price = 30, Description = "Randomize most cosmetics options. Cosmetics changed by bidding wars are unaffected." },
+        new("Randomize Cosmetics", "random_cosmetics") { Category = "Visual Effects", Price = 30, Description = "Randomize most cosmetics options. Cosmetics changed by bidding wars are unaffected." },
 
 
         // Controls


### PR DESCRIPTION
Randomize Cosmetics had a duration in the .cs file which I didn't notice until after it was pushed to the CC client. This has no impact on the game's code and this PR exists to make sure the file is synced up with what the CC team is using.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/684978961.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/684978962.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/684978963.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/684978964.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/684978965.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/684978967.zip)
<!--- section:artifacts:end -->