### PR TITLE
Fix for ImGui assertion fail

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -1794,6 +1794,7 @@ void RandomizerSettingsWindow::DrawElement() {
                 mNeedsUpdate = true;
             }
             ImGui::PopStyleVar(1);
+            ImGui::EndDisabled();
             ImGui::EndTabItem();
         }
         ImGui::EndDisabled();


### PR DESCRIPTION
Missing EndDisabled call was upsetting ImGui and making it crash the game

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1120275289.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1120275291.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1120275292.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1120275293.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1120275294.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1120275295.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1120275296.zip)
<!--- section:artifacts:end -->