### PR TITLE
Add Scene Specific Checks to Dirt Path Fixes

### DIFF
--- a/soh/soh/Enhancements/game-interactor/GameInteractor.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor.h
@@ -87,6 +87,7 @@ uint8_t GameInteractor_SecondCollisionUpdate();
 }
 #endif
 
+void UpdateDirtPathFixState(int32_t sceneNum);
 
 #ifdef __cplusplus
 

--- a/soh/soh/Enhancements/mods.cpp
+++ b/soh/soh/Enhancements/mods.cpp
@@ -487,24 +487,16 @@ void RegisterBonkDamage() {
 }
 
 void RegisterPathFix() {
-    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnInterfaceUpdate>([]() {
-        if ((gPlayState != NULL) && ((gPlayState->sceneNum == SCENE_SPOT00) || (gPlayState->sceneNum == SCENE_SPOT04) || (gPlayState->sceneNum == SCENE_SPOT15))) {
-           
-            switch (CVarGetInteger("gSceneSpecificDirtPathFix", 0)) {
-                case 1:
-                    CVarSetInteger("gDirtPathFix", 1);
-                    break;
-                case 2:
-                    CVarSetInteger("gDirtPathFix", 2);
-                    break;
-                case 0:
-                default:
-                    CVarSetInteger("gDirtPathFix", 0);
-                    break;
-            }
-        }
-        if ((gPlayState != NULL) && !((gPlayState->sceneNum == SCENE_SPOT00) || (gPlayState->sceneNum == SCENE_SPOT04) || (gPlayState->sceneNum == SCENE_SPOT15))) {
-            CVarSetInteger("gDirtPathFix", 0);
+    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnTransitionEnd>([](int32_t sceneNum) {
+        switch (sceneNum) {
+            case SCENE_SPOT00:
+            case SCENE_SPOT04:
+            case SCENE_SPOT15:
+                CVarSetInteger("gDirtPathFix", CVarGetInteger("gSceneSpecificDirtPathFix", 0));
+                break;
+            default:
+                CVarClear("gDirtPathFix");
+                break;
         }
     });
 }

--- a/soh/soh/Enhancements/mods.cpp
+++ b/soh/soh/Enhancements/mods.cpp
@@ -486,6 +486,29 @@ void RegisterBonkDamage() {
     });
 }
 
+void RegisterPathFix() {
+    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnInterfaceUpdate>([]() {
+        if ((gPlayState != NULL) && ((gPlayState->sceneNum == SCENE_SPOT00) || (gPlayState->sceneNum == SCENE_SPOT04) || (gPlayState->sceneNum == SCENE_SPOT15))) {
+           
+            switch (CVarGetInteger("gSceneSpecificDirtPathFix", 0)) {
+                case 1:
+                    CVarSetInteger("gDirtPathFix", 1);
+                    break;
+                case 2:
+                    CVarSetInteger("gDirtPathFix", 2);
+                    break;
+                case 0:
+                default:
+                    CVarSetInteger("gDirtPathFix", 0);
+                    break;
+            }
+        }
+        if ((gPlayState != NULL) && !((gPlayState->sceneNum == SCENE_SPOT00) || (gPlayState->sceneNum == SCENE_SPOT04) || (gPlayState->sceneNum == SCENE_SPOT15))) {
+            CVarSetInteger("gDirtPathFix", 0);
+        }
+    });
+}
+
 void InitMods() {
     RegisterTTS();
     RegisterInfiniteMoney();
@@ -504,4 +527,5 @@ void InitMods() {
     RegisterRupeeDash();
     RegisterHyperBosses();
     RegisterBonkDamage();
+    RegisterPathFix();
 }

--- a/soh/soh/Enhancements/mods.cpp
+++ b/soh/soh/Enhancements/mods.cpp
@@ -486,18 +486,21 @@ void RegisterBonkDamage() {
     });
 }
 
