### PR TITLE
Add `OnCollectCheck` hook.

### DIFF
--- a/soh/include/z64actor.h
+++ b/soh/include/z64actor.h
@@ -7,6 +7,7 @@
 #include "z64collision_check.h"
 #include "z64bgcheck.h"
 #include "soh/Enhancements/item-tables/ItemTableTypes.h"
+#include "soh/Enhancements/randomizer/randomizerTypes.h"
 
 #define ACTOR_NUMBER_MAX 2000
 #define INVISIBLE_ACTOR_MAX 20
@@ -284,6 +285,7 @@ typedef struct EnItem00 {
     /* 0x160 */ ColliderCylinder collider;
     s16 ogParams;
     GetItemEntry randoGiEntry;
+    RandomizerCheck randoCheck;
 } EnItem00; // size = 0x1AC
 
 // Only A_OBJ_SIGNPOST_OBLONG and A_OBJ_SIGNPOST_ARROW are used in room files.

--- a/soh/include/z64player.h
+++ b/soh/include/z64player.h
@@ -684,6 +684,8 @@ typedef struct Player {
     // #endregion
     u8 ivanFloating;
     u8 ivanDamageMultiplier;
+    RandomizerCheck getItemCheck;
+    RandomizerCheck rangeCheck;
 } Player; // size = 0xA94
 
 #endif

--- a/soh/soh/Enhancements/game-interactor/GameInteractor.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor.h
@@ -5,6 +5,7 @@
 
 #include "GameInteractionEffect.h"
 #include "soh/Enhancements/item-tables/ItemTableTypes.h"
+#include "soh/Enhancements/randomizer/randomizerTypes.h"
 
 typedef enum {
     /* 0x00 */ GI_LINK_SIZE_NORMAL,
@@ -85,6 +86,7 @@ uint8_t GameInteractor_GetSlipperyFloorActive();
 uint8_t GameInteractor_SecondCollisionUpdate();
 void GameInteractor_SetTriforceHuntPieceGiven(uint8_t state);
 void GameInteractor_SetTriforceHuntCreditsWarpActive(uint8_t state);
+bool GameInteractor_IsSaveLoaded();
 #ifdef __cplusplus
 }
 #endif
@@ -149,6 +151,7 @@ public:
     DEFINE_HOOK(OnExitGame, void(int32_t fileNum));
     DEFINE_HOOK(OnGameFrameUpdate, void());
     DEFINE_HOOK(OnItemReceive, void(GetItemEntry itemEntry));
+    DEFINE_HOOK(OnCollectCheck, void(RandomizerCheck check));
     DEFINE_HOOK(OnSaleEnd, void(GetItemEntry itemEntry));
     DEFINE_HOOK(OnTransitionEnd, void(int16_t sceneNum));
     DEFINE_HOOK(OnSceneInit, void(int16_t sceneNum));

--- a/soh/soh/Enhancements/game-interactor/GameInteractor_Hooks.cpp
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor_Hooks.cpp
@@ -18,6 +18,10 @@ void GameInteractor_ExecuteOnItemReceiveHooks(GetItemEntry itemEntry) {
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnItemReceive>(itemEntry);
 }
 
+void GameInteractor_ExecuteOnCollectCheckHooks(RandomizerCheck check) {
+    GameInteractor::Instance->ExecuteHooks<GameInteractor::OnCollectCheck>(check);
+}
+
 void GameInteractor_ExecuteOnSaleEndHooks(GetItemEntry itemEntry) {
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnSaleEnd>(itemEntry);
 }

--- a/soh/soh/Enhancements/game-interactor/GameInteractor_Hooks.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor_Hooks.h
@@ -8,6 +8,7 @@ void GameInteractor_ExecuteOnLoadGame(int32_t fileNum);
 void GameInteractor_ExecuteOnExitGame(int32_t fileNum);
 void GameInteractor_ExecuteOnGameFrameUpdate();
 void GameInteractor_ExecuteOnItemReceiveHooks(GetItemEntry itemEntry);
+void GameInteractor_ExecuteOnCollectCheckHooks(RandomizerCheck check);
 void GameInteractor_ExecuteOnSaleEndHooks(GetItemEntry itemEntry);
 void GameInteractor_ExecuteOnTransitionEndHooks(int16_t sceneNum);
 void GameInteractor_ExecuteOnSceneInit(int16_t sceneNum);

--- a/soh/soh/Enhancements/game-interactor/GameInteractor_State.cpp
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor_State.cpp
@@ -139,3 +139,7 @@ void GameInteractor_SetTriforceHuntPieceGiven(uint8_t state) {
 void GameInteractor_SetTriforceHuntCreditsWarpActive(uint8_t state) {
     GameInteractor::State::TriforceHuntCreditsWarpActive = state;
 }
+
+bool GameInteractor_IsSaveLoaded() {
+    return GameInteractor::IsSaveLoaded();
+}

--- a/soh/src/code/z_actor.c
+++ b/soh/src/code/z_actor.c
@@ -2037,6 +2037,8 @@ s32 GiveItemEntryFromActor(Actor* actor, PlayState* play, GetItemEntry getItemEn
                     player->getItemId = getItemEntry.getItemId;
                     player->interactRangeActor = actor;
                     player->getItemDirection = absYawDiff;
+                    player->getItemCheck = player->rangeCheck;
+                    player->rangeCheck = RC_MAX;
                     return true;
                 }
             }

