### PR TITLE
[macOS] Add Architecture Priority to  Info.plist

### DIFF
--- a/soh/macosx/Info.plist.in
+++ b/soh/macosx/Info.plist.in
@@ -33,5 +33,10 @@
     <string>public.app-category.games</string>
     <key>LSMinimumSystemVersion</key>
     <string>10.15</string>
+    <key>LSArchitecturePriority</key>
+    <array>
+        <string>arm64</string>
+        <string>x86_64</string>
+    </array>
 </dict>
 </plist>

--- a/soh/macosx/soh-macos.sh.in
+++ b/soh/macosx/soh-macos.sh.in
@@ -248,11 +248,4 @@ fi
 
 cd "$SNAME"
 
-arch_name="$(uname -m)"
-launch_arch="arm64"
-if [ "${arch_name}" = "x86_64" ] && [ "$(sysctl -in sysctl.proc_translated)" != "1" ]; then
-	launch_arch="x86_64"
-fi
-
-arch -${launch_arch} "$RESPATH"/soh-macos
 exit

--- a/soh/macosx/soh-macos.sh.in
+++ b/soh/macosx/soh-macos.sh.in
@@ -248,4 +248,6 @@ fi
 
 cd "$SNAME"
 
+"$RESPATH"/soh-macos
+
 exit


### PR DESCRIPTION
This allows the app bundle to be launched natively on Arm without the need for Rosetta.

On macOS, when launching an app bundle with a script (like soh does) it currently defaults to running the script with x64, though the app will actually launch using arm64. What this means is that Rosetta must be installed in order to launch the app, which is not optimal. 

The solution is to add the `LSArchitecturePriority` key to the info.plist, and specify for arm64 to be run first. This will not affect Intel Macs, as if the first on the list is not available, the next will be used. 

See [here](https://developer.apple.com/documentation/apple-silicon/building-a-universal-macos-binary#Specify-the-Launch-Behavior-of-Your-App) and [here](https://developer.apple.com/documentation/bundleresources/information_property_list/lsarchitecturepriority) for details.

Testing: 
 - [x] See if the app launches on an Arm Mac without Rosetta installed
 - [x] See if the app runs on an Arm Mac under Rosetta
 - [x] See if the app launches on an Intel Mac

Edit: The information came from issue #1553

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1129300377.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1129300380.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1129300381.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1129300382.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1129300385.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1129300386.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1129300388.zip)
<!--- section:artifacts:end -->