### PR TITLE
tweak shuffle pool tab to better fit voice option

### DIFF
--- a/soh/soh/Enhancements/audio/AudioEditor.cpp
+++ b/soh/soh/Enhancements/audio/AudioEditor.cpp
@@ -330,7 +330,7 @@ ImVec4 GetSequenceTypeColor(SeqType type) {
         case SEQ_SFX:
             return ImVec4(0.4f, 0.33f, 0.0f, 1.0f);
         case SEQ_VOICE:
-            return ImVec4(0.4f, 0.33f, 0.0f, 1.0f);
+            return ImVec4(0.3f, 0.42f, 0.09f, 1.0f);
         case SEQ_INSTRUMENT:
             return ImVec4(0.0f, 0.25f, 0.5f, 1.0f);
         case SEQ_BGM_CUSTOM:
@@ -481,7 +481,7 @@ void AudioEditor::DrawElement() {
                 }
             }
 
-            ImGui::BeginTable("sequenceTypes", 8, ImGuiTableFlags_Resizable | ImGuiTableFlags_NoSavedSettings | ImGuiTableFlags_Borders);
+            ImGui::BeginTable("sequenceTypes", 9, ImGuiTableFlags_Resizable | ImGuiTableFlags_NoSavedSettings | ImGuiTableFlags_Borders);
 
             ImGui::TableNextColumn();
             ImGui::PushStyleColor(ImGuiCol_Header, GetSequenceTypeColor(SEQ_BGM_WORLD));


### PR DESCRIPTION
i didn't like that it was taking up 2 lines and that the sfx color was the same as the voice color

#### note: screenshots taken at default audio editor window size
### before
![image](https://github.com/HarbourMasters/Shipwright/assets/70942617/e6e5f83d-27be-48bf-be6d-b052b1c21ca8)


### after

![image](https://github.com/HarbourMasters/Shipwright/assets/70942617/230ba775-c7f6-419c-b56d-5b6d958fbb08)



<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/931963305.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/931963309.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/931963313.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/931963316.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/931963317.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/931963319.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/931963321.zip)
<!--- section:artifacts:end -->