### PR TITLE
[Difficulty Options] All Dogs are Richard

### DIFF
--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -672,6 +672,8 @@ void DrawEnhancementsMenu() {
                 UIWidgets::PaddedEnhancementCheckbox("Always Win Dampe Digging Game", "gDampeWin", true, false, SaveManager::Instance->IsRandoFile(),
                                                         "This setting is always enabled in randomizer files", UIWidgets::CheckboxGraphics::Checkmark);
                 UIWidgets::Tooltip("Always win the heart piece/purple rupee on the first dig in Dampe's grave digging game, just like in rando\nIn a rando file, this is unconditionally enabled");
+                UIWidgets::PaddedEnhancementCheckbox("All Dogs are Richard", "gAllDogsRichard", true, false);
+                UIWidgets::Tooltip("All dogs can be traded in and will count as Richard.");
                 UIWidgets::Spacer(0);
 
                 if (ImGui::BeginMenu("Potion Values"))

--- a/soh/src/overlays/actors/ovl_En_Hy/z_en_hy.c
+++ b/soh/src/overlays/actors/ovl_En_Hy/z_en_hy.c
@@ -438,7 +438,7 @@ u16 func_80A6F810(PlayState* play, Actor* thisx) {
 
                 if (followingDog != 0) {
                     this->unk_215 = false;
-                    return ((followingDog == 1) || (CVarGetInteger("gAllDogsRichard", 0) && followingDog != 0)) ? 0x709F : 0x709E;
+                    return ((followingDog == 1) || (CVarGetInteger("gAllDogsRichard", 0))) ? 0x709F : 0x709E;
                 } else {
                     return 0x709D;
                 }

--- a/soh/src/overlays/actors/ovl_En_Hy/z_en_hy.c
+++ b/soh/src/overlays/actors/ovl_En_Hy/z_en_hy.c
@@ -438,7 +438,7 @@ u16 func_80A6F810(PlayState* play, Actor* thisx) {
 
                 if (followingDog != 0) {
                     this->unk_215 = false;
-                    return (followingDog == 1) ? 0x709F : 0x709E;
+                    return ((followingDog == 1) || (CVarGetInteger("gAllDogsRichard", 0) && followingDog != 0)) ? 0x709F : 0x709E;
                 } else {
                     return 0x709D;
                 }


### PR DESCRIPTION
Makes any of the dogs be able to be traded in and count as if they are Richard. Useful for newer players or players that just haven't played in a while and aren't sure which one is Richard.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/956269232.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/956269233.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/956269234.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/956269236.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/956269238.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/956269239.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/956269240.zip)
<!--- section:artifacts:end -->