--- a/soh/src/code/z_en_item00.c
+++ b/soh/src/code/z_en_item00.c
@@ -489,9 +489,9 @@ void EnItem00_Init(Actor* thisx, PlayState* play) {
         Randomizer_GetCheckFromActor(this->actor.id, play->sceneNum, this->ogParams);
 
     if (IS_RANDO && randoCheck != RC_UNKNOWN_CHECK) {
-        this->randoGiEntry =
-            Randomizer_GetItemFromKnownCheck(randoCheck, getItemId);
+        this->randoGiEntry = Randomizer_GetItemFromKnownCheck(randoCheck, getItemId);
         this->randoGiEntry.getItemFrom = ITEM_FROM_FREESTANDING;
+        this->randoCheck = randoCheck;
     }
 
     if (!spawnParam8000) {
@@ -581,6 +581,7 @@ void EnItem00_Init(Actor* thisx, PlayState* play) {
             if (!IS_RANDO || this->randoGiEntry.getItemId == GI_NONE) {
                 func_8002F554(&this->actor, play, getItemId);
             } else {
+                GET_PLAYER(play)->rangeCheck = this->randoCheck;
                 GiveItemEntryFromActorWithFixedRange(&this->actor, play, this->randoGiEntry);
             }
         }
@@ -955,6 +956,7 @@ void EnItem00_Update(Actor* thisx, PlayState* play) {
             func_8002F554(&this->actor, play, getItemId);
         } else {
             getItemId = this->randoGiEntry.getItemId;
+            GET_PLAYER(play)->rangeCheck = this->randoCheck;
             GiveItemEntryFromActorWithFixedRange(&this->actor, play, this->randoGiEntry);
         }
     }
@@ -1367,8 +1369,7 @@ void EnItem00_DrawCollectible(EnItem00* this, PlayState* play) {
             Randomizer_GetCheckFromActor(this->actor.id, play->sceneNum, this->ogParams);
 
         if (randoCheck != RC_UNKNOWN_CHECK) {
-            this->randoGiEntry =
-                Randomizer_GetItemFromKnownCheck(randoCheck, GI_NONE);
+            this->randoGiEntry = Randomizer_GetItemFromKnownCheck(randoCheck, GI_NONE);
             this->randoGiEntry.getItemFrom = ITEM_FROM_FREESTANDING;
         }
         

--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -1766,6 +1766,10 @@ u8 Item_Give(PlayState* play, u8 item) {
     s16 temp;
 
     GetItemID returnItem = ITEM_NONE;
+    if (GameInteractor_IsSaveLoaded() && GET_PLAYER(play)->getItemCheck != RC_MAX && GET_PLAYER(play)->getItemCheck != RC_UNKNOWN_CHECK) {
+        GameInteractor_ExecuteOnCollectCheckHooks(GET_PLAYER(play)->getItemCheck);
+        GET_PLAYER(play)->getItemCheck = RC_MAX;
+    }
 
     // Gameplay stats: Update the time the item was obtained
     GameplayStats_SetTimestamp(play, item);
@@ -2322,8 +2326,11 @@ u16 Randomizer_Item_Give(PlayState* play, GetItemEntry giEntry) {
     uint16_t i;
     uint16_t slot;
 
-    // Gameplay stats: Update the time the item was obtained
-    Randomizer_GameplayStats_SetTimestamp(item);
+    GetItemID returnItem = ITEM_NONE;
+    if (GameInteractor_IsSaveLoaded() && GET_PLAYER(play)->getItemCheck != RC_MAX && GET_PLAYER(play)->getItemCheck != RC_UNKNOWN_CHECK) {
+        GameInteractor_ExecuteOnCollectCheckHooks(GET_PLAYER(play)->getItemCheck);
+        GET_PLAYER(play)->getItemCheck = RC_MAX;
+    }
 
     slot = SLOT(item);
     if (item == RG_MAGIC_SINGLE) {

--- a/soh/src/code/z_play.c
+++ b/soh/src/code/z_play.c
@@ -229,6 +229,7 @@ void GivePlayerRandoRewardSongOfTime(PlayState* play, RandomizerCheck check) {
     if (gSaveContext.entranceIndex == 0x050F && player != NULL && !Player_InBlockingCsMode(play, player) &&
         !Flags_GetTreasure(play, 0x1F) && gSaveContext.nextTransitionType == 0xFF && !gSaveContext.pendingIceTrapCount) {
         GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(check, RG_SONG_OF_TIME);
+        GET_PLAYER(play)->getItemCheck = check; // for OnCollectCheck
         GiveItemEntryWithoutActor(play, getItemEntry);
         player->pendingFlag.flagID = 0x1F;
         player->pendingFlag.flagType = FLAG_SCENE_TREASURE;
@@ -244,6 +245,7 @@ void GivePlayerRandoRewardNocturne(PlayState* play, RandomizerCheck check) {
         CHECK_QUEST_ITEM(QUEST_MEDALLION_FIRE) && CHECK_QUEST_ITEM(QUEST_MEDALLION_WATER) && player != NULL &&
         !Player_InBlockingCsMode(play, player) && !Flags_GetEventChkInf(EVENTCHKINF_BONGO_BONGO_ESCAPED_FROM_WELL)) {
         GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(check, RG_NOCTURNE_OF_SHADOW);
+        GET_PLAYER(play)->getItemCheck = check; // for OnCollectCheck
         GiveItemEntryWithoutActor(play, getItemEntry);
         player->pendingFlag.flagID = 0xAA;
         player->pendingFlag.flagType = FLAG_EVENT_CHECK_INF;
@@ -257,6 +259,7 @@ void GivePlayerRandoRewardRequiem(PlayState* play, RandomizerCheck check) {
         if ((gSaveContext.entranceIndex == 0x01E1) && !Flags_GetEventChkInf(EVENTCHKINF_LEARNED_REQUIEM_OF_SPIRIT) && player != NULL &&
             !Player_InBlockingCsMode(play, player)) {
             GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(check, RG_SONG_OF_TIME);
+            GET_PLAYER(play)->getItemCheck = check; // for OnCollectCheck
             GiveItemEntryWithoutActor(play, getItemEntry);
             player->pendingFlag.flagID = 0xAC;
             player->pendingFlag.flagType = FLAG_EVENT_CHECK_INF;
@@ -429,6 +432,7 @@ void GivePlayerRandoRewardZeldaLightArrowsGift(PlayState* play, RandomizerCheck 
         !Flags_GetTreasure(play, 0x1E) && player != NULL && !Player_InBlockingCsMode(play, player) &&
         play->sceneLoadFlag == 0) {
         GetItemEntry getItem = Randomizer_GetItemFromKnownCheck(check, GI_ARROW_LIGHT);
+        GET_PLAYER(play)->getItemCheck = check; // for OnCollectCheck
         if (GiveItemEntryWithoutActor(play, getItem)) {
             player->pendingFlag.flagID = 0x1E;
             player->pendingFlag.flagType = FLAG_SCENE_TREASURE;
@@ -442,6 +446,7 @@ void GivePlayerRandoRewardSariaGift(PlayState* play, RandomizerCheck check) {
         GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(check, RG_ZELDAS_LULLABY);
 
         if (!Flags_GetEventChkInf(EVENTCHKINF_SPOKE_TO_SARIA_ON_BRIDGE) && player != NULL && !Player_InBlockingCsMode(play, player)) {
+            GET_PLAYER(play)->getItemCheck = check; // for OnCollectCheck
             GiveItemEntryWithoutActor(play, getItemEntry);
             player->pendingFlag.flagType = FLAG_EVENT_CHECK_INF;
             player->pendingFlag.flagID = 0xC1;

--- a/soh/src/overlays/actors/ovl_Bg_Dy_Yoseizo/z_bg_dy_yoseizo.c
+++ b/soh/src/overlays/actors/ovl_Bg_Dy_Yoseizo/z_bg_dy_yoseizo.c
@@ -70,13 +70,15 @@ const ActorInit Bg_Dy_Yoseizo_InitVars = {
 
 void GivePlayerRandoRewardGreatFairy(BgDyYoseizo* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
-    GetItemEntry getItemEntry = Randomizer_GetItemFromActor(this->actor.id, play->sceneNum, this->fountainType + 1, GI_NONE);
+    RandomizerCheck check = Randomizer_GetCheckFromActor(this->actor.id, play->sceneNum, this->fountainType + 1);
+    GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(check, GI_NONE);
 
     if (this->actor.parent == GET_PLAYER(play) && !Flags_GetTreasure(play, this->fountainType + 1) &&
         !Player_InBlockingCsMode(play, GET_PLAYER(play))) {
         Flags_SetTreasure(play, this->fountainType + 1);
         Actor_Kill(&this->actor);
     } else if (!Flags_GetTreasure(play, this->fountainType + 1)) {
+        GET_PLAYER(play)->rangeCheck = check; // for OnCollectCheck
         GiveItemEntryFromActor(&this->actor, play, getItemEntry, 10000.0f, 100.0f);
     }
 }

--- a/soh/src/overlays/actors/ovl_Demo_Im/z_demo_im.c
+++ b/soh/src/overlays/actors/ovl_Demo_Im/z_demo_im.c
@@ -910,6 +910,7 @@ void GivePlayerRandoRewardImpa(Actor* impa, PlayState* play, RandomizerCheck che
         !Flags_GetTreasure(play, 0x1F)) {
         Flags_SetTreasure(play, 0x1F);
     } else if (!Flags_GetTreasure(play, 0x1F) && !Randomizer_GetSettingValue(RSK_SKIP_CHILD_ZELDA)) {
+        GET_PLAYER(play)->rangeCheck = check; // for OnCollectCheck
         GiveItemEntryFromActor(impa, play, getItemEntry, 75.0f, 50.0f);
     } else if (!Player_InBlockingCsMode(play, GET_PLAYER(play))) {
         Flags_SetEventChkInf(EVENTCHKINF_LEARNED_ZELDAS_LULLABY);

--- a/soh/src/overlays/actors/ovl_Door_Warp1/z_door_warp1.c
+++ b/soh/src/overlays/actors/ovl_Door_Warp1/z_door_warp1.c
@@ -488,12 +488,14 @@ s32 DoorWarp1_PlayerInRange(DoorWarp1* this, PlayState* play) {
 }
 
 void GivePlayerRandoReward(DoorWarp1* this, Player* player, PlayState* play, u8 ruto, u8 adult) {
-    GetItemEntry getItemEntry = Randomizer_GetItemFromActor(this->actor.id, play->sceneNum, 0x00, GI_NONE);
+    RandomizerCheck check = Randomizer_GetCheckFromActor(this->actor.id, play->sceneNum, 0x00);
+    GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(check, GI_NONE);
 
     if (this->actor.parent != NULL && this->actor.parent->id == GET_PLAYER(play)->actor.id &&
         !Flags_GetTreasure(play, 0x1F)) {
         Flags_SetTreasure(play, 0x1F);
     } else if (!Flags_GetTreasure(play, 0x1F)) {
+        GET_PLAYER(play)->rangeCheck = check; // for OnCollectCheck
         GiveItemEntryFromActor(&this->actor, play, getItemEntry, 10000.0f, 100.0f);
     } else if (!Player_InBlockingCsMode(play, GET_PLAYER(play))) {
         if (adult) {

--- a/soh/src/overlays/actors/ovl_En_Ani/z_en_ani.c
+++ b/soh/src/overlays/actors/ovl_En_Ani/z_en_ani.c
@@ -132,6 +132,7 @@ void func_809B0558(EnAni* this, PlayState* play) {
             func_8002F434(&this->actor, play, GI_HEART_PIECE, 10000.0f, 200.0f);
         } else {
             GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(RC_KAK_MAN_ON_ROOF, GI_HEART_PIECE);
+            GET_PLAYER(play)->rangeCheck = RC_KAK_MAN_ON_ROOF; // for OnCollectCheck
             GiveItemEntryFromActor(&this->actor, play, getItemEntry, 10000.0f, 200.0f);
         }
     }
@@ -146,6 +147,7 @@ void func_809B05F0(EnAni* this, PlayState* play) {
         func_8002F434(&this->actor, play, GI_HEART_PIECE, 10000.0f, 200.0f);
     } else {
         GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(RC_KAK_MAN_ON_ROOF, GI_HEART_PIECE);
+        GET_PLAYER(play)->rangeCheck = RC_KAK_MAN_ON_ROOF; // for OnCollectCheck
         GiveItemEntryFromActor(&this->actor, play, getItemEntry, 10000.0f, 200.0f);
     }
 }

--- a/soh/src/overlays/actors/ovl_En_Bom_Bowl_Pit/z_en_bom_bowl_pit.c
+++ b/soh/src/overlays/actors/ovl_En_Bom_Bowl_Pit/z_en_bom_bowl_pit.c
@@ -183,17 +183,22 @@ void EnBomBowlPit_GivePrize(EnBomBowlPit* this, PlayState* play) {
         this->getItemId = GI_BOMB_BAG_40;
     }
 
+    RandomizerCheck check = RC_MAX; // for OnCollectCheck
+
     if (IS_RANDO) {
         switch (this->prizeIndex) {
             case EXITEM_BOMB_BAG_BOWLING:
+                check = RC_MARKET_BOMBCHU_BOWLING_FIRST_PRIZE; // for OnCollectCheck
                 this->getItemEntry = Randomizer_GetItemFromKnownCheck(RC_MARKET_BOMBCHU_BOWLING_FIRST_PRIZE, GI_BOMB_BAG_20);
                 this->getItemId = this->getItemEntry.getItemId;
                 break;
             case EXITEM_HEART_PIECE_BOWLING:
+                check = RC_MARKET_BOMBCHU_BOWLING_SECOND_PRIZE; // for OnCollectCheck
                 this->getItemEntry = Randomizer_GetItemFromKnownCheck(RC_MARKET_BOMBCHU_BOWLING_SECOND_PRIZE, GI_HEART_PIECE);
                 this->getItemId = this->getItemEntry.getItemId;
                 break;
             case EXITEM_BOMBCHUS_BOWLING:
+                check = RC_MARKET_BOMBCHU_BOWLING_BOMBCHUS; // for OnCollectCheck
                 this->getItemEntry = Randomizer_GetItemFromKnownCheck(RC_MARKET_BOMBCHU_BOWLING_BOMBCHUS, GI_BOMBCHUS_10);
                 this->getItemId = this->getItemEntry.getItemId;
                 break;
@@ -205,6 +210,9 @@ void EnBomBowlPit_GivePrize(EnBomBowlPit* this, PlayState* play) {
     if (!IS_RANDO || this->getItemEntry.getItemId == GI_NONE) {
         func_8002F434(&this->actor, play, this->getItemId, 2000.0f, 1000.0f);
     } else {
+        if (check != RC_MAX) {
+            GET_PLAYER(play)->rangeCheck = check; // for OnCollectCheck
+        }
         GiveItemEntryFromActor(&this->actor, play, this->getItemEntry, 2000.0f, 1000.0f);
     }
     player->stateFlags1 |= 0x20000000;

--- a/soh/src/overlays/actors/ovl_En_Box/z_en_box.c
+++ b/soh/src/overlays/actors/ovl_En_Box/z_en_box.c
@@ -509,6 +509,7 @@ void EnBox_WaitOpen(EnBox* this, PlayState* play) {
             if (IS_RANDO) {
                 sItem.getItemId = 0 - sItem.getItemId;
                 sItem.getItemFrom = ITEM_FROM_CHEST;
+                GET_PLAYER(play)->rangeCheck = Randomizer_GetCheckFromActor(this->dyna.actor.id, play->sceneNum, this->dyna.actor.params); // for OnCollectCheck
                 GiveItemEntryFromActorWithFixedRange(&this->dyna.actor, play, sItem);
             } else {
                 func_8002F554(&this->dyna.actor, play, -(this->dyna.actor.params >> 5 & 0x7F));

--- a/soh/src/overlays/actors/ovl_En_Cow/z_en_cow.c
+++ b/soh/src/overlays/actors/ovl_En_Cow/z_en_cow.c
@@ -290,6 +290,7 @@ void EnCow_GivePlayerRandomizedItem(EnCow* this, PlayState* play) {
     if (!EnCow_HasBeenMilked(this, play)) {
         CowIdentity cowIdentity = Randomizer_IdentifyCow(play->sceneNum, this->actor.world.pos.x, this->actor.world.pos.z);
         GetItemEntry itemEntry = Randomizer_GetItemFromKnownCheck(cowIdentity.randomizerCheck, GI_MILK);
+        GET_PLAYER(play)->rangeCheck = cowIdentity.randomizerCheck; // for OnCollectCheck
         GiveItemEntryFromActor(&this->actor, play, itemEntry, 10000.0f, 100.0f);
     } else {
         // once we've gotten the rando reward from the cow,

--- a/soh/src/overlays/actors/ovl_En_Diving_Game/z_en_diving_game.c
+++ b/soh/src/overlays/actors/ovl_En_Diving_Game/z_en_diving_game.c
@@ -459,6 +459,7 @@ void func_809EEA00(EnDivingGame* this, PlayState* play) {
             func_8002F434(&this->actor, play, GI_SCALE_SILVER, 90.0f, 10.0f);
         } else {
             GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(RC_ZD_DIVING_MINIGAME, GI_SCALE_SILVER);
+            GET_PLAYER(play)->rangeCheck = RC_ZD_DIVING_MINIGAME; // for OnCollectCheck
             GiveItemEntryFromActor(&this->actor, play, getItemEntry, 90.0f, 10.0f);
         }
         this->actionFunc = func_809EEA90;
@@ -474,6 +475,7 @@ void func_809EEA90(EnDivingGame* this, PlayState* play) {
             func_8002F434(&this->actor, play, GI_SCALE_SILVER, 90.0f, 10.0f);
         } else {
             GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(RC_ZD_DIVING_MINIGAME, GI_SCALE_SILVER);
+            GET_PLAYER(play)->rangeCheck = RC_ZD_DIVING_MINIGAME; // for OnCollectCheck
             GiveItemEntryFromActor(&this->actor, play, getItemEntry, 90.0f, 10.0f);
         }
     }

--- a/soh/src/overlays/actors/ovl_En_Dns/z_en_dns.c
+++ b/soh/src/overlays/actors/ovl_En_Dns/z_en_dns.c
@@ -435,7 +435,8 @@ void func_809EFDD0(EnDns* this, PlayState* play) {
     } else {
         GetItemEntry itemEntry = Randomizer_GetItemFromKnownCheck(this->scrubIdentity.randomizerCheck, this->scrubIdentity.getItemId);
         gSaveContext.pendingSale = itemEntry.itemId;
-        gSaveContext.pendingSaleMod = itemEntry.modIndex;
+        gSaveContext.pendingSaleMod = itemEntry.modIndex; // for OnCollectCheck
+        GET_PLAYER(play)->rangeCheck = this->scrubIdentity.randomizerCheck;
         GiveItemEntryFromActor(&this->actor, play, itemEntry, 130.0f, 100.0f);
     }
 }

--- a/soh/src/overlays/actors/ovl_En_Dnt_Demo/z_en_dnt_demo.c
+++ b/soh/src/overlays/actors/ovl_En_Dnt_Demo/z_en_dnt_demo.c
@@ -141,6 +141,7 @@ void EnDntDemo_Judge(EnDntDemo* this, PlayState* play) {
                 case PLAYER_MASK_SKULL:
                     if (!Flags_GetTreasure(play, 0x1F) && !Player_InBlockingCsMode(play, player)) {
                         GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(RC_DEKU_THEATER_SKULL_MASK, GI_STICK_UPGRADE_30);
+                        GET_PLAYER(play)->getItemCheck = RC_DEKU_THEATER_SKULL_MASK; // for OnCollectCheck
                         GiveItemEntryWithoutActor(play, getItemEntry);
                         player->pendingFlag.flagID = 0x1F;
                         player->pendingFlag.flagType = FLAG_SCENE_TREASURE;
@@ -149,6 +150,7 @@ void EnDntDemo_Judge(EnDntDemo* this, PlayState* play) {
                 case PLAYER_MASK_TRUTH:
                     if (!Flags_GetTreasure(play, 0x1E) && !Player_InBlockingCsMode(play, player)) {
                         GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(RC_DEKU_THEATER_MASK_OF_TRUTH, GI_NUT_UPGRADE_40);
+                        GET_PLAYER(play)->getItemCheck = RC_DEKU_THEATER_MASK_OF_TRUTH; // for OnCollectCheck
                         GiveItemEntryWithoutActor(play, getItemEntry);
                         player->pendingFlag.flagID = 0x1E;
                         player->pendingFlag.flagType = FLAG_SCENE_TREASURE;

--- a/soh/src/overlays/actors/ovl_En_Ds/z_en_ds.c
+++ b/soh/src/overlays/actors/ovl_En_Ds/z_en_ds.c
@@ -98,6 +98,7 @@ void EnDs_GiveOddPotion(EnDs* this, PlayState* play) {
         u32 itemId = GI_ODD_POTION;
         if (IS_RANDO) {
             GetItemEntry itemEntry = Randomizer_GetItemFromKnownCheck(RC_KAK_TRADE_ODD_MUSHROOM, GI_ODD_POTION);
+            GET_PLAYER(play)->rangeCheck = RC_KAK_TRADE_ODD_MUSHROOM; // for OnCollectCheck
             GiveItemEntryFromActor(&this->actor, play, itemEntry, 10000.0f, 50.0f);
             Randomizer_ConsumeAdultTradeItem(play, ITEM_ODD_MUSHROOM);
             return;
@@ -113,6 +114,7 @@ void EnDs_TalkAfterBrewOddPotion(EnDs* this, PlayState* play) {
         u32 itemId = GI_ODD_POTION;
         if (IS_RANDO) {
             GetItemEntry itemEntry = Randomizer_GetItemFromKnownCheck(RC_KAK_TRADE_ODD_MUSHROOM, GI_ODD_POTION);
+            GET_PLAYER(play)->rangeCheck = RC_KAK_TRADE_ODD_MUSHROOM; // for OnCollectCheck
             GiveItemEntryFromActor(&this->actor, play, itemEntry, 10000.0f, 50.0f);
             Randomizer_ConsumeAdultTradeItem(play, ITEM_ODD_MUSHROOM);
             return;
@@ -207,6 +209,7 @@ void EnDs_GiveBluePotion(EnDs* this, PlayState* play) {
     } else {
         if (EnDs_RandoCanGetGrannyItem()) {
             GetItemEntry entry = Randomizer_GetItemFromKnownCheck(RC_KAK_GRANNYS_SHOP, GI_POTION_BLUE);
+            GET_PLAYER(play)->rangeCheck = RC_KAK_GRANNYS_SHOP; // for OnCollectCheck
             GiveItemEntryFromActor(&this->actor, play, entry, 10000.0f, 50.0f);
         } else {
             func_8002F434(&this->actor, play, GI_POTION_BLUE, 10000.0f, 50.0f);
@@ -233,6 +236,7 @@ void EnDs_OfferBluePotion(EnDs* this, PlayState* play) {
 
                         if (EnDs_RandoCanGetGrannyItem()) {
                             itemEntry = Randomizer_GetItemFromKnownCheck(RC_KAK_GRANNYS_SHOP, GI_POTION_BLUE);
+                            GET_PLAYER(play)->rangeCheck = RC_KAK_GRANNYS_SHOP; // for OnCollectCheck
                             GiveItemEntryFromActor(&this->actor, play, itemEntry, 10000.0f, 50.0f);
                         } else {
                             itemEntry = ItemTable_Retrieve(GI_POTION_BLUE);

--- a/soh/src/overlays/actors/ovl_En_Du/z_en_du.c
+++ b/soh/src/overlays/actors/ovl_En_Du/z_en_du.c
@@ -552,6 +552,7 @@ void func_809FEC70(EnDu* this, PlayState* play) {
             func_8002F434(&this->actor, play, GI_BRACELET, xzRange, fabsf(this->actor.yDistToPlayer) + 1.0f);
         } else {
             GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(RC_GC_DARUNIAS_JOY, GI_BRACELET);
+            GET_PLAYER(play)->rangeCheck = RC_GC_DARUNIAS_JOY; // for OnCollectCheck
             GiveItemEntryFromActor(&this->actor, play, getItemEntry, xzRange, fabsf(this->actor.yDistToPlayer) + 1.0f);
         }
     }

--- a/soh/src/overlays/actors/ovl_En_Ex_Item/z_en_ex_item.c
+++ b/soh/src/overlays/actors/ovl_En_Ex_Item/z_en_ex_item.c
@@ -417,6 +417,7 @@ void EnExItem_TargetPrizeApproach(EnExItem* this, PlayState* play) {
         if (!IS_RANDO || getItemEntry.getItemId == GI_NONE) {
             func_8002F434(&this->actor, play, getItemId, 2000.0f, 1000.0f);
         } else {
+            GET_PLAYER(play)->rangeCheck = RC_LW_TARGET_IN_WOODS; // for OnCollectCheck
             GiveItemEntryFromActor(&this->actor, play, getItemEntry, 2000.0f, 1000.0f);
         }
         this->actionFunc = EnExItem_TargetPrizeGive;
@@ -432,6 +433,7 @@ void EnExItem_TargetPrizeGive(EnExItem* this, PlayState* play) {
             func_8002F434(&this->actor, play, getItemId, 2000.0f, 1000.0f);
         } else {
             GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(RC_LW_TARGET_IN_WOODS, GI_BULLET_BAG_50);
+            GET_PLAYER(play)->rangeCheck = RC_LW_TARGET_IN_WOODS; // for OnCollectCheck
             GiveItemEntryFromActor(&this->actor, play, getItemEntry, 2000.0f, 1000.0f);
         }
 
@@ -540,8 +542,7 @@ void EnExItem_DrawHeartPiece(EnExItem* this, PlayState* play) {
     func_8002ED80(&this->actor, play, 0);
 
     if (IS_RANDO) {
-        GetItemEntry randoGetItem =
-            Randomizer_GetItemFromKnownCheck(RC_MARKET_BOMBCHU_BOWLING_SECOND_PRIZE, GI_HEART_PIECE);
+        GetItemEntry randoGetItem = Randomizer_GetItemFromKnownCheck(RC_MARKET_BOMBCHU_BOWLING_SECOND_PRIZE, GI_HEART_PIECE);
         EnItem00_CustomItemsParticles(&this->actor, play, randoGetItem);
         GetItemEntry_Draw(play, randoGetItem);
     } else {

--- a/soh/src/overlays/actors/ovl_En_Fr/z_en_fr.c
+++ b/soh/src/overlays/actors/ovl_En_Fr/z_en_fr.c
@@ -971,7 +971,9 @@ void EnFr_SetReward(EnFr* this, PlayState* play) {
             if (!IS_RANDO) {
                 this->reward = GI_RUPEE_PURPLE;
             } else {
-                this->getItemEntry = Randomizer_GetItemFromKnownCheck(EnFr_RandomizerCheckFromSongIndex(songIndex), GI_RUPEE_PURPLE);
+                RandomizerCheck check = EnFr_RandomizerCheckFromSongIndex(songIndex);
+                this->getItemEntry = Randomizer_GetItemFromKnownCheck(check, GI_RUPEE_PURPLE);
+                this->getItemCheck = check;
                 this->reward = this->getItemEntry.getItemId;
             }
         } else {
@@ -985,6 +987,7 @@ void EnFr_SetReward(EnFr* this, PlayState* play) {
                 this->reward = GI_HEART_PIECE;
             } else {
                 this->getItemEntry = Randomizer_GetItemFromKnownCheck(RC_ZR_FROGS_IN_THE_RAIN, GI_HEART_PIECE);
+                this->getItemCheck = RC_ZR_FROGS_IN_THE_RAIN;
                 this->reward = this->getItemEntry.getItemId;
             }
         } else {
@@ -998,6 +1001,7 @@ void EnFr_SetReward(EnFr* this, PlayState* play) {
                 this->reward = GI_HEART_PIECE;
             } else {
                 this->getItemEntry = Randomizer_GetItemFromKnownCheck(RC_ZR_FROGS_OCARINA_GAME, GI_HEART_PIECE);
+                this->getItemCheck = RC_ZR_FROGS_OCARINA_GAME;
                 this->reward = this->getItemEntry.getItemId;
             }
         } else {
@@ -1052,6 +1056,7 @@ void EnFr_Deactivate(EnFr* this, PlayState* play) {
         if (!IS_RANDO || this->getItemEntry.getItemId == GI_NONE) {
             func_8002F434(&this->actor, play, this->reward, 30.0f, 100.0f);
         } else {
+            GET_PLAYER(play)->rangeCheck = this->getItemCheck;
             GiveItemEntryFromActor(&this->actor, play, this->getItemEntry, 30.0f, 100.0f);
         }
     }

--- a/soh/src/overlays/actors/ovl_En_Fr/z_en_fr.h
+++ b/soh/src/overlays/actors/ovl_En_Fr/z_en_fr.h
@@ -74,6 +74,7 @@ typedef struct EnFr {
     /* 0x03AC */ Vec3f posButterfly; // Position/Coordinates of the Butterfly
     /* 0x03B8 */ Vec3f posButterflyLight; // Used in Lights_PointNoGlowSetInfo()
     /*        */ GetItemEntry getItemEntry;
+    /*        */ RandomizerCheck getItemCheck; // for OnCollectCheck
 } EnFr; // size = 0x03C4
 
 typedef struct {

--- a/soh/src/overlays/actors/ovl_En_Fu/z_en_fu.c
+++ b/soh/src/overlays/actors/ovl_En_Fu/z_en_fu.c
@@ -157,6 +157,7 @@ void GivePlayerRandoRewardSongOfStorms(EnFu* windmillGuy, PlayState* play, Rando
         windmillGuy->actionFunc = func_80A1DBD4;
     } else if (!Flags_GetTreasure(play, 0x1F)) {
         GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(check, RG_SONG_OF_STORMS);
+        GET_PLAYER(play)->rangeCheck = check; // for OnCollectCheck
         GiveItemEntryFromActor(&windmillGuy->actor, play, getItemEntry, 10000.0f, 100.0f);
     }
 }

--- a/soh/src/overlays/actors/ovl_En_Gb/z_en_gb.c
+++ b/soh/src/overlays/actors/ovl_En_Gb/z_en_gb.c
@@ -363,6 +363,7 @@ void func_80A2FB40(EnGb* this, PlayState* play) {
             func_8002F434(&this->dyna.actor, play, GI_BOTTLE, 100.0f, 10.0f);
         } else {
             GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(RC_MARKET_10_BIG_POES, GI_BOTTLE);
+            GET_PLAYER(play)->rangeCheck = RC_MARKET_10_BIG_POES; // for OnCollectCheck
             GiveItemEntryFromActor(&this->dyna.actor, play, getItemEntry, 100.0f, 10.0f);
         }
         this->actionFunc = func_80A2FBB0;
@@ -378,6 +379,7 @@ void func_80A2FBB0(EnGb* this, PlayState* play) {
             func_8002F434(&this->dyna.actor, play, GI_BOTTLE, 100.0f, 10.0f);
         } else {
             GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(RC_MARKET_10_BIG_POES, GI_BOTTLE);
+            GET_PLAYER(play)->rangeCheck = RC_MARKET_10_BIG_POES; // for OnCollectCheck
             GiveItemEntryFromActor(&this->dyna.actor, play, getItemEntry, 100.0f, 10.0f);
         }
     }

--- a/soh/src/overlays/actors/ovl_En_Ge1/z_en_ge1.c
+++ b/soh/src/overlays/actors/ovl_En_Ge1/z_en_ge1.c
@@ -548,6 +548,7 @@ void EnGe1_WaitTillItemGiven_Archery(EnGe1* this, PlayState* play) {
             Flags_SetInfTable(INFTABLE_190);
         }
     } else {
+        RandomizerCheck check = RC_MAX;
         if (this->stateFlags & GE1_STATE_GIVE_QUIVER) {
             if (!IS_RANDO) {
                 switch (CUR_UPG_VALUE(UPG_QUIVER)) {
@@ -561,6 +562,7 @@ void EnGe1_WaitTillItemGiven_Archery(EnGe1* this, PlayState* play) {
                 }
             } else {
                 getItemEntry = Randomizer_GetItemFromKnownCheck(RC_GF_HBA_1500_POINTS, CUR_UPG_VALUE(UPG_QUIVER) == 1 ? GI_QUIVER_40 : GI_QUIVER_50);
+                check = RC_GF_HBA_1500_POINTS;
                 getItemId = getItemEntry.getItemId;
             }
         } else {
@@ -568,6 +570,7 @@ void EnGe1_WaitTillItemGiven_Archery(EnGe1* this, PlayState* play) {
                 getItemId = GI_HEART_PIECE;
             } else {
                 getItemEntry = Randomizer_GetItemFromKnownCheck(RC_GF_HBA_1000_POINTS, GI_HEART_PIECE);
+                check = RC_GF_HBA_1000_POINTS;
                 getItemId = getItemEntry.getItemId;
             }
         }
@@ -575,6 +578,9 @@ void EnGe1_WaitTillItemGiven_Archery(EnGe1* this, PlayState* play) {
         if (!IS_RANDO || getItemEntry.getItemId == GI_NONE) {
             func_8002F434(&this->actor, play, getItemId, 10000.0f, 50.0f);
         } else {
+            if (check != RC_MAX) {
+                GET_PLAYER(play)->rangeCheck = check; // for OnCollectCheck
+            }
             GiveItemEntryFromActor(&this->actor, play, getItemEntry, 10000.0f, 50.0f);
         }
     }
@@ -589,6 +595,7 @@ void EnGe1_BeginGiveItem_Archery(EnGe1* this, PlayState* play) {
         this->actionFunc = EnGe1_WaitTillItemGiven_Archery;
     }
 
+    RandomizerCheck check = RC_MAX;
     if (this->stateFlags & GE1_STATE_GIVE_QUIVER) {
         if (!IS_RANDO) {
             switch (CUR_UPG_VALUE(UPG_QUIVER)) {
@@ -602,6 +609,7 @@ void EnGe1_BeginGiveItem_Archery(EnGe1* this, PlayState* play) {
             }
         } else {
             getItemEntry = Randomizer_GetItemFromKnownCheck(RC_GF_HBA_1500_POINTS, CUR_UPG_VALUE(UPG_QUIVER) == 1 ? GI_QUIVER_40 : GI_QUIVER_50);
+            check = RC_GF_HBA_1500_POINTS;
             getItemId = getItemEntry.getItemId;
         }
     } else {
@@ -609,6 +617,7 @@ void EnGe1_BeginGiveItem_Archery(EnGe1* this, PlayState* play) {
             getItemId = GI_HEART_PIECE;
         } else {
             getItemEntry = Randomizer_GetItemFromKnownCheck(RC_GF_HBA_1000_POINTS, GI_HEART_PIECE);
+            check = RC_GF_HBA_1000_POINTS;
             getItemId = getItemEntry.getItemId;
         }
     }
@@ -616,6 +625,9 @@ void EnGe1_BeginGiveItem_Archery(EnGe1* this, PlayState* play) {
     if (!IS_RANDO || getItemEntry.getItemId == GI_NONE) {
         func_8002F434(&this->actor, play, getItemId, 10000.0f, 50.0f);
     } else {
+        if (check != RC_MAX) {
+            GET_PLAYER(play)->rangeCheck = check; // for OnCollectCheck
+        }
         GiveItemEntryFromActor(&this->actor, play, getItemEntry, 10000.0f, 50.0f);
     }
 }

--- a/soh/src/overlays/actors/ovl_En_Ge2/z_en_ge2.c
+++ b/soh/src/overlays/actors/ovl_En_Ge2/z_en_ge2.c
@@ -475,6 +475,7 @@ void EnGe2_WaitTillCardGiven(EnGe2* this, PlayState* play) {
             func_8002F434(&this->actor, play, GI_GERUDO_CARD, 10000.0f, 50.0f);
         } else {
             GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(RC_GF_GERUDO_MEMBERSHIP_CARD, GI_GERUDO_CARD);
+            GET_PLAYER(play)->rangeCheck = RC_GF_GERUDO_MEMBERSHIP_CARD; // for OnCollectCheck
             GiveItemEntryFromActor(&this->actor, play, getItemEntry, 10000.0f, 50.0f);
         }
     }
@@ -489,6 +490,7 @@ void EnGe2_GiveCard(EnGe2* this, PlayState* play) {
             func_8002F434(&this->actor, play, GI_GERUDO_CARD, 10000.0f, 50.0f);
         } else {
             GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(RC_GF_GERUDO_MEMBERSHIP_CARD, GI_GERUDO_CARD);
+            GET_PLAYER(play)->rangeCheck = RC_GF_GERUDO_MEMBERSHIP_CARD; // for OnCollectCheck
             GiveItemEntryFromActor(&this->actor, play, getItemEntry, 10000.0f, 50.0f);
         }
     }

--- a/soh/src/overlays/actors/ovl_En_Ge3/z_en_ge3.c
+++ b/soh/src/overlays/actors/ovl_En_Ge3/z_en_ge3.c
@@ -148,6 +148,7 @@ void EnGe3_WaitTillCardGiven(EnGe3* this, PlayState* play) {
             func_8002F434(&this->actor, play, GI_GERUDO_CARD, 10000.0f, 50.0f);
         } else {
             GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(RC_GF_GERUDO_MEMBERSHIP_CARD, GI_GERUDO_CARD);
+            GET_PLAYER(play)->rangeCheck = RC_GF_GERUDO_MEMBERSHIP_CARD; // for OnCollectCheck
             GiveItemEntryFromActor(&this->actor, play, getItemEntry, 10000.0f, 50.0f);
         }
     }
@@ -162,6 +163,7 @@ void EnGe3_GiveCard(EnGe3* this, PlayState* play) {
             func_8002F434(&this->actor, play, GI_GERUDO_CARD, 10000.0f, 50.0f);
         } else {
             GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(RC_GF_GERUDO_MEMBERSHIP_CARD, GI_GERUDO_CARD);
+            GET_PLAYER(play)->rangeCheck = RC_GF_GERUDO_MEMBERSHIP_CARD; // for OnCollectCheck
             GiveItemEntryFromActor(&this->actor, play, getItemEntry, 10000.0f, 50.0f);
         }
     }

--- a/soh/src/overlays/actors/ovl_En_GirlA/z_en_girla.c
+++ b/soh/src/overlays/actors/ovl_En_GirlA/z_en_girla.c
@@ -985,6 +985,7 @@ void EnGirlA_ItemGive_Randomizer(PlayState* play, EnGirlA* this) {
         }
         Item_Give(play, getItemEntry.itemId);
     } else if (getItemEntry.modIndex == MOD_RANDOMIZER && getItemEntry.getItemId != RG_ICE_TRAP) {
+        GET_PLAYER(play)->getItemCheck = shopItemIdentity.randomizerCheck;
         Randomizer_Item_Give(play, getItemEntry);
     }
 

--- a/soh/src/overlays/actors/ovl_En_Gm/z_en_gm.c
+++ b/soh/src/overlays/actors/ovl_En_Gm/z_en_gm.c
@@ -259,6 +259,7 @@ void EnGm_ProcessChoiceIndex(EnGm* this, PlayState* play) {
                     if (IS_RANDO && Randomizer_GetSettingValue(RSK_SHUFFLE_MERCHANTS) != RO_SHUFFLE_MERCHANTS_OFF &&
                         !Flags_GetRandomizerInf(RAND_INF_MERCHANTS_MEDIGORON)) {
                         itemEntry = Randomizer_GetItemFromKnownCheck(RC_GC_MEDIGORON, GI_SWORD_KNIFE);
+                        GET_PLAYER(play)->rangeCheck = RC_GC_MEDIGORON; // for OnCollectCheck
                         GiveItemEntryFromActor(&this->actor, play, itemEntry, 415.0f, 10.0f);
                         Flags_SetInfTable(INFTABLE_B1);
                     } else {
@@ -292,6 +293,7 @@ void func_80A3DF00(EnGm* this, PlayState* play) {
         if (IS_RANDO && Randomizer_GetSettingValue(RSK_SHUFFLE_MERCHANTS) != RO_SHUFFLE_MERCHANTS_OFF &&
             !Flags_GetRandomizerInf(RAND_INF_MERCHANTS_MEDIGORON)) {
             GetItemEntry itemEntry = Randomizer_GetItemFromKnownCheck(RC_GC_MEDIGORON, GI_SWORD_KNIFE);
+            GET_PLAYER(play)->rangeCheck = RC_GC_MEDIGORON; // for OnCollectCheck
             GiveItemEntryFromActor(&this->actor, play, itemEntry, 415.0f, 10.0f);
             Flags_SetInfTable(INFTABLE_B1);
         }

--- a/soh/src/overlays/actors/ovl_En_Go/z_en_go.c
+++ b/soh/src/overlays/actors/ovl_En_Go/z_en_go.c
@@ -949,6 +949,7 @@ void EnGo_GetItem(EnGo* this, PlayState* play) {
     f32 yDist;
     GetItemEntry getItemEntry = (GetItemEntry)GET_ITEM_NONE;
     s32 getItemId;
+    RandomizerCheck check; // for OnCollectCheck
 
     if (Actor_HasParent(&this->actor, play)) {
         this->interactInfo.talkState = NPC_TALK_STATE_ACTION;
@@ -962,6 +963,7 @@ void EnGo_GetItem(EnGo* this, PlayState* play) {
                     getItemId = GI_SWORD_BGS;
                 } else {
                     getItemEntry = Randomizer_GetItemFromKnownCheck(RC_DMT_TRADE_CLAIM_CHECK, GI_SWORD_BGS);
+                    check = RC_DMT_TRADE_CLAIM_CHECK;
                     getItemId = getItemEntry.getItemId;
                 }
                 this->unk_20C = 1;
@@ -969,6 +971,7 @@ void EnGo_GetItem(EnGo* this, PlayState* play) {
             if (INV_CONTENT(ITEM_TRADE_ADULT) == ITEM_EYEDROPS) {
                 if (IS_RANDO) {
                     getItemEntry = Randomizer_GetItemFromKnownCheck(RC_DMT_TRADE_EYEDROPS, GI_CLAIM_CHECK);
+                    check = RC_DMT_TRADE_CLAIM_CHECK;
                     getItemId = getItemEntry.getItemId;
                     Randomizer_ConsumeAdultTradeItem(play, ITEM_EYEDROPS);
                 } else {
@@ -978,6 +981,7 @@ void EnGo_GetItem(EnGo* this, PlayState* play) {
             if (INV_CONTENT(ITEM_TRADE_ADULT) == ITEM_SWORD_BROKEN) {
                 if (IS_RANDO) {
                     getItemEntry = Randomizer_GetItemFromKnownCheck(RC_DMT_TRADE_BROKEN_SWORD, GI_PRESCRIPTION);
+                    check = RC_DMT_TRADE_BROKEN_SWORD;
                     Randomizer_ConsumeAdultTradeItem(play, ITEM_SWORD_BROKEN);
                     getItemId = getItemEntry.getItemId;
                 } else {
@@ -995,6 +999,7 @@ void EnGo_GetItem(EnGo* this, PlayState* play) {
         if (!IS_RANDO || getItemEntry.getItemId == GI_NONE) {
             func_8002F434(&this->actor, play, getItemId, xzDist, yDist);
         } else {
+            GET_PLAYER(play)->rangeCheck = check; // for OnCollectCheck
             GiveItemEntryFromActor(&this->actor, play, getItemEntry, xzDist, yDist);
         }
     }

--- a/soh/src/overlays/actors/ovl_En_Hs/z_en_hs.c
+++ b/soh/src/overlays/actors/ovl_En_Hs/z_en_hs.c
@@ -182,6 +182,7 @@ void func_80A6E740(EnHs* this, PlayState* play) {
         if (IS_RANDO) {
             GetItemEntry itemEntry = Randomizer_GetItemFromKnownCheck(RC_LW_TRADE_COJIRO, GI_ODD_MUSHROOM);
             Randomizer_ConsumeAdultTradeItem(play, ITEM_COJIRO);
+            GET_PLAYER(play)->rangeCheck = RC_LW_TRADE_COJIRO; // for OnCollectCheck
             GiveItemEntryFromActor(&this->actor, play, itemEntry, 10000.0f, 50.0f);
             Flags_SetRandomizerInf(RAND_INF_ADULT_TRADES_LW_TRADE_COJIRO);
         } else {
@@ -200,6 +201,7 @@ void func_80A6E7BC(EnHs* this, PlayState* play) {
                 func_80A6E3A0(this, func_80A6E740);
                 if (IS_RANDO) {
                     GetItemEntry itemEntry = Randomizer_GetItemFromKnownCheck(RC_LW_TRADE_COJIRO, GI_ODD_MUSHROOM);
+                    GET_PLAYER(play)->rangeCheck = RC_LW_TRADE_COJIRO; // for OnCollectCheck
                     Randomizer_ConsumeAdultTradeItem(play, ITEM_COJIRO);
                     GiveItemEntryFromActor(&this->actor, play, itemEntry, 10000.0f, 50.0f);
                     Flags_SetRandomizerInf(RAND_INF_ADULT_TRADES_LW_TRADE_COJIRO);

--- a/soh/src/overlays/actors/ovl_En_Hy/z_en_hy.c
+++ b/soh/src/overlays/actors/ovl_En_Hy/z_en_hy.c
@@ -668,6 +668,7 @@ s16 func_80A70058(PlayState* play, Actor* thisx) {
                             this->getItemEntry = Randomizer_GetItemFromKnownCheck(RC_MARKET_LOST_DOG, GI_HEART_PIECE);
                             // The follownig line and last arguments of GiveItemEntryFromActor are copied from func_80A6F7CC
                             this->unkGetItemId = this->getItemEntry.getItemId;
+                            GET_PLAYER(play)->rangeCheck = RC_MARKET_LOST_DOG; // for OnCollectCheck
                             GiveItemEntryFromActor(&this->actor, play, this->getItemEntry, this->actor.xzDistToPlayer + 1.0f, fabsf(this->actor.yDistToPlayer) + 1.0f);
                         }
                     }

--- a/soh/src/overlays/actors/ovl_En_Js/z_en_js.c
+++ b/soh/src/overlays/actors/ovl_En_Js/z_en_js.c
@@ -136,6 +136,7 @@ void func_80A89160(EnJs* this, PlayState* play) {
             GetItemEntry itemEntry = Randomizer_GetItemFromKnownCheck(RC_WASTELAND_BOMBCHU_SALESMAN, GI_BOMBCHUS_10);
             gSaveContext.pendingSale = itemEntry.itemId;
             gSaveContext.pendingSaleMod = itemEntry.modIndex;
+            GET_PLAYER(play)->rangeCheck = RC_WASTELAND_BOMBCHU_SALESMAN;
             GiveItemEntryFromActor(&this->actor, play, itemEntry, 10000.0f, 50.0f);
             Flags_SetRandomizerInf(RAND_INF_MERCHANTS_CARPET_SALESMAN);
         } else {

--- a/soh/src/overlays/actors/ovl_En_Ko/z_en_ko.c
+++ b/soh/src/overlays/actors/ovl_En_Ko/z_en_ko.c
@@ -1236,6 +1236,7 @@ void func_80A99504(EnKo* this, PlayState* play) {
     } else {
         if (IS_RANDO) {
             GetItemEntry itemEntry = Randomizer_GetItemFromKnownCheck(RC_LW_TRADE_ODD_POTION, GI_SAW);
+            GET_PLAYER(play)->rangeCheck = RC_LW_TRADE_ODD_POTION; // for OnCollectCheck
             Randomizer_ConsumeAdultTradeItem(play, ITEM_ODD_POTION);
             GiveItemEntryFromActor(&this->actor, play, itemEntry, 120.0f, 10.0f);
         } else {

--- a/soh/src/overlays/actors/ovl_En_Kz/z_en_kz.c
+++ b/soh/src/overlays/actors/ovl_En_Kz/z_en_kz.c
@@ -462,6 +462,7 @@ void EnKz_Wait(EnKz* this, PlayState* play) {
 void EnKz_SetupGetItem(EnKz* this, PlayState* play) {
     GetItemEntry getItemEntry = (GetItemEntry)GET_ITEM_NONE;
     s32 getItemId;
+    RandomizerCheck check = RC_MAX; // for OnCollectCheck
     f32 xzRange;
     f32 yRange;
 
@@ -474,11 +475,13 @@ void EnKz_SetupGetItem(EnKz* this, PlayState* play) {
             if (this->isTrading) {
                 getItemEntry = Randomizer_GetItemFromKnownCheck(RC_ZD_TRADE_PRESCRIPTION, GI_FROG);
                 getItemId = getItemEntry.getItemId;
+                check = RC_ZD_TRADE_PRESCRIPTION;
                 Randomizer_ConsumeAdultTradeItem(play, ITEM_PRESCRIPTION);
                 Flags_SetTreasure(play, 0x1F);
             } else {
                 getItemEntry = Randomizer_GetItemFromKnownCheck(RC_ZD_KING_ZORA_THAWED, GI_TUNIC_ZORA);
                 getItemId = getItemEntry.getItemId;
+                check = RC_ZD_KING_ZORA_THAWED;
             }
         } else {
             getItemId = this->isTrading ? GI_FROG : GI_TUNIC_ZORA;
@@ -488,6 +491,7 @@ void EnKz_SetupGetItem(EnKz* this, PlayState* play) {
         if (!IS_RANDO || getItemEntry.getItemId == GI_NONE) {
             func_8002F434(&this->actor, play, getItemId, xzRange, yRange);
         } else {
+            GET_PLAYER(play)->rangeCheck = check; // for OnCollectCheck
             GiveItemEntryFromActor(&this->actor, play, getItemEntry, xzRange, yRange);
         }
     }

--- a/soh/src/overlays/actors/ovl_En_Ma1/z_en_ma1.c
+++ b/soh/src/overlays/actors/ovl_En_Ma1/z_en_ma1.c
@@ -373,6 +373,7 @@ void func_80AA0EA0(EnMa1* this, PlayState* play) {
             func_8002F434(&this->actor, play, GI_WEIRD_EGG, 120.0f, 10.0f);
         } else {
             GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(RC_HC_MALON_EGG, GI_WEIRD_EGG);
+            GET_PLAYER(play)->rangeCheck = RC_HC_MALON_EGG; // for OnCollectCheck
             GiveItemEntryFromActor(&this->actor, play, getItemEntry, 120.0f, 10.0f);
         }
     }
@@ -398,6 +399,7 @@ void GivePlayerRandoRewardMalon(EnMa1* malon, PlayState* play, RandomizerCheck c
         // (confirmed via breakpoints in a vanilla save).
         malon->actionFunc = func_80AA0D88;
     } else if (!Flags_GetTreasure(play, 0x1F)) {
+        GET_PLAYER(play)->rangeCheck = check; // for OnCollectCheck
         GiveItemEntryFromActor(&malon->actor, play, getItemEntry, 10000.0f, 100.0f);
     }
     // make malon sing again after giving the item.

--- a/soh/src/overlays/actors/ovl_En_Mk/z_en_mk.c
+++ b/soh/src/overlays/actors/ovl_En_Mk/z_en_mk.c
@@ -103,6 +103,7 @@ void func_80AACA94(EnMk* this, PlayState* play) {
     } else {
         if (IS_RANDO) {
             GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(RC_LH_TRADE_FROG, GI_EYEDROPS);
+            GET_PLAYER(play)->rangeCheck = RC_LH_TRADE_FROG; // for OnCollectCheck
             Randomizer_ConsumeAdultTradeItem(play, ITEM_FROG);
             GiveItemEntryFromActor(&this->actor, play, getItemEntry, 10000.0f, 50.0f);
             Flags_SetRandomizerInf(RAND_INF_ADULT_TRADES_LH_TRADE_FROG);
@@ -118,6 +119,7 @@ void func_80AACB14(EnMk* this, PlayState* play) {
         this->actionFunc = func_80AACA94;
         if (IS_RANDO) {
             GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(RC_LH_TRADE_FROG, GI_EYEDROPS);
+            GET_PLAYER(play)->rangeCheck = RC_LH_TRADE_FROG; // for OnCollectCheck
             Randomizer_ConsumeAdultTradeItem(play, ITEM_FROG);
             GiveItemEntryFromActor(&this->actor, play, getItemEntry, 10000.0f, 50.0f);
             Flags_SetRandomizerInf(RAND_INF_ADULT_TRADES_LH_TRADE_FROG);
@@ -223,6 +225,7 @@ void func_80AACFA0(EnMk* this, PlayState* play) {
             func_8002F434(&this->actor, play, GI_HEART_PIECE, 10000.0f, 50.0f);
         } else {
             GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(RC_LH_LAB_DIVE, GI_HEART_PIECE);
+            GET_PLAYER(play)->rangeCheck = RC_LH_LAB_DIVE; // for OnCollectCheck
             GiveItemEntryFromActor(&this->actor, play, getItemEntry, 10000.0f, 50.0f);
         }
     }
@@ -235,6 +238,7 @@ void func_80AAD014(EnMk* this, PlayState* play) {
             func_8002F434(&this->actor, play, GI_HEART_PIECE, 10000.0f, 50.0f);
         } else {
             GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(RC_LH_LAB_DIVE, GI_HEART_PIECE);
+            GET_PLAYER(play)->rangeCheck = RC_LH_LAB_DIVE; // for OnCollectCheck
             GiveItemEntryFromActor(&this->actor, play, getItemEntry, 10000.0f, 50.0f);
         }
     }

--- a/soh/src/overlays/actors/ovl_En_Ms/z_en_ms.c
+++ b/soh/src/overlays/actors/ovl_En_Ms/z_en_ms.c
@@ -135,6 +135,7 @@ void EnMs_Talk(EnMs* this, PlayState* play) {
                     return;
                 }
                 if (IS_RANDO && Randomizer_GetSettingValue(RSK_SHUFFLE_MAGIC_BEANS)) {
+                    GET_PLAYER(play)->rangeCheck = RC_ZR_MAGIC_BEAN_SALESMAN; // for OnCollectCheck
                     GiveItemEntryFromActor(&this->actor, play, 
                         Randomizer_GetItemFromKnownCheck(RC_ZR_MAGIC_BEAN_SALESMAN, GI_BEAN), 90.0f, 10.0f);
                 } else {
@@ -161,6 +162,7 @@ void EnMs_Sell(EnMs* this, PlayState* play) {
             GetItemEntry itemEntry = Randomizer_GetItemFromKnownCheck(RC_ZR_MAGIC_BEAN_SALESMAN, GI_BEAN);
             gSaveContext.pendingSale = itemEntry.itemId;
             gSaveContext.pendingSaleMod = itemEntry.modIndex;
+            GET_PLAYER(play)->rangeCheck = RC_ZR_MAGIC_BEAN_SALESMAN;
             GiveItemEntryFromActor(&this->actor, play, itemEntry, 90.0f, 10.0f);
             BEANS_BOUGHT = 10;
         } else {

--- a/soh/src/overlays/actors/ovl_En_Niw_Lady/z_en_niw_lady.c
+++ b/soh/src/overlays/actors/ovl_En_Niw_Lady/z_en_niw_lady.c
@@ -313,6 +313,7 @@ void func_80ABA654(EnNiwLady* this, PlayState* play) {
                 func_8002F434(&this->actor, play, GI_BOTTLE, 100.0f, 50.0f);
             } else {
                 this->getItemEntry = Randomizer_GetItemFromKnownCheck(RC_KAK_ANJU_AS_CHILD, GI_BOTTLE);
+                GET_PLAYER(play)->rangeCheck = RC_KAK_ANJU_AS_CHILD; // for OnCollectCheck
                 GiveItemEntryFromActor(&this->actor, play, this->getItemEntry, 100.0f, 50.0f);
             }
 
@@ -402,6 +403,7 @@ void func_80ABA9B8(EnNiwLady* this, PlayState* play) {
                     func_8002F434(&this->actor, play, GI_POCKET_EGG, 200.0f, 100.0f);
                 } else {
                     this->getItemEntry = Randomizer_GetItemFromKnownCheck(RC_KAK_ANJU_AS_ADULT, GI_POCKET_EGG);
+                    GET_PLAYER(play)->rangeCheck = RC_KAK_ANJU_AS_ADULT; // for OnCollectCheck
                     GiveItemEntryFromActor(&this->actor, play, this->getItemEntry, 200.0f, 100.0f);
                     Flags_SetItemGetInf(ITEMGETINF_2C);
                 }
@@ -437,6 +439,7 @@ void func_80ABAB08(EnNiwLady* this, PlayState* play) {
                     func_8002F434(&this->actor, play, GI_COJIRO, 200.0f, 100.0f);
                 } else {
                     this->getItemEntry = Randomizer_GetItemFromKnownCheck(RC_KAK_TRADE_POCKET_CUCCO, GI_COJIRO);
+                    GET_PLAYER(play)->rangeCheck = RC_KAK_TRADE_POCKET_CUCCO; // for OnCollectCheck
                     Randomizer_ConsumeAdultTradeItem(play, ITEM_POCKET_CUCCO);
                     GiveItemEntryFromActor(&this->actor, play, this->getItemEntry, 200.0f, 100.0f);
                     Flags_SetItemGetInf(ITEMGETINF_2E);

--- a/soh/src/overlays/actors/ovl_En_Okarina_Tag/z_en_okarina_tag.c
+++ b/soh/src/overlays/actors/ovl_En_Okarina_Tag/z_en_okarina_tag.c
@@ -326,6 +326,7 @@ void func_80ABF708(EnOkarinaTag* this, PlayState* play) {
 void GivePlayerRandoRewardSunSong(EnOkarinaTag* song, PlayState* play, RandomizerCheck check) {
     Flags_SetTreasure(play, 0x1F);
     GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(check, GI_LETTER_ZELDA);
+    GET_PLAYER(play)->rangeCheck = check; // for OnCollectCheck
     GiveItemEntryFromActor(&song->actor, play, getItemEntry, 10000.0f, 100.0f);
 }
 

--- a/soh/src/overlays/actors/ovl_En_Ossan/z_en_ossan.c
+++ b/soh/src/overlays/actors/ovl_En_Ossan/z_en_ossan.c
@@ -1396,6 +1396,7 @@ void EnOssan_GiveItemWithFanfare(PlayState* play, EnOssan* this) {
         // and returns RC_UNKNOWN_CHECK, in which case we should fall back to vanilla logic
         if (shopItemIdentity.randomizerCheck != RC_UNKNOWN_CHECK) {
             GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(shopItemIdentity.randomizerCheck, shopItemIdentity.ogItemId);
+            GET_PLAYER(play)->rangeCheck = shopItemIdentity.randomizerCheck; // for OnCollectCheck
             GiveItemEntryFromActor(&this->actor, play, getItemEntry, 120.0f, 120.0f);
         } else {
             func_8002F434(&this->actor, play, this->shelfSlots[this->cursorIndex]->getItemId, 120.0f, 120.0f);
@@ -1742,8 +1743,8 @@ void EnOssan_State_GiveItemWithFanfare(EnOssan* this, PlayState* play, Player* p
         // en_ossan/en_girla are also used for the happy mask shop, which never has randomized items
         // and returns RC_UNKNOWN_CHECK, in which case we should fall back to vanilla logic
         if (shopItemIdentity.randomizerCheck != RC_UNKNOWN_CHECK) {
-            GetItemEntry getItemEntry =
-                Randomizer_GetItemFromKnownCheck(shopItemIdentity.randomizerCheck, shopItemIdentity.ogItemId);
+            GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(shopItemIdentity.randomizerCheck, shopItemIdentity.ogItemId);
+            GET_PLAYER(play)->rangeCheck = shopItemIdentity.randomizerCheck; // for OnCollectCheck
             GiveItemEntryFromActor(&this->actor, play, getItemEntry, 120.0f, 120.0f);
         } else {
             func_8002F434(&this->actor, play, this->shelfSlots[this->cursorIndex]->getItemId, 120.0f, 120.0f);

--- a/soh/src/overlays/actors/ovl_En_Sa/z_en_sa.c
+++ b/soh/src/overlays/actors/ovl_En_Sa/z_en_sa.c
@@ -628,6 +628,7 @@ void GivePlayerRandoRewardSaria(EnSa* saria, PlayState* play, RandomizerCheck ch
         !Flags_GetTreasure(play, 0x1F)) {
         Flags_SetTreasure(play, 0x1F);
     } else if (!Flags_GetTreasure(play, 0x1F)) {
+        GET_PLAYER(play)->rangeCheck = check; // for OnCollectCheck
         GiveItemEntryFromActor(&saria->actor, play, getItemEntry, 10000.0f, 100.0f);
     }
 }

--- a/soh/src/overlays/actors/ovl_En_Si/z_en_si.c
+++ b/soh/src/overlays/actors/ovl_En_Si/z_en_si.c
@@ -122,11 +122,12 @@ void func_80AFB768(EnSi* this, PlayState* play) {
                 Message_StartTextbox(play, textId, NULL);
 
                 if (IS_RANDO) {
-                    if (getItemId != RG_ICE_TRAP) {
+                    RandomizerCheck check = Randomizer_GetCheckFromActor(this->actor.id, play->sceneNum, this->actor.params);                    if (getItemId != RG_ICE_TRAP) {
                         Randomizer_GiveSkullReward(this, play);
                         Audio_PlayFanfare_Rando(getItem);
                     } else {
                         gSaveContext.pendingIceTrapCount++;
+                        GameInteractor_ExecuteOnCollectCheckHooks(check);
                         Audio_PlayFanfare(NA_BGM_SMALL_ITEM_GET);
                     }
                 } else {
@@ -241,6 +242,10 @@ void Randomizer_UpdateSkullReward(EnSi* this, PlayState* play) {
 void Randomizer_GiveSkullReward(EnSi* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
 
+    RandomizerCheck check = Randomizer_GetCheckFromActor(this->actor.id, play->sceneNum, this->actor.params);
+    if (check != RC_UNKNOWN_CHECK) {
+        GET_PLAYER(play)->getItemCheck = check; // for OnCollectCheck
+    }
     if (getItem.modIndex == MOD_NONE) {
         // RANDOTOD: Move this into Item_Give() or some other more central location
         if (getItem.getItemId == GI_SWORD_BGS) {

--- a/soh/src/overlays/actors/ovl_En_Skj/z_en_skj.c
+++ b/soh/src/overlays/actors/ovl_En_Skj/z_en_skj.c
@@ -1043,6 +1043,7 @@ void EnSkj_SariaSongTalk(EnSkj* this, PlayState* play) {
                 func_8002F434(&this->actor, play, GI_HEART_PIECE, EnSkj_GetItemXzRange(this), EnSkj_GetItemYRange(this));
             } else {
                 GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(RC_LW_SKULL_KID, GI_HEART_PIECE);
+                GET_PLAYER(play)->rangeCheck = RC_LW_SKULL_KID; // for OnCollectCheck
                 GiveItemEntryFromActor(&this->actor, play, getItemEntry, EnSkj_GetItemXzRange(this), EnSkj_GetItemYRange(this));
             }
         }
@@ -1062,6 +1063,7 @@ void func_80AFFE44(EnSkj* this, PlayState* play) {
             func_8002F434(&this->actor, play, GI_HEART_PIECE, EnSkj_GetItemXzRange(this), EnSkj_GetItemYRange(this));
         } else {
             GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(RC_LW_SKULL_KID, GI_HEART_PIECE);
+            GET_PLAYER(play)->rangeCheck = RC_LW_SKULL_KID; // for OnCollectCheck
             GiveItemEntryFromActor(&this->actor, play, getItemEntry, EnSkj_GetItemXzRange(this), EnSkj_GetItemYRange(this));
         }
     }
@@ -1542,6 +1544,7 @@ void EnSkj_WaitToGiveReward(EnSkj* this, PlayState* play) {
     if ((Message_GetState(&play->msgCtx) == TEXT_STATE_DONE) && Message_ShouldAdvance(play)) {
         if (IS_RANDO && gSaveContext.ocarinaGameRoundNum != 3) {
             GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(RC_LW_OCARINA_MEMORY_GAME, GI_HEART_PIECE);
+            GET_PLAYER(play)->rangeCheck = RC_LW_OCARINA_MEMORY_GAME; // for OnCollectCheck
             GiveItemEntryFromActor(&this->actor, play, getItemEntry, 26.0f, 26.0f);
         } else {
             func_8002F434(&this->actor, play, sOcarinaGameRewards[gSaveContext.ocarinaGameRoundNum], 26.0f, 26.0f);
@@ -1558,6 +1561,7 @@ void EnSkj_GiveOcarinaGameReward(EnSkj* this, PlayState* play) {
     } else {
         if (IS_RANDO && gSaveContext.ocarinaGameRoundNum != 3) {
             GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(RC_LW_OCARINA_MEMORY_GAME, GI_HEART_PIECE);
+            GET_PLAYER(play)->rangeCheck = RC_LW_OCARINA_MEMORY_GAME; // for OnCollectCheck
             GiveItemEntryFromActor(&this->actor, play, getItemEntry, 26.0f, 26.0f);
         } else {
             func_8002F434(&this->actor, play, sOcarinaGameRewards[gSaveContext.ocarinaGameRoundNum], 26.0f, 26.0f);

--- a/soh/src/overlays/actors/ovl_En_Sth/z_en_sth.c
+++ b/soh/src/overlays/actors/ovl_En_Sth/z_en_sth.c
@@ -258,29 +258,36 @@ void EnSth_ParentRewardObtainedWait(EnSth* this, PlayState* play) {
 void EnSth_GivePlayerItem(EnSth* this, PlayState* play) {
     u16 getItemId = sGetItemIds[this->actor.params];
     GetItemEntry getItemEntry = (GetItemEntry)GET_ITEM_NONE;
+    RandomizerCheck check = RC_UNKNOWN_CHECK;
     
     if (IS_RANDO) {
         switch (getItemId) {
             case GI_RUPEE_GOLD:
                 if (!Flags_GetRandomizerInf(RAND_INF_KAK_100_GOLD_SKULLTULA_REWARD)) {
                     getItemEntry = Randomizer_GetItemFromKnownCheck(RC_KAK_100_GOLD_SKULLTULA_REWARD, GI_RUPEE_GOLD);
+                    check = RC_KAK_100_GOLD_SKULLTULA_REWARD;
                     Flags_SetRandomizerInf(RAND_INF_KAK_100_GOLD_SKULLTULA_REWARD);
                 }
                 break;
             case GI_WALLET_ADULT:
                 getItemEntry = Randomizer_GetItemFromKnownCheck(RC_KAK_10_GOLD_SKULLTULA_REWARD, GI_WALLET_ADULT);
+                check = RC_KAK_10_GOLD_SKULLTULA_REWARD;
                 break;
             case GI_STONE_OF_AGONY:
                 getItemEntry = Randomizer_GetItemFromKnownCheck(RC_KAK_20_GOLD_SKULLTULA_REWARD, GI_STONE_OF_AGONY);
+                check = RC_KAK_20_GOLD_SKULLTULA_REWARD;
                 break;
             case GI_WALLET_GIANT:
                 getItemEntry = Randomizer_GetItemFromKnownCheck(RC_KAK_30_GOLD_SKULLTULA_REWARD, GI_WALLET_GIANT);
+                check = RC_KAK_30_GOLD_SKULLTULA_REWARD;
                 break;
             case GI_BOMBCHUS_10:
                 getItemEntry = Randomizer_GetItemFromKnownCheck(RC_KAK_40_GOLD_SKULLTULA_REWARD, GI_BOMBCHUS_10);
+                check = RC_KAK_40_GOLD_SKULLTULA_REWARD;
                 break;
             case GI_HEART_PIECE:
                 getItemEntry = Randomizer_GetItemFromKnownCheck(RC_KAK_50_GOLD_SKULLTULA_REWARD, GI_HEART_PIECE);
+                check = RC_KAK_50_GOLD_SKULLTULA_REWARD;
                 break;
         }
         getItemId = getItemEntry.getItemId;
@@ -304,6 +311,9 @@ void EnSth_GivePlayerItem(EnSth* this, PlayState* play) {
     if (!IS_RANDO || getItemEntry.getItemId == GI_NONE) {
         func_8002F434(&this->actor, play, getItemId, 10000.0f, 50.0f);
     } else {
+        if (check != RC_UNKNOWN_CHECK) {
+            GET_PLAYER(play)->rangeCheck = check; // for OnCollectCheck
+        }
         GiveItemEntryFromActor(&this->actor, play, getItemEntry, 10000.0f, 50.0f);
     }
 }

--- a/soh/src/overlays/actors/ovl_En_Syateki_Man/z_en_syateki_man.c
+++ b/soh/src/overlays/actors/ovl_En_Syateki_Man/z_en_syateki_man.c
@@ -397,6 +397,7 @@ void EnSyatekiMan_EndGame(EnSyatekiMan* this, PlayState* play) {
                     if (!IS_RANDO || this->getItemEntry.getItemId == GI_NONE) {
                         func_8002F434(&this->actor, play, this->getItemId, 2000.0f, 1000.0f);
                     } else {
+                        GET_PLAYER(play)->rangeCheck = LINK_IS_ADULT ? RC_KAK_SHOOTING_GALLERY_REWARD : RC_MARKET_SHOOTING_GALLERY_REWARD; // for OnCollectCheck
                         GiveItemEntryFromActor(&this->actor, play, this->getItemEntry, 2000.0f, 1000.0f);
                     }
                     this->actionFunc = EnSyatekiMan_GivePrize;

--- a/soh/src/overlays/actors/ovl_En_Ta/z_en_ta.c
+++ b/soh/src/overlays/actors/ovl_En_Ta/z_en_ta.c
@@ -882,6 +882,7 @@ void func_80B15E80(EnTa* this, PlayState* play) {
             func_8002F434(&this->actor, play, GI_MILK_BOTTLE, 10000.0f, 50.0f);
         } else {
             GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(RC_LLR_TALONS_CHICKENS, GI_MILK_BOTTLE);
+            GET_PLAYER(play)->rangeCheck = RC_LLR_TALONS_CHICKENS; // for OnCollectCheck
             GiveItemEntryFromActor(&this->actor, play, getItemEntry, 10000.0f, 50.0f);
         }
     }
@@ -897,6 +898,7 @@ void func_80B15F54(EnTa* this, PlayState* play) {
             func_8002F434(&this->actor, play, GI_MILK_BOTTLE, 10000.0f, 50.0f);
         } else {
             GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(RC_LLR_TALONS_CHICKENS, GI_MILK_BOTTLE);
+            GET_PLAYER(play)->rangeCheck = RC_LLR_TALONS_CHICKENS; // for OnCollectCheck
             GiveItemEntryFromActor(&this->actor, play, getItemEntry, 10000.0f, 50.0f);
         }
     }

--- a/soh/src/overlays/actors/ovl_En_Toryo/z_en_toryo.c
+++ b/soh/src/overlays/actors/ovl_En_Toryo/z_en_toryo.c
@@ -321,6 +321,7 @@ void func_80B20768(EnToryo* this, PlayState* play) {
         } else {
             if (IS_RANDO) {
                 GetItemEntry itemEntry = Randomizer_GetItemFromKnownCheck(RC_GV_TRADE_SAW, GI_SWORD_BROKEN);
+                GET_PLAYER(play)->rangeCheck = RC_GV_TRADE_SAW; // for OnCollectCheck
                 Randomizer_ConsumeAdultTradeItem(play, ITEM_SAW);
                 GiveItemEntryFromActor(&this->actor, play, itemEntry, 100.0f, 10.0f);
                 Flags_SetRandomizerInf(RAND_INF_ADULT_TRADES_GV_TRADE_SAW);

--- a/soh/src/overlays/actors/ovl_En_Xc/z_en_xc.c
+++ b/soh/src/overlays/actors/ovl_En_Xc/z_en_xc.c
@@ -297,11 +297,13 @@ void GivePlayerRandoRewardSheikSong(EnXc* sheik, PlayState* play, RandomizerChec
     if (!(gSaveContext.eventChkInf[5] & sheikType)) {
         GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(check, ogSongId);
         if (check == RC_SHEIK_AT_TEMPLE && !Flags_GetTreasure(play, 0x1F)) {
+            GET_PLAYER(play)->rangeCheck = RC_SHEIK_AT_TEMPLE; // for OnCollectCheck
             if (GiveItemEntryFromActor(&sheik->actor, play, getItemEntry, 10000.0f, 100.0f)) {
                 player->pendingFlag.flagID = 0x1F;
                 player->pendingFlag.flagType = FLAG_SCENE_TREASURE;
             }
         } else if (check != RC_SHEIK_AT_TEMPLE) {
+            GET_PLAYER(play)->rangeCheck = check; // for OnCollectCheck
             if (GiveItemEntryFromActor(&sheik->actor, play, getItemEntry, 10000.0f, 100.0f)) {
                 player->pendingFlag.flagID = (0x5 << 4) | (sheikType & 0xF) >> 1;
                 player->pendingFlag.flagType = FLAG_EVENT_CHECK_INF;

--- a/soh/src/overlays/actors/ovl_En_Zl4/z_en_zl4.c
+++ b/soh/src/overlays/actors/ovl_En_Zl4/z_en_zl4.c
@@ -234,6 +234,7 @@ void GivePlayerRandoRewardZeldaChild(EnZl4* zelda, PlayState* play, RandomizerCh
     } else if (!Flags_GetTreasure(play, 0x1E) && !Randomizer_GetSettingValue(RSK_SKIP_CHILD_ZELDA) && Actor_TextboxIsClosing(&zelda->actor, play) &&
                (play->msgCtx.textId == 0x703C || play->msgCtx.textId == 0x703D)) {
         GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(check, GI_LETTER_ZELDA);
+        GET_PLAYER(play)->rangeCheck = check; // for OnCollectCheck
         GiveItemEntryFromActor(&zelda->actor, play, getItemEntry, 10000.0f, 100.0f);
     } else if (Flags_GetTreasure(play, 0x1E) && !Player_InBlockingCsMode(play, GET_PLAYER(play))) {
         gSaveContext.unk_13EE = 0x32;

--- a/soh/src/overlays/actors/ovl_Fishing/z_fishing.c
+++ b/soh/src/overlays/actors/ovl_Fishing/z_fishing.c
@@ -5087,6 +5087,7 @@ void Fishing_HandleOwnerDialog(Fishing* this, PlayState* play) {
                 if (!IS_RANDO || getItemEntry.getItemId == GI_NONE) {
                     func_8002F434(&this->actor, play, getItemId, 2000.0f, 1000.0f);
                 } else {
+                    GET_PLAYER(play)->rangeCheck = LINK_IS_ADULT ? RC_LH_ADULT_FISHING : RC_LH_CHILD_FISHING; // for OnCollectCheck
                     GiveItemEntryFromActor(&this->actor, play, getItemEntry, 2000.0f, 1000.0f);
                 }
                 this->unk_15C = 23;
@@ -5153,6 +5154,7 @@ void Fishing_HandleOwnerDialog(Fishing* this, PlayState* play) {
                     func_8002F434(&this->actor, play, GI_SCALE_GOLD, 2000.0f, 1000.0f);
                 } else {
                     GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(RC_LH_ADULT_FISHING, GI_SCALE_GOLD);
+                    GET_PLAYER(play)->rangeCheck = RC_LH_ADULT_FISHING; // for OnCollectCheck
                     GiveItemEntryFromActor(&this->actor, play, getItemEntry, 2000.0f, 1000.0f);
                 }
             }

--- a/soh/src/overlays/actors/ovl_Item_B_Heart/z_item_b_heart.c
+++ b/soh/src/overlays/actors/ovl_Item_B_Heart/z_item_b_heart.c
@@ -62,7 +62,9 @@ void ItemBHeart_Update(Actor* thisx, PlayState* play) {
         if (!IS_RANDO) {
             func_8002F434(&this->actor, play, GI_HEART_CONTAINER_2, 30.0f, 40.0f);
         } else {
-            GetItemEntry getItemEntry = Randomizer_GetItemFromActor(this->actor.id, play->sceneNum, this->actor.params, GI_HEART_CONTAINER_2);
+            RandomizerCheck check = Randomizer_GetCheckFromActor(this->actor.id, play->sceneNum, this->actor.params);
+            GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(check, GI_HEART_CONTAINER_2);
+            GET_PLAYER(play)->rangeCheck = check; // for OnCollectCheck
             GiveItemEntryFromActor(&this->actor, play, getItemEntry, 30.0f, 40.0f);
         }
     }

--- a/soh/src/overlays/actors/ovl_Item_Etcetera/z_item_etcetera.c
+++ b/soh/src/overlays/actors/ovl_Item_Etcetera/z_item_etcetera.c
@@ -137,6 +137,7 @@ void func_80B85824(ItemEtcetera* this, PlayState* play) {
             func_8002F434(&this->actor, play, this->getItemId, 30.0f, 50.0f);
         } else {
             GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(RC_LH_SUN, GI_ARROW_FIRE);
+            GET_PLAYER(play)->rangeCheck = RC_LH_SUN; // for OnCollectCheck
             GiveItemEntryFromActor(&this->actor, play, getItemEntry, 30.0f, 50.0f);
         }
     }
@@ -160,6 +161,7 @@ void func_80B858B4(ItemEtcetera* this, PlayState* play) {
             func_8002F434(&this->actor, play, this->getItemId, 30.0f, 50.0f);
         } else {
             GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(RC_LH_UNDERWATER_ITEM, GI_LETTER_RUTO);
+            GET_PLAYER(play)->rangeCheck = RC_LH_UNDERWATER_ITEM; // for OnCollectCheck
             GiveItemEntryFromActor(&this->actor, play, getItemEntry, 30.0f, 50.0f);
         }
 

--- a/soh/src/overlays/actors/ovl_Item_Ocarina/z_item_ocarina.c
+++ b/soh/src/overlays/actors/ovl_Item_Ocarina/z_item_ocarina.c
@@ -193,6 +193,7 @@ void ItemOcarina_WaitInWater(ItemOcarina* this, PlayState* play) {
             func_8002F434(&this->actor, play, GI_OCARINA_OOT, 30.0f, 50.0f);
         } else {
             GetItemEntry getItemEntry = Randomizer_GetItemFromKnownCheck(RC_HF_OCARINA_OF_TIME_ITEM, GI_OCARINA_OOT);
+            GET_PLAYER(play)->rangeCheck = RC_HF_OCARINA_OF_TIME_ITEM; // for OnCollectCheck
             GiveItemEntryFromActor(&this->actor, play, getItemEntry, 30.0f, 50.0f);
         }
 


### PR DESCRIPTION
It works as such: for the times when an item give is triggered from `GiveItemEntryFromActor`, the `RandomizerCheck` used in `GetItemEntryFromActor` in that same block of the code is assigned to `Player.rangeCheck`, which is later moved to `Player.getItemCheck` inside `GiveItemEntryFromActor` (to allow for the possibility of the range check failing). Otherwise, the `RandomizerCheck` is already specified and directly assigned to `Player.getItemCheck`. Then, when `Item_Give` or `Randomizer_Item_Give` is called, at the beginning of them, if `Player.getItemCheck` is not `RC_MAX` (which is what I use to clear it) or `RC_UNKNOWN_CHECK` (which it can be sometimes based on lookups), it sends the check to `OnCollectCheck` and clears `Player.getItemCheck`.

I decided to do it outside of any `GetItemEntry` lookups because I couldn't otherwise guarantee that anything set from those lookups would be cleared before an `Item_Give` call happened that wasn't a randomizer check.

Can pretty much guarantee this will need to be updated with both beehive shuffle and master sword shuffle.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/967541218.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/967541220.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/967541222.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/967541223.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/967541225.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/967541226.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/967541227.zip)
<!--- section:artifacts:end -->