### PR TITLE
Add "More info in file select" enhancement

### DIFF
--- a/soh/soh/SaveManager.cpp
+++ b/soh/soh/SaveManager.cpp
@@ -423,6 +423,7 @@ void SaveManager::InitMeta(int fileNum) {
     fileMetaInfo[fileNum].isDoubleMagicAcquired = gSaveContext.isDoubleMagicAcquired;
     fileMetaInfo[fileNum].rupees = gSaveContext.rupees;
     fileMetaInfo[fileNum].gsTokens = gSaveContext.inventory.gsTokens;
+    fileMetaInfo[fileNum].gregFound = Flags_GetRandomizerInf(RAND_INF_GREG_FOUND);
     fileMetaInfo[fileNum].defense = gSaveContext.inventory.defenseHearts;
     fileMetaInfo[fileNum].health = gSaveContext.health;
 

--- a/soh/soh/SaveManager.cpp
+++ b/soh/soh/SaveManager.cpp
@@ -420,6 +420,8 @@ void SaveManager::InitMeta(int fileNum) {
     fileMetaInfo[fileNum].equipment = gSaveContext.inventory.equipment;
     fileMetaInfo[fileNum].upgrades = gSaveContext.inventory.upgrades;
     fileMetaInfo[fileNum].isMagicAcquired = gSaveContext.isMagicAcquired;
+    fileMetaInfo[fileNum].isDoubleMagicAcquired = gSaveContext.isDoubleMagicAcquired;
+    fileMetaInfo[fileNum].rupees = gSaveContext.rupees;
     fileMetaInfo[fileNum].defense = gSaveContext.inventory.defenseHearts;
     fileMetaInfo[fileNum].health = gSaveContext.health;
 

--- a/soh/soh/SaveManager.cpp
+++ b/soh/soh/SaveManager.cpp
@@ -418,6 +418,8 @@ void SaveManager::InitMeta(int fileNum) {
         fileMetaInfo[fileNum].inventoryItems[i] = gSaveContext.inventory.items[i];
     }
     fileMetaInfo[fileNum].equipment = gSaveContext.inventory.equipment;
+    fileMetaInfo[fileNum].upgrades = gSaveContext.inventory.upgrades;
+    fileMetaInfo[fileNum].isMagicAcquired = gSaveContext.isMagicAcquired;
     fileMetaInfo[fileNum].defense = gSaveContext.inventory.defenseHearts;
     fileMetaInfo[fileNum].health = gSaveContext.health;
 

--- a/soh/soh/SaveManager.cpp
+++ b/soh/soh/SaveManager.cpp
@@ -422,6 +422,7 @@ void SaveManager::InitMeta(int fileNum) {
     fileMetaInfo[fileNum].isMagicAcquired = gSaveContext.isMagicAcquired;
     fileMetaInfo[fileNum].isDoubleMagicAcquired = gSaveContext.isDoubleMagicAcquired;
     fileMetaInfo[fileNum].rupees = gSaveContext.rupees;
+    fileMetaInfo[fileNum].gsTokens = gSaveContext.inventory.gsTokens;
     fileMetaInfo[fileNum].defense = gSaveContext.inventory.defenseHearts;
     fileMetaInfo[fileNum].health = gSaveContext.health;
 

--- a/soh/soh/SaveManager.cpp
+++ b/soh/soh/SaveManager.cpp
@@ -423,6 +423,7 @@ void SaveManager::InitMeta(int fileNum) {
     fileMetaInfo[fileNum].isDoubleMagicAcquired = gSaveContext.isDoubleMagicAcquired;
     fileMetaInfo[fileNum].rupees = gSaveContext.rupees;
     fileMetaInfo[fileNum].gsTokens = gSaveContext.inventory.gsTokens;
+    fileMetaInfo[fileNum].isDoubleDefenseAcquired = gSaveContext.isDoubleDefenseAcquired;
     fileMetaInfo[fileNum].gregFound = Flags_GetRandomizerInf(RAND_INF_GREG_FOUND);
     fileMetaInfo[fileNum].defense = gSaveContext.inventory.defenseHearts;
     fileMetaInfo[fileNum].health = gSaveContext.health;

--- a/soh/soh/SaveManager.cpp
+++ b/soh/soh/SaveManager.cpp
@@ -414,6 +414,10 @@ void SaveManager::InitMeta(int fileNum) {
     }
     fileMetaInfo[fileNum].healthCapacity = gSaveContext.healthCapacity;
     fileMetaInfo[fileNum].questItems = gSaveContext.inventory.questItems;
+    for (int i = 0; i < ARRAY_COUNT(fileMetaInfo[fileNum].inventoryItems); i++) {
+        fileMetaInfo[fileNum].inventoryItems[i] = gSaveContext.inventory.items[i];
+    }
+    fileMetaInfo[fileNum].equipment = gSaveContext.inventory.equipment;
     fileMetaInfo[fileNum].defense = gSaveContext.inventory.defenseHearts;
     fileMetaInfo[fileNum].health = gSaveContext.health;
 

--- a/soh/soh/SaveManager.h
+++ b/soh/soh/SaveManager.h
@@ -19,6 +19,9 @@ typedef struct {
     s16 buildVersionMajor;
     s16 buildVersionMinor;
     s16 buildVersionPatch;
+
+    u8 inventoryItems[24];
+    u16 equipment;
 } SaveFileMetaInfo;
 
 #ifdef __cplusplus

--- a/soh/soh/SaveManager.h
+++ b/soh/soh/SaveManager.h
@@ -27,6 +27,7 @@ typedef struct {
     u8 isDoubleMagicAcquired;
     s16 rupees;
     s16 gsTokens;
+    u8 isDoubleDefenseAcquired;
     u8 gregFound;
 } SaveFileMetaInfo;
 

--- a/soh/soh/SaveManager.h
+++ b/soh/soh/SaveManager.h
@@ -22,6 +22,8 @@ typedef struct {
 
     u8 inventoryItems[24];
     u16 equipment;
+    u32 upgrades;
+    u8 isMagicAcquired;
 } SaveFileMetaInfo;
 
 #ifdef __cplusplus

--- a/soh/soh/SaveManager.h
+++ b/soh/soh/SaveManager.h
@@ -24,6 +24,8 @@ typedef struct {
     u16 equipment;
     u32 upgrades;
     u8 isMagicAcquired;
+    u8 isDoubleMagicAcquired;
+    s16 rupees;
 } SaveFileMetaInfo;
 
 #ifdef __cplusplus

--- a/soh/soh/SaveManager.h
+++ b/soh/soh/SaveManager.h
@@ -26,6 +26,7 @@ typedef struct {
     u8 isMagicAcquired;
     u8 isDoubleMagicAcquired;
     s16 rupees;
+    s16 gsTokens;
 } SaveFileMetaInfo;
 
 #ifdef __cplusplus

--- a/soh/soh/SaveManager.h
+++ b/soh/soh/SaveManager.h
@@ -27,6 +27,7 @@ typedef struct {
     u8 isDoubleMagicAcquired;
     s16 rupees;
     s16 gsTokens;
+    u8 gregFound;
 } SaveFileMetaInfo;
 
 #ifdef __cplusplus

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -956,6 +956,8 @@ void DrawEnhancementsMenu() {
                                 "This might affect other decal effects\n");
             UIWidgets::PaddedEnhancementSliderInt("Text Spacing: %d", "##TEXTSPACING", "gTextSpacing", 4, 6, "", 6, true, true, true);
             UIWidgets::Tooltip("Space between text characters (useful for HD font textures)");
+            UIWidgets::PaddedEnhancementCheckbox("More info in file select", "gFileSelectMoreInfo", true, false);
+            UIWidgets::Tooltip("Shows what items you have collected in the file select screen, like in N64 randomizer");
             ImGui::EndMenu();
         }
 

--- a/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -66,7 +66,7 @@ typedef struct {
 #define UPG_IC_POS(x, y) {0x5A + ICON_SIZE * x, 0x2A + ICON_SIZE * y}
 #define STN_IC_POS(i) {0x29 + ICON_SIZE * i, 0x31}
 
-static ItemData itemData[86] = {
+static ItemData itemData[87] = {
     {CREATE_SPRITE_32(dgDekuStickIconTex, 1),            ITEM_STICK,            INV_IC_POS(0, 0), SIZE_NORMAL},
     {CREATE_SPRITE_32(dgDekuNutIconTex, 0),              ITEM_NUT,              INV_IC_POS(1, 0), SIZE_NORMAL},
     {CREATE_SPRITE_32(dgBombIconTex, 2),                 ITEM_BOMB,             INV_IC_POS(2, 0), SIZE_NORMAL},
@@ -148,6 +148,7 @@ static ItemData itemData[86] = {
     {CREATE_SPRITE_32(dgGoldenScaleIconTex, 74),         ITEM_SCALE_GOLDEN,     UPG_IC_POS(1, 0), SIZE_NORMAL},
     {CREATE_SPRITE_24(dgSmallMagicJarIconTex, 97),       ITEM_SINGLE_MAGIC,     UPG_IC_POS(2, 0), SIZE_NORMAL},
     {CREATE_SPRITE_24(dgBigMagicJarIconTex, 97),         ITEM_DOUBLE_MAGIC,     UPG_IC_POS(2, 0), SIZE_NORMAL},
+    {CREATE_SPRITE_RUPEE(0xC8, 0xFF, 0x64),              ITEM_RUPEE_GREEN,      UPG_IC_POS(0, 1), SIZE_NORMAL},
     {CREATE_SPRITE_24(dgGerudosCardIconTex, 91),         ITEM_GERUDO_CARD,      UPG_IC_POS(1, 1), SIZE_NORMAL},
     {CREATE_SPRITE_24(dgStoneOfAgonyIconTex, 90),        ITEM_STONE_OF_AGONY,   UPG_IC_POS(2, 1), SIZE_NORMAL},
 
@@ -238,6 +239,11 @@ u8 HasItem(s16 fileIndex, u8 item) {
 
     if (item == ITEM_SCALE_GOLDEN) {
         return ((Save_GetSaveMetaInfo(fileIndex)->upgrades & gUpgradeMasks[UPG_SCALE]) >> gUpgradeShifts[UPG_SCALE]) == 2;
+    }
+
+    //greg
+    if (item == ITEM_RUPEE_GREEN) {
+        return Save_GetSaveMetaInfo(fileIndex)->gregFound;
     }
 
     return 0;
@@ -414,6 +420,11 @@ u8 ShouldRenderItem(s16 fileIndex, u8 item) {
     
     if (item == ITEM_CLAIM_CHECK && HasItem(fileIndex, ITEM_CLAIM_CHECK) == 0) {
         return 0;
+    }
+
+    //greg
+    if (item == ITEM_RUPEE_GREEN) {
+        return Save_GetSaveMetaInfo(fileIndex)->randoSave;
     }
 
     return 1;

--- a/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -33,14 +33,15 @@ typedef struct {
 
 typedef struct {
     Sprite sprite;
+    Color_RGBA8 color;
     u8 item;
     ItemPosition pos;
     ItemSize size;
 } ItemData;
 
-#define CREATE_SPRITE_32(iconTex, spriteId) { iconTex, 32, 32, G_IM_FMT_RGBA, G_IM_SIZ_32b, spriteId }
-#define CREATE_SPRITE_24(iconTex, spriteId) { iconTex, 24, 24, G_IM_FMT_RGBA, G_IM_SIZ_32b, spriteId }
-#define CREATE_SPRITE_SONG { dgSongNoteTex, 16, 24, G_IM_FMT_RGBA, G_IM_SIZ_32b/*G_IM_FMT_IA, G_IM_SIZ_8b*/, 100 }
+#define CREATE_SPRITE_32(iconTex, spriteId) { iconTex, 32, 32, G_IM_FMT_RGBA, G_IM_SIZ_32b, spriteId }, {0xFF, 0xFF, 0xFF, 0xFF}
+#define CREATE_SPRITE_24(iconTex, spriteId) { iconTex, 24, 24, G_IM_FMT_RGBA, G_IM_SIZ_32b, spriteId }, {0xFF, 0xFF, 0xFF, 0xFF}
+#define CREATE_SPRITE_SONG(colorR, colorG, colorB) { dgSongNoteTex, 16, 24, G_IM_FMT_IA, G_IM_SIZ_8b, 100 }, {colorR, colorG, colorB, 0xFF}
 
 #define ICON_SIZE 12
 #define SONG_WIDTH 8
@@ -112,18 +113,18 @@ static ItemData itemData[59] = {
     {CREATE_SPRITE_24(dgGerudosCardIconTex, 91),     ITEM_GERUDO_CARD,      UPG_IT_POS(1, 1), SIZE_NORMAL},
     {CREATE_SPRITE_24(dgStoneOfAgonyIconTex, 90),    ITEM_STONE_OF_AGONY,   UPG_IT_POS(2, 1), SIZE_NORMAL},
     
-    {CREATE_SPRITE_SONG,                             ITEM_SONG_LULLABY,     SNG_IT_POS(0, 0), SIZE_SONG},
-    {CREATE_SPRITE_SONG,                             ITEM_SONG_EPONA,       SNG_IT_POS(1, 0), SIZE_SONG},
-    {CREATE_SPRITE_SONG,                             ITEM_SONG_SARIA,       SNG_IT_POS(2, 0), SIZE_SONG},
-    {CREATE_SPRITE_SONG,                             ITEM_SONG_SUN,         SNG_IT_POS(3, 0), SIZE_SONG},
-    {CREATE_SPRITE_SONG,                             ITEM_SONG_TIME,        SNG_IT_POS(4, 0), SIZE_SONG},
-    {CREATE_SPRITE_SONG,                             ITEM_SONG_STORMS,      SNG_IT_POS(5, 0), SIZE_SONG},
-    {CREATE_SPRITE_SONG,                             ITEM_SONG_MINUET,      SNG_IT_POS(0, 1), SIZE_SONG},
-    {CREATE_SPRITE_SONG,                             ITEM_SONG_BOLERO,      SNG_IT_POS(1, 1), SIZE_SONG},
-    {CREATE_SPRITE_SONG,                             ITEM_SONG_SERENADE,    SNG_IT_POS(2, 1), SIZE_SONG},
-    {CREATE_SPRITE_SONG,                             ITEM_SONG_REQUIEM,     SNG_IT_POS(3, 1), SIZE_SONG},
-    {CREATE_SPRITE_SONG,                             ITEM_SONG_NOCTURNE,    SNG_IT_POS(4, 1), SIZE_SONG},
-    {CREATE_SPRITE_SONG,                             ITEM_SONG_PRELUDE,     SNG_IT_POS(5, 1), SIZE_SONG},
+    {CREATE_SPRITE_SONG(224, 107, 255),              ITEM_SONG_LULLABY,     SNG_IT_POS(0, 0), SIZE_SONG},
+    {CREATE_SPRITE_SONG(255, 195, 60),               ITEM_SONG_EPONA,       SNG_IT_POS(1, 0), SIZE_SONG},
+    {CREATE_SPRITE_SONG(127, 255, 137),              ITEM_SONG_SARIA,       SNG_IT_POS(2, 0), SIZE_SONG},
+    {CREATE_SPRITE_SONG(255, 255, 60),               ITEM_SONG_SUN,         SNG_IT_POS(3, 0), SIZE_SONG},
+    {CREATE_SPRITE_SONG(119, 236, 255),              ITEM_SONG_TIME,        SNG_IT_POS(4, 0), SIZE_SONG},
+    {CREATE_SPRITE_SONG(165, 165, 165),              ITEM_SONG_STORMS,      SNG_IT_POS(5, 0), SIZE_SONG},
+    {CREATE_SPRITE_SONG(150, 255, 100),              ITEM_SONG_MINUET,      SNG_IT_POS(0, 1), SIZE_SONG},
+    {CREATE_SPRITE_SONG(255, 80,  40),               ITEM_SONG_BOLERO,      SNG_IT_POS(1, 1), SIZE_SONG},
+    {CREATE_SPRITE_SONG(100, 150, 255),              ITEM_SONG_SERENADE,    SNG_IT_POS(2, 1), SIZE_SONG},
+    {CREATE_SPRITE_SONG(255, 160, 0),                ITEM_SONG_REQUIEM,     SNG_IT_POS(3, 1), SIZE_SONG},
+    {CREATE_SPRITE_SONG(255, 100, 255),              ITEM_SONG_NOCTURNE,    SNG_IT_POS(4, 1), SIZE_SONG},
+    {CREATE_SPRITE_SONG(255, 240, 100),              ITEM_SONG_PRELUDE,     SNG_IT_POS(5, 1), SIZE_SONG},
 };
 
 static u8 color_product(u8 c1, u8 c2) {
@@ -132,15 +133,7 @@ static u8 color_product(u8 c1, u8 c2) {
     return (u8)div255;
 }
 
-static const Color_RGBA8 WHITE = {0xFF, 0xFF, 0xFF, 0xFF};
-static const Color_RGBA8 DIM   = {0x40, 0x40, 0x40, 0x90};
-
-struct Color_RGBA8 {
-    u8 r;
-    u8 g;
-    u8 b;
-    u8 a;
-};
+static const Color_RGBA8 DIM = {0x40, 0x40, 0x40, 0x90};
 
 void SpriteLoad(FileChooseContext* this, Sprite* sprite);
 void SpriteDraw(FileChooseContext* this, Sprite* sprite, int left, int top, int width, int height);
@@ -212,9 +205,9 @@ static void Draw_Items(FileChooseContext* this, s16 fileIndex, u8 alpha) {
         ItemData* data = &itemData[i];
 
         if (HasItem(fileIndex, data->item) != 0) {
-            gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, WHITE.r, WHITE.g, WHITE.b, color_product(WHITE.a, alpha));
+            gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, data->color.r, data->color.g, data->color.b, color_product(data->color.a, alpha));
         } else {
-            gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, DIM.r, DIM.g, DIM.b, color_product(DIM.a, alpha));
+            gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, color_product(data->color.r, DIM.r), color_product(data->color.g, DIM.g), color_product(data->color.b, DIM.b), color_product(color_product(data->color.a, DIM.a), alpha));
         }
 
         SpriteLoad(this, &(data->sprite));
@@ -475,7 +468,12 @@ void FileChoose_FinishFadeIn(GameState* thisx) {
 void SpriteLoad(FileChooseContext* this, Sprite* sprite) {
     OPEN_DISPS(this->state.gfxCtx);
 
-    if (sprite->im_siz == G_IM_SIZ_16b) {
+    if (sprite->im_siz == G_IM_SIZ_8b) {
+        gDPLoadTextureBlock(POLY_OPA_DISP++, sprite->tex, sprite->im_fmt,
+                            G_IM_SIZ_8b, // @TEMP until I figure out how to use sprite->im_siz
+                            sprite->width, sprite->height, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP,
+                            G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
+    } else if (sprite->im_siz == G_IM_SIZ_16b) {
         gDPLoadTextureBlock(POLY_OPA_DISP++, sprite->tex, sprite->im_fmt,
                             G_IM_SIZ_16b, // @TEMP until I figure out how to use sprite->im_siz
                             sprite->width, sprite->height, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP,

--- a/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -32,87 +32,89 @@ typedef struct {
     ItemPosition pos;
 } ItemData;
 
-#define SPRITE_ID_OFFSET 1000
-
-#define CREATE_SPRITE(iconTex, texSize, origSpriteId) { iconTex, texSize, texSize, G_IM_FMT_RGBA, G_IM_SIZ_32b, SPRITE_ID_OFFSET + origSpriteId }
-
 #define ICON_SIZE 16
+#define SONG_WIDTH 16
+#define SONG_HEIGHT 24
+
+#define CREATE_SPRITE_32(iconTex, spriteId) { iconTex, 32, 32, G_IM_FMT_RGBA, G_IM_SIZ_32b, spriteId }
+#define CREATE_SPRITE_24(iconTex, spriteId) { iconTex, 24, 24, G_IM_FMT_RGBA, G_IM_SIZ_32b, spriteId }
+#define CREATE_SPRITE_SONG { dgSongNoteTex, SONG_WIDTH, SONG_HEIGHT, G_IM_FMT_RGBA, G_IM_SIZ_32b, 100 }
 
 #define INV_IT_POS(x, y) {0x4E + ICON_SIZE * x, 0x00 + ICON_SIZE * y}
 #define EQP_IT_POS(x, y) {0x7E + ICON_SIZE * x, 0x2A + ICON_SIZE * y}
-#define SNG_IT_POS(x, y) {0x4E + ICON_SIZE * x, 0x45 + ICON_SIZE * y}
+#define SNG_IT_POS(x, y) {0x4E + SONG_WIDTH / 2 * x, 0x45 + SONG_HEIGHT / 2 * y}
 #define UPG_IT_POS(i) {0x3E + ICON_SIZE * i, 0x2A}
 
 static ItemData itemData[59] = {
-    {CREATE_SPRITE(dgDekuStickIconTex, 32, 1),        ITEM_STICK,            INV_IT_POS(0, 0)},
-    {CREATE_SPRITE(dgDekuNutIconTex, 32, 0),          ITEM_NUT,              INV_IT_POS(1, 0)},
-    {CREATE_SPRITE(dgBombIconTex, 32, 2),             ITEM_BOMB,             INV_IT_POS(2, 0)},
-    {CREATE_SPRITE(dgFairyBowIconTex, 32, 3),         ITEM_BOW,              INV_IT_POS(3, 0)},
-    {CREATE_SPRITE(dgFireArrowIconTex, 32, 4),        ITEM_ARROW_FIRE,       INV_IT_POS(4, 0)},
-    {CREATE_SPRITE(dgDinsFireIconTex, 32, 5),         ITEM_DINS_FIRE,        INV_IT_POS(5, 0)},
-    {CREATE_SPRITE(dgEmptyBottleIconTex, 32, 20),     ITEM_BOTTLE,           INV_IT_POS(6, 0)},
+    {CREATE_SPRITE_32(dgDekuStickIconTex, 1),        ITEM_STICK,            INV_IT_POS(0, 0)},
+    {CREATE_SPRITE_32(dgDekuNutIconTex, 0),          ITEM_NUT,              INV_IT_POS(1, 0)},
+    {CREATE_SPRITE_32(dgBombIconTex, 2),             ITEM_BOMB,             INV_IT_POS(2, 0)},
+    {CREATE_SPRITE_32(dgFairyBowIconTex, 3),         ITEM_BOW,              INV_IT_POS(3, 0)},
+    {CREATE_SPRITE_32(dgFireArrowIconTex, 4),        ITEM_ARROW_FIRE,       INV_IT_POS(4, 0)},
+    {CREATE_SPRITE_32(dgDinsFireIconTex, 5),         ITEM_DINS_FIRE,        INV_IT_POS(5, 0)},
+    {CREATE_SPRITE_32(dgEmptyBottleIconTex, 20),     ITEM_BOTTLE,           INV_IT_POS(6, 0)},
 
-    {CREATE_SPRITE(dgFairySlingshotIconTex, 32, 6),   ITEM_SLINGSHOT,        INV_IT_POS(0, 1)},
-    {CREATE_SPRITE(dgFairyOcarinaIconTex, 32, 7),     ITEM_OCARINA_FAIRY,    INV_IT_POS(1, 1)},
-    {CREATE_SPRITE(dgBombchuIconTex, 32, 9),          ITEM_BOMBCHU,          INV_IT_POS(2, 1)},
-    {CREATE_SPRITE(dgHookshotIconTex, 32, 10),        ITEM_HOOKSHOT,         INV_IT_POS(3, 1)},
-    {CREATE_SPRITE(dgIceArrowIconTex, 32, 12),        ITEM_ARROW_ICE,        INV_IT_POS(4, 1)},
-    {CREATE_SPRITE(dgFaroresWindIconTex, 32, 13),     ITEM_FARORES_WIND,     INV_IT_POS(5, 1)},
-    {CREATE_SPRITE(dgBunnyHoodIconTex, 32, 37),       ITEM_MASK_BUNNY,       INV_IT_POS(6, 1)},
+    {CREATE_SPRITE_32(dgFairySlingshotIconTex, 6),   ITEM_SLINGSHOT,        INV_IT_POS(0, 1)},
+    {CREATE_SPRITE_32(dgFairyOcarinaIconTex, 7),     ITEM_OCARINA_FAIRY,    INV_IT_POS(1, 1)},
+    {CREATE_SPRITE_32(dgBombchuIconTex, 9),          ITEM_BOMBCHU,          INV_IT_POS(2, 1)},
+    {CREATE_SPRITE_32(dgHookshotIconTex, 10),        ITEM_HOOKSHOT,         INV_IT_POS(3, 1)},
+    {CREATE_SPRITE_32(dgIceArrowIconTex, 12),        ITEM_ARROW_ICE,        INV_IT_POS(4, 1)},
+    {CREATE_SPRITE_32(dgFaroresWindIconTex, 13),     ITEM_FARORES_WIND,     INV_IT_POS(5, 1)},
+    {CREATE_SPRITE_32(dgBunnyHoodIconTex, 37),       ITEM_MASK_BUNNY,       INV_IT_POS(6, 1)},
 
-    {CREATE_SPRITE(dgBoomerangIconTex, 32, 14),       ITEM_BOOMERANG,        INV_IT_POS(0, 2)},
-    {CREATE_SPRITE(dgLensofTruthIconTex, 32, 15),     ITEM_LENS,             INV_IT_POS(1, 2)},
-    {CREATE_SPRITE(dgMagicBeansIconTex, 32, 16),      ITEM_BEAN,             INV_IT_POS(2, 2)},
-    {CREATE_SPRITE(dgMegatonHammerIconTex, 32, 17),   ITEM_HAMMER,           INV_IT_POS(3, 2)},
-    {CREATE_SPRITE(dgLightArrowIconTex, 32, 18),      ITEM_ARROW_LIGHT,      INV_IT_POS(4, 2)},
-    {CREATE_SPRITE(dgNayrusLoveIconTex, 32, 19),      ITEM_NAYRUS_LOVE,      INV_IT_POS(5, 2)},
-    {CREATE_SPRITE(dgClaimCheckIconTex, 32, 53),      ITEM_CLAIM_CHECK,      INV_IT_POS(6, 2)},
+    {CREATE_SPRITE_32(dgBoomerangIconTex, 14),       ITEM_BOOMERANG,        INV_IT_POS(0, 2)},
+    {CREATE_SPRITE_32(dgLensofTruthIconTex, 15),     ITEM_LENS,             INV_IT_POS(1, 2)},
+    {CREATE_SPRITE_32(dgMagicBeansIconTex, 16),      ITEM_BEAN,             INV_IT_POS(2, 2)},
+    {CREATE_SPRITE_32(dgMegatonHammerIconTex, 17),   ITEM_HAMMER,           INV_IT_POS(3, 2)},
+    {CREATE_SPRITE_32(dgLightArrowIconTex, 18),      ITEM_ARROW_LIGHT,      INV_IT_POS(4, 2)},
+    {CREATE_SPRITE_32(dgNayrusLoveIconTex, 19),      ITEM_NAYRUS_LOVE,      INV_IT_POS(5, 2)},
+    {CREATE_SPRITE_32(dgClaimCheckIconTex, 53),      ITEM_CLAIM_CHECK,      INV_IT_POS(6, 2)},
     
-    {CREATE_SPRITE(dgKokiriSwordIconTex, 32, 54),     ITEM_SWORD_KOKIRI,     EQP_IT_POS(0, 0)},
-    {CREATE_SPRITE(dgMasterSwordIconTex, 32, 55),     ITEM_SWORD_MASTER,     EQP_IT_POS(1, 0)},
-    {CREATE_SPRITE(dgBiggoronSwordIconTex, 32, 56),   ITEM_SWORD_BGS,        EQP_IT_POS(2, 0)},
+    {CREATE_SPRITE_32(dgKokiriSwordIconTex, 54),     ITEM_SWORD_KOKIRI,     EQP_IT_POS(0, 0)},
+    {CREATE_SPRITE_32(dgMasterSwordIconTex, 55),     ITEM_SWORD_MASTER,     EQP_IT_POS(1, 0)},
+    {CREATE_SPRITE_32(dgBiggoronSwordIconTex, 56),   ITEM_SWORD_BGS,        EQP_IT_POS(2, 0)},
     
-    {CREATE_SPRITE(dgDekuShieldIconTex, 32, 57),      ITEM_SHIELD_DEKU,      EQP_IT_POS(0, 1)},
-    {CREATE_SPRITE(dgHylianShieldIconTex, 32, 58),    ITEM_SHIELD_HYLIAN,    EQP_IT_POS(1, 1)},
-    {CREATE_SPRITE(dgMirrorShieldIconTex, 32, 59),    ITEM_SHIELD_MIRROR,    EQP_IT_POS(2, 1)},
+    {CREATE_SPRITE_32(dgDekuShieldIconTex, 57),      ITEM_SHIELD_DEKU,      EQP_IT_POS(0, 1)},
+    {CREATE_SPRITE_32(dgHylianShieldIconTex, 58),    ITEM_SHIELD_HYLIAN,    EQP_IT_POS(1, 1)},
+    {CREATE_SPRITE_32(dgMirrorShieldIconTex, 59),    ITEM_SHIELD_MIRROR,    EQP_IT_POS(2, 1)},
     
-    {CREATE_SPRITE(dgKokiriTunicIconTex, 32, 60),     ITEM_TUNIC_KOKIRI,     EQP_IT_POS(0, 2)},
-    {CREATE_SPRITE(dgGoronTunicIconTex, 32, 61),      ITEM_TUNIC_GORON,      EQP_IT_POS(1, 2)},
-    {CREATE_SPRITE(dgZoraTunicIconTex, 32, 62),       ITEM_TUNIC_ZORA,       EQP_IT_POS(2, 2)},
+    {CREATE_SPRITE_32(dgKokiriTunicIconTex, 60),     ITEM_TUNIC_KOKIRI,     EQP_IT_POS(0, 2)},
+    {CREATE_SPRITE_32(dgGoronTunicIconTex, 61),      ITEM_TUNIC_GORON,      EQP_IT_POS(1, 2)},
+    {CREATE_SPRITE_32(dgZoraTunicIconTex, 62),       ITEM_TUNIC_ZORA,       EQP_IT_POS(2, 2)},
     
-    {CREATE_SPRITE(dgKokiriBootsIconTex, 32, 63),     ITEM_BOOTS_KOKIRI,     EQP_IT_POS(0, 3)},
-    {CREATE_SPRITE(dgIronBootsIconTex, 32, 64),       ITEM_BOOTS_IRON,       EQP_IT_POS(1, 3)},
-    {CREATE_SPRITE(dgHoverBootsIconTex, 32, 65),      ITEM_BOOTS_HOVER,      EQP_IT_POS(2, 3)},
+    {CREATE_SPRITE_32(dgKokiriBootsIconTex, 63),     ITEM_BOOTS_KOKIRI,     EQP_IT_POS(0, 3)},
+    {CREATE_SPRITE_32(dgIronBootsIconTex, 64),       ITEM_BOOTS_IRON,       EQP_IT_POS(1, 3)},
+    {CREATE_SPRITE_32(dgHoverBootsIconTex, 65),      ITEM_BOOTS_HOVER,      EQP_IT_POS(2, 3)},
 
-    {CREATE_SPRITE(dgKokiriEmeraldIconTex, 24, 87),   ITEM_KOKIRI_EMERALD,   {0x19, 0x31}},
-    {CREATE_SPRITE(dgGoronRubyIconTex, 24, 88),       ITEM_GORON_RUBY,       {0x29, 0x31}},
-    {CREATE_SPRITE(dgZoraSapphireIconTex, 24, 89),    ITEM_ZORA_SAPPHIRE,    {0x39, 0x31}},
+    {CREATE_SPRITE_24(dgKokiriEmeraldIconTex, 87),   ITEM_KOKIRI_EMERALD,   {0x19, 0x31}},
+    {CREATE_SPRITE_24(dgGoronRubyIconTex, 88),       ITEM_GORON_RUBY,       {0x29, 0x31}},
+    {CREATE_SPRITE_24(dgZoraSapphireIconTex, 89),    ITEM_ZORA_SAPPHIRE,    {0x39, 0x31}},
     
-    {CREATE_SPRITE(dgForestMedallionIconTex, 24, 81), ITEM_MEDALLION_FOREST, {0x37, 0x0A}},
-    {CREATE_SPRITE(dgFireMedallionIconTex, 24, 82),   ITEM_MEDALLION_FIRE,   {0x37, 0x1A}},
-    {CREATE_SPRITE(dgWaterMedallionIconTex, 24, 83),  ITEM_MEDALLION_WATER,  {0x29, 0x22}},
-    {CREATE_SPRITE(dgSpiritMedallionIconTex, 24, 84), ITEM_MEDALLION_SPIRIT, {0x1B, 0x1A}},
-    {CREATE_SPRITE(dgShadowMedallionIconTex, 24, 85), ITEM_MEDALLION_SHADOW, {0x1B, 0x0A}},
-    {CREATE_SPRITE(dgLightMedallionIconTex, 24, 86),  ITEM_MEDALLION_LIGHT,  {0x29, 0x02}},
+    {CREATE_SPRITE_24(dgForestMedallionIconTex, 81), ITEM_MEDALLION_FOREST, {0x37, 0x0A}},
+    {CREATE_SPRITE_24(dgFireMedallionIconTex, 82),   ITEM_MEDALLION_FIRE,   {0x37, 0x1A}},
+    {CREATE_SPRITE_24(dgWaterMedallionIconTex, 83),  ITEM_MEDALLION_WATER,  {0x29, 0x22}},
+    {CREATE_SPRITE_24(dgSpiritMedallionIconTex, 84), ITEM_MEDALLION_SPIRIT, {0x1B, 0x1A}},
+    {CREATE_SPRITE_24(dgShadowMedallionIconTex, 85), ITEM_MEDALLION_SHADOW, {0x1B, 0x0A}},
+    {CREATE_SPRITE_24(dgLightMedallionIconTex, 86),  ITEM_MEDALLION_LIGHT,  {0x29, 0x02}},
 
-    {CREATE_SPRITE(dgGoronsBraceletIconTex, 32, 71),  ITEM_BRACELET,         UPG_IT_POS(0)},
-    {CREATE_SPRITE(dgSilverScaleIconTex, 32, 74),     ITEM_SCALE_SILVER,     UPG_IT_POS(1)},
-    {CREATE_SPRITE(dgSmallKeyIconTex, 24, 97),        ITEM_MAGIC_SMALL,      UPG_IT_POS(2)},
-    {CREATE_SPRITE(dgGerudosCardIconTex, 24, 91),     ITEM_GERUDO_CARD,      UPG_IT_POS(3)},
-    {CREATE_SPRITE(dgStoneOfAgonyIconTex, 24, 90),    ITEM_STONE_OF_AGONY,   {0x6F, 0x51}},
+    {CREATE_SPRITE_32(dgGoronsBraceletIconTex, 71),  ITEM_BRACELET,         UPG_IT_POS(0)},
+    {CREATE_SPRITE_32(dgSilverScaleIconTex, 74),     ITEM_SCALE_SILVER,     UPG_IT_POS(1)},
+    {CREATE_SPRITE_24(dgSmallKeyIconTex, 97),        ITEM_MAGIC_SMALL,      UPG_IT_POS(2)},
+    {CREATE_SPRITE_24(dgGerudosCardIconTex, 91),     ITEM_GERUDO_CARD,      UPG_IT_POS(3)},
+    {CREATE_SPRITE_24(dgStoneOfAgonyIconTex, 90),    ITEM_STONE_OF_AGONY,   {0x6F, 0x51}},
     
-    {CREATE_SPRITE(dgSongNoteTex, 32, 100),           ITEM_SONG_MINUET,      SNG_IT_POS(0, 0)},
-    {CREATE_SPRITE(dgSongNoteTex, 32, 100),           ITEM_SONG_BOLERO,      SNG_IT_POS(1, 0)},
-    {CREATE_SPRITE(dgSongNoteTex, 32, 100),           ITEM_SONG_SERENADE,    SNG_IT_POS(2, 0)},
-    {CREATE_SPRITE(dgSongNoteTex, 32, 100),           ITEM_SONG_REQUIEM,     SNG_IT_POS(3, 0)},
-    {CREATE_SPRITE(dgSongNoteTex, 32, 100),           ITEM_SONG_NOCTURNE,    SNG_IT_POS(4, 0)},
-    {CREATE_SPRITE(dgSongNoteTex, 32, 100),           ITEM_SONG_PRELUDE,     SNG_IT_POS(5, 0)},
-    {CREATE_SPRITE(dgSongNoteTex, 32, 100),           ITEM_SONG_LULLABY,     SNG_IT_POS(0, 1)},
-    {CREATE_SPRITE(dgSongNoteTex, 32, 100),           ITEM_SONG_EPONA,       SNG_IT_POS(1, 1)},
-    {CREATE_SPRITE(dgSongNoteTex, 32, 100),           ITEM_SONG_SARIA,       SNG_IT_POS(2, 1)},
-    {CREATE_SPRITE(dgSongNoteTex, 32, 100),           ITEM_SONG_SUN,         SNG_IT_POS(3, 1)},
-    {CREATE_SPRITE(dgSongNoteTex, 32, 100),           ITEM_SONG_TIME,        SNG_IT_POS(4, 1)},
-    {CREATE_SPRITE(dgSongNoteTex, 32, 100),           ITEM_SONG_STORMS,      SNG_IT_POS(5, 1)},
+    {CREATE_SPRITE_SONG,                             ITEM_SONG_LULLABY,     SNG_IT_POS(0, 0)},
+    {CREATE_SPRITE_SONG,                             ITEM_SONG_EPONA,       SNG_IT_POS(1, 0)},
+    {CREATE_SPRITE_SONG,                             ITEM_SONG_SARIA,       SNG_IT_POS(2, 0)},
+    {CREATE_SPRITE_SONG,                             ITEM_SONG_SUN,         SNG_IT_POS(3, 0)},
+    {CREATE_SPRITE_SONG,                             ITEM_SONG_TIME,        SNG_IT_POS(4, 0)},
+    {CREATE_SPRITE_SONG,                             ITEM_SONG_STORMS,      SNG_IT_POS(5, 0)},
+    {CREATE_SPRITE_SONG,                             ITEM_SONG_MINUET,      SNG_IT_POS(0, 1)},
+    {CREATE_SPRITE_SONG,                             ITEM_SONG_BOLERO,      SNG_IT_POS(1, 1)},
+    {CREATE_SPRITE_SONG,                             ITEM_SONG_SERENADE,    SNG_IT_POS(2, 1)},
+    {CREATE_SPRITE_SONG,                             ITEM_SONG_REQUIEM,     SNG_IT_POS(3, 1)},
+    {CREATE_SPRITE_SONG,                             ITEM_SONG_NOCTURNE,    SNG_IT_POS(4, 1)},
+    {CREATE_SPRITE_SONG,                             ITEM_SONG_PRELUDE,     SNG_IT_POS(5, 1)},
 };
 
 static u8 color_product(u8 c1, u8 c2) {
@@ -182,20 +184,23 @@ u8 HasItem(s16 fileIndex, u8 item) {
 
 static void Draw_Items(FileChooseContext* this, s16 fileIndex, u8 alpha) {
     OPEN_DISPS(this->state.gfxCtx);
+    gDPPipeSync(POLY_OPA_DISP++);
+    gDPSetCombineMode(POLY_OPA_DISP++, G_CC_MODULATEIA_PRIM, G_CC_MODULATEIA_PRIM);
 
     for (int i = 0; i < ARRAY_COUNT(itemData); i += 1) {
-        ItemData data = itemData[i];
+        ItemData* data = &itemData[i];
 
-        if (HasItem(fileIndex, data.item) != 0) {
+        if (HasItem(fileIndex, data->item) != 0) {
             gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, WHITE.r, WHITE.g, WHITE.b, color_product(WHITE.a, alpha));
         } else {
             gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, DIM.r, DIM.g, DIM.b, color_product(DIM.a, alpha));
         }
 
-        SpriteLoad(this, &data.sprite);
-        SpriteDraw(this, &data.sprite, LEFT_OFFSET + data.pos.left, TOP_OFFSET + data.pos.top, ICON_SIZE, ICON_SIZE);
+        SpriteLoad(this, &(data->sprite));
+        SpriteDraw(this, &(data->sprite), LEFT_OFFSET + data->pos.left, TOP_OFFSET + data->pos.top, data->sprite.width / 2, data->sprite.height / 2);
     }
 
+    gDPPipeSync(POLY_OPA_DISP++);
     CLOSE_DISPS(this->state.gfxCtx);
 }
 

--- a/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -5,6 +5,7 @@
 #include "textures/title_static/title_static.h"
 #include "textures/parameter_static/parameter_static.h"
 #include <textures/icon_item_static/icon_item_static.h>
+#include <textures/icon_item_24_static/icon_item_24_static.h>
 #include "soh/frame_interpolation.h"
 #include <GameVersions.h>
 #include "objects/object_mag/object_mag.h"
@@ -17,6 +18,186 @@
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 #include <assert.h>
 
+#define LEFT_OFFSET (int)0x37
+#define TOP_OFFSET  (int)0x5C
+
+typedef struct {
+    s16 left;
+    s16 top;
+} ItemPosition;
+
+typedef struct {
+    Sprite sprite;
+    u8 item;
+    ItemPosition pos;
+} ItemData;
+
+#define SPRITE_ID_OFFSET 1000
+
+#define CREATE_SPRITE(iconTex, texSize, origSpriteId) { iconTex, texSize, texSize, G_IM_FMT_RGBA, G_IM_SIZ_32b, SPRITE_ID_OFFSET + origSpriteId }
+
+#define ICON_SIZE 16
+
+#define INV_IT_POS(x, y) {0x4E + ICON_SIZE * x, 0x00 + ICON_SIZE * y}
+#define EQP_IT_POS(x, y) {0x7E + ICON_SIZE * x, 0x2A + ICON_SIZE * y}
+#define SNG_IT_POS(x, y) {0x4E + ICON_SIZE * x, 0x45 + ICON_SIZE * y}
+#define UPG_IT_POS(i) {0x3E + ICON_SIZE * i, 0x2A}
+
+static ItemData itemData[59] = {
+    {CREATE_SPRITE(dgDekuStickIconTex, 32, 1),        ITEM_STICK,            INV_IT_POS(0, 0)},
+    {CREATE_SPRITE(dgDekuNutIconTex, 32, 0),          ITEM_NUT,              INV_IT_POS(1, 0)},
+    {CREATE_SPRITE(dgBombIconTex, 32, 2),             ITEM_BOMB,             INV_IT_POS(2, 0)},
+    {CREATE_SPRITE(dgFairyBowIconTex, 32, 3),         ITEM_BOW,              INV_IT_POS(3, 0)},
+    {CREATE_SPRITE(dgFireArrowIconTex, 32, 4),        ITEM_ARROW_FIRE,       INV_IT_POS(4, 0)},
+    {CREATE_SPRITE(dgDinsFireIconTex, 32, 5),         ITEM_DINS_FIRE,        INV_IT_POS(5, 0)},
+    {CREATE_SPRITE(dgEmptyBottleIconTex, 32, 20),     ITEM_BOTTLE,           INV_IT_POS(6, 0)},
+
+    {CREATE_SPRITE(dgFairySlingshotIconTex, 32, 6),   ITEM_SLINGSHOT,        INV_IT_POS(0, 1)},
+    {CREATE_SPRITE(dgFairyOcarinaIconTex, 32, 7),     ITEM_OCARINA_FAIRY,    INV_IT_POS(1, 1)},
+    {CREATE_SPRITE(dgBombchuIconTex, 32, 9),          ITEM_BOMBCHU,          INV_IT_POS(2, 1)},
+    {CREATE_SPRITE(dgHookshotIconTex, 32, 10),        ITEM_HOOKSHOT,         INV_IT_POS(3, 1)},
+    {CREATE_SPRITE(dgIceArrowIconTex, 32, 12),        ITEM_ARROW_ICE,        INV_IT_POS(4, 1)},
+    {CREATE_SPRITE(dgFaroresWindIconTex, 32, 13),     ITEM_FARORES_WIND,     INV_IT_POS(5, 1)},
+    {CREATE_SPRITE(dgBunnyHoodIconTex, 32, 37),       ITEM_MASK_BUNNY,       INV_IT_POS(6, 1)},
+
+    {CREATE_SPRITE(dgBoomerangIconTex, 32, 14),       ITEM_BOOMERANG,        INV_IT_POS(0, 2)},
+    {CREATE_SPRITE(dgLensofTruthIconTex, 32, 15),     ITEM_LENS,             INV_IT_POS(1, 2)},
+    {CREATE_SPRITE(dgMagicBeansIconTex, 32, 16),      ITEM_BEAN,             INV_IT_POS(2, 2)},
+    {CREATE_SPRITE(dgMegatonHammerIconTex, 32, 17),   ITEM_HAMMER,           INV_IT_POS(3, 2)},
+    {CREATE_SPRITE(dgLightArrowIconTex, 32, 18),      ITEM_ARROW_LIGHT,      INV_IT_POS(4, 2)},
+    {CREATE_SPRITE(dgNayrusLoveIconTex, 32, 19),      ITEM_NAYRUS_LOVE,      INV_IT_POS(5, 2)},
+    {CREATE_SPRITE(dgClaimCheckIconTex, 32, 53),      ITEM_CLAIM_CHECK,      INV_IT_POS(6, 2)},
+    
+    {CREATE_SPRITE(dgKokiriSwordIconTex, 32, 54),     ITEM_SWORD_KOKIRI,     EQP_IT_POS(0, 0)},
+    {CREATE_SPRITE(dgMasterSwordIconTex, 32, 55),     ITEM_SWORD_MASTER,     EQP_IT_POS(1, 0)},
+    {CREATE_SPRITE(dgBiggoronSwordIconTex, 32, 56),   ITEM_SWORD_BGS,        EQP_IT_POS(2, 0)},
+    
+    {CREATE_SPRITE(dgDekuShieldIconTex, 32, 57),      ITEM_SHIELD_DEKU,      EQP_IT_POS(0, 1)},
+    {CREATE_SPRITE(dgHylianShieldIconTex, 32, 58),    ITEM_SHIELD_HYLIAN,    EQP_IT_POS(1, 1)},
+    {CREATE_SPRITE(dgMirrorShieldIconTex, 32, 59),    ITEM_SHIELD_MIRROR,    EQP_IT_POS(2, 1)},
+    
+    {CREATE_SPRITE(dgKokiriTunicIconTex, 32, 60),     ITEM_TUNIC_KOKIRI,     EQP_IT_POS(0, 2)},
+    {CREATE_SPRITE(dgGoronTunicIconTex, 32, 61),      ITEM_TUNIC_GORON,      EQP_IT_POS(1, 2)},
+    {CREATE_SPRITE(dgZoraTunicIconTex, 32, 62),       ITEM_TUNIC_ZORA,       EQP_IT_POS(2, 2)},
+    
+    {CREATE_SPRITE(dgKokiriBootsIconTex, 32, 63),     ITEM_BOOTS_KOKIRI,     EQP_IT_POS(0, 3)},
+    {CREATE_SPRITE(dgIronBootsIconTex, 32, 64),       ITEM_BOOTS_IRON,       EQP_IT_POS(1, 3)},
+    {CREATE_SPRITE(dgHoverBootsIconTex, 32, 65),      ITEM_BOOTS_HOVER,      EQP_IT_POS(2, 3)},
+
+    {CREATE_SPRITE(dgKokiriEmeraldIconTex, 24, 87),   ITEM_KOKIRI_EMERALD,   {0x19, 0x31}},
+    {CREATE_SPRITE(dgGoronRubyIconTex, 24, 88),       ITEM_GORON_RUBY,       {0x29, 0x31}},
+    {CREATE_SPRITE(dgZoraSapphireIconTex, 24, 89),    ITEM_ZORA_SAPPHIRE,    {0x39, 0x31}},
+    
+    {CREATE_SPRITE(dgForestMedallionIconTex, 24, 81), ITEM_MEDALLION_FOREST, {0x37, 0x0A}},
+    {CREATE_SPRITE(dgFireMedallionIconTex, 24, 82),   ITEM_MEDALLION_FIRE,   {0x37, 0x1A}},
+    {CREATE_SPRITE(dgWaterMedallionIconTex, 24, 83),  ITEM_MEDALLION_WATER,  {0x29, 0x22}},
+    {CREATE_SPRITE(dgSpiritMedallionIconTex, 24, 84), ITEM_MEDALLION_SPIRIT, {0x1B, 0x1A}},
+    {CREATE_SPRITE(dgShadowMedallionIconTex, 24, 85), ITEM_MEDALLION_SHADOW, {0x1B, 0x0A}},
+    {CREATE_SPRITE(dgLightMedallionIconTex, 24, 86),  ITEM_MEDALLION_LIGHT,  {0x29, 0x02}},
+
+    {CREATE_SPRITE(dgGoronsBraceletIconTex, 32, 71),  ITEM_BRACELET,         UPG_IT_POS(0)},
+    {CREATE_SPRITE(dgSilverScaleIconTex, 32, 74),     ITEM_SCALE_SILVER,     UPG_IT_POS(1)},
+    {CREATE_SPRITE(dgSmallKeyIconTex, 24, 97),        ITEM_MAGIC_SMALL,      UPG_IT_POS(2)},
+    {CREATE_SPRITE(dgGerudosCardIconTex, 24, 91),     ITEM_GERUDO_CARD,      UPG_IT_POS(3)},
+    {CREATE_SPRITE(dgStoneOfAgonyIconTex, 24, 90),    ITEM_STONE_OF_AGONY,   {0x6F, 0x51}},
+    
+    {CREATE_SPRITE(dgSongNoteTex, 32, 100),           ITEM_SONG_MINUET,      SNG_IT_POS(0, 0)},
+    {CREATE_SPRITE(dgSongNoteTex, 32, 100),           ITEM_SONG_BOLERO,      SNG_IT_POS(1, 0)},
+    {CREATE_SPRITE(dgSongNoteTex, 32, 100),           ITEM_SONG_SERENADE,    SNG_IT_POS(2, 0)},
+    {CREATE_SPRITE(dgSongNoteTex, 32, 100),           ITEM_SONG_REQUIEM,     SNG_IT_POS(3, 0)},
+    {CREATE_SPRITE(dgSongNoteTex, 32, 100),           ITEM_SONG_NOCTURNE,    SNG_IT_POS(4, 0)},
+    {CREATE_SPRITE(dgSongNoteTex, 32, 100),           ITEM_SONG_PRELUDE,     SNG_IT_POS(5, 0)},
+    {CREATE_SPRITE(dgSongNoteTex, 32, 100),           ITEM_SONG_LULLABY,     SNG_IT_POS(0, 1)},
+    {CREATE_SPRITE(dgSongNoteTex, 32, 100),           ITEM_SONG_EPONA,       SNG_IT_POS(1, 1)},
+    {CREATE_SPRITE(dgSongNoteTex, 32, 100),           ITEM_SONG_SARIA,       SNG_IT_POS(2, 1)},
+    {CREATE_SPRITE(dgSongNoteTex, 32, 100),           ITEM_SONG_SUN,         SNG_IT_POS(3, 1)},
+    {CREATE_SPRITE(dgSongNoteTex, 32, 100),           ITEM_SONG_TIME,        SNG_IT_POS(4, 1)},
+    {CREATE_SPRITE(dgSongNoteTex, 32, 100),           ITEM_SONG_STORMS,      SNG_IT_POS(5, 1)},
+};
+
+static u8 color_product(u8 c1, u8 c2) {
+    u16 prod = (u16)c1 * (u16)c2;
+    u16 div255 = (prod + 1 + (prod >> 8)) >> 8;
+    return (u8)div255;
+}
+
+static const Color_RGBA8 WHITE = {0xFF, 0xFF, 0xFF, 0xFF};
+static const Color_RGBA8 DIM   = {0x40, 0x40, 0x40, 0x90};
+
+struct Color_RGBA8 {
+    u8 r;
+    u8 g;
+    u8 b;
+    u8 a;
+};
+
+void SpriteLoad(FileChooseContext* this, Sprite* sprite);
+void SpriteDraw(FileChooseContext* this, Sprite* sprite, int left, int top, int width, int height);
+
+u8 HasItem(s16 fileIndex, u8 item) {
+    for (int i = 0; i < ARRAY_COUNT(Save_GetSaveMetaInfo(fileIndex)->inventoryItems); i += 1) {
+        u8 it = Save_GetSaveMetaInfo(fileIndex)->inventoryItems[i];
+        if (
+            it == item ||
+            (item == ITEM_BOTTLE && it >= ITEM_BOTTLE && it <= ITEM_POE) ||
+            (item == ITEM_OCARINA_FAIRY && it == ITEM_OCARINA_TIME) || //temporary
+            (item == ITEM_HOOKSHOT && it == ITEM_LONGSHOT) || //temporary
+            (item == ITEM_MASK_BUNNY && it >= ITEM_WEIRD_EGG && it <= ITEM_SOLD_OUT) || //temporary
+            (item == ITEM_CLAIM_CHECK && it >= ITEM_POCKET_EGG && it <= ITEM_CLAIM_CHECK) //temporary
+        ) {
+            return 1;
+        }
+    }
+
+    if (item >= ITEM_SONG_MINUET && item <= ITEM_SONG_STORMS) {
+        return Save_GetSaveMetaInfo(fileIndex)->questItems & (1 << (item - 0x54));
+    }
+
+    if (item >= ITEM_MEDALLION_FOREST && item <= ITEM_MEDALLION_LIGHT) {
+        return Save_GetSaveMetaInfo(fileIndex)->questItems & (1 << (item - 0x66));
+    }
+
+    if (item >= ITEM_KOKIRI_EMERALD && item <= ITEM_GERUDO_CARD) {
+        return Save_GetSaveMetaInfo(fileIndex)->questItems & (1 << (item - 0x5A));
+    }
+
+    if (item >= ITEM_SWORD_KOKIRI && item <= ITEM_SWORD_BGS) {
+        return Save_GetSaveMetaInfo(fileIndex)->equipment & (1 << (item - 0x3B));
+    }
+
+    if (item >= ITEM_SHIELD_DEKU && item <= ITEM_SHIELD_MIRROR) {
+        return Save_GetSaveMetaInfo(fileIndex)->equipment & (1 << (item - 0x3E + 4));
+    }
+
+    if (item >= ITEM_TUNIC_KOKIRI && item <= ITEM_TUNIC_ZORA) {
+        return Save_GetSaveMetaInfo(fileIndex)->equipment & (1 << (item - 0x41 + 8));
+    }
+
+    if (item >= ITEM_BOOTS_KOKIRI && item <= ITEM_BOOTS_HOVER) {
+        return Save_GetSaveMetaInfo(fileIndex)->equipment & (1 << (item - 0x44 + 12));
+    }
+
+    return 0;
+}
+
+static void Draw_Items(FileChooseContext* this, s16 fileIndex, u8 alpha) {
+    OPEN_DISPS(this->state.gfxCtx);
+
+    for (int i = 0; i < ARRAY_COUNT(itemData); i += 1) {
+        ItemData data = itemData[i];
+
+        if (HasItem(fileIndex, data.item) != 0) {
+            gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, WHITE.r, WHITE.g, WHITE.b, color_product(WHITE.a, alpha));
+        } else {
+            gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, DIM.r, DIM.g, DIM.b, color_product(DIM.a, alpha));
+        }
+
+        SpriteLoad(this, &data.sprite);
+        SpriteDraw(this, &data.sprite, LEFT_OFFSET + data.pos.left, TOP_OFFSET + data.pos.top, ICON_SIZE, ICON_SIZE);
+    }
+
+    CLOSE_DISPS(this->state.gfxCtx);
+}
 
 #define MIN_QUEST (ResourceMgr_GameHasOriginal() ? FS_QUEST_NORMAL : FS_QUEST_MASTER)
 #define MAX_QUEST FS_QUEST_BOSSRUSH
@@ -1342,9 +1523,11 @@ void FileChoose_DrawFileInfo(GameState* thisx, s16 fileIndex, s16 isActive) {
                                &deathCountSplit[2]);
 
         // draw death count
-        for (i = 0, vtxOffset = 0; i < 3; i++, vtxOffset += 4) {
-            FileChoose_DrawCharacter(this->state.gfxCtx, sp54->fontBuf + deathCountSplit[i] * FONT_CHAR_TEX_SIZE,
-                                     vtxOffset);
+        if (CVarGetInteger("gFileSelectMoreInfo", 0) == 0) {
+            for (i = 0, vtxOffset = 0; i < 3; i++, vtxOffset += 4) {
+                FileChoose_DrawCharacter(this->state.gfxCtx, sp54->fontBuf + deathCountSplit[i] * FONT_CHAR_TEX_SIZE,
+                                         vtxOffset);
+            }
         }
 
         gDPPipeSync(POLY_OPA_DISP++);
@@ -1364,40 +1547,46 @@ void FileChoose_DrawFileInfo(GameState* thisx, s16 fileIndex, s16 isActive) {
 
         i = Save_GetSaveMetaInfo(fileIndex)->healthCapacity / 0x10;
 
-        // draw hearts
-        for (vtxOffset = 0, j = 0; j < i; j++, vtxOffset += 4) {
-            gSPVertex(POLY_OPA_DISP++, &this->windowContentVtx[D_8081284C[fileIndex] + vtxOffset] + 0x30, 4, 0);
+        if (CVarGetInteger("gFileSelectMoreInfo", 0) == 0) {
+            // draw hearts
+            for (vtxOffset = 0, j = 0; j < i; j++, vtxOffset += 4) {
+                gSPVertex(POLY_OPA_DISP++, &this->windowContentVtx[D_8081284C[fileIndex] + vtxOffset] + 0x30, 4, 0);
 
-            POLY_OPA_DISP = FileChoose_QuadTextureIA8(POLY_OPA_DISP, sHeartTextures[heartType], 0x10, 0x10, 0);
+                POLY_OPA_DISP = FileChoose_QuadTextureIA8(POLY_OPA_DISP, sHeartTextures[heartType], 0x10, 0x10, 0);
+            }
         }
 
         gDPPipeSync(POLY_OPA_DISP++);
-
-        // draw quest items
-        for (vtxOffset = 0, j = 0; j < 9; j++, vtxOffset += 4) {
-            if (Save_GetSaveMetaInfo(fileIndex)->questItems & gBitFlags[sQuestItemFlags[j]]) {
-                gSPVertex(POLY_OPA_DISP++, &this->windowContentVtx[D_8081284C[fileIndex] + vtxOffset] + 0x80, 4, 0);
-                gDPPipeSync(POLY_OPA_DISP++);
-                gDPSetPrimColor(POLY_OPA_DISP++, 0x00, 0x00, sQuestItemRed[j], sQuestItemGreen[j], sQuestItemBlue[j],
-                                this->fileInfoAlpha[fileIndex]);
-                gDPSetEnvColor(POLY_OPA_DISP++, 0, 0, 0, 0);
-
-                if (j < 3) {
-                    gDPLoadTextureBlock(POLY_OPA_DISP++, sQuestItemTextures[j], G_IM_FMT_RGBA, G_IM_SIZ_32b, 16, 16, 0,
-                                        G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOMIRROR | G_TX_WRAP,
-                                        G_TX_NOMASK, G_TX_NOLOD);
-                    gSP1Quadrangle(POLY_OPA_DISP++, 0, 2, 3, 1, 0);
-
-                } else {
-                    POLY_OPA_DISP = FileChoose_QuadTextureIA8(POLY_OPA_DISP, sQuestItemTextures[j], 0x10, 0x10, 0);
-                }
-            }
-        }
 
         // Use file info alpha to match fading
         u8 textAlpha = this->fileInfoAlpha[fileIndex];
         if (textAlpha >= 200) {
             textAlpha = 255;
+        }
+
+        if (CVarGetInteger("gFileSelectMoreInfo", 0) != 0) {
+            Draw_Items(this, fileIndex, textAlpha);
+        } else {
+            // draw quest items
+            for (vtxOffset = 0, j = 0; j < 9; j++, vtxOffset += 4) {
+                if (Save_GetSaveMetaInfo(fileIndex)->questItems & gBitFlags[sQuestItemFlags[j]]) {
+                    gSPVertex(POLY_OPA_DISP++, &this->windowContentVtx[D_8081284C[fileIndex] + vtxOffset] + 0x80, 4, 0);
+                    gDPPipeSync(POLY_OPA_DISP++);
+                    gDPSetPrimColor(POLY_OPA_DISP++, 0x00, 0x00, sQuestItemRed[j], sQuestItemGreen[j], sQuestItemBlue[j],
+                                    this->fileInfoAlpha[fileIndex]);
+                    gDPSetEnvColor(POLY_OPA_DISP++, 0, 0, 0, 0);
+
+                    if (j < 3) {
+                        gDPLoadTextureBlock(POLY_OPA_DISP++, sQuestItemTextures[j], G_IM_FMT_RGBA, G_IM_SIZ_32b, 16, 16, 0,
+                                            G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOMIRROR | G_TX_WRAP,
+                                            G_TX_NOMASK, G_TX_NOLOD);
+                        gSP1Quadrangle(POLY_OPA_DISP++, 0, 2, 3, 1, 0);
+
+                    } else {
+                        POLY_OPA_DISP = FileChoose_QuadTextureIA8(POLY_OPA_DISP, sQuestItemTextures[j], 0x10, 0x10, 0);
+                    }
+                }
+            }
         }
 
         // Draw rando seed warning when build version doesn't match for Major or Minor number

--- a/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -27,94 +27,103 @@ typedef struct {
 } ItemPosition;
 
 typedef struct {
+    s16 width;
+    s16 height;
+} ItemSize;
+
+typedef struct {
     Sprite sprite;
     u8 item;
     ItemPosition pos;
+    ItemSize size;
 } ItemData;
-
-#define ICON_SIZE 16
-#define SONG_WIDTH 16
-#define SONG_HEIGHT 24
 
 #define CREATE_SPRITE_32(iconTex, spriteId) { iconTex, 32, 32, G_IM_FMT_RGBA, G_IM_SIZ_32b, spriteId }
 #define CREATE_SPRITE_24(iconTex, spriteId) { iconTex, 24, 24, G_IM_FMT_RGBA, G_IM_SIZ_32b, spriteId }
-#define CREATE_SPRITE_SONG { dgSongNoteTex, SONG_WIDTH, SONG_HEIGHT, G_IM_FMT_RGBA, G_IM_SIZ_32b, 100 }
+#define CREATE_SPRITE_SONG { dgSongNoteTex, 16, 24, G_IM_FMT_RGBA, G_IM_SIZ_32b/*G_IM_FMT_IA, G_IM_SIZ_8b*/, 100 }
+
+#define ICON_SIZE 12
+#define SONG_WIDTH 8
+#define SONG_HEIGHT 12
+
+#define SIZE_NORMAL {ICON_SIZE, ICON_SIZE}
+#define SIZE_SONG {SONG_WIDTH, SONG_HEIGHT}
 
 #define INV_IT_POS(x, y) {0x4E + ICON_SIZE * x, 0x00 + ICON_SIZE * y}
 #define EQP_IT_POS(x, y) {0x7E + ICON_SIZE * x, 0x2A + ICON_SIZE * y}
-#define SNG_IT_POS(x, y) {0x4E + SONG_WIDTH / 2 * x, 0x45 + SONG_HEIGHT / 2 * y}
-#define UPG_IT_POS(i) {0x3E + ICON_SIZE * i, 0x2A}
+#define SNG_IT_POS(x, y) {0x49 + SONG_WIDTH * x, 0x45 + SONG_HEIGHT * y}
+#define UPG_IT_POS(x, y) {0x5A + ICON_SIZE * x, 0x2A + ICON_SIZE * y}
 
 static ItemData itemData[59] = {
-    {CREATE_SPRITE_32(dgDekuStickIconTex, 1),        ITEM_STICK,            INV_IT_POS(0, 0)},
-    {CREATE_SPRITE_32(dgDekuNutIconTex, 0),          ITEM_NUT,              INV_IT_POS(1, 0)},
-    {CREATE_SPRITE_32(dgBombIconTex, 2),             ITEM_BOMB,             INV_IT_POS(2, 0)},
-    {CREATE_SPRITE_32(dgFairyBowIconTex, 3),         ITEM_BOW,              INV_IT_POS(3, 0)},
-    {CREATE_SPRITE_32(dgFireArrowIconTex, 4),        ITEM_ARROW_FIRE,       INV_IT_POS(4, 0)},
-    {CREATE_SPRITE_32(dgDinsFireIconTex, 5),         ITEM_DINS_FIRE,        INV_IT_POS(5, 0)},
-    {CREATE_SPRITE_32(dgEmptyBottleIconTex, 20),     ITEM_BOTTLE,           INV_IT_POS(6, 0)},
+    {CREATE_SPRITE_32(dgDekuStickIconTex, 1),        ITEM_STICK,            INV_IT_POS(0, 0), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgDekuNutIconTex, 0),          ITEM_NUT,              INV_IT_POS(1, 0), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgBombIconTex, 2),             ITEM_BOMB,             INV_IT_POS(2, 0), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgFairyBowIconTex, 3),         ITEM_BOW,              INV_IT_POS(3, 0), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgFireArrowIconTex, 4),        ITEM_ARROW_FIRE,       INV_IT_POS(4, 0), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgDinsFireIconTex, 5),         ITEM_DINS_FIRE,        INV_IT_POS(5, 0), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgEmptyBottleIconTex, 20),     ITEM_BOTTLE,           INV_IT_POS(6, 0), SIZE_NORMAL},
 
-    {CREATE_SPRITE_32(dgFairySlingshotIconTex, 6),   ITEM_SLINGSHOT,        INV_IT_POS(0, 1)},
-    {CREATE_SPRITE_32(dgFairyOcarinaIconTex, 7),     ITEM_OCARINA_FAIRY,    INV_IT_POS(1, 1)},
-    {CREATE_SPRITE_32(dgBombchuIconTex, 9),          ITEM_BOMBCHU,          INV_IT_POS(2, 1)},
-    {CREATE_SPRITE_32(dgHookshotIconTex, 10),        ITEM_HOOKSHOT,         INV_IT_POS(3, 1)},
-    {CREATE_SPRITE_32(dgIceArrowIconTex, 12),        ITEM_ARROW_ICE,        INV_IT_POS(4, 1)},
-    {CREATE_SPRITE_32(dgFaroresWindIconTex, 13),     ITEM_FARORES_WIND,     INV_IT_POS(5, 1)},
-    {CREATE_SPRITE_32(dgBunnyHoodIconTex, 37),       ITEM_MASK_BUNNY,       INV_IT_POS(6, 1)},
+    {CREATE_SPRITE_32(dgFairySlingshotIconTex, 6),   ITEM_SLINGSHOT,        INV_IT_POS(0, 1), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgFairyOcarinaIconTex, 7),     ITEM_OCARINA_FAIRY,    INV_IT_POS(1, 1), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgBombchuIconTex, 9),          ITEM_BOMBCHU,          INV_IT_POS(2, 1), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgHookshotIconTex, 10),        ITEM_HOOKSHOT,         INV_IT_POS(3, 1), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgIceArrowIconTex, 12),        ITEM_ARROW_ICE,        INV_IT_POS(4, 1), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgFaroresWindIconTex, 13),     ITEM_FARORES_WIND,     INV_IT_POS(5, 1), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgBunnyHoodIconTex, 37),       ITEM_MASK_BUNNY,       INV_IT_POS(6, 1), SIZE_NORMAL},
 
-    {CREATE_SPRITE_32(dgBoomerangIconTex, 14),       ITEM_BOOMERANG,        INV_IT_POS(0, 2)},
-    {CREATE_SPRITE_32(dgLensofTruthIconTex, 15),     ITEM_LENS,             INV_IT_POS(1, 2)},
-    {CREATE_SPRITE_32(dgMagicBeansIconTex, 16),      ITEM_BEAN,             INV_IT_POS(2, 2)},
-    {CREATE_SPRITE_32(dgMegatonHammerIconTex, 17),   ITEM_HAMMER,           INV_IT_POS(3, 2)},
-    {CREATE_SPRITE_32(dgLightArrowIconTex, 18),      ITEM_ARROW_LIGHT,      INV_IT_POS(4, 2)},
-    {CREATE_SPRITE_32(dgNayrusLoveIconTex, 19),      ITEM_NAYRUS_LOVE,      INV_IT_POS(5, 2)},
-    {CREATE_SPRITE_32(dgClaimCheckIconTex, 53),      ITEM_CLAIM_CHECK,      INV_IT_POS(6, 2)},
+    {CREATE_SPRITE_32(dgBoomerangIconTex, 14),       ITEM_BOOMERANG,        INV_IT_POS(0, 2), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgLensofTruthIconTex, 15),     ITEM_LENS,             INV_IT_POS(1, 2), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgMagicBeansIconTex, 16),      ITEM_BEAN,             INV_IT_POS(2, 2), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgMegatonHammerIconTex, 17),   ITEM_HAMMER,           INV_IT_POS(3, 2), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgLightArrowIconTex, 18),      ITEM_ARROW_LIGHT,      INV_IT_POS(4, 2), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgNayrusLoveIconTex, 19),      ITEM_NAYRUS_LOVE,      INV_IT_POS(5, 2), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgClaimCheckIconTex, 53),      ITEM_CLAIM_CHECK,      INV_IT_POS(6, 2), SIZE_NORMAL},
     
