### PR TITLE
Fix: Dark Link's inputs in Mirror mode

### DIFF
--- a/soh/src/overlays/actors/ovl_En_Torch2/z_en_torch2.c
+++ b/soh/src/overlays/actors/ovl_En_Torch2/z_en_torch2.c
@@ -591,6 +591,10 @@ void EnTorch2_Update(Actor* thisx, PlayState* play2) {
     input->prev.button = input->cur.button & (u16) ~(BTN_A | BTN_B);
     PadUtils_UpdateRelXY(input);
 
+    if (CVarGetInteger("gMirroredWorld", 0)) {
+        input->rel.stick_x *= -1;
+    }
+
     input->press.stick_x += (s8)(input->cur.stick_x - input->prev.stick_x);
     input->press.stick_y += (s8)(input->cur.stick_y - input->prev.stick_y);
 


### PR DESCRIPTION
Dark Link's update logic runs through `Player_UpdateCommon` just like the regular player. This means Dark Link's simulated "controller" inputs were getting inverted in mirror mode. This was causing him to move irregularly while mirror mode is active.

This adds another inverse to Dark Link's relative stick x input to negate the second inverse later on in `Player_UpdateCommon`, fixing his "AI" behavior when mirror mode is on.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/848993177.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/848993180.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/848993182.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/848993183.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/848993184.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/848993185.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/848993186.zip)
<!--- section:artifacts:end -->