### PR TITLE
Fix: Entrance Rando validation missing edge cases

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/entrance.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/entrance.cpp
@@ -1232,6 +1232,11 @@ int ShuffleAllEntrances() {
     }
   }
 
+  // Validate the world one last time to ensure all special conditions are still valid
+  if (!ValidateWorld(nullptr)) {
+    return ENTRANCE_SHUFFLE_FAILURE;
+  }
+
   return ENTRANCE_SHUFFLE_SUCCESS;
 }
 


### PR DESCRIPTION
In Entrance Rando, validation is performed on special entrance conditions like Temple of Time, when some entrances are placed. But later in the shuffling process, more entrances are placed without the same validation performed. This could lead to a situation where Temple of Time is no longer accessible after shuffled spawns.

To address this, we validate the world one more time after all entrances are done being shuffled. This matches roughly what N64 does, and pulls in a recent fix from 3ds rando.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1019812118.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1019812119.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1019812120.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1019812122.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1019812123.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1019812124.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1019812127.zip)
<!--- section:artifacts:end -->