### PR TITLE
Fix missing Shuffle Dungeon Reward Option

### DIFF
--- a/soh/soh/Enhancements/randomizer/option.cpp
+++ b/soh/soh/Enhancements/randomizer/option.cpp
@@ -221,7 +221,6 @@ bool Option::RenderCombobox() const {
     if (!description.empty()) {
         UIWidgets::InsertHelpHoverText(description.c_str());
     }
-    ImGui::BeginGroup();
     const std::string comboName = std::string("##") + std::string(cvarName);
     if (ImGui::BeginCombo(comboName.c_str(), options[selected].c_str())) {
         for (size_t i = 0; i < options.size(); i++) {
@@ -236,7 +235,6 @@ bool Option::RenderCombobox() const {
         }
         ImGui::EndCombo();
     }
-    ImGui::EndGroup();
     if (disabled) {
         UIWidgets::ReEnableComponent(disabledText.c_str());
     }


### PR DESCRIPTION
Also fixes some incorrect option disabling logic introduced by the dev->dev-rando merge.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1122741614.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1122741617.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1122741618.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1122741620.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1122741622.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1122741624.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1122741626.zip)
<!--- section:artifacts:end -->