### PR TITLE
Open App Files Folder

### DIFF
--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -155,13 +155,12 @@ void DrawShipMenu() {
         }
 #if !defined(__SWITCH__) && !defined(__WIIU__)
         UIWidgets::Spacer(0);
-#if defined(__APPLE__) || defined(__WINDOWS__) || defined(__LINUX__)
         if (ImGui::MenuItem("Open App Files Folder")) {
             std::string filesPath = LUS::Context::GetInstance()->GetAppDirectoryPath();
             SDL_OpenURL(std::string("file:///" + std::filesystem::absolute(filesPath).string()).c_str());
         }
         UIWidgets::Spacer(0);
-#endif
+
         if (ImGui::MenuItem("Quit")) {
             LUS::Context::GetInstance()->GetWindow()->Close();
         }

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -155,6 +155,17 @@ void DrawShipMenu() {
         }
 #if !defined(__SWITCH__) && !defined(__WIIU__)
         UIWidgets::Spacer(0);
+#if defined(__APPLE__) || defined(__WINDOWS__) || defined(__LINUX__)
+        if (ImGui::MenuItem("Open App Files Folder")) {
+#if defined(__WINDOWS__)
+            std::string filesPath = std::filesystem::current_path().string();
+#else
+            std::string filesPath = LUS::Context::GetInstance()->GetAppBundlePath();
+#endif
+            SDL_OpenURL(std::string("file:///" + filesPath).c_str());
+        }
+        UIWidgets::Spacer(0);
+#endif
         if (ImGui::MenuItem("Quit")) {
             LUS::Context::GetInstance()->GetWindow()->Close();
         }

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -157,12 +157,8 @@ void DrawShipMenu() {
         UIWidgets::Spacer(0);
 #if defined(__APPLE__) || defined(__WINDOWS__) || defined(__LINUX__)
         if (ImGui::MenuItem("Open App Files Folder")) {
-#if defined(__WINDOWS__)
-            std::string filesPath = std::filesystem::current_path().string();
-#else
-            std::string filesPath = LUS::Context::GetInstance()->GetAppBundlePath();
-#endif
-            SDL_OpenURL(std::string("file:///" + filesPath).c_str());
+            std::string filesPath = LUS::Context::GetInstance()->GetAppDirectoryPath();
+            SDL_OpenURL(std::string("file:///" + std::filesystem::absolute(filesPath).string()).c_str());
         }
         UIWidgets::Spacer(0);
 #endif


### PR DESCRIPTION
 Add "Open App Files Folder" menu item to Ship menu on desktop platforms to open the folder where mods, logs, etc, are found.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/942281762.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/942281763.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/942281764.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/942281765.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/942281766.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/942281767.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/942281768.zip)
<!--- section:artifacts:end -->