### PR TITLE
Fix Master Sword Shuffle Sticks on B on Additional Returns to Adult

### DIFF
--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -1464,7 +1464,7 @@ void Inventory_SwapAgeEquipment(void) {
 
         gSaveContext.childEquips.equipment = gSaveContext.equips.equipment;
 
-        if (gSaveContext.adultEquips.buttonItems[0] == ITEM_NONE && !(IS_RANDO && Randomizer_GetSettingValue(RSK_SHUFFLE_MASTER_SWORD) && gSaveContext.adultEquips.equipment)) {
+        if (gSaveContext.adultEquips.buttonItems[0] == ITEM_NONE && !(IS_RANDO && Randomizer_GetSettingValue(RSK_SHUFFLE_MASTER_SWORD) && (gSaveContext.adultEquips.equipment & (EQUIP_VALUE_SWORD_MASTER << (EQUIP_TYPE_SWORD * 4))))) {
             if (!IS_RANDO || !Randomizer_GetSettingValue(RSK_SHUFFLE_MASTER_SWORD)) {
                 gSaveContext.equips.buttonItems[0] = ITEM_SWORD_MASTER;
             } else {


### PR DESCRIPTION
The reproduction steps for before:

- Start as child, go adult. No item will be on the b-button
- Go back to child, and add kokiri sword to inventory and equip it
- Change to adult, sticks will now be on b

This only occured when changing to adult for the second time, as the check being made to use MS Shuffle behaviour was looking for adultEquips.equipment to be set to 0, which is only true when going to adult the first time. Instead what I believe is intended is to check against just the master sword bit in adultEquips.equipment. This PR changes that check against adultEquips.equipment to now use the MS bit.

This change fixes the behaviour under the reproduction steps mentioned.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1088607575.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1088607577.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1088607578.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1088607579.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1088607580.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1088607581.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1088607582.zip)
<!--- section:artifacts:end -->