### PR TITLE
Improve TTS for file select menus

### DIFF
--- a/OTRExporter/assets/accessibility/texts/filechoose_eng.json
+++ b/OTRExporter/assets/accessibility/texts/filechoose_eng.json
@@ -7,10 +7,20 @@
     "erase": "Erase",
     "quit": "Quit",
     "confirm": "Yes",
+    "end": "End",
+    "hyphen": "Hyphen",
+    "period": "Period",
+    "space": "Space",
+    "backspace": "Backspace",
+    "capital_letter": "Capital $0",
     "audio_stereo": "Sound - Stereo",
     "audio_mono": "Sound - Mono",
     "audio_headset": "Sound - Headset",
     "audio_surround": "Sound - Surround",
-    "target_switch": "Targetting Mode - Switch",
-    "target_hold": "Targetting Mode - Hold"
+    "target_switch": "Targeting Mode - Switch",
+    "target_hold": "Targeting Mode - Hold",
+    "quest_sel_vanilla": "Quest - Original",
+    "quest_sel_mq": "Quest - Master Quest",
+    "quest_sel_randomizer": "Quest - Randomizer",
+    "quest_sel_boss_rush": "Quest - Boss Rush"
 }

--- a/OTRExporter/assets/accessibility/texts/filechoose_fra.json
+++ b/OTRExporter/assets/accessibility/texts/filechoose_fra.json
@@ -19,7 +19,7 @@
     "audio_surround": "Son - Surround",
     "target_switch": "Visée - Fixe",
     "target_hold": "Visée - Maintenue",
-    "quest_sel_vanilla": "Quête - Original",
+    "quest_sel_vanilla": "Quête - Originale",
     "quest_sel_mq": "Quête - Master Quest",
     "quest_sel_randomizer": "Quête - Randomizer",
     "quest_sel_boss_rush": "Quête - Boss Rush"

--- a/OTRExporter/assets/accessibility/texts/filechoose_fra.json
+++ b/OTRExporter/assets/accessibility/texts/filechoose_fra.json
@@ -7,10 +7,20 @@
     "erase": "Effacer",
     "quit": "Retour",
     "confirm": "Oui",
+    "end": "Fin",
+    "hyphen": "Trait d'union",
+    "period": "Point",
+    "space": "Espace",
+    "backspace": "Retour arrière",
+    "capital_letter": "Majuscule $0",
     "audio_stereo": "Son - Stéréo",
     "audio_mono": "Son - Mono",
     "audio_headset": "Son - Casque",
     "audio_surround": "Son - Surround",
     "target_switch": "Visée - Fixe",
-    "target_hold": "Visée - Maintenue"
+    "target_hold": "Visée - Maintenue",
+    "quest_sel_vanilla": "Quête - Original",
+    "quest_sel_mq": "Quête - Master Quest",
+    "quest_sel_randomizer": "Quête - Randomizer",
+    "quest_sel_boss_rush": "Quête - Boss Rush"
 }

--- a/OTRExporter/assets/accessibility/texts/filechoose_ger.json
+++ b/OTRExporter/assets/accessibility/texts/filechoose_ger.json
@@ -7,10 +7,20 @@
     "erase": "Löschen",
     "quit": "Zurück",
     "confirm": "Ja",
+    "end": "Ende",
+    "hyphen": "Bindestrich",
+    "period": "Punkt",
+    "space": "Raum",
+    "backspace": "Rücktaste",
+    "capital_letter": "Großbuchstabe $0",
     "audio_stereo": "Sound - Stereo",
     "audio_mono": "Sound - Mono",
     "audio_headset": "Sound - Kopfhörer",
     "audio_surround": "Sound - Surround",
     "target_switch": "Zielerfassung - Einmal drücken",
-    "target_hold": "Zielerfassung - Trigger halten"
+    "target_hold": "Zielerfassung - Trigger halten",
+    "quest_sel_vanilla": "Quest - Original",
+    "quest_sel_mq": "Quest - Master Quest",
+    "quest_sel_randomizer": "Quest - Randomizer",
+    "quest_sel_boss_rush": "Quest - Bosse Rush"
 }

--- a/soh/soh/Enhancements/game-interactor/GameInteractor.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor.h
@@ -166,12 +166,16 @@ public:
     
     DEFINE_HOOK(OnPresentFileSelect, void());
     DEFINE_HOOK(OnUpdateFileSelectSelection, void(uint16_t optionIndex));
