### PR TITLE
Add XML definitions for all textures that are auto-generated by ZAPD

### DIFF
--- a/ZAPDTR/ZAPD/ZTexture.cpp
+++ b/ZAPDTR/ZAPD/ZTexture.cpp
@@ -27,6 +27,13 @@ ZTexture::ZTexture(ZFile* nParent) : ZResource(nParent)
 	RegisterOptionalAttribute("ExternalTlut");
 	RegisterOptionalAttribute("ExternalTlutOffset");
 	RegisterOptionalAttribute("SplitTlut");
+
+	// Dummy property added by https://github.com/HarbourMasters/Shipwright/pull/3161
+	// Used to indicate if a resource definition was added through a script
+	// and to enable easy removal/re-add of the definitions when introducing new rom support
+	// Can be removed once we feel it is no longer useful
+	// This is not used in ZAPD itself, the registration is to prevent missing attribute errors
+	RegisterOptionalAttribute("AddedByScript");
 }
 
 void ZTexture::ExtractFromBinary(uint32_t nRawDataIndex, int32_t nWidth, int32_t nHeight,

--- a/soh/assets/xml/GC_MQ_D/objects/gameplay_dangeon_keep.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/gameplay_dangeon_keep.xml
@@ -1,5 +1,28 @@
 <Root>
     <File Name="gameplay_dangeon_keep" Segment="5">
+        <Texture Name="gameplay_dangeon_keepTex_000000" OutName="gameplay_dangeon_keepTex_000000" Format="i8" Width="16" Height="32" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_000200" OutName="gameplay_dangeon_keepTex_000200" Format="i8" Width="16" Height="32" Offset="0x200" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_0005C0" OutName="gameplay_dangeon_keepTex_0005C0" Format="rgba16" Width="16" Height="16" Offset="0x5C0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_001280" OutName="gameplay_dangeon_keepTex_001280" Format="rgba16" Width="32" Height="32" Offset="0x1280" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_0078A0" OutName="gameplay_dangeon_keepTex_0078A0" Format="i8" Width="32" Height="32" Offset="0x78A0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_007CA0" OutName="gameplay_dangeon_keepTex_007CA0" Format="i8" Width="32" Height="32" Offset="0x7CA0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_0080A0" OutName="gameplay_dangeon_keepTex_0080A0" Format="rgba16" Width="32" Height="32" Offset="0x80A0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_0088A0" OutName="gameplay_dangeon_keepTex_0088A0" Format="rgba16" Width="32" Height="32" Offset="0x88A0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_00D8A0" OutName="gameplay_dangeon_keepTex_00D8A0" Format="rgba16" Width="32" Height="32" Offset="0xD8A0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_00E0A0" OutName="gameplay_dangeon_keepTex_00E0A0" Format="rgba16" Width="32" Height="32" Offset="0xE0A0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_00F8A0" OutName="gameplay_dangeon_keepTex_00F8A0" Format="rgba16" Width="64" Height="32" Offset="0xF8A0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_0108A0" OutName="gameplay_dangeon_keepTex_0108A0" Format="rgba16" Width="32" Height="64" Offset="0x108A0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_0118A0" OutName="gameplay_dangeon_keepTex_0118A0" Format="rgba16" Width="16" Height="16" Offset="0x118A0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_011AA0" OutName="gameplay_dangeon_keepTex_011AA0" Format="rgba16" Width="16" Height="16" Offset="0x11AA0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_011CA0" OutName="gameplay_dangeon_keepTex_011CA0" Format="rgba16" Width="32" Height="64" Offset="0x11CA0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_012CA0" OutName="gameplay_dangeon_keepTex_012CA0" Format="rgba16" Width="64" Height="16" Offset="0x12CA0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_0134A0" OutName="gameplay_dangeon_keepTex_0134A0" Format="rgba16" Width="32" Height="32" Offset="0x134A0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_013CA0" OutName="gameplay_dangeon_keepTex_013CA0" Format="ia8" Width="4" Height="4" Offset="0x13CA0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_013CB0" OutName="gameplay_dangeon_keepTex_013CB0" Format="i4" Width="64" Height="64" Offset="0x13CB0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_0154B0" OutName="gameplay_dangeon_keepTex_0154B0" Format="rgba16" Width="32" Height="32" Offset="0x154B0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_015CB0" OutName="gameplay_dangeon_keepTex_015CB0" Format="rgba16" Width="32" Height="32" Offset="0x15CB0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_0164B0" OutName="gameplay_dangeon_keepTex_0164B0" Format="rgba16" Width="32" Height="32" Offset="0x164B0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_016CB0" OutName="gameplay_dangeon_keepTex_016CB0" Format="rgba16" Width="32" Height="32" Offset="0x16CB0" AddedByScript="true"/>
         <DList Name="gUnusedCandleDL" Offset="0x440"/>
         <DList Name="gBrownFragmentDL" Offset="0x530"/>
         <Texture Name="gUnusedStoneTex" OutName="unused_stone" Format="rgba16" Width="32" Height="32" Offset="0x7C0"/>

--- a/soh/assets/xml/GC_MQ_D/objects/gameplay_keep.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/gameplay_keep.xml
@@ -1,6 +1,10 @@
 <Root>
     <ExternalFile XmlPath="misc/link_animetion.xml" OutPath="misc/link_animetion/"/>
     <File Name="gameplay_keep" Segment="4">
+        <Texture Name="gameplay_keepTex_04C540" OutName="gameplay_keepTex_04C540" Format="i8" Width="64" Height="17" Offset="0x4C540" AddedByScript="true"/>
+        <Texture Name="gameplay_keepTex_04C740" OutName="gameplay_keepTex_04C740" Format="i8" Width="64" Height="17" Offset="0x4C740" AddedByScript="true"/>
+        <Texture Name="gameplay_keepTex_04CD40" OutName="gameplay_keepTex_04CD40" Format="i8" Width="64" Height="17" Offset="0x4CD40" AddedByScript="true"/>
+        <Texture Name="gameplay_keepTex_04CF40" OutName="gameplay_keepTex_04CF40" Format="i8" Width="64" Height="17" Offset="0x4CF40" AddedByScript="true"/>
         <Texture Name="gHilite1Tex" OutName="hilite_1" Format="rgba16" Width="16" Height="16" Offset="0x0"/>
         <Texture Name="gHilite2Tex" OutName="hilite_2" Format="rgba16" Width="16" Height="16" Offset="0x200"/>
         <Texture Name="gHylianShieldDesignTex" OutName="hylian_shield_design" Format="rgba16" Width="32" Height="64" Offset="0x400"/>

--- a/soh/assets/xml/GC_MQ_D/objects/object_am.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_am.xml
@@ -1,5 +1,18 @@
 <Root>
     <File Name="object_am" Segment="6">
+        <Texture Name="object_amTex_002638" OutName="object_amTex_002638" Format="i4" Width="32" Height="32" Offset="0x2638" AddedByScript="true"/>
+        <Texture Name="object_amTex_002838" OutName="object_amTex_002838" Format="i4" Width="16" Height="32" Offset="0x2838" AddedByScript="true"/>
+        <Texture Name="object_amTex_002938" OutName="object_amTex_002938" Format="rgba16" Width="16" Height="32" Offset="0x2938" AddedByScript="true"/>
+        <Texture Name="object_amTex_002D38" OutName="object_amTex_002D38" Format="i4" Width="16" Height="32" Offset="0x2D38" AddedByScript="true"/>
+        <Texture Name="object_amTex_002E38" OutName="object_amTex_002E38" Format="i4" Width="32" Height="32" Offset="0x2E38" AddedByScript="true"/>
+        <Texture Name="object_amTex_003038" OutName="object_amTex_003038" Format="i4" Width="32" Height="32" Offset="0x3038" AddedByScript="true"/>
+        <Texture Name="object_amTex_003238" OutName="object_amTex_003238" Format="rgba16" Width="32" Height="32" Offset="0x3238" AddedByScript="true"/>
+        <Texture Name="object_amTex_003A38" OutName="object_amTex_003A38" Format="rgba16" Width="16" Height="16" Offset="0x3A38" AddedByScript="true"/>
+        <Texture Name="object_amTex_003C38" OutName="object_amTex_003C38" Format="rgba16" Width="32" Height="32" Offset="0x3C38" AddedByScript="true"/>
+        <Texture Name="object_amTex_004438" OutName="object_amTex_004438" Format="rgba16" Width="32" Height="32" Offset="0x4438" AddedByScript="true"/>
+        <Texture Name="object_amTex_004C38" OutName="object_amTex_004C38" Format="rgba16" Width="32" Height="32" Offset="0x4C38" AddedByScript="true"/>
+        <Texture Name="object_amTex_005438" OutName="object_amTex_005438" Format="i4" Width="16" Height="8" Offset="0x5438" AddedByScript="true"/>
+        <Texture Name="object_amTex_005478" OutName="object_amTex_005478" Format="rgba16" Width="16" Height="32" Offset="0x5478" AddedByScript="true"/>
         <Skeleton Name="gArmosSkel" Type="Normal" LimbType="Standard" Offset="0x5948"/>
         <Animation Name="gArmosRicochetAnim" Offset="0x33C"/>
         <Animation Name="gArmosHopAnim" Offset="0x238"/>

--- a/soh/assets/xml/GC_MQ_D/objects/object_ani.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_ani.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_ani" Segment="6">
+        <Texture Name="object_aniTex_0011D8" OutName="object_aniTex_0011D8" Format="ci8" Width="16" Height="16" Offset="0x11D8" TlutOffset="0x1088" AddedByScript="true"/>
         <!-- Kakariko Roof Man Skeleton -->
         <Skeleton Name="gRoofManSkel" Type="Flex" LimbType="Standard" Offset="0xF0"/>
 

--- a/soh/assets/xml/GC_MQ_D/objects/object_anubice.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_anubice.xml
@@ -1,5 +1,14 @@
 <Root>
     <File Name="object_anubice" Segment="6">
+        <Texture Name="object_anubiceTex_000F90" OutName="object_anubiceTex_000F90" Format="rgba16" Width="8" Height="16" Offset="0xF90" AddedByScript="true"/>
+        <Texture Name="object_anubiceTex_001090" OutName="object_anubiceTex_001090" Format="rgba16" Width="4" Height="16" Offset="0x1090" AddedByScript="true"/>
+        <Texture Name="object_anubiceTex_001110" OutName="object_anubiceTex_001110" Format="rgba16" Width="16" Height="32" Offset="0x1110" AddedByScript="true"/>
+        <Texture Name="object_anubiceTex_001510" OutName="object_anubiceTex_001510" Format="rgba16" Width="8" Height="8" Offset="0x1510" AddedByScript="true"/>
+        <Texture Name="object_anubiceTex_001590" OutName="object_anubiceTex_001590" Format="rgba16" Width="8" Height="8" Offset="0x1590" AddedByScript="true"/>
+        <Texture Name="object_anubiceTex_001610" OutName="object_anubiceTex_001610" Format="rgba16" Width="4" Height="16" Offset="0x1610" AddedByScript="true"/>
+        <Texture Name="object_anubiceTex_001690" OutName="object_anubiceTex_001690" Format="ia16" Width="32" Height="16" Offset="0x1690" AddedByScript="true"/>
+        <Texture Name="object_anubiceTex_001A90" OutName="object_anubiceTex_001A90" Format="rgba16" Width="8" Height="8" Offset="0x1A90" AddedByScript="true"/>
+        <Texture Name="object_anubiceTex_0036A0" OutName="object_anubiceTex_0036A0" Format="i4" Width="32" Height="32" Offset="0x36A0" AddedByScript="true"/>
         <Skeleton Name="gAnubiceSkel" Type="Normal" LimbType="Standard" Offset="0x3990"/>
 
         <Animation Name="gAnubiceFallDownAnim" Offset="0x348"/>

--- a/soh/assets/xml/GC_MQ_D/objects/object_blkobj.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_blkobj.xml
@@ -1,5 +1,27 @@
 <Root>
     <File Name="object_blkobj" Segment="6">
+        <Texture Name="object_blkobjTex_008090" OutName="object_blkobjTex_008090" Format="rgba16" Width="32" Height="32" Offset="0x8090" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_008890" OutName="object_blkobjTex_008890" Format="rgba16" Width="32" Height="32" Offset="0x8890" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_009090" OutName="object_blkobjTex_009090" Format="rgba16" Width="32" Height="32" Offset="0x9090" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_009890" OutName="object_blkobjTex_009890" Format="rgba16" Width="32" Height="32" Offset="0x9890" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_00A090" OutName="object_blkobjTex_00A090" Format="ia16" Width="32" Height="32" Offset="0xA090" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_00A890" OutName="object_blkobjTex_00A890" Format="rgba16" Width="32" Height="32" Offset="0xA890" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_00B090" OutName="object_blkobjTex_00B090" Format="rgba16" Width="32" Height="32" Offset="0xB090" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_00B890" OutName="object_blkobjTex_00B890" Format="rgba16" Width="32" Height="32" Offset="0xB890" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_00C090" OutName="object_blkobjTex_00C090" Format="rgba16" Width="32" Height="32" Offset="0xC090" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_00C890" OutName="object_blkobjTex_00C890" Format="rgba16" Width="32" Height="32" Offset="0xC890" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_00D090" OutName="object_blkobjTex_00D090" Format="rgba16" Width="32" Height="32" Offset="0xD090" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_00D890" OutName="object_blkobjTex_00D890" Format="rgba16" Width="32" Height="32" Offset="0xD890" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_00E090" OutName="object_blkobjTex_00E090" Format="rgba16" Width="32" Height="32" Offset="0xE090" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_00E890" OutName="object_blkobjTex_00E890" Format="rgba16" Width="32" Height="64" Offset="0xE890" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_00F890" OutName="object_blkobjTex_00F890" Format="rgba16" Width="32" Height="32" Offset="0xF890" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_010090" OutName="object_blkobjTex_010090" Format="rgba16" Width="32" Height="32" Offset="0x10090" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_010890" OutName="object_blkobjTex_010890" Format="rgba16" Width="32" Height="32" Offset="0x10890" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_011090" OutName="object_blkobjTex_011090" Format="rgba16" Width="32" Height="32" Offset="0x11090" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_011890" OutName="object_blkobjTex_011890" Format="rgba16" Width="32" Height="32" Offset="0x11890" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_012090" OutName="object_blkobjTex_012090" Format="rgba16" Width="32" Height="32" Offset="0x12090" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_012890" OutName="object_blkobjTex_012890" Format="rgba16" Width="32" Height="32" Offset="0x12890" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_013090" OutName="object_blkobjTex_013090" Format="rgba16" Width="32" Height="32" Offset="0x13090" AddedByScript="true"/>
         <!-- Illusion Room Collision -->
         <Collision Name="gIllusionRoomCol" Offset="0x7564"/>
 

--- a/soh/assets/xml/GC_MQ_D/objects/object_box.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_box.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_box" Segment="6">
+        <Texture Name="object_boxTex_004F80" OutName="object_boxTex_004F80" Format="i8" Width="64" Height="32" Offset="0x4F80" AddedByScript="true"/>
         <Skeleton Name="gTreasureChestCurveSkel" Type="Curve" LimbType="Curve" Offset="0x5EB8"/>
         <CurveAnimation Name="gTreasureChestCurveAnim_4B60" SkelOffset="0x5EB8" Offset="0x4B60"/>
         <CurveAnimation Name="gTreasureChestCurveAnim_4F70" SkelOffset="0x5EB8" Offset="0x4F70"/>

--- a/soh/assets/xml/GC_MQ_D/objects/object_bv.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_bv.xml
@@ -1,5 +1,42 @@
 <Root>
     <File Name="object_bv" Segment="6">
+        <Texture Name="object_bvTex_000040" OutName="object_bvTex_000040" Format="ia16" Width="16" Height="64" Offset="0x40" AddedByScript="true"/>
+        <Texture Name="object_bvTex_000840" OutName="object_bvTex_000840" Format="ia16" Width="16" Height="16" Offset="0x840" AddedByScript="true"/>
+        <Texture Name="object_bvTex_000A40" OutName="object_bvTex_000A40" Format="i8" Width="16" Height="32" Offset="0xA40" AddedByScript="true"/>
+        <Texture Name="object_bvTex_0051A0" OutName="object_bvTex_0051A0" Format="rgba16" Width="8" Height="16" Offset="0x51A0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_0052A0" OutName="object_bvTex_0052A0" Format="rgba16" Width="8" Height="16" Offset="0x52A0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_0053A0" OutName="object_bvTex_0053A0" Format="rgba16" Width="16" Height="16" Offset="0x53A0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_0055A0" OutName="object_bvTex_0055A0" Format="ia16" Width="16" Height="32" Offset="0x55A0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_0059A0" OutName="object_bvTex_0059A0" Format="ia16" Width="16" Height="32" Offset="0x59A0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_005DA0" OutName="object_bvTex_005DA0" Format="ia16" Width="16" Height="64" Offset="0x5DA0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_0065A0" OutName="object_bvTex_0065A0" Format="i8" Width="16" Height="32" Offset="0x65A0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_008F88" OutName="object_bvTex_008F88" Format="i8" Width="32" Height="32" Offset="0x8F88" AddedByScript="true"/>
+        <Texture Name="object_bvTex_0117B8" OutName="object_bvTex_0117B8" Format="rgba16" Width="16" Height="16" Offset="0x117B8" AddedByScript="true"/>
+        <Texture Name="object_bvTex_0119B8" OutName="object_bvTex_0119B8" Format="rgba16" Width="16" Height="16" Offset="0x119B8" AddedByScript="true"/>
+        <Texture Name="object_bvTex_011BB8" OutName="object_bvTex_011BB8" Format="rgba16" Width="16" Height="16" Offset="0x11BB8" AddedByScript="true"/>
+        <Texture Name="object_bvTex_012CE0" OutName="object_bvTex_012CE0" Format="i8" Width="64" Height="32" Offset="0x12CE0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_013660" OutName="object_bvTex_013660" Format="ia16" Width="64" Height="64" Offset="0x13660" AddedByScript="true"/>
+        <Texture Name="object_bvTex_0170D8" OutName="object_bvTex_0170D8" Format="rgba16" Width="16" Height="8" Offset="0x170D8" AddedByScript="true"/>
+        <Texture Name="object_bvTex_0171D8" OutName="object_bvTex_0171D8" Format="rgba16" Width="16" Height="16" Offset="0x171D8" AddedByScript="true"/>
+        <Texture Name="object_bvTex_018770" OutName="object_bvTex_018770" Format="rgba16" Width="8" Height="8" Offset="0x18770" AddedByScript="true"/>
+        <Texture Name="object_bvTex_018D30" OutName="object_bvTex_018D30" Format="rgba16" Width="16" Height="8" Offset="0x18D30" AddedByScript="true"/>
+        <Texture Name="object_bvTex_018E30" OutName="object_bvTex_018E30" Format="rgba16" Width="16" Height="16" Offset="0x18E30" AddedByScript="true"/>
+        <Texture Name="object_bvTex_019BB8" OutName="object_bvTex_019BB8" Format="ci8" Width="32" Height="64" Offset="0x19BB8" TlutOffset="0x199B0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_01A6B8" OutName="object_bvTex_01A6B8" Format="ci8" Width="32" Height="64" Offset="0x1A6B8" TlutOffset="0x1A4B0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_01B1B8" OutName="object_bvTex_01B1B8" Format="ci8" Width="32" Height="64" Offset="0x1B1B8" TlutOffset="0x1AFB0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_01BCB8" OutName="object_bvTex_01BCB8" Format="ci8" Width="32" Height="64" Offset="0x1BCB8" TlutOffset="0x1BAB0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_01C7B8" OutName="object_bvTex_01C7B8" Format="ci8" Width="32" Height="64" Offset="0x1C7B8" TlutOffset="0x1C5B0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_01D2B8" OutName="object_bvTex_01D2B8" Format="ci8" Width="32" Height="64" Offset="0x1D2B8" TlutOffset="0x1D0B0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_01DDB8" OutName="object_bvTex_01DDB8" Format="ci8" Width="32" Height="64" Offset="0x1DDB8" TlutOffset="0x1DBB0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_01E8B8" OutName="object_bvTex_01E8B8" Format="ci8" Width="32" Height="64" Offset="0x1E8B8" TlutOffset="0x1E6B0" AddedByScript="true"/>
+        <Texture Name="object_bvTLUT_0199B0" OutName="object_bvTLUT_0199B0" Format="rgba16" Width="16" Height="16" Offset="0x199B0" AddedByScript="true"/>
+        <Texture Name="object_bvTLUT_01A4B0" OutName="object_bvTLUT_01A4B0" Format="rgba16" Width="16" Height="16" Offset="0x1A4B0" AddedByScript="true"/>
+        <Texture Name="object_bvTLUT_01AFB0" OutName="object_bvTLUT_01AFB0" Format="rgba16" Width="16" Height="16" Offset="0x1AFB0" AddedByScript="true"/>
+        <Texture Name="object_bvTLUT_01BAB0" OutName="object_bvTLUT_01BAB0" Format="rgba16" Width="16" Height="16" Offset="0x1BAB0" AddedByScript="true"/>
+        <Texture Name="object_bvTLUT_01C5B0" OutName="object_bvTLUT_01C5B0" Format="rgba16" Width="16" Height="16" Offset="0x1C5B0" AddedByScript="true"/>
+        <Texture Name="object_bvTLUT_01D0B0" OutName="object_bvTLUT_01D0B0" Format="rgba16" Width="16" Height="16" Offset="0x1D0B0" AddedByScript="true"/>
+        <Texture Name="object_bvTLUT_01DBB0" OutName="object_bvTLUT_01DBB0" Format="rgba16" Width="16" Height="16" Offset="0x1DBB0" AddedByScript="true"/>
+        <Texture Name="object_bvTLUT_01E6B0" OutName="object_bvTLUT_01E6B0" Format="rgba16" Width="16" Height="16" Offset="0x1E6B0" AddedByScript="true"/>
         <!-- Boss title card -->
         <Texture Name="gBarinadeTitleCardTex" OutName="barinade_title_card" Format="i8" Width="128" Height="120" Offset="0x1230"/>
 

--- a/soh/assets/xml/GC_MQ_D/objects/object_demo_kekkai.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_demo_kekkai.xml
@@ -1,5 +1,21 @@
 <Root>
     <File Name="object_demo_kekkai" Segment="6">
+        <Texture Name="object_demo_kekkaiTex_000000" OutName="object_demo_kekkaiTex_000000" Format="i8" Width="32" Height="64" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_000800" OutName="object_demo_kekkaiTex_000800" Format="i8" Width="32" Height="64" Offset="0x800" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_001000" OutName="object_demo_kekkaiTex_001000" Format="rgba16" Width="32" Height="64" Offset="0x1000" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_002450" OutName="object_demo_kekkaiTex_002450" Format="rgba16" Width="32" Height="64" Offset="0x2450" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_0036A0" OutName="object_demo_kekkaiTex_0036A0" Format="rgba16" Width="32" Height="32" Offset="0x36A0" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_003EA0" OutName="object_demo_kekkaiTex_003EA0" Format="i8" Width="32" Height="32" Offset="0x3EA0" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_004AC0" OutName="object_demo_kekkaiTex_004AC0" Format="i8" Width="32" Height="32" Offset="0x4AC0" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_006140" OutName="object_demo_kekkaiTex_006140" Format="ia16" Width="8" Height="128" Offset="0x6140" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_006940" OutName="object_demo_kekkaiTex_006940" Format="ia8" Width="64" Height="64" Offset="0x6940" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_007DB0" OutName="object_demo_kekkaiTex_007DB0" Format="rgba16" Width="32" Height="32" Offset="0x7DB0" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_0089D0" OutName="object_demo_kekkaiTex_0089D0" Format="rgba16" Width="32" Height="32" Offset="0x89D0" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_0092D0" OutName="object_demo_kekkaiTex_0092D0" Format="rgba16" Width="32" Height="64" Offset="0x92D0" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_00A440" OutName="object_demo_kekkaiTex_00A440" Format="rgba16" Width="64" Height="32" Offset="0xA440" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_00B540" OutName="object_demo_kekkaiTex_00B540" Format="ia16" Width="32" Height="32" Offset="0xB540" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_00C0B0" OutName="object_demo_kekkaiTex_00C0B0" Format="rgba16" Width="32" Height="32" Offset="0xC0B0" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_00C8B0" OutName="object_demo_kekkaiTex_00C8B0" Format="rgba16" Width="32" Height="64" Offset="0xC8B0" AddedByScript="true"/>
         <!-- Demo_Kekkai -->
         <DList Name="gTowerBarrierDL" Offset="0x4930"/>
         <DList Name="gTrialBarrierFloorDL" Offset="0x4F00"/>

--- a/soh/assets/xml/GC_MQ_D/objects/object_dnk.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_dnk.xml
@@ -1,5 +1,10 @@
 <Root>
     <File Name="object_dnk" Segment="6">
+        <Texture Name="object_dnkTex_001BD0" OutName="object_dnkTex_001BD0" Format="rgba16" Width="32" Height="32" Offset="0x1BD0" AddedByScript="true"/>
+        <Texture Name="object_dnkTex_0023D0" OutName="object_dnkTex_0023D0" Format="rgba16" Width="16" Height="16" Offset="0x23D0" AddedByScript="true"/>
+        <Texture Name="object_dnkTex_002650" OutName="object_dnkTex_002650" Format="rgba16" Width="8" Height="8" Offset="0x2650" AddedByScript="true"/>
+        <Texture Name="object_dnkTex_0026D0" OutName="object_dnkTex_0026D0" Format="rgba16" Width="8" Height="8" Offset="0x26D0" AddedByScript="true"/>
+        <Texture Name="object_dnkTex_002850" OutName="object_dnkTex_002850" Format="rgba16" Width="16" Height="16" Offset="0x2850" AddedByScript="true"/>
         <!-- Forest Stage scrub skeleton -->
         <Skeleton Name="gDntStageSkel" Type="Normal" LimbType="Standard" Offset="0x2AF0"/>
 

--- a/soh/assets/xml/GC_MQ_D/objects/object_dns.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_dns.xml
@@ -1,5 +1,10 @@
 <Root>
     <File Name="object_dns" Segment="6">
+        <Texture Name="object_dnsTex_0024A0" OutName="object_dnsTex_0024A0" Format="rgba16" Width="32" Height="32" Offset="0x24A0" AddedByScript="true"/>
+        <Texture Name="object_dnsTex_002CA0" OutName="object_dnsTex_002CA0" Format="rgba16" Width="16" Height="16" Offset="0x2CA0" AddedByScript="true"/>
+        <Texture Name="object_dnsTex_002F20" OutName="object_dnsTex_002F20" Format="rgba16" Width="8" Height="8" Offset="0x2F20" AddedByScript="true"/>
+        <Texture Name="object_dnsTex_002FA0" OutName="object_dnsTex_002FA0" Format="rgba16" Width="8" Height="8" Offset="0x2FA0" AddedByScript="true"/>
+        <Texture Name="object_dnsTex_003120" OutName="object_dnsTex_003120" Format="rgba16" Width="16" Height="16" Offset="0x3120" AddedByScript="true"/>
         <!-- Forest Stage leader skeleton -->
         <Skeleton Name="gDntJijiSkel" Type="Normal" LimbType="Standard" Offset="0x33E0"/>
 

--- a/soh/assets/xml/GC_MQ_D/objects/object_fd.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_fd.xml
@@ -1,5 +1,32 @@
 <Root>
     <File Name="object_fd" Segment="6">
+        <Texture Name="object_fdTex_000458" OutName="object_fdTex_000458" Format="ci4" Width="32" Height="32" Offset="0x458" TlutOffset="0x438" AddedByScript="true"/>
+        <Texture Name="object_fdTex_000658" OutName="object_fdTex_000658" Format="ci4" Width="32" Height="64" Offset="0x658" TlutOffset="0x438" AddedByScript="true"/>
+        <Texture Name="object_fdTex_000A78" OutName="object_fdTex_000A78" Format="ci4" Width="32" Height="32" Offset="0xA78" TlutOffset="0xA58" AddedByScript="true"/>
+        <Texture Name="object_fdTex_0040A8" OutName="object_fdTex_0040A8" Format="rgba16" Width="32" Height="32" Offset="0x40A8" AddedByScript="true"/>
+        <Texture Name="object_fdTex_0048A8" OutName="object_fdTex_0048A8" Format="rgba16" Width="32" Height="32" Offset="0x48A8" AddedByScript="true"/>
+        <Texture Name="object_fdTex_0050A8" OutName="object_fdTex_0050A8" Format="rgba16" Width="16" Height="16" Offset="0x50A8" AddedByScript="true"/>
+        <Texture Name="object_fdTex_0052A8" OutName="object_fdTex_0052A8" Format="rgba16" Width="16" Height="16" Offset="0x52A8" AddedByScript="true"/>
+        <Texture Name="object_fdTex_0054A8" OutName="object_fdTex_0054A8" Format="rgba16" Width="16" Height="16" Offset="0x54A8" AddedByScript="true"/>
+        <Texture Name="object_fdTex_0056A8" OutName="object_fdTex_0056A8" Format="rgba16" Width="16" Height="16" Offset="0x56A8" AddedByScript="true"/>
+        <Texture Name="object_fdTex_005B60" OutName="object_fdTex_005B60" Format="rgba16" Width="16" Height="16" Offset="0x5B60" AddedByScript="true"/>
+        <Texture Name="object_fdTex_005D60" OutName="object_fdTex_005D60" Format="rgba16" Width="16" Height="16" Offset="0x5D60" AddedByScript="true"/>
+        <Texture Name="object_fdTex_005F60" OutName="object_fdTex_005F60" Format="rgba16" Width="16" Height="16" Offset="0x5F60" AddedByScript="true"/>
+        <Texture Name="object_fdTex_009208" OutName="object_fdTex_009208" Format="i8" Width="16" Height="16" Offset="0x9208" AddedByScript="true"/>
+        <Texture Name="object_fdTex_009780" OutName="object_fdTex_009780" Format="rgba16" Width="16" Height="16" Offset="0x9780" AddedByScript="true"/>
+        <Texture Name="object_fdTex_009980" OutName="object_fdTex_009980" Format="rgba16" Width="16" Height="16" Offset="0x9980" AddedByScript="true"/>
+        <Texture Name="object_fdTex_00A050" OutName="object_fdTex_00A050" Format="rgba16" Width="32" Height="32" Offset="0xA050" AddedByScript="true"/>
+        <Texture Name="object_fdTex_00A918" OutName="object_fdTex_00A918" Format="i8" Width="16" Height="16" Offset="0xA918" AddedByScript="true"/>
+        <Texture Name="object_fdTex_00AA18" OutName="object_fdTex_00AA18" Format="rgba16" Width="32" Height="32" Offset="0xAA18" AddedByScript="true"/>
+        <Texture Name="object_fdTex_00B458" OutName="object_fdTex_00B458" Format="rgba16" Width="32" Height="32" Offset="0xB458" AddedByScript="true"/>
+        <Texture Name="object_fdTex_00BC58" OutName="object_fdTex_00BC58" Format="rgba16" Width="16" Height="16" Offset="0xBC58" AddedByScript="true"/>
+        <Texture Name="object_fdTex_00BE58" OutName="object_fdTex_00BE58" Format="rgba16" Width="16" Height="16" Offset="0xBE58" AddedByScript="true"/>
+        <Texture Name="object_fdTex_00C058" OutName="object_fdTex_00C058" Format="rgba16" Width="16" Height="16" Offset="0xC058" AddedByScript="true"/>
+        <Texture Name="object_fdTex_00D170" OutName="object_fdTex_00D170" Format="rgba16" Width="16" Height="16" Offset="0xD170" AddedByScript="true"/>
+        <Texture Name="object_fdTex_00D438" OutName="object_fdTex_00D438" Format="rgba16" Width="16" Height="16" Offset="0xD438" AddedByScript="true"/>
+        <Texture Name="object_fdTLUT_000438" OutName="object_fdTLUT_000438" Format="rgba16" Width="4" Height="4" Offset="0x438" AddedByScript="true"/>
+        <Texture Name="object_fdTLUT_000A58" OutName="object_fdTLUT_000A58" Format="rgba16" Width="4" Height="4" Offset="0xA58" AddedByScript="true"/>
+        <Texture Name="object_fdTLUT_0032A8" OutName="object_fdTLUT_0032A8" Format="rgba16" Width="16" Height="16" Offset="0x32A8" AddedByScript="true"/>
         <!-- Boss title card -->
         <Texture Name="gVolvagiaBossTitleCardTex" OutName="volvagia_boss_title_card" Format="i8" Width="128" Height="120" Offset="0xD700"/>
 

--- a/soh/assets/xml/GC_MQ_D/objects/object_fd2.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_fd2.xml
@@ -1,5 +1,16 @@
 <Root>
     <File Name="object_fd2" Segment="6">
+        <Texture Name="object_fd2Tex_003308" OutName="object_fd2Tex_003308" Format="rgba16" Width="32" Height="32" Offset="0x3308" AddedByScript="true"/>
+        <Texture Name="object_fd2Tex_003B08" OutName="object_fd2Tex_003B08" Format="rgba16" Width="32" Height="32" Offset="0x3B08" AddedByScript="true"/>
+        <Texture Name="object_fd2Tex_004308" OutName="object_fd2Tex_004308" Format="rgba16" Width="16" Height="16" Offset="0x4308" AddedByScript="true"/>
+        <Texture Name="object_fd2Tex_004508" OutName="object_fd2Tex_004508" Format="rgba16" Width="16" Height="16" Offset="0x4508" AddedByScript="true"/>
+        <Texture Name="object_fd2Tex_004708" OutName="object_fd2Tex_004708" Format="rgba16" Width="16" Height="16" Offset="0x4708" AddedByScript="true"/>
+        <Texture Name="object_fd2Tex_004908" OutName="object_fd2Tex_004908" Format="rgba16" Width="16" Height="16" Offset="0x4908" AddedByScript="true"/>
+        <Texture Name="object_fd2Tex_004BE8" OutName="object_fd2Tex_004BE8" Format="i8" Width="16" Height="16" Offset="0x4BE8" AddedByScript="true"/>
+        <Texture Name="object_fd2Tex_004FA0" OutName="object_fd2Tex_004FA0" Format="rgba16" Width="16" Height="16" Offset="0x4FA0" AddedByScript="true"/>
+        <Texture Name="object_fd2Tex_0051A0" OutName="object_fd2Tex_0051A0" Format="rgba16" Width="16" Height="16" Offset="0x51A0" AddedByScript="true"/>
+        <Texture Name="object_fd2Tex_0053A0" OutName="object_fd2Tex_0053A0" Format="rgba16" Width="16" Height="16" Offset="0x53A0" AddedByScript="true"/>
+        <Texture Name="object_fd2TLUT_002508" OutName="object_fd2TLUT_002508" Format="rgba16" Width="16" Height="16" Offset="0x2508" AddedByScript="true"/>
         <!-- Skeleton -->
         <Skeleton Name="gHoleVolvagiaSkel" Type="Flex" LimbType="Standard" Offset="0x11A78"/>
 

--- a/soh/assets/xml/GC_MQ_D/objects/object_fhg.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_fhg.xml
@@ -1,6 +1,26 @@
 <Root>
     <File Name="object_fhg" Segment="6">
 
+        <Texture Name="object_fhgTex_003320" OutName="object_fhgTex_003320" Format="rgba16" Width="16" Height="16" Offset="0x3320" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_003520" OutName="object_fhgTex_003520" Format="rgba16" Width="16" Height="16" Offset="0x3520" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_003720" OutName="object_fhgTex_003720" Format="rgba16" Width="16" Height="16" Offset="0x3720" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_003920" OutName="object_fhgTex_003920" Format="rgba16" Width="16" Height="16" Offset="0x3920" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_003B20" OutName="object_fhgTex_003B20" Format="rgba16" Width="8" Height="8" Offset="0x3B20" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_003BA0" OutName="object_fhgTex_003BA0" Format="rgba16" Width="16" Height="16" Offset="0x3BA0" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_003DA0" OutName="object_fhgTex_003DA0" Format="rgba16" Width="16" Height="16" Offset="0x3DA0" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_003FA0" OutName="object_fhgTex_003FA0" Format="rgba16" Width="16" Height="32" Offset="0x3FA0" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_0043A0" OutName="object_fhgTex_0043A0" Format="rgba16" Width="16" Height="8" Offset="0x43A0" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_0044A0" OutName="object_fhgTex_0044A0" Format="rgba16" Width="32" Height="32" Offset="0x44A0" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_004CA0" OutName="object_fhgTex_004CA0" Format="rgba16" Width="8" Height="16" Offset="0x4CA0" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_004DA0" OutName="object_fhgTex_004DA0" Format="rgba16" Width="8" Height="8" Offset="0x4DA0" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_00D040" OutName="object_fhgTex_00D040" Format="rgba16" Width="4" Height="4" Offset="0xD040" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_00D060" OutName="object_fhgTex_00D060" Format="rgba16" Width="16" Height="16" Offset="0xD060" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_00E8B0" OutName="object_fhgTex_00E8B0" Format="i4" Width="64" Height="64" Offset="0xE8B0" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_00F0B0" OutName="object_fhgTex_00F0B0" Format="i4" Width="64" Height="64" Offset="0xF0B0" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_00FD98" OutName="object_fhgTex_00FD98" Format="i8" Width="64" Height="32" Offset="0xFD98" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_010660" OutName="object_fhgTex_010660" Format="i4" Width="32" Height="96" Offset="0x10660" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_010D20" OutName="object_fhgTex_010D20" Format="i8" Width="32" Height="32" Offset="0x10D20" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_011120" OutName="object_fhgTex_011120" Format="i8" Width="64" Height="64" Offset="0x11120" AddedByScript="true"/>
         <!-- Skeleton -->
         <Skeleton Name="gPhantomHorseSkel" Type="Normal" LimbType="Skin" Offset="0xB098"/>
 

--- a/soh/assets/xml/GC_MQ_D/objects/object_fw.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_fw.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_fw" Segment="6">
+        <Texture Name="object_fwTex_007A90" OutName="object_fwTex_007A90" Format="i8" Width="16" Height="16" Offset="0x7A90" AddedByScript="true"/>
         <!-- Flare Dancer Enflamed Skeleton -->
         <Skeleton Name="gFlareDancerSkel" Type="Flex" LimbType="Standard" Offset="0x5810"/>
 

--- a/soh/assets/xml/GC_MQ_D/objects/object_geldb.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_geldb.xml
@@ -1,5 +1,21 @@
 <Root>
     <File Name="object_geldb" Segment="6">
+        <Texture Name="object_geldbTex_002700" OutName="object_geldbTex_002700" Format="ci8" Width="8" Height="8" Offset="0x2700" TlutOffset="0x2500" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_002740" OutName="object_geldbTex_002740" Format="ci8" Width="8" Height="8" Offset="0x2740" TlutOffset="0x2500" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_002780" OutName="object_geldbTex_002780" Format="ci8" Width="16" Height="16" Offset="0x2780" TlutOffset="0x2500" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_002880" OutName="object_geldbTex_002880" Format="i8" Width="16" Height="16" Offset="0x2880" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_002980" OutName="object_geldbTex_002980" Format="ci8" Width="16" Height="16" Offset="0x2980" TlutOffset="0x2500" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_002A80" OutName="object_geldbTex_002A80" Format="i8" Width="16" Height="16" Offset="0x2A80" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_002B80" OutName="object_geldbTex_002B80" Format="i8" Width="8" Height="16" Offset="0x2B80" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_005F68" OutName="object_geldbTex_005F68" Format="ci8" Width="8" Height="16" Offset="0x5F68" TlutOffset="0x5D30" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_0063E8" OutName="object_geldbTex_0063E8" Format="i8" Width="16" Height="16" Offset="0x63E8" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_0064E8" OutName="object_geldbTex_0064E8" Format="ci8" Width="8" Height="16" Offset="0x64E8" TlutOffset="0x5D30" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_006568" OutName="object_geldbTex_006568" Format="ci8" Width="8" Height="8" Offset="0x6568" TlutOffset="0x5D30" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_0069A8" OutName="object_geldbTex_0069A8" Format="i8" Width="8" Height="16" Offset="0x69A8" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_006A28" OutName="object_geldbTex_006A28" Format="ci8" Width="16" Height="16" Offset="0x6A28" TlutOffset="0x5D30" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_006B28" OutName="object_geldbTex_006B28" Format="ci8" Width="16" Height="16" Offset="0x6B28" TlutOffset="0x5D30" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_006C28" OutName="object_geldbTex_006C28" Format="ci8" Width="16" Height="16" Offset="0x6C28" TlutOffset="0x5D30" AddedByScript="true"/>
+        <Texture Name="object_geldbTLUT_002500" OutName="object_geldbTLUT_002500" Format="rgba16" Width="16" Height="16" Offset="0x2500" AddedByScript="true"/>
         <!-- Red-clothed Gerudo skeleton -->
         <Skeleton Name="gGerudoRedSkel" Type="Flex" LimbType="Standard" Offset="0xA458"/>
 

--- a/soh/assets/xml/GC_MQ_D/objects/object_gi_boots_2.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_gi_boots_2.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_boots_2" Segment="6">
+        <Texture Name="object_gi_boots_2Tex_000000" OutName="object_gi_boots_2Tex_000000" Format="ia8" Width="16" Height="16" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiIronBootsDL" Offset="0x1630"/>
         <DList Name="gGiIronBootsRivetsDL" Offset="0x1A98"/>
     </File>

--- a/soh/assets/xml/GC_MQ_D/objects/object_gi_butterfly.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_gi_butterfly.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_butterfly" Segment="6">
+        <Texture Name="object_gi_butterflyTex_000000" OutName="object_gi_butterflyTex_000000" Format="ia4" Width="24" Height="48" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiButterflyContainerDL" Offset="0x0830"/>
         <DList Name="gGiButterflyGlassDL" Offset="0x0A70"/>
     </File>

--- a/soh/assets/xml/GC_MQ_D/objects/object_gi_clothes.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_gi_clothes.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_clothes" Segment="6">
+        <Texture Name="object_gi_clothesTex_000000" OutName="object_gi_clothesTex_000000" Format="i4" Width="64" Height="64" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiGoronCollarColorDL" Offset="0x14E0"/>
         <DList Name="gGiZoraCollarColorDL" Offset="0x1500"/>
         <DList Name="gGiGoronTunicColorDL" Offset="0x1520"/>

--- a/soh/assets/xml/GC_MQ_D/objects/object_gi_dekupouch.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_gi_dekupouch.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_gi_dekupouch" Segment="6">
+        <Texture Name="object_gi_dekupouchTex_000000" OutName="object_gi_dekupouchTex_000000" Format="i4" Width="32" Height="16" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_dekupouchTex_000100" OutName="object_gi_dekupouchTex_000100" Format="i4" Width="32" Height="32" Offset="0x100" AddedByScript="true"/>
         <DList Name="gGiBulletBagColorDL" Offset="0x0AF0"/>
         <DList Name="gGiBulletBag50ColorDL" Offset="0x0B10"/>
         <DList Name="gGiBulletBagStringColorDL" Offset="0x0B30"/>

--- a/soh/assets/xml/GC_MQ_D/objects/object_gi_fire.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_gi_fire.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_gi_fire" Segment="6">
+        <Texture Name="object_gi_fireTex_000000" OutName="object_gi_fireTex_000000" Format="i8" Width="16" Height="32" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_fireTex_000200" OutName="object_gi_fireTex_000200" Format="i8" Width="16" Height="32" Offset="0x200" AddedByScript="true"/>
         <DList Name="gGiBlueFireChamberstickDL" Offset="0x0C60"/>
         <DList Name="gGiBlueFireFlameDL" Offset="0x0F08"/>
     </File>

--- a/soh/assets/xml/GC_MQ_D/objects/object_gi_frog.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_gi_frog.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_frog" Segment="6">
+        <Texture Name="object_gi_frogTex_000000" OutName="object_gi_frogTex_000000" Format="i8" Width="32" Height="32" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiFrogDL" Offset="0x0D60"/>
         <DList Name="gGiFrogEyesDL" Offset="0x1060"/>
     </File>

--- a/soh/assets/xml/GC_MQ_D/objects/object_gi_gerudo.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_gi_gerudo.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_gerudo" Segment="6">
+        <Texture Name="object_gi_gerudoTex_000000" OutName="object_gi_gerudoTex_000000" Format="i8" Width="32" Height="32" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiGerudoCardDL" Offset="0x0F60"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_MQ_D/objects/object_gi_gerudomask.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_gi_gerudomask.xml
@@ -1,5 +1,10 @@
 <Root>
     <File Name="object_gi_gerudomask" Segment="6">
+        <Texture Name="object_gi_gerudomaskTex_000208" OutName="object_gi_gerudomaskTex_000208" Format="ci8" Width="8" Height="8" Offset="0x208" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_gerudomaskTex_000248" OutName="object_gi_gerudomaskTex_000248" Format="ci8" Width="16" Height="16" Offset="0x248" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_gerudomaskTex_000348" OutName="object_gi_gerudomaskTex_000348" Format="ci8" Width="16" Height="16" Offset="0x348" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_gerudomaskTex_000448" OutName="object_gi_gerudomaskTex_000448" Format="ci8" Width="32" Height="32" Offset="0x448" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_gerudomaskTLUT_000000" OutName="object_gi_gerudomaskTLUT_000000" Format="rgba16" Width="16" Height="16" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiGerudoMaskDL" Offset="0x10E8"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_MQ_D/objects/object_gi_ghost.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_gi_ghost.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_gi_ghost" Segment="6">
+        <Texture Name="object_gi_ghostTex_000000" OutName="object_gi_ghostTex_000000" Format="i8" Width="16" Height="32" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_ghostTex_000200" OutName="object_gi_ghostTex_000200" Format="i8" Width="16" Height="32" Offset="0x200" AddedByScript="true"/>
         <DList Name="gGiPoeColorDL" Offset="0x0950"/>
         <DList Name="gGiBigPoeColorDL" Offset="0x0970"/>
         <DList Name="gGiGhostContainerLidDL" Offset="0x0990"/>

--- a/soh/assets/xml/GC_MQ_D/objects/object_gi_gloves.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_gi_gloves.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_gloves" Segment="6">
+        <Texture Name="object_gi_glovesTex_000000" OutName="object_gi_glovesTex_000000" Format="i8" Width="64" Height="32" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiSilverGauntletsColorDL" Offset="0x14C0"/>
         <DList Name="gGiGoldenGauntletsColorDL" Offset="0x14E0"/>
         <DList Name="gGiSilverGauntletsPlateColorDL" Offset="0x1500"/>

--- a/soh/assets/xml/GC_MQ_D/objects/object_gi_golonmask.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_gi_golonmask.xml
@@ -1,5 +1,10 @@
 <Root>
     <File Name="object_gi_golonmask" Segment="6">
+        <Texture Name="object_gi_golonmaskTex_000208" OutName="object_gi_golonmaskTex_000208" Format="ci8" Width="8" Height="8" Offset="0x208" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_golonmaskTex_000248" OutName="object_gi_golonmaskTex_000248" Format="ci8" Width="16" Height="16" Offset="0x248" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_golonmaskTex_000348" OutName="object_gi_golonmaskTex_000348" Format="ci8" Width="32" Height="32" Offset="0x348" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_golonmaskTex_000748" OutName="object_gi_golonmaskTex_000748" Format="ci8" Width="64" Height="32" Offset="0x748" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_golonmaskTLUT_000000" OutName="object_gi_golonmaskTLUT_000000" Format="rgba16" Width="16" Height="16" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiGoronMaskDL" Offset="0x14F8"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_MQ_D/objects/object_gi_hoverboots.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_gi_hoverboots.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_gi_hoverboots" Segment="6">
+        <Texture Name="object_gi_hoverbootsTex_000000" OutName="object_gi_hoverbootsTex_000000" Format="ia4" Width="48" Height="32" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_hoverbootsTex_000300" OutName="object_gi_hoverbootsTex_000300" Format="i4" Width="16" Height="32" Offset="0x300" AddedByScript="true"/>
         <DList Name="gGiHoverBootsDL" Offset="0x1850"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_MQ_D/objects/object_gi_ki_tan_mask.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_gi_ki_tan_mask.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_ki_tan_mask" Segment="6">
+        <Texture Name="object_gi_ki_tan_maskTex_000000" OutName="object_gi_ki_tan_maskTex_000000" Format="ia8" Width="8" Height="32" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiKeatonMaskDL" Offset="0x0AC0"/>
         <DList Name="gGiKeatonMaskEyesDL" Offset="0x0D50"/>
     </File>

--- a/soh/assets/xml/GC_MQ_D/objects/object_gi_letter.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_gi_letter.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_gi_letter" Segment="6">
+        <Texture Name="object_gi_letterTex_000000" OutName="object_gi_letterTex_000000" Format="i8" Width="48" Height="32" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_letterTex_000600" OutName="object_gi_letterTex_000600" Format="ia8" Width="48" Height="32" Offset="0x600" AddedByScript="true"/>
         <DList Name="gGiLetterDL" Offset="0x0CC0"/>
         <DList Name="gGiLetterWritingDL" Offset="0x0D60"/>
     </File>

--- a/soh/assets/xml/GC_MQ_D/objects/object_gi_liquid.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_gi_liquid.xml
@@ -1,5 +1,8 @@
 <Root>
     <File Name="object_gi_liquid" Segment="6">
+        <Texture Name="object_gi_liquidTex_000000" OutName="object_gi_liquidTex_000000" Format="ia8" Width="16" Height="32" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_liquidTex_000200" OutName="object_gi_liquidTex_000200" Format="ia8" Width="16" Height="32" Offset="0x200" AddedByScript="true"/>
+        <Texture Name="object_gi_liquidTex_000400" OutName="object_gi_liquidTex_000400" Format="ia8" Width="16" Height="32" Offset="0x400" AddedByScript="true"/>
         <DList Name="gGiGreenPotColorDL" Offset="0x1270"/>
         <DList Name="gGiRedPotColorDL" Offset="0x1290"/>
         <DList Name="gGiBluePotColorDL" Offset="0x12B0"/>

--- a/soh/assets/xml/GC_MQ_D/objects/object_gi_map.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_gi_map.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_map" Segment="6">
+        <Texture Name="object_gi_mapTex_000D60" OutName="object_gi_mapTex_000D60" Format="i8" Width="32" Height="32" Offset="0xD60" AddedByScript="true"/>
         <DList Name="gGiDungeonMapDL" Offset="0x03C0"/>
         <DList Name="gGiStoneOfAgonyDL" Offset="0x0B70"/>
     </File>

--- a/soh/assets/xml/GC_MQ_D/objects/object_gi_milk.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_gi_milk.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_milk" Segment="6">
+        <Texture Name="object_gi_milkTex_000000" OutName="object_gi_milkTex_000000" Format="i8" Width="72" Height="24" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiMilkBottleContentsDL" Offset="0x1060"/>
         <DList Name="gGiMilkBottleDL" Offset="0x1288"/>
     </File>

--- a/soh/assets/xml/GC_MQ_D/objects/object_gi_niwatori.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_gi_niwatori.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_gi_niwatori" Segment="6">
+        <Texture Name="object_gi_niwatoriTex_000000" OutName="object_gi_niwatoriTex_000000" Format="i8" Width="32" Height="64" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_niwatoriTex_000800" OutName="object_gi_niwatoriTex_000800" Format="ia8" Width="32" Height="32" Offset="0x800" AddedByScript="true"/>
         <DList Name="gGiChickenColorDL" Offset="0x15F0"/>
         <DList Name="gGiCojiroColorDL" Offset="0x1610"/>
         <DList Name="gGiChickenDL" Offset="0x1630"/>

--- a/soh/assets/xml/GC_MQ_D/objects/object_gi_nuts.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_gi_nuts.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_nuts" Segment="6">
+        <Texture Name="object_gi_nutsTex_000000" OutName="object_gi_nutsTex_000000" Format="i8" Width="32" Height="32" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiNutDL" Offset="0x0E90"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_MQ_D/objects/object_gi_ocarina.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_gi_ocarina.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_ocarina" Segment="6">
+        <Texture Name="object_gi_ocarinaTex_000000" OutName="object_gi_ocarinaTex_000000" Format="i8" Width="16" Height="16" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiOcarinaTimeDL" Offset="0x08C0"/>
         <DList Name="gGiOcarinaTimeHolesDL" Offset="0x0AF8"/>
     </File>

--- a/soh/assets/xml/GC_MQ_D/objects/object_gi_ocarina_0.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_gi_ocarina_0.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_ocarina_0" Segment="6">
+        <Texture Name="object_gi_ocarina_0Tex_000000" OutName="object_gi_ocarina_0Tex_000000" Format="i8" Width="16" Height="16" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiOcarinaFairyDL" Offset="0x08E0"/>
         <DList Name="gGiOcarinaFairyHolesDL" Offset="0x0B58"/>
     </File>

--- a/soh/assets/xml/GC_MQ_D/objects/object_gi_prescription.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_gi_prescription.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_prescription" Segment="6">
+        <Texture Name="object_gi_prescriptionTex_000000" OutName="object_gi_prescriptionTex_000000" Format="ia8" Width="32" Height="48" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiPrescriptionDL" Offset="0x09C0"/>
         <DList Name="gGiPrescriptionWritingDL" Offset="0x0AF0"/>
     </File>

--- a/soh/assets/xml/GC_MQ_D/objects/object_gi_purse.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_gi_purse.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_purse" Segment="6">
+        <Texture Name="object_gi_purseTex_000000" OutName="object_gi_purseTex_000000" Format="i8" Width="64" Height="64" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiAdultWalletColorDL" Offset="0x1750"/>
         <DList Name="gGiGiantsWalletColorDL" Offset="0x1770"/>
         <DList Name="gGiAdultWalletRupeeOuterColorDL" Offset="0x1790"/>

--- a/soh/assets/xml/GC_MQ_D/objects/object_gi_rabit_mask.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_gi_rabit_mask.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_rabit_mask" Segment="6">
+        <Texture Name="object_gi_rabit_maskTex_000000" OutName="object_gi_rabit_maskTex_000000" Format="ia8" Width="16" Height="16" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiBunnyHoodDL" Offset="0x0BC0"/>
         <DList Name="gGiBunnyHoodEyesDL" Offset="0x0E58"/>
     </File>

--- a/soh/assets/xml/GC_MQ_D/objects/object_gi_shield_1.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_gi_shield_1.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_shield_1" Segment="6">
+        <Texture Name="object_gi_shield_1Tex_000000" OutName="object_gi_shield_1Tex_000000" Format="i8" Width="32" Height="32" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiDekuShieldDL" Offset="0x0A50"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_MQ_D/objects/object_gi_shield_3.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_gi_shield_3.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_gi_shield_3" Segment="6">
+        <Texture Name="object_gi_shield_3Tex_000000" OutName="object_gi_shield_3Tex_000000" Format="i4" Width="64" Height="32" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_shield_3Tex_000400" OutName="object_gi_shield_3Tex_000400" Format="i4" Width="64" Height="64" Offset="0x400" AddedByScript="true"/>
         <DList Name="gGiMirrorShieldDL" Offset="0x0FB0"/>
         <DList Name="gGiMirrorShieldSymbolDL" Offset="0x11C8"/>
     </File>

--- a/soh/assets/xml/GC_MQ_D/objects/object_gi_soldout.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_gi_soldout.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_soldout" Segment="6">
+        <Texture Name="object_gi_soldoutTex_000000" OutName="object_gi_soldoutTex_000000" Format="ia8" Width="32" Height="32" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiSoldOutDL" Offset="0x0440"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_MQ_D/objects/object_gi_soul.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_gi_soul.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_soul" Segment="6">
+        <Texture Name="object_gi_soulTex_000000" OutName="object_gi_soulTex_000000" Format="i8" Width="32" Height="32" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiFairyContainerBaseCapDL" Offset="0x0BD0"/>
         <DList Name="gGiFairyContainerGlassDL" Offset="0x0DB8"/>
         <DList Name="gGiFairyContainerContentsDL" Offset="0x0EF0"/>

--- a/soh/assets/xml/GC_MQ_D/objects/object_gi_ticketstone.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_gi_ticketstone.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_gi_ticketstone" Segment="6">
+        <Texture Name="object_gi_ticketstoneTex_000000" OutName="object_gi_ticketstoneTex_000000" Format="i4" Width="48" Height="24" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_ticketstoneTex_000240" OutName="object_gi_ticketstoneTex_000240" Format="i8" Width="32" Height="24" Offset="0x240" AddedByScript="true"/>
         <DList Name="gGiClaimCheckDL" Offset="0x0F00"/>
         <DList Name="gGiClaimCheckWritingDL" Offset="0x1188"/>
     </File>

--- a/soh/assets/xml/GC_MQ_D/objects/object_gi_truth_mask.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_gi_truth_mask.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_gi_truth_mask" Segment="6">
+        <Texture Name="object_gi_truth_maskTex_000000" OutName="object_gi_truth_maskTex_000000" Format="i8" Width="32" Height="32" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_truth_maskTex_000400" OutName="object_gi_truth_maskTex_000400" Format="i8" Width="32" Height="32" Offset="0x400" AddedByScript="true"/>
         <DList Name="gGiMaskOfTruthDL" Offset="0x13D0"/>
         <DList Name="gGiMaskOfTruthAccentsDL" Offset="0x16B0"/>
     </File>

--- a/soh/assets/xml/GC_MQ_D/objects/object_gi_zoramask.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_gi_zoramask.xml
@@ -1,5 +1,10 @@
 <Root>
     <File Name="object_gi_zoramask" Segment="6">
+        <Texture Name="object_gi_zoramaskTex_000208" OutName="object_gi_zoramaskTex_000208" Format="ci8" Width="8" Height="8" Offset="0x208" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_zoramaskTex_000248" OutName="object_gi_zoramaskTex_000248" Format="ci8" Width="32" Height="32" Offset="0x248" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_zoramaskTex_000648" OutName="object_gi_zoramaskTex_000648" Format="ci8" Width="32" Height="32" Offset="0x648" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_zoramaskTex_000A48" OutName="object_gi_zoramaskTex_000A48" Format="ci8" Width="32" Height="32" Offset="0xA48" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_zoramaskTLUT_000000" OutName="object_gi_zoramaskTLUT_000000" Format="rgba16" Width="16" Height="16" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiZoraMaskDL" Offset="0x1398"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_MQ_D/objects/object_gj.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_gj.xml
@@ -1,5 +1,15 @@
 <Root>
     <File Name="object_gj" Segment="6">
+        <Texture Name="object_gjTex_003B20" OutName="object_gjTex_003B20" Format="ia8" Width="16" Height="16" Offset="0x3B20" AddedByScript="true"/>
+        <Texture Name="object_gjTex_003C20" OutName="object_gjTex_003C20" Format="i4" Width="16" Height="32" Offset="0x3C20" AddedByScript="true"/>
+        <Texture Name="object_gjTex_003D20" OutName="object_gjTex_003D20" Format="rgba16" Width="16" Height="16" Offset="0x3D20" AddedByScript="true"/>
+        <Texture Name="object_gjTex_003F20" OutName="object_gjTex_003F20" Format="i8" Width="64" Height="64" Offset="0x3F20" AddedByScript="true"/>
+        <Texture Name="object_gjTex_004F20" OutName="object_gjTex_004F20" Format="i8" Width="64" Height="64" Offset="0x4F20" AddedByScript="true"/>
+        <Texture Name="object_gjTex_005F20" OutName="object_gjTex_005F20" Format="i8" Width="64" Height="64" Offset="0x5F20" AddedByScript="true"/>
+        <Texture Name="object_gjTex_006F20" OutName="object_gjTex_006F20" Format="i4" Width="32" Height="64" Offset="0x6F20" AddedByScript="true"/>
+        <Texture Name="object_gjTex_007320" OutName="object_gjTex_007320" Format="i8" Width="64" Height="16" Offset="0x7320" AddedByScript="true"/>
+        <Texture Name="object_gjTex_007720" OutName="object_gjTex_007720" Format="ia8" Width="32" Height="32" Offset="0x7720" AddedByScript="true"/>
+        <Texture Name="object_gjTex_007B20" OutName="object_gjTex_007B20" Format="i8" Width="128" Height="32" Offset="0x7B20" AddedByScript="true"/>
         <!-- This is the decorative rubble around the fight arena -->
         <DList Name="gGanonsCastleRubbleAroundArenaDL" Offset="0xDC0"/>
         <Collision Name="gGanonsCastleRubbleAroundArenaCol" Offset="0x1B70"/>

--- a/soh/assets/xml/GC_MQ_D/objects/object_gnd.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_gnd.xml
@@ -1,6 +1,7 @@
 <Root>
     <File Name="object_gnd" Segment="6">
 
+        <Texture Name="object_gndTex_012B50" OutName="object_gndTex_012B50" Format="rgba16" Width="16" Height="32" Offset="0x12B50" AddedByScript="true"/>
         <!-- Skeleton -->
         <Skeleton Name="gPhantomGanonSkel" Type="Normal" LimbType="Standard" Offset="0xC710"/>
 

--- a/soh/assets/xml/GC_MQ_D/objects/object_gr.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_gr.xml
@@ -1,12 +1,23 @@
 <Root>
     <File Name="object_gr" Segment="6">
+        <Texture Name="object_grTex_005D78" OutName="object_grTex_005D78" Format="ci8" Width="16" Height="16" Offset="0x5D78" TlutOffset="0x3F78" AddedByScript="true"/>
+        <Texture Name="object_grTex_005E78" OutName="object_grTex_005E78" Format="ci8" Width="8" Height="8" Offset="0x5E78" TlutOffset="0x3F78" AddedByScript="true"/>
+        <Texture Name="object_grTex_005EB8" OutName="object_grTex_005EB8" Format="ci8" Width="8" Height="8" Offset="0x5EB8" TlutOffset="0x3F78" AddedByScript="true"/>
+        <Texture Name="object_grTex_005EF8" OutName="object_grTex_005EF8" Format="ci8" Width="16" Height="16" Offset="0x5EF8" TlutOffset="0x3F78" AddedByScript="true"/>
+        <Texture Name="object_grTex_0077F8" OutName="object_grTex_0077F8" Format="ci8" Width="32" Height="32" Offset="0x77F8" TlutOffset="0x3F78" AddedByScript="true"/>
+        <Texture Name="object_grTex_007BF8" OutName="object_grTex_007BF8" Format="ci8" Width="32" Height="32" Offset="0x7BF8" TlutOffset="0x3F78" AddedByScript="true"/>
+        <Texture Name="object_grTex_007FF8" OutName="object_grTex_007FF8" Format="ci8" Width="32" Height="32" Offset="0x7FF8" TlutOffset="0x3F78" AddedByScript="true"/>
+        <Texture Name="object_grTex_0083F8" OutName="object_grTex_0083F8" Format="ci8" Width="32" Height="32" Offset="0x83F8" TlutOffset="0x3F78" AddedByScript="true"/>
+        <Texture Name="object_grTex_0097F8" OutName="object_grTex_0097F8" Format="ci8" Width="4" Height="4" Offset="0x97F8" TlutOffset="0x3F78" AddedByScript="true"/>
+        <Texture Name="object_grTex_009808" OutName="object_grTex_009808" Format="ci8" Width="8" Height="8" Offset="0x9808" TlutOffset="0x3F78" AddedByScript="true"/>
+        <Texture Name="object_grTLUT_003F78" OutName="object_grTLUT_003F78" Format="rgba16" Width="16" Height="16" Offset="0x3F78" AddedByScript="true"/>
         <Skeleton Name="gNiwGirlSkel" Type="Flex" LimbType="Standard" Offset="0x9948"/>
         <Animation Name="gNiwGirlRunAnim" Offset="0x0378"/>
         <Animation Name="gNiwGirlJumpAnim" Offset="0x9C78"/>
         <Texture Name="gNiwGirlEyeOpenTex" OutName="eye_open" Format="rgba16" Width="32" Height="32" Offset="0x4178"/>
         <Texture Name="gNiwGirlEyeHalfTex" OutName="eye_half" Format="rgba16" Width="32" Height="32" Offset="0x4978"/>
         <Texture Name="gNiwGirlEyeClosedTex" OutName="eye_closed" Format="rgba16" Width="32" Height="32" Offset="0x5178"/>
-        <Texture Name="gNiwGirlMouthTex"  OutName="mouth" Format="rgba16" Width="32" Height="16" Offset="0x5978"/>
+        <Texture Name="gNiwGirlMouthTex" OutName="mouth" Format="rgba16" Width="32" Height="16" Offset="0x5978"/>
         <Texture Name="gNiwGirlDress1Tex" OutName="dress_1" Format="rgba16" Width="32" Height="32" Offset="0x5FF8"/>
         <Texture Name="gNiwGirlDress2Tex" OutName="dress_2" Format="rgba16" Width="32" Height="32" Offset="0x6FF8"/>
         <Texture Name="gNiwGirlDress3Tex" OutName="dress_3" Format="rgba16" Width="32" Height="32" Offset="0x8FF8"/>

--- a/soh/assets/xml/GC_MQ_D/objects/object_hakach_objects.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_hakach_objects.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_hakach_objects" Segment="6">
+        <Texture Name="object_hakach_objectsTex_0062F0" OutName="object_hakach_objectsTex_0062F0" Format="rgba16" Width="32" Height="32" Offset="0x62F0" AddedByScript="true"/>
         <DList Name="gBotwHoleTrap1DL" Offset="0x01B0"/>
         <DList Name="gBotwHoleTrap2DL" Offset="0x03F0"/>
         <DList Name="gBotwCoffinLidDL" Offset="0x06B0"/>

--- a/soh/assets/xml/GC_MQ_D/objects/object_hidan_objects.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_hidan_objects.xml
@@ -1,5 +1,25 @@
 <Root>
     <File Name="object_hidan_objects" Segment="6">
+        <Texture Name="object_hidan_objectsTex_000040" OutName="object_hidan_objectsTex_000040" Format="ci4" Width="32" Height="32" Offset="0x40" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_000240" OutName="object_hidan_objectsTex_000240" Format="rgba16" Width="32" Height="32" Offset="0x240" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_000A40" OutName="object_hidan_objectsTex_000A40" Format="rgba16" Width="32" Height="64" Offset="0xA40" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_001A40" OutName="object_hidan_objectsTex_001A40" Format="rgba16" Width="32" Height="64" Offset="0x1A40" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_002A40" OutName="object_hidan_objectsTex_002A40" Format="rgba16" Width="32" Height="64" Offset="0x2A40" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_003A40" OutName="object_hidan_objectsTex_003A40" Format="rgba16" Width="32" Height="32" Offset="0x3A40" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_004240" OutName="object_hidan_objectsTex_004240" Format="rgba16" Width="16" Height="64" Offset="0x4240" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_004A40" OutName="object_hidan_objectsTex_004A40" Format="rgba16" Width="32" Height="32" Offset="0x4A40" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_005240" OutName="object_hidan_objectsTex_005240" Format="ci4" Width="32" Height="64" Offset="0x5240" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_005640" OutName="object_hidan_objectsTex_005640" Format="ci4" Width="32" Height="64" Offset="0x5640" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_005A40" OutName="object_hidan_objectsTex_005A40" Format="ci4" Width="64" Height="32" Offset="0x5A40" TlutOffset="0x20" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_005E40" OutName="object_hidan_objectsTex_005E40" Format="rgba16" Width="32" Height="32" Offset="0x5E40" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_006640" OutName="object_hidan_objectsTex_006640" Format="ci4" Width="32" Height="64" Offset="0x6640" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_006A40" OutName="object_hidan_objectsTex_006A40" Format="ci4" Width="32" Height="32" Offset="0x6A40" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_006C40" OutName="object_hidan_objectsTex_006C40" Format="ci4" Width="32" Height="32" Offset="0x6C40" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_006E40" OutName="object_hidan_objectsTex_006E40" Format="rgba16" Width="32" Height="32" Offset="0x6E40" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_00FB20" OutName="object_hidan_objectsTex_00FB20" Format="rgba16" Width="32" Height="64" Offset="0xFB20" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_010D90" OutName="object_hidan_objectsTex_010D90" Format="rgba16" Width="32" Height="64" Offset="0x10D90" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTLUT_000000" OutName="object_hidan_objectsTLUT_000000" Format="rgba16" Width="4" Height="4" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTLUT_000020" OutName="object_hidan_objectsTLUT_000020" Format="rgba16" Width="4" Height="4" Offset="0x20" AddedByScript="true"/>
         <DList Name="gFireTempleHammerableTotemBodyDL" Offset="0xBBF0"/>
         <DList Name="gFireTempleHammerableTotemHeadDL" Offset="0xBDF0"/>
         <Collision Name="gFireTempleHammerableTotemCol" Offset="0xDA10"/>

--- a/soh/assets/xml/GC_MQ_D/objects/object_hintnuts.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_hintnuts.xml
@@ -1,5 +1,11 @@
 <Root>
     <File Name="object_hintnuts" Segment="6">
+        <Texture Name="object_hintnutsTex_0015A8" OutName="object_hintnutsTex_0015A8" Format="rgba16" Width="32" Height="32" Offset="0x15A8" AddedByScript="true"/>
+        <Texture Name="object_hintnutsTex_001DA8" OutName="object_hintnutsTex_001DA8" Format="rgba16" Width="16" Height="16" Offset="0x1DA8" AddedByScript="true"/>
+        <Texture Name="object_hintnutsTex_001FA8" OutName="object_hintnutsTex_001FA8" Format="rgba16" Width="8" Height="8" Offset="0x1FA8" AddedByScript="true"/>
+        <Texture Name="object_hintnutsTex_002028" OutName="object_hintnutsTex_002028" Format="rgba16" Width="8" Height="8" Offset="0x2028" AddedByScript="true"/>
+        <Texture Name="object_hintnutsTex_0020A8" OutName="object_hintnutsTex_0020A8" Format="rgba16" Width="8" Height="8" Offset="0x20A8" AddedByScript="true"/>
+        <Texture Name="object_hintnutsTex_002128" OutName="object_hintnutsTex_002128" Format="rgba16" Width="16" Height="16" Offset="0x2128" AddedByScript="true"/>
         <!-- Deku scrub skeleton -->
         <Skeleton Name="gHintNutsSkel" Type="Normal" LimbType="Standard" Offset="0x23B8"/>
 

--- a/soh/assets/xml/GC_MQ_D/objects/object_horse_ganon.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_horse_ganon.xml
@@ -1,5 +1,16 @@
 <Root>
     <File Name="object_horse_ganon" Segment="6">
+        <Texture Name="object_horse_ganonTex_00A570" OutName="object_horse_ganonTex_00A570" Format="rgba16" Width="8" Height="8" Offset="0xA570" AddedByScript="true"/>
+        <Texture Name="object_horse_ganonTex_00A5F0" OutName="object_horse_ganonTex_00A5F0" Format="rgba16" Width="16" Height="16" Offset="0xA5F0" AddedByScript="true"/>
+        <Texture Name="object_horse_ganonTex_00A7F0" OutName="object_horse_ganonTex_00A7F0" Format="rgba16" Width="4" Height="4" Offset="0xA7F0" AddedByScript="true"/>
+        <Texture Name="object_horse_ganonTex_00A810" OutName="object_horse_ganonTex_00A810" Format="rgba16" Width="16" Height="16" Offset="0xA810" AddedByScript="true"/>
+        <Texture Name="object_horse_ganonTex_00AA10" OutName="object_horse_ganonTex_00AA10" Format="rgba16" Width="16" Height="16" Offset="0xAA10" AddedByScript="true"/>
+        <Texture Name="object_horse_ganonTex_00B010" OutName="object_horse_ganonTex_00B010" Format="rgba16" Width="8" Height="16" Offset="0xB010" AddedByScript="true"/>
+        <Texture Name="object_horse_ganonTex_00B110" OutName="object_horse_ganonTex_00B110" Format="rgba16" Width="16" Height="32" Offset="0xB110" AddedByScript="true"/>
+        <Texture Name="object_horse_ganonTex_00B510" OutName="object_horse_ganonTex_00B510" Format="rgba16" Width="16" Height="8" Offset="0xB510" AddedByScript="true"/>
+        <Texture Name="object_horse_ganonTex_00B610" OutName="object_horse_ganonTex_00B610" Format="rgba16" Width="8" Height="8" Offset="0xB610" AddedByScript="true"/>
+        <Texture Name="object_horse_ganonTex_00B690" OutName="object_horse_ganonTex_00B690" Format="rgba16" Width="32" Height="32" Offset="0xB690" AddedByScript="true"/>
+        <Texture Name="object_horse_ganonTex_00BE90" OutName="object_horse_ganonTex_00BE90" Format="rgba16" Width="16" Height="16" Offset="0xBE90" AddedByScript="true"/>
         <Skeleton Name="gHorseGanonSkel" Type="Normal" LimbType="Skin" Offset="0x8668"/>
 
         <!-- Idle. Horse moving leg. -->

--- a/soh/assets/xml/GC_MQ_D/objects/object_horse_link_child.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_horse_link_child.xml
@@ -1,5 +1,14 @@
 <Root>
     <File Name="object_horse_link_child" Segment="6">
+        <Texture Name="object_horse_link_childTex_001F28" OutName="object_horse_link_childTex_001F28" Format="rgba16" Width="4" Height="8" Offset="0x1F28" AddedByScript="true"/>
+        <Texture Name="object_horse_link_childTex_001F68" OutName="object_horse_link_childTex_001F68" Format="rgba16" Width="16" Height="16" Offset="0x1F68" AddedByScript="true"/>
+        <Texture Name="object_horse_link_childTex_002168" OutName="object_horse_link_childTex_002168" Format="rgba16" Width="16" Height="16" Offset="0x2168" AddedByScript="true"/>
+        <Texture Name="object_horse_link_childTex_002368" OutName="object_horse_link_childTex_002368" Format="rgba16" Width="16" Height="16" Offset="0x2368" AddedByScript="true"/>
+        <Texture Name="object_horse_link_childTex_002568" OutName="object_horse_link_childTex_002568" Format="rgba16" Width="4" Height="4" Offset="0x2568" AddedByScript="true"/>
+        <Texture Name="object_horse_link_childTex_002588" OutName="object_horse_link_childTex_002588" Format="rgba16" Width="8" Height="32" Offset="0x2588" AddedByScript="true"/>
+        <Texture Name="object_horse_link_childTex_002788" OutName="object_horse_link_childTex_002788" Format="rgba16" Width="16" Height="16" Offset="0x2788" AddedByScript="true"/>
+        <Texture Name="object_horse_link_childTex_008120" OutName="object_horse_link_childTex_008120" Format="rgba16" Width="16" Height="16" Offset="0x8120" AddedByScript="true"/>
+        <Texture Name="object_horse_link_childTex_008320" OutName="object_horse_link_childTex_008320" Format="rgba16" Width="32" Height="32" Offset="0x8320" AddedByScript="true"/>
         <Skeleton Name="gChildEponaSkel" Type="Normal" LimbType="Skin" Offset="0x7B20"/>
 
         <!-- Idle animation. -->
@@ -14,8 +23,8 @@
         <Animation Name="gChildEponaGallopingAnim" Offset="0x2F98"/>
 
         <Texture Name="gChildEponaEyeTLUT" OutName="child_epona_eye_tlut" Format="rgba16" Width="16" Height="16" Offset="0x1728"/>
-        <Texture Name="gChildEponaEyeOpenTex" OutName="child_epona_eye_open" Format="ci8" Width="32" Height="16" Offset="0x1D28"  TlutOffset="0x1728"/>
-        <Texture Name="gChildEponaEyeHalfTex" OutName="child_epona_eye_half" Format="ci8" Width="32" Height="16" Offset="0x1928"  TlutOffset="0x1728"/>
-        <Texture Name="gChildEponaEyeCloseTex" OutName="child_epona_eye_close" Format="ci8" Width="32" Height="16" Offset="0x1B28"  TlutOffset="0x1728"/>
+        <Texture Name="gChildEponaEyeOpenTex" OutName="child_epona_eye_open" Format="ci8" Width="32" Height="16" Offset="0x1D28" TlutOffset="0x1728"/>
+        <Texture Name="gChildEponaEyeHalfTex" OutName="child_epona_eye_half" Format="ci8" Width="32" Height="16" Offset="0x1928" TlutOffset="0x1728"/>
+        <Texture Name="gChildEponaEyeCloseTex" OutName="child_epona_eye_close" Format="ci8" Width="32" Height="16" Offset="0x1B28" TlutOffset="0x1728"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_MQ_D/objects/object_horse_normal.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_horse_normal.xml
@@ -1,5 +1,13 @@
 <Root>
     <File Name="object_horse_normal" Segment="6">
+        <Texture Name="object_horse_normalTex_0058D8" OutName="object_horse_normalTex_0058D8" Format="i8" Width="8" Height="8" Offset="0x58D8" AddedByScript="true"/>
+        <Texture Name="object_horse_normalTex_005918" OutName="object_horse_normalTex_005918" Format="rgba16" Width="16" Height="16" Offset="0x5918" AddedByScript="true"/>
+        <Texture Name="object_horse_normalTex_005B18" OutName="object_horse_normalTex_005B18" Format="rgba16" Width="8" Height="8" Offset="0x5B18" AddedByScript="true"/>
+        <Texture Name="object_horse_normalTex_005B98" OutName="object_horse_normalTex_005B98" Format="i8" Width="16" Height="16" Offset="0x5B98" AddedByScript="true"/>
+        <Texture Name="object_horse_normalTex_005C98" OutName="object_horse_normalTex_005C98" Format="i8" Width="16" Height="8" Offset="0x5C98" AddedByScript="true"/>
+        <Texture Name="object_horse_normalTex_006F28" OutName="object_horse_normalTex_006F28" Format="i8" Width="16" Height="16" Offset="0x6F28" AddedByScript="true"/>
+        <Texture Name="object_horse_normalTex_007028" OutName="object_horse_normalTex_007028" Format="i8" Width="16" Height="16" Offset="0x7028" AddedByScript="true"/>
+        <Texture Name="object_horse_normalTex_007128" OutName="object_horse_normalTex_007128" Format="i8" Width="32" Height="32" Offset="0x7128" AddedByScript="true"/>
         <Skeleton Name="gHorseNormalSkel" Type="Normal" LimbType="Skin" Offset="0x9FAC"/>
 
         <!-- Running. -->

--- a/soh/assets/xml/GC_MQ_D/objects/object_horse_zelda.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_horse_zelda.xml
@@ -1,5 +1,17 @@
 <Root>
     <File Name="object_horse_zelda" Segment="6">
+        <Texture Name="object_horse_zeldaTex_000408" OutName="object_horse_zeldaTex_000408" Format="rgba16" Width="8" Height="8" Offset="0x408" AddedByScript="true"/>
+        <Texture Name="object_horse_zeldaTex_000888" OutName="object_horse_zeldaTex_000888" Format="rgba16" Width="8" Height="16" Offset="0x888" AddedByScript="true"/>
+        <Texture Name="object_horse_zeldaTex_000988" OutName="object_horse_zeldaTex_000988" Format="rgba16" Width="4" Height="4" Offset="0x988" AddedByScript="true"/>
+        <Texture Name="object_horse_zeldaTex_002578" OutName="object_horse_zeldaTex_002578" Format="rgba16" Width="8" Height="16" Offset="0x2578" AddedByScript="true"/>
+        <Texture Name="object_horse_zeldaTex_002678" OutName="object_horse_zeldaTex_002678" Format="rgba16" Width="16" Height="8" Offset="0x2678" AddedByScript="true"/>
+        <Texture Name="object_horse_zeldaTex_002778" OutName="object_horse_zeldaTex_002778" Format="rgba16" Width="16" Height="16" Offset="0x2778" AddedByScript="true"/>
+        <Texture Name="object_horse_zeldaTex_002978" OutName="object_horse_zeldaTex_002978" Format="rgba16" Width="32" Height="32" Offset="0x2978" AddedByScript="true"/>
+        <Texture Name="object_horse_zeldaTex_003178" OutName="object_horse_zeldaTex_003178" Format="rgba16" Width="16" Height="8" Offset="0x3178" AddedByScript="true"/>
+        <Texture Name="object_horse_zeldaTex_003278" OutName="object_horse_zeldaTex_003278" Format="rgba16" Width="8" Height="16" Offset="0x3278" AddedByScript="true"/>
+        <Texture Name="object_horse_zeldaTex_003378" OutName="object_horse_zeldaTex_003378" Format="rgba16" Width="8" Height="8" Offset="0x3378" AddedByScript="true"/>
+        <Texture Name="object_horse_zeldaTex_0033F8" OutName="object_horse_zeldaTex_0033F8" Format="rgba16" Width="8" Height="16" Offset="0x33F8" AddedByScript="true"/>
+        <Texture Name="object_horse_zeldaTex_0034F8" OutName="object_horse_zeldaTex_0034F8" Format="rgba16" Width="16" Height="16" Offset="0x34F8" AddedByScript="true"/>
         <Skeleton Name="gHorseZeldaSkel" Type="Normal" LimbType="Skin" Offset="0x6B2C"/>
 
         <!-- Running. -->

--- a/soh/assets/xml/GC_MQ_D/objects/object_jya_obj.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_jya_obj.xml
@@ -1,5 +1,12 @@
 <Root>
     <File Name="object_jya_obj" Segment="6">
+        <Texture Name="object_jya_objTex_00B4B8" OutName="object_jya_objTex_00B4B8" Format="ci8" Width="32" Height="32" Offset="0xB4B8" TlutOffset="0xAC70" AddedByScript="true"/>
+        <Texture Name="object_jya_objTex_011A80" OutName="object_jya_objTex_011A80" Format="ci4" Width="64" Height="64" Offset="0x11A80" TlutOffset="0x11A60" AddedByScript="true"/>
+        <Texture Name="object_jya_objTex_016140" OutName="object_jya_objTex_016140" Format="rgba16" Width="64" Height="32" Offset="0x16140" AddedByScript="true"/>
+        <Texture Name="object_jya_objTex_017140" OutName="object_jya_objTex_017140" Format="rgba16" Width="32" Height="16" Offset="0x17140" AddedByScript="true"/>
+        <Texture Name="object_jya_objTex_01B340" OutName="object_jya_objTex_01B340" Format="ia8" Width="32" Height="32" Offset="0x1B340" AddedByScript="true"/>
+        <Texture Name="object_jya_objTex_01B740" OutName="object_jya_objTex_01B740" Format="rgba16" Width="16" Height="16" Offset="0x1B740" AddedByScript="true"/>
+        <Texture Name="object_jya_objTLUT_011A60" OutName="object_jya_objTLUT_011A60" Format="rgba16" Width="4" Height="4" Offset="0x11A60" AddedByScript="true"/>
         <DList Name="g1fliftDL" Offset="0x1F0"/>
         <Collision Name="g1fliftCol" Offset="0x4A8"/>
         <Texture Name="g1f1fiftTopTex" OutName="1flift_top" Format="rgba16" Width="32" Height="32" Offset="0x1B940"/>

--- a/soh/assets/xml/GC_MQ_D/objects/object_link_boy.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_link_boy.xml
@@ -1,5 +1,12 @@
 <Root>
     <File Name="object_link_boy" Segment="6">
+        <Texture Name="object_link_boyTLUT_005400" OutName="object_link_boyTLUT_005400" Format="rgba16" Width="16" Height="16" Offset="0x5400" AddedByScript="true"/>
+        <Texture Name="object_link_boyTLUT_005800" OutName="object_link_boyTLUT_005800" Format="rgba16" Width="16" Height="16" Offset="0x5800" AddedByScript="true"/>
+        <Texture Name="object_link_boyTLUT_005A00" OutName="object_link_boyTLUT_005A00" Format="rgba16" Width="16" Height="16" Offset="0x5A00" AddedByScript="true"/>
+        <Texture Name="object_link_boyTLUT_00CB40" OutName="object_link_boyTLUT_00CB40" Format="rgba16" Width="16" Height="16" Offset="0xCB40" AddedByScript="true"/>
+        <Texture Name="object_link_boyTLUT_00CD48" OutName="object_link_boyTLUT_00CD48" Format="rgba16" Width="16" Height="16" Offset="0xCD48" AddedByScript="true"/>
+        <Texture Name="object_link_boyTLUT_00CF50" OutName="object_link_boyTLUT_00CF50" Format="rgba16" Width="16" Height="16" Offset="0xCF50" AddedByScript="true"/>
+        <Texture Name="object_link_boyTLUT_00D078" OutName="object_link_boyTLUT_00D078" Format="rgba16" Width="16" Height="16" Offset="0xD078" AddedByScript="true"/>
         <Skeleton Name="gLinkAdultSkel" Type="Flex" LimbType="LOD" Offset="0x377F4"/>
 
         <!-- Far Limb DLists-->

--- a/soh/assets/xml/GC_MQ_D/objects/object_masterkokirihead.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_masterkokirihead.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_masterkokirihead" Segment="6">
+        <Texture Name="object_masterkokiriheadTex_0009F0" OutName="object_masterkokiriheadTex_0009F0" Format="ci8" Width="8" Height="8" Offset="0x9F0" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_masterkokiriheadTex_000A30" OutName="object_masterkokiriheadTex_000A30" Format="ci8" Width="16" Height="16" Offset="0xA30" TlutOffset="0x0" AddedByScript="true"/>
         <DList Name="gKokiriShopkeeperHeadDL" Offset="0x2820"/>
         <Texture Name="gKokiriShopkeeperTLUT" OutName="tlut" Format="rgba16" Width="248" Height="1" Offset="0x0"/>
         <Texture Name="gKokiriShopkeeperEyeHalfTex" OutName="eye_half" Format="rgba16" Width="32" Height="32" Offset="0x1F0"/>

--- a/soh/assets/xml/GC_MQ_D/objects/object_mb.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_mb.xml
@@ -1,5 +1,19 @@
 <Root>
     <File Name="object_mb" Segment="6">
+        <Texture Name="object_mbTex_008128" OutName="object_mbTex_008128" Format="rgba16" Width="16" Height="16" Offset="0x8128" AddedByScript="true"/>
+        <Texture Name="object_mbTex_008328" OutName="object_mbTex_008328" Format="rgba16" Width="8" Height="32" Offset="0x8328" AddedByScript="true"/>
+        <Texture Name="object_mbTex_008928" OutName="object_mbTex_008928" Format="rgba16" Width="8" Height="16" Offset="0x8928" AddedByScript="true"/>
+        <Texture Name="object_mbTex_008A28" OutName="object_mbTex_008A28" Format="rgba16" Width="4" Height="4" Offset="0x8A28" AddedByScript="true"/>
+        <Texture Name="object_mbTex_008A48" OutName="object_mbTex_008A48" Format="rgba16" Width="8" Height="24" Offset="0x8A48" AddedByScript="true"/>
+        <Texture Name="object_mbTex_008BC8" OutName="object_mbTex_008BC8" Format="rgba16" Width="4" Height="16" Offset="0x8BC8" AddedByScript="true"/>
+        <Texture Name="object_mbTex_008C48" OutName="object_mbTex_008C48" Format="rgba16" Width="4" Height="8" Offset="0x8C48" AddedByScript="true"/>
+        <Texture Name="object_mbTex_008C88" OutName="object_mbTex_008C88" Format="rgba16" Width="8" Height="16" Offset="0x8C88" AddedByScript="true"/>
+        <Texture Name="object_mbTex_00EC00" OutName="object_mbTex_00EC00" Format="rgba16" Width="16" Height="16" Offset="0xEC00" AddedByScript="true"/>
+        <Texture Name="object_mbTex_00EE00" OutName="object_mbTex_00EE00" Format="rgba16" Width="8" Height="16" Offset="0xEE00" AddedByScript="true"/>
+        <Texture Name="object_mbTex_00EF00" OutName="object_mbTex_00EF00" Format="rgba16" Width="8" Height="16" Offset="0xEF00" AddedByScript="true"/>
+        <Texture Name="object_mbTex_00F000" OutName="object_mbTex_00F000" Format="rgba16" Width="16" Height="16" Offset="0xF000" AddedByScript="true"/>
+        <Texture Name="object_mbTex_00F200" OutName="object_mbTex_00F200" Format="rgba16" Width="4" Height="16" Offset="0xF200" AddedByScript="true"/>
+        <Texture Name="object_mbTex_00F280" OutName="object_mbTex_00F280" Format="rgba16" Width="4" Height="16" Offset="0xF280" AddedByScript="true"/>
         <Skeleton Name="gEnMbSpearSkel" Type="Flex" LimbType="Standard" Offset="0x8F38"/>
         <Skeleton Name="gEnMbClubSkel" Type="Flex" LimbType="Standard" Offset="0x14190"/>
         <Animation Name="gEnMbSpearFallFaceDownAnim" Offset="0x6A4"/><!--Unused-->

--- a/soh/assets/xml/GC_MQ_D/objects/object_mizu_objects.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_mizu_objects.xml
@@ -1,5 +1,19 @@
 <Root>
     <File Name="object_mizu_objects" Segment="6">
+        <Texture Name="object_mizu_objectsTex_004C00" OutName="object_mizu_objectsTex_004C00" Format="rgba16" Width="32" Height="64" Offset="0x4C00" AddedByScript="true"/>
+        <Texture Name="object_mizu_objectsTex_005E70" OutName="object_mizu_objectsTex_005E70" Format="rgba16" Width="32" Height="64" Offset="0x5E70" AddedByScript="true"/>
+        <Texture Name="object_mizu_objectsTex_007520" OutName="object_mizu_objectsTex_007520" Format="ia16" Width="32" Height="32" Offset="0x7520" AddedByScript="true"/>
+        <Texture Name="object_mizu_objectsTex_007D20" OutName="object_mizu_objectsTex_007D20" Format="rgba16" Width="32" Height="32" Offset="0x7D20" AddedByScript="true"/>
+        <Texture Name="object_mizu_objectsTex_008520" OutName="object_mizu_objectsTex_008520" Format="rgba16" Width="32" Height="32" Offset="0x8520" AddedByScript="true"/>
+        <Texture Name="object_mizu_objectsTex_008D20" OutName="object_mizu_objectsTex_008D20" Format="rgba16" Width="32" Height="32" Offset="0x8D20" AddedByScript="true"/>
+        <Texture Name="object_mizu_objectsTex_009520" OutName="object_mizu_objectsTex_009520" Format="i4" Width="32" Height="32" Offset="0x9520" AddedByScript="true"/>
+        <Texture Name="object_mizu_objectsTex_009720" OutName="object_mizu_objectsTex_009720" Format="i4" Width="32" Height="32" Offset="0x9720" AddedByScript="true"/>
+        <Texture Name="object_mizu_objectsTex_009920" OutName="object_mizu_objectsTex_009920" Format="i4" Width="32" Height="32" Offset="0x9920" AddedByScript="true"/>
+        <Texture Name="object_mizu_objectsTex_009B20" OutName="object_mizu_objectsTex_009B20" Format="i4" Width="32" Height="32" Offset="0x9B20" AddedByScript="true"/>
+        <Texture Name="object_mizu_objectsTex_009D20" OutName="object_mizu_objectsTex_009D20" Format="i4" Width="32" Height="32" Offset="0x9D20" AddedByScript="true"/>
+        <Texture Name="object_mizu_objectsTex_009F20" OutName="object_mizu_objectsTex_009F20" Format="rgba16" Width="32" Height="32" Offset="0x9F20" AddedByScript="true"/>
+        <Texture Name="object_mizu_objectsTex_00A720" OutName="object_mizu_objectsTex_00A720" Format="rgba16" Width="16" Height="32" Offset="0xA720" AddedByScript="true"/>
+        <Texture Name="object_mizu_objectsTex_00AB20" OutName="object_mizu_objectsTex_00AB20" Format="i4" Width="64" Height="64" Offset="0xAB20" AddedByScript="true"/>
         <DList Name="gObjectMizuObjectsMovebgDL_000190" Offset="0x0190"/>
         <Collision Name="gObjectMizuObjectsMovebgCol_0003F0" Offset="0x03F0"/>
         <DList Name="gObjectMizuObjectsMovebgDL_000680" Offset="0x0680"/>

--- a/soh/assets/xml/GC_MQ_D/objects/object_mm.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_mm.xml
@@ -1,5 +1,14 @@
 <Root>
     <File Name="object_mm" Segment="6">
+        <Texture Name="object_mmTex_000930" OutName="object_mmTex_000930" Format="ci8" Width="8" Height="8" Offset="0x930" TlutOffset="0x730" AddedByScript="true"/>
+        <Texture Name="object_mmTex_000970" OutName="object_mmTex_000970" Format="ci8" Width="8" Height="8" Offset="0x970" TlutOffset="0x730" AddedByScript="true"/>
+        <Texture Name="object_mmTex_0009B0" OutName="object_mmTex_0009B0" Format="ci8" Width="8" Height="8" Offset="0x9B0" TlutOffset="0x730" AddedByScript="true"/>
+        <Texture Name="object_mmTex_0009F0" OutName="object_mmTex_0009F0" Format="ci8" Width="8" Height="8" Offset="0x9F0" TlutOffset="0x730" AddedByScript="true"/>
+        <Texture Name="object_mmTex_000A30" OutName="object_mmTex_000A30" Format="ci8" Width="16" Height="16" Offset="0xA30" TlutOffset="0x730" AddedByScript="true"/>
+        <Texture Name="object_mmTex_000B30" OutName="object_mmTex_000B30" Format="ci8" Width="16" Height="16" Offset="0xB30" TlutOffset="0x730" AddedByScript="true"/>
+        <Texture Name="object_mmTex_001030" OutName="object_mmTex_001030" Format="ci8" Width="16" Height="16" Offset="0x1030" TlutOffset="0x730" AddedByScript="true"/>
+        <Texture Name="object_mmTex_001130" OutName="object_mmTex_001130" Format="ci8" Width="32" Height="16" Offset="0x1130" TlutOffset="0x730" AddedByScript="true"/>
+        <Texture Name="object_mmTex_001330" OutName="object_mmTex_001330" Format="ci8" Width="16" Height="16" Offset="0x1330" TlutOffset="0x730" AddedByScript="true"/>
         <Skeleton Name="gRunningManSkel" Type="Flex" LimbType="Standard" Offset="0x5E18"/>
 
         <Animation Name="gRunningManRunAnim" Offset="0x0718"/>

--- a/soh/assets/xml/GC_MQ_D/objects/object_mo.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_mo.xml
@@ -1,5 +1,10 @@
 <Root>
     <File Name="object_mo" Segment="6">
+        <Texture Name="object_moTex_000000" OutName="object_moTex_000000" Format="ia8" Width="16" Height="16" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="object_moTex_000680" OutName="object_moTex_000680" Format="rgba16" Width="32" Height="32" Offset="0x680" AddedByScript="true"/>
+        <Texture Name="object_moTex_004D20" OutName="object_moTex_004D20" Format="ia16" Width="32" Height="32" Offset="0x4D20" AddedByScript="true"/>
+        <Texture Name="object_moTex_005520" OutName="object_moTex_005520" Format="ia16" Width="32" Height="32" Offset="0x5520" AddedByScript="true"/>
+        <Texture Name="object_moTex_005D20" OutName="object_moTex_005D20" Format="ia16" Width="32" Height="32" Offset="0x5D20" AddedByScript="true"/>
         <!-- Morpha's Title Card -->
         <Texture Name="gMorphaTitleCardTex" Format="i8" Width="128" Height="120" Offset="0x1010"/>
 

--- a/soh/assets/xml/GC_MQ_D/objects/object_oE1s.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_oE1s.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_oE1s" Segment="6">
+        <Texture Name="object_oE1sTex_000478" OutName="object_oE1sTex_000478" Format="ci8" Width="32" Height="32" Offset="0x478" TlutOffset="0x1A8" AddedByScript="true"/>
+        <Texture Name="object_oE1sTLUT_0001A8" OutName="object_oE1sTLUT_0001A8" Format="rgba16" Width="16" Height="16" Offset="0x1A8" AddedByScript="true"/>
         <Animation Name="object_oE1s_Anim_00007C" Offset="0x7C"/>
         <Limb Name="object_oE1s_Limb_000090" LimbType="Standard" Offset="0x90"/>
         <Limb Name="object_oE1s_Limb_00009C" LimbType="Standard" Offset="0x9C"/>
@@ -21,15 +23,15 @@
         <!--Blob Name="object_oE1s_Blob_00019C" Size="0x204" Offset="0x19C" /-->
         <Texture Name="object_oE1s_TLUT_0003A0" OutName="tlut_000003A0" Format="rgba16" Width="108" Height="1" Offset="0x3A0"/>
         <!--Blob Name="object_oE1s_Blob_0005A0" Size="0x2D8" Offset="0x5A0" /-->
-        <Texture Name="object_oE1s_Tex_000878" OutName="tex_00000878" Format="ci8" Width="8" Height="8" Offset="0x878"  TlutOffset="0x3A0"/>
+        <Texture Name="object_oE1s_Tex_000878" OutName="tex_00000878" Format="ci8" Width="8" Height="8" Offset="0x878" TlutOffset="0x3A0"/>
         <Texture Name="object_oE1s_Tex_0008B8" OutName="tex_000008B8" Format="rgba16" Width="16" Height="32" Offset="0x8B8"/>
         <Texture Name="object_oE1s_Tex_000CB8" OutName="tex_00000CB8" Format="rgba16" Width="32" Height="32" Offset="0xCB8"/>
-        <Texture Name="object_oE1s_Tex_0014B8" OutName="tex_000014B8" Format="ci8" Width="16" Height="16" Offset="0x14B8"  TlutOffset="0x3A0"/>
+        <Texture Name="object_oE1s_Tex_0014B8" OutName="tex_000014B8" Format="ci8" Width="16" Height="16" Offset="0x14B8" TlutOffset="0x3A0"/>
         <Texture Name="object_oE1s_Tex_0015B8" OutName="tex_000015B8" Format="i4" Width="16" Height="8" Offset="0x15B8"/>
         <Blob Name="object_oE1s_Blob_0015F8" Size="0x400" Offset="0x15F8"/>
         <Texture Name="object_oE1s_Tex_0019F8" OutName="tex_000019F8" Format="i4" Width="16" Height="16" Offset="0x19F8"/>
         <Texture Name="object_oE1s_Tex_001A78" OutName="tex_00001A78" Format="rgba16" Width="16" Height="8" Offset="0x1A78"/>
-        <Texture Name="object_oE1s_Tex_001B78" OutName="tex_00001B78" Format="ci8" Width="16" Height="16" Offset="0x1B78"  TlutOffset="0x3A0"/>
+        <Texture Name="object_oE1s_Tex_001B78" OutName="tex_00001B78" Format="ci8" Width="16" Height="16" Offset="0x1B78" TlutOffset="0x3A0"/>
         <Blob Name="object_oE1s_Blob_001C78" Size="0x400" Offset="0x1C78"/>
         <DList Name="object_oE1s_DL_004D98" Offset="0x4D98"/>
         <DList Name="object_oE1s_DL_005010" Offset="0x5010"/>

--- a/soh/assets/xml/GC_MQ_D/objects/object_oE4s.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_oE4s.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_oE4s" Segment="6">
+        <Texture Name="object_oE4sTex_0002A0" OutName="object_oE4sTex_0002A0" Format="ci8" Width="16" Height="16" Offset="0x2A0" TlutOffset="0x1A8" AddedByScript="true"/>
+        <Texture Name="object_oE4sTex_0003A0" OutName="object_oE4sTex_0003A0" Format="ci8" Width="16" Height="16" Offset="0x3A0" TlutOffset="0x1A8" AddedByScript="true"/>
         <Animation Name="object_oE4s_Anim_00007C" Offset="0x7C"/>
         <Limb Name="object_oE4s_Limb_000090" LimbType="Standard" Offset="0x90"/>
         <Limb Name="object_oE4s_Limb_00009C" LimbType="Standard" Offset="0x9C"/>

--- a/soh/assets/xml/GC_MQ_D/objects/object_oF1d_map.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_oF1d_map.xml
@@ -1,5 +1,22 @@
 <Root>
     <File Name="object_oF1d_map" Segment="6">
+        <Texture Name="object_oF1d_mapTex_009270" OutName="object_oF1d_mapTex_009270" Format="ci8" Width="8" Height="8" Offset="0x9270" TlutOffset="0x9130" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_0092B0" OutName="object_oF1d_mapTex_0092B0" Format="ci8" Width="8" Height="8" Offset="0x92B0" TlutOffset="0x9130" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_0092F0" OutName="object_oF1d_mapTex_0092F0" Format="ci8" Width="8" Height="16" Offset="0x92F0" TlutOffset="0x9130" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_009370" OutName="object_oF1d_mapTex_009370" Format="ci8" Width="32" Height="64" Offset="0x9370" TlutOffset="0x9130" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_009B70" OutName="object_oF1d_mapTex_009B70" Format="ci8" Width="16" Height="16" Offset="0x9B70" TlutOffset="0x9130" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_009C70" OutName="object_oF1d_mapTex_009C70" Format="rgba16" Width="64" Height="32" Offset="0x9C70" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_00C840" OutName="object_oF1d_mapTex_00C840" Format="ci8" Width="8" Height="8" Offset="0xC840" TlutOffset="0xC440" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_00C880" OutName="object_oF1d_mapTex_00C880" Format="ci8" Width="32" Height="16" Offset="0xC880" TlutOffset="0xC440" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_00CA80" OutName="object_oF1d_mapTex_00CA80" Format="ci8" Width="32" Height="32" Offset="0xCA80" TlutOffset="0xC440" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_00EE80" OutName="object_oF1d_mapTex_00EE80" Format="ci8" Width="32" Height="64" Offset="0xEE80" TlutOffset="0xC440" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_00F680" OutName="object_oF1d_mapTex_00F680" Format="ci8" Width="8" Height="8" Offset="0xF680" TlutOffset="0xC440" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_00F6C0" OutName="object_oF1d_mapTex_00F6C0" Format="ci8" Width="16" Height="16" Offset="0xF6C0" TlutOffset="0xC440" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_00F7C0" OutName="object_oF1d_mapTex_00F7C0" Format="ci8" Width="16" Height="16" Offset="0xF7C0" TlutOffset="0xC440" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_00F8C0" OutName="object_oF1d_mapTex_00F8C0" Format="ci8" Width="32" Height="32" Offset="0xF8C0" TlutOffset="0xC440" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_00FCC0" OutName="object_oF1d_mapTex_00FCC0" Format="ci8" Width="8" Height="16" Offset="0xFCC0" TlutOffset="0xC440" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTLUT_009130" OutName="object_oF1d_mapTLUT_009130" Format="rgba16" Width="16" Height="16" Offset="0x9130" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTLUT_00C440" OutName="object_oF1d_mapTLUT_00C440" Format="rgba16" Width="16" Height="16" Offset="0xC440" AddedByScript="true"/>
         <!-- animations -->
         <Animation Name="gGoronAnim_000750" Offset="0x750"/>
         <Animation Name="gGoronAnim_000D5C" Offset="0xD5C"/>

--- a/soh/assets/xml/GC_MQ_D/objects/object_ossan.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_ossan.xml
@@ -1,5 +1,15 @@
 <Root>
     <File Name="object_ossan" Segment="6">
+        <Texture Name="object_ossanTex_005078" OutName="object_ossanTex_005078" Format="ci8" Width="16" Height="16" Offset="0x5078" TlutOffset="0x4728" AddedByScript="true"/>
+        <Texture Name="object_ossanTex_005178" OutName="object_ossanTex_005178" Format="ci8" Width="16" Height="16" Offset="0x5178" TlutOffset="0x4728" AddedByScript="true"/>
+        <Texture Name="object_ossanTex_005278" OutName="object_ossanTex_005278" Format="ci8" Width="8" Height="8" Offset="0x5278" TlutOffset="0x4728" AddedByScript="true"/>
+        <Texture Name="object_ossanTex_005AB8" OutName="object_ossanTex_005AB8" Format="ci8" Width="8" Height="8" Offset="0x5AB8" TlutOffset="0x4728" AddedByScript="true"/>
+        <Texture Name="object_ossanTex_008A38" OutName="object_ossanTex_008A38" Format="rgba16" Width="8" Height="8" Offset="0x8A38" AddedByScript="true"/>
+        <Texture Name="object_ossanTex_008AB8" OutName="object_ossanTex_008AB8" Format="rgba16" Width="16" Height="16" Offset="0x8AB8" AddedByScript="true"/>
+        <Texture Name="object_ossanTex_008CB8" OutName="object_ossanTex_008CB8" Format="rgba16" Width="16" Height="16" Offset="0x8CB8" AddedByScript="true"/>
+        <Texture Name="object_ossanTex_008EB8" OutName="object_ossanTex_008EB8" Format="rgba16" Width="32" Height="32" Offset="0x8EB8" AddedByScript="true"/>
+        <Texture Name="object_ossanTex_0096B8" OutName="object_ossanTex_0096B8" Format="rgba16" Width="16" Height="16" Offset="0x96B8" AddedByScript="true"/>
+        <Texture Name="object_ossanTex_0098B8" OutName="object_ossanTex_0098B8" Format="rgba16" Width="16" Height="16" Offset="0x98B8" AddedByScript="true"/>
         <Animation Name="gObjectOssanAnim_000338" Offset="0x338"/>
         <Texture Name="gOssanEyesTLUT" OutName="ossan_eyes_tlut" Format="rgba16" Width="63" Height="4" Offset="0x4530"/>
         <Texture Name="gOssanTLUT" OutName="ossan_tlut" Format="rgba16" Width="168" Height="1" Offset="0x4728"/>

--- a/soh/assets/xml/GC_MQ_D/objects/object_owl.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_owl.xml
@@ -1,5 +1,13 @@
 <Root>
     <File Name="object_owl" Segment="6">
+        <Texture Name="object_owlTex_0071A8" OutName="object_owlTex_0071A8" Format="rgba16" Width="32" Height="32" Offset="0x71A8" AddedByScript="true"/>
+        <Texture Name="object_owlTex_0079A8" OutName="object_owlTex_0079A8" Format="rgba16" Width="32" Height="32" Offset="0x79A8" AddedByScript="true"/>
+        <Texture Name="object_owlTex_0081A8" OutName="object_owlTex_0081A8" Format="rgba16" Width="32" Height="32" Offset="0x81A8" AddedByScript="true"/>
+        <Texture Name="object_owlTex_0095A8" OutName="object_owlTex_0095A8" Format="rgba16" Width="32" Height="32" Offset="0x95A8" AddedByScript="true"/>
+        <Texture Name="object_owlTex_009DA8" OutName="object_owlTex_009DA8" Format="rgba16" Width="16" Height="16" Offset="0x9DA8" AddedByScript="true"/>
+        <Texture Name="object_owlTex_009FA8" OutName="object_owlTex_009FA8" Format="rgba16" Width="64" Height="32" Offset="0x9FA8" AddedByScript="true"/>
+        <Texture Name="object_owlTex_00AFA8" OutName="object_owlTex_00AFA8" Format="rgba16" Width="32" Height="32" Offset="0xAFA8" AddedByScript="true"/>
+        <Texture Name="object_owlTex_00B7A8" OutName="object_owlTex_00B7A8" Format="rgba16" Width="32" Height="32" Offset="0xB7A8" AddedByScript="true"/>
         <!-- Flying Owl Skeleton -->
         <Skeleton Name="gOwlFlyingSkel" Type="Flex" LimbType="Standard" Offset="0xC0E8"/>
 

--- a/soh/assets/xml/GC_MQ_D/objects/object_po_composer.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_po_composer.xml
@@ -1,6 +1,19 @@
 <Root>
     
     <File Name="object_po_composer" Segment="6">
+        <Texture Name="object_po_composerTex_001450" OutName="object_po_composerTex_001450" Format="i8" Width="32" Height="64" Offset="0x1450" AddedByScript="true"/>
+        <Texture Name="object_po_composerTex_0054E0" OutName="object_po_composerTex_0054E0" Format="rgba16" Width="16" Height="16" Offset="0x54E0" AddedByScript="true"/>
+        <Texture Name="object_po_composerTex_0056E0" OutName="object_po_composerTex_0056E0" Format="rgba16" Width="16" Height="16" Offset="0x56E0" AddedByScript="true"/>
+        <Texture Name="object_po_composerTex_0058E0" OutName="object_po_composerTex_0058E0" Format="rgba16" Width="16" Height="16" Offset="0x58E0" AddedByScript="true"/>
+        <Texture Name="object_po_composerTex_005AE0" OutName="object_po_composerTex_005AE0" Format="rgba16" Width="16" Height="16" Offset="0x5AE0" AddedByScript="true"/>
+        <Texture Name="object_po_composerTex_005CE0" OutName="object_po_composerTex_005CE0" Format="rgba16" Width="16" Height="32" Offset="0x5CE0" AddedByScript="true"/>
+        <Texture Name="object_po_composerTex_0060E0" OutName="object_po_composerTex_0060E0" Format="rgba16" Width="16" Height="16" Offset="0x60E0" AddedByScript="true"/>
+        <Texture Name="object_po_composerTex_0062E0" OutName="object_po_composerTex_0062E0" Format="rgba16" Width="16" Height="16" Offset="0x62E0" AddedByScript="true"/>
+        <Texture Name="object_po_composerTex_0064E0" OutName="object_po_composerTex_0064E0" Format="rgba16" Width="16" Height="16" Offset="0x64E0" AddedByScript="true"/>
+        <Texture Name="object_po_composerTex_0066E0" OutName="object_po_composerTex_0066E0" Format="rgba16" Width="16" Height="16" Offset="0x66E0" AddedByScript="true"/>
+        <Texture Name="object_po_composerTex_0068E0" OutName="object_po_composerTex_0068E0" Format="rgba16" Width="16" Height="16" Offset="0x68E0" AddedByScript="true"/>
+        <Texture Name="object_po_composerTex_006AE0" OutName="object_po_composerTex_006AE0" Format="rgba16" Width="16" Height="16" Offset="0x6AE0" AddedByScript="true"/>
+        <Texture Name="object_po_composerTex_006CE0" OutName="object_po_composerTex_006CE0" Format="rgba16" Width="16" Height="16" Offset="0x6CE0" AddedByScript="true"/>
         <Animation Name="gPoeComposerAttackAnim" Offset="0x020C"/>
         <Animation Name="gPoeComposerDamagedAnim" Offset="0x0570"/>
         <Animation Name="gPoeComposerFleeAnim" Offset="0x0708"/>

--- a/soh/assets/xml/GC_MQ_D/objects/object_po_field.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_po_field.xml
@@ -1,6 +1,17 @@
 <Root>
     
     <File Name="object_po_field" Segment="6">
+        <Texture Name="object_po_fieldTex_002470" OutName="object_po_fieldTex_002470" Format="rgba16" Width="16" Height="16" Offset="0x2470" AddedByScript="true"/>
+        <Texture Name="object_po_fieldTex_002670" OutName="object_po_fieldTex_002670" Format="rgba16" Width="16" Height="16" Offset="0x2670" AddedByScript="true"/>
+        <Texture Name="object_po_fieldTex_002870" OutName="object_po_fieldTex_002870" Format="rgba16" Width="32" Height="32" Offset="0x2870" AddedByScript="true"/>
+        <Texture Name="object_po_fieldTex_003070" OutName="object_po_fieldTex_003070" Format="rgba16" Width="16" Height="16" Offset="0x3070" AddedByScript="true"/>
+        <Texture Name="object_po_fieldTex_003270" OutName="object_po_fieldTex_003270" Format="rgba16" Width="8" Height="8" Offset="0x3270" AddedByScript="true"/>
+        <Texture Name="object_po_fieldTex_0032F0" OutName="object_po_fieldTex_0032F0" Format="rgba16" Width="16" Height="8" Offset="0x32F0" AddedByScript="true"/>
+        <Texture Name="object_po_fieldTex_0033F0" OutName="object_po_fieldTex_0033F0" Format="rgba16" Width="16" Height="16" Offset="0x33F0" AddedByScript="true"/>
+        <Texture Name="object_po_fieldTex_0035F0" OutName="object_po_fieldTex_0035F0" Format="rgba16" Width="16" Height="16" Offset="0x35F0" AddedByScript="true"/>
+        <Texture Name="object_po_fieldTex_0037F0" OutName="object_po_fieldTex_0037F0" Format="rgba16" Width="16" Height="16" Offset="0x37F0" AddedByScript="true"/>
+        <Texture Name="object_po_fieldTex_005AB0" OutName="object_po_fieldTex_005AB0" Format="rgba16" Width="16" Height="16" Offset="0x5AB0" AddedByScript="true"/>
+        <Texture Name="object_po_fieldTex_005CB0" OutName="object_po_fieldTex_005CB0" Format="rgba16" Width="8" Height="8" Offset="0x5CB0" AddedByScript="true"/>
         <Animation Name="gPoeFieldAttackAnim" Offset="0x0158"/>
         <Animation Name="gPoeFieldDamagedAnim" Offset="0x0454"/>
         <Animation Name="gPoeFieldFleeAnim" Offset="0x0608"/>

--- a/soh/assets/xml/GC_MQ_D/objects/object_po_sisters.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_po_sisters.xml
@@ -1,5 +1,33 @@
 <Root>
     <File Name="object_po_sisters" Segment="6">
+        <Texture Name="object_po_sistersTex_0048D8" OutName="object_po_sistersTex_0048D8" Format="rgba16" Width="16" Height="16" Offset="0x48D8" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_004AD8" OutName="object_po_sistersTex_004AD8" Format="rgba16" Width="32" Height="32" Offset="0x4AD8" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_0052D8" OutName="object_po_sistersTex_0052D8" Format="rgba16" Width="32" Height="16" Offset="0x52D8" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_0056D8" OutName="object_po_sistersTex_0056D8" Format="rgba16" Width="16" Height="16" Offset="0x56D8" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_0058D8" OutName="object_po_sistersTex_0058D8" Format="rgba16" Width="4" Height="4" Offset="0x58D8" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_0058F8" OutName="object_po_sistersTex_0058F8" Format="rgba16" Width="16" Height="16" Offset="0x58F8" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_005AF8" OutName="object_po_sistersTex_005AF8" Format="rgba16" Width="16" Height="16" Offset="0x5AF8" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_005CF8" OutName="object_po_sistersTex_005CF8" Format="rgba16" Width="8" Height="8" Offset="0x5CF8" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_005D78" OutName="object_po_sistersTex_005D78" Format="rgba16" Width="16" Height="16" Offset="0x5D78" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_005F78" OutName="object_po_sistersTex_005F78" Format="rgba16" Width="16" Height="8" Offset="0x5F78" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_006078" OutName="object_po_sistersTex_006078" Format="rgba16" Width="16" Height="16" Offset="0x6078" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_006278" OutName="object_po_sistersTex_006278" Format="rgba16" Width="8" Height="8" Offset="0x6278" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_0062F8" OutName="object_po_sistersTex_0062F8" Format="rgba16" Width="4" Height="4" Offset="0x62F8" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_006318" OutName="object_po_sistersTex_006318" Format="rgba16" Width="16" Height="16" Offset="0x6318" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_007AC0" OutName="object_po_sistersTex_007AC0" Format="rgba16" Width="32" Height="32" Offset="0x7AC0" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_0082C0" OutName="object_po_sistersTex_0082C0" Format="rgba16" Width="8" Height="16" Offset="0x82C0" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_0083C0" OutName="object_po_sistersTex_0083C0" Format="rgba16" Width="32" Height="32" Offset="0x83C0" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_008BC0" OutName="object_po_sistersTex_008BC0" Format="rgba16" Width="32" Height="32" Offset="0x8BC0" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_0093C0" OutName="object_po_sistersTex_0093C0" Format="rgba16" Width="32" Height="32" Offset="0x93C0" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_009BC0" OutName="object_po_sistersTex_009BC0" Format="rgba16" Width="32" Height="32" Offset="0x9BC0" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_00A3C0" OutName="object_po_sistersTex_00A3C0" Format="rgba16" Width="32" Height="32" Offset="0xA3C0" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_00ABC0" OutName="object_po_sistersTex_00ABC0" Format="rgba16" Width="32" Height="32" Offset="0xABC0" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_00B3C0" OutName="object_po_sistersTex_00B3C0" Format="rgba16" Width="32" Height="32" Offset="0xB3C0" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_00BBC0" OutName="object_po_sistersTex_00BBC0" Format="rgba16" Width="32" Height="32" Offset="0xBBC0" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_00C3C0" OutName="object_po_sistersTex_00C3C0" Format="rgba16" Width="32" Height="32" Offset="0xC3C0" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_00CBC0" OutName="object_po_sistersTex_00CBC0" Format="rgba16" Width="32" Height="32" Offset="0xCBC0" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_00D3C0" OutName="object_po_sistersTex_00D3C0" Format="rgba16" Width="32" Height="32" Offset="0xD3C0" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_00DBC0" OutName="object_po_sistersTex_00DBC0" Format="rgba16" Width="32" Height="32" Offset="0xDBC0" AddedByScript="true"/>
         <Animation Name="gPoeSistersAttackAnim" Offset="0x0114"/>
         <Animation Name="gPoeSistersMegCryAnim" Offset="0x0680"/>
         <Animation Name="gPoeSistersDamagedAnim" Offset="0x08C0"/>

--- a/soh/assets/xml/GC_MQ_D/objects/object_poh.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_poh.xml
@@ -1,6 +1,17 @@
 <Root>
     
     <File Name="object_poh" Segment="6">
+        <Texture Name="object_pohTex_003010" OutName="object_pohTex_003010" Format="i8" Width="32" Height="64" Offset="0x3010" AddedByScript="true"/>
+        <Texture Name="object_pohTex_003910" OutName="object_pohTex_003910" Format="rgba16" Width="32" Height="16" Offset="0x3910" AddedByScript="true"/>
+        <Texture Name="object_pohTex_003D10" OutName="object_pohTex_003D10" Format="rgba16" Width="32" Height="32" Offset="0x3D10" AddedByScript="true"/>
+        <Texture Name="object_pohTex_004510" OutName="object_pohTex_004510" Format="rgba16" Width="16" Height="16" Offset="0x4510" AddedByScript="true"/>
+        <Texture Name="object_pohTex_004710" OutName="object_pohTex_004710" Format="rgba16" Width="8" Height="8" Offset="0x4710" AddedByScript="true"/>
+        <Texture Name="object_pohTex_004790" OutName="object_pohTex_004790" Format="rgba16" Width="16" Height="16" Offset="0x4790" AddedByScript="true"/>
+        <Texture Name="object_pohTex_004990" OutName="object_pohTex_004990" Format="rgba16" Width="8" Height="8" Offset="0x4990" AddedByScript="true"/>
+        <Texture Name="object_pohTex_004A10" OutName="object_pohTex_004A10" Format="rgba16" Width="8" Height="16" Offset="0x4A10" AddedByScript="true"/>
+        <Texture Name="object_pohTex_004B10" OutName="object_pohTex_004B10" Format="rgba16" Width="16" Height="16" Offset="0x4B10" AddedByScript="true"/>
+        <Texture Name="object_pohTex_004D10" OutName="object_pohTex_004D10" Format="rgba16" Width="16" Height="16" Offset="0x4D10" AddedByScript="true"/>
+        <Texture Name="object_pohTex_004F10" OutName="object_pohTex_004F10" Format="rgba16" Width="8" Height="8" Offset="0x4F10" AddedByScript="true"/>
         <Animation Name="gPoeAttackAnim" Offset="0x01A8"/>
         <Animation Name="gPoeDamagedAnim" Offset="0x04EC"/>
         <Animation Name="gPoeFleeAnim" Offset="0x06E0"/>

--- a/soh/assets/xml/GC_MQ_D/objects/object_ps.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_ps.xml
@@ -1,6 +1,29 @@
 <Root>
     
     <File Name="object_ps" Segment="6">
+        <Texture Name="object_psTex_0005B8" OutName="object_psTex_0005B8" Format="rgba16" Width="32" Height="64" Offset="0x5B8" AddedByScript="true"/>
+        <Texture Name="object_psTex_0015B8" OutName="object_psTex_0015B8" Format="ci8" Width="8" Height="8" Offset="0x15B8" TlutOffset="0x4B0" AddedByScript="true"/>
+        <Texture Name="object_psTex_0015F8" OutName="object_psTex_0015F8" Format="rgba16" Width="16" Height="16" Offset="0x15F8" AddedByScript="true"/>
+        <Texture Name="object_psTex_0017F8" OutName="object_psTex_0017F8" Format="ci8" Width="8" Height="8" Offset="0x17F8" TlutOffset="0x4B0" AddedByScript="true"/>
+        <Texture Name="object_psTex_001838" OutName="object_psTex_001838" Format="ci8" Width="32" Height="32" Offset="0x1838" TlutOffset="0x4B0" AddedByScript="true"/>
+        <Texture Name="object_psTex_001C38" OutName="object_psTex_001C38" Format="ci8" Width="16" Height="16" Offset="0x1C38" TlutOffset="0x4B0" AddedByScript="true"/>
+        <Texture Name="object_psTex_001D38" OutName="object_psTex_001D38" Format="i8" Width="8" Height="8" Offset="0x1D38" AddedByScript="true"/>
+        <Texture Name="object_psTex_001D78" OutName="object_psTex_001D78" Format="ci8" Width="16" Height="16" Offset="0x1D78" TlutOffset="0x4B0" AddedByScript="true"/>
+        <Texture Name="object_psTex_001E78" OutName="object_psTex_001E78" Format="ci8" Width="16" Height="16" Offset="0x1E78" TlutOffset="0x4B0" AddedByScript="true"/>
+        <Texture Name="object_psTex_001F78" OutName="object_psTex_001F78" Format="rgba16" Width="16" Height="16" Offset="0x1F78" AddedByScript="true"/>
+        <Texture Name="object_psTex_002178" OutName="object_psTex_002178" Format="rgba16" Width="16" Height="16" Offset="0x2178" AddedByScript="true"/>
+        <Texture Name="object_psTex_002378" OutName="object_psTex_002378" Format="i4" Width="32" Height="32" Offset="0x2378" AddedByScript="true"/>
+        <Texture Name="object_psTex_002578" OutName="object_psTex_002578" Format="ci8" Width="32" Height="32" Offset="0x2578" TlutOffset="0x4B0" AddedByScript="true"/>
+        <Texture Name="object_psTex_002978" OutName="object_psTex_002978" Format="rgba16" Width="8" Height="16" Offset="0x2978" AddedByScript="true"/>
+        <Texture Name="object_psTex_007180" OutName="object_psTex_007180" Format="ci8" Width="8" Height="8" Offset="0x7180" TlutOffset="0x5880" AddedByScript="true"/>
+        <Texture Name="object_psTex_0071C0" OutName="object_psTex_0071C0" Format="ci8" Width="32" Height="32" Offset="0x71C0" TlutOffset="0x5880" AddedByScript="true"/>
+        <Texture Name="object_psTex_0075C0" OutName="object_psTex_0075C0" Format="ci8" Width="8" Height="8" Offset="0x75C0" TlutOffset="0x5880" AddedByScript="true"/>
+        <Texture Name="object_psTex_007600" OutName="object_psTex_007600" Format="ci8" Width="8" Height="8" Offset="0x7600" TlutOffset="0x5880" AddedByScript="true"/>
+        <Texture Name="object_psTex_007640" OutName="object_psTex_007640" Format="ci8" Width="32" Height="32" Offset="0x7640" TlutOffset="0x5880" AddedByScript="true"/>
+        <Texture Name="object_psTex_007A40" OutName="object_psTex_007A40" Format="rgba16" Width="16" Height="16" Offset="0x7A40" AddedByScript="true"/>
+        <Texture Name="object_psTex_007C40" OutName="object_psTex_007C40" Format="ci8" Width="32" Height="32" Offset="0x7C40" TlutOffset="0x5880" AddedByScript="true"/>
+        <Texture Name="object_psTLUT_0004B0" OutName="object_psTLUT_0004B0" Format="rgba16" Width="16" Height="16" Offset="0x4B0" AddedByScript="true"/>
+        <Texture Name="object_psTLUT_005880" OutName="object_psTLUT_005880" Format="rgba16" Width="16" Height="16" Offset="0x5880" AddedByScript="true"/>
         <Animation Name="gPoeSellerIdleAnim" Offset="0x049C"/>
         <Texture Name="gPoeSellerMetalFrameTex" OutName="poe_seller_metal_frame" Format="rgba16" Width="8" Height="8" Offset="0x5A80"/>
         <Texture Name="gPoeSellerMattressTex" OutName="poe_seller_mattress" Format="rgba16" Width="8" Height="8" Offset="0x5B00"/>

--- a/soh/assets/xml/GC_MQ_D/objects/object_rl.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_rl.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_rl" Segment="6">
+        <Texture Name="object_rlTex_0033E0" OutName="object_rlTex_0033E0" Format="ci8" Width="8" Height="8" Offset="0x33E0" TlutOffset="0x32A0" AddedByScript="true"/>
+        <Texture Name="object_rlTex_003420" OutName="object_rlTex_003420" Format="ci8" Width="16" Height="16" Offset="0x3420" TlutOffset="0x32A0" AddedByScript="true"/>
         <Animation Name="object_rl_Anim_00040C" Offset="0x40C"/>
         <Animation Name="object_rl_Anim_000830" Offset="0x830"/>
         <Animation Name="object_rl_Anim_000A3C" Offset="0xA3C"/>

--- a/soh/assets/xml/GC_MQ_D/objects/object_ru2.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_ru2.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_ru2" Segment="6">
+        <Texture Name="object_ru2Tex_0055C0" OutName="object_ru2Tex_0055C0" Format="ci8" Width="8" Height="32" Offset="0x55C0" TlutOffset="0x43C0" AddedByScript="true"/>
+        <Texture Name="object_ru2Tex_0056C0" OutName="object_ru2Tex_0056C0" Format="rgba16" Width="32" Height="32" Offset="0x56C0" AddedByScript="true"/>
         <!-- Adult Ruto Skeleton -->
         <Skeleton Name="gAdultRutoSkel" Type="Flex" LimbType="Standard" Offset="0xC700"/>
 

--- a/soh/assets/xml/GC_MQ_D/objects/object_sa.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_sa.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_sa" Segment="6">
+        <Texture Name="object_saTex_002530" OutName="object_saTex_002530" Format="ci8" Width="8" Height="8" Offset="0x2530" TlutOffset="0x21F0" AddedByScript="true"/>
         <Skeleton Name="gSariaSkel" Type="Flex" LimbType="Standard" Offset="0xB1A0"/>
 
         <Limb Name="gSariaRootLimb" LimbType="Standard" Offset="0xB0A0"/>

--- a/soh/assets/xml/GC_MQ_D/objects/object_skj.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_skj.xml
@@ -1,5 +1,13 @@
 <Root>
     <File Name="object_skj" Segment="6">
+        <Texture Name="object_skjTex_005300" OutName="object_skjTex_005300" Format="rgba16" Width="16" Height="16" Offset="0x5300" AddedByScript="true"/>
+        <Texture Name="object_skjTex_005500" OutName="object_skjTex_005500" Format="rgba16" Width="16" Height="16" Offset="0x5500" AddedByScript="true"/>
+        <Texture Name="object_skjTex_005700" OutName="object_skjTex_005700" Format="rgba16" Width="16" Height="16" Offset="0x5700" AddedByScript="true"/>
+        <Texture Name="object_skjTex_005900" OutName="object_skjTex_005900" Format="rgba16" Width="16" Height="16" Offset="0x5900" AddedByScript="true"/>
+        <Texture Name="object_skjTex_005B00" OutName="object_skjTex_005B00" Format="rgba16" Width="8" Height="8" Offset="0x5B00" AddedByScript="true"/>
+        <Texture Name="object_skjTex_005B80" OutName="object_skjTex_005B80" Format="rgba16" Width="16" Height="16" Offset="0x5B80" AddedByScript="true"/>
+        <Texture Name="object_skjTex_005D80" OutName="object_skjTex_005D80" Format="rgba16" Width="4" Height="4" Offset="0x5D80" AddedByScript="true"/>
+        <Texture Name="object_skjTex_005DA0" OutName="object_skjTex_005DA0" Format="ia16" Width="8" Height="8" Offset="0x5DA0" AddedByScript="true"/>
         <DList Name="gSkullKidNeedleDL" Offset="0x0EB0"/>
         <DList Name="gSkullKidSkullMaskDL" Offset="0x14C8"/>
 

--- a/soh/assets/xml/GC_MQ_D/objects/object_spot09_obj.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_spot09_obj.xml
@@ -1,5 +1,26 @@
 <Root>
     <File Name="object_spot09_obj" Segment="6">
+        <Texture Name="object_spot09_objTex_008490" OutName="object_spot09_objTex_008490" Format="rgba16" Width="32" Height="32" Offset="0x8490" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_008C90" OutName="object_spot09_objTex_008C90" Format="rgba16" Width="32" Height="32" Offset="0x8C90" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_009490" OutName="object_spot09_objTex_009490" Format="rgba16" Width="64" Height="32" Offset="0x9490" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_00A490" OutName="object_spot09_objTex_00A490" Format="rgba16" Width="32" Height="32" Offset="0xA490" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_00AC90" OutName="object_spot09_objTex_00AC90" Format="rgba16" Width="32" Height="32" Offset="0xAC90" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_00B490" OutName="object_spot09_objTex_00B490" Format="rgba16" Width="32" Height="32" Offset="0xB490" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_00BC90" OutName="object_spot09_objTex_00BC90" Format="rgba16" Width="32" Height="64" Offset="0xBC90" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_00CC90" OutName="object_spot09_objTex_00CC90" Format="rgba16" Width="64" Height="32" Offset="0xCC90" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_00DC90" OutName="object_spot09_objTex_00DC90" Format="rgba16" Width="32" Height="64" Offset="0xDC90" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_00EC90" OutName="object_spot09_objTex_00EC90" Format="rgba16" Width="64" Height="32" Offset="0xEC90" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_00FC90" OutName="object_spot09_objTex_00FC90" Format="rgba16" Width="16" Height="32" Offset="0xFC90" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_010090" OutName="object_spot09_objTex_010090" Format="rgba16" Width="64" Height="32" Offset="0x10090" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_011090" OutName="object_spot09_objTex_011090" Format="rgba16" Width="32" Height="64" Offset="0x11090" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_012090" OutName="object_spot09_objTex_012090" Format="rgba16" Width="64" Height="32" Offset="0x12090" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_013090" OutName="object_spot09_objTex_013090" Format="rgba16" Width="64" Height="32" Offset="0x13090" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_014090" OutName="object_spot09_objTex_014090" Format="rgba16" Width="64" Height="32" Offset="0x14090" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_015090" OutName="object_spot09_objTex_015090" Format="rgba16" Width="32" Height="64" Offset="0x15090" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_016090" OutName="object_spot09_objTex_016090" Format="rgba16" Width="32" Height="64" Offset="0x16090" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_017090" OutName="object_spot09_objTex_017090" Format="i8" Width="32" Height="32" Offset="0x17090" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_017490" OutName="object_spot09_objTex_017490" Format="i8" Width="32" Height="32" Offset="0x17490" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_017890" OutName="object_spot09_objTex_017890" Format="i4" Width="128" Height="64" Offset="0x17890" AddedByScript="true"/>
         <DList Name="gValleyBridgeSidesDL" Offset="0x100"/>
         <DList Name="gValleyBrokenBridgeDL" Offset="0x3970"/>
         <DList Name="gValleyBridgeChildDL" Offset="0x1120"/>

--- a/soh/assets/xml/GC_MQ_D/objects/object_sst.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_sst.xml
@@ -1,6 +1,22 @@
 <Root>
     
     <File Name="object_sst" Segment="6">
+        <Texture Name="object_sstTex_017FE0" OutName="object_sstTex_017FE0" Format="rgba16" Width="32" Height="64" Offset="0x17FE0" AddedByScript="true"/>
+        <Texture Name="object_sstTex_019530" OutName="object_sstTex_019530" Format="rgba16" Width="4" Height="8" Offset="0x19530" AddedByScript="true"/>
+        <Texture Name="object_sstTex_019570" OutName="object_sstTex_019570" Format="rgba16" Width="8" Height="16" Offset="0x19570" AddedByScript="true"/>
+        <Texture Name="object_sstTex_019670" OutName="object_sstTex_019670" Format="rgba16" Width="8" Height="16" Offset="0x19670" AddedByScript="true"/>
+        <Texture Name="object_sstTex_019770" OutName="object_sstTex_019770" Format="rgba16" Width="4" Height="8" Offset="0x19770" AddedByScript="true"/>
+        <Texture Name="object_sstTex_0197B0" OutName="object_sstTex_0197B0" Format="rgba16" Width="16" Height="16" Offset="0x197B0" AddedByScript="true"/>
+        <Texture Name="object_sstTex_0199B0" OutName="object_sstTex_0199B0" Format="rgba16" Width="8" Height="16" Offset="0x199B0" AddedByScript="true"/>
+        <Texture Name="object_sstTex_019AB0" OutName="object_sstTex_019AB0" Format="rgba16" Width="8" Height="16" Offset="0x19AB0" AddedByScript="true"/>
+        <Texture Name="object_sstTex_019BB0" OutName="object_sstTex_019BB0" Format="rgba16" Width="16" Height="32" Offset="0x19BB0" AddedByScript="true"/>
+        <Texture Name="object_sstTex_019FB0" OutName="object_sstTex_019FB0" Format="rgba16" Width="8" Height="16" Offset="0x19FB0" AddedByScript="true"/>
+        <Texture Name="object_sstTex_01A0B0" OutName="object_sstTex_01A0B0" Format="rgba16" Width="8" Height="16" Offset="0x1A0B0" AddedByScript="true"/>
+        <Texture Name="object_sstTex_01A1B0" OutName="object_sstTex_01A1B0" Format="rgba16" Width="8" Height="32" Offset="0x1A1B0" AddedByScript="true"/>
+        <Texture Name="object_sstTex_01A3B0" OutName="object_sstTex_01A3B0" Format="rgba16" Width="16" Height="16" Offset="0x1A3B0" AddedByScript="true"/>
+        <Texture Name="object_sstTex_01A5B0" OutName="object_sstTex_01A5B0" Format="rgba16" Width="8" Height="16" Offset="0x1A5B0" AddedByScript="true"/>
+        <Texture Name="object_sstTex_01A730" OutName="object_sstTex_01A730" Format="rgba16" Width="4" Height="16" Offset="0x1A730" AddedByScript="true"/>
+        <Texture Name="object_sstTex_01A7B0" OutName="object_sstTex_01A7B0" Format="rgba16" Width="16" Height="16" Offset="0x1A7B0" AddedByScript="true"/>
         <!-- Boss Title Card -->
         <Texture Name="gBongoTitleCardTex" OutName="bongo_title_card" Format="i8" Width="128" Height="120" Offset="0x13D80"/>
 

--- a/soh/assets/xml/GC_MQ_D/objects/object_tk.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_tk.xml
@@ -1,5 +1,22 @@
 <Root>
     <File Name="object_tk" Segment="6">
+        <Texture Name="object_tkTex_003980" OutName="object_tkTex_003980" Format="ci8" Width="8" Height="8" Offset="0x3980" TlutOffset="0x3780" AddedByScript="true"/>
+        <Texture Name="object_tkTex_0039C0" OutName="object_tkTex_0039C0" Format="ci8" Width="8" Height="8" Offset="0x39C0" TlutOffset="0x3780" AddedByScript="true"/>
+        <Texture Name="object_tkTex_003A00" OutName="object_tkTex_003A00" Format="ci8" Width="8" Height="8" Offset="0x3A00" TlutOffset="0x3780" AddedByScript="true"/>
+        <Texture Name="object_tkTex_003A40" OutName="object_tkTex_003A40" Format="ci8" Width="16" Height="16" Offset="0x3A40" TlutOffset="0x3780" AddedByScript="true"/>
+        <Texture Name="object_tkTex_005340" OutName="object_tkTex_005340" Format="ci8" Width="16" Height="16" Offset="0x5340" TlutOffset="0x3780" AddedByScript="true"/>
+        <Texture Name="object_tkTex_005440" OutName="object_tkTex_005440" Format="ci8" Width="16" Height="16" Offset="0x5440" TlutOffset="0x3780" AddedByScript="true"/>
+        <Texture Name="object_tkTex_0056C0" OutName="object_tkTex_0056C0" Format="ci8" Width="16" Height="16" Offset="0x56C0" TlutOffset="0x3780" AddedByScript="true"/>
+        <Texture Name="object_tkTex_009B00" OutName="object_tkTex_009B00" Format="ci8" Width="16" Height="16" Offset="0x9B00" TlutOffset="0x9AB0" AddedByScript="true"/>
+        <Texture Name="object_tkTex_009C00" OutName="object_tkTex_009C00" Format="ci8" Width="8" Height="16" Offset="0x9C00" TlutOffset="0x9AB0" AddedByScript="true"/>
+        <Texture Name="object_tkTex_009C80" OutName="object_tkTex_009C80" Format="i8" Width="8" Height="8" Offset="0x9C80" AddedByScript="true"/>
+        <Texture Name="object_tkTex_009CC0" OutName="object_tkTex_009CC0" Format="rgba16" Width="8" Height="8" Offset="0x9CC0" AddedByScript="true"/>
+        <Texture Name="object_tkTex_009D40" OutName="object_tkTex_009D40" Format="i4" Width="16" Height="32" Offset="0x9D40" AddedByScript="true"/>
+        <Texture Name="object_tkTex_00B088" OutName="object_tkTex_00B088" Format="rgba16" Width="16" Height="16" Offset="0xB088" AddedByScript="true"/>
+        <Texture Name="object_tkTex_00B288" OutName="object_tkTex_00B288" Format="rgba16" Width="16" Height="16" Offset="0xB288" AddedByScript="true"/>
+        <Texture Name="object_tkTex_00B488" OutName="object_tkTex_00B488" Format="rgba16" Width="16" Height="16" Offset="0xB488" AddedByScript="true"/>
+        <Texture Name="object_tkTLUT_003780" OutName="object_tkTLUT_003780" Format="rgba16" Width="16" Height="16" Offset="0x3780" AddedByScript="true"/>
+        <Texture Name="object_tkTLUT_009AB0" OutName="object_tkTLUT_009AB0" Format="rgba16" Width="16" Height="16" Offset="0x9AB0" AddedByScript="true"/>
         <Animation Name="gDampeDigAnim" Offset="0x1144"/>
         <Animation Name="gDampeWalkAnim" Offset="0x1FA8"/>
         <Animation Name="gDampeRestAnim" Offset="0x2F84"/>

--- a/soh/assets/xml/GC_MQ_D/objects/object_torch2.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_torch2.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_torch2" Segment="6">
+        <Texture Name="object_torch2Tex_0041C0" OutName="object_torch2Tex_0041C0" Format="rgba16" Width="16" Height="16" Offset="0x41C0" AddedByScript="true"/>
+        <Texture Name="object_torch2Tex_0043C0" OutName="object_torch2Tex_0043C0" Format="ia16" Width="16" Height="16" Offset="0x43C0" AddedByScript="true"/>
         <!-- Dark Link's skeleton -->
         <Skeleton Name="gDarkLinkSkel" Type="Flex" LimbType="LOD" Offset="0x4764"/>
 

--- a/soh/assets/xml/GC_MQ_D/objects/object_xc.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_xc.xml
@@ -1,5 +1,32 @@
 <Root>
     <File Name="object_xc" Segment="6">
+        <Texture Name="object_xcTex_004C40" OutName="object_xcTex_004C40" Format="ci8" Width="8" Height="8" Offset="0x4C40" TlutOffset="0x4840" AddedByScript="true"/>
+        <Texture Name="object_xcTex_004C80" OutName="object_xcTex_004C80" Format="ci8" Width="8" Height="8" Offset="0x4C80" TlutOffset="0x4840" AddedByScript="true"/>
+        <Texture Name="object_xcTex_005CC0" OutName="object_xcTex_005CC0" Format="ci8" Width="32" Height="32" Offset="0x5CC0" TlutOffset="0x4A40" AddedByScript="true"/>
+        <Texture Name="object_xcTex_0060C0" OutName="object_xcTex_0060C0" Format="ci8" Width="32" Height="32" Offset="0x60C0" TlutOffset="0x4840" AddedByScript="true"/>
+        <Texture Name="object_xcTex_0064C0" OutName="object_xcTex_0064C0" Format="rgba16" Width="32" Height="32" Offset="0x64C0" AddedByScript="true"/>
+        <Texture Name="object_xcTex_006CC0" OutName="object_xcTex_006CC0" Format="ci8" Width="8" Height="16" Offset="0x6CC0" TlutOffset="0x4840" AddedByScript="true"/>
+        <Texture Name="object_xcTex_006D40" OutName="object_xcTex_006D40" Format="ci8" Width="8" Height="8" Offset="0x6D40" TlutOffset="0x4840" AddedByScript="true"/>
+        <Texture Name="object_xcTex_006D80" OutName="object_xcTex_006D80" Format="ci8" Width="16" Height="16" Offset="0x6D80" TlutOffset="0x4840" AddedByScript="true"/>
+        <Texture Name="object_xcTex_006E80" OutName="object_xcTex_006E80" Format="ci8" Width="32" Height="32" Offset="0x6E80" TlutOffset="0x4A40" AddedByScript="true"/>
+        <Texture Name="object_xcTex_007280" OutName="object_xcTex_007280" Format="ci8" Width="16" Height="16" Offset="0x7280" TlutOffset="0x4840" AddedByScript="true"/>
+        <Texture Name="object_xcTex_007380" OutName="object_xcTex_007380" Format="rgba16" Width="32" Height="32" Offset="0x7380" AddedByScript="true"/>
+        <Texture Name="object_xcTex_007B80" OutName="object_xcTex_007B80" Format="ci8" Width="32" Height="64" Offset="0x7B80" TlutOffset="0x4840" AddedByScript="true"/>
+        <Texture Name="object_xcTex_008380" OutName="object_xcTex_008380" Format="ci8" Width="32" Height="64" Offset="0x8380" TlutOffset="0x4840" AddedByScript="true"/>
+        <Texture Name="object_xcTex_008B80" OutName="object_xcTex_008B80" Format="ci8" Width="16" Height="8" Offset="0x8B80" TlutOffset="0x4840" AddedByScript="true"/>
+        <Texture Name="object_xcTex_008C00" OutName="object_xcTex_008C00" Format="ci8" Width="32" Height="16" Offset="0x8C00" TlutOffset="0x4840" AddedByScript="true"/>
+        <Texture Name="object_xcTex_00F790" OutName="object_xcTex_00F790" Format="ci8" Width="8" Height="8" Offset="0xF790" TlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="object_xcTex_00F7D0" OutName="object_xcTex_00F7D0" Format="ci8" Width="32" Height="32" Offset="0xF7D0" TlutOffset="0xF720" AddedByScript="true"/>
+        <Texture Name="object_xcTex_00FBD0" OutName="object_xcTex_00FBD0" Format="ci8" Width="16" Height="16" Offset="0xFBD0" TlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="object_xcTex_00FCD0" OutName="object_xcTex_00FCD0" Format="ci8" Width="8" Height="8" Offset="0xFCD0" TlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="object_xcTex_00FD10" OutName="object_xcTex_00FD10" Format="rgba16" Width="8" Height="8" Offset="0xFD10" AddedByScript="true"/>
+        <Texture Name="object_xcTex_00FD90" OutName="object_xcTex_00FD90" Format="i8" Width="8" Height="8" Offset="0xFD90" AddedByScript="true"/>
+        <Texture Name="object_xcTex_00FDD0" OutName="object_xcTex_00FDD0" Format="rgba16" Width="16" Height="32" Offset="0xFDD0" AddedByScript="true"/>
+        <Texture Name="object_xcTex_0101D0" OutName="object_xcTex_0101D0" Format="rgba16" Width="8" Height="16" Offset="0x101D0" AddedByScript="true"/>
+        <Texture Name="object_xcTex_011930" OutName="object_xcTex_011930" Format="i8" Width="64" Height="64" Offset="0x11930" AddedByScript="true"/>
+        <Texture Name="object_xcTLUT_004840" OutName="object_xcTLUT_004840" Format="rgba16" Width="16" Height="16" Offset="0x4840" AddedByScript="true"/>
+        <Texture Name="object_xcTLUT_00F6C0" OutName="object_xcTLUT_00F6C0" Format="rgba16" Width="16" Height="16" Offset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="object_xcTLUT_00F720" OutName="object_xcTLUT_00F720" Format="rgba16" Width="16" Height="16" Offset="0xF720" AddedByScript="true"/>
         <Skeleton Name="gSheikSkel" Type="Flex" LimbType="Standard" Offset="0x12AF0"/>
         <Animation Name="gSheikPlayingHarpAnim" Offset="0xB6C"/>
         <Animation Name="gSheikShowingTriforceOnHandAnim" Offset="0x1A08"/>

--- a/soh/assets/xml/GC_MQ_D/objects/object_zl1.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_zl1.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_zl1" Segment="6">
+        <Texture Name="object_zl1Tex_00EE58" OutName="object_zl1Tex_00EE58" Format="rgba16" Width="32" Height="16" Offset="0xEE58" AddedByScript="true"/>
         <!-- Child Zelda 1 Skeleton -->
         <Skeleton Name="gChildZelda1Skel" Type="Flex" LimbType="Standard" Offset="0xF5D8"/>
 

--- a/soh/assets/xml/GC_MQ_D/objects/object_zl2.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_zl2.xml
@@ -1,5 +1,38 @@
 <Root>
     <File Name="object_zl2" Segment="6">
+        <Texture Name="object_zl2Tex_000E00" OutName="object_zl2Tex_000E00" Format="ci8" Width="16" Height="16" Offset="0xE00" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_000F00" OutName="object_zl2Tex_000F00" Format="ci8" Width="8" Height="8" Offset="0xF00" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_000F40" OutName="object_zl2Tex_000F40" Format="ci8" Width="16" Height="32" Offset="0xF40" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_001140" OutName="object_zl2Tex_001140" Format="ci8" Width="8" Height="8" Offset="0x1140" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_001180" OutName="object_zl2Tex_001180" Format="ci8" Width="16" Height="16" Offset="0x1180" TlutOffset="0x200" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_001280" OutName="object_zl2Tex_001280" Format="ci8" Width="8" Height="8" Offset="0x1280" TlutOffset="0x200" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_0012C0" OutName="object_zl2Tex_0012C0" Format="ci8" Width="16" Height="64" Offset="0x12C0" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_0016C0" OutName="object_zl2Tex_0016C0" Format="ci8" Width="32" Height="32" Offset="0x16C0" TlutOffset="0x400" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_001AC0" OutName="object_zl2Tex_001AC0" Format="ci8" Width="32" Height="16" Offset="0x1AC0" TlutOffset="0x400" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_001CC0" OutName="object_zl2Tex_001CC0" Format="ci8" Width="32" Height="64" Offset="0x1CC0" TlutOffset="0x400" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_0024C0" OutName="object_zl2Tex_0024C0" Format="ci8" Width="8" Height="8" Offset="0x24C0" TlutOffset="0x200" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_002500" OutName="object_zl2Tex_002500" Format="ci8" Width="16" Height="16" Offset="0x2500" TlutOffset="0x200" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_002600" OutName="object_zl2Tex_002600" Format="ci8" Width="32" Height="8" Offset="0x2600" TlutOffset="0x400" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_002700" OutName="object_zl2Tex_002700" Format="ci8" Width="8" Height="8" Offset="0x2700" TlutOffset="0x400" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_002740" OutName="object_zl2Tex_002740" Format="ci8" Width="8" Height="8" Offset="0x2740" TlutOffset="0x400" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_002780" OutName="object_zl2Tex_002780" Format="ci8" Width="16" Height="16" Offset="0x2780" TlutOffset="0x400" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_002880" OutName="object_zl2Tex_002880" Format="ci8" Width="8" Height="16" Offset="0x2880" TlutOffset="0x200" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_0034C8" OutName="object_zl2Tex_0034C8" Format="ci8" Width="8" Height="8" Offset="0x34C8" TlutOffset="0x2D00" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_003908" OutName="object_zl2Tex_003908" Format="ci8" Width="16" Height="16" Offset="0x3908" TlutOffset="0x2D00" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_003A08" OutName="object_zl2Tex_003A08" Format="ci8" Width="8" Height="8" Offset="0x3A08" TlutOffset="0x9490" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_003A48" OutName="object_zl2Tex_003A48" Format="ci8" Width="8" Height="16" Offset="0x3A48" TlutOffset="0x2F50" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_003AC8" OutName="object_zl2Tex_003AC8" Format="ci8" Width="16" Height="8" Offset="0x3AC8" TlutOffset="0x2F50" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_003B48" OutName="object_zl2Tex_003B48" Format="ci8" Width="16" Height="16" Offset="0x3B48" TlutOffset="0x2F50" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_004448" OutName="object_zl2Tex_004448" Format="ci8" Width="16" Height="16" Offset="0x4448" TlutOffset="0x2F50" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_006548" OutName="object_zl2Tex_006548" Format="ci8" Width="32" Height="16" Offset="0x6548" TlutOffset="0x2F50" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_009738" OutName="object_zl2Tex_009738" Format="ci8" Width="16" Height="32" Offset="0x9738" TlutOffset="0x95A0" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_009938" OutName="object_zl2Tex_009938" Format="ci8" Width="16" Height="16" Offset="0x9938" TlutOffset="0x9490" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_009A38" OutName="object_zl2Tex_009A38" Format="ci8" Width="8" Height="8" Offset="0x9A38" TlutOffset="0x9490" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_009A78" OutName="object_zl2Tex_009A78" Format="ci8" Width="32" Height="32" Offset="0x9A78" TlutOffset="0x9490" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_009E78" OutName="object_zl2Tex_009E78" Format="ci8" Width="16" Height="16" Offset="0x9E78" TlutOffset="0x95A0" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_009F78" OutName="object_zl2Tex_009F78" Format="ci8" Width="8" Height="16" Offset="0x9F78" TlutOffset="0x95A0" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_009FF8" OutName="object_zl2Tex_009FF8" Format="ci8" Width="16" Height="16" Offset="0x9FF8" TlutOffset="0x9708" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_00A0F8" OutName="object_zl2Tex_00A0F8" Format="ci8" Width="32" Height="32" Offset="0xA0F8" TlutOffset="0x9708" AddedByScript="true"/>
         <!-- Zelda 2 skeleton -->
         <Skeleton Name="gZelda2Skel" Type="Flex" LimbType="Standard" Offset="0x10D70"/>
 
@@ -19,9 +52,9 @@
 
         <!-- Zelda 2 mouth textures -->
         <Texture Name="gZelda2MouthTLUT" OutName="zelda_2_mouth_tlut" Format="rgba16" Width="16" Height="14" Offset="0x2D90"/>
-        <Texture Name="gZelda2MouthSeriousTex" OutName="zelda_2_mouth_serious" Format="ci8" Width="32" Height="32"  Offset="0x3508" TlutOffset="0x2D90"/>
-        <Texture Name="gZelda2MouthHappyTex" OutName="zelda_2_mouth_happy" Format="ci8" Width="32" Height="32"  Offset="0x5548" TlutOffset="0x2D90"/>
-        <Texture Name="gZelda2MouthOpenTex" OutName="zelda_2_mouth_open" Format="ci8" Width="32" Height="32"  Offset="0x5948" TlutOffset="0x2D90"/>
+        <Texture Name="gZelda2MouthSeriousTex" OutName="zelda_2_mouth_serious" Format="ci8" Width="32" Height="32" Offset="0x3508" TlutOffset="0x2D90"/>
+        <Texture Name="gZelda2MouthHappyTex" OutName="zelda_2_mouth_happy" Format="ci8" Width="32" Height="32" Offset="0x5548" TlutOffset="0x2D90"/>
+        <Texture Name="gZelda2MouthOpenTex" OutName="zelda_2_mouth_open" Format="ci8" Width="32" Height="32" Offset="0x5948" TlutOffset="0x2D90"/>
 
         <!-- Ocarina of time -->
         <DList Name="gZelda2OcarinaDL" Offset="0xBAE8"/>

--- a/soh/assets/xml/GC_MQ_D/objects/object_zl4.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_zl4.xml
@@ -1,5 +1,36 @@
 <Root>
     <File Name="object_zl4" Segment="6">
+        <Texture Name="object_zl4Tex_000C70" OutName="object_zl4Tex_000C70" Format="ci8" Width="8" Height="8" Offset="0xC70" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_000CB0" OutName="object_zl4Tex_000CB0" Format="ci8" Width="16" Height="16" Offset="0xCB0" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_000DB0" OutName="object_zl4Tex_000DB0" Format="ci8" Width="32" Height="64" Offset="0xDB0" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_0015B0" OutName="object_zl4Tex_0015B0" Format="rgba16" Width="8" Height="8" Offset="0x15B0" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_001630" OutName="object_zl4Tex_001630" Format="rgba16" Width="8" Height="8" Offset="0x1630" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_0016B0" OutName="object_zl4Tex_0016B0" Format="ci8" Width="32" Height="8" Offset="0x16B0" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_0017B0" OutName="object_zl4Tex_0017B0" Format="ci8" Width="8" Height="8" Offset="0x17B0" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_0017F0" OutName="object_zl4Tex_0017F0" Format="ci8" Width="32" Height="32" Offset="0x17F0" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_001BF0" OutName="object_zl4Tex_001BF0" Format="rgba16" Width="8" Height="16" Offset="0x1BF0" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_001CF0" OutName="object_zl4Tex_001CF0" Format="ci8" Width="16" Height="16" Offset="0x1CF0" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_001DF0" OutName="object_zl4Tex_001DF0" Format="ci8" Width="8" Height="8" Offset="0x1DF0" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_001E30" OutName="object_zl4Tex_001E30" Format="rgba16" Width="16" Height="32" Offset="0x1E30" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_002230" OutName="object_zl4Tex_002230" Format="ci8" Width="8" Height="8" Offset="0x2230" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_002270" OutName="object_zl4Tex_002270" Format="ci8" Width="8" Height="16" Offset="0x2270" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_0022F0" OutName="object_zl4Tex_0022F0" Format="ci8" Width="16" Height="32" Offset="0x22F0" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_0024F0" OutName="object_zl4Tex_0024F0" Format="rgba16" Width="16" Height="16" Offset="0x24F0" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_0026F0" OutName="object_zl4Tex_0026F0" Format="rgba16" Width="16" Height="16" Offset="0x26F0" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_0028F0" OutName="object_zl4Tex_0028F0" Format="rgba16" Width="8" Height="8" Offset="0x28F0" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_002970" OutName="object_zl4Tex_002970" Format="rgba16" Width="8" Height="8" Offset="0x2970" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_0029F0" OutName="object_zl4Tex_0029F0" Format="rgba16" Width="16" Height="8" Offset="0x29F0" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_0056F0" OutName="object_zl4Tex_0056F0" Format="rgba16" Width="16" Height="16" Offset="0x56F0" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_0058F0" OutName="object_zl4Tex_0058F0" Format="ci8" Width="16" Height="16" Offset="0x58F0" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_0059F0" OutName="object_zl4Tex_0059F0" Format="rgba16" Width="8" Height="8" Offset="0x59F0" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_005A70" OutName="object_zl4Tex_005A70" Format="rgba16" Width="16" Height="16" Offset="0x5A70" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_005C70" OutName="object_zl4Tex_005C70" Format="ci8" Width="8" Height="8" Offset="0x5C70" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_005CB0" OutName="object_zl4Tex_005CB0" Format="ci8" Width="16" Height="16" Offset="0x5CB0" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_005DB0" OutName="object_zl4Tex_005DB0" Format="rgba16" Width="32" Height="32" Offset="0x5DB0" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_00D8B8" OutName="object_zl4Tex_00D8B8" Format="rgba16" Width="32" Height="16" Offset="0xD8B8" AddedByScript="true"/>
+        <Texture Name="object_zl4TLUT_000670" OutName="object_zl4TLUT_000670" Format="rgba16" Width="16" Height="16" Offset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4TLUT_000870" OutName="object_zl4TLUT_000870" Format="rgba16" Width="16" Height="16" Offset="0x870" AddedByScript="true"/>
+        <Texture Name="object_zl4TLUT_000A70" OutName="object_zl4TLUT_000A70" Format="rgba16" Width="16" Height="16" Offset="0xA70" AddedByScript="true"/>
         <!-- Child Zelda's skeleton -->
         <Skeleton Name="gChildZeldaSkel" Type="Flex" LimbType="Standard" Offset="0xE038"/>
 

--- a/soh/assets/xml/GC_MQ_D/overlays/ovl_Boss_Ganon.xml
+++ b/soh/assets/xml/GC_MQ_D/overlays/ovl_Boss_Ganon.xml
@@ -1,6 +1,22 @@
 <Root>
     
     <File Name="ovl_Boss_Ganon" BaseAddress="0x808D6870" RangeStart="0xE6B8" RangeEnd="0x211D8">
+        <Texture Name="ovl_Boss_GanonTex_00E748" OutName="ovl_Boss_GanonTex_00E748" Format="i8" Width="64" Height="64" Offset="0xE748" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_00F848" OutName="ovl_Boss_GanonTex_00F848" Format="ci8" Width="32" Height="32" Offset="0xF848" TlutOffset="0xF808" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_010538" OutName="ovl_Boss_GanonTex_010538" Format="i8" Width="64" Height="64" Offset="0x10538" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_01A7B0" OutName="ovl_Boss_GanonTex_01A7B0" Format="ia16" Width="32" Height="32" Offset="0x1A7B0" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_01AFB0" OutName="ovl_Boss_GanonTex_01AFB0" Format="i4" Width="64" Height="64" Offset="0x1AFB0" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_01B7B0" OutName="ovl_Boss_GanonTex_01B7B0" Format="i4" Width="64" Height="64" Offset="0x1B7B0" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_01C420" OutName="ovl_Boss_GanonTex_01C420" Format="i8" Width="64" Height="32" Offset="0x1C420" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_01CEB8" OutName="ovl_Boss_GanonTex_01CEB8" Format="i8" Width="32" Height="64" Offset="0x1CEB8" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_01D6B8" OutName="ovl_Boss_GanonTex_01D6B8" Format="i8" Width="32" Height="32" Offset="0x1D6B8" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_01DE88" OutName="ovl_Boss_GanonTex_01DE88" Format="i8" Width="32" Height="64" Offset="0x1DE88" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_01E688" OutName="ovl_Boss_GanonTex_01E688" Format="i8" Width="32" Height="64" Offset="0x1E688" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_01EF90" OutName="ovl_Boss_GanonTex_01EF90" Format="i8" Width="96" Height="16" Offset="0x1EF90" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_01FFF8" OutName="ovl_Boss_GanonTex_01FFF8" Format="i4" Width="32" Height="32" Offset="0x1FFF8" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_020370" OutName="ovl_Boss_GanonTex_020370" Format="i8" Width="32" Height="32" Offset="0x20370" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_020770" OutName="ovl_Boss_GanonTex_020770" Format="i8" Width="32" Height="64" Offset="0x20770" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTLUT_00F808" OutName="ovl_Boss_GanonTLUT_00F808" Format="rgba16" Width="16" Height="16" Offset="0xF808" AddedByScript="true"/>
         <Texture Name="gGanondorfLightning1Tex" OutName="lightning_1" Format="i8" Width="32" Height="96" Offset="0x11600" Static="Off"/>
         <Texture Name="gGanondorfLightning2Tex" OutName="lightning_2" Format="i8" Width="32" Height="96" Offset="0x12200" Static="Off"/>
         <Texture Name="gGanondorfLightning3Tex" OutName="lightning_3" Format="i8" Width="32" Height="96" Offset="0x12E00" Static="Off"/>

--- a/soh/assets/xml/GC_MQ_D/overlays/ovl_Boss_Sst.xml
+++ b/soh/assets/xml/GC_MQ_D/overlays/ovl_Boss_Sst.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="ovl_Boss_Sst" BaseAddress="0x8092C5D0" RangeStart="0xA3C0" RangeEnd="0xAD70">
+        <Texture Name="ovl_Boss_SstTex_00A438" OutName="ovl_Boss_SstTex_00A438" Format="i8" Width="16" Height="64" Offset="0xA438" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_SstTex_00A8F0" OutName="ovl_Boss_SstTex_00A8F0" Format="i8" Width="32" Height="32" Offset="0xA8F0" AddedByScript="true"/>
         <DList Name="sBodyStaticDList" Offset="0xA3C0"/>
         <DList Name="sHandTrailDList" Offset="0xA3D8"/>
         <DList Name="sIntroVanishDList" Offset="0xA838"/>

--- a/soh/assets/xml/GC_MQ_D/overlays/ovl_Demo_Shd.xml
+++ b/soh/assets/xml/GC_MQ_D/overlays/ovl_Demo_Shd.xml
@@ -1,7 +1,9 @@
 <Root>
     <File Name="ovl_Demo_Shd" BaseAddress="0x80991230" RangeStart="0x450" RangeEnd="0x23D0">
 
-    <DList Name="D_809932D0" Offset="0x20A0"/>
+    <Texture Name="ovl_Demo_ShdTex_000450" OutName="ovl_Demo_ShdTex_000450" Format="i8" Width="16" Height="128" Offset="0x450" AddedByScript="true"/>
+        <Texture Name="ovl_Demo_ShdTex_000C50" OutName="ovl_Demo_ShdTex_000C50" Format="i8" Width="32" Height="64" Offset="0xC50" AddedByScript="true"/>
+        <DList Name="D_809932D0" Offset="0x20A0"/>
     <DList Name="D_80993390" Offset="0x2160"/>
     <DList Name="D_809934B8" Offset="0x2288"/>
     </File>

--- a/soh/assets/xml/GC_MQ_D/overlays/ovl_En_Clear_Tag.xml
+++ b/soh/assets/xml/GC_MQ_D/overlays/ovl_En_Clear_Tag.xml
@@ -1,5 +1,19 @@
 <Root>
     <File Name="ovl_En_Clear_Tag" BaseAddress="0x809D35B0" RangeStart="0x26F0" RangeEnd="0x89F0">
+        <Texture Name="ovl_En_Clear_TagTex_003308" OutName="ovl_En_Clear_TagTex_003308" Format="rgba16" Width="8" Height="8" Offset="0x3308" AddedByScript="true"/>
+        <Texture Name="ovl_En_Clear_TagTex_003388" OutName="ovl_En_Clear_TagTex_003388" Format="rgba16" Width="32" Height="32" Offset="0x3388" AddedByScript="true"/>
+        <Texture Name="ovl_En_Clear_TagTex_003B88" OutName="ovl_En_Clear_TagTex_003B88" Format="rgba16" Width="64" Height="32" Offset="0x3B88" AddedByScript="true"/>
+        <Texture Name="ovl_En_Clear_TagTex_004B88" OutName="ovl_En_Clear_TagTex_004B88" Format="rgba16" Width="32" Height="32" Offset="0x4B88" AddedByScript="true"/>
+        <Texture Name="ovl_En_Clear_TagTex_005388" OutName="ovl_En_Clear_TagTex_005388" Format="rgba16" Width="32" Height="32" Offset="0x5388" AddedByScript="true"/>
+        <Texture Name="ovl_En_Clear_TagTex_005B88" OutName="ovl_En_Clear_TagTex_005B88" Format="rgba16" Width="32" Height="32" Offset="0x5B88" AddedByScript="true"/>
+        <Texture Name="ovl_En_Clear_TagTex_006458" OutName="ovl_En_Clear_TagTex_006458" Format="rgba16" Width="16" Height="16" Offset="0x6458" AddedByScript="true"/>
+        <Texture Name="ovl_En_Clear_TagTex_006708" OutName="ovl_En_Clear_TagTex_006708" Format="i8" Width="16" Height="16" Offset="0x6708" AddedByScript="true"/>
+        <Texture Name="ovl_En_Clear_TagTex_006808" OutName="ovl_En_Clear_TagTex_006808" Format="rgba16" Width="16" Height="16" Offset="0x6808" AddedByScript="true"/>
+        <Texture Name="ovl_En_Clear_TagTex_006AD0" OutName="ovl_En_Clear_TagTex_006AD0" Format="i4" Width="32" Height="64" Offset="0x6AD0" AddedByScript="true"/>
+        <Texture Name="ovl_En_Clear_TagTex_006ED0" OutName="ovl_En_Clear_TagTex_006ED0" Format="i4" Width="32" Height="32" Offset="0x6ED0" AddedByScript="true"/>
+        <Texture Name="ovl_En_Clear_TagTex_0071C8" OutName="ovl_En_Clear_TagTex_0071C8" Format="i8" Width="64" Height="64" Offset="0x71C8" AddedByScript="true"/>
+        <Texture Name="ovl_En_Clear_TagTex_008288" OutName="ovl_En_Clear_TagTex_008288" Format="i4" Width="32" Height="32" Offset="0x8288" AddedByScript="true"/>
+        <Texture Name="ovl_En_Clear_TagTex_008540" OutName="ovl_En_Clear_TagTex_008540" Format="i8" Width="32" Height="32" Offset="0x8540" AddedByScript="true"/>
         <DList Name="gArwingDL" Offset="0x26F0"/>
         <DList Name="gArwingLaserDL" Offset="0x6388"/>
         <DList Name="gArwingBackfireDL" Offset="0x6688"/>

--- a/soh/assets/xml/GC_MQ_D/scenes/dungeons/Bmori1.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/dungeons/Bmori1.xml
@@ -1,76 +1,231 @@
 <Root>
     <File Name="Bmori1_scene" Segment="2">
+        <Texture Name="Bmori1_sceneTex_014490" OutName="Bmori1_sceneTex_014490" Format="ci8" Width="32" Height="8" Offset="0x14490" TlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_sceneTex_015590" OutName="Bmori1_sceneTex_015590" Format="ci8" Width="16" Height="16" Offset="0x15590" TlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_sceneTex_015690" OutName="Bmori1_sceneTex_015690" Format="ci8" Width="32" Height="32" Offset="0x15690" TlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_sceneTex_015A90" OutName="Bmori1_sceneTex_015A90" Format="ci8" Width="16" Height="16" Offset="0x15A90" TlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_sceneTex_015B90" OutName="Bmori1_sceneTex_015B90" Format="ci8" Width="32" Height="32" Offset="0x15B90" TlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_sceneTLUT_014080" OutName="Bmori1_sceneTLUT_014080" Format="rgba16" Width="16" Height="16" Offset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_sceneTLUT_014288" OutName="Bmori1_sceneTLUT_014288" Format="rgba16" Width="16" Height="16" Offset="0x14288" AddedByScript="true"/>
         <Texture Name="gForestTempleDayEntranceTex" OutName="day_entrance" Format="ia16" Width="8" Height="128" Offset="0x14D90"/>
         <Texture Name="gForestTempleNightEntranceTex" OutName="night_entrance" Format="ia16" Width="8" Height="128" Offset="0x14590"/>
         <Scene Name="Bmori1_scene" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_0" Segment="3">
+        <Texture Name="Bmori1_room_0Tex_005CF8" OutName="Bmori1_room_0Tex_005CF8" Format="ci8" Width="64" Height="32" Offset="0x5CF8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_0Tex_0064F8" OutName="Bmori1_room_0Tex_0064F8" Format="i8" Width="64" Height="64" Offset="0x64F8" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_0Tex_0074F8" OutName="Bmori1_room_0Tex_0074F8" Format="rgba16" Width="32" Height="32" Offset="0x74F8" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_0Tex_007CF8" OutName="Bmori1_room_0Tex_007CF8" Format="rgba16" Width="32" Height="32" Offset="0x7CF8" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_0Tex_0084F8" OutName="Bmori1_room_0Tex_0084F8" Format="ci8" Width="16" Height="64" Offset="0x84F8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_0Tex_0088F8" OutName="Bmori1_room_0Tex_0088F8" Format="rgba16" Width="32" Height="64" Offset="0x88F8" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_0Tex_0098F8" OutName="Bmori1_room_0Tex_0098F8" Format="ci8" Width="32" Height="64" Offset="0x98F8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_0Tex_00A0F8" OutName="Bmori1_room_0Tex_00A0F8" Format="rgba16" Width="32" Height="64" Offset="0xA0F8" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_0Tex_00B0F8" OutName="Bmori1_room_0Tex_00B0F8" Format="ci8" Width="32" Height="32" Offset="0xB0F8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_0Tex_00B4F8" OutName="Bmori1_room_0Tex_00B4F8" Format="ci8" Width="32" Height="32" Offset="0xB4F8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_0Tex_00B8F8" OutName="Bmori1_room_0Tex_00B8F8" Format="ci8" Width="64" Height="32" Offset="0xB8F8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_0Tex_00C0F8" OutName="Bmori1_room_0Tex_00C0F8" Format="ci8" Width="16" Height="32" Offset="0xC0F8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_0Tex_00C2F8" OutName="Bmori1_room_0Tex_00C2F8" Format="ci8" Width="32" Height="32" Offset="0xC2F8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_0Tex_00CB88" OutName="Bmori1_room_0Tex_00CB88" Format="rgba16" Width="32" Height="64" Offset="0xCB88" AddedByScript="true"/>
         <Room Name="Bmori1_room_0" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_1" Segment="3">
+        <Texture Name="Bmori1_room_1Tex_003368" OutName="Bmori1_room_1Tex_003368" Format="rgba16" Width="32" Height="32" Offset="0x3368" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_1Tex_003B68" OutName="Bmori1_room_1Tex_003B68" Format="ci8" Width="64" Height="32" Offset="0x3B68" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_1Tex_004368" OutName="Bmori1_room_1Tex_004368" Format="rgba16" Width="32" Height="64" Offset="0x4368" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_1Tex_005368" OutName="Bmori1_room_1Tex_005368" Format="ci8" Width="32" Height="64" Offset="0x5368" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
         <Room Name="Bmori1_room_1" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_2" Segment="3">
+        <Texture Name="Bmori1_room_2Tex_00A380" OutName="Bmori1_room_2Tex_00A380" Format="ci8" Width="64" Height="32" Offset="0xA380" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_2Tex_00AB80" OutName="Bmori1_room_2Tex_00AB80" Format="ci8" Width="16" Height="64" Offset="0xAB80" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_2Tex_00AF80" OutName="Bmori1_room_2Tex_00AF80" Format="rgba16" Width="32" Height="64" Offset="0xAF80" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_2Tex_00BF80" OutName="Bmori1_room_2Tex_00BF80" Format="rgba16" Width="32" Height="64" Offset="0xBF80" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_2Tex_00CF80" OutName="Bmori1_room_2Tex_00CF80" Format="ci8" Width="32" Height="32" Offset="0xCF80" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_2Tex_00D380" OutName="Bmori1_room_2Tex_00D380" Format="ci8" Width="64" Height="32" Offset="0xD380" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_2Tex_00DB80" OutName="Bmori1_room_2Tex_00DB80" Format="ci8" Width="16" Height="32" Offset="0xDB80" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_2Tex_00DD80" OutName="Bmori1_room_2Tex_00DD80" Format="ci8" Width="64" Height="32" Offset="0xDD80" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_2Tex_00E580" OutName="Bmori1_room_2Tex_00E580" Format="ci8" Width="32" Height="32" Offset="0xE580" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_2Tex_00E980" OutName="Bmori1_room_2Tex_00E980" Format="ci8" Width="32" Height="64" Offset="0xE980" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_2Tex_00F180" OutName="Bmori1_room_2Tex_00F180" Format="rgba16" Width="32" Height="32" Offset="0xF180" AddedByScript="true"/>
         <Room Name="Bmori1_room_2" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_3" Segment="3">
+        <Texture Name="Bmori1_room_3Tex_0023D8" OutName="Bmori1_room_3Tex_0023D8" Format="rgba16" Width="32" Height="32" Offset="0x23D8" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_3Tex_002BD8" OutName="Bmori1_room_3Tex_002BD8" Format="ci8" Width="16" Height="128" Offset="0x2BD8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_3Tex_0033D8" OutName="Bmori1_room_3Tex_0033D8" Format="ci8" Width="32" Height="32" Offset="0x33D8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_3Tex_0037D8" OutName="Bmori1_room_3Tex_0037D8" Format="rgba16" Width="8" Height="16" Offset="0x37D8" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_3Tex_0038D8" OutName="Bmori1_room_3Tex_0038D8" Format="rgba16" Width="16" Height="8" Offset="0x38D8" AddedByScript="true"/>
         <Room Name="Bmori1_room_3" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_4" Segment="3">
+        <Texture Name="Bmori1_room_4Tex_0022B8" OutName="Bmori1_room_4Tex_0022B8" Format="rgba16" Width="32" Height="32" Offset="0x22B8" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_4Tex_002AB8" OutName="Bmori1_room_4Tex_002AB8" Format="ci8" Width="64" Height="32" Offset="0x2AB8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
         <Room Name="Bmori1_room_4" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_5" Segment="3">
+        <Texture Name="Bmori1_room_5Tex_0023D0" OutName="Bmori1_room_5Tex_0023D0" Format="ci8" Width="32" Height="32" Offset="0x23D0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_5Tex_0027D0" OutName="Bmori1_room_5Tex_0027D0" Format="ci8" Width="16" Height="128" Offset="0x27D0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_5Tex_002FD0" OutName="Bmori1_room_5Tex_002FD0" Format="ci8" Width="32" Height="32" Offset="0x2FD0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_5Tex_0033D0" OutName="Bmori1_room_5Tex_0033D0" Format="rgba16" Width="8" Height="16" Offset="0x33D0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_5Tex_0034D0" OutName="Bmori1_room_5Tex_0034D0" Format="rgba16" Width="16" Height="8" Offset="0x34D0" AddedByScript="true"/>
         <Room Name="Bmori1_room_5" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_6" Segment="3">
+        <Texture Name="Bmori1_room_6Tex_006630" OutName="Bmori1_room_6Tex_006630" Format="rgba16" Width="32" Height="32" Offset="0x6630" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_6Tex_006E30" OutName="Bmori1_room_6Tex_006E30" Format="rgba16" Width="32" Height="32" Offset="0x6E30" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_6Tex_007630" OutName="Bmori1_room_6Tex_007630" Format="ci8" Width="32" Height="32" Offset="0x7630" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_6Tex_007A30" OutName="Bmori1_room_6Tex_007A30" Format="ci8" Width="64" Height="32" Offset="0x7A30" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_6Tex_008230" OutName="Bmori1_room_6Tex_008230" Format="ci8" Width="64" Height="32" Offset="0x8230" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_6Tex_008A30" OutName="Bmori1_room_6Tex_008A30" Format="ci8" Width="16" Height="32" Offset="0x8A30" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_6Tex_008C30" OutName="Bmori1_room_6Tex_008C30" Format="ci8" Width="32" Height="64" Offset="0x8C30" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
         <Room Name="Bmori1_room_6" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_7" Segment="3">
+        <Texture Name="Bmori1_room_7Tex_007DD0" OutName="Bmori1_room_7Tex_007DD0" Format="rgba16" Width="32" Height="32" Offset="0x7DD0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_0085D0" OutName="Bmori1_room_7Tex_0085D0" Format="rgba16" Width="32" Height="32" Offset="0x85D0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_008DD0" OutName="Bmori1_room_7Tex_008DD0" Format="ci8" Width="32" Height="32" Offset="0x8DD0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_0091D0" OutName="Bmori1_room_7Tex_0091D0" Format="ci8" Width="32" Height="32" Offset="0x91D0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_0095D0" OutName="Bmori1_room_7Tex_0095D0" Format="ci8" Width="32" Height="64" Offset="0x95D0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_009DD0" OutName="Bmori1_room_7Tex_009DD0" Format="ci8" Width="32" Height="64" Offset="0x9DD0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_00A5D0" OutName="Bmori1_room_7Tex_00A5D0" Format="ci8" Width="64" Height="32" Offset="0xA5D0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_00ADD0" OutName="Bmori1_room_7Tex_00ADD0" Format="rgba16" Width="32" Height="32" Offset="0xADD0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_00B5D0" OutName="Bmori1_room_7Tex_00B5D0" Format="ci8" Width="64" Height="32" Offset="0xB5D0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_00BDD0" OutName="Bmori1_room_7Tex_00BDD0" Format="rgba16" Width="32" Height="64" Offset="0xBDD0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_00CDD0" OutName="Bmori1_room_7Tex_00CDD0" Format="rgba16" Width="32" Height="64" Offset="0xCDD0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_00DDD0" OutName="Bmori1_room_7Tex_00DDD0" Format="rgba16" Width="32" Height="32" Offset="0xDDD0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_00EFD8" OutName="Bmori1_room_7Tex_00EFD8" Format="i4" Width="64" Height="128" Offset="0xEFD8" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_00FFD8" OutName="Bmori1_room_7Tex_00FFD8" Format="rgba16" Width="32" Height="64" Offset="0xFFD8" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_010FD8" OutName="Bmori1_room_7Tex_010FD8" Format="rgba16" Width="32" Height="32" Offset="0x10FD8" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_0117D8" OutName="Bmori1_room_7Tex_0117D8" Format="ia16" Width="32" Height="32" Offset="0x117D8" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_011FD8" OutName="Bmori1_room_7Tex_011FD8" Format="rgba16" Width="32" Height="64" Offset="0x11FD8" AddedByScript="true"/>
         <Room Name="Bmori1_room_7" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_8" Segment="3">
+        <Texture Name="Bmori1_room_8Tex_00AC10" OutName="Bmori1_room_8Tex_00AC10" Format="rgba16" Width="32" Height="32" Offset="0xAC10" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_00B410" OutName="Bmori1_room_8Tex_00B410" Format="rgba16" Width="32" Height="64" Offset="0xB410" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_00C410" OutName="Bmori1_room_8Tex_00C410" Format="rgba16" Width="32" Height="32" Offset="0xC410" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_00CC10" OutName="Bmori1_room_8Tex_00CC10" Format="ci8" Width="32" Height="32" Offset="0xCC10" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_00D010" OutName="Bmori1_room_8Tex_00D010" Format="ci8" Width="32" Height="32" Offset="0xD010" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_00D410" OutName="Bmori1_room_8Tex_00D410" Format="ci8" Width="32" Height="32" Offset="0xD410" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_00D810" OutName="Bmori1_room_8Tex_00D810" Format="ci8" Width="32" Height="64" Offset="0xD810" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_00E010" OutName="Bmori1_room_8Tex_00E010" Format="ci8" Width="32" Height="64" Offset="0xE010" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_00E810" OutName="Bmori1_room_8Tex_00E810" Format="ci8" Width="64" Height="32" Offset="0xE810" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_00F010" OutName="Bmori1_room_8Tex_00F010" Format="ci8" Width="64" Height="32" Offset="0xF010" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_00F810" OutName="Bmori1_room_8Tex_00F810" Format="rgba16" Width="32" Height="64" Offset="0xF810" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_010810" OutName="Bmori1_room_8Tex_010810" Format="rgba16" Width="32" Height="64" Offset="0x10810" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_011810" OutName="Bmori1_room_8Tex_011810" Format="ci8" Width="32" Height="32" Offset="0x11810" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_011C10" OutName="Bmori1_room_8Tex_011C10" Format="ci8" Width="64" Height="32" Offset="0x11C10" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_012410" OutName="Bmori1_room_8Tex_012410" Format="rgba16" Width="32" Height="32" Offset="0x12410" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_013AB0" OutName="Bmori1_room_8Tex_013AB0" Format="i4" Width="64" Height="128" Offset="0x13AB0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_014AB0" OutName="Bmori1_room_8Tex_014AB0" Format="rgba16" Width="32" Height="32" Offset="0x14AB0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_0152B0" OutName="Bmori1_room_8Tex_0152B0" Format="ia16" Width="32" Height="32" Offset="0x152B0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_015AB0" OutName="Bmori1_room_8Tex_015AB0" Format="rgba16" Width="32" Height="64" Offset="0x15AB0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_016AB0" OutName="Bmori1_room_8Tex_016AB0" Format="rgba16" Width="32" Height="64" Offset="0x16AB0" AddedByScript="true"/>
         <Room Name="Bmori1_room_8" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_9" Segment="3">
+        <Texture Name="Bmori1_room_9Tex_0048B8" OutName="Bmori1_room_9Tex_0048B8" Format="rgba16" Width="32" Height="32" Offset="0x48B8" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_9Tex_0050B8" OutName="Bmori1_room_9Tex_0050B8" Format="ci8" Width="32" Height="32" Offset="0x50B8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_9Tex_0054B8" OutName="Bmori1_room_9Tex_0054B8" Format="ci8" Width="32" Height="64" Offset="0x54B8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_9Tex_005CB8" OutName="Bmori1_room_9Tex_005CB8" Format="ci8" Width="64" Height="32" Offset="0x5CB8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_9Tex_0064B8" OutName="Bmori1_room_9Tex_0064B8" Format="rgba16" Width="32" Height="32" Offset="0x64B8" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_9Tex_006CB8" OutName="Bmori1_room_9Tex_006CB8" Format="ci8" Width="64" Height="32" Offset="0x6CB8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_9Tex_0074B8" OutName="Bmori1_room_9Tex_0074B8" Format="rgba16" Width="32" Height="64" Offset="0x74B8" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_9Tex_008958" OutName="Bmori1_room_9Tex_008958" Format="ia16" Width="32" Height="32" Offset="0x8958" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_9Tex_009158" OutName="Bmori1_room_9Tex_009158" Format="rgba16" Width="32" Height="64" Offset="0x9158" AddedByScript="true"/>
         <Room Name="Bmori1_room_9" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_10" Segment="3">
+        <Texture Name="Bmori1_room_10Tex_001260" OutName="Bmori1_room_10Tex_001260" Format="rgba16" Width="32" Height="32" Offset="0x1260" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_10Tex_001A60" OutName="Bmori1_room_10Tex_001A60" Format="ci8" Width="16" Height="128" Offset="0x1A60" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_10Tex_002260" OutName="Bmori1_room_10Tex_002260" Format="ci8" Width="64" Height="32" Offset="0x2260" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_10Tex_002A60" OutName="Bmori1_room_10Tex_002A60" Format="rgba16" Width="32" Height="64" Offset="0x2A60" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_10Tex_003A60" OutName="Bmori1_room_10Tex_003A60" Format="rgba16" Width="32" Height="64" Offset="0x3A60" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_10Tex_004BD8" OutName="Bmori1_room_10Tex_004BD8" Format="ia16" Width="32" Height="32" Offset="0x4BD8" AddedByScript="true"/>
         <Room Name="Bmori1_room_10" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_11" Segment="3">
+        <Texture Name="Bmori1_room_11Tex_008198" OutName="Bmori1_room_11Tex_008198" Format="rgba16" Width="64" Height="32" Offset="0x8198" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_11Tex_009198" OutName="Bmori1_room_11Tex_009198" Format="ci8" Width="32" Height="32" Offset="0x9198" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_11Tex_009598" OutName="Bmori1_room_11Tex_009598" Format="rgba16" Width="32" Height="32" Offset="0x9598" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_11Tex_009D98" OutName="Bmori1_room_11Tex_009D98" Format="i4" Width="64" Height="64" Offset="0x9D98" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_11Tex_00A598" OutName="Bmori1_room_11Tex_00A598" Format="ci8" Width="32" Height="32" Offset="0xA598" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
         <Room Name="Bmori1_room_11" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_12" Segment="3">
+        <Texture Name="Bmori1_room_12Tex_004A00" OutName="Bmori1_room_12Tex_004A00" Format="ci8" Width="32" Height="32" Offset="0x4A00" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_12Tex_004E00" OutName="Bmori1_room_12Tex_004E00" Format="ci8" Width="32" Height="64" Offset="0x4E00" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_12Tex_005600" OutName="Bmori1_room_12Tex_005600" Format="ci8" Width="64" Height="32" Offset="0x5600" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_12Tex_005E00" OutName="Bmori1_room_12Tex_005E00" Format="ci8" Width="64" Height="32" Offset="0x5E00" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_12Tex_006600" OutName="Bmori1_room_12Tex_006600" Format="ci8" Width="64" Height="32" Offset="0x6600" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_12Tex_006E00" OutName="Bmori1_room_12Tex_006E00" Format="ci8" Width="32" Height="32" Offset="0x6E00" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_12Tex_007200" OutName="Bmori1_room_12Tex_007200" Format="rgba16" Width="32" Height="32" Offset="0x7200" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_12Tex_007BD8" OutName="Bmori1_room_12Tex_007BD8" Format="ia16" Width="32" Height="32" Offset="0x7BD8" AddedByScript="true"/>
         <Room Name="Bmori1_room_12" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_13" Segment="3">
+        <Texture Name="Bmori1_room_13Tex_004CD0" OutName="Bmori1_room_13Tex_004CD0" Format="rgba16" Width="32" Height="32" Offset="0x4CD0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_13Tex_0054D0" OutName="Bmori1_room_13Tex_0054D0" Format="ci8" Width="32" Height="64" Offset="0x54D0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_13Tex_005CD0" OutName="Bmori1_room_13Tex_005CD0" Format="ci8" Width="64" Height="32" Offset="0x5CD0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_13Tex_0064D0" OutName="Bmori1_room_13Tex_0064D0" Format="ci8" Width="64" Height="32" Offset="0x64D0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_13Tex_006CD0" OutName="Bmori1_room_13Tex_006CD0" Format="ci8" Width="64" Height="32" Offset="0x6CD0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_13Tex_0074D0" OutName="Bmori1_room_13Tex_0074D0" Format="ci8" Width="32" Height="32" Offset="0x74D0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_13Tex_0078D0" OutName="Bmori1_room_13Tex_0078D0" Format="rgba16" Width="32" Height="32" Offset="0x78D0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_13Tex_0082A8" OutName="Bmori1_room_13Tex_0082A8" Format="ia16" Width="32" Height="32" Offset="0x82A8" AddedByScript="true"/>
         <Room Name="Bmori1_room_13" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_14" Segment="3">
+        <Texture Name="Bmori1_room_14Tex_003560" OutName="Bmori1_room_14Tex_003560" Format="ci8" Width="32" Height="32" Offset="0x3560" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_14Tex_003960" OutName="Bmori1_room_14Tex_003960" Format="rgba16" Width="32" Height="32" Offset="0x3960" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_14Tex_004160" OutName="Bmori1_room_14Tex_004160" Format="rgba16" Width="32" Height="32" Offset="0x4160" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_14Tex_004960" OutName="Bmori1_room_14Tex_004960" Format="ci8" Width="32" Height="32" Offset="0x4960" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_14Tex_004D60" OutName="Bmori1_room_14Tex_004D60" Format="ci8" Width="64" Height="32" Offset="0x4D60" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_14Tex_005770" OutName="Bmori1_room_14Tex_005770" Format="ia8" Width="32" Height="32" Offset="0x5770" AddedByScript="true"/>
         <Room Name="Bmori1_room_14" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_15" Segment="3">
+        <Texture Name="Bmori1_room_15Tex_0012E0" OutName="Bmori1_room_15Tex_0012E0" Format="ci8" Width="32" Height="64" Offset="0x12E0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_15Tex_001AE0" OutName="Bmori1_room_15Tex_001AE0" Format="ci8" Width="32" Height="32" Offset="0x1AE0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_15Tex_001EE0" OutName="Bmori1_room_15Tex_001EE0" Format="ci8" Width="64" Height="32" Offset="0x1EE0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
         <Room Name="Bmori1_room_15" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_16" Segment="3">
+        <Texture Name="Bmori1_room_16Tex_002F98" OutName="Bmori1_room_16Tex_002F98" Format="rgba16" Width="32" Height="32" Offset="0x2F98" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_16Tex_003798" OutName="Bmori1_room_16Tex_003798" Format="ci8" Width="64" Height="32" Offset="0x3798" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_16Tex_003F98" OutName="Bmori1_room_16Tex_003F98" Format="ci8" Width="32" Height="32" Offset="0x3F98" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_16Tex_004398" OutName="Bmori1_room_16Tex_004398" Format="ci8" Width="32" Height="32" Offset="0x4398" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_16Tex_004798" OutName="Bmori1_room_16Tex_004798" Format="ci8" Width="64" Height="32" Offset="0x4798" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
         <Room Name="Bmori1_room_16" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_17" Segment="3">
+        <Texture Name="Bmori1_room_17Tex_0064E8" OutName="Bmori1_room_17Tex_0064E8" Format="rgba16" Width="32" Height="32" Offset="0x64E8" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_17Tex_006CE8" OutName="Bmori1_room_17Tex_006CE8" Format="rgba16" Width="32" Height="32" Offset="0x6CE8" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_17Tex_0074E8" OutName="Bmori1_room_17Tex_0074E8" Format="ci8" Width="32" Height="32" Offset="0x74E8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_17Tex_0078E8" OutName="Bmori1_room_17Tex_0078E8" Format="ci8" Width="32" Height="32" Offset="0x78E8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_17Tex_007CE8" OutName="Bmori1_room_17Tex_007CE8" Format="ci8" Width="32" Height="32" Offset="0x7CE8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_17Tex_0080E8" OutName="Bmori1_room_17Tex_0080E8" Format="ci8" Width="64" Height="32" Offset="0x80E8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_17Tex_0088E8" OutName="Bmori1_room_17Tex_0088E8" Format="ci8" Width="32" Height="64" Offset="0x88E8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
         <Room Name="Bmori1_room_17" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_18" Segment="3">
+        <Texture Name="Bmori1_room_18Tex_000B30" OutName="Bmori1_room_18Tex_000B30" Format="ci8" Width="64" Height="32" Offset="0xB30" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
         <Room Name="Bmori1_room_18" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_19" Segment="3">
         <Room Name="Bmori1_room_19" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_20" Segment="3">
+        <Texture Name="Bmori1_room_20Tex_0006F8" OutName="Bmori1_room_20Tex_0006F8" Format="ci8" Width="32" Height="64" Offset="0x6F8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_20Tex_000EF8" OutName="Bmori1_room_20Tex_000EF8" Format="ci8" Width="32" Height="32" Offset="0xEF8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
         <Room Name="Bmori1_room_20" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_21" Segment="3">
+        <Texture Name="Bmori1_room_21Tex_000F70" OutName="Bmori1_room_21Tex_000F70" Format="ci8" Width="64" Height="32" Offset="0xF70" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
         <Room Name="Bmori1_room_21" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_22" Segment="3">
+        <Texture Name="Bmori1_room_22Tex_0005E0" OutName="Bmori1_room_22Tex_0005E0" Format="rgba16" Width="64" Height="32" Offset="0x5E0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_22Tex_0015E0" OutName="Bmori1_room_22Tex_0015E0" Format="ci8" Width="64" Height="32" Offset="0x15E0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
         <Room Name="Bmori1_room_22" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_MQ_D/scenes/dungeons/FIRE_bs.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/dungeons/FIRE_bs.xml
@@ -1,11 +1,34 @@
 <Root>
     <File Name="FIRE_bs_scene" Segment="2">
+        <Texture Name="FIRE_bs_sceneTex_002C00" OutName="FIRE_bs_sceneTex_002C00" Format="rgba16" Width="32" Height="32" Offset="0x2C00" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_sceneTex_003400" OutName="FIRE_bs_sceneTex_003400" Format="rgba16" Width="32" Height="32" Offset="0x3400" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_sceneTex_003C00" OutName="FIRE_bs_sceneTex_003C00" Format="rgba16" Width="32" Height="32" Offset="0x3C00" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_sceneTex_004400" OutName="FIRE_bs_sceneTex_004400" Format="rgba16" Width="32" Height="32" Offset="0x4400" AddedByScript="true"/>
         <Scene Name="FIRE_bs_scene" Offset="0x0"/>
     </File>
     <File Name="FIRE_bs_room_0" Segment="3">
+        <Texture Name="FIRE_bs_room_0Tex_002E68" OutName="FIRE_bs_room_0Tex_002E68" Format="ci4" Width="32" Height="32" Offset="0x2E68" TlutOffset="0x2E48" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_0Tex_003068" OutName="FIRE_bs_room_0Tex_003068" Format="ci4" Width="32" Height="64" Offset="0x3068" TlutOffset="0x2E48" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_0Tex_003468" OutName="FIRE_bs_room_0Tex_003468" Format="ci4" Width="64" Height="32" Offset="0x3468" TlutOffset="0x2E28" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_0Tex_003868" OutName="FIRE_bs_room_0Tex_003868" Format="ci4" Width="32" Height="32" Offset="0x3868" TlutOffset="0x2E28" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_0Tex_003A68" OutName="FIRE_bs_room_0Tex_003A68" Format="ci4" Width="32" Height="32" Offset="0x3A68" TlutOffset="0x2E28" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_0Tex_003C68" OutName="FIRE_bs_room_0Tex_003C68" Format="ci4" Width="32" Height="64" Offset="0x3C68" TlutOffset="0x2E48" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_0Tex_004068" OutName="FIRE_bs_room_0Tex_004068" Format="ci4" Width="32" Height="32" Offset="0x4068" TlutOffset="0x2E48" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_0TLUT_002E28" OutName="FIRE_bs_room_0TLUT_002E28" Format="rgba16" Width="4" Height="4" Offset="0x2E28" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_0TLUT_002E48" OutName="FIRE_bs_room_0TLUT_002E48" Format="rgba16" Width="4" Height="4" Offset="0x2E48" AddedByScript="true"/>
         <Room Name="FIRE_bs_room_0" Offset="0x0"/>
     </File>
     <File Name="FIRE_bs_room_1" Segment="3">
+        <Texture Name="FIRE_bs_room_1Tex_0049D8" OutName="FIRE_bs_room_1Tex_0049D8" Format="ci4" Width="32" Height="32" Offset="0x49D8" TlutOffset="0x49B8" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_1Tex_004BD8" OutName="FIRE_bs_room_1Tex_004BD8" Format="rgba16" Width="32" Height="32" Offset="0x4BD8" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_1Tex_0053D8" OutName="FIRE_bs_room_1Tex_0053D8" Format="rgba16" Width="32" Height="32" Offset="0x53D8" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_1Tex_005BD8" OutName="FIRE_bs_room_1Tex_005BD8" Format="ci4" Width="64" Height="32" Offset="0x5BD8" TlutOffset="0x4998" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_1Tex_005FD8" OutName="FIRE_bs_room_1Tex_005FD8" Format="ci4" Width="32" Height="32" Offset="0x5FD8" TlutOffset="0x4998" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_1Tex_0061D8" OutName="FIRE_bs_room_1Tex_0061D8" Format="ci4" Width="32" Height="64" Offset="0x61D8" TlutOffset="0x49B8" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_1Tex_0065D8" OutName="FIRE_bs_room_1Tex_0065D8" Format="rgba16" Width="32" Height="32" Offset="0x65D8" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_1Tex_006DD8" OutName="FIRE_bs_room_1Tex_006DD8" Format="ci4" Width="32" Height="32" Offset="0x6DD8" TlutOffset="0x49B8" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_1TLUT_004998" OutName="FIRE_bs_room_1TLUT_004998" Format="rgba16" Width="4" Height="4" Offset="0x4998" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_1TLUT_0049B8" OutName="FIRE_bs_room_1TLUT_0049B8" Format="rgba16" Width="4" Height="4" Offset="0x49B8" AddedByScript="true"/>
         <Room Name="FIRE_bs_room_1" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_MQ_D/scenes/dungeons/HAKAdan.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/dungeons/HAKAdan.xml
@@ -1,74 +1,191 @@
 <Root>
     <File Name="HAKAdan_scene" Segment="2">
+        <Texture Name="HAKAdan_sceneTex_0163C0" OutName="HAKAdan_sceneTex_0163C0" Format="rgba16" Width="32" Height="32" Offset="0x163C0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_sceneTex_016BC0" OutName="HAKAdan_sceneTex_016BC0" Format="rgba16" Width="32" Height="32" Offset="0x16BC0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_sceneTex_0173C0" OutName="HAKAdan_sceneTex_0173C0" Format="rgba16" Width="32" Height="32" Offset="0x173C0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_sceneTex_017BC0" OutName="HAKAdan_sceneTex_017BC0" Format="rgba16" Width="32" Height="32" Offset="0x17BC0" AddedByScript="true"/>
         <Scene Name="HAKAdan_scene" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_0" Segment="3">
+        <Texture Name="HAKAdan_room_0Tex_008230" OutName="HAKAdan_room_0Tex_008230" Format="rgba16" Width="32" Height="64" Offset="0x8230" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_0Tex_009230" OutName="HAKAdan_room_0Tex_009230" Format="rgba16" Width="32" Height="64" Offset="0x9230" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_0Tex_00A230" OutName="HAKAdan_room_0Tex_00A230" Format="rgba16" Width="32" Height="32" Offset="0xA230" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_0Tex_00AD48" OutName="HAKAdan_room_0Tex_00AD48" Format="ia8" Width="32" Height="32" Offset="0xAD48" AddedByScript="true"/>
         <Room Name="HAKAdan_room_0" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_1" Segment="3">
+        <Texture Name="HAKAdan_room_1Tex_0012E8" OutName="HAKAdan_room_1Tex_0012E8" Format="rgba16" Width="32" Height="32" Offset="0x12E8" AddedByScript="true"/>
         <Room Name="HAKAdan_room_1" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_2" Segment="3">
+        <Texture Name="HAKAdan_room_2Tex_006BD8" OutName="HAKAdan_room_2Tex_006BD8" Format="i4" Width="64" Height="64" Offset="0x6BD8" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_2Tex_0073D8" OutName="HAKAdan_room_2Tex_0073D8" Format="rgba16" Width="32" Height="16" Offset="0x73D8" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_2Tex_0077D8" OutName="HAKAdan_room_2Tex_0077D8" Format="rgba16" Width="32" Height="32" Offset="0x77D8" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_2Tex_007FD8" OutName="HAKAdan_room_2Tex_007FD8" Format="rgba16" Width="32" Height="8" Offset="0x7FD8" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_2Tex_0081D8" OutName="HAKAdan_room_2Tex_0081D8" Format="rgba16" Width="32" Height="64" Offset="0x81D8" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_2Tex_0091D8" OutName="HAKAdan_room_2Tex_0091D8" Format="rgba16" Width="32" Height="32" Offset="0x91D8" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_2Tex_0099D8" OutName="HAKAdan_room_2Tex_0099D8" Format="i4" Width="32" Height="32" Offset="0x99D8" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_2Tex_009BD8" OutName="HAKAdan_room_2Tex_009BD8" Format="rgba16" Width="32" Height="32" Offset="0x9BD8" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_2Tex_00A3D8" OutName="HAKAdan_room_2Tex_00A3D8" Format="i4" Width="32" Height="32" Offset="0xA3D8" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_2Tex_00A5D8" OutName="HAKAdan_room_2Tex_00A5D8" Format="i4" Width="32" Height="32" Offset="0xA5D8" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_2Tex_00A7D8" OutName="HAKAdan_room_2Tex_00A7D8" Format="i4" Width="32" Height="32" Offset="0xA7D8" AddedByScript="true"/>
         <Room Name="HAKAdan_room_2" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_3" Segment="3">
+        <Texture Name="HAKAdan_room_3Tex_001578" OutName="HAKAdan_room_3Tex_001578" Format="rgba16" Width="32" Height="32" Offset="0x1578" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_3Tex_001D78" OutName="HAKAdan_room_3Tex_001D78" Format="rgba16" Width="32" Height="32" Offset="0x1D78" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_3Tex_002578" OutName="HAKAdan_room_3Tex_002578" Format="i4" Width="32" Height="32" Offset="0x2578" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_3Tex_002778" OutName="HAKAdan_room_3Tex_002778" Format="i4" Width="32" Height="32" Offset="0x2778" AddedByScript="true"/>
         <Room Name="HAKAdan_room_3" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_4" Segment="3">
+        <Texture Name="HAKAdan_room_4Tex_001458" OutName="HAKAdan_room_4Tex_001458" Format="rgba16" Width="32" Height="32" Offset="0x1458" AddedByScript="true"/>
         <Room Name="HAKAdan_room_4" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_5" Segment="3">
+        <Texture Name="HAKAdan_room_5Tex_003CC0" OutName="HAKAdan_room_5Tex_003CC0" Format="rgba16" Width="32" Height="16" Offset="0x3CC0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_5Tex_0040C0" OutName="HAKAdan_room_5Tex_0040C0" Format="rgba16" Width="32" Height="32" Offset="0x40C0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_5Tex_0048C0" OutName="HAKAdan_room_5Tex_0048C0" Format="rgba16" Width="32" Height="8" Offset="0x48C0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_5Tex_004AC0" OutName="HAKAdan_room_5Tex_004AC0" Format="rgba16" Width="32" Height="32" Offset="0x4AC0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_5Tex_0052C0" OutName="HAKAdan_room_5Tex_0052C0" Format="rgba16" Width="32" Height="32" Offset="0x52C0" AddedByScript="true"/>
         <Room Name="HAKAdan_room_5" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_6" Segment="3">
+        <Texture Name="HAKAdan_room_6Tex_004BF0" OutName="HAKAdan_room_6Tex_004BF0" Format="i4" Width="64" Height="64" Offset="0x4BF0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_6Tex_0053F0" OutName="HAKAdan_room_6Tex_0053F0" Format="rgba16" Width="32" Height="8" Offset="0x53F0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_6Tex_0055F0" OutName="HAKAdan_room_6Tex_0055F0" Format="rgba16" Width="32" Height="64" Offset="0x55F0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_6Tex_0065F0" OutName="HAKAdan_room_6Tex_0065F0" Format="rgba16" Width="32" Height="32" Offset="0x65F0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_6Tex_006DF0" OutName="HAKAdan_room_6Tex_006DF0" Format="rgba16" Width="16" Height="32" Offset="0x6DF0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_6Tex_0071F0" OutName="HAKAdan_room_6Tex_0071F0" Format="rgba16" Width="16" Height="32" Offset="0x71F0" AddedByScript="true"/>
         <Room Name="HAKAdan_room_6" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_7" Segment="3">
+        <Texture Name="HAKAdan_room_7Tex_0012D8" OutName="HAKAdan_room_7Tex_0012D8" Format="rgba16" Width="32" Height="32" Offset="0x12D8" AddedByScript="true"/>
         <Room Name="HAKAdan_room_7" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_8" Segment="3">
+        <Texture Name="HAKAdan_room_8Tex_003098" OutName="HAKAdan_room_8Tex_003098" Format="rgba16" Width="32" Height="8" Offset="0x3098" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_8Tex_003298" OutName="HAKAdan_room_8Tex_003298" Format="ia4" Width="128" Height="64" Offset="0x3298" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_8Tex_004298" OutName="HAKAdan_room_8Tex_004298" Format="rgba16" Width="32" Height="32" Offset="0x4298" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_8Tex_004A98" OutName="HAKAdan_room_8Tex_004A98" Format="i4" Width="32" Height="32" Offset="0x4A98" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_8Tex_004C98" OutName="HAKAdan_room_8Tex_004C98" Format="rgba16" Width="16" Height="32" Offset="0x4C98" AddedByScript="true"/>
         <Room Name="HAKAdan_room_8" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_9" Segment="3">
+        <Texture Name="HAKAdan_room_9Tex_009090" OutName="HAKAdan_room_9Tex_009090" Format="i4" Width="64" Height="64" Offset="0x9090" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_9Tex_009890" OutName="HAKAdan_room_9Tex_009890" Format="rgba16" Width="32" Height="32" Offset="0x9890" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_9Tex_00A090" OutName="HAKAdan_room_9Tex_00A090" Format="rgba16" Width="32" Height="8" Offset="0xA090" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_9Tex_00A290" OutName="HAKAdan_room_9Tex_00A290" Format="ia4" Width="128" Height="64" Offset="0xA290" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_9Tex_00B290" OutName="HAKAdan_room_9Tex_00B290" Format="rgba16" Width="32" Height="32" Offset="0xB290" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_9Tex_00BA90" OutName="HAKAdan_room_9Tex_00BA90" Format="rgba16" Width="16" Height="32" Offset="0xBA90" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_9Tex_00BE90" OutName="HAKAdan_room_9Tex_00BE90" Format="rgba16" Width="32" Height="32" Offset="0xBE90" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_9Tex_00C690" OutName="HAKAdan_room_9Tex_00C690" Format="i4" Width="32" Height="32" Offset="0xC690" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_9Tex_00C890" OutName="HAKAdan_room_9Tex_00C890" Format="rgba16" Width="16" Height="32" Offset="0xC890" AddedByScript="true"/>
         <Room Name="HAKAdan_room_9" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_10" Segment="3">
+        <Texture Name="HAKAdan_room_10Tex_0039F0" OutName="HAKAdan_room_10Tex_0039F0" Format="rgba16" Width="32" Height="16" Offset="0x39F0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_10Tex_003DF0" OutName="HAKAdan_room_10Tex_003DF0" Format="rgba16" Width="32" Height="8" Offset="0x3DF0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_10Tex_003FF0" OutName="HAKAdan_room_10Tex_003FF0" Format="rgba16" Width="32" Height="64" Offset="0x3FF0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_10Tex_004FF0" OutName="HAKAdan_room_10Tex_004FF0" Format="ia4" Width="128" Height="64" Offset="0x4FF0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_10Tex_005FF0" OutName="HAKAdan_room_10Tex_005FF0" Format="rgba16" Width="32" Height="32" Offset="0x5FF0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_10Tex_0067F0" OutName="HAKAdan_room_10Tex_0067F0" Format="rgba16" Width="16" Height="32" Offset="0x67F0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_10Tex_006BF0" OutName="HAKAdan_room_10Tex_006BF0" Format="rgba16" Width="16" Height="64" Offset="0x6BF0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_10Tex_0073F0" OutName="HAKAdan_room_10Tex_0073F0" Format="rgba16" Width="16" Height="32" Offset="0x73F0" AddedByScript="true"/>
         <Room Name="HAKAdan_room_10" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_11" Segment="3">
+        <Texture Name="HAKAdan_room_11Tex_001E60" OutName="HAKAdan_room_11Tex_001E60" Format="i4" Width="64" Height="64" Offset="0x1E60" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_11Tex_002660" OutName="HAKAdan_room_11Tex_002660" Format="rgba16" Width="32" Height="16" Offset="0x2660" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_11Tex_002A60" OutName="HAKAdan_room_11Tex_002A60" Format="rgba16" Width="32" Height="8" Offset="0x2A60" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_11Tex_002C60" OutName="HAKAdan_room_11Tex_002C60" Format="rgba16" Width="32" Height="32" Offset="0x2C60" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_11Tex_003460" OutName="HAKAdan_room_11Tex_003460" Format="rgba16" Width="32" Height="32" Offset="0x3460" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_11Tex_003C60" OutName="HAKAdan_room_11Tex_003C60" Format="i4" Width="32" Height="32" Offset="0x3C60" AddedByScript="true"/>
         <Room Name="HAKAdan_room_11" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_12" Segment="3">
+        <Texture Name="HAKAdan_room_12Tex_003348" OutName="HAKAdan_room_12Tex_003348" Format="i4" Width="32" Height="32" Offset="0x3348" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_12Tex_003548" OutName="HAKAdan_room_12Tex_003548" Format="i4" Width="32" Height="32" Offset="0x3548" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_12Tex_003748" OutName="HAKAdan_room_12Tex_003748" Format="rgba16" Width="32" Height="16" Offset="0x3748" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_12Tex_003B48" OutName="HAKAdan_room_12Tex_003B48" Format="rgba16" Width="32" Height="8" Offset="0x3B48" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_12Tex_003D48" OutName="HAKAdan_room_12Tex_003D48" Format="rgba16" Width="32" Height="64" Offset="0x3D48" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_12Tex_004D48" OutName="HAKAdan_room_12Tex_004D48" Format="rgba16" Width="32" Height="32" Offset="0x4D48" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_12Tex_005548" OutName="HAKAdan_room_12Tex_005548" Format="i4" Width="32" Height="32" Offset="0x5548" AddedByScript="true"/>
         <Room Name="HAKAdan_room_12" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_13" Segment="3">
+        <Texture Name="HAKAdan_room_13Tex_000818" OutName="HAKAdan_room_13Tex_000818" Format="rgba16" Width="32" Height="32" Offset="0x818" AddedByScript="true"/>
         <Room Name="HAKAdan_room_13" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_14" Segment="3">
+        <Texture Name="HAKAdan_room_14Tex_003500" OutName="HAKAdan_room_14Tex_003500" Format="i4" Width="32" Height="32" Offset="0x3500" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_14Tex_003700" OutName="HAKAdan_room_14Tex_003700" Format="i4" Width="32" Height="32" Offset="0x3700" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_14Tex_003900" OutName="HAKAdan_room_14Tex_003900" Format="rgba16" Width="32" Height="16" Offset="0x3900" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_14Tex_003D00" OutName="HAKAdan_room_14Tex_003D00" Format="rgba16" Width="32" Height="8" Offset="0x3D00" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_14Tex_003F00" OutName="HAKAdan_room_14Tex_003F00" Format="rgba16" Width="32" Height="64" Offset="0x3F00" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_14Tex_004F00" OutName="HAKAdan_room_14Tex_004F00" Format="rgba16" Width="32" Height="32" Offset="0x4F00" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_14Tex_005700" OutName="HAKAdan_room_14Tex_005700" Format="i4" Width="32" Height="32" Offset="0x5700" AddedByScript="true"/>
         <Room Name="HAKAdan_room_14" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_15" Segment="3">
+        <Texture Name="HAKAdan_room_15Tex_0056C0" OutName="HAKAdan_room_15Tex_0056C0" Format="i4" Width="32" Height="32" Offset="0x56C0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_15Tex_0058C0" OutName="HAKAdan_room_15Tex_0058C0" Format="i4" Width="32" Height="32" Offset="0x58C0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_15Tex_005AC0" OutName="HAKAdan_room_15Tex_005AC0" Format="rgba16" Width="32" Height="16" Offset="0x5AC0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_15Tex_005EC0" OutName="HAKAdan_room_15Tex_005EC0" Format="rgba16" Width="32" Height="8" Offset="0x5EC0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_15Tex_0060C0" OutName="HAKAdan_room_15Tex_0060C0" Format="rgba16" Width="32" Height="32" Offset="0x60C0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_15Tex_0068C0" OutName="HAKAdan_room_15Tex_0068C0" Format="rgba16" Width="32" Height="32" Offset="0x68C0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_15Tex_0070C0" OutName="HAKAdan_room_15Tex_0070C0" Format="i4" Width="32" Height="32" Offset="0x70C0" AddedByScript="true"/>
         <Room Name="HAKAdan_room_15" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_16" Segment="3">
+        <Texture Name="HAKAdan_room_16Tex_001930" OutName="HAKAdan_room_16Tex_001930" Format="rgba16" Width="32" Height="64" Offset="0x1930" AddedByScript="true"/>
         <Room Name="HAKAdan_room_16" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_17" Segment="3">
+        <Texture Name="HAKAdan_room_17Tex_001248" OutName="HAKAdan_room_17Tex_001248" Format="rgba16" Width="32" Height="8" Offset="0x1248" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_17Tex_001448" OutName="HAKAdan_room_17Tex_001448" Format="rgba16" Width="32" Height="32" Offset="0x1448" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_17Tex_001C48" OutName="HAKAdan_room_17Tex_001C48" Format="rgba16" Width="16" Height="32" Offset="0x1C48" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_17Tex_002048" OutName="HAKAdan_room_17Tex_002048" Format="rgba16" Width="16" Height="32" Offset="0x2048" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_17Tex_0025D8" OutName="HAKAdan_room_17Tex_0025D8" Format="ia16" Width="32" Height="32" Offset="0x25D8" AddedByScript="true"/>
         <Room Name="HAKAdan_room_17" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_18" Segment="3">
+        <Texture Name="HAKAdan_room_18Tex_00B908" OutName="HAKAdan_room_18Tex_00B908" Format="i4" Width="32" Height="32" Offset="0xB908" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_18Tex_00BB08" OutName="HAKAdan_room_18Tex_00BB08" Format="rgba16" Width="32" Height="16" Offset="0xBB08" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_18Tex_00BF08" OutName="HAKAdan_room_18Tex_00BF08" Format="rgba16" Width="32" Height="32" Offset="0xBF08" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_18Tex_00C708" OutName="HAKAdan_room_18Tex_00C708" Format="rgba16" Width="32" Height="8" Offset="0xC708" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_18Tex_00C908" OutName="HAKAdan_room_18Tex_00C908" Format="i4" Width="32" Height="32" Offset="0xC908" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_18Tex_00CB08" OutName="HAKAdan_room_18Tex_00CB08" Format="i4" Width="32" Height="32" Offset="0xCB08" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_18Tex_00CD08" OutName="HAKAdan_room_18Tex_00CD08" Format="i4" Width="32" Height="32" Offset="0xCD08" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_18Tex_00CF08" OutName="HAKAdan_room_18Tex_00CF08" Format="rgba16" Width="16" Height="32" Offset="0xCF08" AddedByScript="true"/>
         <Room Name="HAKAdan_room_18" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_19" Segment="3">
+        <Texture Name="HAKAdan_room_19Tex_001578" OutName="HAKAdan_room_19Tex_001578" Format="rgba16" Width="32" Height="64" Offset="0x1578" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_19Tex_002578" OutName="HAKAdan_room_19Tex_002578" Format="rgba16" Width="32" Height="32" Offset="0x2578" AddedByScript="true"/>
         <Room Name="HAKAdan_room_19" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_20" Segment="3">
+        <Texture Name="HAKAdan_room_20Tex_001640" OutName="HAKAdan_room_20Tex_001640" Format="rgba16" Width="32" Height="32" Offset="0x1640" AddedByScript="true"/>
         <Room Name="HAKAdan_room_20" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_21" Segment="3">
+        <Texture Name="HAKAdan_room_21Tex_006E00" OutName="HAKAdan_room_21Tex_006E00" Format="rgba16" Width="32" Height="32" Offset="0x6E00" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_21Tex_007600" OutName="HAKAdan_room_21Tex_007600" Format="rgba16" Width="32" Height="8" Offset="0x7600" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_21Tex_007800" OutName="HAKAdan_room_21Tex_007800" Format="rgba16" Width="32" Height="64" Offset="0x7800" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_21Tex_008800" OutName="HAKAdan_room_21Tex_008800" Format="rgba16" Width="32" Height="32" Offset="0x8800" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_21Tex_009000" OutName="HAKAdan_room_21Tex_009000" Format="rgba16" Width="32" Height="32" Offset="0x9000" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_21Tex_009800" OutName="HAKAdan_room_21Tex_009800" Format="rgba16" Width="16" Height="64" Offset="0x9800" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_21Tex_00A000" OutName="HAKAdan_room_21Tex_00A000" Format="rgba16" Width="32" Height="32" Offset="0xA000" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_21Tex_00A800" OutName="HAKAdan_room_21Tex_00A800" Format="i4" Width="32" Height="32" Offset="0xA800" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_21Tex_00AA00" OutName="HAKAdan_room_21Tex_00AA00" Format="i4" Width="32" Height="32" Offset="0xAA00" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_21Tex_00ADA8" OutName="HAKAdan_room_21Tex_00ADA8" Format="rgba16" Width="32" Height="32" Offset="0xADA8" AddedByScript="true"/>
         <Room Name="HAKAdan_room_21" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_22" Segment="3">
+        <Texture Name="HAKAdan_room_22Tex_000FA8" OutName="HAKAdan_room_22Tex_000FA8" Format="rgba16" Width="32" Height="8" Offset="0xFA8" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_22Tex_0011A8" OutName="HAKAdan_room_22Tex_0011A8" Format="rgba16" Width="32" Height="64" Offset="0x11A8" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_22Tex_0021A8" OutName="HAKAdan_room_22Tex_0021A8" Format="rgba16" Width="32" Height="32" Offset="0x21A8" AddedByScript="true"/>
         <Room Name="HAKAdan_room_22" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_MQ_D/scenes/dungeons/HAKAdanCH.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/dungeons/HAKAdanCH.xml
@@ -1,27 +1,70 @@
 <Root>
     <File Name="HAKAdanCH_scene" Segment="2">
+        <Texture Name="HAKAdanCH_sceneTex_00A590" OutName="HAKAdanCH_sceneTex_00A590" Format="rgba16" Width="32" Height="32" Offset="0xA590" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_sceneTex_00AD90" OutName="HAKAdanCH_sceneTex_00AD90" Format="rgba16" Width="32" Height="32" Offset="0xAD90" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_sceneTex_00B590" OutName="HAKAdanCH_sceneTex_00B590" Format="rgba16" Width="32" Height="32" Offset="0xB590" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_sceneTex_00BD90" OutName="HAKAdanCH_sceneTex_00BD90" Format="rgba16" Width="32" Height="32" Offset="0xBD90" AddedByScript="true"/>
         <Path Name="HAKAdanCH_scenePathList_000248" Offset="0x0248" NumPaths="2"/>
         <Scene Name="HAKAdanCH_scene" Offset="0x0"/>
     </File>
     <File Name="HAKAdanCH_room_0" Segment="3">
+        <Texture Name="HAKAdanCH_room_0Tex_00D720" OutName="HAKAdanCH_room_0Tex_00D720" Format="rgba16" Width="32" Height="32" Offset="0xD720" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_00DF20" OutName="HAKAdanCH_room_0Tex_00DF20" Format="rgba16" Width="32" Height="8" Offset="0xDF20" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_00E120" OutName="HAKAdanCH_room_0Tex_00E120" Format="rgba16" Width="32" Height="64" Offset="0xE120" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_00F120" OutName="HAKAdanCH_room_0Tex_00F120" Format="rgba16" Width="32" Height="32" Offset="0xF120" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_00F920" OutName="HAKAdanCH_room_0Tex_00F920" Format="rgba16" Width="32" Height="32" Offset="0xF920" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_010120" OutName="HAKAdanCH_room_0Tex_010120" Format="rgba16" Width="32" Height="64" Offset="0x10120" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_011120" OutName="HAKAdanCH_room_0Tex_011120" Format="rgba16" Width="32" Height="32" Offset="0x11120" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_011920" OutName="HAKAdanCH_room_0Tex_011920" Format="rgba16" Width="16" Height="32" Offset="0x11920" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_011D20" OutName="HAKAdanCH_room_0Tex_011D20" Format="i4" Width="32" Height="32" Offset="0x11D20" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_011F20" OutName="HAKAdanCH_room_0Tex_011F20" Format="rgba16" Width="16" Height="64" Offset="0x11F20" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_012720" OutName="HAKAdanCH_room_0Tex_012720" Format="rgba16" Width="32" Height="32" Offset="0x12720" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_012F20" OutName="HAKAdanCH_room_0Tex_012F20" Format="i4" Width="32" Height="32" Offset="0x12F20" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_013120" OutName="HAKAdanCH_room_0Tex_013120" Format="i4" Width="32" Height="32" Offset="0x13120" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_013320" OutName="HAKAdanCH_room_0Tex_013320" Format="rgba16" Width="16" Height="32" Offset="0x13320" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_013720" OutName="HAKAdanCH_room_0Tex_013720" Format="rgba16" Width="32" Height="32" Offset="0x13720" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_013F20" OutName="HAKAdanCH_room_0Tex_013F20" Format="i4" Width="32" Height="32" Offset="0x13F20" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_014B20" OutName="HAKAdanCH_room_0Tex_014B20" Format="ia4" Width="16" Height="128" Offset="0x14B20" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_014F20" OutName="HAKAdanCH_room_0Tex_014F20" Format="ia16" Width="32" Height="32" Offset="0x14F20" AddedByScript="true"/>
         <Room Name="HAKAdanCH_room_0" Offset="0x0"/>
     </File>
     <File Name="HAKAdanCH_room_1" Segment="3">
+        <Texture Name="HAKAdanCH_room_1Tex_008D58" OutName="HAKAdanCH_room_1Tex_008D58" Format="rgba16" Width="32" Height="8" Offset="0x8D58" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_1Tex_008F58" OutName="HAKAdanCH_room_1Tex_008F58" Format="i4" Width="32" Height="32" Offset="0x8F58" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_1Tex_009158" OutName="HAKAdanCH_room_1Tex_009158" Format="i4" Width="32" Height="32" Offset="0x9158" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_1Tex_009358" OutName="HAKAdanCH_room_1Tex_009358" Format="rgba16" Width="32" Height="16" Offset="0x9358" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_1Tex_009758" OutName="HAKAdanCH_room_1Tex_009758" Format="rgba16" Width="32" Height="32" Offset="0x9758" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_1Tex_009F58" OutName="HAKAdanCH_room_1Tex_009F58" Format="i4" Width="32" Height="32" Offset="0x9F58" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_1Tex_00A158" OutName="HAKAdanCH_room_1Tex_00A158" Format="rgba16" Width="16" Height="32" Offset="0xA158" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_1Tex_00A558" OutName="HAKAdanCH_room_1Tex_00A558" Format="rgba16" Width="32" Height="32" Offset="0xA558" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_1Tex_00AD58" OutName="HAKAdanCH_room_1Tex_00AD58" Format="i4" Width="32" Height="32" Offset="0xAD58" AddedByScript="true"/>
         <Room Name="HAKAdanCH_room_1" Offset="0x0"/>
     </File>
     <File Name="HAKAdanCH_room_2" Segment="3">
+        <Texture Name="HAKAdanCH_room_2Tex_002958" OutName="HAKAdanCH_room_2Tex_002958" Format="rgba16" Width="32" Height="8" Offset="0x2958" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_2Tex_002B58" OutName="HAKAdanCH_room_2Tex_002B58" Format="i4" Width="32" Height="32" Offset="0x2B58" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_2Tex_002D58" OutName="HAKAdanCH_room_2Tex_002D58" Format="i4" Width="32" Height="32" Offset="0x2D58" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_2Tex_002F58" OutName="HAKAdanCH_room_2Tex_002F58" Format="i4" Width="32" Height="32" Offset="0x2F58" AddedByScript="true"/>
         <Room Name="HAKAdanCH_room_2" Offset="0x0"/>
     </File>
     <File Name="HAKAdanCH_room_3" Segment="3">
+        <Texture Name="HAKAdanCH_room_3Tex_0014C0" OutName="HAKAdanCH_room_3Tex_0014C0" Format="rgba16" Width="32" Height="32" Offset="0x14C0" AddedByScript="true"/>
         <Room Name="HAKAdanCH_room_3" Offset="0x0"/>
     </File>
     <File Name="HAKAdanCH_room_4" Segment="3">
+        <Texture Name="HAKAdanCH_room_4Tex_001498" OutName="HAKAdanCH_room_4Tex_001498" Format="rgba16" Width="32" Height="32" Offset="0x1498" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_4Tex_001C98" OutName="HAKAdanCH_room_4Tex_001C98" Format="rgba16" Width="32" Height="32" Offset="0x1C98" AddedByScript="true"/>
         <Room Name="HAKAdanCH_room_4" Offset="0x0"/>
     </File>
     <File Name="HAKAdanCH_room_5" Segment="3">
+        <Texture Name="HAKAdanCH_room_5Tex_001190" OutName="HAKAdanCH_room_5Tex_001190" Format="rgba16" Width="32" Height="64" Offset="0x1190" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_5Tex_002190" OutName="HAKAdanCH_room_5Tex_002190" Format="rgba16" Width="32" Height="32" Offset="0x2190" AddedByScript="true"/>
         <Room Name="HAKAdanCH_room_5" Offset="0x0"/>
     </File>
     <File Name="HAKAdanCH_room_6" Segment="3">
+        <Texture Name="HAKAdanCH_room_6Tex_000EA0" OutName="HAKAdanCH_room_6Tex_000EA0" Format="rgba16" Width="32" Height="32" Offset="0xEA0" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_6Tex_0016A0" OutName="HAKAdanCH_room_6Tex_0016A0" Format="rgba16" Width="32" Height="64" Offset="0x16A0" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_6Tex_0026A0" OutName="HAKAdanCH_room_6Tex_0026A0" Format="rgba16" Width="32" Height="32" Offset="0x26A0" AddedByScript="true"/>
         <Room Name="HAKAdanCH_room_6" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_MQ_D/scenes/dungeons/HAKAdan_bs.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/dungeons/HAKAdan_bs.xml
@@ -1,11 +1,23 @@
 <Root>
     <File Name="HAKAdan_bs_scene" Segment="2">
+        <Texture Name="HAKAdan_bs_sceneTex_001380" OutName="HAKAdan_bs_sceneTex_001380" Format="i4" Width="32" Height="32" Offset="0x1380" AddedByScript="true"/>
+        <Texture Name="HAKAdan_bs_sceneTex_001580" OutName="HAKAdan_bs_sceneTex_001580" Format="rgba16" Width="32" Height="8" Offset="0x1580" AddedByScript="true"/>
+        <Texture Name="HAKAdan_bs_sceneTex_001780" OutName="HAKAdan_bs_sceneTex_001780" Format="rgba16" Width="32" Height="32" Offset="0x1780" AddedByScript="true"/>
+        <Texture Name="HAKAdan_bs_sceneTex_001F80" OutName="HAKAdan_bs_sceneTex_001F80" Format="rgba16" Width="32" Height="32" Offset="0x1F80" AddedByScript="true"/>
         <Scene Name="HAKAdan_bs_scene" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_bs_room_0" Segment="3">
+        <Texture Name="HAKAdan_bs_room_0Tex_0021E0" OutName="HAKAdan_bs_room_0Tex_0021E0" Format="i4" Width="32" Height="32" Offset="0x21E0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_bs_room_0Tex_0023E0" OutName="HAKAdan_bs_room_0Tex_0023E0" Format="rgba16" Width="32" Height="16" Offset="0x23E0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_bs_room_0Tex_0027E0" OutName="HAKAdan_bs_room_0Tex_0027E0" Format="i4" Width="32" Height="32" Offset="0x27E0" AddedByScript="true"/>
         <Room Name="HAKAdan_bs_room_0" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_bs_room_1" Segment="3">
+        <Texture Name="HAKAdan_bs_room_1Tex_002D50" OutName="HAKAdan_bs_room_1Tex_002D50" Format="i4" Width="32" Height="32" Offset="0x2D50" AddedByScript="true"/>
+        <Texture Name="HAKAdan_bs_room_1Tex_002F50" OutName="HAKAdan_bs_room_1Tex_002F50" Format="rgba16" Width="32" Height="32" Offset="0x2F50" AddedByScript="true"/>
+        <Texture Name="HAKAdan_bs_room_1Tex_003750" OutName="HAKAdan_bs_room_1Tex_003750" Format="rgba16" Width="32" Height="32" Offset="0x3750" AddedByScript="true"/>
+        <Texture Name="HAKAdan_bs_room_1Tex_003F50" OutName="HAKAdan_bs_room_1Tex_003F50" Format="rgba16" Width="32" Height="64" Offset="0x3F50" AddedByScript="true"/>
+        <Texture Name="HAKAdan_bs_room_1Tex_004F50" OutName="HAKAdan_bs_room_1Tex_004F50" Format="rgba16" Width="32" Height="64" Offset="0x4F50" AddedByScript="true"/>
         <Room Name="HAKAdan_bs_room_1" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_MQ_D/scenes/dungeons/HIDAN.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/dungeons/HIDAN.xml
@@ -1,87 +1,288 @@
 <Root>
     <File Name="HIDAN_scene" Segment="2">
+        <Texture Name="HIDAN_sceneTex_0189D0" OutName="HIDAN_sceneTex_0189D0" Format="ci4" Width="32" Height="32" Offset="0x189D0" TlutOffset="0x189B0" AddedByScript="true"/>
+        <Texture Name="HIDAN_sceneTex_018BD0" OutName="HIDAN_sceneTex_018BD0" Format="ci4" Width="32" Height="32" Offset="0x18BD0" TlutOffset="0x189B0" AddedByScript="true"/>
+        <Texture Name="HIDAN_sceneTex_018DD0" OutName="HIDAN_sceneTex_018DD0" Format="rgba16" Width="32" Height="32" Offset="0x18DD0" AddedByScript="true"/>
+        <Texture Name="HIDAN_sceneTex_0195D0" OutName="HIDAN_sceneTex_0195D0" Format="rgba16" Width="32" Height="32" Offset="0x195D0" AddedByScript="true"/>
+        <Texture Name="HIDAN_sceneTex_019DD0" OutName="HIDAN_sceneTex_019DD0" Format="ci4" Width="32" Height="32" Offset="0x19DD0" TlutOffset="0x189B0" AddedByScript="true"/>
+        <Texture Name="HIDAN_sceneTex_019FD0" OutName="HIDAN_sceneTex_019FD0" Format="rgba16" Width="32" Height="32" Offset="0x19FD0" AddedByScript="true"/>
+        <Texture Name="HIDAN_sceneTLUT_018990" OutName="HIDAN_sceneTLUT_018990" Format="rgba16" Width="4" Height="4" Offset="0x18990" AddedByScript="true"/>
+        <Texture Name="HIDAN_sceneTLUT_0189B0" OutName="HIDAN_sceneTLUT_0189B0" Format="rgba16" Width="4" Height="4" Offset="0x189B0" AddedByScript="true"/>
         <Path Name="HIDAN_scenePathList_000440" Offset="0x0440" NumPaths="4"/>
         <Scene Name="HIDAN_scene" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_0" Segment="3">
+        <Texture Name="HIDAN_room_0Tex_004EF0" OutName="HIDAN_room_0Tex_004EF0" Format="ci4" Width="64" Height="32" Offset="0x4EF0" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18990" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_0Tex_0052F0" OutName="HIDAN_room_0Tex_0052F0" Format="ci4" Width="64" Height="32" Offset="0x52F0" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18990" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_0Tex_0056F0" OutName="HIDAN_room_0Tex_0056F0" Format="ci4" Width="64" Height="32" Offset="0x56F0" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18990" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_0Tex_005AF0" OutName="HIDAN_room_0Tex_005AF0" Format="ci4" Width="32" Height="32" Offset="0x5AF0" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18990" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_0Tex_005CF0" OutName="HIDAN_room_0Tex_005CF0" Format="ci4" Width="32" Height="32" Offset="0x5CF0" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18990" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_0Tex_005EF0" OutName="HIDAN_room_0Tex_005EF0" Format="ci4" Width="32" Height="64" Offset="0x5EF0" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x189B0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_0Tex_0062F0" OutName="HIDAN_room_0Tex_0062F0" Format="rgba16" Width="32" Height="64" Offset="0x62F0" AddedByScript="true"/>
         <Room Name="HIDAN_room_0" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_1" Segment="3">
+        <Texture Name="HIDAN_room_1Tex_008730" OutName="HIDAN_room_1Tex_008730" Format="rgba16" Width="16" Height="16" Offset="0x8730" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_1Tex_008930" OutName="HIDAN_room_1Tex_008930" Format="rgba16" Width="32" Height="32" Offset="0x8930" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_1Tex_009130" OutName="HIDAN_room_1Tex_009130" Format="rgba16" Width="32" Height="32" Offset="0x9130" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_1Tex_009930" OutName="HIDAN_room_1Tex_009930" Format="rgba16" Width="32" Height="32" Offset="0x9930" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_1Tex_00A130" OutName="HIDAN_room_1Tex_00A130" Format="ci4" Width="64" Height="32" Offset="0xA130" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18990" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_1Tex_00A530" OutName="HIDAN_room_1Tex_00A530" Format="rgba16" Width="64" Height="32" Offset="0xA530" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_1Tex_00B530" OutName="HIDAN_room_1Tex_00B530" Format="rgba16" Width="32" Height="32" Offset="0xB530" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_1Tex_00BD30" OutName="HIDAN_room_1Tex_00BD30" Format="ci4" Width="32" Height="64" Offset="0xBD30" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x189B0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_1Tex_00C130" OutName="HIDAN_room_1Tex_00C130" Format="rgba16" Width="32" Height="32" Offset="0xC130" AddedByScript="true"/>
         <Room Name="HIDAN_room_1" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_2" Segment="3">
+        <Texture Name="HIDAN_room_2Tex_009628" OutName="HIDAN_room_2Tex_009628" Format="rgba16" Width="32" Height="8" Offset="0x9628" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_2Tex_009828" OutName="HIDAN_room_2Tex_009828" Format="rgba16" Width="32" Height="32" Offset="0x9828" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_2Tex_00A028" OutName="HIDAN_room_2Tex_00A028" Format="rgba16" Width="32" Height="32" Offset="0xA028" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_2Tex_00A828" OutName="HIDAN_room_2Tex_00A828" Format="ci4" Width="64" Height="32" Offset="0xA828" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18990" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_2Tex_00AC28" OutName="HIDAN_room_2Tex_00AC28" Format="rgba16" Width="64" Height="32" Offset="0xAC28" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_2Tex_00BC28" OutName="HIDAN_room_2Tex_00BC28" Format="rgba16" Width="64" Height="32" Offset="0xBC28" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_2Tex_00CC28" OutName="HIDAN_room_2Tex_00CC28" Format="ci4" Width="32" Height="32" Offset="0xCC28" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18990" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_2Tex_00CE28" OutName="HIDAN_room_2Tex_00CE28" Format="rgba16" Width="64" Height="32" Offset="0xCE28" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_2Tex_00DE28" OutName="HIDAN_room_2Tex_00DE28" Format="ci4" Width="32" Height="32" Offset="0xDE28" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18990" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_2Tex_00E028" OutName="HIDAN_room_2Tex_00E028" Format="ci4" Width="32" Height="64" Offset="0xE028" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x189B0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_2Tex_00E428" OutName="HIDAN_room_2Tex_00E428" Format="rgba16" Width="32" Height="32" Offset="0xE428" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_2Tex_00EC28" OutName="HIDAN_room_2Tex_00EC28" Format="ci4" Width="32" Height="64" Offset="0xEC28" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x189B0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_2Tex_00F028" OutName="HIDAN_room_2Tex_00F028" Format="rgba16" Width="32" Height="32" Offset="0xF028" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_2Tex_00F828" OutName="HIDAN_room_2Tex_00F828" Format="rgba16" Width="32" Height="32" Offset="0xF828" AddedByScript="true"/>
         <Room Name="HIDAN_room_2" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_3" Segment="3">
+        <Texture Name="HIDAN_room_3Tex_001AC8" OutName="HIDAN_room_3Tex_001AC8" Format="ci4" Width="32" Height="64" Offset="0x1AC8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x189B0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_3Tex_001EC8" OutName="HIDAN_room_3Tex_001EC8" Format="ci4" Width="64" Height="32" Offset="0x1EC8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18990" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_3Tex_0022C8" OutName="HIDAN_room_3Tex_0022C8" Format="ci4" Width="32" Height="32" Offset="0x22C8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18990" AddedByScript="true"/>
         <Room Name="HIDAN_room_3" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_4" Segment="3">
+        <Texture Name="HIDAN_room_4Tex_0050F0" OutName="HIDAN_room_4Tex_0050F0" Format="rgba16" Width="32" Height="8" Offset="0x50F0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_4Tex_0052F0" OutName="HIDAN_room_4Tex_0052F0" Format="rgba16" Width="32" Height="32" Offset="0x52F0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_4Tex_005AF0" OutName="HIDAN_room_4Tex_005AF0" Format="rgba16" Width="32" Height="32" Offset="0x5AF0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_4Tex_0062F0" OutName="HIDAN_room_4Tex_0062F0" Format="ci4" Width="32" Height="64" Offset="0x62F0" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x189B0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_4Tex_0066F0" OutName="HIDAN_room_4Tex_0066F0" Format="ci4" Width="32" Height="32" Offset="0x66F0" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18990" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_4Tex_0068F0" OutName="HIDAN_room_4Tex_0068F0" Format="ci4" Width="32" Height="64" Offset="0x68F0" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x189B0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_4Tex_006CF0" OutName="HIDAN_room_4Tex_006CF0" Format="ci4" Width="32" Height="64" Offset="0x6CF0" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x189B0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_4Tex_0070F0" OutName="HIDAN_room_4Tex_0070F0" Format="rgba16" Width="32" Height="32" Offset="0x70F0" AddedByScript="true"/>
         <Room Name="HIDAN_room_4" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_5" Segment="3">
+        <Texture Name="HIDAN_room_5Tex_007EE0" OutName="HIDAN_room_5Tex_007EE0" Format="rgba16" Width="32" Height="8" Offset="0x7EE0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_5Tex_0080E0" OutName="HIDAN_room_5Tex_0080E0" Format="rgba16" Width="32" Height="32" Offset="0x80E0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_5Tex_0088E0" OutName="HIDAN_room_5Tex_0088E0" Format="ci4" Width="32" Height="64" Offset="0x88E0" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x189B0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_5Tex_008CE0" OutName="HIDAN_room_5Tex_008CE0" Format="rgba16" Width="32" Height="32" Offset="0x8CE0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_5Tex_0094E0" OutName="HIDAN_room_5Tex_0094E0" Format="ci4" Width="32" Height="32" Offset="0x94E0" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18990" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_5Tex_0096E0" OutName="HIDAN_room_5Tex_0096E0" Format="ci4" Width="32" Height="64" Offset="0x96E0" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x189B0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_5Tex_009AE0" OutName="HIDAN_room_5Tex_009AE0" Format="ci4" Width="32" Height="64" Offset="0x9AE0" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x189B0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_5Tex_009EE0" OutName="HIDAN_room_5Tex_009EE0" Format="ci4" Width="32" Height="64" Offset="0x9EE0" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x189B0" AddedByScript="true"/>
         <Room Name="HIDAN_room_5" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_6" Segment="3">
+        <Texture Name="HIDAN_room_6Tex_003990" OutName="HIDAN_room_6Tex_003990" Format="rgba16" Width="16" Height="16" Offset="0x3990" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_6Tex_003B90" OutName="HIDAN_room_6Tex_003B90" Format="rgba16" Width="32" Height="32" Offset="0x3B90" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_6Tex_004390" OutName="HIDAN_room_6Tex_004390" Format="rgba16" Width="32" Height="32" Offset="0x4390" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_6Tex_004B90" OutName="HIDAN_room_6Tex_004B90" Format="rgba16" Width="64" Height="32" Offset="0x4B90" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_6Tex_005B90" OutName="HIDAN_room_6Tex_005B90" Format="rgba16" Width="32" Height="32" Offset="0x5B90" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_6Tex_006390" OutName="HIDAN_room_6Tex_006390" Format="ci4" Width="32" Height="64" Offset="0x6390" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x189B0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_6Tex_006790" OutName="HIDAN_room_6Tex_006790" Format="rgba16" Width="32" Height="32" Offset="0x6790" AddedByScript="true"/>
         <Room Name="HIDAN_room_6" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_7" Segment="3">
+        <Texture Name="HIDAN_room_7Tex_001C48" OutName="HIDAN_room_7Tex_001C48" Format="rgba16" Width="32" Height="8" Offset="0x1C48" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_7Tex_001E48" OutName="HIDAN_room_7Tex_001E48" Format="rgba16" Width="32" Height="32" Offset="0x1E48" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_7Tex_002648" OutName="HIDAN_room_7Tex_002648" Format="ci4" Width="32" Height="64" Offset="0x2648" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x189B0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_7Tex_002A48" OutName="HIDAN_room_7Tex_002A48" Format="rgba16" Width="32" Height="64" Offset="0x2A48" AddedByScript="true"/>
         <Room Name="HIDAN_room_7" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_8" Segment="3">
+        <Texture Name="HIDAN_room_8Tex_0050D8" OutName="HIDAN_room_8Tex_0050D8" Format="rgba16" Width="16" Height="16" Offset="0x50D8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_8Tex_0052D8" OutName="HIDAN_room_8Tex_0052D8" Format="rgba16" Width="32" Height="32" Offset="0x52D8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_8Tex_005AD8" OutName="HIDAN_room_8Tex_005AD8" Format="rgba16" Width="32" Height="32" Offset="0x5AD8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_8Tex_0062D8" OutName="HIDAN_room_8Tex_0062D8" Format="rgba16" Width="32" Height="32" Offset="0x62D8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_8Tex_006AD8" OutName="HIDAN_room_8Tex_006AD8" Format="rgba16" Width="64" Height="32" Offset="0x6AD8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_8Tex_007AD8" OutName="HIDAN_room_8Tex_007AD8" Format="rgba16" Width="32" Height="32" Offset="0x7AD8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_8Tex_0082D8" OutName="HIDAN_room_8Tex_0082D8" Format="ci4" Width="32" Height="64" Offset="0x82D8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x189B0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_8Tex_0086D8" OutName="HIDAN_room_8Tex_0086D8" Format="ci4" Width="32" Height="64" Offset="0x86D8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x189B0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_8Tex_008AD8" OutName="HIDAN_room_8Tex_008AD8" Format="rgba16" Width="32" Height="32" Offset="0x8AD8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_8Tex_0092D8" OutName="HIDAN_room_8Tex_0092D8" Format="rgba16" Width="32" Height="32" Offset="0x92D8" AddedByScript="true"/>
         <Room Name="HIDAN_room_8" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_9" Segment="3">
+        <Texture Name="HIDAN_room_9Tex_004768" OutName="HIDAN_room_9Tex_004768" Format="rgba16" Width="32" Height="32" Offset="0x4768" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_9Tex_004F68" OutName="HIDAN_room_9Tex_004F68" Format="rgba16" Width="32" Height="32" Offset="0x4F68" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_9Tex_005768" OutName="HIDAN_room_9Tex_005768" Format="rgba16" Width="32" Height="32" Offset="0x5768" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_9Tex_005F68" OutName="HIDAN_room_9Tex_005F68" Format="rgba16" Width="32" Height="32" Offset="0x5F68" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_9Tex_006768" OutName="HIDAN_room_9Tex_006768" Format="rgba16" Width="32" Height="32" Offset="0x6768" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_9Tex_006F68" OutName="HIDAN_room_9Tex_006F68" Format="rgba16" Width="32" Height="32" Offset="0x6F68" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_9Tex_007768" OutName="HIDAN_room_9Tex_007768" Format="rgba16" Width="32" Height="32" Offset="0x7768" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_9Tex_007F68" OutName="HIDAN_room_9Tex_007F68" Format="rgba16" Width="32" Height="32" Offset="0x7F68" AddedByScript="true"/>
         <Room Name="HIDAN_room_9" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_10" Segment="3">
+        <Texture Name="HIDAN_room_10Tex_011818" OutName="HIDAN_room_10Tex_011818" Format="rgba16" Width="32" Height="8" Offset="0x11818" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_011A18" OutName="HIDAN_room_10Tex_011A18" Format="rgba16" Width="32" Height="32" Offset="0x11A18" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_012218" OutName="HIDAN_room_10Tex_012218" Format="ci4" Width="32" Height="64" Offset="0x12218" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x189B0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_012618" OutName="HIDAN_room_10Tex_012618" Format="rgba16" Width="32" Height="32" Offset="0x12618" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_012E18" OutName="HIDAN_room_10Tex_012E18" Format="ci4" Width="64" Height="32" Offset="0x12E18" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18990" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_013218" OutName="HIDAN_room_10Tex_013218" Format="ci4" Width="32" Height="32" Offset="0x13218" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x189B0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_013418" OutName="HIDAN_room_10Tex_013418" Format="rgba16" Width="64" Height="32" Offset="0x13418" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_014418" OutName="HIDAN_room_10Tex_014418" Format="rgba16" Width="64" Height="32" Offset="0x14418" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_015418" OutName="HIDAN_room_10Tex_015418" Format="ci4" Width="64" Height="32" Offset="0x15418" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18990" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_015818" OutName="HIDAN_room_10Tex_015818" Format="ci4" Width="32" Height="32" Offset="0x15818" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18990" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_015A18" OutName="HIDAN_room_10Tex_015A18" Format="rgba16" Width="64" Height="32" Offset="0x15A18" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_016A18" OutName="HIDAN_room_10Tex_016A18" Format="ci4" Width="32" Height="32" Offset="0x16A18" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18990" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_016C18" OutName="HIDAN_room_10Tex_016C18" Format="ci4" Width="32" Height="64" Offset="0x16C18" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x189B0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_017018" OutName="HIDAN_room_10Tex_017018" Format="rgba16" Width="32" Height="32" Offset="0x17018" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_017818" OutName="HIDAN_room_10Tex_017818" Format="ci4" Width="32" Height="64" Offset="0x17818" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x189B0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_017C18" OutName="HIDAN_room_10Tex_017C18" Format="rgba16" Width="32" Height="32" Offset="0x17C18" AddedByScript="true"/>
         <Room Name="HIDAN_room_10" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_11" Segment="3">
+        <Texture Name="HIDAN_room_11Tex_0027D8" OutName="HIDAN_room_11Tex_0027D8" Format="rgba16" Width="32" Height="32" Offset="0x27D8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_11Tex_002FD8" OutName="HIDAN_room_11Tex_002FD8" Format="ci4" Width="32" Height="64" Offset="0x2FD8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x189B0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_11Tex_0033D8" OutName="HIDAN_room_11Tex_0033D8" Format="ci4" Width="32" Height="64" Offset="0x33D8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x189B0" AddedByScript="true"/>
         <Room Name="HIDAN_room_11" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_12" Segment="3">
+        <Texture Name="HIDAN_room_12Tex_001D68" OutName="HIDAN_room_12Tex_001D68" Format="rgba16" Width="32" Height="8" Offset="0x1D68" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_12Tex_001F68" OutName="HIDAN_room_12Tex_001F68" Format="rgba16" Width="32" Height="32" Offset="0x1F68" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_12Tex_002768" OutName="HIDAN_room_12Tex_002768" Format="ci4" Width="32" Height="64" Offset="0x2768" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x189B0" AddedByScript="true"/>
         <Room Name="HIDAN_room_12" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_13" Segment="3">
+        <Texture Name="HIDAN_room_13Tex_00A788" OutName="HIDAN_room_13Tex_00A788" Format="rgba16" Width="32" Height="32" Offset="0xA788" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_13Tex_00AF88" OutName="HIDAN_room_13Tex_00AF88" Format="ci4" Width="64" Height="32" Offset="0xAF88" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18990" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_13Tex_00B388" OutName="HIDAN_room_13Tex_00B388" Format="ci4" Width="32" Height="64" Offset="0xB388" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x189B0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_13Tex_00B788" OutName="HIDAN_room_13Tex_00B788" Format="ci4" Width="32" Height="64" Offset="0xB788" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x189B0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_13Tex_00BB88" OutName="HIDAN_room_13Tex_00BB88" Format="rgba16" Width="32" Height="32" Offset="0xBB88" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_13Tex_00C388" OutName="HIDAN_room_13Tex_00C388" Format="rgba16" Width="32" Height="32" Offset="0xC388" AddedByScript="true"/>
         <Room Name="HIDAN_room_13" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_14" Segment="3">
+        <Texture Name="HIDAN_room_14Tex_0019F8" OutName="HIDAN_room_14Tex_0019F8" Format="ci4" Width="32" Height="64" Offset="0x19F8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x189B0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_14Tex_001DF8" OutName="HIDAN_room_14Tex_001DF8" Format="ci4" Width="32" Height="64" Offset="0x1DF8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x189B0" AddedByScript="true"/>
         <Room Name="HIDAN_room_14" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_15" Segment="3">
+        <Texture Name="HIDAN_room_15Tex_000D88" OutName="HIDAN_room_15Tex_000D88" Format="ci4" Width="32" Height="64" Offset="0xD88" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x189B0" AddedByScript="true"/>
         <Room Name="HIDAN_room_15" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_16" Segment="3">
+        <Texture Name="HIDAN_room_16Tex_006DE0" OutName="HIDAN_room_16Tex_006DE0" Format="rgba16" Width="32" Height="8" Offset="0x6DE0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_16Tex_006FE0" OutName="HIDAN_room_16Tex_006FE0" Format="rgba16" Width="32" Height="32" Offset="0x6FE0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_16Tex_0077E0" OutName="HIDAN_room_16Tex_0077E0" Format="rgba16" Width="32" Height="32" Offset="0x77E0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_16Tex_007FE0" OutName="HIDAN_room_16Tex_007FE0" Format="ci4" Width="32" Height="64" Offset="0x7FE0" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x189B0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_16Tex_0083E0" OutName="HIDAN_room_16Tex_0083E0" Format="ci4" Width="32" Height="32" Offset="0x83E0" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x189B0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_16Tex_0085E0" OutName="HIDAN_room_16Tex_0085E0" Format="rgba16" Width="32" Height="32" Offset="0x85E0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_16Tex_008DE0" OutName="HIDAN_room_16Tex_008DE0" Format="ci4" Width="32" Height="64" Offset="0x8DE0" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x189B0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_16Tex_0091E0" OutName="HIDAN_room_16Tex_0091E0" Format="ci4" Width="32" Height="64" Offset="0x91E0" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x189B0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_16Tex_0095E0" OutName="HIDAN_room_16Tex_0095E0" Format="rgba16" Width="16" Height="64" Offset="0x95E0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_16Tex_009DE0" OutName="HIDAN_room_16Tex_009DE0" Format="rgba16" Width="32" Height="32" Offset="0x9DE0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_16Tex_00A5E0" OutName="HIDAN_room_16Tex_00A5E0" Format="ci4" Width="32" Height="64" Offset="0xA5E0" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x189B0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_16Tex_00A9E0" OutName="HIDAN_room_16Tex_00A9E0" Format="rgba16" Width="32" Height="32" Offset="0xA9E0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_16Tex_00B1E0" OutName="HIDAN_room_16Tex_00B1E0" Format="rgba16" Width="32" Height="32" Offset="0xB1E0" AddedByScript="true"/>
         <Room Name="HIDAN_room_16" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_17" Segment="3">
+        <Texture Name="HIDAN_room_17Tex_005168" OutName="HIDAN_room_17Tex_005168" Format="rgba16" Width="32" Height="32" Offset="0x5168" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_17Tex_005968" OutName="HIDAN_room_17Tex_005968" Format="rgba16" Width="32" Height="32" Offset="0x5968" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_17Tex_006168" OutName="HIDAN_room_17Tex_006168" Format="rgba16" Width="32" Height="32" Offset="0x6168" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_17Tex_006968" OutName="HIDAN_room_17Tex_006968" Format="rgba16" Width="32" Height="32" Offset="0x6968" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_17Tex_007168" OutName="HIDAN_room_17Tex_007168" Format="rgba16" Width="32" Height="32" Offset="0x7168" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_17Tex_007968" OutName="HIDAN_room_17Tex_007968" Format="rgba16" Width="32" Height="32" Offset="0x7968" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_17Tex_008168" OutName="HIDAN_room_17Tex_008168" Format="rgba16" Width="32" Height="32" Offset="0x8168" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_17Tex_008968" OutName="HIDAN_room_17Tex_008968" Format="rgba16" Width="32" Height="32" Offset="0x8968" AddedByScript="true"/>
         <Room Name="HIDAN_room_17" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_18" Segment="3">
+        <Texture Name="HIDAN_room_18Tex_0027F8" OutName="HIDAN_room_18Tex_0027F8" Format="rgba16" Width="32" Height="32" Offset="0x27F8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_18Tex_002FF8" OutName="HIDAN_room_18Tex_002FF8" Format="ci4" Width="32" Height="64" Offset="0x2FF8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x189B0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_18Tex_0033F8" OutName="HIDAN_room_18Tex_0033F8" Format="ci4" Width="64" Height="32" Offset="0x33F8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18990" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_18Tex_0037F8" OutName="HIDAN_room_18Tex_0037F8" Format="ci4" Width="32" Height="32" Offset="0x37F8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18990" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_18Tex_0039F8" OutName="HIDAN_room_18Tex_0039F8" Format="ci4" Width="32" Height="32" Offset="0x39F8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18990" AddedByScript="true"/>
         <Room Name="HIDAN_room_18" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_19" Segment="3">
+        <Texture Name="HIDAN_room_19Tex_002E28" OutName="HIDAN_room_19Tex_002E28" Format="rgba16" Width="32" Height="32" Offset="0x2E28" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_19Tex_003628" OutName="HIDAN_room_19Tex_003628" Format="ci4" Width="32" Height="64" Offset="0x3628" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x189B0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_19Tex_003A28" OutName="HIDAN_room_19Tex_003A28" Format="ci4" Width="64" Height="32" Offset="0x3A28" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18990" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_19Tex_003E28" OutName="HIDAN_room_19Tex_003E28" Format="ci4" Width="32" Height="32" Offset="0x3E28" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18990" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_19Tex_004028" OutName="HIDAN_room_19Tex_004028" Format="ci4" Width="32" Height="32" Offset="0x4028" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18990" AddedByScript="true"/>
         <Room Name="HIDAN_room_19" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_20" Segment="3">
+        <Texture Name="HIDAN_room_20Tex_002D08" OutName="HIDAN_room_20Tex_002D08" Format="rgba16" Width="32" Height="32" Offset="0x2D08" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_20Tex_003508" OutName="HIDAN_room_20Tex_003508" Format="rgba16" Width="32" Height="32" Offset="0x3508" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_20Tex_003D08" OutName="HIDAN_room_20Tex_003D08" Format="rgba16" Width="32" Height="32" Offset="0x3D08" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_20Tex_004508" OutName="HIDAN_room_20Tex_004508" Format="rgba16" Width="32" Height="32" Offset="0x4508" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_20Tex_004D08" OutName="HIDAN_room_20Tex_004D08" Format="rgba16" Width="32" Height="32" Offset="0x4D08" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_20Tex_005508" OutName="HIDAN_room_20Tex_005508" Format="rgba16" Width="32" Height="32" Offset="0x5508" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_20Tex_005D08" OutName="HIDAN_room_20Tex_005D08" Format="rgba16" Width="32" Height="32" Offset="0x5D08" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_20Tex_006508" OutName="HIDAN_room_20Tex_006508" Format="rgba16" Width="32" Height="32" Offset="0x6508" AddedByScript="true"/>
         <Room Name="HIDAN_room_20" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_21" Segment="3">
+        <Texture Name="HIDAN_room_21Tex_004478" OutName="HIDAN_room_21Tex_004478" Format="rgba16" Width="32" Height="8" Offset="0x4478" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_21Tex_004678" OutName="HIDAN_room_21Tex_004678" Format="rgba16" Width="32" Height="32" Offset="0x4678" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_21Tex_004E78" OutName="HIDAN_room_21Tex_004E78" Format="rgba16" Width="32" Height="32" Offset="0x4E78" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_21Tex_005678" OutName="HIDAN_room_21Tex_005678" Format="rgba16" Width="32" Height="32" Offset="0x5678" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_21Tex_005E78" OutName="HIDAN_room_21Tex_005E78" Format="rgba16" Width="32" Height="32" Offset="0x5E78" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_21Tex_006678" OutName="HIDAN_room_21Tex_006678" Format="ci4" Width="64" Height="32" Offset="0x6678" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18990" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_21Tex_006A78" OutName="HIDAN_room_21Tex_006A78" Format="rgba16" Width="32" Height="32" Offset="0x6A78" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_21Tex_007278" OutName="HIDAN_room_21Tex_007278" Format="ci4" Width="32" Height="32" Offset="0x7278" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18990" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_21Tex_007478" OutName="HIDAN_room_21Tex_007478" Format="rgba16" Width="32" Height="32" Offset="0x7478" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_21Tex_007C78" OutName="HIDAN_room_21Tex_007C78" Format="rgba16" Width="32" Height="32" Offset="0x7C78" AddedByScript="true"/>
         <Room Name="HIDAN_room_21" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_22" Segment="3">
+        <Texture Name="HIDAN_room_22Tex_002AE8" OutName="HIDAN_room_22Tex_002AE8" Format="rgba16" Width="32" Height="32" Offset="0x2AE8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_22Tex_0032E8" OutName="HIDAN_room_22Tex_0032E8" Format="rgba16" Width="32" Height="32" Offset="0x32E8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_22Tex_003AE8" OutName="HIDAN_room_22Tex_003AE8" Format="rgba16" Width="32" Height="32" Offset="0x3AE8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_22Tex_0042E8" OutName="HIDAN_room_22Tex_0042E8" Format="rgba16" Width="32" Height="32" Offset="0x42E8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_22Tex_004AE8" OutName="HIDAN_room_22Tex_004AE8" Format="rgba16" Width="32" Height="32" Offset="0x4AE8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_22Tex_0052E8" OutName="HIDAN_room_22Tex_0052E8" Format="rgba16" Width="32" Height="32" Offset="0x52E8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_22Tex_005AE8" OutName="HIDAN_room_22Tex_005AE8" Format="rgba16" Width="32" Height="32" Offset="0x5AE8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_22Tex_0062E8" OutName="HIDAN_room_22Tex_0062E8" Format="rgba16" Width="32" Height="32" Offset="0x62E8" AddedByScript="true"/>
         <Room Name="HIDAN_room_22" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_23" Segment="3">
+        <Texture Name="HIDAN_room_23Tex_002D18" OutName="HIDAN_room_23Tex_002D18" Format="rgba16" Width="32" Height="32" Offset="0x2D18" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_23Tex_003518" OutName="HIDAN_room_23Tex_003518" Format="rgba16" Width="32" Height="32" Offset="0x3518" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_23Tex_003D18" OutName="HIDAN_room_23Tex_003D18" Format="rgba16" Width="32" Height="32" Offset="0x3D18" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_23Tex_004518" OutName="HIDAN_room_23Tex_004518" Format="rgba16" Width="32" Height="32" Offset="0x4518" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_23Tex_004D18" OutName="HIDAN_room_23Tex_004D18" Format="rgba16" Width="32" Height="32" Offset="0x4D18" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_23Tex_005518" OutName="HIDAN_room_23Tex_005518" Format="rgba16" Width="32" Height="32" Offset="0x5518" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_23Tex_005D18" OutName="HIDAN_room_23Tex_005D18" Format="rgba16" Width="32" Height="32" Offset="0x5D18" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_23Tex_006518" OutName="HIDAN_room_23Tex_006518" Format="rgba16" Width="32" Height="32" Offset="0x6518" AddedByScript="true"/>
         <Room Name="HIDAN_room_23" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_24" Segment="3">
+        <Texture Name="HIDAN_room_24Tex_003B38" OutName="HIDAN_room_24Tex_003B38" Format="ci4" Width="32" Height="64" Offset="0x3B38" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x189B0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_24Tex_003F38" OutName="HIDAN_room_24Tex_003F38" Format="ci4" Width="64" Height="32" Offset="0x3F38" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18990" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_24Tex_004338" OutName="HIDAN_room_24Tex_004338" Format="ci4" Width="64" Height="32" Offset="0x4338" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18990" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_24Tex_004738" OutName="HIDAN_room_24Tex_004738" Format="ci4" Width="32" Height="32" Offset="0x4738" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18990" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_24Tex_004938" OutName="HIDAN_room_24Tex_004938" Format="ci4" Width="32" Height="64" Offset="0x4938" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x189B0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_24Tex_004D38" OutName="HIDAN_room_24Tex_004D38" Format="rgba16" Width="32" Height="32" Offset="0x4D38" AddedByScript="true"/>
         <Room Name="HIDAN_room_24" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_25" Segment="3">
+        <Texture Name="HIDAN_room_25Tex_002AD8" OutName="HIDAN_room_25Tex_002AD8" Format="rgba16" Width="32" Height="32" Offset="0x2AD8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_25Tex_0032D8" OutName="HIDAN_room_25Tex_0032D8" Format="rgba16" Width="32" Height="32" Offset="0x32D8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_25Tex_003AD8" OutName="HIDAN_room_25Tex_003AD8" Format="rgba16" Width="32" Height="32" Offset="0x3AD8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_25Tex_0042D8" OutName="HIDAN_room_25Tex_0042D8" Format="rgba16" Width="32" Height="32" Offset="0x42D8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_25Tex_004AD8" OutName="HIDAN_room_25Tex_004AD8" Format="rgba16" Width="32" Height="32" Offset="0x4AD8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_25Tex_0052D8" OutName="HIDAN_room_25Tex_0052D8" Format="rgba16" Width="32" Height="32" Offset="0x52D8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_25Tex_005AD8" OutName="HIDAN_room_25Tex_005AD8" Format="rgba16" Width="32" Height="32" Offset="0x5AD8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_25Tex_0062D8" OutName="HIDAN_room_25Tex_0062D8" Format="rgba16" Width="32" Height="32" Offset="0x62D8" AddedByScript="true"/>
         <Room Name="HIDAN_room_25" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_26" Segment="3">
+        <Texture Name="HIDAN_room_26Tex_004A98" OutName="HIDAN_room_26Tex_004A98" Format="rgba16" Width="32" Height="32" Offset="0x4A98" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_26Tex_005298" OutName="HIDAN_room_26Tex_005298" Format="ci4" Width="64" Height="32" Offset="0x5298" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18990" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_26Tex_005698" OutName="HIDAN_room_26Tex_005698" Format="ci4" Width="32" Height="32" Offset="0x5698" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18990" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_26Tex_005898" OutName="HIDAN_room_26Tex_005898" Format="rgba16" Width="32" Height="32" Offset="0x5898" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_26Tex_006098" OutName="HIDAN_room_26Tex_006098" Format="rgba16" Width="32" Height="32" Offset="0x6098" AddedByScript="true"/>
         <Room Name="HIDAN_room_26" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_MQ_D/scenes/dungeons/MIZUsin.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/dungeons/MIZUsin.xml
@@ -1,77 +1,262 @@
 <Root>
     <File Name="MIZUsin_scene" Segment="2">
+        <Texture Name="MIZUsin_sceneTex_013C30" OutName="MIZUsin_sceneTex_013C30" Format="rgba16" Width="32" Height="32" Offset="0x13C30" AddedByScript="true"/>
+        <Texture Name="MIZUsin_sceneTex_014430" OutName="MIZUsin_sceneTex_014430" Format="rgba16" Width="32" Height="32" Offset="0x14430" AddedByScript="true"/>
+        <Texture Name="MIZUsin_sceneTex_015030" OutName="MIZUsin_sceneTex_015030" Format="rgba16" Width="32" Height="32" Offset="0x15030" AddedByScript="true"/>
         <Path Name="MIZUsin_scenePathList_000384" Offset="0x0384" NumPaths="2"/>
         <Texture Name="gWaterTempleDayEntranceTex" OutName="day_entrance" Format="ia16" Width="8" Height="64" Offset="0x14C30"/>
         <Texture Name="gWaterTempleNightEntranceTex" OutName="night_entrance" Format="ia16" Width="8" Height="64" Offset="0x15830"/>
         <Scene Name="MIZUsin_scene" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_0" Segment="3">
+        <Texture Name="MIZUsin_room_0Tex_00CDF8" OutName="MIZUsin_room_0Tex_00CDF8" Format="i4" Width="64" Height="64" Offset="0xCDF8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_00D5F8" OutName="MIZUsin_room_0Tex_00D5F8" Format="i4" Width="64" Height="64" Offset="0xD5F8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_00DDF8" OutName="MIZUsin_room_0Tex_00DDF8" Format="rgba16" Width="32" Height="32" Offset="0xDDF8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_00E5F8" OutName="MIZUsin_room_0Tex_00E5F8" Format="rgba16" Width="32" Height="32" Offset="0xE5F8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_00EDF8" OutName="MIZUsin_room_0Tex_00EDF8" Format="rgba16" Width="32" Height="32" Offset="0xEDF8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_00F5F8" OutName="MIZUsin_room_0Tex_00F5F8" Format="rgba16" Width="32" Height="32" Offset="0xF5F8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_00FDF8" OutName="MIZUsin_room_0Tex_00FDF8" Format="rgba16" Width="32" Height="32" Offset="0xFDF8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_0105F8" OutName="MIZUsin_room_0Tex_0105F8" Format="rgba16" Width="32" Height="32" Offset="0x105F8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_010DF8" OutName="MIZUsin_room_0Tex_010DF8" Format="rgba16" Width="32" Height="32" Offset="0x10DF8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_0115F8" OutName="MIZUsin_room_0Tex_0115F8" Format="rgba16" Width="32" Height="32" Offset="0x115F8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_011DF8" OutName="MIZUsin_room_0Tex_011DF8" Format="rgba16" Width="32" Height="32" Offset="0x11DF8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_0125F8" OutName="MIZUsin_room_0Tex_0125F8" Format="rgba16" Width="32" Height="32" Offset="0x125F8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_012DF8" OutName="MIZUsin_room_0Tex_012DF8" Format="rgba16" Width="32" Height="32" Offset="0x12DF8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_0135F8" OutName="MIZUsin_room_0Tex_0135F8" Format="rgba16" Width="32" Height="32" Offset="0x135F8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_013DF8" OutName="MIZUsin_room_0Tex_013DF8" Format="rgba16" Width="32" Height="32" Offset="0x13DF8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_0145F8" OutName="MIZUsin_room_0Tex_0145F8" Format="rgba16" Width="32" Height="32" Offset="0x145F8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_015428" OutName="MIZUsin_room_0Tex_015428" Format="ia16" Width="32" Height="32" Offset="0x15428" AddedByScript="true"/>
         <Room Name="MIZUsin_room_0" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_1" Segment="3">
+        <Texture Name="MIZUsin_room_1Tex_0059D0" OutName="MIZUsin_room_1Tex_0059D0" Format="i4" Width="64" Height="64" Offset="0x59D0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_1Tex_0061D0" OutName="MIZUsin_room_1Tex_0061D0" Format="i4" Width="64" Height="64" Offset="0x61D0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_1Tex_0069D0" OutName="MIZUsin_room_1Tex_0069D0" Format="rgba16" Width="32" Height="32" Offset="0x69D0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_1Tex_0071D0" OutName="MIZUsin_room_1Tex_0071D0" Format="rgba16" Width="32" Height="32" Offset="0x71D0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_1Tex_0079D0" OutName="MIZUsin_room_1Tex_0079D0" Format="rgba16" Width="32" Height="32" Offset="0x79D0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_1Tex_0081D0" OutName="MIZUsin_room_1Tex_0081D0" Format="rgba16" Width="32" Height="32" Offset="0x81D0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_1Tex_0089D0" OutName="MIZUsin_room_1Tex_0089D0" Format="rgba16" Width="32" Height="32" Offset="0x89D0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_1Tex_0091D0" OutName="MIZUsin_room_1Tex_0091D0" Format="rgba16" Width="32" Height="32" Offset="0x91D0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_1Tex_0099D0" OutName="MIZUsin_room_1Tex_0099D0" Format="rgba16" Width="32" Height="32" Offset="0x99D0" AddedByScript="true"/>
         <Room Name="MIZUsin_room_1" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_2" Segment="3">
+        <Texture Name="MIZUsin_room_2Tex_002AB8" OutName="MIZUsin_room_2Tex_002AB8" Format="rgba16" Width="32" Height="32" Offset="0x2AB8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_2Tex_0032B8" OutName="MIZUsin_room_2Tex_0032B8" Format="rgba16" Width="32" Height="32" Offset="0x32B8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_2Tex_003AB8" OutName="MIZUsin_room_2Tex_003AB8" Format="rgba16" Width="32" Height="32" Offset="0x3AB8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_2Tex_0042B8" OutName="MIZUsin_room_2Tex_0042B8" Format="rgba16" Width="32" Height="32" Offset="0x42B8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_2Tex_004AB8" OutName="MIZUsin_room_2Tex_004AB8" Format="rgba16" Width="32" Height="32" Offset="0x4AB8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_2Tex_005488" OutName="MIZUsin_room_2Tex_005488" Format="ia16" Width="32" Height="32" Offset="0x5488" AddedByScript="true"/>
         <Room Name="MIZUsin_room_2" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_3" Segment="3">
+        <Texture Name="MIZUsin_room_3Tex_0037B8" OutName="MIZUsin_room_3Tex_0037B8" Format="rgba16" Width="32" Height="32" Offset="0x37B8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_3Tex_003FB8" OutName="MIZUsin_room_3Tex_003FB8" Format="rgba16" Width="32" Height="32" Offset="0x3FB8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_3Tex_0047B8" OutName="MIZUsin_room_3Tex_0047B8" Format="rgba16" Width="32" Height="32" Offset="0x47B8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_3Tex_004FB8" OutName="MIZUsin_room_3Tex_004FB8" Format="rgba16" Width="32" Height="32" Offset="0x4FB8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_3Tex_0057B8" OutName="MIZUsin_room_3Tex_0057B8" Format="rgba16" Width="32" Height="32" Offset="0x57B8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_3Tex_005FB8" OutName="MIZUsin_room_3Tex_005FB8" Format="rgba16" Width="32" Height="32" Offset="0x5FB8" AddedByScript="true"/>
         <Room Name="MIZUsin_room_3" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_4" Segment="3">
+        <Texture Name="MIZUsin_room_4Tex_002820" OutName="MIZUsin_room_4Tex_002820" Format="i4" Width="64" Height="64" Offset="0x2820" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_4Tex_003020" OutName="MIZUsin_room_4Tex_003020" Format="rgba16" Width="32" Height="32" Offset="0x3020" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_4Tex_003820" OutName="MIZUsin_room_4Tex_003820" Format="rgba16" Width="32" Height="32" Offset="0x3820" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_4Tex_004020" OutName="MIZUsin_room_4Tex_004020" Format="rgba16" Width="32" Height="32" Offset="0x4020" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_4Tex_004820" OutName="MIZUsin_room_4Tex_004820" Format="rgba16" Width="32" Height="32" Offset="0x4820" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_4Tex_005020" OutName="MIZUsin_room_4Tex_005020" Format="rgba16" Width="32" Height="32" Offset="0x5020" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_4Tex_005820" OutName="MIZUsin_room_4Tex_005820" Format="rgba16" Width="32" Height="32" Offset="0x5820" AddedByScript="true"/>
         <Room Name="MIZUsin_room_4" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_5" Segment="3">
+        <Texture Name="MIZUsin_room_5Tex_003A48" OutName="MIZUsin_room_5Tex_003A48" Format="rgba16" Width="32" Height="32" Offset="0x3A48" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_5Tex_004248" OutName="MIZUsin_room_5Tex_004248" Format="rgba16" Width="32" Height="32" Offset="0x4248" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_5Tex_004A48" OutName="MIZUsin_room_5Tex_004A48" Format="rgba16" Width="32" Height="32" Offset="0x4A48" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_5Tex_005248" OutName="MIZUsin_room_5Tex_005248" Format="rgba16" Width="32" Height="32" Offset="0x5248" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_5Tex_005A48" OutName="MIZUsin_room_5Tex_005A48" Format="rgba16" Width="32" Height="32" Offset="0x5A48" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_5Tex_006248" OutName="MIZUsin_room_5Tex_006248" Format="rgba16" Width="32" Height="32" Offset="0x6248" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_5Tex_006A48" OutName="MIZUsin_room_5Tex_006A48" Format="rgba16" Width="32" Height="32" Offset="0x6A48" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_5Tex_007248" OutName="MIZUsin_room_5Tex_007248" Format="rgba16" Width="32" Height="32" Offset="0x7248" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_5Tex_007A48" OutName="MIZUsin_room_5Tex_007A48" Format="rgba16" Width="32" Height="32" Offset="0x7A48" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_5Tex_008248" OutName="MIZUsin_room_5Tex_008248" Format="rgba16" Width="32" Height="32" Offset="0x8248" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_5Tex_008A48" OutName="MIZUsin_room_5Tex_008A48" Format="rgba16" Width="32" Height="32" Offset="0x8A48" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_5Tex_009248" OutName="MIZUsin_room_5Tex_009248" Format="rgba16" Width="32" Height="32" Offset="0x9248" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_5Tex_009E38" OutName="MIZUsin_room_5Tex_009E38" Format="ia16" Width="32" Height="32" Offset="0x9E38" AddedByScript="true"/>
         <Room Name="MIZUsin_room_5" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_6" Segment="3">
+        <Texture Name="MIZUsin_room_6Tex_005100" OutName="MIZUsin_room_6Tex_005100" Format="i4" Width="32" Height="32" Offset="0x5100" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_005300" OutName="MIZUsin_room_6Tex_005300" Format="rgba16" Width="32" Height="32" Offset="0x5300" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_005B00" OutName="MIZUsin_room_6Tex_005B00" Format="rgba16" Width="32" Height="32" Offset="0x5B00" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_006300" OutName="MIZUsin_room_6Tex_006300" Format="i4" Width="32" Height="32" Offset="0x6300" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_006500" OutName="MIZUsin_room_6Tex_006500" Format="i4" Width="32" Height="32" Offset="0x6500" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_006700" OutName="MIZUsin_room_6Tex_006700" Format="i4" Width="32" Height="32" Offset="0x6700" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_006900" OutName="MIZUsin_room_6Tex_006900" Format="i4" Width="32" Height="32" Offset="0x6900" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_006B00" OutName="MIZUsin_room_6Tex_006B00" Format="i4" Width="64" Height="64" Offset="0x6B00" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_007300" OutName="MIZUsin_room_6Tex_007300" Format="rgba16" Width="32" Height="32" Offset="0x7300" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_007B00" OutName="MIZUsin_room_6Tex_007B00" Format="rgba16" Width="32" Height="32" Offset="0x7B00" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_008300" OutName="MIZUsin_room_6Tex_008300" Format="rgba16" Width="32" Height="32" Offset="0x8300" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_008B00" OutName="MIZUsin_room_6Tex_008B00" Format="rgba16" Width="32" Height="32" Offset="0x8B00" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_009300" OutName="MIZUsin_room_6Tex_009300" Format="rgba16" Width="32" Height="32" Offset="0x9300" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_009B00" OutName="MIZUsin_room_6Tex_009B00" Format="rgba16" Width="32" Height="32" Offset="0x9B00" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_00A300" OutName="MIZUsin_room_6Tex_00A300" Format="rgba16" Width="32" Height="32" Offset="0xA300" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_00AB00" OutName="MIZUsin_room_6Tex_00AB00" Format="rgba16" Width="32" Height="32" Offset="0xAB00" AddedByScript="true"/>
         <Room Name="MIZUsin_room_6" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_7" Segment="3">
+        <Texture Name="MIZUsin_room_7Tex_002560" OutName="MIZUsin_room_7Tex_002560" Format="rgba16" Width="32" Height="32" Offset="0x2560" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_7Tex_002D60" OutName="MIZUsin_room_7Tex_002D60" Format="rgba16" Width="32" Height="32" Offset="0x2D60" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_7Tex_003560" OutName="MIZUsin_room_7Tex_003560" Format="rgba16" Width="32" Height="32" Offset="0x3560" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_7Tex_003D60" OutName="MIZUsin_room_7Tex_003D60" Format="rgba16" Width="32" Height="32" Offset="0x3D60" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_7Tex_004560" OutName="MIZUsin_room_7Tex_004560" Format="rgba16" Width="32" Height="32" Offset="0x4560" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_7Tex_004D60" OutName="MIZUsin_room_7Tex_004D60" Format="rgba16" Width="32" Height="32" Offset="0x4D60" AddedByScript="true"/>
         <Room Name="MIZUsin_room_7" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_8" Segment="3">
+        <Texture Name="MIZUsin_room_8Tex_005D98" OutName="MIZUsin_room_8Tex_005D98" Format="i4" Width="32" Height="32" Offset="0x5D98" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_005F98" OutName="MIZUsin_room_8Tex_005F98" Format="i4" Width="32" Height="32" Offset="0x5F98" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_006198" OutName="MIZUsin_room_8Tex_006198" Format="rgba16" Width="32" Height="32" Offset="0x6198" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_006998" OutName="MIZUsin_room_8Tex_006998" Format="rgba16" Width="32" Height="32" Offset="0x6998" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_007198" OutName="MIZUsin_room_8Tex_007198" Format="i4" Width="32" Height="32" Offset="0x7198" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_007398" OutName="MIZUsin_room_8Tex_007398" Format="i4" Width="32" Height="32" Offset="0x7398" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_007598" OutName="MIZUsin_room_8Tex_007598" Format="rgba16" Width="32" Height="32" Offset="0x7598" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_007D98" OutName="MIZUsin_room_8Tex_007D98" Format="i4" Width="64" Height="64" Offset="0x7D98" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_008598" OutName="MIZUsin_room_8Tex_008598" Format="rgba16" Width="32" Height="32" Offset="0x8598" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_008D98" OutName="MIZUsin_room_8Tex_008D98" Format="rgba16" Width="32" Height="32" Offset="0x8D98" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_009598" OutName="MIZUsin_room_8Tex_009598" Format="rgba16" Width="32" Height="32" Offset="0x9598" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_009D98" OutName="MIZUsin_room_8Tex_009D98" Format="rgba16" Width="32" Height="32" Offset="0x9D98" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_00A598" OutName="MIZUsin_room_8Tex_00A598" Format="rgba16" Width="32" Height="32" Offset="0xA598" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_00AD98" OutName="MIZUsin_room_8Tex_00AD98" Format="rgba16" Width="32" Height="32" Offset="0xAD98" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_00B598" OutName="MIZUsin_room_8Tex_00B598" Format="rgba16" Width="32" Height="32" Offset="0xB598" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_00BD98" OutName="MIZUsin_room_8Tex_00BD98" Format="rgba16" Width="32" Height="32" Offset="0xBD98" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_00C598" OutName="MIZUsin_room_8Tex_00C598" Format="rgba16" Width="32" Height="32" Offset="0xC598" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_00D578" OutName="MIZUsin_room_8Tex_00D578" Format="ia16" Width="32" Height="32" Offset="0xD578" AddedByScript="true"/>
         <Room Name="MIZUsin_room_8" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_9" Segment="3">
+        <Texture Name="MIZUsin_room_9Tex_0036D8" OutName="MIZUsin_room_9Tex_0036D8" Format="i4" Width="64" Height="64" Offset="0x36D8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_9Tex_003ED8" OutName="MIZUsin_room_9Tex_003ED8" Format="rgba16" Width="32" Height="32" Offset="0x3ED8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_9Tex_0046D8" OutName="MIZUsin_room_9Tex_0046D8" Format="rgba16" Width="32" Height="32" Offset="0x46D8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_9Tex_004ED8" OutName="MIZUsin_room_9Tex_004ED8" Format="rgba16" Width="32" Height="32" Offset="0x4ED8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_9Tex_0056D8" OutName="MIZUsin_room_9Tex_0056D8" Format="rgba16" Width="32" Height="32" Offset="0x56D8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_9Tex_005ED8" OutName="MIZUsin_room_9Tex_005ED8" Format="rgba16" Width="32" Height="32" Offset="0x5ED8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_9Tex_0066D8" OutName="MIZUsin_room_9Tex_0066D8" Format="rgba16" Width="32" Height="32" Offset="0x66D8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_9Tex_006ED8" OutName="MIZUsin_room_9Tex_006ED8" Format="rgba16" Width="32" Height="32" Offset="0x6ED8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_9Tex_0078A8" OutName="MIZUsin_room_9Tex_0078A8" Format="ia16" Width="32" Height="32" Offset="0x78A8" AddedByScript="true"/>
         <Room Name="MIZUsin_room_9" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_10" Segment="3">
+        <Texture Name="MIZUsin_room_10Tex_003870" OutName="MIZUsin_room_10Tex_003870" Format="rgba16" Width="32" Height="32" Offset="0x3870" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_10Tex_004070" OutName="MIZUsin_room_10Tex_004070" Format="rgba16" Width="32" Height="32" Offset="0x4070" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_10Tex_004870" OutName="MIZUsin_room_10Tex_004870" Format="rgba16" Width="32" Height="32" Offset="0x4870" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_10Tex_005070" OutName="MIZUsin_room_10Tex_005070" Format="rgba16" Width="32" Height="32" Offset="0x5070" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_10Tex_005870" OutName="MIZUsin_room_10Tex_005870" Format="rgba16" Width="32" Height="32" Offset="0x5870" AddedByScript="true"/>
         <Room Name="MIZUsin_room_10" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_11" Segment="3">
+        <Texture Name="MIZUsin_room_11Tex_002220" OutName="MIZUsin_room_11Tex_002220" Format="rgba16" Width="32" Height="32" Offset="0x2220" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_11Tex_002A20" OutName="MIZUsin_room_11Tex_002A20" Format="rgba16" Width="32" Height="32" Offset="0x2A20" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_11Tex_003220" OutName="MIZUsin_room_11Tex_003220" Format="rgba16" Width="32" Height="32" Offset="0x3220" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_11Tex_003A20" OutName="MIZUsin_room_11Tex_003A20" Format="rgba16" Width="32" Height="32" Offset="0x3A20" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_11Tex_004220" OutName="MIZUsin_room_11Tex_004220" Format="rgba16" Width="32" Height="32" Offset="0x4220" AddedByScript="true"/>
         <Room Name="MIZUsin_room_11" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_12" Segment="3">
+        <Texture Name="MIZUsin_room_12Tex_0039C8" OutName="MIZUsin_room_12Tex_0039C8" Format="rgba16" Width="32" Height="32" Offset="0x39C8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_12Tex_0041C8" OutName="MIZUsin_room_12Tex_0041C8" Format="rgba16" Width="32" Height="32" Offset="0x41C8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_12Tex_0049C8" OutName="MIZUsin_room_12Tex_0049C8" Format="rgba16" Width="32" Height="32" Offset="0x49C8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_12Tex_0051C8" OutName="MIZUsin_room_12Tex_0051C8" Format="rgba16" Width="32" Height="32" Offset="0x51C8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_12Tex_006628" OutName="MIZUsin_room_12Tex_006628" Format="ia16" Width="32" Height="32" Offset="0x6628" AddedByScript="true"/>
         <Room Name="MIZUsin_room_12" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_13" Segment="3">
+        <Texture Name="MIZUsin_room_13Tex_0001F8" OutName="MIZUsin_room_13Tex_0001F8" Format="rgba16" Width="32" Height="32" Offset="0x1F8" AddedByScript="true"/>
         <Room Name="MIZUsin_room_13" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_14" Segment="3">
+        <Texture Name="MIZUsin_room_14Tex_003680" OutName="MIZUsin_room_14Tex_003680" Format="i4" Width="64" Height="64" Offset="0x3680" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_14Tex_003E80" OutName="MIZUsin_room_14Tex_003E80" Format="rgba16" Width="32" Height="32" Offset="0x3E80" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_14Tex_004680" OutName="MIZUsin_room_14Tex_004680" Format="rgba16" Width="32" Height="32" Offset="0x4680" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_14Tex_004E80" OutName="MIZUsin_room_14Tex_004E80" Format="rgba16" Width="32" Height="32" Offset="0x4E80" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_14Tex_005680" OutName="MIZUsin_room_14Tex_005680" Format="rgba16" Width="32" Height="32" Offset="0x5680" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_14Tex_005E80" OutName="MIZUsin_room_14Tex_005E80" Format="rgba16" Width="32" Height="32" Offset="0x5E80" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_14Tex_006680" OutName="MIZUsin_room_14Tex_006680" Format="rgba16" Width="32" Height="32" Offset="0x6680" AddedByScript="true"/>
         <Room Name="MIZUsin_room_14" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_15" Segment="3">
+        <Texture Name="MIZUsin_room_15Tex_002C68" OutName="MIZUsin_room_15Tex_002C68" Format="i4" Width="64" Height="64" Offset="0x2C68" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_15Tex_003468" OutName="MIZUsin_room_15Tex_003468" Format="rgba16" Width="32" Height="32" Offset="0x3468" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_15Tex_003C68" OutName="MIZUsin_room_15Tex_003C68" Format="rgba16" Width="32" Height="32" Offset="0x3C68" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_15Tex_004468" OutName="MIZUsin_room_15Tex_004468" Format="rgba16" Width="32" Height="32" Offset="0x4468" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_15Tex_004C68" OutName="MIZUsin_room_15Tex_004C68" Format="rgba16" Width="32" Height="32" Offset="0x4C68" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_15Tex_005468" OutName="MIZUsin_room_15Tex_005468" Format="rgba16" Width="32" Height="32" Offset="0x5468" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_15Tex_005C68" OutName="MIZUsin_room_15Tex_005C68" Format="rgba16" Width="32" Height="32" Offset="0x5C68" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_15Tex_006468" OutName="MIZUsin_room_15Tex_006468" Format="rgba16" Width="32" Height="32" Offset="0x6468" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_15Tex_006C68" OutName="MIZUsin_room_15Tex_006C68" Format="rgba16" Width="32" Height="32" Offset="0x6C68" AddedByScript="true"/>
         <Room Name="MIZUsin_room_15" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_16" Segment="3">
+        <Texture Name="MIZUsin_room_16Tex_001330" OutName="MIZUsin_room_16Tex_001330" Format="rgba16" Width="32" Height="32" Offset="0x1330" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_16Tex_001B30" OutName="MIZUsin_room_16Tex_001B30" Format="rgba16" Width="32" Height="32" Offset="0x1B30" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_16Tex_002330" OutName="MIZUsin_room_16Tex_002330" Format="rgba16" Width="32" Height="32" Offset="0x2330" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_16Tex_002B30" OutName="MIZUsin_room_16Tex_002B30" Format="rgba16" Width="32" Height="32" Offset="0x2B30" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_16Tex_003330" OutName="MIZUsin_room_16Tex_003330" Format="rgba16" Width="32" Height="32" Offset="0x3330" AddedByScript="true"/>
         <Room Name="MIZUsin_room_16" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_17" Segment="3">
+        <Texture Name="MIZUsin_room_17Tex_005AA8" OutName="MIZUsin_room_17Tex_005AA8" Format="rgba16" Width="32" Height="32" Offset="0x5AA8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_17Tex_0062A8" OutName="MIZUsin_room_17Tex_0062A8" Format="i4" Width="64" Height="64" Offset="0x62A8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_17Tex_006AA8" OutName="MIZUsin_room_17Tex_006AA8" Format="rgba16" Width="32" Height="32" Offset="0x6AA8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_17Tex_0072A8" OutName="MIZUsin_room_17Tex_0072A8" Format="rgba16" Width="32" Height="32" Offset="0x72A8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_17Tex_007AA8" OutName="MIZUsin_room_17Tex_007AA8" Format="rgba16" Width="32" Height="32" Offset="0x7AA8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_17Tex_0082A8" OutName="MIZUsin_room_17Tex_0082A8" Format="rgba16" Width="32" Height="32" Offset="0x82A8" AddedByScript="true"/>
         <Room Name="MIZUsin_room_17" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_18" Segment="3">
+        <Texture Name="MIZUsin_room_18Tex_0018F8" OutName="MIZUsin_room_18Tex_0018F8" Format="rgba16" Width="32" Height="32" Offset="0x18F8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_18Tex_0020F8" OutName="MIZUsin_room_18Tex_0020F8" Format="rgba16" Width="32" Height="32" Offset="0x20F8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_18Tex_0028F8" OutName="MIZUsin_room_18Tex_0028F8" Format="rgba16" Width="32" Height="32" Offset="0x28F8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_18Tex_0030F8" OutName="MIZUsin_room_18Tex_0030F8" Format="rgba16" Width="32" Height="32" Offset="0x30F8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_18Tex_0038F8" OutName="MIZUsin_room_18Tex_0038F8" Format="rgba16" Width="32" Height="32" Offset="0x38F8" AddedByScript="true"/>
         <Room Name="MIZUsin_room_18" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_19" Segment="3">
+        <Texture Name="MIZUsin_room_19Tex_001130" OutName="MIZUsin_room_19Tex_001130" Format="rgba16" Width="32" Height="32" Offset="0x1130" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_19Tex_001930" OutName="MIZUsin_room_19Tex_001930" Format="rgba16" Width="32" Height="32" Offset="0x1930" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_19Tex_002130" OutName="MIZUsin_room_19Tex_002130" Format="rgba16" Width="32" Height="32" Offset="0x2130" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_19Tex_002930" OutName="MIZUsin_room_19Tex_002930" Format="rgba16" Width="32" Height="32" Offset="0x2930" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_19Tex_003130" OutName="MIZUsin_room_19Tex_003130" Format="rgba16" Width="32" Height="32" Offset="0x3130" AddedByScript="true"/>
         <Room Name="MIZUsin_room_19" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_20" Segment="3">
+        <Texture Name="MIZUsin_room_20Tex_003040" OutName="MIZUsin_room_20Tex_003040" Format="rgba16" Width="32" Height="32" Offset="0x3040" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_20Tex_003840" OutName="MIZUsin_room_20Tex_003840" Format="i4" Width="64" Height="64" Offset="0x3840" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_20Tex_004040" OutName="MIZUsin_room_20Tex_004040" Format="rgba16" Width="32" Height="32" Offset="0x4040" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_20Tex_004840" OutName="MIZUsin_room_20Tex_004840" Format="rgba16" Width="32" Height="32" Offset="0x4840" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_20Tex_005040" OutName="MIZUsin_room_20Tex_005040" Format="rgba16" Width="32" Height="32" Offset="0x5040" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_20Tex_005840" OutName="MIZUsin_room_20Tex_005840" Format="rgba16" Width="32" Height="32" Offset="0x5840" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_20Tex_006040" OutName="MIZUsin_room_20Tex_006040" Format="rgba16" Width="32" Height="32" Offset="0x6040" AddedByScript="true"/>
         <Room Name="MIZUsin_room_20" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_21" Segment="3">
+        <Texture Name="MIZUsin_room_21Tex_004360" OutName="MIZUsin_room_21Tex_004360" Format="rgba16" Width="32" Height="32" Offset="0x4360" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_21Tex_004B60" OutName="MIZUsin_room_21Tex_004B60" Format="rgba16" Width="32" Height="32" Offset="0x4B60" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_21Tex_005360" OutName="MIZUsin_room_21Tex_005360" Format="rgba16" Width="32" Height="32" Offset="0x5360" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_21Tex_005B60" OutName="MIZUsin_room_21Tex_005B60" Format="rgba16" Width="32" Height="32" Offset="0x5B60" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_21Tex_006CA0" OutName="MIZUsin_room_21Tex_006CA0" Format="ia16" Width="32" Height="32" Offset="0x6CA0" AddedByScript="true"/>
         <Room Name="MIZUsin_room_21" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_22" Segment="3">
+        <Texture Name="MIZUsin_room_22Tex_0044E8" OutName="MIZUsin_room_22Tex_0044E8" Format="rgba16" Width="32" Height="16" Offset="0x44E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_22Tex_0048E8" OutName="MIZUsin_room_22Tex_0048E8" Format="rgba16" Width="32" Height="32" Offset="0x48E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_22Tex_0050E8" OutName="MIZUsin_room_22Tex_0050E8" Format="rgba16" Width="32" Height="32" Offset="0x50E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_22Tex_0058E8" OutName="MIZUsin_room_22Tex_0058E8" Format="rgba16" Width="32" Height="32" Offset="0x58E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_22Tex_0060E8" OutName="MIZUsin_room_22Tex_0060E8" Format="rgba16" Width="32" Height="32" Offset="0x60E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_22Tex_0068E8" OutName="MIZUsin_room_22Tex_0068E8" Format="rgba16" Width="32" Height="32" Offset="0x68E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_22Tex_0070E8" OutName="MIZUsin_room_22Tex_0070E8" Format="rgba16" Width="32" Height="32" Offset="0x70E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_22Tex_0078E8" OutName="MIZUsin_room_22Tex_0078E8" Format="rgba16" Width="32" Height="32" Offset="0x78E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_22Tex_0080E8" OutName="MIZUsin_room_22Tex_0080E8" Format="rgba16" Width="32" Height="32" Offset="0x80E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_22Tex_0088E8" OutName="MIZUsin_room_22Tex_0088E8" Format="rgba16" Width="32" Height="32" Offset="0x88E8" AddedByScript="true"/>
         <Room Name="MIZUsin_room_22" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_MQ_D/scenes/dungeons/MIZUsin_bs.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/dungeons/MIZUsin_bs.xml
@@ -3,9 +3,27 @@
         <Scene Name="MIZUsin_bs_scene" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_bs_room_0" Segment="3">
+        <Texture Name="MIZUsin_bs_room_0Tex_001470" OutName="MIZUsin_bs_room_0Tex_001470" Format="rgba16" Width="32" Height="32" Offset="0x1470" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_0Tex_001C70" OutName="MIZUsin_bs_room_0Tex_001C70" Format="rgba16" Width="32" Height="32" Offset="0x1C70" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_0Tex_002470" OutName="MIZUsin_bs_room_0Tex_002470" Format="rgba16" Width="32" Height="32" Offset="0x2470" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_0Tex_002C70" OutName="MIZUsin_bs_room_0Tex_002C70" Format="rgba16" Width="32" Height="32" Offset="0x2C70" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_0Tex_003470" OutName="MIZUsin_bs_room_0Tex_003470" Format="rgba16" Width="32" Height="32" Offset="0x3470" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_0Tex_003C70" OutName="MIZUsin_bs_room_0Tex_003C70" Format="rgba16" Width="32" Height="32" Offset="0x3C70" AddedByScript="true"/>
         <Room Name="MIZUsin_bs_room_0" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_bs_room_1" Segment="3">
+        <Texture Name="MIZUsin_bs_room_1Tex_0056E8" OutName="MIZUsin_bs_room_1Tex_0056E8" Format="rgba16" Width="32" Height="32" Offset="0x56E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_1Tex_005EE8" OutName="MIZUsin_bs_room_1Tex_005EE8" Format="rgba16" Width="32" Height="32" Offset="0x5EE8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_1Tex_0066E8" OutName="MIZUsin_bs_room_1Tex_0066E8" Format="rgba16" Width="32" Height="32" Offset="0x66E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_1Tex_006EE8" OutName="MIZUsin_bs_room_1Tex_006EE8" Format="rgba16" Width="32" Height="32" Offset="0x6EE8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_1Tex_0076E8" OutName="MIZUsin_bs_room_1Tex_0076E8" Format="rgba16" Width="32" Height="32" Offset="0x76E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_1Tex_007EE8" OutName="MIZUsin_bs_room_1Tex_007EE8" Format="rgba16" Width="32" Height="32" Offset="0x7EE8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_1Tex_0086E8" OutName="MIZUsin_bs_room_1Tex_0086E8" Format="rgba16" Width="32" Height="32" Offset="0x86E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_1Tex_008EE8" OutName="MIZUsin_bs_room_1Tex_008EE8" Format="rgba16" Width="32" Height="16" Offset="0x8EE8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_1Tex_0092E8" OutName="MIZUsin_bs_room_1Tex_0092E8" Format="rgba16" Width="32" Height="32" Offset="0x92E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_1Tex_009AE8" OutName="MIZUsin_bs_room_1Tex_009AE8" Format="rgba16" Width="32" Height="32" Offset="0x9AE8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_1Tex_00A2E8" OutName="MIZUsin_bs_room_1Tex_00A2E8" Format="rgba16" Width="32" Height="32" Offset="0xA2E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_1Tex_00AAE8" OutName="MIZUsin_bs_room_1Tex_00AAE8" Format="i4" Width="64" Height="64" Offset="0xAAE8" AddedByScript="true"/>
         <Room Name="MIZUsin_bs_room_1" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_MQ_D/scenes/dungeons/bdan.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/dungeons/bdan.xml
@@ -1,36 +1,69 @@
 <Root>
     <File Name="bdan_scene" Segment="2">
+        <Texture Name="bdan_sceneTex_013E00" OutName="bdan_sceneTex_013E00" Format="ci8" Width="32" Height="64" Offset="0x13E00" TlutOffset="0x13BF8" AddedByScript="true"/>
+        <Texture Name="bdan_sceneTex_014600" OutName="bdan_sceneTex_014600" Format="ci8" Width="32" Height="32" Offset="0x14600" TlutOffset="0x13BF8" AddedByScript="true"/>
+        <Texture Name="bdan_sceneTex_014A00" OutName="bdan_sceneTex_014A00" Format="ci8" Width="32" Height="64" Offset="0x14A00" TlutOffset="0x13BF8" AddedByScript="true"/>
+        <Texture Name="bdan_sceneTex_015200" OutName="bdan_sceneTex_015200" Format="ci8" Width="32" Height="32" Offset="0x15200" TlutOffset="0x139F0" AddedByScript="true"/>
+        <Texture Name="bdan_sceneTLUT_0139F0" OutName="bdan_sceneTLUT_0139F0" Format="rgba16" Width="16" Height="16" Offset="0x139F0" AddedByScript="true"/>
+        <Texture Name="bdan_sceneTLUT_013BF8" OutName="bdan_sceneTLUT_013BF8" Format="rgba16" Width="16" Height="16" Offset="0x13BF8" AddedByScript="true"/>
         <Cutscene Name="gJabuJabuIntroCs" Offset="0x15600"/>
         <Scene Name="bdan_scene" Offset="0x0"/>
     </File>
     <File Name="bdan_room_0" Segment="3">
+        <Texture Name="bdan_room_0Tex_002DB8" OutName="bdan_room_0Tex_002DB8" Format="ci8" Width="32" Height="32" Offset="0x2DB8" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BF8" AddedByScript="true"/>
+        <Texture Name="bdan_room_0Tex_0031B8" OutName="bdan_room_0Tex_0031B8" Format="ci8" Width="32" Height="64" Offset="0x31B8" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BF8" AddedByScript="true"/>
+        <Texture Name="bdan_room_0Tex_0039B8" OutName="bdan_room_0Tex_0039B8" Format="ci8" Width="32" Height="32" Offset="0x39B8" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BF8" AddedByScript="true"/>
         <Room Name="bdan_room_0" Offset="0x0"/>
     </File>
     <File Name="bdan_room_1" Segment="3">
+        <Texture Name="bdan_room_1Tex_004E00" OutName="bdan_room_1Tex_004E00" Format="ci8" Width="32" Height="64" Offset="0x4E00" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BF8" AddedByScript="true"/>
+        <Texture Name="bdan_room_1Tex_005600" OutName="bdan_room_1Tex_005600" Format="ci8" Width="32" Height="64" Offset="0x5600" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BF8" AddedByScript="true"/>
         <Room Name="bdan_room_1" Offset="0x0"/>
     </File>
     <File Name="bdan_room_2" Segment="3">
+        <Texture Name="bdan_room_2Tex_006E38" OutName="bdan_room_2Tex_006E38" Format="rgba16" Width="32" Height="64" Offset="0x6E38" AddedByScript="true"/>
+        <Texture Name="bdan_room_2Tex_007E38" OutName="bdan_room_2Tex_007E38" Format="ci8" Width="32" Height="64" Offset="0x7E38" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BF8" AddedByScript="true"/>
+        <Texture Name="bdan_room_2Tex_008638" OutName="bdan_room_2Tex_008638" Format="ci8" Width="32" Height="64" Offset="0x8638" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BF8" AddedByScript="true"/>
+        <Texture Name="bdan_room_2Tex_008E38" OutName="bdan_room_2Tex_008E38" Format="ci8" Width="32" Height="32" Offset="0x8E38" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BF8" AddedByScript="true"/>
         <Room Name="bdan_room_2" Offset="0x0"/>
     </File>
     <File Name="bdan_room_3" Segment="3">
+        <Texture Name="bdan_room_3Tex_004888" OutName="bdan_room_3Tex_004888" Format="rgba16" Width="32" Height="64" Offset="0x4888" AddedByScript="true"/>
+        <Texture Name="bdan_room_3Tex_005888" OutName="bdan_room_3Tex_005888" Format="ci8" Width="32" Height="64" Offset="0x5888" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BF8" AddedByScript="true"/>
+        <Texture Name="bdan_room_3Tex_006088" OutName="bdan_room_3Tex_006088" Format="ci8" Width="32" Height="32" Offset="0x6088" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BF8" AddedByScript="true"/>
+        <Texture Name="bdan_room_3Tex_006488" OutName="bdan_room_3Tex_006488" Format="ci8" Width="32" Height="64" Offset="0x6488" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BF8" AddedByScript="true"/>
+        <Texture Name="bdan_room_3Tex_006C88" OutName="bdan_room_3Tex_006C88" Format="ci8" Width="32" Height="32" Offset="0x6C88" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BF8" AddedByScript="true"/>
         <Room Name="bdan_room_3" Offset="0x0"/>
     </File>
     <File Name="bdan_room_4" Segment="3">
+        <Texture Name="bdan_room_4Tex_002B30" OutName="bdan_room_4Tex_002B30" Format="ci8" Width="32" Height="32" Offset="0x2B30" ExternalTlut="bdan_scene" ExternalTlutOffset="0x139F0" AddedByScript="true"/>
+        <Texture Name="bdan_room_4Tex_002F30" OutName="bdan_room_4Tex_002F30" Format="ci8" Width="32" Height="64" Offset="0x2F30" ExternalTlut="bdan_scene" ExternalTlutOffset="0x139F0" AddedByScript="true"/>
+        <Texture Name="bdan_room_4Tex_003730" OutName="bdan_room_4Tex_003730" Format="ci8" Width="32" Height="64" Offset="0x3730" ExternalTlut="bdan_scene" ExternalTlutOffset="0x139F0" AddedByScript="true"/>
         <Room Name="bdan_room_4" Offset="0x0"/>
     </File>
     <File Name="bdan_room_5" Segment="3">
+        <Texture Name="bdan_room_5Tex_0024A8" OutName="bdan_room_5Tex_0024A8" Format="ci8" Width="32" Height="32" Offset="0x24A8" ExternalTlut="bdan_scene" ExternalTlutOffset="0x139F0" AddedByScript="true"/>
+        <Texture Name="bdan_room_5Tex_0028A8" OutName="bdan_room_5Tex_0028A8" Format="ci8" Width="32" Height="64" Offset="0x28A8" ExternalTlut="bdan_scene" ExternalTlutOffset="0x139F0" AddedByScript="true"/>
+        <Texture Name="bdan_room_5Tex_0030A8" OutName="bdan_room_5Tex_0030A8" Format="ci8" Width="32" Height="64" Offset="0x30A8" ExternalTlut="bdan_scene" ExternalTlutOffset="0x139F0" AddedByScript="true"/>
+        <Texture Name="bdan_room_5Tex_004090" OutName="bdan_room_5Tex_004090" Format="rgba16" Width="32" Height="64" Offset="0x4090" AddedByScript="true"/>
+        <Texture Name="bdan_room_5Tex_005090" OutName="bdan_room_5Tex_005090" Format="ia16" Width="32" Height="64" Offset="0x5090" AddedByScript="true"/>
         <Room Name="bdan_room_5" Offset="0x0"/>
     </File>
     <File Name="bdan_room_6" Segment="3">
+        <Texture Name="bdan_room_6Tex_003068" OutName="bdan_room_6Tex_003068" Format="ci8" Width="32" Height="64" Offset="0x3068" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BF8" AddedByScript="true"/>
+        <Texture Name="bdan_room_6Tex_003868" OutName="bdan_room_6Tex_003868" Format="ci8" Width="32" Height="64" Offset="0x3868" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BF8" AddedByScript="true"/>
         <Room Name="bdan_room_6" Offset="0x0"/>
     </File>
     <File Name="bdan_room_7" Segment="3">
+        <Texture Name="bdan_room_7Tex_002CD0" OutName="bdan_room_7Tex_002CD0" Format="ci8" Width="32" Height="32" Offset="0x2CD0" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BF8" AddedByScript="true"/>
+        <Texture Name="bdan_room_7Tex_0030D0" OutName="bdan_room_7Tex_0030D0" Format="ci8" Width="32" Height="32" Offset="0x30D0" ExternalTlut="bdan_scene" ExternalTlutOffset="0x139F0" AddedByScript="true"/>
         <Room Name="bdan_room_7" Offset="0x0"/>
     </File>
     <File Name="bdan_room_8" Segment="3">
         <Room Name="bdan_room_8" Offset="0x0"/>
     </File>
     <File Name="bdan_room_9" Segment="3">
+        <Texture Name="bdan_room_9Tex_003828" OutName="bdan_room_9Tex_003828" Format="ci8" Width="32" Height="32" Offset="0x3828" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BF8" AddedByScript="true"/>
         <Room Name="bdan_room_9" Offset="0x0"/>
     </File>
     <File Name="bdan_room_10" Segment="3">
@@ -40,12 +73,20 @@
         <Room Name="bdan_room_11" Offset="0x0"/>
     </File>
     <File Name="bdan_room_12" Segment="3">
+        <Texture Name="bdan_room_12Tex_0038E0" OutName="bdan_room_12Tex_0038E0" Format="ci8" Width="32" Height="32" Offset="0x38E0" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BF8" AddedByScript="true"/>
         <Room Name="bdan_room_12" Offset="0x0"/>
     </File>
     <File Name="bdan_room_13" Segment="3">
+        <Texture Name="bdan_room_13Tex_0015B8" OutName="bdan_room_13Tex_0015B8" Format="ci8" Width="32" Height="64" Offset="0x15B8" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BF8" AddedByScript="true"/>
+        <Texture Name="bdan_room_13Tex_001DB8" OutName="bdan_room_13Tex_001DB8" Format="ci8" Width="32" Height="32" Offset="0x1DB8" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BF8" AddedByScript="true"/>
+        <Texture Name="bdan_room_13Tex_0021B8" OutName="bdan_room_13Tex_0021B8" Format="ci8" Width="32" Height="64" Offset="0x21B8" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BF8" AddedByScript="true"/>
         <Room Name="bdan_room_13" Offset="0x0"/>
     </File>
     <File Name="bdan_room_14" Segment="3">
+        <Texture Name="bdan_room_14Tex_0045C8" OutName="bdan_room_14Tex_0045C8" Format="ci8" Width="32" Height="64" Offset="0x45C8" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BF8" AddedByScript="true"/>
+        <Texture Name="bdan_room_14Tex_004DC8" OutName="bdan_room_14Tex_004DC8" Format="ci8" Width="32" Height="64" Offset="0x4DC8" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BF8" AddedByScript="true"/>
+        <Texture Name="bdan_room_14Tex_0055C8" OutName="bdan_room_14Tex_0055C8" Format="ci8" Width="32" Height="32" Offset="0x55C8" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BF8" AddedByScript="true"/>
+        <Texture Name="bdan_room_14Tex_0059C8" OutName="bdan_room_14Tex_0059C8" Format="ci8" Width="32" Height="64" Offset="0x59C8" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BF8" AddedByScript="true"/>
         <Room Name="bdan_room_14" Offset="0x0"/>
     </File>
     <File Name="bdan_room_15" Segment="3">

--- a/soh/assets/xml/GC_MQ_D/scenes/dungeons/bdan_boss.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/dungeons/bdan_boss.xml
@@ -3,9 +3,17 @@
         <Scene Name="bdan_boss_scene" Offset="0x0"/>
     </File>
     <File Name="bdan_boss_room_0" Segment="3">
+        <Texture Name="bdan_boss_room_0Tex_002040" OutName="bdan_boss_room_0Tex_002040" Format="ci8" Width="32" Height="64" Offset="0x2040" TlutOffset="0x1E38" AddedByScript="true"/>
+        <Texture Name="bdan_boss_room_0Tex_002C18" OutName="bdan_boss_room_0Tex_002C18" Format="ci8" Width="32" Height="32" Offset="0x2C18" TlutOffset="0x2A10" AddedByScript="true"/>
+        <Texture Name="bdan_boss_room_0TLUT_001E38" OutName="bdan_boss_room_0TLUT_001E38" Format="rgba16" Width="16" Height="16" Offset="0x1E38" AddedByScript="true"/>
+        <Texture Name="bdan_boss_room_0TLUT_002A10" OutName="bdan_boss_room_0TLUT_002A10" Format="rgba16" Width="16" Height="16" Offset="0x2A10" AddedByScript="true"/>
         <Room Name="bdan_boss_room_0" Offset="0x0"/>
     </File>
     <File Name="bdan_boss_room_1" Segment="3">
+        <Texture Name="bdan_boss_room_1Tex_003CB8" OutName="bdan_boss_room_1Tex_003CB8" Format="ci8" Width="32" Height="64" Offset="0x3CB8" TlutOffset="0x3AB0" AddedByScript="true"/>
+        <Texture Name="bdan_boss_room_1Tex_0044B8" OutName="bdan_boss_room_1Tex_0044B8" Format="ci8" Width="32" Height="32" Offset="0x44B8" TlutOffset="0x3AB0" AddedByScript="true"/>
+        <Texture Name="bdan_boss_room_1Tex_0048B8" OutName="bdan_boss_room_1Tex_0048B8" Format="ci8" Width="32" Height="64" Offset="0x48B8" TlutOffset="0x3AB0" AddedByScript="true"/>
+        <Texture Name="bdan_boss_room_1TLUT_003AB0" OutName="bdan_boss_room_1TLUT_003AB0" Format="rgba16" Width="16" Height="16" Offset="0x3AB0" AddedByScript="true"/>
         <Room Name="bdan_boss_room_1" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_MQ_D/scenes/dungeons/ddan.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/dungeons/ddan.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="ddan_scene" Segment="2">
+        <Texture Name="ddan_sceneTLUT_011D70" OutName="ddan_sceneTLUT_011D70" Format="rgba16" Width="16" Height="16" Offset="0x11D70" AddedByScript="true"/>
         <Texture Name="gDCDayEntranceTex" OutName="day_entrance" Format="ci8" Width="32" Height="64" Offset="0x12378" TlutOffset="0x11D70"/>
         <Texture Name="gDCNightEntranceTex" OutName="night_entrance" Format="ci8" Width="32" Height="64" Offset="0x13378" TlutOffset="0x11D70"/>
 
@@ -17,54 +18,203 @@
         <Scene Name="ddan_scene" Offset="0x0"/>
     </File>
     <File Name="ddan_room_0" Segment="3">
+        <Texture Name="ddan_room_0Tex_011498" OutName="ddan_room_0Tex_011498" Format="ci8" Width="32" Height="32" Offset="0x11498" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_011898" OutName="ddan_room_0Tex_011898" Format="ci8" Width="32" Height="32" Offset="0x11898" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_011C98" OutName="ddan_room_0Tex_011C98" Format="ci8" Width="64" Height="32" Offset="0x11C98" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_012498" OutName="ddan_room_0Tex_012498" Format="ci8" Width="32" Height="64" Offset="0x12498" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_012C98" OutName="ddan_room_0Tex_012C98" Format="rgba16" Width="32" Height="64" Offset="0x12C98" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_013C98" OutName="ddan_room_0Tex_013C98" Format="rgba16" Width="32" Height="64" Offset="0x13C98" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_014C98" OutName="ddan_room_0Tex_014C98" Format="rgba16" Width="32" Height="32" Offset="0x14C98" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_015498" OutName="ddan_room_0Tex_015498" Format="ci8" Width="32" Height="64" Offset="0x15498" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_015C98" OutName="ddan_room_0Tex_015C98" Format="ci8" Width="32" Height="64" Offset="0x15C98" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_016498" OutName="ddan_room_0Tex_016498" Format="ci8" Width="32" Height="32" Offset="0x16498" TlutOffset="0x11290" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_016898" OutName="ddan_room_0Tex_016898" Format="ci8" Width="32" Height="64" Offset="0x16898" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_017098" OutName="ddan_room_0Tex_017098" Format="rgba16" Width="32" Height="32" Offset="0x17098" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_017898" OutName="ddan_room_0Tex_017898" Format="ci8" Width="32" Height="32" Offset="0x17898" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_017C98" OutName="ddan_room_0Tex_017C98" Format="rgba16" Width="32" Height="32" Offset="0x17C98" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_018498" OutName="ddan_room_0Tex_018498" Format="ci8" Width="32" Height="64" Offset="0x18498" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_018C98" OutName="ddan_room_0Tex_018C98" Format="ci8" Width="32" Height="64" Offset="0x18C98" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_019498" OutName="ddan_room_0Tex_019498" Format="rgba16" Width="64" Height="32" Offset="0x19498" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_01A498" OutName="ddan_room_0Tex_01A498" Format="rgba16" Width="64" Height="32" Offset="0x1A498" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_01B498" OutName="ddan_room_0Tex_01B498" Format="ci8" Width="32" Height="32" Offset="0x1B498" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_0TLUT_011290" OutName="ddan_room_0TLUT_011290" Format="rgba16" Width="16" Height="16" Offset="0x11290" AddedByScript="true"/>
         <Room Name="ddan_room_0" Offset="0x0"/>
     </File>
     <File Name="ddan_room_1" Segment="3">
+        <Texture Name="ddan_room_1Tex_004770" OutName="ddan_room_1Tex_004770" Format="ci8" Width="32" Height="32" Offset="0x4770" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_1Tex_004B70" OutName="ddan_room_1Tex_004B70" Format="ci8" Width="32" Height="32" Offset="0x4B70" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_1Tex_004F70" OutName="ddan_room_1Tex_004F70" Format="ci8" Width="32" Height="64" Offset="0x4F70" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_1Tex_005770" OutName="ddan_room_1Tex_005770" Format="ci8" Width="64" Height="32" Offset="0x5770" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_1Tex_005F70" OutName="ddan_room_1Tex_005F70" Format="rgba16" Width="32" Height="64" Offset="0x5F70" AddedByScript="true"/>
+        <Texture Name="ddan_room_1Tex_006F70" OutName="ddan_room_1Tex_006F70" Format="rgba16" Width="32" Height="64" Offset="0x6F70" AddedByScript="true"/>
+        <Texture Name="ddan_room_1Tex_007F70" OutName="ddan_room_1Tex_007F70" Format="ci8" Width="32" Height="64" Offset="0x7F70" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_1Tex_008770" OutName="ddan_room_1Tex_008770" Format="ci8" Width="64" Height="32" Offset="0x8770" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_1Tex_008F70" OutName="ddan_room_1Tex_008F70" Format="ci8" Width="32" Height="64" Offset="0x8F70" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_1Tex_009770" OutName="ddan_room_1Tex_009770" Format="ci8" Width="32" Height="32" Offset="0x9770" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
         <Room Name="ddan_room_1" Offset="0x0"/>
     </File>
     <File Name="ddan_room_2" Segment="3">
+        <Texture Name="ddan_room_2Tex_003B80" OutName="ddan_room_2Tex_003B80" Format="ci8" Width="64" Height="32" Offset="0x3B80" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_2Tex_004380" OutName="ddan_room_2Tex_004380" Format="ci8" Width="32" Height="32" Offset="0x4380" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_2Tex_004780" OutName="ddan_room_2Tex_004780" Format="ci8" Width="32" Height="32" Offset="0x4780" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_2Tex_004B80" OutName="ddan_room_2Tex_004B80" Format="ci8" Width="32" Height="64" Offset="0x4B80" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_2Tex_005380" OutName="ddan_room_2Tex_005380" Format="ci8" Width="64" Height="32" Offset="0x5380" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_2Tex_005B80" OutName="ddan_room_2Tex_005B80" Format="ci8" Width="32" Height="32" Offset="0x5B80" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_2Tex_005F80" OutName="ddan_room_2Tex_005F80" Format="ci8" Width="32" Height="32" Offset="0x5F80" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_2Tex_006380" OutName="ddan_room_2Tex_006380" Format="ci8" Width="32" Height="32" Offset="0x6380" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_2Tex_006EB8" OutName="ddan_room_2Tex_006EB8" Format="rgba16" Width="32" Height="64" Offset="0x6EB8" AddedByScript="true"/>
         <Room Name="ddan_room_2" Offset="0x0"/>
     </File>
     <File Name="ddan_room_3" Segment="3">
+        <Texture Name="ddan_room_3Tex_008838" OutName="ddan_room_3Tex_008838" Format="ci8" Width="32" Height="32" Offset="0x8838" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_3Tex_008C38" OutName="ddan_room_3Tex_008C38" Format="ci8" Width="64" Height="32" Offset="0x8C38" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_3Tex_009438" OutName="ddan_room_3Tex_009438" Format="ci8" Width="32" Height="32" Offset="0x9438" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_3Tex_009838" OutName="ddan_room_3Tex_009838" Format="ci8" Width="32" Height="64" Offset="0x9838" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_3Tex_00A038" OutName="ddan_room_3Tex_00A038" Format="ci8" Width="32" Height="64" Offset="0xA038" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_3Tex_00A838" OutName="ddan_room_3Tex_00A838" Format="ci8" Width="32" Height="64" Offset="0xA838" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_3Tex_00B038" OutName="ddan_room_3Tex_00B038" Format="ci8" Width="32" Height="32" Offset="0xB038" TlutOffset="0x8630" AddedByScript="true"/>
+        <Texture Name="ddan_room_3Tex_00B438" OutName="ddan_room_3Tex_00B438" Format="ci8" Width="32" Height="32" Offset="0xB438" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_3Tex_00B838" OutName="ddan_room_3Tex_00B838" Format="ci8" Width="32" Height="32" Offset="0xB838" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_3Tex_00BC38" OutName="ddan_room_3Tex_00BC38" Format="ci8" Width="64" Height="32" Offset="0xBC38" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_3Tex_00C438" OutName="ddan_room_3Tex_00C438" Format="ci8" Width="32" Height="64" Offset="0xC438" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_3Tex_00CC38" OutName="ddan_room_3Tex_00CC38" Format="ci8" Width="32" Height="32" Offset="0xCC38" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_3Tex_00D038" OutName="ddan_room_3Tex_00D038" Format="ci8" Width="32" Height="32" Offset="0xD038" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_3Tex_00D668" OutName="ddan_room_3Tex_00D668" Format="ia8" Width="64" Height="32" Offset="0xD668" AddedByScript="true"/>
+        <Texture Name="ddan_room_3TLUT_008630" OutName="ddan_room_3TLUT_008630" Format="rgba16" Width="16" Height="16" Offset="0x8630" AddedByScript="true"/>
         <Room Name="ddan_room_3" Offset="0x0"/>
     </File>
     <File Name="ddan_room_4" Segment="3">
+        <Texture Name="ddan_room_4Tex_006D58" OutName="ddan_room_4Tex_006D58" Format="ci8" Width="32" Height="32" Offset="0x6D58" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_4Tex_007158" OutName="ddan_room_4Tex_007158" Format="ci8" Width="32" Height="32" Offset="0x7158" TlutOffset="0x6B50" AddedByScript="true"/>
+        <Texture Name="ddan_room_4Tex_007558" OutName="ddan_room_4Tex_007558" Format="ci8" Width="64" Height="32" Offset="0x7558" TlutOffset="0x6B50" AddedByScript="true"/>
+        <Texture Name="ddan_room_4Tex_007D58" OutName="ddan_room_4Tex_007D58" Format="ci8" Width="32" Height="64" Offset="0x7D58" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_4Tex_008558" OutName="ddan_room_4Tex_008558" Format="ci8" Width="32" Height="64" Offset="0x8558" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_4Tex_008D58" OutName="ddan_room_4Tex_008D58" Format="ci8" Width="32" Height="32" Offset="0x8D58" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_4Tex_009158" OutName="ddan_room_4Tex_009158" Format="ci8" Width="64" Height="32" Offset="0x9158" TlutOffset="0x6B50" AddedByScript="true"/>
+        <Texture Name="ddan_room_4TLUT_006B50" OutName="ddan_room_4TLUT_006B50" Format="rgba16" Width="16" Height="16" Offset="0x6B50" AddedByScript="true"/>
         <Room Name="ddan_room_4" Offset="0x0"/>
     </File>
     <File Name="ddan_room_5" Segment="3">
+        <Texture Name="ddan_room_5Tex_0032B8" OutName="ddan_room_5Tex_0032B8" Format="ci8" Width="32" Height="64" Offset="0x32B8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_5Tex_003AB8" OutName="ddan_room_5Tex_003AB8" Format="ci8" Width="32" Height="64" Offset="0x3AB8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_5Tex_0042B8" OutName="ddan_room_5Tex_0042B8" Format="ci8" Width="32" Height="32" Offset="0x42B8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_5Tex_0046B8" OutName="ddan_room_5Tex_0046B8" Format="ci8" Width="32" Height="32" Offset="0x46B8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_5Tex_004AB8" OutName="ddan_room_5Tex_004AB8" Format="ci8" Width="32" Height="32" Offset="0x4AB8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_5Tex_004EB8" OutName="ddan_room_5Tex_004EB8" Format="rgba16" Width="32" Height="32" Offset="0x4EB8" AddedByScript="true"/>
+        <Texture Name="ddan_room_5Tex_0056B8" OutName="ddan_room_5Tex_0056B8" Format="ci8" Width="32" Height="64" Offset="0x56B8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
         <Room Name="ddan_room_5" Offset="0x0"/>
     </File>
     <File Name="ddan_room_6" Segment="3">
+        <Texture Name="ddan_room_6Tex_000CA8" OutName="ddan_room_6Tex_000CA8" Format="ci8" Width="32" Height="64" Offset="0xCA8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_6Tex_0014A8" OutName="ddan_room_6Tex_0014A8" Format="ci8" Width="64" Height="32" Offset="0x14A8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_6Tex_001CA8" OutName="ddan_room_6Tex_001CA8" Format="ci8" Width="32" Height="32" Offset="0x1CA8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_6Tex_0020A8" OutName="ddan_room_6Tex_0020A8" Format="ci8" Width="32" Height="32" Offset="0x20A8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
         <Room Name="ddan_room_6" Offset="0x0"/>
     </File>
     <File Name="ddan_room_7" Segment="3">
+        <Texture Name="ddan_room_7Tex_0046F8" OutName="ddan_room_7Tex_0046F8" Format="ci8" Width="32" Height="32" Offset="0x46F8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_7Tex_004AF8" OutName="ddan_room_7Tex_004AF8" Format="ci8" Width="32" Height="32" Offset="0x4AF8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_7Tex_004EF8" OutName="ddan_room_7Tex_004EF8" Format="ci8" Width="32" Height="64" Offset="0x4EF8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_7Tex_0056F8" OutName="ddan_room_7Tex_0056F8" Format="ci8" Width="32" Height="64" Offset="0x56F8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_7Tex_005EF8" OutName="ddan_room_7Tex_005EF8" Format="ci8" Width="32" Height="64" Offset="0x5EF8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_7Tex_0066F8" OutName="ddan_room_7Tex_0066F8" Format="ci8" Width="32" Height="64" Offset="0x66F8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_7Tex_006EF8" OutName="ddan_room_7Tex_006EF8" Format="ci8" Width="32" Height="64" Offset="0x6EF8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
         <Room Name="ddan_room_7" Offset="0x0"/>
     </File>
     <File Name="ddan_room_8" Segment="3">
+        <Texture Name="ddan_room_8Tex_0041A0" OutName="ddan_room_8Tex_0041A0" Format="ci8" Width="64" Height="32" Offset="0x41A0" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_8Tex_0049A0" OutName="ddan_room_8Tex_0049A0" Format="ci8" Width="32" Height="32" Offset="0x49A0" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_8Tex_004DA0" OutName="ddan_room_8Tex_004DA0" Format="ci8" Width="32" Height="32" Offset="0x4DA0" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_8Tex_0051A0" OutName="ddan_room_8Tex_0051A0" Format="ci8" Width="64" Height="32" Offset="0x51A0" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_8Tex_0059A0" OutName="ddan_room_8Tex_0059A0" Format="ci8" Width="32" Height="64" Offset="0x59A0" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_8Tex_0061A0" OutName="ddan_room_8Tex_0061A0" Format="ci8" Width="32" Height="64" Offset="0x61A0" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_8Tex_0069A0" OutName="ddan_room_8Tex_0069A0" Format="ci8" Width="32" Height="64" Offset="0x69A0" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_8Tex_0071A0" OutName="ddan_room_8Tex_0071A0" Format="ci8" Width="32" Height="64" Offset="0x71A0" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_8Tex_0079A0" OutName="ddan_room_8Tex_0079A0" Format="ci8" Width="64" Height="32" Offset="0x79A0" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_8Tex_0081A0" OutName="ddan_room_8Tex_0081A0" Format="ci8" Width="32" Height="64" Offset="0x81A0" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_8Tex_0089A0" OutName="ddan_room_8Tex_0089A0" Format="ci8" Width="32" Height="64" Offset="0x89A0" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_8Tex_0091A0" OutName="ddan_room_8Tex_0091A0" Format="ci8" Width="32" Height="32" Offset="0x91A0" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
         <Room Name="ddan_room_8" Offset="0x0"/>
     </File>
     <File Name="ddan_room_9" Segment="3">
+        <Texture Name="ddan_room_9Tex_005128" OutName="ddan_room_9Tex_005128" Format="ci8" Width="32" Height="32" Offset="0x5128" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_9Tex_005528" OutName="ddan_room_9Tex_005528" Format="ci8" Width="64" Height="32" Offset="0x5528" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_9Tex_005D28" OutName="ddan_room_9Tex_005D28" Format="ci8" Width="32" Height="32" Offset="0x5D28" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_9Tex_006128" OutName="ddan_room_9Tex_006128" Format="ci8" Width="32" Height="64" Offset="0x6128" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_9Tex_006928" OutName="ddan_room_9Tex_006928" Format="ci8" Width="32" Height="32" Offset="0x6928" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_9Tex_006D28" OutName="ddan_room_9Tex_006D28" Format="rgba16" Width="32" Height="64" Offset="0x6D28" AddedByScript="true"/>
+        <Texture Name="ddan_room_9Tex_007D28" OutName="ddan_room_9Tex_007D28" Format="rgba16" Width="32" Height="64" Offset="0x7D28" AddedByScript="true"/>
+        <Texture Name="ddan_room_9Tex_008D28" OutName="ddan_room_9Tex_008D28" Format="ci8" Width="32" Height="32" Offset="0x8D28" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_9Tex_009128" OutName="ddan_room_9Tex_009128" Format="ci8" Width="32" Height="64" Offset="0x9128" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_9Tex_009928" OutName="ddan_room_9Tex_009928" Format="ci8" Width="64" Height="32" Offset="0x9928" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_9Tex_00A128" OutName="ddan_room_9Tex_00A128" Format="rgba16" Width="32" Height="32" Offset="0xA128" AddedByScript="true"/>
+        <Texture Name="ddan_room_9Tex_00A928" OutName="ddan_room_9Tex_00A928" Format="ci8" Width="32" Height="64" Offset="0xA928" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_9Tex_00B128" OutName="ddan_room_9Tex_00B128" Format="ci8" Width="32" Height="32" Offset="0xB128" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
         <Room Name="ddan_room_9" Offset="0x0"/>
     </File>
     <File Name="ddan_room_10" Segment="3">
+        <Texture Name="ddan_room_10Tex_002B10" OutName="ddan_room_10Tex_002B10" Format="ci8" Width="32" Height="32" Offset="0x2B10" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_10Tex_002F10" OutName="ddan_room_10Tex_002F10" Format="ci8" Width="64" Height="32" Offset="0x2F10" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_10Tex_003710" OutName="ddan_room_10Tex_003710" Format="ci8" Width="32" Height="32" Offset="0x3710" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_10Tex_003B10" OutName="ddan_room_10Tex_003B10" Format="ci8" Width="32" Height="64" Offset="0x3B10" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_10Tex_004310" OutName="ddan_room_10Tex_004310" Format="ci8" Width="32" Height="32" Offset="0x4310" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_10Tex_004710" OutName="ddan_room_10Tex_004710" Format="ci8" Width="32" Height="64" Offset="0x4710" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_10Tex_004F10" OutName="ddan_room_10Tex_004F10" Format="ci8" Width="32" Height="32" Offset="0x4F10" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_10Tex_005310" OutName="ddan_room_10Tex_005310" Format="rgba16" Width="32" Height="64" Offset="0x5310" AddedByScript="true"/>
+        <Texture Name="ddan_room_10Tex_006310" OutName="ddan_room_10Tex_006310" Format="rgba16" Width="32" Height="64" Offset="0x6310" AddedByScript="true"/>
+        <Texture Name="ddan_room_10Tex_007310" OutName="ddan_room_10Tex_007310" Format="ci8" Width="32" Height="64" Offset="0x7310" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_10Tex_007B10" OutName="ddan_room_10Tex_007B10" Format="ci8" Width="32" Height="32" Offset="0x7B10" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
         <Room Name="ddan_room_10" Offset="0x0"/>
     </File>
     <File Name="ddan_room_11" Segment="3">
+        <Texture Name="ddan_room_11Tex_000C30" OutName="ddan_room_11Tex_000C30" Format="ci8" Width="32" Height="64" Offset="0xC30" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_11Tex_001430" OutName="ddan_room_11Tex_001430" Format="ci8" Width="64" Height="32" Offset="0x1430" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_11Tex_001C30" OutName="ddan_room_11Tex_001C30" Format="ci8" Width="32" Height="32" Offset="0x1C30" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
         <Room Name="ddan_room_11" Offset="0x0"/>
     </File>
     <File Name="ddan_room_12" Segment="3">
+        <Texture Name="ddan_room_12Tex_002F80" OutName="ddan_room_12Tex_002F80" Format="ci8" Width="32" Height="32" Offset="0x2F80" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_12Tex_003380" OutName="ddan_room_12Tex_003380" Format="ci8" Width="64" Height="32" Offset="0x3380" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_12Tex_003B80" OutName="ddan_room_12Tex_003B80" Format="ci8" Width="32" Height="32" Offset="0x3B80" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_12Tex_003F80" OutName="ddan_room_12Tex_003F80" Format="ci8" Width="32" Height="64" Offset="0x3F80" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_12Tex_004780" OutName="ddan_room_12Tex_004780" Format="ci8" Width="32" Height="32" Offset="0x4780" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_12Tex_004B80" OutName="ddan_room_12Tex_004B80" Format="ci8" Width="32" Height="64" Offset="0x4B80" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_12Tex_005380" OutName="ddan_room_12Tex_005380" Format="ci8" Width="32" Height="32" Offset="0x5380" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_12Tex_005780" OutName="ddan_room_12Tex_005780" Format="rgba16" Width="32" Height="64" Offset="0x5780" AddedByScript="true"/>
+        <Texture Name="ddan_room_12Tex_006780" OutName="ddan_room_12Tex_006780" Format="rgba16" Width="32" Height="64" Offset="0x6780" AddedByScript="true"/>
+        <Texture Name="ddan_room_12Tex_007780" OutName="ddan_room_12Tex_007780" Format="ci8" Width="32" Height="32" Offset="0x7780" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_12Tex_007B80" OutName="ddan_room_12Tex_007B80" Format="ci8" Width="32" Height="64" Offset="0x7B80" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_12Tex_008380" OutName="ddan_room_12Tex_008380" Format="ci8" Width="32" Height="32" Offset="0x8380" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
         <Room Name="ddan_room_12" Offset="0x0"/>
     </File>
     <File Name="ddan_room_13" Segment="3">
+        <Texture Name="ddan_room_13Tex_000CC8" OutName="ddan_room_13Tex_000CC8" Format="ci8" Width="32" Height="64" Offset="0xCC8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_13Tex_0014C8" OutName="ddan_room_13Tex_0014C8" Format="ci8" Width="64" Height="32" Offset="0x14C8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_13Tex_001CC8" OutName="ddan_room_13Tex_001CC8" Format="ci8" Width="32" Height="32" Offset="0x1CC8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_13Tex_0020C8" OutName="ddan_room_13Tex_0020C8" Format="ci8" Width="32" Height="32" Offset="0x20C8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
         <Room Name="ddan_room_13" Offset="0x0"/>
     </File>
     <File Name="ddan_room_14" Segment="3">
+        <Texture Name="ddan_room_14Tex_000CC8" OutName="ddan_room_14Tex_000CC8" Format="ci8" Width="32" Height="64" Offset="0xCC8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_14Tex_0014C8" OutName="ddan_room_14Tex_0014C8" Format="ci8" Width="64" Height="32" Offset="0x14C8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_14Tex_001CC8" OutName="ddan_room_14Tex_001CC8" Format="ci8" Width="32" Height="32" Offset="0x1CC8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_14Tex_0020C8" OutName="ddan_room_14Tex_0020C8" Format="ci8" Width="32" Height="32" Offset="0x20C8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
         <Room Name="ddan_room_14" Offset="0x0"/>
     </File>
     <File Name="ddan_room_15" Segment="3">
+        <Texture Name="ddan_room_15Tex_000D28" OutName="ddan_room_15Tex_000D28" Format="ci8" Width="64" Height="32" Offset="0xD28" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_15Tex_001528" OutName="ddan_room_15Tex_001528" Format="ci8" Width="32" Height="64" Offset="0x1528" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_15Tex_001D28" OutName="ddan_room_15Tex_001D28" Format="ci8" Width="64" Height="32" Offset="0x1D28" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_15Tex_002528" OutName="ddan_room_15Tex_002528" Format="ci8" Width="32" Height="32" Offset="0x2528" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
         <Room Name="ddan_room_15" Offset="0x0"/>
     </File>
     <File Name="ddan_room_16" Segment="3">
+        <Texture Name="ddan_room_16Tex_002158" OutName="ddan_room_16Tex_002158" Format="rgba16" Width="32" Height="64" Offset="0x2158" AddedByScript="true"/>
+        <Texture Name="ddan_room_16Tex_003158" OutName="ddan_room_16Tex_003158" Format="ci8" Width="32" Height="64" Offset="0x3158" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_16Tex_003958" OutName="ddan_room_16Tex_003958" Format="ci8" Width="32" Height="64" Offset="0x3958" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_16Tex_004158" OutName="ddan_room_16Tex_004158" Format="ci8" Width="32" Height="64" Offset="0x4158" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_16Tex_004958" OutName="ddan_room_16Tex_004958" Format="ci8" Width="32" Height="64" Offset="0x4958" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_16Tex_005158" OutName="ddan_room_16Tex_005158" Format="ci8" Width="32" Height="32" Offset="0x5158" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
         <Room Name="ddan_room_16" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_MQ_D/scenes/dungeons/ddan_boss.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/dungeons/ddan_boss.xml
@@ -1,11 +1,21 @@
 <Root>
     <File Name="ddan_boss_scene" Segment="2">
+        <Texture Name="ddan_boss_sceneTex_001058" OutName="ddan_boss_sceneTex_001058" Format="ci8" Width="32" Height="64" Offset="0x1058" TlutOffset="0xE50" AddedByScript="true"/>
+        <Texture Name="ddan_boss_sceneTex_001858" OutName="ddan_boss_sceneTex_001858" Format="ci8" Width="32" Height="64" Offset="0x1858" TlutOffset="0xE50" AddedByScript="true"/>
+        <Texture Name="ddan_boss_sceneTex_002058" OutName="ddan_boss_sceneTex_002058" Format="ci8" Width="32" Height="64" Offset="0x2058" TlutOffset="0xE50" AddedByScript="true"/>
+        <Texture Name="ddan_boss_sceneTLUT_000E50" OutName="ddan_boss_sceneTLUT_000E50" Format="rgba16" Width="16" Height="16" Offset="0xE50" AddedByScript="true"/>
         <Scene Name="ddan_boss_scene" Offset="0x0"/>
     </File>
     <File Name="ddan_boss_room_0" Segment="3">
+        <Texture Name="ddan_boss_room_0Tex_003628" OutName="ddan_boss_room_0Tex_003628" Format="ci8" Width="32" Height="32" Offset="0x3628" ExternalTlut="ddan_boss_scene" ExternalTlutOffset="0xE50" AddedByScript="true"/>
+        <Texture Name="ddan_boss_room_0Tex_003A28" OutName="ddan_boss_room_0Tex_003A28" Format="ci8" Width="32" Height="32" Offset="0x3A28" ExternalTlut="ddan_boss_scene" ExternalTlutOffset="0xE50" AddedByScript="true"/>
+        <Texture Name="ddan_boss_room_0Tex_003E28" OutName="ddan_boss_room_0Tex_003E28" Format="ci8" Width="32" Height="64" Offset="0x3E28" ExternalTlut="ddan_boss_scene" ExternalTlutOffset="0xE50" AddedByScript="true"/>
+        <Texture Name="ddan_boss_room_0Tex_004628" OutName="ddan_boss_room_0Tex_004628" Format="ci8" Width="32" Height="64" Offset="0x4628" ExternalTlut="ddan_boss_scene" ExternalTlutOffset="0xE50" AddedByScript="true"/>
         <Room Name="ddan_boss_room_0" Offset="0x0"/>
     </File>
     <File Name="ddan_boss_room_1" Segment="3">
+        <Texture Name="ddan_boss_room_1Tex_0031D8" OutName="ddan_boss_room_1Tex_0031D8" Format="ci8" Width="32" Height="64" Offset="0x31D8" ExternalTlut="ddan_boss_scene" ExternalTlutOffset="0xE50" AddedByScript="true"/>
+        <Texture Name="ddan_boss_room_1Tex_0039D8" OutName="ddan_boss_room_1Tex_0039D8" Format="ci8" Width="32" Height="32" Offset="0x39D8" ExternalTlut="ddan_boss_scene" ExternalTlutOffset="0xE50" AddedByScript="true"/>
         <Texture Name="gDodongosCavernBossLavaFloorTex" OutName="lava_floor" Format="rgba16" Width="32" Height="64" Offset="0x21D8"/>
         <Room Name="ddan_boss_room_1" Offset="0x0"/>
     </File>

--- a/soh/assets/xml/GC_MQ_D/scenes/dungeons/ganon.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/dungeons/ganon.xml
@@ -1,35 +1,121 @@
 <Root>
     <File Name="ganon_scene" Segment="2">
+        <Texture Name="ganon_sceneTex_00EFA8" OutName="ganon_sceneTex_00EFA8" Format="ci8" Width="32" Height="32" Offset="0xEFA8" TlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_sceneTex_00F3A8" OutName="ganon_sceneTex_00F3A8" Format="ci8" Width="32" Height="32" Offset="0xF3A8" TlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_sceneTex_00F7A8" OutName="ganon_sceneTex_00F7A8" Format="ci8" Width="32" Height="32" Offset="0xF7A8" TlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_sceneTex_00FBA8" OutName="ganon_sceneTex_00FBA8" Format="ci8" Width="32" Height="32" Offset="0xFBA8" TlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_sceneTex_00FFA8" OutName="ganon_sceneTex_00FFA8" Format="rgba16" Width="32" Height="32" Offset="0xFFA8" AddedByScript="true"/>
+        <Texture Name="ganon_sceneTLUT_00E7D0" OutName="ganon_sceneTLUT_00E7D0" Format="rgba16" Width="16" Height="16" Offset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_sceneTLUT_00E9D8" OutName="ganon_sceneTLUT_00E9D8" Format="rgba16" Width="16" Height="16" Offset="0xE9D8" AddedByScript="true"/>
+        <Texture Name="ganon_sceneTLUT_00EBE0" OutName="ganon_sceneTLUT_00EBE0" Format="rgba16" Width="16" Height="16" Offset="0xEBE0" AddedByScript="true"/>
+        <Texture Name="ganon_sceneTLUT_00EDA0" OutName="ganon_sceneTLUT_00EDA0" Format="rgba16" Width="16" Height="16" Offset="0xEDA0" AddedByScript="true"/>
         <Scene Name="ganon_scene" Offset="0x0"/>
     </File>
     <File Name="ganon_room_0" Segment="3">
+        <Texture Name="ganon_room_0Tex_004C68" OutName="ganon_room_0Tex_004C68" Format="ci8" Width="32" Height="64" Offset="0x4C68" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_0Tex_005468" OutName="ganon_room_0Tex_005468" Format="ci8" Width="32" Height="64" Offset="0x5468" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_0Tex_005C68" OutName="ganon_room_0Tex_005C68" Format="ci8" Width="32" Height="32" Offset="0x5C68" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_0Tex_006068" OutName="ganon_room_0Tex_006068" Format="ci8" Width="64" Height="32" Offset="0x6068" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_0Tex_006868" OutName="ganon_room_0Tex_006868" Format="ci8" Width="64" Height="32" Offset="0x6868" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_0Tex_007068" OutName="ganon_room_0Tex_007068" Format="ci8" Width="32" Height="32" Offset="0x7068" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_0Tex_0076D0" OutName="ganon_room_0Tex_0076D0" Format="ia16" Width="32" Height="32" Offset="0x76D0" AddedByScript="true"/>
         <Room Name="ganon_room_0" Offset="0x0"/>
     </File>
     <File Name="ganon_room_1" Segment="3">
+        <Texture Name="ganon_room_1Tex_005370" OutName="ganon_room_1Tex_005370" Format="ci8" Width="64" Height="32" Offset="0x5370" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_1Tex_005B70" OutName="ganon_room_1Tex_005B70" Format="ci8" Width="32" Height="32" Offset="0x5B70" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_1Tex_005F70" OutName="ganon_room_1Tex_005F70" Format="ci8" Width="32" Height="32" Offset="0x5F70" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_1Tex_006370" OutName="ganon_room_1Tex_006370" Format="ci8" Width="32" Height="32" Offset="0x6370" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_1Tex_006770" OutName="ganon_room_1Tex_006770" Format="rgba16" Width="32" Height="64" Offset="0x6770" AddedByScript="true"/>
         <Room Name="ganon_room_1" Offset="0x0"/>
     </File>
     <File Name="ganon_room_2" Segment="3">
+        <Texture Name="ganon_room_2Tex_003DF0" OutName="ganon_room_2Tex_003DF0" Format="ci8" Width="32" Height="32" Offset="0x3DF0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_2Tex_0041F0" OutName="ganon_room_2Tex_0041F0" Format="ci8" Width="32" Height="64" Offset="0x41F0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_2Tex_0049F0" OutName="ganon_room_2Tex_0049F0" Format="ci8" Width="32" Height="32" Offset="0x49F0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_2Tex_004DF0" OutName="ganon_room_2Tex_004DF0" Format="ci8" Width="32" Height="32" Offset="0x4DF0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_2Tex_0051F0" OutName="ganon_room_2Tex_0051F0" Format="ci8" Width="32" Height="64" Offset="0x51F0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_2Tex_0059F0" OutName="ganon_room_2Tex_0059F0" Format="ci8" Width="32" Height="32" Offset="0x59F0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_2Tex_005DF0" OutName="ganon_room_2Tex_005DF0" Format="rgba16" Width="32" Height="64" Offset="0x5DF0" AddedByScript="true"/>
+        <Texture Name="ganon_room_2Tex_007050" OutName="ganon_room_2Tex_007050" Format="ia16" Width="32" Height="32" Offset="0x7050" AddedByScript="true"/>
         <Room Name="ganon_room_2" Offset="0x0"/>
     </File>
     <File Name="ganon_room_3" Segment="3">
+        <Texture Name="ganon_room_3Tex_004F30" OutName="ganon_room_3Tex_004F30" Format="ci8" Width="32" Height="32" Offset="0x4F30" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_3Tex_005330" OutName="ganon_room_3Tex_005330" Format="ci8" Width="32" Height="32" Offset="0x5330" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_3Tex_005730" OutName="ganon_room_3Tex_005730" Format="ci8" Width="32" Height="64" Offset="0x5730" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_3Tex_005F30" OutName="ganon_room_3Tex_005F30" Format="ci8" Width="32" Height="64" Offset="0x5F30" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_3Tex_006730" OutName="ganon_room_3Tex_006730" Format="rgba16" Width="32" Height="64" Offset="0x6730" AddedByScript="true"/>
         <Room Name="ganon_room_3" Offset="0x0"/>
     </File>
     <File Name="ganon_room_4" Segment="3">
+        <Texture Name="ganon_room_4Tex_004668" OutName="ganon_room_4Tex_004668" Format="ci8" Width="32" Height="64" Offset="0x4668" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_4Tex_004E68" OutName="ganon_room_4Tex_004E68" Format="ci8" Width="32" Height="64" Offset="0x4E68" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_4Tex_005668" OutName="ganon_room_4Tex_005668" Format="ci8" Width="32" Height="32" Offset="0x5668" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_4Tex_005A68" OutName="ganon_room_4Tex_005A68" Format="ci8" Width="32" Height="64" Offset="0x5A68" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_4Tex_006268" OutName="ganon_room_4Tex_006268" Format="ci8" Width="32" Height="32" Offset="0x6268" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_4Tex_006668" OutName="ganon_room_4Tex_006668" Format="ci8" Width="32" Height="32" Offset="0x6668" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_4Tex_006A68" OutName="ganon_room_4Tex_006A68" Format="ci8" Width="32" Height="32" Offset="0x6A68" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_4Tex_006E68" OutName="ganon_room_4Tex_006E68" Format="ci8" Width="32" Height="64" Offset="0x6E68" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_4Tex_007668" OutName="ganon_room_4Tex_007668" Format="ci8" Width="32" Height="64" Offset="0x7668" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_4Tex_007E68" OutName="ganon_room_4Tex_007E68" Format="ci8" Width="32" Height="64" Offset="0x7E68" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_4Tex_0088D0" OutName="ganon_room_4Tex_0088D0" Format="ia16" Width="32" Height="32" Offset="0x88D0" AddedByScript="true"/>
         <Room Name="ganon_room_4" Offset="0x0"/>
     </File>
     <File Name="ganon_room_5" Segment="3">
+        <Texture Name="ganon_room_5Tex_005B08" OutName="ganon_room_5Tex_005B08" Format="ci8" Width="32" Height="64" Offset="0x5B08" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_5Tex_006308" OutName="ganon_room_5Tex_006308" Format="ci8" Width="32" Height="64" Offset="0x6308" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_5Tex_006B08" OutName="ganon_room_5Tex_006B08" Format="rgba16" Width="32" Height="64" Offset="0x6B08" AddedByScript="true"/>
+        <Texture Name="ganon_room_5Tex_007B08" OutName="ganon_room_5Tex_007B08" Format="ci8" Width="32" Height="32" Offset="0x7B08" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_5Tex_007F08" OutName="ganon_room_5Tex_007F08" Format="ci8" Width="32" Height="32" Offset="0x7F08" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_5Tex_008308" OutName="ganon_room_5Tex_008308" Format="ci8" Width="32" Height="64" Offset="0x8308" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
         <Room Name="ganon_room_5" Offset="0x0"/>
     </File>
     <File Name="ganon_room_6" Segment="3">
+        <Texture Name="ganon_room_6Tex_006E00" OutName="ganon_room_6Tex_006E00" Format="ci8" Width="32" Height="32" Offset="0x6E00" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_6Tex_007200" OutName="ganon_room_6Tex_007200" Format="ci8" Width="32" Height="32" Offset="0x7200" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_6Tex_007600" OutName="ganon_room_6Tex_007600" Format="ci8" Width="32" Height="32" Offset="0x7600" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_6Tex_007A00" OutName="ganon_room_6Tex_007A00" Format="ci8" Width="32" Height="64" Offset="0x7A00" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_6Tex_008200" OutName="ganon_room_6Tex_008200" Format="ci8" Width="16" Height="16" Offset="0x8200" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEBE0" AddedByScript="true"/>
+        <Texture Name="ganon_room_6Tex_008300" OutName="ganon_room_6Tex_008300" Format="ci8" Width="32" Height="64" Offset="0x8300" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_6Tex_008B00" OutName="ganon_room_6Tex_008B00" Format="ci8" Width="32" Height="32" Offset="0x8B00" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEBE0" AddedByScript="true"/>
+        <Texture Name="ganon_room_6Tex_009398" OutName="ganon_room_6Tex_009398" Format="rgba16" Width="32" Height="32" Offset="0x9398" AddedByScript="true"/>
         <Room Name="ganon_room_6" Offset="0x0"/>
     </File>
     <File Name="ganon_room_7" Segment="3">
+        <Texture Name="ganon_room_7Tex_0071E0" OutName="ganon_room_7Tex_0071E0" Format="ci8" Width="32" Height="32" Offset="0x71E0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_7Tex_0075E0" OutName="ganon_room_7Tex_0075E0" Format="ci8" Width="64" Height="32" Offset="0x75E0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_7Tex_007DE0" OutName="ganon_room_7Tex_007DE0" Format="ci8" Width="64" Height="32" Offset="0x7DE0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_7Tex_0085E0" OutName="ganon_room_7Tex_0085E0" Format="ci8" Width="32" Height="32" Offset="0x85E0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_7Tex_0089E0" OutName="ganon_room_7Tex_0089E0" Format="ci8" Width="32" Height="64" Offset="0x89E0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_7Tex_0091E0" OutName="ganon_room_7Tex_0091E0" Format="ci8" Width="32" Height="64" Offset="0x91E0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_7Tex_009F98" OutName="ganon_room_7Tex_009F98" Format="rgba16" Width="32" Height="32" Offset="0x9F98" AddedByScript="true"/>
         <Room Name="ganon_room_7" Offset="0x0"/>
     </File>
     <File Name="ganon_room_8" Segment="3">
+        <Texture Name="ganon_room_8Tex_004A20" OutName="ganon_room_8Tex_004A20" Format="ci8" Width="32" Height="64" Offset="0x4A20" TlutOffset="0x4950" AddedByScript="true"/>
+        <Texture Name="ganon_room_8Tex_005220" OutName="ganon_room_8Tex_005220" Format="ci8" Width="16" Height="16" Offset="0x5220" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEBE0" AddedByScript="true"/>
+        <Texture Name="ganon_room_8Tex_005320" OutName="ganon_room_8Tex_005320" Format="ci8" Width="8" Height="8" Offset="0x5320" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEBE0" AddedByScript="true"/>
+        <Texture Name="ganon_room_8Tex_005360" OutName="ganon_room_8Tex_005360" Format="ci8" Width="16" Height="8" Offset="0x5360" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEBE0" AddedByScript="true"/>
+        <Texture Name="ganon_room_8Tex_0053E0" OutName="ganon_room_8Tex_0053E0" Format="ci8" Width="32" Height="64" Offset="0x53E0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE9D8" AddedByScript="true"/>
+        <Texture Name="ganon_room_8Tex_005BE0" OutName="ganon_room_8Tex_005BE0" Format="ci8" Width="32" Height="32" Offset="0x5BE0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEBE0" AddedByScript="true"/>
+        <Texture Name="ganon_room_8Tex_005FE0" OutName="ganon_room_8Tex_005FE0" Format="ci8" Width="32" Height="32" Offset="0x5FE0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_8Tex_0063E0" OutName="ganon_room_8Tex_0063E0" Format="ci8" Width="32" Height="64" Offset="0x63E0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_8TLUT_004950" OutName="ganon_room_8TLUT_004950" Format="rgba16" Width="16" Height="16" Offset="0x4950" AddedByScript="true"/>
         <Room Name="ganon_room_8" Offset="0x0"/>
     </File>
     <File Name="ganon_room_9" Segment="3">
+        <Texture Name="ganon_room_9Tex_002120" OutName="ganon_room_9Tex_002120" Format="ci8" Width="32" Height="64" Offset="0x2120" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE9D8" AddedByScript="true"/>
+        <Texture Name="ganon_room_9Tex_002920" OutName="ganon_room_9Tex_002920" Format="ci8" Width="32" Height="32" Offset="0x2920" TlutOffset="0x1F18" AddedByScript="true"/>
+        <Texture Name="ganon_room_9Tex_002D20" OutName="ganon_room_9Tex_002D20" Format="ci8" Width="32" Height="32" Offset="0x2D20" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEBE0" AddedByScript="true"/>
+        <Texture Name="ganon_room_9Tex_003120" OutName="ganon_room_9Tex_003120" Format="ci8" Width="32" Height="32" Offset="0x3120" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEBE0" AddedByScript="true"/>
+        <Texture Name="ganon_room_9Tex_003520" OutName="ganon_room_9Tex_003520" Format="ci8" Width="32" Height="32" Offset="0x3520" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEBE0" AddedByScript="true"/>
+        <Texture Name="ganon_room_9Tex_003920" OutName="ganon_room_9Tex_003920" Format="ci8" Width="32" Height="32" Offset="0x3920" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_9Tex_003D20" OutName="ganon_room_9Tex_003D20" Format="ci8" Width="32" Height="64" Offset="0x3D20" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE9D8" AddedByScript="true"/>
+        <Texture Name="ganon_room_9Tex_004520" OutName="ganon_room_9Tex_004520" Format="ci8" Width="32" Height="64" Offset="0x4520" TlutOffset="0x1F18" AddedByScript="true"/>
+        <Texture Name="ganon_room_9Tex_004D20" OutName="ganon_room_9Tex_004D20" Format="ci8" Width="16" Height="64" Offset="0x4D20" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEBE0" AddedByScript="true"/>
+        <Texture Name="ganon_room_9Tex_005120" OutName="ganon_room_9Tex_005120" Format="ci8" Width="32" Height="64" Offset="0x5120" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_9TLUT_001F18" OutName="ganon_room_9TLUT_001F18" Format="rgba16" Width="16" Height="16" Offset="0x1F18" AddedByScript="true"/>
         <Room Name="ganon_room_9" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_MQ_D/scenes/dungeons/ganon_boss.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/dungeons/ganon_boss.xml
@@ -1,5 +1,28 @@
 <Root>
     <File Name="ganon_boss_scene" Segment="2">
+        <Texture Name="ganon_boss_sceneTex_001E58" OutName="ganon_boss_sceneTex_001E58" Format="ci8" Width="32" Height="64" Offset="0x1E58" TlutOffset="0x1550" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_002658" OutName="ganon_boss_sceneTex_002658" Format="ci8" Width="16" Height="16" Offset="0x2658" TlutOffset="0x1A90" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_002758" OutName="ganon_boss_sceneTex_002758" Format="ci8" Width="8" Height="8" Offset="0x2758" TlutOffset="0x1A90" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_002798" OutName="ganon_boss_sceneTex_002798" Format="ci8" Width="32" Height="32" Offset="0x2798" TlutOffset="0x1C50" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_002B98" OutName="ganon_boss_sceneTex_002B98" Format="ci8" Width="16" Height="8" Offset="0x2B98" TlutOffset="0x1A90" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_002C18" OutName="ganon_boss_sceneTex_002C18" Format="rgba16" Width="32" Height="64" Offset="0x2C18" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_003C18" OutName="ganon_boss_sceneTex_003C18" Format="ci8" Width="32" Height="32" Offset="0x3C18" TlutOffset="0x1620" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_004018" OutName="ganon_boss_sceneTex_004018" Format="ci8" Width="32" Height="32" Offset="0x4018" TlutOffset="0x1888" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_004418" OutName="ganon_boss_sceneTex_004418" Format="ci8" Width="32" Height="32" Offset="0x4418" TlutOffset="0x1A90" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_004818" OutName="ganon_boss_sceneTex_004818" Format="ci8" Width="32" Height="32" Offset="0x4818" TlutOffset="0x1A90" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_004C18" OutName="ganon_boss_sceneTex_004C18" Format="ci8" Width="32" Height="32" Offset="0x4C18" TlutOffset="0x1A90" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_005018" OutName="ganon_boss_sceneTex_005018" Format="rgba16" Width="32" Height="32" Offset="0x5018" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_005818" OutName="ganon_boss_sceneTex_005818" Format="ci8" Width="32" Height="64" Offset="0x5818" TlutOffset="0x1888" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_006018" OutName="ganon_boss_sceneTex_006018" Format="ci8" Width="16" Height="64" Offset="0x6018" TlutOffset="0x1A90" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_006418" OutName="ganon_boss_sceneTex_006418" Format="ci8" Width="32" Height="64" Offset="0x6418" TlutOffset="0x1C50" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_006C18" OutName="ganon_boss_sceneTex_006C18" Format="ci8" Width="32" Height="64" Offset="0x6C18" TlutOffset="0x1680" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_007418" OutName="ganon_boss_sceneTex_007418" Format="ci8" Width="32" Height="64" Offset="0x7418" TlutOffset="0x1680" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTLUT_001550" OutName="ganon_boss_sceneTLUT_001550" Format="rgba16" Width="16" Height="16" Offset="0x1550" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTLUT_001620" OutName="ganon_boss_sceneTLUT_001620" Format="rgba16" Width="16" Height="16" Offset="0x1620" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTLUT_001680" OutName="ganon_boss_sceneTLUT_001680" Format="rgba16" Width="16" Height="16" Offset="0x1680" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTLUT_001888" OutName="ganon_boss_sceneTLUT_001888" Format="rgba16" Width="16" Height="16" Offset="0x1888" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTLUT_001A90" OutName="ganon_boss_sceneTLUT_001A90" Format="rgba16" Width="16" Height="16" Offset="0x1A90" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTLUT_001C50" OutName="ganon_boss_sceneTLUT_001C50" Format="rgba16" Width="16" Height="16" Offset="0x1C50" AddedByScript="true"/>
         <Scene Name="ganon_boss_scene" Offset="0x0"/>
     </File>
     <File Name="ganon_boss_room_0" Segment="3">

--- a/soh/assets/xml/GC_MQ_D/scenes/dungeons/ganon_demo.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/dungeons/ganon_demo.xml
@@ -1,5 +1,16 @@
 <Root>
     <File Name="ganon_demo_scene" Segment="2">
+        <Texture Name="ganon_demo_sceneTex_001B70" OutName="ganon_demo_sceneTex_001B70" Format="i8" Width="128" Height="32" Offset="0x1B70" AddedByScript="true"/>
+        <Texture Name="ganon_demo_sceneTex_002B70" OutName="ganon_demo_sceneTex_002B70" Format="i8" Width="64" Height="64" Offset="0x2B70" AddedByScript="true"/>
+        <Texture Name="ganon_demo_sceneTex_003B70" OutName="ganon_demo_sceneTex_003B70" Format="i8" Width="64" Height="64" Offset="0x3B70" AddedByScript="true"/>
+        <Texture Name="ganon_demo_sceneTex_004B70" OutName="ganon_demo_sceneTex_004B70" Format="i8" Width="64" Height="64" Offset="0x4B70" AddedByScript="true"/>
+        <Texture Name="ganon_demo_sceneTex_005B70" OutName="ganon_demo_sceneTex_005B70" Format="rgba16" Width="64" Height="16" Offset="0x5B70" AddedByScript="true"/>
+        <Texture Name="ganon_demo_sceneTex_006370" OutName="ganon_demo_sceneTex_006370" Format="rgba16" Width="32" Height="32" Offset="0x6370" AddedByScript="true"/>
+        <Texture Name="ganon_demo_sceneTex_006B70" OutName="ganon_demo_sceneTex_006B70" Format="ia4" Width="128" Height="32" Offset="0x6B70" AddedByScript="true"/>
+        <Texture Name="ganon_demo_sceneTex_007370" OutName="ganon_demo_sceneTex_007370" Format="rgba16" Width="32" Height="64" Offset="0x7370" AddedByScript="true"/>
+        <Texture Name="ganon_demo_sceneTex_008370" OutName="ganon_demo_sceneTex_008370" Format="rgba16" Width="16" Height="32" Offset="0x8370" AddedByScript="true"/>
+        <Texture Name="ganon_demo_sceneTex_008770" OutName="ganon_demo_sceneTex_008770" Format="i8" Width="16" Height="16" Offset="0x8770" AddedByScript="true"/>
+        <Texture Name="ganon_demo_sceneTex_008870" OutName="ganon_demo_sceneTex_008870" Format="rgba16" Width="32" Height="32" Offset="0x8870" AddedByScript="true"/>
         <Scene Name="ganon_demo_scene" Offset="0x0"/>
     </File>
     <File Name="ganon_demo_room_0" Segment="3">

--- a/soh/assets/xml/GC_MQ_D/scenes/dungeons/ganon_final.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/dungeons/ganon_final.xml
@@ -1,5 +1,30 @@
 <Root>
     <File Name="ganon_final_scene" Segment="2">
+        <Texture Name="ganon_final_sceneTex_002380" OutName="ganon_final_sceneTex_002380" Format="ia8" Width="32" Height="32" Offset="0x2380" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_002780" OutName="ganon_final_sceneTex_002780" Format="rgba16" Width="16" Height="16" Offset="0x2780" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_002980" OutName="ganon_final_sceneTex_002980" Format="i8" Width="64" Height="16" Offset="0x2980" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_002D80" OutName="ganon_final_sceneTex_002D80" Format="i4" Width="64" Height="128" Offset="0x2D80" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_003D80" OutName="ganon_final_sceneTex_003D80" Format="i8" Width="32" Height="64" Offset="0x3D80" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_004580" OutName="ganon_final_sceneTex_004580" Format="i8" Width="32" Height="64" Offset="0x4580" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_004D80" OutName="ganon_final_sceneTex_004D80" Format="i8" Width="64" Height="64" Offset="0x4D80" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_005D80" OutName="ganon_final_sceneTex_005D80" Format="i4" Width="64" Height="128" Offset="0x5D80" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_006D80" OutName="ganon_final_sceneTex_006D80" Format="ia8" Width="64" Height="32" Offset="0x6D80" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_007580" OutName="ganon_final_sceneTex_007580" Format="i4" Width="64" Height="128" Offset="0x7580" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_008580" OutName="ganon_final_sceneTex_008580" Format="rgba16" Width="32" Height="64" Offset="0x8580" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_009580" OutName="ganon_final_sceneTex_009580" Format="rgba16" Width="32" Height="64" Offset="0x9580" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_00A580" OutName="ganon_final_sceneTex_00A580" Format="ia4" Width="128" Height="32" Offset="0xA580" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_00AD80" OutName="ganon_final_sceneTex_00AD80" Format="rgba16" Width="32" Height="64" Offset="0xAD80" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_00BD80" OutName="ganon_final_sceneTex_00BD80" Format="rgba16" Width="32" Height="64" Offset="0xBD80" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_00CD80" OutName="ganon_final_sceneTex_00CD80" Format="i8" Width="16" Height="16" Offset="0xCD80" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_00CE80" OutName="ganon_final_sceneTex_00CE80" Format="ia8" Width="64" Height="64" Offset="0xCE80" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_00DE80" OutName="ganon_final_sceneTex_00DE80" Format="i4" Width="64" Height="16" Offset="0xDE80" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_00E080" OutName="ganon_final_sceneTex_00E080" Format="ia8" Width="16" Height="16" Offset="0xE080" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_00E180" OutName="ganon_final_sceneTex_00E180" Format="i4" Width="128" Height="64" Offset="0xE180" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_00F180" OutName="ganon_final_sceneTex_00F180" Format="i8" Width="32" Height="32" Offset="0xF180" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_00F580" OutName="ganon_final_sceneTex_00F580" Format="i8" Width="128" Height="32" Offset="0xF580" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_010580" OutName="ganon_final_sceneTex_010580" Format="i8" Width="32" Height="32" Offset="0x10580" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_010980" OutName="ganon_final_sceneTex_010980" Format="rgba16" Width="16" Height="64" Offset="0x10980" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_011180" OutName="ganon_final_sceneTex_011180" Format="i8" Width="16" Height="256" Offset="0x11180" AddedByScript="true"/>
         <Path Name="ganon_final_scenePathList_0001F4" Offset="0x01F4" NumPaths="4"/>
         <Scene Name="ganon_final_scene" Offset="0x0"/>
     </File>

--- a/soh/assets/xml/GC_MQ_D/scenes/dungeons/ganon_sonogo.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/dungeons/ganon_sonogo.xml
@@ -1,21 +1,72 @@
 <Root>
     <File Name="ganon_sonogo_scene" Segment="2">
+        <Texture Name="ganon_sonogo_sceneTex_006710" OutName="ganon_sonogo_sceneTex_006710" Format="ci8" Width="32" Height="64" Offset="0x6710" TlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_sceneTex_006F10" OutName="ganon_sonogo_sceneTex_006F10" Format="ci8" Width="32" Height="32" Offset="0x6F10" TlutOffset="0x6508" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_sceneTex_007310" OutName="ganon_sonogo_sceneTex_007310" Format="ci8" Width="32" Height="32" Offset="0x7310" TlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_sceneTex_007710" OutName="ganon_sonogo_sceneTex_007710" Format="ia16" Width="32" Height="32" Offset="0x7710" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_sceneTLUT_006300" OutName="ganon_sonogo_sceneTLUT_006300" Format="rgba16" Width="16" Height="16" Offset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_sceneTLUT_006508" OutName="ganon_sonogo_sceneTLUT_006508" Format="rgba16" Width="16" Height="16" Offset="0x6508" AddedByScript="true"/>
         <Path Name="ganon_sonogo_scenePathList_000254" Offset="0x0254" NumPaths="5"/>
         <Scene Name="ganon_sonogo_scene" Offset="0x0"/>
     </File>
     <File Name="ganon_sonogo_room_0" Segment="3">
+        <Texture Name="ganon_sonogo_room_0Tex_005020" OutName="ganon_sonogo_room_0Tex_005020" Format="ci8" Width="32" Height="64" Offset="0x5020" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_0Tex_005820" OutName="ganon_sonogo_room_0Tex_005820" Format="ci8" Width="32" Height="32" Offset="0x5820" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_0Tex_005C20" OutName="ganon_sonogo_room_0Tex_005C20" Format="ci8" Width="32" Height="32" Offset="0x5C20" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_0Tex_006020" OutName="ganon_sonogo_room_0Tex_006020" Format="ci8" Width="64" Height="32" Offset="0x6020" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_0Tex_006820" OutName="ganon_sonogo_room_0Tex_006820" Format="ci8" Width="64" Height="32" Offset="0x6820" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_0Tex_007020" OutName="ganon_sonogo_room_0Tex_007020" Format="ci8" Width="32" Height="32" Offset="0x7020" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_0Tex_007420" OutName="ganon_sonogo_room_0Tex_007420" Format="ci8" Width="32" Height="32" Offset="0x7420" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_0Tex_007820" OutName="ganon_sonogo_room_0Tex_007820" Format="ci8" Width="32" Height="32" Offset="0x7820" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
         <Room Name="ganon_sonogo_room_0" Offset="0x0"/>
     </File>
     <File Name="ganon_sonogo_room_1" Segment="3">
+        <Texture Name="ganon_sonogo_room_1Tex_004148" OutName="ganon_sonogo_room_1Tex_004148" Format="ci8" Width="32" Height="32" Offset="0x4148" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_1Tex_004548" OutName="ganon_sonogo_room_1Tex_004548" Format="ci8" Width="32" Height="32" Offset="0x4548" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_1Tex_004948" OutName="ganon_sonogo_room_1Tex_004948" Format="ci8" Width="32" Height="32" Offset="0x4948" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_1Tex_004D48" OutName="ganon_sonogo_room_1Tex_004D48" Format="ci8" Width="32" Height="64" Offset="0x4D48" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_1Tex_005548" OutName="ganon_sonogo_room_1Tex_005548" Format="ci8" Width="32" Height="32" Offset="0x5548" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_1Tex_005948" OutName="ganon_sonogo_room_1Tex_005948" Format="ci8" Width="32" Height="32" Offset="0x5948" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_1Tex_005D48" OutName="ganon_sonogo_room_1Tex_005D48" Format="ci8" Width="32" Height="64" Offset="0x5D48" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_1Tex_006548" OutName="ganon_sonogo_room_1Tex_006548" Format="ci8" Width="32" Height="32" Offset="0x6548" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_1Tex_006948" OutName="ganon_sonogo_room_1Tex_006948" Format="rgba16" Width="32" Height="64" Offset="0x6948" AddedByScript="true"/>
         <Room Name="ganon_sonogo_room_1" Offset="0x0"/>
     </File>
     <File Name="ganon_sonogo_room_2" Segment="3">
+        <Texture Name="ganon_sonogo_room_2Tex_004A40" OutName="ganon_sonogo_room_2Tex_004A40" Format="ci8" Width="32" Height="64" Offset="0x4A40" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_2Tex_005240" OutName="ganon_sonogo_room_2Tex_005240" Format="ci8" Width="32" Height="32" Offset="0x5240" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_2Tex_005640" OutName="ganon_sonogo_room_2Tex_005640" Format="ci8" Width="32" Height="32" Offset="0x5640" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_2Tex_005A40" OutName="ganon_sonogo_room_2Tex_005A40" Format="ci8" Width="32" Height="64" Offset="0x5A40" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_2Tex_006240" OutName="ganon_sonogo_room_2Tex_006240" Format="ci8" Width="32" Height="32" Offset="0x6240" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_2Tex_006640" OutName="ganon_sonogo_room_2Tex_006640" Format="ci8" Width="32" Height="32" Offset="0x6640" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_2Tex_006A40" OutName="ganon_sonogo_room_2Tex_006A40" Format="ci8" Width="32" Height="32" Offset="0x6A40" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_2Tex_006E40" OutName="ganon_sonogo_room_2Tex_006E40" Format="ci8" Width="32" Height="32" Offset="0x6E40" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_2Tex_007240" OutName="ganon_sonogo_room_2Tex_007240" Format="ci8" Width="32" Height="64" Offset="0x7240" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_2Tex_007A40" OutName="ganon_sonogo_room_2Tex_007A40" Format="ci8" Width="32" Height="64" Offset="0x7A40" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_2Tex_008240" OutName="ganon_sonogo_room_2Tex_008240" Format="ci8" Width="32" Height="64" Offset="0x8240" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
         <Room Name="ganon_sonogo_room_2" Offset="0x0"/>
     </File>
     <File Name="ganon_sonogo_room_3" Segment="3">
+        <Texture Name="ganon_sonogo_room_3Tex_003A38" OutName="ganon_sonogo_room_3Tex_003A38" Format="ci8" Width="32" Height="32" Offset="0x3A38" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_3Tex_003E38" OutName="ganon_sonogo_room_3Tex_003E38" Format="ci8" Width="64" Height="32" Offset="0x3E38" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_3Tex_004638" OutName="ganon_sonogo_room_3Tex_004638" Format="ci8" Width="64" Height="32" Offset="0x4638" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_3Tex_004E38" OutName="ganon_sonogo_room_3Tex_004E38" Format="ci8" Width="32" Height="64" Offset="0x4E38" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
         <Room Name="ganon_sonogo_room_3" Offset="0x0"/>
     </File>
     <File Name="ganon_sonogo_room_4" Segment="3">
+        <Texture Name="ganon_sonogo_room_4Tex_004BA8" OutName="ganon_sonogo_room_4Tex_004BA8" Format="ci8" Width="32" Height="64" Offset="0x4BA8" TlutOffset="0x4840" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_4Tex_0053A8" OutName="ganon_sonogo_room_4Tex_0053A8" Format="ci8" Width="16" Height="16" Offset="0x53A8" TlutOffset="0x4B18" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_4Tex_0054A8" OutName="ganon_sonogo_room_4Tex_0054A8" Format="ci8" Width="8" Height="8" Offset="0x54A8" TlutOffset="0x4B18" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_4Tex_0054E8" OutName="ganon_sonogo_room_4Tex_0054E8" Format="rgba16" Width="32" Height="32" Offset="0x54E8" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_4Tex_005CE8" OutName="ganon_sonogo_room_4Tex_005CE8" Format="ci8" Width="32" Height="64" Offset="0x5CE8" TlutOffset="0x4910" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_4Tex_0064E8" OutName="ganon_sonogo_room_4Tex_0064E8" Format="ci8" Width="32" Height="32" Offset="0x64E8" TlutOffset="0x4B18" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_4Tex_0068E8" OutName="ganon_sonogo_room_4Tex_0068E8" Format="ci8" Width="32" Height="32" Offset="0x68E8" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_4Tex_006CE8" OutName="ganon_sonogo_room_4Tex_006CE8" Format="rgba16" Width="32" Height="32" Offset="0x6CE8" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_4Tex_0074E8" OutName="ganon_sonogo_room_4Tex_0074E8" Format="ci8" Width="32" Height="64" Offset="0x74E8" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_4Tex_007CE8" OutName="ganon_sonogo_room_4Tex_007CE8" Format="rgba16" Width="32" Height="64" Offset="0x7CE8" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_4TLUT_004840" OutName="ganon_sonogo_room_4TLUT_004840" Format="rgba16" Width="16" Height="16" Offset="0x4840" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_4TLUT_004910" OutName="ganon_sonogo_room_4TLUT_004910" Format="rgba16" Width="16" Height="16" Offset="0x4910" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_4TLUT_004B18" OutName="ganon_sonogo_room_4TLUT_004B18" Format="rgba16" Width="16" Height="16" Offset="0x4B18" AddedByScript="true"/>
         <Room Name="ganon_sonogo_room_4" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_MQ_D/scenes/dungeons/ganon_tou.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/dungeons/ganon_tou.xml
@@ -1,10 +1,34 @@
 <Root>
     <File Name="ganon_tou_scene" Segment="2">
+        <Texture Name="ganon_tou_sceneTex_003280" OutName="ganon_tou_sceneTex_003280" Format="i8" Width="64" Height="64" Offset="0x3280" AddedByScript="true"/>
         <Cutscene Name="gRainbowBridgeCs" Offset="0x2640"/>
         <Cutscene Name="gGanonsCastleIntroCs" Offset="0x4280"/>
         <Scene Name="ganon_tou_scene" Offset="0x0"/>
     </File>
     <File Name="ganon_tou_room_0" Segment="3">
+        <Texture Name="ganon_tou_room_0Tex_008550" OutName="ganon_tou_room_0Tex_008550" Format="rgba16" Width="32" Height="32" Offset="0x8550" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_008D50" OutName="ganon_tou_room_0Tex_008D50" Format="rgba16" Width="16" Height="16" Offset="0x8D50" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_008F50" OutName="ganon_tou_room_0Tex_008F50" Format="rgba16" Width="32" Height="8" Offset="0x8F50" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_009150" OutName="ganon_tou_room_0Tex_009150" Format="rgba16" Width="64" Height="32" Offset="0x9150" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_00A150" OutName="ganon_tou_room_0Tex_00A150" Format="rgba16" Width="128" Height="16" Offset="0xA150" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_00B150" OutName="ganon_tou_room_0Tex_00B150" Format="rgba16" Width="32" Height="16" Offset="0xB150" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_00B550" OutName="ganon_tou_room_0Tex_00B550" Format="i8" Width="32" Height="32" Offset="0xB550" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_00B950" OutName="ganon_tou_room_0Tex_00B950" Format="i8" Width="32" Height="32" Offset="0xB950" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_00BD50" OutName="ganon_tou_room_0Tex_00BD50" Format="rgba16" Width="16" Height="16" Offset="0xBD50" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_00BF50" OutName="ganon_tou_room_0Tex_00BF50" Format="i8" Width="64" Height="64" Offset="0xBF50" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_00CF50" OutName="ganon_tou_room_0Tex_00CF50" Format="rgba16" Width="32" Height="32" Offset="0xCF50" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_00D750" OutName="ganon_tou_room_0Tex_00D750" Format="rgba16" Width="32" Height="64" Offset="0xD750" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_00E750" OutName="ganon_tou_room_0Tex_00E750" Format="rgba16" Width="32" Height="64" Offset="0xE750" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_00F750" OutName="ganon_tou_room_0Tex_00F750" Format="i8" Width="32" Height="32" Offset="0xF750" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_00FB50" OutName="ganon_tou_room_0Tex_00FB50" Format="i8" Width="64" Height="16" Offset="0xFB50" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_00FF50" OutName="ganon_tou_room_0Tex_00FF50" Format="rgba16" Width="16" Height="16" Offset="0xFF50" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_010150" OutName="ganon_tou_room_0Tex_010150" Format="rgba16" Width="32" Height="16" Offset="0x10150" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_010550" OutName="ganon_tou_room_0Tex_010550" Format="rgba16" Width="32" Height="32" Offset="0x10550" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_0124F0" OutName="ganon_tou_room_0Tex_0124F0" Format="ia8" Width="32" Height="8" Offset="0x124F0" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_0125F0" OutName="ganon_tou_room_0Tex_0125F0" Format="ia4" Width="128" Height="32" Offset="0x125F0" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_012DF0" OutName="ganon_tou_room_0Tex_012DF0" Format="i4" Width="64" Height="64" Offset="0x12DF0" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_0135F0" OutName="ganon_tou_room_0Tex_0135F0" Format="ia8" Width="32" Height="32" Offset="0x135F0" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_0139F0" OutName="ganon_tou_room_0Tex_0139F0" Format="ia8" Width="16" Height="16" Offset="0x139F0" AddedByScript="true"/>
         <Room Name="ganon_tou_room_0" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_MQ_D/scenes/dungeons/ganontika.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/dungeons/ganontika.xml
@@ -1,5 +1,11 @@
 <Root>
     <File Name="ganontika_scene" Segment="2">
+        <Texture Name="ganontika_sceneTex_01F580" OutName="ganontika_sceneTex_01F580" Format="rgba16" Width="16" Height="16" Offset="0x1F580" AddedByScript="true"/>
+        <Texture Name="ganontika_sceneTex_01F780" OutName="ganontika_sceneTex_01F780" Format="ci8" Width="32" Height="64" Offset="0x1F780" TlutOffset="0x1F380" AddedByScript="true"/>
+        <Texture Name="ganontika_sceneTex_01FF80" OutName="ganontika_sceneTex_01FF80" Format="ci8" Width="32" Height="32" Offset="0x1FF80" TlutOffset="0x1F380" AddedByScript="true"/>
+        <Texture Name="ganontika_sceneTex_020380" OutName="ganontika_sceneTex_020380" Format="ci8" Width="64" Height="32" Offset="0x20380" TlutOffset="0x1F380" AddedByScript="true"/>
+        <Texture Name="ganontika_sceneTex_020B80" OutName="ganontika_sceneTex_020B80" Format="rgba16" Width="32" Height="32" Offset="0x20B80" AddedByScript="true"/>
+        <Texture Name="ganontika_sceneTLUT_01F380" OutName="ganontika_sceneTLUT_01F380" Format="rgba16" Width="16" Height="16" Offset="0x1F380" AddedByScript="true"/>
         <Cutscene Name="gForestTrialSageCs" Offset="0x19EE0"/>
         <Cutscene Name="gWaterTrialSageCs" Offset="0x1A8E0"/>
         <Cutscene Name="gShadowTrialSageCs" Offset="0x1B2B0"/>
@@ -20,63 +26,229 @@
         <Scene Name="ganontika_scene" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_0" Segment="3">
+        <Texture Name="ganontika_room_0Tex_007F48" OutName="ganontika_room_0Tex_007F48" Format="ci8" Width="64" Height="32" Offset="0x7F48" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F380" AddedByScript="true"/>
+        <Texture Name="ganontika_room_0Tex_008A10" OutName="ganontika_room_0Tex_008A10" Format="ia16" Width="8" Height="128" Offset="0x8A10" AddedByScript="true"/>
         <Room Name="ganontika_room_0" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_1" Segment="3">
+        <Texture Name="ganontika_room_1Tex_00D9E0" OutName="ganontika_room_1Tex_00D9E0" Format="i4" Width="128" Height="64" Offset="0xD9E0" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_00E9E0" OutName="ganontika_room_1Tex_00E9E0" Format="i4" Width="128" Height="64" Offset="0xE9E0" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_00F9E0" OutName="ganontika_room_1Tex_00F9E0" Format="i4" Width="128" Height="64" Offset="0xF9E0" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0109E0" OutName="ganontika_room_1Tex_0109E0" Format="rgba16" Width="64" Height="32" Offset="0x109E0" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0119E0" OutName="ganontika_room_1Tex_0119E0" Format="ci8" Width="32" Height="64" Offset="0x119E0" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F380" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0121E0" OutName="ganontika_room_1Tex_0121E0" Format="ci8" Width="64" Height="32" Offset="0x121E0" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F380" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0129E0" OutName="ganontika_room_1Tex_0129E0" Format="ci8" Width="32" Height="64" Offset="0x129E0" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F380" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0131E0" OutName="ganontika_room_1Tex_0131E0" Format="ci8" Width="64" Height="32" Offset="0x131E0" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F380" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0139E0" OutName="ganontika_room_1Tex_0139E0" Format="ci8" Width="64" Height="32" Offset="0x139E0" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F380" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0141E0" OutName="ganontika_room_1Tex_0141E0" Format="ci8" Width="64" Height="32" Offset="0x141E0" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F380" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0149E0" OutName="ganontika_room_1Tex_0149E0" Format="ci8" Width="64" Height="32" Offset="0x149E0" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F380" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0151E0" OutName="ganontika_room_1Tex_0151E0" Format="ci8" Width="32" Height="64" Offset="0x151E0" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F380" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0159E0" OutName="ganontika_room_1Tex_0159E0" Format="ci4" Width="64" Height="64" Offset="0x159E0" TlutOffset="0xD9C0" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0161E0" OutName="ganontika_room_1Tex_0161E0" Format="ci4" Width="64" Height="64" Offset="0x161E0" TlutOffset="0xD9C0" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0169E0" OutName="ganontika_room_1Tex_0169E0" Format="ci4" Width="64" Height="64" Offset="0x169E0" TlutOffset="0xD9C0" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0171E0" OutName="ganontika_room_1Tex_0171E0" Format="ci4" Width="64" Height="64" Offset="0x171E0" TlutOffset="0xD9C0" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0179E0" OutName="ganontika_room_1Tex_0179E0" Format="ci4" Width="64" Height="64" Offset="0x179E0" TlutOffset="0xD9C0" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0181E0" OutName="ganontika_room_1Tex_0181E0" Format="ci4" Width="64" Height="64" Offset="0x181E0" TlutOffset="0xD9C0" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0189E0" OutName="ganontika_room_1Tex_0189E0" Format="rgba16" Width="64" Height="32" Offset="0x189E0" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0199E0" OutName="ganontika_room_1Tex_0199E0" Format="ci8" Width="64" Height="16" Offset="0x199E0" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F380" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_019DE0" OutName="ganontika_room_1Tex_019DE0" Format="ci8" Width="64" Height="32" Offset="0x19DE0" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F380" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_01B9C8" OutName="ganontika_room_1Tex_01B9C8" Format="ia8" Width="64" Height="64" Offset="0x1B9C8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1TLUT_00D9C0" OutName="ganontika_room_1TLUT_00D9C0" Format="rgba16" Width="4" Height="4" Offset="0xD9C0" AddedByScript="true"/>
         <Room Name="ganontika_room_1" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_2" Segment="3">
+        <Texture Name="ganontika_room_2Tex_002FD8" OutName="ganontika_room_2Tex_002FD8" Format="rgba16" Width="32" Height="32" Offset="0x2FD8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_2Tex_0037D8" OutName="ganontika_room_2Tex_0037D8" Format="rgba16" Width="32" Height="32" Offset="0x37D8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_2Tex_003FD8" OutName="ganontika_room_2Tex_003FD8" Format="rgba16" Width="32" Height="32" Offset="0x3FD8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_2Tex_0047D8" OutName="ganontika_room_2Tex_0047D8" Format="rgba16" Width="32" Height="32" Offset="0x47D8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_2Tex_004FD8" OutName="ganontika_room_2Tex_004FD8" Format="rgba16" Width="32" Height="32" Offset="0x4FD8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_2Tex_0057D8" OutName="ganontika_room_2Tex_0057D8" Format="rgba16" Width="32" Height="32" Offset="0x57D8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_2Tex_005FD8" OutName="ganontika_room_2Tex_005FD8" Format="ci8" Width="64" Height="32" Offset="0x5FD8" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F380" AddedByScript="true"/>
+        <Texture Name="ganontika_room_2Tex_0067D8" OutName="ganontika_room_2Tex_0067D8" Format="rgba16" Width="64" Height="32" Offset="0x67D8" AddedByScript="true"/>
         <Room Name="ganontika_room_2" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_3" Segment="3">
+        <Texture Name="ganontika_room_3Tex_003ED8" OutName="ganontika_room_3Tex_003ED8" Format="rgba16" Width="32" Height="32" Offset="0x3ED8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_3Tex_0046D8" OutName="ganontika_room_3Tex_0046D8" Format="rgba16" Width="32" Height="32" Offset="0x46D8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_3Tex_004ED8" OutName="ganontika_room_3Tex_004ED8" Format="rgba16" Width="32" Height="32" Offset="0x4ED8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_3Tex_0056D8" OutName="ganontika_room_3Tex_0056D8" Format="rgba16" Width="32" Height="32" Offset="0x56D8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_3Tex_005ED8" OutName="ganontika_room_3Tex_005ED8" Format="rgba16" Width="32" Height="32" Offset="0x5ED8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_3Tex_0066D8" OutName="ganontika_room_3Tex_0066D8" Format="rgba16" Width="32" Height="32" Offset="0x66D8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_3Tex_006ED8" OutName="ganontika_room_3Tex_006ED8" Format="ci4" Width="64" Height="64" Offset="0x6ED8" TlutOffset="0x3EB8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_3Tex_0076D8" OutName="ganontika_room_3Tex_0076D8" Format="rgba16" Width="64" Height="32" Offset="0x76D8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_3Tex_008A38" OutName="ganontika_room_3Tex_008A38" Format="ia8" Width="64" Height="64" Offset="0x8A38" AddedByScript="true"/>
+        <Texture Name="ganontika_room_3TLUT_003EB8" OutName="ganontika_room_3TLUT_003EB8" Format="rgba16" Width="4" Height="4" Offset="0x3EB8" AddedByScript="true"/>
         <Room Name="ganontika_room_3" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_4" Segment="3">
+        <Texture Name="ganontika_room_4Tex_004288" OutName="ganontika_room_4Tex_004288" Format="rgba16" Width="32" Height="32" Offset="0x4288" AddedByScript="true"/>
+        <Texture Name="ganontika_room_4Tex_004A88" OutName="ganontika_room_4Tex_004A88" Format="ci8" Width="32" Height="64" Offset="0x4A88" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F380" AddedByScript="true"/>
+        <Texture Name="ganontika_room_4Tex_005288" OutName="ganontika_room_4Tex_005288" Format="ci8" Width="64" Height="32" Offset="0x5288" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F380" AddedByScript="true"/>
+        <Texture Name="ganontika_room_4Tex_005A88" OutName="ganontika_room_4Tex_005A88" Format="rgba16" Width="32" Height="32" Offset="0x5A88" AddedByScript="true"/>
+        <Texture Name="ganontika_room_4Tex_006288" OutName="ganontika_room_4Tex_006288" Format="rgba16" Width="32" Height="32" Offset="0x6288" AddedByScript="true"/>
+        <Texture Name="ganontika_room_4Tex_006A88" OutName="ganontika_room_4Tex_006A88" Format="rgba16" Width="16" Height="16" Offset="0x6A88" AddedByScript="true"/>
+        <Texture Name="ganontika_room_4Tex_006C88" OutName="ganontika_room_4Tex_006C88" Format="rgba16" Width="64" Height="32" Offset="0x6C88" AddedByScript="true"/>
         <Room Name="ganontika_room_4" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_5" Segment="3">
+        <Texture Name="ganontika_room_5Tex_003B18" OutName="ganontika_room_5Tex_003B18" Format="rgba16" Width="16" Height="16" Offset="0x3B18" AddedByScript="true"/>
+        <Texture Name="ganontika_room_5Tex_003D18" OutName="ganontika_room_5Tex_003D18" Format="ci8" Width="32" Height="64" Offset="0x3D18" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F380" AddedByScript="true"/>
+        <Texture Name="ganontika_room_5Tex_004518" OutName="ganontika_room_5Tex_004518" Format="rgba16" Width="32" Height="32" Offset="0x4518" AddedByScript="true"/>
+        <Texture Name="ganontika_room_5Tex_004D18" OutName="ganontika_room_5Tex_004D18" Format="ci8" Width="64" Height="32" Offset="0x4D18" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F380" AddedByScript="true"/>
+        <Texture Name="ganontika_room_5Tex_005518" OutName="ganontika_room_5Tex_005518" Format="rgba16" Width="32" Height="32" Offset="0x5518" AddedByScript="true"/>
+        <Texture Name="ganontika_room_5Tex_005D18" OutName="ganontika_room_5Tex_005D18" Format="ci8" Width="64" Height="32" Offset="0x5D18" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F380" AddedByScript="true"/>
+        <Texture Name="ganontika_room_5Tex_006518" OutName="ganontika_room_5Tex_006518" Format="rgba16" Width="64" Height="32" Offset="0x6518" AddedByScript="true"/>
         <Room Name="ganontika_room_5" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_6" Segment="3">
+        <Texture Name="ganontika_room_6Tex_00B500" OutName="ganontika_room_6Tex_00B500" Format="ci8" Width="32" Height="32" Offset="0xB500" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F380" AddedByScript="true"/>
+        <Texture Name="ganontika_room_6Tex_00B900" OutName="ganontika_room_6Tex_00B900" Format="ci8" Width="32" Height="64" Offset="0xB900" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F380" AddedByScript="true"/>
+        <Texture Name="ganontika_room_6Tex_00C100" OutName="ganontika_room_6Tex_00C100" Format="ci8" Width="64" Height="32" Offset="0xC100" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F380" AddedByScript="true"/>
+        <Texture Name="ganontika_room_6Tex_00C900" OutName="ganontika_room_6Tex_00C900" Format="i4" Width="32" Height="32" Offset="0xC900" AddedByScript="true"/>
+        <Texture Name="ganontika_room_6Tex_00CB00" OutName="ganontika_room_6Tex_00CB00" Format="i4" Width="32" Height="32" Offset="0xCB00" AddedByScript="true"/>
+        <Texture Name="ganontika_room_6Tex_00CD00" OutName="ganontika_room_6Tex_00CD00" Format="i4" Width="32" Height="32" Offset="0xCD00" AddedByScript="true"/>
+        <Texture Name="ganontika_room_6Tex_00CF00" OutName="ganontika_room_6Tex_00CF00" Format="ci4" Width="64" Height="64" Offset="0xCF00" TlutOffset="0xB4E0" AddedByScript="true"/>
+        <Texture Name="ganontika_room_6Tex_00D700" OutName="ganontika_room_6Tex_00D700" Format="i4" Width="32" Height="32" Offset="0xD700" AddedByScript="true"/>
+        <Texture Name="ganontika_room_6Tex_00D900" OutName="ganontika_room_6Tex_00D900" Format="rgba16" Width="64" Height="32" Offset="0xD900" AddedByScript="true"/>
+        <Texture Name="ganontika_room_6Tex_00EC58" OutName="ganontika_room_6Tex_00EC58" Format="ia8" Width="64" Height="64" Offset="0xEC58" AddedByScript="true"/>
+        <Texture Name="ganontika_room_6TLUT_00B4E0" OutName="ganontika_room_6TLUT_00B4E0" Format="rgba16" Width="4" Height="4" Offset="0xB4E0" AddedByScript="true"/>
         <Room Name="ganontika_room_6" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_7" Segment="3">
+        <Texture Name="ganontika_room_7Tex_004288" OutName="ganontika_room_7Tex_004288" Format="rgba16" Width="32" Height="32" Offset="0x4288" AddedByScript="true"/>
+        <Texture Name="ganontika_room_7Tex_004A88" OutName="ganontika_room_7Tex_004A88" Format="ci8" Width="32" Height="64" Offset="0x4A88" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F380" AddedByScript="true"/>
+        <Texture Name="ganontika_room_7Tex_005288" OutName="ganontika_room_7Tex_005288" Format="ci8" Width="64" Height="32" Offset="0x5288" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F380" AddedByScript="true"/>
+        <Texture Name="ganontika_room_7Tex_005A88" OutName="ganontika_room_7Tex_005A88" Format="rgba16" Width="32" Height="32" Offset="0x5A88" AddedByScript="true"/>
+        <Texture Name="ganontika_room_7Tex_006288" OutName="ganontika_room_7Tex_006288" Format="rgba16" Width="32" Height="32" Offset="0x6288" AddedByScript="true"/>
+        <Texture Name="ganontika_room_7Tex_006A88" OutName="ganontika_room_7Tex_006A88" Format="rgba16" Width="16" Height="16" Offset="0x6A88" AddedByScript="true"/>
+        <Texture Name="ganontika_room_7Tex_006C88" OutName="ganontika_room_7Tex_006C88" Format="rgba16" Width="64" Height="32" Offset="0x6C88" AddedByScript="true"/>
         <Room Name="ganontika_room_7" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_8" Segment="3">
+        <Texture Name="ganontika_room_8Tex_0034B8" OutName="ganontika_room_8Tex_0034B8" Format="rgba16" Width="32" Height="64" Offset="0x34B8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_8Tex_0044B8" OutName="ganontika_room_8Tex_0044B8" Format="rgba16" Width="32" Height="64" Offset="0x44B8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_8Tex_0054B8" OutName="ganontika_room_8Tex_0054B8" Format="rgba16" Width="32" Height="32" Offset="0x54B8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_8Tex_005CB8" OutName="ganontika_room_8Tex_005CB8" Format="rgba16" Width="32" Height="64" Offset="0x5CB8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_8Tex_006CB8" OutName="ganontika_room_8Tex_006CB8" Format="rgba16" Width="32" Height="32" Offset="0x6CB8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_8Tex_0074B8" OutName="ganontika_room_8Tex_0074B8" Format="ci4" Width="64" Height="64" Offset="0x74B8" TlutOffset="0x3498" AddedByScript="true"/>
+        <Texture Name="ganontika_room_8Tex_008018" OutName="ganontika_room_8Tex_008018" Format="ia8" Width="64" Height="64" Offset="0x8018" AddedByScript="true"/>
+        <Texture Name="ganontika_room_8TLUT_003498" OutName="ganontika_room_8TLUT_003498" Format="rgba16" Width="4" Height="4" Offset="0x3498" AddedByScript="true"/>
         <Room Name="ganontika_room_8" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_9" Segment="3">
+        <Texture Name="ganontika_room_9Tex_005488" OutName="ganontika_room_9Tex_005488" Format="rgba16" Width="64" Height="32" Offset="0x5488" AddedByScript="true"/>
+        <Texture Name="ganontika_room_9Tex_006488" OutName="ganontika_room_9Tex_006488" Format="rgba16" Width="64" Height="32" Offset="0x6488" AddedByScript="true"/>
+        <Texture Name="ganontika_room_9Tex_007488" OutName="ganontika_room_9Tex_007488" Format="rgba16" Width="32" Height="32" Offset="0x7488" AddedByScript="true"/>
+        <Texture Name="ganontika_room_9Tex_007C88" OutName="ganontika_room_9Tex_007C88" Format="rgba16" Width="16" Height="16" Offset="0x7C88" AddedByScript="true"/>
+        <Texture Name="ganontika_room_9Tex_007E88" OutName="ganontika_room_9Tex_007E88" Format="ci8" Width="32" Height="64" Offset="0x7E88" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F380" AddedByScript="true"/>
+        <Texture Name="ganontika_room_9Tex_008688" OutName="ganontika_room_9Tex_008688" Format="ci8" Width="64" Height="32" Offset="0x8688" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F380" AddedByScript="true"/>
+        <Texture Name="ganontika_room_9Tex_008E88" OutName="ganontika_room_9Tex_008E88" Format="ci8" Width="64" Height="32" Offset="0x8E88" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F380" AddedByScript="true"/>
+        <Texture Name="ganontika_room_9Tex_009688" OutName="ganontika_room_9Tex_009688" Format="rgba16" Width="64" Height="32" Offset="0x9688" AddedByScript="true"/>
+        <Texture Name="ganontika_room_9Tex_00A818" OutName="ganontika_room_9Tex_00A818" Format="rgba16" Width="32" Height="64" Offset="0xA818" AddedByScript="true"/>
         <Room Name="ganontika_room_9" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_10" Segment="3">
+        <Texture Name="ganontika_room_10Tex_0039B8" OutName="ganontika_room_10Tex_0039B8" Format="rgba16" Width="32" Height="32" Offset="0x39B8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_10Tex_0041B8" OutName="ganontika_room_10Tex_0041B8" Format="ci8" Width="32" Height="64" Offset="0x41B8" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F380" AddedByScript="true"/>
+        <Texture Name="ganontika_room_10Tex_0049B8" OutName="ganontika_room_10Tex_0049B8" Format="rgba16" Width="32" Height="32" Offset="0x49B8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_10Tex_0051B8" OutName="ganontika_room_10Tex_0051B8" Format="rgba16" Width="32" Height="32" Offset="0x51B8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_10Tex_0059B8" OutName="ganontika_room_10Tex_0059B8" Format="rgba16" Width="16" Height="16" Offset="0x59B8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_10Tex_005BB8" OutName="ganontika_room_10Tex_005BB8" Format="rgba16" Width="64" Height="32" Offset="0x5BB8" AddedByScript="true"/>
         <Room Name="ganontika_room_10" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_11" Segment="3">
+        <Texture Name="ganontika_room_11Tex_004150" OutName="ganontika_room_11Tex_004150" Format="rgba16" Width="32" Height="32" Offset="0x4150" AddedByScript="true"/>
+        <Texture Name="ganontika_room_11Tex_004950" OutName="ganontika_room_11Tex_004950" Format="ci8" Width="32" Height="64" Offset="0x4950" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F380" AddedByScript="true"/>
+        <Texture Name="ganontika_room_11Tex_005150" OutName="ganontika_room_11Tex_005150" Format="ci8" Width="64" Height="32" Offset="0x5150" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F380" AddedByScript="true"/>
+        <Texture Name="ganontika_room_11Tex_005950" OutName="ganontika_room_11Tex_005950" Format="rgba16" Width="32" Height="32" Offset="0x5950" AddedByScript="true"/>
+        <Texture Name="ganontika_room_11Tex_006150" OutName="ganontika_room_11Tex_006150" Format="rgba16" Width="32" Height="32" Offset="0x6150" AddedByScript="true"/>
         <Room Name="ganontika_room_11" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_12" Segment="3">
+        <Texture Name="ganontika_room_12Tex_005160" OutName="ganontika_room_12Tex_005160" Format="rgba16" Width="32" Height="32" Offset="0x5160" AddedByScript="true"/>
+        <Texture Name="ganontika_room_12Tex_005960" OutName="ganontika_room_12Tex_005960" Format="ci8" Width="64" Height="32" Offset="0x5960" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F380" AddedByScript="true"/>
+        <Texture Name="ganontika_room_12Tex_006160" OutName="ganontika_room_12Tex_006160" Format="ci8" Width="32" Height="64" Offset="0x6160" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F380" AddedByScript="true"/>
+        <Texture Name="ganontika_room_12Tex_006960" OutName="ganontika_room_12Tex_006960" Format="ci4" Width="64" Height="64" Offset="0x6960" TlutOffset="0x5140" AddedByScript="true"/>
+        <Texture Name="ganontika_room_12Tex_007160" OutName="ganontika_room_12Tex_007160" Format="rgba16" Width="64" Height="32" Offset="0x7160" AddedByScript="true"/>
+        <Texture Name="ganontika_room_12Tex_008160" OutName="ganontika_room_12Tex_008160" Format="ci8" Width="64" Height="16" Offset="0x8160" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F380" AddedByScript="true"/>
+        <Texture Name="ganontika_room_12Tex_008560" OutName="ganontika_room_12Tex_008560" Format="ci8" Width="64" Height="32" Offset="0x8560" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F380" AddedByScript="true"/>
+        <Texture Name="ganontika_room_12Tex_009270" OutName="ganontika_room_12Tex_009270" Format="ia8" Width="64" Height="64" Offset="0x9270" AddedByScript="true"/>
+        <Texture Name="ganontika_room_12Tex_00A270" OutName="ganontika_room_12Tex_00A270" Format="ia8" Width="32" Height="128" Offset="0xA270" AddedByScript="true"/>
+        <Texture Name="ganontika_room_12TLUT_005140" OutName="ganontika_room_12TLUT_005140" Format="rgba16" Width="4" Height="4" Offset="0x5140" AddedByScript="true"/>
         <Room Name="ganontika_room_12" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_13" Segment="3">
+        <Texture Name="ganontika_room_13Tex_004340" OutName="ganontika_room_13Tex_004340" Format="rgba16" Width="32" Height="32" Offset="0x4340" AddedByScript="true"/>
+        <Texture Name="ganontika_room_13Tex_004B40" OutName="ganontika_room_13Tex_004B40" Format="ci8" Width="32" Height="64" Offset="0x4B40" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F380" AddedByScript="true"/>
+        <Texture Name="ganontika_room_13Tex_005340" OutName="ganontika_room_13Tex_005340" Format="ci8" Width="64" Height="32" Offset="0x5340" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F380" AddedByScript="true"/>
+        <Texture Name="ganontika_room_13Tex_005B40" OutName="ganontika_room_13Tex_005B40" Format="rgba16" Width="32" Height="32" Offset="0x5B40" AddedByScript="true"/>
+        <Texture Name="ganontika_room_13Tex_006340" OutName="ganontika_room_13Tex_006340" Format="rgba16" Width="32" Height="32" Offset="0x6340" AddedByScript="true"/>
+        <Texture Name="ganontika_room_13Tex_006B40" OutName="ganontika_room_13Tex_006B40" Format="rgba16" Width="16" Height="16" Offset="0x6B40" AddedByScript="true"/>
+        <Texture Name="ganontika_room_13Tex_006D40" OutName="ganontika_room_13Tex_006D40" Format="rgba16" Width="64" Height="32" Offset="0x6D40" AddedByScript="true"/>
         <Room Name="ganontika_room_13" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_14" Segment="3">
+        <Texture Name="ganontika_room_14Tex_004FB8" OutName="ganontika_room_14Tex_004FB8" Format="rgba16" Width="32" Height="32" Offset="0x4FB8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_14Tex_0057B8" OutName="ganontika_room_14Tex_0057B8" Format="ci8" Width="64" Height="32" Offset="0x57B8" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F380" AddedByScript="true"/>
+        <Texture Name="ganontika_room_14Tex_005FB8" OutName="ganontika_room_14Tex_005FB8" Format="ci4" Width="64" Height="64" Offset="0x5FB8" TlutOffset="0x4F98" AddedByScript="true"/>
+        <Texture Name="ganontika_room_14Tex_0067B8" OutName="ganontika_room_14Tex_0067B8" Format="rgba16" Width="64" Height="32" Offset="0x67B8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_14Tex_0077B8" OutName="ganontika_room_14Tex_0077B8" Format="ci8" Width="64" Height="16" Offset="0x77B8" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F380" AddedByScript="true"/>
+        <Texture Name="ganontika_room_14Tex_007BB8" OutName="ganontika_room_14Tex_007BB8" Format="ci8" Width="64" Height="32" Offset="0x7BB8" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F380" AddedByScript="true"/>
+        <Texture Name="ganontika_room_14Tex_0089C8" OutName="ganontika_room_14Tex_0089C8" Format="ia8" Width="64" Height="64" Offset="0x89C8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_14Tex_0099C8" OutName="ganontika_room_14Tex_0099C8" Format="rgba16" Width="32" Height="32" Offset="0x99C8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_14TLUT_004F98" OutName="ganontika_room_14TLUT_004F98" Format="rgba16" Width="4" Height="4" Offset="0x4F98" AddedByScript="true"/>
         <Room Name="ganontika_room_14" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_15" Segment="3">
+        <Texture Name="ganontika_room_15Tex_004340" OutName="ganontika_room_15Tex_004340" Format="rgba16" Width="32" Height="32" Offset="0x4340" AddedByScript="true"/>
+        <Texture Name="ganontika_room_15Tex_004B40" OutName="ganontika_room_15Tex_004B40" Format="ci8" Width="32" Height="64" Offset="0x4B40" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F380" AddedByScript="true"/>
+        <Texture Name="ganontika_room_15Tex_005340" OutName="ganontika_room_15Tex_005340" Format="ci8" Width="64" Height="32" Offset="0x5340" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F380" AddedByScript="true"/>
+        <Texture Name="ganontika_room_15Tex_005B40" OutName="ganontika_room_15Tex_005B40" Format="rgba16" Width="32" Height="32" Offset="0x5B40" AddedByScript="true"/>
+        <Texture Name="ganontika_room_15Tex_006340" OutName="ganontika_room_15Tex_006340" Format="rgba16" Width="32" Height="32" Offset="0x6340" AddedByScript="true"/>
+        <Texture Name="ganontika_room_15Tex_006B40" OutName="ganontika_room_15Tex_006B40" Format="rgba16" Width="16" Height="16" Offset="0x6B40" AddedByScript="true"/>
+        <Texture Name="ganontika_room_15Tex_006D40" OutName="ganontika_room_15Tex_006D40" Format="rgba16" Width="64" Height="32" Offset="0x6D40" AddedByScript="true"/>
         <Room Name="ganontika_room_15" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_16" Segment="3">
+        <Texture Name="ganontika_room_16Tex_001630" OutName="ganontika_room_16Tex_001630" Format="rgba16" Width="64" Height="32" Offset="0x1630" AddedByScript="true"/>
+        <Texture Name="ganontika_room_16Tex_002630" OutName="ganontika_room_16Tex_002630" Format="ci8" Width="64" Height="32" Offset="0x2630" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F380" AddedByScript="true"/>
         <Room Name="ganontika_room_16" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_17" Segment="3">
+        <Texture Name="ganontika_room_17Tex_002A18" OutName="ganontika_room_17Tex_002A18" Format="ci8" Width="32" Height="32" Offset="0x2A18" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F380" AddedByScript="true"/>
+        <Texture Name="ganontika_room_17Tex_002E18" OutName="ganontika_room_17Tex_002E18" Format="rgba16" Width="64" Height="32" Offset="0x2E18" AddedByScript="true"/>
+        <Texture Name="ganontika_room_17Tex_003E18" OutName="ganontika_room_17Tex_003E18" Format="rgba16" Width="64" Height="32" Offset="0x3E18" AddedByScript="true"/>
+        <Texture Name="ganontika_room_17Tex_004E18" OutName="ganontika_room_17Tex_004E18" Format="rgba16" Width="32" Height="32" Offset="0x4E18" AddedByScript="true"/>
+        <Texture Name="ganontika_room_17Tex_005618" OutName="ganontika_room_17Tex_005618" Format="rgba16" Width="32" Height="64" Offset="0x5618" AddedByScript="true"/>
+        <Texture Name="ganontika_room_17Tex_006618" OutName="ganontika_room_17Tex_006618" Format="rgba16" Width="32" Height="32" Offset="0x6618" AddedByScript="true"/>
+        <Texture Name="ganontika_room_17Tex_006E18" OutName="ganontika_room_17Tex_006E18" Format="ci8" Width="64" Height="32" Offset="0x6E18" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F380" AddedByScript="true"/>
+        <Texture Name="ganontika_room_17Tex_007618" OutName="ganontika_room_17Tex_007618" Format="rgba16" Width="64" Height="32" Offset="0x7618" AddedByScript="true"/>
         <Room Name="ganontika_room_17" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_18" Segment="3">
+        <Texture Name="ganontika_room_18Tex_004380" OutName="ganontika_room_18Tex_004380" Format="rgba16" Width="32" Height="64" Offset="0x4380" AddedByScript="true"/>
+        <Texture Name="ganontika_room_18Tex_005380" OutName="ganontika_room_18Tex_005380" Format="ci8" Width="32" Height="32" Offset="0x5380" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F380" AddedByScript="true"/>
+        <Texture Name="ganontika_room_18Tex_005780" OutName="ganontika_room_18Tex_005780" Format="rgba16" Width="64" Height="32" Offset="0x5780" AddedByScript="true"/>
+        <Texture Name="ganontika_room_18Tex_006780" OutName="ganontika_room_18Tex_006780" Format="rgba16" Width="64" Height="32" Offset="0x6780" AddedByScript="true"/>
+        <Texture Name="ganontika_room_18Tex_007780" OutName="ganontika_room_18Tex_007780" Format="rgba16" Width="32" Height="32" Offset="0x7780" AddedByScript="true"/>
+        <Texture Name="ganontika_room_18Tex_007F80" OutName="ganontika_room_18Tex_007F80" Format="rgba16" Width="32" Height="64" Offset="0x7F80" AddedByScript="true"/>
+        <Texture Name="ganontika_room_18Tex_008F80" OutName="ganontika_room_18Tex_008F80" Format="rgba16" Width="32" Height="8" Offset="0x8F80" AddedByScript="true"/>
+        <Texture Name="ganontika_room_18Tex_009180" OutName="ganontika_room_18Tex_009180" Format="rgba16" Width="32" Height="32" Offset="0x9180" AddedByScript="true"/>
+        <Texture Name="ganontika_room_18Tex_009980" OutName="ganontika_room_18Tex_009980" Format="ci4" Width="64" Height="64" Offset="0x9980" TlutOffset="0x4360" AddedByScript="true"/>
+        <Texture Name="ganontika_room_18Tex_00A180" OutName="ganontika_room_18Tex_00A180" Format="i4" Width="32" Height="32" Offset="0xA180" AddedByScript="true"/>
+        <Texture Name="ganontika_room_18Tex_00A380" OutName="ganontika_room_18Tex_00A380" Format="rgba16" Width="64" Height="32" Offset="0xA380" AddedByScript="true"/>
+        <Texture Name="ganontika_room_18Tex_00B6E0" OutName="ganontika_room_18Tex_00B6E0" Format="ia8" Width="64" Height="64" Offset="0xB6E0" AddedByScript="true"/>
+        <Texture Name="ganontika_room_18TLUT_004360" OutName="ganontika_room_18TLUT_004360" Format="rgba16" Width="4" Height="4" Offset="0x4360" AddedByScript="true"/>
         <Room Name="ganontika_room_18" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_19" Segment="3">
+        <Texture Name="ganontika_room_19Tex_004340" OutName="ganontika_room_19Tex_004340" Format="rgba16" Width="32" Height="32" Offset="0x4340" AddedByScript="true"/>
+        <Texture Name="ganontika_room_19Tex_004B40" OutName="ganontika_room_19Tex_004B40" Format="ci8" Width="32" Height="64" Offset="0x4B40" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F380" AddedByScript="true"/>
+        <Texture Name="ganontika_room_19Tex_005340" OutName="ganontika_room_19Tex_005340" Format="ci8" Width="64" Height="32" Offset="0x5340" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F380" AddedByScript="true"/>
+        <Texture Name="ganontika_room_19Tex_005B40" OutName="ganontika_room_19Tex_005B40" Format="rgba16" Width="32" Height="32" Offset="0x5B40" AddedByScript="true"/>
+        <Texture Name="ganontika_room_19Tex_006340" OutName="ganontika_room_19Tex_006340" Format="rgba16" Width="32" Height="32" Offset="0x6340" AddedByScript="true"/>
+        <Texture Name="ganontika_room_19Tex_006B40" OutName="ganontika_room_19Tex_006B40" Format="rgba16" Width="16" Height="16" Offset="0x6B40" AddedByScript="true"/>
+        <Texture Name="ganontika_room_19Tex_006D40" OutName="ganontika_room_19Tex_006D40" Format="rgba16" Width="64" Height="32" Offset="0x6D40" AddedByScript="true"/>
         <Room Name="ganontika_room_19" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_MQ_D/scenes/dungeons/ganontikasonogo.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/dungeons/ganontikasonogo.xml
@@ -1,12 +1,36 @@
 <Root>
     <File Name="ganontikasonogo_scene" Segment="2">
+        <Texture Name="ganontikasonogo_sceneTex_002B00" OutName="ganontikasonogo_sceneTex_002B00" Format="rgba16" Width="32" Height="64" Offset="0x2B00" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_sceneTex_003B00" OutName="ganontikasonogo_sceneTex_003B00" Format="rgba16" Width="64" Height="32" Offset="0x3B00" AddedByScript="true"/>
         <Path Name="ganontikasonogo_scenePathList_000184" Offset="0x0184" NumPaths="2"/>
         <Scene Name="ganontikasonogo_scene" Offset="0x0"/>
     </File>
     <File Name="ganontikasonogo_room_0" Segment="3">
+        <Texture Name="ganontikasonogo_room_0Tex_0092D8" OutName="ganontikasonogo_room_0Tex_0092D8" Format="rgba16" Width="64" Height="32" Offset="0x92D8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_00A2D8" OutName="ganontikasonogo_room_0Tex_00A2D8" Format="rgba16" Width="64" Height="32" Offset="0xA2D8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_00B2D8" OutName="ganontikasonogo_room_0Tex_00B2D8" Format="rgba16" Width="32" Height="64" Offset="0xB2D8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_00C2D8" OutName="ganontikasonogo_room_0Tex_00C2D8" Format="rgba16" Width="64" Height="32" Offset="0xC2D8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_00D2D8" OutName="ganontikasonogo_room_0Tex_00D2D8" Format="rgba16" Width="64" Height="32" Offset="0xD2D8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_00E2D8" OutName="ganontikasonogo_room_0Tex_00E2D8" Format="rgba16" Width="64" Height="32" Offset="0xE2D8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_00F2D8" OutName="ganontikasonogo_room_0Tex_00F2D8" Format="rgba16" Width="32" Height="32" Offset="0xF2D8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_00FAD8" OutName="ganontikasonogo_room_0Tex_00FAD8" Format="rgba16" Width="32" Height="64" Offset="0xFAD8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_010AD8" OutName="ganontikasonogo_room_0Tex_010AD8" Format="ci4" Width="64" Height="64" Offset="0x10AD8" TlutOffset="0x92B8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_0112D8" OutName="ganontikasonogo_room_0Tex_0112D8" Format="ci4" Width="64" Height="64" Offset="0x112D8" TlutOffset="0x92B8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_011AD8" OutName="ganontikasonogo_room_0Tex_011AD8" Format="ci4" Width="64" Height="64" Offset="0x11AD8" TlutOffset="0x92B8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_0122D8" OutName="ganontikasonogo_room_0Tex_0122D8" Format="ci4" Width="64" Height="64" Offset="0x122D8" TlutOffset="0x92B8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_012AD8" OutName="ganontikasonogo_room_0Tex_012AD8" Format="ci4" Width="64" Height="64" Offset="0x12AD8" TlutOffset="0x92B8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_0132D8" OutName="ganontikasonogo_room_0Tex_0132D8" Format="rgba16" Width="64" Height="32" Offset="0x132D8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_0142D8" OutName="ganontikasonogo_room_0Tex_0142D8" Format="rgba16" Width="64" Height="16" Offset="0x142D8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_014AD8" OutName="ganontikasonogo_room_0Tex_014AD8" Format="rgba16" Width="64" Height="32" Offset="0x14AD8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_016B78" OutName="ganontikasonogo_room_0Tex_016B78" Format="ia8" Width="64" Height="64" Offset="0x16B78" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0TLUT_0092B8" OutName="ganontikasonogo_room_0TLUT_0092B8" Format="rgba16" Width="4" Height="4" Offset="0x92B8" AddedByScript="true"/>
         <Room Name="ganontikasonogo_room_0" Offset="0x0"/>
     </File>
     <File Name="ganontikasonogo_room_1" Segment="3">
+        <Texture Name="ganontikasonogo_room_1Tex_006C60" OutName="ganontikasonogo_room_1Tex_006C60" Format="rgba16" Width="32" Height="32" Offset="0x6C60" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_1Tex_007460" OutName="ganontikasonogo_room_1Tex_007460" Format="rgba16" Width="64" Height="32" Offset="0x7460" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_1Tex_008460" OutName="ganontikasonogo_room_1Tex_008460" Format="rgba16" Width="32" Height="64" Offset="0x8460" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_1Tex_009720" OutName="ganontikasonogo_room_1Tex_009720" Format="ia16" Width="8" Height="128" Offset="0x9720" AddedByScript="true"/>
         <Room Name="ganontikasonogo_room_1" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_MQ_D/scenes/dungeons/gerudoway.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/dungeons/gerudoway.xml
@@ -1,26 +1,55 @@
 <Root>
     <File Name="gerudoway_scene" Segment="2">
+        <Texture Name="gerudoway_sceneTex_007520" OutName="gerudoway_sceneTex_007520" Format="rgba16" Width="32" Height="64" Offset="0x7520" AddedByScript="true"/>
+        <Texture Name="gerudoway_sceneTex_008520" OutName="gerudoway_sceneTex_008520" Format="ia4" Width="128" Height="32" Offset="0x8520" AddedByScript="true"/>
+        <Texture Name="gerudoway_sceneTex_008D20" OutName="gerudoway_sceneTex_008D20" Format="ia8" Width="64" Height="32" Offset="0x8D20" AddedByScript="true"/>
+        <Texture Name="gerudoway_sceneTex_009520" OutName="gerudoway_sceneTex_009520" Format="ia8" Width="32" Height="64" Offset="0x9520" AddedByScript="true"/>
+        <Texture Name="gerudoway_sceneTex_009D20" OutName="gerudoway_sceneTex_009D20" Format="rgba16" Width="32" Height="32" Offset="0x9D20" AddedByScript="true"/>
+        <Texture Name="gerudoway_sceneTex_00A520" OutName="gerudoway_sceneTex_00A520" Format="rgba16" Width="32" Height="16" Offset="0xA520" AddedByScript="true"/>
+        <Texture Name="gerudoway_sceneTex_00A920" OutName="gerudoway_sceneTex_00A920" Format="rgba16" Width="32" Height="64" Offset="0xA920" AddedByScript="true"/>
+        <Texture Name="gerudoway_sceneTex_00C120" OutName="gerudoway_sceneTex_00C120" Format="rgba16" Width="64" Height="32" Offset="0xC120" AddedByScript="true"/>
+        <Texture Name="gerudoway_sceneTex_00D120" OutName="gerudoway_sceneTex_00D120" Format="rgba16" Width="32" Height="32" Offset="0xD120" AddedByScript="true"/>
         <Texture Name="gThievesHideoutNightEntranceTex" OutName="night_entrance" Format="ia16" Width="128" Height="4" Offset="0xB920"/>
         <Texture Name="gThievesHideoutDayEntranceTex" OutName="day_entrance" Format="ia16" Width="128" Height="4" Offset="0xBD20"/>
         <Path Name="gerudoway_scenePathList_0002AC" Offset="0x02AC" NumPaths="4"/>
         <Scene Name="gerudoway_scene" Offset="0x0"/>
     </File>
     <File Name="gerudoway_room_0" Segment="3">
+        <Texture Name="gerudoway_room_0Tex_002FB0" OutName="gerudoway_room_0Tex_002FB0" Format="rgba16" Width="64" Height="32" Offset="0x2FB0" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_0Tex_003FB0" OutName="gerudoway_room_0Tex_003FB0" Format="rgba16" Width="32" Height="16" Offset="0x3FB0" AddedByScript="true"/>
         <Room Name="gerudoway_room_0" Offset="0x0"/>
     </File>
      <File Name="gerudoway_room_1" Segment="3">
+        <Texture Name="gerudoway_room_1Tex_003710" OutName="gerudoway_room_1Tex_003710" Format="rgba16" Width="32" Height="32" Offset="0x3710" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_1Tex_003F10" OutName="gerudoway_room_1Tex_003F10" Format="ia4" Width="32" Height="128" Offset="0x3F10" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_1Tex_004710" OutName="gerudoway_room_1Tex_004710" Format="rgba16" Width="64" Height="32" Offset="0x4710" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_1Tex_005710" OutName="gerudoway_room_1Tex_005710" Format="rgba16" Width="32" Height="16" Offset="0x5710" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_1Tex_005B10" OutName="gerudoway_room_1Tex_005B10" Format="rgba16" Width="64" Height="16" Offset="0x5B10" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_1Tex_006310" OutName="gerudoway_room_1Tex_006310" Format="rgba16" Width="16" Height="64" Offset="0x6310" AddedByScript="true"/>
         <Room Name="gerudoway_room_1" Offset="0x0"/>
     </File>
      <File Name="gerudoway_room_2" Segment="3">
+        <Texture Name="gerudoway_room_2Tex_002298" OutName="gerudoway_room_2Tex_002298" Format="rgba16" Width="64" Height="16" Offset="0x2298" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_2Tex_002A98" OutName="gerudoway_room_2Tex_002A98" Format="rgba16" Width="16" Height="64" Offset="0x2A98" AddedByScript="true"/>
         <Room Name="gerudoway_room_2" Offset="0x0"/>
     </File>
      <File Name="gerudoway_room_3" Segment="3">
+        <Texture Name="gerudoway_room_3Tex_006EA0" OutName="gerudoway_room_3Tex_006EA0" Format="rgba16" Width="32" Height="32" Offset="0x6EA0" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_3Tex_0076A0" OutName="gerudoway_room_3Tex_0076A0" Format="ia4" Width="32" Height="128" Offset="0x76A0" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_3Tex_007EA0" OutName="gerudoway_room_3Tex_007EA0" Format="rgba16" Width="64" Height="32" Offset="0x7EA0" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_3Tex_008EA0" OutName="gerudoway_room_3Tex_008EA0" Format="rgba16" Width="32" Height="16" Offset="0x8EA0" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_3Tex_0092A0" OutName="gerudoway_room_3Tex_0092A0" Format="rgba16" Width="32" Height="32" Offset="0x92A0" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_3Tex_009AA0" OutName="gerudoway_room_3Tex_009AA0" Format="rgba16" Width="16" Height="64" Offset="0x9AA0" AddedByScript="true"/>
         <Room Name="gerudoway_room_3" Offset="0x0"/>
     </File>
      <File Name="gerudoway_room_4" Segment="3">
+        <Texture Name="gerudoway_room_4Tex_002028" OutName="gerudoway_room_4Tex_002028" Format="rgba16" Width="64" Height="16" Offset="0x2028" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_4Tex_002828" OutName="gerudoway_room_4Tex_002828" Format="rgba16" Width="16" Height="64" Offset="0x2828" AddedByScript="true"/>
         <Room Name="gerudoway_room_4" Offset="0x0"/>
     </File>
      <File Name="gerudoway_room_5" Segment="3">
+        <Texture Name="gerudoway_room_5Tex_002FF8" OutName="gerudoway_room_5Tex_002FF8" Format="rgba16" Width="64" Height="16" Offset="0x2FF8" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_5Tex_0037F8" OutName="gerudoway_room_5Tex_0037F8" Format="rgba16" Width="16" Height="64" Offset="0x37F8" AddedByScript="true"/>
         <Room Name="gerudoway_room_5" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_MQ_D/scenes/dungeons/ice_doukutu.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/dungeons/ice_doukutu.xml
@@ -1,5 +1,11 @@
 <Root>
     <File Name="ice_doukutu_scene" Segment="2">
+        <Texture Name="ice_doukutu_sceneTex_00FCC0" OutName="ice_doukutu_sceneTex_00FCC0" Format="i8" Width="32" Height="32" Offset="0xFCC0" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_sceneTex_0100C0" OutName="ice_doukutu_sceneTex_0100C0" Format="rgba16" Width="32" Height="32" Offset="0x100C0" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_sceneTex_0108C0" OutName="ice_doukutu_sceneTex_0108C0" Format="rgba16" Width="16" Height="16" Offset="0x108C0" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_sceneTex_010AC0" OutName="ice_doukutu_sceneTex_010AC0" Format="i8" Width="32" Height="32" Offset="0x10AC0" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_sceneTex_010EC0" OutName="ice_doukutu_sceneTex_010EC0" Format="rgba16" Width="32" Height="32" Offset="0x10EC0" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_sceneTLUT_00F8A0" OutName="ice_doukutu_sceneTLUT_00F8A0" Format="rgba16" Width="4" Height="4" Offset="0xF8A0" AddedByScript="true"/>
         <Path Name="ice_doukutu_scenePathList_000304" Offset="0x0304" NumPaths="5"/>
         <Cutscene Name="gIceCavernSerenadeCs" Offset="0x330"/>
         <Texture Name="gIceCavernNightEntranceTex" OutName="night_entrance" Format="ia16" Width="64" Height="4" Offset="0xF8C0"/>
@@ -7,39 +13,94 @@
         <Scene Name="ice_doukutu_scene" Offset="0x0"/>
     </File>
     <File Name="ice_doukutu_room_0" Segment="3">
+        <Texture Name="ice_doukutu_room_0Tex_002F50" OutName="ice_doukutu_room_0Tex_002F50" Format="rgba16" Width="32" Height="64" Offset="0x2F50" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_0Tex_003F50" OutName="ice_doukutu_room_0Tex_003F50" Format="rgba16" Width="32" Height="32" Offset="0x3F50" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_0Tex_004750" OutName="ice_doukutu_room_0Tex_004750" Format="rgba16" Width="32" Height="64" Offset="0x4750" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_0Tex_005750" OutName="ice_doukutu_room_0Tex_005750" Format="rgba16" Width="32" Height="32" Offset="0x5750" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_0Tex_005F50" OutName="ice_doukutu_room_0Tex_005F50" Format="i8" Width="64" Height="64" Offset="0x5F50" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_0Tex_007678" OutName="ice_doukutu_room_0Tex_007678" Format="i8" Width="64" Height="64" Offset="0x7678" AddedByScript="true"/>
         <Room Name="ice_doukutu_room_0" Offset="0x0"/>
     </File>
     <File Name="ice_doukutu_room_1" Segment="3">
+        <Texture Name="ice_doukutu_room_1Tex_004110" OutName="ice_doukutu_room_1Tex_004110" Format="rgba16" Width="32" Height="64" Offset="0x4110" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_1Tex_005110" OutName="ice_doukutu_room_1Tex_005110" Format="rgba16" Width="32" Height="32" Offset="0x5110" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_1Tex_005910" OutName="ice_doukutu_room_1Tex_005910" Format="rgba16" Width="32" Height="64" Offset="0x5910" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_1Tex_006910" OutName="ice_doukutu_room_1Tex_006910" Format="rgba16" Width="32" Height="32" Offset="0x6910" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_1Tex_007110" OutName="ice_doukutu_room_1Tex_007110" Format="rgba16" Width="32" Height="64" Offset="0x7110" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_1Tex_008110" OutName="ice_doukutu_room_1Tex_008110" Format="i8" Width="64" Height="64" Offset="0x8110" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_1Tex_009110" OutName="ice_doukutu_room_1Tex_009110" Format="rgba16" Width="32" Height="32" Offset="0x9110" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_1Tex_00AB30" OutName="ice_doukutu_room_1Tex_00AB30" Format="rgba16" Width="32" Height="64" Offset="0xAB30" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_1Tex_00BB30" OutName="ice_doukutu_room_1Tex_00BB30" Format="rgba16" Width="16" Height="16" Offset="0xBB30" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_1Tex_00BD30" OutName="ice_doukutu_room_1Tex_00BD30" Format="rgba16" Width="32" Height="32" Offset="0xBD30" AddedByScript="true"/>
         <Room Name="ice_doukutu_room_1" Offset="0x0"/>
     </File>
     <File Name="ice_doukutu_room_2" Segment="3">
+        <Texture Name="ice_doukutu_room_2Tex_001730" OutName="ice_doukutu_room_2Tex_001730" Format="rgba16" Width="32" Height="64" Offset="0x1730" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_2Tex_002730" OutName="ice_doukutu_room_2Tex_002730" Format="ci4" Width="64" Height="64" Offset="0x2730" ExternalTlut="ice_doukutu_scene" ExternalTlutOffset="0xF8A0" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_2Tex_003AF8" OutName="ice_doukutu_room_2Tex_003AF8" Format="i8" Width="64" Height="64" Offset="0x3AF8" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_2Tex_004AF8" OutName="ice_doukutu_room_2Tex_004AF8" Format="rgba16" Width="32" Height="64" Offset="0x4AF8" AddedByScript="true"/>
         <Room Name="ice_doukutu_room_2" Offset="0x0"/>
     </File>
     <File Name="ice_doukutu_room_3" Segment="3">
+        <Texture Name="ice_doukutu_room_3Tex_003208" OutName="ice_doukutu_room_3Tex_003208" Format="rgba16" Width="32" Height="32" Offset="0x3208" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_3Tex_003A08" OutName="ice_doukutu_room_3Tex_003A08" Format="ci4" Width="64" Height="64" Offset="0x3A08" ExternalTlut="ice_doukutu_scene" ExternalTlutOffset="0xF8A0" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_3Tex_005090" OutName="ice_doukutu_room_3Tex_005090" Format="i8" Width="64" Height="64" Offset="0x5090" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_3Tex_006090" OutName="ice_doukutu_room_3Tex_006090" Format="rgba16" Width="32" Height="64" Offset="0x6090" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_3Tex_007090" OutName="ice_doukutu_room_3Tex_007090" Format="i8" Width="32" Height="128" Offset="0x7090" AddedByScript="true"/>
         <Room Name="ice_doukutu_room_3" Offset="0x0"/>
     </File>
     <File Name="ice_doukutu_room_4" Segment="3">
+        <Texture Name="ice_doukutu_room_4Tex_0028E0" OutName="ice_doukutu_room_4Tex_0028E0" Format="rgba16" Width="32" Height="32" Offset="0x28E0" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_4Tex_0030E0" OutName="ice_doukutu_room_4Tex_0030E0" Format="rgba16" Width="32" Height="32" Offset="0x30E0" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_4Tex_0038E0" OutName="ice_doukutu_room_4Tex_0038E0" Format="ci4" Width="64" Height="64" Offset="0x38E0" ExternalTlut="ice_doukutu_scene" ExternalTlutOffset="0xF8A0" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_4Tex_004650" OutName="ice_doukutu_room_4Tex_004650" Format="i8" Width="64" Height="64" Offset="0x4650" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_4Tex_005650" OutName="ice_doukutu_room_4Tex_005650" Format="rgba16" Width="32" Height="64" Offset="0x5650" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_4Tex_006650" OutName="ice_doukutu_room_4Tex_006650" Format="i8" Width="32" Height="128" Offset="0x6650" AddedByScript="true"/>
         <Room Name="ice_doukutu_room_4" Offset="0x0"/>
     </File>
     <File Name="ice_doukutu_room_5" Segment="3">
+        <Texture Name="ice_doukutu_room_5Tex_004648" OutName="ice_doukutu_room_5Tex_004648" Format="rgba16" Width="16" Height="128" Offset="0x4648" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_5Tex_005648" OutName="ice_doukutu_room_5Tex_005648" Format="rgba16" Width="32" Height="32" Offset="0x5648" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_5Tex_005E48" OutName="ice_doukutu_room_5Tex_005E48" Format="rgba16" Width="32" Height="32" Offset="0x5E48" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_5Tex_006648" OutName="ice_doukutu_room_5Tex_006648" Format="rgba16" Width="32" Height="32" Offset="0x6648" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_5Tex_007478" OutName="ice_doukutu_room_5Tex_007478" Format="i8" Width="32" Height="32" Offset="0x7478" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_5Tex_007878" OutName="ice_doukutu_room_5Tex_007878" Format="i8" Width="64" Height="64" Offset="0x7878" AddedByScript="true"/>
         <Room Name="ice_doukutu_room_5" Offset="0x0"/>
     </File>
     <File Name="ice_doukutu_room_6" Segment="3">
+        <Texture Name="ice_doukutu_room_6Tex_0029B0" OutName="ice_doukutu_room_6Tex_0029B0" Format="i8" Width="64" Height="64" Offset="0x29B0" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_6Tex_0039B0" OutName="ice_doukutu_room_6Tex_0039B0" Format="rgba16" Width="32" Height="32" Offset="0x39B0" AddedByScript="true"/>
         <Room Name="ice_doukutu_room_6" Offset="0x0"/>
     </File>
     <File Name="ice_doukutu_room_7" Segment="3">
+        <Texture Name="ice_doukutu_room_7Tex_001758" OutName="ice_doukutu_room_7Tex_001758" Format="ci4" Width="64" Height="64" Offset="0x1758" ExternalTlut="ice_doukutu_scene" ExternalTlutOffset="0xF8A0" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_7Tex_0040E8" OutName="ice_doukutu_room_7Tex_0040E8" Format="i8" Width="64" Height="64" Offset="0x40E8" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_7Tex_0050E8" OutName="ice_doukutu_room_7Tex_0050E8" Format="rgba16" Width="32" Height="32" Offset="0x50E8" AddedByScript="true"/>
         <Room Name="ice_doukutu_room_7" Offset="0x0"/>
     </File>
     <File Name="ice_doukutu_room_8" Segment="3">
         <Room Name="ice_doukutu_room_8" Offset="0x0"/>
     </File>
     <File Name="ice_doukutu_room_9" Segment="3">
+        <Texture Name="ice_doukutu_room_9Tex_0044A0" OutName="ice_doukutu_room_9Tex_0044A0" Format="rgba16" Width="32" Height="64" Offset="0x44A0" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_9Tex_0054A0" OutName="ice_doukutu_room_9Tex_0054A0" Format="rgba16" Width="32" Height="32" Offset="0x54A0" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_9Tex_005CA0" OutName="ice_doukutu_room_9Tex_005CA0" Format="rgba16" Width="32" Height="32" Offset="0x5CA0" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_9Tex_0064A0" OutName="ice_doukutu_room_9Tex_0064A0" Format="rgba16" Width="32" Height="32" Offset="0x64A0" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_9Tex_006CA0" OutName="ice_doukutu_room_9Tex_006CA0" Format="rgba16" Width="32" Height="32" Offset="0x6CA0" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_9Tex_007690" OutName="ice_doukutu_room_9Tex_007690" Format="rgba16" Width="32" Height="64" Offset="0x7690" AddedByScript="true"/>
         <Room Name="ice_doukutu_room_9" Offset="0x0"/>
     </File>
     <File Name="ice_doukutu_room_10" Segment="3">
+        <Texture Name="ice_doukutu_room_10Tex_001A28" OutName="ice_doukutu_room_10Tex_001A28" Format="rgba16" Width="32" Height="64" Offset="0x1A28" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_10Tex_002A28" OutName="ice_doukutu_room_10Tex_002A28" Format="i8" Width="64" Height="64" Offset="0x2A28" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_10Tex_003BD8" OutName="ice_doukutu_room_10Tex_003BD8" Format="rgba16" Width="32" Height="32" Offset="0x3BD8" AddedByScript="true"/>
         <Room Name="ice_doukutu_room_10" Offset="0x0"/>
     </File>
     <File Name="ice_doukutu_room_11" Segment="3">
+        <Texture Name="ice_doukutu_room_11Tex_002928" OutName="ice_doukutu_room_11Tex_002928" Format="rgba16" Width="32" Height="32" Offset="0x2928" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_11Tex_003128" OutName="ice_doukutu_room_11Tex_003128" Format="rgba16" Width="32" Height="32" Offset="0x3128" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_11Tex_003928" OutName="ice_doukutu_room_11Tex_003928" Format="rgba16" Width="32" Height="32" Offset="0x3928" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_11Tex_004848" OutName="ice_doukutu_room_11Tex_004848" Format="i8" Width="64" Height="64" Offset="0x4848" AddedByScript="true"/>
         <Room Name="ice_doukutu_room_11" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_MQ_D/scenes/dungeons/jyasinboss.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/dungeons/jyasinboss.xml
@@ -1,19 +1,49 @@
 <Root>
     <File Name="jyasinboss_scene" Segment="2">
+        <Texture Name="jyasinboss_sceneTex_006CF0" OutName="jyasinboss_sceneTex_006CF0" Format="rgba16" Width="64" Height="32" Offset="0x6CF0" AddedByScript="true"/>
+        <Texture Name="jyasinboss_sceneTex_007CF0" OutName="jyasinboss_sceneTex_007CF0" Format="rgba16" Width="64" Height="32" Offset="0x7CF0" AddedByScript="true"/>
         <Cutscene Name="gSpiritBossNabooruKnuckleIntroCs" Offset="0x2BB0"/>
         <Cutscene Name="gSpiritBossNabooruKnuckleDefeatCs" Offset="0x3F80"/>
         <Scene Name="jyasinboss_scene" Offset="0x0"/>
     </File>
     <File Name="jyasinboss_room_0" Segment="3">
+        <Texture Name="jyasinboss_room_0Tex_0007C8" OutName="jyasinboss_room_0Tex_0007C8" Format="rgba16" Width="32" Height="32" Offset="0x7C8" AddedByScript="true"/>
         <Room Name="jyasinboss_room_0" Offset="0x0"/>
     </File>
     <File Name="jyasinboss_room_1" Segment="3">
+        <Texture Name="jyasinboss_room_1Tex_002E38" OutName="jyasinboss_room_1Tex_002E38" Format="rgba16" Width="64" Height="32" Offset="0x2E38" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_1Tex_003E38" OutName="jyasinboss_room_1Tex_003E38" Format="rgba16" Width="64" Height="32" Offset="0x3E38" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_1Tex_004E38" OutName="jyasinboss_room_1Tex_004E38" Format="rgba16" Width="32" Height="32" Offset="0x4E38" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_1Tex_005638" OutName="jyasinboss_room_1Tex_005638" Format="rgba16" Width="64" Height="32" Offset="0x5638" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_1Tex_006638" OutName="jyasinboss_room_1Tex_006638" Format="rgba16" Width="64" Height="16" Offset="0x6638" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_1Tex_006E38" OutName="jyasinboss_room_1Tex_006E38" Format="ci4" Width="64" Height="64" Offset="0x6E38" TlutOffset="0x2E18" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_1Tex_007638" OutName="jyasinboss_room_1Tex_007638" Format="rgba16" Width="32" Height="32" Offset="0x7638" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_1TLUT_002E18" OutName="jyasinboss_room_1TLUT_002E18" Format="rgba16" Width="4" Height="4" Offset="0x2E18" AddedByScript="true"/>
         <Room Name="jyasinboss_room_1" Offset="0x0"/>
     </File>
     <File Name="jyasinboss_room_2" Segment="3">
+        <Texture Name="jyasinboss_room_2Tex_0021C0" OutName="jyasinboss_room_2Tex_0021C0" Format="rgba16" Width="64" Height="16" Offset="0x21C0" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_2Tex_0029C0" OutName="jyasinboss_room_2Tex_0029C0" Format="rgba16" Width="32" Height="64" Offset="0x29C0" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_2Tex_0039C0" OutName="jyasinboss_room_2Tex_0039C0" Format="rgba16" Width="16" Height="32" Offset="0x39C0" AddedByScript="true"/>
         <Room Name="jyasinboss_room_2" Offset="0x0"/>
     </File>
     <File Name="jyasinboss_room_3" Segment="3">
+        <Texture Name="jyasinboss_room_3Tex_003F00" OutName="jyasinboss_room_3Tex_003F00" Format="ci8" Width="32" Height="32" Offset="0x3F00" TlutOffset="0x3CE0" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3Tex_004300" OutName="jyasinboss_room_3Tex_004300" Format="ci8" Width="32" Height="32" Offset="0x4300" TlutOffset="0x3CE0" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3Tex_004700" OutName="jyasinboss_room_3Tex_004700" Format="ci8" Width="64" Height="32" Offset="0x4700" TlutOffset="0x3CE0" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3Tex_004F00" OutName="jyasinboss_room_3Tex_004F00" Format="ci8" Width="32" Height="32" Offset="0x4F00" TlutOffset="0x3CE0" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3Tex_005300" OutName="jyasinboss_room_3Tex_005300" Format="ci8" Width="32" Height="32" Offset="0x5300" TlutOffset="0x3CE0" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3Tex_005700" OutName="jyasinboss_room_3Tex_005700" Format="ci8" Width="32" Height="64" Offset="0x5700" TlutOffset="0x3CE0" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3Tex_005F00" OutName="jyasinboss_room_3Tex_005F00" Format="rgba16" Width="32" Height="32" Offset="0x5F00" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3Tex_006700" OutName="jyasinboss_room_3Tex_006700" Format="rgba16" Width="64" Height="32" Offset="0x6700" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3Tex_007700" OutName="jyasinboss_room_3Tex_007700" Format="rgba16" Width="32" Height="32" Offset="0x7700" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3Tex_007F00" OutName="jyasinboss_room_3Tex_007F00" Format="rgba16" Width="16" Height="128" Offset="0x7F00" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3Tex_008F00" OutName="jyasinboss_room_3Tex_008F00" Format="rgba16" Width="64" Height="32" Offset="0x8F00" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3Tex_009F00" OutName="jyasinboss_room_3Tex_009F00" Format="ci4" Width="64" Height="64" Offset="0x9F00" TlutOffset="0x3EE0" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3Tex_00A700" OutName="jyasinboss_room_3Tex_00A700" Format="rgba16" Width="32" Height="32" Offset="0xA700" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3Tex_00AF00" OutName="jyasinboss_room_3Tex_00AF00" Format="rgba16" Width="32" Height="32" Offset="0xAF00" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3TLUT_003CE0" OutName="jyasinboss_room_3TLUT_003CE0" Format="rgba16" Width="16" Height="16" Offset="0x3CE0" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3TLUT_003EE0" OutName="jyasinboss_room_3TLUT_003EE0" Format="rgba16" Width="4" Height="4" Offset="0x3EE0" AddedByScript="true"/>
         <Room Name="jyasinboss_room_3" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_MQ_D/scenes/dungeons/jyasinzou.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/dungeons/jyasinzou.xml
@@ -1,95 +1,358 @@
 <Root>
     <File Name="jyasinzou_scene" Segment="2">
+        <Texture Name="jyasinzou_sceneTex_018820" OutName="jyasinzou_sceneTex_018820" Format="ci8" Width="16" Height="16" Offset="0x18820" TlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_sceneTex_019120" OutName="jyasinzou_sceneTex_019120" Format="rgba16" Width="16" Height="16" Offset="0x19120" AddedByScript="true"/>
+        <Texture Name="jyasinzou_sceneTex_019320" OutName="jyasinzou_sceneTex_019320" Format="ci4" Width="64" Height="64" Offset="0x19320" TlutOffset="0x18000" AddedByScript="true"/>
+        <Texture Name="jyasinzou_sceneTLUT_017BE0" OutName="jyasinzou_sceneTLUT_017BE0" Format="rgba16" Width="16" Height="16" Offset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_sceneTLUT_017DE0" OutName="jyasinzou_sceneTLUT_017DE0" Format="rgba16" Width="16" Height="16" Offset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_sceneTLUT_017FE0" OutName="jyasinzou_sceneTLUT_017FE0" Format="rgba16" Width="4" Height="4" Offset="0x17FE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_sceneTLUT_018000" OutName="jyasinzou_sceneTLUT_018000" Format="rgba16" Width="4" Height="4" Offset="0x18000" AddedByScript="true"/>
         <Path Name="jyasinzou_scenePathList_00049C" Offset="0x049C" NumPaths="5"/>
         <Texture Name="gSpiritTempleDayEntranceTex" OutName="day_entrance" Format="ia16" Width="8" Height="128" Offset="0x18920"/>
         <Texture Name="gSpiritTempleNightEntranceTex" OutName="night_entrance" Format="ia16" Width="8" Height="128" Offset="0x18020"/>
         <Scene Name="jyasinzou_scene" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_0" Segment="3">
+        <Texture Name="jyasinzou_room_0Tex_00A9D8" OutName="jyasinzou_room_0Tex_00A9D8" Format="ci8" Width="64" Height="32" Offset="0xA9D8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_0Tex_00B1D8" OutName="jyasinzou_room_0Tex_00B1D8" Format="ci8" Width="64" Height="32" Offset="0xB1D8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_0Tex_00B9D8" OutName="jyasinzou_room_0Tex_00B9D8" Format="ci8" Width="32" Height="64" Offset="0xB9D8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_0Tex_00C1D8" OutName="jyasinzou_room_0Tex_00C1D8" Format="ci8" Width="32" Height="64" Offset="0xC1D8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_0Tex_00C9D8" OutName="jyasinzou_room_0Tex_00C9D8" Format="ci8" Width="32" Height="64" Offset="0xC9D8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_0Tex_00D1D8" OutName="jyasinzou_room_0Tex_00D1D8" Format="ci8" Width="32" Height="32" Offset="0xD1D8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_0Tex_00D5D8" OutName="jyasinzou_room_0Tex_00D5D8" Format="ci8" Width="16" Height="128" Offset="0xD5D8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_0Tex_00DDD8" OutName="jyasinzou_room_0Tex_00DDD8" Format="ci8" Width="32" Height="32" Offset="0xDDD8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_0Tex_00E1D8" OutName="jyasinzou_room_0Tex_00E1D8" Format="ci8" Width="64" Height="32" Offset="0xE1D8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_0Tex_00E9D8" OutName="jyasinzou_room_0Tex_00E9D8" Format="ci8" Width="64" Height="32" Offset="0xE9D8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_0Tex_00F1D8" OutName="jyasinzou_room_0Tex_00F1D8" Format="ci4" Width="64" Height="64" Offset="0xF1D8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17FE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_0Tex_00F9D8" OutName="jyasinzou_room_0Tex_00F9D8" Format="ci4" Width="64" Height="64" Offset="0xF9D8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18000" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_0Tex_0107E8" OutName="jyasinzou_room_0Tex_0107E8" Format="ia8" Width="64" Height="32" Offset="0x107E8" AddedByScript="true"/>
         <Room Name="jyasinzou_room_0" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_1" Segment="3">
+        <Texture Name="jyasinzou_room_1Tex_004F48" OutName="jyasinzou_room_1Tex_004F48" Format="ci8" Width="64" Height="32" Offset="0x4F48" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_1Tex_005748" OutName="jyasinzou_room_1Tex_005748" Format="ci8" Width="32" Height="64" Offset="0x5748" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_1Tex_005F48" OutName="jyasinzou_room_1Tex_005F48" Format="ci8" Width="32" Height="64" Offset="0x5F48" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_1Tex_006748" OutName="jyasinzou_room_1Tex_006748" Format="ci8" Width="32" Height="32" Offset="0x6748" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_1Tex_006B48" OutName="jyasinzou_room_1Tex_006B48" Format="ci8" Width="32" Height="64" Offset="0x6B48" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_1Tex_007348" OutName="jyasinzou_room_1Tex_007348" Format="ci8" Width="64" Height="32" Offset="0x7348" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_1Tex_007B48" OutName="jyasinzou_room_1Tex_007B48" Format="ci8" Width="64" Height="32" Offset="0x7B48" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_1Tex_008348" OutName="jyasinzou_room_1Tex_008348" Format="ci4" Width="64" Height="64" Offset="0x8348" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17FE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_1Tex_008B48" OutName="jyasinzou_room_1Tex_008B48" Format="ci4" Width="64" Height="64" Offset="0x8B48" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18000" AddedByScript="true"/>
         <Room Name="jyasinzou_room_1" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_2" Segment="3">
+        <Texture Name="jyasinzou_room_2Tex_0023B0" OutName="jyasinzou_room_2Tex_0023B0" Format="rgba16" Width="32" Height="64" Offset="0x23B0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_2Tex_0033B0" OutName="jyasinzou_room_2Tex_0033B0" Format="ci8" Width="64" Height="32" Offset="0x33B0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_2Tex_003BB0" OutName="jyasinzou_room_2Tex_003BB0" Format="rgba16" Width="16" Height="32" Offset="0x3BB0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_2Tex_003FB0" OutName="jyasinzou_room_2Tex_003FB0" Format="rgba16" Width="32" Height="32" Offset="0x3FB0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_2Tex_0047B0" OutName="jyasinzou_room_2Tex_0047B0" Format="ci8" Width="32" Height="32" Offset="0x47B0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_2Tex_004BB0" OutName="jyasinzou_room_2Tex_004BB0" Format="ci8" Width="64" Height="32" Offset="0x4BB0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_2Tex_0053B0" OutName="jyasinzou_room_2Tex_0053B0" Format="ci4" Width="64" Height="64" Offset="0x53B0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18000" AddedByScript="true"/>
         <Room Name="jyasinzou_room_2" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_3" Segment="3">
+        <Texture Name="jyasinzou_room_3Tex_001FC8" OutName="jyasinzou_room_3Tex_001FC8" Format="ci8" Width="32" Height="32" Offset="0x1FC8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_3Tex_0023C8" OutName="jyasinzou_room_3Tex_0023C8" Format="ci8" Width="64" Height="32" Offset="0x23C8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_3Tex_002BC8" OutName="jyasinzou_room_3Tex_002BC8" Format="ci4" Width="64" Height="64" Offset="0x2BC8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17FE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_3Tex_0033C8" OutName="jyasinzou_room_3Tex_0033C8" Format="ci4" Width="64" Height="64" Offset="0x33C8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18000" AddedByScript="true"/>
         <Room Name="jyasinzou_room_3" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_4" Segment="3">
+        <Texture Name="jyasinzou_room_4Tex_003698" OutName="jyasinzou_room_4Tex_003698" Format="ci8" Width="32" Height="64" Offset="0x3698" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_4Tex_003E98" OutName="jyasinzou_room_4Tex_003E98" Format="ci8" Width="32" Height="64" Offset="0x3E98" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_4Tex_004698" OutName="jyasinzou_room_4Tex_004698" Format="ci8" Width="32" Height="64" Offset="0x4698" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_4Tex_004E98" OutName="jyasinzou_room_4Tex_004E98" Format="ci8" Width="64" Height="32" Offset="0x4E98" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_4Tex_005698" OutName="jyasinzou_room_4Tex_005698" Format="ci8" Width="16" Height="16" Offset="0x5698" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_4Tex_005798" OutName="jyasinzou_room_4Tex_005798" Format="ci8" Width="32" Height="32" Offset="0x5798" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_4Tex_005B98" OutName="jyasinzou_room_4Tex_005B98" Format="ci8" Width="64" Height="32" Offset="0x5B98" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_4Tex_006398" OutName="jyasinzou_room_4Tex_006398" Format="ci8" Width="32" Height="32" Offset="0x6398" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_4Tex_006798" OutName="jyasinzou_room_4Tex_006798" Format="ci4" Width="64" Height="64" Offset="0x6798" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18000" AddedByScript="true"/>
         <Room Name="jyasinzou_room_4" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_5" Segment="3">
+        <Texture Name="jyasinzou_room_5Tex_00CBC8" OutName="jyasinzou_room_5Tex_00CBC8" Format="ci8" Width="32" Height="32" Offset="0xCBC8" TlutOffset="0xC9B0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_00CFC8" OutName="jyasinzou_room_5Tex_00CFC8" Format="ci8" Width="64" Height="32" Offset="0xCFC8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_00D7C8" OutName="jyasinzou_room_5Tex_00D7C8" Format="ci8" Width="16" Height="64" Offset="0xD7C8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_00DBC8" OutName="jyasinzou_room_5Tex_00DBC8" Format="ci8" Width="32" Height="32" Offset="0xDBC8" TlutOffset="0xC9B0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_00DFC8" OutName="jyasinzou_room_5Tex_00DFC8" Format="ci8" Width="64" Height="32" Offset="0xDFC8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_00E7C8" OutName="jyasinzou_room_5Tex_00E7C8" Format="rgba16" Width="32" Height="32" Offset="0xE7C8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_00EFC8" OutName="jyasinzou_room_5Tex_00EFC8" Format="rgba16" Width="32" Height="16" Offset="0xEFC8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_00F3C8" OutName="jyasinzou_room_5Tex_00F3C8" Format="ci8" Width="32" Height="32" Offset="0xF3C8" TlutOffset="0xC9B0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_00F7C8" OutName="jyasinzou_room_5Tex_00F7C8" Format="ci8" Width="32" Height="64" Offset="0xF7C8" TlutOffset="0xC9B0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_00FFC8" OutName="jyasinzou_room_5Tex_00FFC8" Format="ci8" Width="16" Height="16" Offset="0xFFC8" TlutOffset="0xC9B0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_0100C8" OutName="jyasinzou_room_5Tex_0100C8" Format="ci8" Width="64" Height="32" Offset="0x100C8" TlutOffset="0xC9B0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_0108C8" OutName="jyasinzou_room_5Tex_0108C8" Format="ci8" Width="32" Height="32" Offset="0x108C8" TlutOffset="0xC9B0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_010CC8" OutName="jyasinzou_room_5Tex_010CC8" Format="ci8" Width="32" Height="32" Offset="0x10CC8" TlutOffset="0xC9B0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_0110C8" OutName="jyasinzou_room_5Tex_0110C8" Format="ci8" Width="32" Height="32" Offset="0x110C8" TlutOffset="0xC9B0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_0114C8" OutName="jyasinzou_room_5Tex_0114C8" Format="ci8" Width="32" Height="32" Offset="0x114C8" TlutOffset="0xC9B0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_0118C8" OutName="jyasinzou_room_5Tex_0118C8" Format="ci8" Width="32" Height="32" Offset="0x118C8" TlutOffset="0xC9B0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_011CC8" OutName="jyasinzou_room_5Tex_011CC8" Format="ci4" Width="32" Height="128" Offset="0x11CC8" TlutOffset="0xCBA8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_0124C8" OutName="jyasinzou_room_5Tex_0124C8" Format="ci8" Width="32" Height="64" Offset="0x124C8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_012CC8" OutName="jyasinzou_room_5Tex_012CC8" Format="ci8" Width="64" Height="32" Offset="0x12CC8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_0134C8" OutName="jyasinzou_room_5Tex_0134C8" Format="ci8" Width="32" Height="32" Offset="0x134C8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_0138C8" OutName="jyasinzou_room_5Tex_0138C8" Format="ci8" Width="32" Height="64" Offset="0x138C8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_0140C8" OutName="jyasinzou_room_5Tex_0140C8" Format="ci8" Width="64" Height="32" Offset="0x140C8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_0148C8" OutName="jyasinzou_room_5Tex_0148C8" Format="ci8" Width="64" Height="32" Offset="0x148C8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_0150C8" OutName="jyasinzou_room_5Tex_0150C8" Format="ci4" Width="64" Height="64" Offset="0x150C8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17FE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_0158C8" OutName="jyasinzou_room_5Tex_0158C8" Format="ci8" Width="32" Height="32" Offset="0x158C8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_015CC8" OutName="jyasinzou_room_5Tex_015CC8" Format="ci4" Width="64" Height="64" Offset="0x15CC8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18000" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_016808" OutName="jyasinzou_room_5Tex_016808" Format="ia8" Width="64" Height="32" Offset="0x16808" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_017008" OutName="jyasinzou_room_5Tex_017008" Format="rgba16" Width="32" Height="64" Offset="0x17008" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5TLUT_00C9B0" OutName="jyasinzou_room_5TLUT_00C9B0" Format="rgba16" Width="16" Height="16" Offset="0xC9B0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5TLUT_00CBA8" OutName="jyasinzou_room_5TLUT_00CBA8" Format="rgba16" Width="4" Height="4" Offset="0xCBA8" AddedByScript="true"/>
         <Room Name="jyasinzou_room_5" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_6" Segment="3">
+        <Texture Name="jyasinzou_room_6Tex_002BE8" OutName="jyasinzou_room_6Tex_002BE8" Format="ci8" Width="64" Height="32" Offset="0x2BE8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_6Tex_0033E8" OutName="jyasinzou_room_6Tex_0033E8" Format="ci8" Width="32" Height="32" Offset="0x33E8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_6Tex_0037E8" OutName="jyasinzou_room_6Tex_0037E8" Format="ci8" Width="64" Height="32" Offset="0x37E8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_6Tex_003FE8" OutName="jyasinzou_room_6Tex_003FE8" Format="ci8" Width="64" Height="32" Offset="0x3FE8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
         <Room Name="jyasinzou_room_6" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_7" Segment="3">
+        <Texture Name="jyasinzou_room_7Tex_002908" OutName="jyasinzou_room_7Tex_002908" Format="rgba16" Width="32" Height="64" Offset="0x2908" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_7Tex_003908" OutName="jyasinzou_room_7Tex_003908" Format="ci8" Width="64" Height="32" Offset="0x3908" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_7Tex_004108" OutName="jyasinzou_room_7Tex_004108" Format="ci8" Width="64" Height="32" Offset="0x4108" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_7Tex_004908" OutName="jyasinzou_room_7Tex_004908" Format="rgba16" Width="16" Height="32" Offset="0x4908" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_7Tex_004D08" OutName="jyasinzou_room_7Tex_004D08" Format="ci4" Width="64" Height="64" Offset="0x4D08" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18000" AddedByScript="true"/>
         <Room Name="jyasinzou_room_7" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_8" Segment="3">
+        <Texture Name="jyasinzou_room_8Tex_003A50" OutName="jyasinzou_room_8Tex_003A50" Format="ci8" Width="64" Height="32" Offset="0x3A50" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_8Tex_004250" OutName="jyasinzou_room_8Tex_004250" Format="ci8" Width="64" Height="32" Offset="0x4250" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_8Tex_004A50" OutName="jyasinzou_room_8Tex_004A50" Format="ci8" Width="32" Height="32" Offset="0x4A50" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_8Tex_004E50" OutName="jyasinzou_room_8Tex_004E50" Format="rgba16" Width="32" Height="32" Offset="0x4E50" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_8Tex_005650" OutName="jyasinzou_room_8Tex_005650" Format="ci8" Width="32" Height="64" Offset="0x5650" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_8Tex_005E50" OutName="jyasinzou_room_8Tex_005E50" Format="ci8" Width="32" Height="32" Offset="0x5E50" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_8Tex_006250" OutName="jyasinzou_room_8Tex_006250" Format="ci8" Width="32" Height="64" Offset="0x6250" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_8Tex_006A50" OutName="jyasinzou_room_8Tex_006A50" Format="ci8" Width="64" Height="32" Offset="0x6A50" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_8Tex_007250" OutName="jyasinzou_room_8Tex_007250" Format="ci4" Width="64" Height="64" Offset="0x7250" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18000" AddedByScript="true"/>
         <Room Name="jyasinzou_room_8" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_9" Segment="3">
+        <Texture Name="jyasinzou_room_9Tex_002DC8" OutName="jyasinzou_room_9Tex_002DC8" Format="rgba16" Width="32" Height="64" Offset="0x2DC8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_9Tex_003DC8" OutName="jyasinzou_room_9Tex_003DC8" Format="ci8" Width="64" Height="32" Offset="0x3DC8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_9Tex_0045C8" OutName="jyasinzou_room_9Tex_0045C8" Format="ci8" Width="64" Height="32" Offset="0x45C8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_9Tex_004DC8" OutName="jyasinzou_room_9Tex_004DC8" Format="rgba16" Width="16" Height="32" Offset="0x4DC8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_9Tex_0051C8" OutName="jyasinzou_room_9Tex_0051C8" Format="ci8" Width="64" Height="16" Offset="0x51C8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_9Tex_0055C8" OutName="jyasinzou_room_9Tex_0055C8" Format="ci8" Width="64" Height="32" Offset="0x55C8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
         <Room Name="jyasinzou_room_9" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_10" Segment="3">
+        <Texture Name="jyasinzou_room_10Tex_0031A0" OutName="jyasinzou_room_10Tex_0031A0" Format="rgba16" Width="32" Height="64" Offset="0x31A0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_10Tex_0041A0" OutName="jyasinzou_room_10Tex_0041A0" Format="ci8" Width="64" Height="32" Offset="0x41A0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_10Tex_0049A0" OutName="jyasinzou_room_10Tex_0049A0" Format="ci8" Width="64" Height="32" Offset="0x49A0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_10Tex_0051A0" OutName="jyasinzou_room_10Tex_0051A0" Format="ci8" Width="64" Height="32" Offset="0x51A0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_10Tex_0059A0" OutName="jyasinzou_room_10Tex_0059A0" Format="rgba16" Width="16" Height="32" Offset="0x59A0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_10Tex_005DA0" OutName="jyasinzou_room_10Tex_005DA0" Format="ci8" Width="64" Height="32" Offset="0x5DA0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_10Tex_0065A0" OutName="jyasinzou_room_10Tex_0065A0" Format="ci8" Width="32" Height="32" Offset="0x65A0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_10Tex_0069A0" OutName="jyasinzou_room_10Tex_0069A0" Format="rgba16" Width="64" Height="32" Offset="0x69A0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_10Tex_0079A0" OutName="jyasinzou_room_10Tex_0079A0" Format="ci8" Width="64" Height="16" Offset="0x79A0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_10Tex_007DA0" OutName="jyasinzou_room_10Tex_007DA0" Format="ci8" Width="32" Height="32" Offset="0x7DA0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
         <Room Name="jyasinzou_room_10" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_11" Segment="3">
+        <Texture Name="jyasinzou_room_11Tex_000780" OutName="jyasinzou_room_11Tex_000780" Format="ci8" Width="32" Height="32" Offset="0x780" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
         <Room Name="jyasinzou_room_11" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_12" Segment="3">
+        <Texture Name="jyasinzou_room_12Tex_0010D8" OutName="jyasinzou_room_12Tex_0010D8" Format="ci8" Width="64" Height="32" Offset="0x10D8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_12Tex_0018D8" OutName="jyasinzou_room_12Tex_0018D8" Format="ci8" Width="32" Height="64" Offset="0x18D8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
         <Room Name="jyasinzou_room_12" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_13" Segment="3">
+        <Texture Name="jyasinzou_room_13Tex_0028A8" OutName="jyasinzou_room_13Tex_0028A8" Format="ci8" Width="32" Height="64" Offset="0x28A8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_13Tex_0030A8" OutName="jyasinzou_room_13Tex_0030A8" Format="ci8" Width="64" Height="32" Offset="0x30A8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_13Tex_0038A8" OutName="jyasinzou_room_13Tex_0038A8" Format="ci8" Width="32" Height="32" Offset="0x38A8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_13Tex_003CA8" OutName="jyasinzou_room_13Tex_003CA8" Format="ci8" Width="64" Height="32" Offset="0x3CA8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_13Tex_0044A8" OutName="jyasinzou_room_13Tex_0044A8" Format="ci8" Width="64" Height="32" Offset="0x44A8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_13Tex_004CA8" OutName="jyasinzou_room_13Tex_004CA8" Format="ci8" Width="32" Height="32" Offset="0x4CA8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_13Tex_0050A8" OutName="jyasinzou_room_13Tex_0050A8" Format="ci4" Width="64" Height="64" Offset="0x50A8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18000" AddedByScript="true"/>
         <Room Name="jyasinzou_room_13" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_14" Segment="3">
+        <Texture Name="jyasinzou_room_14Tex_001CA0" OutName="jyasinzou_room_14Tex_001CA0" Format="ci8" Width="64" Height="32" Offset="0x1CA0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_14Tex_0024A0" OutName="jyasinzou_room_14Tex_0024A0" Format="ci8" Width="32" Height="32" Offset="0x24A0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_14Tex_0028A0" OutName="jyasinzou_room_14Tex_0028A0" Format="ci8" Width="64" Height="32" Offset="0x28A0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_14Tex_0030A0" OutName="jyasinzou_room_14Tex_0030A0" Format="ci8" Width="32" Height="32" Offset="0x30A0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_14Tex_0034A0" OutName="jyasinzou_room_14Tex_0034A0" Format="rgba16" Width="32" Height="64" Offset="0x34A0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_14Tex_0044A0" OutName="jyasinzou_room_14Tex_0044A0" Format="ci4" Width="64" Height="64" Offset="0x44A0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18000" AddedByScript="true"/>
         <Room Name="jyasinzou_room_14" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_15" Segment="3">
+        <Texture Name="jyasinzou_room_15Tex_002FE8" OutName="jyasinzou_room_15Tex_002FE8" Format="rgba16" Width="32" Height="64" Offset="0x2FE8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_15Tex_003FE8" OutName="jyasinzou_room_15Tex_003FE8" Format="rgba16" Width="16" Height="32" Offset="0x3FE8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_15Tex_0043E8" OutName="jyasinzou_room_15Tex_0043E8" Format="ci8" Width="32" Height="64" Offset="0x43E8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_15Tex_004BE8" OutName="jyasinzou_room_15Tex_004BE8" Format="ci8" Width="32" Height="64" Offset="0x4BE8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_15Tex_0053E8" OutName="jyasinzou_room_15Tex_0053E8" Format="ci8" Width="64" Height="32" Offset="0x53E8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_15Tex_005BE8" OutName="jyasinzou_room_15Tex_005BE8" Format="ci8" Width="16" Height="16" Offset="0x5BE8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_15Tex_005CE8" OutName="jyasinzou_room_15Tex_005CE8" Format="ci8" Width="32" Height="32" Offset="0x5CE8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_15Tex_0060E8" OutName="jyasinzou_room_15Tex_0060E8" Format="ci8" Width="64" Height="32" Offset="0x60E8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_15Tex_0068E8" OutName="jyasinzou_room_15Tex_0068E8" Format="ci8" Width="32" Height="32" Offset="0x68E8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_15Tex_006CE8" OutName="jyasinzou_room_15Tex_006CE8" Format="ci4" Width="64" Height="64" Offset="0x6CE8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18000" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_15Tex_007C98" OutName="jyasinzou_room_15Tex_007C98" Format="rgba16" Width="32" Height="32" Offset="0x7C98" AddedByScript="true"/>
         <Room Name="jyasinzou_room_15" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_16" Segment="3">
+        <Texture Name="jyasinzou_room_16Tex_0029B8" OutName="jyasinzou_room_16Tex_0029B8" Format="rgba16" Width="32" Height="64" Offset="0x29B8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_16Tex_0039B8" OutName="jyasinzou_room_16Tex_0039B8" Format="ci8" Width="64" Height="32" Offset="0x39B8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_16Tex_0041B8" OutName="jyasinzou_room_16Tex_0041B8" Format="ci8" Width="16" Height="64" Offset="0x41B8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_16Tex_0045B8" OutName="jyasinzou_room_16Tex_0045B8" Format="ci8" Width="64" Height="32" Offset="0x45B8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_16Tex_004DB8" OutName="jyasinzou_room_16Tex_004DB8" Format="rgba16" Width="16" Height="32" Offset="0x4DB8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_16Tex_0051B8" OutName="jyasinzou_room_16Tex_0051B8" Format="ci8" Width="32" Height="64" Offset="0x51B8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_16Tex_0059B8" OutName="jyasinzou_room_16Tex_0059B8" Format="ci4" Width="64" Height="64" Offset="0x59B8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18000" AddedByScript="true"/>
         <Room Name="jyasinzou_room_16" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_17" Segment="3">
+        <Texture Name="jyasinzou_room_17Tex_005E50" OutName="jyasinzou_room_17Tex_005E50" Format="ci8" Width="64" Height="32" Offset="0x5E50" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_17Tex_006650" OutName="jyasinzou_room_17Tex_006650" Format="ci8" Width="64" Height="32" Offset="0x6650" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_17Tex_006E50" OutName="jyasinzou_room_17Tex_006E50" Format="ci8" Width="32" Height="32" Offset="0x6E50" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_17Tex_007250" OutName="jyasinzou_room_17Tex_007250" Format="ci8" Width="64" Height="32" Offset="0x7250" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_17Tex_007A50" OutName="jyasinzou_room_17Tex_007A50" Format="ci8" Width="64" Height="32" Offset="0x7A50" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_17Tex_008250" OutName="jyasinzou_room_17Tex_008250" Format="ci4" Width="64" Height="64" Offset="0x8250" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17FE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_17Tex_008A50" OutName="jyasinzou_room_17Tex_008A50" Format="ci8" Width="32" Height="32" Offset="0x8A50" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_17Tex_008E50" OutName="jyasinzou_room_17Tex_008E50" Format="ci4" Width="64" Height="64" Offset="0x8E50" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18000" AddedByScript="true"/>
         <Room Name="jyasinzou_room_17" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_18" Segment="3">
+        <Texture Name="jyasinzou_room_18Tex_0020F0" OutName="jyasinzou_room_18Tex_0020F0" Format="ci8" Width="64" Height="32" Offset="0x20F0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_18Tex_0028F0" OutName="jyasinzou_room_18Tex_0028F0" Format="ci8" Width="64" Height="32" Offset="0x28F0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_18Tex_0030F0" OutName="jyasinzou_room_18Tex_0030F0" Format="ci8" Width="32" Height="32" Offset="0x30F0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_18Tex_0034F0" OutName="jyasinzou_room_18Tex_0034F0" Format="rgba16" Width="32" Height="32" Offset="0x34F0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_18Tex_003CF0" OutName="jyasinzou_room_18Tex_003CF0" Format="ci8" Width="16" Height="128" Offset="0x3CF0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_18Tex_0044F0" OutName="jyasinzou_room_18Tex_0044F0" Format="ci8" Width="32" Height="32" Offset="0x44F0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_18Tex_0048F0" OutName="jyasinzou_room_18Tex_0048F0" Format="ci8" Width="32" Height="32" Offset="0x48F0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_18Tex_0054E0" OutName="jyasinzou_room_18Tex_0054E0" Format="rgba16" Width="32" Height="32" Offset="0x54E0" AddedByScript="true"/>
         <Room Name="jyasinzou_room_18" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_19" Segment="3">
+        <Texture Name="jyasinzou_room_19Tex_002DC8" OutName="jyasinzou_room_19Tex_002DC8" Format="rgba16" Width="32" Height="64" Offset="0x2DC8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_19Tex_003DC8" OutName="jyasinzou_room_19Tex_003DC8" Format="ci8" Width="64" Height="32" Offset="0x3DC8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_19Tex_0045C8" OutName="jyasinzou_room_19Tex_0045C8" Format="ci8" Width="64" Height="32" Offset="0x45C8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_19Tex_004DC8" OutName="jyasinzou_room_19Tex_004DC8" Format="rgba16" Width="16" Height="32" Offset="0x4DC8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_19Tex_0051C8" OutName="jyasinzou_room_19Tex_0051C8" Format="ci8" Width="64" Height="16" Offset="0x51C8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_19Tex_0055C8" OutName="jyasinzou_room_19Tex_0055C8" Format="ci8" Width="64" Height="32" Offset="0x55C8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
         <Room Name="jyasinzou_room_19" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_20" Segment="3">
+        <Texture Name="jyasinzou_room_20Tex_0031B8" OutName="jyasinzou_room_20Tex_0031B8" Format="rgba16" Width="32" Height="64" Offset="0x31B8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_20Tex_0041B8" OutName="jyasinzou_room_20Tex_0041B8" Format="ci8" Width="64" Height="32" Offset="0x41B8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_20Tex_0049B8" OutName="jyasinzou_room_20Tex_0049B8" Format="ci8" Width="64" Height="32" Offset="0x49B8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_20Tex_0051B8" OutName="jyasinzou_room_20Tex_0051B8" Format="ci8" Width="64" Height="32" Offset="0x51B8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_20Tex_0059B8" OutName="jyasinzou_room_20Tex_0059B8" Format="rgba16" Width="16" Height="32" Offset="0x59B8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_20Tex_005DB8" OutName="jyasinzou_room_20Tex_005DB8" Format="ci8" Width="64" Height="32" Offset="0x5DB8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_20Tex_0065B8" OutName="jyasinzou_room_20Tex_0065B8" Format="ci8" Width="32" Height="32" Offset="0x65B8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_20Tex_0069B8" OutName="jyasinzou_room_20Tex_0069B8" Format="rgba16" Width="64" Height="32" Offset="0x69B8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_20Tex_0079B8" OutName="jyasinzou_room_20Tex_0079B8" Format="ci8" Width="64" Height="16" Offset="0x79B8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_20Tex_007DB8" OutName="jyasinzou_room_20Tex_007DB8" Format="ci8" Width="32" Height="32" Offset="0x7DB8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
         <Room Name="jyasinzou_room_20" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_21" Segment="3">
+        <Texture Name="jyasinzou_room_21Tex_001660" OutName="jyasinzou_room_21Tex_001660" Format="rgba16" Width="32" Height="64" Offset="0x1660" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_21Tex_002660" OutName="jyasinzou_room_21Tex_002660" Format="ci8" Width="64" Height="32" Offset="0x2660" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_21Tex_002E60" OutName="jyasinzou_room_21Tex_002E60" Format="rgba16" Width="16" Height="32" Offset="0x2E60" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_21Tex_003260" OutName="jyasinzou_room_21Tex_003260" Format="ci8" Width="32" Height="32" Offset="0x3260" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_21Tex_003660" OutName="jyasinzou_room_21Tex_003660" Format="ci8" Width="64" Height="32" Offset="0x3660" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_21Tex_003E60" OutName="jyasinzou_room_21Tex_003E60" Format="ci4" Width="64" Height="64" Offset="0x3E60" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18000" AddedByScript="true"/>
         <Room Name="jyasinzou_room_21" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_22" Segment="3">
+        <Texture Name="jyasinzou_room_22Tex_001468" OutName="jyasinzou_room_22Tex_001468" Format="ci8" Width="64" Height="32" Offset="0x1468" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_22Tex_001C68" OutName="jyasinzou_room_22Tex_001C68" Format="ci8" Width="32" Height="64" Offset="0x1C68" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_22Tex_002468" OutName="jyasinzou_room_22Tex_002468" Format="ci8" Width="32" Height="32" Offset="0x2468" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_22Tex_002868" OutName="jyasinzou_room_22Tex_002868" Format="ci4" Width="64" Height="64" Offset="0x2868" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18000" AddedByScript="true"/>
         <Room Name="jyasinzou_room_22" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_23" Segment="3">
+        <Texture Name="jyasinzou_room_23Tex_004438" OutName="jyasinzou_room_23Tex_004438" Format="ci8" Width="32" Height="64" Offset="0x4438" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_23Tex_004C38" OutName="jyasinzou_room_23Tex_004C38" Format="ci8" Width="64" Height="32" Offset="0x4C38" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_23Tex_005438" OutName="jyasinzou_room_23Tex_005438" Format="ci8" Width="16" Height="64" Offset="0x5438" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_23Tex_005838" OutName="jyasinzou_room_23Tex_005838" Format="ci8" Width="64" Height="32" Offset="0x5838" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_23Tex_006038" OutName="jyasinzou_room_23Tex_006038" Format="ci8" Width="32" Height="32" Offset="0x6038" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_23Tex_006438" OutName="jyasinzou_room_23Tex_006438" Format="ci8" Width="16" Height="128" Offset="0x6438" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_23Tex_006C38" OutName="jyasinzou_room_23Tex_006C38" Format="rgba16" Width="32" Height="32" Offset="0x6C38" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_23Tex_007438" OutName="jyasinzou_room_23Tex_007438" Format="ci8" Width="64" Height="32" Offset="0x7438" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_23Tex_007C38" OutName="jyasinzou_room_23Tex_007C38" Format="ci8" Width="32" Height="32" Offset="0x7C38" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_23Tex_008038" OutName="jyasinzou_room_23Tex_008038" Format="ci8" Width="64" Height="32" Offset="0x8038" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_23Tex_008838" OutName="jyasinzou_room_23Tex_008838" Format="ci4" Width="64" Height="64" Offset="0x8838" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18000" AddedByScript="true"/>
         <Room Name="jyasinzou_room_23" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_24" Segment="3">
+        <Texture Name="jyasinzou_room_24Tex_001B38" OutName="jyasinzou_room_24Tex_001B38" Format="rgba16" Width="32" Height="64" Offset="0x1B38" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_24Tex_002B38" OutName="jyasinzou_room_24Tex_002B38" Format="ci8" Width="64" Height="32" Offset="0x2B38" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_24Tex_003338" OutName="jyasinzou_room_24Tex_003338" Format="ci8" Width="64" Height="32" Offset="0x3338" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_24Tex_003B38" OutName="jyasinzou_room_24Tex_003B38" Format="rgba16" Width="16" Height="32" Offset="0x3B38" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_24Tex_003F38" OutName="jyasinzou_room_24Tex_003F38" Format="ci8" Width="32" Height="32" Offset="0x3F38" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_24Tex_004338" OutName="jyasinzou_room_24Tex_004338" Format="ci8" Width="64" Height="32" Offset="0x4338" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_24Tex_004B38" OutName="jyasinzou_room_24Tex_004B38" Format="ci4" Width="64" Height="64" Offset="0x4B38" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18000" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_24Tex_0054D0" OutName="jyasinzou_room_24Tex_0054D0" Format="rgba16" Width="32" Height="64" Offset="0x54D0" AddedByScript="true"/>
         <Room Name="jyasinzou_room_24" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_25" Segment="3">
+        <Texture Name="jyasinzou_room_25Tex_00BA98" OutName="jyasinzou_room_25Tex_00BA98" Format="rgba16" Width="16" Height="32" Offset="0xBA98" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_00BE98" OutName="jyasinzou_room_25Tex_00BE98" Format="rgba16" Width="32" Height="64" Offset="0xBE98" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_00CE98" OutName="jyasinzou_room_25Tex_00CE98" Format="ci8" Width="32" Height="64" Offset="0xCE98" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_00D698" OutName="jyasinzou_room_25Tex_00D698" Format="ci8" Width="16" Height="64" Offset="0xD698" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_00DA98" OutName="jyasinzou_room_25Tex_00DA98" Format="ci8" Width="32" Height="32" Offset="0xDA98" TlutOffset="0xB8A0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_00DE98" OutName="jyasinzou_room_25Tex_00DE98" Format="ci8" Width="32" Height="64" Offset="0xDE98" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_00E698" OutName="jyasinzou_room_25Tex_00E698" Format="ci8" Width="64" Height="32" Offset="0xE698" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_00EE98" OutName="jyasinzou_room_25Tex_00EE98" Format="rgba16" Width="32" Height="16" Offset="0xEE98" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_00F298" OutName="jyasinzou_room_25Tex_00F298" Format="ci8" Width="32" Height="32" Offset="0xF298" TlutOffset="0xB8A0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_00F698" OutName="jyasinzou_room_25Tex_00F698" Format="ci8" Width="32" Height="64" Offset="0xF698" TlutOffset="0xB8A0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_00FE98" OutName="jyasinzou_room_25Tex_00FE98" Format="ci8" Width="16" Height="16" Offset="0xFE98" TlutOffset="0xB8A0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_00FF98" OutName="jyasinzou_room_25Tex_00FF98" Format="ci8" Width="32" Height="32" Offset="0xFF98" TlutOffset="0xB8A0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_010398" OutName="jyasinzou_room_25Tex_010398" Format="ci8" Width="32" Height="32" Offset="0x10398" TlutOffset="0xB8A0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_010798" OutName="jyasinzou_room_25Tex_010798" Format="ci8" Width="32" Height="32" Offset="0x10798" TlutOffset="0xB8A0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_010B98" OutName="jyasinzou_room_25Tex_010B98" Format="ci8" Width="32" Height="32" Offset="0x10B98" TlutOffset="0xB8A0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_010F98" OutName="jyasinzou_room_25Tex_010F98" Format="ci8" Width="32" Height="32" Offset="0x10F98" TlutOffset="0xB8A0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_011398" OutName="jyasinzou_room_25Tex_011398" Format="ci8" Width="32" Height="32" Offset="0x11398" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_011798" OutName="jyasinzou_room_25Tex_011798" Format="ci8" Width="16" Height="128" Offset="0x11798" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_011F98" OutName="jyasinzou_room_25Tex_011F98" Format="ci8" Width="64" Height="32" Offset="0x11F98" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_012798" OutName="jyasinzou_room_25Tex_012798" Format="ci8" Width="32" Height="32" Offset="0x12798" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_012B98" OutName="jyasinzou_room_25Tex_012B98" Format="ci8" Width="32" Height="64" Offset="0x12B98" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_013398" OutName="jyasinzou_room_25Tex_013398" Format="ci8" Width="64" Height="32" Offset="0x13398" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_013B98" OutName="jyasinzou_room_25Tex_013B98" Format="ci8" Width="64" Height="32" Offset="0x13B98" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_014398" OutName="jyasinzou_room_25Tex_014398" Format="ci8" Width="32" Height="32" Offset="0x14398" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_014798" OutName="jyasinzou_room_25Tex_014798" Format="ci4" Width="64" Height="64" Offset="0x14798" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17FE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_014F98" OutName="jyasinzou_room_25Tex_014F98" Format="ci8" Width="32" Height="32" Offset="0x14F98" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_015398" OutName="jyasinzou_room_25Tex_015398" Format="ci4" Width="64" Height="64" Offset="0x15398" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18000" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25TLUT_00B8A0" OutName="jyasinzou_room_25TLUT_00B8A0" Format="rgba16" Width="16" Height="16" Offset="0xB8A0" AddedByScript="true"/>
         <Room Name="jyasinzou_room_25" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_26" Segment="3">
+        <Texture Name="jyasinzou_room_26Tex_006CC8" OutName="jyasinzou_room_26Tex_006CC8" Format="rgba16" Width="16" Height="32" Offset="0x6CC8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_26Tex_0070C8" OutName="jyasinzou_room_26Tex_0070C8" Format="rgba16" Width="32" Height="64" Offset="0x70C8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_26Tex_0080C8" OutName="jyasinzou_room_26Tex_0080C8" Format="rgba16" Width="16" Height="16" Offset="0x80C8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_26Tex_0082C8" OutName="jyasinzou_room_26Tex_0082C8" Format="ci8" Width="32" Height="64" Offset="0x82C8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_26Tex_008AC8" OutName="jyasinzou_room_26Tex_008AC8" Format="ci8" Width="16" Height="32" Offset="0x8AC8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_26Tex_008CC8" OutName="jyasinzou_room_26Tex_008CC8" Format="ci8" Width="32" Height="64" Offset="0x8CC8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_26Tex_0094C8" OutName="jyasinzou_room_26Tex_0094C8" Format="ci8" Width="64" Height="32" Offset="0x94C8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_26Tex_009CC8" OutName="jyasinzou_room_26Tex_009CC8" Format="rgba16" Width="16" Height="32" Offset="0x9CC8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_26Tex_00A0C8" OutName="jyasinzou_room_26Tex_00A0C8" Format="ci8" Width="16" Height="128" Offset="0xA0C8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_26Tex_00A8C8" OutName="jyasinzou_room_26Tex_00A8C8" Format="ci8" Width="32" Height="32" Offset="0xA8C8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_26Tex_00ACC8" OutName="jyasinzou_room_26Tex_00ACC8" Format="ci4" Width="64" Height="64" Offset="0xACC8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17FE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_26Tex_00B4C8" OutName="jyasinzou_room_26Tex_00B4C8" Format="ci4" Width="64" Height="64" Offset="0xB4C8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18000" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_26Tex_00C2F8" OutName="jyasinzou_room_26Tex_00C2F8" Format="ia16" Width="32" Height="32" Offset="0xC2F8" AddedByScript="true"/>
         <Room Name="jyasinzou_room_26" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_27" Segment="3">
+        <Texture Name="jyasinzou_room_27Tex_004310" OutName="jyasinzou_room_27Tex_004310" Format="ci8" Width="32" Height="64" Offset="0x4310" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_27Tex_004B10" OutName="jyasinzou_room_27Tex_004B10" Format="ci8" Width="32" Height="32" Offset="0x4B10" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_27Tex_004F10" OutName="jyasinzou_room_27Tex_004F10" Format="ci8" Width="64" Height="32" Offset="0x4F10" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17BE0" AddedByScript="true"/>
         <Room Name="jyasinzou_room_27" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_28" Segment="3">
+        <Texture Name="jyasinzou_room_28Tex_004130" OutName="jyasinzou_room_28Tex_004130" Format="ci8" Width="64" Height="32" Offset="0x4130" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_28Tex_004930" OutName="jyasinzou_room_28Tex_004930" Format="ci8" Width="64" Height="32" Offset="0x4930" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_28Tex_005130" OutName="jyasinzou_room_28Tex_005130" Format="ci8" Width="64" Height="32" Offset="0x5130" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_28Tex_005930" OutName="jyasinzou_room_28Tex_005930" Format="ci8" Width="64" Height="32" Offset="0x5930" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_28Tex_006130" OutName="jyasinzou_room_28Tex_006130" Format="ci8" Width="32" Height="32" Offset="0x6130" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_28Tex_006530" OutName="jyasinzou_room_28Tex_006530" Format="rgba16" Width="64" Height="32" Offset="0x6530" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_28Tex_007530" OutName="jyasinzou_room_28Tex_007530" Format="ci8" Width="64" Height="16" Offset="0x7530" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_28Tex_007930" OutName="jyasinzou_room_28Tex_007930" Format="ci8" Width="16" Height="16" Offset="0x7930" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_28Tex_007A30" OutName="jyasinzou_room_28Tex_007A30" Format="ci8" Width="16" Height="64" Offset="0x7A30" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_28Tex_007E30" OutName="jyasinzou_room_28Tex_007E30" Format="ci4" Width="64" Height="64" Offset="0x7E30" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17FE0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_28Tex_008630" OutName="jyasinzou_room_28Tex_008630" Format="ci8" Width="32" Height="32" Offset="0x8630" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17DE0" AddedByScript="true"/>
         <Room Name="jyasinzou_room_28" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_MQ_D/scenes/dungeons/men.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/dungeons/men.xml
@@ -1,42 +1,126 @@
 <Root>
     <File Name="men_scene" Segment="2">
+        <Texture Name="men_sceneTex_0108C0" OutName="men_sceneTex_0108C0" Format="ci8" Width="32" Height="32" Offset="0x108C0" TlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="men_sceneTex_010CC0" OutName="men_sceneTex_010CC0" Format="ci8" Width="64" Height="32" Offset="0x10CC0" TlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="men_sceneTLUT_00F6C0" OutName="men_sceneTLUT_00F6C0" Format="rgba16" Width="16" Height="16" Offset="0xF6C0" AddedByScript="true"/>
         <Texture Name="gGTGDayEntranceTex" OutName="day_entrance" Format="ia16" Width="8" Height="128" Offset="0xF8C0"/>
         <Texture Name="gGTGNightEntranceTex" OutName="night_entrance" Format="ia16" Width="8" Height="128" Offset="0x100C0"/>
         <Scene Name="men_scene" Offset="0x0"/>
     </File>
     <File Name="men_room_0" Segment="3">
+        <Texture Name="men_room_0Tex_008138" OutName="men_room_0Tex_008138" Format="ci8" Width="64" Height="32" Offset="0x8138" ExternalTlut="men_scene" ExternalTlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="men_room_0Tex_008938" OutName="men_room_0Tex_008938" Format="ci8" Width="32" Height="64" Offset="0x8938" ExternalTlut="men_scene" ExternalTlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="men_room_0Tex_009138" OutName="men_room_0Tex_009138" Format="ci8" Width="32" Height="32" Offset="0x9138" ExternalTlut="men_scene" ExternalTlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="men_room_0Tex_009538" OutName="men_room_0Tex_009538" Format="rgba16" Width="32" Height="32" Offset="0x9538" AddedByScript="true"/>
+        <Texture Name="men_room_0Tex_009D38" OutName="men_room_0Tex_009D38" Format="ci8" Width="32" Height="64" Offset="0x9D38" ExternalTlut="men_scene" ExternalTlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="men_room_0Tex_00A538" OutName="men_room_0Tex_00A538" Format="ia8" Width="64" Height="64" Offset="0xA538" AddedByScript="true"/>
+        <Texture Name="men_room_0Tex_00B538" OutName="men_room_0Tex_00B538" Format="ci8" Width="32" Height="64" Offset="0xB538" ExternalTlut="men_scene" ExternalTlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="men_room_0Tex_00BD38" OutName="men_room_0Tex_00BD38" Format="ci8" Width="64" Height="32" Offset="0xBD38" ExternalTlut="men_scene" ExternalTlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="men_room_0Tex_00C538" OutName="men_room_0Tex_00C538" Format="i4" Width="64" Height="128" Offset="0xC538" AddedByScript="true"/>
+        <Texture Name="men_room_0Tex_00D538" OutName="men_room_0Tex_00D538" Format="ci8" Width="64" Height="32" Offset="0xD538" ExternalTlut="men_scene" ExternalTlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="men_room_0Tex_00DD38" OutName="men_room_0Tex_00DD38" Format="rgba16" Width="16" Height="128" Offset="0xDD38" AddedByScript="true"/>
+        <Texture Name="men_room_0Tex_00ED38" OutName="men_room_0Tex_00ED38" Format="ci8" Width="64" Height="32" Offset="0xED38" ExternalTlut="men_scene" ExternalTlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="men_room_0Tex_00F538" OutName="men_room_0Tex_00F538" Format="ci8" Width="64" Height="32" Offset="0xF538" ExternalTlut="men_scene" ExternalTlutOffset="0xF6C0" AddedByScript="true"/>
         <DList Name="gMenDL_008118" Offset="0x8118"/>
         <DList Name="gMenDL_00FF78" Offset="0xFF78"/>
         <Room Name="men_room_0" Offset="0x0"/>
     </File>
     <File Name="men_room_1" Segment="3">
+        <Texture Name="men_room_1Tex_004270" OutName="men_room_1Tex_004270" Format="rgba16" Width="32" Height="32" Offset="0x4270" AddedByScript="true"/>
+        <Texture Name="men_room_1Tex_004A70" OutName="men_room_1Tex_004A70" Format="ci8" Width="64" Height="32" Offset="0x4A70" ExternalTlut="men_scene" ExternalTlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="men_room_1Tex_005270" OutName="men_room_1Tex_005270" Format="ci8" Width="32" Height="64" Offset="0x5270" ExternalTlut="men_scene" ExternalTlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="men_room_1Tex_005A70" OutName="men_room_1Tex_005A70" Format="ci8" Width="64" Height="32" Offset="0x5A70" ExternalTlut="men_scene" ExternalTlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="men_room_1Tex_006270" OutName="men_room_1Tex_006270" Format="rgba16" Width="32" Height="32" Offset="0x6270" AddedByScript="true"/>
+        <Texture Name="men_room_1Tex_006A70" OutName="men_room_1Tex_006A70" Format="rgba16" Width="32" Height="32" Offset="0x6A70" AddedByScript="true"/>
+        <Texture Name="men_room_1Tex_007270" OutName="men_room_1Tex_007270" Format="ci8" Width="64" Height="32" Offset="0x7270" ExternalTlut="men_scene" ExternalTlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="men_room_1Tex_007A70" OutName="men_room_1Tex_007A70" Format="rgba16" Width="16" Height="128" Offset="0x7A70" AddedByScript="true"/>
+        <Texture Name="men_room_1Tex_008A70" OutName="men_room_1Tex_008A70" Format="ci8" Width="64" Height="32" Offset="0x8A70" ExternalTlut="men_scene" ExternalTlutOffset="0xF6C0" AddedByScript="true"/>
         <Room Name="men_room_1" Offset="0x0"/>
     </File>
     <File Name="men_room_2" Segment="3">
+        <Texture Name="men_room_2Tex_003C48" OutName="men_room_2Tex_003C48" Format="ci8" Width="64" Height="32" Offset="0x3C48" ExternalTlut="men_scene" ExternalTlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="men_room_2Tex_004448" OutName="men_room_2Tex_004448" Format="ci8" Width="64" Height="32" Offset="0x4448" ExternalTlut="men_scene" ExternalTlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="men_room_2Tex_004C48" OutName="men_room_2Tex_004C48" Format="ci8" Width="32" Height="32" Offset="0x4C48" ExternalTlut="men_scene" ExternalTlutOffset="0xF6C0" AddedByScript="true"/>
         <Room Name="men_room_2" Offset="0x0"/>
     </File>
     <File Name="men_room_3" Segment="3">
+        <Texture Name="men_room_3Tex_003850" OutName="men_room_3Tex_003850" Format="ci8" Width="64" Height="32" Offset="0x3850" ExternalTlut="men_scene" ExternalTlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="men_room_3Tex_004050" OutName="men_room_3Tex_004050" Format="ci8" Width="64" Height="32" Offset="0x4050" ExternalTlut="men_scene" ExternalTlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="men_room_3Tex_004850" OutName="men_room_3Tex_004850" Format="ci8" Width="32" Height="64" Offset="0x4850" ExternalTlut="men_scene" ExternalTlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="men_room_3Tex_005050" OutName="men_room_3Tex_005050" Format="ci8" Width="64" Height="32" Offset="0x5050" ExternalTlut="men_scene" ExternalTlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="men_room_3Tex_005850" OutName="men_room_3Tex_005850" Format="ci8" Width="32" Height="32" Offset="0x5850" ExternalTlut="men_scene" ExternalTlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="men_room_3Tex_005C50" OutName="men_room_3Tex_005C50" Format="ci8" Width="64" Height="32" Offset="0x5C50" ExternalTlut="men_scene" ExternalTlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="men_room_3Tex_006450" OutName="men_room_3Tex_006450" Format="rgba16" Width="16" Height="128" Offset="0x6450" AddedByScript="true"/>
+        <Texture Name="men_room_3Tex_007450" OutName="men_room_3Tex_007450" Format="ci8" Width="64" Height="32" Offset="0x7450" ExternalTlut="men_scene" ExternalTlutOffset="0xF6C0" AddedByScript="true"/>
         <Room Name="men_room_3" Offset="0x0"/>
     </File>
     <File Name="men_room_4" Segment="3">
+        <Texture Name="men_room_4Tex_0051E0" OutName="men_room_4Tex_0051E0" Format="rgba16" Width="32" Height="32" Offset="0x51E0" AddedByScript="true"/>
+        <Texture Name="men_room_4Tex_0059E0" OutName="men_room_4Tex_0059E0" Format="rgba16" Width="32" Height="32" Offset="0x59E0" AddedByScript="true"/>
+        <Texture Name="men_room_4Tex_0061E0" OutName="men_room_4Tex_0061E0" Format="i4" Width="128" Height="64" Offset="0x61E0" AddedByScript="true"/>
+        <Texture Name="men_room_4Tex_0071E0" OutName="men_room_4Tex_0071E0" Format="i4" Width="64" Height="128" Offset="0x71E0" AddedByScript="true"/>
+        <Texture Name="men_room_4Tex_0081E0" OutName="men_room_4Tex_0081E0" Format="ci8" Width="32" Height="64" Offset="0x81E0" ExternalTlut="men_scene" ExternalTlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="men_room_4Tex_0089E0" OutName="men_room_4Tex_0089E0" Format="i4" Width="64" Height="128" Offset="0x89E0" AddedByScript="true"/>
+        <Texture Name="men_room_4Tex_0099E0" OutName="men_room_4Tex_0099E0" Format="ci8" Width="64" Height="32" Offset="0x99E0" ExternalTlut="men_scene" ExternalTlutOffset="0xF6C0" AddedByScript="true"/>
         <Room Name="men_room_4" Offset="0x0"/>
     </File>
     <File Name="men_room_5" Segment="3">
+        <Texture Name="men_room_5Tex_002418" OutName="men_room_5Tex_002418" Format="ci8" Width="64" Height="32" Offset="0x2418" ExternalTlut="men_scene" ExternalTlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="men_room_5Tex_002C18" OutName="men_room_5Tex_002C18" Format="ci8" Width="32" Height="32" Offset="0x2C18" ExternalTlut="men_scene" ExternalTlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="men_room_5Tex_003018" OutName="men_room_5Tex_003018" Format="ci8" Width="32" Height="64" Offset="0x3018" ExternalTlut="men_scene" ExternalTlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="men_room_5Tex_003818" OutName="men_room_5Tex_003818" Format="ci8" Width="64" Height="32" Offset="0x3818" ExternalTlut="men_scene" ExternalTlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="men_room_5Tex_004018" OutName="men_room_5Tex_004018" Format="ci8" Width="64" Height="32" Offset="0x4018" ExternalTlut="men_scene" ExternalTlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="men_room_5Tex_004818" OutName="men_room_5Tex_004818" Format="ci8" Width="64" Height="32" Offset="0x4818" ExternalTlut="men_scene" ExternalTlutOffset="0xF6C0" AddedByScript="true"/>
         <Room Name="men_room_5" Offset="0x0"/>
     </File>
     <File Name="men_room_6" Segment="3">
+        <Texture Name="men_room_6Tex_003F78" OutName="men_room_6Tex_003F78" Format="rgba16" Width="32" Height="32" Offset="0x3F78" AddedByScript="true"/>
+        <Texture Name="men_room_6Tex_004778" OutName="men_room_6Tex_004778" Format="ci8" Width="32" Height="64" Offset="0x4778" ExternalTlut="men_scene" ExternalTlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="men_room_6Tex_004F78" OutName="men_room_6Tex_004F78" Format="ci8" Width="32" Height="32" Offset="0x4F78" ExternalTlut="men_scene" ExternalTlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="men_room_6Tex_005378" OutName="men_room_6Tex_005378" Format="rgba16" Width="32" Height="32" Offset="0x5378" AddedByScript="true"/>
+        <Texture Name="men_room_6Tex_005B78" OutName="men_room_6Tex_005B78" Format="ci8" Width="32" Height="64" Offset="0x5B78" ExternalTlut="men_scene" ExternalTlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="men_room_6Tex_006378" OutName="men_room_6Tex_006378" Format="ci8" Width="32" Height="64" Offset="0x6378" ExternalTlut="men_scene" ExternalTlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="men_room_6Tex_006B78" OutName="men_room_6Tex_006B78" Format="ci8" Width="64" Height="32" Offset="0x6B78" ExternalTlut="men_scene" ExternalTlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="men_room_6Tex_007378" OutName="men_room_6Tex_007378" Format="ci8" Width="32" Height="32" Offset="0x7378" ExternalTlut="men_scene" ExternalTlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="men_room_6Tex_007778" OutName="men_room_6Tex_007778" Format="ci8" Width="64" Height="32" Offset="0x7778" ExternalTlut="men_scene" ExternalTlutOffset="0xF6C0" AddedByScript="true"/>
         <Room Name="men_room_6" Offset="0x0"/>
     </File>
     <File Name="men_room_7" Segment="3">
+        <Texture Name="men_room_7Tex_0036B8" OutName="men_room_7Tex_0036B8" Format="ci8" Width="32" Height="32" Offset="0x36B8" ExternalTlut="men_scene" ExternalTlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="men_room_7Tex_003AB8" OutName="men_room_7Tex_003AB8" Format="ci8" Width="64" Height="32" Offset="0x3AB8" ExternalTlut="men_scene" ExternalTlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="men_room_7Tex_0042B8" OutName="men_room_7Tex_0042B8" Format="ci8" Width="32" Height="64" Offset="0x42B8" ExternalTlut="men_scene" ExternalTlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="men_room_7Tex_004AB8" OutName="men_room_7Tex_004AB8" Format="rgba16" Width="32" Height="32" Offset="0x4AB8" AddedByScript="true"/>
+        <Texture Name="men_room_7Tex_0052B8" OutName="men_room_7Tex_0052B8" Format="ci8" Width="64" Height="32" Offset="0x52B8" ExternalTlut="men_scene" ExternalTlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="men_room_7Tex_005AB8" OutName="men_room_7Tex_005AB8" Format="ci8" Width="64" Height="32" Offset="0x5AB8" ExternalTlut="men_scene" ExternalTlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="men_room_7Tex_0062B8" OutName="men_room_7Tex_0062B8" Format="rgba16" Width="16" Height="128" Offset="0x62B8" AddedByScript="true"/>
+        <Texture Name="men_room_7Tex_0072B8" OutName="men_room_7Tex_0072B8" Format="ci8" Width="64" Height="32" Offset="0x72B8" ExternalTlut="men_scene" ExternalTlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="men_room_7Tex_007AB8" OutName="men_room_7Tex_007AB8" Format="ci8" Width="64" Height="32" Offset="0x7AB8" ExternalTlut="men_scene" ExternalTlutOffset="0xF6C0" AddedByScript="true"/>
         <Room Name="men_room_7" Offset="0x0"/>
     </File>
     <File Name="men_room_8" Segment="3">
+        <Texture Name="men_room_8Tex_005D30" OutName="men_room_8Tex_005D30" Format="rgba16" Width="16" Height="64" Offset="0x5D30" AddedByScript="true"/>
+        <Texture Name="men_room_8Tex_006530" OutName="men_room_8Tex_006530" Format="rgba16" Width="32" Height="32" Offset="0x6530" AddedByScript="true"/>
+        <Texture Name="men_room_8Tex_006D30" OutName="men_room_8Tex_006D30" Format="ci8" Width="32" Height="64" Offset="0x6D30" ExternalTlut="men_scene" ExternalTlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="men_room_8Tex_007530" OutName="men_room_8Tex_007530" Format="rgba16" Width="8" Height="16" Offset="0x7530" AddedByScript="true"/>
+        <Texture Name="men_room_8Tex_007630" OutName="men_room_8Tex_007630" Format="rgba16" Width="32" Height="32" Offset="0x7630" AddedByScript="true"/>
+        <Texture Name="men_room_8Tex_007E30" OutName="men_room_8Tex_007E30" Format="ci8" Width="32" Height="32" Offset="0x7E30" ExternalTlut="men_scene" ExternalTlutOffset="0xF6C0" AddedByScript="true"/>
         <Room Name="men_room_8" Offset="0x0"/>
     </File>
     <File Name="men_room_9" Segment="3">
+        <Texture Name="men_room_9Tex_001AB0" OutName="men_room_9Tex_001AB0" Format="rgba16" Width="32" Height="32" Offset="0x1AB0" AddedByScript="true"/>
+        <Texture Name="men_room_9Tex_0022B0" OutName="men_room_9Tex_0022B0" Format="ci8" Width="32" Height="32" Offset="0x22B0" ExternalTlut="men_scene" ExternalTlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="men_room_9Tex_0026B0" OutName="men_room_9Tex_0026B0" Format="ci8" Width="64" Height="32" Offset="0x26B0" ExternalTlut="men_scene" ExternalTlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="men_room_9Tex_003070" OutName="men_room_9Tex_003070" Format="rgba16" Width="32" Height="32" Offset="0x3070" AddedByScript="true"/>
         <Room Name="men_room_9" Offset="0x0"/>
     </File>
     <File Name="men_room_10" Segment="3">
+        <Texture Name="men_room_10Tex_002448" OutName="men_room_10Tex_002448" Format="ci8" Width="64" Height="32" Offset="0x2448" ExternalTlut="men_scene" ExternalTlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="men_room_10Tex_002C48" OutName="men_room_10Tex_002C48" Format="rgba16" Width="32" Height="32" Offset="0x2C48" AddedByScript="true"/>
+        <Texture Name="men_room_10Tex_003448" OutName="men_room_10Tex_003448" Format="ci8" Width="32" Height="64" Offset="0x3448" ExternalTlut="men_scene" ExternalTlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="men_room_10Tex_003C48" OutName="men_room_10Tex_003C48" Format="ci8" Width="64" Height="32" Offset="0x3C48" ExternalTlut="men_scene" ExternalTlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="men_room_10Tex_004448" OutName="men_room_10Tex_004448" Format="rgba16" Width="32" Height="32" Offset="0x4448" AddedByScript="true"/>
+        <Texture Name="men_room_10Tex_004C48" OutName="men_room_10Tex_004C48" Format="ci8" Width="32" Height="64" Offset="0x4C48" ExternalTlut="men_scene" ExternalTlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="men_room_10Tex_005448" OutName="men_room_10Tex_005448" Format="ci8" Width="64" Height="32" Offset="0x5448" ExternalTlut="men_scene" ExternalTlutOffset="0xF6C0" AddedByScript="true"/>
         <Room Name="men_room_10" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_MQ_D/scenes/dungeons/moribossroom.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/dungeons/moribossroom.xml
@@ -1,11 +1,33 @@
 <Root>
     <File Name="moribossroom_scene" Segment="2">
+        <Texture Name="moribossroom_sceneTex_000CF8" OutName="moribossroom_sceneTex_000CF8" Format="ci8" Width="32" Height="32" Offset="0xCF8" TlutOffset="0xB50" AddedByScript="true"/>
+        <Texture Name="moribossroom_sceneTex_0010F8" OutName="moribossroom_sceneTex_0010F8" Format="ci8" Width="32" Height="64" Offset="0x10F8" TlutOffset="0xB50" AddedByScript="true"/>
+        <Texture Name="moribossroom_sceneTLUT_000B50" OutName="moribossroom_sceneTLUT_000B50" Format="rgba16" Width="16" Height="16" Offset="0xB50" AddedByScript="true"/>
         <Scene Name="moribossroom_scene" Offset="0x0"/>
     </File>
     <File Name="moribossroom_room_0" Segment="3">
+        <Texture Name="moribossroom_room_0Tex_0038B8" OutName="moribossroom_room_0Tex_0038B8" Format="rgba16" Width="32" Height="32" Offset="0x38B8" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_0Tex_0040B8" OutName="moribossroom_room_0Tex_0040B8" Format="ci8" Width="32" Height="32" Offset="0x40B8" ExternalTlut="moribossroom_scene" ExternalTlutOffset="0xB50" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_0Tex_0044B8" OutName="moribossroom_room_0Tex_0044B8" Format="rgba16" Width="64" Height="32" Offset="0x44B8" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_0Tex_0054B8" OutName="moribossroom_room_0Tex_0054B8" Format="rgba16" Width="16" Height="16" Offset="0x54B8" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_0Tex_0056B8" OutName="moribossroom_room_0Tex_0056B8" Format="ci8" Width="32" Height="64" Offset="0x56B8" ExternalTlut="moribossroom_scene" ExternalTlutOffset="0xB50" AddedByScript="true"/>
         <Room Name="moribossroom_room_0" Offset="0x0"/>
     </File>
     <File Name="moribossroom_room_1" Segment="3">
+        <Texture Name="moribossroom_room_1Tex_006A20" OutName="moribossroom_room_1Tex_006A20" Format="rgba16" Width="32" Height="64" Offset="0x6A20" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_1Tex_007A20" OutName="moribossroom_room_1Tex_007A20" Format="rgba16" Width="64" Height="32" Offset="0x7A20" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_1Tex_008A20" OutName="moribossroom_room_1Tex_008A20" Format="rgba16" Width="64" Height="32" Offset="0x8A20" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_1Tex_009A20" OutName="moribossroom_room_1Tex_009A20" Format="rgba16" Width="8" Height="16" Offset="0x9A20" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_1Tex_009B20" OutName="moribossroom_room_1Tex_009B20" Format="rgba16" Width="16" Height="16" Offset="0x9B20" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_1Tex_009D20" OutName="moribossroom_room_1Tex_009D20" Format="ci8" Width="32" Height="64" Offset="0x9D20" TlutOffset="0x6828" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_1Tex_00A520" OutName="moribossroom_room_1Tex_00A520" Format="ci8" Width="64" Height="32" Offset="0xA520" TlutOffset="0x6828" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_1Tex_00AD20" OutName="moribossroom_room_1Tex_00AD20" Format="ci8" Width="64" Height="32" Offset="0xAD20" TlutOffset="0x6828" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_1Tex_00B520" OutName="moribossroom_room_1Tex_00B520" Format="ci8" Width="64" Height="32" Offset="0xB520" ExternalTlut="moribossroom_scene" ExternalTlutOffset="0xB50" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_1Tex_00BD20" OutName="moribossroom_room_1Tex_00BD20" Format="ci8" Width="32" Height="64" Offset="0xBD20" TlutOffset="0x6828" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_1Tex_00C520" OutName="moribossroom_room_1Tex_00C520" Format="ci8" Width="64" Height="32" Offset="0xC520" TlutOffset="0x6828" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_1Tex_00CD20" OutName="moribossroom_room_1Tex_00CD20" Format="ci8" Width="64" Height="32" Offset="0xCD20" TlutOffset="0x6828" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_1Tex_00D6A8" OutName="moribossroom_room_1Tex_00D6A8" Format="rgba16" Width="16" Height="32" Offset="0xD6A8" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_1TLUT_006828" OutName="moribossroom_room_1TLUT_006828" Format="rgba16" Width="16" Height="16" Offset="0x6828" AddedByScript="true"/>
         <Room Name="moribossroom_room_1" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_MQ_D/scenes/dungeons/ydan.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/dungeons/ydan.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="ydan_scene" Segment="2">
+        <Texture Name="ydan_sceneTLUT_00B810" OutName="ydan_sceneTLUT_00B810" Format="rgba16" Width="16" Height="16" Offset="0xB810" AddedByScript="true"/>
         <Cutscene Name="gDekuTreeIntroCs" Offset="0xB650"/>
         <Texture Name="gYdanTex_00BA18" Format="rgba16" Width="32" Height="64" Offset="0xBA18"/>
         <Texture Name="gYdanTex_00CA18" Format="rgba16" Width="32" Height="64" Offset="0xCA18"/>
@@ -7,39 +8,150 @@
         <Scene Name="ydan_scene" Offset="0x0"/>
     </File>
     <File Name="ydan_room_0" Segment="3">
+        <Texture Name="ydan_room_0Tex_0071C0" OutName="ydan_room_0Tex_0071C0" Format="rgba16" Width="32" Height="64" Offset="0x71C0" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_0081C0" OutName="ydan_room_0Tex_0081C0" Format="rgba16" Width="32" Height="64" Offset="0x81C0" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_0091C0" OutName="ydan_room_0Tex_0091C0" Format="ci8" Width="32" Height="64" Offset="0x91C0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_0099C0" OutName="ydan_room_0Tex_0099C0" Format="ci8" Width="32" Height="64" Offset="0x99C0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_00A1C0" OutName="ydan_room_0Tex_00A1C0" Format="ci8" Width="32" Height="32" Offset="0xA1C0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_00A5C0" OutName="ydan_room_0Tex_00A5C0" Format="ci8" Width="32" Height="64" Offset="0xA5C0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_00ADC0" OutName="ydan_room_0Tex_00ADC0" Format="ci8" Width="32" Height="64" Offset="0xADC0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_00B5C0" OutName="ydan_room_0Tex_00B5C0" Format="ci8" Width="32" Height="64" Offset="0xB5C0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_00BDC0" OutName="ydan_room_0Tex_00BDC0" Format="rgba16" Width="32" Height="32" Offset="0xBDC0" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_00C5C0" OutName="ydan_room_0Tex_00C5C0" Format="ci8" Width="32" Height="64" Offset="0xC5C0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_00CDC0" OutName="ydan_room_0Tex_00CDC0" Format="ci8" Width="32" Height="64" Offset="0xCDC0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_00D5C0" OutName="ydan_room_0Tex_00D5C0" Format="ci8" Width="32" Height="32" Offset="0xD5C0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_00D9C0" OutName="ydan_room_0Tex_00D9C0" Format="ci8" Width="32" Height="64" Offset="0xD9C0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_00E1C0" OutName="ydan_room_0Tex_00E1C0" Format="ci8" Width="32" Height="64" Offset="0xE1C0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_00E9C0" OutName="ydan_room_0Tex_00E9C0" Format="ci8" Width="32" Height="64" Offset="0xE9C0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_00F1C0" OutName="ydan_room_0Tex_00F1C0" Format="ci8" Width="32" Height="64" Offset="0xF1C0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_00F9C0" OutName="ydan_room_0Tex_00F9C0" Format="rgba16" Width="64" Height="32" Offset="0xF9C0" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_0109C0" OutName="ydan_room_0Tex_0109C0" Format="ci8" Width="32" Height="64" Offset="0x109C0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_012F48" OutName="ydan_room_0Tex_012F48" Format="rgba16" Width="32" Height="64" Offset="0x12F48" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_013F48" OutName="ydan_room_0Tex_013F48" Format="ci8" Width="32" Height="32" Offset="0x13F48" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_014348" OutName="ydan_room_0Tex_014348" Format="ia16" Width="32" Height="64" Offset="0x14348" AddedByScript="true"/>
         <Room Name="ydan_room_0" Offset="0x0"/>
     </File>
     <File Name="ydan_room_1" Segment="3">
+        <Texture Name="ydan_room_1Tex_000F98" OutName="ydan_room_1Tex_000F98" Format="ci8" Width="32" Height="64" Offset="0xF98" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_1Tex_001798" OutName="ydan_room_1Tex_001798" Format="ci8" Width="32" Height="64" Offset="0x1798" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_1Tex_001F98" OutName="ydan_room_1Tex_001F98" Format="ci8" Width="32" Height="64" Offset="0x1F98" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_1Tex_002798" OutName="ydan_room_1Tex_002798" Format="ci8" Width="32" Height="64" Offset="0x2798" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_1Tex_003200" OutName="ydan_room_1Tex_003200" Format="ia16" Width="32" Height="64" Offset="0x3200" AddedByScript="true"/>
         <Room Name="ydan_room_1" Offset="0x0"/>
     </File>
     <File Name="ydan_room_2" Segment="3">
+        <Texture Name="ydan_room_2Tex_001D08" OutName="ydan_room_2Tex_001D08" Format="ci8" Width="32" Height="64" Offset="0x1D08" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_2Tex_002508" OutName="ydan_room_2Tex_002508" Format="ci8" Width="32" Height="64" Offset="0x2508" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_2Tex_002D08" OutName="ydan_room_2Tex_002D08" Format="ci8" Width="32" Height="64" Offset="0x2D08" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_2Tex_003508" OutName="ydan_room_2Tex_003508" Format="ci8" Width="32" Height="64" Offset="0x3508" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_2Tex_003D08" OutName="ydan_room_2Tex_003D08" Format="ci8" Width="32" Height="64" Offset="0x3D08" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_2Tex_004508" OutName="ydan_room_2Tex_004508" Format="ci8" Width="32" Height="64" Offset="0x4508" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_2Tex_004F28" OutName="ydan_room_2Tex_004F28" Format="rgba16" Width="32" Height="64" Offset="0x4F28" AddedByScript="true"/>
         <Room Name="ydan_room_2" Offset="0x0"/>
     </File>
     <File Name="ydan_room_3" Segment="3">
+        <Texture Name="ydan_room_3Tex_0074C0" OutName="ydan_room_3Tex_0074C0" Format="rgba16" Width="32" Height="64" Offset="0x74C0" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_0084C0" OutName="ydan_room_3Tex_0084C0" Format="ci8" Width="32" Height="64" Offset="0x84C0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_008CC0" OutName="ydan_room_3Tex_008CC0" Format="ci8" Width="32" Height="64" Offset="0x8CC0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_0094C0" OutName="ydan_room_3Tex_0094C0" Format="ci8" Width="32" Height="64" Offset="0x94C0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_009CC0" OutName="ydan_room_3Tex_009CC0" Format="ci8" Width="32" Height="32" Offset="0x9CC0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_00A0C0" OutName="ydan_room_3Tex_00A0C0" Format="ci8" Width="32" Height="64" Offset="0xA0C0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_00A8C0" OutName="ydan_room_3Tex_00A8C0" Format="ci8" Width="64" Height="32" Offset="0xA8C0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_00B0C0" OutName="ydan_room_3Tex_00B0C0" Format="ci8" Width="32" Height="32" Offset="0xB0C0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_00B4C0" OutName="ydan_room_3Tex_00B4C0" Format="ci8" Width="32" Height="32" Offset="0xB4C0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_00B8C0" OutName="ydan_room_3Tex_00B8C0" Format="ci8" Width="32" Height="64" Offset="0xB8C0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_00C0C0" OutName="ydan_room_3Tex_00C0C0" Format="ci8" Width="32" Height="64" Offset="0xC0C0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_00C8C0" OutName="ydan_room_3Tex_00C8C0" Format="ci8" Width="32" Height="64" Offset="0xC8C0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_00D0C0" OutName="ydan_room_3Tex_00D0C0" Format="ci8" Width="32" Height="32" Offset="0xD0C0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_00D4C0" OutName="ydan_room_3Tex_00D4C0" Format="ci8" Width="32" Height="32" Offset="0xD4C0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_00D8C0" OutName="ydan_room_3Tex_00D8C0" Format="ci8" Width="32" Height="64" Offset="0xD8C0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_00E0C0" OutName="ydan_room_3Tex_00E0C0" Format="ci8" Width="32" Height="64" Offset="0xE0C0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_00E8C0" OutName="ydan_room_3Tex_00E8C0" Format="rgba16" Width="64" Height="32" Offset="0xE8C0" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_00F8C0" OutName="ydan_room_3Tex_00F8C0" Format="ci8" Width="32" Height="64" Offset="0xF8C0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_011DB0" OutName="ydan_room_3Tex_011DB0" Format="rgba16" Width="32" Height="64" Offset="0x11DB0" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_012DB0" OutName="ydan_room_3Tex_012DB0" Format="ci8" Width="32" Height="32" Offset="0x12DB0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_0131B0" OutName="ydan_room_3Tex_0131B0" Format="ia16" Width="32" Height="64" Offset="0x131B0" AddedByScript="true"/>
         <Room Name="ydan_room_3" Offset="0x0"/>
     </File>
     <File Name="ydan_room_4" Segment="3">
+        <Texture Name="ydan_room_4Tex_001920" OutName="ydan_room_4Tex_001920" Format="ci8" Width="32" Height="64" Offset="0x1920" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_4Tex_002120" OutName="ydan_room_4Tex_002120" Format="ci8" Width="32" Height="64" Offset="0x2120" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_4Tex_002920" OutName="ydan_room_4Tex_002920" Format="ci8" Width="32" Height="64" Offset="0x2920" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_4Tex_003120" OutName="ydan_room_4Tex_003120" Format="ci8" Width="64" Height="32" Offset="0x3120" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_4Tex_003C28" OutName="ydan_room_4Tex_003C28" Format="ia16" Width="32" Height="64" Offset="0x3C28" AddedByScript="true"/>
         <Room Name="ydan_room_4" Offset="0x0"/>
     </File>
     <File Name="ydan_room_5" Segment="3">
+        <Texture Name="ydan_room_5Tex_003F88" OutName="ydan_room_5Tex_003F88" Format="ci8" Width="32" Height="64" Offset="0x3F88" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_5Tex_004788" OutName="ydan_room_5Tex_004788" Format="ci8" Width="32" Height="64" Offset="0x4788" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_5Tex_004F88" OutName="ydan_room_5Tex_004F88" Format="ci8" Width="32" Height="64" Offset="0x4F88" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_5Tex_005788" OutName="ydan_room_5Tex_005788" Format="ci8" Width="32" Height="32" Offset="0x5788" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_5Tex_005B88" OutName="ydan_room_5Tex_005B88" Format="ci8" Width="32" Height="64" Offset="0x5B88" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_5Tex_006388" OutName="ydan_room_5Tex_006388" Format="ci8" Width="64" Height="32" Offset="0x6388" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_5Tex_006B88" OutName="ydan_room_5Tex_006B88" Format="ci8" Width="32" Height="32" Offset="0x6B88" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_5Tex_006F88" OutName="ydan_room_5Tex_006F88" Format="ci8" Width="32" Height="32" Offset="0x6F88" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_5Tex_007388" OutName="ydan_room_5Tex_007388" Format="ci8" Width="32" Height="32" Offset="0x7388" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_5Tex_007788" OutName="ydan_room_5Tex_007788" Format="ci8" Width="32" Height="32" Offset="0x7788" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_5Tex_007B88" OutName="ydan_room_5Tex_007B88" Format="ci8" Width="32" Height="64" Offset="0x7B88" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
         <Room Name="ydan_room_5" Offset="0x0"/>
     </File>
     <File Name="ydan_room_6" Segment="3">
+        <Texture Name="ydan_room_6Tex_001F00" OutName="ydan_room_6Tex_001F00" Format="ci8" Width="32" Height="64" Offset="0x1F00" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_6Tex_002700" OutName="ydan_room_6Tex_002700" Format="ci8" Width="32" Height="64" Offset="0x2700" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_6Tex_002F00" OutName="ydan_room_6Tex_002F00" Format="ci8" Width="32" Height="64" Offset="0x2F00" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_6Tex_003700" OutName="ydan_room_6Tex_003700" Format="ci8" Width="32" Height="64" Offset="0x3700" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_6Tex_003F00" OutName="ydan_room_6Tex_003F00" Format="ci8" Width="32" Height="64" Offset="0x3F00" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_6Tex_004700" OutName="ydan_room_6Tex_004700" Format="ci8" Width="32" Height="64" Offset="0x4700" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
         <Room Name="ydan_room_6" Offset="0x0"/>
     </File>
     <File Name="ydan_room_7" Segment="3">
+        <Texture Name="ydan_room_7Tex_002C98" OutName="ydan_room_7Tex_002C98" Format="ci8" Width="32" Height="64" Offset="0x2C98" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_7Tex_003498" OutName="ydan_room_7Tex_003498" Format="ci8" Width="32" Height="64" Offset="0x3498" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_7Tex_003C98" OutName="ydan_room_7Tex_003C98" Format="ci8" Width="32" Height="64" Offset="0x3C98" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_7Tex_004498" OutName="ydan_room_7Tex_004498" Format="ci8" Width="32" Height="64" Offset="0x4498" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_7Tex_004C98" OutName="ydan_room_7Tex_004C98" Format="ci8" Width="64" Height="32" Offset="0x4C98" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_7Tex_005498" OutName="ydan_room_7Tex_005498" Format="ci8" Width="32" Height="32" Offset="0x5498" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_7Tex_005898" OutName="ydan_room_7Tex_005898" Format="ci8" Width="32" Height="64" Offset="0x5898" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_7Tex_006098" OutName="ydan_room_7Tex_006098" Format="ci8" Width="32" Height="64" Offset="0x6098" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_7Tex_006898" OutName="ydan_room_7Tex_006898" Format="ci8" Width="32" Height="32" Offset="0x6898" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_7Tex_006C98" OutName="ydan_room_7Tex_006C98" Format="ci8" Width="32" Height="32" Offset="0x6C98" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_7Tex_007098" OutName="ydan_room_7Tex_007098" Format="ci8" Width="32" Height="64" Offset="0x7098" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_7Tex_007A98" OutName="ydan_room_7Tex_007A98" Format="rgba16" Width="32" Height="64" Offset="0x7A98" AddedByScript="true"/>
         <Room Name="ydan_room_7" Offset="0x0"/>
     </File>
     <File Name="ydan_room_8" Segment="3">
+        <Texture Name="ydan_room_8Tex_000988" OutName="ydan_room_8Tex_000988" Format="ci8" Width="32" Height="32" Offset="0x988" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
         <Room Name="ydan_room_8" Offset="0x0"/>
     </File>
     <File Name="ydan_room_9" Segment="3">
+        <Texture Name="ydan_room_9Tex_002480" OutName="ydan_room_9Tex_002480" Format="ci8" Width="32" Height="64" Offset="0x2480" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_9Tex_002C80" OutName="ydan_room_9Tex_002C80" Format="ci8" Width="32" Height="64" Offset="0x2C80" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_9Tex_003480" OutName="ydan_room_9Tex_003480" Format="ci8" Width="32" Height="64" Offset="0x3480" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_9Tex_003C80" OutName="ydan_room_9Tex_003C80" Format="ci8" Width="32" Height="64" Offset="0x3C80" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_9Tex_004480" OutName="ydan_room_9Tex_004480" Format="ci8" Width="32" Height="64" Offset="0x4480" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_9Tex_004C80" OutName="ydan_room_9Tex_004C80" Format="ci8" Width="32" Height="64" Offset="0x4C80" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_9Tex_005480" OutName="ydan_room_9Tex_005480" Format="ci8" Width="32" Height="64" Offset="0x5480" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_9Tex_005C80" OutName="ydan_room_9Tex_005C80" Format="ci8" Width="32" Height="64" Offset="0x5C80" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_9Tex_006480" OutName="ydan_room_9Tex_006480" Format="ci8" Width="32" Height="64" Offset="0x6480" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_9Tex_007498" OutName="ydan_room_9Tex_007498" Format="rgba16" Width="32" Height="64" Offset="0x7498" AddedByScript="true"/>
+        <Texture Name="ydan_room_9Tex_008498" OutName="ydan_room_9Tex_008498" Format="ci8" Width="32" Height="32" Offset="0x8498" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_9Tex_008898" OutName="ydan_room_9Tex_008898" Format="ia16" Width="32" Height="64" Offset="0x8898" AddedByScript="true"/>
         <Room Name="ydan_room_9" Offset="0x0"/>
     </File>
     <File Name="ydan_room_10" Segment="3">
+        <Texture Name="ydan_room_10Tex_001BE0" OutName="ydan_room_10Tex_001BE0" Format="ci8" Width="32" Height="64" Offset="0x1BE0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_10Tex_0023E0" OutName="ydan_room_10Tex_0023E0" Format="ci8" Width="32" Height="64" Offset="0x23E0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_10Tex_002BE0" OutName="ydan_room_10Tex_002BE0" Format="ci8" Width="32" Height="64" Offset="0x2BE0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_10Tex_0033E0" OutName="ydan_room_10Tex_0033E0" Format="ci8" Width="32" Height="64" Offset="0x33E0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_10Tex_003DF8" OutName="ydan_room_10Tex_003DF8" Format="rgba16" Width="32" Height="64" Offset="0x3DF8" AddedByScript="true"/>
         <Room Name="ydan_room_10" Offset="0x0"/>
     </File>
     <File Name="ydan_room_11" Segment="3">
+        <Texture Name="ydan_room_11Tex_003CD8" OutName="ydan_room_11Tex_003CD8" Format="ci8" Width="32" Height="64" Offset="0x3CD8" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_11Tex_0044D8" OutName="ydan_room_11Tex_0044D8" Format="rgba16" Width="32" Height="64" Offset="0x44D8" AddedByScript="true"/>
+        <Texture Name="ydan_room_11Tex_0054D8" OutName="ydan_room_11Tex_0054D8" Format="ci8" Width="32" Height="64" Offset="0x54D8" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_11Tex_005CD8" OutName="ydan_room_11Tex_005CD8" Format="ci8" Width="32" Height="32" Offset="0x5CD8" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB810" AddedByScript="true"/>
+        <Texture Name="ydan_room_11Tex_006968" OutName="ydan_room_11Tex_006968" Format="ia8" Width="64" Height="32" Offset="0x6968" AddedByScript="true"/>
         <Room Name="ydan_room_11" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_MQ_D/scenes/dungeons/ydan_boss.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/dungeons/ydan_boss.xml
@@ -1,11 +1,26 @@
 <Root>
     <File Name="ydan_boss_scene" Segment="2">
+        <Texture Name="ydan_boss_sceneTex_000F38" OutName="ydan_boss_sceneTex_000F38" Format="ci8" Width="32" Height="64" Offset="0xF38" TlutOffset="0xD30" AddedByScript="true"/>
+        <Texture Name="ydan_boss_sceneTLUT_000D30" OutName="ydan_boss_sceneTLUT_000D30" Format="rgba16" Width="16" Height="16" Offset="0xD30" AddedByScript="true"/>
         <Scene Name="ydan_boss_scene" Offset="0x0"/>
     </File>
     <File Name="ydan_boss_room_0" Segment="3">
+        <Texture Name="ydan_boss_room_0Tex_001790" OutName="ydan_boss_room_0Tex_001790" Format="ci8" Width="32" Height="64" Offset="0x1790" ExternalTlut="ydan_boss_scene" ExternalTlutOffset="0xD30" AddedByScript="true"/>
+        <Texture Name="ydan_boss_room_0Tex_001F90" OutName="ydan_boss_room_0Tex_001F90" Format="ci8" Width="32" Height="64" Offset="0x1F90" ExternalTlut="ydan_boss_scene" ExternalTlutOffset="0xD30" AddedByScript="true"/>
+        <Texture Name="ydan_boss_room_0Tex_002790" OutName="ydan_boss_room_0Tex_002790" Format="ci8" Width="32" Height="64" Offset="0x2790" ExternalTlut="ydan_boss_scene" ExternalTlutOffset="0xD30" AddedByScript="true"/>
+        <Texture Name="ydan_boss_room_0Tex_002F90" OutName="ydan_boss_room_0Tex_002F90" Format="ci8" Width="32" Height="64" Offset="0x2F90" ExternalTlut="ydan_boss_scene" ExternalTlutOffset="0xD30" AddedByScript="true"/>
+        <Texture Name="ydan_boss_room_0Tex_003790" OutName="ydan_boss_room_0Tex_003790" Format="ci8" Width="32" Height="64" Offset="0x3790" ExternalTlut="ydan_boss_scene" ExternalTlutOffset="0xD30" AddedByScript="true"/>
+        <Texture Name="ydan_boss_room_0Tex_003F90" OutName="ydan_boss_room_0Tex_003F90" Format="ci8" Width="32" Height="64" Offset="0x3F90" ExternalTlut="ydan_boss_scene" ExternalTlutOffset="0xD30" AddedByScript="true"/>
+        <Texture Name="ydan_boss_room_0Tex_004BF0" OutName="ydan_boss_room_0Tex_004BF0" Format="rgba16" Width="32" Height="64" Offset="0x4BF0" AddedByScript="true"/>
+        <Texture Name="ydan_boss_room_0Tex_005BF0" OutName="ydan_boss_room_0Tex_005BF0" Format="ci8" Width="32" Height="32" Offset="0x5BF0" ExternalTlut="ydan_boss_scene" ExternalTlutOffset="0xD30" AddedByScript="true"/>
+        <Texture Name="ydan_boss_room_0Tex_005FF0" OutName="ydan_boss_room_0Tex_005FF0" Format="ia16" Width="32" Height="64" Offset="0x5FF0" AddedByScript="true"/>
         <Room Name="ydan_boss_room_0" Offset="0x0"/>
     </File>
     <File Name="ydan_boss_room_1" Segment="3">
+        <Texture Name="ydan_boss_room_1Tex_003B38" OutName="ydan_boss_room_1Tex_003B38" Format="rgba16" Width="32" Height="64" Offset="0x3B38" AddedByScript="true"/>
+        <Texture Name="ydan_boss_room_1Tex_004B38" OutName="ydan_boss_room_1Tex_004B38" Format="ci8" Width="32" Height="64" Offset="0x4B38" ExternalTlut="ydan_boss_scene" ExternalTlutOffset="0xD30" AddedByScript="true"/>
+        <Texture Name="ydan_boss_room_1Tex_005338" OutName="ydan_boss_room_1Tex_005338" Format="ci8" Width="32" Height="32" Offset="0x5338" ExternalTlut="ydan_boss_scene" ExternalTlutOffset="0xD30" AddedByScript="true"/>
+        <Texture Name="ydan_boss_room_1Tex_005FE8" OutName="ydan_boss_room_1Tex_005FE8" Format="ia8" Width="64" Height="32" Offset="0x5FE8" AddedByScript="true"/>
         <Room Name="ydan_boss_room_1" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_MQ_D/scenes/indoors/bowling.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/indoors/bowling.xml
@@ -1,5 +1,33 @@
 <Root>
     <File Name="bowling_scene" Segment="2">
+        <Texture Name="bowling_sceneTex_001AA0" OutName="bowling_sceneTex_001AA0" Format="rgba16" Width="32" Height="32" Offset="0x1AA0" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_0022A0" OutName="bowling_sceneTex_0022A0" Format="i4" Width="16" Height="16" Offset="0x22A0" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_002320" OutName="bowling_sceneTex_002320" Format="rgba16" Width="16" Height="32" Offset="0x2320" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_002720" OutName="bowling_sceneTex_002720" Format="rgba16" Width="32" Height="32" Offset="0x2720" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_002F20" OutName="bowling_sceneTex_002F20" Format="rgba16" Width="32" Height="32" Offset="0x2F20" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_003720" OutName="bowling_sceneTex_003720" Format="i4" Width="64" Height="128" Offset="0x3720" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_004720" OutName="bowling_sceneTex_004720" Format="ia4" Width="64" Height="64" Offset="0x4720" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_004F20" OutName="bowling_sceneTex_004F20" Format="rgba16" Width="16" Height="16" Offset="0x4F20" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_005120" OutName="bowling_sceneTex_005120" Format="rgba16" Width="16" Height="16" Offset="0x5120" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_005320" OutName="bowling_sceneTex_005320" Format="rgba16" Width="16" Height="16" Offset="0x5320" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_005520" OutName="bowling_sceneTex_005520" Format="rgba16" Width="16" Height="32" Offset="0x5520" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_005920" OutName="bowling_sceneTex_005920" Format="rgba16" Width="32" Height="32" Offset="0x5920" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_006120" OutName="bowling_sceneTex_006120" Format="rgba16" Width="64" Height="32" Offset="0x6120" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_007120" OutName="bowling_sceneTex_007120" Format="ia8" Width="128" Height="32" Offset="0x7120" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_008120" OutName="bowling_sceneTex_008120" Format="rgba16" Width="32" Height="32" Offset="0x8120" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_008920" OutName="bowling_sceneTex_008920" Format="rgba16" Width="32" Height="32" Offset="0x8920" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_009120" OutName="bowling_sceneTex_009120" Format="rgba16" Width="32" Height="64" Offset="0x9120" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_00A120" OutName="bowling_sceneTex_00A120" Format="rgba16" Width="32" Height="32" Offset="0xA120" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_00A920" OutName="bowling_sceneTex_00A920" Format="i8" Width="32" Height="16" Offset="0xA920" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_00AB20" OutName="bowling_sceneTex_00AB20" Format="ia8" Width="32" Height="16" Offset="0xAB20" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_00AD20" OutName="bowling_sceneTex_00AD20" Format="i4" Width="32" Height="32" Offset="0xAD20" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_00AF20" OutName="bowling_sceneTex_00AF20" Format="ia8" Width="64" Height="32" Offset="0xAF20" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_00B720" OutName="bowling_sceneTex_00B720" Format="ia8" Width="32" Height="32" Offset="0xB720" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_00BB20" OutName="bowling_sceneTex_00BB20" Format="ia8" Width="32" Height="32" Offset="0xBB20" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_00BF20" OutName="bowling_sceneTex_00BF20" Format="rgba16" Width="32" Height="32" Offset="0xBF20" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_00C720" OutName="bowling_sceneTex_00C720" Format="ia8" Width="64" Height="64" Offset="0xC720" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_00D720" OutName="bowling_sceneTex_00D720" Format="i8" Width="32" Height="32" Offset="0xD720" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_00DB20" OutName="bowling_sceneTex_00DB20" Format="rgba16" Width="64" Height="32" Offset="0xDB20" AddedByScript="true"/>
         <Scene Name="bowling_scene" Offset="0x0"/>
     </File>
     <File Name="bowling_room_0" Segment="3">

--- a/soh/assets/xml/GC_MQ_D/scenes/indoors/daiyousei_izumi.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/indoors/daiyousei_izumi.xml
@@ -1,5 +1,19 @@
 <Root>
     <File Name="daiyousei_izumi_scene" Segment="2">
+        <Texture Name="daiyousei_izumi_sceneTex_004800" OutName="daiyousei_izumi_sceneTex_004800" Format="i8" Width="32" Height="64" Offset="0x4800" AddedByScript="true"/>
+        <Texture Name="daiyousei_izumi_sceneTex_005000" OutName="daiyousei_izumi_sceneTex_005000" Format="rgba16" Width="32" Height="32" Offset="0x5000" AddedByScript="true"/>
+        <Texture Name="daiyousei_izumi_sceneTex_005800" OutName="daiyousei_izumi_sceneTex_005800" Format="rgba16" Width="32" Height="32" Offset="0x5800" AddedByScript="true"/>
+        <Texture Name="daiyousei_izumi_sceneTex_006000" OutName="daiyousei_izumi_sceneTex_006000" Format="ia4" Width="64" Height="128" Offset="0x6000" AddedByScript="true"/>
+        <Texture Name="daiyousei_izumi_sceneTex_007000" OutName="daiyousei_izumi_sceneTex_007000" Format="rgba16" Width="32" Height="64" Offset="0x7000" AddedByScript="true"/>
+        <Texture Name="daiyousei_izumi_sceneTex_008000" OutName="daiyousei_izumi_sceneTex_008000" Format="rgba16" Width="32" Height="64" Offset="0x8000" AddedByScript="true"/>
+        <Texture Name="daiyousei_izumi_sceneTex_009000" OutName="daiyousei_izumi_sceneTex_009000" Format="rgba16" Width="32" Height="64" Offset="0x9000" AddedByScript="true"/>
+        <Texture Name="daiyousei_izumi_sceneTex_00A000" OutName="daiyousei_izumi_sceneTex_00A000" Format="i8" Width="32" Height="64" Offset="0xA000" AddedByScript="true"/>
+        <Texture Name="daiyousei_izumi_sceneTex_00A800" OutName="daiyousei_izumi_sceneTex_00A800" Format="rgba16" Width="32" Height="32" Offset="0xA800" AddedByScript="true"/>
+        <Texture Name="daiyousei_izumi_sceneTex_00B000" OutName="daiyousei_izumi_sceneTex_00B000" Format="i8" Width="32" Height="128" Offset="0xB000" AddedByScript="true"/>
+        <Texture Name="daiyousei_izumi_sceneTex_00C000" OutName="daiyousei_izumi_sceneTex_00C000" Format="rgba16" Width="32" Height="32" Offset="0xC000" AddedByScript="true"/>
+        <Texture Name="daiyousei_izumi_sceneTex_00C800" OutName="daiyousei_izumi_sceneTex_00C800" Format="ia8" Width="64" Height="32" Offset="0xC800" AddedByScript="true"/>
+        <Texture Name="daiyousei_izumi_sceneTex_00D000" OutName="daiyousei_izumi_sceneTex_00D000" Format="rgba16" Width="32" Height="32" Offset="0xD000" AddedByScript="true"/>
+        <Texture Name="daiyousei_izumi_sceneTex_00D800" OutName="daiyousei_izumi_sceneTex_00D800" Format="rgba16" Width="32" Height="32" Offset="0xD800" AddedByScript="true"/>
         <Cutscene Name="gGreatFairyMagicCs" Offset="0x0130"/>
         <Cutscene Name="gGreatFairyDoubleMagicCs" Offset="0x13E0"/>
         <Cutscene Name="gGreatFairyDoubleDefenceCs" Offset="0x25D0"/>

--- a/soh/assets/xml/GC_MQ_D/scenes/indoors/hairal_niwa.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/indoors/hairal_niwa.xml
@@ -1,5 +1,27 @@
 <Root>
     <File Name="hairal_niwa_scene" Segment="2">
+        <Texture Name="hairal_niwa_sceneTex_003390" OutName="hairal_niwa_sceneTex_003390" Format="rgba16" Width="32" Height="32" Offset="0x3390" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_003B90" OutName="hairal_niwa_sceneTex_003B90" Format="ia16" Width="32" Height="64" Offset="0x3B90" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_004B90" OutName="hairal_niwa_sceneTex_004B90" Format="rgba16" Width="32" Height="32" Offset="0x4B90" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_005390" OutName="hairal_niwa_sceneTex_005390" Format="rgba16" Width="32" Height="32" Offset="0x5390" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_005B90" OutName="hairal_niwa_sceneTex_005B90" Format="rgba16" Width="32" Height="32" Offset="0x5B90" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_006390" OutName="hairal_niwa_sceneTex_006390" Format="rgba16" Width="32" Height="64" Offset="0x6390" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_007390" OutName="hairal_niwa_sceneTex_007390" Format="i4" Width="64" Height="64" Offset="0x7390" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_007B90" OutName="hairal_niwa_sceneTex_007B90" Format="rgba16" Width="32" Height="64" Offset="0x7B90" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_008B90" OutName="hairal_niwa_sceneTex_008B90" Format="rgba16" Width="32" Height="32" Offset="0x8B90" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_009390" OutName="hairal_niwa_sceneTex_009390" Format="rgba16" Width="32" Height="32" Offset="0x9390" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_009B90" OutName="hairal_niwa_sceneTex_009B90" Format="rgba16" Width="32" Height="64" Offset="0x9B90" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_00AB90" OutName="hairal_niwa_sceneTex_00AB90" Format="rgba16" Width="32" Height="32" Offset="0xAB90" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_00B390" OutName="hairal_niwa_sceneTex_00B390" Format="rgba16" Width="32" Height="32" Offset="0xB390" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_00BB90" OutName="hairal_niwa_sceneTex_00BB90" Format="rgba16" Width="32" Height="32" Offset="0xBB90" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_00C390" OutName="hairal_niwa_sceneTex_00C390" Format="ia4" Width="64" Height="64" Offset="0xC390" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_00CB90" OutName="hairal_niwa_sceneTex_00CB90" Format="i8" Width="32" Height="64" Offset="0xCB90" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_00D390" OutName="hairal_niwa_sceneTex_00D390" Format="ia4" Width="32" Height="128" Offset="0xD390" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_00DB90" OutName="hairal_niwa_sceneTex_00DB90" Format="rgba16" Width="32" Height="64" Offset="0xDB90" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_00EB90" OutName="hairal_niwa_sceneTex_00EB90" Format="rgba16" Width="32" Height="32" Offset="0xEB90" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_00F390" OutName="hairal_niwa_sceneTex_00F390" Format="rgba16" Width="32" Height="32" Offset="0xF390" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_00FB90" OutName="hairal_niwa_sceneTex_00FB90" Format="rgba16" Width="32" Height="32" Offset="0xFB90" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_010390" OutName="hairal_niwa_sceneTex_010390" Format="rgba16" Width="32" Height="64" Offset="0x10390" AddedByScript="true"/>
         <Path Name="hairal_niwa_scenePathList_000268" Offset="0x0268" NumPaths="8"/>
         <Scene Name="hairal_niwa_scene" Offset="0x0"/>
     </File>

--- a/soh/assets/xml/GC_MQ_D/scenes/indoors/hairal_niwa2.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/indoors/hairal_niwa2.xml
@@ -3,6 +3,28 @@
         <Scene Name="hairal_niwa2_scene" Offset="0x0"/>
     </File>
     <File Name="hairal_niwa2_room_0" Segment="3">
+        <Texture Name="hairal_niwa2_room_0Tex_008750" OutName="hairal_niwa2_room_0Tex_008750" Format="rgba16" Width="32" Height="32" Offset="0x8750" AddedByScript="true"/>
+        <Texture Name="hairal_niwa2_room_0Tex_008F50" OutName="hairal_niwa2_room_0Tex_008F50" Format="rgba16" Width="32" Height="32" Offset="0x8F50" AddedByScript="true"/>
+        <Texture Name="hairal_niwa2_room_0Tex_009750" OutName="hairal_niwa2_room_0Tex_009750" Format="rgba16" Width="32" Height="32" Offset="0x9750" AddedByScript="true"/>
+        <Texture Name="hairal_niwa2_room_0Tex_009F50" OutName="hairal_niwa2_room_0Tex_009F50" Format="rgba16" Width="32" Height="64" Offset="0x9F50" AddedByScript="true"/>
+        <Texture Name="hairal_niwa2_room_0Tex_00AF50" OutName="hairal_niwa2_room_0Tex_00AF50" Format="i4" Width="64" Height="64" Offset="0xAF50" AddedByScript="true"/>
+        <Texture Name="hairal_niwa2_room_0Tex_00B750" OutName="hairal_niwa2_room_0Tex_00B750" Format="rgba16" Width="32" Height="64" Offset="0xB750" AddedByScript="true"/>
+        <Texture Name="hairal_niwa2_room_0Tex_00C750" OutName="hairal_niwa2_room_0Tex_00C750" Format="rgba16" Width="32" Height="32" Offset="0xC750" AddedByScript="true"/>
+        <Texture Name="hairal_niwa2_room_0Tex_00CF50" OutName="hairal_niwa2_room_0Tex_00CF50" Format="rgba16" Width="32" Height="32" Offset="0xCF50" AddedByScript="true"/>
+        <Texture Name="hairal_niwa2_room_0Tex_00D750" OutName="hairal_niwa2_room_0Tex_00D750" Format="rgba16" Width="32" Height="64" Offset="0xD750" AddedByScript="true"/>
+        <Texture Name="hairal_niwa2_room_0Tex_00E750" OutName="hairal_niwa2_room_0Tex_00E750" Format="rgba16" Width="32" Height="32" Offset="0xE750" AddedByScript="true"/>
+        <Texture Name="hairal_niwa2_room_0Tex_00EF50" OutName="hairal_niwa2_room_0Tex_00EF50" Format="rgba16" Width="32" Height="32" Offset="0xEF50" AddedByScript="true"/>
+        <Texture Name="hairal_niwa2_room_0Tex_00F750" OutName="hairal_niwa2_room_0Tex_00F750" Format="rgba16" Width="32" Height="32" Offset="0xF750" AddedByScript="true"/>
+        <Texture Name="hairal_niwa2_room_0Tex_00FF50" OutName="hairal_niwa2_room_0Tex_00FF50" Format="rgba16" Width="32" Height="64" Offset="0xFF50" AddedByScript="true"/>
+        <Texture Name="hairal_niwa2_room_0Tex_010F50" OutName="hairal_niwa2_room_0Tex_010F50" Format="rgba16" Width="32" Height="32" Offset="0x10F50" AddedByScript="true"/>
+        <Texture Name="hairal_niwa2_room_0Tex_011750" OutName="hairal_niwa2_room_0Tex_011750" Format="rgba16" Width="32" Height="32" Offset="0x11750" AddedByScript="true"/>
+        <Texture Name="hairal_niwa2_room_0Tex_011F50" OutName="hairal_niwa2_room_0Tex_011F50" Format="rgba16" Width="32" Height="32" Offset="0x11F50" AddedByScript="true"/>
+        <Texture Name="hairal_niwa2_room_0Tex_012750" OutName="hairal_niwa2_room_0Tex_012750" Format="rgba16" Width="32" Height="64" Offset="0x12750" AddedByScript="true"/>
+        <Texture Name="hairal_niwa2_room_0Tex_014BF8" OutName="hairal_niwa2_room_0Tex_014BF8" Format="ia16" Width="32" Height="64" Offset="0x14BF8" AddedByScript="true"/>
+        <Texture Name="hairal_niwa2_room_0Tex_015BF8" OutName="hairal_niwa2_room_0Tex_015BF8" Format="rgba16" Width="32" Height="32" Offset="0x15BF8" AddedByScript="true"/>
+        <Texture Name="hairal_niwa2_room_0Tex_0163F8" OutName="hairal_niwa2_room_0Tex_0163F8" Format="ia4" Width="64" Height="64" Offset="0x163F8" AddedByScript="true"/>
+        <Texture Name="hairal_niwa2_room_0Tex_016BF8" OutName="hairal_niwa2_room_0Tex_016BF8" Format="i8" Width="32" Height="64" Offset="0x16BF8" AddedByScript="true"/>
+        <Texture Name="hairal_niwa2_room_0Tex_0173F8" OutName="hairal_niwa2_room_0Tex_0173F8" Format="ia4" Width="32" Height="128" Offset="0x173F8" AddedByScript="true"/>
         <Room Name="hairal_niwa2_room_0" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_MQ_D/scenes/indoors/hairal_niwa_n.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/indoors/hairal_niwa_n.xml
@@ -1,5 +1,18 @@
 <Root>
     <File Name="hairal_niwa_n_scene" Segment="2">
+        <Texture Name="hairal_niwa_n_sceneTex_0010F0" OutName="hairal_niwa_n_sceneTex_0010F0" Format="rgba16" Width="32" Height="32" Offset="0x10F0" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_n_sceneTex_0018F0" OutName="hairal_niwa_n_sceneTex_0018F0" Format="rgba16" Width="32" Height="32" Offset="0x18F0" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_n_sceneTex_0020F0" OutName="hairal_niwa_n_sceneTex_0020F0" Format="rgba16" Width="32" Height="32" Offset="0x20F0" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_n_sceneTex_0028F0" OutName="hairal_niwa_n_sceneTex_0028F0" Format="rgba16" Width="32" Height="64" Offset="0x28F0" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_n_sceneTex_0038F0" OutName="hairal_niwa_n_sceneTex_0038F0" Format="i4" Width="64" Height="64" Offset="0x38F0" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_n_sceneTex_0040F0" OutName="hairal_niwa_n_sceneTex_0040F0" Format="rgba16" Width="32" Height="64" Offset="0x40F0" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_n_sceneTex_0050F0" OutName="hairal_niwa_n_sceneTex_0050F0" Format="rgba16" Width="32" Height="32" Offset="0x50F0" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_n_sceneTex_0058F0" OutName="hairal_niwa_n_sceneTex_0058F0" Format="rgba16" Width="32" Height="32" Offset="0x58F0" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_n_sceneTex_0060F0" OutName="hairal_niwa_n_sceneTex_0060F0" Format="ia4" Width="32" Height="128" Offset="0x60F0" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_n_sceneTex_0068F0" OutName="hairal_niwa_n_sceneTex_0068F0" Format="rgba16" Width="32" Height="32" Offset="0x68F0" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_n_sceneTex_0070F0" OutName="hairal_niwa_n_sceneTex_0070F0" Format="rgba16" Width="32" Height="32" Offset="0x70F0" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_n_sceneTex_0078F0" OutName="hairal_niwa_n_sceneTex_0078F0" Format="rgba16" Width="32" Height="32" Offset="0x78F0" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_n_sceneTex_0080F0" OutName="hairal_niwa_n_sceneTex_0080F0" Format="rgba16" Width="32" Height="64" Offset="0x80F0" AddedByScript="true"/>
         <Scene Name="hairal_niwa_n_scene" Offset="0x0"/>
     </File>
     <File Name="hairal_niwa_n_room_0" Segment="3">

--- a/soh/assets/xml/GC_MQ_D/scenes/indoors/hakasitarelay.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/indoors/hakasitarelay.xml
@@ -1,27 +1,80 @@
 <Root>
     <File Name="hakasitarelay_scene" Segment="2">
+        <Texture Name="hakasitarelay_sceneTex_00C080" OutName="hakasitarelay_sceneTex_00C080" Format="rgba16" Width="64" Height="32" Offset="0xC080" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_sceneTex_00D080" OutName="hakasitarelay_sceneTex_00D080" Format="rgba16" Width="32" Height="32" Offset="0xD080" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_sceneTex_00D880" OutName="hakasitarelay_sceneTex_00D880" Format="i4" Width="64" Height="64" Offset="0xD880" AddedByScript="true"/>
         <Scene Name="hakasitarelay_scene" Offset="0x0"/>
         <Cutscene Name="gSongOfStormsCs" Offset="0xE080"/>
     </File>
     <File Name="hakasitarelay_room_0" Segment="3">
+        <Texture Name="hakasitarelay_room_0Tex_003248" OutName="hakasitarelay_room_0Tex_003248" Format="i4" Width="32" Height="32" Offset="0x3248" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_0Tex_003448" OutName="hakasitarelay_room_0Tex_003448" Format="rgba16" Width="32" Height="64" Offset="0x3448" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_0Tex_004448" OutName="hakasitarelay_room_0Tex_004448" Format="i4" Width="128" Height="32" Offset="0x4448" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_0Tex_004C48" OutName="hakasitarelay_room_0Tex_004C48" Format="i4" Width="32" Height="128" Offset="0x4C48" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_0Tex_005448" OutName="hakasitarelay_room_0Tex_005448" Format="i8" Width="32" Height="32" Offset="0x5448" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_0Tex_005848" OutName="hakasitarelay_room_0Tex_005848" Format="i8" Width="64" Height="32" Offset="0x5848" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_0Tex_0062B8" OutName="hakasitarelay_room_0Tex_0062B8" Format="ia16" Width="128" Height="16" Offset="0x62B8" AddedByScript="true"/>
         <Room Name="hakasitarelay_room_0" Offset="0x0"/>
     </File>
     <File Name="hakasitarelay_room_1" Segment="3">
+        <Texture Name="hakasitarelay_room_1Tex_003F20" OutName="hakasitarelay_room_1Tex_003F20" Format="i8" Width="32" Height="32" Offset="0x3F20" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_1Tex_004320" OutName="hakasitarelay_room_1Tex_004320" Format="i8" Width="32" Height="32" Offset="0x4320" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_1Tex_004720" OutName="hakasitarelay_room_1Tex_004720" Format="rgba16" Width="32" Height="64" Offset="0x4720" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_1Tex_005720" OutName="hakasitarelay_room_1Tex_005720" Format="rgba16" Width="32" Height="32" Offset="0x5720" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_1Tex_005F20" OutName="hakasitarelay_room_1Tex_005F20" Format="rgba16" Width="32" Height="16" Offset="0x5F20" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_1Tex_006320" OutName="hakasitarelay_room_1Tex_006320" Format="rgba16" Width="32" Height="16" Offset="0x6320" AddedByScript="true"/>
         <Room Name="hakasitarelay_room_1" Offset="0x0"/>
     </File>
     <File Name="hakasitarelay_room_2" Segment="3">
+        <Texture Name="hakasitarelay_room_2Tex_0054A8" OutName="hakasitarelay_room_2Tex_0054A8" Format="i8" Width="32" Height="32" Offset="0x54A8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_2Tex_0058A8" OutName="hakasitarelay_room_2Tex_0058A8" Format="i8" Width="32" Height="32" Offset="0x58A8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_2Tex_005CA8" OutName="hakasitarelay_room_2Tex_005CA8" Format="rgba16" Width="32" Height="64" Offset="0x5CA8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_2Tex_006CA8" OutName="hakasitarelay_room_2Tex_006CA8" Format="i8" Width="64" Height="32" Offset="0x6CA8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_2Tex_0074A8" OutName="hakasitarelay_room_2Tex_0074A8" Format="rgba16" Width="32" Height="32" Offset="0x74A8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_2Tex_007CA8" OutName="hakasitarelay_room_2Tex_007CA8" Format="rgba16" Width="32" Height="16" Offset="0x7CA8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_2Tex_0080A8" OutName="hakasitarelay_room_2Tex_0080A8" Format="rgba16" Width="32" Height="16" Offset="0x80A8" AddedByScript="true"/>
         <Room Name="hakasitarelay_room_2" Offset="0x0"/>
     </File>
     <File Name="hakasitarelay_room_3" Segment="3">
+        <Texture Name="hakasitarelay_room_3Tex_0056E0" OutName="hakasitarelay_room_3Tex_0056E0" Format="i8" Width="32" Height="32" Offset="0x56E0" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_3Tex_005AE0" OutName="hakasitarelay_room_3Tex_005AE0" Format="i8" Width="32" Height="32" Offset="0x5AE0" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_3Tex_005EE0" OutName="hakasitarelay_room_3Tex_005EE0" Format="i4" Width="32" Height="32" Offset="0x5EE0" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_3Tex_0060E0" OutName="hakasitarelay_room_3Tex_0060E0" Format="rgba16" Width="32" Height="64" Offset="0x60E0" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_3Tex_0070E0" OutName="hakasitarelay_room_3Tex_0070E0" Format="rgba16" Width="32" Height="32" Offset="0x70E0" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_3Tex_0078E0" OutName="hakasitarelay_room_3Tex_0078E0" Format="rgba16" Width="32" Height="16" Offset="0x78E0" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_3Tex_007CE0" OutName="hakasitarelay_room_3Tex_007CE0" Format="i4" Width="128" Height="32" Offset="0x7CE0" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_3Tex_0084E0" OutName="hakasitarelay_room_3Tex_0084E0" Format="i8" Width="64" Height="32" Offset="0x84E0" AddedByScript="true"/>
         <Room Name="hakasitarelay_room_3" Offset="0x0"/>
     </File>
     <File Name="hakasitarelay_room_4" Segment="3">
+        <Texture Name="hakasitarelay_room_4Tex_001E80" OutName="hakasitarelay_room_4Tex_001E80" Format="i4" Width="32" Height="32" Offset="0x1E80" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_4Tex_002080" OutName="hakasitarelay_room_4Tex_002080" Format="i8" Width="64" Height="32" Offset="0x2080" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_4Tex_002880" OutName="hakasitarelay_room_4Tex_002880" Format="i4" Width="32" Height="128" Offset="0x2880" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_4Tex_003080" OutName="hakasitarelay_room_4Tex_003080" Format="i8" Width="32" Height="32" Offset="0x3080" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_4Tex_003480" OutName="hakasitarelay_room_4Tex_003480" Format="i8" Width="64" Height="32" Offset="0x3480" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_4Tex_003C80" OutName="hakasitarelay_room_4Tex_003C80" Format="i4" Width="64" Height="64" Offset="0x3C80" AddedByScript="true"/>
         <Room Name="hakasitarelay_room_4" Offset="0x0"/>
     </File>
     <File Name="hakasitarelay_room_5" Segment="3">
+        <Texture Name="hakasitarelay_room_5Tex_001C48" OutName="hakasitarelay_room_5Tex_001C48" Format="rgba16" Width="32" Height="32" Offset="0x1C48" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_5Tex_002448" OutName="hakasitarelay_room_5Tex_002448" Format="ci4" Width="64" Height="64" Offset="0x2448" TlutOffset="0x1C28" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_5Tex_002C48" OutName="hakasitarelay_room_5Tex_002C48" Format="i8" Width="64" Height="32" Offset="0x2C48" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_5Tex_003448" OutName="hakasitarelay_room_5Tex_003448" Format="i4" Width="64" Height="64" Offset="0x3448" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_5Tex_003C48" OutName="hakasitarelay_room_5Tex_003C48" Format="i4" Width="64" Height="64" Offset="0x3C48" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_5TLUT_001C28" OutName="hakasitarelay_room_5TLUT_001C28" Format="rgba16" Width="4" Height="4" Offset="0x1C28" AddedByScript="true"/>
         <Room Name="hakasitarelay_room_5" Offset="0x0"/>
     </File>
     <File Name="hakasitarelay_room_6" Segment="3">
+        <Texture Name="hakasitarelay_room_6Tex_0041A8" OutName="hakasitarelay_room_6Tex_0041A8" Format="rgba16" Width="16" Height="8" Offset="0x41A8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_6Tex_0042A8" OutName="hakasitarelay_room_6Tex_0042A8" Format="rgba16" Width="32" Height="32" Offset="0x42A8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_6Tex_004AA8" OutName="hakasitarelay_room_6Tex_004AA8" Format="rgba16" Width="32" Height="16" Offset="0x4AA8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_6Tex_004EA8" OutName="hakasitarelay_room_6Tex_004EA8" Format="ci4" Width="64" Height="64" Offset="0x4EA8" TlutOffset="0x4188" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_6Tex_0056A8" OutName="hakasitarelay_room_6Tex_0056A8" Format="i8" Width="64" Height="32" Offset="0x56A8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_6Tex_005EA8" OutName="hakasitarelay_room_6Tex_005EA8" Format="i4" Width="64" Height="64" Offset="0x5EA8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_6Tex_0066A8" OutName="hakasitarelay_room_6Tex_0066A8" Format="i8" Width="32" Height="32" Offset="0x66A8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_6Tex_006AA8" OutName="hakasitarelay_room_6Tex_006AA8" Format="i8" Width="64" Height="32" Offset="0x6AA8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_6Tex_0072A8" OutName="hakasitarelay_room_6Tex_0072A8" Format="i4" Width="64" Height="64" Offset="0x72A8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_6TLUT_004188" OutName="hakasitarelay_room_6TLUT_004188" Format="rgba16" Width="4" Height="4" Offset="0x4188" AddedByScript="true"/>
         <Room Name="hakasitarelay_room_6" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_MQ_D/scenes/indoors/hylia_labo.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/indoors/hylia_labo.xml
@@ -1,5 +1,36 @@
 <Root>
     <File Name="hylia_labo_scene" Segment="2">
+        <Texture Name="hylia_labo_sceneTex_001090" OutName="hylia_labo_sceneTex_001090" Format="ia8" Width="16" Height="64" Offset="0x1090" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_001490" OutName="hylia_labo_sceneTex_001490" Format="rgba16" Width="64" Height="32" Offset="0x1490" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_002490" OutName="hylia_labo_sceneTex_002490" Format="rgba16" Width="32" Height="64" Offset="0x2490" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_003490" OutName="hylia_labo_sceneTex_003490" Format="rgba16" Width="32" Height="32" Offset="0x3490" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_003C90" OutName="hylia_labo_sceneTex_003C90" Format="rgba16" Width="32" Height="64" Offset="0x3C90" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_004C90" OutName="hylia_labo_sceneTex_004C90" Format="rgba16" Width="32" Height="32" Offset="0x4C90" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_005490" OutName="hylia_labo_sceneTex_005490" Format="rgba16" Width="32" Height="32" Offset="0x5490" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_005C90" OutName="hylia_labo_sceneTex_005C90" Format="ia8" Width="64" Height="16" Offset="0x5C90" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_006090" OutName="hylia_labo_sceneTex_006090" Format="rgba16" Width="32" Height="4" Offset="0x6090" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_006190" OutName="hylia_labo_sceneTex_006190" Format="rgba16" Width="32" Height="32" Offset="0x6190" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_006990" OutName="hylia_labo_sceneTex_006990" Format="rgba16" Width="32" Height="16" Offset="0x6990" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_006D90" OutName="hylia_labo_sceneTex_006D90" Format="ia4" Width="64" Height="128" Offset="0x6D90" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_007D90" OutName="hylia_labo_sceneTex_007D90" Format="rgba16" Width="32" Height="32" Offset="0x7D90" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_008590" OutName="hylia_labo_sceneTex_008590" Format="ia8" Width="32" Height="16" Offset="0x8590" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_008790" OutName="hylia_labo_sceneTex_008790" Format="ia8" Width="32" Height="128" Offset="0x8790" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_009790" OutName="hylia_labo_sceneTex_009790" Format="rgba16" Width="32" Height="8" Offset="0x9790" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_009990" OutName="hylia_labo_sceneTex_009990" Format="ia8" Width="16" Height="16" Offset="0x9990" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_009A90" OutName="hylia_labo_sceneTex_009A90" Format="ia8" Width="16" Height="32" Offset="0x9A90" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_009C90" OutName="hylia_labo_sceneTex_009C90" Format="ia8" Width="32" Height="32" Offset="0x9C90" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_00A090" OutName="hylia_labo_sceneTex_00A090" Format="rgba16" Width="32" Height="64" Offset="0xA090" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_00B090" OutName="hylia_labo_sceneTex_00B090" Format="rgba16" Width="64" Height="32" Offset="0xB090" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_00C090" OutName="hylia_labo_sceneTex_00C090" Format="rgba16" Width="64" Height="16" Offset="0xC090" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_00C890" OutName="hylia_labo_sceneTex_00C890" Format="rgba16" Width="32" Height="32" Offset="0xC890" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_00D090" OutName="hylia_labo_sceneTex_00D090" Format="rgba16" Width="64" Height="16" Offset="0xD090" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_00D890" OutName="hylia_labo_sceneTex_00D890" Format="rgba16" Width="64" Height="16" Offset="0xD890" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_00E090" OutName="hylia_labo_sceneTex_00E090" Format="rgba16" Width="32" Height="32" Offset="0xE090" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_00E890" OutName="hylia_labo_sceneTex_00E890" Format="rgba16" Width="32" Height="64" Offset="0xE890" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_00F890" OutName="hylia_labo_sceneTex_00F890" Format="rgba16" Width="32" Height="32" Offset="0xF890" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_010090" OutName="hylia_labo_sceneTex_010090" Format="i8" Width="32" Height="32" Offset="0x10090" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_010490" OutName="hylia_labo_sceneTex_010490" Format="i8" Width="32" Height="32" Offset="0x10490" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_010890" OutName="hylia_labo_sceneTex_010890" Format="rgba16" Width="32" Height="32" Offset="0x10890" AddedByScript="true"/>
         <Scene Name="hylia_labo_scene" Offset="0x0"/>
     </File>
     <File Name="hylia_labo_room_0" Segment="3">

--- a/soh/assets/xml/GC_MQ_D/scenes/indoors/kenjyanoma.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/indoors/kenjyanoma.xml
@@ -3,6 +3,25 @@
         <Scene Name="kenjyanoma_scene" Offset="0x0"/>
     </File>
     <File Name="kenjyanoma_room_0" Segment="3">
+        <Texture Name="kenjyanoma_room_0Tex_001618" OutName="kenjyanoma_room_0Tex_001618" Format="rgba16" Width="64" Height="32" Offset="0x1618" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_002618" OutName="kenjyanoma_room_0Tex_002618" Format="rgba16" Width="64" Height="32" Offset="0x2618" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_003618" OutName="kenjyanoma_room_0Tex_003618" Format="rgba16" Width="64" Height="32" Offset="0x3618" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_004618" OutName="kenjyanoma_room_0Tex_004618" Format="rgba16" Width="64" Height="32" Offset="0x4618" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_005618" OutName="kenjyanoma_room_0Tex_005618" Format="rgba16" Width="64" Height="32" Offset="0x5618" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_006618" OutName="kenjyanoma_room_0Tex_006618" Format="rgba16" Width="64" Height="32" Offset="0x6618" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_007618" OutName="kenjyanoma_room_0Tex_007618" Format="rgba16" Width="64" Height="32" Offset="0x7618" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_008618" OutName="kenjyanoma_room_0Tex_008618" Format="rgba16" Width="64" Height="32" Offset="0x8618" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_009618" OutName="kenjyanoma_room_0Tex_009618" Format="rgba16" Width="32" Height="64" Offset="0x9618" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_00A618" OutName="kenjyanoma_room_0Tex_00A618" Format="rgba16" Width="32" Height="64" Offset="0xA618" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_00B618" OutName="kenjyanoma_room_0Tex_00B618" Format="rgba16" Width="64" Height="32" Offset="0xB618" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_00C618" OutName="kenjyanoma_room_0Tex_00C618" Format="rgba16" Width="64" Height="32" Offset="0xC618" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_00D618" OutName="kenjyanoma_room_0Tex_00D618" Format="rgba16" Width="32" Height="32" Offset="0xD618" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_010CE8" OutName="kenjyanoma_room_0Tex_010CE8" Format="ia16" Width="32" Height="32" Offset="0x10CE8" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_0114E8" OutName="kenjyanoma_room_0Tex_0114E8" Format="i8" Width="32" Height="64" Offset="0x114E8" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_011CE8" OutName="kenjyanoma_room_0Tex_011CE8" Format="rgba16" Width="4" Height="4" Offset="0x11CE8" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_011D08" OutName="kenjyanoma_room_0Tex_011D08" Format="rgba16" Width="32" Height="32" Offset="0x11D08" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_012508" OutName="kenjyanoma_room_0Tex_012508" Format="i8" Width="32" Height="64" Offset="0x12508" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_012D08" OutName="kenjyanoma_room_0Tex_012D08" Format="i8" Width="32" Height="32" Offset="0x12D08" AddedByScript="true"/>
         <Room Name="kenjyanoma_room_0" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_MQ_D/scenes/indoors/mahouya.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/indoors/mahouya.xml
@@ -1,5 +1,18 @@
 <Root>
     <File Name="mahouya_scene" Segment="2">
+        <Texture Name="mahouya_sceneTex_000A20" OutName="mahouya_sceneTex_000A20" Format="rgba16" Width="32" Height="32" Offset="0xA20" AddedByScript="true"/>
+        <Texture Name="mahouya_sceneTex_001220" OutName="mahouya_sceneTex_001220" Format="rgba16" Width="32" Height="32" Offset="0x1220" AddedByScript="true"/>
+        <Texture Name="mahouya_sceneTex_001A20" OutName="mahouya_sceneTex_001A20" Format="rgba16" Width="16" Height="128" Offset="0x1A20" AddedByScript="true"/>
+        <Texture Name="mahouya_sceneTex_002A20" OutName="mahouya_sceneTex_002A20" Format="rgba16" Width="32" Height="64" Offset="0x2A20" AddedByScript="true"/>
+        <Texture Name="mahouya_sceneTex_003A20" OutName="mahouya_sceneTex_003A20" Format="rgba16" Width="64" Height="32" Offset="0x3A20" AddedByScript="true"/>
+        <Texture Name="mahouya_sceneTex_004A20" OutName="mahouya_sceneTex_004A20" Format="rgba16" Width="32" Height="32" Offset="0x4A20" AddedByScript="true"/>
+        <Texture Name="mahouya_sceneTex_005220" OutName="mahouya_sceneTex_005220" Format="rgba16" Width="16" Height="128" Offset="0x5220" AddedByScript="true"/>
+        <Texture Name="mahouya_sceneTex_006220" OutName="mahouya_sceneTex_006220" Format="rgba16" Width="16" Height="128" Offset="0x6220" AddedByScript="true"/>
+        <Texture Name="mahouya_sceneTex_007220" OutName="mahouya_sceneTex_007220" Format="rgba16" Width="32" Height="32" Offset="0x7220" AddedByScript="true"/>
+        <Texture Name="mahouya_sceneTex_007A20" OutName="mahouya_sceneTex_007A20" Format="rgba16" Width="64" Height="32" Offset="0x7A20" AddedByScript="true"/>
+        <Texture Name="mahouya_sceneTex_008A20" OutName="mahouya_sceneTex_008A20" Format="i8" Width="16" Height="128" Offset="0x8A20" AddedByScript="true"/>
+        <Texture Name="mahouya_sceneTex_009220" OutName="mahouya_sceneTex_009220" Format="rgba16" Width="32" Height="32" Offset="0x9220" AddedByScript="true"/>
+        <Texture Name="mahouya_sceneTex_009A20" OutName="mahouya_sceneTex_009A20" Format="rgba16" Width="64" Height="32" Offset="0x9A20" AddedByScript="true"/>
         <Scene Name="mahouya_scene" Offset="0x0"/>
     </File>
     <File Name="mahouya_room_0" Segment="3">

--- a/soh/assets/xml/GC_MQ_D/scenes/indoors/miharigoya.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/indoors/miharigoya.xml
@@ -1,5 +1,19 @@
 <Root>
     <File Name="miharigoya_scene" Segment="2">
+        <Texture Name="miharigoya_sceneTex_000C50" OutName="miharigoya_sceneTex_000C50" Format="ia8" Width="64" Height="16" Offset="0xC50" AddedByScript="true"/>
+        <Texture Name="miharigoya_sceneTex_001050" OutName="miharigoya_sceneTex_001050" Format="rgba16" Width="32" Height="4" Offset="0x1050" AddedByScript="true"/>
+        <Texture Name="miharigoya_sceneTex_001150" OutName="miharigoya_sceneTex_001150" Format="ia8" Width="32" Height="16" Offset="0x1150" AddedByScript="true"/>
+        <Texture Name="miharigoya_sceneTex_003350" OutName="miharigoya_sceneTex_003350" Format="rgba16" Width="32" Height="8" Offset="0x3350" AddedByScript="true"/>
+        <Texture Name="miharigoya_sceneTex_004550" OutName="miharigoya_sceneTex_004550" Format="i8" Width="32" Height="32" Offset="0x4550" AddedByScript="true"/>
+        <Texture Name="miharigoya_sceneTex_004950" OutName="miharigoya_sceneTex_004950" Format="rgba16" Width="64" Height="32" Offset="0x4950" AddedByScript="true"/>
+        <Texture Name="miharigoya_sceneTex_005950" OutName="miharigoya_sceneTex_005950" Format="i8" Width="32" Height="32" Offset="0x5950" AddedByScript="true"/>
+        <Texture Name="miharigoya_sceneTex_005D50" OutName="miharigoya_sceneTex_005D50" Format="rgba16" Width="64" Height="16" Offset="0x5D50" AddedByScript="true"/>
+        <Texture Name="miharigoya_sceneTex_007550" OutName="miharigoya_sceneTex_007550" Format="rgba16" Width="32" Height="64" Offset="0x7550" AddedByScript="true"/>
+        <Texture Name="miharigoya_sceneTex_008550" OutName="miharigoya_sceneTex_008550" Format="i4" Width="64" Height="64" Offset="0x8550" AddedByScript="true"/>
+        <Texture Name="miharigoya_sceneTex_008D50" OutName="miharigoya_sceneTex_008D50" Format="i8" Width="64" Height="64" Offset="0x8D50" AddedByScript="true"/>
+        <Texture Name="miharigoya_sceneTex_009D50" OutName="miharigoya_sceneTex_009D50" Format="rgba16" Width="32" Height="64" Offset="0x9D50" AddedByScript="true"/>
+        <Texture Name="miharigoya_sceneTex_00AD50" OutName="miharigoya_sceneTex_00AD50" Format="i8" Width="64" Height="64" Offset="0xAD50" AddedByScript="true"/>
+        <Texture Name="miharigoya_sceneTex_00BD50" OutName="miharigoya_sceneTex_00BD50" Format="rgba16" Width="32" Height="32" Offset="0xBD50" AddedByScript="true"/>
         <Texture Name="gGuardHouseOutSideView2NightTex" OutName="view_2_night" Format="rgba16" Width="64" Height="32" Offset="0x1350"/>
         <Texture Name="gGuardHouseOutSideView2DayTex" OutName="view_2_day" Format="rgba16" Width="64" Height="32" Offset="0x2350"/>
         <Texture Name="gGuardHouseOutSideView1NightTex" OutName="view_1_night" Format="rgba16" Width="64" Height="32" Offset="0x3550"/>

--- a/soh/assets/xml/GC_MQ_D/scenes/indoors/nakaniwa.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/indoors/nakaniwa.xml
@@ -8,6 +8,37 @@
         <Scene Name="nakaniwa_scene" Offset="0x0"/>
     </File>
     <File Name="nakaniwa_room_0" Segment="3">
+        <Texture Name="nakaniwa_room_0Tex_007218" OutName="nakaniwa_room_0Tex_007218" Format="rgba16" Width="16" Height="16" Offset="0x7218" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_007418" OutName="nakaniwa_room_0Tex_007418" Format="rgba16" Width="16" Height="16" Offset="0x7418" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_007618" OutName="nakaniwa_room_0Tex_007618" Format="rgba16" Width="16" Height="16" Offset="0x7618" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_007818" OutName="nakaniwa_room_0Tex_007818" Format="rgba16" Width="16" Height="16" Offset="0x7818" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_007A18" OutName="nakaniwa_room_0Tex_007A18" Format="rgba16" Width="32" Height="32" Offset="0x7A18" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_008218" OutName="nakaniwa_room_0Tex_008218" Format="rgba16" Width="16" Height="16" Offset="0x8218" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_008418" OutName="nakaniwa_room_0Tex_008418" Format="rgba16" Width="16" Height="16" Offset="0x8418" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_008618" OutName="nakaniwa_room_0Tex_008618" Format="rgba16" Width="32" Height="32" Offset="0x8618" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_008E18" OutName="nakaniwa_room_0Tex_008E18" Format="rgba16" Width="32" Height="64" Offset="0x8E18" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_009E18" OutName="nakaniwa_room_0Tex_009E18" Format="rgba16" Width="32" Height="32" Offset="0x9E18" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_00A618" OutName="nakaniwa_room_0Tex_00A618" Format="rgba16" Width="32" Height="64" Offset="0xA618" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_00B618" OutName="nakaniwa_room_0Tex_00B618" Format="rgba16" Width="32" Height="64" Offset="0xB618" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_00C618" OutName="nakaniwa_room_0Tex_00C618" Format="i4" Width="64" Height="64" Offset="0xC618" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_00CE18" OutName="nakaniwa_room_0Tex_00CE18" Format="rgba16" Width="32" Height="64" Offset="0xCE18" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_00DE18" OutName="nakaniwa_room_0Tex_00DE18" Format="rgba16" Width="32" Height="32" Offset="0xDE18" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_00E618" OutName="nakaniwa_room_0Tex_00E618" Format="rgba16" Width="16" Height="64" Offset="0xE618" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_00EE18" OutName="nakaniwa_room_0Tex_00EE18" Format="rgba16" Width="32" Height="32" Offset="0xEE18" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_00F618" OutName="nakaniwa_room_0Tex_00F618" Format="rgba16" Width="32" Height="32" Offset="0xF618" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_00FE18" OutName="nakaniwa_room_0Tex_00FE18" Format="rgba16" Width="32" Height="32" Offset="0xFE18" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_010618" OutName="nakaniwa_room_0Tex_010618" Format="rgba16" Width="32" Height="32" Offset="0x10618" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_010E18" OutName="nakaniwa_room_0Tex_010E18" Format="rgba16" Width="32" Height="32" Offset="0x10E18" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_011618" OutName="nakaniwa_room_0Tex_011618" Format="rgba16" Width="32" Height="32" Offset="0x11618" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_011E18" OutName="nakaniwa_room_0Tex_011E18" Format="rgba16" Width="32" Height="32" Offset="0x11E18" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_012618" OutName="nakaniwa_room_0Tex_012618" Format="rgba16" Width="32" Height="32" Offset="0x12618" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_012E18" OutName="nakaniwa_room_0Tex_012E18" Format="rgba16" Width="64" Height="16" Offset="0x12E18" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_013618" OutName="nakaniwa_room_0Tex_013618" Format="rgba16" Width="32" Height="32" Offset="0x13618" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_013E18" OutName="nakaniwa_room_0Tex_013E18" Format="i4" Width="32" Height="32" Offset="0x13E18" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_014EC0" OutName="nakaniwa_room_0Tex_014EC0" Format="ia16" Width="32" Height="32" Offset="0x14EC0" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_0156C0" OutName="nakaniwa_room_0Tex_0156C0" Format="ia16" Width="64" Height="32" Offset="0x156C0" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_0166C0" OutName="nakaniwa_room_0Tex_0166C0" Format="rgba16" Width="32" Height="32" Offset="0x166C0" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_016EC0" OutName="nakaniwa_room_0Tex_016EC0" Format="ia16" Width="32" Height="64" Offset="0x16EC0" AddedByScript="true"/>
         <Room Name="nakaniwa_room_0" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_MQ_D/scenes/indoors/syatekijyou.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/indoors/syatekijyou.xml
@@ -1,5 +1,27 @@
 <Root>
     <File Name="syatekijyou_scene" Segment="2">
+        <Texture Name="syatekijyou_sceneTex_001C40" OutName="syatekijyou_sceneTex_001C40" Format="rgba16" Width="32" Height="4" Offset="0x1C40" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_001D40" OutName="syatekijyou_sceneTex_001D40" Format="rgba16" Width="32" Height="16" Offset="0x1D40" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_002140" OutName="syatekijyou_sceneTex_002140" Format="rgba16" Width="32" Height="16" Offset="0x2140" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_002540" OutName="syatekijyou_sceneTex_002540" Format="ia4" Width="32" Height="32" Offset="0x2540" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_002740" OutName="syatekijyou_sceneTex_002740" Format="rgba16" Width="64" Height="32" Offset="0x2740" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_003740" OutName="syatekijyou_sceneTex_003740" Format="ia8" Width="32" Height="16" Offset="0x3740" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_003940" OutName="syatekijyou_sceneTex_003940" Format="rgba16" Width="4" Height="16" Offset="0x3940" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_0039C0" OutName="syatekijyou_sceneTex_0039C0" Format="ia8" Width="16" Height="64" Offset="0x39C0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_003DC0" OutName="syatekijyou_sceneTex_003DC0" Format="rgba16" Width="32" Height="16" Offset="0x3DC0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_0041C0" OutName="syatekijyou_sceneTex_0041C0" Format="rgba16" Width="32" Height="64" Offset="0x41C0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_0051C0" OutName="syatekijyou_sceneTex_0051C0" Format="ia8" Width="16" Height="16" Offset="0x51C0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_0052C0" OutName="syatekijyou_sceneTex_0052C0" Format="ia8" Width="16" Height="32" Offset="0x52C0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_0054C0" OutName="syatekijyou_sceneTex_0054C0" Format="rgba16" Width="32" Height="32" Offset="0x54C0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_005CC0" OutName="syatekijyou_sceneTex_005CC0" Format="rgba16" Width="32" Height="64" Offset="0x5CC0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_006CC0" OutName="syatekijyou_sceneTex_006CC0" Format="rgba16" Width="32" Height="64" Offset="0x6CC0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_007CC0" OutName="syatekijyou_sceneTex_007CC0" Format="i8" Width="64" Height="64" Offset="0x7CC0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_008CC0" OutName="syatekijyou_sceneTex_008CC0" Format="rgba16" Width="32" Height="64" Offset="0x8CC0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_009CC0" OutName="syatekijyou_sceneTex_009CC0" Format="ia4" Width="64" Height="64" Offset="0x9CC0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_00A4C0" OutName="syatekijyou_sceneTex_00A4C0" Format="rgba16" Width="32" Height="32" Offset="0xA4C0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_00ACC0" OutName="syatekijyou_sceneTex_00ACC0" Format="ia8" Width="32" Height="32" Offset="0xACC0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_00B0C0" OutName="syatekijyou_sceneTex_00B0C0" Format="i4" Width="32" Height="32" Offset="0xB0C0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_00B2C0" OutName="syatekijyou_sceneTex_00B2C0" Format="rgba16" Width="64" Height="32" Offset="0xB2C0" AddedByScript="true"/>
         <Scene Name="syatekijyou_scene" Offset="0x0"/>
     </File>
     <File Name="syatekijyou_room_0" Segment="3">

--- a/soh/assets/xml/GC_MQ_D/scenes/indoors/takaraya.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/indoors/takaraya.xml
@@ -1,26 +1,53 @@
 <Root>
     <File Name="takaraya_scene" Segment="2">
+        <Texture Name="takaraya_sceneTex_0051B0" OutName="takaraya_sceneTex_0051B0" Format="rgba16" Width="32" Height="32" Offset="0x51B0" AddedByScript="true"/>
+        <Texture Name="takaraya_sceneTex_0059B0" OutName="takaraya_sceneTex_0059B0" Format="rgba16" Width="32" Height="32" Offset="0x59B0" AddedByScript="true"/>
+        <Texture Name="takaraya_sceneTex_0061B0" OutName="takaraya_sceneTex_0061B0" Format="rgba16" Width="32" Height="32" Offset="0x61B0" AddedByScript="true"/>
+        <Texture Name="takaraya_sceneTex_0069B0" OutName="takaraya_sceneTex_0069B0" Format="rgba16" Width="32" Height="32" Offset="0x69B0" AddedByScript="true"/>
         <Scene Name="takaraya_scene" Offset="0x0"/>
     </File>
     <File Name="takaraya_room_0" Segment="3">
+        <Texture Name="takaraya_room_0Tex_003BE0" OutName="takaraya_room_0Tex_003BE0" Format="rgba16" Width="16" Height="64" Offset="0x3BE0" AddedByScript="true"/>
+        <Texture Name="takaraya_room_0Tex_0043E0" OutName="takaraya_room_0Tex_0043E0" Format="rgba16" Width="32" Height="32" Offset="0x43E0" AddedByScript="true"/>
+        <Texture Name="takaraya_room_0Tex_004BE0" OutName="takaraya_room_0Tex_004BE0" Format="rgba16" Width="64" Height="32" Offset="0x4BE0" AddedByScript="true"/>
+        <Texture Name="takaraya_room_0Tex_005BE0" OutName="takaraya_room_0Tex_005BE0" Format="rgba16" Width="32" Height="32" Offset="0x5BE0" AddedByScript="true"/>
+        <Texture Name="takaraya_room_0Tex_0063E0" OutName="takaraya_room_0Tex_0063E0" Format="rgba16" Width="32" Height="32" Offset="0x63E0" AddedByScript="true"/>
+        <Texture Name="takaraya_room_0Tex_006BE0" OutName="takaraya_room_0Tex_006BE0" Format="rgba16" Width="32" Height="32" Offset="0x6BE0" AddedByScript="true"/>
+        <Texture Name="takaraya_room_0Tex_0073E0" OutName="takaraya_room_0Tex_0073E0" Format="rgba16" Width="32" Height="32" Offset="0x73E0" AddedByScript="true"/>
+        <Texture Name="takaraya_room_0Tex_007BE0" OutName="takaraya_room_0Tex_007BE0" Format="rgba16" Width="32" Height="32" Offset="0x7BE0" AddedByScript="true"/>
+        <Texture Name="takaraya_room_0Tex_0083E0" OutName="takaraya_room_0Tex_0083E0" Format="rgba16" Width="32" Height="64" Offset="0x83E0" AddedByScript="true"/>
+        <Texture Name="takaraya_room_0Tex_0095C0" OutName="takaraya_room_0Tex_0095C0" Format="ia4" Width="64" Height="64" Offset="0x95C0" AddedByScript="true"/>
         <Room Name="takaraya_room_0" Offset="0x0"/>
     </File>
     <File Name="takaraya_room_1" Segment="3">
+        <Texture Name="takaraya_room_1Tex_0017F8" OutName="takaraya_room_1Tex_0017F8" Format="rgba16" Width="16" Height="64" Offset="0x17F8" AddedByScript="true"/>
         <Room Name="takaraya_room_1" Offset="0x0"/>
     </File>
     <File Name="takaraya_room_2" Segment="3">
+        <Texture Name="takaraya_room_2Tex_001828" OutName="takaraya_room_2Tex_001828" Format="rgba16" Width="16" Height="64" Offset="0x1828" AddedByScript="true"/>
         <Room Name="takaraya_room_2" Offset="0x0"/>
     </File>
     <File Name="takaraya_room_3" Segment="3">
+        <Texture Name="takaraya_room_3Tex_001818" OutName="takaraya_room_3Tex_001818" Format="rgba16" Width="16" Height="64" Offset="0x1818" AddedByScript="true"/>
+        <Texture Name="takaraya_room_3Tex_002018" OutName="takaraya_room_3Tex_002018" Format="rgba16" Width="32" Height="32" Offset="0x2018" AddedByScript="true"/>
         <Room Name="takaraya_room_3" Offset="0x0"/>
     </File>
     <File Name="takaraya_room_4" Segment="3">
+        <Texture Name="takaraya_room_4Tex_001820" OutName="takaraya_room_4Tex_001820" Format="rgba16" Width="16" Height="64" Offset="0x1820" AddedByScript="true"/>
+        <Texture Name="takaraya_room_4Tex_002020" OutName="takaraya_room_4Tex_002020" Format="rgba16" Width="32" Height="32" Offset="0x2020" AddedByScript="true"/>
+        <Texture Name="takaraya_room_4Tex_002820" OutName="takaraya_room_4Tex_002820" Format="rgba16" Width="32" Height="32" Offset="0x2820" AddedByScript="true"/>
         <Room Name="takaraya_room_4" Offset="0x0"/>
     </File>
     <File Name="takaraya_room_5" Segment="3">
+        <Texture Name="takaraya_room_5Tex_0017F8" OutName="takaraya_room_5Tex_0017F8" Format="rgba16" Width="32" Height="32" Offset="0x17F8" AddedByScript="true"/>
+        <Texture Name="takaraya_room_5Tex_001FF8" OutName="takaraya_room_5Tex_001FF8" Format="rgba16" Width="32" Height="32" Offset="0x1FF8" AddedByScript="true"/>
+        <Texture Name="takaraya_room_5Tex_0027F8" OutName="takaraya_room_5Tex_0027F8" Format="rgba16" Width="16" Height="64" Offset="0x27F8" AddedByScript="true"/>
         <Room Name="takaraya_room_5" Offset="0x0"/>
     </File>
     <File Name="takaraya_room_6" Segment="3">
+        <Texture Name="takaraya_room_6Tex_0012F8" OutName="takaraya_room_6Tex_0012F8" Format="rgba16" Width="32" Height="32" Offset="0x12F8" AddedByScript="true"/>
+        <Texture Name="takaraya_room_6Tex_001AF8" OutName="takaraya_room_6Tex_001AF8" Format="rgba16" Width="16" Height="64" Offset="0x1AF8" AddedByScript="true"/>
+        <Texture Name="takaraya_room_6Tex_0022F8" OutName="takaraya_room_6Tex_0022F8" Format="rgba16" Width="32" Height="32" Offset="0x22F8" AddedByScript="true"/>
         <Room Name="takaraya_room_6" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_MQ_D/scenes/indoors/tokinoma.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/indoors/tokinoma.xml
@@ -1,14 +1,47 @@
 <Root>
     <File Name="tokinoma_scene" Segment="2">
-        <Cutscene  Name="gTempleOfTimeFirstAdultCs" Offset="0x46F0"/>
-        <Cutscene  Name="gTempleOfTimePreludeCs" Offset="0x6D20"/>
+        <Texture Name="tokinoma_sceneTex_00CFA0" OutName="tokinoma_sceneTex_00CFA0" Format="rgba16" Width="32" Height="32" Offset="0xCFA0" AddedByScript="true"/>
+        <Texture Name="tokinoma_sceneTex_00D7A0" OutName="tokinoma_sceneTex_00D7A0" Format="rgba16" Width="32" Height="32" Offset="0xD7A0" AddedByScript="true"/>
+        <Texture Name="tokinoma_sceneTex_00DFA0" OutName="tokinoma_sceneTex_00DFA0" Format="rgba16" Width="32" Height="64" Offset="0xDFA0" AddedByScript="true"/>
+        <Texture Name="tokinoma_sceneTex_00EFA0" OutName="tokinoma_sceneTex_00EFA0" Format="rgba16" Width="32" Height="64" Offset="0xEFA0" AddedByScript="true"/>
+        <Texture Name="tokinoma_sceneTex_00FFA0" OutName="tokinoma_sceneTex_00FFA0" Format="rgba16" Width="32" Height="32" Offset="0xFFA0" AddedByScript="true"/>
+        <Texture Name="tokinoma_sceneTex_0107A0" OutName="tokinoma_sceneTex_0107A0" Format="rgba16" Width="32" Height="32" Offset="0x107A0" AddedByScript="true"/>
+        <Texture Name="tokinoma_sceneTex_010FA0" OutName="tokinoma_sceneTex_010FA0" Format="rgba16" Width="32" Height="32" Offset="0x10FA0" AddedByScript="true"/>
+        <Texture Name="tokinoma_sceneTex_0117A0" OutName="tokinoma_sceneTex_0117A0" Format="rgba16" Width="32" Height="32" Offset="0x117A0" AddedByScript="true"/>
+        <Texture Name="tokinoma_sceneTex_011FA0" OutName="tokinoma_sceneTex_011FA0" Format="rgba16" Width="32" Height="32" Offset="0x11FA0" AddedByScript="true"/>
+        <Cutscene Name="gTempleOfTimeFirstAdultCs" Offset="0x46F0"/>
+        <Cutscene Name="gTempleOfTimePreludeCs" Offset="0x6D20"/>
         <Cutscene Name="gTempleOfTimeIntroCs" Offset="0xCE00"/>
         <Scene Name="tokinoma_scene" Offset="0x0"/>
     </File>
     <File Name="tokinoma_room_0" Segment="3">
+        <Texture Name="tokinoma_room_0Tex_0081D8" OutName="tokinoma_room_0Tex_0081D8" Format="rgba16" Width="64" Height="32" Offset="0x81D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_0091D8" OutName="tokinoma_room_0Tex_0091D8" Format="rgba16" Width="64" Height="32" Offset="0x91D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_00A1D8" OutName="tokinoma_room_0Tex_00A1D8" Format="rgba16" Width="64" Height="32" Offset="0xA1D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_00B1D8" OutName="tokinoma_room_0Tex_00B1D8" Format="rgba16" Width="64" Height="32" Offset="0xB1D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_00C1D8" OutName="tokinoma_room_0Tex_00C1D8" Format="rgba16" Width="64" Height="32" Offset="0xC1D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_00D1D8" OutName="tokinoma_room_0Tex_00D1D8" Format="rgba16" Width="64" Height="32" Offset="0xD1D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_00E1D8" OutName="tokinoma_room_0Tex_00E1D8" Format="rgba16" Width="64" Height="32" Offset="0xE1D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_00F1D8" OutName="tokinoma_room_0Tex_00F1D8" Format="rgba16" Width="64" Height="32" Offset="0xF1D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_0101D8" OutName="tokinoma_room_0Tex_0101D8" Format="rgba16" Width="64" Height="32" Offset="0x101D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_0111D8" OutName="tokinoma_room_0Tex_0111D8" Format="rgba16" Width="64" Height="32" Offset="0x111D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_0121D8" OutName="tokinoma_room_0Tex_0121D8" Format="rgba16" Width="64" Height="32" Offset="0x121D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_0131D8" OutName="tokinoma_room_0Tex_0131D8" Format="rgba16" Width="64" Height="32" Offset="0x131D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_0141D8" OutName="tokinoma_room_0Tex_0141D8" Format="rgba16" Width="32" Height="32" Offset="0x141D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_0149D8" OutName="tokinoma_room_0Tex_0149D8" Format="rgba16" Width="32" Height="32" Offset="0x149D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_0151D8" OutName="tokinoma_room_0Tex_0151D8" Format="rgba16" Width="32" Height="32" Offset="0x151D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_0159D8" OutName="tokinoma_room_0Tex_0159D8" Format="rgba16" Width="32" Height="32" Offset="0x159D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_0161D8" OutName="tokinoma_room_0Tex_0161D8" Format="rgba16" Width="32" Height="32" Offset="0x161D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_0169D8" OutName="tokinoma_room_0Tex_0169D8" Format="rgba16" Width="32" Height="32" Offset="0x169D8" AddedByScript="true"/>
         <Room Name="tokinoma_room_0" Offset="0x0"/>
     </File>
     <File Name="tokinoma_room_1" Segment="3">
+        <Texture Name="tokinoma_room_1Tex_005458" OutName="tokinoma_room_1Tex_005458" Format="rgba16" Width="16" Height="16" Offset="0x5458" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_1Tex_005658" OutName="tokinoma_room_1Tex_005658" Format="rgba16" Width="16" Height="16" Offset="0x5658" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_1Tex_005858" OutName="tokinoma_room_1Tex_005858" Format="rgba16" Width="32" Height="32" Offset="0x5858" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_1Tex_006488" OutName="tokinoma_room_1Tex_006488" Format="i8" Width="8" Height="8" Offset="0x6488" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_1Tex_0064C8" OutName="tokinoma_room_1Tex_0064C8" Format="ia4" Width="128" Height="16" Offset="0x64C8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_1Tex_0068C8" OutName="tokinoma_room_1Tex_0068C8" Format="ia8" Width="64" Height="32" Offset="0x68C8" AddedByScript="true"/>
         <Room Name="tokinoma_room_1" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_MQ_D/scenes/indoors/yousei_izumi_tate.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/indoors/yousei_izumi_tate.xml
@@ -1,5 +1,15 @@
 <Root>
     <File Name="yousei_izumi_tate_scene" Segment="2">
+        <Texture Name="yousei_izumi_tate_sceneTex_002010" OutName="yousei_izumi_tate_sceneTex_002010" Format="ia8" Width="64" Height="32" Offset="0x2010" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_tate_sceneTex_002810" OutName="yousei_izumi_tate_sceneTex_002810" Format="i8" Width="16" Height="256" Offset="0x2810" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_tate_sceneTex_003810" OutName="yousei_izumi_tate_sceneTex_003810" Format="ia16" Width="128" Height="16" Offset="0x3810" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_tate_sceneTex_004810" OutName="yousei_izumi_tate_sceneTex_004810" Format="i8" Width="32" Height="64" Offset="0x4810" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_tate_sceneTex_005010" OutName="yousei_izumi_tate_sceneTex_005010" Format="i8" Width="32" Height="64" Offset="0x5010" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_tate_sceneTex_005810" OutName="yousei_izumi_tate_sceneTex_005810" Format="rgba16" Width="32" Height="32" Offset="0x5810" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_tate_sceneTex_006010" OutName="yousei_izumi_tate_sceneTex_006010" Format="i4" Width="64" Height="128" Offset="0x6010" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_tate_sceneTex_007010" OutName="yousei_izumi_tate_sceneTex_007010" Format="rgba16" Width="32" Height="32" Offset="0x7010" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_tate_sceneTex_007810" OutName="yousei_izumi_tate_sceneTex_007810" Format="rgba16" Width="32" Height="32" Offset="0x7810" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_tate_sceneTex_008010" OutName="yousei_izumi_tate_sceneTex_008010" Format="rgba16" Width="32" Height="32" Offset="0x8010" AddedByScript="true"/>
         <Scene Name="yousei_izumi_tate_scene" Offset="0x0"/>
     </File>
     <File Name="yousei_izumi_tate_room_0" Segment="3">

--- a/soh/assets/xml/GC_MQ_D/scenes/indoors/yousei_izumi_yoko.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/indoors/yousei_izumi_yoko.xml
@@ -1,5 +1,18 @@
 <Root>
     <File Name="yousei_izumi_yoko_scene" Segment="2">
+        <Texture Name="yousei_izumi_yoko_sceneTex_003DA0" OutName="yousei_izumi_yoko_sceneTex_003DA0" Format="i8" Width="32" Height="64" Offset="0x3DA0" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_yoko_sceneTex_0045A0" OutName="yousei_izumi_yoko_sceneTex_0045A0" Format="rgba16" Width="32" Height="32" Offset="0x45A0" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_yoko_sceneTex_004DA0" OutName="yousei_izumi_yoko_sceneTex_004DA0" Format="rgba16" Width="32" Height="32" Offset="0x4DA0" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_yoko_sceneTex_0055A0" OutName="yousei_izumi_yoko_sceneTex_0055A0" Format="ia4" Width="64" Height="128" Offset="0x55A0" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_yoko_sceneTex_0065A0" OutName="yousei_izumi_yoko_sceneTex_0065A0" Format="rgba16" Width="32" Height="64" Offset="0x65A0" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_yoko_sceneTex_0075A0" OutName="yousei_izumi_yoko_sceneTex_0075A0" Format="rgba16" Width="32" Height="64" Offset="0x75A0" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_yoko_sceneTex_0085A0" OutName="yousei_izumi_yoko_sceneTex_0085A0" Format="rgba16" Width="32" Height="64" Offset="0x85A0" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_yoko_sceneTex_0095A0" OutName="yousei_izumi_yoko_sceneTex_0095A0" Format="rgba16" Width="32" Height="32" Offset="0x95A0" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_yoko_sceneTex_009DA0" OutName="yousei_izumi_yoko_sceneTex_009DA0" Format="i8" Width="32" Height="128" Offset="0x9DA0" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_yoko_sceneTex_00ADA0" OutName="yousei_izumi_yoko_sceneTex_00ADA0" Format="rgba16" Width="32" Height="32" Offset="0xADA0" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_yoko_sceneTex_00B5A0" OutName="yousei_izumi_yoko_sceneTex_00B5A0" Format="ia8" Width="64" Height="32" Offset="0xB5A0" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_yoko_sceneTex_00BDA0" OutName="yousei_izumi_yoko_sceneTex_00BDA0" Format="rgba16" Width="32" Height="32" Offset="0xBDA0" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_yoko_sceneTex_00C5A0" OutName="yousei_izumi_yoko_sceneTex_00C5A0" Format="rgba16" Width="32" Height="32" Offset="0xC5A0" AddedByScript="true"/>
         <Cutscene Name="gGreatFairyFaroresWindCs" Offset="0x0160"/>
         <Cutscene Name="gGreatFairyDinsFireCs" Offset="0x1020"/>
         <Cutscene Name="gGreatFairyNayrusLoveCs" Offset="0x1F40"/>

--- a/soh/assets/xml/GC_MQ_D/scenes/misc/hakaana.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/misc/hakaana.xml
@@ -3,6 +3,16 @@
         <Scene Name="hakaana_scene" Offset="0x0"/>
     </File>
     <File Name="hakaana_room_0" Segment="3">
+        <Texture Name="hakaana_room_0Tex_002658" OutName="hakaana_room_0Tex_002658" Format="rgba16" Width="32" Height="32" Offset="0x2658" AddedByScript="true"/>
+        <Texture Name="hakaana_room_0Tex_002E58" OutName="hakaana_room_0Tex_002E58" Format="rgba16" Width="32" Height="16" Offset="0x2E58" AddedByScript="true"/>
+        <Texture Name="hakaana_room_0Tex_003258" OutName="hakaana_room_0Tex_003258" Format="rgba16" Width="32" Height="16" Offset="0x3258" AddedByScript="true"/>
+        <Texture Name="hakaana_room_0Tex_003658" OutName="hakaana_room_0Tex_003658" Format="rgba16" Width="32" Height="32" Offset="0x3658" AddedByScript="true"/>
+        <Texture Name="hakaana_room_0Tex_003E58" OutName="hakaana_room_0Tex_003E58" Format="i4" Width="128" Height="32" Offset="0x3E58" AddedByScript="true"/>
+        <Texture Name="hakaana_room_0Tex_004658" OutName="hakaana_room_0Tex_004658" Format="rgba16" Width="32" Height="32" Offset="0x4658" AddedByScript="true"/>
+        <Texture Name="hakaana_room_0Tex_004E58" OutName="hakaana_room_0Tex_004E58" Format="i4" Width="64" Height="64" Offset="0x4E58" AddedByScript="true"/>
+        <Texture Name="hakaana_room_0Tex_005658" OutName="hakaana_room_0Tex_005658" Format="i4" Width="64" Height="64" Offset="0x5658" AddedByScript="true"/>
+        <Texture Name="hakaana_room_0Tex_005E58" OutName="hakaana_room_0Tex_005E58" Format="i4" Width="64" Height="64" Offset="0x5E58" AddedByScript="true"/>
+        <Texture Name="hakaana_room_0Tex_0068C8" OutName="hakaana_room_0Tex_0068C8" Format="ia16" Width="128" Height="16" Offset="0x68C8" AddedByScript="true"/>
         <Room Name="hakaana_room_0" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_MQ_D/scenes/misc/hakaana2.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/misc/hakaana2.xml
@@ -1,5 +1,23 @@
 <Root>
     <File Name="hakaana2_scene" Segment="2">
+        <Texture Name="hakaana2_sceneTex_003090" OutName="hakaana2_sceneTex_003090" Format="rgba16" Width="32" Height="32" Offset="0x3090" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_003890" OutName="hakaana2_sceneTex_003890" Format="rgba16" Width="32" Height="32" Offset="0x3890" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_004090" OutName="hakaana2_sceneTex_004090" Format="rgba16" Width="32" Height="16" Offset="0x4090" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_004490" OutName="hakaana2_sceneTex_004490" Format="rgba16" Width="32" Height="16" Offset="0x4490" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_004890" OutName="hakaana2_sceneTex_004890" Format="i4" Width="64" Height="64" Offset="0x4890" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_005090" OutName="hakaana2_sceneTex_005090" Format="i4" Width="64" Height="64" Offset="0x5090" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_005890" OutName="hakaana2_sceneTex_005890" Format="i4" Width="128" Height="32" Offset="0x5890" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_006090" OutName="hakaana2_sceneTex_006090" Format="i4" Width="64" Height="64" Offset="0x6090" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_006890" OutName="hakaana2_sceneTex_006890" Format="ia8" Width="64" Height="32" Offset="0x6890" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_007090" OutName="hakaana2_sceneTex_007090" Format="i8" Width="16" Height="256" Offset="0x7090" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_008090" OutName="hakaana2_sceneTex_008090" Format="ia16" Width="128" Height="16" Offset="0x8090" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_009090" OutName="hakaana2_sceneTex_009090" Format="i8" Width="32" Height="64" Offset="0x9090" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_009890" OutName="hakaana2_sceneTex_009890" Format="i8" Width="32" Height="64" Offset="0x9890" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_00A090" OutName="hakaana2_sceneTex_00A090" Format="rgba16" Width="32" Height="32" Offset="0xA090" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_00A890" OutName="hakaana2_sceneTex_00A890" Format="i4" Width="64" Height="128" Offset="0xA890" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_00B890" OutName="hakaana2_sceneTex_00B890" Format="rgba16" Width="32" Height="32" Offset="0xB890" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_00C090" OutName="hakaana2_sceneTex_00C090" Format="rgba16" Width="32" Height="32" Offset="0xC090" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_00C890" OutName="hakaana2_sceneTex_00C890" Format="rgba16" Width="32" Height="32" Offset="0xC890" AddedByScript="true"/>
         <Scene Name="hakaana2_scene" Offset="0x0"/>
     </File>
     <File Name="hakaana2_room_0" Segment="3">

--- a/soh/assets/xml/GC_MQ_D/scenes/misc/hakaana_ouke.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/misc/hakaana_ouke.xml
@@ -1,16 +1,37 @@
 <Root>
     <File Name="hakaana_ouke_scene" Segment="2">
+        <Texture Name="hakaana_ouke_sceneTex_002AE0" OutName="hakaana_ouke_sceneTex_002AE0" Format="rgba16" Width="32" Height="16" Offset="0x2AE0" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_sceneTex_002EE0" OutName="hakaana_ouke_sceneTex_002EE0" Format="rgba16" Width="32" Height="16" Offset="0x2EE0" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_sceneTex_0032E0" OutName="hakaana_ouke_sceneTex_0032E0" Format="rgba16" Width="32" Height="32" Offset="0x32E0" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_sceneTex_003AE0" OutName="hakaana_ouke_sceneTex_003AE0" Format="i4" Width="64" Height="64" Offset="0x3AE0" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_sceneTex_0042E0" OutName="hakaana_ouke_sceneTex_0042E0" Format="i4" Width="64" Height="64" Offset="0x42E0" AddedByScript="true"/>
         <Cutscene Name="gSunSongGraveSunSongTeachCs" Offset="0x24A0"/>
         <Cutscene Name="gSunSongGraveSunSongTeachPart2Cs" Offset="0x28E0"/>
         <Scene Name="hakaana_ouke_scene" Offset="0x0"/>
     </File>
     <File Name="hakaana_ouke_room_0" Segment="3">
+        <Texture Name="hakaana_ouke_room_0Tex_004F30" OutName="hakaana_ouke_room_0Tex_004F30" Format="rgba16" Width="16" Height="64" Offset="0x4F30" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_room_0Tex_005730" OutName="hakaana_ouke_room_0Tex_005730" Format="rgba16" Width="32" Height="64" Offset="0x5730" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_room_0Tex_006730" OutName="hakaana_ouke_room_0Tex_006730" Format="i4" Width="128" Height="32" Offset="0x6730" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_room_0Tex_006F30" OutName="hakaana_ouke_room_0Tex_006F30" Format="i4" Width="64" Height="64" Offset="0x6F30" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_room_0Tex_007FF8" OutName="hakaana_ouke_room_0Tex_007FF8" Format="ia4" Width="32" Height="256" Offset="0x7FF8" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_room_0Tex_008FF8" OutName="hakaana_ouke_room_0Tex_008FF8" Format="ia8" Width="8" Height="256" Offset="0x8FF8" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_room_0Tex_0097F8" OutName="hakaana_ouke_room_0Tex_0097F8" Format="ia16" Width="128" Height="16" Offset="0x97F8" AddedByScript="true"/>
         <Room Name="hakaana_ouke_room_0" Offset="0x0"/>
     </File>
     <File Name="hakaana_ouke_room_1" Segment="3">
+        <Texture Name="hakaana_ouke_room_1Tex_001FC8" OutName="hakaana_ouke_room_1Tex_001FC8" Format="rgba16" Width="32" Height="32" Offset="0x1FC8" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_room_1Tex_0027C8" OutName="hakaana_ouke_room_1Tex_0027C8" Format="rgba16" Width="32" Height="64" Offset="0x27C8" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_room_1Tex_004000" OutName="hakaana_ouke_room_1Tex_004000" Format="i8" Width="16" Height="128" Offset="0x4000" AddedByScript="true"/>
         <Room Name="hakaana_ouke_room_1" Offset="0x0"/>
     </File>
     <File Name="hakaana_ouke_room_2" Segment="3">
+        <Texture Name="hakaana_ouke_room_2Tex_002778" OutName="hakaana_ouke_room_2Tex_002778" Format="i4" Width="128" Height="32" Offset="0x2778" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_room_2Tex_002F78" OutName="hakaana_ouke_room_2Tex_002F78" Format="rgba16" Width="32" Height="32" Offset="0x2F78" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_room_2Tex_003778" OutName="hakaana_ouke_room_2Tex_003778" Format="i4" Width="128" Height="32" Offset="0x3778" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_room_2Tex_003F78" OutName="hakaana_ouke_room_2Tex_003F78" Format="rgba16" Width="32" Height="32" Offset="0x3F78" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_room_2Tex_004778" OutName="hakaana_ouke_room_2Tex_004778" Format="i4" Width="64" Height="64" Offset="0x4778" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_room_2Tex_005108" OutName="hakaana_ouke_room_2Tex_005108" Format="ia8" Width="128" Height="32" Offset="0x5108" AddedByScript="true"/>
         <Room Name="hakaana_ouke_room_2" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_MQ_D/scenes/misc/kakusiana.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/misc/kakusiana.xml
@@ -1,47 +1,113 @@
 <Root>
     <File Name="kakusiana_scene" Segment="2">
+        <Texture Name="kakusiana_sceneTex_00B820" OutName="kakusiana_sceneTex_00B820" Format="ia4" Width="64" Height="64" Offset="0xB820" AddedByScript="true"/>
+        <Texture Name="kakusiana_sceneTex_00C020" OutName="kakusiana_sceneTex_00C020" Format="ia16" Width="128" Height="16" Offset="0xC020" AddedByScript="true"/>
+        <Texture Name="kakusiana_sceneTex_00D020" OutName="kakusiana_sceneTex_00D020" Format="rgba16" Width="32" Height="32" Offset="0xD020" AddedByScript="true"/>
         <Scene Name="kakusiana_scene" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_0" Segment="3">
+        <Texture Name="kakusiana_room_0Tex_0022A0" OutName="kakusiana_room_0Tex_0022A0" Format="rgba16" Width="64" Height="32" Offset="0x22A0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_0Tex_0032A0" OutName="kakusiana_room_0Tex_0032A0" Format="rgba16" Width="64" Height="32" Offset="0x32A0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_0Tex_0042A0" OutName="kakusiana_room_0Tex_0042A0" Format="rgba16" Width="32" Height="32" Offset="0x42A0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_0Tex_004AA0" OutName="kakusiana_room_0Tex_004AA0" Format="i8" Width="64" Height="64" Offset="0x4AA0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_0Tex_005AA0" OutName="kakusiana_room_0Tex_005AA0" Format="rgba16" Width="32" Height="32" Offset="0x5AA0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_0Tex_006AA0" OutName="kakusiana_room_0Tex_006AA0" Format="rgba16" Width="32" Height="32" Offset="0x6AA0" AddedByScript="true"/>
         <Room Name="kakusiana_room_0" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_1" Segment="3">
+        <Texture Name="kakusiana_room_1Tex_001A18" OutName="kakusiana_room_1Tex_001A18" Format="i8" Width="64" Height="64" Offset="0x1A18" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_1Tex_002A18" OutName="kakusiana_room_1Tex_002A18" Format="rgba16" Width="32" Height="32" Offset="0x2A18" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_1Tex_003218" OutName="kakusiana_room_1Tex_003218" Format="i8" Width="64" Height="64" Offset="0x3218" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_1Tex_004990" OutName="kakusiana_room_1Tex_004990" Format="ia8" Width="8" Height="256" Offset="0x4990" AddedByScript="true"/>
         <Room Name="kakusiana_room_1" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_2" Segment="3">
+        <Texture Name="kakusiana_room_2Tex_001448" OutName="kakusiana_room_2Tex_001448" Format="rgba16" Width="32" Height="32" Offset="0x1448" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_2Tex_001C48" OutName="kakusiana_room_2Tex_001C48" Format="rgba16" Width="32" Height="32" Offset="0x1C48" AddedByScript="true"/>
         <Room Name="kakusiana_room_2" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_3" Segment="3">
+        <Texture Name="kakusiana_room_3Tex_001818" OutName="kakusiana_room_3Tex_001818" Format="i8" Width="64" Height="64" Offset="0x1818" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_3Tex_002818" OutName="kakusiana_room_3Tex_002818" Format="i8" Width="64" Height="64" Offset="0x2818" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_3Tex_004130" OutName="kakusiana_room_3Tex_004130" Format="ia8" Width="8" Height="256" Offset="0x4130" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_3Tex_004930" OutName="kakusiana_room_3Tex_004930" Format="rgba16" Width="32" Height="32" Offset="0x4930" AddedByScript="true"/>
         <Room Name="kakusiana_room_3" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_4" Segment="3">
+        <Texture Name="kakusiana_room_4Tex_002138" OutName="kakusiana_room_4Tex_002138" Format="rgba16" Width="32" Height="64" Offset="0x2138" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_4Tex_003138" OutName="kakusiana_room_4Tex_003138" Format="rgba16" Width="32" Height="64" Offset="0x3138" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_4Tex_004138" OutName="kakusiana_room_4Tex_004138" Format="rgba16" Width="32" Height="32" Offset="0x4138" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_4Tex_005958" OutName="kakusiana_room_4Tex_005958" Format="i8" Width="64" Height="64" Offset="0x5958" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_4Tex_006958" OutName="kakusiana_room_4Tex_006958" Format="i8" Width="64" Height="64" Offset="0x6958" AddedByScript="true"/>
         <Room Name="kakusiana_room_4" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_5" Segment="3">
+        <Texture Name="kakusiana_room_5Tex_001888" OutName="kakusiana_room_5Tex_001888" Format="i8" Width="64" Height="64" Offset="0x1888" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_5Tex_002888" OutName="kakusiana_room_5Tex_002888" Format="i8" Width="64" Height="64" Offset="0x2888" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_5Tex_003ED8" OutName="kakusiana_room_5Tex_003ED8" Format="rgba16" Width="32" Height="32" Offset="0x3ED8" AddedByScript="true"/>
         <Room Name="kakusiana_room_5" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_6" Segment="3">
+        <Texture Name="kakusiana_room_6Tex_0022E0" OutName="kakusiana_room_6Tex_0022E0" Format="rgba16" Width="32" Height="64" Offset="0x22E0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_6Tex_0032E0" OutName="kakusiana_room_6Tex_0032E0" Format="rgba16" Width="32" Height="32" Offset="0x32E0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_6Tex_003AE0" OutName="kakusiana_room_6Tex_003AE0" Format="rgba16" Width="64" Height="32" Offset="0x3AE0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_6Tex_004AE0" OutName="kakusiana_room_6Tex_004AE0" Format="rgba16" Width="32" Height="32" Offset="0x4AE0" AddedByScript="true"/>
         <Room Name="kakusiana_room_6" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_7" Segment="3">
+        <Texture Name="kakusiana_room_7Tex_001D60" OutName="kakusiana_room_7Tex_001D60" Format="rgba16" Width="32" Height="16" Offset="0x1D60" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_7Tex_002160" OutName="kakusiana_room_7Tex_002160" Format="rgba16" Width="32" Height="32" Offset="0x2160" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_7Tex_002960" OutName="kakusiana_room_7Tex_002960" Format="rgba16" Width="16" Height="16" Offset="0x2960" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_7Tex_002B60" OutName="kakusiana_room_7Tex_002B60" Format="i8" Width="64" Height="64" Offset="0x2B60" AddedByScript="true"/>
         <Room Name="kakusiana_room_7" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_8" Segment="3">
+        <Texture Name="kakusiana_room_8Tex_0019C0" OutName="kakusiana_room_8Tex_0019C0" Format="rgba16" Width="32" Height="64" Offset="0x19C0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_8Tex_0029C0" OutName="kakusiana_room_8Tex_0029C0" Format="rgba16" Width="32" Height="32" Offset="0x29C0" AddedByScript="true"/>
         <Room Name="kakusiana_room_8" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_9" Segment="3">
+        <Texture Name="kakusiana_room_9Tex_002340" OutName="kakusiana_room_9Tex_002340" Format="rgba16" Width="32" Height="64" Offset="0x2340" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_9Tex_003340" OutName="kakusiana_room_9Tex_003340" Format="rgba16" Width="32" Height="32" Offset="0x3340" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_9Tex_003B40" OutName="kakusiana_room_9Tex_003B40" Format="rgba16" Width="64" Height="32" Offset="0x3B40" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_9Tex_004B40" OutName="kakusiana_room_9Tex_004B40" Format="rgba16" Width="32" Height="32" Offset="0x4B40" AddedByScript="true"/>
         <Room Name="kakusiana_room_9" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_10" Segment="3">
+        <Texture Name="kakusiana_room_10Tex_0017E0" OutName="kakusiana_room_10Tex_0017E0" Format="i8" Width="32" Height="64" Offset="0x17E0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_10Tex_001FE0" OutName="kakusiana_room_10Tex_001FE0" Format="i8" Width="32" Height="64" Offset="0x1FE0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_10Tex_0027E0" OutName="kakusiana_room_10Tex_0027E0" Format="i8" Width="32" Height="32" Offset="0x27E0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_10Tex_002BE0" OutName="kakusiana_room_10Tex_002BE0" Format="i8" Width="64" Height="64" Offset="0x2BE0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_10Tex_003BE0" OutName="kakusiana_room_10Tex_003BE0" Format="i8" Width="64" Height="64" Offset="0x3BE0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_10Tex_005228" OutName="kakusiana_room_10Tex_005228" Format="rgba16" Width="32" Height="32" Offset="0x5228" AddedByScript="true"/>
         <Room Name="kakusiana_room_10" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_11" Segment="3">
+        <Texture Name="kakusiana_room_11Tex_002848" OutName="kakusiana_room_11Tex_002848" Format="rgba16" Width="32" Height="32" Offset="0x2848" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_11Tex_003048" OutName="kakusiana_room_11Tex_003048" Format="rgba16" Width="32" Height="64" Offset="0x3048" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_11Tex_004048" OutName="kakusiana_room_11Tex_004048" Format="rgba16" Width="32" Height="64" Offset="0x4048" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_11Tex_005048" OutName="kakusiana_room_11Tex_005048" Format="rgba16" Width="32" Height="32" Offset="0x5048" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_11Tex_005848" OutName="kakusiana_room_11Tex_005848" Format="rgba16" Width="64" Height="32" Offset="0x5848" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_11Tex_006848" OutName="kakusiana_room_11Tex_006848" Format="rgba16" Width="64" Height="32" Offset="0x6848" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_11Tex_007848" OutName="kakusiana_room_11Tex_007848" Format="rgba16" Width="32" Height="32" Offset="0x7848" AddedByScript="true"/>
         <Room Name="kakusiana_room_11" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_12" Segment="3">
+        <Texture Name="kakusiana_room_12Tex_001FF0" OutName="kakusiana_room_12Tex_001FF0" Format="rgba16" Width="32" Height="32" Offset="0x1FF0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_12Tex_0027F0" OutName="kakusiana_room_12Tex_0027F0" Format="rgba16" Width="32" Height="64" Offset="0x27F0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_12Tex_0037F0" OutName="kakusiana_room_12Tex_0037F0" Format="rgba16" Width="32" Height="64" Offset="0x37F0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_12Tex_0047F0" OutName="kakusiana_room_12Tex_0047F0" Format="rgba16" Width="32" Height="32" Offset="0x47F0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_12Tex_004FF0" OutName="kakusiana_room_12Tex_004FF0" Format="rgba16" Width="64" Height="32" Offset="0x4FF0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_12Tex_005FF0" OutName="kakusiana_room_12Tex_005FF0" Format="rgba16" Width="64" Height="32" Offset="0x5FF0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_12Tex_006FF0" OutName="kakusiana_room_12Tex_006FF0" Format="rgba16" Width="32" Height="32" Offset="0x6FF0" AddedByScript="true"/>
         <Room Name="kakusiana_room_12" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_13" Segment="3">
+        <Texture Name="kakusiana_room_13Tex_001950" OutName="kakusiana_room_13Tex_001950" Format="rgba16" Width="32" Height="64" Offset="0x1950" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_13Tex_002950" OutName="kakusiana_room_13Tex_002950" Format="rgba16" Width="32" Height="64" Offset="0x2950" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_13Tex_003950" OutName="kakusiana_room_13Tex_003950" Format="rgba16" Width="32" Height="32" Offset="0x3950" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_13Tex_004EC8" OutName="kakusiana_room_13Tex_004EC8" Format="i8" Width="64" Height="64" Offset="0x4EC8" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_13Tex_005EC8" OutName="kakusiana_room_13Tex_005EC8" Format="i8" Width="64" Height="64" Offset="0x5EC8" AddedByScript="true"/>
         <Room Name="kakusiana_room_13" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_MQ_D/scenes/misc/kinsuta.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/misc/kinsuta.xml
@@ -3,6 +3,19 @@
         <Scene Name="kinsuta_scene" Offset="0x0"/>
     </File>
     <File Name="kinsuta_room_0" Segment="3">
+        <Texture Name="kinsuta_room_0Tex_003110" OutName="kinsuta_room_0Tex_003110" Format="ci4" Width="64" Height="64" Offset="0x3110" TlutOffset="0x30F0" AddedByScript="true"/>
+        <Texture Name="kinsuta_room_0Tex_003910" OutName="kinsuta_room_0Tex_003910" Format="i4" Width="64" Height="128" Offset="0x3910" AddedByScript="true"/>
+        <Texture Name="kinsuta_room_0Tex_004910" OutName="kinsuta_room_0Tex_004910" Format="i4" Width="64" Height="128" Offset="0x4910" AddedByScript="true"/>
+        <Texture Name="kinsuta_room_0Tex_005910" OutName="kinsuta_room_0Tex_005910" Format="i4" Width="64" Height="128" Offset="0x5910" AddedByScript="true"/>
+        <Texture Name="kinsuta_room_0Tex_006910" OutName="kinsuta_room_0Tex_006910" Format="rgba16" Width="32" Height="64" Offset="0x6910" AddedByScript="true"/>
+        <Texture Name="kinsuta_room_0Tex_007910" OutName="kinsuta_room_0Tex_007910" Format="rgba16" Width="32" Height="64" Offset="0x7910" AddedByScript="true"/>
+        <Texture Name="kinsuta_room_0Tex_008910" OutName="kinsuta_room_0Tex_008910" Format="i8" Width="32" Height="32" Offset="0x8910" AddedByScript="true"/>
+        <Texture Name="kinsuta_room_0Tex_008D10" OutName="kinsuta_room_0Tex_008D10" Format="rgba16" Width="64" Height="32" Offset="0x8D10" AddedByScript="true"/>
+        <Texture Name="kinsuta_room_0Tex_009D10" OutName="kinsuta_room_0Tex_009D10" Format="rgba16" Width="32" Height="16" Offset="0x9D10" AddedByScript="true"/>
+        <Texture Name="kinsuta_room_0Tex_00B098" OutName="kinsuta_room_0Tex_00B098" Format="ia16" Width="32" Height="64" Offset="0xB098" AddedByScript="true"/>
+        <Texture Name="kinsuta_room_0Tex_00C098" OutName="kinsuta_room_0Tex_00C098" Format="i8" Width="64" Height="64" Offset="0xC098" AddedByScript="true"/>
+        <Texture Name="kinsuta_room_0Tex_00D098" OutName="kinsuta_room_0Tex_00D098" Format="i8" Width="64" Height="64" Offset="0xD098" AddedByScript="true"/>
+        <Texture Name="kinsuta_room_0TLUT_0030F0" OutName="kinsuta_room_0TLUT_0030F0" Format="rgba16" Width="4" Height="4" Offset="0x30F0" AddedByScript="true"/>
         <DList Name="gKinsutaDL_0030B0" Offset="0x30B0"/>
         <DList Name="gKinsutaDL_00B088" Offset="0xB088"/>
         <Room Name="kinsuta_room_0" Offset="0x0"/>

--- a/soh/assets/xml/GC_MQ_D/scenes/misc/turibori.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/misc/turibori.xml
@@ -1,5 +1,32 @@
 <Root>
     <File Name="turibori_scene" Segment="2">
+        <Texture Name="turibori_sceneTex_001CE0" OutName="turibori_sceneTex_001CE0" Format="rgba16" Width="32" Height="64" Offset="0x1CE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_002CE0" OutName="turibori_sceneTex_002CE0" Format="rgba16" Width="64" Height="32" Offset="0x2CE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_003CE0" OutName="turibori_sceneTex_003CE0" Format="rgba16" Width="64" Height="32" Offset="0x3CE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_004CE0" OutName="turibori_sceneTex_004CE0" Format="rgba16" Width="32" Height="4" Offset="0x4CE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_004DE0" OutName="turibori_sceneTex_004DE0" Format="rgba16" Width="32" Height="16" Offset="0x4DE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_0051E0" OutName="turibori_sceneTex_0051E0" Format="ia16" Width="32" Height="32" Offset="0x51E0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_0059E0" OutName="turibori_sceneTex_0059E0" Format="ia8" Width="64" Height="64" Offset="0x59E0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_0069E0" OutName="turibori_sceneTex_0069E0" Format="ia8" Width="32" Height="16" Offset="0x69E0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_006BE0" OutName="turibori_sceneTex_006BE0" Format="rgba16" Width="32" Height="64" Offset="0x6BE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_007BE0" OutName="turibori_sceneTex_007BE0" Format="ia8" Width="64" Height="16" Offset="0x7BE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_007FE0" OutName="turibori_sceneTex_007FE0" Format="rgba16" Width="32" Height="8" Offset="0x7FE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_0081E0" OutName="turibori_sceneTex_0081E0" Format="rgba16" Width="64" Height="32" Offset="0x81E0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_0091E0" OutName="turibori_sceneTex_0091E0" Format="ia8" Width="16" Height="16" Offset="0x91E0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_0092E0" OutName="turibori_sceneTex_0092E0" Format="ia8" Width="16" Height="32" Offset="0x92E0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_0094E0" OutName="turibori_sceneTex_0094E0" Format="rgba16" Width="32" Height="32" Offset="0x94E0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_009CE0" OutName="turibori_sceneTex_009CE0" Format="rgba16" Width="32" Height="64" Offset="0x9CE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_00ACE0" OutName="turibori_sceneTex_00ACE0" Format="rgba16" Width="64" Height="32" Offset="0xACE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_00BCE0" OutName="turibori_sceneTex_00BCE0" Format="ia8" Width="32" Height="128" Offset="0xBCE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_00CCE0" OutName="turibori_sceneTex_00CCE0" Format="rgba16" Width="64" Height="32" Offset="0xCCE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_00DCE0" OutName="turibori_sceneTex_00DCE0" Format="rgba16" Width="32" Height="32" Offset="0xDCE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_00E4E0" OutName="turibori_sceneTex_00E4E0" Format="rgba16" Width="32" Height="32" Offset="0xE4E0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_00ECE0" OutName="turibori_sceneTex_00ECE0" Format="rgba16" Width="32" Height="32" Offset="0xECE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_00F4E0" OutName="turibori_sceneTex_00F4E0" Format="ia4" Width="64" Height="64" Offset="0xF4E0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_00FCE0" OutName="turibori_sceneTex_00FCE0" Format="rgba16" Width="32" Height="32" Offset="0xFCE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_0104E0" OutName="turibori_sceneTex_0104E0" Format="rgba16" Width="64" Height="32" Offset="0x104E0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_0114E0" OutName="turibori_sceneTex_0114E0" Format="i4" Width="32" Height="32" Offset="0x114E0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_0116E0" OutName="turibori_sceneTex_0116E0" Format="rgba16" Width="32" Height="64" Offset="0x116E0" AddedByScript="true"/>
         <Scene Name="turibori_scene" Offset="0x0"/>
     </File>
     <File Name="turibori_room_0" Segment="3">

--- a/soh/assets/xml/GC_MQ_D/scenes/overworld/souko.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/overworld/souko.xml
@@ -1,16 +1,44 @@
 <Root>
     <File Name="souko_scene" Segment="2">
+        <Texture Name="souko_sceneTex_004410" OutName="souko_sceneTex_004410" Format="rgba16" Width="32" Height="32" Offset="0x4410" AddedByScript="true"/>
+        <Texture Name="souko_sceneTex_004C10" OutName="souko_sceneTex_004C10" Format="rgba16" Width="32" Height="16" Offset="0x4C10" AddedByScript="true"/>
+        <Texture Name="souko_sceneTex_005410" OutName="souko_sceneTex_005410" Format="rgba16" Width="32" Height="32" Offset="0x5410" AddedByScript="true"/>
+        <Texture Name="souko_sceneTex_005C10" OutName="souko_sceneTex_005C10" Format="rgba16" Width="64" Height="32" Offset="0x5C10" AddedByScript="true"/>
         <Texture Name="gLonLonHouseDayEntranceTex" OutName="day_entrance" Format="ia16" Width="64" Height="4" Offset="0x5210"/>
         <Texture Name="gLonLonHouseNightEntranceTex" OutName="night_entrance" Format="ia16" Width="64" Height="4" Offset="0x5010"/>
         <Scene Name="souko_scene" Offset="0x0"/>
     </File>
     <File Name="souko_room_0" Segment="3">
+        <Texture Name="souko_room_0Tex_0054F8" OutName="souko_room_0Tex_0054F8" Format="i4" Width="64" Height="64" Offset="0x54F8" AddedByScript="true"/>
+        <Texture Name="souko_room_0Tex_005CF8" OutName="souko_room_0Tex_005CF8" Format="rgba16" Width="32" Height="32" Offset="0x5CF8" AddedByScript="true"/>
+        <Texture Name="souko_room_0Tex_0064F8" OutName="souko_room_0Tex_0064F8" Format="rgba16" Width="32" Height="32" Offset="0x64F8" AddedByScript="true"/>
+        <Texture Name="souko_room_0Tex_006CF8" OutName="souko_room_0Tex_006CF8" Format="rgba16" Width="16" Height="32" Offset="0x6CF8" AddedByScript="true"/>
+        <Texture Name="souko_room_0Tex_0070F8" OutName="souko_room_0Tex_0070F8" Format="rgba16" Width="32" Height="32" Offset="0x70F8" AddedByScript="true"/>
+        <Texture Name="souko_room_0Tex_0078F8" OutName="souko_room_0Tex_0078F8" Format="rgba16" Width="32" Height="32" Offset="0x78F8" AddedByScript="true"/>
+        <Texture Name="souko_room_0Tex_0080F8" OutName="souko_room_0Tex_0080F8" Format="rgba16" Width="32" Height="64" Offset="0x80F8" AddedByScript="true"/>
+        <Texture Name="souko_room_0Tex_0090F8" OutName="souko_room_0Tex_0090F8" Format="i4" Width="32" Height="32" Offset="0x90F8" AddedByScript="true"/>
         <Room Name="souko_room_0" Offset="0x0"/>
     </File>
     <File Name="souko_room_1" Segment="3">
+        <Texture Name="souko_room_1Tex_005118" OutName="souko_room_1Tex_005118" Format="rgba16" Width="16" Height="64" Offset="0x5118" AddedByScript="true"/>
+        <Texture Name="souko_room_1Tex_005918" OutName="souko_room_1Tex_005918" Format="rgba16" Width="32" Height="32" Offset="0x5918" AddedByScript="true"/>
+        <Texture Name="souko_room_1Tex_006118" OutName="souko_room_1Tex_006118" Format="rgba16" Width="32" Height="64" Offset="0x6118" AddedByScript="true"/>
+        <Texture Name="souko_room_1Tex_007118" OutName="souko_room_1Tex_007118" Format="rgba16" Width="16" Height="32" Offset="0x7118" AddedByScript="true"/>
+        <Texture Name="souko_room_1Tex_007518" OutName="souko_room_1Tex_007518" Format="rgba16" Width="32" Height="32" Offset="0x7518" AddedByScript="true"/>
+        <Texture Name="souko_room_1Tex_007D18" OutName="souko_room_1Tex_007D18" Format="rgba16" Width="32" Height="64" Offset="0x7D18" AddedByScript="true"/>
+        <Texture Name="souko_room_1Tex_008D18" OutName="souko_room_1Tex_008D18" Format="rgba16" Width="32" Height="32" Offset="0x8D18" AddedByScript="true"/>
+        <Texture Name="souko_room_1Tex_009F28" OutName="souko_room_1Tex_009F28" Format="rgba16" Width="16" Height="16" Offset="0x9F28" AddedByScript="true"/>
+        <Texture Name="souko_room_1Tex_00A128" OutName="souko_room_1Tex_00A128" Format="ia8" Width="16" Height="16" Offset="0xA128" AddedByScript="true"/>
+        <Texture Name="souko_room_1Tex_00A228" OutName="souko_room_1Tex_00A228" Format="ia8" Width="16" Height="32" Offset="0xA228" AddedByScript="true"/>
         <Room Name="souko_room_1" Offset="0x0"/>
     </File>
     <File Name="souko_room_2" Segment="3">
+        <Texture Name="souko_room_2Tex_004EE0" OutName="souko_room_2Tex_004EE0" Format="rgba16" Width="16" Height="32" Offset="0x4EE0" AddedByScript="true"/>
+        <Texture Name="souko_room_2Tex_0052E0" OutName="souko_room_2Tex_0052E0" Format="i4" Width="64" Height="64" Offset="0x52E0" AddedByScript="true"/>
+        <Texture Name="souko_room_2Tex_005AE0" OutName="souko_room_2Tex_005AE0" Format="rgba16" Width="8" Height="128" Offset="0x5AE0" AddedByScript="true"/>
+        <Texture Name="souko_room_2Tex_0062E0" OutName="souko_room_2Tex_0062E0" Format="rgba16" Width="16" Height="64" Offset="0x62E0" AddedByScript="true"/>
+        <Texture Name="souko_room_2Tex_006AE0" OutName="souko_room_2Tex_006AE0" Format="rgba16" Width="32" Height="64" Offset="0x6AE0" AddedByScript="true"/>
+        <Texture Name="souko_room_2Tex_007F78" OutName="souko_room_2Tex_007F78" Format="ia8" Width="16" Height="32" Offset="0x7F78" AddedByScript="true"/>
         <Room Name="souko_room_2" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_MQ_D/scenes/overworld/spot00.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/overworld/spot00.xml
@@ -1,5 +1,56 @@
 <Root>
     <File Name="spot00_scene" Segment="2">
+        <Texture Name="spot00_sceneTex_013D98" OutName="spot00_sceneTex_013D98" Format="rgba16" Width="32" Height="32" Offset="0x13D98" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_014598" OutName="spot00_sceneTex_014598" Format="rgba16" Width="16" Height="32" Offset="0x14598" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_014998" OutName="spot00_sceneTex_014998" Format="rgba16" Width="32" Height="16" Offset="0x14998" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_014D98" OutName="spot00_sceneTex_014D98" Format="rgba16" Width="64" Height="32" Offset="0x14D98" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_015D98" OutName="spot00_sceneTex_015D98" Format="rgba16" Width="8" Height="16" Offset="0x15D98" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_015E98" OutName="spot00_sceneTex_015E98" Format="rgba16" Width="16" Height="64" Offset="0x15E98" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_016698" OutName="spot00_sceneTex_016698" Format="rgba16" Width="32" Height="16" Offset="0x16698" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_016A98" OutName="spot00_sceneTex_016A98" Format="ia4" Width="16" Height="32" Offset="0x16A98" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_016B98" OutName="spot00_sceneTex_016B98" Format="rgba16" Width="32" Height="32" Offset="0x16B98" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_017398" OutName="spot00_sceneTex_017398" Format="rgba16" Width="32" Height="32" Offset="0x17398" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_017B98" OutName="spot00_sceneTex_017B98" Format="rgba16" Width="32" Height="64" Offset="0x17B98" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_018B98" OutName="spot00_sceneTex_018B98" Format="rgba16" Width="32" Height="32" Offset="0x18B98" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_019398" OutName="spot00_sceneTex_019398" Format="rgba16" Width="32" Height="32" Offset="0x19398" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_019B98" OutName="spot00_sceneTex_019B98" Format="rgba16" Width="32" Height="64" Offset="0x19B98" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_01AB98" OutName="spot00_sceneTex_01AB98" Format="rgba16" Width="32" Height="32" Offset="0x1AB98" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_01B398" OutName="spot00_sceneTex_01B398" Format="rgba16" Width="32" Height="32" Offset="0x1B398" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_01BB98" OutName="spot00_sceneTex_01BB98" Format="rgba16" Width="16" Height="16" Offset="0x1BB98" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_01BD98" OutName="spot00_sceneTex_01BD98" Format="rgba16" Width="16" Height="32" Offset="0x1BD98" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_01C198" OutName="spot00_sceneTex_01C198" Format="rgba16" Width="32" Height="32" Offset="0x1C198" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_01C998" OutName="spot00_sceneTex_01C998" Format="rgba16" Width="32" Height="32" Offset="0x1C998" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_01D198" OutName="spot00_sceneTex_01D198" Format="rgba16" Width="64" Height="16" Offset="0x1D198" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_01D998" OutName="spot00_sceneTex_01D998" Format="rgba16" Width="32" Height="64" Offset="0x1D998" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_01E998" OutName="spot00_sceneTex_01E998" Format="ia4" Width="128" Height="32" Offset="0x1E998" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_01F198" OutName="spot00_sceneTex_01F198" Format="ia4" Width="64" Height="32" Offset="0x1F198" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_01F598" OutName="spot00_sceneTex_01F598" Format="i4" Width="16" Height="16" Offset="0x1F598" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_01F618" OutName="spot00_sceneTex_01F618" Format="rgba16" Width="8" Height="32" Offset="0x1F618" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_01F818" OutName="spot00_sceneTex_01F818" Format="rgba16" Width="32" Height="32" Offset="0x1F818" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_020018" OutName="spot00_sceneTex_020018" Format="i4" Width="64" Height="64" Offset="0x20018" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_020818" OutName="spot00_sceneTex_020818" Format="rgba16" Width="32" Height="32" Offset="0x20818" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_021018" OutName="spot00_sceneTex_021018" Format="rgba16" Width="16" Height="64" Offset="0x21018" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_021818" OutName="spot00_sceneTex_021818" Format="rgba16" Width="16" Height="64" Offset="0x21818" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_022018" OutName="spot00_sceneTex_022018" Format="ia4" Width="128" Height="32" Offset="0x22018" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_022818" OutName="spot00_sceneTex_022818" Format="rgba16" Width="64" Height="16" Offset="0x22818" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_023018" OutName="spot00_sceneTex_023018" Format="rgba16" Width="64" Height="16" Offset="0x23018" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_023818" OutName="spot00_sceneTex_023818" Format="i4" Width="64" Height="64" Offset="0x23818" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_024018" OutName="spot00_sceneTex_024018" Format="i4" Width="64" Height="64" Offset="0x24018" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_024818" OutName="spot00_sceneTex_024818" Format="ci4" Width="64" Height="64" Offset="0x24818" TlutOffset="0x13D70" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_025018" OutName="spot00_sceneTex_025018" Format="i4" Width="64" Height="64" Offset="0x25018" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_025818" OutName="spot00_sceneTex_025818" Format="rgba16" Width="8" Height="8" Offset="0x25818" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_025898" OutName="spot00_sceneTex_025898" Format="rgba16" Width="32" Height="32" Offset="0x25898" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_026098" OutName="spot00_sceneTex_026098" Format="rgba16" Width="32" Height="32" Offset="0x26098" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_026898" OutName="spot00_sceneTex_026898" Format="ia4" Width="16" Height="32" Offset="0x26898" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_026998" OutName="spot00_sceneTex_026998" Format="rgba16" Width="64" Height="32" Offset="0x26998" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_027998" OutName="spot00_sceneTex_027998" Format="i4" Width="32" Height="64" Offset="0x27998" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_027D98" OutName="spot00_sceneTex_027D98" Format="i4" Width="32" Height="64" Offset="0x27D98" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_028198" OutName="spot00_sceneTex_028198" Format="rgba16" Width="8" Height="64" Offset="0x28198" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_028598" OutName="spot00_sceneTex_028598" Format="rgba16" Width="64" Height="32" Offset="0x28598" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_029598" OutName="spot00_sceneTex_029598" Format="i4" Width="64" Height="64" Offset="0x29598" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_029D98" OutName="spot00_sceneTex_029D98" Format="i4" Width="32" Height="32" Offset="0x29D98" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_029F98" OutName="spot00_sceneTex_029F98" Format="i4" Width="32" Height="32" Offset="0x29F98" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTLUT_013D70" OutName="spot00_sceneTLUT_013D70" Format="rgba16" Width="4" Height="4" Offset="0x13D70" AddedByScript="true"/>
         <Cutscene Name="gHyruleFieldGetOoTCs" Offset="0xBB80"/>
         <Cutscene Name="gHyruleFieldZeldaSongOfTimeCs" Offset="0xF870"/>
         <Cutscene Name="gHyruleFieldEastEponaJumpCs" Offset="0xFF00"/>

--- a/soh/assets/xml/GC_MQ_D/scenes/overworld/spot01.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/overworld/spot01.xml
@@ -1,5 +1,43 @@
 <Root>
     <File Name="spot01_scene" Segment="2">
+        <Texture Name="spot01_sceneTex_00AA50" OutName="spot01_sceneTex_00AA50" Format="rgba16" Width="32" Height="32" Offset="0xAA50" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00B250" OutName="spot01_sceneTex_00B250" Format="ci8" Width="16" Height="16" Offset="0xB250" TlutOffset="0xA870" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00B350" OutName="spot01_sceneTex_00B350" Format="ci8" Width="16" Height="64" Offset="0xB350" TlutOffset="0xA870" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00B750" OutName="spot01_sceneTex_00B750" Format="ci8" Width="32" Height="32" Offset="0xB750" TlutOffset="0xA870" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00BB50" OutName="spot01_sceneTex_00BB50" Format="rgba16" Width="16" Height="32" Offset="0xBB50" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00BF50" OutName="spot01_sceneTex_00BF50" Format="rgba16" Width="32" Height="32" Offset="0xBF50" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00C750" OutName="spot01_sceneTex_00C750" Format="ci8" Width="16" Height="32" Offset="0xC750" TlutOffset="0xA870" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00C950" OutName="spot01_sceneTex_00C950" Format="ci8" Width="32" Height="32" Offset="0xC950" TlutOffset="0xA870" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00CD50" OutName="spot01_sceneTex_00CD50" Format="ci8" Width="32" Height="64" Offset="0xCD50" TlutOffset="0xA870" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00D550" OutName="spot01_sceneTex_00D550" Format="i4" Width="64" Height="64" Offset="0xD550" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00DD50" OutName="spot01_sceneTex_00DD50" Format="i4" Width="64" Height="64" Offset="0xDD50" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00E550" OutName="spot01_sceneTex_00E550" Format="ci8" Width="32" Height="64" Offset="0xE550" TlutOffset="0xA870" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00ED50" OutName="spot01_sceneTex_00ED50" Format="ci4" Width="64" Height="64" Offset="0xED50" TlutOffset="0xAA28" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00F550" OutName="spot01_sceneTex_00F550" Format="rgba16" Width="32" Height="16" Offset="0xF550" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00F950" OutName="spot01_sceneTex_00F950" Format="rgba16" Width="32" Height="32" Offset="0xF950" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_010150" OutName="spot01_sceneTex_010150" Format="rgba16" Width="32" Height="32" Offset="0x10150" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_010950" OutName="spot01_sceneTex_010950" Format="rgba16" Width="32" Height="64" Offset="0x10950" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_011950" OutName="spot01_sceneTex_011950" Format="rgba16" Width="32" Height="64" Offset="0x11950" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_012950" OutName="spot01_sceneTex_012950" Format="ci8" Width="16" Height="32" Offset="0x12950" TlutOffset="0xA870" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_012B50" OutName="spot01_sceneTex_012B50" Format="rgba16" Width="64" Height="32" Offset="0x12B50" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_013B50" OutName="spot01_sceneTex_013B50" Format="rgba16" Width="16" Height="64" Offset="0x13B50" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_014350" OutName="spot01_sceneTex_014350" Format="ia4" Width="64" Height="32" Offset="0x14350" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_014750" OutName="spot01_sceneTex_014750" Format="ia4" Width="64" Height="32" Offset="0x14750" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_014B50" OutName="spot01_sceneTex_014B50" Format="ci8" Width="32" Height="32" Offset="0x14B50" TlutOffset="0xA870" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_014F50" OutName="spot01_sceneTex_014F50" Format="ci8" Width="64" Height="16" Offset="0x14F50" TlutOffset="0xA870" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_015350" OutName="spot01_sceneTex_015350" Format="ia4" Width="64" Height="64" Offset="0x15350" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_017B50" OutName="spot01_sceneTex_017B50" Format="ci8" Width="32" Height="64" Offset="0x17B50" TlutOffset="0xA870" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_018350" OutName="spot01_sceneTex_018350" Format="i4" Width="64" Height="64" Offset="0x18350" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_018B50" OutName="spot01_sceneTex_018B50" Format="rgba16" Width="32" Height="32" Offset="0x18B50" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_019350" OutName="spot01_sceneTex_019350" Format="rgba16" Width="32" Height="32" Offset="0x19350" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_019B50" OutName="spot01_sceneTex_019B50" Format="ci8" Width="32" Height="32" Offset="0x19B50" TlutOffset="0xA870" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_019F50" OutName="spot01_sceneTex_019F50" Format="rgba16" Width="32" Height="32" Offset="0x19F50" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_01A750" OutName="spot01_sceneTex_01A750" Format="i4" Width="64" Height="64" Offset="0x1A750" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_01AF50" OutName="spot01_sceneTex_01AF50" Format="rgba16" Width="16" Height="64" Offset="0x1AF50" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_01B750" OutName="spot01_sceneTex_01B750" Format="rgba16" Width="32" Height="32" Offset="0x1B750" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_01BF50" OutName="spot01_sceneTex_01BF50" Format="ci8" Width="16" Height="32" Offset="0x1BF50" TlutOffset="0xA870" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTLUT_00A870" OutName="spot01_sceneTLUT_00A870" Format="rgba16" Width="16" Height="16" Offset="0xA870" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTLUT_00AA28" OutName="spot01_sceneTLUT_00AA28" Format="rgba16" Width="4" Height="4" Offset="0xAA28" AddedByScript="true"/>
         <Path Name="spot01_scenePathList_0003D0" Offset="0x03D0" NumPaths="3"/>
         <Cutscene Name="gKakarikoVillageIntroCs" Offset="0xA540"/>
         <Texture Name="gKakarikoVillageDayWindowTex" OutName="day_window" Format="rgba16" Width="32" Height="64" Offset="0x15B50"/>

--- a/soh/assets/xml/GC_MQ_D/scenes/overworld/spot02.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/overworld/spot02.xml
@@ -1,5 +1,16 @@
 <Root>
     <File Name="spot02_scene" Segment="2">
+        <Texture Name="spot02_sceneTex_007280" OutName="spot02_sceneTex_007280" Format="rgba16" Width="32" Height="32" Offset="0x7280" AddedByScript="true"/>
+        <Texture Name="spot02_sceneTex_007A80" OutName="spot02_sceneTex_007A80" Format="rgba16" Width="32" Height="16" Offset="0x7A80" AddedByScript="true"/>
+        <Texture Name="spot02_sceneTex_007E80" OutName="spot02_sceneTex_007E80" Format="rgba16" Width="32" Height="32" Offset="0x7E80" AddedByScript="true"/>
+        <Texture Name="spot02_sceneTex_008680" OutName="spot02_sceneTex_008680" Format="rgba16" Width="16" Height="64" Offset="0x8680" AddedByScript="true"/>
+        <Texture Name="spot02_sceneTex_008E80" OutName="spot02_sceneTex_008E80" Format="i8" Width="64" Height="64" Offset="0x8E80" AddedByScript="true"/>
+        <Texture Name="spot02_sceneTex_009E80" OutName="spot02_sceneTex_009E80" Format="ia4" Width="32" Height="64" Offset="0x9E80" AddedByScript="true"/>
+        <Texture Name="spot02_sceneTex_00A280" OutName="spot02_sceneTex_00A280" Format="rgba16" Width="32" Height="32" Offset="0xA280" AddedByScript="true"/>
+        <Texture Name="spot02_sceneTex_00AA80" OutName="spot02_sceneTex_00AA80" Format="rgba16" Width="32" Height="16" Offset="0xAA80" AddedByScript="true"/>
+        <Texture Name="spot02_sceneTex_00AE80" OutName="spot02_sceneTex_00AE80" Format="i4" Width="32" Height="32" Offset="0xAE80" AddedByScript="true"/>
+        <Texture Name="spot02_sceneTex_00B080" OutName="spot02_sceneTex_00B080" Format="rgba16" Width="32" Height="32" Offset="0xB080" AddedByScript="true"/>
+        <Texture Name="spot02_sceneTex_00B880" OutName="spot02_sceneTex_00B880" Format="rgba16" Width="16" Height="32" Offset="0xB880" AddedByScript="true"/>
         <Scene Name="spot02_scene" Offset="0x0"/>
 
         <Cutscene Name="spot02_scene_Cs_003C80" Offset="0x3C80"/>
@@ -12,6 +23,42 @@
         <Room Name="spot02_room_0" Offset="0x0"/>
     </File>
     <File Name="spot02_room_1" Segment="3">
+        <Texture Name="spot02_room_1Tex_008F08" OutName="spot02_room_1Tex_008F08" Format="rgba16" Width="32" Height="32" Offset="0x8F08" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_009708" OutName="spot02_room_1Tex_009708" Format="rgba16" Width="16" Height="16" Offset="0x9708" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_009908" OutName="spot02_room_1Tex_009908" Format="rgba16" Width="64" Height="32" Offset="0x9908" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_00A908" OutName="spot02_room_1Tex_00A908" Format="rgba16" Width="32" Height="32" Offset="0xA908" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_00B108" OutName="spot02_room_1Tex_00B108" Format="rgba16" Width="32" Height="64" Offset="0xB108" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_00C108" OutName="spot02_room_1Tex_00C108" Format="rgba16" Width="16" Height="32" Offset="0xC108" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_00C508" OutName="spot02_room_1Tex_00C508" Format="ci4" Width="64" Height="64" Offset="0xC508" TlutOffset="0x8EB8" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_00CD08" OutName="spot02_room_1Tex_00CD08" Format="rgba16" Width="64" Height="32" Offset="0xCD08" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_00DD08" OutName="spot02_room_1Tex_00DD08" Format="ia8" Width="32" Height="32" Offset="0xDD08" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_00E108" OutName="spot02_room_1Tex_00E108" Format="rgba16" Width="16" Height="16" Offset="0xE108" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_00E308" OutName="spot02_room_1Tex_00E308" Format="rgba16" Width="32" Height="32" Offset="0xE308" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_00EB08" OutName="spot02_room_1Tex_00EB08" Format="rgba16" Width="16" Height="64" Offset="0xEB08" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_00F308" OutName="spot02_room_1Tex_00F308" Format="rgba16" Width="32" Height="64" Offset="0xF308" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_010308" OutName="spot02_room_1Tex_010308" Format="rgba16" Width="32" Height="32" Offset="0x10308" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_010B08" OutName="spot02_room_1Tex_010B08" Format="rgba16" Width="16" Height="16" Offset="0x10B08" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_010D08" OutName="spot02_room_1Tex_010D08" Format="rgba16" Width="32" Height="32" Offset="0x10D08" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_011508" OutName="spot02_room_1Tex_011508" Format="ia8" Width="64" Height="64" Offset="0x11508" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_012508" OutName="spot02_room_1Tex_012508" Format="rgba16" Width="32" Height="32" Offset="0x12508" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_012D08" OutName="spot02_room_1Tex_012D08" Format="rgba16" Width="32" Height="32" Offset="0x12D08" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_013508" OutName="spot02_room_1Tex_013508" Format="rgba16" Width="32" Height="64" Offset="0x13508" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_014508" OutName="spot02_room_1Tex_014508" Format="ci4" Width="64" Height="64" Offset="0x14508" TlutOffset="0x8EE0" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_014D08" OutName="spot02_room_1Tex_014D08" Format="rgba16" Width="128" Height="16" Offset="0x14D08" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_015D08" OutName="spot02_room_1Tex_015D08" Format="i8" Width="64" Height="64" Offset="0x15D08" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_016D08" OutName="spot02_room_1Tex_016D08" Format="i4" Width="16" Height="16" Offset="0x16D08" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_016D88" OutName="spot02_room_1Tex_016D88" Format="rgba16" Width="32" Height="32" Offset="0x16D88" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_017588" OutName="spot02_room_1Tex_017588" Format="rgba16" Width="32" Height="16" Offset="0x17588" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_017988" OutName="spot02_room_1Tex_017988" Format="ia8" Width="128" Height="32" Offset="0x17988" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_018988" OutName="spot02_room_1Tex_018988" Format="rgba16" Width="32" Height="64" Offset="0x18988" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_01B690" OutName="spot02_room_1Tex_01B690" Format="ia8" Width="64" Height="32" Offset="0x1B690" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_01BE90" OutName="spot02_room_1Tex_01BE90" Format="ia8" Width="32" Height="32" Offset="0x1BE90" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_01C290" OutName="spot02_room_1Tex_01C290" Format="ia8" Width="32" Height="32" Offset="0x1C290" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_01C690" OutName="spot02_room_1Tex_01C690" Format="ia8" Width="16" Height="16" Offset="0x1C690" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_01C790" OutName="spot02_room_1Tex_01C790" Format="ia8" Width="64" Height="64" Offset="0x1C790" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_01D790" OutName="spot02_room_1Tex_01D790" Format="ia8" Width="32" Height="64" Offset="0x1D790" AddedByScript="true"/>
+        <Texture Name="spot02_room_1TLUT_008EB8" OutName="spot02_room_1TLUT_008EB8" Format="rgba16" Width="4" Height="4" Offset="0x8EB8" AddedByScript="true"/>
+        <Texture Name="spot02_room_1TLUT_008EE0" OutName="spot02_room_1TLUT_008EE0" Format="rgba16" Width="4" Height="4" Offset="0x8EE0" AddedByScript="true"/>
         <Room Name="spot02_room_1" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_MQ_D/scenes/overworld/spot03.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/overworld/spot03.xml
@@ -1,14 +1,40 @@
 <Root>
     <File Name="spot03_scene" Segment="2">
+        <Texture Name="spot03_sceneTex_006D58" OutName="spot03_sceneTex_006D58" Format="ci8" Width="16" Height="64" Offset="0x6D58" TlutOffset="0x6920" AddedByScript="true"/>
+        <Texture Name="spot03_sceneTex_007158" OutName="spot03_sceneTex_007158" Format="rgba16" Width="16" Height="32" Offset="0x7158" AddedByScript="true"/>
+        <Texture Name="spot03_sceneTex_007558" OutName="spot03_sceneTex_007558" Format="rgba16" Width="32" Height="16" Offset="0x7558" AddedByScript="true"/>
+        <Texture Name="spot03_sceneTex_007958" OutName="spot03_sceneTex_007958" Format="ci8" Width="32" Height="32" Offset="0x7958" TlutOffset="0x6B28" AddedByScript="true"/>
+        <Texture Name="spot03_sceneTex_007D58" OutName="spot03_sceneTex_007D58" Format="rgba16" Width="32" Height="32" Offset="0x7D58" AddedByScript="true"/>
+        <Texture Name="spot03_sceneTex_008558" OutName="spot03_sceneTex_008558" Format="ci8" Width="32" Height="64" Offset="0x8558" TlutOffset="0x6B28" AddedByScript="true"/>
+        <Texture Name="spot03_sceneTex_008D58" OutName="spot03_sceneTex_008D58" Format="rgba16" Width="32" Height="32" Offset="0x8D58" AddedByScript="true"/>
+        <Texture Name="spot03_sceneTex_009558" OutName="spot03_sceneTex_009558" Format="ci4" Width="64" Height="64" Offset="0x9558" TlutOffset="0x6D30" AddedByScript="true"/>
+        <Texture Name="spot03_sceneTex_009D58" OutName="spot03_sceneTex_009D58" Format="rgba16" Width="32" Height="32" Offset="0x9D58" AddedByScript="true"/>
+        <Texture Name="spot03_sceneTex_00A558" OutName="spot03_sceneTex_00A558" Format="rgba16" Width="32" Height="32" Offset="0xA558" AddedByScript="true"/>
+        <Texture Name="spot03_sceneTex_00AD58" OutName="spot03_sceneTex_00AD58" Format="ia4" Width="64" Height="64" Offset="0xAD58" AddedByScript="true"/>
+        <Texture Name="spot03_sceneTLUT_006920" OutName="spot03_sceneTLUT_006920" Format="rgba16" Width="16" Height="16" Offset="0x6920" AddedByScript="true"/>
+        <Texture Name="spot03_sceneTLUT_006B28" OutName="spot03_sceneTLUT_006B28" Format="rgba16" Width="16" Height="16" Offset="0x6B28" AddedByScript="true"/>
+        <Texture Name="spot03_sceneTLUT_006D30" OutName="spot03_sceneTLUT_006D30" Format="rgba16" Width="4" Height="4" Offset="0x6D30" AddedByScript="true"/>
         <Path Name="spot03_scenePathList_0002BC" Offset="0x02BC" NumPaths="2"/>
         <Path Name="spot03_scenePathList_006908" Offset="0x6908" NumPaths="3"/>
 
         <Scene Name="spot03_scene" Offset="0x0"/>
     </File>
     <File Name="spot03_room_0" Segment="3">
+        <Texture Name="spot03_room_0Tex_0097B0" OutName="spot03_room_0Tex_0097B0" Format="ci8" Width="32" Height="32" Offset="0x97B0" ExternalTlut="spot03_scene" ExternalTlutOffset="0x6B28" AddedByScript="true"/>
+        <Texture Name="spot03_room_0Tex_009BB0" OutName="spot03_room_0Tex_009BB0" Format="ci8" Width="32" Height="64" Offset="0x9BB0" ExternalTlut="spot03_scene" ExternalTlutOffset="0x6B28" AddedByScript="true"/>
+        <Texture Name="spot03_room_0Tex_00A3B0" OutName="spot03_room_0Tex_00A3B0" Format="rgba16" Width="16" Height="64" Offset="0xA3B0" AddedByScript="true"/>
+        <Texture Name="spot03_room_0Tex_00ABB0" OutName="spot03_room_0Tex_00ABB0" Format="rgba16" Width="64" Height="32" Offset="0xABB0" AddedByScript="true"/>
+        <Texture Name="spot03_room_0Tex_00BBB0" OutName="spot03_room_0Tex_00BBB0" Format="ci8" Width="32" Height="32" Offset="0xBBB0" ExternalTlut="spot03_scene" ExternalTlutOffset="0x6B28" AddedByScript="true"/>
+        <Texture Name="spot03_room_0Tex_00BFB0" OutName="spot03_room_0Tex_00BFB0" Format="ci8" Width="32" Height="32" Offset="0xBFB0" ExternalTlut="spot03_scene" ExternalTlutOffset="0x6B28" AddedByScript="true"/>
+        <Texture Name="spot03_room_0Tex_00D180" OutName="spot03_room_0Tex_00D180" Format="i4" Width="64" Height="64" Offset="0xD180" AddedByScript="true"/>
         <Room Name="spot03_room_0" Offset="0x0"/>
     </File>
     <File Name="spot03_room_1" Segment="3">
+        <Texture Name="spot03_room_1Tex_0050D8" OutName="spot03_room_1Tex_0050D8" Format="ci8" Width="64" Height="32" Offset="0x50D8" ExternalTlut="spot03_scene" ExternalTlutOffset="0x6920" AddedByScript="true"/>
+        <Texture Name="spot03_room_1Tex_0058D8" OutName="spot03_room_1Tex_0058D8" Format="ci8" Width="64" Height="16" Offset="0x58D8" ExternalTlut="spot03_scene" ExternalTlutOffset="0x6920" AddedByScript="true"/>
+        <Texture Name="spot03_room_1Tex_005CD8" OutName="spot03_room_1Tex_005CD8" Format="ci8" Width="32" Height="16" Offset="0x5CD8" ExternalTlut="spot03_scene" ExternalTlutOffset="0x6920" AddedByScript="true"/>
+        <Texture Name="spot03_room_1Tex_005ED8" OutName="spot03_room_1Tex_005ED8" Format="ci8" Width="16" Height="64" Offset="0x5ED8" ExternalTlut="spot03_scene" ExternalTlutOffset="0x6920" AddedByScript="true"/>
+        <Texture Name="spot03_room_1Tex_0062D8" OutName="spot03_room_1Tex_0062D8" Format="ci8" Width="64" Height="32" Offset="0x62D8" ExternalTlut="spot03_scene" ExternalTlutOffset="0x6920" AddedByScript="true"/>
         <DList Name="gSpot03DL_0074E8" Offset="0x74E8"/>
         <Room Name="spot03_room_1" Offset="0x0"/>
     </File>

--- a/soh/assets/xml/GC_MQ_D/scenes/overworld/spot04.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/overworld/spot04.xml
@@ -1,5 +1,12 @@
 <Root>
     <File Name="spot04_scene" Segment="2">
+        <Texture Name="spot04_sceneTex_00E218" OutName="spot04_sceneTex_00E218" Format="rgba16" Width="32" Height="32" Offset="0xE218" AddedByScript="true"/>
+        <Texture Name="spot04_sceneTex_00EA18" OutName="spot04_sceneTex_00EA18" Format="i4" Width="64" Height="64" Offset="0xEA18" AddedByScript="true"/>
+        <Texture Name="spot04_sceneTex_00F218" OutName="spot04_sceneTex_00F218" Format="i4" Width="64" Height="64" Offset="0xF218" AddedByScript="true"/>
+        <Texture Name="spot04_sceneTex_00FA18" OutName="spot04_sceneTex_00FA18" Format="ci8" Width="32" Height="32" Offset="0xFA18" TlutOffset="0xE010" AddedByScript="true"/>
+        <Texture Name="spot04_sceneTex_00FE18" OutName="spot04_sceneTex_00FE18" Format="rgba16" Width="32" Height="32" Offset="0xFE18" AddedByScript="true"/>
+        <Texture Name="spot04_sceneTex_010618" OutName="spot04_sceneTex_010618" Format="rgba16" Width="32" Height="32" Offset="0x10618" AddedByScript="true"/>
+        <Texture Name="spot04_sceneTLUT_00E010" OutName="spot04_sceneTLUT_00E010" Format="rgba16" Width="16" Height="16" Offset="0xE010" AddedByScript="true"/>
         <Path Name="spot04_scenePathList_00030C" Offset="0x030C" NumPaths="3"/>
         <Path Name="spot04_scenePathList_00D728" Offset="0xD728" NumPaths="2"/>
         <Cutscene Name="gKokiriForestDekuSproutCs" Offset="0xC9D0"/>
@@ -8,12 +15,65 @@
         <Scene Name="spot04_scene" Offset="0x0"/>
     </File>
     <File Name="spot04_room_0" Segment="3">
+        <Texture Name="spot04_room_0Tex_00BF08" OutName="spot04_room_0Tex_00BF08" Format="rgba16" Width="32" Height="32" Offset="0xBF08" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_00C708" OutName="spot04_room_0Tex_00C708" Format="rgba16" Width="32" Height="16" Offset="0xC708" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_00CB08" OutName="spot04_room_0Tex_00CB08" Format="rgba16" Width="32" Height="16" Offset="0xCB08" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_00CF08" OutName="spot04_room_0Tex_00CF08" Format="ci8" Width="32" Height="32" Offset="0xCF08" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE010" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_00D308" OutName="spot04_room_0Tex_00D308" Format="ci8" Width="16" Height="16" Offset="0xD308" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE010" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_00D408" OutName="spot04_room_0Tex_00D408" Format="ci8" Width="16" Height="16" Offset="0xD408" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE010" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_00D508" OutName="spot04_room_0Tex_00D508" Format="rgba16" Width="16" Height="32" Offset="0xD508" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_00D908" OutName="spot04_room_0Tex_00D908" Format="rgba16" Width="16" Height="64" Offset="0xD908" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_00E108" OutName="spot04_room_0Tex_00E108" Format="rgba16" Width="32" Height="32" Offset="0xE108" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_00E908" OutName="spot04_room_0Tex_00E908" Format="rgba16" Width="32" Height="32" Offset="0xE908" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_00F108" OutName="spot04_room_0Tex_00F108" Format="rgba16" Width="64" Height="8" Offset="0xF108" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_00F508" OutName="spot04_room_0Tex_00F508" Format="rgba16" Width="32" Height="32" Offset="0xF508" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_00FD08" OutName="spot04_room_0Tex_00FD08" Format="rgba16" Width="32" Height="64" Offset="0xFD08" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_010D08" OutName="spot04_room_0Tex_010D08" Format="rgba16" Width="32" Height="64" Offset="0x10D08" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_011D08" OutName="spot04_room_0Tex_011D08" Format="ci8" Width="16" Height="32" Offset="0x11D08" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE010" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_011F08" OutName="spot04_room_0Tex_011F08" Format="rgba16" Width="64" Height="32" Offset="0x11F08" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_012F08" OutName="spot04_room_0Tex_012F08" Format="ci8" Width="32" Height="16" Offset="0x12F08" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE010" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_013108" OutName="spot04_room_0Tex_013108" Format="ci8" Width="32" Height="16" Offset="0x13108" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE010" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_013308" OutName="spot04_room_0Tex_013308" Format="rgba16" Width="16" Height="32" Offset="0x13308" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_013708" OutName="spot04_room_0Tex_013708" Format="rgba16" Width="32" Height="32" Offset="0x13708" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_013F08" OutName="spot04_room_0Tex_013F08" Format="ci8" Width="32" Height="32" Offset="0x13F08" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE010" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_014308" OutName="spot04_room_0Tex_014308" Format="rgba16" Width="32" Height="32" Offset="0x14308" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_014B08" OutName="spot04_room_0Tex_014B08" Format="rgba16" Width="32" Height="32" Offset="0x14B08" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_015308" OutName="spot04_room_0Tex_015308" Format="rgba16" Width="64" Height="16" Offset="0x15308" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_015B08" OutName="spot04_room_0Tex_015B08" Format="ci8" Width="16" Height="32" Offset="0x15B08" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE010" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_015D08" OutName="spot04_room_0Tex_015D08" Format="ci8" Width="16" Height="64" Offset="0x15D08" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE010" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_016108" OutName="spot04_room_0Tex_016108" Format="ci8" Width="16" Height="64" Offset="0x16108" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE010" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_016508" OutName="spot04_room_0Tex_016508" Format="ci8" Width="32" Height="32" Offset="0x16508" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE010" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_016908" OutName="spot04_room_0Tex_016908" Format="ci8" Width="16" Height="64" Offset="0x16908" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE010" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_016D08" OutName="spot04_room_0Tex_016D08" Format="rgba16" Width="32" Height="16" Offset="0x16D08" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_017108" OutName="spot04_room_0Tex_017108" Format="rgba16" Width="32" Height="32" Offset="0x17108" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_018A90" OutName="spot04_room_0Tex_018A90" Format="rgba16" Width="32" Height="32" Offset="0x18A90" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_019290" OutName="spot04_room_0Tex_019290" Format="i4" Width="64" Height="64" Offset="0x19290" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_019A90" OutName="spot04_room_0Tex_019A90" Format="i4" Width="64" Height="64" Offset="0x19A90" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_01A290" OutName="spot04_room_0Tex_01A290" Format="ia8" Width="16" Height="32" Offset="0x1A290" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_01A490" OutName="spot04_room_0Tex_01A490" Format="ia4" Width="64" Height="64" Offset="0x1A490" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_01AC90" OutName="spot04_room_0Tex_01AC90" Format="ia4" Width="32" Height="32" Offset="0x1AC90" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_01AE90" OutName="spot04_room_0Tex_01AE90" Format="ia4" Width="32" Height="32" Offset="0x1AE90" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_01B090" OutName="spot04_room_0Tex_01B090" Format="rgba16" Width="16" Height="32" Offset="0x1B090" AddedByScript="true"/>
         <Room Name="spot04_room_0" Offset="0x0"/>
     </File>
     <File Name="spot04_room_1" Segment="3">
+        <Texture Name="spot04_room_1Tex_004EA8" OutName="spot04_room_1Tex_004EA8" Format="rgba16" Width="32" Height="16" Offset="0x4EA8" AddedByScript="true"/>
+        <Texture Name="spot04_room_1Tex_0052A8" OutName="spot04_room_1Tex_0052A8" Format="rgba16" Width="32" Height="16" Offset="0x52A8" AddedByScript="true"/>
+        <Texture Name="spot04_room_1Tex_0056A8" OutName="spot04_room_1Tex_0056A8" Format="rgba16" Width="64" Height="32" Offset="0x56A8" AddedByScript="true"/>
+        <Texture Name="spot04_room_1Tex_0066A8" OutName="spot04_room_1Tex_0066A8" Format="rgba16" Width="32" Height="32" Offset="0x66A8" AddedByScript="true"/>
+        <Texture Name="spot04_room_1Tex_006EA8" OutName="spot04_room_1Tex_006EA8" Format="rgba16" Width="32" Height="32" Offset="0x6EA8" AddedByScript="true"/>
+        <Texture Name="spot04_room_1Tex_007B78" OutName="spot04_room_1Tex_007B78" Format="ia8" Width="16" Height="32" Offset="0x7B78" AddedByScript="true"/>
+        <Texture Name="spot04_room_1Tex_007D78" OutName="spot04_room_1Tex_007D78" Format="i4" Width="64" Height="64" Offset="0x7D78" AddedByScript="true"/>
         <Room Name="spot04_room_1" Offset="0x0"/>
     </File>
     <File Name="spot04_room_2" Segment="3">
+        <Texture Name="spot04_room_2Tex_002BF8" OutName="spot04_room_2Tex_002BF8" Format="ci8" Width="32" Height="16" Offset="0x2BF8" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE010" AddedByScript="true"/>
+        <Texture Name="spot04_room_2Tex_002DF8" OutName="spot04_room_2Tex_002DF8" Format="ci8" Width="32" Height="16" Offset="0x2DF8" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE010" AddedByScript="true"/>
+        <Texture Name="spot04_room_2Tex_002FF8" OutName="spot04_room_2Tex_002FF8" Format="ci8" Width="32" Height="32" Offset="0x2FF8" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE010" AddedByScript="true"/>
+        <Texture Name="spot04_room_2Tex_0033F8" OutName="spot04_room_2Tex_0033F8" Format="rgba16" Width="32" Height="32" Offset="0x33F8" AddedByScript="true"/>
+        <Texture Name="spot04_room_2Tex_003BF8" OutName="spot04_room_2Tex_003BF8" Format="rgba16" Width="64" Height="16" Offset="0x3BF8" AddedByScript="true"/>
+        <Texture Name="spot04_room_2Tex_0043F8" OutName="spot04_room_2Tex_0043F8" Format="ci8" Width="16" Height="32" Offset="0x43F8" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE010" AddedByScript="true"/>
+        <Texture Name="spot04_room_2Tex_0045F8" OutName="spot04_room_2Tex_0045F8" Format="rgba16" Width="32" Height="32" Offset="0x45F8" AddedByScript="true"/>
         <DList Name="gSpot04DL_002BB8" Offset="0x2BB8"/>
         <DList Name="gSpot04DL_005058" Offset="0x5058"/>
         <Room Name="spot04_room_2" Offset="0x0"/>

--- a/soh/assets/xml/GC_MQ_D/scenes/overworld/spot05.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/overworld/spot05.xml
@@ -1,5 +1,32 @@
 <Root>
     <File Name="spot05_scene" Segment="2">
+        <Texture Name="spot05_sceneTex_006D60" OutName="spot05_sceneTex_006D60" Format="rgba16" Width="32" Height="64" Offset="0x6D60" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_007D60" OutName="spot05_sceneTex_007D60" Format="rgba16" Width="32" Height="64" Offset="0x7D60" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_008D60" OutName="spot05_sceneTex_008D60" Format="ci8" Width="32" Height="32" Offset="0x8D60" TlutOffset="0x6BC0" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_009160" OutName="spot05_sceneTex_009160" Format="ci8" Width="32" Height="32" Offset="0x9160" TlutOffset="0x6BC0" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_009560" OutName="spot05_sceneTex_009560" Format="rgba16" Width="16" Height="32" Offset="0x9560" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_009960" OutName="spot05_sceneTex_009960" Format="ci8" Width="64" Height="32" Offset="0x9960" TlutOffset="0x6BC0" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_00A160" OutName="spot05_sceneTex_00A160" Format="rgba16" Width="64" Height="32" Offset="0xA160" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_00B160" OutName="spot05_sceneTex_00B160" Format="rgba16" Width="32" Height="32" Offset="0xB160" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_00B960" OutName="spot05_sceneTex_00B960" Format="rgba16" Width="16" Height="16" Offset="0xB960" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_00BB60" OutName="spot05_sceneTex_00BB60" Format="rgba16" Width="16" Height="128" Offset="0xBB60" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_00CB60" OutName="spot05_sceneTex_00CB60" Format="rgba16" Width="32" Height="32" Offset="0xCB60" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_00D360" OutName="spot05_sceneTex_00D360" Format="i4" Width="64" Height="64" Offset="0xD360" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_00DB60" OutName="spot05_sceneTex_00DB60" Format="rgba16" Width="32" Height="32" Offset="0xDB60" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_00E360" OutName="spot05_sceneTex_00E360" Format="i4" Width="64" Height="64" Offset="0xE360" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_00EB60" OutName="spot05_sceneTex_00EB60" Format="rgba16" Width="64" Height="16" Offset="0xEB60" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_00F360" OutName="spot05_sceneTex_00F360" Format="rgba16" Width="32" Height="32" Offset="0xF360" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_00FB60" OutName="spot05_sceneTex_00FB60" Format="i4" Width="64" Height="64" Offset="0xFB60" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_010360" OutName="spot05_sceneTex_010360" Format="rgba16" Width="32" Height="32" Offset="0x10360" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_010B60" OutName="spot05_sceneTex_010B60" Format="rgba16" Width="32" Height="32" Offset="0x10B60" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_011360" OutName="spot05_sceneTex_011360" Format="rgba16" Width="32" Height="64" Offset="0x11360" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_012360" OutName="spot05_sceneTex_012360" Format="rgba16" Width="32" Height="32" Offset="0x12360" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_012B60" OutName="spot05_sceneTex_012B60" Format="rgba16" Width="32" Height="32" Offset="0x12B60" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_013360" OutName="spot05_sceneTex_013360" Format="rgba16" Width="32" Height="32" Offset="0x13360" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_013B60" OutName="spot05_sceneTex_013B60" Format="rgba16" Width="64" Height="16" Offset="0x13B60" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_014360" OutName="spot05_sceneTex_014360" Format="rgba16" Width="32" Height="32" Offset="0x14360" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_014B60" OutName="spot05_sceneTex_014B60" Format="ia8" Width="16" Height="32" Offset="0x14B60" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTLUT_006BC0" OutName="spot05_sceneTLUT_006BC0" Format="rgba16" Width="16" Height="16" Offset="0x6BC0" AddedByScript="true"/>
         <Cutscene Name="gMinuetCs" Offset="0x3F80"/>
 
         <Cutscene Name="spot05_scene_Cs_005730" Offset="0x5730"/>

--- a/soh/assets/xml/GC_MQ_D/scenes/overworld/spot06.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/overworld/spot06.xml
@@ -1,5 +1,48 @@
 <Root>
     <File Name="spot06_scene" Segment="2">
+        <Texture Name="spot06_sceneTex_007C38" OutName="spot06_sceneTex_007C38" Format="rgba16" Width="16" Height="32" Offset="0x7C38" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_008038" OutName="spot06_sceneTex_008038" Format="rgba16" Width="16" Height="32" Offset="0x8038" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_008438" OutName="spot06_sceneTex_008438" Format="rgba16" Width="16" Height="32" Offset="0x8438" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_008838" OutName="spot06_sceneTex_008838" Format="rgba16" Width="32" Height="64" Offset="0x8838" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_009838" OutName="spot06_sceneTex_009838" Format="rgba16" Width="8" Height="8" Offset="0x9838" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_0098B8" OutName="spot06_sceneTex_0098B8" Format="rgba16" Width="8" Height="32" Offset="0x98B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_009AB8" OutName="spot06_sceneTex_009AB8" Format="rgba16" Width="32" Height="64" Offset="0x9AB8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_00AAB8" OutName="spot06_sceneTex_00AAB8" Format="rgba16" Width="32" Height="16" Offset="0xAAB8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_00AEB8" OutName="spot06_sceneTex_00AEB8" Format="rgba16" Width="32" Height="32" Offset="0xAEB8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_00B6B8" OutName="spot06_sceneTex_00B6B8" Format="rgba16" Width="16" Height="32" Offset="0xB6B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_00BAB8" OutName="spot06_sceneTex_00BAB8" Format="ia8" Width="32" Height="32" Offset="0xBAB8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_00BEB8" OutName="spot06_sceneTex_00BEB8" Format="rgba16" Width="32" Height="16" Offset="0xBEB8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_00C2B8" OutName="spot06_sceneTex_00C2B8" Format="rgba16" Width="16" Height="16" Offset="0xC2B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_00C4B8" OutName="spot06_sceneTex_00C4B8" Format="rgba16" Width="32" Height="32" Offset="0xC4B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_00CCB8" OutName="spot06_sceneTex_00CCB8" Format="rgba16" Width="32" Height="64" Offset="0xCCB8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_00DCB8" OutName="spot06_sceneTex_00DCB8" Format="rgba16" Width="32" Height="64" Offset="0xDCB8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_00ECB8" OutName="spot06_sceneTex_00ECB8" Format="rgba16" Width="16" Height="64" Offset="0xECB8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_00F4B8" OutName="spot06_sceneTex_00F4B8" Format="rgba16" Width="16" Height="16" Offset="0xF4B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_00F6B8" OutName="spot06_sceneTex_00F6B8" Format="rgba16" Width="32" Height="32" Offset="0xF6B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_00FEB8" OutName="spot06_sceneTex_00FEB8" Format="rgba16" Width="32" Height="64" Offset="0xFEB8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_010EB8" OutName="spot06_sceneTex_010EB8" Format="rgba16" Width="32" Height="32" Offset="0x10EB8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_0116B8" OutName="spot06_sceneTex_0116B8" Format="rgba16" Width="32" Height="32" Offset="0x116B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_011EB8" OutName="spot06_sceneTex_011EB8" Format="rgba16" Width="16" Height="32" Offset="0x11EB8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_0122B8" OutName="spot06_sceneTex_0122B8" Format="rgba16" Width="32" Height="16" Offset="0x122B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_0126B8" OutName="spot06_sceneTex_0126B8" Format="rgba16" Width="32" Height="32" Offset="0x126B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_012EB8" OutName="spot06_sceneTex_012EB8" Format="rgba16" Width="8" Height="32" Offset="0x12EB8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_0130B8" OutName="spot06_sceneTex_0130B8" Format="rgba16" Width="32" Height="64" Offset="0x130B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_0140B8" OutName="spot06_sceneTex_0140B8" Format="rgba16" Width="16" Height="64" Offset="0x140B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_0148B8" OutName="spot06_sceneTex_0148B8" Format="rgba16" Width="16" Height="32" Offset="0x148B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_014CB8" OutName="spot06_sceneTex_014CB8" Format="rgba16" Width="32" Height="32" Offset="0x14CB8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_0154B8" OutName="spot06_sceneTex_0154B8" Format="rgba16" Width="16" Height="64" Offset="0x154B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_015CB8" OutName="spot06_sceneTex_015CB8" Format="rgba16" Width="16" Height="64" Offset="0x15CB8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_0164B8" OutName="spot06_sceneTex_0164B8" Format="rgba16" Width="32" Height="32" Offset="0x164B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_016CB8" OutName="spot06_sceneTex_016CB8" Format="rgba16" Width="16" Height="32" Offset="0x16CB8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_0170B8" OutName="spot06_sceneTex_0170B8" Format="rgba16" Width="32" Height="32" Offset="0x170B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_0178B8" OutName="spot06_sceneTex_0178B8" Format="rgba16" Width="16" Height="32" Offset="0x178B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_017CB8" OutName="spot06_sceneTex_017CB8" Format="ci4" Width="64" Height="64" Offset="0x17CB8" TlutOffset="0x7C10" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_0184B8" OutName="spot06_sceneTex_0184B8" Format="rgba16" Width="32" Height="32" Offset="0x184B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_018CB8" OutName="spot06_sceneTex_018CB8" Format="rgba16" Width="32" Height="32" Offset="0x18CB8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_0194B8" OutName="spot06_sceneTex_0194B8" Format="rgba16" Width="16" Height="128" Offset="0x194B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_01A4B8" OutName="spot06_sceneTex_01A4B8" Format="i4" Width="64" Height="64" Offset="0x1A4B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_01ACB8" OutName="spot06_sceneTex_01ACB8" Format="rgba16" Width="16" Height="32" Offset="0x1ACB8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTLUT_007C10" OutName="spot06_sceneTLUT_007C10" Format="rgba16" Width="4" Height="4" Offset="0x7C10" AddedByScript="true"/>
         <Cutscene Name="gLakeHyliaFireArrowsCS" Offset="0x7020"/>
         <Cutscene Name="gLakeHyliaOwlCs" Offset="0x1B0C0"/>
         <Path Name="spot06_scenePathList_007764" Offset="0x7764" NumPaths="2"/>

--- a/soh/assets/xml/GC_MQ_D/scenes/overworld/spot07.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/overworld/spot07.xml
@@ -1,5 +1,22 @@
 <Root>
     <File Name="spot07_scene" Segment="2">
+        <Texture Name="spot07_sceneTex_003F98" OutName="spot07_sceneTex_003F98" Format="rgba16" Width="32" Height="64" Offset="0x3F98" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_004F98" OutName="spot07_sceneTex_004F98" Format="ci4" Width="64" Height="32" Offset="0x4F98" TlutOffset="0x3F70" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_005398" OutName="spot07_sceneTex_005398" Format="ci4" Width="64" Height="32" Offset="0x5398" TlutOffset="0x3F70" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_005798" OutName="spot07_sceneTex_005798" Format="ci4" Width="64" Height="32" Offset="0x5798" TlutOffset="0x3F70" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_005B98" OutName="spot07_sceneTex_005B98" Format="ci4" Width="64" Height="32" Offset="0x5B98" TlutOffset="0x3F70" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_005F98" OutName="spot07_sceneTex_005F98" Format="ci4" Width="64" Height="32" Offset="0x5F98" TlutOffset="0x3F70" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_006398" OutName="spot07_sceneTex_006398" Format="ci4" Width="64" Height="32" Offset="0x6398" TlutOffset="0x3F70" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_006798" OutName="spot07_sceneTex_006798" Format="ci4" Width="64" Height="32" Offset="0x6798" TlutOffset="0x3F70" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_006B98" OutName="spot07_sceneTex_006B98" Format="ci4" Width="64" Height="32" Offset="0x6B98" TlutOffset="0x3F70" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_006F98" OutName="spot07_sceneTex_006F98" Format="rgba16" Width="32" Height="32" Offset="0x6F98" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_007798" OutName="spot07_sceneTex_007798" Format="ci4" Width="64" Height="32" Offset="0x7798" TlutOffset="0x3F70" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_007B98" OutName="spot07_sceneTex_007B98" Format="ci4" Width="64" Height="32" Offset="0x7B98" TlutOffset="0x3F70" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_007F98" OutName="spot07_sceneTex_007F98" Format="rgba16" Width="32" Height="32" Offset="0x7F98" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_008798" OutName="spot07_sceneTex_008798" Format="ia4" Width="64" Height="64" Offset="0x8798" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_009018" OutName="spot07_sceneTex_009018" Format="ci4" Width="64" Height="32" Offset="0x9018" TlutOffset="0x3F70" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_009418" OutName="spot07_sceneTex_009418" Format="ci4" Width="64" Height="32" Offset="0x9418" TlutOffset="0x3F70" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTLUT_003F70" OutName="spot07_sceneTLUT_003F70" Format="rgba16" Width="4" Height="4" Offset="0x3F70" AddedByScript="true"/>
         <Path Name="spot07_scenePathList_000234" Offset="0x234" NumPaths="2"/>
         <Cutscene Name="gZorasDomainIntroCs" Offset="0x3D70"/>
         <Texture Name="gZorasDomainDayEntranceTex" OutName="day_entrance" Format="ia8" Width="8" Height="8" Offset="0x8F98"/>
@@ -7,9 +24,24 @@
         <Scene Name="spot07_scene" Offset="0x0"/>
     </File>
     <File Name="spot07_room_0" Segment="3">
+        <Texture Name="spot07_room_0Tex_004748" OutName="spot07_room_0Tex_004748" Format="rgba16" Width="64" Height="16" Offset="0x4748" AddedByScript="true"/>
+        <Texture Name="spot07_room_0Tex_004F48" OutName="spot07_room_0Tex_004F48" Format="rgba16" Width="64" Height="16" Offset="0x4F48" AddedByScript="true"/>
+        <Texture Name="spot07_room_0Tex_005748" OutName="spot07_room_0Tex_005748" Format="rgba16" Width="16" Height="64" Offset="0x5748" AddedByScript="true"/>
         <Room Name="spot07_room_0" Offset="0x0"/>
     </File>
     <File Name="spot07_room_1" Segment="3">
+        <Texture Name="spot07_room_1Tex_0076D8" OutName="spot07_room_1Tex_0076D8" Format="rgba16" Width="32" Height="32" Offset="0x76D8" AddedByScript="true"/>
+        <Texture Name="spot07_room_1Tex_007ED8" OutName="spot07_room_1Tex_007ED8" Format="rgba16" Width="16" Height="64" Offset="0x7ED8" AddedByScript="true"/>
+        <Texture Name="spot07_room_1Tex_0086D8" OutName="spot07_room_1Tex_0086D8" Format="ci4" Width="64" Height="32" Offset="0x86D8" ExternalTlut="spot07_scene" ExternalTlutOffset="0x3F70" AddedByScript="true"/>
+        <Texture Name="spot07_room_1Tex_008AD8" OutName="spot07_room_1Tex_008AD8" Format="ci4" Width="32" Height="16" Offset="0x8AD8" ExternalTlut="spot07_scene" ExternalTlutOffset="0x3F70" AddedByScript="true"/>
+        <Texture Name="spot07_room_1Tex_008BD8" OutName="spot07_room_1Tex_008BD8" Format="ci4" Width="64" Height="32" Offset="0x8BD8" ExternalTlut="spot07_scene" ExternalTlutOffset="0x3F70" AddedByScript="true"/>
+        <Texture Name="spot07_room_1Tex_008FD8" OutName="spot07_room_1Tex_008FD8" Format="ci4" Width="64" Height="32" Offset="0x8FD8" ExternalTlut="spot07_scene" ExternalTlutOffset="0x3F70" AddedByScript="true"/>
+        <Texture Name="spot07_room_1Tex_0093D8" OutName="spot07_room_1Tex_0093D8" Format="ci4" Width="64" Height="32" Offset="0x93D8" ExternalTlut="spot07_scene" ExternalTlutOffset="0x3F70" AddedByScript="true"/>
+        <Texture Name="spot07_room_1Tex_0097D8" OutName="spot07_room_1Tex_0097D8" Format="ci4" Width="64" Height="32" Offset="0x97D8" ExternalTlut="spot07_scene" ExternalTlutOffset="0x3F70" AddedByScript="true"/>
+        <Texture Name="spot07_room_1Tex_009BD8" OutName="spot07_room_1Tex_009BD8" Format="rgba16" Width="32" Height="32" Offset="0x9BD8" AddedByScript="true"/>
+        <Texture Name="spot07_room_1Tex_00A3D8" OutName="spot07_room_1Tex_00A3D8" Format="rgba16" Width="32" Height="32" Offset="0xA3D8" AddedByScript="true"/>
+        <Texture Name="spot07_room_1Tex_00ABD8" OutName="spot07_room_1Tex_00ABD8" Format="rgba16" Width="16" Height="128" Offset="0xABD8" AddedByScript="true"/>
+        <Texture Name="spot07_room_1Tex_00C1A0" OutName="spot07_room_1Tex_00C1A0" Format="rgba16" Width="64" Height="16" Offset="0xC1A0" AddedByScript="true"/>
         <Room Name="spot07_room_1" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_MQ_D/scenes/overworld/spot08.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/overworld/spot08.xml
@@ -1,5 +1,32 @@
 <Root>
     <File Name="spot08_scene" Segment="2">
+        <Texture Name="spot08_sceneTex_004DA0" OutName="spot08_sceneTex_004DA0" Format="rgba16" Width="64" Height="32" Offset="0x4DA0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_005DA0" OutName="spot08_sceneTex_005DA0" Format="rgba16" Width="32" Height="16" Offset="0x5DA0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_0061A0" OutName="spot08_sceneTex_0061A0" Format="rgba16" Width="32" Height="32" Offset="0x61A0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_0069A0" OutName="spot08_sceneTex_0069A0" Format="rgba16" Width="32" Height="32" Offset="0x69A0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_0071A0" OutName="spot08_sceneTex_0071A0" Format="ia4" Width="256" Height="32" Offset="0x71A0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_0081A0" OutName="spot08_sceneTex_0081A0" Format="ci4" Width="128" Height="32" Offset="0x81A0" TlutOffset="0x4CC0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_0089A0" OutName="spot08_sceneTex_0089A0" Format="rgba16" Width="32" Height="32" Offset="0x89A0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_0091A0" OutName="spot08_sceneTex_0091A0" Format="rgba16" Width="16" Height="128" Offset="0x91A0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_00A1A0" OutName="spot08_sceneTex_00A1A0" Format="ci4" Width="128" Height="32" Offset="0xA1A0" TlutOffset="0x4CE8" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_00A9A0" OutName="spot08_sceneTex_00A9A0" Format="ci4" Width="64" Height="64" Offset="0xA9A0" TlutOffset="0x4D38" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_00B1A0" OutName="spot08_sceneTex_00B1A0" Format="ci4" Width="64" Height="64" Offset="0xB1A0" TlutOffset="0x4D10" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_00B9A0" OutName="spot08_sceneTex_00B9A0" Format="ci4" Width="64" Height="64" Offset="0xB9A0" TlutOffset="0x4D38" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_00C1A0" OutName="spot08_sceneTex_00C1A0" Format="rgba16" Width="64" Height="32" Offset="0xC1A0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_00D1A0" OutName="spot08_sceneTex_00D1A0" Format="i8" Width="64" Height="64" Offset="0xD1A0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_00E1A0" OutName="spot08_sceneTex_00E1A0" Format="rgba16" Width="32" Height="64" Offset="0xE1A0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_00F1A0" OutName="spot08_sceneTex_00F1A0" Format="ci4" Width="32" Height="128" Offset="0xF1A0" TlutOffset="0x4D60" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_00F9A0" OutName="spot08_sceneTex_00F9A0" Format="ci4" Width="64" Height="64" Offset="0xF9A0" TlutOffset="0x4D80" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_0101A0" OutName="spot08_sceneTex_0101A0" Format="i4" Width="64" Height="64" Offset="0x101A0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_0109A0" OutName="spot08_sceneTex_0109A0" Format="ia8" Width="16" Height="16" Offset="0x109A0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_010AA0" OutName="spot08_sceneTex_010AA0" Format="rgba16" Width="16" Height="32" Offset="0x10AA0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_010EA0" OutName="spot08_sceneTex_010EA0" Format="rgba16" Width="32" Height="32" Offset="0x10EA0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTLUT_004CC0" OutName="spot08_sceneTLUT_004CC0" Format="rgba16" Width="4" Height="4" Offset="0x4CC0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTLUT_004CE8" OutName="spot08_sceneTLUT_004CE8" Format="rgba16" Width="4" Height="4" Offset="0x4CE8" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTLUT_004D10" OutName="spot08_sceneTLUT_004D10" Format="rgba16" Width="4" Height="4" Offset="0x4D10" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTLUT_004D38" OutName="spot08_sceneTLUT_004D38" Format="rgba16" Width="4" Height="4" Offset="0x4D38" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTLUT_004D60" OutName="spot08_sceneTLUT_004D60" Format="rgba16" Width="4" Height="4" Offset="0x4D60" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTLUT_004D80" OutName="spot08_sceneTLUT_004D80" Format="rgba16" Width="4" Height="4" Offset="0x4D80" AddedByScript="true"/>
         <Cutscene Name="gZorasFountainIntroCs" Offset="0x4A80"/>
         <Scene Name="spot08_scene" Offset="0x0"/>
     </File>

--- a/soh/assets/xml/GC_MQ_D/scenes/overworld/spot09.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/overworld/spot09.xml
@@ -1,5 +1,26 @@
 <Root>
     <File Name="spot09_scene" Segment="2">
+        <Texture Name="spot09_sceneTex_003460" OutName="spot09_sceneTex_003460" Format="rgba16" Width="32" Height="64" Offset="0x3460" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_004460" OutName="spot09_sceneTex_004460" Format="rgba16" Width="64" Height="32" Offset="0x4460" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_005460" OutName="spot09_sceneTex_005460" Format="ci4" Width="32" Height="128" Offset="0x5460" TlutOffset="0x3440" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_005C60" OutName="spot09_sceneTex_005C60" Format="rgba16" Width="32" Height="32" Offset="0x5C60" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_006460" OutName="spot09_sceneTex_006460" Format="rgba16" Width="32" Height="32" Offset="0x6460" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_006C60" OutName="spot09_sceneTex_006C60" Format="i8" Width="16" Height="16" Offset="0x6C60" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_006D60" OutName="spot09_sceneTex_006D60" Format="rgba16" Width="16" Height="32" Offset="0x6D60" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_007160" OutName="spot09_sceneTex_007160" Format="rgba16" Width="64" Height="32" Offset="0x7160" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_008160" OutName="spot09_sceneTex_008160" Format="rgba16" Width="64" Height="32" Offset="0x8160" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_009160" OutName="spot09_sceneTex_009160" Format="rgba16" Width="32" Height="64" Offset="0x9160" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_00A160" OutName="spot09_sceneTex_00A160" Format="rgba16" Width="32" Height="32" Offset="0xA160" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_00A960" OutName="spot09_sceneTex_00A960" Format="rgba16" Width="32" Height="64" Offset="0xA960" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_00B960" OutName="spot09_sceneTex_00B960" Format="rgba16" Width="32" Height="32" Offset="0xB960" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_00C160" OutName="spot09_sceneTex_00C160" Format="rgba16" Width="64" Height="32" Offset="0xC160" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_00D160" OutName="spot09_sceneTex_00D160" Format="rgba16" Width="128" Height="16" Offset="0xD160" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_00E160" OutName="spot09_sceneTex_00E160" Format="rgba16" Width="32" Height="32" Offset="0xE160" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_00E960" OutName="spot09_sceneTex_00E960" Format="i4" Width="64" Height="64" Offset="0xE960" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_00F160" OutName="spot09_sceneTex_00F160" Format="i4" Width="32" Height="128" Offset="0xF160" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_00F960" OutName="spot09_sceneTex_00F960" Format="rgba16" Width="64" Height="32" Offset="0xF960" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_010960" OutName="spot09_sceneTex_010960" Format="rgba16" Width="32" Height="32" Offset="0x10960" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTLUT_003440" OutName="spot09_sceneTLUT_003440" Format="rgba16" Width="4" Height="4" Offset="0x3440" AddedByScript="true"/>
         <Cutscene Name="gGerudoValleyBridgeJumpFieldFortressCs" Offset="0x2AC0"/>
         <Cutscene Name="gGerudoValleyBridgeJumpFortressToFieldCs" Offset="0x230"/>
         <Cutscene Name="gGerudoValleyIntroCs" Offset="0x31E0"/>

--- a/soh/assets/xml/GC_MQ_D/scenes/overworld/spot10.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/overworld/spot10.xml
@@ -1,5 +1,13 @@
 <Root>
     <File Name="spot10_scene" Segment="2">
+        <Texture Name="spot10_sceneTex_00C230" OutName="spot10_sceneTex_00C230" Format="rgba16" Width="32" Height="32" Offset="0xC230" AddedByScript="true"/>
+        <Texture Name="spot10_sceneTex_00CA30" OutName="spot10_sceneTex_00CA30" Format="rgba16" Width="32" Height="32" Offset="0xCA30" AddedByScript="true"/>
+        <Texture Name="spot10_sceneTex_00D230" OutName="spot10_sceneTex_00D230" Format="i4" Width="64" Height="64" Offset="0xD230" AddedByScript="true"/>
+        <Texture Name="spot10_sceneTex_00DA30" OutName="spot10_sceneTex_00DA30" Format="rgba16" Width="32" Height="64" Offset="0xDA30" AddedByScript="true"/>
+        <Texture Name="spot10_sceneTex_00EA30" OutName="spot10_sceneTex_00EA30" Format="rgba16" Width="32" Height="32" Offset="0xEA30" AddedByScript="true"/>
+        <Texture Name="spot10_sceneTex_00F230" OutName="spot10_sceneTex_00F230" Format="rgba16" Width="16" Height="16" Offset="0xF230" AddedByScript="true"/>
+        <Texture Name="spot10_sceneTex_00F430" OutName="spot10_sceneTex_00F430" Format="rgba16" Width="32" Height="32" Offset="0xF430" AddedByScript="true"/>
+        <Texture Name="spot10_sceneTex_00FC30" OutName="spot10_sceneTex_00FC30" Format="rgba16" Width="32" Height="32" Offset="0xFC30" AddedByScript="true"/>
         <Path Name="spot10_scenePathList_00C080" Offset="0xC080" NumPaths="3"/>
 
         <Scene Name="spot10_scene" Offset="0x0"/>
@@ -8,21 +16,44 @@
         <Room Name="spot10_room_0" Offset="0x0"/>
     </File>
     <File Name="spot10_room_1" Segment="3">
+        <Texture Name="spot10_room_1Tex_003BA0" OutName="spot10_room_1Tex_003BA0" Format="rgba16" Width="16" Height="32" Offset="0x3BA0" AddedByScript="true"/>
+        <Texture Name="spot10_room_1Tex_003FA0" OutName="spot10_room_1Tex_003FA0" Format="rgba16" Width="32" Height="32" Offset="0x3FA0" AddedByScript="true"/>
+        <Texture Name="spot10_room_1Tex_0047A0" OutName="spot10_room_1Tex_0047A0" Format="rgba16" Width="32" Height="32" Offset="0x47A0" AddedByScript="true"/>
+        <Texture Name="spot10_room_1Tex_004FA0" OutName="spot10_room_1Tex_004FA0" Format="rgba16" Width="64" Height="32" Offset="0x4FA0" AddedByScript="true"/>
+        <Texture Name="spot10_room_1Tex_005FA0" OutName="spot10_room_1Tex_005FA0" Format="rgba16" Width="32" Height="32" Offset="0x5FA0" AddedByScript="true"/>
+        <Texture Name="spot10_room_1Tex_0067A0" OutName="spot10_room_1Tex_0067A0" Format="rgba16" Width="32" Height="32" Offset="0x67A0" AddedByScript="true"/>
+        <Texture Name="spot10_room_1Tex_006FA0" OutName="spot10_room_1Tex_006FA0" Format="rgba16" Width="64" Height="16" Offset="0x6FA0" AddedByScript="true"/>
+        <Texture Name="spot10_room_1Tex_007C30" OutName="spot10_room_1Tex_007C30" Format="ia8" Width="32" Height="32" Offset="0x7C30" AddedByScript="true"/>
+        <Texture Name="spot10_room_1Tex_008030" OutName="spot10_room_1Tex_008030" Format="ia16" Width="32" Height="16" Offset="0x8030" AddedByScript="true"/>
         <Room Name="spot10_room_1" Offset="0x0"/>
     </File>
     <File Name="spot10_room_2" Segment="3">
+        <Texture Name="spot10_room_2Tex_0023E8" OutName="spot10_room_2Tex_0023E8" Format="rgba16" Width="64" Height="32" Offset="0x23E8" AddedByScript="true"/>
+        <Texture Name="spot10_room_2Tex_0033E8" OutName="spot10_room_2Tex_0033E8" Format="rgba16" Width="64" Height="32" Offset="0x33E8" AddedByScript="true"/>
+        <Texture Name="spot10_room_2Tex_0043E8" OutName="spot10_room_2Tex_0043E8" Format="rgba16" Width="16" Height="64" Offset="0x43E8" AddedByScript="true"/>
         <Room Name="spot10_room_2" Offset="0x0"/>
     </File>
     <File Name="spot10_room_3" Segment="3">
+        <Texture Name="spot10_room_3Tex_0028F8" OutName="spot10_room_3Tex_0028F8" Format="rgba16" Width="64" Height="32" Offset="0x28F8" AddedByScript="true"/>
+        <Texture Name="spot10_room_3Tex_0038F8" OutName="spot10_room_3Tex_0038F8" Format="rgba16" Width="64" Height="32" Offset="0x38F8" AddedByScript="true"/>
+        <Texture Name="spot10_room_3Tex_0048F8" OutName="spot10_room_3Tex_0048F8" Format="rgba16" Width="16" Height="64" Offset="0x48F8" AddedByScript="true"/>
+        <Texture Name="spot10_room_3Tex_0052A8" OutName="spot10_room_3Tex_0052A8" Format="rgba16" Width="32" Height="32" Offset="0x52A8" AddedByScript="true"/>
         <Room Name="spot10_room_3" Offset="0x0"/>
     </File>
     <File Name="spot10_room_4" Segment="3">
         <Room Name="spot10_room_4" Offset="0x0"/>
     </File>
     <File Name="spot10_room_5" Segment="3">
+        <Texture Name="spot10_room_5Tex_0037F0" OutName="spot10_room_5Tex_0037F0" Format="rgba16" Width="32" Height="64" Offset="0x37F0" AddedByScript="true"/>
+        <Texture Name="spot10_room_5Tex_0047F0" OutName="spot10_room_5Tex_0047F0" Format="rgba16" Width="64" Height="32" Offset="0x47F0" AddedByScript="true"/>
+        <Texture Name="spot10_room_5Tex_0057F0" OutName="spot10_room_5Tex_0057F0" Format="rgba16" Width="64" Height="32" Offset="0x57F0" AddedByScript="true"/>
+        <Texture Name="spot10_room_5Tex_0067F0" OutName="spot10_room_5Tex_0067F0" Format="rgba16" Width="32" Height="32" Offset="0x67F0" AddedByScript="true"/>
         <Room Name="spot10_room_5" Offset="0x0"/>
     </File>
     <File Name="spot10_room_6" Segment="3">
+        <Texture Name="spot10_room_6Tex_0022E8" OutName="spot10_room_6Tex_0022E8" Format="rgba16" Width="32" Height="32" Offset="0x22E8" AddedByScript="true"/>
+        <Texture Name="spot10_room_6Tex_002AE8" OutName="spot10_room_6Tex_002AE8" Format="rgba16" Width="64" Height="16" Offset="0x2AE8" AddedByScript="true"/>
+        <Texture Name="spot10_room_6Tex_0032E8" OutName="spot10_room_6Tex_0032E8" Format="rgba16" Width="32" Height="32" Offset="0x32E8" AddedByScript="true"/>
         <Room Name="spot10_room_6" Offset="0x0"/>
     </File>
     <File Name="spot10_room_7" Segment="3">
@@ -32,6 +63,10 @@
         <Room Name="spot10_room_8" Offset="0x0"/>
     </File>
     <File Name="spot10_room_9" Segment="3">
+        <Texture Name="spot10_room_9Tex_001EF8" OutName="spot10_room_9Tex_001EF8" Format="rgba16" Width="32" Height="32" Offset="0x1EF8" AddedByScript="true"/>
+        <Texture Name="spot10_room_9Tex_0026F8" OutName="spot10_room_9Tex_0026F8" Format="rgba16" Width="32" Height="32" Offset="0x26F8" AddedByScript="true"/>
+        <Texture Name="spot10_room_9Tex_0033D8" OutName="spot10_room_9Tex_0033D8" Format="ia8" Width="32" Height="32" Offset="0x33D8" AddedByScript="true"/>
+        <Texture Name="spot10_room_9Tex_0037D8" OutName="spot10_room_9Tex_0037D8" Format="ia16" Width="32" Height="16" Offset="0x37D8" AddedByScript="true"/>
         <Room Name="spot10_room_9" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_MQ_D/scenes/overworld/spot11.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/overworld/spot11.xml
@@ -1,5 +1,37 @@
 <Root>
     <File Name="spot11_scene" Segment="2">
+        <Texture Name="spot11_sceneTex_007CA0" OutName="spot11_sceneTex_007CA0" Format="rgba16" Width="32" Height="32" Offset="0x7CA0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_0084A0" OutName="spot11_sceneTex_0084A0" Format="rgba16" Width="32" Height="32" Offset="0x84A0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_008CA0" OutName="spot11_sceneTex_008CA0" Format="rgba16" Width="16" Height="32" Offset="0x8CA0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_0090A0" OutName="spot11_sceneTex_0090A0" Format="rgba16" Width="128" Height="16" Offset="0x90A0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_00A0A0" OutName="spot11_sceneTex_00A0A0" Format="rgba16" Width="32" Height="32" Offset="0xA0A0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_00A8A0" OutName="spot11_sceneTex_00A8A0" Format="rgba16" Width="64" Height="32" Offset="0xA8A0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_00B8A0" OutName="spot11_sceneTex_00B8A0" Format="rgba16" Width="16" Height="32" Offset="0xB8A0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_00BCA0" OutName="spot11_sceneTex_00BCA0" Format="rgba16" Width="32" Height="32" Offset="0xBCA0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_00C4A0" OutName="spot11_sceneTex_00C4A0" Format="rgba16" Width="32" Height="32" Offset="0xC4A0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_00CCA0" OutName="spot11_sceneTex_00CCA0" Format="rgba16" Width="16" Height="64" Offset="0xCCA0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_00D4A0" OutName="spot11_sceneTex_00D4A0" Format="rgba16" Width="32" Height="32" Offset="0xD4A0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_00DCA0" OutName="spot11_sceneTex_00DCA0" Format="rgba16" Width="64" Height="32" Offset="0xDCA0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_00ECA0" OutName="spot11_sceneTex_00ECA0" Format="rgba16" Width="32" Height="32" Offset="0xECA0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_00F4A0" OutName="spot11_sceneTex_00F4A0" Format="rgba16" Width="32" Height="32" Offset="0xF4A0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_00FCA0" OutName="spot11_sceneTex_00FCA0" Format="ia8" Width="8" Height="8" Offset="0xFCA0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_00FCE0" OutName="spot11_sceneTex_00FCE0" Format="rgba16" Width="32" Height="32" Offset="0xFCE0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_0104E0" OutName="spot11_sceneTex_0104E0" Format="rgba16" Width="32" Height="32" Offset="0x104E0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_010CE0" OutName="spot11_sceneTex_010CE0" Format="rgba16" Width="32" Height="64" Offset="0x10CE0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_011CE0" OutName="spot11_sceneTex_011CE0" Format="rgba16" Width="32" Height="32" Offset="0x11CE0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_0124E0" OutName="spot11_sceneTex_0124E0" Format="rgba16" Width="32" Height="32" Offset="0x124E0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_012CE0" OutName="spot11_sceneTex_012CE0" Format="rgba16" Width="32" Height="32" Offset="0x12CE0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_0134E0" OutName="spot11_sceneTex_0134E0" Format="rgba16" Width="32" Height="32" Offset="0x134E0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_013CE0" OutName="spot11_sceneTex_013CE0" Format="rgba16" Width="32" Height="32" Offset="0x13CE0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_0144E0" OutName="spot11_sceneTex_0144E0" Format="rgba16" Width="32" Height="64" Offset="0x144E0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_0154E0" OutName="spot11_sceneTex_0154E0" Format="rgba16" Width="32" Height="32" Offset="0x154E0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_015CE0" OutName="spot11_sceneTex_015CE0" Format="rgba16" Width="32" Height="32" Offset="0x15CE0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_0164E0" OutName="spot11_sceneTex_0164E0" Format="ia4" Width="32" Height="128" Offset="0x164E0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_016CE0" OutName="spot11_sceneTex_016CE0" Format="rgba16" Width="32" Height="32" Offset="0x16CE0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_0174E0" OutName="spot11_sceneTex_0174E0" Format="rgba16" Width="16" Height="64" Offset="0x174E0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_017CE0" OutName="spot11_sceneTex_017CE0" Format="ia4" Width="64" Height="64" Offset="0x17CE0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_0184E0" OutName="spot11_sceneTex_0184E0" Format="rgba16" Width="32" Height="32" Offset="0x184E0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_018CE0" OutName="spot11_sceneTex_018CE0" Format="rgba16" Width="32" Height="32" Offset="0x18CE0" AddedByScript="true"/>
         <Cutscene Name="gDesertColossusIntroCs" Offset="0x7990"/>
         <Scene Name="spot11_scene" Offset="0x0"/>
     </File>

--- a/soh/assets/xml/GC_MQ_D/scenes/overworld/spot12.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/overworld/spot12.xml
@@ -1,5 +1,17 @@
 <Root>
     <File Name="spot12_scene" Segment="2">
+        <Texture Name="spot12_sceneTex_006678" OutName="spot12_sceneTex_006678" Format="rgba16" Width="32" Height="64" Offset="0x6678" AddedByScript="true"/>
+        <Texture Name="spot12_sceneTex_007678" OutName="spot12_sceneTex_007678" Format="rgba16" Width="32" Height="64" Offset="0x7678" AddedByScript="true"/>
+        <Texture Name="spot12_sceneTex_008678" OutName="spot12_sceneTex_008678" Format="rgba16" Width="32" Height="32" Offset="0x8678" AddedByScript="true"/>
+        <Texture Name="spot12_sceneTex_008E78" OutName="spot12_sceneTex_008E78" Format="ci4" Width="32" Height="128" Offset="0x8E78" TlutOffset="0x6650" AddedByScript="true"/>
+        <Texture Name="spot12_sceneTex_00A678" OutName="spot12_sceneTex_00A678" Format="rgba16" Width="64" Height="32" Offset="0xA678" AddedByScript="true"/>
+        <Texture Name="spot12_sceneTex_00B678" OutName="spot12_sceneTex_00B678" Format="rgba16" Width="32" Height="32" Offset="0xB678" AddedByScript="true"/>
+        <Texture Name="spot12_sceneTex_00BE78" OutName="spot12_sceneTex_00BE78" Format="rgba16" Width="64" Height="16" Offset="0xBE78" AddedByScript="true"/>
+        <Texture Name="spot12_sceneTex_00C678" OutName="spot12_sceneTex_00C678" Format="rgba16" Width="32" Height="32" Offset="0xC678" AddedByScript="true"/>
+        <Texture Name="spot12_sceneTex_00CE78" OutName="spot12_sceneTex_00CE78" Format="rgba16" Width="32" Height="32" Offset="0xCE78" AddedByScript="true"/>
+        <Texture Name="spot12_sceneTex_00D678" OutName="spot12_sceneTex_00D678" Format="rgba16" Width="32" Height="32" Offset="0xD678" AddedByScript="true"/>
+        <Texture Name="spot12_sceneTex_00EE78" OutName="spot12_sceneTex_00EE78" Format="rgba16" Width="64" Height="32" Offset="0xEE78" AddedByScript="true"/>
+        <Texture Name="spot12_sceneTLUT_006650" OutName="spot12_sceneTLUT_006650" Format="rgba16" Width="4" Height="4" Offset="0x6650" AddedByScript="true"/>
         <Cutscene Name="gGerudoFortressFirstCaptureCs" Offset="0x55C0"/>
         <Cutscene Name="gGerudoFortressIntroCs" Offset="0x6490"/>
         <Texture Name="gSpot12_009678Tex" Format="rgba16" Width="64" Height="32" Offset="0x9678"/>
@@ -7,9 +19,34 @@
         <Scene Name="spot12_scene" Offset="0x0"/>
     </File>
     <File Name="spot12_room_0" Segment="3">
+        <Texture Name="spot12_room_0Tex_008AB0" OutName="spot12_room_0Tex_008AB0" Format="rgba16" Width="32" Height="32" Offset="0x8AB0" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_0092B0" OutName="spot12_room_0Tex_0092B0" Format="rgba16" Width="32" Height="16" Offset="0x92B0" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_0096B0" OutName="spot12_room_0Tex_0096B0" Format="rgba16" Width="32" Height="32" Offset="0x96B0" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_009EB0" OutName="spot12_room_0Tex_009EB0" Format="rgba16" Width="32" Height="32" Offset="0x9EB0" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_00A6B0" OutName="spot12_room_0Tex_00A6B0" Format="rgba16" Width="64" Height="32" Offset="0xA6B0" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_00B6B0" OutName="spot12_room_0Tex_00B6B0" Format="rgba16" Width="32" Height="32" Offset="0xB6B0" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_00BEB0" OutName="spot12_room_0Tex_00BEB0" Format="rgba16" Width="32" Height="32" Offset="0xBEB0" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_00C6B0" OutName="spot12_room_0Tex_00C6B0" Format="ci4" Width="64" Height="32" Offset="0xC6B0" TlutOffset="0x8A90" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_00CAB0" OutName="spot12_room_0Tex_00CAB0" Format="rgba16" Width="16" Height="64" Offset="0xCAB0" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_00D2B0" OutName="spot12_room_0Tex_00D2B0" Format="rgba16" Width="64" Height="32" Offset="0xD2B0" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_00E2B0" OutName="spot12_room_0Tex_00E2B0" Format="rgba16" Width="32" Height="32" Offset="0xE2B0" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_00EAB0" OutName="spot12_room_0Tex_00EAB0" Format="rgba16" Width="32" Height="32" Offset="0xEAB0" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_00FD78" OutName="spot12_room_0Tex_00FD78" Format="ia8" Width="8" Height="8" Offset="0xFD78" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_00FDB8" OutName="spot12_room_0Tex_00FDB8" Format="rgba16" Width="16" Height="64" Offset="0xFDB8" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_0105B8" OutName="spot12_room_0Tex_0105B8" Format="rgba16" Width="32" Height="64" Offset="0x105B8" AddedByScript="true"/>
+        <Texture Name="spot12_room_0TLUT_008A90" OutName="spot12_room_0TLUT_008A90" Format="rgba16" Width="4" Height="4" Offset="0x8A90" AddedByScript="true"/>
         <Room Name="spot12_room_0" Offset="0x0"/>
     </File>
     <File Name="spot12_room_1" Segment="3">
+        <Texture Name="spot12_room_1Tex_005638" OutName="spot12_room_1Tex_005638" Format="rgba16" Width="32" Height="64" Offset="0x5638" AddedByScript="true"/>
+        <Texture Name="spot12_room_1Tex_006638" OutName="spot12_room_1Tex_006638" Format="rgba16" Width="32" Height="64" Offset="0x6638" AddedByScript="true"/>
+        <Texture Name="spot12_room_1Tex_007638" OutName="spot12_room_1Tex_007638" Format="rgba16" Width="32" Height="32" Offset="0x7638" AddedByScript="true"/>
+        <Texture Name="spot12_room_1Tex_007E38" OutName="spot12_room_1Tex_007E38" Format="rgba16" Width="64" Height="32" Offset="0x7E38" AddedByScript="true"/>
+        <Texture Name="spot12_room_1Tex_008E38" OutName="spot12_room_1Tex_008E38" Format="rgba16" Width="64" Height="32" Offset="0x8E38" AddedByScript="true"/>
+        <Texture Name="spot12_room_1Tex_009E38" OutName="spot12_room_1Tex_009E38" Format="rgba16" Width="32" Height="32" Offset="0x9E38" AddedByScript="true"/>
+        <Texture Name="spot12_room_1Tex_00A638" OutName="spot12_room_1Tex_00A638" Format="i4" Width="64" Height="64" Offset="0xA638" AddedByScript="true"/>
+        <Texture Name="spot12_room_1Tex_00B0A0" OutName="spot12_room_1Tex_00B0A0" Format="i8" Width="32" Height="64" Offset="0xB0A0" AddedByScript="true"/>
+        <Texture Name="spot12_room_1Tex_00B8A0" OutName="spot12_room_1Tex_00B8A0" Format="i8" Width="32" Height="64" Offset="0xB8A0" AddedByScript="true"/>
         <Room Name="spot12_room_1" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_MQ_D/scenes/overworld/spot13.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/overworld/spot13.xml
@@ -1,11 +1,39 @@
 <Root>
     <File Name="spot13_scene" Segment="2">
+        <Texture Name="spot13_sceneTex_003A30" OutName="spot13_sceneTex_003A30" Format="rgba16" Width="32" Height="16" Offset="0x3A30" AddedByScript="true"/>
+        <Texture Name="spot13_sceneTex_003E30" OutName="spot13_sceneTex_003E30" Format="rgba16" Width="32" Height="64" Offset="0x3E30" AddedByScript="true"/>
+        <Texture Name="spot13_sceneTex_004E30" OutName="spot13_sceneTex_004E30" Format="rgba16" Width="64" Height="32" Offset="0x4E30" AddedByScript="true"/>
         <Scene Name="spot13_scene" Offset="0x0"/>
     </File>
     <File Name="spot13_room_0" Segment="3">
         <Room Name="spot13_room_0" Offset="0x0"/>
     </File>
     <File Name="spot13_room_1" Segment="3">
+        <Texture Name="spot13_room_1Tex_007E08" OutName="spot13_room_1Tex_007E08" Format="rgba16" Width="32" Height="32" Offset="0x7E08" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_008608" OutName="spot13_room_1Tex_008608" Format="rgba16" Width="16" Height="32" Offset="0x8608" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_008A08" OutName="spot13_room_1Tex_008A08" Format="rgba16" Width="32" Height="64" Offset="0x8A08" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_009A08" OutName="spot13_room_1Tex_009A08" Format="rgba16" Width="16" Height="16" Offset="0x9A08" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_009C08" OutName="spot13_room_1Tex_009C08" Format="rgba16" Width="16" Height="16" Offset="0x9C08" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_009E08" OutName="spot13_room_1Tex_009E08" Format="rgba16" Width="32" Height="32" Offset="0x9E08" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_00A608" OutName="spot13_room_1Tex_00A608" Format="rgba16" Width="32" Height="16" Offset="0xA608" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_00AA08" OutName="spot13_room_1Tex_00AA08" Format="rgba16" Width="32" Height="16" Offset="0xAA08" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_00AE08" OutName="spot13_room_1Tex_00AE08" Format="ci4" Width="32" Height="128" Offset="0xAE08" TlutOffset="0x7DC0" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_00B608" OutName="spot13_room_1Tex_00B608" Format="rgba16" Width="16" Height="16" Offset="0xB608" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_00B808" OutName="spot13_room_1Tex_00B808" Format="ci4" Width="64" Height="32" Offset="0xB808" TlutOffset="0x7DE8" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_00BC08" OutName="spot13_room_1Tex_00BC08" Format="rgba16" Width="32" Height="32" Offset="0xBC08" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_00C408" OutName="spot13_room_1Tex_00C408" Format="rgba16" Width="8" Height="32" Offset="0xC408" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_00C608" OutName="spot13_room_1Tex_00C608" Format="rgba16" Width="64" Height="32" Offset="0xC608" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_00D608" OutName="spot13_room_1Tex_00D608" Format="rgba16" Width="32" Height="64" Offset="0xD608" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_00E608" OutName="spot13_room_1Tex_00E608" Format="rgba16" Width="32" Height="32" Offset="0xE608" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_00EE08" OutName="spot13_room_1Tex_00EE08" Format="rgba16" Width="32" Height="64" Offset="0xEE08" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_00FE08" OutName="spot13_room_1Tex_00FE08" Format="rgba16" Width="32" Height="32" Offset="0xFE08" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_010608" OutName="spot13_room_1Tex_010608" Format="rgba16" Width="32" Height="32" Offset="0x10608" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_010E08" OutName="spot13_room_1Tex_010E08" Format="rgba16" Width="32" Height="16" Offset="0x10E08" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_011208" OutName="spot13_room_1Tex_011208" Format="rgba16" Width="32" Height="32" Offset="0x11208" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_011E40" OutName="spot13_room_1Tex_011E40" Format="ia4" Width="64" Height="32" Offset="0x11E40" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_012240" OutName="spot13_room_1Tex_012240" Format="rgba16" Width="32" Height="32" Offset="0x12240" AddedByScript="true"/>
+        <Texture Name="spot13_room_1TLUT_007DC0" OutName="spot13_room_1TLUT_007DC0" Format="rgba16" Width="4" Height="4" Offset="0x7DC0" AddedByScript="true"/>
+        <Texture Name="spot13_room_1TLUT_007DE8" OutName="spot13_room_1TLUT_007DE8" Format="rgba16" Width="4" Height="4" Offset="0x7DE8" AddedByScript="true"/>
         <Room Name="spot13_room_1" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_MQ_D/scenes/overworld/spot15.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/overworld/spot15.xml
@@ -1,5 +1,48 @@
 <Root>
     <File Name="spot15_scene" Segment="2">
+        <Texture Name="spot15_sceneTex_004100" OutName="spot15_sceneTex_004100" Format="rgba16" Width="32" Height="32" Offset="0x4100" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_004900" OutName="spot15_sceneTex_004900" Format="ia4" Width="32" Height="16" Offset="0x4900" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_004A00" OutName="spot15_sceneTex_004A00" Format="ia8" Width="8" Height="64" Offset="0x4A00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_004C00" OutName="spot15_sceneTex_004C00" Format="rgba16" Width="16" Height="64" Offset="0x4C00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_005400" OutName="spot15_sceneTex_005400" Format="rgba16" Width="32" Height="64" Offset="0x5400" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_006400" OutName="spot15_sceneTex_006400" Format="ia8" Width="32" Height="8" Offset="0x6400" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_006500" OutName="spot15_sceneTex_006500" Format="rgba16" Width="32" Height="32" Offset="0x6500" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_006D00" OutName="spot15_sceneTex_006D00" Format="i4" Width="32" Height="32" Offset="0x6D00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_006F00" OutName="spot15_sceneTex_006F00" Format="ia4" Width="32" Height="64" Offset="0x6F00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_007300" OutName="spot15_sceneTex_007300" Format="ia4" Width="32" Height="128" Offset="0x7300" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_007B00" OutName="spot15_sceneTex_007B00" Format="ia4" Width="16" Height="32" Offset="0x7B00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_007C00" OutName="spot15_sceneTex_007C00" Format="rgba16" Width="32" Height="8" Offset="0x7C00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_007E00" OutName="spot15_sceneTex_007E00" Format="rgba16" Width="32" Height="64" Offset="0x7E00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_008E00" OutName="spot15_sceneTex_008E00" Format="rgba16" Width="32" Height="32" Offset="0x8E00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_009600" OutName="spot15_sceneTex_009600" Format="rgba16" Width="16" Height="16" Offset="0x9600" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_009800" OutName="spot15_sceneTex_009800" Format="ia8" Width="16" Height="16" Offset="0x9800" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_009900" OutName="spot15_sceneTex_009900" Format="rgba16" Width="32" Height="32" Offset="0x9900" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_00A100" OutName="spot15_sceneTex_00A100" Format="rgba16" Width="32" Height="32" Offset="0xA100" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_00A900" OutName="spot15_sceneTex_00A900" Format="rgba16" Width="64" Height="32" Offset="0xA900" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_00B900" OutName="spot15_sceneTex_00B900" Format="ia8" Width="16" Height="16" Offset="0xB900" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_00BA00" OutName="spot15_sceneTex_00BA00" Format="rgba16" Width="32" Height="32" Offset="0xBA00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_00C200" OutName="spot15_sceneTex_00C200" Format="rgba16" Width="32" Height="32" Offset="0xC200" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_00CA00" OutName="spot15_sceneTex_00CA00" Format="rgba16" Width="64" Height="32" Offset="0xCA00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_00DA00" OutName="spot15_sceneTex_00DA00" Format="rgba16" Width="128" Height="16" Offset="0xDA00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_00EA00" OutName="spot15_sceneTex_00EA00" Format="i4" Width="32" Height="32" Offset="0xEA00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_00EC00" OutName="spot15_sceneTex_00EC00" Format="i8" Width="128" Height="32" Offset="0xEC00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_00FC00" OutName="spot15_sceneTex_00FC00" Format="rgba16" Width="32" Height="32" Offset="0xFC00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_010400" OutName="spot15_sceneTex_010400" Format="rgba16" Width="32" Height="32" Offset="0x10400" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_010C00" OutName="spot15_sceneTex_010C00" Format="i4" Width="64" Height="64" Offset="0x10C00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_011400" OutName="spot15_sceneTex_011400" Format="rgba16" Width="32" Height="32" Offset="0x11400" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_011C00" OutName="spot15_sceneTex_011C00" Format="ia4" Width="128" Height="32" Offset="0x11C00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_012400" OutName="spot15_sceneTex_012400" Format="rgba16" Width="32" Height="64" Offset="0x12400" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_013400" OutName="spot15_sceneTex_013400" Format="rgba16" Width="32" Height="64" Offset="0x13400" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_014400" OutName="spot15_sceneTex_014400" Format="rgba16" Width="32" Height="32" Offset="0x14400" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_014C00" OutName="spot15_sceneTex_014C00" Format="rgba16" Width="64" Height="32" Offset="0x14C00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_015C00" OutName="spot15_sceneTex_015C00" Format="rgba16" Width="16" Height="16" Offset="0x15C00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_015E00" OutName="spot15_sceneTex_015E00" Format="rgba16" Width="32" Height="32" Offset="0x15E00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_016600" OutName="spot15_sceneTex_016600" Format="rgba16" Width="16" Height="16" Offset="0x16600" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_016800" OutName="spot15_sceneTex_016800" Format="rgba16" Width="32" Height="16" Offset="0x16800" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_016C00" OutName="spot15_sceneTex_016C00" Format="rgba16" Width="32" Height="32" Offset="0x16C00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_017400" OutName="spot15_sceneTex_017400" Format="rgba16" Width="32" Height="32" Offset="0x17400" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_017C00" OutName="spot15_sceneTex_017C00" Format="rgba16" Width="32" Height="32" Offset="0x17C00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_018400" OutName="spot15_sceneTex_018400" Format="ia8" Width="16" Height="16" Offset="0x18400" AddedByScript="true"/>
         <Cutscene Name="gHyruleCastleIntroCs" Offset="0x3F40"/>
         <Scene Name="spot15_scene" Offset="0x0"/>
     </File>

--- a/soh/assets/xml/GC_MQ_D/scenes/overworld/spot16.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/overworld/spot16.xml
@@ -1,5 +1,41 @@
 <Root>
     <File Name="spot16_scene" Segment="2">
+        <Texture Name="spot16_sceneTex_008198" OutName="spot16_sceneTex_008198" Format="i8" Width="64" Height="64" Offset="0x8198" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_009198" OutName="spot16_sceneTex_009198" Format="i8" Width="64" Height="32" Offset="0x9198" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_009998" OutName="spot16_sceneTex_009998" Format="i8" Width="64" Height="16" Offset="0x9998" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_009D98" OutName="spot16_sceneTex_009D98" Format="i8" Width="64" Height="64" Offset="0x9D98" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_00AD98" OutName="spot16_sceneTex_00AD98" Format="i8" Width="64" Height="64" Offset="0xAD98" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_00BD98" OutName="spot16_sceneTex_00BD98" Format="rgba16" Width="64" Height="32" Offset="0xBD98" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_00CD98" OutName="spot16_sceneTex_00CD98" Format="rgba16" Width="16" Height="16" Offset="0xCD98" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_00CF98" OutName="spot16_sceneTex_00CF98" Format="rgba16" Width="32" Height="16" Offset="0xCF98" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_00D398" OutName="spot16_sceneTex_00D398" Format="rgba16" Width="16" Height="32" Offset="0xD398" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_00D798" OutName="spot16_sceneTex_00D798" Format="ci4" Width="64" Height="64" Offset="0xD798" TlutOffset="0x8170" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_00DF98" OutName="spot16_sceneTex_00DF98" Format="i4" Width="64" Height="16" Offset="0xDF98" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_00E198" OutName="spot16_sceneTex_00E198" Format="rgba16" Width="64" Height="32" Offset="0xE198" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_00F198" OutName="spot16_sceneTex_00F198" Format="rgba16" Width="16" Height="128" Offset="0xF198" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_010198" OutName="spot16_sceneTex_010198" Format="rgba16" Width="32" Height="64" Offset="0x10198" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_011198" OutName="spot16_sceneTex_011198" Format="rgba16" Width="16" Height="32" Offset="0x11198" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_011598" OutName="spot16_sceneTex_011598" Format="i4" Width="64" Height="16" Offset="0x11598" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_011798" OutName="spot16_sceneTex_011798" Format="rgba16" Width="64" Height="32" Offset="0x11798" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_012798" OutName="spot16_sceneTex_012798" Format="rgba16" Width="64" Height="32" Offset="0x12798" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_013798" OutName="spot16_sceneTex_013798" Format="i4" Width="64" Height="16" Offset="0x13798" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_013998" OutName="spot16_sceneTex_013998" Format="rgba16" Width="32" Height="16" Offset="0x13998" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_013D98" OutName="spot16_sceneTex_013D98" Format="rgba16" Width="32" Height="64" Offset="0x13D98" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_014D98" OutName="spot16_sceneTex_014D98" Format="rgba16" Width="32" Height="32" Offset="0x14D98" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_015598" OutName="spot16_sceneTex_015598" Format="i4" Width="64" Height="64" Offset="0x15598" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_015D98" OutName="spot16_sceneTex_015D98" Format="ia8" Width="16" Height="16" Offset="0x15D98" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_015E98" OutName="spot16_sceneTex_015E98" Format="ia8" Width="128" Height="32" Offset="0x15E98" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_016E98" OutName="spot16_sceneTex_016E98" Format="i4" Width="128" Height="64" Offset="0x16E98" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_017E98" OutName="spot16_sceneTex_017E98" Format="rgba16" Width="32" Height="32" Offset="0x17E98" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_018698" OutName="spot16_sceneTex_018698" Format="rgba16" Width="32" Height="32" Offset="0x18698" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_018E98" OutName="spot16_sceneTex_018E98" Format="rgba16" Width="32" Height="32" Offset="0x18E98" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_019698" OutName="spot16_sceneTex_019698" Format="rgba16" Width="64" Height="16" Offset="0x19698" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_019E98" OutName="spot16_sceneTex_019E98" Format="rgba16" Width="32" Height="64" Offset="0x19E98" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_01B698" OutName="spot16_sceneTex_01B698" Format="ia8" Width="64" Height="64" Offset="0x1B698" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_01C698" OutName="spot16_sceneTex_01C698" Format="rgba16" Width="32" Height="64" Offset="0x1C698" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_01D698" OutName="spot16_sceneTex_01D698" Format="i8" Width="64" Height="32" Offset="0x1D698" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_01DE98" OutName="spot16_sceneTex_01DE98" Format="rgba16" Width="32" Height="32" Offset="0x1DE98" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTLUT_008170" OutName="spot16_sceneTLUT_008170" Format="rgba16" Width="4" Height="4" Offset="0x8170" AddedByScript="true"/>
         <Cutscene Name="gDMTOwlCs" Offset="0x1E6A0"/>
         <Cutscene Name="gDMTIntroCs" Offset="0x7EA0"/>
         <Path Name="spot16_scenePathList_000254" Offset="0x254" NumPaths="2"/>

--- a/soh/assets/xml/GC_MQ_D/scenes/overworld/spot17.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/overworld/spot17.xml
@@ -1,13 +1,54 @@
 <Root>
     <File Name="spot17_scene" Segment="2">
+        <Texture Name="spot17_sceneTex_007AD8" OutName="spot17_sceneTex_007AD8" Format="ci8" Width="16" Height="128" Offset="0x7AD8" TlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_0082D8" OutName="spot17_sceneTex_0082D8" Format="ci8" Width="32" Height="32" Offset="0x82D8" TlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_0086D8" OutName="spot17_sceneTex_0086D8" Format="ci8" Width="64" Height="32" Offset="0x86D8" TlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_008ED8" OutName="spot17_sceneTex_008ED8" Format="ci8" Width="64" Height="32" Offset="0x8ED8" TlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_0096D8" OutName="spot17_sceneTex_0096D8" Format="ci8" Width="64" Height="32" Offset="0x96D8" TlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_009ED8" OutName="spot17_sceneTex_009ED8" Format="rgba16" Width="32" Height="32" Offset="0x9ED8" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_00A6D8" OutName="spot17_sceneTex_00A6D8" Format="rgba16" Width="32" Height="32" Offset="0xA6D8" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_00AED8" OutName="spot17_sceneTex_00AED8" Format="ci4" Width="64" Height="64" Offset="0xAED8" TlutOffset="0x7A98" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_00B6D8" OutName="spot17_sceneTex_00B6D8" Format="ci8" Width="64" Height="32" Offset="0xB6D8" TlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_00BED8" OutName="spot17_sceneTex_00BED8" Format="ci8" Width="32" Height="64" Offset="0xBED8" TlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_00C6D8" OutName="spot17_sceneTex_00C6D8" Format="rgba16" Width="32" Height="64" Offset="0xC6D8" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_00D6D8" OutName="spot17_sceneTex_00D6D8" Format="ci8" Width="16" Height="32" Offset="0xD6D8" TlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_00D8D8" OutName="spot17_sceneTex_00D8D8" Format="ci8" Width="16" Height="128" Offset="0xD8D8" TlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_00E0D8" OutName="spot17_sceneTex_00E0D8" Format="ci4" Width="64" Height="64" Offset="0xE0D8" TlutOffset="0x7AB8" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_00E8D8" OutName="spot17_sceneTex_00E8D8" Format="ci8" Width="32" Height="64" Offset="0xE8D8" TlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_00F0D8" OutName="spot17_sceneTex_00F0D8" Format="ci8" Width="32" Height="64" Offset="0xF0D8" TlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_00F8D8" OutName="spot17_sceneTex_00F8D8" Format="ci8" Width="32" Height="32" Offset="0xF8D8" TlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_00FCD8" OutName="spot17_sceneTex_00FCD8" Format="ci8" Width="16" Height="32" Offset="0xFCD8" TlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTLUT_007890" OutName="spot17_sceneTLUT_007890" Format="rgba16" Width="16" Height="16" Offset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTLUT_007A98" OutName="spot17_sceneTLUT_007A98" Format="rgba16" Width="4" Height="4" Offset="0x7A98" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTLUT_007AB8" OutName="spot17_sceneTLUT_007AB8" Format="rgba16" Width="4" Height="4" Offset="0x7AB8" AddedByScript="true"/>
         <Cutscene Name="gDeathMountainCraterBoleroCs" Offset="0x45D0"/>
         <Cutscene Name="gDeathMountainCraterIntroCs" Offset="0x76D0"/>
         <Scene Name="spot17_scene" Offset="0x0"/>
     </File>
     <File Name="spot17_room_0" Segment="3">
+        <Texture Name="spot17_room_0Tex_003880" OutName="spot17_room_0Tex_003880" Format="rgba16" Width="64" Height="32" Offset="0x3880" AddedByScript="true"/>
+        <Texture Name="spot17_room_0Tex_004880" OutName="spot17_room_0Tex_004880" Format="rgba16" Width="32" Height="32" Offset="0x4880" AddedByScript="true"/>
+        <Texture Name="spot17_room_0Tex_005080" OutName="spot17_room_0Tex_005080" Format="rgba16" Width="32" Height="32" Offset="0x5080" AddedByScript="true"/>
+        <Texture Name="spot17_room_0Tex_005880" OutName="spot17_room_0Tex_005880" Format="rgba16" Width="32" Height="64" Offset="0x5880" AddedByScript="true"/>
         <Room Name="spot17_room_0" Offset="0x0"/>
     </File>
     <File Name="spot17_room_1" Segment="3">
+        <Texture Name="spot17_room_1Tex_00BBD8" OutName="spot17_room_1Tex_00BBD8" Format="ci8" Width="64" Height="32" Offset="0xBBD8" ExternalTlut="spot17_scene" ExternalTlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_00C3D8" OutName="spot17_room_1Tex_00C3D8" Format="ci8" Width="64" Height="32" Offset="0xC3D8" ExternalTlut="spot17_scene" ExternalTlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_00CBD8" OutName="spot17_room_1Tex_00CBD8" Format="rgba16" Width="32" Height="32" Offset="0xCBD8" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_00D3D8" OutName="spot17_room_1Tex_00D3D8" Format="ci8" Width="32" Height="32" Offset="0xD3D8" ExternalTlut="spot17_scene" ExternalTlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_00D7D8" OutName="spot17_room_1Tex_00D7D8" Format="rgba16" Width="64" Height="32" Offset="0xD7D8" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_00E7D8" OutName="spot17_room_1Tex_00E7D8" Format="ci8" Width="16" Height="16" Offset="0xE7D8" ExternalTlut="spot17_scene" ExternalTlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_00E8D8" OutName="spot17_room_1Tex_00E8D8" Format="ci8" Width="32" Height="32" Offset="0xE8D8" ExternalTlut="spot17_scene" ExternalTlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_00ECD8" OutName="spot17_room_1Tex_00ECD8" Format="ci8" Width="32" Height="32" Offset="0xECD8" ExternalTlut="spot17_scene" ExternalTlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_00F0D8" OutName="spot17_room_1Tex_00F0D8" Format="ci8" Width="32" Height="32" Offset="0xF0D8" ExternalTlut="spot17_scene" ExternalTlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_00F4D8" OutName="spot17_room_1Tex_00F4D8" Format="rgba16" Width="32" Height="32" Offset="0xF4D8" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_00FCD8" OutName="spot17_room_1Tex_00FCD8" Format="ci8" Width="32" Height="16" Offset="0xFCD8" ExternalTlut="spot17_scene" ExternalTlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_010E58" OutName="spot17_room_1Tex_010E58" Format="i4" Width="64" Height="32" Offset="0x10E58" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_011258" OutName="spot17_room_1Tex_011258" Format="i4" Width="64" Height="32" Offset="0x11258" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_011658" OutName="spot17_room_1Tex_011658" Format="i4" Width="64" Height="32" Offset="0x11658" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_011A58" OutName="spot17_room_1Tex_011A58" Format="rgba16" Width="32" Height="32" Offset="0x11A58" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_012258" OutName="spot17_room_1Tex_012258" Format="ia8" Width="16" Height="16" Offset="0x12258" AddedByScript="true"/>
         <Room Name="spot17_room_1" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_MQ_D/scenes/overworld/spot18.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/overworld/spot18.xml
@@ -1,5 +1,10 @@
 <Root>
     <File Name="spot18_scene" Segment="2">
+        <Texture Name="spot18_sceneTex_0087C8" OutName="spot18_sceneTex_0087C8" Format="rgba16" Width="32" Height="32" Offset="0x87C8" AddedByScript="true"/>
+        <Texture Name="spot18_sceneTex_009008" OutName="spot18_sceneTex_009008" Format="ci8" Width="64" Height="32" Offset="0x9008" TlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_sceneTex_009848" OutName="spot18_sceneTex_009848" Format="rgba16" Width="16" Height="32" Offset="0x9848" AddedByScript="true"/>
+        <Texture Name="spot18_sceneTex_009C48" OutName="spot18_sceneTex_009C48" Format="ci8" Width="64" Height="32" Offset="0x9C48" TlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_sceneTLUT_0085C0" OutName="spot18_sceneTLUT_0085C0" Format="rgba16" Width="16" Height="16" Offset="0x85C0" AddedByScript="true"/>
         <Cutscene Name="gGoronCityDaruniaCorrectCs" Offset="0x59E0"/>
         <Cutscene Name="gGoronCityDarunia01Cs" Offset="0x6930"/>
         <Cutscene Name="gGoronCityDaruniaWrongCs" Offset="0x7DE0"/>
@@ -9,15 +14,92 @@
         <Scene Name="spot18_scene" Offset="0x0"/>
     </File>
     <File Name="spot18_room_0" Segment="3">
+        <Texture Name="spot18_room_0Tex_004960" OutName="spot18_room_0Tex_004960" Format="rgba16" Width="32" Height="32" Offset="0x4960" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_005160" OutName="spot18_room_0Tex_005160" Format="rgba16" Width="16" Height="32" Offset="0x5160" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_005560" OutName="spot18_room_0Tex_005560" Format="rgba16" Width="16" Height="32" Offset="0x5560" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_005960" OutName="spot18_room_0Tex_005960" Format="rgba16" Width="32" Height="64" Offset="0x5960" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_006960" OutName="spot18_room_0Tex_006960" Format="ci8" Width="32" Height="64" Offset="0x6960" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_007160" OutName="spot18_room_0Tex_007160" Format="rgba16" Width="32" Height="32" Offset="0x7160" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_007960" OutName="spot18_room_0Tex_007960" Format="rgba16" Width="32" Height="32" Offset="0x7960" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_008160" OutName="spot18_room_0Tex_008160" Format="rgba16" Width="32" Height="32" Offset="0x8160" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_008960" OutName="spot18_room_0Tex_008960" Format="ci8" Width="32" Height="64" Offset="0x8960" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_009160" OutName="spot18_room_0Tex_009160" Format="ci8" Width="32" Height="64" Offset="0x9160" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_009960" OutName="spot18_room_0Tex_009960" Format="rgba16" Width="32" Height="32" Offset="0x9960" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_00A160" OutName="spot18_room_0Tex_00A160" Format="ci8" Width="64" Height="32" Offset="0xA160" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_00A960" OutName="spot18_room_0Tex_00A960" Format="ci8" Width="32" Height="64" Offset="0xA960" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_00B160" OutName="spot18_room_0Tex_00B160" Format="ci8" Width="32" Height="64" Offset="0xB160" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_00B960" OutName="spot18_room_0Tex_00B960" Format="ci8" Width="32" Height="64" Offset="0xB960" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_00C160" OutName="spot18_room_0Tex_00C160" Format="ci8" Width="32" Height="64" Offset="0xC160" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_00C960" OutName="spot18_room_0Tex_00C960" Format="ia8" Width="64" Height="64" Offset="0xC960" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_00DFC8" OutName="spot18_room_0Tex_00DFC8" Format="rgba16" Width="32" Height="64" Offset="0xDFC8" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_00EFC8" OutName="spot18_room_0Tex_00EFC8" Format="rgba16" Width="64" Height="32" Offset="0xEFC8" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_00FFC8" OutName="spot18_room_0Tex_00FFC8" Format="rgba16" Width="32" Height="32" Offset="0xFFC8" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_0107C8" OutName="spot18_room_0Tex_0107C8" Format="rgba16" Width="64" Height="32" Offset="0x107C8" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_0117C8" OutName="spot18_room_0Tex_0117C8" Format="rgba16" Width="64" Height="32" Offset="0x117C8" AddedByScript="true"/>
         <Room Name="spot18_room_0" Offset="0x0"/>
     </File>
     <File Name="spot18_room_1" Segment="3">
+        <Texture Name="spot18_room_1Tex_002868" OutName="spot18_room_1Tex_002868" Format="rgba16" Width="32" Height="32" Offset="0x2868" AddedByScript="true"/>
+        <Texture Name="spot18_room_1Tex_003068" OutName="spot18_room_1Tex_003068" Format="i4" Width="128" Height="64" Offset="0x3068" AddedByScript="true"/>
+        <Texture Name="spot18_room_1Tex_004068" OutName="spot18_room_1Tex_004068" Format="ci8" Width="64" Height="32" Offset="0x4068" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_1Tex_004868" OutName="spot18_room_1Tex_004868" Format="rgba16" Width="32" Height="64" Offset="0x4868" AddedByScript="true"/>
+        <Texture Name="spot18_room_1Tex_005E00" OutName="spot18_room_1Tex_005E00" Format="ia4" Width="32" Height="64" Offset="0x5E00" AddedByScript="true"/>
         <Room Name="spot18_room_1" Offset="0x0"/>
     </File>
     <File Name="spot18_room_2" Segment="3">
+        <Texture Name="spot18_room_2Tex_004818" OutName="spot18_room_2Tex_004818" Format="rgba16" Width="32" Height="64" Offset="0x4818" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_005818" OutName="spot18_room_2Tex_005818" Format="rgba16" Width="32" Height="32" Offset="0x5818" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_006018" OutName="spot18_room_2Tex_006018" Format="rgba16" Width="32" Height="32" Offset="0x6018" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_006818" OutName="spot18_room_2Tex_006818" Format="rgba16" Width="32" Height="32" Offset="0x6818" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_007018" OutName="spot18_room_2Tex_007018" Format="ci8" Width="32" Height="64" Offset="0x7018" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_007818" OutName="spot18_room_2Tex_007818" Format="rgba16" Width="32" Height="32" Offset="0x7818" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_008018" OutName="spot18_room_2Tex_008018" Format="rgba16" Width="32" Height="32" Offset="0x8018" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_008818" OutName="spot18_room_2Tex_008818" Format="ci8" Width="32" Height="64" Offset="0x8818" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_009018" OutName="spot18_room_2Tex_009018" Format="ci8" Width="32" Height="64" Offset="0x9018" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_009818" OutName="spot18_room_2Tex_009818" Format="ci8" Width="32" Height="64" Offset="0x9818" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_00A018" OutName="spot18_room_2Tex_00A018" Format="ci8" Width="32" Height="64" Offset="0xA018" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_00A818" OutName="spot18_room_2Tex_00A818" Format="ci8" Width="32" Height="64" Offset="0xA818" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_00B018" OutName="spot18_room_2Tex_00B018" Format="ci8" Width="32" Height="64" Offset="0xB018" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_00B818" OutName="spot18_room_2Tex_00B818" Format="ia8" Width="64" Height="64" Offset="0xB818" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_00D1A8" OutName="spot18_room_2Tex_00D1A8" Format="rgba16" Width="32" Height="64" Offset="0xD1A8" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_00E1A8" OutName="spot18_room_2Tex_00E1A8" Format="rgba16" Width="64" Height="32" Offset="0xE1A8" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_00F1A8" OutName="spot18_room_2Tex_00F1A8" Format="rgba16" Width="32" Height="32" Offset="0xF1A8" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_00F9A8" OutName="spot18_room_2Tex_00F9A8" Format="rgba16" Width="64" Height="32" Offset="0xF9A8" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_0109A8" OutName="spot18_room_2Tex_0109A8" Format="rgba16" Width="64" Height="32" Offset="0x109A8" AddedByScript="true"/>
         <Room Name="spot18_room_2" Offset="0x0"/>
     </File>
     <File Name="spot18_room_3" Segment="3">
+        <Texture Name="spot18_room_3Tex_00B448" OutName="spot18_room_3Tex_00B448" Format="rgba16" Width="32" Height="32" Offset="0xB448" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_00BC48" OutName="spot18_room_3Tex_00BC48" Format="rgba16" Width="16" Height="32" Offset="0xBC48" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_00C048" OutName="spot18_room_3Tex_00C048" Format="rgba16" Width="16" Height="32" Offset="0xC048" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_00C448" OutName="spot18_room_3Tex_00C448" Format="rgba16" Width="16" Height="32" Offset="0xC448" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_00C848" OutName="spot18_room_3Tex_00C848" Format="rgba16" Width="32" Height="64" Offset="0xC848" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_00D848" OutName="spot18_room_3Tex_00D848" Format="rgba16" Width="16" Height="32" Offset="0xD848" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_00DC48" OutName="spot18_room_3Tex_00DC48" Format="ci8" Width="32" Height="64" Offset="0xDC48" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_00E448" OutName="spot18_room_3Tex_00E448" Format="ci8" Width="32" Height="64" Offset="0xE448" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_00EC48" OutName="spot18_room_3Tex_00EC48" Format="rgba16" Width="32" Height="32" Offset="0xEC48" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_00F448" OutName="spot18_room_3Tex_00F448" Format="rgba16" Width="64" Height="32" Offset="0xF448" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_010448" OutName="spot18_room_3Tex_010448" Format="rgba16" Width="32" Height="32" Offset="0x10448" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_010C48" OutName="spot18_room_3Tex_010C48" Format="rgba16" Width="32" Height="32" Offset="0x10C48" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_011448" OutName="spot18_room_3Tex_011448" Format="ci8" Width="32" Height="64" Offset="0x11448" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_011C48" OutName="spot18_room_3Tex_011C48" Format="ci8" Width="32" Height="64" Offset="0x11C48" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_012448" OutName="spot18_room_3Tex_012448" Format="rgba16" Width="16" Height="16" Offset="0x12448" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_012648" OutName="spot18_room_3Tex_012648" Format="rgba16" Width="16" Height="16" Offset="0x12648" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_012848" OutName="spot18_room_3Tex_012848" Format="i4" Width="128" Height="64" Offset="0x12848" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_013848" OutName="spot18_room_3Tex_013848" Format="ci8" Width="64" Height="32" Offset="0x13848" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_014048" OutName="spot18_room_3Tex_014048" Format="rgba16" Width="32" Height="32" Offset="0x14048" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_014848" OutName="spot18_room_3Tex_014848" Format="ci8" Width="32" Height="64" Offset="0x14848" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_015048" OutName="spot18_room_3Tex_015048" Format="ci8" Width="32" Height="64" Offset="0x15048" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_015848" OutName="spot18_room_3Tex_015848" Format="ci8" Width="32" Height="64" Offset="0x15848" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_016048" OutName="spot18_room_3Tex_016048" Format="ci8" Width="32" Height="64" Offset="0x16048" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_016848" OutName="spot18_room_3Tex_016848" Format="ci8" Width="32" Height="32" Offset="0x16848" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_016C48" OutName="spot18_room_3Tex_016C48" Format="rgba16" Width="32" Height="32" Offset="0x16C48" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_017448" OutName="spot18_room_3Tex_017448" Format="ia8" Width="64" Height="64" Offset="0x17448" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_0194E8" OutName="spot18_room_3Tex_0194E8" Format="rgba16" Width="32" Height="64" Offset="0x194E8" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_01A4E8" OutName="spot18_room_3Tex_01A4E8" Format="rgba16" Width="64" Height="32" Offset="0x1A4E8" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_01B4E8" OutName="spot18_room_3Tex_01B4E8" Format="rgba16" Width="32" Height="32" Offset="0x1B4E8" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_01BCE8" OutName="spot18_room_3Tex_01BCE8" Format="rgba16" Width="64" Height="32" Offset="0x1BCE8" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_01CCE8" OutName="spot18_room_3Tex_01CCE8" Format="rgba16" Width="64" Height="32" Offset="0x1CCE8" AddedByScript="true"/>
         <Room Name="spot18_room_3" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_MQ_D/scenes/overworld/spot20.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/overworld/spot20.xml
@@ -1,5 +1,27 @@
 <Root>
     <File Name="spot20_scene" Segment="2">
+        <Texture Name="spot20_sceneTex_005FE0" OutName="spot20_sceneTex_005FE0" Format="ci8" Width="32" Height="64" Offset="0x5FE0" TlutOffset="0x5DB0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_0067E0" OutName="spot20_sceneTex_0067E0" Format="ci8" Width="16" Height="32" Offset="0x67E0" TlutOffset="0x5DB0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_0069E0" OutName="spot20_sceneTex_0069E0" Format="ci8" Width="64" Height="32" Offset="0x69E0" TlutOffset="0x5DB0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_0071E0" OutName="spot20_sceneTex_0071E0" Format="rgba16" Width="64" Height="32" Offset="0x71E0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_0091E0" OutName="spot20_sceneTex_0091E0" Format="ci8" Width="16" Height="32" Offset="0x91E0" TlutOffset="0x5DB0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_0093E0" OutName="spot20_sceneTex_0093E0" Format="rgba16" Width="16" Height="64" Offset="0x93E0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_009BE0" OutName="spot20_sceneTex_009BE0" Format="rgba16" Width="64" Height="32" Offset="0x9BE0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_00ABE0" OutName="spot20_sceneTex_00ABE0" Format="rgba16" Width="32" Height="64" Offset="0xABE0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_00BBE0" OutName="spot20_sceneTex_00BBE0" Format="ci8" Width="32" Height="16" Offset="0xBBE0" TlutOffset="0x5DB0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_00BDE0" OutName="spot20_sceneTex_00BDE0" Format="ci8" Width="32" Height="32" Offset="0xBDE0" TlutOffset="0x5DB0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_00C1E0" OutName="spot20_sceneTex_00C1E0" Format="ci4" Width="64" Height="64" Offset="0xC1E0" TlutOffset="0x5FB8" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_00C9E0" OutName="spot20_sceneTex_00C9E0" Format="ci8" Width="32" Height="64" Offset="0xC9E0" TlutOffset="0x5DB0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_00D1E0" OutName="spot20_sceneTex_00D1E0" Format="rgba16" Width="32" Height="32" Offset="0xD1E0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_00D9E0" OutName="spot20_sceneTex_00D9E0" Format="rgba16" Width="32" Height="32" Offset="0xD9E0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_00E1E0" OutName="spot20_sceneTex_00E1E0" Format="i4" Width="64" Height="64" Offset="0xE1E0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_00E9E0" OutName="spot20_sceneTex_00E9E0" Format="i4" Width="64" Height="64" Offset="0xE9E0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_00F1E0" OutName="spot20_sceneTex_00F1E0" Format="i4" Width="64" Height="64" Offset="0xF1E0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_00F9E0" OutName="spot20_sceneTex_00F9E0" Format="ci8" Width="8" Height="64" Offset="0xF9E0" TlutOffset="0x5DB0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_010BE0" OutName="spot20_sceneTex_010BE0" Format="i4" Width="64" Height="18" Offset="0x10BE0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_010E20" OutName="spot20_sceneTex_010E20" Format="ia8" Width="64" Height="64" Offset="0x10E20" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTLUT_005DB0" OutName="spot20_sceneTLUT_005DB0" Format="rgba16" Width="16" Height="16" Offset="0x5DB0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTLUT_005FB8" OutName="spot20_sceneTLUT_005FB8" Format="rgba16" Width="4" Height="4" Offset="0x5FB8" AddedByScript="true"/>
         <Cutscene Name="gLonLonRanchIntroCs" Offset="0x5BD0"/>
         <Texture Name="gLonLonRanchDayWindowTex" OutName="day_window" Format="rgba16" Width="32" Height="64" Offset="0x81E0"/>
         <Texture Name="gLonLonRangeNightWindowsTex" OutName="night_window" Format="rgba16" Width="32" Height="64" Offset="0xFBE0"/>

--- a/soh/assets/xml/GC_MQ_D/scenes/test_levels/besitu.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/test_levels/besitu.xml
@@ -3,6 +3,13 @@
         <Scene Name="besitu_scene" Offset="0x0"/>
     </File>
     <File Name="besitu_room_0" Segment="3">
+        <Texture Name="besitu_room_0Tex_001CD8" OutName="besitu_room_0Tex_001CD8" Format="i4" Width="128" Height="64" Offset="0x1CD8" AddedByScript="true"/>
+        <Texture Name="besitu_room_0Tex_002CD8" OutName="besitu_room_0Tex_002CD8" Format="ia4" Width="64" Height="64" Offset="0x2CD8" AddedByScript="true"/>
+        <Texture Name="besitu_room_0Tex_0034D8" OutName="besitu_room_0Tex_0034D8" Format="ia8" Width="32" Height="64" Offset="0x34D8" AddedByScript="true"/>
+        <Texture Name="besitu_room_0Tex_003CD8" OutName="besitu_room_0Tex_003CD8" Format="ia8" Width="32" Height="64" Offset="0x3CD8" AddedByScript="true"/>
+        <Texture Name="besitu_room_0Tex_0044D8" OutName="besitu_room_0Tex_0044D8" Format="ia4" Width="64" Height="64" Offset="0x44D8" AddedByScript="true"/>
+        <Texture Name="besitu_room_0Tex_004CD8" OutName="besitu_room_0Tex_004CD8" Format="ci4" Width="64" Height="64" Offset="0x4CD8" TlutOffset="0x1CB8" AddedByScript="true"/>
+        <Texture Name="besitu_room_0TLUT_001CB8" OutName="besitu_room_0TLUT_001CB8" Format="rgba16" Width="4" Height="4" Offset="0x1CB8" AddedByScript="true"/>
         <Room Name="besitu_room_0" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_MQ_D/scenes/test_levels/sutaru.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/test_levels/sutaru.xml
@@ -3,6 +3,13 @@
         <Scene Name="sutaru_scene" Offset="0x0"/>
     </File>
     <File Name="sutaru_room_0" Segment="3">
+        <Texture Name="sutaru_room_0Tex_0020F0" OutName="sutaru_room_0Tex_0020F0" Format="rgba16" Width="32" Height="32" Offset="0x20F0" AddedByScript="true"/>
+        <Texture Name="sutaru_room_0Tex_0028F0" OutName="sutaru_room_0Tex_0028F0" Format="rgba16" Width="16" Height="16" Offset="0x28F0" AddedByScript="true"/>
+        <Texture Name="sutaru_room_0Tex_002AF0" OutName="sutaru_room_0Tex_002AF0" Format="rgba16" Width="64" Height="32" Offset="0x2AF0" AddedByScript="true"/>
+        <Texture Name="sutaru_room_0Tex_003AF0" OutName="sutaru_room_0Tex_003AF0" Format="rgba16" Width="32" Height="32" Offset="0x3AF0" AddedByScript="true"/>
+        <Texture Name="sutaru_room_0Tex_0042F0" OutName="sutaru_room_0Tex_0042F0" Format="rgba16" Width="64" Height="32" Offset="0x42F0" AddedByScript="true"/>
+        <Texture Name="sutaru_room_0Tex_0052F0" OutName="sutaru_room_0Tex_0052F0" Format="rgba16" Width="32" Height="64" Offset="0x52F0" AddedByScript="true"/>
+        <Texture Name="sutaru_room_0Tex_0062F0" OutName="sutaru_room_0Tex_0062F0" Format="rgba16" Width="32" Height="64" Offset="0x62F0" AddedByScript="true"/>
         <Room Name="sutaru_room_0" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_MQ_D/scenes/test_levels/syotes.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/test_levels/syotes.xml
@@ -3,6 +3,17 @@
         <Scene Name="syotes_scene" Offset="0x0"/>
     </File>
     <File Name="syotes_room_0" Segment="3">
+        <Texture Name="syotes_room_0Tex_0031E8" OutName="syotes_room_0Tex_0031E8" Format="rgba16" Width="32" Height="32" Offset="0x31E8" AddedByScript="true"/>
+        <Texture Name="syotes_room_0Tex_0039E8" OutName="syotes_room_0Tex_0039E8" Format="rgba16" Width="32" Height="32" Offset="0x39E8" AddedByScript="true"/>
+        <Texture Name="syotes_room_0Tex_0041E8" OutName="syotes_room_0Tex_0041E8" Format="rgba16" Width="32" Height="64" Offset="0x41E8" AddedByScript="true"/>
+        <Texture Name="syotes_room_0Tex_0051E8" OutName="syotes_room_0Tex_0051E8" Format="rgba16" Width="32" Height="64" Offset="0x51E8" AddedByScript="true"/>
+        <Texture Name="syotes_room_0Tex_0061E8" OutName="syotes_room_0Tex_0061E8" Format="rgba16" Width="32" Height="32" Offset="0x61E8" AddedByScript="true"/>
+        <Texture Name="syotes_room_0Tex_0069E8" OutName="syotes_room_0Tex_0069E8" Format="rgba16" Width="64" Height="32" Offset="0x69E8" AddedByScript="true"/>
+        <Texture Name="syotes_room_0Tex_0079E8" OutName="syotes_room_0Tex_0079E8" Format="rgba16" Width="64" Height="32" Offset="0x79E8" AddedByScript="true"/>
+        <Texture Name="syotes_room_0Tex_0089E8" OutName="syotes_room_0Tex_0089E8" Format="rgba16" Width="32" Height="64" Offset="0x89E8" AddedByScript="true"/>
+        <Texture Name="syotes_room_0Tex_0099E8" OutName="syotes_room_0Tex_0099E8" Format="rgba16" Width="64" Height="32" Offset="0x99E8" AddedByScript="true"/>
+        <Texture Name="syotes_room_0Tex_00A9E8" OutName="syotes_room_0Tex_00A9E8" Format="rgba16" Width="32" Height="64" Offset="0xA9E8" AddedByScript="true"/>
+        <Texture Name="syotes_room_0Tex_00BF80" OutName="syotes_room_0Tex_00BF80" Format="ia16" Width="32" Height="64" Offset="0xBF80" AddedByScript="true"/>
         <Room Name="syotes_room_0" HackMode="syotes_room" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_MQ_D/scenes/test_levels/syotes2.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/test_levels/syotes2.xml
@@ -3,6 +3,13 @@
         <Scene Name="syotes2_scene" Offset="0x0"/>
     </File>
     <File Name="syotes2_room_0" Segment="3">
+        <Texture Name="syotes2_room_0Tex_0046F8" OutName="syotes2_room_0Tex_0046F8" Format="rgba16" Width="32" Height="32" Offset="0x46F8" AddedByScript="true"/>
+        <Texture Name="syotes2_room_0Tex_004EF8" OutName="syotes2_room_0Tex_004EF8" Format="rgba16" Width="32" Height="32" Offset="0x4EF8" AddedByScript="true"/>
+        <Texture Name="syotes2_room_0Tex_0056F8" OutName="syotes2_room_0Tex_0056F8" Format="rgba16" Width="32" Height="64" Offset="0x56F8" AddedByScript="true"/>
+        <Texture Name="syotes2_room_0Tex_0066F8" OutName="syotes2_room_0Tex_0066F8" Format="rgba16" Width="32" Height="32" Offset="0x66F8" AddedByScript="true"/>
+        <Texture Name="syotes2_room_0Tex_006EF8" OutName="syotes2_room_0Tex_006EF8" Format="rgba16" Width="64" Height="32" Offset="0x6EF8" AddedByScript="true"/>
+        <Texture Name="syotes2_room_0Tex_007EF8" OutName="syotes2_room_0Tex_007EF8" Format="rgba16" Width="32" Height="64" Offset="0x7EF8" AddedByScript="true"/>
+        <Texture Name="syotes2_room_0Tex_008EF8" OutName="syotes2_room_0Tex_008EF8" Format="rgba16" Width="32" Height="64" Offset="0x8EF8" AddedByScript="true"/>
         <Room Name="syotes2_room_0" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_MQ_D/scenes/test_levels/test01.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/test_levels/test01.xml
@@ -3,6 +3,11 @@
         <Scene Name="test01_scene" Offset="0x0"/>
     </File>
     <File Name="test01_room_0" Segment="3">
+        <Texture Name="test01_room_0Tex_006490" OutName="test01_room_0Tex_006490" Format="rgba16" Width="32" Height="32" Offset="0x6490" AddedByScript="true"/>
+        <Texture Name="test01_room_0Tex_006C90" OutName="test01_room_0Tex_006C90" Format="rgba16" Width="32" Height="32" Offset="0x6C90" AddedByScript="true"/>
+        <Texture Name="test01_room_0Tex_007490" OutName="test01_room_0Tex_007490" Format="rgba16" Width="64" Height="32" Offset="0x7490" AddedByScript="true"/>
+        <Texture Name="test01_room_0Tex_008490" OutName="test01_room_0Tex_008490" Format="rgba16" Width="32" Height="32" Offset="0x8490" AddedByScript="true"/>
+        <Texture Name="test01_room_0Tex_0090E8" OutName="test01_room_0Tex_0090E8" Format="rgba16" Width="32" Height="32" Offset="0x90E8" AddedByScript="true"/>
         <Room Name="test01_room_0" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_MQ_D/scenes/test_levels/testroom.xml
+++ b/soh/assets/xml/GC_MQ_D/scenes/test_levels/testroom.xml
@@ -1,17 +1,36 @@
 <Root>
     <File Name="testroom_scene" Segment="2">
+        <Texture Name="testroom_sceneTex_002200" OutName="testroom_sceneTex_002200" Format="rgba16" Width="32" Height="32" Offset="0x2200" AddedByScript="true"/>
+        <Texture Name="testroom_sceneTex_002A00" OutName="testroom_sceneTex_002A00" Format="rgba16" Width="32" Height="64" Offset="0x2A00" AddedByScript="true"/>
+        <Texture Name="testroom_sceneTex_003A00" OutName="testroom_sceneTex_003A00" Format="rgba16" Width="32" Height="32" Offset="0x3A00" AddedByScript="true"/>
         <Scene Name="testroom_scene" Offset="0x0"/>
     </File>
     <File Name="testroom_room_0" Segment="3">
+        <Texture Name="testroom_room_0Tex_000E00" OutName="testroom_room_0Tex_000E00" Format="rgba16" Width="32" Height="32" Offset="0xE00" AddedByScript="true"/>
+        <Texture Name="testroom_room_0Tex_001600" OutName="testroom_room_0Tex_001600" Format="rgba16" Width="32" Height="64" Offset="0x1600" AddedByScript="true"/>
+        <Texture Name="testroom_room_0Tex_002600" OutName="testroom_room_0Tex_002600" Format="rgba16" Width="32" Height="32" Offset="0x2600" AddedByScript="true"/>
+        <Texture Name="testroom_room_0Tex_002E00" OutName="testroom_room_0Tex_002E00" Format="rgba16" Width="32" Height="64" Offset="0x2E00" AddedByScript="true"/>
+        <Texture Name="testroom_room_0Tex_003E00" OutName="testroom_room_0Tex_003E00" Format="rgba16" Width="32" Height="32" Offset="0x3E00" AddedByScript="true"/>
         <Room Name="testroom_room_0" Offset="0x0"/>
     </File>
     <File Name="testroom_room_1" Segment="3">
+        <Texture Name="testroom_room_1Tex_000BE8" OutName="testroom_room_1Tex_000BE8" Format="rgba16" Width="32" Height="32" Offset="0xBE8" AddedByScript="true"/>
+        <Texture Name="testroom_room_1Tex_0013E8" OutName="testroom_room_1Tex_0013E8" Format="rgba16" Width="32" Height="32" Offset="0x13E8" AddedByScript="true"/>
+        <Texture Name="testroom_room_1Tex_001BE8" OutName="testroom_room_1Tex_001BE8" Format="rgba16" Width="32" Height="32" Offset="0x1BE8" AddedByScript="true"/>
         <Room Name="testroom_room_1" Offset="0x0"/>
     </File>
     <File Name="testroom_room_2" Segment="3">
+        <Texture Name="testroom_room_2Tex_001A78" OutName="testroom_room_2Tex_001A78" Format="ci4" Width="64" Height="64" Offset="0x1A78" TlutOffset="0x1A58" AddedByScript="true"/>
+        <Texture Name="testroom_room_2Tex_002278" OutName="testroom_room_2Tex_002278" Format="rgba16" Width="32" Height="32" Offset="0x2278" AddedByScript="true"/>
+        <Texture Name="testroom_room_2Tex_002A78" OutName="testroom_room_2Tex_002A78" Format="rgba16" Width="32" Height="32" Offset="0x2A78" AddedByScript="true"/>
+        <Texture Name="testroom_room_2TLUT_001A58" OutName="testroom_room_2TLUT_001A58" Format="rgba16" Width="4" Height="4" Offset="0x1A58" AddedByScript="true"/>
         <Room Name="testroom_room_2" Offset="0x0"/>
     </File>
     <File Name="testroom_room_3" Segment="3">
+        <Texture Name="testroom_room_3Tex_000A18" OutName="testroom_room_3Tex_000A18" Format="rgba16" Width="32" Height="32" Offset="0xA18" AddedByScript="true"/>
+        <Texture Name="testroom_room_3Tex_001218" OutName="testroom_room_3Tex_001218" Format="rgba16" Width="32" Height="64" Offset="0x1218" AddedByScript="true"/>
+        <Texture Name="testroom_room_3Tex_002218" OutName="testroom_room_3Tex_002218" Format="rgba16" Width="32" Height="64" Offset="0x2218" AddedByScript="true"/>
+        <Texture Name="testroom_room_3Tex_003218" OutName="testroom_room_3Tex_003218" Format="rgba16" Width="32" Height="32" Offset="0x3218" AddedByScript="true"/>
         <Room Name="testroom_room_3" Offset="0x0"/>
     </File>
     <File Name="testroom_room_4" Segment="3">

--- a/soh/assets/xml/GC_MQ_D/textures/nintendo_rogo_static.xml
+++ b/soh/assets/xml/GC_MQ_D/textures/nintendo_rogo_static.xml
@@ -1,7 +1,8 @@
 <Root>
      <File Name="nintendo_rogo_static" Segment="1">
 
-         <Texture Name="nintendo_rogo_static_Tex_000000" OutName="tex_00000000" Format="i8" Width="192" Height="32" Offset="0x0000"/>
+         <Texture Name="nintendo_rogo_staticTex_0029C0" OutName="nintendo_rogo_staticTex_0029C0" Format="i8" Width="32" Height="32" Offset="0x29C0" AddedByScript="true"/>
+        <Texture Name="nintendo_rogo_static_Tex_000000" OutName="tex_00000000" Format="i8" Width="192" Height="32" Offset="0x0000"/>
          <Texture Name="nintendo_rogo_static_Tex_001800" OutName="tex_00001800" Format="i8" Width="32" Height="32" Offset="0x1800"/>
          <DList Name="gNintendo64LogoDL" Offset="0x2720"/>
      </File>

--- a/soh/assets/xml/GC_NMQ_D/objects/gameplay_dangeon_keep.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/gameplay_dangeon_keep.xml
@@ -1,5 +1,28 @@
 <Root>
     <File Name="gameplay_dangeon_keep" Segment="5">
+        <Texture Name="gameplay_dangeon_keepTex_000000" OutName="gameplay_dangeon_keepTex_000000" Format="i8" Width="16" Height="32" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_000200" OutName="gameplay_dangeon_keepTex_000200" Format="i8" Width="16" Height="32" Offset="0x200" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_0005C0" OutName="gameplay_dangeon_keepTex_0005C0" Format="rgba16" Width="16" Height="16" Offset="0x5C0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_001280" OutName="gameplay_dangeon_keepTex_001280" Format="rgba16" Width="32" Height="32" Offset="0x1280" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_0078A0" OutName="gameplay_dangeon_keepTex_0078A0" Format="i8" Width="32" Height="32" Offset="0x78A0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_007CA0" OutName="gameplay_dangeon_keepTex_007CA0" Format="i8" Width="32" Height="32" Offset="0x7CA0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_0080A0" OutName="gameplay_dangeon_keepTex_0080A0" Format="rgba16" Width="32" Height="32" Offset="0x80A0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_0088A0" OutName="gameplay_dangeon_keepTex_0088A0" Format="rgba16" Width="32" Height="32" Offset="0x88A0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_00D8A0" OutName="gameplay_dangeon_keepTex_00D8A0" Format="rgba16" Width="32" Height="32" Offset="0xD8A0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_00E0A0" OutName="gameplay_dangeon_keepTex_00E0A0" Format="rgba16" Width="32" Height="32" Offset="0xE0A0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_00F8A0" OutName="gameplay_dangeon_keepTex_00F8A0" Format="rgba16" Width="64" Height="32" Offset="0xF8A0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_0108A0" OutName="gameplay_dangeon_keepTex_0108A0" Format="rgba16" Width="32" Height="64" Offset="0x108A0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_0118A0" OutName="gameplay_dangeon_keepTex_0118A0" Format="rgba16" Width="16" Height="16" Offset="0x118A0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_011AA0" OutName="gameplay_dangeon_keepTex_011AA0" Format="rgba16" Width="16" Height="16" Offset="0x11AA0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_011CA0" OutName="gameplay_dangeon_keepTex_011CA0" Format="rgba16" Width="32" Height="64" Offset="0x11CA0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_012CA0" OutName="gameplay_dangeon_keepTex_012CA0" Format="rgba16" Width="64" Height="16" Offset="0x12CA0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_0134A0" OutName="gameplay_dangeon_keepTex_0134A0" Format="rgba16" Width="32" Height="32" Offset="0x134A0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_013CA0" OutName="gameplay_dangeon_keepTex_013CA0" Format="ia8" Width="4" Height="4" Offset="0x13CA0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_013CB0" OutName="gameplay_dangeon_keepTex_013CB0" Format="i4" Width="64" Height="64" Offset="0x13CB0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_0154B0" OutName="gameplay_dangeon_keepTex_0154B0" Format="rgba16" Width="32" Height="32" Offset="0x154B0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_015CB0" OutName="gameplay_dangeon_keepTex_015CB0" Format="rgba16" Width="32" Height="32" Offset="0x15CB0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_0164B0" OutName="gameplay_dangeon_keepTex_0164B0" Format="rgba16" Width="32" Height="32" Offset="0x164B0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_016CB0" OutName="gameplay_dangeon_keepTex_016CB0" Format="rgba16" Width="32" Height="32" Offset="0x16CB0" AddedByScript="true"/>
         <DList Name="gUnusedCandleDL" Offset="0x440"/>
         <DList Name="gBrownFragmentDL" Offset="0x530"/>
         <Texture Name="gUnusedStoneTex" OutName="unused_stone" Format="rgba16" Width="32" Height="32" Offset="0x7C0"/>

--- a/soh/assets/xml/GC_NMQ_D/objects/gameplay_keep.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/gameplay_keep.xml
@@ -1,6 +1,10 @@
 <Root>
     <ExternalFile XmlPath="misc/link_animetion.xml" OutPath="misc/link_animetion/"/>
     <File Name="gameplay_keep" Segment="4">
+        <Texture Name="gameplay_keepTex_04C540" OutName="gameplay_keepTex_04C540" Format="i8" Width="64" Height="17" Offset="0x4C540" AddedByScript="true"/>
+        <Texture Name="gameplay_keepTex_04C740" OutName="gameplay_keepTex_04C740" Format="i8" Width="64" Height="17" Offset="0x4C740" AddedByScript="true"/>
+        <Texture Name="gameplay_keepTex_04CD40" OutName="gameplay_keepTex_04CD40" Format="i8" Width="64" Height="17" Offset="0x4CD40" AddedByScript="true"/>
+        <Texture Name="gameplay_keepTex_04CF40" OutName="gameplay_keepTex_04CF40" Format="i8" Width="64" Height="17" Offset="0x4CF40" AddedByScript="true"/>
         <Texture Name="gHilite1Tex" OutName="hilite_1" Format="rgba16" Width="16" Height="16" Offset="0x0"/>
         <Texture Name="gHilite2Tex" OutName="hilite_2" Format="rgba16" Width="16" Height="16" Offset="0x200"/>
         <Texture Name="gHylianShieldDesignTex" OutName="hylian_shield_design" Format="rgba16" Width="32" Height="64" Offset="0x400"/>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_am.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_am.xml
@@ -1,5 +1,18 @@
 <Root>
     <File Name="object_am" Segment="6">
+        <Texture Name="object_amTex_002638" OutName="object_amTex_002638" Format="i4" Width="32" Height="32" Offset="0x2638" AddedByScript="true"/>
+        <Texture Name="object_amTex_002838" OutName="object_amTex_002838" Format="i4" Width="16" Height="32" Offset="0x2838" AddedByScript="true"/>
+        <Texture Name="object_amTex_002938" OutName="object_amTex_002938" Format="rgba16" Width="16" Height="32" Offset="0x2938" AddedByScript="true"/>
+        <Texture Name="object_amTex_002D38" OutName="object_amTex_002D38" Format="i4" Width="16" Height="32" Offset="0x2D38" AddedByScript="true"/>
+        <Texture Name="object_amTex_002E38" OutName="object_amTex_002E38" Format="i4" Width="32" Height="32" Offset="0x2E38" AddedByScript="true"/>
+        <Texture Name="object_amTex_003038" OutName="object_amTex_003038" Format="i4" Width="32" Height="32" Offset="0x3038" AddedByScript="true"/>
+        <Texture Name="object_amTex_003238" OutName="object_amTex_003238" Format="rgba16" Width="32" Height="32" Offset="0x3238" AddedByScript="true"/>
+        <Texture Name="object_amTex_003A38" OutName="object_amTex_003A38" Format="rgba16" Width="16" Height="16" Offset="0x3A38" AddedByScript="true"/>
+        <Texture Name="object_amTex_003C38" OutName="object_amTex_003C38" Format="rgba16" Width="32" Height="32" Offset="0x3C38" AddedByScript="true"/>
+        <Texture Name="object_amTex_004438" OutName="object_amTex_004438" Format="rgba16" Width="32" Height="32" Offset="0x4438" AddedByScript="true"/>
+        <Texture Name="object_amTex_004C38" OutName="object_amTex_004C38" Format="rgba16" Width="32" Height="32" Offset="0x4C38" AddedByScript="true"/>
+        <Texture Name="object_amTex_005438" OutName="object_amTex_005438" Format="i4" Width="16" Height="8" Offset="0x5438" AddedByScript="true"/>
+        <Texture Name="object_amTex_005478" OutName="object_amTex_005478" Format="rgba16" Width="16" Height="32" Offset="0x5478" AddedByScript="true"/>
         <Skeleton Name="gArmosSkel" Type="Normal" LimbType="Standard" Offset="0x5948"/>
         <Animation Name="gArmosRicochetAnim" Offset="0x33C"/>
         <Animation Name="gArmosHopAnim" Offset="0x238"/>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_ani.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_ani.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_ani" Segment="6">
+        <Texture Name="object_aniTex_0011D8" OutName="object_aniTex_0011D8" Format="ci8" Width="16" Height="16" Offset="0x11D8" TlutOffset="0x1088" AddedByScript="true"/>
         <!-- Kakariko Roof Man Skeleton -->
         <Skeleton Name="gRoofManSkel" Type="Flex" LimbType="Standard" Offset="0xF0"/>
 

--- a/soh/assets/xml/GC_NMQ_D/objects/object_anubice.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_anubice.xml
@@ -1,5 +1,14 @@
 <Root>
     <File Name="object_anubice" Segment="6">
+        <Texture Name="object_anubiceTex_000F90" OutName="object_anubiceTex_000F90" Format="rgba16" Width="8" Height="16" Offset="0xF90" AddedByScript="true"/>
+        <Texture Name="object_anubiceTex_001090" OutName="object_anubiceTex_001090" Format="rgba16" Width="4" Height="16" Offset="0x1090" AddedByScript="true"/>
+        <Texture Name="object_anubiceTex_001110" OutName="object_anubiceTex_001110" Format="rgba16" Width="16" Height="32" Offset="0x1110" AddedByScript="true"/>
+        <Texture Name="object_anubiceTex_001510" OutName="object_anubiceTex_001510" Format="rgba16" Width="8" Height="8" Offset="0x1510" AddedByScript="true"/>
+        <Texture Name="object_anubiceTex_001590" OutName="object_anubiceTex_001590" Format="rgba16" Width="8" Height="8" Offset="0x1590" AddedByScript="true"/>
+        <Texture Name="object_anubiceTex_001610" OutName="object_anubiceTex_001610" Format="rgba16" Width="4" Height="16" Offset="0x1610" AddedByScript="true"/>
+        <Texture Name="object_anubiceTex_001690" OutName="object_anubiceTex_001690" Format="ia16" Width="32" Height="16" Offset="0x1690" AddedByScript="true"/>
+        <Texture Name="object_anubiceTex_001A90" OutName="object_anubiceTex_001A90" Format="rgba16" Width="8" Height="8" Offset="0x1A90" AddedByScript="true"/>
+        <Texture Name="object_anubiceTex_0036A0" OutName="object_anubiceTex_0036A0" Format="i4" Width="32" Height="32" Offset="0x36A0" AddedByScript="true"/>
         <Skeleton Name="gAnubiceSkel" Type="Normal" LimbType="Standard" Offset="0x3990"/>
 
         <Animation Name="gAnubiceFallDownAnim" Offset="0x348"/>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_blkobj.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_blkobj.xml
@@ -1,5 +1,27 @@
 <Root>
     <File Name="object_blkobj" Segment="6">
+        <Texture Name="object_blkobjTex_008090" OutName="object_blkobjTex_008090" Format="rgba16" Width="32" Height="32" Offset="0x8090" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_008890" OutName="object_blkobjTex_008890" Format="rgba16" Width="32" Height="32" Offset="0x8890" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_009090" OutName="object_blkobjTex_009090" Format="rgba16" Width="32" Height="32" Offset="0x9090" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_009890" OutName="object_blkobjTex_009890" Format="rgba16" Width="32" Height="32" Offset="0x9890" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_00A090" OutName="object_blkobjTex_00A090" Format="ia16" Width="32" Height="32" Offset="0xA090" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_00A890" OutName="object_blkobjTex_00A890" Format="rgba16" Width="32" Height="32" Offset="0xA890" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_00B090" OutName="object_blkobjTex_00B090" Format="rgba16" Width="32" Height="32" Offset="0xB090" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_00B890" OutName="object_blkobjTex_00B890" Format="rgba16" Width="32" Height="32" Offset="0xB890" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_00C090" OutName="object_blkobjTex_00C090" Format="rgba16" Width="32" Height="32" Offset="0xC090" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_00C890" OutName="object_blkobjTex_00C890" Format="rgba16" Width="32" Height="32" Offset="0xC890" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_00D090" OutName="object_blkobjTex_00D090" Format="rgba16" Width="32" Height="32" Offset="0xD090" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_00D890" OutName="object_blkobjTex_00D890" Format="rgba16" Width="32" Height="32" Offset="0xD890" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_00E090" OutName="object_blkobjTex_00E090" Format="rgba16" Width="32" Height="32" Offset="0xE090" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_00E890" OutName="object_blkobjTex_00E890" Format="rgba16" Width="32" Height="64" Offset="0xE890" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_00F890" OutName="object_blkobjTex_00F890" Format="rgba16" Width="32" Height="32" Offset="0xF890" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_010090" OutName="object_blkobjTex_010090" Format="rgba16" Width="32" Height="32" Offset="0x10090" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_010890" OutName="object_blkobjTex_010890" Format="rgba16" Width="32" Height="32" Offset="0x10890" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_011090" OutName="object_blkobjTex_011090" Format="rgba16" Width="32" Height="32" Offset="0x11090" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_011890" OutName="object_blkobjTex_011890" Format="rgba16" Width="32" Height="32" Offset="0x11890" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_012090" OutName="object_blkobjTex_012090" Format="rgba16" Width="32" Height="32" Offset="0x12090" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_012890" OutName="object_blkobjTex_012890" Format="rgba16" Width="32" Height="32" Offset="0x12890" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_013090" OutName="object_blkobjTex_013090" Format="rgba16" Width="32" Height="32" Offset="0x13090" AddedByScript="true"/>
         <!-- Illusion Room Collision -->
         <Collision Name="gIllusionRoomCol" Offset="0x7564"/>
 

--- a/soh/assets/xml/GC_NMQ_D/objects/object_box.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_box.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_box" Segment="6">
+        <Texture Name="object_boxTex_004F80" OutName="object_boxTex_004F80" Format="i8" Width="64" Height="32" Offset="0x4F80" AddedByScript="true"/>
         <Skeleton Name="gTreasureChestCurveSkel" Type="Curve" LimbType="Curve" Offset="0x5EB8"/>
         <CurveAnimation Name="gTreasureChestCurveAnim_4B60" SkelOffset="0x5EB8" Offset="0x4B60"/>
         <CurveAnimation Name="gTreasureChestCurveAnim_4F70" SkelOffset="0x5EB8" Offset="0x4F70"/>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_bv.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_bv.xml
@@ -1,5 +1,42 @@
 <Root>
     <File Name="object_bv" Segment="6">
+        <Texture Name="object_bvTex_000040" OutName="object_bvTex_000040" Format="ia16" Width="16" Height="64" Offset="0x40" AddedByScript="true"/>
+        <Texture Name="object_bvTex_000840" OutName="object_bvTex_000840" Format="ia16" Width="16" Height="16" Offset="0x840" AddedByScript="true"/>
+        <Texture Name="object_bvTex_000A40" OutName="object_bvTex_000A40" Format="i8" Width="16" Height="32" Offset="0xA40" AddedByScript="true"/>
+        <Texture Name="object_bvTex_0051A0" OutName="object_bvTex_0051A0" Format="rgba16" Width="8" Height="16" Offset="0x51A0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_0052A0" OutName="object_bvTex_0052A0" Format="rgba16" Width="8" Height="16" Offset="0x52A0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_0053A0" OutName="object_bvTex_0053A0" Format="rgba16" Width="16" Height="16" Offset="0x53A0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_0055A0" OutName="object_bvTex_0055A0" Format="ia16" Width="16" Height="32" Offset="0x55A0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_0059A0" OutName="object_bvTex_0059A0" Format="ia16" Width="16" Height="32" Offset="0x59A0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_005DA0" OutName="object_bvTex_005DA0" Format="ia16" Width="16" Height="64" Offset="0x5DA0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_0065A0" OutName="object_bvTex_0065A0" Format="i8" Width="16" Height="32" Offset="0x65A0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_008F88" OutName="object_bvTex_008F88" Format="i8" Width="32" Height="32" Offset="0x8F88" AddedByScript="true"/>
+        <Texture Name="object_bvTex_0117B8" OutName="object_bvTex_0117B8" Format="rgba16" Width="16" Height="16" Offset="0x117B8" AddedByScript="true"/>
+        <Texture Name="object_bvTex_0119B8" OutName="object_bvTex_0119B8" Format="rgba16" Width="16" Height="16" Offset="0x119B8" AddedByScript="true"/>
+        <Texture Name="object_bvTex_011BB8" OutName="object_bvTex_011BB8" Format="rgba16" Width="16" Height="16" Offset="0x11BB8" AddedByScript="true"/>
+        <Texture Name="object_bvTex_012CE0" OutName="object_bvTex_012CE0" Format="i8" Width="64" Height="32" Offset="0x12CE0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_013660" OutName="object_bvTex_013660" Format="ia16" Width="64" Height="64" Offset="0x13660" AddedByScript="true"/>
+        <Texture Name="object_bvTex_0170D8" OutName="object_bvTex_0170D8" Format="rgba16" Width="16" Height="8" Offset="0x170D8" AddedByScript="true"/>
+        <Texture Name="object_bvTex_0171D8" OutName="object_bvTex_0171D8" Format="rgba16" Width="16" Height="16" Offset="0x171D8" AddedByScript="true"/>
+        <Texture Name="object_bvTex_018770" OutName="object_bvTex_018770" Format="rgba16" Width="8" Height="8" Offset="0x18770" AddedByScript="true"/>
+        <Texture Name="object_bvTex_018D30" OutName="object_bvTex_018D30" Format="rgba16" Width="16" Height="8" Offset="0x18D30" AddedByScript="true"/>
+        <Texture Name="object_bvTex_018E30" OutName="object_bvTex_018E30" Format="rgba16" Width="16" Height="16" Offset="0x18E30" AddedByScript="true"/>
+        <Texture Name="object_bvTex_019BB8" OutName="object_bvTex_019BB8" Format="ci8" Width="32" Height="64" Offset="0x19BB8" TlutOffset="0x199B0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_01A6B8" OutName="object_bvTex_01A6B8" Format="ci8" Width="32" Height="64" Offset="0x1A6B8" TlutOffset="0x1A4B0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_01B1B8" OutName="object_bvTex_01B1B8" Format="ci8" Width="32" Height="64" Offset="0x1B1B8" TlutOffset="0x1AFB0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_01BCB8" OutName="object_bvTex_01BCB8" Format="ci8" Width="32" Height="64" Offset="0x1BCB8" TlutOffset="0x1BAB0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_01C7B8" OutName="object_bvTex_01C7B8" Format="ci8" Width="32" Height="64" Offset="0x1C7B8" TlutOffset="0x1C5B0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_01D2B8" OutName="object_bvTex_01D2B8" Format="ci8" Width="32" Height="64" Offset="0x1D2B8" TlutOffset="0x1D0B0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_01DDB8" OutName="object_bvTex_01DDB8" Format="ci8" Width="32" Height="64" Offset="0x1DDB8" TlutOffset="0x1DBB0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_01E8B8" OutName="object_bvTex_01E8B8" Format="ci8" Width="32" Height="64" Offset="0x1E8B8" TlutOffset="0x1E6B0" AddedByScript="true"/>
+        <Texture Name="object_bvTLUT_0199B0" OutName="object_bvTLUT_0199B0" Format="rgba16" Width="16" Height="16" Offset="0x199B0" AddedByScript="true"/>
+        <Texture Name="object_bvTLUT_01A4B0" OutName="object_bvTLUT_01A4B0" Format="rgba16" Width="16" Height="16" Offset="0x1A4B0" AddedByScript="true"/>
+        <Texture Name="object_bvTLUT_01AFB0" OutName="object_bvTLUT_01AFB0" Format="rgba16" Width="16" Height="16" Offset="0x1AFB0" AddedByScript="true"/>
+        <Texture Name="object_bvTLUT_01BAB0" OutName="object_bvTLUT_01BAB0" Format="rgba16" Width="16" Height="16" Offset="0x1BAB0" AddedByScript="true"/>
+        <Texture Name="object_bvTLUT_01C5B0" OutName="object_bvTLUT_01C5B0" Format="rgba16" Width="16" Height="16" Offset="0x1C5B0" AddedByScript="true"/>
+        <Texture Name="object_bvTLUT_01D0B0" OutName="object_bvTLUT_01D0B0" Format="rgba16" Width="16" Height="16" Offset="0x1D0B0" AddedByScript="true"/>
+        <Texture Name="object_bvTLUT_01DBB0" OutName="object_bvTLUT_01DBB0" Format="rgba16" Width="16" Height="16" Offset="0x1DBB0" AddedByScript="true"/>
+        <Texture Name="object_bvTLUT_01E6B0" OutName="object_bvTLUT_01E6B0" Format="rgba16" Width="16" Height="16" Offset="0x1E6B0" AddedByScript="true"/>
         <!-- Boss title card -->
         <Texture Name="gBarinadeTitleCardTex" OutName="barinade_title_card" Format="i8" Width="128" Height="120" Offset="0x1230"/>
 

--- a/soh/assets/xml/GC_NMQ_D/objects/object_demo_kekkai.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_demo_kekkai.xml
@@ -1,5 +1,21 @@
 <Root>
     <File Name="object_demo_kekkai" Segment="6">
+        <Texture Name="object_demo_kekkaiTex_000000" OutName="object_demo_kekkaiTex_000000" Format="i8" Width="32" Height="64" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_000800" OutName="object_demo_kekkaiTex_000800" Format="i8" Width="32" Height="64" Offset="0x800" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_001000" OutName="object_demo_kekkaiTex_001000" Format="rgba16" Width="32" Height="64" Offset="0x1000" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_002450" OutName="object_demo_kekkaiTex_002450" Format="rgba16" Width="32" Height="64" Offset="0x2450" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_0036A0" OutName="object_demo_kekkaiTex_0036A0" Format="rgba16" Width="32" Height="32" Offset="0x36A0" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_003EA0" OutName="object_demo_kekkaiTex_003EA0" Format="i8" Width="32" Height="32" Offset="0x3EA0" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_004AC0" OutName="object_demo_kekkaiTex_004AC0" Format="i8" Width="32" Height="32" Offset="0x4AC0" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_006140" OutName="object_demo_kekkaiTex_006140" Format="ia16" Width="8" Height="128" Offset="0x6140" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_006940" OutName="object_demo_kekkaiTex_006940" Format="ia8" Width="64" Height="64" Offset="0x6940" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_007DB0" OutName="object_demo_kekkaiTex_007DB0" Format="rgba16" Width="32" Height="32" Offset="0x7DB0" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_0089D0" OutName="object_demo_kekkaiTex_0089D0" Format="rgba16" Width="32" Height="32" Offset="0x89D0" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_0092D0" OutName="object_demo_kekkaiTex_0092D0" Format="rgba16" Width="32" Height="64" Offset="0x92D0" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_00A440" OutName="object_demo_kekkaiTex_00A440" Format="rgba16" Width="64" Height="32" Offset="0xA440" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_00B540" OutName="object_demo_kekkaiTex_00B540" Format="ia16" Width="32" Height="32" Offset="0xB540" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_00C0B0" OutName="object_demo_kekkaiTex_00C0B0" Format="rgba16" Width="32" Height="32" Offset="0xC0B0" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_00C8B0" OutName="object_demo_kekkaiTex_00C8B0" Format="rgba16" Width="32" Height="64" Offset="0xC8B0" AddedByScript="true"/>
         <!-- Demo_Kekkai -->
         <DList Name="gTowerBarrierDL" Offset="0x4930"/>
         <DList Name="gTrialBarrierFloorDL" Offset="0x4F00"/>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_dnk.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_dnk.xml
@@ -1,5 +1,10 @@
 <Root>
     <File Name="object_dnk" Segment="6">
+        <Texture Name="object_dnkTex_001BD0" OutName="object_dnkTex_001BD0" Format="rgba16" Width="32" Height="32" Offset="0x1BD0" AddedByScript="true"/>
+        <Texture Name="object_dnkTex_0023D0" OutName="object_dnkTex_0023D0" Format="rgba16" Width="16" Height="16" Offset="0x23D0" AddedByScript="true"/>
+        <Texture Name="object_dnkTex_002650" OutName="object_dnkTex_002650" Format="rgba16" Width="8" Height="8" Offset="0x2650" AddedByScript="true"/>
+        <Texture Name="object_dnkTex_0026D0" OutName="object_dnkTex_0026D0" Format="rgba16" Width="8" Height="8" Offset="0x26D0" AddedByScript="true"/>
+        <Texture Name="object_dnkTex_002850" OutName="object_dnkTex_002850" Format="rgba16" Width="16" Height="16" Offset="0x2850" AddedByScript="true"/>
         <!-- Forest Stage scrub skeleton -->
         <Skeleton Name="gDntStageSkel" Type="Normal" LimbType="Standard" Offset="0x2AF0"/>
         

--- a/soh/assets/xml/GC_NMQ_D/objects/object_dns.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_dns.xml
@@ -1,5 +1,10 @@
 <Root>
     <File Name="object_dns" Segment="6">
+        <Texture Name="object_dnsTex_0024A0" OutName="object_dnsTex_0024A0" Format="rgba16" Width="32" Height="32" Offset="0x24A0" AddedByScript="true"/>
+        <Texture Name="object_dnsTex_002CA0" OutName="object_dnsTex_002CA0" Format="rgba16" Width="16" Height="16" Offset="0x2CA0" AddedByScript="true"/>
+        <Texture Name="object_dnsTex_002F20" OutName="object_dnsTex_002F20" Format="rgba16" Width="8" Height="8" Offset="0x2F20" AddedByScript="true"/>
+        <Texture Name="object_dnsTex_002FA0" OutName="object_dnsTex_002FA0" Format="rgba16" Width="8" Height="8" Offset="0x2FA0" AddedByScript="true"/>
+        <Texture Name="object_dnsTex_003120" OutName="object_dnsTex_003120" Format="rgba16" Width="16" Height="16" Offset="0x3120" AddedByScript="true"/>
         <!-- Forest Stage leader skeleton -->
         <Skeleton Name="gDntJijiSkel" Type="Normal" LimbType="Standard" Offset="0x33E0"/>
 

--- a/soh/assets/xml/GC_NMQ_D/objects/object_fd.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_fd.xml
@@ -1,5 +1,32 @@
 <Root>
     <File Name="object_fd" Segment="6">
+        <Texture Name="object_fdTex_000458" OutName="object_fdTex_000458" Format="ci4" Width="32" Height="32" Offset="0x458" TlutOffset="0x438" AddedByScript="true"/>
+        <Texture Name="object_fdTex_000658" OutName="object_fdTex_000658" Format="ci4" Width="32" Height="64" Offset="0x658" TlutOffset="0x438" AddedByScript="true"/>
+        <Texture Name="object_fdTex_000A78" OutName="object_fdTex_000A78" Format="ci4" Width="32" Height="32" Offset="0xA78" TlutOffset="0xA58" AddedByScript="true"/>
+        <Texture Name="object_fdTex_0040A8" OutName="object_fdTex_0040A8" Format="rgba16" Width="32" Height="32" Offset="0x40A8" AddedByScript="true"/>
+        <Texture Name="object_fdTex_0048A8" OutName="object_fdTex_0048A8" Format="rgba16" Width="32" Height="32" Offset="0x48A8" AddedByScript="true"/>
+        <Texture Name="object_fdTex_0050A8" OutName="object_fdTex_0050A8" Format="rgba16" Width="16" Height="16" Offset="0x50A8" AddedByScript="true"/>
+        <Texture Name="object_fdTex_0052A8" OutName="object_fdTex_0052A8" Format="rgba16" Width="16" Height="16" Offset="0x52A8" AddedByScript="true"/>
+        <Texture Name="object_fdTex_0054A8" OutName="object_fdTex_0054A8" Format="rgba16" Width="16" Height="16" Offset="0x54A8" AddedByScript="true"/>
+        <Texture Name="object_fdTex_0056A8" OutName="object_fdTex_0056A8" Format="rgba16" Width="16" Height="16" Offset="0x56A8" AddedByScript="true"/>
+        <Texture Name="object_fdTex_005B60" OutName="object_fdTex_005B60" Format="rgba16" Width="16" Height="16" Offset="0x5B60" AddedByScript="true"/>
+        <Texture Name="object_fdTex_005D60" OutName="object_fdTex_005D60" Format="rgba16" Width="16" Height="16" Offset="0x5D60" AddedByScript="true"/>
+        <Texture Name="object_fdTex_005F60" OutName="object_fdTex_005F60" Format="rgba16" Width="16" Height="16" Offset="0x5F60" AddedByScript="true"/>
+        <Texture Name="object_fdTex_009208" OutName="object_fdTex_009208" Format="i8" Width="16" Height="16" Offset="0x9208" AddedByScript="true"/>
+        <Texture Name="object_fdTex_009780" OutName="object_fdTex_009780" Format="rgba16" Width="16" Height="16" Offset="0x9780" AddedByScript="true"/>
+        <Texture Name="object_fdTex_009980" OutName="object_fdTex_009980" Format="rgba16" Width="16" Height="16" Offset="0x9980" AddedByScript="true"/>
+        <Texture Name="object_fdTex_00A050" OutName="object_fdTex_00A050" Format="rgba16" Width="32" Height="32" Offset="0xA050" AddedByScript="true"/>
+        <Texture Name="object_fdTex_00A918" OutName="object_fdTex_00A918" Format="i8" Width="16" Height="16" Offset="0xA918" AddedByScript="true"/>
+        <Texture Name="object_fdTex_00AA18" OutName="object_fdTex_00AA18" Format="rgba16" Width="32" Height="32" Offset="0xAA18" AddedByScript="true"/>
+        <Texture Name="object_fdTex_00B458" OutName="object_fdTex_00B458" Format="rgba16" Width="32" Height="32" Offset="0xB458" AddedByScript="true"/>
+        <Texture Name="object_fdTex_00BC58" OutName="object_fdTex_00BC58" Format="rgba16" Width="16" Height="16" Offset="0xBC58" AddedByScript="true"/>
+        <Texture Name="object_fdTex_00BE58" OutName="object_fdTex_00BE58" Format="rgba16" Width="16" Height="16" Offset="0xBE58" AddedByScript="true"/>
+        <Texture Name="object_fdTex_00C058" OutName="object_fdTex_00C058" Format="rgba16" Width="16" Height="16" Offset="0xC058" AddedByScript="true"/>
+        <Texture Name="object_fdTex_00D170" OutName="object_fdTex_00D170" Format="rgba16" Width="16" Height="16" Offset="0xD170" AddedByScript="true"/>
+        <Texture Name="object_fdTex_00D438" OutName="object_fdTex_00D438" Format="rgba16" Width="16" Height="16" Offset="0xD438" AddedByScript="true"/>
+        <Texture Name="object_fdTLUT_000438" OutName="object_fdTLUT_000438" Format="rgba16" Width="4" Height="4" Offset="0x438" AddedByScript="true"/>
+        <Texture Name="object_fdTLUT_000A58" OutName="object_fdTLUT_000A58" Format="rgba16" Width="4" Height="4" Offset="0xA58" AddedByScript="true"/>
+        <Texture Name="object_fdTLUT_0032A8" OutName="object_fdTLUT_0032A8" Format="rgba16" Width="16" Height="16" Offset="0x32A8" AddedByScript="true"/>
         <!-- Boss title card -->
         <Texture Name="gVolvagiaBossTitleCardTex" OutName="volvagia_boss_title_card" Format="i8" Width="128" Height="120" Offset="0xD700"/>
 

--- a/soh/assets/xml/GC_NMQ_D/objects/object_fd2.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_fd2.xml
@@ -1,5 +1,16 @@
 <Root>
     <File Name="object_fd2" Segment="6">
+        <Texture Name="object_fd2Tex_003308" OutName="object_fd2Tex_003308" Format="rgba16" Width="32" Height="32" Offset="0x3308" AddedByScript="true"/>
+        <Texture Name="object_fd2Tex_003B08" OutName="object_fd2Tex_003B08" Format="rgba16" Width="32" Height="32" Offset="0x3B08" AddedByScript="true"/>
+        <Texture Name="object_fd2Tex_004308" OutName="object_fd2Tex_004308" Format="rgba16" Width="16" Height="16" Offset="0x4308" AddedByScript="true"/>
+        <Texture Name="object_fd2Tex_004508" OutName="object_fd2Tex_004508" Format="rgba16" Width="16" Height="16" Offset="0x4508" AddedByScript="true"/>
+        <Texture Name="object_fd2Tex_004708" OutName="object_fd2Tex_004708" Format="rgba16" Width="16" Height="16" Offset="0x4708" AddedByScript="true"/>
+        <Texture Name="object_fd2Tex_004908" OutName="object_fd2Tex_004908" Format="rgba16" Width="16" Height="16" Offset="0x4908" AddedByScript="true"/>
+        <Texture Name="object_fd2Tex_004BE8" OutName="object_fd2Tex_004BE8" Format="i8" Width="16" Height="16" Offset="0x4BE8" AddedByScript="true"/>
+        <Texture Name="object_fd2Tex_004FA0" OutName="object_fd2Tex_004FA0" Format="rgba16" Width="16" Height="16" Offset="0x4FA0" AddedByScript="true"/>
+        <Texture Name="object_fd2Tex_0051A0" OutName="object_fd2Tex_0051A0" Format="rgba16" Width="16" Height="16" Offset="0x51A0" AddedByScript="true"/>
+        <Texture Name="object_fd2Tex_0053A0" OutName="object_fd2Tex_0053A0" Format="rgba16" Width="16" Height="16" Offset="0x53A0" AddedByScript="true"/>
+        <Texture Name="object_fd2TLUT_002508" OutName="object_fd2TLUT_002508" Format="rgba16" Width="16" Height="16" Offset="0x2508" AddedByScript="true"/>
         <!-- Skeleton -->
         <Skeleton Name="gHoleVolvagiaSkel" Type="Flex" LimbType="Standard" Offset="0x11A78"/>
 

--- a/soh/assets/xml/GC_NMQ_D/objects/object_fhg.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_fhg.xml
@@ -1,6 +1,26 @@
 <Root>
     <File Name="object_fhg" Segment="6">
 
+        <Texture Name="object_fhgTex_003320" OutName="object_fhgTex_003320" Format="rgba16" Width="16" Height="16" Offset="0x3320" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_003520" OutName="object_fhgTex_003520" Format="rgba16" Width="16" Height="16" Offset="0x3520" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_003720" OutName="object_fhgTex_003720" Format="rgba16" Width="16" Height="16" Offset="0x3720" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_003920" OutName="object_fhgTex_003920" Format="rgba16" Width="16" Height="16" Offset="0x3920" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_003B20" OutName="object_fhgTex_003B20" Format="rgba16" Width="8" Height="8" Offset="0x3B20" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_003BA0" OutName="object_fhgTex_003BA0" Format="rgba16" Width="16" Height="16" Offset="0x3BA0" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_003DA0" OutName="object_fhgTex_003DA0" Format="rgba16" Width="16" Height="16" Offset="0x3DA0" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_003FA0" OutName="object_fhgTex_003FA0" Format="rgba16" Width="16" Height="32" Offset="0x3FA0" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_0043A0" OutName="object_fhgTex_0043A0" Format="rgba16" Width="16" Height="8" Offset="0x43A0" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_0044A0" OutName="object_fhgTex_0044A0" Format="rgba16" Width="32" Height="32" Offset="0x44A0" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_004CA0" OutName="object_fhgTex_004CA0" Format="rgba16" Width="8" Height="16" Offset="0x4CA0" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_004DA0" OutName="object_fhgTex_004DA0" Format="rgba16" Width="8" Height="8" Offset="0x4DA0" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_00D040" OutName="object_fhgTex_00D040" Format="rgba16" Width="4" Height="4" Offset="0xD040" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_00D060" OutName="object_fhgTex_00D060" Format="rgba16" Width="16" Height="16" Offset="0xD060" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_00E8B0" OutName="object_fhgTex_00E8B0" Format="i4" Width="64" Height="64" Offset="0xE8B0" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_00F0B0" OutName="object_fhgTex_00F0B0" Format="i4" Width="64" Height="64" Offset="0xF0B0" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_00FD98" OutName="object_fhgTex_00FD98" Format="i8" Width="64" Height="32" Offset="0xFD98" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_010660" OutName="object_fhgTex_010660" Format="i4" Width="32" Height="96" Offset="0x10660" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_010D20" OutName="object_fhgTex_010D20" Format="i8" Width="32" Height="32" Offset="0x10D20" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_011120" OutName="object_fhgTex_011120" Format="i8" Width="64" Height="64" Offset="0x11120" AddedByScript="true"/>
         <!-- Skeleton -->
         <Skeleton Name="gPhantomHorseSkel" Type="Normal" LimbType="Skin" Offset="0xB098"/>
 

--- a/soh/assets/xml/GC_NMQ_D/objects/object_fw.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_fw.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_fw" Segment="6">
+        <Texture Name="object_fwTex_007A90" OutName="object_fwTex_007A90" Format="i8" Width="16" Height="16" Offset="0x7A90" AddedByScript="true"/>
         <!-- Flare Dancer Enflamed Skeleton -->
         <Skeleton Name="gFlareDancerSkel" Type="Flex" LimbType="Standard" Offset="0x5810"/>
 

--- a/soh/assets/xml/GC_NMQ_D/objects/object_geldb.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_geldb.xml
@@ -1,5 +1,21 @@
 <Root>
     <File Name="object_geldb" Segment="6">
+        <Texture Name="object_geldbTex_002700" OutName="object_geldbTex_002700" Format="ci8" Width="8" Height="8" Offset="0x2700" TlutOffset="0x2500" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_002740" OutName="object_geldbTex_002740" Format="ci8" Width="8" Height="8" Offset="0x2740" TlutOffset="0x2500" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_002780" OutName="object_geldbTex_002780" Format="ci8" Width="16" Height="16" Offset="0x2780" TlutOffset="0x2500" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_002880" OutName="object_geldbTex_002880" Format="i8" Width="16" Height="16" Offset="0x2880" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_002980" OutName="object_geldbTex_002980" Format="ci8" Width="16" Height="16" Offset="0x2980" TlutOffset="0x2500" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_002A80" OutName="object_geldbTex_002A80" Format="i8" Width="16" Height="16" Offset="0x2A80" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_002B80" OutName="object_geldbTex_002B80" Format="i8" Width="8" Height="16" Offset="0x2B80" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_005F68" OutName="object_geldbTex_005F68" Format="ci8" Width="8" Height="16" Offset="0x5F68" TlutOffset="0x5D30" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_0063E8" OutName="object_geldbTex_0063E8" Format="i8" Width="16" Height="16" Offset="0x63E8" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_0064E8" OutName="object_geldbTex_0064E8" Format="ci8" Width="8" Height="16" Offset="0x64E8" TlutOffset="0x5D30" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_006568" OutName="object_geldbTex_006568" Format="ci8" Width="8" Height="8" Offset="0x6568" TlutOffset="0x5D30" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_0069A8" OutName="object_geldbTex_0069A8" Format="i8" Width="8" Height="16" Offset="0x69A8" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_006A28" OutName="object_geldbTex_006A28" Format="ci8" Width="16" Height="16" Offset="0x6A28" TlutOffset="0x5D30" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_006B28" OutName="object_geldbTex_006B28" Format="ci8" Width="16" Height="16" Offset="0x6B28" TlutOffset="0x5D30" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_006C28" OutName="object_geldbTex_006C28" Format="ci8" Width="16" Height="16" Offset="0x6C28" TlutOffset="0x5D30" AddedByScript="true"/>
+        <Texture Name="object_geldbTLUT_002500" OutName="object_geldbTLUT_002500" Format="rgba16" Width="16" Height="16" Offset="0x2500" AddedByScript="true"/>
         <!-- Red-clothed Gerudo skeleton -->
         <Skeleton Name="gGerudoRedSkel" Type="Flex" LimbType="Standard" Offset="0xA458"/>
 

--- a/soh/assets/xml/GC_NMQ_D/objects/object_gi_boots_2.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_gi_boots_2.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_boots_2" Segment="6">
+        <Texture Name="object_gi_boots_2Tex_000000" OutName="object_gi_boots_2Tex_000000" Format="ia8" Width="16" Height="16" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiIronBootsDL" Offset="0x1630"/>
         <DList Name="gGiIronBootsRivetsDL" Offset="0x1A98"/>
     </File>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_gi_butterfly.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_gi_butterfly.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_butterfly" Segment="6">
+        <Texture Name="object_gi_butterflyTex_000000" OutName="object_gi_butterflyTex_000000" Format="ia4" Width="24" Height="48" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiButterflyContainerDL" Offset="0x0830"/>
         <DList Name="gGiButterflyGlassDL" Offset="0x0A70"/>
     </File>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_gi_clothes.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_gi_clothes.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_clothes" Segment="6">
+        <Texture Name="object_gi_clothesTex_000000" OutName="object_gi_clothesTex_000000" Format="i4" Width="64" Height="64" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiGoronCollarColorDL" Offset="0x14E0"/>
         <DList Name="gGiZoraCollarColorDL" Offset="0x1500"/>
         <DList Name="gGiGoronTunicColorDL" Offset="0x1520"/>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_gi_dekupouch.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_gi_dekupouch.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_gi_dekupouch" Segment="6">
+        <Texture Name="object_gi_dekupouchTex_000000" OutName="object_gi_dekupouchTex_000000" Format="i4" Width="32" Height="16" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_dekupouchTex_000100" OutName="object_gi_dekupouchTex_000100" Format="i4" Width="32" Height="32" Offset="0x100" AddedByScript="true"/>
         <DList Name="gGiBulletBagColorDL" Offset="0x0AF0"/>
         <DList Name="gGiBulletBag50ColorDL" Offset="0x0B10"/>
         <DList Name="gGiBulletBagStringColorDL" Offset="0x0B30"/>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_gi_fire.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_gi_fire.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_gi_fire" Segment="6">
+        <Texture Name="object_gi_fireTex_000000" OutName="object_gi_fireTex_000000" Format="i8" Width="16" Height="32" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_fireTex_000200" OutName="object_gi_fireTex_000200" Format="i8" Width="16" Height="32" Offset="0x200" AddedByScript="true"/>
         <DList Name="gGiBlueFireChamberstickDL" Offset="0x0C60"/>
         <DList Name="gGiBlueFireFlameDL" Offset="0x0F08"/>
     </File>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_gi_frog.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_gi_frog.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_frog" Segment="6">
+        <Texture Name="object_gi_frogTex_000000" OutName="object_gi_frogTex_000000" Format="i8" Width="32" Height="32" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiFrogDL" Offset="0x0D60"/>
         <DList Name="gGiFrogEyesDL" Offset="0x1060"/>
     </File>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_gi_gerudo.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_gi_gerudo.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_gerudo" Segment="6">
+        <Texture Name="object_gi_gerudoTex_000000" OutName="object_gi_gerudoTex_000000" Format="i8" Width="32" Height="32" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiGerudoCardDL" Offset="0x0F60"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_gi_gerudomask.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_gi_gerudomask.xml
@@ -1,5 +1,10 @@
 <Root>
     <File Name="object_gi_gerudomask" Segment="6">
+        <Texture Name="object_gi_gerudomaskTex_000208" OutName="object_gi_gerudomaskTex_000208" Format="ci8" Width="8" Height="8" Offset="0x208" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_gerudomaskTex_000248" OutName="object_gi_gerudomaskTex_000248" Format="ci8" Width="16" Height="16" Offset="0x248" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_gerudomaskTex_000348" OutName="object_gi_gerudomaskTex_000348" Format="ci8" Width="16" Height="16" Offset="0x348" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_gerudomaskTex_000448" OutName="object_gi_gerudomaskTex_000448" Format="ci8" Width="32" Height="32" Offset="0x448" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_gerudomaskTLUT_000000" OutName="object_gi_gerudomaskTLUT_000000" Format="rgba16" Width="16" Height="16" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiGerudoMaskDL" Offset="0x10E8"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_gi_ghost.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_gi_ghost.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_gi_ghost" Segment="6">
+        <Texture Name="object_gi_ghostTex_000000" OutName="object_gi_ghostTex_000000" Format="i8" Width="16" Height="32" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_ghostTex_000200" OutName="object_gi_ghostTex_000200" Format="i8" Width="16" Height="32" Offset="0x200" AddedByScript="true"/>
         <DList Name="gGiPoeColorDL" Offset="0x0950"/>
         <DList Name="gGiBigPoeColorDL" Offset="0x0970"/>
         <DList Name="gGiGhostContainerLidDL" Offset="0x0990"/>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_gi_gloves.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_gi_gloves.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_gloves" Segment="6">
+        <Texture Name="object_gi_glovesTex_000000" OutName="object_gi_glovesTex_000000" Format="i8" Width="64" Height="32" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiSilverGauntletsColorDL" Offset="0x14C0"/>
         <DList Name="gGiGoldenGauntletsColorDL" Offset="0x14E0"/>
         <DList Name="gGiSilverGauntletsPlateColorDL" Offset="0x1500"/>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_gi_golonmask.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_gi_golonmask.xml
@@ -1,5 +1,10 @@
 <Root>
     <File Name="object_gi_golonmask" Segment="6">
+        <Texture Name="object_gi_golonmaskTex_000208" OutName="object_gi_golonmaskTex_000208" Format="ci8" Width="8" Height="8" Offset="0x208" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_golonmaskTex_000248" OutName="object_gi_golonmaskTex_000248" Format="ci8" Width="16" Height="16" Offset="0x248" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_golonmaskTex_000348" OutName="object_gi_golonmaskTex_000348" Format="ci8" Width="32" Height="32" Offset="0x348" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_golonmaskTex_000748" OutName="object_gi_golonmaskTex_000748" Format="ci8" Width="64" Height="32" Offset="0x748" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_golonmaskTLUT_000000" OutName="object_gi_golonmaskTLUT_000000" Format="rgba16" Width="16" Height="16" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiGoronMaskDL" Offset="0x14F8"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_gi_hoverboots.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_gi_hoverboots.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_gi_hoverboots" Segment="6">
+        <Texture Name="object_gi_hoverbootsTex_000000" OutName="object_gi_hoverbootsTex_000000" Format="ia4" Width="48" Height="32" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_hoverbootsTex_000300" OutName="object_gi_hoverbootsTex_000300" Format="i4" Width="16" Height="32" Offset="0x300" AddedByScript="true"/>
         <DList Name="gGiHoverBootsDL" Offset="0x1850"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_gi_ki_tan_mask.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_gi_ki_tan_mask.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_ki_tan_mask" Segment="6">
+        <Texture Name="object_gi_ki_tan_maskTex_000000" OutName="object_gi_ki_tan_maskTex_000000" Format="ia8" Width="8" Height="32" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiKeatonMaskDL" Offset="0x0AC0"/>
         <DList Name="gGiKeatonMaskEyesDL" Offset="0x0D50"/>
     </File>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_gi_letter.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_gi_letter.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_gi_letter" Segment="6">
+        <Texture Name="object_gi_letterTex_000000" OutName="object_gi_letterTex_000000" Format="i8" Width="48" Height="32" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_letterTex_000600" OutName="object_gi_letterTex_000600" Format="ia8" Width="48" Height="32" Offset="0x600" AddedByScript="true"/>
         <DList Name="gGiLetterDL" Offset="0x0CC0"/>
         <DList Name="gGiLetterWritingDL" Offset="0x0D60"/>
     </File>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_gi_liquid.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_gi_liquid.xml
@@ -1,5 +1,8 @@
 <Root>
     <File Name="object_gi_liquid" Segment="6">
+        <Texture Name="object_gi_liquidTex_000000" OutName="object_gi_liquidTex_000000" Format="ia8" Width="16" Height="32" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_liquidTex_000200" OutName="object_gi_liquidTex_000200" Format="ia8" Width="16" Height="32" Offset="0x200" AddedByScript="true"/>
+        <Texture Name="object_gi_liquidTex_000400" OutName="object_gi_liquidTex_000400" Format="ia8" Width="16" Height="32" Offset="0x400" AddedByScript="true"/>
         <DList Name="gGiGreenPotColorDL" Offset="0x1270"/>
         <DList Name="gGiRedPotColorDL" Offset="0x1290"/>
         <DList Name="gGiBluePotColorDL" Offset="0x12B0"/>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_gi_map.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_gi_map.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_map" Segment="6">
+        <Texture Name="object_gi_mapTex_000D60" OutName="object_gi_mapTex_000D60" Format="i8" Width="32" Height="32" Offset="0xD60" AddedByScript="true"/>
         <DList Name="gGiDungeonMapDL" Offset="0x03C0"/>
         <DList Name="gGiStoneOfAgonyDL" Offset="0x0B70"/>
     </File>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_gi_milk.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_gi_milk.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_milk" Segment="6">
+        <Texture Name="object_gi_milkTex_000000" OutName="object_gi_milkTex_000000" Format="i8" Width="72" Height="24" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiMilkBottleContentsDL" Offset="0x1060"/>
         <DList Name="gGiMilkBottleDL" Offset="0x1288"/>
     </File>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_gi_niwatori.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_gi_niwatori.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_gi_niwatori" Segment="6">
+        <Texture Name="object_gi_niwatoriTex_000000" OutName="object_gi_niwatoriTex_000000" Format="i8" Width="32" Height="64" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_niwatoriTex_000800" OutName="object_gi_niwatoriTex_000800" Format="ia8" Width="32" Height="32" Offset="0x800" AddedByScript="true"/>
         <DList Name="gGiChickenColorDL" Offset="0x15F0"/>
         <DList Name="gGiCojiroColorDL" Offset="0x1610"/>
         <DList Name="gGiChickenDL" Offset="0x1630"/>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_gi_nuts.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_gi_nuts.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_nuts" Segment="6">
+        <Texture Name="object_gi_nutsTex_000000" OutName="object_gi_nutsTex_000000" Format="i8" Width="32" Height="32" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiNutDL" Offset="0x0E90"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_gi_ocarina.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_gi_ocarina.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_ocarina" Segment="6">
+        <Texture Name="object_gi_ocarinaTex_000000" OutName="object_gi_ocarinaTex_000000" Format="i8" Width="16" Height="16" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiOcarinaTimeDL" Offset="0x08C0"/>
         <DList Name="gGiOcarinaTimeHolesDL" Offset="0x0AF8"/>
     </File>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_gi_ocarina_0.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_gi_ocarina_0.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_ocarina_0" Segment="6">
+        <Texture Name="object_gi_ocarina_0Tex_000000" OutName="object_gi_ocarina_0Tex_000000" Format="i8" Width="16" Height="16" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiOcarinaFairyDL" Offset="0x08E0"/>
         <DList Name="gGiOcarinaFairyHolesDL" Offset="0x0B58"/>
     </File>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_gi_prescription.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_gi_prescription.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_prescription" Segment="6">
+        <Texture Name="object_gi_prescriptionTex_000000" OutName="object_gi_prescriptionTex_000000" Format="ia8" Width="32" Height="48" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiPrescriptionDL" Offset="0x09C0"/>
         <DList Name="gGiPrescriptionWritingDL" Offset="0x0AF0"/>
     </File>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_gi_purse.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_gi_purse.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_purse" Segment="6">
+        <Texture Name="object_gi_purseTex_000000" OutName="object_gi_purseTex_000000" Format="i8" Width="64" Height="64" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiAdultWalletColorDL" Offset="0x1750"/>
         <DList Name="gGiGiantsWalletColorDL" Offset="0x1770"/>
         <DList Name="gGiAdultWalletRupeeOuterColorDL" Offset="0x1790"/>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_gi_rabit_mask.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_gi_rabit_mask.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_rabit_mask" Segment="6">
+        <Texture Name="object_gi_rabit_maskTex_000000" OutName="object_gi_rabit_maskTex_000000" Format="ia8" Width="16" Height="16" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiBunnyHoodDL" Offset="0x0BC0"/>
         <DList Name="gGiBunnyHoodEyesDL" Offset="0x0E58"/>
     </File>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_gi_shield_1.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_gi_shield_1.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_shield_1" Segment="6">
+        <Texture Name="object_gi_shield_1Tex_000000" OutName="object_gi_shield_1Tex_000000" Format="i8" Width="32" Height="32" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiDekuShieldDL" Offset="0x0A50"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_gi_shield_3.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_gi_shield_3.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_gi_shield_3" Segment="6">
+        <Texture Name="object_gi_shield_3Tex_000000" OutName="object_gi_shield_3Tex_000000" Format="i4" Width="64" Height="32" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_shield_3Tex_000400" OutName="object_gi_shield_3Tex_000400" Format="i4" Width="64" Height="64" Offset="0x400" AddedByScript="true"/>
         <DList Name="gGiMirrorShieldDL" Offset="0x0FB0"/>
         <DList Name="gGiMirrorShieldSymbolDL" Offset="0x11C8"/>
     </File>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_gi_soldout.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_gi_soldout.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_soldout" Segment="6">
+        <Texture Name="object_gi_soldoutTex_000000" OutName="object_gi_soldoutTex_000000" Format="ia8" Width="32" Height="32" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiSoldOutDL" Offset="0x0440"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_gi_soul.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_gi_soul.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_soul" Segment="6">
+        <Texture Name="object_gi_soulTex_000000" OutName="object_gi_soulTex_000000" Format="i8" Width="32" Height="32" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiFairyContainerBaseCapDL" Offset="0x0BD0"/>
         <DList Name="gGiFairyContainerGlassDL" Offset="0x0DB8"/>
         <DList Name="gGiFairyContainerContentsDL" Offset="0x0EF0"/>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_gi_ticketstone.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_gi_ticketstone.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_gi_ticketstone" Segment="6">
+        <Texture Name="object_gi_ticketstoneTex_000000" OutName="object_gi_ticketstoneTex_000000" Format="i4" Width="48" Height="24" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_ticketstoneTex_000240" OutName="object_gi_ticketstoneTex_000240" Format="i8" Width="32" Height="24" Offset="0x240" AddedByScript="true"/>
         <DList Name="gGiClaimCheckDL" Offset="0x0F00"/>
         <DList Name="gGiClaimCheckWritingDL" Offset="0x1188"/>
     </File>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_gi_truth_mask.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_gi_truth_mask.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_gi_truth_mask" Segment="6">
+        <Texture Name="object_gi_truth_maskTex_000000" OutName="object_gi_truth_maskTex_000000" Format="i8" Width="32" Height="32" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_truth_maskTex_000400" OutName="object_gi_truth_maskTex_000400" Format="i8" Width="32" Height="32" Offset="0x400" AddedByScript="true"/>
         <DList Name="gGiMaskOfTruthDL" Offset="0x13D0"/>
         <DList Name="gGiMaskOfTruthAccentsDL" Offset="0x16B0"/>
     </File>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_gi_zoramask.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_gi_zoramask.xml
@@ -1,5 +1,10 @@
 <Root>
     <File Name="object_gi_zoramask" Segment="6">
+        <Texture Name="object_gi_zoramaskTex_000208" OutName="object_gi_zoramaskTex_000208" Format="ci8" Width="8" Height="8" Offset="0x208" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_zoramaskTex_000248" OutName="object_gi_zoramaskTex_000248" Format="ci8" Width="32" Height="32" Offset="0x248" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_zoramaskTex_000648" OutName="object_gi_zoramaskTex_000648" Format="ci8" Width="32" Height="32" Offset="0x648" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_zoramaskTex_000A48" OutName="object_gi_zoramaskTex_000A48" Format="ci8" Width="32" Height="32" Offset="0xA48" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_zoramaskTLUT_000000" OutName="object_gi_zoramaskTLUT_000000" Format="rgba16" Width="16" Height="16" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiZoraMaskDL" Offset="0x1398"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_gj.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_gj.xml
@@ -1,5 +1,15 @@
 <Root>
     <File Name="object_gj" Segment="6">
+        <Texture Name="object_gjTex_003B20" OutName="object_gjTex_003B20" Format="ia8" Width="16" Height="16" Offset="0x3B20" AddedByScript="true"/>
+        <Texture Name="object_gjTex_003C20" OutName="object_gjTex_003C20" Format="i4" Width="16" Height="32" Offset="0x3C20" AddedByScript="true"/>
+        <Texture Name="object_gjTex_003D20" OutName="object_gjTex_003D20" Format="rgba16" Width="16" Height="16" Offset="0x3D20" AddedByScript="true"/>
+        <Texture Name="object_gjTex_003F20" OutName="object_gjTex_003F20" Format="i8" Width="64" Height="64" Offset="0x3F20" AddedByScript="true"/>
+        <Texture Name="object_gjTex_004F20" OutName="object_gjTex_004F20" Format="i8" Width="64" Height="64" Offset="0x4F20" AddedByScript="true"/>
+        <Texture Name="object_gjTex_005F20" OutName="object_gjTex_005F20" Format="i8" Width="64" Height="64" Offset="0x5F20" AddedByScript="true"/>
+        <Texture Name="object_gjTex_006F20" OutName="object_gjTex_006F20" Format="i4" Width="32" Height="64" Offset="0x6F20" AddedByScript="true"/>
+        <Texture Name="object_gjTex_007320" OutName="object_gjTex_007320" Format="i8" Width="64" Height="16" Offset="0x7320" AddedByScript="true"/>
+        <Texture Name="object_gjTex_007720" OutName="object_gjTex_007720" Format="ia8" Width="32" Height="32" Offset="0x7720" AddedByScript="true"/>
+        <Texture Name="object_gjTex_007B20" OutName="object_gjTex_007B20" Format="i8" Width="128" Height="32" Offset="0x7B20" AddedByScript="true"/>
         <!-- This is the decorative rubble around the fight arena -->
         <DList Name="gGanonsCastleRubbleAroundArenaDL" Offset="0xDC0"/>
         <Collision Name="gGanonsCastleRubbleAroundArenaCol" Offset="0x1B70"/>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_gnd.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_gnd.xml
@@ -1,6 +1,7 @@
 <Root>
     <File Name="object_gnd" Segment="6">
         
+        <Texture Name="object_gndTex_012B50" OutName="object_gndTex_012B50" Format="rgba16" Width="16" Height="32" Offset="0x12B50" AddedByScript="true"/>
         <!-- Skeleton -->
         <Skeleton Name="gPhantomGanonSkel" Type="Normal" LimbType="Standard" Offset="0xC710"/>
         

--- a/soh/assets/xml/GC_NMQ_D/objects/object_gr.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_gr.xml
@@ -1,12 +1,23 @@
 <Root>
     <File Name="object_gr" Segment="6">
+        <Texture Name="object_grTex_005D78" OutName="object_grTex_005D78" Format="ci8" Width="16" Height="16" Offset="0x5D78" TlutOffset="0x3F78" AddedByScript="true"/>
+        <Texture Name="object_grTex_005E78" OutName="object_grTex_005E78" Format="ci8" Width="8" Height="8" Offset="0x5E78" TlutOffset="0x3F78" AddedByScript="true"/>
+        <Texture Name="object_grTex_005EB8" OutName="object_grTex_005EB8" Format="ci8" Width="8" Height="8" Offset="0x5EB8" TlutOffset="0x3F78" AddedByScript="true"/>
+        <Texture Name="object_grTex_005EF8" OutName="object_grTex_005EF8" Format="ci8" Width="16" Height="16" Offset="0x5EF8" TlutOffset="0x3F78" AddedByScript="true"/>
+        <Texture Name="object_grTex_0077F8" OutName="object_grTex_0077F8" Format="ci8" Width="32" Height="32" Offset="0x77F8" TlutOffset="0x3F78" AddedByScript="true"/>
+        <Texture Name="object_grTex_007BF8" OutName="object_grTex_007BF8" Format="ci8" Width="32" Height="32" Offset="0x7BF8" TlutOffset="0x3F78" AddedByScript="true"/>
+        <Texture Name="object_grTex_007FF8" OutName="object_grTex_007FF8" Format="ci8" Width="32" Height="32" Offset="0x7FF8" TlutOffset="0x3F78" AddedByScript="true"/>
+        <Texture Name="object_grTex_0083F8" OutName="object_grTex_0083F8" Format="ci8" Width="32" Height="32" Offset="0x83F8" TlutOffset="0x3F78" AddedByScript="true"/>
+        <Texture Name="object_grTex_0097F8" OutName="object_grTex_0097F8" Format="ci8" Width="4" Height="4" Offset="0x97F8" TlutOffset="0x3F78" AddedByScript="true"/>
+        <Texture Name="object_grTex_009808" OutName="object_grTex_009808" Format="ci8" Width="8" Height="8" Offset="0x9808" TlutOffset="0x3F78" AddedByScript="true"/>
+        <Texture Name="object_grTLUT_003F78" OutName="object_grTLUT_003F78" Format="rgba16" Width="16" Height="16" Offset="0x3F78" AddedByScript="true"/>
         <Skeleton Name="gNiwGirlSkel" Type="Flex" LimbType="Standard" Offset="0x9948"/>
         <Animation Name="gNiwGirlRunAnim" Offset="0x0378"/>
         <Animation Name="gNiwGirlJumpAnim" Offset="0x9C78"/>
         <Texture Name="gNiwGirlEyeOpenTex" OutName="eye_open" Format="rgba16" Width="32" Height="32" Offset="0x4178"/>
         <Texture Name="gNiwGirlEyeHalfTex" OutName="eye_half" Format="rgba16" Width="32" Height="32" Offset="0x4978"/>
         <Texture Name="gNiwGirlEyeClosedTex" OutName="eye_closed" Format="rgba16" Width="32" Height="32" Offset="0x5178"/>
-        <Texture Name="gNiwGirlMouthTex"  OutName="mouth" Format="rgba16" Width="32" Height="16" Offset="0x5978"/>
+        <Texture Name="gNiwGirlMouthTex" OutName="mouth" Format="rgba16" Width="32" Height="16" Offset="0x5978"/>
         <Texture Name="gNiwGirlDress1Tex" OutName="dress_1" Format="rgba16" Width="32" Height="32" Offset="0x5FF8"/>
         <Texture Name="gNiwGirlDress2Tex" OutName="dress_2" Format="rgba16" Width="32" Height="32" Offset="0x6FF8"/>
         <Texture Name="gNiwGirlDress3Tex" OutName="dress_3" Format="rgba16" Width="32" Height="32" Offset="0x8FF8"/>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_hakach_objects.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_hakach_objects.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_hakach_objects" Segment="6">
+        <Texture Name="object_hakach_objectsTex_0062F0" OutName="object_hakach_objectsTex_0062F0" Format="rgba16" Width="32" Height="32" Offset="0x62F0" AddedByScript="true"/>
         <DList Name="gBotwHoleTrap1DL" Offset="0x01B0"/>
         <DList Name="gBotwHoleTrap2DL" Offset="0x03F0"/>
         <DList Name="gBotwCoffinLidDL" Offset="0x06B0"/>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_hidan_objects.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_hidan_objects.xml
@@ -1,5 +1,25 @@
 <Root>
     <File Name="object_hidan_objects" Segment="6">
+        <Texture Name="object_hidan_objectsTex_000040" OutName="object_hidan_objectsTex_000040" Format="ci4" Width="32" Height="32" Offset="0x40" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_000240" OutName="object_hidan_objectsTex_000240" Format="rgba16" Width="32" Height="32" Offset="0x240" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_000A40" OutName="object_hidan_objectsTex_000A40" Format="rgba16" Width="32" Height="64" Offset="0xA40" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_001A40" OutName="object_hidan_objectsTex_001A40" Format="rgba16" Width="32" Height="64" Offset="0x1A40" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_002A40" OutName="object_hidan_objectsTex_002A40" Format="rgba16" Width="32" Height="64" Offset="0x2A40" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_003A40" OutName="object_hidan_objectsTex_003A40" Format="rgba16" Width="32" Height="32" Offset="0x3A40" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_004240" OutName="object_hidan_objectsTex_004240" Format="rgba16" Width="16" Height="64" Offset="0x4240" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_004A40" OutName="object_hidan_objectsTex_004A40" Format="rgba16" Width="32" Height="32" Offset="0x4A40" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_005240" OutName="object_hidan_objectsTex_005240" Format="ci4" Width="32" Height="64" Offset="0x5240" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_005640" OutName="object_hidan_objectsTex_005640" Format="ci4" Width="32" Height="64" Offset="0x5640" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_005A40" OutName="object_hidan_objectsTex_005A40" Format="ci4" Width="64" Height="32" Offset="0x5A40" TlutOffset="0x20" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_005E40" OutName="object_hidan_objectsTex_005E40" Format="rgba16" Width="32" Height="32" Offset="0x5E40" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_006640" OutName="object_hidan_objectsTex_006640" Format="ci4" Width="32" Height="64" Offset="0x6640" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_006A40" OutName="object_hidan_objectsTex_006A40" Format="ci4" Width="32" Height="32" Offset="0x6A40" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_006C40" OutName="object_hidan_objectsTex_006C40" Format="ci4" Width="32" Height="32" Offset="0x6C40" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_006E40" OutName="object_hidan_objectsTex_006E40" Format="rgba16" Width="32" Height="32" Offset="0x6E40" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_00FB20" OutName="object_hidan_objectsTex_00FB20" Format="rgba16" Width="32" Height="64" Offset="0xFB20" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_010D90" OutName="object_hidan_objectsTex_010D90" Format="rgba16" Width="32" Height="64" Offset="0x10D90" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTLUT_000000" OutName="object_hidan_objectsTLUT_000000" Format="rgba16" Width="4" Height="4" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTLUT_000020" OutName="object_hidan_objectsTLUT_000020" Format="rgba16" Width="4" Height="4" Offset="0x20" AddedByScript="true"/>
         <DList Name="gFireTempleHammerableTotemBodyDL" Offset="0xBBF0"/>
         <DList Name="gFireTempleHammerableTotemHeadDL" Offset="0xBDF0"/>
         <Collision Name="gFireTempleHammerableTotemCol" Offset="0xDA10"/>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_hintnuts.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_hintnuts.xml
@@ -1,5 +1,11 @@
 <Root>
     <File Name="object_hintnuts" Segment="6">
+        <Texture Name="object_hintnutsTex_0015A8" OutName="object_hintnutsTex_0015A8" Format="rgba16" Width="32" Height="32" Offset="0x15A8" AddedByScript="true"/>
+        <Texture Name="object_hintnutsTex_001DA8" OutName="object_hintnutsTex_001DA8" Format="rgba16" Width="16" Height="16" Offset="0x1DA8" AddedByScript="true"/>
+        <Texture Name="object_hintnutsTex_001FA8" OutName="object_hintnutsTex_001FA8" Format="rgba16" Width="8" Height="8" Offset="0x1FA8" AddedByScript="true"/>
+        <Texture Name="object_hintnutsTex_002028" OutName="object_hintnutsTex_002028" Format="rgba16" Width="8" Height="8" Offset="0x2028" AddedByScript="true"/>
+        <Texture Name="object_hintnutsTex_0020A8" OutName="object_hintnutsTex_0020A8" Format="rgba16" Width="8" Height="8" Offset="0x20A8" AddedByScript="true"/>
+        <Texture Name="object_hintnutsTex_002128" OutName="object_hintnutsTex_002128" Format="rgba16" Width="16" Height="16" Offset="0x2128" AddedByScript="true"/>
         <!-- Deku scrub skeleton -->
         <Skeleton Name="gHintNutsSkel" Type="Normal" LimbType="Standard" Offset="0x23B8"/>
         

--- a/soh/assets/xml/GC_NMQ_D/objects/object_horse_ganon.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_horse_ganon.xml
@@ -1,5 +1,16 @@
 <Root>
     <File Name="object_horse_ganon" Segment="6">
+        <Texture Name="object_horse_ganonTex_00A570" OutName="object_horse_ganonTex_00A570" Format="rgba16" Width="8" Height="8" Offset="0xA570" AddedByScript="true"/>
+        <Texture Name="object_horse_ganonTex_00A5F0" OutName="object_horse_ganonTex_00A5F0" Format="rgba16" Width="16" Height="16" Offset="0xA5F0" AddedByScript="true"/>
+        <Texture Name="object_horse_ganonTex_00A7F0" OutName="object_horse_ganonTex_00A7F0" Format="rgba16" Width="4" Height="4" Offset="0xA7F0" AddedByScript="true"/>
+        <Texture Name="object_horse_ganonTex_00A810" OutName="object_horse_ganonTex_00A810" Format="rgba16" Width="16" Height="16" Offset="0xA810" AddedByScript="true"/>
+        <Texture Name="object_horse_ganonTex_00AA10" OutName="object_horse_ganonTex_00AA10" Format="rgba16" Width="16" Height="16" Offset="0xAA10" AddedByScript="true"/>
+        <Texture Name="object_horse_ganonTex_00B010" OutName="object_horse_ganonTex_00B010" Format="rgba16" Width="8" Height="16" Offset="0xB010" AddedByScript="true"/>
+        <Texture Name="object_horse_ganonTex_00B110" OutName="object_horse_ganonTex_00B110" Format="rgba16" Width="16" Height="32" Offset="0xB110" AddedByScript="true"/>
+        <Texture Name="object_horse_ganonTex_00B510" OutName="object_horse_ganonTex_00B510" Format="rgba16" Width="16" Height="8" Offset="0xB510" AddedByScript="true"/>
+        <Texture Name="object_horse_ganonTex_00B610" OutName="object_horse_ganonTex_00B610" Format="rgba16" Width="8" Height="8" Offset="0xB610" AddedByScript="true"/>
+        <Texture Name="object_horse_ganonTex_00B690" OutName="object_horse_ganonTex_00B690" Format="rgba16" Width="32" Height="32" Offset="0xB690" AddedByScript="true"/>
+        <Texture Name="object_horse_ganonTex_00BE90" OutName="object_horse_ganonTex_00BE90" Format="rgba16" Width="16" Height="16" Offset="0xBE90" AddedByScript="true"/>
         <Skeleton Name="gHorseGanonSkel" Type="Normal" LimbType="Skin" Offset="0x8668"/>
 
         <!-- Idle. Horse moving leg. -->

--- a/soh/assets/xml/GC_NMQ_D/objects/object_horse_link_child.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_horse_link_child.xml
@@ -1,5 +1,14 @@
 <Root>
     <File Name="object_horse_link_child" Segment="6">
+        <Texture Name="object_horse_link_childTex_001F28" OutName="object_horse_link_childTex_001F28" Format="rgba16" Width="4" Height="8" Offset="0x1F28" AddedByScript="true"/>
+        <Texture Name="object_horse_link_childTex_001F68" OutName="object_horse_link_childTex_001F68" Format="rgba16" Width="16" Height="16" Offset="0x1F68" AddedByScript="true"/>
+        <Texture Name="object_horse_link_childTex_002168" OutName="object_horse_link_childTex_002168" Format="rgba16" Width="16" Height="16" Offset="0x2168" AddedByScript="true"/>
+        <Texture Name="object_horse_link_childTex_002368" OutName="object_horse_link_childTex_002368" Format="rgba16" Width="16" Height="16" Offset="0x2368" AddedByScript="true"/>
+        <Texture Name="object_horse_link_childTex_002568" OutName="object_horse_link_childTex_002568" Format="rgba16" Width="4" Height="4" Offset="0x2568" AddedByScript="true"/>
+        <Texture Name="object_horse_link_childTex_002588" OutName="object_horse_link_childTex_002588" Format="rgba16" Width="8" Height="32" Offset="0x2588" AddedByScript="true"/>
+        <Texture Name="object_horse_link_childTex_002788" OutName="object_horse_link_childTex_002788" Format="rgba16" Width="16" Height="16" Offset="0x2788" AddedByScript="true"/>
+        <Texture Name="object_horse_link_childTex_008120" OutName="object_horse_link_childTex_008120" Format="rgba16" Width="16" Height="16" Offset="0x8120" AddedByScript="true"/>
+        <Texture Name="object_horse_link_childTex_008320" OutName="object_horse_link_childTex_008320" Format="rgba16" Width="32" Height="32" Offset="0x8320" AddedByScript="true"/>
         <Skeleton Name="gChildEponaSkel" Type="Normal" LimbType="Skin" Offset="0x7B20"/>
 
         <!-- Idle animation. -->
@@ -14,8 +23,8 @@
         <Animation Name="gChildEponaGallopingAnim" Offset="0x2F98"/>
 
         <Texture Name="gChildEponaEyeTLUT" OutName="child_epona_eye_tlut" Format="rgba16" Width="16" Height="16" Offset="0x1728"/>
-        <Texture Name="gChildEponaEyeOpenTex" OutName="child_epona_eye_open" Format="ci8" Width="32" Height="16" Offset="0x1D28"  TlutOffset="0x1728"/>
-        <Texture Name="gChildEponaEyeHalfTex" OutName="child_epona_eye_half" Format="ci8" Width="32" Height="16" Offset="0x1928"  TlutOffset="0x1728"/>
-        <Texture Name="gChildEponaEyeCloseTex" OutName="child_epona_eye_close" Format="ci8" Width="32" Height="16" Offset="0x1B28"  TlutOffset="0x1728"/>
+        <Texture Name="gChildEponaEyeOpenTex" OutName="child_epona_eye_open" Format="ci8" Width="32" Height="16" Offset="0x1D28" TlutOffset="0x1728"/>
+        <Texture Name="gChildEponaEyeHalfTex" OutName="child_epona_eye_half" Format="ci8" Width="32" Height="16" Offset="0x1928" TlutOffset="0x1728"/>
+        <Texture Name="gChildEponaEyeCloseTex" OutName="child_epona_eye_close" Format="ci8" Width="32" Height="16" Offset="0x1B28" TlutOffset="0x1728"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_horse_normal.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_horse_normal.xml
@@ -1,5 +1,13 @@
 <Root>
     <File Name="object_horse_normal" Segment="6">
+        <Texture Name="object_horse_normalTex_0058D8" OutName="object_horse_normalTex_0058D8" Format="i8" Width="8" Height="8" Offset="0x58D8" AddedByScript="true"/>
+        <Texture Name="object_horse_normalTex_005918" OutName="object_horse_normalTex_005918" Format="rgba16" Width="16" Height="16" Offset="0x5918" AddedByScript="true"/>
+        <Texture Name="object_horse_normalTex_005B18" OutName="object_horse_normalTex_005B18" Format="rgba16" Width="8" Height="8" Offset="0x5B18" AddedByScript="true"/>
+        <Texture Name="object_horse_normalTex_005B98" OutName="object_horse_normalTex_005B98" Format="i8" Width="16" Height="16" Offset="0x5B98" AddedByScript="true"/>
+        <Texture Name="object_horse_normalTex_005C98" OutName="object_horse_normalTex_005C98" Format="i8" Width="16" Height="8" Offset="0x5C98" AddedByScript="true"/>
+        <Texture Name="object_horse_normalTex_006F28" OutName="object_horse_normalTex_006F28" Format="i8" Width="16" Height="16" Offset="0x6F28" AddedByScript="true"/>
+        <Texture Name="object_horse_normalTex_007028" OutName="object_horse_normalTex_007028" Format="i8" Width="16" Height="16" Offset="0x7028" AddedByScript="true"/>
+        <Texture Name="object_horse_normalTex_007128" OutName="object_horse_normalTex_007128" Format="i8" Width="32" Height="32" Offset="0x7128" AddedByScript="true"/>
         <Skeleton Name="gHorseNormalSkel" Type="Normal" LimbType="Skin" Offset="0x9FAC"/>
 
         <!-- Running. -->

--- a/soh/assets/xml/GC_NMQ_D/objects/object_horse_zelda.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_horse_zelda.xml
@@ -1,5 +1,17 @@
 <Root>
     <File Name="object_horse_zelda" Segment="6">
+        <Texture Name="object_horse_zeldaTex_000408" OutName="object_horse_zeldaTex_000408" Format="rgba16" Width="8" Height="8" Offset="0x408" AddedByScript="true"/>
+        <Texture Name="object_horse_zeldaTex_000888" OutName="object_horse_zeldaTex_000888" Format="rgba16" Width="8" Height="16" Offset="0x888" AddedByScript="true"/>
+        <Texture Name="object_horse_zeldaTex_000988" OutName="object_horse_zeldaTex_000988" Format="rgba16" Width="4" Height="4" Offset="0x988" AddedByScript="true"/>
+        <Texture Name="object_horse_zeldaTex_002578" OutName="object_horse_zeldaTex_002578" Format="rgba16" Width="8" Height="16" Offset="0x2578" AddedByScript="true"/>
+        <Texture Name="object_horse_zeldaTex_002678" OutName="object_horse_zeldaTex_002678" Format="rgba16" Width="16" Height="8" Offset="0x2678" AddedByScript="true"/>
+        <Texture Name="object_horse_zeldaTex_002778" OutName="object_horse_zeldaTex_002778" Format="rgba16" Width="16" Height="16" Offset="0x2778" AddedByScript="true"/>
+        <Texture Name="object_horse_zeldaTex_002978" OutName="object_horse_zeldaTex_002978" Format="rgba16" Width="32" Height="32" Offset="0x2978" AddedByScript="true"/>
+        <Texture Name="object_horse_zeldaTex_003178" OutName="object_horse_zeldaTex_003178" Format="rgba16" Width="16" Height="8" Offset="0x3178" AddedByScript="true"/>
+        <Texture Name="object_horse_zeldaTex_003278" OutName="object_horse_zeldaTex_003278" Format="rgba16" Width="8" Height="16" Offset="0x3278" AddedByScript="true"/>
+        <Texture Name="object_horse_zeldaTex_003378" OutName="object_horse_zeldaTex_003378" Format="rgba16" Width="8" Height="8" Offset="0x3378" AddedByScript="true"/>
+        <Texture Name="object_horse_zeldaTex_0033F8" OutName="object_horse_zeldaTex_0033F8" Format="rgba16" Width="8" Height="16" Offset="0x33F8" AddedByScript="true"/>
+        <Texture Name="object_horse_zeldaTex_0034F8" OutName="object_horse_zeldaTex_0034F8" Format="rgba16" Width="16" Height="16" Offset="0x34F8" AddedByScript="true"/>
         <Skeleton Name="gHorseZeldaSkel" Type="Normal" LimbType="Skin" Offset="0x6B2C"/>
 
         <!-- Running. -->

--- a/soh/assets/xml/GC_NMQ_D/objects/object_jya_obj.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_jya_obj.xml
@@ -1,5 +1,12 @@
 <Root>
     <File Name="object_jya_obj" Segment="6">
+        <Texture Name="object_jya_objTex_00B4B8" OutName="object_jya_objTex_00B4B8" Format="ci8" Width="32" Height="32" Offset="0xB4B8" TlutOffset="0xAC70" AddedByScript="true"/>
+        <Texture Name="object_jya_objTex_011A80" OutName="object_jya_objTex_011A80" Format="ci4" Width="64" Height="64" Offset="0x11A80" TlutOffset="0x11A60" AddedByScript="true"/>
+        <Texture Name="object_jya_objTex_016140" OutName="object_jya_objTex_016140" Format="rgba16" Width="64" Height="32" Offset="0x16140" AddedByScript="true"/>
+        <Texture Name="object_jya_objTex_017140" OutName="object_jya_objTex_017140" Format="rgba16" Width="32" Height="16" Offset="0x17140" AddedByScript="true"/>
+        <Texture Name="object_jya_objTex_01B340" OutName="object_jya_objTex_01B340" Format="ia8" Width="32" Height="32" Offset="0x1B340" AddedByScript="true"/>
+        <Texture Name="object_jya_objTex_01B740" OutName="object_jya_objTex_01B740" Format="rgba16" Width="16" Height="16" Offset="0x1B740" AddedByScript="true"/>
+        <Texture Name="object_jya_objTLUT_011A60" OutName="object_jya_objTLUT_011A60" Format="rgba16" Width="4" Height="4" Offset="0x11A60" AddedByScript="true"/>
         <DList Name="g1fliftDL" Offset="0x1F0"/>
         <Collision Name="g1fliftCol" Offset="0x4A8"/>
         <Texture Name="g1f1fiftTopTex" OutName="1flift_top" Format="rgba16" Width="32" Height="32" Offset="0x1B940"/>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_link_boy.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_link_boy.xml
@@ -1,5 +1,12 @@
 <Root>
     <File Name="object_link_boy" Segment="6">
+        <Texture Name="object_link_boyTLUT_005400" OutName="object_link_boyTLUT_005400" Format="rgba16" Width="16" Height="16" Offset="0x5400" AddedByScript="true"/>
+        <Texture Name="object_link_boyTLUT_005800" OutName="object_link_boyTLUT_005800" Format="rgba16" Width="16" Height="16" Offset="0x5800" AddedByScript="true"/>
+        <Texture Name="object_link_boyTLUT_005A00" OutName="object_link_boyTLUT_005A00" Format="rgba16" Width="16" Height="16" Offset="0x5A00" AddedByScript="true"/>
+        <Texture Name="object_link_boyTLUT_00CB40" OutName="object_link_boyTLUT_00CB40" Format="rgba16" Width="16" Height="16" Offset="0xCB40" AddedByScript="true"/>
+        <Texture Name="object_link_boyTLUT_00CD48" OutName="object_link_boyTLUT_00CD48" Format="rgba16" Width="16" Height="16" Offset="0xCD48" AddedByScript="true"/>
+        <Texture Name="object_link_boyTLUT_00CF50" OutName="object_link_boyTLUT_00CF50" Format="rgba16" Width="16" Height="16" Offset="0xCF50" AddedByScript="true"/>
+        <Texture Name="object_link_boyTLUT_00D078" OutName="object_link_boyTLUT_00D078" Format="rgba16" Width="16" Height="16" Offset="0xD078" AddedByScript="true"/>
         <Skeleton Name="gLinkAdultSkel" Type="Flex" LimbType="LOD" Offset="0x377F4"/>
 
         <!-- Far Limb DLists-->

--- a/soh/assets/xml/GC_NMQ_D/objects/object_masterkokirihead.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_masterkokirihead.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_masterkokirihead" Segment="6">
+        <Texture Name="object_masterkokiriheadTex_0009F0" OutName="object_masterkokiriheadTex_0009F0" Format="ci8" Width="8" Height="8" Offset="0x9F0" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_masterkokiriheadTex_000A30" OutName="object_masterkokiriheadTex_000A30" Format="ci8" Width="16" Height="16" Offset="0xA30" TlutOffset="0x0" AddedByScript="true"/>
         <DList Name="gKokiriShopkeeperHeadDL" Offset="0x2820"/>
         <Texture Name="gKokiriShopkeeperTLUT" OutName="tlut" Format="rgba16" Width="248" Height="1" Offset="0x0"/>
         <Texture Name="gKokiriShopkeeperEyeHalfTex" OutName="eye_half" Format="rgba16" Width="32" Height="32" Offset="0x1F0"/>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_mb.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_mb.xml
@@ -1,5 +1,19 @@
 <Root>
     <File Name="object_mb" Segment="6">
+        <Texture Name="object_mbTex_008128" OutName="object_mbTex_008128" Format="rgba16" Width="16" Height="16" Offset="0x8128" AddedByScript="true"/>
+        <Texture Name="object_mbTex_008328" OutName="object_mbTex_008328" Format="rgba16" Width="8" Height="32" Offset="0x8328" AddedByScript="true"/>
+        <Texture Name="object_mbTex_008928" OutName="object_mbTex_008928" Format="rgba16" Width="8" Height="16" Offset="0x8928" AddedByScript="true"/>
+        <Texture Name="object_mbTex_008A28" OutName="object_mbTex_008A28" Format="rgba16" Width="4" Height="4" Offset="0x8A28" AddedByScript="true"/>
+        <Texture Name="object_mbTex_008A48" OutName="object_mbTex_008A48" Format="rgba16" Width="8" Height="24" Offset="0x8A48" AddedByScript="true"/>
+        <Texture Name="object_mbTex_008BC8" OutName="object_mbTex_008BC8" Format="rgba16" Width="4" Height="16" Offset="0x8BC8" AddedByScript="true"/>
+        <Texture Name="object_mbTex_008C48" OutName="object_mbTex_008C48" Format="rgba16" Width="4" Height="8" Offset="0x8C48" AddedByScript="true"/>
+        <Texture Name="object_mbTex_008C88" OutName="object_mbTex_008C88" Format="rgba16" Width="8" Height="16" Offset="0x8C88" AddedByScript="true"/>
+        <Texture Name="object_mbTex_00EC00" OutName="object_mbTex_00EC00" Format="rgba16" Width="16" Height="16" Offset="0xEC00" AddedByScript="true"/>
+        <Texture Name="object_mbTex_00EE00" OutName="object_mbTex_00EE00" Format="rgba16" Width="8" Height="16" Offset="0xEE00" AddedByScript="true"/>
+        <Texture Name="object_mbTex_00EF00" OutName="object_mbTex_00EF00" Format="rgba16" Width="8" Height="16" Offset="0xEF00" AddedByScript="true"/>
+        <Texture Name="object_mbTex_00F000" OutName="object_mbTex_00F000" Format="rgba16" Width="16" Height="16" Offset="0xF000" AddedByScript="true"/>
+        <Texture Name="object_mbTex_00F200" OutName="object_mbTex_00F200" Format="rgba16" Width="4" Height="16" Offset="0xF200" AddedByScript="true"/>
+        <Texture Name="object_mbTex_00F280" OutName="object_mbTex_00F280" Format="rgba16" Width="4" Height="16" Offset="0xF280" AddedByScript="true"/>
         <Skeleton Name="gEnMbSpearSkel" Type="Flex" LimbType="Standard" Offset="0x8F38"/>
         <Skeleton Name="gEnMbClubSkel" Type="Flex" LimbType="Standard" Offset="0x14190"/>
         <Animation Name="gEnMbSpearFallFaceDownAnim" Offset="0x6A4"/><!--Unused-->

--- a/soh/assets/xml/GC_NMQ_D/objects/object_mizu_objects.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_mizu_objects.xml
@@ -1,5 +1,19 @@
 <Root>
     <File Name="object_mizu_objects" Segment="6">
+        <Texture Name="object_mizu_objectsTex_004C00" OutName="object_mizu_objectsTex_004C00" Format="rgba16" Width="32" Height="64" Offset="0x4C00" AddedByScript="true"/>
+        <Texture Name="object_mizu_objectsTex_005E70" OutName="object_mizu_objectsTex_005E70" Format="rgba16" Width="32" Height="64" Offset="0x5E70" AddedByScript="true"/>
+        <Texture Name="object_mizu_objectsTex_007520" OutName="object_mizu_objectsTex_007520" Format="ia16" Width="32" Height="32" Offset="0x7520" AddedByScript="true"/>
+        <Texture Name="object_mizu_objectsTex_007D20" OutName="object_mizu_objectsTex_007D20" Format="rgba16" Width="32" Height="32" Offset="0x7D20" AddedByScript="true"/>
+        <Texture Name="object_mizu_objectsTex_008520" OutName="object_mizu_objectsTex_008520" Format="rgba16" Width="32" Height="32" Offset="0x8520" AddedByScript="true"/>
+        <Texture Name="object_mizu_objectsTex_008D20" OutName="object_mizu_objectsTex_008D20" Format="rgba16" Width="32" Height="32" Offset="0x8D20" AddedByScript="true"/>
+        <Texture Name="object_mizu_objectsTex_009520" OutName="object_mizu_objectsTex_009520" Format="i4" Width="32" Height="32" Offset="0x9520" AddedByScript="true"/>
+        <Texture Name="object_mizu_objectsTex_009720" OutName="object_mizu_objectsTex_009720" Format="i4" Width="32" Height="32" Offset="0x9720" AddedByScript="true"/>
+        <Texture Name="object_mizu_objectsTex_009920" OutName="object_mizu_objectsTex_009920" Format="i4" Width="32" Height="32" Offset="0x9920" AddedByScript="true"/>
+        <Texture Name="object_mizu_objectsTex_009B20" OutName="object_mizu_objectsTex_009B20" Format="i4" Width="32" Height="32" Offset="0x9B20" AddedByScript="true"/>
+        <Texture Name="object_mizu_objectsTex_009D20" OutName="object_mizu_objectsTex_009D20" Format="i4" Width="32" Height="32" Offset="0x9D20" AddedByScript="true"/>
+        <Texture Name="object_mizu_objectsTex_009F20" OutName="object_mizu_objectsTex_009F20" Format="rgba16" Width="32" Height="32" Offset="0x9F20" AddedByScript="true"/>
+        <Texture Name="object_mizu_objectsTex_00A720" OutName="object_mizu_objectsTex_00A720" Format="rgba16" Width="16" Height="32" Offset="0xA720" AddedByScript="true"/>
+        <Texture Name="object_mizu_objectsTex_00AB20" OutName="object_mizu_objectsTex_00AB20" Format="i4" Width="64" Height="64" Offset="0xAB20" AddedByScript="true"/>
         <DList Name="gObjectMizuObjectsMovebgDL_000190" Offset="0x0190"/>
         <Collision Name="gObjectMizuObjectsMovebgCol_0003F0" Offset="0x03F0"/>
         <DList Name="gObjectMizuObjectsMovebgDL_000680" Offset="0x0680"/>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_mm.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_mm.xml
@@ -1,5 +1,14 @@
 <Root>
     <File Name="object_mm" Segment="6">
+        <Texture Name="object_mmTex_000930" OutName="object_mmTex_000930" Format="ci8" Width="8" Height="8" Offset="0x930" TlutOffset="0x730" AddedByScript="true"/>
+        <Texture Name="object_mmTex_000970" OutName="object_mmTex_000970" Format="ci8" Width="8" Height="8" Offset="0x970" TlutOffset="0x730" AddedByScript="true"/>
+        <Texture Name="object_mmTex_0009B0" OutName="object_mmTex_0009B0" Format="ci8" Width="8" Height="8" Offset="0x9B0" TlutOffset="0x730" AddedByScript="true"/>
+        <Texture Name="object_mmTex_0009F0" OutName="object_mmTex_0009F0" Format="ci8" Width="8" Height="8" Offset="0x9F0" TlutOffset="0x730" AddedByScript="true"/>
+        <Texture Name="object_mmTex_000A30" OutName="object_mmTex_000A30" Format="ci8" Width="16" Height="16" Offset="0xA30" TlutOffset="0x730" AddedByScript="true"/>
+        <Texture Name="object_mmTex_000B30" OutName="object_mmTex_000B30" Format="ci8" Width="16" Height="16" Offset="0xB30" TlutOffset="0x730" AddedByScript="true"/>
+        <Texture Name="object_mmTex_001030" OutName="object_mmTex_001030" Format="ci8" Width="16" Height="16" Offset="0x1030" TlutOffset="0x730" AddedByScript="true"/>
+        <Texture Name="object_mmTex_001130" OutName="object_mmTex_001130" Format="ci8" Width="32" Height="16" Offset="0x1130" TlutOffset="0x730" AddedByScript="true"/>
+        <Texture Name="object_mmTex_001330" OutName="object_mmTex_001330" Format="ci8" Width="16" Height="16" Offset="0x1330" TlutOffset="0x730" AddedByScript="true"/>
         <Skeleton Name="gRunningManSkel" Type="Flex" LimbType="Standard" Offset="0x5E18"/>
 
         <Animation Name="gRunningManRunAnim" Offset="0x0718"/>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_mo.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_mo.xml
@@ -1,5 +1,10 @@
 <Root>
     <File Name="object_mo" Segment="6">
+        <Texture Name="object_moTex_000000" OutName="object_moTex_000000" Format="ia8" Width="16" Height="16" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="object_moTex_000680" OutName="object_moTex_000680" Format="rgba16" Width="32" Height="32" Offset="0x680" AddedByScript="true"/>
+        <Texture Name="object_moTex_004D20" OutName="object_moTex_004D20" Format="ia16" Width="32" Height="32" Offset="0x4D20" AddedByScript="true"/>
+        <Texture Name="object_moTex_005520" OutName="object_moTex_005520" Format="ia16" Width="32" Height="32" Offset="0x5520" AddedByScript="true"/>
+        <Texture Name="object_moTex_005D20" OutName="object_moTex_005D20" Format="ia16" Width="32" Height="32" Offset="0x5D20" AddedByScript="true"/>
         <!-- Morpha's Title Card -->
         <Texture Name="gMorphaTitleCardTex" Format="i8" Width="128" Height="120" Offset="0x1010"/>
         <Texture Name="gMorphaWaterTex" Format="rgba16" Width="32" Height="32" Offset="0x8870"/>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_oE1s.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_oE1s.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_oE1s" Segment="6">
+        <Texture Name="object_oE1sTex_000478" OutName="object_oE1sTex_000478" Format="ci8" Width="32" Height="32" Offset="0x478" TlutOffset="0x1A8" AddedByScript="true"/>
+        <Texture Name="object_oE1sTLUT_0001A8" OutName="object_oE1sTLUT_0001A8" Format="rgba16" Width="16" Height="16" Offset="0x1A8" AddedByScript="true"/>
         <Animation Name="object_oE1s_Anim_00007C" Offset="0x7C"/>
         <Limb Name="object_oE1s_Limb_000090" LimbType="Standard" Offset="0x90"/>
         <Limb Name="object_oE1s_Limb_00009C" LimbType="Standard" Offset="0x9C"/>
@@ -21,15 +23,15 @@
         <!--Blob Name="object_oE1s_Blob_00019C" Size="0x204" Offset="0x19C" /-->
         <Texture Name="object_oE1s_TLUT_0003A0" OutName="tlut_000003A0" Format="rgba16" Width="108" Height="1" Offset="0x3A0"/>
         <!--Blob Name="object_oE1s_Blob_0005A0" Size="0x2D8" Offset="0x5A0" /-->
-        <Texture Name="object_oE1s_Tex_000878" OutName="tex_00000878" Format="ci8" Width="8" Height="8" Offset="0x878"  TlutOffset="0x3A0"/>
+        <Texture Name="object_oE1s_Tex_000878" OutName="tex_00000878" Format="ci8" Width="8" Height="8" Offset="0x878" TlutOffset="0x3A0"/>
         <Texture Name="object_oE1s_Tex_0008B8" OutName="tex_000008B8" Format="rgba16" Width="16" Height="32" Offset="0x8B8"/>
         <Texture Name="object_oE1s_Tex_000CB8" OutName="tex_00000CB8" Format="rgba16" Width="32" Height="32" Offset="0xCB8"/>
-        <Texture Name="object_oE1s_Tex_0014B8" OutName="tex_000014B8" Format="ci8" Width="16" Height="16" Offset="0x14B8"  TlutOffset="0x3A0"/>
+        <Texture Name="object_oE1s_Tex_0014B8" OutName="tex_000014B8" Format="ci8" Width="16" Height="16" Offset="0x14B8" TlutOffset="0x3A0"/>
         <Texture Name="object_oE1s_Tex_0015B8" OutName="tex_000015B8" Format="i4" Width="16" Height="8" Offset="0x15B8"/>
         <Blob Name="object_oE1s_Blob_0015F8" Size="0x400" Offset="0x15F8"/>
         <Texture Name="object_oE1s_Tex_0019F8" OutName="tex_000019F8" Format="i4" Width="16" Height="16" Offset="0x19F8"/>
         <Texture Name="object_oE1s_Tex_001A78" OutName="tex_00001A78" Format="rgba16" Width="16" Height="8" Offset="0x1A78"/>
-        <Texture Name="object_oE1s_Tex_001B78" OutName="tex_00001B78" Format="ci8" Width="16" Height="16" Offset="0x1B78"  TlutOffset="0x3A0"/>
+        <Texture Name="object_oE1s_Tex_001B78" OutName="tex_00001B78" Format="ci8" Width="16" Height="16" Offset="0x1B78" TlutOffset="0x3A0"/>
         <Blob Name="object_oE1s_Blob_001C78" Size="0x400" Offset="0x1C78"/>
         <DList Name="object_oE1s_DL_004D98" Offset="0x4D98"/>
         <DList Name="object_oE1s_DL_005010" Offset="0x5010"/>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_oE4s.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_oE4s.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_oE4s" Segment="6">
+        <Texture Name="object_oE4sTex_0002A0" OutName="object_oE4sTex_0002A0" Format="ci8" Width="16" Height="16" Offset="0x2A0" TlutOffset="0x1A8" AddedByScript="true"/>
+        <Texture Name="object_oE4sTex_0003A0" OutName="object_oE4sTex_0003A0" Format="ci8" Width="16" Height="16" Offset="0x3A0" TlutOffset="0x1A8" AddedByScript="true"/>
         <Animation Name="object_oE4s_Anim_00007C" Offset="0x7C"/>
         <Limb Name="object_oE4s_Limb_000090" LimbType="Standard" Offset="0x90"/>
         <Limb Name="object_oE4s_Limb_00009C" LimbType="Standard" Offset="0x9C"/>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_oF1d_map.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_oF1d_map.xml
@@ -1,5 +1,22 @@
 <Root>
     <File Name="object_oF1d_map" Segment="6">
+        <Texture Name="object_oF1d_mapTex_009270" OutName="object_oF1d_mapTex_009270" Format="ci8" Width="8" Height="8" Offset="0x9270" TlutOffset="0x9130" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_0092B0" OutName="object_oF1d_mapTex_0092B0" Format="ci8" Width="8" Height="8" Offset="0x92B0" TlutOffset="0x9130" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_0092F0" OutName="object_oF1d_mapTex_0092F0" Format="ci8" Width="8" Height="16" Offset="0x92F0" TlutOffset="0x9130" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_009370" OutName="object_oF1d_mapTex_009370" Format="ci8" Width="32" Height="64" Offset="0x9370" TlutOffset="0x9130" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_009B70" OutName="object_oF1d_mapTex_009B70" Format="ci8" Width="16" Height="16" Offset="0x9B70" TlutOffset="0x9130" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_009C70" OutName="object_oF1d_mapTex_009C70" Format="rgba16" Width="64" Height="32" Offset="0x9C70" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_00C840" OutName="object_oF1d_mapTex_00C840" Format="ci8" Width="8" Height="8" Offset="0xC840" TlutOffset="0xC440" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_00C880" OutName="object_oF1d_mapTex_00C880" Format="ci8" Width="32" Height="16" Offset="0xC880" TlutOffset="0xC440" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_00CA80" OutName="object_oF1d_mapTex_00CA80" Format="ci8" Width="32" Height="32" Offset="0xCA80" TlutOffset="0xC440" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_00EE80" OutName="object_oF1d_mapTex_00EE80" Format="ci8" Width="32" Height="64" Offset="0xEE80" TlutOffset="0xC440" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_00F680" OutName="object_oF1d_mapTex_00F680" Format="ci8" Width="8" Height="8" Offset="0xF680" TlutOffset="0xC440" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_00F6C0" OutName="object_oF1d_mapTex_00F6C0" Format="ci8" Width="16" Height="16" Offset="0xF6C0" TlutOffset="0xC440" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_00F7C0" OutName="object_oF1d_mapTex_00F7C0" Format="ci8" Width="16" Height="16" Offset="0xF7C0" TlutOffset="0xC440" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_00F8C0" OutName="object_oF1d_mapTex_00F8C0" Format="ci8" Width="32" Height="32" Offset="0xF8C0" TlutOffset="0xC440" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_00FCC0" OutName="object_oF1d_mapTex_00FCC0" Format="ci8" Width="8" Height="16" Offset="0xFCC0" TlutOffset="0xC440" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTLUT_009130" OutName="object_oF1d_mapTLUT_009130" Format="rgba16" Width="16" Height="16" Offset="0x9130" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTLUT_00C440" OutName="object_oF1d_mapTLUT_00C440" Format="rgba16" Width="16" Height="16" Offset="0xC440" AddedByScript="true"/>
         <!-- animations -->
         <Animation Name="gGoronAnim_000750" Offset="0x750"/>
         <Animation Name="gGoronAnim_000D5C" Offset="0xD5C"/>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_ossan.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_ossan.xml
@@ -1,5 +1,15 @@
 <Root>
     <File Name="object_ossan" Segment="6">
+        <Texture Name="object_ossanTex_005078" OutName="object_ossanTex_005078" Format="ci8" Width="16" Height="16" Offset="0x5078" TlutOffset="0x4728" AddedByScript="true"/>
+        <Texture Name="object_ossanTex_005178" OutName="object_ossanTex_005178" Format="ci8" Width="16" Height="16" Offset="0x5178" TlutOffset="0x4728" AddedByScript="true"/>
+        <Texture Name="object_ossanTex_005278" OutName="object_ossanTex_005278" Format="ci8" Width="8" Height="8" Offset="0x5278" TlutOffset="0x4728" AddedByScript="true"/>
+        <Texture Name="object_ossanTex_005AB8" OutName="object_ossanTex_005AB8" Format="ci8" Width="8" Height="8" Offset="0x5AB8" TlutOffset="0x4728" AddedByScript="true"/>
+        <Texture Name="object_ossanTex_008A38" OutName="object_ossanTex_008A38" Format="rgba16" Width="8" Height="8" Offset="0x8A38" AddedByScript="true"/>
+        <Texture Name="object_ossanTex_008AB8" OutName="object_ossanTex_008AB8" Format="rgba16" Width="16" Height="16" Offset="0x8AB8" AddedByScript="true"/>
+        <Texture Name="object_ossanTex_008CB8" OutName="object_ossanTex_008CB8" Format="rgba16" Width="16" Height="16" Offset="0x8CB8" AddedByScript="true"/>
+        <Texture Name="object_ossanTex_008EB8" OutName="object_ossanTex_008EB8" Format="rgba16" Width="32" Height="32" Offset="0x8EB8" AddedByScript="true"/>
+        <Texture Name="object_ossanTex_0096B8" OutName="object_ossanTex_0096B8" Format="rgba16" Width="16" Height="16" Offset="0x96B8" AddedByScript="true"/>
+        <Texture Name="object_ossanTex_0098B8" OutName="object_ossanTex_0098B8" Format="rgba16" Width="16" Height="16" Offset="0x98B8" AddedByScript="true"/>
         <Animation Name="gObjectOssanAnim_000338" Offset="0x338"/>
         <Texture Name="gOssanEyesTLUT" OutName="ossan_eyes_tlut" Format="rgba16" Width="63" Height="4" Offset="0x4530"/>
         <Texture Name="gOssanTLUT" OutName="ossan_tlut" Format="rgba16" Width="168" Height="1" Offset="0x4728"/>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_owl.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_owl.xml
@@ -1,5 +1,13 @@
 <Root>
     <File Name="object_owl" Segment="6">
+        <Texture Name="object_owlTex_0071A8" OutName="object_owlTex_0071A8" Format="rgba16" Width="32" Height="32" Offset="0x71A8" AddedByScript="true"/>
+        <Texture Name="object_owlTex_0079A8" OutName="object_owlTex_0079A8" Format="rgba16" Width="32" Height="32" Offset="0x79A8" AddedByScript="true"/>
+        <Texture Name="object_owlTex_0081A8" OutName="object_owlTex_0081A8" Format="rgba16" Width="32" Height="32" Offset="0x81A8" AddedByScript="true"/>
+        <Texture Name="object_owlTex_0095A8" OutName="object_owlTex_0095A8" Format="rgba16" Width="32" Height="32" Offset="0x95A8" AddedByScript="true"/>
+        <Texture Name="object_owlTex_009DA8" OutName="object_owlTex_009DA8" Format="rgba16" Width="16" Height="16" Offset="0x9DA8" AddedByScript="true"/>
+        <Texture Name="object_owlTex_009FA8" OutName="object_owlTex_009FA8" Format="rgba16" Width="64" Height="32" Offset="0x9FA8" AddedByScript="true"/>
+        <Texture Name="object_owlTex_00AFA8" OutName="object_owlTex_00AFA8" Format="rgba16" Width="32" Height="32" Offset="0xAFA8" AddedByScript="true"/>
+        <Texture Name="object_owlTex_00B7A8" OutName="object_owlTex_00B7A8" Format="rgba16" Width="32" Height="32" Offset="0xB7A8" AddedByScript="true"/>
         <!-- Flying Owl Skeleton -->
         <Skeleton Name="gOwlFlyingSkel" Type="Flex" LimbType="Standard" Offset="0xC0E8"/>
 
@@ -53,11 +61,17 @@
         <Animation Name="gOwlGlideAnim" Offset="0xC1C4"/>
         <Animation Name="gOwlUnfoldWingsAnim" Offset="0xC684"/>
         <Animation Name="gOwlPerchAnim" Offset="0xC8A0"/>
-        
-        <!-- Owl Perching Skeleton -->
-        <Skeleton Name="gOwlPerchingSkel" Type="Flex" LimbType="Standard" Offset="0x100B0"/>  
 
-        <!-- Eye Textures -->      
+        <!-- Owl Perching Skeleton -->
+        <Skeleton Name="gOwlPerchingSkel" Type="Flex" LimbType="Standard" Offset="0x100B0"/>
+
+                <!-- The two following TLUTs are identical and both are used as TLUTs for the eye textures -->
+        <!-- TLUT used in gOwlPerchingSkel -->
+        <Texture Name="object_owl_TLUT_006DA8" OutName="tlut_00006DA8" Format="rgba16" Width="16" Height="16" Offset="0x6DA8"/>
+        <!-- TLUT used in gOwlFlyingSkel -->
+        <Texture Name="object_owl_TLUT_006FA8" OutName="tlut_00006FA8" Format="rgba16" Width="16" Height="16" Offset="0x6FA8"/>
+
+        <!-- Eye Textures -->
         <Texture Name="gObjOwlEyeOpenTex" OutName="owl_eye_open" Format="ci8" Width="32" Height="32" Offset="0x89A8"/>
         <Texture Name="gObjOwlEyeHalfTex" OutName="owl_eye_half" Format="ci8" Width="32" Height="32" Offset="0x8DA8"/>
         <Texture Name="gObjOwlEyeClosedTex" OutName="owl_eye_closed" Format="ci8" Width="32" Height="32" Offset="0x91A8"/>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_po_composer.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_po_composer.xml
@@ -1,5 +1,18 @@
 <Root>
     <File Name="object_po_composer" Segment="6">
+        <Texture Name="object_po_composerTex_001450" OutName="object_po_composerTex_001450" Format="i8" Width="32" Height="64" Offset="0x1450" AddedByScript="true"/>
+        <Texture Name="object_po_composerTex_0054E0" OutName="object_po_composerTex_0054E0" Format="rgba16" Width="16" Height="16" Offset="0x54E0" AddedByScript="true"/>
+        <Texture Name="object_po_composerTex_0056E0" OutName="object_po_composerTex_0056E0" Format="rgba16" Width="16" Height="16" Offset="0x56E0" AddedByScript="true"/>
+        <Texture Name="object_po_composerTex_0058E0" OutName="object_po_composerTex_0058E0" Format="rgba16" Width="16" Height="16" Offset="0x58E0" AddedByScript="true"/>
+        <Texture Name="object_po_composerTex_005AE0" OutName="object_po_composerTex_005AE0" Format="rgba16" Width="16" Height="16" Offset="0x5AE0" AddedByScript="true"/>
+        <Texture Name="object_po_composerTex_005CE0" OutName="object_po_composerTex_005CE0" Format="rgba16" Width="16" Height="32" Offset="0x5CE0" AddedByScript="true"/>
+        <Texture Name="object_po_composerTex_0060E0" OutName="object_po_composerTex_0060E0" Format="rgba16" Width="16" Height="16" Offset="0x60E0" AddedByScript="true"/>
+        <Texture Name="object_po_composerTex_0062E0" OutName="object_po_composerTex_0062E0" Format="rgba16" Width="16" Height="16" Offset="0x62E0" AddedByScript="true"/>
+        <Texture Name="object_po_composerTex_0064E0" OutName="object_po_composerTex_0064E0" Format="rgba16" Width="16" Height="16" Offset="0x64E0" AddedByScript="true"/>
+        <Texture Name="object_po_composerTex_0066E0" OutName="object_po_composerTex_0066E0" Format="rgba16" Width="16" Height="16" Offset="0x66E0" AddedByScript="true"/>
+        <Texture Name="object_po_composerTex_0068E0" OutName="object_po_composerTex_0068E0" Format="rgba16" Width="16" Height="16" Offset="0x68E0" AddedByScript="true"/>
+        <Texture Name="object_po_composerTex_006AE0" OutName="object_po_composerTex_006AE0" Format="rgba16" Width="16" Height="16" Offset="0x6AE0" AddedByScript="true"/>
+        <Texture Name="object_po_composerTex_006CE0" OutName="object_po_composerTex_006CE0" Format="rgba16" Width="16" Height="16" Offset="0x6CE0" AddedByScript="true"/>
         <Animation Name="gPoeComposerAttackAnim" Offset="0x020C"/>
         <Animation Name="gPoeComposerDamagedAnim" Offset="0x0570"/>
         <Animation Name="gPoeComposerFleeAnim" Offset="0x0708"/>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_po_field.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_po_field.xml
@@ -1,5 +1,16 @@
 <Root>
     <File Name="object_po_field" Segment="6">
+        <Texture Name="object_po_fieldTex_002470" OutName="object_po_fieldTex_002470" Format="rgba16" Width="16" Height="16" Offset="0x2470" AddedByScript="true"/>
+        <Texture Name="object_po_fieldTex_002670" OutName="object_po_fieldTex_002670" Format="rgba16" Width="16" Height="16" Offset="0x2670" AddedByScript="true"/>
+        <Texture Name="object_po_fieldTex_002870" OutName="object_po_fieldTex_002870" Format="rgba16" Width="32" Height="32" Offset="0x2870" AddedByScript="true"/>
+        <Texture Name="object_po_fieldTex_003070" OutName="object_po_fieldTex_003070" Format="rgba16" Width="16" Height="16" Offset="0x3070" AddedByScript="true"/>
+        <Texture Name="object_po_fieldTex_003270" OutName="object_po_fieldTex_003270" Format="rgba16" Width="8" Height="8" Offset="0x3270" AddedByScript="true"/>
+        <Texture Name="object_po_fieldTex_0032F0" OutName="object_po_fieldTex_0032F0" Format="rgba16" Width="16" Height="8" Offset="0x32F0" AddedByScript="true"/>
+        <Texture Name="object_po_fieldTex_0033F0" OutName="object_po_fieldTex_0033F0" Format="rgba16" Width="16" Height="16" Offset="0x33F0" AddedByScript="true"/>
+        <Texture Name="object_po_fieldTex_0035F0" OutName="object_po_fieldTex_0035F0" Format="rgba16" Width="16" Height="16" Offset="0x35F0" AddedByScript="true"/>
+        <Texture Name="object_po_fieldTex_0037F0" OutName="object_po_fieldTex_0037F0" Format="rgba16" Width="16" Height="16" Offset="0x37F0" AddedByScript="true"/>
+        <Texture Name="object_po_fieldTex_005AB0" OutName="object_po_fieldTex_005AB0" Format="rgba16" Width="16" Height="16" Offset="0x5AB0" AddedByScript="true"/>
+        <Texture Name="object_po_fieldTex_005CB0" OutName="object_po_fieldTex_005CB0" Format="rgba16" Width="8" Height="8" Offset="0x5CB0" AddedByScript="true"/>
         <Animation Name="gPoeFieldAttackAnim" Offset="0x0158"/>
         <Animation Name="gPoeFieldDamagedAnim" Offset="0x0454"/>
         <Animation Name="gPoeFieldFleeAnim" Offset="0x0608"/>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_po_sisters.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_po_sisters.xml
@@ -1,5 +1,33 @@
 <Root>
     <File Name="object_po_sisters" Segment="6">
+        <Texture Name="object_po_sistersTex_0048D8" OutName="object_po_sistersTex_0048D8" Format="rgba16" Width="16" Height="16" Offset="0x48D8" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_004AD8" OutName="object_po_sistersTex_004AD8" Format="rgba16" Width="32" Height="32" Offset="0x4AD8" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_0052D8" OutName="object_po_sistersTex_0052D8" Format="rgba16" Width="32" Height="16" Offset="0x52D8" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_0056D8" OutName="object_po_sistersTex_0056D8" Format="rgba16" Width="16" Height="16" Offset="0x56D8" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_0058D8" OutName="object_po_sistersTex_0058D8" Format="rgba16" Width="4" Height="4" Offset="0x58D8" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_0058F8" OutName="object_po_sistersTex_0058F8" Format="rgba16" Width="16" Height="16" Offset="0x58F8" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_005AF8" OutName="object_po_sistersTex_005AF8" Format="rgba16" Width="16" Height="16" Offset="0x5AF8" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_005CF8" OutName="object_po_sistersTex_005CF8" Format="rgba16" Width="8" Height="8" Offset="0x5CF8" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_005D78" OutName="object_po_sistersTex_005D78" Format="rgba16" Width="16" Height="16" Offset="0x5D78" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_005F78" OutName="object_po_sistersTex_005F78" Format="rgba16" Width="16" Height="8" Offset="0x5F78" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_006078" OutName="object_po_sistersTex_006078" Format="rgba16" Width="16" Height="16" Offset="0x6078" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_006278" OutName="object_po_sistersTex_006278" Format="rgba16" Width="8" Height="8" Offset="0x6278" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_0062F8" OutName="object_po_sistersTex_0062F8" Format="rgba16" Width="4" Height="4" Offset="0x62F8" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_006318" OutName="object_po_sistersTex_006318" Format="rgba16" Width="16" Height="16" Offset="0x6318" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_007AC0" OutName="object_po_sistersTex_007AC0" Format="rgba16" Width="32" Height="32" Offset="0x7AC0" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_0082C0" OutName="object_po_sistersTex_0082C0" Format="rgba16" Width="8" Height="16" Offset="0x82C0" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_0083C0" OutName="object_po_sistersTex_0083C0" Format="rgba16" Width="32" Height="32" Offset="0x83C0" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_008BC0" OutName="object_po_sistersTex_008BC0" Format="rgba16" Width="32" Height="32" Offset="0x8BC0" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_0093C0" OutName="object_po_sistersTex_0093C0" Format="rgba16" Width="32" Height="32" Offset="0x93C0" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_009BC0" OutName="object_po_sistersTex_009BC0" Format="rgba16" Width="32" Height="32" Offset="0x9BC0" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_00A3C0" OutName="object_po_sistersTex_00A3C0" Format="rgba16" Width="32" Height="32" Offset="0xA3C0" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_00ABC0" OutName="object_po_sistersTex_00ABC0" Format="rgba16" Width="32" Height="32" Offset="0xABC0" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_00B3C0" OutName="object_po_sistersTex_00B3C0" Format="rgba16" Width="32" Height="32" Offset="0xB3C0" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_00BBC0" OutName="object_po_sistersTex_00BBC0" Format="rgba16" Width="32" Height="32" Offset="0xBBC0" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_00C3C0" OutName="object_po_sistersTex_00C3C0" Format="rgba16" Width="32" Height="32" Offset="0xC3C0" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_00CBC0" OutName="object_po_sistersTex_00CBC0" Format="rgba16" Width="32" Height="32" Offset="0xCBC0" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_00D3C0" OutName="object_po_sistersTex_00D3C0" Format="rgba16" Width="32" Height="32" Offset="0xD3C0" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_00DBC0" OutName="object_po_sistersTex_00DBC0" Format="rgba16" Width="32" Height="32" Offset="0xDBC0" AddedByScript="true"/>
         <Animation Name="gPoeSistersAttackAnim" Offset="0x0114"/>
         <Animation Name="gPoeSistersMegCryAnim" Offset="0x0680"/>
         <Animation Name="gPoeSistersDamagedAnim" Offset="0x08C0"/>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_poh.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_poh.xml
@@ -1,5 +1,16 @@
 <Root>
     <File Name="object_poh" Segment="6">
+        <Texture Name="object_pohTex_003010" OutName="object_pohTex_003010" Format="i8" Width="32" Height="64" Offset="0x3010" AddedByScript="true"/>
+        <Texture Name="object_pohTex_003910" OutName="object_pohTex_003910" Format="rgba16" Width="32" Height="16" Offset="0x3910" AddedByScript="true"/>
+        <Texture Name="object_pohTex_003D10" OutName="object_pohTex_003D10" Format="rgba16" Width="32" Height="32" Offset="0x3D10" AddedByScript="true"/>
+        <Texture Name="object_pohTex_004510" OutName="object_pohTex_004510" Format="rgba16" Width="16" Height="16" Offset="0x4510" AddedByScript="true"/>
+        <Texture Name="object_pohTex_004710" OutName="object_pohTex_004710" Format="rgba16" Width="8" Height="8" Offset="0x4710" AddedByScript="true"/>
+        <Texture Name="object_pohTex_004790" OutName="object_pohTex_004790" Format="rgba16" Width="16" Height="16" Offset="0x4790" AddedByScript="true"/>
+        <Texture Name="object_pohTex_004990" OutName="object_pohTex_004990" Format="rgba16" Width="8" Height="8" Offset="0x4990" AddedByScript="true"/>
+        <Texture Name="object_pohTex_004A10" OutName="object_pohTex_004A10" Format="rgba16" Width="8" Height="16" Offset="0x4A10" AddedByScript="true"/>
+        <Texture Name="object_pohTex_004B10" OutName="object_pohTex_004B10" Format="rgba16" Width="16" Height="16" Offset="0x4B10" AddedByScript="true"/>
+        <Texture Name="object_pohTex_004D10" OutName="object_pohTex_004D10" Format="rgba16" Width="16" Height="16" Offset="0x4D10" AddedByScript="true"/>
+        <Texture Name="object_pohTex_004F10" OutName="object_pohTex_004F10" Format="rgba16" Width="8" Height="8" Offset="0x4F10" AddedByScript="true"/>
         <Animation Name="gPoeAttackAnim" Offset="0x01A8"/>
         <Animation Name="gPoeDamagedAnim" Offset="0x04EC"/>
         <Animation Name="gPoeFleeAnim" Offset="0x06E0"/>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_ps.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_ps.xml
@@ -1,5 +1,28 @@
 <Root>
     <File Name="object_ps" Segment="6">
+        <Texture Name="object_psTex_0005B8" OutName="object_psTex_0005B8" Format="rgba16" Width="32" Height="64" Offset="0x5B8" AddedByScript="true"/>
+        <Texture Name="object_psTex_0015B8" OutName="object_psTex_0015B8" Format="ci8" Width="8" Height="8" Offset="0x15B8" TlutOffset="0x4B0" AddedByScript="true"/>
+        <Texture Name="object_psTex_0015F8" OutName="object_psTex_0015F8" Format="rgba16" Width="16" Height="16" Offset="0x15F8" AddedByScript="true"/>
+        <Texture Name="object_psTex_0017F8" OutName="object_psTex_0017F8" Format="ci8" Width="8" Height="8" Offset="0x17F8" TlutOffset="0x4B0" AddedByScript="true"/>
+        <Texture Name="object_psTex_001838" OutName="object_psTex_001838" Format="ci8" Width="32" Height="32" Offset="0x1838" TlutOffset="0x4B0" AddedByScript="true"/>
+        <Texture Name="object_psTex_001C38" OutName="object_psTex_001C38" Format="ci8" Width="16" Height="16" Offset="0x1C38" TlutOffset="0x4B0" AddedByScript="true"/>
+        <Texture Name="object_psTex_001D38" OutName="object_psTex_001D38" Format="i8" Width="8" Height="8" Offset="0x1D38" AddedByScript="true"/>
+        <Texture Name="object_psTex_001D78" OutName="object_psTex_001D78" Format="ci8" Width="16" Height="16" Offset="0x1D78" TlutOffset="0x4B0" AddedByScript="true"/>
+        <Texture Name="object_psTex_001E78" OutName="object_psTex_001E78" Format="ci8" Width="16" Height="16" Offset="0x1E78" TlutOffset="0x4B0" AddedByScript="true"/>
+        <Texture Name="object_psTex_001F78" OutName="object_psTex_001F78" Format="rgba16" Width="16" Height="16" Offset="0x1F78" AddedByScript="true"/>
+        <Texture Name="object_psTex_002178" OutName="object_psTex_002178" Format="rgba16" Width="16" Height="16" Offset="0x2178" AddedByScript="true"/>
+        <Texture Name="object_psTex_002378" OutName="object_psTex_002378" Format="i4" Width="32" Height="32" Offset="0x2378" AddedByScript="true"/>
+        <Texture Name="object_psTex_002578" OutName="object_psTex_002578" Format="ci8" Width="32" Height="32" Offset="0x2578" TlutOffset="0x4B0" AddedByScript="true"/>
+        <Texture Name="object_psTex_002978" OutName="object_psTex_002978" Format="rgba16" Width="8" Height="16" Offset="0x2978" AddedByScript="true"/>
+        <Texture Name="object_psTex_007180" OutName="object_psTex_007180" Format="ci8" Width="8" Height="8" Offset="0x7180" TlutOffset="0x5880" AddedByScript="true"/>
+        <Texture Name="object_psTex_0071C0" OutName="object_psTex_0071C0" Format="ci8" Width="32" Height="32" Offset="0x71C0" TlutOffset="0x5880" AddedByScript="true"/>
+        <Texture Name="object_psTex_0075C0" OutName="object_psTex_0075C0" Format="ci8" Width="8" Height="8" Offset="0x75C0" TlutOffset="0x5880" AddedByScript="true"/>
+        <Texture Name="object_psTex_007600" OutName="object_psTex_007600" Format="ci8" Width="8" Height="8" Offset="0x7600" TlutOffset="0x5880" AddedByScript="true"/>
+        <Texture Name="object_psTex_007640" OutName="object_psTex_007640" Format="ci8" Width="32" Height="32" Offset="0x7640" TlutOffset="0x5880" AddedByScript="true"/>
+        <Texture Name="object_psTex_007A40" OutName="object_psTex_007A40" Format="rgba16" Width="16" Height="16" Offset="0x7A40" AddedByScript="true"/>
+        <Texture Name="object_psTex_007C40" OutName="object_psTex_007C40" Format="ci8" Width="32" Height="32" Offset="0x7C40" TlutOffset="0x5880" AddedByScript="true"/>
+        <Texture Name="object_psTLUT_0004B0" OutName="object_psTLUT_0004B0" Format="rgba16" Width="16" Height="16" Offset="0x4B0" AddedByScript="true"/>
+        <Texture Name="object_psTLUT_005880" OutName="object_psTLUT_005880" Format="rgba16" Width="16" Height="16" Offset="0x5880" AddedByScript="true"/>
         <Animation Name="gPoeSellerIdleAnim" Offset="0x049C"/>
         <Texture Name="gPoeSellerMetalFrameTex" OutName="poe_seller_metal_frame" Format="rgba16" Width="8" Height="8" Offset="0x5A80"/>
         <Texture Name="gPoeSellerMattressTex" OutName="poe_seller_mattress" Format="rgba16" Width="8" Height="8" Offset="0x5B00"/>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_rl.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_rl.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_rl" Segment="6">
+        <Texture Name="object_rlTex_0033E0" OutName="object_rlTex_0033E0" Format="ci8" Width="8" Height="8" Offset="0x33E0" TlutOffset="0x32A0" AddedByScript="true"/>
+        <Texture Name="object_rlTex_003420" OutName="object_rlTex_003420" Format="ci8" Width="16" Height="16" Offset="0x3420" TlutOffset="0x32A0" AddedByScript="true"/>
         <Animation Name="object_rl_Anim_00040C" Offset="0x40C"/>
         <Animation Name="object_rl_Anim_000830" Offset="0x830"/>
         <Animation Name="object_rl_Anim_000A3C" Offset="0xA3C"/>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_ru2.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_ru2.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_ru2" Segment="6">
+        <Texture Name="object_ru2Tex_0055C0" OutName="object_ru2Tex_0055C0" Format="ci8" Width="8" Height="32" Offset="0x55C0" TlutOffset="0x43C0" AddedByScript="true"/>
+        <Texture Name="object_ru2Tex_0056C0" OutName="object_ru2Tex_0056C0" Format="rgba16" Width="32" Height="32" Offset="0x56C0" AddedByScript="true"/>
         <!-- Adult Ruto Skeleton -->
         <Skeleton Name="gAdultRutoSkel" Type="Flex" LimbType="Standard" Offset="0xC700"/>
 

--- a/soh/assets/xml/GC_NMQ_D/objects/object_sa.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_sa.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_sa" Segment="6">
+        <Texture Name="object_saTex_002530" OutName="object_saTex_002530" Format="ci8" Width="8" Height="8" Offset="0x2530" TlutOffset="0x21F0" AddedByScript="true"/>
         <Skeleton Name="gSariaSkel" Type="Flex" LimbType="Standard" Offset="0xB1A0"/>
         
         <Limb Name="gSariaRootLimb" LimbType="Standard" Offset="0xB0A0"/>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_skj.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_skj.xml
@@ -1,5 +1,13 @@
 <Root>
     <File Name="object_skj" Segment="6">
+        <Texture Name="object_skjTex_005300" OutName="object_skjTex_005300" Format="rgba16" Width="16" Height="16" Offset="0x5300" AddedByScript="true"/>
+        <Texture Name="object_skjTex_005500" OutName="object_skjTex_005500" Format="rgba16" Width="16" Height="16" Offset="0x5500" AddedByScript="true"/>
+        <Texture Name="object_skjTex_005700" OutName="object_skjTex_005700" Format="rgba16" Width="16" Height="16" Offset="0x5700" AddedByScript="true"/>
+        <Texture Name="object_skjTex_005900" OutName="object_skjTex_005900" Format="rgba16" Width="16" Height="16" Offset="0x5900" AddedByScript="true"/>
+        <Texture Name="object_skjTex_005B00" OutName="object_skjTex_005B00" Format="rgba16" Width="8" Height="8" Offset="0x5B00" AddedByScript="true"/>
+        <Texture Name="object_skjTex_005B80" OutName="object_skjTex_005B80" Format="rgba16" Width="16" Height="16" Offset="0x5B80" AddedByScript="true"/>
+        <Texture Name="object_skjTex_005D80" OutName="object_skjTex_005D80" Format="rgba16" Width="4" Height="4" Offset="0x5D80" AddedByScript="true"/>
+        <Texture Name="object_skjTex_005DA0" OutName="object_skjTex_005DA0" Format="ia16" Width="8" Height="8" Offset="0x5DA0" AddedByScript="true"/>
         <DList Name="gSkullKidNeedleDL" Offset="0x0EB0"/>
         <DList Name="gSkullKidSkullMaskDL" Offset="0x14C8"/>
 

--- a/soh/assets/xml/GC_NMQ_D/objects/object_spot09_obj.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_spot09_obj.xml
@@ -1,5 +1,26 @@
 <Root>
     <File Name="object_spot09_obj" Segment="6">
+        <Texture Name="object_spot09_objTex_008490" OutName="object_spot09_objTex_008490" Format="rgba16" Width="32" Height="32" Offset="0x8490" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_008C90" OutName="object_spot09_objTex_008C90" Format="rgba16" Width="32" Height="32" Offset="0x8C90" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_009490" OutName="object_spot09_objTex_009490" Format="rgba16" Width="64" Height="32" Offset="0x9490" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_00A490" OutName="object_spot09_objTex_00A490" Format="rgba16" Width="32" Height="32" Offset="0xA490" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_00AC90" OutName="object_spot09_objTex_00AC90" Format="rgba16" Width="32" Height="32" Offset="0xAC90" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_00B490" OutName="object_spot09_objTex_00B490" Format="rgba16" Width="32" Height="32" Offset="0xB490" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_00BC90" OutName="object_spot09_objTex_00BC90" Format="rgba16" Width="32" Height="64" Offset="0xBC90" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_00CC90" OutName="object_spot09_objTex_00CC90" Format="rgba16" Width="64" Height="32" Offset="0xCC90" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_00DC90" OutName="object_spot09_objTex_00DC90" Format="rgba16" Width="32" Height="64" Offset="0xDC90" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_00EC90" OutName="object_spot09_objTex_00EC90" Format="rgba16" Width="64" Height="32" Offset="0xEC90" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_00FC90" OutName="object_spot09_objTex_00FC90" Format="rgba16" Width="16" Height="32" Offset="0xFC90" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_010090" OutName="object_spot09_objTex_010090" Format="rgba16" Width="64" Height="32" Offset="0x10090" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_011090" OutName="object_spot09_objTex_011090" Format="rgba16" Width="32" Height="64" Offset="0x11090" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_012090" OutName="object_spot09_objTex_012090" Format="rgba16" Width="64" Height="32" Offset="0x12090" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_013090" OutName="object_spot09_objTex_013090" Format="rgba16" Width="64" Height="32" Offset="0x13090" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_014090" OutName="object_spot09_objTex_014090" Format="rgba16" Width="64" Height="32" Offset="0x14090" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_015090" OutName="object_spot09_objTex_015090" Format="rgba16" Width="32" Height="64" Offset="0x15090" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_016090" OutName="object_spot09_objTex_016090" Format="rgba16" Width="32" Height="64" Offset="0x16090" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_017090" OutName="object_spot09_objTex_017090" Format="i8" Width="32" Height="32" Offset="0x17090" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_017490" OutName="object_spot09_objTex_017490" Format="i8" Width="32" Height="32" Offset="0x17490" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_017890" OutName="object_spot09_objTex_017890" Format="i4" Width="128" Height="64" Offset="0x17890" AddedByScript="true"/>
         <DList Name="gValleyBridgeSidesDL" Offset="0x100"/>
         <DList Name="gValleyBrokenBridgeDL" Offset="0x3970"/>
         <DList Name="gValleyBridgeChildDL" Offset="0x1120"/>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_sst.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_sst.xml
@@ -1,5 +1,21 @@
 <Root>
     <File Name="object_sst" Segment="6">
+        <Texture Name="object_sstTex_017FE0" OutName="object_sstTex_017FE0" Format="rgba16" Width="32" Height="64" Offset="0x17FE0" AddedByScript="true"/>
+        <Texture Name="object_sstTex_019530" OutName="object_sstTex_019530" Format="rgba16" Width="4" Height="8" Offset="0x19530" AddedByScript="true"/>
+        <Texture Name="object_sstTex_019570" OutName="object_sstTex_019570" Format="rgba16" Width="8" Height="16" Offset="0x19570" AddedByScript="true"/>
+        <Texture Name="object_sstTex_019670" OutName="object_sstTex_019670" Format="rgba16" Width="8" Height="16" Offset="0x19670" AddedByScript="true"/>
+        <Texture Name="object_sstTex_019770" OutName="object_sstTex_019770" Format="rgba16" Width="4" Height="8" Offset="0x19770" AddedByScript="true"/>
+        <Texture Name="object_sstTex_0197B0" OutName="object_sstTex_0197B0" Format="rgba16" Width="16" Height="16" Offset="0x197B0" AddedByScript="true"/>
+        <Texture Name="object_sstTex_0199B0" OutName="object_sstTex_0199B0" Format="rgba16" Width="8" Height="16" Offset="0x199B0" AddedByScript="true"/>
+        <Texture Name="object_sstTex_019AB0" OutName="object_sstTex_019AB0" Format="rgba16" Width="8" Height="16" Offset="0x19AB0" AddedByScript="true"/>
+        <Texture Name="object_sstTex_019BB0" OutName="object_sstTex_019BB0" Format="rgba16" Width="16" Height="32" Offset="0x19BB0" AddedByScript="true"/>
+        <Texture Name="object_sstTex_019FB0" OutName="object_sstTex_019FB0" Format="rgba16" Width="8" Height="16" Offset="0x19FB0" AddedByScript="true"/>
+        <Texture Name="object_sstTex_01A0B0" OutName="object_sstTex_01A0B0" Format="rgba16" Width="8" Height="16" Offset="0x1A0B0" AddedByScript="true"/>
+        <Texture Name="object_sstTex_01A1B0" OutName="object_sstTex_01A1B0" Format="rgba16" Width="8" Height="32" Offset="0x1A1B0" AddedByScript="true"/>
+        <Texture Name="object_sstTex_01A3B0" OutName="object_sstTex_01A3B0" Format="rgba16" Width="16" Height="16" Offset="0x1A3B0" AddedByScript="true"/>
+        <Texture Name="object_sstTex_01A5B0" OutName="object_sstTex_01A5B0" Format="rgba16" Width="8" Height="16" Offset="0x1A5B0" AddedByScript="true"/>
+        <Texture Name="object_sstTex_01A730" OutName="object_sstTex_01A730" Format="rgba16" Width="4" Height="16" Offset="0x1A730" AddedByScript="true"/>
+        <Texture Name="object_sstTex_01A7B0" OutName="object_sstTex_01A7B0" Format="rgba16" Width="16" Height="16" Offset="0x1A7B0" AddedByScript="true"/>
         <!-- Boss Title Card -->
         <Texture Name="gBongoTitleCardTex" OutName="bongo_title_card" Format="i8" Width="128" Height="120" Offset="0x13D80"/>
         

--- a/soh/assets/xml/GC_NMQ_D/objects/object_tk.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_tk.xml
@@ -1,5 +1,22 @@
 <Root>
     <File Name="object_tk" Segment="6">
+        <Texture Name="object_tkTex_003980" OutName="object_tkTex_003980" Format="ci8" Width="8" Height="8" Offset="0x3980" TlutOffset="0x3780" AddedByScript="true"/>
+        <Texture Name="object_tkTex_0039C0" OutName="object_tkTex_0039C0" Format="ci8" Width="8" Height="8" Offset="0x39C0" TlutOffset="0x3780" AddedByScript="true"/>
+        <Texture Name="object_tkTex_003A00" OutName="object_tkTex_003A00" Format="ci8" Width="8" Height="8" Offset="0x3A00" TlutOffset="0x3780" AddedByScript="true"/>
+        <Texture Name="object_tkTex_003A40" OutName="object_tkTex_003A40" Format="ci8" Width="16" Height="16" Offset="0x3A40" TlutOffset="0x3780" AddedByScript="true"/>
+        <Texture Name="object_tkTex_005340" OutName="object_tkTex_005340" Format="ci8" Width="16" Height="16" Offset="0x5340" TlutOffset="0x3780" AddedByScript="true"/>
+        <Texture Name="object_tkTex_005440" OutName="object_tkTex_005440" Format="ci8" Width="16" Height="16" Offset="0x5440" TlutOffset="0x3780" AddedByScript="true"/>
+        <Texture Name="object_tkTex_0056C0" OutName="object_tkTex_0056C0" Format="ci8" Width="16" Height="16" Offset="0x56C0" TlutOffset="0x3780" AddedByScript="true"/>
+        <Texture Name="object_tkTex_009B00" OutName="object_tkTex_009B00" Format="ci8" Width="16" Height="16" Offset="0x9B00" TlutOffset="0x9AB0" AddedByScript="true"/>
+        <Texture Name="object_tkTex_009C00" OutName="object_tkTex_009C00" Format="ci8" Width="8" Height="16" Offset="0x9C00" TlutOffset="0x9AB0" AddedByScript="true"/>
+        <Texture Name="object_tkTex_009C80" OutName="object_tkTex_009C80" Format="i8" Width="8" Height="8" Offset="0x9C80" AddedByScript="true"/>
+        <Texture Name="object_tkTex_009CC0" OutName="object_tkTex_009CC0" Format="rgba16" Width="8" Height="8" Offset="0x9CC0" AddedByScript="true"/>
+        <Texture Name="object_tkTex_009D40" OutName="object_tkTex_009D40" Format="i4" Width="16" Height="32" Offset="0x9D40" AddedByScript="true"/>
+        <Texture Name="object_tkTex_00B088" OutName="object_tkTex_00B088" Format="rgba16" Width="16" Height="16" Offset="0xB088" AddedByScript="true"/>
+        <Texture Name="object_tkTex_00B288" OutName="object_tkTex_00B288" Format="rgba16" Width="16" Height="16" Offset="0xB288" AddedByScript="true"/>
+        <Texture Name="object_tkTex_00B488" OutName="object_tkTex_00B488" Format="rgba16" Width="16" Height="16" Offset="0xB488" AddedByScript="true"/>
+        <Texture Name="object_tkTLUT_003780" OutName="object_tkTLUT_003780" Format="rgba16" Width="16" Height="16" Offset="0x3780" AddedByScript="true"/>
+        <Texture Name="object_tkTLUT_009AB0" OutName="object_tkTLUT_009AB0" Format="rgba16" Width="16" Height="16" Offset="0x9AB0" AddedByScript="true"/>
         <Animation Name="gDampeDigAnim" Offset="0x1144"/>
         <Animation Name="gDampeWalkAnim" Offset="0x1FA8"/>
         <Animation Name="gDampeRestAnim" Offset="0x2F84"/>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_torch2.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_torch2.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_torch2" Segment="6">
+        <Texture Name="object_torch2Tex_0041C0" OutName="object_torch2Tex_0041C0" Format="rgba16" Width="16" Height="16" Offset="0x41C0" AddedByScript="true"/>
+        <Texture Name="object_torch2Tex_0043C0" OutName="object_torch2Tex_0043C0" Format="ia16" Width="16" Height="16" Offset="0x43C0" AddedByScript="true"/>
         <!-- Dark Link's skeleton -->
         <Skeleton Name="gDarkLinkSkel" Type="Flex" LimbType="LOD" Offset="0x4764"/>
 

--- a/soh/assets/xml/GC_NMQ_D/objects/object_xc.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_xc.xml
@@ -1,5 +1,32 @@
 <Root>
     <File Name="object_xc" Segment="6">
+        <Texture Name="object_xcTex_004C40" OutName="object_xcTex_004C40" Format="ci8" Width="8" Height="8" Offset="0x4C40" TlutOffset="0x4840" AddedByScript="true"/>
+        <Texture Name="object_xcTex_004C80" OutName="object_xcTex_004C80" Format="ci8" Width="8" Height="8" Offset="0x4C80" TlutOffset="0x4840" AddedByScript="true"/>
+        <Texture Name="object_xcTex_005CC0" OutName="object_xcTex_005CC0" Format="ci8" Width="32" Height="32" Offset="0x5CC0" TlutOffset="0x4A40" AddedByScript="true"/>
+        <Texture Name="object_xcTex_0060C0" OutName="object_xcTex_0060C0" Format="ci8" Width="32" Height="32" Offset="0x60C0" TlutOffset="0x4840" AddedByScript="true"/>
+        <Texture Name="object_xcTex_0064C0" OutName="object_xcTex_0064C0" Format="rgba16" Width="32" Height="32" Offset="0x64C0" AddedByScript="true"/>
+        <Texture Name="object_xcTex_006CC0" OutName="object_xcTex_006CC0" Format="ci8" Width="8" Height="16" Offset="0x6CC0" TlutOffset="0x4840" AddedByScript="true"/>
+        <Texture Name="object_xcTex_006D40" OutName="object_xcTex_006D40" Format="ci8" Width="8" Height="8" Offset="0x6D40" TlutOffset="0x4840" AddedByScript="true"/>
+        <Texture Name="object_xcTex_006D80" OutName="object_xcTex_006D80" Format="ci8" Width="16" Height="16" Offset="0x6D80" TlutOffset="0x4840" AddedByScript="true"/>
+        <Texture Name="object_xcTex_006E80" OutName="object_xcTex_006E80" Format="ci8" Width="32" Height="32" Offset="0x6E80" TlutOffset="0x4A40" AddedByScript="true"/>
+        <Texture Name="object_xcTex_007280" OutName="object_xcTex_007280" Format="ci8" Width="16" Height="16" Offset="0x7280" TlutOffset="0x4840" AddedByScript="true"/>
+        <Texture Name="object_xcTex_007380" OutName="object_xcTex_007380" Format="rgba16" Width="32" Height="32" Offset="0x7380" AddedByScript="true"/>
+        <Texture Name="object_xcTex_007B80" OutName="object_xcTex_007B80" Format="ci8" Width="32" Height="64" Offset="0x7B80" TlutOffset="0x4840" AddedByScript="true"/>
+        <Texture Name="object_xcTex_008380" OutName="object_xcTex_008380" Format="ci8" Width="32" Height="64" Offset="0x8380" TlutOffset="0x4840" AddedByScript="true"/>
+        <Texture Name="object_xcTex_008B80" OutName="object_xcTex_008B80" Format="ci8" Width="16" Height="8" Offset="0x8B80" TlutOffset="0x4840" AddedByScript="true"/>
+        <Texture Name="object_xcTex_008C00" OutName="object_xcTex_008C00" Format="ci8" Width="32" Height="16" Offset="0x8C00" TlutOffset="0x4840" AddedByScript="true"/>
+        <Texture Name="object_xcTex_00F790" OutName="object_xcTex_00F790" Format="ci8" Width="8" Height="8" Offset="0xF790" TlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="object_xcTex_00F7D0" OutName="object_xcTex_00F7D0" Format="ci8" Width="32" Height="32" Offset="0xF7D0" TlutOffset="0xF720" AddedByScript="true"/>
+        <Texture Name="object_xcTex_00FBD0" OutName="object_xcTex_00FBD0" Format="ci8" Width="16" Height="16" Offset="0xFBD0" TlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="object_xcTex_00FCD0" OutName="object_xcTex_00FCD0" Format="ci8" Width="8" Height="8" Offset="0xFCD0" TlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="object_xcTex_00FD10" OutName="object_xcTex_00FD10" Format="rgba16" Width="8" Height="8" Offset="0xFD10" AddedByScript="true"/>
+        <Texture Name="object_xcTex_00FD90" OutName="object_xcTex_00FD90" Format="i8" Width="8" Height="8" Offset="0xFD90" AddedByScript="true"/>
+        <Texture Name="object_xcTex_00FDD0" OutName="object_xcTex_00FDD0" Format="rgba16" Width="16" Height="32" Offset="0xFDD0" AddedByScript="true"/>
+        <Texture Name="object_xcTex_0101D0" OutName="object_xcTex_0101D0" Format="rgba16" Width="8" Height="16" Offset="0x101D0" AddedByScript="true"/>
+        <Texture Name="object_xcTex_011930" OutName="object_xcTex_011930" Format="i8" Width="64" Height="64" Offset="0x11930" AddedByScript="true"/>
+        <Texture Name="object_xcTLUT_004840" OutName="object_xcTLUT_004840" Format="rgba16" Width="16" Height="16" Offset="0x4840" AddedByScript="true"/>
+        <Texture Name="object_xcTLUT_00F6C0" OutName="object_xcTLUT_00F6C0" Format="rgba16" Width="16" Height="16" Offset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="object_xcTLUT_00F720" OutName="object_xcTLUT_00F720" Format="rgba16" Width="16" Height="16" Offset="0xF720" AddedByScript="true"/>
         <Skeleton Name="gSheikSkel" Type="Flex" LimbType="Standard" Offset="0x12AF0"/>
         <Animation Name="gSheikPlayingHarpAnim" Offset="0xB6C"/>
         <Animation Name="gSheikShowingTriforceOnHandAnim" Offset="0x1A08"/>
@@ -8,6 +35,7 @@
         <Animation Name="gSheikPlayingHarp3Anim" Offset="0x35C8"/>
         <Animation Name="gSheikPlayingHarp4Anim" Offset="0x4570"/>
         <Animation Name="gSheikIdleAnim" Offset="0x4828"/>
+        <Texture Name="object_xcTLUT_004A40" OutName="object_xcTLUT_004A40" Format="rgba16" Width="16" Height="16" Offset="0x4A40"/>
         <Animation Name="gSheikWalkingAnim" Offset="0x12FD0"/>
         <Animation Name="gSheikArmsCrossedIdleAnim" Offset="0x13AA4"/>
         <Animation Name="gSheikFallingFromContortionsAnim" Offset="0x149E4"/>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_zl1.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_zl1.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_zl1" Segment="6">
+        <Texture Name="object_zl1Tex_00EE58" OutName="object_zl1Tex_00EE58" Format="rgba16" Width="32" Height="16" Offset="0xEE58" AddedByScript="true"/>
         <!-- Child Zelda 1 Skeleton -->
         <Skeleton Name="gChildZelda1Skel" Type="Flex" LimbType="Standard" Offset="0xF5D8"/>
 

--- a/soh/assets/xml/GC_NMQ_D/objects/object_zl2.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_zl2.xml
@@ -1,5 +1,38 @@
 <Root>
     <File Name="object_zl2" Segment="6">
+        <Texture Name="object_zl2Tex_000E00" OutName="object_zl2Tex_000E00" Format="ci8" Width="16" Height="16" Offset="0xE00" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_000F00" OutName="object_zl2Tex_000F00" Format="ci8" Width="8" Height="8" Offset="0xF00" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_000F40" OutName="object_zl2Tex_000F40" Format="ci8" Width="16" Height="32" Offset="0xF40" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_001140" OutName="object_zl2Tex_001140" Format="ci8" Width="8" Height="8" Offset="0x1140" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_001180" OutName="object_zl2Tex_001180" Format="ci8" Width="16" Height="16" Offset="0x1180" TlutOffset="0x200" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_001280" OutName="object_zl2Tex_001280" Format="ci8" Width="8" Height="8" Offset="0x1280" TlutOffset="0x200" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_0012C0" OutName="object_zl2Tex_0012C0" Format="ci8" Width="16" Height="64" Offset="0x12C0" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_0016C0" OutName="object_zl2Tex_0016C0" Format="ci8" Width="32" Height="32" Offset="0x16C0" TlutOffset="0x400" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_001AC0" OutName="object_zl2Tex_001AC0" Format="ci8" Width="32" Height="16" Offset="0x1AC0" TlutOffset="0x400" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_001CC0" OutName="object_zl2Tex_001CC0" Format="ci8" Width="32" Height="64" Offset="0x1CC0" TlutOffset="0x400" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_0024C0" OutName="object_zl2Tex_0024C0" Format="ci8" Width="8" Height="8" Offset="0x24C0" TlutOffset="0x200" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_002500" OutName="object_zl2Tex_002500" Format="ci8" Width="16" Height="16" Offset="0x2500" TlutOffset="0x200" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_002600" OutName="object_zl2Tex_002600" Format="ci8" Width="32" Height="8" Offset="0x2600" TlutOffset="0x400" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_002700" OutName="object_zl2Tex_002700" Format="ci8" Width="8" Height="8" Offset="0x2700" TlutOffset="0x400" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_002740" OutName="object_zl2Tex_002740" Format="ci8" Width="8" Height="8" Offset="0x2740" TlutOffset="0x400" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_002780" OutName="object_zl2Tex_002780" Format="ci8" Width="16" Height="16" Offset="0x2780" TlutOffset="0x400" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_002880" OutName="object_zl2Tex_002880" Format="ci8" Width="8" Height="16" Offset="0x2880" TlutOffset="0x200" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_0034C8" OutName="object_zl2Tex_0034C8" Format="ci8" Width="8" Height="8" Offset="0x34C8" TlutOffset="0x2D00" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_003908" OutName="object_zl2Tex_003908" Format="ci8" Width="16" Height="16" Offset="0x3908" TlutOffset="0x2D00" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_003A08" OutName="object_zl2Tex_003A08" Format="ci8" Width="8" Height="8" Offset="0x3A08" TlutOffset="0x9490" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_003A48" OutName="object_zl2Tex_003A48" Format="ci8" Width="8" Height="16" Offset="0x3A48" TlutOffset="0x2F50" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_003AC8" OutName="object_zl2Tex_003AC8" Format="ci8" Width="16" Height="8" Offset="0x3AC8" TlutOffset="0x2F50" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_003B48" OutName="object_zl2Tex_003B48" Format="ci8" Width="16" Height="16" Offset="0x3B48" TlutOffset="0x2F50" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_004448" OutName="object_zl2Tex_004448" Format="ci8" Width="16" Height="16" Offset="0x4448" TlutOffset="0x2F50" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_006548" OutName="object_zl2Tex_006548" Format="ci8" Width="32" Height="16" Offset="0x6548" TlutOffset="0x2F50" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_009738" OutName="object_zl2Tex_009738" Format="ci8" Width="16" Height="32" Offset="0x9738" TlutOffset="0x95A0" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_009938" OutName="object_zl2Tex_009938" Format="ci8" Width="16" Height="16" Offset="0x9938" TlutOffset="0x9490" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_009A38" OutName="object_zl2Tex_009A38" Format="ci8" Width="8" Height="8" Offset="0x9A38" TlutOffset="0x9490" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_009A78" OutName="object_zl2Tex_009A78" Format="ci8" Width="32" Height="32" Offset="0x9A78" TlutOffset="0x9490" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_009E78" OutName="object_zl2Tex_009E78" Format="ci8" Width="16" Height="16" Offset="0x9E78" TlutOffset="0x95A0" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_009F78" OutName="object_zl2Tex_009F78" Format="ci8" Width="8" Height="16" Offset="0x9F78" TlutOffset="0x95A0" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_009FF8" OutName="object_zl2Tex_009FF8" Format="ci8" Width="16" Height="16" Offset="0x9FF8" TlutOffset="0x9708" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_00A0F8" OutName="object_zl2Tex_00A0F8" Format="ci8" Width="32" Height="32" Offset="0xA0F8" TlutOffset="0x9708" AddedByScript="true"/>
         <!-- Zelda 2 skeleton -->
         <Skeleton Name="gZelda2Skel" Type="Flex" LimbType="Standard" Offset="0x10D70"/>
 
@@ -19,9 +52,9 @@
 
         <!-- Zelda 2 mouth textures -->
         <Texture Name="gZelda2MouthTLUT" OutName="zelda_2_mouth_tlut" Format="rgba16" Width="16" Height="14" Offset="0x2D90"/>
-        <Texture Name="gZelda2MouthSeriousTex" OutName="zelda_2_mouth_serious" Format="ci8" Width="32" Height="32"  Offset="0x3508" TlutOffset="0x2D90"/>
-        <Texture Name="gZelda2MouthHappyTex" OutName="zelda_2_mouth_happy" Format="ci8" Width="32" Height="32"  Offset="0x5548" TlutOffset="0x2D90"/>
-        <Texture Name="gZelda2MouthOpenTex" OutName="zelda_2_mouth_open" Format="ci8" Width="32" Height="32"  Offset="0x5948" TlutOffset="0x2D90"/>
+        <Texture Name="gZelda2MouthSeriousTex" OutName="zelda_2_mouth_serious" Format="ci8" Width="32" Height="32" Offset="0x3508" TlutOffset="0x2D90"/>
+        <Texture Name="gZelda2MouthHappyTex" OutName="zelda_2_mouth_happy" Format="ci8" Width="32" Height="32" Offset="0x5548" TlutOffset="0x2D90"/>
+        <Texture Name="gZelda2MouthOpenTex" OutName="zelda_2_mouth_open" Format="ci8" Width="32" Height="32" Offset="0x5948" TlutOffset="0x2D90"/>
 
         <!-- Ocarina of time -->
         <DList Name="gZelda2OcarinaDL" Offset="0xBAE8"/>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_zl4.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_zl4.xml
@@ -1,5 +1,36 @@
 <Root>
     <File Name="object_zl4" Segment="6">
+        <Texture Name="object_zl4Tex_000C70" OutName="object_zl4Tex_000C70" Format="ci8" Width="8" Height="8" Offset="0xC70" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_000CB0" OutName="object_zl4Tex_000CB0" Format="ci8" Width="16" Height="16" Offset="0xCB0" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_000DB0" OutName="object_zl4Tex_000DB0" Format="ci8" Width="32" Height="64" Offset="0xDB0" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_0015B0" OutName="object_zl4Tex_0015B0" Format="rgba16" Width="8" Height="8" Offset="0x15B0" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_001630" OutName="object_zl4Tex_001630" Format="rgba16" Width="8" Height="8" Offset="0x1630" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_0016B0" OutName="object_zl4Tex_0016B0" Format="ci8" Width="32" Height="8" Offset="0x16B0" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_0017B0" OutName="object_zl4Tex_0017B0" Format="ci8" Width="8" Height="8" Offset="0x17B0" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_0017F0" OutName="object_zl4Tex_0017F0" Format="ci8" Width="32" Height="32" Offset="0x17F0" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_001BF0" OutName="object_zl4Tex_001BF0" Format="rgba16" Width="8" Height="16" Offset="0x1BF0" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_001CF0" OutName="object_zl4Tex_001CF0" Format="ci8" Width="16" Height="16" Offset="0x1CF0" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_001DF0" OutName="object_zl4Tex_001DF0" Format="ci8" Width="8" Height="8" Offset="0x1DF0" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_001E30" OutName="object_zl4Tex_001E30" Format="rgba16" Width="16" Height="32" Offset="0x1E30" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_002230" OutName="object_zl4Tex_002230" Format="ci8" Width="8" Height="8" Offset="0x2230" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_002270" OutName="object_zl4Tex_002270" Format="ci8" Width="8" Height="16" Offset="0x2270" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_0022F0" OutName="object_zl4Tex_0022F0" Format="ci8" Width="16" Height="32" Offset="0x22F0" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_0024F0" OutName="object_zl4Tex_0024F0" Format="rgba16" Width="16" Height="16" Offset="0x24F0" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_0026F0" OutName="object_zl4Tex_0026F0" Format="rgba16" Width="16" Height="16" Offset="0x26F0" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_0028F0" OutName="object_zl4Tex_0028F0" Format="rgba16" Width="8" Height="8" Offset="0x28F0" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_002970" OutName="object_zl4Tex_002970" Format="rgba16" Width="8" Height="8" Offset="0x2970" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_0029F0" OutName="object_zl4Tex_0029F0" Format="rgba16" Width="16" Height="8" Offset="0x29F0" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_0056F0" OutName="object_zl4Tex_0056F0" Format="rgba16" Width="16" Height="16" Offset="0x56F0" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_0058F0" OutName="object_zl4Tex_0058F0" Format="ci8" Width="16" Height="16" Offset="0x58F0" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_0059F0" OutName="object_zl4Tex_0059F0" Format="rgba16" Width="8" Height="8" Offset="0x59F0" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_005A70" OutName="object_zl4Tex_005A70" Format="rgba16" Width="16" Height="16" Offset="0x5A70" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_005C70" OutName="object_zl4Tex_005C70" Format="ci8" Width="8" Height="8" Offset="0x5C70" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_005CB0" OutName="object_zl4Tex_005CB0" Format="ci8" Width="16" Height="16" Offset="0x5CB0" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_005DB0" OutName="object_zl4Tex_005DB0" Format="rgba16" Width="32" Height="32" Offset="0x5DB0" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_00D8B8" OutName="object_zl4Tex_00D8B8" Format="rgba16" Width="32" Height="16" Offset="0xD8B8" AddedByScript="true"/>
+        <Texture Name="object_zl4TLUT_000670" OutName="object_zl4TLUT_000670" Format="rgba16" Width="16" Height="16" Offset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4TLUT_000870" OutName="object_zl4TLUT_000870" Format="rgba16" Width="16" Height="16" Offset="0x870" AddedByScript="true"/>
+        <Texture Name="object_zl4TLUT_000A70" OutName="object_zl4TLUT_000A70" Format="rgba16" Width="16" Height="16" Offset="0xA70" AddedByScript="true"/>
         <!-- Child Zelda's skeleton -->
         <Skeleton Name="gChildZeldaSkel" Type="Flex" LimbType="Standard" Offset="0xE038"/>
 

--- a/soh/assets/xml/GC_NMQ_D/overlays/ovl_Boss_Ganon.xml
+++ b/soh/assets/xml/GC_NMQ_D/overlays/ovl_Boss_Ganon.xml
@@ -1,5 +1,21 @@
 <Root>
     <File Name="ovl_Boss_Ganon" BaseAddress="0x808D68F0" RangeStart="0xE6B8" RangeEnd="0x211D8">
+        <Texture Name="ovl_Boss_GanonTex_00E748" OutName="ovl_Boss_GanonTex_00E748" Format="i8" Width="64" Height="64" Offset="0xE748" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_00F848" OutName="ovl_Boss_GanonTex_00F848" Format="ci8" Width="32" Height="32" Offset="0xF848" TlutOffset="0xF808" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_010538" OutName="ovl_Boss_GanonTex_010538" Format="i8" Width="64" Height="64" Offset="0x10538" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_01A7B0" OutName="ovl_Boss_GanonTex_01A7B0" Format="ia16" Width="32" Height="32" Offset="0x1A7B0" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_01AFB0" OutName="ovl_Boss_GanonTex_01AFB0" Format="i4" Width="64" Height="64" Offset="0x1AFB0" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_01B7B0" OutName="ovl_Boss_GanonTex_01B7B0" Format="i4" Width="64" Height="64" Offset="0x1B7B0" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_01C420" OutName="ovl_Boss_GanonTex_01C420" Format="i8" Width="64" Height="32" Offset="0x1C420" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_01CEB8" OutName="ovl_Boss_GanonTex_01CEB8" Format="i8" Width="32" Height="64" Offset="0x1CEB8" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_01D6B8" OutName="ovl_Boss_GanonTex_01D6B8" Format="i8" Width="32" Height="32" Offset="0x1D6B8" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_01DE88" OutName="ovl_Boss_GanonTex_01DE88" Format="i8" Width="32" Height="64" Offset="0x1DE88" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_01E688" OutName="ovl_Boss_GanonTex_01E688" Format="i8" Width="32" Height="64" Offset="0x1E688" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_01EF90" OutName="ovl_Boss_GanonTex_01EF90" Format="i8" Width="96" Height="16" Offset="0x1EF90" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_01FFF8" OutName="ovl_Boss_GanonTex_01FFF8" Format="i4" Width="32" Height="32" Offset="0x1FFF8" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_020370" OutName="ovl_Boss_GanonTex_020370" Format="i8" Width="32" Height="32" Offset="0x20370" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_020770" OutName="ovl_Boss_GanonTex_020770" Format="i8" Width="32" Height="64" Offset="0x20770" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTLUT_00F808" OutName="ovl_Boss_GanonTLUT_00F808" Format="rgba16" Width="16" Height="16" Offset="0xF808" AddedByScript="true"/>
         <Texture Name="gGanondorfLightning1Tex" OutName="lightning_1" Format="i8" Width="32" Height="96" Offset="0x11600" Static="Off"/>
         <Texture Name="gGanondorfLightning2Tex" OutName="lightning_2" Format="i8" Width="32" Height="96" Offset="0x12200" Static="Off"/>
         <Texture Name="gGanondorfLightning3Tex" OutName="lightning_3" Format="i8" Width="32" Height="96" Offset="0x12E00" Static="Off"/>

--- a/soh/assets/xml/GC_NMQ_D/overlays/ovl_Boss_Sst.xml
+++ b/soh/assets/xml/GC_NMQ_D/overlays/ovl_Boss_Sst.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="ovl_Boss_Sst" BaseAddress="0x8092C650" RangeStart="0xA3C0" RangeEnd="0xAD70">
+        <Texture Name="ovl_Boss_SstTex_00A438" OutName="ovl_Boss_SstTex_00A438" Format="i8" Width="16" Height="64" Offset="0xA438" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_SstTex_00A8F0" OutName="ovl_Boss_SstTex_00A8F0" Format="i8" Width="32" Height="32" Offset="0xA8F0" AddedByScript="true"/>
         <DList Name="sBodyStaticDList" Offset="0xA3C0"/>
         <DList Name="sHandTrailDList" Offset="0xA3D8"/>
         <DList Name="sIntroVanishDList" Offset="0xA838"/>

--- a/soh/assets/xml/GC_NMQ_D/overlays/ovl_Demo_Shd.xml
+++ b/soh/assets/xml/GC_NMQ_D/overlays/ovl_Demo_Shd.xml
@@ -1,7 +1,9 @@
 <Root>
     <File Name="ovl_Demo_Shd" BaseAddress="0x809912B0" RangeStart="0x450" RangeEnd="0x23D0">
 
-    <DList Name="D_809932D0" Offset="0x20A0"/>
+    <Texture Name="ovl_Demo_ShdTex_000450" OutName="ovl_Demo_ShdTex_000450" Format="i8" Width="16" Height="128" Offset="0x450" AddedByScript="true"/>
+        <Texture Name="ovl_Demo_ShdTex_000C50" OutName="ovl_Demo_ShdTex_000C50" Format="i8" Width="32" Height="64" Offset="0xC50" AddedByScript="true"/>
+        <DList Name="D_809932D0" Offset="0x20A0"/>
     <DList Name="D_80993390" Offset="0x2160"/>
     <DList Name="D_809934B8" Offset="0x2288"/>
     </File>

--- a/soh/assets/xml/GC_NMQ_D/overlays/ovl_En_Clear_Tag.xml
+++ b/soh/assets/xml/GC_NMQ_D/overlays/ovl_En_Clear_Tag.xml
@@ -1,5 +1,19 @@
 <Root>
     <File Name="ovl_En_Clear_Tag" BaseAddress="0x809D3630" RangeStart="0x26F0" RangeEnd="0x89F0">
+        <Texture Name="ovl_En_Clear_TagTex_003308" OutName="ovl_En_Clear_TagTex_003308" Format="rgba16" Width="8" Height="8" Offset="0x3308" AddedByScript="true"/>
+        <Texture Name="ovl_En_Clear_TagTex_003388" OutName="ovl_En_Clear_TagTex_003388" Format="rgba16" Width="32" Height="32" Offset="0x3388" AddedByScript="true"/>
+        <Texture Name="ovl_En_Clear_TagTex_003B88" OutName="ovl_En_Clear_TagTex_003B88" Format="rgba16" Width="64" Height="32" Offset="0x3B88" AddedByScript="true"/>
+        <Texture Name="ovl_En_Clear_TagTex_004B88" OutName="ovl_En_Clear_TagTex_004B88" Format="rgba16" Width="32" Height="32" Offset="0x4B88" AddedByScript="true"/>
+        <Texture Name="ovl_En_Clear_TagTex_005388" OutName="ovl_En_Clear_TagTex_005388" Format="rgba16" Width="32" Height="32" Offset="0x5388" AddedByScript="true"/>
+        <Texture Name="ovl_En_Clear_TagTex_005B88" OutName="ovl_En_Clear_TagTex_005B88" Format="rgba16" Width="32" Height="32" Offset="0x5B88" AddedByScript="true"/>
+        <Texture Name="ovl_En_Clear_TagTex_006458" OutName="ovl_En_Clear_TagTex_006458" Format="rgba16" Width="16" Height="16" Offset="0x6458" AddedByScript="true"/>
+        <Texture Name="ovl_En_Clear_TagTex_006708" OutName="ovl_En_Clear_TagTex_006708" Format="i8" Width="16" Height="16" Offset="0x6708" AddedByScript="true"/>
+        <Texture Name="ovl_En_Clear_TagTex_006808" OutName="ovl_En_Clear_TagTex_006808" Format="rgba16" Width="16" Height="16" Offset="0x6808" AddedByScript="true"/>
+        <Texture Name="ovl_En_Clear_TagTex_006AD0" OutName="ovl_En_Clear_TagTex_006AD0" Format="i4" Width="32" Height="64" Offset="0x6AD0" AddedByScript="true"/>
+        <Texture Name="ovl_En_Clear_TagTex_006ED0" OutName="ovl_En_Clear_TagTex_006ED0" Format="i4" Width="32" Height="32" Offset="0x6ED0" AddedByScript="true"/>
+        <Texture Name="ovl_En_Clear_TagTex_0071C8" OutName="ovl_En_Clear_TagTex_0071C8" Format="i8" Width="64" Height="64" Offset="0x71C8" AddedByScript="true"/>
+        <Texture Name="ovl_En_Clear_TagTex_008288" OutName="ovl_En_Clear_TagTex_008288" Format="i4" Width="32" Height="32" Offset="0x8288" AddedByScript="true"/>
+        <Texture Name="ovl_En_Clear_TagTex_008540" OutName="ovl_En_Clear_TagTex_008540" Format="i8" Width="32" Height="32" Offset="0x8540" AddedByScript="true"/>
         <DList Name="gArwingDL" Offset="0x26F0"/>
         <DList Name="gArwingLaserDL" Offset="0x6388"/>
         <DList Name="gArwingBackfireDL" Offset="0x6688"/>

--- a/soh/assets/xml/GC_NMQ_D/scenes/dungeons/Bmori1.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/dungeons/Bmori1.xml
@@ -1,76 +1,231 @@
 <Root>
     <File Name="Bmori1_scene" Segment="2">
+        <Texture Name="Bmori1_sceneTex_014490" OutName="Bmori1_sceneTex_014490" Format="ci8" Width="32" Height="8" Offset="0x14490" TlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_sceneTex_015590" OutName="Bmori1_sceneTex_015590" Format="ci8" Width="16" Height="16" Offset="0x15590" TlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_sceneTex_015690" OutName="Bmori1_sceneTex_015690" Format="ci8" Width="32" Height="32" Offset="0x15690" TlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_sceneTex_015A90" OutName="Bmori1_sceneTex_015A90" Format="ci8" Width="16" Height="16" Offset="0x15A90" TlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_sceneTex_015B90" OutName="Bmori1_sceneTex_015B90" Format="ci8" Width="32" Height="32" Offset="0x15B90" TlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_sceneTLUT_014080" OutName="Bmori1_sceneTLUT_014080" Format="rgba16" Width="16" Height="16" Offset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_sceneTLUT_014288" OutName="Bmori1_sceneTLUT_014288" Format="rgba16" Width="16" Height="16" Offset="0x14288" AddedByScript="true"/>
         <Texture Name="gForestTempleDayEntranceTex" OutName="day_entrance" Format="ia16" Width="8" Height="128" Offset="0x14D90"/>
         <Texture Name="gForestTempleNightEntranceTex" OutName="night_entrance" Format="ia16" Width="8" Height="128" Offset="0x14590"/>
         <Scene Name="Bmori1_scene" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_0" Segment="3">
+        <Texture Name="Bmori1_room_0Tex_005CF8" OutName="Bmori1_room_0Tex_005CF8" Format="ci8" Width="64" Height="32" Offset="0x5CC8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_0Tex_0064F8" OutName="Bmori1_room_0Tex_0064F8" Format="i8" Width="64" Height="64" Offset="0x64C8" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_0Tex_0074F8" OutName="Bmori1_room_0Tex_0074F8" Format="rgba16" Width="32" Height="32" Offset="0x74C8" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_0Tex_007CF8" OutName="Bmori1_room_0Tex_007CF8" Format="rgba16" Width="32" Height="32" Offset="0x7CC8" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_0Tex_0084F8" OutName="Bmori1_room_0Tex_0084F8" Format="ci8" Width="16" Height="64" Offset="0x84C8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_0Tex_0088F8" OutName="Bmori1_room_0Tex_0088F8" Format="rgba16" Width="32" Height="64" Offset="0x88C8" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_0Tex_0098F8" OutName="Bmori1_room_0Tex_0098F8" Format="ci8" Width="32" Height="64" Offset="0x98C8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_0Tex_00A0F8" OutName="Bmori1_room_0Tex_00A0F8" Format="rgba16" Width="32" Height="64" Offset="0xA0C8" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_0Tex_00B0F8" OutName="Bmori1_room_0Tex_00B0F8" Format="ci8" Width="32" Height="32" Offset="0xB0C8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_0Tex_00B4F8" OutName="Bmori1_room_0Tex_00B4F8" Format="ci8" Width="32" Height="32" Offset="0xB4C8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_0Tex_00B8F8" OutName="Bmori1_room_0Tex_00B8F8" Format="ci8" Width="64" Height="32" Offset="0xB8C8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_0Tex_00C0F8" OutName="Bmori1_room_0Tex_00C0F8" Format="ci8" Width="16" Height="32" Offset="0xC0C8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_0Tex_00C2F8" OutName="Bmori1_room_0Tex_00C2F8" Format="ci8" Width="32" Height="32" Offset="0xC2C8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_0Tex_00CB88" OutName="Bmori1_room_0Tex_00CB88" Format="rgba16" Width="32" Height="64" Offset="0xCB58" AddedByScript="true"/>
         <Room Name="Bmori1_room_0" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_1" Segment="3">
+        <Texture Name="Bmori1_room_1Tex_003368" OutName="Bmori1_room_1Tex_003368" Format="rgba16" Width="32" Height="32" Offset="0x3348" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_1Tex_003B68" OutName="Bmori1_room_1Tex_003B68" Format="ci8" Width="64" Height="32" Offset="0x3B48" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_1Tex_004368" OutName="Bmori1_room_1Tex_004368" Format="rgba16" Width="32" Height="64" Offset="0x4348" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_1Tex_005368" OutName="Bmori1_room_1Tex_005368" Format="ci8" Width="32" Height="64" Offset="0x5348" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
         <Room Name="Bmori1_room_1" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_2" Segment="3">
+        <Texture Name="Bmori1_room_2Tex_00A380" OutName="Bmori1_room_2Tex_00A380" Format="ci8" Width="64" Height="32" Offset="0xA3A0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_2Tex_00AB80" OutName="Bmori1_room_2Tex_00AB80" Format="ci8" Width="16" Height="64" Offset="0xABA0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_2Tex_00AF80" OutName="Bmori1_room_2Tex_00AF80" Format="rgba16" Width="32" Height="64" Offset="0xAFA0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_2Tex_00BF80" OutName="Bmori1_room_2Tex_00BF80" Format="rgba16" Width="32" Height="64" Offset="0xBFA0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_2Tex_00CF80" OutName="Bmori1_room_2Tex_00CF80" Format="ci8" Width="32" Height="32" Offset="0xCFA0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_2Tex_00D380" OutName="Bmori1_room_2Tex_00D380" Format="ci8" Width="64" Height="32" Offset="0xD3A0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_2Tex_00DB80" OutName="Bmori1_room_2Tex_00DB80" Format="ci8" Width="16" Height="32" Offset="0xDBA0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_2Tex_00DD80" OutName="Bmori1_room_2Tex_00DD80" Format="ci8" Width="64" Height="32" Offset="0xDDA0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_2Tex_00E580" OutName="Bmori1_room_2Tex_00E580" Format="ci8" Width="32" Height="32" Offset="0xE5A0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_2Tex_00E980" OutName="Bmori1_room_2Tex_00E980" Format="ci8" Width="32" Height="64" Offset="0xE9A0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_2Tex_00F180" OutName="Bmori1_room_2Tex_00F180" Format="rgba16" Width="32" Height="32" Offset="0xF1A0" AddedByScript="true"/>
         <Room Name="Bmori1_room_2" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_3" Segment="3">
+        <Texture Name="Bmori1_room_3Tex_0023D8" OutName="Bmori1_room_3Tex_0023D8" Format="rgba16" Width="32" Height="32" Offset="0x23E8" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_3Tex_002BD8" OutName="Bmori1_room_3Tex_002BD8" Format="ci8" Width="16" Height="128" Offset="0x2BE8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_3Tex_0033D8" OutName="Bmori1_room_3Tex_0033D8" Format="ci8" Width="32" Height="32" Offset="0x33E8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_3Tex_0037D8" OutName="Bmori1_room_3Tex_0037D8" Format="rgba16" Width="8" Height="16" Offset="0x37E8" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_3Tex_0038D8" OutName="Bmori1_room_3Tex_0038D8" Format="rgba16" Width="16" Height="8" Offset="0x38E8" AddedByScript="true"/>
         <Room Name="Bmori1_room_3" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_4" Segment="3">
+        <Texture Name="Bmori1_room_4Tex_0022B8" OutName="Bmori1_room_4Tex_0022B8" Format="rgba16" Width="32" Height="32" Offset="0x22A8" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_4Tex_002AB8" OutName="Bmori1_room_4Tex_002AB8" Format="ci8" Width="64" Height="32" Offset="0x2AA8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
         <Room Name="Bmori1_room_4" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_5" Segment="3">
+        <Texture Name="Bmori1_room_5Tex_0023D0" OutName="Bmori1_room_5Tex_0023D0" Format="ci8" Width="32" Height="32" Offset="0x23C0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_5Tex_0027D0" OutName="Bmori1_room_5Tex_0027D0" Format="ci8" Width="16" Height="128" Offset="0x27C0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_5Tex_002FD0" OutName="Bmori1_room_5Tex_002FD0" Format="ci8" Width="32" Height="32" Offset="0x2FC0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_5Tex_0033D0" OutName="Bmori1_room_5Tex_0033D0" Format="rgba16" Width="8" Height="16" Offset="0x33C0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_5Tex_0034D0" OutName="Bmori1_room_5Tex_0034D0" Format="rgba16" Width="16" Height="8" Offset="0x34C0" AddedByScript="true"/>
         <Room Name="Bmori1_room_5" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_6" Segment="3">
+        <Texture Name="Bmori1_room_6Tex_006630" OutName="Bmori1_room_6Tex_006630" Format="rgba16" Width="32" Height="32" Offset="0x6620" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_6Tex_006E30" OutName="Bmori1_room_6Tex_006E30" Format="rgba16" Width="32" Height="32" Offset="0x6E20" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_6Tex_007630" OutName="Bmori1_room_6Tex_007630" Format="ci8" Width="32" Height="32" Offset="0x7620" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_6Tex_007A30" OutName="Bmori1_room_6Tex_007A30" Format="ci8" Width="64" Height="32" Offset="0x7A20" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_6Tex_008230" OutName="Bmori1_room_6Tex_008230" Format="ci8" Width="64" Height="32" Offset="0x8220" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_6Tex_008A30" OutName="Bmori1_room_6Tex_008A30" Format="ci8" Width="16" Height="32" Offset="0x8A20" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_6Tex_008C30" OutName="Bmori1_room_6Tex_008C30" Format="ci8" Width="32" Height="64" Offset="0x8C20" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
         <Room Name="Bmori1_room_6" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_7" Segment="3">
+        <Texture Name="Bmori1_room_7Tex_007DD0" OutName="Bmori1_room_7Tex_007DD0" Format="rgba16" Width="32" Height="32" Offset="0x7D60" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_0085D0" OutName="Bmori1_room_7Tex_0085D0" Format="rgba16" Width="32" Height="32" Offset="0x8560" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_008DD0" OutName="Bmori1_room_7Tex_008DD0" Format="ci8" Width="32" Height="32" Offset="0x8D60" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_0091D0" OutName="Bmori1_room_7Tex_0091D0" Format="ci8" Width="32" Height="32" Offset="0x9160" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_0095D0" OutName="Bmori1_room_7Tex_0095D0" Format="ci8" Width="32" Height="64" Offset="0x9560" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_009DD0" OutName="Bmori1_room_7Tex_009DD0" Format="ci8" Width="32" Height="64" Offset="0x9D60" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_00A5D0" OutName="Bmori1_room_7Tex_00A5D0" Format="ci8" Width="64" Height="32" Offset="0xA560" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_00ADD0" OutName="Bmori1_room_7Tex_00ADD0" Format="rgba16" Width="32" Height="32" Offset="0xAD60" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_00B5D0" OutName="Bmori1_room_7Tex_00B5D0" Format="ci8" Width="64" Height="32" Offset="0xB560" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_00BDD0" OutName="Bmori1_room_7Tex_00BDD0" Format="rgba16" Width="32" Height="64" Offset="0xBD60" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_00CDD0" OutName="Bmori1_room_7Tex_00CDD0" Format="rgba16" Width="32" Height="64" Offset="0xCD60" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_00DDD0" OutName="Bmori1_room_7Tex_00DDD0" Format="rgba16" Width="32" Height="32" Offset="0xDD60" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_00EFD8" OutName="Bmori1_room_7Tex_00EFD8" Format="i4" Width="64" Height="128" Offset="0xEF68" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_00FFD8" OutName="Bmori1_room_7Tex_00FFD8" Format="rgba16" Width="32" Height="64" Offset="0xFF68" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_010FD8" OutName="Bmori1_room_7Tex_010FD8" Format="rgba16" Width="32" Height="32" Offset="0x10F68" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_0117D8" OutName="Bmori1_room_7Tex_0117D8" Format="ia16" Width="32" Height="32" Offset="0x11768" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_011FD8" OutName="Bmori1_room_7Tex_011FD8" Format="rgba16" Width="32" Height="64" Offset="0x11F68" AddedByScript="true"/>
         <Room Name="Bmori1_room_7" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_8" Segment="3">
+        <Texture Name="Bmori1_room_8Tex_00AC10" OutName="Bmori1_room_8Tex_00AC10" Format="rgba16" Width="32" Height="32" Offset="0xABF0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_00B410" OutName="Bmori1_room_8Tex_00B410" Format="rgba16" Width="32" Height="64" Offset="0xB3F0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_00C410" OutName="Bmori1_room_8Tex_00C410" Format="rgba16" Width="32" Height="32" Offset="0xC3F0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_00CC10" OutName="Bmori1_room_8Tex_00CC10" Format="ci8" Width="32" Height="32" Offset="0xCBF0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_00D010" OutName="Bmori1_room_8Tex_00D010" Format="ci8" Width="32" Height="32" Offset="0xCFF0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_00D410" OutName="Bmori1_room_8Tex_00D410" Format="ci8" Width="32" Height="32" Offset="0xD3F0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_00D810" OutName="Bmori1_room_8Tex_00D810" Format="ci8" Width="32" Height="64" Offset="0xD7F0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_00E010" OutName="Bmori1_room_8Tex_00E010" Format="ci8" Width="32" Height="64" Offset="0xDFF0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_00E810" OutName="Bmori1_room_8Tex_00E810" Format="ci8" Width="64" Height="32" Offset="0xE7F0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_00F010" OutName="Bmori1_room_8Tex_00F010" Format="ci8" Width="64" Height="32" Offset="0xEFF0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_00F810" OutName="Bmori1_room_8Tex_00F810" Format="rgba16" Width="32" Height="64" Offset="0xF7F0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_010810" OutName="Bmori1_room_8Tex_010810" Format="rgba16" Width="32" Height="64" Offset="0x107F0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_011810" OutName="Bmori1_room_8Tex_011810" Format="ci8" Width="32" Height="32" Offset="0x117F0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_011C10" OutName="Bmori1_room_8Tex_011C10" Format="ci8" Width="64" Height="32" Offset="0x11BF0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_012410" OutName="Bmori1_room_8Tex_012410" Format="rgba16" Width="32" Height="32" Offset="0x123F0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_013AB0" OutName="Bmori1_room_8Tex_013AB0" Format="i4" Width="64" Height="128" Offset="0x13A90" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_014AB0" OutName="Bmori1_room_8Tex_014AB0" Format="rgba16" Width="32" Height="32" Offset="0x14A90" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_0152B0" OutName="Bmori1_room_8Tex_0152B0" Format="ia16" Width="32" Height="32" Offset="0x15290" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_015AB0" OutName="Bmori1_room_8Tex_015AB0" Format="rgba16" Width="32" Height="64" Offset="0x15A90" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_016AB0" OutName="Bmori1_room_8Tex_016AB0" Format="rgba16" Width="32" Height="64" Offset="0x16A90" AddedByScript="true"/>
         <Room Name="Bmori1_room_8" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_9" Segment="3">
+        <Texture Name="Bmori1_room_9Tex_0048B8" OutName="Bmori1_room_9Tex_0048B8" Format="rgba16" Width="32" Height="32" Offset="0x4888" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_9Tex_0050B8" OutName="Bmori1_room_9Tex_0050B8" Format="ci8" Width="32" Height="32" Offset="0x5088" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_9Tex_0054B8" OutName="Bmori1_room_9Tex_0054B8" Format="ci8" Width="32" Height="64" Offset="0x5488" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_9Tex_005CB8" OutName="Bmori1_room_9Tex_005CB8" Format="ci8" Width="64" Height="32" Offset="0x5C88" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_9Tex_0064B8" OutName="Bmori1_room_9Tex_0064B8" Format="rgba16" Width="32" Height="32" Offset="0x6488" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_9Tex_006CB8" OutName="Bmori1_room_9Tex_006CB8" Format="ci8" Width="64" Height="32" Offset="0x6C88" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_9Tex_0074B8" OutName="Bmori1_room_9Tex_0074B8" Format="rgba16" Width="32" Height="64" Offset="0x7488" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_9Tex_008958" OutName="Bmori1_room_9Tex_008958" Format="ia16" Width="32" Height="32" Offset="0x8928" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_9Tex_009158" OutName="Bmori1_room_9Tex_009158" Format="rgba16" Width="32" Height="64" Offset="0x9128" AddedByScript="true"/>
         <Room Name="Bmori1_room_9" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_10" Segment="3">
+        <Texture Name="Bmori1_room_10Tex_001260" OutName="Bmori1_room_10Tex_001260" Format="rgba16" Width="32" Height="32" Offset="0x1250" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_10Tex_001A60" OutName="Bmori1_room_10Tex_001A60" Format="ci8" Width="16" Height="128" Offset="0x1A50" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_10Tex_002260" OutName="Bmori1_room_10Tex_002260" Format="ci8" Width="64" Height="32" Offset="0x2250" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_10Tex_002A60" OutName="Bmori1_room_10Tex_002A60" Format="rgba16" Width="32" Height="64" Offset="0x2A50" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_10Tex_003A60" OutName="Bmori1_room_10Tex_003A60" Format="rgba16" Width="32" Height="64" Offset="0x3A50" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_10Tex_004BD8" OutName="Bmori1_room_10Tex_004BD8" Format="ia16" Width="32" Height="32" Offset="0x4BC8" AddedByScript="true"/>
         <Room Name="Bmori1_room_10" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_11" Segment="3">
+        <Texture Name="Bmori1_room_11Tex_008198" OutName="Bmori1_room_11Tex_008198" Format="rgba16" Width="64" Height="32" Offset="0x8118" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_11Tex_009198" OutName="Bmori1_room_11Tex_009198" Format="ci8" Width="32" Height="32" Offset="0x9118" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_11Tex_009598" OutName="Bmori1_room_11Tex_009598" Format="rgba16" Width="32" Height="32" Offset="0x9518" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_11Tex_009D98" OutName="Bmori1_room_11Tex_009D98" Format="i4" Width="64" Height="64" Offset="0x9D18" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_11Tex_00A598" OutName="Bmori1_room_11Tex_00A598" Format="ci8" Width="32" Height="32" Offset="0xA518" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
         <Room Name="Bmori1_room_11" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_12" Segment="3">
+        <Texture Name="Bmori1_room_12Tex_004A00" OutName="Bmori1_room_12Tex_004A00" Format="ci8" Width="32" Height="32" Offset="0x49F0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_12Tex_004E00" OutName="Bmori1_room_12Tex_004E00" Format="ci8" Width="32" Height="64" Offset="0x4DF0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_12Tex_005600" OutName="Bmori1_room_12Tex_005600" Format="ci8" Width="64" Height="32" Offset="0x55F0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_12Tex_005E00" OutName="Bmori1_room_12Tex_005E00" Format="ci8" Width="64" Height="32" Offset="0x5DF0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_12Tex_006600" OutName="Bmori1_room_12Tex_006600" Format="ci8" Width="64" Height="32" Offset="0x65F0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_12Tex_006E00" OutName="Bmori1_room_12Tex_006E00" Format="ci8" Width="32" Height="32" Offset="0x6DF0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_12Tex_007200" OutName="Bmori1_room_12Tex_007200" Format="rgba16" Width="32" Height="32" Offset="0x71F0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_12Tex_007BD8" OutName="Bmori1_room_12Tex_007BD8" Format="ia16" Width="32" Height="32" Offset="0x7BC8" AddedByScript="true"/>
         <Room Name="Bmori1_room_12" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_13" Segment="3">
+        <Texture Name="Bmori1_room_13Tex_004CD0" OutName="Bmori1_room_13Tex_004CD0" Format="rgba16" Width="32" Height="32" Offset="0x4CC0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_13Tex_0054D0" OutName="Bmori1_room_13Tex_0054D0" Format="ci8" Width="32" Height="64" Offset="0x54C0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_13Tex_005CD0" OutName="Bmori1_room_13Tex_005CD0" Format="ci8" Width="64" Height="32" Offset="0x5CC0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_13Tex_0064D0" OutName="Bmori1_room_13Tex_0064D0" Format="ci8" Width="64" Height="32" Offset="0x64C0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_13Tex_006CD0" OutName="Bmori1_room_13Tex_006CD0" Format="ci8" Width="64" Height="32" Offset="0x6CC0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_13Tex_0074D0" OutName="Bmori1_room_13Tex_0074D0" Format="ci8" Width="32" Height="32" Offset="0x74C0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_13Tex_0078D0" OutName="Bmori1_room_13Tex_0078D0" Format="rgba16" Width="32" Height="32" Offset="0x78C0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_13Tex_0082A8" OutName="Bmori1_room_13Tex_0082A8" Format="ia16" Width="32" Height="32" Offset="0x8298" AddedByScript="true"/>
         <Room Name="Bmori1_room_13" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_14" Segment="3">
+        <Texture Name="Bmori1_room_14Tex_003560" OutName="Bmori1_room_14Tex_003560" Format="ci8" Width="32" Height="32" Offset="0x3530" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_14Tex_003960" OutName="Bmori1_room_14Tex_003960" Format="rgba16" Width="32" Height="32" Offset="0x3930" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_14Tex_004160" OutName="Bmori1_room_14Tex_004160" Format="rgba16" Width="32" Height="32" Offset="0x4130" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_14Tex_004960" OutName="Bmori1_room_14Tex_004960" Format="ci8" Width="32" Height="32" Offset="0x4930" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_14Tex_004D60" OutName="Bmori1_room_14Tex_004D60" Format="ci8" Width="64" Height="32" Offset="0x4D30" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_14Tex_005770" OutName="Bmori1_room_14Tex_005770" Format="ia8" Width="32" Height="32" Offset="0x5740" AddedByScript="true"/>
         <Room Name="Bmori1_room_14" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_15" Segment="3">
+        <Texture Name="Bmori1_room_15Tex_0012E0" OutName="Bmori1_room_15Tex_0012E0" Format="ci8" Width="32" Height="64" Offset="0x1290" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_15Tex_001AE0" OutName="Bmori1_room_15Tex_001AE0" Format="ci8" Width="32" Height="32" Offset="0x1A90" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_15Tex_001EE0" OutName="Bmori1_room_15Tex_001EE0" Format="ci8" Width="64" Height="32" Offset="0x1E90" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
         <Room Name="Bmori1_room_15" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_16" Segment="3">
+        <Texture Name="Bmori1_room_16Tex_002F98" OutName="Bmori1_room_16Tex_002F98" Format="rgba16" Width="32" Height="32" Offset="0x2F98" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_16Tex_003798" OutName="Bmori1_room_16Tex_003798" Format="ci8" Width="64" Height="32" Offset="0x3798" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_16Tex_003F98" OutName="Bmori1_room_16Tex_003F98" Format="ci8" Width="32" Height="32" Offset="0x3F98" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_16Tex_004398" OutName="Bmori1_room_16Tex_004398" Format="ci8" Width="32" Height="32" Offset="0x4398" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_16Tex_004798" OutName="Bmori1_room_16Tex_004798" Format="ci8" Width="64" Height="32" Offset="0x4798" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
         <Room Name="Bmori1_room_16" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_17" Segment="3">
+        <Texture Name="Bmori1_room_17Tex_0064E8" OutName="Bmori1_room_17Tex_0064E8" Format="rgba16" Width="32" Height="32" Offset="0x64B8" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_17Tex_006CE8" OutName="Bmori1_room_17Tex_006CE8" Format="rgba16" Width="32" Height="32" Offset="0x6CB8" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_17Tex_0074E8" OutName="Bmori1_room_17Tex_0074E8" Format="ci8" Width="32" Height="32" Offset="0x74B8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_17Tex_0078E8" OutName="Bmori1_room_17Tex_0078E8" Format="ci8" Width="32" Height="32" Offset="0x78B8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_17Tex_007CE8" OutName="Bmori1_room_17Tex_007CE8" Format="ci8" Width="32" Height="32" Offset="0x7CB8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_17Tex_0080E8" OutName="Bmori1_room_17Tex_0080E8" Format="ci8" Width="64" Height="32" Offset="0x80B8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_17Tex_0088E8" OutName="Bmori1_room_17Tex_0088E8" Format="ci8" Width="32" Height="64" Offset="0x88B8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
         <Room Name="Bmori1_room_17" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_18" Segment="3">
+        <Texture Name="Bmori1_room_18Tex_000B30" OutName="Bmori1_room_18Tex_000B30" Format="ci8" Width="64" Height="32" Offset="0xB40" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
         <Room Name="Bmori1_room_18" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_19" Segment="3">
         <Room Name="Bmori1_room_19" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_20" Segment="3">
+        <Texture Name="Bmori1_room_20Tex_0006F8" OutName="Bmori1_room_20Tex_0006F8" Format="ci8" Width="32" Height="64" Offset="0x6F8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_20Tex_000EF8" OutName="Bmori1_room_20Tex_000EF8" Format="ci8" Width="32" Height="32" Offset="0xEF8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
         <Room Name="Bmori1_room_20" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_21" Segment="3">
+        <Texture Name="Bmori1_room_21Tex_000F70" OutName="Bmori1_room_21Tex_000F70" Format="ci8" Width="64" Height="32" Offset="0xF80" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
         <Room Name="Bmori1_room_21" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_22" Segment="3">
+        <Texture Name="Bmori1_room_22Tex_0005E0" OutName="Bmori1_room_22Tex_0005E0" Format="rgba16" Width="64" Height="32" Offset="0x5E0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_22Tex_0015E0" OutName="Bmori1_room_22Tex_0015E0" Format="ci8" Width="64" Height="32" Offset="0x15E0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
         <Room Name="Bmori1_room_22" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/scenes/dungeons/FIRE_bs.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/dungeons/FIRE_bs.xml
@@ -1,11 +1,34 @@
 <Root>
     <File Name="FIRE_bs_scene" Segment="2">
+        <Texture Name="FIRE_bs_sceneTex_002C00" OutName="FIRE_bs_sceneTex_002C00" Format="rgba16" Width="32" Height="32" Offset="0x2C00" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_sceneTex_003400" OutName="FIRE_bs_sceneTex_003400" Format="rgba16" Width="32" Height="32" Offset="0x3400" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_sceneTex_003C00" OutName="FIRE_bs_sceneTex_003C00" Format="rgba16" Width="32" Height="32" Offset="0x3C00" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_sceneTex_004400" OutName="FIRE_bs_sceneTex_004400" Format="rgba16" Width="32" Height="32" Offset="0x4400" AddedByScript="true"/>
         <Scene Name="FIRE_bs_scene" Offset="0x0"/>
     </File>
     <File Name="FIRE_bs_room_0" Segment="3">
+        <Texture Name="FIRE_bs_room_0Tex_002E68" OutName="FIRE_bs_room_0Tex_002E68" Format="ci4" Width="32" Height="32" Offset="0x2E68" TlutOffset="0x2E48" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_0Tex_003068" OutName="FIRE_bs_room_0Tex_003068" Format="ci4" Width="32" Height="64" Offset="0x3068" TlutOffset="0x2E48" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_0Tex_003468" OutName="FIRE_bs_room_0Tex_003468" Format="ci4" Width="64" Height="32" Offset="0x3468" TlutOffset="0x2E28" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_0Tex_003868" OutName="FIRE_bs_room_0Tex_003868" Format="ci4" Width="32" Height="32" Offset="0x3868" TlutOffset="0x2E28" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_0Tex_003A68" OutName="FIRE_bs_room_0Tex_003A68" Format="ci4" Width="32" Height="32" Offset="0x3A68" TlutOffset="0x2E28" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_0Tex_003C68" OutName="FIRE_bs_room_0Tex_003C68" Format="ci4" Width="32" Height="64" Offset="0x3C68" TlutOffset="0x2E48" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_0Tex_004068" OutName="FIRE_bs_room_0Tex_004068" Format="ci4" Width="32" Height="32" Offset="0x4068" TlutOffset="0x2E48" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_0TLUT_002E28" OutName="FIRE_bs_room_0TLUT_002E28" Format="rgba16" Width="4" Height="4" Offset="0x2E28" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_0TLUT_002E48" OutName="FIRE_bs_room_0TLUT_002E48" Format="rgba16" Width="4" Height="4" Offset="0x2E48" AddedByScript="true"/>
         <Room Name="FIRE_bs_room_0" Offset="0x0"/>
     </File>
     <File Name="FIRE_bs_room_1" Segment="3">
+        <Texture Name="FIRE_bs_room_1Tex_0049D8" OutName="FIRE_bs_room_1Tex_0049D8" Format="ci4" Width="32" Height="32" Offset="0x49D8" TlutOffset="0x49B8" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_1Tex_004BD8" OutName="FIRE_bs_room_1Tex_004BD8" Format="rgba16" Width="32" Height="32" Offset="0x4BD8" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_1Tex_0053D8" OutName="FIRE_bs_room_1Tex_0053D8" Format="rgba16" Width="32" Height="32" Offset="0x53D8" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_1Tex_005BD8" OutName="FIRE_bs_room_1Tex_005BD8" Format="ci4" Width="64" Height="32" Offset="0x5BD8" TlutOffset="0x4998" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_1Tex_005FD8" OutName="FIRE_bs_room_1Tex_005FD8" Format="ci4" Width="32" Height="32" Offset="0x5FD8" TlutOffset="0x4998" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_1Tex_0061D8" OutName="FIRE_bs_room_1Tex_0061D8" Format="ci4" Width="32" Height="64" Offset="0x61D8" TlutOffset="0x49B8" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_1Tex_0065D8" OutName="FIRE_bs_room_1Tex_0065D8" Format="rgba16" Width="32" Height="32" Offset="0x65D8" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_1Tex_006DD8" OutName="FIRE_bs_room_1Tex_006DD8" Format="ci4" Width="32" Height="32" Offset="0x6DD8" TlutOffset="0x49B8" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_1TLUT_004998" OutName="FIRE_bs_room_1TLUT_004998" Format="rgba16" Width="4" Height="4" Offset="0x4998" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_1TLUT_0049B8" OutName="FIRE_bs_room_1TLUT_0049B8" Format="rgba16" Width="4" Height="4" Offset="0x49B8" AddedByScript="true"/>
         <Room Name="FIRE_bs_room_1" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/scenes/dungeons/HAKAdan.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/dungeons/HAKAdan.xml
@@ -1,74 +1,191 @@
 <Root>
     <File Name="HAKAdan_scene" Segment="2">
+        <Texture Name="HAKAdan_sceneTex_0163C0" OutName="HAKAdan_sceneTex_0163C0" Format="rgba16" Width="32" Height="32" Offset="0x163C0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_sceneTex_016BC0" OutName="HAKAdan_sceneTex_016BC0" Format="rgba16" Width="32" Height="32" Offset="0x16BC0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_sceneTex_0173C0" OutName="HAKAdan_sceneTex_0173C0" Format="rgba16" Width="32" Height="32" Offset="0x173C0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_sceneTex_017BC0" OutName="HAKAdan_sceneTex_017BC0" Format="rgba16" Width="32" Height="32" Offset="0x17BC0" AddedByScript="true"/>
         <Scene Name="HAKAdan_scene" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_0" Segment="3">
+        <Texture Name="HAKAdan_room_0Tex_008230" OutName="HAKAdan_room_0Tex_008230" Format="rgba16" Width="32" Height="64" Offset="0x81A0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_0Tex_009230" OutName="HAKAdan_room_0Tex_009230" Format="rgba16" Width="32" Height="64" Offset="0x91A0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_0Tex_00A230" OutName="HAKAdan_room_0Tex_00A230" Format="rgba16" Width="32" Height="32" Offset="0xA1A0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_0Tex_00AD48" OutName="HAKAdan_room_0Tex_00AD48" Format="ia8" Width="32" Height="32" Offset="0xACB8" AddedByScript="true"/>
         <Room Name="HAKAdan_room_0" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_1" Segment="3">
+        <Texture Name="HAKAdan_room_1Tex_0012E8" OutName="HAKAdan_room_1Tex_0012E8" Format="rgba16" Width="32" Height="32" Offset="0x12B8" AddedByScript="true"/>
         <Room Name="HAKAdan_room_1" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_2" Segment="3">
+        <Texture Name="HAKAdan_room_2Tex_006BD8" OutName="HAKAdan_room_2Tex_006BD8" Format="i4" Width="64" Height="64" Offset="0x6B08" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_2Tex_0073D8" OutName="HAKAdan_room_2Tex_0073D8" Format="rgba16" Width="32" Height="16" Offset="0x7308" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_2Tex_0077D8" OutName="HAKAdan_room_2Tex_0077D8" Format="rgba16" Width="32" Height="32" Offset="0x7708" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_2Tex_007FD8" OutName="HAKAdan_room_2Tex_007FD8" Format="rgba16" Width="32" Height="8" Offset="0x7F08" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_2Tex_0081D8" OutName="HAKAdan_room_2Tex_0081D8" Format="rgba16" Width="32" Height="64" Offset="0x8108" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_2Tex_0091D8" OutName="HAKAdan_room_2Tex_0091D8" Format="rgba16" Width="32" Height="32" Offset="0x9108" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_2Tex_0099D8" OutName="HAKAdan_room_2Tex_0099D8" Format="i4" Width="32" Height="32" Offset="0x9908" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_2Tex_009BD8" OutName="HAKAdan_room_2Tex_009BD8" Format="rgba16" Width="32" Height="32" Offset="0x9B08" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_2Tex_00A3D8" OutName="HAKAdan_room_2Tex_00A3D8" Format="i4" Width="32" Height="32" Offset="0xA308" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_2Tex_00A5D8" OutName="HAKAdan_room_2Tex_00A5D8" Format="i4" Width="32" Height="32" Offset="0xA508" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_2Tex_00A7D8" OutName="HAKAdan_room_2Tex_00A7D8" Format="i4" Width="32" Height="32" Offset="0xA708" AddedByScript="true"/>
         <Room Name="HAKAdan_room_2" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_3" Segment="3">
+        <Texture Name="HAKAdan_room_3Tex_001578" OutName="HAKAdan_room_3Tex_001578" Format="rgba16" Width="32" Height="32" Offset="0x1538" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_3Tex_001D78" OutName="HAKAdan_room_3Tex_001D78" Format="rgba16" Width="32" Height="32" Offset="0x1D38" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_3Tex_002578" OutName="HAKAdan_room_3Tex_002578" Format="i4" Width="32" Height="32" Offset="0x2538" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_3Tex_002778" OutName="HAKAdan_room_3Tex_002778" Format="i4" Width="32" Height="32" Offset="0x2738" AddedByScript="true"/>
         <Room Name="HAKAdan_room_3" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_4" Segment="3">
+        <Texture Name="HAKAdan_room_4Tex_001458" OutName="HAKAdan_room_4Tex_001458" Format="rgba16" Width="32" Height="32" Offset="0x1438" AddedByScript="true"/>
         <Room Name="HAKAdan_room_4" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_5" Segment="3">
+        <Texture Name="HAKAdan_room_5Tex_003CC0" OutName="HAKAdan_room_5Tex_003CC0" Format="rgba16" Width="32" Height="16" Offset="0x3C60" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_5Tex_0040C0" OutName="HAKAdan_room_5Tex_0040C0" Format="rgba16" Width="32" Height="32" Offset="0x4060" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_5Tex_0048C0" OutName="HAKAdan_room_5Tex_0048C0" Format="rgba16" Width="32" Height="8" Offset="0x4860" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_5Tex_004AC0" OutName="HAKAdan_room_5Tex_004AC0" Format="rgba16" Width="32" Height="32" Offset="0x4A60" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_5Tex_0052C0" OutName="HAKAdan_room_5Tex_0052C0" Format="rgba16" Width="32" Height="32" Offset="0x5260" AddedByScript="true"/>
         <Room Name="HAKAdan_room_5" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_6" Segment="3">
+        <Texture Name="HAKAdan_room_6Tex_004BF0" OutName="HAKAdan_room_6Tex_004BF0" Format="i4" Width="64" Height="64" Offset="0x4B70" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_6Tex_0053F0" OutName="HAKAdan_room_6Tex_0053F0" Format="rgba16" Width="32" Height="8" Offset="0x5370" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_6Tex_0055F0" OutName="HAKAdan_room_6Tex_0055F0" Format="rgba16" Width="32" Height="64" Offset="0x5570" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_6Tex_0065F0" OutName="HAKAdan_room_6Tex_0065F0" Format="rgba16" Width="32" Height="32" Offset="0x6570" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_6Tex_006DF0" OutName="HAKAdan_room_6Tex_006DF0" Format="rgba16" Width="16" Height="32" Offset="0x6D70" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_6Tex_0071F0" OutName="HAKAdan_room_6Tex_0071F0" Format="rgba16" Width="16" Height="32" Offset="0x7170" AddedByScript="true"/>
         <Room Name="HAKAdan_room_6" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_7" Segment="3">
+        <Texture Name="HAKAdan_room_7Tex_0012D8" OutName="HAKAdan_room_7Tex_0012D8" Format="rgba16" Width="32" Height="32" Offset="0x12A8" AddedByScript="true"/>
         <Room Name="HAKAdan_room_7" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_8" Segment="3">
+        <Texture Name="HAKAdan_room_8Tex_003098" OutName="HAKAdan_room_8Tex_003098" Format="rgba16" Width="32" Height="8" Offset="0x3058" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_8Tex_003298" OutName="HAKAdan_room_8Tex_003298" Format="ia4" Width="128" Height="64" Offset="0x3258" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_8Tex_004298" OutName="HAKAdan_room_8Tex_004298" Format="rgba16" Width="32" Height="32" Offset="0x4258" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_8Tex_004A98" OutName="HAKAdan_room_8Tex_004A98" Format="i4" Width="32" Height="32" Offset="0x4A58" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_8Tex_004C98" OutName="HAKAdan_room_8Tex_004C98" Format="rgba16" Width="16" Height="32" Offset="0x4C58" AddedByScript="true"/>
         <Room Name="HAKAdan_room_8" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_9" Segment="3">
+        <Texture Name="HAKAdan_room_9Tex_009090" OutName="HAKAdan_room_9Tex_009090" Format="i4" Width="64" Height="64" Offset="0x8F60" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_9Tex_009890" OutName="HAKAdan_room_9Tex_009890" Format="rgba16" Width="32" Height="32" Offset="0x9760" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_9Tex_00A090" OutName="HAKAdan_room_9Tex_00A090" Format="rgba16" Width="32" Height="8" Offset="0x9F60" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_9Tex_00A290" OutName="HAKAdan_room_9Tex_00A290" Format="ia4" Width="128" Height="64" Offset="0xA160" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_9Tex_00B290" OutName="HAKAdan_room_9Tex_00B290" Format="rgba16" Width="32" Height="32" Offset="0xB160" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_9Tex_00BA90" OutName="HAKAdan_room_9Tex_00BA90" Format="rgba16" Width="16" Height="32" Offset="0xB960" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_9Tex_00BE90" OutName="HAKAdan_room_9Tex_00BE90" Format="rgba16" Width="32" Height="32" Offset="0xBD60" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_9Tex_00C690" OutName="HAKAdan_room_9Tex_00C690" Format="i4" Width="32" Height="32" Offset="0xC560" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_9Tex_00C890" OutName="HAKAdan_room_9Tex_00C890" Format="rgba16" Width="16" Height="32" Offset="0xC760" AddedByScript="true"/>
         <Room Name="HAKAdan_room_9" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_10" Segment="3">
+        <Texture Name="HAKAdan_room_10Tex_0039F0" OutName="HAKAdan_room_10Tex_0039F0" Format="rgba16" Width="32" Height="16" Offset="0x39A0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_10Tex_003DF0" OutName="HAKAdan_room_10Tex_003DF0" Format="rgba16" Width="32" Height="8" Offset="0x3DA0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_10Tex_003FF0" OutName="HAKAdan_room_10Tex_003FF0" Format="rgba16" Width="32" Height="64" Offset="0x3FA0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_10Tex_004FF0" OutName="HAKAdan_room_10Tex_004FF0" Format="ia4" Width="128" Height="64" Offset="0x4FA0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_10Tex_005FF0" OutName="HAKAdan_room_10Tex_005FF0" Format="rgba16" Width="32" Height="32" Offset="0x5FA0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_10Tex_0067F0" OutName="HAKAdan_room_10Tex_0067F0" Format="rgba16" Width="16" Height="32" Offset="0x67A0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_10Tex_006BF0" OutName="HAKAdan_room_10Tex_006BF0" Format="rgba16" Width="16" Height="64" Offset="0x6BA0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_10Tex_0073F0" OutName="HAKAdan_room_10Tex_0073F0" Format="rgba16" Width="16" Height="32" Offset="0x73A0" AddedByScript="true"/>
         <Room Name="HAKAdan_room_10" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_11" Segment="3">
+        <Texture Name="HAKAdan_room_11Tex_001E60" OutName="HAKAdan_room_11Tex_001E60" Format="i4" Width="64" Height="64" Offset="0x1D40" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_11Tex_002660" OutName="HAKAdan_room_11Tex_002660" Format="rgba16" Width="32" Height="16" Offset="0x2540" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_11Tex_002A60" OutName="HAKAdan_room_11Tex_002A60" Format="rgba16" Width="32" Height="8" Offset="0x2940" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_11Tex_002C60" OutName="HAKAdan_room_11Tex_002C60" Format="rgba16" Width="32" Height="32" Offset="0x2B40" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_11Tex_003460" OutName="HAKAdan_room_11Tex_003460" Format="rgba16" Width="32" Height="32" Offset="0x3340" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_11Tex_003C60" OutName="HAKAdan_room_11Tex_003C60" Format="i4" Width="32" Height="32" Offset="0x3B40" AddedByScript="true"/>
         <Room Name="HAKAdan_room_11" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_12" Segment="3">
+        <Texture Name="HAKAdan_room_12Tex_003348" OutName="HAKAdan_room_12Tex_003348" Format="i4" Width="32" Height="32" Offset="0x3318" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_12Tex_003548" OutName="HAKAdan_room_12Tex_003548" Format="i4" Width="32" Height="32" Offset="0x3518" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_12Tex_003748" OutName="HAKAdan_room_12Tex_003748" Format="rgba16" Width="32" Height="16" Offset="0x3718" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_12Tex_003B48" OutName="HAKAdan_room_12Tex_003B48" Format="rgba16" Width="32" Height="8" Offset="0x3B18" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_12Tex_003D48" OutName="HAKAdan_room_12Tex_003D48" Format="rgba16" Width="32" Height="64" Offset="0x3D18" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_12Tex_004D48" OutName="HAKAdan_room_12Tex_004D48" Format="rgba16" Width="32" Height="32" Offset="0x4D18" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_12Tex_005548" OutName="HAKAdan_room_12Tex_005548" Format="i4" Width="32" Height="32" Offset="0x5518" AddedByScript="true"/>
         <Room Name="HAKAdan_room_12" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_13" Segment="3">
+        <Texture Name="HAKAdan_room_13Tex_000818" OutName="HAKAdan_room_13Tex_000818" Format="rgba16" Width="32" Height="32" Offset="0x7A8" AddedByScript="true"/>
         <Room Name="HAKAdan_room_13" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_14" Segment="3">
+        <Texture Name="HAKAdan_room_14Tex_003500" OutName="HAKAdan_room_14Tex_003500" Format="i4" Width="32" Height="32" Offset="0x3540" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_14Tex_003700" OutName="HAKAdan_room_14Tex_003700" Format="i4" Width="32" Height="32" Offset="0x3740" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_14Tex_003900" OutName="HAKAdan_room_14Tex_003900" Format="rgba16" Width="32" Height="16" Offset="0x3940" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_14Tex_003D00" OutName="HAKAdan_room_14Tex_003D00" Format="rgba16" Width="32" Height="8" Offset="0x3D40" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_14Tex_003F00" OutName="HAKAdan_room_14Tex_003F00" Format="rgba16" Width="32" Height="64" Offset="0x3F40" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_14Tex_004F00" OutName="HAKAdan_room_14Tex_004F00" Format="rgba16" Width="32" Height="32" Offset="0x4F40" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_14Tex_005700" OutName="HAKAdan_room_14Tex_005700" Format="i4" Width="32" Height="32" Offset="0x5740" AddedByScript="true"/>
         <Room Name="HAKAdan_room_14" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_15" Segment="3">
+        <Texture Name="HAKAdan_room_15Tex_0056C0" OutName="HAKAdan_room_15Tex_0056C0" Format="i4" Width="32" Height="32" Offset="0x5670" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_15Tex_0058C0" OutName="HAKAdan_room_15Tex_0058C0" Format="i4" Width="32" Height="32" Offset="0x5870" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_15Tex_005AC0" OutName="HAKAdan_room_15Tex_005AC0" Format="rgba16" Width="32" Height="16" Offset="0x5A70" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_15Tex_005EC0" OutName="HAKAdan_room_15Tex_005EC0" Format="rgba16" Width="32" Height="8" Offset="0x5E70" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_15Tex_0060C0" OutName="HAKAdan_room_15Tex_0060C0" Format="rgba16" Width="32" Height="32" Offset="0x6070" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_15Tex_0068C0" OutName="HAKAdan_room_15Tex_0068C0" Format="rgba16" Width="32" Height="32" Offset="0x6870" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_15Tex_0070C0" OutName="HAKAdan_room_15Tex_0070C0" Format="i4" Width="32" Height="32" Offset="0x7070" AddedByScript="true"/>
         <Room Name="HAKAdan_room_15" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_16" Segment="3">
+        <Texture Name="HAKAdan_room_16Tex_001930" OutName="HAKAdan_room_16Tex_001930" Format="rgba16" Width="32" Height="64" Offset="0x1880" AddedByScript="true"/>
         <Room Name="HAKAdan_room_16" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_17" Segment="3">
+        <Texture Name="HAKAdan_room_17Tex_001248" OutName="HAKAdan_room_17Tex_001248" Format="rgba16" Width="32" Height="8" Offset="0x1138" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_17Tex_001448" OutName="HAKAdan_room_17Tex_001448" Format="rgba16" Width="32" Height="32" Offset="0x1338" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_17Tex_001C48" OutName="HAKAdan_room_17Tex_001C48" Format="rgba16" Width="16" Height="32" Offset="0x1B38" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_17Tex_002048" OutName="HAKAdan_room_17Tex_002048" Format="rgba16" Width="16" Height="32" Offset="0x1F38" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_17Tex_0025D8" OutName="HAKAdan_room_17Tex_0025D8" Format="ia16" Width="32" Height="32" Offset="0x24C8" AddedByScript="true"/>
         <Room Name="HAKAdan_room_17" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_18" Segment="3">
+        <Texture Name="HAKAdan_room_18Tex_00B908" OutName="HAKAdan_room_18Tex_00B908" Format="i4" Width="32" Height="32" Offset="0xB878" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_18Tex_00BB08" OutName="HAKAdan_room_18Tex_00BB08" Format="rgba16" Width="32" Height="16" Offset="0xBA78" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_18Tex_00BF08" OutName="HAKAdan_room_18Tex_00BF08" Format="rgba16" Width="32" Height="32" Offset="0xBE78" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_18Tex_00C708" OutName="HAKAdan_room_18Tex_00C708" Format="rgba16" Width="32" Height="8" Offset="0xC678" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_18Tex_00C908" OutName="HAKAdan_room_18Tex_00C908" Format="i4" Width="32" Height="32" Offset="0xC878" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_18Tex_00CB08" OutName="HAKAdan_room_18Tex_00CB08" Format="i4" Width="32" Height="32" Offset="0xCA78" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_18Tex_00CD08" OutName="HAKAdan_room_18Tex_00CD08" Format="i4" Width="32" Height="32" Offset="0xCC78" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_18Tex_00CF08" OutName="HAKAdan_room_18Tex_00CF08" Format="rgba16" Width="16" Height="32" Offset="0xCE78" AddedByScript="true"/>
         <Room Name="HAKAdan_room_18" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_19" Segment="3">
+        <Texture Name="HAKAdan_room_19Tex_001578" OutName="HAKAdan_room_19Tex_001578" Format="rgba16" Width="32" Height="64" Offset="0x1518" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_19Tex_002578" OutName="HAKAdan_room_19Tex_002578" Format="rgba16" Width="32" Height="32" Offset="0x2518" AddedByScript="true"/>
         <Room Name="HAKAdan_room_19" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_20" Segment="3">
+        <Texture Name="HAKAdan_room_20Tex_001640" OutName="HAKAdan_room_20Tex_001640" Format="rgba16" Width="32" Height="32" Offset="0x1620" AddedByScript="true"/>
         <Room Name="HAKAdan_room_20" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_21" Segment="3">
+        <Texture Name="HAKAdan_room_21Tex_006E00" OutName="HAKAdan_room_21Tex_006E00" Format="rgba16" Width="32" Height="32" Offset="0x6D00" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_21Tex_007600" OutName="HAKAdan_room_21Tex_007600" Format="rgba16" Width="32" Height="8" Offset="0x7500" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_21Tex_007800" OutName="HAKAdan_room_21Tex_007800" Format="rgba16" Width="32" Height="64" Offset="0x7700" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_21Tex_008800" OutName="HAKAdan_room_21Tex_008800" Format="rgba16" Width="32" Height="32" Offset="0x8700" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_21Tex_009000" OutName="HAKAdan_room_21Tex_009000" Format="rgba16" Width="32" Height="32" Offset="0x8F00" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_21Tex_009800" OutName="HAKAdan_room_21Tex_009800" Format="rgba16" Width="16" Height="64" Offset="0x9700" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_21Tex_00A000" OutName="HAKAdan_room_21Tex_00A000" Format="rgba16" Width="32" Height="32" Offset="0x9F00" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_21Tex_00A800" OutName="HAKAdan_room_21Tex_00A800" Format="i4" Width="32" Height="32" Offset="0xA700" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_21Tex_00AA00" OutName="HAKAdan_room_21Tex_00AA00" Format="i4" Width="32" Height="32" Offset="0xA900" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_21Tex_00ADA8" OutName="HAKAdan_room_21Tex_00ADA8" Format="rgba16" Width="32" Height="32" Offset="0xACA8" AddedByScript="true"/>
         <Room Name="HAKAdan_room_21" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_22" Segment="3">
+        <Texture Name="HAKAdan_room_22Tex_000FA8" OutName="HAKAdan_room_22Tex_000FA8" Format="rgba16" Width="32" Height="8" Offset="0xF98" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_22Tex_0011A8" OutName="HAKAdan_room_22Tex_0011A8" Format="rgba16" Width="32" Height="64" Offset="0x1198" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_22Tex_0021A8" OutName="HAKAdan_room_22Tex_0021A8" Format="rgba16" Width="32" Height="32" Offset="0x2198" AddedByScript="true"/>
         <Room Name="HAKAdan_room_22" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/scenes/dungeons/HAKAdanCH.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/dungeons/HAKAdanCH.xml
@@ -1,26 +1,69 @@
 <Root>
     <File Name="HAKAdanCH_scene" Segment="2">
+        <Texture Name="HAKAdanCH_sceneTex_00A590" OutName="HAKAdanCH_sceneTex_00A590" Format="rgba16" Width="32" Height="32" Offset="0xA560" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_sceneTex_00AD90" OutName="HAKAdanCH_sceneTex_00AD90" Format="rgba16" Width="32" Height="32" Offset="0xAD60" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_sceneTex_00B590" OutName="HAKAdanCH_sceneTex_00B590" Format="rgba16" Width="32" Height="32" Offset="0xB560" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_sceneTex_00BD90" OutName="HAKAdanCH_sceneTex_00BD90" Format="rgba16" Width="32" Height="32" Offset="0xBD60" AddedByScript="true"/>
         <Scene Name="HAKAdanCH_scene" Offset="0x0"/>
     </File>
     <File Name="HAKAdanCH_room_0" Segment="3">
+        <Texture Name="HAKAdanCH_room_0Tex_00D720" OutName="HAKAdanCH_room_0Tex_00D720" Format="rgba16" Width="32" Height="32" Offset="0xD5F0" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_00DF20" OutName="HAKAdanCH_room_0Tex_00DF20" Format="rgba16" Width="32" Height="8" Offset="0xDDF0" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_00E120" OutName="HAKAdanCH_room_0Tex_00E120" Format="rgba16" Width="32" Height="64" Offset="0xDFF0" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_00F120" OutName="HAKAdanCH_room_0Tex_00F120" Format="rgba16" Width="32" Height="32" Offset="0xEFF0" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_00F920" OutName="HAKAdanCH_room_0Tex_00F920" Format="rgba16" Width="32" Height="32" Offset="0xF7F0" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_010120" OutName="HAKAdanCH_room_0Tex_010120" Format="rgba16" Width="32" Height="64" Offset="0xFFF0" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_011120" OutName="HAKAdanCH_room_0Tex_011120" Format="rgba16" Width="32" Height="32" Offset="0x10FF0" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_011920" OutName="HAKAdanCH_room_0Tex_011920" Format="rgba16" Width="16" Height="32" Offset="0x117F0" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_011D20" OutName="HAKAdanCH_room_0Tex_011D20" Format="i4" Width="32" Height="32" Offset="0x11BF0" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_011F20" OutName="HAKAdanCH_room_0Tex_011F20" Format="rgba16" Width="16" Height="64" Offset="0x11DF0" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_012720" OutName="HAKAdanCH_room_0Tex_012720" Format="rgba16" Width="32" Height="32" Offset="0x125F0" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_012F20" OutName="HAKAdanCH_room_0Tex_012F20" Format="i4" Width="32" Height="32" Offset="0x12DF0" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_013120" OutName="HAKAdanCH_room_0Tex_013120" Format="i4" Width="32" Height="32" Offset="0x12FF0" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_013320" OutName="HAKAdanCH_room_0Tex_013320" Format="rgba16" Width="16" Height="32" Offset="0x131F0" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_013720" OutName="HAKAdanCH_room_0Tex_013720" Format="rgba16" Width="32" Height="32" Offset="0x135F0" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_013F20" OutName="HAKAdanCH_room_0Tex_013F20" Format="i4" Width="32" Height="32" Offset="0x13DF0" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_014B20" OutName="HAKAdanCH_room_0Tex_014B20" Format="ia4" Width="16" Height="128" Offset="0x149F0" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_014F20" OutName="HAKAdanCH_room_0Tex_014F20" Format="ia16" Width="32" Height="32" Offset="0x14DF0" AddedByScript="true"/>
         <Room Name="HAKAdanCH_room_0" Offset="0x0"/>
     </File>
     <File Name="HAKAdanCH_room_1" Segment="3">
+        <Texture Name="HAKAdanCH_room_1Tex_008D58" OutName="HAKAdanCH_room_1Tex_008D58" Format="rgba16" Width="32" Height="8" Offset="0x8EF8" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_1Tex_008F58" OutName="HAKAdanCH_room_1Tex_008F58" Format="i4" Width="32" Height="32" Offset="0x90F8" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_1Tex_009158" OutName="HAKAdanCH_room_1Tex_009158" Format="i4" Width="32" Height="32" Offset="0x92F8" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_1Tex_009358" OutName="HAKAdanCH_room_1Tex_009358" Format="rgba16" Width="32" Height="16" Offset="0x94F8" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_1Tex_009758" OutName="HAKAdanCH_room_1Tex_009758" Format="rgba16" Width="32" Height="32" Offset="0x98F8" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_1Tex_009F58" OutName="HAKAdanCH_room_1Tex_009F58" Format="i4" Width="32" Height="32" Offset="0xA0F8" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_1Tex_00A158" OutName="HAKAdanCH_room_1Tex_00A158" Format="rgba16" Width="16" Height="32" Offset="0xA2F8" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_1Tex_00A558" OutName="HAKAdanCH_room_1Tex_00A558" Format="rgba16" Width="32" Height="32" Offset="0xA6F8" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_1Tex_00AD58" OutName="HAKAdanCH_room_1Tex_00AD58" Format="i4" Width="32" Height="32" Offset="0xAEF8" AddedByScript="true"/>
         <Room Name="HAKAdanCH_room_1" Offset="0x0"/>
     </File>
     <File Name="HAKAdanCH_room_2" Segment="3">
+        <Texture Name="HAKAdanCH_room_2Tex_002958" OutName="HAKAdanCH_room_2Tex_002958" Format="rgba16" Width="32" Height="8" Offset="0x2988" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_2Tex_002B58" OutName="HAKAdanCH_room_2Tex_002B58" Format="i4" Width="32" Height="32" Offset="0x2B88" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_2Tex_002D58" OutName="HAKAdanCH_room_2Tex_002D58" Format="i4" Width="32" Height="32" Offset="0x2D88" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_2Tex_002F58" OutName="HAKAdanCH_room_2Tex_002F58" Format="i4" Width="32" Height="32" Offset="0x2F88" AddedByScript="true"/>
         <Room Name="HAKAdanCH_room_2" Offset="0x0"/>
     </File>
     <File Name="HAKAdanCH_room_3" Segment="3">
+        <Texture Name="HAKAdanCH_room_3Tex_0014C0" OutName="HAKAdanCH_room_3Tex_0014C0" Format="rgba16" Width="32" Height="32" Offset="0x1460" AddedByScript="true"/>
         <Room Name="HAKAdanCH_room_3" Offset="0x0"/>
     </File>
     <File Name="HAKAdanCH_room_4" Segment="3">
+        <Texture Name="HAKAdanCH_room_4Tex_001498" OutName="HAKAdanCH_room_4Tex_001498" Format="rgba16" Width="32" Height="32" Offset="0x1448" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_4Tex_001C98" OutName="HAKAdanCH_room_4Tex_001C98" Format="rgba16" Width="32" Height="32" Offset="0x1C48" AddedByScript="true"/>
         <Room Name="HAKAdanCH_room_4" Offset="0x0"/>
     </File>
     <File Name="HAKAdanCH_room_5" Segment="3">
+        <Texture Name="HAKAdanCH_room_5Tex_001190" OutName="HAKAdanCH_room_5Tex_001190" Format="rgba16" Width="32" Height="64" Offset="0x1160" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_5Tex_002190" OutName="HAKAdanCH_room_5Tex_002190" Format="rgba16" Width="32" Height="32" Offset="0x2160" AddedByScript="true"/>
         <Room Name="HAKAdanCH_room_5" Offset="0x0"/>
     </File>
     <File Name="HAKAdanCH_room_6" Segment="3">
+        <Texture Name="HAKAdanCH_room_6Tex_000EA0" OutName="HAKAdanCH_room_6Tex_000EA0" Format="rgba16" Width="32" Height="32" Offset="0xE80" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_6Tex_0016A0" OutName="HAKAdanCH_room_6Tex_0016A0" Format="rgba16" Width="32" Height="64" Offset="0x1680" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_6Tex_0026A0" OutName="HAKAdanCH_room_6Tex_0026A0" Format="rgba16" Width="32" Height="32" Offset="0x2680" AddedByScript="true"/>
         <Room Name="HAKAdanCH_room_6" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/scenes/dungeons/HAKAdan_bs.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/dungeons/HAKAdan_bs.xml
@@ -1,11 +1,23 @@
 <Root>
     <File Name="HAKAdan_bs_scene" Segment="2">
+        <Texture Name="HAKAdan_bs_sceneTex_001380" OutName="HAKAdan_bs_sceneTex_001380" Format="i4" Width="32" Height="32" Offset="0x1380" AddedByScript="true"/>
+        <Texture Name="HAKAdan_bs_sceneTex_001580" OutName="HAKAdan_bs_sceneTex_001580" Format="rgba16" Width="32" Height="8" Offset="0x1580" AddedByScript="true"/>
+        <Texture Name="HAKAdan_bs_sceneTex_001780" OutName="HAKAdan_bs_sceneTex_001780" Format="rgba16" Width="32" Height="32" Offset="0x1780" AddedByScript="true"/>
+        <Texture Name="HAKAdan_bs_sceneTex_001F80" OutName="HAKAdan_bs_sceneTex_001F80" Format="rgba16" Width="32" Height="32" Offset="0x1F80" AddedByScript="true"/>
         <Scene Name="HAKAdan_bs_scene" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_bs_room_0" Segment="3">
+        <Texture Name="HAKAdan_bs_room_0Tex_0021E0" OutName="HAKAdan_bs_room_0Tex_0021E0" Format="i4" Width="32" Height="32" Offset="0x21E0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_bs_room_0Tex_0023E0" OutName="HAKAdan_bs_room_0Tex_0023E0" Format="rgba16" Width="32" Height="16" Offset="0x23E0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_bs_room_0Tex_0027E0" OutName="HAKAdan_bs_room_0Tex_0027E0" Format="i4" Width="32" Height="32" Offset="0x27E0" AddedByScript="true"/>
         <Room Name="HAKAdan_bs_room_0" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_bs_room_1" Segment="3">
+        <Texture Name="HAKAdan_bs_room_1Tex_002D50" OutName="HAKAdan_bs_room_1Tex_002D50" Format="i4" Width="32" Height="32" Offset="0x2D50" AddedByScript="true"/>
+        <Texture Name="HAKAdan_bs_room_1Tex_002F50" OutName="HAKAdan_bs_room_1Tex_002F50" Format="rgba16" Width="32" Height="32" Offset="0x2F50" AddedByScript="true"/>
+        <Texture Name="HAKAdan_bs_room_1Tex_003750" OutName="HAKAdan_bs_room_1Tex_003750" Format="rgba16" Width="32" Height="32" Offset="0x3750" AddedByScript="true"/>
+        <Texture Name="HAKAdan_bs_room_1Tex_003F50" OutName="HAKAdan_bs_room_1Tex_003F50" Format="rgba16" Width="32" Height="64" Offset="0x3F50" AddedByScript="true"/>
+        <Texture Name="HAKAdan_bs_room_1Tex_004F50" OutName="HAKAdan_bs_room_1Tex_004F50" Format="rgba16" Width="32" Height="64" Offset="0x4F50" AddedByScript="true"/>
         <Room Name="HAKAdan_bs_room_1" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/scenes/dungeons/HIDAN.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/dungeons/HIDAN.xml
@@ -1,87 +1,288 @@
 <Root>
     <File Name="HIDAN_scene" Segment="2">
+        <Texture Name="HIDAN_sceneTex_0189D0" OutName="HIDAN_sceneTex_0189D0" Format="ci4" Width="32" Height="32" Offset="0x18B70" TlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_sceneTex_018BD0" OutName="HIDAN_sceneTex_018BD0" Format="ci4" Width="32" Height="32" Offset="0x18D70" TlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_sceneTex_018DD0" OutName="HIDAN_sceneTex_018DD0" Format="rgba16" Width="32" Height="32" Offset="0x18F70" AddedByScript="true"/>
+        <Texture Name="HIDAN_sceneTex_0195D0" OutName="HIDAN_sceneTex_0195D0" Format="rgba16" Width="32" Height="32" Offset="0x19770" AddedByScript="true"/>
+        <Texture Name="HIDAN_sceneTex_019DD0" OutName="HIDAN_sceneTex_019DD0" Format="ci4" Width="32" Height="32" Offset="0x19F70" TlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_sceneTex_019FD0" OutName="HIDAN_sceneTex_019FD0" Format="rgba16" Width="32" Height="32" Offset="0x1A170" AddedByScript="true"/>
+        <Texture Name="HIDAN_sceneTLUT_018990" OutName="HIDAN_sceneTLUT_018990" Format="rgba16" Width="4" Height="4" Offset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_sceneTLUT_0189B0" OutName="HIDAN_sceneTLUT_0189B0" Format="rgba16" Width="4" Height="4" Offset="0x18B50" AddedByScript="true"/>
         <Path Name="gHidanPath_560" Offset="0x558" NumPaths="19"/>
         <Scene Name="HIDAN_scene" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_0" Segment="3">
+        <Texture Name="HIDAN_room_0Tex_004EF0" OutName="HIDAN_room_0Tex_004EF0" Format="ci4" Width="64" Height="32" Offset="0x4EC0" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_0Tex_0052F0" OutName="HIDAN_room_0Tex_0052F0" Format="ci4" Width="64" Height="32" Offset="0x52C0" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_0Tex_0056F0" OutName="HIDAN_room_0Tex_0056F0" Format="ci4" Width="64" Height="32" Offset="0x56C0" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_0Tex_005AF0" OutName="HIDAN_room_0Tex_005AF0" Format="ci4" Width="32" Height="32" Offset="0x5AC0" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_0Tex_005CF0" OutName="HIDAN_room_0Tex_005CF0" Format="ci4" Width="32" Height="32" Offset="0x5CC0" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_0Tex_005EF0" OutName="HIDAN_room_0Tex_005EF0" Format="ci4" Width="32" Height="64" Offset="0x5EC0" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_0Tex_0062F0" OutName="HIDAN_room_0Tex_0062F0" Format="rgba16" Width="32" Height="64" Offset="0x62C0" AddedByScript="true"/>
         <Room Name="HIDAN_room_0" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_1" Segment="3">
+        <Texture Name="HIDAN_room_1Tex_008730" OutName="HIDAN_room_1Tex_008730" Format="rgba16" Width="16" Height="16" Offset="0x87E0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_1Tex_008930" OutName="HIDAN_room_1Tex_008930" Format="rgba16" Width="32" Height="32" Offset="0x89E0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_1Tex_009130" OutName="HIDAN_room_1Tex_009130" Format="rgba16" Width="32" Height="32" Offset="0x91E0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_1Tex_009930" OutName="HIDAN_room_1Tex_009930" Format="rgba16" Width="32" Height="32" Offset="0x99E0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_1Tex_00A130" OutName="HIDAN_room_1Tex_00A130" Format="ci4" Width="64" Height="32" Offset="0xA1E0" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_1Tex_00A530" OutName="HIDAN_room_1Tex_00A530" Format="rgba16" Width="64" Height="32" Offset="0xA5E0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_1Tex_00B530" OutName="HIDAN_room_1Tex_00B530" Format="rgba16" Width="32" Height="32" Offset="0xB5E0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_1Tex_00BD30" OutName="HIDAN_room_1Tex_00BD30" Format="ci4" Width="32" Height="64" Offset="0xBDE0" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_1Tex_00C130" OutName="HIDAN_room_1Tex_00C130" Format="rgba16" Width="32" Height="32" Offset="0xC1E0" AddedByScript="true"/>
         <Room Name="HIDAN_room_1" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_2" Segment="3">
+        <Texture Name="HIDAN_room_2Tex_009628" OutName="HIDAN_room_2Tex_009628" Format="rgba16" Width="32" Height="8" Offset="0x95C8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_2Tex_009828" OutName="HIDAN_room_2Tex_009828" Format="rgba16" Width="32" Height="32" Offset="0x97C8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_2Tex_00A028" OutName="HIDAN_room_2Tex_00A028" Format="rgba16" Width="32" Height="32" Offset="0x9FC8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_2Tex_00A828" OutName="HIDAN_room_2Tex_00A828" Format="ci4" Width="64" Height="32" Offset="0xA7C8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_2Tex_00AC28" OutName="HIDAN_room_2Tex_00AC28" Format="rgba16" Width="64" Height="32" Offset="0xABC8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_2Tex_00BC28" OutName="HIDAN_room_2Tex_00BC28" Format="rgba16" Width="64" Height="32" Offset="0xBBC8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_2Tex_00CC28" OutName="HIDAN_room_2Tex_00CC28" Format="ci4" Width="32" Height="32" Offset="0xCBC8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_2Tex_00CE28" OutName="HIDAN_room_2Tex_00CE28" Format="rgba16" Width="64" Height="32" Offset="0xCDC8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_2Tex_00DE28" OutName="HIDAN_room_2Tex_00DE28" Format="ci4" Width="32" Height="32" Offset="0xDDC8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_2Tex_00E028" OutName="HIDAN_room_2Tex_00E028" Format="ci4" Width="32" Height="64" Offset="0xDFC8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_2Tex_00E428" OutName="HIDAN_room_2Tex_00E428" Format="rgba16" Width="32" Height="32" Offset="0xE3C8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_2Tex_00EC28" OutName="HIDAN_room_2Tex_00EC28" Format="ci4" Width="32" Height="64" Offset="0xEBC8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_2Tex_00F028" OutName="HIDAN_room_2Tex_00F028" Format="rgba16" Width="32" Height="32" Offset="0xEFC8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_2Tex_00F828" OutName="HIDAN_room_2Tex_00F828" Format="rgba16" Width="32" Height="32" Offset="0xF7C8" AddedByScript="true"/>
         <Room Name="HIDAN_room_2" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_3" Segment="3">
+        <Texture Name="HIDAN_room_3Tex_001AC8" OutName="HIDAN_room_3Tex_001AC8" Format="ci4" Width="32" Height="64" Offset="0x1AD8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_3Tex_001EC8" OutName="HIDAN_room_3Tex_001EC8" Format="ci4" Width="64" Height="32" Offset="0x1ED8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_3Tex_0022C8" OutName="HIDAN_room_3Tex_0022C8" Format="ci4" Width="32" Height="32" Offset="0x22D8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
         <Room Name="HIDAN_room_3" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_4" Segment="3">
+        <Texture Name="HIDAN_room_4Tex_0050F0" OutName="HIDAN_room_4Tex_0050F0" Format="rgba16" Width="32" Height="8" Offset="0x5090" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_4Tex_0052F0" OutName="HIDAN_room_4Tex_0052F0" Format="rgba16" Width="32" Height="32" Offset="0x5290" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_4Tex_005AF0" OutName="HIDAN_room_4Tex_005AF0" Format="rgba16" Width="32" Height="32" Offset="0x5A90" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_4Tex_0062F0" OutName="HIDAN_room_4Tex_0062F0" Format="ci4" Width="32" Height="64" Offset="0x6290" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_4Tex_0066F0" OutName="HIDAN_room_4Tex_0066F0" Format="ci4" Width="32" Height="32" Offset="0x6690" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_4Tex_0068F0" OutName="HIDAN_room_4Tex_0068F0" Format="ci4" Width="32" Height="64" Offset="0x6890" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_4Tex_006CF0" OutName="HIDAN_room_4Tex_006CF0" Format="ci4" Width="32" Height="64" Offset="0x6C90" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_4Tex_0070F0" OutName="HIDAN_room_4Tex_0070F0" Format="rgba16" Width="32" Height="32" Offset="0x7090" AddedByScript="true"/>
         <Room Name="HIDAN_room_4" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_5" Segment="3">
+        <Texture Name="HIDAN_room_5Tex_007EE0" OutName="HIDAN_room_5Tex_007EE0" Format="rgba16" Width="32" Height="8" Offset="0x7E30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_5Tex_0080E0" OutName="HIDAN_room_5Tex_0080E0" Format="rgba16" Width="32" Height="32" Offset="0x8030" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_5Tex_0088E0" OutName="HIDAN_room_5Tex_0088E0" Format="ci4" Width="32" Height="64" Offset="0x8830" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_5Tex_008CE0" OutName="HIDAN_room_5Tex_008CE0" Format="rgba16" Width="32" Height="32" Offset="0x8C30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_5Tex_0094E0" OutName="HIDAN_room_5Tex_0094E0" Format="ci4" Width="32" Height="32" Offset="0x9430" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_5Tex_0096E0" OutName="HIDAN_room_5Tex_0096E0" Format="ci4" Width="32" Height="64" Offset="0x9630" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_5Tex_009AE0" OutName="HIDAN_room_5Tex_009AE0" Format="ci4" Width="32" Height="64" Offset="0x9A30" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_5Tex_009EE0" OutName="HIDAN_room_5Tex_009EE0" Format="ci4" Width="32" Height="64" Offset="0x9E30" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
         <Room Name="HIDAN_room_5" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_6" Segment="3">
+        <Texture Name="HIDAN_room_6Tex_003990" OutName="HIDAN_room_6Tex_003990" Format="rgba16" Width="16" Height="16" Offset="0x39A0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_6Tex_003B90" OutName="HIDAN_room_6Tex_003B90" Format="rgba16" Width="32" Height="32" Offset="0x3BA0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_6Tex_004390" OutName="HIDAN_room_6Tex_004390" Format="rgba16" Width="32" Height="32" Offset="0x43A0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_6Tex_004B90" OutName="HIDAN_room_6Tex_004B90" Format="rgba16" Width="64" Height="32" Offset="0x4BA0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_6Tex_005B90" OutName="HIDAN_room_6Tex_005B90" Format="rgba16" Width="32" Height="32" Offset="0x5BA0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_6Tex_006390" OutName="HIDAN_room_6Tex_006390" Format="ci4" Width="32" Height="64" Offset="0x63A0" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_6Tex_006790" OutName="HIDAN_room_6Tex_006790" Format="rgba16" Width="32" Height="32" Offset="0x67A0" AddedByScript="true"/>
         <Room Name="HIDAN_room_6" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_7" Segment="3">
+        <Texture Name="HIDAN_room_7Tex_001C48" OutName="HIDAN_room_7Tex_001C48" Format="rgba16" Width="32" Height="8" Offset="0x1BD8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_7Tex_001E48" OutName="HIDAN_room_7Tex_001E48" Format="rgba16" Width="32" Height="32" Offset="0x1DD8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_7Tex_002648" OutName="HIDAN_room_7Tex_002648" Format="ci4" Width="32" Height="64" Offset="0x25D8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_7Tex_002A48" OutName="HIDAN_room_7Tex_002A48" Format="rgba16" Width="32" Height="64" Offset="0x29D8" AddedByScript="true"/>
         <Room Name="HIDAN_room_7" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_8" Segment="3">
+        <Texture Name="HIDAN_room_8Tex_0050D8" OutName="HIDAN_room_8Tex_0050D8" Format="rgba16" Width="16" Height="16" Offset="0x50B8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_8Tex_0052D8" OutName="HIDAN_room_8Tex_0052D8" Format="rgba16" Width="32" Height="32" Offset="0x52B8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_8Tex_005AD8" OutName="HIDAN_room_8Tex_005AD8" Format="rgba16" Width="32" Height="32" Offset="0x5AB8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_8Tex_0062D8" OutName="HIDAN_room_8Tex_0062D8" Format="rgba16" Width="32" Height="32" Offset="0x62B8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_8Tex_006AD8" OutName="HIDAN_room_8Tex_006AD8" Format="rgba16" Width="64" Height="32" Offset="0x6AB8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_8Tex_007AD8" OutName="HIDAN_room_8Tex_007AD8" Format="rgba16" Width="32" Height="32" Offset="0x7AB8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_8Tex_0082D8" OutName="HIDAN_room_8Tex_0082D8" Format="ci4" Width="32" Height="64" Offset="0x82B8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_8Tex_0086D8" OutName="HIDAN_room_8Tex_0086D8" Format="ci4" Width="32" Height="64" Offset="0x86B8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_8Tex_008AD8" OutName="HIDAN_room_8Tex_008AD8" Format="rgba16" Width="32" Height="32" Offset="0x8AB8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_8Tex_0092D8" OutName="HIDAN_room_8Tex_0092D8" Format="rgba16" Width="32" Height="32" Offset="0x92B8" AddedByScript="true"/>
         <Room Name="HIDAN_room_8" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_9" Segment="3">
+        <Texture Name="HIDAN_room_9Tex_004768" OutName="HIDAN_room_9Tex_004768" Format="rgba16" Width="32" Height="32" Offset="0x4768" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_9Tex_004F68" OutName="HIDAN_room_9Tex_004F68" Format="rgba16" Width="32" Height="32" Offset="0x4F68" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_9Tex_005768" OutName="HIDAN_room_9Tex_005768" Format="rgba16" Width="32" Height="32" Offset="0x5768" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_9Tex_005F68" OutName="HIDAN_room_9Tex_005F68" Format="rgba16" Width="32" Height="32" Offset="0x5F68" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_9Tex_006768" OutName="HIDAN_room_9Tex_006768" Format="rgba16" Width="32" Height="32" Offset="0x6768" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_9Tex_006F68" OutName="HIDAN_room_9Tex_006F68" Format="rgba16" Width="32" Height="32" Offset="0x6F68" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_9Tex_007768" OutName="HIDAN_room_9Tex_007768" Format="rgba16" Width="32" Height="32" Offset="0x7768" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_9Tex_007F68" OutName="HIDAN_room_9Tex_007F68" Format="rgba16" Width="32" Height="32" Offset="0x7F68" AddedByScript="true"/>
         <Room Name="HIDAN_room_9" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_10" Segment="3">
+        <Texture Name="HIDAN_room_10Tex_011818" OutName="HIDAN_room_10Tex_011818" Format="rgba16" Width="32" Height="8" Offset="0x11898" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_011A18" OutName="HIDAN_room_10Tex_011A18" Format="rgba16" Width="32" Height="32" Offset="0x11A98" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_012218" OutName="HIDAN_room_10Tex_012218" Format="ci4" Width="32" Height="64" Offset="0x12298" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_012618" OutName="HIDAN_room_10Tex_012618" Format="rgba16" Width="32" Height="32" Offset="0x12698" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_012E18" OutName="HIDAN_room_10Tex_012E18" Format="ci4" Width="64" Height="32" Offset="0x12E98" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_013218" OutName="HIDAN_room_10Tex_013218" Format="ci4" Width="32" Height="32" Offset="0x13298" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_013418" OutName="HIDAN_room_10Tex_013418" Format="rgba16" Width="64" Height="32" Offset="0x13498" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_014418" OutName="HIDAN_room_10Tex_014418" Format="rgba16" Width="64" Height="32" Offset="0x14498" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_015418" OutName="HIDAN_room_10Tex_015418" Format="ci4" Width="64" Height="32" Offset="0x15498" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_015818" OutName="HIDAN_room_10Tex_015818" Format="ci4" Width="32" Height="32" Offset="0x15898" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_015A18" OutName="HIDAN_room_10Tex_015A18" Format="rgba16" Width="64" Height="32" Offset="0x15A98" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_016A18" OutName="HIDAN_room_10Tex_016A18" Format="ci4" Width="32" Height="32" Offset="0x16A98" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_016C18" OutName="HIDAN_room_10Tex_016C18" Format="ci4" Width="32" Height="64" Offset="0x16C98" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_017018" OutName="HIDAN_room_10Tex_017018" Format="rgba16" Width="32" Height="32" Offset="0x17098" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_017818" OutName="HIDAN_room_10Tex_017818" Format="ci4" Width="32" Height="64" Offset="0x17898" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_017C18" OutName="HIDAN_room_10Tex_017C18" Format="rgba16" Width="32" Height="32" Offset="0x17C98" AddedByScript="true"/>
         <Room Name="HIDAN_room_10" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_11" Segment="3">
+        <Texture Name="HIDAN_room_11Tex_0027D8" OutName="HIDAN_room_11Tex_0027D8" Format="rgba16" Width="32" Height="32" Offset="0x27B8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_11Tex_002FD8" OutName="HIDAN_room_11Tex_002FD8" Format="ci4" Width="32" Height="64" Offset="0x2FB8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_11Tex_0033D8" OutName="HIDAN_room_11Tex_0033D8" Format="ci4" Width="32" Height="64" Offset="0x33B8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
         <Room Name="HIDAN_room_11" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_12" Segment="3">
+        <Texture Name="HIDAN_room_12Tex_001D68" OutName="HIDAN_room_12Tex_001D68" Format="rgba16" Width="32" Height="8" Offset="0x1D78" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_12Tex_001F68" OutName="HIDAN_room_12Tex_001F68" Format="rgba16" Width="32" Height="32" Offset="0x1F78" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_12Tex_002768" OutName="HIDAN_room_12Tex_002768" Format="ci4" Width="32" Height="64" Offset="0x2778" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
         <Room Name="HIDAN_room_12" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_13" Segment="3">
+        <Texture Name="HIDAN_room_13Tex_00A788" OutName="HIDAN_room_13Tex_00A788" Format="rgba16" Width="32" Height="32" Offset="0xA7D8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_13Tex_00AF88" OutName="HIDAN_room_13Tex_00AF88" Format="ci4" Width="64" Height="32" Offset="0xAFD8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_13Tex_00B388" OutName="HIDAN_room_13Tex_00B388" Format="ci4" Width="32" Height="64" Offset="0xB3D8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_13Tex_00B788" OutName="HIDAN_room_13Tex_00B788" Format="ci4" Width="32" Height="64" Offset="0xB7D8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_13Tex_00BB88" OutName="HIDAN_room_13Tex_00BB88" Format="rgba16" Width="32" Height="32" Offset="0xBBD8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_13Tex_00C388" OutName="HIDAN_room_13Tex_00C388" Format="rgba16" Width="32" Height="32" Offset="0xC3D8" AddedByScript="true"/>
         <Room Name="HIDAN_room_13" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_14" Segment="3">
+        <Texture Name="HIDAN_room_14Tex_0019F8" OutName="HIDAN_room_14Tex_0019F8" Format="ci4" Width="32" Height="64" Offset="0x1A58" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_14Tex_001DF8" OutName="HIDAN_room_14Tex_001DF8" Format="ci4" Width="32" Height="64" Offset="0x1E58" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
         <Room Name="HIDAN_room_14" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_15" Segment="3">
+        <Texture Name="HIDAN_room_15Tex_000D88" OutName="HIDAN_room_15Tex_000D88" Format="ci4" Width="32" Height="64" Offset="0xDC8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
         <Room Name="HIDAN_room_15" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_16" Segment="3">
+        <Texture Name="HIDAN_room_16Tex_006DE0" OutName="HIDAN_room_16Tex_006DE0" Format="rgba16" Width="32" Height="8" Offset="0x6D70" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_16Tex_006FE0" OutName="HIDAN_room_16Tex_006FE0" Format="rgba16" Width="32" Height="32" Offset="0x6F70" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_16Tex_0077E0" OutName="HIDAN_room_16Tex_0077E0" Format="rgba16" Width="32" Height="32" Offset="0x7770" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_16Tex_007FE0" OutName="HIDAN_room_16Tex_007FE0" Format="ci4" Width="32" Height="64" Offset="0x7F70" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_16Tex_0083E0" OutName="HIDAN_room_16Tex_0083E0" Format="ci4" Width="32" Height="32" Offset="0x8370" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_16Tex_0085E0" OutName="HIDAN_room_16Tex_0085E0" Format="rgba16" Width="32" Height="32" Offset="0x8570" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_16Tex_008DE0" OutName="HIDAN_room_16Tex_008DE0" Format="ci4" Width="32" Height="64" Offset="0x8D70" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_16Tex_0091E0" OutName="HIDAN_room_16Tex_0091E0" Format="ci4" Width="32" Height="64" Offset="0x9170" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_16Tex_0095E0" OutName="HIDAN_room_16Tex_0095E0" Format="rgba16" Width="16" Height="64" Offset="0x9570" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_16Tex_009DE0" OutName="HIDAN_room_16Tex_009DE0" Format="rgba16" Width="32" Height="32" Offset="0x9D70" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_16Tex_00A5E0" OutName="HIDAN_room_16Tex_00A5E0" Format="ci4" Width="32" Height="64" Offset="0xA570" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_16Tex_00A9E0" OutName="HIDAN_room_16Tex_00A9E0" Format="rgba16" Width="32" Height="32" Offset="0xA970" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_16Tex_00B1E0" OutName="HIDAN_room_16Tex_00B1E0" Format="rgba16" Width="32" Height="32" Offset="0xB170" AddedByScript="true"/>
         <Room Name="HIDAN_room_16" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_17" Segment="3">
+        <Texture Name="HIDAN_room_17Tex_005168" OutName="HIDAN_room_17Tex_005168" Format="rgba16" Width="32" Height="32" Offset="0x5138" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_17Tex_005968" OutName="HIDAN_room_17Tex_005968" Format="rgba16" Width="32" Height="32" Offset="0x5938" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_17Tex_006168" OutName="HIDAN_room_17Tex_006168" Format="rgba16" Width="32" Height="32" Offset="0x6138" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_17Tex_006968" OutName="HIDAN_room_17Tex_006968" Format="rgba16" Width="32" Height="32" Offset="0x6938" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_17Tex_007168" OutName="HIDAN_room_17Tex_007168" Format="rgba16" Width="32" Height="32" Offset="0x7138" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_17Tex_007968" OutName="HIDAN_room_17Tex_007968" Format="rgba16" Width="32" Height="32" Offset="0x7938" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_17Tex_008168" OutName="HIDAN_room_17Tex_008168" Format="rgba16" Width="32" Height="32" Offset="0x8138" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_17Tex_008968" OutName="HIDAN_room_17Tex_008968" Format="rgba16" Width="32" Height="32" Offset="0x8938" AddedByScript="true"/>
         <Room Name="HIDAN_room_17" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_18" Segment="3">
+        <Texture Name="HIDAN_room_18Tex_0027F8" OutName="HIDAN_room_18Tex_0027F8" Format="rgba16" Width="32" Height="32" Offset="0x2778" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_18Tex_002FF8" OutName="HIDAN_room_18Tex_002FF8" Format="ci4" Width="32" Height="64" Offset="0x2F78" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_18Tex_0033F8" OutName="HIDAN_room_18Tex_0033F8" Format="ci4" Width="64" Height="32" Offset="0x3378" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_18Tex_0037F8" OutName="HIDAN_room_18Tex_0037F8" Format="ci4" Width="32" Height="32" Offset="0x3778" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_18Tex_0039F8" OutName="HIDAN_room_18Tex_0039F8" Format="ci4" Width="32" Height="32" Offset="0x3978" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
         <Room Name="HIDAN_room_18" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_19" Segment="3">
+        <Texture Name="HIDAN_room_19Tex_002E28" OutName="HIDAN_room_19Tex_002E28" Format="rgba16" Width="32" Height="32" Offset="0x2DD8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_19Tex_003628" OutName="HIDAN_room_19Tex_003628" Format="ci4" Width="32" Height="64" Offset="0x35D8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_19Tex_003A28" OutName="HIDAN_room_19Tex_003A28" Format="ci4" Width="64" Height="32" Offset="0x39D8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_19Tex_003E28" OutName="HIDAN_room_19Tex_003E28" Format="ci4" Width="32" Height="32" Offset="0x3DD8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_19Tex_004028" OutName="HIDAN_room_19Tex_004028" Format="ci4" Width="32" Height="32" Offset="0x3FD8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
         <Room Name="HIDAN_room_19" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_20" Segment="3">
+        <Texture Name="HIDAN_room_20Tex_002D08" OutName="HIDAN_room_20Tex_002D08" Format="rgba16" Width="32" Height="32" Offset="0x2D08" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_20Tex_003508" OutName="HIDAN_room_20Tex_003508" Format="rgba16" Width="32" Height="32" Offset="0x3508" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_20Tex_003D08" OutName="HIDAN_room_20Tex_003D08" Format="rgba16" Width="32" Height="32" Offset="0x3D08" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_20Tex_004508" OutName="HIDAN_room_20Tex_004508" Format="rgba16" Width="32" Height="32" Offset="0x4508" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_20Tex_004D08" OutName="HIDAN_room_20Tex_004D08" Format="rgba16" Width="32" Height="32" Offset="0x4D08" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_20Tex_005508" OutName="HIDAN_room_20Tex_005508" Format="rgba16" Width="32" Height="32" Offset="0x5508" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_20Tex_005D08" OutName="HIDAN_room_20Tex_005D08" Format="rgba16" Width="32" Height="32" Offset="0x5D08" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_20Tex_006508" OutName="HIDAN_room_20Tex_006508" Format="rgba16" Width="32" Height="32" Offset="0x6508" AddedByScript="true"/>
         <Room Name="HIDAN_room_20" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_21" Segment="3">
+        <Texture Name="HIDAN_room_21Tex_004478" OutName="HIDAN_room_21Tex_004478" Format="rgba16" Width="32" Height="8" Offset="0x44B8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_21Tex_004678" OutName="HIDAN_room_21Tex_004678" Format="rgba16" Width="32" Height="32" Offset="0x46B8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_21Tex_004E78" OutName="HIDAN_room_21Tex_004E78" Format="rgba16" Width="32" Height="32" Offset="0x4EB8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_21Tex_005678" OutName="HIDAN_room_21Tex_005678" Format="rgba16" Width="32" Height="32" Offset="0x56B8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_21Tex_005E78" OutName="HIDAN_room_21Tex_005E78" Format="rgba16" Width="32" Height="32" Offset="0x5EB8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_21Tex_006678" OutName="HIDAN_room_21Tex_006678" Format="ci4" Width="64" Height="32" Offset="0x66B8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_21Tex_006A78" OutName="HIDAN_room_21Tex_006A78" Format="rgba16" Width="32" Height="32" Offset="0x6AB8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_21Tex_007278" OutName="HIDAN_room_21Tex_007278" Format="ci4" Width="32" Height="32" Offset="0x72B8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_21Tex_007478" OutName="HIDAN_room_21Tex_007478" Format="rgba16" Width="32" Height="32" Offset="0x74B8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_21Tex_007C78" OutName="HIDAN_room_21Tex_007C78" Format="rgba16" Width="32" Height="32" Offset="0x7CB8" AddedByScript="true"/>
         <Room Name="HIDAN_room_21" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_22" Segment="3">
+        <Texture Name="HIDAN_room_22Tex_002AE8" OutName="HIDAN_room_22Tex_002AE8" Format="rgba16" Width="32" Height="32" Offset="0x2AF8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_22Tex_0032E8" OutName="HIDAN_room_22Tex_0032E8" Format="rgba16" Width="32" Height="32" Offset="0x32F8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_22Tex_003AE8" OutName="HIDAN_room_22Tex_003AE8" Format="rgba16" Width="32" Height="32" Offset="0x3AF8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_22Tex_0042E8" OutName="HIDAN_room_22Tex_0042E8" Format="rgba16" Width="32" Height="32" Offset="0x42F8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_22Tex_004AE8" OutName="HIDAN_room_22Tex_004AE8" Format="rgba16" Width="32" Height="32" Offset="0x4AF8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_22Tex_0052E8" OutName="HIDAN_room_22Tex_0052E8" Format="rgba16" Width="32" Height="32" Offset="0x52F8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_22Tex_005AE8" OutName="HIDAN_room_22Tex_005AE8" Format="rgba16" Width="32" Height="32" Offset="0x5AF8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_22Tex_0062E8" OutName="HIDAN_room_22Tex_0062E8" Format="rgba16" Width="32" Height="32" Offset="0x62F8" AddedByScript="true"/>
         <Room Name="HIDAN_room_22" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_23" Segment="3">
+        <Texture Name="HIDAN_room_23Tex_002D18" OutName="HIDAN_room_23Tex_002D18" Format="rgba16" Width="32" Height="32" Offset="0x2D18" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_23Tex_003518" OutName="HIDAN_room_23Tex_003518" Format="rgba16" Width="32" Height="32" Offset="0x3518" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_23Tex_003D18" OutName="HIDAN_room_23Tex_003D18" Format="rgba16" Width="32" Height="32" Offset="0x3D18" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_23Tex_004518" OutName="HIDAN_room_23Tex_004518" Format="rgba16" Width="32" Height="32" Offset="0x4518" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_23Tex_004D18" OutName="HIDAN_room_23Tex_004D18" Format="rgba16" Width="32" Height="32" Offset="0x4D18" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_23Tex_005518" OutName="HIDAN_room_23Tex_005518" Format="rgba16" Width="32" Height="32" Offset="0x5518" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_23Tex_005D18" OutName="HIDAN_room_23Tex_005D18" Format="rgba16" Width="32" Height="32" Offset="0x5D18" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_23Tex_006518" OutName="HIDAN_room_23Tex_006518" Format="rgba16" Width="32" Height="32" Offset="0x6518" AddedByScript="true"/>
         <Room Name="HIDAN_room_23" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_24" Segment="3">
+        <Texture Name="HIDAN_room_24Tex_003B38" OutName="HIDAN_room_24Tex_003B38" Format="ci4" Width="32" Height="64" Offset="0x3B38" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_24Tex_003F38" OutName="HIDAN_room_24Tex_003F38" Format="ci4" Width="64" Height="32" Offset="0x3F38" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_24Tex_004338" OutName="HIDAN_room_24Tex_004338" Format="ci4" Width="64" Height="32" Offset="0x4338" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_24Tex_004738" OutName="HIDAN_room_24Tex_004738" Format="ci4" Width="32" Height="32" Offset="0x4738" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_24Tex_004938" OutName="HIDAN_room_24Tex_004938" Format="ci4" Width="32" Height="64" Offset="0x4938" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_24Tex_004D38" OutName="HIDAN_room_24Tex_004D38" Format="rgba16" Width="32" Height="32" Offset="0x4D38" AddedByScript="true"/>
         <Room Name="HIDAN_room_24" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_25" Segment="3">
+        <Texture Name="HIDAN_room_25Tex_002AD8" OutName="HIDAN_room_25Tex_002AD8" Format="rgba16" Width="32" Height="32" Offset="0x2AD8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_25Tex_0032D8" OutName="HIDAN_room_25Tex_0032D8" Format="rgba16" Width="32" Height="32" Offset="0x32D8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_25Tex_003AD8" OutName="HIDAN_room_25Tex_003AD8" Format="rgba16" Width="32" Height="32" Offset="0x3AD8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_25Tex_0042D8" OutName="HIDAN_room_25Tex_0042D8" Format="rgba16" Width="32" Height="32" Offset="0x42D8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_25Tex_004AD8" OutName="HIDAN_room_25Tex_004AD8" Format="rgba16" Width="32" Height="32" Offset="0x4AD8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_25Tex_0052D8" OutName="HIDAN_room_25Tex_0052D8" Format="rgba16" Width="32" Height="32" Offset="0x52D8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_25Tex_005AD8" OutName="HIDAN_room_25Tex_005AD8" Format="rgba16" Width="32" Height="32" Offset="0x5AD8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_25Tex_0062D8" OutName="HIDAN_room_25Tex_0062D8" Format="rgba16" Width="32" Height="32" Offset="0x62D8" AddedByScript="true"/>
         <Room Name="HIDAN_room_25" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_26" Segment="3">
+        <Texture Name="HIDAN_room_26Tex_004A98" OutName="HIDAN_room_26Tex_004A98" Format="rgba16" Width="32" Height="32" Offset="0x4A98" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_26Tex_005298" OutName="HIDAN_room_26Tex_005298" Format="ci4" Width="64" Height="32" Offset="0x5298" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_26Tex_005698" OutName="HIDAN_room_26Tex_005698" Format="ci4" Width="32" Height="32" Offset="0x5698" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_26Tex_005898" OutName="HIDAN_room_26Tex_005898" Format="rgba16" Width="32" Height="32" Offset="0x5898" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_26Tex_006098" OutName="HIDAN_room_26Tex_006098" Format="rgba16" Width="32" Height="32" Offset="0x6098" AddedByScript="true"/>
         <Room Name="HIDAN_room_26" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/scenes/dungeons/MIZUsin.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/dungeons/MIZUsin.xml
@@ -1,77 +1,262 @@
 <Root>
     <File Name="MIZUsin_scene" Segment="2">
+        <Texture Name="MIZUsin_sceneTex_013C30" OutName="MIZUsin_sceneTex_013C30" Format="rgba16" Width="32" Height="32" Offset="0x13CF0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_sceneTex_014430" OutName="MIZUsin_sceneTex_014430" Format="rgba16" Width="32" Height="32" Offset="0x144F0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_sceneTex_015030" OutName="MIZUsin_sceneTex_015030" Format="rgba16" Width="32" Height="32" Offset="0x150F0" AddedByScript="true"/>
         <Path Name="gWaterTemplePath_00424" Offset="0x424" NumPaths="7"/>
         <Texture Name="gWaterTempleDayEntranceTex" OutName="day_entrance" Format="ia16" Width="8" Height="64" Offset="0x14CF0"/>
         <Texture Name="gWaterTempleNightEntranceTex" OutName="night_entrance" Format="ia16" Width="8" Height="64" Offset="0x158F0"/>
         <Scene Name="MIZUsin_scene" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_0" Segment="3">
+        <Texture Name="MIZUsin_room_0Tex_00CDF8" OutName="MIZUsin_room_0Tex_00CDF8" Format="i4" Width="64" Height="64" Offset="0xCE48" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_00D5F8" OutName="MIZUsin_room_0Tex_00D5F8" Format="i4" Width="64" Height="64" Offset="0xD648" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_00DDF8" OutName="MIZUsin_room_0Tex_00DDF8" Format="rgba16" Width="32" Height="32" Offset="0xDE48" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_00E5F8" OutName="MIZUsin_room_0Tex_00E5F8" Format="rgba16" Width="32" Height="32" Offset="0xE648" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_00EDF8" OutName="MIZUsin_room_0Tex_00EDF8" Format="rgba16" Width="32" Height="32" Offset="0xEE48" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_00F5F8" OutName="MIZUsin_room_0Tex_00F5F8" Format="rgba16" Width="32" Height="32" Offset="0xF648" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_00FDF8" OutName="MIZUsin_room_0Tex_00FDF8" Format="rgba16" Width="32" Height="32" Offset="0xFE48" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_0105F8" OutName="MIZUsin_room_0Tex_0105F8" Format="rgba16" Width="32" Height="32" Offset="0x10648" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_010DF8" OutName="MIZUsin_room_0Tex_010DF8" Format="rgba16" Width="32" Height="32" Offset="0x10E48" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_0115F8" OutName="MIZUsin_room_0Tex_0115F8" Format="rgba16" Width="32" Height="32" Offset="0x11648" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_011DF8" OutName="MIZUsin_room_0Tex_011DF8" Format="rgba16" Width="32" Height="32" Offset="0x11E48" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_0125F8" OutName="MIZUsin_room_0Tex_0125F8" Format="rgba16" Width="32" Height="32" Offset="0x12648" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_012DF8" OutName="MIZUsin_room_0Tex_012DF8" Format="rgba16" Width="32" Height="32" Offset="0x12E48" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_0135F8" OutName="MIZUsin_room_0Tex_0135F8" Format="rgba16" Width="32" Height="32" Offset="0x13648" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_013DF8" OutName="MIZUsin_room_0Tex_013DF8" Format="rgba16" Width="32" Height="32" Offset="0x13E48" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_0145F8" OutName="MIZUsin_room_0Tex_0145F8" Format="rgba16" Width="32" Height="32" Offset="0x14648" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_015428" OutName="MIZUsin_room_0Tex_015428" Format="ia16" Width="32" Height="32" Offset="0x15478" AddedByScript="true"/>
         <Room Name="MIZUsin_room_0" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_1" Segment="3">
+        <Texture Name="MIZUsin_room_1Tex_0059D0" OutName="MIZUsin_room_1Tex_0059D0" Format="i4" Width="64" Height="64" Offset="0x5960" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_1Tex_0061D0" OutName="MIZUsin_room_1Tex_0061D0" Format="i4" Width="64" Height="64" Offset="0x6160" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_1Tex_0069D0" OutName="MIZUsin_room_1Tex_0069D0" Format="rgba16" Width="32" Height="32" Offset="0x6960" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_1Tex_0071D0" OutName="MIZUsin_room_1Tex_0071D0" Format="rgba16" Width="32" Height="32" Offset="0x7160" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_1Tex_0079D0" OutName="MIZUsin_room_1Tex_0079D0" Format="rgba16" Width="32" Height="32" Offset="0x7960" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_1Tex_0081D0" OutName="MIZUsin_room_1Tex_0081D0" Format="rgba16" Width="32" Height="32" Offset="0x8160" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_1Tex_0089D0" OutName="MIZUsin_room_1Tex_0089D0" Format="rgba16" Width="32" Height="32" Offset="0x8960" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_1Tex_0091D0" OutName="MIZUsin_room_1Tex_0091D0" Format="rgba16" Width="32" Height="32" Offset="0x9160" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_1Tex_0099D0" OutName="MIZUsin_room_1Tex_0099D0" Format="rgba16" Width="32" Height="32" Offset="0x9960" AddedByScript="true"/>
         <Room Name="MIZUsin_room_1" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_2" Segment="3">
+        <Texture Name="MIZUsin_room_2Tex_002AB8" OutName="MIZUsin_room_2Tex_002AB8" Format="rgba16" Width="32" Height="32" Offset="0x29B8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_2Tex_0032B8" OutName="MIZUsin_room_2Tex_0032B8" Format="rgba16" Width="32" Height="32" Offset="0x31B8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_2Tex_003AB8" OutName="MIZUsin_room_2Tex_003AB8" Format="rgba16" Width="32" Height="32" Offset="0x39B8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_2Tex_0042B8" OutName="MIZUsin_room_2Tex_0042B8" Format="rgba16" Width="32" Height="32" Offset="0x41B8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_2Tex_004AB8" OutName="MIZUsin_room_2Tex_004AB8" Format="rgba16" Width="32" Height="32" Offset="0x49B8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_2Tex_005488" OutName="MIZUsin_room_2Tex_005488" Format="ia16" Width="32" Height="32" Offset="0x5388" AddedByScript="true"/>
         <Room Name="MIZUsin_room_2" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_3" Segment="3">
+        <Texture Name="MIZUsin_room_3Tex_0037B8" OutName="MIZUsin_room_3Tex_0037B8" Format="rgba16" Width="32" Height="32" Offset="0x3708" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_3Tex_003FB8" OutName="MIZUsin_room_3Tex_003FB8" Format="rgba16" Width="32" Height="32" Offset="0x3F08" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_3Tex_0047B8" OutName="MIZUsin_room_3Tex_0047B8" Format="rgba16" Width="32" Height="32" Offset="0x4708" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_3Tex_004FB8" OutName="MIZUsin_room_3Tex_004FB8" Format="rgba16" Width="32" Height="32" Offset="0x4F08" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_3Tex_0057B8" OutName="MIZUsin_room_3Tex_0057B8" Format="rgba16" Width="32" Height="32" Offset="0x5708" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_3Tex_005FB8" OutName="MIZUsin_room_3Tex_005FB8" Format="rgba16" Width="32" Height="32" Offset="0x5F08" AddedByScript="true"/>
         <Room Name="MIZUsin_room_3" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_4" Segment="3">
+        <Texture Name="MIZUsin_room_4Tex_002820" OutName="MIZUsin_room_4Tex_002820" Format="i4" Width="64" Height="64" Offset="0x27E0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_4Tex_003020" OutName="MIZUsin_room_4Tex_003020" Format="rgba16" Width="32" Height="32" Offset="0x2FE0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_4Tex_003820" OutName="MIZUsin_room_4Tex_003820" Format="rgba16" Width="32" Height="32" Offset="0x37E0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_4Tex_004020" OutName="MIZUsin_room_4Tex_004020" Format="rgba16" Width="32" Height="32" Offset="0x3FE0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_4Tex_004820" OutName="MIZUsin_room_4Tex_004820" Format="rgba16" Width="32" Height="32" Offset="0x47E0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_4Tex_005020" OutName="MIZUsin_room_4Tex_005020" Format="rgba16" Width="32" Height="32" Offset="0x4FE0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_4Tex_005820" OutName="MIZUsin_room_4Tex_005820" Format="rgba16" Width="32" Height="32" Offset="0x57E0" AddedByScript="true"/>
         <Room Name="MIZUsin_room_4" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_5" Segment="3">
+        <Texture Name="MIZUsin_room_5Tex_003A48" OutName="MIZUsin_room_5Tex_003A48" Format="rgba16" Width="32" Height="32" Offset="0x39F8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_5Tex_004248" OutName="MIZUsin_room_5Tex_004248" Format="rgba16" Width="32" Height="32" Offset="0x41F8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_5Tex_004A48" OutName="MIZUsin_room_5Tex_004A48" Format="rgba16" Width="32" Height="32" Offset="0x49F8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_5Tex_005248" OutName="MIZUsin_room_5Tex_005248" Format="rgba16" Width="32" Height="32" Offset="0x51F8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_5Tex_005A48" OutName="MIZUsin_room_5Tex_005A48" Format="rgba16" Width="32" Height="32" Offset="0x59F8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_5Tex_006248" OutName="MIZUsin_room_5Tex_006248" Format="rgba16" Width="32" Height="32" Offset="0x61F8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_5Tex_006A48" OutName="MIZUsin_room_5Tex_006A48" Format="rgba16" Width="32" Height="32" Offset="0x69F8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_5Tex_007248" OutName="MIZUsin_room_5Tex_007248" Format="rgba16" Width="32" Height="32" Offset="0x71F8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_5Tex_007A48" OutName="MIZUsin_room_5Tex_007A48" Format="rgba16" Width="32" Height="32" Offset="0x79F8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_5Tex_008248" OutName="MIZUsin_room_5Tex_008248" Format="rgba16" Width="32" Height="32" Offset="0x81F8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_5Tex_008A48" OutName="MIZUsin_room_5Tex_008A48" Format="rgba16" Width="32" Height="32" Offset="0x89F8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_5Tex_009248" OutName="MIZUsin_room_5Tex_009248" Format="rgba16" Width="32" Height="32" Offset="0x91F8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_5Tex_009E38" OutName="MIZUsin_room_5Tex_009E38" Format="ia16" Width="32" Height="32" Offset="0x9DE8" AddedByScript="true"/>
         <Room Name="MIZUsin_room_5" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_6" Segment="3">
+        <Texture Name="MIZUsin_room_6Tex_005100" OutName="MIZUsin_room_6Tex_005100" Format="i4" Width="32" Height="32" Offset="0x50C0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_005300" OutName="MIZUsin_room_6Tex_005300" Format="rgba16" Width="32" Height="32" Offset="0x52C0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_005B00" OutName="MIZUsin_room_6Tex_005B00" Format="rgba16" Width="32" Height="32" Offset="0x5AC0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_006300" OutName="MIZUsin_room_6Tex_006300" Format="i4" Width="32" Height="32" Offset="0x62C0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_006500" OutName="MIZUsin_room_6Tex_006500" Format="i4" Width="32" Height="32" Offset="0x64C0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_006700" OutName="MIZUsin_room_6Tex_006700" Format="i4" Width="32" Height="32" Offset="0x66C0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_006900" OutName="MIZUsin_room_6Tex_006900" Format="i4" Width="32" Height="32" Offset="0x68C0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_006B00" OutName="MIZUsin_room_6Tex_006B00" Format="i4" Width="64" Height="64" Offset="0x6AC0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_007300" OutName="MIZUsin_room_6Tex_007300" Format="rgba16" Width="32" Height="32" Offset="0x72C0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_007B00" OutName="MIZUsin_room_6Tex_007B00" Format="rgba16" Width="32" Height="32" Offset="0x7AC0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_008300" OutName="MIZUsin_room_6Tex_008300" Format="rgba16" Width="32" Height="32" Offset="0x82C0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_008B00" OutName="MIZUsin_room_6Tex_008B00" Format="rgba16" Width="32" Height="32" Offset="0x8AC0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_009300" OutName="MIZUsin_room_6Tex_009300" Format="rgba16" Width="32" Height="32" Offset="0x92C0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_009B00" OutName="MIZUsin_room_6Tex_009B00" Format="rgba16" Width="32" Height="32" Offset="0x9AC0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_00A300" OutName="MIZUsin_room_6Tex_00A300" Format="rgba16" Width="32" Height="32" Offset="0xA2C0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_00AB00" OutName="MIZUsin_room_6Tex_00AB00" Format="rgba16" Width="32" Height="32" Offset="0xAAC0" AddedByScript="true"/>
         <Room Name="MIZUsin_room_6" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_7" Segment="3">
+        <Texture Name="MIZUsin_room_7Tex_002560" OutName="MIZUsin_room_7Tex_002560" Format="rgba16" Width="32" Height="32" Offset="0x2550" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_7Tex_002D60" OutName="MIZUsin_room_7Tex_002D60" Format="rgba16" Width="32" Height="32" Offset="0x2D50" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_7Tex_003560" OutName="MIZUsin_room_7Tex_003560" Format="rgba16" Width="32" Height="32" Offset="0x3550" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_7Tex_003D60" OutName="MIZUsin_room_7Tex_003D60" Format="rgba16" Width="32" Height="32" Offset="0x3D50" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_7Tex_004560" OutName="MIZUsin_room_7Tex_004560" Format="rgba16" Width="32" Height="32" Offset="0x4550" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_7Tex_004D60" OutName="MIZUsin_room_7Tex_004D60" Format="rgba16" Width="32" Height="32" Offset="0x4D50" AddedByScript="true"/>
         <Room Name="MIZUsin_room_7" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_8" Segment="3">
+        <Texture Name="MIZUsin_room_8Tex_005D98" OutName="MIZUsin_room_8Tex_005D98" Format="i4" Width="32" Height="32" Offset="0x5CE8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_005F98" OutName="MIZUsin_room_8Tex_005F98" Format="i4" Width="32" Height="32" Offset="0x5EE8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_006198" OutName="MIZUsin_room_8Tex_006198" Format="rgba16" Width="32" Height="32" Offset="0x60E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_006998" OutName="MIZUsin_room_8Tex_006998" Format="rgba16" Width="32" Height="32" Offset="0x68E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_007198" OutName="MIZUsin_room_8Tex_007198" Format="i4" Width="32" Height="32" Offset="0x70E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_007398" OutName="MIZUsin_room_8Tex_007398" Format="i4" Width="32" Height="32" Offset="0x72E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_007598" OutName="MIZUsin_room_8Tex_007598" Format="rgba16" Width="32" Height="32" Offset="0x74E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_007D98" OutName="MIZUsin_room_8Tex_007D98" Format="i4" Width="64" Height="64" Offset="0x7CE8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_008598" OutName="MIZUsin_room_8Tex_008598" Format="rgba16" Width="32" Height="32" Offset="0x84E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_008D98" OutName="MIZUsin_room_8Tex_008D98" Format="rgba16" Width="32" Height="32" Offset="0x8CE8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_009598" OutName="MIZUsin_room_8Tex_009598" Format="rgba16" Width="32" Height="32" Offset="0x94E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_009D98" OutName="MIZUsin_room_8Tex_009D98" Format="rgba16" Width="32" Height="32" Offset="0x9CE8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_00A598" OutName="MIZUsin_room_8Tex_00A598" Format="rgba16" Width="32" Height="32" Offset="0xA4E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_00AD98" OutName="MIZUsin_room_8Tex_00AD98" Format="rgba16" Width="32" Height="32" Offset="0xACE8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_00B598" OutName="MIZUsin_room_8Tex_00B598" Format="rgba16" Width="32" Height="32" Offset="0xB4E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_00BD98" OutName="MIZUsin_room_8Tex_00BD98" Format="rgba16" Width="32" Height="32" Offset="0xBCE8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_00C598" OutName="MIZUsin_room_8Tex_00C598" Format="rgba16" Width="32" Height="32" Offset="0xC4E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_00D578" OutName="MIZUsin_room_8Tex_00D578" Format="ia16" Width="32" Height="32" Offset="0xD4C8" AddedByScript="true"/>
         <Room Name="MIZUsin_room_8" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_9" Segment="3">
+        <Texture Name="MIZUsin_room_9Tex_0036D8" OutName="MIZUsin_room_9Tex_0036D8" Format="i4" Width="64" Height="64" Offset="0x3608" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_9Tex_003ED8" OutName="MIZUsin_room_9Tex_003ED8" Format="rgba16" Width="32" Height="32" Offset="0x3E08" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_9Tex_0046D8" OutName="MIZUsin_room_9Tex_0046D8" Format="rgba16" Width="32" Height="32" Offset="0x4608" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_9Tex_004ED8" OutName="MIZUsin_room_9Tex_004ED8" Format="rgba16" Width="32" Height="32" Offset="0x4E08" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_9Tex_0056D8" OutName="MIZUsin_room_9Tex_0056D8" Format="rgba16" Width="32" Height="32" Offset="0x5608" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_9Tex_005ED8" OutName="MIZUsin_room_9Tex_005ED8" Format="rgba16" Width="32" Height="32" Offset="0x5E08" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_9Tex_0066D8" OutName="MIZUsin_room_9Tex_0066D8" Format="rgba16" Width="32" Height="32" Offset="0x6608" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_9Tex_006ED8" OutName="MIZUsin_room_9Tex_006ED8" Format="rgba16" Width="32" Height="32" Offset="0x6E08" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_9Tex_0078A8" OutName="MIZUsin_room_9Tex_0078A8" Format="ia16" Width="32" Height="32" Offset="0x77D8" AddedByScript="true"/>
         <Room Name="MIZUsin_room_9" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_10" Segment="3">
+        <Texture Name="MIZUsin_room_10Tex_003870" OutName="MIZUsin_room_10Tex_003870" Format="rgba16" Width="32" Height="32" Offset="0x37B0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_10Tex_004070" OutName="MIZUsin_room_10Tex_004070" Format="rgba16" Width="32" Height="32" Offset="0x3FB0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_10Tex_004870" OutName="MIZUsin_room_10Tex_004870" Format="rgba16" Width="32" Height="32" Offset="0x47B0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_10Tex_005070" OutName="MIZUsin_room_10Tex_005070" Format="rgba16" Width="32" Height="32" Offset="0x4FB0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_10Tex_005870" OutName="MIZUsin_room_10Tex_005870" Format="rgba16" Width="32" Height="32" Offset="0x57B0" AddedByScript="true"/>
         <Room Name="MIZUsin_room_10" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_11" Segment="3">
+        <Texture Name="MIZUsin_room_11Tex_002220" OutName="MIZUsin_room_11Tex_002220" Format="rgba16" Width="32" Height="32" Offset="0x21B0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_11Tex_002A20" OutName="MIZUsin_room_11Tex_002A20" Format="rgba16" Width="32" Height="32" Offset="0x29B0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_11Tex_003220" OutName="MIZUsin_room_11Tex_003220" Format="rgba16" Width="32" Height="32" Offset="0x31B0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_11Tex_003A20" OutName="MIZUsin_room_11Tex_003A20" Format="rgba16" Width="32" Height="32" Offset="0x39B0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_11Tex_004220" OutName="MIZUsin_room_11Tex_004220" Format="rgba16" Width="32" Height="32" Offset="0x41B0" AddedByScript="true"/>
         <Room Name="MIZUsin_room_11" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_12" Segment="3">
+        <Texture Name="MIZUsin_room_12Tex_0039C8" OutName="MIZUsin_room_12Tex_0039C8" Format="rgba16" Width="32" Height="32" Offset="0x3928" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_12Tex_0041C8" OutName="MIZUsin_room_12Tex_0041C8" Format="rgba16" Width="32" Height="32" Offset="0x4128" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_12Tex_0049C8" OutName="MIZUsin_room_12Tex_0049C8" Format="rgba16" Width="32" Height="32" Offset="0x4928" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_12Tex_0051C8" OutName="MIZUsin_room_12Tex_0051C8" Format="rgba16" Width="32" Height="32" Offset="0x5128" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_12Tex_006628" OutName="MIZUsin_room_12Tex_006628" Format="ia16" Width="32" Height="32" Offset="0x6588" AddedByScript="true"/>
         <Room Name="MIZUsin_room_12" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_13" Segment="3">
+        <Texture Name="MIZUsin_room_13Tex_0001F8" OutName="MIZUsin_room_13Tex_0001F8" Format="rgba16" Width="32" Height="32" Offset="0x1F8" AddedByScript="true"/>
         <Room Name="MIZUsin_room_13" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_14" Segment="3">
+        <Texture Name="MIZUsin_room_14Tex_003680" OutName="MIZUsin_room_14Tex_003680" Format="i4" Width="64" Height="64" Offset="0x3660" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_14Tex_003E80" OutName="MIZUsin_room_14Tex_003E80" Format="rgba16" Width="32" Height="32" Offset="0x3E60" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_14Tex_004680" OutName="MIZUsin_room_14Tex_004680" Format="rgba16" Width="32" Height="32" Offset="0x4660" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_14Tex_004E80" OutName="MIZUsin_room_14Tex_004E80" Format="rgba16" Width="32" Height="32" Offset="0x4E60" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_14Tex_005680" OutName="MIZUsin_room_14Tex_005680" Format="rgba16" Width="32" Height="32" Offset="0x5660" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_14Tex_005E80" OutName="MIZUsin_room_14Tex_005E80" Format="rgba16" Width="32" Height="32" Offset="0x5E60" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_14Tex_006680" OutName="MIZUsin_room_14Tex_006680" Format="rgba16" Width="32" Height="32" Offset="0x6660" AddedByScript="true"/>
         <Room Name="MIZUsin_room_14" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_15" Segment="3">
+        <Texture Name="MIZUsin_room_15Tex_002C68" OutName="MIZUsin_room_15Tex_002C68" Format="i4" Width="64" Height="64" Offset="0x2C28" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_15Tex_003468" OutName="MIZUsin_room_15Tex_003468" Format="rgba16" Width="32" Height="32" Offset="0x3428" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_15Tex_003C68" OutName="MIZUsin_room_15Tex_003C68" Format="rgba16" Width="32" Height="32" Offset="0x3C28" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_15Tex_004468" OutName="MIZUsin_room_15Tex_004468" Format="rgba16" Width="32" Height="32" Offset="0x4428" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_15Tex_004C68" OutName="MIZUsin_room_15Tex_004C68" Format="rgba16" Width="32" Height="32" Offset="0x4C28" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_15Tex_005468" OutName="MIZUsin_room_15Tex_005468" Format="rgba16" Width="32" Height="32" Offset="0x5428" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_15Tex_005C68" OutName="MIZUsin_room_15Tex_005C68" Format="rgba16" Width="32" Height="32" Offset="0x5C28" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_15Tex_006468" OutName="MIZUsin_room_15Tex_006468" Format="rgba16" Width="32" Height="32" Offset="0x6428" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_15Tex_006C68" OutName="MIZUsin_room_15Tex_006C68" Format="rgba16" Width="32" Height="32" Offset="0x6C28" AddedByScript="true"/>
         <Room Name="MIZUsin_room_15" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_16" Segment="3">
+        <Texture Name="MIZUsin_room_16Tex_001330" OutName="MIZUsin_room_16Tex_001330" Format="rgba16" Width="32" Height="32" Offset="0x12D0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_16Tex_001B30" OutName="MIZUsin_room_16Tex_001B30" Format="rgba16" Width="32" Height="32" Offset="0x1AD0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_16Tex_002330" OutName="MIZUsin_room_16Tex_002330" Format="rgba16" Width="32" Height="32" Offset="0x22D0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_16Tex_002B30" OutName="MIZUsin_room_16Tex_002B30" Format="rgba16" Width="32" Height="32" Offset="0x2AD0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_16Tex_003330" OutName="MIZUsin_room_16Tex_003330" Format="rgba16" Width="32" Height="32" Offset="0x32D0" AddedByScript="true"/>
         <Room Name="MIZUsin_room_16" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_17" Segment="3">
+        <Texture Name="MIZUsin_room_17Tex_005AA8" OutName="MIZUsin_room_17Tex_005AA8" Format="rgba16" Width="32" Height="32" Offset="0x5A18" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_17Tex_0062A8" OutName="MIZUsin_room_17Tex_0062A8" Format="i4" Width="64" Height="64" Offset="0x6218" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_17Tex_006AA8" OutName="MIZUsin_room_17Tex_006AA8" Format="rgba16" Width="32" Height="32" Offset="0x6A18" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_17Tex_0072A8" OutName="MIZUsin_room_17Tex_0072A8" Format="rgba16" Width="32" Height="32" Offset="0x7218" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_17Tex_007AA8" OutName="MIZUsin_room_17Tex_007AA8" Format="rgba16" Width="32" Height="32" Offset="0x7A18" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_17Tex_0082A8" OutName="MIZUsin_room_17Tex_0082A8" Format="rgba16" Width="32" Height="32" Offset="0x8218" AddedByScript="true"/>
         <Room Name="MIZUsin_room_17" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_18" Segment="3">
+        <Texture Name="MIZUsin_room_18Tex_0018F8" OutName="MIZUsin_room_18Tex_0018F8" Format="rgba16" Width="32" Height="32" Offset="0x18B8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_18Tex_0020F8" OutName="MIZUsin_room_18Tex_0020F8" Format="rgba16" Width="32" Height="32" Offset="0x20B8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_18Tex_0028F8" OutName="MIZUsin_room_18Tex_0028F8" Format="rgba16" Width="32" Height="32" Offset="0x28B8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_18Tex_0030F8" OutName="MIZUsin_room_18Tex_0030F8" Format="rgba16" Width="32" Height="32" Offset="0x30B8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_18Tex_0038F8" OutName="MIZUsin_room_18Tex_0038F8" Format="rgba16" Width="32" Height="32" Offset="0x38B8" AddedByScript="true"/>
         <Room Name="MIZUsin_room_18" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_19" Segment="3">
+        <Texture Name="MIZUsin_room_19Tex_001130" OutName="MIZUsin_room_19Tex_001130" Format="rgba16" Width="32" Height="32" Offset="0x1130" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_19Tex_001930" OutName="MIZUsin_room_19Tex_001930" Format="rgba16" Width="32" Height="32" Offset="0x1930" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_19Tex_002130" OutName="MIZUsin_room_19Tex_002130" Format="rgba16" Width="32" Height="32" Offset="0x2130" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_19Tex_002930" OutName="MIZUsin_room_19Tex_002930" Format="rgba16" Width="32" Height="32" Offset="0x2930" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_19Tex_003130" OutName="MIZUsin_room_19Tex_003130" Format="rgba16" Width="32" Height="32" Offset="0x3130" AddedByScript="true"/>
         <Room Name="MIZUsin_room_19" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_20" Segment="3">
+        <Texture Name="MIZUsin_room_20Tex_003040" OutName="MIZUsin_room_20Tex_003040" Format="rgba16" Width="32" Height="32" Offset="0x2F40" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_20Tex_003840" OutName="MIZUsin_room_20Tex_003840" Format="i4" Width="64" Height="64" Offset="0x3740" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_20Tex_004040" OutName="MIZUsin_room_20Tex_004040" Format="rgba16" Width="32" Height="32" Offset="0x3F40" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_20Tex_004840" OutName="MIZUsin_room_20Tex_004840" Format="rgba16" Width="32" Height="32" Offset="0x4740" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_20Tex_005040" OutName="MIZUsin_room_20Tex_005040" Format="rgba16" Width="32" Height="32" Offset="0x4F40" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_20Tex_005840" OutName="MIZUsin_room_20Tex_005840" Format="rgba16" Width="32" Height="32" Offset="0x5740" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_20Tex_006040" OutName="MIZUsin_room_20Tex_006040" Format="rgba16" Width="32" Height="32" Offset="0x5F40" AddedByScript="true"/>
         <Room Name="MIZUsin_room_20" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_21" Segment="3">
+        <Texture Name="MIZUsin_room_21Tex_004360" OutName="MIZUsin_room_21Tex_004360" Format="rgba16" Width="32" Height="32" Offset="0x4360" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_21Tex_004B60" OutName="MIZUsin_room_21Tex_004B60" Format="rgba16" Width="32" Height="32" Offset="0x4B60" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_21Tex_005360" OutName="MIZUsin_room_21Tex_005360" Format="rgba16" Width="32" Height="32" Offset="0x5360" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_21Tex_005B60" OutName="MIZUsin_room_21Tex_005B60" Format="rgba16" Width="32" Height="32" Offset="0x5B60" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_21Tex_006CA0" OutName="MIZUsin_room_21Tex_006CA0" Format="ia16" Width="32" Height="32" Offset="0x6CA0" AddedByScript="true"/>
         <Room Name="MIZUsin_room_21" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_22" Segment="3">
+        <Texture Name="MIZUsin_room_22Tex_0044E8" OutName="MIZUsin_room_22Tex_0044E8" Format="rgba16" Width="32" Height="16" Offset="0x44E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_22Tex_0048E8" OutName="MIZUsin_room_22Tex_0048E8" Format="rgba16" Width="32" Height="32" Offset="0x48E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_22Tex_0050E8" OutName="MIZUsin_room_22Tex_0050E8" Format="rgba16" Width="32" Height="32" Offset="0x50E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_22Tex_0058E8" OutName="MIZUsin_room_22Tex_0058E8" Format="rgba16" Width="32" Height="32" Offset="0x58E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_22Tex_0060E8" OutName="MIZUsin_room_22Tex_0060E8" Format="rgba16" Width="32" Height="32" Offset="0x60E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_22Tex_0068E8" OutName="MIZUsin_room_22Tex_0068E8" Format="rgba16" Width="32" Height="32" Offset="0x68E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_22Tex_0070E8" OutName="MIZUsin_room_22Tex_0070E8" Format="rgba16" Width="32" Height="32" Offset="0x70E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_22Tex_0078E8" OutName="MIZUsin_room_22Tex_0078E8" Format="rgba16" Width="32" Height="32" Offset="0x78E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_22Tex_0080E8" OutName="MIZUsin_room_22Tex_0080E8" Format="rgba16" Width="32" Height="32" Offset="0x80E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_22Tex_0088E8" OutName="MIZUsin_room_22Tex_0088E8" Format="rgba16" Width="32" Height="32" Offset="0x88E8" AddedByScript="true"/>
         <Room Name="MIZUsin_room_22" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/scenes/dungeons/MIZUsin_bs.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/dungeons/MIZUsin_bs.xml
@@ -3,9 +3,27 @@
         <Scene Name="MIZUsin_bs_scene" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_bs_room_0" Segment="3">
+        <Texture Name="MIZUsin_bs_room_0Tex_001470" OutName="MIZUsin_bs_room_0Tex_001470" Format="rgba16" Width="32" Height="32" Offset="0x1470" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_0Tex_001C70" OutName="MIZUsin_bs_room_0Tex_001C70" Format="rgba16" Width="32" Height="32" Offset="0x1C70" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_0Tex_002470" OutName="MIZUsin_bs_room_0Tex_002470" Format="rgba16" Width="32" Height="32" Offset="0x2470" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_0Tex_002C70" OutName="MIZUsin_bs_room_0Tex_002C70" Format="rgba16" Width="32" Height="32" Offset="0x2C70" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_0Tex_003470" OutName="MIZUsin_bs_room_0Tex_003470" Format="rgba16" Width="32" Height="32" Offset="0x3470" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_0Tex_003C70" OutName="MIZUsin_bs_room_0Tex_003C70" Format="rgba16" Width="32" Height="32" Offset="0x3C70" AddedByScript="true"/>
         <Room Name="MIZUsin_bs_room_0" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_bs_room_1" Segment="3">
+        <Texture Name="MIZUsin_bs_room_1Tex_0056E8" OutName="MIZUsin_bs_room_1Tex_0056E8" Format="rgba16" Width="32" Height="32" Offset="0x56E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_1Tex_005EE8" OutName="MIZUsin_bs_room_1Tex_005EE8" Format="rgba16" Width="32" Height="32" Offset="0x5EE8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_1Tex_0066E8" OutName="MIZUsin_bs_room_1Tex_0066E8" Format="rgba16" Width="32" Height="32" Offset="0x66E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_1Tex_006EE8" OutName="MIZUsin_bs_room_1Tex_006EE8" Format="rgba16" Width="32" Height="32" Offset="0x6EE8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_1Tex_0076E8" OutName="MIZUsin_bs_room_1Tex_0076E8" Format="rgba16" Width="32" Height="32" Offset="0x76E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_1Tex_007EE8" OutName="MIZUsin_bs_room_1Tex_007EE8" Format="rgba16" Width="32" Height="32" Offset="0x7EE8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_1Tex_0086E8" OutName="MIZUsin_bs_room_1Tex_0086E8" Format="rgba16" Width="32" Height="32" Offset="0x86E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_1Tex_008EE8" OutName="MIZUsin_bs_room_1Tex_008EE8" Format="rgba16" Width="32" Height="16" Offset="0x8EE8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_1Tex_0092E8" OutName="MIZUsin_bs_room_1Tex_0092E8" Format="rgba16" Width="32" Height="32" Offset="0x92E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_1Tex_009AE8" OutName="MIZUsin_bs_room_1Tex_009AE8" Format="rgba16" Width="32" Height="32" Offset="0x9AE8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_1Tex_00A2E8" OutName="MIZUsin_bs_room_1Tex_00A2E8" Format="rgba16" Width="32" Height="32" Offset="0xA2E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_1Tex_00AAE8" OutName="MIZUsin_bs_room_1Tex_00AAE8" Format="i4" Width="64" Height="64" Offset="0xAAE8" AddedByScript="true"/>
         <Room Name="MIZUsin_bs_room_1" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/scenes/dungeons/bdan.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/dungeons/bdan.xml
@@ -1,36 +1,69 @@
 <Root>
     <File Name="bdan_scene" Segment="2">
+        <Texture Name="bdan_sceneTex_013E00" OutName="bdan_sceneTex_013E00" Format="ci8" Width="32" Height="64" Offset="0x13DE0" TlutOffset="0x13BD8" AddedByScript="true"/>
+        <Texture Name="bdan_sceneTex_014600" OutName="bdan_sceneTex_014600" Format="ci8" Width="32" Height="32" Offset="0x145E0" TlutOffset="0x13BD8" AddedByScript="true"/>
+        <Texture Name="bdan_sceneTex_014A00" OutName="bdan_sceneTex_014A00" Format="ci8" Width="32" Height="64" Offset="0x149E0" TlutOffset="0x13BD8" AddedByScript="true"/>
+        <Texture Name="bdan_sceneTex_015200" OutName="bdan_sceneTex_015200" Format="ci8" Width="32" Height="32" Offset="0x151E0" TlutOffset="0x139D0" AddedByScript="true"/>
+        <Texture Name="bdan_sceneTLUT_0139F0" OutName="bdan_sceneTLUT_0139F0" Format="rgba16" Width="16" Height="16" Offset="0x139D0" AddedByScript="true"/>
+        <Texture Name="bdan_sceneTLUT_013BF8" OutName="bdan_sceneTLUT_013BF8" Format="rgba16" Width="16" Height="16" Offset="0x13BD8" AddedByScript="true"/>
         <Cutscene Name="gJabuJabuIntroCs" Offset="0x155E0"/>
         <Scene Name="bdan_scene" Offset="0x0"/>
     </File>
     <File Name="bdan_room_0" Segment="3">
+        <Texture Name="bdan_room_0Tex_002DB8" OutName="bdan_room_0Tex_002DB8" Format="ci8" Width="32" Height="32" Offset="0x2CE8" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
+        <Texture Name="bdan_room_0Tex_0031B8" OutName="bdan_room_0Tex_0031B8" Format="ci8" Width="32" Height="64" Offset="0x30E8" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
+        <Texture Name="bdan_room_0Tex_0039B8" OutName="bdan_room_0Tex_0039B8" Format="ci8" Width="32" Height="32" Offset="0x38E8" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
         <Room Name="bdan_room_0" Offset="0x0"/>
     </File>
     <File Name="bdan_room_1" Segment="3">
+        <Texture Name="bdan_room_1Tex_004E00" OutName="bdan_room_1Tex_004E00" Format="ci8" Width="32" Height="64" Offset="0x4CD0" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
+        <Texture Name="bdan_room_1Tex_005600" OutName="bdan_room_1Tex_005600" Format="ci8" Width="32" Height="64" Offset="0x54D0" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
         <Room Name="bdan_room_1" Offset="0x0"/>
     </File>
     <File Name="bdan_room_2" Segment="3">
+        <Texture Name="bdan_room_2Tex_006E38" OutName="bdan_room_2Tex_006E38" Format="rgba16" Width="32" Height="64" Offset="0x6DC8" AddedByScript="true"/>
+        <Texture Name="bdan_room_2Tex_007E38" OutName="bdan_room_2Tex_007E38" Format="ci8" Width="32" Height="64" Offset="0x7DC8" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
+        <Texture Name="bdan_room_2Tex_008638" OutName="bdan_room_2Tex_008638" Format="ci8" Width="32" Height="64" Offset="0x85C8" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
+        <Texture Name="bdan_room_2Tex_008E38" OutName="bdan_room_2Tex_008E38" Format="ci8" Width="32" Height="32" Offset="0x8DC8" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
         <Room Name="bdan_room_2" Offset="0x0"/>
     </File>
     <File Name="bdan_room_3" Segment="3">
+        <Texture Name="bdan_room_3Tex_004888" OutName="bdan_room_3Tex_004888" Format="rgba16" Width="32" Height="64" Offset="0x4788" AddedByScript="true"/>
+        <Texture Name="bdan_room_3Tex_005888" OutName="bdan_room_3Tex_005888" Format="ci8" Width="32" Height="64" Offset="0x5788" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
+        <Texture Name="bdan_room_3Tex_006088" OutName="bdan_room_3Tex_006088" Format="ci8" Width="32" Height="32" Offset="0x5F88" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
+        <Texture Name="bdan_room_3Tex_006488" OutName="bdan_room_3Tex_006488" Format="ci8" Width="32" Height="64" Offset="0x6388" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
+        <Texture Name="bdan_room_3Tex_006C88" OutName="bdan_room_3Tex_006C88" Format="ci8" Width="32" Height="32" Offset="0x6B88" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
         <Room Name="bdan_room_3" Offset="0x0"/>
     </File>
     <File Name="bdan_room_4" Segment="3">
+        <Texture Name="bdan_room_4Tex_002B30" OutName="bdan_room_4Tex_002B30" Format="ci8" Width="32" Height="32" Offset="0x2A80" ExternalTlut="bdan_scene" ExternalTlutOffset="0x139D0" AddedByScript="true"/>
+        <Texture Name="bdan_room_4Tex_002F30" OutName="bdan_room_4Tex_002F30" Format="ci8" Width="32" Height="64" Offset="0x2E80" ExternalTlut="bdan_scene" ExternalTlutOffset="0x139D0" AddedByScript="true"/>
+        <Texture Name="bdan_room_4Tex_003730" OutName="bdan_room_4Tex_003730" Format="ci8" Width="32" Height="64" Offset="0x3680" ExternalTlut="bdan_scene" ExternalTlutOffset="0x139D0" AddedByScript="true"/>
         <Room Name="bdan_room_4" Offset="0x0"/>
     </File>
     <File Name="bdan_room_5" Segment="3">
+        <Texture Name="bdan_room_5Tex_0024A8" OutName="bdan_room_5Tex_0024A8" Format="ci8" Width="32" Height="32" Offset="0x2438" ExternalTlut="bdan_scene" ExternalTlutOffset="0x139D0" AddedByScript="true"/>
+        <Texture Name="bdan_room_5Tex_0028A8" OutName="bdan_room_5Tex_0028A8" Format="ci8" Width="32" Height="64" Offset="0x2838" ExternalTlut="bdan_scene" ExternalTlutOffset="0x139D0" AddedByScript="true"/>
+        <Texture Name="bdan_room_5Tex_0030A8" OutName="bdan_room_5Tex_0030A8" Format="ci8" Width="32" Height="64" Offset="0x3038" ExternalTlut="bdan_scene" ExternalTlutOffset="0x139D0" AddedByScript="true"/>
+        <Texture Name="bdan_room_5Tex_004090" OutName="bdan_room_5Tex_004090" Format="rgba16" Width="32" Height="64" Offset="0x4020" AddedByScript="true"/>
+        <Texture Name="bdan_room_5Tex_005090" OutName="bdan_room_5Tex_005090" Format="ia16" Width="32" Height="64" Offset="0x5020" AddedByScript="true"/>
         <Room Name="bdan_room_5" Offset="0x0"/>
     </File>
     <File Name="bdan_room_6" Segment="3">
+        <Texture Name="bdan_room_6Tex_003068" OutName="bdan_room_6Tex_003068" Format="ci8" Width="32" Height="64" Offset="0x3068" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
+        <Texture Name="bdan_room_6Tex_003868" OutName="bdan_room_6Tex_003868" Format="ci8" Width="32" Height="64" Offset="0x3868" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
         <Room Name="bdan_room_6" Offset="0x0"/>
     </File>
     <File Name="bdan_room_7" Segment="3">
+        <Texture Name="bdan_room_7Tex_002CD0" OutName="bdan_room_7Tex_002CD0" Format="ci8" Width="32" Height="32" Offset="0x2D20" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
+        <Texture Name="bdan_room_7Tex_0030D0" OutName="bdan_room_7Tex_0030D0" Format="ci8" Width="32" Height="32" Offset="0x3120" ExternalTlut="bdan_scene" ExternalTlutOffset="0x139D0" AddedByScript="true"/>
         <Room Name="bdan_room_7" Offset="0x0"/>
     </File>
     <File Name="bdan_room_8" Segment="3">
         <Room Name="bdan_room_8" Offset="0x0"/>
     </File>
     <File Name="bdan_room_9" Segment="3">
+        <Texture Name="bdan_room_9Tex_003828" OutName="bdan_room_9Tex_003828" Format="ci8" Width="32" Height="32" Offset="0x3868" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
         <Room Name="bdan_room_9" Offset="0x0"/>
     </File>
     <File Name="bdan_room_10" Segment="3">
@@ -40,12 +73,20 @@
         <Room Name="bdan_room_11" Offset="0x0"/>
     </File>
     <File Name="bdan_room_12" Segment="3">
+        <Texture Name="bdan_room_12Tex_0038E0" OutName="bdan_room_12Tex_0038E0" Format="ci8" Width="32" Height="32" Offset="0x38D0" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
         <Room Name="bdan_room_12" Offset="0x0"/>
     </File>
     <File Name="bdan_room_13" Segment="3">
+        <Texture Name="bdan_room_13Tex_0015B8" OutName="bdan_room_13Tex_0015B8" Format="ci8" Width="32" Height="64" Offset="0x1588" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
+        <Texture Name="bdan_room_13Tex_001DB8" OutName="bdan_room_13Tex_001DB8" Format="ci8" Width="32" Height="32" Offset="0x1D88" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
+        <Texture Name="bdan_room_13Tex_0021B8" OutName="bdan_room_13Tex_0021B8" Format="ci8" Width="32" Height="64" Offset="0x2188" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
         <Room Name="bdan_room_13" Offset="0x0"/>
     </File>
     <File Name="bdan_room_14" Segment="3">
+        <Texture Name="bdan_room_14Tex_0045C8" OutName="bdan_room_14Tex_0045C8" Format="ci8" Width="32" Height="64" Offset="0x45D8" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
+        <Texture Name="bdan_room_14Tex_004DC8" OutName="bdan_room_14Tex_004DC8" Format="ci8" Width="32" Height="64" Offset="0x4DD8" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
+        <Texture Name="bdan_room_14Tex_0055C8" OutName="bdan_room_14Tex_0055C8" Format="ci8" Width="32" Height="32" Offset="0x55D8" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
+        <Texture Name="bdan_room_14Tex_0059C8" OutName="bdan_room_14Tex_0059C8" Format="ci8" Width="32" Height="64" Offset="0x59D8" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
         <Room Name="bdan_room_14" Offset="0x0"/>
     </File>
     <File Name="bdan_room_15" Segment="3">

--- a/soh/assets/xml/GC_NMQ_D/scenes/dungeons/bdan_boss.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/dungeons/bdan_boss.xml
@@ -3,9 +3,17 @@
         <Scene Name="bdan_boss_scene" Offset="0x0"/>
     </File>
     <File Name="bdan_boss_room_0" Segment="3">
+        <Texture Name="bdan_boss_room_0Tex_002040" OutName="bdan_boss_room_0Tex_002040" Format="ci8" Width="32" Height="64" Offset="0x2040" TlutOffset="0x1E38" AddedByScript="true"/>
+        <Texture Name="bdan_boss_room_0Tex_002C18" OutName="bdan_boss_room_0Tex_002C18" Format="ci8" Width="32" Height="32" Offset="0x2C18" TlutOffset="0x2A10" AddedByScript="true"/>
+        <Texture Name="bdan_boss_room_0TLUT_001E38" OutName="bdan_boss_room_0TLUT_001E38" Format="rgba16" Width="16" Height="16" Offset="0x1E38" AddedByScript="true"/>
+        <Texture Name="bdan_boss_room_0TLUT_002A10" OutName="bdan_boss_room_0TLUT_002A10" Format="rgba16" Width="16" Height="16" Offset="0x2A10" AddedByScript="true"/>
         <Room Name="bdan_boss_room_0" Offset="0x0"/>
     </File>
     <File Name="bdan_boss_room_1" Segment="3">
+        <Texture Name="bdan_boss_room_1Tex_003CB8" OutName="bdan_boss_room_1Tex_003CB8" Format="ci8" Width="32" Height="64" Offset="0x3CB8" TlutOffset="0x3AB0" AddedByScript="true"/>
+        <Texture Name="bdan_boss_room_1Tex_0044B8" OutName="bdan_boss_room_1Tex_0044B8" Format="ci8" Width="32" Height="32" Offset="0x44B8" TlutOffset="0x3AB0" AddedByScript="true"/>
+        <Texture Name="bdan_boss_room_1Tex_0048B8" OutName="bdan_boss_room_1Tex_0048B8" Format="ci8" Width="32" Height="64" Offset="0x48B8" TlutOffset="0x3AB0" AddedByScript="true"/>
+        <Texture Name="bdan_boss_room_1TLUT_003AB0" OutName="bdan_boss_room_1TLUT_003AB0" Format="rgba16" Width="16" Height="16" Offset="0x3AB0" AddedByScript="true"/>
         <Room Name="bdan_boss_room_1" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/scenes/dungeons/ddan.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/dungeons/ddan.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="ddan_scene" Segment="2">
+        <Texture Name="ddan_sceneTLUT_011D70" OutName="ddan_sceneTLUT_011D70" Format="rgba16" Width="16" Height="16" Offset="0x11D70" AddedByScript="true"/>
         <Texture Name="gDCDayEntranceTex" OutName="day_entrance" Format="ci8" Width="32" Height="64" Offset="0x12378" TlutOffset="0x11D70"/>
         <Texture Name="gDCNightEntranceTex" OutName="night_entrance" Format="ci8" Width="32" Height="64" Offset="0x13378" TlutOffset="0x11D70"/>
 
@@ -17,54 +18,203 @@
         <Scene Name="ddan_scene" Offset="0x0"/>
     </File>
     <File Name="ddan_room_0" Segment="3">
+        <Texture Name="ddan_room_0Tex_011498" OutName="ddan_room_0Tex_011498" Format="ci8" Width="32" Height="32" Offset="0x11498" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_011898" OutName="ddan_room_0Tex_011898" Format="ci8" Width="32" Height="32" Offset="0x11898" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_011C98" OutName="ddan_room_0Tex_011C98" Format="ci8" Width="64" Height="32" Offset="0x11C98" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_012498" OutName="ddan_room_0Tex_012498" Format="ci8" Width="32" Height="64" Offset="0x12498" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_012C98" OutName="ddan_room_0Tex_012C98" Format="rgba16" Width="32" Height="64" Offset="0x12C98" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_013C98" OutName="ddan_room_0Tex_013C98" Format="rgba16" Width="32" Height="64" Offset="0x13C98" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_014C98" OutName="ddan_room_0Tex_014C98" Format="rgba16" Width="32" Height="32" Offset="0x14C98" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_015498" OutName="ddan_room_0Tex_015498" Format="ci8" Width="32" Height="64" Offset="0x15498" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_015C98" OutName="ddan_room_0Tex_015C98" Format="ci8" Width="32" Height="64" Offset="0x15C98" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_016498" OutName="ddan_room_0Tex_016498" Format="ci8" Width="32" Height="32" Offset="0x16498" TlutOffset="0x11290" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_016898" OutName="ddan_room_0Tex_016898" Format="ci8" Width="32" Height="64" Offset="0x16898" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_017098" OutName="ddan_room_0Tex_017098" Format="rgba16" Width="32" Height="32" Offset="0x17098" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_017898" OutName="ddan_room_0Tex_017898" Format="ci8" Width="32" Height="32" Offset="0x17898" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_017C98" OutName="ddan_room_0Tex_017C98" Format="rgba16" Width="32" Height="32" Offset="0x17C98" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_018498" OutName="ddan_room_0Tex_018498" Format="ci8" Width="32" Height="64" Offset="0x18498" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_018C98" OutName="ddan_room_0Tex_018C98" Format="ci8" Width="32" Height="64" Offset="0x18C98" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_019498" OutName="ddan_room_0Tex_019498" Format="rgba16" Width="64" Height="32" Offset="0x19498" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_01A498" OutName="ddan_room_0Tex_01A498" Format="rgba16" Width="64" Height="32" Offset="0x1A498" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_01B498" OutName="ddan_room_0Tex_01B498" Format="ci8" Width="32" Height="32" Offset="0x1B498" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_0TLUT_011290" OutName="ddan_room_0TLUT_011290" Format="rgba16" Width="16" Height="16" Offset="0x11290" AddedByScript="true"/>
         <Room Name="ddan_room_0" Offset="0x0"/>
     </File>
     <File Name="ddan_room_1" Segment="3">
+        <Texture Name="ddan_room_1Tex_004770" OutName="ddan_room_1Tex_004770" Format="ci8" Width="32" Height="32" Offset="0x4700" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_1Tex_004B70" OutName="ddan_room_1Tex_004B70" Format="ci8" Width="32" Height="32" Offset="0x4B00" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_1Tex_004F70" OutName="ddan_room_1Tex_004F70" Format="ci8" Width="32" Height="64" Offset="0x4F00" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_1Tex_005770" OutName="ddan_room_1Tex_005770" Format="ci8" Width="64" Height="32" Offset="0x5700" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_1Tex_005F70" OutName="ddan_room_1Tex_005F70" Format="rgba16" Width="32" Height="64" Offset="0x5F00" AddedByScript="true"/>
+        <Texture Name="ddan_room_1Tex_006F70" OutName="ddan_room_1Tex_006F70" Format="rgba16" Width="32" Height="64" Offset="0x6F00" AddedByScript="true"/>
+        <Texture Name="ddan_room_1Tex_007F70" OutName="ddan_room_1Tex_007F70" Format="ci8" Width="32" Height="64" Offset="0x7F00" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_1Tex_008770" OutName="ddan_room_1Tex_008770" Format="ci8" Width="64" Height="32" Offset="0x8700" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_1Tex_008F70" OutName="ddan_room_1Tex_008F70" Format="ci8" Width="32" Height="64" Offset="0x8F00" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_1Tex_009770" OutName="ddan_room_1Tex_009770" Format="ci8" Width="32" Height="32" Offset="0x9700" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
         <Room Name="ddan_room_1" Offset="0x0"/>
     </File>
     <File Name="ddan_room_2" Segment="3">
+        <Texture Name="ddan_room_2Tex_003B80" OutName="ddan_room_2Tex_003B80" Format="ci8" Width="64" Height="32" Offset="0x3A60" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_2Tex_004380" OutName="ddan_room_2Tex_004380" Format="ci8" Width="32" Height="32" Offset="0x4260" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_2Tex_004780" OutName="ddan_room_2Tex_004780" Format="ci8" Width="32" Height="32" Offset="0x4660" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_2Tex_004B80" OutName="ddan_room_2Tex_004B80" Format="ci8" Width="32" Height="64" Offset="0x4A60" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_2Tex_005380" OutName="ddan_room_2Tex_005380" Format="ci8" Width="64" Height="32" Offset="0x5260" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_2Tex_005B80" OutName="ddan_room_2Tex_005B80" Format="ci8" Width="32" Height="32" Offset="0x5A60" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_2Tex_005F80" OutName="ddan_room_2Tex_005F80" Format="ci8" Width="32" Height="32" Offset="0x5E60" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_2Tex_006380" OutName="ddan_room_2Tex_006380" Format="ci8" Width="32" Height="32" Offset="0x6260" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_2Tex_006EB8" OutName="ddan_room_2Tex_006EB8" Format="rgba16" Width="32" Height="64" Offset="0x6D98" AddedByScript="true"/>
         <Room Name="ddan_room_2" Offset="0x0"/>
     </File>
     <File Name="ddan_room_3" Segment="3">
+        <Texture Name="ddan_room_3Tex_008838" OutName="ddan_room_3Tex_008838" Format="ci8" Width="32" Height="32" Offset="0x8788" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_3Tex_008C38" OutName="ddan_room_3Tex_008C38" Format="ci8" Width="64" Height="32" Offset="0x8B88" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_3Tex_009438" OutName="ddan_room_3Tex_009438" Format="ci8" Width="32" Height="32" Offset="0x9388" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_3Tex_009838" OutName="ddan_room_3Tex_009838" Format="ci8" Width="32" Height="64" Offset="0x9788" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_3Tex_00A038" OutName="ddan_room_3Tex_00A038" Format="ci8" Width="32" Height="64" Offset="0x9F88" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_3Tex_00A838" OutName="ddan_room_3Tex_00A838" Format="ci8" Width="32" Height="64" Offset="0xA788" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_3Tex_00B038" OutName="ddan_room_3Tex_00B038" Format="ci8" Width="32" Height="32" Offset="0xAF88" TlutOffset="0x8580" AddedByScript="true"/>
+        <Texture Name="ddan_room_3Tex_00B438" OutName="ddan_room_3Tex_00B438" Format="ci8" Width="32" Height="32" Offset="0xB388" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_3Tex_00B838" OutName="ddan_room_3Tex_00B838" Format="ci8" Width="32" Height="32" Offset="0xB788" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_3Tex_00BC38" OutName="ddan_room_3Tex_00BC38" Format="ci8" Width="64" Height="32" Offset="0xBB88" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_3Tex_00C438" OutName="ddan_room_3Tex_00C438" Format="ci8" Width="32" Height="64" Offset="0xC388" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_3Tex_00CC38" OutName="ddan_room_3Tex_00CC38" Format="ci8" Width="32" Height="32" Offset="0xCB88" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_3Tex_00D038" OutName="ddan_room_3Tex_00D038" Format="ci8" Width="32" Height="32" Offset="0xCF88" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_3Tex_00D668" OutName="ddan_room_3Tex_00D668" Format="ia8" Width="64" Height="32" Offset="0xD5B8" AddedByScript="true"/>
+        <Texture Name="ddan_room_3TLUT_008630" OutName="ddan_room_3TLUT_008630" Format="rgba16" Width="16" Height="16" Offset="0x8580" AddedByScript="true"/>
         <Room Name="ddan_room_3" Offset="0x0"/>
     </File>
     <File Name="ddan_room_4" Segment="3">
+        <Texture Name="ddan_room_4Tex_006D58" OutName="ddan_room_4Tex_006D58" Format="ci8" Width="32" Height="32" Offset="0x6C48" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_4Tex_007158" OutName="ddan_room_4Tex_007158" Format="ci8" Width="32" Height="32" Offset="0x7048" TlutOffset="0x6A40" AddedByScript="true"/>
+        <Texture Name="ddan_room_4Tex_007558" OutName="ddan_room_4Tex_007558" Format="ci8" Width="64" Height="32" Offset="0x7448" TlutOffset="0x6A40" AddedByScript="true"/>
+        <Texture Name="ddan_room_4Tex_007D58" OutName="ddan_room_4Tex_007D58" Format="ci8" Width="32" Height="64" Offset="0x7C48" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_4Tex_008558" OutName="ddan_room_4Tex_008558" Format="ci8" Width="32" Height="64" Offset="0x8448" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_4Tex_008D58" OutName="ddan_room_4Tex_008D58" Format="ci8" Width="32" Height="32" Offset="0x8C48" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_4Tex_009158" OutName="ddan_room_4Tex_009158" Format="ci8" Width="64" Height="32" Offset="0x9048" TlutOffset="0x6A40" AddedByScript="true"/>
+        <Texture Name="ddan_room_4TLUT_006B50" OutName="ddan_room_4TLUT_006B50" Format="rgba16" Width="16" Height="16" Offset="0x6A40" AddedByScript="true"/>
         <Room Name="ddan_room_4" Offset="0x0"/>
     </File>
     <File Name="ddan_room_5" Segment="3">
+        <Texture Name="ddan_room_5Tex_0032B8" OutName="ddan_room_5Tex_0032B8" Format="ci8" Width="32" Height="64" Offset="0x32D8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_5Tex_003AB8" OutName="ddan_room_5Tex_003AB8" Format="ci8" Width="32" Height="64" Offset="0x3AD8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_5Tex_0042B8" OutName="ddan_room_5Tex_0042B8" Format="ci8" Width="32" Height="32" Offset="0x42D8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_5Tex_0046B8" OutName="ddan_room_5Tex_0046B8" Format="ci8" Width="32" Height="32" Offset="0x46D8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_5Tex_004AB8" OutName="ddan_room_5Tex_004AB8" Format="ci8" Width="32" Height="32" Offset="0x4AD8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_5Tex_004EB8" OutName="ddan_room_5Tex_004EB8" Format="rgba16" Width="32" Height="32" Offset="0x4ED8" AddedByScript="true"/>
+        <Texture Name="ddan_room_5Tex_0056B8" OutName="ddan_room_5Tex_0056B8" Format="ci8" Width="32" Height="64" Offset="0x56D8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
         <Room Name="ddan_room_5" Offset="0x0"/>
     </File>
     <File Name="ddan_room_6" Segment="3">
+        <Texture Name="ddan_room_6Tex_000CA8" OutName="ddan_room_6Tex_000CA8" Format="ci8" Width="32" Height="64" Offset="0xBF8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_6Tex_0014A8" OutName="ddan_room_6Tex_0014A8" Format="ci8" Width="64" Height="32" Offset="0x13F8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_6Tex_001CA8" OutName="ddan_room_6Tex_001CA8" Format="ci8" Width="32" Height="32" Offset="0x1BF8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_6Tex_0020A8" OutName="ddan_room_6Tex_0020A8" Format="ci8" Width="32" Height="32" Offset="0x1FF8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
         <Room Name="ddan_room_6" Offset="0x0"/>
     </File>
     <File Name="ddan_room_7" Segment="3">
+        <Texture Name="ddan_room_7Tex_0046F8" OutName="ddan_room_7Tex_0046F8" Format="ci8" Width="32" Height="32" Offset="0x46C8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_7Tex_004AF8" OutName="ddan_room_7Tex_004AF8" Format="ci8" Width="32" Height="32" Offset="0x4AC8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_7Tex_004EF8" OutName="ddan_room_7Tex_004EF8" Format="ci8" Width="32" Height="64" Offset="0x4EC8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_7Tex_0056F8" OutName="ddan_room_7Tex_0056F8" Format="ci8" Width="32" Height="64" Offset="0x56C8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_7Tex_005EF8" OutName="ddan_room_7Tex_005EF8" Format="ci8" Width="32" Height="64" Offset="0x5EC8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_7Tex_0066F8" OutName="ddan_room_7Tex_0066F8" Format="ci8" Width="32" Height="64" Offset="0x66C8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_7Tex_006EF8" OutName="ddan_room_7Tex_006EF8" Format="ci8" Width="32" Height="64" Offset="0x6EC8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
         <Room Name="ddan_room_7" Offset="0x0"/>
     </File>
     <File Name="ddan_room_8" Segment="3">
+        <Texture Name="ddan_room_8Tex_0041A0" OutName="ddan_room_8Tex_0041A0" Format="ci8" Width="64" Height="32" Offset="0x4000" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_8Tex_0049A0" OutName="ddan_room_8Tex_0049A0" Format="ci8" Width="32" Height="32" Offset="0x4800" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_8Tex_004DA0" OutName="ddan_room_8Tex_004DA0" Format="ci8" Width="32" Height="32" Offset="0x4C00" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_8Tex_0051A0" OutName="ddan_room_8Tex_0051A0" Format="ci8" Width="64" Height="32" Offset="0x5000" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_8Tex_0059A0" OutName="ddan_room_8Tex_0059A0" Format="ci8" Width="32" Height="64" Offset="0x5800" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_8Tex_0061A0" OutName="ddan_room_8Tex_0061A0" Format="ci8" Width="32" Height="64" Offset="0x6000" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_8Tex_0069A0" OutName="ddan_room_8Tex_0069A0" Format="ci8" Width="32" Height="64" Offset="0x6800" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_8Tex_0071A0" OutName="ddan_room_8Tex_0071A0" Format="ci8" Width="32" Height="64" Offset="0x7000" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_8Tex_0079A0" OutName="ddan_room_8Tex_0079A0" Format="ci8" Width="64" Height="32" Offset="0x7800" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_8Tex_0081A0" OutName="ddan_room_8Tex_0081A0" Format="ci8" Width="32" Height="64" Offset="0x8000" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_8Tex_0089A0" OutName="ddan_room_8Tex_0089A0" Format="ci8" Width="32" Height="64" Offset="0x8800" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_8Tex_0091A0" OutName="ddan_room_8Tex_0091A0" Format="ci8" Width="32" Height="32" Offset="0x9000" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
         <Room Name="ddan_room_8" Offset="0x0"/>
     </File>
     <File Name="ddan_room_9" Segment="3">
+        <Texture Name="ddan_room_9Tex_005128" OutName="ddan_room_9Tex_005128" Format="ci8" Width="32" Height="32" Offset="0x5148" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_9Tex_005528" OutName="ddan_room_9Tex_005528" Format="ci8" Width="64" Height="32" Offset="0x5548" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_9Tex_005D28" OutName="ddan_room_9Tex_005D28" Format="ci8" Width="32" Height="32" Offset="0x5D48" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_9Tex_006128" OutName="ddan_room_9Tex_006128" Format="ci8" Width="32" Height="64" Offset="0x6148" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_9Tex_006928" OutName="ddan_room_9Tex_006928" Format="ci8" Width="32" Height="32" Offset="0x6948" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_9Tex_006D28" OutName="ddan_room_9Tex_006D28" Format="rgba16" Width="32" Height="64" Offset="0x6D48" AddedByScript="true"/>
+        <Texture Name="ddan_room_9Tex_007D28" OutName="ddan_room_9Tex_007D28" Format="rgba16" Width="32" Height="64" Offset="0x7D48" AddedByScript="true"/>
+        <Texture Name="ddan_room_9Tex_008D28" OutName="ddan_room_9Tex_008D28" Format="ci8" Width="32" Height="32" Offset="0x8D48" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_9Tex_009128" OutName="ddan_room_9Tex_009128" Format="ci8" Width="32" Height="64" Offset="0x9148" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_9Tex_009928" OutName="ddan_room_9Tex_009928" Format="ci8" Width="64" Height="32" Offset="0x9948" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_9Tex_00A128" OutName="ddan_room_9Tex_00A128" Format="rgba16" Width="32" Height="32" Offset="0xA148" AddedByScript="true"/>
+        <Texture Name="ddan_room_9Tex_00A928" OutName="ddan_room_9Tex_00A928" Format="ci8" Width="32" Height="64" Offset="0xA948" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_9Tex_00B128" OutName="ddan_room_9Tex_00B128" Format="ci8" Width="32" Height="32" Offset="0xB148" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
         <Room Name="ddan_room_9" Offset="0x0"/>
     </File>
     <File Name="ddan_room_10" Segment="3">
+        <Texture Name="ddan_room_10Tex_002B10" OutName="ddan_room_10Tex_002B10" Format="ci8" Width="32" Height="32" Offset="0x2A50" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_10Tex_002F10" OutName="ddan_room_10Tex_002F10" Format="ci8" Width="64" Height="32" Offset="0x2E50" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_10Tex_003710" OutName="ddan_room_10Tex_003710" Format="ci8" Width="32" Height="32" Offset="0x3650" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_10Tex_003B10" OutName="ddan_room_10Tex_003B10" Format="ci8" Width="32" Height="64" Offset="0x3A50" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_10Tex_004310" OutName="ddan_room_10Tex_004310" Format="ci8" Width="32" Height="32" Offset="0x4250" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_10Tex_004710" OutName="ddan_room_10Tex_004710" Format="ci8" Width="32" Height="64" Offset="0x4650" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_10Tex_004F10" OutName="ddan_room_10Tex_004F10" Format="ci8" Width="32" Height="32" Offset="0x4E50" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_10Tex_005310" OutName="ddan_room_10Tex_005310" Format="rgba16" Width="32" Height="64" Offset="0x5250" AddedByScript="true"/>
+        <Texture Name="ddan_room_10Tex_006310" OutName="ddan_room_10Tex_006310" Format="rgba16" Width="32" Height="64" Offset="0x6250" AddedByScript="true"/>
+        <Texture Name="ddan_room_10Tex_007310" OutName="ddan_room_10Tex_007310" Format="ci8" Width="32" Height="64" Offset="0x7250" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_10Tex_007B10" OutName="ddan_room_10Tex_007B10" Format="ci8" Width="32" Height="32" Offset="0x7A50" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
         <Room Name="ddan_room_10" Offset="0x0"/>
     </File>
     <File Name="ddan_room_11" Segment="3">
+        <Texture Name="ddan_room_11Tex_000C30" OutName="ddan_room_11Tex_000C30" Format="ci8" Width="32" Height="64" Offset="0xC80" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_11Tex_001430" OutName="ddan_room_11Tex_001430" Format="ci8" Width="64" Height="32" Offset="0x1480" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_11Tex_001C30" OutName="ddan_room_11Tex_001C30" Format="ci8" Width="32" Height="32" Offset="0x1C80" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
         <Room Name="ddan_room_11" Offset="0x0"/>
     </File>
     <File Name="ddan_room_12" Segment="3">
+        <Texture Name="ddan_room_12Tex_002F80" OutName="ddan_room_12Tex_002F80" Format="ci8" Width="32" Height="32" Offset="0x2F30" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_12Tex_003380" OutName="ddan_room_12Tex_003380" Format="ci8" Width="64" Height="32" Offset="0x3330" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_12Tex_003B80" OutName="ddan_room_12Tex_003B80" Format="ci8" Width="32" Height="32" Offset="0x3B30" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_12Tex_003F80" OutName="ddan_room_12Tex_003F80" Format="ci8" Width="32" Height="64" Offset="0x3F30" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_12Tex_004780" OutName="ddan_room_12Tex_004780" Format="ci8" Width="32" Height="32" Offset="0x4730" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_12Tex_004B80" OutName="ddan_room_12Tex_004B80" Format="ci8" Width="32" Height="64" Offset="0x4B30" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_12Tex_005380" OutName="ddan_room_12Tex_005380" Format="ci8" Width="32" Height="32" Offset="0x5330" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_12Tex_005780" OutName="ddan_room_12Tex_005780" Format="rgba16" Width="32" Height="64" Offset="0x5730" AddedByScript="true"/>
+        <Texture Name="ddan_room_12Tex_006780" OutName="ddan_room_12Tex_006780" Format="rgba16" Width="32" Height="64" Offset="0x6730" AddedByScript="true"/>
+        <Texture Name="ddan_room_12Tex_007780" OutName="ddan_room_12Tex_007780" Format="ci8" Width="32" Height="32" Offset="0x7730" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_12Tex_007B80" OutName="ddan_room_12Tex_007B80" Format="ci8" Width="32" Height="64" Offset="0x7B30" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_12Tex_008380" OutName="ddan_room_12Tex_008380" Format="ci8" Width="32" Height="32" Offset="0x8330" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
         <Room Name="ddan_room_12" Offset="0x0"/>
     </File>
     <File Name="ddan_room_13" Segment="3">
+        <Texture Name="ddan_room_13Tex_000CC8" OutName="ddan_room_13Tex_000CC8" Format="ci8" Width="32" Height="64" Offset="0xC78" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_13Tex_0014C8" OutName="ddan_room_13Tex_0014C8" Format="ci8" Width="64" Height="32" Offset="0x1478" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_13Tex_001CC8" OutName="ddan_room_13Tex_001CC8" Format="ci8" Width="32" Height="32" Offset="0x1C78" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_13Tex_0020C8" OutName="ddan_room_13Tex_0020C8" Format="ci8" Width="32" Height="32" Offset="0x2078" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
         <Room Name="ddan_room_13" Offset="0x0"/>
     </File>
     <File Name="ddan_room_14" Segment="3">
+        <Texture Name="ddan_room_14Tex_000CC8" OutName="ddan_room_14Tex_000CC8" Format="ci8" Width="32" Height="64" Offset="0xC88" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_14Tex_0014C8" OutName="ddan_room_14Tex_0014C8" Format="ci8" Width="64" Height="32" Offset="0x1488" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_14Tex_001CC8" OutName="ddan_room_14Tex_001CC8" Format="ci8" Width="32" Height="32" Offset="0x1C88" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_14Tex_0020C8" OutName="ddan_room_14Tex_0020C8" Format="ci8" Width="32" Height="32" Offset="0x2088" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
         <Room Name="ddan_room_14" Offset="0x0"/>
     </File>
     <File Name="ddan_room_15" Segment="3">
+        <Texture Name="ddan_room_15Tex_000D28" OutName="ddan_room_15Tex_000D28" Format="ci8" Width="64" Height="32" Offset="0xC48" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_15Tex_001528" OutName="ddan_room_15Tex_001528" Format="ci8" Width="32" Height="64" Offset="0x1448" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_15Tex_001D28" OutName="ddan_room_15Tex_001D28" Format="ci8" Width="64" Height="32" Offset="0x1C48" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_15Tex_002528" OutName="ddan_room_15Tex_002528" Format="ci8" Width="32" Height="32" Offset="0x2448" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
         <Room Name="ddan_room_15" Offset="0x0"/>
     </File>
     <File Name="ddan_room_16" Segment="3">
+        <Texture Name="ddan_room_16Tex_002158" OutName="ddan_room_16Tex_002158" Format="rgba16" Width="32" Height="64" Offset="0x2148" AddedByScript="true"/>
+        <Texture Name="ddan_room_16Tex_003158" OutName="ddan_room_16Tex_003158" Format="ci8" Width="32" Height="64" Offset="0x3148" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_16Tex_003958" OutName="ddan_room_16Tex_003958" Format="ci8" Width="32" Height="64" Offset="0x3948" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_16Tex_004158" OutName="ddan_room_16Tex_004158" Format="ci8" Width="32" Height="64" Offset="0x4148" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_16Tex_004958" OutName="ddan_room_16Tex_004958" Format="ci8" Width="32" Height="64" Offset="0x4948" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_16Tex_005158" OutName="ddan_room_16Tex_005158" Format="ci8" Width="32" Height="32" Offset="0x5148" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
         <Room Name="ddan_room_16" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/scenes/dungeons/ddan_boss.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/dungeons/ddan_boss.xml
@@ -1,11 +1,21 @@
 <Root>
     <File Name="ddan_boss_scene" Segment="2">
+        <Texture Name="ddan_boss_sceneTex_001058" OutName="ddan_boss_sceneTex_001058" Format="ci8" Width="32" Height="64" Offset="0x1058" TlutOffset="0xE50" AddedByScript="true"/>
+        <Texture Name="ddan_boss_sceneTex_001858" OutName="ddan_boss_sceneTex_001858" Format="ci8" Width="32" Height="64" Offset="0x1858" TlutOffset="0xE50" AddedByScript="true"/>
+        <Texture Name="ddan_boss_sceneTex_002058" OutName="ddan_boss_sceneTex_002058" Format="ci8" Width="32" Height="64" Offset="0x2058" TlutOffset="0xE50" AddedByScript="true"/>
+        <Texture Name="ddan_boss_sceneTLUT_000E50" OutName="ddan_boss_sceneTLUT_000E50" Format="rgba16" Width="16" Height="16" Offset="0xE50" AddedByScript="true"/>
         <Scene Name="ddan_boss_scene" Offset="0x0"/>
     </File>
     <File Name="ddan_boss_room_0" Segment="3">
+        <Texture Name="ddan_boss_room_0Tex_003628" OutName="ddan_boss_room_0Tex_003628" Format="ci8" Width="32" Height="32" Offset="0x3628" ExternalTlut="ddan_boss_scene" ExternalTlutOffset="0xE50" AddedByScript="true"/>
+        <Texture Name="ddan_boss_room_0Tex_003A28" OutName="ddan_boss_room_0Tex_003A28" Format="ci8" Width="32" Height="32" Offset="0x3A28" ExternalTlut="ddan_boss_scene" ExternalTlutOffset="0xE50" AddedByScript="true"/>
+        <Texture Name="ddan_boss_room_0Tex_003E28" OutName="ddan_boss_room_0Tex_003E28" Format="ci8" Width="32" Height="64" Offset="0x3E28" ExternalTlut="ddan_boss_scene" ExternalTlutOffset="0xE50" AddedByScript="true"/>
+        <Texture Name="ddan_boss_room_0Tex_004628" OutName="ddan_boss_room_0Tex_004628" Format="ci8" Width="32" Height="64" Offset="0x4628" ExternalTlut="ddan_boss_scene" ExternalTlutOffset="0xE50" AddedByScript="true"/>
         <Room Name="ddan_boss_room_0" Offset="0x0"/>
     </File>
     <File Name="ddan_boss_room_1" Segment="3">
+        <Texture Name="ddan_boss_room_1Tex_0031D8" OutName="ddan_boss_room_1Tex_0031D8" Format="ci8" Width="32" Height="64" Offset="0x31D8" ExternalTlut="ddan_boss_scene" ExternalTlutOffset="0xE50" AddedByScript="true"/>
+        <Texture Name="ddan_boss_room_1Tex_0039D8" OutName="ddan_boss_room_1Tex_0039D8" Format="ci8" Width="32" Height="32" Offset="0x39D8" ExternalTlut="ddan_boss_scene" ExternalTlutOffset="0xE50" AddedByScript="true"/>
         <Texture Name="gDodongosCavernBossLavaFloorTex" OutName="lava_floor" Format="rgba16" Width="64" Height="32" Offset="0x21D8"/>
         <Room Name="ddan_boss_room_1" Offset="0x0"/>
     </File>

--- a/soh/assets/xml/GC_NMQ_D/scenes/dungeons/ganon.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/dungeons/ganon.xml
@@ -1,35 +1,121 @@
 <Root>
     <File Name="ganon_scene" Segment="2">
+        <Texture Name="ganon_sceneTex_00EFA8" OutName="ganon_sceneTex_00EFA8" Format="ci8" Width="32" Height="32" Offset="0xEFA8" TlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_sceneTex_00F3A8" OutName="ganon_sceneTex_00F3A8" Format="ci8" Width="32" Height="32" Offset="0xF3A8" TlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_sceneTex_00F7A8" OutName="ganon_sceneTex_00F7A8" Format="ci8" Width="32" Height="32" Offset="0xF7A8" TlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_sceneTex_00FBA8" OutName="ganon_sceneTex_00FBA8" Format="ci8" Width="32" Height="32" Offset="0xFBA8" TlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_sceneTex_00FFA8" OutName="ganon_sceneTex_00FFA8" Format="rgba16" Width="32" Height="32" Offset="0xFFA8" AddedByScript="true"/>
+        <Texture Name="ganon_sceneTLUT_00E7D0" OutName="ganon_sceneTLUT_00E7D0" Format="rgba16" Width="16" Height="16" Offset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_sceneTLUT_00E9D8" OutName="ganon_sceneTLUT_00E9D8" Format="rgba16" Width="16" Height="16" Offset="0xE9D8" AddedByScript="true"/>
+        <Texture Name="ganon_sceneTLUT_00EBE0" OutName="ganon_sceneTLUT_00EBE0" Format="rgba16" Width="16" Height="16" Offset="0xEBE0" AddedByScript="true"/>
+        <Texture Name="ganon_sceneTLUT_00EDA0" OutName="ganon_sceneTLUT_00EDA0" Format="rgba16" Width="16" Height="16" Offset="0xEDA0" AddedByScript="true"/>
         <Scene Name="ganon_scene" Offset="0x0"/>
     </File>
     <File Name="ganon_room_0" Segment="3">
+        <Texture Name="ganon_room_0Tex_004C68" OutName="ganon_room_0Tex_004C68" Format="ci8" Width="32" Height="64" Offset="0x4C68" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_0Tex_005468" OutName="ganon_room_0Tex_005468" Format="ci8" Width="32" Height="64" Offset="0x5468" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_0Tex_005C68" OutName="ganon_room_0Tex_005C68" Format="ci8" Width="32" Height="32" Offset="0x5C68" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_0Tex_006068" OutName="ganon_room_0Tex_006068" Format="ci8" Width="64" Height="32" Offset="0x6068" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_0Tex_006868" OutName="ganon_room_0Tex_006868" Format="ci8" Width="64" Height="32" Offset="0x6868" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_0Tex_007068" OutName="ganon_room_0Tex_007068" Format="ci8" Width="32" Height="32" Offset="0x7068" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_0Tex_0076D0" OutName="ganon_room_0Tex_0076D0" Format="ia16" Width="32" Height="32" Offset="0x76D0" AddedByScript="true"/>
         <Room Name="ganon_room_0" Offset="0x0"/>
     </File>
     <File Name="ganon_room_1" Segment="3">
+        <Texture Name="ganon_room_1Tex_005370" OutName="ganon_room_1Tex_005370" Format="ci8" Width="64" Height="32" Offset="0x5370" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_1Tex_005B70" OutName="ganon_room_1Tex_005B70" Format="ci8" Width="32" Height="32" Offset="0x5B70" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_1Tex_005F70" OutName="ganon_room_1Tex_005F70" Format="ci8" Width="32" Height="32" Offset="0x5F70" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_1Tex_006370" OutName="ganon_room_1Tex_006370" Format="ci8" Width="32" Height="32" Offset="0x6370" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_1Tex_006770" OutName="ganon_room_1Tex_006770" Format="rgba16" Width="32" Height="64" Offset="0x6770" AddedByScript="true"/>
         <Room Name="ganon_room_1" Offset="0x0"/>
     </File>
     <File Name="ganon_room_2" Segment="3">
+        <Texture Name="ganon_room_2Tex_003DF0" OutName="ganon_room_2Tex_003DF0" Format="ci8" Width="32" Height="32" Offset="0x3DF0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_2Tex_0041F0" OutName="ganon_room_2Tex_0041F0" Format="ci8" Width="32" Height="64" Offset="0x41F0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_2Tex_0049F0" OutName="ganon_room_2Tex_0049F0" Format="ci8" Width="32" Height="32" Offset="0x49F0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_2Tex_004DF0" OutName="ganon_room_2Tex_004DF0" Format="ci8" Width="32" Height="32" Offset="0x4DF0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_2Tex_0051F0" OutName="ganon_room_2Tex_0051F0" Format="ci8" Width="32" Height="64" Offset="0x51F0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_2Tex_0059F0" OutName="ganon_room_2Tex_0059F0" Format="ci8" Width="32" Height="32" Offset="0x59F0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_2Tex_005DF0" OutName="ganon_room_2Tex_005DF0" Format="rgba16" Width="32" Height="64" Offset="0x5DF0" AddedByScript="true"/>
+        <Texture Name="ganon_room_2Tex_007050" OutName="ganon_room_2Tex_007050" Format="ia16" Width="32" Height="32" Offset="0x7050" AddedByScript="true"/>
         <Room Name="ganon_room_2" Offset="0x0"/>
     </File>
     <File Name="ganon_room_3" Segment="3">
+        <Texture Name="ganon_room_3Tex_004F30" OutName="ganon_room_3Tex_004F30" Format="ci8" Width="32" Height="32" Offset="0x4F30" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_3Tex_005330" OutName="ganon_room_3Tex_005330" Format="ci8" Width="32" Height="32" Offset="0x5330" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_3Tex_005730" OutName="ganon_room_3Tex_005730" Format="ci8" Width="32" Height="64" Offset="0x5730" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_3Tex_005F30" OutName="ganon_room_3Tex_005F30" Format="ci8" Width="32" Height="64" Offset="0x5F30" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_3Tex_006730" OutName="ganon_room_3Tex_006730" Format="rgba16" Width="32" Height="64" Offset="0x6730" AddedByScript="true"/>
         <Room Name="ganon_room_3" Offset="0x0"/>
     </File>
     <File Name="ganon_room_4" Segment="3">
+        <Texture Name="ganon_room_4Tex_004668" OutName="ganon_room_4Tex_004668" Format="ci8" Width="32" Height="64" Offset="0x4668" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_4Tex_004E68" OutName="ganon_room_4Tex_004E68" Format="ci8" Width="32" Height="64" Offset="0x4E68" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_4Tex_005668" OutName="ganon_room_4Tex_005668" Format="ci8" Width="32" Height="32" Offset="0x5668" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_4Tex_005A68" OutName="ganon_room_4Tex_005A68" Format="ci8" Width="32" Height="64" Offset="0x5A68" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_4Tex_006268" OutName="ganon_room_4Tex_006268" Format="ci8" Width="32" Height="32" Offset="0x6268" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_4Tex_006668" OutName="ganon_room_4Tex_006668" Format="ci8" Width="32" Height="32" Offset="0x6668" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_4Tex_006A68" OutName="ganon_room_4Tex_006A68" Format="ci8" Width="32" Height="32" Offset="0x6A68" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_4Tex_006E68" OutName="ganon_room_4Tex_006E68" Format="ci8" Width="32" Height="64" Offset="0x6E68" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_4Tex_007668" OutName="ganon_room_4Tex_007668" Format="ci8" Width="32" Height="64" Offset="0x7668" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_4Tex_007E68" OutName="ganon_room_4Tex_007E68" Format="ci8" Width="32" Height="64" Offset="0x7E68" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_4Tex_0088D0" OutName="ganon_room_4Tex_0088D0" Format="ia16" Width="32" Height="32" Offset="0x88D0" AddedByScript="true"/>
         <Room Name="ganon_room_4" Offset="0x0"/>
     </File>
     <File Name="ganon_room_5" Segment="3">
+        <Texture Name="ganon_room_5Tex_005B08" OutName="ganon_room_5Tex_005B08" Format="ci8" Width="32" Height="64" Offset="0x5B08" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_5Tex_006308" OutName="ganon_room_5Tex_006308" Format="ci8" Width="32" Height="64" Offset="0x6308" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_5Tex_006B08" OutName="ganon_room_5Tex_006B08" Format="rgba16" Width="32" Height="64" Offset="0x6B08" AddedByScript="true"/>
+        <Texture Name="ganon_room_5Tex_007B08" OutName="ganon_room_5Tex_007B08" Format="ci8" Width="32" Height="32" Offset="0x7B08" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_5Tex_007F08" OutName="ganon_room_5Tex_007F08" Format="ci8" Width="32" Height="32" Offset="0x7F08" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_5Tex_008308" OutName="ganon_room_5Tex_008308" Format="ci8" Width="32" Height="64" Offset="0x8308" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
         <Room Name="ganon_room_5" Offset="0x0"/>
     </File>
     <File Name="ganon_room_6" Segment="3">
+        <Texture Name="ganon_room_6Tex_006E00" OutName="ganon_room_6Tex_006E00" Format="ci8" Width="32" Height="32" Offset="0x6E00" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_6Tex_007200" OutName="ganon_room_6Tex_007200" Format="ci8" Width="32" Height="32" Offset="0x7200" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_6Tex_007600" OutName="ganon_room_6Tex_007600" Format="ci8" Width="32" Height="32" Offset="0x7600" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_6Tex_007A00" OutName="ganon_room_6Tex_007A00" Format="ci8" Width="32" Height="64" Offset="0x7A00" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_6Tex_008200" OutName="ganon_room_6Tex_008200" Format="ci8" Width="16" Height="16" Offset="0x8200" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEBE0" AddedByScript="true"/>
+        <Texture Name="ganon_room_6Tex_008300" OutName="ganon_room_6Tex_008300" Format="ci8" Width="32" Height="64" Offset="0x8300" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_6Tex_008B00" OutName="ganon_room_6Tex_008B00" Format="ci8" Width="32" Height="32" Offset="0x8B00" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEBE0" AddedByScript="true"/>
+        <Texture Name="ganon_room_6Tex_009398" OutName="ganon_room_6Tex_009398" Format="rgba16" Width="32" Height="32" Offset="0x9398" AddedByScript="true"/>
         <Room Name="ganon_room_6" Offset="0x0"/>
     </File>
     <File Name="ganon_room_7" Segment="3">
+        <Texture Name="ganon_room_7Tex_0071E0" OutName="ganon_room_7Tex_0071E0" Format="ci8" Width="32" Height="32" Offset="0x71E0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_7Tex_0075E0" OutName="ganon_room_7Tex_0075E0" Format="ci8" Width="64" Height="32" Offset="0x75E0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_7Tex_007DE0" OutName="ganon_room_7Tex_007DE0" Format="ci8" Width="64" Height="32" Offset="0x7DE0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_7Tex_0085E0" OutName="ganon_room_7Tex_0085E0" Format="ci8" Width="32" Height="32" Offset="0x85E0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_7Tex_0089E0" OutName="ganon_room_7Tex_0089E0" Format="ci8" Width="32" Height="64" Offset="0x89E0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_7Tex_0091E0" OutName="ganon_room_7Tex_0091E0" Format="ci8" Width="32" Height="64" Offset="0x91E0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_7Tex_009F98" OutName="ganon_room_7Tex_009F98" Format="rgba16" Width="32" Height="32" Offset="0x9F98" AddedByScript="true"/>
         <Room Name="ganon_room_7" Offset="0x0"/>
     </File>
     <File Name="ganon_room_8" Segment="3">
+        <Texture Name="ganon_room_8Tex_004A20" OutName="ganon_room_8Tex_004A20" Format="ci8" Width="32" Height="64" Offset="0x4A20" TlutOffset="0x4950" AddedByScript="true"/>
+        <Texture Name="ganon_room_8Tex_005220" OutName="ganon_room_8Tex_005220" Format="ci8" Width="16" Height="16" Offset="0x5220" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEBE0" AddedByScript="true"/>
+        <Texture Name="ganon_room_8Tex_005320" OutName="ganon_room_8Tex_005320" Format="ci8" Width="8" Height="8" Offset="0x5320" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEBE0" AddedByScript="true"/>
+        <Texture Name="ganon_room_8Tex_005360" OutName="ganon_room_8Tex_005360" Format="ci8" Width="16" Height="8" Offset="0x5360" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEBE0" AddedByScript="true"/>
+        <Texture Name="ganon_room_8Tex_0053E0" OutName="ganon_room_8Tex_0053E0" Format="ci8" Width="32" Height="64" Offset="0x53E0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE9D8" AddedByScript="true"/>
+        <Texture Name="ganon_room_8Tex_005BE0" OutName="ganon_room_8Tex_005BE0" Format="ci8" Width="32" Height="32" Offset="0x5BE0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEBE0" AddedByScript="true"/>
+        <Texture Name="ganon_room_8Tex_005FE0" OutName="ganon_room_8Tex_005FE0" Format="ci8" Width="32" Height="32" Offset="0x5FE0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_8Tex_0063E0" OutName="ganon_room_8Tex_0063E0" Format="ci8" Width="32" Height="64" Offset="0x63E0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_8TLUT_004950" OutName="ganon_room_8TLUT_004950" Format="rgba16" Width="16" Height="16" Offset="0x4950" AddedByScript="true"/>
         <Room Name="ganon_room_8" Offset="0x0"/>
     </File>
     <File Name="ganon_room_9" Segment="3">
+        <Texture Name="ganon_room_9Tex_002120" OutName="ganon_room_9Tex_002120" Format="ci8" Width="32" Height="64" Offset="0x2120" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE9D8" AddedByScript="true"/>
+        <Texture Name="ganon_room_9Tex_002920" OutName="ganon_room_9Tex_002920" Format="ci8" Width="32" Height="32" Offset="0x2920" TlutOffset="0x1F18" AddedByScript="true"/>
+        <Texture Name="ganon_room_9Tex_002D20" OutName="ganon_room_9Tex_002D20" Format="ci8" Width="32" Height="32" Offset="0x2D20" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEBE0" AddedByScript="true"/>
+        <Texture Name="ganon_room_9Tex_003120" OutName="ganon_room_9Tex_003120" Format="ci8" Width="32" Height="32" Offset="0x3120" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEBE0" AddedByScript="true"/>
+        <Texture Name="ganon_room_9Tex_003520" OutName="ganon_room_9Tex_003520" Format="ci8" Width="32" Height="32" Offset="0x3520" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEBE0" AddedByScript="true"/>
+        <Texture Name="ganon_room_9Tex_003920" OutName="ganon_room_9Tex_003920" Format="ci8" Width="32" Height="32" Offset="0x3920" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_9Tex_003D20" OutName="ganon_room_9Tex_003D20" Format="ci8" Width="32" Height="64" Offset="0x3D20" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE9D8" AddedByScript="true"/>
+        <Texture Name="ganon_room_9Tex_004520" OutName="ganon_room_9Tex_004520" Format="ci8" Width="32" Height="64" Offset="0x4520" TlutOffset="0x1F18" AddedByScript="true"/>
+        <Texture Name="ganon_room_9Tex_004D20" OutName="ganon_room_9Tex_004D20" Format="ci8" Width="16" Height="64" Offset="0x4D20" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEBE0" AddedByScript="true"/>
+        <Texture Name="ganon_room_9Tex_005120" OutName="ganon_room_9Tex_005120" Format="ci8" Width="32" Height="64" Offset="0x5120" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_9TLUT_001F18" OutName="ganon_room_9TLUT_001F18" Format="rgba16" Width="16" Height="16" Offset="0x1F18" AddedByScript="true"/>
         <Room Name="ganon_room_9" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/scenes/dungeons/ganon_boss.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/dungeons/ganon_boss.xml
@@ -1,5 +1,28 @@
 <Root>
     <File Name="ganon_boss_scene" Segment="2">
+        <Texture Name="ganon_boss_sceneTex_001E58" OutName="ganon_boss_sceneTex_001E58" Format="ci8" Width="32" Height="64" Offset="0x1E58" TlutOffset="0x1550" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_002658" OutName="ganon_boss_sceneTex_002658" Format="ci8" Width="16" Height="16" Offset="0x2658" TlutOffset="0x1A90" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_002758" OutName="ganon_boss_sceneTex_002758" Format="ci8" Width="8" Height="8" Offset="0x2758" TlutOffset="0x1A90" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_002798" OutName="ganon_boss_sceneTex_002798" Format="ci8" Width="32" Height="32" Offset="0x2798" TlutOffset="0x1C50" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_002B98" OutName="ganon_boss_sceneTex_002B98" Format="ci8" Width="16" Height="8" Offset="0x2B98" TlutOffset="0x1A90" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_002C18" OutName="ganon_boss_sceneTex_002C18" Format="rgba16" Width="32" Height="64" Offset="0x2C18" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_003C18" OutName="ganon_boss_sceneTex_003C18" Format="ci8" Width="32" Height="32" Offset="0x3C18" TlutOffset="0x1620" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_004018" OutName="ganon_boss_sceneTex_004018" Format="ci8" Width="32" Height="32" Offset="0x4018" TlutOffset="0x1888" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_004418" OutName="ganon_boss_sceneTex_004418" Format="ci8" Width="32" Height="32" Offset="0x4418" TlutOffset="0x1A90" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_004818" OutName="ganon_boss_sceneTex_004818" Format="ci8" Width="32" Height="32" Offset="0x4818" TlutOffset="0x1A90" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_004C18" OutName="ganon_boss_sceneTex_004C18" Format="ci8" Width="32" Height="32" Offset="0x4C18" TlutOffset="0x1A90" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_005018" OutName="ganon_boss_sceneTex_005018" Format="rgba16" Width="32" Height="32" Offset="0x5018" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_005818" OutName="ganon_boss_sceneTex_005818" Format="ci8" Width="32" Height="64" Offset="0x5818" TlutOffset="0x1888" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_006018" OutName="ganon_boss_sceneTex_006018" Format="ci8" Width="16" Height="64" Offset="0x6018" TlutOffset="0x1A90" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_006418" OutName="ganon_boss_sceneTex_006418" Format="ci8" Width="32" Height="64" Offset="0x6418" TlutOffset="0x1C50" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_006C18" OutName="ganon_boss_sceneTex_006C18" Format="ci8" Width="32" Height="64" Offset="0x6C18" TlutOffset="0x1680" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_007418" OutName="ganon_boss_sceneTex_007418" Format="ci8" Width="32" Height="64" Offset="0x7418" TlutOffset="0x1680" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTLUT_001550" OutName="ganon_boss_sceneTLUT_001550" Format="rgba16" Width="16" Height="16" Offset="0x1550" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTLUT_001620" OutName="ganon_boss_sceneTLUT_001620" Format="rgba16" Width="16" Height="16" Offset="0x1620" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTLUT_001680" OutName="ganon_boss_sceneTLUT_001680" Format="rgba16" Width="16" Height="16" Offset="0x1680" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTLUT_001888" OutName="ganon_boss_sceneTLUT_001888" Format="rgba16" Width="16" Height="16" Offset="0x1888" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTLUT_001A90" OutName="ganon_boss_sceneTLUT_001A90" Format="rgba16" Width="16" Height="16" Offset="0x1A90" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTLUT_001C50" OutName="ganon_boss_sceneTLUT_001C50" Format="rgba16" Width="16" Height="16" Offset="0x1C50" AddedByScript="true"/>
         <Scene Name="ganon_boss_scene" Offset="0x0"/>
     </File>
     <File Name="ganon_boss_room_0" Segment="3">

--- a/soh/assets/xml/GC_NMQ_D/scenes/dungeons/ganon_demo.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/dungeons/ganon_demo.xml
@@ -1,5 +1,16 @@
 <Root>
     <File Name="ganon_demo_scene" Segment="2">
+        <Texture Name="ganon_demo_sceneTex_001B70" OutName="ganon_demo_sceneTex_001B70" Format="i8" Width="128" Height="32" Offset="0x1B70" AddedByScript="true"/>
+        <Texture Name="ganon_demo_sceneTex_002B70" OutName="ganon_demo_sceneTex_002B70" Format="i8" Width="64" Height="64" Offset="0x2B70" AddedByScript="true"/>
+        <Texture Name="ganon_demo_sceneTex_003B70" OutName="ganon_demo_sceneTex_003B70" Format="i8" Width="64" Height="64" Offset="0x3B70" AddedByScript="true"/>
+        <Texture Name="ganon_demo_sceneTex_004B70" OutName="ganon_demo_sceneTex_004B70" Format="i8" Width="64" Height="64" Offset="0x4B70" AddedByScript="true"/>
+        <Texture Name="ganon_demo_sceneTex_005B70" OutName="ganon_demo_sceneTex_005B70" Format="rgba16" Width="64" Height="16" Offset="0x5B70" AddedByScript="true"/>
+        <Texture Name="ganon_demo_sceneTex_006370" OutName="ganon_demo_sceneTex_006370" Format="rgba16" Width="32" Height="32" Offset="0x6370" AddedByScript="true"/>
+        <Texture Name="ganon_demo_sceneTex_006B70" OutName="ganon_demo_sceneTex_006B70" Format="ia4" Width="128" Height="32" Offset="0x6B70" AddedByScript="true"/>
+        <Texture Name="ganon_demo_sceneTex_007370" OutName="ganon_demo_sceneTex_007370" Format="rgba16" Width="32" Height="64" Offset="0x7370" AddedByScript="true"/>
+        <Texture Name="ganon_demo_sceneTex_008370" OutName="ganon_demo_sceneTex_008370" Format="rgba16" Width="16" Height="32" Offset="0x8370" AddedByScript="true"/>
+        <Texture Name="ganon_demo_sceneTex_008770" OutName="ganon_demo_sceneTex_008770" Format="i8" Width="16" Height="16" Offset="0x8770" AddedByScript="true"/>
+        <Texture Name="ganon_demo_sceneTex_008870" OutName="ganon_demo_sceneTex_008870" Format="rgba16" Width="32" Height="32" Offset="0x8870" AddedByScript="true"/>
         <Scene Name="ganon_demo_scene" Offset="0x0"/>
     </File>
     <File Name="ganon_demo_room_0" Segment="3">

--- a/soh/assets/xml/GC_NMQ_D/scenes/dungeons/ganon_final.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/dungeons/ganon_final.xml
@@ -1,5 +1,30 @@
 <Root>
     <File Name="ganon_final_scene" Segment="2">
+        <Texture Name="ganon_final_sceneTex_002380" OutName="ganon_final_sceneTex_002380" Format="ia8" Width="32" Height="32" Offset="0x2380" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_002780" OutName="ganon_final_sceneTex_002780" Format="rgba16" Width="16" Height="16" Offset="0x2780" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_002980" OutName="ganon_final_sceneTex_002980" Format="i8" Width="64" Height="16" Offset="0x2980" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_002D80" OutName="ganon_final_sceneTex_002D80" Format="i4" Width="64" Height="128" Offset="0x2D80" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_003D80" OutName="ganon_final_sceneTex_003D80" Format="i8" Width="32" Height="64" Offset="0x3D80" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_004580" OutName="ganon_final_sceneTex_004580" Format="i8" Width="32" Height="64" Offset="0x4580" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_004D80" OutName="ganon_final_sceneTex_004D80" Format="i8" Width="64" Height="64" Offset="0x4D80" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_005D80" OutName="ganon_final_sceneTex_005D80" Format="i4" Width="64" Height="128" Offset="0x5D80" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_006D80" OutName="ganon_final_sceneTex_006D80" Format="ia8" Width="64" Height="32" Offset="0x6D80" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_007580" OutName="ganon_final_sceneTex_007580" Format="i4" Width="64" Height="128" Offset="0x7580" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_008580" OutName="ganon_final_sceneTex_008580" Format="rgba16" Width="32" Height="64" Offset="0x8580" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_009580" OutName="ganon_final_sceneTex_009580" Format="rgba16" Width="32" Height="64" Offset="0x9580" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_00A580" OutName="ganon_final_sceneTex_00A580" Format="ia4" Width="128" Height="32" Offset="0xA580" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_00AD80" OutName="ganon_final_sceneTex_00AD80" Format="rgba16" Width="32" Height="64" Offset="0xAD80" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_00BD80" OutName="ganon_final_sceneTex_00BD80" Format="rgba16" Width="32" Height="64" Offset="0xBD80" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_00CD80" OutName="ganon_final_sceneTex_00CD80" Format="i8" Width="16" Height="16" Offset="0xCD80" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_00CE80" OutName="ganon_final_sceneTex_00CE80" Format="ia8" Width="64" Height="64" Offset="0xCE80" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_00DE80" OutName="ganon_final_sceneTex_00DE80" Format="i4" Width="64" Height="16" Offset="0xDE80" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_00E080" OutName="ganon_final_sceneTex_00E080" Format="ia8" Width="16" Height="16" Offset="0xE080" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_00E180" OutName="ganon_final_sceneTex_00E180" Format="i4" Width="128" Height="64" Offset="0xE180" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_00F180" OutName="ganon_final_sceneTex_00F180" Format="i8" Width="32" Height="32" Offset="0xF180" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_00F580" OutName="ganon_final_sceneTex_00F580" Format="i8" Width="128" Height="32" Offset="0xF580" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_010580" OutName="ganon_final_sceneTex_010580" Format="i8" Width="32" Height="32" Offset="0x10580" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_010980" OutName="ganon_final_sceneTex_010980" Format="rgba16" Width="16" Height="64" Offset="0x10980" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_011180" OutName="ganon_final_sceneTex_011180" Format="i8" Width="16" Height="256" Offset="0x11180" AddedByScript="true"/>
         <Path Name="gGanonFinalPath_001F4" Offset="0x1F4" NumPaths="4"/>
         <Scene Name="ganon_final_scene" Offset="0x0"/>
     </File>

--- a/soh/assets/xml/GC_NMQ_D/scenes/dungeons/ganon_sonogo.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/dungeons/ganon_sonogo.xml
@@ -1,21 +1,72 @@
 <Root>
     <File Name="ganon_sonogo_scene" Segment="2">
+        <Texture Name="ganon_sonogo_sceneTex_006710" OutName="ganon_sonogo_sceneTex_006710" Format="ci8" Width="32" Height="64" Offset="0x6710" TlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_sceneTex_006F10" OutName="ganon_sonogo_sceneTex_006F10" Format="ci8" Width="32" Height="32" Offset="0x6F10" TlutOffset="0x6508" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_sceneTex_007310" OutName="ganon_sonogo_sceneTex_007310" Format="ci8" Width="32" Height="32" Offset="0x7310" TlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_sceneTex_007710" OutName="ganon_sonogo_sceneTex_007710" Format="ia16" Width="32" Height="32" Offset="0x7710" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_sceneTLUT_006300" OutName="ganon_sonogo_sceneTLUT_006300" Format="rgba16" Width="16" Height="16" Offset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_sceneTLUT_006508" OutName="ganon_sonogo_sceneTLUT_006508" Format="rgba16" Width="16" Height="16" Offset="0x6508" AddedByScript="true"/>
         <Path Name="gGanonSonogoPath_00254" Offset="0x254" NumPaths="5"/>
         <Scene Name="ganon_sonogo_scene" Offset="0x0"/>
     </File>
     <File Name="ganon_sonogo_room_0" Segment="3">
+        <Texture Name="ganon_sonogo_room_0Tex_005020" OutName="ganon_sonogo_room_0Tex_005020" Format="ci8" Width="32" Height="64" Offset="0x5020" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_0Tex_005820" OutName="ganon_sonogo_room_0Tex_005820" Format="ci8" Width="32" Height="32" Offset="0x5820" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_0Tex_005C20" OutName="ganon_sonogo_room_0Tex_005C20" Format="ci8" Width="32" Height="32" Offset="0x5C20" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_0Tex_006020" OutName="ganon_sonogo_room_0Tex_006020" Format="ci8" Width="64" Height="32" Offset="0x6020" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_0Tex_006820" OutName="ganon_sonogo_room_0Tex_006820" Format="ci8" Width="64" Height="32" Offset="0x6820" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_0Tex_007020" OutName="ganon_sonogo_room_0Tex_007020" Format="ci8" Width="32" Height="32" Offset="0x7020" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_0Tex_007420" OutName="ganon_sonogo_room_0Tex_007420" Format="ci8" Width="32" Height="32" Offset="0x7420" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_0Tex_007820" OutName="ganon_sonogo_room_0Tex_007820" Format="ci8" Width="32" Height="32" Offset="0x7820" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
         <Room Name="ganon_sonogo_room_0" Offset="0x0"/>
     </File>
     <File Name="ganon_sonogo_room_1" Segment="3">
+        <Texture Name="ganon_sonogo_room_1Tex_004148" OutName="ganon_sonogo_room_1Tex_004148" Format="ci8" Width="32" Height="32" Offset="0x4148" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_1Tex_004548" OutName="ganon_sonogo_room_1Tex_004548" Format="ci8" Width="32" Height="32" Offset="0x4548" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_1Tex_004948" OutName="ganon_sonogo_room_1Tex_004948" Format="ci8" Width="32" Height="32" Offset="0x4948" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_1Tex_004D48" OutName="ganon_sonogo_room_1Tex_004D48" Format="ci8" Width="32" Height="64" Offset="0x4D48" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_1Tex_005548" OutName="ganon_sonogo_room_1Tex_005548" Format="ci8" Width="32" Height="32" Offset="0x5548" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_1Tex_005948" OutName="ganon_sonogo_room_1Tex_005948" Format="ci8" Width="32" Height="32" Offset="0x5948" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_1Tex_005D48" OutName="ganon_sonogo_room_1Tex_005D48" Format="ci8" Width="32" Height="64" Offset="0x5D48" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_1Tex_006548" OutName="ganon_sonogo_room_1Tex_006548" Format="ci8" Width="32" Height="32" Offset="0x6548" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_1Tex_006948" OutName="ganon_sonogo_room_1Tex_006948" Format="rgba16" Width="32" Height="64" Offset="0x6948" AddedByScript="true"/>
         <Room Name="ganon_sonogo_room_1" Offset="0x0"/>
     </File>
     <File Name="ganon_sonogo_room_2" Segment="3">
+        <Texture Name="ganon_sonogo_room_2Tex_004A40" OutName="ganon_sonogo_room_2Tex_004A40" Format="ci8" Width="32" Height="64" Offset="0x4A40" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_2Tex_005240" OutName="ganon_sonogo_room_2Tex_005240" Format="ci8" Width="32" Height="32" Offset="0x5240" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_2Tex_005640" OutName="ganon_sonogo_room_2Tex_005640" Format="ci8" Width="32" Height="32" Offset="0x5640" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_2Tex_005A40" OutName="ganon_sonogo_room_2Tex_005A40" Format="ci8" Width="32" Height="64" Offset="0x5A40" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_2Tex_006240" OutName="ganon_sonogo_room_2Tex_006240" Format="ci8" Width="32" Height="32" Offset="0x6240" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_2Tex_006640" OutName="ganon_sonogo_room_2Tex_006640" Format="ci8" Width="32" Height="32" Offset="0x6640" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_2Tex_006A40" OutName="ganon_sonogo_room_2Tex_006A40" Format="ci8" Width="32" Height="32" Offset="0x6A40" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_2Tex_006E40" OutName="ganon_sonogo_room_2Tex_006E40" Format="ci8" Width="32" Height="32" Offset="0x6E40" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_2Tex_007240" OutName="ganon_sonogo_room_2Tex_007240" Format="ci8" Width="32" Height="64" Offset="0x7240" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_2Tex_007A40" OutName="ganon_sonogo_room_2Tex_007A40" Format="ci8" Width="32" Height="64" Offset="0x7A40" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_2Tex_008240" OutName="ganon_sonogo_room_2Tex_008240" Format="ci8" Width="32" Height="64" Offset="0x8240" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
         <Room Name="ganon_sonogo_room_2" Offset="0x0"/>
     </File>
     <File Name="ganon_sonogo_room_3" Segment="3">
+        <Texture Name="ganon_sonogo_room_3Tex_003A38" OutName="ganon_sonogo_room_3Tex_003A38" Format="ci8" Width="32" Height="32" Offset="0x3A38" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_3Tex_003E38" OutName="ganon_sonogo_room_3Tex_003E38" Format="ci8" Width="64" Height="32" Offset="0x3E38" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_3Tex_004638" OutName="ganon_sonogo_room_3Tex_004638" Format="ci8" Width="64" Height="32" Offset="0x4638" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_3Tex_004E38" OutName="ganon_sonogo_room_3Tex_004E38" Format="ci8" Width="32" Height="64" Offset="0x4E38" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
         <Room Name="ganon_sonogo_room_3" Offset="0x0"/>
     </File>
     <File Name="ganon_sonogo_room_4" Segment="3">
+        <Texture Name="ganon_sonogo_room_4Tex_004BA8" OutName="ganon_sonogo_room_4Tex_004BA8" Format="ci8" Width="32" Height="64" Offset="0x4BA8" TlutOffset="0x4840" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_4Tex_0053A8" OutName="ganon_sonogo_room_4Tex_0053A8" Format="ci8" Width="16" Height="16" Offset="0x53A8" TlutOffset="0x4B18" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_4Tex_0054A8" OutName="ganon_sonogo_room_4Tex_0054A8" Format="ci8" Width="8" Height="8" Offset="0x54A8" TlutOffset="0x4B18" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_4Tex_0054E8" OutName="ganon_sonogo_room_4Tex_0054E8" Format="rgba16" Width="32" Height="32" Offset="0x54E8" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_4Tex_005CE8" OutName="ganon_sonogo_room_4Tex_005CE8" Format="ci8" Width="32" Height="64" Offset="0x5CE8" TlutOffset="0x4910" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_4Tex_0064E8" OutName="ganon_sonogo_room_4Tex_0064E8" Format="ci8" Width="32" Height="32" Offset="0x64E8" TlutOffset="0x4B18" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_4Tex_0068E8" OutName="ganon_sonogo_room_4Tex_0068E8" Format="ci8" Width="32" Height="32" Offset="0x68E8" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_4Tex_006CE8" OutName="ganon_sonogo_room_4Tex_006CE8" Format="rgba16" Width="32" Height="32" Offset="0x6CE8" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_4Tex_0074E8" OutName="ganon_sonogo_room_4Tex_0074E8" Format="ci8" Width="32" Height="64" Offset="0x74E8" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_4Tex_007CE8" OutName="ganon_sonogo_room_4Tex_007CE8" Format="rgba16" Width="32" Height="64" Offset="0x7CE8" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_4TLUT_004840" OutName="ganon_sonogo_room_4TLUT_004840" Format="rgba16" Width="16" Height="16" Offset="0x4840" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_4TLUT_004910" OutName="ganon_sonogo_room_4TLUT_004910" Format="rgba16" Width="16" Height="16" Offset="0x4910" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_4TLUT_004B18" OutName="ganon_sonogo_room_4TLUT_004B18" Format="rgba16" Width="16" Height="16" Offset="0x4B18" AddedByScript="true"/>
         <Room Name="ganon_sonogo_room_4" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/scenes/dungeons/ganon_tou.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/dungeons/ganon_tou.xml
@@ -1,10 +1,34 @@
 <Root>
     <File Name="ganon_tou_scene" Segment="2">
+        <Texture Name="ganon_tou_sceneTex_003280" OutName="ganon_tou_sceneTex_003280" Format="i8" Width="64" Height="64" Offset="0x3280" AddedByScript="true"/>
         <Cutscene Name="gRainbowBridgeCs" Offset="0x2640"/>
         <Cutscene Name="gGanonsCastleIntroCs" Offset="0x4280"/>
         <Scene Name="ganon_tou_scene" Offset="0x0"/>
     </File>
     <File Name="ganon_tou_room_0" Segment="3">
+        <Texture Name="ganon_tou_room_0Tex_008550" OutName="ganon_tou_room_0Tex_008550" Format="rgba16" Width="32" Height="32" Offset="0x8550" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_008D50" OutName="ganon_tou_room_0Tex_008D50" Format="rgba16" Width="16" Height="16" Offset="0x8D50" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_008F50" OutName="ganon_tou_room_0Tex_008F50" Format="rgba16" Width="32" Height="8" Offset="0x8F50" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_009150" OutName="ganon_tou_room_0Tex_009150" Format="rgba16" Width="64" Height="32" Offset="0x9150" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_00A150" OutName="ganon_tou_room_0Tex_00A150" Format="rgba16" Width="128" Height="16" Offset="0xA150" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_00B150" OutName="ganon_tou_room_0Tex_00B150" Format="rgba16" Width="32" Height="16" Offset="0xB150" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_00B550" OutName="ganon_tou_room_0Tex_00B550" Format="i8" Width="32" Height="32" Offset="0xB550" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_00B950" OutName="ganon_tou_room_0Tex_00B950" Format="i8" Width="32" Height="32" Offset="0xB950" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_00BD50" OutName="ganon_tou_room_0Tex_00BD50" Format="rgba16" Width="16" Height="16" Offset="0xBD50" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_00BF50" OutName="ganon_tou_room_0Tex_00BF50" Format="i8" Width="64" Height="64" Offset="0xBF50" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_00CF50" OutName="ganon_tou_room_0Tex_00CF50" Format="rgba16" Width="32" Height="32" Offset="0xCF50" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_00D750" OutName="ganon_tou_room_0Tex_00D750" Format="rgba16" Width="32" Height="64" Offset="0xD750" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_00E750" OutName="ganon_tou_room_0Tex_00E750" Format="rgba16" Width="32" Height="64" Offset="0xE750" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_00F750" OutName="ganon_tou_room_0Tex_00F750" Format="i8" Width="32" Height="32" Offset="0xF750" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_00FB50" OutName="ganon_tou_room_0Tex_00FB50" Format="i8" Width="64" Height="16" Offset="0xFB50" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_00FF50" OutName="ganon_tou_room_0Tex_00FF50" Format="rgba16" Width="16" Height="16" Offset="0xFF50" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_010150" OutName="ganon_tou_room_0Tex_010150" Format="rgba16" Width="32" Height="16" Offset="0x10150" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_010550" OutName="ganon_tou_room_0Tex_010550" Format="rgba16" Width="32" Height="32" Offset="0x10550" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_0124F0" OutName="ganon_tou_room_0Tex_0124F0" Format="ia8" Width="32" Height="8" Offset="0x124F0" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_0125F0" OutName="ganon_tou_room_0Tex_0125F0" Format="ia4" Width="128" Height="32" Offset="0x125F0" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_012DF0" OutName="ganon_tou_room_0Tex_012DF0" Format="i4" Width="64" Height="64" Offset="0x12DF0" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_0135F0" OutName="ganon_tou_room_0Tex_0135F0" Format="ia8" Width="32" Height="32" Offset="0x135F0" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_0139F0" OutName="ganon_tou_room_0Tex_0139F0" Format="ia8" Width="16" Height="16" Offset="0x139F0" AddedByScript="true"/>
         <Room Name="ganon_tou_room_0" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/scenes/dungeons/ganontika.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/dungeons/ganontika.xml
@@ -1,5 +1,11 @@
 <Root>
     <File Name="ganontika_scene" Segment="2">
+        <Texture Name="ganontika_sceneTex_01F580" OutName="ganontika_sceneTex_01F580" Format="rgba16" Width="16" Height="16" Offset="0x1F570" AddedByScript="true"/>
+        <Texture Name="ganontika_sceneTex_01F780" OutName="ganontika_sceneTex_01F780" Format="ci8" Width="32" Height="64" Offset="0x1F770" TlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_sceneTex_01FF80" OutName="ganontika_sceneTex_01FF80" Format="ci8" Width="32" Height="32" Offset="0x1FF70" TlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_sceneTex_020380" OutName="ganontika_sceneTex_020380" Format="ci8" Width="64" Height="32" Offset="0x20370" TlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_sceneTex_020B80" OutName="ganontika_sceneTex_020B80" Format="rgba16" Width="32" Height="32" Offset="0x20B70" AddedByScript="true"/>
+        <Texture Name="ganontika_sceneTLUT_01F380" OutName="ganontika_sceneTLUT_01F380" Format="rgba16" Width="16" Height="16" Offset="0x1F370" AddedByScript="true"/>
         <Path Name="gGanontikaPath_00674" Offset="0x674" NumPaths="3"/>
         <Cutscene Name="gForestTrialSageCs" Offset="0x19ED0"/>
         <Cutscene Name="gWaterTrialSageCs" Offset="0x1A8D0"/>
@@ -20,63 +26,229 @@
         <Scene Name="ganontika_scene" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_0" Segment="3">
+        <Texture Name="ganontika_room_0Tex_007F48" OutName="ganontika_room_0Tex_007F48" Format="ci8" Width="64" Height="32" Offset="0x7EF8" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_0Tex_008A10" OutName="ganontika_room_0Tex_008A10" Format="ia16" Width="8" Height="128" Offset="0x89C0" AddedByScript="true"/>
         <Room Name="ganontika_room_0" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_1" Segment="3">
+        <Texture Name="ganontika_room_1Tex_00D9E0" OutName="ganontika_room_1Tex_00D9E0" Format="i4" Width="128" Height="64" Offset="0xD9C0" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_00E9E0" OutName="ganontika_room_1Tex_00E9E0" Format="i4" Width="128" Height="64" Offset="0xE9C0" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_00F9E0" OutName="ganontika_room_1Tex_00F9E0" Format="i4" Width="128" Height="64" Offset="0xF9C0" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0109E0" OutName="ganontika_room_1Tex_0109E0" Format="rgba16" Width="64" Height="32" Offset="0x109C0" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0119E0" OutName="ganontika_room_1Tex_0119E0" Format="ci8" Width="32" Height="64" Offset="0x119C0" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0121E0" OutName="ganontika_room_1Tex_0121E0" Format="ci8" Width="64" Height="32" Offset="0x121C0" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0129E0" OutName="ganontika_room_1Tex_0129E0" Format="ci8" Width="32" Height="64" Offset="0x129C0" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0131E0" OutName="ganontika_room_1Tex_0131E0" Format="ci8" Width="64" Height="32" Offset="0x131C0" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0139E0" OutName="ganontika_room_1Tex_0139E0" Format="ci8" Width="64" Height="32" Offset="0x139C0" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0141E0" OutName="ganontika_room_1Tex_0141E0" Format="ci8" Width="64" Height="32" Offset="0x141C0" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0149E0" OutName="ganontika_room_1Tex_0149E0" Format="ci8" Width="64" Height="32" Offset="0x149C0" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0151E0" OutName="ganontika_room_1Tex_0151E0" Format="ci8" Width="32" Height="64" Offset="0x151C0" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0159E0" OutName="ganontika_room_1Tex_0159E0" Format="ci4" Width="64" Height="64" Offset="0x159C0" TlutOffset="0xD9A0" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0161E0" OutName="ganontika_room_1Tex_0161E0" Format="ci4" Width="64" Height="64" Offset="0x161C0" TlutOffset="0xD9A0" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0169E0" OutName="ganontika_room_1Tex_0169E0" Format="ci4" Width="64" Height="64" Offset="0x169C0" TlutOffset="0xD9A0" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0171E0" OutName="ganontika_room_1Tex_0171E0" Format="ci4" Width="64" Height="64" Offset="0x171C0" TlutOffset="0xD9A0" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0179E0" OutName="ganontika_room_1Tex_0179E0" Format="ci4" Width="64" Height="64" Offset="0x179C0" TlutOffset="0xD9A0" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0181E0" OutName="ganontika_room_1Tex_0181E0" Format="ci4" Width="64" Height="64" Offset="0x181C0" TlutOffset="0xD9A0" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0189E0" OutName="ganontika_room_1Tex_0189E0" Format="rgba16" Width="64" Height="32" Offset="0x189C0" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0199E0" OutName="ganontika_room_1Tex_0199E0" Format="ci8" Width="64" Height="16" Offset="0x199C0" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_019DE0" OutName="ganontika_room_1Tex_019DE0" Format="ci8" Width="64" Height="32" Offset="0x19DC0" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_01B9C8" OutName="ganontika_room_1Tex_01B9C8" Format="ia8" Width="64" Height="64" Offset="0x1B9A8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1TLUT_00D9C0" OutName="ganontika_room_1TLUT_00D9C0" Format="rgba16" Width="4" Height="4" Offset="0xD9A0" AddedByScript="true"/>
         <Room Name="ganontika_room_1" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_2" Segment="3">
+        <Texture Name="ganontika_room_2Tex_002FD8" OutName="ganontika_room_2Tex_002FD8" Format="rgba16" Width="32" Height="32" Offset="0x2FD8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_2Tex_0037D8" OutName="ganontika_room_2Tex_0037D8" Format="rgba16" Width="32" Height="32" Offset="0x37D8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_2Tex_003FD8" OutName="ganontika_room_2Tex_003FD8" Format="rgba16" Width="32" Height="32" Offset="0x3FD8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_2Tex_0047D8" OutName="ganontika_room_2Tex_0047D8" Format="rgba16" Width="32" Height="32" Offset="0x47D8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_2Tex_004FD8" OutName="ganontika_room_2Tex_004FD8" Format="rgba16" Width="32" Height="32" Offset="0x4FD8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_2Tex_0057D8" OutName="ganontika_room_2Tex_0057D8" Format="rgba16" Width="32" Height="32" Offset="0x57D8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_2Tex_005FD8" OutName="ganontika_room_2Tex_005FD8" Format="ci8" Width="64" Height="32" Offset="0x5FD8" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_2Tex_0067D8" OutName="ganontika_room_2Tex_0067D8" Format="rgba16" Width="64" Height="32" Offset="0x67D8" AddedByScript="true"/>
         <Room Name="ganontika_room_2" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_3" Segment="3">
+        <Texture Name="ganontika_room_3Tex_003ED8" OutName="ganontika_room_3Tex_003ED8" Format="rgba16" Width="32" Height="32" Offset="0x3E28" AddedByScript="true"/>
+        <Texture Name="ganontika_room_3Tex_0046D8" OutName="ganontika_room_3Tex_0046D8" Format="rgba16" Width="32" Height="32" Offset="0x4628" AddedByScript="true"/>
+        <Texture Name="ganontika_room_3Tex_004ED8" OutName="ganontika_room_3Tex_004ED8" Format="rgba16" Width="32" Height="32" Offset="0x4E28" AddedByScript="true"/>
+        <Texture Name="ganontika_room_3Tex_0056D8" OutName="ganontika_room_3Tex_0056D8" Format="rgba16" Width="32" Height="32" Offset="0x5628" AddedByScript="true"/>
+        <Texture Name="ganontika_room_3Tex_005ED8" OutName="ganontika_room_3Tex_005ED8" Format="rgba16" Width="32" Height="32" Offset="0x5E28" AddedByScript="true"/>
+        <Texture Name="ganontika_room_3Tex_0066D8" OutName="ganontika_room_3Tex_0066D8" Format="rgba16" Width="32" Height="32" Offset="0x6628" AddedByScript="true"/>
+        <Texture Name="ganontika_room_3Tex_006ED8" OutName="ganontika_room_3Tex_006ED8" Format="ci4" Width="64" Height="64" Offset="0x6E28" TlutOffset="0x3E08" AddedByScript="true"/>
+        <Texture Name="ganontika_room_3Tex_0076D8" OutName="ganontika_room_3Tex_0076D8" Format="rgba16" Width="64" Height="32" Offset="0x7628" AddedByScript="true"/>
+        <Texture Name="ganontika_room_3Tex_008A38" OutName="ganontika_room_3Tex_008A38" Format="ia8" Width="64" Height="64" Offset="0x8988" AddedByScript="true"/>
+        <Texture Name="ganontika_room_3TLUT_003EB8" OutName="ganontika_room_3TLUT_003EB8" Format="rgba16" Width="4" Height="4" Offset="0x3E08" AddedByScript="true"/>
         <Room Name="ganontika_room_3" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_4" Segment="3">
+        <Texture Name="ganontika_room_4Tex_004288" OutName="ganontika_room_4Tex_004288" Format="rgba16" Width="32" Height="32" Offset="0x4288" AddedByScript="true"/>
+        <Texture Name="ganontika_room_4Tex_004A88" OutName="ganontika_room_4Tex_004A88" Format="ci8" Width="32" Height="64" Offset="0x4A88" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_4Tex_005288" OutName="ganontika_room_4Tex_005288" Format="ci8" Width="64" Height="32" Offset="0x5288" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_4Tex_005A88" OutName="ganontika_room_4Tex_005A88" Format="rgba16" Width="32" Height="32" Offset="0x5A88" AddedByScript="true"/>
+        <Texture Name="ganontika_room_4Tex_006288" OutName="ganontika_room_4Tex_006288" Format="rgba16" Width="32" Height="32" Offset="0x6288" AddedByScript="true"/>
+        <Texture Name="ganontika_room_4Tex_006A88" OutName="ganontika_room_4Tex_006A88" Format="rgba16" Width="16" Height="16" Offset="0x6A88" AddedByScript="true"/>
+        <Texture Name="ganontika_room_4Tex_006C88" OutName="ganontika_room_4Tex_006C88" Format="rgba16" Width="64" Height="32" Offset="0x6C88" AddedByScript="true"/>
         <Room Name="ganontika_room_4" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_5" Segment="3">
+        <Texture Name="ganontika_room_5Tex_003B18" OutName="ganontika_room_5Tex_003B18" Format="rgba16" Width="16" Height="16" Offset="0x3B38" AddedByScript="true"/>
+        <Texture Name="ganontika_room_5Tex_003D18" OutName="ganontika_room_5Tex_003D18" Format="ci8" Width="32" Height="64" Offset="0x3D38" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_5Tex_004518" OutName="ganontika_room_5Tex_004518" Format="rgba16" Width="32" Height="32" Offset="0x4538" AddedByScript="true"/>
+        <Texture Name="ganontika_room_5Tex_004D18" OutName="ganontika_room_5Tex_004D18" Format="ci8" Width="64" Height="32" Offset="0x4D38" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_5Tex_005518" OutName="ganontika_room_5Tex_005518" Format="rgba16" Width="32" Height="32" Offset="0x5538" AddedByScript="true"/>
+        <Texture Name="ganontika_room_5Tex_005D18" OutName="ganontika_room_5Tex_005D18" Format="ci8" Width="64" Height="32" Offset="0x5D38" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_5Tex_006518" OutName="ganontika_room_5Tex_006518" Format="rgba16" Width="64" Height="32" Offset="0x6538" AddedByScript="true"/>
         <Room Name="ganontika_room_5" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_6" Segment="3">
+        <Texture Name="ganontika_room_6Tex_00B500" OutName="ganontika_room_6Tex_00B500" Format="ci8" Width="32" Height="32" Offset="0xB490" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_6Tex_00B900" OutName="ganontika_room_6Tex_00B900" Format="ci8" Width="32" Height="64" Offset="0xB890" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_6Tex_00C100" OutName="ganontika_room_6Tex_00C100" Format="ci8" Width="64" Height="32" Offset="0xC090" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_6Tex_00C900" OutName="ganontika_room_6Tex_00C900" Format="i4" Width="32" Height="32" Offset="0xC890" AddedByScript="true"/>
+        <Texture Name="ganontika_room_6Tex_00CB00" OutName="ganontika_room_6Tex_00CB00" Format="i4" Width="32" Height="32" Offset="0xCA90" AddedByScript="true"/>
+        <Texture Name="ganontika_room_6Tex_00CD00" OutName="ganontika_room_6Tex_00CD00" Format="i4" Width="32" Height="32" Offset="0xCC90" AddedByScript="true"/>
+        <Texture Name="ganontika_room_6Tex_00CF00" OutName="ganontika_room_6Tex_00CF00" Format="ci4" Width="64" Height="64" Offset="0xCE90" TlutOffset="0xB470" AddedByScript="true"/>
+        <Texture Name="ganontika_room_6Tex_00D700" OutName="ganontika_room_6Tex_00D700" Format="i4" Width="32" Height="32" Offset="0xD690" AddedByScript="true"/>
+        <Texture Name="ganontika_room_6Tex_00D900" OutName="ganontika_room_6Tex_00D900" Format="rgba16" Width="64" Height="32" Offset="0xD890" AddedByScript="true"/>
+        <Texture Name="ganontika_room_6Tex_00EC58" OutName="ganontika_room_6Tex_00EC58" Format="ia8" Width="64" Height="64" Offset="0xEBE8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_6TLUT_00B4E0" OutName="ganontika_room_6TLUT_00B4E0" Format="rgba16" Width="4" Height="4" Offset="0xB470" AddedByScript="true"/>
         <Room Name="ganontika_room_6" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_7" Segment="3">
+        <Texture Name="ganontika_room_7Tex_004288" OutName="ganontika_room_7Tex_004288" Format="rgba16" Width="32" Height="32" Offset="0x4288" AddedByScript="true"/>
+        <Texture Name="ganontika_room_7Tex_004A88" OutName="ganontika_room_7Tex_004A88" Format="ci8" Width="32" Height="64" Offset="0x4A88" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_7Tex_005288" OutName="ganontika_room_7Tex_005288" Format="ci8" Width="64" Height="32" Offset="0x5288" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_7Tex_005A88" OutName="ganontika_room_7Tex_005A88" Format="rgba16" Width="32" Height="32" Offset="0x5A88" AddedByScript="true"/>
+        <Texture Name="ganontika_room_7Tex_006288" OutName="ganontika_room_7Tex_006288" Format="rgba16" Width="32" Height="32" Offset="0x6288" AddedByScript="true"/>
+        <Texture Name="ganontika_room_7Tex_006A88" OutName="ganontika_room_7Tex_006A88" Format="rgba16" Width="16" Height="16" Offset="0x6A88" AddedByScript="true"/>
+        <Texture Name="ganontika_room_7Tex_006C88" OutName="ganontika_room_7Tex_006C88" Format="rgba16" Width="64" Height="32" Offset="0x6C88" AddedByScript="true"/>
         <Room Name="ganontika_room_7" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_8" Segment="3">
+        <Texture Name="ganontika_room_8Tex_0034B8" OutName="ganontika_room_8Tex_0034B8" Format="rgba16" Width="32" Height="64" Offset="0x3508" AddedByScript="true"/>
+        <Texture Name="ganontika_room_8Tex_0044B8" OutName="ganontika_room_8Tex_0044B8" Format="rgba16" Width="32" Height="64" Offset="0x4508" AddedByScript="true"/>
+        <Texture Name="ganontika_room_8Tex_0054B8" OutName="ganontika_room_8Tex_0054B8" Format="rgba16" Width="32" Height="32" Offset="0x5508" AddedByScript="true"/>
+        <Texture Name="ganontika_room_8Tex_005CB8" OutName="ganontika_room_8Tex_005CB8" Format="rgba16" Width="32" Height="64" Offset="0x5D08" AddedByScript="true"/>
+        <Texture Name="ganontika_room_8Tex_006CB8" OutName="ganontika_room_8Tex_006CB8" Format="rgba16" Width="32" Height="32" Offset="0x6D08" AddedByScript="true"/>
+        <Texture Name="ganontika_room_8Tex_0074B8" OutName="ganontika_room_8Tex_0074B8" Format="ci4" Width="64" Height="64" Offset="0x7508" TlutOffset="0x34E8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_8Tex_008018" OutName="ganontika_room_8Tex_008018" Format="ia8" Width="64" Height="64" Offset="0x8068" AddedByScript="true"/>
+        <Texture Name="ganontika_room_8TLUT_003498" OutName="ganontika_room_8TLUT_003498" Format="rgba16" Width="4" Height="4" Offset="0x34E8" AddedByScript="true"/>
         <Room Name="ganontika_room_8" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_9" Segment="3">
+        <Texture Name="ganontika_room_9Tex_005488" OutName="ganontika_room_9Tex_005488" Format="rgba16" Width="64" Height="32" Offset="0x54F8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_9Tex_006488" OutName="ganontika_room_9Tex_006488" Format="rgba16" Width="64" Height="32" Offset="0x64F8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_9Tex_007488" OutName="ganontika_room_9Tex_007488" Format="rgba16" Width="32" Height="32" Offset="0x74F8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_9Tex_007C88" OutName="ganontika_room_9Tex_007C88" Format="rgba16" Width="16" Height="16" Offset="0x7CF8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_9Tex_007E88" OutName="ganontika_room_9Tex_007E88" Format="ci8" Width="32" Height="64" Offset="0x7EF8" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_9Tex_008688" OutName="ganontika_room_9Tex_008688" Format="ci8" Width="64" Height="32" Offset="0x86F8" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_9Tex_008E88" OutName="ganontika_room_9Tex_008E88" Format="ci8" Width="64" Height="32" Offset="0x8EF8" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_9Tex_009688" OutName="ganontika_room_9Tex_009688" Format="rgba16" Width="64" Height="32" Offset="0x96F8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_9Tex_00A818" OutName="ganontika_room_9Tex_00A818" Format="rgba16" Width="32" Height="64" Offset="0xA888" AddedByScript="true"/>
         <Room Name="ganontika_room_9" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_10" Segment="3">
+        <Texture Name="ganontika_room_10Tex_0039B8" OutName="ganontika_room_10Tex_0039B8" Format="rgba16" Width="32" Height="32" Offset="0x3968" AddedByScript="true"/>
+        <Texture Name="ganontika_room_10Tex_0041B8" OutName="ganontika_room_10Tex_0041B8" Format="ci8" Width="32" Height="64" Offset="0x4168" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_10Tex_0049B8" OutName="ganontika_room_10Tex_0049B8" Format="rgba16" Width="32" Height="32" Offset="0x4968" AddedByScript="true"/>
+        <Texture Name="ganontika_room_10Tex_0051B8" OutName="ganontika_room_10Tex_0051B8" Format="rgba16" Width="32" Height="32" Offset="0x5168" AddedByScript="true"/>
+        <Texture Name="ganontika_room_10Tex_0059B8" OutName="ganontika_room_10Tex_0059B8" Format="rgba16" Width="16" Height="16" Offset="0x5968" AddedByScript="true"/>
+        <Texture Name="ganontika_room_10Tex_005BB8" OutName="ganontika_room_10Tex_005BB8" Format="rgba16" Width="64" Height="32" Offset="0x5B68" AddedByScript="true"/>
         <Room Name="ganontika_room_10" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_11" Segment="3">
+        <Texture Name="ganontika_room_11Tex_004150" OutName="ganontika_room_11Tex_004150" Format="rgba16" Width="32" Height="32" Offset="0x4150" AddedByScript="true"/>
+        <Texture Name="ganontika_room_11Tex_004950" OutName="ganontika_room_11Tex_004950" Format="ci8" Width="32" Height="64" Offset="0x4950" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_11Tex_005150" OutName="ganontika_room_11Tex_005150" Format="ci8" Width="64" Height="32" Offset="0x5150" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_11Tex_005950" OutName="ganontika_room_11Tex_005950" Format="rgba16" Width="32" Height="32" Offset="0x5950" AddedByScript="true"/>
+        <Texture Name="ganontika_room_11Tex_006150" OutName="ganontika_room_11Tex_006150" Format="rgba16" Width="32" Height="32" Offset="0x6150" AddedByScript="true"/>
         <Room Name="ganontika_room_11" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_12" Segment="3">
+        <Texture Name="ganontika_room_12Tex_005160" OutName="ganontika_room_12Tex_005160" Format="rgba16" Width="32" Height="32" Offset="0x5260" AddedByScript="true"/>
+        <Texture Name="ganontika_room_12Tex_005960" OutName="ganontika_room_12Tex_005960" Format="ci8" Width="64" Height="32" Offset="0x5A60" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_12Tex_006160" OutName="ganontika_room_12Tex_006160" Format="ci8" Width="32" Height="64" Offset="0x6260" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_12Tex_006960" OutName="ganontika_room_12Tex_006960" Format="ci4" Width="64" Height="64" Offset="0x6A60" TlutOffset="0x5240" AddedByScript="true"/>
+        <Texture Name="ganontika_room_12Tex_007160" OutName="ganontika_room_12Tex_007160" Format="rgba16" Width="64" Height="32" Offset="0x7260" AddedByScript="true"/>
+        <Texture Name="ganontika_room_12Tex_008160" OutName="ganontika_room_12Tex_008160" Format="ci8" Width="64" Height="16" Offset="0x8260" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_12Tex_008560" OutName="ganontika_room_12Tex_008560" Format="ci8" Width="64" Height="32" Offset="0x8660" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_12Tex_009270" OutName="ganontika_room_12Tex_009270" Format="ia8" Width="64" Height="64" Offset="0x9370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_12Tex_00A270" OutName="ganontika_room_12Tex_00A270" Format="ia8" Width="32" Height="128" Offset="0xA370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_12TLUT_005140" OutName="ganontika_room_12TLUT_005140" Format="rgba16" Width="4" Height="4" Offset="0x5240" AddedByScript="true"/>
         <Room Name="ganontika_room_12" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_13" Segment="3">
+        <Texture Name="ganontika_room_13Tex_004340" OutName="ganontika_room_13Tex_004340" Format="rgba16" Width="32" Height="32" Offset="0x4340" AddedByScript="true"/>
+        <Texture Name="ganontika_room_13Tex_004B40" OutName="ganontika_room_13Tex_004B40" Format="ci8" Width="32" Height="64" Offset="0x4B40" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_13Tex_005340" OutName="ganontika_room_13Tex_005340" Format="ci8" Width="64" Height="32" Offset="0x5340" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_13Tex_005B40" OutName="ganontika_room_13Tex_005B40" Format="rgba16" Width="32" Height="32" Offset="0x5B40" AddedByScript="true"/>
+        <Texture Name="ganontika_room_13Tex_006340" OutName="ganontika_room_13Tex_006340" Format="rgba16" Width="32" Height="32" Offset="0x6340" AddedByScript="true"/>
+        <Texture Name="ganontika_room_13Tex_006B40" OutName="ganontika_room_13Tex_006B40" Format="rgba16" Width="16" Height="16" Offset="0x6B40" AddedByScript="true"/>
+        <Texture Name="ganontika_room_13Tex_006D40" OutName="ganontika_room_13Tex_006D40" Format="rgba16" Width="64" Height="32" Offset="0x6D40" AddedByScript="true"/>
         <Room Name="ganontika_room_13" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_14" Segment="3">
+        <Texture Name="ganontika_room_14Tex_004FB8" OutName="ganontika_room_14Tex_004FB8" Format="rgba16" Width="32" Height="32" Offset="0x4F88" AddedByScript="true"/>
+        <Texture Name="ganontika_room_14Tex_0057B8" OutName="ganontika_room_14Tex_0057B8" Format="ci8" Width="64" Height="32" Offset="0x5788" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_14Tex_005FB8" OutName="ganontika_room_14Tex_005FB8" Format="ci4" Width="64" Height="64" Offset="0x5F88" TlutOffset="0x4F68" AddedByScript="true"/>
+        <Texture Name="ganontika_room_14Tex_0067B8" OutName="ganontika_room_14Tex_0067B8" Format="rgba16" Width="64" Height="32" Offset="0x6788" AddedByScript="true"/>
+        <Texture Name="ganontika_room_14Tex_0077B8" OutName="ganontika_room_14Tex_0077B8" Format="ci8" Width="64" Height="16" Offset="0x7788" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_14Tex_007BB8" OutName="ganontika_room_14Tex_007BB8" Format="ci8" Width="64" Height="32" Offset="0x7B88" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_14Tex_0089C8" OutName="ganontika_room_14Tex_0089C8" Format="ia8" Width="64" Height="64" Offset="0x8998" AddedByScript="true"/>
+        <Texture Name="ganontika_room_14Tex_0099C8" OutName="ganontika_room_14Tex_0099C8" Format="rgba16" Width="32" Height="32" Offset="0x9998" AddedByScript="true"/>
+        <Texture Name="ganontika_room_14TLUT_004F98" OutName="ganontika_room_14TLUT_004F98" Format="rgba16" Width="4" Height="4" Offset="0x4F68" AddedByScript="true"/>
         <Room Name="ganontika_room_14" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_15" Segment="3">
+        <Texture Name="ganontika_room_15Tex_004340" OutName="ganontika_room_15Tex_004340" Format="rgba16" Width="32" Height="32" Offset="0x4340" AddedByScript="true"/>
+        <Texture Name="ganontika_room_15Tex_004B40" OutName="ganontika_room_15Tex_004B40" Format="ci8" Width="32" Height="64" Offset="0x4B40" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_15Tex_005340" OutName="ganontika_room_15Tex_005340" Format="ci8" Width="64" Height="32" Offset="0x5340" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_15Tex_005B40" OutName="ganontika_room_15Tex_005B40" Format="rgba16" Width="32" Height="32" Offset="0x5B40" AddedByScript="true"/>
+        <Texture Name="ganontika_room_15Tex_006340" OutName="ganontika_room_15Tex_006340" Format="rgba16" Width="32" Height="32" Offset="0x6340" AddedByScript="true"/>
+        <Texture Name="ganontika_room_15Tex_006B40" OutName="ganontika_room_15Tex_006B40" Format="rgba16" Width="16" Height="16" Offset="0x6B40" AddedByScript="true"/>
+        <Texture Name="ganontika_room_15Tex_006D40" OutName="ganontika_room_15Tex_006D40" Format="rgba16" Width="64" Height="32" Offset="0x6D40" AddedByScript="true"/>
         <Room Name="ganontika_room_15" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_16" Segment="3">
+        <Texture Name="ganontika_room_16Tex_001630" OutName="ganontika_room_16Tex_001630" Format="rgba16" Width="64" Height="32" Offset="0x1620" AddedByScript="true"/>
+        <Texture Name="ganontika_room_16Tex_002630" OutName="ganontika_room_16Tex_002630" Format="ci8" Width="64" Height="32" Offset="0x2620" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
         <Room Name="ganontika_room_16" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_17" Segment="3">
+        <Texture Name="ganontika_room_17Tex_002A18" OutName="ganontika_room_17Tex_002A18" Format="ci8" Width="32" Height="32" Offset="0x2A98" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_17Tex_002E18" OutName="ganontika_room_17Tex_002E18" Format="rgba16" Width="64" Height="32" Offset="0x2E98" AddedByScript="true"/>
+        <Texture Name="ganontika_room_17Tex_003E18" OutName="ganontika_room_17Tex_003E18" Format="rgba16" Width="64" Height="32" Offset="0x3E98" AddedByScript="true"/>
+        <Texture Name="ganontika_room_17Tex_004E18" OutName="ganontika_room_17Tex_004E18" Format="rgba16" Width="32" Height="32" Offset="0x4E98" AddedByScript="true"/>
+        <Texture Name="ganontika_room_17Tex_005618" OutName="ganontika_room_17Tex_005618" Format="rgba16" Width="32" Height="64" Offset="0x5698" AddedByScript="true"/>
+        <Texture Name="ganontika_room_17Tex_006618" OutName="ganontika_room_17Tex_006618" Format="rgba16" Width="32" Height="32" Offset="0x6698" AddedByScript="true"/>
+        <Texture Name="ganontika_room_17Tex_006E18" OutName="ganontika_room_17Tex_006E18" Format="ci8" Width="64" Height="32" Offset="0x6E98" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_17Tex_007618" OutName="ganontika_room_17Tex_007618" Format="rgba16" Width="64" Height="32" Offset="0x7698" AddedByScript="true"/>
         <Room Name="ganontika_room_17" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_18" Segment="3">
+        <Texture Name="ganontika_room_18Tex_004380" OutName="ganontika_room_18Tex_004380" Format="rgba16" Width="32" Height="64" Offset="0x4310" AddedByScript="true"/>
+        <Texture Name="ganontika_room_18Tex_005380" OutName="ganontika_room_18Tex_005380" Format="ci8" Width="32" Height="32" Offset="0x5310" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_18Tex_005780" OutName="ganontika_room_18Tex_005780" Format="rgba16" Width="64" Height="32" Offset="0x5710" AddedByScript="true"/>
+        <Texture Name="ganontika_room_18Tex_006780" OutName="ganontika_room_18Tex_006780" Format="rgba16" Width="64" Height="32" Offset="0x6710" AddedByScript="true"/>
+        <Texture Name="ganontika_room_18Tex_007780" OutName="ganontika_room_18Tex_007780" Format="rgba16" Width="32" Height="32" Offset="0x7710" AddedByScript="true"/>
+        <Texture Name="ganontika_room_18Tex_007F80" OutName="ganontika_room_18Tex_007F80" Format="rgba16" Width="32" Height="64" Offset="0x7F10" AddedByScript="true"/>
+        <Texture Name="ganontika_room_18Tex_008F80" OutName="ganontika_room_18Tex_008F80" Format="rgba16" Width="32" Height="8" Offset="0x8F10" AddedByScript="true"/>
+        <Texture Name="ganontika_room_18Tex_009180" OutName="ganontika_room_18Tex_009180" Format="rgba16" Width="32" Height="32" Offset="0x9110" AddedByScript="true"/>
+        <Texture Name="ganontika_room_18Tex_009980" OutName="ganontika_room_18Tex_009980" Format="ci4" Width="64" Height="64" Offset="0x9910" TlutOffset="0x42F0" AddedByScript="true"/>
+        <Texture Name="ganontika_room_18Tex_00A180" OutName="ganontika_room_18Tex_00A180" Format="i4" Width="32" Height="32" Offset="0xA110" AddedByScript="true"/>
+        <Texture Name="ganontika_room_18Tex_00A380" OutName="ganontika_room_18Tex_00A380" Format="rgba16" Width="64" Height="32" Offset="0xA310" AddedByScript="true"/>
+        <Texture Name="ganontika_room_18Tex_00B6E0" OutName="ganontika_room_18Tex_00B6E0" Format="ia8" Width="64" Height="64" Offset="0xB670" AddedByScript="true"/>
+        <Texture Name="ganontika_room_18TLUT_004360" OutName="ganontika_room_18TLUT_004360" Format="rgba16" Width="4" Height="4" Offset="0x42F0" AddedByScript="true"/>
         <Room Name="ganontika_room_18" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_19" Segment="3">
+        <Texture Name="ganontika_room_19Tex_004340" OutName="ganontika_room_19Tex_004340" Format="rgba16" Width="32" Height="32" Offset="0x4340" AddedByScript="true"/>
+        <Texture Name="ganontika_room_19Tex_004B40" OutName="ganontika_room_19Tex_004B40" Format="ci8" Width="32" Height="64" Offset="0x4B40" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_19Tex_005340" OutName="ganontika_room_19Tex_005340" Format="ci8" Width="64" Height="32" Offset="0x5340" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_19Tex_005B40" OutName="ganontika_room_19Tex_005B40" Format="rgba16" Width="32" Height="32" Offset="0x5B40" AddedByScript="true"/>
+        <Texture Name="ganontika_room_19Tex_006340" OutName="ganontika_room_19Tex_006340" Format="rgba16" Width="32" Height="32" Offset="0x6340" AddedByScript="true"/>
+        <Texture Name="ganontika_room_19Tex_006B40" OutName="ganontika_room_19Tex_006B40" Format="rgba16" Width="16" Height="16" Offset="0x6B40" AddedByScript="true"/>
+        <Texture Name="ganontika_room_19Tex_006D40" OutName="ganontika_room_19Tex_006D40" Format="rgba16" Width="64" Height="32" Offset="0x6D40" AddedByScript="true"/>
         <Room Name="ganontika_room_19" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/scenes/dungeons/ganontikasonogo.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/dungeons/ganontikasonogo.xml
@@ -1,12 +1,36 @@
 <Root>
     <File Name="ganontikasonogo_scene" Segment="2">
+        <Texture Name="ganontikasonogo_sceneTex_002B00" OutName="ganontikasonogo_sceneTex_002B00" Format="rgba16" Width="32" Height="64" Offset="0x2B00" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_sceneTex_003B00" OutName="ganontikasonogo_sceneTex_003B00" Format="rgba16" Width="64" Height="32" Offset="0x3B00" AddedByScript="true"/>
         <Path Name="gGanonTikasongsoPath_00184" Offset="0x184" NumPaths="3"/>
         <Scene Name="ganontikasonogo_scene" Offset="0x0"/>
     </File>
     <File Name="ganontikasonogo_room_0" Segment="3">
+        <Texture Name="ganontikasonogo_room_0Tex_0092D8" OutName="ganontikasonogo_room_0Tex_0092D8" Format="rgba16" Width="64" Height="32" Offset="0x92D8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_00A2D8" OutName="ganontikasonogo_room_0Tex_00A2D8" Format="rgba16" Width="64" Height="32" Offset="0xA2D8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_00B2D8" OutName="ganontikasonogo_room_0Tex_00B2D8" Format="rgba16" Width="32" Height="64" Offset="0xB2D8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_00C2D8" OutName="ganontikasonogo_room_0Tex_00C2D8" Format="rgba16" Width="64" Height="32" Offset="0xC2D8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_00D2D8" OutName="ganontikasonogo_room_0Tex_00D2D8" Format="rgba16" Width="64" Height="32" Offset="0xD2D8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_00E2D8" OutName="ganontikasonogo_room_0Tex_00E2D8" Format="rgba16" Width="64" Height="32" Offset="0xE2D8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_00F2D8" OutName="ganontikasonogo_room_0Tex_00F2D8" Format="rgba16" Width="32" Height="32" Offset="0xF2D8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_00FAD8" OutName="ganontikasonogo_room_0Tex_00FAD8" Format="rgba16" Width="32" Height="64" Offset="0xFAD8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_010AD8" OutName="ganontikasonogo_room_0Tex_010AD8" Format="ci4" Width="64" Height="64" Offset="0x10AD8" TlutOffset="0x92B8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_0112D8" OutName="ganontikasonogo_room_0Tex_0112D8" Format="ci4" Width="64" Height="64" Offset="0x112D8" TlutOffset="0x92B8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_011AD8" OutName="ganontikasonogo_room_0Tex_011AD8" Format="ci4" Width="64" Height="64" Offset="0x11AD8" TlutOffset="0x92B8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_0122D8" OutName="ganontikasonogo_room_0Tex_0122D8" Format="ci4" Width="64" Height="64" Offset="0x122D8" TlutOffset="0x92B8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_012AD8" OutName="ganontikasonogo_room_0Tex_012AD8" Format="ci4" Width="64" Height="64" Offset="0x12AD8" TlutOffset="0x92B8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_0132D8" OutName="ganontikasonogo_room_0Tex_0132D8" Format="rgba16" Width="64" Height="32" Offset="0x132D8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_0142D8" OutName="ganontikasonogo_room_0Tex_0142D8" Format="rgba16" Width="64" Height="16" Offset="0x142D8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_014AD8" OutName="ganontikasonogo_room_0Tex_014AD8" Format="rgba16" Width="64" Height="32" Offset="0x14AD8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_016B78" OutName="ganontikasonogo_room_0Tex_016B78" Format="ia8" Width="64" Height="64" Offset="0x16B78" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0TLUT_0092B8" OutName="ganontikasonogo_room_0TLUT_0092B8" Format="rgba16" Width="4" Height="4" Offset="0x92B8" AddedByScript="true"/>
         <Room Name="ganontikasonogo_room_0" Offset="0x0"/>
     </File>
     <File Name="ganontikasonogo_room_1" Segment="3">
+        <Texture Name="ganontikasonogo_room_1Tex_006C60" OutName="ganontikasonogo_room_1Tex_006C60" Format="rgba16" Width="32" Height="32" Offset="0x6C60" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_1Tex_007460" OutName="ganontikasonogo_room_1Tex_007460" Format="rgba16" Width="64" Height="32" Offset="0x7460" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_1Tex_008460" OutName="ganontikasonogo_room_1Tex_008460" Format="rgba16" Width="32" Height="64" Offset="0x8460" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_1Tex_009720" OutName="ganontikasonogo_room_1Tex_009720" Format="ia16" Width="8" Height="128" Offset="0x9720" AddedByScript="true"/>
         <Room Name="ganontikasonogo_room_1" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/scenes/dungeons/gerudoway.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/dungeons/gerudoway.xml
@@ -1,26 +1,55 @@
 <Root>
     <File Name="gerudoway_scene" Segment="2">
+        <Texture Name="gerudoway_sceneTex_007520" OutName="gerudoway_sceneTex_007520" Format="rgba16" Width="32" Height="64" Offset="0x7520" AddedByScript="true"/>
+        <Texture Name="gerudoway_sceneTex_008520" OutName="gerudoway_sceneTex_008520" Format="ia4" Width="128" Height="32" Offset="0x8520" AddedByScript="true"/>
+        <Texture Name="gerudoway_sceneTex_008D20" OutName="gerudoway_sceneTex_008D20" Format="ia8" Width="64" Height="32" Offset="0x8D20" AddedByScript="true"/>
+        <Texture Name="gerudoway_sceneTex_009520" OutName="gerudoway_sceneTex_009520" Format="ia8" Width="32" Height="64" Offset="0x9520" AddedByScript="true"/>
+        <Texture Name="gerudoway_sceneTex_009D20" OutName="gerudoway_sceneTex_009D20" Format="rgba16" Width="32" Height="32" Offset="0x9D20" AddedByScript="true"/>
+        <Texture Name="gerudoway_sceneTex_00A520" OutName="gerudoway_sceneTex_00A520" Format="rgba16" Width="32" Height="16" Offset="0xA520" AddedByScript="true"/>
+        <Texture Name="gerudoway_sceneTex_00A920" OutName="gerudoway_sceneTex_00A920" Format="rgba16" Width="32" Height="64" Offset="0xA920" AddedByScript="true"/>
+        <Texture Name="gerudoway_sceneTex_00C120" OutName="gerudoway_sceneTex_00C120" Format="rgba16" Width="64" Height="32" Offset="0xC120" AddedByScript="true"/>
+        <Texture Name="gerudoway_sceneTex_00D120" OutName="gerudoway_sceneTex_00D120" Format="rgba16" Width="32" Height="32" Offset="0xD120" AddedByScript="true"/>
         <Texture Name="gThievesHideoutNightEntranceTex" OutName="night_entrance" Format="ia16" Width="128" Height="4" Offset="0xB920"/>
         <Texture Name="gThievesHideoutDayEntranceTex" OutName="day_entrance" Format="ia16" Width="128" Height="4" Offset="0xBD20"/>
         <Path Name="gGerudowayPath_002AC" Offset="0x2AC" NumPaths="4"/>
         <Scene Name="gerudoway_scene" Offset="0x0"/>
     </File>
     <File Name="gerudoway_room_0" Segment="3">
+        <Texture Name="gerudoway_room_0Tex_002FB0" OutName="gerudoway_room_0Tex_002FB0" Format="rgba16" Width="64" Height="32" Offset="0x2FB0" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_0Tex_003FB0" OutName="gerudoway_room_0Tex_003FB0" Format="rgba16" Width="32" Height="16" Offset="0x3FB0" AddedByScript="true"/>
         <Room Name="gerudoway_room_0" Offset="0x0"/>
     </File>
      <File Name="gerudoway_room_1" Segment="3">
+        <Texture Name="gerudoway_room_1Tex_003710" OutName="gerudoway_room_1Tex_003710" Format="rgba16" Width="32" Height="32" Offset="0x3710" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_1Tex_003F10" OutName="gerudoway_room_1Tex_003F10" Format="ia4" Width="32" Height="128" Offset="0x3F10" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_1Tex_004710" OutName="gerudoway_room_1Tex_004710" Format="rgba16" Width="64" Height="32" Offset="0x4710" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_1Tex_005710" OutName="gerudoway_room_1Tex_005710" Format="rgba16" Width="32" Height="16" Offset="0x5710" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_1Tex_005B10" OutName="gerudoway_room_1Tex_005B10" Format="rgba16" Width="64" Height="16" Offset="0x5B10" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_1Tex_006310" OutName="gerudoway_room_1Tex_006310" Format="rgba16" Width="16" Height="64" Offset="0x6310" AddedByScript="true"/>
         <Room Name="gerudoway_room_1" Offset="0x0"/>
     </File>
      <File Name="gerudoway_room_2" Segment="3">
+        <Texture Name="gerudoway_room_2Tex_002298" OutName="gerudoway_room_2Tex_002298" Format="rgba16" Width="64" Height="16" Offset="0x2298" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_2Tex_002A98" OutName="gerudoway_room_2Tex_002A98" Format="rgba16" Width="16" Height="64" Offset="0x2A98" AddedByScript="true"/>
         <Room Name="gerudoway_room_2" Offset="0x0"/>
     </File>
      <File Name="gerudoway_room_3" Segment="3">
+        <Texture Name="gerudoway_room_3Tex_006EA0" OutName="gerudoway_room_3Tex_006EA0" Format="rgba16" Width="32" Height="32" Offset="0x6EA0" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_3Tex_0076A0" OutName="gerudoway_room_3Tex_0076A0" Format="ia4" Width="32" Height="128" Offset="0x76A0" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_3Tex_007EA0" OutName="gerudoway_room_3Tex_007EA0" Format="rgba16" Width="64" Height="32" Offset="0x7EA0" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_3Tex_008EA0" OutName="gerudoway_room_3Tex_008EA0" Format="rgba16" Width="32" Height="16" Offset="0x8EA0" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_3Tex_0092A0" OutName="gerudoway_room_3Tex_0092A0" Format="rgba16" Width="32" Height="32" Offset="0x92A0" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_3Tex_009AA0" OutName="gerudoway_room_3Tex_009AA0" Format="rgba16" Width="16" Height="64" Offset="0x9AA0" AddedByScript="true"/>
         <Room Name="gerudoway_room_3" Offset="0x0"/>
     </File>
      <File Name="gerudoway_room_4" Segment="3">
+        <Texture Name="gerudoway_room_4Tex_002028" OutName="gerudoway_room_4Tex_002028" Format="rgba16" Width="64" Height="16" Offset="0x2028" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_4Tex_002828" OutName="gerudoway_room_4Tex_002828" Format="rgba16" Width="16" Height="64" Offset="0x2828" AddedByScript="true"/>
         <Room Name="gerudoway_room_4" Offset="0x0"/>
     </File>
      <File Name="gerudoway_room_5" Segment="3">
+        <Texture Name="gerudoway_room_5Tex_002FF8" OutName="gerudoway_room_5Tex_002FF8" Format="rgba16" Width="64" Height="16" Offset="0x2FF8" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_5Tex_0037F8" OutName="gerudoway_room_5Tex_0037F8" Format="rgba16" Width="16" Height="64" Offset="0x37F8" AddedByScript="true"/>
         <Room Name="gerudoway_room_5" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/scenes/dungeons/ice_doukutu.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/dungeons/ice_doukutu.xml
@@ -1,44 +1,105 @@
 <Root>
     <File Name="ice_doukutu_scene" Segment="2">
+        <Texture Name="ice_doukutu_sceneTex_00FCC0" OutName="ice_doukutu_sceneTex_00FCC0" Format="i8" Width="32" Height="32" Offset="0xFBF0" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_sceneTex_0100C0" OutName="ice_doukutu_sceneTex_0100C0" Format="rgba16" Width="32" Height="32" Offset="0xFFF0" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_sceneTex_0108C0" OutName="ice_doukutu_sceneTex_0108C0" Format="rgba16" Width="16" Height="16" Offset="0x107F0" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_sceneTex_010AC0" OutName="ice_doukutu_sceneTex_010AC0" Format="i8" Width="32" Height="32" Offset="0x109F0" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_sceneTex_010EC0" OutName="ice_doukutu_sceneTex_010EC0" Format="rgba16" Width="32" Height="32" Offset="0x10DF0" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_sceneTLUT_00F8A0" OutName="ice_doukutu_sceneTLUT_00F8A0" Format="rgba16" Width="4" Height="4" Offset="0xF7D0" AddedByScript="true"/>
         <Cutscene Name="gIceCavernSerenadeCs" Offset="0x250"/>
         <Texture Name="gIceCavernNightEntranceTex" OutName="night_entrance" Format="ia16" Width="64" Height="4" Offset="0xF7F0"/>
         <Texture Name="gIceCavernDayEntranceTex" OutName="day_entrance" Format="ia16" Width="64" Height="4" Offset="0xF9F0"/>
         <Scene Name="ice_doukutu_scene" Offset="0x0"/>
     </File>
     <File Name="ice_doukutu_room_0" Segment="3">
+        <Texture Name="ice_doukutu_room_0Tex_002F50" OutName="ice_doukutu_room_0Tex_002F50" Format="rgba16" Width="32" Height="64" Offset="0x2F30" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_0Tex_003F50" OutName="ice_doukutu_room_0Tex_003F50" Format="rgba16" Width="32" Height="32" Offset="0x3F30" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_0Tex_004750" OutName="ice_doukutu_room_0Tex_004750" Format="rgba16" Width="32" Height="64" Offset="0x4730" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_0Tex_005750" OutName="ice_doukutu_room_0Tex_005750" Format="rgba16" Width="32" Height="32" Offset="0x5730" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_0Tex_005F50" OutName="ice_doukutu_room_0Tex_005F50" Format="i8" Width="64" Height="64" Offset="0x5F30" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_0Tex_007678" OutName="ice_doukutu_room_0Tex_007678" Format="i8" Width="64" Height="64" Offset="0x7658" AddedByScript="true"/>
         <Room Name="ice_doukutu_room_0" Offset="0x0"/>
     </File>
     <File Name="ice_doukutu_room_1" Segment="3">
+        <Texture Name="ice_doukutu_room_1Tex_004110" OutName="ice_doukutu_room_1Tex_004110" Format="rgba16" Width="32" Height="64" Offset="0x4120" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_1Tex_005110" OutName="ice_doukutu_room_1Tex_005110" Format="rgba16" Width="32" Height="32" Offset="0x5120" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_1Tex_005910" OutName="ice_doukutu_room_1Tex_005910" Format="rgba16" Width="32" Height="64" Offset="0x5920" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_1Tex_006910" OutName="ice_doukutu_room_1Tex_006910" Format="rgba16" Width="32" Height="32" Offset="0x6920" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_1Tex_007110" OutName="ice_doukutu_room_1Tex_007110" Format="rgba16" Width="32" Height="64" Offset="0x7120" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_1Tex_008110" OutName="ice_doukutu_room_1Tex_008110" Format="i8" Width="64" Height="64" Offset="0x8120" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_1Tex_009110" OutName="ice_doukutu_room_1Tex_009110" Format="rgba16" Width="32" Height="32" Offset="0x9120" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_1Tex_00AB30" OutName="ice_doukutu_room_1Tex_00AB30" Format="rgba16" Width="32" Height="64" Offset="0xAB40" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_1Tex_00BB30" OutName="ice_doukutu_room_1Tex_00BB30" Format="rgba16" Width="16" Height="16" Offset="0xBB40" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_1Tex_00BD30" OutName="ice_doukutu_room_1Tex_00BD30" Format="rgba16" Width="32" Height="32" Offset="0xBD40" AddedByScript="true"/>
         <Room Name="ice_doukutu_room_1" Offset="0x0"/>
     </File>
     <File Name="ice_doukutu_room_2" Segment="3">
+        <Texture Name="ice_doukutu_room_2Tex_001730" OutName="ice_doukutu_room_2Tex_001730" Format="rgba16" Width="32" Height="64" Offset="0x1720" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_2Tex_002730" OutName="ice_doukutu_room_2Tex_002730" Format="ci4" Width="64" Height="64" Offset="0x2720" ExternalTlut="ice_doukutu_scene" ExternalTlutOffset="0xF7D0" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_2Tex_003AF8" OutName="ice_doukutu_room_2Tex_003AF8" Format="i8" Width="64" Height="64" Offset="0x3AE8" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_2Tex_004AF8" OutName="ice_doukutu_room_2Tex_004AF8" Format="rgba16" Width="32" Height="64" Offset="0x4AE8" AddedByScript="true"/>
         <Room Name="ice_doukutu_room_2" Offset="0x0"/>
     </File>
     <File Name="ice_doukutu_room_3" Segment="3">
+        <Texture Name="ice_doukutu_room_3Tex_003208" OutName="ice_doukutu_room_3Tex_003208" Format="rgba16" Width="32" Height="32" Offset="0x31F8" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_3Tex_003A08" OutName="ice_doukutu_room_3Tex_003A08" Format="ci4" Width="64" Height="64" Offset="0x39F8" ExternalTlut="ice_doukutu_scene" ExternalTlutOffset="0xF7D0" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_3Tex_005090" OutName="ice_doukutu_room_3Tex_005090" Format="i8" Width="64" Height="64" Offset="0x5080" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_3Tex_006090" OutName="ice_doukutu_room_3Tex_006090" Format="rgba16" Width="32" Height="64" Offset="0x6080" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_3Tex_007090" OutName="ice_doukutu_room_3Tex_007090" Format="i8" Width="32" Height="128" Offset="0x7080" AddedByScript="true"/>
         <Room Name="ice_doukutu_room_3" Offset="0x0"/>
     </File>
     <File Name="ice_doukutu_room_4" Segment="3">
+        <Texture Name="ice_doukutu_room_4Tex_0028E0" OutName="ice_doukutu_room_4Tex_0028E0" Format="rgba16" Width="32" Height="32" Offset="0x2900" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_4Tex_0030E0" OutName="ice_doukutu_room_4Tex_0030E0" Format="rgba16" Width="32" Height="32" Offset="0x3100" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_4Tex_0038E0" OutName="ice_doukutu_room_4Tex_0038E0" Format="ci4" Width="64" Height="64" Offset="0x3900" ExternalTlut="ice_doukutu_scene" ExternalTlutOffset="0xF7D0" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_4Tex_004650" OutName="ice_doukutu_room_4Tex_004650" Format="i8" Width="64" Height="64" Offset="0x4670" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_4Tex_005650" OutName="ice_doukutu_room_4Tex_005650" Format="rgba16" Width="32" Height="64" Offset="0x5670" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_4Tex_006650" OutName="ice_doukutu_room_4Tex_006650" Format="i8" Width="32" Height="128" Offset="0x6670" AddedByScript="true"/>
         <Room Name="ice_doukutu_room_4" Offset="0x0"/>
     </File>
     <File Name="ice_doukutu_room_5" Segment="3">
+        <Texture Name="ice_doukutu_room_5Tex_004648" OutName="ice_doukutu_room_5Tex_004648" Format="rgba16" Width="16" Height="128" Offset="0x4658" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_5Tex_005648" OutName="ice_doukutu_room_5Tex_005648" Format="rgba16" Width="32" Height="32" Offset="0x5658" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_5Tex_005E48" OutName="ice_doukutu_room_5Tex_005E48" Format="rgba16" Width="32" Height="32" Offset="0x5E58" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_5Tex_006648" OutName="ice_doukutu_room_5Tex_006648" Format="rgba16" Width="32" Height="32" Offset="0x6658" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_5Tex_007478" OutName="ice_doukutu_room_5Tex_007478" Format="i8" Width="32" Height="32" Offset="0x7488" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_5Tex_007878" OutName="ice_doukutu_room_5Tex_007878" Format="i8" Width="64" Height="64" Offset="0x7888" AddedByScript="true"/>
         <Room Name="ice_doukutu_room_5" Offset="0x0"/>
     </File>
     <File Name="ice_doukutu_room_6" Segment="3">
+        <Texture Name="ice_doukutu_room_6Tex_0029B0" OutName="ice_doukutu_room_6Tex_0029B0" Format="i8" Width="64" Height="64" Offset="0x2A60" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_6Tex_0039B0" OutName="ice_doukutu_room_6Tex_0039B0" Format="rgba16" Width="32" Height="32" Offset="0x3A60" AddedByScript="true"/>
         <Room Name="ice_doukutu_room_6" Offset="0x0"/>
     </File>
     <File Name="ice_doukutu_room_7" Segment="3">
+        <Texture Name="ice_doukutu_room_7Tex_001758" OutName="ice_doukutu_room_7Tex_001758" Format="ci4" Width="64" Height="64" Offset="0x1758" ExternalTlut="ice_doukutu_scene" ExternalTlutOffset="0xF7D0" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_7Tex_0040E8" OutName="ice_doukutu_room_7Tex_0040E8" Format="i8" Width="64" Height="64" Offset="0x40E8" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_7Tex_0050E8" OutName="ice_doukutu_room_7Tex_0050E8" Format="rgba16" Width="32" Height="32" Offset="0x50E8" AddedByScript="true"/>
         <Room Name="ice_doukutu_room_7" Offset="0x0"/>
     </File>
     <File Name="ice_doukutu_room_8" Segment="3">
         <Room Name="ice_doukutu_room_8" Offset="0x0"/>
     </File>
     <File Name="ice_doukutu_room_9" Segment="3">
+        <Texture Name="ice_doukutu_room_9Tex_0044A0" OutName="ice_doukutu_room_9Tex_0044A0" Format="rgba16" Width="32" Height="64" Offset="0x4460" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_9Tex_0054A0" OutName="ice_doukutu_room_9Tex_0054A0" Format="rgba16" Width="32" Height="32" Offset="0x5460" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_9Tex_005CA0" OutName="ice_doukutu_room_9Tex_005CA0" Format="rgba16" Width="32" Height="32" Offset="0x5C60" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_9Tex_0064A0" OutName="ice_doukutu_room_9Tex_0064A0" Format="rgba16" Width="32" Height="32" Offset="0x6460" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_9Tex_006CA0" OutName="ice_doukutu_room_9Tex_006CA0" Format="rgba16" Width="32" Height="32" Offset="0x6C60" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_9Tex_007690" OutName="ice_doukutu_room_9Tex_007690" Format="rgba16" Width="32" Height="64" Offset="0x7650" AddedByScript="true"/>
         <Room Name="ice_doukutu_room_9" Offset="0x0"/>
     </File>
     <File Name="ice_doukutu_room_10" Segment="3">
+        <Texture Name="ice_doukutu_room_10Tex_001A28" OutName="ice_doukutu_room_10Tex_001A28" Format="rgba16" Width="32" Height="64" Offset="0x1A28" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_10Tex_002A28" OutName="ice_doukutu_room_10Tex_002A28" Format="i8" Width="64" Height="64" Offset="0x2A28" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_10Tex_003BD8" OutName="ice_doukutu_room_10Tex_003BD8" Format="rgba16" Width="32" Height="32" Offset="0x3BD8" AddedByScript="true"/>
         <Room Name="ice_doukutu_room_10" Offset="0x0"/>
     </File>
     <File Name="ice_doukutu_room_11" Segment="3">
+        <Texture Name="ice_doukutu_room_11Tex_002928" OutName="ice_doukutu_room_11Tex_002928" Format="rgba16" Width="32" Height="32" Offset="0x29D8" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_11Tex_003128" OutName="ice_doukutu_room_11Tex_003128" Format="rgba16" Width="32" Height="32" Offset="0x31D8" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_11Tex_003928" OutName="ice_doukutu_room_11Tex_003928" Format="rgba16" Width="32" Height="32" Offset="0x39D8" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_11Tex_004848" OutName="ice_doukutu_room_11Tex_004848" Format="i8" Width="64" Height="64" Offset="0x48F8" AddedByScript="true"/>
         <Room Name="ice_doukutu_room_11" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/scenes/dungeons/jyasinboss.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/dungeons/jyasinboss.xml
@@ -1,19 +1,49 @@
 <Root>
     <File Name="jyasinboss_scene" Segment="2">
+        <Texture Name="jyasinboss_sceneTex_006CF0" OutName="jyasinboss_sceneTex_006CF0" Format="rgba16" Width="64" Height="32" Offset="0x6CF0" AddedByScript="true"/>
+        <Texture Name="jyasinboss_sceneTex_007CF0" OutName="jyasinboss_sceneTex_007CF0" Format="rgba16" Width="64" Height="32" Offset="0x7CF0" AddedByScript="true"/>
         <Cutscene Name="gSpiritBossNabooruKnuckleIntroCs" Offset="0x2BB0"/>
         <Cutscene Name="gSpiritBossNabooruKnuckleDefeatCs" Offset="0x3F80"/>
         <Scene Name="jyasinboss_scene" Offset="0x0"/>
     </File>
     <File Name="jyasinboss_room_0" Segment="3">
+        <Texture Name="jyasinboss_room_0Tex_0007C8" OutName="jyasinboss_room_0Tex_0007C8" Format="rgba16" Width="32" Height="32" Offset="0x7C8" AddedByScript="true"/>
         <Room Name="jyasinboss_room_0" Offset="0x0"/>
     </File>
     <File Name="jyasinboss_room_1" Segment="3">
+        <Texture Name="jyasinboss_room_1Tex_002E38" OutName="jyasinboss_room_1Tex_002E38" Format="rgba16" Width="64" Height="32" Offset="0x2E38" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_1Tex_003E38" OutName="jyasinboss_room_1Tex_003E38" Format="rgba16" Width="64" Height="32" Offset="0x3E38" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_1Tex_004E38" OutName="jyasinboss_room_1Tex_004E38" Format="rgba16" Width="32" Height="32" Offset="0x4E38" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_1Tex_005638" OutName="jyasinboss_room_1Tex_005638" Format="rgba16" Width="64" Height="32" Offset="0x5638" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_1Tex_006638" OutName="jyasinboss_room_1Tex_006638" Format="rgba16" Width="64" Height="16" Offset="0x6638" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_1Tex_006E38" OutName="jyasinboss_room_1Tex_006E38" Format="ci4" Width="64" Height="64" Offset="0x6E38" TlutOffset="0x2E18" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_1Tex_007638" OutName="jyasinboss_room_1Tex_007638" Format="rgba16" Width="32" Height="32" Offset="0x7638" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_1TLUT_002E18" OutName="jyasinboss_room_1TLUT_002E18" Format="rgba16" Width="4" Height="4" Offset="0x2E18" AddedByScript="true"/>
         <Room Name="jyasinboss_room_1" Offset="0x0"/>
     </File>
     <File Name="jyasinboss_room_2" Segment="3">
+        <Texture Name="jyasinboss_room_2Tex_0021C0" OutName="jyasinboss_room_2Tex_0021C0" Format="rgba16" Width="64" Height="16" Offset="0x21C0" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_2Tex_0029C0" OutName="jyasinboss_room_2Tex_0029C0" Format="rgba16" Width="32" Height="64" Offset="0x29C0" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_2Tex_0039C0" OutName="jyasinboss_room_2Tex_0039C0" Format="rgba16" Width="16" Height="32" Offset="0x39C0" AddedByScript="true"/>
         <Room Name="jyasinboss_room_2" Offset="0x0"/>
     </File>
     <File Name="jyasinboss_room_3" Segment="3">
+        <Texture Name="jyasinboss_room_3Tex_003F00" OutName="jyasinboss_room_3Tex_003F00" Format="ci8" Width="32" Height="32" Offset="0x3F00" TlutOffset="0x3CE0" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3Tex_004300" OutName="jyasinboss_room_3Tex_004300" Format="ci8" Width="32" Height="32" Offset="0x4300" TlutOffset="0x3CE0" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3Tex_004700" OutName="jyasinboss_room_3Tex_004700" Format="ci8" Width="64" Height="32" Offset="0x4700" TlutOffset="0x3CE0" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3Tex_004F00" OutName="jyasinboss_room_3Tex_004F00" Format="ci8" Width="32" Height="32" Offset="0x4F00" TlutOffset="0x3CE0" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3Tex_005300" OutName="jyasinboss_room_3Tex_005300" Format="ci8" Width="32" Height="32" Offset="0x5300" TlutOffset="0x3CE0" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3Tex_005700" OutName="jyasinboss_room_3Tex_005700" Format="ci8" Width="32" Height="64" Offset="0x5700" TlutOffset="0x3CE0" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3Tex_005F00" OutName="jyasinboss_room_3Tex_005F00" Format="rgba16" Width="32" Height="32" Offset="0x5F00" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3Tex_006700" OutName="jyasinboss_room_3Tex_006700" Format="rgba16" Width="64" Height="32" Offset="0x6700" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3Tex_007700" OutName="jyasinboss_room_3Tex_007700" Format="rgba16" Width="32" Height="32" Offset="0x7700" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3Tex_007F00" OutName="jyasinboss_room_3Tex_007F00" Format="rgba16" Width="16" Height="128" Offset="0x7F00" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3Tex_008F00" OutName="jyasinboss_room_3Tex_008F00" Format="rgba16" Width="64" Height="32" Offset="0x8F00" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3Tex_009F00" OutName="jyasinboss_room_3Tex_009F00" Format="ci4" Width="64" Height="64" Offset="0x9F00" TlutOffset="0x3EE0" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3Tex_00A700" OutName="jyasinboss_room_3Tex_00A700" Format="rgba16" Width="32" Height="32" Offset="0xA700" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3Tex_00AF00" OutName="jyasinboss_room_3Tex_00AF00" Format="rgba16" Width="32" Height="32" Offset="0xAF00" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3TLUT_003CE0" OutName="jyasinboss_room_3TLUT_003CE0" Format="rgba16" Width="16" Height="16" Offset="0x3CE0" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3TLUT_003EE0" OutName="jyasinboss_room_3TLUT_003EE0" Format="rgba16" Width="4" Height="4" Offset="0x3EE0" AddedByScript="true"/>
         <Room Name="jyasinboss_room_3" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/scenes/dungeons/jyasinzou.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/dungeons/jyasinzou.xml
@@ -1,95 +1,358 @@
 <Root>
     <File Name="jyasinzou_scene" Segment="2">
+        <Texture Name="jyasinzou_sceneTex_018820" OutName="jyasinzou_sceneTex_018820" Format="ci8" Width="16" Height="16" Offset="0x18840" TlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_sceneTex_019120" OutName="jyasinzou_sceneTex_019120" Format="rgba16" Width="16" Height="16" Offset="0x19140" AddedByScript="true"/>
+        <Texture Name="jyasinzou_sceneTex_019320" OutName="jyasinzou_sceneTex_019320" Format="ci4" Width="64" Height="64" Offset="0x19340" TlutOffset="0x18020" AddedByScript="true"/>
+        <Texture Name="jyasinzou_sceneTLUT_017BE0" OutName="jyasinzou_sceneTLUT_017BE0" Format="rgba16" Width="16" Height="16" Offset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_sceneTLUT_017DE0" OutName="jyasinzou_sceneTLUT_017DE0" Format="rgba16" Width="16" Height="16" Offset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_sceneTLUT_017FE0" OutName="jyasinzou_sceneTLUT_017FE0" Format="rgba16" Width="4" Height="4" Offset="0x18000" AddedByScript="true"/>
+        <Texture Name="jyasinzou_sceneTLUT_018000" OutName="jyasinzou_sceneTLUT_018000" Format="rgba16" Width="4" Height="4" Offset="0x18020" AddedByScript="true"/>
         <Path Name="gSpiritTemplePath_004C0" Offset="0x4C0" NumPaths="6"/>
         <Texture Name="gSpiritTempleDayEntranceTex" OutName="day_entrance" Format="ia16" Width="8" Height="128" Offset="0x18940"/>
         <Texture Name="gSpiritTempleNightEntranceTex" OutName="night_entrance" Format="ia16" Width="8" Height="128" Offset="0x18040"/>
         <Scene Name="jyasinzou_scene" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_0" Segment="3">
+        <Texture Name="jyasinzou_room_0Tex_00A9D8" OutName="jyasinzou_room_0Tex_00A9D8" Format="ci8" Width="64" Height="32" Offset="0xA928" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_0Tex_00B1D8" OutName="jyasinzou_room_0Tex_00B1D8" Format="ci8" Width="64" Height="32" Offset="0xB128" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_0Tex_00B9D8" OutName="jyasinzou_room_0Tex_00B9D8" Format="ci8" Width="32" Height="64" Offset="0xB928" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_0Tex_00C1D8" OutName="jyasinzou_room_0Tex_00C1D8" Format="ci8" Width="32" Height="64" Offset="0xC128" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_0Tex_00C9D8" OutName="jyasinzou_room_0Tex_00C9D8" Format="ci8" Width="32" Height="64" Offset="0xC928" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_0Tex_00D1D8" OutName="jyasinzou_room_0Tex_00D1D8" Format="ci8" Width="32" Height="32" Offset="0xD128" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_0Tex_00D5D8" OutName="jyasinzou_room_0Tex_00D5D8" Format="ci8" Width="16" Height="128" Offset="0xD528" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_0Tex_00DDD8" OutName="jyasinzou_room_0Tex_00DDD8" Format="ci8" Width="32" Height="32" Offset="0xDD28" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_0Tex_00E1D8" OutName="jyasinzou_room_0Tex_00E1D8" Format="ci8" Width="64" Height="32" Offset="0xE128" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_0Tex_00E9D8" OutName="jyasinzou_room_0Tex_00E9D8" Format="ci8" Width="64" Height="32" Offset="0xE928" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_0Tex_00F1D8" OutName="jyasinzou_room_0Tex_00F1D8" Format="ci4" Width="64" Height="64" Offset="0xF128" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18000" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_0Tex_00F9D8" OutName="jyasinzou_room_0Tex_00F9D8" Format="ci4" Width="64" Height="64" Offset="0xF928" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_0Tex_0107E8" OutName="jyasinzou_room_0Tex_0107E8" Format="ia8" Width="64" Height="32" Offset="0x10738" AddedByScript="true"/>
         <Room Name="jyasinzou_room_0" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_1" Segment="3">
+        <Texture Name="jyasinzou_room_1Tex_004F48" OutName="jyasinzou_room_1Tex_004F48" Format="ci8" Width="64" Height="32" Offset="0x4EF8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_1Tex_005748" OutName="jyasinzou_room_1Tex_005748" Format="ci8" Width="32" Height="64" Offset="0x56F8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_1Tex_005F48" OutName="jyasinzou_room_1Tex_005F48" Format="ci8" Width="32" Height="64" Offset="0x5EF8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_1Tex_006748" OutName="jyasinzou_room_1Tex_006748" Format="ci8" Width="32" Height="32" Offset="0x66F8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_1Tex_006B48" OutName="jyasinzou_room_1Tex_006B48" Format="ci8" Width="32" Height="64" Offset="0x6AF8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_1Tex_007348" OutName="jyasinzou_room_1Tex_007348" Format="ci8" Width="64" Height="32" Offset="0x72F8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_1Tex_007B48" OutName="jyasinzou_room_1Tex_007B48" Format="ci8" Width="64" Height="32" Offset="0x7AF8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_1Tex_008348" OutName="jyasinzou_room_1Tex_008348" Format="ci4" Width="64" Height="64" Offset="0x82F8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18000" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_1Tex_008B48" OutName="jyasinzou_room_1Tex_008B48" Format="ci4" Width="64" Height="64" Offset="0x8AF8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
         <Room Name="jyasinzou_room_1" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_2" Segment="3">
+        <Texture Name="jyasinzou_room_2Tex_0023B0" OutName="jyasinzou_room_2Tex_0023B0" Format="rgba16" Width="32" Height="64" Offset="0x2410" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_2Tex_0033B0" OutName="jyasinzou_room_2Tex_0033B0" Format="ci8" Width="64" Height="32" Offset="0x3410" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_2Tex_003BB0" OutName="jyasinzou_room_2Tex_003BB0" Format="rgba16" Width="16" Height="32" Offset="0x3C10" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_2Tex_003FB0" OutName="jyasinzou_room_2Tex_003FB0" Format="rgba16" Width="32" Height="32" Offset="0x4010" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_2Tex_0047B0" OutName="jyasinzou_room_2Tex_0047B0" Format="ci8" Width="32" Height="32" Offset="0x4810" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_2Tex_004BB0" OutName="jyasinzou_room_2Tex_004BB0" Format="ci8" Width="64" Height="32" Offset="0x4C10" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_2Tex_0053B0" OutName="jyasinzou_room_2Tex_0053B0" Format="ci4" Width="64" Height="64" Offset="0x5410" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
         <Room Name="jyasinzou_room_2" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_3" Segment="3">
+        <Texture Name="jyasinzou_room_3Tex_001FC8" OutName="jyasinzou_room_3Tex_001FC8" Format="ci8" Width="32" Height="32" Offset="0x1F48" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_3Tex_0023C8" OutName="jyasinzou_room_3Tex_0023C8" Format="ci8" Width="64" Height="32" Offset="0x2348" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_3Tex_002BC8" OutName="jyasinzou_room_3Tex_002BC8" Format="ci4" Width="64" Height="64" Offset="0x2B48" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18000" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_3Tex_0033C8" OutName="jyasinzou_room_3Tex_0033C8" Format="ci4" Width="64" Height="64" Offset="0x3348" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
         <Room Name="jyasinzou_room_3" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_4" Segment="3">
+        <Texture Name="jyasinzou_room_4Tex_003698" OutName="jyasinzou_room_4Tex_003698" Format="ci8" Width="32" Height="64" Offset="0x3688" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_4Tex_003E98" OutName="jyasinzou_room_4Tex_003E98" Format="ci8" Width="32" Height="64" Offset="0x3E88" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_4Tex_004698" OutName="jyasinzou_room_4Tex_004698" Format="ci8" Width="32" Height="64" Offset="0x4688" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_4Tex_004E98" OutName="jyasinzou_room_4Tex_004E98" Format="ci8" Width="64" Height="32" Offset="0x4E88" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_4Tex_005698" OutName="jyasinzou_room_4Tex_005698" Format="ci8" Width="16" Height="16" Offset="0x5688" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_4Tex_005798" OutName="jyasinzou_room_4Tex_005798" Format="ci8" Width="32" Height="32" Offset="0x5788" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_4Tex_005B98" OutName="jyasinzou_room_4Tex_005B98" Format="ci8" Width="64" Height="32" Offset="0x5B88" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_4Tex_006398" OutName="jyasinzou_room_4Tex_006398" Format="ci8" Width="32" Height="32" Offset="0x6388" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_4Tex_006798" OutName="jyasinzou_room_4Tex_006798" Format="ci4" Width="64" Height="64" Offset="0x6788" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
         <Room Name="jyasinzou_room_4" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_5" Segment="3">
+        <Texture Name="jyasinzou_room_5Tex_00CBC8" OutName="jyasinzou_room_5Tex_00CBC8" Format="ci8" Width="32" Height="32" Offset="0xCAF8" TlutOffset="0xC8E0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_00CFC8" OutName="jyasinzou_room_5Tex_00CFC8" Format="ci8" Width="64" Height="32" Offset="0xCEF8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_00D7C8" OutName="jyasinzou_room_5Tex_00D7C8" Format="ci8" Width="16" Height="64" Offset="0xD6F8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_00DBC8" OutName="jyasinzou_room_5Tex_00DBC8" Format="ci8" Width="32" Height="32" Offset="0xDAF8" TlutOffset="0xC8E0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_00DFC8" OutName="jyasinzou_room_5Tex_00DFC8" Format="ci8" Width="64" Height="32" Offset="0xDEF8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_00E7C8" OutName="jyasinzou_room_5Tex_00E7C8" Format="rgba16" Width="32" Height="32" Offset="0xE6F8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_00EFC8" OutName="jyasinzou_room_5Tex_00EFC8" Format="rgba16" Width="32" Height="16" Offset="0xEEF8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_00F3C8" OutName="jyasinzou_room_5Tex_00F3C8" Format="ci8" Width="32" Height="32" Offset="0xF2F8" TlutOffset="0xC8E0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_00F7C8" OutName="jyasinzou_room_5Tex_00F7C8" Format="ci8" Width="32" Height="64" Offset="0xF6F8" TlutOffset="0xC8E0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_00FFC8" OutName="jyasinzou_room_5Tex_00FFC8" Format="ci8" Width="16" Height="16" Offset="0xFEF8" TlutOffset="0xC8E0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_0100C8" OutName="jyasinzou_room_5Tex_0100C8" Format="ci8" Width="64" Height="32" Offset="0xFFF8" TlutOffset="0xC8E0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_0108C8" OutName="jyasinzou_room_5Tex_0108C8" Format="ci8" Width="32" Height="32" Offset="0x107F8" TlutOffset="0xC8E0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_010CC8" OutName="jyasinzou_room_5Tex_010CC8" Format="ci8" Width="32" Height="32" Offset="0x10BF8" TlutOffset="0xC8E0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_0110C8" OutName="jyasinzou_room_5Tex_0110C8" Format="ci8" Width="32" Height="32" Offset="0x10FF8" TlutOffset="0xC8E0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_0114C8" OutName="jyasinzou_room_5Tex_0114C8" Format="ci8" Width="32" Height="32" Offset="0x113F8" TlutOffset="0xC8E0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_0118C8" OutName="jyasinzou_room_5Tex_0118C8" Format="ci8" Width="32" Height="32" Offset="0x117F8" TlutOffset="0xC8E0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_011CC8" OutName="jyasinzou_room_5Tex_011CC8" Format="ci4" Width="32" Height="128" Offset="0x11BF8" TlutOffset="0xCAD8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_0124C8" OutName="jyasinzou_room_5Tex_0124C8" Format="ci8" Width="32" Height="64" Offset="0x123F8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_012CC8" OutName="jyasinzou_room_5Tex_012CC8" Format="ci8" Width="64" Height="32" Offset="0x12BF8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_0134C8" OutName="jyasinzou_room_5Tex_0134C8" Format="ci8" Width="32" Height="32" Offset="0x133F8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_0138C8" OutName="jyasinzou_room_5Tex_0138C8" Format="ci8" Width="32" Height="64" Offset="0x137F8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_0140C8" OutName="jyasinzou_room_5Tex_0140C8" Format="ci8" Width="64" Height="32" Offset="0x13FF8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_0148C8" OutName="jyasinzou_room_5Tex_0148C8" Format="ci8" Width="64" Height="32" Offset="0x147F8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_0150C8" OutName="jyasinzou_room_5Tex_0150C8" Format="ci4" Width="64" Height="64" Offset="0x14FF8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18000" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_0158C8" OutName="jyasinzou_room_5Tex_0158C8" Format="ci8" Width="32" Height="32" Offset="0x157F8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_015CC8" OutName="jyasinzou_room_5Tex_015CC8" Format="ci4" Width="64" Height="64" Offset="0x15BF8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_016808" OutName="jyasinzou_room_5Tex_016808" Format="ia8" Width="64" Height="32" Offset="0x16738" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_017008" OutName="jyasinzou_room_5Tex_017008" Format="rgba16" Width="32" Height="64" Offset="0x16F38" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5TLUT_00C9B0" OutName="jyasinzou_room_5TLUT_00C9B0" Format="rgba16" Width="16" Height="16" Offset="0xC8E0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5TLUT_00CBA8" OutName="jyasinzou_room_5TLUT_00CBA8" Format="rgba16" Width="4" Height="4" Offset="0xCAD8" AddedByScript="true"/>
         <Room Name="jyasinzou_room_5" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_6" Segment="3">
+        <Texture Name="jyasinzou_room_6Tex_002BE8" OutName="jyasinzou_room_6Tex_002BE8" Format="ci8" Width="64" Height="32" Offset="0x2BF8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_6Tex_0033E8" OutName="jyasinzou_room_6Tex_0033E8" Format="ci8" Width="32" Height="32" Offset="0x33F8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_6Tex_0037E8" OutName="jyasinzou_room_6Tex_0037E8" Format="ci8" Width="64" Height="32" Offset="0x37F8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_6Tex_003FE8" OutName="jyasinzou_room_6Tex_003FE8" Format="ci8" Width="64" Height="32" Offset="0x3FF8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
         <Room Name="jyasinzou_room_6" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_7" Segment="3">
+        <Texture Name="jyasinzou_room_7Tex_002908" OutName="jyasinzou_room_7Tex_002908" Format="rgba16" Width="32" Height="64" Offset="0x2908" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_7Tex_003908" OutName="jyasinzou_room_7Tex_003908" Format="ci8" Width="64" Height="32" Offset="0x3908" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_7Tex_004108" OutName="jyasinzou_room_7Tex_004108" Format="ci8" Width="64" Height="32" Offset="0x4108" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_7Tex_004908" OutName="jyasinzou_room_7Tex_004908" Format="rgba16" Width="16" Height="32" Offset="0x4908" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_7Tex_004D08" OutName="jyasinzou_room_7Tex_004D08" Format="ci4" Width="64" Height="64" Offset="0x4D08" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
         <Room Name="jyasinzou_room_7" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_8" Segment="3">
+        <Texture Name="jyasinzou_room_8Tex_003A50" OutName="jyasinzou_room_8Tex_003A50" Format="ci8" Width="64" Height="32" Offset="0x3A10" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_8Tex_004250" OutName="jyasinzou_room_8Tex_004250" Format="ci8" Width="64" Height="32" Offset="0x4210" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_8Tex_004A50" OutName="jyasinzou_room_8Tex_004A50" Format="ci8" Width="32" Height="32" Offset="0x4A10" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_8Tex_004E50" OutName="jyasinzou_room_8Tex_004E50" Format="rgba16" Width="32" Height="32" Offset="0x4E10" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_8Tex_005650" OutName="jyasinzou_room_8Tex_005650" Format="ci8" Width="32" Height="64" Offset="0x5610" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_8Tex_005E50" OutName="jyasinzou_room_8Tex_005E50" Format="ci8" Width="32" Height="32" Offset="0x5E10" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_8Tex_006250" OutName="jyasinzou_room_8Tex_006250" Format="ci8" Width="32" Height="64" Offset="0x6210" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_8Tex_006A50" OutName="jyasinzou_room_8Tex_006A50" Format="ci8" Width="64" Height="32" Offset="0x6A10" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_8Tex_007250" OutName="jyasinzou_room_8Tex_007250" Format="ci4" Width="64" Height="64" Offset="0x7210" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
         <Room Name="jyasinzou_room_8" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_9" Segment="3">
+        <Texture Name="jyasinzou_room_9Tex_002DC8" OutName="jyasinzou_room_9Tex_002DC8" Format="rgba16" Width="32" Height="64" Offset="0x2DE8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_9Tex_003DC8" OutName="jyasinzou_room_9Tex_003DC8" Format="ci8" Width="64" Height="32" Offset="0x3DE8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_9Tex_0045C8" OutName="jyasinzou_room_9Tex_0045C8" Format="ci8" Width="64" Height="32" Offset="0x45E8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_9Tex_004DC8" OutName="jyasinzou_room_9Tex_004DC8" Format="rgba16" Width="16" Height="32" Offset="0x4DE8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_9Tex_0051C8" OutName="jyasinzou_room_9Tex_0051C8" Format="ci8" Width="64" Height="16" Offset="0x51E8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_9Tex_0055C8" OutName="jyasinzou_room_9Tex_0055C8" Format="ci8" Width="64" Height="32" Offset="0x55E8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
         <Room Name="jyasinzou_room_9" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_10" Segment="3">
+        <Texture Name="jyasinzou_room_10Tex_0031A0" OutName="jyasinzou_room_10Tex_0031A0" Format="rgba16" Width="32" Height="64" Offset="0x31A0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_10Tex_0041A0" OutName="jyasinzou_room_10Tex_0041A0" Format="ci8" Width="64" Height="32" Offset="0x41A0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_10Tex_0049A0" OutName="jyasinzou_room_10Tex_0049A0" Format="ci8" Width="64" Height="32" Offset="0x49A0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_10Tex_0051A0" OutName="jyasinzou_room_10Tex_0051A0" Format="ci8" Width="64" Height="32" Offset="0x51A0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_10Tex_0059A0" OutName="jyasinzou_room_10Tex_0059A0" Format="rgba16" Width="16" Height="32" Offset="0x59A0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_10Tex_005DA0" OutName="jyasinzou_room_10Tex_005DA0" Format="ci8" Width="64" Height="32" Offset="0x5DA0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_10Tex_0065A0" OutName="jyasinzou_room_10Tex_0065A0" Format="ci8" Width="32" Height="32" Offset="0x65A0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_10Tex_0069A0" OutName="jyasinzou_room_10Tex_0069A0" Format="rgba16" Width="64" Height="32" Offset="0x69A0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_10Tex_0079A0" OutName="jyasinzou_room_10Tex_0079A0" Format="ci8" Width="64" Height="16" Offset="0x79A0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_10Tex_007DA0" OutName="jyasinzou_room_10Tex_007DA0" Format="ci8" Width="32" Height="32" Offset="0x7DA0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
         <Room Name="jyasinzou_room_10" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_11" Segment="3">
+        <Texture Name="jyasinzou_room_11Tex_000780" OutName="jyasinzou_room_11Tex_000780" Format="ci8" Width="32" Height="32" Offset="0x780" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
         <Room Name="jyasinzou_room_11" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_12" Segment="3">
+        <Texture Name="jyasinzou_room_12Tex_0010D8" OutName="jyasinzou_room_12Tex_0010D8" Format="ci8" Width="64" Height="32" Offset="0x1058" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_12Tex_0018D8" OutName="jyasinzou_room_12Tex_0018D8" Format="ci8" Width="32" Height="64" Offset="0x1858" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
         <Room Name="jyasinzou_room_12" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_13" Segment="3">
+        <Texture Name="jyasinzou_room_13Tex_0028A8" OutName="jyasinzou_room_13Tex_0028A8" Format="ci8" Width="32" Height="64" Offset="0x2848" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_13Tex_0030A8" OutName="jyasinzou_room_13Tex_0030A8" Format="ci8" Width="64" Height="32" Offset="0x3048" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_13Tex_0038A8" OutName="jyasinzou_room_13Tex_0038A8" Format="ci8" Width="32" Height="32" Offset="0x3848" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_13Tex_003CA8" OutName="jyasinzou_room_13Tex_003CA8" Format="ci8" Width="64" Height="32" Offset="0x3C48" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_13Tex_0044A8" OutName="jyasinzou_room_13Tex_0044A8" Format="ci8" Width="64" Height="32" Offset="0x4448" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_13Tex_004CA8" OutName="jyasinzou_room_13Tex_004CA8" Format="ci8" Width="32" Height="32" Offset="0x4C48" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_13Tex_0050A8" OutName="jyasinzou_room_13Tex_0050A8" Format="ci4" Width="64" Height="64" Offset="0x5048" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
         <Room Name="jyasinzou_room_13" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_14" Segment="3">
+        <Texture Name="jyasinzou_room_14Tex_001CA0" OutName="jyasinzou_room_14Tex_001CA0" Format="ci8" Width="64" Height="32" Offset="0x1C90" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_14Tex_0024A0" OutName="jyasinzou_room_14Tex_0024A0" Format="ci8" Width="32" Height="32" Offset="0x2490" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_14Tex_0028A0" OutName="jyasinzou_room_14Tex_0028A0" Format="ci8" Width="64" Height="32" Offset="0x2890" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_14Tex_0030A0" OutName="jyasinzou_room_14Tex_0030A0" Format="ci8" Width="32" Height="32" Offset="0x3090" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_14Tex_0034A0" OutName="jyasinzou_room_14Tex_0034A0" Format="rgba16" Width="32" Height="64" Offset="0x3490" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_14Tex_0044A0" OutName="jyasinzou_room_14Tex_0044A0" Format="ci4" Width="64" Height="64" Offset="0x4490" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
         <Room Name="jyasinzou_room_14" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_15" Segment="3">
+        <Texture Name="jyasinzou_room_15Tex_002FE8" OutName="jyasinzou_room_15Tex_002FE8" Format="rgba16" Width="32" Height="64" Offset="0x2FB8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_15Tex_003FE8" OutName="jyasinzou_room_15Tex_003FE8" Format="rgba16" Width="16" Height="32" Offset="0x3FB8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_15Tex_0043E8" OutName="jyasinzou_room_15Tex_0043E8" Format="ci8" Width="32" Height="64" Offset="0x43B8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_15Tex_004BE8" OutName="jyasinzou_room_15Tex_004BE8" Format="ci8" Width="32" Height="64" Offset="0x4BB8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_15Tex_0053E8" OutName="jyasinzou_room_15Tex_0053E8" Format="ci8" Width="64" Height="32" Offset="0x53B8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_15Tex_005BE8" OutName="jyasinzou_room_15Tex_005BE8" Format="ci8" Width="16" Height="16" Offset="0x5BB8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_15Tex_005CE8" OutName="jyasinzou_room_15Tex_005CE8" Format="ci8" Width="32" Height="32" Offset="0x5CB8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_15Tex_0060E8" OutName="jyasinzou_room_15Tex_0060E8" Format="ci8" Width="64" Height="32" Offset="0x60B8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_15Tex_0068E8" OutName="jyasinzou_room_15Tex_0068E8" Format="ci8" Width="32" Height="32" Offset="0x68B8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_15Tex_006CE8" OutName="jyasinzou_room_15Tex_006CE8" Format="ci4" Width="64" Height="64" Offset="0x6CB8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_15Tex_007C98" OutName="jyasinzou_room_15Tex_007C98" Format="rgba16" Width="32" Height="32" Offset="0x7C68" AddedByScript="true"/>
         <Room Name="jyasinzou_room_15" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_16" Segment="3">
+        <Texture Name="jyasinzou_room_16Tex_0029B8" OutName="jyasinzou_room_16Tex_0029B8" Format="rgba16" Width="32" Height="64" Offset="0x2988" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_16Tex_0039B8" OutName="jyasinzou_room_16Tex_0039B8" Format="ci8" Width="64" Height="32" Offset="0x3988" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_16Tex_0041B8" OutName="jyasinzou_room_16Tex_0041B8" Format="ci8" Width="16" Height="64" Offset="0x4188" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_16Tex_0045B8" OutName="jyasinzou_room_16Tex_0045B8" Format="ci8" Width="64" Height="32" Offset="0x4588" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_16Tex_004DB8" OutName="jyasinzou_room_16Tex_004DB8" Format="rgba16" Width="16" Height="32" Offset="0x4D88" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_16Tex_0051B8" OutName="jyasinzou_room_16Tex_0051B8" Format="ci8" Width="32" Height="64" Offset="0x5188" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_16Tex_0059B8" OutName="jyasinzou_room_16Tex_0059B8" Format="ci4" Width="64" Height="64" Offset="0x5988" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
         <Room Name="jyasinzou_room_16" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_17" Segment="3">
+        <Texture Name="jyasinzou_room_17Tex_005E50" OutName="jyasinzou_room_17Tex_005E50" Format="ci8" Width="64" Height="32" Offset="0x5E10" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_17Tex_006650" OutName="jyasinzou_room_17Tex_006650" Format="ci8" Width="64" Height="32" Offset="0x6610" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_17Tex_006E50" OutName="jyasinzou_room_17Tex_006E50" Format="ci8" Width="32" Height="32" Offset="0x6E10" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_17Tex_007250" OutName="jyasinzou_room_17Tex_007250" Format="ci8" Width="64" Height="32" Offset="0x7210" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_17Tex_007A50" OutName="jyasinzou_room_17Tex_007A50" Format="ci8" Width="64" Height="32" Offset="0x7A10" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_17Tex_008250" OutName="jyasinzou_room_17Tex_008250" Format="ci4" Width="64" Height="64" Offset="0x8210" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18000" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_17Tex_008A50" OutName="jyasinzou_room_17Tex_008A50" Format="ci8" Width="32" Height="32" Offset="0x8A10" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_17Tex_008E50" OutName="jyasinzou_room_17Tex_008E50" Format="ci4" Width="64" Height="64" Offset="0x8E10" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
         <Room Name="jyasinzou_room_17" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_18" Segment="3">
+        <Texture Name="jyasinzou_room_18Tex_0020F0" OutName="jyasinzou_room_18Tex_0020F0" Format="ci8" Width="64" Height="32" Offset="0x20C0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_18Tex_0028F0" OutName="jyasinzou_room_18Tex_0028F0" Format="ci8" Width="64" Height="32" Offset="0x28C0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_18Tex_0030F0" OutName="jyasinzou_room_18Tex_0030F0" Format="ci8" Width="32" Height="32" Offset="0x30C0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_18Tex_0034F0" OutName="jyasinzou_room_18Tex_0034F0" Format="rgba16" Width="32" Height="32" Offset="0x34C0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_18Tex_003CF0" OutName="jyasinzou_room_18Tex_003CF0" Format="ci8" Width="16" Height="128" Offset="0x3CC0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_18Tex_0044F0" OutName="jyasinzou_room_18Tex_0044F0" Format="ci8" Width="32" Height="32" Offset="0x44C0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_18Tex_0048F0" OutName="jyasinzou_room_18Tex_0048F0" Format="ci8" Width="32" Height="32" Offset="0x48C0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_18Tex_0054E0" OutName="jyasinzou_room_18Tex_0054E0" Format="rgba16" Width="32" Height="32" Offset="0x54B0" AddedByScript="true"/>
         <Room Name="jyasinzou_room_18" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_19" Segment="3">
+        <Texture Name="jyasinzou_room_19Tex_002DC8" OutName="jyasinzou_room_19Tex_002DC8" Format="rgba16" Width="32" Height="64" Offset="0x2DD8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_19Tex_003DC8" OutName="jyasinzou_room_19Tex_003DC8" Format="ci8" Width="64" Height="32" Offset="0x3DD8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_19Tex_0045C8" OutName="jyasinzou_room_19Tex_0045C8" Format="ci8" Width="64" Height="32" Offset="0x45D8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_19Tex_004DC8" OutName="jyasinzou_room_19Tex_004DC8" Format="rgba16" Width="16" Height="32" Offset="0x4DD8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_19Tex_0051C8" OutName="jyasinzou_room_19Tex_0051C8" Format="ci8" Width="64" Height="16" Offset="0x51D8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_19Tex_0055C8" OutName="jyasinzou_room_19Tex_0055C8" Format="ci8" Width="64" Height="32" Offset="0x55D8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
         <Room Name="jyasinzou_room_19" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_20" Segment="3">
+        <Texture Name="jyasinzou_room_20Tex_0031B8" OutName="jyasinzou_room_20Tex_0031B8" Format="rgba16" Width="32" Height="64" Offset="0x31B8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_20Tex_0041B8" OutName="jyasinzou_room_20Tex_0041B8" Format="ci8" Width="64" Height="32" Offset="0x41B8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_20Tex_0049B8" OutName="jyasinzou_room_20Tex_0049B8" Format="ci8" Width="64" Height="32" Offset="0x49B8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_20Tex_0051B8" OutName="jyasinzou_room_20Tex_0051B8" Format="ci8" Width="64" Height="32" Offset="0x51B8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_20Tex_0059B8" OutName="jyasinzou_room_20Tex_0059B8" Format="rgba16" Width="16" Height="32" Offset="0x59B8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_20Tex_005DB8" OutName="jyasinzou_room_20Tex_005DB8" Format="ci8" Width="64" Height="32" Offset="0x5DB8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_20Tex_0065B8" OutName="jyasinzou_room_20Tex_0065B8" Format="ci8" Width="32" Height="32" Offset="0x65B8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_20Tex_0069B8" OutName="jyasinzou_room_20Tex_0069B8" Format="rgba16" Width="64" Height="32" Offset="0x69B8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_20Tex_0079B8" OutName="jyasinzou_room_20Tex_0079B8" Format="ci8" Width="64" Height="16" Offset="0x79B8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_20Tex_007DB8" OutName="jyasinzou_room_20Tex_007DB8" Format="ci8" Width="32" Height="32" Offset="0x7DB8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
         <Room Name="jyasinzou_room_20" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_21" Segment="3">
+        <Texture Name="jyasinzou_room_21Tex_001660" OutName="jyasinzou_room_21Tex_001660" Format="rgba16" Width="32" Height="64" Offset="0x1650" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_21Tex_002660" OutName="jyasinzou_room_21Tex_002660" Format="ci8" Width="64" Height="32" Offset="0x2650" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_21Tex_002E60" OutName="jyasinzou_room_21Tex_002E60" Format="rgba16" Width="16" Height="32" Offset="0x2E50" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_21Tex_003260" OutName="jyasinzou_room_21Tex_003260" Format="ci8" Width="32" Height="32" Offset="0x3250" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_21Tex_003660" OutName="jyasinzou_room_21Tex_003660" Format="ci8" Width="64" Height="32" Offset="0x3650" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_21Tex_003E60" OutName="jyasinzou_room_21Tex_003E60" Format="ci4" Width="64" Height="64" Offset="0x3E50" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
         <Room Name="jyasinzou_room_21" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_22" Segment="3">
+        <Texture Name="jyasinzou_room_22Tex_001468" OutName="jyasinzou_room_22Tex_001468" Format="ci8" Width="64" Height="32" Offset="0x14C8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_22Tex_001C68" OutName="jyasinzou_room_22Tex_001C68" Format="ci8" Width="32" Height="64" Offset="0x1CC8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_22Tex_002468" OutName="jyasinzou_room_22Tex_002468" Format="ci8" Width="32" Height="32" Offset="0x24C8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_22Tex_002868" OutName="jyasinzou_room_22Tex_002868" Format="ci4" Width="64" Height="64" Offset="0x28C8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
         <Room Name="jyasinzou_room_22" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_23" Segment="3">
+        <Texture Name="jyasinzou_room_23Tex_004438" OutName="jyasinzou_room_23Tex_004438" Format="ci8" Width="32" Height="64" Offset="0x43B8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_23Tex_004C38" OutName="jyasinzou_room_23Tex_004C38" Format="ci8" Width="64" Height="32" Offset="0x4BB8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_23Tex_005438" OutName="jyasinzou_room_23Tex_005438" Format="ci8" Width="16" Height="64" Offset="0x53B8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_23Tex_005838" OutName="jyasinzou_room_23Tex_005838" Format="ci8" Width="64" Height="32" Offset="0x57B8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_23Tex_006038" OutName="jyasinzou_room_23Tex_006038" Format="ci8" Width="32" Height="32" Offset="0x5FB8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_23Tex_006438" OutName="jyasinzou_room_23Tex_006438" Format="ci8" Width="16" Height="128" Offset="0x63B8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_23Tex_006C38" OutName="jyasinzou_room_23Tex_006C38" Format="rgba16" Width="32" Height="32" Offset="0x6BB8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_23Tex_007438" OutName="jyasinzou_room_23Tex_007438" Format="ci8" Width="64" Height="32" Offset="0x73B8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_23Tex_007C38" OutName="jyasinzou_room_23Tex_007C38" Format="ci8" Width="32" Height="32" Offset="0x7BB8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_23Tex_008038" OutName="jyasinzou_room_23Tex_008038" Format="ci8" Width="64" Height="32" Offset="0x7FB8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_23Tex_008838" OutName="jyasinzou_room_23Tex_008838" Format="ci4" Width="64" Height="64" Offset="0x87B8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
         <Room Name="jyasinzou_room_23" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_24" Segment="3">
+        <Texture Name="jyasinzou_room_24Tex_001B38" OutName="jyasinzou_room_24Tex_001B38" Format="rgba16" Width="32" Height="64" Offset="0x1B18" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_24Tex_002B38" OutName="jyasinzou_room_24Tex_002B38" Format="ci8" Width="64" Height="32" Offset="0x2B18" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_24Tex_003338" OutName="jyasinzou_room_24Tex_003338" Format="ci8" Width="64" Height="32" Offset="0x3318" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_24Tex_003B38" OutName="jyasinzou_room_24Tex_003B38" Format="rgba16" Width="16" Height="32" Offset="0x3B18" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_24Tex_003F38" OutName="jyasinzou_room_24Tex_003F38" Format="ci8" Width="32" Height="32" Offset="0x3F18" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_24Tex_004338" OutName="jyasinzou_room_24Tex_004338" Format="ci8" Width="64" Height="32" Offset="0x4318" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_24Tex_004B38" OutName="jyasinzou_room_24Tex_004B38" Format="ci4" Width="64" Height="64" Offset="0x4B18" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_24Tex_0054D0" OutName="jyasinzou_room_24Tex_0054D0" Format="rgba16" Width="32" Height="64" Offset="0x54B0" AddedByScript="true"/>
         <Room Name="jyasinzou_room_24" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_25" Segment="3">
+        <Texture Name="jyasinzou_room_25Tex_00BA98" OutName="jyasinzou_room_25Tex_00BA98" Format="rgba16" Width="16" Height="32" Offset="0xBA68" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_00BE98" OutName="jyasinzou_room_25Tex_00BE98" Format="rgba16" Width="32" Height="64" Offset="0xBE68" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_00CE98" OutName="jyasinzou_room_25Tex_00CE98" Format="ci8" Width="32" Height="64" Offset="0xCE68" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_00D698" OutName="jyasinzou_room_25Tex_00D698" Format="ci8" Width="16" Height="64" Offset="0xD668" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_00DA98" OutName="jyasinzou_room_25Tex_00DA98" Format="ci8" Width="32" Height="32" Offset="0xDA68" TlutOffset="0xB870" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_00DE98" OutName="jyasinzou_room_25Tex_00DE98" Format="ci8" Width="32" Height="64" Offset="0xDE68" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_00E698" OutName="jyasinzou_room_25Tex_00E698" Format="ci8" Width="64" Height="32" Offset="0xE668" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_00EE98" OutName="jyasinzou_room_25Tex_00EE98" Format="rgba16" Width="32" Height="16" Offset="0xEE68" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_00F298" OutName="jyasinzou_room_25Tex_00F298" Format="ci8" Width="32" Height="32" Offset="0xF268" TlutOffset="0xB870" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_00F698" OutName="jyasinzou_room_25Tex_00F698" Format="ci8" Width="32" Height="64" Offset="0xF668" TlutOffset="0xB870" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_00FE98" OutName="jyasinzou_room_25Tex_00FE98" Format="ci8" Width="16" Height="16" Offset="0xFE68" TlutOffset="0xB870" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_00FF98" OutName="jyasinzou_room_25Tex_00FF98" Format="ci8" Width="32" Height="32" Offset="0xFF68" TlutOffset="0xB870" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_010398" OutName="jyasinzou_room_25Tex_010398" Format="ci8" Width="32" Height="32" Offset="0x10368" TlutOffset="0xB870" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_010798" OutName="jyasinzou_room_25Tex_010798" Format="ci8" Width="32" Height="32" Offset="0x10768" TlutOffset="0xB870" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_010B98" OutName="jyasinzou_room_25Tex_010B98" Format="ci8" Width="32" Height="32" Offset="0x10B68" TlutOffset="0xB870" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_010F98" OutName="jyasinzou_room_25Tex_010F98" Format="ci8" Width="32" Height="32" Offset="0x10F68" TlutOffset="0xB870" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_011398" OutName="jyasinzou_room_25Tex_011398" Format="ci8" Width="32" Height="32" Offset="0x11368" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_011798" OutName="jyasinzou_room_25Tex_011798" Format="ci8" Width="16" Height="128" Offset="0x11768" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_011F98" OutName="jyasinzou_room_25Tex_011F98" Format="ci8" Width="64" Height="32" Offset="0x11F68" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_012798" OutName="jyasinzou_room_25Tex_012798" Format="ci8" Width="32" Height="32" Offset="0x12768" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_012B98" OutName="jyasinzou_room_25Tex_012B98" Format="ci8" Width="32" Height="64" Offset="0x12B68" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_013398" OutName="jyasinzou_room_25Tex_013398" Format="ci8" Width="64" Height="32" Offset="0x13368" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_013B98" OutName="jyasinzou_room_25Tex_013B98" Format="ci8" Width="64" Height="32" Offset="0x13B68" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_014398" OutName="jyasinzou_room_25Tex_014398" Format="ci8" Width="32" Height="32" Offset="0x14368" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_014798" OutName="jyasinzou_room_25Tex_014798" Format="ci4" Width="64" Height="64" Offset="0x14768" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18000" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_014F98" OutName="jyasinzou_room_25Tex_014F98" Format="ci8" Width="32" Height="32" Offset="0x14F68" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_015398" OutName="jyasinzou_room_25Tex_015398" Format="ci4" Width="64" Height="64" Offset="0x15368" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25TLUT_00B8A0" OutName="jyasinzou_room_25TLUT_00B8A0" Format="rgba16" Width="16" Height="16" Offset="0xB870" AddedByScript="true"/>
         <Room Name="jyasinzou_room_25" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_26" Segment="3">
+        <Texture Name="jyasinzou_room_26Tex_006CC8" OutName="jyasinzou_room_26Tex_006CC8" Format="rgba16" Width="16" Height="32" Offset="0x6CE8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_26Tex_0070C8" OutName="jyasinzou_room_26Tex_0070C8" Format="rgba16" Width="32" Height="64" Offset="0x70E8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_26Tex_0080C8" OutName="jyasinzou_room_26Tex_0080C8" Format="rgba16" Width="16" Height="16" Offset="0x80E8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_26Tex_0082C8" OutName="jyasinzou_room_26Tex_0082C8" Format="ci8" Width="32" Height="64" Offset="0x82E8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_26Tex_008AC8" OutName="jyasinzou_room_26Tex_008AC8" Format="ci8" Width="16" Height="32" Offset="0x8AE8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_26Tex_008CC8" OutName="jyasinzou_room_26Tex_008CC8" Format="ci8" Width="32" Height="64" Offset="0x8CE8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_26Tex_0094C8" OutName="jyasinzou_room_26Tex_0094C8" Format="ci8" Width="64" Height="32" Offset="0x94E8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_26Tex_009CC8" OutName="jyasinzou_room_26Tex_009CC8" Format="rgba16" Width="16" Height="32" Offset="0x9CE8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_26Tex_00A0C8" OutName="jyasinzou_room_26Tex_00A0C8" Format="ci8" Width="16" Height="128" Offset="0xA0E8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_26Tex_00A8C8" OutName="jyasinzou_room_26Tex_00A8C8" Format="ci8" Width="32" Height="32" Offset="0xA8E8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_26Tex_00ACC8" OutName="jyasinzou_room_26Tex_00ACC8" Format="ci4" Width="64" Height="64" Offset="0xACE8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18000" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_26Tex_00B4C8" OutName="jyasinzou_room_26Tex_00B4C8" Format="ci4" Width="64" Height="64" Offset="0xB4E8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_26Tex_00C2F8" OutName="jyasinzou_room_26Tex_00C2F8" Format="ia16" Width="32" Height="32" Offset="0xC318" AddedByScript="true"/>
         <Room Name="jyasinzou_room_26" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_27" Segment="3">
+        <Texture Name="jyasinzou_room_27Tex_004310" OutName="jyasinzou_room_27Tex_004310" Format="ci8" Width="32" Height="64" Offset="0x42C0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_27Tex_004B10" OutName="jyasinzou_room_27Tex_004B10" Format="ci8" Width="32" Height="32" Offset="0x4AC0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_27Tex_004F10" OutName="jyasinzou_room_27Tex_004F10" Format="ci8" Width="64" Height="32" Offset="0x4EC0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
         <Room Name="jyasinzou_room_27" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_28" Segment="3">
+        <Texture Name="jyasinzou_room_28Tex_004130" OutName="jyasinzou_room_28Tex_004130" Format="ci8" Width="64" Height="32" Offset="0x4120" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_28Tex_004930" OutName="jyasinzou_room_28Tex_004930" Format="ci8" Width="64" Height="32" Offset="0x4920" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_28Tex_005130" OutName="jyasinzou_room_28Tex_005130" Format="ci8" Width="64" Height="32" Offset="0x5120" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_28Tex_005930" OutName="jyasinzou_room_28Tex_005930" Format="ci8" Width="64" Height="32" Offset="0x5920" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_28Tex_006130" OutName="jyasinzou_room_28Tex_006130" Format="ci8" Width="32" Height="32" Offset="0x6120" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_28Tex_006530" OutName="jyasinzou_room_28Tex_006530" Format="rgba16" Width="64" Height="32" Offset="0x6520" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_28Tex_007530" OutName="jyasinzou_room_28Tex_007530" Format="ci8" Width="64" Height="16" Offset="0x7520" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_28Tex_007930" OutName="jyasinzou_room_28Tex_007930" Format="ci8" Width="16" Height="16" Offset="0x7920" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_28Tex_007A30" OutName="jyasinzou_room_28Tex_007A30" Format="ci8" Width="16" Height="64" Offset="0x7A20" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_28Tex_007E30" OutName="jyasinzou_room_28Tex_007E30" Format="ci4" Width="64" Height="64" Offset="0x7E20" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18000" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_28Tex_008630" OutName="jyasinzou_room_28Tex_008630" Format="ci8" Width="32" Height="32" Offset="0x8620" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
         <Room Name="jyasinzou_room_28" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/scenes/dungeons/men.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/dungeons/men.xml
@@ -1,43 +1,127 @@
 <Root>
     <File Name="men_scene" Segment="2">
+        <Texture Name="men_sceneTex_0108C0" OutName="men_sceneTex_0108C0" Format="ci8" Width="32" Height="32" Offset="0x10930" TlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_sceneTex_010CC0" OutName="men_sceneTex_010CC0" Format="ci8" Width="64" Height="32" Offset="0x10D30" TlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_sceneTLUT_00F6C0" OutName="men_sceneTLUT_00F6C0" Format="rgba16" Width="16" Height="16" Offset="0xF730" AddedByScript="true"/>
         <Path Name="gGTGPath_002F0" Offset="0x2F0" NumPaths="2"/>
         <Texture Name="gGTGDayEntranceTex" OutName="day_entrance" Format="ia16" Width="8" Height="128" Offset="0xF930"/>
         <Texture Name="gGTGNightEntranceTex" OutName="night_entrance" Format="ia16" Width="8" Height="128" Offset="0x10130"/>
         <Scene Name="men_scene" Offset="0x0"/>
     </File>
     <File Name="men_room_0" Segment="3">
+        <Texture Name="men_room_0Tex_008138" OutName="men_room_0Tex_008138" Format="ci8" Width="64" Height="32" Offset="0x8138" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_0Tex_008938" OutName="men_room_0Tex_008938" Format="ci8" Width="32" Height="64" Offset="0x8938" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_0Tex_009138" OutName="men_room_0Tex_009138" Format="ci8" Width="32" Height="32" Offset="0x9138" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_0Tex_009538" OutName="men_room_0Tex_009538" Format="rgba16" Width="32" Height="32" Offset="0x9538" AddedByScript="true"/>
+        <Texture Name="men_room_0Tex_009D38" OutName="men_room_0Tex_009D38" Format="ci8" Width="32" Height="64" Offset="0x9D38" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_0Tex_00A538" OutName="men_room_0Tex_00A538" Format="ia8" Width="64" Height="64" Offset="0xA538" AddedByScript="true"/>
+        <Texture Name="men_room_0Tex_00B538" OutName="men_room_0Tex_00B538" Format="ci8" Width="32" Height="64" Offset="0xB538" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_0Tex_00BD38" OutName="men_room_0Tex_00BD38" Format="ci8" Width="64" Height="32" Offset="0xBD38" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_0Tex_00C538" OutName="men_room_0Tex_00C538" Format="i4" Width="64" Height="128" Offset="0xC538" AddedByScript="true"/>
+        <Texture Name="men_room_0Tex_00D538" OutName="men_room_0Tex_00D538" Format="ci8" Width="64" Height="32" Offset="0xD538" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_0Tex_00DD38" OutName="men_room_0Tex_00DD38" Format="rgba16" Width="16" Height="128" Offset="0xDD38" AddedByScript="true"/>
+        <Texture Name="men_room_0Tex_00ED38" OutName="men_room_0Tex_00ED38" Format="ci8" Width="64" Height="32" Offset="0xED38" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_0Tex_00F538" OutName="men_room_0Tex_00F538" Format="ci8" Width="64" Height="32" Offset="0xF538" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
         <DList Name="gMenDL_008118" Offset="0x8118"/>
         <DList Name="gMenDL_00FF78" Offset="0xFF78"/>
         <Room Name="men_room_0" Offset="0x0"/>
     </File>
     <File Name="men_room_1" Segment="3">
+        <Texture Name="men_room_1Tex_004270" OutName="men_room_1Tex_004270" Format="rgba16" Width="32" Height="32" Offset="0x4290" AddedByScript="true"/>
+        <Texture Name="men_room_1Tex_004A70" OutName="men_room_1Tex_004A70" Format="ci8" Width="64" Height="32" Offset="0x4A90" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_1Tex_005270" OutName="men_room_1Tex_005270" Format="ci8" Width="32" Height="64" Offset="0x5290" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_1Tex_005A70" OutName="men_room_1Tex_005A70" Format="ci8" Width="64" Height="32" Offset="0x5A90" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_1Tex_006270" OutName="men_room_1Tex_006270" Format="rgba16" Width="32" Height="32" Offset="0x6290" AddedByScript="true"/>
+        <Texture Name="men_room_1Tex_006A70" OutName="men_room_1Tex_006A70" Format="rgba16" Width="32" Height="32" Offset="0x6A90" AddedByScript="true"/>
+        <Texture Name="men_room_1Tex_007270" OutName="men_room_1Tex_007270" Format="ci8" Width="64" Height="32" Offset="0x7290" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_1Tex_007A70" OutName="men_room_1Tex_007A70" Format="rgba16" Width="16" Height="128" Offset="0x7A90" AddedByScript="true"/>
+        <Texture Name="men_room_1Tex_008A70" OutName="men_room_1Tex_008A70" Format="ci8" Width="64" Height="32" Offset="0x8A90" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
         <Room Name="men_room_1" Offset="0x0"/>
     </File>
     <File Name="men_room_2" Segment="3">
+        <Texture Name="men_room_2Tex_003C48" OutName="men_room_2Tex_003C48" Format="ci8" Width="64" Height="32" Offset="0x3B78" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_2Tex_004448" OutName="men_room_2Tex_004448" Format="ci8" Width="64" Height="32" Offset="0x4378" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_2Tex_004C48" OutName="men_room_2Tex_004C48" Format="ci8" Width="32" Height="32" Offset="0x4B78" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
         <Room Name="men_room_2" Offset="0x0"/>
     </File>
     <File Name="men_room_3" Segment="3">
+        <Texture Name="men_room_3Tex_003850" OutName="men_room_3Tex_003850" Format="ci8" Width="64" Height="32" Offset="0x3820" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_3Tex_004050" OutName="men_room_3Tex_004050" Format="ci8" Width="64" Height="32" Offset="0x4020" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_3Tex_004850" OutName="men_room_3Tex_004850" Format="ci8" Width="32" Height="64" Offset="0x4820" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_3Tex_005050" OutName="men_room_3Tex_005050" Format="ci8" Width="64" Height="32" Offset="0x5020" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_3Tex_005850" OutName="men_room_3Tex_005850" Format="ci8" Width="32" Height="32" Offset="0x5820" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_3Tex_005C50" OutName="men_room_3Tex_005C50" Format="ci8" Width="64" Height="32" Offset="0x5C20" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_3Tex_006450" OutName="men_room_3Tex_006450" Format="rgba16" Width="16" Height="128" Offset="0x6420" AddedByScript="true"/>
+        <Texture Name="men_room_3Tex_007450" OutName="men_room_3Tex_007450" Format="ci8" Width="64" Height="32" Offset="0x7420" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
         <Room Name="men_room_3" Offset="0x0"/>
     </File>
     <File Name="men_room_4" Segment="3">
+        <Texture Name="men_room_4Tex_0051E0" OutName="men_room_4Tex_0051E0" Format="rgba16" Width="32" Height="32" Offset="0x5150" AddedByScript="true"/>
+        <Texture Name="men_room_4Tex_0059E0" OutName="men_room_4Tex_0059E0" Format="rgba16" Width="32" Height="32" Offset="0x5950" AddedByScript="true"/>
+        <Texture Name="men_room_4Tex_0061E0" OutName="men_room_4Tex_0061E0" Format="i4" Width="128" Height="64" Offset="0x6150" AddedByScript="true"/>
+        <Texture Name="men_room_4Tex_0071E0" OutName="men_room_4Tex_0071E0" Format="i4" Width="64" Height="128" Offset="0x7150" AddedByScript="true"/>
+        <Texture Name="men_room_4Tex_0081E0" OutName="men_room_4Tex_0081E0" Format="ci8" Width="32" Height="64" Offset="0x8150" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_4Tex_0089E0" OutName="men_room_4Tex_0089E0" Format="i4" Width="64" Height="128" Offset="0x8950" AddedByScript="true"/>
+        <Texture Name="men_room_4Tex_0099E0" OutName="men_room_4Tex_0099E0" Format="ci8" Width="64" Height="32" Offset="0x9950" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
         <Room Name="men_room_4" Offset="0x0"/>
     </File>
     <File Name="men_room_5" Segment="3">
+        <Texture Name="men_room_5Tex_002418" OutName="men_room_5Tex_002418" Format="ci8" Width="64" Height="32" Offset="0x24D8" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_5Tex_002C18" OutName="men_room_5Tex_002C18" Format="ci8" Width="32" Height="32" Offset="0x2CD8" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_5Tex_003018" OutName="men_room_5Tex_003018" Format="ci8" Width="32" Height="64" Offset="0x30D8" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_5Tex_003818" OutName="men_room_5Tex_003818" Format="ci8" Width="64" Height="32" Offset="0x38D8" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_5Tex_004018" OutName="men_room_5Tex_004018" Format="ci8" Width="64" Height="32" Offset="0x40D8" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_5Tex_004818" OutName="men_room_5Tex_004818" Format="ci8" Width="64" Height="32" Offset="0x48D8" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
         <Room Name="men_room_5" Offset="0x0"/>
     </File>
     <File Name="men_room_6" Segment="3">
+        <Texture Name="men_room_6Tex_003F78" OutName="men_room_6Tex_003F78" Format="rgba16" Width="32" Height="32" Offset="0x3F38" AddedByScript="true"/>
+        <Texture Name="men_room_6Tex_004778" OutName="men_room_6Tex_004778" Format="ci8" Width="32" Height="64" Offset="0x4738" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_6Tex_004F78" OutName="men_room_6Tex_004F78" Format="ci8" Width="32" Height="32" Offset="0x4F38" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_6Tex_005378" OutName="men_room_6Tex_005378" Format="rgba16" Width="32" Height="32" Offset="0x5338" AddedByScript="true"/>
+        <Texture Name="men_room_6Tex_005B78" OutName="men_room_6Tex_005B78" Format="ci8" Width="32" Height="64" Offset="0x5B38" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_6Tex_006378" OutName="men_room_6Tex_006378" Format="ci8" Width="32" Height="64" Offset="0x6338" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_6Tex_006B78" OutName="men_room_6Tex_006B78" Format="ci8" Width="64" Height="32" Offset="0x6B38" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_6Tex_007378" OutName="men_room_6Tex_007378" Format="ci8" Width="32" Height="32" Offset="0x7338" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_6Tex_007778" OutName="men_room_6Tex_007778" Format="ci8" Width="64" Height="32" Offset="0x7738" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
         <Room Name="men_room_6" Offset="0x0"/>
     </File>
     <File Name="men_room_7" Segment="3">
+        <Texture Name="men_room_7Tex_0036B8" OutName="men_room_7Tex_0036B8" Format="ci8" Width="32" Height="32" Offset="0x3728" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_7Tex_003AB8" OutName="men_room_7Tex_003AB8" Format="ci8" Width="64" Height="32" Offset="0x3B28" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_7Tex_0042B8" OutName="men_room_7Tex_0042B8" Format="ci8" Width="32" Height="64" Offset="0x4328" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_7Tex_004AB8" OutName="men_room_7Tex_004AB8" Format="rgba16" Width="32" Height="32" Offset="0x4B28" AddedByScript="true"/>
+        <Texture Name="men_room_7Tex_0052B8" OutName="men_room_7Tex_0052B8" Format="ci8" Width="64" Height="32" Offset="0x5328" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_7Tex_005AB8" OutName="men_room_7Tex_005AB8" Format="ci8" Width="64" Height="32" Offset="0x5B28" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_7Tex_0062B8" OutName="men_room_7Tex_0062B8" Format="rgba16" Width="16" Height="128" Offset="0x6328" AddedByScript="true"/>
+        <Texture Name="men_room_7Tex_0072B8" OutName="men_room_7Tex_0072B8" Format="ci8" Width="64" Height="32" Offset="0x7328" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_7Tex_007AB8" OutName="men_room_7Tex_007AB8" Format="ci8" Width="64" Height="32" Offset="0x7B28" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
         <Room Name="men_room_7" Offset="0x0"/>
     </File>
     <File Name="men_room_8" Segment="3">
+        <Texture Name="men_room_8Tex_005D30" OutName="men_room_8Tex_005D30" Format="rgba16" Width="16" Height="64" Offset="0x5D10" AddedByScript="true"/>
+        <Texture Name="men_room_8Tex_006530" OutName="men_room_8Tex_006530" Format="rgba16" Width="32" Height="32" Offset="0x6510" AddedByScript="true"/>
+        <Texture Name="men_room_8Tex_006D30" OutName="men_room_8Tex_006D30" Format="ci8" Width="32" Height="64" Offset="0x6D10" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_8Tex_007530" OutName="men_room_8Tex_007530" Format="rgba16" Width="8" Height="16" Offset="0x7510" AddedByScript="true"/>
+        <Texture Name="men_room_8Tex_007630" OutName="men_room_8Tex_007630" Format="rgba16" Width="32" Height="32" Offset="0x7610" AddedByScript="true"/>
+        <Texture Name="men_room_8Tex_007E30" OutName="men_room_8Tex_007E30" Format="ci8" Width="32" Height="32" Offset="0x7E10" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
         <Room Name="men_room_8" Offset="0x0"/>
     </File>
     <File Name="men_room_9" Segment="3">
+        <Texture Name="men_room_9Tex_001AB0" OutName="men_room_9Tex_001AB0" Format="rgba16" Width="32" Height="32" Offset="0x1B30" AddedByScript="true"/>
+        <Texture Name="men_room_9Tex_0022B0" OutName="men_room_9Tex_0022B0" Format="ci8" Width="32" Height="32" Offset="0x2330" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_9Tex_0026B0" OutName="men_room_9Tex_0026B0" Format="ci8" Width="64" Height="32" Offset="0x2730" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_9Tex_003070" OutName="men_room_9Tex_003070" Format="rgba16" Width="32" Height="32" Offset="0x30F0" AddedByScript="true"/>
         <Room Name="men_room_9" Offset="0x0"/>
     </File>
     <File Name="men_room_10" Segment="3">
+        <Texture Name="men_room_10Tex_002448" OutName="men_room_10Tex_002448" Format="ci8" Width="64" Height="32" Offset="0x2458" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_10Tex_002C48" OutName="men_room_10Tex_002C48" Format="rgba16" Width="32" Height="32" Offset="0x2C58" AddedByScript="true"/>
+        <Texture Name="men_room_10Tex_003448" OutName="men_room_10Tex_003448" Format="ci8" Width="32" Height="64" Offset="0x3458" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_10Tex_003C48" OutName="men_room_10Tex_003C48" Format="ci8" Width="64" Height="32" Offset="0x3C58" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_10Tex_004448" OutName="men_room_10Tex_004448" Format="rgba16" Width="32" Height="32" Offset="0x4458" AddedByScript="true"/>
+        <Texture Name="men_room_10Tex_004C48" OutName="men_room_10Tex_004C48" Format="ci8" Width="32" Height="64" Offset="0x4C58" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_10Tex_005448" OutName="men_room_10Tex_005448" Format="ci8" Width="64" Height="32" Offset="0x5458" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
         <Room Name="men_room_10" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/scenes/dungeons/moribossroom.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/dungeons/moribossroom.xml
@@ -1,11 +1,33 @@
 <Root>
     <File Name="moribossroom_scene" Segment="2">
+        <Texture Name="moribossroom_sceneTex_000CF8" OutName="moribossroom_sceneTex_000CF8" Format="ci8" Width="32" Height="32" Offset="0xCF8" TlutOffset="0xB50" AddedByScript="true"/>
+        <Texture Name="moribossroom_sceneTex_0010F8" OutName="moribossroom_sceneTex_0010F8" Format="ci8" Width="32" Height="64" Offset="0x10F8" TlutOffset="0xB50" AddedByScript="true"/>
+        <Texture Name="moribossroom_sceneTLUT_000B50" OutName="moribossroom_sceneTLUT_000B50" Format="rgba16" Width="16" Height="16" Offset="0xB50" AddedByScript="true"/>
         <Scene Name="moribossroom_scene" Offset="0x0"/>
     </File>
     <File Name="moribossroom_room_0" Segment="3">
+        <Texture Name="moribossroom_room_0Tex_0038B8" OutName="moribossroom_room_0Tex_0038B8" Format="rgba16" Width="32" Height="32" Offset="0x38B8" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_0Tex_0040B8" OutName="moribossroom_room_0Tex_0040B8" Format="ci8" Width="32" Height="32" Offset="0x40B8" ExternalTlut="moribossroom_scene" ExternalTlutOffset="0xB50" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_0Tex_0044B8" OutName="moribossroom_room_0Tex_0044B8" Format="rgba16" Width="64" Height="32" Offset="0x44B8" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_0Tex_0054B8" OutName="moribossroom_room_0Tex_0054B8" Format="rgba16" Width="16" Height="16" Offset="0x54B8" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_0Tex_0056B8" OutName="moribossroom_room_0Tex_0056B8" Format="ci8" Width="32" Height="64" Offset="0x56B8" ExternalTlut="moribossroom_scene" ExternalTlutOffset="0xB50" AddedByScript="true"/>
         <Room Name="moribossroom_room_0" Offset="0x0"/>
     </File>
     <File Name="moribossroom_room_1" Segment="3">
+        <Texture Name="moribossroom_room_1Tex_006A20" OutName="moribossroom_room_1Tex_006A20" Format="rgba16" Width="32" Height="64" Offset="0x6A20" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_1Tex_007A20" OutName="moribossroom_room_1Tex_007A20" Format="rgba16" Width="64" Height="32" Offset="0x7A20" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_1Tex_008A20" OutName="moribossroom_room_1Tex_008A20" Format="rgba16" Width="64" Height="32" Offset="0x8A20" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_1Tex_009A20" OutName="moribossroom_room_1Tex_009A20" Format="rgba16" Width="8" Height="16" Offset="0x9A20" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_1Tex_009B20" OutName="moribossroom_room_1Tex_009B20" Format="rgba16" Width="16" Height="16" Offset="0x9B20" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_1Tex_009D20" OutName="moribossroom_room_1Tex_009D20" Format="ci8" Width="32" Height="64" Offset="0x9D20" TlutOffset="0x6828" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_1Tex_00A520" OutName="moribossroom_room_1Tex_00A520" Format="ci8" Width="64" Height="32" Offset="0xA520" TlutOffset="0x6828" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_1Tex_00AD20" OutName="moribossroom_room_1Tex_00AD20" Format="ci8" Width="64" Height="32" Offset="0xAD20" TlutOffset="0x6828" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_1Tex_00B520" OutName="moribossroom_room_1Tex_00B520" Format="ci8" Width="64" Height="32" Offset="0xB520" ExternalTlut="moribossroom_scene" ExternalTlutOffset="0xB50" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_1Tex_00BD20" OutName="moribossroom_room_1Tex_00BD20" Format="ci8" Width="32" Height="64" Offset="0xBD20" TlutOffset="0x6828" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_1Tex_00C520" OutName="moribossroom_room_1Tex_00C520" Format="ci8" Width="64" Height="32" Offset="0xC520" TlutOffset="0x6828" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_1Tex_00CD20" OutName="moribossroom_room_1Tex_00CD20" Format="ci8" Width="64" Height="32" Offset="0xCD20" TlutOffset="0x6828" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_1Tex_00D6A8" OutName="moribossroom_room_1Tex_00D6A8" Format="rgba16" Width="16" Height="32" Offset="0xD6A8" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_1TLUT_006828" OutName="moribossroom_room_1TLUT_006828" Format="rgba16" Width="16" Height="16" Offset="0x6828" AddedByScript="true"/>
         <Room Name="moribossroom_room_1" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/scenes/dungeons/ydan.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/dungeons/ydan.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="ydan_scene" Segment="2">
+        <Texture Name="ydan_sceneTLUT_00B810" OutName="ydan_sceneTLUT_00B810" Format="rgba16" Width="16" Height="16" Offset="0xB800" AddedByScript="true"/>
         <Cutscene Name="gDekuTreeIntroCs" Offset="0xB640"/>
         <Texture Name="gYdanTex_00BA18" Format="rgba16" Width="32" Height="64" Offset="0xBA08"/>
         <Texture Name="gYdanTex_00CA18" Format="rgba16" Width="32" Height="64" Offset="0xCA08"/>
@@ -7,39 +8,150 @@
         <Scene Name="ydan_scene" Offset="0x0"/>
     </File>
     <File Name="ydan_room_0" Segment="3">
+        <Texture Name="ydan_room_0Tex_0071C0" OutName="ydan_room_0Tex_0071C0" Format="rgba16" Width="32" Height="64" Offset="0x7160" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_0081C0" OutName="ydan_room_0Tex_0081C0" Format="rgba16" Width="32" Height="64" Offset="0x8160" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_0091C0" OutName="ydan_room_0Tex_0091C0" Format="ci8" Width="32" Height="64" Offset="0x9160" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_0099C0" OutName="ydan_room_0Tex_0099C0" Format="ci8" Width="32" Height="64" Offset="0x9960" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_00A1C0" OutName="ydan_room_0Tex_00A1C0" Format="ci8" Width="32" Height="32" Offset="0xA160" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_00A5C0" OutName="ydan_room_0Tex_00A5C0" Format="ci8" Width="32" Height="64" Offset="0xA560" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_00ADC0" OutName="ydan_room_0Tex_00ADC0" Format="ci8" Width="32" Height="64" Offset="0xAD60" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_00B5C0" OutName="ydan_room_0Tex_00B5C0" Format="ci8" Width="32" Height="64" Offset="0xB560" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_00BDC0" OutName="ydan_room_0Tex_00BDC0" Format="rgba16" Width="32" Height="32" Offset="0xBD60" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_00C5C0" OutName="ydan_room_0Tex_00C5C0" Format="ci8" Width="32" Height="64" Offset="0xC560" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_00CDC0" OutName="ydan_room_0Tex_00CDC0" Format="ci8" Width="32" Height="64" Offset="0xCD60" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_00D5C0" OutName="ydan_room_0Tex_00D5C0" Format="ci8" Width="32" Height="32" Offset="0xD560" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_00D9C0" OutName="ydan_room_0Tex_00D9C0" Format="ci8" Width="32" Height="64" Offset="0xD960" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_00E1C0" OutName="ydan_room_0Tex_00E1C0" Format="ci8" Width="32" Height="64" Offset="0xE160" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_00E9C0" OutName="ydan_room_0Tex_00E9C0" Format="ci8" Width="32" Height="64" Offset="0xE960" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_00F1C0" OutName="ydan_room_0Tex_00F1C0" Format="ci8" Width="32" Height="64" Offset="0xF160" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_00F9C0" OutName="ydan_room_0Tex_00F9C0" Format="rgba16" Width="64" Height="32" Offset="0xF960" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_0109C0" OutName="ydan_room_0Tex_0109C0" Format="ci8" Width="32" Height="64" Offset="0x10960" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_012F48" OutName="ydan_room_0Tex_012F48" Format="rgba16" Width="32" Height="64" Offset="0x12EE8" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_013F48" OutName="ydan_room_0Tex_013F48" Format="ci8" Width="32" Height="32" Offset="0x13EE8" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_014348" OutName="ydan_room_0Tex_014348" Format="ia16" Width="32" Height="64" Offset="0x142E8" AddedByScript="true"/>
         <Room Name="ydan_room_0" Offset="0x0"/>
     </File>
     <File Name="ydan_room_1" Segment="3">
+        <Texture Name="ydan_room_1Tex_000F98" OutName="ydan_room_1Tex_000F98" Format="ci8" Width="32" Height="64" Offset="0xEE8" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_1Tex_001798" OutName="ydan_room_1Tex_001798" Format="ci8" Width="32" Height="64" Offset="0x16E8" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_1Tex_001F98" OutName="ydan_room_1Tex_001F98" Format="ci8" Width="32" Height="64" Offset="0x1EE8" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_1Tex_002798" OutName="ydan_room_1Tex_002798" Format="ci8" Width="32" Height="64" Offset="0x26E8" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_1Tex_003200" OutName="ydan_room_1Tex_003200" Format="ia16" Width="32" Height="64" Offset="0x3150" AddedByScript="true"/>
         <Room Name="ydan_room_1" Offset="0x0"/>
     </File>
     <File Name="ydan_room_2" Segment="3">
+        <Texture Name="ydan_room_2Tex_001D08" OutName="ydan_room_2Tex_001D08" Format="ci8" Width="32" Height="64" Offset="0x1C08" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_2Tex_002508" OutName="ydan_room_2Tex_002508" Format="ci8" Width="32" Height="64" Offset="0x2408" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_2Tex_002D08" OutName="ydan_room_2Tex_002D08" Format="ci8" Width="32" Height="64" Offset="0x2C08" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_2Tex_003508" OutName="ydan_room_2Tex_003508" Format="ci8" Width="32" Height="64" Offset="0x3408" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_2Tex_003D08" OutName="ydan_room_2Tex_003D08" Format="ci8" Width="32" Height="64" Offset="0x3C08" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_2Tex_004508" OutName="ydan_room_2Tex_004508" Format="ci8" Width="32" Height="64" Offset="0x4408" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_2Tex_004F28" OutName="ydan_room_2Tex_004F28" Format="rgba16" Width="32" Height="64" Offset="0x4E28" AddedByScript="true"/>
         <Room Name="ydan_room_2" Offset="0x0"/>
     </File>
     <File Name="ydan_room_3" Segment="3">
+        <Texture Name="ydan_room_3Tex_0074C0" OutName="ydan_room_3Tex_0074C0" Format="rgba16" Width="32" Height="64" Offset="0x74B0" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_0084C0" OutName="ydan_room_3Tex_0084C0" Format="ci8" Width="32" Height="64" Offset="0x84B0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_008CC0" OutName="ydan_room_3Tex_008CC0" Format="ci8" Width="32" Height="64" Offset="0x8CB0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_0094C0" OutName="ydan_room_3Tex_0094C0" Format="ci8" Width="32" Height="64" Offset="0x94B0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_009CC0" OutName="ydan_room_3Tex_009CC0" Format="ci8" Width="32" Height="32" Offset="0x9CB0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_00A0C0" OutName="ydan_room_3Tex_00A0C0" Format="ci8" Width="32" Height="64" Offset="0xA0B0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_00A8C0" OutName="ydan_room_3Tex_00A8C0" Format="ci8" Width="64" Height="32" Offset="0xA8B0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_00B0C0" OutName="ydan_room_3Tex_00B0C0" Format="ci8" Width="32" Height="32" Offset="0xB0B0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_00B4C0" OutName="ydan_room_3Tex_00B4C0" Format="ci8" Width="32" Height="32" Offset="0xB4B0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_00B8C0" OutName="ydan_room_3Tex_00B8C0" Format="ci8" Width="32" Height="64" Offset="0xB8B0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_00C0C0" OutName="ydan_room_3Tex_00C0C0" Format="ci8" Width="32" Height="64" Offset="0xC0B0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_00C8C0" OutName="ydan_room_3Tex_00C8C0" Format="ci8" Width="32" Height="64" Offset="0xC8B0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_00D0C0" OutName="ydan_room_3Tex_00D0C0" Format="ci8" Width="32" Height="32" Offset="0xD0B0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_00D4C0" OutName="ydan_room_3Tex_00D4C0" Format="ci8" Width="32" Height="32" Offset="0xD4B0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_00D8C0" OutName="ydan_room_3Tex_00D8C0" Format="ci8" Width="32" Height="64" Offset="0xD8B0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_00E0C0" OutName="ydan_room_3Tex_00E0C0" Format="ci8" Width="32" Height="64" Offset="0xE0B0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_00E8C0" OutName="ydan_room_3Tex_00E8C0" Format="rgba16" Width="64" Height="32" Offset="0xE8B0" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_00F8C0" OutName="ydan_room_3Tex_00F8C0" Format="ci8" Width="32" Height="64" Offset="0xF8B0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_011DB0" OutName="ydan_room_3Tex_011DB0" Format="rgba16" Width="32" Height="64" Offset="0x11DA0" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_012DB0" OutName="ydan_room_3Tex_012DB0" Format="ci8" Width="32" Height="32" Offset="0x12DA0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_0131B0" OutName="ydan_room_3Tex_0131B0" Format="ia16" Width="32" Height="64" Offset="0x131A0" AddedByScript="true"/>
         <Room Name="ydan_room_3" Offset="0x0"/>
     </File>
     <File Name="ydan_room_4" Segment="3">
+        <Texture Name="ydan_room_4Tex_001920" OutName="ydan_room_4Tex_001920" Format="ci8" Width="32" Height="64" Offset="0x18C0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_4Tex_002120" OutName="ydan_room_4Tex_002120" Format="ci8" Width="32" Height="64" Offset="0x20C0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_4Tex_002920" OutName="ydan_room_4Tex_002920" Format="ci8" Width="32" Height="64" Offset="0x28C0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_4Tex_003120" OutName="ydan_room_4Tex_003120" Format="ci8" Width="64" Height="32" Offset="0x30C0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_4Tex_003C28" OutName="ydan_room_4Tex_003C28" Format="ia16" Width="32" Height="64" Offset="0x3BC8" AddedByScript="true"/>
         <Room Name="ydan_room_4" Offset="0x0"/>
     </File>
     <File Name="ydan_room_5" Segment="3">
+        <Texture Name="ydan_room_5Tex_003F88" OutName="ydan_room_5Tex_003F88" Format="ci8" Width="32" Height="64" Offset="0x3F18" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_5Tex_004788" OutName="ydan_room_5Tex_004788" Format="ci8" Width="32" Height="64" Offset="0x4718" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_5Tex_004F88" OutName="ydan_room_5Tex_004F88" Format="ci8" Width="32" Height="64" Offset="0x4F18" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_5Tex_005788" OutName="ydan_room_5Tex_005788" Format="ci8" Width="32" Height="32" Offset="0x5718" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_5Tex_005B88" OutName="ydan_room_5Tex_005B88" Format="ci8" Width="32" Height="64" Offset="0x5B18" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_5Tex_006388" OutName="ydan_room_5Tex_006388" Format="ci8" Width="64" Height="32" Offset="0x6318" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_5Tex_006B88" OutName="ydan_room_5Tex_006B88" Format="ci8" Width="32" Height="32" Offset="0x6B18" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_5Tex_006F88" OutName="ydan_room_5Tex_006F88" Format="ci8" Width="32" Height="32" Offset="0x6F18" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_5Tex_007388" OutName="ydan_room_5Tex_007388" Format="ci8" Width="32" Height="32" Offset="0x7318" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_5Tex_007788" OutName="ydan_room_5Tex_007788" Format="ci8" Width="32" Height="32" Offset="0x7718" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_5Tex_007B88" OutName="ydan_room_5Tex_007B88" Format="ci8" Width="32" Height="64" Offset="0x7B18" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
         <Room Name="ydan_room_5" Offset="0x0"/>
     </File>
     <File Name="ydan_room_6" Segment="3">
+        <Texture Name="ydan_room_6Tex_001F00" OutName="ydan_room_6Tex_001F00" Format="ci8" Width="32" Height="64" Offset="0x1EC0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_6Tex_002700" OutName="ydan_room_6Tex_002700" Format="ci8" Width="32" Height="64" Offset="0x26C0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_6Tex_002F00" OutName="ydan_room_6Tex_002F00" Format="ci8" Width="32" Height="64" Offset="0x2EC0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_6Tex_003700" OutName="ydan_room_6Tex_003700" Format="ci8" Width="32" Height="64" Offset="0x36C0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_6Tex_003F00" OutName="ydan_room_6Tex_003F00" Format="ci8" Width="32" Height="64" Offset="0x3EC0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_6Tex_004700" OutName="ydan_room_6Tex_004700" Format="ci8" Width="32" Height="64" Offset="0x46C0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
         <Room Name="ydan_room_6" Offset="0x0"/>
     </File>
     <File Name="ydan_room_7" Segment="3">
+        <Texture Name="ydan_room_7Tex_002C98" OutName="ydan_room_7Tex_002C98" Format="ci8" Width="32" Height="64" Offset="0x2B08" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_7Tex_003498" OutName="ydan_room_7Tex_003498" Format="ci8" Width="32" Height="64" Offset="0x3308" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_7Tex_003C98" OutName="ydan_room_7Tex_003C98" Format="ci8" Width="32" Height="64" Offset="0x3B08" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_7Tex_004498" OutName="ydan_room_7Tex_004498" Format="ci8" Width="32" Height="64" Offset="0x4308" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_7Tex_004C98" OutName="ydan_room_7Tex_004C98" Format="ci8" Width="64" Height="32" Offset="0x4B08" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_7Tex_005498" OutName="ydan_room_7Tex_005498" Format="ci8" Width="32" Height="32" Offset="0x5308" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_7Tex_005898" OutName="ydan_room_7Tex_005898" Format="ci8" Width="32" Height="64" Offset="0x5708" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_7Tex_006098" OutName="ydan_room_7Tex_006098" Format="ci8" Width="32" Height="64" Offset="0x5F08" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_7Tex_006898" OutName="ydan_room_7Tex_006898" Format="ci8" Width="32" Height="32" Offset="0x6708" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_7Tex_006C98" OutName="ydan_room_7Tex_006C98" Format="ci8" Width="32" Height="32" Offset="0x6B08" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_7Tex_007098" OutName="ydan_room_7Tex_007098" Format="ci8" Width="32" Height="64" Offset="0x6F08" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_7Tex_007A98" OutName="ydan_room_7Tex_007A98" Format="rgba16" Width="32" Height="64" Offset="0x7908" AddedByScript="true"/>
         <Room Name="ydan_room_7" Offset="0x0"/>
     </File>
     <File Name="ydan_room_8" Segment="3">
+        <Texture Name="ydan_room_8Tex_000988" OutName="ydan_room_8Tex_000988" Format="ci8" Width="32" Height="32" Offset="0x8F8" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
         <Room Name="ydan_room_8" Offset="0x0"/>
     </File>
     <File Name="ydan_room_9" Segment="3">
+        <Texture Name="ydan_room_9Tex_002480" OutName="ydan_room_9Tex_002480" Format="ci8" Width="32" Height="64" Offset="0x2480" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_9Tex_002C80" OutName="ydan_room_9Tex_002C80" Format="ci8" Width="32" Height="64" Offset="0x2C80" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_9Tex_003480" OutName="ydan_room_9Tex_003480" Format="ci8" Width="32" Height="64" Offset="0x3480" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_9Tex_003C80" OutName="ydan_room_9Tex_003C80" Format="ci8" Width="32" Height="64" Offset="0x3C80" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_9Tex_004480" OutName="ydan_room_9Tex_004480" Format="ci8" Width="32" Height="64" Offset="0x4480" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_9Tex_004C80" OutName="ydan_room_9Tex_004C80" Format="ci8" Width="32" Height="64" Offset="0x4C80" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_9Tex_005480" OutName="ydan_room_9Tex_005480" Format="ci8" Width="32" Height="64" Offset="0x5480" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_9Tex_005C80" OutName="ydan_room_9Tex_005C80" Format="ci8" Width="32" Height="64" Offset="0x5C80" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_9Tex_006480" OutName="ydan_room_9Tex_006480" Format="ci8" Width="32" Height="64" Offset="0x6480" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_9Tex_007498" OutName="ydan_room_9Tex_007498" Format="rgba16" Width="32" Height="64" Offset="0x7498" AddedByScript="true"/>
+        <Texture Name="ydan_room_9Tex_008498" OutName="ydan_room_9Tex_008498" Format="ci8" Width="32" Height="32" Offset="0x8498" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_9Tex_008898" OutName="ydan_room_9Tex_008898" Format="ia16" Width="32" Height="64" Offset="0x8898" AddedByScript="true"/>
         <Room Name="ydan_room_9" Offset="0x0"/>
     </File>
     <File Name="ydan_room_10" Segment="3">
+        <Texture Name="ydan_room_10Tex_001BE0" OutName="ydan_room_10Tex_001BE0" Format="ci8" Width="32" Height="64" Offset="0x1B60" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_10Tex_0023E0" OutName="ydan_room_10Tex_0023E0" Format="ci8" Width="32" Height="64" Offset="0x2360" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_10Tex_002BE0" OutName="ydan_room_10Tex_002BE0" Format="ci8" Width="32" Height="64" Offset="0x2B60" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_10Tex_0033E0" OutName="ydan_room_10Tex_0033E0" Format="ci8" Width="32" Height="64" Offset="0x3360" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_10Tex_003DF8" OutName="ydan_room_10Tex_003DF8" Format="rgba16" Width="32" Height="64" Offset="0x3D78" AddedByScript="true"/>
         <Room Name="ydan_room_10" Offset="0x0"/>
     </File>
     <File Name="ydan_room_11" Segment="3">
+        <Texture Name="ydan_room_11Tex_003CD8" OutName="ydan_room_11Tex_003CD8" Format="ci8" Width="32" Height="64" Offset="0x3CD8" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_11Tex_0044D8" OutName="ydan_room_11Tex_0044D8" Format="rgba16" Width="32" Height="64" Offset="0x44D8" AddedByScript="true"/>
+        <Texture Name="ydan_room_11Tex_0054D8" OutName="ydan_room_11Tex_0054D8" Format="ci8" Width="32" Height="64" Offset="0x54D8" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_11Tex_005CD8" OutName="ydan_room_11Tex_005CD8" Format="ci8" Width="32" Height="32" Offset="0x5CD8" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_11Tex_006968" OutName="ydan_room_11Tex_006968" Format="ia8" Width="64" Height="32" Offset="0x6968" AddedByScript="true"/>
         <Room Name="ydan_room_11" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/scenes/dungeons/ydan_boss.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/dungeons/ydan_boss.xml
@@ -1,11 +1,26 @@
 <Root>
     <File Name="ydan_boss_scene" Segment="2">
+        <Texture Name="ydan_boss_sceneTex_000F38" OutName="ydan_boss_sceneTex_000F38" Format="ci8" Width="32" Height="64" Offset="0xF38" TlutOffset="0xD30" AddedByScript="true"/>
+        <Texture Name="ydan_boss_sceneTLUT_000D30" OutName="ydan_boss_sceneTLUT_000D30" Format="rgba16" Width="16" Height="16" Offset="0xD30" AddedByScript="true"/>
         <Scene Name="ydan_boss_scene" Offset="0x0"/>
     </File>
     <File Name="ydan_boss_room_0" Segment="3">
+        <Texture Name="ydan_boss_room_0Tex_001790" OutName="ydan_boss_room_0Tex_001790" Format="ci8" Width="32" Height="64" Offset="0x1790" ExternalTlut="ydan_boss_scene" ExternalTlutOffset="0xD30" AddedByScript="true"/>
+        <Texture Name="ydan_boss_room_0Tex_001F90" OutName="ydan_boss_room_0Tex_001F90" Format="ci8" Width="32" Height="64" Offset="0x1F90" ExternalTlut="ydan_boss_scene" ExternalTlutOffset="0xD30" AddedByScript="true"/>
+        <Texture Name="ydan_boss_room_0Tex_002790" OutName="ydan_boss_room_0Tex_002790" Format="ci8" Width="32" Height="64" Offset="0x2790" ExternalTlut="ydan_boss_scene" ExternalTlutOffset="0xD30" AddedByScript="true"/>
+        <Texture Name="ydan_boss_room_0Tex_002F90" OutName="ydan_boss_room_0Tex_002F90" Format="ci8" Width="32" Height="64" Offset="0x2F90" ExternalTlut="ydan_boss_scene" ExternalTlutOffset="0xD30" AddedByScript="true"/>
+        <Texture Name="ydan_boss_room_0Tex_003790" OutName="ydan_boss_room_0Tex_003790" Format="ci8" Width="32" Height="64" Offset="0x3790" ExternalTlut="ydan_boss_scene" ExternalTlutOffset="0xD30" AddedByScript="true"/>
+        <Texture Name="ydan_boss_room_0Tex_003F90" OutName="ydan_boss_room_0Tex_003F90" Format="ci8" Width="32" Height="64" Offset="0x3F90" ExternalTlut="ydan_boss_scene" ExternalTlutOffset="0xD30" AddedByScript="true"/>
+        <Texture Name="ydan_boss_room_0Tex_004BF0" OutName="ydan_boss_room_0Tex_004BF0" Format="rgba16" Width="32" Height="64" Offset="0x4BF0" AddedByScript="true"/>
+        <Texture Name="ydan_boss_room_0Tex_005BF0" OutName="ydan_boss_room_0Tex_005BF0" Format="ci8" Width="32" Height="32" Offset="0x5BF0" ExternalTlut="ydan_boss_scene" ExternalTlutOffset="0xD30" AddedByScript="true"/>
+        <Texture Name="ydan_boss_room_0Tex_005FF0" OutName="ydan_boss_room_0Tex_005FF0" Format="ia16" Width="32" Height="64" Offset="0x5FF0" AddedByScript="true"/>
         <Room Name="ydan_boss_room_0" Offset="0x0"/>
     </File>
     <File Name="ydan_boss_room_1" Segment="3">
+        <Texture Name="ydan_boss_room_1Tex_003B38" OutName="ydan_boss_room_1Tex_003B38" Format="rgba16" Width="32" Height="64" Offset="0x3B38" AddedByScript="true"/>
+        <Texture Name="ydan_boss_room_1Tex_004B38" OutName="ydan_boss_room_1Tex_004B38" Format="ci8" Width="32" Height="64" Offset="0x4B38" ExternalTlut="ydan_boss_scene" ExternalTlutOffset="0xD30" AddedByScript="true"/>
+        <Texture Name="ydan_boss_room_1Tex_005338" OutName="ydan_boss_room_1Tex_005338" Format="ci8" Width="32" Height="32" Offset="0x5338" ExternalTlut="ydan_boss_scene" ExternalTlutOffset="0xD30" AddedByScript="true"/>
+        <Texture Name="ydan_boss_room_1Tex_005FE8" OutName="ydan_boss_room_1Tex_005FE8" Format="ia8" Width="64" Height="32" Offset="0x5FE8" AddedByScript="true"/>
         <Room Name="ydan_boss_room_1" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/scenes/indoors/bowling.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/indoors/bowling.xml
@@ -1,5 +1,33 @@
 <Root>
     <File Name="bowling_scene" Segment="2">
+        <Texture Name="bowling_sceneTex_001AA0" OutName="bowling_sceneTex_001AA0" Format="rgba16" Width="32" Height="32" Offset="0x1AA0" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_0022A0" OutName="bowling_sceneTex_0022A0" Format="i4" Width="16" Height="16" Offset="0x22A0" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_002320" OutName="bowling_sceneTex_002320" Format="rgba16" Width="16" Height="32" Offset="0x2320" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_002720" OutName="bowling_sceneTex_002720" Format="rgba16" Width="32" Height="32" Offset="0x2720" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_002F20" OutName="bowling_sceneTex_002F20" Format="rgba16" Width="32" Height="32" Offset="0x2F20" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_003720" OutName="bowling_sceneTex_003720" Format="i4" Width="64" Height="128" Offset="0x3720" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_004720" OutName="bowling_sceneTex_004720" Format="ia4" Width="64" Height="64" Offset="0x4720" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_004F20" OutName="bowling_sceneTex_004F20" Format="rgba16" Width="16" Height="16" Offset="0x4F20" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_005120" OutName="bowling_sceneTex_005120" Format="rgba16" Width="16" Height="16" Offset="0x5120" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_005320" OutName="bowling_sceneTex_005320" Format="rgba16" Width="16" Height="16" Offset="0x5320" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_005520" OutName="bowling_sceneTex_005520" Format="rgba16" Width="16" Height="32" Offset="0x5520" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_005920" OutName="bowling_sceneTex_005920" Format="rgba16" Width="32" Height="32" Offset="0x5920" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_006120" OutName="bowling_sceneTex_006120" Format="rgba16" Width="64" Height="32" Offset="0x6120" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_007120" OutName="bowling_sceneTex_007120" Format="ia8" Width="128" Height="32" Offset="0x7120" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_008120" OutName="bowling_sceneTex_008120" Format="rgba16" Width="32" Height="32" Offset="0x8120" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_008920" OutName="bowling_sceneTex_008920" Format="rgba16" Width="32" Height="32" Offset="0x8920" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_009120" OutName="bowling_sceneTex_009120" Format="rgba16" Width="32" Height="64" Offset="0x9120" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_00A120" OutName="bowling_sceneTex_00A120" Format="rgba16" Width="32" Height="32" Offset="0xA120" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_00A920" OutName="bowling_sceneTex_00A920" Format="i8" Width="32" Height="16" Offset="0xA920" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_00AB20" OutName="bowling_sceneTex_00AB20" Format="ia8" Width="32" Height="16" Offset="0xAB20" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_00AD20" OutName="bowling_sceneTex_00AD20" Format="i4" Width="32" Height="32" Offset="0xAD20" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_00AF20" OutName="bowling_sceneTex_00AF20" Format="ia8" Width="64" Height="32" Offset="0xAF20" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_00B720" OutName="bowling_sceneTex_00B720" Format="ia8" Width="32" Height="32" Offset="0xB720" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_00BB20" OutName="bowling_sceneTex_00BB20" Format="ia8" Width="32" Height="32" Offset="0xBB20" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_00BF20" OutName="bowling_sceneTex_00BF20" Format="rgba16" Width="32" Height="32" Offset="0xBF20" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_00C720" OutName="bowling_sceneTex_00C720" Format="ia8" Width="64" Height="64" Offset="0xC720" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_00D720" OutName="bowling_sceneTex_00D720" Format="i8" Width="32" Height="32" Offset="0xD720" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_00DB20" OutName="bowling_sceneTex_00DB20" Format="rgba16" Width="64" Height="32" Offset="0xDB20" AddedByScript="true"/>
         <Scene Name="bowling_scene" Offset="0x0"/>
     </File>
     <File Name="bowling_room_0" Segment="3">

--- a/soh/assets/xml/GC_NMQ_D/scenes/indoors/daiyousei_izumi.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/indoors/daiyousei_izumi.xml
@@ -1,5 +1,19 @@
 <Root>
     <File Name="daiyousei_izumi_scene" Segment="2">
+        <Texture Name="daiyousei_izumi_sceneTex_004800" OutName="daiyousei_izumi_sceneTex_004800" Format="i8" Width="32" Height="64" Offset="0x4800" AddedByScript="true"/>
+        <Texture Name="daiyousei_izumi_sceneTex_005000" OutName="daiyousei_izumi_sceneTex_005000" Format="rgba16" Width="32" Height="32" Offset="0x5000" AddedByScript="true"/>
+        <Texture Name="daiyousei_izumi_sceneTex_005800" OutName="daiyousei_izumi_sceneTex_005800" Format="rgba16" Width="32" Height="32" Offset="0x5800" AddedByScript="true"/>
+        <Texture Name="daiyousei_izumi_sceneTex_006000" OutName="daiyousei_izumi_sceneTex_006000" Format="ia4" Width="64" Height="128" Offset="0x6000" AddedByScript="true"/>
+        <Texture Name="daiyousei_izumi_sceneTex_007000" OutName="daiyousei_izumi_sceneTex_007000" Format="rgba16" Width="32" Height="64" Offset="0x7000" AddedByScript="true"/>
+        <Texture Name="daiyousei_izumi_sceneTex_008000" OutName="daiyousei_izumi_sceneTex_008000" Format="rgba16" Width="32" Height="64" Offset="0x8000" AddedByScript="true"/>
+        <Texture Name="daiyousei_izumi_sceneTex_009000" OutName="daiyousei_izumi_sceneTex_009000" Format="rgba16" Width="32" Height="64" Offset="0x9000" AddedByScript="true"/>
+        <Texture Name="daiyousei_izumi_sceneTex_00A000" OutName="daiyousei_izumi_sceneTex_00A000" Format="i8" Width="32" Height="64" Offset="0xA000" AddedByScript="true"/>
+        <Texture Name="daiyousei_izumi_sceneTex_00A800" OutName="daiyousei_izumi_sceneTex_00A800" Format="rgba16" Width="32" Height="32" Offset="0xA800" AddedByScript="true"/>
+        <Texture Name="daiyousei_izumi_sceneTex_00B000" OutName="daiyousei_izumi_sceneTex_00B000" Format="i8" Width="32" Height="128" Offset="0xB000" AddedByScript="true"/>
+        <Texture Name="daiyousei_izumi_sceneTex_00C000" OutName="daiyousei_izumi_sceneTex_00C000" Format="rgba16" Width="32" Height="32" Offset="0xC000" AddedByScript="true"/>
+        <Texture Name="daiyousei_izumi_sceneTex_00C800" OutName="daiyousei_izumi_sceneTex_00C800" Format="ia8" Width="64" Height="32" Offset="0xC800" AddedByScript="true"/>
+        <Texture Name="daiyousei_izumi_sceneTex_00D000" OutName="daiyousei_izumi_sceneTex_00D000" Format="rgba16" Width="32" Height="32" Offset="0xD000" AddedByScript="true"/>
+        <Texture Name="daiyousei_izumi_sceneTex_00D800" OutName="daiyousei_izumi_sceneTex_00D800" Format="rgba16" Width="32" Height="32" Offset="0xD800" AddedByScript="true"/>
         <Cutscene Name="gGreatFairyMagicCs" Offset="0x0130"/>
         <Cutscene Name="gGreatFairyDoubleMagicCs" Offset="0x13E0"/>
         <Cutscene Name="gGreatFairyDoubleDefenceCs" Offset="0x25D0"/>

--- a/soh/assets/xml/GC_NMQ_D/scenes/indoors/hairal_niwa.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/indoors/hairal_niwa.xml
@@ -1,5 +1,27 @@
 <Root>
     <File Name="hairal_niwa_scene" Segment="2">
+        <Texture Name="hairal_niwa_sceneTex_003390" OutName="hairal_niwa_sceneTex_003390" Format="rgba16" Width="32" Height="32" Offset="0x3390" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_003B90" OutName="hairal_niwa_sceneTex_003B90" Format="ia16" Width="32" Height="64" Offset="0x3B90" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_004B90" OutName="hairal_niwa_sceneTex_004B90" Format="rgba16" Width="32" Height="32" Offset="0x4B90" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_005390" OutName="hairal_niwa_sceneTex_005390" Format="rgba16" Width="32" Height="32" Offset="0x5390" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_005B90" OutName="hairal_niwa_sceneTex_005B90" Format="rgba16" Width="32" Height="32" Offset="0x5B90" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_006390" OutName="hairal_niwa_sceneTex_006390" Format="rgba16" Width="32" Height="64" Offset="0x6390" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_007390" OutName="hairal_niwa_sceneTex_007390" Format="i4" Width="64" Height="64" Offset="0x7390" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_007B90" OutName="hairal_niwa_sceneTex_007B90" Format="rgba16" Width="32" Height="64" Offset="0x7B90" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_008B90" OutName="hairal_niwa_sceneTex_008B90" Format="rgba16" Width="32" Height="32" Offset="0x8B90" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_009390" OutName="hairal_niwa_sceneTex_009390" Format="rgba16" Width="32" Height="32" Offset="0x9390" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_009B90" OutName="hairal_niwa_sceneTex_009B90" Format="rgba16" Width="32" Height="64" Offset="0x9B90" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_00AB90" OutName="hairal_niwa_sceneTex_00AB90" Format="rgba16" Width="32" Height="32" Offset="0xAB90" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_00B390" OutName="hairal_niwa_sceneTex_00B390" Format="rgba16" Width="32" Height="32" Offset="0xB390" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_00BB90" OutName="hairal_niwa_sceneTex_00BB90" Format="rgba16" Width="32" Height="32" Offset="0xBB90" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_00C390" OutName="hairal_niwa_sceneTex_00C390" Format="ia4" Width="64" Height="64" Offset="0xC390" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_00CB90" OutName="hairal_niwa_sceneTex_00CB90" Format="i8" Width="32" Height="64" Offset="0xCB90" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_00D390" OutName="hairal_niwa_sceneTex_00D390" Format="ia4" Width="32" Height="128" Offset="0xD390" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_00DB90" OutName="hairal_niwa_sceneTex_00DB90" Format="rgba16" Width="32" Height="64" Offset="0xDB90" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_00EB90" OutName="hairal_niwa_sceneTex_00EB90" Format="rgba16" Width="32" Height="32" Offset="0xEB90" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_00F390" OutName="hairal_niwa_sceneTex_00F390" Format="rgba16" Width="32" Height="32" Offset="0xF390" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_00FB90" OutName="hairal_niwa_sceneTex_00FB90" Format="rgba16" Width="32" Height="32" Offset="0xFB90" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_010390" OutName="hairal_niwa_sceneTex_010390" Format="rgba16" Width="32" Height="64" Offset="0x10390" AddedByScript="true"/>
         <Path Name="hairal_niwa_scenePathway_000268" Offset="0x268" NumPaths="8"/>
 
         <Scene Name="hairal_niwa_scene" Offset="0x0"/>

--- a/soh/assets/xml/GC_NMQ_D/scenes/indoors/hairal_niwa2.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/indoors/hairal_niwa2.xml
@@ -3,6 +3,28 @@
         <Scene Name="hairal_niwa2_scene" Offset="0x0"/>
     </File>
     <File Name="hairal_niwa2_room_0" Segment="3">
+        <Texture Name="hairal_niwa2_room_0Tex_008750" OutName="hairal_niwa2_room_0Tex_008750" Format="rgba16" Width="32" Height="32" Offset="0x8750" AddedByScript="true"/>
+        <Texture Name="hairal_niwa2_room_0Tex_008F50" OutName="hairal_niwa2_room_0Tex_008F50" Format="rgba16" Width="32" Height="32" Offset="0x8F50" AddedByScript="true"/>
+        <Texture Name="hairal_niwa2_room_0Tex_009750" OutName="hairal_niwa2_room_0Tex_009750" Format="rgba16" Width="32" Height="32" Offset="0x9750" AddedByScript="true"/>
+        <Texture Name="hairal_niwa2_room_0Tex_009F50" OutName="hairal_niwa2_room_0Tex_009F50" Format="rgba16" Width="32" Height="64" Offset="0x9F50" AddedByScript="true"/>
+        <Texture Name="hairal_niwa2_room_0Tex_00AF50" OutName="hairal_niwa2_room_0Tex_00AF50" Format="i4" Width="64" Height="64" Offset="0xAF50" AddedByScript="true"/>
+        <Texture Name="hairal_niwa2_room_0Tex_00B750" OutName="hairal_niwa2_room_0Tex_00B750" Format="rgba16" Width="32" Height="64" Offset="0xB750" AddedByScript="true"/>
+        <Texture Name="hairal_niwa2_room_0Tex_00C750" OutName="hairal_niwa2_room_0Tex_00C750" Format="rgba16" Width="32" Height="32" Offset="0xC750" AddedByScript="true"/>
+        <Texture Name="hairal_niwa2_room_0Tex_00CF50" OutName="hairal_niwa2_room_0Tex_00CF50" Format="rgba16" Width="32" Height="32" Offset="0xCF50" AddedByScript="true"/>
+        <Texture Name="hairal_niwa2_room_0Tex_00D750" OutName="hairal_niwa2_room_0Tex_00D750" Format="rgba16" Width="32" Height="64" Offset="0xD750" AddedByScript="true"/>
+        <Texture Name="hairal_niwa2_room_0Tex_00E750" OutName="hairal_niwa2_room_0Tex_00E750" Format="rgba16" Width="32" Height="32" Offset="0xE750" AddedByScript="true"/>
+        <Texture Name="hairal_niwa2_room_0Tex_00EF50" OutName="hairal_niwa2_room_0Tex_00EF50" Format="rgba16" Width="32" Height="32" Offset="0xEF50" AddedByScript="true"/>
+        <Texture Name="hairal_niwa2_room_0Tex_00F750" OutName="hairal_niwa2_room_0Tex_00F750" Format="rgba16" Width="32" Height="32" Offset="0xF750" AddedByScript="true"/>
+        <Texture Name="hairal_niwa2_room_0Tex_00FF50" OutName="hairal_niwa2_room_0Tex_00FF50" Format="rgba16" Width="32" Height="64" Offset="0xFF50" AddedByScript="true"/>
+        <Texture Name="hairal_niwa2_room_0Tex_010F50" OutName="hairal_niwa2_room_0Tex_010F50" Format="rgba16" Width="32" Height="32" Offset="0x10F50" AddedByScript="true"/>
+        <Texture Name="hairal_niwa2_room_0Tex_011750" OutName="hairal_niwa2_room_0Tex_011750" Format="rgba16" Width="32" Height="32" Offset="0x11750" AddedByScript="true"/>
+        <Texture Name="hairal_niwa2_room_0Tex_011F50" OutName="hairal_niwa2_room_0Tex_011F50" Format="rgba16" Width="32" Height="32" Offset="0x11F50" AddedByScript="true"/>
+        <Texture Name="hairal_niwa2_room_0Tex_012750" OutName="hairal_niwa2_room_0Tex_012750" Format="rgba16" Width="32" Height="64" Offset="0x12750" AddedByScript="true"/>
+        <Texture Name="hairal_niwa2_room_0Tex_014BF8" OutName="hairal_niwa2_room_0Tex_014BF8" Format="ia16" Width="32" Height="64" Offset="0x14BF8" AddedByScript="true"/>
+        <Texture Name="hairal_niwa2_room_0Tex_015BF8" OutName="hairal_niwa2_room_0Tex_015BF8" Format="rgba16" Width="32" Height="32" Offset="0x15BF8" AddedByScript="true"/>
+        <Texture Name="hairal_niwa2_room_0Tex_0163F8" OutName="hairal_niwa2_room_0Tex_0163F8" Format="ia4" Width="64" Height="64" Offset="0x163F8" AddedByScript="true"/>
+        <Texture Name="hairal_niwa2_room_0Tex_016BF8" OutName="hairal_niwa2_room_0Tex_016BF8" Format="i8" Width="32" Height="64" Offset="0x16BF8" AddedByScript="true"/>
+        <Texture Name="hairal_niwa2_room_0Tex_0173F8" OutName="hairal_niwa2_room_0Tex_0173F8" Format="ia4" Width="32" Height="128" Offset="0x173F8" AddedByScript="true"/>
         <Room Name="hairal_niwa2_room_0" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/scenes/indoors/hairal_niwa_n.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/indoors/hairal_niwa_n.xml
@@ -1,5 +1,18 @@
 <Root>
     <File Name="hairal_niwa_n_scene" Segment="2">
+        <Texture Name="hairal_niwa_n_sceneTex_0010F0" OutName="hairal_niwa_n_sceneTex_0010F0" Format="rgba16" Width="32" Height="32" Offset="0x10F0" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_n_sceneTex_0018F0" OutName="hairal_niwa_n_sceneTex_0018F0" Format="rgba16" Width="32" Height="32" Offset="0x18F0" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_n_sceneTex_0020F0" OutName="hairal_niwa_n_sceneTex_0020F0" Format="rgba16" Width="32" Height="32" Offset="0x20F0" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_n_sceneTex_0028F0" OutName="hairal_niwa_n_sceneTex_0028F0" Format="rgba16" Width="32" Height="64" Offset="0x28F0" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_n_sceneTex_0038F0" OutName="hairal_niwa_n_sceneTex_0038F0" Format="i4" Width="64" Height="64" Offset="0x38F0" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_n_sceneTex_0040F0" OutName="hairal_niwa_n_sceneTex_0040F0" Format="rgba16" Width="32" Height="64" Offset="0x40F0" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_n_sceneTex_0050F0" OutName="hairal_niwa_n_sceneTex_0050F0" Format="rgba16" Width="32" Height="32" Offset="0x50F0" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_n_sceneTex_0058F0" OutName="hairal_niwa_n_sceneTex_0058F0" Format="rgba16" Width="32" Height="32" Offset="0x58F0" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_n_sceneTex_0060F0" OutName="hairal_niwa_n_sceneTex_0060F0" Format="ia4" Width="32" Height="128" Offset="0x60F0" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_n_sceneTex_0068F0" OutName="hairal_niwa_n_sceneTex_0068F0" Format="rgba16" Width="32" Height="32" Offset="0x68F0" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_n_sceneTex_0070F0" OutName="hairal_niwa_n_sceneTex_0070F0" Format="rgba16" Width="32" Height="32" Offset="0x70F0" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_n_sceneTex_0078F0" OutName="hairal_niwa_n_sceneTex_0078F0" Format="rgba16" Width="32" Height="32" Offset="0x78F0" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_n_sceneTex_0080F0" OutName="hairal_niwa_n_sceneTex_0080F0" Format="rgba16" Width="32" Height="64" Offset="0x80F0" AddedByScript="true"/>
         <Scene Name="hairal_niwa_n_scene" Offset="0x0"/>
     </File>
     <File Name="hairal_niwa_n_room_0" Segment="3">

--- a/soh/assets/xml/GC_NMQ_D/scenes/indoors/hakasitarelay.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/indoors/hakasitarelay.xml
@@ -1,27 +1,80 @@
 <Root>
     <File Name="hakasitarelay_scene" Segment="2">
+        <Texture Name="hakasitarelay_sceneTex_00C080" OutName="hakasitarelay_sceneTex_00C080" Format="rgba16" Width="64" Height="32" Offset="0xC080" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_sceneTex_00D080" OutName="hakasitarelay_sceneTex_00D080" Format="rgba16" Width="32" Height="32" Offset="0xD080" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_sceneTex_00D880" OutName="hakasitarelay_sceneTex_00D880" Format="i4" Width="64" Height="64" Offset="0xD880" AddedByScript="true"/>
         <Scene Name="hakasitarelay_scene" Offset="0x0"/>
         <Cutscene Name="gSongOfStormsCs" Offset="0xE080"/>
     </File>
     <File Name="hakasitarelay_room_0" Segment="3">
+        <Texture Name="hakasitarelay_room_0Tex_003248" OutName="hakasitarelay_room_0Tex_003248" Format="i4" Width="32" Height="32" Offset="0x3248" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_0Tex_003448" OutName="hakasitarelay_room_0Tex_003448" Format="rgba16" Width="32" Height="64" Offset="0x3448" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_0Tex_004448" OutName="hakasitarelay_room_0Tex_004448" Format="i4" Width="128" Height="32" Offset="0x4448" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_0Tex_004C48" OutName="hakasitarelay_room_0Tex_004C48" Format="i4" Width="32" Height="128" Offset="0x4C48" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_0Tex_005448" OutName="hakasitarelay_room_0Tex_005448" Format="i8" Width="32" Height="32" Offset="0x5448" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_0Tex_005848" OutName="hakasitarelay_room_0Tex_005848" Format="i8" Width="64" Height="32" Offset="0x5848" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_0Tex_0062B8" OutName="hakasitarelay_room_0Tex_0062B8" Format="ia16" Width="128" Height="16" Offset="0x62B8" AddedByScript="true"/>
         <Room Name="hakasitarelay_room_0" Offset="0x0"/>
     </File>
     <File Name="hakasitarelay_room_1" Segment="3">
+        <Texture Name="hakasitarelay_room_1Tex_003F20" OutName="hakasitarelay_room_1Tex_003F20" Format="i8" Width="32" Height="32" Offset="0x3F20" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_1Tex_004320" OutName="hakasitarelay_room_1Tex_004320" Format="i8" Width="32" Height="32" Offset="0x4320" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_1Tex_004720" OutName="hakasitarelay_room_1Tex_004720" Format="rgba16" Width="32" Height="64" Offset="0x4720" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_1Tex_005720" OutName="hakasitarelay_room_1Tex_005720" Format="rgba16" Width="32" Height="32" Offset="0x5720" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_1Tex_005F20" OutName="hakasitarelay_room_1Tex_005F20" Format="rgba16" Width="32" Height="16" Offset="0x5F20" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_1Tex_006320" OutName="hakasitarelay_room_1Tex_006320" Format="rgba16" Width="32" Height="16" Offset="0x6320" AddedByScript="true"/>
         <Room Name="hakasitarelay_room_1" Offset="0x0"/>
     </File>
     <File Name="hakasitarelay_room_2" Segment="3">
+        <Texture Name="hakasitarelay_room_2Tex_0054A8" OutName="hakasitarelay_room_2Tex_0054A8" Format="i8" Width="32" Height="32" Offset="0x54A8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_2Tex_0058A8" OutName="hakasitarelay_room_2Tex_0058A8" Format="i8" Width="32" Height="32" Offset="0x58A8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_2Tex_005CA8" OutName="hakasitarelay_room_2Tex_005CA8" Format="rgba16" Width="32" Height="64" Offset="0x5CA8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_2Tex_006CA8" OutName="hakasitarelay_room_2Tex_006CA8" Format="i8" Width="64" Height="32" Offset="0x6CA8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_2Tex_0074A8" OutName="hakasitarelay_room_2Tex_0074A8" Format="rgba16" Width="32" Height="32" Offset="0x74A8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_2Tex_007CA8" OutName="hakasitarelay_room_2Tex_007CA8" Format="rgba16" Width="32" Height="16" Offset="0x7CA8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_2Tex_0080A8" OutName="hakasitarelay_room_2Tex_0080A8" Format="rgba16" Width="32" Height="16" Offset="0x80A8" AddedByScript="true"/>
         <Room Name="hakasitarelay_room_2" Offset="0x0"/>
     </File>
     <File Name="hakasitarelay_room_3" Segment="3">
+        <Texture Name="hakasitarelay_room_3Tex_0056E0" OutName="hakasitarelay_room_3Tex_0056E0" Format="i8" Width="32" Height="32" Offset="0x56E0" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_3Tex_005AE0" OutName="hakasitarelay_room_3Tex_005AE0" Format="i8" Width="32" Height="32" Offset="0x5AE0" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_3Tex_005EE0" OutName="hakasitarelay_room_3Tex_005EE0" Format="i4" Width="32" Height="32" Offset="0x5EE0" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_3Tex_0060E0" OutName="hakasitarelay_room_3Tex_0060E0" Format="rgba16" Width="32" Height="64" Offset="0x60E0" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_3Tex_0070E0" OutName="hakasitarelay_room_3Tex_0070E0" Format="rgba16" Width="32" Height="32" Offset="0x70E0" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_3Tex_0078E0" OutName="hakasitarelay_room_3Tex_0078E0" Format="rgba16" Width="32" Height="16" Offset="0x78E0" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_3Tex_007CE0" OutName="hakasitarelay_room_3Tex_007CE0" Format="i4" Width="128" Height="32" Offset="0x7CE0" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_3Tex_0084E0" OutName="hakasitarelay_room_3Tex_0084E0" Format="i8" Width="64" Height="32" Offset="0x84E0" AddedByScript="true"/>
         <Room Name="hakasitarelay_room_3" Offset="0x0"/>
     </File>
     <File Name="hakasitarelay_room_4" Segment="3">
+        <Texture Name="hakasitarelay_room_4Tex_001E80" OutName="hakasitarelay_room_4Tex_001E80" Format="i4" Width="32" Height="32" Offset="0x1E80" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_4Tex_002080" OutName="hakasitarelay_room_4Tex_002080" Format="i8" Width="64" Height="32" Offset="0x2080" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_4Tex_002880" OutName="hakasitarelay_room_4Tex_002880" Format="i4" Width="32" Height="128" Offset="0x2880" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_4Tex_003080" OutName="hakasitarelay_room_4Tex_003080" Format="i8" Width="32" Height="32" Offset="0x3080" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_4Tex_003480" OutName="hakasitarelay_room_4Tex_003480" Format="i8" Width="64" Height="32" Offset="0x3480" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_4Tex_003C80" OutName="hakasitarelay_room_4Tex_003C80" Format="i4" Width="64" Height="64" Offset="0x3C80" AddedByScript="true"/>
         <Room Name="hakasitarelay_room_4" Offset="0x0"/>
     </File>
     <File Name="hakasitarelay_room_5" Segment="3">
+        <Texture Name="hakasitarelay_room_5Tex_001C48" OutName="hakasitarelay_room_5Tex_001C48" Format="rgba16" Width="32" Height="32" Offset="0x1C48" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_5Tex_002448" OutName="hakasitarelay_room_5Tex_002448" Format="ci4" Width="64" Height="64" Offset="0x2448" TlutOffset="0x1C28" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_5Tex_002C48" OutName="hakasitarelay_room_5Tex_002C48" Format="i8" Width="64" Height="32" Offset="0x2C48" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_5Tex_003448" OutName="hakasitarelay_room_5Tex_003448" Format="i4" Width="64" Height="64" Offset="0x3448" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_5Tex_003C48" OutName="hakasitarelay_room_5Tex_003C48" Format="i4" Width="64" Height="64" Offset="0x3C48" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_5TLUT_001C28" OutName="hakasitarelay_room_5TLUT_001C28" Format="rgba16" Width="4" Height="4" Offset="0x1C28" AddedByScript="true"/>
         <Room Name="hakasitarelay_room_5" Offset="0x0"/>
     </File>
     <File Name="hakasitarelay_room_6" Segment="3">
+        <Texture Name="hakasitarelay_room_6Tex_0041A8" OutName="hakasitarelay_room_6Tex_0041A8" Format="rgba16" Width="16" Height="8" Offset="0x41A8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_6Tex_0042A8" OutName="hakasitarelay_room_6Tex_0042A8" Format="rgba16" Width="32" Height="32" Offset="0x42A8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_6Tex_004AA8" OutName="hakasitarelay_room_6Tex_004AA8" Format="rgba16" Width="32" Height="16" Offset="0x4AA8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_6Tex_004EA8" OutName="hakasitarelay_room_6Tex_004EA8" Format="ci4" Width="64" Height="64" Offset="0x4EA8" TlutOffset="0x4188" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_6Tex_0056A8" OutName="hakasitarelay_room_6Tex_0056A8" Format="i8" Width="64" Height="32" Offset="0x56A8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_6Tex_005EA8" OutName="hakasitarelay_room_6Tex_005EA8" Format="i4" Width="64" Height="64" Offset="0x5EA8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_6Tex_0066A8" OutName="hakasitarelay_room_6Tex_0066A8" Format="i8" Width="32" Height="32" Offset="0x66A8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_6Tex_006AA8" OutName="hakasitarelay_room_6Tex_006AA8" Format="i8" Width="64" Height="32" Offset="0x6AA8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_6Tex_0072A8" OutName="hakasitarelay_room_6Tex_0072A8" Format="i4" Width="64" Height="64" Offset="0x72A8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_6TLUT_004188" OutName="hakasitarelay_room_6TLUT_004188" Format="rgba16" Width="4" Height="4" Offset="0x4188" AddedByScript="true"/>
         <Room Name="hakasitarelay_room_6" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/scenes/indoors/hylia_labo.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/indoors/hylia_labo.xml
@@ -1,5 +1,36 @@
 <Root>
     <File Name="hylia_labo_scene" Segment="2">
+        <Texture Name="hylia_labo_sceneTex_001090" OutName="hylia_labo_sceneTex_001090" Format="ia8" Width="16" Height="64" Offset="0x1090" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_001490" OutName="hylia_labo_sceneTex_001490" Format="rgba16" Width="64" Height="32" Offset="0x1490" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_002490" OutName="hylia_labo_sceneTex_002490" Format="rgba16" Width="32" Height="64" Offset="0x2490" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_003490" OutName="hylia_labo_sceneTex_003490" Format="rgba16" Width="32" Height="32" Offset="0x3490" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_003C90" OutName="hylia_labo_sceneTex_003C90" Format="rgba16" Width="32" Height="64" Offset="0x3C90" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_004C90" OutName="hylia_labo_sceneTex_004C90" Format="rgba16" Width="32" Height="32" Offset="0x4C90" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_005490" OutName="hylia_labo_sceneTex_005490" Format="rgba16" Width="32" Height="32" Offset="0x5490" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_005C90" OutName="hylia_labo_sceneTex_005C90" Format="ia8" Width="64" Height="16" Offset="0x5C90" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_006090" OutName="hylia_labo_sceneTex_006090" Format="rgba16" Width="32" Height="4" Offset="0x6090" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_006190" OutName="hylia_labo_sceneTex_006190" Format="rgba16" Width="32" Height="32" Offset="0x6190" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_006990" OutName="hylia_labo_sceneTex_006990" Format="rgba16" Width="32" Height="16" Offset="0x6990" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_006D90" OutName="hylia_labo_sceneTex_006D90" Format="ia4" Width="64" Height="128" Offset="0x6D90" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_007D90" OutName="hylia_labo_sceneTex_007D90" Format="rgba16" Width="32" Height="32" Offset="0x7D90" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_008590" OutName="hylia_labo_sceneTex_008590" Format="ia8" Width="32" Height="16" Offset="0x8590" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_008790" OutName="hylia_labo_sceneTex_008790" Format="ia8" Width="32" Height="128" Offset="0x8790" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_009790" OutName="hylia_labo_sceneTex_009790" Format="rgba16" Width="32" Height="8" Offset="0x9790" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_009990" OutName="hylia_labo_sceneTex_009990" Format="ia8" Width="16" Height="16" Offset="0x9990" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_009A90" OutName="hylia_labo_sceneTex_009A90" Format="ia8" Width="16" Height="32" Offset="0x9A90" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_009C90" OutName="hylia_labo_sceneTex_009C90" Format="ia8" Width="32" Height="32" Offset="0x9C90" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_00A090" OutName="hylia_labo_sceneTex_00A090" Format="rgba16" Width="32" Height="64" Offset="0xA090" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_00B090" OutName="hylia_labo_sceneTex_00B090" Format="rgba16" Width="64" Height="32" Offset="0xB090" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_00C090" OutName="hylia_labo_sceneTex_00C090" Format="rgba16" Width="64" Height="16" Offset="0xC090" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_00C890" OutName="hylia_labo_sceneTex_00C890" Format="rgba16" Width="32" Height="32" Offset="0xC890" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_00D090" OutName="hylia_labo_sceneTex_00D090" Format="rgba16" Width="64" Height="16" Offset="0xD090" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_00D890" OutName="hylia_labo_sceneTex_00D890" Format="rgba16" Width="64" Height="16" Offset="0xD890" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_00E090" OutName="hylia_labo_sceneTex_00E090" Format="rgba16" Width="32" Height="32" Offset="0xE090" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_00E890" OutName="hylia_labo_sceneTex_00E890" Format="rgba16" Width="32" Height="64" Offset="0xE890" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_00F890" OutName="hylia_labo_sceneTex_00F890" Format="rgba16" Width="32" Height="32" Offset="0xF890" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_010090" OutName="hylia_labo_sceneTex_010090" Format="i8" Width="32" Height="32" Offset="0x10090" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_010490" OutName="hylia_labo_sceneTex_010490" Format="i8" Width="32" Height="32" Offset="0x10490" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_010890" OutName="hylia_labo_sceneTex_010890" Format="rgba16" Width="32" Height="32" Offset="0x10890" AddedByScript="true"/>
         <Scene Name="hylia_labo_scene" Offset="0x0"/>
     </File>
     <File Name="hylia_labo_room_0" Segment="3">

--- a/soh/assets/xml/GC_NMQ_D/scenes/indoors/kenjyanoma.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/indoors/kenjyanoma.xml
@@ -3,6 +3,25 @@
         <Scene Name="kenjyanoma_scene" Offset="0x0"/>
     </File>
     <File Name="kenjyanoma_room_0" Segment="3">
+        <Texture Name="kenjyanoma_room_0Tex_001618" OutName="kenjyanoma_room_0Tex_001618" Format="rgba16" Width="64" Height="32" Offset="0x1618" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_002618" OutName="kenjyanoma_room_0Tex_002618" Format="rgba16" Width="64" Height="32" Offset="0x2618" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_003618" OutName="kenjyanoma_room_0Tex_003618" Format="rgba16" Width="64" Height="32" Offset="0x3618" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_004618" OutName="kenjyanoma_room_0Tex_004618" Format="rgba16" Width="64" Height="32" Offset="0x4618" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_005618" OutName="kenjyanoma_room_0Tex_005618" Format="rgba16" Width="64" Height="32" Offset="0x5618" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_006618" OutName="kenjyanoma_room_0Tex_006618" Format="rgba16" Width="64" Height="32" Offset="0x6618" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_007618" OutName="kenjyanoma_room_0Tex_007618" Format="rgba16" Width="64" Height="32" Offset="0x7618" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_008618" OutName="kenjyanoma_room_0Tex_008618" Format="rgba16" Width="64" Height="32" Offset="0x8618" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_009618" OutName="kenjyanoma_room_0Tex_009618" Format="rgba16" Width="32" Height="64" Offset="0x9618" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_00A618" OutName="kenjyanoma_room_0Tex_00A618" Format="rgba16" Width="32" Height="64" Offset="0xA618" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_00B618" OutName="kenjyanoma_room_0Tex_00B618" Format="rgba16" Width="64" Height="32" Offset="0xB618" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_00C618" OutName="kenjyanoma_room_0Tex_00C618" Format="rgba16" Width="64" Height="32" Offset="0xC618" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_00D618" OutName="kenjyanoma_room_0Tex_00D618" Format="rgba16" Width="32" Height="32" Offset="0xD618" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_010CE8" OutName="kenjyanoma_room_0Tex_010CE8" Format="ia16" Width="32" Height="32" Offset="0x10CE8" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_0114E8" OutName="kenjyanoma_room_0Tex_0114E8" Format="i8" Width="32" Height="64" Offset="0x114E8" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_011CE8" OutName="kenjyanoma_room_0Tex_011CE8" Format="rgba16" Width="4" Height="4" Offset="0x11CE8" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_011D08" OutName="kenjyanoma_room_0Tex_011D08" Format="rgba16" Width="32" Height="32" Offset="0x11D08" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_012508" OutName="kenjyanoma_room_0Tex_012508" Format="i8" Width="32" Height="64" Offset="0x12508" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_012D08" OutName="kenjyanoma_room_0Tex_012D08" Format="i8" Width="32" Height="32" Offset="0x12D08" AddedByScript="true"/>
         <Room Name="kenjyanoma_room_0" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/scenes/indoors/mahouya.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/indoors/mahouya.xml
@@ -1,5 +1,18 @@
 <Root>
     <File Name="mahouya_scene" Segment="2">
+        <Texture Name="mahouya_sceneTex_000A20" OutName="mahouya_sceneTex_000A20" Format="rgba16" Width="32" Height="32" Offset="0xA20" AddedByScript="true"/>
+        <Texture Name="mahouya_sceneTex_001220" OutName="mahouya_sceneTex_001220" Format="rgba16" Width="32" Height="32" Offset="0x1220" AddedByScript="true"/>
+        <Texture Name="mahouya_sceneTex_001A20" OutName="mahouya_sceneTex_001A20" Format="rgba16" Width="16" Height="128" Offset="0x1A20" AddedByScript="true"/>
+        <Texture Name="mahouya_sceneTex_002A20" OutName="mahouya_sceneTex_002A20" Format="rgba16" Width="32" Height="64" Offset="0x2A20" AddedByScript="true"/>
+        <Texture Name="mahouya_sceneTex_003A20" OutName="mahouya_sceneTex_003A20" Format="rgba16" Width="64" Height="32" Offset="0x3A20" AddedByScript="true"/>
+        <Texture Name="mahouya_sceneTex_004A20" OutName="mahouya_sceneTex_004A20" Format="rgba16" Width="32" Height="32" Offset="0x4A20" AddedByScript="true"/>
+        <Texture Name="mahouya_sceneTex_005220" OutName="mahouya_sceneTex_005220" Format="rgba16" Width="16" Height="128" Offset="0x5220" AddedByScript="true"/>
+        <Texture Name="mahouya_sceneTex_006220" OutName="mahouya_sceneTex_006220" Format="rgba16" Width="16" Height="128" Offset="0x6220" AddedByScript="true"/>
+        <Texture Name="mahouya_sceneTex_007220" OutName="mahouya_sceneTex_007220" Format="rgba16" Width="32" Height="32" Offset="0x7220" AddedByScript="true"/>
+        <Texture Name="mahouya_sceneTex_007A20" OutName="mahouya_sceneTex_007A20" Format="rgba16" Width="64" Height="32" Offset="0x7A20" AddedByScript="true"/>
+        <Texture Name="mahouya_sceneTex_008A20" OutName="mahouya_sceneTex_008A20" Format="i8" Width="16" Height="128" Offset="0x8A20" AddedByScript="true"/>
+        <Texture Name="mahouya_sceneTex_009220" OutName="mahouya_sceneTex_009220" Format="rgba16" Width="32" Height="32" Offset="0x9220" AddedByScript="true"/>
+        <Texture Name="mahouya_sceneTex_009A20" OutName="mahouya_sceneTex_009A20" Format="rgba16" Width="64" Height="32" Offset="0x9A20" AddedByScript="true"/>
         <Scene Name="mahouya_scene" Offset="0x0"/>
     </File>
     <File Name="mahouya_room_0" Segment="3">

--- a/soh/assets/xml/GC_NMQ_D/scenes/indoors/miharigoya.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/indoors/miharigoya.xml
@@ -1,5 +1,19 @@
 <Root>
     <File Name="miharigoya_scene" Segment="2">
+        <Texture Name="miharigoya_sceneTex_000C50" OutName="miharigoya_sceneTex_000C50" Format="ia8" Width="64" Height="16" Offset="0xC50" AddedByScript="true"/>
+        <Texture Name="miharigoya_sceneTex_001050" OutName="miharigoya_sceneTex_001050" Format="rgba16" Width="32" Height="4" Offset="0x1050" AddedByScript="true"/>
+        <Texture Name="miharigoya_sceneTex_001150" OutName="miharigoya_sceneTex_001150" Format="ia8" Width="32" Height="16" Offset="0x1150" AddedByScript="true"/>
+        <Texture Name="miharigoya_sceneTex_003350" OutName="miharigoya_sceneTex_003350" Format="rgba16" Width="32" Height="8" Offset="0x3350" AddedByScript="true"/>
+        <Texture Name="miharigoya_sceneTex_004550" OutName="miharigoya_sceneTex_004550" Format="i8" Width="32" Height="32" Offset="0x4550" AddedByScript="true"/>
+        <Texture Name="miharigoya_sceneTex_004950" OutName="miharigoya_sceneTex_004950" Format="rgba16" Width="64" Height="32" Offset="0x4950" AddedByScript="true"/>
+        <Texture Name="miharigoya_sceneTex_005950" OutName="miharigoya_sceneTex_005950" Format="i8" Width="32" Height="32" Offset="0x5950" AddedByScript="true"/>
+        <Texture Name="miharigoya_sceneTex_005D50" OutName="miharigoya_sceneTex_005D50" Format="rgba16" Width="64" Height="16" Offset="0x5D50" AddedByScript="true"/>
+        <Texture Name="miharigoya_sceneTex_007550" OutName="miharigoya_sceneTex_007550" Format="rgba16" Width="32" Height="64" Offset="0x7550" AddedByScript="true"/>
+        <Texture Name="miharigoya_sceneTex_008550" OutName="miharigoya_sceneTex_008550" Format="i4" Width="64" Height="64" Offset="0x8550" AddedByScript="true"/>
+        <Texture Name="miharigoya_sceneTex_008D50" OutName="miharigoya_sceneTex_008D50" Format="i8" Width="64" Height="64" Offset="0x8D50" AddedByScript="true"/>
+        <Texture Name="miharigoya_sceneTex_009D50" OutName="miharigoya_sceneTex_009D50" Format="rgba16" Width="32" Height="64" Offset="0x9D50" AddedByScript="true"/>
+        <Texture Name="miharigoya_sceneTex_00AD50" OutName="miharigoya_sceneTex_00AD50" Format="i8" Width="64" Height="64" Offset="0xAD50" AddedByScript="true"/>
+        <Texture Name="miharigoya_sceneTex_00BD50" OutName="miharigoya_sceneTex_00BD50" Format="rgba16" Width="32" Height="32" Offset="0xBD50" AddedByScript="true"/>
         <Texture Name="gGuardHouseOutSideView2NightTex" OutName="view_2_night" Format="rgba16" Width="64" Height="32" Offset="0x1350"/>
         <Texture Name="gGuardHouseOutSideView2DayTex" OutName="view_2_day" Format="rgba16" Width="64" Height="32" Offset="0x2350"/>
         <Texture Name="gGuardHouseOutSideView1NightTex" OutName="view_1_night" Format="rgba16" Width="64" Height="32" Offset="0x3550"/>

--- a/soh/assets/xml/GC_NMQ_D/scenes/indoors/nakaniwa.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/indoors/nakaniwa.xml
@@ -8,6 +8,37 @@
         <Scene Name="nakaniwa_scene" Offset="0x0"/>
     </File>
     <File Name="nakaniwa_room_0" Segment="3">
+        <Texture Name="nakaniwa_room_0Tex_007218" OutName="nakaniwa_room_0Tex_007218" Format="rgba16" Width="16" Height="16" Offset="0x7218" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_007418" OutName="nakaniwa_room_0Tex_007418" Format="rgba16" Width="16" Height="16" Offset="0x7418" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_007618" OutName="nakaniwa_room_0Tex_007618" Format="rgba16" Width="16" Height="16" Offset="0x7618" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_007818" OutName="nakaniwa_room_0Tex_007818" Format="rgba16" Width="16" Height="16" Offset="0x7818" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_007A18" OutName="nakaniwa_room_0Tex_007A18" Format="rgba16" Width="32" Height="32" Offset="0x7A18" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_008218" OutName="nakaniwa_room_0Tex_008218" Format="rgba16" Width="16" Height="16" Offset="0x8218" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_008418" OutName="nakaniwa_room_0Tex_008418" Format="rgba16" Width="16" Height="16" Offset="0x8418" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_008618" OutName="nakaniwa_room_0Tex_008618" Format="rgba16" Width="32" Height="32" Offset="0x8618" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_008E18" OutName="nakaniwa_room_0Tex_008E18" Format="rgba16" Width="32" Height="64" Offset="0x8E18" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_009E18" OutName="nakaniwa_room_0Tex_009E18" Format="rgba16" Width="32" Height="32" Offset="0x9E18" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_00A618" OutName="nakaniwa_room_0Tex_00A618" Format="rgba16" Width="32" Height="64" Offset="0xA618" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_00B618" OutName="nakaniwa_room_0Tex_00B618" Format="rgba16" Width="32" Height="64" Offset="0xB618" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_00C618" OutName="nakaniwa_room_0Tex_00C618" Format="i4" Width="64" Height="64" Offset="0xC618" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_00CE18" OutName="nakaniwa_room_0Tex_00CE18" Format="rgba16" Width="32" Height="64" Offset="0xCE18" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_00DE18" OutName="nakaniwa_room_0Tex_00DE18" Format="rgba16" Width="32" Height="32" Offset="0xDE18" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_00E618" OutName="nakaniwa_room_0Tex_00E618" Format="rgba16" Width="16" Height="64" Offset="0xE618" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_00EE18" OutName="nakaniwa_room_0Tex_00EE18" Format="rgba16" Width="32" Height="32" Offset="0xEE18" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_00F618" OutName="nakaniwa_room_0Tex_00F618" Format="rgba16" Width="32" Height="32" Offset="0xF618" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_00FE18" OutName="nakaniwa_room_0Tex_00FE18" Format="rgba16" Width="32" Height="32" Offset="0xFE18" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_010618" OutName="nakaniwa_room_0Tex_010618" Format="rgba16" Width="32" Height="32" Offset="0x10618" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_010E18" OutName="nakaniwa_room_0Tex_010E18" Format="rgba16" Width="32" Height="32" Offset="0x10E18" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_011618" OutName="nakaniwa_room_0Tex_011618" Format="rgba16" Width="32" Height="32" Offset="0x11618" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_011E18" OutName="nakaniwa_room_0Tex_011E18" Format="rgba16" Width="32" Height="32" Offset="0x11E18" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_012618" OutName="nakaniwa_room_0Tex_012618" Format="rgba16" Width="32" Height="32" Offset="0x12618" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_012E18" OutName="nakaniwa_room_0Tex_012E18" Format="rgba16" Width="64" Height="16" Offset="0x12E18" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_013618" OutName="nakaniwa_room_0Tex_013618" Format="rgba16" Width="32" Height="32" Offset="0x13618" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_013E18" OutName="nakaniwa_room_0Tex_013E18" Format="i4" Width="32" Height="32" Offset="0x13E18" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_014EC0" OutName="nakaniwa_room_0Tex_014EC0" Format="ia16" Width="32" Height="32" Offset="0x14EC0" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_0156C0" OutName="nakaniwa_room_0Tex_0156C0" Format="ia16" Width="64" Height="32" Offset="0x156C0" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_0166C0" OutName="nakaniwa_room_0Tex_0166C0" Format="rgba16" Width="32" Height="32" Offset="0x166C0" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_016EC0" OutName="nakaniwa_room_0Tex_016EC0" Format="ia16" Width="32" Height="64" Offset="0x16EC0" AddedByScript="true"/>
         <Room Name="nakaniwa_room_0" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/scenes/indoors/syatekijyou.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/indoors/syatekijyou.xml
@@ -1,5 +1,27 @@
 <Root>
     <File Name="syatekijyou_scene" Segment="2">
+        <Texture Name="syatekijyou_sceneTex_001C40" OutName="syatekijyou_sceneTex_001C40" Format="rgba16" Width="32" Height="4" Offset="0x1C40" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_001D40" OutName="syatekijyou_sceneTex_001D40" Format="rgba16" Width="32" Height="16" Offset="0x1D40" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_002140" OutName="syatekijyou_sceneTex_002140" Format="rgba16" Width="32" Height="16" Offset="0x2140" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_002540" OutName="syatekijyou_sceneTex_002540" Format="ia4" Width="32" Height="32" Offset="0x2540" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_002740" OutName="syatekijyou_sceneTex_002740" Format="rgba16" Width="64" Height="32" Offset="0x2740" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_003740" OutName="syatekijyou_sceneTex_003740" Format="ia8" Width="32" Height="16" Offset="0x3740" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_003940" OutName="syatekijyou_sceneTex_003940" Format="rgba16" Width="4" Height="16" Offset="0x3940" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_0039C0" OutName="syatekijyou_sceneTex_0039C0" Format="ia8" Width="16" Height="64" Offset="0x39C0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_003DC0" OutName="syatekijyou_sceneTex_003DC0" Format="rgba16" Width="32" Height="16" Offset="0x3DC0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_0041C0" OutName="syatekijyou_sceneTex_0041C0" Format="rgba16" Width="32" Height="64" Offset="0x41C0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_0051C0" OutName="syatekijyou_sceneTex_0051C0" Format="ia8" Width="16" Height="16" Offset="0x51C0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_0052C0" OutName="syatekijyou_sceneTex_0052C0" Format="ia8" Width="16" Height="32" Offset="0x52C0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_0054C0" OutName="syatekijyou_sceneTex_0054C0" Format="rgba16" Width="32" Height="32" Offset="0x54C0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_005CC0" OutName="syatekijyou_sceneTex_005CC0" Format="rgba16" Width="32" Height="64" Offset="0x5CC0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_006CC0" OutName="syatekijyou_sceneTex_006CC0" Format="rgba16" Width="32" Height="64" Offset="0x6CC0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_007CC0" OutName="syatekijyou_sceneTex_007CC0" Format="i8" Width="64" Height="64" Offset="0x7CC0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_008CC0" OutName="syatekijyou_sceneTex_008CC0" Format="rgba16" Width="32" Height="64" Offset="0x8CC0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_009CC0" OutName="syatekijyou_sceneTex_009CC0" Format="ia4" Width="64" Height="64" Offset="0x9CC0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_00A4C0" OutName="syatekijyou_sceneTex_00A4C0" Format="rgba16" Width="32" Height="32" Offset="0xA4C0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_00ACC0" OutName="syatekijyou_sceneTex_00ACC0" Format="ia8" Width="32" Height="32" Offset="0xACC0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_00B0C0" OutName="syatekijyou_sceneTex_00B0C0" Format="i4" Width="32" Height="32" Offset="0xB0C0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_00B2C0" OutName="syatekijyou_sceneTex_00B2C0" Format="rgba16" Width="64" Height="32" Offset="0xB2C0" AddedByScript="true"/>
         <Scene Name="syatekijyou_scene" Offset="0x0"/>
     </File>
     <File Name="syatekijyou_room_0" Segment="3">

--- a/soh/assets/xml/GC_NMQ_D/scenes/indoors/takaraya.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/indoors/takaraya.xml
@@ -1,26 +1,53 @@
 <Root>
     <File Name="takaraya_scene" Segment="2">
+        <Texture Name="takaraya_sceneTex_0051B0" OutName="takaraya_sceneTex_0051B0" Format="rgba16" Width="32" Height="32" Offset="0x51B0" AddedByScript="true"/>
+        <Texture Name="takaraya_sceneTex_0059B0" OutName="takaraya_sceneTex_0059B0" Format="rgba16" Width="32" Height="32" Offset="0x59B0" AddedByScript="true"/>
+        <Texture Name="takaraya_sceneTex_0061B0" OutName="takaraya_sceneTex_0061B0" Format="rgba16" Width="32" Height="32" Offset="0x61B0" AddedByScript="true"/>
+        <Texture Name="takaraya_sceneTex_0069B0" OutName="takaraya_sceneTex_0069B0" Format="rgba16" Width="32" Height="32" Offset="0x69B0" AddedByScript="true"/>
         <Scene Name="takaraya_scene" Offset="0x0"/>
     </File>
     <File Name="takaraya_room_0" Segment="3">
+        <Texture Name="takaraya_room_0Tex_003BE0" OutName="takaraya_room_0Tex_003BE0" Format="rgba16" Width="16" Height="64" Offset="0x3BE0" AddedByScript="true"/>
+        <Texture Name="takaraya_room_0Tex_0043E0" OutName="takaraya_room_0Tex_0043E0" Format="rgba16" Width="32" Height="32" Offset="0x43E0" AddedByScript="true"/>
+        <Texture Name="takaraya_room_0Tex_004BE0" OutName="takaraya_room_0Tex_004BE0" Format="rgba16" Width="64" Height="32" Offset="0x4BE0" AddedByScript="true"/>
+        <Texture Name="takaraya_room_0Tex_005BE0" OutName="takaraya_room_0Tex_005BE0" Format="rgba16" Width="32" Height="32" Offset="0x5BE0" AddedByScript="true"/>
+        <Texture Name="takaraya_room_0Tex_0063E0" OutName="takaraya_room_0Tex_0063E0" Format="rgba16" Width="32" Height="32" Offset="0x63E0" AddedByScript="true"/>
+        <Texture Name="takaraya_room_0Tex_006BE0" OutName="takaraya_room_0Tex_006BE0" Format="rgba16" Width="32" Height="32" Offset="0x6BE0" AddedByScript="true"/>
+        <Texture Name="takaraya_room_0Tex_0073E0" OutName="takaraya_room_0Tex_0073E0" Format="rgba16" Width="32" Height="32" Offset="0x73E0" AddedByScript="true"/>
+        <Texture Name="takaraya_room_0Tex_007BE0" OutName="takaraya_room_0Tex_007BE0" Format="rgba16" Width="32" Height="32" Offset="0x7BE0" AddedByScript="true"/>
+        <Texture Name="takaraya_room_0Tex_0083E0" OutName="takaraya_room_0Tex_0083E0" Format="rgba16" Width="32" Height="64" Offset="0x83E0" AddedByScript="true"/>
+        <Texture Name="takaraya_room_0Tex_0095C0" OutName="takaraya_room_0Tex_0095C0" Format="ia4" Width="64" Height="64" Offset="0x95C0" AddedByScript="true"/>
         <Room Name="takaraya_room_0" Offset="0x0"/>
     </File>
     <File Name="takaraya_room_1" Segment="3">
+        <Texture Name="takaraya_room_1Tex_0017F8" OutName="takaraya_room_1Tex_0017F8" Format="rgba16" Width="16" Height="64" Offset="0x17F8" AddedByScript="true"/>
         <Room Name="takaraya_room_1" Offset="0x0"/>
     </File>
     <File Name="takaraya_room_2" Segment="3">
+        <Texture Name="takaraya_room_2Tex_001828" OutName="takaraya_room_2Tex_001828" Format="rgba16" Width="16" Height="64" Offset="0x1828" AddedByScript="true"/>
         <Room Name="takaraya_room_2" Offset="0x0"/>
     </File>
     <File Name="takaraya_room_3" Segment="3">
+        <Texture Name="takaraya_room_3Tex_001818" OutName="takaraya_room_3Tex_001818" Format="rgba16" Width="16" Height="64" Offset="0x1818" AddedByScript="true"/>
+        <Texture Name="takaraya_room_3Tex_002018" OutName="takaraya_room_3Tex_002018" Format="rgba16" Width="32" Height="32" Offset="0x2018" AddedByScript="true"/>
         <Room Name="takaraya_room_3" Offset="0x0"/>
     </File>
     <File Name="takaraya_room_4" Segment="3">
+        <Texture Name="takaraya_room_4Tex_001820" OutName="takaraya_room_4Tex_001820" Format="rgba16" Width="16" Height="64" Offset="0x1820" AddedByScript="true"/>
+        <Texture Name="takaraya_room_4Tex_002020" OutName="takaraya_room_4Tex_002020" Format="rgba16" Width="32" Height="32" Offset="0x2020" AddedByScript="true"/>
+        <Texture Name="takaraya_room_4Tex_002820" OutName="takaraya_room_4Tex_002820" Format="rgba16" Width="32" Height="32" Offset="0x2820" AddedByScript="true"/>
         <Room Name="takaraya_room_4" Offset="0x0"/>
     </File>
     <File Name="takaraya_room_5" Segment="3">
+        <Texture Name="takaraya_room_5Tex_0017F8" OutName="takaraya_room_5Tex_0017F8" Format="rgba16" Width="32" Height="32" Offset="0x17F8" AddedByScript="true"/>
+        <Texture Name="takaraya_room_5Tex_001FF8" OutName="takaraya_room_5Tex_001FF8" Format="rgba16" Width="32" Height="32" Offset="0x1FF8" AddedByScript="true"/>
+        <Texture Name="takaraya_room_5Tex_0027F8" OutName="takaraya_room_5Tex_0027F8" Format="rgba16" Width="16" Height="64" Offset="0x27F8" AddedByScript="true"/>
         <Room Name="takaraya_room_5" Offset="0x0"/>
     </File>
     <File Name="takaraya_room_6" Segment="3">
+        <Texture Name="takaraya_room_6Tex_0012F8" OutName="takaraya_room_6Tex_0012F8" Format="rgba16" Width="32" Height="32" Offset="0x12F8" AddedByScript="true"/>
+        <Texture Name="takaraya_room_6Tex_001AF8" OutName="takaraya_room_6Tex_001AF8" Format="rgba16" Width="16" Height="64" Offset="0x1AF8" AddedByScript="true"/>
+        <Texture Name="takaraya_room_6Tex_0022F8" OutName="takaraya_room_6Tex_0022F8" Format="rgba16" Width="32" Height="32" Offset="0x22F8" AddedByScript="true"/>
         <Room Name="takaraya_room_6" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/scenes/indoors/tokinoma.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/indoors/tokinoma.xml
@@ -1,14 +1,47 @@
 <Root>
     <File Name="tokinoma_scene" Segment="2">
-        <Cutscene  Name="gTempleOfTimeFirstAdultCs" Offset="0x46F0"/>
-        <Cutscene  Name="gTempleOfTimePreludeCs" Offset="0x6D20"/>
+        <Texture Name="tokinoma_sceneTex_00CFA0" OutName="tokinoma_sceneTex_00CFA0" Format="rgba16" Width="32" Height="32" Offset="0xCFA0" AddedByScript="true"/>
+        <Texture Name="tokinoma_sceneTex_00D7A0" OutName="tokinoma_sceneTex_00D7A0" Format="rgba16" Width="32" Height="32" Offset="0xD7A0" AddedByScript="true"/>
+        <Texture Name="tokinoma_sceneTex_00DFA0" OutName="tokinoma_sceneTex_00DFA0" Format="rgba16" Width="32" Height="64" Offset="0xDFA0" AddedByScript="true"/>
+        <Texture Name="tokinoma_sceneTex_00EFA0" OutName="tokinoma_sceneTex_00EFA0" Format="rgba16" Width="32" Height="64" Offset="0xEFA0" AddedByScript="true"/>
+        <Texture Name="tokinoma_sceneTex_00FFA0" OutName="tokinoma_sceneTex_00FFA0" Format="rgba16" Width="32" Height="32" Offset="0xFFA0" AddedByScript="true"/>
+        <Texture Name="tokinoma_sceneTex_0107A0" OutName="tokinoma_sceneTex_0107A0" Format="rgba16" Width="32" Height="32" Offset="0x107A0" AddedByScript="true"/>
+        <Texture Name="tokinoma_sceneTex_010FA0" OutName="tokinoma_sceneTex_010FA0" Format="rgba16" Width="32" Height="32" Offset="0x10FA0" AddedByScript="true"/>
+        <Texture Name="tokinoma_sceneTex_0117A0" OutName="tokinoma_sceneTex_0117A0" Format="rgba16" Width="32" Height="32" Offset="0x117A0" AddedByScript="true"/>
+        <Texture Name="tokinoma_sceneTex_011FA0" OutName="tokinoma_sceneTex_011FA0" Format="rgba16" Width="32" Height="32" Offset="0x11FA0" AddedByScript="true"/>
+        <Cutscene Name="gTempleOfTimeFirstAdultCs" Offset="0x46F0"/>
+        <Cutscene Name="gTempleOfTimePreludeCs" Offset="0x6D20"/>
         <Cutscene Name="gTempleOfTimeIntroCs" Offset="0xCE00"/>
         <Scene Name="tokinoma_scene" Offset="0x0"/>
     </File>
     <File Name="tokinoma_room_0" Segment="3">
+        <Texture Name="tokinoma_room_0Tex_0081D8" OutName="tokinoma_room_0Tex_0081D8" Format="rgba16" Width="64" Height="32" Offset="0x81D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_0091D8" OutName="tokinoma_room_0Tex_0091D8" Format="rgba16" Width="64" Height="32" Offset="0x91D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_00A1D8" OutName="tokinoma_room_0Tex_00A1D8" Format="rgba16" Width="64" Height="32" Offset="0xA1D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_00B1D8" OutName="tokinoma_room_0Tex_00B1D8" Format="rgba16" Width="64" Height="32" Offset="0xB1D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_00C1D8" OutName="tokinoma_room_0Tex_00C1D8" Format="rgba16" Width="64" Height="32" Offset="0xC1D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_00D1D8" OutName="tokinoma_room_0Tex_00D1D8" Format="rgba16" Width="64" Height="32" Offset="0xD1D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_00E1D8" OutName="tokinoma_room_0Tex_00E1D8" Format="rgba16" Width="64" Height="32" Offset="0xE1D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_00F1D8" OutName="tokinoma_room_0Tex_00F1D8" Format="rgba16" Width="64" Height="32" Offset="0xF1D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_0101D8" OutName="tokinoma_room_0Tex_0101D8" Format="rgba16" Width="64" Height="32" Offset="0x101D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_0111D8" OutName="tokinoma_room_0Tex_0111D8" Format="rgba16" Width="64" Height="32" Offset="0x111D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_0121D8" OutName="tokinoma_room_0Tex_0121D8" Format="rgba16" Width="64" Height="32" Offset="0x121D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_0131D8" OutName="tokinoma_room_0Tex_0131D8" Format="rgba16" Width="64" Height="32" Offset="0x131D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_0141D8" OutName="tokinoma_room_0Tex_0141D8" Format="rgba16" Width="32" Height="32" Offset="0x141D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_0149D8" OutName="tokinoma_room_0Tex_0149D8" Format="rgba16" Width="32" Height="32" Offset="0x149D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_0151D8" OutName="tokinoma_room_0Tex_0151D8" Format="rgba16" Width="32" Height="32" Offset="0x151D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_0159D8" OutName="tokinoma_room_0Tex_0159D8" Format="rgba16" Width="32" Height="32" Offset="0x159D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_0161D8" OutName="tokinoma_room_0Tex_0161D8" Format="rgba16" Width="32" Height="32" Offset="0x161D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_0169D8" OutName="tokinoma_room_0Tex_0169D8" Format="rgba16" Width="32" Height="32" Offset="0x169D8" AddedByScript="true"/>
         <Room Name="tokinoma_room_0" Offset="0x0"/>
     </File>
     <File Name="tokinoma_room_1" Segment="3">
+        <Texture Name="tokinoma_room_1Tex_005458" OutName="tokinoma_room_1Tex_005458" Format="rgba16" Width="16" Height="16" Offset="0x5458" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_1Tex_005658" OutName="tokinoma_room_1Tex_005658" Format="rgba16" Width="16" Height="16" Offset="0x5658" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_1Tex_005858" OutName="tokinoma_room_1Tex_005858" Format="rgba16" Width="32" Height="32" Offset="0x5858" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_1Tex_006488" OutName="tokinoma_room_1Tex_006488" Format="i8" Width="8" Height="8" Offset="0x6488" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_1Tex_0064C8" OutName="tokinoma_room_1Tex_0064C8" Format="ia4" Width="128" Height="16" Offset="0x64C8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_1Tex_0068C8" OutName="tokinoma_room_1Tex_0068C8" Format="ia8" Width="64" Height="32" Offset="0x68C8" AddedByScript="true"/>
         <Room Name="tokinoma_room_1" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/scenes/indoors/yousei_izumi_tate.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/indoors/yousei_izumi_tate.xml
@@ -1,5 +1,15 @@
 <Root>
     <File Name="yousei_izumi_tate_scene" Segment="2">
+        <Texture Name="yousei_izumi_tate_sceneTex_002010" OutName="yousei_izumi_tate_sceneTex_002010" Format="ia8" Width="64" Height="32" Offset="0x2010" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_tate_sceneTex_002810" OutName="yousei_izumi_tate_sceneTex_002810" Format="i8" Width="16" Height="256" Offset="0x2810" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_tate_sceneTex_003810" OutName="yousei_izumi_tate_sceneTex_003810" Format="ia16" Width="128" Height="16" Offset="0x3810" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_tate_sceneTex_004810" OutName="yousei_izumi_tate_sceneTex_004810" Format="i8" Width="32" Height="64" Offset="0x4810" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_tate_sceneTex_005010" OutName="yousei_izumi_tate_sceneTex_005010" Format="i8" Width="32" Height="64" Offset="0x5010" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_tate_sceneTex_005810" OutName="yousei_izumi_tate_sceneTex_005810" Format="rgba16" Width="32" Height="32" Offset="0x5810" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_tate_sceneTex_006010" OutName="yousei_izumi_tate_sceneTex_006010" Format="i4" Width="64" Height="128" Offset="0x6010" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_tate_sceneTex_007010" OutName="yousei_izumi_tate_sceneTex_007010" Format="rgba16" Width="32" Height="32" Offset="0x7010" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_tate_sceneTex_007810" OutName="yousei_izumi_tate_sceneTex_007810" Format="rgba16" Width="32" Height="32" Offset="0x7810" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_tate_sceneTex_008010" OutName="yousei_izumi_tate_sceneTex_008010" Format="rgba16" Width="32" Height="32" Offset="0x8010" AddedByScript="true"/>
         <Scene Name="yousei_izumi_tate_scene" Offset="0x0"/>
     </File>
     <File Name="yousei_izumi_tate_room_0" Segment="3">

--- a/soh/assets/xml/GC_NMQ_D/scenes/indoors/yousei_izumi_yoko.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/indoors/yousei_izumi_yoko.xml
@@ -1,5 +1,18 @@
 <Root>
     <File Name="yousei_izumi_yoko_scene" Segment="2">
+        <Texture Name="yousei_izumi_yoko_sceneTex_003DA0" OutName="yousei_izumi_yoko_sceneTex_003DA0" Format="i8" Width="32" Height="64" Offset="0x3DA0" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_yoko_sceneTex_0045A0" OutName="yousei_izumi_yoko_sceneTex_0045A0" Format="rgba16" Width="32" Height="32" Offset="0x45A0" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_yoko_sceneTex_004DA0" OutName="yousei_izumi_yoko_sceneTex_004DA0" Format="rgba16" Width="32" Height="32" Offset="0x4DA0" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_yoko_sceneTex_0055A0" OutName="yousei_izumi_yoko_sceneTex_0055A0" Format="ia4" Width="64" Height="128" Offset="0x55A0" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_yoko_sceneTex_0065A0" OutName="yousei_izumi_yoko_sceneTex_0065A0" Format="rgba16" Width="32" Height="64" Offset="0x65A0" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_yoko_sceneTex_0075A0" OutName="yousei_izumi_yoko_sceneTex_0075A0" Format="rgba16" Width="32" Height="64" Offset="0x75A0" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_yoko_sceneTex_0085A0" OutName="yousei_izumi_yoko_sceneTex_0085A0" Format="rgba16" Width="32" Height="64" Offset="0x85A0" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_yoko_sceneTex_0095A0" OutName="yousei_izumi_yoko_sceneTex_0095A0" Format="rgba16" Width="32" Height="32" Offset="0x95A0" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_yoko_sceneTex_009DA0" OutName="yousei_izumi_yoko_sceneTex_009DA0" Format="i8" Width="32" Height="128" Offset="0x9DA0" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_yoko_sceneTex_00ADA0" OutName="yousei_izumi_yoko_sceneTex_00ADA0" Format="rgba16" Width="32" Height="32" Offset="0xADA0" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_yoko_sceneTex_00B5A0" OutName="yousei_izumi_yoko_sceneTex_00B5A0" Format="ia8" Width="64" Height="32" Offset="0xB5A0" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_yoko_sceneTex_00BDA0" OutName="yousei_izumi_yoko_sceneTex_00BDA0" Format="rgba16" Width="32" Height="32" Offset="0xBDA0" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_yoko_sceneTex_00C5A0" OutName="yousei_izumi_yoko_sceneTex_00C5A0" Format="rgba16" Width="32" Height="32" Offset="0xC5A0" AddedByScript="true"/>
         <Cutscene Name="gGreatFairyFaroresWindCs" Offset="0x0160"/>
         <Cutscene Name="gGreatFairyDinsFireCs" Offset="0x1020"/>
         <Cutscene Name="gGreatFairyNayrusLoveCs" Offset="0x1F40"/>

--- a/soh/assets/xml/GC_NMQ_D/scenes/misc/hakaana.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/misc/hakaana.xml
@@ -3,6 +3,16 @@
         <Scene Name="hakaana_scene" Offset="0x0"/>
     </File>
     <File Name="hakaana_room_0" Segment="3">
+        <Texture Name="hakaana_room_0Tex_002658" OutName="hakaana_room_0Tex_002658" Format="rgba16" Width="32" Height="32" Offset="0x2658" AddedByScript="true"/>
+        <Texture Name="hakaana_room_0Tex_002E58" OutName="hakaana_room_0Tex_002E58" Format="rgba16" Width="32" Height="16" Offset="0x2E58" AddedByScript="true"/>
+        <Texture Name="hakaana_room_0Tex_003258" OutName="hakaana_room_0Tex_003258" Format="rgba16" Width="32" Height="16" Offset="0x3258" AddedByScript="true"/>
+        <Texture Name="hakaana_room_0Tex_003658" OutName="hakaana_room_0Tex_003658" Format="rgba16" Width="32" Height="32" Offset="0x3658" AddedByScript="true"/>
+        <Texture Name="hakaana_room_0Tex_003E58" OutName="hakaana_room_0Tex_003E58" Format="i4" Width="128" Height="32" Offset="0x3E58" AddedByScript="true"/>
+        <Texture Name="hakaana_room_0Tex_004658" OutName="hakaana_room_0Tex_004658" Format="rgba16" Width="32" Height="32" Offset="0x4658" AddedByScript="true"/>
+        <Texture Name="hakaana_room_0Tex_004E58" OutName="hakaana_room_0Tex_004E58" Format="i4" Width="64" Height="64" Offset="0x4E58" AddedByScript="true"/>
+        <Texture Name="hakaana_room_0Tex_005658" OutName="hakaana_room_0Tex_005658" Format="i4" Width="64" Height="64" Offset="0x5658" AddedByScript="true"/>
+        <Texture Name="hakaana_room_0Tex_005E58" OutName="hakaana_room_0Tex_005E58" Format="i4" Width="64" Height="64" Offset="0x5E58" AddedByScript="true"/>
+        <Texture Name="hakaana_room_0Tex_0068C8" OutName="hakaana_room_0Tex_0068C8" Format="ia16" Width="128" Height="16" Offset="0x68C8" AddedByScript="true"/>
         <Room Name="hakaana_room_0" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/scenes/misc/hakaana2.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/misc/hakaana2.xml
@@ -1,5 +1,23 @@
 <Root>
     <File Name="hakaana2_scene" Segment="2">
+        <Texture Name="hakaana2_sceneTex_003090" OutName="hakaana2_sceneTex_003090" Format="rgba16" Width="32" Height="32" Offset="0x3090" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_003890" OutName="hakaana2_sceneTex_003890" Format="rgba16" Width="32" Height="32" Offset="0x3890" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_004090" OutName="hakaana2_sceneTex_004090" Format="rgba16" Width="32" Height="16" Offset="0x4090" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_004490" OutName="hakaana2_sceneTex_004490" Format="rgba16" Width="32" Height="16" Offset="0x4490" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_004890" OutName="hakaana2_sceneTex_004890" Format="i4" Width="64" Height="64" Offset="0x4890" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_005090" OutName="hakaana2_sceneTex_005090" Format="i4" Width="64" Height="64" Offset="0x5090" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_005890" OutName="hakaana2_sceneTex_005890" Format="i4" Width="128" Height="32" Offset="0x5890" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_006090" OutName="hakaana2_sceneTex_006090" Format="i4" Width="64" Height="64" Offset="0x6090" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_006890" OutName="hakaana2_sceneTex_006890" Format="ia8" Width="64" Height="32" Offset="0x6890" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_007090" OutName="hakaana2_sceneTex_007090" Format="i8" Width="16" Height="256" Offset="0x7090" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_008090" OutName="hakaana2_sceneTex_008090" Format="ia16" Width="128" Height="16" Offset="0x8090" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_009090" OutName="hakaana2_sceneTex_009090" Format="i8" Width="32" Height="64" Offset="0x9090" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_009890" OutName="hakaana2_sceneTex_009890" Format="i8" Width="32" Height="64" Offset="0x9890" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_00A090" OutName="hakaana2_sceneTex_00A090" Format="rgba16" Width="32" Height="32" Offset="0xA090" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_00A890" OutName="hakaana2_sceneTex_00A890" Format="i4" Width="64" Height="128" Offset="0xA890" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_00B890" OutName="hakaana2_sceneTex_00B890" Format="rgba16" Width="32" Height="32" Offset="0xB890" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_00C090" OutName="hakaana2_sceneTex_00C090" Format="rgba16" Width="32" Height="32" Offset="0xC090" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_00C890" OutName="hakaana2_sceneTex_00C890" Format="rgba16" Width="32" Height="32" Offset="0xC890" AddedByScript="true"/>
         <Scene Name="hakaana2_scene" Offset="0x0"/>
     </File>
     <File Name="hakaana2_room_0" Segment="3">

--- a/soh/assets/xml/GC_NMQ_D/scenes/misc/hakaana_ouke.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/misc/hakaana_ouke.xml
@@ -1,16 +1,37 @@
 <Root>
     <File Name="hakaana_ouke_scene" Segment="2">
+        <Texture Name="hakaana_ouke_sceneTex_002AE0" OutName="hakaana_ouke_sceneTex_002AE0" Format="rgba16" Width="32" Height="16" Offset="0x2AE0" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_sceneTex_002EE0" OutName="hakaana_ouke_sceneTex_002EE0" Format="rgba16" Width="32" Height="16" Offset="0x2EE0" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_sceneTex_0032E0" OutName="hakaana_ouke_sceneTex_0032E0" Format="rgba16" Width="32" Height="32" Offset="0x32E0" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_sceneTex_003AE0" OutName="hakaana_ouke_sceneTex_003AE0" Format="i4" Width="64" Height="64" Offset="0x3AE0" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_sceneTex_0042E0" OutName="hakaana_ouke_sceneTex_0042E0" Format="i4" Width="64" Height="64" Offset="0x42E0" AddedByScript="true"/>
         <Cutscene Name="gSunSongGraveSunSongTeachCs" Offset="0x24A0"/>
         <Cutscene Name="gSunSongGraveSunSongTeachPart2Cs" Offset="0x28E0"/>
         <Scene Name="hakaana_ouke_scene" Offset="0x0"/>
     </File>
     <File Name="hakaana_ouke_room_0" Segment="3">
+        <Texture Name="hakaana_ouke_room_0Tex_004F30" OutName="hakaana_ouke_room_0Tex_004F30" Format="rgba16" Width="16" Height="64" Offset="0x4F30" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_room_0Tex_005730" OutName="hakaana_ouke_room_0Tex_005730" Format="rgba16" Width="32" Height="64" Offset="0x5730" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_room_0Tex_006730" OutName="hakaana_ouke_room_0Tex_006730" Format="i4" Width="128" Height="32" Offset="0x6730" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_room_0Tex_006F30" OutName="hakaana_ouke_room_0Tex_006F30" Format="i4" Width="64" Height="64" Offset="0x6F30" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_room_0Tex_007FF8" OutName="hakaana_ouke_room_0Tex_007FF8" Format="ia4" Width="32" Height="256" Offset="0x7FF8" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_room_0Tex_008FF8" OutName="hakaana_ouke_room_0Tex_008FF8" Format="ia8" Width="8" Height="256" Offset="0x8FF8" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_room_0Tex_0097F8" OutName="hakaana_ouke_room_0Tex_0097F8" Format="ia16" Width="128" Height="16" Offset="0x97F8" AddedByScript="true"/>
         <Room Name="hakaana_ouke_room_0" Offset="0x0"/>
     </File>
     <File Name="hakaana_ouke_room_1" Segment="3">
+        <Texture Name="hakaana_ouke_room_1Tex_001FC8" OutName="hakaana_ouke_room_1Tex_001FC8" Format="rgba16" Width="32" Height="32" Offset="0x1FC8" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_room_1Tex_0027C8" OutName="hakaana_ouke_room_1Tex_0027C8" Format="rgba16" Width="32" Height="64" Offset="0x27C8" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_room_1Tex_004000" OutName="hakaana_ouke_room_1Tex_004000" Format="i8" Width="16" Height="128" Offset="0x4000" AddedByScript="true"/>
         <Room Name="hakaana_ouke_room_1" Offset="0x0"/>
     </File>
     <File Name="hakaana_ouke_room_2" Segment="3">
+        <Texture Name="hakaana_ouke_room_2Tex_002778" OutName="hakaana_ouke_room_2Tex_002778" Format="i4" Width="128" Height="32" Offset="0x2778" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_room_2Tex_002F78" OutName="hakaana_ouke_room_2Tex_002F78" Format="rgba16" Width="32" Height="32" Offset="0x2F78" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_room_2Tex_003778" OutName="hakaana_ouke_room_2Tex_003778" Format="i4" Width="128" Height="32" Offset="0x3778" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_room_2Tex_003F78" OutName="hakaana_ouke_room_2Tex_003F78" Format="rgba16" Width="32" Height="32" Offset="0x3F78" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_room_2Tex_004778" OutName="hakaana_ouke_room_2Tex_004778" Format="i4" Width="64" Height="64" Offset="0x4778" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_room_2Tex_005108" OutName="hakaana_ouke_room_2Tex_005108" Format="ia8" Width="128" Height="32" Offset="0x5108" AddedByScript="true"/>
         <Room Name="hakaana_ouke_room_2" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/scenes/misc/kakusiana.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/misc/kakusiana.xml
@@ -1,47 +1,113 @@
 <Root>
     <File Name="kakusiana_scene" Segment="2">
+        <Texture Name="kakusiana_sceneTex_00B820" OutName="kakusiana_sceneTex_00B820" Format="ia4" Width="64" Height="64" Offset="0xB820" AddedByScript="true"/>
+        <Texture Name="kakusiana_sceneTex_00C020" OutName="kakusiana_sceneTex_00C020" Format="ia16" Width="128" Height="16" Offset="0xC020" AddedByScript="true"/>
+        <Texture Name="kakusiana_sceneTex_00D020" OutName="kakusiana_sceneTex_00D020" Format="rgba16" Width="32" Height="32" Offset="0xD020" AddedByScript="true"/>
         <Scene Name="kakusiana_scene" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_0" Segment="3">
+        <Texture Name="kakusiana_room_0Tex_0022A0" OutName="kakusiana_room_0Tex_0022A0" Format="rgba16" Width="64" Height="32" Offset="0x22A0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_0Tex_0032A0" OutName="kakusiana_room_0Tex_0032A0" Format="rgba16" Width="64" Height="32" Offset="0x32A0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_0Tex_0042A0" OutName="kakusiana_room_0Tex_0042A0" Format="rgba16" Width="32" Height="32" Offset="0x42A0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_0Tex_004AA0" OutName="kakusiana_room_0Tex_004AA0" Format="i8" Width="64" Height="64" Offset="0x4AA0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_0Tex_005AA0" OutName="kakusiana_room_0Tex_005AA0" Format="rgba16" Width="32" Height="32" Offset="0x5AA0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_0Tex_006AA0" OutName="kakusiana_room_0Tex_006AA0" Format="rgba16" Width="32" Height="32" Offset="0x6AA0" AddedByScript="true"/>
         <Room Name="kakusiana_room_0" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_1" Segment="3">
+        <Texture Name="kakusiana_room_1Tex_001A18" OutName="kakusiana_room_1Tex_001A18" Format="i8" Width="64" Height="64" Offset="0x1A18" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_1Tex_002A18" OutName="kakusiana_room_1Tex_002A18" Format="rgba16" Width="32" Height="32" Offset="0x2A18" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_1Tex_003218" OutName="kakusiana_room_1Tex_003218" Format="i8" Width="64" Height="64" Offset="0x3218" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_1Tex_004990" OutName="kakusiana_room_1Tex_004990" Format="ia8" Width="8" Height="256" Offset="0x4990" AddedByScript="true"/>
         <Room Name="kakusiana_room_1" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_2" Segment="3">
+        <Texture Name="kakusiana_room_2Tex_001448" OutName="kakusiana_room_2Tex_001448" Format="rgba16" Width="32" Height="32" Offset="0x1448" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_2Tex_001C48" OutName="kakusiana_room_2Tex_001C48" Format="rgba16" Width="32" Height="32" Offset="0x1C48" AddedByScript="true"/>
         <Room Name="kakusiana_room_2" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_3" Segment="3">
+        <Texture Name="kakusiana_room_3Tex_001818" OutName="kakusiana_room_3Tex_001818" Format="i8" Width="64" Height="64" Offset="0x1818" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_3Tex_002818" OutName="kakusiana_room_3Tex_002818" Format="i8" Width="64" Height="64" Offset="0x2818" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_3Tex_004130" OutName="kakusiana_room_3Tex_004130" Format="ia8" Width="8" Height="256" Offset="0x4130" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_3Tex_004930" OutName="kakusiana_room_3Tex_004930" Format="rgba16" Width="32" Height="32" Offset="0x4930" AddedByScript="true"/>
         <Room Name="kakusiana_room_3" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_4" Segment="3">
+        <Texture Name="kakusiana_room_4Tex_002138" OutName="kakusiana_room_4Tex_002138" Format="rgba16" Width="32" Height="64" Offset="0x2138" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_4Tex_003138" OutName="kakusiana_room_4Tex_003138" Format="rgba16" Width="32" Height="64" Offset="0x3138" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_4Tex_004138" OutName="kakusiana_room_4Tex_004138" Format="rgba16" Width="32" Height="32" Offset="0x4138" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_4Tex_005958" OutName="kakusiana_room_4Tex_005958" Format="i8" Width="64" Height="64" Offset="0x5958" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_4Tex_006958" OutName="kakusiana_room_4Tex_006958" Format="i8" Width="64" Height="64" Offset="0x6958" AddedByScript="true"/>
         <Room Name="kakusiana_room_4" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_5" Segment="3">
+        <Texture Name="kakusiana_room_5Tex_001888" OutName="kakusiana_room_5Tex_001888" Format="i8" Width="64" Height="64" Offset="0x1888" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_5Tex_002888" OutName="kakusiana_room_5Tex_002888" Format="i8" Width="64" Height="64" Offset="0x2888" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_5Tex_003ED8" OutName="kakusiana_room_5Tex_003ED8" Format="rgba16" Width="32" Height="32" Offset="0x3ED8" AddedByScript="true"/>
         <Room Name="kakusiana_room_5" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_6" Segment="3">
+        <Texture Name="kakusiana_room_6Tex_0022E0" OutName="kakusiana_room_6Tex_0022E0" Format="rgba16" Width="32" Height="64" Offset="0x22E0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_6Tex_0032E0" OutName="kakusiana_room_6Tex_0032E0" Format="rgba16" Width="32" Height="32" Offset="0x32E0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_6Tex_003AE0" OutName="kakusiana_room_6Tex_003AE0" Format="rgba16" Width="64" Height="32" Offset="0x3AE0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_6Tex_004AE0" OutName="kakusiana_room_6Tex_004AE0" Format="rgba16" Width="32" Height="32" Offset="0x4AE0" AddedByScript="true"/>
         <Room Name="kakusiana_room_6" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_7" Segment="3">
+        <Texture Name="kakusiana_room_7Tex_001D60" OutName="kakusiana_room_7Tex_001D60" Format="rgba16" Width="32" Height="16" Offset="0x1D60" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_7Tex_002160" OutName="kakusiana_room_7Tex_002160" Format="rgba16" Width="32" Height="32" Offset="0x2160" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_7Tex_002960" OutName="kakusiana_room_7Tex_002960" Format="rgba16" Width="16" Height="16" Offset="0x2960" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_7Tex_002B60" OutName="kakusiana_room_7Tex_002B60" Format="i8" Width="64" Height="64" Offset="0x2B60" AddedByScript="true"/>
         <Room Name="kakusiana_room_7" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_8" Segment="3">
+        <Texture Name="kakusiana_room_8Tex_0019C0" OutName="kakusiana_room_8Tex_0019C0" Format="rgba16" Width="32" Height="64" Offset="0x19C0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_8Tex_0029C0" OutName="kakusiana_room_8Tex_0029C0" Format="rgba16" Width="32" Height="32" Offset="0x29C0" AddedByScript="true"/>
         <Room Name="kakusiana_room_8" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_9" Segment="3">
+        <Texture Name="kakusiana_room_9Tex_002340" OutName="kakusiana_room_9Tex_002340" Format="rgba16" Width="32" Height="64" Offset="0x2340" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_9Tex_003340" OutName="kakusiana_room_9Tex_003340" Format="rgba16" Width="32" Height="32" Offset="0x3340" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_9Tex_003B40" OutName="kakusiana_room_9Tex_003B40" Format="rgba16" Width="64" Height="32" Offset="0x3B40" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_9Tex_004B40" OutName="kakusiana_room_9Tex_004B40" Format="rgba16" Width="32" Height="32" Offset="0x4B40" AddedByScript="true"/>
         <Room Name="kakusiana_room_9" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_10" Segment="3">
+        <Texture Name="kakusiana_room_10Tex_0017E0" OutName="kakusiana_room_10Tex_0017E0" Format="i8" Width="32" Height="64" Offset="0x17E0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_10Tex_001FE0" OutName="kakusiana_room_10Tex_001FE0" Format="i8" Width="32" Height="64" Offset="0x1FE0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_10Tex_0027E0" OutName="kakusiana_room_10Tex_0027E0" Format="i8" Width="32" Height="32" Offset="0x27E0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_10Tex_002BE0" OutName="kakusiana_room_10Tex_002BE0" Format="i8" Width="64" Height="64" Offset="0x2BE0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_10Tex_003BE0" OutName="kakusiana_room_10Tex_003BE0" Format="i8" Width="64" Height="64" Offset="0x3BE0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_10Tex_005228" OutName="kakusiana_room_10Tex_005228" Format="rgba16" Width="32" Height="32" Offset="0x5228" AddedByScript="true"/>
         <Room Name="kakusiana_room_10" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_11" Segment="3">
+        <Texture Name="kakusiana_room_11Tex_002848" OutName="kakusiana_room_11Tex_002848" Format="rgba16" Width="32" Height="32" Offset="0x2848" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_11Tex_003048" OutName="kakusiana_room_11Tex_003048" Format="rgba16" Width="32" Height="64" Offset="0x3048" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_11Tex_004048" OutName="kakusiana_room_11Tex_004048" Format="rgba16" Width="32" Height="64" Offset="0x4048" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_11Tex_005048" OutName="kakusiana_room_11Tex_005048" Format="rgba16" Width="32" Height="32" Offset="0x5048" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_11Tex_005848" OutName="kakusiana_room_11Tex_005848" Format="rgba16" Width="64" Height="32" Offset="0x5848" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_11Tex_006848" OutName="kakusiana_room_11Tex_006848" Format="rgba16" Width="64" Height="32" Offset="0x6848" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_11Tex_007848" OutName="kakusiana_room_11Tex_007848" Format="rgba16" Width="32" Height="32" Offset="0x7848" AddedByScript="true"/>
         <Room Name="kakusiana_room_11" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_12" Segment="3">
+        <Texture Name="kakusiana_room_12Tex_001FF0" OutName="kakusiana_room_12Tex_001FF0" Format="rgba16" Width="32" Height="32" Offset="0x1FF0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_12Tex_0027F0" OutName="kakusiana_room_12Tex_0027F0" Format="rgba16" Width="32" Height="64" Offset="0x27F0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_12Tex_0037F0" OutName="kakusiana_room_12Tex_0037F0" Format="rgba16" Width="32" Height="64" Offset="0x37F0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_12Tex_0047F0" OutName="kakusiana_room_12Tex_0047F0" Format="rgba16" Width="32" Height="32" Offset="0x47F0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_12Tex_004FF0" OutName="kakusiana_room_12Tex_004FF0" Format="rgba16" Width="64" Height="32" Offset="0x4FF0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_12Tex_005FF0" OutName="kakusiana_room_12Tex_005FF0" Format="rgba16" Width="64" Height="32" Offset="0x5FF0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_12Tex_006FF0" OutName="kakusiana_room_12Tex_006FF0" Format="rgba16" Width="32" Height="32" Offset="0x6FF0" AddedByScript="true"/>
         <Room Name="kakusiana_room_12" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_13" Segment="3">
+        <Texture Name="kakusiana_room_13Tex_001950" OutName="kakusiana_room_13Tex_001950" Format="rgba16" Width="32" Height="64" Offset="0x1950" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_13Tex_002950" OutName="kakusiana_room_13Tex_002950" Format="rgba16" Width="32" Height="64" Offset="0x2950" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_13Tex_003950" OutName="kakusiana_room_13Tex_003950" Format="rgba16" Width="32" Height="32" Offset="0x3950" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_13Tex_004EC8" OutName="kakusiana_room_13Tex_004EC8" Format="i8" Width="64" Height="64" Offset="0x4EC8" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_13Tex_005EC8" OutName="kakusiana_room_13Tex_005EC8" Format="i8" Width="64" Height="64" Offset="0x5EC8" AddedByScript="true"/>
         <Room Name="kakusiana_room_13" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/scenes/misc/kinsuta.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/misc/kinsuta.xml
@@ -3,6 +3,19 @@
         <Scene Name="kinsuta_scene" Offset="0x0"/>
     </File>
     <File Name="kinsuta_room_0" Segment="3">
+        <Texture Name="kinsuta_room_0Tex_003110" OutName="kinsuta_room_0Tex_003110" Format="ci4" Width="64" Height="64" Offset="0x3110" TlutOffset="0x30F0" AddedByScript="true"/>
+        <Texture Name="kinsuta_room_0Tex_003910" OutName="kinsuta_room_0Tex_003910" Format="i4" Width="64" Height="128" Offset="0x3910" AddedByScript="true"/>
+        <Texture Name="kinsuta_room_0Tex_004910" OutName="kinsuta_room_0Tex_004910" Format="i4" Width="64" Height="128" Offset="0x4910" AddedByScript="true"/>
+        <Texture Name="kinsuta_room_0Tex_005910" OutName="kinsuta_room_0Tex_005910" Format="i4" Width="64" Height="128" Offset="0x5910" AddedByScript="true"/>
+        <Texture Name="kinsuta_room_0Tex_006910" OutName="kinsuta_room_0Tex_006910" Format="rgba16" Width="32" Height="64" Offset="0x6910" AddedByScript="true"/>
+        <Texture Name="kinsuta_room_0Tex_007910" OutName="kinsuta_room_0Tex_007910" Format="rgba16" Width="32" Height="64" Offset="0x7910" AddedByScript="true"/>
+        <Texture Name="kinsuta_room_0Tex_008910" OutName="kinsuta_room_0Tex_008910" Format="i8" Width="32" Height="32" Offset="0x8910" AddedByScript="true"/>
+        <Texture Name="kinsuta_room_0Tex_008D10" OutName="kinsuta_room_0Tex_008D10" Format="rgba16" Width="64" Height="32" Offset="0x8D10" AddedByScript="true"/>
+        <Texture Name="kinsuta_room_0Tex_009D10" OutName="kinsuta_room_0Tex_009D10" Format="rgba16" Width="32" Height="16" Offset="0x9D10" AddedByScript="true"/>
+        <Texture Name="kinsuta_room_0Tex_00B098" OutName="kinsuta_room_0Tex_00B098" Format="ia16" Width="32" Height="64" Offset="0xB098" AddedByScript="true"/>
+        <Texture Name="kinsuta_room_0Tex_00C098" OutName="kinsuta_room_0Tex_00C098" Format="i8" Width="64" Height="64" Offset="0xC098" AddedByScript="true"/>
+        <Texture Name="kinsuta_room_0Tex_00D098" OutName="kinsuta_room_0Tex_00D098" Format="i8" Width="64" Height="64" Offset="0xD098" AddedByScript="true"/>
+        <Texture Name="kinsuta_room_0TLUT_0030F0" OutName="kinsuta_room_0TLUT_0030F0" Format="rgba16" Width="4" Height="4" Offset="0x30F0" AddedByScript="true"/>
         <DList Name="gKinsutaDL_0030B0" Offset="0x30B0"/>
         <DList Name="gKinsutaDL_00B088" Offset="0xB088"/>
         <Room Name="kinsuta_room_0" Offset="0x0"/>

--- a/soh/assets/xml/GC_NMQ_D/scenes/misc/turibori.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/misc/turibori.xml
@@ -1,5 +1,32 @@
 <Root>
     <File Name="turibori_scene" Segment="2">
+        <Texture Name="turibori_sceneTex_001CE0" OutName="turibori_sceneTex_001CE0" Format="rgba16" Width="32" Height="64" Offset="0x1CE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_002CE0" OutName="turibori_sceneTex_002CE0" Format="rgba16" Width="64" Height="32" Offset="0x2CE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_003CE0" OutName="turibori_sceneTex_003CE0" Format="rgba16" Width="64" Height="32" Offset="0x3CE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_004CE0" OutName="turibori_sceneTex_004CE0" Format="rgba16" Width="32" Height="4" Offset="0x4CE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_004DE0" OutName="turibori_sceneTex_004DE0" Format="rgba16" Width="32" Height="16" Offset="0x4DE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_0051E0" OutName="turibori_sceneTex_0051E0" Format="ia16" Width="32" Height="32" Offset="0x51E0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_0059E0" OutName="turibori_sceneTex_0059E0" Format="ia8" Width="64" Height="64" Offset="0x59E0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_0069E0" OutName="turibori_sceneTex_0069E0" Format="ia8" Width="32" Height="16" Offset="0x69E0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_006BE0" OutName="turibori_sceneTex_006BE0" Format="rgba16" Width="32" Height="64" Offset="0x6BE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_007BE0" OutName="turibori_sceneTex_007BE0" Format="ia8" Width="64" Height="16" Offset="0x7BE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_007FE0" OutName="turibori_sceneTex_007FE0" Format="rgba16" Width="32" Height="8" Offset="0x7FE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_0081E0" OutName="turibori_sceneTex_0081E0" Format="rgba16" Width="64" Height="32" Offset="0x81E0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_0091E0" OutName="turibori_sceneTex_0091E0" Format="ia8" Width="16" Height="16" Offset="0x91E0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_0092E0" OutName="turibori_sceneTex_0092E0" Format="ia8" Width="16" Height="32" Offset="0x92E0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_0094E0" OutName="turibori_sceneTex_0094E0" Format="rgba16" Width="32" Height="32" Offset="0x94E0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_009CE0" OutName="turibori_sceneTex_009CE0" Format="rgba16" Width="32" Height="64" Offset="0x9CE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_00ACE0" OutName="turibori_sceneTex_00ACE0" Format="rgba16" Width="64" Height="32" Offset="0xACE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_00BCE0" OutName="turibori_sceneTex_00BCE0" Format="ia8" Width="32" Height="128" Offset="0xBCE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_00CCE0" OutName="turibori_sceneTex_00CCE0" Format="rgba16" Width="64" Height="32" Offset="0xCCE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_00DCE0" OutName="turibori_sceneTex_00DCE0" Format="rgba16" Width="32" Height="32" Offset="0xDCE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_00E4E0" OutName="turibori_sceneTex_00E4E0" Format="rgba16" Width="32" Height="32" Offset="0xE4E0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_00ECE0" OutName="turibori_sceneTex_00ECE0" Format="rgba16" Width="32" Height="32" Offset="0xECE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_00F4E0" OutName="turibori_sceneTex_00F4E0" Format="ia4" Width="64" Height="64" Offset="0xF4E0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_00FCE0" OutName="turibori_sceneTex_00FCE0" Format="rgba16" Width="32" Height="32" Offset="0xFCE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_0104E0" OutName="turibori_sceneTex_0104E0" Format="rgba16" Width="64" Height="32" Offset="0x104E0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_0114E0" OutName="turibori_sceneTex_0114E0" Format="i4" Width="32" Height="32" Offset="0x114E0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_0116E0" OutName="turibori_sceneTex_0116E0" Format="rgba16" Width="32" Height="64" Offset="0x116E0" AddedByScript="true"/>
         <Scene Name="turibori_scene" Offset="0x0"/>
     </File>
     <File Name="turibori_room_0" Segment="3">

--- a/soh/assets/xml/GC_NMQ_D/scenes/overworld/souko.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/overworld/souko.xml
@@ -1,16 +1,44 @@
 <Root>
     <File Name="souko_scene" Segment="2">
+        <Texture Name="souko_sceneTex_004410" OutName="souko_sceneTex_004410" Format="rgba16" Width="32" Height="32" Offset="0x4410" AddedByScript="true"/>
+        <Texture Name="souko_sceneTex_004C10" OutName="souko_sceneTex_004C10" Format="rgba16" Width="32" Height="16" Offset="0x4C10" AddedByScript="true"/>
+        <Texture Name="souko_sceneTex_005410" OutName="souko_sceneTex_005410" Format="rgba16" Width="32" Height="32" Offset="0x5410" AddedByScript="true"/>
+        <Texture Name="souko_sceneTex_005C10" OutName="souko_sceneTex_005C10" Format="rgba16" Width="64" Height="32" Offset="0x5C10" AddedByScript="true"/>
         <Texture Name="gLonLonHouseDayEntranceTex" OutName="day_entrance" Format="ia16" Width="64" Height="4" Offset="0x5210"/> 
         <Texture Name="gLonLonHouseNightEntranceTex" OutName="night_entrance" Format="ia16" Width="64" Height="4" Offset="0x5010"/> 
         <Scene Name="souko_scene" Offset="0x0"/>
     </File>
     <File Name="souko_room_0" Segment="3">
+        <Texture Name="souko_room_0Tex_0054F8" OutName="souko_room_0Tex_0054F8" Format="i4" Width="64" Height="64" Offset="0x54F8" AddedByScript="true"/>
+        <Texture Name="souko_room_0Tex_005CF8" OutName="souko_room_0Tex_005CF8" Format="rgba16" Width="32" Height="32" Offset="0x5CF8" AddedByScript="true"/>
+        <Texture Name="souko_room_0Tex_0064F8" OutName="souko_room_0Tex_0064F8" Format="rgba16" Width="32" Height="32" Offset="0x64F8" AddedByScript="true"/>
+        <Texture Name="souko_room_0Tex_006CF8" OutName="souko_room_0Tex_006CF8" Format="rgba16" Width="16" Height="32" Offset="0x6CF8" AddedByScript="true"/>
+        <Texture Name="souko_room_0Tex_0070F8" OutName="souko_room_0Tex_0070F8" Format="rgba16" Width="32" Height="32" Offset="0x70F8" AddedByScript="true"/>
+        <Texture Name="souko_room_0Tex_0078F8" OutName="souko_room_0Tex_0078F8" Format="rgba16" Width="32" Height="32" Offset="0x78F8" AddedByScript="true"/>
+        <Texture Name="souko_room_0Tex_0080F8" OutName="souko_room_0Tex_0080F8" Format="rgba16" Width="32" Height="64" Offset="0x80F8" AddedByScript="true"/>
+        <Texture Name="souko_room_0Tex_0090F8" OutName="souko_room_0Tex_0090F8" Format="i4" Width="32" Height="32" Offset="0x90F8" AddedByScript="true"/>
         <Room Name="souko_room_0" Offset="0x0"/>
     </File>
     <File Name="souko_room_1" Segment="3">
+        <Texture Name="souko_room_1Tex_005118" OutName="souko_room_1Tex_005118" Format="rgba16" Width="16" Height="64" Offset="0x5118" AddedByScript="true"/>
+        <Texture Name="souko_room_1Tex_005918" OutName="souko_room_1Tex_005918" Format="rgba16" Width="32" Height="32" Offset="0x5918" AddedByScript="true"/>
+        <Texture Name="souko_room_1Tex_006118" OutName="souko_room_1Tex_006118" Format="rgba16" Width="32" Height="64" Offset="0x6118" AddedByScript="true"/>
+        <Texture Name="souko_room_1Tex_007118" OutName="souko_room_1Tex_007118" Format="rgba16" Width="16" Height="32" Offset="0x7118" AddedByScript="true"/>
+        <Texture Name="souko_room_1Tex_007518" OutName="souko_room_1Tex_007518" Format="rgba16" Width="32" Height="32" Offset="0x7518" AddedByScript="true"/>
+        <Texture Name="souko_room_1Tex_007D18" OutName="souko_room_1Tex_007D18" Format="rgba16" Width="32" Height="64" Offset="0x7D18" AddedByScript="true"/>
+        <Texture Name="souko_room_1Tex_008D18" OutName="souko_room_1Tex_008D18" Format="rgba16" Width="32" Height="32" Offset="0x8D18" AddedByScript="true"/>
+        <Texture Name="souko_room_1Tex_009F28" OutName="souko_room_1Tex_009F28" Format="rgba16" Width="16" Height="16" Offset="0x9F28" AddedByScript="true"/>
+        <Texture Name="souko_room_1Tex_00A128" OutName="souko_room_1Tex_00A128" Format="ia8" Width="16" Height="16" Offset="0xA128" AddedByScript="true"/>
+        <Texture Name="souko_room_1Tex_00A228" OutName="souko_room_1Tex_00A228" Format="ia8" Width="16" Height="32" Offset="0xA228" AddedByScript="true"/>
         <Room Name="souko_room_1" Offset="0x0"/>
     </File>
     <File Name="souko_room_2" Segment="3">
+        <Texture Name="souko_room_2Tex_004EE0" OutName="souko_room_2Tex_004EE0" Format="rgba16" Width="16" Height="32" Offset="0x4EE0" AddedByScript="true"/>
+        <Texture Name="souko_room_2Tex_0052E0" OutName="souko_room_2Tex_0052E0" Format="i4" Width="64" Height="64" Offset="0x52E0" AddedByScript="true"/>
+        <Texture Name="souko_room_2Tex_005AE0" OutName="souko_room_2Tex_005AE0" Format="rgba16" Width="8" Height="128" Offset="0x5AE0" AddedByScript="true"/>
+        <Texture Name="souko_room_2Tex_0062E0" OutName="souko_room_2Tex_0062E0" Format="rgba16" Width="16" Height="64" Offset="0x62E0" AddedByScript="true"/>
+        <Texture Name="souko_room_2Tex_006AE0" OutName="souko_room_2Tex_006AE0" Format="rgba16" Width="32" Height="64" Offset="0x6AE0" AddedByScript="true"/>
+        <Texture Name="souko_room_2Tex_007F78" OutName="souko_room_2Tex_007F78" Format="ia8" Width="16" Height="32" Offset="0x7F78" AddedByScript="true"/>
         <Room Name="souko_room_2" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/scenes/overworld/spot00.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/overworld/spot00.xml
@@ -1,5 +1,56 @@
 <Root>
     <File Name="spot00_scene" Segment="2">
+        <Texture Name="spot00_sceneTex_013D98" OutName="spot00_sceneTex_013D98" Format="rgba16" Width="32" Height="32" Offset="0x13D98" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_014598" OutName="spot00_sceneTex_014598" Format="rgba16" Width="16" Height="32" Offset="0x14598" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_014998" OutName="spot00_sceneTex_014998" Format="rgba16" Width="32" Height="16" Offset="0x14998" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_014D98" OutName="spot00_sceneTex_014D98" Format="rgba16" Width="64" Height="32" Offset="0x14D98" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_015D98" OutName="spot00_sceneTex_015D98" Format="rgba16" Width="8" Height="16" Offset="0x15D98" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_015E98" OutName="spot00_sceneTex_015E98" Format="rgba16" Width="16" Height="64" Offset="0x15E98" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_016698" OutName="spot00_sceneTex_016698" Format="rgba16" Width="32" Height="16" Offset="0x16698" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_016A98" OutName="spot00_sceneTex_016A98" Format="ia4" Width="16" Height="32" Offset="0x16A98" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_016B98" OutName="spot00_sceneTex_016B98" Format="rgba16" Width="32" Height="32" Offset="0x16B98" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_017398" OutName="spot00_sceneTex_017398" Format="rgba16" Width="32" Height="32" Offset="0x17398" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_017B98" OutName="spot00_sceneTex_017B98" Format="rgba16" Width="32" Height="64" Offset="0x17B98" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_018B98" OutName="spot00_sceneTex_018B98" Format="rgba16" Width="32" Height="32" Offset="0x18B98" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_019398" OutName="spot00_sceneTex_019398" Format="rgba16" Width="32" Height="32" Offset="0x19398" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_019B98" OutName="spot00_sceneTex_019B98" Format="rgba16" Width="32" Height="64" Offset="0x19B98" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_01AB98" OutName="spot00_sceneTex_01AB98" Format="rgba16" Width="32" Height="32" Offset="0x1AB98" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_01B398" OutName="spot00_sceneTex_01B398" Format="rgba16" Width="32" Height="32" Offset="0x1B398" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_01BB98" OutName="spot00_sceneTex_01BB98" Format="rgba16" Width="16" Height="16" Offset="0x1BB98" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_01BD98" OutName="spot00_sceneTex_01BD98" Format="rgba16" Width="16" Height="32" Offset="0x1BD98" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_01C198" OutName="spot00_sceneTex_01C198" Format="rgba16" Width="32" Height="32" Offset="0x1C198" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_01C998" OutName="spot00_sceneTex_01C998" Format="rgba16" Width="32" Height="32" Offset="0x1C998" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_01D198" OutName="spot00_sceneTex_01D198" Format="rgba16" Width="64" Height="16" Offset="0x1D198" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_01D998" OutName="spot00_sceneTex_01D998" Format="rgba16" Width="32" Height="64" Offset="0x1D998" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_01E998" OutName="spot00_sceneTex_01E998" Format="ia4" Width="128" Height="32" Offset="0x1E998" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_01F198" OutName="spot00_sceneTex_01F198" Format="ia4" Width="64" Height="32" Offset="0x1F198" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_01F598" OutName="spot00_sceneTex_01F598" Format="i4" Width="16" Height="16" Offset="0x1F598" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_01F618" OutName="spot00_sceneTex_01F618" Format="rgba16" Width="8" Height="32" Offset="0x1F618" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_01F818" OutName="spot00_sceneTex_01F818" Format="rgba16" Width="32" Height="32" Offset="0x1F818" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_020018" OutName="spot00_sceneTex_020018" Format="i4" Width="64" Height="64" Offset="0x20018" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_020818" OutName="spot00_sceneTex_020818" Format="rgba16" Width="32" Height="32" Offset="0x20818" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_021018" OutName="spot00_sceneTex_021018" Format="rgba16" Width="16" Height="64" Offset="0x21018" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_021818" OutName="spot00_sceneTex_021818" Format="rgba16" Width="16" Height="64" Offset="0x21818" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_022018" OutName="spot00_sceneTex_022018" Format="ia4" Width="128" Height="32" Offset="0x22018" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_022818" OutName="spot00_sceneTex_022818" Format="rgba16" Width="64" Height="16" Offset="0x22818" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_023018" OutName="spot00_sceneTex_023018" Format="rgba16" Width="64" Height="16" Offset="0x23018" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_023818" OutName="spot00_sceneTex_023818" Format="i4" Width="64" Height="64" Offset="0x23818" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_024018" OutName="spot00_sceneTex_024018" Format="i4" Width="64" Height="64" Offset="0x24018" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_024818" OutName="spot00_sceneTex_024818" Format="ci4" Width="64" Height="64" Offset="0x24818" TlutOffset="0x13D70" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_025018" OutName="spot00_sceneTex_025018" Format="i4" Width="64" Height="64" Offset="0x25018" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_025818" OutName="spot00_sceneTex_025818" Format="rgba16" Width="8" Height="8" Offset="0x25818" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_025898" OutName="spot00_sceneTex_025898" Format="rgba16" Width="32" Height="32" Offset="0x25898" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_026098" OutName="spot00_sceneTex_026098" Format="rgba16" Width="32" Height="32" Offset="0x26098" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_026898" OutName="spot00_sceneTex_026898" Format="ia4" Width="16" Height="32" Offset="0x26898" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_026998" OutName="spot00_sceneTex_026998" Format="rgba16" Width="64" Height="32" Offset="0x26998" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_027998" OutName="spot00_sceneTex_027998" Format="i4" Width="32" Height="64" Offset="0x27998" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_027D98" OutName="spot00_sceneTex_027D98" Format="i4" Width="32" Height="64" Offset="0x27D98" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_028198" OutName="spot00_sceneTex_028198" Format="rgba16" Width="8" Height="64" Offset="0x28198" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_028598" OutName="spot00_sceneTex_028598" Format="rgba16" Width="64" Height="32" Offset="0x28598" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_029598" OutName="spot00_sceneTex_029598" Format="i4" Width="64" Height="64" Offset="0x29598" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_029D98" OutName="spot00_sceneTex_029D98" Format="i4" Width="32" Height="32" Offset="0x29D98" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_029F98" OutName="spot00_sceneTex_029F98" Format="i4" Width="32" Height="32" Offset="0x29F98" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTLUT_013D70" OutName="spot00_sceneTLUT_013D70" Format="rgba16" Width="4" Height="4" Offset="0x13D70" AddedByScript="true"/>
         <Cutscene Name="gHyruleFieldGetOoTCs" Offset="0xBB80"/>
         <Cutscene Name="gHyruleFieldZeldaSongOfTimeCs" Offset="0xF870"/>
         <Cutscene Name="gHyruleFieldEastEponaJumpCs" Offset="0xFF00"/>

--- a/soh/assets/xml/GC_NMQ_D/scenes/overworld/spot01.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/overworld/spot01.xml
@@ -1,5 +1,43 @@
 <Root>
     <File Name="spot01_scene" Segment="2">
+        <Texture Name="spot01_sceneTex_00AA50" OutName="spot01_sceneTex_00AA50" Format="rgba16" Width="32" Height="32" Offset="0xAA50" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00B250" OutName="spot01_sceneTex_00B250" Format="ci8" Width="16" Height="16" Offset="0xB250" TlutOffset="0xA870" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00B350" OutName="spot01_sceneTex_00B350" Format="ci8" Width="16" Height="64" Offset="0xB350" TlutOffset="0xA870" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00B750" OutName="spot01_sceneTex_00B750" Format="ci8" Width="32" Height="32" Offset="0xB750" TlutOffset="0xA870" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00BB50" OutName="spot01_sceneTex_00BB50" Format="rgba16" Width="16" Height="32" Offset="0xBB50" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00BF50" OutName="spot01_sceneTex_00BF50" Format="rgba16" Width="32" Height="32" Offset="0xBF50" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00C750" OutName="spot01_sceneTex_00C750" Format="ci8" Width="16" Height="32" Offset="0xC750" TlutOffset="0xA870" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00C950" OutName="spot01_sceneTex_00C950" Format="ci8" Width="32" Height="32" Offset="0xC950" TlutOffset="0xA870" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00CD50" OutName="spot01_sceneTex_00CD50" Format="ci8" Width="32" Height="64" Offset="0xCD50" TlutOffset="0xA870" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00D550" OutName="spot01_sceneTex_00D550" Format="i4" Width="64" Height="64" Offset="0xD550" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00DD50" OutName="spot01_sceneTex_00DD50" Format="i4" Width="64" Height="64" Offset="0xDD50" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00E550" OutName="spot01_sceneTex_00E550" Format="ci8" Width="32" Height="64" Offset="0xE550" TlutOffset="0xA870" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00ED50" OutName="spot01_sceneTex_00ED50" Format="ci4" Width="64" Height="64" Offset="0xED50" TlutOffset="0xAA28" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00F550" OutName="spot01_sceneTex_00F550" Format="rgba16" Width="32" Height="16" Offset="0xF550" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00F950" OutName="spot01_sceneTex_00F950" Format="rgba16" Width="32" Height="32" Offset="0xF950" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_010150" OutName="spot01_sceneTex_010150" Format="rgba16" Width="32" Height="32" Offset="0x10150" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_010950" OutName="spot01_sceneTex_010950" Format="rgba16" Width="32" Height="64" Offset="0x10950" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_011950" OutName="spot01_sceneTex_011950" Format="rgba16" Width="32" Height="64" Offset="0x11950" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_012950" OutName="spot01_sceneTex_012950" Format="ci8" Width="16" Height="32" Offset="0x12950" TlutOffset="0xA870" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_012B50" OutName="spot01_sceneTex_012B50" Format="rgba16" Width="64" Height="32" Offset="0x12B50" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_013B50" OutName="spot01_sceneTex_013B50" Format="rgba16" Width="16" Height="64" Offset="0x13B50" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_014350" OutName="spot01_sceneTex_014350" Format="ia4" Width="64" Height="32" Offset="0x14350" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_014750" OutName="spot01_sceneTex_014750" Format="ia4" Width="64" Height="32" Offset="0x14750" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_014B50" OutName="spot01_sceneTex_014B50" Format="ci8" Width="32" Height="32" Offset="0x14B50" TlutOffset="0xA870" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_014F50" OutName="spot01_sceneTex_014F50" Format="ci8" Width="64" Height="16" Offset="0x14F50" TlutOffset="0xA870" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_015350" OutName="spot01_sceneTex_015350" Format="ia4" Width="64" Height="64" Offset="0x15350" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_017B50" OutName="spot01_sceneTex_017B50" Format="ci8" Width="32" Height="64" Offset="0x17B50" TlutOffset="0xA870" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_018350" OutName="spot01_sceneTex_018350" Format="i4" Width="64" Height="64" Offset="0x18350" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_018B50" OutName="spot01_sceneTex_018B50" Format="rgba16" Width="32" Height="32" Offset="0x18B50" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_019350" OutName="spot01_sceneTex_019350" Format="rgba16" Width="32" Height="32" Offset="0x19350" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_019B50" OutName="spot01_sceneTex_019B50" Format="ci8" Width="32" Height="32" Offset="0x19B50" TlutOffset="0xA870" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_019F50" OutName="spot01_sceneTex_019F50" Format="rgba16" Width="32" Height="32" Offset="0x19F50" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_01A750" OutName="spot01_sceneTex_01A750" Format="i4" Width="64" Height="64" Offset="0x1A750" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_01AF50" OutName="spot01_sceneTex_01AF50" Format="rgba16" Width="16" Height="64" Offset="0x1AF50" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_01B750" OutName="spot01_sceneTex_01B750" Format="rgba16" Width="32" Height="32" Offset="0x1B750" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_01BF50" OutName="spot01_sceneTex_01BF50" Format="ci8" Width="16" Height="32" Offset="0x1BF50" TlutOffset="0xA870" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTLUT_00A870" OutName="spot01_sceneTLUT_00A870" Format="rgba16" Width="16" Height="16" Offset="0xA870" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTLUT_00AA28" OutName="spot01_sceneTLUT_00AA28" Format="rgba16" Width="4" Height="4" Offset="0xAA28" AddedByScript="true"/>
         <Path Name="gKakarikoVillagePath_003D0" Offset="0x3D0" NumPaths="3"/>
         <Cutscene Name="gKakarikoVillageIntroCs" Offset="0xA540"/>
         <Texture Name="gKakarikoVillageDayWindowTex" OutName="day_window" Format="rgba16" Width="32" Height="64" Offset="0x15B50"/>

--- a/soh/assets/xml/GC_NMQ_D/scenes/overworld/spot02.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/overworld/spot02.xml
@@ -1,5 +1,16 @@
 <Root>
     <File Name="spot02_scene" Segment="2">
+        <Texture Name="spot02_sceneTex_007280" OutName="spot02_sceneTex_007280" Format="rgba16" Width="32" Height="32" Offset="0x7280" AddedByScript="true"/>
+        <Texture Name="spot02_sceneTex_007A80" OutName="spot02_sceneTex_007A80" Format="rgba16" Width="32" Height="16" Offset="0x7A80" AddedByScript="true"/>
+        <Texture Name="spot02_sceneTex_007E80" OutName="spot02_sceneTex_007E80" Format="rgba16" Width="32" Height="32" Offset="0x7E80" AddedByScript="true"/>
+        <Texture Name="spot02_sceneTex_008680" OutName="spot02_sceneTex_008680" Format="rgba16" Width="16" Height="64" Offset="0x8680" AddedByScript="true"/>
+        <Texture Name="spot02_sceneTex_008E80" OutName="spot02_sceneTex_008E80" Format="i8" Width="64" Height="64" Offset="0x8E80" AddedByScript="true"/>
+        <Texture Name="spot02_sceneTex_009E80" OutName="spot02_sceneTex_009E80" Format="ia4" Width="32" Height="64" Offset="0x9E80" AddedByScript="true"/>
+        <Texture Name="spot02_sceneTex_00A280" OutName="spot02_sceneTex_00A280" Format="rgba16" Width="32" Height="32" Offset="0xA280" AddedByScript="true"/>
+        <Texture Name="spot02_sceneTex_00AA80" OutName="spot02_sceneTex_00AA80" Format="rgba16" Width="32" Height="16" Offset="0xAA80" AddedByScript="true"/>
+        <Texture Name="spot02_sceneTex_00AE80" OutName="spot02_sceneTex_00AE80" Format="i4" Width="32" Height="32" Offset="0xAE80" AddedByScript="true"/>
+        <Texture Name="spot02_sceneTex_00B080" OutName="spot02_sceneTex_00B080" Format="rgba16" Width="32" Height="32" Offset="0xB080" AddedByScript="true"/>
+        <Texture Name="spot02_sceneTex_00B880" OutName="spot02_sceneTex_00B880" Format="rgba16" Width="16" Height="32" Offset="0xB880" AddedByScript="true"/>
         <Scene Name="spot02_scene" Offset="0x0"/>
 
         <Cutscene Name="spot02_scene_Cs_003C80" Offset="0x3C80"/>
@@ -12,6 +23,42 @@
         <Room Name="spot02_room_0" Offset="0x0"/>
     </File>
     <File Name="spot02_room_1" Segment="3">
+        <Texture Name="spot02_room_1Tex_008F08" OutName="spot02_room_1Tex_008F08" Format="rgba16" Width="32" Height="32" Offset="0x8F08" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_009708" OutName="spot02_room_1Tex_009708" Format="rgba16" Width="16" Height="16" Offset="0x9708" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_009908" OutName="spot02_room_1Tex_009908" Format="rgba16" Width="64" Height="32" Offset="0x9908" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_00A908" OutName="spot02_room_1Tex_00A908" Format="rgba16" Width="32" Height="32" Offset="0xA908" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_00B108" OutName="spot02_room_1Tex_00B108" Format="rgba16" Width="32" Height="64" Offset="0xB108" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_00C108" OutName="spot02_room_1Tex_00C108" Format="rgba16" Width="16" Height="32" Offset="0xC108" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_00C508" OutName="spot02_room_1Tex_00C508" Format="ci4" Width="64" Height="64" Offset="0xC508" TlutOffset="0x8EB8" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_00CD08" OutName="spot02_room_1Tex_00CD08" Format="rgba16" Width="64" Height="32" Offset="0xCD08" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_00DD08" OutName="spot02_room_1Tex_00DD08" Format="ia8" Width="32" Height="32" Offset="0xDD08" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_00E108" OutName="spot02_room_1Tex_00E108" Format="rgba16" Width="16" Height="16" Offset="0xE108" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_00E308" OutName="spot02_room_1Tex_00E308" Format="rgba16" Width="32" Height="32" Offset="0xE308" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_00EB08" OutName="spot02_room_1Tex_00EB08" Format="rgba16" Width="16" Height="64" Offset="0xEB08" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_00F308" OutName="spot02_room_1Tex_00F308" Format="rgba16" Width="32" Height="64" Offset="0xF308" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_010308" OutName="spot02_room_1Tex_010308" Format="rgba16" Width="32" Height="32" Offset="0x10308" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_010B08" OutName="spot02_room_1Tex_010B08" Format="rgba16" Width="16" Height="16" Offset="0x10B08" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_010D08" OutName="spot02_room_1Tex_010D08" Format="rgba16" Width="32" Height="32" Offset="0x10D08" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_011508" OutName="spot02_room_1Tex_011508" Format="ia8" Width="64" Height="64" Offset="0x11508" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_012508" OutName="spot02_room_1Tex_012508" Format="rgba16" Width="32" Height="32" Offset="0x12508" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_012D08" OutName="spot02_room_1Tex_012D08" Format="rgba16" Width="32" Height="32" Offset="0x12D08" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_013508" OutName="spot02_room_1Tex_013508" Format="rgba16" Width="32" Height="64" Offset="0x13508" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_014508" OutName="spot02_room_1Tex_014508" Format="ci4" Width="64" Height="64" Offset="0x14508" TlutOffset="0x8EE0" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_014D08" OutName="spot02_room_1Tex_014D08" Format="rgba16" Width="128" Height="16" Offset="0x14D08" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_015D08" OutName="spot02_room_1Tex_015D08" Format="i8" Width="64" Height="64" Offset="0x15D08" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_016D08" OutName="spot02_room_1Tex_016D08" Format="i4" Width="16" Height="16" Offset="0x16D08" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_016D88" OutName="spot02_room_1Tex_016D88" Format="rgba16" Width="32" Height="32" Offset="0x16D88" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_017588" OutName="spot02_room_1Tex_017588" Format="rgba16" Width="32" Height="16" Offset="0x17588" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_017988" OutName="spot02_room_1Tex_017988" Format="ia8" Width="128" Height="32" Offset="0x17988" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_018988" OutName="spot02_room_1Tex_018988" Format="rgba16" Width="32" Height="64" Offset="0x18988" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_01B690" OutName="spot02_room_1Tex_01B690" Format="ia8" Width="64" Height="32" Offset="0x1B690" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_01BE90" OutName="spot02_room_1Tex_01BE90" Format="ia8" Width="32" Height="32" Offset="0x1BE90" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_01C290" OutName="spot02_room_1Tex_01C290" Format="ia8" Width="32" Height="32" Offset="0x1C290" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_01C690" OutName="spot02_room_1Tex_01C690" Format="ia8" Width="16" Height="16" Offset="0x1C690" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_01C790" OutName="spot02_room_1Tex_01C790" Format="ia8" Width="64" Height="64" Offset="0x1C790" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_01D790" OutName="spot02_room_1Tex_01D790" Format="ia8" Width="32" Height="64" Offset="0x1D790" AddedByScript="true"/>
+        <Texture Name="spot02_room_1TLUT_008EB8" OutName="spot02_room_1TLUT_008EB8" Format="rgba16" Width="4" Height="4" Offset="0x8EB8" AddedByScript="true"/>
+        <Texture Name="spot02_room_1TLUT_008EE0" OutName="spot02_room_1TLUT_008EE0" Format="rgba16" Width="4" Height="4" Offset="0x8EE0" AddedByScript="true"/>
         <Room Name="spot02_room_1" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/scenes/overworld/spot03.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/overworld/spot03.xml
@@ -1,14 +1,40 @@
 <Root>
     <File Name="spot03_scene" Segment="2">
+        <Texture Name="spot03_sceneTex_006D58" OutName="spot03_sceneTex_006D58" Format="ci8" Width="16" Height="64" Offset="0x6D58" TlutOffset="0x6920" AddedByScript="true"/>
+        <Texture Name="spot03_sceneTex_007158" OutName="spot03_sceneTex_007158" Format="rgba16" Width="16" Height="32" Offset="0x7158" AddedByScript="true"/>
+        <Texture Name="spot03_sceneTex_007558" OutName="spot03_sceneTex_007558" Format="rgba16" Width="32" Height="16" Offset="0x7558" AddedByScript="true"/>
+        <Texture Name="spot03_sceneTex_007958" OutName="spot03_sceneTex_007958" Format="ci8" Width="32" Height="32" Offset="0x7958" TlutOffset="0x6B28" AddedByScript="true"/>
+        <Texture Name="spot03_sceneTex_007D58" OutName="spot03_sceneTex_007D58" Format="rgba16" Width="32" Height="32" Offset="0x7D58" AddedByScript="true"/>
+        <Texture Name="spot03_sceneTex_008558" OutName="spot03_sceneTex_008558" Format="ci8" Width="32" Height="64" Offset="0x8558" TlutOffset="0x6B28" AddedByScript="true"/>
+        <Texture Name="spot03_sceneTex_008D58" OutName="spot03_sceneTex_008D58" Format="rgba16" Width="32" Height="32" Offset="0x8D58" AddedByScript="true"/>
+        <Texture Name="spot03_sceneTex_009558" OutName="spot03_sceneTex_009558" Format="ci4" Width="64" Height="64" Offset="0x9558" TlutOffset="0x6D30" AddedByScript="true"/>
+        <Texture Name="spot03_sceneTex_009D58" OutName="spot03_sceneTex_009D58" Format="rgba16" Width="32" Height="32" Offset="0x9D58" AddedByScript="true"/>
+        <Texture Name="spot03_sceneTex_00A558" OutName="spot03_sceneTex_00A558" Format="rgba16" Width="32" Height="32" Offset="0xA558" AddedByScript="true"/>
+        <Texture Name="spot03_sceneTex_00AD58" OutName="spot03_sceneTex_00AD58" Format="ia4" Width="64" Height="64" Offset="0xAD58" AddedByScript="true"/>
+        <Texture Name="spot03_sceneTLUT_006920" OutName="spot03_sceneTLUT_006920" Format="rgba16" Width="16" Height="16" Offset="0x6920" AddedByScript="true"/>
+        <Texture Name="spot03_sceneTLUT_006B28" OutName="spot03_sceneTLUT_006B28" Format="rgba16" Width="16" Height="16" Offset="0x6B28" AddedByScript="true"/>
+        <Texture Name="spot03_sceneTLUT_006D30" OutName="spot03_sceneTLUT_006D30" Format="rgba16" Width="4" Height="4" Offset="0x6D30" AddedByScript="true"/>
         <Path Name="gSpot03Path_0002BC" Offset="0x2BC" NumPaths="2"/>
         <Path Name="gSpot03Path_006908" Offset="0x6908" NumPaths="3"/>
 
         <Scene Name="spot03_scene" Offset="0x0"/>
     </File>
     <File Name="spot03_room_0" Segment="3">
+        <Texture Name="spot03_room_0Tex_0097B0" OutName="spot03_room_0Tex_0097B0" Format="ci8" Width="32" Height="32" Offset="0x97B0" ExternalTlut="spot03_scene" ExternalTlutOffset="0x6B28" AddedByScript="true"/>
+        <Texture Name="spot03_room_0Tex_009BB0" OutName="spot03_room_0Tex_009BB0" Format="ci8" Width="32" Height="64" Offset="0x9BB0" ExternalTlut="spot03_scene" ExternalTlutOffset="0x6B28" AddedByScript="true"/>
+        <Texture Name="spot03_room_0Tex_00A3B0" OutName="spot03_room_0Tex_00A3B0" Format="rgba16" Width="16" Height="64" Offset="0xA3B0" AddedByScript="true"/>
+        <Texture Name="spot03_room_0Tex_00ABB0" OutName="spot03_room_0Tex_00ABB0" Format="rgba16" Width="64" Height="32" Offset="0xABB0" AddedByScript="true"/>
+        <Texture Name="spot03_room_0Tex_00BBB0" OutName="spot03_room_0Tex_00BBB0" Format="ci8" Width="32" Height="32" Offset="0xBBB0" ExternalTlut="spot03_scene" ExternalTlutOffset="0x6B28" AddedByScript="true"/>
+        <Texture Name="spot03_room_0Tex_00BFB0" OutName="spot03_room_0Tex_00BFB0" Format="ci8" Width="32" Height="32" Offset="0xBFB0" ExternalTlut="spot03_scene" ExternalTlutOffset="0x6B28" AddedByScript="true"/>
+        <Texture Name="spot03_room_0Tex_00D180" OutName="spot03_room_0Tex_00D180" Format="i4" Width="64" Height="64" Offset="0xD180" AddedByScript="true"/>
         <Room Name="spot03_room_0" Offset="0x0"/>
     </File>
     <File Name="spot03_room_1" Segment="3">
+        <Texture Name="spot03_room_1Tex_0050D8" OutName="spot03_room_1Tex_0050D8" Format="ci8" Width="64" Height="32" Offset="0x50D8" ExternalTlut="spot03_scene" ExternalTlutOffset="0x6920" AddedByScript="true"/>
+        <Texture Name="spot03_room_1Tex_0058D8" OutName="spot03_room_1Tex_0058D8" Format="ci8" Width="64" Height="16" Offset="0x58D8" ExternalTlut="spot03_scene" ExternalTlutOffset="0x6920" AddedByScript="true"/>
+        <Texture Name="spot03_room_1Tex_005CD8" OutName="spot03_room_1Tex_005CD8" Format="ci8" Width="32" Height="16" Offset="0x5CD8" ExternalTlut="spot03_scene" ExternalTlutOffset="0x6920" AddedByScript="true"/>
+        <Texture Name="spot03_room_1Tex_005ED8" OutName="spot03_room_1Tex_005ED8" Format="ci8" Width="16" Height="64" Offset="0x5ED8" ExternalTlut="spot03_scene" ExternalTlutOffset="0x6920" AddedByScript="true"/>
+        <Texture Name="spot03_room_1Tex_0062D8" OutName="spot03_room_1Tex_0062D8" Format="ci8" Width="64" Height="32" Offset="0x62D8" ExternalTlut="spot03_scene" ExternalTlutOffset="0x6920" AddedByScript="true"/>
         <DList Name="gSpot03DL_0074E8" Offset="0x74E8"/>
         <Room Name="spot03_room_1" Offset="0x0"/>
     </File>

--- a/soh/assets/xml/GC_NMQ_D/scenes/overworld/spot04.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/overworld/spot04.xml
@@ -1,5 +1,12 @@
 <Root>
     <File Name="spot04_scene" Segment="2">
+        <Texture Name="spot04_sceneTex_00E218" OutName="spot04_sceneTex_00E218" Format="rgba16" Width="32" Height="32" Offset="0xE218" AddedByScript="true"/>
+        <Texture Name="spot04_sceneTex_00EA18" OutName="spot04_sceneTex_00EA18" Format="i4" Width="64" Height="64" Offset="0xEA18" AddedByScript="true"/>
+        <Texture Name="spot04_sceneTex_00F218" OutName="spot04_sceneTex_00F218" Format="i4" Width="64" Height="64" Offset="0xF218" AddedByScript="true"/>
+        <Texture Name="spot04_sceneTex_00FA18" OutName="spot04_sceneTex_00FA18" Format="ci8" Width="32" Height="32" Offset="0xFA18" TlutOffset="0xE010" AddedByScript="true"/>
+        <Texture Name="spot04_sceneTex_00FE18" OutName="spot04_sceneTex_00FE18" Format="rgba16" Width="32" Height="32" Offset="0xFE18" AddedByScript="true"/>
+        <Texture Name="spot04_sceneTex_010618" OutName="spot04_sceneTex_010618" Format="rgba16" Width="32" Height="32" Offset="0x10618" AddedByScript="true"/>
+        <Texture Name="spot04_sceneTLUT_00E010" OutName="spot04_sceneTLUT_00E010" Format="rgba16" Width="16" Height="16" Offset="0xE010" AddedByScript="true"/>
         <Path Name="gSpot04Path_00030C" Offset="0x30C" NumPaths="3"/>
         <Path Name="gSpot04Path_00D730" Offset="0xD730"/>
         <Cutscene Name="gKokiriForestDekuSproutCs" Offset="0xC9D0"/>
@@ -8,12 +15,65 @@
         <Scene Name="spot04_scene" Offset="0x0"/>
     </File>
     <File Name="spot04_room_0" Segment="3">
+        <Texture Name="spot04_room_0Tex_00BF08" OutName="spot04_room_0Tex_00BF08" Format="rgba16" Width="32" Height="32" Offset="0xBF08" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_00C708" OutName="spot04_room_0Tex_00C708" Format="rgba16" Width="32" Height="16" Offset="0xC708" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_00CB08" OutName="spot04_room_0Tex_00CB08" Format="rgba16" Width="32" Height="16" Offset="0xCB08" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_00CF08" OutName="spot04_room_0Tex_00CF08" Format="ci8" Width="32" Height="32" Offset="0xCF08" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE010" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_00D308" OutName="spot04_room_0Tex_00D308" Format="ci8" Width="16" Height="16" Offset="0xD308" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE010" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_00D408" OutName="spot04_room_0Tex_00D408" Format="ci8" Width="16" Height="16" Offset="0xD408" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE010" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_00D508" OutName="spot04_room_0Tex_00D508" Format="rgba16" Width="16" Height="32" Offset="0xD508" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_00D908" OutName="spot04_room_0Tex_00D908" Format="rgba16" Width="16" Height="64" Offset="0xD908" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_00E108" OutName="spot04_room_0Tex_00E108" Format="rgba16" Width="32" Height="32" Offset="0xE108" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_00E908" OutName="spot04_room_0Tex_00E908" Format="rgba16" Width="32" Height="32" Offset="0xE908" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_00F108" OutName="spot04_room_0Tex_00F108" Format="rgba16" Width="64" Height="8" Offset="0xF108" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_00F508" OutName="spot04_room_0Tex_00F508" Format="rgba16" Width="32" Height="32" Offset="0xF508" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_00FD08" OutName="spot04_room_0Tex_00FD08" Format="rgba16" Width="32" Height="64" Offset="0xFD08" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_010D08" OutName="spot04_room_0Tex_010D08" Format="rgba16" Width="32" Height="64" Offset="0x10D08" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_011D08" OutName="spot04_room_0Tex_011D08" Format="ci8" Width="16" Height="32" Offset="0x11D08" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE010" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_011F08" OutName="spot04_room_0Tex_011F08" Format="rgba16" Width="64" Height="32" Offset="0x11F08" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_012F08" OutName="spot04_room_0Tex_012F08" Format="ci8" Width="32" Height="16" Offset="0x12F08" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE010" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_013108" OutName="spot04_room_0Tex_013108" Format="ci8" Width="32" Height="16" Offset="0x13108" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE010" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_013308" OutName="spot04_room_0Tex_013308" Format="rgba16" Width="16" Height="32" Offset="0x13308" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_013708" OutName="spot04_room_0Tex_013708" Format="rgba16" Width="32" Height="32" Offset="0x13708" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_013F08" OutName="spot04_room_0Tex_013F08" Format="ci8" Width="32" Height="32" Offset="0x13F08" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE010" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_014308" OutName="spot04_room_0Tex_014308" Format="rgba16" Width="32" Height="32" Offset="0x14308" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_014B08" OutName="spot04_room_0Tex_014B08" Format="rgba16" Width="32" Height="32" Offset="0x14B08" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_015308" OutName="spot04_room_0Tex_015308" Format="rgba16" Width="64" Height="16" Offset="0x15308" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_015B08" OutName="spot04_room_0Tex_015B08" Format="ci8" Width="16" Height="32" Offset="0x15B08" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE010" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_015D08" OutName="spot04_room_0Tex_015D08" Format="ci8" Width="16" Height="64" Offset="0x15D08" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE010" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_016108" OutName="spot04_room_0Tex_016108" Format="ci8" Width="16" Height="64" Offset="0x16108" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE010" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_016508" OutName="spot04_room_0Tex_016508" Format="ci8" Width="32" Height="32" Offset="0x16508" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE010" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_016908" OutName="spot04_room_0Tex_016908" Format="ci8" Width="16" Height="64" Offset="0x16908" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE010" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_016D08" OutName="spot04_room_0Tex_016D08" Format="rgba16" Width="32" Height="16" Offset="0x16D08" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_017108" OutName="spot04_room_0Tex_017108" Format="rgba16" Width="32" Height="32" Offset="0x17108" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_018A90" OutName="spot04_room_0Tex_018A90" Format="rgba16" Width="32" Height="32" Offset="0x18A90" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_019290" OutName="spot04_room_0Tex_019290" Format="i4" Width="64" Height="64" Offset="0x19290" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_019A90" OutName="spot04_room_0Tex_019A90" Format="i4" Width="64" Height="64" Offset="0x19A90" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_01A290" OutName="spot04_room_0Tex_01A290" Format="ia8" Width="16" Height="32" Offset="0x1A290" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_01A490" OutName="spot04_room_0Tex_01A490" Format="ia4" Width="64" Height="64" Offset="0x1A490" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_01AC90" OutName="spot04_room_0Tex_01AC90" Format="ia4" Width="32" Height="32" Offset="0x1AC90" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_01AE90" OutName="spot04_room_0Tex_01AE90" Format="ia4" Width="32" Height="32" Offset="0x1AE90" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_01B090" OutName="spot04_room_0Tex_01B090" Format="rgba16" Width="16" Height="32" Offset="0x1B090" AddedByScript="true"/>
         <Room Name="spot04_room_0" Offset="0x0"/>
     </File>
     <File Name="spot04_room_1" Segment="3">
+        <Texture Name="spot04_room_1Tex_004EA8" OutName="spot04_room_1Tex_004EA8" Format="rgba16" Width="32" Height="16" Offset="0x4EA8" AddedByScript="true"/>
+        <Texture Name="spot04_room_1Tex_0052A8" OutName="spot04_room_1Tex_0052A8" Format="rgba16" Width="32" Height="16" Offset="0x52A8" AddedByScript="true"/>
+        <Texture Name="spot04_room_1Tex_0056A8" OutName="spot04_room_1Tex_0056A8" Format="rgba16" Width="64" Height="32" Offset="0x56A8" AddedByScript="true"/>
+        <Texture Name="spot04_room_1Tex_0066A8" OutName="spot04_room_1Tex_0066A8" Format="rgba16" Width="32" Height="32" Offset="0x66A8" AddedByScript="true"/>
+        <Texture Name="spot04_room_1Tex_006EA8" OutName="spot04_room_1Tex_006EA8" Format="rgba16" Width="32" Height="32" Offset="0x6EA8" AddedByScript="true"/>
+        <Texture Name="spot04_room_1Tex_007B78" OutName="spot04_room_1Tex_007B78" Format="ia8" Width="16" Height="32" Offset="0x7B78" AddedByScript="true"/>
+        <Texture Name="spot04_room_1Tex_007D78" OutName="spot04_room_1Tex_007D78" Format="i4" Width="64" Height="64" Offset="0x7D78" AddedByScript="true"/>
         <Room Name="spot04_room_1" Offset="0x0"/>
     </File>
     <File Name="spot04_room_2" Segment="3">
+        <Texture Name="spot04_room_2Tex_002BF8" OutName="spot04_room_2Tex_002BF8" Format="ci8" Width="32" Height="16" Offset="0x2BF8" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE010" AddedByScript="true"/>
+        <Texture Name="spot04_room_2Tex_002DF8" OutName="spot04_room_2Tex_002DF8" Format="ci8" Width="32" Height="16" Offset="0x2DF8" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE010" AddedByScript="true"/>
+        <Texture Name="spot04_room_2Tex_002FF8" OutName="spot04_room_2Tex_002FF8" Format="ci8" Width="32" Height="32" Offset="0x2FF8" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE010" AddedByScript="true"/>
+        <Texture Name="spot04_room_2Tex_0033F8" OutName="spot04_room_2Tex_0033F8" Format="rgba16" Width="32" Height="32" Offset="0x33F8" AddedByScript="true"/>
+        <Texture Name="spot04_room_2Tex_003BF8" OutName="spot04_room_2Tex_003BF8" Format="rgba16" Width="64" Height="16" Offset="0x3BF8" AddedByScript="true"/>
+        <Texture Name="spot04_room_2Tex_0043F8" OutName="spot04_room_2Tex_0043F8" Format="ci8" Width="16" Height="32" Offset="0x43F8" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE010" AddedByScript="true"/>
+        <Texture Name="spot04_room_2Tex_0045F8" OutName="spot04_room_2Tex_0045F8" Format="rgba16" Width="32" Height="32" Offset="0x45F8" AddedByScript="true"/>
         <DList Name="gSpot04DL_002BB8" Offset="0x2BB8"/>
         <DList Name="gSpot04DL_005058" Offset="0x5058"/>
         <Room Name="spot04_room_2" Offset="0x0"/>

--- a/soh/assets/xml/GC_NMQ_D/scenes/overworld/spot05.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/overworld/spot05.xml
@@ -1,5 +1,32 @@
 <Root>
     <File Name="spot05_scene" Segment="2">
+        <Texture Name="spot05_sceneTex_006D60" OutName="spot05_sceneTex_006D60" Format="rgba16" Width="32" Height="64" Offset="0x6D60" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_007D60" OutName="spot05_sceneTex_007D60" Format="rgba16" Width="32" Height="64" Offset="0x7D60" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_008D60" OutName="spot05_sceneTex_008D60" Format="ci8" Width="32" Height="32" Offset="0x8D60" TlutOffset="0x6BC0" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_009160" OutName="spot05_sceneTex_009160" Format="ci8" Width="32" Height="32" Offset="0x9160" TlutOffset="0x6BC0" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_009560" OutName="spot05_sceneTex_009560" Format="rgba16" Width="16" Height="32" Offset="0x9560" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_009960" OutName="spot05_sceneTex_009960" Format="ci8" Width="64" Height="32" Offset="0x9960" TlutOffset="0x6BC0" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_00A160" OutName="spot05_sceneTex_00A160" Format="rgba16" Width="64" Height="32" Offset="0xA160" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_00B160" OutName="spot05_sceneTex_00B160" Format="rgba16" Width="32" Height="32" Offset="0xB160" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_00B960" OutName="spot05_sceneTex_00B960" Format="rgba16" Width="16" Height="16" Offset="0xB960" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_00BB60" OutName="spot05_sceneTex_00BB60" Format="rgba16" Width="16" Height="128" Offset="0xBB60" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_00CB60" OutName="spot05_sceneTex_00CB60" Format="rgba16" Width="32" Height="32" Offset="0xCB60" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_00D360" OutName="spot05_sceneTex_00D360" Format="i4" Width="64" Height="64" Offset="0xD360" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_00DB60" OutName="spot05_sceneTex_00DB60" Format="rgba16" Width="32" Height="32" Offset="0xDB60" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_00E360" OutName="spot05_sceneTex_00E360" Format="i4" Width="64" Height="64" Offset="0xE360" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_00EB60" OutName="spot05_sceneTex_00EB60" Format="rgba16" Width="64" Height="16" Offset="0xEB60" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_00F360" OutName="spot05_sceneTex_00F360" Format="rgba16" Width="32" Height="32" Offset="0xF360" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_00FB60" OutName="spot05_sceneTex_00FB60" Format="i4" Width="64" Height="64" Offset="0xFB60" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_010360" OutName="spot05_sceneTex_010360" Format="rgba16" Width="32" Height="32" Offset="0x10360" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_010B60" OutName="spot05_sceneTex_010B60" Format="rgba16" Width="32" Height="32" Offset="0x10B60" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_011360" OutName="spot05_sceneTex_011360" Format="rgba16" Width="32" Height="64" Offset="0x11360" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_012360" OutName="spot05_sceneTex_012360" Format="rgba16" Width="32" Height="32" Offset="0x12360" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_012B60" OutName="spot05_sceneTex_012B60" Format="rgba16" Width="32" Height="32" Offset="0x12B60" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_013360" OutName="spot05_sceneTex_013360" Format="rgba16" Width="32" Height="32" Offset="0x13360" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_013B60" OutName="spot05_sceneTex_013B60" Format="rgba16" Width="64" Height="16" Offset="0x13B60" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_014360" OutName="spot05_sceneTex_014360" Format="rgba16" Width="32" Height="32" Offset="0x14360" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_014B60" OutName="spot05_sceneTex_014B60" Format="ia8" Width="16" Height="32" Offset="0x14B60" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTLUT_006BC0" OutName="spot05_sceneTLUT_006BC0" Format="rgba16" Width="16" Height="16" Offset="0x6BC0" AddedByScript="true"/>
         <Cutscene Name="gMinuetCs" Offset="0x3F80"/>
 
         <Cutscene Name="spot05_scene_Cs_005730" Offset="0x5730"/>

--- a/soh/assets/xml/GC_NMQ_D/scenes/overworld/spot06.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/overworld/spot06.xml
@@ -1,5 +1,48 @@
 <Root>
     <File Name="spot06_scene" Segment="2">
+        <Texture Name="spot06_sceneTex_007C38" OutName="spot06_sceneTex_007C38" Format="rgba16" Width="16" Height="32" Offset="0x7C38" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_008038" OutName="spot06_sceneTex_008038" Format="rgba16" Width="16" Height="32" Offset="0x8038" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_008438" OutName="spot06_sceneTex_008438" Format="rgba16" Width="16" Height="32" Offset="0x8438" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_008838" OutName="spot06_sceneTex_008838" Format="rgba16" Width="32" Height="64" Offset="0x8838" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_009838" OutName="spot06_sceneTex_009838" Format="rgba16" Width="8" Height="8" Offset="0x9838" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_0098B8" OutName="spot06_sceneTex_0098B8" Format="rgba16" Width="8" Height="32" Offset="0x98B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_009AB8" OutName="spot06_sceneTex_009AB8" Format="rgba16" Width="32" Height="64" Offset="0x9AB8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_00AAB8" OutName="spot06_sceneTex_00AAB8" Format="rgba16" Width="32" Height="16" Offset="0xAAB8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_00AEB8" OutName="spot06_sceneTex_00AEB8" Format="rgba16" Width="32" Height="32" Offset="0xAEB8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_00B6B8" OutName="spot06_sceneTex_00B6B8" Format="rgba16" Width="16" Height="32" Offset="0xB6B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_00BAB8" OutName="spot06_sceneTex_00BAB8" Format="ia8" Width="32" Height="32" Offset="0xBAB8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_00BEB8" OutName="spot06_sceneTex_00BEB8" Format="rgba16" Width="32" Height="16" Offset="0xBEB8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_00C2B8" OutName="spot06_sceneTex_00C2B8" Format="rgba16" Width="16" Height="16" Offset="0xC2B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_00C4B8" OutName="spot06_sceneTex_00C4B8" Format="rgba16" Width="32" Height="32" Offset="0xC4B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_00CCB8" OutName="spot06_sceneTex_00CCB8" Format="rgba16" Width="32" Height="64" Offset="0xCCB8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_00DCB8" OutName="spot06_sceneTex_00DCB8" Format="rgba16" Width="32" Height="64" Offset="0xDCB8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_00ECB8" OutName="spot06_sceneTex_00ECB8" Format="rgba16" Width="16" Height="64" Offset="0xECB8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_00F4B8" OutName="spot06_sceneTex_00F4B8" Format="rgba16" Width="16" Height="16" Offset="0xF4B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_00F6B8" OutName="spot06_sceneTex_00F6B8" Format="rgba16" Width="32" Height="32" Offset="0xF6B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_00FEB8" OutName="spot06_sceneTex_00FEB8" Format="rgba16" Width="32" Height="64" Offset="0xFEB8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_010EB8" OutName="spot06_sceneTex_010EB8" Format="rgba16" Width="32" Height="32" Offset="0x10EB8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_0116B8" OutName="spot06_sceneTex_0116B8" Format="rgba16" Width="32" Height="32" Offset="0x116B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_011EB8" OutName="spot06_sceneTex_011EB8" Format="rgba16" Width="16" Height="32" Offset="0x11EB8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_0122B8" OutName="spot06_sceneTex_0122B8" Format="rgba16" Width="32" Height="16" Offset="0x122B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_0126B8" OutName="spot06_sceneTex_0126B8" Format="rgba16" Width="32" Height="32" Offset="0x126B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_012EB8" OutName="spot06_sceneTex_012EB8" Format="rgba16" Width="8" Height="32" Offset="0x12EB8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_0130B8" OutName="spot06_sceneTex_0130B8" Format="rgba16" Width="32" Height="64" Offset="0x130B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_0140B8" OutName="spot06_sceneTex_0140B8" Format="rgba16" Width="16" Height="64" Offset="0x140B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_0148B8" OutName="spot06_sceneTex_0148B8" Format="rgba16" Width="16" Height="32" Offset="0x148B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_014CB8" OutName="spot06_sceneTex_014CB8" Format="rgba16" Width="32" Height="32" Offset="0x14CB8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_0154B8" OutName="spot06_sceneTex_0154B8" Format="rgba16" Width="16" Height="64" Offset="0x154B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_015CB8" OutName="spot06_sceneTex_015CB8" Format="rgba16" Width="16" Height="64" Offset="0x15CB8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_0164B8" OutName="spot06_sceneTex_0164B8" Format="rgba16" Width="32" Height="32" Offset="0x164B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_016CB8" OutName="spot06_sceneTex_016CB8" Format="rgba16" Width="16" Height="32" Offset="0x16CB8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_0170B8" OutName="spot06_sceneTex_0170B8" Format="rgba16" Width="32" Height="32" Offset="0x170B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_0178B8" OutName="spot06_sceneTex_0178B8" Format="rgba16" Width="16" Height="32" Offset="0x178B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_017CB8" OutName="spot06_sceneTex_017CB8" Format="ci4" Width="64" Height="64" Offset="0x17CB8" TlutOffset="0x7C10" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_0184B8" OutName="spot06_sceneTex_0184B8" Format="rgba16" Width="32" Height="32" Offset="0x184B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_018CB8" OutName="spot06_sceneTex_018CB8" Format="rgba16" Width="32" Height="32" Offset="0x18CB8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_0194B8" OutName="spot06_sceneTex_0194B8" Format="rgba16" Width="16" Height="128" Offset="0x194B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_01A4B8" OutName="spot06_sceneTex_01A4B8" Format="i4" Width="64" Height="64" Offset="0x1A4B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_01ACB8" OutName="spot06_sceneTex_01ACB8" Format="rgba16" Width="16" Height="32" Offset="0x1ACB8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTLUT_007C10" OutName="spot06_sceneTLUT_007C10" Format="rgba16" Width="4" Height="4" Offset="0x7C10" AddedByScript="true"/>
         <Cutscene Name="gLakeHyliaFireArrowsCS" Offset="0x7020"/>
         <Cutscene Name="gLakeHyliaOwlCs" Offset="0x1B0C0"/>
         <Path Name="gSpot06Path_007764" Offset="0x7764" NumPaths="2"/>

--- a/soh/assets/xml/GC_NMQ_D/scenes/overworld/spot07.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/overworld/spot07.xml
@@ -1,5 +1,22 @@
 <Root>
     <File Name="spot07_scene" Segment="2">
+        <Texture Name="spot07_sceneTex_003F98" OutName="spot07_sceneTex_003F98" Format="rgba16" Width="32" Height="64" Offset="0x3F98" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_004F98" OutName="spot07_sceneTex_004F98" Format="ci4" Width="64" Height="32" Offset="0x4F98" TlutOffset="0x3F70" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_005398" OutName="spot07_sceneTex_005398" Format="ci4" Width="64" Height="32" Offset="0x5398" TlutOffset="0x3F70" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_005798" OutName="spot07_sceneTex_005798" Format="ci4" Width="64" Height="32" Offset="0x5798" TlutOffset="0x3F70" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_005B98" OutName="spot07_sceneTex_005B98" Format="ci4" Width="64" Height="32" Offset="0x5B98" TlutOffset="0x3F70" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_005F98" OutName="spot07_sceneTex_005F98" Format="ci4" Width="64" Height="32" Offset="0x5F98" TlutOffset="0x3F70" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_006398" OutName="spot07_sceneTex_006398" Format="ci4" Width="64" Height="32" Offset="0x6398" TlutOffset="0x3F70" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_006798" OutName="spot07_sceneTex_006798" Format="ci4" Width="64" Height="32" Offset="0x6798" TlutOffset="0x3F70" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_006B98" OutName="spot07_sceneTex_006B98" Format="ci4" Width="64" Height="32" Offset="0x6B98" TlutOffset="0x3F70" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_006F98" OutName="spot07_sceneTex_006F98" Format="rgba16" Width="32" Height="32" Offset="0x6F98" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_007798" OutName="spot07_sceneTex_007798" Format="ci4" Width="64" Height="32" Offset="0x7798" TlutOffset="0x3F70" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_007B98" OutName="spot07_sceneTex_007B98" Format="ci4" Width="64" Height="32" Offset="0x7B98" TlutOffset="0x3F70" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_007F98" OutName="spot07_sceneTex_007F98" Format="rgba16" Width="32" Height="32" Offset="0x7F98" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_008798" OutName="spot07_sceneTex_008798" Format="ia4" Width="64" Height="64" Offset="0x8798" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_009018" OutName="spot07_sceneTex_009018" Format="ci4" Width="64" Height="32" Offset="0x9018" TlutOffset="0x3F70" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_009418" OutName="spot07_sceneTex_009418" Format="ci4" Width="64" Height="32" Offset="0x9418" TlutOffset="0x3F70" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTLUT_003F70" OutName="spot07_sceneTLUT_003F70" Format="rgba16" Width="4" Height="4" Offset="0x3F70" AddedByScript="true"/>
         <Path Name="gZorasDomainPath_0234" Offset="0x234" NumPaths="3"/>
         <Cutscene Name="gZorasDomainIntroCs" Offset="0x3D70"/>
         <Texture Name="gZorasDomainDayEntranceTex" OutName="day_entrance" Format="ia8" Width="8" Height="8" Offset="0x8F98"/>
@@ -7,9 +24,24 @@
         <Scene Name="spot07_scene" Offset="0x0"/>
     </File>
     <File Name="spot07_room_0" Segment="3">
+        <Texture Name="spot07_room_0Tex_004748" OutName="spot07_room_0Tex_004748" Format="rgba16" Width="64" Height="16" Offset="0x4748" AddedByScript="true"/>
+        <Texture Name="spot07_room_0Tex_004F48" OutName="spot07_room_0Tex_004F48" Format="rgba16" Width="64" Height="16" Offset="0x4F48" AddedByScript="true"/>
+        <Texture Name="spot07_room_0Tex_005748" OutName="spot07_room_0Tex_005748" Format="rgba16" Width="16" Height="64" Offset="0x5748" AddedByScript="true"/>
         <Room Name="spot07_room_0" Offset="0x0"/>
     </File>
     <File Name="spot07_room_1" Segment="3">
+        <Texture Name="spot07_room_1Tex_0076D8" OutName="spot07_room_1Tex_0076D8" Format="rgba16" Width="32" Height="32" Offset="0x76D8" AddedByScript="true"/>
+        <Texture Name="spot07_room_1Tex_007ED8" OutName="spot07_room_1Tex_007ED8" Format="rgba16" Width="16" Height="64" Offset="0x7ED8" AddedByScript="true"/>
+        <Texture Name="spot07_room_1Tex_0086D8" OutName="spot07_room_1Tex_0086D8" Format="ci4" Width="64" Height="32" Offset="0x86D8" ExternalTlut="spot07_scene" ExternalTlutOffset="0x3F70" AddedByScript="true"/>
+        <Texture Name="spot07_room_1Tex_008AD8" OutName="spot07_room_1Tex_008AD8" Format="ci4" Width="32" Height="16" Offset="0x8AD8" ExternalTlut="spot07_scene" ExternalTlutOffset="0x3F70" AddedByScript="true"/>
+        <Texture Name="spot07_room_1Tex_008BD8" OutName="spot07_room_1Tex_008BD8" Format="ci4" Width="64" Height="32" Offset="0x8BD8" ExternalTlut="spot07_scene" ExternalTlutOffset="0x3F70" AddedByScript="true"/>
+        <Texture Name="spot07_room_1Tex_008FD8" OutName="spot07_room_1Tex_008FD8" Format="ci4" Width="64" Height="32" Offset="0x8FD8" ExternalTlut="spot07_scene" ExternalTlutOffset="0x3F70" AddedByScript="true"/>
+        <Texture Name="spot07_room_1Tex_0093D8" OutName="spot07_room_1Tex_0093D8" Format="ci4" Width="64" Height="32" Offset="0x93D8" ExternalTlut="spot07_scene" ExternalTlutOffset="0x3F70" AddedByScript="true"/>
+        <Texture Name="spot07_room_1Tex_0097D8" OutName="spot07_room_1Tex_0097D8" Format="ci4" Width="64" Height="32" Offset="0x97D8" ExternalTlut="spot07_scene" ExternalTlutOffset="0x3F70" AddedByScript="true"/>
+        <Texture Name="spot07_room_1Tex_009BD8" OutName="spot07_room_1Tex_009BD8" Format="rgba16" Width="32" Height="32" Offset="0x9BD8" AddedByScript="true"/>
+        <Texture Name="spot07_room_1Tex_00A3D8" OutName="spot07_room_1Tex_00A3D8" Format="rgba16" Width="32" Height="32" Offset="0xA3D8" AddedByScript="true"/>
+        <Texture Name="spot07_room_1Tex_00ABD8" OutName="spot07_room_1Tex_00ABD8" Format="rgba16" Width="16" Height="128" Offset="0xABD8" AddedByScript="true"/>
+        <Texture Name="spot07_room_1Tex_00C1A0" OutName="spot07_room_1Tex_00C1A0" Format="rgba16" Width="64" Height="16" Offset="0xC1A0" AddedByScript="true"/>
         <Room Name="spot07_room_1" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/scenes/overworld/spot08.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/overworld/spot08.xml
@@ -1,5 +1,32 @@
 <Root>
     <File Name="spot08_scene" Segment="2">
+        <Texture Name="spot08_sceneTex_004DA0" OutName="spot08_sceneTex_004DA0" Format="rgba16" Width="64" Height="32" Offset="0x4DA0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_005DA0" OutName="spot08_sceneTex_005DA0" Format="rgba16" Width="32" Height="16" Offset="0x5DA0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_0061A0" OutName="spot08_sceneTex_0061A0" Format="rgba16" Width="32" Height="32" Offset="0x61A0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_0069A0" OutName="spot08_sceneTex_0069A0" Format="rgba16" Width="32" Height="32" Offset="0x69A0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_0071A0" OutName="spot08_sceneTex_0071A0" Format="ia4" Width="256" Height="32" Offset="0x71A0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_0081A0" OutName="spot08_sceneTex_0081A0" Format="ci4" Width="128" Height="32" Offset="0x81A0" TlutOffset="0x4CC0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_0089A0" OutName="spot08_sceneTex_0089A0" Format="rgba16" Width="32" Height="32" Offset="0x89A0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_0091A0" OutName="spot08_sceneTex_0091A0" Format="rgba16" Width="16" Height="128" Offset="0x91A0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_00A1A0" OutName="spot08_sceneTex_00A1A0" Format="ci4" Width="128" Height="32" Offset="0xA1A0" TlutOffset="0x4CE8" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_00A9A0" OutName="spot08_sceneTex_00A9A0" Format="ci4" Width="64" Height="64" Offset="0xA9A0" TlutOffset="0x4D38" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_00B1A0" OutName="spot08_sceneTex_00B1A0" Format="ci4" Width="64" Height="64" Offset="0xB1A0" TlutOffset="0x4D10" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_00B9A0" OutName="spot08_sceneTex_00B9A0" Format="ci4" Width="64" Height="64" Offset="0xB9A0" TlutOffset="0x4D38" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_00C1A0" OutName="spot08_sceneTex_00C1A0" Format="rgba16" Width="64" Height="32" Offset="0xC1A0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_00D1A0" OutName="spot08_sceneTex_00D1A0" Format="i8" Width="64" Height="64" Offset="0xD1A0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_00E1A0" OutName="spot08_sceneTex_00E1A0" Format="rgba16" Width="32" Height="64" Offset="0xE1A0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_00F1A0" OutName="spot08_sceneTex_00F1A0" Format="ci4" Width="32" Height="128" Offset="0xF1A0" TlutOffset="0x4D60" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_00F9A0" OutName="spot08_sceneTex_00F9A0" Format="ci4" Width="64" Height="64" Offset="0xF9A0" TlutOffset="0x4D80" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_0101A0" OutName="spot08_sceneTex_0101A0" Format="i4" Width="64" Height="64" Offset="0x101A0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_0109A0" OutName="spot08_sceneTex_0109A0" Format="ia8" Width="16" Height="16" Offset="0x109A0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_010AA0" OutName="spot08_sceneTex_010AA0" Format="rgba16" Width="16" Height="32" Offset="0x10AA0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_010EA0" OutName="spot08_sceneTex_010EA0" Format="rgba16" Width="32" Height="32" Offset="0x10EA0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTLUT_004CC0" OutName="spot08_sceneTLUT_004CC0" Format="rgba16" Width="4" Height="4" Offset="0x4CC0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTLUT_004CE8" OutName="spot08_sceneTLUT_004CE8" Format="rgba16" Width="4" Height="4" Offset="0x4CE8" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTLUT_004D10" OutName="spot08_sceneTLUT_004D10" Format="rgba16" Width="4" Height="4" Offset="0x4D10" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTLUT_004D38" OutName="spot08_sceneTLUT_004D38" Format="rgba16" Width="4" Height="4" Offset="0x4D38" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTLUT_004D60" OutName="spot08_sceneTLUT_004D60" Format="rgba16" Width="4" Height="4" Offset="0x4D60" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTLUT_004D80" OutName="spot08_sceneTLUT_004D80" Format="rgba16" Width="4" Height="4" Offset="0x4D80" AddedByScript="true"/>
         <Cutscene Name="gZorasFountainIntroCs" Offset="0x4A80"/>
         <Scene Name="spot08_scene" Offset="0x0"/>
     </File>

--- a/soh/assets/xml/GC_NMQ_D/scenes/overworld/spot09.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/overworld/spot09.xml
@@ -1,5 +1,26 @@
 <Root>
     <File Name="spot09_scene" Segment="2">
+        <Texture Name="spot09_sceneTex_003460" OutName="spot09_sceneTex_003460" Format="rgba16" Width="32" Height="64" Offset="0x3460" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_004460" OutName="spot09_sceneTex_004460" Format="rgba16" Width="64" Height="32" Offset="0x4460" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_005460" OutName="spot09_sceneTex_005460" Format="ci4" Width="32" Height="128" Offset="0x5460" TlutOffset="0x3440" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_005C60" OutName="spot09_sceneTex_005C60" Format="rgba16" Width="32" Height="32" Offset="0x5C60" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_006460" OutName="spot09_sceneTex_006460" Format="rgba16" Width="32" Height="32" Offset="0x6460" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_006C60" OutName="spot09_sceneTex_006C60" Format="i8" Width="16" Height="16" Offset="0x6C60" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_006D60" OutName="spot09_sceneTex_006D60" Format="rgba16" Width="16" Height="32" Offset="0x6D60" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_007160" OutName="spot09_sceneTex_007160" Format="rgba16" Width="64" Height="32" Offset="0x7160" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_008160" OutName="spot09_sceneTex_008160" Format="rgba16" Width="64" Height="32" Offset="0x8160" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_009160" OutName="spot09_sceneTex_009160" Format="rgba16" Width="32" Height="64" Offset="0x9160" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_00A160" OutName="spot09_sceneTex_00A160" Format="rgba16" Width="32" Height="32" Offset="0xA160" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_00A960" OutName="spot09_sceneTex_00A960" Format="rgba16" Width="32" Height="64" Offset="0xA960" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_00B960" OutName="spot09_sceneTex_00B960" Format="rgba16" Width="32" Height="32" Offset="0xB960" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_00C160" OutName="spot09_sceneTex_00C160" Format="rgba16" Width="64" Height="32" Offset="0xC160" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_00D160" OutName="spot09_sceneTex_00D160" Format="rgba16" Width="128" Height="16" Offset="0xD160" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_00E160" OutName="spot09_sceneTex_00E160" Format="rgba16" Width="32" Height="32" Offset="0xE160" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_00E960" OutName="spot09_sceneTex_00E960" Format="i4" Width="64" Height="64" Offset="0xE960" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_00F160" OutName="spot09_sceneTex_00F160" Format="i4" Width="32" Height="128" Offset="0xF160" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_00F960" OutName="spot09_sceneTex_00F960" Format="rgba16" Width="64" Height="32" Offset="0xF960" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_010960" OutName="spot09_sceneTex_010960" Format="rgba16" Width="32" Height="32" Offset="0x10960" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTLUT_003440" OutName="spot09_sceneTLUT_003440" Format="rgba16" Width="4" Height="4" Offset="0x3440" AddedByScript="true"/>
         <Cutscene Name="gGerudoValleyBridgeJumpFieldFortressCs" Offset="0x2AC0"/>
         <Cutscene Name="gGerudoValleyBridgeJumpFortressToFieldCs" Offset="0x230"/>
         <Cutscene Name="gGerudoValleyIntroCs" Offset="0x31E0"/>

--- a/soh/assets/xml/GC_NMQ_D/scenes/overworld/spot10.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/overworld/spot10.xml
@@ -1,5 +1,13 @@
 <Root>
     <File Name="spot10_scene" Segment="2">
+        <Texture Name="spot10_sceneTex_00C230" OutName="spot10_sceneTex_00C230" Format="rgba16" Width="32" Height="32" Offset="0xC230" AddedByScript="true"/>
+        <Texture Name="spot10_sceneTex_00CA30" OutName="spot10_sceneTex_00CA30" Format="rgba16" Width="32" Height="32" Offset="0xCA30" AddedByScript="true"/>
+        <Texture Name="spot10_sceneTex_00D230" OutName="spot10_sceneTex_00D230" Format="i4" Width="64" Height="64" Offset="0xD230" AddedByScript="true"/>
+        <Texture Name="spot10_sceneTex_00DA30" OutName="spot10_sceneTex_00DA30" Format="rgba16" Width="32" Height="64" Offset="0xDA30" AddedByScript="true"/>
+        <Texture Name="spot10_sceneTex_00EA30" OutName="spot10_sceneTex_00EA30" Format="rgba16" Width="32" Height="32" Offset="0xEA30" AddedByScript="true"/>
+        <Texture Name="spot10_sceneTex_00F230" OutName="spot10_sceneTex_00F230" Format="rgba16" Width="16" Height="16" Offset="0xF230" AddedByScript="true"/>
+        <Texture Name="spot10_sceneTex_00F430" OutName="spot10_sceneTex_00F430" Format="rgba16" Width="32" Height="32" Offset="0xF430" AddedByScript="true"/>
+        <Texture Name="spot10_sceneTex_00FC30" OutName="spot10_sceneTex_00FC30" Format="rgba16" Width="32" Height="32" Offset="0xFC30" AddedByScript="true"/>
         <Path Name="gSpot10Path_00C080" Offset="0xC080" NumPaths="3"/>
         <Scene Name="spot10_scene" Offset="0x0"/>
     </File>
@@ -7,21 +15,44 @@
         <Room Name="spot10_room_0" Offset="0x0"/>
     </File>
     <File Name="spot10_room_1" Segment="3">
+        <Texture Name="spot10_room_1Tex_003BA0" OutName="spot10_room_1Tex_003BA0" Format="rgba16" Width="16" Height="32" Offset="0x3BA0" AddedByScript="true"/>
+        <Texture Name="spot10_room_1Tex_003FA0" OutName="spot10_room_1Tex_003FA0" Format="rgba16" Width="32" Height="32" Offset="0x3FA0" AddedByScript="true"/>
+        <Texture Name="spot10_room_1Tex_0047A0" OutName="spot10_room_1Tex_0047A0" Format="rgba16" Width="32" Height="32" Offset="0x47A0" AddedByScript="true"/>
+        <Texture Name="spot10_room_1Tex_004FA0" OutName="spot10_room_1Tex_004FA0" Format="rgba16" Width="64" Height="32" Offset="0x4FA0" AddedByScript="true"/>
+        <Texture Name="spot10_room_1Tex_005FA0" OutName="spot10_room_1Tex_005FA0" Format="rgba16" Width="32" Height="32" Offset="0x5FA0" AddedByScript="true"/>
+        <Texture Name="spot10_room_1Tex_0067A0" OutName="spot10_room_1Tex_0067A0" Format="rgba16" Width="32" Height="32" Offset="0x67A0" AddedByScript="true"/>
+        <Texture Name="spot10_room_1Tex_006FA0" OutName="spot10_room_1Tex_006FA0" Format="rgba16" Width="64" Height="16" Offset="0x6FA0" AddedByScript="true"/>
+        <Texture Name="spot10_room_1Tex_007C30" OutName="spot10_room_1Tex_007C30" Format="ia8" Width="32" Height="32" Offset="0x7C30" AddedByScript="true"/>
+        <Texture Name="spot10_room_1Tex_008030" OutName="spot10_room_1Tex_008030" Format="ia16" Width="32" Height="16" Offset="0x8030" AddedByScript="true"/>
         <Room Name="spot10_room_1" Offset="0x0"/>
     </File>
     <File Name="spot10_room_2" Segment="3">
+        <Texture Name="spot10_room_2Tex_0023E8" OutName="spot10_room_2Tex_0023E8" Format="rgba16" Width="64" Height="32" Offset="0x23E8" AddedByScript="true"/>
+        <Texture Name="spot10_room_2Tex_0033E8" OutName="spot10_room_2Tex_0033E8" Format="rgba16" Width="64" Height="32" Offset="0x33E8" AddedByScript="true"/>
+        <Texture Name="spot10_room_2Tex_0043E8" OutName="spot10_room_2Tex_0043E8" Format="rgba16" Width="16" Height="64" Offset="0x43E8" AddedByScript="true"/>
         <Room Name="spot10_room_2" Offset="0x0"/>
     </File>
     <File Name="spot10_room_3" Segment="3">
+        <Texture Name="spot10_room_3Tex_0028F8" OutName="spot10_room_3Tex_0028F8" Format="rgba16" Width="64" Height="32" Offset="0x28F8" AddedByScript="true"/>
+        <Texture Name="spot10_room_3Tex_0038F8" OutName="spot10_room_3Tex_0038F8" Format="rgba16" Width="64" Height="32" Offset="0x38F8" AddedByScript="true"/>
+        <Texture Name="spot10_room_3Tex_0048F8" OutName="spot10_room_3Tex_0048F8" Format="rgba16" Width="16" Height="64" Offset="0x48F8" AddedByScript="true"/>
+        <Texture Name="spot10_room_3Tex_0052A8" OutName="spot10_room_3Tex_0052A8" Format="rgba16" Width="32" Height="32" Offset="0x52A8" AddedByScript="true"/>
         <Room Name="spot10_room_3" Offset="0x0"/>
     </File>
     <File Name="spot10_room_4" Segment="3">
         <Room Name="spot10_room_4" Offset="0x0"/>
     </File>
     <File Name="spot10_room_5" Segment="3">
+        <Texture Name="spot10_room_5Tex_0037F0" OutName="spot10_room_5Tex_0037F0" Format="rgba16" Width="32" Height="64" Offset="0x37F0" AddedByScript="true"/>
+        <Texture Name="spot10_room_5Tex_0047F0" OutName="spot10_room_5Tex_0047F0" Format="rgba16" Width="64" Height="32" Offset="0x47F0" AddedByScript="true"/>
+        <Texture Name="spot10_room_5Tex_0057F0" OutName="spot10_room_5Tex_0057F0" Format="rgba16" Width="64" Height="32" Offset="0x57F0" AddedByScript="true"/>
+        <Texture Name="spot10_room_5Tex_0067F0" OutName="spot10_room_5Tex_0067F0" Format="rgba16" Width="32" Height="32" Offset="0x67F0" AddedByScript="true"/>
         <Room Name="spot10_room_5" Offset="0x0"/>
     </File>
     <File Name="spot10_room_6" Segment="3">
+        <Texture Name="spot10_room_6Tex_0022E8" OutName="spot10_room_6Tex_0022E8" Format="rgba16" Width="32" Height="32" Offset="0x22E8" AddedByScript="true"/>
+        <Texture Name="spot10_room_6Tex_002AE8" OutName="spot10_room_6Tex_002AE8" Format="rgba16" Width="64" Height="16" Offset="0x2AE8" AddedByScript="true"/>
+        <Texture Name="spot10_room_6Tex_0032E8" OutName="spot10_room_6Tex_0032E8" Format="rgba16" Width="32" Height="32" Offset="0x32E8" AddedByScript="true"/>
         <Room Name="spot10_room_6" Offset="0x0"/>
     </File>
     <File Name="spot10_room_7" Segment="3">
@@ -31,6 +62,10 @@
         <Room Name="spot10_room_8" Offset="0x0"/>
     </File>
     <File Name="spot10_room_9" Segment="3">
+        <Texture Name="spot10_room_9Tex_001EF8" OutName="spot10_room_9Tex_001EF8" Format="rgba16" Width="32" Height="32" Offset="0x1EF8" AddedByScript="true"/>
+        <Texture Name="spot10_room_9Tex_0026F8" OutName="spot10_room_9Tex_0026F8" Format="rgba16" Width="32" Height="32" Offset="0x26F8" AddedByScript="true"/>
+        <Texture Name="spot10_room_9Tex_0033D8" OutName="spot10_room_9Tex_0033D8" Format="ia8" Width="32" Height="32" Offset="0x33D8" AddedByScript="true"/>
+        <Texture Name="spot10_room_9Tex_0037D8" OutName="spot10_room_9Tex_0037D8" Format="ia16" Width="32" Height="16" Offset="0x37D8" AddedByScript="true"/>
         <Room Name="spot10_room_9" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/scenes/overworld/spot11.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/overworld/spot11.xml
@@ -1,5 +1,37 @@
 <Root>
     <File Name="spot11_scene" Segment="2">
+        <Texture Name="spot11_sceneTex_007CA0" OutName="spot11_sceneTex_007CA0" Format="rgba16" Width="32" Height="32" Offset="0x7CA0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_0084A0" OutName="spot11_sceneTex_0084A0" Format="rgba16" Width="32" Height="32" Offset="0x84A0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_008CA0" OutName="spot11_sceneTex_008CA0" Format="rgba16" Width="16" Height="32" Offset="0x8CA0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_0090A0" OutName="spot11_sceneTex_0090A0" Format="rgba16" Width="128" Height="16" Offset="0x90A0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_00A0A0" OutName="spot11_sceneTex_00A0A0" Format="rgba16" Width="32" Height="32" Offset="0xA0A0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_00A8A0" OutName="spot11_sceneTex_00A8A0" Format="rgba16" Width="64" Height="32" Offset="0xA8A0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_00B8A0" OutName="spot11_sceneTex_00B8A0" Format="rgba16" Width="16" Height="32" Offset="0xB8A0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_00BCA0" OutName="spot11_sceneTex_00BCA0" Format="rgba16" Width="32" Height="32" Offset="0xBCA0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_00C4A0" OutName="spot11_sceneTex_00C4A0" Format="rgba16" Width="32" Height="32" Offset="0xC4A0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_00CCA0" OutName="spot11_sceneTex_00CCA0" Format="rgba16" Width="16" Height="64" Offset="0xCCA0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_00D4A0" OutName="spot11_sceneTex_00D4A0" Format="rgba16" Width="32" Height="32" Offset="0xD4A0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_00DCA0" OutName="spot11_sceneTex_00DCA0" Format="rgba16" Width="64" Height="32" Offset="0xDCA0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_00ECA0" OutName="spot11_sceneTex_00ECA0" Format="rgba16" Width="32" Height="32" Offset="0xECA0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_00F4A0" OutName="spot11_sceneTex_00F4A0" Format="rgba16" Width="32" Height="32" Offset="0xF4A0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_00FCA0" OutName="spot11_sceneTex_00FCA0" Format="ia8" Width="8" Height="8" Offset="0xFCA0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_00FCE0" OutName="spot11_sceneTex_00FCE0" Format="rgba16" Width="32" Height="32" Offset="0xFCE0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_0104E0" OutName="spot11_sceneTex_0104E0" Format="rgba16" Width="32" Height="32" Offset="0x104E0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_010CE0" OutName="spot11_sceneTex_010CE0" Format="rgba16" Width="32" Height="64" Offset="0x10CE0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_011CE0" OutName="spot11_sceneTex_011CE0" Format="rgba16" Width="32" Height="32" Offset="0x11CE0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_0124E0" OutName="spot11_sceneTex_0124E0" Format="rgba16" Width="32" Height="32" Offset="0x124E0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_012CE0" OutName="spot11_sceneTex_012CE0" Format="rgba16" Width="32" Height="32" Offset="0x12CE0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_0134E0" OutName="spot11_sceneTex_0134E0" Format="rgba16" Width="32" Height="32" Offset="0x134E0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_013CE0" OutName="spot11_sceneTex_013CE0" Format="rgba16" Width="32" Height="32" Offset="0x13CE0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_0144E0" OutName="spot11_sceneTex_0144E0" Format="rgba16" Width="32" Height="64" Offset="0x144E0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_0154E0" OutName="spot11_sceneTex_0154E0" Format="rgba16" Width="32" Height="32" Offset="0x154E0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_015CE0" OutName="spot11_sceneTex_015CE0" Format="rgba16" Width="32" Height="32" Offset="0x15CE0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_0164E0" OutName="spot11_sceneTex_0164E0" Format="ia4" Width="32" Height="128" Offset="0x164E0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_016CE0" OutName="spot11_sceneTex_016CE0" Format="rgba16" Width="32" Height="32" Offset="0x16CE0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_0174E0" OutName="spot11_sceneTex_0174E0" Format="rgba16" Width="16" Height="64" Offset="0x174E0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_017CE0" OutName="spot11_sceneTex_017CE0" Format="ia4" Width="64" Height="64" Offset="0x17CE0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_0184E0" OutName="spot11_sceneTex_0184E0" Format="rgba16" Width="32" Height="32" Offset="0x184E0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_018CE0" OutName="spot11_sceneTex_018CE0" Format="rgba16" Width="32" Height="32" Offset="0x18CE0" AddedByScript="true"/>
         <Cutscene Name="gDesertColossusIntroCs" Offset="0x7990"/>
         <Scene Name="spot11_scene" Offset="0x0"/>
     </File>

--- a/soh/assets/xml/GC_NMQ_D/scenes/overworld/spot12.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/overworld/spot12.xml
@@ -1,5 +1,17 @@
 <Root>
     <File Name="spot12_scene" Segment="2">
+        <Texture Name="spot12_sceneTex_006678" OutName="spot12_sceneTex_006678" Format="rgba16" Width="32" Height="64" Offset="0x6678" AddedByScript="true"/>
+        <Texture Name="spot12_sceneTex_007678" OutName="spot12_sceneTex_007678" Format="rgba16" Width="32" Height="64" Offset="0x7678" AddedByScript="true"/>
+        <Texture Name="spot12_sceneTex_008678" OutName="spot12_sceneTex_008678" Format="rgba16" Width="32" Height="32" Offset="0x8678" AddedByScript="true"/>
+        <Texture Name="spot12_sceneTex_008E78" OutName="spot12_sceneTex_008E78" Format="ci4" Width="32" Height="128" Offset="0x8E78" TlutOffset="0x6650" AddedByScript="true"/>
+        <Texture Name="spot12_sceneTex_00A678" OutName="spot12_sceneTex_00A678" Format="rgba16" Width="64" Height="32" Offset="0xA678" AddedByScript="true"/>
+        <Texture Name="spot12_sceneTex_00B678" OutName="spot12_sceneTex_00B678" Format="rgba16" Width="32" Height="32" Offset="0xB678" AddedByScript="true"/>
+        <Texture Name="spot12_sceneTex_00BE78" OutName="spot12_sceneTex_00BE78" Format="rgba16" Width="64" Height="16" Offset="0xBE78" AddedByScript="true"/>
+        <Texture Name="spot12_sceneTex_00C678" OutName="spot12_sceneTex_00C678" Format="rgba16" Width="32" Height="32" Offset="0xC678" AddedByScript="true"/>
+        <Texture Name="spot12_sceneTex_00CE78" OutName="spot12_sceneTex_00CE78" Format="rgba16" Width="32" Height="32" Offset="0xCE78" AddedByScript="true"/>
+        <Texture Name="spot12_sceneTex_00D678" OutName="spot12_sceneTex_00D678" Format="rgba16" Width="32" Height="32" Offset="0xD678" AddedByScript="true"/>
+        <Texture Name="spot12_sceneTex_00EE78" OutName="spot12_sceneTex_00EE78" Format="rgba16" Width="64" Height="32" Offset="0xEE78" AddedByScript="true"/>
+        <Texture Name="spot12_sceneTLUT_006650" OutName="spot12_sceneTLUT_006650" Format="rgba16" Width="4" Height="4" Offset="0x6650" AddedByScript="true"/>
         <Cutscene Name="gGerudoFortressFirstCaptureCs" Offset="0x55C0"/>
         <Cutscene Name="gGerudoFortressIntroCs" Offset="0x6490"/>
         <Texture Name="gSpot12_009678Tex" Format="rgba16" Width="64" Height="32" Offset="0x9678"/>
@@ -7,9 +19,34 @@
         <Scene Name="spot12_scene" Offset="0x0"/>
     </File>
     <File Name="spot12_room_0" Segment="3">
+        <Texture Name="spot12_room_0Tex_008AB0" OutName="spot12_room_0Tex_008AB0" Format="rgba16" Width="32" Height="32" Offset="0x8AB0" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_0092B0" OutName="spot12_room_0Tex_0092B0" Format="rgba16" Width="32" Height="16" Offset="0x92B0" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_0096B0" OutName="spot12_room_0Tex_0096B0" Format="rgba16" Width="32" Height="32" Offset="0x96B0" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_009EB0" OutName="spot12_room_0Tex_009EB0" Format="rgba16" Width="32" Height="32" Offset="0x9EB0" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_00A6B0" OutName="spot12_room_0Tex_00A6B0" Format="rgba16" Width="64" Height="32" Offset="0xA6B0" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_00B6B0" OutName="spot12_room_0Tex_00B6B0" Format="rgba16" Width="32" Height="32" Offset="0xB6B0" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_00BEB0" OutName="spot12_room_0Tex_00BEB0" Format="rgba16" Width="32" Height="32" Offset="0xBEB0" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_00C6B0" OutName="spot12_room_0Tex_00C6B0" Format="ci4" Width="64" Height="32" Offset="0xC6B0" TlutOffset="0x8A90" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_00CAB0" OutName="spot12_room_0Tex_00CAB0" Format="rgba16" Width="16" Height="64" Offset="0xCAB0" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_00D2B0" OutName="spot12_room_0Tex_00D2B0" Format="rgba16" Width="64" Height="32" Offset="0xD2B0" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_00E2B0" OutName="spot12_room_0Tex_00E2B0" Format="rgba16" Width="32" Height="32" Offset="0xE2B0" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_00EAB0" OutName="spot12_room_0Tex_00EAB0" Format="rgba16" Width="32" Height="32" Offset="0xEAB0" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_00FD78" OutName="spot12_room_0Tex_00FD78" Format="ia8" Width="8" Height="8" Offset="0xFD78" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_00FDB8" OutName="spot12_room_0Tex_00FDB8" Format="rgba16" Width="16" Height="64" Offset="0xFDB8" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_0105B8" OutName="spot12_room_0Tex_0105B8" Format="rgba16" Width="32" Height="64" Offset="0x105B8" AddedByScript="true"/>
+        <Texture Name="spot12_room_0TLUT_008A90" OutName="spot12_room_0TLUT_008A90" Format="rgba16" Width="4" Height="4" Offset="0x8A90" AddedByScript="true"/>
         <Room Name="spot12_room_0" Offset="0x0"/>
     </File>
     <File Name="spot12_room_1" Segment="3">
+        <Texture Name="spot12_room_1Tex_005638" OutName="spot12_room_1Tex_005638" Format="rgba16" Width="32" Height="64" Offset="0x5638" AddedByScript="true"/>
+        <Texture Name="spot12_room_1Tex_006638" OutName="spot12_room_1Tex_006638" Format="rgba16" Width="32" Height="64" Offset="0x6638" AddedByScript="true"/>
+        <Texture Name="spot12_room_1Tex_007638" OutName="spot12_room_1Tex_007638" Format="rgba16" Width="32" Height="32" Offset="0x7638" AddedByScript="true"/>
+        <Texture Name="spot12_room_1Tex_007E38" OutName="spot12_room_1Tex_007E38" Format="rgba16" Width="64" Height="32" Offset="0x7E38" AddedByScript="true"/>
+        <Texture Name="spot12_room_1Tex_008E38" OutName="spot12_room_1Tex_008E38" Format="rgba16" Width="64" Height="32" Offset="0x8E38" AddedByScript="true"/>
+        <Texture Name="spot12_room_1Tex_009E38" OutName="spot12_room_1Tex_009E38" Format="rgba16" Width="32" Height="32" Offset="0x9E38" AddedByScript="true"/>
+        <Texture Name="spot12_room_1Tex_00A638" OutName="spot12_room_1Tex_00A638" Format="i4" Width="64" Height="64" Offset="0xA638" AddedByScript="true"/>
+        <Texture Name="spot12_room_1Tex_00B0A0" OutName="spot12_room_1Tex_00B0A0" Format="i8" Width="32" Height="64" Offset="0xB0A0" AddedByScript="true"/>
+        <Texture Name="spot12_room_1Tex_00B8A0" OutName="spot12_room_1Tex_00B8A0" Format="i8" Width="32" Height="64" Offset="0xB8A0" AddedByScript="true"/>
         <Room Name="spot12_room_1" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/scenes/overworld/spot13.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/overworld/spot13.xml
@@ -1,11 +1,39 @@
 <Root>
     <File Name="spot13_scene" Segment="2">
+        <Texture Name="spot13_sceneTex_003A30" OutName="spot13_sceneTex_003A30" Format="rgba16" Width="32" Height="16" Offset="0x3A30" AddedByScript="true"/>
+        <Texture Name="spot13_sceneTex_003E30" OutName="spot13_sceneTex_003E30" Format="rgba16" Width="32" Height="64" Offset="0x3E30" AddedByScript="true"/>
+        <Texture Name="spot13_sceneTex_004E30" OutName="spot13_sceneTex_004E30" Format="rgba16" Width="64" Height="32" Offset="0x4E30" AddedByScript="true"/>
         <Scene Name="spot13_scene" Offset="0x0"/>
     </File>
     <File Name="spot13_room_0" Segment="3">
         <Room Name="spot13_room_0" Offset="0x0"/>
     </File>
     <File Name="spot13_room_1" Segment="3">
+        <Texture Name="spot13_room_1Tex_007E08" OutName="spot13_room_1Tex_007E08" Format="rgba16" Width="32" Height="32" Offset="0x7E08" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_008608" OutName="spot13_room_1Tex_008608" Format="rgba16" Width="16" Height="32" Offset="0x8608" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_008A08" OutName="spot13_room_1Tex_008A08" Format="rgba16" Width="32" Height="64" Offset="0x8A08" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_009A08" OutName="spot13_room_1Tex_009A08" Format="rgba16" Width="16" Height="16" Offset="0x9A08" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_009C08" OutName="spot13_room_1Tex_009C08" Format="rgba16" Width="16" Height="16" Offset="0x9C08" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_009E08" OutName="spot13_room_1Tex_009E08" Format="rgba16" Width="32" Height="32" Offset="0x9E08" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_00A608" OutName="spot13_room_1Tex_00A608" Format="rgba16" Width="32" Height="16" Offset="0xA608" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_00AA08" OutName="spot13_room_1Tex_00AA08" Format="rgba16" Width="32" Height="16" Offset="0xAA08" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_00AE08" OutName="spot13_room_1Tex_00AE08" Format="ci4" Width="32" Height="128" Offset="0xAE08" TlutOffset="0x7DC0" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_00B608" OutName="spot13_room_1Tex_00B608" Format="rgba16" Width="16" Height="16" Offset="0xB608" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_00B808" OutName="spot13_room_1Tex_00B808" Format="ci4" Width="64" Height="32" Offset="0xB808" TlutOffset="0x7DE8" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_00BC08" OutName="spot13_room_1Tex_00BC08" Format="rgba16" Width="32" Height="32" Offset="0xBC08" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_00C408" OutName="spot13_room_1Tex_00C408" Format="rgba16" Width="8" Height="32" Offset="0xC408" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_00C608" OutName="spot13_room_1Tex_00C608" Format="rgba16" Width="64" Height="32" Offset="0xC608" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_00D608" OutName="spot13_room_1Tex_00D608" Format="rgba16" Width="32" Height="64" Offset="0xD608" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_00E608" OutName="spot13_room_1Tex_00E608" Format="rgba16" Width="32" Height="32" Offset="0xE608" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_00EE08" OutName="spot13_room_1Tex_00EE08" Format="rgba16" Width="32" Height="64" Offset="0xEE08" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_00FE08" OutName="spot13_room_1Tex_00FE08" Format="rgba16" Width="32" Height="32" Offset="0xFE08" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_010608" OutName="spot13_room_1Tex_010608" Format="rgba16" Width="32" Height="32" Offset="0x10608" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_010E08" OutName="spot13_room_1Tex_010E08" Format="rgba16" Width="32" Height="16" Offset="0x10E08" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_011208" OutName="spot13_room_1Tex_011208" Format="rgba16" Width="32" Height="32" Offset="0x11208" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_011E40" OutName="spot13_room_1Tex_011E40" Format="ia4" Width="64" Height="32" Offset="0x11E40" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_012240" OutName="spot13_room_1Tex_012240" Format="rgba16" Width="32" Height="32" Offset="0x12240" AddedByScript="true"/>
+        <Texture Name="spot13_room_1TLUT_007DC0" OutName="spot13_room_1TLUT_007DC0" Format="rgba16" Width="4" Height="4" Offset="0x7DC0" AddedByScript="true"/>
+        <Texture Name="spot13_room_1TLUT_007DE8" OutName="spot13_room_1TLUT_007DE8" Format="rgba16" Width="4" Height="4" Offset="0x7DE8" AddedByScript="true"/>
         <Room Name="spot13_room_1" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/scenes/overworld/spot15.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/overworld/spot15.xml
@@ -1,5 +1,48 @@
 <Root>
     <File Name="spot15_scene" Segment="2">
+        <Texture Name="spot15_sceneTex_004100" OutName="spot15_sceneTex_004100" Format="rgba16" Width="32" Height="32" Offset="0x4100" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_004900" OutName="spot15_sceneTex_004900" Format="ia4" Width="32" Height="16" Offset="0x4900" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_004A00" OutName="spot15_sceneTex_004A00" Format="ia8" Width="8" Height="64" Offset="0x4A00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_004C00" OutName="spot15_sceneTex_004C00" Format="rgba16" Width="16" Height="64" Offset="0x4C00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_005400" OutName="spot15_sceneTex_005400" Format="rgba16" Width="32" Height="64" Offset="0x5400" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_006400" OutName="spot15_sceneTex_006400" Format="ia8" Width="32" Height="8" Offset="0x6400" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_006500" OutName="spot15_sceneTex_006500" Format="rgba16" Width="32" Height="32" Offset="0x6500" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_006D00" OutName="spot15_sceneTex_006D00" Format="i4" Width="32" Height="32" Offset="0x6D00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_006F00" OutName="spot15_sceneTex_006F00" Format="ia4" Width="32" Height="64" Offset="0x6F00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_007300" OutName="spot15_sceneTex_007300" Format="ia4" Width="32" Height="128" Offset="0x7300" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_007B00" OutName="spot15_sceneTex_007B00" Format="ia4" Width="16" Height="32" Offset="0x7B00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_007C00" OutName="spot15_sceneTex_007C00" Format="rgba16" Width="32" Height="8" Offset="0x7C00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_007E00" OutName="spot15_sceneTex_007E00" Format="rgba16" Width="32" Height="64" Offset="0x7E00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_008E00" OutName="spot15_sceneTex_008E00" Format="rgba16" Width="32" Height="32" Offset="0x8E00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_009600" OutName="spot15_sceneTex_009600" Format="rgba16" Width="16" Height="16" Offset="0x9600" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_009800" OutName="spot15_sceneTex_009800" Format="ia8" Width="16" Height="16" Offset="0x9800" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_009900" OutName="spot15_sceneTex_009900" Format="rgba16" Width="32" Height="32" Offset="0x9900" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_00A100" OutName="spot15_sceneTex_00A100" Format="rgba16" Width="32" Height="32" Offset="0xA100" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_00A900" OutName="spot15_sceneTex_00A900" Format="rgba16" Width="64" Height="32" Offset="0xA900" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_00B900" OutName="spot15_sceneTex_00B900" Format="ia8" Width="16" Height="16" Offset="0xB900" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_00BA00" OutName="spot15_sceneTex_00BA00" Format="rgba16" Width="32" Height="32" Offset="0xBA00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_00C200" OutName="spot15_sceneTex_00C200" Format="rgba16" Width="32" Height="32" Offset="0xC200" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_00CA00" OutName="spot15_sceneTex_00CA00" Format="rgba16" Width="64" Height="32" Offset="0xCA00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_00DA00" OutName="spot15_sceneTex_00DA00" Format="rgba16" Width="128" Height="16" Offset="0xDA00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_00EA00" OutName="spot15_sceneTex_00EA00" Format="i4" Width="32" Height="32" Offset="0xEA00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_00EC00" OutName="spot15_sceneTex_00EC00" Format="i8" Width="128" Height="32" Offset="0xEC00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_00FC00" OutName="spot15_sceneTex_00FC00" Format="rgba16" Width="32" Height="32" Offset="0xFC00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_010400" OutName="spot15_sceneTex_010400" Format="rgba16" Width="32" Height="32" Offset="0x10400" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_010C00" OutName="spot15_sceneTex_010C00" Format="i4" Width="64" Height="64" Offset="0x10C00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_011400" OutName="spot15_sceneTex_011400" Format="rgba16" Width="32" Height="32" Offset="0x11400" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_011C00" OutName="spot15_sceneTex_011C00" Format="ia4" Width="128" Height="32" Offset="0x11C00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_012400" OutName="spot15_sceneTex_012400" Format="rgba16" Width="32" Height="64" Offset="0x12400" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_013400" OutName="spot15_sceneTex_013400" Format="rgba16" Width="32" Height="64" Offset="0x13400" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_014400" OutName="spot15_sceneTex_014400" Format="rgba16" Width="32" Height="32" Offset="0x14400" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_014C00" OutName="spot15_sceneTex_014C00" Format="rgba16" Width="64" Height="32" Offset="0x14C00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_015C00" OutName="spot15_sceneTex_015C00" Format="rgba16" Width="16" Height="16" Offset="0x15C00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_015E00" OutName="spot15_sceneTex_015E00" Format="rgba16" Width="32" Height="32" Offset="0x15E00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_016600" OutName="spot15_sceneTex_016600" Format="rgba16" Width="16" Height="16" Offset="0x16600" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_016800" OutName="spot15_sceneTex_016800" Format="rgba16" Width="32" Height="16" Offset="0x16800" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_016C00" OutName="spot15_sceneTex_016C00" Format="rgba16" Width="32" Height="32" Offset="0x16C00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_017400" OutName="spot15_sceneTex_017400" Format="rgba16" Width="32" Height="32" Offset="0x17400" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_017C00" OutName="spot15_sceneTex_017C00" Format="rgba16" Width="32" Height="32" Offset="0x17C00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_018400" OutName="spot15_sceneTex_018400" Format="ia8" Width="16" Height="16" Offset="0x18400" AddedByScript="true"/>
         <Cutscene Name="gHyruleCastleIntroCs" Offset="0x3F40"/>
         <Scene Name="spot15_scene" Offset="0x0"/>
     </File>

--- a/soh/assets/xml/GC_NMQ_D/scenes/overworld/spot16.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/overworld/spot16.xml
@@ -1,5 +1,41 @@
 <Root>
     <File Name="spot16_scene" Segment="2">
+        <Texture Name="spot16_sceneTex_008198" OutName="spot16_sceneTex_008198" Format="i8" Width="64" Height="64" Offset="0x8198" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_009198" OutName="spot16_sceneTex_009198" Format="i8" Width="64" Height="32" Offset="0x9198" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_009998" OutName="spot16_sceneTex_009998" Format="i8" Width="64" Height="16" Offset="0x9998" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_009D98" OutName="spot16_sceneTex_009D98" Format="i8" Width="64" Height="64" Offset="0x9D98" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_00AD98" OutName="spot16_sceneTex_00AD98" Format="i8" Width="64" Height="64" Offset="0xAD98" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_00BD98" OutName="spot16_sceneTex_00BD98" Format="rgba16" Width="64" Height="32" Offset="0xBD98" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_00CD98" OutName="spot16_sceneTex_00CD98" Format="rgba16" Width="16" Height="16" Offset="0xCD98" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_00CF98" OutName="spot16_sceneTex_00CF98" Format="rgba16" Width="32" Height="16" Offset="0xCF98" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_00D398" OutName="spot16_sceneTex_00D398" Format="rgba16" Width="16" Height="32" Offset="0xD398" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_00D798" OutName="spot16_sceneTex_00D798" Format="ci4" Width="64" Height="64" Offset="0xD798" TlutOffset="0x8170" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_00DF98" OutName="spot16_sceneTex_00DF98" Format="i4" Width="64" Height="16" Offset="0xDF98" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_00E198" OutName="spot16_sceneTex_00E198" Format="rgba16" Width="64" Height="32" Offset="0xE198" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_00F198" OutName="spot16_sceneTex_00F198" Format="rgba16" Width="16" Height="128" Offset="0xF198" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_010198" OutName="spot16_sceneTex_010198" Format="rgba16" Width="32" Height="64" Offset="0x10198" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_011198" OutName="spot16_sceneTex_011198" Format="rgba16" Width="16" Height="32" Offset="0x11198" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_011598" OutName="spot16_sceneTex_011598" Format="i4" Width="64" Height="16" Offset="0x11598" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_011798" OutName="spot16_sceneTex_011798" Format="rgba16" Width="64" Height="32" Offset="0x11798" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_012798" OutName="spot16_sceneTex_012798" Format="rgba16" Width="64" Height="32" Offset="0x12798" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_013798" OutName="spot16_sceneTex_013798" Format="i4" Width="64" Height="16" Offset="0x13798" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_013998" OutName="spot16_sceneTex_013998" Format="rgba16" Width="32" Height="16" Offset="0x13998" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_013D98" OutName="spot16_sceneTex_013D98" Format="rgba16" Width="32" Height="64" Offset="0x13D98" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_014D98" OutName="spot16_sceneTex_014D98" Format="rgba16" Width="32" Height="32" Offset="0x14D98" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_015598" OutName="spot16_sceneTex_015598" Format="i4" Width="64" Height="64" Offset="0x15598" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_015D98" OutName="spot16_sceneTex_015D98" Format="ia8" Width="16" Height="16" Offset="0x15D98" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_015E98" OutName="spot16_sceneTex_015E98" Format="ia8" Width="128" Height="32" Offset="0x15E98" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_016E98" OutName="spot16_sceneTex_016E98" Format="i4" Width="128" Height="64" Offset="0x16E98" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_017E98" OutName="spot16_sceneTex_017E98" Format="rgba16" Width="32" Height="32" Offset="0x17E98" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_018698" OutName="spot16_sceneTex_018698" Format="rgba16" Width="32" Height="32" Offset="0x18698" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_018E98" OutName="spot16_sceneTex_018E98" Format="rgba16" Width="32" Height="32" Offset="0x18E98" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_019698" OutName="spot16_sceneTex_019698" Format="rgba16" Width="64" Height="16" Offset="0x19698" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_019E98" OutName="spot16_sceneTex_019E98" Format="rgba16" Width="32" Height="64" Offset="0x19E98" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_01B698" OutName="spot16_sceneTex_01B698" Format="ia8" Width="64" Height="64" Offset="0x1B698" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_01C698" OutName="spot16_sceneTex_01C698" Format="rgba16" Width="32" Height="64" Offset="0x1C698" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_01D698" OutName="spot16_sceneTex_01D698" Format="i8" Width="64" Height="32" Offset="0x1D698" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_01DE98" OutName="spot16_sceneTex_01DE98" Format="rgba16" Width="32" Height="32" Offset="0x1DE98" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTLUT_008170" OutName="spot16_sceneTLUT_008170" Format="rgba16" Width="4" Height="4" Offset="0x8170" AddedByScript="true"/>
         <Path Name="gDMTPath_00254" Offset="0x254" NumPaths="3"/>
         <Path Name="gDMTPath_07884" Offset="0x7884" NumPaths="3"/>
         <Cutscene Name="gDMTOwlCs" Offset="0x1E6A0"/>

--- a/soh/assets/xml/GC_NMQ_D/scenes/overworld/spot17.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/overworld/spot17.xml
@@ -1,13 +1,54 @@
 <Root>
     <File Name="spot17_scene" Segment="2">
+        <Texture Name="spot17_sceneTex_007AD8" OutName="spot17_sceneTex_007AD8" Format="ci8" Width="16" Height="128" Offset="0x7AD8" TlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_0082D8" OutName="spot17_sceneTex_0082D8" Format="ci8" Width="32" Height="32" Offset="0x82D8" TlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_0086D8" OutName="spot17_sceneTex_0086D8" Format="ci8" Width="64" Height="32" Offset="0x86D8" TlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_008ED8" OutName="spot17_sceneTex_008ED8" Format="ci8" Width="64" Height="32" Offset="0x8ED8" TlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_0096D8" OutName="spot17_sceneTex_0096D8" Format="ci8" Width="64" Height="32" Offset="0x96D8" TlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_009ED8" OutName="spot17_sceneTex_009ED8" Format="rgba16" Width="32" Height="32" Offset="0x9ED8" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_00A6D8" OutName="spot17_sceneTex_00A6D8" Format="rgba16" Width="32" Height="32" Offset="0xA6D8" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_00AED8" OutName="spot17_sceneTex_00AED8" Format="ci4" Width="64" Height="64" Offset="0xAED8" TlutOffset="0x7A98" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_00B6D8" OutName="spot17_sceneTex_00B6D8" Format="ci8" Width="64" Height="32" Offset="0xB6D8" TlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_00BED8" OutName="spot17_sceneTex_00BED8" Format="ci8" Width="32" Height="64" Offset="0xBED8" TlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_00C6D8" OutName="spot17_sceneTex_00C6D8" Format="rgba16" Width="32" Height="64" Offset="0xC6D8" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_00D6D8" OutName="spot17_sceneTex_00D6D8" Format="ci8" Width="16" Height="32" Offset="0xD6D8" TlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_00D8D8" OutName="spot17_sceneTex_00D8D8" Format="ci8" Width="16" Height="128" Offset="0xD8D8" TlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_00E0D8" OutName="spot17_sceneTex_00E0D8" Format="ci4" Width="64" Height="64" Offset="0xE0D8" TlutOffset="0x7AB8" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_00E8D8" OutName="spot17_sceneTex_00E8D8" Format="ci8" Width="32" Height="64" Offset="0xE8D8" TlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_00F0D8" OutName="spot17_sceneTex_00F0D8" Format="ci8" Width="32" Height="64" Offset="0xF0D8" TlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_00F8D8" OutName="spot17_sceneTex_00F8D8" Format="ci8" Width="32" Height="32" Offset="0xF8D8" TlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_00FCD8" OutName="spot17_sceneTex_00FCD8" Format="ci8" Width="16" Height="32" Offset="0xFCD8" TlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTLUT_007890" OutName="spot17_sceneTLUT_007890" Format="rgba16" Width="16" Height="16" Offset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTLUT_007A98" OutName="spot17_sceneTLUT_007A98" Format="rgba16" Width="4" Height="4" Offset="0x7A98" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTLUT_007AB8" OutName="spot17_sceneTLUT_007AB8" Format="rgba16" Width="4" Height="4" Offset="0x7AB8" AddedByScript="true"/>
         <Cutscene Name="gDeathMountainCraterBoleroCs" Offset="0x45D0"/>
         <Cutscene Name="gDeathMountainCraterIntroCs" Offset="0x76D0"/>
         <Scene Name="spot17_scene" Offset="0x0"/>
     </File>
     <File Name="spot17_room_0" Segment="3">
+        <Texture Name="spot17_room_0Tex_003880" OutName="spot17_room_0Tex_003880" Format="rgba16" Width="64" Height="32" Offset="0x3880" AddedByScript="true"/>
+        <Texture Name="spot17_room_0Tex_004880" OutName="spot17_room_0Tex_004880" Format="rgba16" Width="32" Height="32" Offset="0x4880" AddedByScript="true"/>
+        <Texture Name="spot17_room_0Tex_005080" OutName="spot17_room_0Tex_005080" Format="rgba16" Width="32" Height="32" Offset="0x5080" AddedByScript="true"/>
+        <Texture Name="spot17_room_0Tex_005880" OutName="spot17_room_0Tex_005880" Format="rgba16" Width="32" Height="64" Offset="0x5880" AddedByScript="true"/>
         <Room Name="spot17_room_0" Offset="0x0"/>
     </File>
     <File Name="spot17_room_1" Segment="3">
+        <Texture Name="spot17_room_1Tex_00BBD8" OutName="spot17_room_1Tex_00BBD8" Format="ci8" Width="64" Height="32" Offset="0xBBD8" ExternalTlut="spot17_scene" ExternalTlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_00C3D8" OutName="spot17_room_1Tex_00C3D8" Format="ci8" Width="64" Height="32" Offset="0xC3D8" ExternalTlut="spot17_scene" ExternalTlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_00CBD8" OutName="spot17_room_1Tex_00CBD8" Format="rgba16" Width="32" Height="32" Offset="0xCBD8" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_00D3D8" OutName="spot17_room_1Tex_00D3D8" Format="ci8" Width="32" Height="32" Offset="0xD3D8" ExternalTlut="spot17_scene" ExternalTlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_00D7D8" OutName="spot17_room_1Tex_00D7D8" Format="rgba16" Width="64" Height="32" Offset="0xD7D8" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_00E7D8" OutName="spot17_room_1Tex_00E7D8" Format="ci8" Width="16" Height="16" Offset="0xE7D8" ExternalTlut="spot17_scene" ExternalTlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_00E8D8" OutName="spot17_room_1Tex_00E8D8" Format="ci8" Width="32" Height="32" Offset="0xE8D8" ExternalTlut="spot17_scene" ExternalTlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_00ECD8" OutName="spot17_room_1Tex_00ECD8" Format="ci8" Width="32" Height="32" Offset="0xECD8" ExternalTlut="spot17_scene" ExternalTlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_00F0D8" OutName="spot17_room_1Tex_00F0D8" Format="ci8" Width="32" Height="32" Offset="0xF0D8" ExternalTlut="spot17_scene" ExternalTlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_00F4D8" OutName="spot17_room_1Tex_00F4D8" Format="rgba16" Width="32" Height="32" Offset="0xF4D8" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_00FCD8" OutName="spot17_room_1Tex_00FCD8" Format="ci8" Width="32" Height="16" Offset="0xFCD8" ExternalTlut="spot17_scene" ExternalTlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_010E58" OutName="spot17_room_1Tex_010E58" Format="i4" Width="64" Height="32" Offset="0x10E58" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_011258" OutName="spot17_room_1Tex_011258" Format="i4" Width="64" Height="32" Offset="0x11258" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_011658" OutName="spot17_room_1Tex_011658" Format="i4" Width="64" Height="32" Offset="0x11658" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_011A58" OutName="spot17_room_1Tex_011A58" Format="rgba16" Width="32" Height="32" Offset="0x11A58" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_012258" OutName="spot17_room_1Tex_012258" Format="ia8" Width="16" Height="16" Offset="0x12258" AddedByScript="true"/>
         <Room Name="spot17_room_1" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/scenes/overworld/spot18.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/overworld/spot18.xml
@@ -1,5 +1,10 @@
 <Root>
     <File Name="spot18_scene" Segment="2">
+        <Texture Name="spot18_sceneTex_0087C8" OutName="spot18_sceneTex_0087C8" Format="rgba16" Width="32" Height="32" Offset="0x87C8" AddedByScript="true"/>
+        <Texture Name="spot18_sceneTex_009008" OutName="spot18_sceneTex_009008" Format="ci8" Width="64" Height="32" Offset="0x9008" TlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_sceneTex_009848" OutName="spot18_sceneTex_009848" Format="rgba16" Width="16" Height="32" Offset="0x9848" AddedByScript="true"/>
+        <Texture Name="spot18_sceneTex_009C48" OutName="spot18_sceneTex_009C48" Format="ci8" Width="64" Height="32" Offset="0x9C48" TlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_sceneTLUT_0085C0" OutName="spot18_sceneTLUT_0085C0" Format="rgba16" Width="16" Height="16" Offset="0x85C0" AddedByScript="true"/>
         <Cutscene Name="gGoronCityDaruniaCorrectCs" Offset="0x59E0"/>
         <Cutscene Name="gGoronCityDarunia01Cs" Offset="0x6930"/>
         <Cutscene Name="gGoronCityDaruniaWrongCs" Offset="0x7DE0"/>
@@ -9,15 +14,92 @@
         <Scene Name="spot18_scene" Offset="0x0"/>
     </File>
     <File Name="spot18_room_0" Segment="3">
+        <Texture Name="spot18_room_0Tex_004960" OutName="spot18_room_0Tex_004960" Format="rgba16" Width="32" Height="32" Offset="0x4960" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_005160" OutName="spot18_room_0Tex_005160" Format="rgba16" Width="16" Height="32" Offset="0x5160" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_005560" OutName="spot18_room_0Tex_005560" Format="rgba16" Width="16" Height="32" Offset="0x5560" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_005960" OutName="spot18_room_0Tex_005960" Format="rgba16" Width="32" Height="64" Offset="0x5960" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_006960" OutName="spot18_room_0Tex_006960" Format="ci8" Width="32" Height="64" Offset="0x6960" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_007160" OutName="spot18_room_0Tex_007160" Format="rgba16" Width="32" Height="32" Offset="0x7160" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_007960" OutName="spot18_room_0Tex_007960" Format="rgba16" Width="32" Height="32" Offset="0x7960" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_008160" OutName="spot18_room_0Tex_008160" Format="rgba16" Width="32" Height="32" Offset="0x8160" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_008960" OutName="spot18_room_0Tex_008960" Format="ci8" Width="32" Height="64" Offset="0x8960" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_009160" OutName="spot18_room_0Tex_009160" Format="ci8" Width="32" Height="64" Offset="0x9160" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_009960" OutName="spot18_room_0Tex_009960" Format="rgba16" Width="32" Height="32" Offset="0x9960" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_00A160" OutName="spot18_room_0Tex_00A160" Format="ci8" Width="64" Height="32" Offset="0xA160" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_00A960" OutName="spot18_room_0Tex_00A960" Format="ci8" Width="32" Height="64" Offset="0xA960" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_00B160" OutName="spot18_room_0Tex_00B160" Format="ci8" Width="32" Height="64" Offset="0xB160" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_00B960" OutName="spot18_room_0Tex_00B960" Format="ci8" Width="32" Height="64" Offset="0xB960" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_00C160" OutName="spot18_room_0Tex_00C160" Format="ci8" Width="32" Height="64" Offset="0xC160" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_00C960" OutName="spot18_room_0Tex_00C960" Format="ia8" Width="64" Height="64" Offset="0xC960" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_00DFC8" OutName="spot18_room_0Tex_00DFC8" Format="rgba16" Width="32" Height="64" Offset="0xDFC8" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_00EFC8" OutName="spot18_room_0Tex_00EFC8" Format="rgba16" Width="64" Height="32" Offset="0xEFC8" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_00FFC8" OutName="spot18_room_0Tex_00FFC8" Format="rgba16" Width="32" Height="32" Offset="0xFFC8" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_0107C8" OutName="spot18_room_0Tex_0107C8" Format="rgba16" Width="64" Height="32" Offset="0x107C8" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_0117C8" OutName="spot18_room_0Tex_0117C8" Format="rgba16" Width="64" Height="32" Offset="0x117C8" AddedByScript="true"/>
         <Room Name="spot18_room_0" Offset="0x0"/>
     </File>
     <File Name="spot18_room_1" Segment="3">
+        <Texture Name="spot18_room_1Tex_002868" OutName="spot18_room_1Tex_002868" Format="rgba16" Width="32" Height="32" Offset="0x2868" AddedByScript="true"/>
+        <Texture Name="spot18_room_1Tex_003068" OutName="spot18_room_1Tex_003068" Format="i4" Width="128" Height="64" Offset="0x3068" AddedByScript="true"/>
+        <Texture Name="spot18_room_1Tex_004068" OutName="spot18_room_1Tex_004068" Format="ci8" Width="64" Height="32" Offset="0x4068" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_1Tex_004868" OutName="spot18_room_1Tex_004868" Format="rgba16" Width="32" Height="64" Offset="0x4868" AddedByScript="true"/>
+        <Texture Name="spot18_room_1Tex_005E00" OutName="spot18_room_1Tex_005E00" Format="ia4" Width="32" Height="64" Offset="0x5E00" AddedByScript="true"/>
         <Room Name="spot18_room_1" Offset="0x0"/>
     </File>
     <File Name="spot18_room_2" Segment="3">
+        <Texture Name="spot18_room_2Tex_004818" OutName="spot18_room_2Tex_004818" Format="rgba16" Width="32" Height="64" Offset="0x4818" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_005818" OutName="spot18_room_2Tex_005818" Format="rgba16" Width="32" Height="32" Offset="0x5818" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_006018" OutName="spot18_room_2Tex_006018" Format="rgba16" Width="32" Height="32" Offset="0x6018" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_006818" OutName="spot18_room_2Tex_006818" Format="rgba16" Width="32" Height="32" Offset="0x6818" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_007018" OutName="spot18_room_2Tex_007018" Format="ci8" Width="32" Height="64" Offset="0x7018" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_007818" OutName="spot18_room_2Tex_007818" Format="rgba16" Width="32" Height="32" Offset="0x7818" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_008018" OutName="spot18_room_2Tex_008018" Format="rgba16" Width="32" Height="32" Offset="0x8018" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_008818" OutName="spot18_room_2Tex_008818" Format="ci8" Width="32" Height="64" Offset="0x8818" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_009018" OutName="spot18_room_2Tex_009018" Format="ci8" Width="32" Height="64" Offset="0x9018" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_009818" OutName="spot18_room_2Tex_009818" Format="ci8" Width="32" Height="64" Offset="0x9818" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_00A018" OutName="spot18_room_2Tex_00A018" Format="ci8" Width="32" Height="64" Offset="0xA018" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_00A818" OutName="spot18_room_2Tex_00A818" Format="ci8" Width="32" Height="64" Offset="0xA818" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_00B018" OutName="spot18_room_2Tex_00B018" Format="ci8" Width="32" Height="64" Offset="0xB018" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_00B818" OutName="spot18_room_2Tex_00B818" Format="ia8" Width="64" Height="64" Offset="0xB818" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_00D1A8" OutName="spot18_room_2Tex_00D1A8" Format="rgba16" Width="32" Height="64" Offset="0xD1A8" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_00E1A8" OutName="spot18_room_2Tex_00E1A8" Format="rgba16" Width="64" Height="32" Offset="0xE1A8" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_00F1A8" OutName="spot18_room_2Tex_00F1A8" Format="rgba16" Width="32" Height="32" Offset="0xF1A8" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_00F9A8" OutName="spot18_room_2Tex_00F9A8" Format="rgba16" Width="64" Height="32" Offset="0xF9A8" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_0109A8" OutName="spot18_room_2Tex_0109A8" Format="rgba16" Width="64" Height="32" Offset="0x109A8" AddedByScript="true"/>
         <Room Name="spot18_room_2" Offset="0x0"/>
     </File>
     <File Name="spot18_room_3" Segment="3">
+        <Texture Name="spot18_room_3Tex_00B448" OutName="spot18_room_3Tex_00B448" Format="rgba16" Width="32" Height="32" Offset="0xB448" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_00BC48" OutName="spot18_room_3Tex_00BC48" Format="rgba16" Width="16" Height="32" Offset="0xBC48" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_00C048" OutName="spot18_room_3Tex_00C048" Format="rgba16" Width="16" Height="32" Offset="0xC048" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_00C448" OutName="spot18_room_3Tex_00C448" Format="rgba16" Width="16" Height="32" Offset="0xC448" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_00C848" OutName="spot18_room_3Tex_00C848" Format="rgba16" Width="32" Height="64" Offset="0xC848" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_00D848" OutName="spot18_room_3Tex_00D848" Format="rgba16" Width="16" Height="32" Offset="0xD848" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_00DC48" OutName="spot18_room_3Tex_00DC48" Format="ci8" Width="32" Height="64" Offset="0xDC48" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_00E448" OutName="spot18_room_3Tex_00E448" Format="ci8" Width="32" Height="64" Offset="0xE448" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_00EC48" OutName="spot18_room_3Tex_00EC48" Format="rgba16" Width="32" Height="32" Offset="0xEC48" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_00F448" OutName="spot18_room_3Tex_00F448" Format="rgba16" Width="64" Height="32" Offset="0xF448" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_010448" OutName="spot18_room_3Tex_010448" Format="rgba16" Width="32" Height="32" Offset="0x10448" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_010C48" OutName="spot18_room_3Tex_010C48" Format="rgba16" Width="32" Height="32" Offset="0x10C48" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_011448" OutName="spot18_room_3Tex_011448" Format="ci8" Width="32" Height="64" Offset="0x11448" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_011C48" OutName="spot18_room_3Tex_011C48" Format="ci8" Width="32" Height="64" Offset="0x11C48" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_012448" OutName="spot18_room_3Tex_012448" Format="rgba16" Width="16" Height="16" Offset="0x12448" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_012648" OutName="spot18_room_3Tex_012648" Format="rgba16" Width="16" Height="16" Offset="0x12648" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_012848" OutName="spot18_room_3Tex_012848" Format="i4" Width="128" Height="64" Offset="0x12848" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_013848" OutName="spot18_room_3Tex_013848" Format="ci8" Width="64" Height="32" Offset="0x13848" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_014048" OutName="spot18_room_3Tex_014048" Format="rgba16" Width="32" Height="32" Offset="0x14048" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_014848" OutName="spot18_room_3Tex_014848" Format="ci8" Width="32" Height="64" Offset="0x14848" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_015048" OutName="spot18_room_3Tex_015048" Format="ci8" Width="32" Height="64" Offset="0x15048" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_015848" OutName="spot18_room_3Tex_015848" Format="ci8" Width="32" Height="64" Offset="0x15848" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_016048" OutName="spot18_room_3Tex_016048" Format="ci8" Width="32" Height="64" Offset="0x16048" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_016848" OutName="spot18_room_3Tex_016848" Format="ci8" Width="32" Height="32" Offset="0x16848" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_016C48" OutName="spot18_room_3Tex_016C48" Format="rgba16" Width="32" Height="32" Offset="0x16C48" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_017448" OutName="spot18_room_3Tex_017448" Format="ia8" Width="64" Height="64" Offset="0x17448" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_0194E8" OutName="spot18_room_3Tex_0194E8" Format="rgba16" Width="32" Height="64" Offset="0x194E8" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_01A4E8" OutName="spot18_room_3Tex_01A4E8" Format="rgba16" Width="64" Height="32" Offset="0x1A4E8" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_01B4E8" OutName="spot18_room_3Tex_01B4E8" Format="rgba16" Width="32" Height="32" Offset="0x1B4E8" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_01BCE8" OutName="spot18_room_3Tex_01BCE8" Format="rgba16" Width="64" Height="32" Offset="0x1BCE8" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_01CCE8" OutName="spot18_room_3Tex_01CCE8" Format="rgba16" Width="64" Height="32" Offset="0x1CCE8" AddedByScript="true"/>
         <Room Name="spot18_room_3" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/scenes/overworld/spot20.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/overworld/spot20.xml
@@ -1,5 +1,27 @@
 <Root>
     <File Name="spot20_scene" Segment="2">
+        <Texture Name="spot20_sceneTex_005FE0" OutName="spot20_sceneTex_005FE0" Format="ci8" Width="32" Height="64" Offset="0x5FE0" TlutOffset="0x5DB0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_0067E0" OutName="spot20_sceneTex_0067E0" Format="ci8" Width="16" Height="32" Offset="0x67E0" TlutOffset="0x5DB0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_0069E0" OutName="spot20_sceneTex_0069E0" Format="ci8" Width="64" Height="32" Offset="0x69E0" TlutOffset="0x5DB0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_0071E0" OutName="spot20_sceneTex_0071E0" Format="rgba16" Width="64" Height="32" Offset="0x71E0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_0091E0" OutName="spot20_sceneTex_0091E0" Format="ci8" Width="16" Height="32" Offset="0x91E0" TlutOffset="0x5DB0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_0093E0" OutName="spot20_sceneTex_0093E0" Format="rgba16" Width="16" Height="64" Offset="0x93E0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_009BE0" OutName="spot20_sceneTex_009BE0" Format="rgba16" Width="64" Height="32" Offset="0x9BE0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_00ABE0" OutName="spot20_sceneTex_00ABE0" Format="rgba16" Width="32" Height="64" Offset="0xABE0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_00BBE0" OutName="spot20_sceneTex_00BBE0" Format="ci8" Width="32" Height="16" Offset="0xBBE0" TlutOffset="0x5DB0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_00BDE0" OutName="spot20_sceneTex_00BDE0" Format="ci8" Width="32" Height="32" Offset="0xBDE0" TlutOffset="0x5DB0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_00C1E0" OutName="spot20_sceneTex_00C1E0" Format="ci4" Width="64" Height="64" Offset="0xC1E0" TlutOffset="0x5FB8" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_00C9E0" OutName="spot20_sceneTex_00C9E0" Format="ci8" Width="32" Height="64" Offset="0xC9E0" TlutOffset="0x5DB0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_00D1E0" OutName="spot20_sceneTex_00D1E0" Format="rgba16" Width="32" Height="32" Offset="0xD1E0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_00D9E0" OutName="spot20_sceneTex_00D9E0" Format="rgba16" Width="32" Height="32" Offset="0xD9E0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_00E1E0" OutName="spot20_sceneTex_00E1E0" Format="i4" Width="64" Height="64" Offset="0xE1E0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_00E9E0" OutName="spot20_sceneTex_00E9E0" Format="i4" Width="64" Height="64" Offset="0xE9E0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_00F1E0" OutName="spot20_sceneTex_00F1E0" Format="i4" Width="64" Height="64" Offset="0xF1E0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_00F9E0" OutName="spot20_sceneTex_00F9E0" Format="ci8" Width="8" Height="64" Offset="0xF9E0" TlutOffset="0x5DB0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_010BE0" OutName="spot20_sceneTex_010BE0" Format="i4" Width="64" Height="18" Offset="0x10BE0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_010E20" OutName="spot20_sceneTex_010E20" Format="ia8" Width="64" Height="64" Offset="0x10E20" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTLUT_005DB0" OutName="spot20_sceneTLUT_005DB0" Format="rgba16" Width="16" Height="16" Offset="0x5DB0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTLUT_005FB8" OutName="spot20_sceneTLUT_005FB8" Format="rgba16" Width="4" Height="4" Offset="0x5FB8" AddedByScript="true"/>
         <Path Name="gLonLonPath_05844" Offset="0x5844" NumPaths="3"/>
         <Cutscene Name="gLonLonRanchIntroCs" Offset="0x5BD0"/>
         <Texture Name="gLonLonRanchDayWindowTex" OutName="day_window" Format="rgba16" Width="32" Height="64" Offset="0x81E0"/>

--- a/soh/assets/xml/GC_NMQ_D/scenes/test_levels/besitu.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/test_levels/besitu.xml
@@ -3,6 +3,13 @@
         <Scene Name="besitu_scene" Offset="0x0"/>
     </File>
     <File Name="besitu_room_0" Segment="3">
+        <Texture Name="besitu_room_0Tex_001CD8" OutName="besitu_room_0Tex_001CD8" Format="i4" Width="128" Height="64" Offset="0x1CD8" AddedByScript="true"/>
+        <Texture Name="besitu_room_0Tex_002CD8" OutName="besitu_room_0Tex_002CD8" Format="ia4" Width="64" Height="64" Offset="0x2CD8" AddedByScript="true"/>
+        <Texture Name="besitu_room_0Tex_0034D8" OutName="besitu_room_0Tex_0034D8" Format="ia8" Width="32" Height="64" Offset="0x34D8" AddedByScript="true"/>
+        <Texture Name="besitu_room_0Tex_003CD8" OutName="besitu_room_0Tex_003CD8" Format="ia8" Width="32" Height="64" Offset="0x3CD8" AddedByScript="true"/>
+        <Texture Name="besitu_room_0Tex_0044D8" OutName="besitu_room_0Tex_0044D8" Format="ia4" Width="64" Height="64" Offset="0x44D8" AddedByScript="true"/>
+        <Texture Name="besitu_room_0Tex_004CD8" OutName="besitu_room_0Tex_004CD8" Format="ci4" Width="64" Height="64" Offset="0x4CD8" TlutOffset="0x1CB8" AddedByScript="true"/>
+        <Texture Name="besitu_room_0TLUT_001CB8" OutName="besitu_room_0TLUT_001CB8" Format="rgba16" Width="4" Height="4" Offset="0x1CB8" AddedByScript="true"/>
         <Room Name="besitu_room_0" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/scenes/test_levels/sutaru.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/test_levels/sutaru.xml
@@ -3,6 +3,13 @@
         <Scene Name="sutaru_scene" Offset="0x0"/>
     </File>
     <File Name="sutaru_room_0" Segment="3">
+        <Texture Name="sutaru_room_0Tex_0020F0" OutName="sutaru_room_0Tex_0020F0" Format="rgba16" Width="32" Height="32" Offset="0x20F0" AddedByScript="true"/>
+        <Texture Name="sutaru_room_0Tex_0028F0" OutName="sutaru_room_0Tex_0028F0" Format="rgba16" Width="16" Height="16" Offset="0x28F0" AddedByScript="true"/>
+        <Texture Name="sutaru_room_0Tex_002AF0" OutName="sutaru_room_0Tex_002AF0" Format="rgba16" Width="64" Height="32" Offset="0x2AF0" AddedByScript="true"/>
+        <Texture Name="sutaru_room_0Tex_003AF0" OutName="sutaru_room_0Tex_003AF0" Format="rgba16" Width="32" Height="32" Offset="0x3AF0" AddedByScript="true"/>
+        <Texture Name="sutaru_room_0Tex_0042F0" OutName="sutaru_room_0Tex_0042F0" Format="rgba16" Width="64" Height="32" Offset="0x42F0" AddedByScript="true"/>
+        <Texture Name="sutaru_room_0Tex_0052F0" OutName="sutaru_room_0Tex_0052F0" Format="rgba16" Width="32" Height="64" Offset="0x52F0" AddedByScript="true"/>
+        <Texture Name="sutaru_room_0Tex_0062F0" OutName="sutaru_room_0Tex_0062F0" Format="rgba16" Width="32" Height="64" Offset="0x62F0" AddedByScript="true"/>
         <Room Name="sutaru_room_0" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/scenes/test_levels/syotes.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/test_levels/syotes.xml
@@ -3,6 +3,17 @@
         <Scene Name="syotes_scene" Offset="0x0"/>
     </File>
     <File Name="syotes_room_0" Segment="3">
+        <Texture Name="syotes_room_0Tex_0031E8" OutName="syotes_room_0Tex_0031E8" Format="rgba16" Width="32" Height="32" Offset="0x31E8" AddedByScript="true"/>
+        <Texture Name="syotes_room_0Tex_0039E8" OutName="syotes_room_0Tex_0039E8" Format="rgba16" Width="32" Height="32" Offset="0x39E8" AddedByScript="true"/>
+        <Texture Name="syotes_room_0Tex_0041E8" OutName="syotes_room_0Tex_0041E8" Format="rgba16" Width="32" Height="64" Offset="0x41E8" AddedByScript="true"/>
+        <Texture Name="syotes_room_0Tex_0051E8" OutName="syotes_room_0Tex_0051E8" Format="rgba16" Width="32" Height="64" Offset="0x51E8" AddedByScript="true"/>
+        <Texture Name="syotes_room_0Tex_0061E8" OutName="syotes_room_0Tex_0061E8" Format="rgba16" Width="32" Height="32" Offset="0x61E8" AddedByScript="true"/>
+        <Texture Name="syotes_room_0Tex_0069E8" OutName="syotes_room_0Tex_0069E8" Format="rgba16" Width="64" Height="32" Offset="0x69E8" AddedByScript="true"/>
+        <Texture Name="syotes_room_0Tex_0079E8" OutName="syotes_room_0Tex_0079E8" Format="rgba16" Width="64" Height="32" Offset="0x79E8" AddedByScript="true"/>
+        <Texture Name="syotes_room_0Tex_0089E8" OutName="syotes_room_0Tex_0089E8" Format="rgba16" Width="32" Height="64" Offset="0x89E8" AddedByScript="true"/>
+        <Texture Name="syotes_room_0Tex_0099E8" OutName="syotes_room_0Tex_0099E8" Format="rgba16" Width="64" Height="32" Offset="0x99E8" AddedByScript="true"/>
+        <Texture Name="syotes_room_0Tex_00A9E8" OutName="syotes_room_0Tex_00A9E8" Format="rgba16" Width="32" Height="64" Offset="0xA9E8" AddedByScript="true"/>
+        <Texture Name="syotes_room_0Tex_00BF80" OutName="syotes_room_0Tex_00BF80" Format="ia16" Width="32" Height="64" Offset="0xBF80" AddedByScript="true"/>
         <Room Name="syotes_room_0" HackMode="syotes_room" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/scenes/test_levels/syotes2.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/test_levels/syotes2.xml
@@ -3,6 +3,13 @@
         <Scene Name="syotes2_scene" Offset="0x0"/>
     </File>
     <File Name="syotes2_room_0" Segment="3">
+        <Texture Name="syotes2_room_0Tex_0046F8" OutName="syotes2_room_0Tex_0046F8" Format="rgba16" Width="32" Height="32" Offset="0x46F8" AddedByScript="true"/>
+        <Texture Name="syotes2_room_0Tex_004EF8" OutName="syotes2_room_0Tex_004EF8" Format="rgba16" Width="32" Height="32" Offset="0x4EF8" AddedByScript="true"/>
+        <Texture Name="syotes2_room_0Tex_0056F8" OutName="syotes2_room_0Tex_0056F8" Format="rgba16" Width="32" Height="64" Offset="0x56F8" AddedByScript="true"/>
+        <Texture Name="syotes2_room_0Tex_0066F8" OutName="syotes2_room_0Tex_0066F8" Format="rgba16" Width="32" Height="32" Offset="0x66F8" AddedByScript="true"/>
+        <Texture Name="syotes2_room_0Tex_006EF8" OutName="syotes2_room_0Tex_006EF8" Format="rgba16" Width="64" Height="32" Offset="0x6EF8" AddedByScript="true"/>
+        <Texture Name="syotes2_room_0Tex_007EF8" OutName="syotes2_room_0Tex_007EF8" Format="rgba16" Width="32" Height="64" Offset="0x7EF8" AddedByScript="true"/>
+        <Texture Name="syotes2_room_0Tex_008EF8" OutName="syotes2_room_0Tex_008EF8" Format="rgba16" Width="32" Height="64" Offset="0x8EF8" AddedByScript="true"/>
         <Room Name="syotes2_room_0" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/scenes/test_levels/test01.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/test_levels/test01.xml
@@ -3,6 +3,11 @@
         <Scene Name="test01_scene" Offset="0x0"/>
     </File>
     <File Name="test01_room_0" Segment="3">
+        <Texture Name="test01_room_0Tex_006490" OutName="test01_room_0Tex_006490" Format="rgba16" Width="32" Height="32" Offset="0x6490" AddedByScript="true"/>
+        <Texture Name="test01_room_0Tex_006C90" OutName="test01_room_0Tex_006C90" Format="rgba16" Width="32" Height="32" Offset="0x6C90" AddedByScript="true"/>
+        <Texture Name="test01_room_0Tex_007490" OutName="test01_room_0Tex_007490" Format="rgba16" Width="64" Height="32" Offset="0x7490" AddedByScript="true"/>
+        <Texture Name="test01_room_0Tex_008490" OutName="test01_room_0Tex_008490" Format="rgba16" Width="32" Height="32" Offset="0x8490" AddedByScript="true"/>
+        <Texture Name="test01_room_0Tex_0090E8" OutName="test01_room_0Tex_0090E8" Format="rgba16" Width="32" Height="32" Offset="0x90E8" AddedByScript="true"/>
         <Room Name="test01_room_0" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/scenes/test_levels/testroom.xml
+++ b/soh/assets/xml/GC_NMQ_D/scenes/test_levels/testroom.xml
@@ -1,17 +1,36 @@
 <Root>
     <File Name="testroom_scene" Segment="2">
+        <Texture Name="testroom_sceneTex_002200" OutName="testroom_sceneTex_002200" Format="rgba16" Width="32" Height="32" Offset="0x2200" AddedByScript="true"/>
+        <Texture Name="testroom_sceneTex_002A00" OutName="testroom_sceneTex_002A00" Format="rgba16" Width="32" Height="64" Offset="0x2A00" AddedByScript="true"/>
+        <Texture Name="testroom_sceneTex_003A00" OutName="testroom_sceneTex_003A00" Format="rgba16" Width="32" Height="32" Offset="0x3A00" AddedByScript="true"/>
         <Scene Name="testroom_scene" Offset="0x0"/>
     </File>
     <File Name="testroom_room_0" Segment="3">
+        <Texture Name="testroom_room_0Tex_000E00" OutName="testroom_room_0Tex_000E00" Format="rgba16" Width="32" Height="32" Offset="0xE00" AddedByScript="true"/>
+        <Texture Name="testroom_room_0Tex_001600" OutName="testroom_room_0Tex_001600" Format="rgba16" Width="32" Height="64" Offset="0x1600" AddedByScript="true"/>
+        <Texture Name="testroom_room_0Tex_002600" OutName="testroom_room_0Tex_002600" Format="rgba16" Width="32" Height="32" Offset="0x2600" AddedByScript="true"/>
+        <Texture Name="testroom_room_0Tex_002E00" OutName="testroom_room_0Tex_002E00" Format="rgba16" Width="32" Height="64" Offset="0x2E00" AddedByScript="true"/>
+        <Texture Name="testroom_room_0Tex_003E00" OutName="testroom_room_0Tex_003E00" Format="rgba16" Width="32" Height="32" Offset="0x3E00" AddedByScript="true"/>
         <Room Name="testroom_room_0" Offset="0x0"/>
     </File>
     <File Name="testroom_room_1" Segment="3">
+        <Texture Name="testroom_room_1Tex_000BE8" OutName="testroom_room_1Tex_000BE8" Format="rgba16" Width="32" Height="32" Offset="0xBE8" AddedByScript="true"/>
+        <Texture Name="testroom_room_1Tex_0013E8" OutName="testroom_room_1Tex_0013E8" Format="rgba16" Width="32" Height="32" Offset="0x13E8" AddedByScript="true"/>
+        <Texture Name="testroom_room_1Tex_001BE8" OutName="testroom_room_1Tex_001BE8" Format="rgba16" Width="32" Height="32" Offset="0x1BE8" AddedByScript="true"/>
         <Room Name="testroom_room_1" Offset="0x0"/>
     </File>
     <File Name="testroom_room_2" Segment="3">
+        <Texture Name="testroom_room_2Tex_001A78" OutName="testroom_room_2Tex_001A78" Format="ci4" Width="64" Height="64" Offset="0x1A78" TlutOffset="0x1A58" AddedByScript="true"/>
+        <Texture Name="testroom_room_2Tex_002278" OutName="testroom_room_2Tex_002278" Format="rgba16" Width="32" Height="32" Offset="0x2278" AddedByScript="true"/>
+        <Texture Name="testroom_room_2Tex_002A78" OutName="testroom_room_2Tex_002A78" Format="rgba16" Width="32" Height="32" Offset="0x2A78" AddedByScript="true"/>
+        <Texture Name="testroom_room_2TLUT_001A58" OutName="testroom_room_2TLUT_001A58" Format="rgba16" Width="4" Height="4" Offset="0x1A58" AddedByScript="true"/>
         <Room Name="testroom_room_2" Offset="0x0"/>
     </File>
     <File Name="testroom_room_3" Segment="3">
+        <Texture Name="testroom_room_3Tex_000A18" OutName="testroom_room_3Tex_000A18" Format="rgba16" Width="32" Height="32" Offset="0xA18" AddedByScript="true"/>
+        <Texture Name="testroom_room_3Tex_001218" OutName="testroom_room_3Tex_001218" Format="rgba16" Width="32" Height="64" Offset="0x1218" AddedByScript="true"/>
+        <Texture Name="testroom_room_3Tex_002218" OutName="testroom_room_3Tex_002218" Format="rgba16" Width="32" Height="64" Offset="0x2218" AddedByScript="true"/>
+        <Texture Name="testroom_room_3Tex_003218" OutName="testroom_room_3Tex_003218" Format="rgba16" Width="32" Height="32" Offset="0x3218" AddedByScript="true"/>
         <Room Name="testroom_room_3" Offset="0x0"/>
     </File>
     <File Name="testroom_room_4" Segment="3">

--- a/soh/assets/xml/GC_NMQ_D/textures/nintendo_rogo_static.xml
+++ b/soh/assets/xml/GC_NMQ_D/textures/nintendo_rogo_static.xml
@@ -1,7 +1,8 @@
 <Root>
      <File Name="nintendo_rogo_static" Segment="1">
 
-         <Texture Name="nintendo_rogo_static_Tex_000000" OutName="tex_00000000" Format="i8" Width="192" Height="32" Offset="0x0000"/>
+         <Texture Name="nintendo_rogo_staticTex_0029C0" OutName="nintendo_rogo_staticTex_0029C0" Format="i8" Width="32" Height="32" Offset="0x29C0" AddedByScript="true"/>
+        <Texture Name="nintendo_rogo_static_Tex_000000" OutName="tex_00000000" Format="i8" Width="192" Height="32" Offset="0x0000"/>
          <Texture Name="nintendo_rogo_static_Tex_001800" OutName="tex_00001800" Format="i8" Width="32" Height="32" Offset="0x1800"/>
          <DList Name="gNintendo64LogoDL" Offset="0x2720"/>
      </File>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/gameplay_dangeon_keep.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/gameplay_dangeon_keep.xml
@@ -1,5 +1,28 @@
 <Root>
     <File Name="gameplay_dangeon_keep" Segment="5">
+        <Texture Name="gameplay_dangeon_keepTex_000000" OutName="gameplay_dangeon_keepTex_000000" Format="i8" Width="16" Height="32" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_000200" OutName="gameplay_dangeon_keepTex_000200" Format="i8" Width="16" Height="32" Offset="0x200" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_0005C0" OutName="gameplay_dangeon_keepTex_0005C0" Format="rgba16" Width="16" Height="16" Offset="0x5C0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_001280" OutName="gameplay_dangeon_keepTex_001280" Format="rgba16" Width="32" Height="32" Offset="0x1280" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_0078A0" OutName="gameplay_dangeon_keepTex_0078A0" Format="i8" Width="32" Height="32" Offset="0x78A0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_007CA0" OutName="gameplay_dangeon_keepTex_007CA0" Format="i8" Width="32" Height="32" Offset="0x7CA0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_0080A0" OutName="gameplay_dangeon_keepTex_0080A0" Format="rgba16" Width="32" Height="32" Offset="0x80A0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_0088A0" OutName="gameplay_dangeon_keepTex_0088A0" Format="rgba16" Width="32" Height="32" Offset="0x88A0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_00D8A0" OutName="gameplay_dangeon_keepTex_00D8A0" Format="rgba16" Width="32" Height="32" Offset="0xD8A0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_00E0A0" OutName="gameplay_dangeon_keepTex_00E0A0" Format="rgba16" Width="32" Height="32" Offset="0xE0A0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_00F8A0" OutName="gameplay_dangeon_keepTex_00F8A0" Format="rgba16" Width="64" Height="32" Offset="0xF8A0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_0108A0" OutName="gameplay_dangeon_keepTex_0108A0" Format="rgba16" Width="32" Height="64" Offset="0x108A0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_0118A0" OutName="gameplay_dangeon_keepTex_0118A0" Format="rgba16" Width="16" Height="16" Offset="0x118A0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_011AA0" OutName="gameplay_dangeon_keepTex_011AA0" Format="rgba16" Width="16" Height="16" Offset="0x11AA0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_011CA0" OutName="gameplay_dangeon_keepTex_011CA0" Format="rgba16" Width="32" Height="64" Offset="0x11CA0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_012CA0" OutName="gameplay_dangeon_keepTex_012CA0" Format="rgba16" Width="64" Height="16" Offset="0x12CA0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_0134A0" OutName="gameplay_dangeon_keepTex_0134A0" Format="rgba16" Width="32" Height="32" Offset="0x134A0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_013CA0" OutName="gameplay_dangeon_keepTex_013CA0" Format="ia8" Width="4" Height="4" Offset="0x13CA0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_013CB0" OutName="gameplay_dangeon_keepTex_013CB0" Format="i4" Width="64" Height="64" Offset="0x13CB0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_0154B0" OutName="gameplay_dangeon_keepTex_0154B0" Format="rgba16" Width="32" Height="32" Offset="0x154B0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_015CB0" OutName="gameplay_dangeon_keepTex_015CB0" Format="rgba16" Width="32" Height="32" Offset="0x15CB0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_0164B0" OutName="gameplay_dangeon_keepTex_0164B0" Format="rgba16" Width="32" Height="32" Offset="0x164B0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_016CB0" OutName="gameplay_dangeon_keepTex_016CB0" Format="rgba16" Width="32" Height="32" Offset="0x16CB0" AddedByScript="true"/>
         <DList Name="gUnusedCandleDL" Offset="0x440"/>
         <DList Name="gBrownFragmentDL" Offset="0x530"/>
         <Texture Name="gUnusedStoneTex" OutName="unused_stone" Format="rgba16" Width="32" Height="32" Offset="0x7C0"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/gameplay_keep.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/gameplay_keep.xml
@@ -1,6 +1,10 @@
 <Root>
     <ExternalFile XmlPath="misc/link_animetion.xml" OutPath="misc/link_animetion/"/>
     <File Name="gameplay_keep" Segment="4">
+        <Texture Name="gameplay_keepTex_04C540" OutName="gameplay_keepTex_04C540" Format="i8" Width="64" Height="17" Offset="0x4C540" AddedByScript="true"/>
+        <Texture Name="gameplay_keepTex_04C740" OutName="gameplay_keepTex_04C740" Format="i8" Width="64" Height="17" Offset="0x4C740" AddedByScript="true"/>
+        <Texture Name="gameplay_keepTex_04CD40" OutName="gameplay_keepTex_04CD40" Format="i8" Width="64" Height="17" Offset="0x4CD40" AddedByScript="true"/>
+        <Texture Name="gameplay_keepTex_04CF40" OutName="gameplay_keepTex_04CF40" Format="i8" Width="64" Height="17" Offset="0x4CF40" AddedByScript="true"/>
         <Texture Name="gHilite1Tex" OutName="hilite_1" Format="rgba16" Width="16" Height="16" Offset="0x0"/>
         <Texture Name="gHilite2Tex" OutName="hilite_2" Format="rgba16" Width="16" Height="16" Offset="0x200"/>
         <Texture Name="gHylianShieldDesignTex" OutName="hylian_shield_design" Format="rgba16" Width="32" Height="64" Offset="0x400"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_am.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_am.xml
@@ -1,5 +1,18 @@
 <Root>
     <File Name="object_am" Segment="6">
+        <Texture Name="object_amTex_002638" OutName="object_amTex_002638" Format="i4" Width="32" Height="32" Offset="0x2638" AddedByScript="true"/>
+        <Texture Name="object_amTex_002838" OutName="object_amTex_002838" Format="i4" Width="16" Height="32" Offset="0x2838" AddedByScript="true"/>
+        <Texture Name="object_amTex_002938" OutName="object_amTex_002938" Format="rgba16" Width="16" Height="32" Offset="0x2938" AddedByScript="true"/>
+        <Texture Name="object_amTex_002D38" OutName="object_amTex_002D38" Format="i4" Width="16" Height="32" Offset="0x2D38" AddedByScript="true"/>
+        <Texture Name="object_amTex_002E38" OutName="object_amTex_002E38" Format="i4" Width="32" Height="32" Offset="0x2E38" AddedByScript="true"/>
+        <Texture Name="object_amTex_003038" OutName="object_amTex_003038" Format="i4" Width="32" Height="32" Offset="0x3038" AddedByScript="true"/>
+        <Texture Name="object_amTex_003238" OutName="object_amTex_003238" Format="rgba16" Width="32" Height="32" Offset="0x3238" AddedByScript="true"/>
+        <Texture Name="object_amTex_003A38" OutName="object_amTex_003A38" Format="rgba16" Width="16" Height="16" Offset="0x3A38" AddedByScript="true"/>
+        <Texture Name="object_amTex_003C38" OutName="object_amTex_003C38" Format="rgba16" Width="32" Height="32" Offset="0x3C38" AddedByScript="true"/>
+        <Texture Name="object_amTex_004438" OutName="object_amTex_004438" Format="rgba16" Width="32" Height="32" Offset="0x4438" AddedByScript="true"/>
+        <Texture Name="object_amTex_004C38" OutName="object_amTex_004C38" Format="rgba16" Width="32" Height="32" Offset="0x4C38" AddedByScript="true"/>
+        <Texture Name="object_amTex_005438" OutName="object_amTex_005438" Format="i4" Width="16" Height="8" Offset="0x5438" AddedByScript="true"/>
+        <Texture Name="object_amTex_005478" OutName="object_amTex_005478" Format="rgba16" Width="16" Height="32" Offset="0x5478" AddedByScript="true"/>
         <Skeleton Name="gArmosSkel" Type="Normal" LimbType="Standard" Offset="0x5948"/>
         <Animation Name="gArmosRicochetAnim" Offset="0x33C"/>
         <Animation Name="gArmosHopAnim" Offset="0x238"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_ani.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_ani.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_ani" Segment="6">
+        <Texture Name="object_aniTex_0011D8" OutName="object_aniTex_0011D8" Format="ci8" Width="16" Height="16" Offset="0x11D8" TlutOffset="0x1088" AddedByScript="true"/>
         <!-- Kakariko Roof Man Skeleton -->
         <Skeleton Name="gRoofManSkel" Type="Flex" LimbType="Standard" Offset="0xF0"/>
 

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_anubice.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_anubice.xml
@@ -1,5 +1,14 @@
 <Root>
     <File Name="object_anubice" Segment="6">
+        <Texture Name="object_anubiceTex_000F90" OutName="object_anubiceTex_000F90" Format="rgba16" Width="8" Height="16" Offset="0xF90" AddedByScript="true"/>
+        <Texture Name="object_anubiceTex_001090" OutName="object_anubiceTex_001090" Format="rgba16" Width="4" Height="16" Offset="0x1090" AddedByScript="true"/>
+        <Texture Name="object_anubiceTex_001110" OutName="object_anubiceTex_001110" Format="rgba16" Width="16" Height="32" Offset="0x1110" AddedByScript="true"/>
+        <Texture Name="object_anubiceTex_001510" OutName="object_anubiceTex_001510" Format="rgba16" Width="8" Height="8" Offset="0x1510" AddedByScript="true"/>
+        <Texture Name="object_anubiceTex_001590" OutName="object_anubiceTex_001590" Format="rgba16" Width="8" Height="8" Offset="0x1590" AddedByScript="true"/>
+        <Texture Name="object_anubiceTex_001610" OutName="object_anubiceTex_001610" Format="rgba16" Width="4" Height="16" Offset="0x1610" AddedByScript="true"/>
+        <Texture Name="object_anubiceTex_001690" OutName="object_anubiceTex_001690" Format="ia16" Width="32" Height="16" Offset="0x1690" AddedByScript="true"/>
+        <Texture Name="object_anubiceTex_001A90" OutName="object_anubiceTex_001A90" Format="rgba16" Width="8" Height="8" Offset="0x1A90" AddedByScript="true"/>
+        <Texture Name="object_anubiceTex_0036A0" OutName="object_anubiceTex_0036A0" Format="i4" Width="32" Height="32" Offset="0x36A0" AddedByScript="true"/>
         <Skeleton Name="gAnubiceSkel" Type="Normal" LimbType="Standard" Offset="0x3990"/>
 
         <Animation Name="gAnubiceFallDownAnim" Offset="0x348"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_blkobj.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_blkobj.xml
@@ -1,5 +1,27 @@
 <Root>
     <File Name="object_blkobj" Segment="6">
+        <Texture Name="object_blkobjTex_008090" OutName="object_blkobjTex_008090" Format="rgba16" Width="32" Height="32" Offset="0x8090" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_008890" OutName="object_blkobjTex_008890" Format="rgba16" Width="32" Height="32" Offset="0x8890" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_009090" OutName="object_blkobjTex_009090" Format="rgba16" Width="32" Height="32" Offset="0x9090" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_009890" OutName="object_blkobjTex_009890" Format="rgba16" Width="32" Height="32" Offset="0x9890" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_00A090" OutName="object_blkobjTex_00A090" Format="ia16" Width="32" Height="32" Offset="0xA090" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_00A890" OutName="object_blkobjTex_00A890" Format="rgba16" Width="32" Height="32" Offset="0xA890" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_00B090" OutName="object_blkobjTex_00B090" Format="rgba16" Width="32" Height="32" Offset="0xB090" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_00B890" OutName="object_blkobjTex_00B890" Format="rgba16" Width="32" Height="32" Offset="0xB890" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_00C090" OutName="object_blkobjTex_00C090" Format="rgba16" Width="32" Height="32" Offset="0xC090" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_00C890" OutName="object_blkobjTex_00C890" Format="rgba16" Width="32" Height="32" Offset="0xC890" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_00D090" OutName="object_blkobjTex_00D090" Format="rgba16" Width="32" Height="32" Offset="0xD090" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_00D890" OutName="object_blkobjTex_00D890" Format="rgba16" Width="32" Height="32" Offset="0xD890" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_00E090" OutName="object_blkobjTex_00E090" Format="rgba16" Width="32" Height="32" Offset="0xE090" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_00E890" OutName="object_blkobjTex_00E890" Format="rgba16" Width="32" Height="64" Offset="0xE890" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_00F890" OutName="object_blkobjTex_00F890" Format="rgba16" Width="32" Height="32" Offset="0xF890" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_010090" OutName="object_blkobjTex_010090" Format="rgba16" Width="32" Height="32" Offset="0x10090" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_010890" OutName="object_blkobjTex_010890" Format="rgba16" Width="32" Height="32" Offset="0x10890" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_011090" OutName="object_blkobjTex_011090" Format="rgba16" Width="32" Height="32" Offset="0x11090" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_011890" OutName="object_blkobjTex_011890" Format="rgba16" Width="32" Height="32" Offset="0x11890" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_012090" OutName="object_blkobjTex_012090" Format="rgba16" Width="32" Height="32" Offset="0x12090" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_012890" OutName="object_blkobjTex_012890" Format="rgba16" Width="32" Height="32" Offset="0x12890" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_013090" OutName="object_blkobjTex_013090" Format="rgba16" Width="32" Height="32" Offset="0x13090" AddedByScript="true"/>
         <!-- Illusion Room Collision -->
         <Collision Name="gIllusionRoomCol" Offset="0x7564"/>
 

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_box.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_box.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_box" Segment="6">
+        <Texture Name="object_boxTex_004F80" OutName="object_boxTex_004F80" Format="i8" Width="64" Height="32" Offset="0x4F80" AddedByScript="true"/>
         <Skeleton Name="gTreasureChestCurveSkel" Type="Curve" LimbType="Curve" Offset="0x5EB8"/>
         <CurveAnimation Name="gTreasureChestCurveAnim_4B60" SkelOffset="0x5EB8" Offset="0x4B60"/>
         <CurveAnimation Name="gTreasureChestCurveAnim_4F70" SkelOffset="0x5EB8" Offset="0x4F70"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_bv.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_bv.xml
@@ -1,5 +1,42 @@
 <Root>
     <File Name="object_bv" Segment="6">
+        <Texture Name="object_bvTex_000040" OutName="object_bvTex_000040" Format="ia16" Width="16" Height="64" Offset="0x40" AddedByScript="true"/>
+        <Texture Name="object_bvTex_000840" OutName="object_bvTex_000840" Format="ia16" Width="16" Height="16" Offset="0x840" AddedByScript="true"/>
+        <Texture Name="object_bvTex_000A40" OutName="object_bvTex_000A40" Format="i8" Width="16" Height="32" Offset="0xA40" AddedByScript="true"/>
+        <Texture Name="object_bvTex_0051A0" OutName="object_bvTex_0051A0" Format="rgba16" Width="8" Height="16" Offset="0x51A0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_0052A0" OutName="object_bvTex_0052A0" Format="rgba16" Width="8" Height="16" Offset="0x52A0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_0053A0" OutName="object_bvTex_0053A0" Format="rgba16" Width="16" Height="16" Offset="0x53A0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_0055A0" OutName="object_bvTex_0055A0" Format="ia16" Width="16" Height="32" Offset="0x55A0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_0059A0" OutName="object_bvTex_0059A0" Format="ia16" Width="16" Height="32" Offset="0x59A0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_005DA0" OutName="object_bvTex_005DA0" Format="ia16" Width="16" Height="64" Offset="0x5DA0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_0065A0" OutName="object_bvTex_0065A0" Format="i8" Width="16" Height="32" Offset="0x65A0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_008F88" OutName="object_bvTex_008F88" Format="i8" Width="32" Height="32" Offset="0x8F88" AddedByScript="true"/>
+        <Texture Name="object_bvTex_0117B8" OutName="object_bvTex_0117B8" Format="rgba16" Width="16" Height="16" Offset="0x117B8" AddedByScript="true"/>
+        <Texture Name="object_bvTex_0119B8" OutName="object_bvTex_0119B8" Format="rgba16" Width="16" Height="16" Offset="0x119B8" AddedByScript="true"/>
+        <Texture Name="object_bvTex_011BB8" OutName="object_bvTex_011BB8" Format="rgba16" Width="16" Height="16" Offset="0x11BB8" AddedByScript="true"/>
+        <Texture Name="object_bvTex_012CE0" OutName="object_bvTex_012CE0" Format="i8" Width="64" Height="32" Offset="0x12CE0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_013660" OutName="object_bvTex_013660" Format="ia16" Width="64" Height="64" Offset="0x13660" AddedByScript="true"/>
+        <Texture Name="object_bvTex_0170D8" OutName="object_bvTex_0170D8" Format="rgba16" Width="16" Height="8" Offset="0x170D8" AddedByScript="true"/>
+        <Texture Name="object_bvTex_0171D8" OutName="object_bvTex_0171D8" Format="rgba16" Width="16" Height="16" Offset="0x171D8" AddedByScript="true"/>
+        <Texture Name="object_bvTex_018770" OutName="object_bvTex_018770" Format="rgba16" Width="8" Height="8" Offset="0x18770" AddedByScript="true"/>
+        <Texture Name="object_bvTex_018D30" OutName="object_bvTex_018D30" Format="rgba16" Width="16" Height="8" Offset="0x18D30" AddedByScript="true"/>
+        <Texture Name="object_bvTex_018E30" OutName="object_bvTex_018E30" Format="rgba16" Width="16" Height="16" Offset="0x18E30" AddedByScript="true"/>
+        <Texture Name="object_bvTex_019BB8" OutName="object_bvTex_019BB8" Format="ci8" Width="32" Height="64" Offset="0x19BB8" TlutOffset="0x199B0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_01A6B8" OutName="object_bvTex_01A6B8" Format="ci8" Width="32" Height="64" Offset="0x1A6B8" TlutOffset="0x1A4B0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_01B1B8" OutName="object_bvTex_01B1B8" Format="ci8" Width="32" Height="64" Offset="0x1B1B8" TlutOffset="0x1AFB0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_01BCB8" OutName="object_bvTex_01BCB8" Format="ci8" Width="32" Height="64" Offset="0x1BCB8" TlutOffset="0x1BAB0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_01C7B8" OutName="object_bvTex_01C7B8" Format="ci8" Width="32" Height="64" Offset="0x1C7B8" TlutOffset="0x1C5B0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_01D2B8" OutName="object_bvTex_01D2B8" Format="ci8" Width="32" Height="64" Offset="0x1D2B8" TlutOffset="0x1D0B0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_01DDB8" OutName="object_bvTex_01DDB8" Format="ci8" Width="32" Height="64" Offset="0x1DDB8" TlutOffset="0x1DBB0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_01E8B8" OutName="object_bvTex_01E8B8" Format="ci8" Width="32" Height="64" Offset="0x1E8B8" TlutOffset="0x1E6B0" AddedByScript="true"/>
+        <Texture Name="object_bvTLUT_0199B0" OutName="object_bvTLUT_0199B0" Format="rgba16" Width="16" Height="16" Offset="0x199B0" AddedByScript="true"/>
+        <Texture Name="object_bvTLUT_01A4B0" OutName="object_bvTLUT_01A4B0" Format="rgba16" Width="16" Height="16" Offset="0x1A4B0" AddedByScript="true"/>
+        <Texture Name="object_bvTLUT_01AFB0" OutName="object_bvTLUT_01AFB0" Format="rgba16" Width="16" Height="16" Offset="0x1AFB0" AddedByScript="true"/>
+        <Texture Name="object_bvTLUT_01BAB0" OutName="object_bvTLUT_01BAB0" Format="rgba16" Width="16" Height="16" Offset="0x1BAB0" AddedByScript="true"/>
+        <Texture Name="object_bvTLUT_01C5B0" OutName="object_bvTLUT_01C5B0" Format="rgba16" Width="16" Height="16" Offset="0x1C5B0" AddedByScript="true"/>
+        <Texture Name="object_bvTLUT_01D0B0" OutName="object_bvTLUT_01D0B0" Format="rgba16" Width="16" Height="16" Offset="0x1D0B0" AddedByScript="true"/>
+        <Texture Name="object_bvTLUT_01DBB0" OutName="object_bvTLUT_01DBB0" Format="rgba16" Width="16" Height="16" Offset="0x1DBB0" AddedByScript="true"/>
+        <Texture Name="object_bvTLUT_01E6B0" OutName="object_bvTLUT_01E6B0" Format="rgba16" Width="16" Height="16" Offset="0x1E6B0" AddedByScript="true"/>
         <!-- Boss title card -->
         <Texture Name="gBarinadeTitleCardTex" OutName="barinade_title_card" Format="i8" Width="128" Height="120" Offset="0x1230"/>
 

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_demo_kekkai.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_demo_kekkai.xml
@@ -1,5 +1,21 @@
 <Root>
     <File Name="object_demo_kekkai" Segment="6">
+        <Texture Name="object_demo_kekkaiTex_000000" OutName="object_demo_kekkaiTex_000000" Format="i8" Width="32" Height="64" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_000800" OutName="object_demo_kekkaiTex_000800" Format="i8" Width="32" Height="64" Offset="0x800" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_001000" OutName="object_demo_kekkaiTex_001000" Format="rgba16" Width="32" Height="64" Offset="0x1000" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_002450" OutName="object_demo_kekkaiTex_002450" Format="rgba16" Width="32" Height="64" Offset="0x2450" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_0036A0" OutName="object_demo_kekkaiTex_0036A0" Format="rgba16" Width="32" Height="32" Offset="0x36A0" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_003EA0" OutName="object_demo_kekkaiTex_003EA0" Format="i8" Width="32" Height="32" Offset="0x3EA0" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_004AC0" OutName="object_demo_kekkaiTex_004AC0" Format="i8" Width="32" Height="32" Offset="0x4AC0" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_006140" OutName="object_demo_kekkaiTex_006140" Format="ia16" Width="8" Height="128" Offset="0x6140" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_006940" OutName="object_demo_kekkaiTex_006940" Format="ia8" Width="64" Height="64" Offset="0x6940" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_007DB0" OutName="object_demo_kekkaiTex_007DB0" Format="rgba16" Width="32" Height="32" Offset="0x7DB0" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_0089D0" OutName="object_demo_kekkaiTex_0089D0" Format="rgba16" Width="32" Height="32" Offset="0x89D0" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_0092D0" OutName="object_demo_kekkaiTex_0092D0" Format="rgba16" Width="32" Height="64" Offset="0x92D0" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_00A440" OutName="object_demo_kekkaiTex_00A440" Format="rgba16" Width="64" Height="32" Offset="0xA440" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_00B540" OutName="object_demo_kekkaiTex_00B540" Format="ia16" Width="32" Height="32" Offset="0xB540" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_00C0B0" OutName="object_demo_kekkaiTex_00C0B0" Format="rgba16" Width="32" Height="32" Offset="0xC0B0" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_00C8B0" OutName="object_demo_kekkaiTex_00C8B0" Format="rgba16" Width="32" Height="64" Offset="0xC8B0" AddedByScript="true"/>
         <!-- Demo_Kekkai -->
         <DList Name="gTowerBarrierDL" Offset="0x4930"/>
         <DList Name="gTrialBarrierFloorDL" Offset="0x4F00"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_dnk.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_dnk.xml
@@ -1,5 +1,10 @@
 <Root>
     <File Name="object_dnk" Segment="6">
+        <Texture Name="object_dnkTex_001BD0" OutName="object_dnkTex_001BD0" Format="rgba16" Width="32" Height="32" Offset="0x1BD0" AddedByScript="true"/>
+        <Texture Name="object_dnkTex_0023D0" OutName="object_dnkTex_0023D0" Format="rgba16" Width="16" Height="16" Offset="0x23D0" AddedByScript="true"/>
+        <Texture Name="object_dnkTex_002650" OutName="object_dnkTex_002650" Format="rgba16" Width="8" Height="8" Offset="0x2650" AddedByScript="true"/>
+        <Texture Name="object_dnkTex_0026D0" OutName="object_dnkTex_0026D0" Format="rgba16" Width="8" Height="8" Offset="0x26D0" AddedByScript="true"/>
+        <Texture Name="object_dnkTex_002850" OutName="object_dnkTex_002850" Format="rgba16" Width="16" Height="16" Offset="0x2850" AddedByScript="true"/>
         <!-- Forest Stage scrub skeleton -->
         <Skeleton Name="gDntStageSkel" Type="Normal" LimbType="Standard" Offset="0x2AF0"/>
         

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_dns.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_dns.xml
@@ -1,5 +1,10 @@
 <Root>
     <File Name="object_dns" Segment="6">
+        <Texture Name="object_dnsTex_0024A0" OutName="object_dnsTex_0024A0" Format="rgba16" Width="32" Height="32" Offset="0x24A0" AddedByScript="true"/>
+        <Texture Name="object_dnsTex_002CA0" OutName="object_dnsTex_002CA0" Format="rgba16" Width="16" Height="16" Offset="0x2CA0" AddedByScript="true"/>
+        <Texture Name="object_dnsTex_002F20" OutName="object_dnsTex_002F20" Format="rgba16" Width="8" Height="8" Offset="0x2F20" AddedByScript="true"/>
+        <Texture Name="object_dnsTex_002FA0" OutName="object_dnsTex_002FA0" Format="rgba16" Width="8" Height="8" Offset="0x2FA0" AddedByScript="true"/>
+        <Texture Name="object_dnsTex_003120" OutName="object_dnsTex_003120" Format="rgba16" Width="16" Height="16" Offset="0x3120" AddedByScript="true"/>
         <!-- Forest Stage leader skeleton -->
         <Skeleton Name="gDntJijiSkel" Type="Normal" LimbType="Standard" Offset="0x33E0"/>
 

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_fd.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_fd.xml
@@ -1,5 +1,32 @@
 <Root>
     <File Name="object_fd" Segment="6">
+        <Texture Name="object_fdTex_000458" OutName="object_fdTex_000458" Format="ci4" Width="32" Height="32" Offset="0x458" TlutOffset="0x438" AddedByScript="true"/>
+        <Texture Name="object_fdTex_000658" OutName="object_fdTex_000658" Format="ci4" Width="32" Height="64" Offset="0x658" TlutOffset="0x438" AddedByScript="true"/>
+        <Texture Name="object_fdTex_000A78" OutName="object_fdTex_000A78" Format="ci4" Width="32" Height="32" Offset="0xA78" TlutOffset="0xA58" AddedByScript="true"/>
+        <Texture Name="object_fdTex_0040A8" OutName="object_fdTex_0040A8" Format="rgba16" Width="32" Height="32" Offset="0x40A8" AddedByScript="true"/>
+        <Texture Name="object_fdTex_0048A8" OutName="object_fdTex_0048A8" Format="rgba16" Width="32" Height="32" Offset="0x48A8" AddedByScript="true"/>
+        <Texture Name="object_fdTex_0050A8" OutName="object_fdTex_0050A8" Format="rgba16" Width="16" Height="16" Offset="0x50A8" AddedByScript="true"/>
+        <Texture Name="object_fdTex_0052A8" OutName="object_fdTex_0052A8" Format="rgba16" Width="16" Height="16" Offset="0x52A8" AddedByScript="true"/>
+        <Texture Name="object_fdTex_0054A8" OutName="object_fdTex_0054A8" Format="rgba16" Width="16" Height="16" Offset="0x54A8" AddedByScript="true"/>
+        <Texture Name="object_fdTex_0056A8" OutName="object_fdTex_0056A8" Format="rgba16" Width="16" Height="16" Offset="0x56A8" AddedByScript="true"/>
+        <Texture Name="object_fdTex_005B60" OutName="object_fdTex_005B60" Format="rgba16" Width="16" Height="16" Offset="0x5B60" AddedByScript="true"/>
+        <Texture Name="object_fdTex_005D60" OutName="object_fdTex_005D60" Format="rgba16" Width="16" Height="16" Offset="0x5D60" AddedByScript="true"/>
+        <Texture Name="object_fdTex_005F60" OutName="object_fdTex_005F60" Format="rgba16" Width="16" Height="16" Offset="0x5F60" AddedByScript="true"/>
+        <Texture Name="object_fdTex_009208" OutName="object_fdTex_009208" Format="i8" Width="16" Height="16" Offset="0x9208" AddedByScript="true"/>
+        <Texture Name="object_fdTex_009780" OutName="object_fdTex_009780" Format="rgba16" Width="16" Height="16" Offset="0x9780" AddedByScript="true"/>
+        <Texture Name="object_fdTex_009980" OutName="object_fdTex_009980" Format="rgba16" Width="16" Height="16" Offset="0x9980" AddedByScript="true"/>
+        <Texture Name="object_fdTex_00A050" OutName="object_fdTex_00A050" Format="rgba16" Width="32" Height="32" Offset="0xA050" AddedByScript="true"/>
+        <Texture Name="object_fdTex_00A918" OutName="object_fdTex_00A918" Format="i8" Width="16" Height="16" Offset="0xA918" AddedByScript="true"/>
+        <Texture Name="object_fdTex_00AA18" OutName="object_fdTex_00AA18" Format="rgba16" Width="32" Height="32" Offset="0xAA18" AddedByScript="true"/>
+        <Texture Name="object_fdTex_00B458" OutName="object_fdTex_00B458" Format="rgba16" Width="32" Height="32" Offset="0xB458" AddedByScript="true"/>
+        <Texture Name="object_fdTex_00BC58" OutName="object_fdTex_00BC58" Format="rgba16" Width="16" Height="16" Offset="0xBC58" AddedByScript="true"/>
+        <Texture Name="object_fdTex_00BE58" OutName="object_fdTex_00BE58" Format="rgba16" Width="16" Height="16" Offset="0xBE58" AddedByScript="true"/>
+        <Texture Name="object_fdTex_00C058" OutName="object_fdTex_00C058" Format="rgba16" Width="16" Height="16" Offset="0xC058" AddedByScript="true"/>
+        <Texture Name="object_fdTex_00D170" OutName="object_fdTex_00D170" Format="rgba16" Width="16" Height="16" Offset="0xD170" AddedByScript="true"/>
+        <Texture Name="object_fdTex_00D438" OutName="object_fdTex_00D438" Format="rgba16" Width="16" Height="16" Offset="0xD438" AddedByScript="true"/>
+        <Texture Name="object_fdTLUT_000438" OutName="object_fdTLUT_000438" Format="rgba16" Width="4" Height="4" Offset="0x438" AddedByScript="true"/>
+        <Texture Name="object_fdTLUT_000A58" OutName="object_fdTLUT_000A58" Format="rgba16" Width="4" Height="4" Offset="0xA58" AddedByScript="true"/>
+        <Texture Name="object_fdTLUT_0032A8" OutName="object_fdTLUT_0032A8" Format="rgba16" Width="16" Height="16" Offset="0x32A8" AddedByScript="true"/>
         <!-- Boss title card -->
         <Texture Name="gVolvagiaBossTitleCardTex" OutName="volvagia_boss_title_card" Format="i8" Width="128" Height="120" Offset="0xD700"/>
 

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_fd2.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_fd2.xml
@@ -1,5 +1,16 @@
 <Root>
     <File Name="object_fd2" Segment="6">
+        <Texture Name="object_fd2Tex_003308" OutName="object_fd2Tex_003308" Format="rgba16" Width="32" Height="32" Offset="0x3308" AddedByScript="true"/>
+        <Texture Name="object_fd2Tex_003B08" OutName="object_fd2Tex_003B08" Format="rgba16" Width="32" Height="32" Offset="0x3B08" AddedByScript="true"/>
+        <Texture Name="object_fd2Tex_004308" OutName="object_fd2Tex_004308" Format="rgba16" Width="16" Height="16" Offset="0x4308" AddedByScript="true"/>
+        <Texture Name="object_fd2Tex_004508" OutName="object_fd2Tex_004508" Format="rgba16" Width="16" Height="16" Offset="0x4508" AddedByScript="true"/>
+        <Texture Name="object_fd2Tex_004708" OutName="object_fd2Tex_004708" Format="rgba16" Width="16" Height="16" Offset="0x4708" AddedByScript="true"/>
+        <Texture Name="object_fd2Tex_004908" OutName="object_fd2Tex_004908" Format="rgba16" Width="16" Height="16" Offset="0x4908" AddedByScript="true"/>
+        <Texture Name="object_fd2Tex_004BE8" OutName="object_fd2Tex_004BE8" Format="i8" Width="16" Height="16" Offset="0x4BE8" AddedByScript="true"/>
+        <Texture Name="object_fd2Tex_004FA0" OutName="object_fd2Tex_004FA0" Format="rgba16" Width="16" Height="16" Offset="0x4FA0" AddedByScript="true"/>
+        <Texture Name="object_fd2Tex_0051A0" OutName="object_fd2Tex_0051A0" Format="rgba16" Width="16" Height="16" Offset="0x51A0" AddedByScript="true"/>
+        <Texture Name="object_fd2Tex_0053A0" OutName="object_fd2Tex_0053A0" Format="rgba16" Width="16" Height="16" Offset="0x53A0" AddedByScript="true"/>
+        <Texture Name="object_fd2TLUT_002508" OutName="object_fd2TLUT_002508" Format="rgba16" Width="16" Height="16" Offset="0x2508" AddedByScript="true"/>
         <!-- Skeleton -->
         <Skeleton Name="gHoleVolvagiaSkel" Type="Flex" LimbType="Standard" Offset="0x11A78"/>
 

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_fhg.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_fhg.xml
@@ -1,6 +1,26 @@
 <Root>
     <File Name="object_fhg" Segment="6">
 
+        <Texture Name="object_fhgTex_003320" OutName="object_fhgTex_003320" Format="rgba16" Width="16" Height="16" Offset="0x3320" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_003520" OutName="object_fhgTex_003520" Format="rgba16" Width="16" Height="16" Offset="0x3520" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_003720" OutName="object_fhgTex_003720" Format="rgba16" Width="16" Height="16" Offset="0x3720" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_003920" OutName="object_fhgTex_003920" Format="rgba16" Width="16" Height="16" Offset="0x3920" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_003B20" OutName="object_fhgTex_003B20" Format="rgba16" Width="8" Height="8" Offset="0x3B20" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_003BA0" OutName="object_fhgTex_003BA0" Format="rgba16" Width="16" Height="16" Offset="0x3BA0" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_003DA0" OutName="object_fhgTex_003DA0" Format="rgba16" Width="16" Height="16" Offset="0x3DA0" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_003FA0" OutName="object_fhgTex_003FA0" Format="rgba16" Width="16" Height="32" Offset="0x3FA0" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_0043A0" OutName="object_fhgTex_0043A0" Format="rgba16" Width="16" Height="8" Offset="0x43A0" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_0044A0" OutName="object_fhgTex_0044A0" Format="rgba16" Width="32" Height="32" Offset="0x44A0" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_004CA0" OutName="object_fhgTex_004CA0" Format="rgba16" Width="8" Height="16" Offset="0x4CA0" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_004DA0" OutName="object_fhgTex_004DA0" Format="rgba16" Width="8" Height="8" Offset="0x4DA0" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_00D040" OutName="object_fhgTex_00D040" Format="rgba16" Width="4" Height="4" Offset="0xD040" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_00D060" OutName="object_fhgTex_00D060" Format="rgba16" Width="16" Height="16" Offset="0xD060" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_00E8B0" OutName="object_fhgTex_00E8B0" Format="i4" Width="64" Height="64" Offset="0xE8B0" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_00F0B0" OutName="object_fhgTex_00F0B0" Format="i4" Width="64" Height="64" Offset="0xF0B0" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_00FD98" OutName="object_fhgTex_00FD98" Format="i8" Width="64" Height="32" Offset="0xFD98" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_010660" OutName="object_fhgTex_010660" Format="i4" Width="32" Height="96" Offset="0x10660" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_010D20" OutName="object_fhgTex_010D20" Format="i8" Width="32" Height="32" Offset="0x10D20" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_011120" OutName="object_fhgTex_011120" Format="i8" Width="64" Height="64" Offset="0x11120" AddedByScript="true"/>
         <!-- Skeleton -->
         <Skeleton Name="gPhantomHorseSkel" Type="Normal" LimbType="Skin" Offset="0xB098"/>
 

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_fw.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_fw.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_fw" Segment="6">
+        <Texture Name="object_fwTex_007A90" OutName="object_fwTex_007A90" Format="i8" Width="16" Height="16" Offset="0x7A90" AddedByScript="true"/>
         <!-- Flare Dancer Enflamed Skeleton -->
         <Skeleton Name="gFlareDancerSkel" Type="Flex" LimbType="Standard" Offset="0x5810"/>
 

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_geldb.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_geldb.xml
@@ -1,5 +1,21 @@
 <Root>
     <File Name="object_geldb" Segment="6">
+        <Texture Name="object_geldbTex_002700" OutName="object_geldbTex_002700" Format="ci8" Width="8" Height="8" Offset="0x2700" TlutOffset="0x2500" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_002740" OutName="object_geldbTex_002740" Format="ci8" Width="8" Height="8" Offset="0x2740" TlutOffset="0x2500" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_002780" OutName="object_geldbTex_002780" Format="ci8" Width="16" Height="16" Offset="0x2780" TlutOffset="0x2500" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_002880" OutName="object_geldbTex_002880" Format="i8" Width="16" Height="16" Offset="0x2880" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_002980" OutName="object_geldbTex_002980" Format="ci8" Width="16" Height="16" Offset="0x2980" TlutOffset="0x2500" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_002A80" OutName="object_geldbTex_002A80" Format="i8" Width="16" Height="16" Offset="0x2A80" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_002B80" OutName="object_geldbTex_002B80" Format="i8" Width="8" Height="16" Offset="0x2B80" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_005F68" OutName="object_geldbTex_005F68" Format="ci8" Width="8" Height="16" Offset="0x5F68" TlutOffset="0x5D30" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_0063E8" OutName="object_geldbTex_0063E8" Format="i8" Width="16" Height="16" Offset="0x63E8" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_0064E8" OutName="object_geldbTex_0064E8" Format="ci8" Width="8" Height="16" Offset="0x64E8" TlutOffset="0x5D30" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_006568" OutName="object_geldbTex_006568" Format="ci8" Width="8" Height="8" Offset="0x6568" TlutOffset="0x5D30" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_0069A8" OutName="object_geldbTex_0069A8" Format="i8" Width="8" Height="16" Offset="0x69A8" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_006A28" OutName="object_geldbTex_006A28" Format="ci8" Width="16" Height="16" Offset="0x6A28" TlutOffset="0x5D30" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_006B28" OutName="object_geldbTex_006B28" Format="ci8" Width="16" Height="16" Offset="0x6B28" TlutOffset="0x5D30" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_006C28" OutName="object_geldbTex_006C28" Format="ci8" Width="16" Height="16" Offset="0x6C28" TlutOffset="0x5D30" AddedByScript="true"/>
+        <Texture Name="object_geldbTLUT_002500" OutName="object_geldbTLUT_002500" Format="rgba16" Width="16" Height="16" Offset="0x2500" AddedByScript="true"/>
         <!-- Red-clothed Gerudo skeleton -->
         <Skeleton Name="gGerudoRedSkel" Type="Flex" LimbType="Standard" Offset="0xA458"/>
 

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_boots_2.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_boots_2.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_boots_2" Segment="6">
+        <Texture Name="object_gi_boots_2Tex_000000" OutName="object_gi_boots_2Tex_000000" Format="ia8" Width="16" Height="16" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiIronBootsDL" Offset="0x1630"/>
         <DList Name="gGiIronBootsRivetsDL" Offset="0x1A98"/>
     </File>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_butterfly.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_butterfly.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_butterfly" Segment="6">
+        <Texture Name="object_gi_butterflyTex_000000" OutName="object_gi_butterflyTex_000000" Format="ia4" Width="24" Height="48" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiButterflyContainerDL" Offset="0x0830"/>
         <DList Name="gGiButterflyGlassDL" Offset="0x0A70"/>
     </File>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_clothes.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_clothes.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_clothes" Segment="6">
+        <Texture Name="object_gi_clothesTex_000000" OutName="object_gi_clothesTex_000000" Format="i4" Width="64" Height="64" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiGoronCollarColorDL" Offset="0x14E0"/>
         <DList Name="gGiZoraCollarColorDL" Offset="0x1500"/>
         <DList Name="gGiGoronTunicColorDL" Offset="0x1520"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_dekupouch.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_dekupouch.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_gi_dekupouch" Segment="6">
+        <Texture Name="object_gi_dekupouchTex_000000" OutName="object_gi_dekupouchTex_000000" Format="i4" Width="32" Height="16" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_dekupouchTex_000100" OutName="object_gi_dekupouchTex_000100" Format="i4" Width="32" Height="32" Offset="0x100" AddedByScript="true"/>
         <DList Name="gGiBulletBagColorDL" Offset="0x0AF0"/>
         <DList Name="gGiBulletBag50ColorDL" Offset="0x0B10"/>
         <DList Name="gGiBulletBagStringColorDL" Offset="0x0B30"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_fire.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_fire.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_gi_fire" Segment="6">
+        <Texture Name="object_gi_fireTex_000000" OutName="object_gi_fireTex_000000" Format="i8" Width="16" Height="32" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_fireTex_000200" OutName="object_gi_fireTex_000200" Format="i8" Width="16" Height="32" Offset="0x200" AddedByScript="true"/>
         <DList Name="gGiBlueFireChamberstickDL" Offset="0x0C60"/>
         <DList Name="gGiBlueFireFlameDL" Offset="0x0F08"/>
     </File>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_frog.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_frog.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_frog" Segment="6">
+        <Texture Name="object_gi_frogTex_000000" OutName="object_gi_frogTex_000000" Format="i8" Width="32" Height="32" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiFrogDL" Offset="0x0D60"/>
         <DList Name="gGiFrogEyesDL" Offset="0x1060"/>
     </File>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_gerudo.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_gerudo.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_gerudo" Segment="6">
+        <Texture Name="object_gi_gerudoTex_000000" OutName="object_gi_gerudoTex_000000" Format="i8" Width="32" Height="32" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiGerudoCardDL" Offset="0x0F60"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_gerudomask.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_gerudomask.xml
@@ -1,5 +1,10 @@
 <Root>
     <File Name="object_gi_gerudomask" Segment="6">
+        <Texture Name="object_gi_gerudomaskTex_000208" OutName="object_gi_gerudomaskTex_000208" Format="ci8" Width="8" Height="8" Offset="0x208" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_gerudomaskTex_000248" OutName="object_gi_gerudomaskTex_000248" Format="ci8" Width="16" Height="16" Offset="0x248" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_gerudomaskTex_000348" OutName="object_gi_gerudomaskTex_000348" Format="ci8" Width="16" Height="16" Offset="0x348" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_gerudomaskTex_000448" OutName="object_gi_gerudomaskTex_000448" Format="ci8" Width="32" Height="32" Offset="0x448" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_gerudomaskTLUT_000000" OutName="object_gi_gerudomaskTLUT_000000" Format="rgba16" Width="16" Height="16" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiGerudoMaskDL" Offset="0x10E8"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_ghost.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_ghost.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_gi_ghost" Segment="6">
+        <Texture Name="object_gi_ghostTex_000000" OutName="object_gi_ghostTex_000000" Format="i8" Width="16" Height="32" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_ghostTex_000200" OutName="object_gi_ghostTex_000200" Format="i8" Width="16" Height="32" Offset="0x200" AddedByScript="true"/>
         <DList Name="gGiPoeColorDL" Offset="0x0950"/>
         <DList Name="gGiBigPoeColorDL" Offset="0x0970"/>
         <DList Name="gGiGhostContainerLidDL" Offset="0x0990"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_gloves.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_gloves.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_gloves" Segment="6">
+        <Texture Name="object_gi_glovesTex_000000" OutName="object_gi_glovesTex_000000" Format="i8" Width="64" Height="32" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiSilverGauntletsColorDL" Offset="0x14C0"/>
         <DList Name="gGiGoldenGauntletsColorDL" Offset="0x14E0"/>
         <DList Name="gGiSilverGauntletsPlateColorDL" Offset="0x1500"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_golonmask.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_golonmask.xml
@@ -1,5 +1,10 @@
 <Root>
     <File Name="object_gi_golonmask" Segment="6">
+        <Texture Name="object_gi_golonmaskTex_000208" OutName="object_gi_golonmaskTex_000208" Format="ci8" Width="8" Height="8" Offset="0x208" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_golonmaskTex_000248" OutName="object_gi_golonmaskTex_000248" Format="ci8" Width="16" Height="16" Offset="0x248" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_golonmaskTex_000348" OutName="object_gi_golonmaskTex_000348" Format="ci8" Width="32" Height="32" Offset="0x348" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_golonmaskTex_000748" OutName="object_gi_golonmaskTex_000748" Format="ci8" Width="64" Height="32" Offset="0x748" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_golonmaskTLUT_000000" OutName="object_gi_golonmaskTLUT_000000" Format="rgba16" Width="16" Height="16" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiGoronMaskDL" Offset="0x14F8"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_hoverboots.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_hoverboots.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_gi_hoverboots" Segment="6">
+        <Texture Name="object_gi_hoverbootsTex_000000" OutName="object_gi_hoverbootsTex_000000" Format="ia4" Width="48" Height="32" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_hoverbootsTex_000300" OutName="object_gi_hoverbootsTex_000300" Format="i4" Width="16" Height="32" Offset="0x300" AddedByScript="true"/>
         <DList Name="gGiHoverBootsDL" Offset="0x1850"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_ki_tan_mask.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_ki_tan_mask.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_ki_tan_mask" Segment="6">
+        <Texture Name="object_gi_ki_tan_maskTex_000000" OutName="object_gi_ki_tan_maskTex_000000" Format="ia8" Width="8" Height="32" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiKeatonMaskDL" Offset="0x0AC0"/>
         <DList Name="gGiKeatonMaskEyesDL" Offset="0x0D50"/>
     </File>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_letter.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_letter.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_gi_letter" Segment="6">
+        <Texture Name="object_gi_letterTex_000000" OutName="object_gi_letterTex_000000" Format="i8" Width="48" Height="32" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_letterTex_000600" OutName="object_gi_letterTex_000600" Format="ia8" Width="48" Height="32" Offset="0x600" AddedByScript="true"/>
         <DList Name="gGiLetterDL" Offset="0x0CC0"/>
         <DList Name="gGiLetterWritingDL" Offset="0x0D60"/>
     </File>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_liquid.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_liquid.xml
@@ -1,5 +1,8 @@
 <Root>
     <File Name="object_gi_liquid" Segment="6">
+        <Texture Name="object_gi_liquidTex_000000" OutName="object_gi_liquidTex_000000" Format="ia8" Width="16" Height="32" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_liquidTex_000200" OutName="object_gi_liquidTex_000200" Format="ia8" Width="16" Height="32" Offset="0x200" AddedByScript="true"/>
+        <Texture Name="object_gi_liquidTex_000400" OutName="object_gi_liquidTex_000400" Format="ia8" Width="16" Height="32" Offset="0x400" AddedByScript="true"/>
         <DList Name="gGiGreenPotColorDL" Offset="0x1270"/>
         <DList Name="gGiRedPotColorDL" Offset="0x1290"/>
         <DList Name="gGiBluePotColorDL" Offset="0x12B0"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_map.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_map.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_map" Segment="6">
+        <Texture Name="object_gi_mapTex_000D60" OutName="object_gi_mapTex_000D60" Format="i8" Width="32" Height="32" Offset="0xD60" AddedByScript="true"/>
         <DList Name="gGiDungeonMapDL" Offset="0x03C0"/>
         <DList Name="gGiStoneOfAgonyDL" Offset="0x0B70"/>
     </File>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_milk.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_milk.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_milk" Segment="6">
+        <Texture Name="object_gi_milkTex_000000" OutName="object_gi_milkTex_000000" Format="i8" Width="72" Height="24" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiMilkBottleContentsDL" Offset="0x1060"/>
         <DList Name="gGiMilkBottleDL" Offset="0x1288"/>
     </File>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_niwatori.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_niwatori.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_gi_niwatori" Segment="6">
+        <Texture Name="object_gi_niwatoriTex_000000" OutName="object_gi_niwatoriTex_000000" Format="i8" Width="32" Height="64" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_niwatoriTex_000800" OutName="object_gi_niwatoriTex_000800" Format="ia8" Width="32" Height="32" Offset="0x800" AddedByScript="true"/>
         <DList Name="gGiChickenColorDL" Offset="0x15F0"/>
         <DList Name="gGiCojiroColorDL" Offset="0x1610"/>
         <DList Name="gGiChickenDL" Offset="0x1630"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_nuts.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_nuts.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_nuts" Segment="6">
+        <Texture Name="object_gi_nutsTex_000000" OutName="object_gi_nutsTex_000000" Format="i8" Width="32" Height="32" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiNutDL" Offset="0x0E90"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_ocarina.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_ocarina.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_ocarina" Segment="6">
+        <Texture Name="object_gi_ocarinaTex_000000" OutName="object_gi_ocarinaTex_000000" Format="i8" Width="16" Height="16" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiOcarinaTimeDL" Offset="0x08C0"/>
         <DList Name="gGiOcarinaTimeHolesDL" Offset="0x0AF8"/>
     </File>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_ocarina_0.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_ocarina_0.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_ocarina_0" Segment="6">
+        <Texture Name="object_gi_ocarina_0Tex_000000" OutName="object_gi_ocarina_0Tex_000000" Format="i8" Width="16" Height="16" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiOcarinaFairyDL" Offset="0x08E0"/>
         <DList Name="gGiOcarinaFairyHolesDL" Offset="0x0B58"/>
     </File>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_prescription.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_prescription.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_prescription" Segment="6">
+        <Texture Name="object_gi_prescriptionTex_000000" OutName="object_gi_prescriptionTex_000000" Format="ia8" Width="32" Height="48" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiPrescriptionDL" Offset="0x09C0"/>
         <DList Name="gGiPrescriptionWritingDL" Offset="0x0AF0"/>
     </File>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_purse.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_purse.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_purse" Segment="6">
+        <Texture Name="object_gi_purseTex_000000" OutName="object_gi_purseTex_000000" Format="i8" Width="64" Height="64" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiAdultWalletColorDL" Offset="0x1750"/>
         <DList Name="gGiGiantsWalletColorDL" Offset="0x1770"/>
         <DList Name="gGiAdultWalletRupeeOuterColorDL" Offset="0x1790"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_rabit_mask.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_rabit_mask.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_rabit_mask" Segment="6">
+        <Texture Name="object_gi_rabit_maskTex_000000" OutName="object_gi_rabit_maskTex_000000" Format="ia8" Width="16" Height="16" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiBunnyHoodDL" Offset="0x0BC0"/>
         <DList Name="gGiBunnyHoodEyesDL" Offset="0x0E58"/>
     </File>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_shield_1.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_shield_1.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_shield_1" Segment="6">
+        <Texture Name="object_gi_shield_1Tex_000000" OutName="object_gi_shield_1Tex_000000" Format="i8" Width="32" Height="32" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiDekuShieldDL" Offset="0x0A50"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_shield_3.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_shield_3.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_gi_shield_3" Segment="6">
+        <Texture Name="object_gi_shield_3Tex_000000" OutName="object_gi_shield_3Tex_000000" Format="i4" Width="64" Height="32" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_shield_3Tex_000400" OutName="object_gi_shield_3Tex_000400" Format="i4" Width="64" Height="64" Offset="0x400" AddedByScript="true"/>
         <DList Name="gGiMirrorShieldDL" Offset="0x0FB0"/>
         <DList Name="gGiMirrorShieldSymbolDL" Offset="0x11C8"/>
     </File>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_soldout.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_soldout.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_soldout" Segment="6">
+        <Texture Name="object_gi_soldoutTex_000000" OutName="object_gi_soldoutTex_000000" Format="ia8" Width="32" Height="32" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiSoldOutDL" Offset="0x0440"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_soul.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_soul.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_soul" Segment="6">
+        <Texture Name="object_gi_soulTex_000000" OutName="object_gi_soulTex_000000" Format="i8" Width="32" Height="32" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiFairyContainerBaseCapDL" Offset="0x0BD0"/>
         <DList Name="gGiFairyContainerGlassDL" Offset="0x0DB8"/>
         <DList Name="gGiFairyContainerContentsDL" Offset="0x0EF0"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_ticketstone.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_ticketstone.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_gi_ticketstone" Segment="6">
+        <Texture Name="object_gi_ticketstoneTex_000000" OutName="object_gi_ticketstoneTex_000000" Format="i4" Width="48" Height="24" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_ticketstoneTex_000240" OutName="object_gi_ticketstoneTex_000240" Format="i8" Width="32" Height="24" Offset="0x240" AddedByScript="true"/>
         <DList Name="gGiClaimCheckDL" Offset="0x0F00"/>
         <DList Name="gGiClaimCheckWritingDL" Offset="0x1188"/>
     </File>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_truth_mask.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_truth_mask.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_gi_truth_mask" Segment="6">
+        <Texture Name="object_gi_truth_maskTex_000000" OutName="object_gi_truth_maskTex_000000" Format="i8" Width="32" Height="32" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_truth_maskTex_000400" OutName="object_gi_truth_maskTex_000400" Format="i8" Width="32" Height="32" Offset="0x400" AddedByScript="true"/>
         <DList Name="gGiMaskOfTruthDL" Offset="0x13D0"/>
         <DList Name="gGiMaskOfTruthAccentsDL" Offset="0x16B0"/>
     </File>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_zoramask.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gi_zoramask.xml
@@ -1,5 +1,10 @@
 <Root>
     <File Name="object_gi_zoramask" Segment="6">
+        <Texture Name="object_gi_zoramaskTex_000208" OutName="object_gi_zoramaskTex_000208" Format="ci8" Width="8" Height="8" Offset="0x208" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_zoramaskTex_000248" OutName="object_gi_zoramaskTex_000248" Format="ci8" Width="32" Height="32" Offset="0x248" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_zoramaskTex_000648" OutName="object_gi_zoramaskTex_000648" Format="ci8" Width="32" Height="32" Offset="0x648" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_zoramaskTex_000A48" OutName="object_gi_zoramaskTex_000A48" Format="ci8" Width="32" Height="32" Offset="0xA48" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_zoramaskTLUT_000000" OutName="object_gi_zoramaskTLUT_000000" Format="rgba16" Width="16" Height="16" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiZoraMaskDL" Offset="0x1398"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gj.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gj.xml
@@ -1,5 +1,15 @@
 <Root>
     <File Name="object_gj" Segment="6">
+        <Texture Name="object_gjTex_003B20" OutName="object_gjTex_003B20" Format="ia8" Width="16" Height="16" Offset="0x3B20" AddedByScript="true"/>
+        <Texture Name="object_gjTex_003C20" OutName="object_gjTex_003C20" Format="i4" Width="16" Height="32" Offset="0x3C20" AddedByScript="true"/>
+        <Texture Name="object_gjTex_003D20" OutName="object_gjTex_003D20" Format="rgba16" Width="16" Height="16" Offset="0x3D20" AddedByScript="true"/>
+        <Texture Name="object_gjTex_003F20" OutName="object_gjTex_003F20" Format="i8" Width="64" Height="64" Offset="0x3F20" AddedByScript="true"/>
+        <Texture Name="object_gjTex_004F20" OutName="object_gjTex_004F20" Format="i8" Width="64" Height="64" Offset="0x4F20" AddedByScript="true"/>
+        <Texture Name="object_gjTex_005F20" OutName="object_gjTex_005F20" Format="i8" Width="64" Height="64" Offset="0x5F20" AddedByScript="true"/>
+        <Texture Name="object_gjTex_006F20" OutName="object_gjTex_006F20" Format="i4" Width="32" Height="64" Offset="0x6F20" AddedByScript="true"/>
+        <Texture Name="object_gjTex_007320" OutName="object_gjTex_007320" Format="i8" Width="64" Height="16" Offset="0x7320" AddedByScript="true"/>
+        <Texture Name="object_gjTex_007720" OutName="object_gjTex_007720" Format="ia8" Width="32" Height="32" Offset="0x7720" AddedByScript="true"/>
+        <Texture Name="object_gjTex_007B20" OutName="object_gjTex_007B20" Format="i8" Width="128" Height="32" Offset="0x7B20" AddedByScript="true"/>
         <!-- This is the decorative rubble around the fight arena -->
         <DList Name="gGanonsCastleRubbleAroundArenaDL" Offset="0xDC0"/>
         <Collision Name="gGanonsCastleRubbleAroundArenaCol" Offset="0x1B70"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gnd.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gnd.xml
@@ -1,6 +1,7 @@
 <Root>
     <File Name="object_gnd" Segment="6">
         
+        <Texture Name="object_gndTex_012B50" OutName="object_gndTex_012B50" Format="rgba16" Width="16" Height="32" Offset="0x12B50" AddedByScript="true"/>
         <!-- Skeleton -->
         <Skeleton Name="gPhantomGanonSkel" Type="Normal" LimbType="Standard" Offset="0xC710"/>
         

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gr.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_gr.xml
@@ -1,12 +1,23 @@
 <Root>
     <File Name="object_gr" Segment="6">
+        <Texture Name="object_grTex_005D78" OutName="object_grTex_005D78" Format="ci8" Width="16" Height="16" Offset="0x5D78" TlutOffset="0x3F78" AddedByScript="true"/>
+        <Texture Name="object_grTex_005E78" OutName="object_grTex_005E78" Format="ci8" Width="8" Height="8" Offset="0x5E78" TlutOffset="0x3F78" AddedByScript="true"/>
+        <Texture Name="object_grTex_005EB8" OutName="object_grTex_005EB8" Format="ci8" Width="8" Height="8" Offset="0x5EB8" TlutOffset="0x3F78" AddedByScript="true"/>
+        <Texture Name="object_grTex_005EF8" OutName="object_grTex_005EF8" Format="ci8" Width="16" Height="16" Offset="0x5EF8" TlutOffset="0x3F78" AddedByScript="true"/>
+        <Texture Name="object_grTex_0077F8" OutName="object_grTex_0077F8" Format="ci8" Width="32" Height="32" Offset="0x77F8" TlutOffset="0x3F78" AddedByScript="true"/>
+        <Texture Name="object_grTex_007BF8" OutName="object_grTex_007BF8" Format="ci8" Width="32" Height="32" Offset="0x7BF8" TlutOffset="0x3F78" AddedByScript="true"/>
+        <Texture Name="object_grTex_007FF8" OutName="object_grTex_007FF8" Format="ci8" Width="32" Height="32" Offset="0x7FF8" TlutOffset="0x3F78" AddedByScript="true"/>
+        <Texture Name="object_grTex_0083F8" OutName="object_grTex_0083F8" Format="ci8" Width="32" Height="32" Offset="0x83F8" TlutOffset="0x3F78" AddedByScript="true"/>
+        <Texture Name="object_grTex_0097F8" OutName="object_grTex_0097F8" Format="ci8" Width="4" Height="4" Offset="0x97F8" TlutOffset="0x3F78" AddedByScript="true"/>
+        <Texture Name="object_grTex_009808" OutName="object_grTex_009808" Format="ci8" Width="8" Height="8" Offset="0x9808" TlutOffset="0x3F78" AddedByScript="true"/>
+        <Texture Name="object_grTLUT_003F78" OutName="object_grTLUT_003F78" Format="rgba16" Width="16" Height="16" Offset="0x3F78" AddedByScript="true"/>
         <Skeleton Name="gNiwGirlSkel" Type="Flex" LimbType="Standard" Offset="0x9948"/>
         <Animation Name="gNiwGirlRunAnim" Offset="0x0378"/>
         <Animation Name="gNiwGirlJumpAnim" Offset="0x9C78"/>
         <Texture Name="gNiwGirlEyeOpenTex" OutName="eye_open" Format="rgba16" Width="32" Height="32" Offset="0x4178"/>
         <Texture Name="gNiwGirlEyeHalfTex" OutName="eye_half" Format="rgba16" Width="32" Height="32" Offset="0x4978"/>
         <Texture Name="gNiwGirlEyeClosedTex" OutName="eye_closed" Format="rgba16" Width="32" Height="32" Offset="0x5178"/>
-        <Texture Name="gNiwGirlMouthTex"  OutName="mouth" Format="rgba16" Width="32" Height="16" Offset="0x5978"/>
+        <Texture Name="gNiwGirlMouthTex" OutName="mouth" Format="rgba16" Width="32" Height="16" Offset="0x5978"/>
         <Texture Name="gNiwGirlDress1Tex" OutName="dress_1" Format="rgba16" Width="32" Height="32" Offset="0x5FF8"/>
         <Texture Name="gNiwGirlDress2Tex" OutName="dress_2" Format="rgba16" Width="32" Height="32" Offset="0x6FF8"/>
         <Texture Name="gNiwGirlDress3Tex" OutName="dress_3" Format="rgba16" Width="32" Height="32" Offset="0x8FF8"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_hakach_objects.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_hakach_objects.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_hakach_objects" Segment="6">
+        <Texture Name="object_hakach_objectsTex_0062F0" OutName="object_hakach_objectsTex_0062F0" Format="rgba16" Width="32" Height="32" Offset="0x62F0" AddedByScript="true"/>
         <DList Name="gBotwHoleTrap1DL" Offset="0x01B0"/>
         <DList Name="gBotwHoleTrap2DL" Offset="0x03F0"/>
         <DList Name="gBotwCoffinLidDL" Offset="0x06B0"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_hidan_objects.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_hidan_objects.xml
@@ -1,5 +1,25 @@
 <Root>
     <File Name="object_hidan_objects" Segment="6">
+        <Texture Name="object_hidan_objectsTex_000040" OutName="object_hidan_objectsTex_000040" Format="ci4" Width="32" Height="32" Offset="0x40" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_000240" OutName="object_hidan_objectsTex_000240" Format="rgba16" Width="32" Height="32" Offset="0x240" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_000A40" OutName="object_hidan_objectsTex_000A40" Format="rgba16" Width="32" Height="64" Offset="0xA40" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_001A40" OutName="object_hidan_objectsTex_001A40" Format="rgba16" Width="32" Height="64" Offset="0x1A40" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_002A40" OutName="object_hidan_objectsTex_002A40" Format="rgba16" Width="32" Height="64" Offset="0x2A40" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_003A40" OutName="object_hidan_objectsTex_003A40" Format="rgba16" Width="32" Height="32" Offset="0x3A40" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_004240" OutName="object_hidan_objectsTex_004240" Format="rgba16" Width="16" Height="64" Offset="0x4240" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_004A40" OutName="object_hidan_objectsTex_004A40" Format="rgba16" Width="32" Height="32" Offset="0x4A40" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_005240" OutName="object_hidan_objectsTex_005240" Format="ci4" Width="32" Height="64" Offset="0x5240" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_005640" OutName="object_hidan_objectsTex_005640" Format="ci4" Width="32" Height="64" Offset="0x5640" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_005A40" OutName="object_hidan_objectsTex_005A40" Format="ci4" Width="64" Height="32" Offset="0x5A40" TlutOffset="0x20" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_005E40" OutName="object_hidan_objectsTex_005E40" Format="rgba16" Width="32" Height="32" Offset="0x5E40" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_006640" OutName="object_hidan_objectsTex_006640" Format="ci4" Width="32" Height="64" Offset="0x6640" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_006A40" OutName="object_hidan_objectsTex_006A40" Format="ci4" Width="32" Height="32" Offset="0x6A40" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_006C40" OutName="object_hidan_objectsTex_006C40" Format="ci4" Width="32" Height="32" Offset="0x6C40" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_006E40" OutName="object_hidan_objectsTex_006E40" Format="rgba16" Width="32" Height="32" Offset="0x6E40" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_00FB20" OutName="object_hidan_objectsTex_00FB20" Format="rgba16" Width="32" Height="64" Offset="0xFB20" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_010D90" OutName="object_hidan_objectsTex_010D90" Format="rgba16" Width="32" Height="64" Offset="0x10D90" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTLUT_000000" OutName="object_hidan_objectsTLUT_000000" Format="rgba16" Width="4" Height="4" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTLUT_000020" OutName="object_hidan_objectsTLUT_000020" Format="rgba16" Width="4" Height="4" Offset="0x20" AddedByScript="true"/>
         <DList Name="gFireTempleHammerableTotemBodyDL" Offset="0xBBF0"/>
         <DList Name="gFireTempleHammerableTotemHeadDL" Offset="0xBDF0"/>
         <Collision Name="gFireTempleHammerableTotemCol" Offset="0xDA10"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_hintnuts.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_hintnuts.xml
@@ -1,5 +1,11 @@
 <Root>
     <File Name="object_hintnuts" Segment="6">
+        <Texture Name="object_hintnutsTex_0015A8" OutName="object_hintnutsTex_0015A8" Format="rgba16" Width="32" Height="32" Offset="0x15A8" AddedByScript="true"/>
+        <Texture Name="object_hintnutsTex_001DA8" OutName="object_hintnutsTex_001DA8" Format="rgba16" Width="16" Height="16" Offset="0x1DA8" AddedByScript="true"/>
+        <Texture Name="object_hintnutsTex_001FA8" OutName="object_hintnutsTex_001FA8" Format="rgba16" Width="8" Height="8" Offset="0x1FA8" AddedByScript="true"/>
+        <Texture Name="object_hintnutsTex_002028" OutName="object_hintnutsTex_002028" Format="rgba16" Width="8" Height="8" Offset="0x2028" AddedByScript="true"/>
+        <Texture Name="object_hintnutsTex_0020A8" OutName="object_hintnutsTex_0020A8" Format="rgba16" Width="8" Height="8" Offset="0x20A8" AddedByScript="true"/>
+        <Texture Name="object_hintnutsTex_002128" OutName="object_hintnutsTex_002128" Format="rgba16" Width="16" Height="16" Offset="0x2128" AddedByScript="true"/>
         <!-- Deku scrub skeleton -->
         <Skeleton Name="gHintNutsSkel" Type="Normal" LimbType="Standard" Offset="0x23B8"/>
         

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_horse_ganon.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_horse_ganon.xml
@@ -1,5 +1,16 @@
 <Root>
     <File Name="object_horse_ganon" Segment="6">
+        <Texture Name="object_horse_ganonTex_00A570" OutName="object_horse_ganonTex_00A570" Format="rgba16" Width="8" Height="8" Offset="0xA570" AddedByScript="true"/>
+        <Texture Name="object_horse_ganonTex_00A5F0" OutName="object_horse_ganonTex_00A5F0" Format="rgba16" Width="16" Height="16" Offset="0xA5F0" AddedByScript="true"/>
+        <Texture Name="object_horse_ganonTex_00A7F0" OutName="object_horse_ganonTex_00A7F0" Format="rgba16" Width="4" Height="4" Offset="0xA7F0" AddedByScript="true"/>
+        <Texture Name="object_horse_ganonTex_00A810" OutName="object_horse_ganonTex_00A810" Format="rgba16" Width="16" Height="16" Offset="0xA810" AddedByScript="true"/>
+        <Texture Name="object_horse_ganonTex_00AA10" OutName="object_horse_ganonTex_00AA10" Format="rgba16" Width="16" Height="16" Offset="0xAA10" AddedByScript="true"/>
+        <Texture Name="object_horse_ganonTex_00B010" OutName="object_horse_ganonTex_00B010" Format="rgba16" Width="8" Height="16" Offset="0xB010" AddedByScript="true"/>
+        <Texture Name="object_horse_ganonTex_00B110" OutName="object_horse_ganonTex_00B110" Format="rgba16" Width="16" Height="32" Offset="0xB110" AddedByScript="true"/>
+        <Texture Name="object_horse_ganonTex_00B510" OutName="object_horse_ganonTex_00B510" Format="rgba16" Width="16" Height="8" Offset="0xB510" AddedByScript="true"/>
+        <Texture Name="object_horse_ganonTex_00B610" OutName="object_horse_ganonTex_00B610" Format="rgba16" Width="8" Height="8" Offset="0xB610" AddedByScript="true"/>
+        <Texture Name="object_horse_ganonTex_00B690" OutName="object_horse_ganonTex_00B690" Format="rgba16" Width="32" Height="32" Offset="0xB690" AddedByScript="true"/>
+        <Texture Name="object_horse_ganonTex_00BE90" OutName="object_horse_ganonTex_00BE90" Format="rgba16" Width="16" Height="16" Offset="0xBE90" AddedByScript="true"/>
         <Skeleton Name="gHorseGanonSkel" Type="Normal" LimbType="Skin" Offset="0x8668"/>
 
         <!-- Idle. Horse moving leg. -->

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_horse_link_child.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_horse_link_child.xml
@@ -1,5 +1,14 @@
 <Root>
     <File Name="object_horse_link_child" Segment="6">
+        <Texture Name="object_horse_link_childTex_001F28" OutName="object_horse_link_childTex_001F28" Format="rgba16" Width="4" Height="8" Offset="0x1F28" AddedByScript="true"/>
+        <Texture Name="object_horse_link_childTex_001F68" OutName="object_horse_link_childTex_001F68" Format="rgba16" Width="16" Height="16" Offset="0x1F68" AddedByScript="true"/>
+        <Texture Name="object_horse_link_childTex_002168" OutName="object_horse_link_childTex_002168" Format="rgba16" Width="16" Height="16" Offset="0x2168" AddedByScript="true"/>
+        <Texture Name="object_horse_link_childTex_002368" OutName="object_horse_link_childTex_002368" Format="rgba16" Width="16" Height="16" Offset="0x2368" AddedByScript="true"/>
+        <Texture Name="object_horse_link_childTex_002568" OutName="object_horse_link_childTex_002568" Format="rgba16" Width="4" Height="4" Offset="0x2568" AddedByScript="true"/>
+        <Texture Name="object_horse_link_childTex_002588" OutName="object_horse_link_childTex_002588" Format="rgba16" Width="8" Height="32" Offset="0x2588" AddedByScript="true"/>
+        <Texture Name="object_horse_link_childTex_002788" OutName="object_horse_link_childTex_002788" Format="rgba16" Width="16" Height="16" Offset="0x2788" AddedByScript="true"/>
+        <Texture Name="object_horse_link_childTex_008120" OutName="object_horse_link_childTex_008120" Format="rgba16" Width="16" Height="16" Offset="0x8120" AddedByScript="true"/>
+        <Texture Name="object_horse_link_childTex_008320" OutName="object_horse_link_childTex_008320" Format="rgba16" Width="32" Height="32" Offset="0x8320" AddedByScript="true"/>
         <Skeleton Name="gChildEponaSkel" Type="Normal" LimbType="Skin" Offset="0x7B20"/>
 
         <!-- Idle animation. -->
@@ -14,8 +23,8 @@
         <Animation Name="gChildEponaGallopingAnim" Offset="0x2F98"/>
 
         <Texture Name="gChildEponaEyeTLUT" OutName="child_epona_eye_tlut" Format="rgba16" Width="16" Height="16" Offset="0x1728"/>
-        <Texture Name="gChildEponaEyeOpenTex" OutName="child_epona_eye_open" Format="ci8" Width="32" Height="16" Offset="0x1D28"  TlutOffset="0x1728"/>
-        <Texture Name="gChildEponaEyeHalfTex" OutName="child_epona_eye_half" Format="ci8" Width="32" Height="16" Offset="0x1928"  TlutOffset="0x1728"/>
-        <Texture Name="gChildEponaEyeCloseTex" OutName="child_epona_eye_close" Format="ci8" Width="32" Height="16" Offset="0x1B28"  TlutOffset="0x1728"/>
+        <Texture Name="gChildEponaEyeOpenTex" OutName="child_epona_eye_open" Format="ci8" Width="32" Height="16" Offset="0x1D28" TlutOffset="0x1728"/>
+        <Texture Name="gChildEponaEyeHalfTex" OutName="child_epona_eye_half" Format="ci8" Width="32" Height="16" Offset="0x1928" TlutOffset="0x1728"/>
+        <Texture Name="gChildEponaEyeCloseTex" OutName="child_epona_eye_close" Format="ci8" Width="32" Height="16" Offset="0x1B28" TlutOffset="0x1728"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_horse_normal.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_horse_normal.xml
@@ -1,5 +1,13 @@
 <Root>
     <File Name="object_horse_normal" Segment="6">
+        <Texture Name="object_horse_normalTex_0058D8" OutName="object_horse_normalTex_0058D8" Format="i8" Width="8" Height="8" Offset="0x58D8" AddedByScript="true"/>
+        <Texture Name="object_horse_normalTex_005918" OutName="object_horse_normalTex_005918" Format="rgba16" Width="16" Height="16" Offset="0x5918" AddedByScript="true"/>
+        <Texture Name="object_horse_normalTex_005B18" OutName="object_horse_normalTex_005B18" Format="rgba16" Width="8" Height="8" Offset="0x5B18" AddedByScript="true"/>
+        <Texture Name="object_horse_normalTex_005B98" OutName="object_horse_normalTex_005B98" Format="i8" Width="16" Height="16" Offset="0x5B98" AddedByScript="true"/>
+        <Texture Name="object_horse_normalTex_005C98" OutName="object_horse_normalTex_005C98" Format="i8" Width="16" Height="8" Offset="0x5C98" AddedByScript="true"/>
+        <Texture Name="object_horse_normalTex_006F28" OutName="object_horse_normalTex_006F28" Format="i8" Width="16" Height="16" Offset="0x6F28" AddedByScript="true"/>
+        <Texture Name="object_horse_normalTex_007028" OutName="object_horse_normalTex_007028" Format="i8" Width="16" Height="16" Offset="0x7028" AddedByScript="true"/>
+        <Texture Name="object_horse_normalTex_007128" OutName="object_horse_normalTex_007128" Format="i8" Width="32" Height="32" Offset="0x7128" AddedByScript="true"/>
         <Skeleton Name="gHorseNormalSkel" Type="Normal" LimbType="Skin" Offset="0x9FAC"/>
 
         <!-- Running. -->

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_horse_zelda.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_horse_zelda.xml
@@ -1,5 +1,17 @@
 <Root>
     <File Name="object_horse_zelda" Segment="6">
+        <Texture Name="object_horse_zeldaTex_000408" OutName="object_horse_zeldaTex_000408" Format="rgba16" Width="8" Height="8" Offset="0x408" AddedByScript="true"/>
+        <Texture Name="object_horse_zeldaTex_000888" OutName="object_horse_zeldaTex_000888" Format="rgba16" Width="8" Height="16" Offset="0x888" AddedByScript="true"/>
+        <Texture Name="object_horse_zeldaTex_000988" OutName="object_horse_zeldaTex_000988" Format="rgba16" Width="4" Height="4" Offset="0x988" AddedByScript="true"/>
+        <Texture Name="object_horse_zeldaTex_002578" OutName="object_horse_zeldaTex_002578" Format="rgba16" Width="8" Height="16" Offset="0x2578" AddedByScript="true"/>
+        <Texture Name="object_horse_zeldaTex_002678" OutName="object_horse_zeldaTex_002678" Format="rgba16" Width="16" Height="8" Offset="0x2678" AddedByScript="true"/>
+        <Texture Name="object_horse_zeldaTex_002778" OutName="object_horse_zeldaTex_002778" Format="rgba16" Width="16" Height="16" Offset="0x2778" AddedByScript="true"/>
+        <Texture Name="object_horse_zeldaTex_002978" OutName="object_horse_zeldaTex_002978" Format="rgba16" Width="32" Height="32" Offset="0x2978" AddedByScript="true"/>
+        <Texture Name="object_horse_zeldaTex_003178" OutName="object_horse_zeldaTex_003178" Format="rgba16" Width="16" Height="8" Offset="0x3178" AddedByScript="true"/>
+        <Texture Name="object_horse_zeldaTex_003278" OutName="object_horse_zeldaTex_003278" Format="rgba16" Width="8" Height="16" Offset="0x3278" AddedByScript="true"/>
+        <Texture Name="object_horse_zeldaTex_003378" OutName="object_horse_zeldaTex_003378" Format="rgba16" Width="8" Height="8" Offset="0x3378" AddedByScript="true"/>
+        <Texture Name="object_horse_zeldaTex_0033F8" OutName="object_horse_zeldaTex_0033F8" Format="rgba16" Width="8" Height="16" Offset="0x33F8" AddedByScript="true"/>
+        <Texture Name="object_horse_zeldaTex_0034F8" OutName="object_horse_zeldaTex_0034F8" Format="rgba16" Width="16" Height="16" Offset="0x34F8" AddedByScript="true"/>
         <Skeleton Name="gHorseZeldaSkel" Type="Normal" LimbType="Skin" Offset="0x6B2C"/>
 
         <!-- Running. -->

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_jya_obj.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_jya_obj.xml
@@ -1,5 +1,12 @@
 <Root>
     <File Name="object_jya_obj" Segment="6">
+        <Texture Name="object_jya_objTex_00B4B8" OutName="object_jya_objTex_00B4B8" Format="ci8" Width="32" Height="32" Offset="0xB4B8" TlutOffset="0xAC70" AddedByScript="true"/>
+        <Texture Name="object_jya_objTex_011A80" OutName="object_jya_objTex_011A80" Format="ci4" Width="64" Height="64" Offset="0x11A80" TlutOffset="0x11A60" AddedByScript="true"/>
+        <Texture Name="object_jya_objTex_016140" OutName="object_jya_objTex_016140" Format="rgba16" Width="64" Height="32" Offset="0x16140" AddedByScript="true"/>
+        <Texture Name="object_jya_objTex_017140" OutName="object_jya_objTex_017140" Format="rgba16" Width="32" Height="16" Offset="0x17140" AddedByScript="true"/>
+        <Texture Name="object_jya_objTex_01B340" OutName="object_jya_objTex_01B340" Format="ia8" Width="32" Height="32" Offset="0x1B340" AddedByScript="true"/>
+        <Texture Name="object_jya_objTex_01B740" OutName="object_jya_objTex_01B740" Format="rgba16" Width="16" Height="16" Offset="0x1B740" AddedByScript="true"/>
+        <Texture Name="object_jya_objTLUT_011A60" OutName="object_jya_objTLUT_011A60" Format="rgba16" Width="4" Height="4" Offset="0x11A60" AddedByScript="true"/>
         <DList Name="g1fliftDL" Offset="0x1F0"/>
         <Collision Name="g1fliftCol" Offset="0x4A8"/>
         <Texture Name="g1f1fiftTopTex" OutName="1flift_top" Format="rgba16" Width="32" Height="32" Offset="0x1B940"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_link_boy.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_link_boy.xml
@@ -1,5 +1,12 @@
 <Root>
     <File Name="object_link_boy" Segment="6">
+        <Texture Name="object_link_boyTLUT_005400" OutName="object_link_boyTLUT_005400" Format="rgba16" Width="16" Height="16" Offset="0x5400" AddedByScript="true"/>
+        <Texture Name="object_link_boyTLUT_005800" OutName="object_link_boyTLUT_005800" Format="rgba16" Width="16" Height="16" Offset="0x5800" AddedByScript="true"/>
+        <Texture Name="object_link_boyTLUT_005A00" OutName="object_link_boyTLUT_005A00" Format="rgba16" Width="16" Height="16" Offset="0x5A00" AddedByScript="true"/>
+        <Texture Name="object_link_boyTLUT_00CB40" OutName="object_link_boyTLUT_00CB40" Format="rgba16" Width="16" Height="16" Offset="0xCB40" AddedByScript="true"/>
+        <Texture Name="object_link_boyTLUT_00CD48" OutName="object_link_boyTLUT_00CD48" Format="rgba16" Width="16" Height="16" Offset="0xCD48" AddedByScript="true"/>
+        <Texture Name="object_link_boyTLUT_00CF50" OutName="object_link_boyTLUT_00CF50" Format="rgba16" Width="16" Height="16" Offset="0xCF50" AddedByScript="true"/>
+        <Texture Name="object_link_boyTLUT_00D078" OutName="object_link_boyTLUT_00D078" Format="rgba16" Width="16" Height="16" Offset="0xD078" AddedByScript="true"/>
         <Skeleton Name="gLinkAdultSkel" Type="Flex" LimbType="LOD" Offset="0x377F4"/>
 
         <!-- Far Limb DLists-->

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_masterkokirihead.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_masterkokirihead.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_masterkokirihead" Segment="6">
+        <Texture Name="object_masterkokiriheadTex_0009F0" OutName="object_masterkokiriheadTex_0009F0" Format="ci8" Width="8" Height="8" Offset="0x9F0" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_masterkokiriheadTex_000A30" OutName="object_masterkokiriheadTex_000A30" Format="ci8" Width="16" Height="16" Offset="0xA30" TlutOffset="0x0" AddedByScript="true"/>
         <DList Name="gKokiriShopkeeperHeadDL" Offset="0x2820"/>
         <Texture Name="gKokiriShopkeeperTLUT" OutName="tlut" Format="rgba16" Width="248" Height="1" Offset="0x0"/>
         <Texture Name="gKokiriShopkeeperEyeHalfTex" OutName="eye_half" Format="rgba16" Width="32" Height="32" Offset="0x1F0"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_mb.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_mb.xml
@@ -1,5 +1,19 @@
 <Root>
     <File Name="object_mb" Segment="6">
+        <Texture Name="object_mbTex_008128" OutName="object_mbTex_008128" Format="rgba16" Width="16" Height="16" Offset="0x8128" AddedByScript="true"/>
+        <Texture Name="object_mbTex_008328" OutName="object_mbTex_008328" Format="rgba16" Width="8" Height="32" Offset="0x8328" AddedByScript="true"/>
+        <Texture Name="object_mbTex_008928" OutName="object_mbTex_008928" Format="rgba16" Width="8" Height="16" Offset="0x8928" AddedByScript="true"/>
+        <Texture Name="object_mbTex_008A28" OutName="object_mbTex_008A28" Format="rgba16" Width="4" Height="4" Offset="0x8A28" AddedByScript="true"/>
+        <Texture Name="object_mbTex_008A48" OutName="object_mbTex_008A48" Format="rgba16" Width="8" Height="24" Offset="0x8A48" AddedByScript="true"/>
+        <Texture Name="object_mbTex_008BC8" OutName="object_mbTex_008BC8" Format="rgba16" Width="4" Height="16" Offset="0x8BC8" AddedByScript="true"/>
+        <Texture Name="object_mbTex_008C48" OutName="object_mbTex_008C48" Format="rgba16" Width="4" Height="8" Offset="0x8C48" AddedByScript="true"/>
+        <Texture Name="object_mbTex_008C88" OutName="object_mbTex_008C88" Format="rgba16" Width="8" Height="16" Offset="0x8C88" AddedByScript="true"/>
+        <Texture Name="object_mbTex_00EC00" OutName="object_mbTex_00EC00" Format="rgba16" Width="16" Height="16" Offset="0xEC00" AddedByScript="true"/>
+        <Texture Name="object_mbTex_00EE00" OutName="object_mbTex_00EE00" Format="rgba16" Width="8" Height="16" Offset="0xEE00" AddedByScript="true"/>
+        <Texture Name="object_mbTex_00EF00" OutName="object_mbTex_00EF00" Format="rgba16" Width="8" Height="16" Offset="0xEF00" AddedByScript="true"/>
+        <Texture Name="object_mbTex_00F000" OutName="object_mbTex_00F000" Format="rgba16" Width="16" Height="16" Offset="0xF000" AddedByScript="true"/>
+        <Texture Name="object_mbTex_00F200" OutName="object_mbTex_00F200" Format="rgba16" Width="4" Height="16" Offset="0xF200" AddedByScript="true"/>
+        <Texture Name="object_mbTex_00F280" OutName="object_mbTex_00F280" Format="rgba16" Width="4" Height="16" Offset="0xF280" AddedByScript="true"/>
         <Skeleton Name="gEnMbSpearSkel" Type="Flex" LimbType="Standard" Offset="0x8F38"/>
         <Skeleton Name="gEnMbClubSkel" Type="Flex" LimbType="Standard" Offset="0x14190"/>
         <Animation Name="gEnMbSpearFallFaceDownAnim" Offset="0x6A4"/><!--Unused-->

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_mizu_objects.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_mizu_objects.xml
@@ -1,5 +1,19 @@
 <Root>
     <File Name="object_mizu_objects" Segment="6">
+        <Texture Name="object_mizu_objectsTex_004C00" OutName="object_mizu_objectsTex_004C00" Format="rgba16" Width="32" Height="64" Offset="0x4C00" AddedByScript="true"/>
+        <Texture Name="object_mizu_objectsTex_005E70" OutName="object_mizu_objectsTex_005E70" Format="rgba16" Width="32" Height="64" Offset="0x5E70" AddedByScript="true"/>
+        <Texture Name="object_mizu_objectsTex_007520" OutName="object_mizu_objectsTex_007520" Format="ia16" Width="32" Height="32" Offset="0x7520" AddedByScript="true"/>
+        <Texture Name="object_mizu_objectsTex_007D20" OutName="object_mizu_objectsTex_007D20" Format="rgba16" Width="32" Height="32" Offset="0x7D20" AddedByScript="true"/>
+        <Texture Name="object_mizu_objectsTex_008520" OutName="object_mizu_objectsTex_008520" Format="rgba16" Width="32" Height="32" Offset="0x8520" AddedByScript="true"/>
+        <Texture Name="object_mizu_objectsTex_008D20" OutName="object_mizu_objectsTex_008D20" Format="rgba16" Width="32" Height="32" Offset="0x8D20" AddedByScript="true"/>
+        <Texture Name="object_mizu_objectsTex_009520" OutName="object_mizu_objectsTex_009520" Format="i4" Width="32" Height="32" Offset="0x9520" AddedByScript="true"/>
+        <Texture Name="object_mizu_objectsTex_009720" OutName="object_mizu_objectsTex_009720" Format="i4" Width="32" Height="32" Offset="0x9720" AddedByScript="true"/>
+        <Texture Name="object_mizu_objectsTex_009920" OutName="object_mizu_objectsTex_009920" Format="i4" Width="32" Height="32" Offset="0x9920" AddedByScript="true"/>
+        <Texture Name="object_mizu_objectsTex_009B20" OutName="object_mizu_objectsTex_009B20" Format="i4" Width="32" Height="32" Offset="0x9B20" AddedByScript="true"/>
+        <Texture Name="object_mizu_objectsTex_009D20" OutName="object_mizu_objectsTex_009D20" Format="i4" Width="32" Height="32" Offset="0x9D20" AddedByScript="true"/>
+        <Texture Name="object_mizu_objectsTex_009F20" OutName="object_mizu_objectsTex_009F20" Format="rgba16" Width="32" Height="32" Offset="0x9F20" AddedByScript="true"/>
+        <Texture Name="object_mizu_objectsTex_00A720" OutName="object_mizu_objectsTex_00A720" Format="rgba16" Width="16" Height="32" Offset="0xA720" AddedByScript="true"/>
+        <Texture Name="object_mizu_objectsTex_00AB20" OutName="object_mizu_objectsTex_00AB20" Format="i4" Width="64" Height="64" Offset="0xAB20" AddedByScript="true"/>
         <DList Name="gObjectMizuObjectsMovebgDL_000190" Offset="0x0190"/>
         <Collision Name="gObjectMizuObjectsMovebgCol_0003F0" Offset="0x03F0"/>
         <DList Name="gObjectMizuObjectsMovebgDL_000680" Offset="0x0680"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_mm.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_mm.xml
@@ -1,5 +1,14 @@
 <Root>
     <File Name="object_mm" Segment="6">
+        <Texture Name="object_mmTex_000930" OutName="object_mmTex_000930" Format="ci8" Width="8" Height="8" Offset="0x930" TlutOffset="0x730" AddedByScript="true"/>
+        <Texture Name="object_mmTex_000970" OutName="object_mmTex_000970" Format="ci8" Width="8" Height="8" Offset="0x970" TlutOffset="0x730" AddedByScript="true"/>
+        <Texture Name="object_mmTex_0009B0" OutName="object_mmTex_0009B0" Format="ci8" Width="8" Height="8" Offset="0x9B0" TlutOffset="0x730" AddedByScript="true"/>
+        <Texture Name="object_mmTex_0009F0" OutName="object_mmTex_0009F0" Format="ci8" Width="8" Height="8" Offset="0x9F0" TlutOffset="0x730" AddedByScript="true"/>
+        <Texture Name="object_mmTex_000A30" OutName="object_mmTex_000A30" Format="ci8" Width="16" Height="16" Offset="0xA30" TlutOffset="0x730" AddedByScript="true"/>
+        <Texture Name="object_mmTex_000B30" OutName="object_mmTex_000B30" Format="ci8" Width="16" Height="16" Offset="0xB30" TlutOffset="0x730" AddedByScript="true"/>
+        <Texture Name="object_mmTex_001030" OutName="object_mmTex_001030" Format="ci8" Width="16" Height="16" Offset="0x1030" TlutOffset="0x730" AddedByScript="true"/>
+        <Texture Name="object_mmTex_001130" OutName="object_mmTex_001130" Format="ci8" Width="32" Height="16" Offset="0x1130" TlutOffset="0x730" AddedByScript="true"/>
+        <Texture Name="object_mmTex_001330" OutName="object_mmTex_001330" Format="ci8" Width="16" Height="16" Offset="0x1330" TlutOffset="0x730" AddedByScript="true"/>
         <Skeleton Name="gRunningManSkel" Type="Flex" LimbType="Standard" Offset="0x5E18"/>
 
         <Animation Name="gRunningManRunAnim" Offset="0x0718"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_mo.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_mo.xml
@@ -1,5 +1,10 @@
 <Root>
     <File Name="object_mo" Segment="6">
+        <Texture Name="object_moTex_000000" OutName="object_moTex_000000" Format="ia8" Width="16" Height="16" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="object_moTex_000680" OutName="object_moTex_000680" Format="rgba16" Width="32" Height="32" Offset="0x680" AddedByScript="true"/>
+        <Texture Name="object_moTex_004D20" OutName="object_moTex_004D20" Format="ia16" Width="32" Height="32" Offset="0x4D20" AddedByScript="true"/>
+        <Texture Name="object_moTex_005520" OutName="object_moTex_005520" Format="ia16" Width="32" Height="32" Offset="0x5520" AddedByScript="true"/>
+        <Texture Name="object_moTex_005D20" OutName="object_moTex_005D20" Format="ia16" Width="32" Height="32" Offset="0x5D20" AddedByScript="true"/>
         <!-- Morpha's Title Card -->
         <Texture Name="gMorphaTitleCardTex" Format="i8" Width="128" Height="120" Offset="0x1010"/>
         <Texture Name="gMorphaWaterTex" Format="rgba16" Width="32" Height="32" Offset="0x8870"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_oE1s.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_oE1s.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_oE1s" Segment="6">
+        <Texture Name="object_oE1sTex_000478" OutName="object_oE1sTex_000478" Format="ci8" Width="32" Height="32" Offset="0x478" TlutOffset="0x1A8" AddedByScript="true"/>
+        <Texture Name="object_oE1sTLUT_0001A8" OutName="object_oE1sTLUT_0001A8" Format="rgba16" Width="16" Height="16" Offset="0x1A8" AddedByScript="true"/>
         <Animation Name="object_oE1s_Anim_00007C" Offset="0x7C"/>
         <Limb Name="object_oE1s_Limb_000090" LimbType="Standard" Offset="0x90"/>
         <Limb Name="object_oE1s_Limb_00009C" LimbType="Standard" Offset="0x9C"/>
@@ -21,15 +23,15 @@
         <!--Blob Name="object_oE1s_Blob_00019C" Size="0x204" Offset="0x19C" /-->
         <Texture Name="object_oE1s_TLUT_0003A0" OutName="tlut_000003A0" Format="rgba16" Width="108" Height="1" Offset="0x3A0"/>
         <!--Blob Name="object_oE1s_Blob_0005A0" Size="0x2D8" Offset="0x5A0" /-->
-        <Texture Name="object_oE1s_Tex_000878" OutName="tex_00000878" Format="ci8" Width="8" Height="8" Offset="0x878"  TlutOffset="0x3A0"/>
+        <Texture Name="object_oE1s_Tex_000878" OutName="tex_00000878" Format="ci8" Width="8" Height="8" Offset="0x878" TlutOffset="0x3A0"/>
         <Texture Name="object_oE1s_Tex_0008B8" OutName="tex_000008B8" Format="rgba16" Width="16" Height="32" Offset="0x8B8"/>
         <Texture Name="object_oE1s_Tex_000CB8" OutName="tex_00000CB8" Format="rgba16" Width="32" Height="32" Offset="0xCB8"/>
-        <Texture Name="object_oE1s_Tex_0014B8" OutName="tex_000014B8" Format="ci8" Width="16" Height="16" Offset="0x14B8"  TlutOffset="0x3A0"/>
+        <Texture Name="object_oE1s_Tex_0014B8" OutName="tex_000014B8" Format="ci8" Width="16" Height="16" Offset="0x14B8" TlutOffset="0x3A0"/>
         <Texture Name="object_oE1s_Tex_0015B8" OutName="tex_000015B8" Format="i4" Width="16" Height="8" Offset="0x15B8"/>
         <Blob Name="object_oE1s_Blob_0015F8" Size="0x400" Offset="0x15F8"/>
         <Texture Name="object_oE1s_Tex_0019F8" OutName="tex_000019F8" Format="i4" Width="16" Height="16" Offset="0x19F8"/>
         <Texture Name="object_oE1s_Tex_001A78" OutName="tex_00001A78" Format="rgba16" Width="16" Height="8" Offset="0x1A78"/>
-        <Texture Name="object_oE1s_Tex_001B78" OutName="tex_00001B78" Format="ci8" Width="16" Height="16" Offset="0x1B78"  TlutOffset="0x3A0"/>
+        <Texture Name="object_oE1s_Tex_001B78" OutName="tex_00001B78" Format="ci8" Width="16" Height="16" Offset="0x1B78" TlutOffset="0x3A0"/>
         <Blob Name="object_oE1s_Blob_001C78" Size="0x400" Offset="0x1C78"/>
         <DList Name="object_oE1s_DL_004D98" Offset="0x4D98"/>
         <DList Name="object_oE1s_DL_005010" Offset="0x5010"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_oE4s.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_oE4s.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_oE4s" Segment="6">
+        <Texture Name="object_oE4sTex_0002A0" OutName="object_oE4sTex_0002A0" Format="ci8" Width="16" Height="16" Offset="0x2A0" TlutOffset="0x1A8" AddedByScript="true"/>
+        <Texture Name="object_oE4sTex_0003A0" OutName="object_oE4sTex_0003A0" Format="ci8" Width="16" Height="16" Offset="0x3A0" TlutOffset="0x1A8" AddedByScript="true"/>
         <Animation Name="object_oE4s_Anim_00007C" Offset="0x7C"/>
         <Limb Name="object_oE4s_Limb_000090" LimbType="Standard" Offset="0x90"/>
         <Limb Name="object_oE4s_Limb_00009C" LimbType="Standard" Offset="0x9C"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_oF1d_map.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_oF1d_map.xml
@@ -1,5 +1,22 @@
 <Root>
     <File Name="object_oF1d_map" Segment="6">
+        <Texture Name="object_oF1d_mapTex_009270" OutName="object_oF1d_mapTex_009270" Format="ci8" Width="8" Height="8" Offset="0x9270" TlutOffset="0x9130" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_0092B0" OutName="object_oF1d_mapTex_0092B0" Format="ci8" Width="8" Height="8" Offset="0x92B0" TlutOffset="0x9130" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_0092F0" OutName="object_oF1d_mapTex_0092F0" Format="ci8" Width="8" Height="16" Offset="0x92F0" TlutOffset="0x9130" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_009370" OutName="object_oF1d_mapTex_009370" Format="ci8" Width="32" Height="64" Offset="0x9370" TlutOffset="0x9130" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_009B70" OutName="object_oF1d_mapTex_009B70" Format="ci8" Width="16" Height="16" Offset="0x9B70" TlutOffset="0x9130" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_009C70" OutName="object_oF1d_mapTex_009C70" Format="rgba16" Width="64" Height="32" Offset="0x9C70" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_00C840" OutName="object_oF1d_mapTex_00C840" Format="ci8" Width="8" Height="8" Offset="0xC840" TlutOffset="0xC440" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_00C880" OutName="object_oF1d_mapTex_00C880" Format="ci8" Width="32" Height="16" Offset="0xC880" TlutOffset="0xC440" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_00CA80" OutName="object_oF1d_mapTex_00CA80" Format="ci8" Width="32" Height="32" Offset="0xCA80" TlutOffset="0xC440" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_00EE80" OutName="object_oF1d_mapTex_00EE80" Format="ci8" Width="32" Height="64" Offset="0xEE80" TlutOffset="0xC440" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_00F680" OutName="object_oF1d_mapTex_00F680" Format="ci8" Width="8" Height="8" Offset="0xF680" TlutOffset="0xC440" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_00F6C0" OutName="object_oF1d_mapTex_00F6C0" Format="ci8" Width="16" Height="16" Offset="0xF6C0" TlutOffset="0xC440" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_00F7C0" OutName="object_oF1d_mapTex_00F7C0" Format="ci8" Width="16" Height="16" Offset="0xF7C0" TlutOffset="0xC440" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_00F8C0" OutName="object_oF1d_mapTex_00F8C0" Format="ci8" Width="32" Height="32" Offset="0xF8C0" TlutOffset="0xC440" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_00FCC0" OutName="object_oF1d_mapTex_00FCC0" Format="ci8" Width="8" Height="16" Offset="0xFCC0" TlutOffset="0xC440" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTLUT_009130" OutName="object_oF1d_mapTLUT_009130" Format="rgba16" Width="16" Height="16" Offset="0x9130" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTLUT_00C440" OutName="object_oF1d_mapTLUT_00C440" Format="rgba16" Width="16" Height="16" Offset="0xC440" AddedByScript="true"/>
         <!-- animations -->
         <Animation Name="gGoronAnim_000750" Offset="0x750"/>
         <Animation Name="gGoronAnim_000D5C" Offset="0xD5C"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_ossan.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_ossan.xml
@@ -1,5 +1,15 @@
 <Root>
     <File Name="object_ossan" Segment="6">
+        <Texture Name="object_ossanTex_005078" OutName="object_ossanTex_005078" Format="ci8" Width="16" Height="16" Offset="0x5078" TlutOffset="0x4728" AddedByScript="true"/>
+        <Texture Name="object_ossanTex_005178" OutName="object_ossanTex_005178" Format="ci8" Width="16" Height="16" Offset="0x5178" TlutOffset="0x4728" AddedByScript="true"/>
+        <Texture Name="object_ossanTex_005278" OutName="object_ossanTex_005278" Format="ci8" Width="8" Height="8" Offset="0x5278" TlutOffset="0x4728" AddedByScript="true"/>
+        <Texture Name="object_ossanTex_005AB8" OutName="object_ossanTex_005AB8" Format="ci8" Width="8" Height="8" Offset="0x5AB8" TlutOffset="0x4728" AddedByScript="true"/>
+        <Texture Name="object_ossanTex_008A38" OutName="object_ossanTex_008A38" Format="rgba16" Width="8" Height="8" Offset="0x8A38" AddedByScript="true"/>
+        <Texture Name="object_ossanTex_008AB8" OutName="object_ossanTex_008AB8" Format="rgba16" Width="16" Height="16" Offset="0x8AB8" AddedByScript="true"/>
+        <Texture Name="object_ossanTex_008CB8" OutName="object_ossanTex_008CB8" Format="rgba16" Width="16" Height="16" Offset="0x8CB8" AddedByScript="true"/>
+        <Texture Name="object_ossanTex_008EB8" OutName="object_ossanTex_008EB8" Format="rgba16" Width="32" Height="32" Offset="0x8EB8" AddedByScript="true"/>
+        <Texture Name="object_ossanTex_0096B8" OutName="object_ossanTex_0096B8" Format="rgba16" Width="16" Height="16" Offset="0x96B8" AddedByScript="true"/>
+        <Texture Name="object_ossanTex_0098B8" OutName="object_ossanTex_0098B8" Format="rgba16" Width="16" Height="16" Offset="0x98B8" AddedByScript="true"/>
         <Animation Name="gObjectOssanAnim_000338" Offset="0x338"/>
         <Texture Name="gOssanEyesTLUT" OutName="ossan_eyes_tlut" Format="rgba16" Width="63" Height="4" Offset="0x4530"/>
         <Texture Name="gOssanTLUT" OutName="ossan_tlut" Format="rgba16" Width="168" Height="1" Offset="0x4728"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_owl.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_owl.xml
@@ -1,5 +1,13 @@
 <Root>
     <File Name="object_owl" Segment="6">
+        <Texture Name="object_owlTex_0071A8" OutName="object_owlTex_0071A8" Format="rgba16" Width="32" Height="32" Offset="0x71A8" AddedByScript="true"/>
+        <Texture Name="object_owlTex_0079A8" OutName="object_owlTex_0079A8" Format="rgba16" Width="32" Height="32" Offset="0x79A8" AddedByScript="true"/>
+        <Texture Name="object_owlTex_0081A8" OutName="object_owlTex_0081A8" Format="rgba16" Width="32" Height="32" Offset="0x81A8" AddedByScript="true"/>
+        <Texture Name="object_owlTex_0095A8" OutName="object_owlTex_0095A8" Format="rgba16" Width="32" Height="32" Offset="0x95A8" AddedByScript="true"/>
+        <Texture Name="object_owlTex_009DA8" OutName="object_owlTex_009DA8" Format="rgba16" Width="16" Height="16" Offset="0x9DA8" AddedByScript="true"/>
+        <Texture Name="object_owlTex_009FA8" OutName="object_owlTex_009FA8" Format="rgba16" Width="64" Height="32" Offset="0x9FA8" AddedByScript="true"/>
+        <Texture Name="object_owlTex_00AFA8" OutName="object_owlTex_00AFA8" Format="rgba16" Width="32" Height="32" Offset="0xAFA8" AddedByScript="true"/>
+        <Texture Name="object_owlTex_00B7A8" OutName="object_owlTex_00B7A8" Format="rgba16" Width="32" Height="32" Offset="0xB7A8" AddedByScript="true"/>
         <!-- Flying Owl Skeleton -->
         <Skeleton Name="gOwlFlyingSkel" Type="Flex" LimbType="Standard" Offset="0xC0E8"/>
 
@@ -53,11 +61,17 @@
         <Animation Name="gOwlGlideAnim" Offset="0xC1C4"/>
         <Animation Name="gOwlUnfoldWingsAnim" Offset="0xC684"/>
         <Animation Name="gOwlPerchAnim" Offset="0xC8A0"/>
-        
-        <!-- Owl Perching Skeleton -->
-        <Skeleton Name="gOwlPerchingSkel" Type="Flex" LimbType="Standard" Offset="0x100B0"/>  
 
-        <!-- Eye Textures -->      
+        <!-- Owl Perching Skeleton -->
+        <Skeleton Name="gOwlPerchingSkel" Type="Flex" LimbType="Standard" Offset="0x100B0"/>
+
+        <!-- The two following TLUTs are identical and both are used as TLUTs for the eye textures -->
+        <!-- TLUT used in gOwlPerchingSkel -->
+        <Texture Name="object_owl_TLUT_006DA8" OutName="tlut_00006DA8" Format="rgba16" Width="16" Height="16" Offset="0x6DA8"/>
+        <!-- TLUT used in gOwlFlyingSkel -->
+        <Texture Name="object_owl_TLUT_006FA8" OutName="tlut_00006FA8" Format="rgba16" Width="16" Height="16" Offset="0x6FA8"/>
+
+        <!-- Eye Textures -->
         <Texture Name="gObjOwlEyeOpenTex" OutName="owl_eye_open" Format="ci8" Width="32" Height="32" Offset="0x89A8"/>
         <Texture Name="gObjOwlEyeHalfTex" OutName="owl_eye_half" Format="ci8" Width="32" Height="32" Offset="0x8DA8"/>
         <Texture Name="gObjOwlEyeClosedTex" OutName="owl_eye_closed" Format="ci8" Width="32" Height="32" Offset="0x91A8"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_po_composer.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_po_composer.xml
@@ -1,5 +1,18 @@
 <Root>
     <File Name="object_po_composer" Segment="6">
+        <Texture Name="object_po_composerTex_001450" OutName="object_po_composerTex_001450" Format="i8" Width="32" Height="64" Offset="0x1450" AddedByScript="true"/>
+        <Texture Name="object_po_composerTex_0054E0" OutName="object_po_composerTex_0054E0" Format="rgba16" Width="16" Height="16" Offset="0x54E0" AddedByScript="true"/>
+        <Texture Name="object_po_composerTex_0056E0" OutName="object_po_composerTex_0056E0" Format="rgba16" Width="16" Height="16" Offset="0x56E0" AddedByScript="true"/>
+        <Texture Name="object_po_composerTex_0058E0" OutName="object_po_composerTex_0058E0" Format="rgba16" Width="16" Height="16" Offset="0x58E0" AddedByScript="true"/>
+        <Texture Name="object_po_composerTex_005AE0" OutName="object_po_composerTex_005AE0" Format="rgba16" Width="16" Height="16" Offset="0x5AE0" AddedByScript="true"/>
+        <Texture Name="object_po_composerTex_005CE0" OutName="object_po_composerTex_005CE0" Format="rgba16" Width="16" Height="32" Offset="0x5CE0" AddedByScript="true"/>
+        <Texture Name="object_po_composerTex_0060E0" OutName="object_po_composerTex_0060E0" Format="rgba16" Width="16" Height="16" Offset="0x60E0" AddedByScript="true"/>
+        <Texture Name="object_po_composerTex_0062E0" OutName="object_po_composerTex_0062E0" Format="rgba16" Width="16" Height="16" Offset="0x62E0" AddedByScript="true"/>
+        <Texture Name="object_po_composerTex_0064E0" OutName="object_po_composerTex_0064E0" Format="rgba16" Width="16" Height="16" Offset="0x64E0" AddedByScript="true"/>
+        <Texture Name="object_po_composerTex_0066E0" OutName="object_po_composerTex_0066E0" Format="rgba16" Width="16" Height="16" Offset="0x66E0" AddedByScript="true"/>
+        <Texture Name="object_po_composerTex_0068E0" OutName="object_po_composerTex_0068E0" Format="rgba16" Width="16" Height="16" Offset="0x68E0" AddedByScript="true"/>
+        <Texture Name="object_po_composerTex_006AE0" OutName="object_po_composerTex_006AE0" Format="rgba16" Width="16" Height="16" Offset="0x6AE0" AddedByScript="true"/>
+        <Texture Name="object_po_composerTex_006CE0" OutName="object_po_composerTex_006CE0" Format="rgba16" Width="16" Height="16" Offset="0x6CE0" AddedByScript="true"/>
         <Animation Name="gPoeComposerAttackAnim" Offset="0x020C"/>
         <Animation Name="gPoeComposerDamagedAnim" Offset="0x0570"/>
         <Animation Name="gPoeComposerFleeAnim" Offset="0x0708"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_po_field.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_po_field.xml
@@ -1,5 +1,16 @@
 <Root>
     <File Name="object_po_field" Segment="6">
+        <Texture Name="object_po_fieldTex_002470" OutName="object_po_fieldTex_002470" Format="rgba16" Width="16" Height="16" Offset="0x2470" AddedByScript="true"/>
+        <Texture Name="object_po_fieldTex_002670" OutName="object_po_fieldTex_002670" Format="rgba16" Width="16" Height="16" Offset="0x2670" AddedByScript="true"/>
+        <Texture Name="object_po_fieldTex_002870" OutName="object_po_fieldTex_002870" Format="rgba16" Width="32" Height="32" Offset="0x2870" AddedByScript="true"/>
+        <Texture Name="object_po_fieldTex_003070" OutName="object_po_fieldTex_003070" Format="rgba16" Width="16" Height="16" Offset="0x3070" AddedByScript="true"/>
+        <Texture Name="object_po_fieldTex_003270" OutName="object_po_fieldTex_003270" Format="rgba16" Width="8" Height="8" Offset="0x3270" AddedByScript="true"/>
+        <Texture Name="object_po_fieldTex_0032F0" OutName="object_po_fieldTex_0032F0" Format="rgba16" Width="16" Height="8" Offset="0x32F0" AddedByScript="true"/>
+        <Texture Name="object_po_fieldTex_0033F0" OutName="object_po_fieldTex_0033F0" Format="rgba16" Width="16" Height="16" Offset="0x33F0" AddedByScript="true"/>
+        <Texture Name="object_po_fieldTex_0035F0" OutName="object_po_fieldTex_0035F0" Format="rgba16" Width="16" Height="16" Offset="0x35F0" AddedByScript="true"/>
+        <Texture Name="object_po_fieldTex_0037F0" OutName="object_po_fieldTex_0037F0" Format="rgba16" Width="16" Height="16" Offset="0x37F0" AddedByScript="true"/>
+        <Texture Name="object_po_fieldTex_005AB0" OutName="object_po_fieldTex_005AB0" Format="rgba16" Width="16" Height="16" Offset="0x5AB0" AddedByScript="true"/>
+        <Texture Name="object_po_fieldTex_005CB0" OutName="object_po_fieldTex_005CB0" Format="rgba16" Width="8" Height="8" Offset="0x5CB0" AddedByScript="true"/>
         <Animation Name="gPoeFieldAttackAnim" Offset="0x0158"/>
         <Animation Name="gPoeFieldDamagedAnim" Offset="0x0454"/>
         <Animation Name="gPoeFieldFleeAnim" Offset="0x0608"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_po_sisters.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_po_sisters.xml
@@ -1,5 +1,33 @@
 <Root>
     <File Name="object_po_sisters" Segment="6">
+        <Texture Name="object_po_sistersTex_0048D8" OutName="object_po_sistersTex_0048D8" Format="rgba16" Width="16" Height="16" Offset="0x48D8" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_004AD8" OutName="object_po_sistersTex_004AD8" Format="rgba16" Width="32" Height="32" Offset="0x4AD8" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_0052D8" OutName="object_po_sistersTex_0052D8" Format="rgba16" Width="32" Height="16" Offset="0x52D8" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_0056D8" OutName="object_po_sistersTex_0056D8" Format="rgba16" Width="16" Height="16" Offset="0x56D8" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_0058D8" OutName="object_po_sistersTex_0058D8" Format="rgba16" Width="4" Height="4" Offset="0x58D8" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_0058F8" OutName="object_po_sistersTex_0058F8" Format="rgba16" Width="16" Height="16" Offset="0x58F8" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_005AF8" OutName="object_po_sistersTex_005AF8" Format="rgba16" Width="16" Height="16" Offset="0x5AF8" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_005CF8" OutName="object_po_sistersTex_005CF8" Format="rgba16" Width="8" Height="8" Offset="0x5CF8" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_005D78" OutName="object_po_sistersTex_005D78" Format="rgba16" Width="16" Height="16" Offset="0x5D78" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_005F78" OutName="object_po_sistersTex_005F78" Format="rgba16" Width="16" Height="8" Offset="0x5F78" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_006078" OutName="object_po_sistersTex_006078" Format="rgba16" Width="16" Height="16" Offset="0x6078" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_006278" OutName="object_po_sistersTex_006278" Format="rgba16" Width="8" Height="8" Offset="0x6278" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_0062F8" OutName="object_po_sistersTex_0062F8" Format="rgba16" Width="4" Height="4" Offset="0x62F8" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_006318" OutName="object_po_sistersTex_006318" Format="rgba16" Width="16" Height="16" Offset="0x6318" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_007AC0" OutName="object_po_sistersTex_007AC0" Format="rgba16" Width="32" Height="32" Offset="0x7AC0" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_0082C0" OutName="object_po_sistersTex_0082C0" Format="rgba16" Width="8" Height="16" Offset="0x82C0" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_0083C0" OutName="object_po_sistersTex_0083C0" Format="rgba16" Width="32" Height="32" Offset="0x83C0" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_008BC0" OutName="object_po_sistersTex_008BC0" Format="rgba16" Width="32" Height="32" Offset="0x8BC0" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_0093C0" OutName="object_po_sistersTex_0093C0" Format="rgba16" Width="32" Height="32" Offset="0x93C0" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_009BC0" OutName="object_po_sistersTex_009BC0" Format="rgba16" Width="32" Height="32" Offset="0x9BC0" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_00A3C0" OutName="object_po_sistersTex_00A3C0" Format="rgba16" Width="32" Height="32" Offset="0xA3C0" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_00ABC0" OutName="object_po_sistersTex_00ABC0" Format="rgba16" Width="32" Height="32" Offset="0xABC0" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_00B3C0" OutName="object_po_sistersTex_00B3C0" Format="rgba16" Width="32" Height="32" Offset="0xB3C0" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_00BBC0" OutName="object_po_sistersTex_00BBC0" Format="rgba16" Width="32" Height="32" Offset="0xBBC0" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_00C3C0" OutName="object_po_sistersTex_00C3C0" Format="rgba16" Width="32" Height="32" Offset="0xC3C0" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_00CBC0" OutName="object_po_sistersTex_00CBC0" Format="rgba16" Width="32" Height="32" Offset="0xCBC0" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_00D3C0" OutName="object_po_sistersTex_00D3C0" Format="rgba16" Width="32" Height="32" Offset="0xD3C0" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_00DBC0" OutName="object_po_sistersTex_00DBC0" Format="rgba16" Width="32" Height="32" Offset="0xDBC0" AddedByScript="true"/>
         <Animation Name="gPoeSistersAttackAnim" Offset="0x0114"/>
         <Animation Name="gPoeSistersMegCryAnim" Offset="0x0680"/>
         <Animation Name="gPoeSistersDamagedAnim" Offset="0x08C0"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_poh.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_poh.xml
@@ -1,5 +1,16 @@
 <Root>
     <File Name="object_poh" Segment="6">
+        <Texture Name="object_pohTex_003010" OutName="object_pohTex_003010" Format="i8" Width="32" Height="64" Offset="0x3010" AddedByScript="true"/>
+        <Texture Name="object_pohTex_003910" OutName="object_pohTex_003910" Format="rgba16" Width="32" Height="16" Offset="0x3910" AddedByScript="true"/>
+        <Texture Name="object_pohTex_003D10" OutName="object_pohTex_003D10" Format="rgba16" Width="32" Height="32" Offset="0x3D10" AddedByScript="true"/>
+        <Texture Name="object_pohTex_004510" OutName="object_pohTex_004510" Format="rgba16" Width="16" Height="16" Offset="0x4510" AddedByScript="true"/>
+        <Texture Name="object_pohTex_004710" OutName="object_pohTex_004710" Format="rgba16" Width="8" Height="8" Offset="0x4710" AddedByScript="true"/>
+        <Texture Name="object_pohTex_004790" OutName="object_pohTex_004790" Format="rgba16" Width="16" Height="16" Offset="0x4790" AddedByScript="true"/>
+        <Texture Name="object_pohTex_004990" OutName="object_pohTex_004990" Format="rgba16" Width="8" Height="8" Offset="0x4990" AddedByScript="true"/>
+        <Texture Name="object_pohTex_004A10" OutName="object_pohTex_004A10" Format="rgba16" Width="8" Height="16" Offset="0x4A10" AddedByScript="true"/>
+        <Texture Name="object_pohTex_004B10" OutName="object_pohTex_004B10" Format="rgba16" Width="16" Height="16" Offset="0x4B10" AddedByScript="true"/>
+        <Texture Name="object_pohTex_004D10" OutName="object_pohTex_004D10" Format="rgba16" Width="16" Height="16" Offset="0x4D10" AddedByScript="true"/>
+        <Texture Name="object_pohTex_004F10" OutName="object_pohTex_004F10" Format="rgba16" Width="8" Height="8" Offset="0x4F10" AddedByScript="true"/>
         <Animation Name="gPoeAttackAnim" Offset="0x01A8"/>
         <Animation Name="gPoeDamagedAnim" Offset="0x04EC"/>
         <Animation Name="gPoeFleeAnim" Offset="0x06E0"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_ps.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_ps.xml
@@ -1,5 +1,28 @@
 <Root>
     <File Name="object_ps" Segment="6">
+        <Texture Name="object_psTex_0005B8" OutName="object_psTex_0005B8" Format="rgba16" Width="32" Height="64" Offset="0x5B8" AddedByScript="true"/>
+        <Texture Name="object_psTex_0015B8" OutName="object_psTex_0015B8" Format="ci8" Width="8" Height="8" Offset="0x15B8" TlutOffset="0x4B0" AddedByScript="true"/>
+        <Texture Name="object_psTex_0015F8" OutName="object_psTex_0015F8" Format="rgba16" Width="16" Height="16" Offset="0x15F8" AddedByScript="true"/>
+        <Texture Name="object_psTex_0017F8" OutName="object_psTex_0017F8" Format="ci8" Width="8" Height="8" Offset="0x17F8" TlutOffset="0x4B0" AddedByScript="true"/>
+        <Texture Name="object_psTex_001838" OutName="object_psTex_001838" Format="ci8" Width="32" Height="32" Offset="0x1838" TlutOffset="0x4B0" AddedByScript="true"/>
+        <Texture Name="object_psTex_001C38" OutName="object_psTex_001C38" Format="ci8" Width="16" Height="16" Offset="0x1C38" TlutOffset="0x4B0" AddedByScript="true"/>
+        <Texture Name="object_psTex_001D38" OutName="object_psTex_001D38" Format="i8" Width="8" Height="8" Offset="0x1D38" AddedByScript="true"/>
+        <Texture Name="object_psTex_001D78" OutName="object_psTex_001D78" Format="ci8" Width="16" Height="16" Offset="0x1D78" TlutOffset="0x4B0" AddedByScript="true"/>
+        <Texture Name="object_psTex_001E78" OutName="object_psTex_001E78" Format="ci8" Width="16" Height="16" Offset="0x1E78" TlutOffset="0x4B0" AddedByScript="true"/>
+        <Texture Name="object_psTex_001F78" OutName="object_psTex_001F78" Format="rgba16" Width="16" Height="16" Offset="0x1F78" AddedByScript="true"/>
+        <Texture Name="object_psTex_002178" OutName="object_psTex_002178" Format="rgba16" Width="16" Height="16" Offset="0x2178" AddedByScript="true"/>
+        <Texture Name="object_psTex_002378" OutName="object_psTex_002378" Format="i4" Width="32" Height="32" Offset="0x2378" AddedByScript="true"/>
+        <Texture Name="object_psTex_002578" OutName="object_psTex_002578" Format="ci8" Width="32" Height="32" Offset="0x2578" TlutOffset="0x4B0" AddedByScript="true"/>
+        <Texture Name="object_psTex_002978" OutName="object_psTex_002978" Format="rgba16" Width="8" Height="16" Offset="0x2978" AddedByScript="true"/>
+        <Texture Name="object_psTex_007180" OutName="object_psTex_007180" Format="ci8" Width="8" Height="8" Offset="0x7180" TlutOffset="0x5880" AddedByScript="true"/>
+        <Texture Name="object_psTex_0071C0" OutName="object_psTex_0071C0" Format="ci8" Width="32" Height="32" Offset="0x71C0" TlutOffset="0x5880" AddedByScript="true"/>
+        <Texture Name="object_psTex_0075C0" OutName="object_psTex_0075C0" Format="ci8" Width="8" Height="8" Offset="0x75C0" TlutOffset="0x5880" AddedByScript="true"/>
+        <Texture Name="object_psTex_007600" OutName="object_psTex_007600" Format="ci8" Width="8" Height="8" Offset="0x7600" TlutOffset="0x5880" AddedByScript="true"/>
+        <Texture Name="object_psTex_007640" OutName="object_psTex_007640" Format="ci8" Width="32" Height="32" Offset="0x7640" TlutOffset="0x5880" AddedByScript="true"/>
+        <Texture Name="object_psTex_007A40" OutName="object_psTex_007A40" Format="rgba16" Width="16" Height="16" Offset="0x7A40" AddedByScript="true"/>
+        <Texture Name="object_psTex_007C40" OutName="object_psTex_007C40" Format="ci8" Width="32" Height="32" Offset="0x7C40" TlutOffset="0x5880" AddedByScript="true"/>
+        <Texture Name="object_psTLUT_0004B0" OutName="object_psTLUT_0004B0" Format="rgba16" Width="16" Height="16" Offset="0x4B0" AddedByScript="true"/>
+        <Texture Name="object_psTLUT_005880" OutName="object_psTLUT_005880" Format="rgba16" Width="16" Height="16" Offset="0x5880" AddedByScript="true"/>
         <Animation Name="gPoeSellerIdleAnim" Offset="0x049C"/>
         <Texture Name="gPoeSellerMetalFrameTex" OutName="poe_seller_metal_frame" Format="rgba16" Width="8" Height="8" Offset="0x5A80"/>
         <Texture Name="gPoeSellerMattressTex" OutName="poe_seller_mattress" Format="rgba16" Width="8" Height="8" Offset="0x5B00"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_rl.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_rl.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_rl" Segment="6">
+        <Texture Name="object_rlTex_0033E0" OutName="object_rlTex_0033E0" Format="ci8" Width="8" Height="8" Offset="0x33E0" TlutOffset="0x32A0" AddedByScript="true"/>
+        <Texture Name="object_rlTex_003420" OutName="object_rlTex_003420" Format="ci8" Width="16" Height="16" Offset="0x3420" TlutOffset="0x32A0" AddedByScript="true"/>
         <Animation Name="object_rl_Anim_00040C" Offset="0x40C"/>
         <Animation Name="object_rl_Anim_000830" Offset="0x830"/>
         <Animation Name="object_rl_Anim_000A3C" Offset="0xA3C"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_ru2.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_ru2.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_ru2" Segment="6">
+        <Texture Name="object_ru2Tex_0055C0" OutName="object_ru2Tex_0055C0" Format="ci8" Width="8" Height="32" Offset="0x55C0" TlutOffset="0x43C0" AddedByScript="true"/>
+        <Texture Name="object_ru2Tex_0056C0" OutName="object_ru2Tex_0056C0" Format="rgba16" Width="32" Height="32" Offset="0x56C0" AddedByScript="true"/>
         <!-- Adult Ruto Skeleton -->
         <Skeleton Name="gAdultRutoSkel" Type="Flex" LimbType="Standard" Offset="0xC700"/>
 

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_sa.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_sa.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_sa" Segment="6">
+        <Texture Name="object_saTex_002530" OutName="object_saTex_002530" Format="ci8" Width="8" Height="8" Offset="0x2530" TlutOffset="0x21F0" AddedByScript="true"/>
         <Skeleton Name="gSariaSkel" Type="Flex" LimbType="Standard" Offset="0xB1A0"/>
         
         <Limb Name="gSariaRootLimb" LimbType="Standard" Offset="0xB0A0"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_skj.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_skj.xml
@@ -1,5 +1,13 @@
 <Root>
     <File Name="object_skj" Segment="6">
+        <Texture Name="object_skjTex_005300" OutName="object_skjTex_005300" Format="rgba16" Width="16" Height="16" Offset="0x5300" AddedByScript="true"/>
+        <Texture Name="object_skjTex_005500" OutName="object_skjTex_005500" Format="rgba16" Width="16" Height="16" Offset="0x5500" AddedByScript="true"/>
+        <Texture Name="object_skjTex_005700" OutName="object_skjTex_005700" Format="rgba16" Width="16" Height="16" Offset="0x5700" AddedByScript="true"/>
+        <Texture Name="object_skjTex_005900" OutName="object_skjTex_005900" Format="rgba16" Width="16" Height="16" Offset="0x5900" AddedByScript="true"/>
+        <Texture Name="object_skjTex_005B00" OutName="object_skjTex_005B00" Format="rgba16" Width="8" Height="8" Offset="0x5B00" AddedByScript="true"/>
+        <Texture Name="object_skjTex_005B80" OutName="object_skjTex_005B80" Format="rgba16" Width="16" Height="16" Offset="0x5B80" AddedByScript="true"/>
+        <Texture Name="object_skjTex_005D80" OutName="object_skjTex_005D80" Format="rgba16" Width="4" Height="4" Offset="0x5D80" AddedByScript="true"/>
+        <Texture Name="object_skjTex_005DA0" OutName="object_skjTex_005DA0" Format="ia16" Width="8" Height="8" Offset="0x5DA0" AddedByScript="true"/>
         <DList Name="gSkullKidNeedleDL" Offset="0x0EB0"/>
         <DList Name="gSkullKidSkullMaskDL" Offset="0x14C8"/>
 

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_spot09_obj.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_spot09_obj.xml
@@ -1,5 +1,26 @@
 <Root>
     <File Name="object_spot09_obj" Segment="6">
+        <Texture Name="object_spot09_objTex_008490" OutName="object_spot09_objTex_008490" Format="rgba16" Width="32" Height="32" Offset="0x8490" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_008C90" OutName="object_spot09_objTex_008C90" Format="rgba16" Width="32" Height="32" Offset="0x8C90" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_009490" OutName="object_spot09_objTex_009490" Format="rgba16" Width="64" Height="32" Offset="0x9490" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_00A490" OutName="object_spot09_objTex_00A490" Format="rgba16" Width="32" Height="32" Offset="0xA490" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_00AC90" OutName="object_spot09_objTex_00AC90" Format="rgba16" Width="32" Height="32" Offset="0xAC90" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_00B490" OutName="object_spot09_objTex_00B490" Format="rgba16" Width="32" Height="32" Offset="0xB490" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_00BC90" OutName="object_spot09_objTex_00BC90" Format="rgba16" Width="32" Height="64" Offset="0xBC90" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_00CC90" OutName="object_spot09_objTex_00CC90" Format="rgba16" Width="64" Height="32" Offset="0xCC90" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_00DC90" OutName="object_spot09_objTex_00DC90" Format="rgba16" Width="32" Height="64" Offset="0xDC90" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_00EC90" OutName="object_spot09_objTex_00EC90" Format="rgba16" Width="64" Height="32" Offset="0xEC90" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_00FC90" OutName="object_spot09_objTex_00FC90" Format="rgba16" Width="16" Height="32" Offset="0xFC90" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_010090" OutName="object_spot09_objTex_010090" Format="rgba16" Width="64" Height="32" Offset="0x10090" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_011090" OutName="object_spot09_objTex_011090" Format="rgba16" Width="32" Height="64" Offset="0x11090" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_012090" OutName="object_spot09_objTex_012090" Format="rgba16" Width="64" Height="32" Offset="0x12090" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_013090" OutName="object_spot09_objTex_013090" Format="rgba16" Width="64" Height="32" Offset="0x13090" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_014090" OutName="object_spot09_objTex_014090" Format="rgba16" Width="64" Height="32" Offset="0x14090" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_015090" OutName="object_spot09_objTex_015090" Format="rgba16" Width="32" Height="64" Offset="0x15090" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_016090" OutName="object_spot09_objTex_016090" Format="rgba16" Width="32" Height="64" Offset="0x16090" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_017090" OutName="object_spot09_objTex_017090" Format="i8" Width="32" Height="32" Offset="0x17090" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_017490" OutName="object_spot09_objTex_017490" Format="i8" Width="32" Height="32" Offset="0x17490" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_017890" OutName="object_spot09_objTex_017890" Format="i4" Width="128" Height="64" Offset="0x17890" AddedByScript="true"/>
         <DList Name="gValleyBridgeSidesDL" Offset="0x100"/>
         <DList Name="gValleyBrokenBridgeDL" Offset="0x3970"/>
         <DList Name="gValleyBridgeChildDL" Offset="0x1120"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_sst.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_sst.xml
@@ -1,5 +1,21 @@
 <Root>
     <File Name="object_sst" Segment="6">
+        <Texture Name="object_sstTex_017FE0" OutName="object_sstTex_017FE0" Format="rgba16" Width="32" Height="64" Offset="0x17FE0" AddedByScript="true"/>
+        <Texture Name="object_sstTex_019530" OutName="object_sstTex_019530" Format="rgba16" Width="4" Height="8" Offset="0x19530" AddedByScript="true"/>
+        <Texture Name="object_sstTex_019570" OutName="object_sstTex_019570" Format="rgba16" Width="8" Height="16" Offset="0x19570" AddedByScript="true"/>
+        <Texture Name="object_sstTex_019670" OutName="object_sstTex_019670" Format="rgba16" Width="8" Height="16" Offset="0x19670" AddedByScript="true"/>
+        <Texture Name="object_sstTex_019770" OutName="object_sstTex_019770" Format="rgba16" Width="4" Height="8" Offset="0x19770" AddedByScript="true"/>
+        <Texture Name="object_sstTex_0197B0" OutName="object_sstTex_0197B0" Format="rgba16" Width="16" Height="16" Offset="0x197B0" AddedByScript="true"/>
+        <Texture Name="object_sstTex_0199B0" OutName="object_sstTex_0199B0" Format="rgba16" Width="8" Height="16" Offset="0x199B0" AddedByScript="true"/>
+        <Texture Name="object_sstTex_019AB0" OutName="object_sstTex_019AB0" Format="rgba16" Width="8" Height="16" Offset="0x19AB0" AddedByScript="true"/>
+        <Texture Name="object_sstTex_019BB0" OutName="object_sstTex_019BB0" Format="rgba16" Width="16" Height="32" Offset="0x19BB0" AddedByScript="true"/>
+        <Texture Name="object_sstTex_019FB0" OutName="object_sstTex_019FB0" Format="rgba16" Width="8" Height="16" Offset="0x19FB0" AddedByScript="true"/>
+        <Texture Name="object_sstTex_01A0B0" OutName="object_sstTex_01A0B0" Format="rgba16" Width="8" Height="16" Offset="0x1A0B0" AddedByScript="true"/>
+        <Texture Name="object_sstTex_01A1B0" OutName="object_sstTex_01A1B0" Format="rgba16" Width="8" Height="32" Offset="0x1A1B0" AddedByScript="true"/>
+        <Texture Name="object_sstTex_01A3B0" OutName="object_sstTex_01A3B0" Format="rgba16" Width="16" Height="16" Offset="0x1A3B0" AddedByScript="true"/>
+        <Texture Name="object_sstTex_01A5B0" OutName="object_sstTex_01A5B0" Format="rgba16" Width="8" Height="16" Offset="0x1A5B0" AddedByScript="true"/>
+        <Texture Name="object_sstTex_01A730" OutName="object_sstTex_01A730" Format="rgba16" Width="4" Height="16" Offset="0x1A730" AddedByScript="true"/>
+        <Texture Name="object_sstTex_01A7B0" OutName="object_sstTex_01A7B0" Format="rgba16" Width="16" Height="16" Offset="0x1A7B0" AddedByScript="true"/>
         <!-- Boss Title Card -->
         <Texture Name="gBongoTitleCardTex" OutName="bongo_title_card" Format="i8" Width="128" Height="120" Offset="0x13D80"/>
         

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_tk.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_tk.xml
@@ -1,5 +1,22 @@
 <Root>
     <File Name="object_tk" Segment="6">
+        <Texture Name="object_tkTex_003980" OutName="object_tkTex_003980" Format="ci8" Width="8" Height="8" Offset="0x3980" TlutOffset="0x3780" AddedByScript="true"/>
+        <Texture Name="object_tkTex_0039C0" OutName="object_tkTex_0039C0" Format="ci8" Width="8" Height="8" Offset="0x39C0" TlutOffset="0x3780" AddedByScript="true"/>
+        <Texture Name="object_tkTex_003A00" OutName="object_tkTex_003A00" Format="ci8" Width="8" Height="8" Offset="0x3A00" TlutOffset="0x3780" AddedByScript="true"/>
+        <Texture Name="object_tkTex_003A40" OutName="object_tkTex_003A40" Format="ci8" Width="16" Height="16" Offset="0x3A40" TlutOffset="0x3780" AddedByScript="true"/>
+        <Texture Name="object_tkTex_005340" OutName="object_tkTex_005340" Format="ci8" Width="16" Height="16" Offset="0x5340" TlutOffset="0x3780" AddedByScript="true"/>
+        <Texture Name="object_tkTex_005440" OutName="object_tkTex_005440" Format="ci8" Width="16" Height="16" Offset="0x5440" TlutOffset="0x3780" AddedByScript="true"/>
+        <Texture Name="object_tkTex_0056C0" OutName="object_tkTex_0056C0" Format="ci8" Width="16" Height="16" Offset="0x56C0" TlutOffset="0x3780" AddedByScript="true"/>
+        <Texture Name="object_tkTex_009B00" OutName="object_tkTex_009B00" Format="ci8" Width="16" Height="16" Offset="0x9B00" TlutOffset="0x9AB0" AddedByScript="true"/>
+        <Texture Name="object_tkTex_009C00" OutName="object_tkTex_009C00" Format="ci8" Width="8" Height="16" Offset="0x9C00" TlutOffset="0x9AB0" AddedByScript="true"/>
+        <Texture Name="object_tkTex_009C80" OutName="object_tkTex_009C80" Format="i8" Width="8" Height="8" Offset="0x9C80" AddedByScript="true"/>
+        <Texture Name="object_tkTex_009CC0" OutName="object_tkTex_009CC0" Format="rgba16" Width="8" Height="8" Offset="0x9CC0" AddedByScript="true"/>
+        <Texture Name="object_tkTex_009D40" OutName="object_tkTex_009D40" Format="i4" Width="16" Height="32" Offset="0x9D40" AddedByScript="true"/>
+        <Texture Name="object_tkTex_00B088" OutName="object_tkTex_00B088" Format="rgba16" Width="16" Height="16" Offset="0xB088" AddedByScript="true"/>
+        <Texture Name="object_tkTex_00B288" OutName="object_tkTex_00B288" Format="rgba16" Width="16" Height="16" Offset="0xB288" AddedByScript="true"/>
+        <Texture Name="object_tkTex_00B488" OutName="object_tkTex_00B488" Format="rgba16" Width="16" Height="16" Offset="0xB488" AddedByScript="true"/>
+        <Texture Name="object_tkTLUT_003780" OutName="object_tkTLUT_003780" Format="rgba16" Width="16" Height="16" Offset="0x3780" AddedByScript="true"/>
+        <Texture Name="object_tkTLUT_009AB0" OutName="object_tkTLUT_009AB0" Format="rgba16" Width="16" Height="16" Offset="0x9AB0" AddedByScript="true"/>
         <Animation Name="gDampeDigAnim" Offset="0x1144"/>
         <Animation Name="gDampeWalkAnim" Offset="0x1FA8"/>
         <Animation Name="gDampeRestAnim" Offset="0x2F84"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_torch2.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_torch2.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_torch2" Segment="6">
+        <Texture Name="object_torch2Tex_0041C0" OutName="object_torch2Tex_0041C0" Format="rgba16" Width="16" Height="16" Offset="0x41C0" AddedByScript="true"/>
+        <Texture Name="object_torch2Tex_0043C0" OutName="object_torch2Tex_0043C0" Format="ia16" Width="16" Height="16" Offset="0x43C0" AddedByScript="true"/>
         <!-- Dark Link's skeleton -->
         <Skeleton Name="gDarkLinkSkel" Type="Flex" LimbType="LOD" Offset="0x4764"/>
 

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_xc.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_xc.xml
@@ -1,5 +1,32 @@
 <Root>
     <File Name="object_xc" Segment="6">
+        <Texture Name="object_xcTex_004C40" OutName="object_xcTex_004C40" Format="ci8" Width="8" Height="8" Offset="0x4C40" TlutOffset="0x4840" AddedByScript="true"/>
+        <Texture Name="object_xcTex_004C80" OutName="object_xcTex_004C80" Format="ci8" Width="8" Height="8" Offset="0x4C80" TlutOffset="0x4840" AddedByScript="true"/>
+        <Texture Name="object_xcTex_005CC0" OutName="object_xcTex_005CC0" Format="ci8" Width="32" Height="32" Offset="0x5CC0" TlutOffset="0x4A40" AddedByScript="true"/>
+        <Texture Name="object_xcTex_0060C0" OutName="object_xcTex_0060C0" Format="ci8" Width="32" Height="32" Offset="0x60C0" TlutOffset="0x4840" AddedByScript="true"/>
+        <Texture Name="object_xcTex_0064C0" OutName="object_xcTex_0064C0" Format="rgba16" Width="32" Height="32" Offset="0x64C0" AddedByScript="true"/>
+        <Texture Name="object_xcTex_006CC0" OutName="object_xcTex_006CC0" Format="ci8" Width="8" Height="16" Offset="0x6CC0" TlutOffset="0x4840" AddedByScript="true"/>
+        <Texture Name="object_xcTex_006D40" OutName="object_xcTex_006D40" Format="ci8" Width="8" Height="8" Offset="0x6D40" TlutOffset="0x4840" AddedByScript="true"/>
+        <Texture Name="object_xcTex_006D80" OutName="object_xcTex_006D80" Format="ci8" Width="16" Height="16" Offset="0x6D80" TlutOffset="0x4840" AddedByScript="true"/>
+        <Texture Name="object_xcTex_006E80" OutName="object_xcTex_006E80" Format="ci8" Width="32" Height="32" Offset="0x6E80" TlutOffset="0x4A40" AddedByScript="true"/>
+        <Texture Name="object_xcTex_007280" OutName="object_xcTex_007280" Format="ci8" Width="16" Height="16" Offset="0x7280" TlutOffset="0x4840" AddedByScript="true"/>
+        <Texture Name="object_xcTex_007380" OutName="object_xcTex_007380" Format="rgba16" Width="32" Height="32" Offset="0x7380" AddedByScript="true"/>
+        <Texture Name="object_xcTex_007B80" OutName="object_xcTex_007B80" Format="ci8" Width="32" Height="64" Offset="0x7B80" TlutOffset="0x4840" AddedByScript="true"/>
+        <Texture Name="object_xcTex_008380" OutName="object_xcTex_008380" Format="ci8" Width="32" Height="64" Offset="0x8380" TlutOffset="0x4840" AddedByScript="true"/>
+        <Texture Name="object_xcTex_008B80" OutName="object_xcTex_008B80" Format="ci8" Width="16" Height="8" Offset="0x8B80" TlutOffset="0x4840" AddedByScript="true"/>
+        <Texture Name="object_xcTex_008C00" OutName="object_xcTex_008C00" Format="ci8" Width="32" Height="16" Offset="0x8C00" TlutOffset="0x4840" AddedByScript="true"/>
+        <Texture Name="object_xcTex_00F790" OutName="object_xcTex_00F790" Format="ci8" Width="8" Height="8" Offset="0xF790" TlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="object_xcTex_00F7D0" OutName="object_xcTex_00F7D0" Format="ci8" Width="32" Height="32" Offset="0xF7D0" TlutOffset="0xF720" AddedByScript="true"/>
+        <Texture Name="object_xcTex_00FBD0" OutName="object_xcTex_00FBD0" Format="ci8" Width="16" Height="16" Offset="0xFBD0" TlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="object_xcTex_00FCD0" OutName="object_xcTex_00FCD0" Format="ci8" Width="8" Height="8" Offset="0xFCD0" TlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="object_xcTex_00FD10" OutName="object_xcTex_00FD10" Format="rgba16" Width="8" Height="8" Offset="0xFD10" AddedByScript="true"/>
+        <Texture Name="object_xcTex_00FD90" OutName="object_xcTex_00FD90" Format="i8" Width="8" Height="8" Offset="0xFD90" AddedByScript="true"/>
+        <Texture Name="object_xcTex_00FDD0" OutName="object_xcTex_00FDD0" Format="rgba16" Width="16" Height="32" Offset="0xFDD0" AddedByScript="true"/>
+        <Texture Name="object_xcTex_0101D0" OutName="object_xcTex_0101D0" Format="rgba16" Width="8" Height="16" Offset="0x101D0" AddedByScript="true"/>
+        <Texture Name="object_xcTex_011930" OutName="object_xcTex_011930" Format="i8" Width="64" Height="64" Offset="0x11930" AddedByScript="true"/>
+        <Texture Name="object_xcTLUT_004840" OutName="object_xcTLUT_004840" Format="rgba16" Width="16" Height="16" Offset="0x4840" AddedByScript="true"/>
+        <Texture Name="object_xcTLUT_00F6C0" OutName="object_xcTLUT_00F6C0" Format="rgba16" Width="16" Height="16" Offset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="object_xcTLUT_00F720" OutName="object_xcTLUT_00F720" Format="rgba16" Width="16" Height="16" Offset="0xF720" AddedByScript="true"/>
         <Skeleton Name="gSheikSkel" Type="Flex" LimbType="Standard" Offset="0x12AF0"/>
         <Animation Name="gSheikPlayingHarpAnim" Offset="0xB6C"/>
         <Animation Name="gSheikShowingTriforceOnHandAnim" Offset="0x1A08"/>
@@ -8,6 +35,7 @@
         <Animation Name="gSheikPlayingHarp3Anim" Offset="0x35C8"/>
         <Animation Name="gSheikPlayingHarp4Anim" Offset="0x4570"/>
         <Animation Name="gSheikIdleAnim" Offset="0x4828"/>
+        <Texture Name="object_xcTLUT_004A40" OutName="object_xcTLUT_004A40" Format="rgba16" Width="16" Height="16" Offset="0x4A40"/>
         <Animation Name="gSheikWalkingAnim" Offset="0x12FD0"/>
         <Animation Name="gSheikArmsCrossedIdleAnim" Offset="0x13AA4"/>
         <Animation Name="gSheikFallingFromContortionsAnim" Offset="0x149E4"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_zl1.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_zl1.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_zl1" Segment="6">
+        <Texture Name="object_zl1Tex_00EE58" OutName="object_zl1Tex_00EE58" Format="rgba16" Width="32" Height="16" Offset="0xEE58" AddedByScript="true"/>
         <!-- Child Zelda 1 Skeleton -->
         <Skeleton Name="gChildZelda1Skel" Type="Flex" LimbType="Standard" Offset="0xF5D8"/>
 

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_zl2.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_zl2.xml
@@ -1,5 +1,38 @@
 <Root>
     <File Name="object_zl2" Segment="6">
+        <Texture Name="object_zl2Tex_000E00" OutName="object_zl2Tex_000E00" Format="ci8" Width="16" Height="16" Offset="0xE00" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_000F00" OutName="object_zl2Tex_000F00" Format="ci8" Width="8" Height="8" Offset="0xF00" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_000F40" OutName="object_zl2Tex_000F40" Format="ci8" Width="16" Height="32" Offset="0xF40" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_001140" OutName="object_zl2Tex_001140" Format="ci8" Width="8" Height="8" Offset="0x1140" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_001180" OutName="object_zl2Tex_001180" Format="ci8" Width="16" Height="16" Offset="0x1180" TlutOffset="0x200" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_001280" OutName="object_zl2Tex_001280" Format="ci8" Width="8" Height="8" Offset="0x1280" TlutOffset="0x200" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_0012C0" OutName="object_zl2Tex_0012C0" Format="ci8" Width="16" Height="64" Offset="0x12C0" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_0016C0" OutName="object_zl2Tex_0016C0" Format="ci8" Width="32" Height="32" Offset="0x16C0" TlutOffset="0x400" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_001AC0" OutName="object_zl2Tex_001AC0" Format="ci8" Width="32" Height="16" Offset="0x1AC0" TlutOffset="0x400" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_001CC0" OutName="object_zl2Tex_001CC0" Format="ci8" Width="32" Height="64" Offset="0x1CC0" TlutOffset="0x400" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_0024C0" OutName="object_zl2Tex_0024C0" Format="ci8" Width="8" Height="8" Offset="0x24C0" TlutOffset="0x200" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_002500" OutName="object_zl2Tex_002500" Format="ci8" Width="16" Height="16" Offset="0x2500" TlutOffset="0x200" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_002600" OutName="object_zl2Tex_002600" Format="ci8" Width="32" Height="8" Offset="0x2600" TlutOffset="0x400" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_002700" OutName="object_zl2Tex_002700" Format="ci8" Width="8" Height="8" Offset="0x2700" TlutOffset="0x400" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_002740" OutName="object_zl2Tex_002740" Format="ci8" Width="8" Height="8" Offset="0x2740" TlutOffset="0x400" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_002780" OutName="object_zl2Tex_002780" Format="ci8" Width="16" Height="16" Offset="0x2780" TlutOffset="0x400" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_002880" OutName="object_zl2Tex_002880" Format="ci8" Width="8" Height="16" Offset="0x2880" TlutOffset="0x200" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_0034C8" OutName="object_zl2Tex_0034C8" Format="ci8" Width="8" Height="8" Offset="0x34C8" TlutOffset="0x2D00" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_003908" OutName="object_zl2Tex_003908" Format="ci8" Width="16" Height="16" Offset="0x3908" TlutOffset="0x2D00" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_003A08" OutName="object_zl2Tex_003A08" Format="ci8" Width="8" Height="8" Offset="0x3A08" TlutOffset="0x9490" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_003A48" OutName="object_zl2Tex_003A48" Format="ci8" Width="8" Height="16" Offset="0x3A48" TlutOffset="0x2F50" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_003AC8" OutName="object_zl2Tex_003AC8" Format="ci8" Width="16" Height="8" Offset="0x3AC8" TlutOffset="0x2F50" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_003B48" OutName="object_zl2Tex_003B48" Format="ci8" Width="16" Height="16" Offset="0x3B48" TlutOffset="0x2F50" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_004448" OutName="object_zl2Tex_004448" Format="ci8" Width="16" Height="16" Offset="0x4448" TlutOffset="0x2F50" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_006548" OutName="object_zl2Tex_006548" Format="ci8" Width="32" Height="16" Offset="0x6548" TlutOffset="0x2F50" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_009738" OutName="object_zl2Tex_009738" Format="ci8" Width="16" Height="32" Offset="0x9738" TlutOffset="0x95A0" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_009938" OutName="object_zl2Tex_009938" Format="ci8" Width="16" Height="16" Offset="0x9938" TlutOffset="0x9490" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_009A38" OutName="object_zl2Tex_009A38" Format="ci8" Width="8" Height="8" Offset="0x9A38" TlutOffset="0x9490" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_009A78" OutName="object_zl2Tex_009A78" Format="ci8" Width="32" Height="32" Offset="0x9A78" TlutOffset="0x9490" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_009E78" OutName="object_zl2Tex_009E78" Format="ci8" Width="16" Height="16" Offset="0x9E78" TlutOffset="0x95A0" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_009F78" OutName="object_zl2Tex_009F78" Format="ci8" Width="8" Height="16" Offset="0x9F78" TlutOffset="0x95A0" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_009FF8" OutName="object_zl2Tex_009FF8" Format="ci8" Width="16" Height="16" Offset="0x9FF8" TlutOffset="0x9708" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_00A0F8" OutName="object_zl2Tex_00A0F8" Format="ci8" Width="32" Height="32" Offset="0xA0F8" TlutOffset="0x9708" AddedByScript="true"/>
         <!-- Zelda 2 skeleton -->
         <Skeleton Name="gZelda2Skel" Type="Flex" LimbType="Standard" Offset="0x10D70"/>
 
@@ -19,9 +52,9 @@
 
         <!-- Zelda 2 mouth textures -->
         <Texture Name="gZelda2MouthTLUT" OutName="zelda_2_mouth_tlut" Format="rgba16" Width="16" Height="14" Offset="0x2D90"/>
-        <Texture Name="gZelda2MouthSeriousTex" OutName="zelda_2_mouth_serious" Format="ci8" Width="32" Height="32"  Offset="0x3508" TlutOffset="0x2D90"/>
-        <Texture Name="gZelda2MouthHappyTex" OutName="zelda_2_mouth_happy" Format="ci8" Width="32" Height="32"  Offset="0x5548" TlutOffset="0x2D90"/>
-        <Texture Name="gZelda2MouthOpenTex" OutName="zelda_2_mouth_open" Format="ci8" Width="32" Height="32"  Offset="0x5948" TlutOffset="0x2D90"/>
+        <Texture Name="gZelda2MouthSeriousTex" OutName="zelda_2_mouth_serious" Format="ci8" Width="32" Height="32" Offset="0x3508" TlutOffset="0x2D90"/>
+        <Texture Name="gZelda2MouthHappyTex" OutName="zelda_2_mouth_happy" Format="ci8" Width="32" Height="32" Offset="0x5548" TlutOffset="0x2D90"/>
+        <Texture Name="gZelda2MouthOpenTex" OutName="zelda_2_mouth_open" Format="ci8" Width="32" Height="32" Offset="0x5948" TlutOffset="0x2D90"/>
 
         <!-- Ocarina of time -->
         <DList Name="gZelda2OcarinaDL" Offset="0xBAE8"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_zl4.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_zl4.xml
@@ -1,5 +1,36 @@
 <Root>
     <File Name="object_zl4" Segment="6">
+        <Texture Name="object_zl4Tex_000C70" OutName="object_zl4Tex_000C70" Format="ci8" Width="8" Height="8" Offset="0xC70" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_000CB0" OutName="object_zl4Tex_000CB0" Format="ci8" Width="16" Height="16" Offset="0xCB0" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_000DB0" OutName="object_zl4Tex_000DB0" Format="ci8" Width="32" Height="64" Offset="0xDB0" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_0015B0" OutName="object_zl4Tex_0015B0" Format="rgba16" Width="8" Height="8" Offset="0x15B0" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_001630" OutName="object_zl4Tex_001630" Format="rgba16" Width="8" Height="8" Offset="0x1630" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_0016B0" OutName="object_zl4Tex_0016B0" Format="ci8" Width="32" Height="8" Offset="0x16B0" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_0017B0" OutName="object_zl4Tex_0017B0" Format="ci8" Width="8" Height="8" Offset="0x17B0" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_0017F0" OutName="object_zl4Tex_0017F0" Format="ci8" Width="32" Height="32" Offset="0x17F0" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_001BF0" OutName="object_zl4Tex_001BF0" Format="rgba16" Width="8" Height="16" Offset="0x1BF0" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_001CF0" OutName="object_zl4Tex_001CF0" Format="ci8" Width="16" Height="16" Offset="0x1CF0" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_001DF0" OutName="object_zl4Tex_001DF0" Format="ci8" Width="8" Height="8" Offset="0x1DF0" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_001E30" OutName="object_zl4Tex_001E30" Format="rgba16" Width="16" Height="32" Offset="0x1E30" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_002230" OutName="object_zl4Tex_002230" Format="ci8" Width="8" Height="8" Offset="0x2230" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_002270" OutName="object_zl4Tex_002270" Format="ci8" Width="8" Height="16" Offset="0x2270" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_0022F0" OutName="object_zl4Tex_0022F0" Format="ci8" Width="16" Height="32" Offset="0x22F0" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_0024F0" OutName="object_zl4Tex_0024F0" Format="rgba16" Width="16" Height="16" Offset="0x24F0" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_0026F0" OutName="object_zl4Tex_0026F0" Format="rgba16" Width="16" Height="16" Offset="0x26F0" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_0028F0" OutName="object_zl4Tex_0028F0" Format="rgba16" Width="8" Height="8" Offset="0x28F0" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_002970" OutName="object_zl4Tex_002970" Format="rgba16" Width="8" Height="8" Offset="0x2970" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_0029F0" OutName="object_zl4Tex_0029F0" Format="rgba16" Width="16" Height="8" Offset="0x29F0" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_0056F0" OutName="object_zl4Tex_0056F0" Format="rgba16" Width="16" Height="16" Offset="0x56F0" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_0058F0" OutName="object_zl4Tex_0058F0" Format="ci8" Width="16" Height="16" Offset="0x58F0" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_0059F0" OutName="object_zl4Tex_0059F0" Format="rgba16" Width="8" Height="8" Offset="0x59F0" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_005A70" OutName="object_zl4Tex_005A70" Format="rgba16" Width="16" Height="16" Offset="0x5A70" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_005C70" OutName="object_zl4Tex_005C70" Format="ci8" Width="8" Height="8" Offset="0x5C70" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_005CB0" OutName="object_zl4Tex_005CB0" Format="ci8" Width="16" Height="16" Offset="0x5CB0" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_005DB0" OutName="object_zl4Tex_005DB0" Format="rgba16" Width="32" Height="32" Offset="0x5DB0" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_00D8B8" OutName="object_zl4Tex_00D8B8" Format="rgba16" Width="32" Height="16" Offset="0xD8B8" AddedByScript="true"/>
+        <Texture Name="object_zl4TLUT_000670" OutName="object_zl4TLUT_000670" Format="rgba16" Width="16" Height="16" Offset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4TLUT_000870" OutName="object_zl4TLUT_000870" Format="rgba16" Width="16" Height="16" Offset="0x870" AddedByScript="true"/>
+        <Texture Name="object_zl4TLUT_000A70" OutName="object_zl4TLUT_000A70" Format="rgba16" Width="16" Height="16" Offset="0xA70" AddedByScript="true"/>
         <!-- Child Zelda's skeleton -->
         <Skeleton Name="gChildZeldaSkel" Type="Flex" LimbType="Standard" Offset="0xE038"/>
 

--- a/soh/assets/xml/GC_NMQ_PAL_F/overlays/ovl_Boss_Ganon.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/overlays/ovl_Boss_Ganon.xml
@@ -1,5 +1,21 @@
 <Root>
     <File Name="ovl_Boss_Ganon" BaseAddress="0x808CBF80" RangeStart="0xE3C8" RangeEnd="0x211D8">
+        <Texture Name="ovl_Boss_GanonTex_00E748" OutName="ovl_Boss_GanonTex_00E748" Format="i8" Width="64" Height="64" Offset="0xE458" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_00F848" OutName="ovl_Boss_GanonTex_00F848" Format="ci8" Width="32" Height="32" Offset="0xF558" TlutOffset="0xF518" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_010538" OutName="ovl_Boss_GanonTex_010538" Format="i8" Width="64" Height="64" Offset="0x10248" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_01A7B0" OutName="ovl_Boss_GanonTex_01A7B0" Format="ia16" Width="32" Height="32" Offset="0x1A4C0" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_01AFB0" OutName="ovl_Boss_GanonTex_01AFB0" Format="i4" Width="64" Height="64" Offset="0x1ACC0" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_01B7B0" OutName="ovl_Boss_GanonTex_01B7B0" Format="i4" Width="64" Height="64" Offset="0x1B4C0" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_01C420" OutName="ovl_Boss_GanonTex_01C420" Format="i8" Width="64" Height="32" Offset="0x1C130" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_01CEB8" OutName="ovl_Boss_GanonTex_01CEB8" Format="i8" Width="32" Height="64" Offset="0x1CBC8" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_01D6B8" OutName="ovl_Boss_GanonTex_01D6B8" Format="i8" Width="32" Height="32" Offset="0x1D3C8" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_01DE88" OutName="ovl_Boss_GanonTex_01DE88" Format="i8" Width="32" Height="64" Offset="0x1DB98" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_01E688" OutName="ovl_Boss_GanonTex_01E688" Format="i8" Width="32" Height="64" Offset="0x1E398" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_01EF90" OutName="ovl_Boss_GanonTex_01EF90" Format="i8" Width="96" Height="16" Offset="0x1ECA0" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_01FFF8" OutName="ovl_Boss_GanonTex_01FFF8" Format="i4" Width="32" Height="32" Offset="0x1FD08" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_020370" OutName="ovl_Boss_GanonTex_020370" Format="i8" Width="32" Height="32" Offset="0x20080" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_020770" OutName="ovl_Boss_GanonTex_020770" Format="i8" Width="32" Height="64" Offset="0x20480" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTLUT_00F808" OutName="ovl_Boss_GanonTLUT_00F808" Format="rgba16" Width="16" Height="16" Offset="0xF518" AddedByScript="true"/>
         <Texture Name="gGanondorfLightning1Tex" OutName="lightning_1" Format="i8" Width="32" Height="96" Offset="0x11310" Static="Off"/>
         <Texture Name="gGanondorfLightning2Tex" OutName="lightning_2" Format="i8" Width="32" Height="96" Offset="0x11F10" Static="Off"/>
         <Texture Name="gGanondorfLightning3Tex" OutName="lightning_3" Format="i8" Width="32" Height="96" Offset="0x12B10" Static="Off"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/overlays/ovl_Boss_Sst.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/overlays/ovl_Boss_Sst.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="ovl_Boss_Sst" BaseAddress="0x8091FF30" RangeStart="0xA380" RangeEnd="0xAD70">
+        <Texture Name="ovl_Boss_SstTex_00A438" OutName="ovl_Boss_SstTex_00A438" Format="i8" Width="16" Height="64" Offset="0xA3F8" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_SstTex_00A8F0" OutName="ovl_Boss_SstTex_00A8F0" Format="i8" Width="32" Height="32" Offset="0xA8B0" AddedByScript="true"/>
         <DList Name="sBodyStaticDList" Offset="0xA380"/>
         <DList Name="sHandTrailDList" Offset="0xA398"/>
         <DList Name="sIntroVanishDList" Offset="0xA7F8"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/overlays/ovl_Demo_Shd.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/overlays/ovl_Demo_Shd.xml
@@ -1,7 +1,9 @@
 <Root>
     <File Name="ovl_Demo_Shd" BaseAddress="0x80980DA0" RangeStart="0x410" RangeEnd="0x23D0">
 
-    <DList Name="D_809932D0" Offset="0x2060"/>
+    <Texture Name="ovl_Demo_ShdTex_000450" OutName="ovl_Demo_ShdTex_000450" Format="i8" Width="16" Height="128" Offset="0x410" AddedByScript="true"/>
+        <Texture Name="ovl_Demo_ShdTex_000C50" OutName="ovl_Demo_ShdTex_000C50" Format="i8" Width="32" Height="64" Offset="0xC10" AddedByScript="true"/>
+        <DList Name="D_809932D0" Offset="0x2060"/>
     <DList Name="D_80993390" Offset="0x2120"/>
     <DList Name="D_809934B8" Offset="0x2248"/>
     </File>

--- a/soh/assets/xml/GC_NMQ_PAL_F/overlays/ovl_En_Clear_Tag.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/overlays/ovl_En_Clear_Tag.xml
@@ -1,5 +1,19 @@
 <Root>
     <File Name="ovl_En_Clear_Tag" BaseAddress="0x809BF430" RangeStart="0x2600" RangeEnd="0x89F0">
+        <Texture Name="ovl_En_Clear_TagTex_003308" OutName="ovl_En_Clear_TagTex_003308" Format="rgba16" Width="8" Height="8" Offset="0x3218" AddedByScript="true"/>
+        <Texture Name="ovl_En_Clear_TagTex_003388" OutName="ovl_En_Clear_TagTex_003388" Format="rgba16" Width="32" Height="32" Offset="0x3298" AddedByScript="true"/>
+        <Texture Name="ovl_En_Clear_TagTex_003B88" OutName="ovl_En_Clear_TagTex_003B88" Format="rgba16" Width="64" Height="32" Offset="0x3A98" AddedByScript="true"/>
+        <Texture Name="ovl_En_Clear_TagTex_004B88" OutName="ovl_En_Clear_TagTex_004B88" Format="rgba16" Width="32" Height="32" Offset="0x4A98" AddedByScript="true"/>
+        <Texture Name="ovl_En_Clear_TagTex_005388" OutName="ovl_En_Clear_TagTex_005388" Format="rgba16" Width="32" Height="32" Offset="0x5298" AddedByScript="true"/>
+        <Texture Name="ovl_En_Clear_TagTex_005B88" OutName="ovl_En_Clear_TagTex_005B88" Format="rgba16" Width="32" Height="32" Offset="0x5A98" AddedByScript="true"/>
+        <Texture Name="ovl_En_Clear_TagTex_006458" OutName="ovl_En_Clear_TagTex_006458" Format="rgba16" Width="16" Height="16" Offset="0x6368" AddedByScript="true"/>
+        <Texture Name="ovl_En_Clear_TagTex_006708" OutName="ovl_En_Clear_TagTex_006708" Format="i8" Width="16" Height="16" Offset="0x6618" AddedByScript="true"/>
+        <Texture Name="ovl_En_Clear_TagTex_006808" OutName="ovl_En_Clear_TagTex_006808" Format="rgba16" Width="16" Height="16" Offset="0x6718" AddedByScript="true"/>
+        <Texture Name="ovl_En_Clear_TagTex_006AD0" OutName="ovl_En_Clear_TagTex_006AD0" Format="i4" Width="32" Height="64" Offset="0x69E0" AddedByScript="true"/>
+        <Texture Name="ovl_En_Clear_TagTex_006ED0" OutName="ovl_En_Clear_TagTex_006ED0" Format="i4" Width="32" Height="32" Offset="0x6DE0" AddedByScript="true"/>
+        <Texture Name="ovl_En_Clear_TagTex_0071C8" OutName="ovl_En_Clear_TagTex_0071C8" Format="i8" Width="64" Height="64" Offset="0x70D8" AddedByScript="true"/>
+        <Texture Name="ovl_En_Clear_TagTex_008288" OutName="ovl_En_Clear_TagTex_008288" Format="i4" Width="32" Height="32" Offset="0x8198" AddedByScript="true"/>
+        <Texture Name="ovl_En_Clear_TagTex_008540" OutName="ovl_En_Clear_TagTex_008540" Format="i8" Width="32" Height="32" Offset="0x8450" AddedByScript="true"/>
         <DList Name="gArwingDL" Offset="0x2600"/>
         <DList Name="gArwingLaserDL" Offset="0x6298"/>
         <DList Name="gArwingBackfireDL" Offset="0x6598"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/Bmori1.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/Bmori1.xml
@@ -1,76 +1,231 @@
 <Root>
     <File Name="Bmori1_scene" Segment="2">
+        <Texture Name="Bmori1_sceneTex_014490" OutName="Bmori1_sceneTex_014490" Format="ci8" Width="32" Height="8" Offset="0x14490" TlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_sceneTex_015590" OutName="Bmori1_sceneTex_015590" Format="ci8" Width="16" Height="16" Offset="0x15590" TlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_sceneTex_015690" OutName="Bmori1_sceneTex_015690" Format="ci8" Width="32" Height="32" Offset="0x15690" TlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_sceneTex_015A90" OutName="Bmori1_sceneTex_015A90" Format="ci8" Width="16" Height="16" Offset="0x15A90" TlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_sceneTex_015B90" OutName="Bmori1_sceneTex_015B90" Format="ci8" Width="32" Height="32" Offset="0x15B90" TlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_sceneTLUT_014080" OutName="Bmori1_sceneTLUT_014080" Format="rgba16" Width="16" Height="16" Offset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_sceneTLUT_014288" OutName="Bmori1_sceneTLUT_014288" Format="rgba16" Width="16" Height="16" Offset="0x14288" AddedByScript="true"/>
         <Texture Name="gForestTempleDayEntranceTex" OutName="day_entrance" Format="ia16" Width="8" Height="128" Offset="0x14D90"/>
         <Texture Name="gForestTempleNightEntranceTex" OutName="night_entrance" Format="ia16" Width="8" Height="128" Offset="0x14590"/>
         <Scene Name="Bmori1_scene" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_0" Segment="3">
+        <Texture Name="Bmori1_room_0Tex_005CF8" OutName="Bmori1_room_0Tex_005CF8" Format="ci8" Width="64" Height="32" Offset="0x5CC8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_0Tex_0064F8" OutName="Bmori1_room_0Tex_0064F8" Format="i8" Width="64" Height="64" Offset="0x64C8" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_0Tex_0074F8" OutName="Bmori1_room_0Tex_0074F8" Format="rgba16" Width="32" Height="32" Offset="0x74C8" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_0Tex_007CF8" OutName="Bmori1_room_0Tex_007CF8" Format="rgba16" Width="32" Height="32" Offset="0x7CC8" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_0Tex_0084F8" OutName="Bmori1_room_0Tex_0084F8" Format="ci8" Width="16" Height="64" Offset="0x84C8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_0Tex_0088F8" OutName="Bmori1_room_0Tex_0088F8" Format="rgba16" Width="32" Height="64" Offset="0x88C8" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_0Tex_0098F8" OutName="Bmori1_room_0Tex_0098F8" Format="ci8" Width="32" Height="64" Offset="0x98C8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_0Tex_00A0F8" OutName="Bmori1_room_0Tex_00A0F8" Format="rgba16" Width="32" Height="64" Offset="0xA0C8" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_0Tex_00B0F8" OutName="Bmori1_room_0Tex_00B0F8" Format="ci8" Width="32" Height="32" Offset="0xB0C8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_0Tex_00B4F8" OutName="Bmori1_room_0Tex_00B4F8" Format="ci8" Width="32" Height="32" Offset="0xB4C8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_0Tex_00B8F8" OutName="Bmori1_room_0Tex_00B8F8" Format="ci8" Width="64" Height="32" Offset="0xB8C8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_0Tex_00C0F8" OutName="Bmori1_room_0Tex_00C0F8" Format="ci8" Width="16" Height="32" Offset="0xC0C8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_0Tex_00C2F8" OutName="Bmori1_room_0Tex_00C2F8" Format="ci8" Width="32" Height="32" Offset="0xC2C8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_0Tex_00CB88" OutName="Bmori1_room_0Tex_00CB88" Format="rgba16" Width="32" Height="64" Offset="0xCB58" AddedByScript="true"/>
         <Room Name="Bmori1_room_0" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_1" Segment="3">
+        <Texture Name="Bmori1_room_1Tex_003368" OutName="Bmori1_room_1Tex_003368" Format="rgba16" Width="32" Height="32" Offset="0x3348" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_1Tex_003B68" OutName="Bmori1_room_1Tex_003B68" Format="ci8" Width="64" Height="32" Offset="0x3B48" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_1Tex_004368" OutName="Bmori1_room_1Tex_004368" Format="rgba16" Width="32" Height="64" Offset="0x4348" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_1Tex_005368" OutName="Bmori1_room_1Tex_005368" Format="ci8" Width="32" Height="64" Offset="0x5348" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
         <Room Name="Bmori1_room_1" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_2" Segment="3">
+        <Texture Name="Bmori1_room_2Tex_00A380" OutName="Bmori1_room_2Tex_00A380" Format="ci8" Width="64" Height="32" Offset="0xA3A0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_2Tex_00AB80" OutName="Bmori1_room_2Tex_00AB80" Format="ci8" Width="16" Height="64" Offset="0xABA0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_2Tex_00AF80" OutName="Bmori1_room_2Tex_00AF80" Format="rgba16" Width="32" Height="64" Offset="0xAFA0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_2Tex_00BF80" OutName="Bmori1_room_2Tex_00BF80" Format="rgba16" Width="32" Height="64" Offset="0xBFA0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_2Tex_00CF80" OutName="Bmori1_room_2Tex_00CF80" Format="ci8" Width="32" Height="32" Offset="0xCFA0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_2Tex_00D380" OutName="Bmori1_room_2Tex_00D380" Format="ci8" Width="64" Height="32" Offset="0xD3A0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_2Tex_00DB80" OutName="Bmori1_room_2Tex_00DB80" Format="ci8" Width="16" Height="32" Offset="0xDBA0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_2Tex_00DD80" OutName="Bmori1_room_2Tex_00DD80" Format="ci8" Width="64" Height="32" Offset="0xDDA0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_2Tex_00E580" OutName="Bmori1_room_2Tex_00E580" Format="ci8" Width="32" Height="32" Offset="0xE5A0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_2Tex_00E980" OutName="Bmori1_room_2Tex_00E980" Format="ci8" Width="32" Height="64" Offset="0xE9A0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_2Tex_00F180" OutName="Bmori1_room_2Tex_00F180" Format="rgba16" Width="32" Height="32" Offset="0xF1A0" AddedByScript="true"/>
         <Room Name="Bmori1_room_2" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_3" Segment="3">
+        <Texture Name="Bmori1_room_3Tex_0023D8" OutName="Bmori1_room_3Tex_0023D8" Format="rgba16" Width="32" Height="32" Offset="0x23E8" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_3Tex_002BD8" OutName="Bmori1_room_3Tex_002BD8" Format="ci8" Width="16" Height="128" Offset="0x2BE8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_3Tex_0033D8" OutName="Bmori1_room_3Tex_0033D8" Format="ci8" Width="32" Height="32" Offset="0x33E8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_3Tex_0037D8" OutName="Bmori1_room_3Tex_0037D8" Format="rgba16" Width="8" Height="16" Offset="0x37E8" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_3Tex_0038D8" OutName="Bmori1_room_3Tex_0038D8" Format="rgba16" Width="16" Height="8" Offset="0x38E8" AddedByScript="true"/>
         <Room Name="Bmori1_room_3" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_4" Segment="3">
+        <Texture Name="Bmori1_room_4Tex_0022B8" OutName="Bmori1_room_4Tex_0022B8" Format="rgba16" Width="32" Height="32" Offset="0x22A8" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_4Tex_002AB8" OutName="Bmori1_room_4Tex_002AB8" Format="ci8" Width="64" Height="32" Offset="0x2AA8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
         <Room Name="Bmori1_room_4" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_5" Segment="3">
+        <Texture Name="Bmori1_room_5Tex_0023D0" OutName="Bmori1_room_5Tex_0023D0" Format="ci8" Width="32" Height="32" Offset="0x23C0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_5Tex_0027D0" OutName="Bmori1_room_5Tex_0027D0" Format="ci8" Width="16" Height="128" Offset="0x27C0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_5Tex_002FD0" OutName="Bmori1_room_5Tex_002FD0" Format="ci8" Width="32" Height="32" Offset="0x2FC0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_5Tex_0033D0" OutName="Bmori1_room_5Tex_0033D0" Format="rgba16" Width="8" Height="16" Offset="0x33C0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_5Tex_0034D0" OutName="Bmori1_room_5Tex_0034D0" Format="rgba16" Width="16" Height="8" Offset="0x34C0" AddedByScript="true"/>
         <Room Name="Bmori1_room_5" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_6" Segment="3">
+        <Texture Name="Bmori1_room_6Tex_006630" OutName="Bmori1_room_6Tex_006630" Format="rgba16" Width="32" Height="32" Offset="0x6620" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_6Tex_006E30" OutName="Bmori1_room_6Tex_006E30" Format="rgba16" Width="32" Height="32" Offset="0x6E20" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_6Tex_007630" OutName="Bmori1_room_6Tex_007630" Format="ci8" Width="32" Height="32" Offset="0x7620" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_6Tex_007A30" OutName="Bmori1_room_6Tex_007A30" Format="ci8" Width="64" Height="32" Offset="0x7A20" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_6Tex_008230" OutName="Bmori1_room_6Tex_008230" Format="ci8" Width="64" Height="32" Offset="0x8220" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_6Tex_008A30" OutName="Bmori1_room_6Tex_008A30" Format="ci8" Width="16" Height="32" Offset="0x8A20" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_6Tex_008C30" OutName="Bmori1_room_6Tex_008C30" Format="ci8" Width="32" Height="64" Offset="0x8C20" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
         <Room Name="Bmori1_room_6" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_7" Segment="3">
+        <Texture Name="Bmori1_room_7Tex_007DD0" OutName="Bmori1_room_7Tex_007DD0" Format="rgba16" Width="32" Height="32" Offset="0x7D60" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_0085D0" OutName="Bmori1_room_7Tex_0085D0" Format="rgba16" Width="32" Height="32" Offset="0x8560" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_008DD0" OutName="Bmori1_room_7Tex_008DD0" Format="ci8" Width="32" Height="32" Offset="0x8D60" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_0091D0" OutName="Bmori1_room_7Tex_0091D0" Format="ci8" Width="32" Height="32" Offset="0x9160" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_0095D0" OutName="Bmori1_room_7Tex_0095D0" Format="ci8" Width="32" Height="64" Offset="0x9560" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_009DD0" OutName="Bmori1_room_7Tex_009DD0" Format="ci8" Width="32" Height="64" Offset="0x9D60" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_00A5D0" OutName="Bmori1_room_7Tex_00A5D0" Format="ci8" Width="64" Height="32" Offset="0xA560" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_00ADD0" OutName="Bmori1_room_7Tex_00ADD0" Format="rgba16" Width="32" Height="32" Offset="0xAD60" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_00B5D0" OutName="Bmori1_room_7Tex_00B5D0" Format="ci8" Width="64" Height="32" Offset="0xB560" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_00BDD0" OutName="Bmori1_room_7Tex_00BDD0" Format="rgba16" Width="32" Height="64" Offset="0xBD60" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_00CDD0" OutName="Bmori1_room_7Tex_00CDD0" Format="rgba16" Width="32" Height="64" Offset="0xCD60" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_00DDD0" OutName="Bmori1_room_7Tex_00DDD0" Format="rgba16" Width="32" Height="32" Offset="0xDD60" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_00EFD8" OutName="Bmori1_room_7Tex_00EFD8" Format="i4" Width="64" Height="128" Offset="0xEF68" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_00FFD8" OutName="Bmori1_room_7Tex_00FFD8" Format="rgba16" Width="32" Height="64" Offset="0xFF68" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_010FD8" OutName="Bmori1_room_7Tex_010FD8" Format="rgba16" Width="32" Height="32" Offset="0x10F68" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_0117D8" OutName="Bmori1_room_7Tex_0117D8" Format="ia16" Width="32" Height="32" Offset="0x11768" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_011FD8" OutName="Bmori1_room_7Tex_011FD8" Format="rgba16" Width="32" Height="64" Offset="0x11F68" AddedByScript="true"/>
         <Room Name="Bmori1_room_7" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_8" Segment="3">
+        <Texture Name="Bmori1_room_8Tex_00AC10" OutName="Bmori1_room_8Tex_00AC10" Format="rgba16" Width="32" Height="32" Offset="0xABF0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_00B410" OutName="Bmori1_room_8Tex_00B410" Format="rgba16" Width="32" Height="64" Offset="0xB3F0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_00C410" OutName="Bmori1_room_8Tex_00C410" Format="rgba16" Width="32" Height="32" Offset="0xC3F0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_00CC10" OutName="Bmori1_room_8Tex_00CC10" Format="ci8" Width="32" Height="32" Offset="0xCBF0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_00D010" OutName="Bmori1_room_8Tex_00D010" Format="ci8" Width="32" Height="32" Offset="0xCFF0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_00D410" OutName="Bmori1_room_8Tex_00D410" Format="ci8" Width="32" Height="32" Offset="0xD3F0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_00D810" OutName="Bmori1_room_8Tex_00D810" Format="ci8" Width="32" Height="64" Offset="0xD7F0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_00E010" OutName="Bmori1_room_8Tex_00E010" Format="ci8" Width="32" Height="64" Offset="0xDFF0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_00E810" OutName="Bmori1_room_8Tex_00E810" Format="ci8" Width="64" Height="32" Offset="0xE7F0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_00F010" OutName="Bmori1_room_8Tex_00F010" Format="ci8" Width="64" Height="32" Offset="0xEFF0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_00F810" OutName="Bmori1_room_8Tex_00F810" Format="rgba16" Width="32" Height="64" Offset="0xF7F0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_010810" OutName="Bmori1_room_8Tex_010810" Format="rgba16" Width="32" Height="64" Offset="0x107F0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_011810" OutName="Bmori1_room_8Tex_011810" Format="ci8" Width="32" Height="32" Offset="0x117F0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_011C10" OutName="Bmori1_room_8Tex_011C10" Format="ci8" Width="64" Height="32" Offset="0x11BF0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_012410" OutName="Bmori1_room_8Tex_012410" Format="rgba16" Width="32" Height="32" Offset="0x123F0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_013AB0" OutName="Bmori1_room_8Tex_013AB0" Format="i4" Width="64" Height="128" Offset="0x13A90" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_014AB0" OutName="Bmori1_room_8Tex_014AB0" Format="rgba16" Width="32" Height="32" Offset="0x14A90" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_0152B0" OutName="Bmori1_room_8Tex_0152B0" Format="ia16" Width="32" Height="32" Offset="0x15290" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_015AB0" OutName="Bmori1_room_8Tex_015AB0" Format="rgba16" Width="32" Height="64" Offset="0x15A90" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_016AB0" OutName="Bmori1_room_8Tex_016AB0" Format="rgba16" Width="32" Height="64" Offset="0x16A90" AddedByScript="true"/>
         <Room Name="Bmori1_room_8" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_9" Segment="3">
+        <Texture Name="Bmori1_room_9Tex_0048B8" OutName="Bmori1_room_9Tex_0048B8" Format="rgba16" Width="32" Height="32" Offset="0x4888" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_9Tex_0050B8" OutName="Bmori1_room_9Tex_0050B8" Format="ci8" Width="32" Height="32" Offset="0x5088" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_9Tex_0054B8" OutName="Bmori1_room_9Tex_0054B8" Format="ci8" Width="32" Height="64" Offset="0x5488" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_9Tex_005CB8" OutName="Bmori1_room_9Tex_005CB8" Format="ci8" Width="64" Height="32" Offset="0x5C88" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_9Tex_0064B8" OutName="Bmori1_room_9Tex_0064B8" Format="rgba16" Width="32" Height="32" Offset="0x6488" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_9Tex_006CB8" OutName="Bmori1_room_9Tex_006CB8" Format="ci8" Width="64" Height="32" Offset="0x6C88" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_9Tex_0074B8" OutName="Bmori1_room_9Tex_0074B8" Format="rgba16" Width="32" Height="64" Offset="0x7488" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_9Tex_008958" OutName="Bmori1_room_9Tex_008958" Format="ia16" Width="32" Height="32" Offset="0x8928" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_9Tex_009158" OutName="Bmori1_room_9Tex_009158" Format="rgba16" Width="32" Height="64" Offset="0x9128" AddedByScript="true"/>
         <Room Name="Bmori1_room_9" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_10" Segment="3">
+        <Texture Name="Bmori1_room_10Tex_001260" OutName="Bmori1_room_10Tex_001260" Format="rgba16" Width="32" Height="32" Offset="0x1250" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_10Tex_001A60" OutName="Bmori1_room_10Tex_001A60" Format="ci8" Width="16" Height="128" Offset="0x1A50" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_10Tex_002260" OutName="Bmori1_room_10Tex_002260" Format="ci8" Width="64" Height="32" Offset="0x2250" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_10Tex_002A60" OutName="Bmori1_room_10Tex_002A60" Format="rgba16" Width="32" Height="64" Offset="0x2A50" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_10Tex_003A60" OutName="Bmori1_room_10Tex_003A60" Format="rgba16" Width="32" Height="64" Offset="0x3A50" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_10Tex_004BD8" OutName="Bmori1_room_10Tex_004BD8" Format="ia16" Width="32" Height="32" Offset="0x4BC8" AddedByScript="true"/>
         <Room Name="Bmori1_room_10" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_11" Segment="3">
+        <Texture Name="Bmori1_room_11Tex_008198" OutName="Bmori1_room_11Tex_008198" Format="rgba16" Width="64" Height="32" Offset="0x8118" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_11Tex_009198" OutName="Bmori1_room_11Tex_009198" Format="ci8" Width="32" Height="32" Offset="0x9118" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_11Tex_009598" OutName="Bmori1_room_11Tex_009598" Format="rgba16" Width="32" Height="32" Offset="0x9518" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_11Tex_009D98" OutName="Bmori1_room_11Tex_009D98" Format="i4" Width="64" Height="64" Offset="0x9D18" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_11Tex_00A598" OutName="Bmori1_room_11Tex_00A598" Format="ci8" Width="32" Height="32" Offset="0xA518" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
         <Room Name="Bmori1_room_11" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_12" Segment="3">
+        <Texture Name="Bmori1_room_12Tex_004A00" OutName="Bmori1_room_12Tex_004A00" Format="ci8" Width="32" Height="32" Offset="0x49F0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_12Tex_004E00" OutName="Bmori1_room_12Tex_004E00" Format="ci8" Width="32" Height="64" Offset="0x4DF0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_12Tex_005600" OutName="Bmori1_room_12Tex_005600" Format="ci8" Width="64" Height="32" Offset="0x55F0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_12Tex_005E00" OutName="Bmori1_room_12Tex_005E00" Format="ci8" Width="64" Height="32" Offset="0x5DF0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_12Tex_006600" OutName="Bmori1_room_12Tex_006600" Format="ci8" Width="64" Height="32" Offset="0x65F0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_12Tex_006E00" OutName="Bmori1_room_12Tex_006E00" Format="ci8" Width="32" Height="32" Offset="0x6DF0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_12Tex_007200" OutName="Bmori1_room_12Tex_007200" Format="rgba16" Width="32" Height="32" Offset="0x71F0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_12Tex_007BD8" OutName="Bmori1_room_12Tex_007BD8" Format="ia16" Width="32" Height="32" Offset="0x7BC8" AddedByScript="true"/>
         <Room Name="Bmori1_room_12" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_13" Segment="3">
+        <Texture Name="Bmori1_room_13Tex_004CD0" OutName="Bmori1_room_13Tex_004CD0" Format="rgba16" Width="32" Height="32" Offset="0x4CC0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_13Tex_0054D0" OutName="Bmori1_room_13Tex_0054D0" Format="ci8" Width="32" Height="64" Offset="0x54C0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_13Tex_005CD0" OutName="Bmori1_room_13Tex_005CD0" Format="ci8" Width="64" Height="32" Offset="0x5CC0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_13Tex_0064D0" OutName="Bmori1_room_13Tex_0064D0" Format="ci8" Width="64" Height="32" Offset="0x64C0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_13Tex_006CD0" OutName="Bmori1_room_13Tex_006CD0" Format="ci8" Width="64" Height="32" Offset="0x6CC0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_13Tex_0074D0" OutName="Bmori1_room_13Tex_0074D0" Format="ci8" Width="32" Height="32" Offset="0x74C0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_13Tex_0078D0" OutName="Bmori1_room_13Tex_0078D0" Format="rgba16" Width="32" Height="32" Offset="0x78C0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_13Tex_0082A8" OutName="Bmori1_room_13Tex_0082A8" Format="ia16" Width="32" Height="32" Offset="0x8298" AddedByScript="true"/>
         <Room Name="Bmori1_room_13" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_14" Segment="3">
+        <Texture Name="Bmori1_room_14Tex_003560" OutName="Bmori1_room_14Tex_003560" Format="ci8" Width="32" Height="32" Offset="0x3530" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_14Tex_003960" OutName="Bmori1_room_14Tex_003960" Format="rgba16" Width="32" Height="32" Offset="0x3930" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_14Tex_004160" OutName="Bmori1_room_14Tex_004160" Format="rgba16" Width="32" Height="32" Offset="0x4130" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_14Tex_004960" OutName="Bmori1_room_14Tex_004960" Format="ci8" Width="32" Height="32" Offset="0x4930" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_14Tex_004D60" OutName="Bmori1_room_14Tex_004D60" Format="ci8" Width="64" Height="32" Offset="0x4D30" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_14Tex_005770" OutName="Bmori1_room_14Tex_005770" Format="ia8" Width="32" Height="32" Offset="0x5740" AddedByScript="true"/>
         <Room Name="Bmori1_room_14" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_15" Segment="3">
+        <Texture Name="Bmori1_room_15Tex_0012E0" OutName="Bmori1_room_15Tex_0012E0" Format="ci8" Width="32" Height="64" Offset="0x1290" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_15Tex_001AE0" OutName="Bmori1_room_15Tex_001AE0" Format="ci8" Width="32" Height="32" Offset="0x1A90" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_15Tex_001EE0" OutName="Bmori1_room_15Tex_001EE0" Format="ci8" Width="64" Height="32" Offset="0x1E90" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
         <Room Name="Bmori1_room_15" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_16" Segment="3">
+        <Texture Name="Bmori1_room_16Tex_002F98" OutName="Bmori1_room_16Tex_002F98" Format="rgba16" Width="32" Height="32" Offset="0x2F98" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_16Tex_003798" OutName="Bmori1_room_16Tex_003798" Format="ci8" Width="64" Height="32" Offset="0x3798" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_16Tex_003F98" OutName="Bmori1_room_16Tex_003F98" Format="ci8" Width="32" Height="32" Offset="0x3F98" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_16Tex_004398" OutName="Bmori1_room_16Tex_004398" Format="ci8" Width="32" Height="32" Offset="0x4398" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_16Tex_004798" OutName="Bmori1_room_16Tex_004798" Format="ci8" Width="64" Height="32" Offset="0x4798" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
         <Room Name="Bmori1_room_16" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_17" Segment="3">
+        <Texture Name="Bmori1_room_17Tex_0064E8" OutName="Bmori1_room_17Tex_0064E8" Format="rgba16" Width="32" Height="32" Offset="0x64B8" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_17Tex_006CE8" OutName="Bmori1_room_17Tex_006CE8" Format="rgba16" Width="32" Height="32" Offset="0x6CB8" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_17Tex_0074E8" OutName="Bmori1_room_17Tex_0074E8" Format="ci8" Width="32" Height="32" Offset="0x74B8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_17Tex_0078E8" OutName="Bmori1_room_17Tex_0078E8" Format="ci8" Width="32" Height="32" Offset="0x78B8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_17Tex_007CE8" OutName="Bmori1_room_17Tex_007CE8" Format="ci8" Width="32" Height="32" Offset="0x7CB8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_17Tex_0080E8" OutName="Bmori1_room_17Tex_0080E8" Format="ci8" Width="64" Height="32" Offset="0x80B8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_17Tex_0088E8" OutName="Bmori1_room_17Tex_0088E8" Format="ci8" Width="32" Height="64" Offset="0x88B8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
         <Room Name="Bmori1_room_17" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_18" Segment="3">
+        <Texture Name="Bmori1_room_18Tex_000B30" OutName="Bmori1_room_18Tex_000B30" Format="ci8" Width="64" Height="32" Offset="0xB40" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
         <Room Name="Bmori1_room_18" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_19" Segment="3">
         <Room Name="Bmori1_room_19" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_20" Segment="3">
+        <Texture Name="Bmori1_room_20Tex_0006F8" OutName="Bmori1_room_20Tex_0006F8" Format="ci8" Width="32" Height="64" Offset="0x6F8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_20Tex_000EF8" OutName="Bmori1_room_20Tex_000EF8" Format="ci8" Width="32" Height="32" Offset="0xEF8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
         <Room Name="Bmori1_room_20" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_21" Segment="3">
+        <Texture Name="Bmori1_room_21Tex_000F70" OutName="Bmori1_room_21Tex_000F70" Format="ci8" Width="64" Height="32" Offset="0xF80" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
         <Room Name="Bmori1_room_21" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_22" Segment="3">
+        <Texture Name="Bmori1_room_22Tex_0005E0" OutName="Bmori1_room_22Tex_0005E0" Format="rgba16" Width="64" Height="32" Offset="0x5E0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_22Tex_0015E0" OutName="Bmori1_room_22Tex_0015E0" Format="ci8" Width="64" Height="32" Offset="0x15E0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
         <Room Name="Bmori1_room_22" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/FIRE_bs.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/FIRE_bs.xml
@@ -1,11 +1,34 @@
 <Root>
     <File Name="FIRE_bs_scene" Segment="2">
+        <Texture Name="FIRE_bs_sceneTex_002C00" OutName="FIRE_bs_sceneTex_002C00" Format="rgba16" Width="32" Height="32" Offset="0x2C00" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_sceneTex_003400" OutName="FIRE_bs_sceneTex_003400" Format="rgba16" Width="32" Height="32" Offset="0x3400" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_sceneTex_003C00" OutName="FIRE_bs_sceneTex_003C00" Format="rgba16" Width="32" Height="32" Offset="0x3C00" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_sceneTex_004400" OutName="FIRE_bs_sceneTex_004400" Format="rgba16" Width="32" Height="32" Offset="0x4400" AddedByScript="true"/>
         <Scene Name="FIRE_bs_scene" Offset="0x0"/>
     </File>
     <File Name="FIRE_bs_room_0" Segment="3">
+        <Texture Name="FIRE_bs_room_0Tex_002E68" OutName="FIRE_bs_room_0Tex_002E68" Format="ci4" Width="32" Height="32" Offset="0x2E68" TlutOffset="0x2E48" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_0Tex_003068" OutName="FIRE_bs_room_0Tex_003068" Format="ci4" Width="32" Height="64" Offset="0x3068" TlutOffset="0x2E48" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_0Tex_003468" OutName="FIRE_bs_room_0Tex_003468" Format="ci4" Width="64" Height="32" Offset="0x3468" TlutOffset="0x2E28" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_0Tex_003868" OutName="FIRE_bs_room_0Tex_003868" Format="ci4" Width="32" Height="32" Offset="0x3868" TlutOffset="0x2E28" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_0Tex_003A68" OutName="FIRE_bs_room_0Tex_003A68" Format="ci4" Width="32" Height="32" Offset="0x3A68" TlutOffset="0x2E28" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_0Tex_003C68" OutName="FIRE_bs_room_0Tex_003C68" Format="ci4" Width="32" Height="64" Offset="0x3C68" TlutOffset="0x2E48" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_0Tex_004068" OutName="FIRE_bs_room_0Tex_004068" Format="ci4" Width="32" Height="32" Offset="0x4068" TlutOffset="0x2E48" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_0TLUT_002E28" OutName="FIRE_bs_room_0TLUT_002E28" Format="rgba16" Width="4" Height="4" Offset="0x2E28" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_0TLUT_002E48" OutName="FIRE_bs_room_0TLUT_002E48" Format="rgba16" Width="4" Height="4" Offset="0x2E48" AddedByScript="true"/>
         <Room Name="FIRE_bs_room_0" Offset="0x0"/>
     </File>
     <File Name="FIRE_bs_room_1" Segment="3">
+        <Texture Name="FIRE_bs_room_1Tex_0049D8" OutName="FIRE_bs_room_1Tex_0049D8" Format="ci4" Width="32" Height="32" Offset="0x49D8" TlutOffset="0x49B8" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_1Tex_004BD8" OutName="FIRE_bs_room_1Tex_004BD8" Format="rgba16" Width="32" Height="32" Offset="0x4BD8" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_1Tex_0053D8" OutName="FIRE_bs_room_1Tex_0053D8" Format="rgba16" Width="32" Height="32" Offset="0x53D8" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_1Tex_005BD8" OutName="FIRE_bs_room_1Tex_005BD8" Format="ci4" Width="64" Height="32" Offset="0x5BD8" TlutOffset="0x4998" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_1Tex_005FD8" OutName="FIRE_bs_room_1Tex_005FD8" Format="ci4" Width="32" Height="32" Offset="0x5FD8" TlutOffset="0x4998" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_1Tex_0061D8" OutName="FIRE_bs_room_1Tex_0061D8" Format="ci4" Width="32" Height="64" Offset="0x61D8" TlutOffset="0x49B8" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_1Tex_0065D8" OutName="FIRE_bs_room_1Tex_0065D8" Format="rgba16" Width="32" Height="32" Offset="0x65D8" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_1Tex_006DD8" OutName="FIRE_bs_room_1Tex_006DD8" Format="ci4" Width="32" Height="32" Offset="0x6DD8" TlutOffset="0x49B8" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_1TLUT_004998" OutName="FIRE_bs_room_1TLUT_004998" Format="rgba16" Width="4" Height="4" Offset="0x4998" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_1TLUT_0049B8" OutName="FIRE_bs_room_1TLUT_0049B8" Format="rgba16" Width="4" Height="4" Offset="0x49B8" AddedByScript="true"/>
         <Room Name="FIRE_bs_room_1" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/HAKAdan.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/HAKAdan.xml
@@ -1,74 +1,191 @@
 <Root>
     <File Name="HAKAdan_scene" Segment="2">
+        <Texture Name="HAKAdan_sceneTex_0163C0" OutName="HAKAdan_sceneTex_0163C0" Format="rgba16" Width="32" Height="32" Offset="0x163C0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_sceneTex_016BC0" OutName="HAKAdan_sceneTex_016BC0" Format="rgba16" Width="32" Height="32" Offset="0x16BC0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_sceneTex_0173C0" OutName="HAKAdan_sceneTex_0173C0" Format="rgba16" Width="32" Height="32" Offset="0x173C0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_sceneTex_017BC0" OutName="HAKAdan_sceneTex_017BC0" Format="rgba16" Width="32" Height="32" Offset="0x17BC0" AddedByScript="true"/>
         <Scene Name="HAKAdan_scene" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_0" Segment="3">
+        <Texture Name="HAKAdan_room_0Tex_008230" OutName="HAKAdan_room_0Tex_008230" Format="rgba16" Width="32" Height="64" Offset="0x81A0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_0Tex_009230" OutName="HAKAdan_room_0Tex_009230" Format="rgba16" Width="32" Height="64" Offset="0x91A0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_0Tex_00A230" OutName="HAKAdan_room_0Tex_00A230" Format="rgba16" Width="32" Height="32" Offset="0xA1A0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_0Tex_00AD48" OutName="HAKAdan_room_0Tex_00AD48" Format="ia8" Width="32" Height="32" Offset="0xACB8" AddedByScript="true"/>
         <Room Name="HAKAdan_room_0" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_1" Segment="3">
+        <Texture Name="HAKAdan_room_1Tex_0012E8" OutName="HAKAdan_room_1Tex_0012E8" Format="rgba16" Width="32" Height="32" Offset="0x12B8" AddedByScript="true"/>
         <Room Name="HAKAdan_room_1" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_2" Segment="3">
+        <Texture Name="HAKAdan_room_2Tex_006BD8" OutName="HAKAdan_room_2Tex_006BD8" Format="i4" Width="64" Height="64" Offset="0x6B08" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_2Tex_0073D8" OutName="HAKAdan_room_2Tex_0073D8" Format="rgba16" Width="32" Height="16" Offset="0x7308" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_2Tex_0077D8" OutName="HAKAdan_room_2Tex_0077D8" Format="rgba16" Width="32" Height="32" Offset="0x7708" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_2Tex_007FD8" OutName="HAKAdan_room_2Tex_007FD8" Format="rgba16" Width="32" Height="8" Offset="0x7F08" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_2Tex_0081D8" OutName="HAKAdan_room_2Tex_0081D8" Format="rgba16" Width="32" Height="64" Offset="0x8108" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_2Tex_0091D8" OutName="HAKAdan_room_2Tex_0091D8" Format="rgba16" Width="32" Height="32" Offset="0x9108" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_2Tex_0099D8" OutName="HAKAdan_room_2Tex_0099D8" Format="i4" Width="32" Height="32" Offset="0x9908" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_2Tex_009BD8" OutName="HAKAdan_room_2Tex_009BD8" Format="rgba16" Width="32" Height="32" Offset="0x9B08" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_2Tex_00A3D8" OutName="HAKAdan_room_2Tex_00A3D8" Format="i4" Width="32" Height="32" Offset="0xA308" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_2Tex_00A5D8" OutName="HAKAdan_room_2Tex_00A5D8" Format="i4" Width="32" Height="32" Offset="0xA508" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_2Tex_00A7D8" OutName="HAKAdan_room_2Tex_00A7D8" Format="i4" Width="32" Height="32" Offset="0xA708" AddedByScript="true"/>
         <Room Name="HAKAdan_room_2" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_3" Segment="3">
+        <Texture Name="HAKAdan_room_3Tex_001578" OutName="HAKAdan_room_3Tex_001578" Format="rgba16" Width="32" Height="32" Offset="0x1538" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_3Tex_001D78" OutName="HAKAdan_room_3Tex_001D78" Format="rgba16" Width="32" Height="32" Offset="0x1D38" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_3Tex_002578" OutName="HAKAdan_room_3Tex_002578" Format="i4" Width="32" Height="32" Offset="0x2538" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_3Tex_002778" OutName="HAKAdan_room_3Tex_002778" Format="i4" Width="32" Height="32" Offset="0x2738" AddedByScript="true"/>
         <Room Name="HAKAdan_room_3" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_4" Segment="3">
+        <Texture Name="HAKAdan_room_4Tex_001458" OutName="HAKAdan_room_4Tex_001458" Format="rgba16" Width="32" Height="32" Offset="0x1438" AddedByScript="true"/>
         <Room Name="HAKAdan_room_4" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_5" Segment="3">
+        <Texture Name="HAKAdan_room_5Tex_003CC0" OutName="HAKAdan_room_5Tex_003CC0" Format="rgba16" Width="32" Height="16" Offset="0x3C60" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_5Tex_0040C0" OutName="HAKAdan_room_5Tex_0040C0" Format="rgba16" Width="32" Height="32" Offset="0x4060" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_5Tex_0048C0" OutName="HAKAdan_room_5Tex_0048C0" Format="rgba16" Width="32" Height="8" Offset="0x4860" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_5Tex_004AC0" OutName="HAKAdan_room_5Tex_004AC0" Format="rgba16" Width="32" Height="32" Offset="0x4A60" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_5Tex_0052C0" OutName="HAKAdan_room_5Tex_0052C0" Format="rgba16" Width="32" Height="32" Offset="0x5260" AddedByScript="true"/>
         <Room Name="HAKAdan_room_5" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_6" Segment="3">
+        <Texture Name="HAKAdan_room_6Tex_004BF0" OutName="HAKAdan_room_6Tex_004BF0" Format="i4" Width="64" Height="64" Offset="0x4B70" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_6Tex_0053F0" OutName="HAKAdan_room_6Tex_0053F0" Format="rgba16" Width="32" Height="8" Offset="0x5370" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_6Tex_0055F0" OutName="HAKAdan_room_6Tex_0055F0" Format="rgba16" Width="32" Height="64" Offset="0x5570" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_6Tex_0065F0" OutName="HAKAdan_room_6Tex_0065F0" Format="rgba16" Width="32" Height="32" Offset="0x6570" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_6Tex_006DF0" OutName="HAKAdan_room_6Tex_006DF0" Format="rgba16" Width="16" Height="32" Offset="0x6D70" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_6Tex_0071F0" OutName="HAKAdan_room_6Tex_0071F0" Format="rgba16" Width="16" Height="32" Offset="0x7170" AddedByScript="true"/>
         <Room Name="HAKAdan_room_6" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_7" Segment="3">
+        <Texture Name="HAKAdan_room_7Tex_0012D8" OutName="HAKAdan_room_7Tex_0012D8" Format="rgba16" Width="32" Height="32" Offset="0x12A8" AddedByScript="true"/>
         <Room Name="HAKAdan_room_7" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_8" Segment="3">
+        <Texture Name="HAKAdan_room_8Tex_003098" OutName="HAKAdan_room_8Tex_003098" Format="rgba16" Width="32" Height="8" Offset="0x3058" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_8Tex_003298" OutName="HAKAdan_room_8Tex_003298" Format="ia4" Width="128" Height="64" Offset="0x3258" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_8Tex_004298" OutName="HAKAdan_room_8Tex_004298" Format="rgba16" Width="32" Height="32" Offset="0x4258" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_8Tex_004A98" OutName="HAKAdan_room_8Tex_004A98" Format="i4" Width="32" Height="32" Offset="0x4A58" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_8Tex_004C98" OutName="HAKAdan_room_8Tex_004C98" Format="rgba16" Width="16" Height="32" Offset="0x4C58" AddedByScript="true"/>
         <Room Name="HAKAdan_room_8" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_9" Segment="3">
+        <Texture Name="HAKAdan_room_9Tex_009090" OutName="HAKAdan_room_9Tex_009090" Format="i4" Width="64" Height="64" Offset="0x8F60" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_9Tex_009890" OutName="HAKAdan_room_9Tex_009890" Format="rgba16" Width="32" Height="32" Offset="0x9760" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_9Tex_00A090" OutName="HAKAdan_room_9Tex_00A090" Format="rgba16" Width="32" Height="8" Offset="0x9F60" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_9Tex_00A290" OutName="HAKAdan_room_9Tex_00A290" Format="ia4" Width="128" Height="64" Offset="0xA160" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_9Tex_00B290" OutName="HAKAdan_room_9Tex_00B290" Format="rgba16" Width="32" Height="32" Offset="0xB160" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_9Tex_00BA90" OutName="HAKAdan_room_9Tex_00BA90" Format="rgba16" Width="16" Height="32" Offset="0xB960" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_9Tex_00BE90" OutName="HAKAdan_room_9Tex_00BE90" Format="rgba16" Width="32" Height="32" Offset="0xBD60" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_9Tex_00C690" OutName="HAKAdan_room_9Tex_00C690" Format="i4" Width="32" Height="32" Offset="0xC560" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_9Tex_00C890" OutName="HAKAdan_room_9Tex_00C890" Format="rgba16" Width="16" Height="32" Offset="0xC760" AddedByScript="true"/>
         <Room Name="HAKAdan_room_9" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_10" Segment="3">
+        <Texture Name="HAKAdan_room_10Tex_0039F0" OutName="HAKAdan_room_10Tex_0039F0" Format="rgba16" Width="32" Height="16" Offset="0x39A0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_10Tex_003DF0" OutName="HAKAdan_room_10Tex_003DF0" Format="rgba16" Width="32" Height="8" Offset="0x3DA0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_10Tex_003FF0" OutName="HAKAdan_room_10Tex_003FF0" Format="rgba16" Width="32" Height="64" Offset="0x3FA0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_10Tex_004FF0" OutName="HAKAdan_room_10Tex_004FF0" Format="ia4" Width="128" Height="64" Offset="0x4FA0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_10Tex_005FF0" OutName="HAKAdan_room_10Tex_005FF0" Format="rgba16" Width="32" Height="32" Offset="0x5FA0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_10Tex_0067F0" OutName="HAKAdan_room_10Tex_0067F0" Format="rgba16" Width="16" Height="32" Offset="0x67A0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_10Tex_006BF0" OutName="HAKAdan_room_10Tex_006BF0" Format="rgba16" Width="16" Height="64" Offset="0x6BA0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_10Tex_0073F0" OutName="HAKAdan_room_10Tex_0073F0" Format="rgba16" Width="16" Height="32" Offset="0x73A0" AddedByScript="true"/>
         <Room Name="HAKAdan_room_10" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_11" Segment="3">
+        <Texture Name="HAKAdan_room_11Tex_001E60" OutName="HAKAdan_room_11Tex_001E60" Format="i4" Width="64" Height="64" Offset="0x1D40" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_11Tex_002660" OutName="HAKAdan_room_11Tex_002660" Format="rgba16" Width="32" Height="16" Offset="0x2540" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_11Tex_002A60" OutName="HAKAdan_room_11Tex_002A60" Format="rgba16" Width="32" Height="8" Offset="0x2940" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_11Tex_002C60" OutName="HAKAdan_room_11Tex_002C60" Format="rgba16" Width="32" Height="32" Offset="0x2B40" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_11Tex_003460" OutName="HAKAdan_room_11Tex_003460" Format="rgba16" Width="32" Height="32" Offset="0x3340" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_11Tex_003C60" OutName="HAKAdan_room_11Tex_003C60" Format="i4" Width="32" Height="32" Offset="0x3B40" AddedByScript="true"/>
         <Room Name="HAKAdan_room_11" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_12" Segment="3">
+        <Texture Name="HAKAdan_room_12Tex_003348" OutName="HAKAdan_room_12Tex_003348" Format="i4" Width="32" Height="32" Offset="0x3318" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_12Tex_003548" OutName="HAKAdan_room_12Tex_003548" Format="i4" Width="32" Height="32" Offset="0x3518" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_12Tex_003748" OutName="HAKAdan_room_12Tex_003748" Format="rgba16" Width="32" Height="16" Offset="0x3718" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_12Tex_003B48" OutName="HAKAdan_room_12Tex_003B48" Format="rgba16" Width="32" Height="8" Offset="0x3B18" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_12Tex_003D48" OutName="HAKAdan_room_12Tex_003D48" Format="rgba16" Width="32" Height="64" Offset="0x3D18" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_12Tex_004D48" OutName="HAKAdan_room_12Tex_004D48" Format="rgba16" Width="32" Height="32" Offset="0x4D18" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_12Tex_005548" OutName="HAKAdan_room_12Tex_005548" Format="i4" Width="32" Height="32" Offset="0x5518" AddedByScript="true"/>
         <Room Name="HAKAdan_room_12" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_13" Segment="3">
+        <Texture Name="HAKAdan_room_13Tex_000818" OutName="HAKAdan_room_13Tex_000818" Format="rgba16" Width="32" Height="32" Offset="0x7A8" AddedByScript="true"/>
         <Room Name="HAKAdan_room_13" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_14" Segment="3">
+        <Texture Name="HAKAdan_room_14Tex_003500" OutName="HAKAdan_room_14Tex_003500" Format="i4" Width="32" Height="32" Offset="0x3540" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_14Tex_003700" OutName="HAKAdan_room_14Tex_003700" Format="i4" Width="32" Height="32" Offset="0x3740" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_14Tex_003900" OutName="HAKAdan_room_14Tex_003900" Format="rgba16" Width="32" Height="16" Offset="0x3940" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_14Tex_003D00" OutName="HAKAdan_room_14Tex_003D00" Format="rgba16" Width="32" Height="8" Offset="0x3D40" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_14Tex_003F00" OutName="HAKAdan_room_14Tex_003F00" Format="rgba16" Width="32" Height="64" Offset="0x3F40" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_14Tex_004F00" OutName="HAKAdan_room_14Tex_004F00" Format="rgba16" Width="32" Height="32" Offset="0x4F40" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_14Tex_005700" OutName="HAKAdan_room_14Tex_005700" Format="i4" Width="32" Height="32" Offset="0x5740" AddedByScript="true"/>
         <Room Name="HAKAdan_room_14" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_15" Segment="3">
+        <Texture Name="HAKAdan_room_15Tex_0056C0" OutName="HAKAdan_room_15Tex_0056C0" Format="i4" Width="32" Height="32" Offset="0x5670" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_15Tex_0058C0" OutName="HAKAdan_room_15Tex_0058C0" Format="i4" Width="32" Height="32" Offset="0x5870" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_15Tex_005AC0" OutName="HAKAdan_room_15Tex_005AC0" Format="rgba16" Width="32" Height="16" Offset="0x5A70" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_15Tex_005EC0" OutName="HAKAdan_room_15Tex_005EC0" Format="rgba16" Width="32" Height="8" Offset="0x5E70" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_15Tex_0060C0" OutName="HAKAdan_room_15Tex_0060C0" Format="rgba16" Width="32" Height="32" Offset="0x6070" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_15Tex_0068C0" OutName="HAKAdan_room_15Tex_0068C0" Format="rgba16" Width="32" Height="32" Offset="0x6870" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_15Tex_0070C0" OutName="HAKAdan_room_15Tex_0070C0" Format="i4" Width="32" Height="32" Offset="0x7070" AddedByScript="true"/>
         <Room Name="HAKAdan_room_15" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_16" Segment="3">
+        <Texture Name="HAKAdan_room_16Tex_001930" OutName="HAKAdan_room_16Tex_001930" Format="rgba16" Width="32" Height="64" Offset="0x1880" AddedByScript="true"/>
         <Room Name="HAKAdan_room_16" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_17" Segment="3">
+        <Texture Name="HAKAdan_room_17Tex_001248" OutName="HAKAdan_room_17Tex_001248" Format="rgba16" Width="32" Height="8" Offset="0x1138" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_17Tex_001448" OutName="HAKAdan_room_17Tex_001448" Format="rgba16" Width="32" Height="32" Offset="0x1338" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_17Tex_001C48" OutName="HAKAdan_room_17Tex_001C48" Format="rgba16" Width="16" Height="32" Offset="0x1B38" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_17Tex_002048" OutName="HAKAdan_room_17Tex_002048" Format="rgba16" Width="16" Height="32" Offset="0x1F38" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_17Tex_0025D8" OutName="HAKAdan_room_17Tex_0025D8" Format="ia16" Width="32" Height="32" Offset="0x24C8" AddedByScript="true"/>
         <Room Name="HAKAdan_room_17" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_18" Segment="3">
+        <Texture Name="HAKAdan_room_18Tex_00B908" OutName="HAKAdan_room_18Tex_00B908" Format="i4" Width="32" Height="32" Offset="0xB878" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_18Tex_00BB08" OutName="HAKAdan_room_18Tex_00BB08" Format="rgba16" Width="32" Height="16" Offset="0xBA78" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_18Tex_00BF08" OutName="HAKAdan_room_18Tex_00BF08" Format="rgba16" Width="32" Height="32" Offset="0xBE78" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_18Tex_00C708" OutName="HAKAdan_room_18Tex_00C708" Format="rgba16" Width="32" Height="8" Offset="0xC678" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_18Tex_00C908" OutName="HAKAdan_room_18Tex_00C908" Format="i4" Width="32" Height="32" Offset="0xC878" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_18Tex_00CB08" OutName="HAKAdan_room_18Tex_00CB08" Format="i4" Width="32" Height="32" Offset="0xCA78" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_18Tex_00CD08" OutName="HAKAdan_room_18Tex_00CD08" Format="i4" Width="32" Height="32" Offset="0xCC78" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_18Tex_00CF08" OutName="HAKAdan_room_18Tex_00CF08" Format="rgba16" Width="16" Height="32" Offset="0xCE78" AddedByScript="true"/>
         <Room Name="HAKAdan_room_18" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_19" Segment="3">
+        <Texture Name="HAKAdan_room_19Tex_001578" OutName="HAKAdan_room_19Tex_001578" Format="rgba16" Width="32" Height="64" Offset="0x1518" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_19Tex_002578" OutName="HAKAdan_room_19Tex_002578" Format="rgba16" Width="32" Height="32" Offset="0x2518" AddedByScript="true"/>
         <Room Name="HAKAdan_room_19" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_20" Segment="3">
+        <Texture Name="HAKAdan_room_20Tex_001640" OutName="HAKAdan_room_20Tex_001640" Format="rgba16" Width="32" Height="32" Offset="0x1620" AddedByScript="true"/>
         <Room Name="HAKAdan_room_20" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_21" Segment="3">
+        <Texture Name="HAKAdan_room_21Tex_006E00" OutName="HAKAdan_room_21Tex_006E00" Format="rgba16" Width="32" Height="32" Offset="0x6D00" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_21Tex_007600" OutName="HAKAdan_room_21Tex_007600" Format="rgba16" Width="32" Height="8" Offset="0x7500" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_21Tex_007800" OutName="HAKAdan_room_21Tex_007800" Format="rgba16" Width="32" Height="64" Offset="0x7700" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_21Tex_008800" OutName="HAKAdan_room_21Tex_008800" Format="rgba16" Width="32" Height="32" Offset="0x8700" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_21Tex_009000" OutName="HAKAdan_room_21Tex_009000" Format="rgba16" Width="32" Height="32" Offset="0x8F00" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_21Tex_009800" OutName="HAKAdan_room_21Tex_009800" Format="rgba16" Width="16" Height="64" Offset="0x9700" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_21Tex_00A000" OutName="HAKAdan_room_21Tex_00A000" Format="rgba16" Width="32" Height="32" Offset="0x9F00" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_21Tex_00A800" OutName="HAKAdan_room_21Tex_00A800" Format="i4" Width="32" Height="32" Offset="0xA700" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_21Tex_00AA00" OutName="HAKAdan_room_21Tex_00AA00" Format="i4" Width="32" Height="32" Offset="0xA900" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_21Tex_00ADA8" OutName="HAKAdan_room_21Tex_00ADA8" Format="rgba16" Width="32" Height="32" Offset="0xACA8" AddedByScript="true"/>
         <Room Name="HAKAdan_room_21" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_22" Segment="3">
+        <Texture Name="HAKAdan_room_22Tex_000FA8" OutName="HAKAdan_room_22Tex_000FA8" Format="rgba16" Width="32" Height="8" Offset="0xF98" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_22Tex_0011A8" OutName="HAKAdan_room_22Tex_0011A8" Format="rgba16" Width="32" Height="64" Offset="0x1198" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_22Tex_0021A8" OutName="HAKAdan_room_22Tex_0021A8" Format="rgba16" Width="32" Height="32" Offset="0x2198" AddedByScript="true"/>
         <Room Name="HAKAdan_room_22" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/HAKAdanCH.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/HAKAdanCH.xml
@@ -1,26 +1,69 @@
 <Root>
     <File Name="HAKAdanCH_scene" Segment="2">
+        <Texture Name="HAKAdanCH_sceneTex_00A590" OutName="HAKAdanCH_sceneTex_00A590" Format="rgba16" Width="32" Height="32" Offset="0xA560" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_sceneTex_00AD90" OutName="HAKAdanCH_sceneTex_00AD90" Format="rgba16" Width="32" Height="32" Offset="0xAD60" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_sceneTex_00B590" OutName="HAKAdanCH_sceneTex_00B590" Format="rgba16" Width="32" Height="32" Offset="0xB560" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_sceneTex_00BD90" OutName="HAKAdanCH_sceneTex_00BD90" Format="rgba16" Width="32" Height="32" Offset="0xBD60" AddedByScript="true"/>
         <Scene Name="HAKAdanCH_scene" Offset="0x0"/>
     </File>
     <File Name="HAKAdanCH_room_0" Segment="3">
+        <Texture Name="HAKAdanCH_room_0Tex_00D720" OutName="HAKAdanCH_room_0Tex_00D720" Format="rgba16" Width="32" Height="32" Offset="0xD5F0" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_00DF20" OutName="HAKAdanCH_room_0Tex_00DF20" Format="rgba16" Width="32" Height="8" Offset="0xDDF0" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_00E120" OutName="HAKAdanCH_room_0Tex_00E120" Format="rgba16" Width="32" Height="64" Offset="0xDFF0" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_00F120" OutName="HAKAdanCH_room_0Tex_00F120" Format="rgba16" Width="32" Height="32" Offset="0xEFF0" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_00F920" OutName="HAKAdanCH_room_0Tex_00F920" Format="rgba16" Width="32" Height="32" Offset="0xF7F0" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_010120" OutName="HAKAdanCH_room_0Tex_010120" Format="rgba16" Width="32" Height="64" Offset="0xFFF0" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_011120" OutName="HAKAdanCH_room_0Tex_011120" Format="rgba16" Width="32" Height="32" Offset="0x10FF0" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_011920" OutName="HAKAdanCH_room_0Tex_011920" Format="rgba16" Width="16" Height="32" Offset="0x117F0" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_011D20" OutName="HAKAdanCH_room_0Tex_011D20" Format="i4" Width="32" Height="32" Offset="0x11BF0" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_011F20" OutName="HAKAdanCH_room_0Tex_011F20" Format="rgba16" Width="16" Height="64" Offset="0x11DF0" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_012720" OutName="HAKAdanCH_room_0Tex_012720" Format="rgba16" Width="32" Height="32" Offset="0x125F0" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_012F20" OutName="HAKAdanCH_room_0Tex_012F20" Format="i4" Width="32" Height="32" Offset="0x12DF0" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_013120" OutName="HAKAdanCH_room_0Tex_013120" Format="i4" Width="32" Height="32" Offset="0x12FF0" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_013320" OutName="HAKAdanCH_room_0Tex_013320" Format="rgba16" Width="16" Height="32" Offset="0x131F0" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_013720" OutName="HAKAdanCH_room_0Tex_013720" Format="rgba16" Width="32" Height="32" Offset="0x135F0" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_013F20" OutName="HAKAdanCH_room_0Tex_013F20" Format="i4" Width="32" Height="32" Offset="0x13DF0" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_014B20" OutName="HAKAdanCH_room_0Tex_014B20" Format="ia4" Width="16" Height="128" Offset="0x149F0" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_014F20" OutName="HAKAdanCH_room_0Tex_014F20" Format="ia16" Width="32" Height="32" Offset="0x14DF0" AddedByScript="true"/>
         <Room Name="HAKAdanCH_room_0" Offset="0x0"/>
     </File>
     <File Name="HAKAdanCH_room_1" Segment="3">
+        <Texture Name="HAKAdanCH_room_1Tex_008D58" OutName="HAKAdanCH_room_1Tex_008D58" Format="rgba16" Width="32" Height="8" Offset="0x8EF8" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_1Tex_008F58" OutName="HAKAdanCH_room_1Tex_008F58" Format="i4" Width="32" Height="32" Offset="0x90F8" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_1Tex_009158" OutName="HAKAdanCH_room_1Tex_009158" Format="i4" Width="32" Height="32" Offset="0x92F8" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_1Tex_009358" OutName="HAKAdanCH_room_1Tex_009358" Format="rgba16" Width="32" Height="16" Offset="0x94F8" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_1Tex_009758" OutName="HAKAdanCH_room_1Tex_009758" Format="rgba16" Width="32" Height="32" Offset="0x98F8" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_1Tex_009F58" OutName="HAKAdanCH_room_1Tex_009F58" Format="i4" Width="32" Height="32" Offset="0xA0F8" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_1Tex_00A158" OutName="HAKAdanCH_room_1Tex_00A158" Format="rgba16" Width="16" Height="32" Offset="0xA2F8" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_1Tex_00A558" OutName="HAKAdanCH_room_1Tex_00A558" Format="rgba16" Width="32" Height="32" Offset="0xA6F8" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_1Tex_00AD58" OutName="HAKAdanCH_room_1Tex_00AD58" Format="i4" Width="32" Height="32" Offset="0xAEF8" AddedByScript="true"/>
         <Room Name="HAKAdanCH_room_1" Offset="0x0"/>
     </File>
     <File Name="HAKAdanCH_room_2" Segment="3">
+        <Texture Name="HAKAdanCH_room_2Tex_002958" OutName="HAKAdanCH_room_2Tex_002958" Format="rgba16" Width="32" Height="8" Offset="0x2988" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_2Tex_002B58" OutName="HAKAdanCH_room_2Tex_002B58" Format="i4" Width="32" Height="32" Offset="0x2B88" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_2Tex_002D58" OutName="HAKAdanCH_room_2Tex_002D58" Format="i4" Width="32" Height="32" Offset="0x2D88" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_2Tex_002F58" OutName="HAKAdanCH_room_2Tex_002F58" Format="i4" Width="32" Height="32" Offset="0x2F88" AddedByScript="true"/>
         <Room Name="HAKAdanCH_room_2" Offset="0x0"/>
     </File>
     <File Name="HAKAdanCH_room_3" Segment="3">
+        <Texture Name="HAKAdanCH_room_3Tex_0014C0" OutName="HAKAdanCH_room_3Tex_0014C0" Format="rgba16" Width="32" Height="32" Offset="0x1460" AddedByScript="true"/>
         <Room Name="HAKAdanCH_room_3" Offset="0x0"/>
     </File>
     <File Name="HAKAdanCH_room_4" Segment="3">
+        <Texture Name="HAKAdanCH_room_4Tex_001498" OutName="HAKAdanCH_room_4Tex_001498" Format="rgba16" Width="32" Height="32" Offset="0x1448" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_4Tex_001C98" OutName="HAKAdanCH_room_4Tex_001C98" Format="rgba16" Width="32" Height="32" Offset="0x1C48" AddedByScript="true"/>
         <Room Name="HAKAdanCH_room_4" Offset="0x0"/>
     </File>
     <File Name="HAKAdanCH_room_5" Segment="3">
+        <Texture Name="HAKAdanCH_room_5Tex_001190" OutName="HAKAdanCH_room_5Tex_001190" Format="rgba16" Width="32" Height="64" Offset="0x1160" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_5Tex_002190" OutName="HAKAdanCH_room_5Tex_002190" Format="rgba16" Width="32" Height="32" Offset="0x2160" AddedByScript="true"/>
         <Room Name="HAKAdanCH_room_5" Offset="0x0"/>
     </File>
     <File Name="HAKAdanCH_room_6" Segment="3">
+        <Texture Name="HAKAdanCH_room_6Tex_000EA0" OutName="HAKAdanCH_room_6Tex_000EA0" Format="rgba16" Width="32" Height="32" Offset="0xE80" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_6Tex_0016A0" OutName="HAKAdanCH_room_6Tex_0016A0" Format="rgba16" Width="32" Height="64" Offset="0x1680" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_6Tex_0026A0" OutName="HAKAdanCH_room_6Tex_0026A0" Format="rgba16" Width="32" Height="32" Offset="0x2680" AddedByScript="true"/>
         <Room Name="HAKAdanCH_room_6" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/HAKAdan_bs.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/HAKAdan_bs.xml
@@ -1,11 +1,23 @@
 <Root>
     <File Name="HAKAdan_bs_scene" Segment="2">
+        <Texture Name="HAKAdan_bs_sceneTex_001380" OutName="HAKAdan_bs_sceneTex_001380" Format="i4" Width="32" Height="32" Offset="0x1380" AddedByScript="true"/>
+        <Texture Name="HAKAdan_bs_sceneTex_001580" OutName="HAKAdan_bs_sceneTex_001580" Format="rgba16" Width="32" Height="8" Offset="0x1580" AddedByScript="true"/>
+        <Texture Name="HAKAdan_bs_sceneTex_001780" OutName="HAKAdan_bs_sceneTex_001780" Format="rgba16" Width="32" Height="32" Offset="0x1780" AddedByScript="true"/>
+        <Texture Name="HAKAdan_bs_sceneTex_001F80" OutName="HAKAdan_bs_sceneTex_001F80" Format="rgba16" Width="32" Height="32" Offset="0x1F80" AddedByScript="true"/>
         <Scene Name="HAKAdan_bs_scene" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_bs_room_0" Segment="3">
+        <Texture Name="HAKAdan_bs_room_0Tex_0021E0" OutName="HAKAdan_bs_room_0Tex_0021E0" Format="i4" Width="32" Height="32" Offset="0x21E0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_bs_room_0Tex_0023E0" OutName="HAKAdan_bs_room_0Tex_0023E0" Format="rgba16" Width="32" Height="16" Offset="0x23E0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_bs_room_0Tex_0027E0" OutName="HAKAdan_bs_room_0Tex_0027E0" Format="i4" Width="32" Height="32" Offset="0x27E0" AddedByScript="true"/>
         <Room Name="HAKAdan_bs_room_0" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_bs_room_1" Segment="3">
+        <Texture Name="HAKAdan_bs_room_1Tex_002D50" OutName="HAKAdan_bs_room_1Tex_002D50" Format="i4" Width="32" Height="32" Offset="0x2D50" AddedByScript="true"/>
+        <Texture Name="HAKAdan_bs_room_1Tex_002F50" OutName="HAKAdan_bs_room_1Tex_002F50" Format="rgba16" Width="32" Height="32" Offset="0x2F50" AddedByScript="true"/>
+        <Texture Name="HAKAdan_bs_room_1Tex_003750" OutName="HAKAdan_bs_room_1Tex_003750" Format="rgba16" Width="32" Height="32" Offset="0x3750" AddedByScript="true"/>
+        <Texture Name="HAKAdan_bs_room_1Tex_003F50" OutName="HAKAdan_bs_room_1Tex_003F50" Format="rgba16" Width="32" Height="64" Offset="0x3F50" AddedByScript="true"/>
+        <Texture Name="HAKAdan_bs_room_1Tex_004F50" OutName="HAKAdan_bs_room_1Tex_004F50" Format="rgba16" Width="32" Height="64" Offset="0x4F50" AddedByScript="true"/>
         <Room Name="HAKAdan_bs_room_1" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/HIDAN.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/HIDAN.xml
@@ -1,87 +1,288 @@
 <Root>
     <File Name="HIDAN_scene" Segment="2">
+        <Texture Name="HIDAN_sceneTex_0189D0" OutName="HIDAN_sceneTex_0189D0" Format="ci4" Width="32" Height="32" Offset="0x18B70" TlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_sceneTex_018BD0" OutName="HIDAN_sceneTex_018BD0" Format="ci4" Width="32" Height="32" Offset="0x18D70" TlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_sceneTex_018DD0" OutName="HIDAN_sceneTex_018DD0" Format="rgba16" Width="32" Height="32" Offset="0x18F70" AddedByScript="true"/>
+        <Texture Name="HIDAN_sceneTex_0195D0" OutName="HIDAN_sceneTex_0195D0" Format="rgba16" Width="32" Height="32" Offset="0x19770" AddedByScript="true"/>
+        <Texture Name="HIDAN_sceneTex_019DD0" OutName="HIDAN_sceneTex_019DD0" Format="ci4" Width="32" Height="32" Offset="0x19F70" TlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_sceneTex_019FD0" OutName="HIDAN_sceneTex_019FD0" Format="rgba16" Width="32" Height="32" Offset="0x1A170" AddedByScript="true"/>
+        <Texture Name="HIDAN_sceneTLUT_018990" OutName="HIDAN_sceneTLUT_018990" Format="rgba16" Width="4" Height="4" Offset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_sceneTLUT_0189B0" OutName="HIDAN_sceneTLUT_0189B0" Format="rgba16" Width="4" Height="4" Offset="0x18B50" AddedByScript="true"/>
         <Path Name="gHidanPath_560" Offset="0x558" NumPaths="19"/>
         <Scene Name="HIDAN_scene" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_0" Segment="3">
+        <Texture Name="HIDAN_room_0Tex_004EF0" OutName="HIDAN_room_0Tex_004EF0" Format="ci4" Width="64" Height="32" Offset="0x4EC0" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_0Tex_0052F0" OutName="HIDAN_room_0Tex_0052F0" Format="ci4" Width="64" Height="32" Offset="0x52C0" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_0Tex_0056F0" OutName="HIDAN_room_0Tex_0056F0" Format="ci4" Width="64" Height="32" Offset="0x56C0" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_0Tex_005AF0" OutName="HIDAN_room_0Tex_005AF0" Format="ci4" Width="32" Height="32" Offset="0x5AC0" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_0Tex_005CF0" OutName="HIDAN_room_0Tex_005CF0" Format="ci4" Width="32" Height="32" Offset="0x5CC0" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_0Tex_005EF0" OutName="HIDAN_room_0Tex_005EF0" Format="ci4" Width="32" Height="64" Offset="0x5EC0" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_0Tex_0062F0" OutName="HIDAN_room_0Tex_0062F0" Format="rgba16" Width="32" Height="64" Offset="0x62C0" AddedByScript="true"/>
         <Room Name="HIDAN_room_0" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_1" Segment="3">
+        <Texture Name="HIDAN_room_1Tex_008730" OutName="HIDAN_room_1Tex_008730" Format="rgba16" Width="16" Height="16" Offset="0x87E0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_1Tex_008930" OutName="HIDAN_room_1Tex_008930" Format="rgba16" Width="32" Height="32" Offset="0x89E0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_1Tex_009130" OutName="HIDAN_room_1Tex_009130" Format="rgba16" Width="32" Height="32" Offset="0x91E0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_1Tex_009930" OutName="HIDAN_room_1Tex_009930" Format="rgba16" Width="32" Height="32" Offset="0x99E0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_1Tex_00A130" OutName="HIDAN_room_1Tex_00A130" Format="ci4" Width="64" Height="32" Offset="0xA1E0" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_1Tex_00A530" OutName="HIDAN_room_1Tex_00A530" Format="rgba16" Width="64" Height="32" Offset="0xA5E0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_1Tex_00B530" OutName="HIDAN_room_1Tex_00B530" Format="rgba16" Width="32" Height="32" Offset="0xB5E0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_1Tex_00BD30" OutName="HIDAN_room_1Tex_00BD30" Format="ci4" Width="32" Height="64" Offset="0xBDE0" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_1Tex_00C130" OutName="HIDAN_room_1Tex_00C130" Format="rgba16" Width="32" Height="32" Offset="0xC1E0" AddedByScript="true"/>
         <Room Name="HIDAN_room_1" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_2" Segment="3">
+        <Texture Name="HIDAN_room_2Tex_009628" OutName="HIDAN_room_2Tex_009628" Format="rgba16" Width="32" Height="8" Offset="0x95C8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_2Tex_009828" OutName="HIDAN_room_2Tex_009828" Format="rgba16" Width="32" Height="32" Offset="0x97C8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_2Tex_00A028" OutName="HIDAN_room_2Tex_00A028" Format="rgba16" Width="32" Height="32" Offset="0x9FC8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_2Tex_00A828" OutName="HIDAN_room_2Tex_00A828" Format="ci4" Width="64" Height="32" Offset="0xA7C8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_2Tex_00AC28" OutName="HIDAN_room_2Tex_00AC28" Format="rgba16" Width="64" Height="32" Offset="0xABC8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_2Tex_00BC28" OutName="HIDAN_room_2Tex_00BC28" Format="rgba16" Width="64" Height="32" Offset="0xBBC8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_2Tex_00CC28" OutName="HIDAN_room_2Tex_00CC28" Format="ci4" Width="32" Height="32" Offset="0xCBC8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_2Tex_00CE28" OutName="HIDAN_room_2Tex_00CE28" Format="rgba16" Width="64" Height="32" Offset="0xCDC8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_2Tex_00DE28" OutName="HIDAN_room_2Tex_00DE28" Format="ci4" Width="32" Height="32" Offset="0xDDC8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_2Tex_00E028" OutName="HIDAN_room_2Tex_00E028" Format="ci4" Width="32" Height="64" Offset="0xDFC8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_2Tex_00E428" OutName="HIDAN_room_2Tex_00E428" Format="rgba16" Width="32" Height="32" Offset="0xE3C8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_2Tex_00EC28" OutName="HIDAN_room_2Tex_00EC28" Format="ci4" Width="32" Height="64" Offset="0xEBC8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_2Tex_00F028" OutName="HIDAN_room_2Tex_00F028" Format="rgba16" Width="32" Height="32" Offset="0xEFC8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_2Tex_00F828" OutName="HIDAN_room_2Tex_00F828" Format="rgba16" Width="32" Height="32" Offset="0xF7C8" AddedByScript="true"/>
         <Room Name="HIDAN_room_2" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_3" Segment="3">
+        <Texture Name="HIDAN_room_3Tex_001AC8" OutName="HIDAN_room_3Tex_001AC8" Format="ci4" Width="32" Height="64" Offset="0x1AD8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_3Tex_001EC8" OutName="HIDAN_room_3Tex_001EC8" Format="ci4" Width="64" Height="32" Offset="0x1ED8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_3Tex_0022C8" OutName="HIDAN_room_3Tex_0022C8" Format="ci4" Width="32" Height="32" Offset="0x22D8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
         <Room Name="HIDAN_room_3" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_4" Segment="3">
+        <Texture Name="HIDAN_room_4Tex_0050F0" OutName="HIDAN_room_4Tex_0050F0" Format="rgba16" Width="32" Height="8" Offset="0x5090" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_4Tex_0052F0" OutName="HIDAN_room_4Tex_0052F0" Format="rgba16" Width="32" Height="32" Offset="0x5290" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_4Tex_005AF0" OutName="HIDAN_room_4Tex_005AF0" Format="rgba16" Width="32" Height="32" Offset="0x5A90" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_4Tex_0062F0" OutName="HIDAN_room_4Tex_0062F0" Format="ci4" Width="32" Height="64" Offset="0x6290" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_4Tex_0066F0" OutName="HIDAN_room_4Tex_0066F0" Format="ci4" Width="32" Height="32" Offset="0x6690" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_4Tex_0068F0" OutName="HIDAN_room_4Tex_0068F0" Format="ci4" Width="32" Height="64" Offset="0x6890" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_4Tex_006CF0" OutName="HIDAN_room_4Tex_006CF0" Format="ci4" Width="32" Height="64" Offset="0x6C90" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_4Tex_0070F0" OutName="HIDAN_room_4Tex_0070F0" Format="rgba16" Width="32" Height="32" Offset="0x7090" AddedByScript="true"/>
         <Room Name="HIDAN_room_4" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_5" Segment="3">
+        <Texture Name="HIDAN_room_5Tex_007EE0" OutName="HIDAN_room_5Tex_007EE0" Format="rgba16" Width="32" Height="8" Offset="0x7E30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_5Tex_0080E0" OutName="HIDAN_room_5Tex_0080E0" Format="rgba16" Width="32" Height="32" Offset="0x8030" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_5Tex_0088E0" OutName="HIDAN_room_5Tex_0088E0" Format="ci4" Width="32" Height="64" Offset="0x8830" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_5Tex_008CE0" OutName="HIDAN_room_5Tex_008CE0" Format="rgba16" Width="32" Height="32" Offset="0x8C30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_5Tex_0094E0" OutName="HIDAN_room_5Tex_0094E0" Format="ci4" Width="32" Height="32" Offset="0x9430" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_5Tex_0096E0" OutName="HIDAN_room_5Tex_0096E0" Format="ci4" Width="32" Height="64" Offset="0x9630" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_5Tex_009AE0" OutName="HIDAN_room_5Tex_009AE0" Format="ci4" Width="32" Height="64" Offset="0x9A30" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_5Tex_009EE0" OutName="HIDAN_room_5Tex_009EE0" Format="ci4" Width="32" Height="64" Offset="0x9E30" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
         <Room Name="HIDAN_room_5" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_6" Segment="3">
+        <Texture Name="HIDAN_room_6Tex_003990" OutName="HIDAN_room_6Tex_003990" Format="rgba16" Width="16" Height="16" Offset="0x39A0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_6Tex_003B90" OutName="HIDAN_room_6Tex_003B90" Format="rgba16" Width="32" Height="32" Offset="0x3BA0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_6Tex_004390" OutName="HIDAN_room_6Tex_004390" Format="rgba16" Width="32" Height="32" Offset="0x43A0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_6Tex_004B90" OutName="HIDAN_room_6Tex_004B90" Format="rgba16" Width="64" Height="32" Offset="0x4BA0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_6Tex_005B90" OutName="HIDAN_room_6Tex_005B90" Format="rgba16" Width="32" Height="32" Offset="0x5BA0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_6Tex_006390" OutName="HIDAN_room_6Tex_006390" Format="ci4" Width="32" Height="64" Offset="0x63A0" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_6Tex_006790" OutName="HIDAN_room_6Tex_006790" Format="rgba16" Width="32" Height="32" Offset="0x67A0" AddedByScript="true"/>
         <Room Name="HIDAN_room_6" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_7" Segment="3">
+        <Texture Name="HIDAN_room_7Tex_001C48" OutName="HIDAN_room_7Tex_001C48" Format="rgba16" Width="32" Height="8" Offset="0x1BD8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_7Tex_001E48" OutName="HIDAN_room_7Tex_001E48" Format="rgba16" Width="32" Height="32" Offset="0x1DD8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_7Tex_002648" OutName="HIDAN_room_7Tex_002648" Format="ci4" Width="32" Height="64" Offset="0x25D8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_7Tex_002A48" OutName="HIDAN_room_7Tex_002A48" Format="rgba16" Width="32" Height="64" Offset="0x29D8" AddedByScript="true"/>
         <Room Name="HIDAN_room_7" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_8" Segment="3">
+        <Texture Name="HIDAN_room_8Tex_0050D8" OutName="HIDAN_room_8Tex_0050D8" Format="rgba16" Width="16" Height="16" Offset="0x50B8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_8Tex_0052D8" OutName="HIDAN_room_8Tex_0052D8" Format="rgba16" Width="32" Height="32" Offset="0x52B8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_8Tex_005AD8" OutName="HIDAN_room_8Tex_005AD8" Format="rgba16" Width="32" Height="32" Offset="0x5AB8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_8Tex_0062D8" OutName="HIDAN_room_8Tex_0062D8" Format="rgba16" Width="32" Height="32" Offset="0x62B8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_8Tex_006AD8" OutName="HIDAN_room_8Tex_006AD8" Format="rgba16" Width="64" Height="32" Offset="0x6AB8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_8Tex_007AD8" OutName="HIDAN_room_8Tex_007AD8" Format="rgba16" Width="32" Height="32" Offset="0x7AB8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_8Tex_0082D8" OutName="HIDAN_room_8Tex_0082D8" Format="ci4" Width="32" Height="64" Offset="0x82B8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_8Tex_0086D8" OutName="HIDAN_room_8Tex_0086D8" Format="ci4" Width="32" Height="64" Offset="0x86B8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_8Tex_008AD8" OutName="HIDAN_room_8Tex_008AD8" Format="rgba16" Width="32" Height="32" Offset="0x8AB8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_8Tex_0092D8" OutName="HIDAN_room_8Tex_0092D8" Format="rgba16" Width="32" Height="32" Offset="0x92B8" AddedByScript="true"/>
         <Room Name="HIDAN_room_8" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_9" Segment="3">
+        <Texture Name="HIDAN_room_9Tex_004768" OutName="HIDAN_room_9Tex_004768" Format="rgba16" Width="32" Height="32" Offset="0x4768" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_9Tex_004F68" OutName="HIDAN_room_9Tex_004F68" Format="rgba16" Width="32" Height="32" Offset="0x4F68" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_9Tex_005768" OutName="HIDAN_room_9Tex_005768" Format="rgba16" Width="32" Height="32" Offset="0x5768" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_9Tex_005F68" OutName="HIDAN_room_9Tex_005F68" Format="rgba16" Width="32" Height="32" Offset="0x5F68" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_9Tex_006768" OutName="HIDAN_room_9Tex_006768" Format="rgba16" Width="32" Height="32" Offset="0x6768" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_9Tex_006F68" OutName="HIDAN_room_9Tex_006F68" Format="rgba16" Width="32" Height="32" Offset="0x6F68" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_9Tex_007768" OutName="HIDAN_room_9Tex_007768" Format="rgba16" Width="32" Height="32" Offset="0x7768" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_9Tex_007F68" OutName="HIDAN_room_9Tex_007F68" Format="rgba16" Width="32" Height="32" Offset="0x7F68" AddedByScript="true"/>
         <Room Name="HIDAN_room_9" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_10" Segment="3">
+        <Texture Name="HIDAN_room_10Tex_011818" OutName="HIDAN_room_10Tex_011818" Format="rgba16" Width="32" Height="8" Offset="0x11898" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_011A18" OutName="HIDAN_room_10Tex_011A18" Format="rgba16" Width="32" Height="32" Offset="0x11A98" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_012218" OutName="HIDAN_room_10Tex_012218" Format="ci4" Width="32" Height="64" Offset="0x12298" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_012618" OutName="HIDAN_room_10Tex_012618" Format="rgba16" Width="32" Height="32" Offset="0x12698" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_012E18" OutName="HIDAN_room_10Tex_012E18" Format="ci4" Width="64" Height="32" Offset="0x12E98" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_013218" OutName="HIDAN_room_10Tex_013218" Format="ci4" Width="32" Height="32" Offset="0x13298" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_013418" OutName="HIDAN_room_10Tex_013418" Format="rgba16" Width="64" Height="32" Offset="0x13498" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_014418" OutName="HIDAN_room_10Tex_014418" Format="rgba16" Width="64" Height="32" Offset="0x14498" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_015418" OutName="HIDAN_room_10Tex_015418" Format="ci4" Width="64" Height="32" Offset="0x15498" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_015818" OutName="HIDAN_room_10Tex_015818" Format="ci4" Width="32" Height="32" Offset="0x15898" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_015A18" OutName="HIDAN_room_10Tex_015A18" Format="rgba16" Width="64" Height="32" Offset="0x15A98" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_016A18" OutName="HIDAN_room_10Tex_016A18" Format="ci4" Width="32" Height="32" Offset="0x16A98" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_016C18" OutName="HIDAN_room_10Tex_016C18" Format="ci4" Width="32" Height="64" Offset="0x16C98" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_017018" OutName="HIDAN_room_10Tex_017018" Format="rgba16" Width="32" Height="32" Offset="0x17098" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_017818" OutName="HIDAN_room_10Tex_017818" Format="ci4" Width="32" Height="64" Offset="0x17898" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_017C18" OutName="HIDAN_room_10Tex_017C18" Format="rgba16" Width="32" Height="32" Offset="0x17C98" AddedByScript="true"/>
         <Room Name="HIDAN_room_10" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_11" Segment="3">
+        <Texture Name="HIDAN_room_11Tex_0027D8" OutName="HIDAN_room_11Tex_0027D8" Format="rgba16" Width="32" Height="32" Offset="0x27B8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_11Tex_002FD8" OutName="HIDAN_room_11Tex_002FD8" Format="ci4" Width="32" Height="64" Offset="0x2FB8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_11Tex_0033D8" OutName="HIDAN_room_11Tex_0033D8" Format="ci4" Width="32" Height="64" Offset="0x33B8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
         <Room Name="HIDAN_room_11" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_12" Segment="3">
+        <Texture Name="HIDAN_room_12Tex_001D68" OutName="HIDAN_room_12Tex_001D68" Format="rgba16" Width="32" Height="8" Offset="0x1D78" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_12Tex_001F68" OutName="HIDAN_room_12Tex_001F68" Format="rgba16" Width="32" Height="32" Offset="0x1F78" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_12Tex_002768" OutName="HIDAN_room_12Tex_002768" Format="ci4" Width="32" Height="64" Offset="0x2778" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
         <Room Name="HIDAN_room_12" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_13" Segment="3">
+        <Texture Name="HIDAN_room_13Tex_00A788" OutName="HIDAN_room_13Tex_00A788" Format="rgba16" Width="32" Height="32" Offset="0xA7D8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_13Tex_00AF88" OutName="HIDAN_room_13Tex_00AF88" Format="ci4" Width="64" Height="32" Offset="0xAFD8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_13Tex_00B388" OutName="HIDAN_room_13Tex_00B388" Format="ci4" Width="32" Height="64" Offset="0xB3D8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_13Tex_00B788" OutName="HIDAN_room_13Tex_00B788" Format="ci4" Width="32" Height="64" Offset="0xB7D8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_13Tex_00BB88" OutName="HIDAN_room_13Tex_00BB88" Format="rgba16" Width="32" Height="32" Offset="0xBBD8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_13Tex_00C388" OutName="HIDAN_room_13Tex_00C388" Format="rgba16" Width="32" Height="32" Offset="0xC3D8" AddedByScript="true"/>
         <Room Name="HIDAN_room_13" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_14" Segment="3">
+        <Texture Name="HIDAN_room_14Tex_0019F8" OutName="HIDAN_room_14Tex_0019F8" Format="ci4" Width="32" Height="64" Offset="0x1A58" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_14Tex_001DF8" OutName="HIDAN_room_14Tex_001DF8" Format="ci4" Width="32" Height="64" Offset="0x1E58" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
         <Room Name="HIDAN_room_14" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_15" Segment="3">
+        <Texture Name="HIDAN_room_15Tex_000D88" OutName="HIDAN_room_15Tex_000D88" Format="ci4" Width="32" Height="64" Offset="0xDC8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
         <Room Name="HIDAN_room_15" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_16" Segment="3">
+        <Texture Name="HIDAN_room_16Tex_006DE0" OutName="HIDAN_room_16Tex_006DE0" Format="rgba16" Width="32" Height="8" Offset="0x6D70" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_16Tex_006FE0" OutName="HIDAN_room_16Tex_006FE0" Format="rgba16" Width="32" Height="32" Offset="0x6F70" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_16Tex_0077E0" OutName="HIDAN_room_16Tex_0077E0" Format="rgba16" Width="32" Height="32" Offset="0x7770" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_16Tex_007FE0" OutName="HIDAN_room_16Tex_007FE0" Format="ci4" Width="32" Height="64" Offset="0x7F70" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_16Tex_0083E0" OutName="HIDAN_room_16Tex_0083E0" Format="ci4" Width="32" Height="32" Offset="0x8370" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_16Tex_0085E0" OutName="HIDAN_room_16Tex_0085E0" Format="rgba16" Width="32" Height="32" Offset="0x8570" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_16Tex_008DE0" OutName="HIDAN_room_16Tex_008DE0" Format="ci4" Width="32" Height="64" Offset="0x8D70" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_16Tex_0091E0" OutName="HIDAN_room_16Tex_0091E0" Format="ci4" Width="32" Height="64" Offset="0x9170" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_16Tex_0095E0" OutName="HIDAN_room_16Tex_0095E0" Format="rgba16" Width="16" Height="64" Offset="0x9570" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_16Tex_009DE0" OutName="HIDAN_room_16Tex_009DE0" Format="rgba16" Width="32" Height="32" Offset="0x9D70" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_16Tex_00A5E0" OutName="HIDAN_room_16Tex_00A5E0" Format="ci4" Width="32" Height="64" Offset="0xA570" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_16Tex_00A9E0" OutName="HIDAN_room_16Tex_00A9E0" Format="rgba16" Width="32" Height="32" Offset="0xA970" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_16Tex_00B1E0" OutName="HIDAN_room_16Tex_00B1E0" Format="rgba16" Width="32" Height="32" Offset="0xB170" AddedByScript="true"/>
         <Room Name="HIDAN_room_16" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_17" Segment="3">
+        <Texture Name="HIDAN_room_17Tex_005168" OutName="HIDAN_room_17Tex_005168" Format="rgba16" Width="32" Height="32" Offset="0x5138" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_17Tex_005968" OutName="HIDAN_room_17Tex_005968" Format="rgba16" Width="32" Height="32" Offset="0x5938" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_17Tex_006168" OutName="HIDAN_room_17Tex_006168" Format="rgba16" Width="32" Height="32" Offset="0x6138" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_17Tex_006968" OutName="HIDAN_room_17Tex_006968" Format="rgba16" Width="32" Height="32" Offset="0x6938" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_17Tex_007168" OutName="HIDAN_room_17Tex_007168" Format="rgba16" Width="32" Height="32" Offset="0x7138" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_17Tex_007968" OutName="HIDAN_room_17Tex_007968" Format="rgba16" Width="32" Height="32" Offset="0x7938" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_17Tex_008168" OutName="HIDAN_room_17Tex_008168" Format="rgba16" Width="32" Height="32" Offset="0x8138" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_17Tex_008968" OutName="HIDAN_room_17Tex_008968" Format="rgba16" Width="32" Height="32" Offset="0x8938" AddedByScript="true"/>
         <Room Name="HIDAN_room_17" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_18" Segment="3">
+        <Texture Name="HIDAN_room_18Tex_0027F8" OutName="HIDAN_room_18Tex_0027F8" Format="rgba16" Width="32" Height="32" Offset="0x2778" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_18Tex_002FF8" OutName="HIDAN_room_18Tex_002FF8" Format="ci4" Width="32" Height="64" Offset="0x2F78" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_18Tex_0033F8" OutName="HIDAN_room_18Tex_0033F8" Format="ci4" Width="64" Height="32" Offset="0x3378" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_18Tex_0037F8" OutName="HIDAN_room_18Tex_0037F8" Format="ci4" Width="32" Height="32" Offset="0x3778" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_18Tex_0039F8" OutName="HIDAN_room_18Tex_0039F8" Format="ci4" Width="32" Height="32" Offset="0x3978" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
         <Room Name="HIDAN_room_18" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_19" Segment="3">
+        <Texture Name="HIDAN_room_19Tex_002E28" OutName="HIDAN_room_19Tex_002E28" Format="rgba16" Width="32" Height="32" Offset="0x2DD8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_19Tex_003628" OutName="HIDAN_room_19Tex_003628" Format="ci4" Width="32" Height="64" Offset="0x35D8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_19Tex_003A28" OutName="HIDAN_room_19Tex_003A28" Format="ci4" Width="64" Height="32" Offset="0x39D8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_19Tex_003E28" OutName="HIDAN_room_19Tex_003E28" Format="ci4" Width="32" Height="32" Offset="0x3DD8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_19Tex_004028" OutName="HIDAN_room_19Tex_004028" Format="ci4" Width="32" Height="32" Offset="0x3FD8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
         <Room Name="HIDAN_room_19" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_20" Segment="3">
+        <Texture Name="HIDAN_room_20Tex_002D08" OutName="HIDAN_room_20Tex_002D08" Format="rgba16" Width="32" Height="32" Offset="0x2D08" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_20Tex_003508" OutName="HIDAN_room_20Tex_003508" Format="rgba16" Width="32" Height="32" Offset="0x3508" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_20Tex_003D08" OutName="HIDAN_room_20Tex_003D08" Format="rgba16" Width="32" Height="32" Offset="0x3D08" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_20Tex_004508" OutName="HIDAN_room_20Tex_004508" Format="rgba16" Width="32" Height="32" Offset="0x4508" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_20Tex_004D08" OutName="HIDAN_room_20Tex_004D08" Format="rgba16" Width="32" Height="32" Offset="0x4D08" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_20Tex_005508" OutName="HIDAN_room_20Tex_005508" Format="rgba16" Width="32" Height="32" Offset="0x5508" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_20Tex_005D08" OutName="HIDAN_room_20Tex_005D08" Format="rgba16" Width="32" Height="32" Offset="0x5D08" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_20Tex_006508" OutName="HIDAN_room_20Tex_006508" Format="rgba16" Width="32" Height="32" Offset="0x6508" AddedByScript="true"/>
         <Room Name="HIDAN_room_20" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_21" Segment="3">
+        <Texture Name="HIDAN_room_21Tex_004478" OutName="HIDAN_room_21Tex_004478" Format="rgba16" Width="32" Height="8" Offset="0x44B8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_21Tex_004678" OutName="HIDAN_room_21Tex_004678" Format="rgba16" Width="32" Height="32" Offset="0x46B8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_21Tex_004E78" OutName="HIDAN_room_21Tex_004E78" Format="rgba16" Width="32" Height="32" Offset="0x4EB8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_21Tex_005678" OutName="HIDAN_room_21Tex_005678" Format="rgba16" Width="32" Height="32" Offset="0x56B8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_21Tex_005E78" OutName="HIDAN_room_21Tex_005E78" Format="rgba16" Width="32" Height="32" Offset="0x5EB8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_21Tex_006678" OutName="HIDAN_room_21Tex_006678" Format="ci4" Width="64" Height="32" Offset="0x66B8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_21Tex_006A78" OutName="HIDAN_room_21Tex_006A78" Format="rgba16" Width="32" Height="32" Offset="0x6AB8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_21Tex_007278" OutName="HIDAN_room_21Tex_007278" Format="ci4" Width="32" Height="32" Offset="0x72B8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_21Tex_007478" OutName="HIDAN_room_21Tex_007478" Format="rgba16" Width="32" Height="32" Offset="0x74B8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_21Tex_007C78" OutName="HIDAN_room_21Tex_007C78" Format="rgba16" Width="32" Height="32" Offset="0x7CB8" AddedByScript="true"/>
         <Room Name="HIDAN_room_21" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_22" Segment="3">
+        <Texture Name="HIDAN_room_22Tex_002AE8" OutName="HIDAN_room_22Tex_002AE8" Format="rgba16" Width="32" Height="32" Offset="0x2AF8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_22Tex_0032E8" OutName="HIDAN_room_22Tex_0032E8" Format="rgba16" Width="32" Height="32" Offset="0x32F8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_22Tex_003AE8" OutName="HIDAN_room_22Tex_003AE8" Format="rgba16" Width="32" Height="32" Offset="0x3AF8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_22Tex_0042E8" OutName="HIDAN_room_22Tex_0042E8" Format="rgba16" Width="32" Height="32" Offset="0x42F8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_22Tex_004AE8" OutName="HIDAN_room_22Tex_004AE8" Format="rgba16" Width="32" Height="32" Offset="0x4AF8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_22Tex_0052E8" OutName="HIDAN_room_22Tex_0052E8" Format="rgba16" Width="32" Height="32" Offset="0x52F8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_22Tex_005AE8" OutName="HIDAN_room_22Tex_005AE8" Format="rgba16" Width="32" Height="32" Offset="0x5AF8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_22Tex_0062E8" OutName="HIDAN_room_22Tex_0062E8" Format="rgba16" Width="32" Height="32" Offset="0x62F8" AddedByScript="true"/>
         <Room Name="HIDAN_room_22" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_23" Segment="3">
+        <Texture Name="HIDAN_room_23Tex_002D18" OutName="HIDAN_room_23Tex_002D18" Format="rgba16" Width="32" Height="32" Offset="0x2D18" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_23Tex_003518" OutName="HIDAN_room_23Tex_003518" Format="rgba16" Width="32" Height="32" Offset="0x3518" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_23Tex_003D18" OutName="HIDAN_room_23Tex_003D18" Format="rgba16" Width="32" Height="32" Offset="0x3D18" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_23Tex_004518" OutName="HIDAN_room_23Tex_004518" Format="rgba16" Width="32" Height="32" Offset="0x4518" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_23Tex_004D18" OutName="HIDAN_room_23Tex_004D18" Format="rgba16" Width="32" Height="32" Offset="0x4D18" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_23Tex_005518" OutName="HIDAN_room_23Tex_005518" Format="rgba16" Width="32" Height="32" Offset="0x5518" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_23Tex_005D18" OutName="HIDAN_room_23Tex_005D18" Format="rgba16" Width="32" Height="32" Offset="0x5D18" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_23Tex_006518" OutName="HIDAN_room_23Tex_006518" Format="rgba16" Width="32" Height="32" Offset="0x6518" AddedByScript="true"/>
         <Room Name="HIDAN_room_23" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_24" Segment="3">
+        <Texture Name="HIDAN_room_24Tex_003B38" OutName="HIDAN_room_24Tex_003B38" Format="ci4" Width="32" Height="64" Offset="0x3B38" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_24Tex_003F38" OutName="HIDAN_room_24Tex_003F38" Format="ci4" Width="64" Height="32" Offset="0x3F38" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_24Tex_004338" OutName="HIDAN_room_24Tex_004338" Format="ci4" Width="64" Height="32" Offset="0x4338" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_24Tex_004738" OutName="HIDAN_room_24Tex_004738" Format="ci4" Width="32" Height="32" Offset="0x4738" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_24Tex_004938" OutName="HIDAN_room_24Tex_004938" Format="ci4" Width="32" Height="64" Offset="0x4938" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_24Tex_004D38" OutName="HIDAN_room_24Tex_004D38" Format="rgba16" Width="32" Height="32" Offset="0x4D38" AddedByScript="true"/>
         <Room Name="HIDAN_room_24" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_25" Segment="3">
+        <Texture Name="HIDAN_room_25Tex_002AD8" OutName="HIDAN_room_25Tex_002AD8" Format="rgba16" Width="32" Height="32" Offset="0x2AD8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_25Tex_0032D8" OutName="HIDAN_room_25Tex_0032D8" Format="rgba16" Width="32" Height="32" Offset="0x32D8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_25Tex_003AD8" OutName="HIDAN_room_25Tex_003AD8" Format="rgba16" Width="32" Height="32" Offset="0x3AD8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_25Tex_0042D8" OutName="HIDAN_room_25Tex_0042D8" Format="rgba16" Width="32" Height="32" Offset="0x42D8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_25Tex_004AD8" OutName="HIDAN_room_25Tex_004AD8" Format="rgba16" Width="32" Height="32" Offset="0x4AD8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_25Tex_0052D8" OutName="HIDAN_room_25Tex_0052D8" Format="rgba16" Width="32" Height="32" Offset="0x52D8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_25Tex_005AD8" OutName="HIDAN_room_25Tex_005AD8" Format="rgba16" Width="32" Height="32" Offset="0x5AD8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_25Tex_0062D8" OutName="HIDAN_room_25Tex_0062D8" Format="rgba16" Width="32" Height="32" Offset="0x62D8" AddedByScript="true"/>
         <Room Name="HIDAN_room_25" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_26" Segment="3">
+        <Texture Name="HIDAN_room_26Tex_004A98" OutName="HIDAN_room_26Tex_004A98" Format="rgba16" Width="32" Height="32" Offset="0x4A98" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_26Tex_005298" OutName="HIDAN_room_26Tex_005298" Format="ci4" Width="64" Height="32" Offset="0x5298" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_26Tex_005698" OutName="HIDAN_room_26Tex_005698" Format="ci4" Width="32" Height="32" Offset="0x5698" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_26Tex_005898" OutName="HIDAN_room_26Tex_005898" Format="rgba16" Width="32" Height="32" Offset="0x5898" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_26Tex_006098" OutName="HIDAN_room_26Tex_006098" Format="rgba16" Width="32" Height="32" Offset="0x6098" AddedByScript="true"/>
         <Room Name="HIDAN_room_26" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/MIZUsin.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/MIZUsin.xml
@@ -1,77 +1,262 @@
 <Root>
     <File Name="MIZUsin_scene" Segment="2">
+        <Texture Name="MIZUsin_sceneTex_013C30" OutName="MIZUsin_sceneTex_013C30" Format="rgba16" Width="32" Height="32" Offset="0x13CF0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_sceneTex_014430" OutName="MIZUsin_sceneTex_014430" Format="rgba16" Width="32" Height="32" Offset="0x144F0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_sceneTex_015030" OutName="MIZUsin_sceneTex_015030" Format="rgba16" Width="32" Height="32" Offset="0x150F0" AddedByScript="true"/>
         <Path Name="gWaterTemplePath_00424" Offset="0x424" NumPaths="7"/>
         <Texture Name="gWaterTempleDayEntranceTex" OutName="day_entrance" Format="ia16" Width="8" Height="64" Offset="0x14CF0"/>
         <Texture Name="gWaterTempleNightEntranceTex" OutName="night_entrance" Format="ia16" Width="8" Height="64" Offset="0x158F0"/>
         <Scene Name="MIZUsin_scene" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_0" Segment="3">
+        <Texture Name="MIZUsin_room_0Tex_00CDF8" OutName="MIZUsin_room_0Tex_00CDF8" Format="i4" Width="64" Height="64" Offset="0xCE48" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_00D5F8" OutName="MIZUsin_room_0Tex_00D5F8" Format="i4" Width="64" Height="64" Offset="0xD648" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_00DDF8" OutName="MIZUsin_room_0Tex_00DDF8" Format="rgba16" Width="32" Height="32" Offset="0xDE48" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_00E5F8" OutName="MIZUsin_room_0Tex_00E5F8" Format="rgba16" Width="32" Height="32" Offset="0xE648" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_00EDF8" OutName="MIZUsin_room_0Tex_00EDF8" Format="rgba16" Width="32" Height="32" Offset="0xEE48" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_00F5F8" OutName="MIZUsin_room_0Tex_00F5F8" Format="rgba16" Width="32" Height="32" Offset="0xF648" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_00FDF8" OutName="MIZUsin_room_0Tex_00FDF8" Format="rgba16" Width="32" Height="32" Offset="0xFE48" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_0105F8" OutName="MIZUsin_room_0Tex_0105F8" Format="rgba16" Width="32" Height="32" Offset="0x10648" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_010DF8" OutName="MIZUsin_room_0Tex_010DF8" Format="rgba16" Width="32" Height="32" Offset="0x10E48" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_0115F8" OutName="MIZUsin_room_0Tex_0115F8" Format="rgba16" Width="32" Height="32" Offset="0x11648" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_011DF8" OutName="MIZUsin_room_0Tex_011DF8" Format="rgba16" Width="32" Height="32" Offset="0x11E48" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_0125F8" OutName="MIZUsin_room_0Tex_0125F8" Format="rgba16" Width="32" Height="32" Offset="0x12648" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_012DF8" OutName="MIZUsin_room_0Tex_012DF8" Format="rgba16" Width="32" Height="32" Offset="0x12E48" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_0135F8" OutName="MIZUsin_room_0Tex_0135F8" Format="rgba16" Width="32" Height="32" Offset="0x13648" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_013DF8" OutName="MIZUsin_room_0Tex_013DF8" Format="rgba16" Width="32" Height="32" Offset="0x13E48" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_0145F8" OutName="MIZUsin_room_0Tex_0145F8" Format="rgba16" Width="32" Height="32" Offset="0x14648" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_015428" OutName="MIZUsin_room_0Tex_015428" Format="ia16" Width="32" Height="32" Offset="0x15478" AddedByScript="true"/>
         <Room Name="MIZUsin_room_0" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_1" Segment="3">
+        <Texture Name="MIZUsin_room_1Tex_0059D0" OutName="MIZUsin_room_1Tex_0059D0" Format="i4" Width="64" Height="64" Offset="0x5960" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_1Tex_0061D0" OutName="MIZUsin_room_1Tex_0061D0" Format="i4" Width="64" Height="64" Offset="0x6160" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_1Tex_0069D0" OutName="MIZUsin_room_1Tex_0069D0" Format="rgba16" Width="32" Height="32" Offset="0x6960" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_1Tex_0071D0" OutName="MIZUsin_room_1Tex_0071D0" Format="rgba16" Width="32" Height="32" Offset="0x7160" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_1Tex_0079D0" OutName="MIZUsin_room_1Tex_0079D0" Format="rgba16" Width="32" Height="32" Offset="0x7960" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_1Tex_0081D0" OutName="MIZUsin_room_1Tex_0081D0" Format="rgba16" Width="32" Height="32" Offset="0x8160" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_1Tex_0089D0" OutName="MIZUsin_room_1Tex_0089D0" Format="rgba16" Width="32" Height="32" Offset="0x8960" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_1Tex_0091D0" OutName="MIZUsin_room_1Tex_0091D0" Format="rgba16" Width="32" Height="32" Offset="0x9160" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_1Tex_0099D0" OutName="MIZUsin_room_1Tex_0099D0" Format="rgba16" Width="32" Height="32" Offset="0x9960" AddedByScript="true"/>
         <Room Name="MIZUsin_room_1" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_2" Segment="3">
+        <Texture Name="MIZUsin_room_2Tex_002AB8" OutName="MIZUsin_room_2Tex_002AB8" Format="rgba16" Width="32" Height="32" Offset="0x29B8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_2Tex_0032B8" OutName="MIZUsin_room_2Tex_0032B8" Format="rgba16" Width="32" Height="32" Offset="0x31B8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_2Tex_003AB8" OutName="MIZUsin_room_2Tex_003AB8" Format="rgba16" Width="32" Height="32" Offset="0x39B8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_2Tex_0042B8" OutName="MIZUsin_room_2Tex_0042B8" Format="rgba16" Width="32" Height="32" Offset="0x41B8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_2Tex_004AB8" OutName="MIZUsin_room_2Tex_004AB8" Format="rgba16" Width="32" Height="32" Offset="0x49B8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_2Tex_005488" OutName="MIZUsin_room_2Tex_005488" Format="ia16" Width="32" Height="32" Offset="0x5388" AddedByScript="true"/>
         <Room Name="MIZUsin_room_2" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_3" Segment="3">
+        <Texture Name="MIZUsin_room_3Tex_0037B8" OutName="MIZUsin_room_3Tex_0037B8" Format="rgba16" Width="32" Height="32" Offset="0x3708" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_3Tex_003FB8" OutName="MIZUsin_room_3Tex_003FB8" Format="rgba16" Width="32" Height="32" Offset="0x3F08" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_3Tex_0047B8" OutName="MIZUsin_room_3Tex_0047B8" Format="rgba16" Width="32" Height="32" Offset="0x4708" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_3Tex_004FB8" OutName="MIZUsin_room_3Tex_004FB8" Format="rgba16" Width="32" Height="32" Offset="0x4F08" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_3Tex_0057B8" OutName="MIZUsin_room_3Tex_0057B8" Format="rgba16" Width="32" Height="32" Offset="0x5708" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_3Tex_005FB8" OutName="MIZUsin_room_3Tex_005FB8" Format="rgba16" Width="32" Height="32" Offset="0x5F08" AddedByScript="true"/>
         <Room Name="MIZUsin_room_3" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_4" Segment="3">
+        <Texture Name="MIZUsin_room_4Tex_002820" OutName="MIZUsin_room_4Tex_002820" Format="i4" Width="64" Height="64" Offset="0x27E0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_4Tex_003020" OutName="MIZUsin_room_4Tex_003020" Format="rgba16" Width="32" Height="32" Offset="0x2FE0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_4Tex_003820" OutName="MIZUsin_room_4Tex_003820" Format="rgba16" Width="32" Height="32" Offset="0x37E0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_4Tex_004020" OutName="MIZUsin_room_4Tex_004020" Format="rgba16" Width="32" Height="32" Offset="0x3FE0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_4Tex_004820" OutName="MIZUsin_room_4Tex_004820" Format="rgba16" Width="32" Height="32" Offset="0x47E0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_4Tex_005020" OutName="MIZUsin_room_4Tex_005020" Format="rgba16" Width="32" Height="32" Offset="0x4FE0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_4Tex_005820" OutName="MIZUsin_room_4Tex_005820" Format="rgba16" Width="32" Height="32" Offset="0x57E0" AddedByScript="true"/>
         <Room Name="MIZUsin_room_4" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_5" Segment="3">
+        <Texture Name="MIZUsin_room_5Tex_003A48" OutName="MIZUsin_room_5Tex_003A48" Format="rgba16" Width="32" Height="32" Offset="0x39F8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_5Tex_004248" OutName="MIZUsin_room_5Tex_004248" Format="rgba16" Width="32" Height="32" Offset="0x41F8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_5Tex_004A48" OutName="MIZUsin_room_5Tex_004A48" Format="rgba16" Width="32" Height="32" Offset="0x49F8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_5Tex_005248" OutName="MIZUsin_room_5Tex_005248" Format="rgba16" Width="32" Height="32" Offset="0x51F8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_5Tex_005A48" OutName="MIZUsin_room_5Tex_005A48" Format="rgba16" Width="32" Height="32" Offset="0x59F8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_5Tex_006248" OutName="MIZUsin_room_5Tex_006248" Format="rgba16" Width="32" Height="32" Offset="0x61F8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_5Tex_006A48" OutName="MIZUsin_room_5Tex_006A48" Format="rgba16" Width="32" Height="32" Offset="0x69F8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_5Tex_007248" OutName="MIZUsin_room_5Tex_007248" Format="rgba16" Width="32" Height="32" Offset="0x71F8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_5Tex_007A48" OutName="MIZUsin_room_5Tex_007A48" Format="rgba16" Width="32" Height="32" Offset="0x79F8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_5Tex_008248" OutName="MIZUsin_room_5Tex_008248" Format="rgba16" Width="32" Height="32" Offset="0x81F8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_5Tex_008A48" OutName="MIZUsin_room_5Tex_008A48" Format="rgba16" Width="32" Height="32" Offset="0x89F8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_5Tex_009248" OutName="MIZUsin_room_5Tex_009248" Format="rgba16" Width="32" Height="32" Offset="0x91F8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_5Tex_009E38" OutName="MIZUsin_room_5Tex_009E38" Format="ia16" Width="32" Height="32" Offset="0x9DE8" AddedByScript="true"/>
         <Room Name="MIZUsin_room_5" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_6" Segment="3">
+        <Texture Name="MIZUsin_room_6Tex_005100" OutName="MIZUsin_room_6Tex_005100" Format="i4" Width="32" Height="32" Offset="0x50C0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_005300" OutName="MIZUsin_room_6Tex_005300" Format="rgba16" Width="32" Height="32" Offset="0x52C0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_005B00" OutName="MIZUsin_room_6Tex_005B00" Format="rgba16" Width="32" Height="32" Offset="0x5AC0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_006300" OutName="MIZUsin_room_6Tex_006300" Format="i4" Width="32" Height="32" Offset="0x62C0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_006500" OutName="MIZUsin_room_6Tex_006500" Format="i4" Width="32" Height="32" Offset="0x64C0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_006700" OutName="MIZUsin_room_6Tex_006700" Format="i4" Width="32" Height="32" Offset="0x66C0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_006900" OutName="MIZUsin_room_6Tex_006900" Format="i4" Width="32" Height="32" Offset="0x68C0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_006B00" OutName="MIZUsin_room_6Tex_006B00" Format="i4" Width="64" Height="64" Offset="0x6AC0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_007300" OutName="MIZUsin_room_6Tex_007300" Format="rgba16" Width="32" Height="32" Offset="0x72C0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_007B00" OutName="MIZUsin_room_6Tex_007B00" Format="rgba16" Width="32" Height="32" Offset="0x7AC0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_008300" OutName="MIZUsin_room_6Tex_008300" Format="rgba16" Width="32" Height="32" Offset="0x82C0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_008B00" OutName="MIZUsin_room_6Tex_008B00" Format="rgba16" Width="32" Height="32" Offset="0x8AC0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_009300" OutName="MIZUsin_room_6Tex_009300" Format="rgba16" Width="32" Height="32" Offset="0x92C0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_009B00" OutName="MIZUsin_room_6Tex_009B00" Format="rgba16" Width="32" Height="32" Offset="0x9AC0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_00A300" OutName="MIZUsin_room_6Tex_00A300" Format="rgba16" Width="32" Height="32" Offset="0xA2C0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_00AB00" OutName="MIZUsin_room_6Tex_00AB00" Format="rgba16" Width="32" Height="32" Offset="0xAAC0" AddedByScript="true"/>
         <Room Name="MIZUsin_room_6" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_7" Segment="3">
+        <Texture Name="MIZUsin_room_7Tex_002560" OutName="MIZUsin_room_7Tex_002560" Format="rgba16" Width="32" Height="32" Offset="0x2550" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_7Tex_002D60" OutName="MIZUsin_room_7Tex_002D60" Format="rgba16" Width="32" Height="32" Offset="0x2D50" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_7Tex_003560" OutName="MIZUsin_room_7Tex_003560" Format="rgba16" Width="32" Height="32" Offset="0x3550" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_7Tex_003D60" OutName="MIZUsin_room_7Tex_003D60" Format="rgba16" Width="32" Height="32" Offset="0x3D50" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_7Tex_004560" OutName="MIZUsin_room_7Tex_004560" Format="rgba16" Width="32" Height="32" Offset="0x4550" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_7Tex_004D60" OutName="MIZUsin_room_7Tex_004D60" Format="rgba16" Width="32" Height="32" Offset="0x4D50" AddedByScript="true"/>
         <Room Name="MIZUsin_room_7" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_8" Segment="3">
+        <Texture Name="MIZUsin_room_8Tex_005D98" OutName="MIZUsin_room_8Tex_005D98" Format="i4" Width="32" Height="32" Offset="0x5CE8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_005F98" OutName="MIZUsin_room_8Tex_005F98" Format="i4" Width="32" Height="32" Offset="0x5EE8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_006198" OutName="MIZUsin_room_8Tex_006198" Format="rgba16" Width="32" Height="32" Offset="0x60E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_006998" OutName="MIZUsin_room_8Tex_006998" Format="rgba16" Width="32" Height="32" Offset="0x68E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_007198" OutName="MIZUsin_room_8Tex_007198" Format="i4" Width="32" Height="32" Offset="0x70E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_007398" OutName="MIZUsin_room_8Tex_007398" Format="i4" Width="32" Height="32" Offset="0x72E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_007598" OutName="MIZUsin_room_8Tex_007598" Format="rgba16" Width="32" Height="32" Offset="0x74E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_007D98" OutName="MIZUsin_room_8Tex_007D98" Format="i4" Width="64" Height="64" Offset="0x7CE8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_008598" OutName="MIZUsin_room_8Tex_008598" Format="rgba16" Width="32" Height="32" Offset="0x84E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_008D98" OutName="MIZUsin_room_8Tex_008D98" Format="rgba16" Width="32" Height="32" Offset="0x8CE8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_009598" OutName="MIZUsin_room_8Tex_009598" Format="rgba16" Width="32" Height="32" Offset="0x94E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_009D98" OutName="MIZUsin_room_8Tex_009D98" Format="rgba16" Width="32" Height="32" Offset="0x9CE8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_00A598" OutName="MIZUsin_room_8Tex_00A598" Format="rgba16" Width="32" Height="32" Offset="0xA4E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_00AD98" OutName="MIZUsin_room_8Tex_00AD98" Format="rgba16" Width="32" Height="32" Offset="0xACE8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_00B598" OutName="MIZUsin_room_8Tex_00B598" Format="rgba16" Width="32" Height="32" Offset="0xB4E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_00BD98" OutName="MIZUsin_room_8Tex_00BD98" Format="rgba16" Width="32" Height="32" Offset="0xBCE8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_00C598" OutName="MIZUsin_room_8Tex_00C598" Format="rgba16" Width="32" Height="32" Offset="0xC4E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_00D578" OutName="MIZUsin_room_8Tex_00D578" Format="ia16" Width="32" Height="32" Offset="0xD4C8" AddedByScript="true"/>
         <Room Name="MIZUsin_room_8" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_9" Segment="3">
+        <Texture Name="MIZUsin_room_9Tex_0036D8" OutName="MIZUsin_room_9Tex_0036D8" Format="i4" Width="64" Height="64" Offset="0x3608" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_9Tex_003ED8" OutName="MIZUsin_room_9Tex_003ED8" Format="rgba16" Width="32" Height="32" Offset="0x3E08" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_9Tex_0046D8" OutName="MIZUsin_room_9Tex_0046D8" Format="rgba16" Width="32" Height="32" Offset="0x4608" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_9Tex_004ED8" OutName="MIZUsin_room_9Tex_004ED8" Format="rgba16" Width="32" Height="32" Offset="0x4E08" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_9Tex_0056D8" OutName="MIZUsin_room_9Tex_0056D8" Format="rgba16" Width="32" Height="32" Offset="0x5608" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_9Tex_005ED8" OutName="MIZUsin_room_9Tex_005ED8" Format="rgba16" Width="32" Height="32" Offset="0x5E08" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_9Tex_0066D8" OutName="MIZUsin_room_9Tex_0066D8" Format="rgba16" Width="32" Height="32" Offset="0x6608" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_9Tex_006ED8" OutName="MIZUsin_room_9Tex_006ED8" Format="rgba16" Width="32" Height="32" Offset="0x6E08" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_9Tex_0078A8" OutName="MIZUsin_room_9Tex_0078A8" Format="ia16" Width="32" Height="32" Offset="0x77D8" AddedByScript="true"/>
         <Room Name="MIZUsin_room_9" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_10" Segment="3">
+        <Texture Name="MIZUsin_room_10Tex_003870" OutName="MIZUsin_room_10Tex_003870" Format="rgba16" Width="32" Height="32" Offset="0x37B0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_10Tex_004070" OutName="MIZUsin_room_10Tex_004070" Format="rgba16" Width="32" Height="32" Offset="0x3FB0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_10Tex_004870" OutName="MIZUsin_room_10Tex_004870" Format="rgba16" Width="32" Height="32" Offset="0x47B0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_10Tex_005070" OutName="MIZUsin_room_10Tex_005070" Format="rgba16" Width="32" Height="32" Offset="0x4FB0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_10Tex_005870" OutName="MIZUsin_room_10Tex_005870" Format="rgba16" Width="32" Height="32" Offset="0x57B0" AddedByScript="true"/>
         <Room Name="MIZUsin_room_10" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_11" Segment="3">
+        <Texture Name="MIZUsin_room_11Tex_002220" OutName="MIZUsin_room_11Tex_002220" Format="rgba16" Width="32" Height="32" Offset="0x21B0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_11Tex_002A20" OutName="MIZUsin_room_11Tex_002A20" Format="rgba16" Width="32" Height="32" Offset="0x29B0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_11Tex_003220" OutName="MIZUsin_room_11Tex_003220" Format="rgba16" Width="32" Height="32" Offset="0x31B0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_11Tex_003A20" OutName="MIZUsin_room_11Tex_003A20" Format="rgba16" Width="32" Height="32" Offset="0x39B0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_11Tex_004220" OutName="MIZUsin_room_11Tex_004220" Format="rgba16" Width="32" Height="32" Offset="0x41B0" AddedByScript="true"/>
         <Room Name="MIZUsin_room_11" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_12" Segment="3">
+        <Texture Name="MIZUsin_room_12Tex_0039C8" OutName="MIZUsin_room_12Tex_0039C8" Format="rgba16" Width="32" Height="32" Offset="0x3928" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_12Tex_0041C8" OutName="MIZUsin_room_12Tex_0041C8" Format="rgba16" Width="32" Height="32" Offset="0x4128" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_12Tex_0049C8" OutName="MIZUsin_room_12Tex_0049C8" Format="rgba16" Width="32" Height="32" Offset="0x4928" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_12Tex_0051C8" OutName="MIZUsin_room_12Tex_0051C8" Format="rgba16" Width="32" Height="32" Offset="0x5128" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_12Tex_006628" OutName="MIZUsin_room_12Tex_006628" Format="ia16" Width="32" Height="32" Offset="0x6588" AddedByScript="true"/>
         <Room Name="MIZUsin_room_12" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_13" Segment="3">
+        <Texture Name="MIZUsin_room_13Tex_0001F8" OutName="MIZUsin_room_13Tex_0001F8" Format="rgba16" Width="32" Height="32" Offset="0x1F8" AddedByScript="true"/>
         <Room Name="MIZUsin_room_13" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_14" Segment="3">
+        <Texture Name="MIZUsin_room_14Tex_003680" OutName="MIZUsin_room_14Tex_003680" Format="i4" Width="64" Height="64" Offset="0x3660" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_14Tex_003E80" OutName="MIZUsin_room_14Tex_003E80" Format="rgba16" Width="32" Height="32" Offset="0x3E60" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_14Tex_004680" OutName="MIZUsin_room_14Tex_004680" Format="rgba16" Width="32" Height="32" Offset="0x4660" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_14Tex_004E80" OutName="MIZUsin_room_14Tex_004E80" Format="rgba16" Width="32" Height="32" Offset="0x4E60" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_14Tex_005680" OutName="MIZUsin_room_14Tex_005680" Format="rgba16" Width="32" Height="32" Offset="0x5660" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_14Tex_005E80" OutName="MIZUsin_room_14Tex_005E80" Format="rgba16" Width="32" Height="32" Offset="0x5E60" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_14Tex_006680" OutName="MIZUsin_room_14Tex_006680" Format="rgba16" Width="32" Height="32" Offset="0x6660" AddedByScript="true"/>
         <Room Name="MIZUsin_room_14" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_15" Segment="3">
+        <Texture Name="MIZUsin_room_15Tex_002C68" OutName="MIZUsin_room_15Tex_002C68" Format="i4" Width="64" Height="64" Offset="0x2C28" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_15Tex_003468" OutName="MIZUsin_room_15Tex_003468" Format="rgba16" Width="32" Height="32" Offset="0x3428" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_15Tex_003C68" OutName="MIZUsin_room_15Tex_003C68" Format="rgba16" Width="32" Height="32" Offset="0x3C28" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_15Tex_004468" OutName="MIZUsin_room_15Tex_004468" Format="rgba16" Width="32" Height="32" Offset="0x4428" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_15Tex_004C68" OutName="MIZUsin_room_15Tex_004C68" Format="rgba16" Width="32" Height="32" Offset="0x4C28" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_15Tex_005468" OutName="MIZUsin_room_15Tex_005468" Format="rgba16" Width="32" Height="32" Offset="0x5428" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_15Tex_005C68" OutName="MIZUsin_room_15Tex_005C68" Format="rgba16" Width="32" Height="32" Offset="0x5C28" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_15Tex_006468" OutName="MIZUsin_room_15Tex_006468" Format="rgba16" Width="32" Height="32" Offset="0x6428" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_15Tex_006C68" OutName="MIZUsin_room_15Tex_006C68" Format="rgba16" Width="32" Height="32" Offset="0x6C28" AddedByScript="true"/>
         <Room Name="MIZUsin_room_15" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_16" Segment="3">
+        <Texture Name="MIZUsin_room_16Tex_001330" OutName="MIZUsin_room_16Tex_001330" Format="rgba16" Width="32" Height="32" Offset="0x12D0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_16Tex_001B30" OutName="MIZUsin_room_16Tex_001B30" Format="rgba16" Width="32" Height="32" Offset="0x1AD0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_16Tex_002330" OutName="MIZUsin_room_16Tex_002330" Format="rgba16" Width="32" Height="32" Offset="0x22D0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_16Tex_002B30" OutName="MIZUsin_room_16Tex_002B30" Format="rgba16" Width="32" Height="32" Offset="0x2AD0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_16Tex_003330" OutName="MIZUsin_room_16Tex_003330" Format="rgba16" Width="32" Height="32" Offset="0x32D0" AddedByScript="true"/>
         <Room Name="MIZUsin_room_16" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_17" Segment="3">
+        <Texture Name="MIZUsin_room_17Tex_005AA8" OutName="MIZUsin_room_17Tex_005AA8" Format="rgba16" Width="32" Height="32" Offset="0x5A18" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_17Tex_0062A8" OutName="MIZUsin_room_17Tex_0062A8" Format="i4" Width="64" Height="64" Offset="0x6218" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_17Tex_006AA8" OutName="MIZUsin_room_17Tex_006AA8" Format="rgba16" Width="32" Height="32" Offset="0x6A18" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_17Tex_0072A8" OutName="MIZUsin_room_17Tex_0072A8" Format="rgba16" Width="32" Height="32" Offset="0x7218" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_17Tex_007AA8" OutName="MIZUsin_room_17Tex_007AA8" Format="rgba16" Width="32" Height="32" Offset="0x7A18" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_17Tex_0082A8" OutName="MIZUsin_room_17Tex_0082A8" Format="rgba16" Width="32" Height="32" Offset="0x8218" AddedByScript="true"/>
         <Room Name="MIZUsin_room_17" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_18" Segment="3">
+        <Texture Name="MIZUsin_room_18Tex_0018F8" OutName="MIZUsin_room_18Tex_0018F8" Format="rgba16" Width="32" Height="32" Offset="0x18B8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_18Tex_0020F8" OutName="MIZUsin_room_18Tex_0020F8" Format="rgba16" Width="32" Height="32" Offset="0x20B8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_18Tex_0028F8" OutName="MIZUsin_room_18Tex_0028F8" Format="rgba16" Width="32" Height="32" Offset="0x28B8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_18Tex_0030F8" OutName="MIZUsin_room_18Tex_0030F8" Format="rgba16" Width="32" Height="32" Offset="0x30B8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_18Tex_0038F8" OutName="MIZUsin_room_18Tex_0038F8" Format="rgba16" Width="32" Height="32" Offset="0x38B8" AddedByScript="true"/>
         <Room Name="MIZUsin_room_18" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_19" Segment="3">
+        <Texture Name="MIZUsin_room_19Tex_001130" OutName="MIZUsin_room_19Tex_001130" Format="rgba16" Width="32" Height="32" Offset="0x1130" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_19Tex_001930" OutName="MIZUsin_room_19Tex_001930" Format="rgba16" Width="32" Height="32" Offset="0x1930" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_19Tex_002130" OutName="MIZUsin_room_19Tex_002130" Format="rgba16" Width="32" Height="32" Offset="0x2130" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_19Tex_002930" OutName="MIZUsin_room_19Tex_002930" Format="rgba16" Width="32" Height="32" Offset="0x2930" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_19Tex_003130" OutName="MIZUsin_room_19Tex_003130" Format="rgba16" Width="32" Height="32" Offset="0x3130" AddedByScript="true"/>
         <Room Name="MIZUsin_room_19" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_20" Segment="3">
+        <Texture Name="MIZUsin_room_20Tex_003040" OutName="MIZUsin_room_20Tex_003040" Format="rgba16" Width="32" Height="32" Offset="0x2F40" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_20Tex_003840" OutName="MIZUsin_room_20Tex_003840" Format="i4" Width="64" Height="64" Offset="0x3740" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_20Tex_004040" OutName="MIZUsin_room_20Tex_004040" Format="rgba16" Width="32" Height="32" Offset="0x3F40" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_20Tex_004840" OutName="MIZUsin_room_20Tex_004840" Format="rgba16" Width="32" Height="32" Offset="0x4740" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_20Tex_005040" OutName="MIZUsin_room_20Tex_005040" Format="rgba16" Width="32" Height="32" Offset="0x4F40" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_20Tex_005840" OutName="MIZUsin_room_20Tex_005840" Format="rgba16" Width="32" Height="32" Offset="0x5740" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_20Tex_006040" OutName="MIZUsin_room_20Tex_006040" Format="rgba16" Width="32" Height="32" Offset="0x5F40" AddedByScript="true"/>
         <Room Name="MIZUsin_room_20" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_21" Segment="3">
+        <Texture Name="MIZUsin_room_21Tex_004360" OutName="MIZUsin_room_21Tex_004360" Format="rgba16" Width="32" Height="32" Offset="0x4360" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_21Tex_004B60" OutName="MIZUsin_room_21Tex_004B60" Format="rgba16" Width="32" Height="32" Offset="0x4B60" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_21Tex_005360" OutName="MIZUsin_room_21Tex_005360" Format="rgba16" Width="32" Height="32" Offset="0x5360" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_21Tex_005B60" OutName="MIZUsin_room_21Tex_005B60" Format="rgba16" Width="32" Height="32" Offset="0x5B60" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_21Tex_006CA0" OutName="MIZUsin_room_21Tex_006CA0" Format="ia16" Width="32" Height="32" Offset="0x6CA0" AddedByScript="true"/>
         <Room Name="MIZUsin_room_21" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_22" Segment="3">
+        <Texture Name="MIZUsin_room_22Tex_0044E8" OutName="MIZUsin_room_22Tex_0044E8" Format="rgba16" Width="32" Height="16" Offset="0x44E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_22Tex_0048E8" OutName="MIZUsin_room_22Tex_0048E8" Format="rgba16" Width="32" Height="32" Offset="0x48E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_22Tex_0050E8" OutName="MIZUsin_room_22Tex_0050E8" Format="rgba16" Width="32" Height="32" Offset="0x50E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_22Tex_0058E8" OutName="MIZUsin_room_22Tex_0058E8" Format="rgba16" Width="32" Height="32" Offset="0x58E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_22Tex_0060E8" OutName="MIZUsin_room_22Tex_0060E8" Format="rgba16" Width="32" Height="32" Offset="0x60E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_22Tex_0068E8" OutName="MIZUsin_room_22Tex_0068E8" Format="rgba16" Width="32" Height="32" Offset="0x68E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_22Tex_0070E8" OutName="MIZUsin_room_22Tex_0070E8" Format="rgba16" Width="32" Height="32" Offset="0x70E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_22Tex_0078E8" OutName="MIZUsin_room_22Tex_0078E8" Format="rgba16" Width="32" Height="32" Offset="0x78E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_22Tex_0080E8" OutName="MIZUsin_room_22Tex_0080E8" Format="rgba16" Width="32" Height="32" Offset="0x80E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_22Tex_0088E8" OutName="MIZUsin_room_22Tex_0088E8" Format="rgba16" Width="32" Height="32" Offset="0x88E8" AddedByScript="true"/>
         <Room Name="MIZUsin_room_22" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/MIZUsin_bs.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/MIZUsin_bs.xml
@@ -3,9 +3,27 @@
         <Scene Name="MIZUsin_bs_scene" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_bs_room_0" Segment="3">
+        <Texture Name="MIZUsin_bs_room_0Tex_001470" OutName="MIZUsin_bs_room_0Tex_001470" Format="rgba16" Width="32" Height="32" Offset="0x1470" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_0Tex_001C70" OutName="MIZUsin_bs_room_0Tex_001C70" Format="rgba16" Width="32" Height="32" Offset="0x1C70" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_0Tex_002470" OutName="MIZUsin_bs_room_0Tex_002470" Format="rgba16" Width="32" Height="32" Offset="0x2470" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_0Tex_002C70" OutName="MIZUsin_bs_room_0Tex_002C70" Format="rgba16" Width="32" Height="32" Offset="0x2C70" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_0Tex_003470" OutName="MIZUsin_bs_room_0Tex_003470" Format="rgba16" Width="32" Height="32" Offset="0x3470" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_0Tex_003C70" OutName="MIZUsin_bs_room_0Tex_003C70" Format="rgba16" Width="32" Height="32" Offset="0x3C70" AddedByScript="true"/>
         <Room Name="MIZUsin_bs_room_0" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_bs_room_1" Segment="3">
+        <Texture Name="MIZUsin_bs_room_1Tex_0056E8" OutName="MIZUsin_bs_room_1Tex_0056E8" Format="rgba16" Width="32" Height="32" Offset="0x56E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_1Tex_005EE8" OutName="MIZUsin_bs_room_1Tex_005EE8" Format="rgba16" Width="32" Height="32" Offset="0x5EE8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_1Tex_0066E8" OutName="MIZUsin_bs_room_1Tex_0066E8" Format="rgba16" Width="32" Height="32" Offset="0x66E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_1Tex_006EE8" OutName="MIZUsin_bs_room_1Tex_006EE8" Format="rgba16" Width="32" Height="32" Offset="0x6EE8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_1Tex_0076E8" OutName="MIZUsin_bs_room_1Tex_0076E8" Format="rgba16" Width="32" Height="32" Offset="0x76E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_1Tex_007EE8" OutName="MIZUsin_bs_room_1Tex_007EE8" Format="rgba16" Width="32" Height="32" Offset="0x7EE8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_1Tex_0086E8" OutName="MIZUsin_bs_room_1Tex_0086E8" Format="rgba16" Width="32" Height="32" Offset="0x86E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_1Tex_008EE8" OutName="MIZUsin_bs_room_1Tex_008EE8" Format="rgba16" Width="32" Height="16" Offset="0x8EE8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_1Tex_0092E8" OutName="MIZUsin_bs_room_1Tex_0092E8" Format="rgba16" Width="32" Height="32" Offset="0x92E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_1Tex_009AE8" OutName="MIZUsin_bs_room_1Tex_009AE8" Format="rgba16" Width="32" Height="32" Offset="0x9AE8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_1Tex_00A2E8" OutName="MIZUsin_bs_room_1Tex_00A2E8" Format="rgba16" Width="32" Height="32" Offset="0xA2E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_1Tex_00AAE8" OutName="MIZUsin_bs_room_1Tex_00AAE8" Format="i4" Width="64" Height="64" Offset="0xAAE8" AddedByScript="true"/>
         <Room Name="MIZUsin_bs_room_1" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/bdan.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/bdan.xml
@@ -1,36 +1,69 @@
 <Root>
     <File Name="bdan_scene" Segment="2">
+        <Texture Name="bdan_sceneTex_013E00" OutName="bdan_sceneTex_013E00" Format="ci8" Width="32" Height="64" Offset="0x13DE0" TlutOffset="0x13BD8" AddedByScript="true"/>
+        <Texture Name="bdan_sceneTex_014600" OutName="bdan_sceneTex_014600" Format="ci8" Width="32" Height="32" Offset="0x145E0" TlutOffset="0x13BD8" AddedByScript="true"/>
+        <Texture Name="bdan_sceneTex_014A00" OutName="bdan_sceneTex_014A00" Format="ci8" Width="32" Height="64" Offset="0x149E0" TlutOffset="0x13BD8" AddedByScript="true"/>
+        <Texture Name="bdan_sceneTex_015200" OutName="bdan_sceneTex_015200" Format="ci8" Width="32" Height="32" Offset="0x151E0" TlutOffset="0x139D0" AddedByScript="true"/>
+        <Texture Name="bdan_sceneTLUT_0139F0" OutName="bdan_sceneTLUT_0139F0" Format="rgba16" Width="16" Height="16" Offset="0x139D0" AddedByScript="true"/>
+        <Texture Name="bdan_sceneTLUT_013BF8" OutName="bdan_sceneTLUT_013BF8" Format="rgba16" Width="16" Height="16" Offset="0x13BD8" AddedByScript="true"/>
         <Cutscene Name="gJabuJabuIntroCs" Offset="0x155E0"/>
         <Scene Name="bdan_scene" Offset="0x0"/>
     </File>
     <File Name="bdan_room_0" Segment="3">
+        <Texture Name="bdan_room_0Tex_002DB8" OutName="bdan_room_0Tex_002DB8" Format="ci8" Width="32" Height="32" Offset="0x2CE8" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
+        <Texture Name="bdan_room_0Tex_0031B8" OutName="bdan_room_0Tex_0031B8" Format="ci8" Width="32" Height="64" Offset="0x30E8" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
+        <Texture Name="bdan_room_0Tex_0039B8" OutName="bdan_room_0Tex_0039B8" Format="ci8" Width="32" Height="32" Offset="0x38E8" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
         <Room Name="bdan_room_0" Offset="0x0"/>
     </File>
     <File Name="bdan_room_1" Segment="3">
+        <Texture Name="bdan_room_1Tex_004E00" OutName="bdan_room_1Tex_004E00" Format="ci8" Width="32" Height="64" Offset="0x4CD0" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
+        <Texture Name="bdan_room_1Tex_005600" OutName="bdan_room_1Tex_005600" Format="ci8" Width="32" Height="64" Offset="0x54D0" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
         <Room Name="bdan_room_1" Offset="0x0"/>
     </File>
     <File Name="bdan_room_2" Segment="3">
+        <Texture Name="bdan_room_2Tex_006E38" OutName="bdan_room_2Tex_006E38" Format="rgba16" Width="32" Height="64" Offset="0x6DC8" AddedByScript="true"/>
+        <Texture Name="bdan_room_2Tex_007E38" OutName="bdan_room_2Tex_007E38" Format="ci8" Width="32" Height="64" Offset="0x7DC8" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
+        <Texture Name="bdan_room_2Tex_008638" OutName="bdan_room_2Tex_008638" Format="ci8" Width="32" Height="64" Offset="0x85C8" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
+        <Texture Name="bdan_room_2Tex_008E38" OutName="bdan_room_2Tex_008E38" Format="ci8" Width="32" Height="32" Offset="0x8DC8" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
         <Room Name="bdan_room_2" Offset="0x0"/>
     </File>
     <File Name="bdan_room_3" Segment="3">
+        <Texture Name="bdan_room_3Tex_004888" OutName="bdan_room_3Tex_004888" Format="rgba16" Width="32" Height="64" Offset="0x4788" AddedByScript="true"/>
+        <Texture Name="bdan_room_3Tex_005888" OutName="bdan_room_3Tex_005888" Format="ci8" Width="32" Height="64" Offset="0x5788" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
+        <Texture Name="bdan_room_3Tex_006088" OutName="bdan_room_3Tex_006088" Format="ci8" Width="32" Height="32" Offset="0x5F88" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
+        <Texture Name="bdan_room_3Tex_006488" OutName="bdan_room_3Tex_006488" Format="ci8" Width="32" Height="64" Offset="0x6388" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
+        <Texture Name="bdan_room_3Tex_006C88" OutName="bdan_room_3Tex_006C88" Format="ci8" Width="32" Height="32" Offset="0x6B88" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
         <Room Name="bdan_room_3" Offset="0x0"/>
     </File>
     <File Name="bdan_room_4" Segment="3">
+        <Texture Name="bdan_room_4Tex_002B30" OutName="bdan_room_4Tex_002B30" Format="ci8" Width="32" Height="32" Offset="0x2A80" ExternalTlut="bdan_scene" ExternalTlutOffset="0x139D0" AddedByScript="true"/>
+        <Texture Name="bdan_room_4Tex_002F30" OutName="bdan_room_4Tex_002F30" Format="ci8" Width="32" Height="64" Offset="0x2E80" ExternalTlut="bdan_scene" ExternalTlutOffset="0x139D0" AddedByScript="true"/>
+        <Texture Name="bdan_room_4Tex_003730" OutName="bdan_room_4Tex_003730" Format="ci8" Width="32" Height="64" Offset="0x3680" ExternalTlut="bdan_scene" ExternalTlutOffset="0x139D0" AddedByScript="true"/>
         <Room Name="bdan_room_4" Offset="0x0"/>
     </File>
     <File Name="bdan_room_5" Segment="3">
+        <Texture Name="bdan_room_5Tex_0024A8" OutName="bdan_room_5Tex_0024A8" Format="ci8" Width="32" Height="32" Offset="0x2438" ExternalTlut="bdan_scene" ExternalTlutOffset="0x139D0" AddedByScript="true"/>
+        <Texture Name="bdan_room_5Tex_0028A8" OutName="bdan_room_5Tex_0028A8" Format="ci8" Width="32" Height="64" Offset="0x2838" ExternalTlut="bdan_scene" ExternalTlutOffset="0x139D0" AddedByScript="true"/>
+        <Texture Name="bdan_room_5Tex_0030A8" OutName="bdan_room_5Tex_0030A8" Format="ci8" Width="32" Height="64" Offset="0x3038" ExternalTlut="bdan_scene" ExternalTlutOffset="0x139D0" AddedByScript="true"/>
+        <Texture Name="bdan_room_5Tex_004090" OutName="bdan_room_5Tex_004090" Format="rgba16" Width="32" Height="64" Offset="0x4020" AddedByScript="true"/>
+        <Texture Name="bdan_room_5Tex_005090" OutName="bdan_room_5Tex_005090" Format="ia16" Width="32" Height="64" Offset="0x5020" AddedByScript="true"/>
         <Room Name="bdan_room_5" Offset="0x0"/>
     </File>
     <File Name="bdan_room_6" Segment="3">
+        <Texture Name="bdan_room_6Tex_003068" OutName="bdan_room_6Tex_003068" Format="ci8" Width="32" Height="64" Offset="0x3068" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
+        <Texture Name="bdan_room_6Tex_003868" OutName="bdan_room_6Tex_003868" Format="ci8" Width="32" Height="64" Offset="0x3868" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
         <Room Name="bdan_room_6" Offset="0x0"/>
     </File>
     <File Name="bdan_room_7" Segment="3">
+        <Texture Name="bdan_room_7Tex_002CD0" OutName="bdan_room_7Tex_002CD0" Format="ci8" Width="32" Height="32" Offset="0x2D20" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
+        <Texture Name="bdan_room_7Tex_0030D0" OutName="bdan_room_7Tex_0030D0" Format="ci8" Width="32" Height="32" Offset="0x3120" ExternalTlut="bdan_scene" ExternalTlutOffset="0x139D0" AddedByScript="true"/>
         <Room Name="bdan_room_7" Offset="0x0"/>
     </File>
     <File Name="bdan_room_8" Segment="3">
         <Room Name="bdan_room_8" Offset="0x0"/>
     </File>
     <File Name="bdan_room_9" Segment="3">
+        <Texture Name="bdan_room_9Tex_003828" OutName="bdan_room_9Tex_003828" Format="ci8" Width="32" Height="32" Offset="0x3868" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
         <Room Name="bdan_room_9" Offset="0x0"/>
     </File>
     <File Name="bdan_room_10" Segment="3">
@@ -40,12 +73,20 @@
         <Room Name="bdan_room_11" Offset="0x0"/>
     </File>
     <File Name="bdan_room_12" Segment="3">
+        <Texture Name="bdan_room_12Tex_0038E0" OutName="bdan_room_12Tex_0038E0" Format="ci8" Width="32" Height="32" Offset="0x38D0" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
         <Room Name="bdan_room_12" Offset="0x0"/>
     </File>
     <File Name="bdan_room_13" Segment="3">
+        <Texture Name="bdan_room_13Tex_0015B8" OutName="bdan_room_13Tex_0015B8" Format="ci8" Width="32" Height="64" Offset="0x1588" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
+        <Texture Name="bdan_room_13Tex_001DB8" OutName="bdan_room_13Tex_001DB8" Format="ci8" Width="32" Height="32" Offset="0x1D88" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
+        <Texture Name="bdan_room_13Tex_0021B8" OutName="bdan_room_13Tex_0021B8" Format="ci8" Width="32" Height="64" Offset="0x2188" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
         <Room Name="bdan_room_13" Offset="0x0"/>
     </File>
     <File Name="bdan_room_14" Segment="3">
+        <Texture Name="bdan_room_14Tex_0045C8" OutName="bdan_room_14Tex_0045C8" Format="ci8" Width="32" Height="64" Offset="0x45D8" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
+        <Texture Name="bdan_room_14Tex_004DC8" OutName="bdan_room_14Tex_004DC8" Format="ci8" Width="32" Height="64" Offset="0x4DD8" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
+        <Texture Name="bdan_room_14Tex_0055C8" OutName="bdan_room_14Tex_0055C8" Format="ci8" Width="32" Height="32" Offset="0x55D8" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
+        <Texture Name="bdan_room_14Tex_0059C8" OutName="bdan_room_14Tex_0059C8" Format="ci8" Width="32" Height="64" Offset="0x59D8" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
         <Room Name="bdan_room_14" Offset="0x0"/>
     </File>
     <File Name="bdan_room_15" Segment="3">

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/bdan_boss.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/bdan_boss.xml
@@ -3,9 +3,17 @@
         <Scene Name="bdan_boss_scene" Offset="0x0"/>
     </File>
     <File Name="bdan_boss_room_0" Segment="3">
+        <Texture Name="bdan_boss_room_0Tex_002040" OutName="bdan_boss_room_0Tex_002040" Format="ci8" Width="32" Height="64" Offset="0x2040" TlutOffset="0x1E38" AddedByScript="true"/>
+        <Texture Name="bdan_boss_room_0Tex_002C18" OutName="bdan_boss_room_0Tex_002C18" Format="ci8" Width="32" Height="32" Offset="0x2C18" TlutOffset="0x2A10" AddedByScript="true"/>
+        <Texture Name="bdan_boss_room_0TLUT_001E38" OutName="bdan_boss_room_0TLUT_001E38" Format="rgba16" Width="16" Height="16" Offset="0x1E38" AddedByScript="true"/>
+        <Texture Name="bdan_boss_room_0TLUT_002A10" OutName="bdan_boss_room_0TLUT_002A10" Format="rgba16" Width="16" Height="16" Offset="0x2A10" AddedByScript="true"/>
         <Room Name="bdan_boss_room_0" Offset="0x0"/>
     </File>
     <File Name="bdan_boss_room_1" Segment="3">
+        <Texture Name="bdan_boss_room_1Tex_003CB8" OutName="bdan_boss_room_1Tex_003CB8" Format="ci8" Width="32" Height="64" Offset="0x3CB8" TlutOffset="0x3AB0" AddedByScript="true"/>
+        <Texture Name="bdan_boss_room_1Tex_0044B8" OutName="bdan_boss_room_1Tex_0044B8" Format="ci8" Width="32" Height="32" Offset="0x44B8" TlutOffset="0x3AB0" AddedByScript="true"/>
+        <Texture Name="bdan_boss_room_1Tex_0048B8" OutName="bdan_boss_room_1Tex_0048B8" Format="ci8" Width="32" Height="64" Offset="0x48B8" TlutOffset="0x3AB0" AddedByScript="true"/>
+        <Texture Name="bdan_boss_room_1TLUT_003AB0" OutName="bdan_boss_room_1TLUT_003AB0" Format="rgba16" Width="16" Height="16" Offset="0x3AB0" AddedByScript="true"/>
         <Room Name="bdan_boss_room_1" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/ddan.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/ddan.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="ddan_scene" Segment="2">
+        <Texture Name="ddan_sceneTLUT_011D70" OutName="ddan_sceneTLUT_011D70" Format="rgba16" Width="16" Height="16" Offset="0x11D70" AddedByScript="true"/>
         <Texture Name="gDCDayEntranceTex" OutName="day_entrance" Format="ci8" Width="32" Height="64" Offset="0x12378" TlutOffset="0x11D70"/>
         <Texture Name="gDCNightEntranceTex" OutName="night_entrance" Format="ci8" Width="32" Height="64" Offset="0x13378" TlutOffset="0x11D70"/>
 
@@ -17,54 +18,203 @@
         <Scene Name="ddan_scene" Offset="0x0"/>
     </File>
     <File Name="ddan_room_0" Segment="3">
+        <Texture Name="ddan_room_0Tex_011498" OutName="ddan_room_0Tex_011498" Format="ci8" Width="32" Height="32" Offset="0x11498" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_011898" OutName="ddan_room_0Tex_011898" Format="ci8" Width="32" Height="32" Offset="0x11898" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_011C98" OutName="ddan_room_0Tex_011C98" Format="ci8" Width="64" Height="32" Offset="0x11C98" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_012498" OutName="ddan_room_0Tex_012498" Format="ci8" Width="32" Height="64" Offset="0x12498" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_012C98" OutName="ddan_room_0Tex_012C98" Format="rgba16" Width="32" Height="64" Offset="0x12C98" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_013C98" OutName="ddan_room_0Tex_013C98" Format="rgba16" Width="32" Height="64" Offset="0x13C98" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_014C98" OutName="ddan_room_0Tex_014C98" Format="rgba16" Width="32" Height="32" Offset="0x14C98" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_015498" OutName="ddan_room_0Tex_015498" Format="ci8" Width="32" Height="64" Offset="0x15498" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_015C98" OutName="ddan_room_0Tex_015C98" Format="ci8" Width="32" Height="64" Offset="0x15C98" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_016498" OutName="ddan_room_0Tex_016498" Format="ci8" Width="32" Height="32" Offset="0x16498" TlutOffset="0x11290" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_016898" OutName="ddan_room_0Tex_016898" Format="ci8" Width="32" Height="64" Offset="0x16898" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_017098" OutName="ddan_room_0Tex_017098" Format="rgba16" Width="32" Height="32" Offset="0x17098" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_017898" OutName="ddan_room_0Tex_017898" Format="ci8" Width="32" Height="32" Offset="0x17898" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_017C98" OutName="ddan_room_0Tex_017C98" Format="rgba16" Width="32" Height="32" Offset="0x17C98" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_018498" OutName="ddan_room_0Tex_018498" Format="ci8" Width="32" Height="64" Offset="0x18498" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_018C98" OutName="ddan_room_0Tex_018C98" Format="ci8" Width="32" Height="64" Offset="0x18C98" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_019498" OutName="ddan_room_0Tex_019498" Format="rgba16" Width="64" Height="32" Offset="0x19498" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_01A498" OutName="ddan_room_0Tex_01A498" Format="rgba16" Width="64" Height="32" Offset="0x1A498" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_01B498" OutName="ddan_room_0Tex_01B498" Format="ci8" Width="32" Height="32" Offset="0x1B498" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_0TLUT_011290" OutName="ddan_room_0TLUT_011290" Format="rgba16" Width="16" Height="16" Offset="0x11290" AddedByScript="true"/>
         <Room Name="ddan_room_0" Offset="0x0"/>
     </File>
     <File Name="ddan_room_1" Segment="3">
+        <Texture Name="ddan_room_1Tex_004770" OutName="ddan_room_1Tex_004770" Format="ci8" Width="32" Height="32" Offset="0x4700" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_1Tex_004B70" OutName="ddan_room_1Tex_004B70" Format="ci8" Width="32" Height="32" Offset="0x4B00" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_1Tex_004F70" OutName="ddan_room_1Tex_004F70" Format="ci8" Width="32" Height="64" Offset="0x4F00" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_1Tex_005770" OutName="ddan_room_1Tex_005770" Format="ci8" Width="64" Height="32" Offset="0x5700" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_1Tex_005F70" OutName="ddan_room_1Tex_005F70" Format="rgba16" Width="32" Height="64" Offset="0x5F00" AddedByScript="true"/>
+        <Texture Name="ddan_room_1Tex_006F70" OutName="ddan_room_1Tex_006F70" Format="rgba16" Width="32" Height="64" Offset="0x6F00" AddedByScript="true"/>
+        <Texture Name="ddan_room_1Tex_007F70" OutName="ddan_room_1Tex_007F70" Format="ci8" Width="32" Height="64" Offset="0x7F00" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_1Tex_008770" OutName="ddan_room_1Tex_008770" Format="ci8" Width="64" Height="32" Offset="0x8700" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_1Tex_008F70" OutName="ddan_room_1Tex_008F70" Format="ci8" Width="32" Height="64" Offset="0x8F00" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_1Tex_009770" OutName="ddan_room_1Tex_009770" Format="ci8" Width="32" Height="32" Offset="0x9700" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
         <Room Name="ddan_room_1" Offset="0x0"/>
     </File>
     <File Name="ddan_room_2" Segment="3">
+        <Texture Name="ddan_room_2Tex_003B80" OutName="ddan_room_2Tex_003B80" Format="ci8" Width="64" Height="32" Offset="0x3A60" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_2Tex_004380" OutName="ddan_room_2Tex_004380" Format="ci8" Width="32" Height="32" Offset="0x4260" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_2Tex_004780" OutName="ddan_room_2Tex_004780" Format="ci8" Width="32" Height="32" Offset="0x4660" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_2Tex_004B80" OutName="ddan_room_2Tex_004B80" Format="ci8" Width="32" Height="64" Offset="0x4A60" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_2Tex_005380" OutName="ddan_room_2Tex_005380" Format="ci8" Width="64" Height="32" Offset="0x5260" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_2Tex_005B80" OutName="ddan_room_2Tex_005B80" Format="ci8" Width="32" Height="32" Offset="0x5A60" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_2Tex_005F80" OutName="ddan_room_2Tex_005F80" Format="ci8" Width="32" Height="32" Offset="0x5E60" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_2Tex_006380" OutName="ddan_room_2Tex_006380" Format="ci8" Width="32" Height="32" Offset="0x6260" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_2Tex_006EB8" OutName="ddan_room_2Tex_006EB8" Format="rgba16" Width="32" Height="64" Offset="0x6D98" AddedByScript="true"/>
         <Room Name="ddan_room_2" Offset="0x0"/>
     </File>
     <File Name="ddan_room_3" Segment="3">
+        <Texture Name="ddan_room_3Tex_008838" OutName="ddan_room_3Tex_008838" Format="ci8" Width="32" Height="32" Offset="0x8788" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_3Tex_008C38" OutName="ddan_room_3Tex_008C38" Format="ci8" Width="64" Height="32" Offset="0x8B88" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_3Tex_009438" OutName="ddan_room_3Tex_009438" Format="ci8" Width="32" Height="32" Offset="0x9388" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_3Tex_009838" OutName="ddan_room_3Tex_009838" Format="ci8" Width="32" Height="64" Offset="0x9788" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_3Tex_00A038" OutName="ddan_room_3Tex_00A038" Format="ci8" Width="32" Height="64" Offset="0x9F88" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_3Tex_00A838" OutName="ddan_room_3Tex_00A838" Format="ci8" Width="32" Height="64" Offset="0xA788" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_3Tex_00B038" OutName="ddan_room_3Tex_00B038" Format="ci8" Width="32" Height="32" Offset="0xAF88" TlutOffset="0x8580" AddedByScript="true"/>
+        <Texture Name="ddan_room_3Tex_00B438" OutName="ddan_room_3Tex_00B438" Format="ci8" Width="32" Height="32" Offset="0xB388" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_3Tex_00B838" OutName="ddan_room_3Tex_00B838" Format="ci8" Width="32" Height="32" Offset="0xB788" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_3Tex_00BC38" OutName="ddan_room_3Tex_00BC38" Format="ci8" Width="64" Height="32" Offset="0xBB88" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_3Tex_00C438" OutName="ddan_room_3Tex_00C438" Format="ci8" Width="32" Height="64" Offset="0xC388" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_3Tex_00CC38" OutName="ddan_room_3Tex_00CC38" Format="ci8" Width="32" Height="32" Offset="0xCB88" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_3Tex_00D038" OutName="ddan_room_3Tex_00D038" Format="ci8" Width="32" Height="32" Offset="0xCF88" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_3Tex_00D668" OutName="ddan_room_3Tex_00D668" Format="ia8" Width="64" Height="32" Offset="0xD5B8" AddedByScript="true"/>
+        <Texture Name="ddan_room_3TLUT_008630" OutName="ddan_room_3TLUT_008630" Format="rgba16" Width="16" Height="16" Offset="0x8580" AddedByScript="true"/>
         <Room Name="ddan_room_3" Offset="0x0"/>
     </File>
     <File Name="ddan_room_4" Segment="3">
+        <Texture Name="ddan_room_4Tex_006D58" OutName="ddan_room_4Tex_006D58" Format="ci8" Width="32" Height="32" Offset="0x6C48" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_4Tex_007158" OutName="ddan_room_4Tex_007158" Format="ci8" Width="32" Height="32" Offset="0x7048" TlutOffset="0x6A40" AddedByScript="true"/>
+        <Texture Name="ddan_room_4Tex_007558" OutName="ddan_room_4Tex_007558" Format="ci8" Width="64" Height="32" Offset="0x7448" TlutOffset="0x6A40" AddedByScript="true"/>
+        <Texture Name="ddan_room_4Tex_007D58" OutName="ddan_room_4Tex_007D58" Format="ci8" Width="32" Height="64" Offset="0x7C48" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_4Tex_008558" OutName="ddan_room_4Tex_008558" Format="ci8" Width="32" Height="64" Offset="0x8448" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_4Tex_008D58" OutName="ddan_room_4Tex_008D58" Format="ci8" Width="32" Height="32" Offset="0x8C48" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_4Tex_009158" OutName="ddan_room_4Tex_009158" Format="ci8" Width="64" Height="32" Offset="0x9048" TlutOffset="0x6A40" AddedByScript="true"/>
+        <Texture Name="ddan_room_4TLUT_006B50" OutName="ddan_room_4TLUT_006B50" Format="rgba16" Width="16" Height="16" Offset="0x6A40" AddedByScript="true"/>
         <Room Name="ddan_room_4" Offset="0x0"/>
     </File>
     <File Name="ddan_room_5" Segment="3">
+        <Texture Name="ddan_room_5Tex_0032B8" OutName="ddan_room_5Tex_0032B8" Format="ci8" Width="32" Height="64" Offset="0x32D8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_5Tex_003AB8" OutName="ddan_room_5Tex_003AB8" Format="ci8" Width="32" Height="64" Offset="0x3AD8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_5Tex_0042B8" OutName="ddan_room_5Tex_0042B8" Format="ci8" Width="32" Height="32" Offset="0x42D8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_5Tex_0046B8" OutName="ddan_room_5Tex_0046B8" Format="ci8" Width="32" Height="32" Offset="0x46D8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_5Tex_004AB8" OutName="ddan_room_5Tex_004AB8" Format="ci8" Width="32" Height="32" Offset="0x4AD8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_5Tex_004EB8" OutName="ddan_room_5Tex_004EB8" Format="rgba16" Width="32" Height="32" Offset="0x4ED8" AddedByScript="true"/>
+        <Texture Name="ddan_room_5Tex_0056B8" OutName="ddan_room_5Tex_0056B8" Format="ci8" Width="32" Height="64" Offset="0x56D8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
         <Room Name="ddan_room_5" Offset="0x0"/>
     </File>
     <File Name="ddan_room_6" Segment="3">
+        <Texture Name="ddan_room_6Tex_000CA8" OutName="ddan_room_6Tex_000CA8" Format="ci8" Width="32" Height="64" Offset="0xBF8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_6Tex_0014A8" OutName="ddan_room_6Tex_0014A8" Format="ci8" Width="64" Height="32" Offset="0x13F8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_6Tex_001CA8" OutName="ddan_room_6Tex_001CA8" Format="ci8" Width="32" Height="32" Offset="0x1BF8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_6Tex_0020A8" OutName="ddan_room_6Tex_0020A8" Format="ci8" Width="32" Height="32" Offset="0x1FF8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
         <Room Name="ddan_room_6" Offset="0x0"/>
     </File>
     <File Name="ddan_room_7" Segment="3">
+        <Texture Name="ddan_room_7Tex_0046F8" OutName="ddan_room_7Tex_0046F8" Format="ci8" Width="32" Height="32" Offset="0x46C8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_7Tex_004AF8" OutName="ddan_room_7Tex_004AF8" Format="ci8" Width="32" Height="32" Offset="0x4AC8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_7Tex_004EF8" OutName="ddan_room_7Tex_004EF8" Format="ci8" Width="32" Height="64" Offset="0x4EC8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_7Tex_0056F8" OutName="ddan_room_7Tex_0056F8" Format="ci8" Width="32" Height="64" Offset="0x56C8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_7Tex_005EF8" OutName="ddan_room_7Tex_005EF8" Format="ci8" Width="32" Height="64" Offset="0x5EC8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_7Tex_0066F8" OutName="ddan_room_7Tex_0066F8" Format="ci8" Width="32" Height="64" Offset="0x66C8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_7Tex_006EF8" OutName="ddan_room_7Tex_006EF8" Format="ci8" Width="32" Height="64" Offset="0x6EC8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
         <Room Name="ddan_room_7" Offset="0x0"/>
     </File>
     <File Name="ddan_room_8" Segment="3">
+        <Texture Name="ddan_room_8Tex_0041A0" OutName="ddan_room_8Tex_0041A0" Format="ci8" Width="64" Height="32" Offset="0x4000" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_8Tex_0049A0" OutName="ddan_room_8Tex_0049A0" Format="ci8" Width="32" Height="32" Offset="0x4800" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_8Tex_004DA0" OutName="ddan_room_8Tex_004DA0" Format="ci8" Width="32" Height="32" Offset="0x4C00" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_8Tex_0051A0" OutName="ddan_room_8Tex_0051A0" Format="ci8" Width="64" Height="32" Offset="0x5000" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_8Tex_0059A0" OutName="ddan_room_8Tex_0059A0" Format="ci8" Width="32" Height="64" Offset="0x5800" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_8Tex_0061A0" OutName="ddan_room_8Tex_0061A0" Format="ci8" Width="32" Height="64" Offset="0x6000" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_8Tex_0069A0" OutName="ddan_room_8Tex_0069A0" Format="ci8" Width="32" Height="64" Offset="0x6800" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_8Tex_0071A0" OutName="ddan_room_8Tex_0071A0" Format="ci8" Width="32" Height="64" Offset="0x7000" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_8Tex_0079A0" OutName="ddan_room_8Tex_0079A0" Format="ci8" Width="64" Height="32" Offset="0x7800" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_8Tex_0081A0" OutName="ddan_room_8Tex_0081A0" Format="ci8" Width="32" Height="64" Offset="0x8000" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_8Tex_0089A0" OutName="ddan_room_8Tex_0089A0" Format="ci8" Width="32" Height="64" Offset="0x8800" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_8Tex_0091A0" OutName="ddan_room_8Tex_0091A0" Format="ci8" Width="32" Height="32" Offset="0x9000" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
         <Room Name="ddan_room_8" Offset="0x0"/>
     </File>
     <File Name="ddan_room_9" Segment="3">
+        <Texture Name="ddan_room_9Tex_005128" OutName="ddan_room_9Tex_005128" Format="ci8" Width="32" Height="32" Offset="0x5148" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_9Tex_005528" OutName="ddan_room_9Tex_005528" Format="ci8" Width="64" Height="32" Offset="0x5548" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_9Tex_005D28" OutName="ddan_room_9Tex_005D28" Format="ci8" Width="32" Height="32" Offset="0x5D48" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_9Tex_006128" OutName="ddan_room_9Tex_006128" Format="ci8" Width="32" Height="64" Offset="0x6148" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_9Tex_006928" OutName="ddan_room_9Tex_006928" Format="ci8" Width="32" Height="32" Offset="0x6948" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_9Tex_006D28" OutName="ddan_room_9Tex_006D28" Format="rgba16" Width="32" Height="64" Offset="0x6D48" AddedByScript="true"/>
+        <Texture Name="ddan_room_9Tex_007D28" OutName="ddan_room_9Tex_007D28" Format="rgba16" Width="32" Height="64" Offset="0x7D48" AddedByScript="true"/>
+        <Texture Name="ddan_room_9Tex_008D28" OutName="ddan_room_9Tex_008D28" Format="ci8" Width="32" Height="32" Offset="0x8D48" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_9Tex_009128" OutName="ddan_room_9Tex_009128" Format="ci8" Width="32" Height="64" Offset="0x9148" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_9Tex_009928" OutName="ddan_room_9Tex_009928" Format="ci8" Width="64" Height="32" Offset="0x9948" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_9Tex_00A128" OutName="ddan_room_9Tex_00A128" Format="rgba16" Width="32" Height="32" Offset="0xA148" AddedByScript="true"/>
+        <Texture Name="ddan_room_9Tex_00A928" OutName="ddan_room_9Tex_00A928" Format="ci8" Width="32" Height="64" Offset="0xA948" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_9Tex_00B128" OutName="ddan_room_9Tex_00B128" Format="ci8" Width="32" Height="32" Offset="0xB148" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
         <Room Name="ddan_room_9" Offset="0x0"/>
     </File>
     <File Name="ddan_room_10" Segment="3">
+        <Texture Name="ddan_room_10Tex_002B10" OutName="ddan_room_10Tex_002B10" Format="ci8" Width="32" Height="32" Offset="0x2A50" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_10Tex_002F10" OutName="ddan_room_10Tex_002F10" Format="ci8" Width="64" Height="32" Offset="0x2E50" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_10Tex_003710" OutName="ddan_room_10Tex_003710" Format="ci8" Width="32" Height="32" Offset="0x3650" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_10Tex_003B10" OutName="ddan_room_10Tex_003B10" Format="ci8" Width="32" Height="64" Offset="0x3A50" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_10Tex_004310" OutName="ddan_room_10Tex_004310" Format="ci8" Width="32" Height="32" Offset="0x4250" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_10Tex_004710" OutName="ddan_room_10Tex_004710" Format="ci8" Width="32" Height="64" Offset="0x4650" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_10Tex_004F10" OutName="ddan_room_10Tex_004F10" Format="ci8" Width="32" Height="32" Offset="0x4E50" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_10Tex_005310" OutName="ddan_room_10Tex_005310" Format="rgba16" Width="32" Height="64" Offset="0x5250" AddedByScript="true"/>
+        <Texture Name="ddan_room_10Tex_006310" OutName="ddan_room_10Tex_006310" Format="rgba16" Width="32" Height="64" Offset="0x6250" AddedByScript="true"/>
+        <Texture Name="ddan_room_10Tex_007310" OutName="ddan_room_10Tex_007310" Format="ci8" Width="32" Height="64" Offset="0x7250" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_10Tex_007B10" OutName="ddan_room_10Tex_007B10" Format="ci8" Width="32" Height="32" Offset="0x7A50" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
         <Room Name="ddan_room_10" Offset="0x0"/>
     </File>
     <File Name="ddan_room_11" Segment="3">
+        <Texture Name="ddan_room_11Tex_000C30" OutName="ddan_room_11Tex_000C30" Format="ci8" Width="32" Height="64" Offset="0xC80" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_11Tex_001430" OutName="ddan_room_11Tex_001430" Format="ci8" Width="64" Height="32" Offset="0x1480" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_11Tex_001C30" OutName="ddan_room_11Tex_001C30" Format="ci8" Width="32" Height="32" Offset="0x1C80" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
         <Room Name="ddan_room_11" Offset="0x0"/>
     </File>
     <File Name="ddan_room_12" Segment="3">
+        <Texture Name="ddan_room_12Tex_002F80" OutName="ddan_room_12Tex_002F80" Format="ci8" Width="32" Height="32" Offset="0x2F30" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_12Tex_003380" OutName="ddan_room_12Tex_003380" Format="ci8" Width="64" Height="32" Offset="0x3330" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_12Tex_003B80" OutName="ddan_room_12Tex_003B80" Format="ci8" Width="32" Height="32" Offset="0x3B30" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_12Tex_003F80" OutName="ddan_room_12Tex_003F80" Format="ci8" Width="32" Height="64" Offset="0x3F30" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_12Tex_004780" OutName="ddan_room_12Tex_004780" Format="ci8" Width="32" Height="32" Offset="0x4730" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_12Tex_004B80" OutName="ddan_room_12Tex_004B80" Format="ci8" Width="32" Height="64" Offset="0x4B30" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_12Tex_005380" OutName="ddan_room_12Tex_005380" Format="ci8" Width="32" Height="32" Offset="0x5330" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_12Tex_005780" OutName="ddan_room_12Tex_005780" Format="rgba16" Width="32" Height="64" Offset="0x5730" AddedByScript="true"/>
+        <Texture Name="ddan_room_12Tex_006780" OutName="ddan_room_12Tex_006780" Format="rgba16" Width="32" Height="64" Offset="0x6730" AddedByScript="true"/>
+        <Texture Name="ddan_room_12Tex_007780" OutName="ddan_room_12Tex_007780" Format="ci8" Width="32" Height="32" Offset="0x7730" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_12Tex_007B80" OutName="ddan_room_12Tex_007B80" Format="ci8" Width="32" Height="64" Offset="0x7B30" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_12Tex_008380" OutName="ddan_room_12Tex_008380" Format="ci8" Width="32" Height="32" Offset="0x8330" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
         <Room Name="ddan_room_12" Offset="0x0"/>
     </File>
     <File Name="ddan_room_13" Segment="3">
+        <Texture Name="ddan_room_13Tex_000CC8" OutName="ddan_room_13Tex_000CC8" Format="ci8" Width="32" Height="64" Offset="0xC78" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_13Tex_0014C8" OutName="ddan_room_13Tex_0014C8" Format="ci8" Width="64" Height="32" Offset="0x1478" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_13Tex_001CC8" OutName="ddan_room_13Tex_001CC8" Format="ci8" Width="32" Height="32" Offset="0x1C78" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_13Tex_0020C8" OutName="ddan_room_13Tex_0020C8" Format="ci8" Width="32" Height="32" Offset="0x2078" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
         <Room Name="ddan_room_13" Offset="0x0"/>
     </File>
     <File Name="ddan_room_14" Segment="3">
+        <Texture Name="ddan_room_14Tex_000CC8" OutName="ddan_room_14Tex_000CC8" Format="ci8" Width="32" Height="64" Offset="0xC88" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_14Tex_0014C8" OutName="ddan_room_14Tex_0014C8" Format="ci8" Width="64" Height="32" Offset="0x1488" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_14Tex_001CC8" OutName="ddan_room_14Tex_001CC8" Format="ci8" Width="32" Height="32" Offset="0x1C88" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_14Tex_0020C8" OutName="ddan_room_14Tex_0020C8" Format="ci8" Width="32" Height="32" Offset="0x2088" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
         <Room Name="ddan_room_14" Offset="0x0"/>
     </File>
     <File Name="ddan_room_15" Segment="3">
+        <Texture Name="ddan_room_15Tex_000D28" OutName="ddan_room_15Tex_000D28" Format="ci8" Width="64" Height="32" Offset="0xC48" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_15Tex_001528" OutName="ddan_room_15Tex_001528" Format="ci8" Width="32" Height="64" Offset="0x1448" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_15Tex_001D28" OutName="ddan_room_15Tex_001D28" Format="ci8" Width="64" Height="32" Offset="0x1C48" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_15Tex_002528" OutName="ddan_room_15Tex_002528" Format="ci8" Width="32" Height="32" Offset="0x2448" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
         <Room Name="ddan_room_15" Offset="0x0"/>
     </File>
     <File Name="ddan_room_16" Segment="3">
+        <Texture Name="ddan_room_16Tex_002158" OutName="ddan_room_16Tex_002158" Format="rgba16" Width="32" Height="64" Offset="0x2148" AddedByScript="true"/>
+        <Texture Name="ddan_room_16Tex_003158" OutName="ddan_room_16Tex_003158" Format="ci8" Width="32" Height="64" Offset="0x3148" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_16Tex_003958" OutName="ddan_room_16Tex_003958" Format="ci8" Width="32" Height="64" Offset="0x3948" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_16Tex_004158" OutName="ddan_room_16Tex_004158" Format="ci8" Width="32" Height="64" Offset="0x4148" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_16Tex_004958" OutName="ddan_room_16Tex_004958" Format="ci8" Width="32" Height="64" Offset="0x4948" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_16Tex_005158" OutName="ddan_room_16Tex_005158" Format="ci8" Width="32" Height="32" Offset="0x5148" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
         <Room Name="ddan_room_16" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/ddan_boss.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/ddan_boss.xml
@@ -1,11 +1,21 @@
 <Root>
     <File Name="ddan_boss_scene" Segment="2">
+        <Texture Name="ddan_boss_sceneTex_001058" OutName="ddan_boss_sceneTex_001058" Format="ci8" Width="32" Height="64" Offset="0x1058" TlutOffset="0xE50" AddedByScript="true"/>
+        <Texture Name="ddan_boss_sceneTex_001858" OutName="ddan_boss_sceneTex_001858" Format="ci8" Width="32" Height="64" Offset="0x1858" TlutOffset="0xE50" AddedByScript="true"/>
+        <Texture Name="ddan_boss_sceneTex_002058" OutName="ddan_boss_sceneTex_002058" Format="ci8" Width="32" Height="64" Offset="0x2058" TlutOffset="0xE50" AddedByScript="true"/>
+        <Texture Name="ddan_boss_sceneTLUT_000E50" OutName="ddan_boss_sceneTLUT_000E50" Format="rgba16" Width="16" Height="16" Offset="0xE50" AddedByScript="true"/>
         <Scene Name="ddan_boss_scene" Offset="0x0"/>
     </File>
     <File Name="ddan_boss_room_0" Segment="3">
+        <Texture Name="ddan_boss_room_0Tex_003628" OutName="ddan_boss_room_0Tex_003628" Format="ci8" Width="32" Height="32" Offset="0x3628" ExternalTlut="ddan_boss_scene" ExternalTlutOffset="0xE50" AddedByScript="true"/>
+        <Texture Name="ddan_boss_room_0Tex_003A28" OutName="ddan_boss_room_0Tex_003A28" Format="ci8" Width="32" Height="32" Offset="0x3A28" ExternalTlut="ddan_boss_scene" ExternalTlutOffset="0xE50" AddedByScript="true"/>
+        <Texture Name="ddan_boss_room_0Tex_003E28" OutName="ddan_boss_room_0Tex_003E28" Format="ci8" Width="32" Height="64" Offset="0x3E28" ExternalTlut="ddan_boss_scene" ExternalTlutOffset="0xE50" AddedByScript="true"/>
+        <Texture Name="ddan_boss_room_0Tex_004628" OutName="ddan_boss_room_0Tex_004628" Format="ci8" Width="32" Height="64" Offset="0x4628" ExternalTlut="ddan_boss_scene" ExternalTlutOffset="0xE50" AddedByScript="true"/>
         <Room Name="ddan_boss_room_0" Offset="0x0"/>
     </File>
     <File Name="ddan_boss_room_1" Segment="3">
+        <Texture Name="ddan_boss_room_1Tex_0031D8" OutName="ddan_boss_room_1Tex_0031D8" Format="ci8" Width="32" Height="64" Offset="0x31D8" ExternalTlut="ddan_boss_scene" ExternalTlutOffset="0xE50" AddedByScript="true"/>
+        <Texture Name="ddan_boss_room_1Tex_0039D8" OutName="ddan_boss_room_1Tex_0039D8" Format="ci8" Width="32" Height="32" Offset="0x39D8" ExternalTlut="ddan_boss_scene" ExternalTlutOffset="0xE50" AddedByScript="true"/>
         <Texture Name="gDodongosCavernBossLavaFloorTex" OutName="lava_floor" Format="rgba16" Width="64" Height="32" Offset="0x21D8"/>
         <Room Name="ddan_boss_room_1" Offset="0x0"/>
     </File>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/ganon.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/ganon.xml
@@ -1,35 +1,121 @@
 <Root>
     <File Name="ganon_scene" Segment="2">
+        <Texture Name="ganon_sceneTex_00EFA8" OutName="ganon_sceneTex_00EFA8" Format="ci8" Width="32" Height="32" Offset="0xEFA8" TlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_sceneTex_00F3A8" OutName="ganon_sceneTex_00F3A8" Format="ci8" Width="32" Height="32" Offset="0xF3A8" TlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_sceneTex_00F7A8" OutName="ganon_sceneTex_00F7A8" Format="ci8" Width="32" Height="32" Offset="0xF7A8" TlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_sceneTex_00FBA8" OutName="ganon_sceneTex_00FBA8" Format="ci8" Width="32" Height="32" Offset="0xFBA8" TlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_sceneTex_00FFA8" OutName="ganon_sceneTex_00FFA8" Format="rgba16" Width="32" Height="32" Offset="0xFFA8" AddedByScript="true"/>
+        <Texture Name="ganon_sceneTLUT_00E7D0" OutName="ganon_sceneTLUT_00E7D0" Format="rgba16" Width="16" Height="16" Offset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_sceneTLUT_00E9D8" OutName="ganon_sceneTLUT_00E9D8" Format="rgba16" Width="16" Height="16" Offset="0xE9D8" AddedByScript="true"/>
+        <Texture Name="ganon_sceneTLUT_00EBE0" OutName="ganon_sceneTLUT_00EBE0" Format="rgba16" Width="16" Height="16" Offset="0xEBE0" AddedByScript="true"/>
+        <Texture Name="ganon_sceneTLUT_00EDA0" OutName="ganon_sceneTLUT_00EDA0" Format="rgba16" Width="16" Height="16" Offset="0xEDA0" AddedByScript="true"/>
         <Scene Name="ganon_scene" Offset="0x0"/>
     </File>
     <File Name="ganon_room_0" Segment="3">
+        <Texture Name="ganon_room_0Tex_004C68" OutName="ganon_room_0Tex_004C68" Format="ci8" Width="32" Height="64" Offset="0x4C68" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_0Tex_005468" OutName="ganon_room_0Tex_005468" Format="ci8" Width="32" Height="64" Offset="0x5468" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_0Tex_005C68" OutName="ganon_room_0Tex_005C68" Format="ci8" Width="32" Height="32" Offset="0x5C68" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_0Tex_006068" OutName="ganon_room_0Tex_006068" Format="ci8" Width="64" Height="32" Offset="0x6068" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_0Tex_006868" OutName="ganon_room_0Tex_006868" Format="ci8" Width="64" Height="32" Offset="0x6868" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_0Tex_007068" OutName="ganon_room_0Tex_007068" Format="ci8" Width="32" Height="32" Offset="0x7068" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_0Tex_0076D0" OutName="ganon_room_0Tex_0076D0" Format="ia16" Width="32" Height="32" Offset="0x76D0" AddedByScript="true"/>
         <Room Name="ganon_room_0" Offset="0x0"/>
     </File>
     <File Name="ganon_room_1" Segment="3">
+        <Texture Name="ganon_room_1Tex_005370" OutName="ganon_room_1Tex_005370" Format="ci8" Width="64" Height="32" Offset="0x5370" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_1Tex_005B70" OutName="ganon_room_1Tex_005B70" Format="ci8" Width="32" Height="32" Offset="0x5B70" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_1Tex_005F70" OutName="ganon_room_1Tex_005F70" Format="ci8" Width="32" Height="32" Offset="0x5F70" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_1Tex_006370" OutName="ganon_room_1Tex_006370" Format="ci8" Width="32" Height="32" Offset="0x6370" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_1Tex_006770" OutName="ganon_room_1Tex_006770" Format="rgba16" Width="32" Height="64" Offset="0x6770" AddedByScript="true"/>
         <Room Name="ganon_room_1" Offset="0x0"/>
     </File>
     <File Name="ganon_room_2" Segment="3">
+        <Texture Name="ganon_room_2Tex_003DF0" OutName="ganon_room_2Tex_003DF0" Format="ci8" Width="32" Height="32" Offset="0x3DF0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_2Tex_0041F0" OutName="ganon_room_2Tex_0041F0" Format="ci8" Width="32" Height="64" Offset="0x41F0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_2Tex_0049F0" OutName="ganon_room_2Tex_0049F0" Format="ci8" Width="32" Height="32" Offset="0x49F0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_2Tex_004DF0" OutName="ganon_room_2Tex_004DF0" Format="ci8" Width="32" Height="32" Offset="0x4DF0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_2Tex_0051F0" OutName="ganon_room_2Tex_0051F0" Format="ci8" Width="32" Height="64" Offset="0x51F0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_2Tex_0059F0" OutName="ganon_room_2Tex_0059F0" Format="ci8" Width="32" Height="32" Offset="0x59F0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_2Tex_005DF0" OutName="ganon_room_2Tex_005DF0" Format="rgba16" Width="32" Height="64" Offset="0x5DF0" AddedByScript="true"/>
+        <Texture Name="ganon_room_2Tex_007050" OutName="ganon_room_2Tex_007050" Format="ia16" Width="32" Height="32" Offset="0x7050" AddedByScript="true"/>
         <Room Name="ganon_room_2" Offset="0x0"/>
     </File>
     <File Name="ganon_room_3" Segment="3">
+        <Texture Name="ganon_room_3Tex_004F30" OutName="ganon_room_3Tex_004F30" Format="ci8" Width="32" Height="32" Offset="0x4F30" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_3Tex_005330" OutName="ganon_room_3Tex_005330" Format="ci8" Width="32" Height="32" Offset="0x5330" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_3Tex_005730" OutName="ganon_room_3Tex_005730" Format="ci8" Width="32" Height="64" Offset="0x5730" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_3Tex_005F30" OutName="ganon_room_3Tex_005F30" Format="ci8" Width="32" Height="64" Offset="0x5F30" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_3Tex_006730" OutName="ganon_room_3Tex_006730" Format="rgba16" Width="32" Height="64" Offset="0x6730" AddedByScript="true"/>
         <Room Name="ganon_room_3" Offset="0x0"/>
     </File>
     <File Name="ganon_room_4" Segment="3">
+        <Texture Name="ganon_room_4Tex_004668" OutName="ganon_room_4Tex_004668" Format="ci8" Width="32" Height="64" Offset="0x4668" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_4Tex_004E68" OutName="ganon_room_4Tex_004E68" Format="ci8" Width="32" Height="64" Offset="0x4E68" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_4Tex_005668" OutName="ganon_room_4Tex_005668" Format="ci8" Width="32" Height="32" Offset="0x5668" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_4Tex_005A68" OutName="ganon_room_4Tex_005A68" Format="ci8" Width="32" Height="64" Offset="0x5A68" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_4Tex_006268" OutName="ganon_room_4Tex_006268" Format="ci8" Width="32" Height="32" Offset="0x6268" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_4Tex_006668" OutName="ganon_room_4Tex_006668" Format="ci8" Width="32" Height="32" Offset="0x6668" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_4Tex_006A68" OutName="ganon_room_4Tex_006A68" Format="ci8" Width="32" Height="32" Offset="0x6A68" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_4Tex_006E68" OutName="ganon_room_4Tex_006E68" Format="ci8" Width="32" Height="64" Offset="0x6E68" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_4Tex_007668" OutName="ganon_room_4Tex_007668" Format="ci8" Width="32" Height="64" Offset="0x7668" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_4Tex_007E68" OutName="ganon_room_4Tex_007E68" Format="ci8" Width="32" Height="64" Offset="0x7E68" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_4Tex_0088D0" OutName="ganon_room_4Tex_0088D0" Format="ia16" Width="32" Height="32" Offset="0x88D0" AddedByScript="true"/>
         <Room Name="ganon_room_4" Offset="0x0"/>
     </File>
     <File Name="ganon_room_5" Segment="3">
+        <Texture Name="ganon_room_5Tex_005B08" OutName="ganon_room_5Tex_005B08" Format="ci8" Width="32" Height="64" Offset="0x5B08" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_5Tex_006308" OutName="ganon_room_5Tex_006308" Format="ci8" Width="32" Height="64" Offset="0x6308" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_5Tex_006B08" OutName="ganon_room_5Tex_006B08" Format="rgba16" Width="32" Height="64" Offset="0x6B08" AddedByScript="true"/>
+        <Texture Name="ganon_room_5Tex_007B08" OutName="ganon_room_5Tex_007B08" Format="ci8" Width="32" Height="32" Offset="0x7B08" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_5Tex_007F08" OutName="ganon_room_5Tex_007F08" Format="ci8" Width="32" Height="32" Offset="0x7F08" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_5Tex_008308" OutName="ganon_room_5Tex_008308" Format="ci8" Width="32" Height="64" Offset="0x8308" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
         <Room Name="ganon_room_5" Offset="0x0"/>
     </File>
     <File Name="ganon_room_6" Segment="3">
+        <Texture Name="ganon_room_6Tex_006E00" OutName="ganon_room_6Tex_006E00" Format="ci8" Width="32" Height="32" Offset="0x6E00" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_6Tex_007200" OutName="ganon_room_6Tex_007200" Format="ci8" Width="32" Height="32" Offset="0x7200" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_6Tex_007600" OutName="ganon_room_6Tex_007600" Format="ci8" Width="32" Height="32" Offset="0x7600" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_6Tex_007A00" OutName="ganon_room_6Tex_007A00" Format="ci8" Width="32" Height="64" Offset="0x7A00" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_6Tex_008200" OutName="ganon_room_6Tex_008200" Format="ci8" Width="16" Height="16" Offset="0x8200" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEBE0" AddedByScript="true"/>
+        <Texture Name="ganon_room_6Tex_008300" OutName="ganon_room_6Tex_008300" Format="ci8" Width="32" Height="64" Offset="0x8300" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_6Tex_008B00" OutName="ganon_room_6Tex_008B00" Format="ci8" Width="32" Height="32" Offset="0x8B00" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEBE0" AddedByScript="true"/>
+        <Texture Name="ganon_room_6Tex_009398" OutName="ganon_room_6Tex_009398" Format="rgba16" Width="32" Height="32" Offset="0x9398" AddedByScript="true"/>
         <Room Name="ganon_room_6" Offset="0x0"/>
     </File>
     <File Name="ganon_room_7" Segment="3">
+        <Texture Name="ganon_room_7Tex_0071E0" OutName="ganon_room_7Tex_0071E0" Format="ci8" Width="32" Height="32" Offset="0x71E0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_7Tex_0075E0" OutName="ganon_room_7Tex_0075E0" Format="ci8" Width="64" Height="32" Offset="0x75E0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_7Tex_007DE0" OutName="ganon_room_7Tex_007DE0" Format="ci8" Width="64" Height="32" Offset="0x7DE0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_7Tex_0085E0" OutName="ganon_room_7Tex_0085E0" Format="ci8" Width="32" Height="32" Offset="0x85E0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_7Tex_0089E0" OutName="ganon_room_7Tex_0089E0" Format="ci8" Width="32" Height="64" Offset="0x89E0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_7Tex_0091E0" OutName="ganon_room_7Tex_0091E0" Format="ci8" Width="32" Height="64" Offset="0x91E0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_7Tex_009F98" OutName="ganon_room_7Tex_009F98" Format="rgba16" Width="32" Height="32" Offset="0x9F98" AddedByScript="true"/>
         <Room Name="ganon_room_7" Offset="0x0"/>
     </File>
     <File Name="ganon_room_8" Segment="3">
+        <Texture Name="ganon_room_8Tex_004A20" OutName="ganon_room_8Tex_004A20" Format="ci8" Width="32" Height="64" Offset="0x4A20" TlutOffset="0x4950" AddedByScript="true"/>
+        <Texture Name="ganon_room_8Tex_005220" OutName="ganon_room_8Tex_005220" Format="ci8" Width="16" Height="16" Offset="0x5220" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEBE0" AddedByScript="true"/>
+        <Texture Name="ganon_room_8Tex_005320" OutName="ganon_room_8Tex_005320" Format="ci8" Width="8" Height="8" Offset="0x5320" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEBE0" AddedByScript="true"/>
+        <Texture Name="ganon_room_8Tex_005360" OutName="ganon_room_8Tex_005360" Format="ci8" Width="16" Height="8" Offset="0x5360" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEBE0" AddedByScript="true"/>
+        <Texture Name="ganon_room_8Tex_0053E0" OutName="ganon_room_8Tex_0053E0" Format="ci8" Width="32" Height="64" Offset="0x53E0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE9D8" AddedByScript="true"/>
+        <Texture Name="ganon_room_8Tex_005BE0" OutName="ganon_room_8Tex_005BE0" Format="ci8" Width="32" Height="32" Offset="0x5BE0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEBE0" AddedByScript="true"/>
+        <Texture Name="ganon_room_8Tex_005FE0" OutName="ganon_room_8Tex_005FE0" Format="ci8" Width="32" Height="32" Offset="0x5FE0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_8Tex_0063E0" OutName="ganon_room_8Tex_0063E0" Format="ci8" Width="32" Height="64" Offset="0x63E0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_8TLUT_004950" OutName="ganon_room_8TLUT_004950" Format="rgba16" Width="16" Height="16" Offset="0x4950" AddedByScript="true"/>
         <Room Name="ganon_room_8" Offset="0x0"/>
     </File>
     <File Name="ganon_room_9" Segment="3">
+        <Texture Name="ganon_room_9Tex_002120" OutName="ganon_room_9Tex_002120" Format="ci8" Width="32" Height="64" Offset="0x2120" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE9D8" AddedByScript="true"/>
+        <Texture Name="ganon_room_9Tex_002920" OutName="ganon_room_9Tex_002920" Format="ci8" Width="32" Height="32" Offset="0x2920" TlutOffset="0x1F18" AddedByScript="true"/>
+        <Texture Name="ganon_room_9Tex_002D20" OutName="ganon_room_9Tex_002D20" Format="ci8" Width="32" Height="32" Offset="0x2D20" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEBE0" AddedByScript="true"/>
+        <Texture Name="ganon_room_9Tex_003120" OutName="ganon_room_9Tex_003120" Format="ci8" Width="32" Height="32" Offset="0x3120" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEBE0" AddedByScript="true"/>
+        <Texture Name="ganon_room_9Tex_003520" OutName="ganon_room_9Tex_003520" Format="ci8" Width="32" Height="32" Offset="0x3520" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEBE0" AddedByScript="true"/>
+        <Texture Name="ganon_room_9Tex_003920" OutName="ganon_room_9Tex_003920" Format="ci8" Width="32" Height="32" Offset="0x3920" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_9Tex_003D20" OutName="ganon_room_9Tex_003D20" Format="ci8" Width="32" Height="64" Offset="0x3D20" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE9D8" AddedByScript="true"/>
+        <Texture Name="ganon_room_9Tex_004520" OutName="ganon_room_9Tex_004520" Format="ci8" Width="32" Height="64" Offset="0x4520" TlutOffset="0x1F18" AddedByScript="true"/>
+        <Texture Name="ganon_room_9Tex_004D20" OutName="ganon_room_9Tex_004D20" Format="ci8" Width="16" Height="64" Offset="0x4D20" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEBE0" AddedByScript="true"/>
+        <Texture Name="ganon_room_9Tex_005120" OutName="ganon_room_9Tex_005120" Format="ci8" Width="32" Height="64" Offset="0x5120" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_9TLUT_001F18" OutName="ganon_room_9TLUT_001F18" Format="rgba16" Width="16" Height="16" Offset="0x1F18" AddedByScript="true"/>
         <Room Name="ganon_room_9" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/ganon_boss.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/ganon_boss.xml
@@ -1,5 +1,28 @@
 <Root>
     <File Name="ganon_boss_scene" Segment="2">
+        <Texture Name="ganon_boss_sceneTex_001E58" OutName="ganon_boss_sceneTex_001E58" Format="ci8" Width="32" Height="64" Offset="0x1E58" TlutOffset="0x1550" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_002658" OutName="ganon_boss_sceneTex_002658" Format="ci8" Width="16" Height="16" Offset="0x2658" TlutOffset="0x1A90" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_002758" OutName="ganon_boss_sceneTex_002758" Format="ci8" Width="8" Height="8" Offset="0x2758" TlutOffset="0x1A90" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_002798" OutName="ganon_boss_sceneTex_002798" Format="ci8" Width="32" Height="32" Offset="0x2798" TlutOffset="0x1C50" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_002B98" OutName="ganon_boss_sceneTex_002B98" Format="ci8" Width="16" Height="8" Offset="0x2B98" TlutOffset="0x1A90" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_002C18" OutName="ganon_boss_sceneTex_002C18" Format="rgba16" Width="32" Height="64" Offset="0x2C18" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_003C18" OutName="ganon_boss_sceneTex_003C18" Format="ci8" Width="32" Height="32" Offset="0x3C18" TlutOffset="0x1620" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_004018" OutName="ganon_boss_sceneTex_004018" Format="ci8" Width="32" Height="32" Offset="0x4018" TlutOffset="0x1888" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_004418" OutName="ganon_boss_sceneTex_004418" Format="ci8" Width="32" Height="32" Offset="0x4418" TlutOffset="0x1A90" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_004818" OutName="ganon_boss_sceneTex_004818" Format="ci8" Width="32" Height="32" Offset="0x4818" TlutOffset="0x1A90" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_004C18" OutName="ganon_boss_sceneTex_004C18" Format="ci8" Width="32" Height="32" Offset="0x4C18" TlutOffset="0x1A90" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_005018" OutName="ganon_boss_sceneTex_005018" Format="rgba16" Width="32" Height="32" Offset="0x5018" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_005818" OutName="ganon_boss_sceneTex_005818" Format="ci8" Width="32" Height="64" Offset="0x5818" TlutOffset="0x1888" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_006018" OutName="ganon_boss_sceneTex_006018" Format="ci8" Width="16" Height="64" Offset="0x6018" TlutOffset="0x1A90" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_006418" OutName="ganon_boss_sceneTex_006418" Format="ci8" Width="32" Height="64" Offset="0x6418" TlutOffset="0x1C50" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_006C18" OutName="ganon_boss_sceneTex_006C18" Format="ci8" Width="32" Height="64" Offset="0x6C18" TlutOffset="0x1680" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_007418" OutName="ganon_boss_sceneTex_007418" Format="ci8" Width="32" Height="64" Offset="0x7418" TlutOffset="0x1680" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTLUT_001550" OutName="ganon_boss_sceneTLUT_001550" Format="rgba16" Width="16" Height="16" Offset="0x1550" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTLUT_001620" OutName="ganon_boss_sceneTLUT_001620" Format="rgba16" Width="16" Height="16" Offset="0x1620" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTLUT_001680" OutName="ganon_boss_sceneTLUT_001680" Format="rgba16" Width="16" Height="16" Offset="0x1680" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTLUT_001888" OutName="ganon_boss_sceneTLUT_001888" Format="rgba16" Width="16" Height="16" Offset="0x1888" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTLUT_001A90" OutName="ganon_boss_sceneTLUT_001A90" Format="rgba16" Width="16" Height="16" Offset="0x1A90" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTLUT_001C50" OutName="ganon_boss_sceneTLUT_001C50" Format="rgba16" Width="16" Height="16" Offset="0x1C50" AddedByScript="true"/>
         <Scene Name="ganon_boss_scene" Offset="0x0"/>
     </File>
     <File Name="ganon_boss_room_0" Segment="3">

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/ganon_demo.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/ganon_demo.xml
@@ -1,5 +1,16 @@
 <Root>
     <File Name="ganon_demo_scene" Segment="2">
+        <Texture Name="ganon_demo_sceneTex_001B70" OutName="ganon_demo_sceneTex_001B70" Format="i8" Width="128" Height="32" Offset="0x1B70" AddedByScript="true"/>
+        <Texture Name="ganon_demo_sceneTex_002B70" OutName="ganon_demo_sceneTex_002B70" Format="i8" Width="64" Height="64" Offset="0x2B70" AddedByScript="true"/>
+        <Texture Name="ganon_demo_sceneTex_003B70" OutName="ganon_demo_sceneTex_003B70" Format="i8" Width="64" Height="64" Offset="0x3B70" AddedByScript="true"/>
+        <Texture Name="ganon_demo_sceneTex_004B70" OutName="ganon_demo_sceneTex_004B70" Format="i8" Width="64" Height="64" Offset="0x4B70" AddedByScript="true"/>
+        <Texture Name="ganon_demo_sceneTex_005B70" OutName="ganon_demo_sceneTex_005B70" Format="rgba16" Width="64" Height="16" Offset="0x5B70" AddedByScript="true"/>
+        <Texture Name="ganon_demo_sceneTex_006370" OutName="ganon_demo_sceneTex_006370" Format="rgba16" Width="32" Height="32" Offset="0x6370" AddedByScript="true"/>
+        <Texture Name="ganon_demo_sceneTex_006B70" OutName="ganon_demo_sceneTex_006B70" Format="ia4" Width="128" Height="32" Offset="0x6B70" AddedByScript="true"/>
+        <Texture Name="ganon_demo_sceneTex_007370" OutName="ganon_demo_sceneTex_007370" Format="rgba16" Width="32" Height="64" Offset="0x7370" AddedByScript="true"/>
+        <Texture Name="ganon_demo_sceneTex_008370" OutName="ganon_demo_sceneTex_008370" Format="rgba16" Width="16" Height="32" Offset="0x8370" AddedByScript="true"/>
+        <Texture Name="ganon_demo_sceneTex_008770" OutName="ganon_demo_sceneTex_008770" Format="i8" Width="16" Height="16" Offset="0x8770" AddedByScript="true"/>
+        <Texture Name="ganon_demo_sceneTex_008870" OutName="ganon_demo_sceneTex_008870" Format="rgba16" Width="32" Height="32" Offset="0x8870" AddedByScript="true"/>
         <Scene Name="ganon_demo_scene" Offset="0x0"/>
     </File>
     <File Name="ganon_demo_room_0" Segment="3">

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/ganon_final.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/ganon_final.xml
@@ -1,5 +1,30 @@
 <Root>
     <File Name="ganon_final_scene" Segment="2">
+        <Texture Name="ganon_final_sceneTex_002380" OutName="ganon_final_sceneTex_002380" Format="ia8" Width="32" Height="32" Offset="0x2380" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_002780" OutName="ganon_final_sceneTex_002780" Format="rgba16" Width="16" Height="16" Offset="0x2780" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_002980" OutName="ganon_final_sceneTex_002980" Format="i8" Width="64" Height="16" Offset="0x2980" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_002D80" OutName="ganon_final_sceneTex_002D80" Format="i4" Width="64" Height="128" Offset="0x2D80" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_003D80" OutName="ganon_final_sceneTex_003D80" Format="i8" Width="32" Height="64" Offset="0x3D80" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_004580" OutName="ganon_final_sceneTex_004580" Format="i8" Width="32" Height="64" Offset="0x4580" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_004D80" OutName="ganon_final_sceneTex_004D80" Format="i8" Width="64" Height="64" Offset="0x4D80" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_005D80" OutName="ganon_final_sceneTex_005D80" Format="i4" Width="64" Height="128" Offset="0x5D80" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_006D80" OutName="ganon_final_sceneTex_006D80" Format="ia8" Width="64" Height="32" Offset="0x6D80" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_007580" OutName="ganon_final_sceneTex_007580" Format="i4" Width="64" Height="128" Offset="0x7580" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_008580" OutName="ganon_final_sceneTex_008580" Format="rgba16" Width="32" Height="64" Offset="0x8580" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_009580" OutName="ganon_final_sceneTex_009580" Format="rgba16" Width="32" Height="64" Offset="0x9580" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_00A580" OutName="ganon_final_sceneTex_00A580" Format="ia4" Width="128" Height="32" Offset="0xA580" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_00AD80" OutName="ganon_final_sceneTex_00AD80" Format="rgba16" Width="32" Height="64" Offset="0xAD80" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_00BD80" OutName="ganon_final_sceneTex_00BD80" Format="rgba16" Width="32" Height="64" Offset="0xBD80" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_00CD80" OutName="ganon_final_sceneTex_00CD80" Format="i8" Width="16" Height="16" Offset="0xCD80" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_00CE80" OutName="ganon_final_sceneTex_00CE80" Format="ia8" Width="64" Height="64" Offset="0xCE80" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_00DE80" OutName="ganon_final_sceneTex_00DE80" Format="i4" Width="64" Height="16" Offset="0xDE80" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_00E080" OutName="ganon_final_sceneTex_00E080" Format="ia8" Width="16" Height="16" Offset="0xE080" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_00E180" OutName="ganon_final_sceneTex_00E180" Format="i4" Width="128" Height="64" Offset="0xE180" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_00F180" OutName="ganon_final_sceneTex_00F180" Format="i8" Width="32" Height="32" Offset="0xF180" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_00F580" OutName="ganon_final_sceneTex_00F580" Format="i8" Width="128" Height="32" Offset="0xF580" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_010580" OutName="ganon_final_sceneTex_010580" Format="i8" Width="32" Height="32" Offset="0x10580" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_010980" OutName="ganon_final_sceneTex_010980" Format="rgba16" Width="16" Height="64" Offset="0x10980" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_011180" OutName="ganon_final_sceneTex_011180" Format="i8" Width="16" Height="256" Offset="0x11180" AddedByScript="true"/>
         <Path Name="gGanonFinalPath_001F4" Offset="0x1F4" NumPaths="4"/>
         <Scene Name="ganon_final_scene" Offset="0x0"/>
     </File>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/ganon_sonogo.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/ganon_sonogo.xml
@@ -1,21 +1,72 @@
 <Root>
     <File Name="ganon_sonogo_scene" Segment="2">
+        <Texture Name="ganon_sonogo_sceneTex_006710" OutName="ganon_sonogo_sceneTex_006710" Format="ci8" Width="32" Height="64" Offset="0x6710" TlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_sceneTex_006F10" OutName="ganon_sonogo_sceneTex_006F10" Format="ci8" Width="32" Height="32" Offset="0x6F10" TlutOffset="0x6508" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_sceneTex_007310" OutName="ganon_sonogo_sceneTex_007310" Format="ci8" Width="32" Height="32" Offset="0x7310" TlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_sceneTex_007710" OutName="ganon_sonogo_sceneTex_007710" Format="ia16" Width="32" Height="32" Offset="0x7710" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_sceneTLUT_006300" OutName="ganon_sonogo_sceneTLUT_006300" Format="rgba16" Width="16" Height="16" Offset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_sceneTLUT_006508" OutName="ganon_sonogo_sceneTLUT_006508" Format="rgba16" Width="16" Height="16" Offset="0x6508" AddedByScript="true"/>
         <Path Name="gGanonSonogoPath_00254" Offset="0x254" NumPaths="5"/>
         <Scene Name="ganon_sonogo_scene" Offset="0x0"/>
     </File>
     <File Name="ganon_sonogo_room_0" Segment="3">
+        <Texture Name="ganon_sonogo_room_0Tex_005020" OutName="ganon_sonogo_room_0Tex_005020" Format="ci8" Width="32" Height="64" Offset="0x5020" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_0Tex_005820" OutName="ganon_sonogo_room_0Tex_005820" Format="ci8" Width="32" Height="32" Offset="0x5820" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_0Tex_005C20" OutName="ganon_sonogo_room_0Tex_005C20" Format="ci8" Width="32" Height="32" Offset="0x5C20" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_0Tex_006020" OutName="ganon_sonogo_room_0Tex_006020" Format="ci8" Width="64" Height="32" Offset="0x6020" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_0Tex_006820" OutName="ganon_sonogo_room_0Tex_006820" Format="ci8" Width="64" Height="32" Offset="0x6820" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_0Tex_007020" OutName="ganon_sonogo_room_0Tex_007020" Format="ci8" Width="32" Height="32" Offset="0x7020" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_0Tex_007420" OutName="ganon_sonogo_room_0Tex_007420" Format="ci8" Width="32" Height="32" Offset="0x7420" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_0Tex_007820" OutName="ganon_sonogo_room_0Tex_007820" Format="ci8" Width="32" Height="32" Offset="0x7820" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
         <Room Name="ganon_sonogo_room_0" Offset="0x0"/>
     </File>
     <File Name="ganon_sonogo_room_1" Segment="3">
+        <Texture Name="ganon_sonogo_room_1Tex_004148" OutName="ganon_sonogo_room_1Tex_004148" Format="ci8" Width="32" Height="32" Offset="0x4148" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_1Tex_004548" OutName="ganon_sonogo_room_1Tex_004548" Format="ci8" Width="32" Height="32" Offset="0x4548" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_1Tex_004948" OutName="ganon_sonogo_room_1Tex_004948" Format="ci8" Width="32" Height="32" Offset="0x4948" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_1Tex_004D48" OutName="ganon_sonogo_room_1Tex_004D48" Format="ci8" Width="32" Height="64" Offset="0x4D48" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_1Tex_005548" OutName="ganon_sonogo_room_1Tex_005548" Format="ci8" Width="32" Height="32" Offset="0x5548" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_1Tex_005948" OutName="ganon_sonogo_room_1Tex_005948" Format="ci8" Width="32" Height="32" Offset="0x5948" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_1Tex_005D48" OutName="ganon_sonogo_room_1Tex_005D48" Format="ci8" Width="32" Height="64" Offset="0x5D48" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_1Tex_006548" OutName="ganon_sonogo_room_1Tex_006548" Format="ci8" Width="32" Height="32" Offset="0x6548" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_1Tex_006948" OutName="ganon_sonogo_room_1Tex_006948" Format="rgba16" Width="32" Height="64" Offset="0x6948" AddedByScript="true"/>
         <Room Name="ganon_sonogo_room_1" Offset="0x0"/>
     </File>
     <File Name="ganon_sonogo_room_2" Segment="3">
+        <Texture Name="ganon_sonogo_room_2Tex_004A40" OutName="ganon_sonogo_room_2Tex_004A40" Format="ci8" Width="32" Height="64" Offset="0x4A40" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_2Tex_005240" OutName="ganon_sonogo_room_2Tex_005240" Format="ci8" Width="32" Height="32" Offset="0x5240" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_2Tex_005640" OutName="ganon_sonogo_room_2Tex_005640" Format="ci8" Width="32" Height="32" Offset="0x5640" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_2Tex_005A40" OutName="ganon_sonogo_room_2Tex_005A40" Format="ci8" Width="32" Height="64" Offset="0x5A40" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_2Tex_006240" OutName="ganon_sonogo_room_2Tex_006240" Format="ci8" Width="32" Height="32" Offset="0x6240" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_2Tex_006640" OutName="ganon_sonogo_room_2Tex_006640" Format="ci8" Width="32" Height="32" Offset="0x6640" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_2Tex_006A40" OutName="ganon_sonogo_room_2Tex_006A40" Format="ci8" Width="32" Height="32" Offset="0x6A40" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_2Tex_006E40" OutName="ganon_sonogo_room_2Tex_006E40" Format="ci8" Width="32" Height="32" Offset="0x6E40" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_2Tex_007240" OutName="ganon_sonogo_room_2Tex_007240" Format="ci8" Width="32" Height="64" Offset="0x7240" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_2Tex_007A40" OutName="ganon_sonogo_room_2Tex_007A40" Format="ci8" Width="32" Height="64" Offset="0x7A40" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_2Tex_008240" OutName="ganon_sonogo_room_2Tex_008240" Format="ci8" Width="32" Height="64" Offset="0x8240" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
         <Room Name="ganon_sonogo_room_2" Offset="0x0"/>
     </File>
     <File Name="ganon_sonogo_room_3" Segment="3">
+        <Texture Name="ganon_sonogo_room_3Tex_003A38" OutName="ganon_sonogo_room_3Tex_003A38" Format="ci8" Width="32" Height="32" Offset="0x3A38" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_3Tex_003E38" OutName="ganon_sonogo_room_3Tex_003E38" Format="ci8" Width="64" Height="32" Offset="0x3E38" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_3Tex_004638" OutName="ganon_sonogo_room_3Tex_004638" Format="ci8" Width="64" Height="32" Offset="0x4638" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_3Tex_004E38" OutName="ganon_sonogo_room_3Tex_004E38" Format="ci8" Width="32" Height="64" Offset="0x4E38" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
         <Room Name="ganon_sonogo_room_3" Offset="0x0"/>
     </File>
     <File Name="ganon_sonogo_room_4" Segment="3">
+        <Texture Name="ganon_sonogo_room_4Tex_004BA8" OutName="ganon_sonogo_room_4Tex_004BA8" Format="ci8" Width="32" Height="64" Offset="0x4BA8" TlutOffset="0x4840" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_4Tex_0053A8" OutName="ganon_sonogo_room_4Tex_0053A8" Format="ci8" Width="16" Height="16" Offset="0x53A8" TlutOffset="0x4B18" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_4Tex_0054A8" OutName="ganon_sonogo_room_4Tex_0054A8" Format="ci8" Width="8" Height="8" Offset="0x54A8" TlutOffset="0x4B18" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_4Tex_0054E8" OutName="ganon_sonogo_room_4Tex_0054E8" Format="rgba16" Width="32" Height="32" Offset="0x54E8" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_4Tex_005CE8" OutName="ganon_sonogo_room_4Tex_005CE8" Format="ci8" Width="32" Height="64" Offset="0x5CE8" TlutOffset="0x4910" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_4Tex_0064E8" OutName="ganon_sonogo_room_4Tex_0064E8" Format="ci8" Width="32" Height="32" Offset="0x64E8" TlutOffset="0x4B18" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_4Tex_0068E8" OutName="ganon_sonogo_room_4Tex_0068E8" Format="ci8" Width="32" Height="32" Offset="0x68E8" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_4Tex_006CE8" OutName="ganon_sonogo_room_4Tex_006CE8" Format="rgba16" Width="32" Height="32" Offset="0x6CE8" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_4Tex_0074E8" OutName="ganon_sonogo_room_4Tex_0074E8" Format="ci8" Width="32" Height="64" Offset="0x74E8" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_4Tex_007CE8" OutName="ganon_sonogo_room_4Tex_007CE8" Format="rgba16" Width="32" Height="64" Offset="0x7CE8" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_4TLUT_004840" OutName="ganon_sonogo_room_4TLUT_004840" Format="rgba16" Width="16" Height="16" Offset="0x4840" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_4TLUT_004910" OutName="ganon_sonogo_room_4TLUT_004910" Format="rgba16" Width="16" Height="16" Offset="0x4910" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_4TLUT_004B18" OutName="ganon_sonogo_room_4TLUT_004B18" Format="rgba16" Width="16" Height="16" Offset="0x4B18" AddedByScript="true"/>
         <Room Name="ganon_sonogo_room_4" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/ganon_tou.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/ganon_tou.xml
@@ -1,10 +1,34 @@
 <Root>
     <File Name="ganon_tou_scene" Segment="2">
+        <Texture Name="ganon_tou_sceneTex_003280" OutName="ganon_tou_sceneTex_003280" Format="i8" Width="64" Height="64" Offset="0x3280" AddedByScript="true"/>
         <Cutscene Name="gRainbowBridgeCs" Offset="0x2640"/>
         <Cutscene Name="gGanonsCastleIntroCs" Offset="0x4280"/>
         <Scene Name="ganon_tou_scene" Offset="0x0"/>
     </File>
     <File Name="ganon_tou_room_0" Segment="3">
+        <Texture Name="ganon_tou_room_0Tex_008550" OutName="ganon_tou_room_0Tex_008550" Format="rgba16" Width="32" Height="32" Offset="0x8550" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_008D50" OutName="ganon_tou_room_0Tex_008D50" Format="rgba16" Width="16" Height="16" Offset="0x8D50" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_008F50" OutName="ganon_tou_room_0Tex_008F50" Format="rgba16" Width="32" Height="8" Offset="0x8F50" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_009150" OutName="ganon_tou_room_0Tex_009150" Format="rgba16" Width="64" Height="32" Offset="0x9150" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_00A150" OutName="ganon_tou_room_0Tex_00A150" Format="rgba16" Width="128" Height="16" Offset="0xA150" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_00B150" OutName="ganon_tou_room_0Tex_00B150" Format="rgba16" Width="32" Height="16" Offset="0xB150" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_00B550" OutName="ganon_tou_room_0Tex_00B550" Format="i8" Width="32" Height="32" Offset="0xB550" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_00B950" OutName="ganon_tou_room_0Tex_00B950" Format="i8" Width="32" Height="32" Offset="0xB950" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_00BD50" OutName="ganon_tou_room_0Tex_00BD50" Format="rgba16" Width="16" Height="16" Offset="0xBD50" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_00BF50" OutName="ganon_tou_room_0Tex_00BF50" Format="i8" Width="64" Height="64" Offset="0xBF50" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_00CF50" OutName="ganon_tou_room_0Tex_00CF50" Format="rgba16" Width="32" Height="32" Offset="0xCF50" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_00D750" OutName="ganon_tou_room_0Tex_00D750" Format="rgba16" Width="32" Height="64" Offset="0xD750" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_00E750" OutName="ganon_tou_room_0Tex_00E750" Format="rgba16" Width="32" Height="64" Offset="0xE750" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_00F750" OutName="ganon_tou_room_0Tex_00F750" Format="i8" Width="32" Height="32" Offset="0xF750" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_00FB50" OutName="ganon_tou_room_0Tex_00FB50" Format="i8" Width="64" Height="16" Offset="0xFB50" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_00FF50" OutName="ganon_tou_room_0Tex_00FF50" Format="rgba16" Width="16" Height="16" Offset="0xFF50" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_010150" OutName="ganon_tou_room_0Tex_010150" Format="rgba16" Width="32" Height="16" Offset="0x10150" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_010550" OutName="ganon_tou_room_0Tex_010550" Format="rgba16" Width="32" Height="32" Offset="0x10550" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_0124F0" OutName="ganon_tou_room_0Tex_0124F0" Format="ia8" Width="32" Height="8" Offset="0x124F0" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_0125F0" OutName="ganon_tou_room_0Tex_0125F0" Format="ia4" Width="128" Height="32" Offset="0x125F0" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_012DF0" OutName="ganon_tou_room_0Tex_012DF0" Format="i4" Width="64" Height="64" Offset="0x12DF0" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_0135F0" OutName="ganon_tou_room_0Tex_0135F0" Format="ia8" Width="32" Height="32" Offset="0x135F0" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_0139F0" OutName="ganon_tou_room_0Tex_0139F0" Format="ia8" Width="16" Height="16" Offset="0x139F0" AddedByScript="true"/>
         <Room Name="ganon_tou_room_0" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/ganontika.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/ganontika.xml
@@ -1,5 +1,11 @@
 <Root>
     <File Name="ganontika_scene" Segment="2">
+        <Texture Name="ganontika_sceneTex_01F580" OutName="ganontika_sceneTex_01F580" Format="rgba16" Width="16" Height="16" Offset="0x1F570" AddedByScript="true"/>
+        <Texture Name="ganontika_sceneTex_01F780" OutName="ganontika_sceneTex_01F780" Format="ci8" Width="32" Height="64" Offset="0x1F770" TlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_sceneTex_01FF80" OutName="ganontika_sceneTex_01FF80" Format="ci8" Width="32" Height="32" Offset="0x1FF70" TlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_sceneTex_020380" OutName="ganontika_sceneTex_020380" Format="ci8" Width="64" Height="32" Offset="0x20370" TlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_sceneTex_020B80" OutName="ganontika_sceneTex_020B80" Format="rgba16" Width="32" Height="32" Offset="0x20B70" AddedByScript="true"/>
+        <Texture Name="ganontika_sceneTLUT_01F380" OutName="ganontika_sceneTLUT_01F380" Format="rgba16" Width="16" Height="16" Offset="0x1F370" AddedByScript="true"/>
         <Path Name="gGanontikaPath_00674" Offset="0x674" NumPaths="3"/>
         <Cutscene Name="gForestTrialSageCs" Offset="0x19ED0"/>
         <Cutscene Name="gWaterTrialSageCs" Offset="0x1A8D0"/>
@@ -20,63 +26,229 @@
         <Scene Name="ganontika_scene" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_0" Segment="3">
+        <Texture Name="ganontika_room_0Tex_007F48" OutName="ganontika_room_0Tex_007F48" Format="ci8" Width="64" Height="32" Offset="0x7EF8" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_0Tex_008A10" OutName="ganontika_room_0Tex_008A10" Format="ia16" Width="8" Height="128" Offset="0x89C0" AddedByScript="true"/>
         <Room Name="ganontika_room_0" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_1" Segment="3">
+        <Texture Name="ganontika_room_1Tex_00D9E0" OutName="ganontika_room_1Tex_00D9E0" Format="i4" Width="128" Height="64" Offset="0xD9C0" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_00E9E0" OutName="ganontika_room_1Tex_00E9E0" Format="i4" Width="128" Height="64" Offset="0xE9C0" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_00F9E0" OutName="ganontika_room_1Tex_00F9E0" Format="i4" Width="128" Height="64" Offset="0xF9C0" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0109E0" OutName="ganontika_room_1Tex_0109E0" Format="rgba16" Width="64" Height="32" Offset="0x109C0" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0119E0" OutName="ganontika_room_1Tex_0119E0" Format="ci8" Width="32" Height="64" Offset="0x119C0" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0121E0" OutName="ganontika_room_1Tex_0121E0" Format="ci8" Width="64" Height="32" Offset="0x121C0" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0129E0" OutName="ganontika_room_1Tex_0129E0" Format="ci8" Width="32" Height="64" Offset="0x129C0" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0131E0" OutName="ganontika_room_1Tex_0131E0" Format="ci8" Width="64" Height="32" Offset="0x131C0" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0139E0" OutName="ganontika_room_1Tex_0139E0" Format="ci8" Width="64" Height="32" Offset="0x139C0" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0141E0" OutName="ganontika_room_1Tex_0141E0" Format="ci8" Width="64" Height="32" Offset="0x141C0" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0149E0" OutName="ganontika_room_1Tex_0149E0" Format="ci8" Width="64" Height="32" Offset="0x149C0" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0151E0" OutName="ganontika_room_1Tex_0151E0" Format="ci8" Width="32" Height="64" Offset="0x151C0" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0159E0" OutName="ganontika_room_1Tex_0159E0" Format="ci4" Width="64" Height="64" Offset="0x159C0" TlutOffset="0xD9A0" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0161E0" OutName="ganontika_room_1Tex_0161E0" Format="ci4" Width="64" Height="64" Offset="0x161C0" TlutOffset="0xD9A0" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0169E0" OutName="ganontika_room_1Tex_0169E0" Format="ci4" Width="64" Height="64" Offset="0x169C0" TlutOffset="0xD9A0" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0171E0" OutName="ganontika_room_1Tex_0171E0" Format="ci4" Width="64" Height="64" Offset="0x171C0" TlutOffset="0xD9A0" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0179E0" OutName="ganontika_room_1Tex_0179E0" Format="ci4" Width="64" Height="64" Offset="0x179C0" TlutOffset="0xD9A0" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0181E0" OutName="ganontika_room_1Tex_0181E0" Format="ci4" Width="64" Height="64" Offset="0x181C0" TlutOffset="0xD9A0" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0189E0" OutName="ganontika_room_1Tex_0189E0" Format="rgba16" Width="64" Height="32" Offset="0x189C0" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0199E0" OutName="ganontika_room_1Tex_0199E0" Format="ci8" Width="64" Height="16" Offset="0x199C0" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_019DE0" OutName="ganontika_room_1Tex_019DE0" Format="ci8" Width="64" Height="32" Offset="0x19DC0" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_01B9C8" OutName="ganontika_room_1Tex_01B9C8" Format="ia8" Width="64" Height="64" Offset="0x1B9A8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1TLUT_00D9C0" OutName="ganontika_room_1TLUT_00D9C0" Format="rgba16" Width="4" Height="4" Offset="0xD9A0" AddedByScript="true"/>
         <Room Name="ganontika_room_1" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_2" Segment="3">
+        <Texture Name="ganontika_room_2Tex_002FD8" OutName="ganontika_room_2Tex_002FD8" Format="rgba16" Width="32" Height="32" Offset="0x2FD8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_2Tex_0037D8" OutName="ganontika_room_2Tex_0037D8" Format="rgba16" Width="32" Height="32" Offset="0x37D8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_2Tex_003FD8" OutName="ganontika_room_2Tex_003FD8" Format="rgba16" Width="32" Height="32" Offset="0x3FD8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_2Tex_0047D8" OutName="ganontika_room_2Tex_0047D8" Format="rgba16" Width="32" Height="32" Offset="0x47D8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_2Tex_004FD8" OutName="ganontika_room_2Tex_004FD8" Format="rgba16" Width="32" Height="32" Offset="0x4FD8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_2Tex_0057D8" OutName="ganontika_room_2Tex_0057D8" Format="rgba16" Width="32" Height="32" Offset="0x57D8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_2Tex_005FD8" OutName="ganontika_room_2Tex_005FD8" Format="ci8" Width="64" Height="32" Offset="0x5FD8" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_2Tex_0067D8" OutName="ganontika_room_2Tex_0067D8" Format="rgba16" Width="64" Height="32" Offset="0x67D8" AddedByScript="true"/>
         <Room Name="ganontika_room_2" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_3" Segment="3">
+        <Texture Name="ganontika_room_3Tex_003ED8" OutName="ganontika_room_3Tex_003ED8" Format="rgba16" Width="32" Height="32" Offset="0x3E28" AddedByScript="true"/>
+        <Texture Name="ganontika_room_3Tex_0046D8" OutName="ganontika_room_3Tex_0046D8" Format="rgba16" Width="32" Height="32" Offset="0x4628" AddedByScript="true"/>
+        <Texture Name="ganontika_room_3Tex_004ED8" OutName="ganontika_room_3Tex_004ED8" Format="rgba16" Width="32" Height="32" Offset="0x4E28" AddedByScript="true"/>
+        <Texture Name="ganontika_room_3Tex_0056D8" OutName="ganontika_room_3Tex_0056D8" Format="rgba16" Width="32" Height="32" Offset="0x5628" AddedByScript="true"/>
+        <Texture Name="ganontika_room_3Tex_005ED8" OutName="ganontika_room_3Tex_005ED8" Format="rgba16" Width="32" Height="32" Offset="0x5E28" AddedByScript="true"/>
+        <Texture Name="ganontika_room_3Tex_0066D8" OutName="ganontika_room_3Tex_0066D8" Format="rgba16" Width="32" Height="32" Offset="0x6628" AddedByScript="true"/>
+        <Texture Name="ganontika_room_3Tex_006ED8" OutName="ganontika_room_3Tex_006ED8" Format="ci4" Width="64" Height="64" Offset="0x6E28" TlutOffset="0x3E08" AddedByScript="true"/>
+        <Texture Name="ganontika_room_3Tex_0076D8" OutName="ganontika_room_3Tex_0076D8" Format="rgba16" Width="64" Height="32" Offset="0x7628" AddedByScript="true"/>
+        <Texture Name="ganontika_room_3Tex_008A38" OutName="ganontika_room_3Tex_008A38" Format="ia8" Width="64" Height="64" Offset="0x8988" AddedByScript="true"/>
+        <Texture Name="ganontika_room_3TLUT_003EB8" OutName="ganontika_room_3TLUT_003EB8" Format="rgba16" Width="4" Height="4" Offset="0x3E08" AddedByScript="true"/>
         <Room Name="ganontika_room_3" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_4" Segment="3">
+        <Texture Name="ganontika_room_4Tex_004288" OutName="ganontika_room_4Tex_004288" Format="rgba16" Width="32" Height="32" Offset="0x4288" AddedByScript="true"/>
+        <Texture Name="ganontika_room_4Tex_004A88" OutName="ganontika_room_4Tex_004A88" Format="ci8" Width="32" Height="64" Offset="0x4A88" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_4Tex_005288" OutName="ganontika_room_4Tex_005288" Format="ci8" Width="64" Height="32" Offset="0x5288" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_4Tex_005A88" OutName="ganontika_room_4Tex_005A88" Format="rgba16" Width="32" Height="32" Offset="0x5A88" AddedByScript="true"/>
+        <Texture Name="ganontika_room_4Tex_006288" OutName="ganontika_room_4Tex_006288" Format="rgba16" Width="32" Height="32" Offset="0x6288" AddedByScript="true"/>
+        <Texture Name="ganontika_room_4Tex_006A88" OutName="ganontika_room_4Tex_006A88" Format="rgba16" Width="16" Height="16" Offset="0x6A88" AddedByScript="true"/>
+        <Texture Name="ganontika_room_4Tex_006C88" OutName="ganontika_room_4Tex_006C88" Format="rgba16" Width="64" Height="32" Offset="0x6C88" AddedByScript="true"/>
         <Room Name="ganontika_room_4" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_5" Segment="3">
+        <Texture Name="ganontika_room_5Tex_003B18" OutName="ganontika_room_5Tex_003B18" Format="rgba16" Width="16" Height="16" Offset="0x3B38" AddedByScript="true"/>
+        <Texture Name="ganontika_room_5Tex_003D18" OutName="ganontika_room_5Tex_003D18" Format="ci8" Width="32" Height="64" Offset="0x3D38" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_5Tex_004518" OutName="ganontika_room_5Tex_004518" Format="rgba16" Width="32" Height="32" Offset="0x4538" AddedByScript="true"/>
+        <Texture Name="ganontika_room_5Tex_004D18" OutName="ganontika_room_5Tex_004D18" Format="ci8" Width="64" Height="32" Offset="0x4D38" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_5Tex_005518" OutName="ganontika_room_5Tex_005518" Format="rgba16" Width="32" Height="32" Offset="0x5538" AddedByScript="true"/>
+        <Texture Name="ganontika_room_5Tex_005D18" OutName="ganontika_room_5Tex_005D18" Format="ci8" Width="64" Height="32" Offset="0x5D38" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_5Tex_006518" OutName="ganontika_room_5Tex_006518" Format="rgba16" Width="64" Height="32" Offset="0x6538" AddedByScript="true"/>
         <Room Name="ganontika_room_5" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_6" Segment="3">
+        <Texture Name="ganontika_room_6Tex_00B500" OutName="ganontika_room_6Tex_00B500" Format="ci8" Width="32" Height="32" Offset="0xB490" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_6Tex_00B900" OutName="ganontika_room_6Tex_00B900" Format="ci8" Width="32" Height="64" Offset="0xB890" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_6Tex_00C100" OutName="ganontika_room_6Tex_00C100" Format="ci8" Width="64" Height="32" Offset="0xC090" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_6Tex_00C900" OutName="ganontika_room_6Tex_00C900" Format="i4" Width="32" Height="32" Offset="0xC890" AddedByScript="true"/>
+        <Texture Name="ganontika_room_6Tex_00CB00" OutName="ganontika_room_6Tex_00CB00" Format="i4" Width="32" Height="32" Offset="0xCA90" AddedByScript="true"/>
+        <Texture Name="ganontika_room_6Tex_00CD00" OutName="ganontika_room_6Tex_00CD00" Format="i4" Width="32" Height="32" Offset="0xCC90" AddedByScript="true"/>
+        <Texture Name="ganontika_room_6Tex_00CF00" OutName="ganontika_room_6Tex_00CF00" Format="ci4" Width="64" Height="64" Offset="0xCE90" TlutOffset="0xB470" AddedByScript="true"/>
+        <Texture Name="ganontika_room_6Tex_00D700" OutName="ganontika_room_6Tex_00D700" Format="i4" Width="32" Height="32" Offset="0xD690" AddedByScript="true"/>
+        <Texture Name="ganontika_room_6Tex_00D900" OutName="ganontika_room_6Tex_00D900" Format="rgba16" Width="64" Height="32" Offset="0xD890" AddedByScript="true"/>
+        <Texture Name="ganontika_room_6Tex_00EC58" OutName="ganontika_room_6Tex_00EC58" Format="ia8" Width="64" Height="64" Offset="0xEBE8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_6TLUT_00B4E0" OutName="ganontika_room_6TLUT_00B4E0" Format="rgba16" Width="4" Height="4" Offset="0xB470" AddedByScript="true"/>
         <Room Name="ganontika_room_6" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_7" Segment="3">
+        <Texture Name="ganontika_room_7Tex_004288" OutName="ganontika_room_7Tex_004288" Format="rgba16" Width="32" Height="32" Offset="0x4288" AddedByScript="true"/>
+        <Texture Name="ganontika_room_7Tex_004A88" OutName="ganontika_room_7Tex_004A88" Format="ci8" Width="32" Height="64" Offset="0x4A88" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_7Tex_005288" OutName="ganontika_room_7Tex_005288" Format="ci8" Width="64" Height="32" Offset="0x5288" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_7Tex_005A88" OutName="ganontika_room_7Tex_005A88" Format="rgba16" Width="32" Height="32" Offset="0x5A88" AddedByScript="true"/>
+        <Texture Name="ganontika_room_7Tex_006288" OutName="ganontika_room_7Tex_006288" Format="rgba16" Width="32" Height="32" Offset="0x6288" AddedByScript="true"/>
+        <Texture Name="ganontika_room_7Tex_006A88" OutName="ganontika_room_7Tex_006A88" Format="rgba16" Width="16" Height="16" Offset="0x6A88" AddedByScript="true"/>
+        <Texture Name="ganontika_room_7Tex_006C88" OutName="ganontika_room_7Tex_006C88" Format="rgba16" Width="64" Height="32" Offset="0x6C88" AddedByScript="true"/>
         <Room Name="ganontika_room_7" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_8" Segment="3">
+        <Texture Name="ganontika_room_8Tex_0034B8" OutName="ganontika_room_8Tex_0034B8" Format="rgba16" Width="32" Height="64" Offset="0x3508" AddedByScript="true"/>
+        <Texture Name="ganontika_room_8Tex_0044B8" OutName="ganontika_room_8Tex_0044B8" Format="rgba16" Width="32" Height="64" Offset="0x4508" AddedByScript="true"/>
+        <Texture Name="ganontika_room_8Tex_0054B8" OutName="ganontika_room_8Tex_0054B8" Format="rgba16" Width="32" Height="32" Offset="0x5508" AddedByScript="true"/>
+        <Texture Name="ganontika_room_8Tex_005CB8" OutName="ganontika_room_8Tex_005CB8" Format="rgba16" Width="32" Height="64" Offset="0x5D08" AddedByScript="true"/>
+        <Texture Name="ganontika_room_8Tex_006CB8" OutName="ganontika_room_8Tex_006CB8" Format="rgba16" Width="32" Height="32" Offset="0x6D08" AddedByScript="true"/>
+        <Texture Name="ganontika_room_8Tex_0074B8" OutName="ganontika_room_8Tex_0074B8" Format="ci4" Width="64" Height="64" Offset="0x7508" TlutOffset="0x34E8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_8Tex_008018" OutName="ganontika_room_8Tex_008018" Format="ia8" Width="64" Height="64" Offset="0x8068" AddedByScript="true"/>
+        <Texture Name="ganontika_room_8TLUT_003498" OutName="ganontika_room_8TLUT_003498" Format="rgba16" Width="4" Height="4" Offset="0x34E8" AddedByScript="true"/>
         <Room Name="ganontika_room_8" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_9" Segment="3">
+        <Texture Name="ganontika_room_9Tex_005488" OutName="ganontika_room_9Tex_005488" Format="rgba16" Width="64" Height="32" Offset="0x54F8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_9Tex_006488" OutName="ganontika_room_9Tex_006488" Format="rgba16" Width="64" Height="32" Offset="0x64F8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_9Tex_007488" OutName="ganontika_room_9Tex_007488" Format="rgba16" Width="32" Height="32" Offset="0x74F8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_9Tex_007C88" OutName="ganontika_room_9Tex_007C88" Format="rgba16" Width="16" Height="16" Offset="0x7CF8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_9Tex_007E88" OutName="ganontika_room_9Tex_007E88" Format="ci8" Width="32" Height="64" Offset="0x7EF8" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_9Tex_008688" OutName="ganontika_room_9Tex_008688" Format="ci8" Width="64" Height="32" Offset="0x86F8" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_9Tex_008E88" OutName="ganontika_room_9Tex_008E88" Format="ci8" Width="64" Height="32" Offset="0x8EF8" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_9Tex_009688" OutName="ganontika_room_9Tex_009688" Format="rgba16" Width="64" Height="32" Offset="0x96F8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_9Tex_00A818" OutName="ganontika_room_9Tex_00A818" Format="rgba16" Width="32" Height="64" Offset="0xA888" AddedByScript="true"/>
         <Room Name="ganontika_room_9" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_10" Segment="3">
+        <Texture Name="ganontika_room_10Tex_0039B8" OutName="ganontika_room_10Tex_0039B8" Format="rgba16" Width="32" Height="32" Offset="0x3968" AddedByScript="true"/>
+        <Texture Name="ganontika_room_10Tex_0041B8" OutName="ganontika_room_10Tex_0041B8" Format="ci8" Width="32" Height="64" Offset="0x4168" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_10Tex_0049B8" OutName="ganontika_room_10Tex_0049B8" Format="rgba16" Width="32" Height="32" Offset="0x4968" AddedByScript="true"/>
+        <Texture Name="ganontika_room_10Tex_0051B8" OutName="ganontika_room_10Tex_0051B8" Format="rgba16" Width="32" Height="32" Offset="0x5168" AddedByScript="true"/>
+        <Texture Name="ganontika_room_10Tex_0059B8" OutName="ganontika_room_10Tex_0059B8" Format="rgba16" Width="16" Height="16" Offset="0x5968" AddedByScript="true"/>
+        <Texture Name="ganontika_room_10Tex_005BB8" OutName="ganontika_room_10Tex_005BB8" Format="rgba16" Width="64" Height="32" Offset="0x5B68" AddedByScript="true"/>
         <Room Name="ganontika_room_10" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_11" Segment="3">
+        <Texture Name="ganontika_room_11Tex_004150" OutName="ganontika_room_11Tex_004150" Format="rgba16" Width="32" Height="32" Offset="0x4150" AddedByScript="true"/>
+        <Texture Name="ganontika_room_11Tex_004950" OutName="ganontika_room_11Tex_004950" Format="ci8" Width="32" Height="64" Offset="0x4950" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_11Tex_005150" OutName="ganontika_room_11Tex_005150" Format="ci8" Width="64" Height="32" Offset="0x5150" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_11Tex_005950" OutName="ganontika_room_11Tex_005950" Format="rgba16" Width="32" Height="32" Offset="0x5950" AddedByScript="true"/>
+        <Texture Name="ganontika_room_11Tex_006150" OutName="ganontika_room_11Tex_006150" Format="rgba16" Width="32" Height="32" Offset="0x6150" AddedByScript="true"/>
         <Room Name="ganontika_room_11" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_12" Segment="3">
+        <Texture Name="ganontika_room_12Tex_005160" OutName="ganontika_room_12Tex_005160" Format="rgba16" Width="32" Height="32" Offset="0x5260" AddedByScript="true"/>
+        <Texture Name="ganontika_room_12Tex_005960" OutName="ganontika_room_12Tex_005960" Format="ci8" Width="64" Height="32" Offset="0x5A60" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_12Tex_006160" OutName="ganontika_room_12Tex_006160" Format="ci8" Width="32" Height="64" Offset="0x6260" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_12Tex_006960" OutName="ganontika_room_12Tex_006960" Format="ci4" Width="64" Height="64" Offset="0x6A60" TlutOffset="0x5240" AddedByScript="true"/>
+        <Texture Name="ganontika_room_12Tex_007160" OutName="ganontika_room_12Tex_007160" Format="rgba16" Width="64" Height="32" Offset="0x7260" AddedByScript="true"/>
+        <Texture Name="ganontika_room_12Tex_008160" OutName="ganontika_room_12Tex_008160" Format="ci8" Width="64" Height="16" Offset="0x8260" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_12Tex_008560" OutName="ganontika_room_12Tex_008560" Format="ci8" Width="64" Height="32" Offset="0x8660" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_12Tex_009270" OutName="ganontika_room_12Tex_009270" Format="ia8" Width="64" Height="64" Offset="0x9370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_12Tex_00A270" OutName="ganontika_room_12Tex_00A270" Format="ia8" Width="32" Height="128" Offset="0xA370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_12TLUT_005140" OutName="ganontika_room_12TLUT_005140" Format="rgba16" Width="4" Height="4" Offset="0x5240" AddedByScript="true"/>
         <Room Name="ganontika_room_12" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_13" Segment="3">
+        <Texture Name="ganontika_room_13Tex_004340" OutName="ganontika_room_13Tex_004340" Format="rgba16" Width="32" Height="32" Offset="0x4340" AddedByScript="true"/>
+        <Texture Name="ganontika_room_13Tex_004B40" OutName="ganontika_room_13Tex_004B40" Format="ci8" Width="32" Height="64" Offset="0x4B40" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_13Tex_005340" OutName="ganontika_room_13Tex_005340" Format="ci8" Width="64" Height="32" Offset="0x5340" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_13Tex_005B40" OutName="ganontika_room_13Tex_005B40" Format="rgba16" Width="32" Height="32" Offset="0x5B40" AddedByScript="true"/>
+        <Texture Name="ganontika_room_13Tex_006340" OutName="ganontika_room_13Tex_006340" Format="rgba16" Width="32" Height="32" Offset="0x6340" AddedByScript="true"/>
+        <Texture Name="ganontika_room_13Tex_006B40" OutName="ganontika_room_13Tex_006B40" Format="rgba16" Width="16" Height="16" Offset="0x6B40" AddedByScript="true"/>
+        <Texture Name="ganontika_room_13Tex_006D40" OutName="ganontika_room_13Tex_006D40" Format="rgba16" Width="64" Height="32" Offset="0x6D40" AddedByScript="true"/>
         <Room Name="ganontika_room_13" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_14" Segment="3">
+        <Texture Name="ganontika_room_14Tex_004FB8" OutName="ganontika_room_14Tex_004FB8" Format="rgba16" Width="32" Height="32" Offset="0x4F88" AddedByScript="true"/>
+        <Texture Name="ganontika_room_14Tex_0057B8" OutName="ganontika_room_14Tex_0057B8" Format="ci8" Width="64" Height="32" Offset="0x5788" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_14Tex_005FB8" OutName="ganontika_room_14Tex_005FB8" Format="ci4" Width="64" Height="64" Offset="0x5F88" TlutOffset="0x4F68" AddedByScript="true"/>
+        <Texture Name="ganontika_room_14Tex_0067B8" OutName="ganontika_room_14Tex_0067B8" Format="rgba16" Width="64" Height="32" Offset="0x6788" AddedByScript="true"/>
+        <Texture Name="ganontika_room_14Tex_0077B8" OutName="ganontika_room_14Tex_0077B8" Format="ci8" Width="64" Height="16" Offset="0x7788" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_14Tex_007BB8" OutName="ganontika_room_14Tex_007BB8" Format="ci8" Width="64" Height="32" Offset="0x7B88" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_14Tex_0089C8" OutName="ganontika_room_14Tex_0089C8" Format="ia8" Width="64" Height="64" Offset="0x8998" AddedByScript="true"/>
+        <Texture Name="ganontika_room_14Tex_0099C8" OutName="ganontika_room_14Tex_0099C8" Format="rgba16" Width="32" Height="32" Offset="0x9998" AddedByScript="true"/>
+        <Texture Name="ganontika_room_14TLUT_004F98" OutName="ganontika_room_14TLUT_004F98" Format="rgba16" Width="4" Height="4" Offset="0x4F68" AddedByScript="true"/>
         <Room Name="ganontika_room_14" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_15" Segment="3">
+        <Texture Name="ganontika_room_15Tex_004340" OutName="ganontika_room_15Tex_004340" Format="rgba16" Width="32" Height="32" Offset="0x4340" AddedByScript="true"/>
+        <Texture Name="ganontika_room_15Tex_004B40" OutName="ganontika_room_15Tex_004B40" Format="ci8" Width="32" Height="64" Offset="0x4B40" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_15Tex_005340" OutName="ganontika_room_15Tex_005340" Format="ci8" Width="64" Height="32" Offset="0x5340" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_15Tex_005B40" OutName="ganontika_room_15Tex_005B40" Format="rgba16" Width="32" Height="32" Offset="0x5B40" AddedByScript="true"/>
+        <Texture Name="ganontika_room_15Tex_006340" OutName="ganontika_room_15Tex_006340" Format="rgba16" Width="32" Height="32" Offset="0x6340" AddedByScript="true"/>
+        <Texture Name="ganontika_room_15Tex_006B40" OutName="ganontika_room_15Tex_006B40" Format="rgba16" Width="16" Height="16" Offset="0x6B40" AddedByScript="true"/>
+        <Texture Name="ganontika_room_15Tex_006D40" OutName="ganontika_room_15Tex_006D40" Format="rgba16" Width="64" Height="32" Offset="0x6D40" AddedByScript="true"/>
         <Room Name="ganontika_room_15" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_16" Segment="3">
+        <Texture Name="ganontika_room_16Tex_001630" OutName="ganontika_room_16Tex_001630" Format="rgba16" Width="64" Height="32" Offset="0x1620" AddedByScript="true"/>
+        <Texture Name="ganontika_room_16Tex_002630" OutName="ganontika_room_16Tex_002630" Format="ci8" Width="64" Height="32" Offset="0x2620" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
         <Room Name="ganontika_room_16" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_17" Segment="3">
+        <Texture Name="ganontika_room_17Tex_002A18" OutName="ganontika_room_17Tex_002A18" Format="ci8" Width="32" Height="32" Offset="0x2A98" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_17Tex_002E18" OutName="ganontika_room_17Tex_002E18" Format="rgba16" Width="64" Height="32" Offset="0x2E98" AddedByScript="true"/>
+        <Texture Name="ganontika_room_17Tex_003E18" OutName="ganontika_room_17Tex_003E18" Format="rgba16" Width="64" Height="32" Offset="0x3E98" AddedByScript="true"/>
+        <Texture Name="ganontika_room_17Tex_004E18" OutName="ganontika_room_17Tex_004E18" Format="rgba16" Width="32" Height="32" Offset="0x4E98" AddedByScript="true"/>
+        <Texture Name="ganontika_room_17Tex_005618" OutName="ganontika_room_17Tex_005618" Format="rgba16" Width="32" Height="64" Offset="0x5698" AddedByScript="true"/>
+        <Texture Name="ganontika_room_17Tex_006618" OutName="ganontika_room_17Tex_006618" Format="rgba16" Width="32" Height="32" Offset="0x6698" AddedByScript="true"/>
+        <Texture Name="ganontika_room_17Tex_006E18" OutName="ganontika_room_17Tex_006E18" Format="ci8" Width="64" Height="32" Offset="0x6E98" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_17Tex_007618" OutName="ganontika_room_17Tex_007618" Format="rgba16" Width="64" Height="32" Offset="0x7698" AddedByScript="true"/>
         <Room Name="ganontika_room_17" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_18" Segment="3">
+        <Texture Name="ganontika_room_18Tex_004380" OutName="ganontika_room_18Tex_004380" Format="rgba16" Width="32" Height="64" Offset="0x4310" AddedByScript="true"/>
+        <Texture Name="ganontika_room_18Tex_005380" OutName="ganontika_room_18Tex_005380" Format="ci8" Width="32" Height="32" Offset="0x5310" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_18Tex_005780" OutName="ganontika_room_18Tex_005780" Format="rgba16" Width="64" Height="32" Offset="0x5710" AddedByScript="true"/>
+        <Texture Name="ganontika_room_18Tex_006780" OutName="ganontika_room_18Tex_006780" Format="rgba16" Width="64" Height="32" Offset="0x6710" AddedByScript="true"/>
+        <Texture Name="ganontika_room_18Tex_007780" OutName="ganontika_room_18Tex_007780" Format="rgba16" Width="32" Height="32" Offset="0x7710" AddedByScript="true"/>
+        <Texture Name="ganontika_room_18Tex_007F80" OutName="ganontika_room_18Tex_007F80" Format="rgba16" Width="32" Height="64" Offset="0x7F10" AddedByScript="true"/>
+        <Texture Name="ganontika_room_18Tex_008F80" OutName="ganontika_room_18Tex_008F80" Format="rgba16" Width="32" Height="8" Offset="0x8F10" AddedByScript="true"/>
+        <Texture Name="ganontika_room_18Tex_009180" OutName="ganontika_room_18Tex_009180" Format="rgba16" Width="32" Height="32" Offset="0x9110" AddedByScript="true"/>
+        <Texture Name="ganontika_room_18Tex_009980" OutName="ganontika_room_18Tex_009980" Format="ci4" Width="64" Height="64" Offset="0x9910" TlutOffset="0x42F0" AddedByScript="true"/>
+        <Texture Name="ganontika_room_18Tex_00A180" OutName="ganontika_room_18Tex_00A180" Format="i4" Width="32" Height="32" Offset="0xA110" AddedByScript="true"/>
+        <Texture Name="ganontika_room_18Tex_00A380" OutName="ganontika_room_18Tex_00A380" Format="rgba16" Width="64" Height="32" Offset="0xA310" AddedByScript="true"/>
+        <Texture Name="ganontika_room_18Tex_00B6E0" OutName="ganontika_room_18Tex_00B6E0" Format="ia8" Width="64" Height="64" Offset="0xB670" AddedByScript="true"/>
+        <Texture Name="ganontika_room_18TLUT_004360" OutName="ganontika_room_18TLUT_004360" Format="rgba16" Width="4" Height="4" Offset="0x42F0" AddedByScript="true"/>
         <Room Name="ganontika_room_18" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_19" Segment="3">
+        <Texture Name="ganontika_room_19Tex_004340" OutName="ganontika_room_19Tex_004340" Format="rgba16" Width="32" Height="32" Offset="0x4340" AddedByScript="true"/>
+        <Texture Name="ganontika_room_19Tex_004B40" OutName="ganontika_room_19Tex_004B40" Format="ci8" Width="32" Height="64" Offset="0x4B40" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_19Tex_005340" OutName="ganontika_room_19Tex_005340" Format="ci8" Width="64" Height="32" Offset="0x5340" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_19Tex_005B40" OutName="ganontika_room_19Tex_005B40" Format="rgba16" Width="32" Height="32" Offset="0x5B40" AddedByScript="true"/>
+        <Texture Name="ganontika_room_19Tex_006340" OutName="ganontika_room_19Tex_006340" Format="rgba16" Width="32" Height="32" Offset="0x6340" AddedByScript="true"/>
+        <Texture Name="ganontika_room_19Tex_006B40" OutName="ganontika_room_19Tex_006B40" Format="rgba16" Width="16" Height="16" Offset="0x6B40" AddedByScript="true"/>
+        <Texture Name="ganontika_room_19Tex_006D40" OutName="ganontika_room_19Tex_006D40" Format="rgba16" Width="64" Height="32" Offset="0x6D40" AddedByScript="true"/>
         <Room Name="ganontika_room_19" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/ganontikasonogo.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/ganontikasonogo.xml
@@ -1,12 +1,36 @@
 <Root>
     <File Name="ganontikasonogo_scene" Segment="2">
+        <Texture Name="ganontikasonogo_sceneTex_002B00" OutName="ganontikasonogo_sceneTex_002B00" Format="rgba16" Width="32" Height="64" Offset="0x2B00" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_sceneTex_003B00" OutName="ganontikasonogo_sceneTex_003B00" Format="rgba16" Width="64" Height="32" Offset="0x3B00" AddedByScript="true"/>
         <Path Name="gGanonTikasongsoPath_00184" Offset="0x184" NumPaths="3"/>
         <Scene Name="ganontikasonogo_scene" Offset="0x0"/>
     </File>
     <File Name="ganontikasonogo_room_0" Segment="3">
+        <Texture Name="ganontikasonogo_room_0Tex_0092D8" OutName="ganontikasonogo_room_0Tex_0092D8" Format="rgba16" Width="64" Height="32" Offset="0x92D8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_00A2D8" OutName="ganontikasonogo_room_0Tex_00A2D8" Format="rgba16" Width="64" Height="32" Offset="0xA2D8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_00B2D8" OutName="ganontikasonogo_room_0Tex_00B2D8" Format="rgba16" Width="32" Height="64" Offset="0xB2D8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_00C2D8" OutName="ganontikasonogo_room_0Tex_00C2D8" Format="rgba16" Width="64" Height="32" Offset="0xC2D8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_00D2D8" OutName="ganontikasonogo_room_0Tex_00D2D8" Format="rgba16" Width="64" Height="32" Offset="0xD2D8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_00E2D8" OutName="ganontikasonogo_room_0Tex_00E2D8" Format="rgba16" Width="64" Height="32" Offset="0xE2D8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_00F2D8" OutName="ganontikasonogo_room_0Tex_00F2D8" Format="rgba16" Width="32" Height="32" Offset="0xF2D8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_00FAD8" OutName="ganontikasonogo_room_0Tex_00FAD8" Format="rgba16" Width="32" Height="64" Offset="0xFAD8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_010AD8" OutName="ganontikasonogo_room_0Tex_010AD8" Format="ci4" Width="64" Height="64" Offset="0x10AD8" TlutOffset="0x92B8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_0112D8" OutName="ganontikasonogo_room_0Tex_0112D8" Format="ci4" Width="64" Height="64" Offset="0x112D8" TlutOffset="0x92B8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_011AD8" OutName="ganontikasonogo_room_0Tex_011AD8" Format="ci4" Width="64" Height="64" Offset="0x11AD8" TlutOffset="0x92B8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_0122D8" OutName="ganontikasonogo_room_0Tex_0122D8" Format="ci4" Width="64" Height="64" Offset="0x122D8" TlutOffset="0x92B8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_012AD8" OutName="ganontikasonogo_room_0Tex_012AD8" Format="ci4" Width="64" Height="64" Offset="0x12AD8" TlutOffset="0x92B8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_0132D8" OutName="ganontikasonogo_room_0Tex_0132D8" Format="rgba16" Width="64" Height="32" Offset="0x132D8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_0142D8" OutName="ganontikasonogo_room_0Tex_0142D8" Format="rgba16" Width="64" Height="16" Offset="0x142D8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_014AD8" OutName="ganontikasonogo_room_0Tex_014AD8" Format="rgba16" Width="64" Height="32" Offset="0x14AD8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_016B78" OutName="ganontikasonogo_room_0Tex_016B78" Format="ia8" Width="64" Height="64" Offset="0x16B78" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0TLUT_0092B8" OutName="ganontikasonogo_room_0TLUT_0092B8" Format="rgba16" Width="4" Height="4" Offset="0x92B8" AddedByScript="true"/>
         <Room Name="ganontikasonogo_room_0" Offset="0x0"/>
     </File>
     <File Name="ganontikasonogo_room_1" Segment="3">
+        <Texture Name="ganontikasonogo_room_1Tex_006C60" OutName="ganontikasonogo_room_1Tex_006C60" Format="rgba16" Width="32" Height="32" Offset="0x6C60" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_1Tex_007460" OutName="ganontikasonogo_room_1Tex_007460" Format="rgba16" Width="64" Height="32" Offset="0x7460" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_1Tex_008460" OutName="ganontikasonogo_room_1Tex_008460" Format="rgba16" Width="32" Height="64" Offset="0x8460" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_1Tex_009720" OutName="ganontikasonogo_room_1Tex_009720" Format="ia16" Width="8" Height="128" Offset="0x9720" AddedByScript="true"/>
         <Room Name="ganontikasonogo_room_1" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/gerudoway.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/gerudoway.xml
@@ -1,26 +1,55 @@
 <Root>
     <File Name="gerudoway_scene" Segment="2">
+        <Texture Name="gerudoway_sceneTex_007520" OutName="gerudoway_sceneTex_007520" Format="rgba16" Width="32" Height="64" Offset="0x7520" AddedByScript="true"/>
+        <Texture Name="gerudoway_sceneTex_008520" OutName="gerudoway_sceneTex_008520" Format="ia4" Width="128" Height="32" Offset="0x8520" AddedByScript="true"/>
+        <Texture Name="gerudoway_sceneTex_008D20" OutName="gerudoway_sceneTex_008D20" Format="ia8" Width="64" Height="32" Offset="0x8D20" AddedByScript="true"/>
+        <Texture Name="gerudoway_sceneTex_009520" OutName="gerudoway_sceneTex_009520" Format="ia8" Width="32" Height="64" Offset="0x9520" AddedByScript="true"/>
+        <Texture Name="gerudoway_sceneTex_009D20" OutName="gerudoway_sceneTex_009D20" Format="rgba16" Width="32" Height="32" Offset="0x9D20" AddedByScript="true"/>
+        <Texture Name="gerudoway_sceneTex_00A520" OutName="gerudoway_sceneTex_00A520" Format="rgba16" Width="32" Height="16" Offset="0xA520" AddedByScript="true"/>
+        <Texture Name="gerudoway_sceneTex_00A920" OutName="gerudoway_sceneTex_00A920" Format="rgba16" Width="32" Height="64" Offset="0xA920" AddedByScript="true"/>
+        <Texture Name="gerudoway_sceneTex_00C120" OutName="gerudoway_sceneTex_00C120" Format="rgba16" Width="64" Height="32" Offset="0xC120" AddedByScript="true"/>
+        <Texture Name="gerudoway_sceneTex_00D120" OutName="gerudoway_sceneTex_00D120" Format="rgba16" Width="32" Height="32" Offset="0xD120" AddedByScript="true"/>
         <Texture Name="gThievesHideoutNightEntranceTex" OutName="night_entrance" Format="ia16" Width="128" Height="4" Offset="0xB920"/>
         <Texture Name="gThievesHideoutDayEntranceTex" OutName="day_entrance" Format="ia16" Width="128" Height="4" Offset="0xBD20"/>
         <Path Name="gGerudowayPath_002AC" Offset="0x2AC" NumPaths="4"/>
         <Scene Name="gerudoway_scene" Offset="0x0"/>
     </File>
     <File Name="gerudoway_room_0" Segment="3">
+        <Texture Name="gerudoway_room_0Tex_002FB0" OutName="gerudoway_room_0Tex_002FB0" Format="rgba16" Width="64" Height="32" Offset="0x2FB0" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_0Tex_003FB0" OutName="gerudoway_room_0Tex_003FB0" Format="rgba16" Width="32" Height="16" Offset="0x3FB0" AddedByScript="true"/>
         <Room Name="gerudoway_room_0" Offset="0x0"/>
     </File>
      <File Name="gerudoway_room_1" Segment="3">
+        <Texture Name="gerudoway_room_1Tex_003710" OutName="gerudoway_room_1Tex_003710" Format="rgba16" Width="32" Height="32" Offset="0x3710" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_1Tex_003F10" OutName="gerudoway_room_1Tex_003F10" Format="ia4" Width="32" Height="128" Offset="0x3F10" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_1Tex_004710" OutName="gerudoway_room_1Tex_004710" Format="rgba16" Width="64" Height="32" Offset="0x4710" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_1Tex_005710" OutName="gerudoway_room_1Tex_005710" Format="rgba16" Width="32" Height="16" Offset="0x5710" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_1Tex_005B10" OutName="gerudoway_room_1Tex_005B10" Format="rgba16" Width="64" Height="16" Offset="0x5B10" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_1Tex_006310" OutName="gerudoway_room_1Tex_006310" Format="rgba16" Width="16" Height="64" Offset="0x6310" AddedByScript="true"/>
         <Room Name="gerudoway_room_1" Offset="0x0"/>
     </File>
      <File Name="gerudoway_room_2" Segment="3">
+        <Texture Name="gerudoway_room_2Tex_002298" OutName="gerudoway_room_2Tex_002298" Format="rgba16" Width="64" Height="16" Offset="0x2298" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_2Tex_002A98" OutName="gerudoway_room_2Tex_002A98" Format="rgba16" Width="16" Height="64" Offset="0x2A98" AddedByScript="true"/>
         <Room Name="gerudoway_room_2" Offset="0x0"/>
     </File>
      <File Name="gerudoway_room_3" Segment="3">
+        <Texture Name="gerudoway_room_3Tex_006EA0" OutName="gerudoway_room_3Tex_006EA0" Format="rgba16" Width="32" Height="32" Offset="0x6EA0" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_3Tex_0076A0" OutName="gerudoway_room_3Tex_0076A0" Format="ia4" Width="32" Height="128" Offset="0x76A0" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_3Tex_007EA0" OutName="gerudoway_room_3Tex_007EA0" Format="rgba16" Width="64" Height="32" Offset="0x7EA0" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_3Tex_008EA0" OutName="gerudoway_room_3Tex_008EA0" Format="rgba16" Width="32" Height="16" Offset="0x8EA0" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_3Tex_0092A0" OutName="gerudoway_room_3Tex_0092A0" Format="rgba16" Width="32" Height="32" Offset="0x92A0" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_3Tex_009AA0" OutName="gerudoway_room_3Tex_009AA0" Format="rgba16" Width="16" Height="64" Offset="0x9AA0" AddedByScript="true"/>
         <Room Name="gerudoway_room_3" Offset="0x0"/>
     </File>
      <File Name="gerudoway_room_4" Segment="3">
+        <Texture Name="gerudoway_room_4Tex_002028" OutName="gerudoway_room_4Tex_002028" Format="rgba16" Width="64" Height="16" Offset="0x2028" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_4Tex_002828" OutName="gerudoway_room_4Tex_002828" Format="rgba16" Width="16" Height="64" Offset="0x2828" AddedByScript="true"/>
         <Room Name="gerudoway_room_4" Offset="0x0"/>
     </File>
      <File Name="gerudoway_room_5" Segment="3">
+        <Texture Name="gerudoway_room_5Tex_002FF8" OutName="gerudoway_room_5Tex_002FF8" Format="rgba16" Width="64" Height="16" Offset="0x2FF8" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_5Tex_0037F8" OutName="gerudoway_room_5Tex_0037F8" Format="rgba16" Width="16" Height="64" Offset="0x37F8" AddedByScript="true"/>
         <Room Name="gerudoway_room_5" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/ice_doukutu.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/ice_doukutu.xml
@@ -1,44 +1,105 @@
 <Root>
     <File Name="ice_doukutu_scene" Segment="2">
+        <Texture Name="ice_doukutu_sceneTex_00FCC0" OutName="ice_doukutu_sceneTex_00FCC0" Format="i8" Width="32" Height="32" Offset="0xFBF0" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_sceneTex_0100C0" OutName="ice_doukutu_sceneTex_0100C0" Format="rgba16" Width="32" Height="32" Offset="0xFFF0" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_sceneTex_0108C0" OutName="ice_doukutu_sceneTex_0108C0" Format="rgba16" Width="16" Height="16" Offset="0x107F0" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_sceneTex_010AC0" OutName="ice_doukutu_sceneTex_010AC0" Format="i8" Width="32" Height="32" Offset="0x109F0" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_sceneTex_010EC0" OutName="ice_doukutu_sceneTex_010EC0" Format="rgba16" Width="32" Height="32" Offset="0x10DF0" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_sceneTLUT_00F8A0" OutName="ice_doukutu_sceneTLUT_00F8A0" Format="rgba16" Width="4" Height="4" Offset="0xF7D0" AddedByScript="true"/>
         <Cutscene Name="gIceCavernSerenadeCs" Offset="0x250"/>
         <Texture Name="gIceCavernNightEntranceTex" OutName="night_entrance" Format="ia16" Width="64" Height="4" Offset="0xF7F0"/>
         <Texture Name="gIceCavernDayEntranceTex" OutName="day_entrance" Format="ia16" Width="64" Height="4" Offset="0xF9F0"/>
         <Scene Name="ice_doukutu_scene" Offset="0x0"/>
     </File>
     <File Name="ice_doukutu_room_0" Segment="3">
+        <Texture Name="ice_doukutu_room_0Tex_002F50" OutName="ice_doukutu_room_0Tex_002F50" Format="rgba16" Width="32" Height="64" Offset="0x2F30" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_0Tex_003F50" OutName="ice_doukutu_room_0Tex_003F50" Format="rgba16" Width="32" Height="32" Offset="0x3F30" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_0Tex_004750" OutName="ice_doukutu_room_0Tex_004750" Format="rgba16" Width="32" Height="64" Offset="0x4730" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_0Tex_005750" OutName="ice_doukutu_room_0Tex_005750" Format="rgba16" Width="32" Height="32" Offset="0x5730" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_0Tex_005F50" OutName="ice_doukutu_room_0Tex_005F50" Format="i8" Width="64" Height="64" Offset="0x5F30" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_0Tex_007678" OutName="ice_doukutu_room_0Tex_007678" Format="i8" Width="64" Height="64" Offset="0x7658" AddedByScript="true"/>
         <Room Name="ice_doukutu_room_0" Offset="0x0"/>
     </File>
     <File Name="ice_doukutu_room_1" Segment="3">
+        <Texture Name="ice_doukutu_room_1Tex_004110" OutName="ice_doukutu_room_1Tex_004110" Format="rgba16" Width="32" Height="64" Offset="0x4120" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_1Tex_005110" OutName="ice_doukutu_room_1Tex_005110" Format="rgba16" Width="32" Height="32" Offset="0x5120" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_1Tex_005910" OutName="ice_doukutu_room_1Tex_005910" Format="rgba16" Width="32" Height="64" Offset="0x5920" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_1Tex_006910" OutName="ice_doukutu_room_1Tex_006910" Format="rgba16" Width="32" Height="32" Offset="0x6920" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_1Tex_007110" OutName="ice_doukutu_room_1Tex_007110" Format="rgba16" Width="32" Height="64" Offset="0x7120" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_1Tex_008110" OutName="ice_doukutu_room_1Tex_008110" Format="i8" Width="64" Height="64" Offset="0x8120" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_1Tex_009110" OutName="ice_doukutu_room_1Tex_009110" Format="rgba16" Width="32" Height="32" Offset="0x9120" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_1Tex_00AB30" OutName="ice_doukutu_room_1Tex_00AB30" Format="rgba16" Width="32" Height="64" Offset="0xAB40" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_1Tex_00BB30" OutName="ice_doukutu_room_1Tex_00BB30" Format="rgba16" Width="16" Height="16" Offset="0xBB40" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_1Tex_00BD30" OutName="ice_doukutu_room_1Tex_00BD30" Format="rgba16" Width="32" Height="32" Offset="0xBD40" AddedByScript="true"/>
         <Room Name="ice_doukutu_room_1" Offset="0x0"/>
     </File>
     <File Name="ice_doukutu_room_2" Segment="3">
+        <Texture Name="ice_doukutu_room_2Tex_001730" OutName="ice_doukutu_room_2Tex_001730" Format="rgba16" Width="32" Height="64" Offset="0x1720" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_2Tex_002730" OutName="ice_doukutu_room_2Tex_002730" Format="ci4" Width="64" Height="64" Offset="0x2720" ExternalTlut="ice_doukutu_scene" ExternalTlutOffset="0xF7D0" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_2Tex_003AF8" OutName="ice_doukutu_room_2Tex_003AF8" Format="i8" Width="64" Height="64" Offset="0x3AE8" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_2Tex_004AF8" OutName="ice_doukutu_room_2Tex_004AF8" Format="rgba16" Width="32" Height="64" Offset="0x4AE8" AddedByScript="true"/>
         <Room Name="ice_doukutu_room_2" Offset="0x0"/>
     </File>
     <File Name="ice_doukutu_room_3" Segment="3">
+        <Texture Name="ice_doukutu_room_3Tex_003208" OutName="ice_doukutu_room_3Tex_003208" Format="rgba16" Width="32" Height="32" Offset="0x31F8" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_3Tex_003A08" OutName="ice_doukutu_room_3Tex_003A08" Format="ci4" Width="64" Height="64" Offset="0x39F8" ExternalTlut="ice_doukutu_scene" ExternalTlutOffset="0xF7D0" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_3Tex_005090" OutName="ice_doukutu_room_3Tex_005090" Format="i8" Width="64" Height="64" Offset="0x5080" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_3Tex_006090" OutName="ice_doukutu_room_3Tex_006090" Format="rgba16" Width="32" Height="64" Offset="0x6080" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_3Tex_007090" OutName="ice_doukutu_room_3Tex_007090" Format="i8" Width="32" Height="128" Offset="0x7080" AddedByScript="true"/>
         <Room Name="ice_doukutu_room_3" Offset="0x0"/>
     </File>
     <File Name="ice_doukutu_room_4" Segment="3">
+        <Texture Name="ice_doukutu_room_4Tex_0028E0" OutName="ice_doukutu_room_4Tex_0028E0" Format="rgba16" Width="32" Height="32" Offset="0x2900" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_4Tex_0030E0" OutName="ice_doukutu_room_4Tex_0030E0" Format="rgba16" Width="32" Height="32" Offset="0x3100" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_4Tex_0038E0" OutName="ice_doukutu_room_4Tex_0038E0" Format="ci4" Width="64" Height="64" Offset="0x3900" ExternalTlut="ice_doukutu_scene" ExternalTlutOffset="0xF7D0" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_4Tex_004650" OutName="ice_doukutu_room_4Tex_004650" Format="i8" Width="64" Height="64" Offset="0x4670" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_4Tex_005650" OutName="ice_doukutu_room_4Tex_005650" Format="rgba16" Width="32" Height="64" Offset="0x5670" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_4Tex_006650" OutName="ice_doukutu_room_4Tex_006650" Format="i8" Width="32" Height="128" Offset="0x6670" AddedByScript="true"/>
         <Room Name="ice_doukutu_room_4" Offset="0x0"/>
     </File>
     <File Name="ice_doukutu_room_5" Segment="3">
+        <Texture Name="ice_doukutu_room_5Tex_004648" OutName="ice_doukutu_room_5Tex_004648" Format="rgba16" Width="16" Height="128" Offset="0x4658" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_5Tex_005648" OutName="ice_doukutu_room_5Tex_005648" Format="rgba16" Width="32" Height="32" Offset="0x5658" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_5Tex_005E48" OutName="ice_doukutu_room_5Tex_005E48" Format="rgba16" Width="32" Height="32" Offset="0x5E58" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_5Tex_006648" OutName="ice_doukutu_room_5Tex_006648" Format="rgba16" Width="32" Height="32" Offset="0x6658" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_5Tex_007478" OutName="ice_doukutu_room_5Tex_007478" Format="i8" Width="32" Height="32" Offset="0x7488" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_5Tex_007878" OutName="ice_doukutu_room_5Tex_007878" Format="i8" Width="64" Height="64" Offset="0x7888" AddedByScript="true"/>
         <Room Name="ice_doukutu_room_5" Offset="0x0"/>
     </File>
     <File Name="ice_doukutu_room_6" Segment="3">
+        <Texture Name="ice_doukutu_room_6Tex_0029B0" OutName="ice_doukutu_room_6Tex_0029B0" Format="i8" Width="64" Height="64" Offset="0x2A60" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_6Tex_0039B0" OutName="ice_doukutu_room_6Tex_0039B0" Format="rgba16" Width="32" Height="32" Offset="0x3A60" AddedByScript="true"/>
         <Room Name="ice_doukutu_room_6" Offset="0x0"/>
     </File>
     <File Name="ice_doukutu_room_7" Segment="3">
+        <Texture Name="ice_doukutu_room_7Tex_001758" OutName="ice_doukutu_room_7Tex_001758" Format="ci4" Width="64" Height="64" Offset="0x1758" ExternalTlut="ice_doukutu_scene" ExternalTlutOffset="0xF7D0" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_7Tex_0040E8" OutName="ice_doukutu_room_7Tex_0040E8" Format="i8" Width="64" Height="64" Offset="0x40E8" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_7Tex_0050E8" OutName="ice_doukutu_room_7Tex_0050E8" Format="rgba16" Width="32" Height="32" Offset="0x50E8" AddedByScript="true"/>
         <Room Name="ice_doukutu_room_7" Offset="0x0"/>
     </File>
     <File Name="ice_doukutu_room_8" Segment="3">
         <Room Name="ice_doukutu_room_8" Offset="0x0"/>
     </File>
     <File Name="ice_doukutu_room_9" Segment="3">
+        <Texture Name="ice_doukutu_room_9Tex_0044A0" OutName="ice_doukutu_room_9Tex_0044A0" Format="rgba16" Width="32" Height="64" Offset="0x4460" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_9Tex_0054A0" OutName="ice_doukutu_room_9Tex_0054A0" Format="rgba16" Width="32" Height="32" Offset="0x5460" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_9Tex_005CA0" OutName="ice_doukutu_room_9Tex_005CA0" Format="rgba16" Width="32" Height="32" Offset="0x5C60" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_9Tex_0064A0" OutName="ice_doukutu_room_9Tex_0064A0" Format="rgba16" Width="32" Height="32" Offset="0x6460" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_9Tex_006CA0" OutName="ice_doukutu_room_9Tex_006CA0" Format="rgba16" Width="32" Height="32" Offset="0x6C60" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_9Tex_007690" OutName="ice_doukutu_room_9Tex_007690" Format="rgba16" Width="32" Height="64" Offset="0x7650" AddedByScript="true"/>
         <Room Name="ice_doukutu_room_9" Offset="0x0"/>
     </File>
     <File Name="ice_doukutu_room_10" Segment="3">
+        <Texture Name="ice_doukutu_room_10Tex_001A28" OutName="ice_doukutu_room_10Tex_001A28" Format="rgba16" Width="32" Height="64" Offset="0x1A28" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_10Tex_002A28" OutName="ice_doukutu_room_10Tex_002A28" Format="i8" Width="64" Height="64" Offset="0x2A28" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_10Tex_003BD8" OutName="ice_doukutu_room_10Tex_003BD8" Format="rgba16" Width="32" Height="32" Offset="0x3BD8" AddedByScript="true"/>
         <Room Name="ice_doukutu_room_10" Offset="0x0"/>
     </File>
     <File Name="ice_doukutu_room_11" Segment="3">
+        <Texture Name="ice_doukutu_room_11Tex_002928" OutName="ice_doukutu_room_11Tex_002928" Format="rgba16" Width="32" Height="32" Offset="0x29D8" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_11Tex_003128" OutName="ice_doukutu_room_11Tex_003128" Format="rgba16" Width="32" Height="32" Offset="0x31D8" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_11Tex_003928" OutName="ice_doukutu_room_11Tex_003928" Format="rgba16" Width="32" Height="32" Offset="0x39D8" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_11Tex_004848" OutName="ice_doukutu_room_11Tex_004848" Format="i8" Width="64" Height="64" Offset="0x48F8" AddedByScript="true"/>
         <Room Name="ice_doukutu_room_11" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/jyasinboss.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/jyasinboss.xml
@@ -1,19 +1,49 @@
 <Root>
     <File Name="jyasinboss_scene" Segment="2">
+        <Texture Name="jyasinboss_sceneTex_006CF0" OutName="jyasinboss_sceneTex_006CF0" Format="rgba16" Width="64" Height="32" Offset="0x6CF0" AddedByScript="true"/>
+        <Texture Name="jyasinboss_sceneTex_007CF0" OutName="jyasinboss_sceneTex_007CF0" Format="rgba16" Width="64" Height="32" Offset="0x7CF0" AddedByScript="true"/>
         <Cutscene Name="gSpiritBossNabooruKnuckleIntroCs" Offset="0x2BB0"/>
         <Cutscene Name="gSpiritBossNabooruKnuckleDefeatCs" Offset="0x3F80"/>
         <Scene Name="jyasinboss_scene" Offset="0x0"/>
     </File>
     <File Name="jyasinboss_room_0" Segment="3">
+        <Texture Name="jyasinboss_room_0Tex_0007C8" OutName="jyasinboss_room_0Tex_0007C8" Format="rgba16" Width="32" Height="32" Offset="0x7C8" AddedByScript="true"/>
         <Room Name="jyasinboss_room_0" Offset="0x0"/>
     </File>
     <File Name="jyasinboss_room_1" Segment="3">
+        <Texture Name="jyasinboss_room_1Tex_002E38" OutName="jyasinboss_room_1Tex_002E38" Format="rgba16" Width="64" Height="32" Offset="0x2E38" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_1Tex_003E38" OutName="jyasinboss_room_1Tex_003E38" Format="rgba16" Width="64" Height="32" Offset="0x3E38" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_1Tex_004E38" OutName="jyasinboss_room_1Tex_004E38" Format="rgba16" Width="32" Height="32" Offset="0x4E38" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_1Tex_005638" OutName="jyasinboss_room_1Tex_005638" Format="rgba16" Width="64" Height="32" Offset="0x5638" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_1Tex_006638" OutName="jyasinboss_room_1Tex_006638" Format="rgba16" Width="64" Height="16" Offset="0x6638" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_1Tex_006E38" OutName="jyasinboss_room_1Tex_006E38" Format="ci4" Width="64" Height="64" Offset="0x6E38" TlutOffset="0x2E18" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_1Tex_007638" OutName="jyasinboss_room_1Tex_007638" Format="rgba16" Width="32" Height="32" Offset="0x7638" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_1TLUT_002E18" OutName="jyasinboss_room_1TLUT_002E18" Format="rgba16" Width="4" Height="4" Offset="0x2E18" AddedByScript="true"/>
         <Room Name="jyasinboss_room_1" Offset="0x0"/>
     </File>
     <File Name="jyasinboss_room_2" Segment="3">
+        <Texture Name="jyasinboss_room_2Tex_0021C0" OutName="jyasinboss_room_2Tex_0021C0" Format="rgba16" Width="64" Height="16" Offset="0x21C0" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_2Tex_0029C0" OutName="jyasinboss_room_2Tex_0029C0" Format="rgba16" Width="32" Height="64" Offset="0x29C0" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_2Tex_0039C0" OutName="jyasinboss_room_2Tex_0039C0" Format="rgba16" Width="16" Height="32" Offset="0x39C0" AddedByScript="true"/>
         <Room Name="jyasinboss_room_2" Offset="0x0"/>
     </File>
     <File Name="jyasinboss_room_3" Segment="3">
+        <Texture Name="jyasinboss_room_3Tex_003F00" OutName="jyasinboss_room_3Tex_003F00" Format="ci8" Width="32" Height="32" Offset="0x3F00" TlutOffset="0x3CE0" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3Tex_004300" OutName="jyasinboss_room_3Tex_004300" Format="ci8" Width="32" Height="32" Offset="0x4300" TlutOffset="0x3CE0" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3Tex_004700" OutName="jyasinboss_room_3Tex_004700" Format="ci8" Width="64" Height="32" Offset="0x4700" TlutOffset="0x3CE0" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3Tex_004F00" OutName="jyasinboss_room_3Tex_004F00" Format="ci8" Width="32" Height="32" Offset="0x4F00" TlutOffset="0x3CE0" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3Tex_005300" OutName="jyasinboss_room_3Tex_005300" Format="ci8" Width="32" Height="32" Offset="0x5300" TlutOffset="0x3CE0" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3Tex_005700" OutName="jyasinboss_room_3Tex_005700" Format="ci8" Width="32" Height="64" Offset="0x5700" TlutOffset="0x3CE0" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3Tex_005F00" OutName="jyasinboss_room_3Tex_005F00" Format="rgba16" Width="32" Height="32" Offset="0x5F00" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3Tex_006700" OutName="jyasinboss_room_3Tex_006700" Format="rgba16" Width="64" Height="32" Offset="0x6700" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3Tex_007700" OutName="jyasinboss_room_3Tex_007700" Format="rgba16" Width="32" Height="32" Offset="0x7700" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3Tex_007F00" OutName="jyasinboss_room_3Tex_007F00" Format="rgba16" Width="16" Height="128" Offset="0x7F00" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3Tex_008F00" OutName="jyasinboss_room_3Tex_008F00" Format="rgba16" Width="64" Height="32" Offset="0x8F00" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3Tex_009F00" OutName="jyasinboss_room_3Tex_009F00" Format="ci4" Width="64" Height="64" Offset="0x9F00" TlutOffset="0x3EE0" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3Tex_00A700" OutName="jyasinboss_room_3Tex_00A700" Format="rgba16" Width="32" Height="32" Offset="0xA700" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3Tex_00AF00" OutName="jyasinboss_room_3Tex_00AF00" Format="rgba16" Width="32" Height="32" Offset="0xAF00" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3TLUT_003CE0" OutName="jyasinboss_room_3TLUT_003CE0" Format="rgba16" Width="16" Height="16" Offset="0x3CE0" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3TLUT_003EE0" OutName="jyasinboss_room_3TLUT_003EE0" Format="rgba16" Width="4" Height="4" Offset="0x3EE0" AddedByScript="true"/>
         <Room Name="jyasinboss_room_3" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/jyasinzou.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/jyasinzou.xml
@@ -1,95 +1,358 @@
 <Root>
     <File Name="jyasinzou_scene" Segment="2">
+        <Texture Name="jyasinzou_sceneTex_018820" OutName="jyasinzou_sceneTex_018820" Format="ci8" Width="16" Height="16" Offset="0x18840" TlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_sceneTex_019120" OutName="jyasinzou_sceneTex_019120" Format="rgba16" Width="16" Height="16" Offset="0x19140" AddedByScript="true"/>
+        <Texture Name="jyasinzou_sceneTex_019320" OutName="jyasinzou_sceneTex_019320" Format="ci4" Width="64" Height="64" Offset="0x19340" TlutOffset="0x18020" AddedByScript="true"/>
+        <Texture Name="jyasinzou_sceneTLUT_017BE0" OutName="jyasinzou_sceneTLUT_017BE0" Format="rgba16" Width="16" Height="16" Offset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_sceneTLUT_017DE0" OutName="jyasinzou_sceneTLUT_017DE0" Format="rgba16" Width="16" Height="16" Offset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_sceneTLUT_017FE0" OutName="jyasinzou_sceneTLUT_017FE0" Format="rgba16" Width="4" Height="4" Offset="0x18000" AddedByScript="true"/>
+        <Texture Name="jyasinzou_sceneTLUT_018000" OutName="jyasinzou_sceneTLUT_018000" Format="rgba16" Width="4" Height="4" Offset="0x18020" AddedByScript="true"/>
         <Path Name="gSpiritTemplePath_004C0" Offset="0x4C0" NumPaths="6"/>
         <Texture Name="gSpiritTempleDayEntranceTex" OutName="day_entrance" Format="ia16" Width="8" Height="128" Offset="0x18940"/>
         <Texture Name="gSpiritTempleNightEntranceTex" OutName="night_entrance" Format="ia16" Width="8" Height="128" Offset="0x18040"/>
         <Scene Name="jyasinzou_scene" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_0" Segment="3">
+        <Texture Name="jyasinzou_room_0Tex_00A9D8" OutName="jyasinzou_room_0Tex_00A9D8" Format="ci8" Width="64" Height="32" Offset="0xA928" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_0Tex_00B1D8" OutName="jyasinzou_room_0Tex_00B1D8" Format="ci8" Width="64" Height="32" Offset="0xB128" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_0Tex_00B9D8" OutName="jyasinzou_room_0Tex_00B9D8" Format="ci8" Width="32" Height="64" Offset="0xB928" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_0Tex_00C1D8" OutName="jyasinzou_room_0Tex_00C1D8" Format="ci8" Width="32" Height="64" Offset="0xC128" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_0Tex_00C9D8" OutName="jyasinzou_room_0Tex_00C9D8" Format="ci8" Width="32" Height="64" Offset="0xC928" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_0Tex_00D1D8" OutName="jyasinzou_room_0Tex_00D1D8" Format="ci8" Width="32" Height="32" Offset="0xD128" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_0Tex_00D5D8" OutName="jyasinzou_room_0Tex_00D5D8" Format="ci8" Width="16" Height="128" Offset="0xD528" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_0Tex_00DDD8" OutName="jyasinzou_room_0Tex_00DDD8" Format="ci8" Width="32" Height="32" Offset="0xDD28" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_0Tex_00E1D8" OutName="jyasinzou_room_0Tex_00E1D8" Format="ci8" Width="64" Height="32" Offset="0xE128" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_0Tex_00E9D8" OutName="jyasinzou_room_0Tex_00E9D8" Format="ci8" Width="64" Height="32" Offset="0xE928" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_0Tex_00F1D8" OutName="jyasinzou_room_0Tex_00F1D8" Format="ci4" Width="64" Height="64" Offset="0xF128" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18000" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_0Tex_00F9D8" OutName="jyasinzou_room_0Tex_00F9D8" Format="ci4" Width="64" Height="64" Offset="0xF928" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_0Tex_0107E8" OutName="jyasinzou_room_0Tex_0107E8" Format="ia8" Width="64" Height="32" Offset="0x10738" AddedByScript="true"/>
         <Room Name="jyasinzou_room_0" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_1" Segment="3">
+        <Texture Name="jyasinzou_room_1Tex_004F48" OutName="jyasinzou_room_1Tex_004F48" Format="ci8" Width="64" Height="32" Offset="0x4EF8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_1Tex_005748" OutName="jyasinzou_room_1Tex_005748" Format="ci8" Width="32" Height="64" Offset="0x56F8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_1Tex_005F48" OutName="jyasinzou_room_1Tex_005F48" Format="ci8" Width="32" Height="64" Offset="0x5EF8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_1Tex_006748" OutName="jyasinzou_room_1Tex_006748" Format="ci8" Width="32" Height="32" Offset="0x66F8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_1Tex_006B48" OutName="jyasinzou_room_1Tex_006B48" Format="ci8" Width="32" Height="64" Offset="0x6AF8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_1Tex_007348" OutName="jyasinzou_room_1Tex_007348" Format="ci8" Width="64" Height="32" Offset="0x72F8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_1Tex_007B48" OutName="jyasinzou_room_1Tex_007B48" Format="ci8" Width="64" Height="32" Offset="0x7AF8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_1Tex_008348" OutName="jyasinzou_room_1Tex_008348" Format="ci4" Width="64" Height="64" Offset="0x82F8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18000" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_1Tex_008B48" OutName="jyasinzou_room_1Tex_008B48" Format="ci4" Width="64" Height="64" Offset="0x8AF8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
         <Room Name="jyasinzou_room_1" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_2" Segment="3">
+        <Texture Name="jyasinzou_room_2Tex_0023B0" OutName="jyasinzou_room_2Tex_0023B0" Format="rgba16" Width="32" Height="64" Offset="0x2410" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_2Tex_0033B0" OutName="jyasinzou_room_2Tex_0033B0" Format="ci8" Width="64" Height="32" Offset="0x3410" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_2Tex_003BB0" OutName="jyasinzou_room_2Tex_003BB0" Format="rgba16" Width="16" Height="32" Offset="0x3C10" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_2Tex_003FB0" OutName="jyasinzou_room_2Tex_003FB0" Format="rgba16" Width="32" Height="32" Offset="0x4010" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_2Tex_0047B0" OutName="jyasinzou_room_2Tex_0047B0" Format="ci8" Width="32" Height="32" Offset="0x4810" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_2Tex_004BB0" OutName="jyasinzou_room_2Tex_004BB0" Format="ci8" Width="64" Height="32" Offset="0x4C10" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_2Tex_0053B0" OutName="jyasinzou_room_2Tex_0053B0" Format="ci4" Width="64" Height="64" Offset="0x5410" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
         <Room Name="jyasinzou_room_2" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_3" Segment="3">
+        <Texture Name="jyasinzou_room_3Tex_001FC8" OutName="jyasinzou_room_3Tex_001FC8" Format="ci8" Width="32" Height="32" Offset="0x1F48" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_3Tex_0023C8" OutName="jyasinzou_room_3Tex_0023C8" Format="ci8" Width="64" Height="32" Offset="0x2348" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_3Tex_002BC8" OutName="jyasinzou_room_3Tex_002BC8" Format="ci4" Width="64" Height="64" Offset="0x2B48" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18000" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_3Tex_0033C8" OutName="jyasinzou_room_3Tex_0033C8" Format="ci4" Width="64" Height="64" Offset="0x3348" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
         <Room Name="jyasinzou_room_3" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_4" Segment="3">
+        <Texture Name="jyasinzou_room_4Tex_003698" OutName="jyasinzou_room_4Tex_003698" Format="ci8" Width="32" Height="64" Offset="0x3688" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_4Tex_003E98" OutName="jyasinzou_room_4Tex_003E98" Format="ci8" Width="32" Height="64" Offset="0x3E88" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_4Tex_004698" OutName="jyasinzou_room_4Tex_004698" Format="ci8" Width="32" Height="64" Offset="0x4688" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_4Tex_004E98" OutName="jyasinzou_room_4Tex_004E98" Format="ci8" Width="64" Height="32" Offset="0x4E88" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_4Tex_005698" OutName="jyasinzou_room_4Tex_005698" Format="ci8" Width="16" Height="16" Offset="0x5688" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_4Tex_005798" OutName="jyasinzou_room_4Tex_005798" Format="ci8" Width="32" Height="32" Offset="0x5788" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_4Tex_005B98" OutName="jyasinzou_room_4Tex_005B98" Format="ci8" Width="64" Height="32" Offset="0x5B88" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_4Tex_006398" OutName="jyasinzou_room_4Tex_006398" Format="ci8" Width="32" Height="32" Offset="0x6388" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_4Tex_006798" OutName="jyasinzou_room_4Tex_006798" Format="ci4" Width="64" Height="64" Offset="0x6788" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
         <Room Name="jyasinzou_room_4" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_5" Segment="3">
+        <Texture Name="jyasinzou_room_5Tex_00CBC8" OutName="jyasinzou_room_5Tex_00CBC8" Format="ci8" Width="32" Height="32" Offset="0xCAF8" TlutOffset="0xC8E0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_00CFC8" OutName="jyasinzou_room_5Tex_00CFC8" Format="ci8" Width="64" Height="32" Offset="0xCEF8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_00D7C8" OutName="jyasinzou_room_5Tex_00D7C8" Format="ci8" Width="16" Height="64" Offset="0xD6F8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_00DBC8" OutName="jyasinzou_room_5Tex_00DBC8" Format="ci8" Width="32" Height="32" Offset="0xDAF8" TlutOffset="0xC8E0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_00DFC8" OutName="jyasinzou_room_5Tex_00DFC8" Format="ci8" Width="64" Height="32" Offset="0xDEF8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_00E7C8" OutName="jyasinzou_room_5Tex_00E7C8" Format="rgba16" Width="32" Height="32" Offset="0xE6F8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_00EFC8" OutName="jyasinzou_room_5Tex_00EFC8" Format="rgba16" Width="32" Height="16" Offset="0xEEF8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_00F3C8" OutName="jyasinzou_room_5Tex_00F3C8" Format="ci8" Width="32" Height="32" Offset="0xF2F8" TlutOffset="0xC8E0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_00F7C8" OutName="jyasinzou_room_5Tex_00F7C8" Format="ci8" Width="32" Height="64" Offset="0xF6F8" TlutOffset="0xC8E0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_00FFC8" OutName="jyasinzou_room_5Tex_00FFC8" Format="ci8" Width="16" Height="16" Offset="0xFEF8" TlutOffset="0xC8E0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_0100C8" OutName="jyasinzou_room_5Tex_0100C8" Format="ci8" Width="64" Height="32" Offset="0xFFF8" TlutOffset="0xC8E0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_0108C8" OutName="jyasinzou_room_5Tex_0108C8" Format="ci8" Width="32" Height="32" Offset="0x107F8" TlutOffset="0xC8E0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_010CC8" OutName="jyasinzou_room_5Tex_010CC8" Format="ci8" Width="32" Height="32" Offset="0x10BF8" TlutOffset="0xC8E0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_0110C8" OutName="jyasinzou_room_5Tex_0110C8" Format="ci8" Width="32" Height="32" Offset="0x10FF8" TlutOffset="0xC8E0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_0114C8" OutName="jyasinzou_room_5Tex_0114C8" Format="ci8" Width="32" Height="32" Offset="0x113F8" TlutOffset="0xC8E0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_0118C8" OutName="jyasinzou_room_5Tex_0118C8" Format="ci8" Width="32" Height="32" Offset="0x117F8" TlutOffset="0xC8E0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_011CC8" OutName="jyasinzou_room_5Tex_011CC8" Format="ci4" Width="32" Height="128" Offset="0x11BF8" TlutOffset="0xCAD8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_0124C8" OutName="jyasinzou_room_5Tex_0124C8" Format="ci8" Width="32" Height="64" Offset="0x123F8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_012CC8" OutName="jyasinzou_room_5Tex_012CC8" Format="ci8" Width="64" Height="32" Offset="0x12BF8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_0134C8" OutName="jyasinzou_room_5Tex_0134C8" Format="ci8" Width="32" Height="32" Offset="0x133F8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_0138C8" OutName="jyasinzou_room_5Tex_0138C8" Format="ci8" Width="32" Height="64" Offset="0x137F8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_0140C8" OutName="jyasinzou_room_5Tex_0140C8" Format="ci8" Width="64" Height="32" Offset="0x13FF8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_0148C8" OutName="jyasinzou_room_5Tex_0148C8" Format="ci8" Width="64" Height="32" Offset="0x147F8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_0150C8" OutName="jyasinzou_room_5Tex_0150C8" Format="ci4" Width="64" Height="64" Offset="0x14FF8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18000" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_0158C8" OutName="jyasinzou_room_5Tex_0158C8" Format="ci8" Width="32" Height="32" Offset="0x157F8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_015CC8" OutName="jyasinzou_room_5Tex_015CC8" Format="ci4" Width="64" Height="64" Offset="0x15BF8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_016808" OutName="jyasinzou_room_5Tex_016808" Format="ia8" Width="64" Height="32" Offset="0x16738" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_017008" OutName="jyasinzou_room_5Tex_017008" Format="rgba16" Width="32" Height="64" Offset="0x16F38" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5TLUT_00C9B0" OutName="jyasinzou_room_5TLUT_00C9B0" Format="rgba16" Width="16" Height="16" Offset="0xC8E0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5TLUT_00CBA8" OutName="jyasinzou_room_5TLUT_00CBA8" Format="rgba16" Width="4" Height="4" Offset="0xCAD8" AddedByScript="true"/>
         <Room Name="jyasinzou_room_5" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_6" Segment="3">
+        <Texture Name="jyasinzou_room_6Tex_002BE8" OutName="jyasinzou_room_6Tex_002BE8" Format="ci8" Width="64" Height="32" Offset="0x2BF8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_6Tex_0033E8" OutName="jyasinzou_room_6Tex_0033E8" Format="ci8" Width="32" Height="32" Offset="0x33F8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_6Tex_0037E8" OutName="jyasinzou_room_6Tex_0037E8" Format="ci8" Width="64" Height="32" Offset="0x37F8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_6Tex_003FE8" OutName="jyasinzou_room_6Tex_003FE8" Format="ci8" Width="64" Height="32" Offset="0x3FF8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
         <Room Name="jyasinzou_room_6" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_7" Segment="3">
+        <Texture Name="jyasinzou_room_7Tex_002908" OutName="jyasinzou_room_7Tex_002908" Format="rgba16" Width="32" Height="64" Offset="0x2908" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_7Tex_003908" OutName="jyasinzou_room_7Tex_003908" Format="ci8" Width="64" Height="32" Offset="0x3908" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_7Tex_004108" OutName="jyasinzou_room_7Tex_004108" Format="ci8" Width="64" Height="32" Offset="0x4108" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_7Tex_004908" OutName="jyasinzou_room_7Tex_004908" Format="rgba16" Width="16" Height="32" Offset="0x4908" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_7Tex_004D08" OutName="jyasinzou_room_7Tex_004D08" Format="ci4" Width="64" Height="64" Offset="0x4D08" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
         <Room Name="jyasinzou_room_7" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_8" Segment="3">
+        <Texture Name="jyasinzou_room_8Tex_003A50" OutName="jyasinzou_room_8Tex_003A50" Format="ci8" Width="64" Height="32" Offset="0x3A10" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_8Tex_004250" OutName="jyasinzou_room_8Tex_004250" Format="ci8" Width="64" Height="32" Offset="0x4210" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_8Tex_004A50" OutName="jyasinzou_room_8Tex_004A50" Format="ci8" Width="32" Height="32" Offset="0x4A10" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_8Tex_004E50" OutName="jyasinzou_room_8Tex_004E50" Format="rgba16" Width="32" Height="32" Offset="0x4E10" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_8Tex_005650" OutName="jyasinzou_room_8Tex_005650" Format="ci8" Width="32" Height="64" Offset="0x5610" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_8Tex_005E50" OutName="jyasinzou_room_8Tex_005E50" Format="ci8" Width="32" Height="32" Offset="0x5E10" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_8Tex_006250" OutName="jyasinzou_room_8Tex_006250" Format="ci8" Width="32" Height="64" Offset="0x6210" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_8Tex_006A50" OutName="jyasinzou_room_8Tex_006A50" Format="ci8" Width="64" Height="32" Offset="0x6A10" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_8Tex_007250" OutName="jyasinzou_room_8Tex_007250" Format="ci4" Width="64" Height="64" Offset="0x7210" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
         <Room Name="jyasinzou_room_8" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_9" Segment="3">
+        <Texture Name="jyasinzou_room_9Tex_002DC8" OutName="jyasinzou_room_9Tex_002DC8" Format="rgba16" Width="32" Height="64" Offset="0x2DE8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_9Tex_003DC8" OutName="jyasinzou_room_9Tex_003DC8" Format="ci8" Width="64" Height="32" Offset="0x3DE8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_9Tex_0045C8" OutName="jyasinzou_room_9Tex_0045C8" Format="ci8" Width="64" Height="32" Offset="0x45E8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_9Tex_004DC8" OutName="jyasinzou_room_9Tex_004DC8" Format="rgba16" Width="16" Height="32" Offset="0x4DE8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_9Tex_0051C8" OutName="jyasinzou_room_9Tex_0051C8" Format="ci8" Width="64" Height="16" Offset="0x51E8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_9Tex_0055C8" OutName="jyasinzou_room_9Tex_0055C8" Format="ci8" Width="64" Height="32" Offset="0x55E8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
         <Room Name="jyasinzou_room_9" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_10" Segment="3">
+        <Texture Name="jyasinzou_room_10Tex_0031A0" OutName="jyasinzou_room_10Tex_0031A0" Format="rgba16" Width="32" Height="64" Offset="0x31A0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_10Tex_0041A0" OutName="jyasinzou_room_10Tex_0041A0" Format="ci8" Width="64" Height="32" Offset="0x41A0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_10Tex_0049A0" OutName="jyasinzou_room_10Tex_0049A0" Format="ci8" Width="64" Height="32" Offset="0x49A0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_10Tex_0051A0" OutName="jyasinzou_room_10Tex_0051A0" Format="ci8" Width="64" Height="32" Offset="0x51A0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_10Tex_0059A0" OutName="jyasinzou_room_10Tex_0059A0" Format="rgba16" Width="16" Height="32" Offset="0x59A0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_10Tex_005DA0" OutName="jyasinzou_room_10Tex_005DA0" Format="ci8" Width="64" Height="32" Offset="0x5DA0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_10Tex_0065A0" OutName="jyasinzou_room_10Tex_0065A0" Format="ci8" Width="32" Height="32" Offset="0x65A0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_10Tex_0069A0" OutName="jyasinzou_room_10Tex_0069A0" Format="rgba16" Width="64" Height="32" Offset="0x69A0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_10Tex_0079A0" OutName="jyasinzou_room_10Tex_0079A0" Format="ci8" Width="64" Height="16" Offset="0x79A0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_10Tex_007DA0" OutName="jyasinzou_room_10Tex_007DA0" Format="ci8" Width="32" Height="32" Offset="0x7DA0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
         <Room Name="jyasinzou_room_10" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_11" Segment="3">
+        <Texture Name="jyasinzou_room_11Tex_000780" OutName="jyasinzou_room_11Tex_000780" Format="ci8" Width="32" Height="32" Offset="0x780" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
         <Room Name="jyasinzou_room_11" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_12" Segment="3">
+        <Texture Name="jyasinzou_room_12Tex_0010D8" OutName="jyasinzou_room_12Tex_0010D8" Format="ci8" Width="64" Height="32" Offset="0x1058" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_12Tex_0018D8" OutName="jyasinzou_room_12Tex_0018D8" Format="ci8" Width="32" Height="64" Offset="0x1858" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
         <Room Name="jyasinzou_room_12" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_13" Segment="3">
+        <Texture Name="jyasinzou_room_13Tex_0028A8" OutName="jyasinzou_room_13Tex_0028A8" Format="ci8" Width="32" Height="64" Offset="0x2848" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_13Tex_0030A8" OutName="jyasinzou_room_13Tex_0030A8" Format="ci8" Width="64" Height="32" Offset="0x3048" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_13Tex_0038A8" OutName="jyasinzou_room_13Tex_0038A8" Format="ci8" Width="32" Height="32" Offset="0x3848" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_13Tex_003CA8" OutName="jyasinzou_room_13Tex_003CA8" Format="ci8" Width="64" Height="32" Offset="0x3C48" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_13Tex_0044A8" OutName="jyasinzou_room_13Tex_0044A8" Format="ci8" Width="64" Height="32" Offset="0x4448" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_13Tex_004CA8" OutName="jyasinzou_room_13Tex_004CA8" Format="ci8" Width="32" Height="32" Offset="0x4C48" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_13Tex_0050A8" OutName="jyasinzou_room_13Tex_0050A8" Format="ci4" Width="64" Height="64" Offset="0x5048" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
         <Room Name="jyasinzou_room_13" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_14" Segment="3">
+        <Texture Name="jyasinzou_room_14Tex_001CA0" OutName="jyasinzou_room_14Tex_001CA0" Format="ci8" Width="64" Height="32" Offset="0x1C90" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_14Tex_0024A0" OutName="jyasinzou_room_14Tex_0024A0" Format="ci8" Width="32" Height="32" Offset="0x2490" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_14Tex_0028A0" OutName="jyasinzou_room_14Tex_0028A0" Format="ci8" Width="64" Height="32" Offset="0x2890" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_14Tex_0030A0" OutName="jyasinzou_room_14Tex_0030A0" Format="ci8" Width="32" Height="32" Offset="0x3090" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_14Tex_0034A0" OutName="jyasinzou_room_14Tex_0034A0" Format="rgba16" Width="32" Height="64" Offset="0x3490" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_14Tex_0044A0" OutName="jyasinzou_room_14Tex_0044A0" Format="ci4" Width="64" Height="64" Offset="0x4490" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
         <Room Name="jyasinzou_room_14" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_15" Segment="3">
+        <Texture Name="jyasinzou_room_15Tex_002FE8" OutName="jyasinzou_room_15Tex_002FE8" Format="rgba16" Width="32" Height="64" Offset="0x2FB8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_15Tex_003FE8" OutName="jyasinzou_room_15Tex_003FE8" Format="rgba16" Width="16" Height="32" Offset="0x3FB8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_15Tex_0043E8" OutName="jyasinzou_room_15Tex_0043E8" Format="ci8" Width="32" Height="64" Offset="0x43B8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_15Tex_004BE8" OutName="jyasinzou_room_15Tex_004BE8" Format="ci8" Width="32" Height="64" Offset="0x4BB8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_15Tex_0053E8" OutName="jyasinzou_room_15Tex_0053E8" Format="ci8" Width="64" Height="32" Offset="0x53B8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_15Tex_005BE8" OutName="jyasinzou_room_15Tex_005BE8" Format="ci8" Width="16" Height="16" Offset="0x5BB8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_15Tex_005CE8" OutName="jyasinzou_room_15Tex_005CE8" Format="ci8" Width="32" Height="32" Offset="0x5CB8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_15Tex_0060E8" OutName="jyasinzou_room_15Tex_0060E8" Format="ci8" Width="64" Height="32" Offset="0x60B8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_15Tex_0068E8" OutName="jyasinzou_room_15Tex_0068E8" Format="ci8" Width="32" Height="32" Offset="0x68B8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_15Tex_006CE8" OutName="jyasinzou_room_15Tex_006CE8" Format="ci4" Width="64" Height="64" Offset="0x6CB8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_15Tex_007C98" OutName="jyasinzou_room_15Tex_007C98" Format="rgba16" Width="32" Height="32" Offset="0x7C68" AddedByScript="true"/>
         <Room Name="jyasinzou_room_15" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_16" Segment="3">
+        <Texture Name="jyasinzou_room_16Tex_0029B8" OutName="jyasinzou_room_16Tex_0029B8" Format="rgba16" Width="32" Height="64" Offset="0x2988" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_16Tex_0039B8" OutName="jyasinzou_room_16Tex_0039B8" Format="ci8" Width="64" Height="32" Offset="0x3988" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_16Tex_0041B8" OutName="jyasinzou_room_16Tex_0041B8" Format="ci8" Width="16" Height="64" Offset="0x4188" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_16Tex_0045B8" OutName="jyasinzou_room_16Tex_0045B8" Format="ci8" Width="64" Height="32" Offset="0x4588" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_16Tex_004DB8" OutName="jyasinzou_room_16Tex_004DB8" Format="rgba16" Width="16" Height="32" Offset="0x4D88" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_16Tex_0051B8" OutName="jyasinzou_room_16Tex_0051B8" Format="ci8" Width="32" Height="64" Offset="0x5188" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_16Tex_0059B8" OutName="jyasinzou_room_16Tex_0059B8" Format="ci4" Width="64" Height="64" Offset="0x5988" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
         <Room Name="jyasinzou_room_16" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_17" Segment="3">
+        <Texture Name="jyasinzou_room_17Tex_005E50" OutName="jyasinzou_room_17Tex_005E50" Format="ci8" Width="64" Height="32" Offset="0x5E10" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_17Tex_006650" OutName="jyasinzou_room_17Tex_006650" Format="ci8" Width="64" Height="32" Offset="0x6610" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_17Tex_006E50" OutName="jyasinzou_room_17Tex_006E50" Format="ci8" Width="32" Height="32" Offset="0x6E10" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_17Tex_007250" OutName="jyasinzou_room_17Tex_007250" Format="ci8" Width="64" Height="32" Offset="0x7210" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_17Tex_007A50" OutName="jyasinzou_room_17Tex_007A50" Format="ci8" Width="64" Height="32" Offset="0x7A10" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_17Tex_008250" OutName="jyasinzou_room_17Tex_008250" Format="ci4" Width="64" Height="64" Offset="0x8210" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18000" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_17Tex_008A50" OutName="jyasinzou_room_17Tex_008A50" Format="ci8" Width="32" Height="32" Offset="0x8A10" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_17Tex_008E50" OutName="jyasinzou_room_17Tex_008E50" Format="ci4" Width="64" Height="64" Offset="0x8E10" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
         <Room Name="jyasinzou_room_17" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_18" Segment="3">
+        <Texture Name="jyasinzou_room_18Tex_0020F0" OutName="jyasinzou_room_18Tex_0020F0" Format="ci8" Width="64" Height="32" Offset="0x20C0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_18Tex_0028F0" OutName="jyasinzou_room_18Tex_0028F0" Format="ci8" Width="64" Height="32" Offset="0x28C0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_18Tex_0030F0" OutName="jyasinzou_room_18Tex_0030F0" Format="ci8" Width="32" Height="32" Offset="0x30C0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_18Tex_0034F0" OutName="jyasinzou_room_18Tex_0034F0" Format="rgba16" Width="32" Height="32" Offset="0x34C0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_18Tex_003CF0" OutName="jyasinzou_room_18Tex_003CF0" Format="ci8" Width="16" Height="128" Offset="0x3CC0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_18Tex_0044F0" OutName="jyasinzou_room_18Tex_0044F0" Format="ci8" Width="32" Height="32" Offset="0x44C0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_18Tex_0048F0" OutName="jyasinzou_room_18Tex_0048F0" Format="ci8" Width="32" Height="32" Offset="0x48C0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_18Tex_0054E0" OutName="jyasinzou_room_18Tex_0054E0" Format="rgba16" Width="32" Height="32" Offset="0x54B0" AddedByScript="true"/>
         <Room Name="jyasinzou_room_18" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_19" Segment="3">
+        <Texture Name="jyasinzou_room_19Tex_002DC8" OutName="jyasinzou_room_19Tex_002DC8" Format="rgba16" Width="32" Height="64" Offset="0x2DD8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_19Tex_003DC8" OutName="jyasinzou_room_19Tex_003DC8" Format="ci8" Width="64" Height="32" Offset="0x3DD8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_19Tex_0045C8" OutName="jyasinzou_room_19Tex_0045C8" Format="ci8" Width="64" Height="32" Offset="0x45D8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_19Tex_004DC8" OutName="jyasinzou_room_19Tex_004DC8" Format="rgba16" Width="16" Height="32" Offset="0x4DD8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_19Tex_0051C8" OutName="jyasinzou_room_19Tex_0051C8" Format="ci8" Width="64" Height="16" Offset="0x51D8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_19Tex_0055C8" OutName="jyasinzou_room_19Tex_0055C8" Format="ci8" Width="64" Height="32" Offset="0x55D8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
         <Room Name="jyasinzou_room_19" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_20" Segment="3">
+        <Texture Name="jyasinzou_room_20Tex_0031B8" OutName="jyasinzou_room_20Tex_0031B8" Format="rgba16" Width="32" Height="64" Offset="0x31B8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_20Tex_0041B8" OutName="jyasinzou_room_20Tex_0041B8" Format="ci8" Width="64" Height="32" Offset="0x41B8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_20Tex_0049B8" OutName="jyasinzou_room_20Tex_0049B8" Format="ci8" Width="64" Height="32" Offset="0x49B8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_20Tex_0051B8" OutName="jyasinzou_room_20Tex_0051B8" Format="ci8" Width="64" Height="32" Offset="0x51B8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_20Tex_0059B8" OutName="jyasinzou_room_20Tex_0059B8" Format="rgba16" Width="16" Height="32" Offset="0x59B8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_20Tex_005DB8" OutName="jyasinzou_room_20Tex_005DB8" Format="ci8" Width="64" Height="32" Offset="0x5DB8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_20Tex_0065B8" OutName="jyasinzou_room_20Tex_0065B8" Format="ci8" Width="32" Height="32" Offset="0x65B8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_20Tex_0069B8" OutName="jyasinzou_room_20Tex_0069B8" Format="rgba16" Width="64" Height="32" Offset="0x69B8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_20Tex_0079B8" OutName="jyasinzou_room_20Tex_0079B8" Format="ci8" Width="64" Height="16" Offset="0x79B8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_20Tex_007DB8" OutName="jyasinzou_room_20Tex_007DB8" Format="ci8" Width="32" Height="32" Offset="0x7DB8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
         <Room Name="jyasinzou_room_20" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_21" Segment="3">
+        <Texture Name="jyasinzou_room_21Tex_001660" OutName="jyasinzou_room_21Tex_001660" Format="rgba16" Width="32" Height="64" Offset="0x1650" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_21Tex_002660" OutName="jyasinzou_room_21Tex_002660" Format="ci8" Width="64" Height="32" Offset="0x2650" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_21Tex_002E60" OutName="jyasinzou_room_21Tex_002E60" Format="rgba16" Width="16" Height="32" Offset="0x2E50" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_21Tex_003260" OutName="jyasinzou_room_21Tex_003260" Format="ci8" Width="32" Height="32" Offset="0x3250" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_21Tex_003660" OutName="jyasinzou_room_21Tex_003660" Format="ci8" Width="64" Height="32" Offset="0x3650" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_21Tex_003E60" OutName="jyasinzou_room_21Tex_003E60" Format="ci4" Width="64" Height="64" Offset="0x3E50" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
         <Room Name="jyasinzou_room_21" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_22" Segment="3">
+        <Texture Name="jyasinzou_room_22Tex_001468" OutName="jyasinzou_room_22Tex_001468" Format="ci8" Width="64" Height="32" Offset="0x14C8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_22Tex_001C68" OutName="jyasinzou_room_22Tex_001C68" Format="ci8" Width="32" Height="64" Offset="0x1CC8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_22Tex_002468" OutName="jyasinzou_room_22Tex_002468" Format="ci8" Width="32" Height="32" Offset="0x24C8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_22Tex_002868" OutName="jyasinzou_room_22Tex_002868" Format="ci4" Width="64" Height="64" Offset="0x28C8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
         <Room Name="jyasinzou_room_22" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_23" Segment="3">
+        <Texture Name="jyasinzou_room_23Tex_004438" OutName="jyasinzou_room_23Tex_004438" Format="ci8" Width="32" Height="64" Offset="0x43B8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_23Tex_004C38" OutName="jyasinzou_room_23Tex_004C38" Format="ci8" Width="64" Height="32" Offset="0x4BB8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_23Tex_005438" OutName="jyasinzou_room_23Tex_005438" Format="ci8" Width="16" Height="64" Offset="0x53B8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_23Tex_005838" OutName="jyasinzou_room_23Tex_005838" Format="ci8" Width="64" Height="32" Offset="0x57B8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_23Tex_006038" OutName="jyasinzou_room_23Tex_006038" Format="ci8" Width="32" Height="32" Offset="0x5FB8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_23Tex_006438" OutName="jyasinzou_room_23Tex_006438" Format="ci8" Width="16" Height="128" Offset="0x63B8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_23Tex_006C38" OutName="jyasinzou_room_23Tex_006C38" Format="rgba16" Width="32" Height="32" Offset="0x6BB8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_23Tex_007438" OutName="jyasinzou_room_23Tex_007438" Format="ci8" Width="64" Height="32" Offset="0x73B8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_23Tex_007C38" OutName="jyasinzou_room_23Tex_007C38" Format="ci8" Width="32" Height="32" Offset="0x7BB8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_23Tex_008038" OutName="jyasinzou_room_23Tex_008038" Format="ci8" Width="64" Height="32" Offset="0x7FB8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_23Tex_008838" OutName="jyasinzou_room_23Tex_008838" Format="ci4" Width="64" Height="64" Offset="0x87B8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
         <Room Name="jyasinzou_room_23" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_24" Segment="3">
+        <Texture Name="jyasinzou_room_24Tex_001B38" OutName="jyasinzou_room_24Tex_001B38" Format="rgba16" Width="32" Height="64" Offset="0x1B18" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_24Tex_002B38" OutName="jyasinzou_room_24Tex_002B38" Format="ci8" Width="64" Height="32" Offset="0x2B18" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_24Tex_003338" OutName="jyasinzou_room_24Tex_003338" Format="ci8" Width="64" Height="32" Offset="0x3318" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_24Tex_003B38" OutName="jyasinzou_room_24Tex_003B38" Format="rgba16" Width="16" Height="32" Offset="0x3B18" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_24Tex_003F38" OutName="jyasinzou_room_24Tex_003F38" Format="ci8" Width="32" Height="32" Offset="0x3F18" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_24Tex_004338" OutName="jyasinzou_room_24Tex_004338" Format="ci8" Width="64" Height="32" Offset="0x4318" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_24Tex_004B38" OutName="jyasinzou_room_24Tex_004B38" Format="ci4" Width="64" Height="64" Offset="0x4B18" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_24Tex_0054D0" OutName="jyasinzou_room_24Tex_0054D0" Format="rgba16" Width="32" Height="64" Offset="0x54B0" AddedByScript="true"/>
         <Room Name="jyasinzou_room_24" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_25" Segment="3">
+        <Texture Name="jyasinzou_room_25Tex_00BA98" OutName="jyasinzou_room_25Tex_00BA98" Format="rgba16" Width="16" Height="32" Offset="0xBA68" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_00BE98" OutName="jyasinzou_room_25Tex_00BE98" Format="rgba16" Width="32" Height="64" Offset="0xBE68" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_00CE98" OutName="jyasinzou_room_25Tex_00CE98" Format="ci8" Width="32" Height="64" Offset="0xCE68" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_00D698" OutName="jyasinzou_room_25Tex_00D698" Format="ci8" Width="16" Height="64" Offset="0xD668" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_00DA98" OutName="jyasinzou_room_25Tex_00DA98" Format="ci8" Width="32" Height="32" Offset="0xDA68" TlutOffset="0xB870" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_00DE98" OutName="jyasinzou_room_25Tex_00DE98" Format="ci8" Width="32" Height="64" Offset="0xDE68" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_00E698" OutName="jyasinzou_room_25Tex_00E698" Format="ci8" Width="64" Height="32" Offset="0xE668" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_00EE98" OutName="jyasinzou_room_25Tex_00EE98" Format="rgba16" Width="32" Height="16" Offset="0xEE68" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_00F298" OutName="jyasinzou_room_25Tex_00F298" Format="ci8" Width="32" Height="32" Offset="0xF268" TlutOffset="0xB870" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_00F698" OutName="jyasinzou_room_25Tex_00F698" Format="ci8" Width="32" Height="64" Offset="0xF668" TlutOffset="0xB870" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_00FE98" OutName="jyasinzou_room_25Tex_00FE98" Format="ci8" Width="16" Height="16" Offset="0xFE68" TlutOffset="0xB870" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_00FF98" OutName="jyasinzou_room_25Tex_00FF98" Format="ci8" Width="32" Height="32" Offset="0xFF68" TlutOffset="0xB870" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_010398" OutName="jyasinzou_room_25Tex_010398" Format="ci8" Width="32" Height="32" Offset="0x10368" TlutOffset="0xB870" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_010798" OutName="jyasinzou_room_25Tex_010798" Format="ci8" Width="32" Height="32" Offset="0x10768" TlutOffset="0xB870" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_010B98" OutName="jyasinzou_room_25Tex_010B98" Format="ci8" Width="32" Height="32" Offset="0x10B68" TlutOffset="0xB870" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_010F98" OutName="jyasinzou_room_25Tex_010F98" Format="ci8" Width="32" Height="32" Offset="0x10F68" TlutOffset="0xB870" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_011398" OutName="jyasinzou_room_25Tex_011398" Format="ci8" Width="32" Height="32" Offset="0x11368" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_011798" OutName="jyasinzou_room_25Tex_011798" Format="ci8" Width="16" Height="128" Offset="0x11768" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_011F98" OutName="jyasinzou_room_25Tex_011F98" Format="ci8" Width="64" Height="32" Offset="0x11F68" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_012798" OutName="jyasinzou_room_25Tex_012798" Format="ci8" Width="32" Height="32" Offset="0x12768" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_012B98" OutName="jyasinzou_room_25Tex_012B98" Format="ci8" Width="32" Height="64" Offset="0x12B68" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_013398" OutName="jyasinzou_room_25Tex_013398" Format="ci8" Width="64" Height="32" Offset="0x13368" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_013B98" OutName="jyasinzou_room_25Tex_013B98" Format="ci8" Width="64" Height="32" Offset="0x13B68" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_014398" OutName="jyasinzou_room_25Tex_014398" Format="ci8" Width="32" Height="32" Offset="0x14368" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_014798" OutName="jyasinzou_room_25Tex_014798" Format="ci4" Width="64" Height="64" Offset="0x14768" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18000" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_014F98" OutName="jyasinzou_room_25Tex_014F98" Format="ci8" Width="32" Height="32" Offset="0x14F68" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_015398" OutName="jyasinzou_room_25Tex_015398" Format="ci4" Width="64" Height="64" Offset="0x15368" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25TLUT_00B8A0" OutName="jyasinzou_room_25TLUT_00B8A0" Format="rgba16" Width="16" Height="16" Offset="0xB870" AddedByScript="true"/>
         <Room Name="jyasinzou_room_25" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_26" Segment="3">
+        <Texture Name="jyasinzou_room_26Tex_006CC8" OutName="jyasinzou_room_26Tex_006CC8" Format="rgba16" Width="16" Height="32" Offset="0x6CE8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_26Tex_0070C8" OutName="jyasinzou_room_26Tex_0070C8" Format="rgba16" Width="32" Height="64" Offset="0x70E8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_26Tex_0080C8" OutName="jyasinzou_room_26Tex_0080C8" Format="rgba16" Width="16" Height="16" Offset="0x80E8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_26Tex_0082C8" OutName="jyasinzou_room_26Tex_0082C8" Format="ci8" Width="32" Height="64" Offset="0x82E8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_26Tex_008AC8" OutName="jyasinzou_room_26Tex_008AC8" Format="ci8" Width="16" Height="32" Offset="0x8AE8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_26Tex_008CC8" OutName="jyasinzou_room_26Tex_008CC8" Format="ci8" Width="32" Height="64" Offset="0x8CE8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_26Tex_0094C8" OutName="jyasinzou_room_26Tex_0094C8" Format="ci8" Width="64" Height="32" Offset="0x94E8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_26Tex_009CC8" OutName="jyasinzou_room_26Tex_009CC8" Format="rgba16" Width="16" Height="32" Offset="0x9CE8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_26Tex_00A0C8" OutName="jyasinzou_room_26Tex_00A0C8" Format="ci8" Width="16" Height="128" Offset="0xA0E8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_26Tex_00A8C8" OutName="jyasinzou_room_26Tex_00A8C8" Format="ci8" Width="32" Height="32" Offset="0xA8E8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_26Tex_00ACC8" OutName="jyasinzou_room_26Tex_00ACC8" Format="ci4" Width="64" Height="64" Offset="0xACE8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18000" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_26Tex_00B4C8" OutName="jyasinzou_room_26Tex_00B4C8" Format="ci4" Width="64" Height="64" Offset="0xB4E8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_26Tex_00C2F8" OutName="jyasinzou_room_26Tex_00C2F8" Format="ia16" Width="32" Height="32" Offset="0xC318" AddedByScript="true"/>
         <Room Name="jyasinzou_room_26" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_27" Segment="3">
+        <Texture Name="jyasinzou_room_27Tex_004310" OutName="jyasinzou_room_27Tex_004310" Format="ci8" Width="32" Height="64" Offset="0x42C0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_27Tex_004B10" OutName="jyasinzou_room_27Tex_004B10" Format="ci8" Width="32" Height="32" Offset="0x4AC0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_27Tex_004F10" OutName="jyasinzou_room_27Tex_004F10" Format="ci8" Width="64" Height="32" Offset="0x4EC0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
         <Room Name="jyasinzou_room_27" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_28" Segment="3">
+        <Texture Name="jyasinzou_room_28Tex_004130" OutName="jyasinzou_room_28Tex_004130" Format="ci8" Width="64" Height="32" Offset="0x4120" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_28Tex_004930" OutName="jyasinzou_room_28Tex_004930" Format="ci8" Width="64" Height="32" Offset="0x4920" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_28Tex_005130" OutName="jyasinzou_room_28Tex_005130" Format="ci8" Width="64" Height="32" Offset="0x5120" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_28Tex_005930" OutName="jyasinzou_room_28Tex_005930" Format="ci8" Width="64" Height="32" Offset="0x5920" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_28Tex_006130" OutName="jyasinzou_room_28Tex_006130" Format="ci8" Width="32" Height="32" Offset="0x6120" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_28Tex_006530" OutName="jyasinzou_room_28Tex_006530" Format="rgba16" Width="64" Height="32" Offset="0x6520" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_28Tex_007530" OutName="jyasinzou_room_28Tex_007530" Format="ci8" Width="64" Height="16" Offset="0x7520" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_28Tex_007930" OutName="jyasinzou_room_28Tex_007930" Format="ci8" Width="16" Height="16" Offset="0x7920" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_28Tex_007A30" OutName="jyasinzou_room_28Tex_007A30" Format="ci8" Width="16" Height="64" Offset="0x7A20" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_28Tex_007E30" OutName="jyasinzou_room_28Tex_007E30" Format="ci4" Width="64" Height="64" Offset="0x7E20" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18000" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_28Tex_008630" OutName="jyasinzou_room_28Tex_008630" Format="ci8" Width="32" Height="32" Offset="0x8620" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
         <Room Name="jyasinzou_room_28" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/men.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/men.xml
@@ -1,43 +1,127 @@
 <Root>
     <File Name="men_scene" Segment="2">
+        <Texture Name="men_sceneTex_0108C0" OutName="men_sceneTex_0108C0" Format="ci8" Width="32" Height="32" Offset="0x10930" TlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_sceneTex_010CC0" OutName="men_sceneTex_010CC0" Format="ci8" Width="64" Height="32" Offset="0x10D30" TlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_sceneTLUT_00F6C0" OutName="men_sceneTLUT_00F6C0" Format="rgba16" Width="16" Height="16" Offset="0xF730" AddedByScript="true"/>
         <Path Name="gGTGPath_002F0" Offset="0x2F0" NumPaths="2"/>
         <Texture Name="gGTGDayEntranceTex" OutName="day_entrance" Format="ia16" Width="8" Height="128" Offset="0xF930"/>
         <Texture Name="gGTGNightEntranceTex" OutName="night_entrance" Format="ia16" Width="8" Height="128" Offset="0x10130"/>
         <Scene Name="men_scene" Offset="0x0"/>
     </File>
     <File Name="men_room_0" Segment="3">
+        <Texture Name="men_room_0Tex_008138" OutName="men_room_0Tex_008138" Format="ci8" Width="64" Height="32" Offset="0x8138" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_0Tex_008938" OutName="men_room_0Tex_008938" Format="ci8" Width="32" Height="64" Offset="0x8938" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_0Tex_009138" OutName="men_room_0Tex_009138" Format="ci8" Width="32" Height="32" Offset="0x9138" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_0Tex_009538" OutName="men_room_0Tex_009538" Format="rgba16" Width="32" Height="32" Offset="0x9538" AddedByScript="true"/>
+        <Texture Name="men_room_0Tex_009D38" OutName="men_room_0Tex_009D38" Format="ci8" Width="32" Height="64" Offset="0x9D38" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_0Tex_00A538" OutName="men_room_0Tex_00A538" Format="ia8" Width="64" Height="64" Offset="0xA538" AddedByScript="true"/>
+        <Texture Name="men_room_0Tex_00B538" OutName="men_room_0Tex_00B538" Format="ci8" Width="32" Height="64" Offset="0xB538" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_0Tex_00BD38" OutName="men_room_0Tex_00BD38" Format="ci8" Width="64" Height="32" Offset="0xBD38" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_0Tex_00C538" OutName="men_room_0Tex_00C538" Format="i4" Width="64" Height="128" Offset="0xC538" AddedByScript="true"/>
+        <Texture Name="men_room_0Tex_00D538" OutName="men_room_0Tex_00D538" Format="ci8" Width="64" Height="32" Offset="0xD538" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_0Tex_00DD38" OutName="men_room_0Tex_00DD38" Format="rgba16" Width="16" Height="128" Offset="0xDD38" AddedByScript="true"/>
+        <Texture Name="men_room_0Tex_00ED38" OutName="men_room_0Tex_00ED38" Format="ci8" Width="64" Height="32" Offset="0xED38" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_0Tex_00F538" OutName="men_room_0Tex_00F538" Format="ci8" Width="64" Height="32" Offset="0xF538" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
         <DList Name="gMenDL_008118" Offset="0x8118"/>
         <DList Name="gMenDL_00FF78" Offset="0xFF78"/>
         <Room Name="men_room_0" Offset="0x0"/>
     </File>
     <File Name="men_room_1" Segment="3">
+        <Texture Name="men_room_1Tex_004270" OutName="men_room_1Tex_004270" Format="rgba16" Width="32" Height="32" Offset="0x4290" AddedByScript="true"/>
+        <Texture Name="men_room_1Tex_004A70" OutName="men_room_1Tex_004A70" Format="ci8" Width="64" Height="32" Offset="0x4A90" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_1Tex_005270" OutName="men_room_1Tex_005270" Format="ci8" Width="32" Height="64" Offset="0x5290" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_1Tex_005A70" OutName="men_room_1Tex_005A70" Format="ci8" Width="64" Height="32" Offset="0x5A90" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_1Tex_006270" OutName="men_room_1Tex_006270" Format="rgba16" Width="32" Height="32" Offset="0x6290" AddedByScript="true"/>
+        <Texture Name="men_room_1Tex_006A70" OutName="men_room_1Tex_006A70" Format="rgba16" Width="32" Height="32" Offset="0x6A90" AddedByScript="true"/>
+        <Texture Name="men_room_1Tex_007270" OutName="men_room_1Tex_007270" Format="ci8" Width="64" Height="32" Offset="0x7290" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_1Tex_007A70" OutName="men_room_1Tex_007A70" Format="rgba16" Width="16" Height="128" Offset="0x7A90" AddedByScript="true"/>
+        <Texture Name="men_room_1Tex_008A70" OutName="men_room_1Tex_008A70" Format="ci8" Width="64" Height="32" Offset="0x8A90" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
         <Room Name="men_room_1" Offset="0x0"/>
     </File>
     <File Name="men_room_2" Segment="3">
+        <Texture Name="men_room_2Tex_003C48" OutName="men_room_2Tex_003C48" Format="ci8" Width="64" Height="32" Offset="0x3B78" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_2Tex_004448" OutName="men_room_2Tex_004448" Format="ci8" Width="64" Height="32" Offset="0x4378" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_2Tex_004C48" OutName="men_room_2Tex_004C48" Format="ci8" Width="32" Height="32" Offset="0x4B78" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
         <Room Name="men_room_2" Offset="0x0"/>
     </File>
     <File Name="men_room_3" Segment="3">
+        <Texture Name="men_room_3Tex_003850" OutName="men_room_3Tex_003850" Format="ci8" Width="64" Height="32" Offset="0x3820" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_3Tex_004050" OutName="men_room_3Tex_004050" Format="ci8" Width="64" Height="32" Offset="0x4020" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_3Tex_004850" OutName="men_room_3Tex_004850" Format="ci8" Width="32" Height="64" Offset="0x4820" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_3Tex_005050" OutName="men_room_3Tex_005050" Format="ci8" Width="64" Height="32" Offset="0x5020" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_3Tex_005850" OutName="men_room_3Tex_005850" Format="ci8" Width="32" Height="32" Offset="0x5820" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_3Tex_005C50" OutName="men_room_3Tex_005C50" Format="ci8" Width="64" Height="32" Offset="0x5C20" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_3Tex_006450" OutName="men_room_3Tex_006450" Format="rgba16" Width="16" Height="128" Offset="0x6420" AddedByScript="true"/>
+        <Texture Name="men_room_3Tex_007450" OutName="men_room_3Tex_007450" Format="ci8" Width="64" Height="32" Offset="0x7420" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
         <Room Name="men_room_3" Offset="0x0"/>
     </File>
     <File Name="men_room_4" Segment="3">
+        <Texture Name="men_room_4Tex_0051E0" OutName="men_room_4Tex_0051E0" Format="rgba16" Width="32" Height="32" Offset="0x5150" AddedByScript="true"/>
+        <Texture Name="men_room_4Tex_0059E0" OutName="men_room_4Tex_0059E0" Format="rgba16" Width="32" Height="32" Offset="0x5950" AddedByScript="true"/>
+        <Texture Name="men_room_4Tex_0061E0" OutName="men_room_4Tex_0061E0" Format="i4" Width="128" Height="64" Offset="0x6150" AddedByScript="true"/>
+        <Texture Name="men_room_4Tex_0071E0" OutName="men_room_4Tex_0071E0" Format="i4" Width="64" Height="128" Offset="0x7150" AddedByScript="true"/>
+        <Texture Name="men_room_4Tex_0081E0" OutName="men_room_4Tex_0081E0" Format="ci8" Width="32" Height="64" Offset="0x8150" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_4Tex_0089E0" OutName="men_room_4Tex_0089E0" Format="i4" Width="64" Height="128" Offset="0x8950" AddedByScript="true"/>
+        <Texture Name="men_room_4Tex_0099E0" OutName="men_room_4Tex_0099E0" Format="ci8" Width="64" Height="32" Offset="0x9950" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
         <Room Name="men_room_4" Offset="0x0"/>
     </File>
     <File Name="men_room_5" Segment="3">
+        <Texture Name="men_room_5Tex_002418" OutName="men_room_5Tex_002418" Format="ci8" Width="64" Height="32" Offset="0x24D8" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_5Tex_002C18" OutName="men_room_5Tex_002C18" Format="ci8" Width="32" Height="32" Offset="0x2CD8" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_5Tex_003018" OutName="men_room_5Tex_003018" Format="ci8" Width="32" Height="64" Offset="0x30D8" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_5Tex_003818" OutName="men_room_5Tex_003818" Format="ci8" Width="64" Height="32" Offset="0x38D8" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_5Tex_004018" OutName="men_room_5Tex_004018" Format="ci8" Width="64" Height="32" Offset="0x40D8" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_5Tex_004818" OutName="men_room_5Tex_004818" Format="ci8" Width="64" Height="32" Offset="0x48D8" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
         <Room Name="men_room_5" Offset="0x0"/>
     </File>
     <File Name="men_room_6" Segment="3">
+        <Texture Name="men_room_6Tex_003F78" OutName="men_room_6Tex_003F78" Format="rgba16" Width="32" Height="32" Offset="0x3F38" AddedByScript="true"/>
+        <Texture Name="men_room_6Tex_004778" OutName="men_room_6Tex_004778" Format="ci8" Width="32" Height="64" Offset="0x4738" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_6Tex_004F78" OutName="men_room_6Tex_004F78" Format="ci8" Width="32" Height="32" Offset="0x4F38" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_6Tex_005378" OutName="men_room_6Tex_005378" Format="rgba16" Width="32" Height="32" Offset="0x5338" AddedByScript="true"/>
+        <Texture Name="men_room_6Tex_005B78" OutName="men_room_6Tex_005B78" Format="ci8" Width="32" Height="64" Offset="0x5B38" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_6Tex_006378" OutName="men_room_6Tex_006378" Format="ci8" Width="32" Height="64" Offset="0x6338" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_6Tex_006B78" OutName="men_room_6Tex_006B78" Format="ci8" Width="64" Height="32" Offset="0x6B38" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_6Tex_007378" OutName="men_room_6Tex_007378" Format="ci8" Width="32" Height="32" Offset="0x7338" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_6Tex_007778" OutName="men_room_6Tex_007778" Format="ci8" Width="64" Height="32" Offset="0x7738" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
         <Room Name="men_room_6" Offset="0x0"/>
     </File>
     <File Name="men_room_7" Segment="3">
+        <Texture Name="men_room_7Tex_0036B8" OutName="men_room_7Tex_0036B8" Format="ci8" Width="32" Height="32" Offset="0x3728" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_7Tex_003AB8" OutName="men_room_7Tex_003AB8" Format="ci8" Width="64" Height="32" Offset="0x3B28" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_7Tex_0042B8" OutName="men_room_7Tex_0042B8" Format="ci8" Width="32" Height="64" Offset="0x4328" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_7Tex_004AB8" OutName="men_room_7Tex_004AB8" Format="rgba16" Width="32" Height="32" Offset="0x4B28" AddedByScript="true"/>
+        <Texture Name="men_room_7Tex_0052B8" OutName="men_room_7Tex_0052B8" Format="ci8" Width="64" Height="32" Offset="0x5328" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_7Tex_005AB8" OutName="men_room_7Tex_005AB8" Format="ci8" Width="64" Height="32" Offset="0x5B28" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_7Tex_0062B8" OutName="men_room_7Tex_0062B8" Format="rgba16" Width="16" Height="128" Offset="0x6328" AddedByScript="true"/>
+        <Texture Name="men_room_7Tex_0072B8" OutName="men_room_7Tex_0072B8" Format="ci8" Width="64" Height="32" Offset="0x7328" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_7Tex_007AB8" OutName="men_room_7Tex_007AB8" Format="ci8" Width="64" Height="32" Offset="0x7B28" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
         <Room Name="men_room_7" Offset="0x0"/>
     </File>
     <File Name="men_room_8" Segment="3">
+        <Texture Name="men_room_8Tex_005D30" OutName="men_room_8Tex_005D30" Format="rgba16" Width="16" Height="64" Offset="0x5D10" AddedByScript="true"/>
+        <Texture Name="men_room_8Tex_006530" OutName="men_room_8Tex_006530" Format="rgba16" Width="32" Height="32" Offset="0x6510" AddedByScript="true"/>
+        <Texture Name="men_room_8Tex_006D30" OutName="men_room_8Tex_006D30" Format="ci8" Width="32" Height="64" Offset="0x6D10" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_8Tex_007530" OutName="men_room_8Tex_007530" Format="rgba16" Width="8" Height="16" Offset="0x7510" AddedByScript="true"/>
+        <Texture Name="men_room_8Tex_007630" OutName="men_room_8Tex_007630" Format="rgba16" Width="32" Height="32" Offset="0x7610" AddedByScript="true"/>
+        <Texture Name="men_room_8Tex_007E30" OutName="men_room_8Tex_007E30" Format="ci8" Width="32" Height="32" Offset="0x7E10" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
         <Room Name="men_room_8" Offset="0x0"/>
     </File>
     <File Name="men_room_9" Segment="3">
+        <Texture Name="men_room_9Tex_001AB0" OutName="men_room_9Tex_001AB0" Format="rgba16" Width="32" Height="32" Offset="0x1B30" AddedByScript="true"/>
+        <Texture Name="men_room_9Tex_0022B0" OutName="men_room_9Tex_0022B0" Format="ci8" Width="32" Height="32" Offset="0x2330" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_9Tex_0026B0" OutName="men_room_9Tex_0026B0" Format="ci8" Width="64" Height="32" Offset="0x2730" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_9Tex_003070" OutName="men_room_9Tex_003070" Format="rgba16" Width="32" Height="32" Offset="0x30F0" AddedByScript="true"/>
         <Room Name="men_room_9" Offset="0x0"/>
     </File>
     <File Name="men_room_10" Segment="3">
+        <Texture Name="men_room_10Tex_002448" OutName="men_room_10Tex_002448" Format="ci8" Width="64" Height="32" Offset="0x2458" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_10Tex_002C48" OutName="men_room_10Tex_002C48" Format="rgba16" Width="32" Height="32" Offset="0x2C58" AddedByScript="true"/>
+        <Texture Name="men_room_10Tex_003448" OutName="men_room_10Tex_003448" Format="ci8" Width="32" Height="64" Offset="0x3458" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_10Tex_003C48" OutName="men_room_10Tex_003C48" Format="ci8" Width="64" Height="32" Offset="0x3C58" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_10Tex_004448" OutName="men_room_10Tex_004448" Format="rgba16" Width="32" Height="32" Offset="0x4458" AddedByScript="true"/>
+        <Texture Name="men_room_10Tex_004C48" OutName="men_room_10Tex_004C48" Format="ci8" Width="32" Height="64" Offset="0x4C58" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_10Tex_005448" OutName="men_room_10Tex_005448" Format="ci8" Width="64" Height="32" Offset="0x5458" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
         <Room Name="men_room_10" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/moribossroom.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/moribossroom.xml
@@ -1,11 +1,33 @@
 <Root>
     <File Name="moribossroom_scene" Segment="2">
+        <Texture Name="moribossroom_sceneTex_000CF8" OutName="moribossroom_sceneTex_000CF8" Format="ci8" Width="32" Height="32" Offset="0xCF8" TlutOffset="0xB50" AddedByScript="true"/>
+        <Texture Name="moribossroom_sceneTex_0010F8" OutName="moribossroom_sceneTex_0010F8" Format="ci8" Width="32" Height="64" Offset="0x10F8" TlutOffset="0xB50" AddedByScript="true"/>
+        <Texture Name="moribossroom_sceneTLUT_000B50" OutName="moribossroom_sceneTLUT_000B50" Format="rgba16" Width="16" Height="16" Offset="0xB50" AddedByScript="true"/>
         <Scene Name="moribossroom_scene" Offset="0x0"/>
     </File>
     <File Name="moribossroom_room_0" Segment="3">
+        <Texture Name="moribossroom_room_0Tex_0038B8" OutName="moribossroom_room_0Tex_0038B8" Format="rgba16" Width="32" Height="32" Offset="0x38B8" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_0Tex_0040B8" OutName="moribossroom_room_0Tex_0040B8" Format="ci8" Width="32" Height="32" Offset="0x40B8" ExternalTlut="moribossroom_scene" ExternalTlutOffset="0xB50" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_0Tex_0044B8" OutName="moribossroom_room_0Tex_0044B8" Format="rgba16" Width="64" Height="32" Offset="0x44B8" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_0Tex_0054B8" OutName="moribossroom_room_0Tex_0054B8" Format="rgba16" Width="16" Height="16" Offset="0x54B8" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_0Tex_0056B8" OutName="moribossroom_room_0Tex_0056B8" Format="ci8" Width="32" Height="64" Offset="0x56B8" ExternalTlut="moribossroom_scene" ExternalTlutOffset="0xB50" AddedByScript="true"/>
         <Room Name="moribossroom_room_0" Offset="0x0"/>
     </File>
     <File Name="moribossroom_room_1" Segment="3">
+        <Texture Name="moribossroom_room_1Tex_006A20" OutName="moribossroom_room_1Tex_006A20" Format="rgba16" Width="32" Height="64" Offset="0x6A20" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_1Tex_007A20" OutName="moribossroom_room_1Tex_007A20" Format="rgba16" Width="64" Height="32" Offset="0x7A20" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_1Tex_008A20" OutName="moribossroom_room_1Tex_008A20" Format="rgba16" Width="64" Height="32" Offset="0x8A20" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_1Tex_009A20" OutName="moribossroom_room_1Tex_009A20" Format="rgba16" Width="8" Height="16" Offset="0x9A20" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_1Tex_009B20" OutName="moribossroom_room_1Tex_009B20" Format="rgba16" Width="16" Height="16" Offset="0x9B20" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_1Tex_009D20" OutName="moribossroom_room_1Tex_009D20" Format="ci8" Width="32" Height="64" Offset="0x9D20" TlutOffset="0x6828" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_1Tex_00A520" OutName="moribossroom_room_1Tex_00A520" Format="ci8" Width="64" Height="32" Offset="0xA520" TlutOffset="0x6828" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_1Tex_00AD20" OutName="moribossroom_room_1Tex_00AD20" Format="ci8" Width="64" Height="32" Offset="0xAD20" TlutOffset="0x6828" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_1Tex_00B520" OutName="moribossroom_room_1Tex_00B520" Format="ci8" Width="64" Height="32" Offset="0xB520" ExternalTlut="moribossroom_scene" ExternalTlutOffset="0xB50" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_1Tex_00BD20" OutName="moribossroom_room_1Tex_00BD20" Format="ci8" Width="32" Height="64" Offset="0xBD20" TlutOffset="0x6828" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_1Tex_00C520" OutName="moribossroom_room_1Tex_00C520" Format="ci8" Width="64" Height="32" Offset="0xC520" TlutOffset="0x6828" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_1Tex_00CD20" OutName="moribossroom_room_1Tex_00CD20" Format="ci8" Width="64" Height="32" Offset="0xCD20" TlutOffset="0x6828" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_1Tex_00D6A8" OutName="moribossroom_room_1Tex_00D6A8" Format="rgba16" Width="16" Height="32" Offset="0xD6A8" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_1TLUT_006828" OutName="moribossroom_room_1TLUT_006828" Format="rgba16" Width="16" Height="16" Offset="0x6828" AddedByScript="true"/>
         <Room Name="moribossroom_room_1" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/ydan.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/ydan.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="ydan_scene" Segment="2">
+        <Texture Name="ydan_sceneTLUT_00B810" OutName="ydan_sceneTLUT_00B810" Format="rgba16" Width="16" Height="16" Offset="0xB800" AddedByScript="true"/>
         <Cutscene Name="gDekuTreeIntroCs" Offset="0xB640"/>
         <Texture Name="gYdanTex_00BA18" Format="rgba16" Width="32" Height="64" Offset="0xBA08"/>
         <Texture Name="gYdanTex_00CA18" Format="rgba16" Width="32" Height="64" Offset="0xCA08"/>
@@ -7,39 +8,150 @@
         <Scene Name="ydan_scene" Offset="0x0"/>
     </File>
     <File Name="ydan_room_0" Segment="3">
+        <Texture Name="ydan_room_0Tex_0071C0" OutName="ydan_room_0Tex_0071C0" Format="rgba16" Width="32" Height="64" Offset="0x7160" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_0081C0" OutName="ydan_room_0Tex_0081C0" Format="rgba16" Width="32" Height="64" Offset="0x8160" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_0091C0" OutName="ydan_room_0Tex_0091C0" Format="ci8" Width="32" Height="64" Offset="0x9160" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_0099C0" OutName="ydan_room_0Tex_0099C0" Format="ci8" Width="32" Height="64" Offset="0x9960" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_00A1C0" OutName="ydan_room_0Tex_00A1C0" Format="ci8" Width="32" Height="32" Offset="0xA160" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_00A5C0" OutName="ydan_room_0Tex_00A5C0" Format="ci8" Width="32" Height="64" Offset="0xA560" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_00ADC0" OutName="ydan_room_0Tex_00ADC0" Format="ci8" Width="32" Height="64" Offset="0xAD60" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_00B5C0" OutName="ydan_room_0Tex_00B5C0" Format="ci8" Width="32" Height="64" Offset="0xB560" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_00BDC0" OutName="ydan_room_0Tex_00BDC0" Format="rgba16" Width="32" Height="32" Offset="0xBD60" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_00C5C0" OutName="ydan_room_0Tex_00C5C0" Format="ci8" Width="32" Height="64" Offset="0xC560" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_00CDC0" OutName="ydan_room_0Tex_00CDC0" Format="ci8" Width="32" Height="64" Offset="0xCD60" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_00D5C0" OutName="ydan_room_0Tex_00D5C0" Format="ci8" Width="32" Height="32" Offset="0xD560" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_00D9C0" OutName="ydan_room_0Tex_00D9C0" Format="ci8" Width="32" Height="64" Offset="0xD960" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_00E1C0" OutName="ydan_room_0Tex_00E1C0" Format="ci8" Width="32" Height="64" Offset="0xE160" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_00E9C0" OutName="ydan_room_0Tex_00E9C0" Format="ci8" Width="32" Height="64" Offset="0xE960" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_00F1C0" OutName="ydan_room_0Tex_00F1C0" Format="ci8" Width="32" Height="64" Offset="0xF160" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_00F9C0" OutName="ydan_room_0Tex_00F9C0" Format="rgba16" Width="64" Height="32" Offset="0xF960" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_0109C0" OutName="ydan_room_0Tex_0109C0" Format="ci8" Width="32" Height="64" Offset="0x10960" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_012F48" OutName="ydan_room_0Tex_012F48" Format="rgba16" Width="32" Height="64" Offset="0x12EE8" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_013F48" OutName="ydan_room_0Tex_013F48" Format="ci8" Width="32" Height="32" Offset="0x13EE8" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_014348" OutName="ydan_room_0Tex_014348" Format="ia16" Width="32" Height="64" Offset="0x142E8" AddedByScript="true"/>
         <Room Name="ydan_room_0" Offset="0x0"/>
     </File>
     <File Name="ydan_room_1" Segment="3">
+        <Texture Name="ydan_room_1Tex_000F98" OutName="ydan_room_1Tex_000F98" Format="ci8" Width="32" Height="64" Offset="0xEE8" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_1Tex_001798" OutName="ydan_room_1Tex_001798" Format="ci8" Width="32" Height="64" Offset="0x16E8" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_1Tex_001F98" OutName="ydan_room_1Tex_001F98" Format="ci8" Width="32" Height="64" Offset="0x1EE8" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_1Tex_002798" OutName="ydan_room_1Tex_002798" Format="ci8" Width="32" Height="64" Offset="0x26E8" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_1Tex_003200" OutName="ydan_room_1Tex_003200" Format="ia16" Width="32" Height="64" Offset="0x3150" AddedByScript="true"/>
         <Room Name="ydan_room_1" Offset="0x0"/>
     </File>
     <File Name="ydan_room_2" Segment="3">
+        <Texture Name="ydan_room_2Tex_001D08" OutName="ydan_room_2Tex_001D08" Format="ci8" Width="32" Height="64" Offset="0x1C08" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_2Tex_002508" OutName="ydan_room_2Tex_002508" Format="ci8" Width="32" Height="64" Offset="0x2408" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_2Tex_002D08" OutName="ydan_room_2Tex_002D08" Format="ci8" Width="32" Height="64" Offset="0x2C08" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_2Tex_003508" OutName="ydan_room_2Tex_003508" Format="ci8" Width="32" Height="64" Offset="0x3408" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_2Tex_003D08" OutName="ydan_room_2Tex_003D08" Format="ci8" Width="32" Height="64" Offset="0x3C08" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_2Tex_004508" OutName="ydan_room_2Tex_004508" Format="ci8" Width="32" Height="64" Offset="0x4408" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_2Tex_004F28" OutName="ydan_room_2Tex_004F28" Format="rgba16" Width="32" Height="64" Offset="0x4E28" AddedByScript="true"/>
         <Room Name="ydan_room_2" Offset="0x0"/>
     </File>
     <File Name="ydan_room_3" Segment="3">
+        <Texture Name="ydan_room_3Tex_0074C0" OutName="ydan_room_3Tex_0074C0" Format="rgba16" Width="32" Height="64" Offset="0x74B0" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_0084C0" OutName="ydan_room_3Tex_0084C0" Format="ci8" Width="32" Height="64" Offset="0x84B0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_008CC0" OutName="ydan_room_3Tex_008CC0" Format="ci8" Width="32" Height="64" Offset="0x8CB0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_0094C0" OutName="ydan_room_3Tex_0094C0" Format="ci8" Width="32" Height="64" Offset="0x94B0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_009CC0" OutName="ydan_room_3Tex_009CC0" Format="ci8" Width="32" Height="32" Offset="0x9CB0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_00A0C0" OutName="ydan_room_3Tex_00A0C0" Format="ci8" Width="32" Height="64" Offset="0xA0B0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_00A8C0" OutName="ydan_room_3Tex_00A8C0" Format="ci8" Width="64" Height="32" Offset="0xA8B0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_00B0C0" OutName="ydan_room_3Tex_00B0C0" Format="ci8" Width="32" Height="32" Offset="0xB0B0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_00B4C0" OutName="ydan_room_3Tex_00B4C0" Format="ci8" Width="32" Height="32" Offset="0xB4B0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_00B8C0" OutName="ydan_room_3Tex_00B8C0" Format="ci8" Width="32" Height="64" Offset="0xB8B0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_00C0C0" OutName="ydan_room_3Tex_00C0C0" Format="ci8" Width="32" Height="64" Offset="0xC0B0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_00C8C0" OutName="ydan_room_3Tex_00C8C0" Format="ci8" Width="32" Height="64" Offset="0xC8B0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_00D0C0" OutName="ydan_room_3Tex_00D0C0" Format="ci8" Width="32" Height="32" Offset="0xD0B0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_00D4C0" OutName="ydan_room_3Tex_00D4C0" Format="ci8" Width="32" Height="32" Offset="0xD4B0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_00D8C0" OutName="ydan_room_3Tex_00D8C0" Format="ci8" Width="32" Height="64" Offset="0xD8B0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_00E0C0" OutName="ydan_room_3Tex_00E0C0" Format="ci8" Width="32" Height="64" Offset="0xE0B0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_00E8C0" OutName="ydan_room_3Tex_00E8C0" Format="rgba16" Width="64" Height="32" Offset="0xE8B0" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_00F8C0" OutName="ydan_room_3Tex_00F8C0" Format="ci8" Width="32" Height="64" Offset="0xF8B0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_011DB0" OutName="ydan_room_3Tex_011DB0" Format="rgba16" Width="32" Height="64" Offset="0x11DA0" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_012DB0" OutName="ydan_room_3Tex_012DB0" Format="ci8" Width="32" Height="32" Offset="0x12DA0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_0131B0" OutName="ydan_room_3Tex_0131B0" Format="ia16" Width="32" Height="64" Offset="0x131A0" AddedByScript="true"/>
         <Room Name="ydan_room_3" Offset="0x0"/>
     </File>
     <File Name="ydan_room_4" Segment="3">
+        <Texture Name="ydan_room_4Tex_001920" OutName="ydan_room_4Tex_001920" Format="ci8" Width="32" Height="64" Offset="0x18C0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_4Tex_002120" OutName="ydan_room_4Tex_002120" Format="ci8" Width="32" Height="64" Offset="0x20C0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_4Tex_002920" OutName="ydan_room_4Tex_002920" Format="ci8" Width="32" Height="64" Offset="0x28C0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_4Tex_003120" OutName="ydan_room_4Tex_003120" Format="ci8" Width="64" Height="32" Offset="0x30C0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_4Tex_003C28" OutName="ydan_room_4Tex_003C28" Format="ia16" Width="32" Height="64" Offset="0x3BC8" AddedByScript="true"/>
         <Room Name="ydan_room_4" Offset="0x0"/>
     </File>
     <File Name="ydan_room_5" Segment="3">
+        <Texture Name="ydan_room_5Tex_003F88" OutName="ydan_room_5Tex_003F88" Format="ci8" Width="32" Height="64" Offset="0x3F18" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_5Tex_004788" OutName="ydan_room_5Tex_004788" Format="ci8" Width="32" Height="64" Offset="0x4718" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_5Tex_004F88" OutName="ydan_room_5Tex_004F88" Format="ci8" Width="32" Height="64" Offset="0x4F18" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_5Tex_005788" OutName="ydan_room_5Tex_005788" Format="ci8" Width="32" Height="32" Offset="0x5718" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_5Tex_005B88" OutName="ydan_room_5Tex_005B88" Format="ci8" Width="32" Height="64" Offset="0x5B18" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_5Tex_006388" OutName="ydan_room_5Tex_006388" Format="ci8" Width="64" Height="32" Offset="0x6318" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_5Tex_006B88" OutName="ydan_room_5Tex_006B88" Format="ci8" Width="32" Height="32" Offset="0x6B18" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_5Tex_006F88" OutName="ydan_room_5Tex_006F88" Format="ci8" Width="32" Height="32" Offset="0x6F18" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_5Tex_007388" OutName="ydan_room_5Tex_007388" Format="ci8" Width="32" Height="32" Offset="0x7318" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_5Tex_007788" OutName="ydan_room_5Tex_007788" Format="ci8" Width="32" Height="32" Offset="0x7718" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_5Tex_007B88" OutName="ydan_room_5Tex_007B88" Format="ci8" Width="32" Height="64" Offset="0x7B18" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
         <Room Name="ydan_room_5" Offset="0x0"/>
     </File>
     <File Name="ydan_room_6" Segment="3">
+        <Texture Name="ydan_room_6Tex_001F00" OutName="ydan_room_6Tex_001F00" Format="ci8" Width="32" Height="64" Offset="0x1EC0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_6Tex_002700" OutName="ydan_room_6Tex_002700" Format="ci8" Width="32" Height="64" Offset="0x26C0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_6Tex_002F00" OutName="ydan_room_6Tex_002F00" Format="ci8" Width="32" Height="64" Offset="0x2EC0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_6Tex_003700" OutName="ydan_room_6Tex_003700" Format="ci8" Width="32" Height="64" Offset="0x36C0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_6Tex_003F00" OutName="ydan_room_6Tex_003F00" Format="ci8" Width="32" Height="64" Offset="0x3EC0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_6Tex_004700" OutName="ydan_room_6Tex_004700" Format="ci8" Width="32" Height="64" Offset="0x46C0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
         <Room Name="ydan_room_6" Offset="0x0"/>
     </File>
     <File Name="ydan_room_7" Segment="3">
+        <Texture Name="ydan_room_7Tex_002C98" OutName="ydan_room_7Tex_002C98" Format="ci8" Width="32" Height="64" Offset="0x2B08" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_7Tex_003498" OutName="ydan_room_7Tex_003498" Format="ci8" Width="32" Height="64" Offset="0x3308" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_7Tex_003C98" OutName="ydan_room_7Tex_003C98" Format="ci8" Width="32" Height="64" Offset="0x3B08" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_7Tex_004498" OutName="ydan_room_7Tex_004498" Format="ci8" Width="32" Height="64" Offset="0x4308" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_7Tex_004C98" OutName="ydan_room_7Tex_004C98" Format="ci8" Width="64" Height="32" Offset="0x4B08" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_7Tex_005498" OutName="ydan_room_7Tex_005498" Format="ci8" Width="32" Height="32" Offset="0x5308" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_7Tex_005898" OutName="ydan_room_7Tex_005898" Format="ci8" Width="32" Height="64" Offset="0x5708" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_7Tex_006098" OutName="ydan_room_7Tex_006098" Format="ci8" Width="32" Height="64" Offset="0x5F08" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_7Tex_006898" OutName="ydan_room_7Tex_006898" Format="ci8" Width="32" Height="32" Offset="0x6708" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_7Tex_006C98" OutName="ydan_room_7Tex_006C98" Format="ci8" Width="32" Height="32" Offset="0x6B08" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_7Tex_007098" OutName="ydan_room_7Tex_007098" Format="ci8" Width="32" Height="64" Offset="0x6F08" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_7Tex_007A98" OutName="ydan_room_7Tex_007A98" Format="rgba16" Width="32" Height="64" Offset="0x7908" AddedByScript="true"/>
         <Room Name="ydan_room_7" Offset="0x0"/>
     </File>
     <File Name="ydan_room_8" Segment="3">
+        <Texture Name="ydan_room_8Tex_000988" OutName="ydan_room_8Tex_000988" Format="ci8" Width="32" Height="32" Offset="0x8F8" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
         <Room Name="ydan_room_8" Offset="0x0"/>
     </File>
     <File Name="ydan_room_9" Segment="3">
+        <Texture Name="ydan_room_9Tex_002480" OutName="ydan_room_9Tex_002480" Format="ci8" Width="32" Height="64" Offset="0x2480" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_9Tex_002C80" OutName="ydan_room_9Tex_002C80" Format="ci8" Width="32" Height="64" Offset="0x2C80" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_9Tex_003480" OutName="ydan_room_9Tex_003480" Format="ci8" Width="32" Height="64" Offset="0x3480" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_9Tex_003C80" OutName="ydan_room_9Tex_003C80" Format="ci8" Width="32" Height="64" Offset="0x3C80" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_9Tex_004480" OutName="ydan_room_9Tex_004480" Format="ci8" Width="32" Height="64" Offset="0x4480" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_9Tex_004C80" OutName="ydan_room_9Tex_004C80" Format="ci8" Width="32" Height="64" Offset="0x4C80" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_9Tex_005480" OutName="ydan_room_9Tex_005480" Format="ci8" Width="32" Height="64" Offset="0x5480" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_9Tex_005C80" OutName="ydan_room_9Tex_005C80" Format="ci8" Width="32" Height="64" Offset="0x5C80" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_9Tex_006480" OutName="ydan_room_9Tex_006480" Format="ci8" Width="32" Height="64" Offset="0x6480" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_9Tex_007498" OutName="ydan_room_9Tex_007498" Format="rgba16" Width="32" Height="64" Offset="0x7498" AddedByScript="true"/>
+        <Texture Name="ydan_room_9Tex_008498" OutName="ydan_room_9Tex_008498" Format="ci8" Width="32" Height="32" Offset="0x8498" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_9Tex_008898" OutName="ydan_room_9Tex_008898" Format="ia16" Width="32" Height="64" Offset="0x8898" AddedByScript="true"/>
         <Room Name="ydan_room_9" Offset="0x0"/>
     </File>
     <File Name="ydan_room_10" Segment="3">
+        <Texture Name="ydan_room_10Tex_001BE0" OutName="ydan_room_10Tex_001BE0" Format="ci8" Width="32" Height="64" Offset="0x1B60" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_10Tex_0023E0" OutName="ydan_room_10Tex_0023E0" Format="ci8" Width="32" Height="64" Offset="0x2360" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_10Tex_002BE0" OutName="ydan_room_10Tex_002BE0" Format="ci8" Width="32" Height="64" Offset="0x2B60" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_10Tex_0033E0" OutName="ydan_room_10Tex_0033E0" Format="ci8" Width="32" Height="64" Offset="0x3360" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_10Tex_003DF8" OutName="ydan_room_10Tex_003DF8" Format="rgba16" Width="32" Height="64" Offset="0x3D78" AddedByScript="true"/>
         <Room Name="ydan_room_10" Offset="0x0"/>
     </File>
     <File Name="ydan_room_11" Segment="3">
+        <Texture Name="ydan_room_11Tex_003CD8" OutName="ydan_room_11Tex_003CD8" Format="ci8" Width="32" Height="64" Offset="0x3CD8" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_11Tex_0044D8" OutName="ydan_room_11Tex_0044D8" Format="rgba16" Width="32" Height="64" Offset="0x44D8" AddedByScript="true"/>
+        <Texture Name="ydan_room_11Tex_0054D8" OutName="ydan_room_11Tex_0054D8" Format="ci8" Width="32" Height="64" Offset="0x54D8" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_11Tex_005CD8" OutName="ydan_room_11Tex_005CD8" Format="ci8" Width="32" Height="32" Offset="0x5CD8" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_11Tex_006968" OutName="ydan_room_11Tex_006968" Format="ia8" Width="64" Height="32" Offset="0x6968" AddedByScript="true"/>
         <Room Name="ydan_room_11" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/ydan_boss.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/dungeons/ydan_boss.xml
@@ -1,11 +1,26 @@
 <Root>
     <File Name="ydan_boss_scene" Segment="2">
+        <Texture Name="ydan_boss_sceneTex_000F38" OutName="ydan_boss_sceneTex_000F38" Format="ci8" Width="32" Height="64" Offset="0xF38" TlutOffset="0xD30" AddedByScript="true"/>
+        <Texture Name="ydan_boss_sceneTLUT_000D30" OutName="ydan_boss_sceneTLUT_000D30" Format="rgba16" Width="16" Height="16" Offset="0xD30" AddedByScript="true"/>
         <Scene Name="ydan_boss_scene" Offset="0x0"/>
     </File>
     <File Name="ydan_boss_room_0" Segment="3">
+        <Texture Name="ydan_boss_room_0Tex_001790" OutName="ydan_boss_room_0Tex_001790" Format="ci8" Width="32" Height="64" Offset="0x1790" ExternalTlut="ydan_boss_scene" ExternalTlutOffset="0xD30" AddedByScript="true"/>
+        <Texture Name="ydan_boss_room_0Tex_001F90" OutName="ydan_boss_room_0Tex_001F90" Format="ci8" Width="32" Height="64" Offset="0x1F90" ExternalTlut="ydan_boss_scene" ExternalTlutOffset="0xD30" AddedByScript="true"/>
+        <Texture Name="ydan_boss_room_0Tex_002790" OutName="ydan_boss_room_0Tex_002790" Format="ci8" Width="32" Height="64" Offset="0x2790" ExternalTlut="ydan_boss_scene" ExternalTlutOffset="0xD30" AddedByScript="true"/>
+        <Texture Name="ydan_boss_room_0Tex_002F90" OutName="ydan_boss_room_0Tex_002F90" Format="ci8" Width="32" Height="64" Offset="0x2F90" ExternalTlut="ydan_boss_scene" ExternalTlutOffset="0xD30" AddedByScript="true"/>
+        <Texture Name="ydan_boss_room_0Tex_003790" OutName="ydan_boss_room_0Tex_003790" Format="ci8" Width="32" Height="64" Offset="0x3790" ExternalTlut="ydan_boss_scene" ExternalTlutOffset="0xD30" AddedByScript="true"/>
+        <Texture Name="ydan_boss_room_0Tex_003F90" OutName="ydan_boss_room_0Tex_003F90" Format="ci8" Width="32" Height="64" Offset="0x3F90" ExternalTlut="ydan_boss_scene" ExternalTlutOffset="0xD30" AddedByScript="true"/>
+        <Texture Name="ydan_boss_room_0Tex_004BF0" OutName="ydan_boss_room_0Tex_004BF0" Format="rgba16" Width="32" Height="64" Offset="0x4BF0" AddedByScript="true"/>
+        <Texture Name="ydan_boss_room_0Tex_005BF0" OutName="ydan_boss_room_0Tex_005BF0" Format="ci8" Width="32" Height="32" Offset="0x5BF0" ExternalTlut="ydan_boss_scene" ExternalTlutOffset="0xD30" AddedByScript="true"/>
+        <Texture Name="ydan_boss_room_0Tex_005FF0" OutName="ydan_boss_room_0Tex_005FF0" Format="ia16" Width="32" Height="64" Offset="0x5FF0" AddedByScript="true"/>
         <Room Name="ydan_boss_room_0" Offset="0x0"/>
     </File>
     <File Name="ydan_boss_room_1" Segment="3">
+        <Texture Name="ydan_boss_room_1Tex_003B38" OutName="ydan_boss_room_1Tex_003B38" Format="rgba16" Width="32" Height="64" Offset="0x3B38" AddedByScript="true"/>
+        <Texture Name="ydan_boss_room_1Tex_004B38" OutName="ydan_boss_room_1Tex_004B38" Format="ci8" Width="32" Height="64" Offset="0x4B38" ExternalTlut="ydan_boss_scene" ExternalTlutOffset="0xD30" AddedByScript="true"/>
+        <Texture Name="ydan_boss_room_1Tex_005338" OutName="ydan_boss_room_1Tex_005338" Format="ci8" Width="32" Height="32" Offset="0x5338" ExternalTlut="ydan_boss_scene" ExternalTlutOffset="0xD30" AddedByScript="true"/>
+        <Texture Name="ydan_boss_room_1Tex_005FE8" OutName="ydan_boss_room_1Tex_005FE8" Format="ia8" Width="64" Height="32" Offset="0x5FE8" AddedByScript="true"/>
         <Room Name="ydan_boss_room_1" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/indoors/bowling.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/indoors/bowling.xml
@@ -1,5 +1,33 @@
 <Root>
     <File Name="bowling_scene" Segment="2">
+        <Texture Name="bowling_sceneTex_001AA0" OutName="bowling_sceneTex_001AA0" Format="rgba16" Width="32" Height="32" Offset="0x1AA0" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_0022A0" OutName="bowling_sceneTex_0022A0" Format="i4" Width="16" Height="16" Offset="0x22A0" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_002320" OutName="bowling_sceneTex_002320" Format="rgba16" Width="16" Height="32" Offset="0x2320" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_002720" OutName="bowling_sceneTex_002720" Format="rgba16" Width="32" Height="32" Offset="0x2720" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_002F20" OutName="bowling_sceneTex_002F20" Format="rgba16" Width="32" Height="32" Offset="0x2F20" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_003720" OutName="bowling_sceneTex_003720" Format="i4" Width="64" Height="128" Offset="0x3720" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_004720" OutName="bowling_sceneTex_004720" Format="ia4" Width="64" Height="64" Offset="0x4720" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_004F20" OutName="bowling_sceneTex_004F20" Format="rgba16" Width="16" Height="16" Offset="0x4F20" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_005120" OutName="bowling_sceneTex_005120" Format="rgba16" Width="16" Height="16" Offset="0x5120" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_005320" OutName="bowling_sceneTex_005320" Format="rgba16" Width="16" Height="16" Offset="0x5320" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_005520" OutName="bowling_sceneTex_005520" Format="rgba16" Width="16" Height="32" Offset="0x5520" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_005920" OutName="bowling_sceneTex_005920" Format="rgba16" Width="32" Height="32" Offset="0x5920" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_006120" OutName="bowling_sceneTex_006120" Format="rgba16" Width="64" Height="32" Offset="0x6120" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_007120" OutName="bowling_sceneTex_007120" Format="ia8" Width="128" Height="32" Offset="0x7120" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_008120" OutName="bowling_sceneTex_008120" Format="rgba16" Width="32" Height="32" Offset="0x8120" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_008920" OutName="bowling_sceneTex_008920" Format="rgba16" Width="32" Height="32" Offset="0x8920" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_009120" OutName="bowling_sceneTex_009120" Format="rgba16" Width="32" Height="64" Offset="0x9120" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_00A120" OutName="bowling_sceneTex_00A120" Format="rgba16" Width="32" Height="32" Offset="0xA120" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_00A920" OutName="bowling_sceneTex_00A920" Format="i8" Width="32" Height="16" Offset="0xA920" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_00AB20" OutName="bowling_sceneTex_00AB20" Format="ia8" Width="32" Height="16" Offset="0xAB20" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_00AD20" OutName="bowling_sceneTex_00AD20" Format="i4" Width="32" Height="32" Offset="0xAD20" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_00AF20" OutName="bowling_sceneTex_00AF20" Format="ia8" Width="64" Height="32" Offset="0xAF20" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_00B720" OutName="bowling_sceneTex_00B720" Format="ia8" Width="32" Height="32" Offset="0xB720" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_00BB20" OutName="bowling_sceneTex_00BB20" Format="ia8" Width="32" Height="32" Offset="0xBB20" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_00BF20" OutName="bowling_sceneTex_00BF20" Format="rgba16" Width="32" Height="32" Offset="0xBF20" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_00C720" OutName="bowling_sceneTex_00C720" Format="ia8" Width="64" Height="64" Offset="0xC720" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_00D720" OutName="bowling_sceneTex_00D720" Format="i8" Width="32" Height="32" Offset="0xD720" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_00DB20" OutName="bowling_sceneTex_00DB20" Format="rgba16" Width="64" Height="32" Offset="0xDB20" AddedByScript="true"/>
         <Scene Name="bowling_scene" Offset="0x0"/>
     </File>
     <File Name="bowling_room_0" Segment="3">

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/indoors/daiyousei_izumi.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/indoors/daiyousei_izumi.xml
@@ -1,5 +1,19 @@
 <Root>
     <File Name="daiyousei_izumi_scene" Segment="2">
+        <Texture Name="daiyousei_izumi_sceneTex_004800" OutName="daiyousei_izumi_sceneTex_004800" Format="i8" Width="32" Height="64" Offset="0x4800" AddedByScript="true"/>
+        <Texture Name="daiyousei_izumi_sceneTex_005000" OutName="daiyousei_izumi_sceneTex_005000" Format="rgba16" Width="32" Height="32" Offset="0x5000" AddedByScript="true"/>
+        <Texture Name="daiyousei_izumi_sceneTex_005800" OutName="daiyousei_izumi_sceneTex_005800" Format="rgba16" Width="32" Height="32" Offset="0x5800" AddedByScript="true"/>
+        <Texture Name="daiyousei_izumi_sceneTex_006000" OutName="daiyousei_izumi_sceneTex_006000" Format="ia4" Width="64" Height="128" Offset="0x6000" AddedByScript="true"/>
+        <Texture Name="daiyousei_izumi_sceneTex_007000" OutName="daiyousei_izumi_sceneTex_007000" Format="rgba16" Width="32" Height="64" Offset="0x7000" AddedByScript="true"/>
+        <Texture Name="daiyousei_izumi_sceneTex_008000" OutName="daiyousei_izumi_sceneTex_008000" Format="rgba16" Width="32" Height="64" Offset="0x8000" AddedByScript="true"/>
+        <Texture Name="daiyousei_izumi_sceneTex_009000" OutName="daiyousei_izumi_sceneTex_009000" Format="rgba16" Width="32" Height="64" Offset="0x9000" AddedByScript="true"/>
+        <Texture Name="daiyousei_izumi_sceneTex_00A000" OutName="daiyousei_izumi_sceneTex_00A000" Format="i8" Width="32" Height="64" Offset="0xA000" AddedByScript="true"/>
+        <Texture Name="daiyousei_izumi_sceneTex_00A800" OutName="daiyousei_izumi_sceneTex_00A800" Format="rgba16" Width="32" Height="32" Offset="0xA800" AddedByScript="true"/>
+        <Texture Name="daiyousei_izumi_sceneTex_00B000" OutName="daiyousei_izumi_sceneTex_00B000" Format="i8" Width="32" Height="128" Offset="0xB000" AddedByScript="true"/>
+        <Texture Name="daiyousei_izumi_sceneTex_00C000" OutName="daiyousei_izumi_sceneTex_00C000" Format="rgba16" Width="32" Height="32" Offset="0xC000" AddedByScript="true"/>
+        <Texture Name="daiyousei_izumi_sceneTex_00C800" OutName="daiyousei_izumi_sceneTex_00C800" Format="ia8" Width="64" Height="32" Offset="0xC800" AddedByScript="true"/>
+        <Texture Name="daiyousei_izumi_sceneTex_00D000" OutName="daiyousei_izumi_sceneTex_00D000" Format="rgba16" Width="32" Height="32" Offset="0xD000" AddedByScript="true"/>
+        <Texture Name="daiyousei_izumi_sceneTex_00D800" OutName="daiyousei_izumi_sceneTex_00D800" Format="rgba16" Width="32" Height="32" Offset="0xD800" AddedByScript="true"/>
         <Cutscene Name="gGreatFairyMagicCs" Offset="0x0130"/>
         <Cutscene Name="gGreatFairyDoubleMagicCs" Offset="0x13E0"/>
         <Cutscene Name="gGreatFairyDoubleDefenceCs" Offset="0x25D0"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/indoors/hairal_niwa.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/indoors/hairal_niwa.xml
@@ -1,5 +1,27 @@
 <Root>
     <File Name="hairal_niwa_scene" Segment="2">
+        <Texture Name="hairal_niwa_sceneTex_003390" OutName="hairal_niwa_sceneTex_003390" Format="rgba16" Width="32" Height="32" Offset="0x3390" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_003B90" OutName="hairal_niwa_sceneTex_003B90" Format="ia16" Width="32" Height="64" Offset="0x3B90" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_004B90" OutName="hairal_niwa_sceneTex_004B90" Format="rgba16" Width="32" Height="32" Offset="0x4B90" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_005390" OutName="hairal_niwa_sceneTex_005390" Format="rgba16" Width="32" Height="32" Offset="0x5390" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_005B90" OutName="hairal_niwa_sceneTex_005B90" Format="rgba16" Width="32" Height="32" Offset="0x5B90" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_006390" OutName="hairal_niwa_sceneTex_006390" Format="rgba16" Width="32" Height="64" Offset="0x6390" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_007390" OutName="hairal_niwa_sceneTex_007390" Format="i4" Width="64" Height="64" Offset="0x7390" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_007B90" OutName="hairal_niwa_sceneTex_007B90" Format="rgba16" Width="32" Height="64" Offset="0x7B90" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_008B90" OutName="hairal_niwa_sceneTex_008B90" Format="rgba16" Width="32" Height="32" Offset="0x8B90" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_009390" OutName="hairal_niwa_sceneTex_009390" Format="rgba16" Width="32" Height="32" Offset="0x9390" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_009B90" OutName="hairal_niwa_sceneTex_009B90" Format="rgba16" Width="32" Height="64" Offset="0x9B90" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_00AB90" OutName="hairal_niwa_sceneTex_00AB90" Format="rgba16" Width="32" Height="32" Offset="0xAB90" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_00B390" OutName="hairal_niwa_sceneTex_00B390" Format="rgba16" Width="32" Height="32" Offset="0xB390" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_00BB90" OutName="hairal_niwa_sceneTex_00BB90" Format="rgba16" Width="32" Height="32" Offset="0xBB90" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_00C390" OutName="hairal_niwa_sceneTex_00C390" Format="ia4" Width="64" Height="64" Offset="0xC390" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_00CB90" OutName="hairal_niwa_sceneTex_00CB90" Format="i8" Width="32" Height="64" Offset="0xCB90" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_00D390" OutName="hairal_niwa_sceneTex_00D390" Format="ia4" Width="32" Height="128" Offset="0xD390" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_00DB90" OutName="hairal_niwa_sceneTex_00DB90" Format="rgba16" Width="32" Height="64" Offset="0xDB90" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_00EB90" OutName="hairal_niwa_sceneTex_00EB90" Format="rgba16" Width="32" Height="32" Offset="0xEB90" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_00F390" OutName="hairal_niwa_sceneTex_00F390" Format="rgba16" Width="32" Height="32" Offset="0xF390" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_00FB90" OutName="hairal_niwa_sceneTex_00FB90" Format="rgba16" Width="32" Height="32" Offset="0xFB90" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_010390" OutName="hairal_niwa_sceneTex_010390" Format="rgba16" Width="32" Height="64" Offset="0x10390" AddedByScript="true"/>
         <Path Name="hairal_niwa_scenePathway_000268" Offset="0x268" NumPaths="8"/>
 
         <Scene Name="hairal_niwa_scene" Offset="0x0"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/indoors/hairal_niwa_n.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/indoors/hairal_niwa_n.xml
@@ -1,5 +1,18 @@
 <Root>
     <File Name="hairal_niwa_n_scene" Segment="2">
+        <Texture Name="hairal_niwa_n_sceneTex_0010F0" OutName="hairal_niwa_n_sceneTex_0010F0" Format="rgba16" Width="32" Height="32" Offset="0x10F0" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_n_sceneTex_0018F0" OutName="hairal_niwa_n_sceneTex_0018F0" Format="rgba16" Width="32" Height="32" Offset="0x18F0" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_n_sceneTex_0020F0" OutName="hairal_niwa_n_sceneTex_0020F0" Format="rgba16" Width="32" Height="32" Offset="0x20F0" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_n_sceneTex_0028F0" OutName="hairal_niwa_n_sceneTex_0028F0" Format="rgba16" Width="32" Height="64" Offset="0x28F0" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_n_sceneTex_0038F0" OutName="hairal_niwa_n_sceneTex_0038F0" Format="i4" Width="64" Height="64" Offset="0x38F0" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_n_sceneTex_0040F0" OutName="hairal_niwa_n_sceneTex_0040F0" Format="rgba16" Width="32" Height="64" Offset="0x40F0" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_n_sceneTex_0050F0" OutName="hairal_niwa_n_sceneTex_0050F0" Format="rgba16" Width="32" Height="32" Offset="0x50F0" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_n_sceneTex_0058F0" OutName="hairal_niwa_n_sceneTex_0058F0" Format="rgba16" Width="32" Height="32" Offset="0x58F0" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_n_sceneTex_0060F0" OutName="hairal_niwa_n_sceneTex_0060F0" Format="ia4" Width="32" Height="128" Offset="0x60F0" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_n_sceneTex_0068F0" OutName="hairal_niwa_n_sceneTex_0068F0" Format="rgba16" Width="32" Height="32" Offset="0x68F0" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_n_sceneTex_0070F0" OutName="hairal_niwa_n_sceneTex_0070F0" Format="rgba16" Width="32" Height="32" Offset="0x70F0" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_n_sceneTex_0078F0" OutName="hairal_niwa_n_sceneTex_0078F0" Format="rgba16" Width="32" Height="32" Offset="0x78F0" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_n_sceneTex_0080F0" OutName="hairal_niwa_n_sceneTex_0080F0" Format="rgba16" Width="32" Height="64" Offset="0x80F0" AddedByScript="true"/>
         <Scene Name="hairal_niwa_n_scene" Offset="0x0"/>
     </File>
     <File Name="hairal_niwa_n_room_0" Segment="3">

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/indoors/hakasitarelay.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/indoors/hakasitarelay.xml
@@ -1,27 +1,80 @@
 <Root>
     <File Name="hakasitarelay_scene" Segment="2">
+        <Texture Name="hakasitarelay_sceneTex_00C080" OutName="hakasitarelay_sceneTex_00C080" Format="rgba16" Width="64" Height="32" Offset="0xC080" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_sceneTex_00D080" OutName="hakasitarelay_sceneTex_00D080" Format="rgba16" Width="32" Height="32" Offset="0xD080" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_sceneTex_00D880" OutName="hakasitarelay_sceneTex_00D880" Format="i4" Width="64" Height="64" Offset="0xD880" AddedByScript="true"/>
         <Scene Name="hakasitarelay_scene" Offset="0x0"/>
         <Cutscene Name="gSongOfStormsCs" Offset="0xE080"/>
     </File>
     <File Name="hakasitarelay_room_0" Segment="3">
+        <Texture Name="hakasitarelay_room_0Tex_003248" OutName="hakasitarelay_room_0Tex_003248" Format="i4" Width="32" Height="32" Offset="0x3248" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_0Tex_003448" OutName="hakasitarelay_room_0Tex_003448" Format="rgba16" Width="32" Height="64" Offset="0x3448" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_0Tex_004448" OutName="hakasitarelay_room_0Tex_004448" Format="i4" Width="128" Height="32" Offset="0x4448" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_0Tex_004C48" OutName="hakasitarelay_room_0Tex_004C48" Format="i4" Width="32" Height="128" Offset="0x4C48" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_0Tex_005448" OutName="hakasitarelay_room_0Tex_005448" Format="i8" Width="32" Height="32" Offset="0x5448" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_0Tex_005848" OutName="hakasitarelay_room_0Tex_005848" Format="i8" Width="64" Height="32" Offset="0x5848" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_0Tex_0062B8" OutName="hakasitarelay_room_0Tex_0062B8" Format="ia16" Width="128" Height="16" Offset="0x62B8" AddedByScript="true"/>
         <Room Name="hakasitarelay_room_0" Offset="0x0"/>
     </File>
     <File Name="hakasitarelay_room_1" Segment="3">
+        <Texture Name="hakasitarelay_room_1Tex_003F20" OutName="hakasitarelay_room_1Tex_003F20" Format="i8" Width="32" Height="32" Offset="0x3F20" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_1Tex_004320" OutName="hakasitarelay_room_1Tex_004320" Format="i8" Width="32" Height="32" Offset="0x4320" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_1Tex_004720" OutName="hakasitarelay_room_1Tex_004720" Format="rgba16" Width="32" Height="64" Offset="0x4720" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_1Tex_005720" OutName="hakasitarelay_room_1Tex_005720" Format="rgba16" Width="32" Height="32" Offset="0x5720" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_1Tex_005F20" OutName="hakasitarelay_room_1Tex_005F20" Format="rgba16" Width="32" Height="16" Offset="0x5F20" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_1Tex_006320" OutName="hakasitarelay_room_1Tex_006320" Format="rgba16" Width="32" Height="16" Offset="0x6320" AddedByScript="true"/>
         <Room Name="hakasitarelay_room_1" Offset="0x0"/>
     </File>
     <File Name="hakasitarelay_room_2" Segment="3">
+        <Texture Name="hakasitarelay_room_2Tex_0054A8" OutName="hakasitarelay_room_2Tex_0054A8" Format="i8" Width="32" Height="32" Offset="0x54A8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_2Tex_0058A8" OutName="hakasitarelay_room_2Tex_0058A8" Format="i8" Width="32" Height="32" Offset="0x58A8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_2Tex_005CA8" OutName="hakasitarelay_room_2Tex_005CA8" Format="rgba16" Width="32" Height="64" Offset="0x5CA8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_2Tex_006CA8" OutName="hakasitarelay_room_2Tex_006CA8" Format="i8" Width="64" Height="32" Offset="0x6CA8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_2Tex_0074A8" OutName="hakasitarelay_room_2Tex_0074A8" Format="rgba16" Width="32" Height="32" Offset="0x74A8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_2Tex_007CA8" OutName="hakasitarelay_room_2Tex_007CA8" Format="rgba16" Width="32" Height="16" Offset="0x7CA8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_2Tex_0080A8" OutName="hakasitarelay_room_2Tex_0080A8" Format="rgba16" Width="32" Height="16" Offset="0x80A8" AddedByScript="true"/>
         <Room Name="hakasitarelay_room_2" Offset="0x0"/>
     </File>
     <File Name="hakasitarelay_room_3" Segment="3">
+        <Texture Name="hakasitarelay_room_3Tex_0056E0" OutName="hakasitarelay_room_3Tex_0056E0" Format="i8" Width="32" Height="32" Offset="0x56E0" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_3Tex_005AE0" OutName="hakasitarelay_room_3Tex_005AE0" Format="i8" Width="32" Height="32" Offset="0x5AE0" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_3Tex_005EE0" OutName="hakasitarelay_room_3Tex_005EE0" Format="i4" Width="32" Height="32" Offset="0x5EE0" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_3Tex_0060E0" OutName="hakasitarelay_room_3Tex_0060E0" Format="rgba16" Width="32" Height="64" Offset="0x60E0" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_3Tex_0070E0" OutName="hakasitarelay_room_3Tex_0070E0" Format="rgba16" Width="32" Height="32" Offset="0x70E0" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_3Tex_0078E0" OutName="hakasitarelay_room_3Tex_0078E0" Format="rgba16" Width="32" Height="16" Offset="0x78E0" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_3Tex_007CE0" OutName="hakasitarelay_room_3Tex_007CE0" Format="i4" Width="128" Height="32" Offset="0x7CE0" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_3Tex_0084E0" OutName="hakasitarelay_room_3Tex_0084E0" Format="i8" Width="64" Height="32" Offset="0x84E0" AddedByScript="true"/>
         <Room Name="hakasitarelay_room_3" Offset="0x0"/>
     </File>
     <File Name="hakasitarelay_room_4" Segment="3">
+        <Texture Name="hakasitarelay_room_4Tex_001E80" OutName="hakasitarelay_room_4Tex_001E80" Format="i4" Width="32" Height="32" Offset="0x1E80" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_4Tex_002080" OutName="hakasitarelay_room_4Tex_002080" Format="i8" Width="64" Height="32" Offset="0x2080" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_4Tex_002880" OutName="hakasitarelay_room_4Tex_002880" Format="i4" Width="32" Height="128" Offset="0x2880" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_4Tex_003080" OutName="hakasitarelay_room_4Tex_003080" Format="i8" Width="32" Height="32" Offset="0x3080" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_4Tex_003480" OutName="hakasitarelay_room_4Tex_003480" Format="i8" Width="64" Height="32" Offset="0x3480" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_4Tex_003C80" OutName="hakasitarelay_room_4Tex_003C80" Format="i4" Width="64" Height="64" Offset="0x3C80" AddedByScript="true"/>
         <Room Name="hakasitarelay_room_4" Offset="0x0"/>
     </File>
     <File Name="hakasitarelay_room_5" Segment="3">
+        <Texture Name="hakasitarelay_room_5Tex_001C48" OutName="hakasitarelay_room_5Tex_001C48" Format="rgba16" Width="32" Height="32" Offset="0x1C48" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_5Tex_002448" OutName="hakasitarelay_room_5Tex_002448" Format="ci4" Width="64" Height="64" Offset="0x2448" TlutOffset="0x1C28" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_5Tex_002C48" OutName="hakasitarelay_room_5Tex_002C48" Format="i8" Width="64" Height="32" Offset="0x2C48" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_5Tex_003448" OutName="hakasitarelay_room_5Tex_003448" Format="i4" Width="64" Height="64" Offset="0x3448" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_5Tex_003C48" OutName="hakasitarelay_room_5Tex_003C48" Format="i4" Width="64" Height="64" Offset="0x3C48" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_5TLUT_001C28" OutName="hakasitarelay_room_5TLUT_001C28" Format="rgba16" Width="4" Height="4" Offset="0x1C28" AddedByScript="true"/>
         <Room Name="hakasitarelay_room_5" Offset="0x0"/>
     </File>
     <File Name="hakasitarelay_room_6" Segment="3">
+        <Texture Name="hakasitarelay_room_6Tex_0041A8" OutName="hakasitarelay_room_6Tex_0041A8" Format="rgba16" Width="16" Height="8" Offset="0x41A8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_6Tex_0042A8" OutName="hakasitarelay_room_6Tex_0042A8" Format="rgba16" Width="32" Height="32" Offset="0x42A8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_6Tex_004AA8" OutName="hakasitarelay_room_6Tex_004AA8" Format="rgba16" Width="32" Height="16" Offset="0x4AA8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_6Tex_004EA8" OutName="hakasitarelay_room_6Tex_004EA8" Format="ci4" Width="64" Height="64" Offset="0x4EA8" TlutOffset="0x4188" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_6Tex_0056A8" OutName="hakasitarelay_room_6Tex_0056A8" Format="i8" Width="64" Height="32" Offset="0x56A8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_6Tex_005EA8" OutName="hakasitarelay_room_6Tex_005EA8" Format="i4" Width="64" Height="64" Offset="0x5EA8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_6Tex_0066A8" OutName="hakasitarelay_room_6Tex_0066A8" Format="i8" Width="32" Height="32" Offset="0x66A8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_6Tex_006AA8" OutName="hakasitarelay_room_6Tex_006AA8" Format="i8" Width="64" Height="32" Offset="0x6AA8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_6Tex_0072A8" OutName="hakasitarelay_room_6Tex_0072A8" Format="i4" Width="64" Height="64" Offset="0x72A8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_6TLUT_004188" OutName="hakasitarelay_room_6TLUT_004188" Format="rgba16" Width="4" Height="4" Offset="0x4188" AddedByScript="true"/>
         <Room Name="hakasitarelay_room_6" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/indoors/hylia_labo.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/indoors/hylia_labo.xml
@@ -1,5 +1,36 @@
 <Root>
     <File Name="hylia_labo_scene" Segment="2">
+        <Texture Name="hylia_labo_sceneTex_001090" OutName="hylia_labo_sceneTex_001090" Format="ia8" Width="16" Height="64" Offset="0x1090" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_001490" OutName="hylia_labo_sceneTex_001490" Format="rgba16" Width="64" Height="32" Offset="0x1490" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_002490" OutName="hylia_labo_sceneTex_002490" Format="rgba16" Width="32" Height="64" Offset="0x2490" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_003490" OutName="hylia_labo_sceneTex_003490" Format="rgba16" Width="32" Height="32" Offset="0x3490" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_003C90" OutName="hylia_labo_sceneTex_003C90" Format="rgba16" Width="32" Height="64" Offset="0x3C90" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_004C90" OutName="hylia_labo_sceneTex_004C90" Format="rgba16" Width="32" Height="32" Offset="0x4C90" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_005490" OutName="hylia_labo_sceneTex_005490" Format="rgba16" Width="32" Height="32" Offset="0x5490" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_005C90" OutName="hylia_labo_sceneTex_005C90" Format="ia8" Width="64" Height="16" Offset="0x5C90" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_006090" OutName="hylia_labo_sceneTex_006090" Format="rgba16" Width="32" Height="4" Offset="0x6090" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_006190" OutName="hylia_labo_sceneTex_006190" Format="rgba16" Width="32" Height="32" Offset="0x6190" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_006990" OutName="hylia_labo_sceneTex_006990" Format="rgba16" Width="32" Height="16" Offset="0x6990" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_006D90" OutName="hylia_labo_sceneTex_006D90" Format="ia4" Width="64" Height="128" Offset="0x6D90" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_007D90" OutName="hylia_labo_sceneTex_007D90" Format="rgba16" Width="32" Height="32" Offset="0x7D90" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_008590" OutName="hylia_labo_sceneTex_008590" Format="ia8" Width="32" Height="16" Offset="0x8590" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_008790" OutName="hylia_labo_sceneTex_008790" Format="ia8" Width="32" Height="128" Offset="0x8790" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_009790" OutName="hylia_labo_sceneTex_009790" Format="rgba16" Width="32" Height="8" Offset="0x9790" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_009990" OutName="hylia_labo_sceneTex_009990" Format="ia8" Width="16" Height="16" Offset="0x9990" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_009A90" OutName="hylia_labo_sceneTex_009A90" Format="ia8" Width="16" Height="32" Offset="0x9A90" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_009C90" OutName="hylia_labo_sceneTex_009C90" Format="ia8" Width="32" Height="32" Offset="0x9C90" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_00A090" OutName="hylia_labo_sceneTex_00A090" Format="rgba16" Width="32" Height="64" Offset="0xA090" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_00B090" OutName="hylia_labo_sceneTex_00B090" Format="rgba16" Width="64" Height="32" Offset="0xB090" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_00C090" OutName="hylia_labo_sceneTex_00C090" Format="rgba16" Width="64" Height="16" Offset="0xC090" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_00C890" OutName="hylia_labo_sceneTex_00C890" Format="rgba16" Width="32" Height="32" Offset="0xC890" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_00D090" OutName="hylia_labo_sceneTex_00D090" Format="rgba16" Width="64" Height="16" Offset="0xD090" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_00D890" OutName="hylia_labo_sceneTex_00D890" Format="rgba16" Width="64" Height="16" Offset="0xD890" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_00E090" OutName="hylia_labo_sceneTex_00E090" Format="rgba16" Width="32" Height="32" Offset="0xE090" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_00E890" OutName="hylia_labo_sceneTex_00E890" Format="rgba16" Width="32" Height="64" Offset="0xE890" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_00F890" OutName="hylia_labo_sceneTex_00F890" Format="rgba16" Width="32" Height="32" Offset="0xF890" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_010090" OutName="hylia_labo_sceneTex_010090" Format="i8" Width="32" Height="32" Offset="0x10090" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_010490" OutName="hylia_labo_sceneTex_010490" Format="i8" Width="32" Height="32" Offset="0x10490" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_010890" OutName="hylia_labo_sceneTex_010890" Format="rgba16" Width="32" Height="32" Offset="0x10890" AddedByScript="true"/>
         <Scene Name="hylia_labo_scene" Offset="0x0"/>
     </File>
     <File Name="hylia_labo_room_0" Segment="3">

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/indoors/kenjyanoma.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/indoors/kenjyanoma.xml
@@ -3,6 +3,25 @@
         <Scene Name="kenjyanoma_scene" Offset="0x0"/>
     </File>
     <File Name="kenjyanoma_room_0" Segment="3">
+        <Texture Name="kenjyanoma_room_0Tex_001618" OutName="kenjyanoma_room_0Tex_001618" Format="rgba16" Width="64" Height="32" Offset="0x1618" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_002618" OutName="kenjyanoma_room_0Tex_002618" Format="rgba16" Width="64" Height="32" Offset="0x2618" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_003618" OutName="kenjyanoma_room_0Tex_003618" Format="rgba16" Width="64" Height="32" Offset="0x3618" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_004618" OutName="kenjyanoma_room_0Tex_004618" Format="rgba16" Width="64" Height="32" Offset="0x4618" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_005618" OutName="kenjyanoma_room_0Tex_005618" Format="rgba16" Width="64" Height="32" Offset="0x5618" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_006618" OutName="kenjyanoma_room_0Tex_006618" Format="rgba16" Width="64" Height="32" Offset="0x6618" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_007618" OutName="kenjyanoma_room_0Tex_007618" Format="rgba16" Width="64" Height="32" Offset="0x7618" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_008618" OutName="kenjyanoma_room_0Tex_008618" Format="rgba16" Width="64" Height="32" Offset="0x8618" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_009618" OutName="kenjyanoma_room_0Tex_009618" Format="rgba16" Width="32" Height="64" Offset="0x9618" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_00A618" OutName="kenjyanoma_room_0Tex_00A618" Format="rgba16" Width="32" Height="64" Offset="0xA618" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_00B618" OutName="kenjyanoma_room_0Tex_00B618" Format="rgba16" Width="64" Height="32" Offset="0xB618" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_00C618" OutName="kenjyanoma_room_0Tex_00C618" Format="rgba16" Width="64" Height="32" Offset="0xC618" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_00D618" OutName="kenjyanoma_room_0Tex_00D618" Format="rgba16" Width="32" Height="32" Offset="0xD618" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_010CE8" OutName="kenjyanoma_room_0Tex_010CE8" Format="ia16" Width="32" Height="32" Offset="0x10CE8" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_0114E8" OutName="kenjyanoma_room_0Tex_0114E8" Format="i8" Width="32" Height="64" Offset="0x114E8" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_011CE8" OutName="kenjyanoma_room_0Tex_011CE8" Format="rgba16" Width="4" Height="4" Offset="0x11CE8" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_011D08" OutName="kenjyanoma_room_0Tex_011D08" Format="rgba16" Width="32" Height="32" Offset="0x11D08" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_012508" OutName="kenjyanoma_room_0Tex_012508" Format="i8" Width="32" Height="64" Offset="0x12508" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_012D08" OutName="kenjyanoma_room_0Tex_012D08" Format="i8" Width="32" Height="32" Offset="0x12D08" AddedByScript="true"/>
         <Room Name="kenjyanoma_room_0" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/indoors/mahouya.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/indoors/mahouya.xml
@@ -1,5 +1,18 @@
 <Root>
     <File Name="mahouya_scene" Segment="2">
+        <Texture Name="mahouya_sceneTex_000A20" OutName="mahouya_sceneTex_000A20" Format="rgba16" Width="32" Height="32" Offset="0xA20" AddedByScript="true"/>
+        <Texture Name="mahouya_sceneTex_001220" OutName="mahouya_sceneTex_001220" Format="rgba16" Width="32" Height="32" Offset="0x1220" AddedByScript="true"/>
+        <Texture Name="mahouya_sceneTex_001A20" OutName="mahouya_sceneTex_001A20" Format="rgba16" Width="16" Height="128" Offset="0x1A20" AddedByScript="true"/>
+        <Texture Name="mahouya_sceneTex_002A20" OutName="mahouya_sceneTex_002A20" Format="rgba16" Width="32" Height="64" Offset="0x2A20" AddedByScript="true"/>
+        <Texture Name="mahouya_sceneTex_003A20" OutName="mahouya_sceneTex_003A20" Format="rgba16" Width="64" Height="32" Offset="0x3A20" AddedByScript="true"/>
+        <Texture Name="mahouya_sceneTex_004A20" OutName="mahouya_sceneTex_004A20" Format="rgba16" Width="32" Height="32" Offset="0x4A20" AddedByScript="true"/>
+        <Texture Name="mahouya_sceneTex_005220" OutName="mahouya_sceneTex_005220" Format="rgba16" Width="16" Height="128" Offset="0x5220" AddedByScript="true"/>
+        <Texture Name="mahouya_sceneTex_006220" OutName="mahouya_sceneTex_006220" Format="rgba16" Width="16" Height="128" Offset="0x6220" AddedByScript="true"/>
+        <Texture Name="mahouya_sceneTex_007220" OutName="mahouya_sceneTex_007220" Format="rgba16" Width="32" Height="32" Offset="0x7220" AddedByScript="true"/>
+        <Texture Name="mahouya_sceneTex_007A20" OutName="mahouya_sceneTex_007A20" Format="rgba16" Width="64" Height="32" Offset="0x7A20" AddedByScript="true"/>
+        <Texture Name="mahouya_sceneTex_008A20" OutName="mahouya_sceneTex_008A20" Format="i8" Width="16" Height="128" Offset="0x8A20" AddedByScript="true"/>
+        <Texture Name="mahouya_sceneTex_009220" OutName="mahouya_sceneTex_009220" Format="rgba16" Width="32" Height="32" Offset="0x9220" AddedByScript="true"/>
+        <Texture Name="mahouya_sceneTex_009A20" OutName="mahouya_sceneTex_009A20" Format="rgba16" Width="64" Height="32" Offset="0x9A20" AddedByScript="true"/>
         <Scene Name="mahouya_scene" Offset="0x0"/>
     </File>
     <File Name="mahouya_room_0" Segment="3">

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/indoors/miharigoya.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/indoors/miharigoya.xml
@@ -1,5 +1,19 @@
 <Root>
     <File Name="miharigoya_scene" Segment="2">
+        <Texture Name="miharigoya_sceneTex_000C50" OutName="miharigoya_sceneTex_000C50" Format="ia8" Width="64" Height="16" Offset="0xC50" AddedByScript="true"/>
+        <Texture Name="miharigoya_sceneTex_001050" OutName="miharigoya_sceneTex_001050" Format="rgba16" Width="32" Height="4" Offset="0x1050" AddedByScript="true"/>
+        <Texture Name="miharigoya_sceneTex_001150" OutName="miharigoya_sceneTex_001150" Format="ia8" Width="32" Height="16" Offset="0x1150" AddedByScript="true"/>
+        <Texture Name="miharigoya_sceneTex_003350" OutName="miharigoya_sceneTex_003350" Format="rgba16" Width="32" Height="8" Offset="0x3350" AddedByScript="true"/>
+        <Texture Name="miharigoya_sceneTex_004550" OutName="miharigoya_sceneTex_004550" Format="i8" Width="32" Height="32" Offset="0x4550" AddedByScript="true"/>
+        <Texture Name="miharigoya_sceneTex_004950" OutName="miharigoya_sceneTex_004950" Format="rgba16" Width="64" Height="32" Offset="0x4950" AddedByScript="true"/>
+        <Texture Name="miharigoya_sceneTex_005950" OutName="miharigoya_sceneTex_005950" Format="i8" Width="32" Height="32" Offset="0x5950" AddedByScript="true"/>
+        <Texture Name="miharigoya_sceneTex_005D50" OutName="miharigoya_sceneTex_005D50" Format="rgba16" Width="64" Height="16" Offset="0x5D50" AddedByScript="true"/>
+        <Texture Name="miharigoya_sceneTex_007550" OutName="miharigoya_sceneTex_007550" Format="rgba16" Width="32" Height="64" Offset="0x7550" AddedByScript="true"/>
+        <Texture Name="miharigoya_sceneTex_008550" OutName="miharigoya_sceneTex_008550" Format="i4" Width="64" Height="64" Offset="0x8550" AddedByScript="true"/>
+        <Texture Name="miharigoya_sceneTex_008D50" OutName="miharigoya_sceneTex_008D50" Format="i8" Width="64" Height="64" Offset="0x8D50" AddedByScript="true"/>
+        <Texture Name="miharigoya_sceneTex_009D50" OutName="miharigoya_sceneTex_009D50" Format="rgba16" Width="32" Height="64" Offset="0x9D50" AddedByScript="true"/>
+        <Texture Name="miharigoya_sceneTex_00AD50" OutName="miharigoya_sceneTex_00AD50" Format="i8" Width="64" Height="64" Offset="0xAD50" AddedByScript="true"/>
+        <Texture Name="miharigoya_sceneTex_00BD50" OutName="miharigoya_sceneTex_00BD50" Format="rgba16" Width="32" Height="32" Offset="0xBD50" AddedByScript="true"/>
         <Texture Name="gGuardHouseOutSideView2NightTex" OutName="view_2_night" Format="rgba16" Width="64" Height="32" Offset="0x1350"/>
         <Texture Name="gGuardHouseOutSideView2DayTex" OutName="view_2_day" Format="rgba16" Width="64" Height="32" Offset="0x2350"/>
         <Texture Name="gGuardHouseOutSideView1NightTex" OutName="view_1_night" Format="rgba16" Width="64" Height="32" Offset="0x3550"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/indoors/nakaniwa.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/indoors/nakaniwa.xml
@@ -8,6 +8,37 @@
         <Scene Name="nakaniwa_scene" Offset="0x0"/>
     </File>
     <File Name="nakaniwa_room_0" Segment="3">
+        <Texture Name="nakaniwa_room_0Tex_007218" OutName="nakaniwa_room_0Tex_007218" Format="rgba16" Width="16" Height="16" Offset="0x7218" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_007418" OutName="nakaniwa_room_0Tex_007418" Format="rgba16" Width="16" Height="16" Offset="0x7418" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_007618" OutName="nakaniwa_room_0Tex_007618" Format="rgba16" Width="16" Height="16" Offset="0x7618" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_007818" OutName="nakaniwa_room_0Tex_007818" Format="rgba16" Width="16" Height="16" Offset="0x7818" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_007A18" OutName="nakaniwa_room_0Tex_007A18" Format="rgba16" Width="32" Height="32" Offset="0x7A18" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_008218" OutName="nakaniwa_room_0Tex_008218" Format="rgba16" Width="16" Height="16" Offset="0x8218" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_008418" OutName="nakaniwa_room_0Tex_008418" Format="rgba16" Width="16" Height="16" Offset="0x8418" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_008618" OutName="nakaniwa_room_0Tex_008618" Format="rgba16" Width="32" Height="32" Offset="0x8618" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_008E18" OutName="nakaniwa_room_0Tex_008E18" Format="rgba16" Width="32" Height="64" Offset="0x8E18" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_009E18" OutName="nakaniwa_room_0Tex_009E18" Format="rgba16" Width="32" Height="32" Offset="0x9E18" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_00A618" OutName="nakaniwa_room_0Tex_00A618" Format="rgba16" Width="32" Height="64" Offset="0xA618" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_00B618" OutName="nakaniwa_room_0Tex_00B618" Format="rgba16" Width="32" Height="64" Offset="0xB618" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_00C618" OutName="nakaniwa_room_0Tex_00C618" Format="i4" Width="64" Height="64" Offset="0xC618" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_00CE18" OutName="nakaniwa_room_0Tex_00CE18" Format="rgba16" Width="32" Height="64" Offset="0xCE18" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_00DE18" OutName="nakaniwa_room_0Tex_00DE18" Format="rgba16" Width="32" Height="32" Offset="0xDE18" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_00E618" OutName="nakaniwa_room_0Tex_00E618" Format="rgba16" Width="16" Height="64" Offset="0xE618" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_00EE18" OutName="nakaniwa_room_0Tex_00EE18" Format="rgba16" Width="32" Height="32" Offset="0xEE18" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_00F618" OutName="nakaniwa_room_0Tex_00F618" Format="rgba16" Width="32" Height="32" Offset="0xF618" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_00FE18" OutName="nakaniwa_room_0Tex_00FE18" Format="rgba16" Width="32" Height="32" Offset="0xFE18" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_010618" OutName="nakaniwa_room_0Tex_010618" Format="rgba16" Width="32" Height="32" Offset="0x10618" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_010E18" OutName="nakaniwa_room_0Tex_010E18" Format="rgba16" Width="32" Height="32" Offset="0x10E18" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_011618" OutName="nakaniwa_room_0Tex_011618" Format="rgba16" Width="32" Height="32" Offset="0x11618" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_011E18" OutName="nakaniwa_room_0Tex_011E18" Format="rgba16" Width="32" Height="32" Offset="0x11E18" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_012618" OutName="nakaniwa_room_0Tex_012618" Format="rgba16" Width="32" Height="32" Offset="0x12618" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_012E18" OutName="nakaniwa_room_0Tex_012E18" Format="rgba16" Width="64" Height="16" Offset="0x12E18" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_013618" OutName="nakaniwa_room_0Tex_013618" Format="rgba16" Width="32" Height="32" Offset="0x13618" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_013E18" OutName="nakaniwa_room_0Tex_013E18" Format="i4" Width="32" Height="32" Offset="0x13E18" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_014EC0" OutName="nakaniwa_room_0Tex_014EC0" Format="ia16" Width="32" Height="32" Offset="0x14EC0" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_0156C0" OutName="nakaniwa_room_0Tex_0156C0" Format="ia16" Width="64" Height="32" Offset="0x156C0" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_0166C0" OutName="nakaniwa_room_0Tex_0166C0" Format="rgba16" Width="32" Height="32" Offset="0x166C0" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_016EC0" OutName="nakaniwa_room_0Tex_016EC0" Format="ia16" Width="32" Height="64" Offset="0x16EC0" AddedByScript="true"/>
         <Room Name="nakaniwa_room_0" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/indoors/syatekijyou.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/indoors/syatekijyou.xml
@@ -1,5 +1,27 @@
 <Root>
     <File Name="syatekijyou_scene" Segment="2">
+        <Texture Name="syatekijyou_sceneTex_001C40" OutName="syatekijyou_sceneTex_001C40" Format="rgba16" Width="32" Height="4" Offset="0x1C40" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_001D40" OutName="syatekijyou_sceneTex_001D40" Format="rgba16" Width="32" Height="16" Offset="0x1D40" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_002140" OutName="syatekijyou_sceneTex_002140" Format="rgba16" Width="32" Height="16" Offset="0x2140" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_002540" OutName="syatekijyou_sceneTex_002540" Format="ia4" Width="32" Height="32" Offset="0x2540" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_002740" OutName="syatekijyou_sceneTex_002740" Format="rgba16" Width="64" Height="32" Offset="0x2740" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_003740" OutName="syatekijyou_sceneTex_003740" Format="ia8" Width="32" Height="16" Offset="0x3740" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_003940" OutName="syatekijyou_sceneTex_003940" Format="rgba16" Width="4" Height="16" Offset="0x3940" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_0039C0" OutName="syatekijyou_sceneTex_0039C0" Format="ia8" Width="16" Height="64" Offset="0x39C0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_003DC0" OutName="syatekijyou_sceneTex_003DC0" Format="rgba16" Width="32" Height="16" Offset="0x3DC0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_0041C0" OutName="syatekijyou_sceneTex_0041C0" Format="rgba16" Width="32" Height="64" Offset="0x41C0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_0051C0" OutName="syatekijyou_sceneTex_0051C0" Format="ia8" Width="16" Height="16" Offset="0x51C0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_0052C0" OutName="syatekijyou_sceneTex_0052C0" Format="ia8" Width="16" Height="32" Offset="0x52C0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_0054C0" OutName="syatekijyou_sceneTex_0054C0" Format="rgba16" Width="32" Height="32" Offset="0x54C0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_005CC0" OutName="syatekijyou_sceneTex_005CC0" Format="rgba16" Width="32" Height="64" Offset="0x5CC0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_006CC0" OutName="syatekijyou_sceneTex_006CC0" Format="rgba16" Width="32" Height="64" Offset="0x6CC0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_007CC0" OutName="syatekijyou_sceneTex_007CC0" Format="i8" Width="64" Height="64" Offset="0x7CC0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_008CC0" OutName="syatekijyou_sceneTex_008CC0" Format="rgba16" Width="32" Height="64" Offset="0x8CC0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_009CC0" OutName="syatekijyou_sceneTex_009CC0" Format="ia4" Width="64" Height="64" Offset="0x9CC0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_00A4C0" OutName="syatekijyou_sceneTex_00A4C0" Format="rgba16" Width="32" Height="32" Offset="0xA4C0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_00ACC0" OutName="syatekijyou_sceneTex_00ACC0" Format="ia8" Width="32" Height="32" Offset="0xACC0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_00B0C0" OutName="syatekijyou_sceneTex_00B0C0" Format="i4" Width="32" Height="32" Offset="0xB0C0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_00B2C0" OutName="syatekijyou_sceneTex_00B2C0" Format="rgba16" Width="64" Height="32" Offset="0xB2C0" AddedByScript="true"/>
         <Scene Name="syatekijyou_scene" Offset="0x0"/>
     </File>
     <File Name="syatekijyou_room_0" Segment="3">

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/indoors/takaraya.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/indoors/takaraya.xml
@@ -1,26 +1,53 @@
 <Root>
     <File Name="takaraya_scene" Segment="2">
+        <Texture Name="takaraya_sceneTex_0051B0" OutName="takaraya_sceneTex_0051B0" Format="rgba16" Width="32" Height="32" Offset="0x51B0" AddedByScript="true"/>
+        <Texture Name="takaraya_sceneTex_0059B0" OutName="takaraya_sceneTex_0059B0" Format="rgba16" Width="32" Height="32" Offset="0x59B0" AddedByScript="true"/>
+        <Texture Name="takaraya_sceneTex_0061B0" OutName="takaraya_sceneTex_0061B0" Format="rgba16" Width="32" Height="32" Offset="0x61B0" AddedByScript="true"/>
+        <Texture Name="takaraya_sceneTex_0069B0" OutName="takaraya_sceneTex_0069B0" Format="rgba16" Width="32" Height="32" Offset="0x69B0" AddedByScript="true"/>
         <Scene Name="takaraya_scene" Offset="0x0"/>
     </File>
     <File Name="takaraya_room_0" Segment="3">
+        <Texture Name="takaraya_room_0Tex_003BE0" OutName="takaraya_room_0Tex_003BE0" Format="rgba16" Width="16" Height="64" Offset="0x3BE0" AddedByScript="true"/>
+        <Texture Name="takaraya_room_0Tex_0043E0" OutName="takaraya_room_0Tex_0043E0" Format="rgba16" Width="32" Height="32" Offset="0x43E0" AddedByScript="true"/>
+        <Texture Name="takaraya_room_0Tex_004BE0" OutName="takaraya_room_0Tex_004BE0" Format="rgba16" Width="64" Height="32" Offset="0x4BE0" AddedByScript="true"/>
+        <Texture Name="takaraya_room_0Tex_005BE0" OutName="takaraya_room_0Tex_005BE0" Format="rgba16" Width="32" Height="32" Offset="0x5BE0" AddedByScript="true"/>
+        <Texture Name="takaraya_room_0Tex_0063E0" OutName="takaraya_room_0Tex_0063E0" Format="rgba16" Width="32" Height="32" Offset="0x63E0" AddedByScript="true"/>
+        <Texture Name="takaraya_room_0Tex_006BE0" OutName="takaraya_room_0Tex_006BE0" Format="rgba16" Width="32" Height="32" Offset="0x6BE0" AddedByScript="true"/>
+        <Texture Name="takaraya_room_0Tex_0073E0" OutName="takaraya_room_0Tex_0073E0" Format="rgba16" Width="32" Height="32" Offset="0x73E0" AddedByScript="true"/>
+        <Texture Name="takaraya_room_0Tex_007BE0" OutName="takaraya_room_0Tex_007BE0" Format="rgba16" Width="32" Height="32" Offset="0x7BE0" AddedByScript="true"/>
+        <Texture Name="takaraya_room_0Tex_0083E0" OutName="takaraya_room_0Tex_0083E0" Format="rgba16" Width="32" Height="64" Offset="0x83E0" AddedByScript="true"/>
+        <Texture Name="takaraya_room_0Tex_0095C0" OutName="takaraya_room_0Tex_0095C0" Format="ia4" Width="64" Height="64" Offset="0x95C0" AddedByScript="true"/>
         <Room Name="takaraya_room_0" Offset="0x0"/>
     </File>
     <File Name="takaraya_room_1" Segment="3">
+        <Texture Name="takaraya_room_1Tex_0017F8" OutName="takaraya_room_1Tex_0017F8" Format="rgba16" Width="16" Height="64" Offset="0x17F8" AddedByScript="true"/>
         <Room Name="takaraya_room_1" Offset="0x0"/>
     </File>
     <File Name="takaraya_room_2" Segment="3">
+        <Texture Name="takaraya_room_2Tex_001828" OutName="takaraya_room_2Tex_001828" Format="rgba16" Width="16" Height="64" Offset="0x1828" AddedByScript="true"/>
         <Room Name="takaraya_room_2" Offset="0x0"/>
     </File>
     <File Name="takaraya_room_3" Segment="3">
+        <Texture Name="takaraya_room_3Tex_001818" OutName="takaraya_room_3Tex_001818" Format="rgba16" Width="16" Height="64" Offset="0x1818" AddedByScript="true"/>
+        <Texture Name="takaraya_room_3Tex_002018" OutName="takaraya_room_3Tex_002018" Format="rgba16" Width="32" Height="32" Offset="0x2018" AddedByScript="true"/>
         <Room Name="takaraya_room_3" Offset="0x0"/>
     </File>
     <File Name="takaraya_room_4" Segment="3">
+        <Texture Name="takaraya_room_4Tex_001820" OutName="takaraya_room_4Tex_001820" Format="rgba16" Width="16" Height="64" Offset="0x1820" AddedByScript="true"/>
+        <Texture Name="takaraya_room_4Tex_002020" OutName="takaraya_room_4Tex_002020" Format="rgba16" Width="32" Height="32" Offset="0x2020" AddedByScript="true"/>
+        <Texture Name="takaraya_room_4Tex_002820" OutName="takaraya_room_4Tex_002820" Format="rgba16" Width="32" Height="32" Offset="0x2820" AddedByScript="true"/>
         <Room Name="takaraya_room_4" Offset="0x0"/>
     </File>
     <File Name="takaraya_room_5" Segment="3">
+        <Texture Name="takaraya_room_5Tex_0017F8" OutName="takaraya_room_5Tex_0017F8" Format="rgba16" Width="32" Height="32" Offset="0x17F8" AddedByScript="true"/>
+        <Texture Name="takaraya_room_5Tex_001FF8" OutName="takaraya_room_5Tex_001FF8" Format="rgba16" Width="32" Height="32" Offset="0x1FF8" AddedByScript="true"/>
+        <Texture Name="takaraya_room_5Tex_0027F8" OutName="takaraya_room_5Tex_0027F8" Format="rgba16" Width="16" Height="64" Offset="0x27F8" AddedByScript="true"/>
         <Room Name="takaraya_room_5" Offset="0x0"/>
     </File>
     <File Name="takaraya_room_6" Segment="3">
+        <Texture Name="takaraya_room_6Tex_0012F8" OutName="takaraya_room_6Tex_0012F8" Format="rgba16" Width="32" Height="32" Offset="0x12F8" AddedByScript="true"/>
+        <Texture Name="takaraya_room_6Tex_001AF8" OutName="takaraya_room_6Tex_001AF8" Format="rgba16" Width="16" Height="64" Offset="0x1AF8" AddedByScript="true"/>
+        <Texture Name="takaraya_room_6Tex_0022F8" OutName="takaraya_room_6Tex_0022F8" Format="rgba16" Width="32" Height="32" Offset="0x22F8" AddedByScript="true"/>
         <Room Name="takaraya_room_6" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/indoors/tokinoma.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/indoors/tokinoma.xml
@@ -1,14 +1,47 @@
 <Root>
     <File Name="tokinoma_scene" Segment="2">
-        <Cutscene  Name="gTempleOfTimeFirstAdultCs" Offset="0x46F0"/>
-        <Cutscene  Name="gTempleOfTimePreludeCs" Offset="0x6D20"/>
+        <Texture Name="tokinoma_sceneTex_00CFA0" OutName="tokinoma_sceneTex_00CFA0" Format="rgba16" Width="32" Height="32" Offset="0xCFA0" AddedByScript="true"/>
+        <Texture Name="tokinoma_sceneTex_00D7A0" OutName="tokinoma_sceneTex_00D7A0" Format="rgba16" Width="32" Height="32" Offset="0xD7A0" AddedByScript="true"/>
+        <Texture Name="tokinoma_sceneTex_00DFA0" OutName="tokinoma_sceneTex_00DFA0" Format="rgba16" Width="32" Height="64" Offset="0xDFA0" AddedByScript="true"/>
+        <Texture Name="tokinoma_sceneTex_00EFA0" OutName="tokinoma_sceneTex_00EFA0" Format="rgba16" Width="32" Height="64" Offset="0xEFA0" AddedByScript="true"/>
+        <Texture Name="tokinoma_sceneTex_00FFA0" OutName="tokinoma_sceneTex_00FFA0" Format="rgba16" Width="32" Height="32" Offset="0xFFA0" AddedByScript="true"/>
+        <Texture Name="tokinoma_sceneTex_0107A0" OutName="tokinoma_sceneTex_0107A0" Format="rgba16" Width="32" Height="32" Offset="0x107A0" AddedByScript="true"/>
+        <Texture Name="tokinoma_sceneTex_010FA0" OutName="tokinoma_sceneTex_010FA0" Format="rgba16" Width="32" Height="32" Offset="0x10FA0" AddedByScript="true"/>
+        <Texture Name="tokinoma_sceneTex_0117A0" OutName="tokinoma_sceneTex_0117A0" Format="rgba16" Width="32" Height="32" Offset="0x117A0" AddedByScript="true"/>
+        <Texture Name="tokinoma_sceneTex_011FA0" OutName="tokinoma_sceneTex_011FA0" Format="rgba16" Width="32" Height="32" Offset="0x11FA0" AddedByScript="true"/>
+        <Cutscene Name="gTempleOfTimeFirstAdultCs" Offset="0x46F0"/>
+        <Cutscene Name="gTempleOfTimePreludeCs" Offset="0x6D20"/>
         <Cutscene Name="gTempleOfTimeIntroCs" Offset="0xCE00"/>
         <Scene Name="tokinoma_scene" Offset="0x0"/>
     </File>
     <File Name="tokinoma_room_0" Segment="3">
+        <Texture Name="tokinoma_room_0Tex_0081D8" OutName="tokinoma_room_0Tex_0081D8" Format="rgba16" Width="64" Height="32" Offset="0x81D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_0091D8" OutName="tokinoma_room_0Tex_0091D8" Format="rgba16" Width="64" Height="32" Offset="0x91D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_00A1D8" OutName="tokinoma_room_0Tex_00A1D8" Format="rgba16" Width="64" Height="32" Offset="0xA1D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_00B1D8" OutName="tokinoma_room_0Tex_00B1D8" Format="rgba16" Width="64" Height="32" Offset="0xB1D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_00C1D8" OutName="tokinoma_room_0Tex_00C1D8" Format="rgba16" Width="64" Height="32" Offset="0xC1D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_00D1D8" OutName="tokinoma_room_0Tex_00D1D8" Format="rgba16" Width="64" Height="32" Offset="0xD1D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_00E1D8" OutName="tokinoma_room_0Tex_00E1D8" Format="rgba16" Width="64" Height="32" Offset="0xE1D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_00F1D8" OutName="tokinoma_room_0Tex_00F1D8" Format="rgba16" Width="64" Height="32" Offset="0xF1D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_0101D8" OutName="tokinoma_room_0Tex_0101D8" Format="rgba16" Width="64" Height="32" Offset="0x101D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_0111D8" OutName="tokinoma_room_0Tex_0111D8" Format="rgba16" Width="64" Height="32" Offset="0x111D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_0121D8" OutName="tokinoma_room_0Tex_0121D8" Format="rgba16" Width="64" Height="32" Offset="0x121D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_0131D8" OutName="tokinoma_room_0Tex_0131D8" Format="rgba16" Width="64" Height="32" Offset="0x131D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_0141D8" OutName="tokinoma_room_0Tex_0141D8" Format="rgba16" Width="32" Height="32" Offset="0x141D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_0149D8" OutName="tokinoma_room_0Tex_0149D8" Format="rgba16" Width="32" Height="32" Offset="0x149D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_0151D8" OutName="tokinoma_room_0Tex_0151D8" Format="rgba16" Width="32" Height="32" Offset="0x151D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_0159D8" OutName="tokinoma_room_0Tex_0159D8" Format="rgba16" Width="32" Height="32" Offset="0x159D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_0161D8" OutName="tokinoma_room_0Tex_0161D8" Format="rgba16" Width="32" Height="32" Offset="0x161D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_0169D8" OutName="tokinoma_room_0Tex_0169D8" Format="rgba16" Width="32" Height="32" Offset="0x169D8" AddedByScript="true"/>
         <Room Name="tokinoma_room_0" Offset="0x0"/>
     </File>
     <File Name="tokinoma_room_1" Segment="3">
+        <Texture Name="tokinoma_room_1Tex_005458" OutName="tokinoma_room_1Tex_005458" Format="rgba16" Width="16" Height="16" Offset="0x5458" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_1Tex_005658" OutName="tokinoma_room_1Tex_005658" Format="rgba16" Width="16" Height="16" Offset="0x5658" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_1Tex_005858" OutName="tokinoma_room_1Tex_005858" Format="rgba16" Width="32" Height="32" Offset="0x5858" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_1Tex_006488" OutName="tokinoma_room_1Tex_006488" Format="i8" Width="8" Height="8" Offset="0x6488" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_1Tex_0064C8" OutName="tokinoma_room_1Tex_0064C8" Format="ia4" Width="128" Height="16" Offset="0x64C8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_1Tex_0068C8" OutName="tokinoma_room_1Tex_0068C8" Format="ia8" Width="64" Height="32" Offset="0x68C8" AddedByScript="true"/>
         <Room Name="tokinoma_room_1" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/indoors/yousei_izumi_tate.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/indoors/yousei_izumi_tate.xml
@@ -1,5 +1,15 @@
 <Root>
     <File Name="yousei_izumi_tate_scene" Segment="2">
+        <Texture Name="yousei_izumi_tate_sceneTex_002010" OutName="yousei_izumi_tate_sceneTex_002010" Format="ia8" Width="64" Height="32" Offset="0x2010" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_tate_sceneTex_002810" OutName="yousei_izumi_tate_sceneTex_002810" Format="i8" Width="16" Height="256" Offset="0x2810" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_tate_sceneTex_003810" OutName="yousei_izumi_tate_sceneTex_003810" Format="ia16" Width="128" Height="16" Offset="0x3810" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_tate_sceneTex_004810" OutName="yousei_izumi_tate_sceneTex_004810" Format="i8" Width="32" Height="64" Offset="0x4810" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_tate_sceneTex_005010" OutName="yousei_izumi_tate_sceneTex_005010" Format="i8" Width="32" Height="64" Offset="0x5010" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_tate_sceneTex_005810" OutName="yousei_izumi_tate_sceneTex_005810" Format="rgba16" Width="32" Height="32" Offset="0x5810" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_tate_sceneTex_006010" OutName="yousei_izumi_tate_sceneTex_006010" Format="i4" Width="64" Height="128" Offset="0x6010" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_tate_sceneTex_007010" OutName="yousei_izumi_tate_sceneTex_007010" Format="rgba16" Width="32" Height="32" Offset="0x7010" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_tate_sceneTex_007810" OutName="yousei_izumi_tate_sceneTex_007810" Format="rgba16" Width="32" Height="32" Offset="0x7810" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_tate_sceneTex_008010" OutName="yousei_izumi_tate_sceneTex_008010" Format="rgba16" Width="32" Height="32" Offset="0x8010" AddedByScript="true"/>
         <Scene Name="yousei_izumi_tate_scene" Offset="0x0"/>
     </File>
     <File Name="yousei_izumi_tate_room_0" Segment="3">

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/indoors/yousei_izumi_yoko.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/indoors/yousei_izumi_yoko.xml
@@ -1,5 +1,18 @@
 <Root>
     <File Name="yousei_izumi_yoko_scene" Segment="2">
+        <Texture Name="yousei_izumi_yoko_sceneTex_003DA0" OutName="yousei_izumi_yoko_sceneTex_003DA0" Format="i8" Width="32" Height="64" Offset="0x3DA0" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_yoko_sceneTex_0045A0" OutName="yousei_izumi_yoko_sceneTex_0045A0" Format="rgba16" Width="32" Height="32" Offset="0x45A0" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_yoko_sceneTex_004DA0" OutName="yousei_izumi_yoko_sceneTex_004DA0" Format="rgba16" Width="32" Height="32" Offset="0x4DA0" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_yoko_sceneTex_0055A0" OutName="yousei_izumi_yoko_sceneTex_0055A0" Format="ia4" Width="64" Height="128" Offset="0x55A0" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_yoko_sceneTex_0065A0" OutName="yousei_izumi_yoko_sceneTex_0065A0" Format="rgba16" Width="32" Height="64" Offset="0x65A0" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_yoko_sceneTex_0075A0" OutName="yousei_izumi_yoko_sceneTex_0075A0" Format="rgba16" Width="32" Height="64" Offset="0x75A0" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_yoko_sceneTex_0085A0" OutName="yousei_izumi_yoko_sceneTex_0085A0" Format="rgba16" Width="32" Height="64" Offset="0x85A0" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_yoko_sceneTex_0095A0" OutName="yousei_izumi_yoko_sceneTex_0095A0" Format="rgba16" Width="32" Height="32" Offset="0x95A0" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_yoko_sceneTex_009DA0" OutName="yousei_izumi_yoko_sceneTex_009DA0" Format="i8" Width="32" Height="128" Offset="0x9DA0" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_yoko_sceneTex_00ADA0" OutName="yousei_izumi_yoko_sceneTex_00ADA0" Format="rgba16" Width="32" Height="32" Offset="0xADA0" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_yoko_sceneTex_00B5A0" OutName="yousei_izumi_yoko_sceneTex_00B5A0" Format="ia8" Width="64" Height="32" Offset="0xB5A0" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_yoko_sceneTex_00BDA0" OutName="yousei_izumi_yoko_sceneTex_00BDA0" Format="rgba16" Width="32" Height="32" Offset="0xBDA0" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_yoko_sceneTex_00C5A0" OutName="yousei_izumi_yoko_sceneTex_00C5A0" Format="rgba16" Width="32" Height="32" Offset="0xC5A0" AddedByScript="true"/>
         <Cutscene Name="gGreatFairyFaroresWindCs" Offset="0x0160"/>
         <Cutscene Name="gGreatFairyDinsFireCs" Offset="0x1020"/>
         <Cutscene Name="gGreatFairyNayrusLoveCs" Offset="0x1F40"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/misc/hakaana.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/misc/hakaana.xml
@@ -3,6 +3,16 @@
         <Scene Name="hakaana_scene" Offset="0x0"/>
     </File>
     <File Name="hakaana_room_0" Segment="3">
+        <Texture Name="hakaana_room_0Tex_002658" OutName="hakaana_room_0Tex_002658" Format="rgba16" Width="32" Height="32" Offset="0x2658" AddedByScript="true"/>
+        <Texture Name="hakaana_room_0Tex_002E58" OutName="hakaana_room_0Tex_002E58" Format="rgba16" Width="32" Height="16" Offset="0x2E58" AddedByScript="true"/>
+        <Texture Name="hakaana_room_0Tex_003258" OutName="hakaana_room_0Tex_003258" Format="rgba16" Width="32" Height="16" Offset="0x3258" AddedByScript="true"/>
+        <Texture Name="hakaana_room_0Tex_003658" OutName="hakaana_room_0Tex_003658" Format="rgba16" Width="32" Height="32" Offset="0x3658" AddedByScript="true"/>
+        <Texture Name="hakaana_room_0Tex_003E58" OutName="hakaana_room_0Tex_003E58" Format="i4" Width="128" Height="32" Offset="0x3E58" AddedByScript="true"/>
+        <Texture Name="hakaana_room_0Tex_004658" OutName="hakaana_room_0Tex_004658" Format="rgba16" Width="32" Height="32" Offset="0x4658" AddedByScript="true"/>
+        <Texture Name="hakaana_room_0Tex_004E58" OutName="hakaana_room_0Tex_004E58" Format="i4" Width="64" Height="64" Offset="0x4E58" AddedByScript="true"/>
+        <Texture Name="hakaana_room_0Tex_005658" OutName="hakaana_room_0Tex_005658" Format="i4" Width="64" Height="64" Offset="0x5658" AddedByScript="true"/>
+        <Texture Name="hakaana_room_0Tex_005E58" OutName="hakaana_room_0Tex_005E58" Format="i4" Width="64" Height="64" Offset="0x5E58" AddedByScript="true"/>
+        <Texture Name="hakaana_room_0Tex_0068C8" OutName="hakaana_room_0Tex_0068C8" Format="ia16" Width="128" Height="16" Offset="0x68C8" AddedByScript="true"/>
         <Room Name="hakaana_room_0" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/misc/hakaana2.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/misc/hakaana2.xml
@@ -1,5 +1,23 @@
 <Root>
     <File Name="hakaana2_scene" Segment="2">
+        <Texture Name="hakaana2_sceneTex_003090" OutName="hakaana2_sceneTex_003090" Format="rgba16" Width="32" Height="32" Offset="0x3090" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_003890" OutName="hakaana2_sceneTex_003890" Format="rgba16" Width="32" Height="32" Offset="0x3890" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_004090" OutName="hakaana2_sceneTex_004090" Format="rgba16" Width="32" Height="16" Offset="0x4090" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_004490" OutName="hakaana2_sceneTex_004490" Format="rgba16" Width="32" Height="16" Offset="0x4490" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_004890" OutName="hakaana2_sceneTex_004890" Format="i4" Width="64" Height="64" Offset="0x4890" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_005090" OutName="hakaana2_sceneTex_005090" Format="i4" Width="64" Height="64" Offset="0x5090" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_005890" OutName="hakaana2_sceneTex_005890" Format="i4" Width="128" Height="32" Offset="0x5890" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_006090" OutName="hakaana2_sceneTex_006090" Format="i4" Width="64" Height="64" Offset="0x6090" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_006890" OutName="hakaana2_sceneTex_006890" Format="ia8" Width="64" Height="32" Offset="0x6890" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_007090" OutName="hakaana2_sceneTex_007090" Format="i8" Width="16" Height="256" Offset="0x7090" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_008090" OutName="hakaana2_sceneTex_008090" Format="ia16" Width="128" Height="16" Offset="0x8090" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_009090" OutName="hakaana2_sceneTex_009090" Format="i8" Width="32" Height="64" Offset="0x9090" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_009890" OutName="hakaana2_sceneTex_009890" Format="i8" Width="32" Height="64" Offset="0x9890" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_00A090" OutName="hakaana2_sceneTex_00A090" Format="rgba16" Width="32" Height="32" Offset="0xA090" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_00A890" OutName="hakaana2_sceneTex_00A890" Format="i4" Width="64" Height="128" Offset="0xA890" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_00B890" OutName="hakaana2_sceneTex_00B890" Format="rgba16" Width="32" Height="32" Offset="0xB890" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_00C090" OutName="hakaana2_sceneTex_00C090" Format="rgba16" Width="32" Height="32" Offset="0xC090" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_00C890" OutName="hakaana2_sceneTex_00C890" Format="rgba16" Width="32" Height="32" Offset="0xC890" AddedByScript="true"/>
         <Scene Name="hakaana2_scene" Offset="0x0"/>
     </File>
     <File Name="hakaana2_room_0" Segment="3">

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/misc/hakaana_ouke.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/misc/hakaana_ouke.xml
@@ -1,16 +1,37 @@
 <Root>
     <File Name="hakaana_ouke_scene" Segment="2">
+        <Texture Name="hakaana_ouke_sceneTex_002AE0" OutName="hakaana_ouke_sceneTex_002AE0" Format="rgba16" Width="32" Height="16" Offset="0x2AE0" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_sceneTex_002EE0" OutName="hakaana_ouke_sceneTex_002EE0" Format="rgba16" Width="32" Height="16" Offset="0x2EE0" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_sceneTex_0032E0" OutName="hakaana_ouke_sceneTex_0032E0" Format="rgba16" Width="32" Height="32" Offset="0x32E0" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_sceneTex_003AE0" OutName="hakaana_ouke_sceneTex_003AE0" Format="i4" Width="64" Height="64" Offset="0x3AE0" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_sceneTex_0042E0" OutName="hakaana_ouke_sceneTex_0042E0" Format="i4" Width="64" Height="64" Offset="0x42E0" AddedByScript="true"/>
         <Cutscene Name="gSunSongGraveSunSongTeachCs" Offset="0x24A0"/>
         <Cutscene Name="gSunSongGraveSunSongTeachPart2Cs" Offset="0x28E0"/>
         <Scene Name="hakaana_ouke_scene" Offset="0x0"/>
     </File>
     <File Name="hakaana_ouke_room_0" Segment="3">
+        <Texture Name="hakaana_ouke_room_0Tex_004F30" OutName="hakaana_ouke_room_0Tex_004F30" Format="rgba16" Width="16" Height="64" Offset="0x4F30" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_room_0Tex_005730" OutName="hakaana_ouke_room_0Tex_005730" Format="rgba16" Width="32" Height="64" Offset="0x5730" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_room_0Tex_006730" OutName="hakaana_ouke_room_0Tex_006730" Format="i4" Width="128" Height="32" Offset="0x6730" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_room_0Tex_006F30" OutName="hakaana_ouke_room_0Tex_006F30" Format="i4" Width="64" Height="64" Offset="0x6F30" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_room_0Tex_007FF8" OutName="hakaana_ouke_room_0Tex_007FF8" Format="ia4" Width="32" Height="256" Offset="0x7FF8" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_room_0Tex_008FF8" OutName="hakaana_ouke_room_0Tex_008FF8" Format="ia8" Width="8" Height="256" Offset="0x8FF8" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_room_0Tex_0097F8" OutName="hakaana_ouke_room_0Tex_0097F8" Format="ia16" Width="128" Height="16" Offset="0x97F8" AddedByScript="true"/>
         <Room Name="hakaana_ouke_room_0" Offset="0x0"/>
     </File>
     <File Name="hakaana_ouke_room_1" Segment="3">
+        <Texture Name="hakaana_ouke_room_1Tex_001FC8" OutName="hakaana_ouke_room_1Tex_001FC8" Format="rgba16" Width="32" Height="32" Offset="0x1FC8" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_room_1Tex_0027C8" OutName="hakaana_ouke_room_1Tex_0027C8" Format="rgba16" Width="32" Height="64" Offset="0x27C8" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_room_1Tex_004000" OutName="hakaana_ouke_room_1Tex_004000" Format="i8" Width="16" Height="128" Offset="0x4000" AddedByScript="true"/>
         <Room Name="hakaana_ouke_room_1" Offset="0x0"/>
     </File>
     <File Name="hakaana_ouke_room_2" Segment="3">
+        <Texture Name="hakaana_ouke_room_2Tex_002778" OutName="hakaana_ouke_room_2Tex_002778" Format="i4" Width="128" Height="32" Offset="0x2778" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_room_2Tex_002F78" OutName="hakaana_ouke_room_2Tex_002F78" Format="rgba16" Width="32" Height="32" Offset="0x2F78" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_room_2Tex_003778" OutName="hakaana_ouke_room_2Tex_003778" Format="i4" Width="128" Height="32" Offset="0x3778" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_room_2Tex_003F78" OutName="hakaana_ouke_room_2Tex_003F78" Format="rgba16" Width="32" Height="32" Offset="0x3F78" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_room_2Tex_004778" OutName="hakaana_ouke_room_2Tex_004778" Format="i4" Width="64" Height="64" Offset="0x4778" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_room_2Tex_005108" OutName="hakaana_ouke_room_2Tex_005108" Format="ia8" Width="128" Height="32" Offset="0x5108" AddedByScript="true"/>
         <Room Name="hakaana_ouke_room_2" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/misc/kakusiana.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/misc/kakusiana.xml
@@ -1,47 +1,113 @@
 <Root>
     <File Name="kakusiana_scene" Segment="2">
+        <Texture Name="kakusiana_sceneTex_00B820" OutName="kakusiana_sceneTex_00B820" Format="ia4" Width="64" Height="64" Offset="0xB820" AddedByScript="true"/>
+        <Texture Name="kakusiana_sceneTex_00C020" OutName="kakusiana_sceneTex_00C020" Format="ia16" Width="128" Height="16" Offset="0xC020" AddedByScript="true"/>
+        <Texture Name="kakusiana_sceneTex_00D020" OutName="kakusiana_sceneTex_00D020" Format="rgba16" Width="32" Height="32" Offset="0xD020" AddedByScript="true"/>
         <Scene Name="kakusiana_scene" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_0" Segment="3">
+        <Texture Name="kakusiana_room_0Tex_0022A0" OutName="kakusiana_room_0Tex_0022A0" Format="rgba16" Width="64" Height="32" Offset="0x22A0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_0Tex_0032A0" OutName="kakusiana_room_0Tex_0032A0" Format="rgba16" Width="64" Height="32" Offset="0x32A0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_0Tex_0042A0" OutName="kakusiana_room_0Tex_0042A0" Format="rgba16" Width="32" Height="32" Offset="0x42A0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_0Tex_004AA0" OutName="kakusiana_room_0Tex_004AA0" Format="i8" Width="64" Height="64" Offset="0x4AA0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_0Tex_005AA0" OutName="kakusiana_room_0Tex_005AA0" Format="rgba16" Width="32" Height="32" Offset="0x5AA0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_0Tex_006AA0" OutName="kakusiana_room_0Tex_006AA0" Format="rgba16" Width="32" Height="32" Offset="0x6AA0" AddedByScript="true"/>
         <Room Name="kakusiana_room_0" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_1" Segment="3">
+        <Texture Name="kakusiana_room_1Tex_001A18" OutName="kakusiana_room_1Tex_001A18" Format="i8" Width="64" Height="64" Offset="0x1A18" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_1Tex_002A18" OutName="kakusiana_room_1Tex_002A18" Format="rgba16" Width="32" Height="32" Offset="0x2A18" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_1Tex_003218" OutName="kakusiana_room_1Tex_003218" Format="i8" Width="64" Height="64" Offset="0x3218" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_1Tex_004990" OutName="kakusiana_room_1Tex_004990" Format="ia8" Width="8" Height="256" Offset="0x4990" AddedByScript="true"/>
         <Room Name="kakusiana_room_1" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_2" Segment="3">
+        <Texture Name="kakusiana_room_2Tex_001448" OutName="kakusiana_room_2Tex_001448" Format="rgba16" Width="32" Height="32" Offset="0x1448" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_2Tex_001C48" OutName="kakusiana_room_2Tex_001C48" Format="rgba16" Width="32" Height="32" Offset="0x1C48" AddedByScript="true"/>
         <Room Name="kakusiana_room_2" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_3" Segment="3">
+        <Texture Name="kakusiana_room_3Tex_001818" OutName="kakusiana_room_3Tex_001818" Format="i8" Width="64" Height="64" Offset="0x1818" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_3Tex_002818" OutName="kakusiana_room_3Tex_002818" Format="i8" Width="64" Height="64" Offset="0x2818" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_3Tex_004130" OutName="kakusiana_room_3Tex_004130" Format="ia8" Width="8" Height="256" Offset="0x4130" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_3Tex_004930" OutName="kakusiana_room_3Tex_004930" Format="rgba16" Width="32" Height="32" Offset="0x4930" AddedByScript="true"/>
         <Room Name="kakusiana_room_3" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_4" Segment="3">
+        <Texture Name="kakusiana_room_4Tex_002138" OutName="kakusiana_room_4Tex_002138" Format="rgba16" Width="32" Height="64" Offset="0x2138" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_4Tex_003138" OutName="kakusiana_room_4Tex_003138" Format="rgba16" Width="32" Height="64" Offset="0x3138" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_4Tex_004138" OutName="kakusiana_room_4Tex_004138" Format="rgba16" Width="32" Height="32" Offset="0x4138" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_4Tex_005958" OutName="kakusiana_room_4Tex_005958" Format="i8" Width="64" Height="64" Offset="0x5958" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_4Tex_006958" OutName="kakusiana_room_4Tex_006958" Format="i8" Width="64" Height="64" Offset="0x6958" AddedByScript="true"/>
         <Room Name="kakusiana_room_4" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_5" Segment="3">
+        <Texture Name="kakusiana_room_5Tex_001888" OutName="kakusiana_room_5Tex_001888" Format="i8" Width="64" Height="64" Offset="0x1888" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_5Tex_002888" OutName="kakusiana_room_5Tex_002888" Format="i8" Width="64" Height="64" Offset="0x2888" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_5Tex_003ED8" OutName="kakusiana_room_5Tex_003ED8" Format="rgba16" Width="32" Height="32" Offset="0x3ED8" AddedByScript="true"/>
         <Room Name="kakusiana_room_5" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_6" Segment="3">
+        <Texture Name="kakusiana_room_6Tex_0022E0" OutName="kakusiana_room_6Tex_0022E0" Format="rgba16" Width="32" Height="64" Offset="0x22E0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_6Tex_0032E0" OutName="kakusiana_room_6Tex_0032E0" Format="rgba16" Width="32" Height="32" Offset="0x32E0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_6Tex_003AE0" OutName="kakusiana_room_6Tex_003AE0" Format="rgba16" Width="64" Height="32" Offset="0x3AE0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_6Tex_004AE0" OutName="kakusiana_room_6Tex_004AE0" Format="rgba16" Width="32" Height="32" Offset="0x4AE0" AddedByScript="true"/>
         <Room Name="kakusiana_room_6" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_7" Segment="3">
+        <Texture Name="kakusiana_room_7Tex_001D60" OutName="kakusiana_room_7Tex_001D60" Format="rgba16" Width="32" Height="16" Offset="0x1D60" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_7Tex_002160" OutName="kakusiana_room_7Tex_002160" Format="rgba16" Width="32" Height="32" Offset="0x2160" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_7Tex_002960" OutName="kakusiana_room_7Tex_002960" Format="rgba16" Width="16" Height="16" Offset="0x2960" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_7Tex_002B60" OutName="kakusiana_room_7Tex_002B60" Format="i8" Width="64" Height="64" Offset="0x2B60" AddedByScript="true"/>
         <Room Name="kakusiana_room_7" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_8" Segment="3">
+        <Texture Name="kakusiana_room_8Tex_0019C0" OutName="kakusiana_room_8Tex_0019C0" Format="rgba16" Width="32" Height="64" Offset="0x19C0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_8Tex_0029C0" OutName="kakusiana_room_8Tex_0029C0" Format="rgba16" Width="32" Height="32" Offset="0x29C0" AddedByScript="true"/>
         <Room Name="kakusiana_room_8" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_9" Segment="3">
+        <Texture Name="kakusiana_room_9Tex_002340" OutName="kakusiana_room_9Tex_002340" Format="rgba16" Width="32" Height="64" Offset="0x2340" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_9Tex_003340" OutName="kakusiana_room_9Tex_003340" Format="rgba16" Width="32" Height="32" Offset="0x3340" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_9Tex_003B40" OutName="kakusiana_room_9Tex_003B40" Format="rgba16" Width="64" Height="32" Offset="0x3B40" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_9Tex_004B40" OutName="kakusiana_room_9Tex_004B40" Format="rgba16" Width="32" Height="32" Offset="0x4B40" AddedByScript="true"/>
         <Room Name="kakusiana_room_9" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_10" Segment="3">
+        <Texture Name="kakusiana_room_10Tex_0017E0" OutName="kakusiana_room_10Tex_0017E0" Format="i8" Width="32" Height="64" Offset="0x17E0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_10Tex_001FE0" OutName="kakusiana_room_10Tex_001FE0" Format="i8" Width="32" Height="64" Offset="0x1FE0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_10Tex_0027E0" OutName="kakusiana_room_10Tex_0027E0" Format="i8" Width="32" Height="32" Offset="0x27E0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_10Tex_002BE0" OutName="kakusiana_room_10Tex_002BE0" Format="i8" Width="64" Height="64" Offset="0x2BE0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_10Tex_003BE0" OutName="kakusiana_room_10Tex_003BE0" Format="i8" Width="64" Height="64" Offset="0x3BE0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_10Tex_005228" OutName="kakusiana_room_10Tex_005228" Format="rgba16" Width="32" Height="32" Offset="0x5228" AddedByScript="true"/>
         <Room Name="kakusiana_room_10" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_11" Segment="3">
+        <Texture Name="kakusiana_room_11Tex_002848" OutName="kakusiana_room_11Tex_002848" Format="rgba16" Width="32" Height="32" Offset="0x2848" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_11Tex_003048" OutName="kakusiana_room_11Tex_003048" Format="rgba16" Width="32" Height="64" Offset="0x3048" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_11Tex_004048" OutName="kakusiana_room_11Tex_004048" Format="rgba16" Width="32" Height="64" Offset="0x4048" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_11Tex_005048" OutName="kakusiana_room_11Tex_005048" Format="rgba16" Width="32" Height="32" Offset="0x5048" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_11Tex_005848" OutName="kakusiana_room_11Tex_005848" Format="rgba16" Width="64" Height="32" Offset="0x5848" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_11Tex_006848" OutName="kakusiana_room_11Tex_006848" Format="rgba16" Width="64" Height="32" Offset="0x6848" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_11Tex_007848" OutName="kakusiana_room_11Tex_007848" Format="rgba16" Width="32" Height="32" Offset="0x7848" AddedByScript="true"/>
         <Room Name="kakusiana_room_11" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_12" Segment="3">
+        <Texture Name="kakusiana_room_12Tex_001FF0" OutName="kakusiana_room_12Tex_001FF0" Format="rgba16" Width="32" Height="32" Offset="0x1FF0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_12Tex_0027F0" OutName="kakusiana_room_12Tex_0027F0" Format="rgba16" Width="32" Height="64" Offset="0x27F0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_12Tex_0037F0" OutName="kakusiana_room_12Tex_0037F0" Format="rgba16" Width="32" Height="64" Offset="0x37F0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_12Tex_0047F0" OutName="kakusiana_room_12Tex_0047F0" Format="rgba16" Width="32" Height="32" Offset="0x47F0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_12Tex_004FF0" OutName="kakusiana_room_12Tex_004FF0" Format="rgba16" Width="64" Height="32" Offset="0x4FF0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_12Tex_005FF0" OutName="kakusiana_room_12Tex_005FF0" Format="rgba16" Width="64" Height="32" Offset="0x5FF0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_12Tex_006FF0" OutName="kakusiana_room_12Tex_006FF0" Format="rgba16" Width="32" Height="32" Offset="0x6FF0" AddedByScript="true"/>
         <Room Name="kakusiana_room_12" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_13" Segment="3">
+        <Texture Name="kakusiana_room_13Tex_001950" OutName="kakusiana_room_13Tex_001950" Format="rgba16" Width="32" Height="64" Offset="0x1950" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_13Tex_002950" OutName="kakusiana_room_13Tex_002950" Format="rgba16" Width="32" Height="64" Offset="0x2950" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_13Tex_003950" OutName="kakusiana_room_13Tex_003950" Format="rgba16" Width="32" Height="32" Offset="0x3950" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_13Tex_004EC8" OutName="kakusiana_room_13Tex_004EC8" Format="i8" Width="64" Height="64" Offset="0x4EC8" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_13Tex_005EC8" OutName="kakusiana_room_13Tex_005EC8" Format="i8" Width="64" Height="64" Offset="0x5EC8" AddedByScript="true"/>
         <Room Name="kakusiana_room_13" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/misc/kinsuta.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/misc/kinsuta.xml
@@ -3,6 +3,19 @@
         <Scene Name="kinsuta_scene" Offset="0x0"/>
     </File>
     <File Name="kinsuta_room_0" Segment="3">
+        <Texture Name="kinsuta_room_0Tex_003110" OutName="kinsuta_room_0Tex_003110" Format="ci4" Width="64" Height="64" Offset="0x3110" TlutOffset="0x30F0" AddedByScript="true"/>
+        <Texture Name="kinsuta_room_0Tex_003910" OutName="kinsuta_room_0Tex_003910" Format="i4" Width="64" Height="128" Offset="0x3910" AddedByScript="true"/>
+        <Texture Name="kinsuta_room_0Tex_004910" OutName="kinsuta_room_0Tex_004910" Format="i4" Width="64" Height="128" Offset="0x4910" AddedByScript="true"/>
+        <Texture Name="kinsuta_room_0Tex_005910" OutName="kinsuta_room_0Tex_005910" Format="i4" Width="64" Height="128" Offset="0x5910" AddedByScript="true"/>
+        <Texture Name="kinsuta_room_0Tex_006910" OutName="kinsuta_room_0Tex_006910" Format="rgba16" Width="32" Height="64" Offset="0x6910" AddedByScript="true"/>
+        <Texture Name="kinsuta_room_0Tex_007910" OutName="kinsuta_room_0Tex_007910" Format="rgba16" Width="32" Height="64" Offset="0x7910" AddedByScript="true"/>
+        <Texture Name="kinsuta_room_0Tex_008910" OutName="kinsuta_room_0Tex_008910" Format="i8" Width="32" Height="32" Offset="0x8910" AddedByScript="true"/>
+        <Texture Name="kinsuta_room_0Tex_008D10" OutName="kinsuta_room_0Tex_008D10" Format="rgba16" Width="64" Height="32" Offset="0x8D10" AddedByScript="true"/>
+        <Texture Name="kinsuta_room_0Tex_009D10" OutName="kinsuta_room_0Tex_009D10" Format="rgba16" Width="32" Height="16" Offset="0x9D10" AddedByScript="true"/>
+        <Texture Name="kinsuta_room_0Tex_00B098" OutName="kinsuta_room_0Tex_00B098" Format="ia16" Width="32" Height="64" Offset="0xB098" AddedByScript="true"/>
+        <Texture Name="kinsuta_room_0Tex_00C098" OutName="kinsuta_room_0Tex_00C098" Format="i8" Width="64" Height="64" Offset="0xC098" AddedByScript="true"/>
+        <Texture Name="kinsuta_room_0Tex_00D098" OutName="kinsuta_room_0Tex_00D098" Format="i8" Width="64" Height="64" Offset="0xD098" AddedByScript="true"/>
+        <Texture Name="kinsuta_room_0TLUT_0030F0" OutName="kinsuta_room_0TLUT_0030F0" Format="rgba16" Width="4" Height="4" Offset="0x30F0" AddedByScript="true"/>
         <DList Name="gKinsutaDL_0030B0" Offset="0x30B0"/>
         <DList Name="gKinsutaDL_00B088" Offset="0xB088"/>
         <Room Name="kinsuta_room_0" Offset="0x0"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/misc/turibori.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/misc/turibori.xml
@@ -1,5 +1,32 @@
 <Root>
     <File Name="turibori_scene" Segment="2">
+        <Texture Name="turibori_sceneTex_001CE0" OutName="turibori_sceneTex_001CE0" Format="rgba16" Width="32" Height="64" Offset="0x1CE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_002CE0" OutName="turibori_sceneTex_002CE0" Format="rgba16" Width="64" Height="32" Offset="0x2CE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_003CE0" OutName="turibori_sceneTex_003CE0" Format="rgba16" Width="64" Height="32" Offset="0x3CE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_004CE0" OutName="turibori_sceneTex_004CE0" Format="rgba16" Width="32" Height="4" Offset="0x4CE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_004DE0" OutName="turibori_sceneTex_004DE0" Format="rgba16" Width="32" Height="16" Offset="0x4DE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_0051E0" OutName="turibori_sceneTex_0051E0" Format="ia16" Width="32" Height="32" Offset="0x51E0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_0059E0" OutName="turibori_sceneTex_0059E0" Format="ia8" Width="64" Height="64" Offset="0x59E0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_0069E0" OutName="turibori_sceneTex_0069E0" Format="ia8" Width="32" Height="16" Offset="0x69E0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_006BE0" OutName="turibori_sceneTex_006BE0" Format="rgba16" Width="32" Height="64" Offset="0x6BE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_007BE0" OutName="turibori_sceneTex_007BE0" Format="ia8" Width="64" Height="16" Offset="0x7BE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_007FE0" OutName="turibori_sceneTex_007FE0" Format="rgba16" Width="32" Height="8" Offset="0x7FE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_0081E0" OutName="turibori_sceneTex_0081E0" Format="rgba16" Width="64" Height="32" Offset="0x81E0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_0091E0" OutName="turibori_sceneTex_0091E0" Format="ia8" Width="16" Height="16" Offset="0x91E0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_0092E0" OutName="turibori_sceneTex_0092E0" Format="ia8" Width="16" Height="32" Offset="0x92E0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_0094E0" OutName="turibori_sceneTex_0094E0" Format="rgba16" Width="32" Height="32" Offset="0x94E0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_009CE0" OutName="turibori_sceneTex_009CE0" Format="rgba16" Width="32" Height="64" Offset="0x9CE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_00ACE0" OutName="turibori_sceneTex_00ACE0" Format="rgba16" Width="64" Height="32" Offset="0xACE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_00BCE0" OutName="turibori_sceneTex_00BCE0" Format="ia8" Width="32" Height="128" Offset="0xBCE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_00CCE0" OutName="turibori_sceneTex_00CCE0" Format="rgba16" Width="64" Height="32" Offset="0xCCE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_00DCE0" OutName="turibori_sceneTex_00DCE0" Format="rgba16" Width="32" Height="32" Offset="0xDCE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_00E4E0" OutName="turibori_sceneTex_00E4E0" Format="rgba16" Width="32" Height="32" Offset="0xE4E0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_00ECE0" OutName="turibori_sceneTex_00ECE0" Format="rgba16" Width="32" Height="32" Offset="0xECE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_00F4E0" OutName="turibori_sceneTex_00F4E0" Format="ia4" Width="64" Height="64" Offset="0xF4E0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_00FCE0" OutName="turibori_sceneTex_00FCE0" Format="rgba16" Width="32" Height="32" Offset="0xFCE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_0104E0" OutName="turibori_sceneTex_0104E0" Format="rgba16" Width="64" Height="32" Offset="0x104E0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_0114E0" OutName="turibori_sceneTex_0114E0" Format="i4" Width="32" Height="32" Offset="0x114E0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_0116E0" OutName="turibori_sceneTex_0116E0" Format="rgba16" Width="32" Height="64" Offset="0x116E0" AddedByScript="true"/>
         <Scene Name="turibori_scene" Offset="0x0"/>
     </File>
     <File Name="turibori_room_0" Segment="3">

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/overworld/souko.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/overworld/souko.xml
@@ -1,16 +1,44 @@
 <Root>
     <File Name="souko_scene" Segment="2">
+        <Texture Name="souko_sceneTex_004410" OutName="souko_sceneTex_004410" Format="rgba16" Width="32" Height="32" Offset="0x4410" AddedByScript="true"/>
+        <Texture Name="souko_sceneTex_004C10" OutName="souko_sceneTex_004C10" Format="rgba16" Width="32" Height="16" Offset="0x4C10" AddedByScript="true"/>
+        <Texture Name="souko_sceneTex_005410" OutName="souko_sceneTex_005410" Format="rgba16" Width="32" Height="32" Offset="0x5410" AddedByScript="true"/>
+        <Texture Name="souko_sceneTex_005C10" OutName="souko_sceneTex_005C10" Format="rgba16" Width="64" Height="32" Offset="0x5C10" AddedByScript="true"/>
         <Texture Name="gLonLonHouseDayEntranceTex" OutName="day_entrance" Format="ia16" Width="64" Height="4" Offset="0x5210"/> 
         <Texture Name="gLonLonHouseNightEntranceTex" OutName="night_entrance" Format="ia16" Width="64" Height="4" Offset="0x5010"/> 
         <Scene Name="souko_scene" Offset="0x0"/>
     </File>
     <File Name="souko_room_0" Segment="3">
+        <Texture Name="souko_room_0Tex_0054F8" OutName="souko_room_0Tex_0054F8" Format="i4" Width="64" Height="64" Offset="0x54F8" AddedByScript="true"/>
+        <Texture Name="souko_room_0Tex_005CF8" OutName="souko_room_0Tex_005CF8" Format="rgba16" Width="32" Height="32" Offset="0x5CF8" AddedByScript="true"/>
+        <Texture Name="souko_room_0Tex_0064F8" OutName="souko_room_0Tex_0064F8" Format="rgba16" Width="32" Height="32" Offset="0x64F8" AddedByScript="true"/>
+        <Texture Name="souko_room_0Tex_006CF8" OutName="souko_room_0Tex_006CF8" Format="rgba16" Width="16" Height="32" Offset="0x6CF8" AddedByScript="true"/>
+        <Texture Name="souko_room_0Tex_0070F8" OutName="souko_room_0Tex_0070F8" Format="rgba16" Width="32" Height="32" Offset="0x70F8" AddedByScript="true"/>
+        <Texture Name="souko_room_0Tex_0078F8" OutName="souko_room_0Tex_0078F8" Format="rgba16" Width="32" Height="32" Offset="0x78F8" AddedByScript="true"/>
+        <Texture Name="souko_room_0Tex_0080F8" OutName="souko_room_0Tex_0080F8" Format="rgba16" Width="32" Height="64" Offset="0x80F8" AddedByScript="true"/>
+        <Texture Name="souko_room_0Tex_0090F8" OutName="souko_room_0Tex_0090F8" Format="i4" Width="32" Height="32" Offset="0x90F8" AddedByScript="true"/>
         <Room Name="souko_room_0" Offset="0x0"/>
     </File>
     <File Name="souko_room_1" Segment="3">
+        <Texture Name="souko_room_1Tex_005118" OutName="souko_room_1Tex_005118" Format="rgba16" Width="16" Height="64" Offset="0x5118" AddedByScript="true"/>
+        <Texture Name="souko_room_1Tex_005918" OutName="souko_room_1Tex_005918" Format="rgba16" Width="32" Height="32" Offset="0x5918" AddedByScript="true"/>
+        <Texture Name="souko_room_1Tex_006118" OutName="souko_room_1Tex_006118" Format="rgba16" Width="32" Height="64" Offset="0x6118" AddedByScript="true"/>
+        <Texture Name="souko_room_1Tex_007118" OutName="souko_room_1Tex_007118" Format="rgba16" Width="16" Height="32" Offset="0x7118" AddedByScript="true"/>
+        <Texture Name="souko_room_1Tex_007518" OutName="souko_room_1Tex_007518" Format="rgba16" Width="32" Height="32" Offset="0x7518" AddedByScript="true"/>
+        <Texture Name="souko_room_1Tex_007D18" OutName="souko_room_1Tex_007D18" Format="rgba16" Width="32" Height="64" Offset="0x7D18" AddedByScript="true"/>
+        <Texture Name="souko_room_1Tex_008D18" OutName="souko_room_1Tex_008D18" Format="rgba16" Width="32" Height="32" Offset="0x8D18" AddedByScript="true"/>
+        <Texture Name="souko_room_1Tex_009F28" OutName="souko_room_1Tex_009F28" Format="rgba16" Width="16" Height="16" Offset="0x9F28" AddedByScript="true"/>
+        <Texture Name="souko_room_1Tex_00A128" OutName="souko_room_1Tex_00A128" Format="ia8" Width="16" Height="16" Offset="0xA128" AddedByScript="true"/>
+        <Texture Name="souko_room_1Tex_00A228" OutName="souko_room_1Tex_00A228" Format="ia8" Width="16" Height="32" Offset="0xA228" AddedByScript="true"/>
         <Room Name="souko_room_1" Offset="0x0"/>
     </File>
     <File Name="souko_room_2" Segment="3">
+        <Texture Name="souko_room_2Tex_004EE0" OutName="souko_room_2Tex_004EE0" Format="rgba16" Width="16" Height="32" Offset="0x4EE0" AddedByScript="true"/>
+        <Texture Name="souko_room_2Tex_0052E0" OutName="souko_room_2Tex_0052E0" Format="i4" Width="64" Height="64" Offset="0x52E0" AddedByScript="true"/>
+        <Texture Name="souko_room_2Tex_005AE0" OutName="souko_room_2Tex_005AE0" Format="rgba16" Width="8" Height="128" Offset="0x5AE0" AddedByScript="true"/>
+        <Texture Name="souko_room_2Tex_0062E0" OutName="souko_room_2Tex_0062E0" Format="rgba16" Width="16" Height="64" Offset="0x62E0" AddedByScript="true"/>
+        <Texture Name="souko_room_2Tex_006AE0" OutName="souko_room_2Tex_006AE0" Format="rgba16" Width="32" Height="64" Offset="0x6AE0" AddedByScript="true"/>
+        <Texture Name="souko_room_2Tex_007F78" OutName="souko_room_2Tex_007F78" Format="ia8" Width="16" Height="32" Offset="0x7F78" AddedByScript="true"/>
         <Room Name="souko_room_2" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/overworld/spot00.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/overworld/spot00.xml
@@ -1,5 +1,56 @@
 <Root>
     <File Name="spot00_scene" Segment="2">
+        <Texture Name="spot00_sceneTex_013D98" OutName="spot00_sceneTex_013D98" Format="rgba16" Width="32" Height="32" Offset="0x13D98" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_014598" OutName="spot00_sceneTex_014598" Format="rgba16" Width="16" Height="32" Offset="0x14598" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_014998" OutName="spot00_sceneTex_014998" Format="rgba16" Width="32" Height="16" Offset="0x14998" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_014D98" OutName="spot00_sceneTex_014D98" Format="rgba16" Width="64" Height="32" Offset="0x14D98" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_015D98" OutName="spot00_sceneTex_015D98" Format="rgba16" Width="8" Height="16" Offset="0x15D98" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_015E98" OutName="spot00_sceneTex_015E98" Format="rgba16" Width="16" Height="64" Offset="0x15E98" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_016698" OutName="spot00_sceneTex_016698" Format="rgba16" Width="32" Height="16" Offset="0x16698" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_016A98" OutName="spot00_sceneTex_016A98" Format="ia4" Width="16" Height="32" Offset="0x16A98" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_016B98" OutName="spot00_sceneTex_016B98" Format="rgba16" Width="32" Height="32" Offset="0x16B98" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_017398" OutName="spot00_sceneTex_017398" Format="rgba16" Width="32" Height="32" Offset="0x17398" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_017B98" OutName="spot00_sceneTex_017B98" Format="rgba16" Width="32" Height="64" Offset="0x17B98" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_018B98" OutName="spot00_sceneTex_018B98" Format="rgba16" Width="32" Height="32" Offset="0x18B98" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_019398" OutName="spot00_sceneTex_019398" Format="rgba16" Width="32" Height="32" Offset="0x19398" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_019B98" OutName="spot00_sceneTex_019B98" Format="rgba16" Width="32" Height="64" Offset="0x19B98" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_01AB98" OutName="spot00_sceneTex_01AB98" Format="rgba16" Width="32" Height="32" Offset="0x1AB98" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_01B398" OutName="spot00_sceneTex_01B398" Format="rgba16" Width="32" Height="32" Offset="0x1B398" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_01BB98" OutName="spot00_sceneTex_01BB98" Format="rgba16" Width="16" Height="16" Offset="0x1BB98" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_01BD98" OutName="spot00_sceneTex_01BD98" Format="rgba16" Width="16" Height="32" Offset="0x1BD98" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_01C198" OutName="spot00_sceneTex_01C198" Format="rgba16" Width="32" Height="32" Offset="0x1C198" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_01C998" OutName="spot00_sceneTex_01C998" Format="rgba16" Width="32" Height="32" Offset="0x1C998" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_01D198" OutName="spot00_sceneTex_01D198" Format="rgba16" Width="64" Height="16" Offset="0x1D198" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_01D998" OutName="spot00_sceneTex_01D998" Format="rgba16" Width="32" Height="64" Offset="0x1D998" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_01E998" OutName="spot00_sceneTex_01E998" Format="ia4" Width="128" Height="32" Offset="0x1E998" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_01F198" OutName="spot00_sceneTex_01F198" Format="ia4" Width="64" Height="32" Offset="0x1F198" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_01F598" OutName="spot00_sceneTex_01F598" Format="i4" Width="16" Height="16" Offset="0x1F598" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_01F618" OutName="spot00_sceneTex_01F618" Format="rgba16" Width="8" Height="32" Offset="0x1F618" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_01F818" OutName="spot00_sceneTex_01F818" Format="rgba16" Width="32" Height="32" Offset="0x1F818" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_020018" OutName="spot00_sceneTex_020018" Format="i4" Width="64" Height="64" Offset="0x20018" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_020818" OutName="spot00_sceneTex_020818" Format="rgba16" Width="32" Height="32" Offset="0x20818" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_021018" OutName="spot00_sceneTex_021018" Format="rgba16" Width="16" Height="64" Offset="0x21018" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_021818" OutName="spot00_sceneTex_021818" Format="rgba16" Width="16" Height="64" Offset="0x21818" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_022018" OutName="spot00_sceneTex_022018" Format="ia4" Width="128" Height="32" Offset="0x22018" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_022818" OutName="spot00_sceneTex_022818" Format="rgba16" Width="64" Height="16" Offset="0x22818" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_023018" OutName="spot00_sceneTex_023018" Format="rgba16" Width="64" Height="16" Offset="0x23018" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_023818" OutName="spot00_sceneTex_023818" Format="i4" Width="64" Height="64" Offset="0x23818" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_024018" OutName="spot00_sceneTex_024018" Format="i4" Width="64" Height="64" Offset="0x24018" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_024818" OutName="spot00_sceneTex_024818" Format="ci4" Width="64" Height="64" Offset="0x24818" TlutOffset="0x13D70" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_025018" OutName="spot00_sceneTex_025018" Format="i4" Width="64" Height="64" Offset="0x25018" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_025818" OutName="spot00_sceneTex_025818" Format="rgba16" Width="8" Height="8" Offset="0x25818" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_025898" OutName="spot00_sceneTex_025898" Format="rgba16" Width="32" Height="32" Offset="0x25898" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_026098" OutName="spot00_sceneTex_026098" Format="rgba16" Width="32" Height="32" Offset="0x26098" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_026898" OutName="spot00_sceneTex_026898" Format="ia4" Width="16" Height="32" Offset="0x26898" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_026998" OutName="spot00_sceneTex_026998" Format="rgba16" Width="64" Height="32" Offset="0x26998" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_027998" OutName="spot00_sceneTex_027998" Format="i4" Width="32" Height="64" Offset="0x27998" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_027D98" OutName="spot00_sceneTex_027D98" Format="i4" Width="32" Height="64" Offset="0x27D98" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_028198" OutName="spot00_sceneTex_028198" Format="rgba16" Width="8" Height="64" Offset="0x28198" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_028598" OutName="spot00_sceneTex_028598" Format="rgba16" Width="64" Height="32" Offset="0x28598" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_029598" OutName="spot00_sceneTex_029598" Format="i4" Width="64" Height="64" Offset="0x29598" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_029D98" OutName="spot00_sceneTex_029D98" Format="i4" Width="32" Height="32" Offset="0x29D98" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_029F98" OutName="spot00_sceneTex_029F98" Format="i4" Width="32" Height="32" Offset="0x29F98" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTLUT_013D70" OutName="spot00_sceneTLUT_013D70" Format="rgba16" Width="4" Height="4" Offset="0x13D70" AddedByScript="true"/>
         <Cutscene Name="gHyruleFieldGetOoTCs" Offset="0xBB80"/>
         <Cutscene Name="gHyruleFieldZeldaSongOfTimeCs" Offset="0xF870"/>
         <Cutscene Name="gHyruleFieldEastEponaJumpCs" Offset="0xFF00"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/overworld/spot01.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/overworld/spot01.xml
@@ -1,5 +1,43 @@
 <Root>
     <File Name="spot01_scene" Segment="2">
+        <Texture Name="spot01_sceneTex_00AA50" OutName="spot01_sceneTex_00AA50" Format="rgba16" Width="32" Height="32" Offset="0xAA50" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00B250" OutName="spot01_sceneTex_00B250" Format="ci8" Width="16" Height="16" Offset="0xB250" TlutOffset="0xA870" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00B350" OutName="spot01_sceneTex_00B350" Format="ci8" Width="16" Height="64" Offset="0xB350" TlutOffset="0xA870" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00B750" OutName="spot01_sceneTex_00B750" Format="ci8" Width="32" Height="32" Offset="0xB750" TlutOffset="0xA870" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00BB50" OutName="spot01_sceneTex_00BB50" Format="rgba16" Width="16" Height="32" Offset="0xBB50" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00BF50" OutName="spot01_sceneTex_00BF50" Format="rgba16" Width="32" Height="32" Offset="0xBF50" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00C750" OutName="spot01_sceneTex_00C750" Format="ci8" Width="16" Height="32" Offset="0xC750" TlutOffset="0xA870" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00C950" OutName="spot01_sceneTex_00C950" Format="ci8" Width="32" Height="32" Offset="0xC950" TlutOffset="0xA870" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00CD50" OutName="spot01_sceneTex_00CD50" Format="ci8" Width="32" Height="64" Offset="0xCD50" TlutOffset="0xA870" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00D550" OutName="spot01_sceneTex_00D550" Format="i4" Width="64" Height="64" Offset="0xD550" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00DD50" OutName="spot01_sceneTex_00DD50" Format="i4" Width="64" Height="64" Offset="0xDD50" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00E550" OutName="spot01_sceneTex_00E550" Format="ci8" Width="32" Height="64" Offset="0xE550" TlutOffset="0xA870" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00ED50" OutName="spot01_sceneTex_00ED50" Format="ci4" Width="64" Height="64" Offset="0xED50" TlutOffset="0xAA28" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00F550" OutName="spot01_sceneTex_00F550" Format="rgba16" Width="32" Height="16" Offset="0xF550" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00F950" OutName="spot01_sceneTex_00F950" Format="rgba16" Width="32" Height="32" Offset="0xF950" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_010150" OutName="spot01_sceneTex_010150" Format="rgba16" Width="32" Height="32" Offset="0x10150" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_010950" OutName="spot01_sceneTex_010950" Format="rgba16" Width="32" Height="64" Offset="0x10950" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_011950" OutName="spot01_sceneTex_011950" Format="rgba16" Width="32" Height="64" Offset="0x11950" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_012950" OutName="spot01_sceneTex_012950" Format="ci8" Width="16" Height="32" Offset="0x12950" TlutOffset="0xA870" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_012B50" OutName="spot01_sceneTex_012B50" Format="rgba16" Width="64" Height="32" Offset="0x12B50" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_013B50" OutName="spot01_sceneTex_013B50" Format="rgba16" Width="16" Height="64" Offset="0x13B50" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_014350" OutName="spot01_sceneTex_014350" Format="ia4" Width="64" Height="32" Offset="0x14350" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_014750" OutName="spot01_sceneTex_014750" Format="ia4" Width="64" Height="32" Offset="0x14750" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_014B50" OutName="spot01_sceneTex_014B50" Format="ci8" Width="32" Height="32" Offset="0x14B50" TlutOffset="0xA870" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_014F50" OutName="spot01_sceneTex_014F50" Format="ci8" Width="64" Height="16" Offset="0x14F50" TlutOffset="0xA870" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_015350" OutName="spot01_sceneTex_015350" Format="ia4" Width="64" Height="64" Offset="0x15350" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_017B50" OutName="spot01_sceneTex_017B50" Format="ci8" Width="32" Height="64" Offset="0x17B50" TlutOffset="0xA870" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_018350" OutName="spot01_sceneTex_018350" Format="i4" Width="64" Height="64" Offset="0x18350" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_018B50" OutName="spot01_sceneTex_018B50" Format="rgba16" Width="32" Height="32" Offset="0x18B50" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_019350" OutName="spot01_sceneTex_019350" Format="rgba16" Width="32" Height="32" Offset="0x19350" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_019B50" OutName="spot01_sceneTex_019B50" Format="ci8" Width="32" Height="32" Offset="0x19B50" TlutOffset="0xA870" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_019F50" OutName="spot01_sceneTex_019F50" Format="rgba16" Width="32" Height="32" Offset="0x19F50" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_01A750" OutName="spot01_sceneTex_01A750" Format="i4" Width="64" Height="64" Offset="0x1A750" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_01AF50" OutName="spot01_sceneTex_01AF50" Format="rgba16" Width="16" Height="64" Offset="0x1AF50" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_01B750" OutName="spot01_sceneTex_01B750" Format="rgba16" Width="32" Height="32" Offset="0x1B750" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_01BF50" OutName="spot01_sceneTex_01BF50" Format="ci8" Width="16" Height="32" Offset="0x1BF50" TlutOffset="0xA870" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTLUT_00A870" OutName="spot01_sceneTLUT_00A870" Format="rgba16" Width="16" Height="16" Offset="0xA870" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTLUT_00AA28" OutName="spot01_sceneTLUT_00AA28" Format="rgba16" Width="4" Height="4" Offset="0xAA28" AddedByScript="true"/>
         <Path Name="gKakarikoVillagePath_003D0" Offset="0x3D0" NumPaths="3"/>
         <Cutscene Name="gKakarikoVillageIntroCs" Offset="0xA540"/>
         <Texture Name="gKakarikoVillageDayWindowTex" OutName="day_window" Format="rgba16" Width="32" Height="64" Offset="0x15B50"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/overworld/spot02.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/overworld/spot02.xml
@@ -1,5 +1,16 @@
 <Root>
     <File Name="spot02_scene" Segment="2">
+        <Texture Name="spot02_sceneTex_007280" OutName="spot02_sceneTex_007280" Format="rgba16" Width="32" Height="32" Offset="0x7280" AddedByScript="true"/>
+        <Texture Name="spot02_sceneTex_007A80" OutName="spot02_sceneTex_007A80" Format="rgba16" Width="32" Height="16" Offset="0x7A80" AddedByScript="true"/>
+        <Texture Name="spot02_sceneTex_007E80" OutName="spot02_sceneTex_007E80" Format="rgba16" Width="32" Height="32" Offset="0x7E80" AddedByScript="true"/>
+        <Texture Name="spot02_sceneTex_008680" OutName="spot02_sceneTex_008680" Format="rgba16" Width="16" Height="64" Offset="0x8680" AddedByScript="true"/>
+        <Texture Name="spot02_sceneTex_008E80" OutName="spot02_sceneTex_008E80" Format="i8" Width="64" Height="64" Offset="0x8E80" AddedByScript="true"/>
+        <Texture Name="spot02_sceneTex_009E80" OutName="spot02_sceneTex_009E80" Format="ia4" Width="32" Height="64" Offset="0x9E80" AddedByScript="true"/>
+        <Texture Name="spot02_sceneTex_00A280" OutName="spot02_sceneTex_00A280" Format="rgba16" Width="32" Height="32" Offset="0xA280" AddedByScript="true"/>
+        <Texture Name="spot02_sceneTex_00AA80" OutName="spot02_sceneTex_00AA80" Format="rgba16" Width="32" Height="16" Offset="0xAA80" AddedByScript="true"/>
+        <Texture Name="spot02_sceneTex_00AE80" OutName="spot02_sceneTex_00AE80" Format="i4" Width="32" Height="32" Offset="0xAE80" AddedByScript="true"/>
+        <Texture Name="spot02_sceneTex_00B080" OutName="spot02_sceneTex_00B080" Format="rgba16" Width="32" Height="32" Offset="0xB080" AddedByScript="true"/>
+        <Texture Name="spot02_sceneTex_00B880" OutName="spot02_sceneTex_00B880" Format="rgba16" Width="16" Height="32" Offset="0xB880" AddedByScript="true"/>
         <Scene Name="spot02_scene" Offset="0x0"/>
 
         <Cutscene Name="spot02_scene_Cs_003C80" Offset="0x3C80"/>
@@ -12,6 +23,42 @@
         <Room Name="spot02_room_0" Offset="0x0"/>
     </File>
     <File Name="spot02_room_1" Segment="3">
+        <Texture Name="spot02_room_1Tex_008F08" OutName="spot02_room_1Tex_008F08" Format="rgba16" Width="32" Height="32" Offset="0x8F08" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_009708" OutName="spot02_room_1Tex_009708" Format="rgba16" Width="16" Height="16" Offset="0x9708" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_009908" OutName="spot02_room_1Tex_009908" Format="rgba16" Width="64" Height="32" Offset="0x9908" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_00A908" OutName="spot02_room_1Tex_00A908" Format="rgba16" Width="32" Height="32" Offset="0xA908" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_00B108" OutName="spot02_room_1Tex_00B108" Format="rgba16" Width="32" Height="64" Offset="0xB108" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_00C108" OutName="spot02_room_1Tex_00C108" Format="rgba16" Width="16" Height="32" Offset="0xC108" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_00C508" OutName="spot02_room_1Tex_00C508" Format="ci4" Width="64" Height="64" Offset="0xC508" TlutOffset="0x8EB8" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_00CD08" OutName="spot02_room_1Tex_00CD08" Format="rgba16" Width="64" Height="32" Offset="0xCD08" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_00DD08" OutName="spot02_room_1Tex_00DD08" Format="ia8" Width="32" Height="32" Offset="0xDD08" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_00E108" OutName="spot02_room_1Tex_00E108" Format="rgba16" Width="16" Height="16" Offset="0xE108" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_00E308" OutName="spot02_room_1Tex_00E308" Format="rgba16" Width="32" Height="32" Offset="0xE308" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_00EB08" OutName="spot02_room_1Tex_00EB08" Format="rgba16" Width="16" Height="64" Offset="0xEB08" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_00F308" OutName="spot02_room_1Tex_00F308" Format="rgba16" Width="32" Height="64" Offset="0xF308" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_010308" OutName="spot02_room_1Tex_010308" Format="rgba16" Width="32" Height="32" Offset="0x10308" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_010B08" OutName="spot02_room_1Tex_010B08" Format="rgba16" Width="16" Height="16" Offset="0x10B08" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_010D08" OutName="spot02_room_1Tex_010D08" Format="rgba16" Width="32" Height="32" Offset="0x10D08" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_011508" OutName="spot02_room_1Tex_011508" Format="ia8" Width="64" Height="64" Offset="0x11508" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_012508" OutName="spot02_room_1Tex_012508" Format="rgba16" Width="32" Height="32" Offset="0x12508" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_012D08" OutName="spot02_room_1Tex_012D08" Format="rgba16" Width="32" Height="32" Offset="0x12D08" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_013508" OutName="spot02_room_1Tex_013508" Format="rgba16" Width="32" Height="64" Offset="0x13508" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_014508" OutName="spot02_room_1Tex_014508" Format="ci4" Width="64" Height="64" Offset="0x14508" TlutOffset="0x8EE0" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_014D08" OutName="spot02_room_1Tex_014D08" Format="rgba16" Width="128" Height="16" Offset="0x14D08" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_015D08" OutName="spot02_room_1Tex_015D08" Format="i8" Width="64" Height="64" Offset="0x15D08" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_016D08" OutName="spot02_room_1Tex_016D08" Format="i4" Width="16" Height="16" Offset="0x16D08" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_016D88" OutName="spot02_room_1Tex_016D88" Format="rgba16" Width="32" Height="32" Offset="0x16D88" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_017588" OutName="spot02_room_1Tex_017588" Format="rgba16" Width="32" Height="16" Offset="0x17588" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_017988" OutName="spot02_room_1Tex_017988" Format="ia8" Width="128" Height="32" Offset="0x17988" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_018988" OutName="spot02_room_1Tex_018988" Format="rgba16" Width="32" Height="64" Offset="0x18988" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_01B690" OutName="spot02_room_1Tex_01B690" Format="ia8" Width="64" Height="32" Offset="0x1B690" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_01BE90" OutName="spot02_room_1Tex_01BE90" Format="ia8" Width="32" Height="32" Offset="0x1BE90" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_01C290" OutName="spot02_room_1Tex_01C290" Format="ia8" Width="32" Height="32" Offset="0x1C290" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_01C690" OutName="spot02_room_1Tex_01C690" Format="ia8" Width="16" Height="16" Offset="0x1C690" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_01C790" OutName="spot02_room_1Tex_01C790" Format="ia8" Width="64" Height="64" Offset="0x1C790" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_01D790" OutName="spot02_room_1Tex_01D790" Format="ia8" Width="32" Height="64" Offset="0x1D790" AddedByScript="true"/>
+        <Texture Name="spot02_room_1TLUT_008EB8" OutName="spot02_room_1TLUT_008EB8" Format="rgba16" Width="4" Height="4" Offset="0x8EB8" AddedByScript="true"/>
+        <Texture Name="spot02_room_1TLUT_008EE0" OutName="spot02_room_1TLUT_008EE0" Format="rgba16" Width="4" Height="4" Offset="0x8EE0" AddedByScript="true"/>
         <Room Name="spot02_room_1" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/overworld/spot03.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/overworld/spot03.xml
@@ -1,14 +1,40 @@
 <Root>
     <File Name="spot03_scene" Segment="2">
+        <Texture Name="spot03_sceneTex_006D58" OutName="spot03_sceneTex_006D58" Format="ci8" Width="16" Height="64" Offset="0x6D58" TlutOffset="0x6920" AddedByScript="true"/>
+        <Texture Name="spot03_sceneTex_007158" OutName="spot03_sceneTex_007158" Format="rgba16" Width="16" Height="32" Offset="0x7158" AddedByScript="true"/>
+        <Texture Name="spot03_sceneTex_007558" OutName="spot03_sceneTex_007558" Format="rgba16" Width="32" Height="16" Offset="0x7558" AddedByScript="true"/>
+        <Texture Name="spot03_sceneTex_007958" OutName="spot03_sceneTex_007958" Format="ci8" Width="32" Height="32" Offset="0x7958" TlutOffset="0x6B28" AddedByScript="true"/>
+        <Texture Name="spot03_sceneTex_007D58" OutName="spot03_sceneTex_007D58" Format="rgba16" Width="32" Height="32" Offset="0x7D58" AddedByScript="true"/>
+        <Texture Name="spot03_sceneTex_008558" OutName="spot03_sceneTex_008558" Format="ci8" Width="32" Height="64" Offset="0x8558" TlutOffset="0x6B28" AddedByScript="true"/>
+        <Texture Name="spot03_sceneTex_008D58" OutName="spot03_sceneTex_008D58" Format="rgba16" Width="32" Height="32" Offset="0x8D58" AddedByScript="true"/>
+        <Texture Name="spot03_sceneTex_009558" OutName="spot03_sceneTex_009558" Format="ci4" Width="64" Height="64" Offset="0x9558" TlutOffset="0x6D30" AddedByScript="true"/>
+        <Texture Name="spot03_sceneTex_009D58" OutName="spot03_sceneTex_009D58" Format="rgba16" Width="32" Height="32" Offset="0x9D58" AddedByScript="true"/>
+        <Texture Name="spot03_sceneTex_00A558" OutName="spot03_sceneTex_00A558" Format="rgba16" Width="32" Height="32" Offset="0xA558" AddedByScript="true"/>
+        <Texture Name="spot03_sceneTex_00AD58" OutName="spot03_sceneTex_00AD58" Format="ia4" Width="64" Height="64" Offset="0xAD58" AddedByScript="true"/>
+        <Texture Name="spot03_sceneTLUT_006920" OutName="spot03_sceneTLUT_006920" Format="rgba16" Width="16" Height="16" Offset="0x6920" AddedByScript="true"/>
+        <Texture Name="spot03_sceneTLUT_006B28" OutName="spot03_sceneTLUT_006B28" Format="rgba16" Width="16" Height="16" Offset="0x6B28" AddedByScript="true"/>
+        <Texture Name="spot03_sceneTLUT_006D30" OutName="spot03_sceneTLUT_006D30" Format="rgba16" Width="4" Height="4" Offset="0x6D30" AddedByScript="true"/>
         <Path Name="gSpot03Path_0002BC" Offset="0x2BC" NumPaths="2"/>
         <Path Name="gSpot03Path_006908" Offset="0x6908" NumPaths="3"/>
 
         <Scene Name="spot03_scene" Offset="0x0"/>
     </File>
     <File Name="spot03_room_0" Segment="3">
+        <Texture Name="spot03_room_0Tex_0097B0" OutName="spot03_room_0Tex_0097B0" Format="ci8" Width="32" Height="32" Offset="0x97B0" ExternalTlut="spot03_scene" ExternalTlutOffset="0x6B28" AddedByScript="true"/>
+        <Texture Name="spot03_room_0Tex_009BB0" OutName="spot03_room_0Tex_009BB0" Format="ci8" Width="32" Height="64" Offset="0x9BB0" ExternalTlut="spot03_scene" ExternalTlutOffset="0x6B28" AddedByScript="true"/>
+        <Texture Name="spot03_room_0Tex_00A3B0" OutName="spot03_room_0Tex_00A3B0" Format="rgba16" Width="16" Height="64" Offset="0xA3B0" AddedByScript="true"/>
+        <Texture Name="spot03_room_0Tex_00ABB0" OutName="spot03_room_0Tex_00ABB0" Format="rgba16" Width="64" Height="32" Offset="0xABB0" AddedByScript="true"/>
+        <Texture Name="spot03_room_0Tex_00BBB0" OutName="spot03_room_0Tex_00BBB0" Format="ci8" Width="32" Height="32" Offset="0xBBB0" ExternalTlut="spot03_scene" ExternalTlutOffset="0x6B28" AddedByScript="true"/>
+        <Texture Name="spot03_room_0Tex_00BFB0" OutName="spot03_room_0Tex_00BFB0" Format="ci8" Width="32" Height="32" Offset="0xBFB0" ExternalTlut="spot03_scene" ExternalTlutOffset="0x6B28" AddedByScript="true"/>
+        <Texture Name="spot03_room_0Tex_00D180" OutName="spot03_room_0Tex_00D180" Format="i4" Width="64" Height="64" Offset="0xD180" AddedByScript="true"/>
         <Room Name="spot03_room_0" Offset="0x0"/>
     </File>
     <File Name="spot03_room_1" Segment="3">
+        <Texture Name="spot03_room_1Tex_0050D8" OutName="spot03_room_1Tex_0050D8" Format="ci8" Width="64" Height="32" Offset="0x50D8" ExternalTlut="spot03_scene" ExternalTlutOffset="0x6920" AddedByScript="true"/>
+        <Texture Name="spot03_room_1Tex_0058D8" OutName="spot03_room_1Tex_0058D8" Format="ci8" Width="64" Height="16" Offset="0x58D8" ExternalTlut="spot03_scene" ExternalTlutOffset="0x6920" AddedByScript="true"/>
+        <Texture Name="spot03_room_1Tex_005CD8" OutName="spot03_room_1Tex_005CD8" Format="ci8" Width="32" Height="16" Offset="0x5CD8" ExternalTlut="spot03_scene" ExternalTlutOffset="0x6920" AddedByScript="true"/>
+        <Texture Name="spot03_room_1Tex_005ED8" OutName="spot03_room_1Tex_005ED8" Format="ci8" Width="16" Height="64" Offset="0x5ED8" ExternalTlut="spot03_scene" ExternalTlutOffset="0x6920" AddedByScript="true"/>
+        <Texture Name="spot03_room_1Tex_0062D8" OutName="spot03_room_1Tex_0062D8" Format="ci8" Width="64" Height="32" Offset="0x62D8" ExternalTlut="spot03_scene" ExternalTlutOffset="0x6920" AddedByScript="true"/>
         <DList Name="gSpot03DL_0074E8" Offset="0x74E8"/>
         <Room Name="spot03_room_1" Offset="0x0"/>
     </File>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/overworld/spot04.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/overworld/spot04.xml
@@ -1,5 +1,12 @@
 <Root>
     <File Name="spot04_scene" Segment="2">
+        <Texture Name="spot04_sceneTex_00E218" OutName="spot04_sceneTex_00E218" Format="rgba16" Width="32" Height="32" Offset="0xE218" AddedByScript="true"/>
+        <Texture Name="spot04_sceneTex_00EA18" OutName="spot04_sceneTex_00EA18" Format="i4" Width="64" Height="64" Offset="0xEA18" AddedByScript="true"/>
+        <Texture Name="spot04_sceneTex_00F218" OutName="spot04_sceneTex_00F218" Format="i4" Width="64" Height="64" Offset="0xF218" AddedByScript="true"/>
+        <Texture Name="spot04_sceneTex_00FA18" OutName="spot04_sceneTex_00FA18" Format="ci8" Width="32" Height="32" Offset="0xFA18" TlutOffset="0xE010" AddedByScript="true"/>
+        <Texture Name="spot04_sceneTex_00FE18" OutName="spot04_sceneTex_00FE18" Format="rgba16" Width="32" Height="32" Offset="0xFE18" AddedByScript="true"/>
+        <Texture Name="spot04_sceneTex_010618" OutName="spot04_sceneTex_010618" Format="rgba16" Width="32" Height="32" Offset="0x10618" AddedByScript="true"/>
+        <Texture Name="spot04_sceneTLUT_00E010" OutName="spot04_sceneTLUT_00E010" Format="rgba16" Width="16" Height="16" Offset="0xE010" AddedByScript="true"/>
         <Path Name="gSpot04Path_00030C" Offset="0x30C" NumPaths="3"/>
         <Path Name="gSpot04Path_00D730" Offset="0xD730"/>
         <Cutscene Name="gKokiriForestDekuSproutCs" Offset="0xC9D0"/>
@@ -8,12 +15,65 @@
         <Scene Name="spot04_scene" Offset="0x0"/>
     </File>
     <File Name="spot04_room_0" Segment="3">
+        <Texture Name="spot04_room_0Tex_00BF08" OutName="spot04_room_0Tex_00BF08" Format="rgba16" Width="32" Height="32" Offset="0xBF08" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_00C708" OutName="spot04_room_0Tex_00C708" Format="rgba16" Width="32" Height="16" Offset="0xC708" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_00CB08" OutName="spot04_room_0Tex_00CB08" Format="rgba16" Width="32" Height="16" Offset="0xCB08" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_00CF08" OutName="spot04_room_0Tex_00CF08" Format="ci8" Width="32" Height="32" Offset="0xCF08" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE010" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_00D308" OutName="spot04_room_0Tex_00D308" Format="ci8" Width="16" Height="16" Offset="0xD308" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE010" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_00D408" OutName="spot04_room_0Tex_00D408" Format="ci8" Width="16" Height="16" Offset="0xD408" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE010" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_00D508" OutName="spot04_room_0Tex_00D508" Format="rgba16" Width="16" Height="32" Offset="0xD508" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_00D908" OutName="spot04_room_0Tex_00D908" Format="rgba16" Width="16" Height="64" Offset="0xD908" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_00E108" OutName="spot04_room_0Tex_00E108" Format="rgba16" Width="32" Height="32" Offset="0xE108" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_00E908" OutName="spot04_room_0Tex_00E908" Format="rgba16" Width="32" Height="32" Offset="0xE908" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_00F108" OutName="spot04_room_0Tex_00F108" Format="rgba16" Width="64" Height="8" Offset="0xF108" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_00F508" OutName="spot04_room_0Tex_00F508" Format="rgba16" Width="32" Height="32" Offset="0xF508" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_00FD08" OutName="spot04_room_0Tex_00FD08" Format="rgba16" Width="32" Height="64" Offset="0xFD08" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_010D08" OutName="spot04_room_0Tex_010D08" Format="rgba16" Width="32" Height="64" Offset="0x10D08" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_011D08" OutName="spot04_room_0Tex_011D08" Format="ci8" Width="16" Height="32" Offset="0x11D08" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE010" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_011F08" OutName="spot04_room_0Tex_011F08" Format="rgba16" Width="64" Height="32" Offset="0x11F08" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_012F08" OutName="spot04_room_0Tex_012F08" Format="ci8" Width="32" Height="16" Offset="0x12F08" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE010" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_013108" OutName="spot04_room_0Tex_013108" Format="ci8" Width="32" Height="16" Offset="0x13108" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE010" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_013308" OutName="spot04_room_0Tex_013308" Format="rgba16" Width="16" Height="32" Offset="0x13308" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_013708" OutName="spot04_room_0Tex_013708" Format="rgba16" Width="32" Height="32" Offset="0x13708" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_013F08" OutName="spot04_room_0Tex_013F08" Format="ci8" Width="32" Height="32" Offset="0x13F08" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE010" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_014308" OutName="spot04_room_0Tex_014308" Format="rgba16" Width="32" Height="32" Offset="0x14308" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_014B08" OutName="spot04_room_0Tex_014B08" Format="rgba16" Width="32" Height="32" Offset="0x14B08" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_015308" OutName="spot04_room_0Tex_015308" Format="rgba16" Width="64" Height="16" Offset="0x15308" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_015B08" OutName="spot04_room_0Tex_015B08" Format="ci8" Width="16" Height="32" Offset="0x15B08" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE010" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_015D08" OutName="spot04_room_0Tex_015D08" Format="ci8" Width="16" Height="64" Offset="0x15D08" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE010" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_016108" OutName="spot04_room_0Tex_016108" Format="ci8" Width="16" Height="64" Offset="0x16108" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE010" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_016508" OutName="spot04_room_0Tex_016508" Format="ci8" Width="32" Height="32" Offset="0x16508" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE010" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_016908" OutName="spot04_room_0Tex_016908" Format="ci8" Width="16" Height="64" Offset="0x16908" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE010" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_016D08" OutName="spot04_room_0Tex_016D08" Format="rgba16" Width="32" Height="16" Offset="0x16D08" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_017108" OutName="spot04_room_0Tex_017108" Format="rgba16" Width="32" Height="32" Offset="0x17108" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_018A90" OutName="spot04_room_0Tex_018A90" Format="rgba16" Width="32" Height="32" Offset="0x18A90" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_019290" OutName="spot04_room_0Tex_019290" Format="i4" Width="64" Height="64" Offset="0x19290" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_019A90" OutName="spot04_room_0Tex_019A90" Format="i4" Width="64" Height="64" Offset="0x19A90" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_01A290" OutName="spot04_room_0Tex_01A290" Format="ia8" Width="16" Height="32" Offset="0x1A290" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_01A490" OutName="spot04_room_0Tex_01A490" Format="ia4" Width="64" Height="64" Offset="0x1A490" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_01AC90" OutName="spot04_room_0Tex_01AC90" Format="ia4" Width="32" Height="32" Offset="0x1AC90" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_01AE90" OutName="spot04_room_0Tex_01AE90" Format="ia4" Width="32" Height="32" Offset="0x1AE90" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_01B090" OutName="spot04_room_0Tex_01B090" Format="rgba16" Width="16" Height="32" Offset="0x1B090" AddedByScript="true"/>
         <Room Name="spot04_room_0" Offset="0x0"/>
     </File>
     <File Name="spot04_room_1" Segment="3">
+        <Texture Name="spot04_room_1Tex_004EA8" OutName="spot04_room_1Tex_004EA8" Format="rgba16" Width="32" Height="16" Offset="0x4EA8" AddedByScript="true"/>
+        <Texture Name="spot04_room_1Tex_0052A8" OutName="spot04_room_1Tex_0052A8" Format="rgba16" Width="32" Height="16" Offset="0x52A8" AddedByScript="true"/>
+        <Texture Name="spot04_room_1Tex_0056A8" OutName="spot04_room_1Tex_0056A8" Format="rgba16" Width="64" Height="32" Offset="0x56A8" AddedByScript="true"/>
+        <Texture Name="spot04_room_1Tex_0066A8" OutName="spot04_room_1Tex_0066A8" Format="rgba16" Width="32" Height="32" Offset="0x66A8" AddedByScript="true"/>
+        <Texture Name="spot04_room_1Tex_006EA8" OutName="spot04_room_1Tex_006EA8" Format="rgba16" Width="32" Height="32" Offset="0x6EA8" AddedByScript="true"/>
+        <Texture Name="spot04_room_1Tex_007B78" OutName="spot04_room_1Tex_007B78" Format="ia8" Width="16" Height="32" Offset="0x7B78" AddedByScript="true"/>
+        <Texture Name="spot04_room_1Tex_007D78" OutName="spot04_room_1Tex_007D78" Format="i4" Width="64" Height="64" Offset="0x7D78" AddedByScript="true"/>
         <Room Name="spot04_room_1" Offset="0x0"/>
     </File>
     <File Name="spot04_room_2" Segment="3">
+        <Texture Name="spot04_room_2Tex_002BF8" OutName="spot04_room_2Tex_002BF8" Format="ci8" Width="32" Height="16" Offset="0x2BF8" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE010" AddedByScript="true"/>
+        <Texture Name="spot04_room_2Tex_002DF8" OutName="spot04_room_2Tex_002DF8" Format="ci8" Width="32" Height="16" Offset="0x2DF8" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE010" AddedByScript="true"/>
+        <Texture Name="spot04_room_2Tex_002FF8" OutName="spot04_room_2Tex_002FF8" Format="ci8" Width="32" Height="32" Offset="0x2FF8" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE010" AddedByScript="true"/>
+        <Texture Name="spot04_room_2Tex_0033F8" OutName="spot04_room_2Tex_0033F8" Format="rgba16" Width="32" Height="32" Offset="0x33F8" AddedByScript="true"/>
+        <Texture Name="spot04_room_2Tex_003BF8" OutName="spot04_room_2Tex_003BF8" Format="rgba16" Width="64" Height="16" Offset="0x3BF8" AddedByScript="true"/>
+        <Texture Name="spot04_room_2Tex_0043F8" OutName="spot04_room_2Tex_0043F8" Format="ci8" Width="16" Height="32" Offset="0x43F8" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE010" AddedByScript="true"/>
+        <Texture Name="spot04_room_2Tex_0045F8" OutName="spot04_room_2Tex_0045F8" Format="rgba16" Width="32" Height="32" Offset="0x45F8" AddedByScript="true"/>
         <DList Name="gSpot04DL_002BB8" Offset="0x2BB8"/>
         <DList Name="gSpot04DL_005058" Offset="0x5058"/>
         <Room Name="spot04_room_2" Offset="0x0"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/overworld/spot05.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/overworld/spot05.xml
@@ -1,5 +1,32 @@
 <Root>
     <File Name="spot05_scene" Segment="2">
+        <Texture Name="spot05_sceneTex_006D60" OutName="spot05_sceneTex_006D60" Format="rgba16" Width="32" Height="64" Offset="0x6D60" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_007D60" OutName="spot05_sceneTex_007D60" Format="rgba16" Width="32" Height="64" Offset="0x7D60" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_008D60" OutName="spot05_sceneTex_008D60" Format="ci8" Width="32" Height="32" Offset="0x8D60" TlutOffset="0x6BC0" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_009160" OutName="spot05_sceneTex_009160" Format="ci8" Width="32" Height="32" Offset="0x9160" TlutOffset="0x6BC0" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_009560" OutName="spot05_sceneTex_009560" Format="rgba16" Width="16" Height="32" Offset="0x9560" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_009960" OutName="spot05_sceneTex_009960" Format="ci8" Width="64" Height="32" Offset="0x9960" TlutOffset="0x6BC0" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_00A160" OutName="spot05_sceneTex_00A160" Format="rgba16" Width="64" Height="32" Offset="0xA160" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_00B160" OutName="spot05_sceneTex_00B160" Format="rgba16" Width="32" Height="32" Offset="0xB160" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_00B960" OutName="spot05_sceneTex_00B960" Format="rgba16" Width="16" Height="16" Offset="0xB960" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_00BB60" OutName="spot05_sceneTex_00BB60" Format="rgba16" Width="16" Height="128" Offset="0xBB60" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_00CB60" OutName="spot05_sceneTex_00CB60" Format="rgba16" Width="32" Height="32" Offset="0xCB60" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_00D360" OutName="spot05_sceneTex_00D360" Format="i4" Width="64" Height="64" Offset="0xD360" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_00DB60" OutName="spot05_sceneTex_00DB60" Format="rgba16" Width="32" Height="32" Offset="0xDB60" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_00E360" OutName="spot05_sceneTex_00E360" Format="i4" Width="64" Height="64" Offset="0xE360" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_00EB60" OutName="spot05_sceneTex_00EB60" Format="rgba16" Width="64" Height="16" Offset="0xEB60" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_00F360" OutName="spot05_sceneTex_00F360" Format="rgba16" Width="32" Height="32" Offset="0xF360" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_00FB60" OutName="spot05_sceneTex_00FB60" Format="i4" Width="64" Height="64" Offset="0xFB60" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_010360" OutName="spot05_sceneTex_010360" Format="rgba16" Width="32" Height="32" Offset="0x10360" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_010B60" OutName="spot05_sceneTex_010B60" Format="rgba16" Width="32" Height="32" Offset="0x10B60" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_011360" OutName="spot05_sceneTex_011360" Format="rgba16" Width="32" Height="64" Offset="0x11360" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_012360" OutName="spot05_sceneTex_012360" Format="rgba16" Width="32" Height="32" Offset="0x12360" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_012B60" OutName="spot05_sceneTex_012B60" Format="rgba16" Width="32" Height="32" Offset="0x12B60" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_013360" OutName="spot05_sceneTex_013360" Format="rgba16" Width="32" Height="32" Offset="0x13360" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_013B60" OutName="spot05_sceneTex_013B60" Format="rgba16" Width="64" Height="16" Offset="0x13B60" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_014360" OutName="spot05_sceneTex_014360" Format="rgba16" Width="32" Height="32" Offset="0x14360" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_014B60" OutName="spot05_sceneTex_014B60" Format="ia8" Width="16" Height="32" Offset="0x14B60" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTLUT_006BC0" OutName="spot05_sceneTLUT_006BC0" Format="rgba16" Width="16" Height="16" Offset="0x6BC0" AddedByScript="true"/>
         <Cutscene Name="gMinuetCs" Offset="0x3F80"/>
 
         <Cutscene Name="spot05_scene_Cs_005730" Offset="0x5730"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/overworld/spot06.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/overworld/spot06.xml
@@ -1,5 +1,48 @@
 <Root>
     <File Name="spot06_scene" Segment="2">
+        <Texture Name="spot06_sceneTex_007C38" OutName="spot06_sceneTex_007C38" Format="rgba16" Width="16" Height="32" Offset="0x7C38" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_008038" OutName="spot06_sceneTex_008038" Format="rgba16" Width="16" Height="32" Offset="0x8038" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_008438" OutName="spot06_sceneTex_008438" Format="rgba16" Width="16" Height="32" Offset="0x8438" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_008838" OutName="spot06_sceneTex_008838" Format="rgba16" Width="32" Height="64" Offset="0x8838" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_009838" OutName="spot06_sceneTex_009838" Format="rgba16" Width="8" Height="8" Offset="0x9838" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_0098B8" OutName="spot06_sceneTex_0098B8" Format="rgba16" Width="8" Height="32" Offset="0x98B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_009AB8" OutName="spot06_sceneTex_009AB8" Format="rgba16" Width="32" Height="64" Offset="0x9AB8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_00AAB8" OutName="spot06_sceneTex_00AAB8" Format="rgba16" Width="32" Height="16" Offset="0xAAB8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_00AEB8" OutName="spot06_sceneTex_00AEB8" Format="rgba16" Width="32" Height="32" Offset="0xAEB8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_00B6B8" OutName="spot06_sceneTex_00B6B8" Format="rgba16" Width="16" Height="32" Offset="0xB6B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_00BAB8" OutName="spot06_sceneTex_00BAB8" Format="ia8" Width="32" Height="32" Offset="0xBAB8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_00BEB8" OutName="spot06_sceneTex_00BEB8" Format="rgba16" Width="32" Height="16" Offset="0xBEB8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_00C2B8" OutName="spot06_sceneTex_00C2B8" Format="rgba16" Width="16" Height="16" Offset="0xC2B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_00C4B8" OutName="spot06_sceneTex_00C4B8" Format="rgba16" Width="32" Height="32" Offset="0xC4B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_00CCB8" OutName="spot06_sceneTex_00CCB8" Format="rgba16" Width="32" Height="64" Offset="0xCCB8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_00DCB8" OutName="spot06_sceneTex_00DCB8" Format="rgba16" Width="32" Height="64" Offset="0xDCB8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_00ECB8" OutName="spot06_sceneTex_00ECB8" Format="rgba16" Width="16" Height="64" Offset="0xECB8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_00F4B8" OutName="spot06_sceneTex_00F4B8" Format="rgba16" Width="16" Height="16" Offset="0xF4B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_00F6B8" OutName="spot06_sceneTex_00F6B8" Format="rgba16" Width="32" Height="32" Offset="0xF6B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_00FEB8" OutName="spot06_sceneTex_00FEB8" Format="rgba16" Width="32" Height="64" Offset="0xFEB8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_010EB8" OutName="spot06_sceneTex_010EB8" Format="rgba16" Width="32" Height="32" Offset="0x10EB8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_0116B8" OutName="spot06_sceneTex_0116B8" Format="rgba16" Width="32" Height="32" Offset="0x116B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_011EB8" OutName="spot06_sceneTex_011EB8" Format="rgba16" Width="16" Height="32" Offset="0x11EB8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_0122B8" OutName="spot06_sceneTex_0122B8" Format="rgba16" Width="32" Height="16" Offset="0x122B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_0126B8" OutName="spot06_sceneTex_0126B8" Format="rgba16" Width="32" Height="32" Offset="0x126B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_012EB8" OutName="spot06_sceneTex_012EB8" Format="rgba16" Width="8" Height="32" Offset="0x12EB8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_0130B8" OutName="spot06_sceneTex_0130B8" Format="rgba16" Width="32" Height="64" Offset="0x130B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_0140B8" OutName="spot06_sceneTex_0140B8" Format="rgba16" Width="16" Height="64" Offset="0x140B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_0148B8" OutName="spot06_sceneTex_0148B8" Format="rgba16" Width="16" Height="32" Offset="0x148B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_014CB8" OutName="spot06_sceneTex_014CB8" Format="rgba16" Width="32" Height="32" Offset="0x14CB8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_0154B8" OutName="spot06_sceneTex_0154B8" Format="rgba16" Width="16" Height="64" Offset="0x154B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_015CB8" OutName="spot06_sceneTex_015CB8" Format="rgba16" Width="16" Height="64" Offset="0x15CB8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_0164B8" OutName="spot06_sceneTex_0164B8" Format="rgba16" Width="32" Height="32" Offset="0x164B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_016CB8" OutName="spot06_sceneTex_016CB8" Format="rgba16" Width="16" Height="32" Offset="0x16CB8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_0170B8" OutName="spot06_sceneTex_0170B8" Format="rgba16" Width="32" Height="32" Offset="0x170B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_0178B8" OutName="spot06_sceneTex_0178B8" Format="rgba16" Width="16" Height="32" Offset="0x178B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_017CB8" OutName="spot06_sceneTex_017CB8" Format="ci4" Width="64" Height="64" Offset="0x17CB8" TlutOffset="0x7C10" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_0184B8" OutName="spot06_sceneTex_0184B8" Format="rgba16" Width="32" Height="32" Offset="0x184B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_018CB8" OutName="spot06_sceneTex_018CB8" Format="rgba16" Width="32" Height="32" Offset="0x18CB8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_0194B8" OutName="spot06_sceneTex_0194B8" Format="rgba16" Width="16" Height="128" Offset="0x194B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_01A4B8" OutName="spot06_sceneTex_01A4B8" Format="i4" Width="64" Height="64" Offset="0x1A4B8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_01ACB8" OutName="spot06_sceneTex_01ACB8" Format="rgba16" Width="16" Height="32" Offset="0x1ACB8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTLUT_007C10" OutName="spot06_sceneTLUT_007C10" Format="rgba16" Width="4" Height="4" Offset="0x7C10" AddedByScript="true"/>
         <Cutscene Name="gLakeHyliaFireArrowsCS" Offset="0x7020"/>
         <Cutscene Name="gLakeHyliaOwlCs" Offset="0x1B0C0"/>
         <Path Name="gSpot06Path_007764" Offset="0x7764" NumPaths="2"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/overworld/spot07.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/overworld/spot07.xml
@@ -1,5 +1,22 @@
 <Root>
     <File Name="spot07_scene" Segment="2">
+        <Texture Name="spot07_sceneTex_003F98" OutName="spot07_sceneTex_003F98" Format="rgba16" Width="32" Height="64" Offset="0x3F98" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_004F98" OutName="spot07_sceneTex_004F98" Format="ci4" Width="64" Height="32" Offset="0x4F98" TlutOffset="0x3F70" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_005398" OutName="spot07_sceneTex_005398" Format="ci4" Width="64" Height="32" Offset="0x5398" TlutOffset="0x3F70" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_005798" OutName="spot07_sceneTex_005798" Format="ci4" Width="64" Height="32" Offset="0x5798" TlutOffset="0x3F70" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_005B98" OutName="spot07_sceneTex_005B98" Format="ci4" Width="64" Height="32" Offset="0x5B98" TlutOffset="0x3F70" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_005F98" OutName="spot07_sceneTex_005F98" Format="ci4" Width="64" Height="32" Offset="0x5F98" TlutOffset="0x3F70" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_006398" OutName="spot07_sceneTex_006398" Format="ci4" Width="64" Height="32" Offset="0x6398" TlutOffset="0x3F70" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_006798" OutName="spot07_sceneTex_006798" Format="ci4" Width="64" Height="32" Offset="0x6798" TlutOffset="0x3F70" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_006B98" OutName="spot07_sceneTex_006B98" Format="ci4" Width="64" Height="32" Offset="0x6B98" TlutOffset="0x3F70" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_006F98" OutName="spot07_sceneTex_006F98" Format="rgba16" Width="32" Height="32" Offset="0x6F98" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_007798" OutName="spot07_sceneTex_007798" Format="ci4" Width="64" Height="32" Offset="0x7798" TlutOffset="0x3F70" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_007B98" OutName="spot07_sceneTex_007B98" Format="ci4" Width="64" Height="32" Offset="0x7B98" TlutOffset="0x3F70" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_007F98" OutName="spot07_sceneTex_007F98" Format="rgba16" Width="32" Height="32" Offset="0x7F98" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_008798" OutName="spot07_sceneTex_008798" Format="ia4" Width="64" Height="64" Offset="0x8798" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_009018" OutName="spot07_sceneTex_009018" Format="ci4" Width="64" Height="32" Offset="0x9018" TlutOffset="0x3F70" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_009418" OutName="spot07_sceneTex_009418" Format="ci4" Width="64" Height="32" Offset="0x9418" TlutOffset="0x3F70" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTLUT_003F70" OutName="spot07_sceneTLUT_003F70" Format="rgba16" Width="4" Height="4" Offset="0x3F70" AddedByScript="true"/>
         <Path Name="gZorasDomainPath_0234" Offset="0x234" NumPaths="3"/>
         <Cutscene Name="gZorasDomainIntroCs" Offset="0x3D70"/>
         <Texture Name="gZorasDomainDayEntranceTex" OutName="day_entrance" Format="ia8" Width="8" Height="8" Offset="0x8F98"/>
@@ -7,9 +24,24 @@
         <Scene Name="spot07_scene" Offset="0x0"/>
     </File>
     <File Name="spot07_room_0" Segment="3">
+        <Texture Name="spot07_room_0Tex_004748" OutName="spot07_room_0Tex_004748" Format="rgba16" Width="64" Height="16" Offset="0x4748" AddedByScript="true"/>
+        <Texture Name="spot07_room_0Tex_004F48" OutName="spot07_room_0Tex_004F48" Format="rgba16" Width="64" Height="16" Offset="0x4F48" AddedByScript="true"/>
+        <Texture Name="spot07_room_0Tex_005748" OutName="spot07_room_0Tex_005748" Format="rgba16" Width="16" Height="64" Offset="0x5748" AddedByScript="true"/>
         <Room Name="spot07_room_0" Offset="0x0"/>
     </File>
     <File Name="spot07_room_1" Segment="3">
+        <Texture Name="spot07_room_1Tex_0076D8" OutName="spot07_room_1Tex_0076D8" Format="rgba16" Width="32" Height="32" Offset="0x76D8" AddedByScript="true"/>
+        <Texture Name="spot07_room_1Tex_007ED8" OutName="spot07_room_1Tex_007ED8" Format="rgba16" Width="16" Height="64" Offset="0x7ED8" AddedByScript="true"/>
+        <Texture Name="spot07_room_1Tex_0086D8" OutName="spot07_room_1Tex_0086D8" Format="ci4" Width="64" Height="32" Offset="0x86D8" ExternalTlut="spot07_scene" ExternalTlutOffset="0x3F70" AddedByScript="true"/>
+        <Texture Name="spot07_room_1Tex_008AD8" OutName="spot07_room_1Tex_008AD8" Format="ci4" Width="32" Height="16" Offset="0x8AD8" ExternalTlut="spot07_scene" ExternalTlutOffset="0x3F70" AddedByScript="true"/>
+        <Texture Name="spot07_room_1Tex_008BD8" OutName="spot07_room_1Tex_008BD8" Format="ci4" Width="64" Height="32" Offset="0x8BD8" ExternalTlut="spot07_scene" ExternalTlutOffset="0x3F70" AddedByScript="true"/>
+        <Texture Name="spot07_room_1Tex_008FD8" OutName="spot07_room_1Tex_008FD8" Format="ci4" Width="64" Height="32" Offset="0x8FD8" ExternalTlut="spot07_scene" ExternalTlutOffset="0x3F70" AddedByScript="true"/>
+        <Texture Name="spot07_room_1Tex_0093D8" OutName="spot07_room_1Tex_0093D8" Format="ci4" Width="64" Height="32" Offset="0x93D8" ExternalTlut="spot07_scene" ExternalTlutOffset="0x3F70" AddedByScript="true"/>
+        <Texture Name="spot07_room_1Tex_0097D8" OutName="spot07_room_1Tex_0097D8" Format="ci4" Width="64" Height="32" Offset="0x97D8" ExternalTlut="spot07_scene" ExternalTlutOffset="0x3F70" AddedByScript="true"/>
+        <Texture Name="spot07_room_1Tex_009BD8" OutName="spot07_room_1Tex_009BD8" Format="rgba16" Width="32" Height="32" Offset="0x9BD8" AddedByScript="true"/>
+        <Texture Name="spot07_room_1Tex_00A3D8" OutName="spot07_room_1Tex_00A3D8" Format="rgba16" Width="32" Height="32" Offset="0xA3D8" AddedByScript="true"/>
+        <Texture Name="spot07_room_1Tex_00ABD8" OutName="spot07_room_1Tex_00ABD8" Format="rgba16" Width="16" Height="128" Offset="0xABD8" AddedByScript="true"/>
+        <Texture Name="spot07_room_1Tex_00C1A0" OutName="spot07_room_1Tex_00C1A0" Format="rgba16" Width="64" Height="16" Offset="0xC1A0" AddedByScript="true"/>
         <Room Name="spot07_room_1" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/overworld/spot08.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/overworld/spot08.xml
@@ -1,5 +1,32 @@
 <Root>
     <File Name="spot08_scene" Segment="2">
+        <Texture Name="spot08_sceneTex_004DA0" OutName="spot08_sceneTex_004DA0" Format="rgba16" Width="64" Height="32" Offset="0x4DA0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_005DA0" OutName="spot08_sceneTex_005DA0" Format="rgba16" Width="32" Height="16" Offset="0x5DA0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_0061A0" OutName="spot08_sceneTex_0061A0" Format="rgba16" Width="32" Height="32" Offset="0x61A0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_0069A0" OutName="spot08_sceneTex_0069A0" Format="rgba16" Width="32" Height="32" Offset="0x69A0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_0071A0" OutName="spot08_sceneTex_0071A0" Format="ia4" Width="256" Height="32" Offset="0x71A0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_0081A0" OutName="spot08_sceneTex_0081A0" Format="ci4" Width="128" Height="32" Offset="0x81A0" TlutOffset="0x4CC0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_0089A0" OutName="spot08_sceneTex_0089A0" Format="rgba16" Width="32" Height="32" Offset="0x89A0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_0091A0" OutName="spot08_sceneTex_0091A0" Format="rgba16" Width="16" Height="128" Offset="0x91A0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_00A1A0" OutName="spot08_sceneTex_00A1A0" Format="ci4" Width="128" Height="32" Offset="0xA1A0" TlutOffset="0x4CE8" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_00A9A0" OutName="spot08_sceneTex_00A9A0" Format="ci4" Width="64" Height="64" Offset="0xA9A0" TlutOffset="0x4D38" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_00B1A0" OutName="spot08_sceneTex_00B1A0" Format="ci4" Width="64" Height="64" Offset="0xB1A0" TlutOffset="0x4D10" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_00B9A0" OutName="spot08_sceneTex_00B9A0" Format="ci4" Width="64" Height="64" Offset="0xB9A0" TlutOffset="0x4D38" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_00C1A0" OutName="spot08_sceneTex_00C1A0" Format="rgba16" Width="64" Height="32" Offset="0xC1A0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_00D1A0" OutName="spot08_sceneTex_00D1A0" Format="i8" Width="64" Height="64" Offset="0xD1A0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_00E1A0" OutName="spot08_sceneTex_00E1A0" Format="rgba16" Width="32" Height="64" Offset="0xE1A0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_00F1A0" OutName="spot08_sceneTex_00F1A0" Format="ci4" Width="32" Height="128" Offset="0xF1A0" TlutOffset="0x4D60" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_00F9A0" OutName="spot08_sceneTex_00F9A0" Format="ci4" Width="64" Height="64" Offset="0xF9A0" TlutOffset="0x4D80" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_0101A0" OutName="spot08_sceneTex_0101A0" Format="i4" Width="64" Height="64" Offset="0x101A0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_0109A0" OutName="spot08_sceneTex_0109A0" Format="ia8" Width="16" Height="16" Offset="0x109A0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_010AA0" OutName="spot08_sceneTex_010AA0" Format="rgba16" Width="16" Height="32" Offset="0x10AA0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_010EA0" OutName="spot08_sceneTex_010EA0" Format="rgba16" Width="32" Height="32" Offset="0x10EA0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTLUT_004CC0" OutName="spot08_sceneTLUT_004CC0" Format="rgba16" Width="4" Height="4" Offset="0x4CC0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTLUT_004CE8" OutName="spot08_sceneTLUT_004CE8" Format="rgba16" Width="4" Height="4" Offset="0x4CE8" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTLUT_004D10" OutName="spot08_sceneTLUT_004D10" Format="rgba16" Width="4" Height="4" Offset="0x4D10" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTLUT_004D38" OutName="spot08_sceneTLUT_004D38" Format="rgba16" Width="4" Height="4" Offset="0x4D38" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTLUT_004D60" OutName="spot08_sceneTLUT_004D60" Format="rgba16" Width="4" Height="4" Offset="0x4D60" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTLUT_004D80" OutName="spot08_sceneTLUT_004D80" Format="rgba16" Width="4" Height="4" Offset="0x4D80" AddedByScript="true"/>
         <Cutscene Name="gZorasFountainIntroCs" Offset="0x4A80"/>
         <Scene Name="spot08_scene" Offset="0x0"/>
     </File>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/overworld/spot09.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/overworld/spot09.xml
@@ -1,5 +1,26 @@
 <Root>
     <File Name="spot09_scene" Segment="2">
+        <Texture Name="spot09_sceneTex_003460" OutName="spot09_sceneTex_003460" Format="rgba16" Width="32" Height="64" Offset="0x3460" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_004460" OutName="spot09_sceneTex_004460" Format="rgba16" Width="64" Height="32" Offset="0x4460" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_005460" OutName="spot09_sceneTex_005460" Format="ci4" Width="32" Height="128" Offset="0x5460" TlutOffset="0x3440" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_005C60" OutName="spot09_sceneTex_005C60" Format="rgba16" Width="32" Height="32" Offset="0x5C60" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_006460" OutName="spot09_sceneTex_006460" Format="rgba16" Width="32" Height="32" Offset="0x6460" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_006C60" OutName="spot09_sceneTex_006C60" Format="i8" Width="16" Height="16" Offset="0x6C60" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_006D60" OutName="spot09_sceneTex_006D60" Format="rgba16" Width="16" Height="32" Offset="0x6D60" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_007160" OutName="spot09_sceneTex_007160" Format="rgba16" Width="64" Height="32" Offset="0x7160" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_008160" OutName="spot09_sceneTex_008160" Format="rgba16" Width="64" Height="32" Offset="0x8160" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_009160" OutName="spot09_sceneTex_009160" Format="rgba16" Width="32" Height="64" Offset="0x9160" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_00A160" OutName="spot09_sceneTex_00A160" Format="rgba16" Width="32" Height="32" Offset="0xA160" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_00A960" OutName="spot09_sceneTex_00A960" Format="rgba16" Width="32" Height="64" Offset="0xA960" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_00B960" OutName="spot09_sceneTex_00B960" Format="rgba16" Width="32" Height="32" Offset="0xB960" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_00C160" OutName="spot09_sceneTex_00C160" Format="rgba16" Width="64" Height="32" Offset="0xC160" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_00D160" OutName="spot09_sceneTex_00D160" Format="rgba16" Width="128" Height="16" Offset="0xD160" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_00E160" OutName="spot09_sceneTex_00E160" Format="rgba16" Width="32" Height="32" Offset="0xE160" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_00E960" OutName="spot09_sceneTex_00E960" Format="i4" Width="64" Height="64" Offset="0xE960" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_00F160" OutName="spot09_sceneTex_00F160" Format="i4" Width="32" Height="128" Offset="0xF160" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_00F960" OutName="spot09_sceneTex_00F960" Format="rgba16" Width="64" Height="32" Offset="0xF960" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_010960" OutName="spot09_sceneTex_010960" Format="rgba16" Width="32" Height="32" Offset="0x10960" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTLUT_003440" OutName="spot09_sceneTLUT_003440" Format="rgba16" Width="4" Height="4" Offset="0x3440" AddedByScript="true"/>
         <Cutscene Name="gGerudoValleyBridgeJumpFieldFortressCs" Offset="0x2AC0"/>
         <Cutscene Name="gGerudoValleyBridgeJumpFortressToFieldCs" Offset="0x230"/>
         <Cutscene Name="gGerudoValleyIntroCs" Offset="0x31E0"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/overworld/spot10.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/overworld/spot10.xml
@@ -1,5 +1,13 @@
 <Root>
     <File Name="spot10_scene" Segment="2">
+        <Texture Name="spot10_sceneTex_00C230" OutName="spot10_sceneTex_00C230" Format="rgba16" Width="32" Height="32" Offset="0xC230" AddedByScript="true"/>
+        <Texture Name="spot10_sceneTex_00CA30" OutName="spot10_sceneTex_00CA30" Format="rgba16" Width="32" Height="32" Offset="0xCA30" AddedByScript="true"/>
+        <Texture Name="spot10_sceneTex_00D230" OutName="spot10_sceneTex_00D230" Format="i4" Width="64" Height="64" Offset="0xD230" AddedByScript="true"/>
+        <Texture Name="spot10_sceneTex_00DA30" OutName="spot10_sceneTex_00DA30" Format="rgba16" Width="32" Height="64" Offset="0xDA30" AddedByScript="true"/>
+        <Texture Name="spot10_sceneTex_00EA30" OutName="spot10_sceneTex_00EA30" Format="rgba16" Width="32" Height="32" Offset="0xEA30" AddedByScript="true"/>
+        <Texture Name="spot10_sceneTex_00F230" OutName="spot10_sceneTex_00F230" Format="rgba16" Width="16" Height="16" Offset="0xF230" AddedByScript="true"/>
+        <Texture Name="spot10_sceneTex_00F430" OutName="spot10_sceneTex_00F430" Format="rgba16" Width="32" Height="32" Offset="0xF430" AddedByScript="true"/>
+        <Texture Name="spot10_sceneTex_00FC30" OutName="spot10_sceneTex_00FC30" Format="rgba16" Width="32" Height="32" Offset="0xFC30" AddedByScript="true"/>
         <Path Name="gSpot10Path_00C080" Offset="0xC080" NumPaths="3"/>
         <Scene Name="spot10_scene" Offset="0x0"/>
     </File>
@@ -7,21 +15,44 @@
         <Room Name="spot10_room_0" Offset="0x0"/>
     </File>
     <File Name="spot10_room_1" Segment="3">
+        <Texture Name="spot10_room_1Tex_003BA0" OutName="spot10_room_1Tex_003BA0" Format="rgba16" Width="16" Height="32" Offset="0x3BA0" AddedByScript="true"/>
+        <Texture Name="spot10_room_1Tex_003FA0" OutName="spot10_room_1Tex_003FA0" Format="rgba16" Width="32" Height="32" Offset="0x3FA0" AddedByScript="true"/>
+        <Texture Name="spot10_room_1Tex_0047A0" OutName="spot10_room_1Tex_0047A0" Format="rgba16" Width="32" Height="32" Offset="0x47A0" AddedByScript="true"/>
+        <Texture Name="spot10_room_1Tex_004FA0" OutName="spot10_room_1Tex_004FA0" Format="rgba16" Width="64" Height="32" Offset="0x4FA0" AddedByScript="true"/>
+        <Texture Name="spot10_room_1Tex_005FA0" OutName="spot10_room_1Tex_005FA0" Format="rgba16" Width="32" Height="32" Offset="0x5FA0" AddedByScript="true"/>
+        <Texture Name="spot10_room_1Tex_0067A0" OutName="spot10_room_1Tex_0067A0" Format="rgba16" Width="32" Height="32" Offset="0x67A0" AddedByScript="true"/>
+        <Texture Name="spot10_room_1Tex_006FA0" OutName="spot10_room_1Tex_006FA0" Format="rgba16" Width="64" Height="16" Offset="0x6FA0" AddedByScript="true"/>
+        <Texture Name="spot10_room_1Tex_007C30" OutName="spot10_room_1Tex_007C30" Format="ia8" Width="32" Height="32" Offset="0x7C30" AddedByScript="true"/>
+        <Texture Name="spot10_room_1Tex_008030" OutName="spot10_room_1Tex_008030" Format="ia16" Width="32" Height="16" Offset="0x8030" AddedByScript="true"/>
         <Room Name="spot10_room_1" Offset="0x0"/>
     </File>
     <File Name="spot10_room_2" Segment="3">
+        <Texture Name="spot10_room_2Tex_0023E8" OutName="spot10_room_2Tex_0023E8" Format="rgba16" Width="64" Height="32" Offset="0x23E8" AddedByScript="true"/>
+        <Texture Name="spot10_room_2Tex_0033E8" OutName="spot10_room_2Tex_0033E8" Format="rgba16" Width="64" Height="32" Offset="0x33E8" AddedByScript="true"/>
+        <Texture Name="spot10_room_2Tex_0043E8" OutName="spot10_room_2Tex_0043E8" Format="rgba16" Width="16" Height="64" Offset="0x43E8" AddedByScript="true"/>
         <Room Name="spot10_room_2" Offset="0x0"/>
     </File>
     <File Name="spot10_room_3" Segment="3">
+        <Texture Name="spot10_room_3Tex_0028F8" OutName="spot10_room_3Tex_0028F8" Format="rgba16" Width="64" Height="32" Offset="0x28F8" AddedByScript="true"/>
+        <Texture Name="spot10_room_3Tex_0038F8" OutName="spot10_room_3Tex_0038F8" Format="rgba16" Width="64" Height="32" Offset="0x38F8" AddedByScript="true"/>
+        <Texture Name="spot10_room_3Tex_0048F8" OutName="spot10_room_3Tex_0048F8" Format="rgba16" Width="16" Height="64" Offset="0x48F8" AddedByScript="true"/>
+        <Texture Name="spot10_room_3Tex_0052A8" OutName="spot10_room_3Tex_0052A8" Format="rgba16" Width="32" Height="32" Offset="0x52A8" AddedByScript="true"/>
         <Room Name="spot10_room_3" Offset="0x0"/>
     </File>
     <File Name="spot10_room_4" Segment="3">
         <Room Name="spot10_room_4" Offset="0x0"/>
     </File>
     <File Name="spot10_room_5" Segment="3">
+        <Texture Name="spot10_room_5Tex_0037F0" OutName="spot10_room_5Tex_0037F0" Format="rgba16" Width="32" Height="64" Offset="0x37F0" AddedByScript="true"/>
+        <Texture Name="spot10_room_5Tex_0047F0" OutName="spot10_room_5Tex_0047F0" Format="rgba16" Width="64" Height="32" Offset="0x47F0" AddedByScript="true"/>
+        <Texture Name="spot10_room_5Tex_0057F0" OutName="spot10_room_5Tex_0057F0" Format="rgba16" Width="64" Height="32" Offset="0x57F0" AddedByScript="true"/>
+        <Texture Name="spot10_room_5Tex_0067F0" OutName="spot10_room_5Tex_0067F0" Format="rgba16" Width="32" Height="32" Offset="0x67F0" AddedByScript="true"/>
         <Room Name="spot10_room_5" Offset="0x0"/>
     </File>
     <File Name="spot10_room_6" Segment="3">
+        <Texture Name="spot10_room_6Tex_0022E8" OutName="spot10_room_6Tex_0022E8" Format="rgba16" Width="32" Height="32" Offset="0x22E8" AddedByScript="true"/>
+        <Texture Name="spot10_room_6Tex_002AE8" OutName="spot10_room_6Tex_002AE8" Format="rgba16" Width="64" Height="16" Offset="0x2AE8" AddedByScript="true"/>
+        <Texture Name="spot10_room_6Tex_0032E8" OutName="spot10_room_6Tex_0032E8" Format="rgba16" Width="32" Height="32" Offset="0x32E8" AddedByScript="true"/>
         <Room Name="spot10_room_6" Offset="0x0"/>
     </File>
     <File Name="spot10_room_7" Segment="3">
@@ -31,6 +62,10 @@
         <Room Name="spot10_room_8" Offset="0x0"/>
     </File>
     <File Name="spot10_room_9" Segment="3">
+        <Texture Name="spot10_room_9Tex_001EF8" OutName="spot10_room_9Tex_001EF8" Format="rgba16" Width="32" Height="32" Offset="0x1EF8" AddedByScript="true"/>
+        <Texture Name="spot10_room_9Tex_0026F8" OutName="spot10_room_9Tex_0026F8" Format="rgba16" Width="32" Height="32" Offset="0x26F8" AddedByScript="true"/>
+        <Texture Name="spot10_room_9Tex_0033D8" OutName="spot10_room_9Tex_0033D8" Format="ia8" Width="32" Height="32" Offset="0x33D8" AddedByScript="true"/>
+        <Texture Name="spot10_room_9Tex_0037D8" OutName="spot10_room_9Tex_0037D8" Format="ia16" Width="32" Height="16" Offset="0x37D8" AddedByScript="true"/>
         <Room Name="spot10_room_9" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/overworld/spot11.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/overworld/spot11.xml
@@ -1,5 +1,37 @@
 <Root>
     <File Name="spot11_scene" Segment="2">
+        <Texture Name="spot11_sceneTex_007CA0" OutName="spot11_sceneTex_007CA0" Format="rgba16" Width="32" Height="32" Offset="0x7CA0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_0084A0" OutName="spot11_sceneTex_0084A0" Format="rgba16" Width="32" Height="32" Offset="0x84A0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_008CA0" OutName="spot11_sceneTex_008CA0" Format="rgba16" Width="16" Height="32" Offset="0x8CA0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_0090A0" OutName="spot11_sceneTex_0090A0" Format="rgba16" Width="128" Height="16" Offset="0x90A0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_00A0A0" OutName="spot11_sceneTex_00A0A0" Format="rgba16" Width="32" Height="32" Offset="0xA0A0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_00A8A0" OutName="spot11_sceneTex_00A8A0" Format="rgba16" Width="64" Height="32" Offset="0xA8A0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_00B8A0" OutName="spot11_sceneTex_00B8A0" Format="rgba16" Width="16" Height="32" Offset="0xB8A0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_00BCA0" OutName="spot11_sceneTex_00BCA0" Format="rgba16" Width="32" Height="32" Offset="0xBCA0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_00C4A0" OutName="spot11_sceneTex_00C4A0" Format="rgba16" Width="32" Height="32" Offset="0xC4A0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_00CCA0" OutName="spot11_sceneTex_00CCA0" Format="rgba16" Width="16" Height="64" Offset="0xCCA0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_00D4A0" OutName="spot11_sceneTex_00D4A0" Format="rgba16" Width="32" Height="32" Offset="0xD4A0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_00DCA0" OutName="spot11_sceneTex_00DCA0" Format="rgba16" Width="64" Height="32" Offset="0xDCA0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_00ECA0" OutName="spot11_sceneTex_00ECA0" Format="rgba16" Width="32" Height="32" Offset="0xECA0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_00F4A0" OutName="spot11_sceneTex_00F4A0" Format="rgba16" Width="32" Height="32" Offset="0xF4A0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_00FCA0" OutName="spot11_sceneTex_00FCA0" Format="ia8" Width="8" Height="8" Offset="0xFCA0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_00FCE0" OutName="spot11_sceneTex_00FCE0" Format="rgba16" Width="32" Height="32" Offset="0xFCE0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_0104E0" OutName="spot11_sceneTex_0104E0" Format="rgba16" Width="32" Height="32" Offset="0x104E0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_010CE0" OutName="spot11_sceneTex_010CE0" Format="rgba16" Width="32" Height="64" Offset="0x10CE0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_011CE0" OutName="spot11_sceneTex_011CE0" Format="rgba16" Width="32" Height="32" Offset="0x11CE0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_0124E0" OutName="spot11_sceneTex_0124E0" Format="rgba16" Width="32" Height="32" Offset="0x124E0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_012CE0" OutName="spot11_sceneTex_012CE0" Format="rgba16" Width="32" Height="32" Offset="0x12CE0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_0134E0" OutName="spot11_sceneTex_0134E0" Format="rgba16" Width="32" Height="32" Offset="0x134E0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_013CE0" OutName="spot11_sceneTex_013CE0" Format="rgba16" Width="32" Height="32" Offset="0x13CE0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_0144E0" OutName="spot11_sceneTex_0144E0" Format="rgba16" Width="32" Height="64" Offset="0x144E0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_0154E0" OutName="spot11_sceneTex_0154E0" Format="rgba16" Width="32" Height="32" Offset="0x154E0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_015CE0" OutName="spot11_sceneTex_015CE0" Format="rgba16" Width="32" Height="32" Offset="0x15CE0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_0164E0" OutName="spot11_sceneTex_0164E0" Format="ia4" Width="32" Height="128" Offset="0x164E0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_016CE0" OutName="spot11_sceneTex_016CE0" Format="rgba16" Width="32" Height="32" Offset="0x16CE0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_0174E0" OutName="spot11_sceneTex_0174E0" Format="rgba16" Width="16" Height="64" Offset="0x174E0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_017CE0" OutName="spot11_sceneTex_017CE0" Format="ia4" Width="64" Height="64" Offset="0x17CE0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_0184E0" OutName="spot11_sceneTex_0184E0" Format="rgba16" Width="32" Height="32" Offset="0x184E0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_018CE0" OutName="spot11_sceneTex_018CE0" Format="rgba16" Width="32" Height="32" Offset="0x18CE0" AddedByScript="true"/>
         <Cutscene Name="gDesertColossusIntroCs" Offset="0x7990"/>
         <Scene Name="spot11_scene" Offset="0x0"/>
     </File>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/overworld/spot12.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/overworld/spot12.xml
@@ -1,5 +1,17 @@
 <Root>
     <File Name="spot12_scene" Segment="2">
+        <Texture Name="spot12_sceneTex_006678" OutName="spot12_sceneTex_006678" Format="rgba16" Width="32" Height="64" Offset="0x6678" AddedByScript="true"/>
+        <Texture Name="spot12_sceneTex_007678" OutName="spot12_sceneTex_007678" Format="rgba16" Width="32" Height="64" Offset="0x7678" AddedByScript="true"/>
+        <Texture Name="spot12_sceneTex_008678" OutName="spot12_sceneTex_008678" Format="rgba16" Width="32" Height="32" Offset="0x8678" AddedByScript="true"/>
+        <Texture Name="spot12_sceneTex_008E78" OutName="spot12_sceneTex_008E78" Format="ci4" Width="32" Height="128" Offset="0x8E78" TlutOffset="0x6650" AddedByScript="true"/>
+        <Texture Name="spot12_sceneTex_00A678" OutName="spot12_sceneTex_00A678" Format="rgba16" Width="64" Height="32" Offset="0xA678" AddedByScript="true"/>
+        <Texture Name="spot12_sceneTex_00B678" OutName="spot12_sceneTex_00B678" Format="rgba16" Width="32" Height="32" Offset="0xB678" AddedByScript="true"/>
+        <Texture Name="spot12_sceneTex_00BE78" OutName="spot12_sceneTex_00BE78" Format="rgba16" Width="64" Height="16" Offset="0xBE78" AddedByScript="true"/>
+        <Texture Name="spot12_sceneTex_00C678" OutName="spot12_sceneTex_00C678" Format="rgba16" Width="32" Height="32" Offset="0xC678" AddedByScript="true"/>
+        <Texture Name="spot12_sceneTex_00CE78" OutName="spot12_sceneTex_00CE78" Format="rgba16" Width="32" Height="32" Offset="0xCE78" AddedByScript="true"/>
+        <Texture Name="spot12_sceneTex_00D678" OutName="spot12_sceneTex_00D678" Format="rgba16" Width="32" Height="32" Offset="0xD678" AddedByScript="true"/>
+        <Texture Name="spot12_sceneTex_00EE78" OutName="spot12_sceneTex_00EE78" Format="rgba16" Width="64" Height="32" Offset="0xEE78" AddedByScript="true"/>
+        <Texture Name="spot12_sceneTLUT_006650" OutName="spot12_sceneTLUT_006650" Format="rgba16" Width="4" Height="4" Offset="0x6650" AddedByScript="true"/>
         <Cutscene Name="gGerudoFortressFirstCaptureCs" Offset="0x55C0"/>
         <Cutscene Name="gGerudoFortressIntroCs" Offset="0x6490"/>
         <Texture Name="gSpot12_009678Tex" Format="rgba16" Width="64" Height="32" Offset="0x9678"/>
@@ -7,9 +19,34 @@
         <Scene Name="spot12_scene" Offset="0x0"/>
     </File>
     <File Name="spot12_room_0" Segment="3">
+        <Texture Name="spot12_room_0Tex_008AB0" OutName="spot12_room_0Tex_008AB0" Format="rgba16" Width="32" Height="32" Offset="0x8AB0" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_0092B0" OutName="spot12_room_0Tex_0092B0" Format="rgba16" Width="32" Height="16" Offset="0x92B0" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_0096B0" OutName="spot12_room_0Tex_0096B0" Format="rgba16" Width="32" Height="32" Offset="0x96B0" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_009EB0" OutName="spot12_room_0Tex_009EB0" Format="rgba16" Width="32" Height="32" Offset="0x9EB0" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_00A6B0" OutName="spot12_room_0Tex_00A6B0" Format="rgba16" Width="64" Height="32" Offset="0xA6B0" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_00B6B0" OutName="spot12_room_0Tex_00B6B0" Format="rgba16" Width="32" Height="32" Offset="0xB6B0" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_00BEB0" OutName="spot12_room_0Tex_00BEB0" Format="rgba16" Width="32" Height="32" Offset="0xBEB0" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_00C6B0" OutName="spot12_room_0Tex_00C6B0" Format="ci4" Width="64" Height="32" Offset="0xC6B0" TlutOffset="0x8A90" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_00CAB0" OutName="spot12_room_0Tex_00CAB0" Format="rgba16" Width="16" Height="64" Offset="0xCAB0" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_00D2B0" OutName="spot12_room_0Tex_00D2B0" Format="rgba16" Width="64" Height="32" Offset="0xD2B0" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_00E2B0" OutName="spot12_room_0Tex_00E2B0" Format="rgba16" Width="32" Height="32" Offset="0xE2B0" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_00EAB0" OutName="spot12_room_0Tex_00EAB0" Format="rgba16" Width="32" Height="32" Offset="0xEAB0" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_00FD78" OutName="spot12_room_0Tex_00FD78" Format="ia8" Width="8" Height="8" Offset="0xFD78" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_00FDB8" OutName="spot12_room_0Tex_00FDB8" Format="rgba16" Width="16" Height="64" Offset="0xFDB8" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_0105B8" OutName="spot12_room_0Tex_0105B8" Format="rgba16" Width="32" Height="64" Offset="0x105B8" AddedByScript="true"/>
+        <Texture Name="spot12_room_0TLUT_008A90" OutName="spot12_room_0TLUT_008A90" Format="rgba16" Width="4" Height="4" Offset="0x8A90" AddedByScript="true"/>
         <Room Name="spot12_room_0" Offset="0x0"/>
     </File>
     <File Name="spot12_room_1" Segment="3">
+        <Texture Name="spot12_room_1Tex_005638" OutName="spot12_room_1Tex_005638" Format="rgba16" Width="32" Height="64" Offset="0x5638" AddedByScript="true"/>
+        <Texture Name="spot12_room_1Tex_006638" OutName="spot12_room_1Tex_006638" Format="rgba16" Width="32" Height="64" Offset="0x6638" AddedByScript="true"/>
+        <Texture Name="spot12_room_1Tex_007638" OutName="spot12_room_1Tex_007638" Format="rgba16" Width="32" Height="32" Offset="0x7638" AddedByScript="true"/>
+        <Texture Name="spot12_room_1Tex_007E38" OutName="spot12_room_1Tex_007E38" Format="rgba16" Width="64" Height="32" Offset="0x7E38" AddedByScript="true"/>
+        <Texture Name="spot12_room_1Tex_008E38" OutName="spot12_room_1Tex_008E38" Format="rgba16" Width="64" Height="32" Offset="0x8E38" AddedByScript="true"/>
+        <Texture Name="spot12_room_1Tex_009E38" OutName="spot12_room_1Tex_009E38" Format="rgba16" Width="32" Height="32" Offset="0x9E38" AddedByScript="true"/>
+        <Texture Name="spot12_room_1Tex_00A638" OutName="spot12_room_1Tex_00A638" Format="i4" Width="64" Height="64" Offset="0xA638" AddedByScript="true"/>
+        <Texture Name="spot12_room_1Tex_00B0A0" OutName="spot12_room_1Tex_00B0A0" Format="i8" Width="32" Height="64" Offset="0xB0A0" AddedByScript="true"/>
+        <Texture Name="spot12_room_1Tex_00B8A0" OutName="spot12_room_1Tex_00B8A0" Format="i8" Width="32" Height="64" Offset="0xB8A0" AddedByScript="true"/>
         <Room Name="spot12_room_1" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/overworld/spot13.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/overworld/spot13.xml
@@ -1,11 +1,39 @@
 <Root>
     <File Name="spot13_scene" Segment="2">
+        <Texture Name="spot13_sceneTex_003A30" OutName="spot13_sceneTex_003A30" Format="rgba16" Width="32" Height="16" Offset="0x3A30" AddedByScript="true"/>
+        <Texture Name="spot13_sceneTex_003E30" OutName="spot13_sceneTex_003E30" Format="rgba16" Width="32" Height="64" Offset="0x3E30" AddedByScript="true"/>
+        <Texture Name="spot13_sceneTex_004E30" OutName="spot13_sceneTex_004E30" Format="rgba16" Width="64" Height="32" Offset="0x4E30" AddedByScript="true"/>
         <Scene Name="spot13_scene" Offset="0x0"/>
     </File>
     <File Name="spot13_room_0" Segment="3">
         <Room Name="spot13_room_0" Offset="0x0"/>
     </File>
     <File Name="spot13_room_1" Segment="3">
+        <Texture Name="spot13_room_1Tex_007E08" OutName="spot13_room_1Tex_007E08" Format="rgba16" Width="32" Height="32" Offset="0x7E08" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_008608" OutName="spot13_room_1Tex_008608" Format="rgba16" Width="16" Height="32" Offset="0x8608" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_008A08" OutName="spot13_room_1Tex_008A08" Format="rgba16" Width="32" Height="64" Offset="0x8A08" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_009A08" OutName="spot13_room_1Tex_009A08" Format="rgba16" Width="16" Height="16" Offset="0x9A08" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_009C08" OutName="spot13_room_1Tex_009C08" Format="rgba16" Width="16" Height="16" Offset="0x9C08" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_009E08" OutName="spot13_room_1Tex_009E08" Format="rgba16" Width="32" Height="32" Offset="0x9E08" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_00A608" OutName="spot13_room_1Tex_00A608" Format="rgba16" Width="32" Height="16" Offset="0xA608" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_00AA08" OutName="spot13_room_1Tex_00AA08" Format="rgba16" Width="32" Height="16" Offset="0xAA08" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_00AE08" OutName="spot13_room_1Tex_00AE08" Format="ci4" Width="32" Height="128" Offset="0xAE08" TlutOffset="0x7DC0" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_00B608" OutName="spot13_room_1Tex_00B608" Format="rgba16" Width="16" Height="16" Offset="0xB608" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_00B808" OutName="spot13_room_1Tex_00B808" Format="ci4" Width="64" Height="32" Offset="0xB808" TlutOffset="0x7DE8" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_00BC08" OutName="spot13_room_1Tex_00BC08" Format="rgba16" Width="32" Height="32" Offset="0xBC08" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_00C408" OutName="spot13_room_1Tex_00C408" Format="rgba16" Width="8" Height="32" Offset="0xC408" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_00C608" OutName="spot13_room_1Tex_00C608" Format="rgba16" Width="64" Height="32" Offset="0xC608" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_00D608" OutName="spot13_room_1Tex_00D608" Format="rgba16" Width="32" Height="64" Offset="0xD608" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_00E608" OutName="spot13_room_1Tex_00E608" Format="rgba16" Width="32" Height="32" Offset="0xE608" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_00EE08" OutName="spot13_room_1Tex_00EE08" Format="rgba16" Width="32" Height="64" Offset="0xEE08" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_00FE08" OutName="spot13_room_1Tex_00FE08" Format="rgba16" Width="32" Height="32" Offset="0xFE08" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_010608" OutName="spot13_room_1Tex_010608" Format="rgba16" Width="32" Height="32" Offset="0x10608" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_010E08" OutName="spot13_room_1Tex_010E08" Format="rgba16" Width="32" Height="16" Offset="0x10E08" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_011208" OutName="spot13_room_1Tex_011208" Format="rgba16" Width="32" Height="32" Offset="0x11208" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_011E40" OutName="spot13_room_1Tex_011E40" Format="ia4" Width="64" Height="32" Offset="0x11E40" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_012240" OutName="spot13_room_1Tex_012240" Format="rgba16" Width="32" Height="32" Offset="0x12240" AddedByScript="true"/>
+        <Texture Name="spot13_room_1TLUT_007DC0" OutName="spot13_room_1TLUT_007DC0" Format="rgba16" Width="4" Height="4" Offset="0x7DC0" AddedByScript="true"/>
+        <Texture Name="spot13_room_1TLUT_007DE8" OutName="spot13_room_1TLUT_007DE8" Format="rgba16" Width="4" Height="4" Offset="0x7DE8" AddedByScript="true"/>
         <Room Name="spot13_room_1" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/overworld/spot15.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/overworld/spot15.xml
@@ -1,5 +1,48 @@
 <Root>
     <File Name="spot15_scene" Segment="2">
+        <Texture Name="spot15_sceneTex_004100" OutName="spot15_sceneTex_004100" Format="rgba16" Width="32" Height="32" Offset="0x4100" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_004900" OutName="spot15_sceneTex_004900" Format="ia4" Width="32" Height="16" Offset="0x4900" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_004A00" OutName="spot15_sceneTex_004A00" Format="ia8" Width="8" Height="64" Offset="0x4A00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_004C00" OutName="spot15_sceneTex_004C00" Format="rgba16" Width="16" Height="64" Offset="0x4C00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_005400" OutName="spot15_sceneTex_005400" Format="rgba16" Width="32" Height="64" Offset="0x5400" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_006400" OutName="spot15_sceneTex_006400" Format="ia8" Width="32" Height="8" Offset="0x6400" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_006500" OutName="spot15_sceneTex_006500" Format="rgba16" Width="32" Height="32" Offset="0x6500" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_006D00" OutName="spot15_sceneTex_006D00" Format="i4" Width="32" Height="32" Offset="0x6D00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_006F00" OutName="spot15_sceneTex_006F00" Format="ia4" Width="32" Height="64" Offset="0x6F00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_007300" OutName="spot15_sceneTex_007300" Format="ia4" Width="32" Height="128" Offset="0x7300" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_007B00" OutName="spot15_sceneTex_007B00" Format="ia4" Width="16" Height="32" Offset="0x7B00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_007C00" OutName="spot15_sceneTex_007C00" Format="rgba16" Width="32" Height="8" Offset="0x7C00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_007E00" OutName="spot15_sceneTex_007E00" Format="rgba16" Width="32" Height="64" Offset="0x7E00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_008E00" OutName="spot15_sceneTex_008E00" Format="rgba16" Width="32" Height="32" Offset="0x8E00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_009600" OutName="spot15_sceneTex_009600" Format="rgba16" Width="16" Height="16" Offset="0x9600" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_009800" OutName="spot15_sceneTex_009800" Format="ia8" Width="16" Height="16" Offset="0x9800" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_009900" OutName="spot15_sceneTex_009900" Format="rgba16" Width="32" Height="32" Offset="0x9900" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_00A100" OutName="spot15_sceneTex_00A100" Format="rgba16" Width="32" Height="32" Offset="0xA100" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_00A900" OutName="spot15_sceneTex_00A900" Format="rgba16" Width="64" Height="32" Offset="0xA900" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_00B900" OutName="spot15_sceneTex_00B900" Format="ia8" Width="16" Height="16" Offset="0xB900" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_00BA00" OutName="spot15_sceneTex_00BA00" Format="rgba16" Width="32" Height="32" Offset="0xBA00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_00C200" OutName="spot15_sceneTex_00C200" Format="rgba16" Width="32" Height="32" Offset="0xC200" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_00CA00" OutName="spot15_sceneTex_00CA00" Format="rgba16" Width="64" Height="32" Offset="0xCA00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_00DA00" OutName="spot15_sceneTex_00DA00" Format="rgba16" Width="128" Height="16" Offset="0xDA00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_00EA00" OutName="spot15_sceneTex_00EA00" Format="i4" Width="32" Height="32" Offset="0xEA00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_00EC00" OutName="spot15_sceneTex_00EC00" Format="i8" Width="128" Height="32" Offset="0xEC00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_00FC00" OutName="spot15_sceneTex_00FC00" Format="rgba16" Width="32" Height="32" Offset="0xFC00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_010400" OutName="spot15_sceneTex_010400" Format="rgba16" Width="32" Height="32" Offset="0x10400" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_010C00" OutName="spot15_sceneTex_010C00" Format="i4" Width="64" Height="64" Offset="0x10C00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_011400" OutName="spot15_sceneTex_011400" Format="rgba16" Width="32" Height="32" Offset="0x11400" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_011C00" OutName="spot15_sceneTex_011C00" Format="ia4" Width="128" Height="32" Offset="0x11C00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_012400" OutName="spot15_sceneTex_012400" Format="rgba16" Width="32" Height="64" Offset="0x12400" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_013400" OutName="spot15_sceneTex_013400" Format="rgba16" Width="32" Height="64" Offset="0x13400" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_014400" OutName="spot15_sceneTex_014400" Format="rgba16" Width="32" Height="32" Offset="0x14400" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_014C00" OutName="spot15_sceneTex_014C00" Format="rgba16" Width="64" Height="32" Offset="0x14C00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_015C00" OutName="spot15_sceneTex_015C00" Format="rgba16" Width="16" Height="16" Offset="0x15C00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_015E00" OutName="spot15_sceneTex_015E00" Format="rgba16" Width="32" Height="32" Offset="0x15E00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_016600" OutName="spot15_sceneTex_016600" Format="rgba16" Width="16" Height="16" Offset="0x16600" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_016800" OutName="spot15_sceneTex_016800" Format="rgba16" Width="32" Height="16" Offset="0x16800" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_016C00" OutName="spot15_sceneTex_016C00" Format="rgba16" Width="32" Height="32" Offset="0x16C00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_017400" OutName="spot15_sceneTex_017400" Format="rgba16" Width="32" Height="32" Offset="0x17400" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_017C00" OutName="spot15_sceneTex_017C00" Format="rgba16" Width="32" Height="32" Offset="0x17C00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_018400" OutName="spot15_sceneTex_018400" Format="ia8" Width="16" Height="16" Offset="0x18400" AddedByScript="true"/>
         <Cutscene Name="gHyruleCastleIntroCs" Offset="0x3F40"/>
         <Scene Name="spot15_scene" Offset="0x0"/>
     </File>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/overworld/spot16.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/overworld/spot16.xml
@@ -1,5 +1,41 @@
 <Root>
     <File Name="spot16_scene" Segment="2">
+        <Texture Name="spot16_sceneTex_008198" OutName="spot16_sceneTex_008198" Format="i8" Width="64" Height="64" Offset="0x8198" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_009198" OutName="spot16_sceneTex_009198" Format="i8" Width="64" Height="32" Offset="0x9198" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_009998" OutName="spot16_sceneTex_009998" Format="i8" Width="64" Height="16" Offset="0x9998" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_009D98" OutName="spot16_sceneTex_009D98" Format="i8" Width="64" Height="64" Offset="0x9D98" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_00AD98" OutName="spot16_sceneTex_00AD98" Format="i8" Width="64" Height="64" Offset="0xAD98" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_00BD98" OutName="spot16_sceneTex_00BD98" Format="rgba16" Width="64" Height="32" Offset="0xBD98" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_00CD98" OutName="spot16_sceneTex_00CD98" Format="rgba16" Width="16" Height="16" Offset="0xCD98" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_00CF98" OutName="spot16_sceneTex_00CF98" Format="rgba16" Width="32" Height="16" Offset="0xCF98" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_00D398" OutName="spot16_sceneTex_00D398" Format="rgba16" Width="16" Height="32" Offset="0xD398" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_00D798" OutName="spot16_sceneTex_00D798" Format="ci4" Width="64" Height="64" Offset="0xD798" TlutOffset="0x8170" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_00DF98" OutName="spot16_sceneTex_00DF98" Format="i4" Width="64" Height="16" Offset="0xDF98" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_00E198" OutName="spot16_sceneTex_00E198" Format="rgba16" Width="64" Height="32" Offset="0xE198" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_00F198" OutName="spot16_sceneTex_00F198" Format="rgba16" Width="16" Height="128" Offset="0xF198" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_010198" OutName="spot16_sceneTex_010198" Format="rgba16" Width="32" Height="64" Offset="0x10198" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_011198" OutName="spot16_sceneTex_011198" Format="rgba16" Width="16" Height="32" Offset="0x11198" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_011598" OutName="spot16_sceneTex_011598" Format="i4" Width="64" Height="16" Offset="0x11598" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_011798" OutName="spot16_sceneTex_011798" Format="rgba16" Width="64" Height="32" Offset="0x11798" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_012798" OutName="spot16_sceneTex_012798" Format="rgba16" Width="64" Height="32" Offset="0x12798" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_013798" OutName="spot16_sceneTex_013798" Format="i4" Width="64" Height="16" Offset="0x13798" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_013998" OutName="spot16_sceneTex_013998" Format="rgba16" Width="32" Height="16" Offset="0x13998" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_013D98" OutName="spot16_sceneTex_013D98" Format="rgba16" Width="32" Height="64" Offset="0x13D98" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_014D98" OutName="spot16_sceneTex_014D98" Format="rgba16" Width="32" Height="32" Offset="0x14D98" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_015598" OutName="spot16_sceneTex_015598" Format="i4" Width="64" Height="64" Offset="0x15598" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_015D98" OutName="spot16_sceneTex_015D98" Format="ia8" Width="16" Height="16" Offset="0x15D98" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_015E98" OutName="spot16_sceneTex_015E98" Format="ia8" Width="128" Height="32" Offset="0x15E98" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_016E98" OutName="spot16_sceneTex_016E98" Format="i4" Width="128" Height="64" Offset="0x16E98" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_017E98" OutName="spot16_sceneTex_017E98" Format="rgba16" Width="32" Height="32" Offset="0x17E98" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_018698" OutName="spot16_sceneTex_018698" Format="rgba16" Width="32" Height="32" Offset="0x18698" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_018E98" OutName="spot16_sceneTex_018E98" Format="rgba16" Width="32" Height="32" Offset="0x18E98" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_019698" OutName="spot16_sceneTex_019698" Format="rgba16" Width="64" Height="16" Offset="0x19698" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_019E98" OutName="spot16_sceneTex_019E98" Format="rgba16" Width="32" Height="64" Offset="0x19E98" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_01B698" OutName="spot16_sceneTex_01B698" Format="ia8" Width="64" Height="64" Offset="0x1B698" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_01C698" OutName="spot16_sceneTex_01C698" Format="rgba16" Width="32" Height="64" Offset="0x1C698" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_01D698" OutName="spot16_sceneTex_01D698" Format="i8" Width="64" Height="32" Offset="0x1D698" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_01DE98" OutName="spot16_sceneTex_01DE98" Format="rgba16" Width="32" Height="32" Offset="0x1DE98" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTLUT_008170" OutName="spot16_sceneTLUT_008170" Format="rgba16" Width="4" Height="4" Offset="0x8170" AddedByScript="true"/>
         <Path Name="gDMTPath_00254" Offset="0x254" NumPaths="3"/>
         <Path Name="gDMTPath_07884" Offset="0x7884" NumPaths="3"/>
         <Cutscene Name="gDMTOwlCs" Offset="0x1E6A0"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/overworld/spot17.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/overworld/spot17.xml
@@ -1,13 +1,54 @@
 <Root>
     <File Name="spot17_scene" Segment="2">
+        <Texture Name="spot17_sceneTex_007AD8" OutName="spot17_sceneTex_007AD8" Format="ci8" Width="16" Height="128" Offset="0x7AD8" TlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_0082D8" OutName="spot17_sceneTex_0082D8" Format="ci8" Width="32" Height="32" Offset="0x82D8" TlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_0086D8" OutName="spot17_sceneTex_0086D8" Format="ci8" Width="64" Height="32" Offset="0x86D8" TlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_008ED8" OutName="spot17_sceneTex_008ED8" Format="ci8" Width="64" Height="32" Offset="0x8ED8" TlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_0096D8" OutName="spot17_sceneTex_0096D8" Format="ci8" Width="64" Height="32" Offset="0x96D8" TlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_009ED8" OutName="spot17_sceneTex_009ED8" Format="rgba16" Width="32" Height="32" Offset="0x9ED8" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_00A6D8" OutName="spot17_sceneTex_00A6D8" Format="rgba16" Width="32" Height="32" Offset="0xA6D8" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_00AED8" OutName="spot17_sceneTex_00AED8" Format="ci4" Width="64" Height="64" Offset="0xAED8" TlutOffset="0x7A98" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_00B6D8" OutName="spot17_sceneTex_00B6D8" Format="ci8" Width="64" Height="32" Offset="0xB6D8" TlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_00BED8" OutName="spot17_sceneTex_00BED8" Format="ci8" Width="32" Height="64" Offset="0xBED8" TlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_00C6D8" OutName="spot17_sceneTex_00C6D8" Format="rgba16" Width="32" Height="64" Offset="0xC6D8" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_00D6D8" OutName="spot17_sceneTex_00D6D8" Format="ci8" Width="16" Height="32" Offset="0xD6D8" TlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_00D8D8" OutName="spot17_sceneTex_00D8D8" Format="ci8" Width="16" Height="128" Offset="0xD8D8" TlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_00E0D8" OutName="spot17_sceneTex_00E0D8" Format="ci4" Width="64" Height="64" Offset="0xE0D8" TlutOffset="0x7AB8" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_00E8D8" OutName="spot17_sceneTex_00E8D8" Format="ci8" Width="32" Height="64" Offset="0xE8D8" TlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_00F0D8" OutName="spot17_sceneTex_00F0D8" Format="ci8" Width="32" Height="64" Offset="0xF0D8" TlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_00F8D8" OutName="spot17_sceneTex_00F8D8" Format="ci8" Width="32" Height="32" Offset="0xF8D8" TlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_00FCD8" OutName="spot17_sceneTex_00FCD8" Format="ci8" Width="16" Height="32" Offset="0xFCD8" TlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTLUT_007890" OutName="spot17_sceneTLUT_007890" Format="rgba16" Width="16" Height="16" Offset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTLUT_007A98" OutName="spot17_sceneTLUT_007A98" Format="rgba16" Width="4" Height="4" Offset="0x7A98" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTLUT_007AB8" OutName="spot17_sceneTLUT_007AB8" Format="rgba16" Width="4" Height="4" Offset="0x7AB8" AddedByScript="true"/>
         <Cutscene Name="gDeathMountainCraterBoleroCs" Offset="0x45D0"/>
         <Cutscene Name="gDeathMountainCraterIntroCs" Offset="0x76D0"/>
         <Scene Name="spot17_scene" Offset="0x0"/>
     </File>
     <File Name="spot17_room_0" Segment="3">
+        <Texture Name="spot17_room_0Tex_003880" OutName="spot17_room_0Tex_003880" Format="rgba16" Width="64" Height="32" Offset="0x3880" AddedByScript="true"/>
+        <Texture Name="spot17_room_0Tex_004880" OutName="spot17_room_0Tex_004880" Format="rgba16" Width="32" Height="32" Offset="0x4880" AddedByScript="true"/>
+        <Texture Name="spot17_room_0Tex_005080" OutName="spot17_room_0Tex_005080" Format="rgba16" Width="32" Height="32" Offset="0x5080" AddedByScript="true"/>
+        <Texture Name="spot17_room_0Tex_005880" OutName="spot17_room_0Tex_005880" Format="rgba16" Width="32" Height="64" Offset="0x5880" AddedByScript="true"/>
         <Room Name="spot17_room_0" Offset="0x0"/>
     </File>
     <File Name="spot17_room_1" Segment="3">
+        <Texture Name="spot17_room_1Tex_00BBD8" OutName="spot17_room_1Tex_00BBD8" Format="ci8" Width="64" Height="32" Offset="0xBBD8" ExternalTlut="spot17_scene" ExternalTlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_00C3D8" OutName="spot17_room_1Tex_00C3D8" Format="ci8" Width="64" Height="32" Offset="0xC3D8" ExternalTlut="spot17_scene" ExternalTlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_00CBD8" OutName="spot17_room_1Tex_00CBD8" Format="rgba16" Width="32" Height="32" Offset="0xCBD8" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_00D3D8" OutName="spot17_room_1Tex_00D3D8" Format="ci8" Width="32" Height="32" Offset="0xD3D8" ExternalTlut="spot17_scene" ExternalTlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_00D7D8" OutName="spot17_room_1Tex_00D7D8" Format="rgba16" Width="64" Height="32" Offset="0xD7D8" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_00E7D8" OutName="spot17_room_1Tex_00E7D8" Format="ci8" Width="16" Height="16" Offset="0xE7D8" ExternalTlut="spot17_scene" ExternalTlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_00E8D8" OutName="spot17_room_1Tex_00E8D8" Format="ci8" Width="32" Height="32" Offset="0xE8D8" ExternalTlut="spot17_scene" ExternalTlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_00ECD8" OutName="spot17_room_1Tex_00ECD8" Format="ci8" Width="32" Height="32" Offset="0xECD8" ExternalTlut="spot17_scene" ExternalTlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_00F0D8" OutName="spot17_room_1Tex_00F0D8" Format="ci8" Width="32" Height="32" Offset="0xF0D8" ExternalTlut="spot17_scene" ExternalTlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_00F4D8" OutName="spot17_room_1Tex_00F4D8" Format="rgba16" Width="32" Height="32" Offset="0xF4D8" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_00FCD8" OutName="spot17_room_1Tex_00FCD8" Format="ci8" Width="32" Height="16" Offset="0xFCD8" ExternalTlut="spot17_scene" ExternalTlutOffset="0x7890" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_010E58" OutName="spot17_room_1Tex_010E58" Format="i4" Width="64" Height="32" Offset="0x10E58" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_011258" OutName="spot17_room_1Tex_011258" Format="i4" Width="64" Height="32" Offset="0x11258" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_011658" OutName="spot17_room_1Tex_011658" Format="i4" Width="64" Height="32" Offset="0x11658" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_011A58" OutName="spot17_room_1Tex_011A58" Format="rgba16" Width="32" Height="32" Offset="0x11A58" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_012258" OutName="spot17_room_1Tex_012258" Format="ia8" Width="16" Height="16" Offset="0x12258" AddedByScript="true"/>
         <Room Name="spot17_room_1" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/overworld/spot18.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/overworld/spot18.xml
@@ -1,5 +1,10 @@
 <Root>
     <File Name="spot18_scene" Segment="2">
+        <Texture Name="spot18_sceneTex_0087C8" OutName="spot18_sceneTex_0087C8" Format="rgba16" Width="32" Height="32" Offset="0x87C8" AddedByScript="true"/>
+        <Texture Name="spot18_sceneTex_009008" OutName="spot18_sceneTex_009008" Format="ci8" Width="64" Height="32" Offset="0x9008" TlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_sceneTex_009848" OutName="spot18_sceneTex_009848" Format="rgba16" Width="16" Height="32" Offset="0x9848" AddedByScript="true"/>
+        <Texture Name="spot18_sceneTex_009C48" OutName="spot18_sceneTex_009C48" Format="ci8" Width="64" Height="32" Offset="0x9C48" TlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_sceneTLUT_0085C0" OutName="spot18_sceneTLUT_0085C0" Format="rgba16" Width="16" Height="16" Offset="0x85C0" AddedByScript="true"/>
         <Cutscene Name="gGoronCityDaruniaCorrectCs" Offset="0x59E0"/>
         <Cutscene Name="gGoronCityDarunia01Cs" Offset="0x6930"/>
         <Cutscene Name="gGoronCityDaruniaWrongCs" Offset="0x7DE0"/>
@@ -9,15 +14,92 @@
         <Scene Name="spot18_scene" Offset="0x0"/>
     </File>
     <File Name="spot18_room_0" Segment="3">
+        <Texture Name="spot18_room_0Tex_004960" OutName="spot18_room_0Tex_004960" Format="rgba16" Width="32" Height="32" Offset="0x4960" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_005160" OutName="spot18_room_0Tex_005160" Format="rgba16" Width="16" Height="32" Offset="0x5160" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_005560" OutName="spot18_room_0Tex_005560" Format="rgba16" Width="16" Height="32" Offset="0x5560" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_005960" OutName="spot18_room_0Tex_005960" Format="rgba16" Width="32" Height="64" Offset="0x5960" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_006960" OutName="spot18_room_0Tex_006960" Format="ci8" Width="32" Height="64" Offset="0x6960" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_007160" OutName="spot18_room_0Tex_007160" Format="rgba16" Width="32" Height="32" Offset="0x7160" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_007960" OutName="spot18_room_0Tex_007960" Format="rgba16" Width="32" Height="32" Offset="0x7960" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_008160" OutName="spot18_room_0Tex_008160" Format="rgba16" Width="32" Height="32" Offset="0x8160" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_008960" OutName="spot18_room_0Tex_008960" Format="ci8" Width="32" Height="64" Offset="0x8960" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_009160" OutName="spot18_room_0Tex_009160" Format="ci8" Width="32" Height="64" Offset="0x9160" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_009960" OutName="spot18_room_0Tex_009960" Format="rgba16" Width="32" Height="32" Offset="0x9960" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_00A160" OutName="spot18_room_0Tex_00A160" Format="ci8" Width="64" Height="32" Offset="0xA160" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_00A960" OutName="spot18_room_0Tex_00A960" Format="ci8" Width="32" Height="64" Offset="0xA960" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_00B160" OutName="spot18_room_0Tex_00B160" Format="ci8" Width="32" Height="64" Offset="0xB160" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_00B960" OutName="spot18_room_0Tex_00B960" Format="ci8" Width="32" Height="64" Offset="0xB960" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_00C160" OutName="spot18_room_0Tex_00C160" Format="ci8" Width="32" Height="64" Offset="0xC160" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_00C960" OutName="spot18_room_0Tex_00C960" Format="ia8" Width="64" Height="64" Offset="0xC960" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_00DFC8" OutName="spot18_room_0Tex_00DFC8" Format="rgba16" Width="32" Height="64" Offset="0xDFC8" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_00EFC8" OutName="spot18_room_0Tex_00EFC8" Format="rgba16" Width="64" Height="32" Offset="0xEFC8" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_00FFC8" OutName="spot18_room_0Tex_00FFC8" Format="rgba16" Width="32" Height="32" Offset="0xFFC8" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_0107C8" OutName="spot18_room_0Tex_0107C8" Format="rgba16" Width="64" Height="32" Offset="0x107C8" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_0117C8" OutName="spot18_room_0Tex_0117C8" Format="rgba16" Width="64" Height="32" Offset="0x117C8" AddedByScript="true"/>
         <Room Name="spot18_room_0" Offset="0x0"/>
     </File>
     <File Name="spot18_room_1" Segment="3">
+        <Texture Name="spot18_room_1Tex_002868" OutName="spot18_room_1Tex_002868" Format="rgba16" Width="32" Height="32" Offset="0x2868" AddedByScript="true"/>
+        <Texture Name="spot18_room_1Tex_003068" OutName="spot18_room_1Tex_003068" Format="i4" Width="128" Height="64" Offset="0x3068" AddedByScript="true"/>
+        <Texture Name="spot18_room_1Tex_004068" OutName="spot18_room_1Tex_004068" Format="ci8" Width="64" Height="32" Offset="0x4068" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_1Tex_004868" OutName="spot18_room_1Tex_004868" Format="rgba16" Width="32" Height="64" Offset="0x4868" AddedByScript="true"/>
+        <Texture Name="spot18_room_1Tex_005E00" OutName="spot18_room_1Tex_005E00" Format="ia4" Width="32" Height="64" Offset="0x5E00" AddedByScript="true"/>
         <Room Name="spot18_room_1" Offset="0x0"/>
     </File>
     <File Name="spot18_room_2" Segment="3">
+        <Texture Name="spot18_room_2Tex_004818" OutName="spot18_room_2Tex_004818" Format="rgba16" Width="32" Height="64" Offset="0x4818" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_005818" OutName="spot18_room_2Tex_005818" Format="rgba16" Width="32" Height="32" Offset="0x5818" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_006018" OutName="spot18_room_2Tex_006018" Format="rgba16" Width="32" Height="32" Offset="0x6018" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_006818" OutName="spot18_room_2Tex_006818" Format="rgba16" Width="32" Height="32" Offset="0x6818" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_007018" OutName="spot18_room_2Tex_007018" Format="ci8" Width="32" Height="64" Offset="0x7018" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_007818" OutName="spot18_room_2Tex_007818" Format="rgba16" Width="32" Height="32" Offset="0x7818" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_008018" OutName="spot18_room_2Tex_008018" Format="rgba16" Width="32" Height="32" Offset="0x8018" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_008818" OutName="spot18_room_2Tex_008818" Format="ci8" Width="32" Height="64" Offset="0x8818" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_009018" OutName="spot18_room_2Tex_009018" Format="ci8" Width="32" Height="64" Offset="0x9018" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_009818" OutName="spot18_room_2Tex_009818" Format="ci8" Width="32" Height="64" Offset="0x9818" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_00A018" OutName="spot18_room_2Tex_00A018" Format="ci8" Width="32" Height="64" Offset="0xA018" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_00A818" OutName="spot18_room_2Tex_00A818" Format="ci8" Width="32" Height="64" Offset="0xA818" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_00B018" OutName="spot18_room_2Tex_00B018" Format="ci8" Width="32" Height="64" Offset="0xB018" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_00B818" OutName="spot18_room_2Tex_00B818" Format="ia8" Width="64" Height="64" Offset="0xB818" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_00D1A8" OutName="spot18_room_2Tex_00D1A8" Format="rgba16" Width="32" Height="64" Offset="0xD1A8" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_00E1A8" OutName="spot18_room_2Tex_00E1A8" Format="rgba16" Width="64" Height="32" Offset="0xE1A8" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_00F1A8" OutName="spot18_room_2Tex_00F1A8" Format="rgba16" Width="32" Height="32" Offset="0xF1A8" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_00F9A8" OutName="spot18_room_2Tex_00F9A8" Format="rgba16" Width="64" Height="32" Offset="0xF9A8" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_0109A8" OutName="spot18_room_2Tex_0109A8" Format="rgba16" Width="64" Height="32" Offset="0x109A8" AddedByScript="true"/>
         <Room Name="spot18_room_2" Offset="0x0"/>
     </File>
     <File Name="spot18_room_3" Segment="3">
+        <Texture Name="spot18_room_3Tex_00B448" OutName="spot18_room_3Tex_00B448" Format="rgba16" Width="32" Height="32" Offset="0xB448" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_00BC48" OutName="spot18_room_3Tex_00BC48" Format="rgba16" Width="16" Height="32" Offset="0xBC48" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_00C048" OutName="spot18_room_3Tex_00C048" Format="rgba16" Width="16" Height="32" Offset="0xC048" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_00C448" OutName="spot18_room_3Tex_00C448" Format="rgba16" Width="16" Height="32" Offset="0xC448" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_00C848" OutName="spot18_room_3Tex_00C848" Format="rgba16" Width="32" Height="64" Offset="0xC848" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_00D848" OutName="spot18_room_3Tex_00D848" Format="rgba16" Width="16" Height="32" Offset="0xD848" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_00DC48" OutName="spot18_room_3Tex_00DC48" Format="ci8" Width="32" Height="64" Offset="0xDC48" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_00E448" OutName="spot18_room_3Tex_00E448" Format="ci8" Width="32" Height="64" Offset="0xE448" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_00EC48" OutName="spot18_room_3Tex_00EC48" Format="rgba16" Width="32" Height="32" Offset="0xEC48" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_00F448" OutName="spot18_room_3Tex_00F448" Format="rgba16" Width="64" Height="32" Offset="0xF448" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_010448" OutName="spot18_room_3Tex_010448" Format="rgba16" Width="32" Height="32" Offset="0x10448" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_010C48" OutName="spot18_room_3Tex_010C48" Format="rgba16" Width="32" Height="32" Offset="0x10C48" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_011448" OutName="spot18_room_3Tex_011448" Format="ci8" Width="32" Height="64" Offset="0x11448" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_011C48" OutName="spot18_room_3Tex_011C48" Format="ci8" Width="32" Height="64" Offset="0x11C48" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_012448" OutName="spot18_room_3Tex_012448" Format="rgba16" Width="16" Height="16" Offset="0x12448" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_012648" OutName="spot18_room_3Tex_012648" Format="rgba16" Width="16" Height="16" Offset="0x12648" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_012848" OutName="spot18_room_3Tex_012848" Format="i4" Width="128" Height="64" Offset="0x12848" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_013848" OutName="spot18_room_3Tex_013848" Format="ci8" Width="64" Height="32" Offset="0x13848" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_014048" OutName="spot18_room_3Tex_014048" Format="rgba16" Width="32" Height="32" Offset="0x14048" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_014848" OutName="spot18_room_3Tex_014848" Format="ci8" Width="32" Height="64" Offset="0x14848" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_015048" OutName="spot18_room_3Tex_015048" Format="ci8" Width="32" Height="64" Offset="0x15048" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_015848" OutName="spot18_room_3Tex_015848" Format="ci8" Width="32" Height="64" Offset="0x15848" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_016048" OutName="spot18_room_3Tex_016048" Format="ci8" Width="32" Height="64" Offset="0x16048" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_016848" OutName="spot18_room_3Tex_016848" Format="ci8" Width="32" Height="32" Offset="0x16848" ExternalTlut="spot18_scene" ExternalTlutOffset="0x85C0" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_016C48" OutName="spot18_room_3Tex_016C48" Format="rgba16" Width="32" Height="32" Offset="0x16C48" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_017448" OutName="spot18_room_3Tex_017448" Format="ia8" Width="64" Height="64" Offset="0x17448" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_0194E8" OutName="spot18_room_3Tex_0194E8" Format="rgba16" Width="32" Height="64" Offset="0x194E8" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_01A4E8" OutName="spot18_room_3Tex_01A4E8" Format="rgba16" Width="64" Height="32" Offset="0x1A4E8" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_01B4E8" OutName="spot18_room_3Tex_01B4E8" Format="rgba16" Width="32" Height="32" Offset="0x1B4E8" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_01BCE8" OutName="spot18_room_3Tex_01BCE8" Format="rgba16" Width="64" Height="32" Offset="0x1BCE8" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_01CCE8" OutName="spot18_room_3Tex_01CCE8" Format="rgba16" Width="64" Height="32" Offset="0x1CCE8" AddedByScript="true"/>
         <Room Name="spot18_room_3" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_PAL_F/scenes/overworld/spot20.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/scenes/overworld/spot20.xml
@@ -1,5 +1,27 @@
 <Root>
     <File Name="spot20_scene" Segment="2">
+        <Texture Name="spot20_sceneTex_005FE0" OutName="spot20_sceneTex_005FE0" Format="ci8" Width="32" Height="64" Offset="0x5FE0" TlutOffset="0x5DB0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_0067E0" OutName="spot20_sceneTex_0067E0" Format="ci8" Width="16" Height="32" Offset="0x67E0" TlutOffset="0x5DB0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_0069E0" OutName="spot20_sceneTex_0069E0" Format="ci8" Width="64" Height="32" Offset="0x69E0" TlutOffset="0x5DB0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_0071E0" OutName="spot20_sceneTex_0071E0" Format="rgba16" Width="64" Height="32" Offset="0x71E0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_0091E0" OutName="spot20_sceneTex_0091E0" Format="ci8" Width="16" Height="32" Offset="0x91E0" TlutOffset="0x5DB0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_0093E0" OutName="spot20_sceneTex_0093E0" Format="rgba16" Width="16" Height="64" Offset="0x93E0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_009BE0" OutName="spot20_sceneTex_009BE0" Format="rgba16" Width="64" Height="32" Offset="0x9BE0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_00ABE0" OutName="spot20_sceneTex_00ABE0" Format="rgba16" Width="32" Height="64" Offset="0xABE0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_00BBE0" OutName="spot20_sceneTex_00BBE0" Format="ci8" Width="32" Height="16" Offset="0xBBE0" TlutOffset="0x5DB0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_00BDE0" OutName="spot20_sceneTex_00BDE0" Format="ci8" Width="32" Height="32" Offset="0xBDE0" TlutOffset="0x5DB0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_00C1E0" OutName="spot20_sceneTex_00C1E0" Format="ci4" Width="64" Height="64" Offset="0xC1E0" TlutOffset="0x5FB8" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_00C9E0" OutName="spot20_sceneTex_00C9E0" Format="ci8" Width="32" Height="64" Offset="0xC9E0" TlutOffset="0x5DB0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_00D1E0" OutName="spot20_sceneTex_00D1E0" Format="rgba16" Width="32" Height="32" Offset="0xD1E0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_00D9E0" OutName="spot20_sceneTex_00D9E0" Format="rgba16" Width="32" Height="32" Offset="0xD9E0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_00E1E0" OutName="spot20_sceneTex_00E1E0" Format="i4" Width="64" Height="64" Offset="0xE1E0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_00E9E0" OutName="spot20_sceneTex_00E9E0" Format="i4" Width="64" Height="64" Offset="0xE9E0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_00F1E0" OutName="spot20_sceneTex_00F1E0" Format="i4" Width="64" Height="64" Offset="0xF1E0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_00F9E0" OutName="spot20_sceneTex_00F9E0" Format="ci8" Width="8" Height="64" Offset="0xF9E0" TlutOffset="0x5DB0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_010BE0" OutName="spot20_sceneTex_010BE0" Format="i4" Width="64" Height="18" Offset="0x10BE0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_010E20" OutName="spot20_sceneTex_010E20" Format="ia8" Width="64" Height="64" Offset="0x10E20" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTLUT_005DB0" OutName="spot20_sceneTLUT_005DB0" Format="rgba16" Width="16" Height="16" Offset="0x5DB0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTLUT_005FB8" OutName="spot20_sceneTLUT_005FB8" Format="rgba16" Width="4" Height="4" Offset="0x5FB8" AddedByScript="true"/>
         <Path Name="gLonLonPath_05844" Offset="0x5844" NumPaths="3"/>
         <Cutscene Name="gLonLonRanchIntroCs" Offset="0x5BD0"/>
         <Texture Name="gLonLonRanchDayWindowTex" OutName="day_window" Format="rgba16" Width="32" Height="64" Offset="0x81E0"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/textures/nintendo_rogo_static.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/textures/nintendo_rogo_static.xml
@@ -1,7 +1,8 @@
 <Root>
      <File Name="nintendo_rogo_static" Segment="1">
 
-         <Texture Name="nintendo_rogo_static_Tex_000000" OutName="tex_00000000" Format="i8" Width="192" Height="32" Offset="0x0000"/>
+         <Texture Name="nintendo_rogo_staticTex_0029C0" OutName="nintendo_rogo_staticTex_0029C0" Format="i8" Width="32" Height="32" Offset="0x29C0" AddedByScript="true"/>
+        <Texture Name="nintendo_rogo_static_Tex_000000" OutName="tex_00000000" Format="i8" Width="192" Height="32" Offset="0x0000"/>
          <Texture Name="nintendo_rogo_static_Tex_001800" OutName="tex_00001800" Format="i8" Width="32" Height="32" Offset="0x1800"/>
          <DList Name="gNintendo64LogoDL" Offset="0x2720"/>
      </File>

--- a/soh/assets/xml/N64_PAL_11/objects/gameplay_dangeon_keep.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/gameplay_dangeon_keep.xml
@@ -1,5 +1,28 @@
 <Root>
     <File Name="gameplay_dangeon_keep" Segment="5">
+        <Texture Name="gameplay_dangeon_keepTex_000000" OutName="gameplay_dangeon_keepTex_000000" Format="i8" Width="16" Height="32" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_000200" OutName="gameplay_dangeon_keepTex_000200" Format="i8" Width="16" Height="32" Offset="0x200" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_0005C0" OutName="gameplay_dangeon_keepTex_0005C0" Format="rgba16" Width="16" Height="16" Offset="0x5C0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_001280" OutName="gameplay_dangeon_keepTex_001280" Format="rgba16" Width="32" Height="32" Offset="0x1280" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_0078A0" OutName="gameplay_dangeon_keepTex_0078A0" Format="i8" Width="32" Height="32" Offset="0x78A0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_007CA0" OutName="gameplay_dangeon_keepTex_007CA0" Format="i8" Width="32" Height="32" Offset="0x7CA0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_0080A0" OutName="gameplay_dangeon_keepTex_0080A0" Format="rgba16" Width="32" Height="32" Offset="0x80A0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_0088A0" OutName="gameplay_dangeon_keepTex_0088A0" Format="rgba16" Width="32" Height="32" Offset="0x88A0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_00D8A0" OutName="gameplay_dangeon_keepTex_00D8A0" Format="rgba16" Width="32" Height="32" Offset="0xD8A0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_00E0A0" OutName="gameplay_dangeon_keepTex_00E0A0" Format="rgba16" Width="32" Height="32" Offset="0xE0A0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_00F8A0" OutName="gameplay_dangeon_keepTex_00F8A0" Format="rgba16" Width="64" Height="32" Offset="0xF8A0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_0108A0" OutName="gameplay_dangeon_keepTex_0108A0" Format="rgba16" Width="32" Height="64" Offset="0x108A0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_0118A0" OutName="gameplay_dangeon_keepTex_0118A0" Format="rgba16" Width="16" Height="16" Offset="0x118A0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_011AA0" OutName="gameplay_dangeon_keepTex_011AA0" Format="rgba16" Width="16" Height="16" Offset="0x11AA0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_011CA0" OutName="gameplay_dangeon_keepTex_011CA0" Format="rgba16" Width="32" Height="64" Offset="0x11CA0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_012CA0" OutName="gameplay_dangeon_keepTex_012CA0" Format="rgba16" Width="64" Height="16" Offset="0x12CA0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_0134A0" OutName="gameplay_dangeon_keepTex_0134A0" Format="rgba16" Width="32" Height="32" Offset="0x134A0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_013CA0" OutName="gameplay_dangeon_keepTex_013CA0" Format="ia8" Width="4" Height="4" Offset="0x13CA0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_013CB0" OutName="gameplay_dangeon_keepTex_013CB0" Format="i4" Width="64" Height="64" Offset="0x13CB0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_0154B0" OutName="gameplay_dangeon_keepTex_0154B0" Format="rgba16" Width="32" Height="32" Offset="0x154B0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_015CB0" OutName="gameplay_dangeon_keepTex_015CB0" Format="rgba16" Width="32" Height="32" Offset="0x15CB0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_0164B0" OutName="gameplay_dangeon_keepTex_0164B0" Format="rgba16" Width="32" Height="32" Offset="0x164B0" AddedByScript="true"/>
+        <Texture Name="gameplay_dangeon_keepTex_016CB0" OutName="gameplay_dangeon_keepTex_016CB0" Format="rgba16" Width="32" Height="32" Offset="0x16CB0" AddedByScript="true"/>
         <DList Name="gUnusedCandleDL" Offset="0x440"/>
         <DList Name="gBrownFragmentDL" Offset="0x530"/>
         <Texture Name="gUnusedStoneTex" OutName="unused_stone" Format="rgba16" Width="32" Height="32" Offset="0x7C0"/>

--- a/soh/assets/xml/N64_PAL_11/objects/gameplay_keep.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/gameplay_keep.xml
@@ -1,6 +1,10 @@
 <Root>
     <ExternalFile XmlPath="misc/link_animetion.xml" OutPath="misc/link_animetion/"/>
     <File Name="gameplay_keep" Segment="4">
+        <Texture Name="gameplay_keepTex_04C540" OutName="gameplay_keepTex_04C540" Format="i8" Width="64" Height="17" Offset="0x4C540" AddedByScript="true"/>
+        <Texture Name="gameplay_keepTex_04C740" OutName="gameplay_keepTex_04C740" Format="i8" Width="64" Height="17" Offset="0x4C740" AddedByScript="true"/>
+        <Texture Name="gameplay_keepTex_04CD40" OutName="gameplay_keepTex_04CD40" Format="i8" Width="64" Height="17" Offset="0x4CD40" AddedByScript="true"/>
+        <Texture Name="gameplay_keepTex_04CF40" OutName="gameplay_keepTex_04CF40" Format="i8" Width="64" Height="17" Offset="0x4CF40" AddedByScript="true"/>
         <Texture Name="gHilite1Tex" OutName="hilite_1" Format="rgba16" Width="16" Height="16" Offset="0x0"/>
         <Texture Name="gHilite2Tex" OutName="hilite_2" Format="rgba16" Width="16" Height="16" Offset="0x200"/>
         <Texture Name="gHylianShieldDesignTex" OutName="hylian_shield_design" Format="rgba16" Width="32" Height="64" Offset="0x400"/>

--- a/soh/assets/xml/N64_PAL_11/objects/object_am.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_am.xml
@@ -1,5 +1,18 @@
 <Root>
     <File Name="object_am" Segment="6">
+        <Texture Name="object_amTex_002638" OutName="object_amTex_002638" Format="i4" Width="32" Height="32" Offset="0x2638" AddedByScript="true"/>
+        <Texture Name="object_amTex_002838" OutName="object_amTex_002838" Format="i4" Width="16" Height="32" Offset="0x2838" AddedByScript="true"/>
+        <Texture Name="object_amTex_002938" OutName="object_amTex_002938" Format="rgba16" Width="16" Height="32" Offset="0x2938" AddedByScript="true"/>
+        <Texture Name="object_amTex_002D38" OutName="object_amTex_002D38" Format="i4" Width="16" Height="32" Offset="0x2D38" AddedByScript="true"/>
+        <Texture Name="object_amTex_002E38" OutName="object_amTex_002E38" Format="i4" Width="32" Height="32" Offset="0x2E38" AddedByScript="true"/>
+        <Texture Name="object_amTex_003038" OutName="object_amTex_003038" Format="i4" Width="32" Height="32" Offset="0x3038" AddedByScript="true"/>
+        <Texture Name="object_amTex_003238" OutName="object_amTex_003238" Format="rgba16" Width="32" Height="32" Offset="0x3238" AddedByScript="true"/>
+        <Texture Name="object_amTex_003A38" OutName="object_amTex_003A38" Format="rgba16" Width="16" Height="16" Offset="0x3A38" AddedByScript="true"/>
+        <Texture Name="object_amTex_003C38" OutName="object_amTex_003C38" Format="rgba16" Width="32" Height="32" Offset="0x3C38" AddedByScript="true"/>
+        <Texture Name="object_amTex_004438" OutName="object_amTex_004438" Format="rgba16" Width="32" Height="32" Offset="0x4438" AddedByScript="true"/>
+        <Texture Name="object_amTex_004C38" OutName="object_amTex_004C38" Format="rgba16" Width="32" Height="32" Offset="0x4C38" AddedByScript="true"/>
+        <Texture Name="object_amTex_005438" OutName="object_amTex_005438" Format="i4" Width="16" Height="8" Offset="0x5438" AddedByScript="true"/>
+        <Texture Name="object_amTex_005478" OutName="object_amTex_005478" Format="rgba16" Width="16" Height="32" Offset="0x5478" AddedByScript="true"/>
         <Skeleton Name="gArmosSkel" Type="Normal" LimbType="Standard" Offset="0x5948"/>
         <Animation Name="gArmosRicochetAnim" Offset="0x33C"/>
         <Animation Name="gArmosHopAnim" Offset="0x238"/>

--- a/soh/assets/xml/N64_PAL_11/objects/object_ani.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_ani.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_ani" Segment="6">
+        <Texture Name="object_aniTex_0011D8" OutName="object_aniTex_0011D8" Format="ci8" Width="16" Height="16" Offset="0x11D8" TlutOffset="0x1088" AddedByScript="true"/>
         <!-- Kakariko Roof Man Skeleton -->
         <Skeleton Name="gRoofManSkel" Type="Flex" LimbType="Standard" Offset="0xF0"/>
 

--- a/soh/assets/xml/N64_PAL_11/objects/object_anubice.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_anubice.xml
@@ -1,5 +1,14 @@
 <Root>
     <File Name="object_anubice" Segment="6">
+        <Texture Name="object_anubiceTex_000F90" OutName="object_anubiceTex_000F90" Format="rgba16" Width="8" Height="16" Offset="0xF90" AddedByScript="true"/>
+        <Texture Name="object_anubiceTex_001090" OutName="object_anubiceTex_001090" Format="rgba16" Width="4" Height="16" Offset="0x1090" AddedByScript="true"/>
+        <Texture Name="object_anubiceTex_001110" OutName="object_anubiceTex_001110" Format="rgba16" Width="16" Height="32" Offset="0x1110" AddedByScript="true"/>
+        <Texture Name="object_anubiceTex_001510" OutName="object_anubiceTex_001510" Format="rgba16" Width="8" Height="8" Offset="0x1510" AddedByScript="true"/>
+        <Texture Name="object_anubiceTex_001590" OutName="object_anubiceTex_001590" Format="rgba16" Width="8" Height="8" Offset="0x1590" AddedByScript="true"/>
+        <Texture Name="object_anubiceTex_001610" OutName="object_anubiceTex_001610" Format="rgba16" Width="4" Height="16" Offset="0x1610" AddedByScript="true"/>
+        <Texture Name="object_anubiceTex_001690" OutName="object_anubiceTex_001690" Format="ia16" Width="32" Height="16" Offset="0x1690" AddedByScript="true"/>
+        <Texture Name="object_anubiceTex_001A90" OutName="object_anubiceTex_001A90" Format="rgba16" Width="8" Height="8" Offset="0x1A90" AddedByScript="true"/>
+        <Texture Name="object_anubiceTex_0036A0" OutName="object_anubiceTex_0036A0" Format="i4" Width="32" Height="32" Offset="0x36A0" AddedByScript="true"/>
         <Skeleton Name="gAnubiceSkel" Type="Normal" LimbType="Standard" Offset="0x3990"/>
 
         <Animation Name="gAnubiceFallDownAnim" Offset="0x348"/>

--- a/soh/assets/xml/N64_PAL_11/objects/object_blkobj.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_blkobj.xml
@@ -1,5 +1,27 @@
 <Root>
     <File Name="object_blkobj" Segment="6">
+        <Texture Name="object_blkobjTex_008090" OutName="object_blkobjTex_008090" Format="rgba16" Width="32" Height="32" Offset="0x8090" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_008890" OutName="object_blkobjTex_008890" Format="rgba16" Width="32" Height="32" Offset="0x8890" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_009090" OutName="object_blkobjTex_009090" Format="rgba16" Width="32" Height="32" Offset="0x9090" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_009890" OutName="object_blkobjTex_009890" Format="rgba16" Width="32" Height="32" Offset="0x9890" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_00A090" OutName="object_blkobjTex_00A090" Format="ia16" Width="32" Height="32" Offset="0xA090" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_00A890" OutName="object_blkobjTex_00A890" Format="rgba16" Width="32" Height="32" Offset="0xA890" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_00B090" OutName="object_blkobjTex_00B090" Format="rgba16" Width="32" Height="32" Offset="0xB090" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_00B890" OutName="object_blkobjTex_00B890" Format="rgba16" Width="32" Height="32" Offset="0xB890" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_00C090" OutName="object_blkobjTex_00C090" Format="rgba16" Width="32" Height="32" Offset="0xC090" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_00C890" OutName="object_blkobjTex_00C890" Format="rgba16" Width="32" Height="32" Offset="0xC890" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_00D090" OutName="object_blkobjTex_00D090" Format="rgba16" Width="32" Height="32" Offset="0xD090" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_00D890" OutName="object_blkobjTex_00D890" Format="rgba16" Width="32" Height="32" Offset="0xD890" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_00E090" OutName="object_blkobjTex_00E090" Format="rgba16" Width="32" Height="32" Offset="0xE090" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_00E890" OutName="object_blkobjTex_00E890" Format="rgba16" Width="32" Height="64" Offset="0xE890" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_00F890" OutName="object_blkobjTex_00F890" Format="rgba16" Width="32" Height="32" Offset="0xF890" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_010090" OutName="object_blkobjTex_010090" Format="rgba16" Width="32" Height="32" Offset="0x10090" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_010890" OutName="object_blkobjTex_010890" Format="rgba16" Width="32" Height="32" Offset="0x10890" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_011090" OutName="object_blkobjTex_011090" Format="rgba16" Width="32" Height="32" Offset="0x11090" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_011890" OutName="object_blkobjTex_011890" Format="rgba16" Width="32" Height="32" Offset="0x11890" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_012090" OutName="object_blkobjTex_012090" Format="rgba16" Width="32" Height="32" Offset="0x12090" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_012890" OutName="object_blkobjTex_012890" Format="rgba16" Width="32" Height="32" Offset="0x12890" AddedByScript="true"/>
+        <Texture Name="object_blkobjTex_013090" OutName="object_blkobjTex_013090" Format="rgba16" Width="32" Height="32" Offset="0x13090" AddedByScript="true"/>
         <!-- Illusion Room Collision -->
         <Collision Name="gIllusionRoomCol" Offset="0x7564"/>
 

--- a/soh/assets/xml/N64_PAL_11/objects/object_box.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_box.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_box" Segment="6">
+        <Texture Name="object_boxTex_004F80" OutName="object_boxTex_004F80" Format="i8" Width="64" Height="32" Offset="0x4F80" AddedByScript="true"/>
         <Skeleton Name="gTreasureChestCurveSkel" Type="Curve" LimbType="Curve" Offset="0x5EB8"/>
         <CurveAnimation Name="gTreasureChestCurveAnim_4B60" SkelOffset="0x5EB8" Offset="0x4B60"/>
         <CurveAnimation Name="gTreasureChestCurveAnim_4F70" SkelOffset="0x5EB8" Offset="0x4F70"/>

--- a/soh/assets/xml/N64_PAL_11/objects/object_bv.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_bv.xml
@@ -1,5 +1,42 @@
 <Root>
     <File Name="object_bv" Segment="6">
+        <Texture Name="object_bvTex_000040" OutName="object_bvTex_000040" Format="ia16" Width="16" Height="64" Offset="0x40" AddedByScript="true"/>
+        <Texture Name="object_bvTex_000840" OutName="object_bvTex_000840" Format="ia16" Width="16" Height="16" Offset="0x840" AddedByScript="true"/>
+        <Texture Name="object_bvTex_000A40" OutName="object_bvTex_000A40" Format="i8" Width="16" Height="32" Offset="0xA40" AddedByScript="true"/>
+        <Texture Name="object_bvTex_0051A0" OutName="object_bvTex_0051A0" Format="rgba16" Width="8" Height="16" Offset="0x51A0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_0052A0" OutName="object_bvTex_0052A0" Format="rgba16" Width="8" Height="16" Offset="0x52A0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_0053A0" OutName="object_bvTex_0053A0" Format="rgba16" Width="16" Height="16" Offset="0x53A0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_0055A0" OutName="object_bvTex_0055A0" Format="ia16" Width="16" Height="32" Offset="0x55A0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_0059A0" OutName="object_bvTex_0059A0" Format="ia16" Width="16" Height="32" Offset="0x59A0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_005DA0" OutName="object_bvTex_005DA0" Format="ia16" Width="16" Height="64" Offset="0x5DA0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_0065A0" OutName="object_bvTex_0065A0" Format="i8" Width="16" Height="32" Offset="0x65A0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_008F88" OutName="object_bvTex_008F88" Format="i8" Width="32" Height="32" Offset="0x8F88" AddedByScript="true"/>
+        <Texture Name="object_bvTex_0117B8" OutName="object_bvTex_0117B8" Format="rgba16" Width="16" Height="16" Offset="0x117B8" AddedByScript="true"/>
+        <Texture Name="object_bvTex_0119B8" OutName="object_bvTex_0119B8" Format="rgba16" Width="16" Height="16" Offset="0x119B8" AddedByScript="true"/>
+        <Texture Name="object_bvTex_011BB8" OutName="object_bvTex_011BB8" Format="rgba16" Width="16" Height="16" Offset="0x11BB8" AddedByScript="true"/>
+        <Texture Name="object_bvTex_012CE0" OutName="object_bvTex_012CE0" Format="i8" Width="64" Height="32" Offset="0x12CE0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_013660" OutName="object_bvTex_013660" Format="ia16" Width="64" Height="64" Offset="0x13660" AddedByScript="true"/>
+        <Texture Name="object_bvTex_0170D8" OutName="object_bvTex_0170D8" Format="rgba16" Width="16" Height="8" Offset="0x170D8" AddedByScript="true"/>
+        <Texture Name="object_bvTex_0171D8" OutName="object_bvTex_0171D8" Format="rgba16" Width="16" Height="16" Offset="0x171D8" AddedByScript="true"/>
+        <Texture Name="object_bvTex_018770" OutName="object_bvTex_018770" Format="rgba16" Width="8" Height="8" Offset="0x18770" AddedByScript="true"/>
+        <Texture Name="object_bvTex_018D30" OutName="object_bvTex_018D30" Format="rgba16" Width="16" Height="8" Offset="0x18D30" AddedByScript="true"/>
+        <Texture Name="object_bvTex_018E30" OutName="object_bvTex_018E30" Format="rgba16" Width="16" Height="16" Offset="0x18E30" AddedByScript="true"/>
+        <Texture Name="object_bvTex_019BB8" OutName="object_bvTex_019BB8" Format="ci8" Width="32" Height="64" Offset="0x19BB8" TlutOffset="0x199B0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_01A6B8" OutName="object_bvTex_01A6B8" Format="ci8" Width="32" Height="64" Offset="0x1A6B8" TlutOffset="0x1A4B0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_01B1B8" OutName="object_bvTex_01B1B8" Format="ci8" Width="32" Height="64" Offset="0x1B1B8" TlutOffset="0x1AFB0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_01BCB8" OutName="object_bvTex_01BCB8" Format="ci8" Width="32" Height="64" Offset="0x1BCB8" TlutOffset="0x1BAB0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_01C7B8" OutName="object_bvTex_01C7B8" Format="ci8" Width="32" Height="64" Offset="0x1C7B8" TlutOffset="0x1C5B0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_01D2B8" OutName="object_bvTex_01D2B8" Format="ci8" Width="32" Height="64" Offset="0x1D2B8" TlutOffset="0x1D0B0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_01DDB8" OutName="object_bvTex_01DDB8" Format="ci8" Width="32" Height="64" Offset="0x1DDB8" TlutOffset="0x1DBB0" AddedByScript="true"/>
+        <Texture Name="object_bvTex_01E8B8" OutName="object_bvTex_01E8B8" Format="ci8" Width="32" Height="64" Offset="0x1E8B8" TlutOffset="0x1E6B0" AddedByScript="true"/>
+        <Texture Name="object_bvTLUT_0199B0" OutName="object_bvTLUT_0199B0" Format="rgba16" Width="16" Height="16" Offset="0x199B0" AddedByScript="true"/>
+        <Texture Name="object_bvTLUT_01A4B0" OutName="object_bvTLUT_01A4B0" Format="rgba16" Width="16" Height="16" Offset="0x1A4B0" AddedByScript="true"/>
+        <Texture Name="object_bvTLUT_01AFB0" OutName="object_bvTLUT_01AFB0" Format="rgba16" Width="16" Height="16" Offset="0x1AFB0" AddedByScript="true"/>
+        <Texture Name="object_bvTLUT_01BAB0" OutName="object_bvTLUT_01BAB0" Format="rgba16" Width="16" Height="16" Offset="0x1BAB0" AddedByScript="true"/>
+        <Texture Name="object_bvTLUT_01C5B0" OutName="object_bvTLUT_01C5B0" Format="rgba16" Width="16" Height="16" Offset="0x1C5B0" AddedByScript="true"/>
+        <Texture Name="object_bvTLUT_01D0B0" OutName="object_bvTLUT_01D0B0" Format="rgba16" Width="16" Height="16" Offset="0x1D0B0" AddedByScript="true"/>
+        <Texture Name="object_bvTLUT_01DBB0" OutName="object_bvTLUT_01DBB0" Format="rgba16" Width="16" Height="16" Offset="0x1DBB0" AddedByScript="true"/>
+        <Texture Name="object_bvTLUT_01E6B0" OutName="object_bvTLUT_01E6B0" Format="rgba16" Width="16" Height="16" Offset="0x1E6B0" AddedByScript="true"/>
         <!-- Boss title card -->
         <Texture Name="gBarinadeTitleCardTex" OutName="barinade_title_card" Format="i8" Width="128" Height="120" Offset="0x1230"/>
 

--- a/soh/assets/xml/N64_PAL_11/objects/object_demo_kekkai.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_demo_kekkai.xml
@@ -1,5 +1,21 @@
 <Root>
     <File Name="object_demo_kekkai" Segment="6">
+        <Texture Name="object_demo_kekkaiTex_000000" OutName="object_demo_kekkaiTex_000000" Format="i8" Width="32" Height="64" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_000800" OutName="object_demo_kekkaiTex_000800" Format="i8" Width="32" Height="64" Offset="0x800" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_001000" OutName="object_demo_kekkaiTex_001000" Format="rgba16" Width="32" Height="64" Offset="0x1000" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_002450" OutName="object_demo_kekkaiTex_002450" Format="rgba16" Width="32" Height="64" Offset="0x2450" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_0036A0" OutName="object_demo_kekkaiTex_0036A0" Format="rgba16" Width="32" Height="32" Offset="0x36A0" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_003EA0" OutName="object_demo_kekkaiTex_003EA0" Format="i8" Width="32" Height="32" Offset="0x3EA0" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_004AC0" OutName="object_demo_kekkaiTex_004AC0" Format="i8" Width="32" Height="32" Offset="0x4AC0" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_006140" OutName="object_demo_kekkaiTex_006140" Format="ia16" Width="8" Height="128" Offset="0x6140" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_006940" OutName="object_demo_kekkaiTex_006940" Format="ia8" Width="64" Height="64" Offset="0x6940" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_007DB0" OutName="object_demo_kekkaiTex_007DB0" Format="rgba16" Width="32" Height="32" Offset="0x7DB0" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_0089D0" OutName="object_demo_kekkaiTex_0089D0" Format="rgba16" Width="32" Height="32" Offset="0x89D0" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_0092D0" OutName="object_demo_kekkaiTex_0092D0" Format="rgba16" Width="32" Height="64" Offset="0x92D0" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_00A440" OutName="object_demo_kekkaiTex_00A440" Format="rgba16" Width="64" Height="32" Offset="0xA440" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_00B540" OutName="object_demo_kekkaiTex_00B540" Format="ia16" Width="32" Height="32" Offset="0xB540" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_00C0B0" OutName="object_demo_kekkaiTex_00C0B0" Format="rgba16" Width="32" Height="32" Offset="0xC0B0" AddedByScript="true"/>
+        <Texture Name="object_demo_kekkaiTex_00C8B0" OutName="object_demo_kekkaiTex_00C8B0" Format="rgba16" Width="32" Height="64" Offset="0xC8B0" AddedByScript="true"/>
         <!-- Demo_Kekkai -->
         <DList Name="gTowerBarrierDL" Offset="0x4930"/>
         <DList Name="gTrialBarrierFloorDL" Offset="0x4F00"/>

--- a/soh/assets/xml/N64_PAL_11/objects/object_dnk.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_dnk.xml
@@ -1,5 +1,10 @@
 <Root>
     <File Name="object_dnk" Segment="6">
+        <Texture Name="object_dnkTex_001BD0" OutName="object_dnkTex_001BD0" Format="rgba16" Width="32" Height="32" Offset="0x1BD0" AddedByScript="true"/>
+        <Texture Name="object_dnkTex_0023D0" OutName="object_dnkTex_0023D0" Format="rgba16" Width="16" Height="16" Offset="0x23D0" AddedByScript="true"/>
+        <Texture Name="object_dnkTex_002650" OutName="object_dnkTex_002650" Format="rgba16" Width="8" Height="8" Offset="0x2650" AddedByScript="true"/>
+        <Texture Name="object_dnkTex_0026D0" OutName="object_dnkTex_0026D0" Format="rgba16" Width="8" Height="8" Offset="0x26D0" AddedByScript="true"/>
+        <Texture Name="object_dnkTex_002850" OutName="object_dnkTex_002850" Format="rgba16" Width="16" Height="16" Offset="0x2850" AddedByScript="true"/>
         <!-- Forest Stage scrub skeleton -->
         <Skeleton Name="gDntStageSkel" Type="Normal" LimbType="Standard" Offset="0x2AF0"/>
         

--- a/soh/assets/xml/N64_PAL_11/objects/object_dns.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_dns.xml
@@ -1,5 +1,10 @@
 <Root>
     <File Name="object_dns" Segment="6">
+        <Texture Name="object_dnsTex_0024A0" OutName="object_dnsTex_0024A0" Format="rgba16" Width="32" Height="32" Offset="0x24A0" AddedByScript="true"/>
+        <Texture Name="object_dnsTex_002CA0" OutName="object_dnsTex_002CA0" Format="rgba16" Width="16" Height="16" Offset="0x2CA0" AddedByScript="true"/>
+        <Texture Name="object_dnsTex_002F20" OutName="object_dnsTex_002F20" Format="rgba16" Width="8" Height="8" Offset="0x2F20" AddedByScript="true"/>
+        <Texture Name="object_dnsTex_002FA0" OutName="object_dnsTex_002FA0" Format="rgba16" Width="8" Height="8" Offset="0x2FA0" AddedByScript="true"/>
+        <Texture Name="object_dnsTex_003120" OutName="object_dnsTex_003120" Format="rgba16" Width="16" Height="16" Offset="0x3120" AddedByScript="true"/>
         <!-- Forest Stage leader skeleton -->
         <Skeleton Name="gDntJijiSkel" Type="Normal" LimbType="Standard" Offset="0x33E0"/>
 

--- a/soh/assets/xml/N64_PAL_11/objects/object_fd.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_fd.xml
@@ -1,5 +1,32 @@
 <Root>
     <File Name="object_fd" Segment="6">
+        <Texture Name="object_fdTex_000458" OutName="object_fdTex_000458" Format="ci4" Width="32" Height="32" Offset="0x458" TlutOffset="0x438" AddedByScript="true"/>
+        <Texture Name="object_fdTex_000658" OutName="object_fdTex_000658" Format="ci4" Width="32" Height="64" Offset="0x658" TlutOffset="0x438" AddedByScript="true"/>
+        <Texture Name="object_fdTex_000A78" OutName="object_fdTex_000A78" Format="ci4" Width="32" Height="32" Offset="0xA78" TlutOffset="0xA58" AddedByScript="true"/>
+        <Texture Name="object_fdTex_0040A8" OutName="object_fdTex_0040A8" Format="rgba16" Width="32" Height="32" Offset="0x40A8" AddedByScript="true"/>
+        <Texture Name="object_fdTex_0048A8" OutName="object_fdTex_0048A8" Format="rgba16" Width="32" Height="32" Offset="0x48A8" AddedByScript="true"/>
+        <Texture Name="object_fdTex_0050A8" OutName="object_fdTex_0050A8" Format="rgba16" Width="16" Height="16" Offset="0x50A8" AddedByScript="true"/>
+        <Texture Name="object_fdTex_0052A8" OutName="object_fdTex_0052A8" Format="rgba16" Width="16" Height="16" Offset="0x52A8" AddedByScript="true"/>
+        <Texture Name="object_fdTex_0054A8" OutName="object_fdTex_0054A8" Format="rgba16" Width="16" Height="16" Offset="0x54A8" AddedByScript="true"/>
+        <Texture Name="object_fdTex_0056A8" OutName="object_fdTex_0056A8" Format="rgba16" Width="16" Height="16" Offset="0x56A8" AddedByScript="true"/>
+        <Texture Name="object_fdTex_005B60" OutName="object_fdTex_005B60" Format="rgba16" Width="16" Height="16" Offset="0x5B60" AddedByScript="true"/>
+        <Texture Name="object_fdTex_005D60" OutName="object_fdTex_005D60" Format="rgba16" Width="16" Height="16" Offset="0x5D60" AddedByScript="true"/>
+        <Texture Name="object_fdTex_005F60" OutName="object_fdTex_005F60" Format="rgba16" Width="16" Height="16" Offset="0x5F60" AddedByScript="true"/>
+        <Texture Name="object_fdTex_009208" OutName="object_fdTex_009208" Format="i8" Width="16" Height="16" Offset="0x9208" AddedByScript="true"/>
+        <Texture Name="object_fdTex_009780" OutName="object_fdTex_009780" Format="rgba16" Width="16" Height="16" Offset="0x9780" AddedByScript="true"/>
+        <Texture Name="object_fdTex_009980" OutName="object_fdTex_009980" Format="rgba16" Width="16" Height="16" Offset="0x9980" AddedByScript="true"/>
+        <Texture Name="object_fdTex_00A050" OutName="object_fdTex_00A050" Format="rgba16" Width="32" Height="32" Offset="0xA050" AddedByScript="true"/>
+        <Texture Name="object_fdTex_00A918" OutName="object_fdTex_00A918" Format="i8" Width="16" Height="16" Offset="0xA918" AddedByScript="true"/>
+        <Texture Name="object_fdTex_00AA18" OutName="object_fdTex_00AA18" Format="rgba16" Width="32" Height="32" Offset="0xAA18" AddedByScript="true"/>
+        <Texture Name="object_fdTex_00B458" OutName="object_fdTex_00B458" Format="rgba16" Width="32" Height="32" Offset="0xB458" AddedByScript="true"/>
+        <Texture Name="object_fdTex_00BC58" OutName="object_fdTex_00BC58" Format="rgba16" Width="16" Height="16" Offset="0xBC58" AddedByScript="true"/>
+        <Texture Name="object_fdTex_00BE58" OutName="object_fdTex_00BE58" Format="rgba16" Width="16" Height="16" Offset="0xBE58" AddedByScript="true"/>
+        <Texture Name="object_fdTex_00C058" OutName="object_fdTex_00C058" Format="rgba16" Width="16" Height="16" Offset="0xC058" AddedByScript="true"/>
+        <Texture Name="object_fdTex_00D170" OutName="object_fdTex_00D170" Format="rgba16" Width="16" Height="16" Offset="0xD170" AddedByScript="true"/>
+        <Texture Name="object_fdTex_00D438" OutName="object_fdTex_00D438" Format="rgba16" Width="16" Height="16" Offset="0xD438" AddedByScript="true"/>
+        <Texture Name="object_fdTLUT_000438" OutName="object_fdTLUT_000438" Format="rgba16" Width="4" Height="4" Offset="0x438" AddedByScript="true"/>
+        <Texture Name="object_fdTLUT_000A58" OutName="object_fdTLUT_000A58" Format="rgba16" Width="4" Height="4" Offset="0xA58" AddedByScript="true"/>
+        <Texture Name="object_fdTLUT_0032A8" OutName="object_fdTLUT_0032A8" Format="rgba16" Width="16" Height="16" Offset="0x32A8" AddedByScript="true"/>
         <!-- Boss title card -->
         <Texture Name="gVolvagiaBossTitleCardTex" OutName="volvagia_boss_title_card" Format="i8" Width="128" Height="120" Offset="0xD700"/>
 

--- a/soh/assets/xml/N64_PAL_11/objects/object_fd2.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_fd2.xml
@@ -1,5 +1,16 @@
 <Root>
     <File Name="object_fd2" Segment="6">
+        <Texture Name="object_fd2Tex_003308" OutName="object_fd2Tex_003308" Format="rgba16" Width="32" Height="32" Offset="0x3308" AddedByScript="true"/>
+        <Texture Name="object_fd2Tex_003B08" OutName="object_fd2Tex_003B08" Format="rgba16" Width="32" Height="32" Offset="0x3B08" AddedByScript="true"/>
+        <Texture Name="object_fd2Tex_004308" OutName="object_fd2Tex_004308" Format="rgba16" Width="16" Height="16" Offset="0x4308" AddedByScript="true"/>
+        <Texture Name="object_fd2Tex_004508" OutName="object_fd2Tex_004508" Format="rgba16" Width="16" Height="16" Offset="0x4508" AddedByScript="true"/>
+        <Texture Name="object_fd2Tex_004708" OutName="object_fd2Tex_004708" Format="rgba16" Width="16" Height="16" Offset="0x4708" AddedByScript="true"/>
+        <Texture Name="object_fd2Tex_004908" OutName="object_fd2Tex_004908" Format="rgba16" Width="16" Height="16" Offset="0x4908" AddedByScript="true"/>
+        <Texture Name="object_fd2Tex_004BE8" OutName="object_fd2Tex_004BE8" Format="i8" Width="16" Height="16" Offset="0x4BE8" AddedByScript="true"/>
+        <Texture Name="object_fd2Tex_004FA0" OutName="object_fd2Tex_004FA0" Format="rgba16" Width="16" Height="16" Offset="0x4FA0" AddedByScript="true"/>
+        <Texture Name="object_fd2Tex_0051A0" OutName="object_fd2Tex_0051A0" Format="rgba16" Width="16" Height="16" Offset="0x51A0" AddedByScript="true"/>
+        <Texture Name="object_fd2Tex_0053A0" OutName="object_fd2Tex_0053A0" Format="rgba16" Width="16" Height="16" Offset="0x53A0" AddedByScript="true"/>
+        <Texture Name="object_fd2TLUT_002508" OutName="object_fd2TLUT_002508" Format="rgba16" Width="16" Height="16" Offset="0x2508" AddedByScript="true"/>
         <!-- Skeleton -->
         <Skeleton Name="gHoleVolvagiaSkel" Type="Flex" LimbType="Standard" Offset="0x11A78"/>
 

--- a/soh/assets/xml/N64_PAL_11/objects/object_fhg.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_fhg.xml
@@ -1,6 +1,26 @@
 <Root>
     <File Name="object_fhg" Segment="6">
 
+        <Texture Name="object_fhgTex_003320" OutName="object_fhgTex_003320" Format="rgba16" Width="16" Height="16" Offset="0x3320" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_003520" OutName="object_fhgTex_003520" Format="rgba16" Width="16" Height="16" Offset="0x3520" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_003720" OutName="object_fhgTex_003720" Format="rgba16" Width="16" Height="16" Offset="0x3720" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_003920" OutName="object_fhgTex_003920" Format="rgba16" Width="16" Height="16" Offset="0x3920" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_003B20" OutName="object_fhgTex_003B20" Format="rgba16" Width="8" Height="8" Offset="0x3B20" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_003BA0" OutName="object_fhgTex_003BA0" Format="rgba16" Width="16" Height="16" Offset="0x3BA0" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_003DA0" OutName="object_fhgTex_003DA0" Format="rgba16" Width="16" Height="16" Offset="0x3DA0" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_003FA0" OutName="object_fhgTex_003FA0" Format="rgba16" Width="16" Height="32" Offset="0x3FA0" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_0043A0" OutName="object_fhgTex_0043A0" Format="rgba16" Width="16" Height="8" Offset="0x43A0" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_0044A0" OutName="object_fhgTex_0044A0" Format="rgba16" Width="32" Height="32" Offset="0x44A0" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_004CA0" OutName="object_fhgTex_004CA0" Format="rgba16" Width="8" Height="16" Offset="0x4CA0" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_004DA0" OutName="object_fhgTex_004DA0" Format="rgba16" Width="8" Height="8" Offset="0x4DA0" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_00D040" OutName="object_fhgTex_00D040" Format="rgba16" Width="4" Height="4" Offset="0xD040" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_00D060" OutName="object_fhgTex_00D060" Format="rgba16" Width="16" Height="16" Offset="0xD060" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_00E8B0" OutName="object_fhgTex_00E8B0" Format="i4" Width="64" Height="64" Offset="0xE8B0" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_00F0B0" OutName="object_fhgTex_00F0B0" Format="i4" Width="64" Height="64" Offset="0xF0B0" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_00FD98" OutName="object_fhgTex_00FD98" Format="i8" Width="64" Height="32" Offset="0xFD98" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_010660" OutName="object_fhgTex_010660" Format="i4" Width="32" Height="96" Offset="0x10660" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_010D20" OutName="object_fhgTex_010D20" Format="i8" Width="32" Height="32" Offset="0x10D20" AddedByScript="true"/>
+        <Texture Name="object_fhgTex_011120" OutName="object_fhgTex_011120" Format="i8" Width="64" Height="64" Offset="0x11120" AddedByScript="true"/>
         <!-- Skeleton -->
         <Skeleton Name="gPhantomHorseSkel" Type="Normal" LimbType="Skin" Offset="0xB098"/>
 

--- a/soh/assets/xml/N64_PAL_11/objects/object_fw.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_fw.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_fw" Segment="6">
+        <Texture Name="object_fwTex_007A90" OutName="object_fwTex_007A90" Format="i8" Width="16" Height="16" Offset="0x7A90" AddedByScript="true"/>
         <!-- Flare Dancer Enflamed Skeleton -->
         <Skeleton Name="gFlareDancerSkel" Type="Flex" LimbType="Standard" Offset="0x5810"/>
 

--- a/soh/assets/xml/N64_PAL_11/objects/object_geldb.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_geldb.xml
@@ -1,5 +1,21 @@
 <Root>
     <File Name="object_geldb" Segment="6">
+        <Texture Name="object_geldbTex_002700" OutName="object_geldbTex_002700" Format="ci8" Width="8" Height="8" Offset="0x2700" TlutOffset="0x2500" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_002740" OutName="object_geldbTex_002740" Format="ci8" Width="8" Height="8" Offset="0x2740" TlutOffset="0x2500" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_002780" OutName="object_geldbTex_002780" Format="ci8" Width="16" Height="16" Offset="0x2780" TlutOffset="0x2500" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_002880" OutName="object_geldbTex_002880" Format="i8" Width="16" Height="16" Offset="0x2880" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_002980" OutName="object_geldbTex_002980" Format="ci8" Width="16" Height="16" Offset="0x2980" TlutOffset="0x2500" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_002A80" OutName="object_geldbTex_002A80" Format="i8" Width="16" Height="16" Offset="0x2A80" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_002B80" OutName="object_geldbTex_002B80" Format="i8" Width="8" Height="16" Offset="0x2B80" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_005F68" OutName="object_geldbTex_005F68" Format="ci8" Width="8" Height="16" Offset="0x5F68" TlutOffset="0x5D30" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_0063E8" OutName="object_geldbTex_0063E8" Format="i8" Width="16" Height="16" Offset="0x63E8" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_0064E8" OutName="object_geldbTex_0064E8" Format="ci8" Width="8" Height="16" Offset="0x64E8" TlutOffset="0x5D30" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_006568" OutName="object_geldbTex_006568" Format="ci8" Width="8" Height="8" Offset="0x6568" TlutOffset="0x5D30" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_0069A8" OutName="object_geldbTex_0069A8" Format="i8" Width="8" Height="16" Offset="0x69A8" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_006A28" OutName="object_geldbTex_006A28" Format="ci8" Width="16" Height="16" Offset="0x6A28" TlutOffset="0x5D30" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_006B28" OutName="object_geldbTex_006B28" Format="ci8" Width="16" Height="16" Offset="0x6B28" TlutOffset="0x5D30" AddedByScript="true"/>
+        <Texture Name="object_geldbTex_006C28" OutName="object_geldbTex_006C28" Format="ci8" Width="16" Height="16" Offset="0x6C28" TlutOffset="0x5D30" AddedByScript="true"/>
+        <Texture Name="object_geldbTLUT_002500" OutName="object_geldbTLUT_002500" Format="rgba16" Width="16" Height="16" Offset="0x2500" AddedByScript="true"/>
         <!-- Red-clothed Gerudo skeleton -->
         <Skeleton Name="gGerudoRedSkel" Type="Flex" LimbType="Standard" Offset="0xA458"/>
 

--- a/soh/assets/xml/N64_PAL_11/objects/object_gi_boots_2.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_gi_boots_2.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_boots_2" Segment="6">
+        <Texture Name="object_gi_boots_2Tex_000000" OutName="object_gi_boots_2Tex_000000" Format="ia8" Width="16" Height="16" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiIronBootsDL" Offset="0x1630"/>
         <DList Name="gGiIronBootsRivetsDL" Offset="0x1A98"/>
     </File>

--- a/soh/assets/xml/N64_PAL_11/objects/object_gi_butterfly.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_gi_butterfly.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_butterfly" Segment="6">
+        <Texture Name="object_gi_butterflyTex_000000" OutName="object_gi_butterflyTex_000000" Format="ia4" Width="24" Height="48" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiButterflyContainerDL" Offset="0x0830"/>
         <DList Name="gGiButterflyGlassDL" Offset="0x0A70"/>
     </File>

--- a/soh/assets/xml/N64_PAL_11/objects/object_gi_clothes.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_gi_clothes.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_clothes" Segment="6">
+        <Texture Name="object_gi_clothesTex_000000" OutName="object_gi_clothesTex_000000" Format="i4" Width="64" Height="64" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiGoronCollarColorDL" Offset="0x14E0"/>
         <DList Name="gGiZoraCollarColorDL" Offset="0x1500"/>
         <DList Name="gGiGoronTunicColorDL" Offset="0x1520"/>

--- a/soh/assets/xml/N64_PAL_11/objects/object_gi_dekupouch.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_gi_dekupouch.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_gi_dekupouch" Segment="6">
+        <Texture Name="object_gi_dekupouchTex_000000" OutName="object_gi_dekupouchTex_000000" Format="i4" Width="32" Height="16" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_dekupouchTex_000100" OutName="object_gi_dekupouchTex_000100" Format="i4" Width="32" Height="32" Offset="0x100" AddedByScript="true"/>
         <DList Name="gGiBulletBagColorDL" Offset="0x0AF0"/>
         <DList Name="gGiBulletBag50ColorDL" Offset="0x0B10"/>
         <DList Name="gGiBulletBagStringColorDL" Offset="0x0B30"/>

--- a/soh/assets/xml/N64_PAL_11/objects/object_gi_fire.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_gi_fire.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_gi_fire" Segment="6">
+        <Texture Name="object_gi_fireTex_000000" OutName="object_gi_fireTex_000000" Format="i8" Width="16" Height="32" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_fireTex_000200" OutName="object_gi_fireTex_000200" Format="i8" Width="16" Height="32" Offset="0x200" AddedByScript="true"/>
         <DList Name="gGiBlueFireChamberstickDL" Offset="0x0C60"/>
         <DList Name="gGiBlueFireFlameDL" Offset="0x0F08"/>
     </File>

--- a/soh/assets/xml/N64_PAL_11/objects/object_gi_frog.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_gi_frog.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_frog" Segment="6">
+        <Texture Name="object_gi_frogTex_000000" OutName="object_gi_frogTex_000000" Format="i8" Width="32" Height="32" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiFrogDL" Offset="0x0D60"/>
         <DList Name="gGiFrogEyesDL" Offset="0x1060"/>
     </File>

--- a/soh/assets/xml/N64_PAL_11/objects/object_gi_gerudo.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_gi_gerudo.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_gerudo" Segment="6">
+        <Texture Name="object_gi_gerudoTex_000000" OutName="object_gi_gerudoTex_000000" Format="i8" Width="32" Height="32" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiGerudoCardDL" Offset="0x0F60"/>
     </File>
 </Root>

--- a/soh/assets/xml/N64_PAL_11/objects/object_gi_gerudomask.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_gi_gerudomask.xml
@@ -1,5 +1,10 @@
 <Root>
     <File Name="object_gi_gerudomask" Segment="6">
+        <Texture Name="object_gi_gerudomaskTex_000208" OutName="object_gi_gerudomaskTex_000208" Format="ci8" Width="8" Height="8" Offset="0x208" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_gerudomaskTex_000248" OutName="object_gi_gerudomaskTex_000248" Format="ci8" Width="16" Height="16" Offset="0x248" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_gerudomaskTex_000348" OutName="object_gi_gerudomaskTex_000348" Format="ci8" Width="16" Height="16" Offset="0x348" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_gerudomaskTex_000448" OutName="object_gi_gerudomaskTex_000448" Format="ci8" Width="32" Height="32" Offset="0x448" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_gerudomaskTLUT_000000" OutName="object_gi_gerudomaskTLUT_000000" Format="rgba16" Width="16" Height="16" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiGerudoMaskDL" Offset="0x10E8"/>
     </File>
 </Root>

--- a/soh/assets/xml/N64_PAL_11/objects/object_gi_ghost.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_gi_ghost.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_gi_ghost" Segment="6">
+        <Texture Name="object_gi_ghostTex_000000" OutName="object_gi_ghostTex_000000" Format="i8" Width="16" Height="32" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_ghostTex_000200" OutName="object_gi_ghostTex_000200" Format="i8" Width="16" Height="32" Offset="0x200" AddedByScript="true"/>
         <DList Name="gGiPoeColorDL" Offset="0x0950"/>
         <DList Name="gGiBigPoeColorDL" Offset="0x0970"/>
         <DList Name="gGiGhostContainerLidDL" Offset="0x0990"/>

--- a/soh/assets/xml/N64_PAL_11/objects/object_gi_gloves.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_gi_gloves.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_gloves" Segment="6">
+        <Texture Name="object_gi_glovesTex_000000" OutName="object_gi_glovesTex_000000" Format="i8" Width="64" Height="32" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiSilverGauntletsColorDL" Offset="0x14C0"/>
         <DList Name="gGiGoldenGauntletsColorDL" Offset="0x14E0"/>
         <DList Name="gGiSilverGauntletsPlateColorDL" Offset="0x1500"/>

--- a/soh/assets/xml/N64_PAL_11/objects/object_gi_golonmask.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_gi_golonmask.xml
@@ -1,5 +1,10 @@
 <Root>
     <File Name="object_gi_golonmask" Segment="6">
+        <Texture Name="object_gi_golonmaskTex_000208" OutName="object_gi_golonmaskTex_000208" Format="ci8" Width="8" Height="8" Offset="0x208" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_golonmaskTex_000248" OutName="object_gi_golonmaskTex_000248" Format="ci8" Width="16" Height="16" Offset="0x248" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_golonmaskTex_000348" OutName="object_gi_golonmaskTex_000348" Format="ci8" Width="32" Height="32" Offset="0x348" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_golonmaskTex_000748" OutName="object_gi_golonmaskTex_000748" Format="ci8" Width="64" Height="32" Offset="0x748" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_golonmaskTLUT_000000" OutName="object_gi_golonmaskTLUT_000000" Format="rgba16" Width="16" Height="16" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiGoronMaskDL" Offset="0x14F8"/>
     </File>
 </Root>

--- a/soh/assets/xml/N64_PAL_11/objects/object_gi_hoverboots.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_gi_hoverboots.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_gi_hoverboots" Segment="6">
+        <Texture Name="object_gi_hoverbootsTex_000000" OutName="object_gi_hoverbootsTex_000000" Format="ia4" Width="48" Height="32" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_hoverbootsTex_000300" OutName="object_gi_hoverbootsTex_000300" Format="i4" Width="16" Height="32" Offset="0x300" AddedByScript="true"/>
         <DList Name="gGiHoverBootsDL" Offset="0x1850"/>
     </File>
 </Root>

--- a/soh/assets/xml/N64_PAL_11/objects/object_gi_ki_tan_mask.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_gi_ki_tan_mask.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_ki_tan_mask" Segment="6">
+        <Texture Name="object_gi_ki_tan_maskTex_000000" OutName="object_gi_ki_tan_maskTex_000000" Format="ia8" Width="8" Height="32" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiKeatonMaskDL" Offset="0x0AC0"/>
         <DList Name="gGiKeatonMaskEyesDL" Offset="0x0D50"/>
     </File>

--- a/soh/assets/xml/N64_PAL_11/objects/object_gi_letter.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_gi_letter.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_gi_letter" Segment="6">
+        <Texture Name="object_gi_letterTex_000000" OutName="object_gi_letterTex_000000" Format="i8" Width="48" Height="32" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_letterTex_000600" OutName="object_gi_letterTex_000600" Format="ia8" Width="48" Height="32" Offset="0x600" AddedByScript="true"/>
         <DList Name="gGiLetterDL" Offset="0x0CC0"/>
         <DList Name="gGiLetterWritingDL" Offset="0x0D60"/>
     </File>

--- a/soh/assets/xml/N64_PAL_11/objects/object_gi_liquid.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_gi_liquid.xml
@@ -1,5 +1,8 @@
 <Root>
     <File Name="object_gi_liquid" Segment="6">
+        <Texture Name="object_gi_liquidTex_000000" OutName="object_gi_liquidTex_000000" Format="ia8" Width="16" Height="32" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_liquidTex_000200" OutName="object_gi_liquidTex_000200" Format="ia8" Width="16" Height="32" Offset="0x200" AddedByScript="true"/>
+        <Texture Name="object_gi_liquidTex_000400" OutName="object_gi_liquidTex_000400" Format="ia8" Width="16" Height="32" Offset="0x400" AddedByScript="true"/>
         <DList Name="gGiGreenPotColorDL" Offset="0x1270"/>
         <DList Name="gGiRedPotColorDL" Offset="0x1290"/>
         <DList Name="gGiBluePotColorDL" Offset="0x12B0"/>

--- a/soh/assets/xml/N64_PAL_11/objects/object_gi_map.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_gi_map.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_map" Segment="6">
+        <Texture Name="object_gi_mapTex_000D60" OutName="object_gi_mapTex_000D60" Format="i8" Width="32" Height="32" Offset="0xD60" AddedByScript="true"/>
         <DList Name="gGiDungeonMapDL" Offset="0x03C0"/>
         <DList Name="gGiStoneOfAgonyDL" Offset="0x0B70"/>
     </File>

--- a/soh/assets/xml/N64_PAL_11/objects/object_gi_milk.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_gi_milk.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_milk" Segment="6">
+        <Texture Name="object_gi_milkTex_000000" OutName="object_gi_milkTex_000000" Format="i8" Width="72" Height="24" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiMilkBottleContentsDL" Offset="0x1060"/>
         <DList Name="gGiMilkBottleDL" Offset="0x1288"/>
     </File>

--- a/soh/assets/xml/N64_PAL_11/objects/object_gi_niwatori.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_gi_niwatori.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_gi_niwatori" Segment="6">
+        <Texture Name="object_gi_niwatoriTex_000000" OutName="object_gi_niwatoriTex_000000" Format="i8" Width="32" Height="64" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_niwatoriTex_000800" OutName="object_gi_niwatoriTex_000800" Format="ia8" Width="32" Height="32" Offset="0x800" AddedByScript="true"/>
         <DList Name="gGiChickenColorDL" Offset="0x15F0"/>
         <DList Name="gGiCojiroColorDL" Offset="0x1610"/>
         <DList Name="gGiChickenDL" Offset="0x1630"/>

--- a/soh/assets/xml/N64_PAL_11/objects/object_gi_nuts.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_gi_nuts.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_nuts" Segment="6">
+        <Texture Name="object_gi_nutsTex_000000" OutName="object_gi_nutsTex_000000" Format="i8" Width="32" Height="32" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiNutDL" Offset="0x0E90"/>
     </File>
 </Root>

--- a/soh/assets/xml/N64_PAL_11/objects/object_gi_ocarina.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_gi_ocarina.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_ocarina" Segment="6">
+        <Texture Name="object_gi_ocarinaTex_000000" OutName="object_gi_ocarinaTex_000000" Format="i8" Width="16" Height="16" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiOcarinaTimeDL" Offset="0x08C0"/>
         <DList Name="gGiOcarinaTimeHolesDL" Offset="0x0AF8"/>
     </File>

--- a/soh/assets/xml/N64_PAL_11/objects/object_gi_ocarina_0.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_gi_ocarina_0.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_ocarina_0" Segment="6">
+        <Texture Name="object_gi_ocarina_0Tex_000000" OutName="object_gi_ocarina_0Tex_000000" Format="i8" Width="16" Height="16" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiOcarinaFairyDL" Offset="0x08E0"/>
         <DList Name="gGiOcarinaFairyHolesDL" Offset="0x0B58"/>
     </File>

--- a/soh/assets/xml/N64_PAL_11/objects/object_gi_prescription.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_gi_prescription.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_prescription" Segment="6">
+        <Texture Name="object_gi_prescriptionTex_000000" OutName="object_gi_prescriptionTex_000000" Format="ia8" Width="32" Height="48" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiPrescriptionDL" Offset="0x09C0"/>
         <DList Name="gGiPrescriptionWritingDL" Offset="0x0AF0"/>
     </File>

--- a/soh/assets/xml/N64_PAL_11/objects/object_gi_purse.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_gi_purse.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_purse" Segment="6">
+        <Texture Name="object_gi_purseTex_000000" OutName="object_gi_purseTex_000000" Format="i8" Width="64" Height="64" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiAdultWalletColorDL" Offset="0x1750"/>
         <DList Name="gGiGiantsWalletColorDL" Offset="0x1770"/>
         <DList Name="gGiAdultWalletRupeeOuterColorDL" Offset="0x1790"/>

--- a/soh/assets/xml/N64_PAL_11/objects/object_gi_rabit_mask.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_gi_rabit_mask.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_rabit_mask" Segment="6">
+        <Texture Name="object_gi_rabit_maskTex_000000" OutName="object_gi_rabit_maskTex_000000" Format="ia8" Width="16" Height="16" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiBunnyHoodDL" Offset="0x0BC0"/>
         <DList Name="gGiBunnyHoodEyesDL" Offset="0x0E58"/>
     </File>

--- a/soh/assets/xml/N64_PAL_11/objects/object_gi_shield_1.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_gi_shield_1.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_shield_1" Segment="6">
+        <Texture Name="object_gi_shield_1Tex_000000" OutName="object_gi_shield_1Tex_000000" Format="i8" Width="32" Height="32" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiDekuShieldDL" Offset="0x0A50"/>
     </File>
 </Root>

--- a/soh/assets/xml/N64_PAL_11/objects/object_gi_shield_3.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_gi_shield_3.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_gi_shield_3" Segment="6">
+        <Texture Name="object_gi_shield_3Tex_000000" OutName="object_gi_shield_3Tex_000000" Format="i4" Width="64" Height="32" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_shield_3Tex_000400" OutName="object_gi_shield_3Tex_000400" Format="i4" Width="64" Height="64" Offset="0x400" AddedByScript="true"/>
         <DList Name="gGiMirrorShieldDL" Offset="0x0FB0"/>
         <DList Name="gGiMirrorShieldSymbolDL" Offset="0x11C8"/>
     </File>

--- a/soh/assets/xml/N64_PAL_11/objects/object_gi_soldout.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_gi_soldout.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_soldout" Segment="6">
+        <Texture Name="object_gi_soldoutTex_000000" OutName="object_gi_soldoutTex_000000" Format="ia8" Width="32" Height="32" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiSoldOutDL" Offset="0x0440"/>
     </File>
 </Root>

--- a/soh/assets/xml/N64_PAL_11/objects/object_gi_soul.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_gi_soul.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_gi_soul" Segment="6">
+        <Texture Name="object_gi_soulTex_000000" OutName="object_gi_soulTex_000000" Format="i8" Width="32" Height="32" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiFairyContainerBaseCapDL" Offset="0x0BD0"/>
         <DList Name="gGiFairyContainerGlassDL" Offset="0x0DB8"/>
         <DList Name="gGiFairyContainerContentsDL" Offset="0x0EF0"/>

--- a/soh/assets/xml/N64_PAL_11/objects/object_gi_ticketstone.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_gi_ticketstone.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_gi_ticketstone" Segment="6">
+        <Texture Name="object_gi_ticketstoneTex_000000" OutName="object_gi_ticketstoneTex_000000" Format="i4" Width="48" Height="24" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_ticketstoneTex_000240" OutName="object_gi_ticketstoneTex_000240" Format="i8" Width="32" Height="24" Offset="0x240" AddedByScript="true"/>
         <DList Name="gGiClaimCheckDL" Offset="0x0F00"/>
         <DList Name="gGiClaimCheckWritingDL" Offset="0x1188"/>
     </File>

--- a/soh/assets/xml/N64_PAL_11/objects/object_gi_truth_mask.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_gi_truth_mask.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_gi_truth_mask" Segment="6">
+        <Texture Name="object_gi_truth_maskTex_000000" OutName="object_gi_truth_maskTex_000000" Format="i8" Width="32" Height="32" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_truth_maskTex_000400" OutName="object_gi_truth_maskTex_000400" Format="i8" Width="32" Height="32" Offset="0x400" AddedByScript="true"/>
         <DList Name="gGiMaskOfTruthDL" Offset="0x13D0"/>
         <DList Name="gGiMaskOfTruthAccentsDL" Offset="0x16B0"/>
     </File>

--- a/soh/assets/xml/N64_PAL_11/objects/object_gi_zoramask.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_gi_zoramask.xml
@@ -1,5 +1,10 @@
 <Root>
     <File Name="object_gi_zoramask" Segment="6">
+        <Texture Name="object_gi_zoramaskTex_000208" OutName="object_gi_zoramaskTex_000208" Format="ci8" Width="8" Height="8" Offset="0x208" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_zoramaskTex_000248" OutName="object_gi_zoramaskTex_000248" Format="ci8" Width="32" Height="32" Offset="0x248" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_zoramaskTex_000648" OutName="object_gi_zoramaskTex_000648" Format="ci8" Width="32" Height="32" Offset="0x648" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_zoramaskTex_000A48" OutName="object_gi_zoramaskTex_000A48" Format="ci8" Width="32" Height="32" Offset="0xA48" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_gi_zoramaskTLUT_000000" OutName="object_gi_zoramaskTLUT_000000" Format="rgba16" Width="16" Height="16" Offset="0x0" AddedByScript="true"/>
         <DList Name="gGiZoraMaskDL" Offset="0x1398"/>
     </File>
 </Root>

--- a/soh/assets/xml/N64_PAL_11/objects/object_gj.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_gj.xml
@@ -1,5 +1,15 @@
 <Root>
     <File Name="object_gj" Segment="6">
+        <Texture Name="object_gjTex_003B20" OutName="object_gjTex_003B20" Format="ia8" Width="16" Height="16" Offset="0x3B20" AddedByScript="true"/>
+        <Texture Name="object_gjTex_003C20" OutName="object_gjTex_003C20" Format="i4" Width="16" Height="32" Offset="0x3C20" AddedByScript="true"/>
+        <Texture Name="object_gjTex_003D20" OutName="object_gjTex_003D20" Format="rgba16" Width="16" Height="16" Offset="0x3D20" AddedByScript="true"/>
+        <Texture Name="object_gjTex_003F20" OutName="object_gjTex_003F20" Format="i8" Width="64" Height="64" Offset="0x3F20" AddedByScript="true"/>
+        <Texture Name="object_gjTex_004F20" OutName="object_gjTex_004F20" Format="i8" Width="64" Height="64" Offset="0x4F20" AddedByScript="true"/>
+        <Texture Name="object_gjTex_005F20" OutName="object_gjTex_005F20" Format="i8" Width="64" Height="64" Offset="0x5F20" AddedByScript="true"/>
+        <Texture Name="object_gjTex_006F20" OutName="object_gjTex_006F20" Format="i4" Width="32" Height="64" Offset="0x6F20" AddedByScript="true"/>
+        <Texture Name="object_gjTex_007320" OutName="object_gjTex_007320" Format="i8" Width="64" Height="16" Offset="0x7320" AddedByScript="true"/>
+        <Texture Name="object_gjTex_007720" OutName="object_gjTex_007720" Format="ia8" Width="32" Height="32" Offset="0x7720" AddedByScript="true"/>
+        <Texture Name="object_gjTex_007B20" OutName="object_gjTex_007B20" Format="i8" Width="128" Height="32" Offset="0x7B20" AddedByScript="true"/>
         <!-- This is the decorative rubble around the fight arena -->
         <DList Name="gGanonsCastleRubbleAroundArenaDL" Offset="0xDC0"/>
         <Collision Name="gGanonsCastleRubbleAroundArenaCol" Offset="0x1B70"/>

--- a/soh/assets/xml/N64_PAL_11/objects/object_gnd.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_gnd.xml
@@ -1,6 +1,7 @@
 <Root>
     <File Name="object_gnd" Segment="6">
         
+        <Texture Name="object_gndTex_012B50" OutName="object_gndTex_012B50" Format="rgba16" Width="16" Height="32" Offset="0x12B50" AddedByScript="true"/>
         <!-- Skeleton -->
         <Skeleton Name="gPhantomGanonSkel" Type="Normal" LimbType="Standard" Offset="0xC710"/>
         

--- a/soh/assets/xml/N64_PAL_11/objects/object_gr.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_gr.xml
@@ -1,12 +1,23 @@
 <Root>
     <File Name="object_gr" Segment="6">
+        <Texture Name="object_grTex_005D78" OutName="object_grTex_005D78" Format="ci8" Width="16" Height="16" Offset="0x5D78" TlutOffset="0x3F78" AddedByScript="true"/>
+        <Texture Name="object_grTex_005E78" OutName="object_grTex_005E78" Format="ci8" Width="8" Height="8" Offset="0x5E78" TlutOffset="0x3F78" AddedByScript="true"/>
+        <Texture Name="object_grTex_005EB8" OutName="object_grTex_005EB8" Format="ci8" Width="8" Height="8" Offset="0x5EB8" TlutOffset="0x3F78" AddedByScript="true"/>
+        <Texture Name="object_grTex_005EF8" OutName="object_grTex_005EF8" Format="ci8" Width="16" Height="16" Offset="0x5EF8" TlutOffset="0x3F78" AddedByScript="true"/>
+        <Texture Name="object_grTex_0077F8" OutName="object_grTex_0077F8" Format="ci8" Width="32" Height="32" Offset="0x77F8" TlutOffset="0x3F78" AddedByScript="true"/>
+        <Texture Name="object_grTex_007BF8" OutName="object_grTex_007BF8" Format="ci8" Width="32" Height="32" Offset="0x7BF8" TlutOffset="0x3F78" AddedByScript="true"/>
+        <Texture Name="object_grTex_007FF8" OutName="object_grTex_007FF8" Format="ci8" Width="32" Height="32" Offset="0x7FF8" TlutOffset="0x3F78" AddedByScript="true"/>
+        <Texture Name="object_grTex_0083F8" OutName="object_grTex_0083F8" Format="ci8" Width="32" Height="32" Offset="0x83F8" TlutOffset="0x3F78" AddedByScript="true"/>
+        <Texture Name="object_grTex_0097F8" OutName="object_grTex_0097F8" Format="ci8" Width="4" Height="4" Offset="0x97F8" TlutOffset="0x3F78" AddedByScript="true"/>
+        <Texture Name="object_grTex_009808" OutName="object_grTex_009808" Format="ci8" Width="8" Height="8" Offset="0x9808" TlutOffset="0x3F78" AddedByScript="true"/>
+        <Texture Name="object_grTLUT_003F78" OutName="object_grTLUT_003F78" Format="rgba16" Width="16" Height="16" Offset="0x3F78" AddedByScript="true"/>
         <Skeleton Name="gNiwGirlSkel" Type="Flex" LimbType="Standard" Offset="0x9948"/>
         <Animation Name="gNiwGirlRunAnim" Offset="0x0378"/>
         <Animation Name="gNiwGirlJumpAnim" Offset="0x9C78"/>
         <Texture Name="gNiwGirlEyeOpenTex" OutName="eye_open" Format="rgba16" Width="32" Height="32" Offset="0x4178"/>
         <Texture Name="gNiwGirlEyeHalfTex" OutName="eye_half" Format="rgba16" Width="32" Height="32" Offset="0x4978"/>
         <Texture Name="gNiwGirlEyeClosedTex" OutName="eye_closed" Format="rgba16" Width="32" Height="32" Offset="0x5178"/>
-        <Texture Name="gNiwGirlMouthTex"  OutName="mouth" Format="rgba16" Width="32" Height="16" Offset="0x5978"/>
+        <Texture Name="gNiwGirlMouthTex" OutName="mouth" Format="rgba16" Width="32" Height="16" Offset="0x5978"/>
         <Texture Name="gNiwGirlDress1Tex" OutName="dress_1" Format="rgba16" Width="32" Height="32" Offset="0x5FF8"/>
         <Texture Name="gNiwGirlDress2Tex" OutName="dress_2" Format="rgba16" Width="32" Height="32" Offset="0x6FF8"/>
         <Texture Name="gNiwGirlDress3Tex" OutName="dress_3" Format="rgba16" Width="32" Height="32" Offset="0x8FF8"/>

--- a/soh/assets/xml/N64_PAL_11/objects/object_hakach_objects.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_hakach_objects.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_hakach_objects" Segment="6">
+        <Texture Name="object_hakach_objectsTex_0062F0" OutName="object_hakach_objectsTex_0062F0" Format="rgba16" Width="32" Height="32" Offset="0x62F0" AddedByScript="true"/>
         <DList Name="gBotwHoleTrap1DL" Offset="0x01B0"/>
         <DList Name="gBotwHoleTrap2DL" Offset="0x03F0"/>
         <DList Name="gBotwCoffinLidDL" Offset="0x06B0"/>

--- a/soh/assets/xml/N64_PAL_11/objects/object_hidan_objects.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_hidan_objects.xml
@@ -1,5 +1,25 @@
 <Root>
     <File Name="object_hidan_objects" Segment="6">
+        <Texture Name="object_hidan_objectsTex_000040" OutName="object_hidan_objectsTex_000040" Format="ci4" Width="32" Height="32" Offset="0x40" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_000240" OutName="object_hidan_objectsTex_000240" Format="rgba16" Width="32" Height="32" Offset="0x240" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_000A40" OutName="object_hidan_objectsTex_000A40" Format="rgba16" Width="32" Height="64" Offset="0xA40" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_001A40" OutName="object_hidan_objectsTex_001A40" Format="rgba16" Width="32" Height="64" Offset="0x1A40" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_002A40" OutName="object_hidan_objectsTex_002A40" Format="rgba16" Width="32" Height="64" Offset="0x2A40" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_003A40" OutName="object_hidan_objectsTex_003A40" Format="rgba16" Width="32" Height="32" Offset="0x3A40" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_004240" OutName="object_hidan_objectsTex_004240" Format="rgba16" Width="16" Height="64" Offset="0x4240" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_004A40" OutName="object_hidan_objectsTex_004A40" Format="rgba16" Width="32" Height="32" Offset="0x4A40" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_005240" OutName="object_hidan_objectsTex_005240" Format="ci4" Width="32" Height="64" Offset="0x5240" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_005640" OutName="object_hidan_objectsTex_005640" Format="ci4" Width="32" Height="64" Offset="0x5640" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_005A40" OutName="object_hidan_objectsTex_005A40" Format="ci4" Width="64" Height="32" Offset="0x5A40" TlutOffset="0x20" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_005E40" OutName="object_hidan_objectsTex_005E40" Format="rgba16" Width="32" Height="32" Offset="0x5E40" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_006640" OutName="object_hidan_objectsTex_006640" Format="ci4" Width="32" Height="64" Offset="0x6640" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_006A40" OutName="object_hidan_objectsTex_006A40" Format="ci4" Width="32" Height="32" Offset="0x6A40" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_006C40" OutName="object_hidan_objectsTex_006C40" Format="ci4" Width="32" Height="32" Offset="0x6C40" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_006E40" OutName="object_hidan_objectsTex_006E40" Format="rgba16" Width="32" Height="32" Offset="0x6E40" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_00FB20" OutName="object_hidan_objectsTex_00FB20" Format="rgba16" Width="32" Height="64" Offset="0xFB20" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTex_010D90" OutName="object_hidan_objectsTex_010D90" Format="rgba16" Width="32" Height="64" Offset="0x10D90" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTLUT_000000" OutName="object_hidan_objectsTLUT_000000" Format="rgba16" Width="4" Height="4" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="object_hidan_objectsTLUT_000020" OutName="object_hidan_objectsTLUT_000020" Format="rgba16" Width="4" Height="4" Offset="0x20" AddedByScript="true"/>
         <DList Name="gFireTempleHammerableTotemBodyDL" Offset="0xBBF0"/>
         <DList Name="gFireTempleHammerableTotemHeadDL" Offset="0xBDF0"/>
         <Collision Name="gFireTempleHammerableTotemCol" Offset="0xDA10"/>

--- a/soh/assets/xml/N64_PAL_11/objects/object_hintnuts.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_hintnuts.xml
@@ -1,5 +1,11 @@
 <Root>
     <File Name="object_hintnuts" Segment="6">
+        <Texture Name="object_hintnutsTex_0015A8" OutName="object_hintnutsTex_0015A8" Format="rgba16" Width="32" Height="32" Offset="0x15A8" AddedByScript="true"/>
+        <Texture Name="object_hintnutsTex_001DA8" OutName="object_hintnutsTex_001DA8" Format="rgba16" Width="16" Height="16" Offset="0x1DA8" AddedByScript="true"/>
+        <Texture Name="object_hintnutsTex_001FA8" OutName="object_hintnutsTex_001FA8" Format="rgba16" Width="8" Height="8" Offset="0x1FA8" AddedByScript="true"/>
+        <Texture Name="object_hintnutsTex_002028" OutName="object_hintnutsTex_002028" Format="rgba16" Width="8" Height="8" Offset="0x2028" AddedByScript="true"/>
+        <Texture Name="object_hintnutsTex_0020A8" OutName="object_hintnutsTex_0020A8" Format="rgba16" Width="8" Height="8" Offset="0x20A8" AddedByScript="true"/>
+        <Texture Name="object_hintnutsTex_002128" OutName="object_hintnutsTex_002128" Format="rgba16" Width="16" Height="16" Offset="0x2128" AddedByScript="true"/>
         <!-- Deku scrub skeleton -->
         <Skeleton Name="gHintNutsSkel" Type="Normal" LimbType="Standard" Offset="0x23B8"/>
         

--- a/soh/assets/xml/N64_PAL_11/objects/object_horse_ganon.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_horse_ganon.xml
@@ -1,5 +1,16 @@
 <Root>
     <File Name="object_horse_ganon" Segment="6">
+        <Texture Name="object_horse_ganonTex_00A570" OutName="object_horse_ganonTex_00A570" Format="rgba16" Width="8" Height="8" Offset="0xA570" AddedByScript="true"/>
+        <Texture Name="object_horse_ganonTex_00A5F0" OutName="object_horse_ganonTex_00A5F0" Format="rgba16" Width="16" Height="16" Offset="0xA5F0" AddedByScript="true"/>
+        <Texture Name="object_horse_ganonTex_00A7F0" OutName="object_horse_ganonTex_00A7F0" Format="rgba16" Width="4" Height="4" Offset="0xA7F0" AddedByScript="true"/>
+        <Texture Name="object_horse_ganonTex_00A810" OutName="object_horse_ganonTex_00A810" Format="rgba16" Width="16" Height="16" Offset="0xA810" AddedByScript="true"/>
+        <Texture Name="object_horse_ganonTex_00AA10" OutName="object_horse_ganonTex_00AA10" Format="rgba16" Width="16" Height="16" Offset="0xAA10" AddedByScript="true"/>
+        <Texture Name="object_horse_ganonTex_00B010" OutName="object_horse_ganonTex_00B010" Format="rgba16" Width="8" Height="16" Offset="0xB010" AddedByScript="true"/>
+        <Texture Name="object_horse_ganonTex_00B110" OutName="object_horse_ganonTex_00B110" Format="rgba16" Width="16" Height="32" Offset="0xB110" AddedByScript="true"/>
+        <Texture Name="object_horse_ganonTex_00B510" OutName="object_horse_ganonTex_00B510" Format="rgba16" Width="16" Height="8" Offset="0xB510" AddedByScript="true"/>
+        <Texture Name="object_horse_ganonTex_00B610" OutName="object_horse_ganonTex_00B610" Format="rgba16" Width="8" Height="8" Offset="0xB610" AddedByScript="true"/>
+        <Texture Name="object_horse_ganonTex_00B690" OutName="object_horse_ganonTex_00B690" Format="rgba16" Width="32" Height="32" Offset="0xB690" AddedByScript="true"/>
+        <Texture Name="object_horse_ganonTex_00BE90" OutName="object_horse_ganonTex_00BE90" Format="rgba16" Width="16" Height="16" Offset="0xBE90" AddedByScript="true"/>
         <Skeleton Name="gHorseGanonSkel" Type="Normal" LimbType="Skin" Offset="0x8668"/>
 
         <!-- Idle. Horse moving leg. -->

--- a/soh/assets/xml/N64_PAL_11/objects/object_horse_link_child.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_horse_link_child.xml
@@ -1,5 +1,14 @@
 <Root>
     <File Name="object_horse_link_child" Segment="6">
+        <Texture Name="object_horse_link_childTex_001F28" OutName="object_horse_link_childTex_001F28" Format="rgba16" Width="4" Height="8" Offset="0x1F28" AddedByScript="true"/>
+        <Texture Name="object_horse_link_childTex_001F68" OutName="object_horse_link_childTex_001F68" Format="rgba16" Width="16" Height="16" Offset="0x1F68" AddedByScript="true"/>
+        <Texture Name="object_horse_link_childTex_002168" OutName="object_horse_link_childTex_002168" Format="rgba16" Width="16" Height="16" Offset="0x2168" AddedByScript="true"/>
+        <Texture Name="object_horse_link_childTex_002368" OutName="object_horse_link_childTex_002368" Format="rgba16" Width="16" Height="16" Offset="0x2368" AddedByScript="true"/>
+        <Texture Name="object_horse_link_childTex_002568" OutName="object_horse_link_childTex_002568" Format="rgba16" Width="4" Height="4" Offset="0x2568" AddedByScript="true"/>
+        <Texture Name="object_horse_link_childTex_002588" OutName="object_horse_link_childTex_002588" Format="rgba16" Width="8" Height="32" Offset="0x2588" AddedByScript="true"/>
+        <Texture Name="object_horse_link_childTex_002788" OutName="object_horse_link_childTex_002788" Format="rgba16" Width="16" Height="16" Offset="0x2788" AddedByScript="true"/>
+        <Texture Name="object_horse_link_childTex_008120" OutName="object_horse_link_childTex_008120" Format="rgba16" Width="16" Height="16" Offset="0x8120" AddedByScript="true"/>
+        <Texture Name="object_horse_link_childTex_008320" OutName="object_horse_link_childTex_008320" Format="rgba16" Width="32" Height="32" Offset="0x8320" AddedByScript="true"/>
         <Skeleton Name="gChildEponaSkel" Type="Normal" LimbType="Skin" Offset="0x7B20"/>
 
         <!-- Idle animation. -->
@@ -14,8 +23,8 @@
         <Animation Name="gChildEponaGallopingAnim" Offset="0x2F98"/>
 
         <Texture Name="gChildEponaEyeTLUT" OutName="child_epona_eye_tlut" Format="rgba16" Width="16" Height="16" Offset="0x1728"/>
-        <Texture Name="gChildEponaEyeOpenTex" OutName="child_epona_eye_open" Format="ci8" Width="32" Height="16" Offset="0x1D28"  TlutOffset="0x1728"/>
-        <Texture Name="gChildEponaEyeHalfTex" OutName="child_epona_eye_half" Format="ci8" Width="32" Height="16" Offset="0x1928"  TlutOffset="0x1728"/>
-        <Texture Name="gChildEponaEyeCloseTex" OutName="child_epona_eye_close" Format="ci8" Width="32" Height="16" Offset="0x1B28"  TlutOffset="0x1728"/>
+        <Texture Name="gChildEponaEyeOpenTex" OutName="child_epona_eye_open" Format="ci8" Width="32" Height="16" Offset="0x1D28" TlutOffset="0x1728"/>
+        <Texture Name="gChildEponaEyeHalfTex" OutName="child_epona_eye_half" Format="ci8" Width="32" Height="16" Offset="0x1928" TlutOffset="0x1728"/>
+        <Texture Name="gChildEponaEyeCloseTex" OutName="child_epona_eye_close" Format="ci8" Width="32" Height="16" Offset="0x1B28" TlutOffset="0x1728"/>
     </File>
 </Root>

--- a/soh/assets/xml/N64_PAL_11/objects/object_horse_normal.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_horse_normal.xml
@@ -1,5 +1,13 @@
 <Root>
     <File Name="object_horse_normal" Segment="6">
+        <Texture Name="object_horse_normalTex_0058D8" OutName="object_horse_normalTex_0058D8" Format="i8" Width="8" Height="8" Offset="0x58D8" AddedByScript="true"/>
+        <Texture Name="object_horse_normalTex_005918" OutName="object_horse_normalTex_005918" Format="rgba16" Width="16" Height="16" Offset="0x5918" AddedByScript="true"/>
+        <Texture Name="object_horse_normalTex_005B18" OutName="object_horse_normalTex_005B18" Format="rgba16" Width="8" Height="8" Offset="0x5B18" AddedByScript="true"/>
+        <Texture Name="object_horse_normalTex_005B98" OutName="object_horse_normalTex_005B98" Format="i8" Width="16" Height="16" Offset="0x5B98" AddedByScript="true"/>
+        <Texture Name="object_horse_normalTex_005C98" OutName="object_horse_normalTex_005C98" Format="i8" Width="16" Height="8" Offset="0x5C98" AddedByScript="true"/>
+        <Texture Name="object_horse_normalTex_006F28" OutName="object_horse_normalTex_006F28" Format="i8" Width="16" Height="16" Offset="0x6F28" AddedByScript="true"/>
+        <Texture Name="object_horse_normalTex_007028" OutName="object_horse_normalTex_007028" Format="i8" Width="16" Height="16" Offset="0x7028" AddedByScript="true"/>
+        <Texture Name="object_horse_normalTex_007128" OutName="object_horse_normalTex_007128" Format="i8" Width="32" Height="32" Offset="0x7128" AddedByScript="true"/>
         <Skeleton Name="gHorseNormalSkel" Type="Normal" LimbType="Skin" Offset="0x9FAC"/>
 
         <!-- Running. -->

--- a/soh/assets/xml/N64_PAL_11/objects/object_horse_zelda.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_horse_zelda.xml
@@ -1,5 +1,17 @@
 <Root>
     <File Name="object_horse_zelda" Segment="6">
+        <Texture Name="object_horse_zeldaTex_000408" OutName="object_horse_zeldaTex_000408" Format="rgba16" Width="8" Height="8" Offset="0x408" AddedByScript="true"/>
+        <Texture Name="object_horse_zeldaTex_000888" OutName="object_horse_zeldaTex_000888" Format="rgba16" Width="8" Height="16" Offset="0x888" AddedByScript="true"/>
+        <Texture Name="object_horse_zeldaTex_000988" OutName="object_horse_zeldaTex_000988" Format="rgba16" Width="4" Height="4" Offset="0x988" AddedByScript="true"/>
+        <Texture Name="object_horse_zeldaTex_002578" OutName="object_horse_zeldaTex_002578" Format="rgba16" Width="8" Height="16" Offset="0x2578" AddedByScript="true"/>
+        <Texture Name="object_horse_zeldaTex_002678" OutName="object_horse_zeldaTex_002678" Format="rgba16" Width="16" Height="8" Offset="0x2678" AddedByScript="true"/>
+        <Texture Name="object_horse_zeldaTex_002778" OutName="object_horse_zeldaTex_002778" Format="rgba16" Width="16" Height="16" Offset="0x2778" AddedByScript="true"/>
+        <Texture Name="object_horse_zeldaTex_002978" OutName="object_horse_zeldaTex_002978" Format="rgba16" Width="32" Height="32" Offset="0x2978" AddedByScript="true"/>
+        <Texture Name="object_horse_zeldaTex_003178" OutName="object_horse_zeldaTex_003178" Format="rgba16" Width="16" Height="8" Offset="0x3178" AddedByScript="true"/>
+        <Texture Name="object_horse_zeldaTex_003278" OutName="object_horse_zeldaTex_003278" Format="rgba16" Width="8" Height="16" Offset="0x3278" AddedByScript="true"/>
+        <Texture Name="object_horse_zeldaTex_003378" OutName="object_horse_zeldaTex_003378" Format="rgba16" Width="8" Height="8" Offset="0x3378" AddedByScript="true"/>
+        <Texture Name="object_horse_zeldaTex_0033F8" OutName="object_horse_zeldaTex_0033F8" Format="rgba16" Width="8" Height="16" Offset="0x33F8" AddedByScript="true"/>
+        <Texture Name="object_horse_zeldaTex_0034F8" OutName="object_horse_zeldaTex_0034F8" Format="rgba16" Width="16" Height="16" Offset="0x34F8" AddedByScript="true"/>
         <Skeleton Name="gHorseZeldaSkel" Type="Normal" LimbType="Skin" Offset="0x6B2C"/>
 
         <!-- Running. -->

--- a/soh/assets/xml/N64_PAL_11/objects/object_jya_obj.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_jya_obj.xml
@@ -1,5 +1,12 @@
 <Root>
     <File Name="object_jya_obj" Segment="6">
+        <Texture Name="object_jya_objTex_00B4B8" OutName="object_jya_objTex_00B4B8" Format="ci8" Width="32" Height="32" Offset="0xB4B8" TlutOffset="0xAC70" AddedByScript="true"/>
+        <Texture Name="object_jya_objTex_011A80" OutName="object_jya_objTex_011A80" Format="ci4" Width="64" Height="64" Offset="0x11A80" TlutOffset="0x11A60" AddedByScript="true"/>
+        <Texture Name="object_jya_objTex_016140" OutName="object_jya_objTex_016140" Format="rgba16" Width="64" Height="32" Offset="0x16140" AddedByScript="true"/>
+        <Texture Name="object_jya_objTex_017140" OutName="object_jya_objTex_017140" Format="rgba16" Width="32" Height="16" Offset="0x17140" AddedByScript="true"/>
+        <Texture Name="object_jya_objTex_01B340" OutName="object_jya_objTex_01B340" Format="ia8" Width="32" Height="32" Offset="0x1B340" AddedByScript="true"/>
+        <Texture Name="object_jya_objTex_01B740" OutName="object_jya_objTex_01B740" Format="rgba16" Width="16" Height="16" Offset="0x1B740" AddedByScript="true"/>
+        <Texture Name="object_jya_objTLUT_011A60" OutName="object_jya_objTLUT_011A60" Format="rgba16" Width="4" Height="4" Offset="0x11A60" AddedByScript="true"/>
         <DList Name="g1fliftDL" Offset="0x1F0"/>
         <Collision Name="g1fliftCol" Offset="0x4A8"/>
         <Texture Name="g1f1fiftTopTex" OutName="1flift_top" Format="rgba16" Width="32" Height="32" Offset="0x1B940"/>

--- a/soh/assets/xml/N64_PAL_11/objects/object_link_boy.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_link_boy.xml
@@ -1,5 +1,12 @@
 <Root>
     <File Name="object_link_boy" Segment="6">
+        <Texture Name="object_link_boyTLUT_005400" OutName="object_link_boyTLUT_005400" Format="rgba16" Width="16" Height="16" Offset="0x5400" AddedByScript="true"/>
+        <Texture Name="object_link_boyTLUT_005800" OutName="object_link_boyTLUT_005800" Format="rgba16" Width="16" Height="16" Offset="0x5800" AddedByScript="true"/>
+        <Texture Name="object_link_boyTLUT_005A00" OutName="object_link_boyTLUT_005A00" Format="rgba16" Width="16" Height="16" Offset="0x5A00" AddedByScript="true"/>
+        <Texture Name="object_link_boyTLUT_00CB40" OutName="object_link_boyTLUT_00CB40" Format="rgba16" Width="16" Height="16" Offset="0xCB40" AddedByScript="true"/>
+        <Texture Name="object_link_boyTLUT_00CD48" OutName="object_link_boyTLUT_00CD48" Format="rgba16" Width="16" Height="16" Offset="0xCD48" AddedByScript="true"/>
+        <Texture Name="object_link_boyTLUT_00CF50" OutName="object_link_boyTLUT_00CF50" Format="rgba16" Width="16" Height="16" Offset="0xCF50" AddedByScript="true"/>
+        <Texture Name="object_link_boyTLUT_00D078" OutName="object_link_boyTLUT_00D078" Format="rgba16" Width="16" Height="16" Offset="0xD078" AddedByScript="true"/>
         <Skeleton Name="gLinkAdultSkel" Type="Flex" LimbType="LOD" Offset="0x377F4"/>
 
         <!-- Far Limb DLists-->

--- a/soh/assets/xml/N64_PAL_11/objects/object_masterkokirihead.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_masterkokirihead.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_masterkokirihead" Segment="6">
+        <Texture Name="object_masterkokiriheadTex_0009F0" OutName="object_masterkokiriheadTex_0009F0" Format="ci8" Width="8" Height="8" Offset="0x9F0" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_masterkokiriheadTex_000A30" OutName="object_masterkokiriheadTex_000A30" Format="ci8" Width="16" Height="16" Offset="0xA30" TlutOffset="0x0" AddedByScript="true"/>
         <DList Name="gKokiriShopkeeperHeadDL" Offset="0x2820"/>
         <Texture Name="gKokiriShopkeeperTLUT" OutName="tlut" Format="rgba16" Width="248" Height="1" Offset="0x0"/>
         <Texture Name="gKokiriShopkeeperEyeHalfTex" OutName="eye_half" Format="rgba16" Width="32" Height="32" Offset="0x1F0"/>

--- a/soh/assets/xml/N64_PAL_11/objects/object_mb.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_mb.xml
@@ -1,5 +1,19 @@
 <Root>
     <File Name="object_mb" Segment="6">
+        <Texture Name="object_mbTex_008128" OutName="object_mbTex_008128" Format="rgba16" Width="16" Height="16" Offset="0x8128" AddedByScript="true"/>
+        <Texture Name="object_mbTex_008328" OutName="object_mbTex_008328" Format="rgba16" Width="8" Height="32" Offset="0x8328" AddedByScript="true"/>
+        <Texture Name="object_mbTex_008928" OutName="object_mbTex_008928" Format="rgba16" Width="8" Height="16" Offset="0x8928" AddedByScript="true"/>
+        <Texture Name="object_mbTex_008A28" OutName="object_mbTex_008A28" Format="rgba16" Width="4" Height="4" Offset="0x8A28" AddedByScript="true"/>
+        <Texture Name="object_mbTex_008A48" OutName="object_mbTex_008A48" Format="rgba16" Width="8" Height="24" Offset="0x8A48" AddedByScript="true"/>
+        <Texture Name="object_mbTex_008BC8" OutName="object_mbTex_008BC8" Format="rgba16" Width="4" Height="16" Offset="0x8BC8" AddedByScript="true"/>
+        <Texture Name="object_mbTex_008C48" OutName="object_mbTex_008C48" Format="rgba16" Width="4" Height="8" Offset="0x8C48" AddedByScript="true"/>
+        <Texture Name="object_mbTex_008C88" OutName="object_mbTex_008C88" Format="rgba16" Width="8" Height="16" Offset="0x8C88" AddedByScript="true"/>
+        <Texture Name="object_mbTex_00EC00" OutName="object_mbTex_00EC00" Format="rgba16" Width="16" Height="16" Offset="0xEC00" AddedByScript="true"/>
+        <Texture Name="object_mbTex_00EE00" OutName="object_mbTex_00EE00" Format="rgba16" Width="8" Height="16" Offset="0xEE00" AddedByScript="true"/>
+        <Texture Name="object_mbTex_00EF00" OutName="object_mbTex_00EF00" Format="rgba16" Width="8" Height="16" Offset="0xEF00" AddedByScript="true"/>
+        <Texture Name="object_mbTex_00F000" OutName="object_mbTex_00F000" Format="rgba16" Width="16" Height="16" Offset="0xF000" AddedByScript="true"/>
+        <Texture Name="object_mbTex_00F200" OutName="object_mbTex_00F200" Format="rgba16" Width="4" Height="16" Offset="0xF200" AddedByScript="true"/>
+        <Texture Name="object_mbTex_00F280" OutName="object_mbTex_00F280" Format="rgba16" Width="4" Height="16" Offset="0xF280" AddedByScript="true"/>
         <Skeleton Name="gEnMbSpearSkel" Type="Flex" LimbType="Standard" Offset="0x8F38"/>
         <Skeleton Name="gEnMbClubSkel" Type="Flex" LimbType="Standard" Offset="0x14190"/>
         <Animation Name="gEnMbSpearFallFaceDownAnim" Offset="0x6A4"/><!--Unused-->

--- a/soh/assets/xml/N64_PAL_11/objects/object_mizu_objects.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_mizu_objects.xml
@@ -1,5 +1,19 @@
 <Root>
     <File Name="object_mizu_objects" Segment="6">
+        <Texture Name="object_mizu_objectsTex_004C00" OutName="object_mizu_objectsTex_004C00" Format="rgba16" Width="32" Height="64" Offset="0x4C00" AddedByScript="true"/>
+        <Texture Name="object_mizu_objectsTex_005E70" OutName="object_mizu_objectsTex_005E70" Format="rgba16" Width="32" Height="64" Offset="0x5E70" AddedByScript="true"/>
+        <Texture Name="object_mizu_objectsTex_007520" OutName="object_mizu_objectsTex_007520" Format="ia16" Width="32" Height="32" Offset="0x7520" AddedByScript="true"/>
+        <Texture Name="object_mizu_objectsTex_007D20" OutName="object_mizu_objectsTex_007D20" Format="rgba16" Width="32" Height="32" Offset="0x7D20" AddedByScript="true"/>
+        <Texture Name="object_mizu_objectsTex_008520" OutName="object_mizu_objectsTex_008520" Format="rgba16" Width="32" Height="32" Offset="0x8520" AddedByScript="true"/>
+        <Texture Name="object_mizu_objectsTex_008D20" OutName="object_mizu_objectsTex_008D20" Format="rgba16" Width="32" Height="32" Offset="0x8D20" AddedByScript="true"/>
+        <Texture Name="object_mizu_objectsTex_009520" OutName="object_mizu_objectsTex_009520" Format="i4" Width="32" Height="32" Offset="0x9520" AddedByScript="true"/>
+        <Texture Name="object_mizu_objectsTex_009720" OutName="object_mizu_objectsTex_009720" Format="i4" Width="32" Height="32" Offset="0x9720" AddedByScript="true"/>
+        <Texture Name="object_mizu_objectsTex_009920" OutName="object_mizu_objectsTex_009920" Format="i4" Width="32" Height="32" Offset="0x9920" AddedByScript="true"/>
+        <Texture Name="object_mizu_objectsTex_009B20" OutName="object_mizu_objectsTex_009B20" Format="i4" Width="32" Height="32" Offset="0x9B20" AddedByScript="true"/>
+        <Texture Name="object_mizu_objectsTex_009D20" OutName="object_mizu_objectsTex_009D20" Format="i4" Width="32" Height="32" Offset="0x9D20" AddedByScript="true"/>
+        <Texture Name="object_mizu_objectsTex_009F20" OutName="object_mizu_objectsTex_009F20" Format="rgba16" Width="32" Height="32" Offset="0x9F20" AddedByScript="true"/>
+        <Texture Name="object_mizu_objectsTex_00A720" OutName="object_mizu_objectsTex_00A720" Format="rgba16" Width="16" Height="32" Offset="0xA720" AddedByScript="true"/>
+        <Texture Name="object_mizu_objectsTex_00AB20" OutName="object_mizu_objectsTex_00AB20" Format="i4" Width="64" Height="64" Offset="0xAB20" AddedByScript="true"/>
         <DList Name="gObjectMizuObjectsMovebgDL_000190" Offset="0x0190"/>
         <Collision Name="gObjectMizuObjectsMovebgCol_0003F0" Offset="0x03F0"/>
         <DList Name="gObjectMizuObjectsMovebgDL_000680" Offset="0x0680"/>

--- a/soh/assets/xml/N64_PAL_11/objects/object_mm.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_mm.xml
@@ -1,5 +1,14 @@
 <Root>
     <File Name="object_mm" Segment="6">
+        <Texture Name="object_mmTex_000930" OutName="object_mmTex_000930" Format="ci8" Width="8" Height="8" Offset="0x930" TlutOffset="0x730" AddedByScript="true"/>
+        <Texture Name="object_mmTex_000970" OutName="object_mmTex_000970" Format="ci8" Width="8" Height="8" Offset="0x970" TlutOffset="0x730" AddedByScript="true"/>
+        <Texture Name="object_mmTex_0009B0" OutName="object_mmTex_0009B0" Format="ci8" Width="8" Height="8" Offset="0x9B0" TlutOffset="0x730" AddedByScript="true"/>
+        <Texture Name="object_mmTex_0009F0" OutName="object_mmTex_0009F0" Format="ci8" Width="8" Height="8" Offset="0x9F0" TlutOffset="0x730" AddedByScript="true"/>
+        <Texture Name="object_mmTex_000A30" OutName="object_mmTex_000A30" Format="ci8" Width="16" Height="16" Offset="0xA30" TlutOffset="0x730" AddedByScript="true"/>
+        <Texture Name="object_mmTex_000B30" OutName="object_mmTex_000B30" Format="ci8" Width="16" Height="16" Offset="0xB30" TlutOffset="0x730" AddedByScript="true"/>
+        <Texture Name="object_mmTex_001030" OutName="object_mmTex_001030" Format="ci8" Width="16" Height="16" Offset="0x1030" TlutOffset="0x730" AddedByScript="true"/>
+        <Texture Name="object_mmTex_001130" OutName="object_mmTex_001130" Format="ci8" Width="32" Height="16" Offset="0x1130" TlutOffset="0x730" AddedByScript="true"/>
+        <Texture Name="object_mmTex_001330" OutName="object_mmTex_001330" Format="ci8" Width="16" Height="16" Offset="0x1330" TlutOffset="0x730" AddedByScript="true"/>
         <Skeleton Name="gRunningManSkel" Type="Flex" LimbType="Standard" Offset="0x5E18"/>
 
         <Animation Name="gRunningManRunAnim" Offset="0x0718"/>

--- a/soh/assets/xml/N64_PAL_11/objects/object_mo.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_mo.xml
@@ -1,5 +1,10 @@
 <Root>
     <File Name="object_mo" Segment="6">
+        <Texture Name="object_moTex_000000" OutName="object_moTex_000000" Format="ia8" Width="16" Height="16" Offset="0x0" AddedByScript="true"/>
+        <Texture Name="object_moTex_000680" OutName="object_moTex_000680" Format="rgba16" Width="32" Height="32" Offset="0x680" AddedByScript="true"/>
+        <Texture Name="object_moTex_004D20" OutName="object_moTex_004D20" Format="ia16" Width="32" Height="32" Offset="0x4D20" AddedByScript="true"/>
+        <Texture Name="object_moTex_005520" OutName="object_moTex_005520" Format="ia16" Width="32" Height="32" Offset="0x5520" AddedByScript="true"/>
+        <Texture Name="object_moTex_005D20" OutName="object_moTex_005D20" Format="ia16" Width="32" Height="32" Offset="0x5D20" AddedByScript="true"/>
         <!-- Morpha's Title Card -->
         <Texture Name="gMorphaTitleCardTex" Format="i8" Width="128" Height="120" Offset="0x1010"/>
         <Texture Name="gMorphaWaterTex" Format="rgba16" Width="32" Height="32" Offset="0x8870"/>

--- a/soh/assets/xml/N64_PAL_11/objects/object_oE1s.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_oE1s.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_oE1s" Segment="6">
+        <Texture Name="object_oE1sTex_000478" OutName="object_oE1sTex_000478" Format="ci8" Width="32" Height="32" Offset="0x478" TlutOffset="0x1A8" AddedByScript="true"/>
+        <Texture Name="object_oE1sTLUT_0001A8" OutName="object_oE1sTLUT_0001A8" Format="rgba16" Width="16" Height="16" Offset="0x1A8" AddedByScript="true"/>
         <Animation Name="object_oE1s_Anim_00007C" Offset="0x7C"/>
         <Limb Name="object_oE1s_Limb_000090" LimbType="Standard" Offset="0x90"/>
         <Limb Name="object_oE1s_Limb_00009C" LimbType="Standard" Offset="0x9C"/>
@@ -21,15 +23,15 @@
         <!--Blob Name="object_oE1s_Blob_00019C" Size="0x204" Offset="0x19C" /-->
         <Texture Name="object_oE1s_TLUT_0003A0" OutName="tlut_000003A0" Format="rgba16" Width="108" Height="1" Offset="0x3A0"/>
         <!--Blob Name="object_oE1s_Blob_0005A0" Size="0x2D8" Offset="0x5A0" /-->
-        <Texture Name="object_oE1s_Tex_000878" OutName="tex_00000878" Format="ci8" Width="8" Height="8" Offset="0x878"  TlutOffset="0x3A0"/>
+        <Texture Name="object_oE1s_Tex_000878" OutName="tex_00000878" Format="ci8" Width="8" Height="8" Offset="0x878" TlutOffset="0x3A0"/>
         <Texture Name="object_oE1s_Tex_0008B8" OutName="tex_000008B8" Format="rgba16" Width="16" Height="32" Offset="0x8B8"/>
         <Texture Name="object_oE1s_Tex_000CB8" OutName="tex_00000CB8" Format="rgba16" Width="32" Height="32" Offset="0xCB8"/>
-        <Texture Name="object_oE1s_Tex_0014B8" OutName="tex_000014B8" Format="ci8" Width="16" Height="16" Offset="0x14B8"  TlutOffset="0x3A0"/>
+        <Texture Name="object_oE1s_Tex_0014B8" OutName="tex_000014B8" Format="ci8" Width="16" Height="16" Offset="0x14B8" TlutOffset="0x3A0"/>
         <Texture Name="object_oE1s_Tex_0015B8" OutName="tex_000015B8" Format="i4" Width="16" Height="8" Offset="0x15B8"/>
         <Blob Name="object_oE1s_Blob_0015F8" Size="0x400" Offset="0x15F8"/>
         <Texture Name="object_oE1s_Tex_0019F8" OutName="tex_000019F8" Format="i4" Width="16" Height="16" Offset="0x19F8"/>
         <Texture Name="object_oE1s_Tex_001A78" OutName="tex_00001A78" Format="rgba16" Width="16" Height="8" Offset="0x1A78"/>
-        <Texture Name="object_oE1s_Tex_001B78" OutName="tex_00001B78" Format="ci8" Width="16" Height="16" Offset="0x1B78"  TlutOffset="0x3A0"/>
+        <Texture Name="object_oE1s_Tex_001B78" OutName="tex_00001B78" Format="ci8" Width="16" Height="16" Offset="0x1B78" TlutOffset="0x3A0"/>
         <Blob Name="object_oE1s_Blob_001C78" Size="0x400" Offset="0x1C78"/>
         <DList Name="object_oE1s_DL_004D98" Offset="0x4D98"/>
         <DList Name="object_oE1s_DL_005010" Offset="0x5010"/>

--- a/soh/assets/xml/N64_PAL_11/objects/object_oE4s.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_oE4s.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_oE4s" Segment="6">
+        <Texture Name="object_oE4sTex_0002A0" OutName="object_oE4sTex_0002A0" Format="ci8" Width="16" Height="16" Offset="0x2A0" TlutOffset="0x1A8" AddedByScript="true"/>
+        <Texture Name="object_oE4sTex_0003A0" OutName="object_oE4sTex_0003A0" Format="ci8" Width="16" Height="16" Offset="0x3A0" TlutOffset="0x1A8" AddedByScript="true"/>
         <Animation Name="object_oE4s_Anim_00007C" Offset="0x7C"/>
         <Limb Name="object_oE4s_Limb_000090" LimbType="Standard" Offset="0x90"/>
         <Limb Name="object_oE4s_Limb_00009C" LimbType="Standard" Offset="0x9C"/>

--- a/soh/assets/xml/N64_PAL_11/objects/object_oF1d_map.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_oF1d_map.xml
@@ -1,5 +1,22 @@
 <Root>
     <File Name="object_oF1d_map" Segment="6">
+        <Texture Name="object_oF1d_mapTex_009270" OutName="object_oF1d_mapTex_009270" Format="ci8" Width="8" Height="8" Offset="0x9270" TlutOffset="0x9130" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_0092B0" OutName="object_oF1d_mapTex_0092B0" Format="ci8" Width="8" Height="8" Offset="0x92B0" TlutOffset="0x9130" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_0092F0" OutName="object_oF1d_mapTex_0092F0" Format="ci8" Width="8" Height="16" Offset="0x92F0" TlutOffset="0x9130" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_009370" OutName="object_oF1d_mapTex_009370" Format="ci8" Width="32" Height="64" Offset="0x9370" TlutOffset="0x9130" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_009B70" OutName="object_oF1d_mapTex_009B70" Format="ci8" Width="16" Height="16" Offset="0x9B70" TlutOffset="0x9130" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_009C70" OutName="object_oF1d_mapTex_009C70" Format="rgba16" Width="64" Height="32" Offset="0x9C70" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_00C840" OutName="object_oF1d_mapTex_00C840" Format="ci8" Width="8" Height="8" Offset="0xC840" TlutOffset="0xC440" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_00C880" OutName="object_oF1d_mapTex_00C880" Format="ci8" Width="32" Height="16" Offset="0xC880" TlutOffset="0xC440" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_00CA80" OutName="object_oF1d_mapTex_00CA80" Format="ci8" Width="32" Height="32" Offset="0xCA80" TlutOffset="0xC440" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_00EE80" OutName="object_oF1d_mapTex_00EE80" Format="ci8" Width="32" Height="64" Offset="0xEE80" TlutOffset="0xC440" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_00F680" OutName="object_oF1d_mapTex_00F680" Format="ci8" Width="8" Height="8" Offset="0xF680" TlutOffset="0xC440" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_00F6C0" OutName="object_oF1d_mapTex_00F6C0" Format="ci8" Width="16" Height="16" Offset="0xF6C0" TlutOffset="0xC440" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_00F7C0" OutName="object_oF1d_mapTex_00F7C0" Format="ci8" Width="16" Height="16" Offset="0xF7C0" TlutOffset="0xC440" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_00F8C0" OutName="object_oF1d_mapTex_00F8C0" Format="ci8" Width="32" Height="32" Offset="0xF8C0" TlutOffset="0xC440" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTex_00FCC0" OutName="object_oF1d_mapTex_00FCC0" Format="ci8" Width="8" Height="16" Offset="0xFCC0" TlutOffset="0xC440" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTLUT_009130" OutName="object_oF1d_mapTLUT_009130" Format="rgba16" Width="16" Height="16" Offset="0x9130" AddedByScript="true"/>
+        <Texture Name="object_oF1d_mapTLUT_00C440" OutName="object_oF1d_mapTLUT_00C440" Format="rgba16" Width="16" Height="16" Offset="0xC440" AddedByScript="true"/>
         <!-- animations -->
         <Animation Name="gGoronAnim_000750" Offset="0x750"/>
         <Animation Name="gGoronAnim_000D5C" Offset="0xD5C"/>

--- a/soh/assets/xml/N64_PAL_11/objects/object_ossan.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_ossan.xml
@@ -1,5 +1,15 @@
 <Root>
     <File Name="object_ossan" Segment="6">
+        <Texture Name="object_ossanTex_005078" OutName="object_ossanTex_005078" Format="ci8" Width="16" Height="16" Offset="0x5078" TlutOffset="0x4728" AddedByScript="true"/>
+        <Texture Name="object_ossanTex_005178" OutName="object_ossanTex_005178" Format="ci8" Width="16" Height="16" Offset="0x5178" TlutOffset="0x4728" AddedByScript="true"/>
+        <Texture Name="object_ossanTex_005278" OutName="object_ossanTex_005278" Format="ci8" Width="8" Height="8" Offset="0x5278" TlutOffset="0x4728" AddedByScript="true"/>
+        <Texture Name="object_ossanTex_005AB8" OutName="object_ossanTex_005AB8" Format="ci8" Width="8" Height="8" Offset="0x5AB8" TlutOffset="0x4728" AddedByScript="true"/>
+        <Texture Name="object_ossanTex_008A38" OutName="object_ossanTex_008A38" Format="rgba16" Width="8" Height="8" Offset="0x8A38" AddedByScript="true"/>
+        <Texture Name="object_ossanTex_008AB8" OutName="object_ossanTex_008AB8" Format="rgba16" Width="16" Height="16" Offset="0x8AB8" AddedByScript="true"/>
+        <Texture Name="object_ossanTex_008CB8" OutName="object_ossanTex_008CB8" Format="rgba16" Width="16" Height="16" Offset="0x8CB8" AddedByScript="true"/>
+        <Texture Name="object_ossanTex_008EB8" OutName="object_ossanTex_008EB8" Format="rgba16" Width="32" Height="32" Offset="0x8EB8" AddedByScript="true"/>
+        <Texture Name="object_ossanTex_0096B8" OutName="object_ossanTex_0096B8" Format="rgba16" Width="16" Height="16" Offset="0x96B8" AddedByScript="true"/>
+        <Texture Name="object_ossanTex_0098B8" OutName="object_ossanTex_0098B8" Format="rgba16" Width="16" Height="16" Offset="0x98B8" AddedByScript="true"/>
         <Animation Name="gObjectOssanAnim_000338" Offset="0x338"/>
         <Texture Name="gOssanEyesTLUT" OutName="ossan_eyes_tlut" Format="rgba16" Width="63" Height="4" Offset="0x4530"/>
         <Texture Name="gOssanTLUT" OutName="ossan_tlut" Format="rgba16" Width="168" Height="1" Offset="0x4728"/>

--- a/soh/assets/xml/N64_PAL_11/objects/object_owl.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_owl.xml
@@ -1,5 +1,13 @@
 <Root>
     <File Name="object_owl" Segment="6">
+        <Texture Name="object_owlTex_0071A8" OutName="object_owlTex_0071A8" Format="rgba16" Width="32" Height="32" Offset="0x71A8" AddedByScript="true"/>
+        <Texture Name="object_owlTex_0079A8" OutName="object_owlTex_0079A8" Format="rgba16" Width="32" Height="32" Offset="0x79A8" AddedByScript="true"/>
+        <Texture Name="object_owlTex_0081A8" OutName="object_owlTex_0081A8" Format="rgba16" Width="32" Height="32" Offset="0x81A8" AddedByScript="true"/>
+        <Texture Name="object_owlTex_0095A8" OutName="object_owlTex_0095A8" Format="rgba16" Width="32" Height="32" Offset="0x95A8" AddedByScript="true"/>
+        <Texture Name="object_owlTex_009DA8" OutName="object_owlTex_009DA8" Format="rgba16" Width="16" Height="16" Offset="0x9DA8" AddedByScript="true"/>
+        <Texture Name="object_owlTex_009FA8" OutName="object_owlTex_009FA8" Format="rgba16" Width="64" Height="32" Offset="0x9FA8" AddedByScript="true"/>
+        <Texture Name="object_owlTex_00AFA8" OutName="object_owlTex_00AFA8" Format="rgba16" Width="32" Height="32" Offset="0xAFA8" AddedByScript="true"/>
+        <Texture Name="object_owlTex_00B7A8" OutName="object_owlTex_00B7A8" Format="rgba16" Width="32" Height="32" Offset="0xB7A8" AddedByScript="true"/>
         <!-- Flying Owl Skeleton -->
         <Skeleton Name="gOwlFlyingSkel" Type="Flex" LimbType="Standard" Offset="0xC0E8"/>
 
@@ -53,11 +61,17 @@
         <Animation Name="gOwlGlideAnim" Offset="0xC1C4"/>
         <Animation Name="gOwlUnfoldWingsAnim" Offset="0xC684"/>
         <Animation Name="gOwlPerchAnim" Offset="0xC8A0"/>
-        
-        <!-- Owl Perching Skeleton -->
-        <Skeleton Name="gOwlPerchingSkel" Type="Flex" LimbType="Standard" Offset="0x100B0"/>  
 
-        <!-- Eye Textures -->      
+        <!-- Owl Perching Skeleton -->
+        <Skeleton Name="gOwlPerchingSkel" Type="Flex" LimbType="Standard" Offset="0x100B0"/>
+
+        <!-- The two following TLUTs are identical and both are used as TLUTs for the eye textures -->
+        <!-- TLUT used in gOwlPerchingSkel -->
+        <Texture Name="object_owl_TLUT_006DA8" OutName="tlut_00006DA8" Format="rgba16" Width="16" Height="16" Offset="0x6DA8"/>
+        <!-- TLUT used in gOwlFlyingSkel -->
+        <Texture Name="object_owl_TLUT_006FA8" OutName="tlut_00006FA8" Format="rgba16" Width="16" Height="16" Offset="0x6FA8"/>
+
+        <!-- Eye Textures -->
         <Texture Name="gObjOwlEyeOpenTex" OutName="owl_eye_open" Format="ci8" Width="32" Height="32" Offset="0x89A8"/>
         <Texture Name="gObjOwlEyeHalfTex" OutName="owl_eye_half" Format="ci8" Width="32" Height="32" Offset="0x8DA8"/>
         <Texture Name="gObjOwlEyeClosedTex" OutName="owl_eye_closed" Format="ci8" Width="32" Height="32" Offset="0x91A8"/>

--- a/soh/assets/xml/N64_PAL_11/objects/object_po_composer.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_po_composer.xml
@@ -1,5 +1,18 @@
 <Root>
     <File Name="object_po_composer" Segment="6">
+        <Texture Name="object_po_composerTex_001450" OutName="object_po_composerTex_001450" Format="i8" Width="32" Height="64" Offset="0x1450" AddedByScript="true"/>
+        <Texture Name="object_po_composerTex_0054E0" OutName="object_po_composerTex_0054E0" Format="rgba16" Width="16" Height="16" Offset="0x54E0" AddedByScript="true"/>
+        <Texture Name="object_po_composerTex_0056E0" OutName="object_po_composerTex_0056E0" Format="rgba16" Width="16" Height="16" Offset="0x56E0" AddedByScript="true"/>
+        <Texture Name="object_po_composerTex_0058E0" OutName="object_po_composerTex_0058E0" Format="rgba16" Width="16" Height="16" Offset="0x58E0" AddedByScript="true"/>
+        <Texture Name="object_po_composerTex_005AE0" OutName="object_po_composerTex_005AE0" Format="rgba16" Width="16" Height="16" Offset="0x5AE0" AddedByScript="true"/>
+        <Texture Name="object_po_composerTex_005CE0" OutName="object_po_composerTex_005CE0" Format="rgba16" Width="16" Height="32" Offset="0x5CE0" AddedByScript="true"/>
+        <Texture Name="object_po_composerTex_0060E0" OutName="object_po_composerTex_0060E0" Format="rgba16" Width="16" Height="16" Offset="0x60E0" AddedByScript="true"/>
+        <Texture Name="object_po_composerTex_0062E0" OutName="object_po_composerTex_0062E0" Format="rgba16" Width="16" Height="16" Offset="0x62E0" AddedByScript="true"/>
+        <Texture Name="object_po_composerTex_0064E0" OutName="object_po_composerTex_0064E0" Format="rgba16" Width="16" Height="16" Offset="0x64E0" AddedByScript="true"/>
+        <Texture Name="object_po_composerTex_0066E0" OutName="object_po_composerTex_0066E0" Format="rgba16" Width="16" Height="16" Offset="0x66E0" AddedByScript="true"/>
+        <Texture Name="object_po_composerTex_0068E0" OutName="object_po_composerTex_0068E0" Format="rgba16" Width="16" Height="16" Offset="0x68E0" AddedByScript="true"/>
+        <Texture Name="object_po_composerTex_006AE0" OutName="object_po_composerTex_006AE0" Format="rgba16" Width="16" Height="16" Offset="0x6AE0" AddedByScript="true"/>
+        <Texture Name="object_po_composerTex_006CE0" OutName="object_po_composerTex_006CE0" Format="rgba16" Width="16" Height="16" Offset="0x6CE0" AddedByScript="true"/>
         <Animation Name="gPoeComposerAttackAnim" Offset="0x020C"/>
         <Animation Name="gPoeComposerDamagedAnim" Offset="0x0570"/>
         <Animation Name="gPoeComposerFleeAnim" Offset="0x0708"/>

--- a/soh/assets/xml/N64_PAL_11/objects/object_po_field.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_po_field.xml
@@ -1,5 +1,16 @@
 <Root>
     <File Name="object_po_field" Segment="6">
+        <Texture Name="object_po_fieldTex_002470" OutName="object_po_fieldTex_002470" Format="rgba16" Width="16" Height="16" Offset="0x2470" AddedByScript="true"/>
+        <Texture Name="object_po_fieldTex_002670" OutName="object_po_fieldTex_002670" Format="rgba16" Width="16" Height="16" Offset="0x2670" AddedByScript="true"/>
+        <Texture Name="object_po_fieldTex_002870" OutName="object_po_fieldTex_002870" Format="rgba16" Width="32" Height="32" Offset="0x2870" AddedByScript="true"/>
+        <Texture Name="object_po_fieldTex_003070" OutName="object_po_fieldTex_003070" Format="rgba16" Width="16" Height="16" Offset="0x3070" AddedByScript="true"/>
+        <Texture Name="object_po_fieldTex_003270" OutName="object_po_fieldTex_003270" Format="rgba16" Width="8" Height="8" Offset="0x3270" AddedByScript="true"/>
+        <Texture Name="object_po_fieldTex_0032F0" OutName="object_po_fieldTex_0032F0" Format="rgba16" Width="16" Height="8" Offset="0x32F0" AddedByScript="true"/>
+        <Texture Name="object_po_fieldTex_0033F0" OutName="object_po_fieldTex_0033F0" Format="rgba16" Width="16" Height="16" Offset="0x33F0" AddedByScript="true"/>
+        <Texture Name="object_po_fieldTex_0035F0" OutName="object_po_fieldTex_0035F0" Format="rgba16" Width="16" Height="16" Offset="0x35F0" AddedByScript="true"/>
+        <Texture Name="object_po_fieldTex_0037F0" OutName="object_po_fieldTex_0037F0" Format="rgba16" Width="16" Height="16" Offset="0x37F0" AddedByScript="true"/>
+        <Texture Name="object_po_fieldTex_005AB0" OutName="object_po_fieldTex_005AB0" Format="rgba16" Width="16" Height="16" Offset="0x5AB0" AddedByScript="true"/>
+        <Texture Name="object_po_fieldTex_005CB0" OutName="object_po_fieldTex_005CB0" Format="rgba16" Width="8" Height="8" Offset="0x5CB0" AddedByScript="true"/>
         <Animation Name="gPoeFieldAttackAnim" Offset="0x0158"/>
         <Animation Name="gPoeFieldDamagedAnim" Offset="0x0454"/>
         <Animation Name="gPoeFieldFleeAnim" Offset="0x0608"/>

--- a/soh/assets/xml/N64_PAL_11/objects/object_po_sisters.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_po_sisters.xml
@@ -1,5 +1,33 @@
 <Root>
     <File Name="object_po_sisters" Segment="6">
+        <Texture Name="object_po_sistersTex_0048D8" OutName="object_po_sistersTex_0048D8" Format="rgba16" Width="16" Height="16" Offset="0x48D8" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_004AD8" OutName="object_po_sistersTex_004AD8" Format="rgba16" Width="32" Height="32" Offset="0x4AD8" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_0052D8" OutName="object_po_sistersTex_0052D8" Format="rgba16" Width="32" Height="16" Offset="0x52D8" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_0056D8" OutName="object_po_sistersTex_0056D8" Format="rgba16" Width="16" Height="16" Offset="0x56D8" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_0058D8" OutName="object_po_sistersTex_0058D8" Format="rgba16" Width="4" Height="4" Offset="0x58D8" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_0058F8" OutName="object_po_sistersTex_0058F8" Format="rgba16" Width="16" Height="16" Offset="0x58F8" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_005AF8" OutName="object_po_sistersTex_005AF8" Format="rgba16" Width="16" Height="16" Offset="0x5AF8" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_005CF8" OutName="object_po_sistersTex_005CF8" Format="rgba16" Width="8" Height="8" Offset="0x5CF8" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_005D78" OutName="object_po_sistersTex_005D78" Format="rgba16" Width="16" Height="16" Offset="0x5D78" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_005F78" OutName="object_po_sistersTex_005F78" Format="rgba16" Width="16" Height="8" Offset="0x5F78" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_006078" OutName="object_po_sistersTex_006078" Format="rgba16" Width="16" Height="16" Offset="0x6078" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_006278" OutName="object_po_sistersTex_006278" Format="rgba16" Width="8" Height="8" Offset="0x6278" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_0062F8" OutName="object_po_sistersTex_0062F8" Format="rgba16" Width="4" Height="4" Offset="0x62F8" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_006318" OutName="object_po_sistersTex_006318" Format="rgba16" Width="16" Height="16" Offset="0x6318" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_007AC0" OutName="object_po_sistersTex_007AC0" Format="rgba16" Width="32" Height="32" Offset="0x7AC0" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_0082C0" OutName="object_po_sistersTex_0082C0" Format="rgba16" Width="8" Height="16" Offset="0x82C0" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_0083C0" OutName="object_po_sistersTex_0083C0" Format="rgba16" Width="32" Height="32" Offset="0x83C0" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_008BC0" OutName="object_po_sistersTex_008BC0" Format="rgba16" Width="32" Height="32" Offset="0x8BC0" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_0093C0" OutName="object_po_sistersTex_0093C0" Format="rgba16" Width="32" Height="32" Offset="0x93C0" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_009BC0" OutName="object_po_sistersTex_009BC0" Format="rgba16" Width="32" Height="32" Offset="0x9BC0" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_00A3C0" OutName="object_po_sistersTex_00A3C0" Format="rgba16" Width="32" Height="32" Offset="0xA3C0" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_00ABC0" OutName="object_po_sistersTex_00ABC0" Format="rgba16" Width="32" Height="32" Offset="0xABC0" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_00B3C0" OutName="object_po_sistersTex_00B3C0" Format="rgba16" Width="32" Height="32" Offset="0xB3C0" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_00BBC0" OutName="object_po_sistersTex_00BBC0" Format="rgba16" Width="32" Height="32" Offset="0xBBC0" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_00C3C0" OutName="object_po_sistersTex_00C3C0" Format="rgba16" Width="32" Height="32" Offset="0xC3C0" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_00CBC0" OutName="object_po_sistersTex_00CBC0" Format="rgba16" Width="32" Height="32" Offset="0xCBC0" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_00D3C0" OutName="object_po_sistersTex_00D3C0" Format="rgba16" Width="32" Height="32" Offset="0xD3C0" AddedByScript="true"/>
+        <Texture Name="object_po_sistersTex_00DBC0" OutName="object_po_sistersTex_00DBC0" Format="rgba16" Width="32" Height="32" Offset="0xDBC0" AddedByScript="true"/>
         <Animation Name="gPoeSistersAttackAnim" Offset="0x0114"/>
         <Animation Name="gPoeSistersMegCryAnim" Offset="0x0680"/>
         <Animation Name="gPoeSistersDamagedAnim" Offset="0x08C0"/>

--- a/soh/assets/xml/N64_PAL_11/objects/object_poh.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_poh.xml
@@ -1,5 +1,16 @@
 <Root>
     <File Name="object_poh" Segment="6">
+        <Texture Name="object_pohTex_003010" OutName="object_pohTex_003010" Format="i8" Width="32" Height="64" Offset="0x3010" AddedByScript="true"/>
+        <Texture Name="object_pohTex_003910" OutName="object_pohTex_003910" Format="rgba16" Width="32" Height="16" Offset="0x3910" AddedByScript="true"/>
+        <Texture Name="object_pohTex_003D10" OutName="object_pohTex_003D10" Format="rgba16" Width="32" Height="32" Offset="0x3D10" AddedByScript="true"/>
+        <Texture Name="object_pohTex_004510" OutName="object_pohTex_004510" Format="rgba16" Width="16" Height="16" Offset="0x4510" AddedByScript="true"/>
+        <Texture Name="object_pohTex_004710" OutName="object_pohTex_004710" Format="rgba16" Width="8" Height="8" Offset="0x4710" AddedByScript="true"/>
+        <Texture Name="object_pohTex_004790" OutName="object_pohTex_004790" Format="rgba16" Width="16" Height="16" Offset="0x4790" AddedByScript="true"/>
+        <Texture Name="object_pohTex_004990" OutName="object_pohTex_004990" Format="rgba16" Width="8" Height="8" Offset="0x4990" AddedByScript="true"/>
+        <Texture Name="object_pohTex_004A10" OutName="object_pohTex_004A10" Format="rgba16" Width="8" Height="16" Offset="0x4A10" AddedByScript="true"/>
+        <Texture Name="object_pohTex_004B10" OutName="object_pohTex_004B10" Format="rgba16" Width="16" Height="16" Offset="0x4B10" AddedByScript="true"/>
+        <Texture Name="object_pohTex_004D10" OutName="object_pohTex_004D10" Format="rgba16" Width="16" Height="16" Offset="0x4D10" AddedByScript="true"/>
+        <Texture Name="object_pohTex_004F10" OutName="object_pohTex_004F10" Format="rgba16" Width="8" Height="8" Offset="0x4F10" AddedByScript="true"/>
         <Animation Name="gPoeAttackAnim" Offset="0x01A8"/>
         <Animation Name="gPoeDamagedAnim" Offset="0x04EC"/>
         <Animation Name="gPoeFleeAnim" Offset="0x06E0"/>

--- a/soh/assets/xml/N64_PAL_11/objects/object_ps.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_ps.xml
@@ -1,5 +1,28 @@
 <Root>
     <File Name="object_ps" Segment="6">
+        <Texture Name="object_psTex_0005B8" OutName="object_psTex_0005B8" Format="rgba16" Width="32" Height="64" Offset="0x5B8" AddedByScript="true"/>
+        <Texture Name="object_psTex_0015B8" OutName="object_psTex_0015B8" Format="ci8" Width="8" Height="8" Offset="0x15B8" TlutOffset="0x4B0" AddedByScript="true"/>
+        <Texture Name="object_psTex_0015F8" OutName="object_psTex_0015F8" Format="rgba16" Width="16" Height="16" Offset="0x15F8" AddedByScript="true"/>
+        <Texture Name="object_psTex_0017F8" OutName="object_psTex_0017F8" Format="ci8" Width="8" Height="8" Offset="0x17F8" TlutOffset="0x4B0" AddedByScript="true"/>
+        <Texture Name="object_psTex_001838" OutName="object_psTex_001838" Format="ci8" Width="32" Height="32" Offset="0x1838" TlutOffset="0x4B0" AddedByScript="true"/>
+        <Texture Name="object_psTex_001C38" OutName="object_psTex_001C38" Format="ci8" Width="16" Height="16" Offset="0x1C38" TlutOffset="0x4B0" AddedByScript="true"/>
+        <Texture Name="object_psTex_001D38" OutName="object_psTex_001D38" Format="i8" Width="8" Height="8" Offset="0x1D38" AddedByScript="true"/>
+        <Texture Name="object_psTex_001D78" OutName="object_psTex_001D78" Format="ci8" Width="16" Height="16" Offset="0x1D78" TlutOffset="0x4B0" AddedByScript="true"/>
+        <Texture Name="object_psTex_001E78" OutName="object_psTex_001E78" Format="ci8" Width="16" Height="16" Offset="0x1E78" TlutOffset="0x4B0" AddedByScript="true"/>
+        <Texture Name="object_psTex_001F78" OutName="object_psTex_001F78" Format="rgba16" Width="16" Height="16" Offset="0x1F78" AddedByScript="true"/>
+        <Texture Name="object_psTex_002178" OutName="object_psTex_002178" Format="rgba16" Width="16" Height="16" Offset="0x2178" AddedByScript="true"/>
+        <Texture Name="object_psTex_002378" OutName="object_psTex_002378" Format="i4" Width="32" Height="32" Offset="0x2378" AddedByScript="true"/>
+        <Texture Name="object_psTex_002578" OutName="object_psTex_002578" Format="ci8" Width="32" Height="32" Offset="0x2578" TlutOffset="0x4B0" AddedByScript="true"/>
+        <Texture Name="object_psTex_002978" OutName="object_psTex_002978" Format="rgba16" Width="8" Height="16" Offset="0x2978" AddedByScript="true"/>
+        <Texture Name="object_psTex_007180" OutName="object_psTex_007180" Format="ci8" Width="8" Height="8" Offset="0x7180" TlutOffset="0x5880" AddedByScript="true"/>
+        <Texture Name="object_psTex_0071C0" OutName="object_psTex_0071C0" Format="ci8" Width="32" Height="32" Offset="0x71C0" TlutOffset="0x5880" AddedByScript="true"/>
+        <Texture Name="object_psTex_0075C0" OutName="object_psTex_0075C0" Format="ci8" Width="8" Height="8" Offset="0x75C0" TlutOffset="0x5880" AddedByScript="true"/>
+        <Texture Name="object_psTex_007600" OutName="object_psTex_007600" Format="ci8" Width="8" Height="8" Offset="0x7600" TlutOffset="0x5880" AddedByScript="true"/>
+        <Texture Name="object_psTex_007640" OutName="object_psTex_007640" Format="ci8" Width="32" Height="32" Offset="0x7640" TlutOffset="0x5880" AddedByScript="true"/>
+        <Texture Name="object_psTex_007A40" OutName="object_psTex_007A40" Format="rgba16" Width="16" Height="16" Offset="0x7A40" AddedByScript="true"/>
+        <Texture Name="object_psTex_007C40" OutName="object_psTex_007C40" Format="ci8" Width="32" Height="32" Offset="0x7C40" TlutOffset="0x5880" AddedByScript="true"/>
+        <Texture Name="object_psTLUT_0004B0" OutName="object_psTLUT_0004B0" Format="rgba16" Width="16" Height="16" Offset="0x4B0" AddedByScript="true"/>
+        <Texture Name="object_psTLUT_005880" OutName="object_psTLUT_005880" Format="rgba16" Width="16" Height="16" Offset="0x5880" AddedByScript="true"/>
         <Animation Name="gPoeSellerIdleAnim" Offset="0x049C"/>
         <Texture Name="gPoeSellerMetalFrameTex" OutName="poe_seller_metal_frame" Format="rgba16" Width="8" Height="8" Offset="0x5A80"/>
         <Texture Name="gPoeSellerMattressTex" OutName="poe_seller_mattress" Format="rgba16" Width="8" Height="8" Offset="0x5B00"/>

--- a/soh/assets/xml/N64_PAL_11/objects/object_rl.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_rl.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_rl" Segment="6">
+        <Texture Name="object_rlTex_0033E0" OutName="object_rlTex_0033E0" Format="ci8" Width="8" Height="8" Offset="0x33E0" TlutOffset="0x32A0" AddedByScript="true"/>
+        <Texture Name="object_rlTex_003420" OutName="object_rlTex_003420" Format="ci8" Width="16" Height="16" Offset="0x3420" TlutOffset="0x32A0" AddedByScript="true"/>
         <Animation Name="object_rl_Anim_00040C" Offset="0x40C"/>
         <Animation Name="object_rl_Anim_000830" Offset="0x830"/>
         <Animation Name="object_rl_Anim_000A3C" Offset="0xA3C"/>

--- a/soh/assets/xml/N64_PAL_11/objects/object_ru2.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_ru2.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_ru2" Segment="6">
+        <Texture Name="object_ru2Tex_0055C0" OutName="object_ru2Tex_0055C0" Format="ci8" Width="8" Height="32" Offset="0x55C0" TlutOffset="0x43C0" AddedByScript="true"/>
+        <Texture Name="object_ru2Tex_0056C0" OutName="object_ru2Tex_0056C0" Format="rgba16" Width="32" Height="32" Offset="0x56C0" AddedByScript="true"/>
         <!-- Adult Ruto Skeleton -->
         <Skeleton Name="gAdultRutoSkel" Type="Flex" LimbType="Standard" Offset="0xC700"/>
 

--- a/soh/assets/xml/N64_PAL_11/objects/object_sa.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_sa.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_sa" Segment="6">
+        <Texture Name="object_saTex_002530" OutName="object_saTex_002530" Format="ci8" Width="8" Height="8" Offset="0x2530" TlutOffset="0x21F0" AddedByScript="true"/>
         <Skeleton Name="gSariaSkel" Type="Flex" LimbType="Standard" Offset="0xB1A0"/>
         
         <Limb Name="gSariaRootLimb" LimbType="Standard" Offset="0xB0A0"/>

--- a/soh/assets/xml/N64_PAL_11/objects/object_skj.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_skj.xml
@@ -1,5 +1,13 @@
 <Root>
     <File Name="object_skj" Segment="6">
+        <Texture Name="object_skjTex_005300" OutName="object_skjTex_005300" Format="rgba16" Width="16" Height="16" Offset="0x5300" AddedByScript="true"/>
+        <Texture Name="object_skjTex_005500" OutName="object_skjTex_005500" Format="rgba16" Width="16" Height="16" Offset="0x5500" AddedByScript="true"/>
+        <Texture Name="object_skjTex_005700" OutName="object_skjTex_005700" Format="rgba16" Width="16" Height="16" Offset="0x5700" AddedByScript="true"/>
+        <Texture Name="object_skjTex_005900" OutName="object_skjTex_005900" Format="rgba16" Width="16" Height="16" Offset="0x5900" AddedByScript="true"/>
+        <Texture Name="object_skjTex_005B00" OutName="object_skjTex_005B00" Format="rgba16" Width="8" Height="8" Offset="0x5B00" AddedByScript="true"/>
+        <Texture Name="object_skjTex_005B80" OutName="object_skjTex_005B80" Format="rgba16" Width="16" Height="16" Offset="0x5B80" AddedByScript="true"/>
+        <Texture Name="object_skjTex_005D80" OutName="object_skjTex_005D80" Format="rgba16" Width="4" Height="4" Offset="0x5D80" AddedByScript="true"/>
+        <Texture Name="object_skjTex_005DA0" OutName="object_skjTex_005DA0" Format="ia16" Width="8" Height="8" Offset="0x5DA0" AddedByScript="true"/>
         <DList Name="gSkullKidNeedleDL" Offset="0x0EB0"/>
         <DList Name="gSkullKidSkullMaskDL" Offset="0x14C8"/>
 

--- a/soh/assets/xml/N64_PAL_11/objects/object_spot09_obj.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_spot09_obj.xml
@@ -1,5 +1,26 @@
 <Root>
     <File Name="object_spot09_obj" Segment="6">
+        <Texture Name="object_spot09_objTex_008490" OutName="object_spot09_objTex_008490" Format="rgba16" Width="32" Height="32" Offset="0x8490" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_008C90" OutName="object_spot09_objTex_008C90" Format="rgba16" Width="32" Height="32" Offset="0x8C90" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_009490" OutName="object_spot09_objTex_009490" Format="rgba16" Width="64" Height="32" Offset="0x9490" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_00A490" OutName="object_spot09_objTex_00A490" Format="rgba16" Width="32" Height="32" Offset="0xA490" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_00AC90" OutName="object_spot09_objTex_00AC90" Format="rgba16" Width="32" Height="32" Offset="0xAC90" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_00B490" OutName="object_spot09_objTex_00B490" Format="rgba16" Width="32" Height="32" Offset="0xB490" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_00BC90" OutName="object_spot09_objTex_00BC90" Format="rgba16" Width="32" Height="64" Offset="0xBC90" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_00CC90" OutName="object_spot09_objTex_00CC90" Format="rgba16" Width="64" Height="32" Offset="0xCC90" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_00DC90" OutName="object_spot09_objTex_00DC90" Format="rgba16" Width="32" Height="64" Offset="0xDC90" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_00EC90" OutName="object_spot09_objTex_00EC90" Format="rgba16" Width="64" Height="32" Offset="0xEC90" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_00FC90" OutName="object_spot09_objTex_00FC90" Format="rgba16" Width="16" Height="32" Offset="0xFC90" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_010090" OutName="object_spot09_objTex_010090" Format="rgba16" Width="64" Height="32" Offset="0x10090" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_011090" OutName="object_spot09_objTex_011090" Format="rgba16" Width="32" Height="64" Offset="0x11090" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_012090" OutName="object_spot09_objTex_012090" Format="rgba16" Width="64" Height="32" Offset="0x12090" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_013090" OutName="object_spot09_objTex_013090" Format="rgba16" Width="64" Height="32" Offset="0x13090" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_014090" OutName="object_spot09_objTex_014090" Format="rgba16" Width="64" Height="32" Offset="0x14090" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_015090" OutName="object_spot09_objTex_015090" Format="rgba16" Width="32" Height="64" Offset="0x15090" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_016090" OutName="object_spot09_objTex_016090" Format="rgba16" Width="32" Height="64" Offset="0x16090" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_017090" OutName="object_spot09_objTex_017090" Format="i8" Width="32" Height="32" Offset="0x17090" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_017490" OutName="object_spot09_objTex_017490" Format="i8" Width="32" Height="32" Offset="0x17490" AddedByScript="true"/>
+        <Texture Name="object_spot09_objTex_017890" OutName="object_spot09_objTex_017890" Format="i4" Width="128" Height="64" Offset="0x17890" AddedByScript="true"/>
         <DList Name="gValleyBridgeSidesDL" Offset="0x100"/>
         <DList Name="gValleyBrokenBridgeDL" Offset="0x3970"/>
         <DList Name="gValleyBridgeChildDL" Offset="0x1120"/>

--- a/soh/assets/xml/N64_PAL_11/objects/object_sst.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_sst.xml
@@ -1,5 +1,21 @@
 <Root>
     <File Name="object_sst" Segment="6">
+        <Texture Name="object_sstTex_017FE0" OutName="object_sstTex_017FE0" Format="rgba16" Width="32" Height="64" Offset="0x17FE0" AddedByScript="true"/>
+        <Texture Name="object_sstTex_019530" OutName="object_sstTex_019530" Format="rgba16" Width="4" Height="8" Offset="0x19530" AddedByScript="true"/>
+        <Texture Name="object_sstTex_019570" OutName="object_sstTex_019570" Format="rgba16" Width="8" Height="16" Offset="0x19570" AddedByScript="true"/>
+        <Texture Name="object_sstTex_019670" OutName="object_sstTex_019670" Format="rgba16" Width="8" Height="16" Offset="0x19670" AddedByScript="true"/>
+        <Texture Name="object_sstTex_019770" OutName="object_sstTex_019770" Format="rgba16" Width="4" Height="8" Offset="0x19770" AddedByScript="true"/>
+        <Texture Name="object_sstTex_0197B0" OutName="object_sstTex_0197B0" Format="rgba16" Width="16" Height="16" Offset="0x197B0" AddedByScript="true"/>
+        <Texture Name="object_sstTex_0199B0" OutName="object_sstTex_0199B0" Format="rgba16" Width="8" Height="16" Offset="0x199B0" AddedByScript="true"/>
+        <Texture Name="object_sstTex_019AB0" OutName="object_sstTex_019AB0" Format="rgba16" Width="8" Height="16" Offset="0x19AB0" AddedByScript="true"/>
+        <Texture Name="object_sstTex_019BB0" OutName="object_sstTex_019BB0" Format="rgba16" Width="16" Height="32" Offset="0x19BB0" AddedByScript="true"/>
+        <Texture Name="object_sstTex_019FB0" OutName="object_sstTex_019FB0" Format="rgba16" Width="8" Height="16" Offset="0x19FB0" AddedByScript="true"/>
+        <Texture Name="object_sstTex_01A0B0" OutName="object_sstTex_01A0B0" Format="rgba16" Width="8" Height="16" Offset="0x1A0B0" AddedByScript="true"/>
+        <Texture Name="object_sstTex_01A1B0" OutName="object_sstTex_01A1B0" Format="rgba16" Width="8" Height="32" Offset="0x1A1B0" AddedByScript="true"/>
+        <Texture Name="object_sstTex_01A3B0" OutName="object_sstTex_01A3B0" Format="rgba16" Width="16" Height="16" Offset="0x1A3B0" AddedByScript="true"/>
+        <Texture Name="object_sstTex_01A5B0" OutName="object_sstTex_01A5B0" Format="rgba16" Width="8" Height="16" Offset="0x1A5B0" AddedByScript="true"/>
+        <Texture Name="object_sstTex_01A730" OutName="object_sstTex_01A730" Format="rgba16" Width="4" Height="16" Offset="0x1A730" AddedByScript="true"/>
+        <Texture Name="object_sstTex_01A7B0" OutName="object_sstTex_01A7B0" Format="rgba16" Width="16" Height="16" Offset="0x1A7B0" AddedByScript="true"/>
         <!-- Boss Title Card -->
         <Texture Name="gBongoTitleCardTex" OutName="bongo_title_card" Format="i8" Width="128" Height="120" Offset="0x13D80"/>
         

--- a/soh/assets/xml/N64_PAL_11/objects/object_tk.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_tk.xml
@@ -1,5 +1,22 @@
 <Root>
     <File Name="object_tk" Segment="6">
+        <Texture Name="object_tkTex_003980" OutName="object_tkTex_003980" Format="ci8" Width="8" Height="8" Offset="0x3980" TlutOffset="0x3780" AddedByScript="true"/>
+        <Texture Name="object_tkTex_0039C0" OutName="object_tkTex_0039C0" Format="ci8" Width="8" Height="8" Offset="0x39C0" TlutOffset="0x3780" AddedByScript="true"/>
+        <Texture Name="object_tkTex_003A00" OutName="object_tkTex_003A00" Format="ci8" Width="8" Height="8" Offset="0x3A00" TlutOffset="0x3780" AddedByScript="true"/>
+        <Texture Name="object_tkTex_003A40" OutName="object_tkTex_003A40" Format="ci8" Width="16" Height="16" Offset="0x3A40" TlutOffset="0x3780" AddedByScript="true"/>
+        <Texture Name="object_tkTex_005340" OutName="object_tkTex_005340" Format="ci8" Width="16" Height="16" Offset="0x5340" TlutOffset="0x3780" AddedByScript="true"/>
+        <Texture Name="object_tkTex_005440" OutName="object_tkTex_005440" Format="ci8" Width="16" Height="16" Offset="0x5440" TlutOffset="0x3780" AddedByScript="true"/>
+        <Texture Name="object_tkTex_0056C0" OutName="object_tkTex_0056C0" Format="ci8" Width="16" Height="16" Offset="0x56C0" TlutOffset="0x3780" AddedByScript="true"/>
+        <Texture Name="object_tkTex_009B00" OutName="object_tkTex_009B00" Format="ci8" Width="16" Height="16" Offset="0x9B00" TlutOffset="0x9AB0" AddedByScript="true"/>
+        <Texture Name="object_tkTex_009C00" OutName="object_tkTex_009C00" Format="ci8" Width="8" Height="16" Offset="0x9C00" TlutOffset="0x9AB0" AddedByScript="true"/>
+        <Texture Name="object_tkTex_009C80" OutName="object_tkTex_009C80" Format="i8" Width="8" Height="8" Offset="0x9C80" AddedByScript="true"/>
+        <Texture Name="object_tkTex_009CC0" OutName="object_tkTex_009CC0" Format="rgba16" Width="8" Height="8" Offset="0x9CC0" AddedByScript="true"/>
+        <Texture Name="object_tkTex_009D40" OutName="object_tkTex_009D40" Format="i4" Width="16" Height="32" Offset="0x9D40" AddedByScript="true"/>
+        <Texture Name="object_tkTex_00B088" OutName="object_tkTex_00B088" Format="rgba16" Width="16" Height="16" Offset="0xB088" AddedByScript="true"/>
+        <Texture Name="object_tkTex_00B288" OutName="object_tkTex_00B288" Format="rgba16" Width="16" Height="16" Offset="0xB288" AddedByScript="true"/>
+        <Texture Name="object_tkTex_00B488" OutName="object_tkTex_00B488" Format="rgba16" Width="16" Height="16" Offset="0xB488" AddedByScript="true"/>
+        <Texture Name="object_tkTLUT_003780" OutName="object_tkTLUT_003780" Format="rgba16" Width="16" Height="16" Offset="0x3780" AddedByScript="true"/>
+        <Texture Name="object_tkTLUT_009AB0" OutName="object_tkTLUT_009AB0" Format="rgba16" Width="16" Height="16" Offset="0x9AB0" AddedByScript="true"/>
         <Animation Name="gDampeDigAnim" Offset="0x1144"/>
         <Animation Name="gDampeWalkAnim" Offset="0x1FA8"/>
         <Animation Name="gDampeRestAnim" Offset="0x2F84"/>

--- a/soh/assets/xml/N64_PAL_11/objects/object_torch2.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_torch2.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="object_torch2" Segment="6">
+        <Texture Name="object_torch2Tex_0041C0" OutName="object_torch2Tex_0041C0" Format="rgba16" Width="16" Height="16" Offset="0x41C0" AddedByScript="true"/>
+        <Texture Name="object_torch2Tex_0043C0" OutName="object_torch2Tex_0043C0" Format="ia16" Width="16" Height="16" Offset="0x43C0" AddedByScript="true"/>
         <!-- Dark Link's skeleton -->
         <Skeleton Name="gDarkLinkSkel" Type="Flex" LimbType="LOD" Offset="0x4764"/>
 

--- a/soh/assets/xml/N64_PAL_11/objects/object_xc.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_xc.xml
@@ -1,5 +1,32 @@
 <Root>
     <File Name="object_xc" Segment="6">
+        <Texture Name="object_xcTex_004C40" OutName="object_xcTex_004C40" Format="ci8" Width="8" Height="8" Offset="0x4C40" TlutOffset="0x4840" AddedByScript="true"/>
+        <Texture Name="object_xcTex_004C80" OutName="object_xcTex_004C80" Format="ci8" Width="8" Height="8" Offset="0x4C80" TlutOffset="0x4840" AddedByScript="true"/>
+        <Texture Name="object_xcTex_005CC0" OutName="object_xcTex_005CC0" Format="ci8" Width="32" Height="32" Offset="0x5CC0" TlutOffset="0x4A40" AddedByScript="true"/>
+        <Texture Name="object_xcTex_0060C0" OutName="object_xcTex_0060C0" Format="ci8" Width="32" Height="32" Offset="0x60C0" TlutOffset="0x4840" AddedByScript="true"/>
+        <Texture Name="object_xcTex_0064C0" OutName="object_xcTex_0064C0" Format="rgba16" Width="32" Height="32" Offset="0x64C0" AddedByScript="true"/>
+        <Texture Name="object_xcTex_006CC0" OutName="object_xcTex_006CC0" Format="ci8" Width="8" Height="16" Offset="0x6CC0" TlutOffset="0x4840" AddedByScript="true"/>
+        <Texture Name="object_xcTex_006D40" OutName="object_xcTex_006D40" Format="ci8" Width="8" Height="8" Offset="0x6D40" TlutOffset="0x4840" AddedByScript="true"/>
+        <Texture Name="object_xcTex_006D80" OutName="object_xcTex_006D80" Format="ci8" Width="16" Height="16" Offset="0x6D80" TlutOffset="0x4840" AddedByScript="true"/>
+        <Texture Name="object_xcTex_006E80" OutName="object_xcTex_006E80" Format="ci8" Width="32" Height="32" Offset="0x6E80" TlutOffset="0x4A40" AddedByScript="true"/>
+        <Texture Name="object_xcTex_007280" OutName="object_xcTex_007280" Format="ci8" Width="16" Height="16" Offset="0x7280" TlutOffset="0x4840" AddedByScript="true"/>
+        <Texture Name="object_xcTex_007380" OutName="object_xcTex_007380" Format="rgba16" Width="32" Height="32" Offset="0x7380" AddedByScript="true"/>
+        <Texture Name="object_xcTex_007B80" OutName="object_xcTex_007B80" Format="ci8" Width="32" Height="64" Offset="0x7B80" TlutOffset="0x4840" AddedByScript="true"/>
+        <Texture Name="object_xcTex_008380" OutName="object_xcTex_008380" Format="ci8" Width="32" Height="64" Offset="0x8380" TlutOffset="0x4840" AddedByScript="true"/>
+        <Texture Name="object_xcTex_008B80" OutName="object_xcTex_008B80" Format="ci8" Width="16" Height="8" Offset="0x8B80" TlutOffset="0x4840" AddedByScript="true"/>
+        <Texture Name="object_xcTex_008C00" OutName="object_xcTex_008C00" Format="ci8" Width="32" Height="16" Offset="0x8C00" TlutOffset="0x4840" AddedByScript="true"/>
+        <Texture Name="object_xcTex_00F790" OutName="object_xcTex_00F790" Format="ci8" Width="8" Height="8" Offset="0xF790" TlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="object_xcTex_00F7D0" OutName="object_xcTex_00F7D0" Format="ci8" Width="32" Height="32" Offset="0xF7D0" TlutOffset="0xF720" AddedByScript="true"/>
+        <Texture Name="object_xcTex_00FBD0" OutName="object_xcTex_00FBD0" Format="ci8" Width="16" Height="16" Offset="0xFBD0" TlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="object_xcTex_00FCD0" OutName="object_xcTex_00FCD0" Format="ci8" Width="8" Height="8" Offset="0xFCD0" TlutOffset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="object_xcTex_00FD10" OutName="object_xcTex_00FD10" Format="rgba16" Width="8" Height="8" Offset="0xFD10" AddedByScript="true"/>
+        <Texture Name="object_xcTex_00FD90" OutName="object_xcTex_00FD90" Format="i8" Width="8" Height="8" Offset="0xFD90" AddedByScript="true"/>
+        <Texture Name="object_xcTex_00FDD0" OutName="object_xcTex_00FDD0" Format="rgba16" Width="16" Height="32" Offset="0xFDD0" AddedByScript="true"/>
+        <Texture Name="object_xcTex_0101D0" OutName="object_xcTex_0101D0" Format="rgba16" Width="8" Height="16" Offset="0x101D0" AddedByScript="true"/>
+        <Texture Name="object_xcTex_011930" OutName="object_xcTex_011930" Format="i8" Width="64" Height="64" Offset="0x11930" AddedByScript="true"/>
+        <Texture Name="object_xcTLUT_004840" OutName="object_xcTLUT_004840" Format="rgba16" Width="16" Height="16" Offset="0x4840" AddedByScript="true"/>
+        <Texture Name="object_xcTLUT_00F6C0" OutName="object_xcTLUT_00F6C0" Format="rgba16" Width="16" Height="16" Offset="0xF6C0" AddedByScript="true"/>
+        <Texture Name="object_xcTLUT_00F720" OutName="object_xcTLUT_00F720" Format="rgba16" Width="16" Height="16" Offset="0xF720" AddedByScript="true"/>
         <Skeleton Name="gSheikSkel" Type="Flex" LimbType="Standard" Offset="0x12AF0"/>
         <Animation Name="gSheikPlayingHarpAnim" Offset="0xB6C"/>
         <Animation Name="gSheikShowingTriforceOnHandAnim" Offset="0x1A08"/>
@@ -8,6 +35,7 @@
         <Animation Name="gSheikPlayingHarp3Anim" Offset="0x35C8"/>
         <Animation Name="gSheikPlayingHarp4Anim" Offset="0x4570"/>
         <Animation Name="gSheikIdleAnim" Offset="0x4828"/>
+        <Texture Name="object_xcTLUT_004A40" OutName="object_xcTLUT_004A40" Format="rgba16" Width="16" Height="16" Offset="0x4A40"/>
         <Animation Name="gSheikWalkingAnim" Offset="0x12FD0"/>
         <Animation Name="gSheikArmsCrossedIdleAnim" Offset="0x13AA4"/>
         <Animation Name="gSheikFallingFromContortionsAnim" Offset="0x149E4"/>

--- a/soh/assets/xml/N64_PAL_11/objects/object_zl1.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_zl1.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="object_zl1" Segment="6">
+        <Texture Name="object_zl1Tex_00EE58" OutName="object_zl1Tex_00EE58" Format="rgba16" Width="32" Height="16" Offset="0xEE58" AddedByScript="true"/>
         <!-- Child Zelda 1 Skeleton -->
         <Skeleton Name="gChildZelda1Skel" Type="Flex" LimbType="Standard" Offset="0xF5D8"/>
 

--- a/soh/assets/xml/N64_PAL_11/objects/object_zl2.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_zl2.xml
@@ -1,5 +1,38 @@
 <Root>
     <File Name="object_zl2" Segment="6">
+        <Texture Name="object_zl2Tex_000E00" OutName="object_zl2Tex_000E00" Format="ci8" Width="16" Height="16" Offset="0xE00" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_000F00" OutName="object_zl2Tex_000F00" Format="ci8" Width="8" Height="8" Offset="0xF00" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_000F40" OutName="object_zl2Tex_000F40" Format="ci8" Width="16" Height="32" Offset="0xF40" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_001140" OutName="object_zl2Tex_001140" Format="ci8" Width="8" Height="8" Offset="0x1140" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_001180" OutName="object_zl2Tex_001180" Format="ci8" Width="16" Height="16" Offset="0x1180" TlutOffset="0x200" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_001280" OutName="object_zl2Tex_001280" Format="ci8" Width="8" Height="8" Offset="0x1280" TlutOffset="0x200" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_0012C0" OutName="object_zl2Tex_0012C0" Format="ci8" Width="16" Height="64" Offset="0x12C0" TlutOffset="0x0" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_0016C0" OutName="object_zl2Tex_0016C0" Format="ci8" Width="32" Height="32" Offset="0x16C0" TlutOffset="0x400" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_001AC0" OutName="object_zl2Tex_001AC0" Format="ci8" Width="32" Height="16" Offset="0x1AC0" TlutOffset="0x400" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_001CC0" OutName="object_zl2Tex_001CC0" Format="ci8" Width="32" Height="64" Offset="0x1CC0" TlutOffset="0x400" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_0024C0" OutName="object_zl2Tex_0024C0" Format="ci8" Width="8" Height="8" Offset="0x24C0" TlutOffset="0x200" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_002500" OutName="object_zl2Tex_002500" Format="ci8" Width="16" Height="16" Offset="0x2500" TlutOffset="0x200" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_002600" OutName="object_zl2Tex_002600" Format="ci8" Width="32" Height="8" Offset="0x2600" TlutOffset="0x400" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_002700" OutName="object_zl2Tex_002700" Format="ci8" Width="8" Height="8" Offset="0x2700" TlutOffset="0x400" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_002740" OutName="object_zl2Tex_002740" Format="ci8" Width="8" Height="8" Offset="0x2740" TlutOffset="0x400" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_002780" OutName="object_zl2Tex_002780" Format="ci8" Width="16" Height="16" Offset="0x2780" TlutOffset="0x400" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_002880" OutName="object_zl2Tex_002880" Format="ci8" Width="8" Height="16" Offset="0x2880" TlutOffset="0x200" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_0034C8" OutName="object_zl2Tex_0034C8" Format="ci8" Width="8" Height="8" Offset="0x34C8" TlutOffset="0x2D00" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_003908" OutName="object_zl2Tex_003908" Format="ci8" Width="16" Height="16" Offset="0x3908" TlutOffset="0x2D00" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_003A08" OutName="object_zl2Tex_003A08" Format="ci8" Width="8" Height="8" Offset="0x3A08" TlutOffset="0x9490" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_003A48" OutName="object_zl2Tex_003A48" Format="ci8" Width="8" Height="16" Offset="0x3A48" TlutOffset="0x2F50" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_003AC8" OutName="object_zl2Tex_003AC8" Format="ci8" Width="16" Height="8" Offset="0x3AC8" TlutOffset="0x2F50" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_003B48" OutName="object_zl2Tex_003B48" Format="ci8" Width="16" Height="16" Offset="0x3B48" TlutOffset="0x2F50" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_004448" OutName="object_zl2Tex_004448" Format="ci8" Width="16" Height="16" Offset="0x4448" TlutOffset="0x2F50" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_006548" OutName="object_zl2Tex_006548" Format="ci8" Width="32" Height="16" Offset="0x6548" TlutOffset="0x2F50" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_009738" OutName="object_zl2Tex_009738" Format="ci8" Width="16" Height="32" Offset="0x9738" TlutOffset="0x95A0" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_009938" OutName="object_zl2Tex_009938" Format="ci8" Width="16" Height="16" Offset="0x9938" TlutOffset="0x9490" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_009A38" OutName="object_zl2Tex_009A38" Format="ci8" Width="8" Height="8" Offset="0x9A38" TlutOffset="0x9490" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_009A78" OutName="object_zl2Tex_009A78" Format="ci8" Width="32" Height="32" Offset="0x9A78" TlutOffset="0x9490" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_009E78" OutName="object_zl2Tex_009E78" Format="ci8" Width="16" Height="16" Offset="0x9E78" TlutOffset="0x95A0" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_009F78" OutName="object_zl2Tex_009F78" Format="ci8" Width="8" Height="16" Offset="0x9F78" TlutOffset="0x95A0" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_009FF8" OutName="object_zl2Tex_009FF8" Format="ci8" Width="16" Height="16" Offset="0x9FF8" TlutOffset="0x9708" AddedByScript="true"/>
+        <Texture Name="object_zl2Tex_00A0F8" OutName="object_zl2Tex_00A0F8" Format="ci8" Width="32" Height="32" Offset="0xA0F8" TlutOffset="0x9708" AddedByScript="true"/>
         <!-- Zelda 2 skeleton -->
         <Skeleton Name="gZelda2Skel" Type="Flex" LimbType="Standard" Offset="0x10D70"/>
 
@@ -19,9 +52,9 @@
 
         <!-- Zelda 2 mouth textures -->
         <Texture Name="gZelda2MouthTLUT" OutName="zelda_2_mouth_tlut" Format="rgba16" Width="16" Height="14" Offset="0x2D90"/>
-        <Texture Name="gZelda2MouthSeriousTex" OutName="zelda_2_mouth_serious" Format="ci8" Width="32" Height="32"  Offset="0x3508" TlutOffset="0x2D90"/>
-        <Texture Name="gZelda2MouthHappyTex" OutName="zelda_2_mouth_happy" Format="ci8" Width="32" Height="32"  Offset="0x5548" TlutOffset="0x2D90"/>
-        <Texture Name="gZelda2MouthOpenTex" OutName="zelda_2_mouth_open" Format="ci8" Width="32" Height="32"  Offset="0x5948" TlutOffset="0x2D90"/>
+        <Texture Name="gZelda2MouthSeriousTex" OutName="zelda_2_mouth_serious" Format="ci8" Width="32" Height="32" Offset="0x3508" TlutOffset="0x2D90"/>
+        <Texture Name="gZelda2MouthHappyTex" OutName="zelda_2_mouth_happy" Format="ci8" Width="32" Height="32" Offset="0x5548" TlutOffset="0x2D90"/>
+        <Texture Name="gZelda2MouthOpenTex" OutName="zelda_2_mouth_open" Format="ci8" Width="32" Height="32" Offset="0x5948" TlutOffset="0x2D90"/>
 
         <!-- Ocarina of time -->
         <DList Name="gZelda2OcarinaDL" Offset="0xBAE8"/>

--- a/soh/assets/xml/N64_PAL_11/objects/object_zl4.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_zl4.xml
@@ -1,5 +1,36 @@
 <Root>
     <File Name="object_zl4" Segment="6">
+        <Texture Name="object_zl4Tex_000C70" OutName="object_zl4Tex_000C70" Format="ci8" Width="8" Height="8" Offset="0xC70" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_000CB0" OutName="object_zl4Tex_000CB0" Format="ci8" Width="16" Height="16" Offset="0xCB0" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_000DB0" OutName="object_zl4Tex_000DB0" Format="ci8" Width="32" Height="64" Offset="0xDB0" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_0015B0" OutName="object_zl4Tex_0015B0" Format="rgba16" Width="8" Height="8" Offset="0x15B0" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_001630" OutName="object_zl4Tex_001630" Format="rgba16" Width="8" Height="8" Offset="0x1630" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_0016B0" OutName="object_zl4Tex_0016B0" Format="ci8" Width="32" Height="8" Offset="0x16B0" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_0017B0" OutName="object_zl4Tex_0017B0" Format="ci8" Width="8" Height="8" Offset="0x17B0" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_0017F0" OutName="object_zl4Tex_0017F0" Format="ci8" Width="32" Height="32" Offset="0x17F0" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_001BF0" OutName="object_zl4Tex_001BF0" Format="rgba16" Width="8" Height="16" Offset="0x1BF0" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_001CF0" OutName="object_zl4Tex_001CF0" Format="ci8" Width="16" Height="16" Offset="0x1CF0" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_001DF0" OutName="object_zl4Tex_001DF0" Format="ci8" Width="8" Height="8" Offset="0x1DF0" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_001E30" OutName="object_zl4Tex_001E30" Format="rgba16" Width="16" Height="32" Offset="0x1E30" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_002230" OutName="object_zl4Tex_002230" Format="ci8" Width="8" Height="8" Offset="0x2230" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_002270" OutName="object_zl4Tex_002270" Format="ci8" Width="8" Height="16" Offset="0x2270" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_0022F0" OutName="object_zl4Tex_0022F0" Format="ci8" Width="16" Height="32" Offset="0x22F0" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_0024F0" OutName="object_zl4Tex_0024F0" Format="rgba16" Width="16" Height="16" Offset="0x24F0" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_0026F0" OutName="object_zl4Tex_0026F0" Format="rgba16" Width="16" Height="16" Offset="0x26F0" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_0028F0" OutName="object_zl4Tex_0028F0" Format="rgba16" Width="8" Height="8" Offset="0x28F0" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_002970" OutName="object_zl4Tex_002970" Format="rgba16" Width="8" Height="8" Offset="0x2970" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_0029F0" OutName="object_zl4Tex_0029F0" Format="rgba16" Width="16" Height="8" Offset="0x29F0" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_0056F0" OutName="object_zl4Tex_0056F0" Format="rgba16" Width="16" Height="16" Offset="0x56F0" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_0058F0" OutName="object_zl4Tex_0058F0" Format="ci8" Width="16" Height="16" Offset="0x58F0" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_0059F0" OutName="object_zl4Tex_0059F0" Format="rgba16" Width="8" Height="8" Offset="0x59F0" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_005A70" OutName="object_zl4Tex_005A70" Format="rgba16" Width="16" Height="16" Offset="0x5A70" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_005C70" OutName="object_zl4Tex_005C70" Format="ci8" Width="8" Height="8" Offset="0x5C70" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_005CB0" OutName="object_zl4Tex_005CB0" Format="ci8" Width="16" Height="16" Offset="0x5CB0" TlutOffset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_005DB0" OutName="object_zl4Tex_005DB0" Format="rgba16" Width="32" Height="32" Offset="0x5DB0" AddedByScript="true"/>
+        <Texture Name="object_zl4Tex_00D8B8" OutName="object_zl4Tex_00D8B8" Format="rgba16" Width="32" Height="16" Offset="0xD8B8" AddedByScript="true"/>
+        <Texture Name="object_zl4TLUT_000670" OutName="object_zl4TLUT_000670" Format="rgba16" Width="16" Height="16" Offset="0x670" AddedByScript="true"/>
+        <Texture Name="object_zl4TLUT_000870" OutName="object_zl4TLUT_000870" Format="rgba16" Width="16" Height="16" Offset="0x870" AddedByScript="true"/>
+        <Texture Name="object_zl4TLUT_000A70" OutName="object_zl4TLUT_000A70" Format="rgba16" Width="16" Height="16" Offset="0xA70" AddedByScript="true"/>
         <!-- Child Zelda's skeleton -->
         <Skeleton Name="gChildZeldaSkel" Type="Flex" LimbType="Standard" Offset="0xE038"/>
 

--- a/soh/assets/xml/N64_PAL_11/overlays/ovl_Boss_Ganon.xml
+++ b/soh/assets/xml/N64_PAL_11/overlays/ovl_Boss_Ganon.xml
@@ -1,5 +1,21 @@
 <Root>
     <File Name="ovl_Boss_Ganon" BaseAddress="0x809F2C80" RangeStart="0xE388" RangeEnd="0x211D8">
+        <Texture Name="ovl_Boss_GanonTex_00E748" OutName="ovl_Boss_GanonTex_00E748" Format="i8" Width="64" Height="64" Offset="0xE418" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_00F848" OutName="ovl_Boss_GanonTex_00F848" Format="ci8" Width="32" Height="32" Offset="0xF518" TluOffset="0xF4D8" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_010538" OutName="ovl_Boss_GanonTex_010538" Format="i8" Width="64" Height="64" Offset="0x10208" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_01A7B0" OutName="ovl_Boss_GanonTex_01A7B0" Format="ia16" Width="32" Height="32" Offset="0x1A480" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_01AFB0" OutName="ovl_Boss_GanonTex_01AFB0" Format="i4" Width="64" Height="64" Offset="0x1AC80" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_01B7B0" OutName="ovl_Boss_GanonTex_01B7B0" Format="i4" Width="64" Height="64" Offset="0x1B480" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_01C420" OutName="ovl_Boss_GanonTex_01C420" Format="i8" Width="64" Height="32" Offset="0x1C0F0" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_01CEB8" OutName="ovl_Boss_GanonTex_01CEB8" Format="i8" Width="32" Height="64" Offset="0x1CB88" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_01D6B8" OutName="ovl_Boss_GanonTex_01D6B8" Format="i8" Width="32" Height="32" Offset="0x1D388" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_01DE88" OutName="ovl_Boss_GanonTex_01DE88" Format="i8" Width="32" Height="64" Offset="0x1DB58" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_01E688" OutName="ovl_Boss_GanonTex_01E688" Format="i8" Width="32" Height="64" Offset="0x1E358" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_01EF90" OutName="ovl_Boss_GanonTex_01EF90" Format="i8" Width="96" Height="16" Offset="0x1EC60" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_01FFF8" OutName="ovl_Boss_GanonTex_01FFF8" Format="i4" Width="32" Height="32" Offset="0x1FCC8" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_020370" OutName="ovl_Boss_GanonTex_020370" Format="i8" Width="32" Height="32" Offset="0x20040" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_020770" OutName="ovl_Boss_GanonTex_020770" Format="i8" Width="32" Height="64" Offset="0x20440" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTLUT_00F808" OutName="ovl_Boss_GanonTLUT_00F808" Format="rgba16" Width="16" Height="16" Offset="0xF4D8" AddedByScript="true"/>
         <Texture Name="gGanondorfLightning1Tex" OutName="lightning_1" Format="i8" Width="32" Height="96" Offset="0x112D0" Static="Off"/>
         <Texture Name="gGanondorfLightning2Tex" OutName="lightning_2" Format="i8" Width="32" Height="96" Offset="0x11ED0" Static="Off"/>
         <Texture Name="gGanondorfLightning3Tex" OutName="lightning_3" Format="i8" Width="32" Height="96" Offset="0x12AD0" Static="Off"/>

--- a/soh/assets/xml/N64_PAL_11/overlays/ovl_Boss_Sst.xml
+++ b/soh/assets/xml/N64_PAL_11/overlays/ovl_Boss_Sst.xml
@@ -1,5 +1,7 @@
 <Root>
     <File Name="ovl_Boss_Sst" BaseAddress="0x80A18A60" RangeStart="0xA370" RangeEnd="0xAD70">
+        <Texture Name="ovl_Boss_SstTex_00A438" OutName="ovl_Boss_SstTex_00A438" Format="i8" Width="16" Height="64" Offset="0xA3E8" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_SstTex_00A8F0" OutName="ovl_Boss_SstTex_00A8F0" Format="i8" Width="32" Height="32" Offset="0xA8A0" AddedByScript="true"/>
         <DList Name="sBodyStaticDList" Offset="0xA370"/>
         <DList Name="sHandTrailDList" Offset="0xA388"/>
         <DList Name="sIntroVanishDList" Offset="0xA7E8"/>

--- a/soh/assets/xml/N64_PAL_11/overlays/ovl_Demo_Shd.xml
+++ b/soh/assets/xml/N64_PAL_11/overlays/ovl_Demo_Shd.xml
@@ -1,7 +1,9 @@
 <Root>
     <File Name="ovl_Demo_Shd" BaseAddress="0x80A737F0" RangeStart="0x410" RangeEnd="0x23D0">
 
-    <DList Name="D_809932D0" Offset="0x2060"/>
+    <Texture Name="ovl_Demo_ShdTex_000450" OutName="ovl_Demo_ShdTex_000450" Format="i8" Width="16" Height="128" Offset="0x410" AddedByScript="true"/>
+        <Texture Name="ovl_Demo_ShdTex_000C50" OutName="ovl_Demo_ShdTex_000C50" Format="i8" Width="32" Height="64" Offset="0xC10" AddedByScript="true"/>
+        <DList Name="D_809932D0" Offset="0x2060"/>
     <DList Name="D_80993390" Offset="0x2120"/>
     <DList Name="D_809934B8" Offset="0x2248"/>
     </File>

--- a/soh/assets/xml/N64_PAL_11/overlays/ovl_En_Clear_Tag.xml
+++ b/soh/assets/xml/N64_PAL_11/overlays/ovl_En_Clear_Tag.xml
@@ -1,5 +1,19 @@
 <Root>
     <File Name="ovl_En_Clear_Tag" BaseAddress="0x80A939A0" RangeStart="0x2600" RangeEnd="0x89F0">
+        <Texture Name="ovl_En_Clear_TagTex_003308" OutName="ovl_En_Clear_TagTex_003308" Format="rgba16" Width="8" Height="8" Offset="0x3218" AddedByScript="true"/>
+        <Texture Name="ovl_En_Clear_TagTex_003388" OutName="ovl_En_Clear_TagTex_003388" Format="rgba16" Width="32" Height="32" Offset="0x3298" AddedByScript="true"/>
+        <Texture Name="ovl_En_Clear_TagTex_003B88" OutName="ovl_En_Clear_TagTex_003B88" Format="rgba16" Width="64" Height="32" Offset="0x3A98" AddedByScript="true"/>
+        <Texture Name="ovl_En_Clear_TagTex_004B88" OutName="ovl_En_Clear_TagTex_004B88" Format="rgba16" Width="32" Height="32" Offset="0x4A98" AddedByScript="true"/>
+        <Texture Name="ovl_En_Clear_TagTex_005388" OutName="ovl_En_Clear_TagTex_005388" Format="rgba16" Width="32" Height="32" Offset="0x5298" AddedByScript="true"/>
+        <Texture Name="ovl_En_Clear_TagTex_005B88" OutName="ovl_En_Clear_TagTex_005B88" Format="rgba16" Width="32" Height="32" Offset="0x5A98" AddedByScript="true"/>
+        <Texture Name="ovl_En_Clear_TagTex_006458" OutName="ovl_En_Clear_TagTex_006458" Format="rgba16" Width="16" Height="16" Offset="0x6368" AddedByScript="true"/>
+        <Texture Name="ovl_En_Clear_TagTex_006708" OutName="ovl_En_Clear_TagTex_006708" Format="i8" Width="16" Height="16" Offset="0x6618" AddedByScript="true"/>
+        <Texture Name="ovl_En_Clear_TagTex_006808" OutName="ovl_En_Clear_TagTex_006808" Format="rgba16" Width="16" Height="16" Offset="0x6718" AddedByScript="true"/>
+        <Texture Name="ovl_En_Clear_TagTex_006AD0" OutName="ovl_En_Clear_TagTex_006AD0" Format="i4" Width="32" Height="64" Offset="0x69E0" AddedByScript="true"/>
+        <Texture Name="ovl_En_Clear_TagTex_006ED0" OutName="ovl_En_Clear_TagTex_006ED0" Format="i4" Width="32" Height="32" Offset="0x6DE0" AddedByScript="true"/>
+        <Texture Name="ovl_En_Clear_TagTex_0071C8" OutName="ovl_En_Clear_TagTex_0071C8" Format="i8" Width="64" Height="64" Offset="0x70D8" AddedByScript="true"/>
+        <Texture Name="ovl_En_Clear_TagTex_008288" OutName="ovl_En_Clear_TagTex_008288" Format="i4" Width="32" Height="32" Offset="0x8198" AddedByScript="true"/>
+        <Texture Name="ovl_En_Clear_TagTex_008540" OutName="ovl_En_Clear_TagTex_008540" Format="i8" Width="32" Height="32" Offset="0x8450" AddedByScript="true"/>
         <DList Name="gArwingDL" Offset="0x2600"/>
         <DList Name="gArwingLaserDL" Offset="0x6298"/>
         <DList Name="gArwingBackfireDL" Offset="0x6598"/>

--- a/soh/assets/xml/N64_PAL_11/scenes/dungeons/Bmori1.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/dungeons/Bmori1.xml
@@ -1,76 +1,231 @@
 <Root>
     <File Name="Bmori1_scene" Segment="2">
+        <Texture Name="Bmori1_sceneTex_014490" OutName="Bmori1_sceneTex_014490" Format="ci8" Width="32" Height="8" Offset="0x14490" TlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_sceneTex_015590" OutName="Bmori1_sceneTex_015590" Format="ci8" Width="16" Height="16" Offset="0x15590" TlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_sceneTex_015690" OutName="Bmori1_sceneTex_015690" Format="ci8" Width="32" Height="32" Offset="0x15690" TlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_sceneTex_015A90" OutName="Bmori1_sceneTex_015A90" Format="ci8" Width="16" Height="16" Offset="0x15A90" TlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_sceneTex_015B90" OutName="Bmori1_sceneTex_015B90" Format="ci8" Width="32" Height="32" Offset="0x15B90" TlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_sceneTLUT_014080" OutName="Bmori1_sceneTLUT_014080" Format="rgba16" Width="16" Height="16" Offset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_sceneTLUT_014288" OutName="Bmori1_sceneTLUT_014288" Format="rgba16" Width="16" Height="16" Offset="0x14288" AddedByScript="true"/>
         <Texture Name="gForestTempleDayEntranceTex" OutName="day_entrance" Format="ia16" Width="8" Height="128" Offset="0x14D90"/>
         <Texture Name="gForestTempleNightEntranceTex" OutName="night_entrance" Format="ia16" Width="8" Height="128" Offset="0x14590"/>
         <Scene Name="Bmori1_scene" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_0" Segment="3">
+        <Texture Name="Bmori1_room_0Tex_005CF8" OutName="Bmori1_room_0Tex_005CF8" Format="ci8" Width="64" Height="32" Offset="0x5D28" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_0Tex_0064F8" OutName="Bmori1_room_0Tex_0064F8" Format="i8" Width="64" Height="64" Offset="0x6528" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_0Tex_0074F8" OutName="Bmori1_room_0Tex_0074F8" Format="rgba16" Width="32" Height="32" Offset="0x7528" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_0Tex_007CF8" OutName="Bmori1_room_0Tex_007CF8" Format="rgba16" Width="32" Height="32" Offset="0x7D28" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_0Tex_0084F8" OutName="Bmori1_room_0Tex_0084F8" Format="ci8" Width="16" Height="64" Offset="0x8528" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_0Tex_0088F8" OutName="Bmori1_room_0Tex_0088F8" Format="rgba16" Width="32" Height="64" Offset="0x8928" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_0Tex_0098F8" OutName="Bmori1_room_0Tex_0098F8" Format="ci8" Width="32" Height="64" Offset="0x9928" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_0Tex_00A0F8" OutName="Bmori1_room_0Tex_00A0F8" Format="rgba16" Width="32" Height="64" Offset="0xA128" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_0Tex_00B0F8" OutName="Bmori1_room_0Tex_00B0F8" Format="ci8" Width="32" Height="32" Offset="0xB128" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_0Tex_00B4F8" OutName="Bmori1_room_0Tex_00B4F8" Format="ci8" Width="32" Height="32" Offset="0xB528" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_0Tex_00B8F8" OutName="Bmori1_room_0Tex_00B8F8" Format="ci8" Width="64" Height="32" Offset="0xB928" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_0Tex_00C0F8" OutName="Bmori1_room_0Tex_00C0F8" Format="ci8" Width="16" Height="32" Offset="0xC128" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_0Tex_00C2F8" OutName="Bmori1_room_0Tex_00C2F8" Format="ci8" Width="32" Height="32" Offset="0xC328" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_0Tex_00CB88" OutName="Bmori1_room_0Tex_00CB88" Format="rgba16" Width="32" Height="64" Offset="0xCBB8" AddedByScript="true"/>
         <Room Name="Bmori1_room_0" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_1" Segment="3">
+        <Texture Name="Bmori1_room_1Tex_003368" OutName="Bmori1_room_1Tex_003368" Format="rgba16" Width="32" Height="32" Offset="0x3358" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_1Tex_003B68" OutName="Bmori1_room_1Tex_003B68" Format="ci8" Width="64" Height="32" Offset="0x3B58" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_1Tex_004368" OutName="Bmori1_room_1Tex_004368" Format="rgba16" Width="32" Height="64" Offset="0x4358" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_1Tex_005368" OutName="Bmori1_room_1Tex_005368" Format="ci8" Width="32" Height="64" Offset="0x5358" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
         <Room Name="Bmori1_room_1" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_2" Segment="3">
+        <Texture Name="Bmori1_room_2Tex_00A380" OutName="Bmori1_room_2Tex_00A380" Format="ci8" Width="64" Height="32" Offset="0xA430" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_2Tex_00AB80" OutName="Bmori1_room_2Tex_00AB80" Format="ci8" Width="16" Height="64" Offset="0xAC30" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_2Tex_00AF80" OutName="Bmori1_room_2Tex_00AF80" Format="rgba16" Width="32" Height="64" Offset="0xB030" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_2Tex_00BF80" OutName="Bmori1_room_2Tex_00BF80" Format="rgba16" Width="32" Height="64" Offset="0xC030" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_2Tex_00CF80" OutName="Bmori1_room_2Tex_00CF80" Format="ci8" Width="32" Height="32" Offset="0xD030" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_2Tex_00D380" OutName="Bmori1_room_2Tex_00D380" Format="ci8" Width="64" Height="32" Offset="0xD430" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_2Tex_00DB80" OutName="Bmori1_room_2Tex_00DB80" Format="ci8" Width="16" Height="32" Offset="0xDC30" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_2Tex_00DD80" OutName="Bmori1_room_2Tex_00DD80" Format="ci8" Width="64" Height="32" Offset="0xDE30" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_2Tex_00E580" OutName="Bmori1_room_2Tex_00E580" Format="ci8" Width="32" Height="32" Offset="0xE630" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_2Tex_00E980" OutName="Bmori1_room_2Tex_00E980" Format="ci8" Width="32" Height="64" Offset="0xEA30" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_2Tex_00F180" OutName="Bmori1_room_2Tex_00F180" Format="rgba16" Width="32" Height="32" Offset="0xF230" AddedByScript="true"/>
         <Room Name="Bmori1_room_2" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_3" Segment="3">
+        <Texture Name="Bmori1_room_3Tex_0023D8" OutName="Bmori1_room_3Tex_0023D8" Format="rgba16" Width="32" Height="32" Offset="0x2408" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_3Tex_002BD8" OutName="Bmori1_room_3Tex_002BD8" Format="ci8" Width="16" Height="128" Offset="0x2C08" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_3Tex_0033D8" OutName="Bmori1_room_3Tex_0033D8" Format="ci8" Width="32" Height="32" Offset="0x3408" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_3Tex_0037D8" OutName="Bmori1_room_3Tex_0037D8" Format="rgba16" Width="8" Height="16" Offset="0x3808" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_3Tex_0038D8" OutName="Bmori1_room_3Tex_0038D8" Format="rgba16" Width="16" Height="8" Offset="0x3908" AddedByScript="true"/>
         <Room Name="Bmori1_room_3" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_4" Segment="3">
+        <Texture Name="Bmori1_room_4Tex_0022B8" OutName="Bmori1_room_4Tex_0022B8" Format="rgba16" Width="32" Height="32" Offset="0x22A8" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_4Tex_002AB8" OutName="Bmori1_room_4Tex_002AB8" Format="ci8" Width="64" Height="32" Offset="0x2AA8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
         <Room Name="Bmori1_room_4" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_5" Segment="3">
+        <Texture Name="Bmori1_room_5Tex_0023D0" OutName="Bmori1_room_5Tex_0023D0" Format="ci8" Width="32" Height="32" Offset="0x23E0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_5Tex_0027D0" OutName="Bmori1_room_5Tex_0027D0" Format="ci8" Width="16" Height="128" Offset="0x27E0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_5Tex_002FD0" OutName="Bmori1_room_5Tex_002FD0" Format="ci8" Width="32" Height="32" Offset="0x2FE0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_5Tex_0033D0" OutName="Bmori1_room_5Tex_0033D0" Format="rgba16" Width="8" Height="16" Offset="0x33E0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_5Tex_0034D0" OutName="Bmori1_room_5Tex_0034D0" Format="rgba16" Width="16" Height="8" Offset="0x34E0" AddedByScript="true"/>
         <Room Name="Bmori1_room_5" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_6" Segment="3">
+        <Texture Name="Bmori1_room_6Tex_006630" OutName="Bmori1_room_6Tex_006630" Format="rgba16" Width="32" Height="32" Offset="0x66C0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_6Tex_006E30" OutName="Bmori1_room_6Tex_006E30" Format="rgba16" Width="32" Height="32" Offset="0x6EC0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_6Tex_007630" OutName="Bmori1_room_6Tex_007630" Format="ci8" Width="32" Height="32" Offset="0x76C0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_6Tex_007A30" OutName="Bmori1_room_6Tex_007A30" Format="ci8" Width="64" Height="32" Offset="0x7AC0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_6Tex_008230" OutName="Bmori1_room_6Tex_008230" Format="ci8" Width="64" Height="32" Offset="0x82C0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_6Tex_008A30" OutName="Bmori1_room_6Tex_008A30" Format="ci8" Width="16" Height="32" Offset="0x8AC0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_6Tex_008C30" OutName="Bmori1_room_6Tex_008C30" Format="ci8" Width="32" Height="64" Offset="0x8CC0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
         <Room Name="Bmori1_room_6" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_7" Segment="3">
+        <Texture Name="Bmori1_room_7Tex_007DD0" OutName="Bmori1_room_7Tex_007DD0" Format="rgba16" Width="32" Height="32" Offset="0x7DF0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_0085D0" OutName="Bmori1_room_7Tex_0085D0" Format="rgba16" Width="32" Height="32" Offset="0x85F0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_008DD0" OutName="Bmori1_room_7Tex_008DD0" Format="ci8" Width="32" Height="32" Offset="0x8DF0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_0091D0" OutName="Bmori1_room_7Tex_0091D0" Format="ci8" Width="32" Height="32" Offset="0x91F0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_0095D0" OutName="Bmori1_room_7Tex_0095D0" Format="ci8" Width="32" Height="64" Offset="0x95F0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_009DD0" OutName="Bmori1_room_7Tex_009DD0" Format="ci8" Width="32" Height="64" Offset="0x9DF0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_00A5D0" OutName="Bmori1_room_7Tex_00A5D0" Format="ci8" Width="64" Height="32" Offset="0xA5F0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_00ADD0" OutName="Bmori1_room_7Tex_00ADD0" Format="rgba16" Width="32" Height="32" Offset="0xADF0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_00B5D0" OutName="Bmori1_room_7Tex_00B5D0" Format="ci8" Width="64" Height="32" Offset="0xB5F0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_00BDD0" OutName="Bmori1_room_7Tex_00BDD0" Format="rgba16" Width="32" Height="64" Offset="0xBDF0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_00CDD0" OutName="Bmori1_room_7Tex_00CDD0" Format="rgba16" Width="32" Height="64" Offset="0xCDF0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_00DDD0" OutName="Bmori1_room_7Tex_00DDD0" Format="rgba16" Width="32" Height="32" Offset="0xDDF0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_00EFD8" OutName="Bmori1_room_7Tex_00EFD8" Format="i4" Width="64" Height="128" Offset="0xEFF8" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_00FFD8" OutName="Bmori1_room_7Tex_00FFD8" Format="rgba16" Width="32" Height="64" Offset="0xFFF8" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_010FD8" OutName="Bmori1_room_7Tex_010FD8" Format="rgba16" Width="32" Height="32" Offset="0x10FF8" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_0117D8" OutName="Bmori1_room_7Tex_0117D8" Format="ia16" Width="32" Height="32" Offset="0x117F8" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_7Tex_011FD8" OutName="Bmori1_room_7Tex_011FD8" Format="rgba16" Width="32" Height="64" Offset="0x11FF8" AddedByScript="true"/>
         <Room Name="Bmori1_room_7" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_8" Segment="3">
+        <Texture Name="Bmori1_room_8Tex_00AC10" OutName="Bmori1_room_8Tex_00AC10" Format="rgba16" Width="32" Height="32" Offset="0xACD0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_00B410" OutName="Bmori1_room_8Tex_00B410" Format="rgba16" Width="32" Height="64" Offset="0xB4D0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_00C410" OutName="Bmori1_room_8Tex_00C410" Format="rgba16" Width="32" Height="32" Offset="0xC4D0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_00CC10" OutName="Bmori1_room_8Tex_00CC10" Format="ci8" Width="32" Height="32" Offset="0xCCD0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_00D010" OutName="Bmori1_room_8Tex_00D010" Format="ci8" Width="32" Height="32" Offset="0xD0D0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_00D410" OutName="Bmori1_room_8Tex_00D410" Format="ci8" Width="32" Height="32" Offset="0xD4D0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_00D810" OutName="Bmori1_room_8Tex_00D810" Format="ci8" Width="32" Height="64" Offset="0xD8D0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_00E010" OutName="Bmori1_room_8Tex_00E010" Format="ci8" Width="32" Height="64" Offset="0xE0D0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_00E810" OutName="Bmori1_room_8Tex_00E810" Format="ci8" Width="64" Height="32" Offset="0xE8D0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_00F010" OutName="Bmori1_room_8Tex_00F010" Format="ci8" Width="64" Height="32" Offset="0xF0D0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_00F810" OutName="Bmori1_room_8Tex_00F810" Format="rgba16" Width="32" Height="64" Offset="0xF8D0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_010810" OutName="Bmori1_room_8Tex_010810" Format="rgba16" Width="32" Height="64" Offset="0x108D0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_011810" OutName="Bmori1_room_8Tex_011810" Format="ci8" Width="32" Height="32" Offset="0x118D0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_011C10" OutName="Bmori1_room_8Tex_011C10" Format="ci8" Width="64" Height="32" Offset="0x11CD0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_012410" OutName="Bmori1_room_8Tex_012410" Format="rgba16" Width="32" Height="32" Offset="0x124D0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_013AB0" OutName="Bmori1_room_8Tex_013AB0" Format="i4" Width="64" Height="128" Offset="0x13B70" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_014AB0" OutName="Bmori1_room_8Tex_014AB0" Format="rgba16" Width="32" Height="32" Offset="0x14B70" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_0152B0" OutName="Bmori1_room_8Tex_0152B0" Format="ia16" Width="32" Height="32" Offset="0x15370" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_015AB0" OutName="Bmori1_room_8Tex_015AB0" Format="rgba16" Width="32" Height="64" Offset="0x15B70" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_8Tex_016AB0" OutName="Bmori1_room_8Tex_016AB0" Format="rgba16" Width="32" Height="64" Offset="0x16B70" AddedByScript="true"/>
         <Room Name="Bmori1_room_8" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_9" Segment="3">
+        <Texture Name="Bmori1_room_9Tex_0048B8" OutName="Bmori1_room_9Tex_0048B8" Format="rgba16" Width="32" Height="32" Offset="0x48E8" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_9Tex_0050B8" OutName="Bmori1_room_9Tex_0050B8" Format="ci8" Width="32" Height="32" Offset="0x50E8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_9Tex_0054B8" OutName="Bmori1_room_9Tex_0054B8" Format="ci8" Width="32" Height="64" Offset="0x54E8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_9Tex_005CB8" OutName="Bmori1_room_9Tex_005CB8" Format="ci8" Width="64" Height="32" Offset="0x5CE8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_9Tex_0064B8" OutName="Bmori1_room_9Tex_0064B8" Format="rgba16" Width="32" Height="32" Offset="0x64E8" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_9Tex_006CB8" OutName="Bmori1_room_9Tex_006CB8" Format="ci8" Width="64" Height="32" Offset="0x6CE8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_9Tex_0074B8" OutName="Bmori1_room_9Tex_0074B8" Format="rgba16" Width="32" Height="64" Offset="0x74E8" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_9Tex_008958" OutName="Bmori1_room_9Tex_008958" Format="ia16" Width="32" Height="32" Offset="0x8988" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_9Tex_009158" OutName="Bmori1_room_9Tex_009158" Format="rgba16" Width="32" Height="64" Offset="0x9188" AddedByScript="true"/>
         <Room Name="Bmori1_room_9" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_10" Segment="3">
+        <Texture Name="Bmori1_room_10Tex_001260" OutName="Bmori1_room_10Tex_001260" Format="rgba16" Width="32" Height="32" Offset="0x1260" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_10Tex_001A60" OutName="Bmori1_room_10Tex_001A60" Format="ci8" Width="16" Height="128" Offset="0x1A60" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_10Tex_002260" OutName="Bmori1_room_10Tex_002260" Format="ci8" Width="64" Height="32" Offset="0x2260" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_10Tex_002A60" OutName="Bmori1_room_10Tex_002A60" Format="rgba16" Width="32" Height="64" Offset="0x2A60" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_10Tex_003A60" OutName="Bmori1_room_10Tex_003A60" Format="rgba16" Width="32" Height="64" Offset="0x3A60" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_10Tex_004BD8" OutName="Bmori1_room_10Tex_004BD8" Format="ia16" Width="32" Height="32" Offset="0x4BD8" AddedByScript="true"/>
         <Room Name="Bmori1_room_10" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_11" Segment="3">
+        <Texture Name="Bmori1_room_11Tex_008198" OutName="Bmori1_room_11Tex_008198" Format="rgba16" Width="64" Height="32" Offset="0x8188" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_11Tex_009198" OutName="Bmori1_room_11Tex_009198" Format="ci8" Width="32" Height="32" Offset="0x9188" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_11Tex_009598" OutName="Bmori1_room_11Tex_009598" Format="rgba16" Width="32" Height="32" Offset="0x9588" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_11Tex_009D98" OutName="Bmori1_room_11Tex_009D98" Format="i4" Width="64" Height="64" Offset="0x9D88" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_11Tex_00A598" OutName="Bmori1_room_11Tex_00A598" Format="ci8" Width="32" Height="32" Offset="0xA588" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
         <Room Name="Bmori1_room_11" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_12" Segment="3">
+        <Texture Name="Bmori1_room_12Tex_004A00" OutName="Bmori1_room_12Tex_004A00" Format="ci8" Width="32" Height="32" Offset="0x4A00" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_12Tex_004E00" OutName="Bmori1_room_12Tex_004E00" Format="ci8" Width="32" Height="64" Offset="0x4E00" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_12Tex_005600" OutName="Bmori1_room_12Tex_005600" Format="ci8" Width="64" Height="32" Offset="0x5600" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_12Tex_005E00" OutName="Bmori1_room_12Tex_005E00" Format="ci8" Width="64" Height="32" Offset="0x5E00" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_12Tex_006600" OutName="Bmori1_room_12Tex_006600" Format="ci8" Width="64" Height="32" Offset="0x6600" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_12Tex_006E00" OutName="Bmori1_room_12Tex_006E00" Format="ci8" Width="32" Height="32" Offset="0x6E00" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_12Tex_007200" OutName="Bmori1_room_12Tex_007200" Format="rgba16" Width="32" Height="32" Offset="0x7200" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_12Tex_007BD8" OutName="Bmori1_room_12Tex_007BD8" Format="ia16" Width="32" Height="32" Offset="0x7BD8" AddedByScript="true"/>
         <Room Name="Bmori1_room_12" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_13" Segment="3">
+        <Texture Name="Bmori1_room_13Tex_004CD0" OutName="Bmori1_room_13Tex_004CD0" Format="rgba16" Width="32" Height="32" Offset="0x4CD0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_13Tex_0054D0" OutName="Bmori1_room_13Tex_0054D0" Format="ci8" Width="32" Height="64" Offset="0x54D0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_13Tex_005CD0" OutName="Bmori1_room_13Tex_005CD0" Format="ci8" Width="64" Height="32" Offset="0x5CD0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_13Tex_0064D0" OutName="Bmori1_room_13Tex_0064D0" Format="ci8" Width="64" Height="32" Offset="0x64D0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_13Tex_006CD0" OutName="Bmori1_room_13Tex_006CD0" Format="ci8" Width="64" Height="32" Offset="0x6CD0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_13Tex_0074D0" OutName="Bmori1_room_13Tex_0074D0" Format="ci8" Width="32" Height="32" Offset="0x74D0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_13Tex_0078D0" OutName="Bmori1_room_13Tex_0078D0" Format="rgba16" Width="32" Height="32" Offset="0x78D0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_13Tex_0082A8" OutName="Bmori1_room_13Tex_0082A8" Format="ia16" Width="32" Height="32" Offset="0x82A8" AddedByScript="true"/>
         <Room Name="Bmori1_room_13" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_14" Segment="3">
+        <Texture Name="Bmori1_room_14Tex_003560" OutName="Bmori1_room_14Tex_003560" Format="ci8" Width="32" Height="32" Offset="0x35A0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_14Tex_003960" OutName="Bmori1_room_14Tex_003960" Format="rgba16" Width="32" Height="32" Offset="0x39A0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_14Tex_004160" OutName="Bmori1_room_14Tex_004160" Format="rgba16" Width="32" Height="32" Offset="0x41A0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_14Tex_004960" OutName="Bmori1_room_14Tex_004960" Format="ci8" Width="32" Height="32" Offset="0x49A0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_14Tex_004D60" OutName="Bmori1_room_14Tex_004D60" Format="ci8" Width="64" Height="32" Offset="0x4DA0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_14Tex_005770" OutName="Bmori1_room_14Tex_005770" Format="ia8" Width="32" Height="32" Offset="0x57B0" AddedByScript="true"/>
         <Room Name="Bmori1_room_14" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_15" Segment="3">
+        <Texture Name="Bmori1_room_15Tex_0012E0" OutName="Bmori1_room_15Tex_0012E0" Format="ci8" Width="32" Height="64" Offset="0x1290" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_15Tex_001AE0" OutName="Bmori1_room_15Tex_001AE0" Format="ci8" Width="32" Height="32" Offset="0x1A90" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_15Tex_001EE0" OutName="Bmori1_room_15Tex_001EE0" Format="ci8" Width="64" Height="32" Offset="0x1E90" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
         <Room Name="Bmori1_room_15" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_16" Segment="3">
+        <Texture Name="Bmori1_room_16Tex_002F98" OutName="Bmori1_room_16Tex_002F98" Format="rgba16" Width="32" Height="32" Offset="0x2F98" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_16Tex_003798" OutName="Bmori1_room_16Tex_003798" Format="ci8" Width="64" Height="32" Offset="0x3798" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_16Tex_003F98" OutName="Bmori1_room_16Tex_003F98" Format="ci8" Width="32" Height="32" Offset="0x3F98" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_16Tex_004398" OutName="Bmori1_room_16Tex_004398" Format="ci8" Width="32" Height="32" Offset="0x4398" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_16Tex_004798" OutName="Bmori1_room_16Tex_004798" Format="ci8" Width="64" Height="32" Offset="0x4798" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
         <Room Name="Bmori1_room_16" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_17" Segment="3">
+        <Texture Name="Bmori1_room_17Tex_0064E8" OutName="Bmori1_room_17Tex_0064E8" Format="rgba16" Width="32" Height="32" Offset="0x6548" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_17Tex_006CE8" OutName="Bmori1_room_17Tex_006CE8" Format="rgba16" Width="32" Height="32" Offset="0x6D48" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_17Tex_0074E8" OutName="Bmori1_room_17Tex_0074E8" Format="ci8" Width="32" Height="32" Offset="0x7548" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_17Tex_0078E8" OutName="Bmori1_room_17Tex_0078E8" Format="ci8" Width="32" Height="32" Offset="0x7948" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_17Tex_007CE8" OutName="Bmori1_room_17Tex_007CE8" Format="ci8" Width="32" Height="32" Offset="0x7D48" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_17Tex_0080E8" OutName="Bmori1_room_17Tex_0080E8" Format="ci8" Width="64" Height="32" Offset="0x8148" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_17Tex_0088E8" OutName="Bmori1_room_17Tex_0088E8" Format="ci8" Width="32" Height="64" Offset="0x8948" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
         <Room Name="Bmori1_room_17" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_18" Segment="3">
+        <Texture Name="Bmori1_room_18Tex_000B30" OutName="Bmori1_room_18Tex_000B30" Format="ci8" Width="64" Height="32" Offset="0xB40" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
         <Room Name="Bmori1_room_18" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_19" Segment="3">
         <Room Name="Bmori1_room_19" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_20" Segment="3">
+        <Texture Name="Bmori1_room_20Tex_0006F8" OutName="Bmori1_room_20Tex_0006F8" Format="ci8" Width="32" Height="64" Offset="0x6F8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_20Tex_000EF8" OutName="Bmori1_room_20Tex_000EF8" Format="ci8" Width="32" Height="32" Offset="0xEF8" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14080" AddedByScript="true"/>
         <Room Name="Bmori1_room_20" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_21" Segment="3">
+        <Texture Name="Bmori1_room_21Tex_000F70" OutName="Bmori1_room_21Tex_000F70" Format="ci8" Width="64" Height="32" Offset="0xF80" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
         <Room Name="Bmori1_room_21" Offset="0x0"/>
     </File>
     <File Name="Bmori1_room_22" Segment="3">
+        <Texture Name="Bmori1_room_22Tex_0005E0" OutName="Bmori1_room_22Tex_0005E0" Format="rgba16" Width="64" Height="32" Offset="0x5E0" AddedByScript="true"/>
+        <Texture Name="Bmori1_room_22Tex_0015E0" OutName="Bmori1_room_22Tex_0015E0" Format="ci8" Width="64" Height="32" Offset="0x15E0" ExternalTlut="Bmori1_scene" ExternalTlutOffset="0x14288" AddedByScript="true"/>
         <Room Name="Bmori1_room_22" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/N64_PAL_11/scenes/dungeons/FIRE_bs.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/dungeons/FIRE_bs.xml
@@ -1,11 +1,34 @@
 <Root>
     <File Name="FIRE_bs_scene" Segment="2">
+        <Texture Name="FIRE_bs_sceneTex_002C00" OutName="FIRE_bs_sceneTex_002C00" Format="rgba16" Width="32" Height="32" Offset="0x2C00" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_sceneTex_003400" OutName="FIRE_bs_sceneTex_003400" Format="rgba16" Width="32" Height="32" Offset="0x3400" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_sceneTex_003C00" OutName="FIRE_bs_sceneTex_003C00" Format="rgba16" Width="32" Height="32" Offset="0x3C00" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_sceneTex_004400" OutName="FIRE_bs_sceneTex_004400" Format="rgba16" Width="32" Height="32" Offset="0x4400" AddedByScript="true"/>
         <Scene Name="FIRE_bs_scene" Offset="0x0"/>
     </File>
     <File Name="FIRE_bs_room_0" Segment="3">
+        <Texture Name="FIRE_bs_room_0Tex_002E68" OutName="FIRE_bs_room_0Tex_002E68" Format="ci4" Width="32" Height="32" Offset="0x2E68" TlutOffset="0x2E48" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_0Tex_003068" OutName="FIRE_bs_room_0Tex_003068" Format="ci4" Width="32" Height="64" Offset="0x3068" TlutOffset="0x2E48" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_0Tex_003468" OutName="FIRE_bs_room_0Tex_003468" Format="ci4" Width="64" Height="32" Offset="0x3468" TlutOffset="0x2E28" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_0Tex_003868" OutName="FIRE_bs_room_0Tex_003868" Format="ci4" Width="32" Height="32" Offset="0x3868" TlutOffset="0x2E28" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_0Tex_003A68" OutName="FIRE_bs_room_0Tex_003A68" Format="ci4" Width="32" Height="32" Offset="0x3A68" TlutOffset="0x2E28" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_0Tex_003C68" OutName="FIRE_bs_room_0Tex_003C68" Format="ci4" Width="32" Height="64" Offset="0x3C68" TlutOffset="0x2E48" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_0Tex_004068" OutName="FIRE_bs_room_0Tex_004068" Format="ci4" Width="32" Height="32" Offset="0x4068" TlutOffset="0x2E48" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_0TLUT_002E28" OutName="FIRE_bs_room_0TLUT_002E28" Format="rgba16" Width="4" Height="4" Offset="0x2E28" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_0TLUT_002E48" OutName="FIRE_bs_room_0TLUT_002E48" Format="rgba16" Width="4" Height="4" Offset="0x2E48" AddedByScript="true"/>
         <Room Name="FIRE_bs_room_0" Offset="0x0"/>
     </File>
     <File Name="FIRE_bs_room_1" Segment="3">
+        <Texture Name="FIRE_bs_room_1Tex_0049D8" OutName="FIRE_bs_room_1Tex_0049D8" Format="ci4" Width="32" Height="32" Offset="0x49D8" TlutOffset="0x49B8" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_1Tex_004BD8" OutName="FIRE_bs_room_1Tex_004BD8" Format="rgba16" Width="32" Height="32" Offset="0x4BD8" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_1Tex_0053D8" OutName="FIRE_bs_room_1Tex_0053D8" Format="rgba16" Width="32" Height="32" Offset="0x53D8" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_1Tex_005BD8" OutName="FIRE_bs_room_1Tex_005BD8" Format="ci4" Width="64" Height="32" Offset="0x5BD8" TlutOffset="0x4998" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_1Tex_005FD8" OutName="FIRE_bs_room_1Tex_005FD8" Format="ci4" Width="32" Height="32" Offset="0x5FD8" TlutOffset="0x4998" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_1Tex_0061D8" OutName="FIRE_bs_room_1Tex_0061D8" Format="ci4" Width="32" Height="64" Offset="0x61D8" TlutOffset="0x49B8" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_1Tex_0065D8" OutName="FIRE_bs_room_1Tex_0065D8" Format="rgba16" Width="32" Height="32" Offset="0x65D8" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_1Tex_006DD8" OutName="FIRE_bs_room_1Tex_006DD8" Format="ci4" Width="32" Height="32" Offset="0x6DD8" TlutOffset="0x49B8" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_1TLUT_004998" OutName="FIRE_bs_room_1TLUT_004998" Format="rgba16" Width="4" Height="4" Offset="0x4998" AddedByScript="true"/>
+        <Texture Name="FIRE_bs_room_1TLUT_0049B8" OutName="FIRE_bs_room_1TLUT_0049B8" Format="rgba16" Width="4" Height="4" Offset="0x49B8" AddedByScript="true"/>
         <Room Name="FIRE_bs_room_1" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/N64_PAL_11/scenes/dungeons/HAKAdan.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/dungeons/HAKAdan.xml
@@ -1,74 +1,191 @@
 <Root>
     <File Name="HAKAdan_scene" Segment="2">
+        <Texture Name="HAKAdan_sceneTex_0163C0" OutName="HAKAdan_sceneTex_0163C0" Format="rgba16" Width="32" Height="32" Offset="0x163C0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_sceneTex_016BC0" OutName="HAKAdan_sceneTex_016BC0" Format="rgba16" Width="32" Height="32" Offset="0x16BC0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_sceneTex_0173C0" OutName="HAKAdan_sceneTex_0173C0" Format="rgba16" Width="32" Height="32" Offset="0x173C0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_sceneTex_017BC0" OutName="HAKAdan_sceneTex_017BC0" Format="rgba16" Width="32" Height="32" Offset="0x17BC0" AddedByScript="true"/>
         <Scene Name="HAKAdan_scene" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_0" Segment="3">
+        <Texture Name="HAKAdan_room_0Tex_008230" OutName="HAKAdan_room_0Tex_008230" Format="rgba16" Width="32" Height="64" Offset="0x81A0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_0Tex_009230" OutName="HAKAdan_room_0Tex_009230" Format="rgba16" Width="32" Height="64" Offset="0x91A0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_0Tex_00A230" OutName="HAKAdan_room_0Tex_00A230" Format="rgba16" Width="32" Height="32" Offset="0xA1A0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_0Tex_00AD48" OutName="HAKAdan_room_0Tex_00AD48" Format="ia8" Width="32" Height="32" Offset="0xACB8" AddedByScript="true"/>
         <Room Name="HAKAdan_room_0" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_1" Segment="3">
+        <Texture Name="HAKAdan_room_1Tex_0012E8" OutName="HAKAdan_room_1Tex_0012E8" Format="rgba16" Width="32" Height="32" Offset="0x12B8" AddedByScript="true"/>
         <Room Name="HAKAdan_room_1" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_2" Segment="3">
+        <Texture Name="HAKAdan_room_2Tex_006BD8" OutName="HAKAdan_room_2Tex_006BD8" Format="i4" Width="64" Height="64" Offset="0x6B08" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_2Tex_0073D8" OutName="HAKAdan_room_2Tex_0073D8" Format="rgba16" Width="32" Height="16" Offset="0x7308" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_2Tex_0077D8" OutName="HAKAdan_room_2Tex_0077D8" Format="rgba16" Width="32" Height="32" Offset="0x7708" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_2Tex_007FD8" OutName="HAKAdan_room_2Tex_007FD8" Format="rgba16" Width="32" Height="8" Offset="0x7F08" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_2Tex_0081D8" OutName="HAKAdan_room_2Tex_0081D8" Format="rgba16" Width="32" Height="64" Offset="0x8108" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_2Tex_0091D8" OutName="HAKAdan_room_2Tex_0091D8" Format="rgba16" Width="32" Height="32" Offset="0x9108" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_2Tex_0099D8" OutName="HAKAdan_room_2Tex_0099D8" Format="i4" Width="32" Height="32" Offset="0x9908" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_2Tex_009BD8" OutName="HAKAdan_room_2Tex_009BD8" Format="rgba16" Width="32" Height="32" Offset="0x9B08" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_2Tex_00A3D8" OutName="HAKAdan_room_2Tex_00A3D8" Format="i4" Width="32" Height="32" Offset="0xA308" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_2Tex_00A5D8" OutName="HAKAdan_room_2Tex_00A5D8" Format="i4" Width="32" Height="32" Offset="0xA508" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_2Tex_00A7D8" OutName="HAKAdan_room_2Tex_00A7D8" Format="i4" Width="32" Height="32" Offset="0xA708" AddedByScript="true"/>
         <Room Name="HAKAdan_room_2" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_3" Segment="3">
+        <Texture Name="HAKAdan_room_3Tex_001578" OutName="HAKAdan_room_3Tex_001578" Format="rgba16" Width="32" Height="32" Offset="0x1538" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_3Tex_001D78" OutName="HAKAdan_room_3Tex_001D78" Format="rgba16" Width="32" Height="32" Offset="0x1D38" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_3Tex_002578" OutName="HAKAdan_room_3Tex_002578" Format="i4" Width="32" Height="32" Offset="0x2538" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_3Tex_002778" OutName="HAKAdan_room_3Tex_002778" Format="i4" Width="32" Height="32" Offset="0x2738" AddedByScript="true"/>
         <Room Name="HAKAdan_room_3" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_4" Segment="3">
+        <Texture Name="HAKAdan_room_4Tex_001458" OutName="HAKAdan_room_4Tex_001458" Format="rgba16" Width="32" Height="32" Offset="0x1438" AddedByScript="true"/>
         <Room Name="HAKAdan_room_4" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_5" Segment="3">
+        <Texture Name="HAKAdan_room_5Tex_003CC0" OutName="HAKAdan_room_5Tex_003CC0" Format="rgba16" Width="32" Height="16" Offset="0x3C60" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_5Tex_0040C0" OutName="HAKAdan_room_5Tex_0040C0" Format="rgba16" Width="32" Height="32" Offset="0x4060" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_5Tex_0048C0" OutName="HAKAdan_room_5Tex_0048C0" Format="rgba16" Width="32" Height="8" Offset="0x4860" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_5Tex_004AC0" OutName="HAKAdan_room_5Tex_004AC0" Format="rgba16" Width="32" Height="32" Offset="0x4A60" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_5Tex_0052C0" OutName="HAKAdan_room_5Tex_0052C0" Format="rgba16" Width="32" Height="32" Offset="0x5260" AddedByScript="true"/>
         <Room Name="HAKAdan_room_5" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_6" Segment="3">
+        <Texture Name="HAKAdan_room_6Tex_004BF0" OutName="HAKAdan_room_6Tex_004BF0" Format="i4" Width="64" Height="64" Offset="0x4B70" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_6Tex_0053F0" OutName="HAKAdan_room_6Tex_0053F0" Format="rgba16" Width="32" Height="8" Offset="0x5370" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_6Tex_0055F0" OutName="HAKAdan_room_6Tex_0055F0" Format="rgba16" Width="32" Height="64" Offset="0x5570" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_6Tex_0065F0" OutName="HAKAdan_room_6Tex_0065F0" Format="rgba16" Width="32" Height="32" Offset="0x6570" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_6Tex_006DF0" OutName="HAKAdan_room_6Tex_006DF0" Format="rgba16" Width="16" Height="32" Offset="0x6D70" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_6Tex_0071F0" OutName="HAKAdan_room_6Tex_0071F0" Format="rgba16" Width="16" Height="32" Offset="0x7170" AddedByScript="true"/>
         <Room Name="HAKAdan_room_6" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_7" Segment="3">
+        <Texture Name="HAKAdan_room_7Tex_0012D8" OutName="HAKAdan_room_7Tex_0012D8" Format="rgba16" Width="32" Height="32" Offset="0x12A8" AddedByScript="true"/>
         <Room Name="HAKAdan_room_7" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_8" Segment="3">
+        <Texture Name="HAKAdan_room_8Tex_003098" OutName="HAKAdan_room_8Tex_003098" Format="rgba16" Width="32" Height="8" Offset="0x3058" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_8Tex_003298" OutName="HAKAdan_room_8Tex_003298" Format="ia4" Width="128" Height="64" Offset="0x3258" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_8Tex_004298" OutName="HAKAdan_room_8Tex_004298" Format="rgba16" Width="32" Height="32" Offset="0x4258" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_8Tex_004A98" OutName="HAKAdan_room_8Tex_004A98" Format="i4" Width="32" Height="32" Offset="0x4A58" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_8Tex_004C98" OutName="HAKAdan_room_8Tex_004C98" Format="rgba16" Width="16" Height="32" Offset="0x4C58" AddedByScript="true"/>
         <Room Name="HAKAdan_room_8" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_9" Segment="3">
+        <Texture Name="HAKAdan_room_9Tex_009090" OutName="HAKAdan_room_9Tex_009090" Format="i4" Width="64" Height="64" Offset="0x8F60" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_9Tex_009890" OutName="HAKAdan_room_9Tex_009890" Format="rgba16" Width="32" Height="32" Offset="0x9760" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_9Tex_00A090" OutName="HAKAdan_room_9Tex_00A090" Format="rgba16" Width="32" Height="8" Offset="0x9F60" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_9Tex_00A290" OutName="HAKAdan_room_9Tex_00A290" Format="ia4" Width="128" Height="64" Offset="0xA160" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_9Tex_00B290" OutName="HAKAdan_room_9Tex_00B290" Format="rgba16" Width="32" Height="32" Offset="0xB160" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_9Tex_00BA90" OutName="HAKAdan_room_9Tex_00BA90" Format="rgba16" Width="16" Height="32" Offset="0xB960" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_9Tex_00BE90" OutName="HAKAdan_room_9Tex_00BE90" Format="rgba16" Width="32" Height="32" Offset="0xBD60" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_9Tex_00C690" OutName="HAKAdan_room_9Tex_00C690" Format="i4" Width="32" Height="32" Offset="0xC560" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_9Tex_00C890" OutName="HAKAdan_room_9Tex_00C890" Format="rgba16" Width="16" Height="32" Offset="0xC760" AddedByScript="true"/>
         <Room Name="HAKAdan_room_9" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_10" Segment="3">
+        <Texture Name="HAKAdan_room_10Tex_0039F0" OutName="HAKAdan_room_10Tex_0039F0" Format="rgba16" Width="32" Height="16" Offset="0x39A0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_10Tex_003DF0" OutName="HAKAdan_room_10Tex_003DF0" Format="rgba16" Width="32" Height="8" Offset="0x3DA0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_10Tex_003FF0" OutName="HAKAdan_room_10Tex_003FF0" Format="rgba16" Width="32" Height="64" Offset="0x3FA0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_10Tex_004FF0" OutName="HAKAdan_room_10Tex_004FF0" Format="ia4" Width="128" Height="64" Offset="0x4FA0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_10Tex_005FF0" OutName="HAKAdan_room_10Tex_005FF0" Format="rgba16" Width="32" Height="32" Offset="0x5FA0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_10Tex_0067F0" OutName="HAKAdan_room_10Tex_0067F0" Format="rgba16" Width="16" Height="32" Offset="0x67A0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_10Tex_006BF0" OutName="HAKAdan_room_10Tex_006BF0" Format="rgba16" Width="16" Height="64" Offset="0x6BA0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_10Tex_0073F0" OutName="HAKAdan_room_10Tex_0073F0" Format="rgba16" Width="16" Height="32" Offset="0x73A0" AddedByScript="true"/>
         <Room Name="HAKAdan_room_10" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_11" Segment="3">
+        <Texture Name="HAKAdan_room_11Tex_001E60" OutName="HAKAdan_room_11Tex_001E60" Format="i4" Width="64" Height="64" Offset="0x1D40" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_11Tex_002660" OutName="HAKAdan_room_11Tex_002660" Format="rgba16" Width="32" Height="16" Offset="0x2540" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_11Tex_002A60" OutName="HAKAdan_room_11Tex_002A60" Format="rgba16" Width="32" Height="8" Offset="0x2940" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_11Tex_002C60" OutName="HAKAdan_room_11Tex_002C60" Format="rgba16" Width="32" Height="32" Offset="0x2B40" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_11Tex_003460" OutName="HAKAdan_room_11Tex_003460" Format="rgba16" Width="32" Height="32" Offset="0x3340" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_11Tex_003C60" OutName="HAKAdan_room_11Tex_003C60" Format="i4" Width="32" Height="32" Offset="0x3B40" AddedByScript="true"/>
         <Room Name="HAKAdan_room_11" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_12" Segment="3">
+        <Texture Name="HAKAdan_room_12Tex_003348" OutName="HAKAdan_room_12Tex_003348" Format="i4" Width="32" Height="32" Offset="0x3318" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_12Tex_003548" OutName="HAKAdan_room_12Tex_003548" Format="i4" Width="32" Height="32" Offset="0x3518" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_12Tex_003748" OutName="HAKAdan_room_12Tex_003748" Format="rgba16" Width="32" Height="16" Offset="0x3718" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_12Tex_003B48" OutName="HAKAdan_room_12Tex_003B48" Format="rgba16" Width="32" Height="8" Offset="0x3B18" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_12Tex_003D48" OutName="HAKAdan_room_12Tex_003D48" Format="rgba16" Width="32" Height="64" Offset="0x3D18" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_12Tex_004D48" OutName="HAKAdan_room_12Tex_004D48" Format="rgba16" Width="32" Height="32" Offset="0x4D18" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_12Tex_005548" OutName="HAKAdan_room_12Tex_005548" Format="i4" Width="32" Height="32" Offset="0x5518" AddedByScript="true"/>
         <Room Name="HAKAdan_room_12" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_13" Segment="3">
+        <Texture Name="HAKAdan_room_13Tex_000818" OutName="HAKAdan_room_13Tex_000818" Format="rgba16" Width="32" Height="32" Offset="0x7A8" AddedByScript="true"/>
         <Room Name="HAKAdan_room_13" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_14" Segment="3">
+        <Texture Name="HAKAdan_room_14Tex_003500" OutName="HAKAdan_room_14Tex_003500" Format="i4" Width="32" Height="32" Offset="0x3540" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_14Tex_003700" OutName="HAKAdan_room_14Tex_003700" Format="i4" Width="32" Height="32" Offset="0x3740" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_14Tex_003900" OutName="HAKAdan_room_14Tex_003900" Format="rgba16" Width="32" Height="16" Offset="0x3940" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_14Tex_003D00" OutName="HAKAdan_room_14Tex_003D00" Format="rgba16" Width="32" Height="8" Offset="0x3D40" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_14Tex_003F00" OutName="HAKAdan_room_14Tex_003F00" Format="rgba16" Width="32" Height="64" Offset="0x3F40" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_14Tex_004F00" OutName="HAKAdan_room_14Tex_004F00" Format="rgba16" Width="32" Height="32" Offset="0x4F40" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_14Tex_005700" OutName="HAKAdan_room_14Tex_005700" Format="i4" Width="32" Height="32" Offset="0x5740" AddedByScript="true"/>
         <Room Name="HAKAdan_room_14" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_15" Segment="3">
+        <Texture Name="HAKAdan_room_15Tex_0056C0" OutName="HAKAdan_room_15Tex_0056C0" Format="i4" Width="32" Height="32" Offset="0x5670" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_15Tex_0058C0" OutName="HAKAdan_room_15Tex_0058C0" Format="i4" Width="32" Height="32" Offset="0x5870" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_15Tex_005AC0" OutName="HAKAdan_room_15Tex_005AC0" Format="rgba16" Width="32" Height="16" Offset="0x5A70" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_15Tex_005EC0" OutName="HAKAdan_room_15Tex_005EC0" Format="rgba16" Width="32" Height="8" Offset="0x5E70" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_15Tex_0060C0" OutName="HAKAdan_room_15Tex_0060C0" Format="rgba16" Width="32" Height="32" Offset="0x6070" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_15Tex_0068C0" OutName="HAKAdan_room_15Tex_0068C0" Format="rgba16" Width="32" Height="32" Offset="0x6870" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_15Tex_0070C0" OutName="HAKAdan_room_15Tex_0070C0" Format="i4" Width="32" Height="32" Offset="0x7070" AddedByScript="true"/>
         <Room Name="HAKAdan_room_15" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_16" Segment="3">
+        <Texture Name="HAKAdan_room_16Tex_001930" OutName="HAKAdan_room_16Tex_001930" Format="rgba16" Width="32" Height="64" Offset="0x1880" AddedByScript="true"/>
         <Room Name="HAKAdan_room_16" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_17" Segment="3">
+        <Texture Name="HAKAdan_room_17Tex_001248" OutName="HAKAdan_room_17Tex_001248" Format="rgba16" Width="32" Height="8" Offset="0x1138" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_17Tex_001448" OutName="HAKAdan_room_17Tex_001448" Format="rgba16" Width="32" Height="32" Offset="0x1338" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_17Tex_001C48" OutName="HAKAdan_room_17Tex_001C48" Format="rgba16" Width="16" Height="32" Offset="0x1B38" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_17Tex_002048" OutName="HAKAdan_room_17Tex_002048" Format="rgba16" Width="16" Height="32" Offset="0x1F38" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_17Tex_0025D8" OutName="HAKAdan_room_17Tex_0025D8" Format="ia16" Width="32" Height="32" Offset="0x24C8" AddedByScript="true"/>
         <Room Name="HAKAdan_room_17" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_18" Segment="3">
+        <Texture Name="HAKAdan_room_18Tex_00B908" OutName="HAKAdan_room_18Tex_00B908" Format="i4" Width="32" Height="32" Offset="0xB878" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_18Tex_00BB08" OutName="HAKAdan_room_18Tex_00BB08" Format="rgba16" Width="32" Height="16" Offset="0xBA78" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_18Tex_00BF08" OutName="HAKAdan_room_18Tex_00BF08" Format="rgba16" Width="32" Height="32" Offset="0xBE78" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_18Tex_00C708" OutName="HAKAdan_room_18Tex_00C708" Format="rgba16" Width="32" Height="8" Offset="0xC678" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_18Tex_00C908" OutName="HAKAdan_room_18Tex_00C908" Format="i4" Width="32" Height="32" Offset="0xC878" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_18Tex_00CB08" OutName="HAKAdan_room_18Tex_00CB08" Format="i4" Width="32" Height="32" Offset="0xCA78" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_18Tex_00CD08" OutName="HAKAdan_room_18Tex_00CD08" Format="i4" Width="32" Height="32" Offset="0xCC78" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_18Tex_00CF08" OutName="HAKAdan_room_18Tex_00CF08" Format="rgba16" Width="16" Height="32" Offset="0xCE78" AddedByScript="true"/>
         <Room Name="HAKAdan_room_18" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_19" Segment="3">
+        <Texture Name="HAKAdan_room_19Tex_001578" OutName="HAKAdan_room_19Tex_001578" Format="rgba16" Width="32" Height="64" Offset="0x1518" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_19Tex_002578" OutName="HAKAdan_room_19Tex_002578" Format="rgba16" Width="32" Height="32" Offset="0x2518" AddedByScript="true"/>
         <Room Name="HAKAdan_room_19" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_20" Segment="3">
+        <Texture Name="HAKAdan_room_20Tex_001640" OutName="HAKAdan_room_20Tex_001640" Format="rgba16" Width="32" Height="32" Offset="0x1620" AddedByScript="true"/>
         <Room Name="HAKAdan_room_20" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_21" Segment="3">
+        <Texture Name="HAKAdan_room_21Tex_006E00" OutName="HAKAdan_room_21Tex_006E00" Format="rgba16" Width="32" Height="32" Offset="0x6D00" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_21Tex_007600" OutName="HAKAdan_room_21Tex_007600" Format="rgba16" Width="32" Height="8" Offset="0x7500" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_21Tex_007800" OutName="HAKAdan_room_21Tex_007800" Format="rgba16" Width="32" Height="64" Offset="0x7700" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_21Tex_008800" OutName="HAKAdan_room_21Tex_008800" Format="rgba16" Width="32" Height="32" Offset="0x8700" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_21Tex_009000" OutName="HAKAdan_room_21Tex_009000" Format="rgba16" Width="32" Height="32" Offset="0x8F00" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_21Tex_009800" OutName="HAKAdan_room_21Tex_009800" Format="rgba16" Width="16" Height="64" Offset="0x9700" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_21Tex_00A000" OutName="HAKAdan_room_21Tex_00A000" Format="rgba16" Width="32" Height="32" Offset="0x9F00" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_21Tex_00A800" OutName="HAKAdan_room_21Tex_00A800" Format="i4" Width="32" Height="32" Offset="0xA700" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_21Tex_00AA00" OutName="HAKAdan_room_21Tex_00AA00" Format="i4" Width="32" Height="32" Offset="0xA900" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_21Tex_00ADA8" OutName="HAKAdan_room_21Tex_00ADA8" Format="rgba16" Width="32" Height="32" Offset="0xACA8" AddedByScript="true"/>
         <Room Name="HAKAdan_room_21" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_room_22" Segment="3">
+        <Texture Name="HAKAdan_room_22Tex_000FA8" OutName="HAKAdan_room_22Tex_000FA8" Format="rgba16" Width="32" Height="8" Offset="0xF98" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_22Tex_0011A8" OutName="HAKAdan_room_22Tex_0011A8" Format="rgba16" Width="32" Height="64" Offset="0x1198" AddedByScript="true"/>
+        <Texture Name="HAKAdan_room_22Tex_0021A8" OutName="HAKAdan_room_22Tex_0021A8" Format="rgba16" Width="32" Height="32" Offset="0x2198" AddedByScript="true"/>
         <Room Name="HAKAdan_room_22" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/N64_PAL_11/scenes/dungeons/HAKAdanCH.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/dungeons/HAKAdanCH.xml
@@ -1,26 +1,69 @@
 <Root>
     <File Name="HAKAdanCH_scene" Segment="2">
+        <Texture Name="HAKAdanCH_sceneTex_00A590" OutName="HAKAdanCH_sceneTex_00A590" Format="rgba16" Width="32" Height="32" Offset="0xA560" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_sceneTex_00AD90" OutName="HAKAdanCH_sceneTex_00AD90" Format="rgba16" Width="32" Height="32" Offset="0xAD60" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_sceneTex_00B590" OutName="HAKAdanCH_sceneTex_00B590" Format="rgba16" Width="32" Height="32" Offset="0xB560" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_sceneTex_00BD90" OutName="HAKAdanCH_sceneTex_00BD90" Format="rgba16" Width="32" Height="32" Offset="0xBD60" AddedByScript="true"/>
         <Scene Name="HAKAdanCH_scene" Offset="0x0"/>
     </File>
     <File Name="HAKAdanCH_room_0" Segment="3">
+        <Texture Name="HAKAdanCH_room_0Tex_00D720" OutName="HAKAdanCH_room_0Tex_00D720" Format="rgba16" Width="32" Height="32" Offset="0xD5F0" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_00DF20" OutName="HAKAdanCH_room_0Tex_00DF20" Format="rgba16" Width="32" Height="8" Offset="0xDDF0" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_00E120" OutName="HAKAdanCH_room_0Tex_00E120" Format="rgba16" Width="32" Height="64" Offset="0xDFF0" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_00F120" OutName="HAKAdanCH_room_0Tex_00F120" Format="rgba16" Width="32" Height="32" Offset="0xEFF0" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_00F920" OutName="HAKAdanCH_room_0Tex_00F920" Format="rgba16" Width="32" Height="32" Offset="0xF7F0" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_010120" OutName="HAKAdanCH_room_0Tex_010120" Format="rgba16" Width="32" Height="64" Offset="0xFFF0" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_011120" OutName="HAKAdanCH_room_0Tex_011120" Format="rgba16" Width="32" Height="32" Offset="0x10FF0" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_011920" OutName="HAKAdanCH_room_0Tex_011920" Format="rgba16" Width="16" Height="32" Offset="0x117F0" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_011D20" OutName="HAKAdanCH_room_0Tex_011D20" Format="i4" Width="32" Height="32" Offset="0x11BF0" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_011F20" OutName="HAKAdanCH_room_0Tex_011F20" Format="rgba16" Width="16" Height="64" Offset="0x11DF0" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_012720" OutName="HAKAdanCH_room_0Tex_012720" Format="rgba16" Width="32" Height="32" Offset="0x125F0" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_012F20" OutName="HAKAdanCH_room_0Tex_012F20" Format="i4" Width="32" Height="32" Offset="0x12DF0" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_013120" OutName="HAKAdanCH_room_0Tex_013120" Format="i4" Width="32" Height="32" Offset="0x12FF0" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_013320" OutName="HAKAdanCH_room_0Tex_013320" Format="rgba16" Width="16" Height="32" Offset="0x131F0" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_013720" OutName="HAKAdanCH_room_0Tex_013720" Format="rgba16" Width="32" Height="32" Offset="0x135F0" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_013F20" OutName="HAKAdanCH_room_0Tex_013F20" Format="i4" Width="32" Height="32" Offset="0x13DF0" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_014B20" OutName="HAKAdanCH_room_0Tex_014B20" Format="ia4" Width="16" Height="128" Offset="0x149F0" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_0Tex_014F20" OutName="HAKAdanCH_room_0Tex_014F20" Format="ia16" Width="32" Height="32" Offset="0x14DF0" AddedByScript="true"/>
         <Room Name="HAKAdanCH_room_0" Offset="0x0"/>
     </File>
     <File Name="HAKAdanCH_room_1" Segment="3">
+        <Texture Name="HAKAdanCH_room_1Tex_008D58" OutName="HAKAdanCH_room_1Tex_008D58" Format="rgba16" Width="32" Height="8" Offset="0x8EF8" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_1Tex_008F58" OutName="HAKAdanCH_room_1Tex_008F58" Format="i4" Width="32" Height="32" Offset="0x90F8" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_1Tex_009158" OutName="HAKAdanCH_room_1Tex_009158" Format="i4" Width="32" Height="32" Offset="0x92F8" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_1Tex_009358" OutName="HAKAdanCH_room_1Tex_009358" Format="rgba16" Width="32" Height="16" Offset="0x94F8" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_1Tex_009758" OutName="HAKAdanCH_room_1Tex_009758" Format="rgba16" Width="32" Height="32" Offset="0x98F8" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_1Tex_009F58" OutName="HAKAdanCH_room_1Tex_009F58" Format="i4" Width="32" Height="32" Offset="0xA0F8" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_1Tex_00A158" OutName="HAKAdanCH_room_1Tex_00A158" Format="rgba16" Width="16" Height="32" Offset="0xA2F8" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_1Tex_00A558" OutName="HAKAdanCH_room_1Tex_00A558" Format="rgba16" Width="32" Height="32" Offset="0xA6F8" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_1Tex_00AD58" OutName="HAKAdanCH_room_1Tex_00AD58" Format="i4" Width="32" Height="32" Offset="0xAEF8" AddedByScript="true"/>
         <Room Name="HAKAdanCH_room_1" Offset="0x0"/>
     </File>
     <File Name="HAKAdanCH_room_2" Segment="3">
+        <Texture Name="HAKAdanCH_room_2Tex_002958" OutName="HAKAdanCH_room_2Tex_002958" Format="rgba16" Width="32" Height="8" Offset="0x2988" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_2Tex_002B58" OutName="HAKAdanCH_room_2Tex_002B58" Format="i4" Width="32" Height="32" Offset="0x2B88" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_2Tex_002D58" OutName="HAKAdanCH_room_2Tex_002D58" Format="i4" Width="32" Height="32" Offset="0x2D88" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_2Tex_002F58" OutName="HAKAdanCH_room_2Tex_002F58" Format="i4" Width="32" Height="32" Offset="0x2F88" AddedByScript="true"/>
         <Room Name="HAKAdanCH_room_2" Offset="0x0"/>
     </File>
     <File Name="HAKAdanCH_room_3" Segment="3">
+        <Texture Name="HAKAdanCH_room_3Tex_0014C0" OutName="HAKAdanCH_room_3Tex_0014C0" Format="rgba16" Width="32" Height="32" Offset="0x1460" AddedByScript="true"/>
         <Room Name="HAKAdanCH_room_3" Offset="0x0"/>
     </File>
     <File Name="HAKAdanCH_room_4" Segment="3">
+        <Texture Name="HAKAdanCH_room_4Tex_001498" OutName="HAKAdanCH_room_4Tex_001498" Format="rgba16" Width="32" Height="32" Offset="0x1448" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_4Tex_001C98" OutName="HAKAdanCH_room_4Tex_001C98" Format="rgba16" Width="32" Height="32" Offset="0x1C48" AddedByScript="true"/>
         <Room Name="HAKAdanCH_room_4" Offset="0x0"/>
     </File>
     <File Name="HAKAdanCH_room_5" Segment="3">
+        <Texture Name="HAKAdanCH_room_5Tex_001190" OutName="HAKAdanCH_room_5Tex_001190" Format="rgba16" Width="32" Height="64" Offset="0x1160" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_5Tex_002190" OutName="HAKAdanCH_room_5Tex_002190" Format="rgba16" Width="32" Height="32" Offset="0x2160" AddedByScript="true"/>
         <Room Name="HAKAdanCH_room_5" Offset="0x0"/>
     </File>
     <File Name="HAKAdanCH_room_6" Segment="3">
+        <Texture Name="HAKAdanCH_room_6Tex_000EA0" OutName="HAKAdanCH_room_6Tex_000EA0" Format="rgba16" Width="32" Height="32" Offset="0xE80" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_6Tex_0016A0" OutName="HAKAdanCH_room_6Tex_0016A0" Format="rgba16" Width="32" Height="64" Offset="0x1680" AddedByScript="true"/>
+        <Texture Name="HAKAdanCH_room_6Tex_0026A0" OutName="HAKAdanCH_room_6Tex_0026A0" Format="rgba16" Width="32" Height="32" Offset="0x2680" AddedByScript="true"/>
         <Room Name="HAKAdanCH_room_6" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/N64_PAL_11/scenes/dungeons/HAKAdan_bs.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/dungeons/HAKAdan_bs.xml
@@ -1,11 +1,23 @@
 <Root>
     <File Name="HAKAdan_bs_scene" Segment="2">
+        <Texture Name="HAKAdan_bs_sceneTex_001380" OutName="HAKAdan_bs_sceneTex_001380" Format="i4" Width="32" Height="32" Offset="0x1380" AddedByScript="true"/>
+        <Texture Name="HAKAdan_bs_sceneTex_001580" OutName="HAKAdan_bs_sceneTex_001580" Format="rgba16" Width="32" Height="8" Offset="0x1580" AddedByScript="true"/>
+        <Texture Name="HAKAdan_bs_sceneTex_001780" OutName="HAKAdan_bs_sceneTex_001780" Format="rgba16" Width="32" Height="32" Offset="0x1780" AddedByScript="true"/>
+        <Texture Name="HAKAdan_bs_sceneTex_001F80" OutName="HAKAdan_bs_sceneTex_001F80" Format="rgba16" Width="32" Height="32" Offset="0x1F80" AddedByScript="true"/>
         <Scene Name="HAKAdan_bs_scene" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_bs_room_0" Segment="3">
+        <Texture Name="HAKAdan_bs_room_0Tex_0021E0" OutName="HAKAdan_bs_room_0Tex_0021E0" Format="i4" Width="32" Height="32" Offset="0x21E0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_bs_room_0Tex_0023E0" OutName="HAKAdan_bs_room_0Tex_0023E0" Format="rgba16" Width="32" Height="16" Offset="0x23E0" AddedByScript="true"/>
+        <Texture Name="HAKAdan_bs_room_0Tex_0027E0" OutName="HAKAdan_bs_room_0Tex_0027E0" Format="i4" Width="32" Height="32" Offset="0x27E0" AddedByScript="true"/>
         <Room Name="HAKAdan_bs_room_0" Offset="0x0"/>
     </File>
     <File Name="HAKAdan_bs_room_1" Segment="3">
+        <Texture Name="HAKAdan_bs_room_1Tex_002D50" OutName="HAKAdan_bs_room_1Tex_002D50" Format="i4" Width="32" Height="32" Offset="0x2D50" AddedByScript="true"/>
+        <Texture Name="HAKAdan_bs_room_1Tex_002F50" OutName="HAKAdan_bs_room_1Tex_002F50" Format="rgba16" Width="32" Height="32" Offset="0x2F50" AddedByScript="true"/>
+        <Texture Name="HAKAdan_bs_room_1Tex_003750" OutName="HAKAdan_bs_room_1Tex_003750" Format="rgba16" Width="32" Height="32" Offset="0x3750" AddedByScript="true"/>
+        <Texture Name="HAKAdan_bs_room_1Tex_003F50" OutName="HAKAdan_bs_room_1Tex_003F50" Format="rgba16" Width="32" Height="64" Offset="0x3F50" AddedByScript="true"/>
+        <Texture Name="HAKAdan_bs_room_1Tex_004F50" OutName="HAKAdan_bs_room_1Tex_004F50" Format="rgba16" Width="32" Height="64" Offset="0x4F50" AddedByScript="true"/>
         <Room Name="HAKAdan_bs_room_1" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/N64_PAL_11/scenes/dungeons/HIDAN.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/dungeons/HIDAN.xml
@@ -1,87 +1,288 @@
 <Root>
     <File Name="HIDAN_scene" Segment="2">
+        <Texture Name="HIDAN_sceneTex_0189D0" OutName="HIDAN_sceneTex_0189D0" Format="ci4" Width="32" Height="32" Offset="0x18B70" TlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_sceneTex_018BD0" OutName="HIDAN_sceneTex_018BD0" Format="ci4" Width="32" Height="32" Offset="0x18D70" TlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_sceneTex_018DD0" OutName="HIDAN_sceneTex_018DD0" Format="rgba16" Width="32" Height="32" Offset="0x18F70" AddedByScript="true"/>
+        <Texture Name="HIDAN_sceneTex_0195D0" OutName="HIDAN_sceneTex_0195D0" Format="rgba16" Width="32" Height="32" Offset="0x19770" AddedByScript="true"/>
+        <Texture Name="HIDAN_sceneTex_019DD0" OutName="HIDAN_sceneTex_019DD0" Format="ci4" Width="32" Height="32" Offset="0x19F70" TlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_sceneTex_019FD0" OutName="HIDAN_sceneTex_019FD0" Format="rgba16" Width="32" Height="32" Offset="0x1A170" AddedByScript="true"/>
+        <Texture Name="HIDAN_sceneTLUT_018990" OutName="HIDAN_sceneTLUT_018990" Format="rgba16" Width="4" Height="4" Offset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_sceneTLUT_0189B0" OutName="HIDAN_sceneTLUT_0189B0" Format="rgba16" Width="4" Height="4" Offset="0x18B50" AddedByScript="true"/>
         <Path Name="gHidanPath_560" Offset="0x558" NumPaths="19"/>
         <Scene Name="HIDAN_scene" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_0" Segment="3">
+        <Texture Name="HIDAN_room_0Tex_004EF0" OutName="HIDAN_room_0Tex_004EF0" Format="ci4" Width="64" Height="32" Offset="0x4EC0" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_0Tex_0052F0" OutName="HIDAN_room_0Tex_0052F0" Format="ci4" Width="64" Height="32" Offset="0x52C0" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_0Tex_0056F0" OutName="HIDAN_room_0Tex_0056F0" Format="ci4" Width="64" Height="32" Offset="0x56C0" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_0Tex_005AF0" OutName="HIDAN_room_0Tex_005AF0" Format="ci4" Width="32" Height="32" Offset="0x5AC0" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_0Tex_005CF0" OutName="HIDAN_room_0Tex_005CF0" Format="ci4" Width="32" Height="32" Offset="0x5CC0" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_0Tex_005EF0" OutName="HIDAN_room_0Tex_005EF0" Format="ci4" Width="32" Height="64" Offset="0x5EC0" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_0Tex_0062F0" OutName="HIDAN_room_0Tex_0062F0" Format="rgba16" Width="32" Height="64" Offset="0x62C0" AddedByScript="true"/>
         <Room Name="HIDAN_room_0" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_1" Segment="3">
+        <Texture Name="HIDAN_room_1Tex_008730" OutName="HIDAN_room_1Tex_008730" Format="rgba16" Width="16" Height="16" Offset="0x87E0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_1Tex_008930" OutName="HIDAN_room_1Tex_008930" Format="rgba16" Width="32" Height="32" Offset="0x89E0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_1Tex_009130" OutName="HIDAN_room_1Tex_009130" Format="rgba16" Width="32" Height="32" Offset="0x91E0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_1Tex_009930" OutName="HIDAN_room_1Tex_009930" Format="rgba16" Width="32" Height="32" Offset="0x99E0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_1Tex_00A130" OutName="HIDAN_room_1Tex_00A130" Format="ci4" Width="64" Height="32" Offset="0xA1E0" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_1Tex_00A530" OutName="HIDAN_room_1Tex_00A530" Format="rgba16" Width="64" Height="32" Offset="0xA5E0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_1Tex_00B530" OutName="HIDAN_room_1Tex_00B530" Format="rgba16" Width="32" Height="32" Offset="0xB5E0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_1Tex_00BD30" OutName="HIDAN_room_1Tex_00BD30" Format="ci4" Width="32" Height="64" Offset="0xBDE0" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_1Tex_00C130" OutName="HIDAN_room_1Tex_00C130" Format="rgba16" Width="32" Height="32" Offset="0xC1E0" AddedByScript="true"/>
         <Room Name="HIDAN_room_1" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_2" Segment="3">
+        <Texture Name="HIDAN_room_2Tex_009628" OutName="HIDAN_room_2Tex_009628" Format="rgba16" Width="32" Height="8" Offset="0x95C8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_2Tex_009828" OutName="HIDAN_room_2Tex_009828" Format="rgba16" Width="32" Height="32" Offset="0x97C8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_2Tex_00A028" OutName="HIDAN_room_2Tex_00A028" Format="rgba16" Width="32" Height="32" Offset="0x9FC8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_2Tex_00A828" OutName="HIDAN_room_2Tex_00A828" Format="ci4" Width="64" Height="32" Offset="0xA7C8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_2Tex_00AC28" OutName="HIDAN_room_2Tex_00AC28" Format="rgba16" Width="64" Height="32" Offset="0xABC8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_2Tex_00BC28" OutName="HIDAN_room_2Tex_00BC28" Format="rgba16" Width="64" Height="32" Offset="0xBBC8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_2Tex_00CC28" OutName="HIDAN_room_2Tex_00CC28" Format="ci4" Width="32" Height="32" Offset="0xCBC8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_2Tex_00CE28" OutName="HIDAN_room_2Tex_00CE28" Format="rgba16" Width="64" Height="32" Offset="0xCDC8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_2Tex_00DE28" OutName="HIDAN_room_2Tex_00DE28" Format="ci4" Width="32" Height="32" Offset="0xDDC8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_2Tex_00E028" OutName="HIDAN_room_2Tex_00E028" Format="ci4" Width="32" Height="64" Offset="0xDFC8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_2Tex_00E428" OutName="HIDAN_room_2Tex_00E428" Format="rgba16" Width="32" Height="32" Offset="0xE3C8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_2Tex_00EC28" OutName="HIDAN_room_2Tex_00EC28" Format="ci4" Width="32" Height="64" Offset="0xEBC8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_2Tex_00F028" OutName="HIDAN_room_2Tex_00F028" Format="rgba16" Width="32" Height="32" Offset="0xEFC8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_2Tex_00F828" OutName="HIDAN_room_2Tex_00F828" Format="rgba16" Width="32" Height="32" Offset="0xF7C8" AddedByScript="true"/>
         <Room Name="HIDAN_room_2" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_3" Segment="3">
+        <Texture Name="HIDAN_room_3Tex_001AC8" OutName="HIDAN_room_3Tex_001AC8" Format="ci4" Width="32" Height="64" Offset="0x1AD8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_3Tex_001EC8" OutName="HIDAN_room_3Tex_001EC8" Format="ci4" Width="64" Height="32" Offset="0x1ED8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_3Tex_0022C8" OutName="HIDAN_room_3Tex_0022C8" Format="ci4" Width="32" Height="32" Offset="0x22D8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
         <Room Name="HIDAN_room_3" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_4" Segment="3">
+        <Texture Name="HIDAN_room_4Tex_0050F0" OutName="HIDAN_room_4Tex_0050F0" Format="rgba16" Width="32" Height="8" Offset="0x5090" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_4Tex_0052F0" OutName="HIDAN_room_4Tex_0052F0" Format="rgba16" Width="32" Height="32" Offset="0x5290" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_4Tex_005AF0" OutName="HIDAN_room_4Tex_005AF0" Format="rgba16" Width="32" Height="32" Offset="0x5A90" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_4Tex_0062F0" OutName="HIDAN_room_4Tex_0062F0" Format="ci4" Width="32" Height="64" Offset="0x6290" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_4Tex_0066F0" OutName="HIDAN_room_4Tex_0066F0" Format="ci4" Width="32" Height="32" Offset="0x6690" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_4Tex_0068F0" OutName="HIDAN_room_4Tex_0068F0" Format="ci4" Width="32" Height="64" Offset="0x6890" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_4Tex_006CF0" OutName="HIDAN_room_4Tex_006CF0" Format="ci4" Width="32" Height="64" Offset="0x6C90" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_4Tex_0070F0" OutName="HIDAN_room_4Tex_0070F0" Format="rgba16" Width="32" Height="32" Offset="0x7090" AddedByScript="true"/>
         <Room Name="HIDAN_room_4" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_5" Segment="3">
+        <Texture Name="HIDAN_room_5Tex_007EE0" OutName="HIDAN_room_5Tex_007EE0" Format="rgba16" Width="32" Height="8" Offset="0x7E30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_5Tex_0080E0" OutName="HIDAN_room_5Tex_0080E0" Format="rgba16" Width="32" Height="32" Offset="0x8030" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_5Tex_0088E0" OutName="HIDAN_room_5Tex_0088E0" Format="ci4" Width="32" Height="64" Offset="0x8830" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_5Tex_008CE0" OutName="HIDAN_room_5Tex_008CE0" Format="rgba16" Width="32" Height="32" Offset="0x8C30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_5Tex_0094E0" OutName="HIDAN_room_5Tex_0094E0" Format="ci4" Width="32" Height="32" Offset="0x9430" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_5Tex_0096E0" OutName="HIDAN_room_5Tex_0096E0" Format="ci4" Width="32" Height="64" Offset="0x9630" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_5Tex_009AE0" OutName="HIDAN_room_5Tex_009AE0" Format="ci4" Width="32" Height="64" Offset="0x9A30" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_5Tex_009EE0" OutName="HIDAN_room_5Tex_009EE0" Format="ci4" Width="32" Height="64" Offset="0x9E30" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
         <Room Name="HIDAN_room_5" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_6" Segment="3">
+        <Texture Name="HIDAN_room_6Tex_003990" OutName="HIDAN_room_6Tex_003990" Format="rgba16" Width="16" Height="16" Offset="0x39A0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_6Tex_003B90" OutName="HIDAN_room_6Tex_003B90" Format="rgba16" Width="32" Height="32" Offset="0x3BA0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_6Tex_004390" OutName="HIDAN_room_6Tex_004390" Format="rgba16" Width="32" Height="32" Offset="0x43A0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_6Tex_004B90" OutName="HIDAN_room_6Tex_004B90" Format="rgba16" Width="64" Height="32" Offset="0x4BA0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_6Tex_005B90" OutName="HIDAN_room_6Tex_005B90" Format="rgba16" Width="32" Height="32" Offset="0x5BA0" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_6Tex_006390" OutName="HIDAN_room_6Tex_006390" Format="ci4" Width="32" Height="64" Offset="0x63A0" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_6Tex_006790" OutName="HIDAN_room_6Tex_006790" Format="rgba16" Width="32" Height="32" Offset="0x67A0" AddedByScript="true"/>
         <Room Name="HIDAN_room_6" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_7" Segment="3">
+        <Texture Name="HIDAN_room_7Tex_001C48" OutName="HIDAN_room_7Tex_001C48" Format="rgba16" Width="32" Height="8" Offset="0x1BD8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_7Tex_001E48" OutName="HIDAN_room_7Tex_001E48" Format="rgba16" Width="32" Height="32" Offset="0x1DD8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_7Tex_002648" OutName="HIDAN_room_7Tex_002648" Format="ci4" Width="32" Height="64" Offset="0x25D8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_7Tex_002A48" OutName="HIDAN_room_7Tex_002A48" Format="rgba16" Width="32" Height="64" Offset="0x29D8" AddedByScript="true"/>
         <Room Name="HIDAN_room_7" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_8" Segment="3">
+        <Texture Name="HIDAN_room_8Tex_0050D8" OutName="HIDAN_room_8Tex_0050D8" Format="rgba16" Width="16" Height="16" Offset="0x50B8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_8Tex_0052D8" OutName="HIDAN_room_8Tex_0052D8" Format="rgba16" Width="32" Height="32" Offset="0x52B8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_8Tex_005AD8" OutName="HIDAN_room_8Tex_005AD8" Format="rgba16" Width="32" Height="32" Offset="0x5AB8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_8Tex_0062D8" OutName="HIDAN_room_8Tex_0062D8" Format="rgba16" Width="32" Height="32" Offset="0x62B8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_8Tex_006AD8" OutName="HIDAN_room_8Tex_006AD8" Format="rgba16" Width="64" Height="32" Offset="0x6AB8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_8Tex_007AD8" OutName="HIDAN_room_8Tex_007AD8" Format="rgba16" Width="32" Height="32" Offset="0x7AB8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_8Tex_0082D8" OutName="HIDAN_room_8Tex_0082D8" Format="ci4" Width="32" Height="64" Offset="0x82B8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_8Tex_0086D8" OutName="HIDAN_room_8Tex_0086D8" Format="ci4" Width="32" Height="64" Offset="0x86B8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_8Tex_008AD8" OutName="HIDAN_room_8Tex_008AD8" Format="rgba16" Width="32" Height="32" Offset="0x8AB8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_8Tex_0092D8" OutName="HIDAN_room_8Tex_0092D8" Format="rgba16" Width="32" Height="32" Offset="0x92B8" AddedByScript="true"/>
         <Room Name="HIDAN_room_8" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_9" Segment="3">
+        <Texture Name="HIDAN_room_9Tex_004768" OutName="HIDAN_room_9Tex_004768" Format="rgba16" Width="32" Height="32" Offset="0x4768" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_9Tex_004F68" OutName="HIDAN_room_9Tex_004F68" Format="rgba16" Width="32" Height="32" Offset="0x4F68" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_9Tex_005768" OutName="HIDAN_room_9Tex_005768" Format="rgba16" Width="32" Height="32" Offset="0x5768" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_9Tex_005F68" OutName="HIDAN_room_9Tex_005F68" Format="rgba16" Width="32" Height="32" Offset="0x5F68" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_9Tex_006768" OutName="HIDAN_room_9Tex_006768" Format="rgba16" Width="32" Height="32" Offset="0x6768" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_9Tex_006F68" OutName="HIDAN_room_9Tex_006F68" Format="rgba16" Width="32" Height="32" Offset="0x6F68" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_9Tex_007768" OutName="HIDAN_room_9Tex_007768" Format="rgba16" Width="32" Height="32" Offset="0x7768" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_9Tex_007F68" OutName="HIDAN_room_9Tex_007F68" Format="rgba16" Width="32" Height="32" Offset="0x7F68" AddedByScript="true"/>
         <Room Name="HIDAN_room_9" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_10" Segment="3">
+        <Texture Name="HIDAN_room_10Tex_011818" OutName="HIDAN_room_10Tex_011818" Format="rgba16" Width="32" Height="8" Offset="0x11898" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_011A18" OutName="HIDAN_room_10Tex_011A18" Format="rgba16" Width="32" Height="32" Offset="0x11A98" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_012218" OutName="HIDAN_room_10Tex_012218" Format="ci4" Width="32" Height="64" Offset="0x12298" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_012618" OutName="HIDAN_room_10Tex_012618" Format="rgba16" Width="32" Height="32" Offset="0x12698" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_012E18" OutName="HIDAN_room_10Tex_012E18" Format="ci4" Width="64" Height="32" Offset="0x12E98" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_013218" OutName="HIDAN_room_10Tex_013218" Format="ci4" Width="32" Height="32" Offset="0x13298" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_013418" OutName="HIDAN_room_10Tex_013418" Format="rgba16" Width="64" Height="32" Offset="0x13498" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_014418" OutName="HIDAN_room_10Tex_014418" Format="rgba16" Width="64" Height="32" Offset="0x14498" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_015418" OutName="HIDAN_room_10Tex_015418" Format="ci4" Width="64" Height="32" Offset="0x15498" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_015818" OutName="HIDAN_room_10Tex_015818" Format="ci4" Width="32" Height="32" Offset="0x15898" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_015A18" OutName="HIDAN_room_10Tex_015A18" Format="rgba16" Width="64" Height="32" Offset="0x15A98" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_016A18" OutName="HIDAN_room_10Tex_016A18" Format="ci4" Width="32" Height="32" Offset="0x16A98" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_016C18" OutName="HIDAN_room_10Tex_016C18" Format="ci4" Width="32" Height="64" Offset="0x16C98" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_017018" OutName="HIDAN_room_10Tex_017018" Format="rgba16" Width="32" Height="32" Offset="0x17098" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_017818" OutName="HIDAN_room_10Tex_017818" Format="ci4" Width="32" Height="64" Offset="0x17898" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_10Tex_017C18" OutName="HIDAN_room_10Tex_017C18" Format="rgba16" Width="32" Height="32" Offset="0x17C98" AddedByScript="true"/>
         <Room Name="HIDAN_room_10" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_11" Segment="3">
+        <Texture Name="HIDAN_room_11Tex_0027D8" OutName="HIDAN_room_11Tex_0027D8" Format="rgba16" Width="32" Height="32" Offset="0x27B8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_11Tex_002FD8" OutName="HIDAN_room_11Tex_002FD8" Format="ci4" Width="32" Height="64" Offset="0x2FB8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_11Tex_0033D8" OutName="HIDAN_room_11Tex_0033D8" Format="ci4" Width="32" Height="64" Offset="0x33B8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
         <Room Name="HIDAN_room_11" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_12" Segment="3">
+        <Texture Name="HIDAN_room_12Tex_001D68" OutName="HIDAN_room_12Tex_001D68" Format="rgba16" Width="32" Height="8" Offset="0x1D78" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_12Tex_001F68" OutName="HIDAN_room_12Tex_001F68" Format="rgba16" Width="32" Height="32" Offset="0x1F78" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_12Tex_002768" OutName="HIDAN_room_12Tex_002768" Format="ci4" Width="32" Height="64" Offset="0x2778" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
         <Room Name="HIDAN_room_12" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_13" Segment="3">
+        <Texture Name="HIDAN_room_13Tex_00A788" OutName="HIDAN_room_13Tex_00A788" Format="rgba16" Width="32" Height="32" Offset="0xA7D8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_13Tex_00AF88" OutName="HIDAN_room_13Tex_00AF88" Format="ci4" Width="64" Height="32" Offset="0xAFD8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_13Tex_00B388" OutName="HIDAN_room_13Tex_00B388" Format="ci4" Width="32" Height="64" Offset="0xB3D8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_13Tex_00B788" OutName="HIDAN_room_13Tex_00B788" Format="ci4" Width="32" Height="64" Offset="0xB7D8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_13Tex_00BB88" OutName="HIDAN_room_13Tex_00BB88" Format="rgba16" Width="32" Height="32" Offset="0xBBD8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_13Tex_00C388" OutName="HIDAN_room_13Tex_00C388" Format="rgba16" Width="32" Height="32" Offset="0xC3D8" AddedByScript="true"/>
         <Room Name="HIDAN_room_13" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_14" Segment="3">
+        <Texture Name="HIDAN_room_14Tex_0019F8" OutName="HIDAN_room_14Tex_0019F8" Format="ci4" Width="32" Height="64" Offset="0x1A58" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_14Tex_001DF8" OutName="HIDAN_room_14Tex_001DF8" Format="ci4" Width="32" Height="64" Offset="0x1E58" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
         <Room Name="HIDAN_room_14" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_15" Segment="3">
+        <Texture Name="HIDAN_room_15Tex_000D88" OutName="HIDAN_room_15Tex_000D88" Format="ci4" Width="32" Height="64" Offset="0xDC8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
         <Room Name="HIDAN_room_15" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_16" Segment="3">
+        <Texture Name="HIDAN_room_16Tex_006DE0" OutName="HIDAN_room_16Tex_006DE0" Format="rgba16" Width="32" Height="8" Offset="0x6D70" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_16Tex_006FE0" OutName="HIDAN_room_16Tex_006FE0" Format="rgba16" Width="32" Height="32" Offset="0x6F70" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_16Tex_0077E0" OutName="HIDAN_room_16Tex_0077E0" Format="rgba16" Width="32" Height="32" Offset="0x7770" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_16Tex_007FE0" OutName="HIDAN_room_16Tex_007FE0" Format="ci4" Width="32" Height="64" Offset="0x7F70" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_16Tex_0083E0" OutName="HIDAN_room_16Tex_0083E0" Format="ci4" Width="32" Height="32" Offset="0x8370" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_16Tex_0085E0" OutName="HIDAN_room_16Tex_0085E0" Format="rgba16" Width="32" Height="32" Offset="0x8570" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_16Tex_008DE0" OutName="HIDAN_room_16Tex_008DE0" Format="ci4" Width="32" Height="64" Offset="0x8D70" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_16Tex_0091E0" OutName="HIDAN_room_16Tex_0091E0" Format="ci4" Width="32" Height="64" Offset="0x9170" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_16Tex_0095E0" OutName="HIDAN_room_16Tex_0095E0" Format="rgba16" Width="16" Height="64" Offset="0x9570" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_16Tex_009DE0" OutName="HIDAN_room_16Tex_009DE0" Format="rgba16" Width="32" Height="32" Offset="0x9D70" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_16Tex_00A5E0" OutName="HIDAN_room_16Tex_00A5E0" Format="ci4" Width="32" Height="64" Offset="0xA570" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_16Tex_00A9E0" OutName="HIDAN_room_16Tex_00A9E0" Format="rgba16" Width="32" Height="32" Offset="0xA970" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_16Tex_00B1E0" OutName="HIDAN_room_16Tex_00B1E0" Format="rgba16" Width="32" Height="32" Offset="0xB170" AddedByScript="true"/>
         <Room Name="HIDAN_room_16" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_17" Segment="3">
+        <Texture Name="HIDAN_room_17Tex_005168" OutName="HIDAN_room_17Tex_005168" Format="rgba16" Width="32" Height="32" Offset="0x5138" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_17Tex_005968" OutName="HIDAN_room_17Tex_005968" Format="rgba16" Width="32" Height="32" Offset="0x5938" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_17Tex_006168" OutName="HIDAN_room_17Tex_006168" Format="rgba16" Width="32" Height="32" Offset="0x6138" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_17Tex_006968" OutName="HIDAN_room_17Tex_006968" Format="rgba16" Width="32" Height="32" Offset="0x6938" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_17Tex_007168" OutName="HIDAN_room_17Tex_007168" Format="rgba16" Width="32" Height="32" Offset="0x7138" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_17Tex_007968" OutName="HIDAN_room_17Tex_007968" Format="rgba16" Width="32" Height="32" Offset="0x7938" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_17Tex_008168" OutName="HIDAN_room_17Tex_008168" Format="rgba16" Width="32" Height="32" Offset="0x8138" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_17Tex_008968" OutName="HIDAN_room_17Tex_008968" Format="rgba16" Width="32" Height="32" Offset="0x8938" AddedByScript="true"/>
         <Room Name="HIDAN_room_17" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_18" Segment="3">
+        <Texture Name="HIDAN_room_18Tex_0027F8" OutName="HIDAN_room_18Tex_0027F8" Format="rgba16" Width="32" Height="32" Offset="0x2778" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_18Tex_002FF8" OutName="HIDAN_room_18Tex_002FF8" Format="ci4" Width="32" Height="64" Offset="0x2F78" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_18Tex_0033F8" OutName="HIDAN_room_18Tex_0033F8" Format="ci4" Width="64" Height="32" Offset="0x3378" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_18Tex_0037F8" OutName="HIDAN_room_18Tex_0037F8" Format="ci4" Width="32" Height="32" Offset="0x3778" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_18Tex_0039F8" OutName="HIDAN_room_18Tex_0039F8" Format="ci4" Width="32" Height="32" Offset="0x3978" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
         <Room Name="HIDAN_room_18" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_19" Segment="3">
+        <Texture Name="HIDAN_room_19Tex_002E28" OutName="HIDAN_room_19Tex_002E28" Format="rgba16" Width="32" Height="32" Offset="0x2DD8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_19Tex_003628" OutName="HIDAN_room_19Tex_003628" Format="ci4" Width="32" Height="64" Offset="0x35D8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_19Tex_003A28" OutName="HIDAN_room_19Tex_003A28" Format="ci4" Width="64" Height="32" Offset="0x39D8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_19Tex_003E28" OutName="HIDAN_room_19Tex_003E28" Format="ci4" Width="32" Height="32" Offset="0x3DD8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_19Tex_004028" OutName="HIDAN_room_19Tex_004028" Format="ci4" Width="32" Height="32" Offset="0x3FD8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
         <Room Name="HIDAN_room_19" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_20" Segment="3">
+        <Texture Name="HIDAN_room_20Tex_002D08" OutName="HIDAN_room_20Tex_002D08" Format="rgba16" Width="32" Height="32" Offset="0x2D08" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_20Tex_003508" OutName="HIDAN_room_20Tex_003508" Format="rgba16" Width="32" Height="32" Offset="0x3508" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_20Tex_003D08" OutName="HIDAN_room_20Tex_003D08" Format="rgba16" Width="32" Height="32" Offset="0x3D08" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_20Tex_004508" OutName="HIDAN_room_20Tex_004508" Format="rgba16" Width="32" Height="32" Offset="0x4508" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_20Tex_004D08" OutName="HIDAN_room_20Tex_004D08" Format="rgba16" Width="32" Height="32" Offset="0x4D08" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_20Tex_005508" OutName="HIDAN_room_20Tex_005508" Format="rgba16" Width="32" Height="32" Offset="0x5508" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_20Tex_005D08" OutName="HIDAN_room_20Tex_005D08" Format="rgba16" Width="32" Height="32" Offset="0x5D08" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_20Tex_006508" OutName="HIDAN_room_20Tex_006508" Format="rgba16" Width="32" Height="32" Offset="0x6508" AddedByScript="true"/>
         <Room Name="HIDAN_room_20" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_21" Segment="3">
+        <Texture Name="HIDAN_room_21Tex_004478" OutName="HIDAN_room_21Tex_004478" Format="rgba16" Width="32" Height="8" Offset="0x44B8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_21Tex_004678" OutName="HIDAN_room_21Tex_004678" Format="rgba16" Width="32" Height="32" Offset="0x46B8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_21Tex_004E78" OutName="HIDAN_room_21Tex_004E78" Format="rgba16" Width="32" Height="32" Offset="0x4EB8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_21Tex_005678" OutName="HIDAN_room_21Tex_005678" Format="rgba16" Width="32" Height="32" Offset="0x56B8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_21Tex_005E78" OutName="HIDAN_room_21Tex_005E78" Format="rgba16" Width="32" Height="32" Offset="0x5EB8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_21Tex_006678" OutName="HIDAN_room_21Tex_006678" Format="ci4" Width="64" Height="32" Offset="0x66B8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_21Tex_006A78" OutName="HIDAN_room_21Tex_006A78" Format="rgba16" Width="32" Height="32" Offset="0x6AB8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_21Tex_007278" OutName="HIDAN_room_21Tex_007278" Format="ci4" Width="32" Height="32" Offset="0x72B8" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_21Tex_007478" OutName="HIDAN_room_21Tex_007478" Format="rgba16" Width="32" Height="32" Offset="0x74B8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_21Tex_007C78" OutName="HIDAN_room_21Tex_007C78" Format="rgba16" Width="32" Height="32" Offset="0x7CB8" AddedByScript="true"/>
         <Room Name="HIDAN_room_21" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_22" Segment="3">
+        <Texture Name="HIDAN_room_22Tex_002AE8" OutName="HIDAN_room_22Tex_002AE8" Format="rgba16" Width="32" Height="32" Offset="0x2AF8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_22Tex_0032E8" OutName="HIDAN_room_22Tex_0032E8" Format="rgba16" Width="32" Height="32" Offset="0x32F8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_22Tex_003AE8" OutName="HIDAN_room_22Tex_003AE8" Format="rgba16" Width="32" Height="32" Offset="0x3AF8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_22Tex_0042E8" OutName="HIDAN_room_22Tex_0042E8" Format="rgba16" Width="32" Height="32" Offset="0x42F8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_22Tex_004AE8" OutName="HIDAN_room_22Tex_004AE8" Format="rgba16" Width="32" Height="32" Offset="0x4AF8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_22Tex_0052E8" OutName="HIDAN_room_22Tex_0052E8" Format="rgba16" Width="32" Height="32" Offset="0x52F8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_22Tex_005AE8" OutName="HIDAN_room_22Tex_005AE8" Format="rgba16" Width="32" Height="32" Offset="0x5AF8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_22Tex_0062E8" OutName="HIDAN_room_22Tex_0062E8" Format="rgba16" Width="32" Height="32" Offset="0x62F8" AddedByScript="true"/>
         <Room Name="HIDAN_room_22" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_23" Segment="3">
+        <Texture Name="HIDAN_room_23Tex_002D18" OutName="HIDAN_room_23Tex_002D18" Format="rgba16" Width="32" Height="32" Offset="0x2D18" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_23Tex_003518" OutName="HIDAN_room_23Tex_003518" Format="rgba16" Width="32" Height="32" Offset="0x3518" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_23Tex_003D18" OutName="HIDAN_room_23Tex_003D18" Format="rgba16" Width="32" Height="32" Offset="0x3D18" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_23Tex_004518" OutName="HIDAN_room_23Tex_004518" Format="rgba16" Width="32" Height="32" Offset="0x4518" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_23Tex_004D18" OutName="HIDAN_room_23Tex_004D18" Format="rgba16" Width="32" Height="32" Offset="0x4D18" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_23Tex_005518" OutName="HIDAN_room_23Tex_005518" Format="rgba16" Width="32" Height="32" Offset="0x5518" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_23Tex_005D18" OutName="HIDAN_room_23Tex_005D18" Format="rgba16" Width="32" Height="32" Offset="0x5D18" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_23Tex_006518" OutName="HIDAN_room_23Tex_006518" Format="rgba16" Width="32" Height="32" Offset="0x6518" AddedByScript="true"/>
         <Room Name="HIDAN_room_23" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_24" Segment="3">
+        <Texture Name="HIDAN_room_24Tex_003B38" OutName="HIDAN_room_24Tex_003B38" Format="ci4" Width="32" Height="64" Offset="0x3B38" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_24Tex_003F38" OutName="HIDAN_room_24Tex_003F38" Format="ci4" Width="64" Height="32" Offset="0x3F38" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_24Tex_004338" OutName="HIDAN_room_24Tex_004338" Format="ci4" Width="64" Height="32" Offset="0x4338" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_24Tex_004738" OutName="HIDAN_room_24Tex_004738" Format="ci4" Width="32" Height="32" Offset="0x4738" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_24Tex_004938" OutName="HIDAN_room_24Tex_004938" Format="ci4" Width="32" Height="64" Offset="0x4938" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B50" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_24Tex_004D38" OutName="HIDAN_room_24Tex_004D38" Format="rgba16" Width="32" Height="32" Offset="0x4D38" AddedByScript="true"/>
         <Room Name="HIDAN_room_24" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_25" Segment="3">
+        <Texture Name="HIDAN_room_25Tex_002AD8" OutName="HIDAN_room_25Tex_002AD8" Format="rgba16" Width="32" Height="32" Offset="0x2AD8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_25Tex_0032D8" OutName="HIDAN_room_25Tex_0032D8" Format="rgba16" Width="32" Height="32" Offset="0x32D8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_25Tex_003AD8" OutName="HIDAN_room_25Tex_003AD8" Format="rgba16" Width="32" Height="32" Offset="0x3AD8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_25Tex_0042D8" OutName="HIDAN_room_25Tex_0042D8" Format="rgba16" Width="32" Height="32" Offset="0x42D8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_25Tex_004AD8" OutName="HIDAN_room_25Tex_004AD8" Format="rgba16" Width="32" Height="32" Offset="0x4AD8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_25Tex_0052D8" OutName="HIDAN_room_25Tex_0052D8" Format="rgba16" Width="32" Height="32" Offset="0x52D8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_25Tex_005AD8" OutName="HIDAN_room_25Tex_005AD8" Format="rgba16" Width="32" Height="32" Offset="0x5AD8" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_25Tex_0062D8" OutName="HIDAN_room_25Tex_0062D8" Format="rgba16" Width="32" Height="32" Offset="0x62D8" AddedByScript="true"/>
         <Room Name="HIDAN_room_25" Offset="0x0"/>
     </File>
     <File Name="HIDAN_room_26" Segment="3">
+        <Texture Name="HIDAN_room_26Tex_004A98" OutName="HIDAN_room_26Tex_004A98" Format="rgba16" Width="32" Height="32" Offset="0x4A98" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_26Tex_005298" OutName="HIDAN_room_26Tex_005298" Format="ci4" Width="64" Height="32" Offset="0x5298" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_26Tex_005698" OutName="HIDAN_room_26Tex_005698" Format="ci4" Width="32" Height="32" Offset="0x5698" ExternalTlut="HIDAN_scene" ExternalTlutOffset="0x18B30" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_26Tex_005898" OutName="HIDAN_room_26Tex_005898" Format="rgba16" Width="32" Height="32" Offset="0x5898" AddedByScript="true"/>
+        <Texture Name="HIDAN_room_26Tex_006098" OutName="HIDAN_room_26Tex_006098" Format="rgba16" Width="32" Height="32" Offset="0x6098" AddedByScript="true"/>
         <Room Name="HIDAN_room_26" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/N64_PAL_11/scenes/dungeons/MIZUsin.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/dungeons/MIZUsin.xml
@@ -1,77 +1,262 @@
 <Root>
     <File Name="MIZUsin_scene" Segment="2">
+        <Texture Name="MIZUsin_sceneTex_013C30" OutName="MIZUsin_sceneTex_013C30" Format="rgba16" Width="32" Height="32" Offset="0x13CF0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_sceneTex_014430" OutName="MIZUsin_sceneTex_014430" Format="rgba16" Width="32" Height="32" Offset="0x144F0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_sceneTex_015030" OutName="MIZUsin_sceneTex_015030" Format="rgba16" Width="32" Height="32" Offset="0x150F0" AddedByScript="true"/>
         <Path Name="gWaterTemplePath_00424" Offset="0x424" NumPaths="7"/>
         <Texture Name="gWaterTempleDayEntranceTex" OutName="day_entrance" Format="ia16" Width="8" Height="64" Offset="0x14CF0"/>
         <Texture Name="gWaterTempleNightEntranceTex" OutName="night_entrance" Format="ia16" Width="8" Height="64" Offset="0x158F0"/>
         <Scene Name="MIZUsin_scene" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_0" Segment="3">
+        <Texture Name="MIZUsin_room_0Tex_00CDF8" OutName="MIZUsin_room_0Tex_00CDF8" Format="i4" Width="64" Height="64" Offset="0xCE48" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_00D5F8" OutName="MIZUsin_room_0Tex_00D5F8" Format="i4" Width="64" Height="64" Offset="0xD648" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_00DDF8" OutName="MIZUsin_room_0Tex_00DDF8" Format="rgba16" Width="32" Height="32" Offset="0xDE48" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_00E5F8" OutName="MIZUsin_room_0Tex_00E5F8" Format="rgba16" Width="32" Height="32" Offset="0xE648" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_00EDF8" OutName="MIZUsin_room_0Tex_00EDF8" Format="rgba16" Width="32" Height="32" Offset="0xEE48" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_00F5F8" OutName="MIZUsin_room_0Tex_00F5F8" Format="rgba16" Width="32" Height="32" Offset="0xF648" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_00FDF8" OutName="MIZUsin_room_0Tex_00FDF8" Format="rgba16" Width="32" Height="32" Offset="0xFE48" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_0105F8" OutName="MIZUsin_room_0Tex_0105F8" Format="rgba16" Width="32" Height="32" Offset="0x10648" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_010DF8" OutName="MIZUsin_room_0Tex_010DF8" Format="rgba16" Width="32" Height="32" Offset="0x10E48" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_0115F8" OutName="MIZUsin_room_0Tex_0115F8" Format="rgba16" Width="32" Height="32" Offset="0x11648" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_011DF8" OutName="MIZUsin_room_0Tex_011DF8" Format="rgba16" Width="32" Height="32" Offset="0x11E48" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_0125F8" OutName="MIZUsin_room_0Tex_0125F8" Format="rgba16" Width="32" Height="32" Offset="0x12648" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_012DF8" OutName="MIZUsin_room_0Tex_012DF8" Format="rgba16" Width="32" Height="32" Offset="0x12E48" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_0135F8" OutName="MIZUsin_room_0Tex_0135F8" Format="rgba16" Width="32" Height="32" Offset="0x13648" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_013DF8" OutName="MIZUsin_room_0Tex_013DF8" Format="rgba16" Width="32" Height="32" Offset="0x13E48" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_0145F8" OutName="MIZUsin_room_0Tex_0145F8" Format="rgba16" Width="32" Height="32" Offset="0x14648" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_0Tex_015428" OutName="MIZUsin_room_0Tex_015428" Format="ia16" Width="32" Height="32" Offset="0x15478" AddedByScript="true"/>
         <Room Name="MIZUsin_room_0" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_1" Segment="3">
+        <Texture Name="MIZUsin_room_1Tex_0059D0" OutName="MIZUsin_room_1Tex_0059D0" Format="i4" Width="64" Height="64" Offset="0x5960" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_1Tex_0061D0" OutName="MIZUsin_room_1Tex_0061D0" Format="i4" Width="64" Height="64" Offset="0x6160" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_1Tex_0069D0" OutName="MIZUsin_room_1Tex_0069D0" Format="rgba16" Width="32" Height="32" Offset="0x6960" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_1Tex_0071D0" OutName="MIZUsin_room_1Tex_0071D0" Format="rgba16" Width="32" Height="32" Offset="0x7160" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_1Tex_0079D0" OutName="MIZUsin_room_1Tex_0079D0" Format="rgba16" Width="32" Height="32" Offset="0x7960" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_1Tex_0081D0" OutName="MIZUsin_room_1Tex_0081D0" Format="rgba16" Width="32" Height="32" Offset="0x8160" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_1Tex_0089D0" OutName="MIZUsin_room_1Tex_0089D0" Format="rgba16" Width="32" Height="32" Offset="0x8960" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_1Tex_0091D0" OutName="MIZUsin_room_1Tex_0091D0" Format="rgba16" Width="32" Height="32" Offset="0x9160" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_1Tex_0099D0" OutName="MIZUsin_room_1Tex_0099D0" Format="rgba16" Width="32" Height="32" Offset="0x9960" AddedByScript="true"/>
         <Room Name="MIZUsin_room_1" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_2" Segment="3">
+        <Texture Name="MIZUsin_room_2Tex_002AB8" OutName="MIZUsin_room_2Tex_002AB8" Format="rgba16" Width="32" Height="32" Offset="0x29B8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_2Tex_0032B8" OutName="MIZUsin_room_2Tex_0032B8" Format="rgba16" Width="32" Height="32" Offset="0x31B8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_2Tex_003AB8" OutName="MIZUsin_room_2Tex_003AB8" Format="rgba16" Width="32" Height="32" Offset="0x39B8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_2Tex_0042B8" OutName="MIZUsin_room_2Tex_0042B8" Format="rgba16" Width="32" Height="32" Offset="0x41B8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_2Tex_004AB8" OutName="MIZUsin_room_2Tex_004AB8" Format="rgba16" Width="32" Height="32" Offset="0x49B8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_2Tex_005488" OutName="MIZUsin_room_2Tex_005488" Format="ia16" Width="32" Height="32" Offset="0x5388" AddedByScript="true"/>
         <Room Name="MIZUsin_room_2" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_3" Segment="3">
+        <Texture Name="MIZUsin_room_3Tex_0037B8" OutName="MIZUsin_room_3Tex_0037B8" Format="rgba16" Width="32" Height="32" Offset="0x3708" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_3Tex_003FB8" OutName="MIZUsin_room_3Tex_003FB8" Format="rgba16" Width="32" Height="32" Offset="0x3F08" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_3Tex_0047B8" OutName="MIZUsin_room_3Tex_0047B8" Format="rgba16" Width="32" Height="32" Offset="0x4708" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_3Tex_004FB8" OutName="MIZUsin_room_3Tex_004FB8" Format="rgba16" Width="32" Height="32" Offset="0x4F08" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_3Tex_0057B8" OutName="MIZUsin_room_3Tex_0057B8" Format="rgba16" Width="32" Height="32" Offset="0x5708" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_3Tex_005FB8" OutName="MIZUsin_room_3Tex_005FB8" Format="rgba16" Width="32" Height="32" Offset="0x5F08" AddedByScript="true"/>
         <Room Name="MIZUsin_room_3" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_4" Segment="3">
+        <Texture Name="MIZUsin_room_4Tex_002820" OutName="MIZUsin_room_4Tex_002820" Format="i4" Width="64" Height="64" Offset="0x27E0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_4Tex_003020" OutName="MIZUsin_room_4Tex_003020" Format="rgba16" Width="32" Height="32" Offset="0x2FE0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_4Tex_003820" OutName="MIZUsin_room_4Tex_003820" Format="rgba16" Width="32" Height="32" Offset="0x37E0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_4Tex_004020" OutName="MIZUsin_room_4Tex_004020" Format="rgba16" Width="32" Height="32" Offset="0x3FE0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_4Tex_004820" OutName="MIZUsin_room_4Tex_004820" Format="rgba16" Width="32" Height="32" Offset="0x47E0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_4Tex_005020" OutName="MIZUsin_room_4Tex_005020" Format="rgba16" Width="32" Height="32" Offset="0x4FE0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_4Tex_005820" OutName="MIZUsin_room_4Tex_005820" Format="rgba16" Width="32" Height="32" Offset="0x57E0" AddedByScript="true"/>
         <Room Name="MIZUsin_room_4" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_5" Segment="3">
+        <Texture Name="MIZUsin_room_5Tex_003A48" OutName="MIZUsin_room_5Tex_003A48" Format="rgba16" Width="32" Height="32" Offset="0x39F8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_5Tex_004248" OutName="MIZUsin_room_5Tex_004248" Format="rgba16" Width="32" Height="32" Offset="0x41F8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_5Tex_004A48" OutName="MIZUsin_room_5Tex_004A48" Format="rgba16" Width="32" Height="32" Offset="0x49F8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_5Tex_005248" OutName="MIZUsin_room_5Tex_005248" Format="rgba16" Width="32" Height="32" Offset="0x51F8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_5Tex_005A48" OutName="MIZUsin_room_5Tex_005A48" Format="rgba16" Width="32" Height="32" Offset="0x59F8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_5Tex_006248" OutName="MIZUsin_room_5Tex_006248" Format="rgba16" Width="32" Height="32" Offset="0x61F8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_5Tex_006A48" OutName="MIZUsin_room_5Tex_006A48" Format="rgba16" Width="32" Height="32" Offset="0x69F8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_5Tex_007248" OutName="MIZUsin_room_5Tex_007248" Format="rgba16" Width="32" Height="32" Offset="0x71F8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_5Tex_007A48" OutName="MIZUsin_room_5Tex_007A48" Format="rgba16" Width="32" Height="32" Offset="0x79F8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_5Tex_008248" OutName="MIZUsin_room_5Tex_008248" Format="rgba16" Width="32" Height="32" Offset="0x81F8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_5Tex_008A48" OutName="MIZUsin_room_5Tex_008A48" Format="rgba16" Width="32" Height="32" Offset="0x89F8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_5Tex_009248" OutName="MIZUsin_room_5Tex_009248" Format="rgba16" Width="32" Height="32" Offset="0x91F8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_5Tex_009E38" OutName="MIZUsin_room_5Tex_009E38" Format="ia16" Width="32" Height="32" Offset="0x9DE8" AddedByScript="true"/>
         <Room Name="MIZUsin_room_5" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_6" Segment="3">
+        <Texture Name="MIZUsin_room_6Tex_005100" OutName="MIZUsin_room_6Tex_005100" Format="i4" Width="32" Height="32" Offset="0x50C0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_005300" OutName="MIZUsin_room_6Tex_005300" Format="rgba16" Width="32" Height="32" Offset="0x52C0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_005B00" OutName="MIZUsin_room_6Tex_005B00" Format="rgba16" Width="32" Height="32" Offset="0x5AC0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_006300" OutName="MIZUsin_room_6Tex_006300" Format="i4" Width="32" Height="32" Offset="0x62C0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_006500" OutName="MIZUsin_room_6Tex_006500" Format="i4" Width="32" Height="32" Offset="0x64C0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_006700" OutName="MIZUsin_room_6Tex_006700" Format="i4" Width="32" Height="32" Offset="0x66C0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_006900" OutName="MIZUsin_room_6Tex_006900" Format="i4" Width="32" Height="32" Offset="0x68C0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_006B00" OutName="MIZUsin_room_6Tex_006B00" Format="i4" Width="64" Height="64" Offset="0x6AC0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_007300" OutName="MIZUsin_room_6Tex_007300" Format="rgba16" Width="32" Height="32" Offset="0x72C0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_007B00" OutName="MIZUsin_room_6Tex_007B00" Format="rgba16" Width="32" Height="32" Offset="0x7AC0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_008300" OutName="MIZUsin_room_6Tex_008300" Format="rgba16" Width="32" Height="32" Offset="0x82C0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_008B00" OutName="MIZUsin_room_6Tex_008B00" Format="rgba16" Width="32" Height="32" Offset="0x8AC0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_009300" OutName="MIZUsin_room_6Tex_009300" Format="rgba16" Width="32" Height="32" Offset="0x92C0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_009B00" OutName="MIZUsin_room_6Tex_009B00" Format="rgba16" Width="32" Height="32" Offset="0x9AC0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_00A300" OutName="MIZUsin_room_6Tex_00A300" Format="rgba16" Width="32" Height="32" Offset="0xA2C0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_6Tex_00AB00" OutName="MIZUsin_room_6Tex_00AB00" Format="rgba16" Width="32" Height="32" Offset="0xAAC0" AddedByScript="true"/>
         <Room Name="MIZUsin_room_6" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_7" Segment="3">
+        <Texture Name="MIZUsin_room_7Tex_002560" OutName="MIZUsin_room_7Tex_002560" Format="rgba16" Width="32" Height="32" Offset="0x2550" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_7Tex_002D60" OutName="MIZUsin_room_7Tex_002D60" Format="rgba16" Width="32" Height="32" Offset="0x2D50" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_7Tex_003560" OutName="MIZUsin_room_7Tex_003560" Format="rgba16" Width="32" Height="32" Offset="0x3550" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_7Tex_003D60" OutName="MIZUsin_room_7Tex_003D60" Format="rgba16" Width="32" Height="32" Offset="0x3D50" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_7Tex_004560" OutName="MIZUsin_room_7Tex_004560" Format="rgba16" Width="32" Height="32" Offset="0x4550" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_7Tex_004D60" OutName="MIZUsin_room_7Tex_004D60" Format="rgba16" Width="32" Height="32" Offset="0x4D50" AddedByScript="true"/>
         <Room Name="MIZUsin_room_7" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_8" Segment="3">
+        <Texture Name="MIZUsin_room_8Tex_005D98" OutName="MIZUsin_room_8Tex_005D98" Format="i4" Width="32" Height="32" Offset="0x5CE8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_005F98" OutName="MIZUsin_room_8Tex_005F98" Format="i4" Width="32" Height="32" Offset="0x5EE8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_006198" OutName="MIZUsin_room_8Tex_006198" Format="rgba16" Width="32" Height="32" Offset="0x60E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_006998" OutName="MIZUsin_room_8Tex_006998" Format="rgba16" Width="32" Height="32" Offset="0x68E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_007198" OutName="MIZUsin_room_8Tex_007198" Format="i4" Width="32" Height="32" Offset="0x70E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_007398" OutName="MIZUsin_room_8Tex_007398" Format="i4" Width="32" Height="32" Offset="0x72E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_007598" OutName="MIZUsin_room_8Tex_007598" Format="rgba16" Width="32" Height="32" Offset="0x74E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_007D98" OutName="MIZUsin_room_8Tex_007D98" Format="i4" Width="64" Height="64" Offset="0x7CE8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_008598" OutName="MIZUsin_room_8Tex_008598" Format="rgba16" Width="32" Height="32" Offset="0x84E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_008D98" OutName="MIZUsin_room_8Tex_008D98" Format="rgba16" Width="32" Height="32" Offset="0x8CE8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_009598" OutName="MIZUsin_room_8Tex_009598" Format="rgba16" Width="32" Height="32" Offset="0x94E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_009D98" OutName="MIZUsin_room_8Tex_009D98" Format="rgba16" Width="32" Height="32" Offset="0x9CE8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_00A598" OutName="MIZUsin_room_8Tex_00A598" Format="rgba16" Width="32" Height="32" Offset="0xA4E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_00AD98" OutName="MIZUsin_room_8Tex_00AD98" Format="rgba16" Width="32" Height="32" Offset="0xACE8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_00B598" OutName="MIZUsin_room_8Tex_00B598" Format="rgba16" Width="32" Height="32" Offset="0xB4E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_00BD98" OutName="MIZUsin_room_8Tex_00BD98" Format="rgba16" Width="32" Height="32" Offset="0xBCE8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_00C598" OutName="MIZUsin_room_8Tex_00C598" Format="rgba16" Width="32" Height="32" Offset="0xC4E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_8Tex_00D578" OutName="MIZUsin_room_8Tex_00D578" Format="ia16" Width="32" Height="32" Offset="0xD4C8" AddedByScript="true"/>
         <Room Name="MIZUsin_room_8" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_9" Segment="3">
+        <Texture Name="MIZUsin_room_9Tex_0036D8" OutName="MIZUsin_room_9Tex_0036D8" Format="i4" Width="64" Height="64" Offset="0x3608" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_9Tex_003ED8" OutName="MIZUsin_room_9Tex_003ED8" Format="rgba16" Width="32" Height="32" Offset="0x3E08" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_9Tex_0046D8" OutName="MIZUsin_room_9Tex_0046D8" Format="rgba16" Width="32" Height="32" Offset="0x4608" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_9Tex_004ED8" OutName="MIZUsin_room_9Tex_004ED8" Format="rgba16" Width="32" Height="32" Offset="0x4E08" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_9Tex_0056D8" OutName="MIZUsin_room_9Tex_0056D8" Format="rgba16" Width="32" Height="32" Offset="0x5608" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_9Tex_005ED8" OutName="MIZUsin_room_9Tex_005ED8" Format="rgba16" Width="32" Height="32" Offset="0x5E08" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_9Tex_0066D8" OutName="MIZUsin_room_9Tex_0066D8" Format="rgba16" Width="32" Height="32" Offset="0x6608" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_9Tex_006ED8" OutName="MIZUsin_room_9Tex_006ED8" Format="rgba16" Width="32" Height="32" Offset="0x6E08" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_9Tex_0078A8" OutName="MIZUsin_room_9Tex_0078A8" Format="ia16" Width="32" Height="32" Offset="0x77D8" AddedByScript="true"/>
         <Room Name="MIZUsin_room_9" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_10" Segment="3">
+        <Texture Name="MIZUsin_room_10Tex_003870" OutName="MIZUsin_room_10Tex_003870" Format="rgba16" Width="32" Height="32" Offset="0x37B0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_10Tex_004070" OutName="MIZUsin_room_10Tex_004070" Format="rgba16" Width="32" Height="32" Offset="0x3FB0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_10Tex_004870" OutName="MIZUsin_room_10Tex_004870" Format="rgba16" Width="32" Height="32" Offset="0x47B0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_10Tex_005070" OutName="MIZUsin_room_10Tex_005070" Format="rgba16" Width="32" Height="32" Offset="0x4FB0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_10Tex_005870" OutName="MIZUsin_room_10Tex_005870" Format="rgba16" Width="32" Height="32" Offset="0x57B0" AddedByScript="true"/>
         <Room Name="MIZUsin_room_10" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_11" Segment="3">
+        <Texture Name="MIZUsin_room_11Tex_002220" OutName="MIZUsin_room_11Tex_002220" Format="rgba16" Width="32" Height="32" Offset="0x21B0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_11Tex_002A20" OutName="MIZUsin_room_11Tex_002A20" Format="rgba16" Width="32" Height="32" Offset="0x29B0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_11Tex_003220" OutName="MIZUsin_room_11Tex_003220" Format="rgba16" Width="32" Height="32" Offset="0x31B0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_11Tex_003A20" OutName="MIZUsin_room_11Tex_003A20" Format="rgba16" Width="32" Height="32" Offset="0x39B0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_11Tex_004220" OutName="MIZUsin_room_11Tex_004220" Format="rgba16" Width="32" Height="32" Offset="0x41B0" AddedByScript="true"/>
         <Room Name="MIZUsin_room_11" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_12" Segment="3">
+        <Texture Name="MIZUsin_room_12Tex_0039C8" OutName="MIZUsin_room_12Tex_0039C8" Format="rgba16" Width="32" Height="32" Offset="0x3928" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_12Tex_0041C8" OutName="MIZUsin_room_12Tex_0041C8" Format="rgba16" Width="32" Height="32" Offset="0x4128" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_12Tex_0049C8" OutName="MIZUsin_room_12Tex_0049C8" Format="rgba16" Width="32" Height="32" Offset="0x4928" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_12Tex_0051C8" OutName="MIZUsin_room_12Tex_0051C8" Format="rgba16" Width="32" Height="32" Offset="0x5128" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_12Tex_006628" OutName="MIZUsin_room_12Tex_006628" Format="ia16" Width="32" Height="32" Offset="0x6588" AddedByScript="true"/>
         <Room Name="MIZUsin_room_12" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_13" Segment="3">
+        <Texture Name="MIZUsin_room_13Tex_0001F8" OutName="MIZUsin_room_13Tex_0001F8" Format="rgba16" Width="32" Height="32" Offset="0x1F8" AddedByScript="true"/>
         <Room Name="MIZUsin_room_13" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_14" Segment="3">
+        <Texture Name="MIZUsin_room_14Tex_003680" OutName="MIZUsin_room_14Tex_003680" Format="i4" Width="64" Height="64" Offset="0x3660" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_14Tex_003E80" OutName="MIZUsin_room_14Tex_003E80" Format="rgba16" Width="32" Height="32" Offset="0x3E60" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_14Tex_004680" OutName="MIZUsin_room_14Tex_004680" Format="rgba16" Width="32" Height="32" Offset="0x4660" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_14Tex_004E80" OutName="MIZUsin_room_14Tex_004E80" Format="rgba16" Width="32" Height="32" Offset="0x4E60" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_14Tex_005680" OutName="MIZUsin_room_14Tex_005680" Format="rgba16" Width="32" Height="32" Offset="0x5660" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_14Tex_005E80" OutName="MIZUsin_room_14Tex_005E80" Format="rgba16" Width="32" Height="32" Offset="0x5E60" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_14Tex_006680" OutName="MIZUsin_room_14Tex_006680" Format="rgba16" Width="32" Height="32" Offset="0x6660" AddedByScript="true"/>
         <Room Name="MIZUsin_room_14" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_15" Segment="3">
+        <Texture Name="MIZUsin_room_15Tex_002C68" OutName="MIZUsin_room_15Tex_002C68" Format="i4" Width="64" Height="64" Offset="0x2C28" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_15Tex_003468" OutName="MIZUsin_room_15Tex_003468" Format="rgba16" Width="32" Height="32" Offset="0x3428" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_15Tex_003C68" OutName="MIZUsin_room_15Tex_003C68" Format="rgba16" Width="32" Height="32" Offset="0x3C28" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_15Tex_004468" OutName="MIZUsin_room_15Tex_004468" Format="rgba16" Width="32" Height="32" Offset="0x4428" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_15Tex_004C68" OutName="MIZUsin_room_15Tex_004C68" Format="rgba16" Width="32" Height="32" Offset="0x4C28" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_15Tex_005468" OutName="MIZUsin_room_15Tex_005468" Format="rgba16" Width="32" Height="32" Offset="0x5428" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_15Tex_005C68" OutName="MIZUsin_room_15Tex_005C68" Format="rgba16" Width="32" Height="32" Offset="0x5C28" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_15Tex_006468" OutName="MIZUsin_room_15Tex_006468" Format="rgba16" Width="32" Height="32" Offset="0x6428" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_15Tex_006C68" OutName="MIZUsin_room_15Tex_006C68" Format="rgba16" Width="32" Height="32" Offset="0x6C28" AddedByScript="true"/>
         <Room Name="MIZUsin_room_15" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_16" Segment="3">
+        <Texture Name="MIZUsin_room_16Tex_001330" OutName="MIZUsin_room_16Tex_001330" Format="rgba16" Width="32" Height="32" Offset="0x12D0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_16Tex_001B30" OutName="MIZUsin_room_16Tex_001B30" Format="rgba16" Width="32" Height="32" Offset="0x1AD0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_16Tex_002330" OutName="MIZUsin_room_16Tex_002330" Format="rgba16" Width="32" Height="32" Offset="0x22D0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_16Tex_002B30" OutName="MIZUsin_room_16Tex_002B30" Format="rgba16" Width="32" Height="32" Offset="0x2AD0" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_16Tex_003330" OutName="MIZUsin_room_16Tex_003330" Format="rgba16" Width="32" Height="32" Offset="0x32D0" AddedByScript="true"/>
         <Room Name="MIZUsin_room_16" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_17" Segment="3">
+        <Texture Name="MIZUsin_room_17Tex_005AA8" OutName="MIZUsin_room_17Tex_005AA8" Format="rgba16" Width="32" Height="32" Offset="0x5A18" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_17Tex_0062A8" OutName="MIZUsin_room_17Tex_0062A8" Format="i4" Width="64" Height="64" Offset="0x6218" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_17Tex_006AA8" OutName="MIZUsin_room_17Tex_006AA8" Format="rgba16" Width="32" Height="32" Offset="0x6A18" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_17Tex_0072A8" OutName="MIZUsin_room_17Tex_0072A8" Format="rgba16" Width="32" Height="32" Offset="0x7218" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_17Tex_007AA8" OutName="MIZUsin_room_17Tex_007AA8" Format="rgba16" Width="32" Height="32" Offset="0x7A18" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_17Tex_0082A8" OutName="MIZUsin_room_17Tex_0082A8" Format="rgba16" Width="32" Height="32" Offset="0x8218" AddedByScript="true"/>
         <Room Name="MIZUsin_room_17" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_18" Segment="3">
+        <Texture Name="MIZUsin_room_18Tex_0018F8" OutName="MIZUsin_room_18Tex_0018F8" Format="rgba16" Width="32" Height="32" Offset="0x18B8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_18Tex_0020F8" OutName="MIZUsin_room_18Tex_0020F8" Format="rgba16" Width="32" Height="32" Offset="0x20B8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_18Tex_0028F8" OutName="MIZUsin_room_18Tex_0028F8" Format="rgba16" Width="32" Height="32" Offset="0x28B8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_18Tex_0030F8" OutName="MIZUsin_room_18Tex_0030F8" Format="rgba16" Width="32" Height="32" Offset="0x30B8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_18Tex_0038F8" OutName="MIZUsin_room_18Tex_0038F8" Format="rgba16" Width="32" Height="32" Offset="0x38B8" AddedByScript="true"/>
         <Room Name="MIZUsin_room_18" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_19" Segment="3">
+        <Texture Name="MIZUsin_room_19Tex_001130" OutName="MIZUsin_room_19Tex_001130" Format="rgba16" Width="32" Height="32" Offset="0x1130" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_19Tex_001930" OutName="MIZUsin_room_19Tex_001930" Format="rgba16" Width="32" Height="32" Offset="0x1930" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_19Tex_002130" OutName="MIZUsin_room_19Tex_002130" Format="rgba16" Width="32" Height="32" Offset="0x2130" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_19Tex_002930" OutName="MIZUsin_room_19Tex_002930" Format="rgba16" Width="32" Height="32" Offset="0x2930" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_19Tex_003130" OutName="MIZUsin_room_19Tex_003130" Format="rgba16" Width="32" Height="32" Offset="0x3130" AddedByScript="true"/>
         <Room Name="MIZUsin_room_19" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_20" Segment="3">
+        <Texture Name="MIZUsin_room_20Tex_003040" OutName="MIZUsin_room_20Tex_003040" Format="rgba16" Width="32" Height="32" Offset="0x2F40" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_20Tex_003840" OutName="MIZUsin_room_20Tex_003840" Format="i4" Width="64" Height="64" Offset="0x3740" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_20Tex_004040" OutName="MIZUsin_room_20Tex_004040" Format="rgba16" Width="32" Height="32" Offset="0x3F40" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_20Tex_004840" OutName="MIZUsin_room_20Tex_004840" Format="rgba16" Width="32" Height="32" Offset="0x4740" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_20Tex_005040" OutName="MIZUsin_room_20Tex_005040" Format="rgba16" Width="32" Height="32" Offset="0x4F40" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_20Tex_005840" OutName="MIZUsin_room_20Tex_005840" Format="rgba16" Width="32" Height="32" Offset="0x5740" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_20Tex_006040" OutName="MIZUsin_room_20Tex_006040" Format="rgba16" Width="32" Height="32" Offset="0x5F40" AddedByScript="true"/>
         <Room Name="MIZUsin_room_20" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_21" Segment="3">
+        <Texture Name="MIZUsin_room_21Tex_004360" OutName="MIZUsin_room_21Tex_004360" Format="rgba16" Width="32" Height="32" Offset="0x4360" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_21Tex_004B60" OutName="MIZUsin_room_21Tex_004B60" Format="rgba16" Width="32" Height="32" Offset="0x4B60" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_21Tex_005360" OutName="MIZUsin_room_21Tex_005360" Format="rgba16" Width="32" Height="32" Offset="0x5360" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_21Tex_005B60" OutName="MIZUsin_room_21Tex_005B60" Format="rgba16" Width="32" Height="32" Offset="0x5B60" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_21Tex_006CA0" OutName="MIZUsin_room_21Tex_006CA0" Format="ia16" Width="32" Height="32" Offset="0x6CA0" AddedByScript="true"/>
         <Room Name="MIZUsin_room_21" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_room_22" Segment="3">
+        <Texture Name="MIZUsin_room_22Tex_0044E8" OutName="MIZUsin_room_22Tex_0044E8" Format="rgba16" Width="32" Height="16" Offset="0x44E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_22Tex_0048E8" OutName="MIZUsin_room_22Tex_0048E8" Format="rgba16" Width="32" Height="32" Offset="0x48E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_22Tex_0050E8" OutName="MIZUsin_room_22Tex_0050E8" Format="rgba16" Width="32" Height="32" Offset="0x50E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_22Tex_0058E8" OutName="MIZUsin_room_22Tex_0058E8" Format="rgba16" Width="32" Height="32" Offset="0x58E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_22Tex_0060E8" OutName="MIZUsin_room_22Tex_0060E8" Format="rgba16" Width="32" Height="32" Offset="0x60E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_22Tex_0068E8" OutName="MIZUsin_room_22Tex_0068E8" Format="rgba16" Width="32" Height="32" Offset="0x68E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_22Tex_0070E8" OutName="MIZUsin_room_22Tex_0070E8" Format="rgba16" Width="32" Height="32" Offset="0x70E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_22Tex_0078E8" OutName="MIZUsin_room_22Tex_0078E8" Format="rgba16" Width="32" Height="32" Offset="0x78E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_22Tex_0080E8" OutName="MIZUsin_room_22Tex_0080E8" Format="rgba16" Width="32" Height="32" Offset="0x80E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_room_22Tex_0088E8" OutName="MIZUsin_room_22Tex_0088E8" Format="rgba16" Width="32" Height="32" Offset="0x88E8" AddedByScript="true"/>
         <Room Name="MIZUsin_room_22" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/N64_PAL_11/scenes/dungeons/MIZUsin_bs.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/dungeons/MIZUsin_bs.xml
@@ -3,9 +3,27 @@
         <Scene Name="MIZUsin_bs_scene" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_bs_room_0" Segment="3">
+        <Texture Name="MIZUsin_bs_room_0Tex_001470" OutName="MIZUsin_bs_room_0Tex_001470" Format="rgba16" Width="32" Height="32" Offset="0x1470" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_0Tex_001C70" OutName="MIZUsin_bs_room_0Tex_001C70" Format="rgba16" Width="32" Height="32" Offset="0x1C70" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_0Tex_002470" OutName="MIZUsin_bs_room_0Tex_002470" Format="rgba16" Width="32" Height="32" Offset="0x2470" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_0Tex_002C70" OutName="MIZUsin_bs_room_0Tex_002C70" Format="rgba16" Width="32" Height="32" Offset="0x2C70" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_0Tex_003470" OutName="MIZUsin_bs_room_0Tex_003470" Format="rgba16" Width="32" Height="32" Offset="0x3470" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_0Tex_003C70" OutName="MIZUsin_bs_room_0Tex_003C70" Format="rgba16" Width="32" Height="32" Offset="0x3C70" AddedByScript="true"/>
         <Room Name="MIZUsin_bs_room_0" Offset="0x0"/>
     </File>
     <File Name="MIZUsin_bs_room_1" Segment="3">
+        <Texture Name="MIZUsin_bs_room_1Tex_0056E8" OutName="MIZUsin_bs_room_1Tex_0056E8" Format="rgba16" Width="32" Height="32" Offset="0x56E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_1Tex_005EE8" OutName="MIZUsin_bs_room_1Tex_005EE8" Format="rgba16" Width="32" Height="32" Offset="0x5EE8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_1Tex_0066E8" OutName="MIZUsin_bs_room_1Tex_0066E8" Format="rgba16" Width="32" Height="32" Offset="0x66E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_1Tex_006EE8" OutName="MIZUsin_bs_room_1Tex_006EE8" Format="rgba16" Width="32" Height="32" Offset="0x6EE8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_1Tex_0076E8" OutName="MIZUsin_bs_room_1Tex_0076E8" Format="rgba16" Width="32" Height="32" Offset="0x76E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_1Tex_007EE8" OutName="MIZUsin_bs_room_1Tex_007EE8" Format="rgba16" Width="32" Height="32" Offset="0x7EE8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_1Tex_0086E8" OutName="MIZUsin_bs_room_1Tex_0086E8" Format="rgba16" Width="32" Height="32" Offset="0x86E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_1Tex_008EE8" OutName="MIZUsin_bs_room_1Tex_008EE8" Format="rgba16" Width="32" Height="16" Offset="0x8EE8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_1Tex_0092E8" OutName="MIZUsin_bs_room_1Tex_0092E8" Format="rgba16" Width="32" Height="32" Offset="0x92E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_1Tex_009AE8" OutName="MIZUsin_bs_room_1Tex_009AE8" Format="rgba16" Width="32" Height="32" Offset="0x9AE8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_1Tex_00A2E8" OutName="MIZUsin_bs_room_1Tex_00A2E8" Format="rgba16" Width="32" Height="32" Offset="0xA2E8" AddedByScript="true"/>
+        <Texture Name="MIZUsin_bs_room_1Tex_00AAE8" OutName="MIZUsin_bs_room_1Tex_00AAE8" Format="i4" Width="64" Height="64" Offset="0xAAE8" AddedByScript="true"/>
         <Room Name="MIZUsin_bs_room_1" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/N64_PAL_11/scenes/dungeons/bdan.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/dungeons/bdan.xml
@@ -1,36 +1,69 @@
 <Root>
     <File Name="bdan_scene" Segment="2">
+        <Texture Name="bdan_sceneTex_013E00" OutName="bdan_sceneTex_013E00" Format="ci8" Width="32" Height="64" Offset="0x13DE0" TlutOffset="0x13BD8" AddedByScript="true"/>
+        <Texture Name="bdan_sceneTex_014600" OutName="bdan_sceneTex_014600" Format="ci8" Width="32" Height="32" Offset="0x145E0" TlutOffset="0x13BD8" AddedByScript="true"/>
+        <Texture Name="bdan_sceneTex_014A00" OutName="bdan_sceneTex_014A00" Format="ci8" Width="32" Height="64" Offset="0x149E0" TlutOffset="0x13BD8" AddedByScript="true"/>
+        <Texture Name="bdan_sceneTex_015200" OutName="bdan_sceneTex_015200" Format="ci8" Width="32" Height="32" Offset="0x151E0" TlutOffset="0x139D0" AddedByScript="true"/>
+        <Texture Name="bdan_sceneTLUT_0139F0" OutName="bdan_sceneTLUT_0139F0" Format="rgba16" Width="16" Height="16" Offset="0x139D0" AddedByScript="true"/>
+        <Texture Name="bdan_sceneTLUT_013BF8" OutName="bdan_sceneTLUT_013BF8" Format="rgba16" Width="16" Height="16" Offset="0x13BD8" AddedByScript="true"/>
         <Cutscene Name="gJabuJabuIntroCs" Offset="0x155E0"/>
         <Scene Name="bdan_scene" Offset="0x0"/>
     </File>
     <File Name="bdan_room_0" Segment="3">
+        <Texture Name="bdan_room_0Tex_002DB8" OutName="bdan_room_0Tex_002DB8" Format="ci8" Width="32" Height="32" Offset="0x2CE8" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
+        <Texture Name="bdan_room_0Tex_0031B8" OutName="bdan_room_0Tex_0031B8" Format="ci8" Width="32" Height="64" Offset="0x30E8" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
+        <Texture Name="bdan_room_0Tex_0039B8" OutName="bdan_room_0Tex_0039B8" Format="ci8" Width="32" Height="32" Offset="0x38E8" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
         <Room Name="bdan_room_0" Offset="0x0"/>
     </File>
     <File Name="bdan_room_1" Segment="3">
+        <Texture Name="bdan_room_1Tex_004E00" OutName="bdan_room_1Tex_004E00" Format="ci8" Width="32" Height="64" Offset="0x4CD0" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
+        <Texture Name="bdan_room_1Tex_005600" OutName="bdan_room_1Tex_005600" Format="ci8" Width="32" Height="64" Offset="0x54D0" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
         <Room Name="bdan_room_1" Offset="0x0"/>
     </File>
     <File Name="bdan_room_2" Segment="3">
+        <Texture Name="bdan_room_2Tex_006E38" OutName="bdan_room_2Tex_006E38" Format="rgba16" Width="32" Height="64" Offset="0x6DC8" AddedByScript="true"/>
+        <Texture Name="bdan_room_2Tex_007E38" OutName="bdan_room_2Tex_007E38" Format="ci8" Width="32" Height="64" Offset="0x7DC8" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
+        <Texture Name="bdan_room_2Tex_008638" OutName="bdan_room_2Tex_008638" Format="ci8" Width="32" Height="64" Offset="0x85C8" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
+        <Texture Name="bdan_room_2Tex_008E38" OutName="bdan_room_2Tex_008E38" Format="ci8" Width="32" Height="32" Offset="0x8DC8" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
         <Room Name="bdan_room_2" Offset="0x0"/>
     </File>
     <File Name="bdan_room_3" Segment="3">
+        <Texture Name="bdan_room_3Tex_004888" OutName="bdan_room_3Tex_004888" Format="rgba16" Width="32" Height="64" Offset="0x4788" AddedByScript="true"/>
+        <Texture Name="bdan_room_3Tex_005888" OutName="bdan_room_3Tex_005888" Format="ci8" Width="32" Height="64" Offset="0x5788" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
+        <Texture Name="bdan_room_3Tex_006088" OutName="bdan_room_3Tex_006088" Format="ci8" Width="32" Height="32" Offset="0x5F88" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
+        <Texture Name="bdan_room_3Tex_006488" OutName="bdan_room_3Tex_006488" Format="ci8" Width="32" Height="64" Offset="0x6388" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
+        <Texture Name="bdan_room_3Tex_006C88" OutName="bdan_room_3Tex_006C88" Format="ci8" Width="32" Height="32" Offset="0x6B88" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
         <Room Name="bdan_room_3" Offset="0x0"/>
     </File>
     <File Name="bdan_room_4" Segment="3">
+        <Texture Name="bdan_room_4Tex_002B30" OutName="bdan_room_4Tex_002B30" Format="ci8" Width="32" Height="32" Offset="0x2A80" ExternalTlut="bdan_scene" ExternalTlutOffset="0x139D0" AddedByScript="true"/>
+        <Texture Name="bdan_room_4Tex_002F30" OutName="bdan_room_4Tex_002F30" Format="ci8" Width="32" Height="64" Offset="0x2E80" ExternalTlut="bdan_scene" ExternalTlutOffset="0x139D0" AddedByScript="true"/>
+        <Texture Name="bdan_room_4Tex_003730" OutName="bdan_room_4Tex_003730" Format="ci8" Width="32" Height="64" Offset="0x3680" ExternalTlut="bdan_scene" ExternalTlutOffset="0x139D0" AddedByScript="true"/>
         <Room Name="bdan_room_4" Offset="0x0"/>
     </File>
     <File Name="bdan_room_5" Segment="3">
+        <Texture Name="bdan_room_5Tex_0024A8" OutName="bdan_room_5Tex_0024A8" Format="ci8" Width="32" Height="32" Offset="0x2438" ExternalTlut="bdan_scene" ExternalTlutOffset="0x139D0" AddedByScript="true"/>
+        <Texture Name="bdan_room_5Tex_0028A8" OutName="bdan_room_5Tex_0028A8" Format="ci8" Width="32" Height="64" Offset="0x2838" ExternalTlut="bdan_scene" ExternalTlutOffset="0x139D0" AddedByScript="true"/>
+        <Texture Name="bdan_room_5Tex_0030A8" OutName="bdan_room_5Tex_0030A8" Format="ci8" Width="32" Height="64" Offset="0x3038" ExternalTlut="bdan_scene" ExternalTlutOffset="0x139D0" AddedByScript="true"/>
+        <Texture Name="bdan_room_5Tex_004090" OutName="bdan_room_5Tex_004090" Format="rgba16" Width="32" Height="64" Offset="0x4020" AddedByScript="true"/>
+        <Texture Name="bdan_room_5Tex_005090" OutName="bdan_room_5Tex_005090" Format="ia16" Width="32" Height="64" Offset="0x5020" AddedByScript="true"/>
         <Room Name="bdan_room_5" Offset="0x0"/>
     </File>
     <File Name="bdan_room_6" Segment="3">
+        <Texture Name="bdan_room_6Tex_003068" OutName="bdan_room_6Tex_003068" Format="ci8" Width="32" Height="64" Offset="0x3068" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
+        <Texture Name="bdan_room_6Tex_003868" OutName="bdan_room_6Tex_003868" Format="ci8" Width="32" Height="64" Offset="0x3868" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
         <Room Name="bdan_room_6" Offset="0x0"/>
     </File>
     <File Name="bdan_room_7" Segment="3">
+        <Texture Name="bdan_room_7Tex_002CD0" OutName="bdan_room_7Tex_002CD0" Format="ci8" Width="32" Height="32" Offset="0x2D20" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
+        <Texture Name="bdan_room_7Tex_0030D0" OutName="bdan_room_7Tex_0030D0" Format="ci8" Width="32" Height="32" Offset="0x3120" ExternalTlut="bdan_scene" ExternalTlutOffset="0x139D0" AddedByScript="true"/>
         <Room Name="bdan_room_7" Offset="0x0"/>
     </File>
     <File Name="bdan_room_8" Segment="3">
         <Room Name="bdan_room_8" Offset="0x0"/>
     </File>
     <File Name="bdan_room_9" Segment="3">
+        <Texture Name="bdan_room_9Tex_003828" OutName="bdan_room_9Tex_003828" Format="ci8" Width="32" Height="32" Offset="0x3868" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
         <Room Name="bdan_room_9" Offset="0x0"/>
     </File>
     <File Name="bdan_room_10" Segment="3">
@@ -40,12 +73,20 @@
         <Room Name="bdan_room_11" Offset="0x0"/>
     </File>
     <File Name="bdan_room_12" Segment="3">
+        <Texture Name="bdan_room_12Tex_0038E0" OutName="bdan_room_12Tex_0038E0" Format="ci8" Width="32" Height="32" Offset="0x38D0" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
         <Room Name="bdan_room_12" Offset="0x0"/>
     </File>
     <File Name="bdan_room_13" Segment="3">
+        <Texture Name="bdan_room_13Tex_0015B8" OutName="bdan_room_13Tex_0015B8" Format="ci8" Width="32" Height="64" Offset="0x1588" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
+        <Texture Name="bdan_room_13Tex_001DB8" OutName="bdan_room_13Tex_001DB8" Format="ci8" Width="32" Height="32" Offset="0x1D88" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
+        <Texture Name="bdan_room_13Tex_0021B8" OutName="bdan_room_13Tex_0021B8" Format="ci8" Width="32" Height="64" Offset="0x2188" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
         <Room Name="bdan_room_13" Offset="0x0"/>
     </File>
     <File Name="bdan_room_14" Segment="3">
+        <Texture Name="bdan_room_14Tex_0045C8" OutName="bdan_room_14Tex_0045C8" Format="ci8" Width="32" Height="64" Offset="0x45D8" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
+        <Texture Name="bdan_room_14Tex_004DC8" OutName="bdan_room_14Tex_004DC8" Format="ci8" Width="32" Height="64" Offset="0x4DD8" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
+        <Texture Name="bdan_room_14Tex_0055C8" OutName="bdan_room_14Tex_0055C8" Format="ci8" Width="32" Height="32" Offset="0x55D8" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
+        <Texture Name="bdan_room_14Tex_0059C8" OutName="bdan_room_14Tex_0059C8" Format="ci8" Width="32" Height="64" Offset="0x59D8" ExternalTlut="bdan_scene" ExternalTlutOffset="0x13BD8" AddedByScript="true"/>
         <Room Name="bdan_room_14" Offset="0x0"/>
     </File>
     <File Name="bdan_room_15" Segment="3">

--- a/soh/assets/xml/N64_PAL_11/scenes/dungeons/bdan_boss.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/dungeons/bdan_boss.xml
@@ -3,9 +3,17 @@
         <Scene Name="bdan_boss_scene" Offset="0x0"/>
     </File>
     <File Name="bdan_boss_room_0" Segment="3">
+        <Texture Name="bdan_boss_room_0Tex_002040" OutName="bdan_boss_room_0Tex_002040" Format="ci8" Width="32" Height="64" Offset="0x2040" TlutOffset="0x1E38" AddedByScript="true"/>
+        <Texture Name="bdan_boss_room_0Tex_002C18" OutName="bdan_boss_room_0Tex_002C18" Format="ci8" Width="32" Height="32" Offset="0x2C18" TlutOffset="0x2A10" AddedByScript="true"/>
+        <Texture Name="bdan_boss_room_0TLUT_001E38" OutName="bdan_boss_room_0TLUT_001E38" Format="rgba16" Width="16" Height="16" Offset="0x1E38" AddedByScript="true"/>
+        <Texture Name="bdan_boss_room_0TLUT_002A10" OutName="bdan_boss_room_0TLUT_002A10" Format="rgba16" Width="16" Height="16" Offset="0x2A10" AddedByScript="true"/>
         <Room Name="bdan_boss_room_0" Offset="0x0"/>
     </File>
     <File Name="bdan_boss_room_1" Segment="3">
+        <Texture Name="bdan_boss_room_1Tex_003CB8" OutName="bdan_boss_room_1Tex_003CB8" Format="ci8" Width="32" Height="64" Offset="0x3CB8" TlutOffset="0x3AB0" AddedByScript="true"/>
+        <Texture Name="bdan_boss_room_1Tex_0044B8" OutName="bdan_boss_room_1Tex_0044B8" Format="ci8" Width="32" Height="32" Offset="0x44B8" TlutOffset="0x3AB0" AddedByScript="true"/>
+        <Texture Name="bdan_boss_room_1Tex_0048B8" OutName="bdan_boss_room_1Tex_0048B8" Format="ci8" Width="32" Height="64" Offset="0x48B8" TlutOffset="0x3AB0" AddedByScript="true"/>
+        <Texture Name="bdan_boss_room_1TLUT_003AB0" OutName="bdan_boss_room_1TLUT_003AB0" Format="rgba16" Width="16" Height="16" Offset="0x3AB0" AddedByScript="true"/>
         <Room Name="bdan_boss_room_1" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/N64_PAL_11/scenes/dungeons/ddan.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/dungeons/ddan.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="ddan_scene" Segment="2">
+        <Texture Name="ddan_sceneTLUT_011D70" OutName="ddan_sceneTLUT_011D70" Format="rgba16" Width="16" Height="16" Offset="0x11D70" AddedByScript="true"/>
         <Texture Name="gDCDayEntranceTex" OutName="day_entrance" Format="ci8" Width="32" Height="64" Offset="0x12378" TlutOffset="0x11D70"/>
         <Texture Name="gDCNightEntranceTex" OutName="night_entrance" Format="ci8" Width="32" Height="64" Offset="0x13378" TlutOffset="0x11D70"/>
 
@@ -17,54 +18,203 @@
         <Scene Name="ddan_scene" Offset="0x0"/>
     </File>
     <File Name="ddan_room_0" Segment="3">
+        <Texture Name="ddan_room_0Tex_011498" OutName="ddan_room_0Tex_011498" Format="ci8" Width="32" Height="32" Offset="0x11498" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_011898" OutName="ddan_room_0Tex_011898" Format="ci8" Width="32" Height="32" Offset="0x11898" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_011C98" OutName="ddan_room_0Tex_011C98" Format="ci8" Width="64" Height="32" Offset="0x11C98" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_012498" OutName="ddan_room_0Tex_012498" Format="ci8" Width="32" Height="64" Offset="0x12498" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_012C98" OutName="ddan_room_0Tex_012C98" Format="rgba16" Width="32" Height="64" Offset="0x12C98" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_013C98" OutName="ddan_room_0Tex_013C98" Format="rgba16" Width="32" Height="64" Offset="0x13C98" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_014C98" OutName="ddan_room_0Tex_014C98" Format="rgba16" Width="32" Height="32" Offset="0x14C98" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_015498" OutName="ddan_room_0Tex_015498" Format="ci8" Width="32" Height="64" Offset="0x15498" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_015C98" OutName="ddan_room_0Tex_015C98" Format="ci8" Width="32" Height="64" Offset="0x15C98" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_016498" OutName="ddan_room_0Tex_016498" Format="ci8" Width="32" Height="32" Offset="0x16498" TlutOffset="0x11290" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_016898" OutName="ddan_room_0Tex_016898" Format="ci8" Width="32" Height="64" Offset="0x16898" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_017098" OutName="ddan_room_0Tex_017098" Format="rgba16" Width="32" Height="32" Offset="0x17098" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_017898" OutName="ddan_room_0Tex_017898" Format="ci8" Width="32" Height="32" Offset="0x17898" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_017C98" OutName="ddan_room_0Tex_017C98" Format="rgba16" Width="32" Height="32" Offset="0x17C98" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_018498" OutName="ddan_room_0Tex_018498" Format="ci8" Width="32" Height="64" Offset="0x18498" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_018C98" OutName="ddan_room_0Tex_018C98" Format="ci8" Width="32" Height="64" Offset="0x18C98" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_019498" OutName="ddan_room_0Tex_019498" Format="rgba16" Width="64" Height="32" Offset="0x19498" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_01A498" OutName="ddan_room_0Tex_01A498" Format="rgba16" Width="64" Height="32" Offset="0x1A498" AddedByScript="true"/>
+        <Texture Name="ddan_room_0Tex_01B498" OutName="ddan_room_0Tex_01B498" Format="ci8" Width="32" Height="32" Offset="0x1B498" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_0TLUT_011290" OutName="ddan_room_0TLUT_011290" Format="rgba16" Width="16" Height="16" Offset="0x11290" AddedByScript="true"/>
         <Room Name="ddan_room_0" Offset="0x0"/>
     </File>
     <File Name="ddan_room_1" Segment="3">
+        <Texture Name="ddan_room_1Tex_004770" OutName="ddan_room_1Tex_004770" Format="ci8" Width="32" Height="32" Offset="0x4700" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_1Tex_004B70" OutName="ddan_room_1Tex_004B70" Format="ci8" Width="32" Height="32" Offset="0x4B00" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_1Tex_004F70" OutName="ddan_room_1Tex_004F70" Format="ci8" Width="32" Height="64" Offset="0x4F00" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_1Tex_005770" OutName="ddan_room_1Tex_005770" Format="ci8" Width="64" Height="32" Offset="0x5700" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_1Tex_005F70" OutName="ddan_room_1Tex_005F70" Format="rgba16" Width="32" Height="64" Offset="0x5F00" AddedByScript="true"/>
+        <Texture Name="ddan_room_1Tex_006F70" OutName="ddan_room_1Tex_006F70" Format="rgba16" Width="32" Height="64" Offset="0x6F00" AddedByScript="true"/>
+        <Texture Name="ddan_room_1Tex_007F70" OutName="ddan_room_1Tex_007F70" Format="ci8" Width="32" Height="64" Offset="0x7F00" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_1Tex_008770" OutName="ddan_room_1Tex_008770" Format="ci8" Width="64" Height="32" Offset="0x8700" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_1Tex_008F70" OutName="ddan_room_1Tex_008F70" Format="ci8" Width="32" Height="64" Offset="0x8F00" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_1Tex_009770" OutName="ddan_room_1Tex_009770" Format="ci8" Width="32" Height="32" Offset="0x9700" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
         <Room Name="ddan_room_1" Offset="0x0"/>
     </File>
     <File Name="ddan_room_2" Segment="3">
+        <Texture Name="ddan_room_2Tex_003B80" OutName="ddan_room_2Tex_003B80" Format="ci8" Width="64" Height="32" Offset="0x3A60" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_2Tex_004380" OutName="ddan_room_2Tex_004380" Format="ci8" Width="32" Height="32" Offset="0x4260" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_2Tex_004780" OutName="ddan_room_2Tex_004780" Format="ci8" Width="32" Height="32" Offset="0x4660" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_2Tex_004B80" OutName="ddan_room_2Tex_004B80" Format="ci8" Width="32" Height="64" Offset="0x4A60" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_2Tex_005380" OutName="ddan_room_2Tex_005380" Format="ci8" Width="64" Height="32" Offset="0x5260" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_2Tex_005B80" OutName="ddan_room_2Tex_005B80" Format="ci8" Width="32" Height="32" Offset="0x5A60" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_2Tex_005F80" OutName="ddan_room_2Tex_005F80" Format="ci8" Width="32" Height="32" Offset="0x5E60" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_2Tex_006380" OutName="ddan_room_2Tex_006380" Format="ci8" Width="32" Height="32" Offset="0x6260" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_2Tex_006EB8" OutName="ddan_room_2Tex_006EB8" Format="rgba16" Width="32" Height="64" Offset="0x6D98" AddedByScript="true"/>
         <Room Name="ddan_room_2" Offset="0x0"/>
     </File>
     <File Name="ddan_room_3" Segment="3">
+        <Texture Name="ddan_room_3Tex_008838" OutName="ddan_room_3Tex_008838" Format="ci8" Width="32" Height="32" Offset="0x8788" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_3Tex_008C38" OutName="ddan_room_3Tex_008C38" Format="ci8" Width="64" Height="32" Offset="0x8B88" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_3Tex_009438" OutName="ddan_room_3Tex_009438" Format="ci8" Width="32" Height="32" Offset="0x9388" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_3Tex_009838" OutName="ddan_room_3Tex_009838" Format="ci8" Width="32" Height="64" Offset="0x9788" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_3Tex_00A038" OutName="ddan_room_3Tex_00A038" Format="ci8" Width="32" Height="64" Offset="0x9F88" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_3Tex_00A838" OutName="ddan_room_3Tex_00A838" Format="ci8" Width="32" Height="64" Offset="0xA788" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_3Tex_00B038" OutName="ddan_room_3Tex_00B038" Format="ci8" Width="32" Height="32" Offset="0xAF88" TlutOffset="0x8580" AddedByScript="true"/>
+        <Texture Name="ddan_room_3Tex_00B438" OutName="ddan_room_3Tex_00B438" Format="ci8" Width="32" Height="32" Offset="0xB388" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_3Tex_00B838" OutName="ddan_room_3Tex_00B838" Format="ci8" Width="32" Height="32" Offset="0xB788" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_3Tex_00BC38" OutName="ddan_room_3Tex_00BC38" Format="ci8" Width="64" Height="32" Offset="0xBB88" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_3Tex_00C438" OutName="ddan_room_3Tex_00C438" Format="ci8" Width="32" Height="64" Offset="0xC388" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_3Tex_00CC38" OutName="ddan_room_3Tex_00CC38" Format="ci8" Width="32" Height="32" Offset="0xCB88" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_3Tex_00D038" OutName="ddan_room_3Tex_00D038" Format="ci8" Width="32" Height="32" Offset="0xCF88" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_3Tex_00D668" OutName="ddan_room_3Tex_00D668" Format="ia8" Width="64" Height="32" Offset="0xD5B8" AddedByScript="true"/>
+        <Texture Name="ddan_room_3TLUT_008630" OutName="ddan_room_3TLUT_008630" Format="rgba16" Width="16" Height="16" Offset="0x8580" AddedByScript="true"/>
         <Room Name="ddan_room_3" Offset="0x0"/>
     </File>
     <File Name="ddan_room_4" Segment="3">
+        <Texture Name="ddan_room_4Tex_006D58" OutName="ddan_room_4Tex_006D58" Format="ci8" Width="32" Height="32" Offset="0x6C48" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_4Tex_007158" OutName="ddan_room_4Tex_007158" Format="ci8" Width="32" Height="32" Offset="0x7048" TlutOffset="0x6A40" AddedByScript="true"/>
+        <Texture Name="ddan_room_4Tex_007558" OutName="ddan_room_4Tex_007558" Format="ci8" Width="64" Height="32" Offset="0x7448" TlutOffset="0x6A40" AddedByScript="true"/>
+        <Texture Name="ddan_room_4Tex_007D58" OutName="ddan_room_4Tex_007D58" Format="ci8" Width="32" Height="64" Offset="0x7C48" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_4Tex_008558" OutName="ddan_room_4Tex_008558" Format="ci8" Width="32" Height="64" Offset="0x8448" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_4Tex_008D58" OutName="ddan_room_4Tex_008D58" Format="ci8" Width="32" Height="32" Offset="0x8C48" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_4Tex_009158" OutName="ddan_room_4Tex_009158" Format="ci8" Width="64" Height="32" Offset="0x9048" TlutOffset="0x6A40" AddedByScript="true"/>
+        <Texture Name="ddan_room_4TLUT_006B50" OutName="ddan_room_4TLUT_006B50" Format="rgba16" Width="16" Height="16" Offset="0x6A40" AddedByScript="true"/>
         <Room Name="ddan_room_4" Offset="0x0"/>
     </File>
     <File Name="ddan_room_5" Segment="3">
+        <Texture Name="ddan_room_5Tex_0032B8" OutName="ddan_room_5Tex_0032B8" Format="ci8" Width="32" Height="64" Offset="0x32D8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_5Tex_003AB8" OutName="ddan_room_5Tex_003AB8" Format="ci8" Width="32" Height="64" Offset="0x3AD8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_5Tex_0042B8" OutName="ddan_room_5Tex_0042B8" Format="ci8" Width="32" Height="32" Offset="0x42D8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_5Tex_0046B8" OutName="ddan_room_5Tex_0046B8" Format="ci8" Width="32" Height="32" Offset="0x46D8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_5Tex_004AB8" OutName="ddan_room_5Tex_004AB8" Format="ci8" Width="32" Height="32" Offset="0x4AD8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_5Tex_004EB8" OutName="ddan_room_5Tex_004EB8" Format="rgba16" Width="32" Height="32" Offset="0x4ED8" AddedByScript="true"/>
+        <Texture Name="ddan_room_5Tex_0056B8" OutName="ddan_room_5Tex_0056B8" Format="ci8" Width="32" Height="64" Offset="0x56D8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
         <Room Name="ddan_room_5" Offset="0x0"/>
     </File>
     <File Name="ddan_room_6" Segment="3">
+        <Texture Name="ddan_room_6Tex_000CA8" OutName="ddan_room_6Tex_000CA8" Format="ci8" Width="32" Height="64" Offset="0xBF8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_6Tex_0014A8" OutName="ddan_room_6Tex_0014A8" Format="ci8" Width="64" Height="32" Offset="0x13F8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_6Tex_001CA8" OutName="ddan_room_6Tex_001CA8" Format="ci8" Width="32" Height="32" Offset="0x1BF8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_6Tex_0020A8" OutName="ddan_room_6Tex_0020A8" Format="ci8" Width="32" Height="32" Offset="0x1FF8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
         <Room Name="ddan_room_6" Offset="0x0"/>
     </File>
     <File Name="ddan_room_7" Segment="3">
+        <Texture Name="ddan_room_7Tex_0046F8" OutName="ddan_room_7Tex_0046F8" Format="ci8" Width="32" Height="32" Offset="0x46C8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_7Tex_004AF8" OutName="ddan_room_7Tex_004AF8" Format="ci8" Width="32" Height="32" Offset="0x4AC8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_7Tex_004EF8" OutName="ddan_room_7Tex_004EF8" Format="ci8" Width="32" Height="64" Offset="0x4EC8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_7Tex_0056F8" OutName="ddan_room_7Tex_0056F8" Format="ci8" Width="32" Height="64" Offset="0x56C8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_7Tex_005EF8" OutName="ddan_room_7Tex_005EF8" Format="ci8" Width="32" Height="64" Offset="0x5EC8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_7Tex_0066F8" OutName="ddan_room_7Tex_0066F8" Format="ci8" Width="32" Height="64" Offset="0x66C8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_7Tex_006EF8" OutName="ddan_room_7Tex_006EF8" Format="ci8" Width="32" Height="64" Offset="0x6EC8" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
         <Room Name="ddan_room_7" Offset="0x0"/>
     </File>
     <File Name="ddan_room_8" Segment="3">
+        <Texture Name="ddan_room_8Tex_0041A0" OutName="ddan_room_8Tex_0041A0" Format="ci8" Width="64" Height="32" Offset="0x4000" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_8Tex_0049A0" OutName="ddan_room_8Tex_0049A0" Format="ci8" Width="32" Height="32" Offset="0x4800" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_8Tex_004DA0" OutName="ddan_room_8Tex_004DA0" Format="ci8" Width="32" Height="32" Offset="0x4C00" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_8Tex_0051A0" OutName="ddan_room_8Tex_0051A0" Format="ci8" Width="64" Height="32" Offset="0x5000" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_8Tex_0059A0" OutName="ddan_room_8Tex_0059A0" Format="ci8" Width="32" Height="64" Offset="0x5800" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_8Tex_0061A0" OutName="ddan_room_8Tex_0061A0" Format="ci8" Width="32" Height="64" Offset="0x6000" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_8Tex_0069A0" OutName="ddan_room_8Tex_0069A0" Format="ci8" Width="32" Height="64" Offset="0x6800" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_8Tex_0071A0" OutName="ddan_room_8Tex_0071A0" Format="ci8" Width="32" Height="64" Offset="0x7000" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_8Tex_0079A0" OutName="ddan_room_8Tex_0079A0" Format="ci8" Width="64" Height="32" Offset="0x7800" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_8Tex_0081A0" OutName="ddan_room_8Tex_0081A0" Format="ci8" Width="32" Height="64" Offset="0x8000" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_8Tex_0089A0" OutName="ddan_room_8Tex_0089A0" Format="ci8" Width="32" Height="64" Offset="0x8800" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_8Tex_0091A0" OutName="ddan_room_8Tex_0091A0" Format="ci8" Width="32" Height="32" Offset="0x9000" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
         <Room Name="ddan_room_8" Offset="0x0"/>
     </File>
     <File Name="ddan_room_9" Segment="3">
+        <Texture Name="ddan_room_9Tex_005128" OutName="ddan_room_9Tex_005128" Format="ci8" Width="32" Height="32" Offset="0x5148" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_9Tex_005528" OutName="ddan_room_9Tex_005528" Format="ci8" Width="64" Height="32" Offset="0x5548" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_9Tex_005D28" OutName="ddan_room_9Tex_005D28" Format="ci8" Width="32" Height="32" Offset="0x5D48" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_9Tex_006128" OutName="ddan_room_9Tex_006128" Format="ci8" Width="32" Height="64" Offset="0x6148" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_9Tex_006928" OutName="ddan_room_9Tex_006928" Format="ci8" Width="32" Height="32" Offset="0x6948" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_9Tex_006D28" OutName="ddan_room_9Tex_006D28" Format="rgba16" Width="32" Height="64" Offset="0x6D48" AddedByScript="true"/>
+        <Texture Name="ddan_room_9Tex_007D28" OutName="ddan_room_9Tex_007D28" Format="rgba16" Width="32" Height="64" Offset="0x7D48" AddedByScript="true"/>
+        <Texture Name="ddan_room_9Tex_008D28" OutName="ddan_room_9Tex_008D28" Format="ci8" Width="32" Height="32" Offset="0x8D48" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_9Tex_009128" OutName="ddan_room_9Tex_009128" Format="ci8" Width="32" Height="64" Offset="0x9148" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_9Tex_009928" OutName="ddan_room_9Tex_009928" Format="ci8" Width="64" Height="32" Offset="0x9948" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_9Tex_00A128" OutName="ddan_room_9Tex_00A128" Format="rgba16" Width="32" Height="32" Offset="0xA148" AddedByScript="true"/>
+        <Texture Name="ddan_room_9Tex_00A928" OutName="ddan_room_9Tex_00A928" Format="ci8" Width="32" Height="64" Offset="0xA948" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_9Tex_00B128" OutName="ddan_room_9Tex_00B128" Format="ci8" Width="32" Height="32" Offset="0xB148" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
         <Room Name="ddan_room_9" Offset="0x0"/>
     </File>
     <File Name="ddan_room_10" Segment="3">
+        <Texture Name="ddan_room_10Tex_002B10" OutName="ddan_room_10Tex_002B10" Format="ci8" Width="32" Height="32" Offset="0x2A50" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_10Tex_002F10" OutName="ddan_room_10Tex_002F10" Format="ci8" Width="64" Height="32" Offset="0x2E50" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_10Tex_003710" OutName="ddan_room_10Tex_003710" Format="ci8" Width="32" Height="32" Offset="0x3650" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_10Tex_003B10" OutName="ddan_room_10Tex_003B10" Format="ci8" Width="32" Height="64" Offset="0x3A50" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_10Tex_004310" OutName="ddan_room_10Tex_004310" Format="ci8" Width="32" Height="32" Offset="0x4250" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_10Tex_004710" OutName="ddan_room_10Tex_004710" Format="ci8" Width="32" Height="64" Offset="0x4650" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_10Tex_004F10" OutName="ddan_room_10Tex_004F10" Format="ci8" Width="32" Height="32" Offset="0x4E50" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_10Tex_005310" OutName="ddan_room_10Tex_005310" Format="rgba16" Width="32" Height="64" Offset="0x5250" AddedByScript="true"/>
+        <Texture Name="ddan_room_10Tex_006310" OutName="ddan_room_10Tex_006310" Format="rgba16" Width="32" Height="64" Offset="0x6250" AddedByScript="true"/>
+        <Texture Name="ddan_room_10Tex_007310" OutName="ddan_room_10Tex_007310" Format="ci8" Width="32" Height="64" Offset="0x7250" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_10Tex_007B10" OutName="ddan_room_10Tex_007B10" Format="ci8" Width="32" Height="32" Offset="0x7A50" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
         <Room Name="ddan_room_10" Offset="0x0"/>
     </File>
     <File Name="ddan_room_11" Segment="3">
+        <Texture Name="ddan_room_11Tex_000C30" OutName="ddan_room_11Tex_000C30" Format="ci8" Width="32" Height="64" Offset="0xC80" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_11Tex_001430" OutName="ddan_room_11Tex_001430" Format="ci8" Width="64" Height="32" Offset="0x1480" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_11Tex_001C30" OutName="ddan_room_11Tex_001C30" Format="ci8" Width="32" Height="32" Offset="0x1C80" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
         <Room Name="ddan_room_11" Offset="0x0"/>
     </File>
     <File Name="ddan_room_12" Segment="3">
+        <Texture Name="ddan_room_12Tex_002F80" OutName="ddan_room_12Tex_002F80" Format="ci8" Width="32" Height="32" Offset="0x2F30" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_12Tex_003380" OutName="ddan_room_12Tex_003380" Format="ci8" Width="64" Height="32" Offset="0x3330" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_12Tex_003B80" OutName="ddan_room_12Tex_003B80" Format="ci8" Width="32" Height="32" Offset="0x3B30" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_12Tex_003F80" OutName="ddan_room_12Tex_003F80" Format="ci8" Width="32" Height="64" Offset="0x3F30" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_12Tex_004780" OutName="ddan_room_12Tex_004780" Format="ci8" Width="32" Height="32" Offset="0x4730" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_12Tex_004B80" OutName="ddan_room_12Tex_004B80" Format="ci8" Width="32" Height="64" Offset="0x4B30" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_12Tex_005380" OutName="ddan_room_12Tex_005380" Format="ci8" Width="32" Height="32" Offset="0x5330" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_12Tex_005780" OutName="ddan_room_12Tex_005780" Format="rgba16" Width="32" Height="64" Offset="0x5730" AddedByScript="true"/>
+        <Texture Name="ddan_room_12Tex_006780" OutName="ddan_room_12Tex_006780" Format="rgba16" Width="32" Height="64" Offset="0x6730" AddedByScript="true"/>
+        <Texture Name="ddan_room_12Tex_007780" OutName="ddan_room_12Tex_007780" Format="ci8" Width="32" Height="32" Offset="0x7730" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_12Tex_007B80" OutName="ddan_room_12Tex_007B80" Format="ci8" Width="32" Height="64" Offset="0x7B30" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_12Tex_008380" OutName="ddan_room_12Tex_008380" Format="ci8" Width="32" Height="32" Offset="0x8330" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
         <Room Name="ddan_room_12" Offset="0x0"/>
     </File>
     <File Name="ddan_room_13" Segment="3">
+        <Texture Name="ddan_room_13Tex_000CC8" OutName="ddan_room_13Tex_000CC8" Format="ci8" Width="32" Height="64" Offset="0xC78" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_13Tex_0014C8" OutName="ddan_room_13Tex_0014C8" Format="ci8" Width="64" Height="32" Offset="0x1478" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_13Tex_001CC8" OutName="ddan_room_13Tex_001CC8" Format="ci8" Width="32" Height="32" Offset="0x1C78" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_13Tex_0020C8" OutName="ddan_room_13Tex_0020C8" Format="ci8" Width="32" Height="32" Offset="0x2078" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
         <Room Name="ddan_room_13" Offset="0x0"/>
     </File>
     <File Name="ddan_room_14" Segment="3">
+        <Texture Name="ddan_room_14Tex_000CC8" OutName="ddan_room_14Tex_000CC8" Format="ci8" Width="32" Height="64" Offset="0xC88" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_14Tex_0014C8" OutName="ddan_room_14Tex_0014C8" Format="ci8" Width="64" Height="32" Offset="0x1488" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_14Tex_001CC8" OutName="ddan_room_14Tex_001CC8" Format="ci8" Width="32" Height="32" Offset="0x1C88" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_14Tex_0020C8" OutName="ddan_room_14Tex_0020C8" Format="ci8" Width="32" Height="32" Offset="0x2088" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
         <Room Name="ddan_room_14" Offset="0x0"/>
     </File>
     <File Name="ddan_room_15" Segment="3">
+        <Texture Name="ddan_room_15Tex_000D28" OutName="ddan_room_15Tex_000D28" Format="ci8" Width="64" Height="32" Offset="0xC48" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_15Tex_001528" OutName="ddan_room_15Tex_001528" Format="ci8" Width="32" Height="64" Offset="0x1448" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_15Tex_001D28" OutName="ddan_room_15Tex_001D28" Format="ci8" Width="64" Height="32" Offset="0x1C48" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_15Tex_002528" OutName="ddan_room_15Tex_002528" Format="ci8" Width="32" Height="32" Offset="0x2448" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
         <Room Name="ddan_room_15" Offset="0x0"/>
     </File>
     <File Name="ddan_room_16" Segment="3">
+        <Texture Name="ddan_room_16Tex_002158" OutName="ddan_room_16Tex_002158" Format="rgba16" Width="32" Height="64" Offset="0x2148" AddedByScript="true"/>
+        <Texture Name="ddan_room_16Tex_003158" OutName="ddan_room_16Tex_003158" Format="ci8" Width="32" Height="64" Offset="0x3148" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_16Tex_003958" OutName="ddan_room_16Tex_003958" Format="ci8" Width="32" Height="64" Offset="0x3948" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_16Tex_004158" OutName="ddan_room_16Tex_004158" Format="ci8" Width="32" Height="64" Offset="0x4148" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_16Tex_004958" OutName="ddan_room_16Tex_004958" Format="ci8" Width="32" Height="64" Offset="0x4948" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
+        <Texture Name="ddan_room_16Tex_005158" OutName="ddan_room_16Tex_005158" Format="ci8" Width="32" Height="32" Offset="0x5148" ExternalTlut="ddan_scene" ExternalTlutOffset="0x11D70" AddedByScript="true"/>
         <Room Name="ddan_room_16" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/N64_PAL_11/scenes/dungeons/ddan_boss.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/dungeons/ddan_boss.xml
@@ -1,11 +1,21 @@
 <Root>
     <File Name="ddan_boss_scene" Segment="2">
+        <Texture Name="ddan_boss_sceneTex_001058" OutName="ddan_boss_sceneTex_001058" Format="ci8" Width="32" Height="64" Offset="0x1058" TlutOffset="0xE50" AddedByScript="true"/>
+        <Texture Name="ddan_boss_sceneTex_001858" OutName="ddan_boss_sceneTex_001858" Format="ci8" Width="32" Height="64" Offset="0x1858" TlutOffset="0xE50" AddedByScript="true"/>
+        <Texture Name="ddan_boss_sceneTex_002058" OutName="ddan_boss_sceneTex_002058" Format="ci8" Width="32" Height="64" Offset="0x2058" TlutOffset="0xE50" AddedByScript="true"/>
+        <Texture Name="ddan_boss_sceneTLUT_000E50" OutName="ddan_boss_sceneTLUT_000E50" Format="rgba16" Width="16" Height="16" Offset="0xE50" AddedByScript="true"/>
         <Scene Name="ddan_boss_scene" Offset="0x0"/>
     </File>
     <File Name="ddan_boss_room_0" Segment="3">
+        <Texture Name="ddan_boss_room_0Tex_003628" OutName="ddan_boss_room_0Tex_003628" Format="ci8" Width="32" Height="32" Offset="0x3628" ExternalTlut="ddan_boss_scene" ExternalTlutOffset="0xE50" AddedByScript="true"/>
+        <Texture Name="ddan_boss_room_0Tex_003A28" OutName="ddan_boss_room_0Tex_003A28" Format="ci8" Width="32" Height="32" Offset="0x3A28" ExternalTlut="ddan_boss_scene" ExternalTlutOffset="0xE50" AddedByScript="true"/>
+        <Texture Name="ddan_boss_room_0Tex_003E28" OutName="ddan_boss_room_0Tex_003E28" Format="ci8" Width="32" Height="64" Offset="0x3E28" ExternalTlut="ddan_boss_scene" ExternalTlutOffset="0xE50" AddedByScript="true"/>
+        <Texture Name="ddan_boss_room_0Tex_004628" OutName="ddan_boss_room_0Tex_004628" Format="ci8" Width="32" Height="64" Offset="0x4628" ExternalTlut="ddan_boss_scene" ExternalTlutOffset="0xE50" AddedByScript="true"/>
         <Room Name="ddan_boss_room_0" Offset="0x0"/>
     </File>
     <File Name="ddan_boss_room_1" Segment="3">
+        <Texture Name="ddan_boss_room_1Tex_0031D8" OutName="ddan_boss_room_1Tex_0031D8" Format="ci8" Width="32" Height="64" Offset="0x31D8" ExternalTlut="ddan_boss_scene" ExternalTlutOffset="0xE50" AddedByScript="true"/>
+        <Texture Name="ddan_boss_room_1Tex_0039D8" OutName="ddan_boss_room_1Tex_0039D8" Format="ci8" Width="32" Height="32" Offset="0x39D8" ExternalTlut="ddan_boss_scene" ExternalTlutOffset="0xE50" AddedByScript="true"/>
         <Texture Name="gDodongosCavernBossLavaFloorTex" OutName="lava_floor" Format="rgba16" Width="64" Height="32" Offset="0x21D8"/>
         <Room Name="ddan_boss_room_1" Offset="0x0"/>
     </File>

--- a/soh/assets/xml/N64_PAL_11/scenes/dungeons/ganon.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/dungeons/ganon.xml
@@ -1,35 +1,121 @@
 <Root>
     <File Name="ganon_scene" Segment="2">
+        <Texture Name="ganon_sceneTex_00EFA8" OutName="ganon_sceneTex_00EFA8" Format="ci8" Width="32" Height="32" Offset="0xEFA8" TlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_sceneTex_00F3A8" OutName="ganon_sceneTex_00F3A8" Format="ci8" Width="32" Height="32" Offset="0xF3A8" TlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_sceneTex_00F7A8" OutName="ganon_sceneTex_00F7A8" Format="ci8" Width="32" Height="32" Offset="0xF7A8" TlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_sceneTex_00FBA8" OutName="ganon_sceneTex_00FBA8" Format="ci8" Width="32" Height="32" Offset="0xFBA8" TlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_sceneTex_00FFA8" OutName="ganon_sceneTex_00FFA8" Format="rgba16" Width="32" Height="32" Offset="0xFFA8" AddedByScript="true"/>
+        <Texture Name="ganon_sceneTLUT_00E7D0" OutName="ganon_sceneTLUT_00E7D0" Format="rgba16" Width="16" Height="16" Offset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_sceneTLUT_00E9D8" OutName="ganon_sceneTLUT_00E9D8" Format="rgba16" Width="16" Height="16" Offset="0xE9D8" AddedByScript="true"/>
+        <Texture Name="ganon_sceneTLUT_00EBE0" OutName="ganon_sceneTLUT_00EBE0" Format="rgba16" Width="16" Height="16" Offset="0xEBE0" AddedByScript="true"/>
+        <Texture Name="ganon_sceneTLUT_00EDA0" OutName="ganon_sceneTLUT_00EDA0" Format="rgba16" Width="16" Height="16" Offset="0xEDA0" AddedByScript="true"/>
         <Scene Name="ganon_scene" Offset="0x0"/>
     </File>
     <File Name="ganon_room_0" Segment="3">
+        <Texture Name="ganon_room_0Tex_004C68" OutName="ganon_room_0Tex_004C68" Format="ci8" Width="32" Height="64" Offset="0x4C68" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_0Tex_005468" OutName="ganon_room_0Tex_005468" Format="ci8" Width="32" Height="64" Offset="0x5468" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_0Tex_005C68" OutName="ganon_room_0Tex_005C68" Format="ci8" Width="32" Height="32" Offset="0x5C68" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_0Tex_006068" OutName="ganon_room_0Tex_006068" Format="ci8" Width="64" Height="32" Offset="0x6068" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_0Tex_006868" OutName="ganon_room_0Tex_006868" Format="ci8" Width="64" Height="32" Offset="0x6868" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_0Tex_007068" OutName="ganon_room_0Tex_007068" Format="ci8" Width="32" Height="32" Offset="0x7068" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_0Tex_0076D0" OutName="ganon_room_0Tex_0076D0" Format="ia16" Width="32" Height="32" Offset="0x76D0" AddedByScript="true"/>
         <Room Name="ganon_room_0" Offset="0x0"/>
     </File>
     <File Name="ganon_room_1" Segment="3">
+        <Texture Name="ganon_room_1Tex_005370" OutName="ganon_room_1Tex_005370" Format="ci8" Width="64" Height="32" Offset="0x5370" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_1Tex_005B70" OutName="ganon_room_1Tex_005B70" Format="ci8" Width="32" Height="32" Offset="0x5B70" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_1Tex_005F70" OutName="ganon_room_1Tex_005F70" Format="ci8" Width="32" Height="32" Offset="0x5F70" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_1Tex_006370" OutName="ganon_room_1Tex_006370" Format="ci8" Width="32" Height="32" Offset="0x6370" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_1Tex_006770" OutName="ganon_room_1Tex_006770" Format="rgba16" Width="32" Height="64" Offset="0x6770" AddedByScript="true"/>
         <Room Name="ganon_room_1" Offset="0x0"/>
     </File>
     <File Name="ganon_room_2" Segment="3">
+        <Texture Name="ganon_room_2Tex_003DF0" OutName="ganon_room_2Tex_003DF0" Format="ci8" Width="32" Height="32" Offset="0x3DF0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_2Tex_0041F0" OutName="ganon_room_2Tex_0041F0" Format="ci8" Width="32" Height="64" Offset="0x41F0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_2Tex_0049F0" OutName="ganon_room_2Tex_0049F0" Format="ci8" Width="32" Height="32" Offset="0x49F0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_2Tex_004DF0" OutName="ganon_room_2Tex_004DF0" Format="ci8" Width="32" Height="32" Offset="0x4DF0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_2Tex_0051F0" OutName="ganon_room_2Tex_0051F0" Format="ci8" Width="32" Height="64" Offset="0x51F0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_2Tex_0059F0" OutName="ganon_room_2Tex_0059F0" Format="ci8" Width="32" Height="32" Offset="0x59F0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_2Tex_005DF0" OutName="ganon_room_2Tex_005DF0" Format="rgba16" Width="32" Height="64" Offset="0x5DF0" AddedByScript="true"/>
+        <Texture Name="ganon_room_2Tex_007050" OutName="ganon_room_2Tex_007050" Format="ia16" Width="32" Height="32" Offset="0x7050" AddedByScript="true"/>
         <Room Name="ganon_room_2" Offset="0x0"/>
     </File>
     <File Name="ganon_room_3" Segment="3">
+        <Texture Name="ganon_room_3Tex_004F30" OutName="ganon_room_3Tex_004F30" Format="ci8" Width="32" Height="32" Offset="0x4F30" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_3Tex_005330" OutName="ganon_room_3Tex_005330" Format="ci8" Width="32" Height="32" Offset="0x5330" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_3Tex_005730" OutName="ganon_room_3Tex_005730" Format="ci8" Width="32" Height="64" Offset="0x5730" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_3Tex_005F30" OutName="ganon_room_3Tex_005F30" Format="ci8" Width="32" Height="64" Offset="0x5F30" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_3Tex_006730" OutName="ganon_room_3Tex_006730" Format="rgba16" Width="32" Height="64" Offset="0x6730" AddedByScript="true"/>
         <Room Name="ganon_room_3" Offset="0x0"/>
     </File>
     <File Name="ganon_room_4" Segment="3">
+        <Texture Name="ganon_room_4Tex_004668" OutName="ganon_room_4Tex_004668" Format="ci8" Width="32" Height="64" Offset="0x4668" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_4Tex_004E68" OutName="ganon_room_4Tex_004E68" Format="ci8" Width="32" Height="64" Offset="0x4E68" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_4Tex_005668" OutName="ganon_room_4Tex_005668" Format="ci8" Width="32" Height="32" Offset="0x5668" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_4Tex_005A68" OutName="ganon_room_4Tex_005A68" Format="ci8" Width="32" Height="64" Offset="0x5A68" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_4Tex_006268" OutName="ganon_room_4Tex_006268" Format="ci8" Width="32" Height="32" Offset="0x6268" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_4Tex_006668" OutName="ganon_room_4Tex_006668" Format="ci8" Width="32" Height="32" Offset="0x6668" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_4Tex_006A68" OutName="ganon_room_4Tex_006A68" Format="ci8" Width="32" Height="32" Offset="0x6A68" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_4Tex_006E68" OutName="ganon_room_4Tex_006E68" Format="ci8" Width="32" Height="64" Offset="0x6E68" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_4Tex_007668" OutName="ganon_room_4Tex_007668" Format="ci8" Width="32" Height="64" Offset="0x7668" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_4Tex_007E68" OutName="ganon_room_4Tex_007E68" Format="ci8" Width="32" Height="64" Offset="0x7E68" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_4Tex_0088D0" OutName="ganon_room_4Tex_0088D0" Format="ia16" Width="32" Height="32" Offset="0x88D0" AddedByScript="true"/>
         <Room Name="ganon_room_4" Offset="0x0"/>
     </File>
     <File Name="ganon_room_5" Segment="3">
+        <Texture Name="ganon_room_5Tex_005B08" OutName="ganon_room_5Tex_005B08" Format="ci8" Width="32" Height="64" Offset="0x5B08" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_5Tex_006308" OutName="ganon_room_5Tex_006308" Format="ci8" Width="32" Height="64" Offset="0x6308" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_5Tex_006B08" OutName="ganon_room_5Tex_006B08" Format="rgba16" Width="32" Height="64" Offset="0x6B08" AddedByScript="true"/>
+        <Texture Name="ganon_room_5Tex_007B08" OutName="ganon_room_5Tex_007B08" Format="ci8" Width="32" Height="32" Offset="0x7B08" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_5Tex_007F08" OutName="ganon_room_5Tex_007F08" Format="ci8" Width="32" Height="32" Offset="0x7F08" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_5Tex_008308" OutName="ganon_room_5Tex_008308" Format="ci8" Width="32" Height="64" Offset="0x8308" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
         <Room Name="ganon_room_5" Offset="0x0"/>
     </File>
     <File Name="ganon_room_6" Segment="3">
+        <Texture Name="ganon_room_6Tex_006E00" OutName="ganon_room_6Tex_006E00" Format="ci8" Width="32" Height="32" Offset="0x6E00" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_6Tex_007200" OutName="ganon_room_6Tex_007200" Format="ci8" Width="32" Height="32" Offset="0x7200" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_6Tex_007600" OutName="ganon_room_6Tex_007600" Format="ci8" Width="32" Height="32" Offset="0x7600" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_6Tex_007A00" OutName="ganon_room_6Tex_007A00" Format="ci8" Width="32" Height="64" Offset="0x7A00" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_6Tex_008200" OutName="ganon_room_6Tex_008200" Format="ci8" Width="16" Height="16" Offset="0x8200" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEBE0" AddedByScript="true"/>
+        <Texture Name="ganon_room_6Tex_008300" OutName="ganon_room_6Tex_008300" Format="ci8" Width="32" Height="64" Offset="0x8300" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_6Tex_008B00" OutName="ganon_room_6Tex_008B00" Format="ci8" Width="32" Height="32" Offset="0x8B00" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEBE0" AddedByScript="true"/>
+        <Texture Name="ganon_room_6Tex_009398" OutName="ganon_room_6Tex_009398" Format="rgba16" Width="32" Height="32" Offset="0x9398" AddedByScript="true"/>
         <Room Name="ganon_room_6" Offset="0x0"/>
     </File>
     <File Name="ganon_room_7" Segment="3">
+        <Texture Name="ganon_room_7Tex_0071E0" OutName="ganon_room_7Tex_0071E0" Format="ci8" Width="32" Height="32" Offset="0x71E0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_7Tex_0075E0" OutName="ganon_room_7Tex_0075E0" Format="ci8" Width="64" Height="32" Offset="0x75E0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_7Tex_007DE0" OutName="ganon_room_7Tex_007DE0" Format="ci8" Width="64" Height="32" Offset="0x7DE0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_7Tex_0085E0" OutName="ganon_room_7Tex_0085E0" Format="ci8" Width="32" Height="32" Offset="0x85E0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_7Tex_0089E0" OutName="ganon_room_7Tex_0089E0" Format="ci8" Width="32" Height="64" Offset="0x89E0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE7D0" AddedByScript="true"/>
+        <Texture Name="ganon_room_7Tex_0091E0" OutName="ganon_room_7Tex_0091E0" Format="ci8" Width="32" Height="64" Offset="0x91E0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_7Tex_009F98" OutName="ganon_room_7Tex_009F98" Format="rgba16" Width="32" Height="32" Offset="0x9F98" AddedByScript="true"/>
         <Room Name="ganon_room_7" Offset="0x0"/>
     </File>
     <File Name="ganon_room_8" Segment="3">
+        <Texture Name="ganon_room_8Tex_004A20" OutName="ganon_room_8Tex_004A20" Format="ci8" Width="32" Height="64" Offset="0x4A20" TlutOffset="0x4950" AddedByScript="true"/>
+        <Texture Name="ganon_room_8Tex_005220" OutName="ganon_room_8Tex_005220" Format="ci8" Width="16" Height="16" Offset="0x5220" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEBE0" AddedByScript="true"/>
+        <Texture Name="ganon_room_8Tex_005320" OutName="ganon_room_8Tex_005320" Format="ci8" Width="8" Height="8" Offset="0x5320" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEBE0" AddedByScript="true"/>
+        <Texture Name="ganon_room_8Tex_005360" OutName="ganon_room_8Tex_005360" Format="ci8" Width="16" Height="8" Offset="0x5360" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEBE0" AddedByScript="true"/>
+        <Texture Name="ganon_room_8Tex_0053E0" OutName="ganon_room_8Tex_0053E0" Format="ci8" Width="32" Height="64" Offset="0x53E0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE9D8" AddedByScript="true"/>
+        <Texture Name="ganon_room_8Tex_005BE0" OutName="ganon_room_8Tex_005BE0" Format="ci8" Width="32" Height="32" Offset="0x5BE0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEBE0" AddedByScript="true"/>
+        <Texture Name="ganon_room_8Tex_005FE0" OutName="ganon_room_8Tex_005FE0" Format="ci8" Width="32" Height="32" Offset="0x5FE0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_8Tex_0063E0" OutName="ganon_room_8Tex_0063E0" Format="ci8" Width="32" Height="64" Offset="0x63E0" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_8TLUT_004950" OutName="ganon_room_8TLUT_004950" Format="rgba16" Width="16" Height="16" Offset="0x4950" AddedByScript="true"/>
         <Room Name="ganon_room_8" Offset="0x0"/>
     </File>
     <File Name="ganon_room_9" Segment="3">
+        <Texture Name="ganon_room_9Tex_002120" OutName="ganon_room_9Tex_002120" Format="ci8" Width="32" Height="64" Offset="0x2120" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE9D8" AddedByScript="true"/>
+        <Texture Name="ganon_room_9Tex_002920" OutName="ganon_room_9Tex_002920" Format="ci8" Width="32" Height="32" Offset="0x2920" TlutOffset="0x1F18" AddedByScript="true"/>
+        <Texture Name="ganon_room_9Tex_002D20" OutName="ganon_room_9Tex_002D20" Format="ci8" Width="32" Height="32" Offset="0x2D20" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEBE0" AddedByScript="true"/>
+        <Texture Name="ganon_room_9Tex_003120" OutName="ganon_room_9Tex_003120" Format="ci8" Width="32" Height="32" Offset="0x3120" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEBE0" AddedByScript="true"/>
+        <Texture Name="ganon_room_9Tex_003520" OutName="ganon_room_9Tex_003520" Format="ci8" Width="32" Height="32" Offset="0x3520" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEBE0" AddedByScript="true"/>
+        <Texture Name="ganon_room_9Tex_003920" OutName="ganon_room_9Tex_003920" Format="ci8" Width="32" Height="32" Offset="0x3920" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_9Tex_003D20" OutName="ganon_room_9Tex_003D20" Format="ci8" Width="32" Height="64" Offset="0x3D20" ExternalTlut="ganon_scene" ExternalTlutOffset="0xE9D8" AddedByScript="true"/>
+        <Texture Name="ganon_room_9Tex_004520" OutName="ganon_room_9Tex_004520" Format="ci8" Width="32" Height="64" Offset="0x4520" TlutOffset="0x1F18" AddedByScript="true"/>
+        <Texture Name="ganon_room_9Tex_004D20" OutName="ganon_room_9Tex_004D20" Format="ci8" Width="16" Height="64" Offset="0x4D20" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEBE0" AddedByScript="true"/>
+        <Texture Name="ganon_room_9Tex_005120" OutName="ganon_room_9Tex_005120" Format="ci8" Width="32" Height="64" Offset="0x5120" ExternalTlut="ganon_scene" ExternalTlutOffset="0xEDA0" AddedByScript="true"/>
+        <Texture Name="ganon_room_9TLUT_001F18" OutName="ganon_room_9TLUT_001F18" Format="rgba16" Width="16" Height="16" Offset="0x1F18" AddedByScript="true"/>
         <Room Name="ganon_room_9" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/N64_PAL_11/scenes/dungeons/ganon_boss.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/dungeons/ganon_boss.xml
@@ -1,5 +1,28 @@
 <Root>
     <File Name="ganon_boss_scene" Segment="2">
+        <Texture Name="ganon_boss_sceneTex_001E58" OutName="ganon_boss_sceneTex_001E58" Format="ci8" Width="32" Height="64" Offset="0x1E58" TlutOffset="0x1550" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_002658" OutName="ganon_boss_sceneTex_002658" Format="ci8" Width="16" Height="16" Offset="0x2658" TlutOffset="0x1A90" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_002758" OutName="ganon_boss_sceneTex_002758" Format="ci8" Width="8" Height="8" Offset="0x2758" TlutOffset="0x1A90" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_002798" OutName="ganon_boss_sceneTex_002798" Format="ci8" Width="32" Height="32" Offset="0x2798" TlutOffset="0x1C50" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_002B98" OutName="ganon_boss_sceneTex_002B98" Format="ci8" Width="16" Height="8" Offset="0x2B98" TlutOffset="0x1A90" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_002C18" OutName="ganon_boss_sceneTex_002C18" Format="rgba16" Width="32" Height="64" Offset="0x2C18" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_003C18" OutName="ganon_boss_sceneTex_003C18" Format="ci8" Width="32" Height="32" Offset="0x3C18" TlutOffset="0x1620" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_004018" OutName="ganon_boss_sceneTex_004018" Format="ci8" Width="32" Height="32" Offset="0x4018" TlutOffset="0x1888" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_004418" OutName="ganon_boss_sceneTex_004418" Format="ci8" Width="32" Height="32" Offset="0x4418" TlutOffset="0x1A90" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_004818" OutName="ganon_boss_sceneTex_004818" Format="ci8" Width="32" Height="32" Offset="0x4818" TlutOffset="0x1A90" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_004C18" OutName="ganon_boss_sceneTex_004C18" Format="ci8" Width="32" Height="32" Offset="0x4C18" TlutOffset="0x1A90" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_005018" OutName="ganon_boss_sceneTex_005018" Format="rgba16" Width="32" Height="32" Offset="0x5018" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_005818" OutName="ganon_boss_sceneTex_005818" Format="ci8" Width="32" Height="64" Offset="0x5818" TlutOffset="0x1888" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_006018" OutName="ganon_boss_sceneTex_006018" Format="ci8" Width="16" Height="64" Offset="0x6018" TlutOffset="0x1A90" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_006418" OutName="ganon_boss_sceneTex_006418" Format="ci8" Width="32" Height="64" Offset="0x6418" TlutOffset="0x1C50" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_006C18" OutName="ganon_boss_sceneTex_006C18" Format="ci8" Width="32" Height="64" Offset="0x6C18" TlutOffset="0x1680" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTex_007418" OutName="ganon_boss_sceneTex_007418" Format="ci8" Width="32" Height="64" Offset="0x7418" TlutOffset="0x1680" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTLUT_001550" OutName="ganon_boss_sceneTLUT_001550" Format="rgba16" Width="16" Height="16" Offset="0x1550" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTLUT_001620" OutName="ganon_boss_sceneTLUT_001620" Format="rgba16" Width="16" Height="16" Offset="0x1620" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTLUT_001680" OutName="ganon_boss_sceneTLUT_001680" Format="rgba16" Width="16" Height="16" Offset="0x1680" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTLUT_001888" OutName="ganon_boss_sceneTLUT_001888" Format="rgba16" Width="16" Height="16" Offset="0x1888" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTLUT_001A90" OutName="ganon_boss_sceneTLUT_001A90" Format="rgba16" Width="16" Height="16" Offset="0x1A90" AddedByScript="true"/>
+        <Texture Name="ganon_boss_sceneTLUT_001C50" OutName="ganon_boss_sceneTLUT_001C50" Format="rgba16" Width="16" Height="16" Offset="0x1C50" AddedByScript="true"/>
         <Scene Name="ganon_boss_scene" Offset="0x0"/>
     </File>
     <File Name="ganon_boss_room_0" Segment="3">

--- a/soh/assets/xml/N64_PAL_11/scenes/dungeons/ganon_demo.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/dungeons/ganon_demo.xml
@@ -1,5 +1,16 @@
 <Root>
     <File Name="ganon_demo_scene" Segment="2">
+        <Texture Name="ganon_demo_sceneTex_001B70" OutName="ganon_demo_sceneTex_001B70" Format="i8" Width="128" Height="32" Offset="0x1B70" AddedByScript="true"/>
+        <Texture Name="ganon_demo_sceneTex_002B70" OutName="ganon_demo_sceneTex_002B70" Format="i8" Width="64" Height="64" Offset="0x2B70" AddedByScript="true"/>
+        <Texture Name="ganon_demo_sceneTex_003B70" OutName="ganon_demo_sceneTex_003B70" Format="i8" Width="64" Height="64" Offset="0x3B70" AddedByScript="true"/>
+        <Texture Name="ganon_demo_sceneTex_004B70" OutName="ganon_demo_sceneTex_004B70" Format="i8" Width="64" Height="64" Offset="0x4B70" AddedByScript="true"/>
+        <Texture Name="ganon_demo_sceneTex_005B70" OutName="ganon_demo_sceneTex_005B70" Format="rgba16" Width="64" Height="16" Offset="0x5B70" AddedByScript="true"/>
+        <Texture Name="ganon_demo_sceneTex_006370" OutName="ganon_demo_sceneTex_006370" Format="rgba16" Width="32" Height="32" Offset="0x6370" AddedByScript="true"/>
+        <Texture Name="ganon_demo_sceneTex_006B70" OutName="ganon_demo_sceneTex_006B70" Format="ia4" Width="128" Height="32" Offset="0x6B70" AddedByScript="true"/>
+        <Texture Name="ganon_demo_sceneTex_007370" OutName="ganon_demo_sceneTex_007370" Format="rgba16" Width="32" Height="64" Offset="0x7370" AddedByScript="true"/>
+        <Texture Name="ganon_demo_sceneTex_008370" OutName="ganon_demo_sceneTex_008370" Format="rgba16" Width="16" Height="32" Offset="0x8370" AddedByScript="true"/>
+        <Texture Name="ganon_demo_sceneTex_008770" OutName="ganon_demo_sceneTex_008770" Format="i8" Width="16" Height="16" Offset="0x8770" AddedByScript="true"/>
+        <Texture Name="ganon_demo_sceneTex_008870" OutName="ganon_demo_sceneTex_008870" Format="rgba16" Width="32" Height="32" Offset="0x8870" AddedByScript="true"/>
         <Scene Name="ganon_demo_scene" Offset="0x0"/>
     </File>
     <File Name="ganon_demo_room_0" Segment="3">

--- a/soh/assets/xml/N64_PAL_11/scenes/dungeons/ganon_final.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/dungeons/ganon_final.xml
@@ -1,5 +1,30 @@
 <Root>
     <File Name="ganon_final_scene" Segment="2">
+        <Texture Name="ganon_final_sceneTex_002380" OutName="ganon_final_sceneTex_002380" Format="ia8" Width="32" Height="32" Offset="0x2380" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_002780" OutName="ganon_final_sceneTex_002780" Format="rgba16" Width="16" Height="16" Offset="0x2780" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_002980" OutName="ganon_final_sceneTex_002980" Format="i8" Width="64" Height="16" Offset="0x2980" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_002D80" OutName="ganon_final_sceneTex_002D80" Format="i4" Width="64" Height="128" Offset="0x2D80" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_003D80" OutName="ganon_final_sceneTex_003D80" Format="i8" Width="32" Height="64" Offset="0x3D80" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_004580" OutName="ganon_final_sceneTex_004580" Format="i8" Width="32" Height="64" Offset="0x4580" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_004D80" OutName="ganon_final_sceneTex_004D80" Format="i8" Width="64" Height="64" Offset="0x4D80" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_005D80" OutName="ganon_final_sceneTex_005D80" Format="i4" Width="64" Height="128" Offset="0x5D80" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_006D80" OutName="ganon_final_sceneTex_006D80" Format="ia8" Width="64" Height="32" Offset="0x6D80" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_007580" OutName="ganon_final_sceneTex_007580" Format="i4" Width="64" Height="128" Offset="0x7580" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_008580" OutName="ganon_final_sceneTex_008580" Format="rgba16" Width="32" Height="64" Offset="0x8580" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_009580" OutName="ganon_final_sceneTex_009580" Format="rgba16" Width="32" Height="64" Offset="0x9580" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_00A580" OutName="ganon_final_sceneTex_00A580" Format="ia4" Width="128" Height="32" Offset="0xA580" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_00AD80" OutName="ganon_final_sceneTex_00AD80" Format="rgba16" Width="32" Height="64" Offset="0xAD80" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_00BD80" OutName="ganon_final_sceneTex_00BD80" Format="rgba16" Width="32" Height="64" Offset="0xBD80" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_00CD80" OutName="ganon_final_sceneTex_00CD80" Format="i8" Width="16" Height="16" Offset="0xCD80" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_00CE80" OutName="ganon_final_sceneTex_00CE80" Format="ia8" Width="64" Height="64" Offset="0xCE80" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_00DE80" OutName="ganon_final_sceneTex_00DE80" Format="i4" Width="64" Height="16" Offset="0xDE80" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_00E080" OutName="ganon_final_sceneTex_00E080" Format="ia8" Width="16" Height="16" Offset="0xE080" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_00E180" OutName="ganon_final_sceneTex_00E180" Format="i4" Width="128" Height="64" Offset="0xE180" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_00F180" OutName="ganon_final_sceneTex_00F180" Format="i8" Width="32" Height="32" Offset="0xF180" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_00F580" OutName="ganon_final_sceneTex_00F580" Format="i8" Width="128" Height="32" Offset="0xF580" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_010580" OutName="ganon_final_sceneTex_010580" Format="i8" Width="32" Height="32" Offset="0x10580" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_010980" OutName="ganon_final_sceneTex_010980" Format="rgba16" Width="16" Height="64" Offset="0x10980" AddedByScript="true"/>
+        <Texture Name="ganon_final_sceneTex_011180" OutName="ganon_final_sceneTex_011180" Format="i8" Width="16" Height="256" Offset="0x11180" AddedByScript="true"/>
         <Path Name="gGanonFinalPath_001F4" Offset="0x1F4" NumPaths="4"/>
         <Scene Name="ganon_final_scene" Offset="0x0"/>
     </File>

--- a/soh/assets/xml/N64_PAL_11/scenes/dungeons/ganon_sonogo.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/dungeons/ganon_sonogo.xml
@@ -1,21 +1,72 @@
 <Root>
     <File Name="ganon_sonogo_scene" Segment="2">
+        <Texture Name="ganon_sonogo_sceneTex_006710" OutName="ganon_sonogo_sceneTex_006710" Format="ci8" Width="32" Height="64" Offset="0x6710" TlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_sceneTex_006F10" OutName="ganon_sonogo_sceneTex_006F10" Format="ci8" Width="32" Height="32" Offset="0x6F10" TlutOffset="0x6508" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_sceneTex_007310" OutName="ganon_sonogo_sceneTex_007310" Format="ci8" Width="32" Height="32" Offset="0x7310" TlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_sceneTex_007710" OutName="ganon_sonogo_sceneTex_007710" Format="ia16" Width="32" Height="32" Offset="0x7710" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_sceneTLUT_006300" OutName="ganon_sonogo_sceneTLUT_006300" Format="rgba16" Width="16" Height="16" Offset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_sceneTLUT_006508" OutName="ganon_sonogo_sceneTLUT_006508" Format="rgba16" Width="16" Height="16" Offset="0x6508" AddedByScript="true"/>
         <Path Name="gGanonSonogoPath_00254" Offset="0x254" NumPaths="5"/>
         <Scene Name="ganon_sonogo_scene" Offset="0x0"/>
     </File>
     <File Name="ganon_sonogo_room_0" Segment="3">
+        <Texture Name="ganon_sonogo_room_0Tex_005020" OutName="ganon_sonogo_room_0Tex_005020" Format="ci8" Width="32" Height="64" Offset="0x5020" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_0Tex_005820" OutName="ganon_sonogo_room_0Tex_005820" Format="ci8" Width="32" Height="32" Offset="0x5820" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_0Tex_005C20" OutName="ganon_sonogo_room_0Tex_005C20" Format="ci8" Width="32" Height="32" Offset="0x5C20" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_0Tex_006020" OutName="ganon_sonogo_room_0Tex_006020" Format="ci8" Width="64" Height="32" Offset="0x6020" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_0Tex_006820" OutName="ganon_sonogo_room_0Tex_006820" Format="ci8" Width="64" Height="32" Offset="0x6820" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_0Tex_007020" OutName="ganon_sonogo_room_0Tex_007020" Format="ci8" Width="32" Height="32" Offset="0x7020" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_0Tex_007420" OutName="ganon_sonogo_room_0Tex_007420" Format="ci8" Width="32" Height="32" Offset="0x7420" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_0Tex_007820" OutName="ganon_sonogo_room_0Tex_007820" Format="ci8" Width="32" Height="32" Offset="0x7820" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
         <Room Name="ganon_sonogo_room_0" Offset="0x0"/>
     </File>
     <File Name="ganon_sonogo_room_1" Segment="3">
+        <Texture Name="ganon_sonogo_room_1Tex_004148" OutName="ganon_sonogo_room_1Tex_004148" Format="ci8" Width="32" Height="32" Offset="0x4148" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_1Tex_004548" OutName="ganon_sonogo_room_1Tex_004548" Format="ci8" Width="32" Height="32" Offset="0x4548" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_1Tex_004948" OutName="ganon_sonogo_room_1Tex_004948" Format="ci8" Width="32" Height="32" Offset="0x4948" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_1Tex_004D48" OutName="ganon_sonogo_room_1Tex_004D48" Format="ci8" Width="32" Height="64" Offset="0x4D48" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_1Tex_005548" OutName="ganon_sonogo_room_1Tex_005548" Format="ci8" Width="32" Height="32" Offset="0x5548" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_1Tex_005948" OutName="ganon_sonogo_room_1Tex_005948" Format="ci8" Width="32" Height="32" Offset="0x5948" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_1Tex_005D48" OutName="ganon_sonogo_room_1Tex_005D48" Format="ci8" Width="32" Height="64" Offset="0x5D48" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_1Tex_006548" OutName="ganon_sonogo_room_1Tex_006548" Format="ci8" Width="32" Height="32" Offset="0x6548" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_1Tex_006948" OutName="ganon_sonogo_room_1Tex_006948" Format="rgba16" Width="32" Height="64" Offset="0x6948" AddedByScript="true"/>
         <Room Name="ganon_sonogo_room_1" Offset="0x0"/>
     </File>
     <File Name="ganon_sonogo_room_2" Segment="3">
+        <Texture Name="ganon_sonogo_room_2Tex_004A40" OutName="ganon_sonogo_room_2Tex_004A40" Format="ci8" Width="32" Height="64" Offset="0x4A40" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_2Tex_005240" OutName="ganon_sonogo_room_2Tex_005240" Format="ci8" Width="32" Height="32" Offset="0x5240" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_2Tex_005640" OutName="ganon_sonogo_room_2Tex_005640" Format="ci8" Width="32" Height="32" Offset="0x5640" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_2Tex_005A40" OutName="ganon_sonogo_room_2Tex_005A40" Format="ci8" Width="32" Height="64" Offset="0x5A40" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_2Tex_006240" OutName="ganon_sonogo_room_2Tex_006240" Format="ci8" Width="32" Height="32" Offset="0x6240" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_2Tex_006640" OutName="ganon_sonogo_room_2Tex_006640" Format="ci8" Width="32" Height="32" Offset="0x6640" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_2Tex_006A40" OutName="ganon_sonogo_room_2Tex_006A40" Format="ci8" Width="32" Height="32" Offset="0x6A40" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_2Tex_006E40" OutName="ganon_sonogo_room_2Tex_006E40" Format="ci8" Width="32" Height="32" Offset="0x6E40" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_2Tex_007240" OutName="ganon_sonogo_room_2Tex_007240" Format="ci8" Width="32" Height="64" Offset="0x7240" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_2Tex_007A40" OutName="ganon_sonogo_room_2Tex_007A40" Format="ci8" Width="32" Height="64" Offset="0x7A40" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_2Tex_008240" OutName="ganon_sonogo_room_2Tex_008240" Format="ci8" Width="32" Height="64" Offset="0x8240" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
         <Room Name="ganon_sonogo_room_2" Offset="0x0"/>
     </File>
     <File Name="ganon_sonogo_room_3" Segment="3">
+        <Texture Name="ganon_sonogo_room_3Tex_003A38" OutName="ganon_sonogo_room_3Tex_003A38" Format="ci8" Width="32" Height="32" Offset="0x3A38" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_3Tex_003E38" OutName="ganon_sonogo_room_3Tex_003E38" Format="ci8" Width="64" Height="32" Offset="0x3E38" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_3Tex_004638" OutName="ganon_sonogo_room_3Tex_004638" Format="ci8" Width="64" Height="32" Offset="0x4638" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_3Tex_004E38" OutName="ganon_sonogo_room_3Tex_004E38" Format="ci8" Width="32" Height="64" Offset="0x4E38" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6300" AddedByScript="true"/>
         <Room Name="ganon_sonogo_room_3" Offset="0x0"/>
     </File>
     <File Name="ganon_sonogo_room_4" Segment="3">
+        <Texture Name="ganon_sonogo_room_4Tex_004BA8" OutName="ganon_sonogo_room_4Tex_004BA8" Format="ci8" Width="32" Height="64" Offset="0x4BA8" TlutOffset="0x4840" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_4Tex_0053A8" OutName="ganon_sonogo_room_4Tex_0053A8" Format="ci8" Width="16" Height="16" Offset="0x53A8" TlutOffset="0x4B18" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_4Tex_0054A8" OutName="ganon_sonogo_room_4Tex_0054A8" Format="ci8" Width="8" Height="8" Offset="0x54A8" TlutOffset="0x4B18" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_4Tex_0054E8" OutName="ganon_sonogo_room_4Tex_0054E8" Format="rgba16" Width="32" Height="32" Offset="0x54E8" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_4Tex_005CE8" OutName="ganon_sonogo_room_4Tex_005CE8" Format="ci8" Width="32" Height="64" Offset="0x5CE8" TlutOffset="0x4910" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_4Tex_0064E8" OutName="ganon_sonogo_room_4Tex_0064E8" Format="ci8" Width="32" Height="32" Offset="0x64E8" TlutOffset="0x4B18" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_4Tex_0068E8" OutName="ganon_sonogo_room_4Tex_0068E8" Format="ci8" Width="32" Height="32" Offset="0x68E8" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_4Tex_006CE8" OutName="ganon_sonogo_room_4Tex_006CE8" Format="rgba16" Width="32" Height="32" Offset="0x6CE8" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_4Tex_0074E8" OutName="ganon_sonogo_room_4Tex_0074E8" Format="ci8" Width="32" Height="64" Offset="0x74E8" ExternalTlut="ganon_sonogo_scene" ExternalTlutOffset="0x6508" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_4Tex_007CE8" OutName="ganon_sonogo_room_4Tex_007CE8" Format="rgba16" Width="32" Height="64" Offset="0x7CE8" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_4TLUT_004840" OutName="ganon_sonogo_room_4TLUT_004840" Format="rgba16" Width="16" Height="16" Offset="0x4840" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_4TLUT_004910" OutName="ganon_sonogo_room_4TLUT_004910" Format="rgba16" Width="16" Height="16" Offset="0x4910" AddedByScript="true"/>
+        <Texture Name="ganon_sonogo_room_4TLUT_004B18" OutName="ganon_sonogo_room_4TLUT_004B18" Format="rgba16" Width="16" Height="16" Offset="0x4B18" AddedByScript="true"/>
         <Room Name="ganon_sonogo_room_4" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/N64_PAL_11/scenes/dungeons/ganon_tou.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/dungeons/ganon_tou.xml
@@ -1,10 +1,34 @@
 <Root>
     <File Name="ganon_tou_scene" Segment="2">
+        <Texture Name="ganon_tou_sceneTex_003280" OutName="ganon_tou_sceneTex_003280" Format="i8" Width="64" Height="64" Offset="0x3280" AddedByScript="true"/>
         <Cutscene Name="gRainbowBridgeCs" Offset="0x2640"/>
         <Cutscene Name="gGanonsCastleIntroCs" Offset="0x4280"/>
         <Scene Name="ganon_tou_scene" Offset="0x0"/>
     </File>
     <File Name="ganon_tou_room_0" Segment="3">
+        <Texture Name="ganon_tou_room_0Tex_008550" OutName="ganon_tou_room_0Tex_008550" Format="rgba16" Width="32" Height="32" Offset="0x8550" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_008D50" OutName="ganon_tou_room_0Tex_008D50" Format="rgba16" Width="16" Height="16" Offset="0x8D50" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_008F50" OutName="ganon_tou_room_0Tex_008F50" Format="rgba16" Width="32" Height="8" Offset="0x8F50" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_009150" OutName="ganon_tou_room_0Tex_009150" Format="rgba16" Width="64" Height="32" Offset="0x9150" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_00A150" OutName="ganon_tou_room_0Tex_00A150" Format="rgba16" Width="128" Height="16" Offset="0xA150" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_00B150" OutName="ganon_tou_room_0Tex_00B150" Format="rgba16" Width="32" Height="16" Offset="0xB150" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_00B550" OutName="ganon_tou_room_0Tex_00B550" Format="i8" Width="32" Height="32" Offset="0xB550" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_00B950" OutName="ganon_tou_room_0Tex_00B950" Format="i8" Width="32" Height="32" Offset="0xB950" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_00BD50" OutName="ganon_tou_room_0Tex_00BD50" Format="rgba16" Width="16" Height="16" Offset="0xBD50" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_00BF50" OutName="ganon_tou_room_0Tex_00BF50" Format="i8" Width="64" Height="64" Offset="0xBF50" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_00CF50" OutName="ganon_tou_room_0Tex_00CF50" Format="rgba16" Width="32" Height="32" Offset="0xCF50" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_00D750" OutName="ganon_tou_room_0Tex_00D750" Format="rgba16" Width="32" Height="64" Offset="0xD750" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_00E750" OutName="ganon_tou_room_0Tex_00E750" Format="rgba16" Width="32" Height="64" Offset="0xE750" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_00F750" OutName="ganon_tou_room_0Tex_00F750" Format="i8" Width="32" Height="32" Offset="0xF750" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_00FB50" OutName="ganon_tou_room_0Tex_00FB50" Format="i8" Width="64" Height="16" Offset="0xFB50" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_00FF50" OutName="ganon_tou_room_0Tex_00FF50" Format="rgba16" Width="16" Height="16" Offset="0xFF50" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_010150" OutName="ganon_tou_room_0Tex_010150" Format="rgba16" Width="32" Height="16" Offset="0x10150" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_010550" OutName="ganon_tou_room_0Tex_010550" Format="rgba16" Width="32" Height="32" Offset="0x10550" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_0124F0" OutName="ganon_tou_room_0Tex_0124F0" Format="ia8" Width="32" Height="8" Offset="0x124F0" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_0125F0" OutName="ganon_tou_room_0Tex_0125F0" Format="ia4" Width="128" Height="32" Offset="0x125F0" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_012DF0" OutName="ganon_tou_room_0Tex_012DF0" Format="i4" Width="64" Height="64" Offset="0x12DF0" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_0135F0" OutName="ganon_tou_room_0Tex_0135F0" Format="ia8" Width="32" Height="32" Offset="0x135F0" AddedByScript="true"/>
+        <Texture Name="ganon_tou_room_0Tex_0139F0" OutName="ganon_tou_room_0Tex_0139F0" Format="ia8" Width="16" Height="16" Offset="0x139F0" AddedByScript="true"/>
         <Room Name="ganon_tou_room_0" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/N64_PAL_11/scenes/dungeons/ganontika.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/dungeons/ganontika.xml
@@ -1,5 +1,11 @@
 <Root>
     <File Name="ganontika_scene" Segment="2">
+        <Texture Name="ganontika_sceneTex_01F580" OutName="ganontika_sceneTex_01F580" Format="rgba16" Width="16" Height="16" Offset="0x1F570" AddedByScript="true"/>
+        <Texture Name="ganontika_sceneTex_01F780" OutName="ganontika_sceneTex_01F780" Format="ci8" Width="32" Height="64" Offset="0x1F770" TlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_sceneTex_01FF80" OutName="ganontika_sceneTex_01FF80" Format="ci8" Width="32" Height="32" Offset="0x1FF70" TlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_sceneTex_020380" OutName="ganontika_sceneTex_020380" Format="ci8" Width="64" Height="32" Offset="0x20370" TlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_sceneTex_020B80" OutName="ganontika_sceneTex_020B80" Format="rgba16" Width="32" Height="32" Offset="0x20B70" AddedByScript="true"/>
+        <Texture Name="ganontika_sceneTLUT_01F380" OutName="ganontika_sceneTLUT_01F380" Format="rgba16" Width="16" Height="16" Offset="0x1F370" AddedByScript="true"/>
         <Path Name="gGanontikaPath_00674" Offset="0x674" NumPaths="3"/>
         <Cutscene Name="gForestTrialSageCs" Offset="0x19ED0"/>
         <Cutscene Name="gWaterTrialSageCs" Offset="0x1A8D0"/>
@@ -20,63 +26,229 @@
         <Scene Name="ganontika_scene" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_0" Segment="3">
+        <Texture Name="ganontika_room_0Tex_007F48" OutName="ganontika_room_0Tex_007F48" Format="ci8" Width="64" Height="32" Offset="0x7EF8" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_0Tex_008A10" OutName="ganontika_room_0Tex_008A10" Format="ia16" Width="8" Height="128" Offset="0x89C0" AddedByScript="true"/>
         <Room Name="ganontika_room_0" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_1" Segment="3">
+        <Texture Name="ganontika_room_1Tex_00D9E0" OutName="ganontika_room_1Tex_00D9E0" Format="i4" Width="128" Height="64" Offset="0xD9C0" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_00E9E0" OutName="ganontika_room_1Tex_00E9E0" Format="i4" Width="128" Height="64" Offset="0xE9C0" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_00F9E0" OutName="ganontika_room_1Tex_00F9E0" Format="i4" Width="128" Height="64" Offset="0xF9C0" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0109E0" OutName="ganontika_room_1Tex_0109E0" Format="rgba16" Width="64" Height="32" Offset="0x109C0" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0119E0" OutName="ganontika_room_1Tex_0119E0" Format="ci8" Width="32" Height="64" Offset="0x119C0" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0121E0" OutName="ganontika_room_1Tex_0121E0" Format="ci8" Width="64" Height="32" Offset="0x121C0" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0129E0" OutName="ganontika_room_1Tex_0129E0" Format="ci8" Width="32" Height="64" Offset="0x129C0" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0131E0" OutName="ganontika_room_1Tex_0131E0" Format="ci8" Width="64" Height="32" Offset="0x131C0" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0139E0" OutName="ganontika_room_1Tex_0139E0" Format="ci8" Width="64" Height="32" Offset="0x139C0" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0141E0" OutName="ganontika_room_1Tex_0141E0" Format="ci8" Width="64" Height="32" Offset="0x141C0" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0149E0" OutName="ganontika_room_1Tex_0149E0" Format="ci8" Width="64" Height="32" Offset="0x149C0" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0151E0" OutName="ganontika_room_1Tex_0151E0" Format="ci8" Width="32" Height="64" Offset="0x151C0" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0159E0" OutName="ganontika_room_1Tex_0159E0" Format="ci4" Width="64" Height="64" Offset="0x159C0" TlutOffset="0xD9A0" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0161E0" OutName="ganontika_room_1Tex_0161E0" Format="ci4" Width="64" Height="64" Offset="0x161C0" TlutOffset="0xD9A0" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0169E0" OutName="ganontika_room_1Tex_0169E0" Format="ci4" Width="64" Height="64" Offset="0x169C0" TlutOffset="0xD9A0" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0171E0" OutName="ganontika_room_1Tex_0171E0" Format="ci4" Width="64" Height="64" Offset="0x171C0" TlutOffset="0xD9A0" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0179E0" OutName="ganontika_room_1Tex_0179E0" Format="ci4" Width="64" Height="64" Offset="0x179C0" TlutOffset="0xD9A0" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0181E0" OutName="ganontika_room_1Tex_0181E0" Format="ci4" Width="64" Height="64" Offset="0x181C0" TlutOffset="0xD9A0" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0189E0" OutName="ganontika_room_1Tex_0189E0" Format="rgba16" Width="64" Height="32" Offset="0x189C0" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_0199E0" OutName="ganontika_room_1Tex_0199E0" Format="ci8" Width="64" Height="16" Offset="0x199C0" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_019DE0" OutName="ganontika_room_1Tex_019DE0" Format="ci8" Width="64" Height="32" Offset="0x19DC0" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1Tex_01B9C8" OutName="ganontika_room_1Tex_01B9C8" Format="ia8" Width="64" Height="64" Offset="0x1B9A8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_1TLUT_00D9C0" OutName="ganontika_room_1TLUT_00D9C0" Format="rgba16" Width="4" Height="4" Offset="0xD9A0" AddedByScript="true"/>
         <Room Name="ganontika_room_1" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_2" Segment="3">
+        <Texture Name="ganontika_room_2Tex_002FD8" OutName="ganontika_room_2Tex_002FD8" Format="rgba16" Width="32" Height="32" Offset="0x2FD8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_2Tex_0037D8" OutName="ganontika_room_2Tex_0037D8" Format="rgba16" Width="32" Height="32" Offset="0x37D8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_2Tex_003FD8" OutName="ganontika_room_2Tex_003FD8" Format="rgba16" Width="32" Height="32" Offset="0x3FD8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_2Tex_0047D8" OutName="ganontika_room_2Tex_0047D8" Format="rgba16" Width="32" Height="32" Offset="0x47D8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_2Tex_004FD8" OutName="ganontika_room_2Tex_004FD8" Format="rgba16" Width="32" Height="32" Offset="0x4FD8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_2Tex_0057D8" OutName="ganontika_room_2Tex_0057D8" Format="rgba16" Width="32" Height="32" Offset="0x57D8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_2Tex_005FD8" OutName="ganontika_room_2Tex_005FD8" Format="ci8" Width="64" Height="32" Offset="0x5FD8" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_2Tex_0067D8" OutName="ganontika_room_2Tex_0067D8" Format="rgba16" Width="64" Height="32" Offset="0x67D8" AddedByScript="true"/>
         <Room Name="ganontika_room_2" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_3" Segment="3">
+        <Texture Name="ganontika_room_3Tex_003ED8" OutName="ganontika_room_3Tex_003ED8" Format="rgba16" Width="32" Height="32" Offset="0x3E28" AddedByScript="true"/>
+        <Texture Name="ganontika_room_3Tex_0046D8" OutName="ganontika_room_3Tex_0046D8" Format="rgba16" Width="32" Height="32" Offset="0x4628" AddedByScript="true"/>
+        <Texture Name="ganontika_room_3Tex_004ED8" OutName="ganontika_room_3Tex_004ED8" Format="rgba16" Width="32" Height="32" Offset="0x4E28" AddedByScript="true"/>
+        <Texture Name="ganontika_room_3Tex_0056D8" OutName="ganontika_room_3Tex_0056D8" Format="rgba16" Width="32" Height="32" Offset="0x5628" AddedByScript="true"/>
+        <Texture Name="ganontika_room_3Tex_005ED8" OutName="ganontika_room_3Tex_005ED8" Format="rgba16" Width="32" Height="32" Offset="0x5E28" AddedByScript="true"/>
+        <Texture Name="ganontika_room_3Tex_0066D8" OutName="ganontika_room_3Tex_0066D8" Format="rgba16" Width="32" Height="32" Offset="0x6628" AddedByScript="true"/>
+        <Texture Name="ganontika_room_3Tex_006ED8" OutName="ganontika_room_3Tex_006ED8" Format="ci4" Width="64" Height="64" Offset="0x6E28" TlutOffset="0x3E08" AddedByScript="true"/>
+        <Texture Name="ganontika_room_3Tex_0076D8" OutName="ganontika_room_3Tex_0076D8" Format="rgba16" Width="64" Height="32" Offset="0x7628" AddedByScript="true"/>
+        <Texture Name="ganontika_room_3Tex_008A38" OutName="ganontika_room_3Tex_008A38" Format="ia8" Width="64" Height="64" Offset="0x8988" AddedByScript="true"/>
+        <Texture Name="ganontika_room_3TLUT_003EB8" OutName="ganontika_room_3TLUT_003EB8" Format="rgba16" Width="4" Height="4" Offset="0x3E08" AddedByScript="true"/>
         <Room Name="ganontika_room_3" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_4" Segment="3">
+        <Texture Name="ganontika_room_4Tex_004288" OutName="ganontika_room_4Tex_004288" Format="rgba16" Width="32" Height="32" Offset="0x4288" AddedByScript="true"/>
+        <Texture Name="ganontika_room_4Tex_004A88" OutName="ganontika_room_4Tex_004A88" Format="ci8" Width="32" Height="64" Offset="0x4A88" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_4Tex_005288" OutName="ganontika_room_4Tex_005288" Format="ci8" Width="64" Height="32" Offset="0x5288" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_4Tex_005A88" OutName="ganontika_room_4Tex_005A88" Format="rgba16" Width="32" Height="32" Offset="0x5A88" AddedByScript="true"/>
+        <Texture Name="ganontika_room_4Tex_006288" OutName="ganontika_room_4Tex_006288" Format="rgba16" Width="32" Height="32" Offset="0x6288" AddedByScript="true"/>
+        <Texture Name="ganontika_room_4Tex_006A88" OutName="ganontika_room_4Tex_006A88" Format="rgba16" Width="16" Height="16" Offset="0x6A88" AddedByScript="true"/>
+        <Texture Name="ganontika_room_4Tex_006C88" OutName="ganontika_room_4Tex_006C88" Format="rgba16" Width="64" Height="32" Offset="0x6C88" AddedByScript="true"/>
         <Room Name="ganontika_room_4" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_5" Segment="3">
+        <Texture Name="ganontika_room_5Tex_003B18" OutName="ganontika_room_5Tex_003B18" Format="rgba16" Width="16" Height="16" Offset="0x3B38" AddedByScript="true"/>
+        <Texture Name="ganontika_room_5Tex_003D18" OutName="ganontika_room_5Tex_003D18" Format="ci8" Width="32" Height="64" Offset="0x3D38" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_5Tex_004518" OutName="ganontika_room_5Tex_004518" Format="rgba16" Width="32" Height="32" Offset="0x4538" AddedByScript="true"/>
+        <Texture Name="ganontika_room_5Tex_004D18" OutName="ganontika_room_5Tex_004D18" Format="ci8" Width="64" Height="32" Offset="0x4D38" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_5Tex_005518" OutName="ganontika_room_5Tex_005518" Format="rgba16" Width="32" Height="32" Offset="0x5538" AddedByScript="true"/>
+        <Texture Name="ganontika_room_5Tex_005D18" OutName="ganontika_room_5Tex_005D18" Format="ci8" Width="64" Height="32" Offset="0x5D38" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_5Tex_006518" OutName="ganontika_room_5Tex_006518" Format="rgba16" Width="64" Height="32" Offset="0x6538" AddedByScript="true"/>
         <Room Name="ganontika_room_5" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_6" Segment="3">
+        <Texture Name="ganontika_room_6Tex_00B500" OutName="ganontika_room_6Tex_00B500" Format="ci8" Width="32" Height="32" Offset="0xB490" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_6Tex_00B900" OutName="ganontika_room_6Tex_00B900" Format="ci8" Width="32" Height="64" Offset="0xB890" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_6Tex_00C100" OutName="ganontika_room_6Tex_00C100" Format="ci8" Width="64" Height="32" Offset="0xC090" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_6Tex_00C900" OutName="ganontika_room_6Tex_00C900" Format="i4" Width="32" Height="32" Offset="0xC890" AddedByScript="true"/>
+        <Texture Name="ganontika_room_6Tex_00CB00" OutName="ganontika_room_6Tex_00CB00" Format="i4" Width="32" Height="32" Offset="0xCA90" AddedByScript="true"/>
+        <Texture Name="ganontika_room_6Tex_00CD00" OutName="ganontika_room_6Tex_00CD00" Format="i4" Width="32" Height="32" Offset="0xCC90" AddedByScript="true"/>
+        <Texture Name="ganontika_room_6Tex_00CF00" OutName="ganontika_room_6Tex_00CF00" Format="ci4" Width="64" Height="64" Offset="0xCE90" TlutOffset="0xB470" AddedByScript="true"/>
+        <Texture Name="ganontika_room_6Tex_00D700" OutName="ganontika_room_6Tex_00D700" Format="i4" Width="32" Height="32" Offset="0xD690" AddedByScript="true"/>
+        <Texture Name="ganontika_room_6Tex_00D900" OutName="ganontika_room_6Tex_00D900" Format="rgba16" Width="64" Height="32" Offset="0xD890" AddedByScript="true"/>
+        <Texture Name="ganontika_room_6Tex_00EC58" OutName="ganontika_room_6Tex_00EC58" Format="ia8" Width="64" Height="64" Offset="0xEBE8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_6TLUT_00B4E0" OutName="ganontika_room_6TLUT_00B4E0" Format="rgba16" Width="4" Height="4" Offset="0xB470" AddedByScript="true"/>
         <Room Name="ganontika_room_6" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_7" Segment="3">
+        <Texture Name="ganontika_room_7Tex_004288" OutName="ganontika_room_7Tex_004288" Format="rgba16" Width="32" Height="32" Offset="0x4288" AddedByScript="true"/>
+        <Texture Name="ganontika_room_7Tex_004A88" OutName="ganontika_room_7Tex_004A88" Format="ci8" Width="32" Height="64" Offset="0x4A88" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_7Tex_005288" OutName="ganontika_room_7Tex_005288" Format="ci8" Width="64" Height="32" Offset="0x5288" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_7Tex_005A88" OutName="ganontika_room_7Tex_005A88" Format="rgba16" Width="32" Height="32" Offset="0x5A88" AddedByScript="true"/>
+        <Texture Name="ganontika_room_7Tex_006288" OutName="ganontika_room_7Tex_006288" Format="rgba16" Width="32" Height="32" Offset="0x6288" AddedByScript="true"/>
+        <Texture Name="ganontika_room_7Tex_006A88" OutName="ganontika_room_7Tex_006A88" Format="rgba16" Width="16" Height="16" Offset="0x6A88" AddedByScript="true"/>
+        <Texture Name="ganontika_room_7Tex_006C88" OutName="ganontika_room_7Tex_006C88" Format="rgba16" Width="64" Height="32" Offset="0x6C88" AddedByScript="true"/>
         <Room Name="ganontika_room_7" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_8" Segment="3">
+        <Texture Name="ganontika_room_8Tex_0034B8" OutName="ganontika_room_8Tex_0034B8" Format="rgba16" Width="32" Height="64" Offset="0x3508" AddedByScript="true"/>
+        <Texture Name="ganontika_room_8Tex_0044B8" OutName="ganontika_room_8Tex_0044B8" Format="rgba16" Width="32" Height="64" Offset="0x4508" AddedByScript="true"/>
+        <Texture Name="ganontika_room_8Tex_0054B8" OutName="ganontika_room_8Tex_0054B8" Format="rgba16" Width="32" Height="32" Offset="0x5508" AddedByScript="true"/>
+        <Texture Name="ganontika_room_8Tex_005CB8" OutName="ganontika_room_8Tex_005CB8" Format="rgba16" Width="32" Height="64" Offset="0x5D08" AddedByScript="true"/>
+        <Texture Name="ganontika_room_8Tex_006CB8" OutName="ganontika_room_8Tex_006CB8" Format="rgba16" Width="32" Height="32" Offset="0x6D08" AddedByScript="true"/>
+        <Texture Name="ganontika_room_8Tex_0074B8" OutName="ganontika_room_8Tex_0074B8" Format="ci4" Width="64" Height="64" Offset="0x7508" TlutOffset="0x34E8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_8Tex_008018" OutName="ganontika_room_8Tex_008018" Format="ia8" Width="64" Height="64" Offset="0x8068" AddedByScript="true"/>
+        <Texture Name="ganontika_room_8TLUT_003498" OutName="ganontika_room_8TLUT_003498" Format="rgba16" Width="4" Height="4" Offset="0x34E8" AddedByScript="true"/>
         <Room Name="ganontika_room_8" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_9" Segment="3">
+        <Texture Name="ganontika_room_9Tex_005488" OutName="ganontika_room_9Tex_005488" Format="rgba16" Width="64" Height="32" Offset="0x54F8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_9Tex_006488" OutName="ganontika_room_9Tex_006488" Format="rgba16" Width="64" Height="32" Offset="0x64F8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_9Tex_007488" OutName="ganontika_room_9Tex_007488" Format="rgba16" Width="32" Height="32" Offset="0x74F8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_9Tex_007C88" OutName="ganontika_room_9Tex_007C88" Format="rgba16" Width="16" Height="16" Offset="0x7CF8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_9Tex_007E88" OutName="ganontika_room_9Tex_007E88" Format="ci8" Width="32" Height="64" Offset="0x7EF8" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_9Tex_008688" OutName="ganontika_room_9Tex_008688" Format="ci8" Width="64" Height="32" Offset="0x86F8" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_9Tex_008E88" OutName="ganontika_room_9Tex_008E88" Format="ci8" Width="64" Height="32" Offset="0x8EF8" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_9Tex_009688" OutName="ganontika_room_9Tex_009688" Format="rgba16" Width="64" Height="32" Offset="0x96F8" AddedByScript="true"/>
+        <Texture Name="ganontika_room_9Tex_00A818" OutName="ganontika_room_9Tex_00A818" Format="rgba16" Width="32" Height="64" Offset="0xA888" AddedByScript="true"/>
         <Room Name="ganontika_room_9" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_10" Segment="3">
+        <Texture Name="ganontika_room_10Tex_0039B8" OutName="ganontika_room_10Tex_0039B8" Format="rgba16" Width="32" Height="32" Offset="0x3968" AddedByScript="true"/>
+        <Texture Name="ganontika_room_10Tex_0041B8" OutName="ganontika_room_10Tex_0041B8" Format="ci8" Width="32" Height="64" Offset="0x4168" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_10Tex_0049B8" OutName="ganontika_room_10Tex_0049B8" Format="rgba16" Width="32" Height="32" Offset="0x4968" AddedByScript="true"/>
+        <Texture Name="ganontika_room_10Tex_0051B8" OutName="ganontika_room_10Tex_0051B8" Format="rgba16" Width="32" Height="32" Offset="0x5168" AddedByScript="true"/>
+        <Texture Name="ganontika_room_10Tex_0059B8" OutName="ganontika_room_10Tex_0059B8" Format="rgba16" Width="16" Height="16" Offset="0x5968" AddedByScript="true"/>
+        <Texture Name="ganontika_room_10Tex_005BB8" OutName="ganontika_room_10Tex_005BB8" Format="rgba16" Width="64" Height="32" Offset="0x5B68" AddedByScript="true"/>
         <Room Name="ganontika_room_10" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_11" Segment="3">
+        <Texture Name="ganontika_room_11Tex_004150" OutName="ganontika_room_11Tex_004150" Format="rgba16" Width="32" Height="32" Offset="0x4150" AddedByScript="true"/>
+        <Texture Name="ganontika_room_11Tex_004950" OutName="ganontika_room_11Tex_004950" Format="ci8" Width="32" Height="64" Offset="0x4950" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_11Tex_005150" OutName="ganontika_room_11Tex_005150" Format="ci8" Width="64" Height="32" Offset="0x5150" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_11Tex_005950" OutName="ganontika_room_11Tex_005950" Format="rgba16" Width="32" Height="32" Offset="0x5950" AddedByScript="true"/>
+        <Texture Name="ganontika_room_11Tex_006150" OutName="ganontika_room_11Tex_006150" Format="rgba16" Width="32" Height="32" Offset="0x6150" AddedByScript="true"/>
         <Room Name="ganontika_room_11" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_12" Segment="3">
+        <Texture Name="ganontika_room_12Tex_005160" OutName="ganontika_room_12Tex_005160" Format="rgba16" Width="32" Height="32" Offset="0x5260" AddedByScript="true"/>
+        <Texture Name="ganontika_room_12Tex_005960" OutName="ganontika_room_12Tex_005960" Format="ci8" Width="64" Height="32" Offset="0x5A60" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_12Tex_006160" OutName="ganontika_room_12Tex_006160" Format="ci8" Width="32" Height="64" Offset="0x6260" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_12Tex_006960" OutName="ganontika_room_12Tex_006960" Format="ci4" Width="64" Height="64" Offset="0x6A60" TlutOffset="0x5240" AddedByScript="true"/>
+        <Texture Name="ganontika_room_12Tex_007160" OutName="ganontika_room_12Tex_007160" Format="rgba16" Width="64" Height="32" Offset="0x7260" AddedByScript="true"/>
+        <Texture Name="ganontika_room_12Tex_008160" OutName="ganontika_room_12Tex_008160" Format="ci8" Width="64" Height="16" Offset="0x8260" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_12Tex_008560" OutName="ganontika_room_12Tex_008560" Format="ci8" Width="64" Height="32" Offset="0x8660" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_12Tex_009270" OutName="ganontika_room_12Tex_009270" Format="ia8" Width="64" Height="64" Offset="0x9370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_12Tex_00A270" OutName="ganontika_room_12Tex_00A270" Format="ia8" Width="32" Height="128" Offset="0xA370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_12TLUT_005140" OutName="ganontika_room_12TLUT_005140" Format="rgba16" Width="4" Height="4" Offset="0x5240" AddedByScript="true"/>
         <Room Name="ganontika_room_12" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_13" Segment="3">
+        <Texture Name="ganontika_room_13Tex_004340" OutName="ganontika_room_13Tex_004340" Format="rgba16" Width="32" Height="32" Offset="0x4340" AddedByScript="true"/>
+        <Texture Name="ganontika_room_13Tex_004B40" OutName="ganontika_room_13Tex_004B40" Format="ci8" Width="32" Height="64" Offset="0x4B40" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_13Tex_005340" OutName="ganontika_room_13Tex_005340" Format="ci8" Width="64" Height="32" Offset="0x5340" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_13Tex_005B40" OutName="ganontika_room_13Tex_005B40" Format="rgba16" Width="32" Height="32" Offset="0x5B40" AddedByScript="true"/>
+        <Texture Name="ganontika_room_13Tex_006340" OutName="ganontika_room_13Tex_006340" Format="rgba16" Width="32" Height="32" Offset="0x6340" AddedByScript="true"/>
+        <Texture Name="ganontika_room_13Tex_006B40" OutName="ganontika_room_13Tex_006B40" Format="rgba16" Width="16" Height="16" Offset="0x6B40" AddedByScript="true"/>
+        <Texture Name="ganontika_room_13Tex_006D40" OutName="ganontika_room_13Tex_006D40" Format="rgba16" Width="64" Height="32" Offset="0x6D40" AddedByScript="true"/>
         <Room Name="ganontika_room_13" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_14" Segment="3">
+        <Texture Name="ganontika_room_14Tex_004FB8" OutName="ganontika_room_14Tex_004FB8" Format="rgba16" Width="32" Height="32" Offset="0x4F88" AddedByScript="true"/>
+        <Texture Name="ganontika_room_14Tex_0057B8" OutName="ganontika_room_14Tex_0057B8" Format="ci8" Width="64" Height="32" Offset="0x5788" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_14Tex_005FB8" OutName="ganontika_room_14Tex_005FB8" Format="ci4" Width="64" Height="64" Offset="0x5F88" TlutOffset="0x4F68" AddedByScript="true"/>
+        <Texture Name="ganontika_room_14Tex_0067B8" OutName="ganontika_room_14Tex_0067B8" Format="rgba16" Width="64" Height="32" Offset="0x6788" AddedByScript="true"/>
+        <Texture Name="ganontika_room_14Tex_0077B8" OutName="ganontika_room_14Tex_0077B8" Format="ci8" Width="64" Height="16" Offset="0x7788" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_14Tex_007BB8" OutName="ganontika_room_14Tex_007BB8" Format="ci8" Width="64" Height="32" Offset="0x7B88" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_14Tex_0089C8" OutName="ganontika_room_14Tex_0089C8" Format="ia8" Width="64" Height="64" Offset="0x8998" AddedByScript="true"/>
+        <Texture Name="ganontika_room_14Tex_0099C8" OutName="ganontika_room_14Tex_0099C8" Format="rgba16" Width="32" Height="32" Offset="0x9998" AddedByScript="true"/>
+        <Texture Name="ganontika_room_14TLUT_004F98" OutName="ganontika_room_14TLUT_004F98" Format="rgba16" Width="4" Height="4" Offset="0x4F68" AddedByScript="true"/>
         <Room Name="ganontika_room_14" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_15" Segment="3">
+        <Texture Name="ganontika_room_15Tex_004340" OutName="ganontika_room_15Tex_004340" Format="rgba16" Width="32" Height="32" Offset="0x4340" AddedByScript="true"/>
+        <Texture Name="ganontika_room_15Tex_004B40" OutName="ganontika_room_15Tex_004B40" Format="ci8" Width="32" Height="64" Offset="0x4B40" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_15Tex_005340" OutName="ganontika_room_15Tex_005340" Format="ci8" Width="64" Height="32" Offset="0x5340" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_15Tex_005B40" OutName="ganontika_room_15Tex_005B40" Format="rgba16" Width="32" Height="32" Offset="0x5B40" AddedByScript="true"/>
+        <Texture Name="ganontika_room_15Tex_006340" OutName="ganontika_room_15Tex_006340" Format="rgba16" Width="32" Height="32" Offset="0x6340" AddedByScript="true"/>
+        <Texture Name="ganontika_room_15Tex_006B40" OutName="ganontika_room_15Tex_006B40" Format="rgba16" Width="16" Height="16" Offset="0x6B40" AddedByScript="true"/>
+        <Texture Name="ganontika_room_15Tex_006D40" OutName="ganontika_room_15Tex_006D40" Format="rgba16" Width="64" Height="32" Offset="0x6D40" AddedByScript="true"/>
         <Room Name="ganontika_room_15" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_16" Segment="3">
+        <Texture Name="ganontika_room_16Tex_001630" OutName="ganontika_room_16Tex_001630" Format="rgba16" Width="64" Height="32" Offset="0x1620" AddedByScript="true"/>
+        <Texture Name="ganontika_room_16Tex_002630" OutName="ganontika_room_16Tex_002630" Format="ci8" Width="64" Height="32" Offset="0x2620" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
         <Room Name="ganontika_room_16" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_17" Segment="3">
+        <Texture Name="ganontika_room_17Tex_002A18" OutName="ganontika_room_17Tex_002A18" Format="ci8" Width="32" Height="32" Offset="0x2A98" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_17Tex_002E18" OutName="ganontika_room_17Tex_002E18" Format="rgba16" Width="64" Height="32" Offset="0x2E98" AddedByScript="true"/>
+        <Texture Name="ganontika_room_17Tex_003E18" OutName="ganontika_room_17Tex_003E18" Format="rgba16" Width="64" Height="32" Offset="0x3E98" AddedByScript="true"/>
+        <Texture Name="ganontika_room_17Tex_004E18" OutName="ganontika_room_17Tex_004E18" Format="rgba16" Width="32" Height="32" Offset="0x4E98" AddedByScript="true"/>
+        <Texture Name="ganontika_room_17Tex_005618" OutName="ganontika_room_17Tex_005618" Format="rgba16" Width="32" Height="64" Offset="0x5698" AddedByScript="true"/>
+        <Texture Name="ganontika_room_17Tex_006618" OutName="ganontika_room_17Tex_006618" Format="rgba16" Width="32" Height="32" Offset="0x6698" AddedByScript="true"/>
+        <Texture Name="ganontika_room_17Tex_006E18" OutName="ganontika_room_17Tex_006E18" Format="ci8" Width="64" Height="32" Offset="0x6E98" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_17Tex_007618" OutName="ganontika_room_17Tex_007618" Format="rgba16" Width="64" Height="32" Offset="0x7698" AddedByScript="true"/>
         <Room Name="ganontika_room_17" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_18" Segment="3">
+        <Texture Name="ganontika_room_18Tex_004380" OutName="ganontika_room_18Tex_004380" Format="rgba16" Width="32" Height="64" Offset="0x4310" AddedByScript="true"/>
+        <Texture Name="ganontika_room_18Tex_005380" OutName="ganontika_room_18Tex_005380" Format="ci8" Width="32" Height="32" Offset="0x5310" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_18Tex_005780" OutName="ganontika_room_18Tex_005780" Format="rgba16" Width="64" Height="32" Offset="0x5710" AddedByScript="true"/>
+        <Texture Name="ganontika_room_18Tex_006780" OutName="ganontika_room_18Tex_006780" Format="rgba16" Width="64" Height="32" Offset="0x6710" AddedByScript="true"/>
+        <Texture Name="ganontika_room_18Tex_007780" OutName="ganontika_room_18Tex_007780" Format="rgba16" Width="32" Height="32" Offset="0x7710" AddedByScript="true"/>
+        <Texture Name="ganontika_room_18Tex_007F80" OutName="ganontika_room_18Tex_007F80" Format="rgba16" Width="32" Height="64" Offset="0x7F10" AddedByScript="true"/>
+        <Texture Name="ganontika_room_18Tex_008F80" OutName="ganontika_room_18Tex_008F80" Format="rgba16" Width="32" Height="8" Offset="0x8F10" AddedByScript="true"/>
+        <Texture Name="ganontika_room_18Tex_009180" OutName="ganontika_room_18Tex_009180" Format="rgba16" Width="32" Height="32" Offset="0x9110" AddedByScript="true"/>
+        <Texture Name="ganontika_room_18Tex_009980" OutName="ganontika_room_18Tex_009980" Format="ci4" Width="64" Height="64" Offset="0x9910" TlutOffset="0x42F0" AddedByScript="true"/>
+        <Texture Name="ganontika_room_18Tex_00A180" OutName="ganontika_room_18Tex_00A180" Format="i4" Width="32" Height="32" Offset="0xA110" AddedByScript="true"/>
+        <Texture Name="ganontika_room_18Tex_00A380" OutName="ganontika_room_18Tex_00A380" Format="rgba16" Width="64" Height="32" Offset="0xA310" AddedByScript="true"/>
+        <Texture Name="ganontika_room_18Tex_00B6E0" OutName="ganontika_room_18Tex_00B6E0" Format="ia8" Width="64" Height="64" Offset="0xB670" AddedByScript="true"/>
+        <Texture Name="ganontika_room_18TLUT_004360" OutName="ganontika_room_18TLUT_004360" Format="rgba16" Width="4" Height="4" Offset="0x42F0" AddedByScript="true"/>
         <Room Name="ganontika_room_18" Offset="0x0"/>
     </File>
     <File Name="ganontika_room_19" Segment="3">
+        <Texture Name="ganontika_room_19Tex_004340" OutName="ganontika_room_19Tex_004340" Format="rgba16" Width="32" Height="32" Offset="0x4340" AddedByScript="true"/>
+        <Texture Name="ganontika_room_19Tex_004B40" OutName="ganontika_room_19Tex_004B40" Format="ci8" Width="32" Height="64" Offset="0x4B40" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_19Tex_005340" OutName="ganontika_room_19Tex_005340" Format="ci8" Width="64" Height="32" Offset="0x5340" ExternalTlut="ganontika_scene" ExternalTlutOffset="0x1F370" AddedByScript="true"/>
+        <Texture Name="ganontika_room_19Tex_005B40" OutName="ganontika_room_19Tex_005B40" Format="rgba16" Width="32" Height="32" Offset="0x5B40" AddedByScript="true"/>
+        <Texture Name="ganontika_room_19Tex_006340" OutName="ganontika_room_19Tex_006340" Format="rgba16" Width="32" Height="32" Offset="0x6340" AddedByScript="true"/>
+        <Texture Name="ganontika_room_19Tex_006B40" OutName="ganontika_room_19Tex_006B40" Format="rgba16" Width="16" Height="16" Offset="0x6B40" AddedByScript="true"/>
+        <Texture Name="ganontika_room_19Tex_006D40" OutName="ganontika_room_19Tex_006D40" Format="rgba16" Width="64" Height="32" Offset="0x6D40" AddedByScript="true"/>
         <Room Name="ganontika_room_19" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/N64_PAL_11/scenes/dungeons/ganontikasonogo.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/dungeons/ganontikasonogo.xml
@@ -1,12 +1,36 @@
 <Root>
     <File Name="ganontikasonogo_scene" Segment="2">
+        <Texture Name="ganontikasonogo_sceneTex_002B00" OutName="ganontikasonogo_sceneTex_002B00" Format="rgba16" Width="32" Height="64" Offset="0x2B00" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_sceneTex_003B00" OutName="ganontikasonogo_sceneTex_003B00" Format="rgba16" Width="64" Height="32" Offset="0x3B00" AddedByScript="true"/>
         <Path Name="gGanonTikasongsoPath_00184" Offset="0x184" NumPaths="3"/>
         <Scene Name="ganontikasonogo_scene" Offset="0x0"/>
     </File>
     <File Name="ganontikasonogo_room_0" Segment="3">
+        <Texture Name="ganontikasonogo_room_0Tex_0092D8" OutName="ganontikasonogo_room_0Tex_0092D8" Format="rgba16" Width="64" Height="32" Offset="0x92D8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_00A2D8" OutName="ganontikasonogo_room_0Tex_00A2D8" Format="rgba16" Width="64" Height="32" Offset="0xA2D8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_00B2D8" OutName="ganontikasonogo_room_0Tex_00B2D8" Format="rgba16" Width="32" Height="64" Offset="0xB2D8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_00C2D8" OutName="ganontikasonogo_room_0Tex_00C2D8" Format="rgba16" Width="64" Height="32" Offset="0xC2D8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_00D2D8" OutName="ganontikasonogo_room_0Tex_00D2D8" Format="rgba16" Width="64" Height="32" Offset="0xD2D8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_00E2D8" OutName="ganontikasonogo_room_0Tex_00E2D8" Format="rgba16" Width="64" Height="32" Offset="0xE2D8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_00F2D8" OutName="ganontikasonogo_room_0Tex_00F2D8" Format="rgba16" Width="32" Height="32" Offset="0xF2D8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_00FAD8" OutName="ganontikasonogo_room_0Tex_00FAD8" Format="rgba16" Width="32" Height="64" Offset="0xFAD8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_010AD8" OutName="ganontikasonogo_room_0Tex_010AD8" Format="ci4" Width="64" Height="64" Offset="0x10AD8" TlutOffset="0x92B8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_0112D8" OutName="ganontikasonogo_room_0Tex_0112D8" Format="ci4" Width="64" Height="64" Offset="0x112D8" TlutOffset="0x92B8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_011AD8" OutName="ganontikasonogo_room_0Tex_011AD8" Format="ci4" Width="64" Height="64" Offset="0x11AD8" TlutOffset="0x92B8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_0122D8" OutName="ganontikasonogo_room_0Tex_0122D8" Format="ci4" Width="64" Height="64" Offset="0x122D8" TlutOffset="0x92B8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_012AD8" OutName="ganontikasonogo_room_0Tex_012AD8" Format="ci4" Width="64" Height="64" Offset="0x12AD8" TlutOffset="0x92B8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_0132D8" OutName="ganontikasonogo_room_0Tex_0132D8" Format="rgba16" Width="64" Height="32" Offset="0x132D8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_0142D8" OutName="ganontikasonogo_room_0Tex_0142D8" Format="rgba16" Width="64" Height="16" Offset="0x142D8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_014AD8" OutName="ganontikasonogo_room_0Tex_014AD8" Format="rgba16" Width="64" Height="32" Offset="0x14AD8" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0Tex_016B78" OutName="ganontikasonogo_room_0Tex_016B78" Format="ia8" Width="64" Height="64" Offset="0x16B78" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_0TLUT_0092B8" OutName="ganontikasonogo_room_0TLUT_0092B8" Format="rgba16" Width="4" Height="4" Offset="0x92B8" AddedByScript="true"/>
         <Room Name="ganontikasonogo_room_0" Offset="0x0"/>
     </File>
     <File Name="ganontikasonogo_room_1" Segment="3">
+        <Texture Name="ganontikasonogo_room_1Tex_006C60" OutName="ganontikasonogo_room_1Tex_006C60" Format="rgba16" Width="32" Height="32" Offset="0x6C60" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_1Tex_007460" OutName="ganontikasonogo_room_1Tex_007460" Format="rgba16" Width="64" Height="32" Offset="0x7460" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_1Tex_008460" OutName="ganontikasonogo_room_1Tex_008460" Format="rgba16" Width="32" Height="64" Offset="0x8460" AddedByScript="true"/>
+        <Texture Name="ganontikasonogo_room_1Tex_009720" OutName="ganontikasonogo_room_1Tex_009720" Format="ia16" Width="8" Height="128" Offset="0x9720" AddedByScript="true"/>
         <Room Name="ganontikasonogo_room_1" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/N64_PAL_11/scenes/dungeons/gerudoway.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/dungeons/gerudoway.xml
@@ -1,26 +1,55 @@
 <Root>
     <File Name="gerudoway_scene" Segment="2">
+        <Texture Name="gerudoway_sceneTex_007520" OutName="gerudoway_sceneTex_007520" Format="rgba16" Width="32" Height="64" Offset="0x7520" AddedByScript="true"/>
+        <Texture Name="gerudoway_sceneTex_008520" OutName="gerudoway_sceneTex_008520" Format="ia4" Width="128" Height="32" Offset="0x8520" AddedByScript="true"/>
+        <Texture Name="gerudoway_sceneTex_008D20" OutName="gerudoway_sceneTex_008D20" Format="ia8" Width="64" Height="32" Offset="0x8D20" AddedByScript="true"/>
+        <Texture Name="gerudoway_sceneTex_009520" OutName="gerudoway_sceneTex_009520" Format="ia8" Width="32" Height="64" Offset="0x9520" AddedByScript="true"/>
+        <Texture Name="gerudoway_sceneTex_009D20" OutName="gerudoway_sceneTex_009D20" Format="rgba16" Width="32" Height="32" Offset="0x9D20" AddedByScript="true"/>
+        <Texture Name="gerudoway_sceneTex_00A520" OutName="gerudoway_sceneTex_00A520" Format="rgba16" Width="32" Height="16" Offset="0xA520" AddedByScript="true"/>
+        <Texture Name="gerudoway_sceneTex_00A920" OutName="gerudoway_sceneTex_00A920" Format="rgba16" Width="32" Height="64" Offset="0xA920" AddedByScript="true"/>
+        <Texture Name="gerudoway_sceneTex_00C120" OutName="gerudoway_sceneTex_00C120" Format="rgba16" Width="64" Height="32" Offset="0xC120" AddedByScript="true"/>
+        <Texture Name="gerudoway_sceneTex_00D120" OutName="gerudoway_sceneTex_00D120" Format="rgba16" Width="32" Height="32" Offset="0xD120" AddedByScript="true"/>
         <Texture Name="gThievesHideoutNightEntranceTex" OutName="night_entrance" Format="ia16" Width="128" Height="4" Offset="0xB920"/>
         <Texture Name="gThievesHideoutDayEntranceTex" OutName="day_entrance" Format="ia16" Width="128" Height="4" Offset="0xBD20"/>
         <Path Name="gGerudowayPath_002AC" Offset="0x2AC" NumPaths="4"/>
         <Scene Name="gerudoway_scene" Offset="0x0"/>
     </File>
     <File Name="gerudoway_room_0" Segment="3">
+        <Texture Name="gerudoway_room_0Tex_002FB0" OutName="gerudoway_room_0Tex_002FB0" Format="rgba16" Width="64" Height="32" Offset="0x2FB0" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_0Tex_003FB0" OutName="gerudoway_room_0Tex_003FB0" Format="rgba16" Width="32" Height="16" Offset="0x3FB0" AddedByScript="true"/>
         <Room Name="gerudoway_room_0" Offset="0x0"/>
     </File>
      <File Name="gerudoway_room_1" Segment="3">
+        <Texture Name="gerudoway_room_1Tex_003710" OutName="gerudoway_room_1Tex_003710" Format="rgba16" Width="32" Height="32" Offset="0x3710" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_1Tex_003F10" OutName="gerudoway_room_1Tex_003F10" Format="ia4" Width="32" Height="128" Offset="0x3F10" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_1Tex_004710" OutName="gerudoway_room_1Tex_004710" Format="rgba16" Width="64" Height="32" Offset="0x4710" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_1Tex_005710" OutName="gerudoway_room_1Tex_005710" Format="rgba16" Width="32" Height="16" Offset="0x5710" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_1Tex_005B10" OutName="gerudoway_room_1Tex_005B10" Format="rgba16" Width="64" Height="16" Offset="0x5B10" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_1Tex_006310" OutName="gerudoway_room_1Tex_006310" Format="rgba16" Width="16" Height="64" Offset="0x6310" AddedByScript="true"/>
         <Room Name="gerudoway_room_1" Offset="0x0"/>
     </File>
      <File Name="gerudoway_room_2" Segment="3">
+        <Texture Name="gerudoway_room_2Tex_002298" OutName="gerudoway_room_2Tex_002298" Format="rgba16" Width="64" Height="16" Offset="0x2298" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_2Tex_002A98" OutName="gerudoway_room_2Tex_002A98" Format="rgba16" Width="16" Height="64" Offset="0x2A98" AddedByScript="true"/>
         <Room Name="gerudoway_room_2" Offset="0x0"/>
     </File>
      <File Name="gerudoway_room_3" Segment="3">
+        <Texture Name="gerudoway_room_3Tex_006EA0" OutName="gerudoway_room_3Tex_006EA0" Format="rgba16" Width="32" Height="32" Offset="0x6EA0" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_3Tex_0076A0" OutName="gerudoway_room_3Tex_0076A0" Format="ia4" Width="32" Height="128" Offset="0x76A0" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_3Tex_007EA0" OutName="gerudoway_room_3Tex_007EA0" Format="rgba16" Width="64" Height="32" Offset="0x7EA0" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_3Tex_008EA0" OutName="gerudoway_room_3Tex_008EA0" Format="rgba16" Width="32" Height="16" Offset="0x8EA0" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_3Tex_0092A0" OutName="gerudoway_room_3Tex_0092A0" Format="rgba16" Width="32" Height="32" Offset="0x92A0" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_3Tex_009AA0" OutName="gerudoway_room_3Tex_009AA0" Format="rgba16" Width="16" Height="64" Offset="0x9AA0" AddedByScript="true"/>
         <Room Name="gerudoway_room_3" Offset="0x0"/>
     </File>
      <File Name="gerudoway_room_4" Segment="3">
+        <Texture Name="gerudoway_room_4Tex_002028" OutName="gerudoway_room_4Tex_002028" Format="rgba16" Width="64" Height="16" Offset="0x2028" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_4Tex_002828" OutName="gerudoway_room_4Tex_002828" Format="rgba16" Width="16" Height="64" Offset="0x2828" AddedByScript="true"/>
         <Room Name="gerudoway_room_4" Offset="0x0"/>
     </File>
      <File Name="gerudoway_room_5" Segment="3">
+        <Texture Name="gerudoway_room_5Tex_002FF8" OutName="gerudoway_room_5Tex_002FF8" Format="rgba16" Width="64" Height="16" Offset="0x2FF8" AddedByScript="true"/>
+        <Texture Name="gerudoway_room_5Tex_0037F8" OutName="gerudoway_room_5Tex_0037F8" Format="rgba16" Width="16" Height="64" Offset="0x37F8" AddedByScript="true"/>
         <Room Name="gerudoway_room_5" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/N64_PAL_11/scenes/dungeons/ice_doukutu.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/dungeons/ice_doukutu.xml
@@ -1,44 +1,105 @@
 <Root>
     <File Name="ice_doukutu_scene" Segment="2">
+        <Texture Name="ice_doukutu_sceneTex_00FCC0" OutName="ice_doukutu_sceneTex_00FCC0" Format="i8" Width="32" Height="32" Offset="0xFC00" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_sceneTex_0100C0" OutName="ice_doukutu_sceneTex_0100C0" Format="rgba16" Width="32" Height="32" Offset="0x10000" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_sceneTex_0108C0" OutName="ice_doukutu_sceneTex_0108C0" Format="rgba16" Width="16" Height="16" Offset="0x10800" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_sceneTex_010AC0" OutName="ice_doukutu_sceneTex_010AC0" Format="i8" Width="32" Height="32" Offset="0x10A00" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_sceneTex_010EC0" OutName="ice_doukutu_sceneTex_010EC0" Format="rgba16" Width="32" Height="32" Offset="0x10E00" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_sceneTLUT_00F8A0" OutName="ice_doukutu_sceneTLUT_00F8A0" Format="rgba16" Width="4" Height="4" Offset="0xF7E0" AddedByScript="true"/>
         <Cutscene Name="gIceCavernSerenadeCs" Offset="0x250"/>
         <Texture Name="gIceCavernNightEntranceTex" OutName="night_entrance" Format="ia16" Width="64" Height="4" Offset="0xF800"/>
         <Texture Name="gIceCavernDayEntranceTex" OutName="day_entrance" Format="ia16" Width="64" Height="4" Offset="0xFA00"/>
         <Scene Name="ice_doukutu_scene" Offset="0x0"/>
     </File>
     <File Name="ice_doukutu_room_0" Segment="3">
+        <Texture Name="ice_doukutu_room_0Tex_002F50" OutName="ice_doukutu_room_0Tex_002F50" Format="rgba16" Width="32" Height="64" Offset="0x2F30" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_0Tex_003F50" OutName="ice_doukutu_room_0Tex_003F50" Format="rgba16" Width="32" Height="32" Offset="0x3F30" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_0Tex_004750" OutName="ice_doukutu_room_0Tex_004750" Format="rgba16" Width="32" Height="64" Offset="0x4730" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_0Tex_005750" OutName="ice_doukutu_room_0Tex_005750" Format="rgba16" Width="32" Height="32" Offset="0x5730" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_0Tex_005F50" OutName="ice_doukutu_room_0Tex_005F50" Format="i8" Width="64" Height="64" Offset="0x5F30" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_0Tex_007678" OutName="ice_doukutu_room_0Tex_007678" Format="i8" Width="64" Height="64" Offset="0x7658" AddedByScript="true"/>
         <Room Name="ice_doukutu_room_0" Offset="0x0"/>
     </File>
     <File Name="ice_doukutu_room_1" Segment="3">
+        <Texture Name="ice_doukutu_room_1Tex_004110" OutName="ice_doukutu_room_1Tex_004110" Format="rgba16" Width="32" Height="64" Offset="0x4120" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_1Tex_005110" OutName="ice_doukutu_room_1Tex_005110" Format="rgba16" Width="32" Height="32" Offset="0x5120" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_1Tex_005910" OutName="ice_doukutu_room_1Tex_005910" Format="rgba16" Width="32" Height="64" Offset="0x5920" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_1Tex_006910" OutName="ice_doukutu_room_1Tex_006910" Format="rgba16" Width="32" Height="32" Offset="0x6920" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_1Tex_007110" OutName="ice_doukutu_room_1Tex_007110" Format="rgba16" Width="32" Height="64" Offset="0x7120" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_1Tex_008110" OutName="ice_doukutu_room_1Tex_008110" Format="i8" Width="64" Height="64" Offset="0x8120" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_1Tex_009110" OutName="ice_doukutu_room_1Tex_009110" Format="rgba16" Width="32" Height="32" Offset="0x9120" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_1Tex_00AB30" OutName="ice_doukutu_room_1Tex_00AB30" Format="rgba16" Width="32" Height="64" Offset="0xAB40" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_1Tex_00BB30" OutName="ice_doukutu_room_1Tex_00BB30" Format="rgba16" Width="16" Height="16" Offset="0xBB40" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_1Tex_00BD30" OutName="ice_doukutu_room_1Tex_00BD30" Format="rgba16" Width="32" Height="32" Offset="0xBD40" AddedByScript="true"/>
         <Room Name="ice_doukutu_room_1" Offset="0x0"/>
     </File>
     <File Name="ice_doukutu_room_2" Segment="3">
+        <Texture Name="ice_doukutu_room_2Tex_001730" OutName="ice_doukutu_room_2Tex_001730" Format="rgba16" Width="32" Height="64" Offset="0x1720" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_2Tex_002730" OutName="ice_doukutu_room_2Tex_002730" Format="ci4" Width="64" Height="64" Offset="0x2720" ExternalTlut="ice_doukutu_scene" ExternalTlutOffset="0xF7E0" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_2Tex_003AF8" OutName="ice_doukutu_room_2Tex_003AF8" Format="i8" Width="64" Height="64" Offset="0x3AE8" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_2Tex_004AF8" OutName="ice_doukutu_room_2Tex_004AF8" Format="rgba16" Width="32" Height="64" Offset="0x4AE8" AddedByScript="true"/>
         <Room Name="ice_doukutu_room_2" Offset="0x0"/>
     </File>
     <File Name="ice_doukutu_room_3" Segment="3">
+        <Texture Name="ice_doukutu_room_3Tex_003208" OutName="ice_doukutu_room_3Tex_003208" Format="rgba16" Width="32" Height="32" Offset="0x31F8" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_3Tex_003A08" OutName="ice_doukutu_room_3Tex_003A08" Format="ci4" Width="64" Height="64" Offset="0x39F8" ExternalTlut="ice_doukutu_scene" ExternalTlutOffset="0xF7E0" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_3Tex_005090" OutName="ice_doukutu_room_3Tex_005090" Format="i8" Width="64" Height="64" Offset="0x5080" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_3Tex_006090" OutName="ice_doukutu_room_3Tex_006090" Format="rgba16" Width="32" Height="64" Offset="0x6080" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_3Tex_007090" OutName="ice_doukutu_room_3Tex_007090" Format="i8" Width="32" Height="128" Offset="0x7080" AddedByScript="true"/>
         <Room Name="ice_doukutu_room_3" Offset="0x0"/>
     </File>
     <File Name="ice_doukutu_room_4" Segment="3">
+        <Texture Name="ice_doukutu_room_4Tex_0028E0" OutName="ice_doukutu_room_4Tex_0028E0" Format="rgba16" Width="32" Height="32" Offset="0x2900" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_4Tex_0030E0" OutName="ice_doukutu_room_4Tex_0030E0" Format="rgba16" Width="32" Height="32" Offset="0x3100" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_4Tex_0038E0" OutName="ice_doukutu_room_4Tex_0038E0" Format="ci4" Width="64" Height="64" Offset="0x3900" ExternalTlut="ice_doukutu_scene" ExternalTlutOffset="0xF7E0" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_4Tex_004650" OutName="ice_doukutu_room_4Tex_004650" Format="i8" Width="64" Height="64" Offset="0x4670" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_4Tex_005650" OutName="ice_doukutu_room_4Tex_005650" Format="rgba16" Width="32" Height="64" Offset="0x5670" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_4Tex_006650" OutName="ice_doukutu_room_4Tex_006650" Format="i8" Width="32" Height="128" Offset="0x6670" AddedByScript="true"/>
         <Room Name="ice_doukutu_room_4" Offset="0x0"/>
     </File>
     <File Name="ice_doukutu_room_5" Segment="3">
+        <Texture Name="ice_doukutu_room_5Tex_004648" OutName="ice_doukutu_room_5Tex_004648" Format="rgba16" Width="16" Height="128" Offset="0x4658" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_5Tex_005648" OutName="ice_doukutu_room_5Tex_005648" Format="rgba16" Width="32" Height="32" Offset="0x5658" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_5Tex_005E48" OutName="ice_doukutu_room_5Tex_005E48" Format="rgba16" Width="32" Height="32" Offset="0x5E58" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_5Tex_006648" OutName="ice_doukutu_room_5Tex_006648" Format="rgba16" Width="32" Height="32" Offset="0x6658" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_5Tex_007478" OutName="ice_doukutu_room_5Tex_007478" Format="i8" Width="32" Height="32" Offset="0x7488" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_5Tex_007878" OutName="ice_doukutu_room_5Tex_007878" Format="i8" Width="64" Height="64" Offset="0x7888" AddedByScript="true"/>
         <Room Name="ice_doukutu_room_5" Offset="0x0"/>
     </File>
     <File Name="ice_doukutu_room_6" Segment="3">
+        <Texture Name="ice_doukutu_room_6Tex_0029B0" OutName="ice_doukutu_room_6Tex_0029B0" Format="i8" Width="64" Height="64" Offset="0x2A60" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_6Tex_0039B0" OutName="ice_doukutu_room_6Tex_0039B0" Format="rgba16" Width="32" Height="32" Offset="0x3A60" AddedByScript="true"/>
         <Room Name="ice_doukutu_room_6" Offset="0x0"/>
     </File>
     <File Name="ice_doukutu_room_7" Segment="3">
+        <Texture Name="ice_doukutu_room_7Tex_001758" OutName="ice_doukutu_room_7Tex_001758" Format="ci4" Width="64" Height="64" Offset="0x1758" ExternalTlut="ice_doukutu_scene" ExternalTlutOffset="0xF7E0" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_7Tex_0040E8" OutName="ice_doukutu_room_7Tex_0040E8" Format="i8" Width="64" Height="64" Offset="0x40E8" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_7Tex_0050E8" OutName="ice_doukutu_room_7Tex_0050E8" Format="rgba16" Width="32" Height="32" Offset="0x50E8" AddedByScript="true"/>
         <Room Name="ice_doukutu_room_7" Offset="0x0"/>
     </File>
     <File Name="ice_doukutu_room_8" Segment="3">
         <Room Name="ice_doukutu_room_8" Offset="0x0"/>
     </File>
     <File Name="ice_doukutu_room_9" Segment="3">
+        <Texture Name="ice_doukutu_room_9Tex_0044A0" OutName="ice_doukutu_room_9Tex_0044A0" Format="rgba16" Width="32" Height="64" Offset="0x4460" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_9Tex_0054A0" OutName="ice_doukutu_room_9Tex_0054A0" Format="rgba16" Width="32" Height="32" Offset="0x5460" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_9Tex_005CA0" OutName="ice_doukutu_room_9Tex_005CA0" Format="rgba16" Width="32" Height="32" Offset="0x5C60" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_9Tex_0064A0" OutName="ice_doukutu_room_9Tex_0064A0" Format="rgba16" Width="32" Height="32" Offset="0x6460" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_9Tex_006CA0" OutName="ice_doukutu_room_9Tex_006CA0" Format="rgba16" Width="32" Height="32" Offset="0x6C60" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_9Tex_007690" OutName="ice_doukutu_room_9Tex_007690" Format="rgba16" Width="32" Height="64" Offset="0x7650" AddedByScript="true"/>
         <Room Name="ice_doukutu_room_9" Offset="0x0"/>
     </File>
     <File Name="ice_doukutu_room_10" Segment="3">
+        <Texture Name="ice_doukutu_room_10Tex_001A28" OutName="ice_doukutu_room_10Tex_001A28" Format="rgba16" Width="32" Height="64" Offset="0x1A28" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_10Tex_002A28" OutName="ice_doukutu_room_10Tex_002A28" Format="i8" Width="64" Height="64" Offset="0x2A28" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_10Tex_003BD8" OutName="ice_doukutu_room_10Tex_003BD8" Format="rgba16" Width="32" Height="32" Offset="0x3BD8" AddedByScript="true"/>
         <Room Name="ice_doukutu_room_10" Offset="0x0"/>
     </File>
     <File Name="ice_doukutu_room_11" Segment="3">
+        <Texture Name="ice_doukutu_room_11Tex_002928" OutName="ice_doukutu_room_11Tex_002928" Format="rgba16" Width="32" Height="32" Offset="0x29D8" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_11Tex_003128" OutName="ice_doukutu_room_11Tex_003128" Format="rgba16" Width="32" Height="32" Offset="0x31D8" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_11Tex_003928" OutName="ice_doukutu_room_11Tex_003928" Format="rgba16" Width="32" Height="32" Offset="0x39D8" AddedByScript="true"/>
+        <Texture Name="ice_doukutu_room_11Tex_004848" OutName="ice_doukutu_room_11Tex_004848" Format="i8" Width="64" Height="64" Offset="0x48F8" AddedByScript="true"/>
         <Room Name="ice_doukutu_room_11" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/N64_PAL_11/scenes/dungeons/jyasinboss.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/dungeons/jyasinboss.xml
@@ -1,19 +1,49 @@
 <Root>
     <File Name="jyasinboss_scene" Segment="2">
+        <Texture Name="jyasinboss_sceneTex_006CF0" OutName="jyasinboss_sceneTex_006CF0" Format="rgba16" Width="64" Height="32" Offset="0x6CF0" AddedByScript="true"/>
+        <Texture Name="jyasinboss_sceneTex_007CF0" OutName="jyasinboss_sceneTex_007CF0" Format="rgba16" Width="64" Height="32" Offset="0x7CF0" AddedByScript="true"/>
         <Cutscene Name="gSpiritBossNabooruKnuckleIntroCs" Offset="0x2BB0"/>
         <Cutscene Name="gSpiritBossNabooruKnuckleDefeatCs" Offset="0x3F80"/>
         <Scene Name="jyasinboss_scene" Offset="0x0"/>
     </File>
     <File Name="jyasinboss_room_0" Segment="3">
+        <Texture Name="jyasinboss_room_0Tex_0007C8" OutName="jyasinboss_room_0Tex_0007C8" Format="rgba16" Width="32" Height="32" Offset="0x7C8" AddedByScript="true"/>
         <Room Name="jyasinboss_room_0" Offset="0x0"/>
     </File>
     <File Name="jyasinboss_room_1" Segment="3">
+        <Texture Name="jyasinboss_room_1Tex_002E38" OutName="jyasinboss_room_1Tex_002E38" Format="rgba16" Width="64" Height="32" Offset="0x2E38" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_1Tex_003E38" OutName="jyasinboss_room_1Tex_003E38" Format="rgba16" Width="64" Height="32" Offset="0x3E38" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_1Tex_004E38" OutName="jyasinboss_room_1Tex_004E38" Format="rgba16" Width="32" Height="32" Offset="0x4E38" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_1Tex_005638" OutName="jyasinboss_room_1Tex_005638" Format="rgba16" Width="64" Height="32" Offset="0x5638" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_1Tex_006638" OutName="jyasinboss_room_1Tex_006638" Format="rgba16" Width="64" Height="16" Offset="0x6638" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_1Tex_006E38" OutName="jyasinboss_room_1Tex_006E38" Format="ci4" Width="64" Height="64" Offset="0x6E38" TlutOffset="0x2E18" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_1Tex_007638" OutName="jyasinboss_room_1Tex_007638" Format="rgba16" Width="32" Height="32" Offset="0x7638" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_1TLUT_002E18" OutName="jyasinboss_room_1TLUT_002E18" Format="rgba16" Width="4" Height="4" Offset="0x2E18" AddedByScript="true"/>
         <Room Name="jyasinboss_room_1" Offset="0x0"/>
     </File>
     <File Name="jyasinboss_room_2" Segment="3">
+        <Texture Name="jyasinboss_room_2Tex_0021C0" OutName="jyasinboss_room_2Tex_0021C0" Format="rgba16" Width="64" Height="16" Offset="0x21C0" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_2Tex_0029C0" OutName="jyasinboss_room_2Tex_0029C0" Format="rgba16" Width="32" Height="64" Offset="0x29C0" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_2Tex_0039C0" OutName="jyasinboss_room_2Tex_0039C0" Format="rgba16" Width="16" Height="32" Offset="0x39C0" AddedByScript="true"/>
         <Room Name="jyasinboss_room_2" Offset="0x0"/>
     </File>
     <File Name="jyasinboss_room_3" Segment="3">
+        <Texture Name="jyasinboss_room_3Tex_003F00" OutName="jyasinboss_room_3Tex_003F00" Format="ci8" Width="32" Height="32" Offset="0x3F00" TlutOffset="0x3CE0" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3Tex_004300" OutName="jyasinboss_room_3Tex_004300" Format="ci8" Width="32" Height="32" Offset="0x4300" TlutOffset="0x3CE0" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3Tex_004700" OutName="jyasinboss_room_3Tex_004700" Format="ci8" Width="64" Height="32" Offset="0x4700" TlutOffset="0x3CE0" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3Tex_004F00" OutName="jyasinboss_room_3Tex_004F00" Format="ci8" Width="32" Height="32" Offset="0x4F00" TlutOffset="0x3CE0" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3Tex_005300" OutName="jyasinboss_room_3Tex_005300" Format="ci8" Width="32" Height="32" Offset="0x5300" TlutOffset="0x3CE0" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3Tex_005700" OutName="jyasinboss_room_3Tex_005700" Format="ci8" Width="32" Height="64" Offset="0x5700" TlutOffset="0x3CE0" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3Tex_005F00" OutName="jyasinboss_room_3Tex_005F00" Format="rgba16" Width="32" Height="32" Offset="0x5F00" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3Tex_006700" OutName="jyasinboss_room_3Tex_006700" Format="rgba16" Width="64" Height="32" Offset="0x6700" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3Tex_007700" OutName="jyasinboss_room_3Tex_007700" Format="rgba16" Width="32" Height="32" Offset="0x7700" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3Tex_007F00" OutName="jyasinboss_room_3Tex_007F00" Format="rgba16" Width="16" Height="128" Offset="0x7F00" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3Tex_008F00" OutName="jyasinboss_room_3Tex_008F00" Format="rgba16" Width="64" Height="32" Offset="0x8F00" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3Tex_009F00" OutName="jyasinboss_room_3Tex_009F00" Format="ci4" Width="64" Height="64" Offset="0x9F00" TlutOffset="0x3EE0" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3Tex_00A700" OutName="jyasinboss_room_3Tex_00A700" Format="rgba16" Width="32" Height="32" Offset="0xA700" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3Tex_00AF00" OutName="jyasinboss_room_3Tex_00AF00" Format="rgba16" Width="32" Height="32" Offset="0xAF00" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3TLUT_003CE0" OutName="jyasinboss_room_3TLUT_003CE0" Format="rgba16" Width="16" Height="16" Offset="0x3CE0" AddedByScript="true"/>
+        <Texture Name="jyasinboss_room_3TLUT_003EE0" OutName="jyasinboss_room_3TLUT_003EE0" Format="rgba16" Width="4" Height="4" Offset="0x3EE0" AddedByScript="true"/>
         <Room Name="jyasinboss_room_3" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/N64_PAL_11/scenes/dungeons/jyasinzou.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/dungeons/jyasinzou.xml
@@ -1,95 +1,358 @@
 <Root>
     <File Name="jyasinzou_scene" Segment="2">
+        <Texture Name="jyasinzou_sceneTex_018820" OutName="jyasinzou_sceneTex_018820" Format="ci8" Width="16" Height="16" Offset="0x18840" TlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_sceneTex_019120" OutName="jyasinzou_sceneTex_019120" Format="rgba16" Width="16" Height="16" Offset="0x19140" AddedByScript="true"/>
+        <Texture Name="jyasinzou_sceneTex_019320" OutName="jyasinzou_sceneTex_019320" Format="ci4" Width="64" Height="64" Offset="0x19340" TlutOffset="0x18020" AddedByScript="true"/>
+        <Texture Name="jyasinzou_sceneTLUT_017BE0" OutName="jyasinzou_sceneTLUT_017BE0" Format="rgba16" Width="16" Height="16" Offset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_sceneTLUT_017DE0" OutName="jyasinzou_sceneTLUT_017DE0" Format="rgba16" Width="16" Height="16" Offset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_sceneTLUT_017FE0" OutName="jyasinzou_sceneTLUT_017FE0" Format="rgba16" Width="4" Height="4" Offset="0x18000" AddedByScript="true"/>
+        <Texture Name="jyasinzou_sceneTLUT_018000" OutName="jyasinzou_sceneTLUT_018000" Format="rgba16" Width="4" Height="4" Offset="0x18020" AddedByScript="true"/>
         <Path Name="gSpiritTemplePath_004C0" Offset="0x4C0" NumPaths="6"/>
         <Texture Name="gSpiritTempleDayEntranceTex" OutName="day_entrance" Format="ia16" Width="8" Height="128" Offset="0x18940"/>
         <Texture Name="gSpiritTempleNightEntranceTex" OutName="night_entrance" Format="ia16" Width="8" Height="128" Offset="0x18040"/>
         <Scene Name="jyasinzou_scene" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_0" Segment="3">
+        <Texture Name="jyasinzou_room_0Tex_00A9D8" OutName="jyasinzou_room_0Tex_00A9D8" Format="ci8" Width="64" Height="32" Offset="0xA928" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_0Tex_00B1D8" OutName="jyasinzou_room_0Tex_00B1D8" Format="ci8" Width="64" Height="32" Offset="0xB128" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_0Tex_00B9D8" OutName="jyasinzou_room_0Tex_00B9D8" Format="ci8" Width="32" Height="64" Offset="0xB928" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_0Tex_00C1D8" OutName="jyasinzou_room_0Tex_00C1D8" Format="ci8" Width="32" Height="64" Offset="0xC128" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_0Tex_00C9D8" OutName="jyasinzou_room_0Tex_00C9D8" Format="ci8" Width="32" Height="64" Offset="0xC928" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_0Tex_00D1D8" OutName="jyasinzou_room_0Tex_00D1D8" Format="ci8" Width="32" Height="32" Offset="0xD128" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_0Tex_00D5D8" OutName="jyasinzou_room_0Tex_00D5D8" Format="ci8" Width="16" Height="128" Offset="0xD528" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_0Tex_00DDD8" OutName="jyasinzou_room_0Tex_00DDD8" Format="ci8" Width="32" Height="32" Offset="0xDD28" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_0Tex_00E1D8" OutName="jyasinzou_room_0Tex_00E1D8" Format="ci8" Width="64" Height="32" Offset="0xE128" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_0Tex_00E9D8" OutName="jyasinzou_room_0Tex_00E9D8" Format="ci8" Width="64" Height="32" Offset="0xE928" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_0Tex_00F1D8" OutName="jyasinzou_room_0Tex_00F1D8" Format="ci4" Width="64" Height="64" Offset="0xF128" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18000" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_0Tex_00F9D8" OutName="jyasinzou_room_0Tex_00F9D8" Format="ci4" Width="64" Height="64" Offset="0xF928" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_0Tex_0107E8" OutName="jyasinzou_room_0Tex_0107E8" Format="ia8" Width="64" Height="32" Offset="0x10738" AddedByScript="true"/>
         <Room Name="jyasinzou_room_0" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_1" Segment="3">
+        <Texture Name="jyasinzou_room_1Tex_004F48" OutName="jyasinzou_room_1Tex_004F48" Format="ci8" Width="64" Height="32" Offset="0x4EF8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_1Tex_005748" OutName="jyasinzou_room_1Tex_005748" Format="ci8" Width="32" Height="64" Offset="0x56F8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_1Tex_005F48" OutName="jyasinzou_room_1Tex_005F48" Format="ci8" Width="32" Height="64" Offset="0x5EF8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_1Tex_006748" OutName="jyasinzou_room_1Tex_006748" Format="ci8" Width="32" Height="32" Offset="0x66F8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_1Tex_006B48" OutName="jyasinzou_room_1Tex_006B48" Format="ci8" Width="32" Height="64" Offset="0x6AF8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_1Tex_007348" OutName="jyasinzou_room_1Tex_007348" Format="ci8" Width="64" Height="32" Offset="0x72F8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_1Tex_007B48" OutName="jyasinzou_room_1Tex_007B48" Format="ci8" Width="64" Height="32" Offset="0x7AF8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_1Tex_008348" OutName="jyasinzou_room_1Tex_008348" Format="ci4" Width="64" Height="64" Offset="0x82F8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18000" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_1Tex_008B48" OutName="jyasinzou_room_1Tex_008B48" Format="ci4" Width="64" Height="64" Offset="0x8AF8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
         <Room Name="jyasinzou_room_1" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_2" Segment="3">
+        <Texture Name="jyasinzou_room_2Tex_0023B0" OutName="jyasinzou_room_2Tex_0023B0" Format="rgba16" Width="32" Height="64" Offset="0x2410" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_2Tex_0033B0" OutName="jyasinzou_room_2Tex_0033B0" Format="ci8" Width="64" Height="32" Offset="0x3410" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_2Tex_003BB0" OutName="jyasinzou_room_2Tex_003BB0" Format="rgba16" Width="16" Height="32" Offset="0x3C10" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_2Tex_003FB0" OutName="jyasinzou_room_2Tex_003FB0" Format="rgba16" Width="32" Height="32" Offset="0x4010" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_2Tex_0047B0" OutName="jyasinzou_room_2Tex_0047B0" Format="ci8" Width="32" Height="32" Offset="0x4810" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_2Tex_004BB0" OutName="jyasinzou_room_2Tex_004BB0" Format="ci8" Width="64" Height="32" Offset="0x4C10" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_2Tex_0053B0" OutName="jyasinzou_room_2Tex_0053B0" Format="ci4" Width="64" Height="64" Offset="0x5410" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
         <Room Name="jyasinzou_room_2" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_3" Segment="3">
+        <Texture Name="jyasinzou_room_3Tex_001FC8" OutName="jyasinzou_room_3Tex_001FC8" Format="ci8" Width="32" Height="32" Offset="0x1F48" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_3Tex_0023C8" OutName="jyasinzou_room_3Tex_0023C8" Format="ci8" Width="64" Height="32" Offset="0x2348" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_3Tex_002BC8" OutName="jyasinzou_room_3Tex_002BC8" Format="ci4" Width="64" Height="64" Offset="0x2B48" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18000" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_3Tex_0033C8" OutName="jyasinzou_room_3Tex_0033C8" Format="ci4" Width="64" Height="64" Offset="0x3348" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
         <Room Name="jyasinzou_room_3" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_4" Segment="3">
+        <Texture Name="jyasinzou_room_4Tex_003698" OutName="jyasinzou_room_4Tex_003698" Format="ci8" Width="32" Height="64" Offset="0x3688" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_4Tex_003E98" OutName="jyasinzou_room_4Tex_003E98" Format="ci8" Width="32" Height="64" Offset="0x3E88" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_4Tex_004698" OutName="jyasinzou_room_4Tex_004698" Format="ci8" Width="32" Height="64" Offset="0x4688" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_4Tex_004E98" OutName="jyasinzou_room_4Tex_004E98" Format="ci8" Width="64" Height="32" Offset="0x4E88" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_4Tex_005698" OutName="jyasinzou_room_4Tex_005698" Format="ci8" Width="16" Height="16" Offset="0x5688" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_4Tex_005798" OutName="jyasinzou_room_4Tex_005798" Format="ci8" Width="32" Height="32" Offset="0x5788" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_4Tex_005B98" OutName="jyasinzou_room_4Tex_005B98" Format="ci8" Width="64" Height="32" Offset="0x5B88" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_4Tex_006398" OutName="jyasinzou_room_4Tex_006398" Format="ci8" Width="32" Height="32" Offset="0x6388" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_4Tex_006798" OutName="jyasinzou_room_4Tex_006798" Format="ci4" Width="64" Height="64" Offset="0x6788" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
         <Room Name="jyasinzou_room_4" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_5" Segment="3">
+        <Texture Name="jyasinzou_room_5Tex_00CBC8" OutName="jyasinzou_room_5Tex_00CBC8" Format="ci8" Width="32" Height="32" Offset="0xCAF8" TlutOffset="0xC8E0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_00CFC8" OutName="jyasinzou_room_5Tex_00CFC8" Format="ci8" Width="64" Height="32" Offset="0xCEF8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_00D7C8" OutName="jyasinzou_room_5Tex_00D7C8" Format="ci8" Width="16" Height="64" Offset="0xD6F8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_00DBC8" OutName="jyasinzou_room_5Tex_00DBC8" Format="ci8" Width="32" Height="32" Offset="0xDAF8" TlutOffset="0xC8E0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_00DFC8" OutName="jyasinzou_room_5Tex_00DFC8" Format="ci8" Width="64" Height="32" Offset="0xDEF8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_00E7C8" OutName="jyasinzou_room_5Tex_00E7C8" Format="rgba16" Width="32" Height="32" Offset="0xE6F8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_00EFC8" OutName="jyasinzou_room_5Tex_00EFC8" Format="rgba16" Width="32" Height="16" Offset="0xEEF8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_00F3C8" OutName="jyasinzou_room_5Tex_00F3C8" Format="ci8" Width="32" Height="32" Offset="0xF2F8" TlutOffset="0xC8E0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_00F7C8" OutName="jyasinzou_room_5Tex_00F7C8" Format="ci8" Width="32" Height="64" Offset="0xF6F8" TlutOffset="0xC8E0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_00FFC8" OutName="jyasinzou_room_5Tex_00FFC8" Format="ci8" Width="16" Height="16" Offset="0xFEF8" TlutOffset="0xC8E0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_0100C8" OutName="jyasinzou_room_5Tex_0100C8" Format="ci8" Width="64" Height="32" Offset="0xFFF8" TlutOffset="0xC8E0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_0108C8" OutName="jyasinzou_room_5Tex_0108C8" Format="ci8" Width="32" Height="32" Offset="0x107F8" TlutOffset="0xC8E0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_010CC8" OutName="jyasinzou_room_5Tex_010CC8" Format="ci8" Width="32" Height="32" Offset="0x10BF8" TlutOffset="0xC8E0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_0110C8" OutName="jyasinzou_room_5Tex_0110C8" Format="ci8" Width="32" Height="32" Offset="0x10FF8" TlutOffset="0xC8E0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_0114C8" OutName="jyasinzou_room_5Tex_0114C8" Format="ci8" Width="32" Height="32" Offset="0x113F8" TlutOffset="0xC8E0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_0118C8" OutName="jyasinzou_room_5Tex_0118C8" Format="ci8" Width="32" Height="32" Offset="0x117F8" TlutOffset="0xC8E0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_011CC8" OutName="jyasinzou_room_5Tex_011CC8" Format="ci4" Width="32" Height="128" Offset="0x11BF8" TlutOffset="0xCAD8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_0124C8" OutName="jyasinzou_room_5Tex_0124C8" Format="ci8" Width="32" Height="64" Offset="0x123F8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_012CC8" OutName="jyasinzou_room_5Tex_012CC8" Format="ci8" Width="64" Height="32" Offset="0x12BF8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_0134C8" OutName="jyasinzou_room_5Tex_0134C8" Format="ci8" Width="32" Height="32" Offset="0x133F8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_0138C8" OutName="jyasinzou_room_5Tex_0138C8" Format="ci8" Width="32" Height="64" Offset="0x137F8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_0140C8" OutName="jyasinzou_room_5Tex_0140C8" Format="ci8" Width="64" Height="32" Offset="0x13FF8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_0148C8" OutName="jyasinzou_room_5Tex_0148C8" Format="ci8" Width="64" Height="32" Offset="0x147F8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_0150C8" OutName="jyasinzou_room_5Tex_0150C8" Format="ci4" Width="64" Height="64" Offset="0x14FF8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18000" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_0158C8" OutName="jyasinzou_room_5Tex_0158C8" Format="ci8" Width="32" Height="32" Offset="0x157F8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_015CC8" OutName="jyasinzou_room_5Tex_015CC8" Format="ci4" Width="64" Height="64" Offset="0x15BF8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_016808" OutName="jyasinzou_room_5Tex_016808" Format="ia8" Width="64" Height="32" Offset="0x16738" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5Tex_017008" OutName="jyasinzou_room_5Tex_017008" Format="rgba16" Width="32" Height="64" Offset="0x16F38" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5TLUT_00C9B0" OutName="jyasinzou_room_5TLUT_00C9B0" Format="rgba16" Width="16" Height="16" Offset="0xC8E0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_5TLUT_00CBA8" OutName="jyasinzou_room_5TLUT_00CBA8" Format="rgba16" Width="4" Height="4" Offset="0xCAD8" AddedByScript="true"/>
         <Room Name="jyasinzou_room_5" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_6" Segment="3">
+        <Texture Name="jyasinzou_room_6Tex_002BE8" OutName="jyasinzou_room_6Tex_002BE8" Format="ci8" Width="64" Height="32" Offset="0x2BF8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_6Tex_0033E8" OutName="jyasinzou_room_6Tex_0033E8" Format="ci8" Width="32" Height="32" Offset="0x33F8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_6Tex_0037E8" OutName="jyasinzou_room_6Tex_0037E8" Format="ci8" Width="64" Height="32" Offset="0x37F8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_6Tex_003FE8" OutName="jyasinzou_room_6Tex_003FE8" Format="ci8" Width="64" Height="32" Offset="0x3FF8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
         <Room Name="jyasinzou_room_6" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_7" Segment="3">
+        <Texture Name="jyasinzou_room_7Tex_002908" OutName="jyasinzou_room_7Tex_002908" Format="rgba16" Width="32" Height="64" Offset="0x2908" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_7Tex_003908" OutName="jyasinzou_room_7Tex_003908" Format="ci8" Width="64" Height="32" Offset="0x3908" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_7Tex_004108" OutName="jyasinzou_room_7Tex_004108" Format="ci8" Width="64" Height="32" Offset="0x4108" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_7Tex_004908" OutName="jyasinzou_room_7Tex_004908" Format="rgba16" Width="16" Height="32" Offset="0x4908" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_7Tex_004D08" OutName="jyasinzou_room_7Tex_004D08" Format="ci4" Width="64" Height="64" Offset="0x4D08" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
         <Room Name="jyasinzou_room_7" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_8" Segment="3">
+        <Texture Name="jyasinzou_room_8Tex_003A50" OutName="jyasinzou_room_8Tex_003A50" Format="ci8" Width="64" Height="32" Offset="0x3A10" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_8Tex_004250" OutName="jyasinzou_room_8Tex_004250" Format="ci8" Width="64" Height="32" Offset="0x4210" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_8Tex_004A50" OutName="jyasinzou_room_8Tex_004A50" Format="ci8" Width="32" Height="32" Offset="0x4A10" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_8Tex_004E50" OutName="jyasinzou_room_8Tex_004E50" Format="rgba16" Width="32" Height="32" Offset="0x4E10" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_8Tex_005650" OutName="jyasinzou_room_8Tex_005650" Format="ci8" Width="32" Height="64" Offset="0x5610" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_8Tex_005E50" OutName="jyasinzou_room_8Tex_005E50" Format="ci8" Width="32" Height="32" Offset="0x5E10" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_8Tex_006250" OutName="jyasinzou_room_8Tex_006250" Format="ci8" Width="32" Height="64" Offset="0x6210" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_8Tex_006A50" OutName="jyasinzou_room_8Tex_006A50" Format="ci8" Width="64" Height="32" Offset="0x6A10" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_8Tex_007250" OutName="jyasinzou_room_8Tex_007250" Format="ci4" Width="64" Height="64" Offset="0x7210" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
         <Room Name="jyasinzou_room_8" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_9" Segment="3">
+        <Texture Name="jyasinzou_room_9Tex_002DC8" OutName="jyasinzou_room_9Tex_002DC8" Format="rgba16" Width="32" Height="64" Offset="0x2DE8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_9Tex_003DC8" OutName="jyasinzou_room_9Tex_003DC8" Format="ci8" Width="64" Height="32" Offset="0x3DE8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_9Tex_0045C8" OutName="jyasinzou_room_9Tex_0045C8" Format="ci8" Width="64" Height="32" Offset="0x45E8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_9Tex_004DC8" OutName="jyasinzou_room_9Tex_004DC8" Format="rgba16" Width="16" Height="32" Offset="0x4DE8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_9Tex_0051C8" OutName="jyasinzou_room_9Tex_0051C8" Format="ci8" Width="64" Height="16" Offset="0x51E8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_9Tex_0055C8" OutName="jyasinzou_room_9Tex_0055C8" Format="ci8" Width="64" Height="32" Offset="0x55E8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
         <Room Name="jyasinzou_room_9" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_10" Segment="3">
+        <Texture Name="jyasinzou_room_10Tex_0031A0" OutName="jyasinzou_room_10Tex_0031A0" Format="rgba16" Width="32" Height="64" Offset="0x31A0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_10Tex_0041A0" OutName="jyasinzou_room_10Tex_0041A0" Format="ci8" Width="64" Height="32" Offset="0x41A0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_10Tex_0049A0" OutName="jyasinzou_room_10Tex_0049A0" Format="ci8" Width="64" Height="32" Offset="0x49A0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_10Tex_0051A0" OutName="jyasinzou_room_10Tex_0051A0" Format="ci8" Width="64" Height="32" Offset="0x51A0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_10Tex_0059A0" OutName="jyasinzou_room_10Tex_0059A0" Format="rgba16" Width="16" Height="32" Offset="0x59A0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_10Tex_005DA0" OutName="jyasinzou_room_10Tex_005DA0" Format="ci8" Width="64" Height="32" Offset="0x5DA0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_10Tex_0065A0" OutName="jyasinzou_room_10Tex_0065A0" Format="ci8" Width="32" Height="32" Offset="0x65A0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_10Tex_0069A0" OutName="jyasinzou_room_10Tex_0069A0" Format="rgba16" Width="64" Height="32" Offset="0x69A0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_10Tex_0079A0" OutName="jyasinzou_room_10Tex_0079A0" Format="ci8" Width="64" Height="16" Offset="0x79A0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_10Tex_007DA0" OutName="jyasinzou_room_10Tex_007DA0" Format="ci8" Width="32" Height="32" Offset="0x7DA0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
         <Room Name="jyasinzou_room_10" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_11" Segment="3">
+        <Texture Name="jyasinzou_room_11Tex_000780" OutName="jyasinzou_room_11Tex_000780" Format="ci8" Width="32" Height="32" Offset="0x780" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
         <Room Name="jyasinzou_room_11" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_12" Segment="3">
+        <Texture Name="jyasinzou_room_12Tex_0010D8" OutName="jyasinzou_room_12Tex_0010D8" Format="ci8" Width="64" Height="32" Offset="0x1058" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_12Tex_0018D8" OutName="jyasinzou_room_12Tex_0018D8" Format="ci8" Width="32" Height="64" Offset="0x1858" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
         <Room Name="jyasinzou_room_12" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_13" Segment="3">
+        <Texture Name="jyasinzou_room_13Tex_0028A8" OutName="jyasinzou_room_13Tex_0028A8" Format="ci8" Width="32" Height="64" Offset="0x2848" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_13Tex_0030A8" OutName="jyasinzou_room_13Tex_0030A8" Format="ci8" Width="64" Height="32" Offset="0x3048" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_13Tex_0038A8" OutName="jyasinzou_room_13Tex_0038A8" Format="ci8" Width="32" Height="32" Offset="0x3848" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_13Tex_003CA8" OutName="jyasinzou_room_13Tex_003CA8" Format="ci8" Width="64" Height="32" Offset="0x3C48" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_13Tex_0044A8" OutName="jyasinzou_room_13Tex_0044A8" Format="ci8" Width="64" Height="32" Offset="0x4448" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_13Tex_004CA8" OutName="jyasinzou_room_13Tex_004CA8" Format="ci8" Width="32" Height="32" Offset="0x4C48" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_13Tex_0050A8" OutName="jyasinzou_room_13Tex_0050A8" Format="ci4" Width="64" Height="64" Offset="0x5048" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
         <Room Name="jyasinzou_room_13" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_14" Segment="3">
+        <Texture Name="jyasinzou_room_14Tex_001CA0" OutName="jyasinzou_room_14Tex_001CA0" Format="ci8" Width="64" Height="32" Offset="0x1C90" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_14Tex_0024A0" OutName="jyasinzou_room_14Tex_0024A0" Format="ci8" Width="32" Height="32" Offset="0x2490" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_14Tex_0028A0" OutName="jyasinzou_room_14Tex_0028A0" Format="ci8" Width="64" Height="32" Offset="0x2890" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_14Tex_0030A0" OutName="jyasinzou_room_14Tex_0030A0" Format="ci8" Width="32" Height="32" Offset="0x3090" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_14Tex_0034A0" OutName="jyasinzou_room_14Tex_0034A0" Format="rgba16" Width="32" Height="64" Offset="0x3490" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_14Tex_0044A0" OutName="jyasinzou_room_14Tex_0044A0" Format="ci4" Width="64" Height="64" Offset="0x4490" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
         <Room Name="jyasinzou_room_14" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_15" Segment="3">
+        <Texture Name="jyasinzou_room_15Tex_002FE8" OutName="jyasinzou_room_15Tex_002FE8" Format="rgba16" Width="32" Height="64" Offset="0x2FB8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_15Tex_003FE8" OutName="jyasinzou_room_15Tex_003FE8" Format="rgba16" Width="16" Height="32" Offset="0x3FB8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_15Tex_0043E8" OutName="jyasinzou_room_15Tex_0043E8" Format="ci8" Width="32" Height="64" Offset="0x43B8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_15Tex_004BE8" OutName="jyasinzou_room_15Tex_004BE8" Format="ci8" Width="32" Height="64" Offset="0x4BB8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_15Tex_0053E8" OutName="jyasinzou_room_15Tex_0053E8" Format="ci8" Width="64" Height="32" Offset="0x53B8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_15Tex_005BE8" OutName="jyasinzou_room_15Tex_005BE8" Format="ci8" Width="16" Height="16" Offset="0x5BB8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_15Tex_005CE8" OutName="jyasinzou_room_15Tex_005CE8" Format="ci8" Width="32" Height="32" Offset="0x5CB8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_15Tex_0060E8" OutName="jyasinzou_room_15Tex_0060E8" Format="ci8" Width="64" Height="32" Offset="0x60B8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_15Tex_0068E8" OutName="jyasinzou_room_15Tex_0068E8" Format="ci8" Width="32" Height="32" Offset="0x68B8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_15Tex_006CE8" OutName="jyasinzou_room_15Tex_006CE8" Format="ci4" Width="64" Height="64" Offset="0x6CB8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_15Tex_007C98" OutName="jyasinzou_room_15Tex_007C98" Format="rgba16" Width="32" Height="32" Offset="0x7C68" AddedByScript="true"/>
         <Room Name="jyasinzou_room_15" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_16" Segment="3">
+        <Texture Name="jyasinzou_room_16Tex_0029B8" OutName="jyasinzou_room_16Tex_0029B8" Format="rgba16" Width="32" Height="64" Offset="0x2988" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_16Tex_0039B8" OutName="jyasinzou_room_16Tex_0039B8" Format="ci8" Width="64" Height="32" Offset="0x3988" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_16Tex_0041B8" OutName="jyasinzou_room_16Tex_0041B8" Format="ci8" Width="16" Height="64" Offset="0x4188" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_16Tex_0045B8" OutName="jyasinzou_room_16Tex_0045B8" Format="ci8" Width="64" Height="32" Offset="0x4588" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_16Tex_004DB8" OutName="jyasinzou_room_16Tex_004DB8" Format="rgba16" Width="16" Height="32" Offset="0x4D88" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_16Tex_0051B8" OutName="jyasinzou_room_16Tex_0051B8" Format="ci8" Width="32" Height="64" Offset="0x5188" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_16Tex_0059B8" OutName="jyasinzou_room_16Tex_0059B8" Format="ci4" Width="64" Height="64" Offset="0x5988" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
         <Room Name="jyasinzou_room_16" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_17" Segment="3">
+        <Texture Name="jyasinzou_room_17Tex_005E50" OutName="jyasinzou_room_17Tex_005E50" Format="ci8" Width="64" Height="32" Offset="0x5E10" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_17Tex_006650" OutName="jyasinzou_room_17Tex_006650" Format="ci8" Width="64" Height="32" Offset="0x6610" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_17Tex_006E50" OutName="jyasinzou_room_17Tex_006E50" Format="ci8" Width="32" Height="32" Offset="0x6E10" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_17Tex_007250" OutName="jyasinzou_room_17Tex_007250" Format="ci8" Width="64" Height="32" Offset="0x7210" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_17Tex_007A50" OutName="jyasinzou_room_17Tex_007A50" Format="ci8" Width="64" Height="32" Offset="0x7A10" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_17Tex_008250" OutName="jyasinzou_room_17Tex_008250" Format="ci4" Width="64" Height="64" Offset="0x8210" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18000" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_17Tex_008A50" OutName="jyasinzou_room_17Tex_008A50" Format="ci8" Width="32" Height="32" Offset="0x8A10" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_17Tex_008E50" OutName="jyasinzou_room_17Tex_008E50" Format="ci4" Width="64" Height="64" Offset="0x8E10" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
         <Room Name="jyasinzou_room_17" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_18" Segment="3">
+        <Texture Name="jyasinzou_room_18Tex_0020F0" OutName="jyasinzou_room_18Tex_0020F0" Format="ci8" Width="64" Height="32" Offset="0x20C0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_18Tex_0028F0" OutName="jyasinzou_room_18Tex_0028F0" Format="ci8" Width="64" Height="32" Offset="0x28C0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_18Tex_0030F0" OutName="jyasinzou_room_18Tex_0030F0" Format="ci8" Width="32" Height="32" Offset="0x30C0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_18Tex_0034F0" OutName="jyasinzou_room_18Tex_0034F0" Format="rgba16" Width="32" Height="32" Offset="0x34C0" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_18Tex_003CF0" OutName="jyasinzou_room_18Tex_003CF0" Format="ci8" Width="16" Height="128" Offset="0x3CC0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_18Tex_0044F0" OutName="jyasinzou_room_18Tex_0044F0" Format="ci8" Width="32" Height="32" Offset="0x44C0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_18Tex_0048F0" OutName="jyasinzou_room_18Tex_0048F0" Format="ci8" Width="32" Height="32" Offset="0x48C0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_18Tex_0054E0" OutName="jyasinzou_room_18Tex_0054E0" Format="rgba16" Width="32" Height="32" Offset="0x54B0" AddedByScript="true"/>
         <Room Name="jyasinzou_room_18" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_19" Segment="3">
+        <Texture Name="jyasinzou_room_19Tex_002DC8" OutName="jyasinzou_room_19Tex_002DC8" Format="rgba16" Width="32" Height="64" Offset="0x2DD8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_19Tex_003DC8" OutName="jyasinzou_room_19Tex_003DC8" Format="ci8" Width="64" Height="32" Offset="0x3DD8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_19Tex_0045C8" OutName="jyasinzou_room_19Tex_0045C8" Format="ci8" Width="64" Height="32" Offset="0x45D8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_19Tex_004DC8" OutName="jyasinzou_room_19Tex_004DC8" Format="rgba16" Width="16" Height="32" Offset="0x4DD8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_19Tex_0051C8" OutName="jyasinzou_room_19Tex_0051C8" Format="ci8" Width="64" Height="16" Offset="0x51D8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_19Tex_0055C8" OutName="jyasinzou_room_19Tex_0055C8" Format="ci8" Width="64" Height="32" Offset="0x55D8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
         <Room Name="jyasinzou_room_19" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_20" Segment="3">
+        <Texture Name="jyasinzou_room_20Tex_0031B8" OutName="jyasinzou_room_20Tex_0031B8" Format="rgba16" Width="32" Height="64" Offset="0x31B8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_20Tex_0041B8" OutName="jyasinzou_room_20Tex_0041B8" Format="ci8" Width="64" Height="32" Offset="0x41B8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_20Tex_0049B8" OutName="jyasinzou_room_20Tex_0049B8" Format="ci8" Width="64" Height="32" Offset="0x49B8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_20Tex_0051B8" OutName="jyasinzou_room_20Tex_0051B8" Format="ci8" Width="64" Height="32" Offset="0x51B8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_20Tex_0059B8" OutName="jyasinzou_room_20Tex_0059B8" Format="rgba16" Width="16" Height="32" Offset="0x59B8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_20Tex_005DB8" OutName="jyasinzou_room_20Tex_005DB8" Format="ci8" Width="64" Height="32" Offset="0x5DB8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_20Tex_0065B8" OutName="jyasinzou_room_20Tex_0065B8" Format="ci8" Width="32" Height="32" Offset="0x65B8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_20Tex_0069B8" OutName="jyasinzou_room_20Tex_0069B8" Format="rgba16" Width="64" Height="32" Offset="0x69B8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_20Tex_0079B8" OutName="jyasinzou_room_20Tex_0079B8" Format="ci8" Width="64" Height="16" Offset="0x79B8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_20Tex_007DB8" OutName="jyasinzou_room_20Tex_007DB8" Format="ci8" Width="32" Height="32" Offset="0x7DB8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
         <Room Name="jyasinzou_room_20" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_21" Segment="3">
+        <Texture Name="jyasinzou_room_21Tex_001660" OutName="jyasinzou_room_21Tex_001660" Format="rgba16" Width="32" Height="64" Offset="0x1650" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_21Tex_002660" OutName="jyasinzou_room_21Tex_002660" Format="ci8" Width="64" Height="32" Offset="0x2650" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_21Tex_002E60" OutName="jyasinzou_room_21Tex_002E60" Format="rgba16" Width="16" Height="32" Offset="0x2E50" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_21Tex_003260" OutName="jyasinzou_room_21Tex_003260" Format="ci8" Width="32" Height="32" Offset="0x3250" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_21Tex_003660" OutName="jyasinzou_room_21Tex_003660" Format="ci8" Width="64" Height="32" Offset="0x3650" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_21Tex_003E60" OutName="jyasinzou_room_21Tex_003E60" Format="ci4" Width="64" Height="64" Offset="0x3E50" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
         <Room Name="jyasinzou_room_21" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_22" Segment="3">
+        <Texture Name="jyasinzou_room_22Tex_001468" OutName="jyasinzou_room_22Tex_001468" Format="ci8" Width="64" Height="32" Offset="0x14C8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_22Tex_001C68" OutName="jyasinzou_room_22Tex_001C68" Format="ci8" Width="32" Height="64" Offset="0x1CC8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_22Tex_002468" OutName="jyasinzou_room_22Tex_002468" Format="ci8" Width="32" Height="32" Offset="0x24C8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_22Tex_002868" OutName="jyasinzou_room_22Tex_002868" Format="ci4" Width="64" Height="64" Offset="0x28C8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
         <Room Name="jyasinzou_room_22" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_23" Segment="3">
+        <Texture Name="jyasinzou_room_23Tex_004438" OutName="jyasinzou_room_23Tex_004438" Format="ci8" Width="32" Height="64" Offset="0x43B8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_23Tex_004C38" OutName="jyasinzou_room_23Tex_004C38" Format="ci8" Width="64" Height="32" Offset="0x4BB8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_23Tex_005438" OutName="jyasinzou_room_23Tex_005438" Format="ci8" Width="16" Height="64" Offset="0x53B8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_23Tex_005838" OutName="jyasinzou_room_23Tex_005838" Format="ci8" Width="64" Height="32" Offset="0x57B8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_23Tex_006038" OutName="jyasinzou_room_23Tex_006038" Format="ci8" Width="32" Height="32" Offset="0x5FB8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_23Tex_006438" OutName="jyasinzou_room_23Tex_006438" Format="ci8" Width="16" Height="128" Offset="0x63B8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_23Tex_006C38" OutName="jyasinzou_room_23Tex_006C38" Format="rgba16" Width="32" Height="32" Offset="0x6BB8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_23Tex_007438" OutName="jyasinzou_room_23Tex_007438" Format="ci8" Width="64" Height="32" Offset="0x73B8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_23Tex_007C38" OutName="jyasinzou_room_23Tex_007C38" Format="ci8" Width="32" Height="32" Offset="0x7BB8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_23Tex_008038" OutName="jyasinzou_room_23Tex_008038" Format="ci8" Width="64" Height="32" Offset="0x7FB8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_23Tex_008838" OutName="jyasinzou_room_23Tex_008838" Format="ci4" Width="64" Height="64" Offset="0x87B8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
         <Room Name="jyasinzou_room_23" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_24" Segment="3">
+        <Texture Name="jyasinzou_room_24Tex_001B38" OutName="jyasinzou_room_24Tex_001B38" Format="rgba16" Width="32" Height="64" Offset="0x1B18" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_24Tex_002B38" OutName="jyasinzou_room_24Tex_002B38" Format="ci8" Width="64" Height="32" Offset="0x2B18" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_24Tex_003338" OutName="jyasinzou_room_24Tex_003338" Format="ci8" Width="64" Height="32" Offset="0x3318" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_24Tex_003B38" OutName="jyasinzou_room_24Tex_003B38" Format="rgba16" Width="16" Height="32" Offset="0x3B18" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_24Tex_003F38" OutName="jyasinzou_room_24Tex_003F38" Format="ci8" Width="32" Height="32" Offset="0x3F18" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_24Tex_004338" OutName="jyasinzou_room_24Tex_004338" Format="ci8" Width="64" Height="32" Offset="0x4318" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_24Tex_004B38" OutName="jyasinzou_room_24Tex_004B38" Format="ci4" Width="64" Height="64" Offset="0x4B18" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_24Tex_0054D0" OutName="jyasinzou_room_24Tex_0054D0" Format="rgba16" Width="32" Height="64" Offset="0x54B0" AddedByScript="true"/>
         <Room Name="jyasinzou_room_24" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_25" Segment="3">
+        <Texture Name="jyasinzou_room_25Tex_00BA98" OutName="jyasinzou_room_25Tex_00BA98" Format="rgba16" Width="16" Height="32" Offset="0xBA68" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_00BE98" OutName="jyasinzou_room_25Tex_00BE98" Format="rgba16" Width="32" Height="64" Offset="0xBE68" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_00CE98" OutName="jyasinzou_room_25Tex_00CE98" Format="ci8" Width="32" Height="64" Offset="0xCE68" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_00D698" OutName="jyasinzou_room_25Tex_00D698" Format="ci8" Width="16" Height="64" Offset="0xD668" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_00DA98" OutName="jyasinzou_room_25Tex_00DA98" Format="ci8" Width="32" Height="32" Offset="0xDA68" TlutOffset="0xB870" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_00DE98" OutName="jyasinzou_room_25Tex_00DE98" Format="ci8" Width="32" Height="64" Offset="0xDE68" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_00E698" OutName="jyasinzou_room_25Tex_00E698" Format="ci8" Width="64" Height="32" Offset="0xE668" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_00EE98" OutName="jyasinzou_room_25Tex_00EE98" Format="rgba16" Width="32" Height="16" Offset="0xEE68" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_00F298" OutName="jyasinzou_room_25Tex_00F298" Format="ci8" Width="32" Height="32" Offset="0xF268" TlutOffset="0xB870" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_00F698" OutName="jyasinzou_room_25Tex_00F698" Format="ci8" Width="32" Height="64" Offset="0xF668" TlutOffset="0xB870" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_00FE98" OutName="jyasinzou_room_25Tex_00FE98" Format="ci8" Width="16" Height="16" Offset="0xFE68" TlutOffset="0xB870" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_00FF98" OutName="jyasinzou_room_25Tex_00FF98" Format="ci8" Width="32" Height="32" Offset="0xFF68" TlutOffset="0xB870" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_010398" OutName="jyasinzou_room_25Tex_010398" Format="ci8" Width="32" Height="32" Offset="0x10368" TlutOffset="0xB870" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_010798" OutName="jyasinzou_room_25Tex_010798" Format="ci8" Width="32" Height="32" Offset="0x10768" TlutOffset="0xB870" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_010B98" OutName="jyasinzou_room_25Tex_010B98" Format="ci8" Width="32" Height="32" Offset="0x10B68" TlutOffset="0xB870" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_010F98" OutName="jyasinzou_room_25Tex_010F98" Format="ci8" Width="32" Height="32" Offset="0x10F68" TlutOffset="0xB870" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_011398" OutName="jyasinzou_room_25Tex_011398" Format="ci8" Width="32" Height="32" Offset="0x11368" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_011798" OutName="jyasinzou_room_25Tex_011798" Format="ci8" Width="16" Height="128" Offset="0x11768" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_011F98" OutName="jyasinzou_room_25Tex_011F98" Format="ci8" Width="64" Height="32" Offset="0x11F68" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_012798" OutName="jyasinzou_room_25Tex_012798" Format="ci8" Width="32" Height="32" Offset="0x12768" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_012B98" OutName="jyasinzou_room_25Tex_012B98" Format="ci8" Width="32" Height="64" Offset="0x12B68" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_013398" OutName="jyasinzou_room_25Tex_013398" Format="ci8" Width="64" Height="32" Offset="0x13368" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_013B98" OutName="jyasinzou_room_25Tex_013B98" Format="ci8" Width="64" Height="32" Offset="0x13B68" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_014398" OutName="jyasinzou_room_25Tex_014398" Format="ci8" Width="32" Height="32" Offset="0x14368" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_014798" OutName="jyasinzou_room_25Tex_014798" Format="ci4" Width="64" Height="64" Offset="0x14768" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18000" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_014F98" OutName="jyasinzou_room_25Tex_014F98" Format="ci8" Width="32" Height="32" Offset="0x14F68" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25Tex_015398" OutName="jyasinzou_room_25Tex_015398" Format="ci4" Width="64" Height="64" Offset="0x15368" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_25TLUT_00B8A0" OutName="jyasinzou_room_25TLUT_00B8A0" Format="rgba16" Width="16" Height="16" Offset="0xB870" AddedByScript="true"/>
         <Room Name="jyasinzou_room_25" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_26" Segment="3">
+        <Texture Name="jyasinzou_room_26Tex_006CC8" OutName="jyasinzou_room_26Tex_006CC8" Format="rgba16" Width="16" Height="32" Offset="0x6CE8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_26Tex_0070C8" OutName="jyasinzou_room_26Tex_0070C8" Format="rgba16" Width="32" Height="64" Offset="0x70E8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_26Tex_0080C8" OutName="jyasinzou_room_26Tex_0080C8" Format="rgba16" Width="16" Height="16" Offset="0x80E8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_26Tex_0082C8" OutName="jyasinzou_room_26Tex_0082C8" Format="ci8" Width="32" Height="64" Offset="0x82E8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_26Tex_008AC8" OutName="jyasinzou_room_26Tex_008AC8" Format="ci8" Width="16" Height="32" Offset="0x8AE8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_26Tex_008CC8" OutName="jyasinzou_room_26Tex_008CC8" Format="ci8" Width="32" Height="64" Offset="0x8CE8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_26Tex_0094C8" OutName="jyasinzou_room_26Tex_0094C8" Format="ci8" Width="64" Height="32" Offset="0x94E8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_26Tex_009CC8" OutName="jyasinzou_room_26Tex_009CC8" Format="rgba16" Width="16" Height="32" Offset="0x9CE8" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_26Tex_00A0C8" OutName="jyasinzou_room_26Tex_00A0C8" Format="ci8" Width="16" Height="128" Offset="0xA0E8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_26Tex_00A8C8" OutName="jyasinzou_room_26Tex_00A8C8" Format="ci8" Width="32" Height="32" Offset="0xA8E8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_26Tex_00ACC8" OutName="jyasinzou_room_26Tex_00ACC8" Format="ci4" Width="64" Height="64" Offset="0xACE8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18000" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_26Tex_00B4C8" OutName="jyasinzou_room_26Tex_00B4C8" Format="ci4" Width="64" Height="64" Offset="0xB4E8" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18020" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_26Tex_00C2F8" OutName="jyasinzou_room_26Tex_00C2F8" Format="ia16" Width="32" Height="32" Offset="0xC318" AddedByScript="true"/>
         <Room Name="jyasinzou_room_26" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_27" Segment="3">
+        <Texture Name="jyasinzou_room_27Tex_004310" OutName="jyasinzou_room_27Tex_004310" Format="ci8" Width="32" Height="64" Offset="0x42C0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_27Tex_004B10" OutName="jyasinzou_room_27Tex_004B10" Format="ci8" Width="32" Height="32" Offset="0x4AC0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_27Tex_004F10" OutName="jyasinzou_room_27Tex_004F10" Format="ci8" Width="64" Height="32" Offset="0x4EC0" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17C00" AddedByScript="true"/>
         <Room Name="jyasinzou_room_27" Offset="0x0"/>
     </File>
     <File Name="jyasinzou_room_28" Segment="3">
+        <Texture Name="jyasinzou_room_28Tex_004130" OutName="jyasinzou_room_28Tex_004130" Format="ci8" Width="64" Height="32" Offset="0x4120" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_28Tex_004930" OutName="jyasinzou_room_28Tex_004930" Format="ci8" Width="64" Height="32" Offset="0x4920" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_28Tex_005130" OutName="jyasinzou_room_28Tex_005130" Format="ci8" Width="64" Height="32" Offset="0x5120" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_28Tex_005930" OutName="jyasinzou_room_28Tex_005930" Format="ci8" Width="64" Height="32" Offset="0x5920" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_28Tex_006130" OutName="jyasinzou_room_28Tex_006130" Format="ci8" Width="32" Height="32" Offset="0x6120" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_28Tex_006530" OutName="jyasinzou_room_28Tex_006530" Format="rgba16" Width="64" Height="32" Offset="0x6520" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_28Tex_007530" OutName="jyasinzou_room_28Tex_007530" Format="ci8" Width="64" Height="16" Offset="0x7520" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_28Tex_007930" OutName="jyasinzou_room_28Tex_007930" Format="ci8" Width="16" Height="16" Offset="0x7920" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_28Tex_007A30" OutName="jyasinzou_room_28Tex_007A30" Format="ci8" Width="16" Height="64" Offset="0x7A20" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_28Tex_007E30" OutName="jyasinzou_room_28Tex_007E30" Format="ci4" Width="64" Height="64" Offset="0x7E20" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x18000" AddedByScript="true"/>
+        <Texture Name="jyasinzou_room_28Tex_008630" OutName="jyasinzou_room_28Tex_008630" Format="ci8" Width="32" Height="32" Offset="0x8620" ExternalTlut="jyasinzou_scene" ExternalTlutOffset="0x17E00" AddedByScript="true"/>
         <Room Name="jyasinzou_room_28" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/N64_PAL_11/scenes/dungeons/men.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/dungeons/men.xml
@@ -1,43 +1,127 @@
 <Root>
     <File Name="men_scene" Segment="2">
+        <Texture Name="men_sceneTex_0108C0" OutName="men_sceneTex_0108C0" Format="ci8" Width="32" Height="32" Offset="0x10930" TlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_sceneTex_010CC0" OutName="men_sceneTex_010CC0" Format="ci8" Width="64" Height="32" Offset="0x10D30" TlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_sceneTLUT_00F6C0" OutName="men_sceneTLUT_00F6C0" Format="rgba16" Width="16" Height="16" Offset="0xF730" AddedByScript="true"/>
         <Path Name="gGTGPath_002F0" Offset="0x2F0" NumPaths="2"/>
         <Texture Name="gGTGDayEntranceTex" OutName="day_entrance" Format="ia16" Width="8" Height="128" Offset="0xF930"/>
         <Texture Name="gGTGNightEntranceTex" OutName="night_entrance" Format="ia16" Width="8" Height="128" Offset="0x10130"/>
         <Scene Name="men_scene" Offset="0x0"/>
     </File>
     <File Name="men_room_0" Segment="3">
+        <Texture Name="men_room_0Tex_008138" OutName="men_room_0Tex_008138" Format="ci8" Width="64" Height="32" Offset="0x8138" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_0Tex_008938" OutName="men_room_0Tex_008938" Format="ci8" Width="32" Height="64" Offset="0x8938" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_0Tex_009138" OutName="men_room_0Tex_009138" Format="ci8" Width="32" Height="32" Offset="0x9138" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_0Tex_009538" OutName="men_room_0Tex_009538" Format="rgba16" Width="32" Height="32" Offset="0x9538" AddedByScript="true"/>
+        <Texture Name="men_room_0Tex_009D38" OutName="men_room_0Tex_009D38" Format="ci8" Width="32" Height="64" Offset="0x9D38" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_0Tex_00A538" OutName="men_room_0Tex_00A538" Format="ia8" Width="64" Height="64" Offset="0xA538" AddedByScript="true"/>
+        <Texture Name="men_room_0Tex_00B538" OutName="men_room_0Tex_00B538" Format="ci8" Width="32" Height="64" Offset="0xB538" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_0Tex_00BD38" OutName="men_room_0Tex_00BD38" Format="ci8" Width="64" Height="32" Offset="0xBD38" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_0Tex_00C538" OutName="men_room_0Tex_00C538" Format="i4" Width="64" Height="128" Offset="0xC538" AddedByScript="true"/>
+        <Texture Name="men_room_0Tex_00D538" OutName="men_room_0Tex_00D538" Format="ci8" Width="64" Height="32" Offset="0xD538" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_0Tex_00DD38" OutName="men_room_0Tex_00DD38" Format="rgba16" Width="16" Height="128" Offset="0xDD38" AddedByScript="true"/>
+        <Texture Name="men_room_0Tex_00ED38" OutName="men_room_0Tex_00ED38" Format="ci8" Width="64" Height="32" Offset="0xED38" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_0Tex_00F538" OutName="men_room_0Tex_00F538" Format="ci8" Width="64" Height="32" Offset="0xF538" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
         <DList Name="gMenDL_008118" Offset="0x8118"/>
         <DList Name="gMenDL_00FF78" Offset="0xFF78"/>
         <Room Name="men_room_0" Offset="0x0"/>
     </File>
     <File Name="men_room_1" Segment="3">
+        <Texture Name="men_room_1Tex_004270" OutName="men_room_1Tex_004270" Format="rgba16" Width="32" Height="32" Offset="0x4290" AddedByScript="true"/>
+        <Texture Name="men_room_1Tex_004A70" OutName="men_room_1Tex_004A70" Format="ci8" Width="64" Height="32" Offset="0x4A90" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_1Tex_005270" OutName="men_room_1Tex_005270" Format="ci8" Width="32" Height="64" Offset="0x5290" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_1Tex_005A70" OutName="men_room_1Tex_005A70" Format="ci8" Width="64" Height="32" Offset="0x5A90" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_1Tex_006270" OutName="men_room_1Tex_006270" Format="rgba16" Width="32" Height="32" Offset="0x6290" AddedByScript="true"/>
+        <Texture Name="men_room_1Tex_006A70" OutName="men_room_1Tex_006A70" Format="rgba16" Width="32" Height="32" Offset="0x6A90" AddedByScript="true"/>
+        <Texture Name="men_room_1Tex_007270" OutName="men_room_1Tex_007270" Format="ci8" Width="64" Height="32" Offset="0x7290" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_1Tex_007A70" OutName="men_room_1Tex_007A70" Format="rgba16" Width="16" Height="128" Offset="0x7A90" AddedByScript="true"/>
+        <Texture Name="men_room_1Tex_008A70" OutName="men_room_1Tex_008A70" Format="ci8" Width="64" Height="32" Offset="0x8A90" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
         <Room Name="men_room_1" Offset="0x0"/>
     </File>
     <File Name="men_room_2" Segment="3">
+        <Texture Name="men_room_2Tex_003C48" OutName="men_room_2Tex_003C48" Format="ci8" Width="64" Height="32" Offset="0x3B78" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_2Tex_004448" OutName="men_room_2Tex_004448" Format="ci8" Width="64" Height="32" Offset="0x4378" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_2Tex_004C48" OutName="men_room_2Tex_004C48" Format="ci8" Width="32" Height="32" Offset="0x4B78" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
         <Room Name="men_room_2" Offset="0x0"/>
     </File>
     <File Name="men_room_3" Segment="3">
+        <Texture Name="men_room_3Tex_003850" OutName="men_room_3Tex_003850" Format="ci8" Width="64" Height="32" Offset="0x3820" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_3Tex_004050" OutName="men_room_3Tex_004050" Format="ci8" Width="64" Height="32" Offset="0x4020" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_3Tex_004850" OutName="men_room_3Tex_004850" Format="ci8" Width="32" Height="64" Offset="0x4820" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_3Tex_005050" OutName="men_room_3Tex_005050" Format="ci8" Width="64" Height="32" Offset="0x5020" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_3Tex_005850" OutName="men_room_3Tex_005850" Format="ci8" Width="32" Height="32" Offset="0x5820" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_3Tex_005C50" OutName="men_room_3Tex_005C50" Format="ci8" Width="64" Height="32" Offset="0x5C20" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_3Tex_006450" OutName="men_room_3Tex_006450" Format="rgba16" Width="16" Height="128" Offset="0x6420" AddedByScript="true"/>
+        <Texture Name="men_room_3Tex_007450" OutName="men_room_3Tex_007450" Format="ci8" Width="64" Height="32" Offset="0x7420" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
         <Room Name="men_room_3" Offset="0x0"/>
     </File>
     <File Name="men_room_4" Segment="3">
+        <Texture Name="men_room_4Tex_0051E0" OutName="men_room_4Tex_0051E0" Format="rgba16" Width="32" Height="32" Offset="0x5150" AddedByScript="true"/>
+        <Texture Name="men_room_4Tex_0059E0" OutName="men_room_4Tex_0059E0" Format="rgba16" Width="32" Height="32" Offset="0x5950" AddedByScript="true"/>
+        <Texture Name="men_room_4Tex_0061E0" OutName="men_room_4Tex_0061E0" Format="i4" Width="128" Height="64" Offset="0x6150" AddedByScript="true"/>
+        <Texture Name="men_room_4Tex_0071E0" OutName="men_room_4Tex_0071E0" Format="i4" Width="64" Height="128" Offset="0x7150" AddedByScript="true"/>
+        <Texture Name="men_room_4Tex_0081E0" OutName="men_room_4Tex_0081E0" Format="ci8" Width="32" Height="64" Offset="0x8150" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_4Tex_0089E0" OutName="men_room_4Tex_0089E0" Format="i4" Width="64" Height="128" Offset="0x8950" AddedByScript="true"/>
+        <Texture Name="men_room_4Tex_0099E0" OutName="men_room_4Tex_0099E0" Format="ci8" Width="64" Height="32" Offset="0x9950" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
         <Room Name="men_room_4" Offset="0x0"/>
     </File>
     <File Name="men_room_5" Segment="3">
+        <Texture Name="men_room_5Tex_002418" OutName="men_room_5Tex_002418" Format="ci8" Width="64" Height="32" Offset="0x24D8" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_5Tex_002C18" OutName="men_room_5Tex_002C18" Format="ci8" Width="32" Height="32" Offset="0x2CD8" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_5Tex_003018" OutName="men_room_5Tex_003018" Format="ci8" Width="32" Height="64" Offset="0x30D8" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_5Tex_003818" OutName="men_room_5Tex_003818" Format="ci8" Width="64" Height="32" Offset="0x38D8" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_5Tex_004018" OutName="men_room_5Tex_004018" Format="ci8" Width="64" Height="32" Offset="0x40D8" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_5Tex_004818" OutName="men_room_5Tex_004818" Format="ci8" Width="64" Height="32" Offset="0x48D8" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
         <Room Name="men_room_5" Offset="0x0"/>
     </File>
     <File Name="men_room_6" Segment="3">
+        <Texture Name="men_room_6Tex_003F78" OutName="men_room_6Tex_003F78" Format="rgba16" Width="32" Height="32" Offset="0x3F38" AddedByScript="true"/>
+        <Texture Name="men_room_6Tex_004778" OutName="men_room_6Tex_004778" Format="ci8" Width="32" Height="64" Offset="0x4738" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_6Tex_004F78" OutName="men_room_6Tex_004F78" Format="ci8" Width="32" Height="32" Offset="0x4F38" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_6Tex_005378" OutName="men_room_6Tex_005378" Format="rgba16" Width="32" Height="32" Offset="0x5338" AddedByScript="true"/>
+        <Texture Name="men_room_6Tex_005B78" OutName="men_room_6Tex_005B78" Format="ci8" Width="32" Height="64" Offset="0x5B38" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_6Tex_006378" OutName="men_room_6Tex_006378" Format="ci8" Width="32" Height="64" Offset="0x6338" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_6Tex_006B78" OutName="men_room_6Tex_006B78" Format="ci8" Width="64" Height="32" Offset="0x6B38" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_6Tex_007378" OutName="men_room_6Tex_007378" Format="ci8" Width="32" Height="32" Offset="0x7338" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_6Tex_007778" OutName="men_room_6Tex_007778" Format="ci8" Width="64" Height="32" Offset="0x7738" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
         <Room Name="men_room_6" Offset="0x0"/>
     </File>
     <File Name="men_room_7" Segment="3">
+        <Texture Name="men_room_7Tex_0036B8" OutName="men_room_7Tex_0036B8" Format="ci8" Width="32" Height="32" Offset="0x3728" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_7Tex_003AB8" OutName="men_room_7Tex_003AB8" Format="ci8" Width="64" Height="32" Offset="0x3B28" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_7Tex_0042B8" OutName="men_room_7Tex_0042B8" Format="ci8" Width="32" Height="64" Offset="0x4328" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_7Tex_004AB8" OutName="men_room_7Tex_004AB8" Format="rgba16" Width="32" Height="32" Offset="0x4B28" AddedByScript="true"/>
+        <Texture Name="men_room_7Tex_0052B8" OutName="men_room_7Tex_0052B8" Format="ci8" Width="64" Height="32" Offset="0x5328" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_7Tex_005AB8" OutName="men_room_7Tex_005AB8" Format="ci8" Width="64" Height="32" Offset="0x5B28" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_7Tex_0062B8" OutName="men_room_7Tex_0062B8" Format="rgba16" Width="16" Height="128" Offset="0x6328" AddedByScript="true"/>
+        <Texture Name="men_room_7Tex_0072B8" OutName="men_room_7Tex_0072B8" Format="ci8" Width="64" Height="32" Offset="0x7328" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_7Tex_007AB8" OutName="men_room_7Tex_007AB8" Format="ci8" Width="64" Height="32" Offset="0x7B28" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
         <Room Name="men_room_7" Offset="0x0"/>
     </File>
     <File Name="men_room_8" Segment="3">
+        <Texture Name="men_room_8Tex_005D30" OutName="men_room_8Tex_005D30" Format="rgba16" Width="16" Height="64" Offset="0x5D10" AddedByScript="true"/>
+        <Texture Name="men_room_8Tex_006530" OutName="men_room_8Tex_006530" Format="rgba16" Width="32" Height="32" Offset="0x6510" AddedByScript="true"/>
+        <Texture Name="men_room_8Tex_006D30" OutName="men_room_8Tex_006D30" Format="ci8" Width="32" Height="64" Offset="0x6D10" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_8Tex_007530" OutName="men_room_8Tex_007530" Format="rgba16" Width="8" Height="16" Offset="0x7510" AddedByScript="true"/>
+        <Texture Name="men_room_8Tex_007630" OutName="men_room_8Tex_007630" Format="rgba16" Width="32" Height="32" Offset="0x7610" AddedByScript="true"/>
+        <Texture Name="men_room_8Tex_007E30" OutName="men_room_8Tex_007E30" Format="ci8" Width="32" Height="32" Offset="0x7E10" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
         <Room Name="men_room_8" Offset="0x0"/>
     </File>
     <File Name="men_room_9" Segment="3">
+        <Texture Name="men_room_9Tex_001AB0" OutName="men_room_9Tex_001AB0" Format="rgba16" Width="32" Height="32" Offset="0x1B30" AddedByScript="true"/>
+        <Texture Name="men_room_9Tex_0022B0" OutName="men_room_9Tex_0022B0" Format="ci8" Width="32" Height="32" Offset="0x2330" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_9Tex_0026B0" OutName="men_room_9Tex_0026B0" Format="ci8" Width="64" Height="32" Offset="0x2730" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_9Tex_003070" OutName="men_room_9Tex_003070" Format="rgba16" Width="32" Height="32" Offset="0x30F0" AddedByScript="true"/>
         <Room Name="men_room_9" Offset="0x0"/>
     </File>
     <File Name="men_room_10" Segment="3">
+        <Texture Name="men_room_10Tex_002448" OutName="men_room_10Tex_002448" Format="ci8" Width="64" Height="32" Offset="0x2458" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_10Tex_002C48" OutName="men_room_10Tex_002C48" Format="rgba16" Width="32" Height="32" Offset="0x2C58" AddedByScript="true"/>
+        <Texture Name="men_room_10Tex_003448" OutName="men_room_10Tex_003448" Format="ci8" Width="32" Height="64" Offset="0x3458" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_10Tex_003C48" OutName="men_room_10Tex_003C48" Format="ci8" Width="64" Height="32" Offset="0x3C58" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_10Tex_004448" OutName="men_room_10Tex_004448" Format="rgba16" Width="32" Height="32" Offset="0x4458" AddedByScript="true"/>
+        <Texture Name="men_room_10Tex_004C48" OutName="men_room_10Tex_004C48" Format="ci8" Width="32" Height="64" Offset="0x4C58" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
+        <Texture Name="men_room_10Tex_005448" OutName="men_room_10Tex_005448" Format="ci8" Width="64" Height="32" Offset="0x5458" ExternalTlut="men_scene" ExternalTlutOffset="0xF730" AddedByScript="true"/>
         <Room Name="men_room_10" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/N64_PAL_11/scenes/dungeons/moribossroom.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/dungeons/moribossroom.xml
@@ -1,11 +1,33 @@
 <Root>
     <File Name="moribossroom_scene" Segment="2">
+        <Texture Name="moribossroom_sceneTex_000CF8" OutName="moribossroom_sceneTex_000CF8" Format="ci8" Width="32" Height="32" Offset="0xCF8" TlutOffset="0xB50" AddedByScript="true"/>
+        <Texture Name="moribossroom_sceneTex_0010F8" OutName="moribossroom_sceneTex_0010F8" Format="ci8" Width="32" Height="64" Offset="0x10F8" TlutOffset="0xB50" AddedByScript="true"/>
+        <Texture Name="moribossroom_sceneTLUT_000B50" OutName="moribossroom_sceneTLUT_000B50" Format="rgba16" Width="16" Height="16" Offset="0xB50" AddedByScript="true"/>
         <Scene Name="moribossroom_scene" Offset="0x0"/>
     </File>
     <File Name="moribossroom_room_0" Segment="3">
+        <Texture Name="moribossroom_room_0Tex_0038B8" OutName="moribossroom_room_0Tex_0038B8" Format="rgba16" Width="32" Height="32" Offset="0x38B8" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_0Tex_0040B8" OutName="moribossroom_room_0Tex_0040B8" Format="ci8" Width="32" Height="32" Offset="0x40B8" ExternalTlut="moribossroom_scene" ExternalTlutOffset="0xB50" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_0Tex_0044B8" OutName="moribossroom_room_0Tex_0044B8" Format="rgba16" Width="64" Height="32" Offset="0x44B8" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_0Tex_0054B8" OutName="moribossroom_room_0Tex_0054B8" Format="rgba16" Width="16" Height="16" Offset="0x54B8" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_0Tex_0056B8" OutName="moribossroom_room_0Tex_0056B8" Format="ci8" Width="32" Height="64" Offset="0x56B8" ExternalTlut="moribossroom_scene" ExternalTlutOffset="0xB50" AddedByScript="true"/>
         <Room Name="moribossroom_room_0" Offset="0x0"/>
     </File>
     <File Name="moribossroom_room_1" Segment="3">
+        <Texture Name="moribossroom_room_1Tex_006A20" OutName="moribossroom_room_1Tex_006A20" Format="rgba16" Width="32" Height="64" Offset="0x6A20" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_1Tex_007A20" OutName="moribossroom_room_1Tex_007A20" Format="rgba16" Width="64" Height="32" Offset="0x7A20" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_1Tex_008A20" OutName="moribossroom_room_1Tex_008A20" Format="rgba16" Width="64" Height="32" Offset="0x8A20" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_1Tex_009A20" OutName="moribossroom_room_1Tex_009A20" Format="rgba16" Width="8" Height="16" Offset="0x9A20" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_1Tex_009B20" OutName="moribossroom_room_1Tex_009B20" Format="rgba16" Width="16" Height="16" Offset="0x9B20" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_1Tex_009D20" OutName="moribossroom_room_1Tex_009D20" Format="ci8" Width="32" Height="64" Offset="0x9D20" TlutOffset="0x6828" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_1Tex_00A520" OutName="moribossroom_room_1Tex_00A520" Format="ci8" Width="64" Height="32" Offset="0xA520" TlutOffset="0x6828" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_1Tex_00AD20" OutName="moribossroom_room_1Tex_00AD20" Format="ci8" Width="64" Height="32" Offset="0xAD20" TlutOffset="0x6828" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_1Tex_00B520" OutName="moribossroom_room_1Tex_00B520" Format="ci8" Width="64" Height="32" Offset="0xB520" ExternalTlut="moribossroom_scene" ExternalTlutOffset="0xB50" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_1Tex_00BD20" OutName="moribossroom_room_1Tex_00BD20" Format="ci8" Width="32" Height="64" Offset="0xBD20" TlutOffset="0x6828" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_1Tex_00C520" OutName="moribossroom_room_1Tex_00C520" Format="ci8" Width="64" Height="32" Offset="0xC520" TlutOffset="0x6828" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_1Tex_00CD20" OutName="moribossroom_room_1Tex_00CD20" Format="ci8" Width="64" Height="32" Offset="0xCD20" TlutOffset="0x6828" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_1Tex_00D6A8" OutName="moribossroom_room_1Tex_00D6A8" Format="rgba16" Width="16" Height="32" Offset="0xD6A8" AddedByScript="true"/>
+        <Texture Name="moribossroom_room_1TLUT_006828" OutName="moribossroom_room_1TLUT_006828" Format="rgba16" Width="16" Height="16" Offset="0x6828" AddedByScript="true"/>
         <Room Name="moribossroom_room_1" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/N64_PAL_11/scenes/dungeons/ydan.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/dungeons/ydan.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="ydan_scene" Segment="2">
+        <Texture Name="ydan_sceneTLUT_00B810" OutName="ydan_sceneTLUT_00B810" Format="rgba16" Width="16" Height="16" Offset="0xB800" AddedByScript="true"/>
         <Cutscene Name="gDekuTreeIntroCs" Offset="0xB640"/>
         <Texture Name="gYdanTex_00BA18" Format="rgba16" Width="32" Height="64" Offset="0xBA08"/>
         <Texture Name="gYdanTex_00CA18" Format="rgba16" Width="32" Height="64" Offset="0xCA08"/>
@@ -7,39 +8,150 @@
         <Scene Name="ydan_scene" Offset="0x0"/>
     </File>
     <File Name="ydan_room_0" Segment="3">
+        <Texture Name="ydan_room_0Tex_0071C0" OutName="ydan_room_0Tex_0071C0" Format="rgba16" Width="32" Height="64" Offset="0x7160" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_0081C0" OutName="ydan_room_0Tex_0081C0" Format="rgba16" Width="32" Height="64" Offset="0x8160" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_0091C0" OutName="ydan_room_0Tex_0091C0" Format="ci8" Width="32" Height="64" Offset="0x9160" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_0099C0" OutName="ydan_room_0Tex_0099C0" Format="ci8" Width="32" Height="64" Offset="0x9960" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_00A1C0" OutName="ydan_room_0Tex_00A1C0" Format="ci8" Width="32" Height="32" Offset="0xA160" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_00A5C0" OutName="ydan_room_0Tex_00A5C0" Format="ci8" Width="32" Height="64" Offset="0xA560" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_00ADC0" OutName="ydan_room_0Tex_00ADC0" Format="ci8" Width="32" Height="64" Offset="0xAD60" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_00B5C0" OutName="ydan_room_0Tex_00B5C0" Format="ci8" Width="32" Height="64" Offset="0xB560" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_00BDC0" OutName="ydan_room_0Tex_00BDC0" Format="rgba16" Width="32" Height="32" Offset="0xBD60" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_00C5C0" OutName="ydan_room_0Tex_00C5C0" Format="ci8" Width="32" Height="64" Offset="0xC560" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_00CDC0" OutName="ydan_room_0Tex_00CDC0" Format="ci8" Width="32" Height="64" Offset="0xCD60" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_00D5C0" OutName="ydan_room_0Tex_00D5C0" Format="ci8" Width="32" Height="32" Offset="0xD560" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_00D9C0" OutName="ydan_room_0Tex_00D9C0" Format="ci8" Width="32" Height="64" Offset="0xD960" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_00E1C0" OutName="ydan_room_0Tex_00E1C0" Format="ci8" Width="32" Height="64" Offset="0xE160" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_00E9C0" OutName="ydan_room_0Tex_00E9C0" Format="ci8" Width="32" Height="64" Offset="0xE960" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_00F1C0" OutName="ydan_room_0Tex_00F1C0" Format="ci8" Width="32" Height="64" Offset="0xF160" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_00F9C0" OutName="ydan_room_0Tex_00F9C0" Format="rgba16" Width="64" Height="32" Offset="0xF960" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_0109C0" OutName="ydan_room_0Tex_0109C0" Format="ci8" Width="32" Height="64" Offset="0x10960" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_012F48" OutName="ydan_room_0Tex_012F48" Format="rgba16" Width="32" Height="64" Offset="0x12EE8" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_013F48" OutName="ydan_room_0Tex_013F48" Format="ci8" Width="32" Height="32" Offset="0x13EE8" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_0Tex_014348" OutName="ydan_room_0Tex_014348" Format="ia16" Width="32" Height="64" Offset="0x142E8" AddedByScript="true"/>
         <Room Name="ydan_room_0" Offset="0x0"/>
     </File>
     <File Name="ydan_room_1" Segment="3">
+        <Texture Name="ydan_room_1Tex_000F98" OutName="ydan_room_1Tex_000F98" Format="ci8" Width="32" Height="64" Offset="0xEE8" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_1Tex_001798" OutName="ydan_room_1Tex_001798" Format="ci8" Width="32" Height="64" Offset="0x16E8" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_1Tex_001F98" OutName="ydan_room_1Tex_001F98" Format="ci8" Width="32" Height="64" Offset="0x1EE8" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_1Tex_002798" OutName="ydan_room_1Tex_002798" Format="ci8" Width="32" Height="64" Offset="0x26E8" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_1Tex_003200" OutName="ydan_room_1Tex_003200" Format="ia16" Width="32" Height="64" Offset="0x3150" AddedByScript="true"/>
         <Room Name="ydan_room_1" Offset="0x0"/>
     </File>
     <File Name="ydan_room_2" Segment="3">
+        <Texture Name="ydan_room_2Tex_001D08" OutName="ydan_room_2Tex_001D08" Format="ci8" Width="32" Height="64" Offset="0x1C08" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_2Tex_002508" OutName="ydan_room_2Tex_002508" Format="ci8" Width="32" Height="64" Offset="0x2408" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_2Tex_002D08" OutName="ydan_room_2Tex_002D08" Format="ci8" Width="32" Height="64" Offset="0x2C08" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_2Tex_003508" OutName="ydan_room_2Tex_003508" Format="ci8" Width="32" Height="64" Offset="0x3408" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_2Tex_003D08" OutName="ydan_room_2Tex_003D08" Format="ci8" Width="32" Height="64" Offset="0x3C08" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_2Tex_004508" OutName="ydan_room_2Tex_004508" Format="ci8" Width="32" Height="64" Offset="0x4408" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_2Tex_004F28" OutName="ydan_room_2Tex_004F28" Format="rgba16" Width="32" Height="64" Offset="0x4E28" AddedByScript="true"/>
         <Room Name="ydan_room_2" Offset="0x0"/>
     </File>
     <File Name="ydan_room_3" Segment="3">
+        <Texture Name="ydan_room_3Tex_0074C0" OutName="ydan_room_3Tex_0074C0" Format="rgba16" Width="32" Height="64" Offset="0x74B0" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_0084C0" OutName="ydan_room_3Tex_0084C0" Format="ci8" Width="32" Height="64" Offset="0x84B0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_008CC0" OutName="ydan_room_3Tex_008CC0" Format="ci8" Width="32" Height="64" Offset="0x8CB0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_0094C0" OutName="ydan_room_3Tex_0094C0" Format="ci8" Width="32" Height="64" Offset="0x94B0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_009CC0" OutName="ydan_room_3Tex_009CC0" Format="ci8" Width="32" Height="32" Offset="0x9CB0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_00A0C0" OutName="ydan_room_3Tex_00A0C0" Format="ci8" Width="32" Height="64" Offset="0xA0B0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_00A8C0" OutName="ydan_room_3Tex_00A8C0" Format="ci8" Width="64" Height="32" Offset="0xA8B0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_00B0C0" OutName="ydan_room_3Tex_00B0C0" Format="ci8" Width="32" Height="32" Offset="0xB0B0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_00B4C0" OutName="ydan_room_3Tex_00B4C0" Format="ci8" Width="32" Height="32" Offset="0xB4B0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_00B8C0" OutName="ydan_room_3Tex_00B8C0" Format="ci8" Width="32" Height="64" Offset="0xB8B0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_00C0C0" OutName="ydan_room_3Tex_00C0C0" Format="ci8" Width="32" Height="64" Offset="0xC0B0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_00C8C0" OutName="ydan_room_3Tex_00C8C0" Format="ci8" Width="32" Height="64" Offset="0xC8B0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_00D0C0" OutName="ydan_room_3Tex_00D0C0" Format="ci8" Width="32" Height="32" Offset="0xD0B0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_00D4C0" OutName="ydan_room_3Tex_00D4C0" Format="ci8" Width="32" Height="32" Offset="0xD4B0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_00D8C0" OutName="ydan_room_3Tex_00D8C0" Format="ci8" Width="32" Height="64" Offset="0xD8B0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_00E0C0" OutName="ydan_room_3Tex_00E0C0" Format="ci8" Width="32" Height="64" Offset="0xE0B0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_00E8C0" OutName="ydan_room_3Tex_00E8C0" Format="rgba16" Width="64" Height="32" Offset="0xE8B0" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_00F8C0" OutName="ydan_room_3Tex_00F8C0" Format="ci8" Width="32" Height="64" Offset="0xF8B0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_011DB0" OutName="ydan_room_3Tex_011DB0" Format="rgba16" Width="32" Height="64" Offset="0x11DA0" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_012DB0" OutName="ydan_room_3Tex_012DB0" Format="ci8" Width="32" Height="32" Offset="0x12DA0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_3Tex_0131B0" OutName="ydan_room_3Tex_0131B0" Format="ia16" Width="32" Height="64" Offset="0x131A0" AddedByScript="true"/>
         <Room Name="ydan_room_3" Offset="0x0"/>
     </File>
     <File Name="ydan_room_4" Segment="3">
+        <Texture Name="ydan_room_4Tex_001920" OutName="ydan_room_4Tex_001920" Format="ci8" Width="32" Height="64" Offset="0x18C0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_4Tex_002120" OutName="ydan_room_4Tex_002120" Format="ci8" Width="32" Height="64" Offset="0x20C0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_4Tex_002920" OutName="ydan_room_4Tex_002920" Format="ci8" Width="32" Height="64" Offset="0x28C0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_4Tex_003120" OutName="ydan_room_4Tex_003120" Format="ci8" Width="64" Height="32" Offset="0x30C0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_4Tex_003C28" OutName="ydan_room_4Tex_003C28" Format="ia16" Width="32" Height="64" Offset="0x3BC8" AddedByScript="true"/>
         <Room Name="ydan_room_4" Offset="0x0"/>
     </File>
     <File Name="ydan_room_5" Segment="3">
+        <Texture Name="ydan_room_5Tex_003F88" OutName="ydan_room_5Tex_003F88" Format="ci8" Width="32" Height="64" Offset="0x3F18" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_5Tex_004788" OutName="ydan_room_5Tex_004788" Format="ci8" Width="32" Height="64" Offset="0x4718" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_5Tex_004F88" OutName="ydan_room_5Tex_004F88" Format="ci8" Width="32" Height="64" Offset="0x4F18" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_5Tex_005788" OutName="ydan_room_5Tex_005788" Format="ci8" Width="32" Height="32" Offset="0x5718" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_5Tex_005B88" OutName="ydan_room_5Tex_005B88" Format="ci8" Width="32" Height="64" Offset="0x5B18" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_5Tex_006388" OutName="ydan_room_5Tex_006388" Format="ci8" Width="64" Height="32" Offset="0x6318" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_5Tex_006B88" OutName="ydan_room_5Tex_006B88" Format="ci8" Width="32" Height="32" Offset="0x6B18" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_5Tex_006F88" OutName="ydan_room_5Tex_006F88" Format="ci8" Width="32" Height="32" Offset="0x6F18" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_5Tex_007388" OutName="ydan_room_5Tex_007388" Format="ci8" Width="32" Height="32" Offset="0x7318" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_5Tex_007788" OutName="ydan_room_5Tex_007788" Format="ci8" Width="32" Height="32" Offset="0x7718" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_5Tex_007B88" OutName="ydan_room_5Tex_007B88" Format="ci8" Width="32" Height="64" Offset="0x7B18" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
         <Room Name="ydan_room_5" Offset="0x0"/>
     </File>
     <File Name="ydan_room_6" Segment="3">
+        <Texture Name="ydan_room_6Tex_001F00" OutName="ydan_room_6Tex_001F00" Format="ci8" Width="32" Height="64" Offset="0x1EC0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_6Tex_002700" OutName="ydan_room_6Tex_002700" Format="ci8" Width="32" Height="64" Offset="0x26C0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_6Tex_002F00" OutName="ydan_room_6Tex_002F00" Format="ci8" Width="32" Height="64" Offset="0x2EC0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_6Tex_003700" OutName="ydan_room_6Tex_003700" Format="ci8" Width="32" Height="64" Offset="0x36C0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_6Tex_003F00" OutName="ydan_room_6Tex_003F00" Format="ci8" Width="32" Height="64" Offset="0x3EC0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_6Tex_004700" OutName="ydan_room_6Tex_004700" Format="ci8" Width="32" Height="64" Offset="0x46C0" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
         <Room Name="ydan_room_6" Offset="0x0"/>
     </File>
     <File Name="ydan_room_7" Segment="3">
+        <Texture Name="ydan_room_7Tex_002C98" OutName="ydan_room_7Tex_002C98" Format="ci8" Width="32" Height="64" Offset="0x2B08" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_7Tex_003498" OutName="ydan_room_7Tex_003498" Format="ci8" Width="32" Height="64" Offset="0x3308" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_7Tex_003C98" OutName="ydan_room_7Tex_003C98" Format="ci8" Width="32" Height="64" Offset="0x3B08" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_7Tex_004498" OutName="ydan_room_7Tex_004498" Format="ci8" Width="32" Height="64" Offset="0x4308" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_7Tex_004C98" OutName="ydan_room_7Tex_004C98" Format="ci8" Width="64" Height="32" Offset="0x4B08" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_7Tex_005498" OutName="ydan_room_7Tex_005498" Format="ci8" Width="32" Height="32" Offset="0x5308" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_7Tex_005898" OutName="ydan_room_7Tex_005898" Format="ci8" Width="32" Height="64" Offset="0x5708" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_7Tex_006098" OutName="ydan_room_7Tex_006098" Format="ci8" Width="32" Height="64" Offset="0x5F08" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_7Tex_006898" OutName="ydan_room_7Tex_006898" Format="ci8" Width="32" Height="32" Offset="0x6708" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_7Tex_006C98" OutName="ydan_room_7Tex_006C98" Format="ci8" Width="32" Height="32" Offset="0x6B08" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_7Tex_007098" OutName="ydan_room_7Tex_007098" Format="ci8" Width="32" Height="64" Offset="0x6F08" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_7Tex_007A98" OutName="ydan_room_7Tex_007A98" Format="rgba16" Width="32" Height="64" Offset="0x7908" AddedByScript="true"/>
         <Room Name="ydan_room_7" Offset="0x0"/>
     </File>
     <File Name="ydan_room_8" Segment="3">
+        <Texture Name="ydan_room_8Tex_000988" OutName="ydan_room_8Tex_000988" Format="ci8" Width="32" Height="32" Offset="0x8F8" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
         <Room Name="ydan_room_8" Offset="0x0"/>
     </File>
     <File Name="ydan_room_9" Segment="3">
+        <Texture Name="ydan_room_9Tex_002480" OutName="ydan_room_9Tex_002480" Format="ci8" Width="32" Height="64" Offset="0x2480" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_9Tex_002C80" OutName="ydan_room_9Tex_002C80" Format="ci8" Width="32" Height="64" Offset="0x2C80" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_9Tex_003480" OutName="ydan_room_9Tex_003480" Format="ci8" Width="32" Height="64" Offset="0x3480" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_9Tex_003C80" OutName="ydan_room_9Tex_003C80" Format="ci8" Width="32" Height="64" Offset="0x3C80" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_9Tex_004480" OutName="ydan_room_9Tex_004480" Format="ci8" Width="32" Height="64" Offset="0x4480" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_9Tex_004C80" OutName="ydan_room_9Tex_004C80" Format="ci8" Width="32" Height="64" Offset="0x4C80" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_9Tex_005480" OutName="ydan_room_9Tex_005480" Format="ci8" Width="32" Height="64" Offset="0x5480" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_9Tex_005C80" OutName="ydan_room_9Tex_005C80" Format="ci8" Width="32" Height="64" Offset="0x5C80" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_9Tex_006480" OutName="ydan_room_9Tex_006480" Format="ci8" Width="32" Height="64" Offset="0x6480" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_9Tex_007498" OutName="ydan_room_9Tex_007498" Format="rgba16" Width="32" Height="64" Offset="0x7498" AddedByScript="true"/>
+        <Texture Name="ydan_room_9Tex_008498" OutName="ydan_room_9Tex_008498" Format="ci8" Width="32" Height="32" Offset="0x8498" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_9Tex_008898" OutName="ydan_room_9Tex_008898" Format="ia16" Width="32" Height="64" Offset="0x8898" AddedByScript="true"/>
         <Room Name="ydan_room_9" Offset="0x0"/>
     </File>
     <File Name="ydan_room_10" Segment="3">
+        <Texture Name="ydan_room_10Tex_001BE0" OutName="ydan_room_10Tex_001BE0" Format="ci8" Width="32" Height="64" Offset="0x1B60" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_10Tex_0023E0" OutName="ydan_room_10Tex_0023E0" Format="ci8" Width="32" Height="64" Offset="0x2360" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_10Tex_002BE0" OutName="ydan_room_10Tex_002BE0" Format="ci8" Width="32" Height="64" Offset="0x2B60" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_10Tex_0033E0" OutName="ydan_room_10Tex_0033E0" Format="ci8" Width="32" Height="64" Offset="0x3360" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_10Tex_003DF8" OutName="ydan_room_10Tex_003DF8" Format="rgba16" Width="32" Height="64" Offset="0x3D78" AddedByScript="true"/>
         <Room Name="ydan_room_10" Offset="0x0"/>
     </File>
     <File Name="ydan_room_11" Segment="3">
+        <Texture Name="ydan_room_11Tex_003CD8" OutName="ydan_room_11Tex_003CD8" Format="ci8" Width="32" Height="64" Offset="0x3CD8" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_11Tex_0044D8" OutName="ydan_room_11Tex_0044D8" Format="rgba16" Width="32" Height="64" Offset="0x44D8" AddedByScript="true"/>
+        <Texture Name="ydan_room_11Tex_0054D8" OutName="ydan_room_11Tex_0054D8" Format="ci8" Width="32" Height="64" Offset="0x54D8" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_11Tex_005CD8" OutName="ydan_room_11Tex_005CD8" Format="ci8" Width="32" Height="32" Offset="0x5CD8" ExternalTlut="ydan_scene" ExternalTlutOffset="0xB800" AddedByScript="true"/>
+        <Texture Name="ydan_room_11Tex_006968" OutName="ydan_room_11Tex_006968" Format="ia8" Width="64" Height="32" Offset="0x6968" AddedByScript="true"/>
         <Room Name="ydan_room_11" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/N64_PAL_11/scenes/dungeons/ydan_boss.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/dungeons/ydan_boss.xml
@@ -1,11 +1,26 @@
 <Root>
     <File Name="ydan_boss_scene" Segment="2">
+        <Texture Name="ydan_boss_sceneTex_000F38" OutName="ydan_boss_sceneTex_000F38" Format="ci8" Width="32" Height="64" Offset="0xF38" TlutOffset="0xD30" AddedByScript="true"/>
+        <Texture Name="ydan_boss_sceneTLUT_000D30" OutName="ydan_boss_sceneTLUT_000D30" Format="rgba16" Width="16" Height="16" Offset="0xD30" AddedByScript="true"/>
         <Scene Name="ydan_boss_scene" Offset="0x0"/>
     </File>
     <File Name="ydan_boss_room_0" Segment="3">
+        <Texture Name="ydan_boss_room_0Tex_001790" OutName="ydan_boss_room_0Tex_001790" Format="ci8" Width="32" Height="64" Offset="0x1790" ExternalTlut="ydan_boss_scene" ExternalTlutOffset="0xD30" AddedByScript="true"/>
+        <Texture Name="ydan_boss_room_0Tex_001F90" OutName="ydan_boss_room_0Tex_001F90" Format="ci8" Width="32" Height="64" Offset="0x1F90" ExternalTlut="ydan_boss_scene" ExternalTlutOffset="0xD30" AddedByScript="true"/>
+        <Texture Name="ydan_boss_room_0Tex_002790" OutName="ydan_boss_room_0Tex_002790" Format="ci8" Width="32" Height="64" Offset="0x2790" ExternalTlut="ydan_boss_scene" ExternalTlutOffset="0xD30" AddedByScript="true"/>
+        <Texture Name="ydan_boss_room_0Tex_002F90" OutName="ydan_boss_room_0Tex_002F90" Format="ci8" Width="32" Height="64" Offset="0x2F90" ExternalTlut="ydan_boss_scene" ExternalTlutOffset="0xD30" AddedByScript="true"/>
+        <Texture Name="ydan_boss_room_0Tex_003790" OutName="ydan_boss_room_0Tex_003790" Format="ci8" Width="32" Height="64" Offset="0x3790" ExternalTlut="ydan_boss_scene" ExternalTlutOffset="0xD30" AddedByScript="true"/>
+        <Texture Name="ydan_boss_room_0Tex_003F90" OutName="ydan_boss_room_0Tex_003F90" Format="ci8" Width="32" Height="64" Offset="0x3F90" ExternalTlut="ydan_boss_scene" ExternalTlutOffset="0xD30" AddedByScript="true"/>
+        <Texture Name="ydan_boss_room_0Tex_004BF0" OutName="ydan_boss_room_0Tex_004BF0" Format="rgba16" Width="32" Height="64" Offset="0x4BF0" AddedByScript="true"/>
+        <Texture Name="ydan_boss_room_0Tex_005BF0" OutName="ydan_boss_room_0Tex_005BF0" Format="ci8" Width="32" Height="32" Offset="0x5BF0" ExternalTlut="ydan_boss_scene" ExternalTlutOffset="0xD30" AddedByScript="true"/>
+        <Texture Name="ydan_boss_room_0Tex_005FF0" OutName="ydan_boss_room_0Tex_005FF0" Format="ia16" Width="32" Height="64" Offset="0x5FF0" AddedByScript="true"/>
         <Room Name="ydan_boss_room_0" Offset="0x0"/>
     </File>
     <File Name="ydan_boss_room_1" Segment="3">
+        <Texture Name="ydan_boss_room_1Tex_003B38" OutName="ydan_boss_room_1Tex_003B38" Format="rgba16" Width="32" Height="64" Offset="0x3B38" AddedByScript="true"/>
+        <Texture Name="ydan_boss_room_1Tex_004B38" OutName="ydan_boss_room_1Tex_004B38" Format="ci8" Width="32" Height="64" Offset="0x4B38" ExternalTlut="ydan_boss_scene" ExternalTlutOffset="0xD30" AddedByScript="true"/>
+        <Texture Name="ydan_boss_room_1Tex_005338" OutName="ydan_boss_room_1Tex_005338" Format="ci8" Width="32" Height="32" Offset="0x5338" ExternalTlut="ydan_boss_scene" ExternalTlutOffset="0xD30" AddedByScript="true"/>
+        <Texture Name="ydan_boss_room_1Tex_005FE8" OutName="ydan_boss_room_1Tex_005FE8" Format="ia8" Width="64" Height="32" Offset="0x5FE8" AddedByScript="true"/>
         <Room Name="ydan_boss_room_1" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/N64_PAL_11/scenes/indoors/bowling.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/indoors/bowling.xml
@@ -1,5 +1,33 @@
 <Root>
     <File Name="bowling_scene" Segment="2">
+        <Texture Name="bowling_sceneTex_001AA0" OutName="bowling_sceneTex_001AA0" Format="rgba16" Width="32" Height="32" Offset="0x1AA0" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_0022A0" OutName="bowling_sceneTex_0022A0" Format="i4" Width="16" Height="16" Offset="0x22A0" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_002320" OutName="bowling_sceneTex_002320" Format="rgba16" Width="16" Height="32" Offset="0x2320" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_002720" OutName="bowling_sceneTex_002720" Format="rgba16" Width="32" Height="32" Offset="0x2720" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_002F20" OutName="bowling_sceneTex_002F20" Format="rgba16" Width="32" Height="32" Offset="0x2F20" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_003720" OutName="bowling_sceneTex_003720" Format="i4" Width="64" Height="128" Offset="0x3720" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_004720" OutName="bowling_sceneTex_004720" Format="ia4" Width="64" Height="64" Offset="0x4720" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_004F20" OutName="bowling_sceneTex_004F20" Format="rgba16" Width="16" Height="16" Offset="0x4F20" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_005120" OutName="bowling_sceneTex_005120" Format="rgba16" Width="16" Height="16" Offset="0x5120" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_005320" OutName="bowling_sceneTex_005320" Format="rgba16" Width="16" Height="16" Offset="0x5320" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_005520" OutName="bowling_sceneTex_005520" Format="rgba16" Width="16" Height="32" Offset="0x5520" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_005920" OutName="bowling_sceneTex_005920" Format="rgba16" Width="32" Height="32" Offset="0x5920" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_006120" OutName="bowling_sceneTex_006120" Format="rgba16" Width="64" Height="32" Offset="0x6120" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_007120" OutName="bowling_sceneTex_007120" Format="ia8" Width="128" Height="32" Offset="0x7120" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_008120" OutName="bowling_sceneTex_008120" Format="rgba16" Width="32" Height="32" Offset="0x8120" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_008920" OutName="bowling_sceneTex_008920" Format="rgba16" Width="32" Height="32" Offset="0x8920" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_009120" OutName="bowling_sceneTex_009120" Format="rgba16" Width="32" Height="64" Offset="0x9120" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_00A120" OutName="bowling_sceneTex_00A120" Format="rgba16" Width="32" Height="32" Offset="0xA120" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_00A920" OutName="bowling_sceneTex_00A920" Format="i8" Width="32" Height="16" Offset="0xA920" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_00AB20" OutName="bowling_sceneTex_00AB20" Format="ia8" Width="32" Height="16" Offset="0xAB20" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_00AD20" OutName="bowling_sceneTex_00AD20" Format="i4" Width="32" Height="32" Offset="0xAD20" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_00AF20" OutName="bowling_sceneTex_00AF20" Format="ia8" Width="64" Height="32" Offset="0xAF20" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_00B720" OutName="bowling_sceneTex_00B720" Format="ia8" Width="32" Height="32" Offset="0xB720" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_00BB20" OutName="bowling_sceneTex_00BB20" Format="ia8" Width="32" Height="32" Offset="0xBB20" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_00BF20" OutName="bowling_sceneTex_00BF20" Format="rgba16" Width="32" Height="32" Offset="0xBF20" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_00C720" OutName="bowling_sceneTex_00C720" Format="ia8" Width="64" Height="64" Offset="0xC720" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_00D720" OutName="bowling_sceneTex_00D720" Format="i8" Width="32" Height="32" Offset="0xD720" AddedByScript="true"/>
+        <Texture Name="bowling_sceneTex_00DB20" OutName="bowling_sceneTex_00DB20" Format="rgba16" Width="64" Height="32" Offset="0xDB20" AddedByScript="true"/>
         <Scene Name="bowling_scene" Offset="0x0"/>
     </File>
     <File Name="bowling_room_0" Segment="3">

--- a/soh/assets/xml/N64_PAL_11/scenes/indoors/daiyousei_izumi.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/indoors/daiyousei_izumi.xml
@@ -1,5 +1,19 @@
 <Root>
     <File Name="daiyousei_izumi_scene" Segment="2">
+        <Texture Name="daiyousei_izumi_sceneTex_004800" OutName="daiyousei_izumi_sceneTex_004800" Format="i8" Width="32" Height="64" Offset="0x4800" AddedByScript="true"/>
+        <Texture Name="daiyousei_izumi_sceneTex_005000" OutName="daiyousei_izumi_sceneTex_005000" Format="rgba16" Width="32" Height="32" Offset="0x5000" AddedByScript="true"/>
+        <Texture Name="daiyousei_izumi_sceneTex_005800" OutName="daiyousei_izumi_sceneTex_005800" Format="rgba16" Width="32" Height="32" Offset="0x5800" AddedByScript="true"/>
+        <Texture Name="daiyousei_izumi_sceneTex_006000" OutName="daiyousei_izumi_sceneTex_006000" Format="ia4" Width="64" Height="128" Offset="0x6000" AddedByScript="true"/>
+        <Texture Name="daiyousei_izumi_sceneTex_007000" OutName="daiyousei_izumi_sceneTex_007000" Format="rgba16" Width="32" Height="64" Offset="0x7000" AddedByScript="true"/>
+        <Texture Name="daiyousei_izumi_sceneTex_008000" OutName="daiyousei_izumi_sceneTex_008000" Format="rgba16" Width="32" Height="64" Offset="0x8000" AddedByScript="true"/>
+        <Texture Name="daiyousei_izumi_sceneTex_009000" OutName="daiyousei_izumi_sceneTex_009000" Format="rgba16" Width="32" Height="64" Offset="0x9000" AddedByScript="true"/>
+        <Texture Name="daiyousei_izumi_sceneTex_00A000" OutName="daiyousei_izumi_sceneTex_00A000" Format="i8" Width="32" Height="64" Offset="0xA000" AddedByScript="true"/>
+        <Texture Name="daiyousei_izumi_sceneTex_00A800" OutName="daiyousei_izumi_sceneTex_00A800" Format="rgba16" Width="32" Height="32" Offset="0xA800" AddedByScript="true"/>
+        <Texture Name="daiyousei_izumi_sceneTex_00B000" OutName="daiyousei_izumi_sceneTex_00B000" Format="i8" Width="32" Height="128" Offset="0xB000" AddedByScript="true"/>
+        <Texture Name="daiyousei_izumi_sceneTex_00C000" OutName="daiyousei_izumi_sceneTex_00C000" Format="rgba16" Width="32" Height="32" Offset="0xC000" AddedByScript="true"/>
+        <Texture Name="daiyousei_izumi_sceneTex_00C800" OutName="daiyousei_izumi_sceneTex_00C800" Format="ia8" Width="64" Height="32" Offset="0xC800" AddedByScript="true"/>
+        <Texture Name="daiyousei_izumi_sceneTex_00D000" OutName="daiyousei_izumi_sceneTex_00D000" Format="rgba16" Width="32" Height="32" Offset="0xD000" AddedByScript="true"/>
+        <Texture Name="daiyousei_izumi_sceneTex_00D800" OutName="daiyousei_izumi_sceneTex_00D800" Format="rgba16" Width="32" Height="32" Offset="0xD800" AddedByScript="true"/>
         <Cutscene Name="gGreatFairyMagicCs" Offset="0x0130"/>
         <Cutscene Name="gGreatFairyDoubleMagicCs" Offset="0x13E0"/>
         <Cutscene Name="gGreatFairyDoubleDefenceCs" Offset="0x25D0"/>

--- a/soh/assets/xml/N64_PAL_11/scenes/indoors/hairal_niwa.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/indoors/hairal_niwa.xml
@@ -1,5 +1,27 @@
 <Root>
     <File Name="hairal_niwa_scene" Segment="2">
+        <Texture Name="hairal_niwa_sceneTex_003390" OutName="hairal_niwa_sceneTex_003390" Format="rgba16" Width="32" Height="32" Offset="0x3390" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_003B90" OutName="hairal_niwa_sceneTex_003B90" Format="ia16" Width="32" Height="64" Offset="0x3B90" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_004B90" OutName="hairal_niwa_sceneTex_004B90" Format="rgba16" Width="32" Height="32" Offset="0x4B90" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_005390" OutName="hairal_niwa_sceneTex_005390" Format="rgba16" Width="32" Height="32" Offset="0x5390" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_005B90" OutName="hairal_niwa_sceneTex_005B90" Format="rgba16" Width="32" Height="32" Offset="0x5B90" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_006390" OutName="hairal_niwa_sceneTex_006390" Format="rgba16" Width="32" Height="64" Offset="0x6390" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_007390" OutName="hairal_niwa_sceneTex_007390" Format="i4" Width="64" Height="64" Offset="0x7390" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_007B90" OutName="hairal_niwa_sceneTex_007B90" Format="rgba16" Width="32" Height="64" Offset="0x7B90" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_008B90" OutName="hairal_niwa_sceneTex_008B90" Format="rgba16" Width="32" Height="32" Offset="0x8B90" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_009390" OutName="hairal_niwa_sceneTex_009390" Format="rgba16" Width="32" Height="32" Offset="0x9390" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_009B90" OutName="hairal_niwa_sceneTex_009B90" Format="rgba16" Width="32" Height="64" Offset="0x9B90" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_00AB90" OutName="hairal_niwa_sceneTex_00AB90" Format="rgba16" Width="32" Height="32" Offset="0xAB90" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_00B390" OutName="hairal_niwa_sceneTex_00B390" Format="rgba16" Width="32" Height="32" Offset="0xB390" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_00BB90" OutName="hairal_niwa_sceneTex_00BB90" Format="rgba16" Width="32" Height="32" Offset="0xBB90" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_00C390" OutName="hairal_niwa_sceneTex_00C390" Format="ia4" Width="64" Height="64" Offset="0xC390" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_00CB90" OutName="hairal_niwa_sceneTex_00CB90" Format="i8" Width="32" Height="64" Offset="0xCB90" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_00D390" OutName="hairal_niwa_sceneTex_00D390" Format="ia4" Width="32" Height="128" Offset="0xD390" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_00DB90" OutName="hairal_niwa_sceneTex_00DB90" Format="rgba16" Width="32" Height="64" Offset="0xDB90" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_00EB90" OutName="hairal_niwa_sceneTex_00EB90" Format="rgba16" Width="32" Height="32" Offset="0xEB90" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_00F390" OutName="hairal_niwa_sceneTex_00F390" Format="rgba16" Width="32" Height="32" Offset="0xF390" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_00FB90" OutName="hairal_niwa_sceneTex_00FB90" Format="rgba16" Width="32" Height="32" Offset="0xFB90" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_sceneTex_010390" OutName="hairal_niwa_sceneTex_010390" Format="rgba16" Width="32" Height="64" Offset="0x10390" AddedByScript="true"/>
         <Path Name="hairal_niwa_scenePathway_000268" Offset="0x268" NumPaths="8"/>
 
         <Scene Name="hairal_niwa_scene" Offset="0x0"/>

--- a/soh/assets/xml/N64_PAL_11/scenes/indoors/hairal_niwa_n.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/indoors/hairal_niwa_n.xml
@@ -1,5 +1,18 @@
 <Root>
     <File Name="hairal_niwa_n_scene" Segment="2">
+        <Texture Name="hairal_niwa_n_sceneTex_0010F0" OutName="hairal_niwa_n_sceneTex_0010F0" Format="rgba16" Width="32" Height="32" Offset="0x10F0" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_n_sceneTex_0018F0" OutName="hairal_niwa_n_sceneTex_0018F0" Format="rgba16" Width="32" Height="32" Offset="0x18F0" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_n_sceneTex_0020F0" OutName="hairal_niwa_n_sceneTex_0020F0" Format="rgba16" Width="32" Height="32" Offset="0x20F0" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_n_sceneTex_0028F0" OutName="hairal_niwa_n_sceneTex_0028F0" Format="rgba16" Width="32" Height="64" Offset="0x28F0" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_n_sceneTex_0038F0" OutName="hairal_niwa_n_sceneTex_0038F0" Format="i4" Width="64" Height="64" Offset="0x38F0" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_n_sceneTex_0040F0" OutName="hairal_niwa_n_sceneTex_0040F0" Format="rgba16" Width="32" Height="64" Offset="0x40F0" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_n_sceneTex_0050F0" OutName="hairal_niwa_n_sceneTex_0050F0" Format="rgba16" Width="32" Height="32" Offset="0x50F0" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_n_sceneTex_0058F0" OutName="hairal_niwa_n_sceneTex_0058F0" Format="rgba16" Width="32" Height="32" Offset="0x58F0" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_n_sceneTex_0060F0" OutName="hairal_niwa_n_sceneTex_0060F0" Format="ia4" Width="32" Height="128" Offset="0x60F0" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_n_sceneTex_0068F0" OutName="hairal_niwa_n_sceneTex_0068F0" Format="rgba16" Width="32" Height="32" Offset="0x68F0" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_n_sceneTex_0070F0" OutName="hairal_niwa_n_sceneTex_0070F0" Format="rgba16" Width="32" Height="32" Offset="0x70F0" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_n_sceneTex_0078F0" OutName="hairal_niwa_n_sceneTex_0078F0" Format="rgba16" Width="32" Height="32" Offset="0x78F0" AddedByScript="true"/>
+        <Texture Name="hairal_niwa_n_sceneTex_0080F0" OutName="hairal_niwa_n_sceneTex_0080F0" Format="rgba16" Width="32" Height="64" Offset="0x80F0" AddedByScript="true"/>
         <Scene Name="hairal_niwa_n_scene" Offset="0x0"/>
     </File>
     <File Name="hairal_niwa_n_room_0" Segment="3">

--- a/soh/assets/xml/N64_PAL_11/scenes/indoors/hakasitarelay.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/indoors/hakasitarelay.xml
@@ -1,27 +1,80 @@
 <Root>
     <File Name="hakasitarelay_scene" Segment="2">
+        <Texture Name="hakasitarelay_sceneTex_00C080" OutName="hakasitarelay_sceneTex_00C080" Format="rgba16" Width="64" Height="32" Offset="0xC080" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_sceneTex_00D080" OutName="hakasitarelay_sceneTex_00D080" Format="rgba16" Width="32" Height="32" Offset="0xD080" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_sceneTex_00D880" OutName="hakasitarelay_sceneTex_00D880" Format="i4" Width="64" Height="64" Offset="0xD880" AddedByScript="true"/>
         <Scene Name="hakasitarelay_scene" Offset="0x0"/>
         <Cutscene Name="gSongOfStormsCs" Offset="0xE080"/>
     </File>
     <File Name="hakasitarelay_room_0" Segment="3">
+        <Texture Name="hakasitarelay_room_0Tex_003248" OutName="hakasitarelay_room_0Tex_003248" Format="i4" Width="32" Height="32" Offset="0x3248" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_0Tex_003448" OutName="hakasitarelay_room_0Tex_003448" Format="rgba16" Width="32" Height="64" Offset="0x3448" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_0Tex_004448" OutName="hakasitarelay_room_0Tex_004448" Format="i4" Width="128" Height="32" Offset="0x4448" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_0Tex_004C48" OutName="hakasitarelay_room_0Tex_004C48" Format="i4" Width="32" Height="128" Offset="0x4C48" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_0Tex_005448" OutName="hakasitarelay_room_0Tex_005448" Format="i8" Width="32" Height="32" Offset="0x5448" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_0Tex_005848" OutName="hakasitarelay_room_0Tex_005848" Format="i8" Width="64" Height="32" Offset="0x5848" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_0Tex_0062B8" OutName="hakasitarelay_room_0Tex_0062B8" Format="ia16" Width="128" Height="16" Offset="0x62B8" AddedByScript="true"/>
         <Room Name="hakasitarelay_room_0" Offset="0x0"/>
     </File>
     <File Name="hakasitarelay_room_1" Segment="3">
+        <Texture Name="hakasitarelay_room_1Tex_003F20" OutName="hakasitarelay_room_1Tex_003F20" Format="i8" Width="32" Height="32" Offset="0x3F20" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_1Tex_004320" OutName="hakasitarelay_room_1Tex_004320" Format="i8" Width="32" Height="32" Offset="0x4320" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_1Tex_004720" OutName="hakasitarelay_room_1Tex_004720" Format="rgba16" Width="32" Height="64" Offset="0x4720" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_1Tex_005720" OutName="hakasitarelay_room_1Tex_005720" Format="rgba16" Width="32" Height="32" Offset="0x5720" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_1Tex_005F20" OutName="hakasitarelay_room_1Tex_005F20" Format="rgba16" Width="32" Height="16" Offset="0x5F20" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_1Tex_006320" OutName="hakasitarelay_room_1Tex_006320" Format="rgba16" Width="32" Height="16" Offset="0x6320" AddedByScript="true"/>
         <Room Name="hakasitarelay_room_1" Offset="0x0"/>
     </File>
     <File Name="hakasitarelay_room_2" Segment="3">
+        <Texture Name="hakasitarelay_room_2Tex_0054A8" OutName="hakasitarelay_room_2Tex_0054A8" Format="i8" Width="32" Height="32" Offset="0x54A8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_2Tex_0058A8" OutName="hakasitarelay_room_2Tex_0058A8" Format="i8" Width="32" Height="32" Offset="0x58A8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_2Tex_005CA8" OutName="hakasitarelay_room_2Tex_005CA8" Format="rgba16" Width="32" Height="64" Offset="0x5CA8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_2Tex_006CA8" OutName="hakasitarelay_room_2Tex_006CA8" Format="i8" Width="64" Height="32" Offset="0x6CA8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_2Tex_0074A8" OutName="hakasitarelay_room_2Tex_0074A8" Format="rgba16" Width="32" Height="32" Offset="0x74A8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_2Tex_007CA8" OutName="hakasitarelay_room_2Tex_007CA8" Format="rgba16" Width="32" Height="16" Offset="0x7CA8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_2Tex_0080A8" OutName="hakasitarelay_room_2Tex_0080A8" Format="rgba16" Width="32" Height="16" Offset="0x80A8" AddedByScript="true"/>
         <Room Name="hakasitarelay_room_2" Offset="0x0"/>
     </File>
     <File Name="hakasitarelay_room_3" Segment="3">
+        <Texture Name="hakasitarelay_room_3Tex_0056E0" OutName="hakasitarelay_room_3Tex_0056E0" Format="i8" Width="32" Height="32" Offset="0x56E0" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_3Tex_005AE0" OutName="hakasitarelay_room_3Tex_005AE0" Format="i8" Width="32" Height="32" Offset="0x5AE0" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_3Tex_005EE0" OutName="hakasitarelay_room_3Tex_005EE0" Format="i4" Width="32" Height="32" Offset="0x5EE0" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_3Tex_0060E0" OutName="hakasitarelay_room_3Tex_0060E0" Format="rgba16" Width="32" Height="64" Offset="0x60E0" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_3Tex_0070E0" OutName="hakasitarelay_room_3Tex_0070E0" Format="rgba16" Width="32" Height="32" Offset="0x70E0" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_3Tex_0078E0" OutName="hakasitarelay_room_3Tex_0078E0" Format="rgba16" Width="32" Height="16" Offset="0x78E0" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_3Tex_007CE0" OutName="hakasitarelay_room_3Tex_007CE0" Format="i4" Width="128" Height="32" Offset="0x7CE0" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_3Tex_0084E0" OutName="hakasitarelay_room_3Tex_0084E0" Format="i8" Width="64" Height="32" Offset="0x84E0" AddedByScript="true"/>
         <Room Name="hakasitarelay_room_3" Offset="0x0"/>
     </File>
     <File Name="hakasitarelay_room_4" Segment="3">
+        <Texture Name="hakasitarelay_room_4Tex_001E80" OutName="hakasitarelay_room_4Tex_001E80" Format="i4" Width="32" Height="32" Offset="0x1E80" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_4Tex_002080" OutName="hakasitarelay_room_4Tex_002080" Format="i8" Width="64" Height="32" Offset="0x2080" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_4Tex_002880" OutName="hakasitarelay_room_4Tex_002880" Format="i4" Width="32" Height="128" Offset="0x2880" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_4Tex_003080" OutName="hakasitarelay_room_4Tex_003080" Format="i8" Width="32" Height="32" Offset="0x3080" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_4Tex_003480" OutName="hakasitarelay_room_4Tex_003480" Format="i8" Width="64" Height="32" Offset="0x3480" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_4Tex_003C80" OutName="hakasitarelay_room_4Tex_003C80" Format="i4" Width="64" Height="64" Offset="0x3C80" AddedByScript="true"/>
         <Room Name="hakasitarelay_room_4" Offset="0x0"/>
     </File>
     <File Name="hakasitarelay_room_5" Segment="3">
+        <Texture Name="hakasitarelay_room_5Tex_001C48" OutName="hakasitarelay_room_5Tex_001C48" Format="rgba16" Width="32" Height="32" Offset="0x1C48" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_5Tex_002448" OutName="hakasitarelay_room_5Tex_002448" Format="ci4" Width="64" Height="64" Offset="0x2448" TlutOffset="0x1C28" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_5Tex_002C48" OutName="hakasitarelay_room_5Tex_002C48" Format="i8" Width="64" Height="32" Offset="0x2C48" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_5Tex_003448" OutName="hakasitarelay_room_5Tex_003448" Format="i4" Width="64" Height="64" Offset="0x3448" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_5Tex_003C48" OutName="hakasitarelay_room_5Tex_003C48" Format="i4" Width="64" Height="64" Offset="0x3C48" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_5TLUT_001C28" OutName="hakasitarelay_room_5TLUT_001C28" Format="rgba16" Width="4" Height="4" Offset="0x1C28" AddedByScript="true"/>
         <Room Name="hakasitarelay_room_5" Offset="0x0"/>
     </File>
     <File Name="hakasitarelay_room_6" Segment="3">
+        <Texture Name="hakasitarelay_room_6Tex_0041A8" OutName="hakasitarelay_room_6Tex_0041A8" Format="rgba16" Width="16" Height="8" Offset="0x41A8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_6Tex_0042A8" OutName="hakasitarelay_room_6Tex_0042A8" Format="rgba16" Width="32" Height="32" Offset="0x42A8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_6Tex_004AA8" OutName="hakasitarelay_room_6Tex_004AA8" Format="rgba16" Width="32" Height="16" Offset="0x4AA8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_6Tex_004EA8" OutName="hakasitarelay_room_6Tex_004EA8" Format="ci4" Width="64" Height="64" Offset="0x4EA8" TlutOffset="0x4188" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_6Tex_0056A8" OutName="hakasitarelay_room_6Tex_0056A8" Format="i8" Width="64" Height="32" Offset="0x56A8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_6Tex_005EA8" OutName="hakasitarelay_room_6Tex_005EA8" Format="i4" Width="64" Height="64" Offset="0x5EA8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_6Tex_0066A8" OutName="hakasitarelay_room_6Tex_0066A8" Format="i8" Width="32" Height="32" Offset="0x66A8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_6Tex_006AA8" OutName="hakasitarelay_room_6Tex_006AA8" Format="i8" Width="64" Height="32" Offset="0x6AA8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_6Tex_0072A8" OutName="hakasitarelay_room_6Tex_0072A8" Format="i4" Width="64" Height="64" Offset="0x72A8" AddedByScript="true"/>
+        <Texture Name="hakasitarelay_room_6TLUT_004188" OutName="hakasitarelay_room_6TLUT_004188" Format="rgba16" Width="4" Height="4" Offset="0x4188" AddedByScript="true"/>
         <Room Name="hakasitarelay_room_6" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/N64_PAL_11/scenes/indoors/hylia_labo.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/indoors/hylia_labo.xml
@@ -1,5 +1,36 @@
 <Root>
     <File Name="hylia_labo_scene" Segment="2">
+        <Texture Name="hylia_labo_sceneTex_001090" OutName="hylia_labo_sceneTex_001090" Format="ia8" Width="16" Height="64" Offset="0x1090" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_001490" OutName="hylia_labo_sceneTex_001490" Format="rgba16" Width="64" Height="32" Offset="0x1490" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_002490" OutName="hylia_labo_sceneTex_002490" Format="rgba16" Width="32" Height="64" Offset="0x2490" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_003490" OutName="hylia_labo_sceneTex_003490" Format="rgba16" Width="32" Height="32" Offset="0x3490" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_003C90" OutName="hylia_labo_sceneTex_003C90" Format="rgba16" Width="32" Height="64" Offset="0x3C90" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_004C90" OutName="hylia_labo_sceneTex_004C90" Format="rgba16" Width="32" Height="32" Offset="0x4C90" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_005490" OutName="hylia_labo_sceneTex_005490" Format="rgba16" Width="32" Height="32" Offset="0x5490" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_005C90" OutName="hylia_labo_sceneTex_005C90" Format="ia8" Width="64" Height="16" Offset="0x5C90" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_006090" OutName="hylia_labo_sceneTex_006090" Format="rgba16" Width="32" Height="4" Offset="0x6090" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_006190" OutName="hylia_labo_sceneTex_006190" Format="rgba16" Width="32" Height="32" Offset="0x6190" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_006990" OutName="hylia_labo_sceneTex_006990" Format="rgba16" Width="32" Height="16" Offset="0x6990" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_006D90" OutName="hylia_labo_sceneTex_006D90" Format="ia4" Width="64" Height="128" Offset="0x6D90" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_007D90" OutName="hylia_labo_sceneTex_007D90" Format="rgba16" Width="32" Height="32" Offset="0x7D90" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_008590" OutName="hylia_labo_sceneTex_008590" Format="ia8" Width="32" Height="16" Offset="0x8590" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_008790" OutName="hylia_labo_sceneTex_008790" Format="ia8" Width="32" Height="128" Offset="0x8790" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_009790" OutName="hylia_labo_sceneTex_009790" Format="rgba16" Width="32" Height="8" Offset="0x9790" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_009990" OutName="hylia_labo_sceneTex_009990" Format="ia8" Width="16" Height="16" Offset="0x9990" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_009A90" OutName="hylia_labo_sceneTex_009A90" Format="ia8" Width="16" Height="32" Offset="0x9A90" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_009C90" OutName="hylia_labo_sceneTex_009C90" Format="ia8" Width="32" Height="32" Offset="0x9C90" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_00A090" OutName="hylia_labo_sceneTex_00A090" Format="rgba16" Width="32" Height="64" Offset="0xA090" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_00B090" OutName="hylia_labo_sceneTex_00B090" Format="rgba16" Width="64" Height="32" Offset="0xB090" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_00C090" OutName="hylia_labo_sceneTex_00C090" Format="rgba16" Width="64" Height="16" Offset="0xC090" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_00C890" OutName="hylia_labo_sceneTex_00C890" Format="rgba16" Width="32" Height="32" Offset="0xC890" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_00D090" OutName="hylia_labo_sceneTex_00D090" Format="rgba16" Width="64" Height="16" Offset="0xD090" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_00D890" OutName="hylia_labo_sceneTex_00D890" Format="rgba16" Width="64" Height="16" Offset="0xD890" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_00E090" OutName="hylia_labo_sceneTex_00E090" Format="rgba16" Width="32" Height="32" Offset="0xE090" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_00E890" OutName="hylia_labo_sceneTex_00E890" Format="rgba16" Width="32" Height="64" Offset="0xE890" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_00F890" OutName="hylia_labo_sceneTex_00F890" Format="rgba16" Width="32" Height="32" Offset="0xF890" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_010090" OutName="hylia_labo_sceneTex_010090" Format="i8" Width="32" Height="32" Offset="0x10090" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_010490" OutName="hylia_labo_sceneTex_010490" Format="i8" Width="32" Height="32" Offset="0x10490" AddedByScript="true"/>
+        <Texture Name="hylia_labo_sceneTex_010890" OutName="hylia_labo_sceneTex_010890" Format="rgba16" Width="32" Height="32" Offset="0x10890" AddedByScript="true"/>
         <Scene Name="hylia_labo_scene" Offset="0x0"/>
     </File>
     <File Name="hylia_labo_room_0" Segment="3">

--- a/soh/assets/xml/N64_PAL_11/scenes/indoors/kenjyanoma.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/indoors/kenjyanoma.xml
@@ -3,6 +3,25 @@
         <Scene Name="kenjyanoma_scene" Offset="0x0"/>
     </File>
     <File Name="kenjyanoma_room_0" Segment="3">
+        <Texture Name="kenjyanoma_room_0Tex_001618" OutName="kenjyanoma_room_0Tex_001618" Format="rgba16" Width="64" Height="32" Offset="0x1618" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_002618" OutName="kenjyanoma_room_0Tex_002618" Format="rgba16" Width="64" Height="32" Offset="0x2618" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_003618" OutName="kenjyanoma_room_0Tex_003618" Format="rgba16" Width="64" Height="32" Offset="0x3618" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_004618" OutName="kenjyanoma_room_0Tex_004618" Format="rgba16" Width="64" Height="32" Offset="0x4618" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_005618" OutName="kenjyanoma_room_0Tex_005618" Format="rgba16" Width="64" Height="32" Offset="0x5618" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_006618" OutName="kenjyanoma_room_0Tex_006618" Format="rgba16" Width="64" Height="32" Offset="0x6618" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_007618" OutName="kenjyanoma_room_0Tex_007618" Format="rgba16" Width="64" Height="32" Offset="0x7618" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_008618" OutName="kenjyanoma_room_0Tex_008618" Format="rgba16" Width="64" Height="32" Offset="0x8618" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_009618" OutName="kenjyanoma_room_0Tex_009618" Format="rgba16" Width="32" Height="64" Offset="0x9618" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_00A618" OutName="kenjyanoma_room_0Tex_00A618" Format="rgba16" Width="32" Height="64" Offset="0xA618" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_00B618" OutName="kenjyanoma_room_0Tex_00B618" Format="rgba16" Width="64" Height="32" Offset="0xB618" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_00C618" OutName="kenjyanoma_room_0Tex_00C618" Format="rgba16" Width="64" Height="32" Offset="0xC618" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_00D618" OutName="kenjyanoma_room_0Tex_00D618" Format="rgba16" Width="32" Height="32" Offset="0xD618" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_010CE8" OutName="kenjyanoma_room_0Tex_010CE8" Format="ia16" Width="32" Height="32" Offset="0x10CE8" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_0114E8" OutName="kenjyanoma_room_0Tex_0114E8" Format="i8" Width="32" Height="64" Offset="0x114E8" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_011CE8" OutName="kenjyanoma_room_0Tex_011CE8" Format="rgba16" Width="4" Height="4" Offset="0x11CE8" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_011D08" OutName="kenjyanoma_room_0Tex_011D08" Format="rgba16" Width="32" Height="32" Offset="0x11D08" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_012508" OutName="kenjyanoma_room_0Tex_012508" Format="i8" Width="32" Height="64" Offset="0x12508" AddedByScript="true"/>
+        <Texture Name="kenjyanoma_room_0Tex_012D08" OutName="kenjyanoma_room_0Tex_012D08" Format="i8" Width="32" Height="32" Offset="0x12D08" AddedByScript="true"/>
         <Room Name="kenjyanoma_room_0" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/N64_PAL_11/scenes/indoors/mahouya.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/indoors/mahouya.xml
@@ -1,5 +1,18 @@
 <Root>
     <File Name="mahouya_scene" Segment="2">
+        <Texture Name="mahouya_sceneTex_000A20" OutName="mahouya_sceneTex_000A20" Format="rgba16" Width="32" Height="32" Offset="0xA20" AddedByScript="true"/>
+        <Texture Name="mahouya_sceneTex_001220" OutName="mahouya_sceneTex_001220" Format="rgba16" Width="32" Height="32" Offset="0x1220" AddedByScript="true"/>
+        <Texture Name="mahouya_sceneTex_001A20" OutName="mahouya_sceneTex_001A20" Format="rgba16" Width="16" Height="128" Offset="0x1A20" AddedByScript="true"/>
+        <Texture Name="mahouya_sceneTex_002A20" OutName="mahouya_sceneTex_002A20" Format="rgba16" Width="32" Height="64" Offset="0x2A20" AddedByScript="true"/>
+        <Texture Name="mahouya_sceneTex_003A20" OutName="mahouya_sceneTex_003A20" Format="rgba16" Width="64" Height="32" Offset="0x3A20" AddedByScript="true"/>
+        <Texture Name="mahouya_sceneTex_004A20" OutName="mahouya_sceneTex_004A20" Format="rgba16" Width="32" Height="32" Offset="0x4A20" AddedByScript="true"/>
+        <Texture Name="mahouya_sceneTex_005220" OutName="mahouya_sceneTex_005220" Format="rgba16" Width="16" Height="128" Offset="0x5220" AddedByScript="true"/>
+        <Texture Name="mahouya_sceneTex_006220" OutName="mahouya_sceneTex_006220" Format="rgba16" Width="16" Height="128" Offset="0x6220" AddedByScript="true"/>
+        <Texture Name="mahouya_sceneTex_007220" OutName="mahouya_sceneTex_007220" Format="rgba16" Width="32" Height="32" Offset="0x7220" AddedByScript="true"/>
+        <Texture Name="mahouya_sceneTex_007A20" OutName="mahouya_sceneTex_007A20" Format="rgba16" Width="64" Height="32" Offset="0x7A20" AddedByScript="true"/>
+        <Texture Name="mahouya_sceneTex_008A20" OutName="mahouya_sceneTex_008A20" Format="i8" Width="16" Height="128" Offset="0x8A20" AddedByScript="true"/>
+        <Texture Name="mahouya_sceneTex_009220" OutName="mahouya_sceneTex_009220" Format="rgba16" Width="32" Height="32" Offset="0x9220" AddedByScript="true"/>
+        <Texture Name="mahouya_sceneTex_009A20" OutName="mahouya_sceneTex_009A20" Format="rgba16" Width="64" Height="32" Offset="0x9A20" AddedByScript="true"/>
         <Scene Name="mahouya_scene" Offset="0x0"/>
     </File>
     <File Name="mahouya_room_0" Segment="3">

--- a/soh/assets/xml/N64_PAL_11/scenes/indoors/miharigoya.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/indoors/miharigoya.xml
@@ -1,5 +1,19 @@
 <Root>
     <File Name="miharigoya_scene" Segment="2">
+        <Texture Name="miharigoya_sceneTex_000C50" OutName="miharigoya_sceneTex_000C50" Format="ia8" Width="64" Height="16" Offset="0xC50" AddedByScript="true"/>
+        <Texture Name="miharigoya_sceneTex_001050" OutName="miharigoya_sceneTex_001050" Format="rgba16" Width="32" Height="4" Offset="0x1050" AddedByScript="true"/>
+        <Texture Name="miharigoya_sceneTex_001150" OutName="miharigoya_sceneTex_001150" Format="ia8" Width="32" Height="16" Offset="0x1150" AddedByScript="true"/>
+        <Texture Name="miharigoya_sceneTex_003350" OutName="miharigoya_sceneTex_003350" Format="rgba16" Width="32" Height="8" Offset="0x3350" AddedByScript="true"/>
+        <Texture Name="miharigoya_sceneTex_004550" OutName="miharigoya_sceneTex_004550" Format="i8" Width="32" Height="32" Offset="0x4550" AddedByScript="true"/>
+        <Texture Name="miharigoya_sceneTex_004950" OutName="miharigoya_sceneTex_004950" Format="rgba16" Width="64" Height="32" Offset="0x4950" AddedByScript="true"/>
+        <Texture Name="miharigoya_sceneTex_005950" OutName="miharigoya_sceneTex_005950" Format="i8" Width="32" Height="32" Offset="0x5950" AddedByScript="true"/>
+        <Texture Name="miharigoya_sceneTex_005D50" OutName="miharigoya_sceneTex_005D50" Format="rgba16" Width="64" Height="16" Offset="0x5D50" AddedByScript="true"/>
+        <Texture Name="miharigoya_sceneTex_007550" OutName="miharigoya_sceneTex_007550" Format="rgba16" Width="32" Height="64" Offset="0x7550" AddedByScript="true"/>
+        <Texture Name="miharigoya_sceneTex_008550" OutName="miharigoya_sceneTex_008550" Format="i4" Width="64" Height="64" Offset="0x8550" AddedByScript="true"/>
+        <Texture Name="miharigoya_sceneTex_008D50" OutName="miharigoya_sceneTex_008D50" Format="i8" Width="64" Height="64" Offset="0x8D50" AddedByScript="true"/>
+        <Texture Name="miharigoya_sceneTex_009D50" OutName="miharigoya_sceneTex_009D50" Format="rgba16" Width="32" Height="64" Offset="0x9D50" AddedByScript="true"/>
+        <Texture Name="miharigoya_sceneTex_00AD50" OutName="miharigoya_sceneTex_00AD50" Format="i8" Width="64" Height="64" Offset="0xAD50" AddedByScript="true"/>
+        <Texture Name="miharigoya_sceneTex_00BD50" OutName="miharigoya_sceneTex_00BD50" Format="rgba16" Width="32" Height="32" Offset="0xBD50" AddedByScript="true"/>
         <Texture Name="gGuardHouseOutSideView2NightTex" OutName="view_2_night" Format="rgba16" Width="64" Height="32" Offset="0x1350"/>
         <Texture Name="gGuardHouseOutSideView2DayTex" OutName="view_2_day" Format="rgba16" Width="64" Height="32" Offset="0x2350"/>
         <Texture Name="gGuardHouseOutSideView1NightTex" OutName="view_1_night" Format="rgba16" Width="64" Height="32" Offset="0x3550"/>

--- a/soh/assets/xml/N64_PAL_11/scenes/indoors/nakaniwa.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/indoors/nakaniwa.xml
@@ -8,6 +8,37 @@
         <Scene Name="nakaniwa_scene" Offset="0x0"/>
     </File>
     <File Name="nakaniwa_room_0" Segment="3">
+        <Texture Name="nakaniwa_room_0Tex_007218" OutName="nakaniwa_room_0Tex_007218" Format="rgba16" Width="16" Height="16" Offset="0x7218" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_007418" OutName="nakaniwa_room_0Tex_007418" Format="rgba16" Width="16" Height="16" Offset="0x7418" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_007618" OutName="nakaniwa_room_0Tex_007618" Format="rgba16" Width="16" Height="16" Offset="0x7618" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_007818" OutName="nakaniwa_room_0Tex_007818" Format="rgba16" Width="16" Height="16" Offset="0x7818" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_007A18" OutName="nakaniwa_room_0Tex_007A18" Format="rgba16" Width="32" Height="32" Offset="0x7A18" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_008218" OutName="nakaniwa_room_0Tex_008218" Format="rgba16" Width="16" Height="16" Offset="0x8218" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_008418" OutName="nakaniwa_room_0Tex_008418" Format="rgba16" Width="16" Height="16" Offset="0x8418" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_008618" OutName="nakaniwa_room_0Tex_008618" Format="rgba16" Width="32" Height="32" Offset="0x8618" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_008E18" OutName="nakaniwa_room_0Tex_008E18" Format="rgba16" Width="32" Height="64" Offset="0x8E18" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_009E18" OutName="nakaniwa_room_0Tex_009E18" Format="rgba16" Width="32" Height="32" Offset="0x9E18" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_00A618" OutName="nakaniwa_room_0Tex_00A618" Format="rgba16" Width="32" Height="64" Offset="0xA618" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_00B618" OutName="nakaniwa_room_0Tex_00B618" Format="rgba16" Width="32" Height="64" Offset="0xB618" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_00C618" OutName="nakaniwa_room_0Tex_00C618" Format="i4" Width="64" Height="64" Offset="0xC618" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_00CE18" OutName="nakaniwa_room_0Tex_00CE18" Format="rgba16" Width="32" Height="64" Offset="0xCE18" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_00DE18" OutName="nakaniwa_room_0Tex_00DE18" Format="rgba16" Width="32" Height="32" Offset="0xDE18" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_00E618" OutName="nakaniwa_room_0Tex_00E618" Format="rgba16" Width="16" Height="64" Offset="0xE618" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_00EE18" OutName="nakaniwa_room_0Tex_00EE18" Format="rgba16" Width="32" Height="32" Offset="0xEE18" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_00F618" OutName="nakaniwa_room_0Tex_00F618" Format="rgba16" Width="32" Height="32" Offset="0xF618" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_00FE18" OutName="nakaniwa_room_0Tex_00FE18" Format="rgba16" Width="32" Height="32" Offset="0xFE18" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_010618" OutName="nakaniwa_room_0Tex_010618" Format="rgba16" Width="32" Height="32" Offset="0x10618" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_010E18" OutName="nakaniwa_room_0Tex_010E18" Format="rgba16" Width="32" Height="32" Offset="0x10E18" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_011618" OutName="nakaniwa_room_0Tex_011618" Format="rgba16" Width="32" Height="32" Offset="0x11618" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_011E18" OutName="nakaniwa_room_0Tex_011E18" Format="rgba16" Width="32" Height="32" Offset="0x11E18" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_012618" OutName="nakaniwa_room_0Tex_012618" Format="rgba16" Width="32" Height="32" Offset="0x12618" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_012E18" OutName="nakaniwa_room_0Tex_012E18" Format="rgba16" Width="64" Height="16" Offset="0x12E18" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_013618" OutName="nakaniwa_room_0Tex_013618" Format="rgba16" Width="32" Height="32" Offset="0x13618" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_013E18" OutName="nakaniwa_room_0Tex_013E18" Format="i4" Width="32" Height="32" Offset="0x13E18" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_014EC0" OutName="nakaniwa_room_0Tex_014EC0" Format="ia16" Width="32" Height="32" Offset="0x14EC0" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_0156C0" OutName="nakaniwa_room_0Tex_0156C0" Format="ia16" Width="64" Height="32" Offset="0x156C0" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_0166C0" OutName="nakaniwa_room_0Tex_0166C0" Format="rgba16" Width="32" Height="32" Offset="0x166C0" AddedByScript="true"/>
+        <Texture Name="nakaniwa_room_0Tex_016EC0" OutName="nakaniwa_room_0Tex_016EC0" Format="ia16" Width="32" Height="64" Offset="0x16EC0" AddedByScript="true"/>
         <Room Name="nakaniwa_room_0" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/N64_PAL_11/scenes/indoors/syatekijyou.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/indoors/syatekijyou.xml
@@ -1,5 +1,27 @@
 <Root>
     <File Name="syatekijyou_scene" Segment="2">
+        <Texture Name="syatekijyou_sceneTex_001C40" OutName="syatekijyou_sceneTex_001C40" Format="rgba16" Width="32" Height="4" Offset="0x1C40" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_001D40" OutName="syatekijyou_sceneTex_001D40" Format="rgba16" Width="32" Height="16" Offset="0x1D40" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_002140" OutName="syatekijyou_sceneTex_002140" Format="rgba16" Width="32" Height="16" Offset="0x2140" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_002540" OutName="syatekijyou_sceneTex_002540" Format="ia4" Width="32" Height="32" Offset="0x2540" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_002740" OutName="syatekijyou_sceneTex_002740" Format="rgba16" Width="64" Height="32" Offset="0x2740" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_003740" OutName="syatekijyou_sceneTex_003740" Format="ia8" Width="32" Height="16" Offset="0x3740" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_003940" OutName="syatekijyou_sceneTex_003940" Format="rgba16" Width="4" Height="16" Offset="0x3940" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_0039C0" OutName="syatekijyou_sceneTex_0039C0" Format="ia8" Width="16" Height="64" Offset="0x39C0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_003DC0" OutName="syatekijyou_sceneTex_003DC0" Format="rgba16" Width="32" Height="16" Offset="0x3DC0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_0041C0" OutName="syatekijyou_sceneTex_0041C0" Format="rgba16" Width="32" Height="64" Offset="0x41C0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_0051C0" OutName="syatekijyou_sceneTex_0051C0" Format="ia8" Width="16" Height="16" Offset="0x51C0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_0052C0" OutName="syatekijyou_sceneTex_0052C0" Format="ia8" Width="16" Height="32" Offset="0x52C0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_0054C0" OutName="syatekijyou_sceneTex_0054C0" Format="rgba16" Width="32" Height="32" Offset="0x54C0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_005CC0" OutName="syatekijyou_sceneTex_005CC0" Format="rgba16" Width="32" Height="64" Offset="0x5CC0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_006CC0" OutName="syatekijyou_sceneTex_006CC0" Format="rgba16" Width="32" Height="64" Offset="0x6CC0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_007CC0" OutName="syatekijyou_sceneTex_007CC0" Format="i8" Width="64" Height="64" Offset="0x7CC0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_008CC0" OutName="syatekijyou_sceneTex_008CC0" Format="rgba16" Width="32" Height="64" Offset="0x8CC0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_009CC0" OutName="syatekijyou_sceneTex_009CC0" Format="ia4" Width="64" Height="64" Offset="0x9CC0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_00A4C0" OutName="syatekijyou_sceneTex_00A4C0" Format="rgba16" Width="32" Height="32" Offset="0xA4C0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_00ACC0" OutName="syatekijyou_sceneTex_00ACC0" Format="ia8" Width="32" Height="32" Offset="0xACC0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_00B0C0" OutName="syatekijyou_sceneTex_00B0C0" Format="i4" Width="32" Height="32" Offset="0xB0C0" AddedByScript="true"/>
+        <Texture Name="syatekijyou_sceneTex_00B2C0" OutName="syatekijyou_sceneTex_00B2C0" Format="rgba16" Width="64" Height="32" Offset="0xB2C0" AddedByScript="true"/>
         <Scene Name="syatekijyou_scene" Offset="0x0"/>
     </File>
     <File Name="syatekijyou_room_0" Segment="3">

--- a/soh/assets/xml/N64_PAL_11/scenes/indoors/takaraya.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/indoors/takaraya.xml
@@ -1,26 +1,53 @@
 <Root>
     <File Name="takaraya_scene" Segment="2">
+        <Texture Name="takaraya_sceneTex_0051B0" OutName="takaraya_sceneTex_0051B0" Format="rgba16" Width="32" Height="32" Offset="0x51B0" AddedByScript="true"/>
+        <Texture Name="takaraya_sceneTex_0059B0" OutName="takaraya_sceneTex_0059B0" Format="rgba16" Width="32" Height="32" Offset="0x59B0" AddedByScript="true"/>
+        <Texture Name="takaraya_sceneTex_0061B0" OutName="takaraya_sceneTex_0061B0" Format="rgba16" Width="32" Height="32" Offset="0x61B0" AddedByScript="true"/>
+        <Texture Name="takaraya_sceneTex_0069B0" OutName="takaraya_sceneTex_0069B0" Format="rgba16" Width="32" Height="32" Offset="0x69B0" AddedByScript="true"/>
         <Scene Name="takaraya_scene" Offset="0x0"/>
     </File>
     <File Name="takaraya_room_0" Segment="3">
+        <Texture Name="takaraya_room_0Tex_003BE0" OutName="takaraya_room_0Tex_003BE0" Format="rgba16" Width="16" Height="64" Offset="0x3BE0" AddedByScript="true"/>
+        <Texture Name="takaraya_room_0Tex_0043E0" OutName="takaraya_room_0Tex_0043E0" Format="rgba16" Width="32" Height="32" Offset="0x43E0" AddedByScript="true"/>
+        <Texture Name="takaraya_room_0Tex_004BE0" OutName="takaraya_room_0Tex_004BE0" Format="rgba16" Width="64" Height="32" Offset="0x4BE0" AddedByScript="true"/>
+        <Texture Name="takaraya_room_0Tex_005BE0" OutName="takaraya_room_0Tex_005BE0" Format="rgba16" Width="32" Height="32" Offset="0x5BE0" AddedByScript="true"/>
+        <Texture Name="takaraya_room_0Tex_0063E0" OutName="takaraya_room_0Tex_0063E0" Format="rgba16" Width="32" Height="32" Offset="0x63E0" AddedByScript="true"/>
+        <Texture Name="takaraya_room_0Tex_006BE0" OutName="takaraya_room_0Tex_006BE0" Format="rgba16" Width="32" Height="32" Offset="0x6BE0" AddedByScript="true"/>
+        <Texture Name="takaraya_room_0Tex_0073E0" OutName="takaraya_room_0Tex_0073E0" Format="rgba16" Width="32" Height="32" Offset="0x73E0" AddedByScript="true"/>
+        <Texture Name="takaraya_room_0Tex_007BE0" OutName="takaraya_room_0Tex_007BE0" Format="rgba16" Width="32" Height="32" Offset="0x7BE0" AddedByScript="true"/>
+        <Texture Name="takaraya_room_0Tex_0083E0" OutName="takaraya_room_0Tex_0083E0" Format="rgba16" Width="32" Height="64" Offset="0x83E0" AddedByScript="true"/>
+        <Texture Name="takaraya_room_0Tex_0095C0" OutName="takaraya_room_0Tex_0095C0" Format="ia4" Width="64" Height="64" Offset="0x95C0" AddedByScript="true"/>
         <Room Name="takaraya_room_0" Offset="0x0"/>
     </File>
     <File Name="takaraya_room_1" Segment="3">
+        <Texture Name="takaraya_room_1Tex_0017F8" OutName="takaraya_room_1Tex_0017F8" Format="rgba16" Width="16" Height="64" Offset="0x17F8" AddedByScript="true"/>
         <Room Name="takaraya_room_1" Offset="0x0"/>
     </File>
     <File Name="takaraya_room_2" Segment="3">
+        <Texture Name="takaraya_room_2Tex_001828" OutName="takaraya_room_2Tex_001828" Format="rgba16" Width="16" Height="64" Offset="0x1828" AddedByScript="true"/>
         <Room Name="takaraya_room_2" Offset="0x0"/>
     </File>
     <File Name="takaraya_room_3" Segment="3">
+        <Texture Name="takaraya_room_3Tex_001818" OutName="takaraya_room_3Tex_001818" Format="rgba16" Width="16" Height="64" Offset="0x1818" AddedByScript="true"/>
+        <Texture Name="takaraya_room_3Tex_002018" OutName="takaraya_room_3Tex_002018" Format="rgba16" Width="32" Height="32" Offset="0x2018" AddedByScript="true"/>
         <Room Name="takaraya_room_3" Offset="0x0"/>
     </File>
     <File Name="takaraya_room_4" Segment="3">
+        <Texture Name="takaraya_room_4Tex_001820" OutName="takaraya_room_4Tex_001820" Format="rgba16" Width="16" Height="64" Offset="0x1820" AddedByScript="true"/>
+        <Texture Name="takaraya_room_4Tex_002020" OutName="takaraya_room_4Tex_002020" Format="rgba16" Width="32" Height="32" Offset="0x2020" AddedByScript="true"/>
+        <Texture Name="takaraya_room_4Tex_002820" OutName="takaraya_room_4Tex_002820" Format="rgba16" Width="32" Height="32" Offset="0x2820" AddedByScript="true"/>
         <Room Name="takaraya_room_4" Offset="0x0"/>
     </File>
     <File Name="takaraya_room_5" Segment="3">
+        <Texture Name="takaraya_room_5Tex_0017F8" OutName="takaraya_room_5Tex_0017F8" Format="rgba16" Width="32" Height="32" Offset="0x17F8" AddedByScript="true"/>
+        <Texture Name="takaraya_room_5Tex_001FF8" OutName="takaraya_room_5Tex_001FF8" Format="rgba16" Width="32" Height="32" Offset="0x1FF8" AddedByScript="true"/>
+        <Texture Name="takaraya_room_5Tex_0027F8" OutName="takaraya_room_5Tex_0027F8" Format="rgba16" Width="16" Height="64" Offset="0x27F8" AddedByScript="true"/>
         <Room Name="takaraya_room_5" Offset="0x0"/>
     </File>
     <File Name="takaraya_room_6" Segment="3">
+        <Texture Name="takaraya_room_6Tex_0012F8" OutName="takaraya_room_6Tex_0012F8" Format="rgba16" Width="32" Height="32" Offset="0x12F8" AddedByScript="true"/>
+        <Texture Name="takaraya_room_6Tex_001AF8" OutName="takaraya_room_6Tex_001AF8" Format="rgba16" Width="16" Height="64" Offset="0x1AF8" AddedByScript="true"/>
+        <Texture Name="takaraya_room_6Tex_0022F8" OutName="takaraya_room_6Tex_0022F8" Format="rgba16" Width="32" Height="32" Offset="0x22F8" AddedByScript="true"/>
         <Room Name="takaraya_room_6" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/N64_PAL_11/scenes/indoors/tokinoma.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/indoors/tokinoma.xml
@@ -1,14 +1,47 @@
 <Root>
     <File Name="tokinoma_scene" Segment="2">
-        <Cutscene  Name="gTempleOfTimeFirstAdultCs" Offset="0x4700"/>
-        <Cutscene  Name="gTempleOfTimePreludeCs" Offset="0x6D30"/>
+        <Texture Name="tokinoma_sceneTex_00CFA0" OutName="tokinoma_sceneTex_00CFA0" Format="rgba16" Width="32" Height="32" Offset="0xCFC0" AddedByScript="true"/>
+        <Texture Name="tokinoma_sceneTex_00D7A0" OutName="tokinoma_sceneTex_00D7A0" Format="rgba16" Width="32" Height="32" Offset="0xD7C0" AddedByScript="true"/>
+        <Texture Name="tokinoma_sceneTex_00DFA0" OutName="tokinoma_sceneTex_00DFA0" Format="rgba16" Width="32" Height="64" Offset="0xDFC0" AddedByScript="true"/>
+        <Texture Name="tokinoma_sceneTex_00EFA0" OutName="tokinoma_sceneTex_00EFA0" Format="rgba16" Width="32" Height="64" Offset="0xEFC0" AddedByScript="true"/>
+        <Texture Name="tokinoma_sceneTex_00FFA0" OutName="tokinoma_sceneTex_00FFA0" Format="rgba16" Width="32" Height="32" Offset="0xFFC0" AddedByScript="true"/>
+        <Texture Name="tokinoma_sceneTex_0107A0" OutName="tokinoma_sceneTex_0107A0" Format="rgba16" Width="32" Height="32" Offset="0x107C0" AddedByScript="true"/>
+        <Texture Name="tokinoma_sceneTex_010FA0" OutName="tokinoma_sceneTex_010FA0" Format="rgba16" Width="32" Height="32" Offset="0x10FC0" AddedByScript="true"/>
+        <Texture Name="tokinoma_sceneTex_0117A0" OutName="tokinoma_sceneTex_0117A0" Format="rgba16" Width="32" Height="32" Offset="0x117C0" AddedByScript="true"/>
+        <Texture Name="tokinoma_sceneTex_011FA0" OutName="tokinoma_sceneTex_011FA0" Format="rgba16" Width="32" Height="32" Offset="0x11FC0" AddedByScript="true"/>
+        <Cutscene Name="gTempleOfTimeFirstAdultCs" Offset="0x4700"/>
+        <Cutscene Name="gTempleOfTimePreludeCs" Offset="0x6D30"/>
         <Cutscene Name="gTempleOfTimeIntroCs" Offset="0xCE20"/>
         <Scene Name="tokinoma_scene" Offset="0x0"/>
     </File>
     <File Name="tokinoma_room_0" Segment="3">
+        <Texture Name="tokinoma_room_0Tex_0081D8" OutName="tokinoma_room_0Tex_0081D8" Format="rgba16" Width="64" Height="32" Offset="0x81D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_0091D8" OutName="tokinoma_room_0Tex_0091D8" Format="rgba16" Width="64" Height="32" Offset="0x91D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_00A1D8" OutName="tokinoma_room_0Tex_00A1D8" Format="rgba16" Width="64" Height="32" Offset="0xA1D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_00B1D8" OutName="tokinoma_room_0Tex_00B1D8" Format="rgba16" Width="64" Height="32" Offset="0xB1D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_00C1D8" OutName="tokinoma_room_0Tex_00C1D8" Format="rgba16" Width="64" Height="32" Offset="0xC1D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_00D1D8" OutName="tokinoma_room_0Tex_00D1D8" Format="rgba16" Width="64" Height="32" Offset="0xD1D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_00E1D8" OutName="tokinoma_room_0Tex_00E1D8" Format="rgba16" Width="64" Height="32" Offset="0xE1D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_00F1D8" OutName="tokinoma_room_0Tex_00F1D8" Format="rgba16" Width="64" Height="32" Offset="0xF1D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_0101D8" OutName="tokinoma_room_0Tex_0101D8" Format="rgba16" Width="64" Height="32" Offset="0x101D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_0111D8" OutName="tokinoma_room_0Tex_0111D8" Format="rgba16" Width="64" Height="32" Offset="0x111D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_0121D8" OutName="tokinoma_room_0Tex_0121D8" Format="rgba16" Width="64" Height="32" Offset="0x121D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_0131D8" OutName="tokinoma_room_0Tex_0131D8" Format="rgba16" Width="64" Height="32" Offset="0x131D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_0141D8" OutName="tokinoma_room_0Tex_0141D8" Format="rgba16" Width="32" Height="32" Offset="0x141D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_0149D8" OutName="tokinoma_room_0Tex_0149D8" Format="rgba16" Width="32" Height="32" Offset="0x149D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_0151D8" OutName="tokinoma_room_0Tex_0151D8" Format="rgba16" Width="32" Height="32" Offset="0x151D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_0159D8" OutName="tokinoma_room_0Tex_0159D8" Format="rgba16" Width="32" Height="32" Offset="0x159D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_0161D8" OutName="tokinoma_room_0Tex_0161D8" Format="rgba16" Width="32" Height="32" Offset="0x161D8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_0Tex_0169D8" OutName="tokinoma_room_0Tex_0169D8" Format="rgba16" Width="32" Height="32" Offset="0x169D8" AddedByScript="true"/>
         <Room Name="tokinoma_room_0" Offset="0x0"/>
     </File>
     <File Name="tokinoma_room_1" Segment="3">
+        <Texture Name="tokinoma_room_1Tex_005458" OutName="tokinoma_room_1Tex_005458" Format="rgba16" Width="16" Height="16" Offset="0x5458" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_1Tex_005658" OutName="tokinoma_room_1Tex_005658" Format="rgba16" Width="16" Height="16" Offset="0x5658" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_1Tex_005858" OutName="tokinoma_room_1Tex_005858" Format="rgba16" Width="32" Height="32" Offset="0x5858" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_1Tex_006488" OutName="tokinoma_room_1Tex_006488" Format="i8" Width="8" Height="8" Offset="0x6488" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_1Tex_0064C8" OutName="tokinoma_room_1Tex_0064C8" Format="ia4" Width="128" Height="16" Offset="0x64C8" AddedByScript="true"/>
+        <Texture Name="tokinoma_room_1Tex_0068C8" OutName="tokinoma_room_1Tex_0068C8" Format="ia8" Width="64" Height="32" Offset="0x68C8" AddedByScript="true"/>
         <Room Name="tokinoma_room_1" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/N64_PAL_11/scenes/indoors/yousei_izumi_tate.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/indoors/yousei_izumi_tate.xml
@@ -1,5 +1,15 @@
 <Root>
     <File Name="yousei_izumi_tate_scene" Segment="2">
+        <Texture Name="yousei_izumi_tate_sceneTex_002010" OutName="yousei_izumi_tate_sceneTex_002010" Format="ia8" Width="64" Height="32" Offset="0x2010" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_tate_sceneTex_002810" OutName="yousei_izumi_tate_sceneTex_002810" Format="i8" Width="16" Height="256" Offset="0x2810" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_tate_sceneTex_003810" OutName="yousei_izumi_tate_sceneTex_003810" Format="ia16" Width="128" Height="16" Offset="0x3810" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_tate_sceneTex_004810" OutName="yousei_izumi_tate_sceneTex_004810" Format="i8" Width="32" Height="64" Offset="0x4810" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_tate_sceneTex_005010" OutName="yousei_izumi_tate_sceneTex_005010" Format="i8" Width="32" Height="64" Offset="0x5010" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_tate_sceneTex_005810" OutName="yousei_izumi_tate_sceneTex_005810" Format="rgba16" Width="32" Height="32" Offset="0x5810" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_tate_sceneTex_006010" OutName="yousei_izumi_tate_sceneTex_006010" Format="i4" Width="64" Height="128" Offset="0x6010" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_tate_sceneTex_007010" OutName="yousei_izumi_tate_sceneTex_007010" Format="rgba16" Width="32" Height="32" Offset="0x7010" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_tate_sceneTex_007810" OutName="yousei_izumi_tate_sceneTex_007810" Format="rgba16" Width="32" Height="32" Offset="0x7810" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_tate_sceneTex_008010" OutName="yousei_izumi_tate_sceneTex_008010" Format="rgba16" Width="32" Height="32" Offset="0x8010" AddedByScript="true"/>
         <Scene Name="yousei_izumi_tate_scene" Offset="0x0"/>
     </File>
     <File Name="yousei_izumi_tate_room_0" Segment="3">

--- a/soh/assets/xml/N64_PAL_11/scenes/indoors/yousei_izumi_yoko.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/indoors/yousei_izumi_yoko.xml
@@ -1,5 +1,18 @@
 <Root>
     <File Name="yousei_izumi_yoko_scene" Segment="2">
+        <Texture Name="yousei_izumi_yoko_sceneTex_003DA0" OutName="yousei_izumi_yoko_sceneTex_003DA0" Format="i8" Width="32" Height="64" Offset="0x3DA0" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_yoko_sceneTex_0045A0" OutName="yousei_izumi_yoko_sceneTex_0045A0" Format="rgba16" Width="32" Height="32" Offset="0x45A0" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_yoko_sceneTex_004DA0" OutName="yousei_izumi_yoko_sceneTex_004DA0" Format="rgba16" Width="32" Height="32" Offset="0x4DA0" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_yoko_sceneTex_0055A0" OutName="yousei_izumi_yoko_sceneTex_0055A0" Format="ia4" Width="64" Height="128" Offset="0x55A0" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_yoko_sceneTex_0065A0" OutName="yousei_izumi_yoko_sceneTex_0065A0" Format="rgba16" Width="32" Height="64" Offset="0x65A0" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_yoko_sceneTex_0075A0" OutName="yousei_izumi_yoko_sceneTex_0075A0" Format="rgba16" Width="32" Height="64" Offset="0x75A0" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_yoko_sceneTex_0085A0" OutName="yousei_izumi_yoko_sceneTex_0085A0" Format="rgba16" Width="32" Height="64" Offset="0x85A0" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_yoko_sceneTex_0095A0" OutName="yousei_izumi_yoko_sceneTex_0095A0" Format="rgba16" Width="32" Height="32" Offset="0x95A0" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_yoko_sceneTex_009DA0" OutName="yousei_izumi_yoko_sceneTex_009DA0" Format="i8" Width="32" Height="128" Offset="0x9DA0" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_yoko_sceneTex_00ADA0" OutName="yousei_izumi_yoko_sceneTex_00ADA0" Format="rgba16" Width="32" Height="32" Offset="0xADA0" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_yoko_sceneTex_00B5A0" OutName="yousei_izumi_yoko_sceneTex_00B5A0" Format="ia8" Width="64" Height="32" Offset="0xB5A0" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_yoko_sceneTex_00BDA0" OutName="yousei_izumi_yoko_sceneTex_00BDA0" Format="rgba16" Width="32" Height="32" Offset="0xBDA0" AddedByScript="true"/>
+        <Texture Name="yousei_izumi_yoko_sceneTex_00C5A0" OutName="yousei_izumi_yoko_sceneTex_00C5A0" Format="rgba16" Width="32" Height="32" Offset="0xC5A0" AddedByScript="true"/>
         <Cutscene Name="gGreatFairyFaroresWindCs" Offset="0x0160"/>
         <Cutscene Name="gGreatFairyDinsFireCs" Offset="0x1020"/>
         <Cutscene Name="gGreatFairyNayrusLoveCs" Offset="0x1F40"/>

--- a/soh/assets/xml/N64_PAL_11/scenes/misc/hakaana.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/misc/hakaana.xml
@@ -3,6 +3,16 @@
         <Scene Name="hakaana_scene" Offset="0x0"/>
     </File>
     <File Name="hakaana_room_0" Segment="3">
+        <Texture Name="hakaana_room_0Tex_002658" OutName="hakaana_room_0Tex_002658" Format="rgba16" Width="32" Height="32" Offset="0x2658" AddedByScript="true"/>
+        <Texture Name="hakaana_room_0Tex_002E58" OutName="hakaana_room_0Tex_002E58" Format="rgba16" Width="32" Height="16" Offset="0x2E58" AddedByScript="true"/>
+        <Texture Name="hakaana_room_0Tex_003258" OutName="hakaana_room_0Tex_003258" Format="rgba16" Width="32" Height="16" Offset="0x3258" AddedByScript="true"/>
+        <Texture Name="hakaana_room_0Tex_003658" OutName="hakaana_room_0Tex_003658" Format="rgba16" Width="32" Height="32" Offset="0x3658" AddedByScript="true"/>
+        <Texture Name="hakaana_room_0Tex_003E58" OutName="hakaana_room_0Tex_003E58" Format="i4" Width="128" Height="32" Offset="0x3E58" AddedByScript="true"/>
+        <Texture Name="hakaana_room_0Tex_004658" OutName="hakaana_room_0Tex_004658" Format="rgba16" Width="32" Height="32" Offset="0x4658" AddedByScript="true"/>
+        <Texture Name="hakaana_room_0Tex_004E58" OutName="hakaana_room_0Tex_004E58" Format="i4" Width="64" Height="64" Offset="0x4E58" AddedByScript="true"/>
+        <Texture Name="hakaana_room_0Tex_005658" OutName="hakaana_room_0Tex_005658" Format="i4" Width="64" Height="64" Offset="0x5658" AddedByScript="true"/>
+        <Texture Name="hakaana_room_0Tex_005E58" OutName="hakaana_room_0Tex_005E58" Format="i4" Width="64" Height="64" Offset="0x5E58" AddedByScript="true"/>
+        <Texture Name="hakaana_room_0Tex_0068C8" OutName="hakaana_room_0Tex_0068C8" Format="ia16" Width="128" Height="16" Offset="0x68C8" AddedByScript="true"/>
         <Room Name="hakaana_room_0" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/N64_PAL_11/scenes/misc/hakaana2.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/misc/hakaana2.xml
@@ -1,5 +1,23 @@
 <Root>
     <File Name="hakaana2_scene" Segment="2">
+        <Texture Name="hakaana2_sceneTex_003090" OutName="hakaana2_sceneTex_003090" Format="rgba16" Width="32" Height="32" Offset="0x3090" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_003890" OutName="hakaana2_sceneTex_003890" Format="rgba16" Width="32" Height="32" Offset="0x3890" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_004090" OutName="hakaana2_sceneTex_004090" Format="rgba16" Width="32" Height="16" Offset="0x4090" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_004490" OutName="hakaana2_sceneTex_004490" Format="rgba16" Width="32" Height="16" Offset="0x4490" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_004890" OutName="hakaana2_sceneTex_004890" Format="i4" Width="64" Height="64" Offset="0x4890" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_005090" OutName="hakaana2_sceneTex_005090" Format="i4" Width="64" Height="64" Offset="0x5090" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_005890" OutName="hakaana2_sceneTex_005890" Format="i4" Width="128" Height="32" Offset="0x5890" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_006090" OutName="hakaana2_sceneTex_006090" Format="i4" Width="64" Height="64" Offset="0x6090" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_006890" OutName="hakaana2_sceneTex_006890" Format="ia8" Width="64" Height="32" Offset="0x6890" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_007090" OutName="hakaana2_sceneTex_007090" Format="i8" Width="16" Height="256" Offset="0x7090" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_008090" OutName="hakaana2_sceneTex_008090" Format="ia16" Width="128" Height="16" Offset="0x8090" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_009090" OutName="hakaana2_sceneTex_009090" Format="i8" Width="32" Height="64" Offset="0x9090" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_009890" OutName="hakaana2_sceneTex_009890" Format="i8" Width="32" Height="64" Offset="0x9890" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_00A090" OutName="hakaana2_sceneTex_00A090" Format="rgba16" Width="32" Height="32" Offset="0xA090" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_00A890" OutName="hakaana2_sceneTex_00A890" Format="i4" Width="64" Height="128" Offset="0xA890" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_00B890" OutName="hakaana2_sceneTex_00B890" Format="rgba16" Width="32" Height="32" Offset="0xB890" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_00C090" OutName="hakaana2_sceneTex_00C090" Format="rgba16" Width="32" Height="32" Offset="0xC090" AddedByScript="true"/>
+        <Texture Name="hakaana2_sceneTex_00C890" OutName="hakaana2_sceneTex_00C890" Format="rgba16" Width="32" Height="32" Offset="0xC890" AddedByScript="true"/>
         <Scene Name="hakaana2_scene" Offset="0x0"/>
     </File>
     <File Name="hakaana2_room_0" Segment="3">

--- a/soh/assets/xml/N64_PAL_11/scenes/misc/hakaana_ouke.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/misc/hakaana_ouke.xml
@@ -1,16 +1,37 @@
 <Root>
     <File Name="hakaana_ouke_scene" Segment="2">
+        <Texture Name="hakaana_ouke_sceneTex_002AE0" OutName="hakaana_ouke_sceneTex_002AE0" Format="rgba16" Width="32" Height="16" Offset="0x2AE0" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_sceneTex_002EE0" OutName="hakaana_ouke_sceneTex_002EE0" Format="rgba16" Width="32" Height="16" Offset="0x2EE0" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_sceneTex_0032E0" OutName="hakaana_ouke_sceneTex_0032E0" Format="rgba16" Width="32" Height="32" Offset="0x32E0" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_sceneTex_003AE0" OutName="hakaana_ouke_sceneTex_003AE0" Format="i4" Width="64" Height="64" Offset="0x3AE0" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_sceneTex_0042E0" OutName="hakaana_ouke_sceneTex_0042E0" Format="i4" Width="64" Height="64" Offset="0x42E0" AddedByScript="true"/>
         <Cutscene Name="gSunSongGraveSunSongTeachCs" Offset="0x24A0"/>
         <Cutscene Name="gSunSongGraveSunSongTeachPart2Cs" Offset="0x28E0"/>
         <Scene Name="hakaana_ouke_scene" Offset="0x0"/>
     </File>
     <File Name="hakaana_ouke_room_0" Segment="3">
+        <Texture Name="hakaana_ouke_room_0Tex_004F30" OutName="hakaana_ouke_room_0Tex_004F30" Format="rgba16" Width="16" Height="64" Offset="0x4F30" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_room_0Tex_005730" OutName="hakaana_ouke_room_0Tex_005730" Format="rgba16" Width="32" Height="64" Offset="0x5730" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_room_0Tex_006730" OutName="hakaana_ouke_room_0Tex_006730" Format="i4" Width="128" Height="32" Offset="0x6730" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_room_0Tex_006F30" OutName="hakaana_ouke_room_0Tex_006F30" Format="i4" Width="64" Height="64" Offset="0x6F30" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_room_0Tex_007FF8" OutName="hakaana_ouke_room_0Tex_007FF8" Format="ia4" Width="32" Height="256" Offset="0x7FF8" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_room_0Tex_008FF8" OutName="hakaana_ouke_room_0Tex_008FF8" Format="ia8" Width="8" Height="256" Offset="0x8FF8" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_room_0Tex_0097F8" OutName="hakaana_ouke_room_0Tex_0097F8" Format="ia16" Width="128" Height="16" Offset="0x97F8" AddedByScript="true"/>
         <Room Name="hakaana_ouke_room_0" Offset="0x0"/>
     </File>
     <File Name="hakaana_ouke_room_1" Segment="3">
+        <Texture Name="hakaana_ouke_room_1Tex_001FC8" OutName="hakaana_ouke_room_1Tex_001FC8" Format="rgba16" Width="32" Height="32" Offset="0x1FC8" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_room_1Tex_0027C8" OutName="hakaana_ouke_room_1Tex_0027C8" Format="rgba16" Width="32" Height="64" Offset="0x27C8" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_room_1Tex_004000" OutName="hakaana_ouke_room_1Tex_004000" Format="i8" Width="16" Height="128" Offset="0x4000" AddedByScript="true"/>
         <Room Name="hakaana_ouke_room_1" Offset="0x0"/>
     </File>
     <File Name="hakaana_ouke_room_2" Segment="3">
+        <Texture Name="hakaana_ouke_room_2Tex_002778" OutName="hakaana_ouke_room_2Tex_002778" Format="i4" Width="128" Height="32" Offset="0x2778" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_room_2Tex_002F78" OutName="hakaana_ouke_room_2Tex_002F78" Format="rgba16" Width="32" Height="32" Offset="0x2F78" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_room_2Tex_003778" OutName="hakaana_ouke_room_2Tex_003778" Format="i4" Width="128" Height="32" Offset="0x3778" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_room_2Tex_003F78" OutName="hakaana_ouke_room_2Tex_003F78" Format="rgba16" Width="32" Height="32" Offset="0x3F78" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_room_2Tex_004778" OutName="hakaana_ouke_room_2Tex_004778" Format="i4" Width="64" Height="64" Offset="0x4778" AddedByScript="true"/>
+        <Texture Name="hakaana_ouke_room_2Tex_005108" OutName="hakaana_ouke_room_2Tex_005108" Format="ia8" Width="128" Height="32" Offset="0x5108" AddedByScript="true"/>
         <Room Name="hakaana_ouke_room_2" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/N64_PAL_11/scenes/misc/kakusiana.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/misc/kakusiana.xml
@@ -1,47 +1,113 @@
 <Root>
     <File Name="kakusiana_scene" Segment="2">
+        <Texture Name="kakusiana_sceneTex_00B820" OutName="kakusiana_sceneTex_00B820" Format="ia4" Width="64" Height="64" Offset="0xB820" AddedByScript="true"/>
+        <Texture Name="kakusiana_sceneTex_00C020" OutName="kakusiana_sceneTex_00C020" Format="ia16" Width="128" Height="16" Offset="0xC020" AddedByScript="true"/>
+        <Texture Name="kakusiana_sceneTex_00D020" OutName="kakusiana_sceneTex_00D020" Format="rgba16" Width="32" Height="32" Offset="0xD020" AddedByScript="true"/>
         <Scene Name="kakusiana_scene" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_0" Segment="3">
+        <Texture Name="kakusiana_room_0Tex_0022A0" OutName="kakusiana_room_0Tex_0022A0" Format="rgba16" Width="64" Height="32" Offset="0x22A0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_0Tex_0032A0" OutName="kakusiana_room_0Tex_0032A0" Format="rgba16" Width="64" Height="32" Offset="0x32A0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_0Tex_0042A0" OutName="kakusiana_room_0Tex_0042A0" Format="rgba16" Width="32" Height="32" Offset="0x42A0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_0Tex_004AA0" OutName="kakusiana_room_0Tex_004AA0" Format="i8" Width="64" Height="64" Offset="0x4AA0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_0Tex_005AA0" OutName="kakusiana_room_0Tex_005AA0" Format="rgba16" Width="32" Height="32" Offset="0x5AA0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_0Tex_006AA0" OutName="kakusiana_room_0Tex_006AA0" Format="rgba16" Width="32" Height="32" Offset="0x6AA0" AddedByScript="true"/>
         <Room Name="kakusiana_room_0" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_1" Segment="3">
+        <Texture Name="kakusiana_room_1Tex_001A18" OutName="kakusiana_room_1Tex_001A18" Format="i8" Width="64" Height="64" Offset="0x1A18" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_1Tex_002A18" OutName="kakusiana_room_1Tex_002A18" Format="rgba16" Width="32" Height="32" Offset="0x2A18" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_1Tex_003218" OutName="kakusiana_room_1Tex_003218" Format="i8" Width="64" Height="64" Offset="0x3218" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_1Tex_004990" OutName="kakusiana_room_1Tex_004990" Format="ia8" Width="8" Height="256" Offset="0x4990" AddedByScript="true"/>
         <Room Name="kakusiana_room_1" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_2" Segment="3">
+        <Texture Name="kakusiana_room_2Tex_001448" OutName="kakusiana_room_2Tex_001448" Format="rgba16" Width="32" Height="32" Offset="0x1448" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_2Tex_001C48" OutName="kakusiana_room_2Tex_001C48" Format="rgba16" Width="32" Height="32" Offset="0x1C48" AddedByScript="true"/>
         <Room Name="kakusiana_room_2" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_3" Segment="3">
+        <Texture Name="kakusiana_room_3Tex_001818" OutName="kakusiana_room_3Tex_001818" Format="i8" Width="64" Height="64" Offset="0x1818" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_3Tex_002818" OutName="kakusiana_room_3Tex_002818" Format="i8" Width="64" Height="64" Offset="0x2818" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_3Tex_004130" OutName="kakusiana_room_3Tex_004130" Format="ia8" Width="8" Height="256" Offset="0x4130" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_3Tex_004930" OutName="kakusiana_room_3Tex_004930" Format="rgba16" Width="32" Height="32" Offset="0x4930" AddedByScript="true"/>
         <Room Name="kakusiana_room_3" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_4" Segment="3">
+        <Texture Name="kakusiana_room_4Tex_002138" OutName="kakusiana_room_4Tex_002138" Format="rgba16" Width="32" Height="64" Offset="0x2138" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_4Tex_003138" OutName="kakusiana_room_4Tex_003138" Format="rgba16" Width="32" Height="64" Offset="0x3138" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_4Tex_004138" OutName="kakusiana_room_4Tex_004138" Format="rgba16" Width="32" Height="32" Offset="0x4138" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_4Tex_005958" OutName="kakusiana_room_4Tex_005958" Format="i8" Width="64" Height="64" Offset="0x5958" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_4Tex_006958" OutName="kakusiana_room_4Tex_006958" Format="i8" Width="64" Height="64" Offset="0x6958" AddedByScript="true"/>
         <Room Name="kakusiana_room_4" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_5" Segment="3">
+        <Texture Name="kakusiana_room_5Tex_001888" OutName="kakusiana_room_5Tex_001888" Format="i8" Width="64" Height="64" Offset="0x1888" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_5Tex_002888" OutName="kakusiana_room_5Tex_002888" Format="i8" Width="64" Height="64" Offset="0x2888" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_5Tex_003ED8" OutName="kakusiana_room_5Tex_003ED8" Format="rgba16" Width="32" Height="32" Offset="0x3ED8" AddedByScript="true"/>
         <Room Name="kakusiana_room_5" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_6" Segment="3">
+        <Texture Name="kakusiana_room_6Tex_0022E0" OutName="kakusiana_room_6Tex_0022E0" Format="rgba16" Width="32" Height="64" Offset="0x22E0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_6Tex_0032E0" OutName="kakusiana_room_6Tex_0032E0" Format="rgba16" Width="32" Height="32" Offset="0x32E0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_6Tex_003AE0" OutName="kakusiana_room_6Tex_003AE0" Format="rgba16" Width="64" Height="32" Offset="0x3AE0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_6Tex_004AE0" OutName="kakusiana_room_6Tex_004AE0" Format="rgba16" Width="32" Height="32" Offset="0x4AE0" AddedByScript="true"/>
         <Room Name="kakusiana_room_6" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_7" Segment="3">
+        <Texture Name="kakusiana_room_7Tex_001D60" OutName="kakusiana_room_7Tex_001D60" Format="rgba16" Width="32" Height="16" Offset="0x1D60" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_7Tex_002160" OutName="kakusiana_room_7Tex_002160" Format="rgba16" Width="32" Height="32" Offset="0x2160" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_7Tex_002960" OutName="kakusiana_room_7Tex_002960" Format="rgba16" Width="16" Height="16" Offset="0x2960" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_7Tex_002B60" OutName="kakusiana_room_7Tex_002B60" Format="i8" Width="64" Height="64" Offset="0x2B60" AddedByScript="true"/>
         <Room Name="kakusiana_room_7" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_8" Segment="3">
+        <Texture Name="kakusiana_room_8Tex_0019C0" OutName="kakusiana_room_8Tex_0019C0" Format="rgba16" Width="32" Height="64" Offset="0x19C0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_8Tex_0029C0" OutName="kakusiana_room_8Tex_0029C0" Format="rgba16" Width="32" Height="32" Offset="0x29C0" AddedByScript="true"/>
         <Room Name="kakusiana_room_8" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_9" Segment="3">
+        <Texture Name="kakusiana_room_9Tex_002340" OutName="kakusiana_room_9Tex_002340" Format="rgba16" Width="32" Height="64" Offset="0x2340" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_9Tex_003340" OutName="kakusiana_room_9Tex_003340" Format="rgba16" Width="32" Height="32" Offset="0x3340" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_9Tex_003B40" OutName="kakusiana_room_9Tex_003B40" Format="rgba16" Width="64" Height="32" Offset="0x3B40" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_9Tex_004B40" OutName="kakusiana_room_9Tex_004B40" Format="rgba16" Width="32" Height="32" Offset="0x4B40" AddedByScript="true"/>
         <Room Name="kakusiana_room_9" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_10" Segment="3">
+        <Texture Name="kakusiana_room_10Tex_0017E0" OutName="kakusiana_room_10Tex_0017E0" Format="i8" Width="32" Height="64" Offset="0x17E0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_10Tex_001FE0" OutName="kakusiana_room_10Tex_001FE0" Format="i8" Width="32" Height="64" Offset="0x1FE0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_10Tex_0027E0" OutName="kakusiana_room_10Tex_0027E0" Format="i8" Width="32" Height="32" Offset="0x27E0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_10Tex_002BE0" OutName="kakusiana_room_10Tex_002BE0" Format="i8" Width="64" Height="64" Offset="0x2BE0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_10Tex_003BE0" OutName="kakusiana_room_10Tex_003BE0" Format="i8" Width="64" Height="64" Offset="0x3BE0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_10Tex_005228" OutName="kakusiana_room_10Tex_005228" Format="rgba16" Width="32" Height="32" Offset="0x5228" AddedByScript="true"/>
         <Room Name="kakusiana_room_10" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_11" Segment="3">
+        <Texture Name="kakusiana_room_11Tex_002848" OutName="kakusiana_room_11Tex_002848" Format="rgba16" Width="32" Height="32" Offset="0x2848" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_11Tex_003048" OutName="kakusiana_room_11Tex_003048" Format="rgba16" Width="32" Height="64" Offset="0x3048" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_11Tex_004048" OutName="kakusiana_room_11Tex_004048" Format="rgba16" Width="32" Height="64" Offset="0x4048" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_11Tex_005048" OutName="kakusiana_room_11Tex_005048" Format="rgba16" Width="32" Height="32" Offset="0x5048" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_11Tex_005848" OutName="kakusiana_room_11Tex_005848" Format="rgba16" Width="64" Height="32" Offset="0x5848" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_11Tex_006848" OutName="kakusiana_room_11Tex_006848" Format="rgba16" Width="64" Height="32" Offset="0x6848" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_11Tex_007848" OutName="kakusiana_room_11Tex_007848" Format="rgba16" Width="32" Height="32" Offset="0x7848" AddedByScript="true"/>
         <Room Name="kakusiana_room_11" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_12" Segment="3">
+        <Texture Name="kakusiana_room_12Tex_001FF0" OutName="kakusiana_room_12Tex_001FF0" Format="rgba16" Width="32" Height="32" Offset="0x1FF0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_12Tex_0027F0" OutName="kakusiana_room_12Tex_0027F0" Format="rgba16" Width="32" Height="64" Offset="0x27F0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_12Tex_0037F0" OutName="kakusiana_room_12Tex_0037F0" Format="rgba16" Width="32" Height="64" Offset="0x37F0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_12Tex_0047F0" OutName="kakusiana_room_12Tex_0047F0" Format="rgba16" Width="32" Height="32" Offset="0x47F0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_12Tex_004FF0" OutName="kakusiana_room_12Tex_004FF0" Format="rgba16" Width="64" Height="32" Offset="0x4FF0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_12Tex_005FF0" OutName="kakusiana_room_12Tex_005FF0" Format="rgba16" Width="64" Height="32" Offset="0x5FF0" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_12Tex_006FF0" OutName="kakusiana_room_12Tex_006FF0" Format="rgba16" Width="32" Height="32" Offset="0x6FF0" AddedByScript="true"/>
         <Room Name="kakusiana_room_12" Offset="0x0"/>
     </File>
     <File Name="kakusiana_room_13" Segment="3">
+        <Texture Name="kakusiana_room_13Tex_001950" OutName="kakusiana_room_13Tex_001950" Format="rgba16" Width="32" Height="64" Offset="0x1950" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_13Tex_002950" OutName="kakusiana_room_13Tex_002950" Format="rgba16" Width="32" Height="64" Offset="0x2950" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_13Tex_003950" OutName="kakusiana_room_13Tex_003950" Format="rgba16" Width="32" Height="32" Offset="0x3950" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_13Tex_004EC8" OutName="kakusiana_room_13Tex_004EC8" Format="i8" Width="64" Height="64" Offset="0x4EC8" AddedByScript="true"/>
+        <Texture Name="kakusiana_room_13Tex_005EC8" OutName="kakusiana_room_13Tex_005EC8" Format="i8" Width="64" Height="64" Offset="0x5EC8" AddedByScript="true"/>
         <Room Name="kakusiana_room_13" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/N64_PAL_11/scenes/misc/kinsuta.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/misc/kinsuta.xml
@@ -3,6 +3,19 @@
         <Scene Name="kinsuta_scene" Offset="0x0"/>
     </File>
     <File Name="kinsuta_room_0" Segment="3">
+        <Texture Name="kinsuta_room_0Tex_003110" OutName="kinsuta_room_0Tex_003110" Format="ci4" Width="64" Height="64" Offset="0x3110" TlutOffset="0x30F0" AddedByScript="true"/>
+        <Texture Name="kinsuta_room_0Tex_003910" OutName="kinsuta_room_0Tex_003910" Format="i4" Width="64" Height="128" Offset="0x3910" AddedByScript="true"/>
+        <Texture Name="kinsuta_room_0Tex_004910" OutName="kinsuta_room_0Tex_004910" Format="i4" Width="64" Height="128" Offset="0x4910" AddedByScript="true"/>
+        <Texture Name="kinsuta_room_0Tex_005910" OutName="kinsuta_room_0Tex_005910" Format="i4" Width="64" Height="128" Offset="0x5910" AddedByScript="true"/>
+        <Texture Name="kinsuta_room_0Tex_006910" OutName="kinsuta_room_0Tex_006910" Format="rgba16" Width="32" Height="64" Offset="0x6910" AddedByScript="true"/>
+        <Texture Name="kinsuta_room_0Tex_007910" OutName="kinsuta_room_0Tex_007910" Format="rgba16" Width="32" Height="64" Offset="0x7910" AddedByScript="true"/>
+        <Texture Name="kinsuta_room_0Tex_008910" OutName="kinsuta_room_0Tex_008910" Format="i8" Width="32" Height="32" Offset="0x8910" AddedByScript="true"/>
+        <Texture Name="kinsuta_room_0Tex_008D10" OutName="kinsuta_room_0Tex_008D10" Format="rgba16" Width="64" Height="32" Offset="0x8D10" AddedByScript="true"/>
+        <Texture Name="kinsuta_room_0Tex_009D10" OutName="kinsuta_room_0Tex_009D10" Format="rgba16" Width="32" Height="16" Offset="0x9D10" AddedByScript="true"/>
+        <Texture Name="kinsuta_room_0Tex_00B098" OutName="kinsuta_room_0Tex_00B098" Format="ia16" Width="32" Height="64" Offset="0xB098" AddedByScript="true"/>
+        <Texture Name="kinsuta_room_0Tex_00C098" OutName="kinsuta_room_0Tex_00C098" Format="i8" Width="64" Height="64" Offset="0xC098" AddedByScript="true"/>
+        <Texture Name="kinsuta_room_0Tex_00D098" OutName="kinsuta_room_0Tex_00D098" Format="i8" Width="64" Height="64" Offset="0xD098" AddedByScript="true"/>
+        <Texture Name="kinsuta_room_0TLUT_0030F0" OutName="kinsuta_room_0TLUT_0030F0" Format="rgba16" Width="4" Height="4" Offset="0x30F0" AddedByScript="true"/>
         <DList Name="gKinsutaDL_0030B0" Offset="0x30B0"/>
         <DList Name="gKinsutaDL_00B088" Offset="0xB088"/>
         <Room Name="kinsuta_room_0" Offset="0x0"/>

--- a/soh/assets/xml/N64_PAL_11/scenes/misc/turibori.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/misc/turibori.xml
@@ -1,5 +1,32 @@
 <Root>
     <File Name="turibori_scene" Segment="2">
+        <Texture Name="turibori_sceneTex_001CE0" OutName="turibori_sceneTex_001CE0" Format="rgba16" Width="32" Height="64" Offset="0x1CE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_002CE0" OutName="turibori_sceneTex_002CE0" Format="rgba16" Width="64" Height="32" Offset="0x2CE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_003CE0" OutName="turibori_sceneTex_003CE0" Format="rgba16" Width="64" Height="32" Offset="0x3CE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_004CE0" OutName="turibori_sceneTex_004CE0" Format="rgba16" Width="32" Height="4" Offset="0x4CE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_004DE0" OutName="turibori_sceneTex_004DE0" Format="rgba16" Width="32" Height="16" Offset="0x4DE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_0051E0" OutName="turibori_sceneTex_0051E0" Format="ia16" Width="32" Height="32" Offset="0x51E0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_0059E0" OutName="turibori_sceneTex_0059E0" Format="ia8" Width="64" Height="64" Offset="0x59E0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_0069E0" OutName="turibori_sceneTex_0069E0" Format="ia8" Width="32" Height="16" Offset="0x69E0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_006BE0" OutName="turibori_sceneTex_006BE0" Format="rgba16" Width="32" Height="64" Offset="0x6BE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_007BE0" OutName="turibori_sceneTex_007BE0" Format="ia8" Width="64" Height="16" Offset="0x7BE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_007FE0" OutName="turibori_sceneTex_007FE0" Format="rgba16" Width="32" Height="8" Offset="0x7FE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_0081E0" OutName="turibori_sceneTex_0081E0" Format="rgba16" Width="64" Height="32" Offset="0x81E0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_0091E0" OutName="turibori_sceneTex_0091E0" Format="ia8" Width="16" Height="16" Offset="0x91E0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_0092E0" OutName="turibori_sceneTex_0092E0" Format="ia8" Width="16" Height="32" Offset="0x92E0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_0094E0" OutName="turibori_sceneTex_0094E0" Format="rgba16" Width="32" Height="32" Offset="0x94E0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_009CE0" OutName="turibori_sceneTex_009CE0" Format="rgba16" Width="32" Height="64" Offset="0x9CE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_00ACE0" OutName="turibori_sceneTex_00ACE0" Format="rgba16" Width="64" Height="32" Offset="0xACE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_00BCE0" OutName="turibori_sceneTex_00BCE0" Format="ia8" Width="32" Height="128" Offset="0xBCE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_00CCE0" OutName="turibori_sceneTex_00CCE0" Format="rgba16" Width="64" Height="32" Offset="0xCCE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_00DCE0" OutName="turibori_sceneTex_00DCE0" Format="rgba16" Width="32" Height="32" Offset="0xDCE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_00E4E0" OutName="turibori_sceneTex_00E4E0" Format="rgba16" Width="32" Height="32" Offset="0xE4E0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_00ECE0" OutName="turibori_sceneTex_00ECE0" Format="rgba16" Width="32" Height="32" Offset="0xECE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_00F4E0" OutName="turibori_sceneTex_00F4E0" Format="ia4" Width="64" Height="64" Offset="0xF4E0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_00FCE0" OutName="turibori_sceneTex_00FCE0" Format="rgba16" Width="32" Height="32" Offset="0xFCE0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_0104E0" OutName="turibori_sceneTex_0104E0" Format="rgba16" Width="64" Height="32" Offset="0x104E0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_0114E0" OutName="turibori_sceneTex_0114E0" Format="i4" Width="32" Height="32" Offset="0x114E0" AddedByScript="true"/>
+        <Texture Name="turibori_sceneTex_0116E0" OutName="turibori_sceneTex_0116E0" Format="rgba16" Width="32" Height="64" Offset="0x116E0" AddedByScript="true"/>
         <Scene Name="turibori_scene" Offset="0x0"/>
     </File>
     <File Name="turibori_room_0" Segment="3">

--- a/soh/assets/xml/N64_PAL_11/scenes/overworld/souko.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/overworld/souko.xml
@@ -1,16 +1,44 @@
 <Root>
     <File Name="souko_scene" Segment="2">
+        <Texture Name="souko_sceneTex_004410" OutName="souko_sceneTex_004410" Format="rgba16" Width="32" Height="32" Offset="0x4410" AddedByScript="true"/>
+        <Texture Name="souko_sceneTex_004C10" OutName="souko_sceneTex_004C10" Format="rgba16" Width="32" Height="16" Offset="0x4C10" AddedByScript="true"/>
+        <Texture Name="souko_sceneTex_005410" OutName="souko_sceneTex_005410" Format="rgba16" Width="32" Height="32" Offset="0x5410" AddedByScript="true"/>
+        <Texture Name="souko_sceneTex_005C10" OutName="souko_sceneTex_005C10" Format="rgba16" Width="64" Height="32" Offset="0x5C10" AddedByScript="true"/>
         <Texture Name="gLonLonHouseDayEntranceTex" OutName="day_entrance" Format="ia16" Width="64" Height="4" Offset="0x5210"/> 
         <Texture Name="gLonLonHouseNightEntranceTex" OutName="night_entrance" Format="ia16" Width="64" Height="4" Offset="0x5010"/> 
         <Scene Name="souko_scene" Offset="0x0"/>
     </File>
     <File Name="souko_room_0" Segment="3">
+        <Texture Name="souko_room_0Tex_0054F8" OutName="souko_room_0Tex_0054F8" Format="i4" Width="64" Height="64" Offset="0x54F8" AddedByScript="true"/>
+        <Texture Name="souko_room_0Tex_005CF8" OutName="souko_room_0Tex_005CF8" Format="rgba16" Width="32" Height="32" Offset="0x5CF8" AddedByScript="true"/>
+        <Texture Name="souko_room_0Tex_0064F8" OutName="souko_room_0Tex_0064F8" Format="rgba16" Width="32" Height="32" Offset="0x64F8" AddedByScript="true"/>
+        <Texture Name="souko_room_0Tex_006CF8" OutName="souko_room_0Tex_006CF8" Format="rgba16" Width="16" Height="32" Offset="0x6CF8" AddedByScript="true"/>
+        <Texture Name="souko_room_0Tex_0070F8" OutName="souko_room_0Tex_0070F8" Format="rgba16" Width="32" Height="32" Offset="0x70F8" AddedByScript="true"/>
+        <Texture Name="souko_room_0Tex_0078F8" OutName="souko_room_0Tex_0078F8" Format="rgba16" Width="32" Height="32" Offset="0x78F8" AddedByScript="true"/>
+        <Texture Name="souko_room_0Tex_0080F8" OutName="souko_room_0Tex_0080F8" Format="rgba16" Width="32" Height="64" Offset="0x80F8" AddedByScript="true"/>
+        <Texture Name="souko_room_0Tex_0090F8" OutName="souko_room_0Tex_0090F8" Format="i4" Width="32" Height="32" Offset="0x90F8" AddedByScript="true"/>
         <Room Name="souko_room_0" Offset="0x0"/>
     </File>
     <File Name="souko_room_1" Segment="3">
+        <Texture Name="souko_room_1Tex_005118" OutName="souko_room_1Tex_005118" Format="rgba16" Width="16" Height="64" Offset="0x5118" AddedByScript="true"/>
+        <Texture Name="souko_room_1Tex_005918" OutName="souko_room_1Tex_005918" Format="rgba16" Width="32" Height="32" Offset="0x5918" AddedByScript="true"/>
+        <Texture Name="souko_room_1Tex_006118" OutName="souko_room_1Tex_006118" Format="rgba16" Width="32" Height="64" Offset="0x6118" AddedByScript="true"/>
+        <Texture Name="souko_room_1Tex_007118" OutName="souko_room_1Tex_007118" Format="rgba16" Width="16" Height="32" Offset="0x7118" AddedByScript="true"/>
+        <Texture Name="souko_room_1Tex_007518" OutName="souko_room_1Tex_007518" Format="rgba16" Width="32" Height="32" Offset="0x7518" AddedByScript="true"/>
+        <Texture Name="souko_room_1Tex_007D18" OutName="souko_room_1Tex_007D18" Format="rgba16" Width="32" Height="64" Offset="0x7D18" AddedByScript="true"/>
+        <Texture Name="souko_room_1Tex_008D18" OutName="souko_room_1Tex_008D18" Format="rgba16" Width="32" Height="32" Offset="0x8D18" AddedByScript="true"/>
+        <Texture Name="souko_room_1Tex_009F28" OutName="souko_room_1Tex_009F28" Format="rgba16" Width="16" Height="16" Offset="0x9F28" AddedByScript="true"/>
+        <Texture Name="souko_room_1Tex_00A128" OutName="souko_room_1Tex_00A128" Format="ia8" Width="16" Height="16" Offset="0xA128" AddedByScript="true"/>
+        <Texture Name="souko_room_1Tex_00A228" OutName="souko_room_1Tex_00A228" Format="ia8" Width="16" Height="32" Offset="0xA228" AddedByScript="true"/>
         <Room Name="souko_room_1" Offset="0x0"/>
     </File>
     <File Name="souko_room_2" Segment="3">
+        <Texture Name="souko_room_2Tex_004EE0" OutName="souko_room_2Tex_004EE0" Format="rgba16" Width="16" Height="32" Offset="0x4EE0" AddedByScript="true"/>
+        <Texture Name="souko_room_2Tex_0052E0" OutName="souko_room_2Tex_0052E0" Format="i4" Width="64" Height="64" Offset="0x52E0" AddedByScript="true"/>
+        <Texture Name="souko_room_2Tex_005AE0" OutName="souko_room_2Tex_005AE0" Format="rgba16" Width="8" Height="128" Offset="0x5AE0" AddedByScript="true"/>
+        <Texture Name="souko_room_2Tex_0062E0" OutName="souko_room_2Tex_0062E0" Format="rgba16" Width="16" Height="64" Offset="0x62E0" AddedByScript="true"/>
+        <Texture Name="souko_room_2Tex_006AE0" OutName="souko_room_2Tex_006AE0" Format="rgba16" Width="32" Height="64" Offset="0x6AE0" AddedByScript="true"/>
+        <Texture Name="souko_room_2Tex_007F78" OutName="souko_room_2Tex_007F78" Format="ia8" Width="16" Height="32" Offset="0x7F78" AddedByScript="true"/>
         <Room Name="souko_room_2" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/N64_PAL_11/scenes/overworld/spot00.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/overworld/spot00.xml
@@ -1,5 +1,56 @@
 <Root>
     <File Name="spot00_scene" Segment="2">
+        <Texture Name="spot00_sceneTex_013D98" OutName="spot00_sceneTex_013D98" Format="rgba16" Width="32" Height="32" Offset="0x13DB8" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_014598" OutName="spot00_sceneTex_014598" Format="rgba16" Width="16" Height="32" Offset="0x145B8" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_014998" OutName="spot00_sceneTex_014998" Format="rgba16" Width="32" Height="16" Offset="0x149B8" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_014D98" OutName="spot00_sceneTex_014D98" Format="rgba16" Width="64" Height="32" Offset="0x14DB8" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_015D98" OutName="spot00_sceneTex_015D98" Format="rgba16" Width="8" Height="16" Offset="0x15DB8" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_015E98" OutName="spot00_sceneTex_015E98" Format="rgba16" Width="16" Height="64" Offset="0x15EB8" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_016698" OutName="spot00_sceneTex_016698" Format="rgba16" Width="32" Height="16" Offset="0x166B8" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_016A98" OutName="spot00_sceneTex_016A98" Format="ia4" Width="16" Height="32" Offset="0x16AB8" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_016B98" OutName="spot00_sceneTex_016B98" Format="rgba16" Width="32" Height="32" Offset="0x16BB8" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_017398" OutName="spot00_sceneTex_017398" Format="rgba16" Width="32" Height="32" Offset="0x173B8" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_017B98" OutName="spot00_sceneTex_017B98" Format="rgba16" Width="32" Height="64" Offset="0x17BB8" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_018B98" OutName="spot00_sceneTex_018B98" Format="rgba16" Width="32" Height="32" Offset="0x18BB8" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_019398" OutName="spot00_sceneTex_019398" Format="rgba16" Width="32" Height="32" Offset="0x193B8" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_019B98" OutName="spot00_sceneTex_019B98" Format="rgba16" Width="32" Height="64" Offset="0x19BB8" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_01AB98" OutName="spot00_sceneTex_01AB98" Format="rgba16" Width="32" Height="32" Offset="0x1ABB8" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_01B398" OutName="spot00_sceneTex_01B398" Format="rgba16" Width="32" Height="32" Offset="0x1B3B8" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_01BB98" OutName="spot00_sceneTex_01BB98" Format="rgba16" Width="16" Height="16" Offset="0x1BBB8" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_01BD98" OutName="spot00_sceneTex_01BD98" Format="rgba16" Width="16" Height="32" Offset="0x1BDB8" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_01C198" OutName="spot00_sceneTex_01C198" Format="rgba16" Width="32" Height="32" Offset="0x1C1B8" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_01C998" OutName="spot00_sceneTex_01C998" Format="rgba16" Width="32" Height="32" Offset="0x1C9B8" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_01D198" OutName="spot00_sceneTex_01D198" Format="rgba16" Width="64" Height="16" Offset="0x1D1B8" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_01D998" OutName="spot00_sceneTex_01D998" Format="rgba16" Width="32" Height="64" Offset="0x1D9B8" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_01E998" OutName="spot00_sceneTex_01E998" Format="ia4" Width="128" Height="32" Offset="0x1E9B8" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_01F198" OutName="spot00_sceneTex_01F198" Format="ia4" Width="64" Height="32" Offset="0x1F1B8" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_01F598" OutName="spot00_sceneTex_01F598" Format="i4" Width="16" Height="16" Offset="0x1F5B8" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_01F618" OutName="spot00_sceneTex_01F618" Format="rgba16" Width="8" Height="32" Offset="0x1F638" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_01F818" OutName="spot00_sceneTex_01F818" Format="rgba16" Width="32" Height="32" Offset="0x1F838" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_020018" OutName="spot00_sceneTex_020018" Format="i4" Width="64" Height="64" Offset="0x20038" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_020818" OutName="spot00_sceneTex_020818" Format="rgba16" Width="32" Height="32" Offset="0x20838" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_021018" OutName="spot00_sceneTex_021018" Format="rgba16" Width="16" Height="64" Offset="0x21038" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_021818" OutName="spot00_sceneTex_021818" Format="rgba16" Width="16" Height="64" Offset="0x21838" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_022018" OutName="spot00_sceneTex_022018" Format="ia4" Width="128" Height="32" Offset="0x22038" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_022818" OutName="spot00_sceneTex_022818" Format="rgba16" Width="64" Height="16" Offset="0x22838" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_023018" OutName="spot00_sceneTex_023018" Format="rgba16" Width="64" Height="16" Offset="0x23038" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_023818" OutName="spot00_sceneTex_023818" Format="i4" Width="64" Height="64" Offset="0x23838" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_024018" OutName="spot00_sceneTex_024018" Format="i4" Width="64" Height="64" Offset="0x24038" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_024818" OutName="spot00_sceneTex_024818" Format="ci4" Width="64" Height="64" Offset="0x24838" TlutOffset="0x13D90" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_025018" OutName="spot00_sceneTex_025018" Format="i4" Width="64" Height="64" Offset="0x25038" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_025818" OutName="spot00_sceneTex_025818" Format="rgba16" Width="8" Height="8" Offset="0x25838" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_025898" OutName="spot00_sceneTex_025898" Format="rgba16" Width="32" Height="32" Offset="0x258B8" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_026098" OutName="spot00_sceneTex_026098" Format="rgba16" Width="32" Height="32" Offset="0x260B8" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_026898" OutName="spot00_sceneTex_026898" Format="ia4" Width="16" Height="32" Offset="0x268B8" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_026998" OutName="spot00_sceneTex_026998" Format="rgba16" Width="64" Height="32" Offset="0x269B8" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_027998" OutName="spot00_sceneTex_027998" Format="i4" Width="32" Height="64" Offset="0x279B8" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_027D98" OutName="spot00_sceneTex_027D98" Format="i4" Width="32" Height="64" Offset="0x27DB8" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_028198" OutName="spot00_sceneTex_028198" Format="rgba16" Width="8" Height="64" Offset="0x281B8" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_028598" OutName="spot00_sceneTex_028598" Format="rgba16" Width="64" Height="32" Offset="0x285B8" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_029598" OutName="spot00_sceneTex_029598" Format="i4" Width="64" Height="64" Offset="0x295B8" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_029D98" OutName="spot00_sceneTex_029D98" Format="i4" Width="32" Height="32" Offset="0x29DB8" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTex_029F98" OutName="spot00_sceneTex_029F98" Format="i4" Width="32" Height="32" Offset="0x29FB8" AddedByScript="true"/>
+        <Texture Name="spot00_sceneTLUT_013D70" OutName="spot00_sceneTLUT_013D70" Format="rgba16" Width="4" Height="4" Offset="0x13D90" AddedByScript="true"/>
         <Cutscene Name="gHyruleFieldGetOoTCs" Offset="0xBB80"/>
         <Cutscene Name="gHyruleFieldZeldaSongOfTimeCs" Offset="0xF890"/>
         <Cutscene Name="gHyruleFieldEastEponaJumpCs" Offset="0xFF20"/>

--- a/soh/assets/xml/N64_PAL_11/scenes/overworld/spot01.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/overworld/spot01.xml
@@ -1,5 +1,43 @@
 <Root>
     <File Name="spot01_scene" Segment="2">
+        <Texture Name="spot01_sceneTex_00AA50" OutName="spot01_sceneTex_00AA50" Format="rgba16" Width="32" Height="32" Offset="0xAA70" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00B250" OutName="spot01_sceneTex_00B250" Format="ci8" Width="16" Height="16" Offset="0xB270" TlutOffset="0xA890" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00B350" OutName="spot01_sceneTex_00B350" Format="ci8" Width="16" Height="64" Offset="0xB370" TlutOffset="0xA890" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00B750" OutName="spot01_sceneTex_00B750" Format="ci8" Width="32" Height="32" Offset="0xB770" TlutOffset="0xA890" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00BB50" OutName="spot01_sceneTex_00BB50" Format="rgba16" Width="16" Height="32" Offset="0xBB70" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00BF50" OutName="spot01_sceneTex_00BF50" Format="rgba16" Width="32" Height="32" Offset="0xBF70" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00C750" OutName="spot01_sceneTex_00C750" Format="ci8" Width="16" Height="32" Offset="0xC770" TlutOffset="0xA890" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00C950" OutName="spot01_sceneTex_00C950" Format="ci8" Width="32" Height="32" Offset="0xC970" TlutOffset="0xA890" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00CD50" OutName="spot01_sceneTex_00CD50" Format="ci8" Width="32" Height="64" Offset="0xCD70" TlutOffset="0xA890" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00D550" OutName="spot01_sceneTex_00D550" Format="i4" Width="64" Height="64" Offset="0xD570" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00DD50" OutName="spot01_sceneTex_00DD50" Format="i4" Width="64" Height="64" Offset="0xDD70" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00E550" OutName="spot01_sceneTex_00E550" Format="ci8" Width="32" Height="64" Offset="0xE570" TlutOffset="0xA890" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00ED50" OutName="spot01_sceneTex_00ED50" Format="ci4" Width="64" Height="64" Offset="0xED70" TlutOffset="0xAA48" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00F550" OutName="spot01_sceneTex_00F550" Format="rgba16" Width="32" Height="16" Offset="0xF570" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_00F950" OutName="spot01_sceneTex_00F950" Format="rgba16" Width="32" Height="32" Offset="0xF970" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_010150" OutName="spot01_sceneTex_010150" Format="rgba16" Width="32" Height="32" Offset="0x10170" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_010950" OutName="spot01_sceneTex_010950" Format="rgba16" Width="32" Height="64" Offset="0x10970" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_011950" OutName="spot01_sceneTex_011950" Format="rgba16" Width="32" Height="64" Offset="0x11970" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_012950" OutName="spot01_sceneTex_012950" Format="ci8" Width="16" Height="32" Offset="0x12970" TlutOffset="0xA890" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_012B50" OutName="spot01_sceneTex_012B50" Format="rgba16" Width="64" Height="32" Offset="0x12B70" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_013B50" OutName="spot01_sceneTex_013B50" Format="rgba16" Width="16" Height="64" Offset="0x13B70" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_014350" OutName="spot01_sceneTex_014350" Format="ia4" Width="64" Height="32" Offset="0x14370" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_014750" OutName="spot01_sceneTex_014750" Format="ia4" Width="64" Height="32" Offset="0x14770" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_014B50" OutName="spot01_sceneTex_014B50" Format="ci8" Width="32" Height="32" Offset="0x14B70" TlutOffset="0xA890" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_014F50" OutName="spot01_sceneTex_014F50" Format="ci8" Width="64" Height="16" Offset="0x14F70" TlutOffset="0xA890" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_015350" OutName="spot01_sceneTex_015350" Format="ia4" Width="64" Height="64" Offset="0x15370" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_017B50" OutName="spot01_sceneTex_017B50" Format="ci8" Width="32" Height="64" Offset="0x17B70" TlutOffset="0xA890" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_018350" OutName="spot01_sceneTex_018350" Format="i4" Width="64" Height="64" Offset="0x18370" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_018B50" OutName="spot01_sceneTex_018B50" Format="rgba16" Width="32" Height="32" Offset="0x18B70" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_019350" OutName="spot01_sceneTex_019350" Format="rgba16" Width="32" Height="32" Offset="0x19370" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_019B50" OutName="spot01_sceneTex_019B50" Format="ci8" Width="32" Height="32" Offset="0x19B70" TlutOffset="0xA890" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_019F50" OutName="spot01_sceneTex_019F50" Format="rgba16" Width="32" Height="32" Offset="0x19F70" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_01A750" OutName="spot01_sceneTex_01A750" Format="i4" Width="64" Height="64" Offset="0x1A770" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_01AF50" OutName="spot01_sceneTex_01AF50" Format="rgba16" Width="16" Height="64" Offset="0x1AF70" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_01B750" OutName="spot01_sceneTex_01B750" Format="rgba16" Width="32" Height="32" Offset="0x1B770" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTex_01BF50" OutName="spot01_sceneTex_01BF50" Format="ci8" Width="16" Height="32" Offset="0x1BF70" TlutOffset="0xA890" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTLUT_00A870" OutName="spot01_sceneTLUT_00A870" Format="rgba16" Width="16" Height="16" Offset="0xA890" AddedByScript="true"/>
+        <Texture Name="spot01_sceneTLUT_00AA28" OutName="spot01_sceneTLUT_00AA28" Format="rgba16" Width="4" Height="4" Offset="0xAA48" AddedByScript="true"/>
         <Path Name="gKakarikoVillagePath_003D0" Offset="0x3D0" NumPaths="3"/>
         <Cutscene Name="gKakarikoVillageIntroCs" Offset="0xA560"/>
         <Texture Name="gKakarikoVillageDayWindowTex" OutName="day_window" Format="rgba16" Width="32" Height="64" Offset="0x15B70"/>

--- a/soh/assets/xml/N64_PAL_11/scenes/overworld/spot02.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/overworld/spot02.xml
@@ -1,5 +1,16 @@
 <Root>
     <File Name="spot02_scene" Segment="2">
+        <Texture Name="spot02_sceneTex_007280" OutName="spot02_sceneTex_007280" Format="rgba16" Width="32" Height="32" Offset="0x7280" AddedByScript="true"/>
+        <Texture Name="spot02_sceneTex_007A80" OutName="spot02_sceneTex_007A80" Format="rgba16" Width="32" Height="16" Offset="0x7A80" AddedByScript="true"/>
+        <Texture Name="spot02_sceneTex_007E80" OutName="spot02_sceneTex_007E80" Format="rgba16" Width="32" Height="32" Offset="0x7E80" AddedByScript="true"/>
+        <Texture Name="spot02_sceneTex_008680" OutName="spot02_sceneTex_008680" Format="rgba16" Width="16" Height="64" Offset="0x8680" AddedByScript="true"/>
+        <Texture Name="spot02_sceneTex_008E80" OutName="spot02_sceneTex_008E80" Format="i8" Width="64" Height="64" Offset="0x8E80" AddedByScript="true"/>
+        <Texture Name="spot02_sceneTex_009E80" OutName="spot02_sceneTex_009E80" Format="ia4" Width="32" Height="64" Offset="0x9E80" AddedByScript="true"/>
+        <Texture Name="spot02_sceneTex_00A280" OutName="spot02_sceneTex_00A280" Format="rgba16" Width="32" Height="32" Offset="0xA280" AddedByScript="true"/>
+        <Texture Name="spot02_sceneTex_00AA80" OutName="spot02_sceneTex_00AA80" Format="rgba16" Width="32" Height="16" Offset="0xAA80" AddedByScript="true"/>
+        <Texture Name="spot02_sceneTex_00AE80" OutName="spot02_sceneTex_00AE80" Format="i4" Width="32" Height="32" Offset="0xAE80" AddedByScript="true"/>
+        <Texture Name="spot02_sceneTex_00B080" OutName="spot02_sceneTex_00B080" Format="rgba16" Width="32" Height="32" Offset="0xB080" AddedByScript="true"/>
+        <Texture Name="spot02_sceneTex_00B880" OutName="spot02_sceneTex_00B880" Format="rgba16" Width="16" Height="32" Offset="0xB880" AddedByScript="true"/>
         <Scene Name="spot02_scene" Offset="0x0"/>
 
         <Cutscene Name="spot02_scene_Cs_003C80" Offset="0x3C80"/>
@@ -12,6 +23,42 @@
         <Room Name="spot02_room_0" Offset="0x0"/>
     </File>
     <File Name="spot02_room_1" Segment="3">
+        <Texture Name="spot02_room_1Tex_008F08" OutName="spot02_room_1Tex_008F08" Format="rgba16" Width="32" Height="32" Offset="0x8F08" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_009708" OutName="spot02_room_1Tex_009708" Format="rgba16" Width="16" Height="16" Offset="0x9708" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_009908" OutName="spot02_room_1Tex_009908" Format="rgba16" Width="64" Height="32" Offset="0x9908" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_00A908" OutName="spot02_room_1Tex_00A908" Format="rgba16" Width="32" Height="32" Offset="0xA908" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_00B108" OutName="spot02_room_1Tex_00B108" Format="rgba16" Width="32" Height="64" Offset="0xB108" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_00C108" OutName="spot02_room_1Tex_00C108" Format="rgba16" Width="16" Height="32" Offset="0xC108" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_00C508" OutName="spot02_room_1Tex_00C508" Format="ci4" Width="64" Height="64" Offset="0xC508" TlutOffset="0x8EB8" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_00CD08" OutName="spot02_room_1Tex_00CD08" Format="rgba16" Width="64" Height="32" Offset="0xCD08" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_00DD08" OutName="spot02_room_1Tex_00DD08" Format="ia8" Width="32" Height="32" Offset="0xDD08" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_00E108" OutName="spot02_room_1Tex_00E108" Format="rgba16" Width="16" Height="16" Offset="0xE108" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_00E308" OutName="spot02_room_1Tex_00E308" Format="rgba16" Width="32" Height="32" Offset="0xE308" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_00EB08" OutName="spot02_room_1Tex_00EB08" Format="rgba16" Width="16" Height="64" Offset="0xEB08" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_00F308" OutName="spot02_room_1Tex_00F308" Format="rgba16" Width="32" Height="64" Offset="0xF308" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_010308" OutName="spot02_room_1Tex_010308" Format="rgba16" Width="32" Height="32" Offset="0x10308" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_010B08" OutName="spot02_room_1Tex_010B08" Format="rgba16" Width="16" Height="16" Offset="0x10B08" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_010D08" OutName="spot02_room_1Tex_010D08" Format="rgba16" Width="32" Height="32" Offset="0x10D08" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_011508" OutName="spot02_room_1Tex_011508" Format="ia8" Width="64" Height="64" Offset="0x11508" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_012508" OutName="spot02_room_1Tex_012508" Format="rgba16" Width="32" Height="32" Offset="0x12508" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_012D08" OutName="spot02_room_1Tex_012D08" Format="rgba16" Width="32" Height="32" Offset="0x12D08" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_013508" OutName="spot02_room_1Tex_013508" Format="rgba16" Width="32" Height="64" Offset="0x13508" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_014508" OutName="spot02_room_1Tex_014508" Format="ci4" Width="64" Height="64" Offset="0x14508" TlutOffset="0x8EE0" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_014D08" OutName="spot02_room_1Tex_014D08" Format="rgba16" Width="128" Height="16" Offset="0x14D08" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_015D08" OutName="spot02_room_1Tex_015D08" Format="i8" Width="64" Height="64" Offset="0x15D08" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_016D08" OutName="spot02_room_1Tex_016D08" Format="i4" Width="16" Height="16" Offset="0x16D08" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_016D88" OutName="spot02_room_1Tex_016D88" Format="rgba16" Width="32" Height="32" Offset="0x16D88" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_017588" OutName="spot02_room_1Tex_017588" Format="rgba16" Width="32" Height="16" Offset="0x17588" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_017988" OutName="spot02_room_1Tex_017988" Format="ia8" Width="128" Height="32" Offset="0x17988" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_018988" OutName="spot02_room_1Tex_018988" Format="rgba16" Width="32" Height="64" Offset="0x18988" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_01B690" OutName="spot02_room_1Tex_01B690" Format="ia8" Width="64" Height="32" Offset="0x1B690" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_01BE90" OutName="spot02_room_1Tex_01BE90" Format="ia8" Width="32" Height="32" Offset="0x1BE90" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_01C290" OutName="spot02_room_1Tex_01C290" Format="ia8" Width="32" Height="32" Offset="0x1C290" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_01C690" OutName="spot02_room_1Tex_01C690" Format="ia8" Width="16" Height="16" Offset="0x1C690" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_01C790" OutName="spot02_room_1Tex_01C790" Format="ia8" Width="64" Height="64" Offset="0x1C790" AddedByScript="true"/>
+        <Texture Name="spot02_room_1Tex_01D790" OutName="spot02_room_1Tex_01D790" Format="ia8" Width="32" Height="64" Offset="0x1D790" AddedByScript="true"/>
+        <Texture Name="spot02_room_1TLUT_008EB8" OutName="spot02_room_1TLUT_008EB8" Format="rgba16" Width="4" Height="4" Offset="0x8EB8" AddedByScript="true"/>
+        <Texture Name="spot02_room_1TLUT_008EE0" OutName="spot02_room_1TLUT_008EE0" Format="rgba16" Width="4" Height="4" Offset="0x8EE0" AddedByScript="true"/>
         <Room Name="spot02_room_1" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/N64_PAL_11/scenes/overworld/spot03.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/overworld/spot03.xml
@@ -1,14 +1,40 @@
 <Root>
     <File Name="spot03_scene" Segment="2">
+        <Texture Name="spot03_sceneTex_006D58" OutName="spot03_sceneTex_006D58" Format="ci8" Width="16" Height="64" Offset="0x6D58" TlutOffset="0x6920" AddedByScript="true"/>
+        <Texture Name="spot03_sceneTex_007158" OutName="spot03_sceneTex_007158" Format="rgba16" Width="16" Height="32" Offset="0x7158" AddedByScript="true"/>
+        <Texture Name="spot03_sceneTex_007558" OutName="spot03_sceneTex_007558" Format="rgba16" Width="32" Height="16" Offset="0x7558" AddedByScript="true"/>
+        <Texture Name="spot03_sceneTex_007958" OutName="spot03_sceneTex_007958" Format="ci8" Width="32" Height="32" Offset="0x7958" TlutOffset="0x6B28" AddedByScript="true"/>
+        <Texture Name="spot03_sceneTex_007D58" OutName="spot03_sceneTex_007D58" Format="rgba16" Width="32" Height="32" Offset="0x7D58" AddedByScript="true"/>
+        <Texture Name="spot03_sceneTex_008558" OutName="spot03_sceneTex_008558" Format="ci8" Width="32" Height="64" Offset="0x8558" TlutOffset="0x6B28" AddedByScript="true"/>
+        <Texture Name="spot03_sceneTex_008D58" OutName="spot03_sceneTex_008D58" Format="rgba16" Width="32" Height="32" Offset="0x8D58" AddedByScript="true"/>
+        <Texture Name="spot03_sceneTex_009558" OutName="spot03_sceneTex_009558" Format="ci4" Width="64" Height="64" Offset="0x9558" TlutOffset="0x6D30" AddedByScript="true"/>
+        <Texture Name="spot03_sceneTex_009D58" OutName="spot03_sceneTex_009D58" Format="rgba16" Width="32" Height="32" Offset="0x9D58" AddedByScript="true"/>
+        <Texture Name="spot03_sceneTex_00A558" OutName="spot03_sceneTex_00A558" Format="rgba16" Width="32" Height="32" Offset="0xA558" AddedByScript="true"/>
+        <Texture Name="spot03_sceneTex_00AD58" OutName="spot03_sceneTex_00AD58" Format="ia4" Width="64" Height="64" Offset="0xAD58" AddedByScript="true"/>
+        <Texture Name="spot03_sceneTLUT_006920" OutName="spot03_sceneTLUT_006920" Format="rgba16" Width="16" Height="16" Offset="0x6920" AddedByScript="true"/>
+        <Texture Name="spot03_sceneTLUT_006B28" OutName="spot03_sceneTLUT_006B28" Format="rgba16" Width="16" Height="16" Offset="0x6B28" AddedByScript="true"/>
+        <Texture Name="spot03_sceneTLUT_006D30" OutName="spot03_sceneTLUT_006D30" Format="rgba16" Width="4" Height="4" Offset="0x6D30" AddedByScript="true"/>
         <Path Name="gSpot03Path_0002BC" Offset="0x2BC" NumPaths="2"/>
         <Path Name="gSpot03Path_006908" Offset="0x6908" NumPaths="3"/>
 
         <Scene Name="spot03_scene" Offset="0x0"/>
     </File>
     <File Name="spot03_room_0" Segment="3">
+        <Texture Name="spot03_room_0Tex_0097B0" OutName="spot03_room_0Tex_0097B0" Format="ci8" Width="32" Height="32" Offset="0x97B0" ExternalTlut="spot03_scene" ExternalTlutOffset="0x6B28" AddedByScript="true"/>
+        <Texture Name="spot03_room_0Tex_009BB0" OutName="spot03_room_0Tex_009BB0" Format="ci8" Width="32" Height="64" Offset="0x9BB0" ExternalTlut="spot03_scene" ExternalTlutOffset="0x6B28" AddedByScript="true"/>
+        <Texture Name="spot03_room_0Tex_00A3B0" OutName="spot03_room_0Tex_00A3B0" Format="rgba16" Width="16" Height="64" Offset="0xA3B0" AddedByScript="true"/>
+        <Texture Name="spot03_room_0Tex_00ABB0" OutName="spot03_room_0Tex_00ABB0" Format="rgba16" Width="64" Height="32" Offset="0xABB0" AddedByScript="true"/>
+        <Texture Name="spot03_room_0Tex_00BBB0" OutName="spot03_room_0Tex_00BBB0" Format="ci8" Width="32" Height="32" Offset="0xBBB0" ExternalTlut="spot03_scene" ExternalTlutOffset="0x6B28" AddedByScript="true"/>
+        <Texture Name="spot03_room_0Tex_00BFB0" OutName="spot03_room_0Tex_00BFB0" Format="ci8" Width="32" Height="32" Offset="0xBFB0" ExternalTlut="spot03_scene" ExternalTlutOffset="0x6B28" AddedByScript="true"/>
+        <Texture Name="spot03_room_0Tex_00D180" OutName="spot03_room_0Tex_00D180" Format="i4" Width="64" Height="64" Offset="0xD180" AddedByScript="true"/>
         <Room Name="spot03_room_0" Offset="0x0"/>
     </File>
     <File Name="spot03_room_1" Segment="3">
+        <Texture Name="spot03_room_1Tex_0050D8" OutName="spot03_room_1Tex_0050D8" Format="ci8" Width="64" Height="32" Offset="0x50D8" ExternalTlut="spot03_scene" ExternalTlutOffset="0x6920" AddedByScript="true"/>
+        <Texture Name="spot03_room_1Tex_0058D8" OutName="spot03_room_1Tex_0058D8" Format="ci8" Width="64" Height="16" Offset="0x58D8" ExternalTlut="spot03_scene" ExternalTlutOffset="0x6920" AddedByScript="true"/>
+        <Texture Name="spot03_room_1Tex_005CD8" OutName="spot03_room_1Tex_005CD8" Format="ci8" Width="32" Height="16" Offset="0x5CD8" ExternalTlut="spot03_scene" ExternalTlutOffset="0x6920" AddedByScript="true"/>
+        <Texture Name="spot03_room_1Tex_005ED8" OutName="spot03_room_1Tex_005ED8" Format="ci8" Width="16" Height="64" Offset="0x5ED8" ExternalTlut="spot03_scene" ExternalTlutOffset="0x6920" AddedByScript="true"/>
+        <Texture Name="spot03_room_1Tex_0062D8" OutName="spot03_room_1Tex_0062D8" Format="ci8" Width="64" Height="32" Offset="0x62D8" ExternalTlut="spot03_scene" ExternalTlutOffset="0x6920" AddedByScript="true"/>
         <DList Name="gSpot03DL_0074E8" Offset="0x74E8"/>
         <Room Name="spot03_room_1" Offset="0x0"/>
     </File>

--- a/soh/assets/xml/N64_PAL_11/scenes/overworld/spot04.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/overworld/spot04.xml
@@ -1,5 +1,12 @@
 <Root>
     <File Name="spot04_scene" Segment="2">
+        <Texture Name="spot04_sceneTex_00E218" OutName="spot04_sceneTex_00E218" Format="rgba16" Width="32" Height="32" Offset="0xE248" AddedByScript="true"/>
+        <Texture Name="spot04_sceneTex_00EA18" OutName="spot04_sceneTex_00EA18" Format="i4" Width="64" Height="64" Offset="0xEA48" AddedByScript="true"/>
+        <Texture Name="spot04_sceneTex_00F218" OutName="spot04_sceneTex_00F218" Format="i4" Width="64" Height="64" Offset="0xF248" AddedByScript="true"/>
+        <Texture Name="spot04_sceneTex_00FA18" OutName="spot04_sceneTex_00FA18" Format="ci8" Width="32" Height="32" Offset="0xFA48" TlutOffset="0xE040" AddedByScript="true"/>
+        <Texture Name="spot04_sceneTex_00FE18" OutName="spot04_sceneTex_00FE18" Format="rgba16" Width="32" Height="32" Offset="0xFE48" AddedByScript="true"/>
+        <Texture Name="spot04_sceneTex_010618" OutName="spot04_sceneTex_010618" Format="rgba16" Width="32" Height="32" Offset="0x10648" AddedByScript="true"/>
+        <Texture Name="spot04_sceneTLUT_00E010" OutName="spot04_sceneTLUT_00E010" Format="rgba16" Width="16" Height="16" Offset="0xE040" AddedByScript="true"/>
         <Path Name="gSpot04Path_00030C" Offset="0x30C" NumPaths="3"/>
         <Path Name="gSpot04Path_00D730" Offset="0xD760"/>
         <Cutscene Name="gKokiriForestDekuSproutCs" Offset="0xCA00"/>
@@ -8,12 +15,65 @@
         <Scene Name="spot04_scene" Offset="0x0"/>
     </File>
     <File Name="spot04_room_0" Segment="3">
+        <Texture Name="spot04_room_0Tex_00BF08" OutName="spot04_room_0Tex_00BF08" Format="rgba16" Width="32" Height="32" Offset="0xBF08" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_00C708" OutName="spot04_room_0Tex_00C708" Format="rgba16" Width="32" Height="16" Offset="0xC708" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_00CB08" OutName="spot04_room_0Tex_00CB08" Format="rgba16" Width="32" Height="16" Offset="0xCB08" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_00CF08" OutName="spot04_room_0Tex_00CF08" Format="ci8" Width="32" Height="32" Offset="0xCF08" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE040" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_00D308" OutName="spot04_room_0Tex_00D308" Format="ci8" Width="16" Height="16" Offset="0xD308" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE040" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_00D408" OutName="spot04_room_0Tex_00D408" Format="ci8" Width="16" Height="16" Offset="0xD408" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE040" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_00D508" OutName="spot04_room_0Tex_00D508" Format="rgba16" Width="16" Height="32" Offset="0xD508" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_00D908" OutName="spot04_room_0Tex_00D908" Format="rgba16" Width="16" Height="64" Offset="0xD908" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_00E108" OutName="spot04_room_0Tex_00E108" Format="rgba16" Width="32" Height="32" Offset="0xE108" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_00E908" OutName="spot04_room_0Tex_00E908" Format="rgba16" Width="32" Height="32" Offset="0xE908" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_00F108" OutName="spot04_room_0Tex_00F108" Format="rgba16" Width="64" Height="8" Offset="0xF108" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_00F508" OutName="spot04_room_0Tex_00F508" Format="rgba16" Width="32" Height="32" Offset="0xF508" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_00FD08" OutName="spot04_room_0Tex_00FD08" Format="rgba16" Width="32" Height="64" Offset="0xFD08" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_010D08" OutName="spot04_room_0Tex_010D08" Format="rgba16" Width="32" Height="64" Offset="0x10D08" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_011D08" OutName="spot04_room_0Tex_011D08" Format="ci8" Width="16" Height="32" Offset="0x11D08" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE040" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_011F08" OutName="spot04_room_0Tex_011F08" Format="rgba16" Width="64" Height="32" Offset="0x11F08" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_012F08" OutName="spot04_room_0Tex_012F08" Format="ci8" Width="32" Height="16" Offset="0x12F08" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE040" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_013108" OutName="spot04_room_0Tex_013108" Format="ci8" Width="32" Height="16" Offset="0x13108" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE040" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_013308" OutName="spot04_room_0Tex_013308" Format="rgba16" Width="16" Height="32" Offset="0x13308" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_013708" OutName="spot04_room_0Tex_013708" Format="rgba16" Width="32" Height="32" Offset="0x13708" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_013F08" OutName="spot04_room_0Tex_013F08" Format="ci8" Width="32" Height="32" Offset="0x13F08" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE040" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_014308" OutName="spot04_room_0Tex_014308" Format="rgba16" Width="32" Height="32" Offset="0x14308" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_014B08" OutName="spot04_room_0Tex_014B08" Format="rgba16" Width="32" Height="32" Offset="0x14B08" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_015308" OutName="spot04_room_0Tex_015308" Format="rgba16" Width="64" Height="16" Offset="0x15308" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_015B08" OutName="spot04_room_0Tex_015B08" Format="ci8" Width="16" Height="32" Offset="0x15B08" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE040" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_015D08" OutName="spot04_room_0Tex_015D08" Format="ci8" Width="16" Height="64" Offset="0x15D08" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE040" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_016108" OutName="spot04_room_0Tex_016108" Format="ci8" Width="16" Height="64" Offset="0x16108" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE040" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_016508" OutName="spot04_room_0Tex_016508" Format="ci8" Width="32" Height="32" Offset="0x16508" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE040" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_016908" OutName="spot04_room_0Tex_016908" Format="ci8" Width="16" Height="64" Offset="0x16908" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE040" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_016D08" OutName="spot04_room_0Tex_016D08" Format="rgba16" Width="32" Height="16" Offset="0x16D08" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_017108" OutName="spot04_room_0Tex_017108" Format="rgba16" Width="32" Height="32" Offset="0x17108" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_018A90" OutName="spot04_room_0Tex_018A90" Format="rgba16" Width="32" Height="32" Offset="0x18A90" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_019290" OutName="spot04_room_0Tex_019290" Format="i4" Width="64" Height="64" Offset="0x19290" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_019A90" OutName="spot04_room_0Tex_019A90" Format="i4" Width="64" Height="64" Offset="0x19A90" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_01A290" OutName="spot04_room_0Tex_01A290" Format="ia8" Width="16" Height="32" Offset="0x1A290" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_01A490" OutName="spot04_room_0Tex_01A490" Format="ia4" Width="64" Height="64" Offset="0x1A490" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_01AC90" OutName="spot04_room_0Tex_01AC90" Format="ia4" Width="32" Height="32" Offset="0x1AC90" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_01AE90" OutName="spot04_room_0Tex_01AE90" Format="ia4" Width="32" Height="32" Offset="0x1AE90" AddedByScript="true"/>
+        <Texture Name="spot04_room_0Tex_01B090" OutName="spot04_room_0Tex_01B090" Format="rgba16" Width="16" Height="32" Offset="0x1B090" AddedByScript="true"/>
         <Room Name="spot04_room_0" Offset="0x0"/>
     </File>
     <File Name="spot04_room_1" Segment="3">
+        <Texture Name="spot04_room_1Tex_004EA8" OutName="spot04_room_1Tex_004EA8" Format="rgba16" Width="32" Height="16" Offset="0x4EA8" AddedByScript="true"/>
+        <Texture Name="spot04_room_1Tex_0052A8" OutName="spot04_room_1Tex_0052A8" Format="rgba16" Width="32" Height="16" Offset="0x52A8" AddedByScript="true"/>
+        <Texture Name="spot04_room_1Tex_0056A8" OutName="spot04_room_1Tex_0056A8" Format="rgba16" Width="64" Height="32" Offset="0x56A8" AddedByScript="true"/>
+        <Texture Name="spot04_room_1Tex_0066A8" OutName="spot04_room_1Tex_0066A8" Format="rgba16" Width="32" Height="32" Offset="0x66A8" AddedByScript="true"/>
+        <Texture Name="spot04_room_1Tex_006EA8" OutName="spot04_room_1Tex_006EA8" Format="rgba16" Width="32" Height="32" Offset="0x6EA8" AddedByScript="true"/>
+        <Texture Name="spot04_room_1Tex_007B78" OutName="spot04_room_1Tex_007B78" Format="ia8" Width="16" Height="32" Offset="0x7B78" AddedByScript="true"/>
+        <Texture Name="spot04_room_1Tex_007D78" OutName="spot04_room_1Tex_007D78" Format="i4" Width="64" Height="64" Offset="0x7D78" AddedByScript="true"/>
         <Room Name="spot04_room_1" Offset="0x0"/>
     </File>
     <File Name="spot04_room_2" Segment="3">
+        <Texture Name="spot04_room_2Tex_002BF8" OutName="spot04_room_2Tex_002BF8" Format="ci8" Width="32" Height="16" Offset="0x2BF8" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE040" AddedByScript="true"/>
+        <Texture Name="spot04_room_2Tex_002DF8" OutName="spot04_room_2Tex_002DF8" Format="ci8" Width="32" Height="16" Offset="0x2DF8" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE040" AddedByScript="true"/>
+        <Texture Name="spot04_room_2Tex_002FF8" OutName="spot04_room_2Tex_002FF8" Format="ci8" Width="32" Height="32" Offset="0x2FF8" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE040" AddedByScript="true"/>
+        <Texture Name="spot04_room_2Tex_0033F8" OutName="spot04_room_2Tex_0033F8" Format="rgba16" Width="32" Height="32" Offset="0x33F8" AddedByScript="true"/>
+        <Texture Name="spot04_room_2Tex_003BF8" OutName="spot04_room_2Tex_003BF8" Format="rgba16" Width="64" Height="16" Offset="0x3BF8" AddedByScript="true"/>
+        <Texture Name="spot04_room_2Tex_0043F8" OutName="spot04_room_2Tex_0043F8" Format="ci8" Width="16" Height="32" Offset="0x43F8" ExternalTlut="spot04_scene" ExternalTlutOffset="0xE040" AddedByScript="true"/>
+        <Texture Name="spot04_room_2Tex_0045F8" OutName="spot04_room_2Tex_0045F8" Format="rgba16" Width="32" Height="32" Offset="0x45F8" AddedByScript="true"/>
         <DList Name="gSpot04DL_002BB8" Offset="0x2BB8"/>
         <DList Name="gSpot04DL_005058" Offset="0x5058"/>
         <Room Name="spot04_room_2" Offset="0x0"/>

--- a/soh/assets/xml/N64_PAL_11/scenes/overworld/spot05.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/overworld/spot05.xml
@@ -1,5 +1,32 @@
 <Root>
     <File Name="spot05_scene" Segment="2">
+        <Texture Name="spot05_sceneTex_006D60" OutName="spot05_sceneTex_006D60" Format="rgba16" Width="32" Height="64" Offset="0x6D70" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_007D60" OutName="spot05_sceneTex_007D60" Format="rgba16" Width="32" Height="64" Offset="0x7D70" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_008D60" OutName="spot05_sceneTex_008D60" Format="ci8" Width="32" Height="32" Offset="0x8D70" TlutOffset="0x6BD0" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_009160" OutName="spot05_sceneTex_009160" Format="ci8" Width="32" Height="32" Offset="0x9170" TlutOffset="0x6BD0" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_009560" OutName="spot05_sceneTex_009560" Format="rgba16" Width="16" Height="32" Offset="0x9570" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_009960" OutName="spot05_sceneTex_009960" Format="ci8" Width="64" Height="32" Offset="0x9970" TlutOffset="0x6BD0" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_00A160" OutName="spot05_sceneTex_00A160" Format="rgba16" Width="64" Height="32" Offset="0xA170" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_00B160" OutName="spot05_sceneTex_00B160" Format="rgba16" Width="32" Height="32" Offset="0xB170" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_00B960" OutName="spot05_sceneTex_00B960" Format="rgba16" Width="16" Height="16" Offset="0xB970" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_00BB60" OutName="spot05_sceneTex_00BB60" Format="rgba16" Width="16" Height="128" Offset="0xBB70" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_00CB60" OutName="spot05_sceneTex_00CB60" Format="rgba16" Width="32" Height="32" Offset="0xCB70" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_00D360" OutName="spot05_sceneTex_00D360" Format="i4" Width="64" Height="64" Offset="0xD370" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_00DB60" OutName="spot05_sceneTex_00DB60" Format="rgba16" Width="32" Height="32" Offset="0xDB70" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_00E360" OutName="spot05_sceneTex_00E360" Format="i4" Width="64" Height="64" Offset="0xE370" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_00EB60" OutName="spot05_sceneTex_00EB60" Format="rgba16" Width="64" Height="16" Offset="0xEB70" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_00F360" OutName="spot05_sceneTex_00F360" Format="rgba16" Width="32" Height="32" Offset="0xF370" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_00FB60" OutName="spot05_sceneTex_00FB60" Format="i4" Width="64" Height="64" Offset="0xFB70" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_010360" OutName="spot05_sceneTex_010360" Format="rgba16" Width="32" Height="32" Offset="0x10370" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_010B60" OutName="spot05_sceneTex_010B60" Format="rgba16" Width="32" Height="32" Offset="0x10B70" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_011360" OutName="spot05_sceneTex_011360" Format="rgba16" Width="32" Height="64" Offset="0x11370" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_012360" OutName="spot05_sceneTex_012360" Format="rgba16" Width="32" Height="32" Offset="0x12370" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_012B60" OutName="spot05_sceneTex_012B60" Format="rgba16" Width="32" Height="32" Offset="0x12B70" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_013360" OutName="spot05_sceneTex_013360" Format="rgba16" Width="32" Height="32" Offset="0x13370" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_013B60" OutName="spot05_sceneTex_013B60" Format="rgba16" Width="64" Height="16" Offset="0x13B70" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_014360" OutName="spot05_sceneTex_014360" Format="rgba16" Width="32" Height="32" Offset="0x14370" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTex_014B60" OutName="spot05_sceneTex_014B60" Format="ia8" Width="16" Height="32" Offset="0x14B70" AddedByScript="true"/>
+        <Texture Name="spot05_sceneTLUT_006BC0" OutName="spot05_sceneTLUT_006BC0" Format="rgba16" Width="16" Height="16" Offset="0x6BD0" AddedByScript="true"/>
         <Cutscene Name="gMinuetCs" Offset="0x3F84"/>
 
         <Cutscene Name="spot05_scene_Cs_005730" Offset="0x5740"/>

--- a/soh/assets/xml/N64_PAL_11/scenes/overworld/spot06.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/overworld/spot06.xml
@@ -1,5 +1,48 @@
 <Root>
     <File Name="spot06_scene" Segment="2">
+        <Texture Name="spot06_sceneTex_007C38" OutName="spot06_sceneTex_007C38" Format="rgba16" Width="16" Height="32" Offset="0x7C48" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_008038" OutName="spot06_sceneTex_008038" Format="rgba16" Width="16" Height="32" Offset="0x8048" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_008438" OutName="spot06_sceneTex_008438" Format="rgba16" Width="16" Height="32" Offset="0x8448" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_008838" OutName="spot06_sceneTex_008838" Format="rgba16" Width="32" Height="64" Offset="0x8848" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_009838" OutName="spot06_sceneTex_009838" Format="rgba16" Width="8" Height="8" Offset="0x9848" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_0098B8" OutName="spot06_sceneTex_0098B8" Format="rgba16" Width="8" Height="32" Offset="0x98C8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_009AB8" OutName="spot06_sceneTex_009AB8" Format="rgba16" Width="32" Height="64" Offset="0x9AC8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_00AAB8" OutName="spot06_sceneTex_00AAB8" Format="rgba16" Width="32" Height="16" Offset="0xAAC8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_00AEB8" OutName="spot06_sceneTex_00AEB8" Format="rgba16" Width="32" Height="32" Offset="0xAEC8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_00B6B8" OutName="spot06_sceneTex_00B6B8" Format="rgba16" Width="16" Height="32" Offset="0xB6C8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_00BAB8" OutName="spot06_sceneTex_00BAB8" Format="ia8" Width="32" Height="32" Offset="0xBAC8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_00BEB8" OutName="spot06_sceneTex_00BEB8" Format="rgba16" Width="32" Height="16" Offset="0xBEC8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_00C2B8" OutName="spot06_sceneTex_00C2B8" Format="rgba16" Width="16" Height="16" Offset="0xC2C8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_00C4B8" OutName="spot06_sceneTex_00C4B8" Format="rgba16" Width="32" Height="32" Offset="0xC4C8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_00CCB8" OutName="spot06_sceneTex_00CCB8" Format="rgba16" Width="32" Height="64" Offset="0xCCC8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_00DCB8" OutName="spot06_sceneTex_00DCB8" Format="rgba16" Width="32" Height="64" Offset="0xDCC8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_00ECB8" OutName="spot06_sceneTex_00ECB8" Format="rgba16" Width="16" Height="64" Offset="0xECC8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_00F4B8" OutName="spot06_sceneTex_00F4B8" Format="rgba16" Width="16" Height="16" Offset="0xF4C8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_00F6B8" OutName="spot06_sceneTex_00F6B8" Format="rgba16" Width="32" Height="32" Offset="0xF6C8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_00FEB8" OutName="spot06_sceneTex_00FEB8" Format="rgba16" Width="32" Height="64" Offset="0xFEC8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_010EB8" OutName="spot06_sceneTex_010EB8" Format="rgba16" Width="32" Height="32" Offset="0x10EC8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_0116B8" OutName="spot06_sceneTex_0116B8" Format="rgba16" Width="32" Height="32" Offset="0x116C8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_011EB8" OutName="spot06_sceneTex_011EB8" Format="rgba16" Width="16" Height="32" Offset="0x11EC8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_0122B8" OutName="spot06_sceneTex_0122B8" Format="rgba16" Width="32" Height="16" Offset="0x122C8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_0126B8" OutName="spot06_sceneTex_0126B8" Format="rgba16" Width="32" Height="32" Offset="0x126C8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_012EB8" OutName="spot06_sceneTex_012EB8" Format="rgba16" Width="8" Height="32" Offset="0x12EC8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_0130B8" OutName="spot06_sceneTex_0130B8" Format="rgba16" Width="32" Height="64" Offset="0x130C8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_0140B8" OutName="spot06_sceneTex_0140B8" Format="rgba16" Width="16" Height="64" Offset="0x140C8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_0148B8" OutName="spot06_sceneTex_0148B8" Format="rgba16" Width="16" Height="32" Offset="0x148C8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_014CB8" OutName="spot06_sceneTex_014CB8" Format="rgba16" Width="32" Height="32" Offset="0x14CC8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_0154B8" OutName="spot06_sceneTex_0154B8" Format="rgba16" Width="16" Height="64" Offset="0x154C8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_015CB8" OutName="spot06_sceneTex_015CB8" Format="rgba16" Width="16" Height="64" Offset="0x15CC8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_0164B8" OutName="spot06_sceneTex_0164B8" Format="rgba16" Width="32" Height="32" Offset="0x164C8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_016CB8" OutName="spot06_sceneTex_016CB8" Format="rgba16" Width="16" Height="32" Offset="0x16CC8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_0170B8" OutName="spot06_sceneTex_0170B8" Format="rgba16" Width="32" Height="32" Offset="0x170C8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_0178B8" OutName="spot06_sceneTex_0178B8" Format="rgba16" Width="16" Height="32" Offset="0x178C8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_017CB8" OutName="spot06_sceneTex_017CB8" Format="ci4" Width="64" Height="64" Offset="0x17CC8" TlutOffset="0x7C20" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_0184B8" OutName="spot06_sceneTex_0184B8" Format="rgba16" Width="32" Height="32" Offset="0x184C8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_018CB8" OutName="spot06_sceneTex_018CB8" Format="rgba16" Width="32" Height="32" Offset="0x18CC8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_0194B8" OutName="spot06_sceneTex_0194B8" Format="rgba16" Width="16" Height="128" Offset="0x194C8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_01A4B8" OutName="spot06_sceneTex_01A4B8" Format="i4" Width="64" Height="64" Offset="0x1A4C8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTex_01ACB8" OutName="spot06_sceneTex_01ACB8" Format="rgba16" Width="16" Height="32" Offset="0x1ACC8" AddedByScript="true"/>
+        <Texture Name="spot06_sceneTLUT_007C10" OutName="spot06_sceneTLUT_007C10" Format="rgba16" Width="4" Height="4" Offset="0x7C20" AddedByScript="true"/>
         <Cutscene Name="gLakeHyliaFireArrowsCS" Offset="0x7030"/>
         <Cutscene Name="gLakeHyliaOwlCs" Offset="0x1B0D0"/>
         <Path Name="gSpot06Path_007764" Offset="0x7774" NumPaths="2"/>

--- a/soh/assets/xml/N64_PAL_11/scenes/overworld/spot07.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/overworld/spot07.xml
@@ -1,5 +1,22 @@
 <Root>
     <File Name="spot07_scene" Segment="2">
+        <Texture Name="spot07_sceneTex_003F98" OutName="spot07_sceneTex_003F98" Format="rgba16" Width="32" Height="64" Offset="0x3FA8" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_004F98" OutName="spot07_sceneTex_004F98" Format="ci4" Width="64" Height="32" Offset="0x4FA8" TlutOffset="0x3F80" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_005398" OutName="spot07_sceneTex_005398" Format="ci4" Width="64" Height="32" Offset="0x53A8" TlutOffset="0x3F80" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_005798" OutName="spot07_sceneTex_005798" Format="ci4" Width="64" Height="32" Offset="0x57A8" TlutOffset="0x3F80" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_005B98" OutName="spot07_sceneTex_005B98" Format="ci4" Width="64" Height="32" Offset="0x5BA8" TlutOffset="0x3F80" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_005F98" OutName="spot07_sceneTex_005F98" Format="ci4" Width="64" Height="32" Offset="0x5FA8" TlutOffset="0x3F80" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_006398" OutName="spot07_sceneTex_006398" Format="ci4" Width="64" Height="32" Offset="0x63A8" TlutOffset="0x3F80" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_006798" OutName="spot07_sceneTex_006798" Format="ci4" Width="64" Height="32" Offset="0x67A8" TlutOffset="0x3F80" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_006B98" OutName="spot07_sceneTex_006B98" Format="ci4" Width="64" Height="32" Offset="0x6BA8" TlutOffset="0x3F80" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_006F98" OutName="spot07_sceneTex_006F98" Format="rgba16" Width="32" Height="32" Offset="0x6FA8" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_007798" OutName="spot07_sceneTex_007798" Format="ci4" Width="64" Height="32" Offset="0x77A8" TlutOffset="0x3F80" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_007B98" OutName="spot07_sceneTex_007B98" Format="ci4" Width="64" Height="32" Offset="0x7BA8" TlutOffset="0x3F80" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_007F98" OutName="spot07_sceneTex_007F98" Format="rgba16" Width="32" Height="32" Offset="0x7FA8" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_008798" OutName="spot07_sceneTex_008798" Format="ia4" Width="64" Height="64" Offset="0x87A8" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_009018" OutName="spot07_sceneTex_009018" Format="ci4" Width="64" Height="32" Offset="0x9028" TlutOffset="0x3F80" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTex_009418" OutName="spot07_sceneTex_009418" Format="ci4" Width="64" Height="32" Offset="0x9428" TlutOffset="0x3F80" AddedByScript="true"/>
+        <Texture Name="spot07_sceneTLUT_003F70" OutName="spot07_sceneTLUT_003F70" Format="rgba16" Width="4" Height="4" Offset="0x3F80" AddedByScript="true"/>
         <Path Name="gZorasDomainPath_0234" Offset="0x234" NumPaths="3"/>
         <Cutscene Name="gZorasDomainIntroCs" Offset="0x3D80"/>
         <Texture Name="gZorasDomainDayEntranceTex" OutName="day_entrance" Format="ia8" Width="8" Height="8" Offset="0x8FA8"/>
@@ -7,9 +24,24 @@
         <Scene Name="spot07_scene" Offset="0x0"/>
     </File>
     <File Name="spot07_room_0" Segment="3">
+        <Texture Name="spot07_room_0Tex_004748" OutName="spot07_room_0Tex_004748" Format="rgba16" Width="64" Height="16" Offset="0x4748" AddedByScript="true"/>
+        <Texture Name="spot07_room_0Tex_004F48" OutName="spot07_room_0Tex_004F48" Format="rgba16" Width="64" Height="16" Offset="0x4F48" AddedByScript="true"/>
+        <Texture Name="spot07_room_0Tex_005748" OutName="spot07_room_0Tex_005748" Format="rgba16" Width="16" Height="64" Offset="0x5748" AddedByScript="true"/>
         <Room Name="spot07_room_0" Offset="0x0"/>
     </File>
     <File Name="spot07_room_1" Segment="3">
+        <Texture Name="spot07_room_1Tex_0076D8" OutName="spot07_room_1Tex_0076D8" Format="rgba16" Width="32" Height="32" Offset="0x76D8" AddedByScript="true"/>
+        <Texture Name="spot07_room_1Tex_007ED8" OutName="spot07_room_1Tex_007ED8" Format="rgba16" Width="16" Height="64" Offset="0x7ED8" AddedByScript="true"/>
+        <Texture Name="spot07_room_1Tex_0086D8" OutName="spot07_room_1Tex_0086D8" Format="ci4" Width="64" Height="32" Offset="0x86D8" ExternalTlut="spot07_scene" ExternalTlutOffset="0x3F80" AddedByScript="true"/>
+        <Texture Name="spot07_room_1Tex_008AD8" OutName="spot07_room_1Tex_008AD8" Format="ci4" Width="32" Height="16" Offset="0x8AD8" ExternalTlut="spot07_scene" ExternalTlutOffset="0x3F80" AddedByScript="true"/>
+        <Texture Name="spot07_room_1Tex_008BD8" OutName="spot07_room_1Tex_008BD8" Format="ci4" Width="64" Height="32" Offset="0x8BD8" ExternalTlut="spot07_scene" ExternalTlutOffset="0x3F80" AddedByScript="true"/>
+        <Texture Name="spot07_room_1Tex_008FD8" OutName="spot07_room_1Tex_008FD8" Format="ci4" Width="64" Height="32" Offset="0x8FD8" ExternalTlut="spot07_scene" ExternalTlutOffset="0x3F80" AddedByScript="true"/>
+        <Texture Name="spot07_room_1Tex_0093D8" OutName="spot07_room_1Tex_0093D8" Format="ci4" Width="64" Height="32" Offset="0x93D8" ExternalTlut="spot07_scene" ExternalTlutOffset="0x3F80" AddedByScript="true"/>
+        <Texture Name="spot07_room_1Tex_0097D8" OutName="spot07_room_1Tex_0097D8" Format="ci4" Width="64" Height="32" Offset="0x97D8" ExternalTlut="spot07_scene" ExternalTlutOffset="0x3F80" AddedByScript="true"/>
+        <Texture Name="spot07_room_1Tex_009BD8" OutName="spot07_room_1Tex_009BD8" Format="rgba16" Width="32" Height="32" Offset="0x9BD8" AddedByScript="true"/>
+        <Texture Name="spot07_room_1Tex_00A3D8" OutName="spot07_room_1Tex_00A3D8" Format="rgba16" Width="32" Height="32" Offset="0xA3D8" AddedByScript="true"/>
+        <Texture Name="spot07_room_1Tex_00ABD8" OutName="spot07_room_1Tex_00ABD8" Format="rgba16" Width="16" Height="128" Offset="0xABD8" AddedByScript="true"/>
+        <Texture Name="spot07_room_1Tex_00C1A0" OutName="spot07_room_1Tex_00C1A0" Format="rgba16" Width="64" Height="16" Offset="0xC1A0" AddedByScript="true"/>
         <Room Name="spot07_room_1" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/N64_PAL_11/scenes/overworld/spot08.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/overworld/spot08.xml
@@ -1,5 +1,32 @@
 <Root>
     <File Name="spot08_scene" Segment="2">
+        <Texture Name="spot08_sceneTex_004DA0" OutName="spot08_sceneTex_004DA0" Format="rgba16" Width="64" Height="32" Offset="0x4DA0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_005DA0" OutName="spot08_sceneTex_005DA0" Format="rgba16" Width="32" Height="16" Offset="0x5DA0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_0061A0" OutName="spot08_sceneTex_0061A0" Format="rgba16" Width="32" Height="32" Offset="0x61A0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_0069A0" OutName="spot08_sceneTex_0069A0" Format="rgba16" Width="32" Height="32" Offset="0x69A0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_0071A0" OutName="spot08_sceneTex_0071A0" Format="ia4" Width="256" Height="32" Offset="0x71A0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_0081A0" OutName="spot08_sceneTex_0081A0" Format="ci4" Width="128" Height="32" Offset="0x81A0" TlutOffset="0x4CC0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_0089A0" OutName="spot08_sceneTex_0089A0" Format="rgba16" Width="32" Height="32" Offset="0x89A0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_0091A0" OutName="spot08_sceneTex_0091A0" Format="rgba16" Width="16" Height="128" Offset="0x91A0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_00A1A0" OutName="spot08_sceneTex_00A1A0" Format="ci4" Width="128" Height="32" Offset="0xA1A0" TlutOffset="0x4CE8" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_00A9A0" OutName="spot08_sceneTex_00A9A0" Format="ci4" Width="64" Height="64" Offset="0xA9A0" TlutOffset="0x4D38" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_00B1A0" OutName="spot08_sceneTex_00B1A0" Format="ci4" Width="64" Height="64" Offset="0xB1A0" TlutOffset="0x4D10" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_00B9A0" OutName="spot08_sceneTex_00B9A0" Format="ci4" Width="64" Height="64" Offset="0xB9A0" TlutOffset="0x4D38" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_00C1A0" OutName="spot08_sceneTex_00C1A0" Format="rgba16" Width="64" Height="32" Offset="0xC1A0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_00D1A0" OutName="spot08_sceneTex_00D1A0" Format="i8" Width="64" Height="64" Offset="0xD1A0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_00E1A0" OutName="spot08_sceneTex_00E1A0" Format="rgba16" Width="32" Height="64" Offset="0xE1A0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_00F1A0" OutName="spot08_sceneTex_00F1A0" Format="ci4" Width="32" Height="128" Offset="0xF1A0" TlutOffset="0x4D60" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_00F9A0" OutName="spot08_sceneTex_00F9A0" Format="ci4" Width="64" Height="64" Offset="0xF9A0" TlutOffset="0x4D80" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_0101A0" OutName="spot08_sceneTex_0101A0" Format="i4" Width="64" Height="64" Offset="0x101A0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_0109A0" OutName="spot08_sceneTex_0109A0" Format="ia8" Width="16" Height="16" Offset="0x109A0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_010AA0" OutName="spot08_sceneTex_010AA0" Format="rgba16" Width="16" Height="32" Offset="0x10AA0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTex_010EA0" OutName="spot08_sceneTex_010EA0" Format="rgba16" Width="32" Height="32" Offset="0x10EA0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTLUT_004CC0" OutName="spot08_sceneTLUT_004CC0" Format="rgba16" Width="4" Height="4" Offset="0x4CC0" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTLUT_004CE8" OutName="spot08_sceneTLUT_004CE8" Format="rgba16" Width="4" Height="4" Offset="0x4CE8" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTLUT_004D10" OutName="spot08_sceneTLUT_004D10" Format="rgba16" Width="4" Height="4" Offset="0x4D10" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTLUT_004D38" OutName="spot08_sceneTLUT_004D38" Format="rgba16" Width="4" Height="4" Offset="0x4D38" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTLUT_004D60" OutName="spot08_sceneTLUT_004D60" Format="rgba16" Width="4" Height="4" Offset="0x4D60" AddedByScript="true"/>
+        <Texture Name="spot08_sceneTLUT_004D80" OutName="spot08_sceneTLUT_004D80" Format="rgba16" Width="4" Height="4" Offset="0x4D80" AddedByScript="true"/>
         <Cutscene Name="gZorasFountainIntroCs" Offset="0x4A80"/>
         <Scene Name="spot08_scene" Offset="0x0"/>
     </File>

--- a/soh/assets/xml/N64_PAL_11/scenes/overworld/spot09.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/overworld/spot09.xml
@@ -1,5 +1,26 @@
 <Root>
     <File Name="spot09_scene" Segment="2">
+        <Texture Name="spot09_sceneTex_003460" OutName="spot09_sceneTex_003460" Format="rgba16" Width="32" Height="64" Offset="0x3490" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_004460" OutName="spot09_sceneTex_004460" Format="rgba16" Width="64" Height="32" Offset="0x4490" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_005460" OutName="spot09_sceneTex_005460" Format="ci4" Width="32" Height="128" Offset="0x5490" TlutOffset="0x3470" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_005C60" OutName="spot09_sceneTex_005C60" Format="rgba16" Width="32" Height="32" Offset="0x5C90" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_006460" OutName="spot09_sceneTex_006460" Format="rgba16" Width="32" Height="32" Offset="0x6490" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_006C60" OutName="spot09_sceneTex_006C60" Format="i8" Width="16" Height="16" Offset="0x6C90" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_006D60" OutName="spot09_sceneTex_006D60" Format="rgba16" Width="16" Height="32" Offset="0x6D90" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_007160" OutName="spot09_sceneTex_007160" Format="rgba16" Width="64" Height="32" Offset="0x7190" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_008160" OutName="spot09_sceneTex_008160" Format="rgba16" Width="64" Height="32" Offset="0x8190" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_009160" OutName="spot09_sceneTex_009160" Format="rgba16" Width="32" Height="64" Offset="0x9190" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_00A160" OutName="spot09_sceneTex_00A160" Format="rgba16" Width="32" Height="32" Offset="0xA190" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_00A960" OutName="spot09_sceneTex_00A960" Format="rgba16" Width="32" Height="64" Offset="0xA990" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_00B960" OutName="spot09_sceneTex_00B960" Format="rgba16" Width="32" Height="32" Offset="0xB990" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_00C160" OutName="spot09_sceneTex_00C160" Format="rgba16" Width="64" Height="32" Offset="0xC190" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_00D160" OutName="spot09_sceneTex_00D160" Format="rgba16" Width="128" Height="16" Offset="0xD190" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_00E160" OutName="spot09_sceneTex_00E160" Format="rgba16" Width="32" Height="32" Offset="0xE190" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_00E960" OutName="spot09_sceneTex_00E960" Format="i4" Width="64" Height="64" Offset="0xE990" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_00F160" OutName="spot09_sceneTex_00F160" Format="i4" Width="32" Height="128" Offset="0xF190" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_00F960" OutName="spot09_sceneTex_00F960" Format="rgba16" Width="64" Height="32" Offset="0xF990" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTex_010960" OutName="spot09_sceneTex_010960" Format="rgba16" Width="32" Height="32" Offset="0x10990" AddedByScript="true"/>
+        <Texture Name="spot09_sceneTLUT_003440" OutName="spot09_sceneTLUT_003440" Format="rgba16" Width="4" Height="4" Offset="0x3470" AddedByScript="true"/>
         <Cutscene Name="gGerudoValleyBridgeJumpFieldFortressCs" Offset="0x2AF0"/>
         <Cutscene Name="gGerudoValleyBridgeJumpFortressToFieldCs" Offset="0x230"/>
         <Cutscene Name="gGerudoValleyIntroCs" Offset="0x3210"/>

--- a/soh/assets/xml/N64_PAL_11/scenes/overworld/spot10.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/overworld/spot10.xml
@@ -1,5 +1,13 @@
 <Root>
     <File Name="spot10_scene" Segment="2">
+        <Texture Name="spot10_sceneTex_00C230" OutName="spot10_sceneTex_00C230" Format="rgba16" Width="32" Height="32" Offset="0xC230" AddedByScript="true"/>
+        <Texture Name="spot10_sceneTex_00CA30" OutName="spot10_sceneTex_00CA30" Format="rgba16" Width="32" Height="32" Offset="0xCA30" AddedByScript="true"/>
+        <Texture Name="spot10_sceneTex_00D230" OutName="spot10_sceneTex_00D230" Format="i4" Width="64" Height="64" Offset="0xD230" AddedByScript="true"/>
+        <Texture Name="spot10_sceneTex_00DA30" OutName="spot10_sceneTex_00DA30" Format="rgba16" Width="32" Height="64" Offset="0xDA30" AddedByScript="true"/>
+        <Texture Name="spot10_sceneTex_00EA30" OutName="spot10_sceneTex_00EA30" Format="rgba16" Width="32" Height="32" Offset="0xEA30" AddedByScript="true"/>
+        <Texture Name="spot10_sceneTex_00F230" OutName="spot10_sceneTex_00F230" Format="rgba16" Width="16" Height="16" Offset="0xF230" AddedByScript="true"/>
+        <Texture Name="spot10_sceneTex_00F430" OutName="spot10_sceneTex_00F430" Format="rgba16" Width="32" Height="32" Offset="0xF430" AddedByScript="true"/>
+        <Texture Name="spot10_sceneTex_00FC30" OutName="spot10_sceneTex_00FC30" Format="rgba16" Width="32" Height="32" Offset="0xFC30" AddedByScript="true"/>
         <Path Name="gSpot10Path_00C080" Offset="0xC080" NumPaths="3"/>
         <Scene Name="spot10_scene" Offset="0x0"/>
     </File>
@@ -7,21 +15,44 @@
         <Room Name="spot10_room_0" Offset="0x0"/>
     </File>
     <File Name="spot10_room_1" Segment="3">
+        <Texture Name="spot10_room_1Tex_003BA0" OutName="spot10_room_1Tex_003BA0" Format="rgba16" Width="16" Height="32" Offset="0x3BA0" AddedByScript="true"/>
+        <Texture Name="spot10_room_1Tex_003FA0" OutName="spot10_room_1Tex_003FA0" Format="rgba16" Width="32" Height="32" Offset="0x3FA0" AddedByScript="true"/>
+        <Texture Name="spot10_room_1Tex_0047A0" OutName="spot10_room_1Tex_0047A0" Format="rgba16" Width="32" Height="32" Offset="0x47A0" AddedByScript="true"/>
+        <Texture Name="spot10_room_1Tex_004FA0" OutName="spot10_room_1Tex_004FA0" Format="rgba16" Width="64" Height="32" Offset="0x4FA0" AddedByScript="true"/>
+        <Texture Name="spot10_room_1Tex_005FA0" OutName="spot10_room_1Tex_005FA0" Format="rgba16" Width="32" Height="32" Offset="0x5FA0" AddedByScript="true"/>
+        <Texture Name="spot10_room_1Tex_0067A0" OutName="spot10_room_1Tex_0067A0" Format="rgba16" Width="32" Height="32" Offset="0x67A0" AddedByScript="true"/>
+        <Texture Name="spot10_room_1Tex_006FA0" OutName="spot10_room_1Tex_006FA0" Format="rgba16" Width="64" Height="16" Offset="0x6FA0" AddedByScript="true"/>
+        <Texture Name="spot10_room_1Tex_007C30" OutName="spot10_room_1Tex_007C30" Format="ia8" Width="32" Height="32" Offset="0x7C30" AddedByScript="true"/>
+        <Texture Name="spot10_room_1Tex_008030" OutName="spot10_room_1Tex_008030" Format="ia16" Width="32" Height="16" Offset="0x8030" AddedByScript="true"/>
         <Room Name="spot10_room_1" Offset="0x0"/>
     </File>
     <File Name="spot10_room_2" Segment="3">
+        <Texture Name="spot10_room_2Tex_0023E8" OutName="spot10_room_2Tex_0023E8" Format="rgba16" Width="64" Height="32" Offset="0x23E8" AddedByScript="true"/>
+        <Texture Name="spot10_room_2Tex_0033E8" OutName="spot10_room_2Tex_0033E8" Format="rgba16" Width="64" Height="32" Offset="0x33E8" AddedByScript="true"/>
+        <Texture Name="spot10_room_2Tex_0043E8" OutName="spot10_room_2Tex_0043E8" Format="rgba16" Width="16" Height="64" Offset="0x43E8" AddedByScript="true"/>
         <Room Name="spot10_room_2" Offset="0x0"/>
     </File>
     <File Name="spot10_room_3" Segment="3">
+        <Texture Name="spot10_room_3Tex_0028F8" OutName="spot10_room_3Tex_0028F8" Format="rgba16" Width="64" Height="32" Offset="0x28F8" AddedByScript="true"/>
+        <Texture Name="spot10_room_3Tex_0038F8" OutName="spot10_room_3Tex_0038F8" Format="rgba16" Width="64" Height="32" Offset="0x38F8" AddedByScript="true"/>
+        <Texture Name="spot10_room_3Tex_0048F8" OutName="spot10_room_3Tex_0048F8" Format="rgba16" Width="16" Height="64" Offset="0x48F8" AddedByScript="true"/>
+        <Texture Name="spot10_room_3Tex_0052A8" OutName="spot10_room_3Tex_0052A8" Format="rgba16" Width="32" Height="32" Offset="0x52A8" AddedByScript="true"/>
         <Room Name="spot10_room_3" Offset="0x0"/>
     </File>
     <File Name="spot10_room_4" Segment="3">
         <Room Name="spot10_room_4" Offset="0x0"/>
     </File>
     <File Name="spot10_room_5" Segment="3">
+        <Texture Name="spot10_room_5Tex_0037F0" OutName="spot10_room_5Tex_0037F0" Format="rgba16" Width="32" Height="64" Offset="0x37F0" AddedByScript="true"/>
+        <Texture Name="spot10_room_5Tex_0047F0" OutName="spot10_room_5Tex_0047F0" Format="rgba16" Width="64" Height="32" Offset="0x47F0" AddedByScript="true"/>
+        <Texture Name="spot10_room_5Tex_0057F0" OutName="spot10_room_5Tex_0057F0" Format="rgba16" Width="64" Height="32" Offset="0x57F0" AddedByScript="true"/>
+        <Texture Name="spot10_room_5Tex_0067F0" OutName="spot10_room_5Tex_0067F0" Format="rgba16" Width="32" Height="32" Offset="0x67F0" AddedByScript="true"/>
         <Room Name="spot10_room_5" Offset="0x0"/>
     </File>
     <File Name="spot10_room_6" Segment="3">
+        <Texture Name="spot10_room_6Tex_0022E8" OutName="spot10_room_6Tex_0022E8" Format="rgba16" Width="32" Height="32" Offset="0x22E8" AddedByScript="true"/>
+        <Texture Name="spot10_room_6Tex_002AE8" OutName="spot10_room_6Tex_002AE8" Format="rgba16" Width="64" Height="16" Offset="0x2AE8" AddedByScript="true"/>
+        <Texture Name="spot10_room_6Tex_0032E8" OutName="spot10_room_6Tex_0032E8" Format="rgba16" Width="32" Height="32" Offset="0x32E8" AddedByScript="true"/>
         <Room Name="spot10_room_6" Offset="0x0"/>
     </File>
     <File Name="spot10_room_7" Segment="3">
@@ -31,6 +62,10 @@
         <Room Name="spot10_room_8" Offset="0x0"/>
     </File>
     <File Name="spot10_room_9" Segment="3">
+        <Texture Name="spot10_room_9Tex_001EF8" OutName="spot10_room_9Tex_001EF8" Format="rgba16" Width="32" Height="32" Offset="0x1EF8" AddedByScript="true"/>
+        <Texture Name="spot10_room_9Tex_0026F8" OutName="spot10_room_9Tex_0026F8" Format="rgba16" Width="32" Height="32" Offset="0x26F8" AddedByScript="true"/>
+        <Texture Name="spot10_room_9Tex_0033D8" OutName="spot10_room_9Tex_0033D8" Format="ia8" Width="32" Height="32" Offset="0x33D8" AddedByScript="true"/>
+        <Texture Name="spot10_room_9Tex_0037D8" OutName="spot10_room_9Tex_0037D8" Format="ia16" Width="32" Height="16" Offset="0x37D8" AddedByScript="true"/>
         <Room Name="spot10_room_9" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/N64_PAL_11/scenes/overworld/spot11.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/overworld/spot11.xml
@@ -1,5 +1,37 @@
 <Root>
     <File Name="spot11_scene" Segment="2">
+        <Texture Name="spot11_sceneTex_007CA0" OutName="spot11_sceneTex_007CA0" Format="rgba16" Width="32" Height="32" Offset="0x7CB0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_0084A0" OutName="spot11_sceneTex_0084A0" Format="rgba16" Width="32" Height="32" Offset="0x84B0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_008CA0" OutName="spot11_sceneTex_008CA0" Format="rgba16" Width="16" Height="32" Offset="0x8CB0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_0090A0" OutName="spot11_sceneTex_0090A0" Format="rgba16" Width="128" Height="16" Offset="0x90B0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_00A0A0" OutName="spot11_sceneTex_00A0A0" Format="rgba16" Width="32" Height="32" Offset="0xA0B0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_00A8A0" OutName="spot11_sceneTex_00A8A0" Format="rgba16" Width="64" Height="32" Offset="0xA8B0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_00B8A0" OutName="spot11_sceneTex_00B8A0" Format="rgba16" Width="16" Height="32" Offset="0xB8B0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_00BCA0" OutName="spot11_sceneTex_00BCA0" Format="rgba16" Width="32" Height="32" Offset="0xBCB0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_00C4A0" OutName="spot11_sceneTex_00C4A0" Format="rgba16" Width="32" Height="32" Offset="0xC4B0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_00CCA0" OutName="spot11_sceneTex_00CCA0" Format="rgba16" Width="16" Height="64" Offset="0xCCB0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_00D4A0" OutName="spot11_sceneTex_00D4A0" Format="rgba16" Width="32" Height="32" Offset="0xD4B0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_00DCA0" OutName="spot11_sceneTex_00DCA0" Format="rgba16" Width="64" Height="32" Offset="0xDCB0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_00ECA0" OutName="spot11_sceneTex_00ECA0" Format="rgba16" Width="32" Height="32" Offset="0xECB0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_00F4A0" OutName="spot11_sceneTex_00F4A0" Format="rgba16" Width="32" Height="32" Offset="0xF4B0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_00FCA0" OutName="spot11_sceneTex_00FCA0" Format="ia8" Width="8" Height="8" Offset="0xFCB0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_00FCE0" OutName="spot11_sceneTex_00FCE0" Format="rgba16" Width="32" Height="32" Offset="0xFCF0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_0104E0" OutName="spot11_sceneTex_0104E0" Format="rgba16" Width="32" Height="32" Offset="0x104F0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_010CE0" OutName="spot11_sceneTex_010CE0" Format="rgba16" Width="32" Height="64" Offset="0x10CF0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_011CE0" OutName="spot11_sceneTex_011CE0" Format="rgba16" Width="32" Height="32" Offset="0x11CF0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_0124E0" OutName="spot11_sceneTex_0124E0" Format="rgba16" Width="32" Height="32" Offset="0x124F0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_012CE0" OutName="spot11_sceneTex_012CE0" Format="rgba16" Width="32" Height="32" Offset="0x12CF0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_0134E0" OutName="spot11_sceneTex_0134E0" Format="rgba16" Width="32" Height="32" Offset="0x134F0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_013CE0" OutName="spot11_sceneTex_013CE0" Format="rgba16" Width="32" Height="32" Offset="0x13CF0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_0144E0" OutName="spot11_sceneTex_0144E0" Format="rgba16" Width="32" Height="64" Offset="0x144F0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_0154E0" OutName="spot11_sceneTex_0154E0" Format="rgba16" Width="32" Height="32" Offset="0x154F0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_015CE0" OutName="spot11_sceneTex_015CE0" Format="rgba16" Width="32" Height="32" Offset="0x15CF0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_0164E0" OutName="spot11_sceneTex_0164E0" Format="ia4" Width="32" Height="128" Offset="0x164F0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_016CE0" OutName="spot11_sceneTex_016CE0" Format="rgba16" Width="32" Height="32" Offset="0x16CF0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_0174E0" OutName="spot11_sceneTex_0174E0" Format="rgba16" Width="16" Height="64" Offset="0x174F0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_017CE0" OutName="spot11_sceneTex_017CE0" Format="ia4" Width="64" Height="64" Offset="0x17CF0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_0184E0" OutName="spot11_sceneTex_0184E0" Format="rgba16" Width="32" Height="32" Offset="0x184F0" AddedByScript="true"/>
+        <Texture Name="spot11_sceneTex_018CE0" OutName="spot11_sceneTex_018CE0" Format="rgba16" Width="32" Height="32" Offset="0x18CF0" AddedByScript="true"/>
         <Cutscene Name="gDesertColossusIntroCs" Offset="0x79A0"/>
         <Scene Name="spot11_scene" Offset="0x0"/>
     </File>

--- a/soh/assets/xml/N64_PAL_11/scenes/overworld/spot12.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/overworld/spot12.xml
@@ -1,5 +1,17 @@
 <Root>
     <File Name="spot12_scene" Segment="2">
+        <Texture Name="spot12_sceneTex_006678" OutName="spot12_sceneTex_006678" Format="rgba16" Width="32" Height="64" Offset="0x6688" AddedByScript="true"/>
+        <Texture Name="spot12_sceneTex_007678" OutName="spot12_sceneTex_007678" Format="rgba16" Width="32" Height="64" Offset="0x7688" AddedByScript="true"/>
+        <Texture Name="spot12_sceneTex_008678" OutName="spot12_sceneTex_008678" Format="rgba16" Width="32" Height="32" Offset="0x8688" AddedByScript="true"/>
+        <Texture Name="spot12_sceneTex_008E78" OutName="spot12_sceneTex_008E78" Format="ci4" Width="32" Height="128" Offset="0x8E88" TlutOffset="0x6660" AddedByScript="true"/>
+        <Texture Name="spot12_sceneTex_00A678" OutName="spot12_sceneTex_00A678" Format="rgba16" Width="64" Height="32" Offset="0xA688" AddedByScript="true"/>
+        <Texture Name="spot12_sceneTex_00B678" OutName="spot12_sceneTex_00B678" Format="rgba16" Width="32" Height="32" Offset="0xB688" AddedByScript="true"/>
+        <Texture Name="spot12_sceneTex_00BE78" OutName="spot12_sceneTex_00BE78" Format="rgba16" Width="64" Height="16" Offset="0xBE88" AddedByScript="true"/>
+        <Texture Name="spot12_sceneTex_00C678" OutName="spot12_sceneTex_00C678" Format="rgba16" Width="32" Height="32" Offset="0xC688" AddedByScript="true"/>
+        <Texture Name="spot12_sceneTex_00CE78" OutName="spot12_sceneTex_00CE78" Format="rgba16" Width="32" Height="32" Offset="0xCE88" AddedByScript="true"/>
+        <Texture Name="spot12_sceneTex_00D678" OutName="spot12_sceneTex_00D678" Format="rgba16" Width="32" Height="32" Offset="0xD688" AddedByScript="true"/>
+        <Texture Name="spot12_sceneTex_00EE78" OutName="spot12_sceneTex_00EE78" Format="rgba16" Width="64" Height="32" Offset="0xEE88" AddedByScript="true"/>
+        <Texture Name="spot12_sceneTLUT_006650" OutName="spot12_sceneTLUT_006650" Format="rgba16" Width="4" Height="4" Offset="0x6660" AddedByScript="true"/>
         <Cutscene Name="gGerudoFortressFirstCaptureCs" Offset="0x55D0"/>
         <Cutscene Name="gGerudoFortressIntroCs" Offset="0x64A0"/>
         <Texture Name="gSpot12_009678Tex" Format="rgba16" Width="64" Height="32" Offset="0x9688"/>
@@ -7,9 +19,34 @@
         <Scene Name="spot12_scene" Offset="0x0"/>
     </File>
     <File Name="spot12_room_0" Segment="3">
+        <Texture Name="spot12_room_0Tex_008AB0" OutName="spot12_room_0Tex_008AB0" Format="rgba16" Width="32" Height="32" Offset="0x8AB0" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_0092B0" OutName="spot12_room_0Tex_0092B0" Format="rgba16" Width="32" Height="16" Offset="0x92B0" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_0096B0" OutName="spot12_room_0Tex_0096B0" Format="rgba16" Width="32" Height="32" Offset="0x96B0" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_009EB0" OutName="spot12_room_0Tex_009EB0" Format="rgba16" Width="32" Height="32" Offset="0x9EB0" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_00A6B0" OutName="spot12_room_0Tex_00A6B0" Format="rgba16" Width="64" Height="32" Offset="0xA6B0" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_00B6B0" OutName="spot12_room_0Tex_00B6B0" Format="rgba16" Width="32" Height="32" Offset="0xB6B0" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_00BEB0" OutName="spot12_room_0Tex_00BEB0" Format="rgba16" Width="32" Height="32" Offset="0xBEB0" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_00C6B0" OutName="spot12_room_0Tex_00C6B0" Format="ci4" Width="64" Height="32" Offset="0xC6B0" TlutOffset="0x8A90" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_00CAB0" OutName="spot12_room_0Tex_00CAB0" Format="rgba16" Width="16" Height="64" Offset="0xCAB0" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_00D2B0" OutName="spot12_room_0Tex_00D2B0" Format="rgba16" Width="64" Height="32" Offset="0xD2B0" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_00E2B0" OutName="spot12_room_0Tex_00E2B0" Format="rgba16" Width="32" Height="32" Offset="0xE2B0" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_00EAB0" OutName="spot12_room_0Tex_00EAB0" Format="rgba16" Width="32" Height="32" Offset="0xEAB0" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_00FD78" OutName="spot12_room_0Tex_00FD78" Format="ia8" Width="8" Height="8" Offset="0xFD78" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_00FDB8" OutName="spot12_room_0Tex_00FDB8" Format="rgba16" Width="16" Height="64" Offset="0xFDB8" AddedByScript="true"/>
+        <Texture Name="spot12_room_0Tex_0105B8" OutName="spot12_room_0Tex_0105B8" Format="rgba16" Width="32" Height="64" Offset="0x105B8" AddedByScript="true"/>
+        <Texture Name="spot12_room_0TLUT_008A90" OutName="spot12_room_0TLUT_008A90" Format="rgba16" Width="4" Height="4" Offset="0x8A90" AddedByScript="true"/>
         <Room Name="spot12_room_0" Offset="0x0"/>
     </File>
     <File Name="spot12_room_1" Segment="3">
+        <Texture Name="spot12_room_1Tex_005638" OutName="spot12_room_1Tex_005638" Format="rgba16" Width="32" Height="64" Offset="0x5638" AddedByScript="true"/>
+        <Texture Name="spot12_room_1Tex_006638" OutName="spot12_room_1Tex_006638" Format="rgba16" Width="32" Height="64" Offset="0x6638" AddedByScript="true"/>
+        <Texture Name="spot12_room_1Tex_007638" OutName="spot12_room_1Tex_007638" Format="rgba16" Width="32" Height="32" Offset="0x7638" AddedByScript="true"/>
+        <Texture Name="spot12_room_1Tex_007E38" OutName="spot12_room_1Tex_007E38" Format="rgba16" Width="64" Height="32" Offset="0x7E38" AddedByScript="true"/>
+        <Texture Name="spot12_room_1Tex_008E38" OutName="spot12_room_1Tex_008E38" Format="rgba16" Width="64" Height="32" Offset="0x8E38" AddedByScript="true"/>
+        <Texture Name="spot12_room_1Tex_009E38" OutName="spot12_room_1Tex_009E38" Format="rgba16" Width="32" Height="32" Offset="0x9E38" AddedByScript="true"/>
+        <Texture Name="spot12_room_1Tex_00A638" OutName="spot12_room_1Tex_00A638" Format="i4" Width="64" Height="64" Offset="0xA638" AddedByScript="true"/>
+        <Texture Name="spot12_room_1Tex_00B0A0" OutName="spot12_room_1Tex_00B0A0" Format="i8" Width="32" Height="64" Offset="0xB0A0" AddedByScript="true"/>
+        <Texture Name="spot12_room_1Tex_00B8A0" OutName="spot12_room_1Tex_00B8A0" Format="i8" Width="32" Height="64" Offset="0xB8A0" AddedByScript="true"/>
         <Room Name="spot12_room_1" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/N64_PAL_11/scenes/overworld/spot13.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/overworld/spot13.xml
@@ -1,11 +1,39 @@
 <Root>
     <File Name="spot13_scene" Segment="2">
+        <Texture Name="spot13_sceneTex_003A30" OutName="spot13_sceneTex_003A30" Format="rgba16" Width="32" Height="16" Offset="0x3A30" AddedByScript="true"/>
+        <Texture Name="spot13_sceneTex_003E30" OutName="spot13_sceneTex_003E30" Format="rgba16" Width="32" Height="64" Offset="0x3E30" AddedByScript="true"/>
+        <Texture Name="spot13_sceneTex_004E30" OutName="spot13_sceneTex_004E30" Format="rgba16" Width="64" Height="32" Offset="0x4E30" AddedByScript="true"/>
         <Scene Name="spot13_scene" Offset="0x0"/>
     </File>
     <File Name="spot13_room_0" Segment="3">
         <Room Name="spot13_room_0" Offset="0x0"/>
     </File>
     <File Name="spot13_room_1" Segment="3">
+        <Texture Name="spot13_room_1Tex_007E08" OutName="spot13_room_1Tex_007E08" Format="rgba16" Width="32" Height="32" Offset="0x7E08" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_008608" OutName="spot13_room_1Tex_008608" Format="rgba16" Width="16" Height="32" Offset="0x8608" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_008A08" OutName="spot13_room_1Tex_008A08" Format="rgba16" Width="32" Height="64" Offset="0x8A08" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_009A08" OutName="spot13_room_1Tex_009A08" Format="rgba16" Width="16" Height="16" Offset="0x9A08" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_009C08" OutName="spot13_room_1Tex_009C08" Format="rgba16" Width="16" Height="16" Offset="0x9C08" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_009E08" OutName="spot13_room_1Tex_009E08" Format="rgba16" Width="32" Height="32" Offset="0x9E08" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_00A608" OutName="spot13_room_1Tex_00A608" Format="rgba16" Width="32" Height="16" Offset="0xA608" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_00AA08" OutName="spot13_room_1Tex_00AA08" Format="rgba16" Width="32" Height="16" Offset="0xAA08" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_00AE08" OutName="spot13_room_1Tex_00AE08" Format="ci4" Width="32" Height="128" Offset="0xAE08" TlutOffset="0x7DC0" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_00B608" OutName="spot13_room_1Tex_00B608" Format="rgba16" Width="16" Height="16" Offset="0xB608" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_00B808" OutName="spot13_room_1Tex_00B808" Format="ci4" Width="64" Height="32" Offset="0xB808" TlutOffset="0x7DE8" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_00BC08" OutName="spot13_room_1Tex_00BC08" Format="rgba16" Width="32" Height="32" Offset="0xBC08" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_00C408" OutName="spot13_room_1Tex_00C408" Format="rgba16" Width="8" Height="32" Offset="0xC408" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_00C608" OutName="spot13_room_1Tex_00C608" Format="rgba16" Width="64" Height="32" Offset="0xC608" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_00D608" OutName="spot13_room_1Tex_00D608" Format="rgba16" Width="32" Height="64" Offset="0xD608" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_00E608" OutName="spot13_room_1Tex_00E608" Format="rgba16" Width="32" Height="32" Offset="0xE608" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_00EE08" OutName="spot13_room_1Tex_00EE08" Format="rgba16" Width="32" Height="64" Offset="0xEE08" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_00FE08" OutName="spot13_room_1Tex_00FE08" Format="rgba16" Width="32" Height="32" Offset="0xFE08" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_010608" OutName="spot13_room_1Tex_010608" Format="rgba16" Width="32" Height="32" Offset="0x10608" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_010E08" OutName="spot13_room_1Tex_010E08" Format="rgba16" Width="32" Height="16" Offset="0x10E08" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_011208" OutName="spot13_room_1Tex_011208" Format="rgba16" Width="32" Height="32" Offset="0x11208" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_011E40" OutName="spot13_room_1Tex_011E40" Format="ia4" Width="64" Height="32" Offset="0x11E40" AddedByScript="true"/>
+        <Texture Name="spot13_room_1Tex_012240" OutName="spot13_room_1Tex_012240" Format="rgba16" Width="32" Height="32" Offset="0x12240" AddedByScript="true"/>
+        <Texture Name="spot13_room_1TLUT_007DC0" OutName="spot13_room_1TLUT_007DC0" Format="rgba16" Width="4" Height="4" Offset="0x7DC0" AddedByScript="true"/>
+        <Texture Name="spot13_room_1TLUT_007DE8" OutName="spot13_room_1TLUT_007DE8" Format="rgba16" Width="4" Height="4" Offset="0x7DE8" AddedByScript="true"/>
         <Room Name="spot13_room_1" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/N64_PAL_11/scenes/overworld/spot15.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/overworld/spot15.xml
@@ -1,5 +1,48 @@
 <Root>
     <File Name="spot15_scene" Segment="2">
+        <Texture Name="spot15_sceneTex_004100" OutName="spot15_sceneTex_004100" Format="rgba16" Width="32" Height="32" Offset="0x4100" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_004900" OutName="spot15_sceneTex_004900" Format="ia4" Width="32" Height="16" Offset="0x4900" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_004A00" OutName="spot15_sceneTex_004A00" Format="ia8" Width="8" Height="64" Offset="0x4A00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_004C00" OutName="spot15_sceneTex_004C00" Format="rgba16" Width="16" Height="64" Offset="0x4C00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_005400" OutName="spot15_sceneTex_005400" Format="rgba16" Width="32" Height="64" Offset="0x5400" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_006400" OutName="spot15_sceneTex_006400" Format="ia8" Width="32" Height="8" Offset="0x6400" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_006500" OutName="spot15_sceneTex_006500" Format="rgba16" Width="32" Height="32" Offset="0x6500" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_006D00" OutName="spot15_sceneTex_006D00" Format="i4" Width="32" Height="32" Offset="0x6D00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_006F00" OutName="spot15_sceneTex_006F00" Format="ia4" Width="32" Height="64" Offset="0x6F00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_007300" OutName="spot15_sceneTex_007300" Format="ia4" Width="32" Height="128" Offset="0x7300" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_007B00" OutName="spot15_sceneTex_007B00" Format="ia4" Width="16" Height="32" Offset="0x7B00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_007C00" OutName="spot15_sceneTex_007C00" Format="rgba16" Width="32" Height="8" Offset="0x7C00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_007E00" OutName="spot15_sceneTex_007E00" Format="rgba16" Width="32" Height="64" Offset="0x7E00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_008E00" OutName="spot15_sceneTex_008E00" Format="rgba16" Width="32" Height="32" Offset="0x8E00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_009600" OutName="spot15_sceneTex_009600" Format="rgba16" Width="16" Height="16" Offset="0x9600" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_009800" OutName="spot15_sceneTex_009800" Format="ia8" Width="16" Height="16" Offset="0x9800" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_009900" OutName="spot15_sceneTex_009900" Format="rgba16" Width="32" Height="32" Offset="0x9900" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_00A100" OutName="spot15_sceneTex_00A100" Format="rgba16" Width="32" Height="32" Offset="0xA100" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_00A900" OutName="spot15_sceneTex_00A900" Format="rgba16" Width="64" Height="32" Offset="0xA900" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_00B900" OutName="spot15_sceneTex_00B900" Format="ia8" Width="16" Height="16" Offset="0xB900" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_00BA00" OutName="spot15_sceneTex_00BA00" Format="rgba16" Width="32" Height="32" Offset="0xBA00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_00C200" OutName="spot15_sceneTex_00C200" Format="rgba16" Width="32" Height="32" Offset="0xC200" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_00CA00" OutName="spot15_sceneTex_00CA00" Format="rgba16" Width="64" Height="32" Offset="0xCA00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_00DA00" OutName="spot15_sceneTex_00DA00" Format="rgba16" Width="128" Height="16" Offset="0xDA00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_00EA00" OutName="spot15_sceneTex_00EA00" Format="i4" Width="32" Height="32" Offset="0xEA00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_00EC00" OutName="spot15_sceneTex_00EC00" Format="i8" Width="128" Height="32" Offset="0xEC00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_00FC00" OutName="spot15_sceneTex_00FC00" Format="rgba16" Width="32" Height="32" Offset="0xFC00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_010400" OutName="spot15_sceneTex_010400" Format="rgba16" Width="32" Height="32" Offset="0x10400" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_010C00" OutName="spot15_sceneTex_010C00" Format="i4" Width="64" Height="64" Offset="0x10C00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_011400" OutName="spot15_sceneTex_011400" Format="rgba16" Width="32" Height="32" Offset="0x11400" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_011C00" OutName="spot15_sceneTex_011C00" Format="ia4" Width="128" Height="32" Offset="0x11C00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_012400" OutName="spot15_sceneTex_012400" Format="rgba16" Width="32" Height="64" Offset="0x12400" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_013400" OutName="spot15_sceneTex_013400" Format="rgba16" Width="32" Height="64" Offset="0x13400" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_014400" OutName="spot15_sceneTex_014400" Format="rgba16" Width="32" Height="32" Offset="0x14400" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_014C00" OutName="spot15_sceneTex_014C00" Format="rgba16" Width="64" Height="32" Offset="0x14C00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_015C00" OutName="spot15_sceneTex_015C00" Format="rgba16" Width="16" Height="16" Offset="0x15C00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_015E00" OutName="spot15_sceneTex_015E00" Format="rgba16" Width="32" Height="32" Offset="0x15E00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_016600" OutName="spot15_sceneTex_016600" Format="rgba16" Width="16" Height="16" Offset="0x16600" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_016800" OutName="spot15_sceneTex_016800" Format="rgba16" Width="32" Height="16" Offset="0x16800" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_016C00" OutName="spot15_sceneTex_016C00" Format="rgba16" Width="32" Height="32" Offset="0x16C00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_017400" OutName="spot15_sceneTex_017400" Format="rgba16" Width="32" Height="32" Offset="0x17400" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_017C00" OutName="spot15_sceneTex_017C00" Format="rgba16" Width="32" Height="32" Offset="0x17C00" AddedByScript="true"/>
+        <Texture Name="spot15_sceneTex_018400" OutName="spot15_sceneTex_018400" Format="ia8" Width="16" Height="16" Offset="0x18400" AddedByScript="true"/>
         <Cutscene Name="gHyruleCastleIntroCs" Offset="0x3F40"/>
         <Scene Name="spot15_scene" Offset="0x0"/>
     </File>

--- a/soh/assets/xml/N64_PAL_11/scenes/overworld/spot16.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/overworld/spot16.xml
@@ -1,5 +1,41 @@
 <Root>
     <File Name="spot16_scene" Segment="2">
+        <Texture Name="spot16_sceneTex_008198" OutName="spot16_sceneTex_008198" Format="i8" Width="64" Height="64" Offset="0x81C8" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_009198" OutName="spot16_sceneTex_009198" Format="i8" Width="64" Height="32" Offset="0x91C8" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_009998" OutName="spot16_sceneTex_009998" Format="i8" Width="64" Height="16" Offset="0x99C8" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_009D98" OutName="spot16_sceneTex_009D98" Format="i8" Width="64" Height="64" Offset="0x9DC8" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_00AD98" OutName="spot16_sceneTex_00AD98" Format="i8" Width="64" Height="64" Offset="0xADC8" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_00BD98" OutName="spot16_sceneTex_00BD98" Format="rgba16" Width="64" Height="32" Offset="0xBDC8" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_00CD98" OutName="spot16_sceneTex_00CD98" Format="rgba16" Width="16" Height="16" Offset="0xCDC8" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_00CF98" OutName="spot16_sceneTex_00CF98" Format="rgba16" Width="32" Height="16" Offset="0xCFC8" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_00D398" OutName="spot16_sceneTex_00D398" Format="rgba16" Width="16" Height="32" Offset="0xD3C8" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_00D798" OutName="spot16_sceneTex_00D798" Format="ci4" Width="64" Height="64" Offset="0xD7C8" TlutOffset="0x81A0" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_00DF98" OutName="spot16_sceneTex_00DF98" Format="i4" Width="64" Height="16" Offset="0xDFC8" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_00E198" OutName="spot16_sceneTex_00E198" Format="rgba16" Width="64" Height="32" Offset="0xE1C8" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_00F198" OutName="spot16_sceneTex_00F198" Format="rgba16" Width="16" Height="128" Offset="0xF1C8" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_010198" OutName="spot16_sceneTex_010198" Format="rgba16" Width="32" Height="64" Offset="0x101C8" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_011198" OutName="spot16_sceneTex_011198" Format="rgba16" Width="16" Height="32" Offset="0x111C8" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_011598" OutName="spot16_sceneTex_011598" Format="i4" Width="64" Height="16" Offset="0x115C8" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_011798" OutName="spot16_sceneTex_011798" Format="rgba16" Width="64" Height="32" Offset="0x117C8" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_012798" OutName="spot16_sceneTex_012798" Format="rgba16" Width="64" Height="32" Offset="0x127C8" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_013798" OutName="spot16_sceneTex_013798" Format="i4" Width="64" Height="16" Offset="0x137C8" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_013998" OutName="spot16_sceneTex_013998" Format="rgba16" Width="32" Height="16" Offset="0x139C8" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_013D98" OutName="spot16_sceneTex_013D98" Format="rgba16" Width="32" Height="64" Offset="0x13DC8" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_014D98" OutName="spot16_sceneTex_014D98" Format="rgba16" Width="32" Height="32" Offset="0x14DC8" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_015598" OutName="spot16_sceneTex_015598" Format="i4" Width="64" Height="64" Offset="0x155C8" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_015D98" OutName="spot16_sceneTex_015D98" Format="ia8" Width="16" Height="16" Offset="0x15DC8" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_015E98" OutName="spot16_sceneTex_015E98" Format="ia8" Width="128" Height="32" Offset="0x15EC8" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_016E98" OutName="spot16_sceneTex_016E98" Format="i4" Width="128" Height="64" Offset="0x16EC8" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_017E98" OutName="spot16_sceneTex_017E98" Format="rgba16" Width="32" Height="32" Offset="0x17EC8" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_018698" OutName="spot16_sceneTex_018698" Format="rgba16" Width="32" Height="32" Offset="0x186C8" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_018E98" OutName="spot16_sceneTex_018E98" Format="rgba16" Width="32" Height="32" Offset="0x18EC8" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_019698" OutName="spot16_sceneTex_019698" Format="rgba16" Width="64" Height="16" Offset="0x196C8" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_019E98" OutName="spot16_sceneTex_019E98" Format="rgba16" Width="32" Height="64" Offset="0x19EC8" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_01B698" OutName="spot16_sceneTex_01B698" Format="ia8" Width="64" Height="64" Offset="0x1B6C8" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_01C698" OutName="spot16_sceneTex_01C698" Format="rgba16" Width="32" Height="64" Offset="0x1C6C8" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_01D698" OutName="spot16_sceneTex_01D698" Format="i8" Width="64" Height="32" Offset="0x1D6C8" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTex_01DE98" OutName="spot16_sceneTex_01DE98" Format="rgba16" Width="32" Height="32" Offset="0x1DEC8" AddedByScript="true"/>
+        <Texture Name="spot16_sceneTLUT_008170" OutName="spot16_sceneTLUT_008170" Format="rgba16" Width="4" Height="4" Offset="0x81A0" AddedByScript="true"/>
         <Path Name="gDMTPath_00254" Offset="0x254" NumPaths="3"/>
         <Path Name="gDMTPath_07884" Offset="0x78B4" NumPaths="3"/>
         <Cutscene Name="gDMTOwlCs" Offset="0x1E6D0"/>

--- a/soh/assets/xml/N64_PAL_11/scenes/overworld/spot17.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/overworld/spot17.xml
@@ -1,13 +1,54 @@
 <Root>
     <File Name="spot17_scene" Segment="2">
+        <Texture Name="spot17_sceneTex_007AD8" OutName="spot17_sceneTex_007AD8" Format="ci8" Width="16" Height="128" Offset="0x7AE8" TlutOffset="0x78A0" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_0082D8" OutName="spot17_sceneTex_0082D8" Format="ci8" Width="32" Height="32" Offset="0x82E8" TlutOffset="0x78A0" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_0086D8" OutName="spot17_sceneTex_0086D8" Format="ci8" Width="64" Height="32" Offset="0x86E8" TlutOffset="0x78A0" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_008ED8" OutName="spot17_sceneTex_008ED8" Format="ci8" Width="64" Height="32" Offset="0x8EE8" TlutOffset="0x78A0" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_0096D8" OutName="spot17_sceneTex_0096D8" Format="ci8" Width="64" Height="32" Offset="0x96E8" TlutOffset="0x78A0" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_009ED8" OutName="spot17_sceneTex_009ED8" Format="rgba16" Width="32" Height="32" Offset="0x9EE8" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_00A6D8" OutName="spot17_sceneTex_00A6D8" Format="rgba16" Width="32" Height="32" Offset="0xA6E8" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_00AED8" OutName="spot17_sceneTex_00AED8" Format="ci4" Width="64" Height="64" Offset="0xAEE8" TlutOffset="0x7AA8" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_00B6D8" OutName="spot17_sceneTex_00B6D8" Format="ci8" Width="64" Height="32" Offset="0xB6E8" TlutOffset="0x78A0" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_00BED8" OutName="spot17_sceneTex_00BED8" Format="ci8" Width="32" Height="64" Offset="0xBEE8" TlutOffset="0x78A0" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_00C6D8" OutName="spot17_sceneTex_00C6D8" Format="rgba16" Width="32" Height="64" Offset="0xC6E8" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_00D6D8" OutName="spot17_sceneTex_00D6D8" Format="ci8" Width="16" Height="32" Offset="0xD6E8" TlutOffset="0x78A0" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_00D8D8" OutName="spot17_sceneTex_00D8D8" Format="ci8" Width="16" Height="128" Offset="0xD8E8" TlutOffset="0x78A0" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_00E0D8" OutName="spot17_sceneTex_00E0D8" Format="ci4" Width="64" Height="64" Offset="0xE0E8" TlutOffset="0x7AC8" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_00E8D8" OutName="spot17_sceneTex_00E8D8" Format="ci8" Width="32" Height="64" Offset="0xE8E8" TlutOffset="0x78A0" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_00F0D8" OutName="spot17_sceneTex_00F0D8" Format="ci8" Width="32" Height="64" Offset="0xF0E8" TlutOffset="0x78A0" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_00F8D8" OutName="spot17_sceneTex_00F8D8" Format="ci8" Width="32" Height="32" Offset="0xF8E8" TlutOffset="0x78A0" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTex_00FCD8" OutName="spot17_sceneTex_00FCD8" Format="ci8" Width="16" Height="32" Offset="0xFCE8" TlutOffset="0x78A0" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTLUT_007890" OutName="spot17_sceneTLUT_007890" Format="rgba16" Width="16" Height="16" Offset="0x78A0" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTLUT_007A98" OutName="spot17_sceneTLUT_007A98" Format="rgba16" Width="4" Height="4" Offset="0x7AA8" AddedByScript="true"/>
+        <Texture Name="spot17_sceneTLUT_007AB8" OutName="spot17_sceneTLUT_007AB8" Format="rgba16" Width="4" Height="4" Offset="0x7AC8" AddedByScript="true"/>
         <Cutscene Name="gDeathMountainCraterBoleroCs" Offset="0x45D4"/>
         <Cutscene Name="gDeathMountainCraterIntroCs" Offset="0x76E0"/>
         <Scene Name="spot17_scene" Offset="0x0"/>
     </File>
     <File Name="spot17_room_0" Segment="3">
+        <Texture Name="spot17_room_0Tex_003880" OutName="spot17_room_0Tex_003880" Format="rgba16" Width="64" Height="32" Offset="0x3880" AddedByScript="true"/>
+        <Texture Name="spot17_room_0Tex_004880" OutName="spot17_room_0Tex_004880" Format="rgba16" Width="32" Height="32" Offset="0x4880" AddedByScript="true"/>
+        <Texture Name="spot17_room_0Tex_005080" OutName="spot17_room_0Tex_005080" Format="rgba16" Width="32" Height="32" Offset="0x5080" AddedByScript="true"/>
+        <Texture Name="spot17_room_0Tex_005880" OutName="spot17_room_0Tex_005880" Format="rgba16" Width="32" Height="64" Offset="0x5880" AddedByScript="true"/>
         <Room Name="spot17_room_0" Offset="0x0"/>
     </File>
     <File Name="spot17_room_1" Segment="3">
+        <Texture Name="spot17_room_1Tex_00BBD8" OutName="spot17_room_1Tex_00BBD8" Format="ci8" Width="64" Height="32" Offset="0xBBD8" ExternalTlut="spot17_scene" ExternalTlutOffset="0x78A0" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_00C3D8" OutName="spot17_room_1Tex_00C3D8" Format="ci8" Width="64" Height="32" Offset="0xC3D8" ExternalTlut="spot17_scene" ExternalTlutOffset="0x78A0" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_00CBD8" OutName="spot17_room_1Tex_00CBD8" Format="rgba16" Width="32" Height="32" Offset="0xCBD8" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_00D3D8" OutName="spot17_room_1Tex_00D3D8" Format="ci8" Width="32" Height="32" Offset="0xD3D8" ExternalTlut="spot17_scene" ExternalTlutOffset="0x78A0" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_00D7D8" OutName="spot17_room_1Tex_00D7D8" Format="rgba16" Width="64" Height="32" Offset="0xD7D8" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_00E7D8" OutName="spot17_room_1Tex_00E7D8" Format="ci8" Width="16" Height="16" Offset="0xE7D8" ExternalTlut="spot17_scene" ExternalTlutOffset="0x78A0" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_00E8D8" OutName="spot17_room_1Tex_00E8D8" Format="ci8" Width="32" Height="32" Offset="0xE8D8" ExternalTlut="spot17_scene" ExternalTlutOffset="0x78A0" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_00ECD8" OutName="spot17_room_1Tex_00ECD8" Format="ci8" Width="32" Height="32" Offset="0xECD8" ExternalTlut="spot17_scene" ExternalTlutOffset="0x78A0" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_00F0D8" OutName="spot17_room_1Tex_00F0D8" Format="ci8" Width="32" Height="32" Offset="0xF0D8" ExternalTlut="spot17_scene" ExternalTlutOffset="0x78A0" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_00F4D8" OutName="spot17_room_1Tex_00F4D8" Format="rgba16" Width="32" Height="32" Offset="0xF4D8" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_00FCD8" OutName="spot17_room_1Tex_00FCD8" Format="ci8" Width="32" Height="16" Offset="0xFCD8" ExternalTlut="spot17_scene" ExternalTlutOffset="0x78A0" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_010E58" OutName="spot17_room_1Tex_010E58" Format="i4" Width="64" Height="32" Offset="0x10E58" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_011258" OutName="spot17_room_1Tex_011258" Format="i4" Width="64" Height="32" Offset="0x11258" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_011658" OutName="spot17_room_1Tex_011658" Format="i4" Width="64" Height="32" Offset="0x11658" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_011A58" OutName="spot17_room_1Tex_011A58" Format="rgba16" Width="32" Height="32" Offset="0x11A58" AddedByScript="true"/>
+        <Texture Name="spot17_room_1Tex_012258" OutName="spot17_room_1Tex_012258" Format="ia8" Width="16" Height="16" Offset="0x12258" AddedByScript="true"/>
         <Room Name="spot17_room_1" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/N64_PAL_11/scenes/overworld/spot18.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/overworld/spot18.xml
@@ -1,5 +1,10 @@
 <Root>
     <File Name="spot18_scene" Segment="2">
+        <Texture Name="spot18_sceneTex_0087C8" OutName="spot18_sceneTex_0087C8" Format="rgba16" Width="32" Height="32" Offset="0x8748" AddedByScript="true"/>
+        <Texture Name="spot18_sceneTex_009008" OutName="spot18_sceneTex_009008" Format="ci8" Width="64" Height="32" Offset="0x8F88" TlutOffset="0x8540" AddedByScript="true"/>
+        <Texture Name="spot18_sceneTex_009848" OutName="spot18_sceneTex_009848" Format="rgba16" Width="16" Height="32" Offset="0x97C8" AddedByScript="true"/>
+        <Texture Name="spot18_sceneTex_009C48" OutName="spot18_sceneTex_009C48" Format="ci8" Width="64" Height="32" Offset="0x9BC8" TlutOffset="0x8540" AddedByScript="true"/>
+        <Texture Name="spot18_sceneTLUT_0085C0" OutName="spot18_sceneTLUT_0085C0" Format="rgba16" Width="16" Height="16" Offset="0x8540" AddedByScript="true"/>
         <Cutscene Name="gGoronCityDaruniaCorrectCs" Offset="0x59E0"/>
         <Cutscene Name="gGoronCityDarunia01Cs" Offset="0x6930"/>
         <Cutscene Name="gGoronCityDaruniaWrongCs" Offset="0x7DF4"/>
@@ -9,15 +14,92 @@
         <Scene Name="spot18_scene" Offset="0x0"/>
     </File>
     <File Name="spot18_room_0" Segment="3">
+        <Texture Name="spot18_room_0Tex_004960" OutName="spot18_room_0Tex_004960" Format="rgba16" Width="32" Height="32" Offset="0x4960" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_005160" OutName="spot18_room_0Tex_005160" Format="rgba16" Width="16" Height="32" Offset="0x5160" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_005560" OutName="spot18_room_0Tex_005560" Format="rgba16" Width="16" Height="32" Offset="0x5560" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_005960" OutName="spot18_room_0Tex_005960" Format="rgba16" Width="32" Height="64" Offset="0x5960" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_006960" OutName="spot18_room_0Tex_006960" Format="ci8" Width="32" Height="64" Offset="0x6960" ExternalTlut="spot18_scene" ExternalTlutOffset="0x8540" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_007160" OutName="spot18_room_0Tex_007160" Format="rgba16" Width="32" Height="32" Offset="0x7160" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_007960" OutName="spot18_room_0Tex_007960" Format="rgba16" Width="32" Height="32" Offset="0x7960" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_008160" OutName="spot18_room_0Tex_008160" Format="rgba16" Width="32" Height="32" Offset="0x8160" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_008960" OutName="spot18_room_0Tex_008960" Format="ci8" Width="32" Height="64" Offset="0x8960" ExternalTlut="spot18_scene" ExternalTlutOffset="0x8540" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_009160" OutName="spot18_room_0Tex_009160" Format="ci8" Width="32" Height="64" Offset="0x9160" ExternalTlut="spot18_scene" ExternalTlutOffset="0x8540" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_009960" OutName="spot18_room_0Tex_009960" Format="rgba16" Width="32" Height="32" Offset="0x9960" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_00A160" OutName="spot18_room_0Tex_00A160" Format="ci8" Width="64" Height="32" Offset="0xA160" ExternalTlut="spot18_scene" ExternalTlutOffset="0x8540" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_00A960" OutName="spot18_room_0Tex_00A960" Format="ci8" Width="32" Height="64" Offset="0xA960" ExternalTlut="spot18_scene" ExternalTlutOffset="0x8540" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_00B160" OutName="spot18_room_0Tex_00B160" Format="ci8" Width="32" Height="64" Offset="0xB160" ExternalTlut="spot18_scene" ExternalTlutOffset="0x8540" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_00B960" OutName="spot18_room_0Tex_00B960" Format="ci8" Width="32" Height="64" Offset="0xB960" ExternalTlut="spot18_scene" ExternalTlutOffset="0x8540" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_00C160" OutName="spot18_room_0Tex_00C160" Format="ci8" Width="32" Height="64" Offset="0xC160" ExternalTlut="spot18_scene" ExternalTlutOffset="0x8540" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_00C960" OutName="spot18_room_0Tex_00C960" Format="ia8" Width="64" Height="64" Offset="0xC960" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_00DFC8" OutName="spot18_room_0Tex_00DFC8" Format="rgba16" Width="32" Height="64" Offset="0xDFC8" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_00EFC8" OutName="spot18_room_0Tex_00EFC8" Format="rgba16" Width="64" Height="32" Offset="0xEFC8" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_00FFC8" OutName="spot18_room_0Tex_00FFC8" Format="rgba16" Width="32" Height="32" Offset="0xFFC8" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_0107C8" OutName="spot18_room_0Tex_0107C8" Format="rgba16" Width="64" Height="32" Offset="0x107C8" AddedByScript="true"/>
+        <Texture Name="spot18_room_0Tex_0117C8" OutName="spot18_room_0Tex_0117C8" Format="rgba16" Width="64" Height="32" Offset="0x117C8" AddedByScript="true"/>
         <Room Name="spot18_room_0" Offset="0x0"/>
     </File>
     <File Name="spot18_room_1" Segment="3">
+        <Texture Name="spot18_room_1Tex_002868" OutName="spot18_room_1Tex_002868" Format="rgba16" Width="32" Height="32" Offset="0x2868" AddedByScript="true"/>
+        <Texture Name="spot18_room_1Tex_003068" OutName="spot18_room_1Tex_003068" Format="i4" Width="128" Height="64" Offset="0x3068" AddedByScript="true"/>
+        <Texture Name="spot18_room_1Tex_004068" OutName="spot18_room_1Tex_004068" Format="ci8" Width="64" Height="32" Offset="0x4068" ExternalTlut="spot18_scene" ExternalTlutOffset="0x8540" AddedByScript="true"/>
+        <Texture Name="spot18_room_1Tex_004868" OutName="spot18_room_1Tex_004868" Format="rgba16" Width="32" Height="64" Offset="0x4868" AddedByScript="true"/>
+        <Texture Name="spot18_room_1Tex_005E00" OutName="spot18_room_1Tex_005E00" Format="ia4" Width="32" Height="64" Offset="0x5E00" AddedByScript="true"/>
         <Room Name="spot18_room_1" Offset="0x0"/>
     </File>
     <File Name="spot18_room_2" Segment="3">
+        <Texture Name="spot18_room_2Tex_004818" OutName="spot18_room_2Tex_004818" Format="rgba16" Width="32" Height="64" Offset="0x4818" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_005818" OutName="spot18_room_2Tex_005818" Format="rgba16" Width="32" Height="32" Offset="0x5818" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_006018" OutName="spot18_room_2Tex_006018" Format="rgba16" Width="32" Height="32" Offset="0x6018" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_006818" OutName="spot18_room_2Tex_006818" Format="rgba16" Width="32" Height="32" Offset="0x6818" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_007018" OutName="spot18_room_2Tex_007018" Format="ci8" Width="32" Height="64" Offset="0x7018" ExternalTlut="spot18_scene" ExternalTlutOffset="0x8540" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_007818" OutName="spot18_room_2Tex_007818" Format="rgba16" Width="32" Height="32" Offset="0x7818" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_008018" OutName="spot18_room_2Tex_008018" Format="rgba16" Width="32" Height="32" Offset="0x8018" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_008818" OutName="spot18_room_2Tex_008818" Format="ci8" Width="32" Height="64" Offset="0x8818" ExternalTlut="spot18_scene" ExternalTlutOffset="0x8540" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_009018" OutName="spot18_room_2Tex_009018" Format="ci8" Width="32" Height="64" Offset="0x9018" ExternalTlut="spot18_scene" ExternalTlutOffset="0x8540" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_009818" OutName="spot18_room_2Tex_009818" Format="ci8" Width="32" Height="64" Offset="0x9818" ExternalTlut="spot18_scene" ExternalTlutOffset="0x8540" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_00A018" OutName="spot18_room_2Tex_00A018" Format="ci8" Width="32" Height="64" Offset="0xA018" ExternalTlut="spot18_scene" ExternalTlutOffset="0x8540" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_00A818" OutName="spot18_room_2Tex_00A818" Format="ci8" Width="32" Height="64" Offset="0xA818" ExternalTlut="spot18_scene" ExternalTlutOffset="0x8540" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_00B018" OutName="spot18_room_2Tex_00B018" Format="ci8" Width="32" Height="64" Offset="0xB018" ExternalTlut="spot18_scene" ExternalTlutOffset="0x8540" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_00B818" OutName="spot18_room_2Tex_00B818" Format="ia8" Width="64" Height="64" Offset="0xB818" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_00D1A8" OutName="spot18_room_2Tex_00D1A8" Format="rgba16" Width="32" Height="64" Offset="0xD1A8" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_00E1A8" OutName="spot18_room_2Tex_00E1A8" Format="rgba16" Width="64" Height="32" Offset="0xE1A8" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_00F1A8" OutName="spot18_room_2Tex_00F1A8" Format="rgba16" Width="32" Height="32" Offset="0xF1A8" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_00F9A8" OutName="spot18_room_2Tex_00F9A8" Format="rgba16" Width="64" Height="32" Offset="0xF9A8" AddedByScript="true"/>
+        <Texture Name="spot18_room_2Tex_0109A8" OutName="spot18_room_2Tex_0109A8" Format="rgba16" Width="64" Height="32" Offset="0x109A8" AddedByScript="true"/>
         <Room Name="spot18_room_2" Offset="0x0"/>
     </File>
     <File Name="spot18_room_3" Segment="3">
+        <Texture Name="spot18_room_3Tex_00B448" OutName="spot18_room_3Tex_00B448" Format="rgba16" Width="32" Height="32" Offset="0xB448" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_00BC48" OutName="spot18_room_3Tex_00BC48" Format="rgba16" Width="16" Height="32" Offset="0xBC48" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_00C048" OutName="spot18_room_3Tex_00C048" Format="rgba16" Width="16" Height="32" Offset="0xC048" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_00C448" OutName="spot18_room_3Tex_00C448" Format="rgba16" Width="16" Height="32" Offset="0xC448" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_00C848" OutName="spot18_room_3Tex_00C848" Format="rgba16" Width="32" Height="64" Offset="0xC848" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_00D848" OutName="spot18_room_3Tex_00D848" Format="rgba16" Width="16" Height="32" Offset="0xD848" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_00DC48" OutName="spot18_room_3Tex_00DC48" Format="ci8" Width="32" Height="64" Offset="0xDC48" ExternalTlut="spot18_scene" ExternalTlutOffset="0x8540" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_00E448" OutName="spot18_room_3Tex_00E448" Format="ci8" Width="32" Height="64" Offset="0xE448" ExternalTlut="spot18_scene" ExternalTlutOffset="0x8540" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_00EC48" OutName="spot18_room_3Tex_00EC48" Format="rgba16" Width="32" Height="32" Offset="0xEC48" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_00F448" OutName="spot18_room_3Tex_00F448" Format="rgba16" Width="64" Height="32" Offset="0xF448" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_010448" OutName="spot18_room_3Tex_010448" Format="rgba16" Width="32" Height="32" Offset="0x10448" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_010C48" OutName="spot18_room_3Tex_010C48" Format="rgba16" Width="32" Height="32" Offset="0x10C48" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_011448" OutName="spot18_room_3Tex_011448" Format="ci8" Width="32" Height="64" Offset="0x11448" ExternalTlut="spot18_scene" ExternalTlutOffset="0x8540" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_011C48" OutName="spot18_room_3Tex_011C48" Format="ci8" Width="32" Height="64" Offset="0x11C48" ExternalTlut="spot18_scene" ExternalTlutOffset="0x8540" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_012448" OutName="spot18_room_3Tex_012448" Format="rgba16" Width="16" Height="16" Offset="0x12448" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_012648" OutName="spot18_room_3Tex_012648" Format="rgba16" Width="16" Height="16" Offset="0x12648" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_012848" OutName="spot18_room_3Tex_012848" Format="i4" Width="128" Height="64" Offset="0x12848" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_013848" OutName="spot18_room_3Tex_013848" Format="ci8" Width="64" Height="32" Offset="0x13848" ExternalTlut="spot18_scene" ExternalTlutOffset="0x8540" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_014048" OutName="spot18_room_3Tex_014048" Format="rgba16" Width="32" Height="32" Offset="0x14048" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_014848" OutName="spot18_room_3Tex_014848" Format="ci8" Width="32" Height="64" Offset="0x14848" ExternalTlut="spot18_scene" ExternalTlutOffset="0x8540" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_015048" OutName="spot18_room_3Tex_015048" Format="ci8" Width="32" Height="64" Offset="0x15048" ExternalTlut="spot18_scene" ExternalTlutOffset="0x8540" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_015848" OutName="spot18_room_3Tex_015848" Format="ci8" Width="32" Height="64" Offset="0x15848" ExternalTlut="spot18_scene" ExternalTlutOffset="0x8540" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_016048" OutName="spot18_room_3Tex_016048" Format="ci8" Width="32" Height="64" Offset="0x16048" ExternalTlut="spot18_scene" ExternalTlutOffset="0x8540" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_016848" OutName="spot18_room_3Tex_016848" Format="ci8" Width="32" Height="32" Offset="0x16848" ExternalTlut="spot18_scene" ExternalTlutOffset="0x8540" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_016C48" OutName="spot18_room_3Tex_016C48" Format="rgba16" Width="32" Height="32" Offset="0x16C48" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_017448" OutName="spot18_room_3Tex_017448" Format="ia8" Width="64" Height="64" Offset="0x17448" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_0194E8" OutName="spot18_room_3Tex_0194E8" Format="rgba16" Width="32" Height="64" Offset="0x194E8" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_01A4E8" OutName="spot18_room_3Tex_01A4E8" Format="rgba16" Width="64" Height="32" Offset="0x1A4E8" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_01B4E8" OutName="spot18_room_3Tex_01B4E8" Format="rgba16" Width="32" Height="32" Offset="0x1B4E8" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_01BCE8" OutName="spot18_room_3Tex_01BCE8" Format="rgba16" Width="64" Height="32" Offset="0x1BCE8" AddedByScript="true"/>
+        <Texture Name="spot18_room_3Tex_01CCE8" OutName="spot18_room_3Tex_01CCE8" Format="rgba16" Width="64" Height="32" Offset="0x1CCE8" AddedByScript="true"/>
         <Room Name="spot18_room_3" Offset="0x0"/>
     </File>
 </Root>

--- a/soh/assets/xml/N64_PAL_11/scenes/overworld/spot20.xml
+++ b/soh/assets/xml/N64_PAL_11/scenes/overworld/spot20.xml
@@ -1,5 +1,27 @@
 <Root>
     <File Name="spot20_scene" Segment="2">
+        <Texture Name="spot20_sceneTex_005FE0" OutName="spot20_sceneTex_005FE0" Format="ci8" Width="32" Height="64" Offset="0x5FE0" TlutOffset="0x5DB0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_0067E0" OutName="spot20_sceneTex_0067E0" Format="ci8" Width="16" Height="32" Offset="0x67E0" TlutOffset="0x5DB0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_0069E0" OutName="spot20_sceneTex_0069E0" Format="ci8" Width="64" Height="32" Offset="0x69E0" TlutOffset="0x5DB0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_0071E0" OutName="spot20_sceneTex_0071E0" Format="rgba16" Width="64" Height="32" Offset="0x71E0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_0091E0" OutName="spot20_sceneTex_0091E0" Format="ci8" Width="16" Height="32" Offset="0x91E0" TlutOffset="0x5DB0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_0093E0" OutName="spot20_sceneTex_0093E0" Format="rgba16" Width="16" Height="64" Offset="0x93E0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_009BE0" OutName="spot20_sceneTex_009BE0" Format="rgba16" Width="64" Height="32" Offset="0x9BE0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_00ABE0" OutName="spot20_sceneTex_00ABE0" Format="rgba16" Width="32" Height="64" Offset="0xABE0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_00BBE0" OutName="spot20_sceneTex_00BBE0" Format="ci8" Width="32" Height="16" Offset="0xBBE0" TlutOffset="0x5DB0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_00BDE0" OutName="spot20_sceneTex_00BDE0" Format="ci8" Width="32" Height="32" Offset="0xBDE0" TlutOffset="0x5DB0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_00C1E0" OutName="spot20_sceneTex_00C1E0" Format="ci4" Width="64" Height="64" Offset="0xC1E0" TlutOffset="0x5FB8" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_00C9E0" OutName="spot20_sceneTex_00C9E0" Format="ci8" Width="32" Height="64" Offset="0xC9E0" TlutOffset="0x5DB0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_00D1E0" OutName="spot20_sceneTex_00D1E0" Format="rgba16" Width="32" Height="32" Offset="0xD1E0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_00D9E0" OutName="spot20_sceneTex_00D9E0" Format="rgba16" Width="32" Height="32" Offset="0xD9E0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_00E1E0" OutName="spot20_sceneTex_00E1E0" Format="i4" Width="64" Height="64" Offset="0xE1E0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_00E9E0" OutName="spot20_sceneTex_00E9E0" Format="i4" Width="64" Height="64" Offset="0xE9E0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_00F1E0" OutName="spot20_sceneTex_00F1E0" Format="i4" Width="64" Height="64" Offset="0xF1E0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_00F9E0" OutName="spot20_sceneTex_00F9E0" Format="ci8" Width="8" Height="64" Offset="0xF9E0" TlutOffset="0x5DB0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_010BE0" OutName="spot20_sceneTex_010BE0" Format="i4" Width="64" Height="18" Offset="0x10BE0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTex_010E20" OutName="spot20_sceneTex_010E20" Format="ia8" Width="64" Height="64" Offset="0x10E20" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTLUT_005DB0" OutName="spot20_sceneTLUT_005DB0" Format="rgba16" Width="16" Height="16" Offset="0x5DB0" AddedByScript="true"/>
+        <Texture Name="spot20_sceneTLUT_005FB8" OutName="spot20_sceneTLUT_005FB8" Format="rgba16" Width="4" Height="4" Offset="0x5FB8" AddedByScript="true"/>
         <Path Name="gLonLonPath_05844" Offset="0x5844" NumPaths="3"/>
         <Cutscene Name="gLonLonRanchIntroCs" Offset="0x5BD0"/>
         <Texture Name="gLonLonRanchDayWindowTex" OutName="day_window" Format="rgba16" Width="32" Height="64" Offset="0x81E0"/>

--- a/soh/assets/xml/N64_PAL_11/textures/nintendo_rogo_static.xml
+++ b/soh/assets/xml/N64_PAL_11/textures/nintendo_rogo_static.xml
@@ -1,7 +1,8 @@
 <Root>
      <File Name="nintendo_rogo_static" Segment="1">
 
-         <Texture Name="nintendo_rogo_static_Tex_000000" OutName="tex_00000000" Format="i8" Width="192" Height="32" Offset="0x0000"/>
+         <Texture Name="nintendo_rogo_staticTex_0029C0" OutName="nintendo_rogo_staticTex_0029C0" Format="i8" Width="32" Height="32" Offset="0x29C0" AddedByScript="true"/>
+        <Texture Name="nintendo_rogo_static_Tex_000000" OutName="tex_00000000" Format="i8" Width="192" Height="32" Offset="0x0000"/>
          <Texture Name="nintendo_rogo_static_Tex_001800" OutName="tex_00001800" Format="i8" Width="32" Height="32" Offset="0x1800"/>
          <DList Name="gNintendo64LogoDL" Offset="0x2720"/>
      </File>


### PR DESCRIPTION
This PR adds dedicated texture definitions to all resource files so that we can control the output names that get used in the resulting OTR files. The goal is to align texture names across roms so that texture packs do not have to provide duplicate textures to cover all possible roms.

Without definitions, ZAPD will auto-detect these texture resources when referenced by a DList and assign them a name based on the resource file and the offset value. Since offset values are not guaranteed to be the same across different roms, this resulted in names that aren't the same. Although this doesn't cause extraction issues and running the game works fine, it makes managing and using texture packs more annoying.

To achieve this I have written a [python script](https://gist.github.com/Archez/2d561b0d9de9641a7921a33f266d6af3) that will leverage ZAPD's output to add new definitions to the XMLs so that these textures now have a hard coded output name. The hard coded names will be taken from the MQ debug rom definitions as decomp is based on the MQ debug and existing hard coded names follow this pattern.

The script achieves this by doing a few things:
1. Extract all roms so that we can read the `(listfiles)` from each OTR
2. Set ZAPD to output textures to a folder (I also made a change so that any palette textures will also append the referenced TLUT name to be used later)
3. Filter the listfiles for any textures and TLUTs that do not have existing XML definitions
4. Determine the width/height/format based on the texture output file
5. Add each missing texture to the appropriate File resource, and for palette based textures, also add the TlutOffset information based on the TLUT name from ZAPD
6. Once all XMLs have their definitions, we then compare the actual texture output files against the MQ debug textures
   * Use direct file comparison to find matches, otherwise
   * Use Structural Similarity image recognition to get similarity scores (this works nicely as textures being matched would have to be the same height/width, as needed by SSIM)
   * For any similarity scores that are too low, use a manual verification to select the appropriate matches
7. Look for any texture definitions who's names do not already match the MQ debug name and update them

Essentially only PAL1.1 needed to utilize SSIM recognition due to the gerudo symbol changes, and only about ~20 files needed to be manually verified in those cases. Outside of that, there was about 10 textures that could not have the TLUT information automated (ZAPD bug I guess), so these were also handled manually by looking at the DList in decomp. Technically the TLUT information is only necessary for outputting to files from ZAPD, but I think it is best to set this information if we have it available rather than losing it.

I have confirmed these changes by using retro to compare the manifest between PAL1.1 and MQ debug, and only the expected files (gerudo symbol, texture screen, button prompts, etc) had different hash values, otherwise all scenes were identical. I also prepared a custom OoT-Reloaded pack that only uses the mq version of the texture files (copied over to nonmq) and all textures were changed in game when running the PAL1.1 rom.

Attached is the outputs from the different stages and the final list of replacements for each rom. The replacements are comma delimited where the left value is the old name, and the right value is the new name. These can be used for texture pack makers to automate the renames. But if they have an MQ set of textures, then copying those over to nonmq should be sufficient 😉 
[outputs.zip](https://github.com/HarbourMasters/Shipwright/files/12460392/outputs.zip)

Fixes #3024

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/891590012.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/891590016.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/891590019.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/891590022.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/891590025.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/891590027.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/891590030.zip)
<!--- section:artifacts:end -->