-    {CREATE_SPRITE_32(dgKokiriSwordIconTex, 54),     ITEM_SWORD_KOKIRI,     EQP_IT_POS(0, 0)},
-    {CREATE_SPRITE_32(dgMasterSwordIconTex, 55),     ITEM_SWORD_MASTER,     EQP_IT_POS(1, 0)},
-    {CREATE_SPRITE_32(dgBiggoronSwordIconTex, 56),   ITEM_SWORD_BGS,        EQP_IT_POS(2, 0)},
+    {CREATE_SPRITE_32(dgKokiriSwordIconTex, 54),     ITEM_SWORD_KOKIRI,     EQP_IT_POS(0, 0), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgMasterSwordIconTex, 55),     ITEM_SWORD_MASTER,     EQP_IT_POS(1, 0), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgBiggoronSwordIconTex, 56),   ITEM_SWORD_BGS,        EQP_IT_POS(2, 0), SIZE_NORMAL},
     
-    {CREATE_SPRITE_32(dgDekuShieldIconTex, 57),      ITEM_SHIELD_DEKU,      EQP_IT_POS(0, 1)},
-    {CREATE_SPRITE_32(dgHylianShieldIconTex, 58),    ITEM_SHIELD_HYLIAN,    EQP_IT_POS(1, 1)},
-    {CREATE_SPRITE_32(dgMirrorShieldIconTex, 59),    ITEM_SHIELD_MIRROR,    EQP_IT_POS(2, 1)},
+    {CREATE_SPRITE_32(dgDekuShieldIconTex, 57),      ITEM_SHIELD_DEKU,      EQP_IT_POS(0, 1), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgHylianShieldIconTex, 58),    ITEM_SHIELD_HYLIAN,    EQP_IT_POS(1, 1), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgMirrorShieldIconTex, 59),    ITEM_SHIELD_MIRROR,    EQP_IT_POS(2, 1), SIZE_NORMAL},
     
