### PR TITLE
Fix: Anju rando item gives failing when performing an action

### DIFF
--- a/soh/src/overlays/actors/ovl_En_Niw_Lady/z_en_niw_lady.c
+++ b/soh/src/overlays/actors/ovl_En_Niw_Lady/z_en_niw_lady.c
@@ -401,8 +401,8 @@ void func_80ABA9B8(EnNiwLady* this, PlayState* play) {
                 if (!gSaveContext.n64ddFlag) {
                     func_8002F434(&this->actor, play, GI_POCKET_EGG, 200.0f, 100.0f);
                 } else {
-                    // TODO: get-item-rework Adult trade sequence
                     this->getItemEntry = Randomizer_GetItemFromKnownCheck(RC_KAK_ANJU_AS_ADULT, GI_POCKET_EGG);
+                    GiveItemEntryFromActor(&this->actor, play, this->getItemEntry, 200.0f, 100.0f);
                     gSaveContext.itemGetInf[2] |= 0x1000;
                 }
 
@@ -436,9 +436,9 @@ void func_80ABAB08(EnNiwLady* this, PlayState* play) {
                 if (!gSaveContext.n64ddFlag) {
                     func_8002F434(&this->actor, play, GI_COJIRO, 200.0f, 100.0f);
                 } else {
-                    // TODO: get-item-rework Adult trade sequence
                     this->getItemEntry = Randomizer_GetItemFromKnownCheck(RC_KAK_TRADE_POCKET_CUCCO, GI_COJIRO);
                     Randomizer_ConsumeAdultTradeItem(play, ITEM_POCKET_CUCCO);
+                    GiveItemEntryFromActor(&this->actor, play, this->getItemEntry, 200.0f, 100.0f);
                     gSaveContext.itemGetInf[2] |= 0x4000;
                 }
                 this->actionFunc = func_80ABAC00;
@@ -462,21 +462,17 @@ void func_80ABAC00(EnNiwLady* this, PlayState* play) {
     if (Actor_HasParent(&this->actor, play)) {
         this->actionFunc = func_80ABAC84;
     } else {
+         if (gSaveContext.n64ddFlag) {
+            getItemId = this->getItemEntry.getItemId;
+            GiveItemEntryFromActor(&this->actor, play, this->getItemEntry, 200.0f, 100.0f);
+            return;
+        }
+
         getItemId = this->getItemId;
         if (LINK_IS_ADULT) {
-            if (!gSaveContext.n64ddFlag) {
-                getItemId = !(gSaveContext.itemGetInf[2] & 0x1000) ? GI_POCKET_EGG : GI_COJIRO;
-            } else {
-                // TODO: get-item-rework Adult trade sequence
-                getItemId = this->getItemEntry.getItemId;
-                GiveItemEntryFromActor(&this->actor, play, this->getItemEntry, 200.0f, 100.0f);
-                // Skip setting item flags because that was done earlier
-                this->actionFunc = func_80ABA778;
-            }
+            getItemId = !(gSaveContext.itemGetInf[2] & 0x1000) ? GI_POCKET_EGG : GI_COJIRO;
         }
-        if (this->getItemEntry.getItemId == GI_NONE) {
-            func_8002F434(&this->actor, play, getItemId, 200.0f, 100.0f);
-        }
+        func_8002F434(&this->actor, play, getItemId, 200.0f, 100.0f);
     }
 }
 
@@ -486,10 +482,13 @@ void func_80ABAC84(EnNiwLady* this, PlayState* play) {
     }
     osSyncPrintf(VT_FGCOL(GREEN) "☆☆☆☆☆ 正常終了 ☆☆☆☆☆ \n" VT_RST);
     if (LINK_IS_ADULT) {
-        if (!(gSaveContext.itemGetInf[2] & 0x1000)) {
-            gSaveContext.itemGetInf[2] |= 0x1000;
-        } else {
-            gSaveContext.itemGetInf[2] |= 0x4000;
+        // Flags for randomizer gives are set in the original message prompt choice handling
+        if (!gSaveContext.n64ddFlag) {
+            if (!(gSaveContext.itemGetInf[2] & 0x1000)) {
+                gSaveContext.itemGetInf[2] |= 0x1000;
+            } else {
+                gSaveContext.itemGetInf[2] |= 0x4000;
+            }
         }
         this->actionFunc = func_80ABA778;
     } else {


### PR DESCRIPTION
A previous fix to Anju for adult rando item gives (#1766) introduced a bug where the GiveItem calls were only executed once, which meant if the player performed any action that blocks an GiveItem for the frame (shielding, pulling out any items, etc), the item would not be given on the next frame as the code path for Anju has finished.

This PR restores the desired code paths, matching what the vanilla item gives do, while maintaining that the correct flags are set in rando.

There were todo statements that weren't clear why they were there, so I removed them as the item gives now match the same behavior as the rest of the code base in my opinion.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/848587494.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/848587495.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/848587496.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/848587497.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/848587498.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/848587499.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/848587500.zip)
<!--- section:artifacts:end -->