### PR TITLE
Fix: Use blue potion refill for Granny Shop item when unshuffled

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/item_pool.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/item_pool.cpp
@@ -725,7 +725,7 @@ void GenerateItemPool() {
       AddItemToMainPool(BOMBCHU_10);
     }
   } else {
-    PlaceItemInLocation(KAK_GRANNYS_SHOP, BOTTLE_WITH_BLUE_POTION, false, true);
+    PlaceItemInLocation(KAK_GRANNYS_SHOP, BLUE_POTION_REFILL, false, true);
     PlaceItemInLocation(GC_MEDIGORON, GIANTS_KNIFE, false, true);
     PlaceItemInLocation(WASTELAND_BOMBCHU_SALESMAN, BOMBCHU_10, false, true);
   }


### PR DESCRIPTION
When merchants are set to unshuffled, the Granny Shop location was having a `BOTTLE_WITH_BLUE_POTION` placed in it which is considered a real bottle in logic.

This was leading to logic sometimes expecting you to buy the blue potion from granny to get the first bottle, and in some rare cases it may consider this the "only" bottle you can get and causing a soft lock (bottle locking all other bottles).

This PR sets the placed item to be `BLUE_POTION_REFILL`, instead to follow what is already declared in item_locations.cpp and what the game actually does (granny sells refills, not bottles).

See https://github.com/gamestabled/OoT3D_Randomizer/pull/676

(can point this to `develop-spock` instead if we prefer)

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/715478156.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/715478157.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/715478159.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/715478161.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/715478162.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/715478163.zip)
<!--- section:artifacts:end -->