### PR TITLE
Use a different color when aiming at hookshotable collision

### DIFF
--- a/soh/assets/objects/object_link_boy/object_link_boy.h
+++ b/soh/assets/objects/object_link_boy/object_link_boy.h
@@ -308,6 +308,9 @@ static const ALIGN_ASSET(2) char gLinkAdultHookshotDesignTex[] = dgLinkAdultHook
 #define dgLinkAdultHookshotChainTex "__OTR__objects/object_link_boy/gLinkAdultHookshotChainTex"
 static const ALIGN_ASSET(2) char gLinkAdultHookshotChainTex[] = dgLinkAdultHookshotChainTex;
 
+#define dgLinkAdultHookshotRedicleVtx "__OTR__objects/object_link_boy/gLinkAdultHookshotRedicleVtx"
+static const ALIGN_ASSET(2) char gLinkAdultHookshotRedicleVtx[] = dgLinkAdultHookshotRedicleVtx;
+
 #define dgLinkAdultHookshotReticleTex "__OTR__objects/object_link_boy/gLinkAdultHookshotReticleTex"
 static const ALIGN_ASSET(2) char gLinkAdultHookshotReticleTex[] = dgLinkAdultHookshotReticleTex;
 

--- a/soh/assets/xml/GC_MQ_D/objects/object_link_boy.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_link_boy.xml
@@ -202,6 +202,10 @@
         <Texture Name="gLinkAdultGauntletPlate1Tex" OutName="gauntlet_plate_1" Format="rgba16" Width="16" Height="32" Offset="0x9980"/>
         <Texture Name="gLinkAdultGauntletPlate2Tex" OutName="gauntlet_plate_2" Format="rgba16" Width="32" Height="32" Offset="0x9D80"/>
 
+        <Array Name="gLinkAdultHookshotRedicleVtx" Count="3" Offset="0x2CB18">
+            <Vtx/>
+        </Array>
+
         <DList Name="gLinkAdultHookshotReticleDL" Offset="0x2CB48"/>
 
         <!-- Boots -->

--- a/soh/assets/xml/GC_NMQ_D/objects/object_link_boy.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_link_boy.xml
@@ -202,6 +202,10 @@
         <Texture Name="gLinkAdultGauntletPlate1Tex" OutName="gauntlet_plate_1" Format="rgba16" Width="16" Height="32" Offset="0x9980"/>
         <Texture Name="gLinkAdultGauntletPlate2Tex" OutName="gauntlet_plate_2" Format="rgba16" Width="32" Height="32" Offset="0x9D80"/>
 
+        <Array Name="gLinkAdultHookshotRedicleVtx" Count="3" Offset="0x2CB18">
+            <Vtx/>
+        </Array>
+
         <DList Name="gLinkAdultHookshotReticleDL" Offset="0x2CB48"/>
 
         <!-- Boots -->

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_link_boy.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_link_boy.xml
@@ -202,6 +202,10 @@
         <Texture Name="gLinkAdultGauntletPlate1Tex" OutName="gauntlet_plate_1" Format="rgba16" Width="16" Height="32" Offset="0x9980"/>
         <Texture Name="gLinkAdultGauntletPlate2Tex" OutName="gauntlet_plate_2" Format="rgba16" Width="32" Height="32" Offset="0x9D80"/>
 
+        <Array Name="gLinkAdultHookshotRedicleVtx" Count="3" Offset="0x2CB18">
+            <Vtx/>
+        </Array>
+
         <DList Name="gLinkAdultHookshotReticleDL" Offset="0x2CB48"/>
 
         <!-- Boots -->

--- a/soh/assets/xml/N64_PAL_11/objects/object_link_boy.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_link_boy.xml
@@ -202,6 +202,10 @@
         <Texture Name="gLinkAdultGauntletPlate1Tex" OutName="gauntlet_plate_1" Format="rgba16" Width="16" Height="32" Offset="0x9980"/>
         <Texture Name="gLinkAdultGauntletPlate2Tex" OutName="gauntlet_plate_2" Format="rgba16" Width="32" Height="32" Offset="0x9D80"/>
 
+        <Array Name="gLinkAdultHookshotRedicleVtx" Count="3" Offset="0x2CB18">
+            <Vtx/>
+        </Array>
+
         <DList Name="gLinkAdultHookshotReticleDL" Offset="0x2CB48"/>
 
         <!-- Boots -->

