### PR TITLE
Audio Editor UI Improvements and Scene Init Randomization

### DIFF
--- a/soh/soh/Enhancements/audio/AudioEditor.cpp
+++ b/soh/soh/Enhancements/audio/AudioEditor.cpp
@@ -525,7 +525,7 @@ void AudioEditor::DrawElement() {
                 }
 
                 ImGui::NewLine();
-                UIWidgets::EnhancementCheckbox("Randomize All Music and Sound Effects on New Scene", "gAudioRandomizeAllOnNewScene");
+                UIWidgets::EnhancementCheckbox("Randomize All Music and Sound Effects on New Scene", "gAudioEditor.RandomizeAllOnNewScene");
                 UIWidgets::Tooltip("Enables randomizing all unlocked music and sound effects when you enter a new scene.");
 
                 ImGui::NewLine();

--- a/soh/soh/Enhancements/audio/AudioEditor.cpp
+++ b/soh/soh/Enhancements/audio/AudioEditor.cpp
@@ -411,7 +411,7 @@ void DrawTypeChip(SeqType type) {
 
 void AudioEditorRegisterOnSceneInitHook() {
     GameInteractor::Instance->RegisterGameHook<GameInteractor::OnSceneInit>([](int16_t sceneNum) {
-        if (CVarGetInteger("gAudioRandomizeAllOnNewScene", 0)) {
+        if (CVarGetInteger("gAudioEditor.RandomizeAllOnNewScene", 0)) {
             AudioEditor_RandomizeAll();
         }
     });

--- a/soh/soh/Enhancements/audio/AudioEditor.cpp
+++ b/soh/soh/Enhancements/audio/AudioEditor.cpp
@@ -12,6 +12,7 @@
 #include <Utils/StringHelper.h>
 #include "../../UIWidgets.hpp"
 #include "AudioCollection.h"
+#include "soh/Enhancements/game-interactor/GameInteractor.h"
 
 Vec3f pos = { 0.0f, 0.0f, 0.0f };
 f32 freqScale = 1.0f;
@@ -78,7 +79,12 @@ void UpdateCurrentBGM(u16 seqKey, SeqType seqType) {
 
 void RandomizeGroup(SeqType type) {
     std::vector<u16> values;
-    
+
+    // An empty IncludedSequences set means that the AudioEditor window has never been drawn
+    if (AudioCollection::Instance->GetIncludedSequences().empty()) {
+        AudioCollection::Instance->InitializeShufflePool();
+    }
+
     // use a while loop to add duplicates if we don't have enough included sequences
     while (values.size() < AuthenticCountBySequenceType(type)) {
         for (const auto& seqData : AudioCollection::Instance->GetIncludedSequences()) {
@@ -123,6 +129,34 @@ void ResetGroup(const std::map<u16, SequenceInfo>& map, SeqType type) {
     }
 }
 
+void LockGroup(const std::map<u16, SequenceInfo>& map, SeqType type) {
+    for (const auto& [defaultValue, seqData] : map) {
+        if (seqData.category == type) {
+            // Only save authentic sequence CVars
+            if (seqData.category == SEQ_FANFARE && defaultValue >= MAX_AUTHENTIC_SEQID) {
+                continue;
+            }
+            const std::string cvarKey = AudioCollection::Instance->GetCvarKey(seqData.sfxKey);
+            const std::string cvarLockKey = AudioCollection::Instance->GetCvarLockKey(seqData.sfxKey);
+            CVarSetInteger(cvarLockKey.c_str(), 1);
+        }
+    }
+}
+
+void UnlockGroup(const std::map<u16, SequenceInfo>& map, SeqType type) {
+    for (const auto& [defaultValue, seqData] : map) {
+        if (seqData.category == type) {
+            // Only save authentic sequence CVars
+            if (seqData.category == SEQ_FANFARE && defaultValue >= MAX_AUTHENTIC_SEQID) {
+                continue;
+            }
+            const std::string cvarKey = AudioCollection::Instance->GetCvarKey(seqData.sfxKey);
+            const std::string cvarLockKey = AudioCollection::Instance->GetCvarLockKey(seqData.sfxKey);
+            CVarSetInteger(cvarLockKey.c_str(), 0);
+        }
+    }
+}
+
 void DrawPreviewButton(uint16_t sequenceId, std::string sfxKey, SeqType sequenceType) {
     const std::string cvarKey = AudioCollection::Instance->GetCvarKey(sfxKey);
     const std::string hiddenKey = "##" + cvarKey;
@@ -163,6 +197,8 @@ void Draw_SfxTab(const std::string& tabId, SeqType type) {
     const std::string hiddenTabId = "##" + tabId;
     const std::string resetAllButton = "Reset All" + hiddenTabId;
     const std::string randomizeAllButton = "Randomize All" + hiddenTabId;
+    const std::string lockAllButton = "Lock All" + hiddenTabId;
+    const std::string unlockAllButton = "Unlock All" + hiddenTabId;
     if (ImGui::Button(resetAllButton.c_str())) {
         auto currentBGM = func_800FA0B4(SEQ_PLAYER_BGM_MAIN);
         auto prevReplacement = AudioCollection::Instance->GetReplacementSequence(currentBGM);
@@ -178,6 +214,28 @@ void Draw_SfxTab(const std::string& tabId, SeqType type) {
         auto currentBGM = func_800FA0B4(SEQ_PLAYER_BGM_MAIN);
         auto prevReplacement = AudioCollection::Instance->GetReplacementSequence(currentBGM);
         RandomizeGroup(type);
+        LUS::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
+        auto curReplacement = AudioCollection::Instance->GetReplacementSequence(currentBGM);
+        if (type == SEQ_BGM_WORLD && prevReplacement != curReplacement) {
+            ReplayCurrentBGM();
+        }
+    }
+    ImGui::SameLine();
+    if (ImGui::Button(lockAllButton.c_str())) {
+        auto currentBGM = func_800FA0B4(SEQ_PLAYER_BGM_MAIN);
+        auto prevReplacement = AudioCollection::Instance->GetReplacementSequence(currentBGM);
+        LockGroup(map, type);
+        LUS::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
+        auto curReplacement = AudioCollection::Instance->GetReplacementSequence(currentBGM);
+        if (type == SEQ_BGM_WORLD && prevReplacement != curReplacement) {
+            ReplayCurrentBGM();
+        }
+    }
+    ImGui::SameLine();
+    if (ImGui::Button(unlockAllButton.c_str())) {
+        auto currentBGM = func_800FA0B4(SEQ_PLAYER_BGM_MAIN);
+        auto prevReplacement = AudioCollection::Instance->GetReplacementSequence(currentBGM);
+        UnlockGroup(map, type);
         LUS::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
         auto curReplacement = AudioCollection::Instance->GetReplacementSequence(currentBGM);
         if (type == SEQ_BGM_WORLD && prevReplacement != curReplacement) {
@@ -350,6 +408,19 @@ void DrawTypeChip(SeqType type) {
     ImGui::EndDisabled();
 }
 
+
+void AudioEditorRegisterOnSceneInitHook() {
+    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnSceneInit>([](int16_t sceneNum) {
+        if (CVarGetInteger("gAudioRandomizeAllOnNewScene", 0)) {
+            AudioEditor_RandomizeAll();
+        }
+    });
+}
+
+void AudioEditor::InitElement() {
+    AudioEditorRegisterOnSceneInitHook();
+}
+
 void AudioEditor::DrawElement() {
     AudioCollection::Instance->InitializeShufflePool();
 
@@ -358,6 +429,28 @@ void AudioEditor::DrawElement() {
         ImGui::End();
         return;
     }
+
+    float buttonSegments = ImGui::GetContentRegionAvail().x / 4;
+    if (ImGui::Button("Randomize All Groups", ImVec2(buttonSegments, 30.0f))) {
+        AudioEditor_RandomizeAll();
+    }
+    UIWidgets::Tooltip("Randomizes all unlocked music and sound effects across tab groups");
+    ImGui::SameLine();
+    if (ImGui::Button("Reset All Groups", ImVec2(buttonSegments, 30.0f))) {
+        AudioEditor_ResetAll();
+    }
+    UIWidgets::Tooltip("Resets all unlocked music and sound effects across tab groups");
+    ImGui::SameLine();
+    if (ImGui::Button("Lock All Groups", ImVec2(buttonSegments, 30.0f))) {
+        AudioEditor_LockAll();
+    }
+    UIWidgets::Tooltip("Locks all music and sound effects across tab groups");
+    ImGui::SameLine();
+    if (ImGui::Button("Unlock All Groups", ImVec2(buttonSegments, 30.0f))) {
+        AudioEditor_UnlockAll();
+    }
+    UIWidgets::Tooltip("Unlocks all music and sound effects across tab groups");
+
 
     if (ImGui::BeginTabBar("SfxContextTabBar", ImGuiTabBarFlags_NoCloseWithMiddleMouseButton)) {
         if (ImGui::BeginTabItem("Background Music")) {
@@ -430,6 +523,10 @@ void AudioEditor::DrawElement() {
                     CVarSetFloat("gLinkVoiceFreqMultiplier", 1.0f);
                     LUS::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
                 }
+
+                ImGui::NewLine();
+                UIWidgets::EnhancementCheckbox("Randomize All Music and Sound Effects on New Scene", "gAudioRandomizeAllOnNewScene");
+                UIWidgets::Tooltip("Enables randomizing all unlocked music and sound effects when you enter a new scene.");
 
                 ImGui::NewLine();
                 ImGui::PushItemWidth(-FLT_MIN);
@@ -624,4 +721,20 @@ void AudioEditor_ResetAll() {
 
     LUS::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
     ReplayCurrentBGM();
+}
+
+void AudioEditor_LockAll() {
+    for (auto type : allTypes) {
+        LockGroup(AudioCollection::Instance->GetAllSequences(), type);
+    }
+
+    LUS::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
+}
+
+void AudioEditor_UnlockAll() {
+    for (auto type : allTypes) {
+        UnlockGroup(AudioCollection::Instance->GetAllSequences(), type);
+    }
+
+    LUS::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
 }

--- a/soh/soh/Enhancements/audio/AudioEditor.h
+++ b/soh/soh/Enhancements/audio/AudioEditor.h
@@ -14,13 +14,15 @@ class AudioEditor : public LUS::GuiWindow {
         using LUS::GuiWindow::GuiWindow;
 
         void DrawElement() override;
-        void InitElement() override {};
+        void InitElement() override;
         void UpdateElement() override {};
         ~AudioEditor() {};
 };
 
 void AudioEditor_RandomizeAll();
 void AudioEditor_ResetAll();
+void AudioEditor_LockAll();
+void AudioEditor_UnlockAll();
 
 extern "C" {
 #endif


### PR DESCRIPTION
Minor enhancements to the Audio Editor UI:
- Allow randomizing/resetting/locking/unlocking all groups with a single button
- Allow locking/unlocking a single group

Adds a setting to randomize all unlocked audio groups/songs/fanfares etc on scene init
Similar in nature to #3342 
- If the audio editor UI is never opened, the shuffle pool is empty.  Adds a simple check to init if necessary
- Adds a new hook for audio editor
- Hook is functionally the same as clicking "Randomize All Groups"

Here's some screenshots of what is proposed:

UI enhancements 👇 
![image](https://github.com/HarbourMasters/Shipwright/assets/984790/e5e7f5a8-d2c0-4a8d-82d4-118b505b65cd)

Randomize on new scene setting 👇 
![image](https://github.com/HarbourMasters/Shipwright/assets/984790/90aa9e64-6146-4a14-9545-4a9f8a6bb756)

I've ran a few randos with this changeset and it works as expected

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1044851107.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1044851108.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1044851109.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1044851110.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1044851111.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1044851112.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1044851113.zip)
<!--- section:artifacts:end -->