### PR TITLE
No Magic Numbers for Preset Location Exclusions

### DIFF
--- a/soh/soh/Enhancements/presets.cpp
+++ b/soh/soh/Enhancements/presets.cpp
@@ -16,7 +16,7 @@ void clearCvars(std::vector<const char*> cvarsToClear) {
 std::string FormatLocations(std::vector<RandomizerCheck> locs) {
     std::string locString = "";
     for (auto loc: locs) {
-        locString += std::format("{},", (uint32_t)loc);
+        locString += std::to_string(loc) + ",";
     }
     return locString;
 }

--- a/soh/soh/Enhancements/presets.cpp
+++ b/soh/soh/Enhancements/presets.cpp
@@ -1,4 +1,5 @@
 #include "presets.h"
+#include <format>
 #include <variant>
 #include <string>
 #include <cstdint>
@@ -12,6 +13,14 @@ void clearCvars(std::vector<const char*> cvarsToClear) {
     }
 }
 
+std::string FormatLocations(std::vector<RandomizerCheck> locs) {
+    std::string locString = "";
+    for (auto loc: locs) {
+        locString += std::format("{},", (uint32_t)loc);
+    }
+    return locString;
+}
+
 void applyPreset(std::vector<PresetEntry> entries) {
     for(auto& [cvar, type, value] : entries) {
         switch (type) {
@@ -23,6 +32,9 @@ void applyPreset(std::vector<PresetEntry> entries) {
                 break;
             case PRESET_ENTRY_TYPE_STRING:
                 CVarSetString(cvar, std::get<const char*>(value));
+                break;
+            case PRESET_ENTRY_TYPE_CPP_STRING:
+                CVarSetString(cvar, std::get<std::string>(value).c_str());
                 break;
         }
     }

--- a/soh/soh/Enhancements/presets.cpp
+++ b/soh/soh/Enhancements/presets.cpp
@@ -1,5 +1,4 @@
 #include "presets.h"
-#include <format>
 #include <variant>
 #include <string>
 #include <cstdint>

--- a/soh/soh/Enhancements/presets.h
+++ b/soh/soh/Enhancements/presets.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <map>
+#include <string>
 #include <vector>
 #include <variant>
 #include <cstdint>
@@ -11,6 +12,7 @@ enum PresetEntryType {
     PRESET_ENTRY_TYPE_S32,
     PRESET_ENTRY_TYPE_FLOAT,
     PRESET_ENTRY_TYPE_STRING,
+    PRESET_ENTRY_TYPE_CPP_STRING,
 };
 
 enum PresetType {
@@ -36,8 +38,10 @@ enum RandomizerPreset {
 typedef struct PresetEntry {
     const char* cvar;
     PresetEntryType type;
-    std::variant<int32_t, float, const char*> value;
+    std::variant<int32_t, float, const char*, std::string> value;
 } PresetEntry;
+
+std::string FormatLocations(std::vector<RandomizerCheck> locs);
 
 #define PRESET_ENTRY_S32(cvar, value) \
     { cvar,    PRESET_ENTRY_TYPE_S32, value }
@@ -45,6 +49,8 @@ typedef struct PresetEntry {
     { cvar,  PRESET_ENTRY_TYPE_FLOAT, value }
 #define PRESET_ENTRY_STRING(cvar, value) \
     { cvar, PRESET_ENTRY_TYPE_STRING, value }
+#define PRESET_ENTRY_CPP_STRING(cvar, value) \
+    { cvar, PRESET_ENTRY_TYPE_CPP_STRING, value }
 
 void DrawPresetSelector(PresetType presetType);
 void clearCvars(std::vector<const char*> cvarsToClear);
@@ -866,7 +872,8 @@ const std::vector<PresetEntry> spockRacePresetEntries = {
     PRESET_ENTRY_S32("gRandomizeDampeHint", 1),
     PRESET_ENTRY_S32("gRandomizeDoorOfTime", RO_DOOROFTIME_OPEN),
     PRESET_ENTRY_S32("gRandomizeEnableBombchuDrops", 1),
-    PRESET_ENTRY_STRING("gRandomizeExcludedLocations", "78,143,144,229,"),
+    PRESET_ENTRY_CPP_STRING("gRandomizeExcludedLocations", FormatLocations( 
+        { RC_MARKET_10_BIG_POES, RC_KAK_40_GOLD_SKULLTULA_REWARD, RC_KAK_50_GOLD_SKULLTULA_REWARD, RC_ZR_FROGS_OCARINA_GAME })),
     PRESET_ENTRY_S32("gRandomizeForest", RO_FOREST_OPEN),
     PRESET_ENTRY_S32("gRandomizeFullWallets", 1),
     PRESET_ENTRY_S32("gRandomizeGanonTrial", RO_GANONS_TRIALS_SKIP),
@@ -958,7 +965,8 @@ const std::vector<PresetEntry> spockRaceNoLogicPresetEntries = {
     PRESET_ENTRY_S32("gRandomizeDampeHint", 1),
     PRESET_ENTRY_S32("gRandomizeDoorOfTime", RO_DOOROFTIME_OPEN),
     PRESET_ENTRY_S32("gRandomizeEnableBombchuDrops", 1),
-    PRESET_ENTRY_STRING("gRandomizeExcludedLocations", "78,143,144,229,"),
+    PRESET_ENTRY_CPP_STRING("gRandomizeExcludedLocations", FormatLocations(
+        { RC_MARKET_10_BIG_POES, RC_KAK_40_GOLD_SKULLTULA_REWARD, RC_KAK_50_GOLD_SKULLTULA_REWARD, RC_ZR_FROGS_OCARINA_GAME })),
     PRESET_ENTRY_S32("gRandomizeForest", RO_FOREST_OPEN),
     PRESET_ENTRY_S32("gRandomizeFullWallets", 1),
     PRESET_ENTRY_S32("gRandomizeGanonTrial", RO_GANONS_TRIALS_SKIP),
@@ -1011,7 +1019,7 @@ const std::vector<PresetEntry> s6PresetEntries = {
     PRESET_ENTRY_S32("gRandomizeBigPoeTargetCount", 1),
     PRESET_ENTRY_S32("gRandomizeCuccosToReturn", 4),
     PRESET_ENTRY_S32("gRandomizeDoorOfTime", RO_DOOROFTIME_OPEN),
-    PRESET_ENTRY_STRING("gRandomizeExcludedLocations", "48,"),
+    PRESET_ENTRY_CPP_STRING("gRandomizeExcludedLocations", FormatLocations({ RC_DEKU_THEATER_MASK_OF_TRUTH })),
     PRESET_ENTRY_S32("gRandomizeForest", RO_FOREST_CLOSED_DEKU),
     PRESET_ENTRY_S32("gRandomizeGanonTrial", RO_GANONS_TRIALS_SKIP),
     PRESET_ENTRY_S32("gRandomizeGerudoFortress", RO_GF_FAST),


### PR DESCRIPTION
Previously, a change to the `RandomizerCheck` enum caused all location exclusions in the presets to be off by 1 because they were feeding literal strings.  This adds `FormatLocations` and `PRESET_ENTRY_TYPE_CPP_STRING` to allow for feeding `RandomizerCheck` values directly in presets instead of a string with magic numbers to prevent this in the future.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1149023102.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1149023103.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1149023104.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1149023105.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1149023106.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1149023107.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1149023108.zip)
<!--- section:artifacts:end -->