### PR TITLE
[Enhancement] Scale Enemy Health with Size

### DIFF
--- a/soh/soh/Enhancements/mods.cpp
+++ b/soh/soh/Enhancements/mods.cpp
@@ -1069,6 +1069,17 @@ void RegisterRandomizedEnemySizes() {
         }
 
         Actor_SetScale(actor, actor->scale.z * randomScale);
+
+        if (CVarGetInteger("gEnemySizeScalesHealth", 0) && (actor->category == ACTORCAT_ENEMY)) {
+            // Scale the health based on a smaller factor than randomScale
+            float healthScalingFactor = 0.8f; // Adjust this factor as needed
+            float scaledHealth = actor->colChkInfo.health * (randomScale * healthScalingFactor);
+
+            // Ensure the scaled health doesn't go below zero
+            actor->colChkInfo.health = fmax(scaledHealth, 1.0f);
+        } else {
+            return;
+        }
     });
 }
 

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -1130,6 +1130,11 @@ void DrawEnhancementsMenu() {
             UIWidgets::PaddedEnhancementCheckbox("Randomized Enemy Sizes", "gRandomizedEnemySizes", true, false);
             UIWidgets::Tooltip("Enemies and Bosses spawn with random sizes.");
 
+            if (CVarGetInteger("gRandomizedEnemySizes", 0)) {
+                UIWidgets::EnhancementCheckbox("Scale Health with Size", "gEnemySizeScalesHealth");
+                UIWidgets::Tooltip("Scales normal enemies health with their randomized size. *This will NOT affect bosses*");
+            }
+
             UIWidgets::PaddedEnhancementCheckbox("Ivan the Fairy (Coop Mode)", "gIvanCoopModeEnabled", true, false);
             UIWidgets::Tooltip("Enables Ivan the Fairy upon the next map change. Player 2 can control Ivan and "
                                 "press the C-Buttons to use items and mess with Player 1!");


### PR DESCRIPTION
When Randomized Enemy Sizes is on, this can be toggled on to also scale the health based on the enemies sizes. It will only affect normal enemies and not bosses, due to how their health is handled differently.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1047560557.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1047560559.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1047560560.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1047560563.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1047560565.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1047560569.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1047560571.zip)
<!--- section:artifacts:end -->