### PR TITLE
Change declaration of Morpha tentacle verts to combine them all and avoid overlaps that result in dropped verts

### DIFF
--- a/soh/assets/xml/GC_MQ_D/objects/object_mo.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_mo.xml
@@ -79,7 +79,7 @@
             <Vtx/>
         </Array>
 
-        <Array Name="gMorphaVtx_007BB8" Count="4" Offset="0x7BB8">
+        <Array Name="gMorphaVtx_006A18" Count="286" Offset="0x006A18">
             <Vtx/>
         </Array>
 

--- a/soh/assets/xml/GC_MQ_PAL_F/objects/object_mo.xml
+++ b/soh/assets/xml/GC_MQ_PAL_F/objects/object_mo.xml
@@ -8,7 +8,7 @@
         <!-- Morpha's Title Card -->
         <Texture Name="gMorphaTitleCardTex" Format="i8" Width="128" Height="120" Offset="0x1010"/>
         <Texture Name="gMorphaWaterTex" Format="rgba16" Width="32" Height="32" Offset="0x8870"/>
-				
+
         <!-- DLists for Morpha's Core -->
         <DList Name="gMorphaCoreMembraneDL" Offset="0x6700"/>
         <DList Name="gMorphaCoreNucleusDL" Offset="0x6838"/>
@@ -69,17 +69,17 @@
         <!-- Unused content -->
 
         <!-- This is the dlist for EnVbBall for some reason. -->
-        <DList Name="gMorphaDL_000550" Offset="0x550"/> 
+        <DList Name="gMorphaDL_000550" Offset="0x550"/>
 
         <DList Name="gMorphaDL_000EC0" Offset="0xEC0"/>
         <DList Name="gMorphaDL_000EF8" Offset="0xEF8"/>
         <DList Name="gMorphaDL_007BF8" Offset="0x7BF8"/>
-        
+
         <Array Name="gMorphaVtx_006938" Count="14" Offset="0x6938">
             <Vtx/>
         </Array>
 
-        <Array Name="gMorphaVtx_007BB8" Count="4" Offset="0x7BB8">
+        <Array Name="gMorphaVtx_006A18" Count="286" Offset="0x006A18">
             <Vtx/>
         </Array>
 

--- a/soh/assets/xml/GC_NMQ_D/objects/object_mo.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_mo.xml
@@ -8,7 +8,7 @@
         <!-- Morpha's Title Card -->
         <Texture Name="gMorphaTitleCardTex" Format="i8" Width="128" Height="120" Offset="0x1010"/>
         <Texture Name="gMorphaWaterTex" Format="rgba16" Width="32" Height="32" Offset="0x8870"/>
-				
+
         <!-- DLists for Morpha's Core -->
         <DList Name="gMorphaCoreMembraneDL" Offset="0x6700"/>
         <DList Name="gMorphaCoreNucleusDL" Offset="0x6838"/>
@@ -69,17 +69,17 @@
         <!-- Unused content -->
 
         <!-- This is the dlist for EnVbBall for some reason. -->
-        <DList Name="gMorphaDL_000550" Offset="0x550"/> 
+        <DList Name="gMorphaDL_000550" Offset="0x550"/>
 
         <DList Name="gMorphaDL_000EC0" Offset="0xEC0"/>
         <DList Name="gMorphaDL_000EF8" Offset="0xEF8"/>
         <DList Name="gMorphaDL_007BF8" Offset="0x7BF8"/>
-        
+
         <Array Name="gMorphaVtx_006938" Count="14" Offset="0x6938">
             <Vtx/>
         </Array>
 
-        <Array Name="gMorphaVtx_007BB8" Count="4" Offset="0x7BB8">
+        <Array Name="gMorphaVtx_006A18" Count="286" Offset="0x006A18">
             <Vtx/>
         </Array>
 

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_mo.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_mo.xml
@@ -8,7 +8,7 @@
         <!-- Morpha's Title Card -->
         <Texture Name="gMorphaTitleCardTex" Format="i8" Width="128" Height="120" Offset="0x1010"/>
         <Texture Name="gMorphaWaterTex" Format="rgba16" Width="32" Height="32" Offset="0x8870"/>
-				
+
         <!-- DLists for Morpha's Core -->
         <DList Name="gMorphaCoreMembraneDL" Offset="0x6700"/>
         <DList Name="gMorphaCoreNucleusDL" Offset="0x6838"/>
@@ -69,17 +69,17 @@
         <!-- Unused content -->
 
         <!-- This is the dlist for EnVbBall for some reason. -->
-        <DList Name="gMorphaDL_000550" Offset="0x550"/> 
+        <DList Name="gMorphaDL_000550" Offset="0x550"/>
 
         <DList Name="gMorphaDL_000EC0" Offset="0xEC0"/>
         <DList Name="gMorphaDL_000EF8" Offset="0xEF8"/>
         <DList Name="gMorphaDL_007BF8" Offset="0x7BF8"/>
-        
+
         <Array Name="gMorphaVtx_006938" Count="14" Offset="0x6938">
             <Vtx/>
         </Array>
 
