### PR TITLE
Fix audio cutoff issues

### DIFF
--- a/soh/soh/stubs.c
+++ b/soh/soh/stubs.c
@@ -260,7 +260,7 @@ void Audio_osWritebackDCache(void* mem, s32 size)
 
 s32 osAiSetFrequency(u32 freq)
 {
-
+	return 1;
 }
 
 s32 osEPiStartDma(OSPiHandle* handle, OSIoMesg* mb, s32 direction)


### PR DESCRIPTION
The result of osAiSetFrequency was being used later on to multiply the length an audio sequence would play. In debug mode this stub was returning 1, whereas in release mode this would return whatever was passed in as the `freq` argument.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1067578288.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1067578290.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1067578292.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1067578294.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1067578296.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1067578297.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1067578299.zip)
<!--- section:artifacts:end -->