### PR TITLE
Add LLR entrance from silo to the better debug warp screen

### DIFF
--- a/soh/src/overlays/gamestates/ovl_select/z_select.c
+++ b/soh/src/overlays/gamestates/ovl_select/z_select.c
@@ -355,10 +355,11 @@ static BetterSceneSelectEntry sBetterScenes[] = {
         { "From Zelda", "Von Zelda", "Depuis Zelda", ENTR_CASTLE_COURTYARD_GUARDS_DAY_1, 0 },
         { "Zeldas Courtyard", "Zeldas Burghof", "Depuis la Cour de Zelda", ENTR_CASTLE_COURTYARD_ZELDA_0, 0 },
     }},
-    { "13:Lon Lon Ranch", "13:Lon Lon-Farm", "13:Ranch Lon Lon", Select_LoadGame, 4, { 
+    { "13:Lon Lon Ranch", "13:Lon Lon-Farm", "13:Ranch Lon Lon", Select_LoadGame, 5, { 
         { "From Hyrule Field", "Von der Hylianischen Steppe", "Depuis la Plaine d'Hyrule", ENTR_LON_LON_RANCH_0, 0 },
         { "From Ranch House", "Vom Farmhaus", "Depuis la Maison du Ranch", ENTR_LON_LON_RANCH_4, 0 },
         { "From Stables", "Vom Stall", "Depuis l'Etable", ENTR_LON_LON_RANCH_5, 0 },
+        { "From Silo", "Vom Silo", "Depuis Silo du Ranch", ENTR_LON_LON_RANCH_10, 0 },
         { "Epona Song Cutscene", "Eponas Song Cutscene", "Cinematique du Chant d'Epona", ENTR_LON_LON_RANCH_1, 0 },
     }},
     { "14:Lon Lon Ranch Buildings", "14:Lon Lon-Farm Gebaeude", "14:Batiments du Ranch Lon Lon", Select_LoadGame, 3, {

--- a/soh/src/overlays/gamestates/ovl_select/z_select.c
+++ b/soh/src/overlays/gamestates/ovl_select/z_select.c
@@ -359,7 +359,7 @@ static BetterSceneSelectEntry sBetterScenes[] = {
         { "From Hyrule Field", "Von der Hylianischen Steppe", "Depuis la Plaine d'Hyrule", ENTR_LON_LON_RANCH_0, 0 },
         { "From Ranch House", "Vom Farmhaus", "Depuis la Maison du Ranch", ENTR_LON_LON_RANCH_4, 0 },
         { "From Stables", "Vom Stall", "Depuis l'Etable", ENTR_LON_LON_RANCH_5, 0 },
-        { "From Silo", "Vom Silo", "Depuis Silo du Ranch", ENTR_LON_LON_RANCH_10, 0 },
+        { "From Back Tower", "Vom Silo", "Depuis Silo du Ranch", ENTR_LON_LON_RANCH_10, 0 },
         { "Epona Song Cutscene", "Eponas Song Cutscene", "Cinematique du Chant d'Epona", ENTR_LON_LON_RANCH_1, 0 },
     }},
     { "14:Lon Lon Ranch Buildings", "14:Lon Lon-Farm Gebaeude", "14:Batiments du Ranch Lon Lon", Select_LoadGame, 3, {


### PR DESCRIPTION
I couldn't see any obvious reason for this one not to be in the list (just went unnoticed, I'm guessing).

To be clear, this is the entrance to Lon Lon Ranch from the silo at the back.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1065613541.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1065613543.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1065613545.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1065613547.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1065613549.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1065613551.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1065613553.zip)
<!--- section:artifacts:end -->