### PR TITLE
[Bugfix] Fix audio editor drowpdown list inclusions and shuffle exclusions

### DIFF
--- a/soh/soh/Enhancements/audio/AudioCollection.cpp
+++ b/soh/soh/Enhancements/audio/AudioCollection.cpp
@@ -353,7 +353,7 @@ void AudioCollection::AddToCollection(char* otrPath, uint16_t seqNum) {
     SequenceInfo info = {seqNum,
                          sequenceName,
                          StringHelper::Replace(StringHelper::Replace(StringHelper::Replace(sequenceName, " ", "_"), "~", "-"),".", ""),
-                         type, false, false};
+                         type, false, true};
     sequenceMap.emplace(seqNum, info);
 }
 

--- a/soh/soh/Enhancements/audio/AudioEditor.cpp
+++ b/soh/soh/Enhancements/audio/AudioEditor.cpp
@@ -82,7 +82,7 @@ void RandomizeGroup(SeqType type) {
     // use a while loop to add duplicates if we don't have enough included sequences
     while (values.size() < AuthenticCountBySequenceType(type)) {
         for (const auto& seqData : AudioCollection::Instance->GetIncludedSequences()) {
-            if (seqData->category & type) {
+            if (seqData->category & type && seqData->canBeUsedAsReplacement) {
                 values.push_back(seqData->sequenceId);
             }
         }


### PR DESCRIPTION
Fixes custom sequences not being listed in Audio Manager dropdowns due to all sequences being added with `canBeUsedAsReplacement = false`, and adds a check to the shuffle function to make sure sequences with `canBeUsedAsReplacement = false` can't be shuffled in.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1000395444.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1000395445.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1000395446.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1000395447.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1000395448.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1000395449.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1000395450.zip)
<!--- section:artifacts:end -->