### PR TITLE
Use UTF-8 for MSVC and enable visual styles for Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ set(PROJECT_TEAM "github.com/harbourmasters" CACHE STRING "")
 
 set_property(DIRECTORY ${CMAKE_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT soh)
 add_compile_options($<$<CXX_COMPILER_ID:MSVC>:/MP>)
+add_compile_options($<$<CXX_COMPILER_ID:MSVC>:/utf-8>)
 
 if (CMAKE_SYSTEM_NAME MATCHES "Windows|Linux")
     if(NOT DEFINED BUILD_CROWD_CONTROL)

--- a/soh/CMakeLists.txt
+++ b/soh/CMakeLists.txt
@@ -500,6 +500,7 @@ if(MSVC)
                 /INCREMENTAL:NO;
                 /FORCE:MULTIPLE
             >
+            /MANIFEST:NO;
             /DEBUG;
             /SUBSYSTEM:WINDOWS
         )
@@ -514,6 +515,7 @@ if(MSVC)
                 /INCREMENTAL:NO;
                 /FORCE:MULTIPLE
             >
+            /MANIFEST:NO;
             /DEBUG;
             /SUBSYSTEM:WINDOWS
         )

--- a/soh/Resource.rc
+++ b/soh/Resource.rc
@@ -91,6 +91,13 @@ END
 // remains consistent on all systems.
 IDI_ICON1               ICON                    "SHIPOFHARKINIAN.ico"
 
+/////////////////////////////////////////////////////////////////////////////
+//
+// RT_MANIFEST
+//
+
+1                       RT_MANIFEST             "SHIPOFHARKINIAN.manifest"
+
 #endif    // English (United States) resources
 /////////////////////////////////////////////////////////////////////////////
 

--- a/soh/SHIPOFHARKINIAN.manifest
+++ b/soh/SHIPOFHARKINIAN.manifest
@@ -1,0 +1,31 @@
+<?xml version='1.0' encoding='UTF-8' standalone='yes'?>
+<assembly xmlns='urn:schemas-microsoft-com:asm.v1' manifestVersion='1.0'>
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+        type="win32"
+        name="Microsoft.Windows.Common-Controls"
+        version="6.0.0.0"
+        publicKeyToken="6595b64144ccf1df"
+        language="*"
+        processorArchitecture="*" />
+      </dependentAssembly>
+  </dependency>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level='asInvoker' uiAccess='false' />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- Windows 8 -->
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />
+      <!-- Windows 8.1 -->
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />
+      <!-- Windows 10 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+</assembly>


### PR DESCRIPTION
- Adds a Windows [application manifest](https://en.wikipedia.org/wiki/Manifest_file) that provides specific information about supported OS versions and [enables visual styles](https://learn.microsoft.com/en-us/windows/win32/controls/cookbook-overview)
- Uses the UTF-8 encoding compilation option to allow the project to compile on Windows regardless of [the language for non-Unicode programs](https://learn.microsoft.com/en-us/windows-hardware/customize/desktop/unattend/microsoft-windows-international-core-winpe-systemlocale) (this fixes compilation if you have this setting in Japanese and other languages)

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/694382663.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/694382664.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/694382665.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/694382666.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/694382667.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/694382668.zip)
<!--- section:artifacts:end -->