### PR TITLE
fix: build wii u

### DIFF
--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -229,48 +229,48 @@ jobs:
           soh.nro
           soh.otr
           readme.txt
-  # build-wiiu:
-  #   needs: generate-soh-otr
-  #   runs-on: ${{ (vars.LINUX_RUNNER && fromJSON(vars.LINUX_RUNNER)) || 'ubuntu-latest' }}
-  #   container:
-  #     image: devkitpro/devkitppc:latest
-  #   steps:
-  #   - name: Install dependencies
-  #     if: ${{ !vars.LINUX_RUNNER }}
-  #     run: |
-  #       sudo apt-get update
-  #       sudo apt-get install -y ninja-build
-  #   - uses: actions/checkout@v3
-  #     with:
-  #       submodules: true
-  #   - name: ccache
-  #     uses: hendrikmuhs/ccache-action@v1.2
-  #     with:
-  #       key: ${{ runner.os }}-wiiu-ccache
-  #   - name: Build SoH
-  #     run: |
-  #       cmake -H. -Bbuild-wiiu -GNinja -DCMAKE_TOOLCHAIN_FILE=/opt/devkitpro/cmake/WiiU.cmake -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache
-  #       cmake --build build-wiiu --target soh_wuhb --config Release -j3
+  build-wiiu:
+    needs: generate-soh-otr
+    runs-on: ${{ (vars.LINUX_RUNNER && fromJSON(vars.LINUX_RUNNER)) || 'ubuntu-latest' }}
+    container:
+      image: devkitpro/devkitppc:20230110
+    steps:
+    - name: Install dependencies
+      if: ${{ !vars.LINUX_RUNNER }}
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y ninja-build
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - name: ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: ${{ runner.os }}-wiiu-ccache
+    - name: Build SoH
+      run: |
+        cmake -H. -Bbuild-wiiu -GNinja -DCMAKE_TOOLCHAIN_FILE=/opt/devkitpro/cmake/WiiU.cmake -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache
+        cmake --build build-wiiu --target soh_wuhb --config Release -j3
 
-  #       mv build-wiiu/soh/*.rpx soh.rpx
-  #       mv build-wiiu/soh/*.wuhb soh.wuhb
-  #       mv README.md readme.txt
-  #     env:
-  #       DEVKITPRO: /opt/devkitpro
-  #       DEVKITPPC: /opt/devkitpro/devkitPPC
-  #   - name: Download soh.otr
-  #     uses: actions/download-artifact@v3
-  #     with:
-  #       name: soh.otr
-  #   - name: Upload build
-  #     uses: actions/upload-artifact@v3
-  #     with:
-  #       name: soh-wiiu
-  #       path: |
-  #         soh.rpx
-  #         soh.wuhb
-  #         soh.otr
-  #         readme.txt
+        mv build-wiiu/soh/*.rpx soh.rpx
+        mv build-wiiu/soh/*.wuhb soh.wuhb
+        mv README.md readme.txt
+      env:
+        DEVKITPRO: /opt/devkitpro
+        DEVKITPPC: /opt/devkitpro/devkitPPC
+    - name: Download soh.otr
+      uses: actions/download-artifact@v3
+      with:
+        name: soh.otr
+    - name: Upload build
+      uses: actions/upload-artifact@v3
+      with:
+        name: soh-wiiu
+        path: |
+          soh.rpx
+          soh.wuhb
+          soh.otr
+          readme.txt
   build-windows:
     needs: generate-soh-otr
     runs-on: ${{ (vars.WINDOWS_RUNNER && fromJSON(vars.WINDOWS_RUNNER)) || 'windows-latest' }}

--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -240,9 +240,9 @@ namespace GameMenuBar {
                     ImGui::SameLine();
                     ImGui::SetCursorPosX(ImGui::GetCursorPosX() - 7.0f);
 
-                    UIWidgets::Spacer(0);
-
+                    ImGui::PushItemWidth(std::min((ImGui::GetContentRegionAvail().x - 60.0f), 260.0f));
                     ImGui::SliderInt("##WiiUFPSSlider", &fpsSlider, 1, 3, "", ImGuiSliderFlags_AlwaysClamp);
+                    ImGui::PopItemWidth();
 
                     ImGui::SameLine();
                     ImGui::SetCursorPosX(ImGui::GetCursorPosX() - 7.0f);

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -737,7 +737,7 @@ extern "C" void InitOTR() {
 #ifdef __SWITCH__
     LUS::Switch::Init(LUS::PreInitPhase);
 #elif defined(__WIIU__)
-    LUS::WiiU::Init();
+    LUS::WiiU::Init("soh");
 #endif
     LUS::AddSetupHooksDelegate(GameMenuBar::SetupHooks);
     LUS::RegisterMenuDrawMethod(GameMenuBar::Draw);


### PR DESCRIPTION
This continue from #2841.
- Fixes the FPS slider
- Uses an older devkitPPC image to work with cemu and workaround some issues with the latest ones
- Passes shortname to `LUS::WiiU::Init`

Requires https://github.com/Kenix3/libultraship/pull/212

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/691016023.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/691016025.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/691016026.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/691016027.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/691016028.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/691016029.zip)
<!--- section:artifacts:end -->