### PR TITLE
Fix a seed gen bug surrounding new area enum

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/fill.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/fill.cpp
@@ -1009,6 +1009,7 @@ int Fill() {
     AreaTable_Init(); //Reset the world graph to intialize the proper locations
     ctx->ItemReset(); //Reset shops incase of shopsanity random
     ctx->GenerateLocationPool();
+    SetAreas();
     GenerateItemPool();
     GenerateStartingInventory();
     RemoveStartingItemsFromPool();
@@ -1137,7 +1138,6 @@ int Fill() {
     if(ctx->playthroughBeatable && !placementFailure) {
       printf("Done");
       printf("\x1b[9;10HCalculating Playthrough...");
-      SetAreas();
       PareDownPlaythrough();
       CalculateWotH();
       CalculateBarren(); 

--- a/soh/soh/Enhancements/randomizer/3drando/fill.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/fill.cpp
@@ -1009,7 +1009,6 @@ int Fill() {
     AreaTable_Init(); //Reset the world graph to intialize the proper locations
     ctx->ItemReset(); //Reset shops incase of shopsanity random
     ctx->GenerateLocationPool();
-    SetAreas();
     GenerateItemPool();
     GenerateStartingInventory();
     RemoveStartingItemsFromPool();
@@ -1027,6 +1026,7 @@ int Fill() {
       }
       printf("\x1b[7;32HDone");
     }
+    SetAreas();
     //erase temporary shop items
     FilterAndEraseFromPool(ItemPool, [](const auto item) { return Rando::StaticData::RetrieveItem(item).GetItemType() == ITEMTYPE_SHOP; });
 

--- a/soh/soh/Enhancements/randomizer/3drando/playthrough.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/playthrough.cpp
@@ -30,7 +30,7 @@ int Playthrough_Init(uint32_t seed, std::unordered_map<RandomizerSettingKey, uin
     std::string settingsStr;
     for (const Rando::OptionGroup& optionGroup : ctx->GetSettings()->GetOptionGroups()) {
         // don't go through non-menus
-        if (optionGroup.GetContainsType() != Rando::OptionGroupType::SUBGROUP) {
+        if (optionGroup.GetContainsType() == Rando::OptionGroupType::SUBGROUP) {
             continue;
         }
 


### PR DESCRIPTION
new RandomizerArea enum is used to filter dungeonLocations out of allLocations during item placement, but the itemLocations weren't getting a RandomizerArea set until after the playthrough was already confirmed to be beatable, thus we would get a placement error because we wouldn't be able to pull any dungeon locations and never actually set the RandomizerArea. This calls `SetArea` earlier.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1102374966.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1102374969.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1102374972.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1102374976.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1102374979.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1102374980.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1102374982.zip)
<!--- section:artifacts:end -->