### PR TITLE
Fix: Cosmetic HUD placement reset position corrupting ship json

### DIFF
--- a/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
+++ b/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
@@ -371,13 +371,11 @@ void SetMarginAll(const char* ButtonName, bool SetActivated) {
 }
 void ResetPositionAll() {
     if (ImGui::Button("Reset all positions")) {
-        u8 arrayLength = sizeof(MarginCvarList) / sizeof(*MarginCvarList);
-        for (u8 s = 0; s < arrayLength; s++) {
-            const char* cvarName = MarginCvarList[s];
-            const char* cvarPosType = std::string(cvarName).append("PosType").c_str();
-            const char* cvarNameMargins = std::string(cvarName).append("UseMargins").c_str();
-            CVarSetInteger(cvarPosType, 0);
-            CVarSetInteger(cvarNameMargins, false); //Turn margin off to everythings as that original position.
+        for (auto cvarName : MarginCvarList) {
+            std::string cvarPosType = std::string(cvarName).append("PosType");
+            std::string cvarNameMargins = std::string(cvarName).append("UseMargins");
+            CVarSetInteger(cvarPosType.c_str(), 0);
+            CVarSetInteger(cvarNameMargins.c_str(), false); //Turn margin off to everythings as that original position.
         }
     }
 }


### PR DESCRIPTION
The ship.json was getting corrupted upon saving after pressing the "Reset all positions" button in the hud placements section for the Cosmetic Editor.

The problem was the variable type we were assigning to was `const char*` and in the assignment we were doing a call to `std::string(const char* str)` this resulted in a `Implicit Constructor call not supported` leading to undefined behavior when building the final CVar name.

The solution is to capture the assignment as a `std:string` and performing the final `.c_str()` when calling the CVar method. This is how it was being done for all the other buttons here.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/734962685.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/734962687.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/734962688.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/734962689.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/734962690.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/734962691.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/734962692.zip)
<!--- section:artifacts:end -->