### PR TITLE
Enhancement: Enemy Health Bar

### DIFF
--- a/soh/include/z64actor.h
+++ b/soh/include/z64actor.h
@@ -178,6 +178,9 @@ typedef struct Actor {
     /* 0x134 */ ActorFunc draw; // Draw Routine. Called by `Actor_Draw`
     /* 0x138 */ ActorResetFunc reset;
     /* 0x13C */ char dbgPad[0x10]; // Padding that only exists in the debug rom
+    // #region SOH [General]
+    /*       */ u8 maxHealth; // Health value for an actor immediately after actor init is finished
+    // #endregion
 } Actor; // size = 0x14C
 
 typedef enum {

--- a/soh/include/z64actor.h
+++ b/soh/include/z64actor.h
@@ -179,7 +179,7 @@ typedef struct Actor {
     /* 0x138 */ ActorResetFunc reset;
     /* 0x13C */ char dbgPad[0x10]; // Padding that only exists in the debug rom
     // #region SOH [General]
-    /*       */ u8 maxHealth; // Health value for an actor immediately after actor init is finished
+    /*       */ u8 maximumHealth; // Max health value for use with health bars, set on actor init
     // #endregion
 } Actor; // size = 0x14C
 

--- a/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
+++ b/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
@@ -1446,6 +1446,7 @@ void Draw_Placements(){
             if (UIWidgets::EnhancementSliderInt("Health Bar Width: %d", "##EnemyHealthBarWidth", "gCosmetics.Hud_EnemyHealthBarWidth.Value", 32, 128, "", 64)) {
                 CVarSetInteger("gCosmetics.Hud_EnemyHealthBarWidth.Changed", 1);
             }
+            UIWidgets::Tooltip("This will change the width of the health bar");
             ImGui::SameLine();
             if (ImGui::Button("Reset##EnemyHealthBarWidth")) {
                 CVarClear("gCosmetics.Hud_EnemyHealthBarWidth.Value");
@@ -1570,7 +1571,7 @@ void RandomizeColor(CosmeticOption& cosmeticOption) {
     newColor.g = Random(0, 255);
     newColor.b = Random(0, 255);
     newColor.a = 255;
-    // For alpha support options, retain the last set alpha instead of overwriting
+    // For alpha supported options, retain the last set alpha instead of overwriting
     if (cosmeticOption.supportsAlpha) {
         newColor.a = cosmeticOption.currentColor.w * 255;
     }

--- a/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
+++ b/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
@@ -257,6 +257,8 @@ static std::map<std::string, CosmeticOption> cosmeticOptions = {
     COSMETIC_OPTION("Hud_Minimap",                   "Minimap",              GROUP_HUD,          ImVec4(  0, 255, 255, 255), false, true, false),
     COSMETIC_OPTION("Hud_MinimapPosition",           "Minimap Position",     GROUP_HUD,          ImVec4(200, 255,   0, 255), false, true, true),
     COSMETIC_OPTION("Hud_MinimapEntrance",           "Minimap Entrance",     GROUP_HUD,          ImVec4(200,   0,   0, 255), false, true, true),
+    COSMETIC_OPTION("Hud_EnemyHealthBar",            "Enemy Health Bar",     GROUP_HUD,          ImVec4(255,   0,   0, 255), true, true, false),
+    COSMETIC_OPTION("Hud_EnemyHealthBorder",         "Enemy Health Border",  GROUP_HUD,          ImVec4(255, 255, 255, 255), true, false, true),
 
     COSMETIC_OPTION("Title_FileChoose",              "File Choose",          GROUP_TITLE,        ImVec4(100, 150, 255, 255), false, true, false),
     COSMETIC_OPTION("Title_NintendoLogo",            "Nintendo Logo",        GROUP_TITLE,        ImVec4(  0,   0, 255, 255), false, true, true),
@@ -322,8 +324,6 @@ static std::map<std::string, CosmeticOption> cosmeticOptions = {
     COSMETIC_OPTION("NPC_Gerudo",                    "Gerudo",               GROUP_NPC,          ImVec4( 90,   0, 140, 255), false, true, false),
     COSMETIC_OPTION("NPC_MetalTrap",                 "Metal Trap",           GROUP_NPC,          ImVec4(255, 255, 255, 255), false, true, true),
     COSMETIC_OPTION("NPC_IronKnuckles",              "Iron Knuckles",        GROUP_NPC,          ImVec4(245, 255, 205, 255), false, true, false),
-    COSMETIC_OPTION("NPC_EnemyHealthBar",            "Enemy Health Bar",     GROUP_NPC,          ImVec4(255,   0,   0, 255), true, true, false),
-    COSMETIC_OPTION("NPC_EnemyHealthBorder",         "Enemy Health Border",  GROUP_NPC,          ImVec4(255, 255, 255, 255), true, false, true),
 };
 
 static const char* MarginCvarList[] {
@@ -402,6 +402,10 @@ void CosmeticsUpdateTick() {
             newColor.g = sin(frequency * (hue + index) + (2 * M_PI / 3)) * 127 + 128;
             newColor.b = sin(frequency * (hue + index) + (4 * M_PI / 3)) * 127 + 128;
             newColor.a = 255;
+            // For alpha supported options, retain the last set alpha instead of overwriting
+            if (cosmeticOption.supportsAlpha) {
+                newColor.a = cosmeticOption.currentColor.w * 255;
+            }
 
             cosmeticOption.currentColor.x = newColor.r / 255.0;
             cosmeticOption.currentColor.y = newColor.g / 255.0;
@@ -1427,6 +1431,31 @@ void Draw_Placements(){
             ImGui::EndTable();
         }
     }
+    if (ImGui::CollapsingHeader("Enemy Health Bar position")) {
+        if (ImGui::BeginTable("enemyhealthbar", 1, FlagsTable)) {
+            ImGui::TableSetupColumn("Enemy Health Bar settings", FlagsCell, TablesCellsWidth);
+            Table_InitHeader(false);
+            std::string posTypeCVar = "gCosmetics.Hud_EnemyHealthBarPosType";
+            UIWidgets::EnhancementRadioButton("Anchor to Enemy", posTypeCVar.c_str(), ENEMYHEALTH_ANCHOR_ACTOR);
+            UIWidgets::Tooltip("This will use enemy on screen position");
+            UIWidgets::EnhancementRadioButton("Anchor to the top", posTypeCVar.c_str(), ENEMYHEALTH_ANCHOR_TOP);
+            UIWidgets::Tooltip("This will make your elements follow the top edge of your game window");
+            UIWidgets::EnhancementRadioButton("Anchor to the bottom", posTypeCVar.c_str(), ENEMYHEALTH_ANCHOR_BOTTOM);
+            UIWidgets::Tooltip("This will make your elements follow the bottom edge of your game window");
+            DrawPositionSlider("gCosmetics.Hud_EnemyHealthBar", -SCREEN_HEIGHT, SCREEN_HEIGHT, -ImGui::GetWindowViewport()->Size.x / 2, ImGui::GetWindowViewport()->Size.x / 2);
+            if (UIWidgets::EnhancementSliderInt("Health Bar Width: %d", "##EnemyHealthBarWidth", "gCosmetics.Hud_EnemyHealthBarWidth.Value", 32, 128, "", 64)) {
+                CVarSetInteger("gCosmetics.Hud_EnemyHealthBarWidth.Changed", 1);
+            }
+            ImGui::SameLine();
+            if (ImGui::Button("Reset##EnemyHealthBarWidth")) {
+                CVarClear("gCosmetics.Hud_EnemyHealthBarWidth.Value");
+                CVarClear("gCosmetics.Hud_EnemyHealthBarWidth.Changed");
+                LUS::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
+            }
+            ImGui::NewLine();
+            ImGui::EndTable();
+        }
+    }
 }
 
 void DrawSillyTab() {
@@ -1541,6 +1570,10 @@ void RandomizeColor(CosmeticOption& cosmeticOption) {
     newColor.g = Random(0, 255);
     newColor.b = Random(0, 255);
     newColor.a = 255;
+    // For alpha support options, retain the last set alpha instead of overwriting
+    if (cosmeticOption.supportsAlpha) {
+        newColor.a = cosmeticOption.currentColor.w * 255;
+    }
 
     cosmeticOption.currentColor.x = newColor.r / 255.0;
     cosmeticOption.currentColor.y = newColor.g / 255.0;
@@ -1609,7 +1642,13 @@ void ResetColor(CosmeticOption& cosmeticOption) {
 }
 
 void DrawCosmeticRow(CosmeticOption& cosmeticOption) {
-    if (ImGui::ColorEdit3(cosmeticOption.label.c_str(), (float*)&cosmeticOption.currentColor, ImGuiColorEditFlags_NoInputs | ImGuiColorEditFlags_NoLabel)) {
+    bool colorChanged;
+    if (cosmeticOption.supportsAlpha) {
+        colorChanged = ImGui::ColorEdit4(cosmeticOption.label.c_str(), (float*)&cosmeticOption.currentColor, ImGuiColorEditFlags_NoInputs | ImGuiColorEditFlags_NoLabel);
+    } else {
+        colorChanged = ImGui::ColorEdit3(cosmeticOption.label.c_str(), (float*)&cosmeticOption.currentColor, ImGuiColorEditFlags_NoInputs | ImGuiColorEditFlags_NoLabel);
+    }
+    if (colorChanged) {
         Color_RGBA8 color;
         color.r = cosmeticOption.currentColor.x * 255.0;
         color.g = cosmeticOption.currentColor.y * 255.0;
@@ -1630,13 +1669,15 @@ void DrawCosmeticRow(CosmeticOption& cosmeticOption) {
         ApplyOrResetCustomGfxPatches();
         LUS::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
     }
-    ImGui::SameLine();
-    bool isRainbow = (bool)CVarGetInteger((cosmeticOption.rainbowCvar), 0);
-    if (ImGui::Checkbox(("Rainbow##" + cosmeticOption.label).c_str(), &isRainbow)) {
-        CVarSetInteger((cosmeticOption.rainbowCvar), isRainbow);
-        CVarSetInteger((cosmeticOption.changedCvar), 1);
-        ApplyOrResetCustomGfxPatches();
-        LUS::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
+    if (cosmeticOption.supportsRainbow) {
+        ImGui::SameLine();
+        bool isRainbow = (bool)CVarGetInteger((cosmeticOption.rainbowCvar), 0);
+        if (ImGui::Checkbox(("Rainbow##" + cosmeticOption.label).c_str(), &isRainbow)) {
+            CVarSetInteger((cosmeticOption.rainbowCvar), isRainbow);
+            CVarSetInteger((cosmeticOption.changedCvar), 1);
+            ApplyOrResetCustomGfxPatches();
+            LUS::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
+        }
     }
     ImGui::SameLine();
     bool isLocked = (bool)CVarGetInteger((cosmeticOption.lockedCvar), 0);

--- a/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
+++ b/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
@@ -322,6 +322,8 @@ static std::map<std::string, CosmeticOption> cosmeticOptions = {
     COSMETIC_OPTION("NPC_Gerudo",                    "Gerudo",               GROUP_NPC,          ImVec4( 90,   0, 140, 255), false, true, false),
     COSMETIC_OPTION("NPC_MetalTrap",                 "Metal Trap",           GROUP_NPC,          ImVec4(255, 255, 255, 255), false, true, true),
     COSMETIC_OPTION("NPC_IronKnuckles",              "Iron Knuckles",        GROUP_NPC,          ImVec4(245, 255, 205, 255), false, true, false),
+    COSMETIC_OPTION("NPC_EnemyHealthBar",            "Enemy Health Bar",     GROUP_NPC,          ImVec4(255,   0,   0, 255), true, true, false),
+    COSMETIC_OPTION("NPC_EnemyHealthBorder",         "Enemy Health Border",  GROUP_NPC,          ImVec4(255, 255, 255, 255), true, false, true),
 };
 
 static const char* MarginCvarList[] {

--- a/soh/soh/Enhancements/cosmetics/cosmeticsTypes.h
+++ b/soh/soh/Enhancements/cosmetics/cosmeticsTypes.h
@@ -2,3 +2,9 @@ typedef enum {
     COLORSCHEME_N64,
     COLORSCHEME_GAMECUBE
 } DefaultColorScheme;
+
+typedef enum {
+    ENEMYHEALTH_ANCHOR_ACTOR,
+    ENEMYHEALTH_ANCHOR_TOP,
+    ENEMYHEALTH_ANCHOR_BOTTOM,
+} EnemyHealthBarAnchorType;

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -902,6 +902,8 @@ void DrawEnhancementsMenu() {
             UIWidgets::Tooltip("Always shows dungeon entrance icons on the minimap");
             UIWidgets::PaddedEnhancementCheckbox("Show Gauntlets in First Person", "gFPSGauntlets", true, false);
             UIWidgets::Tooltip("Renders Gauntlets when using the Bow and Hookshot like in OOT3D");
+            UIWidgets::PaddedEnhancementCheckbox("Enemy Health Bars", "gEnemyHealthBar", true, false);
+            UIWidgets::Tooltip("Renders a health bar above enemies when Z-Targeted");
             UIWidgets::Spacer(0);
             if (ImGui::BeginMenu("Animated Link in Pause Menu")) {
                 ImGui::Text("Rotation");

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -865,6 +865,8 @@ void DrawEnhancementsMenu() {
 
             UIWidgets::PaddedEnhancementCheckbox("Disable Crit wiggle", "gDisableCritWiggle", true, false);
             UIWidgets::Tooltip("Disable random camera wiggle at low health");
+            UIWidgets::PaddedEnhancementCheckbox("Enemy Health Bars", "gEnemyHealthBar", true, false);
+            UIWidgets::Tooltip("Renders a health bar for enemies when Z-Targeted");
 
             ImGui::EndMenu();
         }
@@ -902,8 +904,6 @@ void DrawEnhancementsMenu() {
             UIWidgets::Tooltip("Always shows dungeon entrance icons on the minimap");
             UIWidgets::PaddedEnhancementCheckbox("Show Gauntlets in First Person", "gFPSGauntlets", true, false);
             UIWidgets::Tooltip("Renders Gauntlets when using the Bow and Hookshot like in OOT3D");
-            UIWidgets::PaddedEnhancementCheckbox("Enemy Health Bars", "gEnemyHealthBar", true, false);
-            UIWidgets::Tooltip("Renders a health bar above enemies when Z-Targeted");
             UIWidgets::Spacer(0);
             if (ImGui::BeginMenu("Animated Link in Pause Menu")) {
                 ImGui::Text("Rotation");

--- a/soh/src/code/z_actor.c
+++ b/soh/src/code/z_actor.c
@@ -1213,9 +1213,9 @@ void Actor_Init(Actor* actor, PlayState* play) {
         actor->init(actor, play);
         actor->init = NULL;
 
-        // For enenmy health bar we need to know the max health after init
+        // For enemy health bar we need to know the max health during init
         if (actor->category == ACTORCAT_ENEMY) {
-            actor->maxHealth = actor->colChkInfo.health;
+            actor->maximumHealth = actor->colChkInfo.health;
         }
     }
 }

--- a/soh/src/code/z_actor.c
+++ b/soh/src/code/z_actor.c
@@ -1212,6 +1212,11 @@ void Actor_Init(Actor* actor, PlayState* play) {
         //Actor_SetObjectDependency(play, actor);
         actor->init(actor, play);
         actor->init = NULL;
+
+        // For enenmy health bar we need to know the max health after init
+        if (actor->category == ACTORCAT_ENEMY) {
+            actor->maxHealth = actor->colChkInfo.health;
+        }
     }
 }
 

--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -3761,6 +3761,7 @@ void Interface_DrawEnemyHealthBar(TargetContext* targetCtx, PlayState* play) {
             gSPMatrix(OVERLAY_DISP++, MATRIX_NEWMTX(play->state.gfxCtx), G_MTX_MODELVIEW | G_MTX_LOAD);
 
             // Health bar border
+            gDPPipeSync(OVERLAY_DISP++);
             gDPSetPrimColor(OVERLAY_DISP++, 0, 0, healthbar_border.r, healthbar_border.g, healthbar_border.b,
                             healthbar_border.a);
             gDPSetEnvColor(OVERLAY_DISP++, 100, 50, 50, 255);
@@ -3773,7 +3774,7 @@ void Interface_DrawEnemyHealthBar(TargetContext* targetCtx, PlayState* play) {
 
             gSP1Quadrangle(OVERLAY_DISP++, 0, 2, 3, 1, 0);
 
-            gDPLoadTextureBlock(OVERLAY_DISP++, gMagicMeterMidTex, G_IM_FMT_IA, G_IM_SIZ_8b, endTexWidth, texHeight, 0,
+            gDPLoadTextureBlock(OVERLAY_DISP++, gMagicMeterMidTex, G_IM_FMT_IA, G_IM_SIZ_8b, 24, texHeight, 0,
                                 G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK,
                                 G_TX_NOLOD, G_TX_NOLOD);
 


### PR DESCRIPTION
This adds an enhancement to display health bars above enemies when Z-Targeted.

This health bar is rendered by reusing the magic bar textures with a red color by default (supports cosmetic editor overrides). The health bar is placed above the actors projected target center by following similar logic of the Z-Target placement. The health bar will slide in from the top edge of the screen, mimicking the Z-Target triangle fly in effect.

In HUD placements, the health bar can either be anchored to the actor, or anchored to the top/bottom edges. The up/down offset values apply to all anchor positions, where as left/right apply only to top/bottom anchor types. The health bar width can be changed from here as well.

The actor struct was updated to add a new `maximumHealth` property that is set after init, to track the total health of all actors.

Some enemies may use their own health calculation outside of the collision health, meaning the bar may not drain in those instances.

This health bar will only apply to enemies and not bosses. In a future PR, I will investigate what it would take to add boss health bars.

https://github.com/HarbourMasters/Shipwright/assets/13861068/5a9c2650-5f15-4d07-88d9-17f240a8a3e8

![image](https://github.com/HarbourMasters/Shipwright/assets/13861068/9ba94628-d9c4-4aef-a6ff-3109b2d9fc07)

---

Other additions in here is adding support for alpha setting in the cosmetic editor. When enabled, randomize/rainbow changes will retain the last set alpha value. This allows the enemy health bar to have an alpha applied to it. This is controlled by `supportsAlpha`.
Similarly, there was a `supportsRainbow` flag, but it wasn't hiding the rainbow toggle. Now it is.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/781473049.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/781473050.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/781473052.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/781473053.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/781473054.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/781473055.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/781473056.zip)
<!--- section:artifacts:end -->