### PR TITLE
Toggle Strength Option

### DIFF
--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -604,6 +604,12 @@ void DrawEnhancementsMenu() {
                 UIWidgets::Tooltip("Prevent bombchus from forcing the camera into first-person mode when released.");
                 UIWidgets::PaddedEnhancementCheckbox("Aiming reticle for the bow/slingshot", "gBowReticle", true, false);
                 UIWidgets::Tooltip("Aiming with a bow or slingshot will display a reticle as with the hookshot when the projectile is ready to fire.");
+                if (UIWidgets::PaddedEnhancementCheckbox("Allow strength equipment to be toggled", "gToggleStrength", true, false)) {
+                    if (!CVarGetInteger("gToggleStrength", 0)) {
+                        CVarSetInteger("gStrengthDisabled", 0);
+                    }
+                }
+                UIWidgets::Tooltip("Allows strength to be toggled on and off by pressing A on the strength upgrade in the equipment subscreen of the pause menu");
                 ImGui::EndMenu();
             }
 

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -609,7 +609,7 @@ void DrawEnhancementsMenu() {
                         CVarSetInteger("gStrengthDisabled", 0);
                     }
                 }
-                UIWidgets::Tooltip("Allows strength to be toggled on and off by pressing A on the strength upgrade in the equipment subscreen of the pause menu");
+                UIWidgets::Tooltip("Allows strength to be toggled on and off by pressing A on the strength upgrade in the equipment subscreen of the pause menu (This allows performing some glitches that require the player to not have strength).");
                 ImGui::EndMenu();
             }
 

