### PR TITLE
[Feature] "Select Spoiler" Button

### DIFF
--- a/soh/CMakeLists.txt
+++ b/soh/CMakeLists.txt
@@ -205,6 +205,12 @@ else()
 # }}}
 endif()
 
+# soh/ImGuiFileBrowser {{{
+file(GLOB_RECURSE soh__ImGuiFileBrowser RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "soh/ImGuiFileBrowser/*.cpp" "soh/ImGuiFileBrowser/*.h")
+
+source_group("soh\\ImGuiFileBrowser" REGULAR_EXPRESSION "soh/ImGuiFileBrowser/*")
+# }}}
+
 # soh/resource {{{
 file(GLOB_RECURSE soh__Resource RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "soh/resource/*.cpp" "soh/resource/*.h")
 
@@ -256,6 +262,7 @@ set(ALL_FILES
     ${soh__config}
     ${soh__Enhancements}
     ${soh__Extractor}
+	${soh__ImGuiFileBrowser}
     ${soh__Resource}
     ${src__}
 )

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -3181,7 +3181,7 @@ void RandomizerSettingsWindow::DrawElement() {
     if (ImGui::Button("Generate Randomizer")) {
         GenerateRandomizer(CVarGetInteger("gRandoManualSeedEntry", 0) ? seedString : "");
     }
-
+#ifndef __WIIU__
     UIWidgets::Spacer(0);
     if (ImGui::Button("Select Spoiler")) {
         ImGui::OpenPopup("Open File");
@@ -3196,6 +3196,7 @@ void RandomizerSettingsWindow::DrawElement() {
         CVarLoad();
     }
     ImGui::SameLine();
+#endif
     std::string spoilerfilepath = CVarGetString("gSpoilerLog", "");
     ImGui::Text("Spoiler File: %s", spoilerfilepath.c_str());
 
@@ -6274,5 +6275,7 @@ void RandomizerSettingsWindow::InitElement() {
     Randomizer::CreateCustomMessages();
     seedString = (char*)calloc(MAX_SEED_STRING_SIZE, sizeof(char));
     InitRandoItemTable();
+#ifndef __WIIU__
     spoiler_dialog.setCurrentPath(CVarGetString("gSpoilerLastPath", "./"));
+#endif
 }

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -3190,6 +3190,7 @@ void RandomizerSettingsWindow::DrawElement() {
         auto path = spoiler_dialog.selected_path.c_str();
         CVarSetInteger("gNewFileDropped", 1);
         CVarSetString("gDroppedFile", path);
+        CVarSetString("gSpoilerLastPath", spoiler_dialog.selected_dir.c_str());
         CVarSetString("gSpoilerLog", path);
         CVarSave();
         CVarLoad();
@@ -6273,4 +6274,5 @@ void RandomizerSettingsWindow::InitElement() {
     Randomizer::CreateCustomMessages();
     seedString = (char*)calloc(MAX_SEED_STRING_SIZE, sizeof(char));
     InitRandoItemTable();
+    spoiler_dialog.setCurrentPath(CVarGetString("gSpoilerLastPath", "./"));
 }

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -6276,6 +6276,6 @@ void RandomizerSettingsWindow::InitElement() {
     seedString = (char*)calloc(MAX_SEED_STRING_SIZE, sizeof(char));
     InitRandoItemTable();
 #ifndef __WIIU__
-    spoiler_dialog.setCurrentPath(CVarGetString("gSpoilerLastPath", "./"));
+    spoiler_dialog.setCurrentPath(CVarGetString("gSpoilerLastPath", LUS::Context::GetAppDirectoryPath().c_str()));
 #endif
 }

--- a/soh/soh/Enhancements/randomizer/randomizer_settings_window.h
+++ b/soh/soh/Enhancements/randomizer/randomizer_settings_window.h
@@ -1,10 +1,14 @@
 #include <libultraship/libultraship.h>
+#ifndef __WIIU__
 #include "soh/ImGuiFileBrowser/ImGuiFileBrowser.h"
+#endif
 
 class RandomizerSettingsWindow : public LUS::GuiWindow {
   public:
     using GuiWindow::GuiWindow;
+#ifndef __WIIU__
     imgui_addons::ImGuiFileBrowser spoiler_dialog;
+#endif
 
     void InitElement() override;
     void DrawElement() override;

--- a/soh/soh/Enhancements/randomizer/randomizer_settings_window.h
+++ b/soh/soh/Enhancements/randomizer/randomizer_settings_window.h
@@ -1,8 +1,10 @@
 #include <libultraship/libultraship.h>
+#include "soh/ImGuiFileBrowser/ImGuiFileBrowser.h"
 
 class RandomizerSettingsWindow : public LUS::GuiWindow {
   public:
     using GuiWindow::GuiWindow;
+    imgui_addons::ImGuiFileBrowser spoiler_dialog;
 
     void InitElement() override;
     void DrawElement() override;

--- a/soh/soh/ImGuiFileBrowser/ImGuiFileBrowser.cpp
+++ b/soh/soh/ImGuiFileBrowser/ImGuiFileBrowser.cpp
@@ -1,0 +1,1262 @@
+#ifndef IMGUI_DEFINE_MATH_OPERATORS
+#define IMGUI_DEFINE_MATH_OPERATORS
+#endif
+
+#include "ImGuiFileBrowser.h"
+#include "imgui_internal.h"
+
+#include <iostream>
+#include <functional>
+#include <climits>
+#include <string.h>
+#include <sstream>
+#include <cwchar>
+#include <cctype>
+#include <algorithm>
+#include <cmath>
+
+#include <sys/stat.h>
+
+#if defined (WIN32) || defined (_WIN32) || defined (__WIN32)
+#define OSWIN
+#ifndef NOMINMAX
+    #define NOMINMAX
+#endif
+#include "dirent.h"
+#include <windows.h>
+#else
+#include <dirent.h>
+#endif // defined (WIN32) || defined (_WIN32)
+
+namespace imgui_addons
+{
+    static const char *ALL_VALID_FILES_EXT_TXT = "All valid files";
+
+    ImGuiFileBrowser::ImGuiFileBrowser()
+    {
+        filter_mode = FilterMode_Files | FilterMode_Dirs;
+
+        show_inputbar_combobox = false;
+        validate_file = false;
+        show_hidden = false;
+        is_dir = false;
+        filter_dirty = true;
+        is_appearing = true;
+        show_all_valid_files = false;
+
+        col_items_limit = 12;
+        selected_idx = -1;
+        selected_ext_idx = 0;
+        ext_box_width = -1.0f;
+        col_width = 280.0f;
+        min_size = ImVec2(500,300);
+
+        invfile_modal_id = "Invalid File!";
+        repfile_modal_id = "Replace File?";
+        selected_fn = "";
+        selected_path = "";
+        input_fn[0] = '\0';
+
+        #ifdef OSWIN
+        current_path = "./";
+        #else
+        initCurrentPath();
+        #endif
+    }
+
+    ImGuiFileBrowser::~ImGuiFileBrowser()
+    {
+
+    }
+
+    void ImGuiFileBrowser::clearFileList()
+    {
+        //Clear pointer references to subdirs and subfiles
+        filtered_dirs.clear();
+        filtered_files.clear();
+        inputcb_filter_files.clear();
+
+        //Now clear subdirs and subfiles
+        subdirs.clear();
+        subfiles.clear();
+        filter_dirty = true;
+        selected_idx = -1;
+    }
+
+    void ImGuiFileBrowser::closeDialog()
+    {
+        valid_types = "";
+        valid_exts.clear();
+        selected_ext_idx = 0;
+        selected_idx = -1;
+
+        input_fn[0] = '\0';  //Hide any text in Input bar for the next time save dialog is opened.
+        filter.Clear();     //Clear Filter for the next time open dialog is called.
+
+        show_inputbar_combobox = false;
+        validate_file = false;
+        show_hidden = false;
+        is_dir = false;
+        filter_dirty = true;
+        is_appearing = true;
+        show_all_valid_files = false;
+
+        //Clear pointer references to subdirs and subfiles
+        filtered_dirs.clear();
+        filtered_files.clear();
+        inputcb_filter_files.clear();
+
+        //Now clear subdirs and subfiles
+        subdirs.clear();
+        subfiles.clear();
+
+        ImGui::CloseCurrentPopup();
+    }
+
+    bool ImGuiFileBrowser::showFileDialog(const std::string& label, const DialogMode mode, const ImVec2& sz_xy, const std::string& valid_types)
+    {
+
+        dialog_mode = mode;
+        ImGuiIO& io = ImGui::GetIO();
+        max_size.x = io.DisplaySize.x;
+        max_size.y = io.DisplaySize.y;
+        ImGui::SetNextWindowSizeConstraints(min_size, max_size);
+        ImGui::SetNextWindowPos(io.DisplaySize * 0.5f, ImGuiCond_Appearing, ImVec2(0.5f,0.5f));
+        ImGui::SetNextWindowSize(ImVec2(std::max<float>(sz_xy.x, min_size.x), std::max<float>(sz_xy.y, min_size.y)), ImGuiCond_Appearing);
+
+        //Set Proper Filter Mode.
+        if(mode == DialogMode::SELECT)
+            filter_mode = FilterMode_Dirs;
+        else
+            filter_mode = FilterMode_Files | FilterMode_Dirs;
+
+        if (ImGui::BeginPopupModal(label.c_str(), nullptr, ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse))
+        {
+            bool show_error = false;
+
+            // If this is the initial run, read current directory and load data once.
+            if(is_appearing)
+            {
+                selected_fn.clear();
+                selected_path.clear();
+                if(mode != DialogMode::SELECT)
+                {
+                    this->valid_types = valid_types;
+                    setValidExtTypes(valid_types);
+                }
+
+                /* If current path is empty (can happen on Windows if user closes dialog while inside MyComputer.
+                 * Since this is a virtual folder, path would be empty) load the drives on Windows else initialize the current path on Unix.
+                 */
+                if(current_path.empty())
+                {
+                    #ifdef OSWIN
+                    show_error |= !(loadWindowsDrives());
+                    #else
+                    initCurrentPath();
+                    show_error |= !(readDIR(current_path));
+                    #endif // OSWIN
+                }
+                else
+                    show_error |= !(readDIR(current_path));
+                is_appearing = false;
+            }
+
+            show_error |= renderNavAndSearchBarRegion();
+            show_error |= renderFileListRegion();
+            show_error |= renderInputTextAndExtRegion();
+            show_error |= renderButtonsAndCheckboxRegion();
+
+            if(validate_file)
+            {
+                validate_file = false;
+                bool check = validateFile();
+
+                if(!check && dialog_mode == DialogMode::OPEN)
+                {
+                    ImGui::OpenPopup(invfile_modal_id.c_str());
+                    selected_fn.clear();
+                    selected_path.clear();
+                }
+
+                else if(!check && dialog_mode == DialogMode::SAVE)
+                    ImGui::OpenPopup(repfile_modal_id.c_str());
+
+                else if(!check && dialog_mode == DialogMode::SELECT)
+                {
+                    selected_fn.clear();
+                    selected_path.clear();
+                    show_error = true;
+                    error_title = "Invalid Directory!";
+                    error_msg = "Invalid Directory Selected. Please make sure the directory exists.";
+                }
+
+                //If selected file passes through validation check, set path to the file and close file dialog
+                if(check)
+                {
+                    selected_path = current_path + selected_fn;
+
+                    //Add a trailing "/" to emphasize its a directory not a file. If you want just the dir name it's accessible through "selected_fn"
+                    if(dialog_mode == DialogMode::SELECT)
+                        selected_path += "/";
+                    closeDialog();
+                }
+            }
+
+            // We don't need to check as the modals will only be shown if OpenPopup is called
+            showInvalidFileModal();
+            if(showReplaceFileModal())
+                closeDialog();
+
+            //Show Error Modal if there was an error opening any directory
+            if(show_error)
+                ImGui::OpenPopup(error_title.c_str());
+            showErrorModal();
+
+            ImGui::EndPopup();
+            return (!selected_fn.empty() && !selected_path.empty());
+        }
+        else
+            return false;
+    }
+
+    bool ImGuiFileBrowser::renderNavAndSearchBarRegion()
+    {
+        ImGuiStyle& style = ImGui::GetStyle();
+        bool show_error = false;
+        float frame_height = ImGui::GetFrameHeight();
+        float list_item_height = GImGui->FontSize + style.ItemSpacing.y;
+
+        ImVec2 pw_content_size = ImGui::GetWindowSize() - style.WindowPadding * 2.0;
+        ImVec2 sw_size = ImVec2(ImGui::CalcTextSize("Random").x + 140, style.WindowPadding.y * 2.0f + frame_height);
+        ImVec2 sw_content_size = sw_size - style.WindowPadding * 2.0;
+        ImVec2 nw_size = ImVec2(pw_content_size.x - style.ItemSpacing.x - sw_size.x, sw_size.y);
+
+
+        ImGui::BeginChild("##NavigationWindow", nw_size, true, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoScrollbar);
+
+        ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.882f, 0.745f, 0.078f,1.0f));
+        for(std::vector<std::string>::size_type i = 0; i < current_dirlist.size(); i++)
+        {
+            if( ImGui::Button(current_dirlist[i].c_str()) )
+            {
+                //If last button clicked, nothing happens
+                if(i != current_dirlist.size() - 1)
+                    show_error |= !(onNavigationButtonClick(i));
+            }
+
+            //Draw Arrow Buttons
+            if(i != current_dirlist.size() - 1)
+            {
+                ImGui::SameLine(0,0);
+                float next_label_width = ImGui::CalcTextSize(current_dirlist[i+1].c_str()).x;
+
+                if(i+1 < current_dirlist.size() - 1)
+                    next_label_width += frame_height + ImGui::CalcTextSize(">>").x;
+
+                if(ImGui::GetCursorPosX() + next_label_width >= (nw_size.x - style.WindowPadding.x * 3.0))
+                {
+                    ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(1.0f, 1.0f, 1.0f, 0.01f));
+                    ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f,1.0f));
+
+                    //Render a drop down of navigation items on button press
+                    if(ImGui::Button(">>"))
+                        ImGui::OpenPopup("##NavBarDropboxPopup");
+                    if(ImGui::BeginPopup("##NavBarDropboxPopup"))
+                    {
+                        ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(0.125f, 0.125f, 0.125f, 1.0f));
+                        if(ImGui::BeginListBox("##NavBarDropBox", ImVec2(0, list_item_height* 5)))
+                        {
+                            ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.882f, 0.745f, 0.078f,1.0f));
+                            for(std::vector<std::string>::size_type j = i+1; j < current_dirlist.size(); j++)
+                            {
+                                if(ImGui::Selectable(current_dirlist[j].c_str(), false) && j != current_dirlist.size() - 1)
+                                {
+                                    show_error |= !(onNavigationButtonClick(j));
+                                    ImGui::CloseCurrentPopup();
+                                }
+                            }
+                            ImGui::PopStyleColor();
+                            ImGui::EndListBox();
+                        }
+                        ImGui::PopStyleColor();
+                        ImGui::EndPopup();
+                    }
+                    ImGui::PopStyleColor(2);
+                    break;
+                }
+                else
+                {
+                    ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(1.0f, 1.0f, 1.0f, 0.01f));
+                    ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f,1.0f));
+                    ImGui::ArrowButtonEx("##Right", ImGuiDir_Right, ImVec2(frame_height, frame_height), ImGuiItemFlags_Disabled);
+                    ImGui::SameLine(0,0);
+                    ImGui::PopStyleColor(2);
+                }
+            }
+        }
+        ImGui::PopStyleColor();
+        ImGui::EndChild();
+
+        ImGui::SameLine();
+        ImGui::BeginChild("##SearchWindow", sw_size, true, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoScrollbar);
+
+        //Render Search/Filter bar
+        float marker_width = ImGui::CalcTextSize("(?)").x + style.ItemSpacing.x;
+        if(filter.Draw("##SearchBar", sw_content_size.x - marker_width) || filter_dirty )
+            filterFiles(filter_mode);
+
+        //If filter bar was focused clear selection
+        if(ImGui::GetFocusID() == ImGui::GetID("##SearchBar"))
+            selected_idx = -1;
+
+        ImGui::SameLine();
+        showHelpMarker("Filter (inc, -exc)");
+
+        ImGui::EndChild();
+        return show_error;
+    }
+
+    bool ImGuiFileBrowser::renderFileListRegion()
+    {
+        ImGuiStyle& style = ImGui::GetStyle();
+        ImVec2 pw_size = ImGui::GetWindowSize();
+        bool show_error = false;
+        float list_item_height = ImGui::CalcTextSize("").y + style.ItemSpacing.y;
+        float input_bar_ypos = pw_size.y - ImGui::GetFrameHeightWithSpacing() * 2.5f - style.WindowPadding.y;
+        float window_height = input_bar_ypos - ImGui::GetCursorPosY() - style.ItemSpacing.y;
+        float window_content_height = window_height - style.WindowPadding.y * 2.0f;
+        float min_content_size = pw_size.x - style.WindowPadding.x * 4.0f;
+
+        if(window_content_height <= 0.0f)
+            return show_error;
+
+        //Reinitialize the limit on number of selectables in one column based on height
+        col_items_limit = static_cast<int>(std::max<float>(1.0f, window_content_height/list_item_height));
+        int num_cols = static_cast<int>(std::max<float>(1.0f, std::ceil(static_cast<float>(filtered_dirs.size() + filtered_files.size()) / col_items_limit)));
+
+        //Limitation by ImGUI in 1.75. If columns are greater than 64 readjust the limit on items per column and recalculate number of columns
+        if(num_cols > 64)
+        {
+            int exceed_items_amount = (num_cols - 64) * col_items_limit;
+            col_items_limit += static_cast<int>(std::ceil(exceed_items_amount/64.0));
+            num_cols = static_cast<int>(std::max<float>(1.0f, std::ceil(static_cast<float>(filtered_dirs.size() + filtered_files.size()) / col_items_limit)));
+        }
+
+        float content_width = num_cols * col_width;
+        if(content_width < min_content_size)
+            content_width = 0;
+
+        ImGui::SetNextWindowContentSize(ImVec2(content_width, 0));
+        ImGui::BeginChild("##ScrollingRegion", ImVec2(0, window_height), true, ImGuiWindowFlags_HorizontalScrollbar);
+        ImGui::Columns(num_cols);
+
+        //Output directories in yellow
+        ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.882f, 0.745f, 0.078f,1.0f));
+        int items = 0;
+        for (std::vector<const Info*>::size_type i = 0; i < filtered_dirs.size(); i++)
+        {
+            if(!filtered_dirs[i]->is_hidden || show_hidden)
+            {
+                items++;
+                if(ImGui::Selectable(filtered_dirs[i]->name.c_str(),selected_idx == static_cast<int>(i) && is_dir, ImGuiSelectableFlags_AllowDoubleClick))
+                {
+                    selected_idx = i;
+                    is_dir = true;
+
+                    // If dialog mode is SELECT then copy the selected dir name to the input text bar
+                    if(dialog_mode == DialogMode::SELECT)
+                        strcpy(input_fn, filtered_dirs[i]->name.c_str());
+
+                    if(ImGui::IsMouseDoubleClicked(0))
+                    {
+                        show_error |= !(onDirClick(i));
+                        break;
+                    }
+                }
+                if( (items) % col_items_limit == 0)
+                    ImGui::NextColumn();
+            }
+        }
+        ImGui::PopStyleColor(1);
+
+        //Output files
+        for (std::vector<const Info*>::size_type i = 0; i < filtered_files.size(); i++)
+        {
+            if(!filtered_files[i]->is_hidden || show_hidden)
+            {
+                items++;
+                if(ImGui::Selectable(filtered_files[i]->name.c_str(), selected_idx == static_cast<int>(i) && !is_dir, ImGuiSelectableFlags_AllowDoubleClick))
+                {
+                    //int len = filtered_files[i]->name.length();
+                    selected_idx = i;
+                    is_dir = false;
+
+                    // If dialog mode is OPEN/SAVE then copy the selected file name to the input text bar
+                    strcpy(input_fn, filtered_files[i]->name.c_str());
+
+                    if(ImGui::IsMouseDoubleClicked(0))
+                    {
+                        selected_fn = filtered_files[i]->name;
+                        validate_file = true;
+                    }
+                }
+                if( (items) % col_items_limit == 0)
+                    ImGui::NextColumn();
+            }
+        }
+        ImGui::Columns(1);
+        ImGui::EndChild();
+
+        return show_error;
+    }
+
+    bool ImGuiFileBrowser::renderInputTextAndExtRegion()
+    {
+        std::string label = (dialog_mode == DialogMode::SAVE) ? "Save As:" : "Open:";
+        ImGuiStyle& style = ImGui::GetStyle();
+
+        ImVec2 pw_pos = ImGui::GetWindowPos();
+        ImVec2 pw_content_sz = ImGui::GetWindowSize() - style.WindowPadding * 2.0;
+        ImVec2 cursor_pos = ImGui::GetCursorPos();
+
+        float label_width = ImGui::CalcTextSize(label.c_str()).x + style.ItemSpacing.x;
+        float frame_height_spacing = ImGui::GetFrameHeightWithSpacing();
+        float input_bar_width = pw_content_sz.x - label_width;
+
+        if(ext_box_width < 0.0)
+            ext_box_width = ImGui::CalcTextSize("All Valid Files").x + style.ItemSpacing.x + ImGui::GetFrameHeightWithSpacing() + 10;
+
+        if(dialog_mode != DialogMode::SELECT)
+            input_bar_width -= (ext_box_width + style.ItemSpacing.x);
+
+        bool show_error = false;
+        ImGui::SetCursorPosY(pw_content_sz.y - frame_height_spacing * 2.0f);
+
+        //Render Input Text Bar label
+        ImGui::Text("%s", label.c_str());
+        ImGui::SameLine();
+
+        //Render Input Text Bar
+        input_combobox_pos = ImVec2(pw_pos + ImGui::GetCursorPos());
+        input_combobox_sz = ImVec2(input_bar_width, 0);
+        ImGui::PushItemWidth(input_bar_width);
+        if(ImGui::InputTextWithHint("##FileNameInput", "Type a name...", &input_fn[0], 256, ImGuiInputTextFlags_EnterReturnsTrue | ImGuiInputTextFlags_AutoSelectAll))
+        {
+            if ( strlen( input_fn ) > 0 )
+            {
+                struct stat s;
+                stat( input_fn, &s );
+
+                //If input is a directory...
+                if ( S_ISDIR( s.st_mode ) )
+                {
+                    current_path = input_fn;
+                    std::replace( current_path.begin(), current_path.end(), '\\', '/' );
+
+                    //Browse there
+                    readDIR( current_path );
+
+                    //Reset nav tabs
+                    current_dirlist.clear();
+                    parsePathTabs( current_path );
+
+                    //Clean out inputbox
+                    input_fn[ 0 ] = 0;
+                }
+                else
+                {
+                    selected_fn = std::string( input_fn );
+                    validate_file = true;
+                }
+            }
+        }
+        ImGui::PopItemWidth();
+
+        // If Input Bar is edited show a list of files or dirs matching the input text.
+        if(ImGui::IsItemEdited() || ImGui::IsItemActivated())
+        {
+            //If input bar was focused clear selection
+            selected_idx = -1;
+            //If dialog_mode is OPEN/SAVE then filter from list of files..
+            if(dialog_mode == DialogMode::OPEN || dialog_mode == DialogMode::SAVE)
+            {
+                inputcb_filter_files.clear();
+                for(std::vector<Info>::size_type i = 0; i < subfiles.size(); i++)
+                {
+                    if(ImStristr(subfiles[i].name.c_str(), nullptr, input_fn, nullptr) != nullptr)
+                        inputcb_filter_files.push_back(std::ref(subfiles[i].name));
+                }
+            }
+
+            //If dialog_mode == SELECT then filter from list of directories
+            else if(dialog_mode == DialogMode::SELECT)
+            {
+                inputcb_filter_files.clear();
+                for(std::vector<Info>::size_type i = 0; i < subdirs.size(); i++)
+                {
+                    if(ImStristr(subdirs[i].name.c_str(), nullptr, input_fn, nullptr) != nullptr)
+                        inputcb_filter_files.push_back(std::ref(subdirs[i].name));
+                }
+            }
+
+            //If filtered list has any items show dropdown
+            if(inputcb_filter_files.size() > 0)
+                show_inputbar_combobox = true;
+            else
+                show_inputbar_combobox = false;
+        }
+
+        //Render Extensions and File Types DropDown
+        if(dialog_mode != DialogMode::SELECT)
+        {
+            ImGui::SameLine();
+            renderExtBox();
+        }
+
+        //Render a Drop Down of files/dirs (depending on mode) that have matching characters as the input text only.
+        show_error |= renderInputComboBox();
+
+        ImGui::SetCursorPos(cursor_pos);
+        return show_error;
+    }
+
+    bool ImGuiFileBrowser::renderButtonsAndCheckboxRegion()
+    {
+        ImVec2 pw_size = ImGui::GetWindowSize();
+        ImGuiStyle& style = ImGui::GetStyle();
+        bool show_error = false;
+        float frame_height = ImGui::GetFrameHeight();
+        float frame_height_spacing = ImGui::GetFrameHeightWithSpacing();
+        float button_width = (ext_box_width - style.ItemSpacing.x) / ( (dialog_mode == DialogMode::SELECT) ? 3.0 : 2.0 );
+        float buttons_xpos =  pw_size.x - button_width * ( (dialog_mode == DialogMode::SELECT) ? 3.0 : 2.0 ) - style.ItemSpacing.x * ( ( dialog_mode == DialogMode::SELECT ) ? 2 : 1 ) - style.WindowPadding.x;
+
+        ImGui::SetCursorPosY(pw_size.y - frame_height_spacing - style.WindowPadding.y);
+
+        //Render Checkbox
+        float label_width = ImGui::CalcTextSize("Show Hidden Files and Folders").x + ImGui::GetCursorPosX() + frame_height;
+        bool show_marker = (label_width >= buttons_xpos);
+        ImGui::Checkbox( (show_marker) ? "##showHiddenFiles" : "Show Hidden Files and Folders", &show_hidden);
+        if(show_marker)
+        {
+            ImGui::SameLine();
+            showHelpMarker("Show Hidden Files and Folders");
+        }
+
+        //Render an Open Button (in OPEN/SELECT dialog_mode) or Open/Save depending on what's selected in SAVE dialog_mode
+        ImGui::SameLine();
+        ImGui::SetCursorPosX(buttons_xpos);
+        if(dialog_mode == DialogMode::SAVE)
+        {
+            // If directory selected and Input Text Bar doesn't have focus, render Open Button
+            if(selected_idx != -1 && is_dir && ImGui::GetFocusID() != ImGui::GetID("##FileNameInput"))
+            {
+                if (ImGui::Button("Open", ImVec2(button_width, 0)))
+                    show_error |= !(onDirClick(selected_idx));
+            }
+            else if (ImGui::Button("Save", ImVec2(button_width, 0)) && strlen(input_fn) > 0)
+            {
+                selected_fn = std::string(input_fn);
+                validate_file = true;
+            }
+        }
+        else
+        {
+            if (ImGui::Button("Open", ImVec2(button_width, 0)))
+            {
+                //It's possible for both to be true at once (user selected directory but input bar has some text. In this case we chose to open the directory instead of opening the file.
+                //Also note that we don't need to access the selected file through "selected_idx" since the if a file is selected, input bar will get populated with that name.
+                if(selected_idx >= 0 && is_dir)
+                    show_error |= !(onDirClick(selected_idx));
+                else if(strlen(input_fn) > 0)
+                {
+                    selected_fn = std::string(input_fn);
+                    validate_file = true;
+                }
+            }
+
+            //Render Select Button if in SELECT Mode
+            if(dialog_mode == DialogMode::SELECT)
+            {
+                //Render Select Button
+                ImGui::SameLine();
+                if (ImGui::Button("Select", ImVec2(button_width, 0)))
+                {
+                    if(strlen(input_fn) > 0)
+                    {
+                        selected_fn = std::string(input_fn);
+                        validate_file = true;
+                    }
+                }
+            }
+        }
+
+        //Render Cancel Button
+        ImGui::SameLine();
+        if (ImGui::Button("Cancel", ImVec2(button_width, 0)))
+            closeDialog();
+
+        return show_error;
+    }
+
+    bool ImGuiFileBrowser::renderInputComboBox()
+    {
+        bool show_error = false;
+        ImGuiStyle& style = ImGui::GetStyle();
+        ImGuiID input_id =  ImGui::GetID("##FileNameInput");
+        ImGuiID focus_scope_id = ImGui::GetID("##InputBarComboBoxListScope");
+        float frame_height = ImGui::GetFrameHeight();
+
+        input_combobox_sz.y = std::min<float>((inputcb_filter_files.size() + 1) * frame_height + style.WindowPadding.y *  2.0f,
+                                        8 * ImGui::GetFrameHeight() + style.WindowPadding.y *  2.0f);
+
+        if(show_inputbar_combobox && ( ImGui::GetCurrentFocusScope() == focus_scope_id || ImGui::GetCurrentContext()->ActiveIdIsAlive == input_id  ))
+        {
+            ImGuiWindowFlags popupFlags = ImGuiWindowFlags_NoTitleBar           |
+                                          ImGuiWindowFlags_NoResize             |
+                                          ImGuiWindowFlags_NoMove               |
+                                          ImGuiWindowFlags_NoFocusOnAppearing   |
+                                          ImGuiWindowFlags_NoScrollbar          |
+                                          ImGuiWindowFlags_NoSavedSettings;
+
+
+            ImGui::PushStyleColor(ImGuiCol_ChildBg, ImVec4(0.1f, 0.1f, 0.1f, 1.0f));
+            ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(0.125f, 0.125f, 0.125f, 1.0f));
+            ImGui::SetNextWindowBgAlpha(1.0);
+            ImGui::SetNextWindowPos(input_combobox_pos + ImVec2(0, ImGui::GetFrameHeightWithSpacing()));
+            ImGui::PushClipRect(ImVec2(0,0), ImGui::GetIO().DisplaySize, false);
+
+            ImGui::BeginChild("##InputBarComboBox", input_combobox_sz, true, popupFlags);
+
+            ImVec2 listbox_size = input_combobox_sz - ImGui::GetStyle().WindowPadding * 2.0f;
+            if(ImGui::BeginListBox("##InputBarComboBoxList", listbox_size))
+            {
+                ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f,1.0f));
+                ImGui::PushFocusScope(focus_scope_id);
+                for(auto& element : inputcb_filter_files)
+                {
+                    if(ImGui::Selectable(element.get().c_str(), false, ImGuiSelectableFlags_NoHoldingActiveID | ImGuiSelectableFlags_SelectOnClick))
+                    {
+                        if(element.get().size() > 256)
+                        {
+                            error_title = "Error!";
+                            error_msg = "Selected File Name is longer than 256 characters.";
+                            show_error = true;
+                        }
+                        else
+                        {
+                            strcpy(input_fn, element.get().c_str());
+                            show_inputbar_combobox = false;
+                        }
+                    }
+                }
+                ImGui::PopFocusScope();
+                ImGui::PopStyleColor(1);
+                ImGui::EndListBox();
+            }
+            ImGui::EndChild();
+            ImGui::PopStyleColor(2);
+            ImGui::PopClipRect();
+        }
+        return show_error;
+    }
+
+    void ImGuiFileBrowser::renderExtBox()
+    {
+        const char * selected_label = valid_exts[ selected_ext_idx ].c_str();
+        ImGui::PushItemWidth(ext_box_width);
+        if(ImGui::BeginCombo("##FileTypes", selected_label ))
+        {
+            for(std::vector<std::string>::size_type i = 0; i < valid_exts.size(); i++)
+            {
+                std::string label_text = valid_exts[i];
+                if(label_text == "*.*")
+                    label_text = "All Files (*.*)";
+
+                if(ImGui::Selectable(label_text.c_str(), selected_ext_idx == static_cast<int>(i)))
+                {
+                    show_all_valid_files = (label_text == ALL_VALID_FILES_EXT_TXT);
+                    selected_ext_idx = i;
+                    //Automatically append extension to input filename when changing extensions from dropdown
+                    if(dialog_mode == DialogMode::SAVE)
+                    {
+                        std::string name(input_fn);
+                        size_t idx = name.find_last_of(".");
+                        if(idx == std::string::npos)
+                            idx = strlen(input_fn);
+                        for(std::vector<std::string>::size_type j = 0; j < valid_exts[selected_ext_idx].size(); j++)
+                            input_fn[idx++] = valid_exts[selected_ext_idx][j];
+                        input_fn[idx++] = '\0';
+                    }
+                    filterFiles(FilterMode_Files);
+                }
+            }
+
+            ImGui::EndCombo();
+        }
+        ext = valid_exts[selected_ext_idx];
+        ImGui::PopItemWidth();
+    }
+
+    bool ImGuiFileBrowser::onNavigationButtonClick(int idx)
+    {
+        std::string new_path = "";
+
+        //First Button corresponds to virtual folder Computer which lists all logical drives (hard disks and removables) and "/" on Unix
+        if(idx == 0)
+        {
+            #ifdef OSWIN
+            if(!loadWindowsDrives())
+                return false;
+            current_path.clear();
+            current_dirlist.clear();
+            current_dirlist.push_back("Computer");
+            return true;
+            #else
+            new_path = "/";
+            #endif // OSWIN
+        }
+        else
+        {
+            #ifdef OSWIN
+            //Clicked on a drive letter?
+            if(idx == 1)
+                new_path = current_path.substr(0, 3);
+            else
+            {
+                //Start from i=1 since at 0 lies "MyComputer" which is only virtual and shouldn't be read by readDIR
+                for (int i = 1; i <= idx; i++)
+                    new_path += current_dirlist[i] + "/";
+            }
+            #else
+            //Since UNIX absolute paths start at "/", we handle this separately to avoid adding a double slash at the beginning
+            new_path += current_dirlist[0];
+            for (int i = 1; i <= idx; i++)
+                new_path += current_dirlist[i] + "/";
+            #endif
+        }
+
+        if(readDIR(new_path))
+        {
+            current_dirlist.erase(current_dirlist.begin()+idx+1, current_dirlist.end());
+            current_path = new_path;
+            return true;
+        }
+        else
+            return false;
+    }
+
+    bool ImGuiFileBrowser::onDirClick(int idx)
+    {
+        std::string name;
+        std::string new_path(current_path);
+        bool drives_shown = false;
+
+        #ifdef OSWIN
+        drives_shown = (current_dirlist.size() == 1 && current_dirlist.back() == "Computer");
+        #endif // OSWIN
+
+        name = filtered_dirs[idx]->name;
+
+        if(name == "..")
+        {
+            new_path.pop_back(); // Remove trailing '/'
+            new_path = new_path.substr(0, new_path.find_last_of('/') + 1); // Also include a trailing '/'
+        }
+        else
+        {
+            //Remember we displayed drives on Windows as *Local/Removable Disk: X* hence we need last char only
+            if(drives_shown)
+                name = std::string(1, name.back()) + ":";
+            new_path += name + "/";
+        }
+
+        if(readDIR(new_path))
+        {
+            if(name == "..")
+                current_dirlist.pop_back();
+            else
+                current_dirlist.push_back(name);
+
+             current_path = new_path;
+             return true;
+        }
+        else
+           return false;
+    }
+
+    bool ImGuiFileBrowser::readDIR(std::string pathdir)
+    {
+        DIR* dir;
+        struct dirent *ent;
+
+        /* If the current directory doesn't exist, and we are opening the dialog for the first time, reset to defaults to avoid looping of showing error modal.
+         * An example case is when user closes the dialog in a folder. Then deletes the folder outside. On reopening the dialog the current path (previous) would be invalid.
+         */
+        dir = opendir(pathdir.c_str());
+        if(dir == nullptr && is_appearing)
+        {
+            current_dirlist.clear();
+            #ifdef OSWIN
+            current_path = pathdir = "./";
+            #else
+            initCurrentPath();
+            pathdir = current_path;
+            #endif // OSWIN
+
+            dir = opendir(pathdir.c_str());
+        }
+
+        if (dir != nullptr)
+        {
+            #ifdef OSWIN
+            // If we are on Windows and current path is relative then get absolute path from dirent structure
+            if(current_dirlist.empty() && pathdir == "./")
+            {
+                const wchar_t* absolute_path = dir->wdirp->patt;
+                std::string current_directory = wStringToString(absolute_path);
+                std::replace(current_directory.begin(), current_directory.end(), '\\', '/');
+
+                //Remove trailing "*" returned by ** dir->wdirp->patt **
+                current_directory.pop_back();
+                current_path = current_directory;
+
+                //Create a vector of each directory in the file path for the filepath bar. Not Necessary for linux as starting directory is "/"
+                parsePathTabs(current_path);
+            }
+            #endif // OSWIN
+
+            // store all the files and directories within directory and clear previous entries
+            clearFileList();
+            while ((ent = readdir (dir)) != nullptr)
+            {
+                bool is_hidden = false;
+                std::string name(ent->d_name);
+
+                //Ignore current directory
+                if(name == ".")
+                    continue;
+
+                //Somehow there is a '..' present in root directory in linux.
+                #ifndef OSWIN
+                if(name == ".." && pathdir == "/")
+                    continue;
+                #endif // OSWIN
+
+                if(name != "..")
+                {
+                    #ifdef OSWIN
+                    std::string dir = pathdir + std::string(ent->d_name);
+                    // IF system file skip it...
+                    if (FILE_ATTRIBUTE_SYSTEM & GetFileAttributesA(dir.c_str()))
+                        continue;
+                    if (FILE_ATTRIBUTE_HIDDEN & GetFileAttributesA(dir.c_str()))
+                        is_hidden = true;
+                    #else
+                    if(name[0] == '.')
+                        is_hidden = true;
+                    #endif // OSWIN
+                }
+                //Store directories and files in separate vectors
+                if(ent->d_type == DT_DIR)
+                    subdirs.push_back(Info(name, is_hidden));
+                else if(ent->d_type == DT_REG && dialog_mode != DialogMode::SELECT)
+                    subfiles.push_back(Info(name, is_hidden));
+            }
+            closedir (dir);
+            std::sort(subdirs.begin(), subdirs.end(), alphaSortComparator);
+            std::sort(subfiles.begin(), subfiles.end(), alphaSortComparator);
+
+            //Initialize Filtered dirs and files
+            filterFiles(filter_mode);
+        }
+        else
+        {
+            error_title = "Error!";
+            error_msg = "Error opening directory! Make sure the directory exists and you have the proper rights to access the directory.";
+            return false;
+        }
+        return true;
+    }
+
+    void ImGuiFileBrowser::filterFiles(int filter_mode)
+    {
+        filter_dirty = false;
+        if(filter_mode | FilterMode_Dirs)
+        {
+            filtered_dirs.clear();
+            for (std::vector<Info>::size_type i = 0; i < subdirs.size(); ++i)
+            {
+                if(filter.PassFilter(subdirs[i].name.c_str()))
+                    filtered_dirs.push_back(&subdirs[i]);
+            }
+        }
+        if(filter_mode | FilterMode_Files)
+        {
+            filtered_files.clear();
+            for (std::vector<Info>::size_type i = 0; i < subfiles.size(); ++i)
+            {
+                // If the option to show all supported formats is selected, filter all files supported
+                if (show_all_valid_files)
+                {
+                    if(filter.PassFilter(subfiles[i].name.c_str()))
+                    {
+                        std::string ext = subfiles[i].name.find_last_of('.') == std::string::npos ? "" : subfiles[i].name.substr(subfiles[i].name.find_last_of('.'));
+                        std::transform(ext.begin(), ext.end(), ext.begin(), [](unsigned char c){ return std::tolower(c); });
+                        if (ext.length() > 0 && find(valid_exts.begin(), valid_exts.end(), ext) != valid_exts.end())
+                        {
+                            filtered_files.push_back(&subfiles[i]);
+                        }
+                    }
+                }
+                // If the option to show all files is selected, filter all files
+                else if(valid_exts[selected_ext_idx] == "*.*")
+                {
+                    if(filter.PassFilter(subfiles[i].name.c_str()))
+                        filtered_files.push_back(&subfiles[i]);
+                }
+                //If any other extension is selected, filter files having only that extension
+                else
+                {
+                    if(filter.PassFilter(subfiles[i].name.c_str()) && (ImStristr(subfiles[i].name.c_str(), nullptr, valid_exts[selected_ext_idx].c_str(), nullptr)) != nullptr)
+                        filtered_files.push_back(&subfiles[i]);
+                }
+            }
+        }
+    }
+
+    void ImGuiFileBrowser::showHelpMarker(std::string desc)
+    {
+        ImGui::TextDisabled("(?)");
+        if (ImGui::IsItemHovered())
+        {
+            ImGui::BeginTooltip();
+            ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+            ImGui::TextUnformatted(desc.c_str());
+            ImGui::PopTextWrapPos();
+            ImGui::EndTooltip();
+        }
+    }
+
+    void ImGuiFileBrowser::showErrorModal()
+    {
+        ImVec2 window_size(260, 0);
+        ImGui::SetNextWindowSize(window_size);
+
+        if (ImGui::BeginPopupModal(error_title.c_str(), nullptr, ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoResize))
+        {
+            ImGui::TextWrapped("%s", error_msg.c_str());
+
+            ImGui::Separator();
+            ImGui::SetCursorPosX(window_size.x/2.0f - getButtonSize("OK").x/2.0f);
+            if (ImGui::Button("OK", getButtonSize("OK")))
+                ImGui::CloseCurrentPopup();
+            ImGui::EndPopup();
+        }
+    }
+
+    bool ImGuiFileBrowser::showReplaceFileModal()
+    {
+        ImVec2 window_size(250, 0);
+        ImGui::SetNextWindowSize(window_size);
+        bool ret_val = false;
+        if (ImGui::BeginPopupModal(repfile_modal_id.c_str(), nullptr, ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoResize))
+        {
+            std::string text = "A file with the following filename already exists. Are you sure you want to replace the existing file?";
+            ImGui::TextWrapped("%s", text.c_str());
+
+            ImGui::Separator();
+
+            float buttons_width = getButtonSize("Yes").x + getButtonSize("No").x + ImGui::GetStyle().ItemSpacing.x;
+            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + ImGui::GetWindowWidth()/2.0f - buttons_width/2.0f - ImGui::GetStyle().WindowPadding.x);
+
+            if (ImGui::Button("Yes", getButtonSize("Yes")))
+            {
+                selected_path = current_path + selected_fn;
+                ImGui::CloseCurrentPopup();
+                ret_val = true;
+            }
+
+            ImGui::SameLine();
+            if (ImGui::Button("No", getButtonSize("No")))
+            {
+                selected_fn.clear();
+                selected_path.clear();
+                ImGui::CloseCurrentPopup();
+                ret_val = false;
+            }
+            ImGui::EndPopup();
+        }
+        return ret_val;
+    }
+
+    void ImGuiFileBrowser::showInvalidFileModal()
+    {
+        ImVec2 window_size(350, 0);
+        ImGui::SetNextWindowSize(window_size);
+
+        if (ImGui::BeginPopupModal(invfile_modal_id.c_str(), nullptr, ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoResize))
+        {
+
+            std::string text = "";
+            if(valid_exts.back() == "*.*")
+                text = "Selected file doesn't exist. Make sure the file you are trying to open exists and the name matches including the extension.";
+            else
+                text = "Selected file either doesn't exist or is not supported. Please select a file with the following extensions...";
+
+            ImVec2 button_size = getButtonSize("OK");
+
+            ImGui::TextWrapped("%s", text.c_str());
+            if(valid_exts.back() != "*.*")
+            {
+                // Number of extension to display in the child window.
+                auto ext_count = (valid_exts.back() == ALL_VALID_FILES_EXT_TXT) ? (valid_exts.size() - 1) : valid_exts.size();
+                // Clamp to item count of 4 for window height.
+                auto items_for_height = std::min<decltype(ext_count)>(4, ext_count);
+                // Get window height by item count.
+                ImGuiStyle &style = ImGui::GetStyle();
+                // ext_count (thus items_for_height) > 0 holds for current implementation.
+                float cw_height = items_for_height * ImGui::GetTextLineHeightWithSpacing() - style.ItemSpacing.y + style.WindowPadding.y * 2;
+                ImGui::BeginChild("##SupportedExts", ImVec2(0, cw_height), true);
+                for(decltype(ext_count) i = 0; i < ext_count; i++)
+                    ImGui::BulletText("%s", valid_exts[i].c_str());
+                ImGui::EndChild();
+            }
+
+            ImGui::SetCursorPosX(window_size.x/2.0f - button_size.x/2.0f);
+            if (ImGui::Button("OK", button_size))
+                ImGui::CloseCurrentPopup();
+            ImGui::EndPopup();
+        }
+    }
+
+    void ImGuiFileBrowser::setValidExtTypes(const std::string& valid_types_string)
+    {
+        /* Initialize a list of files extensions that are valid.
+         * If the user chooses a file that doesn't match the extensions in the
+         * list, we will show an error modal...
+         */
+        bool all_files = false;
+        valid_exts.clear();
+
+        if(valid_types_string == "")
+            return;
+
+        std::string valid_str_lower( valid_types_string );
+        std::transform( valid_str_lower.begin(), valid_str_lower.end(), valid_str_lower.begin(), []( unsigned char c ) { return std::tolower( c ); } );
+
+        std::string extension = "";
+        std::istringstream iss(valid_str_lower);
+        while(std::getline(iss, extension, ','))
+        {
+            if(!extension.empty() && extension != "*.*")
+                valid_exts.push_back(extension);
+            else if(extension == "*.*")
+                all_files = true;
+        }
+
+        //Add an option to support all valid extensions
+        if(valid_exts.size() > 1 && dialog_mode == DialogMode::OPEN)
+            valid_exts.push_back(ALL_VALID_FILES_EXT_TXT);
+
+        //Add all files option in last
+        if(all_files)
+            valid_exts.push_back("*.*");
+
+    }
+
+    bool ImGuiFileBrowser::validateFile()
+    {
+        bool match = false;
+
+        //If there is an item selected, check if the selected file name (the input filename, in other words) matches the selection.
+        if(selected_idx >= 0)
+        {
+            if(dialog_mode == DialogMode::SELECT)
+                match = (filtered_dirs[selected_idx]->name == selected_fn);
+            else
+                match = (filtered_files[selected_idx]->name == selected_fn);
+        }
+
+        //If the input filename doesn't match we need to explicitly find the input filename..
+        if(!match)
+        {
+            if(dialog_mode == DialogMode::SELECT)
+            {
+                for(std::vector<Info>::size_type i = 0; i < subdirs.size(); i++)
+                {
+                    if(subdirs[i].name == selected_fn)
+                    {
+                        match = true;
+                        break;
+                    }
+                }
+
+            }
+            else
+            {
+                for(std::vector<Info>::size_type i = 0; i < subfiles.size(); i++)
+                {
+                    if(subfiles[i].name == selected_fn)
+                    {
+                        match = true;
+                        break;
+                    }
+                }
+            }
+        }
+
+        // If file doesn't match, return true on SAVE mode (since file doesn't exist, hence can be saved directly) and return false on other modes (since file doesn't exist so cant open/select)
+        if(!match)
+            return (dialog_mode == DialogMode::SAVE);
+
+        // If file matches, return false on SAVE, we need to show a replace file modal
+        if(dialog_mode == DialogMode::SAVE)
+            return false;
+
+        // Return true on SELECT, no need to validate extensions
+        else if(dialog_mode == DialogMode::SELECT)
+            return true;
+
+        else
+        {
+            // If list of extensions has all types, no need to validate.
+            for(auto ext : valid_exts)
+            {
+                if(ext == "*.*")
+                    return true;
+            }
+            size_t idx = selected_fn.find_last_of('.');
+            std::string file_ext = idx == std::string::npos ? "" : selected_fn.substr(idx, selected_fn.length() - idx);
+
+            std::transform( file_ext.begin(), file_ext.end(), file_ext.begin(), []( unsigned char c ) { return std::tolower( c ); } );
+
+            return (std::find(valid_exts.begin(), valid_exts.end(), file_ext) != valid_exts.end());
+        }
+    }
+
+    ImVec2 ImGuiFileBrowser::getButtonSize(std::string button_text)
+    {
+        return (ImGui::CalcTextSize(button_text.c_str()) + ImGui::GetStyle().FramePadding * 2.0);
+    }
+
+    void ImGuiFileBrowser::parsePathTabs(std::string path)
+    {
+        std::string path_element = "";
+        std::string root = "";
+
+        #ifdef OSWIN
+        current_dirlist.push_back("Computer");
+        #else
+        if(path[0] == '/')
+            current_dirlist.push_back("/");
+        #endif //OSWIN
+
+        std::istringstream iss(path);
+        while(std::getline(iss, path_element, '/'))
+        {
+            if(!path_element.empty())
+                current_dirlist.push_back(path_element);
+        }
+    }
+
+    std::string ImGuiFileBrowser::wStringToString(const wchar_t* wchar_arr)
+    {
+        std::mbstate_t state = std::mbstate_t();
+
+         //MinGW bug (patched in mingw-w64), wcsrtombs doesn't ignore length parameter when dest = nullptr. Hence the large number.
+        size_t len = 1 + std::wcsrtombs(nullptr, &(wchar_arr), 600000, &state);
+
+        char* char_arr = new char[len];
+        std::wcsrtombs(char_arr, &wchar_arr, len, &state);
+
+        std::string ret_val(char_arr);
+
+        delete[] char_arr;
+        return ret_val;
+    }
+
+    bool ImGuiFileBrowser::alphaSortComparator(const Info& a, const Info& b)
+    {
+        const char* str1 = a.name.c_str();
+        const char* str2 = b.name.c_str();
+        int ca, cb;
+        do
+        {
+            ca = (unsigned char) *str1++;
+            cb = (unsigned char) *str2++;
+            ca = std::tolower(std::toupper(ca));
+            cb = std::tolower(std::toupper(cb));
+        }
+        while (ca == cb && ca != '\0');
+        if(ca  < cb)
+            return true;
+        else
+            return false;
+    }
+
+    //Windows Exclusive function
+    #ifdef OSWIN
+    bool ImGuiFileBrowser::loadWindowsDrives()
+    {
+        DWORD len = GetLogicalDriveStringsA(0,nullptr);
+        char* drives = new char[len];
+        if(!GetLogicalDriveStringsA(len,drives))
+        {
+            delete[] drives;
+            return false;
+        }
+
+        clearFileList();
+        char* temp = drives;
+        for(char *drv = nullptr; *temp != '\0'; temp++)
+        {
+            drv = temp;
+            if(DRIVE_REMOVABLE == GetDriveTypeA(drv))
+                subdirs.push_back({"Removable Disk: " + std::string(1,drv[0]), false});
+            else if(DRIVE_FIXED == GetDriveTypeA(drv))
+                subdirs.push_back({"Local Disk: " + std::string(1,drv[0]), false});
+            //Go to nullptr character
+            while(*(++temp));
+        }
+        delete[] drives;
+        return true;
+    }
+    #endif
+
+    //Unix only
+    #ifndef OSWIN
+    void ImGuiFileBrowser::initCurrentPath()
+    {
+        bool path_max_def = false;
+
+        #ifdef PATH_MAX
+        path_max_def = true;
+        #endif // PATH_MAX
+
+        char* buffer = nullptr;
+
+        //If PATH_MAX is defined deal with memory using new/delete. Else fallback to malloc'ed memory from `realpath()`
+        if(path_max_def)
+            buffer = new char[PATH_MAX];
+
+        char* real_path = realpath("./", buffer);
+        if (real_path == nullptr)
+        {
+            current_path = "/";
+            current_dirlist.push_back("/");
+        }
+        else
+        {
+            current_path = std::string(real_path);
+            current_path += "/";
+            parsePathTabs(current_path);
+        }
+
+        if(path_max_def)
+            delete[] buffer;
+        else
+            free(real_path);
+    }
+    #endif // OSWIN
+}

