### PR TITLE
Fix: Carpet Merchant rando GiveItem distance check

### DIFF
--- a/soh/src/overlays/actors/ovl_En_Js/z_en_js.c
+++ b/soh/src/overlays/actors/ovl_En_Js/z_en_js.c
@@ -136,7 +136,7 @@ void func_80A89160(EnJs* this, PlayState* play) {
             GetItemEntry itemEntry = Randomizer_GetItemFromKnownCheck(RC_WASTELAND_BOMBCHU_SALESMAN, GI_BOMBCHUS_10);
             gSaveContext.pendingSale = itemEntry.itemId;
             gSaveContext.pendingSaleMod = itemEntry.modIndex;
-            GiveItemEntryFromActor(&this->actor, play, itemEntry, 90.0f, 10.0f);
+            GiveItemEntryFromActor(&this->actor, play, itemEntry, 10000.0f, 50.0f);
             Flags_SetRandomizerInf(RAND_INF_MERCHANTS_CARPET_SALESMAN);
         } else {
             GetItemEntry itemEntry = ItemTable_Retrieve(GI_BOMBCHUS_10);


### PR DESCRIPTION
The carpet merchant had an incorrect actor dist check for the rando give item call, causing the vanilla bombchus to be granted instead if the player was on the far edge of the "speak" radius.

This PR just matches the rando dist checks with the vanilla ones.

I've also audited the rest of the code base and confirmed there are no other mismatching distance checks for vanilla/rando give item situations.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/842397941.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/842397943.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/842397945.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/842397947.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/842397949.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/842397952.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/842397954.zip)
<!--- section:artifacts:end -->