### PR TITLE
Fix magic being zeroed out when using fast file select

### DIFF
--- a/soh/soh/Enhancements/debugconsole.cpp
+++ b/soh/soh/Enhancements/debugconsole.cpp
@@ -207,6 +207,7 @@ static bool ResetHandler(std::shared_ptr<LUS::Console> Console, std::vector<std:
         return 1;
     }
 
+    gPlayState->gameplayFrames = 0;
     SET_NEXT_GAMESTATE(&gPlayState->state, TitleSetup_Init, GameState);
     gPlayState->state.running = false;
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnExitGame>(gSaveContext.fileNum);

--- a/soh/src/code/z_play.c
+++ b/soh/src/code/z_play.c
@@ -33,6 +33,7 @@ u64 D_801614D0[0xA00];
 #endif
 
 PlayState* gPlayState;
+s16 firstInit = 0;
 
 s16 gEnPartnerId;
 
@@ -173,11 +174,6 @@ void Play_Destroy(GameState* thisx) {
     Player* player = GET_PLAYER(play);
 
     GameInteractor_ExecuteOnPlayDestroy();
-
-    // Only initialize the frame counter when exiting the title screen
-    if (gSaveContext.fileNum == 0xFF) {
-        play->gameplayFrames = 0;
-    }
 
     // In ER, remove link from epona when entering somewhere that doesn't support epona
     if (IS_RANDO && Randomizer_GetSettingValue(RSK_SHUFFLE_OVERWORLD_ENTRANCES)) {
@@ -488,6 +484,12 @@ void Play_Init(GameState* thisx) {
         if (gSaveContext.entranceIndex == 0x7A) {
             gSaveContext.entranceIndex = 0x400;
         }
+    }
+
+    // Properly initialize the frame counter so it doesn't use garbage data
+    if (!firstInit) {
+        play->gameplayFrames = 0;
+        firstInit = 1;
     }
 
     // Invalid entrance, so immediately exit the game to opening title

--- a/soh/src/code/z_play.c
+++ b/soh/src/code/z_play.c
@@ -175,6 +175,11 @@ void Play_Destroy(GameState* thisx) {
 
     GameInteractor_ExecuteOnPlayDestroy();
 
+    // Only initialize the frame counter when exiting the title screen
+    if (gSaveContext.fileNum == 0xFF) {
+        play->gameplayFrames = 0;
+    }
+
     // In ER, remove link from epona when entering somewhere that doesn't support epona
     if (IS_RANDO && Randomizer_GetSettingValue(RSK_SHUFFLE_OVERWORLD_ENTRANCES)) {
         Entrance_HandleEponaState();

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
@@ -4290,6 +4290,8 @@ void KaleidoScope_Update(PlayState* play)
                         if (IS_RANDO && Randomizer_GetSettingValue(RSK_SHUFFLE_ENTRANCES)) {
                             Grotto_ForceGrottoReturn();
                         }
+                        // Reset frame counter to prevent autosave on respawn
+                        play->gameplayFrames = 0;
                         gSaveContext.nextTransitionType = 2;
                         gSaveContext.health = CVarGetInteger("gFullHealthSpawn", 0) ? gSaveContext.healthCapacity : 0x30;
                         Audio_QueueSeqCmd(0xF << 28 | SEQ_PLAYER_BGM_MAIN << 24 | 0xA);


### PR DESCRIPTION
Closes #1187 for good.  After spending 2 hours stepping through the application starting up line by line, I determined that since the file select screen rework was done in #1854, there was no point at which play state was valid AND the save context didn't have a file selected when fast file select is turned on, which is what the old fix used to determine when we were exiting the title screen.  

The old fix specifically set `gPlayState->gameplayFrames` to 0 when exiting the title screen, which is why it didn't cover when fast file select was used.  That frame counter is used in vanilla gameplay for animation timing, which means it's usually masked off/modulused down/used in a trig function for the timing of a specific animation, so its full value was never important.  The important exceptions to that appear to be:
- In Dark Link's code, which may explain some of his differences here compared to console
- A flame damage counter that appears to still be functional
- A timer for one of Twinrova's cutscenes (specifically the "FlyKidnapCutscene")

Because the variable was uninitialized, it was just incrementing starting at the garbage value 0xabababab, which meant the trigger not to autosave during the first few seconds of gameplay wasn't happening, causing the described behavior of magic being zeroed out on first load via autosave triggering while the value is at 0 before the fill-up animation plays. 

Given how many checks in vanilla code appear to want a counter value of 0, I suspect this variable was originally zeroed by the hardware.  It's possible it even was zeroed on every play initialization like `play->state->frames` is, so if we're still looking for effects that aren't triggering like they should, this is a likely culprit.  

This fix uses the classic "set a variable to say we've set a variable" to set the frame counter the first time play is initialized, and it also resets the counter when the in-game Reset is triggered.  The old fix to reset the counter when leaving the title screen is retained so that title screen time doesn't count towards the counter, meaning the counter can now be used as an accurate counter of play time elapsed since last reset (gameover also counts as a reset).  

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1045298577.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1045298578.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1045298580.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1045298581.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1045298584.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1045298585.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1045298586.zip)
<!--- section:artifacts:end -->