-    {CREATE_SPRITE_32(dgKokiriTunicIconTex, 60),     ITEM_TUNIC_KOKIRI,     EQP_IT_POS(0, 2)},
-    {CREATE_SPRITE_32(dgGoronTunicIconTex, 61),      ITEM_TUNIC_GORON,      EQP_IT_POS(1, 2)},
-    {CREATE_SPRITE_32(dgZoraTunicIconTex, 62),       ITEM_TUNIC_ZORA,       EQP_IT_POS(2, 2)},
+    {CREATE_SPRITE_32(dgKokiriTunicIconTex, 60),     ITEM_TUNIC_KOKIRI,     EQP_IT_POS(0, 2), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgGoronTunicIconTex, 61),      ITEM_TUNIC_GORON,      EQP_IT_POS(1, 2), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgZoraTunicIconTex, 62),       ITEM_TUNIC_ZORA,       EQP_IT_POS(2, 2), SIZE_NORMAL},
     
-    {CREATE_SPRITE_32(dgKokiriBootsIconTex, 63),     ITEM_BOOTS_KOKIRI,     EQP_IT_POS(0, 3)},
-    {CREATE_SPRITE_32(dgIronBootsIconTex, 64),       ITEM_BOOTS_IRON,       EQP_IT_POS(1, 3)},
-    {CREATE_SPRITE_32(dgHoverBootsIconTex, 65),      ITEM_BOOTS_HOVER,      EQP_IT_POS(2, 3)},
+    {CREATE_SPRITE_32(dgKokiriBootsIconTex, 63),     ITEM_BOOTS_KOKIRI,     EQP_IT_POS(0, 3), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgIronBootsIconTex, 64),       ITEM_BOOTS_IRON,       EQP_IT_POS(1, 3), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgHoverBootsIconTex, 65),      ITEM_BOOTS_HOVER,      EQP_IT_POS(2, 3), SIZE_NORMAL},
 
