### PR TITLE
Fixup remaining n64ddflag after IS_RANDO merge

### DIFF
--- a/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
+++ b/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
@@ -514,7 +514,7 @@ void DrawInfoTab() {
     }
     UIWidgets::InsertHelpHoverText("Z-Targeting behavior");
 
-    if (gSaveContext.n64ddFlag && OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_TRIFORCE_HUNT)) {
+    if (IS_RANDO && OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_TRIFORCE_HUNT)) {
         ImGui::InputScalar("Triforce Pieces", ImGuiDataType_U16, &gSaveContext.triforcePiecesCollected);
         UIWidgets::InsertHelpHoverText("Currently obtained Triforce Pieces. For Triforce Hunt.");
     }

--- a/soh/soh/Enhancements/mods.cpp
+++ b/soh/soh/Enhancements/mods.cpp
@@ -998,7 +998,7 @@ void RegisterRandomizerSheikSpawn() {
         if (!gPlayState) return;
         bool canSheik = (OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_TRIAL_COUNT) != RO_GANONS_TRIALS_SKIP && 
           OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_LIGHT_ARROWS_HINT));
-        if (!gSaveContext.n64ddFlag || !LINK_IS_ADULT || !canSheik) return;
+        if (!IS_RANDO || !LINK_IS_ADULT || !canSheik) return;
         switch (gPlayState->sceneNum) {
             case SCENE_TEMPLE_OF_TIME:
                 if (gPlayState->roomCtx.curRoom.num == 1) {

--- a/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
@@ -497,7 +497,7 @@ void DrawItemCount(ItemTrackerItem item) {
         ImGui::PushStyleColor(ImGuiCol_Text, maxColor);
         ImGui::Text("%s", maxString.c_str());
         ImGui::PopStyleColor();
-    } else if (item.id == RG_TRIFORCE_PIECE && gSaveContext.n64ddFlag &&
+    } else if (item.id == RG_TRIFORCE_PIECE && IS_RANDO &&
                OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_TRIFORCE_HUNT) && IsValidSaveFile()) {
         std::string currentString = "";
         std::string requiredString = "";
@@ -606,7 +606,7 @@ void DrawItem(ItemTrackerItem item) {
             break;
         case RG_TRIFORCE_PIECE:
             actualItemId = item.id;
-            hasItem = gSaveContext.n64ddFlag && OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_TRIFORCE_HUNT);
+            hasItem = IS_RANDO && OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_TRIFORCE_HUNT);
             itemName = "Triforce Piece";
             break;
     }

