### PR TITLE
Boss Rush - Fix missing goron bracelet

### DIFF
--- a/soh/soh/Enhancements/boss-rush/BossRush.cpp
+++ b/soh/soh/Enhancements/boss-rush/BossRush.cpp
@@ -426,6 +426,7 @@ void BossRush_InitSave() {
     Inventory_ChangeUpgrade(UPG_BULLET_BAG, upgradeLevel);
     Inventory_ChangeUpgrade(UPG_STICKS, upgradeLevel);
     Inventory_ChangeUpgrade(UPG_NUTS, upgradeLevel);
+    Inventory_ChangeUpgrade(UPG_STRENGTH, 1);
 
     // Set flags and Link's age based on chosen settings.
     if (gSaveContext.bossRushOptions[BR_OPTIONS_BOSSES] == BR_CHOICE_BOSSES_ADULT ||


### PR DESCRIPTION
Must've missed it when I refactored some stuff during development. It is intended to allow the use of bomb flowers in the king dodongo fight.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/738449427.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/738449428.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/738449431.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/738449432.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/738449433.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/738449434.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/738449435.zip)
<!--- section:artifacts:end -->