### PR TITLE
[Tweak] Update Rando save warning message for new file info screen

### DIFF
--- a/soh/soh/Enhancements/custom-message/CustomMessageTypes.h
+++ b/soh/soh/Enhancements/custom-message/CustomMessageTypes.h
@@ -46,7 +46,6 @@ typedef enum {
     TEXT_WARP_RANDOM_REPLACED_TEXT = 0x9200,
     TEXT_LAKE_HYLIA_WATER_SWITCH_SIGN = 0x346, // 0x3yy for cuttable sign range
     TEXT_LAKE_HYLIA_WATER_SWITCH_NAVI = 0x1B3, // 0x1yy for Navi msg range
-    TEXT_RANDO_SAVE_VERSION_WARNING = 0x9300,
 } TextIDs;
 
 #ifdef __cplusplus

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -2143,9 +2143,6 @@ extern "C" int CustomMessage_RetrieveIfExists(PlayState* play) {
     if (textId == TEXT_MARKET_GUARD_NIGHT && CVarGetInteger("gMarketSneak", 0) && play->sceneNum == SCENE_ENTRA_N) {
         messageEntry = CustomMessageManager::Instance->RetrieveMessage(customMessageTableID, TEXT_MARKET_GUARD_NIGHT);
     }
-    if (textId == TEXT_RANDO_SAVE_VERSION_WARNING) {
-        messageEntry = CustomMessageManager::Instance->RetrieveMessage(customMessageTableID, TEXT_RANDO_SAVE_VERSION_WARNING);
-    }
     font->charTexBuf[0] = (messageEntry.GetTextBoxType() << 4) | messageEntry.GetTextBoxPosition();
     switch (gSaveContext.language) {
         case LANGUAGE_FRA:

--- a/soh/soh/z_message_OTR.cpp
+++ b/soh/soh/z_message_OTR.cpp
@@ -154,12 +154,4 @@ extern "C" void OTRMessage_Init()
         CustomMessage("You look bored. Wanna go out for a&walk?\x1B&%gYes&No%w",
                       "Du siehst gelangweilt aus.&Willst du einen Spaziergang machen?\x1B&%gJa&Nein%w",
                       "Tu as l'air de t'ennuyer. Tu veux&aller faire un tour?\x1B&%gOui&Non%w"));
-    CustomMessageManager::Instance->CreateMessage(
-        customMessageTableID, TEXT_RANDO_SAVE_VERSION_WARNING,
-        CustomMessage(
-            "This save was created on&a different version of SoH.&&Things may be broken.",
-            "Dieser Spielstand wurde auf einer&anderen Version von SoH erstellt.&&Es könnten Fehler auftreten.",
-            "Cette sauvegarde a été créée sur&une version différente de SoH.&Certaines fonctionnalités&peuvent être "
-            "corrompues.",
-            TEXTBOX_TYPE_NONE_BOTTOM));
 }

--- a/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -3117,7 +3117,7 @@ static const char* randoWarningText[] = {
     // German
     "Dieser Spielstand wurde auf einer anderen Version\nvon SoH erstellt.\nEs könnten Fehler auftreten.",
     // French
-    "Cette sauvegarde a été créée sur une version\ndifférente de SoH.\nCertaines fonctionnalités peuventêtre corrompues."
+    "Cette sauvegarde a été créée sur une version\ndifférente de SoH.\nCertaines fonctionnalités peuvent être corrompues."
 };
 
 void FileChoose_DrawRandoSaveWarning(GameState* thisx) {


### PR DESCRIPTION
After the introduction of the "more file info" enhancement, the rando save warning message was overlapping it and hard to read if the enhancement was on.

This PR updates the rando save warning to now render beneath the main menu window with a textbox backdrop, so now it doesn't matter if the "more file info" enhancement is on or not. The message is still within the 4:3 ratio.

While updating, I also opted to switch to the newer `Interface_DrawTextLine` as it is less buggy than the older approach of using a dummy message context.

![image](https://github.com/HarbourMasters/Shipwright/assets/13861068/6a2df287-576e-4cbd-b424-50835ed34441)

https://github.com/HarbourMasters/Shipwright/assets/13861068/09691c74-2984-4bd0-b52c-76a8adc412c9



<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/893363872.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/893363873.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/893363876.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/893363878.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/893363880.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/893363881.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/893363882.zip)
<!--- section:artifacts:end -->