### PR TITLE
SaveManager cleanup

### DIFF
--- a/soh/soh/SaveManager.cpp
+++ b/soh/soh/SaveManager.cpp
@@ -363,6 +363,8 @@ void SaveManager::SaveRandomizer(SaveContext* saveContext, int sectionID, bool f
 
 // Init() here is an extension of InitSram, and thus not truly an initializer for SaveManager itself. don't put any class initialization stuff here
 void SaveManager::Init() {
+    // Wait on saves that snuck through the Wait in OnExitGame
+    ThreadPoolWait();
     const std::filesystem::path sSavePath(LUS::Context::GetPathRelativeToAppDirectory("Save"));
     const std::filesystem::path sGlobalPath = sSavePath / std::string("global.sav");
     auto sOldSavePath = LUS::Context::GetPathRelativeToAppDirectory("oot_save.sav");
@@ -933,10 +935,6 @@ void SaveManager::SaveFileThreaded(int fileNum, SaveContext* saveContext, int se
 void SaveManager::SaveSection(int fileNum, int sectionID, bool threaded) {
     // Don't save in Boss rush.
     if (fileNum == 0xFF || fileNum == 0xFE) {
-        return;
-    }
-    // Don't save if after OnExitGame
-    if (!GameInteractor::IsSaveLoaded()) {
         return;
     }
     // Don't save a nonexistent section


### PR DESCRIPTION
Move thread pool initialization and `OnExitGame` registration from `SaveManager::Init()` to SM's constructor.

This is necessary because `SaveManager::Init()` is merely an extension of `Sram_InitSram()`, and as such is not an initializer for `SaveManager` itself. Before now, every reset would add another registration for `OnExitGame` and reinitialize the thread pool, which was definitely not a good thing.

Also added call to `ThreadPoolWait()` in `Init()`, as it was relatively easy, especially on Anchor, to trigger a save after `OnExitGame` was already processed, thus introducing the possibility that `Init()` would be loading a file (or reinitializing the thread pool, for that matter) at the same time the save worker was writing to the file, causing it to try to load incomplete and malformed save data.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1044319375.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1044319376.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1044319377.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1044319379.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1044319380.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1044319381.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1044319382.zip)
<!--- section:artifacts:end -->