### PR TITLE
Use manifest for windows DPI awareness

### DIFF
--- a/soh/SHIPOFHARKINIAN.manifest
+++ b/soh/SHIPOFHARKINIAN.manifest
@@ -28,4 +28,10 @@
       <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
     </application>
   </compatibility>
+  <asmv3:application xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+    <asmv3:windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware> <!-- legacy -->
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">permonitorv2,permonitor</dpiAwareness> <!-- falls back to pm if pmv2 is not available -->
+    </asmv3:windowsSettings>
+  </asmv3:application>
 </assembly>


### PR DESCRIPTION
This is needed for proper DPI awareness on Windows.

- [x] Needs LUS PR: https://github.com/Kenix3/libultraship/pull/365

The LUS PR pushes the responsibility of making the Windows app DPI aware to the port, so we need this change to the Windows app manifest on the ports side, to tell Windows that we can handle it. 

This means when the LUS changes are merged, the port is completely DPI unaware under Windows until the app manifest changes in this PR are merged!

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1236276147.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1236285602.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1236286274.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1236286329.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1236287770.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1236288099.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1236293930.zip)
<!--- section:artifacts:end -->