### PR TITLE
Rewrite the logic to check for CRC32 at runtime

### DIFF
--- a/soh/soh/Extractor/FastCrc32C.c
+++ b/soh/soh/Extractor/FastCrc32C.c
@@ -16,6 +16,8 @@
 #elif ((defined(__GNUC__) && defined(__x86_64__) || defined(__i386__)))
 #include <nmmintrin.h>
 #include <cpuid.h>
+#elif defined (__APPLE__)
+#include <cpuid.h>
 #elif defined(__aarch64__) && defined(__ARM_FEATURE_CRC32)
 // Nothing cause its a compiler builtin
 #else

--- a/soh/soh/Extractor/FastCrc32C.c
+++ b/soh/soh/Extractor/FastCrc32C.c
@@ -22,11 +22,6 @@
 #define NO_CRC_INTRIN
 #endif
 
-#ifdef __APPLE__
-#include <cpuid.h>
-extern void do_cpuid(uint32_t selector, uint32_t *data);
-#endif
-
 #if defined(__aarch64__) && defined(__ARM_FEATURE_CRC32)
 #define INTRIN_CRC32_64(crc, value) __asm__("crc32cx %w[c], %w[c], %x[v]" : [c] "+r"(crc) : [v] "r"(value))
 #define INTRIN_CRC32_32(crc, value) __asm__("crc32cw %w[c], %w[c], %w[v]" : [c] "+r"(crc) : [v] "r"(value))
