### PR TITLE
Stop hardcoding skeleton type to flex

### DIFF
--- a/soh/soh/resource/importer/SkeletonFactory.cpp
+++ b/soh/soh/resource/importer/SkeletonFactory.cpp
@@ -103,37 +103,41 @@ void SkeletonFactoryV0::ParseFileXML(tinyxml2::XMLElement* reader, std::shared_p
 {
     std::shared_ptr<Skeleton> skel = std::static_pointer_cast<Skeleton>(resource);
 
-    std::string skeletonType = reader->Attribute("Type");
-    // std::string skeletonLimbType = reader->Attribute("LimbType");
-    int numLimbs = reader->IntAttribute("LimbCount");
-    int numDLs = reader->IntAttribute("DisplayListCount");
+    skel->type = SkeletonType::Flex; // Default to Flex for legacy reasons
+    if (reader->FindAttribute("Type")) {
+        std::string skeletonType = reader->Attribute("Type");
 
-    if (skeletonType == "Flex") {
-        skel->type = SkeletonType::Flex;
-    } else if (skeletonType == "Curve") {
-        skel->type = SkeletonType::Curve;
-    } else if (skeletonType == "Normal") {
-        skel->type = SkeletonType::Normal;
+        if (skeletonType == "Flex") {
+            skel->type = SkeletonType::Flex;
+        } else if (skeletonType == "Curve") {
+            skel->type = SkeletonType::Curve;
+        } else if (skeletonType == "Normal") {
+            skel->type = SkeletonType::Normal;
+        }
     }
 
-    skel->type = SkeletonType::Flex;
-    skel->limbType = LimbType::LOD;
+    skel->limbType = LimbType::LOD; // Default to LOD for legacy reasons
+    if (reader->FindAttribute("LimbType")) {
+        std::string skeletonLimbType = reader->Attribute("LimbType");
 
-    // if (skeletonLimbType == "Standard")
-    // skel->limbType = LimbType::Standard;
-    // else if (skeletonLimbType == "LOD")
-    // skel->limbType = LimbType::LOD;
-    // else if (skeletonLimbType == "Curve")
-    // skel->limbType = LimbType::Curve;
-    // else if (skeletonLimbType == "Skin")
-    // skel->limbType = LimbType::Skin;
-    // else if (skeletonLimbType == "Legacy")
-    // Sskel->limbType = LimbType::Legacy;
+        if (skeletonLimbType == "Standard") {
+            skel->limbType = LimbType::Standard;
+        } else if (skeletonLimbType == "LOD") {
+            skel->limbType = LimbType::LOD;
+        } else if (skeletonLimbType == "Curve") {
+            skel->limbType = LimbType::Curve;
+        } else if (skeletonLimbType == "Skin") {
+            skel->limbType = LimbType::Skin;
+        } else if (skeletonLimbType == "Legacy") {
+            skel->limbType = LimbType::Legacy;
+        }
+    }
+
+
+    skel->limbCount = reader->IntAttribute("LimbCount");
+    skel->dListCount = reader->IntAttribute("DisplayListCount");
 
     auto child = reader->FirstChildElement();
-
-    skel->limbCount = numLimbs;
-    skel->dListCount = numDLs;
 
     while (child != nullptr) {
         std::string childName = child->Name();


### PR DESCRIPTION
For an unknown reason, since the introduction of custom models we had hardcoded their skeleton type to `SkeletonType::Flex`. 

This seemingly did not cause any issues, because regardless of skeleton type the actor files had inline draw calls that determined how the skeleton should be drawn. 

This was changed in 8.0.0 https://github.com/HarbourMasters/Shipwright/pull/2979 in which all actors now ensure to check the skeleton type before attempting to draw. This change now meant that all custom models were now rendered as `SkeletonType::Flex`, whether their exported type was flex or not, leading to unknown behavior and/or crashes with all models that aren't specifically meant to be using `SkeletonType::Flex`.

This PR also removes the hardcoding of LimbType, it doesn't seem like fast64 exports this for now, but if/when we want it to this should account for it.


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1049413416.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1049413419.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1049413421.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1049413424.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1049413428.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1049413430.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1049413431.zip)
<!--- section:artifacts:end -->