--- a/soh/src/code/z_player_lib.c
+++ b/soh/src/code/z_player_lib.c
@@ -509,6 +509,10 @@ s32 Player_IsBurningStickInRange(PlayState* play, Vec3f* pos, f32 xzRange, f32 y
 s32 Player_GetStrength(void) {
     s32 strengthUpgrade = CUR_UPG_VALUE(UPG_STRENGTH);
 
+    if (CVarGetInteger("gToggleStrength", 0) && CVarGetInteger("gStrengthDisabled", 0)) {
+        return PLAYER_STR_NONE;
+    }
+
     if (CVarGetInteger("gTimelessEquipment", 0) || LINK_IS_ADULT) {
         return strengthUpgrade;
     } else if (strengthUpgrade != 0) {

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_equipment.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_equipment.c
@@ -1,6 +1,7 @@
 #include "z_kaleido_scope.h"
 #include "textures/icon_item_static/icon_item_static.h"
 #include "textures/parameter_static/parameter_static.h"
+#include "soh/Enhancements/cosmetics/cosmeticsTypes.h"
 
 static u8 sChildUpgrades[] = { UPG_BULLET_BAG, UPG_BOMB_BAG, UPG_STRENGTH, UPG_SCALE };
 static u8 sAdultUpgrades[] = { UPG_QUIVER, UPG_BOMB_BAG, UPG_STRENGTH, UPG_SCALE };
@@ -12,6 +13,15 @@ static u8 sUpgradeItemOffsets[] = { 0x00, 0x03, 0x06, 0x09 };
 
 static u8 sEquipmentItemOffsets[] = {
     0x00, 0x00, 0x01, 0x02, 0x00, 0x03, 0x04, 0x05, 0x00, 0x06, 0x07, 0x08, 0x00, 0x09, 0x0A, 0x0B,
+};
+
+// Vertices for A button indicator (coordinates 0.75x the texture size)
+// pt (-97, -36)
+static Vtx sStrengthAButtonVtx[] = {
+    VTX(-9,  6, 0, 0 << 5, 0 << 5, 0xFF, 0xFF, 0xFF, 0xFF),
+    VTX( 9,  6, 0, 24 << 5, 0 << 5, 0xFF, 0xFF, 0xFF, 0xFF),
+    VTX(-9, -6, 0, 0 << 5, 16 << 5, 0xFF, 0xFF, 0xFF, 0xFF),
+    VTX( 9, -6, 0, 24 << 5, 16 << 5, 0xFF, 0xFF, 0xFF, 0xFF),
 };
 
 static s16 sEquipTimer = 0;
@@ -86,6 +96,30 @@ void KaleidoScope_DrawEquipmentImage(PlayState* play, void* source, u32 width, u
         vtxIndex += 4;
     }
 
+    CLOSE_DISPS(play->state.gfxCtx);
+}
+
+void KaleidoScope_DrawAButton(PlayState* play, Vtx* vtx, int16_t xTranslate, int16_t yTranslate) {
+    PauseContext* pauseCtx = &play->pauseCtx;
+    OPEN_DISPS(play->state.gfxCtx);
+    Matrix_Push();
+
+    Matrix_Translate(xTranslate, yTranslate, 0, MTXMODE_APPLY);
+    gSPMatrix(POLY_KAL_DISP++, MATRIX_NEWMTX(play->state.gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+    Color_RGB8 aButtonColor = { 0, 100, 255 };
+    if (CVarGetInteger("gCosmetics.Hud_AButton.Changed", 0)) {
+        aButtonColor = CVarGetColor24("gCosmetics.Hud_AButton.Value", aButtonColor);
+    } else if (CVarGetInteger("gCosmetics.DefaultColorScheme", COLORSCHEME_N64) == COLORSCHEME_GAMECUBE) {
+        aButtonColor = (Color_RGB8){ 0, 255, 100 };
+    }
+
+    gSPVertex(POLY_KAL_DISP++, vtx, 4, 0);
+    gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, aButtonColor.r, aButtonColor.g, aButtonColor.b, pauseCtx->alpha);
+    gDPLoadTextureBlock(POLY_KAL_DISP++, gABtnSymbolTex, G_IM_FMT_IA, G_IM_SIZ_8b, 24, 16, 0,
+                        G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR | G_TX_CLAMP, 4, 4, G_TX_NOLOD, G_TX_NOLOD);
+    gSP1Quadrangle(POLY_KAL_DISP++, 0, 2, 3, 1, 0);
+    Matrix_Pop();
+    gSPMatrix(POLY_KAL_DISP++, MATRIX_NEWMTX(play->state.gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
     CLOSE_DISPS(play->state.gfxCtx);
 }
 
@@ -686,18 +720,18 @@ void KaleidoScope_DrawEquipment(PlayState* play) {
 
     // Add zoom effect to strength item if cursor is hovering over it when toggle option is on
     if ((pauseCtx->cursorX[PAUSE_EQUIP] == 0) && (pauseCtx->cursorY[PAUSE_EQUIP] == 2) &&
-        CVarGetInteger("gToggleStrength", 0)) {
-        i = 2; // row
-        k = 0; // column
-        j = 16 * i + 4 * k; // vtx index
-        pauseCtx->equipVtx[j].v.ob[0] = pauseCtx->equipVtx[j + 2].v.ob[0] =
-            pauseCtx->equipVtx[j].v.ob[0] - 2;
-        pauseCtx->equipVtx[j + 1].v.ob[0] = pauseCtx->equipVtx[j + 3].v.ob[0] =
-            pauseCtx->equipVtx[j + 1].v.ob[0] + 4;
-        pauseCtx->equipVtx[j].v.ob[1] = pauseCtx->equipVtx[j + 1].v.ob[1] =
-            pauseCtx->equipVtx[j].v.ob[1] + 2;
-        pauseCtx->equipVtx[j + 2].v.ob[1] = pauseCtx->equipVtx[j + 3].v.ob[1] =
-            pauseCtx->equipVtx[j + 2].v.ob[1] - 4;
+        CVarGetInteger("gToggleStrength", 0) && pauseCtx->cursorSpecialPos == 0) {
+        u8 row = 2;
+        u8 column = 0;
+        u8 equipVtxIndex = 16 * row + 4 * column;
+        pauseCtx->equipVtx[equipVtxIndex].v.ob[0] = pauseCtx->equipVtx[equipVtxIndex + 2].v.ob[0] =
+            pauseCtx->equipVtx[equipVtxIndex].v.ob[0] - 2;
+        pauseCtx->equipVtx[equipVtxIndex + 1].v.ob[0] = pauseCtx->equipVtx[equipVtxIndex + 3].v.ob[0] =
+            pauseCtx->equipVtx[equipVtxIndex + 1].v.ob[0] + 4;
+        pauseCtx->equipVtx[equipVtxIndex].v.ob[1] = pauseCtx->equipVtx[equipVtxIndex + 1].v.ob[1] =
+            pauseCtx->equipVtx[equipVtxIndex].v.ob[1] + 2;
+        pauseCtx->equipVtx[equipVtxIndex + 2].v.ob[1] = pauseCtx->equipVtx[equipVtxIndex + 3].v.ob[1] =
+            pauseCtx->equipVtx[equipVtxIndex + 2].v.ob[1] - 4;
     }
 
     Gfx_SetupDL_42Opa(play->state.gfxCtx);
@@ -763,6 +797,20 @@ void KaleidoScope_DrawEquipment(PlayState* play) {
             }
             gSPGrayscale(POLY_KAL_DISP++, false);
         }
+    }
+
+    // Render A button indicator when hovered over strength
+    if ((pauseCtx->cursorX[PAUSE_EQUIP] == 0) && (pauseCtx->cursorY[PAUSE_EQUIP] == 2) &&
+        CVarGetInteger("gToggleStrength", 0) && pauseCtx->cursorSpecialPos == 0
+        && pauseCtx->unk_1E4 == 0 && pauseCtx->state == 6) {
+        u8 row = 2;
+        u8 column = 0;
+        u8 equipVtxIndex = 16 * row + 4 * column;
+        // Get Bottom Bisector of the Quad
+        s16 translateX = (pauseCtx->equipVtx[equipVtxIndex].v.ob[0] + pauseCtx->equipVtx[equipVtxIndex + 1].v.ob[0]) / 2;
+        // Add 4 since the icon will be zoomed in on
+        s16 translateY = pauseCtx->equipVtx[equipVtxIndex + 2].v.ob[1] + 4;
+        KaleidoScope_DrawAButton(play, sStrengthAButtonVtx, translateX, translateY);
     }
 
     KaleidoScope_DrawPlayerWork(play);

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_equipment.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_equipment.c
@@ -700,7 +700,7 @@ void KaleidoScope_DrawEquipment(PlayState* play) {
             point = CUR_UPG_VALUE(sChildUpgrades[i]);
             if ((point != 0) && (CUR_UPG_VALUE(sChildUpgrades[i]) != 0)) {
                 // Grey Out the Gauntlets as Child
-                // Grey Out Strength Upgrades when Disabled and the Toggle Option is on
+                // Grey Out Strength Upgrades when Disabled and the Toggle Strength Option is on
                 if ((drawGreyItems &&
                     ((sChildUpgradeItemBases[i] + CUR_UPG_VALUE(sChildUpgrades[i]) - 1) == ITEM_GAUNTLETS_SILVER || 
                     (sChildUpgradeItemBases[i] + CUR_UPG_VALUE(sChildUpgrades[i]) - 1) == ITEM_GAUNTLETS_GOLD)) ||
@@ -720,11 +720,11 @@ void KaleidoScope_DrawEquipment(PlayState* play) {
                 KaleidoScope_DrawQuadTextureRGBA32(play->state.gfxCtx, gItemIcons[sChildUpgradeItemBases[i] + CUR_UPG_VALUE(sChildUpgrades[i]) - 1], 32, 32, 0);
                 gSPGrayscale(POLY_KAL_DISP++, false);
             } else if (CUR_UPG_VALUE(sAdultUpgrades[i]) != 0) {
-                // Grey Out the Goron Bracelet when Not Randomized
-                // Grey Out Strength Upgrades when Disabled and the Toggle Option is on
+                // Grey Out the Goron Bracelet when Not Randomized and Toggle Strength Option is off
+                // Grey Out Strength Upgrades when Disabled and the Toggle Strength Option is on
                 if ((drawGreyItems &&
                     (((sAdultUpgradeItemBases[i] + CUR_UPG_VALUE(sAdultUpgrades[i]) - 1) == ITEM_BRACELET &&
-                        !(IS_RANDO)))) || 
+                        !(IS_RANDO) && !CVarGetInteger("gToggleStrength", 0)))) || 
                      (CVarGetInteger("gToggleStrength", 0) && CVarGetInteger("gStrengthDisabled", 0) && sAdultUpgrades[i] == UPG_STRENGTH)) {
                     gDPSetGrayscaleColor(POLY_KAL_DISP++, 109, 109, 109, 255);
                     gSPGrayscale(POLY_KAL_DISP++, true);

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_equipment.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_equipment.c
@@ -488,18 +488,6 @@ void KaleidoScope_DrawEquipment(PlayState* play) {
             }
         }
 
-        // Grey Out Strength Upgrade Name when Disabled
-        // Do not Grey Out Strength Upgrade Name when Enabled
-        if ((pauseCtx->cursorX[PAUSE_EQUIP] == 0) && (pauseCtx->cursorY[PAUSE_EQUIP] == 2) &&
-            CVarGetInteger("gToggleStrength", 0)) {
-            if (CVarGetInteger("gStrengthDisabled", 0)) {
-                pauseCtx->nameColorSet = 1;
-            } else {
-                pauseCtx->nameColorSet = 0;
-            }
-        }
-
-
         if ((pauseCtx->cursorX[PAUSE_EQUIP] == 0) && (pauseCtx->cursorY[PAUSE_EQUIP] == 0)) {
             if (LINK_AGE_IN_YEARS != YEARS_CHILD) {
                 if ((cursorItem >= ITEM_BULLET_BAG_30) && (cursorItem <= ITEM_BULLET_BAG_50)) {
@@ -514,16 +502,21 @@ void KaleidoScope_DrawEquipment(PlayState* play) {
 
         KaleidoScope_SetCursorVtx(pauseCtx, cursorSlot * 4, pauseCtx->equipVtx);
 
-        u16 buttonsToCheck = BTN_A | BTN_CLEFT | BTN_CDOWN | BTN_CRIGHT;
-        if (CVarGetInteger("gDpadEquips", 0) && (!CVarGetInteger("gDpadPause", 0) || CHECK_BTN_ALL(input->cur.button, BTN_CUP))) {
-            buttonsToCheck |= BTN_DUP | BTN_DDOWN | BTN_DLEFT | BTN_DRIGHT;
-        }
-
         // Allow Toggling of Strength when Pressing A on Strength Upgrade Slot
         if ((pauseCtx->cursorSpecialPos == 0) && (pauseCtx->state == 6) &&
             (pauseCtx->unk_1E4 == 0) && CHECK_BTN_ALL(input->press.button, BTN_A) &&
             (pauseCtx->cursorX[PAUSE_EQUIP] == 0) && (pauseCtx->cursorY[PAUSE_EQUIP] == 2) && CVarGetInteger("gToggleStrength", 0)) {
             CVarSetInteger("gStrengthDisabled", !CVarGetInteger("gStrengthDisabled", 0));
+            // Equip success sound
+            Audio_PlaySoundGeneral(NA_SE_SY_DECIDE, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
+            // Wait 10 frames before accepting input again
+            pauseCtx->unk_1E4 = 7;
+            sEquipTimer = 10;
+        }
+
+        u16 buttonsToCheck = BTN_A | BTN_CLEFT | BTN_CDOWN | BTN_CRIGHT;
+        if (CVarGetInteger("gDpadEquips", 0) && (!CVarGetInteger("gDpadPause", 0) || CHECK_BTN_ALL(input->cur.button, BTN_CUP))) {
+            buttonsToCheck |= BTN_DUP | BTN_DDOWN | BTN_DLEFT | BTN_DRIGHT;
         }
 
         if ((pauseCtx->cursorSpecialPos == 0) && (cursorItem != PAUSE_ITEM_NONE) && (pauseCtx->state == 6) &&
@@ -654,6 +647,19 @@ void KaleidoScope_DrawEquipment(PlayState* play) {
         sEquipTimer--;
         if (sEquipTimer == 0) {
             pauseCtx->unk_1E4 = 0;
+        }
+    }
+
+
+    // Grey Out Strength Upgrade Name when Disabled
+    // Do not Grey Out Strength Upgrade Name when Enabled
+    // This needs to be outside the previous block since otherwise the nameColorSet is cleared to 0 by other menu pages when toggling
+    if ((pauseCtx->pageIndex == PAUSE_EQUIP) && (pauseCtx->cursorX[PAUSE_EQUIP] == 0) &&
+        (pauseCtx->cursorY[PAUSE_EQUIP] == 2) && CVarGetInteger("gToggleStrength", 0)) {
+        if (CVarGetInteger("gStrengthDisabled", 0)) {
+            pauseCtx->nameColorSet = 1;
+        } else {
+            pauseCtx->nameColorSet = 0;
         }
     }
 

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_equipment.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_equipment.c
@@ -489,10 +489,16 @@ void KaleidoScope_DrawEquipment(PlayState* play) {
         }
 
         // Grey Out Strength Upgrade Name when Disabled
+        // Do not Grey Out Strength Upgrade Name when Enabled
         if ((pauseCtx->cursorX[PAUSE_EQUIP] == 0) && (pauseCtx->cursorY[PAUSE_EQUIP] == 2) &&
-            CVarGetInteger("gToggleStrength", 0) && CVarGetInteger("gStrengthDisabled", 0)) {
-            pauseCtx->nameColorSet = 1;
+            CVarGetInteger("gToggleStrength", 0)) {
+            if (CVarGetInteger("gStrengthDisabled", 0)) {
+                pauseCtx->nameColorSet = 1;
+            } else {
+                pauseCtx->nameColorSet = 0;
+            }
         }
+
 
         if ((pauseCtx->cursorX[PAUSE_EQUIP] == 0) && (pauseCtx->cursorY[PAUSE_EQUIP] == 0)) {
             if (LINK_AGE_IN_YEARS != YEARS_CHILD) {
@@ -672,9 +678,9 @@ void KaleidoScope_DrawEquipment(PlayState* play) {
         }
     }
 
-    // Add zoom effect to strength item if cursor is hovering over it and strength is not disabled when the toggle is on
+    // Add zoom effect to strength item if cursor is hovering over it when toggle option is on
     if ((pauseCtx->cursorX[PAUSE_EQUIP] == 0) && (pauseCtx->cursorY[PAUSE_EQUIP] == 2) &&
-        CVarGetInteger("gToggleStrength", 0) && !CVarGetInteger("gStrengthDisabled", 0)) {
+        CVarGetInteger("gToggleStrength", 0)) {
         i = 2; // row
         k = 0; // column
         j = 16 * i + 4 * k; // vtx index


### PR DESCRIPTION
Allows the toggling of the strength upgrade from the pause menu. When toggled link will effectively take off the equipment and have no strength. 

I made this because I think it's the best solution to a future issue that glitch logic may have and forcing this toggle option would allow for the glitch to be in logic.

I wasnt sure what the best method to convey this toggle-ability in the ui was but providing a video to help show (save file is vanilla in example)

https://github.com/HarbourMasters/Shipwright/assets/78732756/743f0800-12a2-4b2e-b573-b3525e8df116



<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1010410124.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1010410125.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1010410126.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1010410127.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1010410128.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1010410130.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1010410133.zip)
<!--- section:artifacts:end -->