### PR TITLE
Add instant transitions

### DIFF
--- a/soh/soh/Enhancements/mods.cpp
+++ b/soh/soh/Enhancements/mods.cpp
@@ -979,6 +979,11 @@ void RegisterInstantTransitions() {
         if (CVarGetInteger("gInstantTransitions", 0)) {
             gPlayState->fadeTransition = 11;
             gSaveContext.nextTransitionType = 11;
+            //still play the transition when entering the haunted wasteland because if not,
+            //the sandstorm never appears
+            if (gPlayState->nextEntranceIndex == 0x0130 || gPlayState->nextEntranceIndex == 0x0365) {
+                gSaveContext.nextTransitionType = 14;
+            }
         }
     });
 }

--- a/soh/soh/Enhancements/mods.cpp
+++ b/soh/soh/Enhancements/mods.cpp
@@ -974,6 +974,15 @@ void RegisterRandomizerSheikSpawn() {
     });
 }
 
+void RegisterInstantTransitions() {
+    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnPlayerUpdate>([]() {
+        if (CVarGetInteger("gInstantTransitions", 0)) {
+            gPlayState->fadeTransition = 11;
+            gSaveContext.nextTransitionType = 11;
+        }
+    });
+}
+
 void InitMods() {
     RegisterTTS();
     RegisterInfiniteMoney();
@@ -1000,4 +1009,5 @@ void InitMods() {
     RegisterAltTrapTypes();
     RegisterRandomizerSheikSpawn();
     NameTag_RegisterHooks();
+    RegisterInstantTransitions();
 }

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -560,6 +560,8 @@ void DrawEnhancementsMenu() {
                     "- Obtained the Master Sword\n"
                     "- Not within range of Time Block\n"
                     "- Not within range of Ocarina playing spots");
+                UIWidgets::PaddedEnhancementCheckbox("Instant transitions", "gInstantTransitions", true, false);
+                UIWidgets::Tooltip("Skips the transitions when changing scenes");
                 ImGui::EndMenu();
             }
 

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -9225,6 +9225,7 @@ void func_80845CA4(Player* this, PlayState* play) {
             }
 
             if (CVarGetInteger("gInstantTransitions", 0)) {
+                //instantly end the "walking" animation on scene load
                 func_8083CF5C(this, play);
             }
 

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -9224,6 +9224,10 @@ void func_80845CA4(Player* this, PlayState* play) {
                 sp30 = -1;
             }
 
+            if (CVarGetInteger("gInstantTransitions", 0)) {
+                func_8083CF5C(this, play);
+            }
+
             temp = func_80845BA0(play, this, &sp34, sp30);
 
             if ((this->unk_850 == 0) ||


### PR DESCRIPTION
Adds a new cvar that skips the transitions between scenes.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/935719447.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/935719450.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/935719452.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/935719454.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/935719456.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/935719458.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/935719460.zip)
<!--- section:artifacts:end -->