### PR TITLE
Fixes error sound when seed generation fails

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/menu.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/menu.cpp
@@ -21,28 +21,28 @@ std::vector<std::string> presetEntries;
 Rando::Option* currentSetting;
 } // namespace
 
-std::string GenerateRandomizer(std::set<RandomizerCheck> excludedLocations, std::set<RandomizerTrick> enabledTricks,
-    std::string seedString) {
-    auto ctx = Rando::Context::GetInstance();
+bool GenerateRandomizer(std::set<RandomizerCheck> excludedLocations, std::set<RandomizerTrick> enabledTricks,
+    std::string seedInput) {
+    const auto ctx = Rando::Context::GetInstance();
 
     srand(time(NULL));
     // if a blank seed was entered, make a random one
-    if (seedString.empty()) {
-        seedString = std::to_string(rand() % 0xFFFFFFFF);
-    } else if (seedString.rfind("seed_testing_count", 0) == 0 && seedString.length() > 18) {
+    if (seedInput.empty()) {
+        seedInput = std::to_string(rand() % 0xFFFFFFFF);
+    } else if (seedInput.rfind("seed_testing_count", 0) == 0 && seedInput.length() > 18) {
         int count;
         try {
-            count = std::stoi(seedString.substr(18), nullptr);
+            count = std::stoi(seedInput.substr(18), nullptr);
         } catch (std::invalid_argument &e) {
             count = 1;
         } catch (std::out_of_range &e) {
             count = 1;
         }
         Playthrough::Playthrough_Repeat(excludedLocations, enabledTricks, count);
-        return "";
+        return false; // TODO: Not sure if this is correct but I don't think we support this functionality yet anyway.
     }
 
-    ctx->GetSettings()->SetSeedString(seedString);
+    ctx->GetSettings()->SetSeedString(seedInput);
     uint32_t seedHash = boost::hash_32<std::string>{}(ctx->GetSettings()->GetSeedString());
     ctx->GetSettings()->SetSeed(seedHash & 0xFFFFFFFF);
 
@@ -52,10 +52,10 @@ std::string GenerateRandomizer(std::set<RandomizerCheck> excludedLocations, std:
             printf("\n\nFailed to generate after 5 tries.\nPress B to go back to the menu.\nA different seed might be "
                    "successful.");
             SPDLOG_DEBUG("\nRANDOMIZATION FAILED COMPLETELY. PLZ FIX\n");//RANDOTODO print seed for reproduction purposes
-            return "";
+            return false;
         } else {
             printf("\n\nError %d with fill.\nPress Select to exit or B to go back to the menu.\n", ret);
-            return "";
+            return false;
         }
     }
 
@@ -66,16 +66,5 @@ std::string GenerateRandomizer(std::set<RandomizerCheck> excludedLocations, std:
         }
         ctx->GetOption(RSK_KEYSANITY).RestoreDelayedOption();
     }
-    std::ostringstream fileNameStream;
-    for (int i = 0; i < ctx->hashIconIndexes.size(); i++) {
-        if (i) {
-            fileNameStream << '-';
-        }
-        if (ctx->hashIconIndexes[i] < 10) {
-            fileNameStream << '0';
-        }
-        fileNameStream << std::to_string(ctx->hashIconIndexes[i]);
-    }
-    std::string fileName = fileNameStream.str();
-    return "./Randomizer/" + fileName + ".json";
+    return true;
 }

--- a/soh/soh/Enhancements/randomizer/3drando/menu.hpp
+++ b/soh/soh/Enhancements/randomizer/3drando/menu.hpp
@@ -25,4 +25,4 @@
 // #define CYAN    "\x1b[36m"
 // #define WHITE   "\x1b[37m"
 
-std::string GenerateRandomizer(std::set<RandomizerCheck> excludedLocations, std::set<RandomizerTrick> enabledTricks, std::string seedInput);
+bool GenerateRandomizer(std::set<RandomizerCheck> excludedLocations, std::set<RandomizerTrick> enabledTricks, std::string seedInput);

--- a/soh/soh/Enhancements/randomizer/3drando/rando_main.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/rando_main.cpp
@@ -17,11 +17,10 @@ void RandoMain::GenerateRando(std::set<RandomizerCheck> excludedLocations, std::
     // std::string settingsFileName = "./randomizer/latest_settings.json";
     // CVarSetString("gLoadedPreset", settingsFileName.c_str());
 
-    std::string fileName = LUS::Context::GetPathRelativeToAppDirectory(GenerateRandomizer(excludedLocations, enabledTricks, seedString).c_str());
+    Rando::Context::GetInstance()->SetSeedGenerated(GenerateRandomizer(excludedLocations, enabledTricks, seedString));
 
     CVarSave();
     CVarLoad();
-    Rando::Context::GetInstance()->SetSeedGenerated();
     Rando::Context::GetInstance()->SetSpoilerLoaded(false);
     Rando::Context::GetInstance()->SetPlandoLoaded(false);
 }


### PR DESCRIPTION
At some point I accidentally broke this so that when seeds failed to generate, it still played the success sound. This is fixed now in this PR.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1118243449.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1118243451.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1118243453.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1118243455.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1118243456.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1118243459.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1118243461.zip)
<!--- section:artifacts:end -->