### PR TITLE
Bunny Hood Unequip On Load Fix

### DIFF
--- a/soh/include/variables.h
+++ b/soh/include/variables.h
@@ -103,6 +103,7 @@ extern "C"
 	extern u32 gGsFlagsShifts[4];
 	extern void* gItemIcons[0x82];
 	extern u8 gItemAgeReqs[];
+	extern u8 gSlotAgeReqs[];
 	extern u8 gItemSlots[56];
 	extern void (*gSceneCmdHandlers[SCENE_CMD_ID_MAX])(PlayState*, SceneCmd*);
 	extern s16 gLinkObjectIds[2];

--- a/soh/src/code/z_play.c
+++ b/soh/src/code/z_play.c
@@ -604,6 +604,15 @@ void Play_Init(GameState* thisx) {
                  (s32)(zAllocAligned + zAllocSize) - (s32)(zAllocAligned - zAlloc));
 
     Fault_AddClient(&D_801614B8, ZeldaArena_Display, NULL, NULL);
+    // In order to keep bunny hood equipped on first load, we need to pre-set the age reqs for the item and slot
+    if (CVarGetInteger("gMMBunnyHood", 0) || CVarGetInteger("gTimelessEquipment", 0)) {
+        gItemAgeReqs[ITEM_MASK_BUNNY] = 9;
+        if(INV_CONTENT(ITEM_TRADE_CHILD) == ITEM_MASK_BUNNY)
+            gSlotAgeReqs[SLOT_TRADE_CHILD] = 9;
+    }
+    else {
+        gItemAgeReqs[ITEM_MASK_BUNNY] = gSlotAgeReqs[SLOT_TRADE_CHILD] = 1;
+    }
     func_800304DC(play, &play->actorCtx, play->linkActorEntry);
 
     while (!func_800973FC(play, &play->roomCtx)) {

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_item.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_item.c
@@ -344,12 +344,6 @@ void KaleidoScope_DrawItemSelect(PlayState* play) {
             pauseCtx->cursorItem[PAUSE_ITEM] = cursorItem;
             pauseCtx->cursorSlot[PAUSE_ITEM] = cursorSlot;
 
-            gSlotAgeReqs[SLOT_TRADE_CHILD] = gItemAgeReqs[ITEM_MASK_BUNNY] =
-                ((CVarGetInteger("gMMBunnyHood", 0) || CVarGetInteger("gTimelessEquipment", 0)) &&
-                 INV_CONTENT(ITEM_TRADE_CHILD) == ITEM_MASK_BUNNY)
-                    ? 9
-                    : 1;
-
             if (!CHECK_SLOT_AGE(cursorSlot)) {
                 pauseCtx->nameColorSet = 1;
             }
@@ -405,6 +399,12 @@ void KaleidoScope_DrawItemSelect(PlayState* play) {
                             }
                         }
                         gSelectingMask = cursorSlot == SLOT_TRADE_CHILD;
+
+                        gSlotAgeReqs[SLOT_TRADE_CHILD] = gItemAgeReqs[ITEM_MASK_BUNNY] =
+                            ((CVarGetInteger("gMMBunnyHood", 0) || CVarGetInteger("gTimelessEquipment", 0)) &&
+                             INV_CONTENT(ITEM_TRADE_CHILD) == ITEM_MASK_BUNNY)
+                                ? 9
+                                : 1;
                     }
                     if (gSaveContext.n64ddFlag && Randomizer_GetSettingValue(RSK_SHUFFLE_ADULT_TRADE) &&
                         cursorSlot == SLOT_TRADE_ADULT && CHECK_BTN_ALL(input->press.button, BTN_A)) {

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope.h
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope.h
@@ -7,7 +7,6 @@
 extern u8 gAmmoItems[];
 extern s16 D_8082AAEC[];
 extern s16 D_8082AB2C[];
-extern u8 gSlotAgeReqs[];
 extern u8 gEquipAgeReqs[][4];
 extern u8 gAreaGsFlags[];
 extern bool gSelectingMask;


### PR DESCRIPTION
The code that was supposed to set the variables to allow adult Link to equip the bunny hood was located in the inventory display loop. So, on first load of a save, if Link's age was adult and the bunny hood was on an equip slot, it would be removed since the check to allow or remove them on save initialization was comparing against default values. This adds a step to loading a save file that checks against `gMMBunnyHood` and `gTimelessEqupment` to set the age requirements for the bunny hood and the child trade slot to their appropriate values before processing equips for age-restricted items.

The code for updating the age requirements was also being run on every frame you had the inventory open. This moves that check to within the part of that code that was only active while you were selecting the child trade item.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/706279911.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/706279912.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/706279913.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/706279914.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/706279915.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/706279916.zip)
<!--- section:artifacts:end -->