### PR TITLE
Tweak: Better Easy Pause Buffer input tracking

### DIFF
--- a/soh/soh/Enhancements/bootcommands.c
+++ b/soh/soh/Enhancements/bootcommands.c
@@ -26,6 +26,8 @@ void BootCommands_Init()
     CVarClear("gOnFileSelectNameEntry"); // Clear when soh is killed on the file name entry page
     CVarClear("gBetterDebugWarpScreenMQMode");
     CVarClear("gBetterDebugWarpScreenMQModeScene");
+    CVarClear("gCheatEasyPauseBufferLastInputs");
+    CVarClear("gCheatEasyPauseBufferTimer");
 #if defined(__SWITCH__) || defined(__WIIU__)
     CVarRegisterInteger("gControlNav", 1); // always enable controller nav on switch/wii u
 #endif

--- a/soh/src/code/padmgr.c
+++ b/soh/src/code/padmgr.c
@@ -287,6 +287,13 @@ void PadMgr_ProcessInputs(PadMgr* padMgr) {
                 Fault_AddHungupAndCrash(__FILE__, __LINE__);
         }
 
+        // When 3 frames are left on easy pause buffer, re-apply the last held inputs to the prev inputs
+        // to compute the pressed difference. This makes it so previously held inputs are continued as "held",
+        // but new inputs when unpausing are "pressed" out of the pause menu.
+        if (CVarGetInteger("gCheatEasyPauseBufferTimer", 0) == 3) {
+            input->prev.button = CVarGetInteger("gCheatEasyPauseBufferLastInputs", 0);
+        }
+
         buttonDiff = input->prev.button ^ input->cur.button;
         input->press.button |= (u16)(buttonDiff & input->cur.button);
         input->rel.button |= (u16)(buttonDiff & input->prev.button);
@@ -297,12 +304,6 @@ void PadMgr_ProcessInputs(PadMgr* padMgr) {
 
     uint8_t rumble = (padMgr->rumbleEnable[0] > 0);
     OTRControllerCallback(rumble);
-
-    if (CVarGetInteger("gPauseBufferBlockInputFrame", 0)) {
-        ControllerBlockGameInput(PAUSE_BUFFER_INPUT_BLOCK_ID);
-    } else {
-        ControllerUnblockGameInput(PAUSE_BUFFER_INPUT_BLOCK_ID);
-    }
 
     PadMgr_UnlockPadData(padMgr);
 }

