### PR TITLE
Fixes some "seed bleed" instances

### DIFF
--- a/soh/soh/SaveManager.cpp
+++ b/soh/soh/SaveManager.cpp
@@ -2721,8 +2721,11 @@ extern "C" void Save_SaveGlobal(void) {
 }
 
 extern "C" void Save_LoadFile(void) {
-    OTRGlobals::Instance->gRandoContext.reset();
-    OTRGlobals::Instance->gRandoContext = Rando::Context::CreateInstance();
+    if (gSaveContext.questId == QUEST_RANDOMIZER) {
+        // Reset rando context for rando saves.
+        OTRGlobals::Instance->gRandoContext.reset();
+        OTRGlobals::Instance->gRandoContext = Rando::Context::CreateInstance();
+    }
     SaveManager::Instance->LoadFile(gSaveContext.fileNum);
 }
 

--- a/soh/soh/SaveManager.cpp
+++ b/soh/soh/SaveManager.cpp
@@ -2721,6 +2721,8 @@ extern "C" void Save_SaveGlobal(void) {
 }
 
 extern "C" void Save_LoadFile(void) {
+    OTRGlobals::Instance->gRandoContext.reset();
+    OTRGlobals::Instance->gRandoContext = Rando::Context::CreateInstance();
     SaveManager::Instance->LoadFile(gSaveContext.fileNum);
 }
 


### PR DESCRIPTION
Should fix seed bleed between multiple saves and loaded spoilers by resetting the Rando::Context before loading a save.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1140405459.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1140405460.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1140405461.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1140405462.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1140405463.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1140405464.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1140405465.zip)
<!--- section:artifacts:end -->