### PR TITLE
Fix: Various PAL GC asset offset issues

### DIFF
--- a/soh/assets/xml/GC_NMQ_PAL_F/code/fbdemo_circle.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/code/fbdemo_circle.xml
@@ -1,14 +1,14 @@
 <Root>
-    <File Name="code" OutName="z_fbdemo_circle" RangeStart="0xE90E0" RangeEnd="0x12CBB0">
-      <Texture Name="sTransCircleNormalTex" Format="i8" Width="16" Height="64" Offset="0xE90E0"/>
-        <Texture Name="sTransCircleWaveTex" Format="i8" Width="16" Height="64" Offset="0xE94E0"/>
-        <Texture Name="sTransCircleRippleTex" Format="i8" Width="16" Height="64" Offset="0xE98E0"/>
-        <Texture Name="sTransCircleStarburstTex" Format="i8" Width="16" Height="64" Offset="0xE9CE0"/>
-        <Array Name="sCircleWipeVtx" Count="34" Offset="0xEA0E0">
+    <File Name="code" OutName="z_fbdemo_circle" RangeStart="0xE90C8" RangeEnd="0x106F10">
+      <Texture Name="sTransCircleNormalTex" Format="i8" Width="16" Height="64" Offset="0xE90C8"/>
+        <Texture Name="sTransCircleWaveTex" Format="i8" Width="16" Height="64" Offset="0xE94C8"/>
+        <Texture Name="sTransCircleRippleTex" Format="i8" Width="16" Height="64" Offset="0xE98C8"/>
+        <Texture Name="sTransCircleStarburstTex" Format="i8" Width="16" Height="64" Offset="0xE9CC8"/>
+        <Array Name="sCircleWipeVtx" Count="34" Offset="0xEA0C8">
             <Vtx/>
         </Array>
         <!-- ZAPD isn't finding symbols correctly, instead finding them much later in `code`-->
         <!--<DList Name="sCircleWipeDL" Offset="0x10FF68"/>-->
-      <DList Name="sCircleDList" Offset="0xEA2E0"/>
+      <DList Name="sCircleDList" Offset="0xEA2C8"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_PAL_F/overlays/ovl_En_Ganon_Mant.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/overlays/ovl_En_Ganon_Mant.xml
@@ -1,21 +1,21 @@
 <Root>
-    <File Name="ovl_En_Ganon_Mant" BaseAddress="0x80A23D60" RangeStart="0x1218" RangeEnd="0x4118">
-        <Texture Name="gMantTex" OutName="mant" Format="rgba16" Width="32" Height="64" Offset="0x1218"/>
+    <File Name="ovl_En_Ganon_Mant" BaseAddress="0x80A0BCC0" RangeStart="0x11F8" RangeEnd="0x40F8">
+        <Texture Name="gMantTex" OutName="mant" Format="rgba16" Width="32" Height="64" Offset="0x11F8"/>
 
-        <Texture Name="gMantUnusedTex" OutName="mant_unused" Format="rgba16" Width="32" Height="32" Offset="0x2218"/>
+        <Texture Name="gMantUnusedTex" OutName="mant_unused" Format="rgba16" Width="32" Height="32" Offset="0x21F8"/>
 
-        <Array Name="gMant1Vtx" Count="144" Offset="0x2A18">
+        <Array Name="gMant1Vtx" Count="144" Offset="0x29F8">
             <Vtx/>
         </Array>
 
-        <DList Name="gMantMaterialDL" Offset="0x3318"/>
+        <DList Name="gMantMaterialDL" Offset="0x32F8"/>
 
         <!-- ! @bug gMantUnusedTex is 32x32 not 32x64, however this dlist is unused -->
-        <DList Name="gMantUnusedMaterialDL" Offset="0x3370"/>
+        <DList Name="gMantUnusedMaterialDL" Offset="0x3350"/>
 
-        <DList Name="gMantDL" Offset="0x33C8"/>
+        <DList Name="gMantDL" Offset="0x33A8"/>
 
-        <Array Name="gMant2Vtx" Count="144" Offset="0x3818">
+        <Array Name="gMant2Vtx" Count="144" Offset="0x37F8">
             <Vtx/>
         </Array>
     </File>

--- a/soh/assets/xml/GC_NMQ_PAL_F/overlays/ovl_Oceff_Spot.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/overlays/ovl_Oceff_Spot.xml
@@ -1,10 +1,10 @@
 <Root>
-    <File Name="ovl_Oceff_Spot" BaseAddress="0x80BA6070" RangeStart="0x7F0" RangeEnd="0xEC8">
-        <Texture Name="sTex" OutName="sun_song_effect" Format="i8" Width="32" Height="32" Offset="0x7F0"/>
-        <Array Name="sCylinderVtx" Count="27" Offset="0xBF0">
+    <File Name="ovl_Oceff_Spot" BaseAddress="0x80B7CDC0" RangeStart="0x780" RangeEnd="0xE58">
+        <Texture Name="sTex" OutName="sun_song_effect" Format="i8" Width="32" Height="32" Offset="0x780"/>
+        <Array Name="sCylinderVtx" Count="27" Offset="0xB80">
             <Vtx/>
         </Array>
-        <DList Name="sCylinderMaterialDL" Offset="0xDA0"/>
-        <DList Name="sCylinderModelDL" Offset="0xE38"/>
+        <DList Name="sCylinderMaterialDL" Offset="0xD30"/>
+        <DList Name="sCylinderModelDL" Offset="0xDC8"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_PAL_F/overlays/ovl_Oceff_Wipe3.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/overlays/ovl_Oceff_Wipe3.xml
@@ -1,10 +1,10 @@
 <Root>
-    <File Name="ovl_Oceff_Wipe3" BaseAddress="0x80BAB3F0" RangeStart="0x480" RangeEnd="0x16C8">
-        <Texture Name="sTex" OutName="saria_song_effect" Format="i8" Width="64" Height="64" Offset="0x480"/>
-        <Array Name="sFrustumVtx" Count="22" Offset="0x1480">
+    <File Name="ovl_Oceff_Wipe3" BaseAddress="0x80B81D90" RangeStart="0x430" RangeEnd="0x1678">
+        <Texture Name="sTex" OutName="saria_song_effect" Format="i8" Width="64" Height="64" Offset="0x430"/>
+        <Array Name="sFrustumVtx" Count="22" Offset="0x1430">
             <Vtx/>
         </Array>
-        <DList Name="sMaterialDL" Offset="0x15E0"/>
-        <DList Name="sFrustumDL" Offset="0x1668"/>
+        <DList Name="sMaterialDL" Offset="0x1590"/>
+        <DList Name="sFrustumDL" Offset="0x1618"/>
     </File>
 </Root>


### PR DESCRIPTION
Fixes some various asset offset issues for PAL GC:
* Circle wipe transition
* Ganondorf's cape
* Sun's song effect
* Saria's song effect

Targeting Sulu as not re-generating an OTR doesn't cause any crashes.

Fixes #2994, #2993, #2992

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/780556933.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/780556934.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/780556935.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/780556936.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/780556938.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/780556939.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/780556940.zip)
<!--- section:artifacts:end -->