--- a/soh/src/code/z_kaleido_setup.c
+++ b/soh/src/code/z_kaleido_setup.c
@@ -18,15 +18,24 @@ void KaleidoSetup_Update(PlayState* play) {
         play->shootingGalleryStatus <= 1 && gSaveContext.magicState != 8 && gSaveContext.magicState != 9 &&
         (play->sceneNum != SCENE_BOWLING || !Flags_GetSwitch(play, 0x38))) {
 
-        if (CVarGetInteger("gCheatEasyPauseBufferFrameAdvance", 0) == 2 && !CHECK_BTN_ALL(input->press.button, BTN_START)) {
-            CVarSetInteger("gCheatEasyPauseBufferFrameAdvance", 0);
+        u8 easyPauseBufferEnabled = CVarGetInteger("gCheatEasyPauseBufferEnabled", 0);
+        u8 easyPauseBufferTimer = CVarGetInteger("gCheatEasyPauseBufferTimer", 0);
+
+        // If start is not seen as pressed on the 2nd to last frame then we should end the easy frame advance flow
+        if (easyPauseBufferEnabled && easyPauseBufferTimer == 2 &&
+            !CHECK_BTN_ALL(input->press.button, BTN_START)) {
+            CVarSetInteger("gCheatEasyPauseBufferTimer", 0);
         }
 
         if (CHECK_BTN_ALL(input->cur.button, BTN_L) && CHECK_BTN_ALL(input->press.button, BTN_CUP)) {
             if (BREG(0)) {
                 pauseCtx->debugState = 3;
             }
-        } else if ((CHECK_BTN_ALL(input->press.button, BTN_START) && !CVarGetInteger("gCheatEasyPauseBufferFrameAdvance", 0)) || CVarGetInteger("gCheatEasyPauseBufferFrameAdvance", 0) == 1) {
+        } else if ((CHECK_BTN_ALL(input->press.button, BTN_START) && (!easyPauseBufferEnabled || !easyPauseBufferTimer)) ||
+            (easyPauseBufferEnabled && easyPauseBufferTimer == 1)) { // Force Kaleido open when easy pause buffer reaches 0
+            // Remember last held buttons for pause buffer cheat (minus start so easy frame advance works)
+            CVarSetInteger("gCheatEasyPauseBufferLastInputs", input->cur.button & ~(BTN_START));
+
             gSaveContext.unk_13EE = gSaveContext.unk_13EA;
 
             if (CHECK_BTN_ALL(input->cur.button, BTN_L))

--- a/soh/src/code/z_play.c
+++ b/soh/src/code/z_play.c
@@ -1754,12 +1754,11 @@ time_t Play_GetRealTime() {
 void Play_Main(GameState* thisx) {
     PlayState* play = (PlayState*)thisx;
 
-    if (CVarGetInteger("gCheatEasyPauseBufferFrameAdvance", 0)) {
-        CVarSetInteger("gCheatEasyPauseBufferFrameAdvance", CVarGetInteger("gCheatEasyPauseBufferFrameAdvance", 0) - 1);
+    // Decrease the easy pause buffer timer every frame
+    if (CVarGetInteger("gCheatEasyPauseBufferTimer", 0) > 0) {
+        CVarSetInteger("gCheatEasyPauseBufferTimer", CVarGetInteger("gCheatEasyPauseBufferTimer", 0) - 1);
     }
-    if (CVarGetInteger("gPauseBufferBlockInputFrame", 0)) {
-        CVarSetInteger("gPauseBufferBlockInputFrame", CVarGetInteger("gPauseBufferBlockInputFrame", 0) - 1);
-    }
+
     if (play->envCtx.unk_EE[2] == 0 && CVarGetInteger("gLetItSnow", 0)) {
         play->envCtx.unk_EE[3] = 64;
         Actor_Spawn(&gPlayState->actorCtx, gPlayState, ACTOR_OBJECT_KANKYO, 0, 0, 0, 0, 0, 0, 3, 0);

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
@@ -3649,10 +3649,8 @@ void KaleidoScope_Update(PlayState* play)
                     if (CHECK_BTN_ALL(input->press.button, BTN_START) ||
                         (CHECK_BTN_ALL(input->press.button, BTN_B) && gSaveContext.isBossRush)) {
                         if (CVarGetInteger("gCheatEasyPauseBufferEnabled", 0) || CVarGetInteger("gCheatEasyInputBufferingEnabled", 0)) {
-                            CVarSetInteger("gPauseBufferBlockInputFrame", 9);
-                        }
-                        if (CVarGetInteger("gCheatEasyPauseBufferEnabled", 0)) {
-                            CVarSetInteger("gCheatEasyPauseBufferFrameAdvance", 13);
+                            // Easy pause buffer is 13 frames, 12 for kaledio to end, and one more to advance a single frame
+                            CVarSetInteger("gCheatEasyPauseBufferTimer", 13);
                         }
                         Interface_SetDoAction(play, DO_ACTION_NONE);
                         pauseCtx->state = 0x12;


### PR DESCRIPTION
We have two cheats to help with buffering inputs during un-pause for frame perfect tricks. The implementation for this had limitations and conflicts.

### How it currently works
The vanilla game treats held inputs from before pausing as still held, and newly held inputs when un-pause finishes as ignored (unless frame perfect).

Enabling "Easy Input Buffering" makes it so during un-pause, any held inputs are triggered as pressed on first frame. This worked by blocking input from the pad manager during the un-pause. This has the effect that once unblocked, any held buttons will by seen as "newly pressed". This was timed such that it would happen on the first game frame after un-pause is finished. Coupled with "Easy Frame Advance" we would wait one extra frame then re-trigger the pause menu if start was held.

### The Problems
There are two main issues with this approach:
1. Any held inputs from before the pause (like Z-Target) are treated as repressed, messing up certain tricks like chu mega flips.
2. Combining these cheats with simulated input lag would cause the pause menu to re-open even if you didn't hold start, as input blocking does not clear the controller input buffer (meaning blocking for 30 seconds means that on first frame(s) after unblock, simulated lag will replay the inputs from before the blocking.

### The Proposed Changes
Instead of relying on input blocking, I have adjusted the flow to remember all held inputs when pausing, and then at the last frame of un-pause, those last held inputs are re-assigned to the pad manager `prev` inputs. This addresses both problems above by maintaining previously held inputs, and treating newly held inputs as "pressed" on first game frame, making it so inputs are dropped, and simulated lag has no impact on the behavior.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/781190072.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/781190073.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/781190074.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/781190075.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/781190076.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/781190077.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/781190078.zip)
<!--- section:artifacts:end -->