### PR TITLE
[Feature/fix] Save to temp file first

### DIFF
--- a/soh/soh/SaveManager.h
+++ b/soh/soh/SaveManager.h
@@ -142,6 +142,7 @@ class SaveManager {
 
   private:
     std::filesystem::path GetFileName(int fileNum);
+    std::filesystem::path GetFileTempName(int fileNum);
     nlohmann::json saveBlock;
 
     void ConvertFromUnversioned();


### PR DESCRIPTION
Due to the nature of crashes sometimes causing save corruption, and then causing more severe crashes because of the corruption, this PR changes `SaveManager::SaveFileThreaded` to utilize a temp file to save to, which is then copied to the real save file, to try to preserve all save files in a workable state, even if a crash interrupts the save thread. Also adds a "Save finish" log message to the end of the function to mirror the log message at the start of it.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1050237247.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1050237248.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1050237249.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1050237250.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1050237252.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1050237253.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1050237254.zip)
<!--- section:artifacts:end -->