### PR TITLE
Bush Item Drops: Vanilla Bug

### DIFF
--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -1017,6 +1017,8 @@ void DrawEnhancementsMenu() {
             UIWidgets::PaddedEnhancementCheckbox("Fix Poacher's Saw Softlock", "gFixSawSoftlock", true, false, CVarGetInteger("gSkipText", 0),
                 "This is disabled because it is forced on when Skip Text is enabled.", UIWidgets::CheckboxGraphics::Checkmark);
             UIWidgets::Tooltip("Prevents the Poacher's Saw softlock from mashing through the text, or with Skip Text enabled.");
+            UIWidgets::PaddedEnhancementCheckbox("Fix Bush Item Drops", "gBushDropFix", true, false);
+            UIWidgets::Tooltip("Fixes the bushes to drop items correctly rather than spawning undefined items.");
 
             ImGui::EndMenu();
         }

--- a/soh/src/code/z_en_item00.c
+++ b/soh/src/code/z_en_item00.c
@@ -1753,7 +1753,11 @@ void Item_DropCollectibleRandom(PlayState* play, Actor* fromActor, Vec3f* spawnP
                     }
                 }
             } else {
-                Item_DropCollectible(play, spawnPos, params | 0x8000);
+                if (CVarGetInteger("gBushDropFix", 0)) {
+                    Item_DropCollectible(play, spawnPos, dropId | 0x8000);
+                } else {
+                    Item_DropCollectible(play, spawnPos, params | 0x8000);
+                }
             }
             dropQuantity--;
         }


### PR DESCRIPTION
I found this a while ago when discussing why fairies would spawn from bushes but other items seemingly wouldn't. It turns out that the wrong actor parameter was being passed to the function which would call the actor spawn and so item00 actors were being spawned with undefined actor params, causing uncollectible and invisible items (due to the undefined nature) to spawn; fairies turned out to be handled as a special case before this function would get called.

May need more testing but I believe this path is only reachable from rustling the bushes, from memory the function's params need params & 0x8000 to be true. In the case of the bush the function param is 0x8020 and there is no defined item00 with actor param 0x20 (only the last part is taken into account). Regular items would be spawned with params in the range 0x8000 -> 0x8019 (0x8018 without chu drops), however, this would still be what I believe is 'unintended' behaviour.

Wasn't sure if this should be added to any enhancement presets so lmk if any are suitable.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/881706991.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/881706994.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/881706996.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/881706998.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/881707000.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/881707003.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/881707006.zip)
<!--- section:artifacts:end -->