-    {CREATE_SPRITE_24(dgKokiriEmeraldIconTex, 87),   ITEM_KOKIRI_EMERALD,   {0x19, 0x31}},
-    {CREATE_SPRITE_24(dgGoronRubyIconTex, 88),       ITEM_GORON_RUBY,       {0x29, 0x31}},
-    {CREATE_SPRITE_24(dgZoraSapphireIconTex, 89),    ITEM_ZORA_SAPPHIRE,    {0x39, 0x31}},
+    {CREATE_SPRITE_24(dgKokiriEmeraldIconTex, 87),   ITEM_KOKIRI_EMERALD,   {0x19, 0x31},     SIZE_NORMAL},
+    {CREATE_SPRITE_24(dgGoronRubyIconTex, 88),       ITEM_GORON_RUBY,       {0x29, 0x31},     SIZE_NORMAL},
+    {CREATE_SPRITE_24(dgZoraSapphireIconTex, 89),    ITEM_ZORA_SAPPHIRE,    {0x39, 0x31},     SIZE_NORMAL},
     
-    {CREATE_SPRITE_24(dgForestMedallionIconTex, 81), ITEM_MEDALLION_FOREST, {0x37, 0x0A}},
-    {CREATE_SPRITE_24(dgFireMedallionIconTex, 82),   ITEM_MEDALLION_FIRE,   {0x37, 0x1A}},
-    {CREATE_SPRITE_24(dgWaterMedallionIconTex, 83),  ITEM_MEDALLION_WATER,  {0x29, 0x22}},
-    {CREATE_SPRITE_24(dgSpiritMedallionIconTex, 84), ITEM_MEDALLION_SPIRIT, {0x1B, 0x1A}},
-    {CREATE_SPRITE_24(dgShadowMedallionIconTex, 85), ITEM_MEDALLION_SHADOW, {0x1B, 0x0A}},
-    {CREATE_SPRITE_24(dgLightMedallionIconTex, 86),  ITEM_MEDALLION_LIGHT,  {0x29, 0x02}},
+    {CREATE_SPRITE_24(dgForestMedallionIconTex, 81), ITEM_MEDALLION_FOREST, {0x37, 0x0A},     SIZE_NORMAL},
+    {CREATE_SPRITE_24(dgFireMedallionIconTex, 82),   ITEM_MEDALLION_FIRE,   {0x37, 0x1A},     SIZE_NORMAL},
+    {CREATE_SPRITE_24(dgWaterMedallionIconTex, 83),  ITEM_MEDALLION_WATER,  {0x29, 0x22},     SIZE_NORMAL},
+    {CREATE_SPRITE_24(dgSpiritMedallionIconTex, 84), ITEM_MEDALLION_SPIRIT, {0x1B, 0x1A},     SIZE_NORMAL},
+    {CREATE_SPRITE_24(dgShadowMedallionIconTex, 85), ITEM_MEDALLION_SHADOW, {0x1B, 0x0A},     SIZE_NORMAL},
+    {CREATE_SPRITE_24(dgLightMedallionIconTex, 86),  ITEM_MEDALLION_LIGHT,  {0x29, 0x02},     SIZE_NORMAL},
 
-    {CREATE_SPRITE_32(dgGoronsBraceletIconTex, 71),  ITEM_BRACELET,         UPG_IT_POS(0)},
-    {CREATE_SPRITE_32(dgSilverScaleIconTex, 74),     ITEM_SCALE_SILVER,     UPG_IT_POS(1)},
-    {CREATE_SPRITE_24(dgSmallKeyIconTex, 97),        ITEM_MAGIC_SMALL,      UPG_IT_POS(2)},
-    {CREATE_SPRITE_24(dgGerudosCardIconTex, 91),     ITEM_GERUDO_CARD,      UPG_IT_POS(3)},
-    {CREATE_SPRITE_24(dgStoneOfAgonyIconTex, 90),    ITEM_STONE_OF_AGONY,   {0x6F, 0x51}},
+    {CREATE_SPRITE_32(dgGoronsBraceletIconTex, 71),  ITEM_BRACELET,         UPG_IT_POS(0, 0), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgSilverScaleIconTex, 74),     ITEM_SCALE_SILVER,     UPG_IT_POS(1, 0), SIZE_NORMAL},
+    {CREATE_SPRITE_24(dgSmallMagicJarIconTex, 97),   ITEM_MAGIC_SMALL,      UPG_IT_POS(2, 0), SIZE_NORMAL},
+    {CREATE_SPRITE_24(dgGerudosCardIconTex, 91),     ITEM_GERUDO_CARD,      UPG_IT_POS(1, 1), SIZE_NORMAL},
+    {CREATE_SPRITE_24(dgStoneOfAgonyIconTex, 90),    ITEM_STONE_OF_AGONY,   UPG_IT_POS(2, 1), SIZE_NORMAL},
     
-    {CREATE_SPRITE_SONG,                             ITEM_SONG_LULLABY,     SNG_IT_POS(0, 0)},
-    {CREATE_SPRITE_SONG,                             ITEM_SONG_EPONA,       SNG_IT_POS(1, 0)},
-    {CREATE_SPRITE_SONG,                             ITEM_SONG_SARIA,       SNG_IT_POS(2, 0)},
-    {CREATE_SPRITE_SONG,                             ITEM_SONG_SUN,         SNG_IT_POS(3, 0)},
-    {CREATE_SPRITE_SONG,                             ITEM_SONG_TIME,        SNG_IT_POS(4, 0)},
-    {CREATE_SPRITE_SONG,                             ITEM_SONG_STORMS,      SNG_IT_POS(5, 0)},
-    {CREATE_SPRITE_SONG,                             ITEM_SONG_MINUET,      SNG_IT_POS(0, 1)},
-    {CREATE_SPRITE_SONG,                             ITEM_SONG_BOLERO,      SNG_IT_POS(1, 1)},
-    {CREATE_SPRITE_SONG,                             ITEM_SONG_SERENADE,    SNG_IT_POS(2, 1)},
-    {CREATE_SPRITE_SONG,                             ITEM_SONG_REQUIEM,     SNG_IT_POS(3, 1)},
-    {CREATE_SPRITE_SONG,                             ITEM_SONG_NOCTURNE,    SNG_IT_POS(4, 1)},
-    {CREATE_SPRITE_SONG,                             ITEM_SONG_PRELUDE,     SNG_IT_POS(5, 1)},
+    {CREATE_SPRITE_SONG,                             ITEM_SONG_LULLABY,     SNG_IT_POS(0, 0), SIZE_SONG},
+    {CREATE_SPRITE_SONG,                             ITEM_SONG_EPONA,       SNG_IT_POS(1, 0), SIZE_SONG},
+    {CREATE_SPRITE_SONG,                             ITEM_SONG_SARIA,       SNG_IT_POS(2, 0), SIZE_SONG},
+    {CREATE_SPRITE_SONG,                             ITEM_SONG_SUN,         SNG_IT_POS(3, 0), SIZE_SONG},
+    {CREATE_SPRITE_SONG,                             ITEM_SONG_TIME,        SNG_IT_POS(4, 0), SIZE_SONG},
+    {CREATE_SPRITE_SONG,                             ITEM_SONG_STORMS,      SNG_IT_POS(5, 0), SIZE_SONG},
+    {CREATE_SPRITE_SONG,                             ITEM_SONG_MINUET,      SNG_IT_POS(0, 1), SIZE_SONG},
+    {CREATE_SPRITE_SONG,                             ITEM_SONG_BOLERO,      SNG_IT_POS(1, 1), SIZE_SONG},
+    {CREATE_SPRITE_SONG,                             ITEM_SONG_SERENADE,    SNG_IT_POS(2, 1), SIZE_SONG},
+    {CREATE_SPRITE_SONG,                             ITEM_SONG_REQUIEM,     SNG_IT_POS(3, 1), SIZE_SONG},
+    {CREATE_SPRITE_SONG,                             ITEM_SONG_NOCTURNE,    SNG_IT_POS(4, 1), SIZE_SONG},
+    {CREATE_SPRITE_SONG,                             ITEM_SONG_PRELUDE,     SNG_IT_POS(5, 1), SIZE_SONG},
 };
 
 static u8 color_product(u8 c1, u8 c2) {
@@ -197,7 +206,7 @@ static void Draw_Items(FileChooseContext* this, s16 fileIndex, u8 alpha) {
         }
 
         SpriteLoad(this, &(data->sprite));
-        SpriteDraw(this, &(data->sprite), LEFT_OFFSET + data->pos.left, TOP_OFFSET + data->pos.top, data->sprite.width / 2, data->sprite.height / 2);
+        SpriteDraw(this, &(data->sprite), LEFT_OFFSET + data->pos.left, TOP_OFFSET + data->pos.top, data->size.width, data->size.height);
     }
 
     gDPPipeSync(POLY_OPA_DISP++);

--- a/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -573,15 +573,15 @@ void DrawCounterValue(FileChooseContext* this, s16 fileIndex, u8 alpha, CounterD
     }
 
     OPEN_DISPS(this->state.gfxCtx);
-    gDPPipeSync(POLY_KAL_DISP++);
+    gDPPipeSync(POLY_OPA_DISP++);
     gDPSetCombineMode(POLY_OPA_DISP++, G_CC_MODULATEIA_PRIM, G_CC_MODULATEIA_PRIM);
 
     if (currentValue == 0) {
-        gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 130, 130, 130, alpha);
+        gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 130, 130, 130, alpha);
     } else if (currentValue == maxValue) {
-        gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 120, 255, 0, alpha);
+        gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 120, 255, 0, alpha);
     } else {
-        gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 255, 255, 255, alpha);
+        gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 255, 255, 255, alpha);
     }
 
     for (hundreds = 0; currentValue >= 100; hundreds++) {
@@ -612,7 +612,7 @@ void DrawCounterValue(FileChooseContext* this, s16 fileIndex, u8 alpha, CounterD
         SpriteDraw(this, &counterDigitSprites[currentValue], LEFT_OFFSET + COUNTER_DIGITS_LEFT_OFFSET + data->pos.left, TOP_OFFSET + COUNTER_DIGITS_TOP_OFFSET + data->pos.top, 8, 8);
     }
 
-    gDPPipeSync(POLY_KAL_DISP++);
+    gDPPipeSync(POLY_OPA_DISP++);
     CLOSE_DISPS(this->state.gfxCtx);
 }
 

--- a/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -540,9 +540,8 @@ u16 GetMaxCounterValue(s16 fileIndex, u8 counter) {
         return 100;
     }
 
-    //this is fine because if the value is 0 the number will be grey
     if (counter == ITEM_INVALID_8) {
-        return 0;
+        return 999;
     }
 
     return 0;
