### PR TITLE
vcpkg root stuff

### DIFF
--- a/CMake/automate-vcpkg.cmake
+++ b/CMake/automate-vcpkg.cmake
@@ -82,11 +82,7 @@ if (WIN32)
 endif()
 
 if(NOT DEFINED VCPKG_ROOT)
-    if(NOT DEFINED ENV{VCPKG_ROOT})
-	    set(VCPKG_ROOT ${VCPKG_FALLBACK_ROOT})
-    else()
-        set(VCPKG_ROOT $ENV{VCPKG_ROOT})
-    endif()
+    set(VCPKG_ROOT ${VCPKG_FALLBACK_ROOT})
 endif()
 
 # Installs a new copy of Vcpkg or updates an existing one


### PR DESCRIPTION
it seems the gh actions builders now set `VCPKG_ROOT` as an environment variable. this doesn't play nicely with our vcpkg auto update stuff since they don't have that dir as a git repo. this is a quick fix that ignores env vars for vcpkg and just goes to the fallback instead.

a longer term solution would be to implement some conditional logic to better handle non-git repo versions of vcpkg being installed, but i'm not sure what impact that would have on local windows dev

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/727609994.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/727609995.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/727609996.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/727609997.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/727609998.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/727609999.zip)
<!--- section:artifacts:end -->