### PR TITLE
Add player state dead check to Player_UseTunicBoots

### DIFF
--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -10629,7 +10629,14 @@ void Player_UseTunicBoots(Player* this, PlayState* play) {
     s32 i;
     s32 item;
     s32 actionParam;
-    if (!(this->stateFlags1 & PLAYER_STATE1_INPUT_DISABLED || this->stateFlags1 & PLAYER_STATE1_IN_ITEM_CS || this->stateFlags1 & PLAYER_STATE1_IN_CUTSCENE || this->stateFlags1 & PLAYER_STATE1_TEXT_ON_SCREEN || this->stateFlags1 & PLAYER_STATE1_DEAD || this->stateFlags2 & PLAYER_STATE2_OCARINA_PLAYING)) {
+    if (!(
+        this->stateFlags1 & PLAYER_STATE1_INPUT_DISABLED || 
+        this->stateFlags1 & PLAYER_STATE1_IN_ITEM_CS || 
+        this->stateFlags1 & PLAYER_STATE1_IN_CUTSCENE || 
+        this->stateFlags1 & PLAYER_STATE1_TEXT_ON_SCREEN || 
+        this->stateFlags1 & PLAYER_STATE1_DEAD || 
+        this->stateFlags2 & PLAYER_STATE2_OCARINA_PLAYING
+    )) {
         for (i = 0; i < ARRAY_COUNT(D_80854388); i++) {
             if (CHECK_BTN_ALL(sControlInput->press.button, D_80854388[i])) {
                 break;

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -10629,7 +10629,7 @@ void Player_UseTunicBoots(Player* this, PlayState* play) {
     s32 i;
     s32 item;
     s32 actionParam;
-    if (!(this->stateFlags1 & PLAYER_STATE1_INPUT_DISABLED || this->stateFlags1 & PLAYER_STATE1_IN_ITEM_CS || this->stateFlags1 & PLAYER_STATE1_IN_CUTSCENE || this->stateFlags1 & PLAYER_STATE1_TEXT_ON_SCREEN || this->stateFlags2 & PLAYER_STATE2_OCARINA_PLAYING)) {
+    if (!(this->stateFlags1 & PLAYER_STATE1_INPUT_DISABLED || this->stateFlags1 & PLAYER_STATE1_IN_ITEM_CS || this->stateFlags1 & PLAYER_STATE1_IN_CUTSCENE || this->stateFlags1 & PLAYER_STATE1_TEXT_ON_SCREEN || this->stateFlags1 & PLAYER_STATE1_DEAD || this->stateFlags2 & PLAYER_STATE2_OCARINA_PLAYING)) {
         for (i = 0; i < ARRAY_COUNT(D_80854388); i++) {
             if (CHECK_BTN_ALL(sControlInput->press.button, D_80854388[i])) {
                 break;


### PR DESCRIPTION
This stops the player from equipping/unequipping boots/tunics once the player is dead. This stops a softlock which could occur when unequipping iron boots after dying underwater.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1119562380.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1119562381.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1119562382.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1119562383.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1119562384.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1119562385.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1119562386.zip)
<!--- section:artifacts:end -->