### PR TITLE
Fix: More swordless fixes when time traveling

### DIFF
--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -1521,6 +1521,13 @@ void Inventory_SwapAgeEquipment(void) {
                 }
             }
 
+            // In Rando, when switching to adult for the second+ time, if a sword was not previously
+            // equiped in MS shuffle, then we need to set the swordless flag again
+            if (IS_RANDO && Randomizer_GetSettingValue(RSK_SHUFFLE_MASTER_SWORD) &&
+                gSaveContext.equips.buttonItems[0] == ITEM_NONE) {
+                Flags_SetInfTable(INFTABLE_SWORDLESS);
+            }
+
             gSaveContext.equips.equipment = gSaveContext.adultEquips.equipment;
         }
     } else {
@@ -1587,6 +1594,13 @@ void Inventory_SwapAgeEquipment(void) {
                     gSaveContext.equips.buttonItems[i] =
                         gSaveContext.inventory.items[gSaveContext.equips.cButtonSlots[i - 1]];
                 }
+            }
+
+            // In Rando, when switching to child from a swordless adult, and child Link previously had a
+            // sword equiped, then we need to unset the swordless flag to match
+            if (IS_RANDO && Randomizer_GetSettingValue(RSK_SHUFFLE_MASTER_SWORD) &&
+                gSaveContext.equips.buttonItems[0] != ITEM_NONE) {
+                Flags_UnsetInfTable(INFTABLE_SWORDLESS);
             }
 
             gSaveContext.equips.equipment = gSaveContext.childEquips.equipment;


### PR DESCRIPTION
Stick on B was occurring in MS shuffle when traveling as child -> adult for the second+ time while having a Kokiri sword equipped as child. The root cause is the swordless flag is unset for child and carries over to adult, causing stick on B. This PR adds a check for adult not having a sword equiped and to set the swordless flag again as adult.

Conversely, in this same situation, when switching back to child (swordless adult, to kokiri sword as child), the swordless flag was left on. This doesn't have any immediate impact from what I can see, but for correctness sake, this PR also adds a similar check to explicit remove the swordless flag as child.

---

This func is getting quite messy between regular rando, the change age cheats/enhancements, and now MS shuffle. Will most likely add this func to my list of things that can be cleaned up in develop.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1105229427.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1105229429.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1105229431.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1105229432.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1105229434.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1105229436.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1105229438.zip)
<!--- section:artifacts:end -->