### PR TITLE
Tweak: Order spoiler log print out to match insertion order

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/spoiler_log.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/spoiler_log.cpp
@@ -32,7 +32,7 @@
 
 #include <libultraship/libultraship.h>
 
-using json = nlohmann::json;
+using json = nlohmann::ordered_json;
 
 json jsonData;
 std::map<HintKey, ItemLocation*> hintedLocations;
@@ -843,8 +843,8 @@ const char* SpoilerLog_Write(int language) {
 
     jsonData.clear();
 
-    jsonData["_version"] = (char*) gBuildVersion;
-    jsonData["_seed"] = Settings::seedString;
+    jsonData["version"] = (char*) gBuildVersion;
+    jsonData["seed"] = Settings::seedString;
 
     // Write Hash
     int index = 0;


### PR DESCRIPTION
This is something that has bothered me for a long time. The json write out for the spoiler log was alphabetizing all objects. This led to things like child/adult altar hints being the first keys in the spoiler. Dropping a spoiler log into discord will reveal the first 10~ ish lines so anything in this range would spoil for someone uploading it to get help from others.

nholmannjson offers a [ordered_json](https://json.nlohmann.me/features/object_order) that can preserve the insertion order.

Switching to this now preserves the spoiler log write out such that settings are displayed first, then the playthrough, then hints, etc.
Within each object like playthrough spheres and item locations, they are now also in the "order" that the playthrough determines it (e.g. Links pocket is first, Ganons Triforce is last). This will help when deciphering what the logic did _**exactly**_.

Lastly `_seed` and `_version` where prefixed with `_` to make them rise up to the top, now that can be removed and they automatically are printed first along with the file hash icons.

Example log with this change: 
[18-21-62-74-15.txt](https://github.com/HarbourMasters/Shipwright/files/11749819/18-21-62-74-15.txt)


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/750416801.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/750416802.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/750416803.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/750416804.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/750416805.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/750416806.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/750416808.zip)
<!--- section:artifacts:end -->