### PR TITLE
Add Scene Specific Checks to Dirt Path Fixes

### DIFF
--- a/soh/soh/Enhancements/game-interactor/GameInteractor.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor.h
@@ -87,6 +87,7 @@ uint8_t GameInteractor_SecondCollisionUpdate();
 }
 #endif
 
+void UpdateDirtPathFixState(int32_t sceneNum);
 
 #ifdef __cplusplus
 

--- a/soh/soh/Enhancements/game-interactor/GameInteractor.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor.h
@@ -87,8 +87,6 @@ uint8_t GameInteractor_SecondCollisionUpdate();
 }
 #endif
 
-void UpdateDirtPathFixState(int32_t sceneNum);
-
 #ifdef __cplusplus
 
 #include <vector>

--- a/soh/soh/Enhancements/game-interactor/GameInteractor.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor.h
@@ -87,6 +87,7 @@ uint8_t GameInteractor_SecondCollisionUpdate();
 }
 #endif
 
+
 #ifdef __cplusplus
 
 #include <vector>

--- a/soh/soh/Enhancements/mods.cpp
+++ b/soh/soh/Enhancements/mods.cpp
@@ -486,6 +486,24 @@ void RegisterBonkDamage() {
     });
 }
 
+void UpdateDirtPathFixState(int32_t sceneNum) {
+    switch (sceneNum) {
+        case SCENE_SPOT00:
+        case SCENE_SPOT04:
+        case SCENE_SPOT15:
+            CVarSetInteger("gDirtPathFix", CVarGetInteger("gSceneSpecificDirtPathFix", 0));
+            return;
+        default:
+            CVarClear("gDirtPathFix");
+    }
+}
+
+void RegisterMenuPathFix() {
+    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnTransitionEnd>([](int32_t sceneNum) {
+        UpdateDirtPathFixState(sceneNum);
+    });
+}
+
 void InitMods() {
     RegisterTTS();
     RegisterInfiniteMoney();
@@ -504,4 +522,5 @@ void InitMods() {
     RegisterRupeeDash();
     RegisterHyperBosses();
     RegisterBonkDamage();
+    RegisterMenuPathFix();
 }

--- a/soh/soh/Enhancements/mods.h
+++ b/soh/soh/Enhancements/mods.h
@@ -1,3 +1,5 @@
+#include <stdint.h>
+
 #ifndef MODS_H
 #define MODS_H
 
@@ -5,6 +7,7 @@
 extern "C" {
 #endif
 
+void UpdateDirtPathFixState(int32_t sceneNum);
 void InitMods();
 
 #ifdef __cplusplus

--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -29,6 +29,7 @@
 #include "soh/SaveManager.h"
 #include "OTRGlobals.h"
 #include "soh/Enhancements/presets.h"
+#include "soh/Enhancements/mods.h"
 #include "soh/resource/type/Skeleton.h"
 
 #ifdef ENABLE_CROWD_CONTROL

--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -46,6 +46,8 @@ extern "C" {
     void disableBetaQuest() { isBetaQuestEnabled = false; }
 }
 
+extern "C" PlayState* gPlayState;
+
 enum SeqPlayers {
     /* 0 */ SEQ_BGM_MAIN,
     /* 1 */ SEQ_FANFARE,
@@ -860,7 +862,9 @@ namespace GameMenuBar {
                     ImGui::EndMenu();
                 }
                 UIWidgets::PaddedText("Fix Vanishing Paths", true, false);
-                UIWidgets::EnhancementCombobox("gDirtPathFix", zFightingOptions, 0);
+                if (UIWidgets::EnhancementCombobox("gSceneSpecificDirtPathFix", zFightingOptions, 0) && gPlayState != NULL) {
+                    UpdateDirtPathFixState(gPlayState->sceneNum);
+                }
                 UIWidgets::Tooltip("Disabled: Paths vanish more the higher the resolution (Z-fighting is based on resolution)\n"
                                    "Consistent: Certain paths vanish the same way in all resolutions\n"
                                    "No Vanish: Paths do not vanish, Link seems to sink in to some paths\n"


### PR DESCRIPTION
This makes it to where it only activates in the specific scenes with paths. (Hyrule Field, Hyrule Castle, and Kokiri Forest)

It will then be disabled in any other scenes, so that other decals, like scrub shadows, are not affected.

Moved from develop PR #2903 to develop-spock

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/706960723.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/706960724.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/706960725.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/706960726.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/706960727.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/706960728.zip)
<!--- section:artifacts:end -->