### PR TITLE
typo on asset attribute for pal1.1

### DIFF
--- a/soh/assets/xml/N64_PAL_11/overlays/ovl_Boss_Ganon.xml
+++ b/soh/assets/xml/N64_PAL_11/overlays/ovl_Boss_Ganon.xml
@@ -1,7 +1,7 @@
 <Root>
     <File Name="ovl_Boss_Ganon" BaseAddress="0x809F2C80" RangeStart="0xE388" RangeEnd="0x211D8">
         <Texture Name="ovl_Boss_GanonTex_00E748" OutName="ovl_Boss_GanonTex_00E748" Format="i8" Width="64" Height="64" Offset="0xE418" AddedByScript="true"/>
-        <Texture Name="ovl_Boss_GanonTex_00F848" OutName="ovl_Boss_GanonTex_00F848" Format="ci8" Width="32" Height="32" Offset="0xF518" TluOffset="0xF4D8" AddedByScript="true"/>
+        <Texture Name="ovl_Boss_GanonTex_00F848" OutName="ovl_Boss_GanonTex_00F848" Format="ci8" Width="32" Height="32" Offset="0xF518" TlutOffset="0xF4D8" AddedByScript="true"/>
         <Texture Name="ovl_Boss_GanonTex_010538" OutName="ovl_Boss_GanonTex_010538" Format="i8" Width="64" Height="64" Offset="0x10208" AddedByScript="true"/>
         <Texture Name="ovl_Boss_GanonTex_01A7B0" OutName="ovl_Boss_GanonTex_01A7B0" Format="ia16" Width="32" Height="32" Offset="0x1A480" AddedByScript="true"/>
         <Texture Name="ovl_Boss_GanonTex_01AFB0" OutName="ovl_Boss_GanonTex_01AFB0" Format="i4" Width="64" Height="64" Offset="0x1AC80" AddedByScript="true"/>

--- a/soh/assets/xml/N64_PAL_11/overlays/ovl_Oceff_Spot.xml
+++ b/soh/assets/xml/N64_PAL_11/overlays/ovl_Oceff_Spot.xml
@@ -1,5 +1,5 @@
 <Root>
-    <File Name="ovl_Oceff_Spot" BaseAddress="0x80BA6070" RangeStart="0x780" RangeEnd="0xE58">
+    <File Name="ovl_Oceff_Spot" BaseAddress="0x80B1AA20" RangeStart="0x780" RangeEnd="0xE58">
         <Texture Name="sTex" OutName="sun_song_effect" Format="i8" Width="32" Height="32" Offset="0x780"/>
         <Array Name="sCylinderVtx" Count="27" Offset="0xB80">
             <Vtx/>


### PR DESCRIPTION
This was one of like 5 assets that needed the tlutoffset manually applied because the script/zapd process wasn't smart enough to do it. This was breaking extraction for PAL1.1 due to "unexpected attribute found".

silly typo on my part 🥖 

Also a fix for sun song overlay base address

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/967367898.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/967367899.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/967367900.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/967367901.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/967367902.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/967367903.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/967367904.zip)
<!--- section:artifacts:end -->