### PR TITLE
Fix: seed srand on launch and fix spoiler log for seed testing generation

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/menu.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/menu.cpp
@@ -518,7 +518,7 @@ std::string GenerateRandomizer(std::unordered_map<RandomizerSettingKey, uint8_t>
     srand(time(NULL));
     // if a blank seed was entered, make a random one
     if (seedString.empty()) {
-        Settings::seed = rand() & 0xFFFFFFFF;
+        seedString = std::to_string(rand() % 0xFFFFFFFF);
     } else if (seedString.rfind("seed_testing_count", 0) == 0 && seedString.length() > 18) {
         int count;
         try {
@@ -530,15 +530,11 @@ std::string GenerateRandomizer(std::unordered_map<RandomizerSettingKey, uint8_t>
         }
         Playthrough::Playthrough_Repeat(cvarSettings, excludedLocations, count);
         return "";
-    } else {
-        try {
-            uint32_t seedHash = boost::hash_32<std::string>{}(seedString);
-            Settings::seed = seedHash & 0xFFFFFFFF;
-            Settings::seedString = seedString;
-        } catch (...) {
-            return "";
-        }
     }
+
+    Settings::seedString = seedString;
+    uint32_t seedHash = boost::hash_32<std::string>{}(Settings::seedString);
+    Settings::seed = seedHash & 0xFFFFFFFF;
 
     int ret = Playthrough::Playthrough_Init(Settings::seed, cvarSettings, excludedLocations);
     if (ret < 0) {

--- a/soh/soh/Enhancements/randomizer/3drando/menu.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/menu.cpp
@@ -533,8 +533,7 @@ std::string GenerateRandomizer(std::unordered_map<RandomizerSettingKey, uint8_t>
     } else {
         try {
             uint32_t seedHash = boost::hash_32<std::string>{}(seedString);
-            int seed = seedHash & 0xFFFFFFFF;
-            Settings::seed = seed;
+            Settings::seed = seedHash & 0xFFFFFFFF;
             Settings::seedString = seedString;
         } catch (...) {
             return "";

--- a/soh/soh/Enhancements/randomizer/3drando/playthrough.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/playthrough.cpp
@@ -87,8 +87,9 @@ int Playthrough_Repeat(std::unordered_map<RandomizerSettingKey, uint8_t> cvarSet
     printf("\x1b[0;0HGENERATING %d SEEDS", count);
     uint32_t repeatedSeed = 0;
     for (int i = 0; i < count; i++) {
-        repeatedSeed = rand() % 0xFFFFFFFF;
-        Settings::seed = repeatedSeed;
+        Settings::seedString = std::to_string(rand() % 0xFFFFFFFF);
+        repeatedSeed = boost::hash_32<std::string>{}(Settings::seedString);
+        Settings::seed = repeatedSeed % 0xFFFFFFFF;
         CitraPrint("testing seed: " + std::to_string(Settings::seed));
         ClearProgress();
         Playthrough_Init(Settings::seed, cvarSettings, excludedLocations);

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -3191,8 +3191,8 @@ void DrawRandoEditor(bool& open) {
     }
 
     UIWidgets::Spacer(0);
-    if (ImGui::Button("Generate Randomizer")) {        
-        GenerateRandomizer(CVarGetInteger("gRandoManualSeedEntry", 0) ? seedString : std::to_string(rand() & 0xFFFFFFFF).c_str());
+    if (ImGui::Button("Generate Randomizer")) {
+        GenerateRandomizer(CVarGetInteger("gRandoManualSeedEntry", 0) ? seedString : "");
     }
 
     UIWidgets::Spacer(0);

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -781,6 +781,8 @@ extern "C" void InitOTR() {
     } else {
         CVarClear("gLetItSnow");
     }
+
+    srand(now);
 #ifdef ENABLE_CROWD_CONTROL
     CrowdControl::Instance = new CrowdControl();
     CrowdControl::Instance->Init();


### PR DESCRIPTION
This adds a call to `srand()` in launch flow so that the first call to `rand()` is unique. I figure placing this in `OTRGlobals::InitOTR` is sufficient for our needs (early enough in the app launch and in a visible place).

I also deferred random seed generation to pass in an empty string so the 3drando code can handle the rest of the logic for setting a random seed.

There is also a fix for the multi seed testing count logic to ensure we save the seed as a string, and hash it. This is to replicate the real flow so that the seed number tracked in the spoiler log is the same string you can enter in manually (string value pre-hashed).

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/706174245.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/706174246.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/706174247.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/706174248.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/706174249.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/706174250.zip)
<!--- section:artifacts:end -->