### PR TITLE
Item Tracker Combo Button Fix

### DIFF
--- a/soh/soh/UIWidgets.cpp
+++ b/soh/soh/UIWidgets.cpp
@@ -240,7 +240,7 @@ namespace UIWidgets {
         std::string comboName = std::string("##") + std::string(cvarName);
         if (ImGui::BeginCombo(comboName.c_str(), comboArray[selected])) {
             for (uint8_t i = 0; i < comboArray.size(); i++) {
-                if (strlen(comboArray[i]) >= 1) {
+                if (strlen(comboArray[i]) > 0) {
                     if (ImGui::Selectable(comboArray[i], i == selected)) {
                         CVarSetInteger(cvarName, i);
                         selected = i;

--- a/soh/soh/UIWidgets.cpp
+++ b/soh/soh/UIWidgets.cpp
@@ -240,7 +240,7 @@ namespace UIWidgets {
         std::string comboName = std::string("##") + std::string(cvarName);
         if (ImGui::BeginCombo(comboName.c_str(), comboArray[selected])) {
             for (uint8_t i = 0; i < comboArray.size(); i++) {
-                if (strlen(comboArray[i]) > 1) {
+                if (strlen(comboArray[i]) >= 1) {
                     if (ImGui::Selectable(comboArray[i], i == selected)) {
                         CVarSetInteger(cvarName, i);
                         selected = i;


### PR DESCRIPTION
Problem: The item tracker combo button options would no longer show all the button options to the user in the dropdown, including the default buttons L and R.

Introduced in the ImGui cleanup #2576 where the Item Tracker Combo Button ComboBox was changed to utilise the EnhancementComboBox, which itself had an issue where strings of length 1 were not added to the combobox.

I'm not sure if it was intentional to ever exclude single letter strings from being allowed in the combobox so lmk if you know of a place this may affect incorrectly

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/944660378.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/944660380.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/944660381.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/944660385.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/944660390.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/944660398.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/944660403.zip)
<!--- section:artifacts:end -->