@@ -124,7 +119,8 @@ uint32_t CRC32C(unsigned char* data, size_t dataSize) {
 #ifdef _WIN32
     __cpuid(cpuidData, 1);
 #elif __APPLE__
-    do_cpuid(1,cpuidData);
+// I'm 99% sure there are no Macs that run a version of MacOS that also don't support this intrinsic
+   return CRC32IntrinImpl(data, dataSize);
 #else
     __get_cpuid(1, &cpuidData[0], &cpuidData[1], &cpuidData[2], &cpuidData[3]);
 #endif

--- a/soh/soh/Extractor/FastCrc32C.c
+++ b/soh/soh/Extractor/FastCrc32C.c
@@ -3,7 +3,7 @@
 
 #ifdef _WIN32
 #include <immintrin.h>
-#include <cpuid.h>
+#include <intrin.h>
 #elif ((defined(__GNUC__) && defined(__x86_64__) || defined(__i386__)))
 // Force the compiler to assume we have support for the CRC32 intrinsic. We will check for our selves later.
 #pragma GCC target("crc32")

--- a/soh/soh/Extractor/FastCrc32C.c
+++ b/soh/soh/Extractor/FastCrc32C.c
@@ -3,17 +3,20 @@
 
 // Force the compiler to assume we have support for the CRC32 intrinsic. We will check for our selves later.
 // Clang will define both __llvm__ and __GNUC__ but GCC will only define __GNUC__. So we need to check for __llvm__ first.
-#if ((defined(__llvm__) && defined(__x86_64__) || defined(__i386__)))
+#if ((defined(__llvm__) && (defined(__x86_64__) || defined(__i386__))))
 #pragma clang attribute push(__attribute__((target("crc32"))), apply_to = function)
-#elif ((defined(__GNUC__) && defined(__x86_64__) || defined(__i386__)))
+#elif ((defined(__GNUC__) && (defined(__x86_64__) || defined(__i386__))))
+// GCC Only lets you enable all of sse4.2 so we will for just this file and reset it at the end.
 #pragma GCC push_options
 #pragma GCC target("sse4.2")
 #endif
 
+// Include headers for the CRC32 intrinsic and cpuid instruction on windows. No need to do any other checks because it assumes the target will support CRC32
 #ifdef _WIN32
 #include <immintrin.h>
 #include <intrin.h>
-#elif ((defined(__GNUC__) && defined(__x86_64__) || defined(__i386__)))
+// Same as above but these platforms use slightly different headers
+#elif ((defined(__GNUC__) && (defined(__x86_64__) || defined(__i386__))))
 #include <nmmintrin.h>
 #include <cpuid.h>
 #elif defined(__aarch64__) && defined(__ARM_FEATURE_CRC32)
@@ -65,13 +68,13 @@ static const uint32_t crc32Table[256] = {
     0xE03E9C81L, 0x34F4F86AL, 0xC69F7B69L, 0xD5CF889DL, 0x27A40B9EL, 0x79B737BAL, 0x8BDCB4B9L, 0x988C474DL, 0x6AE7C44EL,
     0xBE2DA0A5L, 0x4C4623A6L, 0x5F16D052L, 0xAD7D5351L
 };
-
+// On platforms that we know will never support a crc32 instruction (such as the WiiU) we will skip compiling this function in.
 #ifndef NO_CRC_INTRIN
 
 static uint32_t CRC32IntrinImpl(unsigned char* data, size_t dataSize) {
     uint32_t ret = 0xFFFFFFFF;
     int64_t sizeSigned = dataSize;
-
+// Only 64bit platforms support doing a CRC32 operation on a 64bit value
 #if defined(_M_X64) || defined(__x86_64__) || defined(__aarch64__)
     while ((sizeSigned -= sizeof(uint64_t)) >= 0) {
         INTRIN_CRC32_64(ret, *(uint64_t*)data);
@@ -83,6 +86,7 @@ static uint32_t CRC32IntrinImpl(unsigned char* data, size_t dataSize) {
 
         data += sizeof(uint32_t);
     }
+// On 32 bit we can only do 32bit operations
 #elif defined(_M_IX86) || defined(__i386__)
     while ((sizeSigned -= sizeof(uint32_t)) >= 0) {
         INTRIN_CRC32_32(ret, *(uint32_t*)data);
@@ -132,9 +136,9 @@ uint32_t CRC32C(unsigned char* data, size_t dataSize) {
     return CRC32TableImpl(data, dataSize);
 }
 
-#if ((defined(__llvm__) && defined(__x86_64__) || defined(__i386__)))
+#if ((defined(__llvm__) && (defined(__x86_64__) || defined(__i386__))))
 #pragma clang attribute pop
-#elif ((defined(__GNUC__) && defined(__x86_64__) || defined(__i386__)))
+#elif ((defined(__GNUC__) && (defined(__x86_64__) || defined(__i386__))))
 #pragma GCC pop_options
 #else
 #endif

--- a/soh/soh/Extractor/FastCrc32C.c
+++ b/soh/soh/Extractor/FastCrc32C.c
@@ -122,9 +122,9 @@ uint32_t CRC32C(unsigned char* data, size_t dataSize) {
     unsigned int cpuidData[4];
 #ifdef _WIN32
     __cpuid(cpuidData, 1);
-#elif __APPLE__
-// I'm 99% sure there are no Macs that run a version of MacOS that also don't support this intrinsic
-   return CRC32IntrinImpl(data, dataSize);
+#elif __APPLE__ || (defined(__aarch64__) && defined(__ARM_FEATURE_CRC32))
+// Every Mac that supports SoH should support this instruction. Also check for ARM64 at the same time
+    return CRC32IntrinImpl(data, dataSize);
 #else
     __get_cpuid(1, &cpuidData[0], &cpuidData[1], &cpuidData[2], &cpuidData[3]);
 #endif

--- a/soh/soh/Extractor/FastCrc32C.c
+++ b/soh/soh/Extractor/FastCrc32C.c
@@ -16,12 +16,14 @@
 #elif ((defined(__GNUC__) && defined(__x86_64__) || defined(__i386__)))
 #include <nmmintrin.h>
 #include <cpuid.h>
-#elif defined (__APPLE__)
-#include <cpuid.h>
 #elif defined(__aarch64__) && defined(__ARM_FEATURE_CRC32)
 // Nothing cause its a compiler builtin
 #else
 #define NO_CRC_INTRIN
+#endif
+
+#ifdef __APPLE__
+#include <cpuid.h>
 #endif
 
 #if defined(__aarch64__) && defined(__ARM_FEATURE_CRC32)

--- a/soh/soh/Extractor/FastCrc32C.c
+++ b/soh/soh/Extractor/FastCrc32C.c
@@ -24,6 +24,7 @@
 
 #ifdef __APPLE__
 #include <cpuid.h>
+extern void do_cpuid(uint32_t selector, uint32_t *data);
 #endif
 
 #if defined(__aarch64__) && defined(__ARM_FEATURE_CRC32)


### PR DESCRIPTION
Some users of older AMD CPUs have issues with the CRC intrinsic not being supported on their CPU leading to a crash.  This changes the logic to check for the instruction at run time before running the CRC check on the rom.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/857796713.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/857796714.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/857796715.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/857796716.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/857796717.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/857796718.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/857796719.zip)
<!--- section:artifacts:end -->