--- a/soh/soh/ImGuiFileBrowser/ImGuiFileBrowser.cpp
+++ b/soh/soh/ImGuiFileBrowser/ImGuiFileBrowser.cpp
@@ -55,6 +55,7 @@ namespace imgui_addons
         repfile_modal_id = "Replace File?";
         selected_fn = "";
         selected_path = "";
+        selected_dir = "";
         input_fn[0] = '\0';
 
         #ifdef OSWIN
@@ -67,6 +68,14 @@ namespace imgui_addons
     ImGuiFileBrowser::~ImGuiFileBrowser()
     {
 
+    }
+
+    void ImGuiFileBrowser::setCurrentPath(const std::string& path) {
+        current_path = path;
+        std::replace(current_path.begin(), current_path.end(), '\\', '/' );
+        if (!current_path.ends_with("/")) {
+            current_path += "/";
+        }
     }
 
     void ImGuiFileBrowser::clearFileList()
@@ -139,6 +148,7 @@ namespace imgui_addons
             {
                 selected_fn.clear();
                 selected_path.clear();
+                selected_dir.clear();
                 if(mode != DialogMode::SELECT)
                 {
                     this->valid_types = valid_types;
@@ -177,6 +187,7 @@ namespace imgui_addons
                     ImGui::OpenPopup(invfile_modal_id.c_str());
                     selected_fn.clear();
                     selected_path.clear();
+                    selected_dir.clear();
                 }
 
                 else if(!check && dialog_mode == DialogMode::SAVE)
@@ -186,6 +197,7 @@ namespace imgui_addons
                 {
                     selected_fn.clear();
                     selected_path.clear();
+                    selected_dir.clear();
                     show_error = true;
                     error_title = "Invalid Directory!";
                     error_msg = "Invalid Directory Selected. Please make sure the directory exists.";
@@ -195,6 +207,7 @@ namespace imgui_addons
                 if(check)
                 {
                     selected_path = current_path + selected_fn;
+                    selected_dir = current_path;
 
                     //Add a trailing "/" to emphasize its a directory not a file. If you want just the dir name it's accessible through "selected_fn"
                     if(dialog_mode == DialogMode::SELECT)
@@ -811,15 +824,17 @@ namespace imgui_addons
         {
             #ifdef OSWIN
             // If we are on Windows and current path is relative then get absolute path from dirent structure
-            if(current_dirlist.empty() && pathdir == "./")
+            if(current_dirlist.empty())
             {
-                const wchar_t* absolute_path = dir->wdirp->patt;
-                std::string current_directory = wStringToString(absolute_path);
-                std::replace(current_directory.begin(), current_directory.end(), '\\', '/');
+                if (pathdir == "./") {
+                    const wchar_t* absolute_path = dir->wdirp->patt;
+                    std::string current_directory = wStringToString(absolute_path);
+                	std::replace(current_directory.begin(), current_directory.end(), '\\', '/');
 
-                //Remove trailing "*" returned by ** dir->wdirp->patt **
-                current_directory.pop_back();
-                current_path = current_directory;
+                    //Remove trailing "*" returned by ** dir->wdirp->patt **
+                    current_directory.pop_back();
+                    current_path = current_directory;
+                }
 
                 //Create a vector of each directory in the file path for the filepath bar. Not Necessary for linux as starting directory is "/"
                 parsePathTabs(current_path);
@@ -973,6 +988,7 @@ namespace imgui_addons
             if (ImGui::Button("Yes", getButtonSize("Yes")))
             {
                 selected_path = current_path + selected_fn;
+                selected_dir = current_path;
                 ImGui::CloseCurrentPopup();
                 ret_val = true;
             }
@@ -982,6 +998,7 @@ namespace imgui_addons
             {
                 selected_fn.clear();
                 selected_path.clear();
+                selected_dir.clear();
                 ImGui::CloseCurrentPopup();
                 ret_val = false;
             }

--- a/soh/soh/ImGuiFileBrowser/ImGuiFileBrowser.h
+++ b/soh/soh/ImGuiFileBrowser/ImGuiFileBrowser.h
@@ -1,0 +1,122 @@
+#ifndef IMGUIFILEBROWSER_H
+#define IMGUIFILEBROWSER_H
+
+#include <imgui.h>
+#include <string>
+#include <vector>
+
+namespace imgui_addons
+{
+    class ImGuiFileBrowser
+    {
+        public:
+            ImGuiFileBrowser();
+            ~ImGuiFileBrowser();
+
+            enum class DialogMode
+            {
+                SELECT, //Select Directory Mode
+                OPEN,   //Open File mode
+                SAVE    //Save File mode.
+            };
+
+            /* Use this to show an open file dialog. The function takes label for the window,
+             * the size, a DialogMode enum value defining in which mode the dialog should operate and optionally the extensions that are valid for opening.
+             * Note that the select directory mode doesn't need any extensions.
+             */
+            bool showFileDialog(const std::string& label, const DialogMode mode, const ImVec2& sz_xy = ImVec2(0,0), const std::string& valid_types = "*.*");
+
+            /* Store the opened/saved file name or dir name (incase of selectDirectoryDialog) and the absolute path to the selection
+             * Should only be accessed when above functions return true else may contain garbage.
+             */
+            std::string selected_fn;
+            std::string selected_path;
+            std::string ext;    // Store the saved file extension
+
+
+        private:
+            struct Info
+            {
+                Info(std::string name, bool is_hidden) : name(name), is_hidden(is_hidden)
+                {
+                }
+                std::string name;
+                bool is_hidden;
+            };
+
+            //Enum used as bit flags.
+            enum FilterMode
+            {
+                FilterMode_Files = 0x01,
+                FilterMode_Dirs = 0x02
+            };
+
+            //Helper Functions
+            static std::string wStringToString(const wchar_t* wchar_arr);
+            static bool alphaSortComparator(const Info& a, const Info& b);
+            ImVec2 getButtonSize(std::string button_text);
+
+            /* Helper Functions that render secondary modals
+             * and help in validating file extensions and for filtering, parsing top navigation bar.
+             */
+            void setValidExtTypes(const std::string& valid_types_string);
+            bool validateFile();
+            void showErrorModal();
+            void showInvalidFileModal();
+            bool showReplaceFileModal();
+            void showHelpMarker(std::string desc);
+            void parsePathTabs(std::string str);
+            void filterFiles(int filter_mode);
+
+            /* Core Functions that render the 4 different regions making up
+             * a simple file dialog
+             */
+            bool renderNavAndSearchBarRegion();
+            bool renderFileListRegion();
+            bool renderInputTextAndExtRegion();
+            bool renderButtonsAndCheckboxRegion();
+            bool renderInputComboBox();
+            void renderExtBox();
+
+            /* Core Functions that handle navigation and
+             * reading directories/files
+             */
+            bool readDIR(std::string path);
+            bool onNavigationButtonClick(int idx);
+            bool onDirClick(int idx);
+
+            // Functions that reset state and/or clear file list when reading new directory
+            void clearFileList();
+            void closeDialog();
+
+            #if defined (WIN32) || defined (_WIN32) || defined (__WIN32)
+            bool loadWindowsDrives(); // Helper Function for Windows to load Drive Letters.
+            #endif
+
+            #if defined(unix) || defined(__unix__) || defined(__unix) || defined(__APPLE__)
+            void initCurrentPath();   // Helper function for UNIX based system to load Absolute path using realpath
+            #endif
+
+            ImVec2 min_size, max_size, input_combobox_pos, input_combobox_sz;
+            DialogMode dialog_mode;
+            int filter_mode, col_items_limit, selected_idx, selected_ext_idx;
+            float col_width, ext_box_width;
+            bool show_hidden, show_inputbar_combobox, is_dir, is_appearing, filter_dirty, validate_file, show_all_valid_files;
+            char input_fn[256];
+
+            std::vector<std::string> valid_exts;
+            std::vector<std::string> current_dirlist;
+            std::vector<Info> subdirs;
+            std::vector<Info> subfiles;
+            std::string current_path, error_msg, error_title, invfile_modal_id, repfile_modal_id;
+
+            ImGuiTextFilter filter;
+            std::string valid_types;
+            std::vector<const Info*> filtered_dirs; // Note: We don't need to call delete. It's just for storing filtered items from subdirs and subfiles so we don't use PassFilter every frame.
+            std::vector<const Info*> filtered_files;
+            std::vector< std::reference_wrapper<std::string> > inputcb_filter_files;
+    };
+}
+
+
+#endif // IMGUIFILEBROWSER_H

--- a/soh/soh/ImGuiFileBrowser/ImGuiFileBrowser.h
+++ b/soh/soh/ImGuiFileBrowser/ImGuiFileBrowser.h
@@ -91,9 +91,7 @@ namespace imgui_addons
 
             #if defined (WIN32) || defined (_WIN32) || defined (__WIN32)
             bool loadWindowsDrives(); // Helper Function for Windows to load Drive Letters.
-            #endif
-
-            #if defined(unix) || defined(__unix__) || defined(__unix) || defined(__APPLE__)
+            #else
             void initCurrentPath();   // Helper function for UNIX based system to load Absolute path using realpath
             #endif
 

--- a/soh/soh/ImGuiFileBrowser/ImGuiFileBrowser.h
+++ b/soh/soh/ImGuiFileBrowser/ImGuiFileBrowser.h
@@ -24,6 +24,7 @@ namespace imgui_addons
              * the size, a DialogMode enum value defining in which mode the dialog should operate and optionally the extensions that are valid for opening.
              * Note that the select directory mode doesn't need any extensions.
              */
+            void setCurrentPath(const std::string& path);
             bool showFileDialog(const std::string& label, const DialogMode mode, const ImVec2& sz_xy = ImVec2(0,0), const std::string& valid_types = "*.*");
 
             /* Store the opened/saved file name or dir name (incase of selectDirectoryDialog) and the absolute path to the selection
@@ -31,6 +32,7 @@ namespace imgui_addons
              */
             std::string selected_fn;
             std::string selected_path;
+            std::string selected_dir;
             std::string ext;    // Store the saved file extension
 
 

--- a/soh/soh/ImGuiFileBrowser/dirent.h
+++ b/soh/soh/ImGuiFileBrowser/dirent.h
@@ -1,0 +1,1160 @@
+/*
+ * Dirent interface for Microsoft Visual Studio
+ * Version 1.23.1
+ *
+ * Copyright (C) 2006-2012 Toni Ronkko
+ * This file is part of dirent.  Dirent may be freely distributed
+ * under the MIT license.  For all details and documentation, see
+ * https://github.com/tronkko/dirent
+ */
+#ifndef DIRENT_H
+#define DIRENT_H
+
+/*
+ * Include windows.h without Windows Sockets 1.1 to prevent conflicts with
+ * Windows Sockets 2.0.
+ */
+#ifndef WIN32_LEAN_AND_MEAN
+#   define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+
+#include <stdio.h>
+#include <stdarg.h>
+#include <wchar.h>
+#include <string.h>
+#include <stdlib.h>
+#include <malloc.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <errno.h>
+
+/* Indicates that d_type field is available in dirent structure */
+#define _DIRENT_HAVE_D_TYPE
+
+/* Indicates that d_namlen field is available in dirent structure */
+#define _DIRENT_HAVE_D_NAMLEN
+
+/* Entries missing from MSVC 6.0 */
+#if !defined(FILE_ATTRIBUTE_DEVICE)
+#   define FILE_ATTRIBUTE_DEVICE 0x40
+#endif
+
+/* File type and permission flags for stat(), general mask */
+#if !defined(S_IFMT)
+#   define S_IFMT _S_IFMT
+#endif
+
+/* Directory bit */
+#if !defined(S_IFDIR)
+#   define S_IFDIR _S_IFDIR
+#endif
+
+/* Character device bit */
+#if !defined(S_IFCHR)
+#   define S_IFCHR _S_IFCHR
+#endif
+
+/* Pipe bit */
+#if !defined(S_IFFIFO)
+#   define S_IFFIFO _S_IFFIFO
+#endif
+
+/* Regular file bit */
+#if !defined(S_IFREG)
+#   define S_IFREG _S_IFREG
+#endif
+
+/* Read permission */
+#if !defined(S_IREAD)
+#   define S_IREAD _S_IREAD
+#endif
+
+/* Write permission */
+#if !defined(S_IWRITE)
+#   define S_IWRITE _S_IWRITE
+#endif
+
+/* Execute permission */
+#if !defined(S_IEXEC)
+#   define S_IEXEC _S_IEXEC
+#endif
+
+/* Pipe */
+#if !defined(S_IFIFO)
+#   define S_IFIFO _S_IFIFO
+#endif
+
+/* Block device */
+#if !defined(S_IFBLK)
+#   define S_IFBLK 0
+#endif
+
+/* Link */
+#if !defined(S_IFLNK)
+#   define S_IFLNK 0
+#endif
+
+/* Socket */
+#if !defined(S_IFSOCK)
+#   define S_IFSOCK 0
+#endif
+
+/* Read user permission */
+#if !defined(S_IRUSR)
+#   define S_IRUSR S_IREAD
+#endif
+
+/* Write user permission */
+#if !defined(S_IWUSR)
+#   define S_IWUSR S_IWRITE
+#endif
+
+/* Execute user permission */
+#if !defined(S_IXUSR)
+#   define S_IXUSR 0
+#endif
+
+/* Read group permission */
+#if !defined(S_IRGRP)
+#   define S_IRGRP 0
+#endif
+
+/* Write group permission */
+#if !defined(S_IWGRP)
+#   define S_IWGRP 0
+#endif
+
+/* Execute group permission */
+#if !defined(S_IXGRP)
+#   define S_IXGRP 0
+#endif
+
+/* Read others permission */
+#if !defined(S_IROTH)
+#   define S_IROTH 0
+#endif
+
+/* Write others permission */
+#if !defined(S_IWOTH)
+#   define S_IWOTH 0
+#endif
+
+/* Execute others permission */
+#if !defined(S_IXOTH)
+#   define S_IXOTH 0
+#endif
+
+/* Maximum length of file name */
+#if !defined(PATH_MAX)
+#   define PATH_MAX MAX_PATH
+#endif
+#if !defined(FILENAME_MAX)
+#   define FILENAME_MAX MAX_PATH
+#endif
+#if !defined(NAME_MAX)
+#   define NAME_MAX FILENAME_MAX
+#endif
+
+/* File type flags for d_type */
+#define DT_UNKNOWN 0
+#define DT_REG S_IFREG
+#define DT_DIR S_IFDIR
+#define DT_FIFO S_IFIFO
+#define DT_SOCK S_IFSOCK
+#define DT_CHR S_IFCHR
+#define DT_BLK S_IFBLK
+#define DT_LNK S_IFLNK
+
+/* Macros for converting between st_mode and d_type */
+#define IFTODT(mode) ((mode) & S_IFMT)
+#define DTTOIF(type) (type)
+
+/*
+ * File type macros.  Note that block devices, sockets and links cannot be
+ * distinguished on Windows and the macros S_ISBLK, S_ISSOCK and S_ISLNK are
+ * only defined for compatibility.  These macros should always return false
+ * on Windows.
+ */
+#if !defined(S_ISFIFO)
+#   define S_ISFIFO(mode) (((mode) & S_IFMT) == S_IFIFO)
+#endif
+#if !defined(S_ISDIR)
+#   define S_ISDIR(mode) (((mode) & S_IFMT) == S_IFDIR)
+#endif
+#if !defined(S_ISREG)
+#   define S_ISREG(mode) (((mode) & S_IFMT) == S_IFREG)
+#endif
+#if !defined(S_ISLNK)
+#   define S_ISLNK(mode) (((mode) & S_IFMT) == S_IFLNK)
+#endif
+#if !defined(S_ISSOCK)
+#   define S_ISSOCK(mode) (((mode) & S_IFMT) == S_IFSOCK)
+#endif
+#if !defined(S_ISCHR)
+#   define S_ISCHR(mode) (((mode) & S_IFMT) == S_IFCHR)
+#endif
+#if !defined(S_ISBLK)
+#   define S_ISBLK(mode) (((mode) & S_IFMT) == S_IFBLK)
+#endif
+
+/* Return the exact length of the file name without zero terminator */
+#define _D_EXACT_NAMLEN(p) ((p)->d_namlen)
+
+/* Return the maximum size of a file name */
+#define _D_ALLOC_NAMLEN(p) ((PATH_MAX)+1)
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/* Wide-character version */
+struct _wdirent {
+    /* Always zero */
+    long d_ino;
+
+    /* File position within stream */
+    long d_off;
+
+    /* Structure size */
+    unsigned short d_reclen;
+
+    /* Length of name without \0 */
+    size_t d_namlen;
+
+    /* File type */
+    int d_type;
+
+    /* File name */
+    wchar_t d_name[PATH_MAX+1];
+};
+typedef struct _wdirent _wdirent;
+
+struct _WDIR {
+    /* Current directory entry */
+    struct _wdirent ent;
+
+    /* Private file data */
+    WIN32_FIND_DATAW data;
+
+    /* True if data is valid */
+    int cached;
+
+    /* Win32 search handle */
+    HANDLE handle;
+
+    /* Initial directory name */
+    wchar_t *patt;
+};
+typedef struct _WDIR _WDIR;
+
+/* Multi-byte character version */
+struct dirent {
+    /* Always zero */
+    long d_ino;
+
+    /* File position within stream */
+    long d_off;
+
+    /* Structure size */
+    unsigned short d_reclen;
+
+    /* Length of name without \0 */
+    size_t d_namlen;
+
+    /* File type */
+    int d_type;
+
+    /* File name */
+    char d_name[PATH_MAX+1];
+};
+typedef struct dirent dirent;
+
+struct DIR {
+    struct dirent ent;
+    struct _WDIR *wdirp;
+};
+typedef struct DIR DIR;
+
+
+/* Dirent functions */
+static DIR *opendir (const char *dirname);
+static _WDIR *_wopendir (const wchar_t *dirname);
+
+static struct dirent *readdir (DIR *dirp);
+static struct _wdirent *_wreaddir (_WDIR *dirp);
+
+static int readdir_r(
+    DIR *dirp, struct dirent *entry, struct dirent **result);
+static int _wreaddir_r(
+    _WDIR *dirp, struct _wdirent *entry, struct _wdirent **result);
+
+static int closedir (DIR *dirp);
+static int _wclosedir (_WDIR *dirp);
+
+static void rewinddir (DIR* dirp);
+static void _wrewinddir (_WDIR* dirp);
+
+static int scandir (const char *dirname, struct dirent ***namelist,
+    int (*filter)(const struct dirent*),
+    int (*compare)(const struct dirent**, const struct dirent**));
+
+static int alphasort (const struct dirent **a, const struct dirent **b);
+
+static int versionsort (const struct dirent **a, const struct dirent **b);
+
+
+/* For compatibility with Symbian */
+#define wdirent _wdirent
+#define WDIR _WDIR
+#define wopendir _wopendir
+#define wreaddir _wreaddir
+#define wclosedir _wclosedir
+#define wrewinddir _wrewinddir
+
+
+/* Internal utility functions */
+static WIN32_FIND_DATAW *dirent_first (_WDIR *dirp);
+static WIN32_FIND_DATAW *dirent_next (_WDIR *dirp);
+
+static int dirent_mbstowcs_s(
+    size_t *pReturnValue,
+    wchar_t *wcstr,
+    size_t sizeInWords,
+    const char *mbstr,
+    size_t count);
+
+static int dirent_wcstombs_s(
+    size_t *pReturnValue,
+    char *mbstr,
+    size_t sizeInBytes,
+    const wchar_t *wcstr,
+    size_t count);
+
+static void dirent_set_errno (int error);
+
+
+/*
+ * Open directory stream DIRNAME for read and return a pointer to the
+ * internal working area that is used to retrieve individual directory
+ * entries.
+ */
+static _WDIR*
+_wopendir(
+    const wchar_t *dirname)
+{
+    _WDIR *dirp = NULL;
+    int error;
+
+    /* Must have directory name */
+    if (dirname == NULL  ||  dirname[0] == '\0') {
+        dirent_set_errno (ENOENT);
+        return NULL;
+    }
+
+    /* Allocate new _WDIR structure */
+    dirp = (_WDIR*) malloc (sizeof (struct _WDIR));
+    if (dirp != NULL) {
+        DWORD n;
+
+        /* Reset _WDIR structure */
+        dirp->handle = INVALID_HANDLE_VALUE;
+        dirp->patt = NULL;
+        dirp->cached = 0;
+
+        /* Compute the length of full path plus zero terminator
+         *
+         * Note that on WinRT there's no way to convert relative paths
+         * into absolute paths, so just assume it is an absolute path.
+         */
+#       if defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP)
+            n = wcslen(dirname);
+#       else
+            n = GetFullPathNameW (dirname, 0, NULL, NULL);
+#       endif
+
+        /* Allocate room for absolute directory name and search pattern */
+        dirp->patt = (wchar_t*) malloc (sizeof (wchar_t) * n + 16);
+        if (dirp->patt) {
+
+            /*
+             * Convert relative directory name to an absolute one.  This
+             * allows rewinddir() to function correctly even when current
+             * working directory is changed between opendir() and rewinddir().
+             *
+             * Note that on WinRT there's no way to convert relative paths
+             * into absolute paths, so just assume it is an absolute path.
+             */
+#           if defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP)
+                wcsncpy_s(dirp->patt, n+1, dirname, n);
+#           else
+                n = GetFullPathNameW (dirname, n, dirp->patt, NULL);
+#           endif
+            if (n > 0) {
+                wchar_t *p;
+
+                /* Append search pattern \* to the directory name */
+                p = dirp->patt + n;
+                if (dirp->patt < p) {
+                    switch (p[-1]) {
+                    case '\\':
+                    case '/':
+                    case ':':
+                        /* Directory ends in path separator, e.g. c:\temp\ */
+                        /*NOP*/;
+                        break;
+
+                    default:
+                        /* Directory name doesn't end in path separator */
+                        *p++ = '\\';
+                    }
+                }
+                *p++ = '*';
+                *p = '\0';
+
+                /* Open directory stream and retrieve the first entry */
+                if (dirent_first (dirp)) {
+                    /* Directory stream opened successfully */
+                    error = 0;
+                } else {
+                    /* Cannot retrieve first entry */
+                    error = 1;
+                    dirent_set_errno (ENOENT);
+                }
+
+            } else {
+                /* Cannot retrieve full path name */
+                dirent_set_errno (ENOENT);
+                error = 1;
+            }
+
+        } else {
+            /* Cannot allocate memory for search pattern */
+            error = 1;
+        }
+
+    } else {
+        /* Cannot allocate _WDIR structure */
+        error = 1;
+    }
+
+    /* Clean up in case of error */
+    if (error  &&  dirp) {
+        _wclosedir (dirp);
+        dirp = NULL;
+    }
+
+    return dirp;
+}
+
+/*
+ * Read next directory entry.
+ *
+ * Returns pointer to static directory entry which may be overwritten by
+ * subsequent calls to _wreaddir().
+ */
+static struct _wdirent*
+_wreaddir(
+    _WDIR *dirp)
+{
+    struct _wdirent *entry;
+
+    /*
+     * Read directory entry to buffer.  We can safely ignore the return value
+     * as entry will be set to NULL in case of error.
+     */
+    (void) _wreaddir_r (dirp, &dirp->ent, &entry);
+
+    /* Return pointer to statically allocated directory entry */
+    return entry;
+}
+
+/*
+ * Read next directory entry.
+ *
+ * Returns zero on success.  If end of directory stream is reached, then sets
+ * result to NULL and returns zero.
+ */
+static int
+_wreaddir_r(
+    _WDIR *dirp,
+    struct _wdirent *entry,
+    struct _wdirent **result)
+{
+    WIN32_FIND_DATAW *datap;
+
+    /* Read next directory entry */
+    datap = dirent_next (dirp);
+    if (datap) {
+        size_t n;
+        DWORD attr;
+
+        /*
+         * Copy file name as wide-character string.  If the file name is too
+         * long to fit in to the destination buffer, then truncate file name
+         * to PATH_MAX characters and zero-terminate the buffer.
+         */
+        n = 0;
+        while (n < PATH_MAX  &&  datap->cFileName[n] != 0) {
+            entry->d_name[n] = datap->cFileName[n];
+            n++;
+        }
+        entry->d_name[n] = 0;
+
+        /* Length of file name excluding zero terminator */
+        entry->d_namlen = n;
+
+        /* File type */
+        attr = datap->dwFileAttributes;
+        if ((attr & FILE_ATTRIBUTE_DEVICE) != 0) {
+            entry->d_type = DT_CHR;
+        } else if ((attr & FILE_ATTRIBUTE_DIRECTORY) != 0) {
+            entry->d_type = DT_DIR;
+        } else {
+            entry->d_type = DT_REG;
+        }
+
+        /* Reset dummy fields */
+        entry->d_ino = 0;
+        entry->d_off = 0;
+        entry->d_reclen = sizeof (struct _wdirent);
+
+        /* Set result address */
+        *result = entry;
+
+    } else {
+
+        /* Return NULL to indicate end of directory */
+        *result = NULL;
+
+    }
+
+    return /*OK*/0;
+}
+
+/*
+ * Close directory stream opened by opendir() function.  This invalidates the
+ * DIR structure as well as any directory entry read previously by
+ * _wreaddir().
+ */
+static int
+_wclosedir(
+    _WDIR *dirp)
+{
+    int ok;
+    if (dirp) {
+
+        /* Release search handle */
+        if (dirp->handle != INVALID_HANDLE_VALUE) {
+            FindClose (dirp->handle);
+            dirp->handle = INVALID_HANDLE_VALUE;
+        }
+
+        /* Release search pattern */
+        if (dirp->patt) {
+            free (dirp->patt);
+            dirp->patt = NULL;
+        }
+
+        /* Release directory structure */
+        free (dirp);
+        ok = /*success*/0;
+
+    } else {
+
+        /* Invalid directory stream */
+        dirent_set_errno (EBADF);
+        ok = /*failure*/-1;
+
+    }
+    return ok;
+}
+
+/*
+ * Rewind directory stream such that _wreaddir() returns the very first
+ * file name again.
+ */
+static void
+_wrewinddir(
+    _WDIR* dirp)
+{
+    if (dirp) {
+        /* Release existing search handle */
+        if (dirp->handle != INVALID_HANDLE_VALUE) {
+            FindClose (dirp->handle);
+        }
+
+        /* Open new search handle */
+        dirent_first (dirp);
+    }
+}
+
+/* Get first directory entry (internal) */
+static WIN32_FIND_DATAW*
+dirent_first(
+    _WDIR *dirp)
+{
+    WIN32_FIND_DATAW *datap;
+
+    /* Open directory and retrieve the first entry */
+    dirp->handle = FindFirstFileExW(
+        dirp->patt, FindExInfoStandard, &dirp->data,
+        FindExSearchNameMatch, NULL, 0);
+    if (dirp->handle != INVALID_HANDLE_VALUE) {
+
+        /* a directory entry is now waiting in memory */
+        datap = &dirp->data;
+        dirp->cached = 1;
+
+    } else {
+
+        /* Failed to re-open directory: no directory entry in memory */
+        dirp->cached = 0;
+        datap = NULL;
+
+    }
+    return datap;
+}
+
+/*
+ * Get next directory entry (internal).
+ *
+ * Returns 
+ */
+static WIN32_FIND_DATAW*
+dirent_next(
+    _WDIR *dirp)
+{
+    WIN32_FIND_DATAW *p;
+
+    /* Get next directory entry */
+    if (dirp->cached != 0) {
+
+        /* A valid directory entry already in memory */
+        p = &dirp->data;
+        dirp->cached = 0;
+
+    } else if (dirp->handle != INVALID_HANDLE_VALUE) {
+
+        /* Get the next directory entry from stream */
+        if (FindNextFileW (dirp->handle, &dirp->data) != FALSE) {
+            /* Got a file */
+            p = &dirp->data;
+        } else {
+            /* The very last entry has been processed or an error occurred */
+            FindClose (dirp->handle);
+            dirp->handle = INVALID_HANDLE_VALUE;
+            p = NULL;
+        }
+
+    } else {
+
+        /* End of directory stream reached */
+        p = NULL;
+
+    }
+
+    return p;
+}
+
+/*
+ * Open directory stream using plain old C-string.
+ */
+static DIR*
+opendir(
+    const char *dirname) 
+{
+    struct DIR *dirp;
+    int error;
+
+    /* Must have directory name */
+    if (dirname == NULL  ||  dirname[0] == '\0') {
+        dirent_set_errno (ENOENT);
+        return NULL;
+    }
+
+    /* Allocate memory for DIR structure */
+    dirp = (DIR*) malloc (sizeof (struct DIR));
+    if (dirp) {
+        wchar_t wname[PATH_MAX + 1];
+        size_t n;
+
+        /* Convert directory name to wide-character string */
+        error = dirent_mbstowcs_s(
+            &n, wname, PATH_MAX + 1, dirname, PATH_MAX + 1);
+        if (!error) {
+
+            /* Open directory stream using wide-character name */
+            dirp->wdirp = _wopendir (wname);
+            if (dirp->wdirp) {
+                /* Directory stream opened */
+                error = 0;
+            } else {
+                /* Failed to open directory stream */
+                error = 1;
+            }
+
+        } else {
+            /*
+             * Cannot convert file name to wide-character string.  This
+             * occurs if the string contains invalid multi-byte sequences or
+             * the output buffer is too small to contain the resulting
+             * string.
+             */
+            error = 1;
+        }
+
+    } else {
+        /* Cannot allocate DIR structure */
+        error = 1;
+    }
+
+    /* Clean up in case of error */
+    if (error  &&  dirp) {
+        free (dirp);
+        dirp = NULL;
+    }
+
+    return dirp;
+}
+
+/*
+ * Read next directory entry.
+ */
+static struct dirent*
+readdir(
+    DIR *dirp)
+{
+    struct dirent *entry;
+
+    /*
+     * Read directory entry to buffer.  We can safely ignore the return value
+     * as entry will be set to NULL in case of error.
+     */
+    (void) readdir_r (dirp, &dirp->ent, &entry);
+
+    /* Return pointer to statically allocated directory entry */
+    return entry;
+}
+
+/*
+ * Read next directory entry into called-allocated buffer.
+ *
+ * Returns zero on success.  If the end of directory stream is reached, then
+ * sets result to NULL and returns zero.
+ */
+static int
+readdir_r(
+    DIR *dirp,
+    struct dirent *entry,
+    struct dirent **result)
+{
+    WIN32_FIND_DATAW *datap;
+
+    /* Read next directory entry */
+    datap = dirent_next (dirp->wdirp);
+    if (datap) {
+        size_t n;
+        int error;
+
+        /* Attempt to convert file name to multi-byte string */
+        error = dirent_wcstombs_s(
+            &n, entry->d_name, PATH_MAX + 1, datap->cFileName, PATH_MAX + 1);
+
+        /*
+         * If the file name cannot be represented by a multi-byte string,
+         * then attempt to use old 8+3 file name.  This allows traditional
+         * Unix-code to access some file names despite of unicode
+         * characters, although file names may seem unfamiliar to the user.
+         *
+         * Be ware that the code below cannot come up with a short file
+         * name unless the file system provides one.  At least
+         * VirtualBox shared folders fail to do this.
+         */
+        if (error  &&  datap->cAlternateFileName[0] != '\0') {
+            error = dirent_wcstombs_s(
+                &n, entry->d_name, PATH_MAX + 1,
+                datap->cAlternateFileName, PATH_MAX + 1);
+        }
+
+        if (!error) {
+            DWORD attr;
+
+            /* Length of file name excluding zero terminator */
+            entry->d_namlen = n - 1;
+
+            /* File attributes */
+            attr = datap->dwFileAttributes;
+            if ((attr & FILE_ATTRIBUTE_DEVICE) != 0) {
+                entry->d_type = DT_CHR;
+            } else if ((attr & FILE_ATTRIBUTE_DIRECTORY) != 0) {
+                entry->d_type = DT_DIR;
+            } else {
+                entry->d_type = DT_REG;
+            }
+
+            /* Reset dummy fields */
+            entry->d_ino = 0;
+            entry->d_off = 0;
+            entry->d_reclen = sizeof (struct dirent);
+
+        } else {
+
+            /*
+             * Cannot convert file name to multi-byte string so construct
+             * an erroneous directory entry and return that.  Note that
+             * we cannot return NULL as that would stop the processing
+             * of directory entries completely.
+             */
+            entry->d_name[0] = '?';
+            entry->d_name[1] = '\0';
+            entry->d_namlen = 1;
+            entry->d_type = DT_UNKNOWN;
+            entry->d_ino = 0;
+            entry->d_off = -1;
+            entry->d_reclen = 0;
+
+        }
+
+        /* Return pointer to directory entry */
+        *result = entry;
+
+    } else {
+
+        /* No more directory entries */
+        *result = NULL;
+
+    }
+
+    return /*OK*/0;
+}
+
+/*
+ * Close directory stream.
+ */
+static int
+closedir(
+    DIR *dirp)
+{
+    int ok;
+    if (dirp) {
+
+        /* Close wide-character directory stream */
+        ok = _wclosedir (dirp->wdirp);
+        dirp->wdirp = NULL;
+
+        /* Release multi-byte character version */
+        free (dirp);
+
+    } else {
+
+        /* Invalid directory stream */
+        dirent_set_errno (EBADF);
+        ok = /*failure*/-1;
+
+    }
+    return ok;
+}
+
+/*
+ * Rewind directory stream to beginning.
+ */
+static void
+rewinddir(
+    DIR* dirp)
+{
+    /* Rewind wide-character string directory stream */
+    _wrewinddir (dirp->wdirp);
+}
+
+/*
+ * Scan directory for entries.
+ */
+static int
+scandir(
+    const char *dirname,
+    struct dirent ***namelist,
+    int (*filter)(const struct dirent*),
+    int (*compare)(const struct dirent**, const struct dirent**))
+{
+    struct dirent **files = NULL;
+    size_t size = 0;
+    size_t allocated = 0;
+    const size_t init_size = 1;
+    DIR *dir = NULL;
+    struct dirent *entry;
+    struct dirent *tmp = NULL;
+    size_t i;
+    int result = 0;
+
+    /* Open directory stream */
+    dir = opendir (dirname);
+    if (dir) {
+
+        /* Read directory entries to memory */
+        while (1) {
+
+            /* Enlarge pointer table to make room for another pointer */
+            if (size >= allocated) {
+                void *p;
+                size_t num_entries;
+
+                /* Compute number of entries in the enlarged pointer table */
+                if (size < init_size) {
+                    /* Allocate initial pointer table */
+                    num_entries = init_size;
+                } else {
+                    /* Double the size */
+                    num_entries = size * 2;
+                }
+
+                /* Allocate first pointer table or enlarge existing table */
+                p = realloc (files, sizeof (void*) * num_entries);
+                if (p != NULL) {
+                    /* Got the memory */
+                    files = (dirent**) p;
+                    allocated = num_entries;
+                } else {
+                    /* Out of memory */
+                    result = -1;
+                    break;
+                }
+
+            }
+
+            /* Allocate room for temporary directory entry */
+            if (tmp == NULL) {
+                tmp = (struct dirent*) malloc (sizeof (struct dirent));
+                if (tmp == NULL) {
+                    /* Cannot allocate temporary directory entry */
+                    result = -1;
+                    break;
+                }
+            }
+
+            /* Read directory entry to temporary area */
+            if (readdir_r (dir, tmp, &entry) == /*OK*/0) {
+
+                /* Did we get an entry? */
+                if (entry != NULL) {
+                    int pass;
+
+                    /* Determine whether to include the entry in result */
+                    if (filter) {
+                        /* Let the filter function decide */
+                        pass = filter (tmp);
+                    } else {
+                        /* No filter function, include everything */
+                        pass = 1;
+                    }
+
+                    if (pass) {
+                        /* Store the temporary entry to pointer table */
+                        files[size++] = tmp;
+                        tmp = NULL;
+
+                        /* Keep up with the number of files */
+                        result++;
+                    }
+
+                } else {
+
+                    /*
+                     * End of directory stream reached => sort entries and
+                     * exit.
+                     */
+                    qsort (files, size, sizeof (void*),
+                        (int (*) (const void*, const void*)) compare);
+                    break;
+
+                }
+
+            } else {
+                /* Error reading directory entry */
+                result = /*Error*/ -1;
+                break;
+            }
+
+        }
+
+    } else {
+        /* Cannot open directory */
+        result = /*Error*/ -1;
+    }
+
+    /* Release temporary directory entry */
+    if (tmp) {
+        free (tmp);
+    }
+
+    /* Release allocated memory on error */
+    if (result < 0) {
+        for (i = 0; i < size; i++) {
+            free (files[i]);
+        }
+        free (files);
+        files = NULL;
+    }
+
+    /* Close directory stream */
+    if (dir) {
+        closedir (dir);
+    }
+
+    /* Pass pointer table to caller */
+    if (namelist) {
+        *namelist = files;
+    }
+    return result;
+}
+
+/* Alphabetical sorting */
+static int
+alphasort(
+    const struct dirent **a, const struct dirent **b)
+{
+    return strcoll ((*a)->d_name, (*b)->d_name);
+}
+
+/* Sort versions */
+static int
+versionsort(
+    const struct dirent **a, const struct dirent **b)
+{
+    /* FIXME: implement strverscmp and use that */
+    return alphasort (a, b);
+}
+
+
+/* Convert multi-byte string to wide character string */
+static int
+dirent_mbstowcs_s(
+    size_t *pReturnValue,
+    wchar_t *wcstr,
+    size_t sizeInWords,
+    const char *mbstr,
+    size_t count)
+{
+    int error;
+
+#if defined(_MSC_VER)  &&  _MSC_VER >= 1400
+
+    /* Microsoft Visual Studio 2005 or later */
+    error = mbstowcs_s (pReturnValue, wcstr, sizeInWords, mbstr, count);
+
+#else
+
+    /* Older Visual Studio or non-Microsoft compiler */
+    size_t n;
+
+    /* Convert to wide-character string (or count characters) */
+    n = mbstowcs (wcstr, mbstr, sizeInWords);
+    if (!wcstr  ||  n < count) {
+
+        /* Zero-terminate output buffer */
+        if (wcstr  &&  sizeInWords) {
+            if (n >= sizeInWords) {
+                n = sizeInWords - 1;
+            }
+            wcstr[n] = 0;
+        }
+
+        /* Length of resulting multi-byte string WITH zero terminator */
+        if (pReturnValue) {
+            *pReturnValue = n + 1;
+        }
+
+        /* Success */
+        error = 0;
+
+    } else {
+
+        /* Could not convert string */
+        error = 1;
+
+    }
+
+#endif
+
+    return error;
+}
+
+/* Convert wide-character string to multi-byte string */
+static int
+dirent_wcstombs_s(
+    size_t *pReturnValue,
+    char *mbstr,
+    size_t sizeInBytes, /* max size of mbstr */
+    const wchar_t *wcstr,
+    size_t count)
+{
+    int error;
+
+#if defined(_MSC_VER)  &&  _MSC_VER >= 1400
+
+    /* Microsoft Visual Studio 2005 or later */
+    error = wcstombs_s (pReturnValue, mbstr, sizeInBytes, wcstr, count);
+
+#else
+
+    /* Older Visual Studio or non-Microsoft compiler */
+    size_t n;
+
+    /* Convert to multi-byte string (or count the number of bytes needed) */
+    n = wcstombs (mbstr, wcstr, sizeInBytes);
+    if (!mbstr  ||  n < count) {
+
+        /* Zero-terminate output buffer */
+        if (mbstr  &&  sizeInBytes) {
+            if (n >= sizeInBytes) {
+                n = sizeInBytes - 1;
+            }
+            mbstr[n] = '\0';
+        }
+
+        /* Length of resulting multi-bytes string WITH zero-terminator */
+        if (pReturnValue) {
+            *pReturnValue = n + 1;
+        }
+
+        /* Success */
+        error = 0;
+
+    } else {
+
+        /* Cannot convert string */
+        error = 1;
+
+    }
+
+#endif
+
+    return error;
+}
+
+/* Set errno variable */
+static void
+dirent_set_errno(
+    int error)
+{
+#if defined(_MSC_VER)  &&  _MSC_VER >= 1400
+
+    /* Microsoft Visual Studio 2005 and later */
+    _set_errno (error);
+
+#else
+
+    /* Non-Microsoft compiler or older Microsoft compiler */
+    errno = error;
+
+#endif
+}
+
+
+#ifdef __cplusplus
+}
+#endif
+#endif /*DIRENT_H*/
+


### PR DESCRIPTION
Adds a button to open a file picker dialog to be able to open a spoiler file instead of having to drag and drop onto the game window. Picker is threaded so the game can keep running, but adds `pickingSpoiler` to the check to disable the Randomizer Settings window while it's open. No idea if this does anything on Switch or Wii U, but might need to be #ifdef'd out for those platforms until some platform-specific option can be implemented (which I want to do, because the main point of this is to be available for platforms that can't drag and drop).

Also adds `SpoilerError` which plays an error sound and resets "gSpoilerLog" to blank ("None" in practice) so that it's more obvious that loading the spoiler file failed. Called from any catch portion of `try ... catch` blocks in the file parsing chain.

Todo: Needs testing on every platform other than Windows.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1029773363.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1029773364.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1029773365.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1029773366.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1029773367.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1029773369.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1029773370.zip)
<!--- section:artifacts:end -->