### PR TITLE
Fixes buying songs crash on Switch

### DIFF
--- a/soh/soh/Enhancements/game-interactor/GameInteractor_Hooks.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor_Hooks.h
@@ -1,40 +1,46 @@
 #include "GameInteractor.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 // MARK: - Gameplay
-extern "C" void GameInteractor_ExecuteOnLoadGame(int32_t fileNum);
-extern "C" void GameInteractor_ExecuteOnExitGame(int32_t fileNum);
-extern "C" void GameInteractor_ExecuteOnGameFrameUpdate();
-extern "C" void GameInteractor_ExecuteOnItemReceiveHooks(GetItemEntry itemEntry);
-extern "C" void GameInteractor_ExecuteOnSaleEndHooks(GetItemEntry itemEntry);
-extern "C" void GameInteractor_ExecuteOnTransitionEndHooks(int16_t sceneNum);
-extern "C" void GameInteractor_ExecuteOnSceneInit(int16_t sceneNum);
-extern "C" void GameInteractor_ExecuteOnSceneSpawnActors();
-extern "C" void GameInteractor_ExecuteOnPlayerUpdate();
-extern "C" void GameInteractor_ExecuteOnOcarinaSongAction();
-extern "C" void GameInteractor_ExecuteOnActorUpdate(void* actor);
-extern "C" void GameInteractor_ExecuteOnPlayerBonk();
-extern "C" void GameInteractor_ExecuteOnOcarinaSongAction();
+void GameInteractor_ExecuteOnLoadGame(int32_t fileNum);
+void GameInteractor_ExecuteOnExitGame(int32_t fileNum);
+void GameInteractor_ExecuteOnGameFrameUpdate();
+void GameInteractor_ExecuteOnItemReceiveHooks(GetItemEntry itemEntry);
+void GameInteractor_ExecuteOnSaleEndHooks(GetItemEntry itemEntry);
+void GameInteractor_ExecuteOnTransitionEndHooks(int16_t sceneNum);
+void GameInteractor_ExecuteOnSceneInit(int16_t sceneNum);
+void GameInteractor_ExecuteOnSceneSpawnActors();
+void GameInteractor_ExecuteOnPlayerUpdate();
+void GameInteractor_ExecuteOnOcarinaSongAction();
+void GameInteractor_ExecuteOnActorUpdate(void* actor);
+void GameInteractor_ExecuteOnPlayerBonk();
+void GameInteractor_ExecuteOnOcarinaSongAction();
 
 // MARK: -  Save Files
-extern "C" void GameInteractor_ExecuteOnSaveFile(int32_t fileNum);
-extern "C" void GameInteractor_ExecuteOnLoadFile(int32_t fileNum);
-extern "C" void GameInteractor_ExecuteOnDeleteFile(int32_t fileNum);
+void GameInteractor_ExecuteOnSaveFile(int32_t fileNum);
+void GameInteractor_ExecuteOnLoadFile(int32_t fileNum);
+void GameInteractor_ExecuteOnDeleteFile(int32_t fileNum);
 
 // MARK: - Dialog
-extern "C" void GameInteractor_ExecuteOnDialogMessage();
-extern "C" void GameInteractor_ExecuteOnPresentTitleCard();
-extern "C" void GameInteractor_ExecuteOnInterfaceUpdate();
-extern "C" void GameInteractor_ExecuteOnKaleidoscopeUpdate(int16_t inDungeonScene);
+void GameInteractor_ExecuteOnDialogMessage();
+void GameInteractor_ExecuteOnPresentTitleCard();
+void GameInteractor_ExecuteOnInterfaceUpdate();
+void GameInteractor_ExecuteOnKaleidoscopeUpdate(int16_t inDungeonScene);
 
 // MARK: - Main Menu
