### PR TITLE
Fix: Skybox crash for Mask Shop

### DIFF
--- a/soh/src/code/z_vr_box.c
+++ b/soh/src/code/z_vr_box.c
@@ -417,7 +417,12 @@ void func_800AEFC8(SkyboxContext* skyboxCtx, s16 skyboxId) {
     s32 j;
     s32 phi_s3 = 0;
 
-    if (skyboxId == SKYBOX_BAZAAR || (skyboxId > SKYBOX_HOUSE_KAKARIKO && skyboxId <= SKYBOX_BOMBCHU_SHOP)) {
+    //! @bug All shops only provide 2 faces for their sky box. Mask shop is missing from the condition
+    // meaning that the Mask shop will calculate 4 faces
+    // This effect is not noticed as the faces are behind the camera, but will cause a crash in SoH.
+    // SOH General: We have added the Mask shop to this check so only the 2 expected faces are calculated.
+    if (skyboxId == SKYBOX_BAZAAR || skyboxId == SKYBOX_HAPPY_MASK_SHOP ||
+        (skyboxId >= SKYBOX_KOKIRI_SHOP && skyboxId <= SKYBOX_BOMBCHU_SHOP)) {
         for (j = 0, i = 0; i < 2; i++, j += 2) {
             phi_s3 = func_800ADBB0(skyboxCtx, skyboxCtx->roomVtx, phi_s3, D_8012AEBC[i].unk_0, D_8012AEBC[i].unk_4,
                                    D_8012AEBC[i].unk_8, D_8012AEBC[i].unk_C, D_8012AEBC[i].unk_10, i, j);

--- a/soh/src/code/z_vr_box_draw.c
+++ b/soh/src/code/z_vr_box_draw.c
@@ -59,8 +59,14 @@ void SkyboxDraw_Draw(SkyboxContext* skyboxCtx, GraphicsContext* gfxCtx, s16 skyb
         gSPDisplayList(POLY_OPA_DISP++, skyboxCtx->dListBuf[2]);
         gSPDisplayList(POLY_OPA_DISP++, skyboxCtx->dListBuf[3]);
 
-        if (skyboxId != SKYBOX_BAZAAR) {
-            if (skyboxId <= SKYBOX_HOUSE_KAKARIKO || skyboxId > SKYBOX_BOMBCHU_SHOP) {
+        //! @bug All shops only provide 2 faces for their sky box. Mask shop is missing from the condition
+        // meaning that the Mask shop will render the previously loaded sky box values, or uninitialized data.
+        // This effect is not noticed as the faces are behind the camera, but will cause a crash in SoH.
+        // SOH General: We have added the Mask shop to this check so only the 2 expected faces are rendered.
+        if (skyboxId != SKYBOX_BAZAAR && skyboxId != SKYBOX_HAPPY_MASK_SHOP) {
+            if (skyboxId < SKYBOX_KOKIRI_SHOP || skyboxId > SKYBOX_BOMBCHU_SHOP) {
+                // Skip remaining faces for most shop skyboxes
+
                 gDPPipeSync(POLY_OPA_DISP++);
                 gDPLoadTLUT_pal256(POLY_OPA_DISP++, skyboxCtx->palettes[2]);
                 gSPDisplayList(POLY_OPA_DISP++, skyboxCtx->dListBuf[4]);


### PR DESCRIPTION
After the investigation for the Mask Shop crash in Entrance rando here #2577, it was found that the skybox rendering garbage data was responsible for the crash. The original skybox code makes it so only 2 faces are rendered for all the shops, but Mask Shop was not included. This is most likely an authentic bug that is not known as the camera is locked in place for shops and on console most likely garbage data is rendered behind the camera.

On SoH however this garbage data will crash the rendered. I've updated the skybox code to include the Mask Shop so that only the 2 expected faces are rendered like the other shops.

---

I've left a comment documenting the authentic bug and a tag about why it is being fixed by SoH. I am unsure if we would want this behind a CVar. This feels like something that should always apply and not be toggle-able by players. I'd be open to a hidden CVar if we want it, but maybe the comment is sufficient enough.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1065506702.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1065506703.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1065506704.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1065506705.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1065506706.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1065506707.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1065506708.zip)
<!--- section:artifacts:end -->