### PR TITLE
[Difficulty Option] Cuccos Stay Put Multiplier

### DIFF
--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -686,6 +686,8 @@ void DrawEnhancementsMenu() {
                 UIWidgets::Tooltip("Always win the heart piece/purple rupee on the first dig in Dampe's grave digging game, just like in rando\nIn a rando file, this is unconditionally enabled");
                 UIWidgets::PaddedEnhancementCheckbox("All Dogs are Richard", "gAllDogsRichard", true, false);
                 UIWidgets::Tooltip("All dogs can be traded in and will count as Richard.");
+                UIWidgets::PaddedEnhancementSliderInt("Cuccos Stay Put Multiplier: %dx", "##CuccoStayDurationMultiplier", "gCuccoStayDurationMultiplier", 1, 5, "", 1, true, true, false);
+                UIWidgets::Tooltip("Cuccos will stay in place longer after putting them down, by a multiple of the value of the slider.");
                 UIWidgets::Spacer(0);
 
                 if (ImGui::BeginMenu("Potion Values"))

--- a/soh/src/overlays/actors/ovl_En_Niw/z_en_niw.c
+++ b/soh/src/overlays/actors/ovl_En_Niw/z_en_niw.c
@@ -666,7 +666,7 @@ void func_80AB6D08(EnNiw* this, PlayState* play) {
         }
 
         this->path = 1;
-        this->timer5 = 80;
+        this->timer5 = 80 * CVarGetInteger("gCuccoStayDurationMultiplier", 1);
         this->actor.speedXZ = 0.0f;
         this->actor.velocity.y = 4.0f;
     } else {


### PR DESCRIPTION
With this, when you put a cucco down, you can choose a multiplier of 1-5, 1 being the vanilla time, 5 being 5 times as long. This will make it to where people don't loose the cucco as much, while still being able to not make it TOO easy if they'd like.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1047731576.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1047731577.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1047731578.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1047731580.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1047731581.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1047731582.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1047731583.zip)
<!--- section:artifacts:end -->