### PR TITLE
Rename Freecam to Free Look

### DIFF
--- a/soh/soh/Enhancements/controls/GameControlEditor.cpp
+++ b/soh/soh/Enhancements/controls/GameControlEditor.cpp
@@ -258,24 +258,28 @@ namespace GameControlEditor {
         window->EndGroupPanelPublic(0);
 
         UIWidgets::Spacer(0);
-        window->BeginGroupPanelPublic("Third-Person Camera", ImGui::GetContentRegionAvail());
+        window->BeginGroupPanelPublic("Free Look/Third-person Camera", ImGui::GetContentRegionAvail());
 
-        UIWidgets::PaddedEnhancementCheckbox("Free Camera", "gFreeCamera");
-        DrawHelpIcon("Enables free camera control\nNote: You must remap C buttons off of the right stick in the "
+        UIWidgets::PaddedEnhancementCheckbox("Enable Free Look", "gFreeCamera");
+        DrawHelpIcon("Enables free look camera control\nNote: You must remap C buttons off of the right stick in the "
                             "controller config menu, and map the camera stick to the right stick.");
-        UIWidgets::PaddedEnhancementCheckbox("Invert Camera X Axis", "gInvertXAxis");
-        DrawHelpIcon("Inverts the Camera X Axis in:\n-Free camera");
-        UIWidgets::PaddedEnhancementCheckbox("Invert Camera Y Axis", "gInvertYAxis", true, true, false, "", UIWidgets::CheckboxGraphics::Cross, true);
-        DrawHelpIcon("Inverts the Camera Y Axis in:\n-Free camera");
+        UIWidgets::PaddedEnhancementCheckbox("Invert X Axis", "gInvertXAxis");
+        DrawHelpIcon("Inverts the Camera X Axis in:\n-Free Look");
+        UIWidgets::PaddedEnhancementCheckbox("Invert Y Axis", "gInvertYAxis", true, true, false, "", UIWidgets::CheckboxGraphics::Cross, true);
+        DrawHelpIcon("Inverts the Camera Y Axis in:\n-Free Look");
         UIWidgets::Spacer(0);
-        UIWidgets::PaddedEnhancementSliderFloat("Third-Person Horizontal Sensitivity: %d %%", "##ThirdPersonSensitivity Horizontal",
+        UIWidgets::PaddedEnhancementSliderFloat("Horizontal Sensitivity: %d %%", "##ThirdPersonSensitivity Horizontal",
                                                 "gThirdPersonCameraSensitivityX", 0.01f, 5.0f, "", 1.0f, true, true, false, true);
-        UIWidgets::PaddedEnhancementSliderFloat("Third-Person Vertical Sensitivity: %d %%", "##ThirdPersonSensitivity Vertical",
+        DrawHelpIcon("Changes the sensitivity of the X axis control for Free Look");
+        UIWidgets::PaddedEnhancementSliderFloat("Vertical Sensitivity: %d %%", "##ThirdPersonSensitivity Vertical",
                                                 "gThirdPersonCameraSensitivityY", 0.01f, 5.0f, "", 1.0f, true, true, false, true);
+        DrawHelpIcon("Changes the sensitivity of the Y axis control for Free Look");
         UIWidgets::PaddedEnhancementSliderInt("Camera Distance: %d", "##CamDist",
                                         "gFreeCameraDistMax", 100, 900, "", 185, true, false, true);
-        UIWidgets::PaddedEnhancementSliderInt("Camera Transition Speed: %d", "##CamTranSpeed",
+        DrawHelpIcon("How far the camera sits from Link while in Free Look mode");
+        UIWidgets::PaddedEnhancementSliderInt("Transition Speed: %d", "##CamTranSpeed",
                                         "gFreeCameraTransitionSpeed", 0, 900, "", 25, true, false, true);
+        DrawHelpIcon("How quickly the camera changes to the distance specified above");
         window->EndGroupPanelPublic(0);
     }
 

--- a/soh/src/code/z_camera.c
+++ b/soh/src/code/z_camera.c
@@ -7887,7 +7887,7 @@ s32 Camera_ChangeModeFlags(Camera* camera, s16 mode, u8 flags) {
             }
         }
 
-        // Clear free camera if an action is performed that would move the camera (targeting, first person, talking)
+        // Clear free look if an action is performed that would move the camera (targeting, first person, talking)
         if (CVarGetInteger("gFreeCamera", 0) && SetCameraManual(camera) == 1 &&
             ((mode >= CAM_MODE_TARGET && mode <= CAM_MODE_BATTLE) ||
              (mode >= CAM_MODE_FIRSTPERSON && mode <= CAM_MODE_CLIMBZ) || mode == CAM_MODE_HANGZ ||


### PR DESCRIPTION
To avoid future confusion with the traditional definition of freecam, that being camera movement independent of the player character. Also adds helper info for invert, distance, and transition speed options, and clarifies language in the other helper info.

Note: The CVars for free look (7 of them total) need to be renamed to reflect the change from freecam, but this is being postponed to be wrapped into my CVar name/path rework to avoid the need for a migrator here.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1139968700.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1139968702.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1139968703.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1139968704.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1139968705.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1139968706.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1139968707.zip)
<!--- section:artifacts:end -->