### PR TITLE
Fix: Various PAL1.1 asset offsets and Main Menu options screen

### DIFF
--- a/soh/assets/xml/N64_PAL_11/overlays/ovl_Bg_Ganon_Otyuka.xml
+++ b/soh/assets/xml/N64_PAL_11/overlays/ovl_Bg_Ganon_Otyuka.xml
@@ -1,8 +1,8 @@
 <Root>
-    <File Name="ovl_Bg_Ganon_Otyuka" BaseAddress="0x80A54D80" RangeStart="0x1100" RangeEnd="0x259C">
-        <Texture Name="sPlatformTex" OutName="platform_tex" Format="rgba16" Width="32" Height="32" Offset="0x1100"/>
+    <File Name="ovl_Bg_Ganon_Otyuka" BaseAddress="0x80A54D80" RangeStart="0x1110" RangeEnd="0x24EC">
+        <Texture Name="sPlatformTex" OutName="platform_tex" Format="rgba16" Width="32" Height="32" Offset="0x1110"/>
         
-        <Array Name="sPlatformTopVtx" Count="4" Offset="0x1908">
+        <Array Name="sPlatformTopVtx" Count="4" Offset="0x1918">
             <Vtx/>
         </Array>
         <DList Name="sPlatformMaterialDL" Offset="0x1958"/>

--- a/soh/assets/xml/N64_PAL_11/overlays/ovl_File_Choose.xml
+++ b/soh/assets/xml/N64_PAL_11/overlays/ovl_File_Choose.xml
@@ -3,18 +3,20 @@
         <Array Name="D_80811BB0" Count="24" Offset="0xF120" Static="Off">
             <Vtx/>
         </Array>
-        <Array Name="D_80811D30" Count="16" Offset="0xF2A0" Static="Off">
+        <!-- German vertices are combined into one array -->
+        <Array Name="D_80811D30" Count="24" Offset="0xF2A0" Static="Off">
             <Vtx/>
         </Array>
-        <Array Name="D_80811E30" Count="16" Offset="0xF3A0" Static="Off">
+        <!-- <Array Name="D_80811E30" Count="16" Offset="0xF3A0" Static="Off">
+            <Vtx/>
+        </Array> -->
+        <!-- German vertices are combined into one array -->
+        <Array Name="D_80811F30" Count="40" Offset="0xF420" Static="Off">
             <Vtx/>
         </Array>
-        <Array Name="D_80811F30" Count="32" Offset="0xF4A0" Static="Off">
+        <!-- <Array Name="D_80812130" Count="32" Offset="0xF6A0" Static="Off">
             <Vtx/>
-        </Array>
-        <Array Name="D_80812130" Count="32" Offset="0xF6A0" Static="Off">
-            <Vtx/>
-        </Array>
+        </Array> -->
         <Array Name="gOptionsDividerTopVtx" Count="4" Offset="0xF8A0" Static="Off">
             <Vtx/>
         </Array>
@@ -24,5 +26,6 @@
         <Array Name="gOptionsDividerBottomVtx" Count="4" Offset="0xF920" Static="Off">
             <Vtx/>
         </Array>
+        <!-- OTRTODO: Vertices for Choose Language header, options, and divider -->
     </File>
 </Root>

--- a/soh/assets/xml/N64_PAL_11/overlays/ovl_Magic_Fire.xml
+++ b/soh/assets/xml/N64_PAL_11/overlays/ovl_Magic_Fire.xml
@@ -1,10 +1,10 @@
 <Root>
-    <File Name="ovl_Magic_Fire" BaseAddress="0x8095E690" RangeStart="0x600" RangeEnd="0x21E0">
-        <Texture Name="sTex" OutName="dins_fire" Format="i8" Width="64" Height="64" Offset="0xB50"/>
-        <Array Name="sSphereVtx" Count="76" Offset="0x1B50">
+    <File Name="ovl_Magic_Fire" BaseAddress="0x8095E690" RangeStart="0xB20" RangeEnd="0x2170">
+        <Texture Name="sTex" OutName="dins_fire" Format="i8" Width="64" Height="64" Offset="0xB20"/>
+        <Array Name="sSphereVtx" Count="76" Offset="0x1B20">
             <Vtx/>
         </Array>
-        <DList Name="sMaterialDL" Offset="0x2010"/>
-        <DList Name="sModelDL" Offset="0x2038"/>
+        <DList Name="sMaterialDL" Offset="0x1FE0"/>
+        <DList Name="sModelDL" Offset="0x2008"/>
     </File>
 </Root>

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -1030,6 +1030,52 @@ extern "C" uint32_t ResourceMgr_GetGameVersion(int index) {
     return LUS::Context::GetInstance()->GetResourceManager()->GetArchive()->GetGameVersions()[index];
 }
 
