### PR TITLE
apparently windows needs `-DBUILD_REMOTE_CONTROL=1`

### DIFF
--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -33,9 +33,9 @@ _Note: Instructions assume using powershell_
 cd Shipwright
 
 # Setup cmake project
-& 'C:\Program Files\CMake\bin\cmake' -S . -B "build/x64" -G "Visual Studio 17 2022" -T v142 -A x64 # -DCMAKE_BUILD_TYPE:STRING=Release (if you're packaging)
+& 'C:\Program Files\CMake\bin\cmake' -S . -B "build/x64" -G "Visual Studio 17 2022" -T v142 -A x64 -DBUILD_REMOTE_CONTROL=1 # -DCMAKE_BUILD_TYPE:STRING=Release (if you're packaging)
 # or for VS2019
-& 'C:\Program Files\CMake\bin\cmake' -S . -B "build/x64" -G "Visual Studio 16 2019" -T v142 -A x64
+& 'C:\Program Files\CMake\bin\cmake' -S . -B "build/x64" -G "Visual Studio 16 2019" -T v142 -A x64 -DBUILD_REMOTE_CONTROL=1
 # Extract assets & generate OTR (run this anytime you need to regenerate OTR)
 & 'C:\Program Files\CMake\bin\cmake.exe' --build .\build\x64 --target ExtractAssets # --config Release (if you're packaging)
 # Compile project
@@ -60,9 +60,9 @@ With the cmake build system you have two options for working on the project:
 To develop using Visual Studio you only need to use cmake to generate the solution file:
 ```powershell
 # Generates Ship.sln at `build/x64` for Visual Studio 2022
-& 'C:\Program Files\CMake\bin\cmake' -S . -B "build/x64" -G "Visual Studio 17 2022" -T v142 -A x64
+& 'C:\Program Files\CMake\bin\cmake' -S . -B "build/x64" -G "Visual Studio 17 2022" -T v142 -A x64 -DBUILD_REMOTE_CONTROL=1
 # or for Visual Studio 2019
-& 'C:\Program Files\CMake\bin\cmake' -S . -B "build/x64" -G "Visual Studio 16 2019" -T v142 -A x64
+& 'C:\Program Files\CMake\bin\cmake' -S . -B "build/x64" -G "Visual Studio 16 2019" -T v142 -A x64 -DBUILD_REMOTE_CONTROL=1
 ```
 
 #### Visual Studio Code or another editor


### PR DESCRIPTION
windows won't build without this, probably would be good to figure out why but this at least makes it so our docs don't lead people to linker errors