### PR TITLE
Fix: Better debug warp MQ detection and other warp menu bugs

### DIFF
--- a/soh/include/z64.h
+++ b/soh/include/z64.h
@@ -1293,9 +1293,12 @@ typedef struct SelectContext {
     /* 0x0230 */ s32 lockDown;
     /* 0x0234 */ s32 unk_234; // unused
     /* 0x0238 */ u8* staticSegment;
+    // #region SOH [General]
     /*        */ s32 currentEntrance;
+    /*        */ u8 isBetterWarp;
     /*        */ BetterSceneSelectEntry* betterScenes;
     /*        */ BetterSceneSelectGrottoData* betterGrottos;
+    // #endregion
 } SelectContext; // size = 0x240
 
 typedef struct {

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -1025,9 +1025,9 @@ extern "C" uint32_t ResourceMgr_GetGameVersion(int index) {
 uint32_t IsSceneMasterQuest(s16 sceneNum) {
     uint32_t value = 0;
     uint8_t mqMode = CVarGetInteger("gBetterDebugWarpScreenMQMode", 0);
-    if (mqMode == 1) { //non-mq wants to be mq
+    if (mqMode == 1) { // non-mq wants to be mq
         return 1;
-    } else if (mqMode == 2) {//mq wants to be non-mq
+    } else if (mqMode == 2) { // mq wants to be non-mq
         return 0;
     } else {
         if (OTRGlobals::Instance->HasMasterQuest()) {
@@ -1035,18 +1035,16 @@ uint32_t IsSceneMasterQuest(s16 sceneNum) {
                 value = 1;
             } else if (gSaveContext.isMasterQuest) {
                 value = 1;
-            }
             } else {
                 value = 0;
-                if (gSaveContext.n64ddFlag) {
-                    if (!OTRGlobals::Instance->gRandomizer->masterQuestDungeons.empty()) {
-                        if (gPlayState != NULL && OTRGlobals::Instance->gRandomizer->masterQuestDungeons.contains(sceneNum)) {
-                            value = 1;
-                        }
-                    }
+                if (gSaveContext.n64ddFlag &&
+                    !OTRGlobals::Instance->gRandomizer->masterQuestDungeons.empty() &&
+                    OTRGlobals::Instance->gRandomizer->masterQuestDungeons.contains(sceneNum)) {
+                    value = 1;
                 }
             }
         }
+    }
     return value;
 }
 

--- a/soh/soh/OTRGlobals.h
+++ b/soh/soh/OTRGlobals.h
@@ -54,6 +54,7 @@ void OTRGetPixelDepthPrepare(float x, float y);
 uint16_t OTRGetPixelDepth(float x, float y);
 int32_t OTRGetLastScancode();
 uint32_t ResourceMgr_IsGameMasterQuest();
+uint32_t ResourceMgr_IsSceneMasterQuest(s16 sceneNum);
 uint32_t ResourceMgr_GameHasMasterQuest();
 uint32_t ResourceMgr_GameHasOriginal();
 uint32_t ResourceMgr_GetNumGameVersions();

--- a/soh/src/code/z_play.c
+++ b/soh/src/code/z_play.c
@@ -1923,7 +1923,7 @@ void Play_SpawnScene(PlayState* play, s32 sceneNum, s32 spawn) {
         Entrance_OverrideSpawnScene(sceneNum, spawn);
     }
 
-    CVarSetInteger("gBetterDebugWarpScreenMQMode", 0);
+    CVarClear("gBetterDebugWarpScreenMQMode");
 }
 
 void func_800C016C(PlayState* play, Vec3f* src, Vec3f* dest) {

--- a/soh/src/overlays/gamestates/ovl_select/z_select.c
+++ b/soh/src/overlays/gamestates/ovl_select/z_select.c
@@ -467,7 +467,7 @@ static BetterSceneSelectEntry sBetterScenes[] = {
         { "From Gerudo Fortress", "Von der Gerudo-Festung", "Depuis la Forteresse Gerudo", 0x022D, 0 },
         { "From Carpenter's Tent", "Vom Zelt der Zimmerleute", "Depuis la Tente du Charpentier", 0x03D0, 0 },
         { "Carpenter's Tent/ Running Man Minigame", "Zelt der Zimmerleute/ Rennlaeufer Minispiel", "Tente du Charpentier/ Marathonien", 0x03A0, 0 },
-        { "Thrown out of Fortress", "Aus der Festung geworfen", "Expulsé de la Forteresse", 0x01A5, 0 },
+        { "Thrown out of Fortress", "Aus der Festung geworfen", "Expulse de la Forteresse", 0x01A5, 0 },
     }},
     { "28:Gerudo Fortress", "28:Gerudo-Festung", "28:Forteresse Gerudo", Select_LoadGame, 18, {
         { "From Gerudo Valley", "Vom Gerudotal", "Depuis la Vallee Gerudo", 0x0129, 0 },
@@ -637,8 +637,8 @@ static BetterSceneSelectEntry sBetterScenes[] = {
         { "Spider Grotto (Hyrule Castle)", "Spinnen-Grotte (Schloss Hyrule)", "Grotte Araignee (Chateau d'Hyrule)", 0x17, 0 },
         { "Cow Grotto (Hyrule Field)", "Kuh-Grotte (Hylianische Steppe)", "Grotte a Vache (Plaine d'Hyrule)", 0x18, 0 },
         { "Cow Grotto (Death Mountain Trail)", "Kuh-Grotte (Gebirgspfad)", "Grotte a Vache (Chemin du Peril)", 0x19, 0 },
-        { "Flooded Grotto (Gerudo Valley)", "Geflutete Grotte (Gerudotal)", "Grotte Inondée (Vallee Gerudo)", 0x1A, 0 },
-        { "Flooded Grotto (Hyrule Field)", "Geflutete Grotte (Hylianische Steppe)", "Grotte Inondée (Plaine d'Hyrule)", 0x1B, 0 },
+        { "Flooded Grotto (Gerudo Valley)", "Geflutete Grotte (Gerudotal)", "Grotte Inondee (Vallee Gerudo)", 0x1A, 0 },
+        { "Flooded Grotto (Hyrule Field)", "Geflutete Grotte (Hylianische Steppe)", "Grotte Inondee (Plaine d'Hyrule)", 0x1B, 0 },
     }},
     { "50:Debug (Use with caution)", "50:Debug (Mit Vorsicht benutzen)", "50:Debug (A utiliser avec prudence)", Select_LoadGame, 10, {
         { "Test Room", "Test Raum", "Salle de Test", 0x0520, 0 },
@@ -1174,7 +1174,7 @@ void Better_Select_PrintMenu(SelectContext* this, GfxPrint* printer) {
 
 static SceneSelectLoadingMessages sLoadingMessages[] = {
     { GFXP_HIRAGANA "ｼﾊﾞﾗｸｵﾏﾁｸﾀﾞｻｲ", "Please wait a minute", "Bitte warte eine Minute", "Veuillez patienter une minute" },
-    { GFXP_HIRAGANA "ﾁｮｯﾄ ﾏｯﾃﾈ", "Hold on a sec", "Warte mal 'ne Sekunde" "Une seconde, ça arrive" },
+    { GFXP_HIRAGANA "ﾁｮｯﾄ ﾏｯﾃﾈ", "Hold on a sec", "Warte mal 'ne Sekunde" "Une seconde, ca arrive" },
     { GFXP_KATAKANA "ｳｪｲﾄ ｱ ﾓｰﾒﾝﾄ", "Wait a moment", "Warte einen Moment", "Patientez un instant" },
     { GFXP_KATAKANA "ﾛｰﾄﾞ" GFXP_HIRAGANA "ﾁｭｳ", "Loading", "Ladevorgang", "Chargement" },
     { GFXP_HIRAGANA "ﾅｳ ﾜｰｷﾝｸﾞ", "Now working", "Verarbeite", "Au travail" },
@@ -1182,7 +1182,7 @@ static SceneSelectLoadingMessages sLoadingMessages[] = {
     { GFXP_HIRAGANA "ｺｼｮｳｼﾞｬﾅｲﾖ", "It's not broken", "Es ist nicht kaputt", "C'est pas casse!" },
     { GFXP_KATAKANA "ｺｰﾋｰ ﾌﾞﾚｲｸ", "Coffee Break", "Kaffee-Pause", "Pause Cafe" },
     { GFXP_KATAKANA "Bﾒﾝｦｾｯﾄｼﾃｸﾀﾞｻｲ", "Please set B side", "Please set B side", "Please set B side" },
-    { GFXP_HIRAGANA "ｼﾞｯﾄ" GFXP_KATAKANA "ｶﾞﾏﾝ" GFXP_HIRAGANA "ﾉ" GFXP_KATAKANA "ｺ" GFXP_HIRAGANA "ﾃﾞｱｯﾀ", "Be patient, now", "Übe dich in Geduld", "Veuillez patientez" },
+    { GFXP_HIRAGANA "ｼﾞｯﾄ" GFXP_KATAKANA "ｶﾞﾏﾝ" GFXP_HIRAGANA "ﾉ" GFXP_KATAKANA "ｺ" GFXP_HIRAGANA "ﾃﾞｱｯﾀ", "Be patient, now", "Ube dich in Geduld", "Veuillez patientez" },
     { GFXP_HIRAGANA "ｲﾏｼﾊﾞﾗｸｵﾏﾁｸﾀﾞｻｲ", "Please wait just a minute", "Bitte warte noch eine Minute", "Patientez un peu" },
     { GFXP_HIRAGANA "ｱﾜﾃﾅｲｱﾜﾃﾅｲ｡ﾋﾄﾔｽﾐﾋﾄﾔｽﾐ｡", "Don't panic, don't panic. Take a break, take a break.", "Keine Panik! Nimm dir eine Auszeit", "Pas de panique. Prenez une pause." },
     { "Enough! My ship sails in the morning!", "Enough! My ship sails in the morning!", "Enough! My ship sails in the morning!", "Enough! My ship sails in the morning!" },

--- a/soh/src/overlays/gamestates/ovl_select/z_select.c
+++ b/soh/src/overlays/gamestates/ovl_select/z_select.c
@@ -43,6 +43,11 @@ void Select_LoadGame(SelectContext* this, s32 entranceIndex) {
     }
 
     if (this->isBetterWarp) {
+        CVarSetInteger("gBetterDebugWarpScreenCurrentScene", this->currentScene);
+        CVarSetInteger("gBetterDebugWarpScreenTopDisplayedScene", this->topDisplayedScene);
+        CVarSetInteger("gBetterDebugWarpScreenPageDownIndex", this->pageDownIndex);
+        CVarSave();
+
         if (ResourceMgr_GameHasMasterQuest() && ResourceMgr_GameHasOriginal()) {
             BetterSceneSelectEntrancePair entrancePair = this->betterScenes[this->currentScene].entrancePairs[this->pageDownIndex];
             // Check to see if the scene/entrance we just picked can be MQ'd
@@ -54,12 +59,7 @@ void Select_LoadGame(SelectContext* this, s32 entranceIndex) {
                     CVarSetInteger("gBetterDebugWarpScreenMQMode", 2); // Force MQ for default vanilla scene
                 }
             }
-        };
-
-        CVarSetInteger("gBetterDebugWarpScreenCurrentScene", this->currentScene);
-        CVarSetInteger("gBetterDebugWarpScreenTopDisplayedScene", this->topDisplayedScene);
-        CVarSetInteger("gBetterDebugWarpScreenPageDownIndex", this->pageDownIndex);
-        CVarSave();
+        }
     }
 
     gSaveContext.respawnFlag = 0;
@@ -1468,10 +1468,10 @@ void Select_DrawMenu(SelectContext* this) {
     GfxPrint_Init(printer);
     GfxPrint_Open(printer, POLY_OPA_DISP);
     if (this->isBetterWarp) {
-        Better_Select_PrintMenu(this, printer);
-        Better_Select_PrintAgeSetting(this, printer, ((void)0, gSaveContext.linkAge));
         Better_Select_PrintTimeSetting(this, printer);
+        Better_Select_PrintAgeSetting(this, printer, ((void)0, gSaveContext.linkAge));
         Better_Select_PrintMQSetting(this, printer);
+        Better_Select_PrintMenu(this, printer);
     } else {
         Select_PrintMenu(this, printer);
         Select_PrintAgeSetting(this, printer, ((void)0, gSaveContext.linkAge));

--- a/soh/src/overlays/gamestates/ovl_select/z_select.c
+++ b/soh/src/overlays/gamestates/ovl_select/z_select.c
@@ -1440,7 +1440,7 @@ void Better_Select_PrintMQSetting(SelectContext* this, GfxPrint* printer) {
                     label = this->opt ? "AN" : "AUS";
                     break;
                 case LANGUAGE_FRA:
-                    label = this->opt ? "ALLUME" : "ETEINT";
+                    label = this->opt ? "ACTIVE" : "DESACTIVE";
                     break;
             }
         } else {


### PR DESCRIPTION
This PR extends #2876 to improve the MQ handling for the better debug warp screen.

I've exposed `ResourceMgr_IsSceneMasterQuest()` so it can be used to find out what the scenes default MQ status should be. As the menu is scrolled up/down, the MQ status will reflect the currently highlighted scenes default state.

Now the better debug warp screen will auto detect the default MQ status, even for randomizer saves. If only a vanilla game is provided, or only a mq game is provided, the `(L)` toggle indicator is removed, and the MQ status will reflect based on the game in use.

Notable other bug fixes:
* There was a misplaced curly brace in `IsSceneMasterQuest()` that broke MQ support for randomizer saves (introduced by #2876)
* There were some special characters in the debug warp translation texts, but debug gfx print font does not support/display these characters. I opted to replace them with their non-accented characters.
* Refactored better debug warp mode detection/switching to prevent the menu list from having improper data and failing to work (total list size, list position, etc)

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/725231170.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/725231172.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/725231174.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/725231175.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/725231177.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/725231178.zip)
<!--- section:artifacts:end -->