### PR TITLE
Fix: Minimap dungeon entrance placement

### DIFF
--- a/soh/src/code/z_map_exp.c
+++ b/soh/src/code/z_map_exp.c
@@ -392,7 +392,9 @@ void Map_InitData(PlayState* play, s16 room) {
                     extendedMapIndex = 0x14;
                 }
             } else if (play->sceneNum == SCENE_SPOT06) {
-                if ((LINK_AGE_IN_YEARS == YEARS_ADULT) && !CHECK_QUEST_ITEM(QUEST_MEDALLION_WATER)) {
+                if ((LINK_AGE_IN_YEARS == YEARS_ADULT) &&
+                    ((!gSaveContext.n64ddFlag && !CHECK_QUEST_ITEM(QUEST_MEDALLION_WATER)) ||
+                     (gSaveContext.n64ddFlag && !Flags_GetRandomizerInf(RAND_INF_DUNGEONS_DONE_WATER_TEMPLE)))) {
                     extendedMapIndex = 0x15;
                 }
             } else if (play->sceneNum == SCENE_SPOT09) {
@@ -400,7 +402,8 @@ void Map_InitData(PlayState* play, s16 room) {
                     extendedMapIndex = 0x16;
                 }
             } else if (play->sceneNum == SCENE_SPOT12) {
-                if ((gSaveContext.eventChkInf[9] & 0xF) == 0xF) {
+                if ((!gSaveContext.n64ddFlag && ((gSaveContext.eventChkInf[9] & 0xF) == 0xF)) ||
+                    (gSaveContext.n64ddFlag && CHECK_QUEST_ITEM(QUEST_GERUDO_CARD))) {
                     extendedMapIndex = 0x17;
                 }
             }

--- a/soh/src/code/z_map_exp.c
+++ b/soh/src/code/z_map_exp.c
@@ -654,10 +654,6 @@ void Minimap_DrawCompassIcons(PlayState* play) {
                 Matrix_Translate(
                     (R_COMPASS_OFFSET_X + tempX + (CVarGetInteger("gMinimapPosX", 0)*10) / 10.0f),
                     (R_COMPASS_OFFSET_Y + ((Y_Margins_Minimap*10)*-1) - tempZ + ((CVarGetInteger("gMinimapPosY", 0)*10)*-1)) / 10.0f, 0.0f, MTXMODE_NEW);
-            } else if (CVarGetInteger("gMinimapPosType", 0) == 4) {//Hidden
-                Matrix_Translate(
-                    (R_COMPASS_OFFSET_X+(9999*10) + tempX / 10.0f),
-                    (R_COMPASS_OFFSET_Y+(9999*10) - tempZ) / 10.0f, 0.0f, MTXMODE_NEW);
             }
         } else {
             Matrix_Translate(OTRGetDimensionFromRightEdge((R_COMPASS_OFFSET_X+(X_Margins_Minimap*10) + tempX) / 10.0f), (R_COMPASS_OFFSET_Y+((Y_Margins_Minimap*10)*-1) - tempZ) / 10.0f, 0.0f, MTXMODE_NEW);
@@ -692,10 +688,6 @@ void Minimap_DrawCompassIcons(PlayState* play) {
                 Matrix_Translate(
                     (R_COMPASS_OFFSET_X + tempX + (CVarGetInteger("gMinimapPosX", 0)*10) / 10.0f),
                     (R_COMPASS_OFFSET_Y - tempZ + ((CVarGetInteger("gMinimapPosY", 0)*10)*-1)) / 10.0f, 0.0f, MTXMODE_NEW);
-            } else if (CVarGetInteger("gMinimapPosType", 0) == 4) {//Hidden
-                Matrix_Translate(
-                    (R_COMPASS_OFFSET_X+(9999*10) + tempX / 10.0f),
-                    (R_COMPASS_OFFSET_Y+(9999*10) - tempZ) / 10.0f, 0.0f, MTXMODE_NEW);
             }
         } else {
             Matrix_Translate(OTRGetDimensionFromRightEdge((R_COMPASS_OFFSET_X+(X_Margins_Minimap*10) + tempX) / 10.0f), (R_COMPASS_OFFSET_Y+((Y_Margins_Minimap*10)*-1) - tempZ) / 10.0f, 0.0f, MTXMODE_NEW);
@@ -752,7 +744,7 @@ void Minimap_Draw(PlayState* play) {
             case SCENE_HAKADAN:
             case SCENE_HAKADANCH:
             case SCENE_ICE_DOUKUTO:
-                if (!R_MINIMAP_DISABLED) {
+                if (!R_MINIMAP_DISABLED && CVarGetInteger("gMinimapPosType", 0) != 4) { // Not Hidden
                     Gfx_SetupDL_39Overlay(play->state.gfxCtx);
                     gDPSetCombineLERP(OVERLAY_DISP++, 1, 0, PRIMITIVE, 0, TEXEL0, 0, PRIMITIVE, 0, 1, 0, PRIMITIVE, 0,
                                       TEXEL0, 0, PRIMITIVE, 0);
@@ -776,8 +768,6 @@ void Minimap_Draw(PlayState* play) {
                                 dgnMiniMapX = OTRGetDimensionFromRightEdge(R_DGN_MINIMAP_X+CVarGetInteger("gMinimapPosX", 0)+X_Margins_Minimap);
                             } else if (CVarGetInteger("gMinimapPosType", 0) == 3) {//Anchor None
                                 dgnMiniMapX = CVarGetInteger("gMinimapPosX", 0);
-                            } else if (CVarGetInteger("gMinimapPosType", 0) == 4) {//Hidden
-                                dgnMiniMapX = -9999;
                             }
                         }
                         gSPWideTextureRectangle(OVERLAY_DISP++, dgnMiniMapX << 2, dgnMiniMapY << 2,
@@ -824,7 +814,7 @@ void Minimap_Draw(PlayState* play) {
             case SCENE_SPOT18:
             case SCENE_SPOT20:
             case SCENE_GANON_TOU:
-                if (!R_MINIMAP_DISABLED) {
+                if (!R_MINIMAP_DISABLED && CVarGetInteger("gMinimapPosType", 0) != 4) { // Not Hidden
                     Gfx_SetupDL_39Overlay(play->state.gfxCtx);
 
                     gDPSetCombineMode(OVERLAY_DISP++, G_CC_MODULATEIA_PRIM, G_CC_MODULATEIA_PRIM);
@@ -847,8 +837,6 @@ void Minimap_Draw(PlayState* play) {
                             oWMiniMapX = OTRGetDimensionFromRightEdge(R_OW_MINIMAP_X+CVarGetInteger("gMinimapPosX", 0)+X_Margins_Minimap);
                         } else if (CVarGetInteger("gMinimapPosType", 0) == 3) {//Anchor None
                             oWMiniMapX = CVarGetInteger("gMinimapPosX", 0);
-                        } else if (CVarGetInteger("gMinimapPosType", 0) == 4) {//Hidden
-                            oWMiniMapX = -9999;
                         }
                     }
                     gSPWideTextureRectangle(OVERLAY_DISP++, oWMiniMapX << 2, oWMiniMapY << 2,
@@ -883,20 +871,14 @@ void Minimap_Draw(PlayState* play) {
                                 entranceX = OTRGetRectDimensionFromRightEdge(PosX + CVarGetInteger("gMinimapPosX", 0));
                             } else if (CVarGetInteger("gMinimapPosType", 0) == 3) { // Anchor None
                                 entranceX = PosX + CVarGetInteger("gMinimapPosX", 0);
-                            } else if (CVarGetInteger("gMinimapPosType", 0) == 4) { // Hidden
-                                entranceX = -9999;
                             }
                         }
 
                         // For icons that normally would be placed in 0,0 leave them there based on the left edge dimension
-                        // or hide them entirely based on the settings
+                        // or hide them entirely if the fix is applied
                         if (gMapData->owEntranceIconPosY[sEntranceIconMapIndex] == 0) {
                             entranceY = 0;
-                            if (CVarGetInteger("gFixDungeonMinimapIcon", 0) || CVarGetInteger("gMinimapPosType", 0) == 4) { // Hidden
-                                entranceX = -9999;
-                            } else {
-                                entranceX = OTRGetRectDimensionFromLeftEdge(0);
-                            }
+                            entranceX = CVarGetInteger("gFixDungeonMinimapIcon", 0) ? -9999 : OTRGetRectDimensionFromLeftEdge(0);
                         }
 
                         //! @bug UB: sEntranceIconMapIndex can be up to 23 and is accessing owEntranceFlag which is size 20
@@ -924,8 +906,6 @@ void Minimap_Draw(PlayState* play) {
                             entranceX = OTRGetRectDimensionFromRightEdge(270 + X_Margins_Minimap + CVarGetInteger("gMinimapPosX", 0));
                         } else if (CVarGetInteger("gMinimapPosType", 0) == 3) {//Anchor None
                             entranceX = 270 + X_Margins_Minimap + CVarGetInteger("gMinimapPosX", 0);
-                        } else if (CVarGetInteger("gMinimapPosType", 0) == 4) {//Hidden
-                            entranceX = -9999;
                         }
                     }
 

--- a/soh/src/code/z_map_exp.c
+++ b/soh/src/code/z_map_exp.c
@@ -870,24 +870,33 @@ void Minimap_Draw(PlayState* play) {
                         // To address this, we take only the first 10 bits (which are later left-shifted by 2 to get our final 12 bits)
                         // to fix the entrance icon position when used with `gSPWideTextureRectangle`
                         s16 newY = gMapData->owEntranceIconPosY[sEntranceIconMapIndex] & 0x3FF;
-                        s16 PosX = gMapData->owEntranceIconPosX[sEntranceIconMapIndex] + (topLeft0 ? 0 : X_Margins_Minimap);
+                        s16 PosX = gMapData->owEntranceIconPosX[sEntranceIconMapIndex] + X_Margins_Minimap;
 
-                        s16 entranceX = topLeft0 ? OTRGetRectDimensionFromLeftEdge(PosX) : OTRGetRectDimensionFromRightEdge(PosX);
-                        s16 entranceY = newY + (topLeft0 ? 0 : Y_Margins_Minimap);
+                        s16 entranceX = OTRGetRectDimensionFromRightEdge(PosX);
+                        s16 entranceY = newY + Y_Margins_Minimap;
                         if (CVarGetInteger("gMinimapPosType", 0) != 0) {
-                            if (!topLeft0) {
-                                entranceY = newY + CVarGetInteger("gMinimapPosY", 0) + Y_Margins_Minimap;
-                                if (CVarGetInteger("gMinimapPosType", 0) == 1) {//Anchor Left
-                                    if (CVarGetInteger("gMinimapUseMargins", 0) != 0) {X_Margins_Minimap = Left_MM_Margin;};
-                                    entranceX = OTRGetRectDimensionFromLeftEdge(PosX + CVarGetInteger("gMinimapPosX", 0));
-                                } else if (CVarGetInteger("gMinimapPosType", 0) == 2) {//Anchor Right
-                                    if (CVarGetInteger("gMinimapUseMargins", 0) != 0) {X_Margins_Minimap = Right_MM_Margin;};
-                                    entranceX = OTRGetRectDimensionFromRightEdge(PosX + CVarGetInteger("gMinimapPosX", 0));
-                                } else if (CVarGetInteger("gMinimapPosType", 0) == 3) {//Anchor None
-                                    entranceX = PosX + CVarGetInteger("gMinimapPosX", 0);
-                                }
-                            } else if (CVarGetInteger("gMinimapPosType", 0) == 4) {//Hidden
+                            entranceY = newY + CVarGetInteger("gMinimapPosY", 0) + Y_Margins_Minimap;
+                            if (CVarGetInteger("gMinimapPosType", 0) == 1) { // Anchor Left
+                                if (CVarGetInteger("gMinimapUseMargins", 0) != 0) {X_Margins_Minimap = Left_MM_Margin;};
+                                entranceX = OTRGetRectDimensionFromLeftEdge(PosX + CVarGetInteger("gMinimapPosX", 0));
+                            } else if (CVarGetInteger("gMinimapPosType", 0) == 2) { // Anchor Right
+                                if (CVarGetInteger("gMinimapUseMargins", 0) != 0) {X_Margins_Minimap = Right_MM_Margin;};
+                                entranceX = OTRGetRectDimensionFromRightEdge(PosX + CVarGetInteger("gMinimapPosX", 0));
+                            } else if (CVarGetInteger("gMinimapPosType", 0) == 3) { // Anchor None
+                                entranceX = PosX + CVarGetInteger("gMinimapPosX", 0);
+                            } else if (CVarGetInteger("gMinimapPosType", 0) == 4) { // Hidden
                                 entranceX = -9999;
+                            }
+                        }
+
+                        // For icons that normally would be placed in 0,0 leave them there based on the left edge dimension
+                        // or hide them entirely based on the settings
+                        if (topLeft0) {
+                            entranceY = 0;
+                            if (CVarGetInteger("gFixDungeonMinimapIcon", 0) || CVarGetInteger("gMinimapPosType", 0) == 4) { // Hidden
+                                entranceX = -9999;
+                            } else {
+                                entranceX = OTRGetRectDimensionFromLeftEdge(0);
                             }
                         }
 
@@ -896,13 +905,11 @@ void Minimap_Draw(PlayState* play) {
                             ((gMapData->owEntranceFlag[sEntranceIconMapIndex] != 0xFFFF) &&
                               ((gSaveContext.infTable[26] & gBitFlags[gMapData->owEntranceFlag[mapIndex]]) ||
                                CVarGetInteger("gAlwaysShowDungeonMinimapIcon", 0)))) {
-                            if (!topLeft0 || !CVarGetInteger("gFixDungeonMinimapIcon", 0)) {
-                                gDPLoadTextureBlock(OVERLAY_DISP++, gMapDungeonEntranceIconTex, G_IM_FMT_RGBA, G_IM_SIZ_16b,
-                                                    iconSize, iconSize, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP,
-                                                    G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
-                                gSPWideTextureRectangle(OVERLAY_DISP++, entranceX << 2, entranceY << 2, (entranceX + iconSize) << 2,
-                                                       (entranceY + iconSize) << 2, G_TX_RENDERTILE, 0, 0, 1 << 10, 1 << 10);
-                            }
+                            gDPLoadTextureBlock(OVERLAY_DISP++, gMapDungeonEntranceIconTex, G_IM_FMT_RGBA, G_IM_SIZ_16b,
+                                                iconSize, iconSize, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP,
+                                                G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
+                            gSPWideTextureRectangle(OVERLAY_DISP++, entranceX << 2, entranceY << 2, (entranceX + iconSize) << 2,
+                                                    (entranceY + iconSize) << 2, G_TX_RENDERTILE, 0, 0, 1 << 10, 1 << 10);
                         }
                     }
 

--- a/soh/src/code/z_map_exp.c
+++ b/soh/src/code/z_map_exp.c
@@ -858,58 +858,50 @@ void Minimap_Draw(PlayState* play) {
 
                     gDPSetPrimColor(OVERLAY_DISP++, 0, 0, minimapColor.r, minimapColor.g, minimapColor.b, interfaceCtx->minimapAlpha);
 
+                    s16 iconSize = 8;
+
                     if (((play->sceneNum != SCENE_SPOT01) && (play->sceneNum != SCENE_SPOT04) &&
                          (play->sceneNum != SCENE_SPOT08)) ||
                         (LINK_AGE_IN_YEARS != YEARS_ADULT)) {
-                        bool Map0 = gMapData->owEntranceIconPosY[sEntranceIconMapIndex] << 2 == 0;
-                        s16 IconSize = 8;
-                        s16 PosX = gMapData->owEntranceIconPosX[sEntranceIconMapIndex] + (Map0 ? 0 : X_Margins_Minimap);
-                        s16 PosY = gMapData->owEntranceIconPosY[sEntranceIconMapIndex] + (Map0 ? 0 : Y_Margins_Minimap);
-                        //gFixDungeonMinimapIcon fix both Y position of visible icon and hide these non needed.
+                        u8 topLeft0 = gMapData->owEntranceIconPosY[sEntranceIconMapIndex] == 0;
+                        // The game authentically uses larger negative values for the entrance icon Y pos value. Normally only the first 12 bits
+                        // would be read when the final value is passed into `gSPTextureRectangle`, but our cosmetic hud placements requires using
+                        // `gSPWideTextureRectangle` which reads the first 24 bits instead. This caused the icon to be placed off screen.
+                        // To address this, we take only the first 10 bits (which are later left-shifted by 2 to get our final 12 bits)
+                        // to fix the entrance icon position when used with `gSPWideTextureRectangle`
+                        s16 newY = gMapData->owEntranceIconPosY[sEntranceIconMapIndex] & 0x3FF;
+                        s16 PosX = gMapData->owEntranceIconPosX[sEntranceIconMapIndex] + (topLeft0 ? 0 : X_Margins_Minimap);
 
-                        s16 TopLeftX = (Map0 ? OTRGetRectDimensionFromLeftEdge(PosX) : OTRGetRectDimensionFromRightEdge(PosX)) << 2;
-                        s16 TopLeftY = PosY << 2;
-                        s16 TopLeftW = (Map0 ? OTRGetRectDimensionFromLeftEdge(PosX + IconSize) : OTRGetRectDimensionFromRightEdge(PosX + IconSize)) << 2;
-                        s16 TopLeftH = (PosY + IconSize) << 2;
+                        s16 entranceX = topLeft0 ? OTRGetRectDimensionFromLeftEdge(PosX) : OTRGetRectDimensionFromRightEdge(PosX);
+                        s16 entranceY = newY + (topLeft0 ? 0 : Y_Margins_Minimap);
                         if (CVarGetInteger("gMinimapPosType", 0) != 0) {
-                            PosX = gMapData->owEntranceIconPosX[sEntranceIconMapIndex] + CVarGetInteger("gMinimapPosX", 0) + X_Margins_Minimap;
-                            PosY = gMapData->owEntranceIconPosY[sEntranceIconMapIndex] + CVarGetInteger("gMinimapPosY", 0) + Y_Margins_Minimap;
-                            if (CVarGetInteger("gMinimapPosType", 0) == 1) {//Anchor Left
-                                if (CVarGetInteger("gMinimapUseMargins", 0) != 0) {X_Margins_Minimap = Left_MM_Margin;};
-                                TopLeftX = OTRGetRectDimensionFromLeftEdge(PosX) << 2;
-                                TopLeftW = OTRGetRectDimensionFromLeftEdge(PosX + IconSize) << 2;
-                            } else if (CVarGetInteger("gMinimapPosType", 0) == 2) {//Anchor Right
-                                if (CVarGetInteger("gMinimapUseMargins", 0) != 0) {X_Margins_Minimap = Right_MM_Margin;};
-                                TopLeftX = OTRGetRectDimensionFromRightEdge(PosX) << 2;
-                                TopLeftW = OTRGetRectDimensionFromRightEdge(PosX + IconSize) << 2;
-                            } else if (CVarGetInteger("gMinimapPosType", 0) == 3) {//Anchor None
-                                TopLeftX = PosX << 2;
-                                TopLeftW = PosX + IconSize << 2;
+                            if (!topLeft0) {
+                                entranceY = newY + CVarGetInteger("gMinimapPosY", 0) + Y_Margins_Minimap;
+                                if (CVarGetInteger("gMinimapPosType", 0) == 1) {//Anchor Left
+                                    if (CVarGetInteger("gMinimapUseMargins", 0) != 0) {X_Margins_Minimap = Left_MM_Margin;};
+                                    entranceX = OTRGetRectDimensionFromLeftEdge(PosX + CVarGetInteger("gMinimapPosX", 0));
+                                } else if (CVarGetInteger("gMinimapPosType", 0) == 2) {//Anchor Right
+                                    if (CVarGetInteger("gMinimapUseMargins", 0) != 0) {X_Margins_Minimap = Right_MM_Margin;};
+                                    entranceX = OTRGetRectDimensionFromRightEdge(PosX + CVarGetInteger("gMinimapPosX", 0));
+                                } else if (CVarGetInteger("gMinimapPosType", 0) == 3) {//Anchor None
+                                    entranceX = PosX + CVarGetInteger("gMinimapPosX", 0);
+                                }
                             } else if (CVarGetInteger("gMinimapPosType", 0) == 4) {//Hidden
-                                TopLeftX = -9999 << 2;
-                                TopLeftW = -9999 + IconSize << 2;
+                                entranceX = -9999;
                             }
-                            if (!CVarGetInteger("gMinimapPosType", 0) != 4 && Map0 && !CVarGetInteger("gFixDungeonMinimapIcon", 0)) { //Force top left icon if fix not applied.
-                                TopLeftX = OTRGetRectDimensionFromLeftEdge(gMapData->owEntranceIconPosX[sEntranceIconMapIndex]) << 2;
-                                TopLeftY = gMapData->owEntranceIconPosY[sEntranceIconMapIndex] << 2;
-                                TopLeftW = OTRGetRectDimensionFromLeftEdge(gMapData->owEntranceIconPosX[sEntranceIconMapIndex] + IconSize) << 2;
-                                TopLeftH = (gMapData->owEntranceIconPosY[sEntranceIconMapIndex] + IconSize) << 2;
-                            }
-                        }
-                        if (CVarGetInteger("gFixDungeonMinimapIcon", 0) != 0){
-                            //No idea why and how Original value work but this does actually fix them all.
-                            PosY = PosY+1024;
                         }
 
-                        if (((gMapData->owEntranceFlag[sEntranceIconMapIndex] == 0xFFFF) ||
-                             ((gMapData->owEntranceFlag[sEntranceIconMapIndex] != 0xFFFF) &&
-                              (gSaveContext.infTable[26] & gBitFlags[gMapData->owEntranceFlag[mapIndex]])
-                             )) || CVarGetInteger("gAlwaysShowDungeonMinimapIcon", 0)) {
-                            if (!Map0 || !CVarGetInteger("gFixDungeonMinimapIcon", 0)) {
+                        //! @bug UB: sEntranceIconMapIndex can be up to 23 and is accessing owEntranceFlag which is size 20
+                        if ((gMapData->owEntranceFlag[sEntranceIconMapIndex] == 0xFFFF) ||
+                            ((gMapData->owEntranceFlag[sEntranceIconMapIndex] != 0xFFFF) &&
+                              ((gSaveContext.infTable[26] & gBitFlags[gMapData->owEntranceFlag[mapIndex]]) ||
+                               CVarGetInteger("gAlwaysShowDungeonMinimapIcon", 0)))) {
+                            if (!topLeft0 || !CVarGetInteger("gFixDungeonMinimapIcon", 0)) {
                                 gDPLoadTextureBlock(OVERLAY_DISP++, gMapDungeonEntranceIconTex, G_IM_FMT_RGBA, G_IM_SIZ_16b,
-                                                    IconSize, IconSize, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP,
+                                                    iconSize, iconSize, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP,
                                                     G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
-                                gSPWideTextureRectangle(OVERLAY_DISP++, TopLeftX, TopLeftY, TopLeftW, TopLeftH, G_TX_RENDERTILE, 0, 0, 1 << 10, 1 << 10);
+                                gSPWideTextureRectangle(OVERLAY_DISP++, entranceX << 2, entranceY << 2, (entranceX + iconSize) << 2,
+                                                       (entranceY + iconSize) << 2, G_TX_RENDERTILE, 0, 0, 1 << 10, 1 << 10);
                             }
                         }
                     }
@@ -931,20 +923,14 @@ void Minimap_Draw(PlayState* play) {
                         }
                     }
 
-                    if ((play->sceneNum == SCENE_SPOT08) && (gSaveContext.infTable[26] & gBitFlags[9])) {
-                        gDPLoadTextureBlock(OVERLAY_DISP++, gMapDungeonEntranceIconTex, G_IM_FMT_RGBA, G_IM_SIZ_16b, 8,
-                                            8, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK,
+                    // Ice Cavern entrance icon
+                    if ((play->sceneNum == SCENE_SPOT08) && ((gSaveContext.infTable[26] & gBitFlags[9]) ||
+                        CVarGetInteger("gAlwaysShowDungeonMinimapIcon", 0))) {
+                        gDPLoadTextureBlock(OVERLAY_DISP++, gMapDungeonEntranceIconTex, G_IM_FMT_RGBA, G_IM_SIZ_16b, iconSize,
+                                            iconSize, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK,
                                             G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
-                        gSPWideTextureRectangle(OVERLAY_DISP++, entranceX << 2, entranceY << 2, (entranceX + 32) << 2, (entranceY + 8) << 2,
-                                                G_TX_RENDERTILE, 0, 0, 1 << 10, 1 << 10);
-                    } else if ((play->sceneNum == SCENE_SPOT08) && CVarGetInteger("gAlwaysShowDungeonMinimapIcon", 0) != 0){
-
-                        gDPLoadTextureBlock(OVERLAY_DISP++, gMapDungeonEntranceIconTex, G_IM_FMT_RGBA, G_IM_SIZ_16b, 8,
-                                            8, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK,
-                                            G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
-
-                        gSPWideTextureRectangle(OVERLAY_DISP++, entranceX << 2, entranceY << 2, (entranceX + 32) << 2, (entranceY + 8) << 2,
-                                                G_TX_RENDERTILE, 0, 0, 1 << 10, 1 << 10);
+                        gSPWideTextureRectangle(OVERLAY_DISP++, entranceX << 2, entranceY << 2, (entranceX + iconSize) << 2,
+                                               (entranceY + iconSize) << 2, G_TX_RENDERTILE, 0, 0, 1 << 10, 1 << 10);
                     }
 
                     Minimap_DrawCompassIcons(play); // Draw icons for the player spawn and current position

--- a/soh/src/code/z_map_exp.c
+++ b/soh/src/code/z_map_exp.c
@@ -863,7 +863,6 @@ void Minimap_Draw(PlayState* play) {
                     if (((play->sceneNum != SCENE_SPOT01) && (play->sceneNum != SCENE_SPOT04) &&
                          (play->sceneNum != SCENE_SPOT08)) ||
                         (LINK_AGE_IN_YEARS != YEARS_ADULT)) {
-                        u8 topLeft0 = gMapData->owEntranceIconPosY[sEntranceIconMapIndex] == 0;
                         // The game authentically uses larger negative values for the entrance icon Y pos value. Normally only the first 12 bits
                         // would be read when the final value is passed into `gSPTextureRectangle`, but our cosmetic hud placements requires using
                         // `gSPWideTextureRectangle` which reads the first 24 bits instead. This caused the icon to be placed off screen.
@@ -891,7 +890,7 @@ void Minimap_Draw(PlayState* play) {
 
                         // For icons that normally would be placed in 0,0 leave them there based on the left edge dimension
                         // or hide them entirely based on the settings
-                        if (topLeft0) {
+                        if (gMapData->owEntranceIconPosY[sEntranceIconMapIndex] == 0) {
                             entranceY = 0;
                             if (CVarGetInteger("gFixDungeonMinimapIcon", 0) || CVarGetInteger("gMinimapPosType", 0) == 4) { // Hidden
                                 entranceX = -9999;


### PR DESCRIPTION
This PR accomplishes a few goals around the minimap dungeon entrance icon:

* Fix the missing dungeon entrance icons due to authentic game data values and our custom Fast3D opcodes
* Fix dungeon entrance icon not positioning correctly with various hud placement settings
* Simply the dungeon entrance icon logic

The first issue I noticed when working on the Mirror World PR was that all the dungeon entrance icons (except for ice cavern) never appeared. Digging into it I found the issue is that the games data uses large negative values for the Y pos values here:

https://github.com/HarbourMasters/Shipwright/blob/7e1ee6e23efc08feb209f285b0e7c3d896399024/soh/src/code/z_map_data.c#L227-L229

In hardware this is fine as the game uses `gSPTextureRectangle` which truncates the number and only keeps 12 bits (U10.2). The issue is after we introduced and switched to `gSPWideTextureRectangle` the value was now only truncated at 24 bits, meaning the icon would now be placed off screen. Early cosmetic editor days shows that we were applying an arbitrary `+ 1024` which pushed the authentic value back to a positive number in the range that it should have been, but after a later cosmetic editor change, this "fix" was running after all the checks and was effectively dead code.

To address this I am reapplying this fix at the beginning of all the logic to bitwise AND with `0x3FF` to keep only the first 10 bits (and later will be shifted by 2 for the U10.2 value). I opted for the bitwise over the 1024 cause it felt more clear why it was happening.

The second issue I noticed is that all the cosmetic margin/anchor logic was essentially broken for the icon, so I've refactored it following the pattern used for the minimap itself.

Other refactorings I did was merge duplicate code paths under a single branch and apply the `gAlwaysShowDungeonMinimapIcon` in the right spot (where the entrance flag is checked).

The other fix I added was to display the correct minimap in randomizer:
* The Lake Hylia with filled lake minimap is now displayed when the water temple is cleared for rando
* The Gerudo Fortress map showing horse back archery is shown when the membership card is found for rando

Let me know if we want to reduce the scope of this PR

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/738193636.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/738193637.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/738193639.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/738193640.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/738193643.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/738193645.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/738193648.zip)
<!--- section:artifacts:end -->