### PR TITLE
[Test Build] Mac dpi test

### DIFF
--- a/soh/macosx/Info.plist.in
+++ b/soh/macosx/Info.plist.in
@@ -38,5 +38,7 @@
         <string>arm64</string>
         <string>x86_64</string>
     </array>
+    <key>NSHighResolutionCapable</key>
+    <true/>
 </dict>
 </plist>


### PR DESCRIPTION
This is a test, if there is just some flag missing in the MacOS manifest for the app (plist) to properly enable DPI awareness.


I can't test anything on Mac, so Mac users: please test this, if it even does anything on your retina screen (and doesn't break on your non-retina ones, if you have one) 😬

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1294394385.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1294433989.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1294440040.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1294440457.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1294448778.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1294451499.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1294545478.zip)
<!--- section:artifacts:end -->