### PR TITLE
Fix: MS Shuffle edge case

### DIFF
--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -1469,6 +1469,7 @@ void Inventory_SwapAgeEquipment(void) {
                 gSaveContext.equips.buttonItems[0] = ITEM_SWORD_MASTER;
             } else {
                 gSaveContext.equips.buttonItems[0] = ITEM_NONE;
+                Flags_SetInfTable(INFTABLE_SWORDLESS);
             }
 
             if (gSaveContext.inventory.items[SLOT_NUT] != ITEM_NONE) {


### PR DESCRIPTION
With MS Shuffle, there apparently was an edge case not accounted for:

- Start as child Link.
- Obtain the Kokiri Sword (or something similar on B).
- Go to the Master Sword pedestal for the first time and press A.
Although Link is swordless as adult, the Kokiri Sword clears the swordless flag and isn't reset when transitioning ages. This makes the first age transition set the swordless flag to have the respective swordless logic in the interface update work as expected.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1033103232.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1033103234.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1033103236.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1033103237.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1033103238.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1033103240.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1033103242.zip)
<!--- section:artifacts:end -->