### PR TITLE
CrowdControl bypass voidout/die crash in pre-rendered background areas

### DIFF
--- a/soh/src/code/z_room.c
+++ b/soh/src/code/z_room.c
@@ -403,7 +403,7 @@ BgImage* func_80096A74(PolygonType1* polygon1, PlayState* play) {
 
     camera = GET_ACTIVE_CAM(play);
     camId = camera->camDataIdx;
-    if (camId == -1 && CVarGetInteger("gNoRestrictItems", 0)) {
+    if (camId == -1 && (CVarGetInteger("gNoRestrictItems", 0) || CVarGetInteger("gCrowdControl", 0))) {
         // This prevents a crash when using items that change the
         // camera (such as din's fire) on scenes with prerendered backgrounds
         return NULL;

--- a/soh/src/code/z_room.c
+++ b/soh/src/code/z_room.c
@@ -405,7 +405,8 @@ BgImage* func_80096A74(PolygonType1* polygon1, PlayState* play) {
     camId = camera->camDataIdx;
     if (camId == -1 && (CVarGetInteger("gNoRestrictItems", 0) || CVarGetInteger("gCrowdControl", 0))) {
         // This prevents a crash when using items that change the
-        // camera (such as din's fire) on scenes with prerendered backgrounds
+        // camera (such as din's fire), voiding out or dying on 
+        // scenes with prerendered backgrounds.
         return NULL;
     }
 


### PR DESCRIPTION
Fixes https://github.com/HarbourMasters/Shipwright/issues/2492

Looks like this: 

https://github.com/HarbourMasters/Shipwright/assets/4244591/f564b7a2-df3a-4118-a758-a23fd005d107

Not ideal but definitely better than the game crashing.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/917763139.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/917763143.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/917763147.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/917763151.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/917763153.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/917763155.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/917763157.zip)
<!--- section:artifacts:end -->