### PR TITLE
Fix: Align remaining unaligned assets for mac

### DIFF
--- a/soh/src/code/gfxprint.c
+++ b/soh/src/code/gfxprint.c
@@ -1,4 +1,5 @@
 #include "global.h"
+#include "align_asset_macro.h"
 
 u16 sGfxPrintFontTLUT[64] = {
     0x0000, 0xFFFF, 0x0000, 0xFFFF, 0x0000, 0xFFFF, 0x0000, 0xFFFF, 0x0000, 0xFFFF, 0x0000, 0xFFFF, 0x0000,
@@ -128,8 +129,12 @@ u8 sGfxPrintFontData[(16 * 256) / 2] = {
 
 // Can be used to set GFXP_FLAG_ENLARGE by default
 static u8 sDefaultSpecialFlags;
-static const char rGfxPrintFontData[] = "__OTR__textures/font/sGfxPrintFontData";
-static const char rGfxPrintFontDataAlt[] = "__OTR__alt/textures/font/sGfxPrintFontData";
+
+#define drGfxPrintFontData "__OTR__textures/font/sGfxPrintFontData";
+static const ALIGN_ASSET(2) char rGfxPrintFontData[] = drGfxPrintFontData;
+
+#define drGfxPrintFontDataAlt "__OTR__alt/textures/font/sGfxPrintFontData";
+static const ALIGN_ASSET(2) char rGfxPrintFontDataAlt[] = drGfxPrintFontDataAlt;
 
 // OTRTODO: this isn't as clean as it could be if we implemented
 // the GfxPrint texture extraction to `.otr` as described in

--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -211,8 +211,6 @@ static const char* actionsTbl[] =
     gNum8DoActionENGTex,
 };
 
-static const char gDoEmptyTexture[] = "__OTR__textures/virtual/gEmptyTexture";
-
 // original name: "alpha_change"
 void Interface_ChangeAlpha(u16 alphaType) {
     if (alphaType != gSaveContext.unk_13EA) {
@@ -2897,7 +2895,7 @@ void Interface_LoadActionLabel(InterfaceContext* interfaceCtx, u16 action, s16 l
     }
     
     char* segment = interfaceCtx->doActionSegment[loadOffset];
-    interfaceCtx->doActionSegment[loadOffset] = action != DO_ACTION_NONE ? doAction : gDoEmptyTexture;
+    interfaceCtx->doActionSegment[loadOffset] = action != DO_ACTION_NONE ? doAction : gEmptyTexture;
     gSegments[7] = interfaceCtx->doActionSegment[loadOffset];
 }
 
@@ -2964,7 +2962,7 @@ void Interface_LoadActionLabelB(PlayState* play, u16 action) {
     interfaceCtx->unk_1FC = action;
     
     char* segment = interfaceCtx->doActionSegment[1];
-    interfaceCtx->doActionSegment[1] = action != DO_ACTION_NONE ? doAction : gDoEmptyTexture;
+    interfaceCtx->doActionSegment[1] = action != DO_ACTION_NONE ? doAction : gEmptyTexture;
     osRecvMesg(&interfaceCtx->loadQueue, NULL, OS_MESG_BLOCK);
 
     interfaceCtx->unk_1FA = 1;


### PR DESCRIPTION
This continues the fix done in #2819 to cover a few more left over spots that were still using unaligned string values.
This fixes a reported issue of some texture packs causing crashes on Macs with a M processor.

Fixes #3125

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/875344827.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/875344833.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/875344841.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/875344846.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/875344852.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/875344856.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/875344861.zip)
<!--- section:artifacts:end -->