### PR TITLE
Fix Entrance hubs having no HintKey, causing hints to No Item

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/hint_list.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/hint_list.cpp
@@ -1046,6 +1046,11 @@ void HintTable_Init() {
         Text{ "Temple of Time", /*french*/ "le Temple du Temps", /*spanish*/ "el Templo del Tiempo" },
     });
 
+    hintTable[CASTLE_GROUNDS] = HintText::Exclude({
+        // obscure text
+        Text{ "the Castle Grounds", /*french*/ "le Château d'Hyrule", /*spanish*/ "" },
+    });
+
     hintTable[HYRULE_CASTLE] = HintText::Exclude({
         // obscure text
         Text{ "Hyrule Castle", /*french*/ "le Château d'Hyrule", /*spanish*/ "el Castillo de Hyrule" },

--- a/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_castle_town.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_castle_town.cpp
@@ -70,7 +70,7 @@ void AreaTable_Init_CastleTown() {
                   Entrance(TEMPLE_OF_TIME, {[]{return true;}}),
   });
 
-  areaTable[CASTLE_GROUNDS] = Area("Castle Grounds", "Castle Grounds", THE_MARKET, NO_DAY_NIGHT_CYCLE, {}, {}, {
+  areaTable[CASTLE_GROUNDS] = Area("Castle Grounds", "Castle Grounds", CASTLE_GROUNDS, NO_DAY_NIGHT_CYCLE, {}, {}, {
                   //Exits
                   Entrance(THE_MARKET,            {[]{return true;}}),
                   Entrance(HYRULE_CASTLE_GROUNDS, {[]{return IsChild;}}),

--- a/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_castle_town.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_castle_town.cpp
@@ -70,7 +70,7 @@ void AreaTable_Init_CastleTown() {
                   Entrance(TEMPLE_OF_TIME, {[]{return true;}}),
   });
 
-  areaTable[CASTLE_GROUNDS] = Area("Castle Grounds", "Castle Grounds", NONE, NO_DAY_NIGHT_CYCLE, {}, {}, {
+  areaTable[CASTLE_GROUNDS] = Area("Castle Grounds", "Castle Grounds", THE_MARKET, NO_DAY_NIGHT_CYCLE, {}, {}, {
                   //Exits
                   Entrance(THE_MARKET,            {[]{return true;}}),
                   Entrance(HYRULE_CASTLE_GROUNDS, {[]{return IsChild;}}),
@@ -156,7 +156,7 @@ void AreaTable_Init_CastleTown() {
     Entrance(GANONS_CASTLE_LEDGE, { [] { return IsAdult; }}),
   });
 
-  areaTable[GANONS_CASTLE_LEDGE] = Area("Ganon's Castle Ledge", "OGC Ganon's Castle Ledge", NONE, NO_DAY_NIGHT_CYCLE,
+  areaTable[GANONS_CASTLE_LEDGE] = Area("Ganon's Castle Ledge", "OGC Ganon's Castle Ledge", OUTSIDE_GANONS_CASTLE, NO_DAY_NIGHT_CYCLE,
   {}, {}, {
     // Exits
     Entrance(GANONS_CASTLE_GROUNDS, {[]{return BuiltRainbowBridge;}}),

--- a/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_death_mountain.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_death_mountain.cpp
@@ -46,7 +46,7 @@ void AreaTable_Init_DeathMountain() {
                   Entrance(DMT_GREAT_FAIRY_FOUNTAIN, {[]{return Here(DEATH_MOUNTAIN_SUMMIT, []{return CanBlastOrSmash;});}}),
   });
 
-  areaTable[DMT_OWL_FLIGHT] = Area("DMT Owl Flight", "Death Mountain", NONE, NO_DAY_NIGHT_CYCLE, {}, {}, {
+  areaTable[DMT_OWL_FLIGHT] = Area("DMT Owl Flight", "Death Mountain", DEATH_MOUNTAIN_TRAIL, NO_DAY_NIGHT_CYCLE, {}, {}, {
                   //Exits
                   Entrance(KAK_IMPAS_ROOFTOP, {[]{return true;}}),
   });
@@ -108,7 +108,7 @@ void AreaTable_Init_DeathMountain() {
                   Entrance(GC_GROTTO_PLATFORM,   {[]{return IsAdult && ((CanPlay(SongOfTime) && ((EffectiveHealth > 2) || CanUse(GORON_TUNIC) || CanUse(LONGSHOT) || CanUse(NAYRUS_LOVE))) || (EffectiveHealth > 1 && CanUse(GORON_TUNIC) && CanUse(HOOKSHOT)) || (CanUse(NAYRUS_LOVE) && CanUse(HOOKSHOT)) || (EffectiveHealth > 2 && CanUse(HOOKSHOT) && LogicGoronCityGrotto));}}),
   });
 
-  areaTable[GC_WOODS_WARP] = Area("GC Woods Warp", "Goron City", NONE, NO_DAY_NIGHT_CYCLE, {
+  areaTable[GC_WOODS_WARP] = Area("GC Woods Warp", "Goron City", GORON_CITY, NO_DAY_NIGHT_CYCLE, {
                   //Events
                   EventAccess(&GCWoodsWarpOpen, {[]{return GCWoodsWarpOpen || (CanBlastOrSmash || CanUse(DINS_FIRE));}}),
                 }, {}, {

--- a/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_gerudo_valley.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_gerudo_valley.cpp
@@ -119,7 +119,7 @@ void AreaTable_Init_GerudoValley() {
                   Entrance(GF_STORMS_GROTTO,                 {[]{return IsAdult && CanOpenStormGrotto;}}),
   });
 
-  areaTable[GF_OUTSIDE_GATE] = Area("GF Outside Gate", "Gerudo Fortress", NONE, NO_DAY_NIGHT_CYCLE, {
+  areaTable[GF_OUTSIDE_GATE] = Area("GF Outside Gate", "Gerudo Fortress", GERUDO_FORTRESS, NO_DAY_NIGHT_CYCLE, {
                   //Events
                   EventAccess(&GF_GateOpen, {[]{return IsAdult && GerudoToken && (ShuffleGerudoToken || ShuffleOverworldEntrances /*|| ShuffleSpecialIndoorEntrances*/);}}),
                 }, {}, {
@@ -157,7 +157,7 @@ void AreaTable_Init_GerudoValley() {
                   Entrance(WASTELAND_NEAR_FORTRESS, {[]{return CanUse(HOVER_BOOTS) || CanUse(LONGSHOT) || LogicWastelandCrossing;}}),
   });
 
-  areaTable[WASTELAND_NEAR_COLOSSUS] = Area("Wasteland Near Colossus", "Haunted Wasteland", NONE, NO_DAY_NIGHT_CYCLE, {}, {}, {
+  areaTable[WASTELAND_NEAR_COLOSSUS] = Area("Wasteland Near Colossus", "Haunted Wasteland", HAUNTED_WASTELAND, NO_DAY_NIGHT_CYCLE, {}, {}, {
                   //Exits
                   Entrance(DESERT_COLOSSUS,   {[]{return true;}}),
                   Entrance(HAUNTED_WASTELAND, {[]{return LogicReverseWasteland || false;}}),

--- a/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_hyrule_field.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_hyrule_field.cpp
@@ -138,7 +138,7 @@ void AreaTable_Init_HyruleField() {
                   Entrance(LH_FISHING_HOLE, {[]{return true;}}),
   });
 
-  areaTable[LH_OWL_FLIGHT] = Area("LH Owl Flight", "Lake Hylia", NONE, NO_DAY_NIGHT_CYCLE, {}, {}, {
+  areaTable[LH_OWL_FLIGHT] = Area("LH Owl Flight", "Lake Hylia", LAKE_HYLIA, NO_DAY_NIGHT_CYCLE, {}, {}, {
                   //Exits
                   Entrance(HYRULE_FIELD, {[]{return true;}}),
   });

--- a/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_kakariko.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_kakariko.cpp
@@ -278,7 +278,7 @@ void AreaTable_Init_Kakariko() {
                   Entrance(SHADOW_TEMPLE_ENTRYWAY,    {[]{return CanUse(DINS_FIRE) || (LogicShadowFireArrowEntry && IsAdult && CanUse(FIRE_ARROWS));}}),
   });
 
-  areaTable[KAK_BEHIND_GATE] = Area("Kak Behind Gate", "Kakariko Village", NONE, NO_DAY_NIGHT_CYCLE, {}, {}, {
+  areaTable[KAK_BEHIND_GATE] = Area("Kak Behind Gate", "Kakariko Village", KAKARIKO_VILLAGE, NO_DAY_NIGHT_CYCLE, {}, {}, {
                   //Exits
                   Entrance(KAKARIKO_VILLAGE,     {[]{return IsAdult || LogicVisibleCollision || KakarikoVillageGateOpen || OpenKakariko.Is(OPENKAKARIKO_OPEN);}}),
                   Entrance(DEATH_MOUNTAIN_TRAIL, {[]{return true;}}),

--- a/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_lost_woods.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_lost_woods.cpp
@@ -105,7 +105,7 @@ void AreaTable_Init_LostWoods() {
                   Entrance(KOKIRI_FOREST, {[]{return true;}})
   });
 
-  areaTable[LW_FOREST_EXIT] = Area("LW Forest Exit", "Lost Woods", NONE, NO_DAY_NIGHT_CYCLE, {}, {}, {
+  areaTable[LW_FOREST_EXIT] = Area("LW Forest Exit", "Lost Woods", THE_LOST_WOODS, NO_DAY_NIGHT_CYCLE, {}, {}, {
                   //Exits
                   Entrance(KOKIRI_FOREST, {[]{return true;}})
   });

--- a/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_zoras_domain.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_zoras_domain.cpp
@@ -48,7 +48,7 @@ void AreaTable_Init_ZorasDomain() {
                   Entrance(ZR_BEHIND_WATERFALL, {[]{return CanPlay(ZeldasLullaby) || (IsChild && LogicZoraWithCucco) || (IsAdult && CanUse(HOVER_BOOTS) && LogicZoraWithHovers);}}),
   });
 
-  areaTable[ZR_BEHIND_WATERFALL] = Area("ZR Behind Waterfall", "Zora River", NONE, DAY_NIGHT_CYCLE, {}, {}, {
+  areaTable[ZR_BEHIND_WATERFALL] = Area("ZR Behind Waterfall", "Zora River", ZORAS_RIVER, DAY_NIGHT_CYCLE, {}, {}, {
                   //Exits
                   Entrance(ZORAS_RIVER,  {[]{return true;}}),
                   Entrance(ZORAS_DOMAIN, {[]{return true;}}),
@@ -106,7 +106,7 @@ void AreaTable_Init_ZorasDomain() {
                   Entrance(ZD_STORMS_GROTTO,    {[]{return CanOpenStormGrotto;}}),
   });
 
-  areaTable[ZD_BEHIND_KING_ZORA] = Area("ZD Behind King Zora", "Zoras Domain", NONE, NO_DAY_NIGHT_CYCLE, {}, {}, {
+  areaTable[ZD_BEHIND_KING_ZORA] = Area("ZD Behind King Zora", "Zoras Domain", ZORAS_DOMAIN, NO_DAY_NIGHT_CYCLE, {}, {}, {
                   //Exits
                   Entrance(ZORAS_DOMAIN,   {[]{return DeliverLetter || ZorasFountain.Is(ZORASFOUNTAIN_OPEN) || (ZorasFountain.Is(ZORASFOUNTAIN_ADULT) && IsAdult);}}),
                   Entrance(ZORAS_FOUNTAIN, {[]{return true;}}),


### PR DESCRIPTION
As Title, addresses the issues Cob had in discord. I'm pretty sure I gave everything the correct location but a doublecheck would be nice.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/995213973.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/995213974.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/995213976.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/995213978.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/995213979.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/995213982.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/995213984.zip)
<!--- section:artifacts:end -->