### PR TITLE
Fix Starting Triforce Piece Count

### DIFF
--- a/soh/soh/Enhancements/randomizer/savefile.cpp
+++ b/soh/soh/Enhancements/randomizer/savefile.cpp
@@ -207,6 +207,9 @@ extern "C" void Randomizer_InitSaveFile() {
         gSaveContext.randomizerInf[i] = 0;
     }
 
+    // Reset triforce pieces collected
+    gSaveContext.triforcePiecesCollected = 0;
+
     gSaveContext.cutsceneIndex = 0; // no intro cutscene
     // Starts pending ice traps out at 0 before potentially incrementing them down the line.
     gSaveContext.pendingIceTrapCount = 0;
@@ -441,9 +444,6 @@ extern "C" void Randomizer_InitSaveFile() {
         gSaveContext.itemGetInf[3] |= 0x800;  // bunny hood related
         gSaveContext.itemGetInf[3] |= 0x8000; // Obtained Mask of Truth
     }
-
-    // Reset triforce pieces collected
-    gSaveContext.triforcePiecesCollected = 0;
 
     SetStartingItems();
 }


### PR DESCRIPTION
Turns out, `triforcePiecesCollected` was getting zeroed at the end of `Randomizer_InitSaveFile()`, which was undoing any counting being done for starting triforce pieces, thus preventing triforce hunt completion when starting with any pieces and requiring the exact number as in the pool. This moves that to the start of `Randomizer_InitSaveFile()` instead.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1148292545.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1148292547.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1148292548.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1148292549.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1148292550.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1148292551.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1148292553.zip)
<!--- section:artifacts:end -->