### PR TITLE
Scaling and text sizes

### DIFF
--- a/soh/soh/OTRGlobals.h
+++ b/soh/soh/OTRGlobals.h
@@ -21,6 +21,14 @@
 const std::string customMessageTableID = "BaseGameOverrides";
 const std::string appShortName = "soh";
 
+#ifdef __WIIU__
+const uint32_t defaultImGuiScale = 3;
+#else
+const uint32_t defaultImGuiScale = 1;
+#endif
+
+const float imguiScaleOptionToValue[4] = { 0.75f, 1.0f, 1.5f, 2.0f };
+
 class OTRGlobals
 {
 public:
@@ -30,8 +38,14 @@ public:
     std::shared_ptr<SaveStateMgr> gSaveStateMgr;
     std::shared_ptr<Randomizer> gRandomizer;
 
+    ImFont* defaultFontSmaller;
+    ImFont* defaultFontLarger;
+    ImFont* defaultFontLargest;
+
     OTRGlobals();
     ~OTRGlobals();
+    
+    void ScaleImGui();
 
     bool HasMasterQuest();
     bool HasOriginal();
@@ -42,6 +56,7 @@ private:
 	void CheckSaveFile(size_t sramSize) const;
     bool hasMasterQuest;
     bool hasOriginal;
+    ImFont* CreateDefaultFontWithSize(float size);
 };
 
 uint32_t IsGameMasterQuest();

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -51,6 +51,8 @@ std::string GetWindowButtonText(const char* text, bool menuOpen) {
     return buttonText;
 }
 
+static const char* imguiScaleOptions[4] = { "Small", "Normal", "Large", "X-Large" };
+
     static const char* filters[3] = {
 #ifdef __WIIU__
             "",
@@ -380,7 +382,15 @@ void DrawSettingsMenu() {
             }
 
             UIWidgets::PaddedSeparator(true, true, 3.0f, 3.0f);
+            ImGui::Text("ImGui Menu Scale");
+            ImGui::SameLine();
+            ImGui::TextColored({ 0.85f, 0.35f, 0.0f, 1.0f }, "(Experimental)");
+            if (UIWidgets::EnhancementCombobox("gImGuiScale", imguiScaleOptions, 1)) {
+                OTRGlobals::Instance->ScaleImGui();
+            }
+            UIWidgets::Tooltip("Changes the scaling of the ImGui menu elements.");
 
+            UIWidgets::PaddedSeparator(true, true, 3.0f, 3.0f);
             
             static std::unordered_map<LUS::WindowBackend, const char*> windowBackendNames = {
                 { LUS::WindowBackend::DX11, "DirectX" },


### PR DESCRIPTION
Add ImGui scaling slider. Values between 100% and 150% exhibit the weird expanding slider glitch known on Switch and WiiU. Another known issue is with padding values not scaling properly with multiple changes to the scale factor in a row. Restarting SoH fixes them.

Also adds multiple font sizes that can be used concurrently. 1 smaller than default, 2 larger. Total memory usage was only increased by about 12MB.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1029809826.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1029809827.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1029809828.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1029809829.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1029809831.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1029809833.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1029809834.zip)
<!--- section:artifacts:end -->