-void RegisterPathFix() {
+void UpdateDirtPathFixState(int32_t sceneNum) {
+    switch (sceneNum) {
+        case SCENE_SPOT00:
+        case SCENE_SPOT04:
+        case SCENE_SPOT15:
+            CVarSetInteger("gDirtPathFix", CVarGetInteger("gSceneSpecificDirtPathFix", 0));
+            return;
+        default:
+            CVarClear("gDirtPathFix");
+    }
+}
+
+void RegisterMenuPathFix() {
     GameInteractor::Instance->RegisterGameHook<GameInteractor::OnTransitionEnd>([](int32_t sceneNum) {
-        switch (sceneNum) {
-            case SCENE_SPOT00:
-            case SCENE_SPOT04:
-            case SCENE_SPOT15:
-                CVarSetInteger("gDirtPathFix", CVarGetInteger("gSceneSpecificDirtPathFix", 0));
-                break;
-            default:
-                CVarClear("gDirtPathFix");
-                break;
-        }
+        UpdateDirtPathFixState(sceneNum);
     });
 }
 
@@ -519,5 +522,5 @@ void InitMods() {
     RegisterRupeeDash();
     RegisterHyperBosses();
     RegisterBonkDamage();
-    RegisterPathFix();
+    RegisterMenuPathFix();
 }

--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -860,7 +860,7 @@ namespace GameMenuBar {
                     ImGui::EndMenu();
                 }
                 UIWidgets::PaddedText("Fix Vanishing Paths", true, false);
-                UIWidgets::EnhancementCombobox("gDirtPathFix", zFightingOptions, 0);
+                UIWidgets::EnhancementCombobox("gSceneSpecificDirtPathFix", zFightingOptions, 0);
                 UIWidgets::Tooltip("Disabled: Paths vanish more the higher the resolution (Z-fighting is based on resolution)\n"
                                    "Consistent: Certain paths vanish the same way in all resolutions\n"
                                    "No Vanish: Paths do not vanish, Link seems to sink in to some paths\n"

--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -864,16 +864,7 @@ namespace GameMenuBar {
                 UIWidgets::PaddedText("Fix Vanishing Paths", true, false);
                
                 if (UIWidgets::EnhancementCombobox("gSceneSpecificDirtPathFix", zFightingOptions, 0) && gPlayState != NULL) {
-                    switch (gPlayState->sceneNum) {
-                        case SCENE_SPOT00:
-                        case SCENE_SPOT04:
-                        case SCENE_SPOT15:
-                            CVarSetInteger("gDirtPathFix", CVarGetInteger("gSceneSpecificDirtPathFix", 0));
-                            break;
-                        default:
-                            CVarClear("gDirtPathFix");
-                            break;
-                    }
+                    UpdateDirtPathFixState(gPlayState->sceneNum);
                 }
                 UIWidgets::Tooltip("Disabled: Paths vanish more the higher the resolution (Z-fighting is based on resolution)\n"
                                    "Consistent: Certain paths vanish the same way in all resolutions\n"

--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -46,6 +46,8 @@ extern "C" {
     void disableBetaQuest() { isBetaQuestEnabled = false; }
 }
 
+extern "C" PlayState* gPlayState;
+
 enum SeqPlayers {
     /* 0 */ SEQ_BGM_MAIN,
     /* 1 */ SEQ_FANFARE,
@@ -860,7 +862,19 @@ namespace GameMenuBar {
                     ImGui::EndMenu();
                 }
                 UIWidgets::PaddedText("Fix Vanishing Paths", true, false);
-                UIWidgets::EnhancementCombobox("gSceneSpecificDirtPathFix", zFightingOptions, 0);
+               
+                if (UIWidgets::EnhancementCombobox("gSceneSpecificDirtPathFix", zFightingOptions, 0) && gPlayState != NULL) {
+                    switch (gPlayState->sceneNum) {
+                        case SCENE_SPOT00:
+                        case SCENE_SPOT04:
+                        case SCENE_SPOT15:
+                            CVarSetInteger("gDirtPathFix", CVarGetInteger("gSceneSpecificDirtPathFix", 0));
+                            break;
+                        default:
+                            CVarClear("gDirtPathFix");
+                            break;
+                    }
+                }
                 UIWidgets::Tooltip("Disabled: Paths vanish more the higher the resolution (Z-fighting is based on resolution)\n"
                                    "Consistent: Certain paths vanish the same way in all resolutions\n"
                                    "No Vanish: Paths do not vanish, Link seems to sink in to some paths\n"


### PR DESCRIPTION
This makes it to where it only activates in the specific scenes with paths. (Hyrule Field, Hyrule Castle, and Kokiri Forest)

It will then be disabled in any other scenes, so that other decals, like scrub shadows, are not affected.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/706338391.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/706338392.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/706338393.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/706338394.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/706338395.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/706338396.zip)
<!--- section:artifacts:end -->