@@ -556,6 +555,11 @@ void DrawCounterValue(FileChooseContext* this, s16 fileIndex, u8 alpha, CounterD
 
     currentValue = GetCurrentCounterValue(fileIndex, data->item);
     maxValue = GetMaxCounterValue(fileIndex, data->item);
+
+    //to prevent crashes if you use the save editor
+    if (currentValue > 999) {
+        currentValue = 999;
+    }
 
     OPEN_DISPS(this->state.gfxCtx);
     gDPPipeSync(POLY_KAL_DISP++);

--- a/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -53,8 +53,8 @@ typedef struct {
 #define LEFT_OFFSET (int)0x37
 #define TOP_OFFSET  (int)0x5C
 
-#define COUNTER_DIGITS_LEFT_OFFSET COUNTER_SIZE / 2
-#define COUNTER_DIGITS_TOP_OFFSET 13
+#define COUNTER_DIGITS_LEFT_OFFSET COUNTER_SIZE / 2 - 3
+#define COUNTER_DIGITS_TOP_OFFSET COUNTER_SIZE - 3
 
 #define SIZE_NORMAL {ICON_SIZE, ICON_SIZE}
 #define SIZE_COUNTER {COUNTER_SIZE, COUNTER_SIZE}
@@ -554,10 +554,20 @@ void DrawCounterValue(FileChooseContext* this, s16 fileIndex, u8 alpha, CounterD
     s16 hundreds;
     s16 tens;
 
-    OPEN_DISPS(this->state.gfxCtx);
-
     currentValue = GetCurrentCounterValue(fileIndex, data->item);
     maxValue = GetMaxCounterValue(fileIndex, data->item);
+
+    OPEN_DISPS(this->state.gfxCtx);
+    gDPPipeSync(POLY_KAL_DISP++);
+    gDPSetCombineMode(POLY_OPA_DISP++, G_CC_MODULATEIA_PRIM, G_CC_MODULATEIA_PRIM);
+
+    if (currentValue == 0) {
+        gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 130, 130, 130, alpha);
+    } else if (currentValue == maxValue) {
+        gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 120, 255, 0, alpha);
+    } else {
+        gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 255, 255, 255, alpha);
+    }
 
     for (hundreds = 0; currentValue >= 100; hundreds++) {
         currentValue -= 100;
@@ -567,36 +577,27 @@ void DrawCounterValue(FileChooseContext* this, s16 fileIndex, u8 alpha, CounterD
         currentValue -= 10;
     }
 
-    gDPPipeSync(POLY_KAL_DISP++);
-
-    gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 255, 255, 255, alpha);
-
-    if (currentValue == 0) {
-        gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 130, 130, 130, alpha);
-    } else if (currentValue == maxValue) {
-        gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 120, 255, 0, alpha);
-    }
-    
     if (hundreds != 0) {
         SpriteLoad(this, &counterDigitSprites[hundreds]);
-        SpriteDraw(this, &counterDigitSprites[hundreds], LEFT_OFFSET + COUNTER_DIGITS_LEFT_OFFSET - 8 + data->pos.left, TOP_OFFSET + COUNTER_DIGITS_TOP_OFFSET + data->pos.top, 8, 8);
+        SpriteDraw(this, &counterDigitSprites[hundreds], LEFT_OFFSET + COUNTER_DIGITS_LEFT_OFFSET - 6 + data->pos.left, TOP_OFFSET + COUNTER_DIGITS_TOP_OFFSET + data->pos.top, 8, 8);
 
         SpriteLoad(this, &counterDigitSprites[tens]);
         SpriteDraw(this, &counterDigitSprites[tens], LEFT_OFFSET + COUNTER_DIGITS_LEFT_OFFSET + data->pos.left, TOP_OFFSET + COUNTER_DIGITS_TOP_OFFSET + data->pos.top, 8, 8);
 
         SpriteLoad(this, &counterDigitSprites[currentValue]);
-        SpriteDraw(this, &counterDigitSprites[currentValue], LEFT_OFFSET + COUNTER_DIGITS_LEFT_OFFSET + 8 + data->pos.left, TOP_OFFSET + COUNTER_DIGITS_TOP_OFFSET + data->pos.top, 8, 8);
+        SpriteDraw(this, &counterDigitSprites[currentValue], LEFT_OFFSET + COUNTER_DIGITS_LEFT_OFFSET + 6 + data->pos.left, TOP_OFFSET + COUNTER_DIGITS_TOP_OFFSET + data->pos.top, 8, 8);
     } else if (tens != 0) {
         SpriteLoad(this, &counterDigitSprites[tens]);
-        SpriteDraw(this, &counterDigitSprites[tens], LEFT_OFFSET + COUNTER_DIGITS_LEFT_OFFSET - 4 + data->pos.left, TOP_OFFSET + COUNTER_DIGITS_TOP_OFFSET + data->pos.top, 8, 8);
+        SpriteDraw(this, &counterDigitSprites[tens], LEFT_OFFSET + COUNTER_DIGITS_LEFT_OFFSET - 3 + data->pos.left, TOP_OFFSET + COUNTER_DIGITS_TOP_OFFSET + data->pos.top, 8, 8);
 
         SpriteLoad(this, &counterDigitSprites[currentValue]);
-        SpriteDraw(this, &counterDigitSprites[currentValue], LEFT_OFFSET + COUNTER_DIGITS_LEFT_OFFSET + 4 + data->pos.left, TOP_OFFSET + COUNTER_DIGITS_TOP_OFFSET + data->pos.top, 8, 8);
+        SpriteDraw(this, &counterDigitSprites[currentValue], LEFT_OFFSET + COUNTER_DIGITS_LEFT_OFFSET + 3 + data->pos.left, TOP_OFFSET + COUNTER_DIGITS_TOP_OFFSET + data->pos.top, 8, 8);
     } else {
         SpriteLoad(this, &counterDigitSprites[currentValue]);
         SpriteDraw(this, &counterDigitSprites[currentValue], LEFT_OFFSET + COUNTER_DIGITS_LEFT_OFFSET + data->pos.left, TOP_OFFSET + COUNTER_DIGITS_TOP_OFFSET + data->pos.top, 8, 8);
     }
 
+    gDPPipeSync(POLY_KAL_DISP++);
     CLOSE_DISPS(this->state.gfxCtx);
 }
 

--- a/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -50,55 +50,56 @@ typedef struct {
 #define SIZE_NORMAL {ICON_SIZE, ICON_SIZE}
 #define SIZE_SONG {SONG_WIDTH, SONG_HEIGHT}
 
-#define INV_IT_POS(x, y) {0x4E + ICON_SIZE * x, 0x00 + ICON_SIZE * y}
-#define EQP_IT_POS(x, y) {0x7E + ICON_SIZE * x, 0x2A + ICON_SIZE * y}
-#define SNG_IT_POS(x, y) {0x49 + SONG_WIDTH * x, 0x45 + SONG_HEIGHT * y}
-#define UPG_IT_POS(x, y) {0x5A + ICON_SIZE * x, 0x2A + ICON_SIZE * y}
+#define INV_IC_POS(x, y) {0x4E + ICON_SIZE * x, 0x00 + ICON_SIZE * y}
+#define EQP_IC_POS(x, y) {0x7E + ICON_SIZE * x, 0x2A + ICON_SIZE * y}
+#define SNG_IC_POS(x, y) {0x49 + SONG_WIDTH * x, 0x45 + SONG_HEIGHT * y}
+#define UPG_IC_POS(x, y) {0x5A + ICON_SIZE * x, 0x2A + ICON_SIZE * y}
+#define STN_IC_POS(i) {0x29 + ICON_SIZE * i, 0x31}
 
 static ItemData itemData[59] = {
-    {CREATE_SPRITE_32(dgDekuStickIconTex, 1),        ITEM_STICK,            INV_IT_POS(0, 0), SIZE_NORMAL},
-    {CREATE_SPRITE_32(dgDekuNutIconTex, 0),          ITEM_NUT,              INV_IT_POS(1, 0), SIZE_NORMAL},
-    {CREATE_SPRITE_32(dgBombIconTex, 2),             ITEM_BOMB,             INV_IT_POS(2, 0), SIZE_NORMAL},
-    {CREATE_SPRITE_32(dgFairyBowIconTex, 3),         ITEM_BOW,              INV_IT_POS(3, 0), SIZE_NORMAL},
-    {CREATE_SPRITE_32(dgFireArrowIconTex, 4),        ITEM_ARROW_FIRE,       INV_IT_POS(4, 0), SIZE_NORMAL},
-    {CREATE_SPRITE_32(dgDinsFireIconTex, 5),         ITEM_DINS_FIRE,        INV_IT_POS(5, 0), SIZE_NORMAL},
-    {CREATE_SPRITE_32(dgEmptyBottleIconTex, 20),     ITEM_BOTTLE,           INV_IT_POS(6, 0), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgDekuStickIconTex, 1),        ITEM_STICK,            INV_IC_POS(0, 0), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgDekuNutIconTex, 0),          ITEM_NUT,              INV_IC_POS(1, 0), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgBombIconTex, 2),             ITEM_BOMB,             INV_IC_POS(2, 0), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgFairyBowIconTex, 3),         ITEM_BOW,              INV_IC_POS(3, 0), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgFireArrowIconTex, 4),        ITEM_ARROW_FIRE,       INV_IC_POS(4, 0), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgDinsFireIconTex, 5),         ITEM_DINS_FIRE,        INV_IC_POS(5, 0), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgEmptyBottleIconTex, 20),     ITEM_BOTTLE,           INV_IC_POS(6, 0), SIZE_NORMAL},
 
-    {CREATE_SPRITE_32(dgFairySlingshotIconTex, 6),   ITEM_SLINGSHOT,        INV_IT_POS(0, 1), SIZE_NORMAL},
-    {CREATE_SPRITE_32(dgFairyOcarinaIconTex, 7),     ITEM_OCARINA_FAIRY,    INV_IT_POS(1, 1), SIZE_NORMAL},
-    {CREATE_SPRITE_32(dgBombchuIconTex, 9),          ITEM_BOMBCHU,          INV_IT_POS(2, 1), SIZE_NORMAL},
-    {CREATE_SPRITE_32(dgHookshotIconTex, 10),        ITEM_HOOKSHOT,         INV_IT_POS(3, 1), SIZE_NORMAL},
-    {CREATE_SPRITE_32(dgIceArrowIconTex, 12),        ITEM_ARROW_ICE,        INV_IT_POS(4, 1), SIZE_NORMAL},
-    {CREATE_SPRITE_32(dgFaroresWindIconTex, 13),     ITEM_FARORES_WIND,     INV_IT_POS(5, 1), SIZE_NORMAL},
-    {CREATE_SPRITE_32(dgBunnyHoodIconTex, 37),       ITEM_MASK_BUNNY,       INV_IT_POS(6, 1), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgFairySlingshotIconTex, 6),   ITEM_SLINGSHOT,        INV_IC_POS(0, 1), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgFairyOcarinaIconTex, 7),     ITEM_OCARINA_FAIRY,    INV_IC_POS(1, 1), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgBombchuIconTex, 9),          ITEM_BOMBCHU,          INV_IC_POS(2, 1), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgHookshotIconTex, 10),        ITEM_HOOKSHOT,         INV_IC_POS(3, 1), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgIceArrowIconTex, 12),        ITEM_ARROW_ICE,        INV_IC_POS(4, 1), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgFaroresWindIconTex, 13),     ITEM_FARORES_WIND,     INV_IC_POS(5, 1), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgBunnyHoodIconTex, 37),       ITEM_MASK_BUNNY,       INV_IC_POS(6, 1), SIZE_NORMAL},
 
-    {CREATE_SPRITE_32(dgBoomerangIconTex, 14),       ITEM_BOOMERANG,        INV_IT_POS(0, 2), SIZE_NORMAL},
-    {CREATE_SPRITE_32(dgLensofTruthIconTex, 15),     ITEM_LENS,             INV_IT_POS(1, 2), SIZE_NORMAL},
-    {CREATE_SPRITE_32(dgMagicBeansIconTex, 16),      ITEM_BEAN,             INV_IT_POS(2, 2), SIZE_NORMAL},
-    {CREATE_SPRITE_32(dgMegatonHammerIconTex, 17),   ITEM_HAMMER,           INV_IT_POS(3, 2), SIZE_NORMAL},
-    {CREATE_SPRITE_32(dgLightArrowIconTex, 18),      ITEM_ARROW_LIGHT,      INV_IT_POS(4, 2), SIZE_NORMAL},
-    {CREATE_SPRITE_32(dgNayrusLoveIconTex, 19),      ITEM_NAYRUS_LOVE,      INV_IT_POS(5, 2), SIZE_NORMAL},
-    {CREATE_SPRITE_32(dgClaimCheckIconTex, 53),      ITEM_CLAIM_CHECK,      INV_IT_POS(6, 2), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgBoomerangIconTex, 14),       ITEM_BOOMERANG,        INV_IC_POS(0, 2), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgLensofTruthIconTex, 15),     ITEM_LENS,             INV_IC_POS(1, 2), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgMagicBeansIconTex, 16),      ITEM_BEAN,             INV_IC_POS(2, 2), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgMegatonHammerIconTex, 17),   ITEM_HAMMER,           INV_IC_POS(3, 2), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgLightArrowIconTex, 18),      ITEM_ARROW_LIGHT,      INV_IC_POS(4, 2), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgNayrusLoveIconTex, 19),      ITEM_NAYRUS_LOVE,      INV_IC_POS(5, 2), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgClaimCheckIconTex, 53),      ITEM_CLAIM_CHECK,      INV_IC_POS(6, 2), SIZE_NORMAL},
     
-    {CREATE_SPRITE_32(dgKokiriSwordIconTex, 54),     ITEM_SWORD_KOKIRI,     EQP_IT_POS(0, 0), SIZE_NORMAL},
-    {CREATE_SPRITE_32(dgMasterSwordIconTex, 55),     ITEM_SWORD_MASTER,     EQP_IT_POS(1, 0), SIZE_NORMAL},
-    {CREATE_SPRITE_32(dgBiggoronSwordIconTex, 56),   ITEM_SWORD_BGS,        EQP_IT_POS(2, 0), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgKokiriSwordIconTex, 54),     ITEM_SWORD_KOKIRI,     EQP_IC_POS(0, 0), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgMasterSwordIconTex, 55),     ITEM_SWORD_MASTER,     EQP_IC_POS(1, 0), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgBiggoronSwordIconTex, 56),   ITEM_SWORD_BGS,        EQP_IC_POS(2, 0), SIZE_NORMAL},
     
-    {CREATE_SPRITE_32(dgDekuShieldIconTex, 57),      ITEM_SHIELD_DEKU,      EQP_IT_POS(0, 1), SIZE_NORMAL},
-    {CREATE_SPRITE_32(dgHylianShieldIconTex, 58),    ITEM_SHIELD_HYLIAN,    EQP_IT_POS(1, 1), SIZE_NORMAL},
-    {CREATE_SPRITE_32(dgMirrorShieldIconTex, 59),    ITEM_SHIELD_MIRROR,    EQP_IT_POS(2, 1), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgDekuShieldIconTex, 57),      ITEM_SHIELD_DEKU,      EQP_IC_POS(0, 1), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgHylianShieldIconTex, 58),    ITEM_SHIELD_HYLIAN,    EQP_IC_POS(1, 1), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgMirrorShieldIconTex, 59),    ITEM_SHIELD_MIRROR,    EQP_IC_POS(2, 1), SIZE_NORMAL},
     
-    {CREATE_SPRITE_32(dgKokiriTunicIconTex, 60),     ITEM_TUNIC_KOKIRI,     EQP_IT_POS(0, 2), SIZE_NORMAL},
-    {CREATE_SPRITE_32(dgGoronTunicIconTex, 61),      ITEM_TUNIC_GORON,      EQP_IT_POS(1, 2), SIZE_NORMAL},
-    {CREATE_SPRITE_32(dgZoraTunicIconTex, 62),       ITEM_TUNIC_ZORA,       EQP_IT_POS(2, 2), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgKokiriTunicIconTex, 60),     ITEM_TUNIC_KOKIRI,     EQP_IC_POS(0, 2), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgGoronTunicIconTex, 61),      ITEM_TUNIC_GORON,      EQP_IC_POS(1, 2), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgZoraTunicIconTex, 62),       ITEM_TUNIC_ZORA,       EQP_IC_POS(2, 2), SIZE_NORMAL},
     
-    {CREATE_SPRITE_32(dgKokiriBootsIconTex, 63),     ITEM_BOOTS_KOKIRI,     EQP_IT_POS(0, 3), SIZE_NORMAL},
-    {CREATE_SPRITE_32(dgIronBootsIconTex, 64),       ITEM_BOOTS_IRON,       EQP_IT_POS(1, 3), SIZE_NORMAL},
-    {CREATE_SPRITE_32(dgHoverBootsIconTex, 65),      ITEM_BOOTS_HOVER,      EQP_IT_POS(2, 3), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgKokiriBootsIconTex, 63),     ITEM_BOOTS_KOKIRI,     EQP_IC_POS(0, 3), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgIronBootsIconTex, 64),       ITEM_BOOTS_IRON,       EQP_IC_POS(1, 3), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgHoverBootsIconTex, 65),      ITEM_BOOTS_HOVER,      EQP_IC_POS(2, 3), SIZE_NORMAL},
 
-    {CREATE_SPRITE_24(dgKokiriEmeraldIconTex, 87),   ITEM_KOKIRI_EMERALD,   {0x19, 0x31},     SIZE_NORMAL},
-    {CREATE_SPRITE_24(dgGoronRubyIconTex, 88),       ITEM_GORON_RUBY,       {0x29, 0x31},     SIZE_NORMAL},
-    {CREATE_SPRITE_24(dgZoraSapphireIconTex, 89),    ITEM_ZORA_SAPPHIRE,    {0x39, 0x31},     SIZE_NORMAL},
+    {CREATE_SPRITE_24(dgKokiriEmeraldIconTex, 87),   ITEM_KOKIRI_EMERALD,   STN_IC_POS(-1),   SIZE_NORMAL},
+    {CREATE_SPRITE_24(dgGoronRubyIconTex, 88),       ITEM_GORON_RUBY,       STN_IC_POS(0),    SIZE_NORMAL},
+    {CREATE_SPRITE_24(dgZoraSapphireIconTex, 89),    ITEM_ZORA_SAPPHIRE,    STN_IC_POS(1),    SIZE_NORMAL},
     
     {CREATE_SPRITE_24(dgForestMedallionIconTex, 81), ITEM_MEDALLION_FOREST, {0x37, 0x0A},     SIZE_NORMAL},
     {CREATE_SPRITE_24(dgFireMedallionIconTex, 82),   ITEM_MEDALLION_FIRE,   {0x37, 0x1A},     SIZE_NORMAL},
@@ -107,24 +108,24 @@ static ItemData itemData[59] = {
     {CREATE_SPRITE_24(dgShadowMedallionIconTex, 85), ITEM_MEDALLION_SHADOW, {0x1B, 0x0A},     SIZE_NORMAL},
     {CREATE_SPRITE_24(dgLightMedallionIconTex, 86),  ITEM_MEDALLION_LIGHT,  {0x29, 0x02},     SIZE_NORMAL},
 
-    {CREATE_SPRITE_32(dgGoronsBraceletIconTex, 71),  ITEM_BRACELET,         UPG_IT_POS(0, 0), SIZE_NORMAL},
-    {CREATE_SPRITE_32(dgSilverScaleIconTex, 74),     ITEM_SCALE_SILVER,     UPG_IT_POS(1, 0), SIZE_NORMAL},
-    {CREATE_SPRITE_24(dgSmallMagicJarIconTex, 97),   ITEM_SINGLE_MAGIC,     UPG_IT_POS(2, 0), SIZE_NORMAL},
-    {CREATE_SPRITE_24(dgGerudosCardIconTex, 91),     ITEM_GERUDO_CARD,      UPG_IT_POS(1, 1), SIZE_NORMAL},
-    {CREATE_SPRITE_24(dgStoneOfAgonyIconTex, 90),    ITEM_STONE_OF_AGONY,   UPG_IT_POS(2, 1), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgGoronsBraceletIconTex, 71),  ITEM_BRACELET,         UPG_IC_POS(0, 0), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgSilverScaleIconTex, 74),     ITEM_SCALE_SILVER,     UPG_IC_POS(1, 0), SIZE_NORMAL},
+    {CREATE_SPRITE_24(dgSmallMagicJarIconTex, 97),   ITEM_SINGLE_MAGIC,     UPG_IC_POS(2, 0), SIZE_NORMAL},
+    {CREATE_SPRITE_24(dgGerudosCardIconTex, 91),     ITEM_GERUDO_CARD,      UPG_IC_POS(1, 1), SIZE_NORMAL},
+    {CREATE_SPRITE_24(dgStoneOfAgonyIconTex, 90),    ITEM_STONE_OF_AGONY,   UPG_IC_POS(2, 1), SIZE_NORMAL},
     
