### PR TITLE
Cleanup cvars that are set on boot and in the navigation

### DIFF
--- a/soh/soh/Enhancements/audio/AudioEditor.cpp
+++ b/soh/soh/Enhancements/audio/AudioEditor.cpp
@@ -308,7 +308,10 @@ void DrawTypeChip(SeqType type) {
 
 void DrawSfxEditor(bool& open) {
     if (!open) {
-        CVarSetInteger("gAudioEditor.WindowOpen", 0);
+        if (CVarGetInteger("gAudioEditor.WindowOpen", 0)) {
+            CVarClear("gAudioEditor.WindowOpen");
+            LUS::RequestCvarSaveOnNextTick();
+        }
         return;
     }
 
@@ -552,7 +555,7 @@ void DrawSfxEditor(bool& open) {
 
 void InitAudioEditor() {
     //Draw the bar in the menu.
-    LUS::AddWindow("Enhancements", "Audio Editor", DrawSfxEditor);
+    LUS::AddWindow("Enhancements", "Audio Editor", DrawSfxEditor, CVarGetInteger("gAudioEditor.WindowOpen", 0));
 }
 
 std::vector<SeqType> allTypes = { SEQ_BGM_WORLD, SEQ_BGM_EVENT, SEQ_BGM_BATTLE, SEQ_OCARINA, SEQ_FANFARE, SEQ_INSTRUMENT, SEQ_SFX };

--- a/soh/soh/Enhancements/bootcommands.c
+++ b/soh/soh/Enhancements/bootcommands.c
@@ -20,13 +20,10 @@ static BootCommand sCommands[] = { { "--skiplogo", BootCommands_Command_SkipLogo
 
 void BootCommands_Init()
 {
-    CVarRegisterInteger("gDebugEnabled", 0);
-    CVarRegisterInteger("gLanguages", LANGUAGE_ENG);
-    CVarRegisterInteger("gDebugWarpScreenTranslation", 1);
-    CVarRegisterInteger("gInvertYAxis", 1);
     // Clears vars to prevent randomizer menu from being disabled
-    CVarSetInteger("gRandoGenerating", 0); // Clear when a crash happened during rando seed generation
-    CVarSetInteger("gOnFileSelectNameEntry", 0); // Clear when soh is killed on the file name entry page
+    CVarClear("gRandoGenerating"); // Clear when a crash happened during rando seed generation
+    CVarClear("gNewSeedGenerated");
+    CVarClear("gOnFileSelectNameEntry"); // Clear when soh is killed on the file name entry page
 #if defined(__SWITCH__) || defined(__WIIU__)
     CVarRegisterInteger("gControlNav", 1); // always enable controller nav on switch/wii u
 #endif

--- a/soh/soh/Enhancements/controls/GameControlEditor.cpp
+++ b/soh/soh/Enhancements/controls/GameControlEditor.cpp
@@ -88,7 +88,7 @@ namespace GameControlEditor {
     void DrawUI(bool&);
 
     void Init() {
-        LUS::AddWindow("Enhancements", "Game Control Editor", DrawUI);
+        LUS::AddWindow("Enhancements", "Game Control Editor", DrawUI, CVarGetInteger("gGameControlEditorEnabled", 0));
 
         addButtonName(BTN_A,		"A");
         addButtonName(BTN_B,		"B");
@@ -242,14 +242,16 @@ namespace GameControlEditor {
         DrawHelpIcon("Inverts the Camera Y Axis in:\n-First-Person/C-Up view\n-Weapon Aiming");
         UIWidgets::PaddedEnhancementCheckbox("Disable Auto-Centering in First-Person View", "gDisableAutoCenterViewFirstPerson");
         DrawHelpIcon("Prevents the C-Up view from auto-centering, allowing for Gyro Aiming");
-        UIWidgets::PaddedEnhancementCheckbox("Enable Custom Aiming/First-Person sensitivity", "gEnableFirstPersonSensitivity", true, false);
+        if (UIWidgets::PaddedEnhancementCheckbox("Enable Custom Aiming/First-Person sensitivity", "gEnableFirstPersonSensitivity", true, false)) {
+            if (!CVarGetInteger("gEnableFirstPersonSensitivity", 0)) {
+                CVarClear("gFirstPersonCameraSensitivity");
+            }
+        }
         if (CVarGetInteger("gEnableFirstPersonSensitivity", 0)) {
             UIWidgets::EnhancementSliderFloat("Aiming/First-Person Horizontal Sensitivity: %d %%", "##FirstPersonSensitivity Horizontal",
                                                 "gFirstPersonCameraSensitivityX", 0.01f, 5.0f, "", 1.0f, true);
             UIWidgets::EnhancementSliderFloat("Aiming/First-Person Vertical Sensitivity: %d %%", "##FirstPersonSensitivity Vertical",
                                               "gFirstPersonCameraSensitivityY", 0.01f, 5.0f, "", 1.0f, true);
-        } else {
-            CVarSetFloat("gFirstPersonCameraSensitivity", 1.0f);
         }
         UIWidgets::Spacer(0);
         LUS::EndGroupPanel();
@@ -262,7 +264,7 @@ namespace GameControlEditor {
                             "controller config menu, and map the camera stick to the right stick.");
         UIWidgets::PaddedEnhancementCheckbox("Invert Camera X Axis", "gInvertXAxis");
         DrawHelpIcon("Inverts the Camera X Axis in:\n-Free camera");
-        UIWidgets::PaddedEnhancementCheckbox("Invert Camera Y Axis", "gInvertYAxis");
+        UIWidgets::PaddedEnhancementCheckbox("Invert Camera Y Axis", "gInvertYAxis", true, true, false, "", UIWidgets::CheckboxGraphics::Cross, true);
         DrawHelpIcon("Inverts the Camera Y Axis in:\n-Free camera");
         UIWidgets::Spacer(0);
 +       UIWidgets::PaddedEnhancementSliderFloat("Third-Person Horizontal Sensitivity: %d %%", "##ThirdPersonSensitivity Horizontal",
@@ -328,7 +330,10 @@ namespace GameControlEditor {
 
     void DrawUI(bool& open) {
         if (!open) {
-            CVarSetInteger("gGameControlEditorEnabled", false);
+            if (CVarGetInteger("gGameControlEditorEnabled", 0)) {
+                CVarClear("gGameControlEditorEnabled");
+                LUS::RequestCvarSaveOnNextTick();
+            }
             return;
         }
 

--- a/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
+++ b/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
@@ -1668,7 +1668,10 @@ static const char* colorSchemes[2] = {
 
 void DrawCosmeticsEditor(bool& open) {
     if (!open) {
-        CVarSetInteger("gCosmeticsEditorEnabled", 0);
+        if (CVarGetInteger("gCosmeticsEditorEnabled", 0)) {
+            CVarClear("gCosmeticsEditorEnabled");
+            LUS::RequestCvarSaveOnNextTick();
+        }
         return;
     }
 
@@ -1803,7 +1806,7 @@ void InitCosmeticsEditor() {
     LUS::AddWindow("Enhancements", "Cosmetics Update Tick", CosmeticsUpdateTick, true, true);
 
     // Draw the bar in the menu.
-    LUS::AddWindow("Enhancements", "Cosmetics Editor", DrawCosmeticsEditor);
+    LUS::AddWindow("Enhancements", "Cosmetics Editor", DrawCosmeticsEditor, CVarGetInteger("gCosmeticsEditorEnabled", 0));
     // Convert the `current color` into the format that the ImGui color picker expects
     for (auto& [id, cosmeticOption] : cosmeticOptions) {
         Color_RGBA8 defaultColor = {cosmeticOption.defaultColor.x, cosmeticOption.defaultColor.y, cosmeticOption.defaultColor.z, cosmeticOption.defaultColor.w};

--- a/soh/soh/Enhancements/debugger/actorViewer.cpp
+++ b/soh/soh/Enhancements/debugger/actorViewer.cpp
@@ -531,7 +531,10 @@ void PopulateActorDropdown(int i, std::vector<Actor*>& data) {
 
 void DrawActorViewer(bool& open) {
     if (!open) {
-        CVarSetInteger("gActorViewerEnabled", 0);
+        if (CVarGetInteger("gActorViewerEnabled", 0)) {
+            CVarClear("gActorViewerEnabled");
+            LUS::RequestCvarSaveOnNextTick();
+        }
         return;
     }
 
@@ -787,5 +790,5 @@ void DrawActorViewer(bool& open) {
 }
 
 void InitActorViewer() {
-    LUS::AddWindow("Developer Tools", "Actor Viewer", DrawActorViewer);
+    LUS::AddWindow("Developer Tools", "Actor Viewer", DrawActorViewer, CVarGetInteger("gActorViewerEnabled", 0));
 }

--- a/soh/soh/Enhancements/debugger/colViewer.cpp
+++ b/soh/soh/Enhancements/debugger/colViewer.cpp
@@ -53,7 +53,10 @@ static std::vector<Vtx> sphereVtx;
 // Draws the ImGui window for the collision viewer
 void DrawColViewerWindow(bool& open) {
     if (!open) {
-        CVarSetInteger("gCollisionViewerEnabled", 0);
+        if (CVarGetInteger("gCollisionViewerEnabled", 0)) {
+            CVarClear("gCollisionViewerEnabled");
+            LUS::RequestCvarSaveOnNextTick();
+        }
         return;
     }
 
@@ -288,7 +291,7 @@ void CreateSphereData() {
 }
 
 void InitColViewer() {
-    LUS::AddWindow("Developer Tools", "Collision Viewer", DrawColViewerWindow);
+    LUS::AddWindow("Developer Tools", "Collision Viewer", DrawColViewerWindow, CVarGetInteger("gCollisionViewerEnabled", 0));
 
     CreateCylinderData();
     CreateSphereData();

--- a/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
+++ b/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
@@ -1733,7 +1733,10 @@ void DrawPlayerTab() {
 
 void DrawSaveEditor(bool& open) {
     if (!open) {
-        CVarSetInteger("gSaveEditorEnabled", 0);
+        if (CVarGetInteger("gSaveEditorEnabled", 0)) {
+            CVarClear("gSaveEditorEnabled");
+            LUS::RequestCvarSaveOnNextTick();
+        }
         return;
     }
 
@@ -1781,7 +1784,7 @@ void DrawSaveEditor(bool& open) {
 }
 
 void InitSaveEditor() {
-    LUS::AddWindow("Developer Tools", "Save Editor", DrawSaveEditor);
+    LUS::AddWindow("Developer Tools", "Save Editor", DrawSaveEditor, CVarGetInteger("gSaveEditorEnabled", 0));
 
     // Load item icons into ImGui
     for (const auto& entry : itemMapping) {

--- a/soh/soh/Enhancements/debugger/dlViewer.cpp
+++ b/soh/soh/Enhancements/debugger/dlViewer.cpp
@@ -40,7 +40,10 @@ std::map<int, std::string> cmdMap = {
 
 void DrawDLViewer(bool& open) {
     if (!open) {
-        CVarSetInteger("gDLViewerEnabled", 0);
+        if (CVarGetInteger("gDLViewerEnabled", 0)) {
+            CVarClear("gDLViewerEnabled");
+            LUS::RequestCvarSaveOnNextTick();
+        }
         return;
     }
 
@@ -138,7 +141,7 @@ void DrawDLViewer(bool& open) {
 }
 
 void InitDLViewer() {
-    LUS::AddWindow("Developer Tools", "Display List Viewer", DrawDLViewer);
+    LUS::AddWindow("Developer Tools", "Display List Viewer", DrawDLViewer, CVarGetInteger("gDLViewerEnabled", 0));
 
     displayListsSearchResults = ResourceMgr_ListFiles("*DL", &displayListsSearchResultsCount);
 }

--- a/soh/soh/Enhancements/gameplaystats.cpp
+++ b/soh/soh/Enhancements/gameplaystats.cpp
@@ -263,7 +263,10 @@ std::string ResolveSceneID(int sceneID, int roomID){
 
 void DrawStatsTracker(bool& open) {
     if (!open) {
-        CVarSetInteger("gGameplayStatsEnabled", 0);
+        if (CVarGetInteger("gGameplayStatsEnabled", 0)) {
+            CVarClear("gGameplayStatsEnabled");
+            LUS::RequestCvarSaveOnNextTick();
+        }
         return;
     }
 
@@ -667,8 +670,7 @@ void SetupDisplayColors() {
 }
 
 extern "C" void InitStatTracker() {
-    LUS::AddWindow("Enhancements", "Gameplay Stats", DrawStatsTracker,
-                    CVarGetInteger("gGameplayStatsEnabled", 0) == 1);
+    LUS::AddWindow("Enhancements", "Gameplay Stats", DrawStatsTracker, CVarGetInteger("gGameplayStatsEnabled", 0));
     SetupDisplayNames();
     SetupDisplayColors();
 }

--- a/soh/soh/Enhancements/mods.cpp
+++ b/soh/soh/Enhancements/mods.cpp
@@ -152,7 +152,7 @@ void RegisterFreezeTime() {
             int32_t prevTime = CVarGetInteger("gPrevTime", gSaveContext.dayTime);
             gSaveContext.dayTime = prevTime;
         } else {
-            CVarSetInteger("gPrevTime", -1);
+            CVarClear("gPrevTime");
         }
     });
 }

--- a/soh/soh/Enhancements/randomizer/draw.cpp
+++ b/soh/soh/Enhancements/randomizer/draw.cpp
@@ -12,7 +12,7 @@
 
 extern "C" void Randomizer_DrawSmallKey(PlayState* play, GetItemEntry* getItemEntry) {
     s32 pad;
-    s8 isColoredKeysEnabled = CVarGetInteger("gRandoMatchKeyColors", 0);
+    s8 isColoredKeysEnabled = CVarGetInteger("gRandoMatchKeyColors", 1);
     s16 color_slot = getItemEntry->getItemId - RG_FOREST_TEMPLE_SMALL_KEY;
     s16 colors[9][3] = {
         { 4, 195, 46 },    // Forest Temple
@@ -49,7 +49,7 @@ extern "C" void Randomizer_DrawSmallKey(PlayState* play, GetItemEntry* getItemEn
 
 extern "C" void Randomizer_DrawBossKey(PlayState* play, GetItemEntry* getItemEntry) {
     s32 pad;
-    s8 isColoredKeysEnabled = CVarGetInteger("gRandoMatchKeyColors", 0);
+    s8 isColoredKeysEnabled = CVarGetInteger("gRandoMatchKeyColors", 1);
     s16 color_slot;
     color_slot = getItemEntry->getItemId - RG_FOREST_TEMPLE_BOSS_KEY;
     s16 colors[6][3] = {

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -3090,7 +3090,10 @@ void DrawRandoEditor(bool& open) {
     }
 
     if (!open) {
-        CVarSetInteger("gRandomizerSettingsEnabled", 0);
+        if (CVarGetInteger("gRandomizerSettingsEnabled", 0)) {
+            CVarClear("gRandomizerSettingsEnabled");
+            LUS::RequestCvarSaveOnNextTick();
+        }
         return;
     }
 
@@ -5452,7 +5455,7 @@ void InitRandoItemTable() {
 
 
 void InitRando() {
-    LUS::AddWindow("Randomizer", "Randomizer Settings", DrawRandoEditor);
+    LUS::AddWindow("Randomizer", "Randomizer Settings", DrawRandoEditor, CVarGetInteger("gRandomizerSettingsEnabled", 0));
     Randomizer::CreateCustomMessages();
     seedString = (char*)calloc(MAX_SEED_STRING_SIZE, sizeof(char));
     InitRandoItemTable();

--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -110,7 +110,10 @@ std::vector<uint32_t> buttons = { BTN_A, BTN_B, BTN_CUP,   BTN_CDOWN, BTN_CLEFT,
 
 void DrawCheckTracker(bool& open) {
     if (!open) {
-        CVarSetInteger("gCheckTrackerEnabled", 0);
+        if (CVarGetInteger("gCheckTrackerEnabled", 0)) {
+            CVarClear("gCheckTrackerEnabled");
+            LUS::RequestCvarSaveOnNextTick();
+        }
         return;
     }
 
@@ -962,7 +965,10 @@ static const char* buttonStrings[] = { "A Button", "B Button", "C-Up",  "C-Down"
                                        "Z Button", "R Button", "Start", "D-Up",   "D-Down", "D-Left",  "D-Right" };
 void DrawCheckTrackerOptions(bool& open) {
     if (!open) {
-        CVarSetInteger("gCheckTrackerSettingsEnabled", 0);
+        if (CVarGetInteger("gCheckTrackerSettingsEnabled", 0)) {
+            CVarClear("gCheckTrackerSettingsEnabled");
+            LUS::RequestCvarSaveOnNextTick();
+        }
         return;
     }
 
@@ -1023,8 +1029,8 @@ void DrawCheckTrackerOptions(bool& open) {
 }
 
 void InitCheckTracker() {
-    LUS::AddWindow("Randomizer", "Check Tracker", DrawCheckTracker, CVarGetInteger("gCheckTrackerEnabled", 0) == 1);
-    LUS::AddWindow("Randomizer", "Check Tracker Settings", DrawCheckTrackerOptions);
+    LUS::AddWindow("Randomizer", "Check Tracker", DrawCheckTracker, CVarGetInteger("gCheckTrackerEnabled", 0));
+    LUS::AddWindow("Randomizer", "Check Tracker Settings", DrawCheckTrackerOptions, CVarGetInteger("gCheckTrackerSettingsEnabled", 0));
     Color_Background = CVarGetColor("gCheckTrackerBgColor", Color_Bg_Default);
     Color_Area_Incomplete_Main  = CVarGetColor("gCheckTrackerAreaMainIncompleteColor",    Color_Main_Default);
     Color_Area_Incomplete_Extra = CVarGetColor("gCheckTrackerAreaExtraIncompleteColor",   Color_Area_Incomplete_Extra_Default);

--- a/soh/soh/Enhancements/randomizer/randomizer_entrance_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_entrance_tracker.cpp
@@ -623,7 +623,10 @@ void InitEntranceTrackingData() {
 
 void DrawEntranceTracker(bool& open) {
     if (!open) {
-        CVarSetInteger("gEntranceTrackerEnabled", 0);
+        if (CVarGetInteger("gEntranceTrackerEnabled", 0)) {
+            CVarClear("gEntranceTrackerEnabled");
+            LUS::RequestCvarSaveOnNextTick();
+        }
         return;
     }
 
@@ -919,8 +922,7 @@ void DrawEntranceTracker(bool& open) {
 }
 
 void InitEntranceTracker() {
-    LUS::AddWindow("Randomizer", "Entrance Tracker", DrawEntranceTracker,
-                    CVarGetInteger("gEntranceTrackerEnabled", 0) == 1);
+    LUS::AddWindow("Randomizer", "Entrance Tracker", DrawEntranceTracker, CVarGetInteger("gEntranceTrackerEnabled", 0));
 
     // Setup hooks for loading and clearing the entrance tracker data
     GameInteractor::Instance->RegisterGameHook<GameInteractor::OnLoadGame>([](int32_t fileNum) {

--- a/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
@@ -851,7 +851,10 @@ void UpdateVectors() {
 void DrawItemTracker(bool& open) {
     UpdateVectors();
     if (!open) {
-        CVarSetInteger("gItemTrackerEnabled", 0);
+        if (CVarGetInteger("gItemTrackerEnabled", 0)) {
+            CVarClear("gItemTrackerEnabled");
+            LUS::RequestCvarSaveOnNextTick();
+        }
         return;
     }
     int iconSize = CVarGetInteger("gItemTrackerIconSize", 36);
@@ -959,7 +962,10 @@ static const char* extendedDisplayTypes[4] = { "Hidden", "Main Window", "Misc Wi
 
 void DrawItemTrackerOptions(bool& open) {
     if (!open) {
-        CVarSetInteger("gItemTrackerSettingsEnabled", 0);
+        if (CVarGetInteger("gItemTrackerSettingsEnabled", 0)) {
+            CVarClear("gItemTrackerSettingsEnabled");
+            LUS::RequestCvarSaveOnNextTick();
+        }
         return;
     }
 
@@ -1081,8 +1087,8 @@ void DrawItemTrackerOptions(bool& open) {
 }
 
 void InitItemTracker() {
-    LUS::AddWindow("Randomizer", "Item Tracker", DrawItemTracker, CVarGetInteger("gItemTrackerEnabled", 0) == 1);
-    LUS::AddWindow("Randomizer", "Item Tracker Settings", DrawItemTrackerOptions);
+    LUS::AddWindow("Randomizer", "Item Tracker", DrawItemTracker, CVarGetInteger("gItemTrackerEnabled", 0));
+    LUS::AddWindow("Randomizer", "Item Tracker Settings", DrawItemTrackerOptions, CVarGetInteger("gItemTrackerSettingsEnabled", 0));
     float trackerBgR = CVarGetFloat("gItemTrackerBgColorR", 0);
     float trackerBgG = CVarGetFloat("gItemTrackerBgColorG", 0);
     float trackerBgB = CVarGetFloat("gItemTrackerBgColorB", 0);

--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -162,8 +162,11 @@ namespace GameMenuBar {
                 ImGui::PushStyleColor(ImGuiCol_Border, ImVec4(0.22f, 0.38f, 0.56f, 1.0f));
                 if (ImGui::Button(GetWindowButtonText("Controller Configuration", CVarGetInteger("gControllerConfigurationEnabled", 0)).c_str(), ImVec2 (-1.0f, 0.0f)))
                 {
-                    bool currentValue = CVarGetInteger("gControllerConfigurationEnabled", 0);
-                    CVarSetInteger("gControllerConfigurationEnabled", !currentValue);
+                    if (CVarGetInteger("gControllerConfigurationEnabled", 0)) {
+                        CVarClear("gControllerConfigurationEnabled");
+                    } else {
+                        CVarSetInteger("gControllerConfigurationEnabled", 1);
+                    }
                     LUS::RequestCvarSaveOnNextTick();
                     LUS::ToggleInputEditorWindow(CVarGetInteger("gControllerConfigurationEnabled", 0));
                 }
@@ -337,7 +340,7 @@ namespace GameMenuBar {
                 }
 
                 if (LUS::SupportsViewports()) {
-                    UIWidgets::PaddedEnhancementCheckbox("Allow multi-windows", "gEnableMultiViewports", true, false);
+                    UIWidgets::PaddedEnhancementCheckbox("Allow multi-windows", "gEnableMultiViewports", true, false, false, "", UIWidgets::CheckboxGraphics::Cross, true);
                     UIWidgets::Tooltip("Allows windows to be able to be dragged off of the main game window. Requires a reload to take effect.");
                 }
 
@@ -887,11 +890,13 @@ namespace GameMenuBar {
                 UIWidgets::Tooltip("Correctly centers the Navi text prompt on the HUD's C-Up button");
                 UIWidgets::PaddedEnhancementCheckbox("Fix Anubis fireballs", "gAnubisFix", true, false);
                 UIWidgets::Tooltip("Make Anubis fireballs do fire damage when reflected back at them with the Mirror Shield");
-                UIWidgets::PaddedEnhancementCheckbox("Fix Megaton Hammer crouch stab", "gCrouchStabHammerFix", true, false);
+                if (UIWidgets::PaddedEnhancementCheckbox("Fix Megaton Hammer crouch stab", "gCrouchStabHammerFix", true, false)) {
+                    if (!CVarGetInteger("gCrouchStabHammerFix", 0)) {
+                        CVarClear("gCrouchStabFix");
+                    }
+                }
                 UIWidgets::Tooltip("Make the Megaton Hammer's crouch stab able to destroy rocks without first swinging it normally");
-                if (CVarGetInteger("gCrouchStabHammerFix", 0) == 0) {
-                    CVarSetInteger("gCrouchStabFix", 0);
-                } else {
+                if (CVarGetInteger("gCrouchStabHammerFix", 0)) {
                     UIWidgets::PaddedEnhancementCheckbox("Remove power crouch stab", "gCrouchStabFix", true, false);
                     UIWidgets::Tooltip("Make crouch stabbing always do the same damage as a regular slash");
                 }
@@ -980,28 +985,40 @@ namespace GameMenuBar {
 
             if (ImGui::Button(GetWindowButtonText("Customize Game Controls", CVarGetInteger("gGameControlEditorEnabled", 0)).c_str(), ImVec2(-1.0f, 0.0f)))
             {
-                bool currentValue = CVarGetInteger("gGameControlEditorEnabled", 0);
-                CVarSetInteger("gGameControlEditorEnabled", !currentValue);
+                if (CVarGetInteger("gGameControlEditorEnabled", 0)) {
+                    CVarClear("gGameControlEditorEnabled");
+                } else {
+                    CVarSetInteger("gGameControlEditorEnabled", 1);
+                }
                 LUS::RequestCvarSaveOnNextTick();
                 LUS::EnableWindow("Game Control Editor", CVarGetInteger("gGameControlEditorEnabled", 0));
             }
             if (ImGui::Button(GetWindowButtonText("Cosmetics Editor", CVarGetInteger("gCosmeticsEditorEnabled", 0)).c_str(), ImVec2(-1.0f, 0.0f)))
             {
-                bool currentValue = CVarGetInteger("gCosmeticsEditorEnabled", 0);
-                CVarSetInteger("gCosmeticsEditorEnabled", !currentValue);
+                if (CVarGetInteger("gCosmeticsEditorEnabled", 0)) {
+                    CVarClear("gCosmeticsEditorEnabled");
+                } else {
+                    CVarSetInteger("gCosmeticsEditorEnabled", 1);
+                }
                 LUS::RequestCvarSaveOnNextTick();
                 LUS::EnableWindow("Cosmetics Editor", CVarGetInteger("gCosmeticsEditorEnabled", 0));
             }
             if (ImGui::Button(GetWindowButtonText("Audio Editor", CVarGetInteger("gAudioEditor.WindowOpen", 0)).c_str(), ImVec2(-1.0f, 0.0f)))
             {
-                bool currentValue = CVarGetInteger("gAudioEditor.WindowOpen", 0);
-                CVarSetInteger("gAudioEditor.WindowOpen", !currentValue);
+                if (CVarGetInteger("gAudioEditor.WindowOpen", 0)) {
+                    CVarClear("gAudioEditor.WindowOpen");
+                } else {
+                    CVarSetInteger("gAudioEditor.WindowOpen", 1);
+                }
                 LUS::RequestCvarSaveOnNextTick();
                 LUS::EnableWindow("Audio Editor", CVarGetInteger("gAudioEditor.WindowOpen", 0));
             }
             if (ImGui::Button(GetWindowButtonText("Gameplay Stats", CVarGetInteger("gGameplayStatsEnabled", 0)).c_str(), ImVec2(-1.0f, 0.0f))) {
-                bool currentValue = CVarGetInteger("gGameplayStatsEnabled", 0);
-                CVarSetInteger("gGameplayStatsEnabled", !currentValue);
+                if (CVarGetInteger("gGameplayStatsEnabled", 0)) {
+                    CVarClear("gGameplayStatsEnabled");
+                } else {
+                    CVarSetInteger("gGameplayStatsEnabled", 1);
+                }
                 LUS::RequestCvarSaveOnNextTick();
                 LUS::EnableWindow("Gameplay Stats", CVarGetInteger("gGameplayStatsEnabled", 0));
             }
@@ -1114,7 +1131,7 @@ namespace GameMenuBar {
                 }
                 else {
                     lastBetaQuestWorld = betaQuestWorld = 0xFFEF;
-                    CVarSetInteger("gBetaQuestWorld", betaQuestWorld);
+                    CVarClear("gBetaQuestWorld");
                 }
                 if (betaQuestEnabled != lastBetaQuestEnabled || betaQuestWorld != lastBetaQuestWorld)
                 {
@@ -1158,7 +1175,7 @@ namespace GameMenuBar {
             };
             UIWidgets::PaddedEnhancementCheckbox("Better Debug Warp Screen", "gBetterDebugWarpScreen", true, false);
             UIWidgets::Tooltip("Optimized debug warp screen, with the added ability to chose entrances and time of day");
-            UIWidgets::PaddedEnhancementCheckbox("Debug Warp Screen Translation", "gDebugWarpScreenTranslation", true, false);
+            UIWidgets::PaddedEnhancementCheckbox("Debug Warp Screen Translation", "gDebugWarpScreenTranslation", true, false, false, "", UIWidgets::CheckboxGraphics::Cross, true);
             UIWidgets::Tooltip("Translate the Debug Warp Screen based on the game language");
             UIWidgets::PaddedSeparator();
             ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(12.0f, 6.0f));
@@ -1167,50 +1184,68 @@ namespace GameMenuBar {
             ImGui::PushStyleColor(ImGuiCol_Border, ImVec4(0.22f, 0.38f, 0.56f, 1.0f));
             if (ImGui::Button(GetWindowButtonText("Stats", CVarGetInteger("gStatsEnabled", 0)).c_str(), ImVec2(-1.0f, 0.0f)))
             {
-                bool currentValue = CVarGetInteger("gStatsEnabled", 0);
-                CVarSetInteger("gStatsEnabled", !currentValue);
-                LUS::ToggleStatisticsWindow(true);
+                if (CVarGetInteger("gStatsEnabled", 0)) {
+                    CVarClear("gStatsEnabled");
+                } else {
+                    CVarSetInteger("gStatsEnabled", 1);
+                }
+                LUS::ToggleStatisticsWindow(CVarGetInteger("gStatsEnabled", 0));
                 LUS::RequestCvarSaveOnNextTick();
             }
             UIWidgets::Tooltip("Shows the stats window, with your FPS and frametimes, and the OS you're playing on");
             UIWidgets::Spacer(0);
             if (ImGui::Button(GetWindowButtonText("Console", CVarGetInteger("gConsoleEnabled", 0)).c_str(), ImVec2(-1.0f, 0.0f)))
             {
-                bool currentValue = CVarGetInteger("gConsoleEnabled", 0);
-                CVarSetInteger("gConsoleEnabled", !currentValue);
+                if (CVarGetInteger("gConsoleEnabled", 0)) {
+                    CVarClear("gConsoleEnabled");
+                } else {
+                    CVarSetInteger("gConsoleEnabled", 1);
+                }
                 LUS::RequestCvarSaveOnNextTick();
-                LUS::ToggleConsoleWindow(!currentValue);
+                LUS::ToggleConsoleWindow(CVarGetInteger("gConsoleEnabled", 0));
             }
             UIWidgets::Tooltip("Enables the console window, allowing you to input commands, type help for some examples");
             UIWidgets::Spacer(0);
             if (ImGui::Button(GetWindowButtonText("Save Editor", CVarGetInteger("gSaveEditorEnabled", 0)).c_str(), ImVec2(-1.0f, 0.0f)))
             {
-                bool currentValue = CVarGetInteger("gSaveEditorEnabled", 0);
-                CVarSetInteger("gSaveEditorEnabled", !currentValue);
+                if (CVarGetInteger("gSaveEditorEnabled", 0)) {
+                    CVarClear("gSaveEditorEnabled");
+                } else {
+                    CVarSetInteger("gSaveEditorEnabled", 1);
+                }
                 LUS::RequestCvarSaveOnNextTick();
                 LUS::EnableWindow("Save Editor", CVarGetInteger("gSaveEditorEnabled", 0));
             }
             UIWidgets::Spacer(0);
             if (ImGui::Button(GetWindowButtonText("Collision Viewer", CVarGetInteger("gCollisionViewerEnabled", 0)).c_str(), ImVec2(-1.0f, 0.0f)))
             {
-                bool currentValue = CVarGetInteger("gCollisionViewerEnabled", 0);
-                CVarSetInteger("gCollisionViewerEnabled", !currentValue);
+                if (CVarGetInteger("gCollisionViewerEnabled", 0)) {
+                    CVarClear("gCollisionViewerEnabled");
+                } else {
+                    CVarSetInteger("gCollisionViewerEnabled", 1);
+                }
                 LUS::RequestCvarSaveOnNextTick();
                 LUS::EnableWindow("Collision Viewer", CVarGetInteger("gCollisionViewerEnabled", 0));
             }
             UIWidgets::Spacer(0);
             if (ImGui::Button(GetWindowButtonText("Actor Viewer", CVarGetInteger("gActorViewerEnabled", 0)).c_str(), ImVec2(-1.0f, 0.0f)))
             {
-                bool currentValue = CVarGetInteger("gActorViewerEnabled", 0);
-                CVarSetInteger("gActorViewerEnabled", !currentValue);
+                if (CVarGetInteger("gActorViewerEnabled", 0)) {
+                    CVarClear("gActorViewerEnabled");
+                } else {
+                    CVarSetInteger("gActorViewerEnabled", 1);
+                }
                 LUS::RequestCvarSaveOnNextTick();
                 LUS::EnableWindow("Actor Viewer", CVarGetInteger("gActorViewerEnabled", 0));
             }
             UIWidgets::Spacer(0);
             if (ImGui::Button(GetWindowButtonText("Display List Viewer", CVarGetInteger("gDLViewerEnabled", 0)).c_str(), ImVec2(-1.0f, 0.0f)))
             {
-                bool currentValue = CVarGetInteger("gDLViewerEnabled", 0);
-                CVarSetInteger("gDLViewerEnabled", !currentValue);
+                if (CVarGetInteger("gDLViewerEnabled", 0)) {
+                    CVarClear("gDLViewerEnabled");
+                } else {
+                    CVarSetInteger("gDLViewerEnabled", 1);
+                }
                 LUS::RequestCvarSaveOnNextTick();
                 LUS::EnableWindow("Display List Viewer", CVarGetInteger("gDLViewerEnabled", 0));
             }
@@ -1235,48 +1270,66 @@ namespace GameMenuBar {
         #endif
             if (ImGui::Button(GetWindowButtonText("Randomizer Settings", CVarGetInteger("gRandomizerSettingsEnabled", 0)).c_str(), buttonSize))
             {
-                bool currentValue = CVarGetInteger("gRandomizerSettingsEnabled", 0);
-                CVarSetInteger("gRandomizerSettingsEnabled", !currentValue);
+                if (CVarGetInteger("gRandomizerSettingsEnabled", 0)) {
+                    CVarClear("gRandomizerSettingsEnabled");
+                } else {
+                    CVarSetInteger("gRandomizerSettingsEnabled", 1);
+                }
                 LUS::RequestCvarSaveOnNextTick();
                 LUS::EnableWindow("Randomizer Settings", CVarGetInteger("gRandomizerSettingsEnabled", 0));
             }
             UIWidgets::Spacer(0);
             if (ImGui::Button(GetWindowButtonText("Item Tracker", CVarGetInteger("gItemTrackerEnabled", 0)).c_str(), buttonSize))
             {
-                bool currentValue = CVarGetInteger("gItemTrackerEnabled", 0);
-                CVarSetInteger("gItemTrackerEnabled", !currentValue);
+                if (CVarGetInteger("gItemTrackerEnabled", 0)) {
+                    CVarClear("gItemTrackerEnabled");
+                } else {
+                    CVarSetInteger("gItemTrackerEnabled", 1);
+                }
                 LUS::RequestCvarSaveOnNextTick();
                 LUS::EnableWindow("Item Tracker", CVarGetInteger("gItemTrackerEnabled", 0));
             }
             UIWidgets::Spacer(0);
             if (ImGui::Button(GetWindowButtonText("Item Tracker Settings", CVarGetInteger("gItemTrackerSettingsEnabled", 0)).c_str(), buttonSize))
             {
-                bool currentValue = CVarGetInteger("gItemTrackerSettingsEnabled", 0);
-                CVarSetInteger("gItemTrackerSettingsEnabled", !currentValue);
+                if (CVarGetInteger("gItemTrackerSettingsEnabled", 0)) {
+                    CVarClear("gItemTrackerSettingsEnabled");
+                } else {
+                    CVarSetInteger("gItemTrackerSettingsEnabled", 1);
+                }
                 LUS::RequestCvarSaveOnNextTick();
                 LUS::EnableWindow("Item Tracker Settings", CVarGetInteger("gItemTrackerSettingsEnabled", 0));
             }
             UIWidgets::Spacer(0);
             if (ImGui::Button(GetWindowButtonText("Entrance Tracker", CVarGetInteger("gEntranceTrackerEnabled", 0)).c_str(), buttonSize))
             {
-                bool currentValue = CVarGetInteger("gEntranceTrackerEnabled", 0);
-                CVarSetInteger("gEntranceTrackerEnabled", !currentValue);
+                if (CVarGetInteger("gEntranceTrackerEnabled", 0)) {
+                    CVarClear("gEntranceTrackerEnabled");
+                } else {
+                    CVarSetInteger("gEntranceTrackerEnabled", 1);
+                }
                 LUS::RequestCvarSaveOnNextTick();
                 LUS::EnableWindow("Entrance Tracker", CVarGetInteger("gEntranceTrackerEnabled", 0));
             }
             UIWidgets::Spacer(0);
             if (ImGui::Button(GetWindowButtonText("Check Tracker", CVarGetInteger("gCheckTrackerEnabled", 0)).c_str(), buttonSize))
             {
-                bool currentValue = CVarGetInteger("gCheckTrackerEnabled", 0);
-                CVarSetInteger("gCheckTrackerEnabled", !currentValue);
+                if (CVarGetInteger("gCheckTrackerEnabled", 0)) {
+                    CVarClear("gCheckTrackerEnabled");
+                } else {
+                    CVarSetInteger("gCheckTrackerEnabled", 1);
+                }
                 LUS::RequestCvarSaveOnNextTick();
                 LUS::EnableWindow("Check Tracker", CVarGetInteger("gCheckTrackerEnabled", 0));
             }
             UIWidgets::Spacer(0);
             if (ImGui::Button(GetWindowButtonText("Check Tracker Settings", CVarGetInteger("gCheckTrackerSettingsEnabled", 0)).c_str(), buttonSize))
             {
-                bool currentValue = CVarGetInteger("gCheckTrackerSettingsEnabled", 0);
-                CVarSetInteger("gCheckTrackerSettingsEnabled", !currentValue);
+                if (CVarGetInteger("gCheckTrackerSettingsEnabled", 0)) {
+                    CVarClear("gCheckTrackerSettingsEnabled");
+                } else {
+                    CVarSetInteger("gCheckTrackerSettingsEnabled", 1);
+                }
                 LUS::RequestCvarSaveOnNextTick();
                 LUS::EnableWindow("Check Tracker Settings", CVarGetInteger("gCheckTrackerSettingsEnabled", 0));
             }
@@ -1287,11 +1340,11 @@ namespace GameMenuBar {
 
             if (ImGui::BeginMenu("Rando Enhancements"))
             {
-                UIWidgets::EnhancementCheckbox("Rando-Relevant Navi Hints", "gRandoRelevantNavi");
+                UIWidgets::EnhancementCheckbox("Rando-Relevant Navi Hints", "gRandoRelevantNavi", false, "", UIWidgets::CheckboxGraphics::Cross, true);
                 UIWidgets::Tooltip(
                     "Replace Navi's overworld quest hints with rando-related gameplay hints."
                 );
-                UIWidgets::PaddedEnhancementCheckbox("Random Rupee Names", "gRandomizeRupeeNames", true, false);
+                UIWidgets::PaddedEnhancementCheckbox("Random Rupee Names", "gRandomizeRupeeNames", true, false, false, "", UIWidgets::CheckboxGraphics::Cross, true);
                 UIWidgets::Tooltip(
                     "When obtaining rupees, randomize what the rupee is called in the textbox."
                 );
@@ -1318,7 +1371,7 @@ namespace GameMenuBar {
                     "shuffle settings set to \"Any Dungeon\", \"Overworld\" or \"Anywhere\"";
 
                 UIWidgets::PaddedEnhancementCheckbox("Key Colors Match Dungeon", "gRandoMatchKeyColors", true, false,
-                                                     disableKeyColors, disableKeyColorsText);
+                                                     disableKeyColors, disableKeyColorsText, UIWidgets::CheckboxGraphics::Cross, true);
                 UIWidgets::Tooltip(
                     "Matches the color of small keys and boss keys to the dungeon they belong to. "
                     "This helps identify keys from afar and adds a little bit of flair.\n\nThis only "

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -1883,7 +1883,7 @@ extern "C" int CustomMessage_RetrieveIfExists(PlayState* play) {
                 RandomizerInf randoInf = (RandomizerInf)((textId - (TEXT_SHOP_ITEM_RANDOM + NUM_SHOP_ITEMS)) + RAND_INF_SHOP_ITEMS_KF_SHOP_ITEM_1);
                 messageEntry = OTRGlobals::Instance->gRandomizer->GetMerchantMessage(randoInf, TEXT_SHOP_ITEM_RANDOM_CONFIRM);
             }
-        } else if (CVarGetInteger("gRandomizeRupeeNames", 0) &&
+        } else if (CVarGetInteger("gRandomizeRupeeNames", 1) &&
                    (textId == TEXT_BLUE_RUPEE || textId == TEXT_RED_RUPEE || textId == TEXT_PURPLE_RUPEE ||
                    textId == TEXT_HUGE_RUPEE)) {
             messageEntry = Randomizer::GetRupeeMessage(textId);

--- a/soh/src/overlays/gamestates/ovl_select/z_select.c
+++ b/soh/src/overlays/gamestates/ovl_select/z_select.c
@@ -1035,7 +1035,7 @@ void Select_PrintMenu(SelectContext* this, GfxPrint* printer) {
             GfxPrint_SetColor(printer, 200, 200, 55, 255);
         }
 
-        if (CVarGetInteger("gDebugWarpScreenTranslation", 0)) {
+        if (CVarGetInteger("gDebugWarpScreenTranslation", 1)) {
             switch (gSaveContext.language) {
                 case LANGUAGE_ENG:
                 default:
@@ -1062,7 +1062,7 @@ void Select_PrintMenu(SelectContext* this, GfxPrint* printer) {
     GfxPrint_SetColor(printer, 155, 55, 150, 255);
 
     // Small position hack of the OPT=X text since german Link's Age overlap if translated
-    if (CVarGetInteger("gDebugWarpScreenTranslation", 0) && gSaveContext.language == LANGUAGE_GER) {
+    if (CVarGetInteger("gDebugWarpScreenTranslation", 1) && gSaveContext.language == LANGUAGE_GER) {
         GfxPrint_SetPos(printer, 26, 26);
     } else {
         GfxPrint_SetPos(printer, 20, 26);
@@ -1091,7 +1091,7 @@ void Better_Select_PrintMenu(SelectContext* this, GfxPrint* printer) {
             GfxPrint_SetColor(printer, 175, 175, 175, 255);
         }
         
-        if (CVarGetInteger("gDebugWarpScreenTranslation", 0)) {
+        if (CVarGetInteger("gDebugWarpScreenTranslation", 1)) {
             switch (gSaveContext.language) {
                 case LANGUAGE_ENG:
                 default:
@@ -1117,7 +1117,7 @@ void Better_Select_PrintMenu(SelectContext* this, GfxPrint* printer) {
     GfxPrint_SetColor(printer, 205, 100, 200, 255);
     GfxPrint_SetPos(printer, 3, 26);
 
-    if (CVarGetInteger("gDebugWarpScreenTranslation", 0)) {
+    if (CVarGetInteger("gDebugWarpScreenTranslation", 1)) {
         switch (gSaveContext.language) {
             case LANGUAGE_ENG:
             default:
@@ -1157,7 +1157,7 @@ void Select_PrintLoadingMessage(SelectContext* this, GfxPrint* printer) {
     GfxPrint_SetPos(printer, 10, 15);
     GfxPrint_SetColor(printer, 255, 255, 255, 255);
     randomMsg = Rand_ZeroOne() * ARRAY_COUNT(sLoadingMessages);
-    if (CVarGetInteger("gDebugWarpScreenTranslation", 0)) {
+    if (CVarGetInteger("gDebugWarpScreenTranslation", 1)) {
         switch (gSaveContext.language) {
             case LANGUAGE_ENG:
             default:
@@ -1188,7 +1188,7 @@ static BetterSceneSelectAgeLabels sBetterAgeLabels[] = {
 void Select_PrintAgeSetting(SelectContext* this, GfxPrint* printer, s32 age) {
     GfxPrint_SetPos(printer, 4, 26);
     GfxPrint_SetColor(printer, 255, 255, 55, 255);
-    if (CVarGetInteger("gDebugWarpScreenTranslation", 0)) {
+    if (CVarGetInteger("gDebugWarpScreenTranslation", 1)) {
         switch (gSaveContext.language) {
             case LANGUAGE_ENG:
             default:
@@ -1209,7 +1209,7 @@ void Select_PrintAgeSetting(SelectContext* this, GfxPrint* printer, s32 age) {
 void Better_Select_PrintAgeSetting(SelectContext* this, GfxPrint* printer, s32 age) {
     GfxPrint_SetPos(printer, 25, 25);
     GfxPrint_SetColor(printer, 100, 100, 100, 255);
-    if (CVarGetInteger("gDebugWarpScreenTranslation", 0)) {
+    if (CVarGetInteger("gDebugWarpScreenTranslation", 1)) {
         switch (gSaveContext.language) {
             case LANGUAGE_ENG:
             case LANGUAGE_FRA:
@@ -1225,7 +1225,7 @@ void Better_Select_PrintAgeSetting(SelectContext* this, GfxPrint* printer, s32 a
     }
     
     GfxPrint_SetColor(printer, 55, 200, 50, 255);
-    if (CVarGetInteger("gDebugWarpScreenTranslation", 0)) {
+    if (CVarGetInteger("gDebugWarpScreenTranslation", 1)) {
         switch (gSaveContext.language) {
             case LANGUAGE_ENG:
             default:
@@ -1261,7 +1261,7 @@ void Select_PrintCutsceneSetting(SelectContext* this, GfxPrint* printer, u16 csI
     };
     
     char* label;
-    int lang = CVarGetInteger("gDebugWarpScreenTranslation", 0) ? gSaveContext.language + 1 : 0;
+    int lang = CVarGetInteger("gDebugWarpScreenTranslation", 1) ? gSaveContext.language + 1 : 0;
 
     GfxPrint_SetPos(printer, 4, 25);
     GfxPrint_SetColor(printer, 255, 255, 55, 255);
@@ -1324,7 +1324,7 @@ void Better_Select_PrintTimeSetting(SelectContext* this, GfxPrint* printer) {
     GfxPrint_SetColor(printer, 100, 100, 100, 255);
 
     if (gSaveContext.dayTime > 0xC000 || gSaveContext.dayTime < 0x4555) {
-        if (CVarGetInteger("gDebugWarpScreenTranslation", 0)) {
+        if (CVarGetInteger("gDebugWarpScreenTranslation", 1)) {
             switch (gSaveContext.language) {
                 case LANGUAGE_ENG:
                 default:
@@ -1341,7 +1341,7 @@ void Better_Select_PrintTimeSetting(SelectContext* this, GfxPrint* printer) {
             label = "Night";
         }
     } else {
-        if (CVarGetInteger("gDebugWarpScreenTranslation", 0)) {
+        if (CVarGetInteger("gDebugWarpScreenTranslation", 1)) {
             switch (gSaveContext.language) {
                 case LANGUAGE_ENG:
                 default:
@@ -1358,7 +1358,7 @@ void Better_Select_PrintTimeSetting(SelectContext* this, GfxPrint* printer) {
             label = "Day";
         }
     }
-    if (CVarGetInteger("gDebugWarpScreenTranslation", 0)) {
+    if (CVarGetInteger("gDebugWarpScreenTranslation", 1)) {
         switch (gSaveContext.language) {
             case LANGUAGE_ENG:
             default:


### PR DESCRIPTION
This PR aims to clean up the cvars so that when users back them up or share them they aren't littered with changes they didn't make.

This PR will be accompanied by a smaller PR to LUS (https://github.com/Kenix3/libultraship/pull/204)

This is achieved by:
- Fixing some issues where we were just setting cvars every frame
- Making UI checkboxes use defaultValue instead of setting it on startup
- Fixing some cvars that had incorrect default values

One intentional change with this PR is all windows are consistent now, and will preserve their open/close state through a restart. I see no reason why we should have inconsistency here anyway.

When booting + opening nav before this PR:
<img width="436" alt="Screenshot 2023-05-09 at 12 39 38 PM" src="https://github.com/HarbourMasters/Shipwright/assets/7316699/426147b3-41a0-4a0c-afd7-95962593c29d">

When booting + opening nav after this PR:
<img width="618" alt="Screenshot 2023-05-09 at 12 29 39 PM" src="https://github.com/HarbourMasters/Shipwright/assets/7316699/53a8ff60-f286-45f3-aa48-77e1e8ab1dec">


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/688420091.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/688420094.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/688420095.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/688420096.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/688420097.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/688420098.zip)
<!--- section:artifacts:end -->