### PR TITLE
Fix Excluded Sequences not loading 

### DIFF
--- a/soh/soh/Enhancements/audio/AudioCollection.cpp
+++ b/soh/soh/Enhancements/audio/AudioCollection.cpp
@@ -400,8 +400,9 @@ void AudioCollection::InitializeShufflePool() {
     if (shufflePoolInitialized) return;
     
     for (auto& [seqId, seqInfo] : sequenceMap) {
+        if (!seqInfo.canBeUsedAsReplacement) continue;
         const std::string cvarKey = "gAudioEditor.Excluded." + seqInfo.sfxKey;
-        if (CVarGetInteger(cvarKey.c_str(), 0) && !seqInfo.canBeUsedAsReplacement) {
+        if (CVarGetInteger(cvarKey.c_str(), 0)) {
             excludedSequences.insert(&seqInfo);
         } else {
             includedSequences.insert(&seqInfo);


### PR DESCRIPTION
Moved the check for `!seqInfo.canBeUsedAsReplacement` in `InitializeShufflePool` to exclude them before modifying either shuffle pool. Fixes saved exclusions not loading properly.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1037500240.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1037500241.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1037500242.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1037500243.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1037500244.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1037500245.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1037500246.zip)
<!--- section:artifacts:end -->