### PR TITLE
Add Mirror World gfx patches and patch Royal Grave Sun Song etching

### DIFF
--- a/soh/soh/Enhancements/cosmetics/authenticGfxPatches.cpp
+++ b/soh/soh/Enhancements/cosmetics/authenticGfxPatches.cpp
@@ -200,6 +200,8 @@ void PatchMirroredSunSongEtching() {
     static const char gMqRoyalGraveBackRoomSongVtx[] = "__OTR__scenes/mq/hakaana_ouke_scene/hakaana_ouke_room_2Vtx_004F80";
     static const char gNonMqRoyalGraveBackRoomSongVtx[] = "__OTR__scenes/nonmq/hakaana_ouke_scene/hakaana_ouke_room_2Vtx_004F80";
 
+    static Vtx* mirroredVtx;
+
     // Using a dummy texture here, but will be ignoring the texture command itself
     // Only need to patch over the two SetTile commands to get the MIRROR effect
     Gfx mirroredSunSongTex[] = {
@@ -207,13 +209,23 @@ void PatchMirroredSunSongEtching() {
                              G_TX_NOMIRROR | G_TX_CLAMP, 7, 5, G_TX_NOLOD, G_TX_NOLOD)
     };
 
-    static Vtx* mirroredVtx;
+    const char* royalGraveBackRoomDL;
+    const char* royalGraveBackRoomSongVtx;
+
+    // If we have the original game, then always prefer the nonmq paths as that is what will be used in game
+    if (ResourceMgr_GameHasOriginal()) {
+        royalGraveBackRoomDL = gNonMqRoyalGraveBackRoomDL;
+        royalGraveBackRoomSongVtx = gNonMqRoyalGraveBackRoomSongVtx;
+    } else {
+        royalGraveBackRoomDL = gMqRoyalGraveBackRoomDL;
+        royalGraveBackRoomSongVtx = gMqRoyalGraveBackRoomSongVtx;
+    }
 
     if (CVarGetInteger("gMirroredWorld", 0)) {
         if (mirroredVtx == nullptr) {
-            // Copy the original vertices that we want to modify
+            // Copy the original vertices that we want to modify (4 at the beginning of the resource)
             mirroredVtx = (Vtx*)malloc(sizeof(Vtx) * 4);
-            Vtx* origVtx = (Vtx*)ResourceGetDataByName(ResourceMgr_GameHasOriginal() ? gNonMqRoyalGraveBackRoomSongVtx : gMqRoyalGraveBackRoomSongVtx);
+            Vtx* origVtx = (Vtx*)ResourceGetDataByName(royalGraveBackRoomSongVtx);
             memcpy(mirroredVtx, origVtx, sizeof(Vtx) * 4);
 
             // Offset the vertex U coordinate values by the width of the texture
@@ -222,38 +234,21 @@ void PatchMirroredSunSongEtching() {
             }
         }
 
-        if (ResourceMgr_GameHasMasterQuest()) {
-            ResourceMgr_PatchGfxByName(gMqRoyalGraveBackRoomDL, "MQRoyalGraveSunSongTexture_1", 13, mirroredSunSongTex[1]);
-            ResourceMgr_PatchGfxByName(gMqRoyalGraveBackRoomDL, "MQRoyalGraveSunSongTexture_2", 17, mirroredSunSongTex[5]);
-            ResourceMgr_PatchGfxByName(gMqRoyalGraveBackRoomDL, "MQRoyalGraveSunSongTextureCords_1", 24, gsSPVertex(mirroredVtx, 4, 0));
-            // noop as the original vertex command is 128 bit wide
-            ResourceMgr_PatchGfxByName(gMqRoyalGraveBackRoomDL, "MQRoyalGraveSunSongTextureCords_2", 25, gsSPNoOp());
-        }
-        if (ResourceMgr_GameHasOriginal()) {
-            ResourceMgr_PatchGfxByName(gNonMqRoyalGraveBackRoomDL, "NonMQRoyalGraveSunSongTexture_1", 13, mirroredSunSongTex[1]);
-            ResourceMgr_PatchGfxByName(gNonMqRoyalGraveBackRoomDL, "NonMQRoyalGraveSunSongTexture_2", 17, mirroredSunSongTex[5]);
-            ResourceMgr_PatchGfxByName(gNonMqRoyalGraveBackRoomDL, "NonMQRoyalGraveSunSongTextureCords_1", 24, gsSPVertex(mirroredVtx, 4, 0));
-            // noop as the original vertex command is 128 bit wide
-            ResourceMgr_PatchGfxByName(gNonMqRoyalGraveBackRoomDL, "NonMQRoyalGraveSunSongTextureCords_2", 25, gsSPNoOp());
-        }
+        ResourceMgr_PatchGfxByName(royalGraveBackRoomDL, "RoyalGraveSunSongTexture_1", 13, mirroredSunSongTex[1]);
+        ResourceMgr_PatchGfxByName(royalGraveBackRoomDL, "RoyalGraveSunSongTexture_2", 17, mirroredSunSongTex[5]);
+        ResourceMgr_PatchGfxByName(royalGraveBackRoomDL, "RoyalGraveSunSongTextureCords_1", 24, gsSPVertex(mirroredVtx, 4, 0));
+        // noop as the original vertex command is 128 bit wide
+        ResourceMgr_PatchGfxByName(royalGraveBackRoomDL, "RoyalGraveSunSongTextureCords_2", 25, gsSPNoOp());
     } else {
         if (mirroredVtx != nullptr) {
             free(mirroredVtx);
             mirroredVtx = nullptr;
         }
 
-        if (ResourceMgr_GameHasMasterQuest()) {
-            ResourceMgr_UnpatchGfxByName(gMqRoyalGraveBackRoomDL, "MQRoyalGraveSunSongTexture_1");
-            ResourceMgr_UnpatchGfxByName(gMqRoyalGraveBackRoomDL, "MQRoyalGraveSunSongTexture_2");
-            ResourceMgr_UnpatchGfxByName(gMqRoyalGraveBackRoomDL, "MQRoyalGraveSunSongTextureCords_1");
-            ResourceMgr_UnpatchGfxByName(gMqRoyalGraveBackRoomDL, "MQRoyalGraveSunSongTextureCords_2");
-        }
-        if (ResourceMgr_GameHasOriginal()) {
-            ResourceMgr_UnpatchGfxByName(gNonMqRoyalGraveBackRoomDL, "NonMQRoyalGraveSunSongTexture_1");
-            ResourceMgr_UnpatchGfxByName(gNonMqRoyalGraveBackRoomDL, "NonMQRoyalGraveSunSongTexture_2");
-            ResourceMgr_UnpatchGfxByName(gNonMqRoyalGraveBackRoomDL, "NonMQRoyalGraveSunSongTextureCords_1");
-            ResourceMgr_UnpatchGfxByName(gNonMqRoyalGraveBackRoomDL, "NonMQRoyalGraveSunSongTextureCords_2");
-        }
+        ResourceMgr_UnpatchGfxByName(royalGraveBackRoomDL, "RoyalGraveSunSongTexture_1");
+        ResourceMgr_UnpatchGfxByName(royalGraveBackRoomDL, "RoyalGraveSunSongTexture_2");
+        ResourceMgr_UnpatchGfxByName(royalGraveBackRoomDL, "RoyalGraveSunSongTextureCords_1");
+        ResourceMgr_UnpatchGfxByName(royalGraveBackRoomDL, "RoyalGraveSunSongTextureCords_2");
     }
 }
 

