### PR TITLE
Extra modes tweaks

### DIFF
--- a/soh/soh/Enhancements/enemyrandomizer.cpp
+++ b/soh/soh/Enhancements/enemyrandomizer.cpp
@@ -2,6 +2,7 @@
 #include "functions.h"
 #include "macros.h"
 #include "soh/Enhancements/randomizer/3drando/random.hpp"
+#include "soh/Enhancements/enhancementTypes.h"
 #include "variables.h"
 
 extern "C" {
@@ -232,16 +233,13 @@ extern "C" uint8_t GetRandomizedEnemy(PlayState* play, int16_t *actorId, f32 *po
 }
 
 EnemyEntry GetRandomizedEnemyEntry(uint32_t seed) {
-    if (CVarGetInteger("gSeededRandomizedEnemies", 0) && gSaveContext.n64ddFlag) {
-        uint32_t finalSeed = seed + gSaveContext.seedIcons[0] + gSaveContext.seedIcons[1] + gSaveContext.seedIcons[2] +
-                        gSaveContext.seedIcons[3] + gSaveContext.seedIcons[4];
+    if (CVarGetInteger("gRandomizedEnemies", ENEMY_RANDOMIZER_OFF) == ENEMY_RANDOMIZER_RANDOM_SEEDED) {
+        uint32_t finalSeed = seed + (gSaveContext.n64ddFlag ? (gSaveContext.seedIcons[0] + gSaveContext.seedIcons[1] + gSaveContext.seedIcons[2] + gSaveContext.seedIcons[3] + gSaveContext.seedIcons[4]) : gSaveContext.sohStats.fileCreatedAt);
         Random_Init(finalSeed);
-        uint32_t randomNumber = Random(0, RANDOMIZED_ENEMY_SPAWN_TABLE_SIZE);
-        return randomizedEnemySpawnTable[randomNumber];
-    } else {
-        uint32_t randomNumber = rand() + seed;
-        return randomizedEnemySpawnTable[randomNumber % RANDOMIZED_ENEMY_SPAWN_TABLE_SIZE];
     }
+
+    uint32_t randomNumber = Random(0, RANDOMIZED_ENEMY_SPAWN_TABLE_SIZE);
+    return randomizedEnemySpawnTable[randomNumber];
 }
 
 bool IsEnemyFoundToRandomize(int16_t sceneNum, int8_t roomNum, int16_t actorId, int16_t params, float posX) {

--- a/soh/soh/Enhancements/enhancementTypes.h
+++ b/soh/soh/Enhancements/enhancementTypes.h
@@ -19,6 +19,12 @@ typedef enum {
 } MirroredWorldMode;
 
 typedef enum {
+    ENEMY_RANDOMIZER_OFF,
+    ENEMY_RANDOMIZER_RANDOM,
+    ENEMY_RANDOMIZER_RANDOM_SEEDED,
+} EnemyRandomizerMode;
+
+typedef enum {
     FASTFILE_1,
     FASTFILE_2,
     FASTFILE_3,

--- a/soh/soh/config/ConfigUpdaters.cpp
+++ b/soh/soh/config/ConfigUpdaters.cpp
@@ -57,7 +57,7 @@ namespace LUS {
             if (CVarGetInteger("gSeededRandomizedEnemies", 0)) {
                 CVarSetInteger("gRandomizedEnemies", 2);
             }
-            CVarClear("gSeededRandomizedEnemies");
         }
+        CVarClear("gSeededRandomizedEnemies");
     }
 }

--- a/soh/soh/config/ConfigUpdaters.cpp
+++ b/soh/soh/config/ConfigUpdaters.cpp
@@ -53,5 +53,11 @@ namespace LUS {
             CVarSetInteger("gZFightingMode", CVarGetInteger("gDirtPathFix", 0));
             CVarClear("gDirtPathFix");
         }
+        if (CVarGetInteger("gRandomizedEnemies", 0) != 0) {
+            if (CVarGetInteger("gSeededRandomizedEnemies", 0)) {
+                CVarSetInteger("gRandomizedEnemies", 2);
+            }
+            CVarClear("gSeededRandomizedEnemies");
+        }
     }
 }


### PR DESCRIPTION
Summary:
- Moved CC checkbox to extra modes
  - CC now only calls enable/disable on click instead of every frame menu is open
- Moved enemy rando to extra modes
  - Combined both enemy rando checkboxes into a single combobox (migration included)
  - Seeded enemy rando can now be enabled on vanilla saves (previously limited to rando)
  - Enemy rando now always relies on 3drando algorithm
- Fixed tooltips for Rupee Dash and Shadow Tag

<img width="747" alt="Screenshot 2023-06-12 at 9 50 44 PM" src="https://github.com/HarbourMasters/Shipwright/assets/7316699/2059742d-4e80-44f3-b695-5ad4ecdf76b0">

<img width="191" alt="Screenshot 2023-06-12 at 9 36 07 PM" src="https://github.com/HarbourMasters/Shipwright/assets/7316699/fdc50b38-c879-49a4-abb6-c3a324de0ac1">

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/750867299.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/750867300.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/750867301.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/750867302.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/750867303.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/750867304.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/750867305.zip)
<!--- section:artifacts:end -->