### PR TITLE
[Rando] Cursed skulltula people instantly drop in house of skulltula

### DIFF
--- a/soh/src/overlays/actors/ovl_En_Ssh/z_en_ssh.c
+++ b/soh/src/overlays/actors/ovl_En_Ssh/z_en_ssh.c
@@ -353,6 +353,9 @@ s32 EnSsh_IsCloseToLink(EnSsh* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
     f32 yDist;
 
+    if (IS_RANDO) {
+        return true;
+    }
     if (this->stateFlags & SSH_STATE_GROUND_START) {
         return true;
     }


### PR DESCRIPTION
See #3156, this PR will make it so the cursed skulltula people instantly drop when entering in randomiser. Could be put behind a cvar too (in addition to rando) or require a cvar even in rando but wanted to hear opinions on that. I think that it should always be on in rando or at least default to being set in rando as it's a time saver and behaviour expected by those coming from n64

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/961011536.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/961011541.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/961011544.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/961011546.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/961011549.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/961011552.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/961011556.zip)
<!--- section:artifacts:end -->