+extern "C" uint32_t ResourceMgr_GetGamePlatform(int index) {
+    uint32_t version = LUS::Context::GetInstance()->GetResourceManager()->GetArchive()->GetGameVersions()[index];
+
+    switch (version) {
+        case OOT_NTSC_US_10:
+        case OOT_NTSC_US_11:
+        case OOT_NTSC_US_12:
+        case OOT_PAL_10:
+        case OOT_PAL_11:
+            return GAME_PLATFORM_N64;
+        case OOT_NTSC_JP_GC:
+        case OOT_NTSC_US_GC:
+        case OOT_PAL_GC:
+        case OOT_NTSC_JP_MQ:
+        case OOT_NTSC_US_MQ:
+        case OOT_PAL_MQ:
+        case OOT_PAL_GC_DBG1:
+        case OOT_PAL_GC_DBG2:
+        case OOT_PAL_GC_MQ_DBG:
+            return GAME_PLATFORM_GC;
+    }
+}
+
+extern "C" uint32_t ResourceMgr_GetGameRegion(int index) {
+    uint32_t version = LUS::Context::GetInstance()->GetResourceManager()->GetArchive()->GetGameVersions()[index];
+
+    switch (version) {
+        case OOT_NTSC_US_10:
+        case OOT_NTSC_US_11:
+        case OOT_NTSC_US_12:
+        case OOT_NTSC_JP_GC:
+        case OOT_NTSC_US_GC:
+        case OOT_NTSC_JP_MQ:
+        case OOT_NTSC_US_MQ:
+            return GAME_REGION_NTSC;
+        case OOT_PAL_10:
+        case OOT_PAL_11:
+        case OOT_PAL_GC:
+        case OOT_PAL_MQ:
+        case OOT_PAL_GC_DBG1:
+        case OOT_PAL_GC_DBG2:
+        case OOT_PAL_GC_MQ_DBG:
+            return GAME_REGION_PAL;
+    }
+}
+
 uint32_t IsSceneMasterQuest(s16 sceneNum) {
     uint32_t value = 0;
     uint8_t mqMode = CVarGetInteger("gBetterDebugWarpScreenMQMode", WARP_MODE_OVERRIDE_OFF);

--- a/soh/soh/OTRGlobals.h
+++ b/soh/soh/OTRGlobals.h
@@ -6,6 +6,12 @@
 #include "SaveManager.h"
 #include <soh/Enhancements/item-tables/ItemTableTypes.h>
 
+#define GAME_REGION_NTSC 0
+#define GAME_REGION_PAL 1
+
+#define GAME_PLATFORM_N64 0
+#define GAME_PLATFORM_GC 1
+
 #ifdef __cplusplus
 #include <Context.h>
 #include "Enhancements/savestates.h"
@@ -59,6 +65,8 @@ uint32_t ResourceMgr_GameHasMasterQuest();
 uint32_t ResourceMgr_GameHasOriginal();
 uint32_t ResourceMgr_GetNumGameVersions();
 uint32_t ResourceMgr_GetGameVersion(int index);
+uint32_t ResourceMgr_GetGamePlatform(int index);
+uint32_t ResourceMgr_GetGameRegion(int index);
 void ResourceMgr_LoadDirectory(const char* resName);
 char** ResourceMgr_ListFiles(const char* searchMask, int* resultSize);
 uint8_t ResourceMgr_FileExists(const char* resName);

--- a/soh/src/overlays/gamestates/ovl_file_choose/z_file_nameset_PAL.c
+++ b/soh/src/overlays/gamestates/ovl_file_choose/z_file_nameset_PAL.c
@@ -1004,12 +1004,12 @@ void FileChoose_DrawOptionsImpl(GameState* thisx) {
         }
     }
 
-    gDPPipeSync(POLY_OPA_DISP++);
-
     // Pal N64 needs to skip over the extra german vertices to get to brightness vertices
     if (isPalN64) {
         vtx += 8;
     }
+
+    gDPPipeSync(POLY_OPA_DISP++);
 
     // check brightness bars
     gDPLoadTextureBlock_4b(POLY_OPA_DISP++, gFileSelBrightnessCheckTex, G_IM_FMT_IA, 96, 16, 0,

--- a/soh/src/overlays/gamestates/ovl_file_choose/z_file_nameset_PAL.c
+++ b/soh/src/overlays/gamestates/ovl_file_choose/z_file_nameset_PAL.c
@@ -909,7 +909,13 @@ void FileChoose_DrawOptionsImpl(GameState* thisx) {
         }
     }
 