-        <Array Name="gMorphaVtx_007BB8" Count="4" Offset="0x7BB8">
+        <Array Name="gMorphaVtx_006A18" Count="286" Offset="0x006A18">
             <Vtx/>
         </Array>
 

--- a/soh/assets/xml/N64_PAL_10/objects/object_mo.xml
+++ b/soh/assets/xml/N64_PAL_10/objects/object_mo.xml
@@ -8,7 +8,7 @@
         <!-- Morpha's Title Card -->
         <Texture Name="gMorphaTitleCardTex" Format="i8" Width="128" Height="120" Offset="0x1010"/>
         <Texture Name="gMorphaWaterTex" Format="rgba16" Width="32" Height="32" Offset="0x8870"/>
-				
+
         <!-- DLists for Morpha's Core -->
         <DList Name="gMorphaCoreMembraneDL" Offset="0x6700"/>
         <DList Name="gMorphaCoreNucleusDL" Offset="0x6838"/>
@@ -69,17 +69,17 @@
         <!-- Unused content -->
 
         <!-- This is the dlist for EnVbBall for some reason. -->
-        <DList Name="gMorphaDL_000550" Offset="0x550"/> 
+        <DList Name="gMorphaDL_000550" Offset="0x550"/>
 
         <DList Name="gMorphaDL_000EC0" Offset="0xEC0"/>
         <DList Name="gMorphaDL_000EF8" Offset="0xEF8"/>
         <DList Name="gMorphaDL_007BF8" Offset="0x7BF8"/>
-        
+
         <Array Name="gMorphaVtx_006938" Count="14" Offset="0x6938">
             <Vtx/>
         </Array>
 
-        <Array Name="gMorphaVtx_007BB8" Count="4" Offset="0x7BB8">
+        <Array Name="gMorphaVtx_006A18" Count="286" Offset="0x006A18">
             <Vtx/>
         </Array>
 

--- a/soh/assets/xml/N64_PAL_11/objects/object_mo.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_mo.xml
@@ -8,7 +8,7 @@
         <!-- Morpha's Title Card -->
         <Texture Name="gMorphaTitleCardTex" Format="i8" Width="128" Height="120" Offset="0x1010"/>
         <Texture Name="gMorphaWaterTex" Format="rgba16" Width="32" Height="32" Offset="0x8870"/>
-				
+
         <!-- DLists for Morpha's Core -->
         <DList Name="gMorphaCoreMembraneDL" Offset="0x6700"/>
         <DList Name="gMorphaCoreNucleusDL" Offset="0x6838"/>
@@ -69,17 +69,17 @@
         <!-- Unused content -->
 
         <!-- This is the dlist for EnVbBall for some reason. -->
-        <DList Name="gMorphaDL_000550" Offset="0x550"/> 
+        <DList Name="gMorphaDL_000550" Offset="0x550"/>
 
         <DList Name="gMorphaDL_000EC0" Offset="0xEC0"/>
         <DList Name="gMorphaDL_000EF8" Offset="0xEF8"/>
         <DList Name="gMorphaDL_007BF8" Offset="0x7BF8"/>
-        
+
         <Array Name="gMorphaVtx_006938" Count="14" Offset="0x6938">
             <Vtx/>
         </Array>
 
-        <Array Name="gMorphaVtx_007BB8" Count="4" Offset="0x7BB8">
+        <Array Name="gMorphaVtx_006A18" Count="286" Offset="0x006A18">
             <Vtx/>
         </Array>
 


### PR DESCRIPTION
Fixes #962

Hey! Been a long time. I'm still around but have been very unmotivated. Anyways, I was pinged, and while I was catching up a little, I saw someone ask about the Morpha vertex explosion and it made me annoyed it wasn't fixed. So, I finally fixed it!

It was an asset problem. So, the way ZAPD detects vertex arrays is a little finicky. SoH has additional difficulties in that code can reference vertices in the middle of arrays, so we don't actually merge vertex arrays as aggressively as what base decomp ZAPD does.

Typically, vertices in DLs are accessed in the order they are in DLs. In the Morpha DLs, however, they split the DLs up in a unique way so that in code, they can be manipulated to achieve all the wiggling and pulsating effects. This is how the end of the vertices (the ones that make up the tip) was laid out:
```
     VERTS
       X |
       X | DL39
     | X |
Base:| X
     | X |
       X | DL40
       X |
```

Because `Base` was declared earlier than `DL40`, ZAPD created an array containing those vertices. When `DL39` was encountered, it saw the overlap, but created a new array with a copy instead of merging. For `DL40`, however, it saw that the start was already inside an existing array and didn't create a new one. However, it didn't account for the fact that it went outside of that existing array, so when it loaded, those vertices contained garbage data.

The fix is to declare the whole array up front so that for every DL, it treated it as a reference to the middle of it. The decomp didn't solve this issue in quite the right way, and instead made those trailing vertices into their own array. But, due to the way they handle data, it wasn't an issue that the arrays were split. It was for us, however.

This is an XML change, so it requires a regeneration of the OTR. I'm not sure if there is some additional work to bump the version, so please let me know if that is the case.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1077161817.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1077161818.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1077161819.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1077161820.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1077161821.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1077161822.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1077161823.zip)
<!--- section:artifacts:end -->