--- a/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
+++ b/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
@@ -195,7 +195,9 @@ static std::map<std::string, CosmeticOption> cosmeticOptions = {
     COSMETIC_OPTION("Link_Hair",                     "Hair",                 GROUP_LINK,         ImVec4(255, 173,  27, 255), false, true, true),
     COSMETIC_OPTION("Link_Linen",                    "Linen",                GROUP_LINK,         ImVec4(255, 255, 255, 255), false, true, true),
     COSMETIC_OPTION("Link_Boots",                    "Boots",                GROUP_LINK,         ImVec4( 93,  44,  18, 255), false, true, true),
-
+    COSMETIC_OPTION("HookshotReticle_Target",        "Hookshotable Reticle", GROUP_LINK,         ImVec4(  0, 255,   0, 255), false, false, false),
+    COSMETIC_OPTION("HookshotReticle_NonTarget",     "Non-Hookshotable Reticle", GROUP_LINK,     ImVec4(255,   0,   0, 255), false, false, false),
+    
     COSMETIC_OPTION("MirrorShield_Body",             "Body",                 GROUP_MIRRORSHIELD, ImVec4(215,   0,   0, 255), false, true, false),
     COSMETIC_OPTION("MirrorShield_Mirror",           "Mirror",               GROUP_MIRRORSHIELD, ImVec4(255, 255, 255, 255), false, true, true),
     COSMETIC_OPTION("MirrorShield_Emblem",           "Emblem",               GROUP_MIRRORSHIELD, ImVec4(205, 225, 255, 255), false, true, true),

--- a/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
+++ b/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
@@ -195,8 +195,6 @@ static std::map<std::string, CosmeticOption> cosmeticOptions = {
     COSMETIC_OPTION("Link_Hair",                     "Hair",                 GROUP_LINK,         ImVec4(255, 173,  27, 255), false, true, true),
     COSMETIC_OPTION("Link_Linen",                    "Linen",                GROUP_LINK,         ImVec4(255, 255, 255, 255), false, true, true),
     COSMETIC_OPTION("Link_Boots",                    "Boots",                GROUP_LINK,         ImVec4( 93,  44,  18, 255), false, true, true),
-    COSMETIC_OPTION("HookshotReticle_Target",        "Hookshotable Reticle", GROUP_LINK,         ImVec4(  0, 255,   0, 255), false, false, false),
-    COSMETIC_OPTION("HookshotReticle_NonTarget",     "Non-Hookshotable Reticle", GROUP_LINK,     ImVec4(255,   0,   0, 255), false, false, false),
     
     COSMETIC_OPTION("MirrorShield_Body",             "Body",                 GROUP_MIRRORSHIELD, ImVec4(215,   0,   0, 255), false, true, false),
     COSMETIC_OPTION("MirrorShield_Mirror",           "Mirror",               GROUP_MIRRORSHIELD, ImVec4(255, 255, 255, 255), false, true, true),
@@ -221,8 +219,9 @@ static std::map<std::string, CosmeticOption> cosmeticOptions = {
     COSMETIC_OPTION("Equipment_HammerHead",          "Hammer Head",          GROUP_EQUIPMENT,    ImVec4(155, 192, 201, 255), false, true, false),
     COSMETIC_OPTION("Equipment_HammerHandle",        "Hammer Handle",        GROUP_EQUIPMENT,    ImVec4(110,  60,   0, 255), false, true, true),
     // COSMETIC_OPTION("Equipment_HookshotChain",       "Hookshot Chain",       GROUP_EQUIPMENT,    ImVec4(255, 255, 255, 255), false, true, true), // Todo (Cosmetics): Implement
-    // COSMETIC_OPTION("Equipment_HookshotReticle",     "Hookshot Reticle",     GROUP_EQUIPMENT,    ImVec4(255, 255, 255, 255), false, true, true), // Todo (Cosmetics): Implement
     // COSMETIC_OPTION("Equipment_HookshotTip",         "Hookshot Tip",         GROUP_EQUIPMENT,    ImVec4(255, 255, 255, 255), false, true, false), // Todo (Cosmetics): Implement
+    COSMETIC_OPTION("HookshotReticle_Target",        "Hookshotable Reticle", GROUP_EQUIPMENT,         ImVec4(  0, 255,   0, 255), false, false, false),
+    COSMETIC_OPTION("HookshotReticle_NonTarget",     "Non-Hookshotable Reticle", GROUP_EQUIPMENT,     ImVec4(255,   0,   0, 255), false, false, false),
     COSMETIC_OPTION("Equipment_BowTips",             "Bow Tips",             GROUP_EQUIPMENT,    ImVec4(200,   0,   0, 255), false, true, true),
     COSMETIC_OPTION("Equipment_BowString",           "Bow String",           GROUP_EQUIPMENT,    ImVec4(255, 255, 255, 255), false, true, true),
     COSMETIC_OPTION("Equipment_BowBody",             "Bow Body",             GROUP_EQUIPMENT,    ImVec4(140,  90,  10, 255), false, true, false),

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -868,6 +868,9 @@ void DrawEnhancementsMenu() {
             UIWidgets::PaddedEnhancementCheckbox("Enemy Health Bars", "gEnemyHealthBar", true, false);
             UIWidgets::Tooltip("Renders a health bar for enemies when Z-Targeted");
 
+            UIWidgets::PaddedEnhancementCheckbox("Targetable Hookshot Reticle", "gHookshotableReticle", true, false);
+            UIWidgets::Tooltip("Use a different color when aiming at hookshotable collision");
+
             ImGui::EndMenu();
         }
 

--- a/soh/src/code/z_player_lib.c
+++ b/soh/src/code/z_player_lib.c
@@ -1325,12 +1325,6 @@ void func_80090A28(Player* this, Vec3f* vecs) {
     Matrix_MultVec3f(&D_80126098, &vecs[2]);
 }
 
-static const Vtx object_link_boyVtx_02CB18_B[] = {
-    VTX(-50, -30, 0, -683, 2048, 255, 0, 0, 255),
-    VTX(50, -30, 0, 2731, 2048, 255, 0, 0, 255),
-    VTX(0, 70, 0, 1024, -1365, 255, 0, 0, 255),
-};
-
 void Player_DrawHookshotReticle(PlayState* play, Player* this, f32 hookshotRange) {
     static Vec3f D_801260C8 = { -500.0f, -100.0f, 0.0f };
     CollisionPoly* colPoly;
@@ -1373,7 +1367,7 @@ void Player_DrawHookshotReticle(PlayState* play, Player* this, f32 hookshotRange
             const Color_RGBA8 color = CVarGetColor("gCosmetics.HookshotReticle_NonTarget.Value", defaultColor);
             gDPSetPrimColor(WORLD_OVERLAY_DISP++, 0, 0, color.r, color.g, color.b, color.a);
         }
-        gSPVertex(WORLD_OVERLAY_DISP++, &object_link_boyVtx_02CB18_B[0], 3, 0);
+        gSPVertex(WORLD_OVERLAY_DISP++, (uintptr_t)gLinkAdultHookshotReticleTex, 3, 0);
         gSP1Triangle(WORLD_OVERLAY_DISP++, 0, 1, 2, 0);
 
         CLOSE_DISPS(play->state.gfxCtx);

--- a/soh/src/code/z_player_lib.c
+++ b/soh/src/code/z_player_lib.c
@@ -1325,38 +1325,56 @@ void func_80090A28(Player* this, Vec3f* vecs) {
     Matrix_MultVec3f(&D_80126098, &vecs[2]);
 }
 
-void Player_DrawHookshotReticle(PlayState* play, Player* this, f32 arg2) {
+static const Vtx object_link_boyVtx_02CB18_B[] = {
+    VTX(-50, -30, 0, -683, 2048, 255, 0, 0, 255),
+    VTX(50, -30, 0, 2731, 2048, 255, 0, 0, 255),
+    VTX(0, 70, 0, 1024, -1365, 255, 0, 0, 255),
+};
+
+void Player_DrawHookshotReticle(PlayState* play, Player* this, f32 hookshotRange) {
     static Vec3f D_801260C8 = { -500.0f, -100.0f, 0.0f };
-    CollisionPoly* sp9C;
+    CollisionPoly* colPoly;
     s32 bgId;
-    Vec3f sp8C;
-    Vec3f sp80;
-    Vec3f sp74;
+    Vec3f hookshotStart;
+    Vec3f hookshotEnd;
+    Vec3f firstHit;
     Vec3f sp68;
     f32 sp64;
-    f32 sp60;
 
     D_801260C8.z = 0.0f;
-    Matrix_MultVec3f(&D_801260C8, &sp8C);
-    D_801260C8.z = arg2;
-    Matrix_MultVec3f(&D_801260C8, &sp80);
+    Matrix_MultVec3f(&D_801260C8, &hookshotStart);
+    D_801260C8.z = hookshotRange;
+    Matrix_MultVec3f(&D_801260C8, &hookshotEnd);
 
-    if (BgCheck_AnyLineTest3(&play->colCtx, &sp8C, &sp80, &sp74, &sp9C, 1, 1, 1, 1, &bgId)) {
+    if (BgCheck_AnyLineTest3(&play->colCtx, &hookshotStart, &hookshotEnd, &firstHit, &colPoly, 1, 1, 1, 1, &bgId)) {
         OPEN_DISPS(play->state.gfxCtx);
 
         WORLD_OVERLAY_DISP = Gfx_SetupDL(WORLD_OVERLAY_DISP, 0x07);
 
-        SkinMatrix_Vec3fMtxFMultXYZW(&play->viewProjectionMtxF, &sp74, &sp68, &sp64);
+        SkinMatrix_Vec3fMtxFMultXYZW(&play->viewProjectionMtxF, &firstHit, &sp68, &sp64);
 
-        sp60 = (sp64 < 200.0f) ? 0.08f : (sp64 / 200.0f) * 0.08f;
+        const f32 sp60 = (sp64 < 200.0f) ? 0.08f : (sp64 / 200.0f) * 0.08f;
 
-        Matrix_Translate(sp74.x, sp74.y, sp74.z, MTXMODE_NEW);
+        Matrix_Translate(firstHit.x, firstHit.y, firstHit.z, MTXMODE_NEW);
         Matrix_Scale(sp60, sp60, sp60, MTXMODE_APPLY);
 
-        gSPMatrix(WORLD_OVERLAY_DISP++, MATRIX_NEWMTX(play->state.gfxCtx),
-                  G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
-        gSPSegment(WORLD_OVERLAY_DISP++, 0x06, play->objectCtx.status[this->actor.objBankIndex].segment);
-        gSPDisplayList(WORLD_OVERLAY_DISP++, gLinkAdultHookshotReticleDL);
+        gSPMatrix(WORLD_OVERLAY_DISP++, MATRIX_NEWMTX(play->state.gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+        char* tex = ResourceMgr_LoadTexOrDListByName(gLinkAdultHookshotReticleTex);
+        gSPMatrix(WORLD_OVERLAY_DISP++, SEG_ADDR(1, 0), G_MTX_NOPUSH | G_MTX_MUL | G_MTX_MODELVIEW);
+        gSPTexture(WORLD_OVERLAY_DISP++, 0xFFFF, 0xFFFF, 0, G_TX_RENDERTILE, G_ON);
+        gDPLoadTextureBlock(WORLD_OVERLAY_DISP++, tex, G_IM_FMT_I, G_IM_SIZ_8b, 64, 64, 0, G_TX_NOMIRROR | G_TX_CLAMP,
+                            G_TX_NOMIRROR | G_TX_CLAMP, 6, 6, G_TX_NOLOD, G_TX_NOLOD);
+        if (SurfaceType_IsHookshotSurface(&play->colCtx, colPoly, bgId) && CVarGetInteger("gHookshotableReticle", false)) {
+            const Color_RGBA8 defaultColor = { .r = 0, .g = 255, .b = 0, .a = 255 };
+            const Color_RGBA8 color = CVarGetColor("gCosmetics.HookshotReticle_Target.Value", defaultColor);
+            gDPSetPrimColor(WORLD_OVERLAY_DISP++, 0, 0, color.r, color.g, color.b, color.a);
+        } else {
+            const Color_RGBA8 defaultColor = { .r = 255, .g = 0, .b = 0, .a = 255 };
+            const Color_RGBA8 color = CVarGetColor("gCosmetics.HookshotReticle_NonTarget.Value", defaultColor);
+            gDPSetPrimColor(WORLD_OVERLAY_DISP++, 0, 0, color.r, color.g, color.b, color.a);
+        }
+        gSPVertex(WORLD_OVERLAY_DISP++, &object_link_boyVtx_02CB18_B[0], 3, 0);
+        gSP1Triangle(WORLD_OVERLAY_DISP++, 0, 1, 2, 0);
 
         CLOSE_DISPS(play->state.gfxCtx);
     }


### PR DESCRIPTION
Resolves #2811
There are a few things I don't like. The name in the editor feels too long. Also, I had to convert the DL to a dynamic DL for the CVar and bring the VTX to C because ZAPD wouldn't extract it.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/851345690.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/851345691.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/851345692.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/851345693.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/851345696.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/851345697.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/851345700.zip)
<!--- section:artifacts:end -->