### PR TITLE
Fix: Audio crash when trying to detect BGM_DISABLED

### DIFF
--- a/soh/src/code/audio_load.c
+++ b/soh/src/code/audio_load.c
@@ -486,8 +486,10 @@ void AudioLoad_AsyncLoadFont(s32 fontId, s32 arg1, s32 retData, OSMesgQueue* ret
 u8* AudioLoad_GetFontsForSequence(s32 seqId, u32* outNumFonts) {
     s32 index;
 
-     if (seqId == NA_BGM_DISABLED)
-         return NULL;
+    // Check for NA_BGM_DISABLED and account for seqId that are stripped with `& 0xFF` by the caller
+    if (seqId == NA_BGM_DISABLED || seqId == 0xFF) {
+        return NULL;
+    }
 
     u16 newSeqId = AudioEditor_GetReplacementSeq(seqId);
     if (newSeqId > sequenceMapSize || !sequenceMap[newSeqId]) {

--- a/soh/src/code/code_800EC960.c
+++ b/soh/src/code/code_800EC960.c
@@ -4659,19 +4659,25 @@ void func_800F5C2C(void) {
 
 void Audio_PlayFanfare(u16 seqId)
 {
-    u16 sp26;
-    u32 sp20;
-    u8* sp1C;
-    u8* sp18;
+    u16 curSeqId;
+    u32 outNumFonts;
+    u8* curFontId;
+    u8* requestedFontId;
 
-    sp26 = func_800FA0B4(SEQ_PLAYER_FANFARE);
-    sp1C = func_800E5E84(sp26 & 0xFF, &sp20);
-    sp18 = func_800E5E84(seqId, &sp20);
-	if (!sp1C || !sp18) {
+    curSeqId = func_800FA0B4(SEQ_PLAYER_FANFARE);
+
+    // Although seqIds are u16, there is no fanfare that is above 0xFF
+    // Sometimes the game will add 0x900 to a requested fanfare ID
+    // The `& 0xFF` here is to strip off this 0x900 and get the original fanfare ID
+    // when getting the sound font data for the sequence
+    curFontId = func_800E5E84(curSeqId & 0xFF, &outNumFonts);
+    requestedFontId = func_800E5E84(seqId & 0xFF, &outNumFonts);
+
+	if (!curFontId || !requestedFontId) {
 		// disable BGM, we're about to null deref!
 		D_8016B9F4 = 1;
 	} else {
-		if ((sp26 == NA_BGM_DISABLED) || (*sp1C == *sp18)) {
+		if ((curSeqId == NA_BGM_DISABLED) || (*curFontId == *requestedFontId)) {
 			D_8016B9F4 = 1;
 		} else {
 			D_8016B9F4 = 5;


### PR DESCRIPTION
The introduction of #3080 exposed a bug where we were improperly detecting the `BGM_DISABLED` sequence.

The bug previously was obscured if you didn't have any custom sequences loaded, as `BGM_DISABLED & 0xFF` is 255 and there was only like 110 sequences in `sequenceMap` meaning that `AudioLoad_GetFontsForSequence` would return `null`. If you had custom sequences loaded, it was possible that the 255 would then load whatever font data exists for the sequence in that location (undefined behavior), but in `Audio_PlayFanfare` the font data is never read, only that it is or isn't null, so nothing bad ever happened.

With the voice additions from #3080, without custom sequences loaded, `sequenceMap` now has a size of 255, meaning that we were attempting to read the font data for `BGM_DISABLED & 0xFF` which lead to a invalid pointer de-reference and crashing.

When introducing custom sequences we removed one of the `& 0xFF` from `Audio_PlayFanfare` and added a check for `BGM_DSIABLED` to prevent a audio crash. Although removing the other `& 0xFF` from here will resolve the new audio crash in develop today, there is an incorrect sequence look up happening.

In reviewing all uses of `Audio_PlayFanfare` there is no such fanfare ID above `u8` even though sequence ID types are `u16`, however sometimes the game will append `0x900` to fanfare requests (Item Gets, opening big treasure chests, etc). This explains the original reason for `& 0xFF` from the original game as the `0x900` needs to be stripped off before looking up the sequence ID's font data.

In this case, I have opted to bring back the original `& 0xFF` that we removed, and instead updated of catch for `BGM_DISABLED` in `AudioLoad_GetFontsForSequence` to account for seq ID being stripped to `u8` range.

I think this is the better approach to resolving the crashes and accounting for authentic behavior.

(I also synced some var names with decomp documentation while updating this)

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/882968630.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/882968631.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/882968632.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/882968633.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/882968634.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/882968635.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/882968636.zip)
<!--- section:artifacts:end -->