### PR TITLE
Use OnGameFrameUpdate for rainbow tick instead of relying on ImGui hidden window

### DIFF
--- a/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
+++ b/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
@@ -385,7 +385,7 @@ void ResetPositionAll() {
 int hue = 0;
 
 // Runs every frame to update rainbow hue, a potential future optimization is to only run this a once or twice a second and increase the speed of the rainbow hue rotation.
-void CosmeticsUpdateTick(bool& open) {
+void CosmeticsUpdateTick() {
     int index = 0;
     float rainbowSpeed = CVarGetFloat("gCosmetics.RainbowSpeed", 0.6f);
     for (auto& [id, cosmeticOption] : cosmeticOptions) {
@@ -1800,11 +1800,13 @@ void RegisterOnLoadGameHook() {
     });
 }
 
-void InitCosmeticsEditor() {
-    // There's probably a better way to do this, but leaving as is for historical reasons. Even though there is no
-    // real window being rendered here, it calls this every frame allowing us to rotate through the rainbow hue for cosmetics
-    LUS::AddWindow("Enhancements", "Cosmetics Update Tick", CosmeticsUpdateTick, true, true);
+void RegisterOnGameFrameUpdateHook() {
+    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnGameFrameUpdate>([]() {
+        CosmeticsUpdateTick();
+    });
+}
 
+void InitCosmeticsEditor() {
     // Draw the bar in the menu.
     LUS::AddWindow("Enhancements", "Cosmetics Editor", DrawCosmeticsEditor, CVarGetInteger("gCosmeticsEditorEnabled", 0));
     // Convert the `current color` into the format that the ImGui color picker expects
@@ -1822,6 +1824,7 @@ void InitCosmeticsEditor() {
     ApplyAuthenticGfxPatches();
 
     RegisterOnLoadGameHook();
+    RegisterOnGameFrameUpdateHook();
 }
 
 void CosmeticsEditor_RandomizeAll() {


### PR DESCRIPTION
This should make rainbow mode consistent regardless of FPS

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/689995135.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/689995136.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/689995137.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/689995138.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/689995139.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/689995140.zip)
<!--- section:artifacts:end -->