### PR TITLE
Fixes some places where Shadow Tag can be problematic.

### DIFF
--- a/soh/soh/Enhancements/mods.cpp
+++ b/soh/soh/Enhancements/mods.cpp
@@ -355,11 +355,19 @@ void RegisterShadowTag() {
         if (!CVarGetInteger("gShadowTag", 0)) {
             return;
         }
-        if (shouldSpawn && (delayTimer <= 0)) {
-            Actor_Spawn(&gPlayState->actorCtx, gPlayState, ACTOR_EN_WALLMAS, 0, 0, 0, 0, 0, 0, 3, false);
-            shouldSpawn = false;
+        
+        if (gPlayState->sceneNum == SCENE_BMORI1 &&  //Forest Temple Scene
+            gPlayState->roomCtx.curRoom.num == 16 || //Green Poe Room
+            gPlayState->roomCtx.curRoom.num == 13 || //Blue Poe Room
+            gPlayState->roomCtx.curRoom.num == 12) { //Red Poe Room
+            return;
         } else {
-            delayTimer--;
+            if (shouldSpawn && (delayTimer <= 0)) {
+                Actor_Spawn(&gPlayState->actorCtx, gPlayState, ACTOR_EN_WALLMAS, 0, 0, 0, 0, 0, 0, 3, false);
+                shouldSpawn = false;
+            } else {
+                delayTimer--;
+            }
         }
     });
     GameInteractor::Instance->RegisterGameHook<GameInteractor::OnSceneSpawnActors>([]() {

--- a/soh/src/overlays/actors/ovl_En_Wallmas/z_en_wallmas.c
+++ b/soh/src/overlays/actors/ovl_En_Wallmas/z_en_wallmas.c
@@ -327,7 +327,11 @@ void EnWallmas_WaitToDrop(EnWallmas* this, PlayState* play) {
     }
 
     if (this->timer == 0) {
-        EnWallmas_SetupDrop(this, play);
+        if (this->actor.params == WMT_SHADOWTAG && player->stateFlags1) {
+        this->timer = 0x82; // Prevents Shadow Tag Hand from dropping when in an event.
+        } else {
+            EnWallmas_SetupDrop(this, play);
+        }
     }
 }
 

--- a/soh/src/overlays/actors/ovl_En_Wallmas/z_en_wallmas.c
+++ b/soh/src/overlays/actors/ovl_En_Wallmas/z_en_wallmas.c
@@ -327,8 +327,8 @@ void EnWallmas_WaitToDrop(EnWallmas* this, PlayState* play) {
     }
 
     if (this->timer == 0) {
-        if (this->actor.params == WMT_SHADOWTAG && player->stateFlags1) {
-        this->timer = 0x82; // Prevents Shadow Tag Hand from dropping when in an event.
+        if (this->actor.params == WMT_SHADOWTAG && (player->stateFlags1 & PLAYER_STATE1_IN_CUTSCENE)) {
+        this->timer = 0x82; // Prevents Shadow Tag Hand from dropping when talking to an NPC or Signpost.
         } else {
             EnWallmas_SetupDrop(this, play);
         }


### PR DESCRIPTION
In the Forest Temple, the Wallmaster would interfere with the Green, Blue, and Red Poe Sisters Flags. This will prevent the Shadow Tag Wallmaster from spawing in this rooms.

In place like Goron City where the cutscene/text interaction with NPCs prevents link from moving, the Shadow Tag Wallmasters timer gets reset until the dialogue/interaction is over.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/886880134.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/886880135.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/886880137.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/886880138.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/886880139.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/886880140.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/886880141.zip)
<!--- section:artifacts:end -->