### PR TITLE
Tweak skeleton limbs to use OTR path strings for loading DList and improve Alt toggling

### DIFF
--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -1145,7 +1145,7 @@ extern "C" void Graph_ProcessFrame(void (*run_one_game_iter)(void)) {
     OTRGlobals::Instance->context->GetWindow()->MainLoop(run_one_game_iter);
 }
 
-extern bool ShouldClearTextureCacheAtEndOfFrame;
+extern bool ToggleAltAssetsAtEndOfFrame;
 
 extern "C" void Graph_StartFrame() {
 #ifndef __WIIU__
@@ -1228,10 +1228,7 @@ extern "C" void Graph_StartFrame() {
         }
 #endif
         case KbScancode::LUS_KB_TAB: {
-            // Toggle HD Assets
-            CVarSetInteger("gAltAssets", !CVarGetInteger("gAltAssets", 0));
-            GameInteractor::Instance->ExecuteHooks<GameInteractor::OnAssetAltChange>();
-            ShouldClearTextureCacheAtEndOfFrame = true;
+            ToggleAltAssetsAtEndOfFrame = true;
             break;
         }
     }
@@ -1301,10 +1298,14 @@ extern "C" void Graph_ProcessGfxCommands(Gfx* commands) {
         }
     }
 
-    if (ShouldClearTextureCacheAtEndOfFrame) {
+    if (ToggleAltAssetsAtEndOfFrame) {
+        ToggleAltAssetsAtEndOfFrame = false;
+
+        // Actually update the CVar now before runing the alt asset update listeners
+        CVarSetInteger("gAltAssets", !CVarGetInteger("gAltAssets", 0));
         gfx_texture_cache_clear();
         LUS::SkeletonPatcher::UpdateSkeletons();
-        ShouldClearTextureCacheAtEndOfFrame = false;
+        GameInteractor::Instance->ExecuteHooks<GameInteractor::OnAssetAltChange>();
     }
 
     // OTRTODO: FIGURE OUT END FRAME POINT

--- a/soh/soh/SohGui.cpp
+++ b/soh/soh/SohGui.cpp
@@ -38,7 +38,7 @@
 #include "Enhancements/game-interactor/GameInteractor.h"
 #include "Enhancements/cosmetics/authenticGfxPatches.h"
 
-bool ShouldClearTextureCacheAtEndOfFrame = false;
+bool ToggleAltAssetsAtEndOfFrame = false;
 bool isBetaQuestEnabled = false;
 
 extern "C" {

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -28,7 +28,7 @@
 #include "Enhancements/randomizer/randomizer_item_tracker.h"
 #include "Enhancements/randomizer/randomizer_settings_window.h"
 
-extern bool ShouldClearTextureCacheAtEndOfFrame;
+extern bool ToggleAltAssetsAtEndOfFrame;
 extern bool isBetaQuestEnabled;
 
 extern "C" PlayState* gPlayState;
@@ -908,8 +908,10 @@ void DrawEnhancementsMenu() {
         {
             if (ImGui::BeginMenu("Mods")) {
                 if (UIWidgets::PaddedEnhancementCheckbox("Use Alternate Assets", "gAltAssets", false, false)) {
-                    ShouldClearTextureCacheAtEndOfFrame = true;
-                    GameInteractor::Instance->ExecuteHooks<GameInteractor::OnAssetAltChange>();
+                    // The checkbox will flip the alt asset CVar, but we instead want it to change at the end of the game frame
+                    // We toggle it back while setting the flag to update the CVar later
+                    CVarSetInteger("gAltAssets", !CVarGetInteger("gAltAssets", 0));
+                    ToggleAltAssetsAtEndOfFrame = true;
                 }
                 UIWidgets::Tooltip("Toggle between standard assets and alternate assets. Usually mods will indicate if this setting has to be used or not.");
                 UIWidgets::PaddedEnhancementCheckbox("Disable Bomb Billboarding", "gDisableBombBillboarding", true, false);

--- a/soh/soh/resource/importer/SkeletonLimbFactory.cpp
+++ b/soh/soh/resource/importer/SkeletonLimbFactory.cpp
@@ -132,15 +132,15 @@ void LUS::SkeletonLimbFactoryV0::ParseFileBinary(std::shared_ptr<BinaryReader> r
         skeletonLimb->limbData.lodLimb.sibling = skeletonLimb->siblingIndex;
 
         if (skeletonLimb->dListPtr != "") {
-            auto dList = LUS::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(skeletonLimb->dListPtr.c_str());
-            skeletonLimb->limbData.lodLimb.dLists[0] = (Gfx*)(dList ? dList->GetRawPointer() : nullptr);
+            skeletonLimb->dListPtr = "__OTR__" + skeletonLimb->dListPtr;
+            skeletonLimb->limbData.lodLimb.dLists[0] = (Gfx*)skeletonLimb->dListPtr.c_str();
         } else {
             skeletonLimb->limbData.lodLimb.dLists[0] = nullptr;
         }
 
         if (skeletonLimb->dList2Ptr != "") {
-            auto dList = LUS::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(skeletonLimb->dList2Ptr.c_str());
-            skeletonLimb->limbData.lodLimb.dLists[1] = (Gfx*)(dList ? dList->GetRawPointer() : nullptr);
+            skeletonLimb->dList2Ptr = "__OTR__" + skeletonLimb->dList2Ptr;
+            skeletonLimb->limbData.lodLimb.dLists[1] = (Gfx*)skeletonLimb->dList2Ptr.c_str();
         } else {
             skeletonLimb->limbData.lodLimb.dLists[1] = nullptr;
         }
@@ -153,8 +153,8 @@ void LUS::SkeletonLimbFactoryV0::ParseFileBinary(std::shared_ptr<BinaryReader> r
         skeletonLimb->limbData.standardLimb.dList = nullptr;
 
         if (!skeletonLimb->dListPtr.empty()) {
-            const auto dList = LUS::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(skeletonLimb->dListPtr.c_str());
-            skeletonLimb->limbData.standardLimb.dList = (Gfx*)(dList ? dList->GetRawPointer() : nullptr);
+            skeletonLimb->dListPtr = "__OTR__" + skeletonLimb->dListPtr;
+            skeletonLimb->limbData.standardLimb.dList = (Gfx*)skeletonLimb->dListPtr.c_str();
         }
     } else if (skeletonLimb->limbType == LUS::LimbType::Curve) {
         skeletonLimb->limbData.skelCurveLimb.firstChildIdx = skeletonLimb->childIndex;
@@ -163,13 +163,13 @@ void LUS::SkeletonLimbFactoryV0::ParseFileBinary(std::shared_ptr<BinaryReader> r
         skeletonLimb->limbData.skelCurveLimb.dList[1] = nullptr;
 
         if (!skeletonLimb->dListPtr.empty()) {
-            const auto dList = LUS::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(skeletonLimb->dListPtr.c_str());
-            skeletonLimb->limbData.skelCurveLimb.dList[0] = (Gfx*)(dList ? dList->GetRawPointer() : nullptr);
+            skeletonLimb->dListPtr = "__OTR__" + skeletonLimb->dListPtr;
+            skeletonLimb->limbData.skelCurveLimb.dList[0] = (Gfx*)skeletonLimb->dListPtr.c_str();
         }
 
         if (!skeletonLimb->dList2Ptr.empty()) {
-            const auto dList = LUS::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(skeletonLimb->dList2Ptr.c_str());
-            skeletonLimb->limbData.skelCurveLimb.dList[1] = (Gfx*)(dList ? dList->GetRawPointer() : nullptr);
+            skeletonLimb->dList2Ptr = "__OTR__" + skeletonLimb->dList2Ptr;
+            skeletonLimb->limbData.skelCurveLimb.dList[1] = (Gfx*)skeletonLimb->dList2Ptr.c_str();
         }
     } else if (skeletonLimb->limbType == LUS::LimbType::Skin) {
         skeletonLimb->limbData.skinLimb.jointPos.x = skeletonLimb->transX;
@@ -189,14 +189,23 @@ void LUS::SkeletonLimbFactoryV0::ParseFileBinary(std::shared_ptr<BinaryReader> r
         }
 
         if (skeletonLimb->skinSegmentType == LUS::ZLimbSkinType::SkinType_DList) {
-            auto res = LUS::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(skeletonLimb->skinDList.c_str());
-            skeletonLimb->limbData.skinLimb.segment = res ? res->GetRawPointer() : nullptr;
+            if (skeletonLimb->skinDList != "") {
+                skeletonLimb->skinDList = "__OTR__" + skeletonLimb->skinDList;
+                skeletonLimb->limbData.skinLimb.segment = (Gfx*)skeletonLimb->skinDList.c_str();
+            } else {
+                skeletonLimb->limbData.skinLimb.segment = nullptr;
+            }
         } else if (skeletonLimb->skinSegmentType == LUS::ZLimbSkinType::SkinType_4) {
             skeletonLimb->skinAnimLimbData.totalVtxCount = skeletonLimb->skinVtxCnt;
             skeletonLimb->skinAnimLimbData.limbModifCount = skeletonLimb->skinLimbModifCount;
             skeletonLimb->skinAnimLimbData.limbModifications = skeletonLimb->skinLimbModifArray.data();
-            auto res = LUS::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(skeletonLimb->skinDList2.c_str());
-            skeletonLimb->skinAnimLimbData.dlist = (Gfx*)(res ? res->GetRawPointer() : nullptr);
+
+            if (skeletonLimb->skinDList2 != "") {
+                skeletonLimb->skinDList2 = "__OTR__" + skeletonLimb->skinDList2;
+                skeletonLimb->skinAnimLimbData.dlist = (Gfx*)skeletonLimb->skinDList2.c_str();
+            } else {
+                skeletonLimb->skinAnimLimbData.dlist = nullptr;
+            }
 
             for (size_t i = 0; i < skeletonLimb->skinLimbModifArray.size(); i++) {
                 skeletonLimb->skinAnimLimbData.limbModifications[i].vtxCount = skeletonLimb->skinLimbModifVertexArrays[i].size();
@@ -254,8 +263,8 @@ void SkeletonLimbFactoryV0::ParseFileXML(tinyxml2::XMLElement* reader, std::shar
     limbData.lodLimb.jointPos.z = skelLimb->transZ;
 
     if (skelLimb->dListPtr != "") {
-        auto res = LUS::Context::GetInstance()->GetResourceManager()->LoadResourceProcess((const char*)skelLimb->dListPtr.c_str());
-        limbData.lodLimb.dLists[0] = (Gfx*)(res ? res->GetRawPointer() : nullptr);
+        skelLimb->dListPtr = "__OTR__" + skelLimb->dListPtr;
+        limbData.lodLimb.dLists[0] = (Gfx*)skelLimb->dListPtr.c_str();
     } else {
         limbData.lodLimb.dLists[0] = nullptr;
     }


### PR DESCRIPTION
Our skeleton limb resources were loading the raw resource for the specified DList and assigning a pointer to the Gfx instructions when parsing the limb resource. This lead to the issue where the underlying DList resource could be unloaded, but the skeleton limb is not, causing either garbage data to render for the DList or straight up crash.

This situation could happen with the following example:
1. The user has a mod that has an Alt replacement for a DList that is used by a skeleton limb
2. The system has Alt toggled on
3. Upon loading the skeleton, there is no Alt replacement for the skeleton, so the non-alt version is loaded.
4. Then the limbs load (same thing happens, no Alt replacement)
5. Then the DList for the limb is loaded, this ends up loading as the Alt version, and the raw pointer assigned to the non-alt skeleton
6. Upon rendering in game, the first time the skeleton is rendered after loading everything seems fine
7. After transitioning scenes, all Alt resources are unloaded. This means the DList raw data assigned to the limb resource is now a dangling pointer
8. Depending on memory, the next time you enter the scene with the skeleton, the pointer could now be garbage data, leading to a crash
9. Alternatively, toggling off Alt assets will unload the DList too, but the skeleton is not unloaded/reloaded since its a non-Alt asset, leading to a similar issue

The proposed changes/fixes here is to instead use the string reference of the DList path, and assign its pointer to the limb's DList. Later on when the limb is rendered, `gSPDisplayList` will recognize the OTR signature and dynamically load the DList resource for either Alt or non-Alt as necessary. This pattern matches roughly with how scene MeshLists are registered, and textures in DLists themselves.

---

To support these changes, I also needed to defer actually toggling the `gAltAssets` CVar to the end of the game frame, similar to how we defer skeleton patching updates. This is necessary as we don't want a skeleton to try to load a DList for the wrong assets mode due to race conditions. Pressing Tab or clicking the checkbox in the menu for it will appropriately handle toggling the actual CVar at the right time.

Currently though, it is not advised to set `gAltAssets` via the debug console, as that will set the CVar immediately and potentially cause crashes depending on the used mods. A CVar refactor could mitigate this in the future.



<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1085038064.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1085038067.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1085038069.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1085038070.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1085038071.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1085038072.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1085038073.zip)
<!--- section:artifacts:end -->