### PR TITLE
Fix: Bugs not working for soil patches with bugs don't despawn cheat

### DIFF
--- a/soh/src/overlays/actors/ovl_En_Insect/z_en_insect.c
+++ b/soh/src/overlays/actors/ovl_En_Insect/z_en_insect.c
@@ -211,6 +211,13 @@ void EnInsect_Init(Actor* thisx, PlayState* play2) {
 
         func_80A7D39C(this);
 
+        // For bugs that aren't linked to a soil patch, we remove the "short lived" flag to prevent them from despawning
+        // And exit early to not increment the "bugs dropped count"
+        if (CVarGetInteger("gNoBugsDespawn", 0) && this->soilActor == NULL) {
+            this->unk_314 &= ~4;
+            return;
+        }
+
         D_80A7DEB8++;
     } else {
         rand = Rand_ZeroOne();
@@ -394,9 +401,6 @@ void func_80A7CAD0(EnInsect* this, PlayState* play) {
 }
 
 void func_80A7CBC8(EnInsect* this) {
-    if (CVarGetInteger("gNoBugsDespawn", 0) != 0) {
-        return;
-    }
     this->unk_31A = 60;
     func_80A7BF58(this);
     this->skelAnime.playSpeed = 1.9f;


### PR DESCRIPTION
The "Bugs Don't despawn" cheat was interferring with bugs ability to dig into the soil patches as the check was preventing the "dig" action func from ever running. The dig action func is responsible for informing the soil patch that the bugs are done digging and to then spawn the gold skulltula.

This PR resolves that by moving the logic to the init func and checking to see if a soil patch is linked to the bugs. If there is no soil patch, then we remove the flag that marks the bug as a "short lived" bug, effectively making it never dig. The other important part is to not increment the "bugs dropped count" value. Normally if there is 4 or more bugs "dropped", then new bugs dropped instantly dig in place. For a soil patch to spawn the GS, the bugs need to dig directly in the center. By not incrementing the dropped count for the bugs, the new ones will correctly path find to the soil patch and dig properly.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1076787925.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1076787928.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1076787930.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1076787932.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1076787933.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1076787934.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1076787935.zip)
<!--- section:artifacts:end -->