### PR TITLE
Fix: Master Sword shuffle check and logic conditions

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_castle_town.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_castle_town.cpp
@@ -52,7 +52,6 @@ void AreaTable_Init_CastleTown() {
 
   areaTable[TEMPLE_OF_TIME] = Area("Temple of Time", "Temple of Time", TEMPLE_OF_TIME, NO_DAY_NIGHT_CYCLE, {}, {
                   //Locations
-                  LocationAccess(TOT_MASTER_SWORD, {[]{return IsAdult;}}),
                   LocationAccess(TOT_LIGHT_ARROWS_CUTSCENE, {[]{return IsAdult && CanTriggerLACS;}}),
                 }, {
                   //Exits
@@ -65,6 +64,7 @@ void AreaTable_Init_CastleTown() {
                   //EventAccess(&TimeTravel, {[]{return true;}}),
                 }, {
                   //Locations
+                  LocationAccess(TOT_MASTER_SWORD, {[]{return IsAdult;}}),
                   LocationAccess(SHEIK_AT_TEMPLE, {[]{return ForestMedallion && IsAdult;}}),
                 }, {
                   //Exits

--- a/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_gerudo_training_grounds.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_gerudo_training_grounds.cpp
@@ -69,7 +69,7 @@ void AreaTable_Init_GerudoTrainingGrounds() {
 
   areaTable[GERUDO_TRAINING_GROUNDS_HAMMER_ROOM] = Area("Gerudo Training Grounds Hammer Room", "Gerudo Training Grounds", GERUDO_TRAINING_GROUNDS, NO_DAY_NIGHT_CYCLE, {}, {
                   //Locations
-                  LocationAccess(GERUDO_TRAINING_GROUNDS_HAMMER_ROOM_CLEAR_CHEST,  {[]{return CanUse(KOKIRI_SWORD) || CanUse(MASTER_SWORD) || CanUse(BIGGORON_SWORD) || CanUse(MEGATON_HAMMER);}}),
+                  LocationAccess(GERUDO_TRAINING_GROUNDS_HAMMER_ROOM_CLEAR_CHEST,  {[]{return CanAdultAttack || CanChildAttack;}}),
                   LocationAccess(GERUDO_TRAINING_GROUNDS_HAMMER_ROOM_SWITCH_CHEST, {[]{return CanUse(MEGATON_HAMMER) || (CanTakeDamage && LogicFlamingChests);}}),
                 }, {
                   //Exits

--- a/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_ice_cavern.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_ice_cavern.cpp
@@ -13,7 +13,7 @@ void AreaTable_Init_IceCavern() {
   areaTable[ICE_CAVERN_ENTRYWAY] = Area("Ice Cavern Entryway", "Ice Cavern", ICE_CAVERN, NO_DAY_NIGHT_CYCLE, {}, {}, {
                   //Exits
                   Entrance(ICE_CAVERN_BEGINNING,    {[]{return Dungeon::IceCavern.IsVanilla();}}),
-                  Entrance(ICE_CAVERN_MQ_BEGINNING, {[]{return Dungeon::IceCavern.IsMQ() && CanUseProjectile;}}),
+                  Entrance(ICE_CAVERN_MQ_BEGINNING, {[]{return Dungeon::IceCavern.IsMQ();}}),
                   Entrance(ZORAS_FOUNTAIN,          {[]{return true;}}),
   });
 
@@ -24,7 +24,7 @@ void AreaTable_Init_IceCavern() {
   areaTable[ICE_CAVERN_BEGINNING] = Area("Ice Cavern Beginning", "Ice Cavern", ICE_CAVERN, NO_DAY_NIGHT_CYCLE, {}, {}, {
                   //Exits
                   Entrance(ICE_CAVERN_ENTRYWAY, {[]{return true;}}),
-                  Entrance(ICE_CAVERN_MAIN,     {[]{return Here(ICE_CAVERN_BEGINNING, []{return (CanUse(MASTER_SWORD) || CanUse(KOKIRI_SWORD) || CanUse(BIGGORON_SWORD)) || HasExplosives || CanUse(DINS_FIRE);});}}),
+                  Entrance(ICE_CAVERN_MAIN,     {[]{return Here(ICE_CAVERN_BEGINNING, []{return (CanUse(MASTER_SWORD) || CanUse(BIGGORON_SWORD)) || CanUse(RG_MEGATON_HAMMER) || HasExplosives || CanUse(HOOKSHOT) || CanUse(DINS_FIRE);});}}),
   });
 
   areaTable[ICE_CAVERN_MAIN] = Area("Ice Cavern", "Ice Cavern", ICE_CAVERN, NO_DAY_NIGHT_CYCLE, {
@@ -53,7 +53,7 @@ void AreaTable_Init_IceCavern() {
   }, {}, {
                   //Exits
                   Entrance(ICE_CAVERN_ENTRYWAY,             {[]{return true;}}),
-                  Entrance(ICE_CAVERN_MQ_MAP_ROOM,          {[]{return CanUse(MASTER_SWORD) || CanUse(KOKIRI_SWORD) || CanUse(BIGGORON_SWORD) || CanUse(DINS_FIRE) || (HasExplosives && (CanUse(STICKS) || CanUse(SLINGSHOT) || CanUse(BOW)));}}),
+                  Entrance(ICE_CAVERN_MQ_MAP_ROOM,          {[]{return CanUse(MASTER_SWORD) || CanUse(BIGGORON_SWORD) || CanUse(MEGATON_HAMMER) || CanUse(DINS_FIRE) || (HasExplosives && (CanUse(KOKIRI_SWORD) || CanUse(STICKS) || CanUse(SLINGSHOT) || CanUse(BOW)));}}),
                   Entrance(ICE_CAVERN_MQ_COMPASS_ROOM,      {[]{return IsAdult && BlueFire;}}),
                   Entrance(ICE_CAVERN_MQ_IRON_BOOTS_REGION, {[]{return BlueFire;}}),
   });
@@ -63,15 +63,15 @@ void AreaTable_Init_IceCavern() {
                   EventAccess(&BlueFireAccess,  {[]{return BlueFireAccess || (HasBottle && CanJumpslash);}}),
   }, {
                   //Locations
-                  LocationAccess(ICE_CAVERN_MQ_MAP_CHEST, {[]{return BlueFire && (CanJumpslash || CanUseProjectile);}}),
+                  LocationAccess(ICE_CAVERN_MQ_MAP_CHEST, {[]{return BlueFire && (CanJumpslash || HasExplosives || CanUseProjectile);}}),
   }, {});
 
   areaTable[ICE_CAVERN_MQ_IRON_BOOTS_REGION] = Area("Ice Cavern MQ Iron Boots Region", "Ice Cavern", ICE_CAVERN, NO_DAY_NIGHT_CYCLE, {}, {
                   //Locations
-                  LocationAccess(ICE_CAVERN_MQ_IRON_BOOTS_CHEST, {[]{return IsAdult && (CanUse(KOKIRI_SWORD) || CanUse(MASTER_SWORD) || CanUse(BIGGORON_SWORD)) ;}}),
-                  LocationAccess(SHEIK_IN_ICE_CAVERN,            {[]{return IsAdult;}}),
-                  LocationAccess(ICE_CAVERN_MQ_GS_ICE_BLOCK,     {[]{return (IsAdult && CanJumpslash) || CanUseProjectile;}}),
-                  LocationAccess(ICE_CAVERN_MQ_GS_SCARECROW,     {[]{return (CanUse(SCARECROW) || (HoverBoots && CanUse(LONGSHOT)) || LogicIceMQScarecrow) && IsAdult;}}),
+                  LocationAccess(ICE_CAVERN_MQ_IRON_BOOTS_CHEST, {[]{return IsAdult && (CanJumpslash || CanUse(RG_MEGATON_HAMMER));}}),
+                  LocationAccess(SHEIK_IN_ICE_CAVERN,            {[]{return IsAdult && (CanJumpslash || CanUse(RG_MEGATON_HAMMER));}}),
+                  LocationAccess(ICE_CAVERN_MQ_GS_ICE_BLOCK,     {[]{return CanAdultAttack || CanChildAttack;}}),
+                  LocationAccess(ICE_CAVERN_MQ_GS_SCARECROW,     {[]{return CanUse(SCARECROW) || (HoverBoots && CanUse(LONGSHOT)) || (LogicIceMQScarecrow && IsAdult);}}),
                     //Tricks: (CanUse(SCARECROW) || (HoverBoots && CanUse(LONGSHOT)) || LogicIceMQScarecrow) && IsAdult
   }, {});
 


### PR DESCRIPTION
The master sword check was not correctly placed behind door of time, allowing it in logic before door of time is open

I also fixed up some logic for ice cavern and other spots for some various things:
* Kokiri sword cannot kill Freezards (but hammer and hookshot can!)
* Projectiles was incorrectly applied to the vanilla/mq decider region which should not contain any other conditions. This most likely was added because of the crystal switch in MQ ice cavern, but simply picking up the pot at the front and throwing it is enough to hit the crystal.
* The serenade check in MQ cavern was missing the clear condition for defeating the stalfos
* The logic for killing the GS at the end of MQ cavern was not considering child sword/stick attacks.

OoTR wiki logic comments regarding MQ cavern crystal switches: https://wiki.ootrandomizer.com/index.php?title=Logic#MQ_Ice_Cavern

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1028176394.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1028176395.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1028176396.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1028176397.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1028176398.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1028176400.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1028176401.zip)
<!--- section:artifacts:end -->