### PR TITLE
Fix settings persistence across sessions

### DIFF
--- a/soh/soh/SaveManager.cpp
+++ b/soh/soh/SaveManager.cpp
@@ -2725,6 +2725,8 @@ extern "C" void Save_LoadFile(void) {
         // Reset rando context for rando saves.
         OTRGlobals::Instance->gRandoContext.reset();
         OTRGlobals::Instance->gRandoContext = Rando::Context::CreateInstance();
+        OTRGlobals::Instance->gRandoContext->AddExcludedOptions();
+        OTRGlobals::Instance->gRandoContext->GetSettings()->CreateOptions();
     }
     SaveManager::Instance->LoadFile(gSaveContext.fileNum);
 }


### PR DESCRIPTION
Adds in the option initializations from OTRGlobals to the rando context reset added in #3766 to address an issue where rando settings would no longer persist after saving a game https://github.com/HarbourMasters/Shipwright/blob/c9907ed5fc823a31394730ae41b3bc5f5ad4086d/soh/soh/OTRGlobals.cpp#L339 

<!--- section:artifacts:start -->
### Build Artifacts
<!--- section:artifacts:end -->