### PR TITLE
[Debug] Add input field to modify current B button item in the Save Editor

### DIFF
--- a/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
+++ b/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
@@ -1694,6 +1694,10 @@ void DrawPlayerTab() {
         ImU16 one = 1;
         ImGui::PushItemWidth(ImGui::GetFontSize() * 6);
         DrawGroupWithBorder([&]() {
+            ImGui::Text("Current B Item");
+            ImGui::InputScalar("B Button", ImGuiDataType_U8, &gSaveContext.equips.buttonItems[0], &one, NULL);
+            ImGui::NewLine();
+
             ImGui::Text("Current C Equips");
             ImGui::InputScalar("C Left", ImGuiDataType_U8, &gSaveContext.equips.buttonItems[1], &one, NULL);
             ImGui::SameLine();


### PR DESCRIPTION
Wanted to get RBA to test out #2672 but realized I am very lazy and didn't want to learn bottle on B setups, so instead just added a field to edit the B button item in the debug save editor.

![image](https://github.com/HarbourMasters/Shipwright/assets/13861068/d419c68d-42ea-426b-91dc-5cd6865813f6)


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/964909977.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/964909978.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/964909980.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/964909981.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/964909982.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/964909983.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/964909984.zip)
<!--- section:artifacts:end -->