### PR TITLE
Update cvar clear lists and add cheatCvars clear list(not currently used)

### DIFF
--- a/soh/soh/Enhancements/presets.h
+++ b/soh/soh/Enhancements/presets.h
@@ -44,6 +44,8 @@ typedef struct PresetEntry {
     { cvar, PRESET_ENTRY_TYPE_STRING, value }
 
 void DrawPresetSelector(PresetType presetType);
+void clearCvars(std::vector<const char*> cvarsToClear);
+void applyPreset(std::vector<PresetEntry> entries);
 
 // TODO: Ideally everything below this point will come from one/many JSON files
 
@@ -201,6 +203,61 @@ const std::vector<const char*> enhancementsCvars = {
     "gLowResMode",
     "gDrawLineupTick",
     "gQuickBongoKill",
+    "gDirtPathFix",
+    "gAuthenticLogo",
+    "gPauseLiveLinkRotationSpeed",
+    "gBowReticle",
+    "gFixTexturesOOB",
+    "gIvanCoopModeEnabled",
+};
+
+const std::vector<const char*> cheatCvars = {
+    "gConsoleEnabled",
+    "gActorViewerEnabled",
+    "gCollisionViewerEnabled",
+    "gDLViewerEnabled",
+    "gSaveEditorEnabled",
+    "gEnableWalkModify",
+    "gWalkSpeedToggle",
+    "gWalkModifierOne",
+    "gWalkModifierTwo",
+    "gGoronPot",
+    "gDampeWin",
+    "gCustomizeShootingGallery",
+    "gCustomizeBombchuBowling",
+    "gCustomizeFishing",
+    "gInfiniteAmmo",
+    "gInfiniteEpona",
+    "gInfiniteHealth",
+    "gInfiniteMagic",
+    "gInfiniteMoney",
+    "gInfiniteNayru",
+    "gNoClip",
+    "gClimbEverything",
+    "gHookshotEverything",
+    "gCheatHookshotReachMultiplier",
+    "gMoonJumpOnL",
+    "gSuperTunic",
+    "gEzISG",
+    "gTimelessEquipment",
+    "gCheatEasyPauseBufferEnabled",
+    "gCheatEasyInputBufferingEnabled",
+    "gNoRestrictItems",
+    "gFreezeTime",
+    "gPrevTime",
+    "gDropsDontDie",
+    "gFireproofDekuShield",
+    "gShieldTwoHanded",
+    "gTimeSync",
+    "gDebugEnabled",
+    "gSkulltulaDebugEnabled",
+    "gSkipLogoTitle",
+    "gSaveFileID",
+    "gEnableBetaQuest",
+    "gBetterDebugWarpScreen",
+    "gSwitchAge",
+    "gSwitchTimeline",
+    "gNoRedeadFreeze",
 };
 
 const std::vector<const char*> randomizerCvars = {
@@ -321,6 +378,10 @@ const std::vector<const char*> randomizerCvars = {
     "gRandomizeTokenCount",
     "gRandomizeWarpSongText",
     "gRandomizeZorasFountain",
+    "gRandomizeShuffle100GSReward",
+    "gRandomizeGregHint",
+    "gRandoManualSeedEntry",
+    "gRandomizerSettingsEnabled",
 };
 
 const std::vector<PresetEntry> vanillaPlusPresetEntries = {


### PR DESCRIPTION
I've been keeping the cheatCVars clear list locally for my speedrunning build, but figured it'd be good to get in, in case others want to use it.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/712660563.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/712660565.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/712660566.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/712660567.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/712660568.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/712660569.zip)
<!--- section:artifacts:end -->