### PR TITLE
No UI command - Remove debug elements and visual SoA

### DIFF
--- a/soh/src/code/z_debug.c
+++ b/soh/src/code/z_debug.c
@@ -1,4 +1,5 @@
 #include "global.h"
+#include "soh/Enhancements/game-interactor/GameInteractor.h"
 
 typedef struct {
     u8 x;
@@ -219,8 +220,9 @@ void func_80063D7C(GraphicsContext* gfxCtx) {
     GfxPrint printer;
     Gfx* tempRet;
 
-    if (!CVarGetInteger("gDebugEnabled", 0))
+    if (!CVarGetInteger("gDebugEnabled", 0) || GameInteractor_NoUIActive()) {
         return;
+    }
 
     OPEN_DISPS(gfxCtx);
 

--- a/soh/src/code/z_debug_display.c
+++ b/soh/src/code/z_debug_display.c
@@ -1,5 +1,6 @@
 #include "global.h"
 #include "objects/gameplay_keep/gameplay_keep.h"
+#include "soh/Enhancements/game-interactor/GameInteractor.h"
 
 typedef struct {
     /* 0x00 */ s16 drawType;  // indicates which draw function to use when displaying the object
@@ -33,6 +34,10 @@ DebugDispObject* DebugDisplay_AddObject(f32 posX, f32 posY, f32 posZ, s16 rotX, 
                                         f32 scaleY, f32 scaleZ, u8 red, u8 green, u8 blue, u8 alpha, s16 type,
                                         GraphicsContext* gfxCtx) {
     DebugDispObject* prevHead = sDebugObjectListHead;
+
+    if (GameInteractor_NoUIActive()) {
+        return sDebugObjectListHead;
+    }
 
     sDebugObjectListHead = Graph_Alloc(gfxCtx, sizeof(DebugDispObject));
 

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -10490,7 +10490,7 @@ void func_80848EF8(Player* this, PlayState* play) {
         if (CVarGetInteger("gCosmetics.Hud_StoneOfAgony.Changed", 0)) {
             stoneOfAgonyColor = CVarGetColor24("gCosmetics.Hud_StoneOfAgony.Value", stoneOfAgonyColor);
         }
-        if (CVarGetInteger("gVisualAgony", 0) != 0 && !this->stateFlags1) {
+        if (CVarGetInteger("gVisualAgony", 0) && !this->stateFlags1 && !GameInteractor_NoUIActive()) {
             s16 Top_Margins = (CVarGetInteger("gHUDMargin_T", 0) * -1);
             s16 Left_Margins = CVarGetInteger("gHUDMargin_L", 0);
             s16 Right_Margins = CVarGetInteger("gHUDMargin_R", 0);
@@ -10574,7 +10574,7 @@ void func_80848EF8(Player* this, PlayState* play) {
 
         if (this->unk_6A0 > 4000000.0f) {
             this->unk_6A0 = 0.0f;
-            if (CVarGetInteger("gVisualAgony", 0) != 0 && !this->stateFlags1) {
+            if (CVarGetInteger("gVisualAgony", 0) && !this->stateFlags1 && !GameInteractor_NoUIActive()) {
                 // This audio is placed here and not in previous CVar check to prevent ears ra.. :)
                 Audio_PlaySoundGeneral(NA_SE_SY_MESSAGE_WOMAN, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E0);
             }


### PR DESCRIPTION
But schmiiiiiiffiiiiic...

Removes debug information like the markers used in the debug camera and debug print when using the no_ui command. 

Made on request to use the debug camera for filmic purposes.

Shoddy showcase: https://cdn.discordapp.com/attachments/1082248954835640341/1131668543679766588/2023-07-20_21-20-24.mp4

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/816045516.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/816045517.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/816045521.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/816045522.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/816045524.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/816045525.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/816045526.zip)
<!--- section:artifacts:end -->