### PR TITLE
[Rando Fix] Able to pick up/put down Master Sword after using certain bottled Items

### DIFF
--- a/soh/src/overlays/actors/ovl_Bg_Toki_Swd/z_bg_toki_swd.c
+++ b/soh/src/overlays/actors/ovl_Bg_Toki_Swd/z_bg_toki_swd.c
@@ -134,8 +134,7 @@ void func_808BAF40(BgTokiSwd* this, PlayState* play) {
             BgTokiSwd_SetupAction(this, func_808BB0AC);
         } else {
             Player* player = GET_PLAYER(play);
-            if (Actor_IsFacingPlayer(&this->actor, 0x2000) && 
-                (!IS_RANDO || (IS_RANDO && player->getItemId == GI_NONE))) {
+            if (Actor_IsFacingPlayer(&this->actor, 0x2000)) {
                 func_8002F580(&this->actor, play);
             }
         }


### PR DESCRIPTION
addresses #3048 where using bottled bugs or fish would set the getitemid to 0x7E, which in turn would no longer allow the player to pick up the master sword without reloading the scene or receiving a different item

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/953399074.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/953399075.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/953399076.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/953399077.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/953399078.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/953399080.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/953399081.zip)
<!--- section:artifacts:end -->