### PR TITLE
[Tweak] Improve Free Camera clear action

### DIFF
--- a/soh/src/code/z_camera.c
+++ b/soh/src/code/z_camera.c
@@ -2138,8 +2138,6 @@ s32 Camera_Parallel1(Camera* camera) {
     OLib_Vec3fDiffToVecSphGeo(&atToEyeDir, at, eye);
     OLib_Vec3fDiffToVecSphGeo(&atToEyeNextDir, at, eyeNext);
 
-    camera->play->manualCamera = false;
-
     switch (camera->animState) {
         case 0:
         case 0xA:
@@ -7888,6 +7886,15 @@ s32 Camera_ChangeModeFlags(Camera* camera, s16 mode, u8 flags) {
                     break;
             }
         }
+
+        // Clear free camera if an action is performed that would move the camera (targeting, first person, talking)
+        if (CVarGetInteger("gFreeCamera", 0) && SetCameraManual(camera) == 1 &&
+            ((mode >= CAM_MODE_TARGET && mode <= CAM_MODE_BATTLE) ||
+             (mode >= CAM_MODE_FIRSTPERSON && mode <= CAM_MODE_CLIMBZ) || mode == CAM_MODE_HANGZ ||
+             mode == CAM_MODE_FOLLOWBOOMERANG)) {
+            camera->play->manualCamera = false;
+        }
+
         func_8005A02C(camera);
         camera->mode = mode;
         return 0x80000000 | mode;


### PR DESCRIPTION
The original intention was that pressing Z-target was how to reset the free camera and go back to the normal camera. This was done by clearing free camera when the "parallel cam" was active (the standard Z-Target cam). The problem is this camera is only used when Link is idle. Free camera could not be reset when actively climbing or riding Epona.

This PR is to improve how free camera is cleared and handle more situations that cause jarring camera movement. The logic for determining this is moved to the `Camera_ChangeMode` flow and using the mode directly to decide the action. Specifically the following situations will now clear the free cam.

* Z-Targetting enemies or friendlies
* Z-Targetting while on Epona
* Z-Targetting wile climbing or hanging on a ledge
* Entering first person mode or first person aiming
* Entering Z-Target aiming
* Talking to signs/NPCs

Fixes #790 and most likely is the "real" fix for #863

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/942218242.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/942218243.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/942218244.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/942218245.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/942218246.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/942218247.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/942218248.zip)
<!--- section:artifacts:end -->