--- a/soh/soh/Enhancements/cosmetics/authenticGfxPatches.cpp
+++ b/soh/soh/Enhancements/cosmetics/authenticGfxPatches.cpp
@@ -8,6 +8,8 @@ extern "C" {
 #include "objects/object_ik/object_ik.h"
 #include "objects/object_link_child/object_link_child.h"
 
+uint32_t ResourceMgr_GameHasMasterQuest();
+uint32_t ResourceMgr_GameHasOriginal();
 void ResourceMgr_PatchGfxByName(const char* path, const char* patchName, int index, Gfx instruction);
 void ResourceMgr_UnpatchGfxByName(const char* path, const char* patchName);
 }
@@ -188,4 +190,73 @@ void ApplyAuthenticGfxPatches() {
     PatchDekuStickTextureOverflow();
     PatchFreezardTextureOverflow();
     PatchIronKnuckleTextureOverflow();
+}
+
+// Patches the Sun Song Etching in the Royal Grave to be mirrored in mirror mode
+// This is achieved by mirroring the texture at the boundary and overriding the vertex texture coordinates
+void PatchMirroredSunSongEtching() {
+    static const char gMqRoyalGraveBackRoomDL[] = "__OTR__scenes/mq/hakaana_ouke_scene/hakaana_ouke_room_2DL_005040";
+    static const char gNonMqRoyalGraveBackRoomDL[] = "__OTR__scenes/nonmq/hakaana_ouke_scene/hakaana_ouke_room_2DL_005040";
+    static const char gMqRoyalGraveBackRoomSongVtx[] = "__OTR__scenes/mq/hakaana_ouke_scene/hakaana_ouke_room_2Vtx_004F80";
+    static const char gNonMqRoyalGraveBackRoomSongVtx[] = "__OTR__scenes/nonmq/hakaana_ouke_scene/hakaana_ouke_room_2Vtx_004F80";
+
+    // Using a dummy texture here, but will be ignoring the texture command itself
+    // Only need to patch over the two SetTile commands to get the MIRROR effect
+    Gfx mirroredSunSongTex[] = {
+        gsDPLoadTextureBlock("", G_IM_FMT_IA, G_IM_SIZ_8b, 128, 32, 0, G_TX_MIRROR | G_TX_WRAP,
+                             G_TX_NOMIRROR | G_TX_CLAMP, 7, 5, G_TX_NOLOD, G_TX_NOLOD)
+    };
+
+    static Vtx* mirroredVtx;
+
+    if (CVarGetInteger("gMirroredWorld", 0)) {
+        if (mirroredVtx == nullptr) {
+            // Copy the original vertices that we want to modify
+            mirroredVtx = (Vtx*)malloc(sizeof(Vtx) * 4);
+            Vtx* origVtx = (Vtx*)ResourceGetDataByName(ResourceMgr_GameHasOriginal() ? gNonMqRoyalGraveBackRoomSongVtx : gMqRoyalGraveBackRoomSongVtx);
+            memcpy(mirroredVtx, origVtx, sizeof(Vtx) * 4);
+
+            // Offset the vertex U coordinate values by the width of the texture
+            for (size_t i = 0; i < 4; i++) {
+                mirroredVtx[i].v.tc[0] += 128 << 5;
+            }
+        }
+
+        if (ResourceMgr_GameHasMasterQuest()) {
+            ResourceMgr_PatchGfxByName(gMqRoyalGraveBackRoomDL, "MQRoyalGraveSunSongTexture_1", 13, mirroredSunSongTex[1]);
+            ResourceMgr_PatchGfxByName(gMqRoyalGraveBackRoomDL, "MQRoyalGraveSunSongTexture_2", 17, mirroredSunSongTex[5]);
+            ResourceMgr_PatchGfxByName(gMqRoyalGraveBackRoomDL, "MQRoyalGraveSunSongTextureCords_1", 24, gsSPVertex(mirroredVtx, 4, 0));
+            // noop as the original vertex command is 128 bit wide
+            ResourceMgr_PatchGfxByName(gMqRoyalGraveBackRoomDL, "MQRoyalGraveSunSongTextureCords_2", 25, gsSPNoOp());
+        }
+        if (ResourceMgr_GameHasOriginal()) {
+            ResourceMgr_PatchGfxByName(gNonMqRoyalGraveBackRoomDL, "NonMQRoyalGraveSunSongTexture_1", 13, mirroredSunSongTex[1]);
+            ResourceMgr_PatchGfxByName(gNonMqRoyalGraveBackRoomDL, "NonMQRoyalGraveSunSongTexture_2", 17, mirroredSunSongTex[5]);
+            ResourceMgr_PatchGfxByName(gNonMqRoyalGraveBackRoomDL, "NonMQRoyalGraveSunSongTextureCords_1", 24, gsSPVertex(mirroredVtx, 4, 0));
+            // noop as the original vertex command is 128 bit wide
+            ResourceMgr_PatchGfxByName(gNonMqRoyalGraveBackRoomDL, "NonMQRoyalGraveSunSongTextureCords_2", 25, gsSPNoOp());
+        }
+    } else {
+        if (mirroredVtx != nullptr) {
+            free(mirroredVtx);
+            mirroredVtx = nullptr;
+        }
+
+        if (ResourceMgr_GameHasMasterQuest()) {
+            ResourceMgr_UnpatchGfxByName(gMqRoyalGraveBackRoomDL, "MQRoyalGraveSunSongTexture_1");
+            ResourceMgr_UnpatchGfxByName(gMqRoyalGraveBackRoomDL, "MQRoyalGraveSunSongTexture_2");
+            ResourceMgr_UnpatchGfxByName(gMqRoyalGraveBackRoomDL, "MQRoyalGraveSunSongTextureCords_1");
+            ResourceMgr_UnpatchGfxByName(gMqRoyalGraveBackRoomDL, "MQRoyalGraveSunSongTextureCords_2");
+        }
+        if (ResourceMgr_GameHasOriginal()) {
+            ResourceMgr_UnpatchGfxByName(gNonMqRoyalGraveBackRoomDL, "NonMQRoyalGraveSunSongTexture_1");
+            ResourceMgr_UnpatchGfxByName(gNonMqRoyalGraveBackRoomDL, "NonMQRoyalGraveSunSongTexture_2");
+            ResourceMgr_UnpatchGfxByName(gNonMqRoyalGraveBackRoomDL, "NonMQRoyalGraveSunSongTextureCords_1");
+            ResourceMgr_UnpatchGfxByName(gNonMqRoyalGraveBackRoomDL, "NonMQRoyalGraveSunSongTextureCords_2");
+        }
+    }
+}
+
+void ApplyMirrorWorldGfxPatches() {
+    PatchMirroredSunSongEtching();
 }

