### PR TITLE
[Modding Improvement] Improved Bottle Loading

### DIFF
--- a/soh/assets/soh_assets.h
+++ b/soh/assets/soh_assets.h
@@ -56,6 +56,13 @@ static const ALIGN_ASSET(2) char gTriforcePiece2DL[] = dgTriforcePiece2DL;
 #define dgTriforcePieceCompletedDL "__OTR__objects/object_triforce_completed/gTriforcePieceCompletedDL"
 static const ALIGN_ASSET(2) char gTriforcePieceCompletedDL[] = dgTriforcePieceCompletedDL;
 
+#define dgLinkBottleDL "__OTR__objects/object_link_eq/gLinkBottleDL"
+static const ALIGN_ASSET(2) char gLinkBottleDL[] = dgLinkBottleDL;
+
+#define dgLinkBottleContentsDL "__OTR__objects/object_link_eq/gLinkBottleContentsDL"
+static const ALIGN_ASSET(2) char gLinkBottleContentsDL[] = dgLinkBottleContentsDL;
+
+
 // overlays
 #define dgOptionsDividerChangeLangVtx "__OTR__overlays/ovl_file_choose/gOptionsDividerChangeLangVtx"
 static const ALIGN_ASSET(2) char gOptionsDividerChangeLangVtx[] = dgOptionsDividerChangeLangVtx;


### PR DESCRIPTION
Derived from code originally in #3002.

This PR does one thing, which is improving how the game can load bottles for modding. This introduces 2 new mod-only DisplayLists:

- gLinkBottleDL in objects/object_link_eq
- gLinkBottleContentsDL in objects/object_link_eq

This allows both ages of Link to use the same bottle DL, as the two already used near identical meshes in the first place, and allows for the colored contents of bottles to be its own mesh, just like in Majora's Mask and its remake.


![image](https://github.com/HarbourMasters/Shipwright/assets/46070717/df5638a8-00b5-4ea7-be7d-c7af2656313c)
![image](https://github.com/HarbourMasters/Shipwright/assets/46070717/782f3da0-7c5c-49c0-8c48-5f31de87a56e)


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1023065321.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1023065323.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1023065327.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1023065328.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1023065329.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1023065330.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1023065331.zip)
<!--- section:artifacts:end -->