### PR TITLE
Fix: Quest ID not assigning in all situations

### DIFF
--- a/soh/include/z64save.h
+++ b/soh/include/z64save.h
@@ -279,14 +279,13 @@ typedef struct {
     /* 0x1420 */ s16 worldMapArea;
     /* 0x1422 */ s16 sunsSongState; // controls the effects of suns song
     /* 0x1424 */ s16 healthAccumulator;
-    /* 0x1426 */ u16 pendingSale;
-    /* 0x1428 */ u16 pendingSaleMod;
     // #region SOH [General]
     // Upstream TODO: Move these to their own struct or name to more obviously specific to SoH
+    /*        */ u16 pendingSale;
+    /*        */ u16 pendingSaleMod;
     /*        */ uint8_t questId;
     /*        */ uint32_t isBossRushPaused;
     /*        */ uint8_t bossRushOptions[BOSSRUSH_OPTIONS_AMOUNT];
-    /*        */ u8 mqDungeonCount;
     /*        */ u8 pendingIceTrapCount;
     /*        */ SohStats sohStats;
     /*        */ FaroresWindData backupFW;
@@ -322,6 +321,7 @@ typedef struct {
     /*        */ u32 finalSeed;
     /*        */ u8 seedIcons[5];
     /*        */ u16 randomizerInf[10];
+    /*        */ u8 mqDungeonCount;
     /*        */ u16 adultTradeItems;
     /*        */ u8 triforcePiecesCollected;
     // #endregion

--- a/soh/soh/Enhancements/boss-rush/BossRush.cpp
+++ b/soh/soh/Enhancements/boss-rush/BossRush.cpp
@@ -291,6 +291,7 @@ void BossRush_InitSave() {
         gSaveContext.playerName[i] = brPlayerName[i];
     }
 
+    gSaveContext.questId = QUEST_BOSSRUSH;
     gSaveContext.isBossRushPaused = 1;
     gSaveContext.entranceIndex = 107;
     gSaveContext.cutsceneIndex = 0x8000;

--- a/soh/soh/SaveManager.cpp
+++ b/soh/soh/SaveManager.cpp
@@ -603,13 +603,11 @@ void SaveManager::InitFileNormal() {
     gSaveContext.backupFW = gSaveContext.fw;
     gSaveContext.pendingSale = ITEM_NONE;
     gSaveContext.pendingSaleMod = MOD_NONE;
+    gSaveContext.isBossRushPaused = 0;
+    gSaveContext.pendingIceTrapCount = 0;
 
-    // Boss Rush is set ahead of time in z_file_choose, otherwise init the save with the normal quest
-    if (IS_BOSS_RUSH) {
-        BossRush_InitSave();
-    } else {
-        gSaveContext.questId = QUEST_NORMAL;
-    }
+    // Init with normal quest unless only an MQ rom is provided
+    gSaveContext.questId = OTRGlobals::Instance->HasOriginal() ? QUEST_NORMAL : QUEST_MASTER;
 
     //RANDOTODO (ADD ITEMLOCATIONS TO GSAVECONTEXT)
 }

--- a/soh/src/code/z_play.c
+++ b/soh/src/code/z_play.c
@@ -1202,7 +1202,7 @@ void Play_Update(PlayState* play) {
                 play->gameplayFrames++;
                 // Gameplay stat tracking
                 if (!gSaveContext.sohStats.gameComplete &&
-                    (!IS_BOSS_RUSH || (IS_BOSS_RUSH && !gSaveContext.isBossRushPaused))) {
+                    (!IS_BOSS_RUSH || !gSaveContext.isBossRushPaused)) {
                       gSaveContext.sohStats.playTimer++;
                       gSaveContext.sohStats.sceneTimer++;
                       gSaveContext.sohStats.roomTimer++;

--- a/soh/src/code/z_sram.c
+++ b/soh/src/code/z_sram.c
@@ -10,6 +10,8 @@
 
 void Save_LoadFile(void);
 
+void BossRush_InitSave(void);
+
 /**
  *  Initialize new save.
  *  This save has an empty inventory with 3 hearts and single magic.
@@ -33,6 +35,7 @@ void Sram_InitDebugSave(void) {
 
 void Sram_InitBossRushSave(void) {
     Save_InitFile(false);
+    BossRush_InitSave();
 }
 
 /**
@@ -222,11 +225,15 @@ void Sram_InitSave(FileChooseContext* fileChooseCtx) {
 
     gSaveContext.n64ddFlag = fileChooseCtx->n64ddFlag;
 
-    if (fileChooseCtx->questType[fileChooseCtx->buttonIndex] == QUEST_RANDOMIZER &&
+    u8 currentQuest = fileChooseCtx->questType[fileChooseCtx->buttonIndex];
+
+    if (currentQuest == QUEST_RANDOMIZER &&
         strnlen(CVarGetString("gSpoilerLog", ""), 1) != 0) {
         gSaveContext.questId = QUEST_RANDOMIZER;
 
         Randomizer_InitSaveFile();
+    } else if (currentQuest == QUEST_MASTER) {
+        gSaveContext.questId = QUEST_MASTER;
     }
 
     Save_SaveFile();

--- a/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -1293,8 +1293,6 @@ void FileChoose_UpdateQuestMenu(GameState* thisx) {
     if (CHECK_BTN_ALL(input->press.button, BTN_A)) {
         gSaveContext.questId = this->questType[this->buttonIndex];
 
-        gSaveContext.isBossRushPaused = false;
-
         if (this->questType[this->buttonIndex] == QUEST_BOSSRUSH) {
             Audio_PlaySoundGeneral(NA_SE_SY_FSEL_DECIDE_L, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
             this->prevConfigMode = this->configMode;
@@ -2819,10 +2817,6 @@ void FileChoose_ConfirmFile(GameState* thisx) {
         if (this->confirmButtonIndex == FS_BTN_CONFIRM_YES) {
             func_800AA000(300.0f, 180, 20, 100);
             Audio_PlaySoundGeneral(NA_SE_SY_FSEL_DECIDE_L, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
-            // Reset Boss Rush because it's only ever saved in memory.
-            if (IS_BOSS_RUSH) {
-                gSaveContext.questId = QUEST_NORMAL;
-            }
             this->selectMode = SM_FADE_OUT;
             func_800F6964(0xF);
         } else {

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
@@ -4307,9 +4307,6 @@ void KaleidoScope_Update(PlayState* play)
                         osSyncPrintf(VT_RST);
                     } else {
                         play->state.running = 0;
-                        if (IS_BOSS_RUSH) {
-                            gSaveContext.questId = QUEST_NORMAL;
-                        }
                         SET_NEXT_GAMESTATE(&play->state, Opening_Init, OpeningContext);
                         GameInteractor_ExecuteOnExitGame(gSaveContext.fileNum);
                     }


### PR DESCRIPTION
This adjusts how the quest ID is assigned so that it is always applied after init-ing a save file. Some of the boss rush intermediate clearing values is now placed in the file init (where all struct "zeroing" should be), and the boss rush save file init is moved out of the savemanager so that we can explicitly init it when we want, rather than using the quest ID in a non-standard way to achieve that.

The default quest ID that is assigned during init file is either NORMAL or MASTER depending on if the vanilla game is loaded.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1014260389.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1014260390.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1014260391.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1014260392.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1014260393.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1014260394.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1014260395.zip)
<!--- section:artifacts:end -->