### PR TITLE
Fix: Warp override MQ mode for room loads

### DIFF
--- a/soh/soh/Enhancements/bootcommands.c
+++ b/soh/soh/Enhancements/bootcommands.c
@@ -24,6 +24,8 @@ void BootCommands_Init()
     CVarClear("gRandoGenerating"); // Clear when a crash happened during rando seed generation
     CVarClear("gNewSeedGenerated");
     CVarClear("gOnFileSelectNameEntry"); // Clear when soh is killed on the file name entry page
+    CVarClear("gBetterDebugWarpScreenMQMode");
+    CVarClear("gBetterDebugWarpScreenMQModeScene");
 #if defined(__SWITCH__) || defined(__WIIU__)
     CVarRegisterInteger("gControlNav", 1); // always enable controller nav on switch/wii u
 #endif

--- a/soh/soh/Enhancements/enhancementTypes.h
+++ b/soh/soh/Enhancements/enhancementTypes.h
@@ -1,4 +1,10 @@
 typedef enum {
+    WARP_MODE_OVERRIDE_OFF,
+    WARP_MODE_OVERRIDE_MQ_AS_VANILLA,
+    WARP_MODE_OVERRIDE_VANILLA_AS_MQ,
+} BetterDebugWarpOverrideMQMode;
+
+typedef enum {
     CSMC_DISABLED,
     CSMC_BOTH,
     CSMC_TEXTURE,

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -33,6 +33,7 @@
 #include "Enhancements/cosmetics/CosmeticsEditor.h"
 #include "Enhancements/audio/AudioCollection.h"
 #include "Enhancements/audio/AudioEditor.h"
+#include "Enhancements/enhancementTypes.h"
 #include "Enhancements/debugconsole.h"
 #include "Enhancements/randomizer/randomizer.h"
 #include "Enhancements/randomizer/randomizer_entrance_tracker.h"
@@ -1031,10 +1032,10 @@ extern "C" uint32_t ResourceMgr_GetGameVersion(int index) {
 
 uint32_t IsSceneMasterQuest(s16 sceneNum) {
     uint32_t value = 0;
-    uint8_t mqMode = CVarGetInteger("gBetterDebugWarpScreenMQMode", 0);
-    if (mqMode == 1) { // non-mq wants to be mq
+    uint8_t mqMode = CVarGetInteger("gBetterDebugWarpScreenMQMode", WARP_MODE_OVERRIDE_OFF);
+    if (mqMode == WARP_MODE_OVERRIDE_MQ_AS_VANILLA) {
         return 1;
-    } else if (mqMode == 2) { // mq wants to be non-mq
+    } else if (mqMode == WARP_MODE_OVERRIDE_VANILLA_AS_MQ) {
         return 0;
     } else {
         if (OTRGlobals::Instance->HasMasterQuest()) {

--- a/soh/src/code/z_play.c
+++ b/soh/src/code/z_play.c
@@ -1937,14 +1937,18 @@ void Play_InitScene(PlayState* play, s32 spawn)
 }
 
 void Play_SpawnScene(PlayState* play, s32 sceneNum, s32 spawn) {
+    uint8_t mqMode = CVarGetInteger("gBetterDebugWarpScreenMQMode", WARP_MODE_OVERRIDE_OFF);
+    int16_t mqModeScene = CVarGetInteger("gBetterDebugWarpScreenMQModeScene", -1);
+    if (mqMode != WARP_MODE_OVERRIDE_OFF && sceneNum != mqModeScene) {
+        CVarClear("gBetterDebugWarpScreenMQMode");
+        CVarClear("gBetterDebugWarpScreenMQModeScene");
+    }
 
     OTRPlay_SpawnScene(play, sceneNum, spawn);
 
     if (gSaveContext.n64ddFlag && Randomizer_GetSettingValue(RSK_SHUFFLE_ENTRANCES)) {
         Entrance_OverrideSpawnScene(sceneNum, spawn);
     }
-
-    CVarClear("gBetterDebugWarpScreenMQMode");
 }
 
 void func_800C016C(PlayState* play, Vec3f* src, Vec3f* dest) {

--- a/soh/src/overlays/gamestates/ovl_select/z_select.c
+++ b/soh/src/overlays/gamestates/ovl_select/z_select.c
@@ -9,6 +9,7 @@
 #include "vt.h"
 #include "alloca.h"
 
+#include "soh/Enhancements/enhancementTypes.h"
 #include "soh/Enhancements/randomizer/randomizer_entrance.h"
 
 void Select_SwitchBetterWarpMode(SelectContext* this, u8 isBetterWarpMode);
@@ -52,11 +53,14 @@ void Select_LoadGame(SelectContext* this, s32 entranceIndex) {
             BetterSceneSelectEntrancePair entrancePair = this->betterScenes[this->currentScene].entrancePairs[this->pageDownIndex];
             // Check to see if the scene/entrance we just picked can be MQ'd
             if (entrancePair.canBeMQ) {
-                u8 isEntranceDefaultMQ = ResourceMgr_IsSceneMasterQuest(gEntranceTable[entrancePair.entranceIndex].scene);
-                if (!isEntranceDefaultMQ && this->opt) {
-                    CVarSetInteger("gBetterDebugWarpScreenMQMode", 1); // Force vanilla for default MQ scene
-                } else if (isEntranceDefaultMQ && !this->opt) {
-                    CVarSetInteger("gBetterDebugWarpScreenMQMode", 2); // Force MQ for default vanilla scene
+                s16 scene = gEntranceTable[entrancePair.entranceIndex].scene;
+                u8 isEntranceDefaultMQ = ResourceMgr_IsSceneMasterQuest(scene);
+                if (!isEntranceDefaultMQ && this->opt) { // Force vanilla for default MQ scene
+                    CVarSetInteger("gBetterDebugWarpScreenMQMode", WARP_MODE_OVERRIDE_MQ_AS_VANILLA);
+                    CVarSetInteger("gBetterDebugWarpScreenMQModeScene", scene);
+                } else if (isEntranceDefaultMQ && !this->opt) { // Force MQ for default vanilla scene
+                    CVarSetInteger("gBetterDebugWarpScreenMQMode", WARP_MODE_OVERRIDE_VANILLA_AS_MQ);
+                    CVarSetInteger("gBetterDebugWarpScreenMQModeScene", scene);
                 }
             }
         }
@@ -1633,5 +1637,6 @@ void Select_Init(GameState* thisx) {
     gSaveContext.dayTime = 0x8000;
 
     CVarClear("gBetterDebugWarpScreenMQMode");
+    CVarClear("gBetterDebugWarpScreenMQModeScene");
     Select_SwitchBetterWarpMode(this, CVarGetInteger("gBetterDebugWarpScreen", 0));
 }


### PR DESCRIPTION
The better debug warp menu override for MQ dungeons would only work for the initial scene load. The CVar was cleared after loading the scene so then any subsequent room loads would switch to the original dungeon setting.

This PR tracks the scene being overridden and only clears the CVars once a new scene is loaded, fixing room loads in the dungeon to have the same override logic throughout the whole dungeon.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/756592583.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/756592584.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/756592585.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/756592586.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/756592587.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/756592588.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/756592589.zip)
<!--- section:artifacts:end -->