### PR TITLE
Check for compressed files in the extractor

### DIFF
--- a/soh/soh/Extractor/Extract.cpp
+++ b/soh/soh/Extractor/Extract.cpp
@@ -336,14 +336,18 @@ bool Extractor::ValidateAndFixRom() {
 bool Extractor::ValidateNotCompressed() const {
     // ZIP file header
     if (mRomData[0] == 'P' && mRomData[1] == 'K' && mRomData[2] == 0x03 && mRomData[3] == 0x04) {
-        return 0;
+        return false;
     }
     // RAR file header. Only the first 4 bytes.
     if (mRomData[0] == 'R' && mRomData[1] == 'a' && mRomData[2] == 'r' && mRomData[3] == 0x21) {
-        return 0;
+        return false;
+    }
+    // 7z file header. 37 7A BC AF 27 1C
+    if (mRomData[0] == '7' && mRomData[1] == 'z' && mRomData[2] == 0xBC && mRomData[3] == 0xAF && mRomData[4] == 0x27 && mRomData[5] == 0x1C) {
+        return false;
     }
 
-    return 1;
+    return true;
 }
 
 bool Extractor::ValidateRomSize() const {

--- a/soh/soh/Extractor/Extract.h
+++ b/soh/soh/Extractor/Extract.h
@@ -38,6 +38,7 @@ class Extractor {
     bool ValidateRomSize() const;
 
     bool ValidateRom(bool skipCrcBox = false);
+    bool ValidateNotCompressed() const;
     const char* GetZapdVerStr() const;
 
     void SetRomInfo(const std::string& path);
@@ -46,6 +47,7 @@ class Extractor {
     void GetRoms(std::vector<std::string>& roms);
     void ShowSizeErrorBox() const;
     void ShowCrcErrorBox() const;
+    void ShowCompressedErrorBox() const;
     int ShowRomPickBox(uint32_t verCrc) const;
     bool ManuallySearchForRom();
     bool ManuallySearchForRomMatchingType(RomSearchMode searchMode);


### PR DESCRIPTION
In some rare situations a zip file can make its way into the extractor. Instead of just throwing the normal size error be more specific with the error.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/985619292.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/985619293.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/985619296.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/985619298.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/985619299.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/985619300.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/985619301.zip)
<!--- section:artifacts:end -->