-    {CREATE_SPRITE_SONG(224, 107, 255),              ITEM_SONG_LULLABY,     SNG_IT_POS(0, 0), SIZE_SONG},
-    {CREATE_SPRITE_SONG(255, 195, 60),               ITEM_SONG_EPONA,       SNG_IT_POS(1, 0), SIZE_SONG},
-    {CREATE_SPRITE_SONG(127, 255, 137),              ITEM_SONG_SARIA,       SNG_IT_POS(2, 0), SIZE_SONG},
-    {CREATE_SPRITE_SONG(255, 255, 60),               ITEM_SONG_SUN,         SNG_IT_POS(3, 0), SIZE_SONG},
-    {CREATE_SPRITE_SONG(119, 236, 255),              ITEM_SONG_TIME,        SNG_IT_POS(4, 0), SIZE_SONG},
-    {CREATE_SPRITE_SONG(165, 165, 165),              ITEM_SONG_STORMS,      SNG_IT_POS(5, 0), SIZE_SONG},
-    {CREATE_SPRITE_SONG(150, 255, 100),              ITEM_SONG_MINUET,      SNG_IT_POS(0, 1), SIZE_SONG},
-    {CREATE_SPRITE_SONG(255, 80,  40),               ITEM_SONG_BOLERO,      SNG_IT_POS(1, 1), SIZE_SONG},
-    {CREATE_SPRITE_SONG(100, 150, 255),              ITEM_SONG_SERENADE,    SNG_IT_POS(2, 1), SIZE_SONG},
-    {CREATE_SPRITE_SONG(255, 160, 0),                ITEM_SONG_REQUIEM,     SNG_IT_POS(3, 1), SIZE_SONG},
-    {CREATE_SPRITE_SONG(255, 100, 255),              ITEM_SONG_NOCTURNE,    SNG_IT_POS(4, 1), SIZE_SONG},
-    {CREATE_SPRITE_SONG(255, 240, 100),              ITEM_SONG_PRELUDE,     SNG_IT_POS(5, 1), SIZE_SONG},
+    {CREATE_SPRITE_SONG(224, 107, 255),              ITEM_SONG_LULLABY,     SNG_IC_POS(0, 0), SIZE_SONG},
+    {CREATE_SPRITE_SONG(255, 195, 60),               ITEM_SONG_EPONA,       SNG_IC_POS(1, 0), SIZE_SONG},
+    {CREATE_SPRITE_SONG(127, 255, 137),              ITEM_SONG_SARIA,       SNG_IC_POS(2, 0), SIZE_SONG},
+    {CREATE_SPRITE_SONG(255, 255, 60),               ITEM_SONG_SUN,         SNG_IC_POS(3, 0), SIZE_SONG},
+    {CREATE_SPRITE_SONG(119, 236, 255),              ITEM_SONG_TIME,        SNG_IC_POS(4, 0), SIZE_SONG},
+    {CREATE_SPRITE_SONG(165, 165, 165),              ITEM_SONG_STORMS,      SNG_IC_POS(5, 0), SIZE_SONG},
+    {CREATE_SPRITE_SONG(150, 255, 100),              ITEM_SONG_MINUET,      SNG_IC_POS(0, 1), SIZE_SONG},
+    {CREATE_SPRITE_SONG(255, 80,  40),               ITEM_SONG_BOLERO,      SNG_IC_POS(1, 1), SIZE_SONG},
+    {CREATE_SPRITE_SONG(100, 150, 255),              ITEM_SONG_SERENADE,    SNG_IC_POS(2, 1), SIZE_SONG},
+    {CREATE_SPRITE_SONG(255, 160, 0),                ITEM_SONG_REQUIEM,     SNG_IC_POS(3, 1), SIZE_SONG},
+    {CREATE_SPRITE_SONG(255, 100, 255),              ITEM_SONG_NOCTURNE,    SNG_IC_POS(4, 1), SIZE_SONG},
+    {CREATE_SPRITE_SONG(255, 240, 100),              ITEM_SONG_PRELUDE,     SNG_IC_POS(5, 1), SIZE_SONG},
 };
 
 static u8 color_product(u8 c1, u8 c2) {
@@ -196,7 +197,7 @@ u8 HasItem(s16 fileIndex, u8 item) {
     return 0;
 }
 
-static void Draw_Items(FileChooseContext* this, s16 fileIndex, u8 alpha) {
+static void DrawItems(FileChooseContext* this, s16 fileIndex, u8 alpha) {
     OPEN_DISPS(this->state.gfxCtx);
     gDPPipeSync(POLY_OPA_DISP++);
     gDPSetCombineMode(POLY_OPA_DISP++, G_CC_MODULATEIA_PRIM, G_CC_MODULATEIA_PRIM);
@@ -522,7 +523,7 @@ void DrawSeedHashSprites(FileChooseContext* this) {
                 if (Save_GetSaveMetaInfo(this->selectedFileIndex)->randoSave == 1) {
                     SpriteLoad(this, GetSeedTexture(Save_GetSaveMetaInfo(this->selectedFileIndex)->seedHash[i]));
                     SpriteDraw(this, GetSeedTexture(Save_GetSaveMetaInfo(this->selectedFileIndex)->seedHash[i]),
-                                xStart + (18 * i), 136, 16, 16);
+                                xStart + (40 * i), 10, 24, 24);
                 }
             }
         }
@@ -534,15 +535,6 @@ void DrawSeedHashSprites(FileChooseContext* this) {
         }
 
         gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 0xFF, 0xFF, 0xFF, alpha);
-
-        // Draw Seed Icons for spoiler log
-        if (strnlen(CVarGetString("gSpoilerLog", ""), 1) != 0 && fileSelectSpoilerFileLoaded) {
-            u16 xStart = 64;
-            for (unsigned int i = 0; i < 5; i++) {
-                SpriteLoad(this, GetSeedTexture(gSaveContext.seedIcons[i]));
-                SpriteDraw(this, GetSeedTexture(gSaveContext.seedIcons[i]), xStart + (40 * i), 10, 24, 24);
-            }
-        }
     }
 
     gDPPipeSync(POLY_OPA_DISP++);
@@ -1589,7 +1581,7 @@ void FileChoose_DrawFileInfo(GameState* thisx, s16 fileIndex, s16 isActive) {
         }
 
         if (CVarGetInteger("gFileSelectMoreInfo", 0) != 0) {
-            Draw_Items(this, fileIndex, textAlpha);
+            DrawItems(this, fileIndex, textAlpha);
         } else {
             // draw quest items
             for (vtxOffset = 0, j = 0; j < 9; j++, vtxOffset += 4) {
@@ -1907,13 +1899,25 @@ void FileChoose_DrawWindowContents(GameState* thisx) {
             gDPPipeSync(POLY_OPA_DISP++);
             gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, this->windowColor[0], this->windowColor[1], this->windowColor[2],
                             this->fileInfoAlpha[fileIndex]);
-            gSPVertex(POLY_OPA_DISP++, &this->windowContentVtx[temp], 20, 0);
 
-            for (quadVtxIndex = 0, i = 0; i < 5; i++, quadVtxIndex += 4) {
-                gDPLoadTextureBlock(POLY_OPA_DISP++, sFileInfoBoxTextures[i], G_IM_FMT_IA, G_IM_SIZ_16b,
-                                    sFileInfoBoxPartWidths[i], 56, 0, G_TX_NOMIRROR | G_TX_WRAP,
-                                    G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
-                gSP1Quadrangle(POLY_OPA_DISP++, quadVtxIndex, quadVtxIndex + 2, quadVtxIndex + 3, quadVtxIndex + 1, 0);
+            // Draw the small file name box instead when more meta info is enabled
+            if (CVarGetInteger("gFileSelectMoreInfo", 0)) {
+                // Location of file 1 small name box vertices
+                gSPVertex(POLY_OPA_DISP++, &this->windowContentVtx[68], 4, 0);
+
+                gDPLoadTextureBlock(POLY_OPA_DISP++, gFileSelNameBoxTex, G_IM_FMT_IA, G_IM_SIZ_16b, 108, 16, 0,
+                                G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK,
+                                G_TX_NOLOD, G_TX_NOLOD);
+                gSP1Quadrangle(POLY_OPA_DISP++, 0, 2, 3, 1, 0);
+            } else {
+                gSPVertex(POLY_OPA_DISP++, &this->windowContentVtx[temp], 20, 0);
+
+                for (quadVtxIndex = 0, i = 0; i < 5; i++, quadVtxIndex += 4) {
+                    gDPLoadTextureBlock(POLY_OPA_DISP++, sFileInfoBoxTextures[i], G_IM_FMT_IA, G_IM_SIZ_16b,
+                                        sFileInfoBoxPartWidths[i], 56, 0, G_TX_NOMIRROR | G_TX_WRAP,
+                                        G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
+                    gSP1Quadrangle(POLY_OPA_DISP++, quadVtxIndex, quadVtxIndex + 2, quadVtxIndex + 3, quadVtxIndex + 1, 0);
+                }
             }
         }
 

--- a/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -66,7 +66,7 @@ typedef struct {
 #define UPG_IC_POS(x, y) {0x5A + ICON_SIZE * x, 0x2A + ICON_SIZE * y}
 #define STN_IC_POS(i) {0x29 + ICON_SIZE * i, 0x31}
 
-static ItemData itemData[87] = {
+static ItemData itemData[88] = {
     {CREATE_SPRITE_32(dgDekuStickIconTex, 1),            ITEM_STICK,            INV_IC_POS(0, 0), SIZE_NORMAL},
     {CREATE_SPRITE_32(dgDekuNutIconTex, 0),              ITEM_NUT,              INV_IC_POS(1, 0), SIZE_NORMAL},
     {CREATE_SPRITE_32(dgBombIconTex, 2),                 ITEM_BOMB,             INV_IC_POS(2, 0), SIZE_NORMAL},
@@ -164,6 +164,8 @@ static ItemData itemData[87] = {
     {CREATE_SPRITE_SONG(255, 160, 0),                    ITEM_SONG_REQUIEM,     SNG_IC_POS(3, 1), SIZE_SONG},
     {CREATE_SPRITE_SONG(255, 100, 255),                  ITEM_SONG_NOCTURNE,    SNG_IC_POS(4, 1), SIZE_SONG},
     {CREATE_SPRITE_SONG(255, 240, 100),                  ITEM_SONG_PRELUDE,     SNG_IC_POS(5, 1), SIZE_SONG},
+
+    {CREATE_SPRITE_24(dgHeartContainerIconTex, 101),     ITEM_DOUBLE_DEFENSE,   {0x05, -0x04},    SIZE_COUNTER},
 };
 
 static u8 color_product(u8 c1, u8 c2) {
@@ -239,6 +241,10 @@ u8 HasItem(s16 fileIndex, u8 item) {
 
     if (item == ITEM_SCALE_GOLDEN) {
         return ((Save_GetSaveMetaInfo(fileIndex)->upgrades & gUpgradeMasks[UPG_SCALE]) >> gUpgradeShifts[UPG_SCALE]) == 2;
+    }
+
+    if (item == ITEM_DOUBLE_DEFENSE) {
+        return Save_GetSaveMetaInfo(fileIndex)->isDoubleDefenseAcquired;
     }
 
     //greg
@@ -419,6 +425,10 @@ u8 ShouldRenderItem(s16 fileIndex, u8 item) {
     }
     
     if (item == ITEM_CLAIM_CHECK && HasItem(fileIndex, ITEM_CLAIM_CHECK) == 0) {
+        return 0;
+    }
+
+    if (item == ITEM_DOUBLE_DEFENSE && !Save_GetSaveMetaInfo(fileIndex)->isDoubleDefenseAcquired) {
         return 0;
     }
 

--- a/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -108,7 +108,7 @@ static ItemData itemData[59] = {
 
     {CREATE_SPRITE_32(dgGoronsBraceletIconTex, 71),  ITEM_BRACELET,         UPG_IT_POS(0, 0), SIZE_NORMAL},
     {CREATE_SPRITE_32(dgSilverScaleIconTex, 74),     ITEM_SCALE_SILVER,     UPG_IT_POS(1, 0), SIZE_NORMAL},
-    {CREATE_SPRITE_24(dgSmallMagicJarIconTex, 97),   ITEM_MAGIC_SMALL,      UPG_IT_POS(2, 0), SIZE_NORMAL},
+    {CREATE_SPRITE_24(dgSmallMagicJarIconTex, 97),   ITEM_SINGLE_MAGIC,     UPG_IT_POS(2, 0), SIZE_NORMAL},
     {CREATE_SPRITE_24(dgGerudosCardIconTex, 91),     ITEM_GERUDO_CARD,      UPG_IT_POS(1, 1), SIZE_NORMAL},
     {CREATE_SPRITE_24(dgStoneOfAgonyIconTex, 90),    ITEM_STONE_OF_AGONY,   UPG_IT_POS(2, 1), SIZE_NORMAL},
     
@@ -161,31 +161,43 @@ u8 HasItem(s16 fileIndex, u8 item) {
     }
 
     if (item >= ITEM_SONG_MINUET && item <= ITEM_SONG_STORMS) {
-        return Save_GetSaveMetaInfo(fileIndex)->questItems & (1 << (item - 0x54));
+        return (Save_GetSaveMetaInfo(fileIndex)->questItems & (1 << (item - 0x54))) != 0;
     }
 
     if (item >= ITEM_MEDALLION_FOREST && item <= ITEM_MEDALLION_LIGHT) {
-        return Save_GetSaveMetaInfo(fileIndex)->questItems & (1 << (item - 0x66));
+        return (Save_GetSaveMetaInfo(fileIndex)->questItems & (1 << (item - 0x66))) != 0;
     }
 
     if (item >= ITEM_KOKIRI_EMERALD && item <= ITEM_GERUDO_CARD) {
-        return Save_GetSaveMetaInfo(fileIndex)->questItems & (1 << (item - 0x5A));
+        return (Save_GetSaveMetaInfo(fileIndex)->questItems & (1 << (item - 0x5A))) != 0;
     }
 
     if (item >= ITEM_SWORD_KOKIRI && item <= ITEM_SWORD_BGS) {
-        return Save_GetSaveMetaInfo(fileIndex)->equipment & (1 << (item - 0x3B));
+        return (Save_GetSaveMetaInfo(fileIndex)->equipment & (1 << (item - 0x3B))) != 0;
     }
 
     if (item >= ITEM_SHIELD_DEKU && item <= ITEM_SHIELD_MIRROR) {
-        return Save_GetSaveMetaInfo(fileIndex)->equipment & (1 << (item - 0x3E + 4));
+        return (Save_GetSaveMetaInfo(fileIndex)->equipment & (1 << (item - 0x3E + 4))) != 0;
     }
 
     if (item >= ITEM_TUNIC_KOKIRI && item <= ITEM_TUNIC_ZORA) {
-        return Save_GetSaveMetaInfo(fileIndex)->equipment & (1 << (item - 0x41 + 8));
+        return (Save_GetSaveMetaInfo(fileIndex)->equipment & (1 << (item - 0x41 + 8))) != 0;
     }
 
     if (item >= ITEM_BOOTS_KOKIRI && item <= ITEM_BOOTS_HOVER) {
-        return Save_GetSaveMetaInfo(fileIndex)->equipment & (1 << (item - 0x44 + 12));
+        return (Save_GetSaveMetaInfo(fileIndex)->equipment & (1 << (item - 0x44 + 12))) != 0;
+    }
+
+    if (item == ITEM_SINGLE_MAGIC) {
+        return Save_GetSaveMetaInfo(fileIndex)->isMagicAcquired;
+    }
+
+    if (item == ITEM_BRACELET) {
+        return ((Save_GetSaveMetaInfo(fileIndex)->upgrades & gUpgradeMasks[UPG_STRENGTH]) >> gUpgradeShifts[UPG_STRENGTH]) != 0;
+    }
+
+    if (item == ITEM_SCALE_SILVER) {
+        return ((Save_GetSaveMetaInfo(fileIndex)->upgrades & gUpgradeMasks[UPG_SCALE]) >> gUpgradeShifts[UPG_SCALE]) != 0;
     }
 
     return 0;

--- a/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -60,76 +60,103 @@ typedef struct {
 #define UPG_IC_POS(x, y) {0x5A + ICON_SIZE * x, 0x2A + ICON_SIZE * y}
 #define STN_IC_POS(i) {0x29 + ICON_SIZE * i, 0x31}
 
-static ItemData itemData[59] = {
-    {CREATE_SPRITE_32(dgDekuStickIconTex, 1),        ITEM_STICK,            INV_IC_POS(0, 0), SIZE_NORMAL},
-    {CREATE_SPRITE_32(dgDekuNutIconTex, 0),          ITEM_NUT,              INV_IC_POS(1, 0), SIZE_NORMAL},
-    {CREATE_SPRITE_32(dgBombIconTex, 2),             ITEM_BOMB,             INV_IC_POS(2, 0), SIZE_NORMAL},
-    {CREATE_SPRITE_32(dgFairyBowIconTex, 3),         ITEM_BOW,              INV_IC_POS(3, 0), SIZE_NORMAL},
-    {CREATE_SPRITE_32(dgFireArrowIconTex, 4),        ITEM_ARROW_FIRE,       INV_IC_POS(4, 0), SIZE_NORMAL},
-    {CREATE_SPRITE_32(dgDinsFireIconTex, 5),         ITEM_DINS_FIRE,        INV_IC_POS(5, 0), SIZE_NORMAL},
-    {CREATE_SPRITE_32(dgEmptyBottleIconTex, 20),     ITEM_BOTTLE,           INV_IC_POS(6, 0), SIZE_NORMAL},
+static ItemData itemData[86] = {
+    {CREATE_SPRITE_32(dgDekuStickIconTex, 1),            ITEM_STICK,            INV_IC_POS(0, 0), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgDekuNutIconTex, 0),              ITEM_NUT,              INV_IC_POS(1, 0), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgBombIconTex, 2),                 ITEM_BOMB,             INV_IC_POS(2, 0), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgFairyBowIconTex, 3),             ITEM_BOW,              INV_IC_POS(3, 0), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgFireArrowIconTex, 4),            ITEM_ARROW_FIRE,       INV_IC_POS(4, 0), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgDinsFireIconTex, 5),             ITEM_DINS_FIRE,        INV_IC_POS(5, 0), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgEmptyBottleIconTex, 20),         ITEM_BOTTLE,           INV_IC_POS(6, 0), SIZE_NORMAL},
 
-    {CREATE_SPRITE_32(dgFairySlingshotIconTex, 6),   ITEM_SLINGSHOT,        INV_IC_POS(0, 1), SIZE_NORMAL},
-    {CREATE_SPRITE_32(dgFairyOcarinaIconTex, 7),     ITEM_OCARINA_FAIRY,    INV_IC_POS(1, 1), SIZE_NORMAL},
-    {CREATE_SPRITE_32(dgBombchuIconTex, 9),          ITEM_BOMBCHU,          INV_IC_POS(2, 1), SIZE_NORMAL},
-    {CREATE_SPRITE_32(dgHookshotIconTex, 10),        ITEM_HOOKSHOT,         INV_IC_POS(3, 1), SIZE_NORMAL},
-    {CREATE_SPRITE_32(dgIceArrowIconTex, 12),        ITEM_ARROW_ICE,        INV_IC_POS(4, 1), SIZE_NORMAL},
-    {CREATE_SPRITE_32(dgFaroresWindIconTex, 13),     ITEM_FARORES_WIND,     INV_IC_POS(5, 1), SIZE_NORMAL},
-    {CREATE_SPRITE_32(dgBunnyHoodIconTex, 37),       ITEM_MASK_BUNNY,       INV_IC_POS(6, 1), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgFairySlingshotIconTex, 6),       ITEM_SLINGSHOT,        INV_IC_POS(0, 1), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgFairyOcarinaIconTex, 7),         ITEM_OCARINA_FAIRY,    INV_IC_POS(1, 1), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgOcarinaofTimeIconTex, 7),        ITEM_OCARINA_TIME,     INV_IC_POS(1, 1), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgBombchuIconTex, 9),              ITEM_BOMBCHU,          INV_IC_POS(2, 1), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgHookshotIconTex, 10),            ITEM_HOOKSHOT,         INV_IC_POS(3, 1), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgLongshotIconTex, 10),            ITEM_LONGSHOT,         INV_IC_POS(3, 1), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgIceArrowIconTex, 12),            ITEM_ARROW_ICE,        INV_IC_POS(4, 1), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgFaroresWindIconTex, 13),         ITEM_FARORES_WIND,     INV_IC_POS(5, 1), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgWeirdEggIconTex, 37),            ITEM_WEIRD_EGG,        INV_IC_POS(6, 1), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgCuccoIconTex, 37),               ITEM_CHICKEN,          INV_IC_POS(6, 1), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgZeldasLetterIconTex, 37),        ITEM_LETTER_ZELDA,     INV_IC_POS(6, 1), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgKeatonMaskIconTex, 37),          ITEM_MASK_KEATON,      INV_IC_POS(6, 1), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgSkullMaskIconTex, 37),           ITEM_MASK_SKULL,       INV_IC_POS(6, 1), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgSpookyMaskIconTex, 37),          ITEM_MASK_SPOOKY,      INV_IC_POS(6, 1), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgBunnyHoodIconTex, 37),           ITEM_MASK_BUNNY,       INV_IC_POS(6, 1), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgGoronMaskIconTex, 37),           ITEM_MASK_GORON,       INV_IC_POS(6, 1), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgZoraMaskIconTex, 37),            ITEM_MASK_ZORA,        INV_IC_POS(6, 1), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgGerudoMaskIconTex, 37),          ITEM_MASK_GERUDO,      INV_IC_POS(6, 1), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgMaskofTruthIconTex, 37),         ITEM_MASK_TRUTH,       INV_IC_POS(6, 1), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgSoldOutIconTex, 37),             ITEM_SOLD_OUT,         INV_IC_POS(6, 1), SIZE_NORMAL},
+    
+    {CREATE_SPRITE_32(dgBoomerangIconTex, 14),           ITEM_BOOMERANG,        INV_IC_POS(0, 2), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgLensofTruthIconTex, 15),         ITEM_LENS,             INV_IC_POS(1, 2), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgMagicBeansIconTex, 16),          ITEM_BEAN,             INV_IC_POS(2, 2), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgMegatonHammerIconTex, 17),       ITEM_HAMMER,           INV_IC_POS(3, 2), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgLightArrowIconTex, 18),          ITEM_ARROW_LIGHT,      INV_IC_POS(4, 2), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgNayrusLoveIconTex, 19),          ITEM_NAYRUS_LOVE,      INV_IC_POS(5, 2), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgPocketEggIconTex, 53),           ITEM_POCKET_EGG,       INV_IC_POS(6, 2), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgPocketCuccoIconTex, 53),         ITEM_POCKET_CUCCO,     INV_IC_POS(6, 2), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgCojiroIconTex, 53),              ITEM_COJIRO,           INV_IC_POS(6, 2), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgOddMushroomIconTex, 53),         ITEM_ODD_MUSHROOM,     INV_IC_POS(6, 2), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgOddPotionIconTex, 53),           ITEM_ODD_POTION,       INV_IC_POS(6, 2), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgPoachersSawIconTex, 53),         ITEM_SAW,              INV_IC_POS(6, 2), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgBrokenBiggoronSwordIconTex, 53), ITEM_SWORD_BROKEN,     INV_IC_POS(6, 2), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgPrescriptionIconTex, 53),        ITEM_PRESCRIPTION,     INV_IC_POS(6, 2), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgEyeBallFrogIconTex, 53),         ITEM_FROG,             INV_IC_POS(6, 2), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgEyeDropsIconTex, 53),            ITEM_EYEDROPS,         INV_IC_POS(6, 2), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgClaimCheckIconTex, 53),          ITEM_CLAIM_CHECK,      INV_IC_POS(6, 2), SIZE_NORMAL},
+    
+    {CREATE_SPRITE_32(dgKokiriSwordIconTex, 54),         ITEM_SWORD_KOKIRI,     EQP_IC_POS(0, 0), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgMasterSwordIconTex, 55),         ITEM_SWORD_MASTER,     EQP_IC_POS(1, 0), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgBiggoronSwordIconTex, 56),       ITEM_SWORD_BGS,        EQP_IC_POS(2, 0), SIZE_NORMAL},
+    
+    {CREATE_SPRITE_32(dgDekuShieldIconTex, 57),          ITEM_SHIELD_DEKU,      EQP_IC_POS(0, 1), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgHylianShieldIconTex, 58),        ITEM_SHIELD_HYLIAN,    EQP_IC_POS(1, 1), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgMirrorShieldIconTex, 59),        ITEM_SHIELD_MIRROR,    EQP_IC_POS(2, 1), SIZE_NORMAL},
+    
+    {CREATE_SPRITE_32(dgKokiriTunicIconTex, 60),         ITEM_TUNIC_KOKIRI,     EQP_IC_POS(0, 2), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgGoronTunicIconTex, 61),          ITEM_TUNIC_GORON,      EQP_IC_POS(1, 2), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgZoraTunicIconTex, 62),           ITEM_TUNIC_ZORA,       EQP_IC_POS(2, 2), SIZE_NORMAL},
+    
+    {CREATE_SPRITE_32(dgKokiriBootsIconTex, 63),         ITEM_BOOTS_KOKIRI,     EQP_IC_POS(0, 3), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgIronBootsIconTex, 64),           ITEM_BOOTS_IRON,       EQP_IC_POS(1, 3), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgHoverBootsIconTex, 65),          ITEM_BOOTS_HOVER,      EQP_IC_POS(2, 3), SIZE_NORMAL},
 