-extern "C" void GameInteractor_ExecuteOnPresentFileSelect();
-extern "C" void GameInteractor_ExecuteOnUpdateFileSelectSelection(uint16_t optionIndex);
-extern "C" void GameInteractor_ExecuteOnUpdateFileCopySelection(uint16_t optionIndex);
-extern "C" void GameInteractor_ExecuteOnUpdateFileCopyConfirmationSelection(uint16_t optionIndex);
-extern "C" void GameInteractor_ExecuteOnUpdateFileEraseSelection(uint16_t optionIndex);
-extern "C" void GameInteractor_ExecuteOnUpdateFileEraseConfirmationSelection(uint16_t optionIndex);
-extern "C" void GameInteractor_ExecuteOnUpdateFileAudioSelection(uint8_t optionIndex);
-extern "C" void GameInteractor_ExecuteOnUpdateFileTargetSelection(uint8_t optionIndex);
+void GameInteractor_ExecuteOnPresentFileSelect();
+void GameInteractor_ExecuteOnUpdateFileSelectSelection(uint16_t optionIndex);
+void GameInteractor_ExecuteOnUpdateFileCopySelection(uint16_t optionIndex);
+void GameInteractor_ExecuteOnUpdateFileCopyConfirmationSelection(uint16_t optionIndex);
+void GameInteractor_ExecuteOnUpdateFileEraseSelection(uint16_t optionIndex);
+void GameInteractor_ExecuteOnUpdateFileEraseConfirmationSelection(uint16_t optionIndex);
+void GameInteractor_ExecuteOnUpdateFileAudioSelection(uint8_t optionIndex);
+void GameInteractor_ExecuteOnUpdateFileTargetSelection(uint8_t optionIndex);
 
 // MARK: - Game
-extern "C" void GameInteractor_ExecuteOnSetGameLanguage();
+void GameInteractor_ExecuteOnSetGameLanguage();
+#ifdef __cplusplus
+}
+#endif

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -688,9 +688,10 @@ std::unordered_map<uint32_t, uint32_t> ItemIDtoGetItemID{
     { ITEM_WEIRD_EGG, GI_WEIRD_EGG }
 };
 
-extern "C" uint32_t GetGIID(uint32_t itemID) {
-    if (ItemIDtoGetItemID.contains(itemID))
+extern "C" int32_t GetGIID(uint32_t itemID) {
+    if (ItemIDtoGetItemID.contains(itemID)) {
         return ItemIDtoGetItemID.at(itemID);
+    }
     return -1;
 }
 

--- a/soh/soh/OTRGlobals.h
+++ b/soh/soh/OTRGlobals.h
@@ -145,7 +145,7 @@ void EntranceTracker_SetLastEntranceOverride(s16 entranceIndex);
 void Gfx_RegisterBlendedTexture(const char* name, u8* mask, u8* replacement);
 void SaveManager_ThreadPoolWait();
 
-uint32_t GetGIID(uint32_t itemID);
+int32_t GetGIID(uint32_t itemID);
 #endif
 
 #endif

--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -15,6 +15,7 @@
 #endif
 
 #include "soh/Enhancements/game-interactor/GameInteractor.h"
+#include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
 
 #define DO_ACTION_TEX_WIDTH() 48
@@ -1706,7 +1707,7 @@ u8 Return_Item_Entry(GetItemEntry itemEntry, ItemID returnItem ) {
 
 // Processes Item_Give returns
 u8 Return_Item(u8 itemID, ModIndex modId, ItemID returnItem) {
-    uint32_t get = GetGIID(itemID);
+    int32_t get = GetGIID(itemID);
     if (get == -1) {
         modId = MOD_RANDOMIZER;
         get = itemID;
@@ -6158,8 +6159,13 @@ void Interface_Update(PlayState* play) {
                     u16 tempSaleMod = gSaveContext.pendingSaleMod;
                     gSaveContext.pendingSale = ITEM_NONE;
                     gSaveContext.pendingSaleMod = MOD_NONE;
-                    if (tempSaleMod == 0) {
-                        tempSaleItem = GetGIID(tempSaleItem);
+                    if (tempSaleMod == MOD_NONE) {
+                        s16 giid = GetGIID(tempSaleItem);
+                        if (giid == -1) {
+                            tempSaleMod = MOD_RANDOMIZER;
+                        } else {
+                            tempSaleItem = giid;
+                        }
                     }
                     GameInteractor_ExecuteOnSaleEndHooks(ItemTable_RetrieveEntry(tempSaleMod, tempSaleItem));
                 }


### PR DESCRIPTION
The same crash would have occurred with dungeon rewards as well but that was never reported to my knowledge. The problem was that we were using the ModIndex from inside the GetItemEntry to look up the item entry again later during some OnSaleEnd logic. However, Songs and Dungeon Rewards are in the MOD_RANDOMIZER GetItemTable, but have MOD_VANILLA as the ModIndex inside their GetItemEntry since they have vanilla ItemIDs, unlike the other randomizer exclusive items. This adds some extra logic to double check that. It also fixes some signedness issues surrounding a function that could return -1 but it's signature said it returned a uint32_t. Finally, there was an issue with the GameInteractor_Hooks header not being imported causing an implicitly declared function.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/705720933.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/705720934.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/705720935.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/705720936.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/705720937.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/705720939.zip)
<!--- section:artifacts:end -->