### PR TITLE
Tweak: Refactor 3D drops handling

### DIFF
--- a/soh/src/code/z_en_item00.c
+++ b/soh/src/code/z_en_item00.c
@@ -372,14 +372,31 @@ void EnItem00_Init(Actor* thisx, PlayState* play) {
         case ITEM00_RUPEE_GREEN:
         case ITEM00_RUPEE_BLUE:
         case ITEM00_RUPEE_RED:
+            Actor_SetScale(&this->actor, 0.015f);
+            this->scale = 0.015f;
+            yOffset = 750.0f;
             break;
         case ITEM00_SMALL_KEY:
             this->unk_158 = 0;
+            Actor_SetScale(&this->actor, 0.03f);
+            this->scale = 0.03f;
+            if (!gSaveContext.n64ddFlag) {
+                yOffset = 350.0f;
+            } else {
+                yOffset = 430.0f;
+            }
             break;
         case ITEM00_HEART_PIECE:
             this->unk_158 = 0;
+            yOffset = 650.0f;
+            Actor_SetScale(&this->actor, 0.02f);
+            this->scale = 0.02f;
             break;
         case ITEM00_HEART:
+            this->actor.home.rot.z = Rand_CenteredFloat(65535.0f);
+            yOffset = 430.0f;
+            Actor_SetScale(&this->actor, 0.02f);
+            this->scale = 0.02f;
             break;
         case ITEM00_HEART_CONTAINER:
             yOffset = 430.0f;
@@ -388,9 +405,17 @@ void EnItem00_Init(Actor* thisx, PlayState* play) {
             this->scale = 0.02f;
             break;
         case ITEM00_ARROWS_SINGLE:
+            yOffset = 400.0f;
+            Actor_SetScale(&this->actor, 0.02f);
+            this->scale = 0.02f;
+            break;
         case ITEM00_ARROWS_SMALL:
         case ITEM00_ARROWS_MEDIUM:
         case ITEM00_ARROWS_LARGE:
+            Actor_SetScale(&this->actor, 0.035f);
+            this->scale = 0.035f;
+            yOffset = 250.0f;
+            break;
         case ITEM00_BOMBS_A:
         case ITEM00_BOMBS_B:
         case ITEM00_NUTS:
@@ -398,11 +423,26 @@ void EnItem00_Init(Actor* thisx, PlayState* play) {
         case ITEM00_MAGIC_SMALL:
         case ITEM00_SEEDS:
         case ITEM00_BOMBS_SPECIAL:
+            Actor_SetScale(&this->actor, 0.03f);
+            this->scale = 0.03f;
+            yOffset = 320.0f;
+            break;
         case ITEM00_MAGIC_LARGE:
+            Actor_SetScale(&this->actor, 0.045 - 1e-10);
+            this->scale = 0.045 - 1e-10;
+            yOffset = 320.0f;
+            break;
         case ITEM00_RUPEE_ORANGE:
+            Actor_SetScale(&this->actor, 0.045 - 1e-10);
+            this->scale = 0.045 - 1e-10;
+            yOffset = 750.0f;
+            break;
         case ITEM00_RUPEE_PURPLE:
+            Actor_SetScale(&this->actor, 0.03f);
+            this->scale = 0.03f;
+            yOffset = 750.0f;
+            break;
         case ITEM00_FLEXIBLE:
-        case ITEM00_BOMBCHU:
             yOffset = 500.0f;
             Actor_SetScale(&this->actor, 0.01f);
             this->scale = 0.01f;
@@ -431,6 +471,11 @@ void EnItem00_Init(Actor* thisx, PlayState* play) {
             yOffset = 0.0f;
             shadowScale = 0.6f;
             this->actor.world.rot.x = 0x4000;
+            break;
+        case ITEM00_BOMBCHU:
+            yOffset = 320.0f;
+            Actor_SetScale(&this->actor, 0.03f);
+            this->scale = 0.03f;
             break;
     }
 
@@ -551,41 +596,29 @@ void EnItem00_Destroy(Actor* thisx, PlayState* play) {
 }
 
 void func_8001DFC8(EnItem00* this, PlayState* play) {
-
-    if (!CVarGetInteger("gNewDrops", 0)){
-        if ((this->actor.params <= ITEM00_RUPEE_RED) || ((this->actor.params == ITEM00_HEART) && (this->unk_15A < 0)) ||
-            (this->actor.params == ITEM00_HEART_PIECE)) {
-            this->actor.shape.rot.y += 960;
-        } else {
-            if ((this->actor.params >= ITEM00_SHIELD_DEKU) && (this->actor.params != ITEM00_BOMBS_SPECIAL) &&
-                (this->actor.params != ITEM00_BOMBCHU)) {
-                if (this->unk_15A == -1) {
-                    if (Math_SmoothStepToS(&this->actor.shape.rot.x, this->actor.world.rot.x - 0x4000, 2, 3000, 1500) ==
-                        0) {
-                        this->unk_15A = -2;
-                    }
-                } else {
-                    if (Math_SmoothStepToS(&this->actor.shape.rot.x, -this->actor.world.rot.x - 0x4000, 2, 3000, 1500) ==
-                        0) {
-                        this->unk_15A = -1;
-                    }
+    if ((this->actor.params <= ITEM00_RUPEE_RED) || ((this->actor.params == ITEM00_HEART) && (this->unk_15A < 0)) ||
+        (this->actor.params == ITEM00_HEART_PIECE)) {
+        this->actor.shape.rot.y += 960;
+    } else {
+        if ((this->actor.params >= ITEM00_SHIELD_DEKU) && (this->actor.params != ITEM00_BOMBS_SPECIAL) &&
+            (this->actor.params != ITEM00_BOMBCHU)) {
+            if (this->unk_15A == -1) {
+                if (Math_SmoothStepToS(&this->actor.shape.rot.x, this->actor.world.rot.x - 0x4000, 2, 3000, 1500) ==
+                    0) {
+                    this->unk_15A = -2;
                 }
-                Math_SmoothStepToS(&this->actor.world.rot.x, 0, 2, 2500, 500);
+            } else {
+                if (Math_SmoothStepToS(&this->actor.shape.rot.x, -this->actor.world.rot.x - 0x4000, 2, 3000, 1500) ==
+                    0) {
+                    this->unk_15A = -1;
+                }
             }
+            Math_SmoothStepToS(&this->actor.world.rot.x, 0, 2, 2500, 500);
         }
     }
 
     if (this->actor.params == ITEM00_HEART_PIECE) {
-        if (CVarGetInteger("gNewDrops", 0) && !gSaveContext.n64ddFlag) {
-            this->actor.shape.yOffset = Math_SinS(this->actor.shape.rot.y) * 20.0f + 50.0f;
-        } else {
-            this->actor.shape.yOffset = Math_SinS(this->actor.shape.rot.y) * 150.0f + 850.0f;
-        }
-    }
-
-    if (gSaveContext.n64ddFlag && this->actor.params == ITEM00_SMALL_KEY) {
-        this->actor.shape.yOffset = 600.0f;
-        this->actor.shape.rot.y += 960;
+        this->actor.shape.yOffset = Math_SinS(this->actor.shape.rot.y) * 150.0f + 850.0f;
     }
 
     Math_SmoothStepToF(&this->actor.speedXZ, 0.0f, 1.0f, 0.5f, 0.0f);
@@ -613,7 +646,7 @@ void func_8001E1C8(EnItem00* this, PlayState* play) {
     f32 originalVelocity;
     Vec3f effectPos;
 
-    if (this->actor.params <= ITEM00_RUPEE_RED && !CVarGetInteger("gNewDrops", 0)) {
+    if (this->actor.params <= ITEM00_RUPEE_RED) {
         this->actor.shape.rot.y += 960;
     }
 
@@ -715,12 +748,13 @@ void func_8001E5C8(EnItem00* this, PlayState* play) {
 
     this->actor.world.pos = player->actor.world.pos;
 
-    if (this->actor.params <= ITEM00_RUPEE_RED && !CVarGetInteger("gNewDrops", 0)) {
+    if (this->actor.params <= ITEM00_RUPEE_RED) {
         this->actor.shape.rot.y += 960;
-    } else if (this->actor.params == ITEM00_HEART && !CVarGetInteger("gNewDrops", 0)) {
+    } else if (this->actor.params == ITEM00_HEART) {
         this->actor.shape.rot.y = 0;
     }
 
+    // bounces up and down above player's head
     this->actor.world.pos.y += 40.0f + Math_SinS(this->unk_15A * 15000) * (this->unk_15A * 0.3f);
 
     if (LINK_IS_ADULT) {
@@ -741,21 +775,17 @@ void EnItem00_Update(Actor* thisx, PlayState* play) {
     EnItem00* this = (EnItem00*)thisx;
     s32 pad;
 
-	// OTRTODO: remove special case for bombchu when its 2D drop is implemented
-    if (CVarGetInteger("gNewDrops", 0) || this->actor.params == ITEM00_BOMBCHU) { //set the rotation system on selected model only :)
-        if ((this->actor.params == ITEM00_RUPEE_GREEN) || (this->actor.params == ITEM00_RUPEE_BLUE) ||
-            (this->actor.params == ITEM00_RUPEE_RED) || (this->actor.params == ITEM00_ARROWS_SINGLE) || 
-            (this->actor.params == ITEM00_ARROWS_SMALL) || (this->actor.params == ITEM00_ARROWS_MEDIUM) ||
-            (this->actor.params == ITEM00_ARROWS_LARGE) || (this->actor.params == ITEM00_BOMBS_A) || 
-            (this->actor.params == ITEM00_BOMBS_B) || (this->actor.params == ITEM00_NUTS) || 
-            (this->actor.params == ITEM00_MAGIC_SMALL) || (this->actor.params == ITEM00_SEEDS) ||  
-            (this->actor.params == ITEM00_MAGIC_LARGE) || (this->actor.params == ITEM00_HEART) || 
-            (this->actor.params == ITEM00_BOMBS_SPECIAL) || this->actor.params == ITEM00_HEART_PIECE ||
-            (this->actor.params == ITEM00_BOMBCHU)) {
+    // Rotate some drops when 3D drops are on, otherwise reset rotation back to 0 for billboard effect
+    if ((this->actor.params == ITEM00_HEART && this->unk_15A >= 0) ||
+        (this->actor.params >= ITEM00_ARROWS_SMALL && this->actor.params <= ITEM00_SMALL_KEY) ||
+        this->actor.params == ITEM00_BOMBS_A || this->actor.params == ITEM00_ARROWS_SINGLE ||
+        this->actor.params == ITEM00_BOMBS_SPECIAL || this->actor.params == ITEM00_BOMBCHU) {
+        // OTRTODO: remove special case for bombchu when its 2D drop is implemented
+        if (CVarGetInteger("gNewDrops", 0) || this->actor.params == ITEM00_BOMBCHU ||
+            (gSaveContext.n64ddFlag && this->actor.params == ITEM00_SMALL_KEY)) { // 
             this->actor.shape.rot.y += 960;
-        }
-        if (this->actor.params == ITEM00_SMALL_KEY && !gSaveContext.n64ddFlag) {
-            this->actor.shape.rot.y += 960;
+        } else {
+            this->actor.shape.rot.y = 0;
         }
     }
 
@@ -978,88 +1008,49 @@ void EnItem00_Draw(Actor* thisx, PlayState* play) {
         switch (this->actor.params) {
             case ITEM00_RUPEE_GREEN:
                 if (CVarGetInteger("gNewDrops", 0)) {
-                    Actor_SetScale(&this->actor, 0.3f);
-                    this->scale = 0.3f;
-                    this->actor.shape.yOffset = 50.0f;
-                    this->actor.shape.shadowScale = 0.3f;
-                    this->actor.world.rot.x = 0x4000;
+                    mtxScale = 25.0f;
+                    Matrix_Scale(mtxScale, mtxScale, mtxScale, MTXMODE_APPLY);
                     GetItem_Draw(play, GID_RUPEE_GREEN);
                     break;
-                }    
+                }
             case ITEM00_RUPEE_BLUE:
                 if (CVarGetInteger("gNewDrops", 0)) {
-                    Actor_SetScale(&this->actor, 0.3f);
-                    this->scale = 0.3f;
-                    this->actor.shape.yOffset = 50.0f;
-                    this->actor.shape.shadowScale = 0.3f;
-                    this->actor.world.rot.x = 0x4000;
+                    mtxScale = 25.0f;
+                    Matrix_Scale(mtxScale, mtxScale, mtxScale, MTXMODE_APPLY);
                     GetItem_Draw(play, GID_RUPEE_BLUE);
                     break;
                 }
             case ITEM00_RUPEE_RED:
                 if (CVarGetInteger("gNewDrops", 0)) {
-                    Actor_SetScale(&this->actor, 0.3f);
-                    this->scale = 0.3f;
-                    this->actor.shape.yOffset = 50.0f;
-                    this->actor.shape.shadowScale = 0.3f;
-                    this->actor.world.rot.x = 0x4000;
+                    mtxScale = 25.0f;
+                    Matrix_Scale(mtxScale, mtxScale, mtxScale, MTXMODE_APPLY);
                     GetItem_Draw(play, GID_RUPEE_RED);
-                    break;
-                } else {
-                    this->actor.shape.shadowScale = 6.0f;
-                    Actor_SetScale(&this->actor, 0.015f);
-                    this->scale = 0.015f;
-                    this->actor.shape.yOffset = 750.0f;
-                    EnItem00_DrawRupee(this, play);
                     break;
                 }
             case ITEM00_RUPEE_ORANGE:
                 if (CVarGetInteger("gNewDrops", 0)) {
-                    Actor_SetScale(&this->actor, 0.45f);
-                    this->scale = 0.45f;
-                    this->actor.shape.yOffset = 50.0f;
-                    this->actor.shape.shadowScale = 0.3f;
-                    this->actor.world.rot.x = 0x4000;
+                    mtxScale = 17.5f;
+                    Matrix_Scale(mtxScale, mtxScale, mtxScale, MTXMODE_APPLY);
                     GetItem_Draw(play, GID_RUPEE_GOLD);
-                    break;
-                } else {
-                    Actor_SetScale(&this->actor, 0.045 - 1e-10);
-                    this->actor.shape.shadowScale = 6.0f;
-                    this->scale = 0.045 - 1e-10;
-                    this->actor.shape.yOffset = 750.0f;
-                    EnItem00_DrawRupee(this, play);
                     break;
                 }
             case ITEM00_RUPEE_PURPLE:
                 if (CVarGetInteger("gNewDrops", 0)) {
-                    Actor_SetScale(&this->actor, 0.4f);
-                    this->scale = 0.4f;
-                    this->actor.shape.yOffset = 50.0f;
-                    this->actor.shape.shadowScale = 0.3f;
-                    this->actor.world.rot.x = 0x4000;
+                    mtxScale = 17.5f;
+                    Matrix_Scale(mtxScale, mtxScale, mtxScale, MTXMODE_APPLY);
                     GetItem_Draw(play, GID_RUPEE_PURPLE);
                     break;
                 } else {
-                    Actor_SetScale(&this->actor, 0.03f);
-                    this->actor.shape.shadowScale = 6.0f;
-                    this->scale = 0.03f;
-                    this->actor.shape.yOffset = 750.0f;
+                    // All rupees fallthrough here when 3d drops are off
                     EnItem00_DrawRupee(this, play);
                     break;
                 }
             case ITEM00_HEART_PIECE:
                 if (CVarGetInteger("gNewDrops", 0) && !gSaveContext.n64ddFlag) {
-                    Actor_SetScale(&this->actor, 0.5f);
-                    this->scale = 0.5f;
-                    this->actor.shape.yOffset = 50.0f;
-                    this->actor.world.rot.x = 0x4000;
-                    this->actor.shape.shadowScale = 0.3f;
+                    mtxScale = 21.0f;
+                    Matrix_Scale(mtxScale, mtxScale, mtxScale, MTXMODE_APPLY);
                     GetItem_Draw(play, GID_HEART_PIECE);
                 } else {
-                    this->actor.shape.yOffset = 650.0f;
-                    this->actor.shape.shadowScale = 0.03f;
-                    Actor_SetScale(&this->actor, 0.02f);
-                    this->scale = 0.02f;
                     EnItem00_DrawHeartPiece(this, play);
                 }
                 break;
@@ -1067,15 +1058,10 @@ void EnItem00_Draw(Actor* thisx, PlayState* play) {
                 EnItem00_DrawHeartContainer(this, play);
                 break;
             case ITEM00_HEART:
-                if (CVarGetInteger("gNewDrops", 0)) {
-                    this->actor.home.rot.z = Rand_CenteredFloat(65535.0f);
-                    this->actor.shape.yOffset = 25.0f;
-                    this->actor.shape.shadowScale = 0.3f;
-                    Actor_SetScale(&this->actor, 0.3f);
-                    this->scale = 0.3f;
-                    GetItem_Draw(play, GID_HEART);
+                if (CVarGetInteger("gNewDrops", 0) && this->unk_15A >= 0) {
                     mtxScale = 16.0f;
                     Matrix_Scale(mtxScale, mtxScale, mtxScale, MTXMODE_APPLY);
+                    GetItem_Draw(play, GID_HEART);
                     break;
                 } else {
                     if (this->unk_15A < 0) {
@@ -1093,155 +1079,88 @@ void EnItem00_Draw(Actor* thisx, PlayState* play) {
                         }
                         break;
                     }
-                    //Big hearts workaround
-                    this->actor.home.rot.z = Rand_CenteredFloat(65535.0f);
-                    this->actor.shape.yOffset = 430.0f;
-                    this->actor.shape.shadowScale = 6.0f;
-                    Actor_SetScale(&this->actor, 0.02f);
-                    this->scale = 0.02f;
-                    EnItem00_DrawCollectible(this, play);
-                    break;
                 }
-                
             case ITEM00_BOMBS_A:
-                if (CVarGetInteger("gNewDrops", 0)) {
-                    Actor_SetScale(&this->actor, 0.2f);
-                    this->scale = 0.2f;
-                    this->actor.shape.yOffset = 50.0f;
-                    this->actor.world.rot.x = 0x4000;
-                    this->actor.shape.shadowScale = 0.3f;
-                    GetItem_Draw(play, GID_BOMB);
-                    break;
-                }
             case ITEM00_BOMBS_B:
+            case ITEM00_BOMBS_SPECIAL:
                 if (CVarGetInteger("gNewDrops", 0)) {
-                    Actor_SetScale(&this->actor, 0.2f);
-                    this->scale = 0.2f;
-                    this->actor.shape.yOffset = 50.0f;
-                    this->actor.world.rot.x = 0x4000;
-                    this->actor.shape.shadowScale = 0.3f;
+                    mtxScale = 8.0f;
+                    Matrix_Scale(mtxScale, mtxScale, mtxScale, MTXMODE_APPLY);
                     GetItem_Draw(play, GID_BOMB);
                     break;
                 }
-            case ITEM00_BOMBS_SPECIAL:
             case ITEM00_ARROWS_SINGLE:
-                if (CVarGetInteger("gNewDrops", 0)) {
-                    Actor_SetScale(&this->actor, 0.2f);
-                    this->scale = 0.2f;
-                    this->actor.shape.yOffset = 50.0f;
-                    this->actor.world.rot.x = 0x4000;
-                    this->actor.shape.shadowScale = 0.3f;
-                    GetItem_Draw(play, GID_ARROWS_SMALL);
-                    break;
-                }
             case ITEM00_ARROWS_SMALL:
                 if (CVarGetInteger("gNewDrops", 0)) {
-                    Actor_SetScale(&this->actor, 0.2f);
-                    this->scale = 0.2f;
-                    this->actor.shape.yOffset = 50.0f;
-                    this->actor.world.rot.x = 0x4000;
-                    this->actor.shape.shadowScale = 0.3f;
+                    mtxScale = 7.0f;
+                    Matrix_Scale(mtxScale, mtxScale, mtxScale, MTXMODE_APPLY);
                     GetItem_Draw(play, GID_ARROWS_SMALL);
                     break;
                 }
             case ITEM00_ARROWS_MEDIUM:
                 if (CVarGetInteger("gNewDrops", 0)) {
-                    Actor_SetScale(&this->actor, 0.2f);
-                    this->scale = 0.2f;
-                    this->actor.shape.yOffset = 50.0f;
-                    this->actor.world.rot.x = 0x4000;
-                    this->actor.shape.shadowScale = 0.3f;
+                    mtxScale = 7.0f;
+                    Matrix_Scale(mtxScale, mtxScale, mtxScale, MTXMODE_APPLY);
                     GetItem_Draw(play, GID_ARROWS_MEDIUM);
                     break;
                 }
             case ITEM00_ARROWS_LARGE:
                 if (CVarGetInteger("gNewDrops", 0)) {
-                    Actor_SetScale(&this->actor, 0.2f);
-                    this->scale = 0.2f;
-                    this->actor.shape.yOffset = 50.0f;
-                    this->actor.world.rot.x = 0x4000;
-                    this->actor.shape.shadowScale = 0.3f;
+                    mtxScale = 7.0f;
+                    Matrix_Scale(mtxScale, mtxScale, mtxScale, MTXMODE_APPLY);
                     GetItem_Draw(play, GID_ARROWS_LARGE);
                     break;
                 }
             case ITEM00_NUTS:
                 if (CVarGetInteger("gNewDrops", 0)) {
-                    Actor_SetScale(&this->actor, 0.2f);
-                    this->scale = 0.2f;
-                    this->actor.shape.yOffset = 50.0f;
-                    this->actor.world.rot.x = 0x4000;
-                    this->actor.shape.shadowScale = 0.3f;
+                    mtxScale = 9.0f;
+                    Matrix_Scale(mtxScale, mtxScale, mtxScale, MTXMODE_APPLY);
                     GetItem_Draw(play, GID_NUTS);
                     break;
                 }
             case ITEM00_STICK:
                 if (CVarGetInteger("gNewDrops", 0)) {
-                    Actor_SetScale(&this->actor, 0.2f);
-                    this->scale = 0.2f;
-                    this->actor.shape.yOffset = 50.0f;
-                    this->actor.world.rot.x = 0x4000;
-                    this->actor.shape.shadowScale = 0.3f;
+                    mtxScale = 7.5f;
+                    Matrix_Scale(mtxScale, mtxScale, mtxScale, MTXMODE_APPLY);
                     GetItem_Draw(play, GID_STICK);
                     break;
                 }
             case ITEM00_MAGIC_LARGE:
                 if (CVarGetInteger("gNewDrops", 0)) {
-                    Actor_SetScale(&this->actor, 0.2f);
-                    this->scale = 0.2f;
-                    this->actor.shape.yOffset = 50.0f;
-                    this->actor.world.rot.x = 0x4000;
-                    this->actor.shape.shadowScale = 0.3f;
+                    mtxScale = 8.0f;
+                    Matrix_Scale(mtxScale, mtxScale, mtxScale, MTXMODE_APPLY);
                     GetItem_Draw(play, GID_MAGIC_LARGE);
                     break;
                 }
             case ITEM00_MAGIC_SMALL:
                 if (CVarGetInteger("gNewDrops", 0)) {
-                    Actor_SetScale(&this->actor, 0.2f);
-                    this->scale = 0.2f;
-                    this->actor.shape.yOffset = 50.0f;
-                    this->actor.shape.shadowScale = 0.3f;
-                    this->actor.world.rot.x = 0x4000;
+                    mtxScale = 8.0f;
+                    Matrix_Scale(mtxScale, mtxScale, mtxScale, MTXMODE_APPLY);
                     GetItem_Draw(play, GID_MAGIC_SMALL);
                     break;
                 }
             case ITEM00_SEEDS:
                 if (CVarGetInteger("gNewDrops", 0)) {
-                    Actor_SetScale(&this->actor, 0.2f);
-                    this->scale = 0.2f;
-                    this->actor.shape.yOffset = 50.0f;
-                    this->actor.shape.shadowScale = 0.3f;
-                    this->actor.world.rot.x = 0x4000;
+                    mtxScale = 7.0f;
+                    Matrix_Scale(mtxScale, mtxScale, mtxScale, MTXMODE_APPLY);
                     GetItem_Draw(play, GID_SEEDS);
                     break;
                 }
             case ITEM00_SMALL_KEY:
                 if (CVarGetInteger("gNewDrops", 0) && !gSaveContext.n64ddFlag) {
-                    Actor_SetScale(&this->actor, 0.2f);
-                    this->scale = 0.2f;
-                    this->actor.shape.yOffset = 50.0f;
-                    this->actor.world.rot.x = 0x4000;
-                    this->actor.shape.shadowScale = 0.5f;
+                    mtxScale = 8.0f;
+                    Matrix_Scale(mtxScale, mtxScale, mtxScale, MTXMODE_APPLY);
                     GetItem_Draw(play, GID_KEY_SMALL);
                     break;
                 } else {
-                    Actor_SetScale(&this->actor, 0.03f);
-                    this->scale = 0.03f;
-                    this->actor.shape.yOffset = 320.0f;
-                    this->actor.shape.shadowScale = 6.0f;
-                    if (!gSaveContext.n64ddFlag) {
-                        this->actor.world.rot.x = 0;
-                        this->actor.shape.rot.y = 0;
-                    }
+                    // All collectibles fallthrough here when 3d drops are off
                     EnItem00_DrawCollectible(this, play);
                     break;
                 }
             case ITEM00_BOMBCHU:
-            	// OTRTODO: Stop forcing chu drops to be 3D when the texture is added
-                Actor_SetScale(&this->actor, 0.2f);
-                this->scale = 0.2f;
-                this->actor.shape.yOffset = 50.0f;
-                this->actor.world.rot.x = 0x4000;
-                this->actor.shape.shadowScale = 0.3f;
+                // OTRTODO: Stop forcing chu drops to be 3D when the texture is added
+                mtxScale = 9.0f;
+                Matrix_Scale(mtxScale, mtxScale, mtxScale, MTXMODE_APPLY);
                 GetItem_Draw(play, GID_BOMBCHU);
                 break;
             case ITEM00_SHIELD_DEKU:
@@ -1406,11 +1325,11 @@ void EnItem00_DrawRupee(EnItem00* this, PlayState* play) {
             rupeeColor = CVarGetColor24("gCosmetics.Consumable_RedRupee.Value", (Color_RGB8){ 255, 255, 255 });
             shouldColor = CVarGetInteger("gCosmetics.Consumable_RedRupee.Changed", 0);
             break;
-        case 3:
+        case 4: // orange rupee texture corresponds to the purple rupee (authentic bug)
             rupeeColor = CVarGetColor24("gCosmetics.Consumable_PurpleRupee.Value", (Color_RGB8){ 255, 255, 255 });
             shouldColor = CVarGetInteger("gCosmetics.Consumable_PurpleRupee.Changed", 0);
             break;
-        case 4:
+        case 3: // pink rupee texture corresponds to the gold rupee (authentic bug)
             rupeeColor = CVarGetColor24("gCosmetics.Consumable_GoldRupee.Value", (Color_RGB8){ 255, 255, 255 });
             shouldColor = CVarGetInteger("gCosmetics.Consumable_GoldRupee.Changed", 0);
             break;
@@ -1444,7 +1363,7 @@ void EnItem00_DrawCollectible(EnItem00* this, PlayState* play) {
             this->randoGiEntry.getItemFrom = ITEM_FROM_FREESTANDING;
         }
         
-        f32 mtxScale = 16.0f;
+        f32 mtxScale = 10.67f;
         Matrix_Scale(mtxScale, mtxScale, mtxScale, MTXMODE_APPLY);
         EnItem00_CustomItemsParticles(&this->actor, play, this->randoGiEntry);
         GetItemEntry_Draw(play, this->randoGiEntry);

--- a/soh/src/code/z_en_item00.c
+++ b/soh/src/code/z_en_item00.c
@@ -380,6 +380,7 @@ void EnItem00_Init(Actor* thisx, PlayState* play) {
             this->unk_158 = 0;
             Actor_SetScale(&this->actor, 0.03f);
             this->scale = 0.03f;
+            // Offset keys in randomizer slightly higher for their GID replacement
             if (!gSaveContext.n64ddFlag) {
                 yOffset = 350.0f;
             } else {
@@ -782,7 +783,8 @@ void EnItem00_Update(Actor* thisx, PlayState* play) {
         this->actor.params == ITEM00_BOMBS_SPECIAL || this->actor.params == ITEM00_BOMBCHU) {
         // OTRTODO: remove special case for bombchu when its 2D drop is implemented
         if (CVarGetInteger("gNewDrops", 0) || this->actor.params == ITEM00_BOMBCHU ||
-            (gSaveContext.n64ddFlag && this->actor.params == ITEM00_SMALL_KEY)) { // 
+            // Keys in randomizer need to always rotate for their GID replacement
+            (gSaveContext.n64ddFlag && this->actor.params == ITEM00_SMALL_KEY)) {
             this->actor.shape.rot.y += 960;
         } else {
             this->actor.shape.rot.y = 0;
@@ -1039,12 +1041,11 @@ void EnItem00_Draw(Actor* thisx, PlayState* play) {
                     mtxScale = 17.5f;
                     Matrix_Scale(mtxScale, mtxScale, mtxScale, MTXMODE_APPLY);
                     GetItem_Draw(play, GID_RUPEE_PURPLE);
-                    break;
                 } else {
                     // All rupees fallthrough here when 3d drops are off
                     EnItem00_DrawRupee(this, play);
-                    break;
                 }
+                break;
             case ITEM00_HEART_PIECE:
                 if (CVarGetInteger("gNewDrops", 0) && !gSaveContext.n64ddFlag) {
                     mtxScale = 21.0f;
@@ -1058,12 +1059,14 @@ void EnItem00_Draw(Actor* thisx, PlayState* play) {
                 EnItem00_DrawHeartContainer(this, play);
                 break;
             case ITEM00_HEART:
+                // Only change despawn-able recovery hearts
                 if (CVarGetInteger("gNewDrops", 0) && this->unk_15A >= 0) {
                     mtxScale = 16.0f;
                     Matrix_Scale(mtxScale, mtxScale, mtxScale, MTXMODE_APPLY);
                     GetItem_Draw(play, GID_HEART);
                     break;
                 } else {
+                    // Overworld hearts that are always 3D
                     if (this->unk_15A < 0) {
                         if (this->unk_15A == -1) {
                             s8 bankIndex = Object_GetIndex(&play->objectCtx, OBJECT_GI_HEART);
@@ -1151,12 +1154,11 @@ void EnItem00_Draw(Actor* thisx, PlayState* play) {
                     mtxScale = 8.0f;
                     Matrix_Scale(mtxScale, mtxScale, mtxScale, MTXMODE_APPLY);
                     GetItem_Draw(play, GID_KEY_SMALL);
-                    break;
                 } else {
                     // All collectibles fallthrough here when 3d drops are off
                     EnItem00_DrawCollectible(this, play);
-                    break;
                 }
+                break;
             case ITEM00_BOMBCHU:
                 // OTRTODO: Stop forcing chu drops to be 3D when the texture is added
                 mtxScale = 9.0f;

--- a/soh/src/overlays/actors/ovl_En_Ex_Ruppy/z_en_ex_ruppy.c
+++ b/soh/src/overlays/actors/ovl_En_Ex_Ruppy/z_en_ex_ruppy.c
@@ -55,12 +55,7 @@ void EnExRuppy_Init(Actor* thisx, PlayState* play) {
 
     switch (this->type) {
         case 0:
-            
-            if (CVarGetInteger("gNewDrops", 0) !=0) {
-                this->unk_160 = 0.3f;
-            } else {
-                this->unk_160 = 0.01f;
-            }
+            this->unk_160 = 0.01f;
             Actor_SetScale(&this->actor, this->unk_160);
             this->actor.room = -1;
             this->actor.gravity = 0.0f;
@@ -105,13 +100,9 @@ void EnExRuppy_Init(Actor* thisx, PlayState* play) {
                     }
                 }
             }
-            if (CVarGetInteger("gNewDrops", 0) !=0) {
-                this->actor.shape.shadowScale = 0.3f;
-                this->actor.shape.yOffset = 35.0f;
-            } else {
-                this->actor.shape.shadowScale = 7.0f;
-                this->actor.shape.yOffset = 700.0f;
-            }
+
+            this->actor.shape.shadowScale = 7.0f;
+            this->actor.shape.yOffset = 700.0f;
             this->unk_15A = this->actor.world.rot.z;
             this->actor.world.rot.z = 0;
             this->timer = 30;
@@ -122,40 +113,23 @@ void EnExRuppy_Init(Actor* thisx, PlayState* play) {
         case 1:
         case 2: // Giant pink ruppe that explodes when you touch it
             if (this->type == 1) {
+                Actor_SetScale(&this->actor, 0.1f);
                 this->colorIdx = 4;
-                if (CVarGetInteger("gNewDrops", 0) !=0) {
-                    Actor_SetScale(&this->actor, 2.0f);
-                } else {
-                    Actor_SetScale(&this->actor, 0.1f);
-                }
             } else {
+                Actor_SetScale(thisx, 0.02f);
                 this->colorIdx = (s16)Rand_ZeroFloat(3.99f) + 1;
-                if (CVarGetInteger("gNewDrops", 0) !=0) {
-                    Actor_SetScale(thisx, 0.4f);
-                } else {
-                    Actor_SetScale(thisx, 0.02f);
-                }
             }
             this->actor.gravity = -3.0f;
             // "Wow Coin"
             osSyncPrintf(VT_FGCOL(GREEN) "☆☆☆☆☆ わーなーコイン ☆☆☆☆☆ \n" VT_RST);
-            if (CVarGetInteger("gNewDrops", 0) !=0) {
-                this->actor.shape.shadowScale = 0.3f;
-                this->actor.shape.yOffset = 35.0f;
-            } else {
-                this->actor.shape.shadowScale = 6.0f;
-                this->actor.shape.yOffset = 700.0f;
-            }
+            this->actor.shape.shadowScale = 6.0f;
+            this->actor.shape.yOffset = 700.0f;
             this->actor.flags &= ~ACTOR_FLAG_TARGETABLE;
             this->actionFunc = EnExRuppy_WaitToBlowUp;
             break;
 
         case 3: // Spawned by the guard in Hyrule courtyard
-            if (CVarGetInteger("gNewDrops", 0) !=0) {
-                Actor_SetScale(&this->actor, 0.4f);
-            } else {
-                Actor_SetScale(&this->actor, 0.02f);
-            }
+            Actor_SetScale(&this->actor, 0.02f);
             this->colorIdx = 0;
             switch ((s16)Rand_ZeroFloat(30.99f)) {
                 case 0:
@@ -170,13 +144,8 @@ void EnExRuppy_Init(Actor* thisx, PlayState* play) {
             this->actor.gravity = -3.0f;
             // "Normal rupee"
             osSyncPrintf(VT_FGCOL(GREEN) "☆☆☆☆☆ ノーマルルピー ☆☆☆☆☆ \n" VT_RST);
-            if (CVarGetInteger("gNewDrops", 0) !=0) {
-                this->actor.shape.shadowScale = 0.3f;
-                this->actor.shape.yOffset = 35.0f;
-            } else {
-                this->actor.shape.yOffset = 700.0f;
-                this->actor.shape.shadowScale = 6.0f;
-            }
+            this->actor.shape.shadowScale = 6.0f;
+            this->actor.shape.yOffset = 700.0f;
             this->actor.flags &= ~ACTOR_FLAG_TARGETABLE;
             this->actionFunc = EnExRuppy_WaitAsCollectible;
             break;
@@ -184,16 +153,9 @@ void EnExRuppy_Init(Actor* thisx, PlayState* play) {
         case 4: // Progress markers in the shooting gallery
             this->actor.gravity = -3.0f;
             this->actor.flags &= ~ACTOR_FLAG_TARGETABLE;
-            if (CVarGetInteger("gNewDrops", 0) !=0) {
-                Actor_SetScale(&this->actor, 0.3f);
-                this->actor.shape.shadowScale = 0.3f;
-                this->actor.shape.yOffset = -1365.0f;
-            } else {
-                Actor_SetScale(&this->actor, 0.01f);
-                this->actor.shape.shadowScale = 6.0f;
-                this->actor.shape.yOffset = -700.0f;
-            }
-
+            Actor_SetScale(&this->actor, 0.01f);
+            this->actor.shape.shadowScale = 6.0f;
+            this->actor.shape.yOffset = -700.0f;
             this->actionFunc = EnExRuppy_GalleryTarget;
             break;
     }
@@ -393,18 +355,10 @@ void EnExRuppy_WaitAsCollectible(EnExRuppy* this, PlayState* play) {
 }
 
 void EnExRuppy_GalleryTarget(EnExRuppy* this, PlayState* play) {
-    if (CVarGetInteger("gNewDrops", 0) !=0) {
-        if (this->galleryFlag) {
-            Math_ApproachF(&this->actor.shape.yOffset, 35.0f, 0.5f, 200.0f);
-        } else {
-            Math_ApproachF(&this->actor.shape.yOffset, -1365.0f, 0.5f, 200.0f);
-        }
+    if (this->galleryFlag) {
+        Math_ApproachF(&this->actor.shape.yOffset, 700.0f, 0.5f, 200.0f);
     } else {
-        if (this->galleryFlag) {
-            Math_ApproachF(&this->actor.shape.yOffset, 700.0f, 0.5f, 200.0f);
-        } else {
-            Math_ApproachF(&this->actor.shape.yOffset, -700.0f, 0.5f, 200.0f);
-        }
+        Math_ApproachF(&this->actor.shape.yOffset, -700.0f, 0.5f, 200.0f);
     }
 }
 
@@ -424,8 +378,9 @@ void EnExRuppy_Draw(Actor* thisx, PlayState* play) {
     static void* rupeeTextures[] = {
         gRupeeGreenTex, gRupeeBlueTex, gRupeeRedTex, gRupeePinkTex, gRupeeOrangeTex,
     };
+    // The pink/orange rupee textures are authentically reversed, so the GID models should be gold/purple respectively
     static void* rupeeTexturesNew[] = {
-        GID_RUPEE_GREEN, GID_RUPEE_BLUE, GID_RUPEE_RED, GID_RUPEE_PURPLE, GID_RUPEE_GOLD,
+        GID_RUPEE_GREEN, GID_RUPEE_BLUE, GID_RUPEE_RED, GID_RUPEE_GOLD, GID_RUPEE_PURPLE,
     };
     s32 pad;
     EnExRuppy* this = (EnExRuppy*)thisx;
@@ -433,19 +388,51 @@ void EnExRuppy_Draw(Actor* thisx, PlayState* play) {
     if (!this->invisible) {
         OPEN_DISPS(play->state.gfxCtx);
 
-        Gfx_SetupDL_25Opa(play->state.gfxCtx);
-        func_8002EBCC(thisx, play, 0);
-        gSPMatrix(POLY_OPA_DISP++, MATRIX_NEWMTX(play->state.gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
-        if (CVarGetInteger("gNewDrops", 0) !=0) {
-            if (this->type == 4 && this->colorIdx >= 3) {
-                //For some reason the red rupee target become purple.
-                //when using new drops it will show as Gold and that wrong it need to be red.
-                this->colorIdx = 2;
-            }
+        if (CVarGetInteger("gNewDrops", 0)) {
+            // purple/gold rupees need less scaling
+            f32 mtxScale = this->colorIdx >= 3 ? 17.5f : 25.0f;
+            Matrix_Scale(mtxScale, mtxScale, mtxScale, MTXMODE_APPLY);
             GetItem_Draw(play, rupeeTexturesNew[this->colorIdx]);
         } else {
-            gSPSegment(POLY_OPA_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(rupeeTextures[this->colorIdx]));
-            gSPDisplayList(POLY_OPA_DISP++, gRupeeDL);
+            Color_RGB8 rupeeColor;
+            u8 shouldColor = 0;
+            switch (this->colorIdx) {
+                case 0:
+                    rupeeColor = CVarGetColor24("gCosmetics.Consumable_GreenRupee.Value", (Color_RGB8){ 255, 255, 255 });
+                    shouldColor = CVarGetInteger("gCosmetics.Consumable_GreenRupee.Changed", 0);
+                    break;
+                case 1:
+                    rupeeColor = CVarGetColor24("gCosmetics.Consumable_BlueRupee.Value", (Color_RGB8){ 255, 255, 255 });
+                    shouldColor = CVarGetInteger("gCosmetics.Consumable_BlueRupee.Changed", 0);
+                    break;
+                case 2:
+                    rupeeColor = CVarGetColor24("gCosmetics.Consumable_RedRupee.Value", (Color_RGB8){ 255, 255, 255 });
+                    shouldColor = CVarGetInteger("gCosmetics.Consumable_RedRupee.Changed", 0);
+                    break;
+                case 4: // orange rupee texture corresponds to the purple rupee (authentic bug)
+                    rupeeColor = CVarGetColor24("gCosmetics.Consumable_PurpleRupee.Value", (Color_RGB8){ 255, 255, 255 });
+                    shouldColor = CVarGetInteger("gCosmetics.Consumable_PurpleRupee.Changed", 0);
+                    break;
+                case 3: // pink rupee texture corresponds to the gold rupee (authentic bug)
+                    rupeeColor = CVarGetColor24("gCosmetics.Consumable_GoldRupee.Value", (Color_RGB8){ 255, 255, 255 });
+                    shouldColor = CVarGetInteger("gCosmetics.Consumable_GoldRupee.Changed", 0);
+                    break;
+            }
+
+            Gfx_SetupDL_25Opa(play->state.gfxCtx);
+            func_8002EBCC(thisx, play, 0);
+            gSPMatrix(POLY_OPA_DISP++, MATRIX_NEWMTX(play->state.gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+
+            if (shouldColor) {
+                gDPSetGrayscaleColor(POLY_OPA_DISP++, rupeeColor.r, rupeeColor.g, rupeeColor.b, 255);
+                gSPGrayscale(POLY_OPA_DISP++, true);
+                gSPSegment(POLY_OPA_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(rupeeTextures[this->colorIdx]));
+                gSPDisplayList(POLY_OPA_DISP++, gRupeeDL);
+                gSPGrayscale(POLY_OPA_DISP++, false);
+            } else {
+                gSPSegment(POLY_OPA_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(rupeeTextures[this->colorIdx]));
+                gSPDisplayList(POLY_OPA_DISP++, gRupeeDL);
+            }
         }
 
         CLOSE_DISPS(play->state.gfxCtx);


### PR DESCRIPTION
This PR aims to refactor and improve the 3D drops handling to address bugs when toggling on/off and simplify the logic.

The way 3d drops worked before was applying a different actor scale, yOffset and sometimes shadowScale either during actor init or actor update/draw. This resulted in having to constantly apply the original or 3d drop specific values which lead to the drops flashing or ending up in a stuck state when toggled on/off.

Instead, this PR uses the pattern that the authentic game does for making recovery hearts 3D, by applying a `Matrix_Scale`. Doing this I was able to remove all the actor scale yOffset changes such that all the drops uses the authentic game values now, and only when 3d drops is only do we apply the `Matrix_Scale` to make the GID appear as the right size. This resolves any lingering issues with toggling on the fly and ensures actor properties aren't left in a partially modified state.

Ultimately this minimizes the original code changes while restoring authentic code/behavior. I have verified all drops have an appropriate scale with these changes.

#### Notable bug fixes in these changes:
* Freestanding recovery hearts are no longer giant when turning 3d drops off
* Shields and Tunics dropped by Like-Likes no longer despawn when 3d drops are on
* The purple/gold rupee cosmetic colors for "3d drops off" rupees were backwards due to an authentic naming bug
* Diving rupee game was using the incorrect 3d drop version for purple/gold rupees (backwards due to a similar naming)
* Silver rupees with 3d drops on have the incorrect hitbox causing them to be difficult to collect compared to authentic behavior (especially with trick setups in rando)
* Silver rupees are no longer the wrong scale when toggling 3d drops on/off
* `ITEM00_BOMB_SPECIAL` was using the arrow GID instead of the bomb GID

#### Notable additions:
* Add 2d bombchu drop support by using the inventory icon for bombchus
* The rupees in the Diving rupee game now match the cosmetic editor colors when 3d drops are off
* The rupees in the Shooting gallery games with 3d drops on now better match the same scale as the 3d drops off versions
* The progress tracking rupees at the bottom of the Shooting gallery now use the proper cosmetic color when 3d drops are off
* The rupees in Castle courtyard stealth section now use the proper cosmetic color when 3d drops are off

#### Notable change:
Previously when 3d drops are on, the "red" rupees in the Shooting gallery tracker section where being switched from purple (authentic) to red. This was due to the GID for gold rupees matching the color. The problem is that the game authentically incorrectly labels gold rupees as pink, and purple rupees as orange, and so this "adjustment" was used to make the rupee match the red ones in the mini-game. After swapping the GID to match this behavior (pink using purple GID), I have removed this change as it was only applied to 3d drops and was changing authentic behavior beyond what the toggle implies.
So now the progress tracker rupees are correctly their "pink" variant (purple GID when 3d drops are on).

---

Admittedly, this PR is doing a bit, so I am targeting develop as it is more of a refactor than just "bug fixes" alone. I can rebase if we prefer it for Sulu instead.

Fixes #1343 


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/798617454.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/798617455.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/798617456.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/798617457.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/798617458.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/798617459.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/798617460.zip)
<!--- section:artifacts:end -->