-    {CREATE_SPRITE_32(dgBoomerangIconTex, 14),       ITEM_BOOMERANG,        INV_IC_POS(0, 2), SIZE_NORMAL},
-    {CREATE_SPRITE_32(dgLensofTruthIconTex, 15),     ITEM_LENS,             INV_IC_POS(1, 2), SIZE_NORMAL},
-    {CREATE_SPRITE_32(dgMagicBeansIconTex, 16),      ITEM_BEAN,             INV_IC_POS(2, 2), SIZE_NORMAL},
-    {CREATE_SPRITE_32(dgMegatonHammerIconTex, 17),   ITEM_HAMMER,           INV_IC_POS(3, 2), SIZE_NORMAL},
-    {CREATE_SPRITE_32(dgLightArrowIconTex, 18),      ITEM_ARROW_LIGHT,      INV_IC_POS(4, 2), SIZE_NORMAL},
-    {CREATE_SPRITE_32(dgNayrusLoveIconTex, 19),      ITEM_NAYRUS_LOVE,      INV_IC_POS(5, 2), SIZE_NORMAL},
-    {CREATE_SPRITE_32(dgClaimCheckIconTex, 53),      ITEM_CLAIM_CHECK,      INV_IC_POS(6, 2), SIZE_NORMAL},
+    {CREATE_SPRITE_24(dgKokiriEmeraldIconTex, 87),       ITEM_KOKIRI_EMERALD,   STN_IC_POS(-1),   SIZE_NORMAL},
+    {CREATE_SPRITE_24(dgGoronRubyIconTex, 88),           ITEM_GORON_RUBY,       STN_IC_POS(0),    SIZE_NORMAL},
+    {CREATE_SPRITE_24(dgZoraSapphireIconTex, 89),        ITEM_ZORA_SAPPHIRE,    STN_IC_POS(1),    SIZE_NORMAL},
     
-    {CREATE_SPRITE_32(dgKokiriSwordIconTex, 54),     ITEM_SWORD_KOKIRI,     EQP_IC_POS(0, 0), SIZE_NORMAL},
-    {CREATE_SPRITE_32(dgMasterSwordIconTex, 55),     ITEM_SWORD_MASTER,     EQP_IC_POS(1, 0), SIZE_NORMAL},
-    {CREATE_SPRITE_32(dgBiggoronSwordIconTex, 56),   ITEM_SWORD_BGS,        EQP_IC_POS(2, 0), SIZE_NORMAL},
-    
-    {CREATE_SPRITE_32(dgDekuShieldIconTex, 57),      ITEM_SHIELD_DEKU,      EQP_IC_POS(0, 1), SIZE_NORMAL},
-    {CREATE_SPRITE_32(dgHylianShieldIconTex, 58),    ITEM_SHIELD_HYLIAN,    EQP_IC_POS(1, 1), SIZE_NORMAL},
-    {CREATE_SPRITE_32(dgMirrorShieldIconTex, 59),    ITEM_SHIELD_MIRROR,    EQP_IC_POS(2, 1), SIZE_NORMAL},
-    
-    {CREATE_SPRITE_32(dgKokiriTunicIconTex, 60),     ITEM_TUNIC_KOKIRI,     EQP_IC_POS(0, 2), SIZE_NORMAL},
-    {CREATE_SPRITE_32(dgGoronTunicIconTex, 61),      ITEM_TUNIC_GORON,      EQP_IC_POS(1, 2), SIZE_NORMAL},
-    {CREATE_SPRITE_32(dgZoraTunicIconTex, 62),       ITEM_TUNIC_ZORA,       EQP_IC_POS(2, 2), SIZE_NORMAL},
-    
-    {CREATE_SPRITE_32(dgKokiriBootsIconTex, 63),     ITEM_BOOTS_KOKIRI,     EQP_IC_POS(0, 3), SIZE_NORMAL},
-    {CREATE_SPRITE_32(dgIronBootsIconTex, 64),       ITEM_BOOTS_IRON,       EQP_IC_POS(1, 3), SIZE_NORMAL},
-    {CREATE_SPRITE_32(dgHoverBootsIconTex, 65),      ITEM_BOOTS_HOVER,      EQP_IC_POS(2, 3), SIZE_NORMAL},
+    {CREATE_SPRITE_24(dgForestMedallionIconTex, 81),     ITEM_MEDALLION_FOREST, {0x37, 0x0A},     SIZE_NORMAL},
+    {CREATE_SPRITE_24(dgFireMedallionIconTex, 82),       ITEM_MEDALLION_FIRE,   {0x37, 0x1A},     SIZE_NORMAL},
+    {CREATE_SPRITE_24(dgWaterMedallionIconTex, 83),      ITEM_MEDALLION_WATER,  {0x29, 0x22},     SIZE_NORMAL},
+    {CREATE_SPRITE_24(dgSpiritMedallionIconTex, 84),     ITEM_MEDALLION_SPIRIT, {0x1B, 0x1A},     SIZE_NORMAL},
+    {CREATE_SPRITE_24(dgShadowMedallionIconTex, 85),     ITEM_MEDALLION_SHADOW, {0x1B, 0x0A},     SIZE_NORMAL},
+    {CREATE_SPRITE_24(dgLightMedallionIconTex, 86),      ITEM_MEDALLION_LIGHT,  {0x29, 0x02},     SIZE_NORMAL},
 
-    {CREATE_SPRITE_24(dgKokiriEmeraldIconTex, 87),   ITEM_KOKIRI_EMERALD,   STN_IC_POS(-1),   SIZE_NORMAL},
-    {CREATE_SPRITE_24(dgGoronRubyIconTex, 88),       ITEM_GORON_RUBY,       STN_IC_POS(0),    SIZE_NORMAL},
-    {CREATE_SPRITE_24(dgZoraSapphireIconTex, 89),    ITEM_ZORA_SAPPHIRE,    STN_IC_POS(1),    SIZE_NORMAL},
-    
-    {CREATE_SPRITE_24(dgForestMedallionIconTex, 81), ITEM_MEDALLION_FOREST, {0x37, 0x0A},     SIZE_NORMAL},
-    {CREATE_SPRITE_24(dgFireMedallionIconTex, 82),   ITEM_MEDALLION_FIRE,   {0x37, 0x1A},     SIZE_NORMAL},
-    {CREATE_SPRITE_24(dgWaterMedallionIconTex, 83),  ITEM_MEDALLION_WATER,  {0x29, 0x22},     SIZE_NORMAL},
-    {CREATE_SPRITE_24(dgSpiritMedallionIconTex, 84), ITEM_MEDALLION_SPIRIT, {0x1B, 0x1A},     SIZE_NORMAL},
-    {CREATE_SPRITE_24(dgShadowMedallionIconTex, 85), ITEM_MEDALLION_SHADOW, {0x1B, 0x0A},     SIZE_NORMAL},
-    {CREATE_SPRITE_24(dgLightMedallionIconTex, 86),  ITEM_MEDALLION_LIGHT,  {0x29, 0x02},     SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgGoronsBraceletIconTex, 71),      ITEM_BRACELET,         UPG_IC_POS(0, 0), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgSilverGauntletsIconTex, 71),     ITEM_GAUNTLETS_SILVER, UPG_IC_POS(0, 0), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgGoldenGauntletsIconTex, 71),     ITEM_GAUNTLETS_GOLD,   UPG_IC_POS(0, 0), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgSilverScaleIconTex, 74),         ITEM_SCALE_SILVER,     UPG_IC_POS(1, 0), SIZE_NORMAL},
+    {CREATE_SPRITE_32(dgGoldenScaleIconTex, 74),         ITEM_SCALE_GOLDEN,     UPG_IC_POS(1, 0), SIZE_NORMAL},
+    {CREATE_SPRITE_24(dgSmallMagicJarIconTex, 97),       ITEM_SINGLE_MAGIC,     UPG_IC_POS(2, 0), SIZE_NORMAL},
+    {CREATE_SPRITE_24(dgBigMagicJarIconTex, 97),         ITEM_DOUBLE_MAGIC,     UPG_IC_POS(2, 0), SIZE_NORMAL},
+    {CREATE_SPRITE_24(dgGerudosCardIconTex, 91),         ITEM_GERUDO_CARD,      UPG_IC_POS(1, 1), SIZE_NORMAL},
+    {CREATE_SPRITE_24(dgStoneOfAgonyIconTex, 90),        ITEM_STONE_OF_AGONY,   UPG_IC_POS(2, 1), SIZE_NORMAL},
 
