### PR TITLE
[Test Build] Windows DPI awareness & Keyboard resize fix

### DIFF
--- a/soh/SHIPOFHARKINIAN.manifest
+++ b/soh/SHIPOFHARKINIAN.manifest
@@ -28,4 +28,10 @@
       <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
     </application>
   </compatibility>
+  <asmv3:application xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+    <asmv3:windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware> <!-- legacy -->
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">permonitorv2,permonitor</dpiAwareness> <!-- falls back to pm if pmv2 is not available -->
+    </asmv3:windowsSettings>
+  </asmv3:application>
 </assembly>


### PR DESCRIPTION
Includes https://github.com/Kenix3/libultraship/pull/385, https://github.com/Kenix3/libultraship/pull/365 and https://github.com/HarbourMasters/Shipwright/pull/3270


Things that needs testing under Windows (DirectX and OpenGL):

Keyboard resize fix related:
- resizing and moving the window via keyboard (system move/resize context menu)
- keyboard and controller still working correctly

DPI related:
- moving the window to a monitor with different Dpi settings (multiple times back and forth for a good measure) 
- changing the monitors DPI settings while SoH is running there
- for both DPI 100% and >100%:
  - position and size saving/loading
  - fullscreen correctly working, also when starting in fullscreen 
  - N64 Mode 
- probably more things I forgot

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1135434970.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1135434972.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1135434974.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1135434975.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1135434977.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1135434979.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1135434980.zip)
<!--- section:artifacts:end -->