### PR TITLE
Item cycling improvements

### DIFF
--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_item.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_item.c
@@ -234,7 +234,7 @@ void KaleidoScope_DrawItemCycleExtras(PlayState* play, u8 slot, u8 canCycle, u8 
     CLOSE_DISPS(play->state.gfxCtx);
 }
 
-void KaleidoScope_HandleItemCycleExtras(PlayState* play, u8 slot, bool canCycle, u8 leftItem, u8 rightItem) {
+void KaleidoScope_HandleItemCycleExtras(PlayState* play, u8 slot, bool canCycle, u8 leftItem, u8 rightItem, bool replaceCButtons) {
     Input* input = &play->state.input[0];
     PauseContext* pauseCtx = &play->pauseCtx;
     bool dpad = (CVarGetInteger("gDpadPause", 0) && !CHECK_BTN_ALL(input->cur.button, BTN_CUP));
@@ -256,10 +256,36 @@ void KaleidoScope_HandleItemCycleExtras(PlayState* play, u8 slot, bool canCycle,
         if ((pauseCtx->stickRelX > 30 || pauseCtx->stickRelY > 30) ||
              dpad && CHECK_BTN_ANY(input->press.button, BTN_DRIGHT | BTN_DUP)) {
             Audio_PlaySoundGeneral(NA_SE_SY_CURSOR, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
+            if (replaceCButtons) {
+                for (int i = 1; i < ARRAY_COUNT(gSaveContext.equips.buttonItems); i++) {
+                    if (gSaveContext.equips.buttonItems[i] == gSaveContext.inventory.items[slot]) {
+                        if (CHECK_AGE_REQ_ITEM(rightItem)) {
+                            gSaveContext.equips.buttonItems[i] = rightItem;
+                            Interface_LoadItemIcon1(play, i);
+                        } else {
+                            gSaveContext.equips.buttonItems[i] = ITEM_NONE;
+                        }
+                        break;
+                    }
+                }
+            }
             gSaveContext.inventory.items[slot] = rightItem;
         } else if ((pauseCtx->stickRelX < -30 || pauseCtx->stickRelY < -30) ||
             dpad && CHECK_BTN_ANY(input->press.button, BTN_DLEFT | BTN_DDOWN)) {
             Audio_PlaySoundGeneral(NA_SE_SY_CURSOR, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
+            if (replaceCButtons) {
+                for (int i = 1; i < ARRAY_COUNT(gSaveContext.equips.buttonItems); i++) {
+                    if (gSaveContext.equips.buttonItems[i] == gSaveContext.inventory.items[slot]) {
+                        if (CHECK_AGE_REQ_ITEM(leftItem)) {
+                            gSaveContext.equips.buttonItems[i] = leftItem;
+                            Interface_LoadItemIcon1(play, i);
+                        } else {
+                            gSaveContext.equips.buttonItems[i] = ITEM_NONE;
+                        }
+                        break;
+                    }
+                }
+            }
             gSaveContext.inventory.items[slot] = leftItem;
         }
         gCurrentItemCyclingSlot = pauseCtx->cursorSlot[PAUSE_ITEM] == slot ? slot : -1;
@@ -288,7 +314,8 @@ void KaleidoScope_HandleItemCycles(PlayState* play) {
             INV_CONTENT(ITEM_TRADE_CHILD) - 1,
         INV_CONTENT(ITEM_TRADE_CHILD) >= ITEM_MASK_TRUTH || INV_CONTENT(ITEM_TRADE_CHILD) < ITEM_MASK_KEATON ?
             ITEM_MASK_KEATON :
-            INV_CONTENT(ITEM_TRADE_CHILD) + 1
+            INV_CONTENT(ITEM_TRADE_CHILD) + 1,
+        true
     );
 
     gSlotAgeReqs[SLOT_TRADE_CHILD] =
@@ -311,7 +338,8 @@ void KaleidoScope_HandleItemCycles(PlayState* play) {
         SLOT_TRADE_ADULT,
         IS_RANDO && Randomizer_GetSettingValue(RSK_SHUFFLE_ADULT_TRADE),
         Randomizer_GetPrevAdultTradeItem(),
-        Randomizer_GetNextAdultTradeItem()
+        Randomizer_GetNextAdultTradeItem(),
+        true
     );
 }
 

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_item.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_item.c
@@ -238,7 +238,16 @@ void KaleidoScope_HandleItemCycleExtras(PlayState* play, u8 slot, bool canCycle,
     Input* input = &play->state.input[0];
     PauseContext* pauseCtx = &play->pauseCtx;
     bool dpad = (CVarGetInteger("gDpadPause", 0) && !CHECK_BTN_ALL(input->cur.button, BTN_CUP));
-    if (canCycle && pauseCtx->cursorSlot[PAUSE_ITEM] == slot && CHECK_BTN_ALL(input->press.button, BTN_A)) {
+    u8 slotItem = gSaveContext.inventory.items[slot];
+    u8 hasLeftItem = leftItem != ITEM_NONE && slotItem != leftItem;
+    u8 hasRightItem = rightItem != ITEM_NONE && slotItem != rightItem && leftItem != rightItem;
+
+    if (
+        canCycle &&
+        pauseCtx->cursorSlot[PAUSE_ITEM] == slot &&
+        CHECK_BTN_ALL(input->press.button, BTN_A) &&
+        (hasLeftItem || hasRightItem)
+    ) {
         Audio_PlaySoundGeneral(NA_SE_SY_DECIDE, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
         gCurrentItemCyclingSlot = gCurrentItemCyclingSlot == slot ? -1 : slot;
     }

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_item.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_item.c
@@ -305,6 +305,7 @@ bool CanMaskSelect() {
 }
 
 void KaleidoScope_HandleItemCycles(PlayState* play) {
+    //handle the mask select
     KaleidoScope_HandleItemCycleExtras(
         play,
         SLOT_TRADE_CHILD,
@@ -318,6 +319,9 @@ void KaleidoScope_HandleItemCycles(PlayState* play) {
         true
     );
 
+    //the slot age requirement for the child trade slot has to be updated
+    //in case it currently holds the bunny hood
+    //to allow adult link to wear it if the setting is enabled
     gSlotAgeReqs[SLOT_TRADE_CHILD] =
         (
             ((CVarGetInteger("gMMBunnyHood", BUNNY_HOOD_VANILLA) != BUNNY_HOOD_VANILLA) && CVarGetInteger("gAdultBunnyHood", 0)) ||
@@ -327,12 +331,14 @@ void KaleidoScope_HandleItemCycles(PlayState* play) {
             ? AGE_REQ_NONE
             : AGE_REQ_CHILD;
     
+    //also update the age requirement for the bunny hood itself
     gItemAgeReqs[ITEM_MASK_BUNNY] =
         ((CVarGetInteger("gMMBunnyHood", BUNNY_HOOD_VANILLA) != BUNNY_HOOD_VANILLA) && CVarGetInteger("gAdultBunnyHood", 0)) ||
         CVarGetInteger("gTimelessEquipment", 0)
             ? AGE_REQ_NONE
             : AGE_REQ_CHILD;
 
+    //handle the adult trade select
     KaleidoScope_HandleItemCycleExtras(
         play,
         SLOT_TRADE_ADULT,
@@ -344,6 +350,7 @@ void KaleidoScope_HandleItemCycles(PlayState* play) {
 }
 
 void KaleidoScope_DrawItemCycles(PlayState* play) {
+    //draw the mask select
     KaleidoScope_DrawItemCycleExtras(
         play,
         SLOT_TRADE_CHILD,
@@ -356,6 +363,7 @@ void KaleidoScope_DrawItemCycles(PlayState* play) {
             INV_CONTENT(ITEM_TRADE_CHILD) + 1
     );
     
+    //draw the adult trade select
     KaleidoScope_DrawItemCycleExtras(
         play,
         SLOT_TRADE_ADULT,
@@ -369,7 +377,7 @@ bool IsItemCycling() {
     return gCurrentItemCyclingSlot != -1;
 }
 
-void KaleidoScope_ResetTradeSelect() {
+void KaleidoScope_ResetItemCycling() {
     gCurrentItemCyclingSlot = -1;
 }
 
@@ -770,7 +778,7 @@ void KaleidoScope_DrawItemSelect(PlayState* play) {
 void KaleidoScope_SetupItemEquip(PlayState* play, u16 item, u16 slot, s16 animX, s16 animY) {
     Input* input = &play->state.input[0];
     PauseContext* pauseCtx = &play->pauseCtx;
-    KaleidoScope_ResetTradeSelect();
+    KaleidoScope_ResetItemCycling();
 
     if (CHECK_BTN_ALL(input->press.button, BTN_CLEFT)) {
         pauseCtx->equipTargetCBtn = 0;

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_item.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_item.c
@@ -212,10 +212,20 @@ void KaleidoScope_DrawItemCycleExtras(PlayState* play, u8 slot, u8 canCycle, u8 
         gSPVertex(POLY_KAL_DISP++, sCycleExtraItemVtx, 8, 0);
 
         if (showLeftItem) {
+            if (!CHECK_AGE_REQ_ITEM(leftItem)) {
+                gDPSetGrayscaleColor(POLY_KAL_DISP++, 109, 109, 109, 255);
+                gSPGrayscale(POLY_KAL_DISP++, true);
+            }
             KaleidoScope_DrawQuadTextureRGBA32(play->state.gfxCtx, gItemIcons[leftItem], 32, 32, 0);
+            gSPGrayscale(POLY_KAL_DISP++, false);
         }
         if (showRightItem) {
+            if (!CHECK_AGE_REQ_ITEM(rightItem)) {
+                gDPSetGrayscaleColor(POLY_KAL_DISP++, 109, 109, 109, 255);
+                gSPGrayscale(POLY_KAL_DISP++, true);
+            }
             KaleidoScope_DrawQuadTextureRGBA32(play->state.gfxCtx, gItemIcons[rightItem], 32, 32, 4);
+            gSPGrayscale(POLY_KAL_DISP++, false);
         }
 
         Matrix_Pop();
@@ -271,6 +281,21 @@ void KaleidoScope_HandleItemCycles(PlayState* play) {
             ITEM_MASK_KEATON :
             INV_CONTENT(ITEM_TRADE_CHILD) + 1
     );
+
+    gSlotAgeReqs[SLOT_TRADE_CHILD] =
+        (
+            ((CVarGetInteger("gMMBunnyHood", BUNNY_HOOD_VANILLA) != BUNNY_HOOD_VANILLA) && CVarGetInteger("gAdultBunnyHood", 0)) ||
+            CVarGetInteger("gTimelessEquipment", 0)
+        ) &&
+        INV_CONTENT(ITEM_TRADE_CHILD) == ITEM_MASK_BUNNY
+            ? AGE_REQ_NONE
+            : AGE_REQ_CHILD;
+    
+    gItemAgeReqs[ITEM_MASK_BUNNY] =
+        ((CVarGetInteger("gMMBunnyHood", BUNNY_HOOD_VANILLA) != BUNNY_HOOD_VANILLA) && CVarGetInteger("gAdultBunnyHood", 0)) ||
+        CVarGetInteger("gTimelessEquipment", 0)
+            ? AGE_REQ_NONE
+            : AGE_REQ_CHILD;
 
     KaleidoScope_HandleItemCycleExtras(
         play,

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope.h
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope.h
@@ -45,6 +45,6 @@ void PauseMapMark_Draw(PlayState* play);
 
 void KaleidoScope_UpdateCursorSize(PauseContext* pauseCtx);
 
-void KaleidoScope_ResetTradeSelect();
+void KaleidoScope_ResetItemCycling();
 
 #endif

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope.h
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope.h
@@ -11,7 +11,6 @@ extern u8 gEquipAgeReqs[][4];
 extern u8 gSlotAgeReqs[];
 extern u8 gItemAgeReqs[];
 extern u8 gAreaGsFlags[];
-extern bool gSelectingMask;
 
 #define AGE_REQ_ADULT LINK_AGE_ADULT
 #define AGE_REQ_CHILD LINK_AGE_CHILD

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
@@ -1008,7 +1008,7 @@ void KaleidoScope_SetDefaultCursor(PlayState* play) {
     PauseContext* pauseCtx = &play->pauseCtx;
     s16 s;
     s16 i;
-    gSelectingMask = false;
+    KaleidoScope_ResetTradeSelect();
 
     switch (pauseCtx->pageIndex) {
         case PAUSE_ITEM:
@@ -1042,7 +1042,6 @@ void KaleidoScope_SetDefaultCursor(PlayState* play) {
 void KaleidoScope_SwitchPage(PauseContext* pauseCtx, u8 pt) {
     pauseCtx->unk_1E4 = 1;
     pauseCtx->unk_1EA = 0;
-    gSelectingMask = false;
 
     if (!pt) {
         pauseCtx->mode = pauseCtx->pageIndex * 2 + 1;

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
@@ -1008,7 +1008,7 @@ void KaleidoScope_SetDefaultCursor(PlayState* play) {
     PauseContext* pauseCtx = &play->pauseCtx;
     s16 s;
     s16 i;
-    KaleidoScope_ResetTradeSelect();
+    KaleidoScope_ResetItemCycling();
 
     switch (pauseCtx->pageIndex) {
         case PAUSE_ITEM:
@@ -1073,7 +1073,7 @@ void KaleidoScope_SwitchPage(PauseContext* pauseCtx, u8 pt) {
     gSaveContext.unk_13EA = 0;
     Interface_ChangeAlpha(50);
 
-    KaleidoScope_ResetTradeSelect();
+    KaleidoScope_ResetItemCycling();
 }
 
 void KaleidoScope_HandlePageToggles(PauseContext* pauseCtx, Input* input) {
@@ -3735,7 +3735,7 @@ void KaleidoScope_Update(PlayState* play)
                 }
             }
 
-            KaleidoScope_ResetTradeSelect();
+            KaleidoScope_ResetItemCycling();
 
             pauseCtx->state = 4;
             break;


### PR DESCRIPTION
This PR improves several aspects of the item cycling implementation making it easier to modify (or add new item cycles) in code.
It also makes items for the wrong age grayed out when they're the previous or next item in the cycle.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1136734217.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1136734220.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1136734224.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1136734226.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1136734229.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1136734234.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1136734236.zip)
<!--- section:artifacts:end -->