### PR TITLE
Fix: Add missing hashes to launch scripts

### DIFF
--- a/scripts/linux/appimage/soh.sh
+++ b/scripts/linux/appimage/soh.sh
@@ -69,6 +69,14 @@ while [[ (! -e "$SHIP_HOME"/oot.otr) || (! -e "$SHIP_HOME"/oot-mq.otr) ]]; do
                         continue
                     fi
                     ;;
+                cfecfdc58d650e71a200c81f033de4e6d617a9f6)
+                    if [[ ! -e "$SHIP_HOME"/oot-mq.otr ]]; then
+                        ROM=GC_MQ_D
+                        OTRNAME="oot-mq.otr"
+                    else
+                        continue
+                    fi
+                    ;;
                 517bd9714c73cb96c21e7c2ef640d7b55186102f)
                     if [[ ! -e "$SHIP_HOME"/oot-mq.otr ]]; then
                         ROM=GC_MQ_D

--- a/soh/macosx/soh-macos.sh
+++ b/soh/macosx/soh-macos.sh
@@ -44,9 +44,13 @@ if [ ! -e "$SHIP_HOME"/oot.otr ] || [ ! -e "$SHIP_HOME"/oot-mq.otr ]; then
 					ROM_TYPE=0;;
 				0227d7c0074f2d0ac935631990da8ec5914597b4)
 					ROM_TYPE=0;;
+				cfbb98d392e4a9d39da8285d10cbef3974c2f012)
+					ROM_TYPE=0;;
 				50bebedad9e0f10746a52b07239e47fa6c284d03)
 					ROM_TYPE=1;;
 				079b855b943d6ad8bd1eb026c0ed169ecbdac7da)
+					ROM_TYPE=1;;
+				cfecfdc58d650e71a200c81f033de4e6d617a9f6)
 					ROM_TYPE=1;;
 				517bd9714c73cb96c21e7c2ef640d7b55186102f)
 					ROM_TYPE=1;;
@@ -128,6 +132,9 @@ if [ ! -e "$SHIP_HOME"/oot.otr ] || [ ! -e "$SHIP_HOME"/oot-mq.otr ]; then
 				ROM=GC_MQ_D
 				OTRNAME="oot-mq.otr";;
 			079b855b943d6ad8bd1eb026c0ed169ecbdac7da)
+				ROM=GC_MQ_D
+				OTRNAME="oot-mq.otr";;
+			cfecfdc58d650e71a200c81f033de4e6d617a9f6)
 				ROM=GC_MQ_D
 				OTRNAME="oot-mq.otr";;
 			517bd9714c73cb96c21e7c2ef640d7b55186102f)


### PR DESCRIPTION
The PAL 1.1 hash was missing from Mac's launch script in the copy step, but was there in the extract step. This meant users couldn't import the rom, but if they manually copied it to the app support folder, it would extract correctly.

This adds the missing hash to the copy step.

Also for Mac and Linux one of the hashes listed in the readme was missing entirely from the launch scripts, so this adds those as well to match the readme.

(Split off from https://github.com/HarbourMasters/Shipwright/pull/3042 as these changes are more suited/desired for a Sulu bugfix)

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/790185893.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/790185894.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/790185896.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/790185898.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/790185899.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/790185900.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/790185901.zip)
<!--- section:artifacts:end -->