### PR TITLE
[Bugfix] Move `Heaps_Free` after `DeinitOTR` in `SDL_main`

### DIFF
--- a/soh/src/code/main.c
+++ b/soh/src/code/main.c
@@ -65,8 +65,10 @@ int main(int argc, char** argv)
     CrashHandlerRegisterCallback(CrashHandler_PrintSohData);
     BootCommands_Init();
 
+    Heaps_Alloc();
     Main(0);
     DeinitOTR();
+    Heaps_Free();
     return 0;
 }
 
@@ -87,7 +89,6 @@ void Main(void* arg) {
     PreNmiBuff_Init(gAppNmiBufferPtr);
     Fault_Init();
     SysCfb_Init(0);
-    Heaps_Alloc();
     sysHeap = (uintptr_t)gSystemHeap;
     fb = SysCfb_GetFbPtr(0);
     gSystemHeapSize = 1024 * 1024 * 4;
@@ -156,6 +157,4 @@ void Main(void* arg) {
     osDestroyThread(&sGraphThread);
     func_800FBFD8();
     osSyncPrintf("mainproc 実行終了\n"); // "End of execution"
-
-    Heaps_Free();
 }


### PR DESCRIPTION
Anchor was having some issues with accessing a non-null, garbage `gPlayState` from `DeinitOTR` as part of cleanup when closing while the game was running, causing a crash on closing. This was caused by `Heaps_Free` in `Main` deallocating the memory for `gPlayState` without making its pointer null. This PR moves `Heaps_Free` after `DeinitOTR` in `SDL_main` so all closing/cleanup operations can be done without worrying about non-null garbage pointers/references.

I took this approach instead of moving `DeinitOTR` inside `Main` before `Heaps_Free` as I figured there was probably a reason Deinit wasn't added inside Main in the first place, and this provides a better model for adding anything else that we might need in the future before `Heaps_Free`.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/996274687.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/996274689.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/996274691.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/996274692.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/996274694.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/996274696.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/996274697.zip)
<!--- section:artifacts:end -->