+    DEFINE_HOOK(OnUpdateFileSelectConfirmationSelection, void(uint16_t optionIndex));
     DEFINE_HOOK(OnUpdateFileCopySelection, void(uint16_t optionIndex));
     DEFINE_HOOK(OnUpdateFileCopyConfirmationSelection, void(uint16_t optionIndex));
     DEFINE_HOOK(OnUpdateFileEraseSelection, void(uint16_t optionIndex));
     DEFINE_HOOK(OnUpdateFileEraseConfirmationSelection, void(uint16_t optionIndex));
     DEFINE_HOOK(OnUpdateFileAudioSelection, void(uint8_t optionIndex));
     DEFINE_HOOK(OnUpdateFileTargetSelection, void(uint8_t optionIndex));
+    DEFINE_HOOK(OnUpdateFileQuestSelection, void(uint8_t questIndex));
+    DEFINE_HOOK(OnUpdateFileBossRushOptionSelection, void(uint8_t optionIndex, uint8_t optionValue));
+    DEFINE_HOOK(OnUpdateFileNameSelection, void(int16_t charCode));
     
     DEFINE_HOOK(OnSetGameLanguage, void());
 

--- a/soh/soh/Enhancements/game-interactor/GameInteractor_Hooks.cpp
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor_Hooks.cpp
@@ -92,6 +92,10 @@ void GameInteractor_ExecuteOnUpdateFileSelectSelection(uint16_t optionIndex) {
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnUpdateFileSelectSelection>(optionIndex);
 }
 
+void GameInteractor_ExecuteOnUpdateFileSelectConfirmationSelection(uint16_t optionIndex) {
+    GameInteractor::Instance->ExecuteHooks<GameInteractor::OnUpdateFileSelectConfirmationSelection>(optionIndex);
+}
+
 void GameInteractor_ExecuteOnUpdateFileCopySelection(uint16_t optionIndex) {
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnUpdateFileCopySelection>(optionIndex);
 }
@@ -114,6 +118,18 @@ void GameInteractor_ExecuteOnUpdateFileAudioSelection(uint8_t optionIndex) {
 
 void GameInteractor_ExecuteOnUpdateFileTargetSelection(uint8_t optionIndex) {
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnUpdateFileTargetSelection>(optionIndex);
+}
+
+void GameInteractor_ExecuteOnUpdateFileQuestSelection(uint8_t questIndex) {
+    GameInteractor::Instance->ExecuteHooks<GameInteractor::OnUpdateFileQuestSelection>(questIndex);
+}
+
+void GameInteractor_ExecuteOnUpdateFileBossRushOptionSelection(uint8_t optionIndex, uint8_t optionValue) {
+    GameInteractor::Instance->ExecuteHooks<GameInteractor::OnUpdateFileBossRushOptionSelection>(optionIndex, optionValue);
+}
+
+void GameInteractor_ExecuteOnUpdateFileNameSelection(int16_t charCode) {
+    GameInteractor::Instance->ExecuteHooks<GameInteractor::OnUpdateFileNameSelection>(charCode);
 }
 
 // MARK: - Game

--- a/soh/soh/Enhancements/game-interactor/GameInteractor_Hooks.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor_Hooks.h
@@ -32,12 +32,16 @@ void GameInteractor_ExecuteOnKaleidoscopeUpdate(int16_t inDungeonScene);
 // MARK: - Main Menu
 void GameInteractor_ExecuteOnPresentFileSelect();
 void GameInteractor_ExecuteOnUpdateFileSelectSelection(uint16_t optionIndex);
+void GameInteractor_ExecuteOnUpdateFileSelectConfirmationSelection(uint16_t optionIndex);
 void GameInteractor_ExecuteOnUpdateFileCopySelection(uint16_t optionIndex);
 void GameInteractor_ExecuteOnUpdateFileCopyConfirmationSelection(uint16_t optionIndex);
 void GameInteractor_ExecuteOnUpdateFileEraseSelection(uint16_t optionIndex);
 void GameInteractor_ExecuteOnUpdateFileEraseConfirmationSelection(uint16_t optionIndex);
 void GameInteractor_ExecuteOnUpdateFileAudioSelection(uint8_t optionIndex);
 void GameInteractor_ExecuteOnUpdateFileTargetSelection(uint8_t optionIndex);
+void GameInteractor_ExecuteOnUpdateFileQuestSelection(uint8_t questIndex);
+void GameInteractor_ExecuteOnUpdateFileBossRushOptionSelection(uint8_t optionIndex, uint8_t optionValue);
+void GameInteractor_ExecuteOnUpdateFileNameSelection(int16_t charCode);
 
 // MARK: - Game
 void GameInteractor_ExecuteOnSetGameLanguage();

--- a/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -383,7 +383,7 @@ void FileChoose_UpdateRandomizer() {
     }
 }
 
