### PR TITLE
CrowdControl 2.0: Fix several effects by no longer relying on received parameter to be 0

### DIFF
--- a/soh/soh/Enhancements/crowd-control/CrowdControl.cpp
+++ b/soh/soh/Enhancements/crowd-control/CrowdControl.cpp
@@ -417,6 +417,7 @@ CrowdControl::Effect* CrowdControl::ParseMessage(char payload[512]) {
             break;
         case kEffectFillHeart:
             effect->giEffect = new GameInteractionEffect::ModifyHealth();
+            effect->giEffect->parameters[0] = receivedParameter;
             break;
         case kEffectKnockbackLinkWeak:
             effect->giEffect = new GameInteractionEffect::KnockbackPlayer();
@@ -454,6 +455,7 @@ CrowdControl::Effect* CrowdControl::ParseMessage(char payload[512]) {
             break;
         case kEffectAddRupees:
             effect->giEffect = new GameInteractionEffect::ModifyRupees();
+            effect->giEffect->parameters[0] = receivedParameter;
             break;
         case kEffectGiveDekuShield:
             effect->giEffect = new GameInteractionEffect::GiveOrTakeShield();
@@ -465,26 +467,32 @@ CrowdControl::Effect* CrowdControl::ParseMessage(char payload[512]) {
             break;
         case kEffectRefillSticks:
             effect->giEffect = new GameInteractionEffect::AddOrTakeAmmo();
+            effect->giEffect->parameters[0] = receivedParameter;
             effect->giEffect->parameters[1] = ITEM_STICK;
             break;
         case kEffectRefillNuts:
             effect->giEffect = new GameInteractionEffect::AddOrTakeAmmo();
+            effect->giEffect->parameters[0] = receivedParameter;
             effect->giEffect->parameters[1] = ITEM_NUT;
             break;
         case kEffectRefillBombs:
             effect->giEffect = new GameInteractionEffect::AddOrTakeAmmo();
+            effect->giEffect->parameters[0] = receivedParameter;
             effect->giEffect->parameters[1] = ITEM_BOMB;
             break;
         case kEffectRefillSeeds:
             effect->giEffect = new GameInteractionEffect::AddOrTakeAmmo();
+            effect->giEffect->parameters[0] = receivedParameter;
             effect->giEffect->parameters[1] = ITEM_SLINGSHOT;
             break;
         case kEffectRefillArrows:
             effect->giEffect = new GameInteractionEffect::AddOrTakeAmmo();
+            effect->giEffect->parameters[0] = receivedParameter;
             effect->giEffect->parameters[1] = ITEM_BOW;
             break;
         case kEffectRefillBombchus:
             effect->giEffect = new GameInteractionEffect::AddOrTakeAmmo();
+            effect->giEffect->parameters[0] = receivedParameter;
             effect->giEffect->parameters[1] = ITEM_BOMBCHU;
             break;
 
@@ -809,16 +817,6 @@ CrowdControl::Effect* CrowdControl::ParseMessage(char payload[512]) {
 
         default:
             break;
-    }
-
-    // If no value is specifically set, default to using whatever CC sends us.
-    // Values are used for various things depending on the effect, but they 
-    // usually represent the "amount" of an effect. Amount of hearts healed,
-    // strength of knockback, etc.
-    if (effect->giEffect != NULL) {
-        if (!effect->giEffect->parameters[0]) {
-            effect->giEffect->parameters[0] = receivedParameter;
-        }
     }
 
     return effect;


### PR DESCRIPTION
I was relying on the parameter I receive from the CC client to be 0 by having a function assign the received parameter if I didn't set the parameter by myself. The 2.0 SDK indeed returns the parameter as 0 when not specifically set by effect quantities etc, but the live app was returning a parameter of 1.

This PR removes this reliance and builds on the parameter to be 0 when intializing it (this was already happening) instead, and assigning the received parameter manually whenever neccesary (essentially any effect that requires a positive quantity).

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/689048197.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/689048198.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/689048200.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/689048201.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/689048202.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/689048203.zip)
<!--- section:artifacts:end -->