### PR TITLE
Fix Audio Editor Instruments mistake

### DIFF
--- a/soh/soh/Enhancements/audio/AudioCollection.cpp
+++ b/soh/soh/Enhancements/audio/AudioCollection.cpp
@@ -114,12 +114,12 @@ AudioCollection::AudioCollection() {
         SEQUENCE_MAP_ENTRY(NA_BGM_STAFF_4,                      "End Credits IV",                           "NA_BGM_STAFF_4",                 SEQ_BGM_EVENT,    false,    false), // Previously SEQ_UNUSED, so not shown anywhere?
         
         // SEQ_INSTRUMENT
-        SEQUENCE_MAP_ENTRY(INSTRUMENT_OFFSET + 1,               "Ocarina",                                  "OCARINA_INSTRUMENT_DEFAULT",     SEQ_INSTRUMENT,   true,     false),
-        SEQUENCE_MAP_ENTRY(INSTRUMENT_OFFSET + 2,               "Malon",                                    "OCARINA_INSTRUMENT_MALON",       SEQ_INSTRUMENT,   true,     false),
-        SEQUENCE_MAP_ENTRY(INSTRUMENT_OFFSET + 3,               "Whistle",                                  "OCARINA_INSTRUMENT_WHISTLE",     SEQ_INSTRUMENT,   true,     false),
-        SEQUENCE_MAP_ENTRY(INSTRUMENT_OFFSET + 4,               "Harp",                                     "OCARINA_INSTRUMENT_HARP",        SEQ_INSTRUMENT,   true,     false),
-        SEQUENCE_MAP_ENTRY(INSTRUMENT_OFFSET + 5,               "Organ",                                    "OCARINA_INSTRUMENT_GRIND_ORGAN", SEQ_INSTRUMENT,   true,     false),
-        SEQUENCE_MAP_ENTRY(INSTRUMENT_OFFSET + 6,               "Flute",                                    "OCARINA_INSTRUMENT_FLUTE",       SEQ_INSTRUMENT,   true,     false),
+        SEQUENCE_MAP_ENTRY(INSTRUMENT_OFFSET + 1,               "Ocarina",                                  "OCARINA_INSTRUMENT_DEFAULT",     SEQ_INSTRUMENT,   true,     true),
+        SEQUENCE_MAP_ENTRY(INSTRUMENT_OFFSET + 2,               "Malon",                                    "OCARINA_INSTRUMENT_MALON",       SEQ_INSTRUMENT,   true,     true),
+        SEQUENCE_MAP_ENTRY(INSTRUMENT_OFFSET + 3,               "Whistle",                                  "OCARINA_INSTRUMENT_WHISTLE",     SEQ_INSTRUMENT,   true,     true),
+        SEQUENCE_MAP_ENTRY(INSTRUMENT_OFFSET + 4,               "Harp",                                     "OCARINA_INSTRUMENT_HARP",        SEQ_INSTRUMENT,   true,     true),
+        SEQUENCE_MAP_ENTRY(INSTRUMENT_OFFSET + 5,               "Organ",                                    "OCARINA_INSTRUMENT_GRIND_ORGAN", SEQ_INSTRUMENT,   true,     true),
+        SEQUENCE_MAP_ENTRY(INSTRUMENT_OFFSET + 6,               "Flute",                                    "OCARINA_INSTRUMENT_FLUTE",       SEQ_INSTRUMENT,   true,     true),
 
         // SEQ_SFX
         SEQUENCE_MAP_ENTRY(NA_SE_EV_SMALL_DOG_BARK,             "Bark",                                     "NA_SE_EV_SMALL_DOG_BARK",        SEQ_SFX,          true,     true),


### PR DESCRIPTION
When renaming and inverting the new variables for the Sound Editor, I made a mistake for the instruments. This fixes that.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1028569513.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1028569514.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1028569515.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1028569516.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1028569517.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1028569519.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1028569521.zip)
<!--- section:artifacts:end -->