### PR TITLE
Fix: crash when resetting links scale without a playstate

### DIFF
--- a/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
+++ b/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
@@ -1427,7 +1427,7 @@ void DrawSillyTab() {
             LUS::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
         }
     }
-    if (UIWidgets::EnhancementSliderFloat("Link Body Scale: %f", "##Link_BodyScale", "gCosmetics.Link_BodyScale.Value", 0.001f, 0.025f, "", 0.01f, false)) {
+    if (UIWidgets::EnhancementSliderFloat("Link Body Scale: %f", "##Link_BodyScale", "gCosmetics.Link_BodyScale.Value", 0.001f, 0.025f, "", 0.01f, true)) {
         CVarSetInteger("gCosmetics.Link_BodyScale.Changed", 1);
     }
     ImGui::SameLine();
@@ -1435,10 +1435,12 @@ void DrawSillyTab() {
         CVarClear("gCosmetics.Link_BodyScale.Value");
         CVarClear("gCosmetics.Link_BodyScale.Changed");
         LUS::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
-        static Player* player = GET_PLAYER(gPlayState);
-        player->actor.scale.x = 0.01f;
-        player->actor.scale.y = 0.01f;
-        player->actor.scale.z = 0.01f;
+        if (gPlayState != nullptr) {
+            static Player* player = GET_PLAYER(gPlayState);
+            player->actor.scale.x = 0.01f;
+            player->actor.scale.y = 0.01f;
+            player->actor.scale.z = 0.01f;
+        }
     }
     if (UIWidgets::EnhancementSliderFloat("Link Head Scale: %f", "##Link_HeadScale", "gCosmetics.Link_HeadScale.Value", 0.4f, 4.0f, "", 1.0f, false)) {
         CVarSetInteger("gCosmetics.Link_HeadScale.Changed", 1);


### PR DESCRIPTION
The reset button for links body scale in the cosmetic editor was missing a playstate null check. This addresses a crash when clicking the reset button without a playstate.

Also switch the slider for links body scale to be in "percent mode" so the step size is smaller, otherwise the plus/mins buttons only worked once and would go to the min/max values.

A better solution is to allow passing in the step-size to the slider component, but thats out of scope here.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/737500890.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/737500892.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/737500893.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/737500894.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/737500895.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/737500896.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/737500898.zip)
<!--- section:artifacts:end -->