### PR TITLE
Fixes regression in random rupee names

### DIFF
--- a/soh/soh/Enhancements/custom-message/CustomMessageManager.cpp
+++ b/soh/soh/Enhancements/custom-message/CustomMessageManager.cpp
@@ -89,12 +89,12 @@ void CustomMessage::Replace(std::string&& oldStr, std::string&& newEnglish, std:
     }
     position = french.find(oldStr);
     while (position != std::string::npos) {
-        french.replace(position, oldStr.length(), newEnglish);
+        french.replace(position, oldStr.length(), newFrench);
         position = french.find(oldStr);
     }
     position = german.find(oldStr);
     while (position != std::string::npos) {
-        german.replace(position, oldStr.length(), newEnglish);
+        german.replace(position, oldStr.length(), newGerman);
         position = german.find(oldStr);
     }
     Format();


### PR DESCRIPTION
Technically was a CustomMessageManager bug but it was in a function that I believe is only used for random rupee names.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/720617933.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/720617934.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/720617935.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/720617936.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/720617937.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/720617938.zip)
<!--- section:artifacts:end -->