### PR TITLE
Fix Market Sneak enhancement with masks on

### DIFF
--- a/soh/src/overlays/actors/ovl_En_Heishi4/z_en_heishi4.c
+++ b/soh/src/overlays/actors/ovl_En_Heishi4/z_en_heishi4.c
@@ -334,7 +334,12 @@ void func_80A56B40(EnHeishi4* this, PlayState* play) {
             return;
         }
         if (this->type == HEISHI4_AT_MARKET_NIGHT) {
-            if (CVarGetInteger("gMarketSneak", 0)) {
+            Player* player = GET_PLAYER(play);
+            // Only allow sneaking when not wearing a mask as that triggers different dialogue. MM Bunny hood disables
+            // these interactions, so bunny hood is fine in that case.
+            if (CVarGetInteger("gMarketSneak", 0) &&
+                (player->currentMask == PLAYER_MASK_NONE ||
+                 (player->currentMask == PLAYER_MASK_BUNNY && CVarGetInteger("gMMBunnyHood", 0)))) {
                 this->actionFunc = EnHeishi4_MarketSneak;
             } else {
                 this->actionFunc = func_80A56614;


### PR DESCRIPTION
Resolves https://github.com/HarbourMasters/Shipwright/issues/3046

Wearing a mask when triggering the hyrule market guard with the sneak enhancement on made it impossible to talk to him again until you reloaded the area. This keeps the original mask dialogue but fixes the talking to him again issue.

https://cdn.discordapp.com/attachments/935186300032667658/1123926092982534194/2023-06-29_12-40-30.mp4

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/777245381.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/777245384.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/777245387.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/777245390.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/777245391.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/777245392.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/777245394.zip)
<!--- section:artifacts:end -->