-    if (gSaveContext.language == LANGUAGE_GER) {
+    uint8_t versionIndex = ResourceMgr_GameHasMasterQuest() && ResourceMgr_GameHasOriginal();
+    uint8_t isPalN64 = ResourceMgr_GetGameRegion(versionIndex) == GAME_REGION_PAL &&
+                       ResourceMgr_GetGamePlatform(versionIndex) == GAME_PLATFORM_N64;
+    uint8_t isPalGC = ResourceMgr_GetGameRegion(versionIndex) == GAME_REGION_PAL &&
+                      ResourceMgr_GetGamePlatform(versionIndex) == GAME_PLATFORM_GC;
+
+    if (gSaveContext.language == LANGUAGE_GER && isPalGC) {
         gSPVertex(POLY_OPA_DISP++, D_80811E30, 32, 0);
     } else {
         gSPVertex(POLY_OPA_DISP++, D_80811D30, 32, 0);
@@ -926,13 +932,24 @@ void FileChoose_DrawOptionsImpl(GameState* thisx) {
                             G_IM_SIZ_8b, gOptionsMenuHeaders[i].width[gSaveContext.language],
                             gOptionsMenuHeaders[i].height, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP,
                             G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
-        gSP1Quadrangle(POLY_OPA_DISP++, vtx, vtx + 2, vtx + 3, vtx + 1, 0);
+
+        if (i == 2 && gSaveContext.language == LANGUAGE_GER && isPalN64) {
+            // Pal N64 German vertex for Z target header are offset by 12 vertices
+            gSP1Quadrangle(POLY_OPA_DISP++, vtx + 12, vtx + 2 + 12, vtx + 3 + 12, vtx + 1 + 12, 0);
+        } else {
+            gSP1Quadrangle(POLY_OPA_DISP++, vtx, vtx + 2, vtx + 3, vtx + 1, 0);
+        }
     }
 
-    if (gSaveContext.language == LANGUAGE_GER) {
+    if (gSaveContext.language == LANGUAGE_GER && isPalGC) {
         gSPVertex(POLY_OPA_DISP++, D_80812130, 32, 0);
     } else {
-        gSPVertex(POLY_OPA_DISP++, D_80811F30, 32, 0);
+        // PAL N64 has extra german vertices combined in the regular array instead of a dedicated array
+        if (isPalN64) {
+            gSPVertex(POLY_OPA_DISP++, D_80811F30, 40, 0);
+        } else {
+            gSPVertex(POLY_OPA_DISP++, D_80811F30, 32, 0);
+        }
     }
 
     for (i = 0, vtx = 0; i < 4; i++, vtx += 4) {
@@ -979,10 +996,20 @@ void FileChoose_DrawOptionsImpl(GameState* thisx) {
                             G_IM_SIZ_8b, gOptionsMenuSettings[i].width[gSaveContext.language],
                             gOptionsMenuSettings[i].height, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP,
                             G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
-        gSP1Quadrangle(POLY_OPA_DISP++, vtx, vtx + 2, vtx + 3, vtx + 1, 0);
+        // Pal N64 German vertices for z target options are offset an by 8
+        if (gSaveContext.language == LANGUAGE_GER && isPalN64) {
+            gSP1Quadrangle(POLY_OPA_DISP++, vtx + 8, vtx + 2 + 8, vtx + 3 + 8, vtx + 1 + 8, 0);
+        } else {
+            gSP1Quadrangle(POLY_OPA_DISP++, vtx, vtx + 2, vtx + 3, vtx + 1, 0);
+        }
     }
 
     gDPPipeSync(POLY_OPA_DISP++);
+
+    // Pal N64 needs to skip over the extra german vertices to get to brightness vertices
+    if (isPalN64) {
+        vtx += 8;
+    }
 
     // check brightness bars
     gDPLoadTextureBlock_4b(POLY_OPA_DISP++, gFileSelBrightnessCheckTex, G_IM_FMT_IA, 96, 16, 0,


### PR DESCRIPTION
This address some reported PAL1.1 asset issues
* Falling platforms in Ganondorf's lair had incorrect vertex values
* Din's Fire magic effect had incorrect offset values
* Main Menu options screen has dramatically different data compared to PAL GC

Regarding the PAL N64 Main Menu option screen, there are additional options for changing the game language. The corresponding code does not exist for this feature and the way the assets are defined differ quite a bit.

PAL GC defines one list of vertices for the headers and a separate copy for German. Similarly one list for the options vertices and a separate copy for German.

However, PAL N64 doesn't define a separate copy for German, instead the german specific vertices are listed in a separate spot. PAL N64 also has vertices for the change language mixed in, so those are currently ignored and skipped over as necessary.

I have added resource methods to query the region and platform type of a game version (`ResourceMgr_GetGamePlatform` and `ResourceMgr_GetGameRegion`). In the case of the Main Menu, I am using this to detect if the loaded game (original in the case both original and MQ are provided) is PAL N64 or PAL GC to conditionally apply the different vertices.

Targeting Sulu even though it would require re-generating the PAL1.1 otr, but the game wont crash in this case if users don't re-gen. Fixing the asset issues seems preferable as a bugfix release.

These changes were aimed as a bug fix for current PAL 1.1 issues. It's possible that as we expand rom support, we may find it better to create specific draw methods for the different types here. That would also open the possibility if we wanted to support the in-game language change feature for PAL N64.

Fixes #3022, #3023

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/780194132.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/780194133.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/780194134.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/780194135.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/780194136.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/780194137.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/780194138.zip)
<!--- section:artifacts:end -->