### PR TITLE
Add gFixEyesOpenWhileSleeping

### DIFF
--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -1059,6 +1059,8 @@ void DrawEnhancementsMenu() {
             UIWidgets::Tooltip("Fixes the bushes to drop items correctly rather than spawning undefined items.");
             UIWidgets::PaddedEnhancementCheckbox("Fix falling from vine edges", "gFixVineFall", true, false); 
             UIWidgets::Tooltip("Prevents immediately falling off climbable surfaces if climbing on the edges."); 
+            UIWidgets::PaddedEnhancementCheckbox("Fix Link's eyes open while sleeping", "gFixEyesOpenWhileSleeping", true, false);
+            UIWidgets::Tooltip("Fixes Link's eyes being open in the opening cutscene when he is supposed to be sleeping.");
 
             ImGui::EndMenu();
         }

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -15169,6 +15169,10 @@ void func_80852C50(PlayState* play, Player* this, CsCmdActorAction* arg2) {
 
     sp24 = D_808547C4[this->unk_446];
     func_80852B4C(play, this, linkCsAction, &D_80854E50[ABS(sp24)]);
+
+    if (CVarGetInteger("gFixEyesOpenWhileSleeping", 0) && (play->csCtx.linkAction->action == 28 || play->csCtx.linkAction->action == 29)) {
+        this->skelAnime.jointTable[22].x = 8;
+    }
 }
 
 void func_80852E14(Player* this, PlayState* play) {


### PR DESCRIPTION
At the request of Djipi, solution found by @MelonSpeedruns 

Before & After, with and without custom texture pack

<img width="1417" alt="open-og" src="https://github.com/HarbourMasters/Shipwright/assets/7316699/6365ad0a-78d7-432a-8b86-90cc7b34d403">
<img width="1377" alt="open-djipi" src="https://github.com/HarbourMasters/Shipwright/assets/7316699/fa9f5f4d-311f-4343-b025-fed627ff0597">
<img width="1418" alt="closed-og" src="https://github.com/HarbourMasters/Shipwright/assets/7316699/bde9799c-d98a-47c7-9003-8456d825b3ea">
<img width="1367" alt="closed-djipi" src="https://github.com/HarbourMasters/Shipwright/assets/7316699/9261dca4-0b98-417a-90cc-604134f46a05">


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1034394938.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1034394941.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1034394944.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1034394946.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1034394947.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1034394949.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1034394951.zip)
<!--- section:artifacts:end -->