### PR TITLE
Fix: Better debug warp Deku Tree entrance

### DIFF
--- a/soh/src/overlays/gamestates/ovl_select/z_select.c
+++ b/soh/src/overlays/gamestates/ovl_select/z_select.c
@@ -523,7 +523,7 @@ static BetterSceneSelectEntry sBetterScenes[] = {
         { "Requiem of Spirit Warp", "Requiem der Geister Teleport", "Teleporteur du Requiem de l'Esprit", 0x01F1, 0 },
     }},
     { "32:Deku Tree", "32:Deku-Baum", "32:Arbre Mojo", Select_LoadGame, 3, {
-        { "Entrance", "Eingang", "Entree", 0x0001, 1 },
+        { "Entrance", "Eingang", "Entree", 0x0000, 1 },
         { "From Gohma's Lair", "Vom Gohma Kampf", "Depuis le Repaire de Gohma", 0x0252, 1 },
         { "Gohma's Lair", "Gohma Kampf", "Repaire de Gohma", 0x040F, 0 },
     }},


### PR DESCRIPTION
The entrance for Deku Tree in the better debug warp menu was off which made it so trying to warp as adult at night would overflow the entrance table and return Dodongo's Cavern scene instead.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/924355866.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/924355867.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/924355868.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/924355869.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/924355870.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/924355871.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/924355872.zip)
<!--- section:artifacts:end -->