### PR TITLE
Fix typos in scenes_fra.json

### DIFF
--- a/soh/assets/custom/accessibility/texts/scenes_fra.json
+++ b/soh/assets/custom/accessibility/texts/scenes_fra.json
@@ -1,5 +1,5 @@
 {
-    "0": "Abre Mojo",
+    "0": "Arbre Mojo",
     "1": "Caverne Dodongo",
     "2": "Ventre de Jabu-Jabu",
     "3": "Temple de la Forêt",
@@ -58,9 +58,9 @@
     "56": "Laboratoire du Lac",
     "57": "", // Tente du Marathonien (No title card)
     "58": "Cabane du fossoyeur",
-    "59": "Fountaine Royale des Fées",
-    "60": "Fountaine des Fées",
-    "61": "Fountaine Royale des Fées",
+    "59": "Fontaine Royale des Fées",
+    "60": "Fontaine des Fées",
+    "61": "Fontaine Royale des Fées",
     "62": "", // Grottes (No title card)
     "63": "", // Tombe 1 (No title card)
     "64": "", // Tombe 2 (No title card)


### PR DESCRIPTION
Fix some typos in scenes_fra.json file

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1135369952.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1135369954.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1135369955.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1135369956.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1135369957.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1135369958.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1135369959.zip)
<!--- section:artifacts:end -->