### PR TITLE
Fix Check Tracker Vanilla/MQ Dungeon Spoilers

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -738,7 +738,7 @@ void InitTrackerData(bool isDebug) {
         }
     }
     UpdateAllOrdering();
-} 
+}
 
 void SaveTrackerData(SaveContext* saveContext, int sectionID, bool gameSave) {
     SaveManager::Instance->SaveArray("checks", ARRAY_COUNT(saveContext->checkTrackerData), [&](size_t i) {

--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -738,7 +738,6 @@ void InitTrackerData(bool isDebug) {
         }
     }
     UpdateAllOrdering();
-    UpdateInventoryChecks();
 }
 
 void SaveTrackerData(SaveContext* saveContext, int sectionID, bool gameSave) {

--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -738,7 +738,7 @@ void InitTrackerData(bool isDebug) {
         }
     }
     UpdateAllOrdering();
-}
+} 
 
 void SaveTrackerData(SaveContext* saveContext, int sectionID, bool gameSave) {
     SaveManager::Instance->SaveArray("checks", ARRAY_COUNT(saveContext->checkTrackerData), [&](size_t i) {


### PR DESCRIPTION
Dungeons were being marked as already spoiled because it was checking if we had the map before loading a save.
`UpdateInventoryChecks` is run on loading a save, so there shouldn't be any problem with not running it at program start.