-    {CREATE_SPRITE_32(dgGoronsBraceletIconTex, 71),  ITEM_BRACELET,         UPG_IC_POS(0, 0), SIZE_NORMAL},
-    {CREATE_SPRITE_32(dgSilverScaleIconTex, 74),     ITEM_SCALE_SILVER,     UPG_IC_POS(1, 0), SIZE_NORMAL},
-    {CREATE_SPRITE_24(dgSmallMagicJarIconTex, 97),   ITEM_SINGLE_MAGIC,     UPG_IC_POS(2, 0), SIZE_NORMAL},
-    {CREATE_SPRITE_24(dgGerudosCardIconTex, 91),     ITEM_GERUDO_CARD,      UPG_IC_POS(1, 1), SIZE_NORMAL},
-    {CREATE_SPRITE_24(dgStoneOfAgonyIconTex, 90),    ITEM_STONE_OF_AGONY,   UPG_IC_POS(2, 1), SIZE_NORMAL},
-    
-    {CREATE_SPRITE_SONG(224, 107, 255),              ITEM_SONG_LULLABY,     SNG_IC_POS(0, 0), SIZE_SONG},
-    {CREATE_SPRITE_SONG(255, 195, 60),               ITEM_SONG_EPONA,       SNG_IC_POS(1, 0), SIZE_SONG},
-    {CREATE_SPRITE_SONG(127, 255, 137),              ITEM_SONG_SARIA,       SNG_IC_POS(2, 0), SIZE_SONG},
-    {CREATE_SPRITE_SONG(255, 255, 60),               ITEM_SONG_SUN,         SNG_IC_POS(3, 0), SIZE_SONG},
-    {CREATE_SPRITE_SONG(119, 236, 255),              ITEM_SONG_TIME,        SNG_IC_POS(4, 0), SIZE_SONG},
-    {CREATE_SPRITE_SONG(165, 165, 165),              ITEM_SONG_STORMS,      SNG_IC_POS(5, 0), SIZE_SONG},
-    {CREATE_SPRITE_SONG(150, 255, 100),              ITEM_SONG_MINUET,      SNG_IC_POS(0, 1), SIZE_SONG},
-    {CREATE_SPRITE_SONG(255, 80,  40),               ITEM_SONG_BOLERO,      SNG_IC_POS(1, 1), SIZE_SONG},
-    {CREATE_SPRITE_SONG(100, 150, 255),              ITEM_SONG_SERENADE,    SNG_IC_POS(2, 1), SIZE_SONG},
-    {CREATE_SPRITE_SONG(255, 160, 0),                ITEM_SONG_REQUIEM,     SNG_IC_POS(3, 1), SIZE_SONG},
-    {CREATE_SPRITE_SONG(255, 100, 255),              ITEM_SONG_NOCTURNE,    SNG_IC_POS(4, 1), SIZE_SONG},
-    {CREATE_SPRITE_SONG(255, 240, 100),              ITEM_SONG_PRELUDE,     SNG_IC_POS(5, 1), SIZE_SONG},
+    {CREATE_SPRITE_SONG(224, 107, 255),                  ITEM_SONG_LULLABY,     SNG_IC_POS(0, 0), SIZE_SONG},
+    {CREATE_SPRITE_SONG(255, 195, 60),                   ITEM_SONG_EPONA,       SNG_IC_POS(1, 0), SIZE_SONG},
+    {CREATE_SPRITE_SONG(127, 255, 137),                  ITEM_SONG_SARIA,       SNG_IC_POS(2, 0), SIZE_SONG},
+    {CREATE_SPRITE_SONG(255, 255, 60),                   ITEM_SONG_SUN,         SNG_IC_POS(3, 0), SIZE_SONG},
+    {CREATE_SPRITE_SONG(119, 236, 255),                  ITEM_SONG_TIME,        SNG_IC_POS(4, 0), SIZE_SONG},
+    {CREATE_SPRITE_SONG(165, 165, 165),                  ITEM_SONG_STORMS,      SNG_IC_POS(5, 0), SIZE_SONG},
+    {CREATE_SPRITE_SONG(150, 255, 100),                  ITEM_SONG_MINUET,      SNG_IC_POS(0, 1), SIZE_SONG},
+    {CREATE_SPRITE_SONG(255, 80,  40),                   ITEM_SONG_BOLERO,      SNG_IC_POS(1, 1), SIZE_SONG},
+    {CREATE_SPRITE_SONG(100, 150, 255),                  ITEM_SONG_SERENADE,    SNG_IC_POS(2, 1), SIZE_SONG},
+    {CREATE_SPRITE_SONG(255, 160, 0),                    ITEM_SONG_REQUIEM,     SNG_IC_POS(3, 1), SIZE_SONG},
+    {CREATE_SPRITE_SONG(255, 100, 255),                  ITEM_SONG_NOCTURNE,    SNG_IC_POS(4, 1), SIZE_SONG},
+    {CREATE_SPRITE_SONG(255, 240, 100),                  ITEM_SONG_PRELUDE,     SNG_IC_POS(5, 1), SIZE_SONG},
 };
 
 static u8 color_product(u8 c1, u8 c2) {
@@ -146,14 +173,7 @@ void SpriteDraw(FileChooseContext* this, Sprite* sprite, int left, int top, int 
 u8 HasItem(s16 fileIndex, u8 item) {
     for (int i = 0; i < ARRAY_COUNT(Save_GetSaveMetaInfo(fileIndex)->inventoryItems); i += 1) {
         u8 it = Save_GetSaveMetaInfo(fileIndex)->inventoryItems[i];
-        if (
-            it == item ||
-            (item == ITEM_BOTTLE && it >= ITEM_BOTTLE && it <= ITEM_POE) ||
-            (item == ITEM_OCARINA_FAIRY && it == ITEM_OCARINA_TIME) || //temporary
-            (item == ITEM_HOOKSHOT && it == ITEM_LONGSHOT) || //temporary
-            (item == ITEM_MASK_BUNNY && it >= ITEM_WEIRD_EGG && it <= ITEM_SOLD_OUT) || //temporary
-            (item == ITEM_CLAIM_CHECK && it >= ITEM_POCKET_EGG && it <= ITEM_CLAIM_CHECK) //temporary
-        ) {
+        if (it == item || (item == ITEM_BOTTLE && it >= ITEM_BOTTLE && it <= ITEM_POE)) {
             return 1;
         }
     }
@@ -190,15 +210,207 @@ u8 HasItem(s16 fileIndex, u8 item) {
         return Save_GetSaveMetaInfo(fileIndex)->isMagicAcquired;
     }
 
+    if (item == ITEM_DOUBLE_MAGIC) {
+        return Save_GetSaveMetaInfo(fileIndex)->isDoubleMagicAcquired;
+    }
+
     if (item == ITEM_BRACELET) {
-        return ((Save_GetSaveMetaInfo(fileIndex)->upgrades & gUpgradeMasks[UPG_STRENGTH]) >> gUpgradeShifts[UPG_STRENGTH]) != 0;
+        return ((Save_GetSaveMetaInfo(fileIndex)->upgrades & gUpgradeMasks[UPG_STRENGTH]) >> gUpgradeShifts[UPG_STRENGTH]) == 1;
+    }
+
+    if (item == ITEM_GAUNTLETS_SILVER) {
+        return ((Save_GetSaveMetaInfo(fileIndex)->upgrades & gUpgradeMasks[UPG_STRENGTH]) >> gUpgradeShifts[UPG_STRENGTH]) == 2;
+    }
+
+    if (item == ITEM_GAUNTLETS_GOLD) {
+        return ((Save_GetSaveMetaInfo(fileIndex)->upgrades & gUpgradeMasks[UPG_STRENGTH]) >> gUpgradeShifts[UPG_STRENGTH]) == 3;
     }
 
     if (item == ITEM_SCALE_SILVER) {
-        return ((Save_GetSaveMetaInfo(fileIndex)->upgrades & gUpgradeMasks[UPG_SCALE]) >> gUpgradeShifts[UPG_SCALE]) != 0;
+        return ((Save_GetSaveMetaInfo(fileIndex)->upgrades & gUpgradeMasks[UPG_SCALE]) >> gUpgradeShifts[UPG_SCALE]) == 1;
+    }
+
+    if (item == ITEM_SCALE_GOLDEN) {
+        return ((Save_GetSaveMetaInfo(fileIndex)->upgrades & gUpgradeMasks[UPG_SCALE]) >> gUpgradeShifts[UPG_SCALE]) == 2;
     }
 
     return 0;
+}
+
+u8 ShouldRenderItem(s16 fileIndex, u8 item) {
+    //strength
+    if (item == ITEM_BRACELET && (HasItem(fileIndex, ITEM_GAUNTLETS_SILVER) != 0 || HasItem(fileIndex, ITEM_GAUNTLETS_GOLD) != 0)) {
+        return 0;
+    }
+
+    if (item == ITEM_GAUNTLETS_SILVER && HasItem(fileIndex, ITEM_GAUNTLETS_SILVER) == 0) {
+        return 0;
+    }
+
+    if (item == ITEM_GAUNTLETS_GOLD && HasItem(fileIndex, ITEM_GAUNTLETS_GOLD) == 0) {
+        return 0;
+    }
+
+    //magic
+    if (item == ITEM_SINGLE_MAGIC && HasItem(fileIndex, ITEM_DOUBLE_MAGIC) != 0) {
+        return 0;
+    }
+
+    if (item == ITEM_DOUBLE_MAGIC && HasItem(fileIndex, ITEM_DOUBLE_MAGIC) == 0) {
+        return 0;
+    }
+
+    //scales
+    if (item == ITEM_SCALE_SILVER && HasItem(fileIndex, ITEM_SCALE_GOLDEN) != 0) {
+        return 0;
+    }
+
+    if (item == ITEM_SCALE_GOLDEN && HasItem(fileIndex, ITEM_SCALE_GOLDEN) == 0) {
+        return 0;
+    }
+
+    //hookshot/longshot
+    if (item == ITEM_HOOKSHOT && HasItem(fileIndex, ITEM_LONGSHOT) != 0) {
+        return 0;
+    }
+
+    if (item == ITEM_LONGSHOT && HasItem(fileIndex, ITEM_LONGSHOT) == 0) {
+        return 0;
+    }
+
+    //ocarinas
+    if (item == ITEM_OCARINA_FAIRY && HasItem(fileIndex, ITEM_OCARINA_TIME) != 0) {
+        return 0;
+    }
+
+    if (item == ITEM_OCARINA_TIME && HasItem(fileIndex, ITEM_OCARINA_TIME) == 0) {
+        return 0;
+    }
+
+    //trade child
+    if (item == ITEM_WEIRD_EGG && HasItem(fileIndex, ITEM_WEIRD_EGG) == 0) {
+        return 0;
+    }
+
+    if (item == ITEM_CHICKEN && HasItem(fileIndex, ITEM_CHICKEN) == 0) {
+        return 0;
+    }
+
+    if (item == ITEM_LETTER_ZELDA && HasItem(fileIndex, ITEM_LETTER_ZELDA) == 0) {
+        return 0;
+    }
+
+    if (
+        item == ITEM_MASK_KEATON &&
+        (
+            HasItem(fileIndex, ITEM_WEIRD_EGG) != 0 ||
+            HasItem(fileIndex, ITEM_CHICKEN) != 0 ||
+            HasItem(fileIndex, ITEM_LETTER_ZELDA) != 0 ||
+            HasItem(fileIndex, ITEM_MASK_SKULL) != 0 ||
+            HasItem(fileIndex, ITEM_MASK_SPOOKY) != 0 ||
+            HasItem(fileIndex, ITEM_MASK_BUNNY) != 0 ||
+            HasItem(fileIndex, ITEM_MASK_GORON) != 0 ||
+            HasItem(fileIndex, ITEM_MASK_ZORA) != 0 ||
+            HasItem(fileIndex, ITEM_MASK_GERUDO) != 0 ||
+            HasItem(fileIndex, ITEM_MASK_TRUTH) != 0 ||
+            HasItem(fileIndex, ITEM_SOLD_OUT) != 0
+        )
+    ) {
+        return 0;
+    }
+
+    if (item == ITEM_MASK_SKULL && HasItem(fileIndex, ITEM_MASK_SKULL) == 0) {
+        return 0;
+    }
+
+    if (item == ITEM_MASK_SPOOKY && HasItem(fileIndex, ITEM_MASK_SPOOKY) == 0) {
+        return 0;
+    }
+
+    if (item == ITEM_MASK_BUNNY && HasItem(fileIndex, ITEM_MASK_BUNNY) == 0) {
+        return 0;
+    }
+
+    if (item == ITEM_MASK_GORON && HasItem(fileIndex, ITEM_MASK_GORON) == 0) {
+        return 0;
+    }
+
+    if (item == ITEM_MASK_ZORA && HasItem(fileIndex, ITEM_MASK_ZORA) == 0) {
+        return 0;
+    }
+
+    if (item == ITEM_MASK_GERUDO && HasItem(fileIndex, ITEM_MASK_GERUDO) == 0) {
+        return 0;
+    }
+
+    if (item == ITEM_MASK_TRUTH && HasItem(fileIndex, ITEM_MASK_TRUTH) == 0) {
+        return 0;
+    }
+
+    if (item == ITEM_SOLD_OUT && HasItem(fileIndex, ITEM_SOLD_OUT) == 0) {
+        return 0;
+    }
+
+    //trade adult
+    if (
+        item == ITEM_POCKET_EGG &&
+        (
+            HasItem(fileIndex, ITEM_POCKET_CUCCO) != 0 ||
+            HasItem(fileIndex, ITEM_COJIRO) != 0 ||
+            HasItem(fileIndex, ITEM_ODD_MUSHROOM) != 0 ||
+            HasItem(fileIndex, ITEM_ODD_POTION) != 0 ||
+            HasItem(fileIndex, ITEM_SAW) != 0 ||
+            HasItem(fileIndex, ITEM_SWORD_BROKEN) != 0 ||
+            HasItem(fileIndex, ITEM_PRESCRIPTION) != 0 ||
+            HasItem(fileIndex, ITEM_FROG) != 0 ||
+            HasItem(fileIndex, ITEM_EYEDROPS) != 0 ||
+            HasItem(fileIndex, ITEM_CLAIM_CHECK) != 0
+        )
+    ) {
+        return 0;
+    }
+
+    if (item == ITEM_POCKET_CUCCO && HasItem(fileIndex, ITEM_POCKET_CUCCO) == 0) {
+        return 0;
+    }
+    
+    if (item == ITEM_COJIRO && HasItem(fileIndex, ITEM_COJIRO) == 0) {
+        return 0;
+    }
+    
+    if (item == ITEM_ODD_MUSHROOM && HasItem(fileIndex, ITEM_ODD_MUSHROOM) == 0) {
+        return 0;
+    }
+    
+    if (item == ITEM_ODD_POTION && HasItem(fileIndex, ITEM_ODD_POTION) == 0) {
+        return 0;
+    }
+    
+    if (item == ITEM_SAW && HasItem(fileIndex, ITEM_SAW) == 0) {
+        return 0;
+    }
+    
+    if (item == ITEM_SWORD_BROKEN && HasItem(fileIndex, ITEM_SWORD_BROKEN) == 0) {
+        return 0;
+    }
+    
+    if (item == ITEM_PRESCRIPTION && HasItem(fileIndex, ITEM_PRESCRIPTION) == 0) {
+        return 0;
+    }
+    
+    if (item == ITEM_FROG && HasItem(fileIndex, ITEM_FROG) == 0) {
+        return 0;
+    }
+    
+    if (item == ITEM_EYEDROPS && HasItem(fileIndex, ITEM_EYEDROPS) == 0) {
+        return 0;
+    }
+    
+    if (item == ITEM_CLAIM_CHECK && HasItem(fileIndex, ITEM_CLAIM_CHECK) == 0) {
+        return 0;
+    }
+
+    return 1;
 }
 
 static void DrawItems(FileChooseContext* this, s16 fileIndex, u8 alpha) {
@@ -209,14 +421,16 @@ static void DrawItems(FileChooseContext* this, s16 fileIndex, u8 alpha) {
     for (int i = 0; i < ARRAY_COUNT(itemData); i += 1) {
         ItemData* data = &itemData[i];
 
-        if (HasItem(fileIndex, data->item) != 0) {
-            gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, data->color.r, data->color.g, data->color.b, color_product(data->color.a, alpha));
-        } else {
-            gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, color_product(data->color.r, DIM.r), color_product(data->color.g, DIM.g), color_product(data->color.b, DIM.b), color_product(color_product(data->color.a, DIM.a), alpha));
+        if (ShouldRenderItem(fileIndex, data->item) != 0) {
+            if (HasItem(fileIndex, data->item) != 0) {
+                gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, data->color.r, data->color.g, data->color.b, color_product(data->color.a, alpha));
+            } else {
+                gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, color_product(data->color.r, DIM.r), color_product(data->color.g, DIM.g), color_product(data->color.b, DIM.b), color_product(color_product(data->color.a, DIM.a), alpha));
+            }
+        
+            SpriteLoad(this, &(data->sprite));
+            SpriteDraw(this, &(data->sprite), LEFT_OFFSET + data->pos.left, TOP_OFFSET + data->pos.top, data->size.width, data->size.height);
         }
-
-        SpriteLoad(this, &(data->sprite));
-        SpriteDraw(this, &(data->sprite), LEFT_OFFSET + data->pos.left, TOP_OFFSET + data->pos.top, data->size.width, data->size.height);
     }
 
     gDPPipeSync(POLY_OPA_DISP++);

--- a/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -257,115 +257,115 @@ u8 HasItem(s16 fileIndex, u8 item) {
 
 u8 ShouldRenderItem(s16 fileIndex, u8 item) {
     //strength
-    if (item == ITEM_BRACELET && (HasItem(fileIndex, ITEM_GAUNTLETS_SILVER) != 0 || HasItem(fileIndex, ITEM_GAUNTLETS_GOLD) != 0)) {
+    if (item == ITEM_BRACELET && (HasItem(fileIndex, ITEM_GAUNTLETS_SILVER) || HasItem(fileIndex, ITEM_GAUNTLETS_GOLD))) {
         return 0;
     }
 
-    if (item == ITEM_GAUNTLETS_SILVER && HasItem(fileIndex, ITEM_GAUNTLETS_SILVER) == 0) {
+    if (item == ITEM_GAUNTLETS_SILVER && !HasItem(fileIndex, ITEM_GAUNTLETS_SILVER)) {
         return 0;
     }
 
-    if (item == ITEM_GAUNTLETS_GOLD && HasItem(fileIndex, ITEM_GAUNTLETS_GOLD) == 0) {
+    if (item == ITEM_GAUNTLETS_GOLD && !HasItem(fileIndex, ITEM_GAUNTLETS_GOLD)) {
         return 0;
     }
 
     //magic
-    if (item == ITEM_SINGLE_MAGIC && HasItem(fileIndex, ITEM_DOUBLE_MAGIC) != 0) {
+    if (item == ITEM_SINGLE_MAGIC && HasItem(fileIndex, ITEM_DOUBLE_MAGIC)) {
         return 0;
     }
 
-    if (item == ITEM_DOUBLE_MAGIC && HasItem(fileIndex, ITEM_DOUBLE_MAGIC) == 0) {
+    if (item == ITEM_DOUBLE_MAGIC && !HasItem(fileIndex, ITEM_DOUBLE_MAGIC)) {
         return 0;
     }
 
     //scales
-    if (item == ITEM_SCALE_SILVER && HasItem(fileIndex, ITEM_SCALE_GOLDEN) != 0) {
+    if (item == ITEM_SCALE_SILVER && HasItem(fileIndex, ITEM_SCALE_GOLDEN)) {
         return 0;
     }
 
-    if (item == ITEM_SCALE_GOLDEN && HasItem(fileIndex, ITEM_SCALE_GOLDEN) == 0) {
+    if (item == ITEM_SCALE_GOLDEN && !HasItem(fileIndex, ITEM_SCALE_GOLDEN)) {
         return 0;
     }
 
     //hookshot/longshot
-    if (item == ITEM_HOOKSHOT && HasItem(fileIndex, ITEM_LONGSHOT) != 0) {
+    if (item == ITEM_HOOKSHOT && HasItem(fileIndex, ITEM_LONGSHOT)) {
         return 0;
     }
 
-    if (item == ITEM_LONGSHOT && HasItem(fileIndex, ITEM_LONGSHOT) == 0) {
+    if (item == ITEM_LONGSHOT && !HasItem(fileIndex, ITEM_LONGSHOT)) {
         return 0;
     }
 
     //ocarinas
-    if (item == ITEM_OCARINA_FAIRY && HasItem(fileIndex, ITEM_OCARINA_TIME) != 0) {
+    if (item == ITEM_OCARINA_FAIRY && HasItem(fileIndex, ITEM_OCARINA_TIME)) {
         return 0;
     }
 
-    if (item == ITEM_OCARINA_TIME && HasItem(fileIndex, ITEM_OCARINA_TIME) == 0) {
+    if (item == ITEM_OCARINA_TIME && !HasItem(fileIndex, ITEM_OCARINA_TIME)) {
         return 0;
     }
 
     //trade child
-    if (item == ITEM_WEIRD_EGG && HasItem(fileIndex, ITEM_WEIRD_EGG) == 0) {
+    if (item == ITEM_WEIRD_EGG && !HasItem(fileIndex, ITEM_WEIRD_EGG)) {
         return 0;
     }
 
-    if (item == ITEM_CHICKEN && HasItem(fileIndex, ITEM_CHICKEN) == 0) {
+    if (item == ITEM_CHICKEN && !HasItem(fileIndex, ITEM_CHICKEN)) {
         return 0;
     }
 
-    if (item == ITEM_LETTER_ZELDA && HasItem(fileIndex, ITEM_LETTER_ZELDA) == 0) {
+    if (item == ITEM_LETTER_ZELDA && !HasItem(fileIndex, ITEM_LETTER_ZELDA)) {
         return 0;
     }
 
     if (
         item == ITEM_MASK_KEATON &&
         (
-            HasItem(fileIndex, ITEM_WEIRD_EGG) != 0 ||
-            HasItem(fileIndex, ITEM_CHICKEN) != 0 ||
-            HasItem(fileIndex, ITEM_LETTER_ZELDA) != 0 ||
-            HasItem(fileIndex, ITEM_MASK_SKULL) != 0 ||
-            HasItem(fileIndex, ITEM_MASK_SPOOKY) != 0 ||
-            HasItem(fileIndex, ITEM_MASK_BUNNY) != 0 ||
-            HasItem(fileIndex, ITEM_MASK_GORON) != 0 ||
-            HasItem(fileIndex, ITEM_MASK_ZORA) != 0 ||
-            HasItem(fileIndex, ITEM_MASK_GERUDO) != 0 ||
-            HasItem(fileIndex, ITEM_MASK_TRUTH) != 0 ||
-            HasItem(fileIndex, ITEM_SOLD_OUT) != 0
+            HasItem(fileIndex, ITEM_WEIRD_EGG) ||
+            HasItem(fileIndex, ITEM_CHICKEN) ||
+            HasItem(fileIndex, ITEM_LETTER_ZELDA) ||
+            HasItem(fileIndex, ITEM_MASK_SKULL) ||
+            HasItem(fileIndex, ITEM_MASK_SPOOKY) ||
+            HasItem(fileIndex, ITEM_MASK_BUNNY) ||
+            HasItem(fileIndex, ITEM_MASK_GORON) ||
+            HasItem(fileIndex, ITEM_MASK_ZORA) ||
+            HasItem(fileIndex, ITEM_MASK_GERUDO) ||
+            HasItem(fileIndex, ITEM_MASK_TRUTH) ||
+            HasItem(fileIndex, ITEM_SOLD_OUT)
         )
     ) {
         return 0;
     }
 
-    if (item == ITEM_MASK_SKULL && HasItem(fileIndex, ITEM_MASK_SKULL) == 0) {
+    if (item == ITEM_MASK_SKULL && !HasItem(fileIndex, ITEM_MASK_SKULL)) {
         return 0;
     }
 
-    if (item == ITEM_MASK_SPOOKY && HasItem(fileIndex, ITEM_MASK_SPOOKY) == 0) {
+    if (item == ITEM_MASK_SPOOKY && !HasItem(fileIndex, ITEM_MASK_SPOOKY)) {
         return 0;
     }
 
-    if (item == ITEM_MASK_BUNNY && HasItem(fileIndex, ITEM_MASK_BUNNY) == 0) {
+    if (item == ITEM_MASK_BUNNY && !HasItem(fileIndex, ITEM_MASK_BUNNY)) {
         return 0;
     }
 
-    if (item == ITEM_MASK_GORON && HasItem(fileIndex, ITEM_MASK_GORON) == 0) {
+    if (item == ITEM_MASK_GORON && !HasItem(fileIndex, ITEM_MASK_GORON)) {
         return 0;
     }
 
-    if (item == ITEM_MASK_ZORA && HasItem(fileIndex, ITEM_MASK_ZORA) == 0) {
+    if (item == ITEM_MASK_ZORA && !HasItem(fileIndex, ITEM_MASK_ZORA)) {
         return 0;
     }
 
-    if (item == ITEM_MASK_GERUDO && HasItem(fileIndex, ITEM_MASK_GERUDO) == 0) {
+    if (item == ITEM_MASK_GERUDO && !HasItem(fileIndex, ITEM_MASK_GERUDO)) {
         return 0;
     }
 
-    if (item == ITEM_MASK_TRUTH && HasItem(fileIndex, ITEM_MASK_TRUTH) == 0) {
+    if (item == ITEM_MASK_TRUTH && !HasItem(fileIndex, ITEM_MASK_TRUTH)) {
         return 0;
     }
 
-    if (item == ITEM_SOLD_OUT && HasItem(fileIndex, ITEM_SOLD_OUT) == 0) {
+    if (item == ITEM_SOLD_OUT && !HasItem(fileIndex, ITEM_SOLD_OUT)) {
         return 0;
     }
 
@@ -373,58 +373,58 @@ u8 ShouldRenderItem(s16 fileIndex, u8 item) {
     if (
         item == ITEM_POCKET_EGG &&
         (
-            HasItem(fileIndex, ITEM_POCKET_CUCCO) != 0 ||
-            HasItem(fileIndex, ITEM_COJIRO) != 0 ||
-            HasItem(fileIndex, ITEM_ODD_MUSHROOM) != 0 ||
-            HasItem(fileIndex, ITEM_ODD_POTION) != 0 ||
-            HasItem(fileIndex, ITEM_SAW) != 0 ||
-            HasItem(fileIndex, ITEM_SWORD_BROKEN) != 0 ||
-            HasItem(fileIndex, ITEM_PRESCRIPTION) != 0 ||
-            HasItem(fileIndex, ITEM_FROG) != 0 ||
-            HasItem(fileIndex, ITEM_EYEDROPS) != 0 ||
-            HasItem(fileIndex, ITEM_CLAIM_CHECK) != 0
+            HasItem(fileIndex, ITEM_POCKET_CUCCO) ||
+            HasItem(fileIndex, ITEM_COJIRO) ||
+            HasItem(fileIndex, ITEM_ODD_MUSHROOM) ||
+            HasItem(fileIndex, ITEM_ODD_POTION) ||
+            HasItem(fileIndex, ITEM_SAW) ||
+            HasItem(fileIndex, ITEM_SWORD_BROKEN) ||
+            HasItem(fileIndex, ITEM_PRESCRIPTION) ||
+            HasItem(fileIndex, ITEM_FROG) ||
+            HasItem(fileIndex, ITEM_EYEDROPS) ||
+            HasItem(fileIndex, ITEM_CLAIM_CHECK)
         )
     ) {
         return 0;
     }
 
-    if (item == ITEM_POCKET_CUCCO && HasItem(fileIndex, ITEM_POCKET_CUCCO) == 0) {
+    if (item == ITEM_POCKET_CUCCO && !HasItem(fileIndex, ITEM_POCKET_CUCCO)) {
         return 0;
     }
     
-    if (item == ITEM_COJIRO && HasItem(fileIndex, ITEM_COJIRO) == 0) {
+    if (item == ITEM_COJIRO && !HasItem(fileIndex, ITEM_COJIRO)) {
         return 0;
     }
     
-    if (item == ITEM_ODD_MUSHROOM && HasItem(fileIndex, ITEM_ODD_MUSHROOM) == 0) {
+    if (item == ITEM_ODD_MUSHROOM && !HasItem(fileIndex, ITEM_ODD_MUSHROOM)) {
         return 0;
     }
     
-    if (item == ITEM_ODD_POTION && HasItem(fileIndex, ITEM_ODD_POTION) == 0) {
+    if (item == ITEM_ODD_POTION && !HasItem(fileIndex, ITEM_ODD_POTION)) {
         return 0;
     }
     
-    if (item == ITEM_SAW && HasItem(fileIndex, ITEM_SAW) == 0) {
+    if (item == ITEM_SAW && !HasItem(fileIndex, ITEM_SAW)) {
         return 0;
     }
     
-    if (item == ITEM_SWORD_BROKEN && HasItem(fileIndex, ITEM_SWORD_BROKEN) == 0) {
+    if (item == ITEM_SWORD_BROKEN && !HasItem(fileIndex, ITEM_SWORD_BROKEN)) {
         return 0;
     }
     
-    if (item == ITEM_PRESCRIPTION && HasItem(fileIndex, ITEM_PRESCRIPTION) == 0) {
+    if (item == ITEM_PRESCRIPTION && !HasItem(fileIndex, ITEM_PRESCRIPTION)) {
         return 0;
     }
     
-    if (item == ITEM_FROG && HasItem(fileIndex, ITEM_FROG) == 0) {
+    if (item == ITEM_FROG && !HasItem(fileIndex, ITEM_FROG)) {
         return 0;
     }
     
-    if (item == ITEM_EYEDROPS && HasItem(fileIndex, ITEM_EYEDROPS) == 0) {
+    if (item == ITEM_EYEDROPS && !HasItem(fileIndex, ITEM_EYEDROPS)) {
         return 0;
     }
     
-    if (item == ITEM_CLAIM_CHECK && HasItem(fileIndex, ITEM_CLAIM_CHECK) == 0) {
+    if (item == ITEM_CLAIM_CHECK && !HasItem(fileIndex, ITEM_CLAIM_CHECK)) {
         return 0;
     }
 
@@ -448,8 +448,8 @@ static void DrawItems(FileChooseContext* this, s16 fileIndex, u8 alpha) {
     for (int i = 0; i < ARRAY_COUNT(itemData); i += 1) {
         ItemData* data = &itemData[i];
 
-        if (ShouldRenderItem(fileIndex, data->item) != 0) {
-            if (HasItem(fileIndex, data->item) != 0) {
+        if (ShouldRenderItem(fileIndex, data->item)) {
+            if (HasItem(fileIndex, data->item)) {
                 gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, data->color.r, data->color.g, data->color.b, color_product(data->color.a, alpha));
             } else {
                 gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, color_product(data->color.r, DIM.r), color_product(data->color.g, DIM.g), color_product(data->color.b, DIM.b), color_product(color_product(data->color.a, DIM.a), alpha));


### PR DESCRIPTION
Adds the "More info in file select" enhancement which shows the items that you've obtained similarly to how n64 randomizer does it.

Here is a 100% vanilla save file:
![image](https://github.com/HarbourMasters/Shipwright/assets/72659707/31f8f37d-db12-417c-9ce8-9b08cfd5fe60)

Here is a new vanilla save file:
![Screenshot_3](https://github.com/HarbourMasters/Shipwright/assets/72659707/db361624-1eef-4148-aa33-cbf74fbd58a4)

Here is a new randomizer save file:
![Screenshot_2](https://github.com/HarbourMasters/Shipwright/assets/72659707/fe1b1d97-bc05-4a5c-94fe-0a09a6d03c5f)

This doesn't apply when copying or erasing save files:
![image](https://github.com/HarbourMasters/Shipwright/assets/72659707/eec4e59a-d15b-40d7-8df2-18015506b5ab)

This PR also changes the spoiler log seed hash icons to only appear on quest selection and the file hash icons to appear at the top when a randomizer save file is selected.