### PR TITLE
proof of concept otr load order thing

### DIFF
--- a/soh/soh/Enhancements/otrloadorder.cpp
+++ b/soh/soh/Enhancements/otrloadorder.cpp
@@ -1,0 +1,83 @@
+#include "otrloadorder.h"
+
+#include <Utils/StringHelper.h>
+
+
+// Refresh the list of otrs based on what's in the directory
+void ModLoadOrderWindow::RefreshOtrList(bool ignoreCvar) {
+    mOtrList.clear();
+
+    if (ignoreCvar || !strnlen(CVarGetString("gModLoadOrder", ""), 1)) {
+        std::string patchesPath = LUS::Context::LocateFileAcrossAppDirs("mods", "soh");
+        if (patchesPath.length() > 0 && std::filesystem::exists(patchesPath)) {
+            if (std::filesystem::is_directory(patchesPath)) {
+                for (const auto& p : std::filesystem::recursive_directory_iterator(patchesPath)) {
+                    if (StringHelper::IEquals(p.path().extension().string(), ".otr")) {
+                        mOtrList.push_back(p.path().generic_string());
+                    }
+                }
+            }
+        }
+    } else {
+        // todo: this efficently when we build out cvar array support
+        std::stringstream otrListStringStream(CVarGetString("gModLoadOrder", ""));
+        std::string otrString;
+        while (getline(otrListStringStream, otrString, ',')) {
+            mOtrList.push_back(otrString);
+        }
+    }
+
+    mOtrListLoaded = true;
+}
+
+void ModLoadOrderWindow::SaveAndQuit() {
+    // todo: this efficently when we build out cvar array support
+    std::string otrListString = "";
+    for (auto otrIt : mOtrList) {
+        otrListString += otrIt;
+        otrListString += ",";
+    }
+    CVarSetString("gModLoadOrder", otrListString.c_str());
+    LUS::Context::GetInstance()->GetConsoleVariables()->Save();
+    LUS::Context::GetInstance()->GetWindow()->Close();
+}
+
+void ModLoadOrderWindow::DrawElement() {
+    if (!mOtrListLoaded) {
+        RefreshOtrList(false);
+    }
+
+    ImGui::SetNextWindowSize(ImVec2(820, 630), ImGuiCond_FirstUseEver);
+    if (!ImGui::Begin("Mod .otr Load Order", &mIsVisible)) {
+        ImGui::End();
+        return;
+    }
+
+    if (ImGui::Button("Refresh list")) {
+        RefreshOtrList(true);
+    }
+
+    for (int n = 0; n < mOtrList.size(); n++)
+    {
+        const char* item = mOtrList[n].c_str();
+        ImGui::Selectable(item);
+
+        if (ImGui::IsItemActive() && !ImGui::IsItemHovered())
+        {
+            int n_next = n + (ImGui::GetMouseDragDelta(0).y < 0.f ? -1 : 1);
+            if (n_next >= 0 && n_next < mOtrList.size())
+            {
+                std::string swapped = mOtrList[n];
+                mOtrList[n] = mOtrList[n_next];
+                mOtrList[n_next] = swapped;
+                ImGui::ResetMouseDragDelta();
+            }
+        }
+    }
+
+    if (ImGui::Button("Save and Quit (like fully quit the game)")) {
+        SaveAndQuit();
+    }
+
+    ImGui::End();
+}

--- a/soh/soh/Enhancements/otrloadorder.h
+++ b/soh/soh/Enhancements/otrloadorder.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#ifdef __cplusplus
+
+#include <libultraship/libultraship.h>
+#include <ImGui/imgui.h>
+#include <vector>
+
+class ModLoadOrderWindow : public LUS::GuiWindow {
+    public:
+        using LUS::GuiWindow::GuiWindow;
+
+        void DrawElement() override;
+        void InitElement() override {};
+        void UpdateElement() override {};
+        ~ModLoadOrderWindow() {};
+    private:
+        void RefreshOtrList(bool ignoreCvar);
+        void SaveAndQuit();
+        bool mOtrListLoaded;
+        std::vector<std::string> mOtrList;
+};
+
+#endif

