### PR TITLE
Fix: Triforce transition offset values

### DIFF
--- a/soh/assets/xml/GC_NMQ_D/code/fbdemo_triforce.xml
+++ b/soh/assets/xml/GC_NMQ_D/code/fbdemo_triforce.xml
@@ -1,7 +1,7 @@
 <Root>
-    <File Name="code" OutName="z_fbdemo_triforce" RangeStart="0x10E1D0" RangeEnd="0x10E2A0">
-        <DList Name="sTransTriforceDL" Offset="0x10E1D0"/>
-        <Array Name="sTransTriforceVtx" Count="10" Offset="0x10E200">
+    <File Name="code" OutName="z_fbdemo_triforce" RangeStart="0x10E1F0" RangeEnd="0x10E2C0">
+        <DList Name="sTransTriforceDL" Offset="0x10E1F0"/>
+        <Array Name="sTransTriforceVtx" Count="10" Offset="0x10E220">
             <Vtx/>
         </Array>
     </File>


### PR DESCRIPTION
After all the asset changes for the other ROMs, the transitions have been fixed, but the triforce transition for GC debug apparently has been broken since the beginning. This corrects the offset values and now the triforce transition works for all roms.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/984621704.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/984621705.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/984621707.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/984621709.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/984621711.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/984621715.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/984621717.zip)
<!--- section:artifacts:end -->