### PR TITLE
Fix obvious hint regressions

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/fill.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/fill.cpp
@@ -572,7 +572,7 @@ static void CalculateWotH() {
     for (size_t j = 0; j < ctx->playthroughLocations[i].size(); j++) {
       //If removing this item and no other item caused the game to become unbeatable, then it is strictly necessary, so add it
       if (ctx->GetItemLocation(ctx->playthroughLocations[i][j])->IsHintable() 
-          && IsBeatableWithout(ctx->playthroughLocations[i][j], true)) {
+          && !(IsBeatableWithout(ctx->playthroughLocations[i][j], true))) {
         ctx->GetItemLocation(ctx->playthroughLocations[i][j])->SetWothCandidate();
       }
     }
@@ -585,20 +585,21 @@ static void CalculateWotH() {
 //Calculate barren locations and assign Barren Candidacy to all locations inside those areas
 static void CalculateBarren() {
   auto ctx = Rando::Context::GetInstance();
-  std::array<bool, RA_MAX> IsBarren = {true};
+  std::array<bool, RA_MAX> NotBarren = {}; //I would invert this but the "initialise all as true" syntax wasn't working
 
   for (RandomizerCheck loc : ctx->allLocations) {
-  Rando::ItemLocation* itemLoc = ctx->GetItemLocation(loc);
-  RandomizerArea locArea = itemLoc->GetArea();
-  // If a location has a major item or is a way of the hero location, it is not barren
-  if (IsBarren[locArea] == true && locArea > RA_LINKS_POCKET && (itemLoc->GetPlacedItem().IsMajorItem() || itemLoc->IsWothCandidate())) {
-    IsBarren[locArea] = false;
-  } 
+    Rando::ItemLocation* itemLoc = ctx->GetItemLocation(loc);
+    RandomizerArea locArea = itemLoc->GetArea();
+    bool test = (itemLoc->GetPlacedItem().IsMajorItem() || itemLoc->IsWothCandidate());
+    // If a location has a major item or is a way of the hero location, it is not barren
+    if (NotBarren[locArea] == false && locArea > RA_LINKS_POCKET && (itemLoc->GetPlacedItem().IsMajorItem() || itemLoc->IsWothCandidate())) {
+      NotBarren[locArea] = true;
+    } 
   }
 
   for (RandomizerCheck loc : ctx->allLocations) {
     Rando::ItemLocation* itemLoc = ctx->GetItemLocation(loc);
-    if (IsBarren[itemLoc->GetArea()]){
+    if (!NotBarren[itemLoc->GetArea()]){
       itemLoc->SetBarrenCandidate();
     }
   }

--- a/soh/soh/Enhancements/randomizer/3drando/hint_list.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/hint_list.cpp
@@ -1060,7 +1060,7 @@ void HintTable_Init() {
 
     hintTable[RHT_OUTSIDE_GANONS_CASTLE] = HintText::Exclude({
         // obscure text
-        Text{ "outside Ganon's Castle", /*french*/ "les alentours du Château&de Ganon",
+        Text{ "outside Ganon's Castle", /*french*/ "les alentours du Château de Ganon",
               /*spanish*/ "el exterior del Castillo de Ganon" },
     });
 

--- a/soh/soh/Enhancements/randomizer/3drando/hints.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/hints.cpp
@@ -494,8 +494,8 @@ static std::vector<RandomizerCheck> FilterHintability(std::vector<RandomizerChec
                                                       std::function<bool(RandomizerCheck)> extraFilter = NoFilter){
   auto ctx = Rando::Context::GetInstance();
   return FilterFromPool(locations, [extraFilter, ctx](const RandomizerCheck loc) {
-    return ctx->GetItemLocation(loc)->IsHintable() && !(ctx->GetItemLocation(loc)->IsHintedAt()
-    && extraFilter(loc));
+    return ctx->GetItemLocation(loc)->IsHintable() && !(ctx->GetItemLocation(loc)->IsHintedAt())
+    && extraFilter(loc);
   });
 }
 
@@ -1033,7 +1033,8 @@ void CreateStoneHints() {
                   // If we have Rainbow Bridge set to Greg, add a hint for where Greg is
                   (ctx->GetOption(RSK_RAINBOW_BRIDGE).Is(RO_BRIDGE_GREG) &&
                    ctx->GetItemLocation(loc)->GetPlacedRandomizerGet() == RG_GREG_RUPEE)) &&
-                 ctx->GetItemLocation(loc)->IsHintable() && !(ctx->GetItemLocation(loc)->IsHintedAt());
+                  ctx->GetItemLocation(loc)->IsHintable() &&
+                  !(ctx->GetOption(RSK_GREG_HINT) && (IsReachableWithout({RC_GREG_HINT}, loc, true)));
       });
 
       for (auto& hint : conditionalAlwaysHints) {

--- a/soh/soh/Enhancements/randomizer/settings.cpp
+++ b/soh/soh/Enhancements/randomizer/settings.cpp
@@ -134,7 +134,7 @@ void Settings::CreateOptions() {
     mOptions[RSK_KEYRINGS_BOTTOM_OF_THE_WELL] = Option::Bool("Bottom of the Well", "gRandomizeShuffleKeyRingsBottomOfTheWell", "", IMFLAG_NONE);
     mOptions[RSK_KEYRINGS_GTG] = Option::Bool("Gerudo Training Grounds", "gRandomizeShuffleKeyRingsGTG", "", IMFLAG_NONE);
     mOptions[RSK_KEYRINGS_GANONS_CASTLE] = Option::Bool("Ganon's Castle", "gRandomizeShuffleKeyRingsGanonsCastle");
-    mOptions[RSK_SKIP_CHILD_STEALTH] = Option::Bool("Skip Child Stealth", {"Don't Skip", "Skip"}, OptionCategory::Setting, "gRandomizeSkipChildZelda", mOptionDescriptions[RSK_SKIP_CHILD_STEALTH], WidgetType::Checkbox, RO_GENERIC_DONT_SKIP);
+    mOptions[RSK_SKIP_CHILD_STEALTH] = Option::Bool("Skip Child Stealth", {"Don't Skip", "Skip"}, OptionCategory::Setting, "gRandomizeSkipChildStealth", mOptionDescriptions[RSK_SKIP_CHILD_STEALTH], WidgetType::Checkbox, RO_GENERIC_DONT_SKIP);
     mOptions[RSK_SKIP_CHILD_ZELDA] = Option::Bool("Skip Child Zelda", {"Don't Skip", "Skip"}, OptionCategory::Setting, "gRandomizeSkipChildZelda", mOptionDescriptions[RSK_SKIP_CHILD_ZELDA], WidgetType::Checkbox, RO_GENERIC_DONT_SKIP);
     mOptions[RSK_SKIP_TOWER_ESCAPE] = Option::Bool("Skip Tower Escape", {"Don't Skip", "Skip"}, OptionCategory::Setting, "gRandomizeSkipTowerEscape", mOptionDescriptions[RSK_SKIP_TOWER_ESCAPE], WidgetType::Checkbox, RO_GENERIC_DONT_SKIP);
     mOptions[RSK_SKIP_EPONA_RACE] = Option::Bool("Skip Epona Race", {"Don't Skip", "Skip"}, OptionCategory::Setting, "gRandomizeSkipEponaRace", mOptionDescriptions[RSK_SKIP_EPONA_RACE], WidgetType::Checkbox, RO_GENERIC_DONT_SKIP);
@@ -1667,6 +1667,8 @@ void Settings::FinalizeSettings(const std::set<RandomizerCheck>& excludedLocatio
             || mOptions[RSK_SHUFFLE_GROTTO_ENTRANCES] || mOptions[RSK_SHUFFLE_OWL_DROPS]
             || mOptions[RSK_SHUFFLE_WARP_SONGS] || mOptions[RSK_SHUFFLE_OVERWORLD_SPAWNS]) {
             mOptions[RSK_SHUFFLE_ENTRANCES].SetSelectedIndex(RO_GENERIC_ON);
+        } else {
+            mOptions[RSK_SHUFFLE_ENTRANCES].SetSelectedIndex(RO_GENERIC_OFF);
         }
 
         if (mOptions[RSK_SHUFFLE_DUNGEON_REWARDS].Is(RO_DUNGEON_REWARDS_END_OF_DUNGEON)) {


### PR DESCRIPTION
This isn't everything, because my debugging has taken me into GetAcessableLocations and triggered a refactor to that I had on my todo list, but this should at least make basic hints work again. 

Not well tested due to there being little point until I fix the other bug.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1135379595.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1135379596.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1135379597.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1135379600.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1135379601.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1135379603.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1135379605.zip)
<!--- section:artifacts:end -->