--- a/soh/soh/SohGui.cpp
+++ b/soh/soh/SohGui.cpp
@@ -119,6 +119,7 @@ namespace SohGui {
     std::shared_ptr<SaveEditorWindow> mSaveEditorWindow;
     std::shared_ptr<DLViewerWindow> mDLViewerWindow;
     std::shared_ptr<GameplayStatsWindow> mGameplayStatsWindow;
+    std::shared_ptr<ModLoadOrderWindow> mModLoadOrderWindow;
     std::shared_ptr<CheckTracker::CheckTrackerSettingsWindow> mCheckTrackerSettingsWindow;
     std::shared_ptr<CheckTracker::CheckTrackerWindow> mCheckTrackerWindow;
     std::shared_ptr<EntranceTrackerWindow> mEntranceTrackerWindow;
@@ -171,6 +172,8 @@ namespace SohGui {
         gui->AddGuiWindow(mDLViewerWindow);
         mGameplayStatsWindow = std::make_shared<GameplayStatsWindow>("gGameplayStatsEnabled", "Gameplay Stats");
         gui->AddGuiWindow(mGameplayStatsWindow);
+        mModLoadOrderWindow = std::make_shared<ModLoadOrderWindow>("gModLoadOrderWindowOpen", "Mod .otr Load Order");
+        gui->AddGuiWindow(mModLoadOrderWindow);
         mCheckTrackerWindow = std::make_shared<CheckTracker::CheckTrackerWindow>("gCheckTrackerEnabled", "Check Tracker");
         gui->AddGuiWindow(mCheckTrackerWindow);
         mCheckTrackerSettingsWindow = std::make_shared<CheckTracker::CheckTrackerSettingsWindow>("gCheckTrackerSettingsEnabled", "Check Tracker Settings");

--- a/soh/soh/SohGui.hpp
+++ b/soh/soh/SohGui.hpp
@@ -18,6 +18,7 @@
 #include "Enhancements/debugger/debugSaveEditor.h"
 #include "Enhancements/debugger/dlViewer.h"
 #include "Enhancements/gameplaystatswindow.h"
+#include "Enhancements/otrloadorder.h"
 #include "Enhancements/randomizer/randomizer_check_tracker.h"
 #include "Enhancements/randomizer/randomizer_entrance_tracker.h"
 #include "Enhancements/randomizer/randomizer_item_tracker.h"

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -23,6 +23,7 @@
 #include "Enhancements/debugger/debugSaveEditor.h"
 #include "Enhancements/debugger/dlViewer.h"
 #include "Enhancements/gameplaystatswindow.h"
+#include "Enhancements/otrloadorder.h"
 #include "Enhancements/randomizer/randomizer_check_tracker.h"
 #include "Enhancements/randomizer/randomizer_entrance_tracker.h"
 #include "Enhancements/randomizer/randomizer_item_tracker.h"
@@ -470,6 +471,7 @@ void DrawSettingsMenu() {
 extern std::shared_ptr<AudioEditor> mAudioEditorWindow;
 extern std::shared_ptr<CosmeticsEditorWindow> mCosmeticsEditorWindow;
 extern std::shared_ptr<GameplayStatsWindow> mGameplayStatsWindow;
+extern std::shared_ptr<ModLoadOrderWindow> mModLoadOrderWindow;
 
 void DrawEnhancementsMenu() {
     if (ImGui::BeginMenu("Enhancements"))
@@ -1169,6 +1171,12 @@ void DrawEnhancementsMenu() {
         if (mGameplayStatsWindow) {
             if (ImGui::Button(GetWindowButtonText("Gameplay Stats", CVarGetInteger("gGameplayStatsEnabled", 0)).c_str(), ImVec2(-1.0f, 0.0f))) {
                 mGameplayStatsWindow->ToggleVisibility();
+            }
+        }
+
+        if (mModLoadOrderWindow) {
+            if (ImGui::Button(GetWindowButtonText("Mod .otr Load Order", CVarGetInteger("gModLoadOrderWindowOpen", 0)).c_str(), ImVec2(-1.0f, 0.0f))) {
+                mModLoadOrderWindow->ToggleVisibility();
             }
         }
         ImGui::PopStyleVar(3);


### PR DESCRIPTION
this isn't pretty and it isn't good and i don't plan on trying to fully build it out but it's probably a decent jumping off point for anyone that wants to implement something like this

the biggest part i don't like about this is that it's using the old "just shove an array into a string" cvar strat we use for location exclusion in rando, it'd be much better to store these cleanly.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/919890134.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/919890135.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/919890136.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/919890140.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/919890142.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/919890143.zip)
<!--- section:artifacts:end -->