### PR TITLE
[Tweak] Better GS Ice Trap Collection Handling

### DIFF
--- a/soh/src/overlays/actors/ovl_En_Si/z_en_si.c
+++ b/soh/src/overlays/actors/ovl_En_Si/z_en_si.c
@@ -181,6 +181,12 @@ void func_80AFB950(EnSi* this, PlayState* play) {
     } else {
         SET_GS_FLAGS((this->actor.params & 0x1F00) >> 8, this->actor.params & 0xFF);
         Actor_Kill(&this->actor);
+        if (gSaveContext.pendingIceTrapCount > 0 && player->heldItemId == 11) {
+            player->actor.freezeTimer = 0;
+            func_8083C148(GET_PLAYER(play), play);
+            func_80078884(NA_SE_SY_CAMERA_ZOOM_UP);
+            player->currentYaw = player->actor.shape.rot.y;
+        }
     }
 }
 

--- a/soh/src/overlays/actors/ovl_En_Si/z_en_si.c
+++ b/soh/src/overlays/actors/ovl_En_Si/z_en_si.c
@@ -6,6 +6,9 @@
 
 #include "z_en_si.h"
 
+extern void func_8083C148(Player*, PlayState*);
+extern void func_80078884(uint16_t);
+
 #define FLAGS (ACTOR_FLAG_TARGETABLE | ACTOR_FLAG_HOOKSHOT_DRAGS)
 
 void EnSi_Init(Actor* thisx, PlayState* play);


### PR DESCRIPTION
Currently, when collecting an ice trap from a GS token, the game would let the player stay in first-person mode indefinitely even after closing the text box. This makes it so that the player is forced out of first-person as soon as they close the text box, thus triggering the ice trap, to bring it more in line with every other instance when you get an ice trap.

Before: 

https://github.com/HarbourMasters/Shipwright/assets/774771/310a81e6-0409-4118-b047-1d426f0c0cef

After:

https://github.com/HarbourMasters/Shipwright/assets/774771/10ee1289-0d14-4497-bf50-f2932cc2e5c8



<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/798606282.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/798606283.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/798606284.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/798606285.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/798606286.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/798606287.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/798606288.zip)
<!--- section:artifacts:end -->