### PR TITLE
hide menu bar from menu bar

### DIFF
--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -131,11 +131,6 @@ void DrawShipMenu() {
                             )) {
             std::reinterpret_pointer_cast<LUS::ConsoleWindow>(LUS::Context::GetInstance()->GetWindow()->GetGui()->GetGuiWindow("Console"))->Dispatch("reset");
         }
-#if !defined(__SWITCH__) && !defined(__WIIU__)
-        auto backend = LUS::Context::GetInstance()->GetWindow()->GetWindowBackend();
-        if (ImGui::MenuItem("Toggle Fullscreen", "F11")) {
-            LUS::Context::GetInstance()->GetWindow()->ToggleFullscreen();
-        }
         if (ImGui::MenuItem("Hide Menu Bar",
 #if !defined(__SWITCH__) && !defined(__WIIU__)
          "F1"
@@ -144,6 +139,11 @@ void DrawShipMenu() {
 #endif
         )) {
             LUS::Context::GetInstance()->GetWindow()->GetGui()->GetMenuBar()->ToggleVisibility();
+        }
+#if !defined(__SWITCH__) && !defined(__WIIU__)
+        auto backend = LUS::Context::GetInstance()->GetWindow()->GetWindowBackend();
+        if (ImGui::MenuItem("Toggle Fullscreen", "F11")) {
+            LUS::Context::GetInstance()->GetWindow()->ToggleFullscreen();
         }
         if (ImGui::MenuItem("Quit")) {
             LUS::Context::GetInstance()->GetWindow()->Close();

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -131,6 +131,7 @@ void DrawShipMenu() {
                             )) {
             std::reinterpret_pointer_cast<LUS::ConsoleWindow>(LUS::Context::GetInstance()->GetWindow()->GetGui()->GetGuiWindow("Console"))->Dispatch("reset");
         }
+        UIWidgets::Spacer(0);
         if (ImGui::MenuItem("Hide Menu Bar",
 #if !defined(__SWITCH__) && !defined(__WIIU__)
          "F1"
@@ -142,9 +143,11 @@ void DrawShipMenu() {
         }
 #if !defined(__SWITCH__) && !defined(__WIIU__)
         auto backend = LUS::Context::GetInstance()->GetWindow()->GetWindowBackend();
+        UIWidgets::Spacer(0);
         if (ImGui::MenuItem("Toggle Fullscreen", "F11")) {
             LUS::Context::GetInstance()->GetWindow()->ToggleFullscreen();
         }
+        UIWidgets::Spacer(0);
         if (ImGui::MenuItem("Quit")) {
             LUS::Context::GetInstance()->GetWindow()->Close();
         }

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -123,8 +123,10 @@ void DrawShipMenu() {
         if (ImGui::MenuItem("Reset",
 #ifdef __APPLE__
                             "Command-R"
-#else
+#elif !defined(__SWITCH__) && !defined(__WIIU__)
                             "Ctrl+R"
+#else
+                            ""
 #endif
                             )) {
             std::reinterpret_pointer_cast<LUS::ConsoleWindow>(LUS::Context::GetInstance()->GetWindow()->GetGui()->GetGuiWindow("Console"))->Dispatch("reset");
@@ -134,7 +136,13 @@ void DrawShipMenu() {
         if (ImGui::MenuItem("Toggle Fullscreen", "F11")) {
             LUS::Context::GetInstance()->GetWindow()->ToggleFullscreen();
         }
-        if (ImGui::MenuItem("Hide Menu Bar", "F1")) {
+        if (ImGui::MenuItem("Hide Menu Bar",
+#if !defined(__SWITCH__) && !defined(__WIIU__)
+         "F1"
+#else
+         ""
+#endif
+        )) {
             LUS::Context::GetInstance()->GetWindow()->GetGui()->GetMenuBar()->ToggleVisibility();
         }
         if (ImGui::MenuItem("Quit")) {

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -134,6 +134,9 @@ void DrawShipMenu() {
         if (ImGui::MenuItem("Toggle Fullscreen", "F11")) {
             LUS::Context::GetInstance()->GetWindow()->ToggleFullscreen();
         }
+        if (ImGui::MenuItem("Hide Menu Bar", "F1")) {
+            LUS::Context::GetInstance()->GetWindow()->GetGui()->GetMenuBar()->ToggleVisibility();
+        }
         if (ImGui::MenuItem("Quit")) {
             LUS::Context::GetInstance()->GetWindow()->Close();
         }

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -120,6 +120,22 @@ void DrawMenuBarIcon() {
 
 void DrawShipMenu() {
     if (ImGui::BeginMenu("Ship")) {
+        if (ImGui::MenuItem("Hide Menu Bar",
+#if !defined(__SWITCH__) && !defined(__WIIU__)
+         "F1"
+#else
+         "[-]"
+#endif
+        )) {
+            LUS::Context::GetInstance()->GetWindow()->GetGui()->GetMenuBar()->ToggleVisibility();
+        }
+        UIWidgets::Spacer(0);
+#if !defined(__SWITCH__) && !defined(__WIIU__)
+        if (ImGui::MenuItem("Toggle Fullscreen", "F11")) {
+            LUS::Context::GetInstance()->GetWindow()->ToggleFullscreen();
+        }
+        UIWidgets::Spacer(0);
+#endif
         if (ImGui::MenuItem("Reset",
 #ifdef __APPLE__
                             "Command-R"
@@ -131,22 +147,7 @@ void DrawShipMenu() {
                             )) {
             std::reinterpret_pointer_cast<LUS::ConsoleWindow>(LUS::Context::GetInstance()->GetWindow()->GetGui()->GetGuiWindow("Console"))->Dispatch("reset");
         }
-        UIWidgets::Spacer(0);
-        if (ImGui::MenuItem("Hide Menu Bar",
 #if !defined(__SWITCH__) && !defined(__WIIU__)
-         "F1"
-#else
-         "-"
-#endif
-        )) {
-            LUS::Context::GetInstance()->GetWindow()->GetGui()->GetMenuBar()->ToggleVisibility();
-        }
-#if !defined(__SWITCH__) && !defined(__WIIU__)
-        auto backend = LUS::Context::GetInstance()->GetWindow()->GetWindowBackend();
-        UIWidgets::Spacer(0);
-        if (ImGui::MenuItem("Toggle Fullscreen", "F11")) {
-            LUS::Context::GetInstance()->GetWindow()->ToggleFullscreen();
-        }
         UIWidgets::Spacer(0);
         if (ImGui::MenuItem("Quit")) {
             LUS::Context::GetInstance()->GetWindow()->Close();

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -140,7 +140,7 @@ void DrawShipMenu() {
 #if !defined(__SWITCH__) && !defined(__WIIU__)
          "F1"
 #else
-         ""
+         "-"
 #endif
         )) {
             LUS::Context::GetInstance()->GetWindow()->GetGui()->GetMenuBar()->ToggleVisibility();


### PR DESCRIPTION
![image](https://github.com/HarbourMasters/Shipwright/assets/70942617/3af617e6-2104-441c-bf76-70e0cf250e5e)
![image](https://github.com/HarbourMasters/Shipwright/assets/70942617/5982dd66-617e-4a3b-944c-fc2719e32608)
![image](https://github.com/HarbourMasters/Shipwright/assets/70942617/0413d64e-7a86-44f1-9b70-ad2814265471)

people didn't know how to hide it (forgot what they pressed to open it), this should make that functionality more discoverable

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/748302991.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/748302992.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/748302993.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/748302994.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/748302995.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/748302996.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/748302997.zip)
<!--- section:artifacts:end -->