### PR TITLE
Old Save Conversion Fix, mark II

### DIFF
--- a/soh/soh/SaveManager.cpp
+++ b/soh/soh/SaveManager.cpp
@@ -754,14 +754,18 @@ void SaveManager::SaveFileThreaded(int fileNum, SaveContext* saveContext) {
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnSaveFile>(fileNum);
 }
 
-void SaveManager::SaveFile(int fileNum) {
+void SaveManager::SaveFile(int fileNum, bool threaded) {
     if (fileNum == 0xFF) {
         return;
     }
     // Can't think of any time the promise would be needed, so use push_task instead of submit
     auto saveContext = new SaveContext;
     memcpy(saveContext, &gSaveContext, sizeof(gSaveContext));
-    smThreadPool->push_task_back(&SaveManager::SaveFileThreaded, this, fileNum, saveContext);
+    if (threaded) {
+        smThreadPool->push_task_back(&SaveManager::SaveFileThreaded, this, fileNum, saveContext);
+    } else {
+        SaveFileThreaded(fileNum, saveContext);
+    }
 }
 
 void SaveManager::SaveGlobal() {
@@ -2135,7 +2139,7 @@ void SaveManager::ConvertFromUnversioned() {
             static SaveContext saveContextSave = gSaveContext;
             InitFile(false);
             CopyV0Save(*file, gSaveContext);
-            SaveFile(fileNum);
+            SaveFile(fileNum, false);
             InitMeta(fileNum);
             gSaveContext = saveContextSave;
         }
@@ -2156,7 +2160,7 @@ extern "C" void Save_InitFile(int isDebug) {
 }
 
 extern "C" void Save_SaveFile(void) {
-    SaveManager::Instance->SaveFile(gSaveContext.fileNum);
+    SaveManager::Instance->SaveFile(gSaveContext.fileNum, true);
 }
 
 extern "C" void Save_SaveGlobal(void) {

--- a/soh/soh/SaveManager.h
+++ b/soh/soh/SaveManager.h
@@ -52,7 +52,7 @@ public:
 
     void Init();
     void InitFile(bool isDebug);
-    void SaveFile(int fileNum);
+    void SaveFile(int fileNum, bool threaded);
     void SaveGlobal();
     void LoadFile(int fileNum);
     bool SaveFile_Exist(int fileNum);


### PR DESCRIPTION
Threaded save was causing issues for old `oot-save.sav` conversion. Added an option just for that instance to run `SaveManager::SaveFileThreaded` outside of a thread. Everything else still runs threaded. (updated local develop-spock before creating this time).

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/701373042.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/701373043.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/701373044.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/701373045.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/701373046.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/701373047.zip)
<!--- section:artifacts:end -->