### PR TITLE
Random Enemy Sizes small fixes

### DIFF
--- a/soh/soh/Enhancements/mods.cpp
+++ b/soh/soh/Enhancements/mods.cpp
@@ -1025,8 +1025,16 @@ void RegisterRandomizedEnemySizes() {
         Player* player = GET_PLAYER(gPlayState);
         Actor* actor = static_cast<Actor*>(refActor);
 
-        // Only apply to enemies and bosses. Exclude the wobbly platforms in Jabu because they need to act like platforms.
-        if (!CVarGetInteger("gRandomizedEnemySizes", 0) || (actor->category != ACTORCAT_ENEMY && actor->category != ACTORCAT_BOSS) || actor->id == ACTOR_EN_BROB) {
+        // Exclude wobbly platforms in Jabu because they need to act like platforms.
+        // Exclude Dead Hand hands and Bongo Bongo main body because they make the fights (near) impossible.
+        uint8_t excludedEnemy = actor->id == ACTOR_EN_BROB || actor->id == ACTOR_EN_DHA || (actor->id == ACTOR_BOSS_SST && actor->params == -1);
+
+        // Dodongo, Volvagia and Dead Hand are always smaller because they're impossible when bigger.
+        uint8_t smallOnlyEnemy =
+            actor->id == ACTOR_BOSS_DODONGO || actor->id == ACTOR_BOSS_FD || actor->id == ACTOR_BOSS_FD2 || ACTOR_EN_DH;
+
+        // Only apply to enemies and bosses.
+        if (!CVarGetInteger("gRandomizedEnemySizes", 0) || (actor->category != ACTORCAT_ENEMY && actor->category != ACTORCAT_BOSS) || excludedEnemy) {
             return;
         }
 
@@ -1035,9 +1043,8 @@ void RegisterRandomizedEnemySizes() {
 
         uint8_t bigActor = rand() % 2;
 
-        // Big actor. Dodongo and Volvagia are always smaller because they're impossible when bigger.
-        if (bigActor && actor->id != ACTOR_BOSS_DODONGO && actor->id != ACTOR_BOSS_FD &&
-            actor->id != ACTOR_BOSS_FD2) {
+        // Big actor
+        if (bigActor && !smallOnlyEnemy) {
             randomNumber = rand() % 200;
             // Between 100% and 300% size.
             randomScale = 1.0f + (randomNumber / 100);


### PR DESCRIPTION
Disables it for Dead Hand hands and Bongo Bongo's main body, and Dead Hand can only be smaller now, The fights were very likely to be impossible without these exclusions.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1074831709.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1074831712.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1074831713.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1074831714.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1074831715.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1074831716.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1074831717.zip)
<!--- section:artifacts:end -->