--- a/soh/src/code/z_elf_message.c
+++ b/soh/src/code/z_elf_message.c
@@ -155,7 +155,7 @@ u16 ElfMessage_GetSariaText(PlayState* play) {
 
     if (!LINK_IS_ADULT) {
         if (Actor_FindNearby(play, &player->actor, ACTOR_EN_SA, 4, 800.0f) == NULL) {
-             if (gSaveContext.n64ddFlag && Randomizer_GetSettingValue(RSK_SARIA_HINT)) {
+             if (IS_RANDO && Randomizer_GetSettingValue(RSK_SARIA_HINT)) {
                 return 0x161;
             }
             msgs = sChildSariaMsgs;

--- a/soh/src/code/z_play.c
+++ b/soh/src/code/z_play.c
@@ -2319,7 +2319,8 @@ void Play_PerformSave(PlayState* play) {
             Save_SaveFile();
         }
         uint8_t triforceHuntCompleted =
-            gSaveContext.n64ddFlag && gSaveContext.triforcePiecesCollected == Randomizer_GetSettingValue(RSK_TRIFORCE_HUNT_PIECES_REQUIRED) &&
+            IS_RANDO &&
+            gSaveContext.triforcePiecesCollected == Randomizer_GetSettingValue(RSK_TRIFORCE_HUNT_PIECES_REQUIRED) &&
             Randomizer_GetSettingValue(RSK_TRIFORCE_HUNT);
         if (CVarGetInteger("gAutosave", AUTOSAVE_OFF) != AUTOSAVE_OFF || triforceHuntCompleted) {
             Overlay_DisplayText(3.0f, "Game Saved");

--- a/soh/src/overlays/actors/ovl_En_Gb/z_en_gb.c
+++ b/soh/src/overlays/actors/ovl_En_Gb/z_en_gb.c
@@ -338,8 +338,8 @@ void func_80A2FA50(EnGb* this, PlayState* play) {
         Rupees_ChangeBy(50);
         HIGH_SCORE(HS_POE_POINTS) += 100;
         if (
-            (!gSaveContext.n64ddFlag && HIGH_SCORE(HS_POE_POINTS) != 1000) ||
-            (gSaveContext.n64ddFlag && (HIGH_SCORE(HS_POE_POINTS) != 1000 || Flags_GetRandomizerInf(RAND_INF_10_BIG_POES)))
+            (!IS_RANDO && HIGH_SCORE(HS_POE_POINTS) != 1000) ||
+            (IS_RANDO && (HIGH_SCORE(HS_POE_POINTS) != 1000 || Flags_GetRandomizerInf(RAND_INF_10_BIG_POES)))
         ) {
             if (HIGH_SCORE(HS_POE_POINTS) > 1100) {
                 HIGH_SCORE(HS_POE_POINTS) = 1100;

--- a/soh/src/overlays/actors/ovl_En_Sa/z_en_sa.c
+++ b/soh/src/overlays/actors/ovl_En_Sa/z_en_sa.c
@@ -146,7 +146,7 @@ u16 func_80AF55E0(PlayState* play, Actor* thisx) {
     if (reaction != 0) {
         return reaction;
     }
-    if (gSaveContext.n64ddFlag && Randomizer_GetSettingValue(RSK_SARIA_HINT)) {
+    if (IS_RANDO && Randomizer_GetSettingValue(RSK_SARIA_HINT)) {
         return 0x10AD;
     }
     if (CHECK_QUEST_ITEM(QUEST_SONG_SARIA)) {

--- a/soh/src/overlays/actors/ovl_En_Xc/z_en_xc.c
+++ b/soh/src/overlays/actors/ovl_En_Xc/z_en_xc.c
@@ -425,7 +425,7 @@ void EnXc_RandoStand(EnXc* this, PlayState* play) {
     this->action = SHEIK_ACTION_BLOCK_PEDESTAL;
     this->drawMode = SHEIK_DRAW_DEFAULT;
     this->unk_30C = 1;
-    if (!gSaveContext.n64ddFlag) {
+    if (!IS_RANDO) {
         Actor_Kill(&this->actor);
     }
 }
@@ -2240,13 +2240,13 @@ void EnXc_SetupDialogueAction(EnXc* this, PlayState* play) {
         this->action = SHEIK_ACTION_IN_DIALOGUE;
     } else {
          this->actor.flags |= ACTOR_FLAG_TARGETABLE | ACTOR_FLAG_FRIENDLY;
-        if (gSaveContext.n64ddFlag && gPlayState->sceneNum == SCENE_TEMPLE_OF_TIME) {
+        if (IS_RANDO && gPlayState->sceneNum == SCENE_TEMPLE_OF_TIME) {
             if (!CHECK_DUNGEON_ITEM(DUNGEON_KEY_BOSS, SCENE_GANONS_TOWER)) {
                 this->actor.textId = TEXT_SHEIK_NEED_HOOK;
             } else {
-                this->actor.textId = TEXT_SHEIK_HAVE_HOOK;    
+                this->actor.textId = TEXT_SHEIK_HAVE_HOOK;
             }
-        } else if (gSaveContext.n64ddFlag && gPlayState->sceneNum == SCENE_INSIDE_GANONS_CASTLE) {
+        } else if (IS_RANDO && gPlayState->sceneNum == SCENE_INSIDE_GANONS_CASTLE) {
             if (CHECK_OWNED_EQUIP(EQUIP_SWORD, 1) && INV_CONTENT(ITEM_ARROW_LIGHT) == ITEM_ARROW_LIGHT &&
             CUR_CAPACITY(UPG_QUIVER) >= 30 && gSaveContext.isMagicAcquired) {
                 this->actor.textId = TEXT_SHEIK_HAVE_HOOK;

--- a/soh/src/overlays/actors/ovl_Fishing/z_fishing.c
+++ b/soh/src/overlays/actors/ovl_Fishing/z_fishing.c
@@ -5045,8 +5045,8 @@ void Fishing_HandleOwnerDialog(Fishing* this, PlayState* play) {
 
                     if (sLinkAge == 1) {
                         if (
-                            (!gSaveContext.n64ddFlag && !(HIGH_SCORE(HS_FISHING) & 0x400)) ||
-                            (gSaveContext.n64ddFlag && !Flags_GetRandomizerInf(RAND_INF_CHILD_FISHING))
+                            (!IS_RANDO && !(HIGH_SCORE(HS_FISHING) & 0x400)) ||
+                            (IS_RANDO && !Flags_GetRandomizerInf(RAND_INF_CHILD_FISHING))
                         ) {
                             if (D_80B7E078 >= Fishing_GetMinimumRequiredScore()) {
                                 HIGH_SCORE(HS_FISHING) |= 0x400;
@@ -5062,8 +5062,8 @@ void Fishing_HandleOwnerDialog(Fishing* this, PlayState* play) {
                         }
                     } else {
                         if (
-                            (!gSaveContext.n64ddFlag && !(HIGH_SCORE(HS_FISHING) & 0x800)) ||
-                            (gSaveContext.n64ddFlag && !Flags_GetRandomizerInf(RAND_INF_ADULT_FISHING))
+                            (!IS_RANDO && !(HIGH_SCORE(HS_FISHING) & 0x800)) ||
+                            (IS_RANDO && !Flags_GetRandomizerInf(RAND_INF_ADULT_FISHING))
                         ) {
                             if (D_80B7E078 >= Fishing_GetMinimumRequiredScore()) {
                                 HIGH_SCORE(HS_FISHING) |= 0x800;


### PR DESCRIPTION
A couple of `gSaveContext.n64ddflag` usage made their way in around the time the `IS_RANDO` merge happened. Converting those over to fix develop.

The only uses left are the expected authentic uses of n64ddflag in the save/file choose areas.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/955330128.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/955330131.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/955330134.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/955330135.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/955330136.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/955330137.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/955330138.zip)
<!--- section:artifacts:end -->