### PR TITLE
Mask Sale Fix

### DIFF
--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -2305,6 +2305,8 @@ u8 Item_Give(PlayState* play, u8 item) {
                         }
                     } else {
                         gSaveContext.equips.buttonItems[i] = ITEM_NONE;
+                        // No need to call OnItemGive for ITEM_SOLD_OUT. Doesn't have any ItemTable entries anyway.
+                        return -1;
                     }
                     return Return_Item(item, MOD_NONE, ITEM_NONE);
                 }

--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -1706,6 +1706,10 @@ u8 Return_Item_Entry(GetItemEntry itemEntry, ItemID returnItem ) {
 
 // Processes Item_Give returns
 u8 Return_Item(u8 itemID, ModIndex modId, ItemID returnItem) {
+    // No need to call OnItemGive for ITEM_SOLD_OUT. Doesn't have any ItemTable entries anyway.
+    if (itemID == ITEM_SOLD_OUT) {
+        return ITEM_NONE;
+    }
     uint32_t get = GetGIID(itemID);
     if (get == -1) {
         modId = MOD_RANDOMIZER;
@@ -2305,8 +2309,6 @@ u8 Item_Give(PlayState* play, u8 item) {
                         }
                     } else {
                         gSaveContext.equips.buttonItems[i] = ITEM_NONE;
-                        // No need to call OnItemGive for ITEM_SOLD_OUT. Doesn't have any ItemTable entries anyway.
-                        return -1;
                     }
                     return Return_Item(item, MOD_NONE, ITEM_NONE);
                 }

--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -1706,9 +1706,10 @@ u8 Return_Item_Entry(GetItemEntry itemEntry, ItemID returnItem ) {
 
 // Processes Item_Give returns
 u8 Return_Item(u8 itemID, ModIndex modId, ItemID returnItem) {
-    // No need to call OnItemGive for ITEM_SOLD_OUT. Doesn't have any ItemTable entries anyway.
+    // ITEM_SOLD_OUT doesn't have an ItemTable entry, so pass custom entry instead
     if (itemID == ITEM_SOLD_OUT) {
-        return ITEM_NONE;
+        GetItemEntry gie = { ITEM_SOLD_OUT, 0, 0, 0, 0, 0, 0, 0, false, ITEM_FROM_NPC, ITEM_CATEGORY_LESSER, NULL };
+        return Return_Item_Entry(gie, returnItem);
     }
     uint32_t get = GetGIID(itemID);
     if (get == -1) {


### PR DESCRIPTION
Prevent calling OnItemReceive for ITEM_SOLD_OUT, as there is no ItemTable entry and trying to find it in one would always error, and also no need I can think of for anyone to know about that item in the context of the hook.

Should fix mask sale crash on Switch.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/705864988.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/705864990.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/705864991.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/705864993.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/705864994.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/705864995.zip)
<!--- section:artifacts:end -->