### PR TITLE
Fix: Granny empty bottle check

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -3973,7 +3973,10 @@ void RandomizerSettingsWindow::DrawElement() {
                     "A Giant's Knife and a pack of Bombchus will be added to the item pool, and "
                     "one of the bottles will contain a Blue Potion.\n\n"
                     "On (no hints) - Salesmen will be included but won't tell you what you'll get.\n"
-                    "On (with hints) - Salesmen will be included and you'll know what you're buying."
+                    "On (with hints) - Salesmen will be included and you'll know what you're buying.\n"
+                    "\n"
+                    "Granny's item will only be offered after you have traded in the Odd Mushroom when Shuffle Adult Trade is on. "
+                    "Otherwise when off, you will need to have found the Claim Check to buy her item (simulating the trade quest is complete)."
                 );
                 UIWidgets::EnhancementCombobox("gRandomizeShuffleMerchants", randoShuffleMerchants, RO_SHUFFLE_MERCHANTS_OFF);
 

--- a/soh/src/overlays/actors/ovl_En_Ds/z_en_ds.c
+++ b/soh/src/overlays/actors/ovl_En_Ds/z_en_ds.c
@@ -174,11 +174,20 @@ void EnDs_OfferOddPotion(EnDs* this, PlayState* play) {
     }
 }
 
+u8 EnDs_RandoCanGetGrannyItem() {
+    return gSaveContext.n64ddFlag && Randomizer_GetSettingValue(RSK_SHUFFLE_MERCHANTS) != RO_SHUFFLE_MERCHANTS_OFF &&
+           !Flags_GetRandomizerInf(RAND_INF_MERCHANTS_GRANNYS_SHOP) &&
+           // Traded odd mushroom when adult trade is on
+           ((Randomizer_GetSettingValue(RSK_SHUFFLE_ADULT_TRADE) && (gSaveContext.itemGetInf[3] & 1)) ||
+            // Found claim check when adult trade is off
+            (!Randomizer_GetSettingValue(RSK_SHUFFLE_ADULT_TRADE) &&
+             INV_CONTENT(ITEM_CLAIM_CHECK) == ITEM_CLAIM_CHECK));
+}
+
 s32 EnDs_CheckRupeesAndBottle() {
     if (gSaveContext.rupees < 100) {
         return 0;
-    } else if (gSaveContext.n64ddFlag && Randomizer_GetSettingValue(RSK_SHUFFLE_MERCHANTS) != RO_SHUFFLE_MERCHANTS_OFF &&
-        !Flags_GetRandomizerInf(RAND_INF_MERCHANTS_GRANNYS_SHOP)) {
+    } else if (EnDs_RandoCanGetGrannyItem()) { // Allow buying the rando item regardless of having a bottle
         return 2;
     } else if (Inventory_HasEmptyBottle() == 0) {
         return 1;
@@ -189,18 +198,14 @@ s32 EnDs_CheckRupeesAndBottle() {
 
 void EnDs_GiveBluePotion(EnDs* this, PlayState* play) {
     if (Actor_HasParent(&this->actor, play)) {
-        if (gSaveContext.n64ddFlag && Randomizer_GetSettingValue(RSK_SHUFFLE_MERCHANTS) != RO_SHUFFLE_MERCHANTS_OFF &&
-            (Randomizer_GetSettingValue(RSK_SHUFFLE_ADULT_TRADE) || INV_CONTENT(ITEM_CLAIM_CHECK) == ITEM_CLAIM_CHECK) &&
-            !Flags_GetRandomizerInf(RAND_INF_MERCHANTS_GRANNYS_SHOP)) {
+        if (EnDs_RandoCanGetGrannyItem()) {
             Flags_SetRandomizerInf(RAND_INF_MERCHANTS_GRANNYS_SHOP);
         }
 
         this->actor.parent = NULL;
         this->actionFunc = EnDs_Talk;
     } else {
-        if (gSaveContext.n64ddFlag && Randomizer_GetSettingValue(RSK_SHUFFLE_MERCHANTS) != RO_SHUFFLE_MERCHANTS_OFF &&
-            (Randomizer_GetSettingValue(RSK_SHUFFLE_ADULT_TRADE) || INV_CONTENT(ITEM_CLAIM_CHECK) == ITEM_CLAIM_CHECK) &&
-            !Flags_GetRandomizerInf(RAND_INF_MERCHANTS_GRANNYS_SHOP)) {
+        if (EnDs_RandoCanGetGrannyItem()) {
             GetItemEntry entry = Randomizer_GetItemFromKnownCheck(RC_KAK_GRANNYS_SHOP, GI_POTION_BLUE);
             GiveItemEntryFromActor(&this->actor, play, entry, 10000.0f, 50.0f);
         } else {
@@ -226,9 +231,7 @@ void EnDs_OfferBluePotion(EnDs* this, PlayState* play) {
                         this->actor.flags &= ~ACTOR_FLAG_WILL_TALK;
                         GetItemEntry itemEntry;
 
-                        if (gSaveContext.n64ddFlag && Randomizer_GetSettingValue(RSK_SHUFFLE_MERCHANTS) != RO_SHUFFLE_MERCHANTS_OFF &&
-                            (Randomizer_GetSettingValue(RSK_SHUFFLE_ADULT_TRADE) || INV_CONTENT(ITEM_CLAIM_CHECK) == ITEM_CLAIM_CHECK) &&
-                            !Flags_GetRandomizerInf(RAND_INF_MERCHANTS_GRANNYS_SHOP)) {
+                        if (EnDs_RandoCanGetGrannyItem()) {
                             itemEntry = Randomizer_GetItemFromKnownCheck(RC_KAK_GRANNYS_SHOP, GI_POTION_BLUE);
                             GiveItemEntryFromActor(&this->actor, play, itemEntry, 10000.0f, 50.0f);
                         } else {
@@ -258,8 +261,10 @@ void EnDs_Wait(EnDs* this, PlayState* play) {
             Audio_PlaySoundGeneral(NA_SE_SY_TRE_BOX_APPEAR, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
             player->actor.textId = 0x504A;
             this->actionFunc = EnDs_OfferOddPotion;
-        } else if ((gSaveContext.n64ddFlag && Randomizer_GetSettingValue(RSK_SHUFFLE_ADULT_TRADE) == RO_GENERIC_OFF) ||
-            gSaveContext.itemGetInf[3] & 1) {
+        } else if (
+            // Always offer blue potion when adult trade is off
+            (gSaveContext.n64ddFlag && Randomizer_GetSettingValue(RSK_SHUFFLE_ADULT_TRADE) == RO_GENERIC_OFF) ||
+            gSaveContext.itemGetInf[3] & 1) { // Traded odd mushroom
             player->actor.textId = 0x500C;
             this->actionFunc = EnDs_OfferBluePotion;
         } else {


### PR DESCRIPTION
When Merchant shuffle is on, and Adult Trade shuffle is off, if you have not found the claim check yet the rando item trade offer should be skipped, and the Blue potion refill flow happens instead. The bug was that the "can buy" logic was missing a check for claim check, which meant that Granny was offering a blue potion refill, but the empty bottle check was skipped.

This PR abstracts the "can buy rando" item logic into a method and re-uses that in all the relevant places to avoid any inconsistent logic.

The tooltip for shuffle merchants is also updated to call out the behavior when shuffle adult trade is on/off.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/787446878.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/787446879.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/787446880.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/787446881.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/787446882.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/787446883.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/787446884.zip)
<!--- section:artifacts:end -->