### PR TITLE
Fix some ganon2 offsets

### DIFF
--- a/soh/assets/xml/GC_NMQ_PAL_F/overlays/ovl_Boss_Ganon2.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/overlays/ovl_Boss_Ganon2.xml
@@ -36,7 +36,7 @@
         <Array Name="ovl_Boss_Ganon2_Vtx_00EAE0" Count="22" Offset="0x00E7A0">
             <Vtx/>
         </Array>
-        <DList Name="ovl_Boss_Ganon2_DL_00EC40" Offset="0x00E900"/>
+        <DList Name="ovl_Boss_Ganon2_DL_00EC40" Offset="0x00E8E0"/>
         <Texture Name="ovl_Boss_Ganon2_Tex_00ED48" OutName="tex_0000ED48" Format="i8" Width="32" Height="32" Offset="0x00EA08"/>
         <Array Name="ovl_Boss_Ganon2_Vtx_00F148" Count="4" Offset="0x00EE08">
             <Vtx/>
@@ -71,6 +71,6 @@
         <Array Name="ovl_Boss_Ganon2_Vtx_010298" Count="17" Offset="0xFF58">
             <Vtx/>
         </Array>
-        <DList Name="ovl_Boss_Ganon2_DL_0103A8" Offset="0x010168"/>
+        <DList Name="ovl_Boss_Ganon2_DL_0103A8" Offset="0x010160"/>
     </File>
 </Root>


### PR DESCRIPTION
@NEstelami or @Jack-Walker would you mind spot checking these to verify they were wrong and these new ones are right if/when you have a chance?

My initial theory after seeing these were wrong was that this would fix the flashing master sword issue right before you finish off ganon, but I am unable to reproduce that on my Mac.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/736946217.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/736946219.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/736946221.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/736946223.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/736946225.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/736946227.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/736946230.zip)
<!--- section:artifacts:end -->