### PR TITLE
Hyper boss - Several actor ID fixes

### DIFF
--- a/soh/soh/Enhancements/mods.cpp
+++ b/soh/soh/Enhancements/mods.cpp
@@ -408,11 +408,13 @@ void RegisterHyperBosses() {
         uint8_t isBossActor =
             actor->id == ACTOR_BOSS_GOMA ||                              // Gohma
             actor->id == ACTOR_BOSS_DODONGO ||                           // King Dodongo
+            actor->id == ACTOR_EN_BDFIRE ||                              // King Dodongo Fire Breath
             actor->id == ACTOR_BOSS_VA ||                                // Barinade
             actor->id == ACTOR_BOSS_GANONDROF ||                         // Phantom Ganon
-            (actor->id == 0 && actor->category == ACTORCAT_BOSS) ||      // Phantom Ganon/Ganondorf Energy Ball/Thunder
+            actor->id == ACTOR_EN_FHG_FIRE ||                            // Phantom Ganon/Ganondorf Energy Ball/Thunder
             actor->id == ACTOR_EN_FHG ||                                 // Phantom Ganon's Horse
             actor->id == ACTOR_BOSS_FD || actor->id == ACTOR_BOSS_FD2 || // Volvagia (grounded/flying)
+            actor->id == ACTOR_EN_VB_BALL ||                             // Volvagia Rocks
             actor->id == ACTOR_BOSS_MO ||                                // Morpha
             actor->id == ACTOR_BOSS_SST ||                               // Bongo Bongo
             actor->id == ACTOR_BOSS_TW ||                                // Twinrova

--- a/soh/src/overlays/actors/ovl_En_Bdfire/z_en_bdfire.c
+++ b/soh/src/overlays/actors/ovl_En_Bdfire/z_en_bdfire.c
@@ -19,7 +19,7 @@ void func_809BC2A4(EnBdfire* this, PlayState* play);
 void func_809BC598(EnBdfire* this, PlayState* play);
 
 const ActorInit En_Bdfire_InitVars = {
-    0,
+    ACTOR_EN_BDFIRE,
     ACTORCAT_ENEMY,
     FLAGS,
     OBJECT_KINGDODONGO,

--- a/soh/src/overlays/actors/ovl_En_Fhg_Fire/z_en_fhg_fire.c
+++ b/soh/src/overlays/actors/ovl_En_Fhg_Fire/z_en_fhg_fire.c
@@ -45,7 +45,7 @@ void EnFhgFire_EnergyBall(EnFhgFire* this, PlayState* play);
 void EnFhgFire_PhantomWarp(EnFhgFire* this, PlayState* play);
 
 const ActorInit En_Fhg_Fire_InitVars = {
-    0,
+    ACTOR_EN_FHG_FIRE,
     ACTORCAT_BOSS,
     FLAGS,
     OBJECT_FHG,

--- a/soh/src/overlays/actors/ovl_En_Goma/z_en_goma.c
+++ b/soh/src/overlays/actors/ovl_En_Goma/z_en_goma.c
@@ -44,7 +44,7 @@ void EnGoma_SetupJump(EnGoma* this);
 void EnGoma_SetupStunned(EnGoma* this, PlayState* play);
 
 const ActorInit En_Goma_InitVars = {
-    ACTOR_BOSS_GOMA,
+    ACTOR_EN_GOMA,
     ACTORCAT_ENEMY,
     FLAGS,
     OBJECT_GOL,

--- a/soh/src/overlays/actors/ovl_En_Vb_Ball/z_en_vb_ball.c
+++ b/soh/src/overlays/actors/ovl_En_Vb_Ball/z_en_vb_ball.c
@@ -17,7 +17,7 @@ void EnVbBall_Update(Actor* thisx, PlayState* play);
 void EnVbBall_Draw(Actor* thisx, PlayState* play);
 
 const ActorInit En_Vb_Ball_InitVars = {
-    0,
+    ACTOR_EN_VB_BALL,
     ACTORCAT_BOSS,
     FLAGS,
     OBJECT_FD,


### PR DESCRIPTION
Gohma larvae were sped up because they shared Gohma's ID even when sometimes outside of the boss fight. Dodongo's fire breath wasn't sped up at all. Phantom ganon's and Volvagia's attacks were identified with an almost hacky-like solution. This PR fixes these.

Some of these changes are pulled from https://github.com/HarbourMasters/Shipwright/pull/1729

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/689088851.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/689088853.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/689088854.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/689088855.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/689088856.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/689088857.zip)
<!--- section:artifacts:end -->