### PR TITLE
[Feature Fix] Tunics stolen by like likes now removed from the item buttons

### DIFF
--- a/soh/src/code/code_80097A00.c
+++ b/soh/src/code/code_80097A00.c
@@ -204,6 +204,7 @@ u8 Inventory_DeleteEquipment(PlayState* play, s16 equipment) {
 
         if (equipment == EQUIP_TYPE_TUNIC) {
             gSaveContext.equips.equipment |= EQUIP_VALUE_TUNIC_KOKIRI << (EQUIP_TYPE_TUNIC * 4);
+            // non-vanilla: remove goron and zora tunics from item buttons if assignable tunics is on
             if (CVarGetInteger("gAssignableTunicsAndBoots", 0) && equipValue != EQUIP_VALUE_TUNIC_KOKIRI) {
                 ItemID item = (equipValue == EQUIP_VALUE_TUNIC_GORON ? ITEM_TUNIC_GORON : ITEM_TUNIC_ZORA);
                 for (int i = 1; i < ARRAY_COUNT(gSaveContext.equips.buttonItems); i++) {
@@ -213,6 +214,7 @@ u8 Inventory_DeleteEquipment(PlayState* play, s16 equipment) {
                     }
                 }
             }
+            // end non-vanilla
         }
 
         if (equipment == EQUIP_TYPE_SWORD) {

--- a/soh/src/code/code_80097A00.c
+++ b/soh/src/code/code_80097A00.c
@@ -204,6 +204,15 @@ u8 Inventory_DeleteEquipment(PlayState* play, s16 equipment) {
 
         if (equipment == EQUIP_TYPE_TUNIC) {
             gSaveContext.equips.equipment |= EQUIP_VALUE_TUNIC_KOKIRI << (EQUIP_TYPE_TUNIC * 4);
+            if (CVarGetInteger("gAssignableTunicsAndBoots", 0) && equipValue != EQUIP_VALUE_TUNIC_KOKIRI) {
+                ItemID item = (equipValue == EQUIP_VALUE_TUNIC_GORON ? ITEM_TUNIC_GORON : ITEM_TUNIC_ZORA);
+                for (int i = 1; i < ARRAY_COUNT(gSaveContext.equips.buttonItems); i++) {
+                    if (gSaveContext.equips.buttonItems[i] == item) {
+                        gSaveContext.equips.buttonItems[i] = ITEM_NONE;
+                        gSaveContext.equips.cButtonSlots[i - 1] = SLOT_NONE;
+                    }
+                }
+            }
         }
 
         if (equipment == EQUIP_TYPE_SWORD) {


### PR DESCRIPTION
This adds a check in the function that removes the Goron or Zora tunic from the player's equipment if equipped to check for and remove said tunic from the item buttons if `Assignable Boots and Tunics` is enabled. Resolves #937. As labelled by briaguya, kind of a feature bug, but a bug nonetheless, so I'm targeting develop-macready.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1038331214.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1038331215.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1038331216.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1038331217.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1038331219.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1038331221.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1038331223.zip)
<!--- section:artifacts:end -->