### PR TITLE
Fix: Tektite texture not loading for death animation

### DIFF
--- a/soh/src/overlays/actors/ovl_En_Part/z_en_part.c
+++ b/soh/src/overlays/actors/ovl_En_Part/z_en_part.c
@@ -8,6 +8,8 @@
 #include "objects/object_tite/object_tite.h"
 #include "objects/object_ik/object_ik.h"
 
+#include <string.h> // strcmp
+
 #define FLAGS ACTOR_FLAG_UPDATE_WHILE_CULLED
 
 void EnPart_Init(Actor* thisx, PlayState* play);

--- a/soh/src/overlays/actors/ovl_En_Part/z_en_part.c
+++ b/soh/src/overlays/actors/ovl_En_Part/z_en_part.c
@@ -297,11 +297,11 @@ void EnPart_Draw(Actor* thisx, PlayState* play) {
         gSPSegment(POLY_OPA_DISP++, 0x08, func_80ACEAC0(play->state.gfxCtx, 255, 255, 255, 180, 180, 180));
         gSPSegment(POLY_OPA_DISP++, 0x09, func_80ACEAC0(play->state.gfxCtx, 225, 205, 115, 25, 20, 0));
         gSPSegment(POLY_OPA_DISP++, 0x0A, func_80ACEAC0(play->state.gfxCtx, 225, 205, 115, 25, 20, 0));
-    } else if ((thisx->params == 9) && (this->displayList == ResourceMgr_LoadGfxByName(object_tite_DL_002FF0))) {
+    } else if ((thisx->params == 9) && (strcmp((const char*)this->displayList, object_tite_DL_002FF0) == 0)) {
         gSPSegment(POLY_OPA_DISP++, 0x08, object_tite_Tex_001300);
         gSPSegment(POLY_OPA_DISP++, 0x09, object_tite_Tex_001700);
         gSPSegment(POLY_OPA_DISP++, 0x0A, object_tite_Tex_001900);
-    } else if ((thisx->params == 10) && (this->displayList == ResourceMgr_LoadGfxByName(object_tite_DL_002FF0))) {
+    } else if ((thisx->params == 10) && (strcmp((const char*)this->displayList, object_tite_DL_002FF0) == 0)) {
         gSPSegment(POLY_OPA_DISP++, 0x08, object_tite_Tex_001B00);
         gSPSegment(POLY_OPA_DISP++, 0x09, object_tite_Tex_001F00);
         gSPSegment(POLY_OPA_DISP++, 0x0A, object_tite_Tex_002100);


### PR DESCRIPTION
After #3479, DList values on limbs are now OTR string paths instead of the raw gfx data.

Tektites have a condition to use a blue or red texture for their main body. When the tektite is killed, a set of EnParts are spawned which need to do a similar lookup for red vs blue.

This needed to be updated to new compare OTR string paths together instead of comparing raw gfx pointers.

Fixes #3775

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1156014960.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1156014961.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1156014962.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1156014963.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1156014964.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1156014965.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1156014968.zip)
<!--- section:artifacts:end -->