### PR TITLE
[Bugfix] Add check for animation count to prevent continuing final saw textbox while putaway is happening

### DIFF
--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -1007,6 +1007,9 @@ void DrawEnhancementsMenu() {
                 ApplyAuthenticGfxPatches();
             }
             UIWidgets::Tooltip("Fixes authentic out of bounds texture reads, instead loading textures with the correct size");
+            UIWidgets::PaddedEnhancementCheckbox("Fix Poacher's Saw Softlock", "gFixSawSoftlock", true, false, CVarGetInteger("gSkipText", 0),
+                "This is disabled because it is forced on when Skip Text is enabled.", UIWidgets::CheckboxGraphics::Checkmark);
+            UIWidgets::Tooltip("Prevents the Poacher's Saw softlock from mashing through the text, or with Skip Text enabled.");
 
             ImGui::EndMenu();
         }

--- a/soh/src/overlays/actors/ovl_En_Toryo/z_en_toryo.c
+++ b/soh/src/overlays/actors/ovl_En_Toryo/z_en_toryo.c
@@ -292,7 +292,8 @@ void func_80B20768(EnToryo* this, PlayState* play) {
     s16 sp30;
 
     // Animation Count should be no more than 1 to guarantee putaway is complete after giving the saw
-    if (this->unk_1E4 == 3 && play->animationCtx.animationCount <= 1) {
+    bool checkAnim = (CVarGetInteger("gFixSawSoftlock", 0) != 0 || CVarGetInteger("gSkipText", 0) != 0) ? play->animationCtx.animationCount <= 1 : true;
+    if (this->unk_1E4 == 3 && checkAnim) {
         Actor_ProcessTalkRequest(&this->actor, play);
         Message_ContinueTextbox(play, this->actor.textId);
         this->unk_1E4 = 1;

--- a/soh/src/overlays/actors/ovl_En_Toryo/z_en_toryo.c
+++ b/soh/src/overlays/actors/ovl_En_Toryo/z_en_toryo.c
@@ -292,6 +292,7 @@ void func_80B20768(EnToryo* this, PlayState* play) {
     s16 sp30;
 
     // Animation Count should be no more than 1 to guarantee putaway is complete after giving the saw
+    // As this is vanilla behavior, it only applies with the Fix toggle or Skip Text enabled.
     bool checkAnim = (CVarGetInteger("gFixSawSoftlock", 0) != 0 || CVarGetInteger("gSkipText", 0) != 0) ? play->animationCtx.animationCount <= 1 : true;
     if (this->unk_1E4 == 3 && checkAnim) {
         Actor_ProcessTalkRequest(&this->actor, play);

--- a/soh/src/overlays/actors/ovl_En_Toryo/z_en_toryo.c
+++ b/soh/src/overlays/actors/ovl_En_Toryo/z_en_toryo.c
@@ -291,7 +291,8 @@ void func_80B20768(EnToryo* this, PlayState* play) {
     s16 sp32;
     s16 sp30;
 
-    if (this->unk_1E4 == 3) {
+    // Animation Count should be no more than 1 to guarantee putaway is complete after giving the saw
+    if (this->unk_1E4 == 3 && play->animationCtx.animationCount <= 1) {
         Actor_ProcessTalkRequest(&this->actor, play);
         Message_ContinueTextbox(play, this->actor.textId);
         this->unk_1E4 = 1;


### PR DESCRIPTION
Fixes #2200 - softlock when holding an item and skipping text giving the saw. 

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/845009967.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/845009968.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/845009970.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/845009971.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/845009972.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/845009974.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/845009975.zip)
<!--- section:artifacts:end -->