### PR TITLE
Use Correct Player Boot Enums in CC

### DIFF
--- a/soh/soh/Enhancements/crowd-control/CrowdControl.cpp
+++ b/soh/soh/Enhancements/crowd-control/CrowdControl.cpp
@@ -380,13 +380,13 @@ CrowdControl::Effect* CrowdControl::ParseMessage(char payload[512]) {
             effect->category = kEffectCatBoots;
             effect->timeRemaining = 30000;
             effect->giEffect = new GameInteractionEffect::ForceEquipBoots();
-            effect->giEffect->parameters[0] = PLAYER_BOOTS_IRON;
+            effect->giEffect->parameters[0] = EQUIP_VALUE_BOOTS_IRON;
             break;
         case kEffectForceHoverBoots:
             effect->category = kEffectCatBoots;
             effect->timeRemaining = 30000;
             effect->giEffect = new GameInteractionEffect::ForceEquipBoots();
-            effect->giEffect->parameters[0] = PLAYER_BOOTS_HOVER;
+            effect->giEffect->parameters[0] = EQUIP_VALUE_BOOTS_HOVER;
             break;
         case kEffectSlipperyFloor:
             effect->category = kEffectCatSlipperyFloor;


### PR DESCRIPTION
Tested now, this fixes the issue with crowd control forcing the wrong boot values to the player. This pr points to macready

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1053170757.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1053170759.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1053170761.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1053170763.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1053170765.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1053170768.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1053170771.zip)
<!--- section:artifacts:end -->