### PR TITLE
ADD: No HUD Heart animation

### DIFF
--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -834,6 +834,7 @@ void DrawEnhancementsMenu() {
                 UIWidgets::Tooltip("Disables the voice audio when Navi calls you");
                 UIWidgets::PaddedEnhancementCheckbox("Disable Hot/Underwater Warning Text", "gDisableTunicWarningText", true, false);
                 UIWidgets::Tooltip("Disables warning text when you don't have on the Goron/Zora Tunic in Hot/Underwater conditions.");
+                
                 ImGui::EndMenu();
             }
 

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -834,7 +834,8 @@ void DrawEnhancementsMenu() {
                 UIWidgets::Tooltip("Disables the voice audio when Navi calls you");
                 UIWidgets::PaddedEnhancementCheckbox("Disable Hot/Underwater Warning Text", "gDisableTunicWarningText", true, false);
                 UIWidgets::Tooltip("Disables warning text when you don't have on the Goron/Zora Tunic in Hot/Underwater conditions.");
-
+                UIWidgets::PaddedEnhancementCheckbox("Disable HUD Heart animations", "gNoHUDHeartAnimation", true, false);
+                UIWidgets::Tooltip("Disables the beating animation of the hearts on the HUD.");
                 ImGui::EndMenu();
             }
 

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -834,8 +834,6 @@ void DrawEnhancementsMenu() {
                 UIWidgets::Tooltip("Disables the voice audio when Navi calls you");
                 UIWidgets::PaddedEnhancementCheckbox("Disable Hot/Underwater Warning Text", "gDisableTunicWarningText", true, false);
                 UIWidgets::Tooltip("Disables warning text when you don't have on the Goron/Zora Tunic in Hot/Underwater conditions.");
-                UIWidgets::PaddedEnhancementCheckbox("Disable HUD Heart animations", "gNoHUDHeartAnimation", true, false);
-                UIWidgets::Tooltip("Disables the beating animation of the hearts on the HUD.");
                 ImGui::EndMenu();
             }
 
@@ -904,6 +902,8 @@ void DrawEnhancementsMenu() {
                 UIWidgets::Tooltip("Disables grottos rotating with the camera. To be used in conjunction with mods that want to replace grottos with 3D objects.");
                 UIWidgets::PaddedEnhancementCheckbox("Invisible Bunny Hood", "gHideBunnyHood", true, false);
                 UIWidgets::Tooltip("Turns Bunny Hood invisible while still maintaining its effects.");
+                UIWidgets::PaddedEnhancementCheckbox("Disable HUD Heart animations", "gNoHUDHeartAnimation", true, false);
+                UIWidgets::Tooltip("Disables the beating animation of the hearts on the HUD.");
 
                 ImGui::EndMenu();
             }

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -834,7 +834,7 @@ void DrawEnhancementsMenu() {
                 UIWidgets::Tooltip("Disables the voice audio when Navi calls you");
                 UIWidgets::PaddedEnhancementCheckbox("Disable Hot/Underwater Warning Text", "gDisableTunicWarningText", true, false);
                 UIWidgets::Tooltip("Disables warning text when you don't have on the Goron/Zora Tunic in Hot/Underwater conditions.");
-                
+
                 ImGui::EndMenu();
             }
 

--- a/soh/src/code/z_lifemeter.c
+++ b/soh/src/code/z_lifemeter.c
@@ -602,7 +602,7 @@ void HealthMeter_Draw(PlayState* play) {
             {
                 Mtx* matrix = Graph_Alloc(gfxCtx, sizeof(Mtx));
                 
-                if (CVarGetInteger("gNoHUDHeartAnimation", 1)) {
+                if (CVarGetInteger("gNoHUDHeartAnimation", 0)) {
                     Matrix_SetTranslateScaleMtx2(matrix,
                         HeartsScale,          // Scale X
                         HeartsScale,          // Scale Y

--- a/soh/src/code/z_lifemeter.c
+++ b/soh/src/code/z_lifemeter.c
@@ -601,13 +601,24 @@ void HealthMeter_Draw(PlayState* play) {
 
             {
                 Mtx* matrix = Graph_Alloc(gfxCtx, sizeof(Mtx));
-                Matrix_SetTranslateScaleMtx2(matrix, 
-                HeartsScale+(HeartsScale/3) - ((HeartsScale/3) * sp144), 
-                HeartsScale+(HeartsScale/3) - ((HeartsScale/3) * sp144),
-                HeartsScale+(HeartsScale/3) - ((HeartsScale/3) * sp144), 
-                -130+offsetX, //Pos X
-                (-94+offsetY) *-1, //Pos Y
-                0.0f);
+                
+                if (CVarGetInteger("gNoHUDHeartAnimation", 1)) {
+                    Matrix_SetTranslateScaleMtx2(matrix,
+                        HeartsScale,          // Scale X
+                        HeartsScale,          // Scale Y
+                        HeartsScale,          // Scale Z
+                        -130 + offsetX,       // Pos X
+                        (-94 + offsetY) * -1, // Pos Y
+                        0.0f);
+                } else {
+                    Matrix_SetTranslateScaleMtx2(matrix, HeartsScale + (HeartsScale / 3) - ((HeartsScale / 3) * sp144),
+                        HeartsScale + (HeartsScale / 3) - ((HeartsScale / 3) * sp144),
+                        HeartsScale + (HeartsScale / 3) - ((HeartsScale / 3) * sp144),
+                        -130 + offsetX,       // Pos X
+                        (-94 + offsetY) * -1, // Pos Y
+                        0.0f);
+                }
+
                 gSPMatrix(OVERLAY_DISP++, matrix, G_MTX_MODELVIEW | G_MTX_LOAD);
                 gSPVertex(OVERLAY_DISP++, sp154, 4, 0);
                 gSP1Quadrangle(OVERLAY_DISP++, 0, 2, 3, 1, 0);


### PR DESCRIPTION
I've seen this requested multiple times for modding purposes for the case of using "lifebars" instead of hearts


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1044694217.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1044694218.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1044694222.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1044694223.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1044694224.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1044694225.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1044694226.zip)
<!--- section:artifacts:end -->