### PR TITLE
Store seed string in the save, and use it for mirror mode & enemy rando

### DIFF
--- a/soh/include/z64save.h
+++ b/soh/include/z64save.h
@@ -316,6 +316,7 @@ typedef struct {
     /*        */ RandomizerCheck ganonHintCheck;
     /*        */ RandomizerCheck gregCheck;
     /*        */ RandomizerCheck dampeCheck;
+    /*        */ char seed[255];
     /*        */ u8 seedIcons[5];
     /*        */ u16 randomizerInf[9];
     /*        */ u16 adultTradeItems;

--- a/soh/soh/Enhancements/enemyrandomizer.cpp
+++ b/soh/soh/Enhancements/enemyrandomizer.cpp
@@ -3,6 +3,7 @@
 #include "macros.h"
 #include "soh/Enhancements/randomizer/3drando/random.hpp"
 #include "soh/Enhancements/enhancementTypes.h"
+#include "boost_custom/container_hash/hash_32.hpp"
 #include "variables.h"
 
 extern "C" {
@@ -234,7 +235,7 @@ extern "C" uint8_t GetRandomizedEnemy(PlayState* play, int16_t *actorId, f32 *po
 
 EnemyEntry GetRandomizedEnemyEntry(uint32_t seed) {
     if (CVarGetInteger("gRandomizedEnemies", ENEMY_RANDOMIZER_OFF) == ENEMY_RANDOMIZER_RANDOM_SEEDED) {
-        uint32_t finalSeed = seed + (gSaveContext.n64ddFlag ? (gSaveContext.seedIcons[0] + gSaveContext.seedIcons[1] + gSaveContext.seedIcons[2] + gSaveContext.seedIcons[3] + gSaveContext.seedIcons[4]) : gSaveContext.sohStats.fileCreatedAt);
+        uint32_t finalSeed = seed + (gSaveContext.n64ddFlag ? boost::hash_32<std::string>{}(gSaveContext.seed) : gSaveContext.sohStats.fileCreatedAt);
         Random_Init(finalSeed);
     }
 

--- a/soh/soh/Enhancements/mods.cpp
+++ b/soh/soh/Enhancements/mods.cpp
@@ -2,6 +2,7 @@
 #include <libultraship/bridge.h>
 #include "game-interactor/GameInteractor.h"
 #include "soh/Enhancements/randomizer/3drando/random.hpp"
+#include "boost_custom/container_hash/hash_32.hpp"
 #include "tts/tts.h"
 #include "soh/Enhancements/boss-rush/BossRushTypes.h"
 #include "soh/Enhancements/enhancementTypes.h"
@@ -566,8 +567,7 @@ void UpdateMirrorModeState(int32_t sceneNum) {
                         (sceneNum == SCENE_GANON_BOSS);
 
     if (mirroredMode == MIRRORED_WORLD_RANDOM_SEEDED || mirroredMode == MIRRORED_WORLD_DUNGEONS_RANDOM_SEEDED) {
-        uint32_t seed = sceneNum + (gSaveContext.n64ddFlag ? (gSaveContext.seedIcons[0] + gSaveContext.seedIcons[1] +
-                        gSaveContext.seedIcons[2] + gSaveContext.seedIcons[3] + gSaveContext.seedIcons[4]) : gSaveContext.sohStats.fileCreatedAt);
+        uint32_t seed = sceneNum + (gSaveContext.n64ddFlag ? boost::hash_32<std::string>{}(gSaveContext.seed) : gSaveContext.sohStats.fileCreatedAt);
         Random_Init(seed);
     }
 

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -1509,6 +1509,10 @@ void Randomizer::ParseItemLocationsFile(const char* spoilerFileName, bool silent
             index++;
         }
 
+        std::string seed = spoilerFileJson["seed"].get<std::string>();
+        strncpy(gSaveContext.seed, seed.c_str(), sizeof(gSaveContext.seed) - 1);
+        gSaveContext.seed[sizeof(gSaveContext.seed) - 1] = 0;
+
         for (auto it = locationsJson.begin(); it != locationsJson.end(); ++it) {
             RandomizerCheck randomizerCheck = SpoilerfileCheckNameToEnum[it.key()];
             if (it->is_structured()) {

--- a/soh/soh/SaveManager.cpp
+++ b/soh/soh/SaveManager.cpp
@@ -186,6 +186,11 @@ void SaveManager::LoadRandomizerVersion2() {
         SaveManager::Instance->LoadData("", gSaveContext.seedIcons[i]);
     });
 
+    std::string seed;
+    // Eventually I'd like this to use the key "seed", and migrate the array stored above to "seedIcons"
+    SaveManager::Instance->LoadData("seedString", seed);
+    memcpy(gSaveContext.seed, seed.c_str(), seed.length() + 1);
+
     SaveManager::Instance->LoadArray("randoSettings", RSK_MAX, [&](size_t i) {
         gSaveContext.randoSettings[i].key = RandomizerSettingKey(i);
         SaveManager::Instance->LoadData("", gSaveContext.randoSettings[i].value);
@@ -293,6 +298,8 @@ void SaveManager::SaveRandomizer(SaveContext* saveContext, int sectionID, bool f
     SaveManager::Instance->SaveArray("seed", ARRAY_COUNT(saveContext->seedIcons), [&](size_t i) {
         SaveManager::Instance->SaveData("", saveContext->seedIcons[i]);
     });
+
+    SaveManager::Instance->SaveData("seedString", saveContext->seed);
 
     SaveManager::Instance->SaveArray("randoSettings", RSK_MAX, [&](size_t i) {
         SaveManager::Instance->SaveData("", saveContext->randoSettings[i].value);


### PR DESCRIPTION
Needed this for some race stuff, to enforce everyone is on the set seed string (we can't determine the original seed string from the currently stored seedIcons)

Eventually we can probably compute the seedIcons on the fly using this string instead of storing them, but I'd rather that be separate from introducing this

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/900386107.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/900386108.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/900386110.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/900386111.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/900386112.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/900386113.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/900386114.zip)
<!--- section:artifacts:end -->