### PR TITLE
Tweak: Update Mac and Linux launch scripts to make mods dir

### DIFF
--- a/scripts/linux/appimage/soh.sh
+++ b/scripts/linux/appimage/soh.sh
@@ -13,6 +13,11 @@ if [ -z ${SHIP_BIN_DIR+x} ]; then
 export SHIP_BIN_DIR="$HERE/usr/bin"
 fi
 
+if [[ ! -e "$SHIP_HOME"/mods ]]; then
+    mkdir -p "$SHIP_HOME"/mods
+    touch "$SHIP_HOME"/mods/custom_otr_files_go_here.txt
+fi
+
 while [[ (! -e "$SHIP_HOME"/oot.otr) || (! -e "$SHIP_HOME"/oot-mq.otr) ]]; do
         for romfile in "$SHIP_HOME"/*.*64
         do

--- a/soh/macosx/soh-macos.sh
+++ b/soh/macosx/soh-macos.sh
@@ -9,6 +9,11 @@ export DYLD_FALLBACK_LIBRARY_PATH="$LIBPATH"
 
 if [ ! -e "$SHIP_HOME" ]; then	mkdir "$SHIP_HOME"; fi
 
+if [ ! -e "$SHIP_HOME"/mods ]; then
+	mkdir -p "$SHIP_HOME"/mods
+	touch "$SHIP_HOME"/mods/custom_otr_files_go_here.txt
+fi
+
 # If either OTR doesn't exist kick off the OTR gen process
 if [ ! -e "$SHIP_HOME"/oot.otr ] || [ ! -e "$SHIP_HOME"/oot-mq.otr ]; then
 


### PR DESCRIPTION
Our release files for Windows includes a pre-made `mods` dir with a "otr files go here" file to guide users.

Support tracking has revealed users are confused on linux and mac when these folders don't exist, and sometimes get the casing/plurality wrong when they make it themselves.

This modifies the mac and linux launch scripts to check for the directory, and if it doesn't exist, make it and the "otr files go here" file.

Tested on Mac and Linux.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/755113636.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/755113638.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/755113640.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/755113641.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/755113642.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/755113643.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/755113644.zip)
<!--- section:artifacts:end -->