### PR TITLE
Fix ParseFileXML for Text resources

### DIFF
--- a/soh/soh/resource/importer/TextFactory.cpp
+++ b/soh/soh/resource/importer/TextFactory.cpp
@@ -66,6 +66,10 @@ void LUS::TextFactoryV0::ParseFileBinary(std::shared_ptr<BinaryReader> reader,
 	text->messages.push_back(entry);
     }
 }
+
+// This is a special character that we use to replace the null terminator in the message, otherwise tinyxml2 will stop reading the string
+const char* XML_NULL_TERMINATOR = "\x7F";
+
 void TextFactoryV0::ParseFileXML(tinyxml2::XMLElement* reader, std::shared_ptr<IResource> resource) {
     std::shared_ptr<Text> txt = std::static_pointer_cast<Text>(resource);
 
@@ -80,10 +84,16 @@ void TextFactoryV0::ParseFileXML(tinyxml2::XMLElement* reader, std::shared_ptr<I
             entry.textboxType = child->IntAttribute("TextboxType");
             entry.textboxYPos = child->IntAttribute("TextboxYPos");
             entry.msg = child->Attribute("Message");
-            entry.msg += "\x2";
+
+            // Replace the special string with a null terminator if it exists
+            size_t nullTerminatorPos = entry.msg.find(XML_NULL_TERMINATOR);
+            while (nullTerminatorPos != std::string::npos) {
+                entry.msg.replace(nullTerminatorPos, strlen(XML_NULL_TERMINATOR), " ");
+                entry.msg[nullTerminatorPos] = '\0';
+                nullTerminatorPos = entry.msg.find(XML_NULL_TERMINATOR);
+            }
 
             txt->messages.push_back(entry);
-            int bp = 0;
         }
 
         child = child->NextSiblingElement();


### PR DESCRIPTION
Basically no one is using this in practice yet, and if they had been they would have run into issues. Only effects incoming text resources as XML.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1076223423.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1076223427.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1076223430.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1076223433.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1076223437.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1076223438.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1076223440.zip)
<!--- section:artifacts:end -->