### PR TITLE
fix epona stealing in rando

### DIFF
--- a/soh/include/functions.h
+++ b/soh/include/functions.h
@@ -553,6 +553,7 @@ Actor* func_800358DC(Actor* actor, Vec3f* spawnPos, Vec3s* spawnRot, f32* arg3, 
 void func_800359B8(Actor* actor, s16 arg1, Vec3s* arg2);
 s32 Flags_GetEventChkInf(s32 flag);
 void Flags_SetEventChkInf(s32 flag);
+void Flags_UnsetEventChkInf(s32 flag);
 s32 Flags_GetInfTable(s32 flag);
 void Flags_SetInfTable(s32 flag);
 s32 Flags_GetRandomizerInf(RandomizerInf flag);

--- a/soh/src/code/z_actor.c
+++ b/soh/src/code/z_actor.c
@@ -4706,6 +4706,13 @@ void Flags_SetEventChkInf(s32 flag) {
 }
 
 /**
+ * Unsets event_chk_inf flag.
+ */
+void Flags_UnsetEventChkInf(s32 flag) {
+    gSaveContext.eventChkInf[flag >> 4] &= ~(1 << (flag & 0xF));
+}
+
+/**
  * Tests if "inf_table flag is set.
  */
 s32 Flags_GetInfTable(s32 flag) {

--- a/soh/src/code/z_demo.c
+++ b/soh/src/code/z_demo.c
@@ -2125,6 +2125,15 @@ void Cutscene_HandleEntranceTriggers(PlayState* play) {
         return;
     }
 
+    // epona steal fix
+    if (gSaveContext.n64ddFlag &&
+        gSaveContext.entranceIndex == 650 ||
+        gSaveContext.entranceIndex == 654 ||
+        gSaveContext.entranceIndex == 658 ||
+        gSaveContext.entranceIndex == 1142) {
+        Flags_UnsetEventChkInf(EVENTCHKINF_EPONA_OBTAINED);
+    }
+
     for (i = 0; i < ARRAY_COUNT(sEntranceCutsceneTable); i++) {
         entranceCutscene = &sEntranceCutsceneTable[i];
 


### PR DESCRIPTION
pretty sure this fixes https://github.com/HarbourMasters/Shipwright/issues/1938 (cutscene played and i was riding epona out of every exit i tested)

edit for clarity: on a seed that leads to the horseless epona cutscenes on dev (`RSK_SKIP_EPONA_RACE` set to "Skip")

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/748621113.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/748621114.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/748621116.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/748621117.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/748621118.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/748621119.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/748621120.zip)
<!--- section:artifacts:end -->