### PR TITLE
Mask improvements

### DIFF
--- a/soh/include/z64save.h
+++ b/soh/include/z64save.h
@@ -290,6 +290,7 @@ typedef struct {
     /*        */ SohStats sohStats;
     /*        */ FaroresWindData backupFW;
     /*        */ RandomizerCheckTrackerData checkTrackerData[RC_MAX];
+    /*        */ u8 maskMemory;
     // #endregion
     // #region SOH [Randomizer]
     // Upstream TODO: Move these to their own struct or name to more obviously specific to Randomizer

--- a/soh/soh/SaveManager.cpp
+++ b/soh/soh/SaveManager.cpp
@@ -1915,6 +1915,7 @@ void SaveManager::LoadBaseVersion4() {
         SaveManager::Instance->LoadData("tempCollectFlags", gSaveContext.backupFW.tempCollectFlags);
     });
     SaveManager::Instance->LoadData("dogParams", gSaveContext.dogParams);
+    SaveManager::Instance->LoadData("maskMemory", gSaveContext.maskMemory);
 }
 
 void SaveManager::SaveBase(SaveContext* saveContext, int sectionID, bool fullSave) {
@@ -2084,6 +2085,7 @@ void SaveManager::SaveBase(SaveContext* saveContext, int sectionID, bool fullSav
         SaveManager::Instance->SaveData("tempCollectFlags", saveContext->backupFW.tempCollectFlags);
     });
     SaveManager::Instance->SaveData("dogParams", saveContext->dogParams);
+    SaveManager::Instance->SaveData("maskMemory", saveContext->maskMemory);
 }
 
 // Load a string into a char array based on size and ensuring it is null terminated when overflowed

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -600,6 +600,8 @@ void DrawEnhancementsMenu() {
                 );
                 UIWidgets::PaddedEnhancementCheckbox("Bunny Hood Equippable as Adult", "gAdultBunnyHood", true, false, (CVarGetInteger("gMMBunnyHood", BUNNY_HOOD_VANILLA) == BUNNY_HOOD_VANILLA), "Only available with increased bunny hood speed", UIWidgets::CheckboxGraphics::Cross, false);
                 UIWidgets::Tooltip("Allows the bunny hood to be equipped normally from the pause menu as adult.");
+                UIWidgets::PaddedEnhancementCheckbox("Stop automatic mask unequipping", "gKeepMasks", true, false);
+                UIWidgets::Tooltip("Stops masks from automatically unequipping when not in any C button or the dpad.");
                 UIWidgets::PaddedEnhancementCheckbox("Mask Select in Inventory", "gMaskSelect", true, false);
                 UIWidgets::Tooltip("After completing the mask trading sub-quest, press A and any direction on the mask slot to change masks");
                 UIWidgets::PaddedEnhancementCheckbox("Nuts explode bombs", "gNutsExplodeBombs", true, false);

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -602,6 +602,8 @@ void DrawEnhancementsMenu() {
                 UIWidgets::Tooltip("Allows the bunny hood to be equipped normally from the pause menu as adult.");
                 UIWidgets::PaddedEnhancementCheckbox("Stop automatic mask unequipping", "gKeepMasks", true, false);
                 UIWidgets::Tooltip("Stops masks from automatically unequipping when not in any C button or the dpad.");
+                UIWidgets::PaddedEnhancementCheckbox("Save equipped mask to file", "gSaveMasksToFile", true, false);
+                UIWidgets::Tooltip("If you save and quit with a mask on, it'll still be on when you load back in.");
                 UIWidgets::PaddedEnhancementCheckbox("Mask Select in Inventory", "gMaskSelect", true, false);
                 UIWidgets::Tooltip("After completing the mask trading sub-quest, press A and any direction on the mask slot to change masks");
                 UIWidgets::PaddedEnhancementCheckbox("Nuts explode bombs", "gNutsExplodeBombs", true, false);

--- a/soh/src/code/z_sram.c
+++ b/soh/src/code/z_sram.c
@@ -120,6 +120,10 @@ void Sram_OpenSave() {
         }
     }
 
