### PR TITLE
Fix order of auto equip message

### DIFF
--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -1736,12 +1736,12 @@ extern "C" void* getN64WeirdFrame(s32 i) {
 
 extern "C" int GetEquipNowMessage(char* buffer, char* src, const int maxBufferSize) {
     CustomMessage customMessage("\x04\x1A\x08"
-                                "D\x96sirez-vous l'\x96quiper maintenant?"
+                                "Would you like to equip it now?"
                                 "\x09&&"
                                 "\x1B%g"
-                                "Oui"
+                                "Yes"
                                 "&"
-                                "Non"
+                                "No"
                                 "%w\x02",
                                 "\x04\x1A\x08"
                                 "M"
@@ -1753,13 +1753,13 @@ extern "C" int GetEquipNowMessage(char* buffer, char* src, const int maxBufferSi
                                 "&"
                                 "Nein!"
                                 "%w\x02",
-                                "\x04\x1A\x08"
-                                "Would you like to equip it now?"
+				"\x04\x1A\x08"
+                                "D\x96sirez-vous l'\x96quiper maintenant?"
                                 "\x09&&"
                                 "\x1B%g"
-                                "Yes"
+                                "Oui"
                                 "&"
-                                "No"
+                                "Non"
                                 "%w\x02");
     customMessage.Format();
 


### PR DESCRIPTION
French text was being displayed in English and vice versa due to incorrectly ordered parameters.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/724884633.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/724884634.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/724884635.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/724884638.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/724884640.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/724884641.zip)
<!--- section:artifacts:end -->