### PR TITLE
Replace some printfs with spdlogs

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/entrance.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/entrance.cpp
@@ -60,7 +60,7 @@ static void DisplayEntranceProgress() {
   } else {
     dots += " ";
   }
-  printf("\x1b[7;29H%s", dots.c_str());
+  SPDLOG_DEBUG(dots);
   #ifdef ENABLE_DEBUG
     if (curNumRandomizedEntrances == totalRandomizableEntrances) {
       Areas::DumpWorldGraph("Finish Validation");

--- a/soh/soh/Enhancements/randomizer/3drando/fill.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/fill.cpp
@@ -586,7 +586,7 @@ static void AssumedFill(const std::vector<RandomizerGet>& items, const std::vect
                         bool setLocationsAsHintable = false) {
     auto ctx = Rando::Context::GetInstance();
     if (items.size() > allowedLocations.size()) {
-        printf("\x1b[2;2HERROR: MORE ITEMS THAN LOCATIONS IN GIVEN LISTS");
+        SPDLOG_ERROR("ERROR: MORE ITEMS THAN LOCATIONS IN GIVEN LISTS");
         SPDLOG_DEBUG("Items:\n");
         // NOLINTNEXTLINE(clang-diagnostic-unused-variable)
         for (const RandomizerGet item : items) {
@@ -935,9 +935,9 @@ void VanillaFill() {
   }
   //If necessary, handle ER stuff
   if (ShuffleEntrances) {
-    printf("\x1b[7;10HShuffling Entrances...");
+    SPDLOG_INFO("Shuffling Entrances...");
     ShuffleAllEntrances();
-    printf("\x1b[7;32HDone");
+    SPDLOG_INFO("Shuffling Entrances Done");
   }
   //Finish up
   ctx->CreateItemOverrides();
@@ -946,11 +946,6 @@ void VanillaFill() {
 }
 
 void ClearProgress() {
-  printf("\x1b[7;32H    "); // Done
-  printf("\x1b[8;10H                    "); // Placing Items...Done
-  printf("\x1b[9;10H                              "); // Calculating Playthrough...Done
-  printf("\x1b[10;10H                     "); // Creating Hints...Done
-  printf("\x1b[11;10H                                  "); // Writing Spoiler Log...Done
 }
 
 int Fill() {
@@ -974,13 +969,13 @@ int Fill() {
     //can validate the world using deku/hylian shields
     AddElementsToPool(ItemPool, GetMinVanillaShopItems(32)); //assume worst case shopsanity 4
     if (ShuffleEntrances) {
-      printf("\x1b[7;10HShuffling Entrances");
+      SPDLOG_INFO("Shuffling Entrances");
       if (ShuffleAllEntrances() == ENTRANCE_SHUFFLE_FAILURE) {
         retries++;
         ClearProgress();
         continue;
       }
-      printf("\x1b[7;32HDone");
+      SPDLOG_INFO("Shuffling Entrances Done");
     }
     //erase temporary shop items
     FilterAndEraseFromPool(ItemPool, [](const auto item) { return Rando::StaticData::RetrieveItem(item).GetItemType() == ITEMTYPE_SHOP; });
@@ -1091,33 +1086,38 @@ int Fill() {
     GeneratePlaythrough();
     //Successful placement, produced beatable result
     if(ctx->playthroughBeatable && !placementFailure) {
-      printf("Done");
-      printf("\x1b[9;10HCalculating Playthrough...");
+      SPDLOG_INFO("Calculating Playthrough...");
       PareDownPlaythrough();
       CalculateWotH();
-      printf("Done");
+      SPDLOG_INFO("Calculating Playthrough Done");
       ctx->CreateItemOverrides();
       CreateEntranceOverrides();
+      SPDLOG_INFO("Creating Other Hint Texts...");
       //Always execute ganon hint generation for the funny line  
       CreateGanonAndSheikText();
       CreateAltarText();
       CreateDampesDiaryText();
       CreateGregRupeeHint();
       CreateSariaText();
+      SPDLOG_INFO("Creating Other Hint Texts Done");
       if (GossipStoneHints.IsNot(HINTS_NO_HINTS)) {
-        printf("\x1b[10;10HCreating Hints...");
+        SPDLOG_INFO("Creating Hints...");
         CreateAllHints();
-        printf("Done");
+        SPDLOG_INFO("Creating Hints Done");
       }
       if (ShuffleMerchants.Is(SHUFFLEMERCHANTS_HINTS)) {
+        SPDLOG_INFO("Creating Merchant Hints...");
         CreateMerchantsHints();
+        SPDLOG_INFO("Creating Merchant Hints Done");
       }
+      SPDLOG_INFO("Creating Warp Song Texts...");
       CreateWarpSongTexts();
+      SPDLOG_INFO("Creating Warp Song Texts Done");
       return 1;
     }
     //Unsuccessful placement
     if(retries < 4) {
-      SPDLOG_DEBUG("\nGOT STUCK. RETRYING...\n");
+      SPDLOG_DEBUG("Failed to generate a beatable seed. Retrying...");
       Areas::ResetAllLocations();
       LogicReset();
       ClearProgress();

--- a/soh/soh/Enhancements/randomizer/3drando/item_pool.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/item_pool.cpp
@@ -472,7 +472,7 @@ void PlaceJunkInExcludedLocation(const RandomizerCheck il) {
       return;
     }
   }
-  printf("ERROR: No Junk to Place!!!\n");
+  SPDLOG_ERROR("ERROR: No Junk to Place!!!");
 }
 
 static void PlaceVanillaDekuScrubItems() {

--- a/soh/soh/Enhancements/randomizer/3drando/location_access.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/location_access.cpp
@@ -28,7 +28,7 @@ std::vector<EventAccess> grottoEvents = {
 //set the logic to be a specific age and time of day and see if the condition still holds
 bool LocationAccess::CheckConditionAtAgeTime(bool& age, bool& time) const {
 
-  IsChild = false;
+  Logic::IsChild = false;
   IsAdult = false;
   AtDay   = false;
   AtNight = false;
@@ -45,8 +45,8 @@ bool LocationAccess::ConditionsMet() const {
   Area* parentRegion = AreaTable(Rando::Context::GetInstance()->GetItemLocation(location)->GetParentRegionKey());
   bool conditionsMet = false;
 
-  if ((parentRegion->childDay   && CheckConditionAtAgeTime(IsChild, AtDay))   ||
-      (parentRegion->childNight && CheckConditionAtAgeTime(IsChild, AtNight)) ||
+  if ((parentRegion->childDay   && CheckConditionAtAgeTime(Logic::IsChild, AtDay))   ||
+      (parentRegion->childNight && CheckConditionAtAgeTime(Logic::IsChild, AtNight)) ||
       (parentRegion->adultDay   && CheckConditionAtAgeTime(IsAdult, AtDay))   ||
       (parentRegion->adultNight && CheckConditionAtAgeTime(IsAdult, AtNight))) {
         conditionsMet = true;
@@ -128,8 +128,8 @@ bool Area::UpdateEvents(SearchMode mode) {
       continue;
     }
 
-    if ((childDay   && event.CheckConditionAtAgeTime(IsChild, AtDay))    ||
-        (childNight && event.CheckConditionAtAgeTime(IsChild, AtNight))  ||
+    if ((childDay   && event.CheckConditionAtAgeTime(Logic::IsChild, AtDay))    ||
+        (childNight && event.CheckConditionAtAgeTime(Logic::IsChild, AtNight))  ||
         (adultDay   && event.CheckConditionAtAgeTime(IsAdult, AtDay))    ||
         (adultNight && event.CheckConditionAtAgeTime(IsAdult, AtNight))) {
           event.EventOccurred();
@@ -269,7 +269,7 @@ void AreaTable_Init() {
 
   areaTable[RR_ROOT_EXITS] = Area("Root Exits", "", RHT_NONE, NO_DAY_NIGHT_CYCLE, {}, {}, {
                   //Exits
-                  Entrance(RR_CHILD_SPAWN,             {[]{return IsChild;}}),
+                  Entrance(RR_CHILD_SPAWN,             {[]{return Logic::IsChild;}}),
                   Entrance(RR_ADULT_SPAWN,             {[]{return IsAdult;}}),
                   Entrance(RR_MINUET_OF_FOREST_WARP,   {[]{return CanPlay(MinuetOfForest);}}),
                   Entrance(RR_BOLERO_OF_FIRE_WARP,     {[]{return CanPlay(BoleroOfFire)     && CanLeaveForest;}}),

--- a/soh/soh/Enhancements/randomizer/3drando/location_access.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/location_access.cpp
@@ -9,6 +9,7 @@
 #include "spoiler_log.hpp"
 #include "trial.hpp"
 #include "entrance.hpp"
+#include "spdlog/spdlog.h"
 
 #include <fstream>
 #include <iostream>
@@ -489,7 +490,7 @@ namespace Areas {
 
 Area* AreaTable(const RandomizerRegion areaKey) {
   if (areaKey > RR_MAX) {
-    printf("\x1b[1;1HERROR: AREAKEY TOO BIG");
+    SPDLOG_ERROR("ERROR: AREAKEY TOO BIG");
   }
   return &(areaTable[areaKey]);
 }

--- a/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_bottom_of_the_well.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_bottom_of_the_well.cpp
@@ -12,8 +12,8 @@ void AreaTable_Init_BottomOfTheWell() {
   ---------------------------*/
   areaTable[RR_BOTTOM_OF_THE_WELL_ENTRYWAY] = Area("Bottom of the Well Entryway", "Bottom of the Well", RHT_BOTTOM_OF_THE_WELL, NO_DAY_NIGHT_CYCLE, {}, {}, {
                   //Exits
-                  Entrance(RR_BOTTOM_OF_THE_WELL_MAIN_AREA,    {[]{return Dungeon::BottomOfTheWell.IsVanilla() && IsChild && (CanChildAttack || Nuts);}}),
-                  Entrance(RR_BOTTOM_OF_THE_WELL_MQ_PERIMETER, {[]{return Dungeon::BottomOfTheWell.IsMQ()      && IsChild;}}),
+                  Entrance(RR_BOTTOM_OF_THE_WELL_MAIN_AREA,    {[]{return Dungeon::BottomOfTheWell.IsVanilla() && Logic::IsChild && (CanChildAttack || Nuts);}}),
+                  Entrance(RR_BOTTOM_OF_THE_WELL_MQ_PERIMETER, {[]{return Dungeon::BottomOfTheWell.IsMQ()      && Logic::IsChild;}}),
                   Entrance(RR_KAKARIKO_VILLAGE,                {[]{return true;}}),
   });
 

--- a/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_castle_town.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_castle_town.cpp
@@ -18,13 +18,13 @@ void AreaTable_Init_CastleTown() {
                   Entrance(RR_MARKET_ENTRANCE,            {[]{return true;}}),
                   Entrance(RR_TOT_ENTRANCE,               {[]{return true;}}),
                   Entrance(RR_CASTLE_GROUNDS,             {[]{return true;}}),
-                  Entrance(RR_MARKET_BAZAAR,              {[]{return IsChild && AtDay;}}),
-                  Entrance(RR_MARKET_MASK_SHOP,           {[]{return IsChild && AtDay;}}),
-                  Entrance(RR_MARKET_SHOOTING_GALLERY,    {[]{return IsChild && AtDay;}}),
-                  Entrance(RR_MARKET_BOMBCHU_BOWLING,     {[]{return IsChild;}}),
-                  Entrance(RR_MARKET_TREASURE_CHEST_GAME, {[]{return IsChild && AtNight;}}),
-                  Entrance(RR_MARKET_POTION_SHOP,         {[]{return IsChild && AtDay;}}),
-                  Entrance(RR_MARKET_BACK_ALLEY,          {[]{return IsChild;}}),
+                  Entrance(RR_MARKET_BAZAAR,              {[]{return Logic::IsChild && AtDay;}}),
+                  Entrance(RR_MARKET_MASK_SHOP,           {[]{return Logic::IsChild && AtDay;}}),
+                  Entrance(RR_MARKET_SHOOTING_GALLERY,    {[]{return Logic::IsChild && AtDay;}}),
+                  Entrance(RR_MARKET_BOMBCHU_BOWLING,     {[]{return Logic::IsChild;}}),
+                  Entrance(RR_MARKET_TREASURE_CHEST_GAME, {[]{return Logic::IsChild && AtNight;}}),
+                  Entrance(RR_MARKET_POTION_SHOP,         {[]{return Logic::IsChild && AtDay;}}),
+                  Entrance(RR_MARKET_BACK_ALLEY,          {[]{return Logic::IsChild;}}),
   });
 
   areaTable[RR_MARKET_BACK_ALLEY] = Area("Market Back Alley", "Market", RHT_THE_MARKET, NO_DAY_NIGHT_CYCLE, {}, {}, {
@@ -53,7 +53,7 @@ void AreaTable_Init_CastleTown() {
   areaTable[RR_TEMPLE_OF_TIME] = Area("Temple of Time", "Temple of Time", RHT_TEMPLE_OF_TIME, NO_DAY_NIGHT_CYCLE, {}, {
                   //Locations
                   LocationAccess(RC_TOT_LIGHT_ARROWS_CUTSCENE, {[]{return IsAdult && CanTriggerLACS;}}),
-                  LocationAccess(RC_ALTAR_HINT_CHILD, {[]{return IsChild;}}),
+                  LocationAccess(RC_ALTAR_HINT_CHILD, {[]{return Logic::IsChild;}}),
                   LocationAccess(RC_ALTAR_HINT_ADULT, {[]{return IsAdult;}}),
                 }, {
                   //Exits
@@ -75,7 +75,7 @@ void AreaTable_Init_CastleTown() {
   areaTable[RR_CASTLE_GROUNDS] = Area("Castle Grounds", "Castle Grounds", RHT_NONE, NO_DAY_NIGHT_CYCLE, {}, {}, {
                   //Exits
                   Entrance(RR_THE_MARKET,            {[]{return true;}}),
-                  Entrance(RR_HYRULE_CASTLE_GROUNDS, {[]{return IsChild;}}),
+                  Entrance(RR_HYRULE_CASTLE_GROUNDS, {[]{return Logic::IsChild;}}),
                   Entrance(RR_GANONS_CASTLE_GROUNDS, {[]{return IsAdult;}}),
   });
 
@@ -154,7 +154,7 @@ void AreaTable_Init_CastleTown() {
 
   areaTable[RR_CASTLE_GROUNDS_FROM_GANONS_CASTLE] = Area("Castle Grounds From Ganon's Castle", "Castle Grounds From Ganon's Castle", RHT_NONE, NO_DAY_NIGHT_CYCLE, {}, {}, {
     // Exits
-    Entrance(RR_HYRULE_CASTLE_GROUNDS, { [] { return IsChild; }}),
+    Entrance(RR_HYRULE_CASTLE_GROUNDS, { [] { return Logic::IsChild; }}),
     Entrance(RR_GANONS_CASTLE_LEDGE, { [] { return IsAdult; }}),
   });
 
@@ -168,7 +168,7 @@ void AreaTable_Init_CastleTown() {
   areaTable[RR_MARKET_GUARD_HOUSE] = Area("Market Guard House", "Market Guard House", RHT_NONE, NO_DAY_NIGHT_CYCLE, {}, {
                   //Locations
                   LocationAccess(RC_MARKET_10_BIG_POES,    {[]{return IsAdult && BigPoeKill;}}),
-                  LocationAccess(RC_MARKET_GS_GUARD_HOUSE, {[]{return IsChild;}}),
+                  LocationAccess(RC_MARKET_GS_GUARD_HOUSE, {[]{return Logic::IsChild;}}),
                 }, {
                   //Exits
                   Entrance(RR_MARKET_ENTRANCE, {[]{return true;}}),
@@ -200,7 +200,7 @@ void AreaTable_Init_CastleTown() {
 
   areaTable[RR_MARKET_SHOOTING_GALLERY] = Area("Market Shooting Gallery", "Market Shooting Gallery", RHT_NONE, NO_DAY_NIGHT_CYCLE, {}, {
                   //Locations
-                  LocationAccess(RC_MARKET_SHOOTING_GALLERY_REWARD, {[]{return IsChild;}}),
+                  LocationAccess(RC_MARKET_SHOOTING_GALLERY_REWARD, {[]{return Logic::IsChild;}}),
                 }, {
                   //Exits
                   Entrance(RR_THE_MARKET, {[]{return true;}}),
@@ -262,7 +262,7 @@ void AreaTable_Init_CastleTown() {
 
   areaTable[RR_MARKET_DOG_LADY_HOUSE] = Area("Market Dog Lady House", "Market Dog Lady House", RHT_NONE, NO_DAY_NIGHT_CYCLE, {}, {
                   //Locations
-                  LocationAccess(RC_MARKET_LOST_DOG, {[]{return IsChild && AtNight;}}),
+                  LocationAccess(RC_MARKET_LOST_DOG, {[]{return Logic::IsChild && AtNight;}}),
                 }, {
                   //Exits
                   Entrance(RR_MARKET_BACK_ALLEY, {[]{return true;}}),

--- a/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_death_mountain.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_death_mountain.cpp
@@ -11,7 +11,7 @@ void AreaTable_Init_DeathMountain() {
                   EventAccess(&BeanPlantFairy, {[]{return BeanPlantFairy || (CanPlantBean(RR_DEATH_MOUNTAIN_TRAIL) && CanPlay(SongOfStorms) && (HasExplosives || GoronBracelet));}}),
                 }, {
                   //Locations
-                  LocationAccess(RC_DMT_CHEST,                    {[]{return CanBlastOrSmash || (LogicDMTBombable && IsChild && GoronBracelet);}}),
+                  LocationAccess(RC_DMT_CHEST,                    {[]{return CanBlastOrSmash || (LogicDMTBombable && Logic::IsChild && GoronBracelet);}}),
                   LocationAccess(RC_DMT_FREESTANDING_POH,         {[]{return CanTakeDamage || CanUse(RG_HOVER_BOOTS) || (IsAdult && CanPlantBean(RR_DEATH_MOUNTAIN_TRAIL) && (HasExplosives || GoronBracelet));}}),
                   LocationAccess(RC_DMT_GS_BEAN_PATCH,            {[]{return CanPlantBugs && (HasExplosives || GoronBracelet || (LogicDMTSoilGS && (CanTakeDamage || CanUse(RG_HOVER_BOOTS)) && CanUse(RG_BOOMERANG)));}}),
                   LocationAccess(RC_DMT_GS_NEAR_KAK,              {[]{return CanBlastOrSmash;}}),
@@ -29,7 +29,7 @@ void AreaTable_Init_DeathMountain() {
                   //Events
                   EventAccess(&PrescriptionAccess, {[]{return PrescriptionAccess || (IsAdult && (BrokenSwordAccess || BrokenSword));}}),
                   EventAccess(&GossipStoneFairy,   {[]{return GossipStoneFairy   || CanSummonGossipFairy;}}),
-                  EventAccess(&BugRock,            {[]{return BugRock            || IsChild;}}),
+                  EventAccess(&BugRock,            {[]{return BugRock            || Logic::IsChild;}}),
                 }, {
                   //Locations
                   LocationAccess(RC_DMT_TRADE_BROKEN_SWORD,    {[]{return IsAdult && BrokenSword;}}),
@@ -41,7 +41,7 @@ void AreaTable_Init_DeathMountain() {
                   //Exits
                   Entrance(RR_DEATH_MOUNTAIN_TRAIL,     {[]{return true;}}),
                   Entrance(RR_DMC_UPPER_LOCAL,          {[]{return true;}}),
-                  Entrance(RR_DMT_OWL_FLIGHT,           {[]{return IsChild;}}),
+                  Entrance(RR_DMT_OWL_FLIGHT,           {[]{return Logic::IsChild;}}),
                   Entrance(RR_DMT_COW_GROTTO,           {[]{return Here(RR_DEATH_MOUNTAIN_SUMMIT, []{return CanBlastOrSmash;});}}),
                   Entrance(RR_DMT_GREAT_FAIRY_FOUNTAIN, {[]{return Here(RR_DEATH_MOUNTAIN_SUMMIT, []{return CanBlastOrSmash;});}}),
   });
@@ -80,21 +80,21 @@ void AreaTable_Init_DeathMountain() {
   areaTable[RR_GORON_CITY] = Area("Goron City", "Goron City", RHT_GORON_CITY, NO_DAY_NIGHT_CYCLE, {
                   //Events
                   EventAccess(&GossipStoneFairy,          {[]{return GossipStoneFairy          || CanSummonGossipFairyWithoutSuns;}}),
-                  EventAccess(&StickPot,                  {[]{return StickPot                  || IsChild;}}),
+                  EventAccess(&StickPot,                  {[]{return StickPot                  || Logic::IsChild;}}),
                   EventAccess(&BugRock,                   {[]{return BugRock                   || (CanBlastOrSmash || CanUse(RG_SILVER_GAUNTLETS));}}),
-                  EventAccess(&GoronCityChildFire,        {[]{return GoronCityChildFire        || (IsChild && CanUse(RG_DINS_FIRE));}}),
+                  EventAccess(&GoronCityChildFire,        {[]{return GoronCityChildFire        || (Logic::IsChild && CanUse(RG_DINS_FIRE));}}),
                   EventAccess(&GCWoodsWarpOpen,           {[]{return GCWoodsWarpOpen           || (CanBlastOrSmash || CanUse(RG_DINS_FIRE) || CanUse(RG_FAIRY_BOW) || GoronBracelet || GoronCityChildFire);}}),
-                  EventAccess(&GCDaruniasDoorOpenChild,   {[]{return GCDaruniasDoorOpenChild   || (IsChild && CanPlay(ZeldasLullaby));}}),
+                  EventAccess(&GCDaruniasDoorOpenChild,   {[]{return GCDaruniasDoorOpenChild   || (Logic::IsChild && CanPlay(ZeldasLullaby));}}),
                   EventAccess(&StopGCRollingGoronAsAdult, {[]{return StopGCRollingGoronAsAdult || (IsAdult && (GoronBracelet || HasExplosives || Bow || (LogicGoronCityLinkGoronDins && CanUse(RG_DINS_FIRE))));}}),
                 }, {
                   //Locations
                   LocationAccess(RC_GC_MAZE_LEFT_CHEST,        {[]{return CanUse(RG_MEGATON_HAMMER) || CanUse(RG_SILVER_GAUNTLETS) || (LogicGoronCityLeftMost && HasExplosives && CanUse(RG_HOVER_BOOTS));}}),
                   LocationAccess(RC_GC_MAZE_CENTER_CHEST,      {[]{return CanBlastOrSmash  || CanUse(RG_SILVER_GAUNTLETS);}}),
                   LocationAccess(RC_GC_MAZE_RIGHT_CHEST,       {[]{return CanBlastOrSmash  || CanUse(RG_SILVER_GAUNTLETS);}}),
-                  LocationAccess(RC_GC_POT_FREESTANDING_POH,   {[]{return IsChild && GoronCityChildFire && (Bombs || (GoronBracelet && LogicGoronCityPotWithStrength) || (HasBombchus && LogicGoronCityPot));}}),
-                  LocationAccess(RC_GC_ROLLING_GORON_AS_CHILD, {[]{return IsChild && (HasExplosives || (GoronBracelet && LogicChildRollingWithStrength));}}),
+                  LocationAccess(RC_GC_POT_FREESTANDING_POH,   {[]{return Logic::IsChild && GoronCityChildFire && (Bombs || (GoronBracelet && LogicGoronCityPotWithStrength) || (HasBombchus && LogicGoronCityPot));}}),
+                  LocationAccess(RC_GC_ROLLING_GORON_AS_CHILD, {[]{return Logic::IsChild && (HasExplosives || (GoronBracelet && LogicChildRollingWithStrength));}}),
                   LocationAccess(RC_GC_ROLLING_GORON_AS_ADULT, {[]{return StopGCRollingGoronAsAdult;}}),
-                  LocationAccess(RC_GC_GS_BOULDER_MAZE,        {[]{return IsChild && CanBlastOrSmash;}}),
+                  LocationAccess(RC_GC_GS_BOULDER_MAZE,        {[]{return Logic::IsChild && CanBlastOrSmash;}}),
                   LocationAccess(RC_GC_GS_CENTER_PLATFORM,     {[]{return IsAdult;}}),
                   LocationAccess(RC_GC_MEDIGORON,              {[]{return IsAdult && AdultsWallet && (CanBlastOrSmash || GoronBracelet);}}),
                   LocationAccess(RC_GC_MAZE_GOSSIP_STONE,      {[]{return CanBlastOrSmash || CanUse(RG_SILVER_GAUNTLETS);}}),
@@ -103,7 +103,7 @@ void AreaTable_Init_DeathMountain() {
                   //Exits
                   Entrance(RR_DEATH_MOUNTAIN_TRAIL, {[]{return true;}}),
                   Entrance(RR_GC_WOODS_WARP,        {[]{return GCWoodsWarpOpen;}}),
-                  Entrance(RR_GC_SHOP,              {[]{return (IsAdult && StopGCRollingGoronAsAdult) || (IsChild && (CanBlastOrSmash || GoronBracelet || GoronCityChildFire || CanUse(RG_FAIRY_BOW)));}}),
+                  Entrance(RR_GC_SHOP,              {[]{return (IsAdult && StopGCRollingGoronAsAdult) || (Logic::IsChild && (CanBlastOrSmash || GoronBracelet || GoronCityChildFire || CanUse(RG_FAIRY_BOW)));}}),
                   Entrance(RR_GC_DARUNIAS_CHAMBER,  {[]{return (IsAdult && StopGCRollingGoronAsAdult) || GCDaruniasDoorOpenChild;}}),
                   Entrance(RR_GC_GROTTO_PLATFORM,   {[]{return IsAdult && ((CanPlay(SongOfTime) && ((EffectiveHealth > 2) || CanUse(RG_GORON_TUNIC) || CanUse(RG_LONGSHOT) || CanUse(RG_NAYRUS_LOVE))) || (EffectiveHealth > 1 && CanUse(RG_GORON_TUNIC) && CanUse(RG_HOOKSHOT)) || (CanUse(RG_NAYRUS_LOVE) && CanUse(RG_HOOKSHOT)) || (EffectiveHealth > 2 && CanUse(RG_HOOKSHOT) && LogicGoronCityGrotto));}}),
   });
@@ -119,10 +119,10 @@ void AreaTable_Init_DeathMountain() {
 
   areaTable[RR_GC_DARUNIAS_CHAMBER] = Area("GC Darunias Chamber", "Goron City", RHT_GORON_CITY, NO_DAY_NIGHT_CYCLE, {
                   //Events
-                  EventAccess(&GoronCityChildFire, {[]{return GoronCityChildFire || (IsChild && CanUse(RG_STICKS));}}),
+                  EventAccess(&GoronCityChildFire, {[]{return GoronCityChildFire || (Logic::IsChild && CanUse(RG_STICKS));}}),
                 }, {
                   //Locations
-                  LocationAccess(RC_GC_DARUNIAS_JOY, {[]{return IsChild && CanPlay(SariasSong);}}),
+                  LocationAccess(RC_GC_DARUNIAS_JOY, {[]{return Logic::IsChild && CanPlay(SariasSong);}}),
                 }, {
                   //Exits
                   Entrance(RR_GORON_CITY,      {[]{return true;}}),
@@ -132,7 +132,7 @@ void AreaTable_Init_DeathMountain() {
   areaTable[RR_GC_GROTTO_PLATFORM] = Area("GC Grotto Platform", "Goron City", RHT_GORON_CITY, NO_DAY_NIGHT_CYCLE, {}, {}, {
                   //Exits
                   Entrance(RR_GC_GROTTO,  {[]{return true;}}),
-                  Entrance(RR_GORON_CITY, {[]{return EffectiveHealth > 2 || CanUse(RG_GORON_TUNIC) || CanUse(RG_NAYRUS_LOVE) || ((IsChild || CanPlay(SongOfTime)) && CanUse(RG_LONGSHOT));}}),
+                  Entrance(RR_GORON_CITY, {[]{return EffectiveHealth > 2 || CanUse(RG_GORON_TUNIC) || CanUse(RG_NAYRUS_LOVE) || ((Logic::IsChild || CanPlay(SongOfTime)) && CanUse(RG_LONGSHOT));}}),
   });
 
   areaTable[RR_GC_SHOP] = Area("GC Shop", "GC Shop", RHT_NONE, NO_DAY_NIGHT_CYCLE, {}, {
@@ -173,7 +173,7 @@ void AreaTable_Init_DeathMountain() {
                 }, {
                   //Locations
                   LocationAccess(RC_DMC_WALL_FREESTANDING_POH, {[]{return FireTimer >= 16 || Hearts >= 3;}}),
-                  LocationAccess(RC_DMC_GS_CRATE,              {[]{return (FireTimer >= 8 || Hearts >= 3) && IsChild && CanChildAttack;}}),
+                  LocationAccess(RC_DMC_GS_CRATE,              {[]{return (FireTimer >= 8 || Hearts >= 3) && Logic::IsChild && CanChildAttack;}}),
                   LocationAccess(RC_DMC_GOSSIP_STONE,          {[]{return HasExplosives && (FireTimer >= 16 || Hearts >= 3);}}),
                 }, {
                   //Exits
@@ -185,7 +185,7 @@ void AreaTable_Init_DeathMountain() {
 
   areaTable[RR_DMC_LADDER_AREA_NEARBY] = Area("DMC Ladder Area Nearby", "Death Mountain Crater", RHT_DEATH_MOUNTAIN_CRATER, NO_DAY_NIGHT_CYCLE, {}, {
                   //Locations
-                  LocationAccess(RC_DMC_DEKU_SCRUB, {[]{return IsChild && CanStunDeku;}}),
+                  LocationAccess(RC_DMC_DEKU_SCRUB, {[]{return Logic::IsChild && CanStunDeku;}}),
                 }, {
                   //Exits
                   Entrance(RR_DMC_UPPER_NEARBY, {[]{return Hearts >= 3;}}),
@@ -228,7 +228,7 @@ void AreaTable_Init_DeathMountain() {
                   Entrance(RR_DMC_CENTRAL_NEARBY,   {[]{return true;}}),
                   Entrance(RR_DMC_LOWER_NEARBY,     {[]{return (IsAdult && CanPlantBean(RR_DMC_CENTRAL_LOCAL)) || CanUse(RG_HOVER_BOOTS) || CanUse(RG_HOOKSHOT);}}),
                   Entrance(RR_DMC_UPPER_NEARBY,     {[]{return IsAdult && CanPlantBean(RR_DMC_CENTRAL_LOCAL);}}),
-                  Entrance(RR_FIRE_TEMPLE_ENTRYWAY, {[]{return (IsChild && Hearts >= 3 && ShuffleDungeonEntrances.IsNot(SHUFFLEDUNGEONS_OFF)) || (IsAdult && FireTimer >= 24);}}),
+                  Entrance(RR_FIRE_TEMPLE_ENTRYWAY, {[]{return (Logic::IsChild && Hearts >= 3 && ShuffleDungeonEntrances.IsNot(SHUFFLEDUNGEONS_OFF)) || (IsAdult && FireTimer >= 24);}}),
   });
 
   areaTable[RR_DMC_GREAT_FAIRY_FOUNTAIN] = Area("DMC Great Fairy Fountain", "DMC Great Fairy Fountain", RHT_NONE, NO_DAY_NIGHT_CYCLE, {}, {

--- a/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_deku_tree.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_deku_tree.cpp
@@ -118,7 +118,7 @@ void AreaTable_Init_DekuTree() {
                   Entrance(RR_DEKU_TREE_BASEMENT_TORCH_ROOM, {[]{return true;}}),
                   Entrance(RR_DEKU_TREE_BASEMENT_BACK_ROOM,  {[]{return Here(RR_DEKU_TREE_BASEMENT_BACK_LOBBY, []{return HasFireSourceWithTorch || CanUse(RG_FAIRY_BOW);}) &&
                                                                      Here(RR_DEKU_TREE_BASEMENT_BACK_LOBBY, []{return CanBlastOrSmash;});}}),
-                  Entrance(RR_DEKU_TREE_BASEMENT_UPPER,      {[]{return Here(RR_DEKU_TREE_BASEMENT_BACK_LOBBY, []{return HasFireSourceWithTorch || CanUse(RG_FAIRY_BOW);}) && IsChild;}}),
+                  Entrance(RR_DEKU_TREE_BASEMENT_UPPER,      {[]{return Here(RR_DEKU_TREE_BASEMENT_BACK_LOBBY, []{return HasFireSourceWithTorch || CanUse(RG_FAIRY_BOW);}) && Logic::IsChild;}}),
   });
 
   areaTable[RR_DEKU_TREE_BASEMENT_BACK_ROOM] = Area("Deku Tree Basement Back Room", "Deku Tree", RHT_DEKU_TREE, NO_DAY_NIGHT_CYCLE, {}, {
@@ -136,7 +136,7 @@ void AreaTable_Init_DekuTree() {
                 }, {}, {
                   //Exits
                   Entrance(RR_DEKU_TREE_BASEMENT_LOWER,      {[]{return true;}}),
-                  Entrance(RR_DEKU_TREE_BASEMENT_BACK_LOBBY, {[]{return IsChild;}}),
+                  Entrance(RR_DEKU_TREE_BASEMENT_BACK_LOBBY, {[]{return Logic::IsChild;}}),
                   Entrance(RR_DEKU_TREE_OUTSIDE_BOSS_ROOM,   {[]{return Here(RR_DEKU_TREE_BASEMENT_UPPER, []{return HasFireSourceWithTorch || (LogicDekuB1WebsWithBow && IsAdult && CanUse(RG_FAIRY_BOW));});}}),
   });
 
@@ -165,9 +165,9 @@ void AreaTable_Init_DekuTree() {
   }, {
                   //Exits
                   Entrance(RR_DEKU_TREE_ENTRYWAY,                     {[]{return true;}}),
-                  Entrance(RR_DEKU_TREE_MQ_COMPASS_ROOM,              {[]{return Here(RR_DEKU_TREE_MQ_LOBBY, []{return (IsChild && CanUse(RG_FAIRY_SLINGSHOT)) || (IsAdult && CanUse(RG_FAIRY_BOW));}) &&
+                  Entrance(RR_DEKU_TREE_MQ_COMPASS_ROOM,              {[]{return Here(RR_DEKU_TREE_MQ_LOBBY, []{return (Logic::IsChild && CanUse(RG_FAIRY_SLINGSHOT)) || (IsAdult && CanUse(RG_FAIRY_BOW));}) &&
                                                                                Here(RR_DEKU_TREE_MQ_LOBBY, []{return HasFireSourceWithTorch || (IsAdult && CanUse(RG_FAIRY_BOW));});}}),
-                  Entrance(RR_DEKU_TREE_MQ_BASEMENT_WATER_ROOM_FRONT, {[]{return Here(RR_DEKU_TREE_MQ_LOBBY, []{return (IsChild && CanUse(RG_FAIRY_SLINGSHOT)) || (IsAdult && CanUse(RG_FAIRY_BOW));}) &&
+                  Entrance(RR_DEKU_TREE_MQ_BASEMENT_WATER_ROOM_FRONT, {[]{return Here(RR_DEKU_TREE_MQ_LOBBY, []{return (Logic::IsChild && CanUse(RG_FAIRY_SLINGSHOT)) || (IsAdult && CanUse(RG_FAIRY_BOW));}) &&
                                                                                Here(RR_DEKU_TREE_MQ_LOBBY, []{return HasFireSourceWithTorch;});}}),
                   Entrance(RR_DEKU_TREE_MQ_BASEMENT_LEDGE,            {[]{return LogicDekuB1Skip || Here(RR_DEKU_TREE_MQ_LOBBY, []{return IsAdult;});}}),
   });
@@ -189,7 +189,7 @@ void AreaTable_Init_DekuTree() {
                   LocationAccess(RC_DEKU_TREE_MQ_BEFORE_SPINNING_LOG_CHEST, {[]{return true;}}),
   }, {
                   //Exits
-                  Entrance(RR_DEKU_TREE_MQ_BASEMENT_WATER_ROOM_BACK, {[]{return LogicDekuMQLog ||  (IsChild && (DekuShield || HylianShield)) ||
+                  Entrance(RR_DEKU_TREE_MQ_BASEMENT_WATER_ROOM_BACK, {[]{return LogicDekuMQLog ||  (Logic::IsChild && (DekuShield || HylianShield)) ||
                                                                              (IsAdult && (CanUse(RG_LONGSHOT) || (CanUse(RG_HOOKSHOT) && CanUse(RG_IRON_BOOTS))));}}),
                   Entrance(RR_DEKU_TREE_MQ_LOBBY,                    {[]{return true;}}),
   });
@@ -199,7 +199,7 @@ void AreaTable_Init_DekuTree() {
                   LocationAccess(RC_DEKU_TREE_MQ_AFTER_SPINNING_LOG_CHEST, {[]{return CanPlay(SongOfTime);}}),
   }, {
                   //Exits
-                  Entrance(RR_DEKU_TREE_MQ_BASEMENT_BACK_ROOM,        {[]{return Here(RR_DEKU_TREE_MQ_BASEMENT_WATER_ROOM_BACK, []{return (IsChild && CanUse(RG_STICKS)) || CanUse(RG_DINS_FIRE) ||
+                  Entrance(RR_DEKU_TREE_MQ_BASEMENT_BACK_ROOM,        {[]{return Here(RR_DEKU_TREE_MQ_BASEMENT_WATER_ROOM_BACK, []{return (Logic::IsChild && CanUse(RG_STICKS)) || CanUse(RG_DINS_FIRE) ||
                                                                                Here(RR_DEKU_TREE_MQ_BASEMENT_WATER_ROOM_FRONT, []{return IsAdult && CanUse(RG_FIRE_ARROWS);});}) &&
                                                                                  Here(RR_DEKU_TREE_MQ_BASEMENT_WATER_ROOM_BACK, []{return IsAdult || KokiriSword || CanUseProjectile || (Nuts && Sticks);});}}),
                   Entrance(RR_DEKU_TREE_MQ_BASEMENT_WATER_ROOM_FRONT, {[]{return true;}}),
@@ -211,8 +211,8 @@ void AreaTable_Init_DekuTree() {
                   LocationAccess(RC_DEKU_TREE_MQ_GS_BASEMENT_BACK_ROOM,   {[]{return HasFireSourceWithTorch && HookshotOrBoomerang;}}),
   }, {
                   //Exits
-                  Entrance(RR_DEKU_TREE_MQ_BASEMENT_LEDGE,           {[]{return IsChild;}}),
-                  Entrance(RR_DEKU_TREE_MQ_BASEMENT_WATER_ROOM_BACK, {[]{return (IsChild && CanUse(RG_KOKIRI_SWORD)) || CanUseProjectile || (Nuts && (IsChild && CanUse(RG_STICKS)));}}),
+                  Entrance(RR_DEKU_TREE_MQ_BASEMENT_LEDGE,           {[]{return Logic::IsChild;}}),
+                  Entrance(RR_DEKU_TREE_MQ_BASEMENT_WATER_ROOM_BACK, {[]{return (Logic::IsChild && CanUse(RG_KOKIRI_SWORD)) || CanUseProjectile || (Nuts && (Logic::IsChild && CanUse(RG_STICKS)));}}),
   });
 
   areaTable[RR_DEKU_TREE_MQ_BASEMENT_LEDGE] = Area("Deku Tree MQ Basement Ledge", "Deku Tree", RHT_DEKU_TREE, NO_DAY_NIGHT_CYCLE, {}, {
@@ -220,7 +220,7 @@ void AreaTable_Init_DekuTree() {
                   LocationAccess(RC_DEKU_TREE_MQ_DEKU_SCRUB, {[]{return CanStunDeku;}}),
   }, {
                   //Exits
-                  Entrance(RR_DEKU_TREE_MQ_BASEMENT_BACK_ROOM, {[]{return IsChild;}}),
+                  Entrance(RR_DEKU_TREE_MQ_BASEMENT_BACK_ROOM, {[]{return Logic::IsChild;}}),
                   Entrance(RR_DEKU_TREE_MQ_LOBBY,              {[]{return true;}}),
                   Entrance(RR_DEKU_TREE_MQ_OUTSIDE_BOSS_ROOM,
                          { [] { return Here(RR_DEKU_TREE_MQ_BASEMENT_LEDGE, [] { return HasFireSourceWithTorch; }); } }),

--- a/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_dodongos_cavern.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_dodongos_cavern.cpp
@@ -222,10 +222,10 @@ void AreaTable_Init_DodongosCavern() {
                   //Locations
                   LocationAccess(RC_DODONGOS_CAVERN_MQ_MAP_CHEST,                  {[]{return true;}}),
                   LocationAccess(RC_DODONGOS_CAVERN_MQ_COMPASS_CHEST,              {[]{return IsAdult || CanChildAttack || Nuts;}}),
-                  LocationAccess(RC_DODONGOS_CAVERN_MQ_LARVAE_ROOM_CHEST,          {[]{return (IsChild && CanUse(RG_STICKS)) || HasFireSource;}}),
-                  LocationAccess(RC_DODONGOS_CAVERN_MQ_TORCH_PUZZLE_ROOM_CHEST,    {[]{return CanBlastOrSmash || (IsChild && CanUse(RG_STICKS)) || CanUse(RG_DINS_FIRE) || (IsAdult && (LogicDCJump || HoverBoots || Hookshot));}}),
+                  LocationAccess(RC_DODONGOS_CAVERN_MQ_LARVAE_ROOM_CHEST,          {[]{return (Logic::IsChild && CanUse(RG_STICKS)) || HasFireSource;}}),
+                  LocationAccess(RC_DODONGOS_CAVERN_MQ_TORCH_PUZZLE_ROOM_CHEST,    {[]{return CanBlastOrSmash || (Logic::IsChild && CanUse(RG_STICKS)) || CanUse(RG_DINS_FIRE) || (IsAdult && (LogicDCJump || HoverBoots || Hookshot));}}),
                   LocationAccess(RC_DODONGOS_CAVERN_MQ_GS_SONG_OF_TIME_BLOCK_ROOM, {[]{return CanPlay(SongOfTime) && (CanChildAttack || IsAdult);}}),
-                  LocationAccess(RC_DODONGOS_CAVERN_MQ_GS_LARVAE_ROOM,             {[]{return (IsChild && CanUse(RG_STICKS)) || HasFireSource;}}),
+                  LocationAccess(RC_DODONGOS_CAVERN_MQ_GS_LARVAE_ROOM,             {[]{return (Logic::IsChild && CanUse(RG_STICKS)) || HasFireSource;}}),
                   LocationAccess(RC_DODONGOS_CAVERN_MQ_GS_LIZALFOS_ROOM,           {[]{return CanBlastOrSmash;}}),
                   LocationAccess(RC_DODONGOS_CAVERN_MQ_DEKU_SCRUB_LOBBY_REAR,      {[]{return CanStunDeku;}}),
                   LocationAccess(RC_DODONGOS_CAVERN_MQ_DEKU_SCRUB_LOBBY_FRONT,     {[]{return CanStunDeku;}}),
@@ -233,11 +233,11 @@ void AreaTable_Init_DodongosCavern() {
                   LocationAccess(RC_DODONGOS_CAVERN_GOSSIP_STONE,                  {[]{return true;}}),
   }, {
                   //Exits
-                  Entrance(RR_DODONGOS_CAVERN_MQ_LOWER_RIGHT_SIDE,  {[]{return Here(RR_DODONGOS_CAVERN_MQ_LOBBY, []{return CanBlastOrSmash || (((IsChild && CanUse(RG_STICKS)) || CanUse(RG_DINS_FIRE)) && CanTakeDamage);});}}),
+                  Entrance(RR_DODONGOS_CAVERN_MQ_LOWER_RIGHT_SIDE,  {[]{return Here(RR_DODONGOS_CAVERN_MQ_LOBBY, []{return CanBlastOrSmash || (((Logic::IsChild && CanUse(RG_STICKS)) || CanUse(RG_DINS_FIRE)) && CanTakeDamage);});}}),
                   Entrance(RR_DODONGOS_CAVERN_MQ_BOMB_BAG_AREA,     {[]{return IsAdult || (Here(RR_DODONGOS_CAVERN_MQ_LOBBY, []{return IsAdult;}) && HasExplosives) || (LogicDCMQChildBombs && CanJumpslash && CanTakeDamage);}}),
                     //Trick: IsAdult || HasExplosives || (LogicDCMQChildBombs && (KokiriSword || Sticks) && DamageMultiplier.IsNot(DAMAGEMULTIPLIER_OHKO))
-                  Entrance(RR_DODONGOS_CAVERN_MQ_BOSS_AREA,         {[]{return HasExplosives || (GoronBracelet && ((IsAdult && LogicDCMQEyesAdult) || (IsChild && LogicDCMQEyesChild)) && ((IsChild && (CanUse(RG_STICKS))) || CanUse(RG_DINS_FIRE) || (IsAdult && (LogicDCJump || Hammer || HoverBoots || Hookshot))));}}), 
-                    //Trick: HasExplosives || (LogicDCMQEyes && GoronBracelet && (IsAdult || LogicDCMQChildBack) && ((IsChild && CanUse(RG_STICKS)) || CanUse(RG_DINS_FIRE) || (IsAdult && (LogicDCJump || Hammer || HoverBoots || Hookshot))))
+                  Entrance(RR_DODONGOS_CAVERN_MQ_BOSS_AREA,         {[]{return HasExplosives || (GoronBracelet && ((IsAdult && LogicDCMQEyesAdult) || (Logic::IsChild && LogicDCMQEyesChild)) && ((Logic::IsChild && (CanUse(RG_STICKS))) || CanUse(RG_DINS_FIRE) || (IsAdult && (LogicDCJump || Hammer || HoverBoots || Hookshot))));}}), 
+                    //Trick: HasExplosives || (LogicDCMQEyes && GoronBracelet && (IsAdult || LogicDCMQChildBack) && ((Logic::IsChild && CanUse(RG_STICKS)) || CanUse(RG_DINS_FIRE) || (IsAdult && (LogicDCJump || Hammer || HoverBoots || Hookshot))))
   });
 
   areaTable[RR_DODONGOS_CAVERN_MQ_LOWER_RIGHT_SIDE] = Area("Dodongos Cavern MQ Lower Right Side", "Dodongos Cavern", RHT_DODONGOS_CAVERN, NO_DAY_NIGHT_CYCLE, {}, {
@@ -247,7 +247,7 @@ void AreaTable_Init_DodongosCavern() {
                   //Exits
                   Entrance(RR_DODONGOS_CAVERN_MQ_BOMB_BAG_AREA, {[]{return (Here(RR_DODONGOS_CAVERN_MQ_LOWER_RIGHT_SIDE, []{return IsAdult && CanUse(RG_FAIRY_BOW);}) || GoronBracelet ||
                                                                                 CanUse(RG_DINS_FIRE) || HasExplosives) &&
-                                                                                IsChild && CanUse(RG_FAIRY_SLINGSHOT);}}),
+                                                                                Logic::IsChild && CanUse(RG_FAIRY_SLINGSHOT);}}),
   });
 
   areaTable[RR_DODONGOS_CAVERN_MQ_BOMB_BAG_AREA] = Area("Dodongos Cavern MQ Bomb Bag Area", "Dodongos Cavern", RHT_DODONGOS_CAVERN, NO_DAY_NIGHT_CYCLE, {}, {

--- a/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_forest_temple.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_forest_temple.cpp
@@ -24,7 +24,7 @@ void AreaTable_Init_ForestTemple() {
   areaTable[RR_FOREST_TEMPLE_FIRST_ROOM] = Area("Forest Temple First Room", "Forest Temple", RHT_FOREST_TEMPLE, NO_DAY_NIGHT_CYCLE, {}, {
                   //Locations
                   LocationAccess(RC_FOREST_TEMPLE_FIRST_ROOM_CHEST, {[]{return true;}}),
-                  LocationAccess(RC_FOREST_TEMPLE_GS_FIRST_ROOM,    {[]{return (IsAdult && Bombs) || CanUse(RG_FAIRY_BOW) || CanUse(RG_HOOKSHOT) || CanUse(RG_BOOMERANG) || CanUse(RG_FAIRY_SLINGSHOT) || HasBombchus || CanUse(RG_DINS_FIRE) || (LogicForestFirstGS && (CanJumpslash || (IsChild && Bombs)));}}),
+                  LocationAccess(RC_FOREST_TEMPLE_GS_FIRST_ROOM,    {[]{return (IsAdult && Bombs) || CanUse(RG_FAIRY_BOW) || CanUse(RG_HOOKSHOT) || CanUse(RG_BOOMERANG) || CanUse(RG_FAIRY_SLINGSHOT) || HasBombchus || CanUse(RG_DINS_FIRE) || (LogicForestFirstGS && (CanJumpslash || (Logic::IsChild && Bombs)));}}),
                 }, {
                   //Exits
                   Entrance(RR_FOREST_TEMPLE_ENTRYWAY,       {[]{return true;}}),
@@ -47,7 +47,7 @@ void AreaTable_Init_ForestTemple() {
                   //Exits
                   Entrance(RR_FOREST_TEMPLE_SOUTH_CORRIDOR,    {[]{return true;}}),
                   Entrance(RR_FOREST_TEMPLE_NORTH_CORRIDOR,    {[]{return true;}}),
-                  Entrance(RR_FOREST_TEMPLE_NW_OUTDOORS_LOWER, {[]{return CanPlay(SongOfTime) || IsChild;}}),
+                  Entrance(RR_FOREST_TEMPLE_NW_OUTDOORS_LOWER, {[]{return CanPlay(SongOfTime) || Logic::IsChild;}}),
                   Entrance(RR_FOREST_TEMPLE_NE_OUTDOORS_LOWER, {[]{return CanUse(RG_FAIRY_BOW) || CanUse(RG_FAIRY_SLINGSHOT);}}),
                   Entrance(RR_FOREST_TEMPLE_WEST_CORRIDOR,     {[]{return SmallKeys(RR_FOREST_TEMPLE, 1, 5);}}),
                   Entrance(RR_FOREST_TEMPLE_EAST_CORRIDOR,     {[]{return false;}}),
@@ -295,12 +295,12 @@ void AreaTable_Init_ForestTemple() {
                   EventAccess(&FairyPot, {[]{return true;}}),
   }, {
                   //Locations
-                  LocationAccess(RC_FOREST_TEMPLE_MQ_WOLFOS_CHEST,       {[]{return (CanPlay(SongOfTime) || IsChild) && (IsAdult || CanUse(RG_DINS_FIRE) || CanUse(RG_STICKS) || CanUse(RG_FAIRY_SLINGSHOT) || KokiriSword);}}),
+                  LocationAccess(RC_FOREST_TEMPLE_MQ_WOLFOS_CHEST,       {[]{return (CanPlay(SongOfTime) || Logic::IsChild) && (IsAdult || CanUse(RG_DINS_FIRE) || CanUse(RG_STICKS) || CanUse(RG_FAIRY_SLINGSHOT) || KokiriSword);}}),
                   LocationAccess(RC_FOREST_TEMPLE_MQ_GS_BLOCK_PUSH_ROOM, {[]{return IsAdult || KokiriSword;}}),
   }, {
                   //Exits
-                  Entrance(RR_FOREST_TEMPLE_MQ_NW_OUTDOORS,        {[]{return (IsAdult && CanUse(RG_FAIRY_BOW)) || (IsChild && CanUse(RG_FAIRY_SLINGSHOT));}}),
-                  Entrance(RR_FOREST_TEMPLE_MQ_NE_OUTDOORS,        {[]{return (IsAdult && CanUse(RG_FAIRY_BOW)) || (IsChild && CanUse(RG_FAIRY_SLINGSHOT));}}), //This is as far as child can get
+                  Entrance(RR_FOREST_TEMPLE_MQ_NW_OUTDOORS,        {[]{return (IsAdult && CanUse(RG_FAIRY_BOW)) || (Logic::IsChild && CanUse(RG_FAIRY_SLINGSHOT));}}),
+                  Entrance(RR_FOREST_TEMPLE_MQ_NE_OUTDOORS,        {[]{return (IsAdult && CanUse(RG_FAIRY_BOW)) || (Logic::IsChild && CanUse(RG_FAIRY_SLINGSHOT));}}), //This is as far as child can get
                   Entrance(RR_FOREST_TEMPLE_MQ_AFTER_BLOCK_PUZZLE, {[]{return IsAdult && (GoronBracelet || (LogicForestMQBlockPuzzle && HasBombchus && IsAdult && CanUse(RG_HOOKSHOT)));}}),
                     //Trick: IsAdult && (GoronBracelet || (LogicForestMQBlockPuzzle && HasBombchus && IsAdult && CanUse(RG_HOOKSHOT)))
                   Entrance(RR_FOREST_TEMPLE_MQ_OUTDOOR_LEDGE,      {[]{return (LogicForestMQHallwaySwitchJS && IsAdult && CanUse(RG_HOVER_BOOTS)) || (LogicForestMQHallwaySwitchBoomerang && CanUse(RG_BOOMERANG)) || (LogicForestMQHallwaySwitchHookshot && IsAdult && CanUse(RG_HOOKSHOT));}}),
@@ -314,7 +314,7 @@ void AreaTable_Init_ForestTemple() {
   }, {
                   //Exits
                   Entrance(RR_FOREST_TEMPLE_MQ_BOW_REGION,    {[]{return SmallKeys(RR_FOREST_TEMPLE, 4);}}),
-                  Entrance(RR_FOREST_TEMPLE_MQ_OUTDOOR_LEDGE, {[]{return  SmallKeys(RR_FOREST_TEMPLE, 3) || (LogicForestMQHallwaySwitchJS && ((IsAdult && CanUse(RG_HOOKSHOT)) || (LogicForestOutsideBackdoor && (IsAdult || (IsChild && CanUse(RG_STICKS))))));}}),
+                  Entrance(RR_FOREST_TEMPLE_MQ_OUTDOOR_LEDGE, {[]{return  SmallKeys(RR_FOREST_TEMPLE, 3) || (LogicForestMQHallwaySwitchJS && ((IsAdult && CanUse(RG_HOOKSHOT)) || (LogicForestOutsideBackdoor && (IsAdult || (Logic::IsChild && CanUse(RG_STICKS))))));}}),
                     //Trick (Doing the hallway switch jumpslash as child requires sticks and has been added above): SmallKeys(RR_FOREST_TEMPLE, 3) || (LogicForestMQHallwaySwitchJS && ((IsAdult && CanUse(RG_HOOKSHOT)) || LogicForestOutsideBackdoor))
                   Entrance(RR_FOREST_TEMPLE_MQ_NW_OUTDOORS,   {[]{return SmallKeys(RR_FOREST_TEMPLE, 2);}}),
   });
@@ -343,9 +343,9 @@ void AreaTable_Init_ForestTemple() {
                   EventAccess(&DekuBabaNuts,   {[]{return DekuBabaNuts   || (IsAdult || KokiriSword || Slingshot || Sticks || HasExplosives || CanUse(RG_DINS_FIRE));}}),
   }, {
                   //Locations
-                  LocationAccess(RC_FOREST_TEMPLE_MQ_WELL_CHEST,                 {[]{return (IsAdult && CanUse(RG_FAIRY_BOW)) || (IsChild && CanUse(RG_FAIRY_SLINGSHOT));}}),
+                  LocationAccess(RC_FOREST_TEMPLE_MQ_WELL_CHEST,                 {[]{return (IsAdult && CanUse(RG_FAIRY_BOW)) || (Logic::IsChild && CanUse(RG_FAIRY_SLINGSHOT));}}),
                   LocationAccess(RC_FOREST_TEMPLE_MQ_GS_RAISED_ISLAND_COURTYARD, {[]{return HookshotOrBoomerang || (IsAdult && CanUse(RG_FIRE_ARROWS) && (CanPlay(SongOfTime) || (CanUse(RG_HOVER_BOOTS) && LogicForestDoorFrame)));}}),
-                  LocationAccess(RC_FOREST_TEMPLE_MQ_GS_WELL,                    {[]{return (IsAdult && ((CanUse(RG_IRON_BOOTS) && CanUse(RG_HOOKSHOT)) || CanUse(RG_FAIRY_BOW))) || (IsChild && CanUse(RG_FAIRY_SLINGSHOT));}}),
+                  LocationAccess(RC_FOREST_TEMPLE_MQ_GS_WELL,                    {[]{return (IsAdult && ((CanUse(RG_IRON_BOOTS) && CanUse(RG_HOOKSHOT)) || CanUse(RG_FAIRY_BOW))) || (Logic::IsChild && CanUse(RG_FAIRY_SLINGSHOT));}}),
   }, {
                   //Exits
                   Entrance(RR_FOREST_TEMPLE_MQ_OUTDOORS_TOP_LEDGES, {[]{return IsAdult && CanUse(RG_HOOKSHOT) && (CanUse(RG_LONGSHOT) || CanUse(RG_HOVER_BOOTS) || CanPlay(SongOfTime));}}),

--- a/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_ganons_castle.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_ganons_castle.cpp
@@ -83,7 +83,7 @@ void AreaTable_Init_GanonsCastle() {
                   EventAccess(&ShadowTrialClear, {[]{return CanUse(RG_LIGHT_ARROWS) && Hammer && ((FireArrows && (LogicLensCastle || CanUse(RG_LENS_OF_TRUTH))) || (CanUse(RG_LONGSHOT) && (CanUse(RG_HOVER_BOOTS) || (DinsFire && (LogicLensCastle || CanUse(RG_LENS_OF_TRUTH))))));}}),
                 }, {
                   //Locations
-                  LocationAccess(RC_GANONS_CASTLE_SHADOW_TRIAL_FRONT_CHEST,            {[]{return CanUse(RG_FIRE_ARROWS) || CanUse(RG_HOOKSHOT) || CanUse(RG_HOVER_BOOTS) || CanPlay(SongOfTime) || IsChild;}}),
+                  LocationAccess(RC_GANONS_CASTLE_SHADOW_TRIAL_FRONT_CHEST,            {[]{return CanUse(RG_FIRE_ARROWS) || CanUse(RG_HOOKSHOT) || CanUse(RG_HOVER_BOOTS) || CanPlay(SongOfTime) || Logic::IsChild;}}),
                   LocationAccess(RC_GANONS_CASTLE_SHADOW_TRIAL_GOLDEN_GAUNTLETS_CHEST, {[]{return CanUse(RG_FIRE_ARROWS) || (CanUse(RG_LONGSHOT) && (CanUse(RG_HOVER_BOOTS) || CanUse(RG_DINS_FIRE)));}}),
   }, {});
 
@@ -162,7 +162,7 @@ void AreaTable_Init_GanonsCastle() {
                   EventAccess(&ForestTrialClear, {[]{return IsAdult && CanUse(RG_LIGHT_ARROWS) && CanPlay(SongOfTime);}}),
   }, {
                   //Locations
-                  LocationAccess(RC_GANONS_CASTLE_MQ_FOREST_TRIAL_EYE_SWITCH_CHEST,        {[]{return (IsAdult && CanUse(RG_FAIRY_BOW)) || (IsChild && CanUse(RG_FAIRY_SLINGSHOT));}}),
+                  LocationAccess(RC_GANONS_CASTLE_MQ_FOREST_TRIAL_EYE_SWITCH_CHEST,        {[]{return (IsAdult && CanUse(RG_FAIRY_BOW)) || (Logic::IsChild && CanUse(RG_FAIRY_SLINGSHOT));}}),
                   LocationAccess(RC_GANONS_CASTLE_MQ_FOREST_TRIAL_FROZEN_EYE_SWITCH_CHEST, {[]{return HasFireSource;}}),
                   LocationAccess(RC_GANONS_CASTLE_MQ_FOREST_TRIAL_FREESTANDING_KEY,        {[]{return HookshotOrBoomerang;}}),
   }, {});

--- a/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_gerudo_training_grounds.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_gerudo_training_grounds.cpp
@@ -63,7 +63,7 @@ void AreaTable_Init_GerudoTrainingGrounds() {
                   LocationAccess(RC_GERUDO_TRAINING_GROUND_UNDERWATER_SILVER_RUPEE_CHEST, {[]{return CanUse(RG_HOOKSHOT) && CanPlay(SongOfTime) && IronBoots && WaterTimer >= 24;}}),
                 }, {
                   //Exits
-                  Entrance(RR_GERUDO_TRAINING_GROUNDS_CENTRAL_MAZE_RIGHT, {[]{return CanPlay(SongOfTime) || IsChild;}}),
+                  Entrance(RR_GERUDO_TRAINING_GROUNDS_CENTRAL_MAZE_RIGHT, {[]{return CanPlay(SongOfTime) || Logic::IsChild;}}),
                   Entrance(RR_GERUDO_TRAINING_GROUNDS_HAMMER_ROOM,        {[]{return CanUse(RG_LONGSHOT)  || (CanUse(RG_HOVER_BOOTS) && CanUse(RG_HOOKSHOT));}}),
   });
 
@@ -127,7 +127,7 @@ void AreaTable_Init_GerudoTrainingGrounds() {
                   //Exits
                   Entrance(RR_GERUDO_TRAINING_GROUNDS_ENTRYWAY,      {[]{return true;}}),
                   Entrance(RR_GERUDO_TRAINING_GROUNDS_MQ_LEFT_SIDE,  {[]{return Here(RR_GERUDO_TRAINING_GROUNDS_MQ_LOBBY, []{return HasFireSource;});}}),
-                  Entrance(RR_GERUDO_TRAINING_GROUNDS_MQ_RIGHT_SIDE, {[]{return Here(RR_GERUDO_TRAINING_GROUNDS_MQ_LOBBY, []{return (IsAdult && CanUse(RG_FAIRY_BOW)) || (IsChild && CanUse(RG_FAIRY_SLINGSHOT));});}}),
+                  Entrance(RR_GERUDO_TRAINING_GROUNDS_MQ_RIGHT_SIDE, {[]{return Here(RR_GERUDO_TRAINING_GROUNDS_MQ_LOBBY, []{return (IsAdult && CanUse(RG_FAIRY_BOW)) || (Logic::IsChild && CanUse(RG_FAIRY_SLINGSHOT));});}}),
   });
 
   areaTable[RR_GERUDO_TRAINING_GROUNDS_MQ_RIGHT_SIDE] = Area("Gerudo Training Grounds MQ Right Side", "Gerudo Training Grounds", RHT_GERUDO_TRAINING_GROUND, NO_DAY_NIGHT_CYCLE, {

--- a/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_gerudo_valley.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_gerudo_valley.cpp
@@ -8,17 +8,17 @@ using namespace Settings;
 void AreaTable_Init_GerudoValley() {
   areaTable[RR_GERUDO_VALLEY] = Area("Gerudo Valley", "Gerudo Valley", RHT_GERUDO_VALLEY, DAY_NIGHT_CYCLE, {
                   //Events
-                  EventAccess(&BugRock, {[]{return BugRock || IsChild;}}),
+                  EventAccess(&BugRock, {[]{return BugRock || Logic::IsChild;}}),
                 }, {
                   //Locations
-                  LocationAccess(RC_GV_GS_SMALL_BRIDGE, {[]{return IsChild && HookshotOrBoomerang && AtNight && CanGetNightTimeGS;}}),
+                  LocationAccess(RC_GV_GS_SMALL_BRIDGE, {[]{return Logic::IsChild && HookshotOrBoomerang && AtNight && CanGetNightTimeGS;}}),
                 }, {
                   //Exits
                   Entrance(RR_HYRULE_FIELD,      {[]{return true;}}),
                   Entrance(RR_GV_UPPER_STREAM,   {[]{return true;}}),
-                  Entrance(RR_GV_CRATE_LEDGE,    {[]{return IsChild || CanUse(RG_LONGSHOT);}}),
+                  Entrance(RR_GV_CRATE_LEDGE,    {[]{return Logic::IsChild || CanUse(RG_LONGSHOT);}}),
                   Entrance(RR_GV_GROTTO_LEDGE,   {[]{return true;}}),
-                  Entrance(RR_GV_FORTRESS_SIDE,  {[]{return (IsAdult && (CanRideEpona || CanUse(RG_LONGSHOT) || GerudoFortress.Is(GERUDOFORTRESS_OPEN) || CarpenterRescue)) || (IsChild && CanUse(RG_HOOKSHOT));}}),
+                  Entrance(RR_GV_FORTRESS_SIDE,  {[]{return (IsAdult && (CanRideEpona || CanUse(RG_LONGSHOT) || GerudoFortress.Is(GERUDOFORTRESS_OPEN) || CarpenterRescue)) || (Logic::IsChild && CanUse(RG_HOOKSHOT));}}),
   });
 
   areaTable[RR_GV_UPPER_STREAM] = Area("GV Upper Stream", "Gerudo Valley", RHT_GERUDO_VALLEY, DAY_NIGHT_CYCLE, {
@@ -29,7 +29,7 @@ void AreaTable_Init_GerudoValley() {
                   //Locations
                   LocationAccess(RC_GV_WATERFALL_FREESTANDING_POH, {[]{return true;}}),
                   LocationAccess(RC_GV_GS_BEAN_PATCH,              {[]{return CanPlantBugs && CanChildAttack;}}),
-                  LocationAccess(RC_GV_COW,                        {[]{return IsChild && CanPlay(EponasSong);}}),
+                  LocationAccess(RC_GV_COW,                        {[]{return Logic::IsChild && CanPlay(EponasSong);}}),
                   LocationAccess(RC_GV_GOSSIP_STONE,               {[]{return true;}}),
                 }, {
                   //Exits
@@ -69,7 +69,7 @@ void AreaTable_Init_GerudoValley() {
                   //Exits
                   Entrance(RR_GERUDO_FORTRESS,   {[]{return true;}}),
                   Entrance(RR_GV_UPPER_STREAM,   {[]{return true;}}),
-                  Entrance(RR_GERUDO_VALLEY,     {[]{return IsChild || CanRideEpona || CanUse(RG_LONGSHOT) || GerudoFortress.Is(GERUDOFORTRESS_OPEN) || CarpenterRescue;}}),
+                  Entrance(RR_GERUDO_VALLEY,     {[]{return Logic::IsChild || CanRideEpona || CanUse(RG_LONGSHOT) || GerudoFortress.Is(GERUDOFORTRESS_OPEN) || CarpenterRescue;}}),
                   Entrance(RR_GV_CARPENTER_TENT, {[]{return IsAdult;}}),
                   Entrance(RR_GV_STORMS_GROTTO,  {[]{return IsAdult && CanOpenStormGrotto;}}),
                   Entrance(RR_GV_CRATE_LEDGE, {[]{return false;}}),

--- a/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_hyrule_field.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_hyrule_field.cpp
@@ -11,8 +11,8 @@ void AreaTable_Init_HyruleField() {
                   EventAccess(&BigPoeKill, {[]{return CanUse(RG_FAIRY_BOW) && CanRideEpona && HasBottle;}}),
                 }, {
                   //Locations
-                  LocationAccess(RC_HF_OCARINA_OF_TIME_ITEM,   {[]{return IsChild && HasAllStones;}}),
-                  LocationAccess(RC_SONG_FROM_OCARINA_OF_TIME, {[]{return IsChild && HasAllStones;}}),
+                  LocationAccess(RC_HF_OCARINA_OF_TIME_ITEM,   {[]{return Logic::IsChild && HasAllStones;}}),
+                  LocationAccess(RC_SONG_FROM_OCARINA_OF_TIME, {[]{return Logic::IsChild && HasAllStones;}}),
                 }, {
                   //Exits
                   Entrance(RR_LW_BRIDGE,              {[]{return true;}}),
@@ -25,7 +25,7 @@ void AreaTable_Init_HyruleField() {
                   Entrance(RR_HF_SOUTHEAST_GROTTO,    {[]{return Here(RR_HYRULE_FIELD, []{return CanBlastOrSmash;});}}),
                   Entrance(RR_HF_OPEN_GROTTO,         {[]{return true;}}),
                   Entrance(RR_HF_INSIDE_FENCE_GROTTO, {[]{return CanOpenBombGrotto;}}),
-                  Entrance(RR_HF_COW_GROTTO,          {[]{return (CanUse(RG_MEGATON_HAMMER) || IsChild) && CanOpenBombGrotto;}}),
+                  Entrance(RR_HF_COW_GROTTO,          {[]{return (CanUse(RG_MEGATON_HAMMER) || Logic::IsChild) && CanOpenBombGrotto;}}),
                   Entrance(RR_HF_NEAR_MARKET_GROTTO,  {[]{return Here(RR_HYRULE_FIELD, []{return CanBlastOrSmash;});}}),
                   Entrance(RR_HF_FAIRY_GROTTO,        {[]{return Here(RR_HYRULE_FIELD, []{return CanBlastOrSmash;});}}),
                   Entrance(RR_HF_NEAR_KAK_GROTTO,     {[]{return CanOpenBombGrotto;}}),
@@ -106,17 +106,17 @@ void AreaTable_Init_HyruleField() {
                   EventAccess(&GossipStoneFairy, {[]{return GossipStoneFairy || CanSummonGossipFairy;}}),
                   EventAccess(&BeanPlantFairy,   {[]{return BeanPlantFairy   || (CanPlantBean(RR_LAKE_HYLIA) && CanPlay(SongOfStorms));}}),
                   EventAccess(&ButterflyFairy,   {[]{return ButterflyFairy   || CanUse(RG_STICKS);}}),
-                  EventAccess(&BugShrub,         {[]{return BugShrub         || (IsChild && CanCutShrubs);}}),
-                  EventAccess(&ChildScarecrow,   {[]{return ChildScarecrow   || (IsChild && Ocarina);}}),
+                  EventAccess(&BugShrub,         {[]{return BugShrub         || (Logic::IsChild && CanCutShrubs);}}),
+                  EventAccess(&ChildScarecrow,   {[]{return ChildScarecrow   || (Logic::IsChild && Ocarina);}}),
                   EventAccess(&AdultScarecrow,   {[]{return AdultScarecrow   || (IsAdult && Ocarina);}}),
                 }, {
                   //Locations
-                  LocationAccess(RC_LH_UNDERWATER_ITEM,        {[]{return IsChild && CanDive;}}),
+                  LocationAccess(RC_LH_UNDERWATER_ITEM,        {[]{return Logic::IsChild && CanDive;}}),
                   LocationAccess(RC_LH_SUN,                    {[]{return IsAdult && WaterTempleClear && CanUse(RG_FAIRY_BOW);}}),
                   LocationAccess(RC_LH_FREESTANDING_POH,       {[]{return IsAdult && (CanUse(RG_SCARECROW) || CanPlantBean(RR_LAKE_HYLIA));}}),
                   LocationAccess(RC_LH_GS_BEAN_PATCH,          {[]{return CanPlantBugs && CanChildAttack;}}),
-                  LocationAccess(RC_LH_GS_LAB_WALL,            {[]{return IsChild && (HookshotOrBoomerang || (LogicLabWallGS && (Sticks || KokiriSword || CanUse(RG_MASTER_SWORD) || CanUse(RG_BIGGORON_SWORD)))) && AtNight && CanGetNightTimeGS;}}),
-                  LocationAccess(RC_LH_GS_SMALL_ISLAND,        {[]{return IsChild && CanChildAttack && AtNight && CanGetNightTimeGS;}}),
+                  LocationAccess(RC_LH_GS_LAB_WALL,            {[]{return Logic::IsChild && (HookshotOrBoomerang || (LogicLabWallGS && (Sticks || KokiriSword || CanUse(RG_MASTER_SWORD) || CanUse(RG_BIGGORON_SWORD)))) && AtNight && CanGetNightTimeGS;}}),
+                  LocationAccess(RC_LH_GS_SMALL_ISLAND,        {[]{return Logic::IsChild && CanChildAttack && AtNight && CanGetNightTimeGS;}}),
                   LocationAccess(RC_LH_GS_TREE,                {[]{return IsAdult && CanUse(RG_LONGSHOT) && AtNight && CanGetNightTimeGS;}}),
                   LocationAccess(RC_LH_LAB_GOSSIP_STONE,       {[]{return true;}}),
                   LocationAccess(RC_LH_SOUTHEAST_GOSSIP_STONE, {[]{return true;}}),
@@ -124,9 +124,9 @@ void AreaTable_Init_HyruleField() {
                 }, {
                   //Exits
                   Entrance(RR_HYRULE_FIELD,          {[]{return true;}}),
-                  Entrance(RR_ZORAS_DOMAIN,          {[]{return IsChild && (CanDive || CanUse(RG_IRON_BOOTS));}}),
-                  Entrance(RR_LH_OWL_FLIGHT,         {[]{return IsChild;}}),
-                  Entrance(RR_LH_FISHING_ISLAND,     {[]{return IsChild || CanUse(RG_SCARECROW) || CanPlantBean(RR_LAKE_HYLIA) || WaterTempleClear;}}),
+                  Entrance(RR_ZORAS_DOMAIN,          {[]{return Logic::IsChild && (CanDive || CanUse(RG_IRON_BOOTS));}}),
+                  Entrance(RR_LH_OWL_FLIGHT,         {[]{return Logic::IsChild;}}),
+                  Entrance(RR_LH_FISHING_ISLAND,     {[]{return Logic::IsChild || CanUse(RG_SCARECROW) || CanPlantBean(RR_LAKE_HYLIA) || WaterTempleClear;}}),
                   Entrance(RR_LH_LAB,                {[]{return true;}}),
                   Entrance(RR_WATER_TEMPLE_ENTRYWAY, {[]{return CanUse(RG_HOOKSHOT) && ((CanUse(RG_IRON_BOOTS) || (LogicWaterHookshotEntry && ProgressiveScale >= 2)) || (IsAdult && CanUse(RG_LONGSHOT) && ProgressiveScale >= 2));}}),
                   Entrance(RR_LH_GROTTO,             {[]{return true;}}),
@@ -158,7 +158,7 @@ void AreaTable_Init_HyruleField() {
 
   areaTable[RR_LH_FISHING_HOLE] = Area("LH Fishing Hole", "LH Fishing Hole", RHT_NONE, DAY_NIGHT_CYCLE, {}, {
                   //Locations
-                  LocationAccess(RC_LH_CHILD_FISHING, {[]{return IsChild;}}),
+                  LocationAccess(RC_LH_CHILD_FISHING, {[]{return Logic::IsChild;}}),
                   LocationAccess(RC_LH_ADULT_FISHING, {[]{return IsAdult;}}),
                 }, {
                   //Exits
@@ -181,23 +181,23 @@ void AreaTable_Init_HyruleField() {
                   EventAccess(&LinksCow, {[]{return LinksCow || (CanPlay(EponasSong) && IsAdult && AtDay);}}),
                 }, {
                   //Locations
-                  LocationAccess(RC_SONG_FROM_MALON,     {[]{return IsChild && ZeldasLetter && Ocarina && AtDay;}}),
-                  LocationAccess(RC_LLR_GS_TREE,         {[]{return IsChild;}}),
-                  LocationAccess(RC_LLR_GS_RAIN_SHED,    {[]{return IsChild && AtNight && CanGetNightTimeGS;}}),
-                  LocationAccess(RC_LLR_GS_HOUSE_WINDOW, {[]{return IsChild && HookshotOrBoomerang && AtNight && CanGetNightTimeGS;}}),
-                  LocationAccess(RC_LLR_GS_BACK_WALL,    {[]{return IsChild && HookshotOrBoomerang && AtNight && CanGetNightTimeGS;}}),
+                  LocationAccess(RC_SONG_FROM_MALON,     {[]{return Logic::IsChild && ZeldasLetter && Ocarina && AtDay;}}),
+                  LocationAccess(RC_LLR_GS_TREE,         {[]{return Logic::IsChild;}}),
+                  LocationAccess(RC_LLR_GS_RAIN_SHED,    {[]{return Logic::IsChild && AtNight && CanGetNightTimeGS;}}),
+                  LocationAccess(RC_LLR_GS_HOUSE_WINDOW, {[]{return Logic::IsChild && HookshotOrBoomerang && AtNight && CanGetNightTimeGS;}}),
+                  LocationAccess(RC_LLR_GS_BACK_WALL,    {[]{return Logic::IsChild && HookshotOrBoomerang && AtNight && CanGetNightTimeGS;}}),
                 }, {
                   //Exits
                   Entrance(RR_HYRULE_FIELD,     {[]{return true;}}),
                   Entrance(RR_LLR_TALONS_HOUSE, {[]{return true;}}),
                   Entrance(RR_LLR_STABLES,      {[]{return true;}}),
                   Entrance(RR_LLR_TOWER,        {[]{return true;}}),
-                  Entrance(RR_LLR_GROTTO,       {[]{return IsChild;}}),
+                  Entrance(RR_LLR_GROTTO,       {[]{return Logic::IsChild;}}),
   });
 
   areaTable[RR_LLR_TALONS_HOUSE] = Area("LLR Talons House", "LLR Talons House", RHT_NONE, NO_DAY_NIGHT_CYCLE, {}, {
                   //Locations
-                  LocationAccess(RC_LLR_TALONS_CHICKENS, {[]{return IsChild && AtDay && ZeldasLetter;}}),
+                  LocationAccess(RC_LLR_TALONS_CHICKENS, {[]{return Logic::IsChild && AtDay && ZeldasLetter;}}),
                 }, {
                   //Exits
                   Entrance(RR_LON_LON_RANCH, {[]{return true;}}),
@@ -214,7 +214,7 @@ void AreaTable_Init_HyruleField() {
 
   areaTable[RR_LLR_TOWER] = Area("LLR Tower", "LLR Tower", RHT_NONE, NO_DAY_NIGHT_CYCLE, {}, {
                   //Locations
-                  LocationAccess(RC_LLR_FREESTANDING_POH, {[]{return IsChild;}}),
+                  LocationAccess(RC_LLR_FREESTANDING_POH, {[]{return Logic::IsChild;}}),
                   LocationAccess(RC_LLR_TOWER_LEFT_COW,   {[]{return CanPlay(EponasSong);}}),
                   LocationAccess(RC_LLR_TOWER_RIGHT_COW,  {[]{return CanPlay(EponasSong);}}),
                 }, {

--- a/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_jabujabus_belly.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_jabujabus_belly.cpp
@@ -76,7 +76,7 @@ void AreaTable_Init_JabuJabusBelly() {
 
   areaTable[RR_JABU_JABUS_BELLY_LIFT_LOWER] = Area("Jabu Jabus Belly Lift Lower", "Jabu Jabus Belly", RHT_JABU_JABUS_BELLY, NO_DAY_NIGHT_CYCLE, {}, {
                   //Locations
-                  LocationAccess(RC_JABU_JABUS_BELLY_DEKU_SCRUB, {[]{return (IsChild || CanDive || LogicJabuAlcoveJumpDive || CanUse(RG_IRON_BOOTS)) && CanStunDeku;}}),
+                  LocationAccess(RC_JABU_JABUS_BELLY_DEKU_SCRUB, {[]{return (Logic::IsChild || CanDive || LogicJabuAlcoveJumpDive || CanUse(RG_IRON_BOOTS)) && CanStunDeku;}}),
                 }, {
                   //Exits
                   Entrance(RR_JABU_JABUS_BELLY_SHABOMB_CORRIDOR, {[]{return true;}}),
@@ -154,7 +154,7 @@ void AreaTable_Init_JabuJabusBelly() {
                 }, {
                   //Exits
                   Entrance(RR_JABU_JABUS_BELLY_LIFT_MIDDLE, {[]{return true;}}),
-                  Entrance(RR_JABU_JABUS_BELLY_BOSS_ENTRYWAY, {[]{return CanUse(RG_BOOMERANG) || (LogicJabuNearBossRanged && ((IsAdult && (CanUse(RG_HOOKSHOT) || CanUse(RG_FAIRY_BOW))) || (IsChild && CanUse(RG_FAIRY_SLINGSHOT)))) || (LogicJabuNearBossExplosives && (HasBombchus || (IsAdult && CanUse(RG_HOVER_BOOTS) && Bombs)));}}),
+                  Entrance(RR_JABU_JABUS_BELLY_BOSS_ENTRYWAY, {[]{return CanUse(RG_BOOMERANG) || (LogicJabuNearBossRanged && ((IsAdult && (CanUse(RG_HOOKSHOT) || CanUse(RG_FAIRY_BOW))) || (Logic::IsChild && CanUse(RG_FAIRY_SLINGSHOT)))) || (LogicJabuNearBossExplosives && (HasBombchus || (IsAdult && CanUse(RG_HOVER_BOOTS) && Bombs)));}}),
   });
   }
 
@@ -168,11 +168,11 @@ void AreaTable_Init_JabuJabusBelly() {
   }, {
                   //Locations
                   LocationAccess(RC_JABU_JABUS_BELLY_MQ_MAP_CHEST,             {[]{return CanBlastOrSmash;}}),
-                  LocationAccess(RC_JABU_JABUS_BELLY_MQ_FIRST_ROOM_SIDE_CHEST, {[]{return IsChild && CanUse(RG_FAIRY_SLINGSHOT);}}),
+                  LocationAccess(RC_JABU_JABUS_BELLY_MQ_FIRST_ROOM_SIDE_CHEST, {[]{return Logic::IsChild && CanUse(RG_FAIRY_SLINGSHOT);}}),
   }, {
                   //Exits
                   Entrance(RR_JABU_JABUS_BELLY_ENTRYWAY, {[]{return true;}}),
-                  Entrance(RR_JABU_JABUS_BELLY_MQ_MAIN,  {[]{return Here(RR_JABU_JABUS_BELLY_MQ_BEGINNING, []{return IsChild && CanUse(RG_FAIRY_SLINGSHOT);});}}),
+                  Entrance(RR_JABU_JABUS_BELLY_MQ_MAIN,  {[]{return Here(RR_JABU_JABUS_BELLY_MQ_BEGINNING, []{return Logic::IsChild && CanUse(RG_FAIRY_SLINGSHOT);});}}),
   });
 
   areaTable[RR_JABU_JABUS_BELLY_MQ_MAIN] = Area("Jabu Jabus Belly MQ Main", "Jabu Jabus Belly", RHT_JABU_JABUS_BELLY, NO_DAY_NIGHT_CYCLE, {}, {
@@ -184,12 +184,12 @@ void AreaTable_Init_JabuJabusBelly() {
                   LocationAccess(RC_JABU_JABUS_BELLY_MQ_BASEMENT_NEAR_SWITCHES_CHEST, {[]{return true;}}),
                   LocationAccess(RC_JABU_JABUS_BELLY_MQ_BOOMERANG_ROOM_SMALL_CHEST,   {[]{return true;}}),
                   LocationAccess(RC_JABU_JABUS_BELLY_MQ_BOOMERANG_CHEST,              {[]{return true;}}),
-                  LocationAccess(RC_JABU_JABUS_BELLY_MQ_GS_BOOMERANG_CHEST_ROOM,      {[]{return CanPlay(SongOfTime) || (LogicJabuMQSoTGS && IsChild && CanUse(RG_BOOMERANG));}}),
-                    //Trick: CanPlay(SongOfTime) || (LogicJabuMQSoTGS && IsChild && CanUse(RG_BOOMERANG))
+                  LocationAccess(RC_JABU_JABUS_BELLY_MQ_GS_BOOMERANG_CHEST_ROOM,      {[]{return CanPlay(SongOfTime) || (LogicJabuMQSoTGS && Logic::IsChild && CanUse(RG_BOOMERANG));}}),
+                    //Trick: CanPlay(SongOfTime) || (LogicJabuMQSoTGS && Logic::IsChild && CanUse(RG_BOOMERANG))
   }, {
                   //Exits
                   Entrance(RR_JABU_JABUS_BELLY_MQ_BEGINNING, {[]{return true;}}),
-                  Entrance(RR_JABU_JABUS_BELLY_MQ_DEPTHS,    {[]{return HasExplosives && IsChild && CanUse(RG_BOOMERANG);}}),
+                  Entrance(RR_JABU_JABUS_BELLY_MQ_DEPTHS,    {[]{return HasExplosives && Logic::IsChild && CanUse(RG_BOOMERANG);}}),
   });
 
   areaTable[RR_JABU_JABUS_BELLY_MQ_DEPTHS] = Area("Jabu Jabus Belly MQ Depths", "Jabu Jabus Belly", RHT_JABU_JABUS_BELLY, NO_DAY_NIGHT_CYCLE, {}, {

--- a/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_kakariko.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_kakariko.cpp
@@ -10,18 +10,18 @@ void AreaTable_Init_Kakariko() {
                   //Events
                   EventAccess(&CojiroAccess,            {[]{return CojiroAccess || (IsAdult && WakeUpAdultTalon);}}),
                   EventAccess(&BugRock,                 {[]{return true;}}),
-                  EventAccess(&KakarikoVillageGateOpen, {[]{return KakarikoVillageGateOpen || (IsChild && (ZeldasLetter || OpenKakariko.Is(OPENKAKARIKO_OPEN)));}}),
+                  EventAccess(&KakarikoVillageGateOpen, {[]{return KakarikoVillageGateOpen || (Logic::IsChild && (ZeldasLetter || OpenKakariko.Is(OPENKAKARIKO_OPEN)));}}),
                 }, {
                   //Locations
                   LocationAccess(RC_SHEIK_IN_KAKARIKO,               {[]{return IsAdult && ForestMedallion && FireMedallion && WaterMedallion;}}),
-                  LocationAccess(RC_KAK_ANJU_AS_CHILD,               {[]{return IsChild && AtDay;}}),
+                  LocationAccess(RC_KAK_ANJU_AS_CHILD,               {[]{return Logic::IsChild && AtDay;}}),
                   LocationAccess(RC_KAK_ANJU_AS_ADULT,               {[]{return IsAdult && AtDay;}}),
                   LocationAccess(RC_KAK_TRADE_POCKET_CUCCO,          {[]{return IsAdult && AtDay && PocketEgg && WakeUpAdultTalon;}}),
-                  LocationAccess(RC_KAK_GS_HOUSE_UNDER_CONSTRUCTION, {[]{return IsChild && AtNight && CanGetNightTimeGS;}}),
-                  LocationAccess(RC_KAK_GS_SKULLTULA_HOUSE,          {[]{return IsChild && AtNight && CanGetNightTimeGS;}}),
-                  LocationAccess(RC_KAK_GS_GUARDS_HOUSE,             {[]{return IsChild && AtNight && CanGetNightTimeGS;}}),
-                  LocationAccess(RC_KAK_GS_TREE,                     {[]{return IsChild && AtNight && CanGetNightTimeGS;}}),
-                  LocationAccess(RC_KAK_GS_WATCHTOWER,               {[]{return IsChild && (Slingshot || HasBombchus || CanUse(RG_FAIRY_BOW) || CanUse(RG_LONGSHOT) || (LogicKakarikoTowerGS && CanJumpslash)) && AtNight && CanGetNightTimeGS;}}),
+                  LocationAccess(RC_KAK_GS_HOUSE_UNDER_CONSTRUCTION, {[]{return Logic::IsChild && AtNight && CanGetNightTimeGS;}}),
+                  LocationAccess(RC_KAK_GS_SKULLTULA_HOUSE,          {[]{return Logic::IsChild && AtNight && CanGetNightTimeGS;}}),
+                  LocationAccess(RC_KAK_GS_GUARDS_HOUSE,             {[]{return Logic::IsChild && AtNight && CanGetNightTimeGS;}}),
+                  LocationAccess(RC_KAK_GS_TREE,                     {[]{return Logic::IsChild && AtNight && CanGetNightTimeGS;}}),
+                  LocationAccess(RC_KAK_GS_WATCHTOWER,               {[]{return Logic::IsChild && (Slingshot || HasBombchus || CanUse(RG_FAIRY_BOW) || CanUse(RG_LONGSHOT) || (LogicKakarikoTowerGS && CanJumpslash)) && AtNight && CanGetNightTimeGS;}}),
                 }, {
                   //Exits
                   Entrance(RR_HYRULE_FIELD,                {[]{return true;}}),
@@ -31,10 +31,10 @@ void AreaTable_Init_Kakariko() {
                   Entrance(RR_KAK_WINDMILL,                {[]{return true;}}),
                   Entrance(RR_KAK_BAZAAR,                  {[]{return IsAdult && AtDay;}}),
                   Entrance(RR_KAK_SHOOTING_GALLERY,        {[]{return IsAdult && AtDay;}}),
-                  Entrance(RR_BOTTOM_OF_THE_WELL_ENTRYWAY, {[]{return DrainWell && (IsChild || ShuffleDungeonEntrances.IsNot(SHUFFLEDUNGEONS_OFF));}}),
-                  Entrance(RR_KAK_POTION_SHOP_FRONT,       {[]{return AtDay || IsChild;}}),
+                  Entrance(RR_BOTTOM_OF_THE_WELL_ENTRYWAY, {[]{return DrainWell && (Logic::IsChild || ShuffleDungeonEntrances.IsNot(SHUFFLEDUNGEONS_OFF));}}),
+                  Entrance(RR_KAK_POTION_SHOP_FRONT,       {[]{return AtDay || Logic::IsChild;}}),
                   Entrance(RR_KAK_REDEAD_GROTTO,           {[]{return CanOpenBombGrotto;}}),
-                  Entrance(RR_KAK_IMPAS_LEDGE,             {[]{return (IsChild && AtDay) || CanUse(RG_HOOKSHOT) || (IsAdult && LogicVisibleCollision);}}),
+                  Entrance(RR_KAK_IMPAS_LEDGE,             {[]{return (Logic::IsChild && AtDay) || CanUse(RG_HOOKSHOT) || (IsAdult && LogicVisibleCollision);}}),
                   Entrance(RR_KAK_ROOFTOP,                 {[]{return CanUse(RG_HOOKSHOT) || (LogicManOnRoof && (IsAdult || AtDay || Slingshot || HasBombchus || CanUse(RG_FAIRY_BOW) || CanUse(RG_LONGSHOT)));}}),
                   Entrance(RR_KAK_IMPAS_ROOFTOP,           {[]{return CanUse(RG_HOOKSHOT) || (LogicKakarikoRooftopGS && CanUse(RG_HOVER_BOOTS));}}),
                   Entrance(RR_THE_GRAVEYARD,               {[]{return true;}}),
@@ -115,10 +115,10 @@ void AreaTable_Init_Kakariko() {
 
   areaTable[RR_KAK_WINDMILL] = Area("Kak Windmill", "Windmill and Dampes Grave", RHT_NONE, NO_DAY_NIGHT_CYCLE, {
                   //Events
-                  EventAccess(&DrainWell, {[]{return DrainWell || (IsChild && CanPlay(SongOfStorms));}}),
+                  EventAccess(&DrainWell, {[]{return DrainWell || (Logic::IsChild && CanPlay(SongOfStorms));}}),
                 }, {
                   //Locations
-                  LocationAccess(RC_KAK_WINDMILL_FREESTANDING_POH, {[]{return CanUse(RG_BOOMERANG) || DampesWindmillAccess || (IsAdult && LogicAdultWindmillPoH) || (IsChild && CanJumpslash && LogicChildWindmillPoH);}}),
+                  LocationAccess(RC_KAK_WINDMILL_FREESTANDING_POH, {[]{return CanUse(RG_BOOMERANG) || DampesWindmillAccess || (IsAdult && LogicAdultWindmillPoH) || (Logic::IsChild && CanJumpslash && LogicChildWindmillPoH);}}),
                     //PoH as child not added to trick options yet (needs uncommenting in randomizer_tricks.cpp)
                   LocationAccess(RC_SONG_FROM_WINDMILL,            {[]{return IsAdult && Ocarina;}}),
                 }, {
@@ -213,8 +213,8 @@ void AreaTable_Init_Kakariko() {
                 }, {
                   //Locations
                   LocationAccess(RC_GRAVEYARD_FREESTANDING_POH,        {[]{return (IsAdult && CanPlantBean(RR_THE_GRAVEYARD)) || CanUse(RG_LONGSHOT) || (LogicGraveyardPoH && CanUse(RG_BOOMERANG));}}),
-                  LocationAccess(RC_GRAVEYARD_DAMPE_GRAVEDIGGING_TOUR, {[]{return IsChild && AtNight;}}), //TODO: This needs to change
-                  LocationAccess(RC_GRAVEYARD_GS_WALL,                 {[]{return IsChild && HookshotOrBoomerang && AtNight && CanGetNightTimeGS;}}),
+                  LocationAccess(RC_GRAVEYARD_DAMPE_GRAVEDIGGING_TOUR, {[]{return Logic::IsChild && AtNight;}}), //TODO: This needs to change
+                  LocationAccess(RC_GRAVEYARD_GS_WALL,                 {[]{return Logic::IsChild && HookshotOrBoomerang && AtNight && CanGetNightTimeGS;}}),
                   LocationAccess(RC_GRAVEYARD_GS_BEAN_PATCH,           {[]{return CanPlantBugs && CanChildAttack;}}),
                 }, {
                   //Exits

--- a/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_lost_woods.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_lost_woods.cpp
@@ -10,11 +10,11 @@ void AreaTable_Init_LostWoods() {
                   //Events
                   EventAccess(&BeanPlantFairy,           {[]{return BeanPlantFairy   || (CanPlantBean(RR_KOKIRI_FOREST) && CanPlay(SongOfStorms));}}),
                   EventAccess(&GossipStoneFairy,         {[]{return GossipStoneFairy || CanSummonGossipFairyWithoutSuns;}}),
-                  EventAccess(&ShowedMidoSwordAndShield, {[]{return ShowedMidoSwordAndShield || (IsChild && KokiriSword && DekuShield);}}),
+                  EventAccess(&ShowedMidoSwordAndShield, {[]{return ShowedMidoSwordAndShield || (Logic::IsChild && KokiriSword && DekuShield);}}),
                 }, {
                   //Locations
-                  LocationAccess(RC_KF_KOKIRI_SWORD_CHEST,   {[]{return IsChild;}}),
-                  LocationAccess(RC_KF_GS_KNOW_IT_ALL_HOUSE, {[]{return IsChild && CanChildAttack && AtNight && (HasNightStart || CanLeaveForest || CanPlay(SunsSong)) && CanGetNightTimeGS;}}),
+                  LocationAccess(RC_KF_KOKIRI_SWORD_CHEST,   {[]{return Logic::IsChild;}}),
+                  LocationAccess(RC_KF_GS_KNOW_IT_ALL_HOUSE, {[]{return Logic::IsChild && CanChildAttack && AtNight && (HasNightStart || CanLeaveForest || CanPlay(SunsSong)) && CanGetNightTimeGS;}}),
                   LocationAccess(RC_KF_GS_BEAN_PATCH,        {[]{return CanPlantBugs && CanChildAttack;}}),
                   LocationAccess(RC_KF_GS_HOUSE_OF_TWINS,    {[]{return IsAdult && AtNight && (HookshotOrBoomerang || (LogicAdultKokiriGS && CanUse(RG_HOVER_BOOTS))) && CanGetNightTimeGS;}}),
                   LocationAccess(RC_KF_GOSSIP_STONE,         {[]{return true;}}),
@@ -36,14 +36,14 @@ void AreaTable_Init_LostWoods() {
                   //Events
                   EventAccess(&DekuBabaSticks,           {[]{return DekuBabaSticks || ((IsAdult && ShuffleDungeonEntrances.Is(SHUFFLEDUNGEONS_OFF)) || KokiriSword || Boomerang);}}),
                   EventAccess(&DekuBabaNuts,             {[]{return DekuBabaNuts   || ((IsAdult && ShuffleDungeonEntrances.Is(SHUFFLEDUNGEONS_OFF)) || KokiriSword || Slingshot || Sticks || HasExplosives || CanUse(RG_DINS_FIRE));}}),
-                  EventAccess(&ShowedMidoSwordAndShield, {[]{return ShowedMidoSwordAndShield || (IsChild && KokiriSword && DekuShield);}}),
+                  EventAccess(&ShowedMidoSwordAndShield, {[]{return ShowedMidoSwordAndShield || (Logic::IsChild && KokiriSword && DekuShield);}}),
                 }, {
                   //Locations
                   LocationAccess(RC_KF_DEKU_TREE_LEFT_GOSSIP_STONE,  {[]{return true;}}),
                   LocationAccess(RC_KF_DEKU_TREE_RIGHT_GOSSIP_STONE, {[]{return true;}}),
                 }, {
                   //Exits
-                  Entrance(RR_DEKU_TREE_ENTRYWAY, {[]{return IsChild || (ShuffleDungeonEntrances.IsNot(SHUFFLEDUNGEONS_OFF) && (OpenForest.Is(OPENFOREST_OPEN) || ShowedMidoSwordAndShield));}}),
+                  Entrance(RR_DEKU_TREE_ENTRYWAY, {[]{return Logic::IsChild || (ShuffleDungeonEntrances.IsNot(SHUFFLEDUNGEONS_OFF) && (OpenForest.Is(OPENFOREST_OPEN) || ShowedMidoSwordAndShield));}}),
                   Entrance(RR_KOKIRI_FOREST,      {[]{return IsAdult || OpenForest.Is(OPENFOREST_OPEN) || ShowedMidoSwordAndShield;}}),
   });
 
@@ -116,15 +116,15 @@ void AreaTable_Init_LostWoods() {
                   EventAccess(&PoachersSawAccess, {[]{return PoachersSawAccess || (IsAdult && OddPoulticeAccess);}}),
                   EventAccess(&GossipStoneFairy,  {[]{return GossipStoneFairy  || CanSummonGossipFairyWithoutSuns;}}),
                   EventAccess(&BeanPlantFairy,    {[]{return BeanPlantFairy    || CanPlay(SongOfStorms);}}),
-                  EventAccess(&BugShrub,          {[]{return IsChild && CanCutShrubs;}}),
+                  EventAccess(&BugShrub,          {[]{return Logic::IsChild && CanCutShrubs;}}),
                 }, {
                   //Locations
-                  LocationAccess(RC_LW_SKULL_KID,                 {[]{return IsChild && CanPlay(SariasSong);}}),
+                  LocationAccess(RC_LW_SKULL_KID,                 {[]{return Logic::IsChild && CanPlay(SariasSong);}}),
                   LocationAccess(RC_LW_TRADE_COJIRO,              {[]{return IsAdult && Cojiro;}}),
                   LocationAccess(RC_LW_TRADE_ODD_POTION,        {[]{return IsAdult && OddPoultice && Cojiro;}}),
-                  LocationAccess(RC_LW_OCARINA_MEMORY_GAME,       {[]{return IsChild && Ocarina;}}),
-                  LocationAccess(RC_LW_TARGET_IN_WOODS,           {[]{return IsChild && CanUse(RG_FAIRY_SLINGSHOT);}}),
-                  LocationAccess(RC_LW_DEKU_SCRUB_NEAR_BRIDGE,    {[]{return IsChild && CanStunDeku;}}),
+                  LocationAccess(RC_LW_OCARINA_MEMORY_GAME,       {[]{return Logic::IsChild && Ocarina;}}),
+                  LocationAccess(RC_LW_TARGET_IN_WOODS,           {[]{return Logic::IsChild && CanUse(RG_FAIRY_SLINGSHOT);}}),
+                  LocationAccess(RC_LW_DEKU_SCRUB_NEAR_BRIDGE,    {[]{return Logic::IsChild && CanStunDeku;}}),
                   LocationAccess(RC_LW_GS_BEAN_PATCH_NEAR_BRIDGE, {[]{return CanPlantBugs && CanChildAttack;}}),
                   LocationAccess(RC_LW_GOSSIP_STONE,              {[]{return true;}}),
                 }, {
@@ -133,7 +133,7 @@ void AreaTable_Init_LostWoods() {
                   Entrance(RR_GC_WOODS_WARP,            {[]{return true;}}),
                   Entrance(RR_LW_BRIDGE,                {[]{return CanLeaveForest && ((IsAdult && (CanPlantBean(RR_THE_LOST_WOODS) || LogicLostWoodsBridge)) || CanUse(RG_HOVER_BOOTS) || CanUse(RG_LONGSHOT));}}),
                   Entrance(RR_ZORAS_RIVER,              {[]{return CanLeaveForest && (CanDive || CanUse(RG_IRON_BOOTS));}}),
-                  Entrance(RR_LW_BEYOND_MIDO,           {[]{return IsChild || CanPlay(SariasSong) || LogicMidoBackflip;}}),
+                  Entrance(RR_LW_BEYOND_MIDO,           {[]{return Logic::IsChild || CanPlay(SariasSong) || LogicMidoBackflip;}}),
                   Entrance(RR_LW_NEAR_SHORTCUTS_GROTTO, {[]{return Here(RR_THE_LOST_WOODS, []{return CanBlastOrSmash;});}}),
   });
 
@@ -142,14 +142,14 @@ void AreaTable_Init_LostWoods() {
                   EventAccess(&ButterflyFairy, {[]{return ButterflyFairy || CanUse(RG_STICKS);}}),
                 }, {
                   //Locations
-                  LocationAccess(RC_LW_DEKU_SCRUB_NEAR_DEKU_THEATER_RIGHT, {[]{return IsChild && CanStunDeku;}}),
-                  LocationAccess(RC_LW_DEKU_SCRUB_NEAR_DEKU_THEATER_LEFT,  {[]{return IsChild && CanStunDeku;}}),
+                  LocationAccess(RC_LW_DEKU_SCRUB_NEAR_DEKU_THEATER_RIGHT, {[]{return Logic::IsChild && CanStunDeku;}}),
+                  LocationAccess(RC_LW_DEKU_SCRUB_NEAR_DEKU_THEATER_LEFT,  {[]{return Logic::IsChild && CanStunDeku;}}),
                   LocationAccess(RC_LW_GS_ABOVE_THEATER,                   {[]{return IsAdult && AtNight && (CanPlantBean(RR_LW_BEYOND_MIDO) || (LogicLostWoodsGSBean && CanUse(RG_HOOKSHOT) && (CanUse(RG_LONGSHOT) || CanUse(RG_FAIRY_BOW) || CanUse(RG_FAIRY_SLINGSHOT) || HasBombchus || CanUse(RG_DINS_FIRE)))) && CanGetNightTimeGS;}}),
                   LocationAccess(RC_LW_GS_BEAN_PATCH_NEAR_THEATER,         {[]{return CanPlantBugs && (CanChildAttack || (Scrubsanity.Is(SCRUBSANITY_OFF) && DekuShield));}}),
                 }, {
                   //Exits
                   Entrance(RR_LW_FOREST_EXIT,   {[]{return true;}}),
-                  Entrance(RR_THE_LOST_WOODS,   {[]{return IsChild || CanPlay(SariasSong);}}),
+                  Entrance(RR_THE_LOST_WOODS,   {[]{return Logic::IsChild || CanPlay(SariasSong);}}),
                   Entrance(RR_SFM_ENTRYWAY,     {[]{return true;}}),
                   Entrance(RR_DEKU_THEATER,     {[]{return true;}}),
                   Entrance(RR_LW_SCRUBS_GROTTO, {[]{return Here(RR_LW_BEYOND_MIDO, []{return CanBlastOrSmash;});}}),
@@ -166,8 +166,8 @@ void AreaTable_Init_LostWoods() {
 
   areaTable[RR_DEKU_THEATER] = Area("Deku Theater", "Deku Theater", RHT_NONE, NO_DAY_NIGHT_CYCLE, {}, {
                   //Locations
-                  LocationAccess(RC_DEKU_THEATER_SKULL_MASK,    {[]{return IsChild && SkullMask;}}),
-                  LocationAccess(RC_DEKU_THEATER_MASK_OF_TRUTH, {[]{return IsChild && MaskOfTruth;}}),
+                  LocationAccess(RC_DEKU_THEATER_SKULL_MASK,    {[]{return Logic::IsChild && SkullMask;}}),
+                  LocationAccess(RC_DEKU_THEATER_MASK_OF_TRUTH, {[]{return Logic::IsChild && MaskOfTruth;}}),
                 }, {
                   //Exits
                   Entrance(RR_LW_BEYOND_MIDO, {[]{return true;}}),
@@ -194,7 +194,7 @@ void AreaTable_Init_LostWoods() {
                   EventAccess(&GossipStoneFairy, {[]{return GossipStoneFairy || CanSummonGossipFairyWithoutSuns;}}),
                 }, {
                   //Locations
-                  LocationAccess(RC_SONG_FROM_SARIA,             {[]{return IsChild && ZeldasLetter;}}),
+                  LocationAccess(RC_SONG_FROM_SARIA,             {[]{return Logic::IsChild && ZeldasLetter;}}),
                   LocationAccess(RC_SHEIK_IN_FOREST,             {[]{return IsAdult;}}),
                   LocationAccess(RC_SFM_GS,                      {[]{return IsAdult && HookshotOrBoomerang && AtNight && CanGetNightTimeGS;}}),
                   LocationAccess(RC_SFM_MAZE_LOWER_GOSSIP_STONE, {[]{return true;}}),

--- a/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_spirit_temple.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_spirit_temple.cpp
@@ -24,7 +24,7 @@ void AreaTable_Init_SpiritTemple() {
   areaTable[RR_SPIRIT_TEMPLE_LOBBY] = Area("Spirit Temple Lobby", "Spirit Temple", RHT_SPIRIT_TEMPLE, NO_DAY_NIGHT_CYCLE, {}, {}, {
                   //Exits
                   Entrance(RR_SPIRIT_TEMPLE_ENTRYWAY,    {[]{return true;}}),
-                  Entrance(RR_SPIRIT_TEMPLE_CHILD,       {[]{return IsChild;}}),
+                  Entrance(RR_SPIRIT_TEMPLE_CHILD,       {[]{return Logic::IsChild;}}),
                   Entrance(RR_SPIRIT_TEMPLE_EARLY_ADULT, {[]{return CanUse(RG_SILVER_GAUNTLETS);}}),
   });
 
@@ -43,11 +43,11 @@ void AreaTable_Init_SpiritTemple() {
 
   areaTable[RR_SPIRIT_TEMPLE_CHILD_CLIMB] = Area("Child Spirit Temple Climb", "Spirit Temple", RHT_SPIRIT_TEMPLE, NO_DAY_NIGHT_CYCLE, {}, {
                   //Locations
-                  LocationAccess(RC_SPIRIT_TEMPLE_CHILD_CLIMB_NORTH_CHEST, {[]{return HasProjectile(HasProjectileAge::Both) || ((SmallKeys(RR_SPIRIT_TEMPLE, 3) || (SmallKeys(RR_SPIRIT_TEMPLE, 2) && BombchusInLogic && ShuffleDungeonEntrances.Is(SHUFFLEDUNGEONS_OFF))) && CanUse(RG_SILVER_GAUNTLETS) && HasProjectile(HasProjectileAge::Adult)) || (SmallKeys(RR_SPIRIT_TEMPLE, 5) && IsChild && HasProjectile(HasProjectileAge::Child));}}),
-                  LocationAccess(RC_SPIRIT_TEMPLE_CHILD_CLIMB_EAST_CHEST,  {[]{return HasProjectile(HasProjectileAge::Both) || ((SmallKeys(RR_SPIRIT_TEMPLE, 3) || (SmallKeys(RR_SPIRIT_TEMPLE, 2) && BombchusInLogic && ShuffleDungeonEntrances.Is(SHUFFLEDUNGEONS_OFF))) && CanUse(RG_SILVER_GAUNTLETS) && HasProjectile(HasProjectileAge::Adult)) || (SmallKeys(RR_SPIRIT_TEMPLE, 5) && IsChild && HasProjectile(HasProjectileAge::Child));}}),
+                  LocationAccess(RC_SPIRIT_TEMPLE_CHILD_CLIMB_NORTH_CHEST, {[]{return HasProjectile(HasProjectileAge::Both) || ((SmallKeys(RR_SPIRIT_TEMPLE, 3) || (SmallKeys(RR_SPIRIT_TEMPLE, 2) && BombchusInLogic && ShuffleDungeonEntrances.Is(SHUFFLEDUNGEONS_OFF))) && CanUse(RG_SILVER_GAUNTLETS) && HasProjectile(HasProjectileAge::Adult)) || (SmallKeys(RR_SPIRIT_TEMPLE, 5) && Logic::IsChild && HasProjectile(HasProjectileAge::Child));}}),
+                  LocationAccess(RC_SPIRIT_TEMPLE_CHILD_CLIMB_EAST_CHEST,  {[]{return HasProjectile(HasProjectileAge::Both) || ((SmallKeys(RR_SPIRIT_TEMPLE, 3) || (SmallKeys(RR_SPIRIT_TEMPLE, 2) && BombchusInLogic && ShuffleDungeonEntrances.Is(SHUFFLEDUNGEONS_OFF))) && CanUse(RG_SILVER_GAUNTLETS) && HasProjectile(HasProjectileAge::Adult)) || (SmallKeys(RR_SPIRIT_TEMPLE, 5) && Logic::IsChild && HasProjectile(HasProjectileAge::Child));}}),
                   LocationAccess(RC_SPIRIT_TEMPLE_GS_SUN_ON_FLOOR_ROOM,    {[]{return HasProjectile(HasProjectileAge::Both) || CanUse(RG_DINS_FIRE) ||
                                                                                       (CanTakeDamage && (Sticks || KokiriSword || HasProjectile(HasProjectileAge::Child))) ||
-                                                                                        (IsChild && SmallKeys(RR_SPIRIT_TEMPLE, 5) && HasProjectile(HasProjectileAge::Child)) ||
+                                                                                        (Logic::IsChild && SmallKeys(RR_SPIRIT_TEMPLE, 5) && HasProjectile(HasProjectileAge::Child)) ||
                                                                                           ((SmallKeys(RR_SPIRIT_TEMPLE, 3) || (SmallKeys(RR_SPIRIT_TEMPLE, 2) && BombchusInLogic && ShuffleDungeonEntrances.Is(SHUFFLEDUNGEONS_OFF))) && CanUse(RG_SILVER_GAUNTLETS) && (HasProjectile(HasProjectileAge::Adult) || CanTakeDamage));}}),
                 }, {
                   //Exits
@@ -109,7 +109,7 @@ void AreaTable_Init_SpiritTemple() {
                   LocationAccess(RC_SPIRIT_TEMPLE_MIRROR_SHIELD_CHEST,    {[]{return SmallKeys(RR_SPIRIT_TEMPLE, 4) && CanUse(RG_SILVER_GAUNTLETS) && HasExplosives;}}),
                 }, {
                   //Exits
-                  Entrance(RR_DESERT_COLOSSUS, {[]{return (IsChild && SmallKeys(RR_SPIRIT_TEMPLE, 5)) || (CanUse(RG_SILVER_GAUNTLETS) && ((SmallKeys(RR_SPIRIT_TEMPLE, 3) && HasExplosives) || SmallKeys(RR_SPIRIT_TEMPLE, 5)));}}),
+                  Entrance(RR_DESERT_COLOSSUS, {[]{return (Logic::IsChild && SmallKeys(RR_SPIRIT_TEMPLE, 5)) || (CanUse(RG_SILVER_GAUNTLETS) && ((SmallKeys(RR_SPIRIT_TEMPLE, 3) && HasExplosives) || SmallKeys(RR_SPIRIT_TEMPLE, 5)));}}),
   });
 
   areaTable[RR_SPIRIT_TEMPLE_BEYOND_CENTRAL_LOCKED_DOOR] = Area("Spirit Temple Beyond Central Locked Door", "Spirit Temple", RHT_SPIRIT_TEMPLE, NO_DAY_NIGHT_CYCLE, {}, {
@@ -147,12 +147,12 @@ void AreaTable_Init_SpiritTemple() {
   areaTable[RR_SPIRIT_TEMPLE_MQ_LOBBY] = Area("Spirit Temple MQ Lobby", "Spirit Temple", RHT_SPIRIT_TEMPLE, NO_DAY_NIGHT_CYCLE, {}, {
                   //Locations
                   LocationAccess(RC_SPIRIT_TEMPLE_MQ_ENTRANCE_FRONT_LEFT_CHEST, {[]{return true;}}),
-                  LocationAccess(RC_SPIRIT_TEMPLE_MQ_ENTRANCE_BACK_LEFT_CHEST,  {[]{return Here(RR_SPIRIT_TEMPLE_MQ_LOBBY, []{return CanBlastOrSmash;}) && ((IsChild && CanUse(RG_FAIRY_SLINGSHOT)) || (IsAdult && CanUse(RG_FAIRY_BOW)));}}),
-                  LocationAccess(RC_SPIRIT_TEMPLE_MQ_ENTRANCE_BACK_RIGHT_CHEST, {[]{return HasBombchus || (IsAdult && (CanUse(RG_FAIRY_BOW) || CanUse(RG_HOOKSHOT))) || (IsChild && (CanUse(RG_FAIRY_SLINGSHOT) || CanUse(RG_BOOMERANG)));}}),
+                  LocationAccess(RC_SPIRIT_TEMPLE_MQ_ENTRANCE_BACK_LEFT_CHEST,  {[]{return Here(RR_SPIRIT_TEMPLE_MQ_LOBBY, []{return CanBlastOrSmash;}) && ((Logic::IsChild && CanUse(RG_FAIRY_SLINGSHOT)) || (IsAdult && CanUse(RG_FAIRY_BOW)));}}),
+                  LocationAccess(RC_SPIRIT_TEMPLE_MQ_ENTRANCE_BACK_RIGHT_CHEST, {[]{return HasBombchus || (IsAdult && (CanUse(RG_FAIRY_BOW) || CanUse(RG_HOOKSHOT))) || (Logic::IsChild && (CanUse(RG_FAIRY_SLINGSHOT) || CanUse(RG_BOOMERANG)));}}),
   }, {
                   //Exits
                   Entrance(RR_SPIRIT_TEMPLE_ENTRYWAY, {[]{return true;}}),
-                  Entrance(RR_SPIRIT_TEMPLE_MQ_CHILD, {[]{return IsChild;}}),
+                  Entrance(RR_SPIRIT_TEMPLE_MQ_CHILD, {[]{return Logic::IsChild;}}),
                   Entrance(RR_SPIRIT_TEMPLE_MQ_ADULT, {[]{return HasBombchus && IsAdult && CanUse(RG_LONGSHOT) && CanUse(RG_SILVER_GAUNTLETS);}}),
   });
 
@@ -193,7 +193,7 @@ void AreaTable_Init_SpiritTemple() {
   areaTable[RR_SPIRIT_TEMPLE_MQ_SHARED] = Area("Spirit Temple MQ Shared", "Spirit Temple", RHT_SPIRIT_TEMPLE, NO_DAY_NIGHT_CYCLE, {}, {
                   //Locations
                   LocationAccess(RC_SPIRIT_TEMPLE_MQ_CHILD_CLIMB_NORTH_CHEST, {[]{return SmallKeys(RR_SPIRIT_TEMPLE, 6);}}),
-                  LocationAccess(RC_SPIRIT_TEMPLE_MQ_COMPASS_CHEST,           {[]{return (IsChild && CanUse(RG_FAIRY_SLINGSHOT) && SmallKeys(RR_SPIRIT_TEMPLE, 7)) || (IsAdult && CanUse(RG_FAIRY_BOW)) || (Bow && Slingshot);}}),
+                  LocationAccess(RC_SPIRIT_TEMPLE_MQ_COMPASS_CHEST,           {[]{return (Logic::IsChild && CanUse(RG_FAIRY_SLINGSHOT) && SmallKeys(RR_SPIRIT_TEMPLE, 7)) || (IsAdult && CanUse(RG_FAIRY_BOW)) || (Bow && Slingshot);}}),
                   LocationAccess(RC_SPIRIT_TEMPLE_MQ_SUN_BLOCK_ROOM_CHEST,    {[]{return CanPlay(SongOfTime) || LogicSpiritMQSunBlockSoT || IsAdult;}}),
                     //Trick: CanPlay(SongOfTime) || LogicSpiritMQSunBlockSoT || IsAdult
                   LocationAccess(RC_SPIRIT_TEMPLE_MQ_GS_SUN_BLOCK_ROOM,       {[]{return (LogicSpiritMQSunBlockGS && Boomerang && (CanPlay(SongOfTime) || LogicSpiritMQSunBlockSoT)) || IsAdult;}}),

--- a/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_water_temple.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_water_temple.cpp
@@ -28,7 +28,7 @@ void AreaTable_Init_WaterTemple() {
                   Entrance(RR_WATER_TEMPLE_EAST_LOWER,            {[]{return WaterTempleLow || ((LogicFewerTunicRequirements || CanUse(RG_ZORA_TUNIC)) && (CanUse(RG_IRON_BOOTS) || (CanUse(RG_LONGSHOT) && LogicWaterTempleTorchLongshot)));}}),
                   Entrance(RR_WATER_TEMPLE_NORTH_LOWER,           {[]{return WaterTempleLow || ((LogicFewerTunicRequirements || CanUse(RG_ZORA_TUNIC)) && CanUse(RG_IRON_BOOTS));}}),
                   Entrance(RR_WATER_TEMPLE_SOUTH_LOWER,           {[]{return WaterTempleLow && HasExplosives && (CanDive || CanUse(RG_IRON_BOOTS)) && (LogicFewerTunicRequirements || CanUse(RG_ZORA_TUNIC));}}),
-                  Entrance(RR_WATER_TEMPLE_WEST_LOWER,            {[]{return WaterTempleLow && GoronBracelet && (IsChild || CanDive || CanUse(RG_IRON_BOOTS)) && (LogicFewerTunicRequirements || CanUse(RG_ZORA_TUNIC));}}),
+                  Entrance(RR_WATER_TEMPLE_WEST_LOWER,            {[]{return WaterTempleLow && GoronBracelet && (Logic::IsChild || CanDive || CanUse(RG_IRON_BOOTS)) && (LogicFewerTunicRequirements || CanUse(RG_ZORA_TUNIC));}}),
                   Entrance(RR_WATER_TEMPLE_CENTRAL_PILLAR_LOWER,  {[]{return WaterTempleLow && SmallKeys(RR_WATER_TEMPLE, 5);}}),
                   Entrance(RR_WATER_TEMPLE_CENTRAL_PILLAR_UPPER,  {[]{return (WaterTempleLow || WaterTempleMiddle) && (HasFireSourceWithTorch || CanUse(RG_FAIRY_BOW));}}),
                   Entrance(RR_WATER_TEMPLE_EAST_MIDDLE,           {[]{return (WaterTempleLow || WaterTempleMiddle || (CanUse(RG_IRON_BOOTS) && WaterTimer >= 16)) && CanUse(RG_HOOKSHOT);}}),
@@ -117,7 +117,7 @@ void AreaTable_Init_WaterTemple() {
                   LocationAccess(RC_WATER_TEMPLE_BOSS_KEY_CHEST, {[]{return true;}}),
                 }, {
                   //Exits
-                  Entrance(RR_WATER_TEMPLE_BOULDERS_UPPER, {[]{return (CanUse(RG_IRON_BOOTS) || (IsAdult && LogicWaterBKJumpDive) || IsChild || CanDive) && SmallKeys(RR_WATER_TEMPLE, 5);}}),
+                  Entrance(RR_WATER_TEMPLE_BOULDERS_UPPER, {[]{return (CanUse(RG_IRON_BOOTS) || (IsAdult && LogicWaterBKJumpDive) || Logic::IsChild || CanDive) && SmallKeys(RR_WATER_TEMPLE, 5);}}),
   });
 
   areaTable[RR_WATER_TEMPLE_SOUTH_LOWER] = Area("Water Temple South Lower", "Water Temple", RHT_WATER_TEMPLE, NO_DAY_NIGHT_CYCLE, {}, {
@@ -136,7 +136,7 @@ void AreaTable_Init_WaterTemple() {
 
   areaTable[RR_WATER_TEMPLE_DRAGON_ROOM] = Area("Water Temple Dragon Room", "Water Temple", RHT_WATER_TEMPLE, NO_DAY_NIGHT_CYCLE, {}, {
                   //Locations
-                  LocationAccess(RC_WATER_TEMPLE_DRAGON_CHEST, {[]{return (CanUse(RG_HOOKSHOT) && CanUse(RG_IRON_BOOTS)) || (((IsAdult && LogicWaterDragonAdult && (CanUse(RG_HOOKSHOT) || CanUse(RG_FAIRY_BOW) || HasBombchus)) || (IsChild && LogicWaterDragonChild && (CanUse(RG_FAIRY_SLINGSHOT) || CanUse(RG_BOOMERANG) || HasBombchus))) && (CanDive || CanUse(RG_IRON_BOOTS))) ||
+                  LocationAccess(RC_WATER_TEMPLE_DRAGON_CHEST, {[]{return (CanUse(RG_HOOKSHOT) && CanUse(RG_IRON_BOOTS)) || (((IsAdult && LogicWaterDragonAdult && (CanUse(RG_HOOKSHOT) || CanUse(RG_FAIRY_BOW) || HasBombchus)) || (Logic::IsChild && LogicWaterDragonChild && (CanUse(RG_FAIRY_SLINGSHOT) || CanUse(RG_BOOMERANG) || HasBombchus))) && (CanDive || CanUse(RG_IRON_BOOTS))) ||
                                                                        Here(RR_WATER_TEMPLE_RIVER, []{return IsAdult && CanUse(RG_FAIRY_BOW) && ((LogicWaterDragonAdult && (CanDive || CanUse(RG_IRON_BOOTS))) || LogicWaterDragonJumpDive);});}}),
                 }, {
                   //Exits
@@ -202,7 +202,7 @@ void AreaTable_Init_WaterTemple() {
 
   areaTable[RR_WATER_TEMPLE_FALLING_PLATFORM_ROOM] = Area("Water Temple Falling Platform Room", "Water Temple", RHT_WATER_TEMPLE, NO_DAY_NIGHT_CYCLE, {}, {
                   //Locations
-                  LocationAccess(RC_WATER_TEMPLE_GS_FALLING_PLATFORM_ROOM, {[]{return CanUse(RG_LONGSHOT) || (LogicWaterFallingPlatformGSBoomerang && IsChild && CanUse(RG_BOOMERANG)) || (LogicWaterFallingPlatformGSHookshot && IsAdult && CanUse(RG_HOOKSHOT));}}),
+                  LocationAccess(RC_WATER_TEMPLE_GS_FALLING_PLATFORM_ROOM, {[]{return CanUse(RG_LONGSHOT) || (LogicWaterFallingPlatformGSBoomerang && Logic::IsChild && CanUse(RG_BOOMERANG)) || (LogicWaterFallingPlatformGSHookshot && IsAdult && CanUse(RG_HOOKSHOT));}}),
                 }, {
                   //Exits
                   Entrance(RR_WATER_TEMPLE_LOBBY,               {[]{return CanUse(RG_HOOKSHOT) && SmallKeys(RR_WATER_TEMPLE, 4);}}),
@@ -227,7 +227,7 @@ void AreaTable_Init_WaterTemple() {
                 }, {
                   //Exits
                   Entrance(RR_WATER_TEMPLE_DARK_LINK_ROOM, {[]{return true;}}),
-                  Entrance(RR_WATER_TEMPLE_RIVER,          {[]{return IsChild || CanPlay(SongOfTime);}}),
+                  Entrance(RR_WATER_TEMPLE_RIVER,          {[]{return Logic::IsChild || CanPlay(SongOfTime);}}),
   });
 
   areaTable[RR_WATER_TEMPLE_RIVER] = Area("Water Temple River", "Water Temple", RHT_WATER_TEMPLE, NO_DAY_NIGHT_CYCLE, {}, {
@@ -273,7 +273,7 @@ void AreaTable_Init_WaterTemple() {
 
   areaTable[RR_WATER_TEMPLE_MQ_LOWERED_WATER_LEVELS] = Area("Water Temple MQ Lowered Water Levels", "Water Temple", RHT_WATER_TEMPLE, NO_DAY_NIGHT_CYCLE, {}, {
                   //Locations
-                  LocationAccess(RC_WATER_TEMPLE_MQ_COMPASS_CHEST,                {[]{return (IsAdult && CanUse(RG_FAIRY_BOW)) || CanUse(RG_DINS_FIRE) || Here(RR_WATER_TEMPLE_MQ_LOBBY, []{return IsChild && CanUse(RG_STICKS) && HasExplosives;});}}),
+                  LocationAccess(RC_WATER_TEMPLE_MQ_COMPASS_CHEST,                {[]{return (IsAdult && CanUse(RG_FAIRY_BOW)) || CanUse(RG_DINS_FIRE) || Here(RR_WATER_TEMPLE_MQ_LOBBY, []{return Logic::IsChild && CanUse(RG_STICKS) && HasExplosives;});}}),
                   LocationAccess(RC_WATER_TEMPLE_MQ_LONGSHOT_CHEST,               {[]{return IsAdult && CanUse(RG_HOOKSHOT);}}),
                   LocationAccess(RC_WATER_TEMPLE_MQ_GS_LIZALFOS_HALLWAY,          {[]{return CanUse(RG_DINS_FIRE);}}),
                   LocationAccess(RC_WATER_TEMPLE_MQ_GS_BEFORE_UPPER_WATER_SWITCH, {[]{return IsAdult && CanUse(RG_LONGSHOT);}}),

--- a/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_zoras_domain.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_zoras_domain.cpp
@@ -8,7 +8,7 @@ using namespace Settings;
 void AreaTable_Init_ZorasDomain() {
   areaTable[RR_ZR_FRONT] = Area("ZR Front", "Zora River", RHT_ZORAS_RIVER, DAY_NIGHT_CYCLE, {}, {
                   //Locations
-                  LocationAccess(RC_ZR_GS_TREE, {[]{return IsChild && CanChildAttack;}}),
+                  LocationAccess(RC_ZR_GS_TREE, {[]{return Logic::IsChild && CanChildAttack;}}),
                 }, {
                   //Exits
                   Entrance(RR_ZORAS_RIVER,  {[]{return IsAdult || CanBlastOrSmash;}}),
@@ -23,17 +23,17 @@ void AreaTable_Init_ZorasDomain() {
                   EventAccess(&BugShrub,         {[]{return BugShrub         || CanCutShrubs;}}),
                 }, {
                   //Locations
-                  LocationAccess(RC_ZR_MAGIC_BEAN_SALESMAN,               {[]{return IsChild;}}),
-                  LocationAccess(RC_ZR_FROGS_OCARINA_GAME,                {[]{return IsChild && CanPlay(ZeldasLullaby) && CanPlay(SariasSong) && CanPlay(SunsSong) && CanPlay(EponasSong) && CanPlay(SongOfTime) && CanPlay(SongOfStorms);}}),
-                  LocationAccess(RC_ZR_FROGS_IN_THE_RAIN,                 {[]{return IsChild && CanPlay(SongOfStorms);}}),
-                  LocationAccess(RC_ZR_FROGS_ZELDAS_LULLABY,              {[]{return IsChild && CanPlay(ZeldasLullaby);}}),
-                  LocationAccess(RC_ZR_FROGS_EPONAS_SONG,                 {[]{return IsChild && CanPlay(EponasSong);}}),
-                  LocationAccess(RC_ZR_FROGS_SARIAS_SONG,                 {[]{return IsChild && CanPlay(SariasSong);}}),
-                  LocationAccess(RC_ZR_FROGS_SUNS_SONG,                   {[]{return IsChild && CanPlay(SunsSong);}}),
-                  LocationAccess(RC_ZR_FROGS_SONG_OF_TIME,                {[]{return IsChild && CanPlay(SongOfTime);}}),
-                  LocationAccess(RC_ZR_NEAR_OPEN_GROTTO_FREESTANDING_POH, {[]{return IsChild || CanUse(RG_HOVER_BOOTS) || (IsAdult && LogicZoraRiverLower);}}),
-                  LocationAccess(RC_ZR_NEAR_DOMAIN_FREESTANDING_POH,      {[]{return IsChild || CanUse(RG_HOVER_BOOTS) || (IsAdult && LogicZoraRiverUpper);}}),
-                  LocationAccess(RC_ZR_GS_LADDER,                         {[]{return IsChild && AtNight && CanChildAttack && CanGetNightTimeGS;}}),
+                  LocationAccess(RC_ZR_MAGIC_BEAN_SALESMAN,               {[]{return Logic::IsChild;}}),
+                  LocationAccess(RC_ZR_FROGS_OCARINA_GAME,                {[]{return Logic::IsChild && CanPlay(ZeldasLullaby) && CanPlay(SariasSong) && CanPlay(SunsSong) && CanPlay(EponasSong) && CanPlay(SongOfTime) && CanPlay(SongOfStorms);}}),
+                  LocationAccess(RC_ZR_FROGS_IN_THE_RAIN,                 {[]{return Logic::IsChild && CanPlay(SongOfStorms);}}),
+                  LocationAccess(RC_ZR_FROGS_ZELDAS_LULLABY,              {[]{return Logic::IsChild && CanPlay(ZeldasLullaby);}}),
+                  LocationAccess(RC_ZR_FROGS_EPONAS_SONG,                 {[]{return Logic::IsChild && CanPlay(EponasSong);}}),
+                  LocationAccess(RC_ZR_FROGS_SARIAS_SONG,                 {[]{return Logic::IsChild && CanPlay(SariasSong);}}),
+                  LocationAccess(RC_ZR_FROGS_SUNS_SONG,                   {[]{return Logic::IsChild && CanPlay(SunsSong);}}),
+                  LocationAccess(RC_ZR_FROGS_SONG_OF_TIME,                {[]{return Logic::IsChild && CanPlay(SongOfTime);}}),
+                  LocationAccess(RC_ZR_NEAR_OPEN_GROTTO_FREESTANDING_POH, {[]{return Logic::IsChild || CanUse(RG_HOVER_BOOTS) || (IsAdult && LogicZoraRiverLower);}}),
+                  LocationAccess(RC_ZR_NEAR_DOMAIN_FREESTANDING_POH,      {[]{return Logic::IsChild || CanUse(RG_HOVER_BOOTS) || (IsAdult && LogicZoraRiverUpper);}}),
+                  LocationAccess(RC_ZR_GS_LADDER,                         {[]{return Logic::IsChild && AtNight && CanChildAttack && CanGetNightTimeGS;}}),
                   LocationAccess(RC_ZR_GS_NEAR_RAISED_GROTTOS,            {[]{return IsAdult && HookshotOrBoomerang && AtNight && CanGetNightTimeGS;}}),
                   LocationAccess(RC_ZR_GS_ABOVE_BRIDGE,                   {[]{return IsAdult && CanUse(RG_HOOKSHOT) && AtNight && CanGetNightTimeGS;}}),
                   LocationAccess(RC_ZR_NEAR_GROTTOS_GOSSIP_STONE,         {[]{return true;}}),
@@ -45,7 +45,7 @@ void AreaTable_Init_ZorasDomain() {
                   Entrance(RR_ZR_FAIRY_GROTTO,     {[]{return Here(RR_ZORAS_RIVER, []{return CanBlastOrSmash;});}}),
                   Entrance(RR_THE_LOST_WOODS,      {[]{return CanDive || CanUse(RG_IRON_BOOTS);}}),
                   Entrance(RR_ZR_STORMS_GROTTO,    {[]{return CanOpenStormGrotto;}}),
-                  Entrance(RR_ZR_BEHIND_WATERFALL, {[]{return CanPlay(ZeldasLullaby) || (IsChild && LogicZoraWithCucco) || (IsAdult && CanUse(RG_HOVER_BOOTS) && LogicZoraWithHovers);}}),
+                  Entrance(RR_ZR_BEHIND_WATERFALL, {[]{return CanPlay(ZeldasLullaby) || (Logic::IsChild && LogicZoraWithCucco) || (IsAdult && CanUse(RG_HOVER_BOOTS) && LogicZoraWithHovers);}}),
   });
 
   areaTable[RR_ZR_BEHIND_WATERFALL] = Area("ZR Behind Waterfall", "Zora River", RHT_NONE, DAY_NIGHT_CYCLE, {}, {}, {
@@ -85,14 +85,14 @@ void AreaTable_Init_ZorasDomain() {
                   EventAccess(&EyeballFrogAccess, {[]{return EyeballFrogAccess || (IsAdult && KingZoraThawed && (Eyedrops || EyeballFrog || Prescription || PrescriptionAccess));}}),
                   EventAccess(&GossipStoneFairy,  {[]{return GossipStoneFairy  || CanSummonGossipFairyWithoutSuns;}}),
                   EventAccess(&NutPot,            {[]{return true;}}),
-                  EventAccess(&StickPot,          {[]{return StickPot          || IsChild;}}),
-                  EventAccess(&FishGroup,         {[]{return FishGroup         || IsChild;}}),
+                  EventAccess(&StickPot,          {[]{return StickPot          || Logic::IsChild;}}),
+                  EventAccess(&FishGroup,         {[]{return FishGroup         || Logic::IsChild;}}),
                   EventAccess(&KingZoraThawed,    {[]{return KingZoraThawed    || (IsAdult     && BlueFire);}}),
-                  EventAccess(&DeliverLetter,     {[]{return DeliverLetter     || (RutosLetter && IsChild && ZorasFountain.IsNot(ZORASFOUNTAIN_OPEN));}}),
+                  EventAccess(&DeliverLetter,     {[]{return DeliverLetter     || (RutosLetter && Logic::IsChild && ZorasFountain.IsNot(ZORASFOUNTAIN_OPEN));}}),
                 }, {
                   //Locations
-                  LocationAccess(RC_ZD_DIVING_MINIGAME,     {[]{return IsChild;}}),
-                  LocationAccess(RC_ZD_CHEST,               {[]{return IsChild && CanUse(RG_STICKS);}}),
+                  LocationAccess(RC_ZD_DIVING_MINIGAME,     {[]{return Logic::IsChild;}}),
+                  LocationAccess(RC_ZD_CHEST,               {[]{return Logic::IsChild && CanUse(RG_STICKS);}}),
                   LocationAccess(RC_ZD_KING_ZORA_THAWED,    {[]{return KingZoraThawed;}}),
                   LocationAccess(RC_ZD_TRADE_PRESCRIPTION,  {[]{return KingZoraThawed && Prescription;}}),
                   LocationAccess(RC_ZD_GS_FROZEN_WATERFALL, {[]{return IsAdult && AtNight && (HookshotOrBoomerang || CanUse(RG_FAIRY_SLINGSHOT) || Bow || MagicMeter || LogicDomainGS) && CanGetNightTimeGS;}}),
@@ -100,9 +100,9 @@ void AreaTable_Init_ZorasDomain() {
                 }, {
                   //Exits
                   Entrance(RR_ZR_BEHIND_WATERFALL, {[]{return true;}}),
-                  Entrance(RR_LAKE_HYLIA,          {[]{return IsChild && (CanDive || CanUse(RG_IRON_BOOTS));}}),
+                  Entrance(RR_LAKE_HYLIA,          {[]{return Logic::IsChild && (CanDive || CanUse(RG_IRON_BOOTS));}}),
                   Entrance(RR_ZD_BEHIND_KING_ZORA, {[]{return DeliverLetter || ZorasFountain.Is(ZORASFOUNTAIN_OPEN) || (ZorasFountain.Is(ZORASFOUNTAIN_ADULT) && IsAdult) || (LogicKingZoraSkip && IsAdult);}}),
-                  Entrance(RR_ZD_SHOP,             {[]{return IsChild || BlueFire;}}),
+                  Entrance(RR_ZD_SHOP,             {[]{return Logic::IsChild || BlueFire;}}),
                   Entrance(RR_ZD_STORMS_GROTTO,    {[]{return CanOpenStormGrotto;}}),
   });
 
@@ -143,15 +143,15 @@ void AreaTable_Init_ZorasDomain() {
                   //Locations
                   LocationAccess(RC_ZF_ICEBERC_FREESTANDING_POH, {[]{return IsAdult;}}),
                   LocationAccess(RC_ZF_BOTTOM_FREESTANDING_POH,  {[]{return IsAdult && IronBoots && WaterTimer >= 24;}}),
-                  LocationAccess(RC_ZF_GS_TREE,                  {[]{return IsChild;}}),
-                  LocationAccess(RC_ZF_GS_ABOVE_THE_LOG,         {[]{return IsChild && HookshotOrBoomerang && AtNight && CanGetNightTimeGS;}}),
+                  LocationAccess(RC_ZF_GS_TREE,                  {[]{return Logic::IsChild;}}),
+                  LocationAccess(RC_ZF_GS_ABOVE_THE_LOG,         {[]{return Logic::IsChild && HookshotOrBoomerang && AtNight && CanGetNightTimeGS;}}),
                   LocationAccess(RC_ZF_GS_HIDDEN_CAVE,           {[]{return CanUse(RG_SILVER_GAUNTLETS) && CanBlastOrSmash && HookshotOrBoomerang && IsAdult && AtNight && CanGetNightTimeGS;}}),
                   LocationAccess(RC_FAIRY_GOSSIP_STONE,       {[]{return true;}}),
                   LocationAccess(RC_JABU_GOSSIP_STONE,        {[]{return true;}}),
                 }, {
                   //Exits
                   Entrance(RR_ZD_BEHIND_KING_ZORA,       {[]{return true;}}),
-                  Entrance(RR_JABU_JABUS_BELLY_ENTRYWAY, {[]{return (IsChild && Fish);}}),
+                  Entrance(RR_JABU_JABUS_BELLY_ENTRYWAY, {[]{return (Logic::IsChild && Fish);}}),
                   Entrance(RR_ICE_CAVERN_ENTRYWAY,       {[]{return IsAdult;}}),
                   Entrance(RR_ZF_GREAT_FAIRY_FOUNTAIN,   {[]{return HasExplosives;}}),
   });

--- a/soh/soh/Enhancements/randomizer/3drando/logic.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/logic.cpp
@@ -445,11 +445,11 @@ namespace Logic {
       case RG_BIGGORON_SWORD:    return IsAdult || BiggoronSwordAsChild;
 
       // Child items
-      case RG_FAIRY_SLINGSHOT:         return IsChild || SlingshotAsAdult;
-      case RG_BOOMERANG:         return IsChild || BoomerangAsAdult;
-      case RG_KOKIRI_SWORD:      return IsChild || KokiriSwordAsAdult;
-      case RG_STICKS:            return IsChild || StickAsAdult;
-      case RG_DEKU_SHIELD:       return IsChild || DekuShieldAsAdult;
+      case RG_FAIRY_SLINGSHOT:         return Logic::IsChild || SlingshotAsAdult;
+      case RG_BOOMERANG:         return Logic::IsChild || BoomerangAsAdult;
+      case RG_KOKIRI_SWORD:      return Logic::IsChild || KokiriSwordAsAdult;
+      case RG_STICKS:            return Logic::IsChild || StickAsAdult;
+      case RG_DEKU_SHIELD:       return Logic::IsChild || DekuShieldAsAdult;
 
       // Magic items
       default: return MagicMeter && (IsMagicItem(itemName) || (IsMagicArrow(itemName) && CanUse(RG_FAIRY_BOW)));
@@ -483,9 +483,9 @@ namespace Logic {
   bool CanDoGlitch(GlitchType glitch) {
     switch(glitch) {
       case GlitchType::EquipSwapDins:
-        return ((IsAdult && HasItem(RG_DINS_FIRE)) || (IsChild && (HasItem(RG_STICKS) || HasItem(RG_DINS_FIRE)))) && GlitchEquipSwapDins;
+        return ((IsAdult && HasItem(RG_DINS_FIRE)) || (Logic::IsChild && (HasItem(RG_STICKS) || HasItem(RG_DINS_FIRE)))) && GlitchEquipSwapDins;
       case GlitchType::EquipSwap: // todo: add bunny hood to adult item equippable list and child trade item to child item equippable list
-        return ((IsAdult && (HasItem(RG_DINS_FIRE) || HasItem(RG_FARORES_WIND) || HasItem(RG_NAYRUS_LOVE))) || (IsChild && (HasItem(RG_STICKS) || HasItem(RG_FAIRY_SLINGSHOT) || HasItem(RG_BOOMERANG) || HasBottle || Nuts || Ocarina || HasItem(RG_LENS_OF_TRUTH) || HasExplosives || (MagicBean || MagicBeanPack) || HasItem(RG_DINS_FIRE) || HasItem(RG_FARORES_WIND) || HasItem(RG_NAYRUS_LOVE)))) && GlitchEquipSwap;
+        return ((IsAdult && (HasItem(RG_DINS_FIRE) || HasItem(RG_FARORES_WIND) || HasItem(RG_NAYRUS_LOVE))) || (Logic::IsChild && (HasItem(RG_STICKS) || HasItem(RG_FAIRY_SLINGSHOT) || HasItem(RG_BOOMERANG) || HasBottle || Nuts || Ocarina || HasItem(RG_LENS_OF_TRUTH) || HasExplosives || (MagicBean || MagicBeanPack) || HasItem(RG_DINS_FIRE) || HasItem(RG_FARORES_WIND) || HasItem(RG_NAYRUS_LOVE)))) && GlitchEquipSwap;
     }
 
     //Shouldn't be reached
@@ -553,17 +553,17 @@ namespace Logic {
     Cojiro       = Cojiro       || (!ShuffleAdultTradeQuest && OddMushroom);
     PocketEgg    = PocketEgg    || (!ShuffleAdultTradeQuest && Cojiro);
 
-    // IsChild = Age == AGE_CHILD;
+    // Logic::IsChild = Age == AGE_CHILD;
     // IsAdult = Age == AGE_ADULT;
 
     CanBlastOrSmash = HasExplosives || CanUse(RG_MEGATON_HAMMER);
-    CanChildAttack  = IsChild && (Slingshot || Boomerang || Sticks || KokiriSword || HasExplosives || CanUse(RG_DINS_FIRE) || CanUse(RG_MASTER_SWORD) || CanUse(RG_MEGATON_HAMMER) || CanUse(RG_BIGGORON_SWORD));
-    CanChildDamage  = IsChild && (Slingshot ||              Sticks || KokiriSword || HasExplosives || CanUse(RG_DINS_FIRE) || CanUse(RG_MASTER_SWORD) || CanUse(RG_MEGATON_HAMMER) || CanUse(RG_BIGGORON_SWORD));
+    CanChildAttack  = Logic::IsChild && (Slingshot || Boomerang || Sticks || KokiriSword || HasExplosives || CanUse(RG_DINS_FIRE) || CanUse(RG_MASTER_SWORD) || CanUse(RG_MEGATON_HAMMER) || CanUse(RG_BIGGORON_SWORD));
+    CanChildDamage  = Logic::IsChild && (Slingshot ||              Sticks || KokiriSword || HasExplosives || CanUse(RG_DINS_FIRE) || CanUse(RG_MASTER_SWORD) || CanUse(RG_MEGATON_HAMMER) || CanUse(RG_BIGGORON_SWORD));
     CanStunDeku     = IsAdult || CanChildAttack || Nuts || HasShield;
     CanCutShrubs    = IsAdult /*|| Sticks*/ || KokiriSword || Boomerang || HasExplosives || CanUse(RG_MASTER_SWORD) || CanUse(RG_MEGATON_HAMMER) || CanUse(RG_BIGGORON_SWORD);
     CanDive         = ProgressiveScale >= 1;
     CanLeaveForest  = OpenForest.IsNot(OPENFOREST_CLOSED) || IsAdult || DekuTreeClear || ShuffleInteriorEntrances || ShuffleOverworldEntrances;
-    CanPlantBugs    = IsChild && Bugs;
+    CanPlantBugs    = Logic::IsChild && Bugs;
     CanRideEpona    = IsAdult && Epona && CanPlay(EponasSong);
     CanSummonGossipFairy            = Ocarina && (ZeldasLullaby || EponasSong || SongOfTime || SunsSong);
     CanSummonGossipFairyWithoutSuns = Ocarina && (ZeldasLullaby || EponasSong || SongOfTime);
@@ -575,7 +575,7 @@ namespace Logic {
     CanSurviveDamage    = !NeedNayrusLove || CanUse(RG_NAYRUS_LOVE);
     CanTakeDamage       = Fairy || CanSurviveDamage;
     CanTakeDamageTwice  = (Fairy && NumBottles >= 2) || ((EffectiveHealth == 2) && (CanUse(RG_NAYRUS_LOVE) || Fairy)) || (EffectiveHealth > 2);
-    //CanPlantBean        = IsChild && (MagicBean || MagicBeanPack);
+    //CanPlantBean        = Logic::IsChild && (MagicBean || MagicBeanPack);
     CanOpenBombGrotto   = CanBlastOrSmash       && (ShardOfAgony || LogicGrottosWithoutAgony);
     CanOpenStormGrotto  = CanPlay(SongOfStorms) && (ShardOfAgony || LogicGrottosWithoutAgony);
     HookshotOrBoomerang = CanUse(RG_HOOKSHOT) || CanUse(RG_BOOMERANG);
@@ -593,7 +593,7 @@ namespace Logic {
 
     HasShield          = CanUse(RG_HYLIAN_SHIELD) || CanUse(RG_DEKU_SHIELD); //Mirror shield can't reflect attacks
     CanShield          = CanUse(RG_MIRROR_SHIELD) || HasShield;
-    ChildShield        = IsChild && CanUse(RG_DEKU_SHIELD); //hylian shield is not helpful for child
+    ChildShield        = Logic::IsChild && CanUse(RG_DEKU_SHIELD); //hylian shield is not helpful for child
     AdultReflectShield = IsAdult && CanUse(RG_HYLIAN_SHIELD); //Mirror shield can't reflect attacks
     AdultShield        = IsAdult && (CanUse(RG_HYLIAN_SHIELD) || CanUse(RG_MIRROR_SHIELD));
     CanShieldFlick     = ChildShield || AdultShield;
@@ -959,7 +959,7 @@ namespace Logic {
      HasBombchus      = false;
      HasExplosives    = false;
      HasBoots         = false;
-     IsChild          = false;
+     Logic::IsChild          = false;
      IsAdult          = false;
      IsGlitched       = Settings::Logic.Is(LOGIC_GLITCHED);
      CanBlastOrSmash  = false;

--- a/soh/soh/Enhancements/randomizer/3drando/menu.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/menu.cpp
@@ -49,12 +49,10 @@ std::string GenerateRandomizer(std::unordered_map<RandomizerSettingKey, uint8_t>
     int ret = Playthrough::Playthrough_Init(Settings::seed, cvarSettings, excludedLocations, enabledTricks);
     if (ret < 0) {
         if (ret == -1) { // Failed to generate after 5 tries
-            printf("\n\nFailed to generate after 5 tries.\nPress B to go back to the menu.\nA different seed might be "
-                   "successful.");
-            SPDLOG_DEBUG("\nRANDOMIZATION FAILED COMPLETELY. PLZ FIX\n");
+            SPDLOG_ERROR("Failed to generate after 5 tries.");
             return "";
         } else {
-            printf("\n\nError %d with fill.\nPress Select to exit or B to go back to the menu.\n", ret);
+            SPDLOG_ERROR("Error {} with fill.", ret);
             return "";
         }
     }

--- a/soh/soh/Enhancements/randomizer/3drando/playthrough.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/playthrough.cpp
@@ -7,6 +7,7 @@
 #include "logic.hpp"
 #include "random.hpp"
 #include "spoiler_log.hpp"
+#include "spdlog/spdlog.h"
 #include "soh/Enhancements/randomizer/randomizerTypes.h"
 
 namespace Playthrough {
@@ -60,18 +61,18 @@ int Playthrough_Init(uint32_t seed, std::unordered_map<RandomizerSettingKey, uin
 
     if (Settings::GenerateSpoilerLog) {
         // write logs
-        printf("\x1b[11;10HWriting Spoiler Log...");
+        SPDLOG_INFO("Writing Spoiler Log...");
         if (SpoilerLog_Write(cvarSettings[RSK_LANGUAGE])) {
-            printf("Done");
+            SPDLOG_INFO("Writing Spoiler Log Done");
         } else {
-            printf("Failed");
+            SPDLOG_INFO("Writing Spoiler Log Failed");
         }
 #ifdef ENABLE_DEBUG
-        printf("\x1b[11;10HWriting Placement Log...");
+        SPDLOG_INFO("Writing Placement Log...");
         if (PlacementLog_Write()) {
-            printf("Done\n");
+            SPDLOG_INFO("Writing Placement Log Done");
         } else {
-            printf("Failed\n");
+            SPDLOG_INFO("Writing Placement Log Failed");
         }
 #endif
     }
@@ -85,7 +86,7 @@ int Playthrough_Init(uint32_t seed, std::unordered_map<RandomizerSettingKey, uin
 
 // used for generating a lot of seeds at once
 int Playthrough_Repeat(std::unordered_map<RandomizerSettingKey, uint8_t> cvarSettings, std::set<RandomizerCheck> excludedLocations, std::set<RandomizerTrick> enabledTricks, int count /*= 1*/) {
-    printf("\x1b[0;0HGENERATING %d SEEDS", count);
+    SPDLOG_INFO("GENERATING {} SEEDS", count);
     uint32_t repeatedSeed = 0;
     for (int i = 0; i < count; i++) {
         Settings::seedString = std::to_string(rand() % 0xFFFFFFFF);
@@ -94,7 +95,7 @@ int Playthrough_Repeat(std::unordered_map<RandomizerSettingKey, uint8_t> cvarSet
         //CitraPrint("testing seed: " + std::to_string(Settings::seed));
         ClearProgress();
         Playthrough_Init(Settings::seed, cvarSettings, excludedLocations, enabledTricks);
-        printf("\x1b[15;15HSeeds Generated: %d\n", i + 1);
+        SPDLOG_INFO("Seeds Generated: {}", i + 1);
     }
 
     return 1;

--- a/soh/soh/Enhancements/randomizer/3drando/settings.hpp
+++ b/soh/soh/Enhancements/randomizer/3drando/settings.hpp
@@ -9,6 +9,7 @@
 #include <variant>
 #include <vector>
 
+#include "spdlog/spdlog.h"
 #include "category.hpp"
 #include "menu.hpp"
 #include "pool_functions.hpp"
@@ -644,7 +645,7 @@ public:
     void SetSelectedIndex(size_t idx) {
       selectedOption = idx;
       if (selectedOption >= options.size()) {
-        printf("\x1b[30;0HERROR: Incompatible selection for %s\n", name.c_str());
+        SPDLOG_ERROR("ERROR: Incompatible selection for {}", name);
         selectedOption = 0;
       }
 

--- a/soh/soh/Enhancements/randomizer/3drando/spoiler_log.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/spoiler_log.cpp
@@ -254,7 +254,7 @@ void WriteIngameSpoilerLog() {
             }
         }
         if (spoilerOutOfSpace || playthroughItemNotFound) {
-            printf("Error! ");
+            SPDLOG_ERROR("In-game spoiler log is out of space, playthrough data will not be written");
         }
     }
 }


### PR DESCRIPTION
I'd like to completely overhaul all of the logging here for v3, but this is a step to just remove the printf's that kept messing with cursor position (and making the rest of the logs look odd)

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1016939800.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1016939803.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1016939807.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1016939811.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1016939817.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1016939821.zip)
<!--- section:artifacts:end -->