+    if (!CVarGetInteger("gSaveMasksToFile", 0)) {
+        gSaveContext.maskMemory = PLAYER_MASK_NONE;
+    }
+
     osSyncPrintf("scene_no = %d\n", gSaveContext.entranceIndex);
     osSyncPrintf(VT_RST);
 

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -2069,7 +2069,7 @@ void func_80833DF8(Player* this, PlayState* play) {
 
             if (gSaveContext.equips.buttonItems[0] != maskItem && gSaveContext.equips.buttonItems[1] != maskItem &&
                 gSaveContext.equips.buttonItems[2] != maskItem && gSaveContext.equips.buttonItems[3] != maskItem &&
-                !hasOnDpad) {
+                !hasOnDpad && !CVarGetInteger("gKeepMasks", 0)) {
                 this->currentMask = sMaskMemory = PLAYER_MASK_NONE;
                 func_808328EC(this, NA_SE_PL_CHANGE_ARMS);
             }

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -1064,7 +1064,6 @@ static s8 sItemActionParams[] = {
     PLAYER_IA_BOOTS_HOVER,
 };
 
-static u8 sMaskMemory;
 u8 gWalkSpeedToggle1;
 u8 gWalkSpeedToggle2;
 
@@ -2070,7 +2069,7 @@ void func_80833DF8(Player* this, PlayState* play) {
             if (gSaveContext.equips.buttonItems[0] != maskItem && gSaveContext.equips.buttonItems[1] != maskItem &&
                 gSaveContext.equips.buttonItems[2] != maskItem && gSaveContext.equips.buttonItems[3] != maskItem &&
                 !hasOnDpad && !CVarGetInteger("gKeepMasks", 0)) {
-                this->currentMask = sMaskMemory = PLAYER_MASK_NONE;
+                this->currentMask = gSaveContext.maskMemory = PLAYER_MASK_NONE;
                 func_808328EC(this, NA_SE_PL_CHANGE_ARMS);
             }
         } else {
@@ -3021,7 +3020,7 @@ void func_80835F44(PlayState* play, Player* this, s32 item) {
                 } else {
                     this->currentMask = actionParam - PLAYER_IA_MASK_KEATON + 1;
                 }
-                sMaskMemory = this->currentMask;
+                gSaveContext.maskMemory = this->currentMask;
                 func_808328EC(this, NA_SE_PL_CHANGE_ARMS);
                 return;
             }
@@ -4648,7 +4647,7 @@ void func_8083A0F4(PlayState* play, Player* this) {
             this->interactRangeActor->parent = &this->actor;
             func_80835C58(play, this, func_8084F608, 0);
             this->stateFlags1 |= PLAYER_STATE1_IN_CUTSCENE;
-            sMaskMemory = PLAYER_MASK_NONE;
+            gSaveContext.maskMemory = PLAYER_MASK_NONE;
         } else {
             LinkAnimationHeader* anim;
 
@@ -8408,7 +8407,7 @@ void func_80843AE8(PlayState* play, Player* this) {
         OnePointCutscene_Init(play, 9908, 125, &this->actor, MAIN_CAM);
     } else if (play->gameOverCtx.state == GAMEOVER_DEATH_WAIT_GROUND) {
         play->gameOverCtx.state = GAMEOVER_DEATH_DELAY_MENU;
-        sMaskMemory = PLAYER_MASK_NONE;
+        gSaveContext.maskMemory = PLAYER_MASK_NONE;
     }
 }
 
@@ -9663,9 +9662,9 @@ void Player_Init(Actor* thisx, PlayState* play2) {
     this->prevBoots = this->currentBoots;
     if (CVarGetInteger("gMMBunnyHood", BUNNY_HOOD_VANILLA) != BUNNY_HOOD_VANILLA) {
         if (INV_CONTENT(ITEM_TRADE_CHILD) == ITEM_SOLD_OUT) {
-            sMaskMemory = PLAYER_MASK_NONE;
+            gSaveContext.maskMemory = PLAYER_MASK_NONE;
         }
-        this->currentMask = sMaskMemory;
+        this->currentMask = gSaveContext.maskMemory;
     }
     Player_InitCommon(this, play, gPlayerSkelHeaders[((void)0, gSaveContext.linkAge)]);
     this->giObjectSegment = (void*)(((uintptr_t)ZELDA_ARENA_MALLOC_DEBUG(0x3008) + 8) & ~0xF);


### PR DESCRIPTION
Adds an enhancement to stop masks from automatically unequipping when not in any C button or the dpad and also adds an enhancement so that if you save and quit with a mask on, it'll still be on when you load back in.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1067733902.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1067733903.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1067733905.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1067733907.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1067733910.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1067733911.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1067733912.zip)
<!--- section:artifacts:end -->