### PR TITLE
Fix greg as reward logic

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/logic.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/logic.cpp
@@ -121,7 +121,8 @@ namespace Logic {
 
   //Greg
   bool Greg = false;
-  bool GregInLogic = false;
+  bool GregInBridgeLogic = false;
+  bool GregInLacsLogic = false;
 
   //Progressive Items
   uint8_t ProgressiveBulletBag  = 0;
@@ -607,22 +608,23 @@ namespace Logic {
     DungeonCount          = (DekuTreeClear ? 1:0) + (DodongosCavernClear ? 1:0) + (JabuJabusBellyClear ? 1:0) + (ForestTempleClear ? 1:0) + (FireTempleClear ? 1:0) + (WaterTempleClear ? 1:0) + (SpiritTempleClear ? 1:0) + (ShadowTempleClear ? 1:0);
     HasAllStones          = StoneCount == 3;
     HasAllMedallions      = MedallionCount == 6;
-    GregInLogic           = BridgeRewardOptions.Is(BRIDGE_OPTION_GREG) || LACSRewardOptions.Is(LACS_OPTION_GREG);
+    GregInBridgeLogic     = BridgeRewardOptions.Is(BRIDGE_OPTION_GREG);
+    GregInLacsLogic       = LACSRewardOptions.Is(LACS_OPTION_GREG);
 
     CanBuildRainbowBridge = Bridge.Is(RAINBOWBRIDGE_OPEN)                                                                         ||
                            (Bridge.Is(RAINBOWBRIDGE_VANILLA)    && ShadowMedallion && SpiritMedallion && LightArrows)             ||
-                           (Bridge.Is(RAINBOWBRIDGE_STONES)     && StoneCount + (Greg && GregInLogic ? 1 : 0) >= BridgeStoneCount.Value<uint8_t>())                    ||
-                           (Bridge.Is(RAINBOWBRIDGE_MEDALLIONS) && MedallionCount + (Greg && GregInLogic ? 1 : 0) >= BridgeMedallionCount.Value<uint8_t>())            ||
-                           (Bridge.Is(RAINBOWBRIDGE_REWARDS)    && StoneCount + MedallionCount + (Greg && GregInLogic ? 1 : 0) >= BridgeRewardCount.Value<uint8_t>())  ||
-                           (Bridge.Is(RAINBOWBRIDGE_DUNGEONS)   && DungeonCount + (Greg && GregInLogic ? 1 : 0) >= BridgeDungeonCount.Value<uint8_t>())                ||
+                           (Bridge.Is(RAINBOWBRIDGE_STONES)     && StoneCount + (Greg && GregInBridgeLogic ? 1 : 0) >= BridgeStoneCount.Value<uint8_t>())                    ||
+                           (Bridge.Is(RAINBOWBRIDGE_MEDALLIONS) && MedallionCount + (Greg && GregInBridgeLogic ? 1 : 0) >= BridgeMedallionCount.Value<uint8_t>())            ||
+                           (Bridge.Is(RAINBOWBRIDGE_REWARDS)    && StoneCount + MedallionCount + (Greg && GregInBridgeLogic ? 1 : 0) >= BridgeRewardCount.Value<uint8_t>())  ||
+                           (Bridge.Is(RAINBOWBRIDGE_DUNGEONS)   && DungeonCount + (Greg && GregInBridgeLogic ? 1 : 0) >= BridgeDungeonCount.Value<uint8_t>())                ||
                            (Bridge.Is(RAINBOWBRIDGE_TOKENS)     && GoldSkulltulaTokens >= BridgeTokenCount.Value<uint8_t>()) ||
                            (Bridge.Is(RAINBOWBRIDGE_GREG)       && Greg);
 
     CanTriggerLACS = (LACSCondition == LACSCONDITION_VANILLA    && ShadowMedallion && SpiritMedallion)                          ||
-                     (LACSCondition == LACSCONDITION_STONES     && StoneCount + (Greg && GregInLogic ? 1 : 0) >= LACSStoneCount.Value<uint8_t>())                    ||
-                     (LACSCondition == LACSCONDITION_MEDALLIONS && MedallionCount + (Greg && GregInLogic ? 1 : 0) >= LACSMedallionCount.Value<uint8_t>())            ||
-                     (LACSCondition == LACSCONDITION_REWARDS    && StoneCount + MedallionCount + (Greg && GregInLogic ? 1 : 0) >= LACSRewardCount.Value<uint8_t>())  ||
-                     (LACSCondition == LACSCONDITION_DUNGEONS   && DungeonCount + (Greg && GregInLogic ? 1 : 0) >= LACSDungeonCount.Value<uint8_t>())                ||
+                     (LACSCondition == LACSCONDITION_STONES     && StoneCount + (Greg && GregInLacsLogic ? 1 : 0) >= LACSStoneCount.Value<uint8_t>())                    ||
+                     (LACSCondition == LACSCONDITION_MEDALLIONS && MedallionCount + (Greg && GregInLacsLogic ? 1 : 0) >= LACSMedallionCount.Value<uint8_t>())            ||
+                     (LACSCondition == LACSCONDITION_REWARDS    && StoneCount + MedallionCount + (Greg && GregInLacsLogic ? 1 : 0) >= LACSRewardCount.Value<uint8_t>())  ||
+                     (LACSCondition == LACSCONDITION_DUNGEONS   && DungeonCount + (Greg && GregInLacsLogic ? 1 : 0) >= LACSDungeonCount.Value<uint8_t>())                ||
                      (LACSCondition == LACSCONDITION_TOKENS     && GoldSkulltulaTokens >= LACSTokenCount.Value<uint8_t>());
     CanCompleteTriforce = TriforcePieces >= TriforceHuntRequired.Value<uint8_t>();
   }
@@ -835,6 +837,8 @@ namespace Logic {
 
      //Greg
      Greg = false;
+     GregInBridgeLogic = false;
+     GregInLacsLogic = false;
 
      //Progressive Items
      ProgressiveBulletBag  = 0;

--- a/soh/soh/Enhancements/randomizer/3drando/logic.hpp
+++ b/soh/soh/Enhancements/randomizer/3drando/logic.hpp
@@ -115,6 +115,8 @@ extern bool LightTrialClear;
 
 //Greg
 extern bool Greg;
+extern bool GregInBridgeLogic;
+extern bool GregInLacsLogic;
 
 // Progression Items
 extern uint8_t ProgressiveBulletBag;


### PR DESCRIPTION
Initially the reward logic would internally be set to 'greg as reward' for both the bridge and lacs rewards only if at least 1 had that option selected. This lead to scenarios where the bridge rewards would be set to standard, and the lacs rewards would be set to greg as reward, which caused the bridge logic to require greg 

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/988047745.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/988047748.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/988047749.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/988047752.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/988047756.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/988047758.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/988047760.zip)
<!--- section:artifacts:end -->