-uint16_t lastFileChooseButtonIndex;
+static s16 sLastFileChooseButtonIndex;
 
 /**
  * Update the cursor and wait for the player to select a button to change menus accordingly.
@@ -441,6 +441,8 @@ void FileChoose_UpdateMainMenu(GameState* thisx) {
                     this->nameEntryBoxPosX = 120;
                 }
 
+                sLastFileChooseButtonIndex = -1;
+
                 this->actionTimer = 8;
             } else {
                 Audio_PlaySoundGeneral(NA_SE_SY_FSEL_ERROR, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
@@ -487,10 +489,10 @@ void FileChoose_UpdateMainMenu(GameState* thisx) {
         } else {
             this->warningLabel = FS_WARNING_NONE;
         }
-        
-        if (lastFileChooseButtonIndex != this->buttonIndex) {
+
+        if (sLastFileChooseButtonIndex != this->buttonIndex) {
             GameInteractor_ExecuteOnUpdateFileSelectSelection(this->buttonIndex);
-            lastFileChooseButtonIndex = this->buttonIndex;
+            sLastFileChooseButtonIndex = this->buttonIndex;
         }
     }
 }
@@ -560,6 +562,8 @@ void FileChoose_StartQuestMenu(GameState* thisx) {
     if (this->logoAlpha >= 255) {
         this->logoAlpha = 255;
         this->configMode = CM_QUEST_MENU;
+
+        GameInteractor_ExecuteOnUpdateFileQuestSelection(this->questType[this->buttonIndex]);
     }
 }
 
@@ -614,6 +618,8 @@ void FileChoose_UpdateQuestMenu(GameState* thisx) {
         }
 
         Audio_PlaySoundGeneral(NA_SE_SY_FSEL_CURSOR, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
+
+        GameInteractor_ExecuteOnUpdateFileQuestSelection(this->questType[this->buttonIndex]);
     }
 
     if (CHECK_BTN_ALL(input->press.button, BTN_A)) {
@@ -651,9 +657,13 @@ void FileChoose_UpdateQuestMenu(GameState* thisx) {
 
     if (CHECK_BTN_ALL(input->press.button, BTN_B)) {
         this->configMode = CM_QUEST_TO_MAIN;
+        sLastFileChooseButtonIndex = -1;
         return;
     }
 }
+
+static s8 sLastBossRushOptionIndex = -1;
+static s8 sLastBossRushOptionValue = -1;
 
 void FileChoose_UpdateBossRushMenu(GameState* thisx) {
     FileChoose_UpdateStickDirectionPromptAnim(thisx);
@@ -724,6 +734,13 @@ void FileChoose_UpdateBossRushMenu(GameState* thisx) {
         }
 
         Audio_PlaySoundGeneral(NA_SE_SY_FSEL_CURSOR, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
+    }
+
+    if (sLastBossRushOptionIndex != this->bossRushIndex ||
+        sLastBossRushOptionValue != gSaveContext.bossRushOptions[this->bossRushIndex]) {
+        GameInteractor_ExecuteOnUpdateFileBossRushOptionSelection(this->bossRushIndex, gSaveContext.bossRushOptions[this->bossRushIndex]);
+        sLastBossRushOptionIndex = this->bossRushIndex;
+        sLastBossRushOptionValue = gSaveContext.bossRushOptions[this->bossRushIndex];
     }
 
     if (CHECK_BTN_ALL(input->press.button, BTN_B)) {
@@ -2072,6 +2089,7 @@ void FileChoose_FadeMainToSelect(GameState* thisx) {
         this->actionTimer = 8;
         this->selectMode++;
         this->confirmButtonIndex = FS_BTN_CONFIRM_YES;
+        sLastFileChooseButtonIndex = -1;
     }
 }
 
@@ -2149,6 +2167,11 @@ void FileChoose_ConfirmFile(GameState* thisx) {
         Audio_PlaySoundGeneral(NA_SE_SY_FSEL_CURSOR, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
         this->confirmButtonIndex ^= 1;
     }
+
+    if (sLastFileChooseButtonIndex != this->confirmButtonIndex) {
+        GameInteractor_ExecuteOnUpdateFileSelectConfirmationSelection(this->confirmButtonIndex);
+        sLastFileChooseButtonIndex = this->confirmButtonIndex;
+    }
 }
 
 /**
@@ -2169,6 +2192,7 @@ void FileChoose_FadeOutFileInfo(GameState* thisx) {
         this->nextTitleLabel = FS_TITLE_SELECT_FILE;
         this->actionTimer = 8;
         this->selectMode++;
+        sLastFileChooseButtonIndex = -1;
     }
 
     this->confirmButtonAlpha[0] = this->confirmButtonAlpha[1] = this->fileInfoAlpha[this->buttonIndex];

--- a/soh/src/overlays/gamestates/ovl_file_choose/z_file_copy_erase.c
+++ b/soh/src/overlays/gamestates/ovl_file_choose/z_file_copy_erase.c
@@ -54,7 +54,7 @@ void FileChoose_SetupCopySource(GameState* thisx) {
     }
 }
 
-uint16_t lastCopyEraseButtonIndex;
+static s16 sLastCopyEraseButtonIndex;
 
 /**
  * Allow the player to select a file to copy or exit back to the main menu.
@@ -112,10 +112,10 @@ void FileChoose_SelectCopySource(GameState* thisx) {
             }
         }
     }
-    
-    if (lastCopyEraseButtonIndex != this->buttonIndex) {
+
+    if (sLastCopyEraseButtonIndex != this->buttonIndex) {
         GameInteractor_ExecuteOnUpdateFileCopySelection(this->buttonIndex);
-        lastCopyEraseButtonIndex = this->buttonIndex;
+        sLastCopyEraseButtonIndex = this->buttonIndex;
     }
 }
 
@@ -239,6 +239,11 @@ void FileChoose_SelectCopyDest(GameState* thisx) {
             } else {
                 this->warningLabel = FS_WARNING_NONE;
             }
+        }
+
+        if (sLastCopyEraseButtonIndex != this->buttonIndex) {
+            GameInteractor_ExecuteOnUpdateFileCopySelection(this->buttonIndex);
+            sLastCopyEraseButtonIndex = this->buttonIndex;
         }
     }
 }
@@ -386,10 +391,10 @@ void FileChoose_CopyConfirm(GameState* thisx) {
         Audio_PlaySoundGeneral(NA_SE_SY_FSEL_CURSOR, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
         this->buttonIndex ^= 1;
     }
-    
-    if (lastCopyEraseButtonIndex != this->buttonIndex) {
+
+    if (sLastCopyEraseButtonIndex != this->buttonIndex) {
         GameInteractor_ExecuteOnUpdateFileCopyConfirmationSelection(this->buttonIndex);
-        lastCopyEraseButtonIndex = this->buttonIndex;
+        sLastCopyEraseButtonIndex = this->buttonIndex;
     }
 }
 
@@ -630,6 +635,8 @@ void FileChoose_ExitCopyToMain(GameState* thisx) {
 
     this->optionButtonAlpha = this->actionButtonAlpha[FS_BTN_ACTION_ERASE] =
         this->actionButtonAlpha[FS_BTN_ACTION_COPY];
+
+    sLastCopyEraseButtonIndex = -1;
 }
 
 /**
@@ -736,10 +743,10 @@ void FileChoose_EraseSelect(GameState* thisx) {
             this->warningLabel = FS_WARNING_NONE;
         }
     }
-    
-    if (lastCopyEraseButtonIndex != this->buttonIndex) {
+
+    if (sLastCopyEraseButtonIndex != this->buttonIndex) {
         GameInteractor_ExecuteOnUpdateFileEraseSelection(this->buttonIndex);
-        lastCopyEraseButtonIndex = this->buttonIndex;
+        sLastCopyEraseButtonIndex = this->buttonIndex;
     }
 }
 
@@ -850,10 +857,10 @@ void FileChoose_EraseConfirm(GameState* thisx) {
         Audio_PlaySoundGeneral(NA_SE_SY_FSEL_CURSOR, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
         this->buttonIndex ^= 1;
     }
-    
-    if (lastCopyEraseButtonIndex != this->buttonIndex) {
+
+    if (sLastCopyEraseButtonIndex != this->buttonIndex) {
         GameInteractor_ExecuteOnUpdateFileEraseConfirmationSelection(this->buttonIndex);
-        lastCopyEraseButtonIndex = this->buttonIndex;
+        sLastCopyEraseButtonIndex = this->buttonIndex;
     }
 }
 
@@ -1084,4 +1091,6 @@ void FileChoose_ExitEraseToMain(GameState* thisx) {
 
     this->optionButtonAlpha = this->actionButtonAlpha[FS_BTN_ACTION_ERASE] =
         this->actionButtonAlpha[FS_BTN_ACTION_COPY];
+
+    sLastCopyEraseButtonIndex = -1;
 }


### PR DESCRIPTION
There was some TTS on the file select menus, but not all of them, and now with boss rush in, the quest selection screen is always presented.

This PR adds TTS support for the missing areas:
* Quest Selection
* Name Entry
* Boss Rush options

This PR also more carefully reads out the last button hovered when going forward/back between menus.

https://github.com/HarbourMasters/Shipwright/assets/13861068/4f106097-e541-4837-9bd4-f8746c78d047

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/732216880.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/732216883.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/732216886.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/732216889.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/732216892.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/732216896.zip)
<!--- section:artifacts:end -->