### PR TITLE
Fix bombs not showing up

### DIFF
--- a/soh/src/overlays/actors/ovl_En_Bom/z_en_bom.c
+++ b/soh/src/overlays/actors/ovl_En_Bom/z_en_bom.c
@@ -267,7 +267,7 @@ void EnBom_Update(Actor* thisx, PlayState* play2) {
     }
 
     // With random bomb fuse timer or gBombTimerMultiplier, sound effect and scaling is already done on init.
-    if (this->timer == 67 && !GameInteractor_GetRandomBombFuseTimerActive() && CVarGetFloat("gBombTimerMultiplier", 1.0f) != 1.0f) {
+    if (this->timer == 67 && !GameInteractor_GetRandomBombFuseTimerActive() && CVarGetFloat("gBombTimerMultiplier", 1.0f) == 1.0f) {
         Audio_PlayActorSound2(thisx, NA_SE_PL_TAKE_OUT_SHIELD);
         Actor_SetScale(thisx, 0.01f);
     }


### PR DESCRIPTION
If statement wasn't entered when bomb duration value wasn't changed because it was reversed.

That said, I'm still not sure if it's ok to directly compare float values.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/880228774.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/880228775.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/880228776.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/880228777.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/880228779.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/880228780.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/880228784.zip)
<!--- section:artifacts:end -->