--- a/soh/soh/Enhancements/cosmetics/authenticGfxPatches.h
+++ b/soh/soh/Enhancements/cosmetics/authenticGfxPatches.h
@@ -1,3 +1,4 @@
 #pragma once
 
 void ApplyAuthenticGfxPatches();
+void ApplyMirrorWorldGfxPatches();

--- a/soh/soh/Enhancements/mods.cpp
+++ b/soh/soh/Enhancements/mods.cpp
@@ -5,6 +5,7 @@
 #include "soh/Enhancements/boss-rush/BossRushTypes.h"
 #include "soh/Enhancements/enhancementTypes.h"
 #include "soh/Enhancements/randomizer/3drando/random.hpp"
+#include "soh/Enhancements/cosmetics/authenticGfxPatches.h"
 
 extern "C" {
 #include <z64.h>
@@ -552,19 +553,31 @@ void RegisterMenuPathFix() {
 }
 
 void UpdateMirrorModeState(int32_t sceneNum) {
-    if (CVarGetInteger("gMirroredWorldMode", MIRRORED_WORLD_OFF) == MIRRORED_WORLD_RANDOM_SEEDED) {
+    static bool prevMirroredWorld = false;
+    bool nextMirroredWorld = false;
+
+    int16_t mirroredMode = CVarGetInteger("gMirroredWorldMode", MIRRORED_WORLD_OFF);
+
+    if (mirroredMode == MIRRORED_WORLD_RANDOM_SEEDED) {
         uint32_t seed = sceneNum + (gSaveContext.n64ddFlag ? (gSaveContext.seedIcons[0] + gSaveContext.seedIcons[1] + gSaveContext.seedIcons[2] + gSaveContext.seedIcons[3] + gSaveContext.seedIcons[4]) : gSaveContext.sohStats.fileCreatedAt);
         Random_Init(seed);
     }
 
     uint8_t randomNumber = Random(0, 2);
     if (
-        CVarGetInteger("gMirroredWorldMode", MIRRORED_WORLD_OFF) == MIRRORED_WORLD_ALWAYS ||
-        CVarGetInteger("gMirroredWorldMode", MIRRORED_WORLD_OFF) > MIRRORED_WORLD_ALWAYS && randomNumber == 1
+        mirroredMode == MIRRORED_WORLD_ALWAYS ||
+        (mirroredMode > MIRRORED_WORLD_ALWAYS && randomNumber == 1)
     ) {
+        nextMirroredWorld = true;
         CVarSetInteger("gMirroredWorld", 1);
     } else {
+        nextMirroredWorld = false;
         CVarClear("gMirroredWorld");
+    }
+
+    if (prevMirroredWorld != nextMirroredWorld) {
+        prevMirroredWorld = nextMirroredWorld;
+        ApplyMirrorWorldGfxPatches();
     }
 }
 


### PR DESCRIPTION
This adds a pattern for applying DL patches for mirror world. The patch/unpatch logic will be called once whenever the mirrored world effect changes.

The included example is a patch to flip the Sun Song etching at the back of the Royal Grave so the etching still resembles the ocarina notes to be played.

This patch relies on copying the existing vertex info from the resource manager into a new vertex list, applying an offset to the copied vertex data so the `U` texture coordinates are in the mirror boundary range. These modified vertices will be in a static malloc pointer and will be freed when the effect is unpatched.

The patch will prefer to fix nonmq DL if we have the original game, otherwise uses mq for patching.

Maybe this is overkill, but I consider this in the "desirable to fix for mirror mode" category.

### Before
![image](https://github.com/HarbourMasters/Shipwright/assets/13861068/20000a7c-32ed-4d19-a1d6-cc32328fb389)

### After
![image](https://github.com/HarbourMasters/Shipwright/assets/13861068/23dfe20c-1c67-40cd-8fca-ef541e29bcaf)


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/750014461.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/750014464.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/750014466.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/750014469.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/750014472.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/750014474.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/750014478.zip)
<!--- section:artifacts:end -->