### PR TITLE
caps for locations in altar text

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/hints.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/hints.cpp
@@ -607,7 +607,7 @@ static Text BuildDungeonRewardText(const uint32_t itemKey) {
   std::string rewardString = "$" + std::to_string(itemKey - KOKIRI_EMERALD);
 
   // RANDOTODO implement colors for locations
-  return Text()+rewardString+GetHintRegion(Location(location)->GetParentRegionKey())->GetHint().GetText()+"...^";
+  return Text()+rewardString+GetHintRegion(Location(location)->GetParentRegionKey())->GetHint().GetText().Capitalize()+"...^";
 }
 
 static Text BuildDoorOfTimeText() {


### PR DESCRIPTION
fixes https://github.com/HarbourMasters/Shipwright/issues/710
# before
![image](https://github.com/HarbourMasters/Shipwright/assets/70942617/d06c2da0-fff5-4782-a19a-4d8804f77432)
# after
![image](https://github.com/HarbourMasters/Shipwright/assets/70942617/5c3cc75a-782b-4716-8469-51416ede89e0)


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/748872162.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/748872163.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/748872164.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/748872165.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/748872166.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/748872167.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/748872168.zip)
<!--- section:artifacts:end -->