### PR TITLE
Fixes a potential crash with saves made on older commit.

### DIFF
--- a/soh/soh/SaveManager.cpp
+++ b/soh/soh/SaveManager.cpp
@@ -231,9 +231,11 @@ void SaveManager::LoadRandomizerVersion2() {
         SaveManager::Instance->LoadStruct("", [&]() {
             RandomizerCheck rc = RC_UNKNOWN_CHECK;
             SaveManager::Instance->LoadData("check", rc);
-            std::string hintText;
-            SaveManager::Instance->LoadData("hintText", hintText);
-            randoContext->AddHint(RandomizerHintKey(rc - RC_COLOSSUS_GOSSIP_STONE + 1), Text(hintText), RC_UNKNOWN_CHECK, HINT_TYPE_STATIC, Text());
+            if (rc != RC_UNKNOWN_CHECK) {
+                std::string hintText;
+                SaveManager::Instance->LoadData("hintText", hintText);
+                randoContext->AddHint(RandomizerHintKey(rc - RC_COLOSSUS_GOSSIP_STONE + 1), Text(hintText), RC_UNKNOWN_CHECK, HINT_TYPE_STATIC, Text());
+            }
         });
     });
 


### PR DESCRIPTION
I had an Off By One Bug in a previous commit, and saves made on that commit ended up crashing on boot due to attempting to access a negative index of an array. Added a bounds check to prevent attempting to load that data.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1055627018.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1055627020.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1055627026.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1055627033.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1055627036.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1055627038.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1055627039.zip)
<!--- section:artifacts:end -->