### PR TITLE
Add no rando generated warning

### DIFF
--- a/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -3195,7 +3195,7 @@ static const char* noRandoGeneratedText[] = {
     ",\nor drop a spoiler log on the game window.",
 #endif
     // French
-    "Aucune Seed de Randomizer actuellement disponoble.\nGénérez-en une dans les \"Randomizer Settings\""
+    "Aucune Seed de Randomizer actuellement disponible.\nGénérez-en une dans les \"Randomizer Settings\""
 #if (defined(__WIIU__) || defined(__SWITCH__))
     "."
 #else

--- a/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -3181,11 +3181,19 @@ void FileChoose_DrawRandoSaveVersionWarning(GameState* thisx) {
 
 static const char* noRandoGeneratedText[] = {
     // English
-    "No randomizer generated.\nGenerate one in the randomizer menu.",
+    "No Randomizer seed currently available.\nGenerate one in the Randomizer Settings"
+    #if defined(__WIIU__) || defined(__SWITCH__)
+        ".",
+    #else
+        ",\nor drop a spoiler log on the game window.",
+    #endif
     // German
     "!!!",
     // French
-    "!!!"
+    "Aucune Seed de Randomizer actuellement disponoble.\nGénérez-en une dans les \"Randomizer Settings\""
+    #if !(defined(__WIIU__) || defined(__SWITCH__))
+        "\nou glissez un spoiler log sur la fenêtre du jeu"
+    #endif
 };
 
 void FileChoose_DrawNoRandoGeneratedWarning(GameState* thisx) {
@@ -3198,7 +3206,11 @@ void FileChoose_DrawNoRandoGeneratedWarning(GameState* thisx) {
         u8 textAlpha = 225;
 
         // Compute the height for a "squished" textbox texture
-        s16 height = gSaveContext.language == LANGUAGE_ENG ? 32 : 40; // English is only 2 lines
+        #if defined(__WIIU__) || defined(__SWITCH__)
+            s16 height = 32;// 2 lines
+        #else
+            s16 height = 40;// 3 lines
+        #endif
         // float math to get a S5.10 number that will squish the texture
         f32 texCoordinateHeightF = 512 / ((f32)height / 64);
         s16 texCoordinateHeightScale = texCoordinateHeightF + 0.5f;

--- a/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -3182,18 +3182,25 @@ void FileChoose_DrawRandoSaveVersionWarning(GameState* thisx) {
 static const char* noRandoGeneratedText[] = {
     // English
     "No Randomizer seed currently available.\nGenerate one in the Randomizer Settings"
-    #if defined(__WIIU__) || defined(__SWITCH__)
-        ".",
-    #else
-        ",\nor drop a spoiler log on the game window.",
-    #endif
+#if defined(__WIIU__) || defined(__SWITCH__)
+    ".",
+#else
+    ",\nor drop a spoiler log on the game window.",
+#endif
     // German
-    "!!!",
+    "No Randomizer seed currently available.\nGenerate one in the Randomizer Settings"
+#if defined(__WIIU__) || defined(__SWITCH__)
+    ".",
+#else
+    ",\nor drop a spoiler log on the game window.",
+#endif
     // French
     "Aucune Seed de Randomizer actuellement disponoble.\nGénérez-en une dans les \"Randomizer Settings\""
-    #if !(defined(__WIIU__) || defined(__SWITCH__))
-        "\nou glissez un spoiler log sur la fenêtre du jeu"
-    #endif
+#if (defined(__WIIU__) || defined(__SWITCH__))
+    "."
+#else
+    "\nou glissez un spoilerlog sur la fenêtre du jeu."
+#endif
 };
 
 void FileChoose_DrawNoRandoGeneratedWarning(GameState* thisx) {
@@ -3203,33 +3210,41 @@ void FileChoose_DrawNoRandoGeneratedWarning(GameState* thisx) {
 
     // Draw rando seed warning when build version doesn't match for Major or Minor number
     if (this->configMode == CM_QUEST_MENU && this->questType[this->buttonIndex] == QUEST_RANDOMIZER && !hasRandomizerQuest()) {
-        u8 textAlpha = 225;
+        uint8_t textAlpha = 225;
+        uint8_t textboxAlpha = 170;
+        float textboxScale = 0.7f;
 
-        // Compute the height for a "squished" textbox texture
-        #if defined(__WIIU__) || defined(__SWITCH__)
-            s16 height = 32;// 2 lines
-        #else
-            s16 height = 40;// 3 lines
-        #endif
         // float math to get a S5.10 number that will squish the texture
-        f32 texCoordinateHeightF = 512 / ((f32)height / 64);
-        s16 texCoordinateHeightScale = texCoordinateHeightF + 0.5f;
-        s16 bottomOffset = 4;
+        float texCoordinateHeightF = 512 / textboxScale;
+        uint16_t texCoordinateHeightScale = texCoordinateHeightF + 0.5f;
+        float texCoordinateWidthF = 512 / textboxScale;
+        uint16_t texCoordinateWidthScale = texCoordinateWidthF + 0.5f;
+        uint16_t textboxWidth = 256 * textboxScale;
+        uint16_t textboxHeight = 64 * textboxScale;
+        uint8_t leftOffset = 72;
+        uint8_t bottomOffset = 84;
+        uint8_t textVerticalOffset;
+#if defined(__WIIU__) || defined(__SWITCH__)
+        textVerticalOffset = 127; // 2 lines
+#else
+        textVerticalOffset = 122; // 3 lines
+#endif
 
         Gfx_SetupDL_39Opa(this->state.gfxCtx);
         gDPSetAlphaDither(POLY_OPA_DISP++, G_AD_DISABLE);
         gSPClearGeometryMode(POLY_OPA_DISP++, G_SHADE);
         gDPSetCombineLERP(POLY_OPA_DISP++, 0, 0, 0, PRIMITIVE, TEXEL0, 0, PRIMITIVE, 0, 0, 0, 0, PRIMITIVE, TEXEL0,
                           0, PRIMITIVE, 0);
-        gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 0, 0, 0, textAlpha);
+        gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 0, 0, 0, textboxAlpha);
         gDPLoadTextureBlock_4b(POLY_OPA_DISP++, gDefaultMessageBackgroundTex, G_IM_FMT_I, 128, 64, 0, G_TX_MIRROR,
                                G_TX_MIRROR, 7, 0, G_TX_NOLOD, G_TX_NOLOD);
-        gSPTextureRectangle(POLY_OPA_DISP++, 32 << 2, (SCREEN_HEIGHT - height - bottomOffset) << 2,
-                            (SCREEN_WIDTH - 32) << 2, (SCREEN_HEIGHT - bottomOffset) << 2, G_TX_RENDERTILE, 0, 0,
-                            1 << 10, texCoordinateHeightScale << 1);
 
-        Interface_DrawTextLine(this->state.gfxCtx, noRandoGeneratedText[gSaveContext.language], 36,
-                               SCREEN_HEIGHT - height, 255, 255, 255, textAlpha, 0.8f, 1);
+        gSPTextureRectangle(POLY_OPA_DISP++, leftOffset << 2, (SCREEN_HEIGHT - bottomOffset - textboxHeight) << 2,
+                            (textboxWidth + leftOffset) << 2, (SCREEN_HEIGHT - bottomOffset) << 2, G_TX_RENDERTILE, 0, 0,
+                            texCoordinateWidthScale << 1, texCoordinateHeightScale << 1);
+
+        Interface_DrawTextLine(this->state.gfxCtx, noRandoGeneratedText[gSaveContext.language], 80, textVerticalOffset,
+                               255, 255, 255, textAlpha, 0.6f, 1);
     }
     
     CLOSE_DISPS(this->state.gfxCtx);


### PR DESCRIPTION
This PR adds a warning when trying to select randomizer in the quest menu instead of skipping it when there's no loaded spoiler log. Uses the same format as the save version warning.

https://github.com/HarbourMasters/Shipwright/assets/72659707/b980ea72-d553-441d-823c-2fb0bae5f2bd

Needs french and german translations.


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/989443298.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/989443299.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/989443301.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/989443306.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/989443309.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/989443311.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/989443314.zip)
<!--- section:artifacts:end -->