### PR TITLE
Fix: Move Ruto earring fix to graphic patch and fix Ganon fight rubble DL reference

### DIFF
--- a/soh/soh/Enhancements/cosmetics/authenticGfxPatches.cpp
+++ b/soh/soh/Enhancements/cosmetics/authenticGfxPatches.cpp
@@ -8,6 +8,7 @@ extern "C" {
 #include "objects/object_gi_soldout/object_gi_soldout.h"
 #include "objects/object_ik/object_ik.h"
 #include "objects/object_link_child/object_link_child.h"
+#include "objects/object_ru2/object_ru2.h"
 
 uint32_t ResourceMgr_GameHasMasterQuest();
 uint32_t ResourceMgr_GameHasOriginal();
@@ -187,10 +188,25 @@ void PatchIronKnuckleTextureOverflow() {
     }
 }
 
+void PatchPrincessRutoEaring() {
+    // FAST3D: This is a hack for the issue of both TEXEL0 and TEXEL1 using the same texture with different settings.
+    // Ruto's earring uses both TEXEL0 and TEXEL1 to render. The issue is that it never loads anything into TEXEL1, so
+    // it reuses whatever happens to be there, which is the water temple brick texture. It just so happens that the
+    // earring texture loads into the same place in TMEM as the brick texture, so when it comes to rendering, TEXEL1
+    // uses the earring texture with different clamp settings, and it displays without noticeable error. However, both
+    // texel samplers are not intended to be used for the same texture with different settings, so this misuse confuses
+    // our texture cache, and we load the wrong settings for the earrings texture. This patch is a hack that replaces
+    // TEXEL1 with TEXEL0, which is most likely the original intention, and all is well.
+    ResourceMgr_PatchGfxByName(gAdultRutoHeadDL, "RutoEaringTileFix", 162,
+                               gsDPSetCombineLERP(TEXEL0, 0, PRIMITIVE, 0, TEXEL0, 0, ENVIRONMENT, 0, 0, 0, 0, COMBINED,
+                                                  TEXEL0, 0, PRIM_LOD_FRAC, COMBINED));
+}
+
 void ApplyAuthenticGfxPatches() {
     PatchDekuStickTextureOverflow();
     PatchFreezardTextureOverflow();
     PatchIronKnuckleTextureOverflow();
+    PatchPrincessRutoEaring();
 }
 
 // Patches the Sold Out GI DL to render the texture in the mirror boundary

--- a/soh/src/overlays/actors/ovl_Demo_Gj/z_demo_gj.c
+++ b/soh/src/overlays/actors/ovl_Demo_Gj/z_demo_gj.c
@@ -192,11 +192,11 @@ void DemoGj_Explode(DemoGj* this, PlayState* play, Vec3f* initialPos, Vec3f* dir
             phi_s0 = 0x21;
         }
 
-        Gfx* gfx = ResourceMgr_LoadGfxByName(gGanonRubbleDL);
-
+        // SoH [Port] Changed from &gGanonsCastleRubbleAroundArenaDL[28] to gGanonRubbleDL as it seems this was an error in the original rom/decomp
+        // Other calls to EffectSsKakera_Spawn with OBJECT_GEFF use gGanonRubbleDL, so this change is to match that
         EffectSsKakera_Spawn(play, &explosionPos, &velocity, initialPos, -200, phi_s0, 10, 10, 0,
                              Rand_ZeroOne() * 20.0f + 20.0f, 20, 300, (s32)(Rand_ZeroOne() * 30.0f) + 30, -1,
-                             OBJECT_GEFF, gfx);
+                             OBJECT_GEFF, gGanonRubbleDL);
 
         theta += 0x2AAA;
     }

--- a/soh/src/overlays/actors/ovl_En_Ru2/z_en_ru2.c
+++ b/soh/src/overlays/actors/ovl_En_Ru2/z_en_ru2.c
@@ -821,19 +821,6 @@ void func_80AF3F20(EnRu2* this, PlayState* play) {
 void EnRu2_Draw(Actor* thisx, PlayState* play) {
     EnRu2* this = (EnRu2*)thisx;
 
-    // FAST3D: This is a hack for the issue of both TEXEL0 and TEXEL1 using the same texture with different settings.
-    // Ruto's earring uses both TEXEL0 and TEXEL1 to render. The issue is that it never loads anything into TEXEL1, so
-    // it reuses whatever happens to be there, which is the water temple brick texture. It just so happens that the
-    // earring texture loads into the same place in tmem as the brick texture, so when it comes to rendering, TEXEL1
-    // uses the earring texture with diffrent clamp settings, and it displays without noticeable error. However, both
-    // texel samplers are not intended to be used for the same texture with different settings, so this misuse confuses
-    // our texture cache, and we load the wrong settings for the earrings texture. This patch is a hack that replaces
-    // TEXEL1 with TEXEL0, which is most likely the original intention, and all is well.
-    Gfx* gfx = ResourceMgr_LoadGfxByName(gAdultRutoHeadDL);
-    Gfx patch = gsDPSetCombineLERP(TEXEL0, 0, PRIMITIVE, 0, TEXEL0, 0, ENVIRONMENT, 0, 0, 0, 0, COMBINED, TEXEL0, 0,
-                                  PRIM_LOD_FRAC, COMBINED);
-    gfx[0xA2] = patch;
-
     if ((this->drawConfig < 0) || (this->drawConfig >= ARRAY_COUNT(sDrawFuncs)) ||
         (sDrawFuncs[this->drawConfig] == 0)) {
         // "Draw Mode is improper!"


### PR DESCRIPTION
This moves the adult Ruto earring DL patch to a proper patch under `authenticGfxPatches` via `ResourceMgr_PatchGfxByName` so that it only applies to the original DL and not custom model DLs.

This also removes a `ResourceMgr_LoadGfxByName` for one of the ganon rubble effects that should be passing the OTR string path instead to support alt toggling situations.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1151148360.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1151148362.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1151148364.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1151148365.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1151148366.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1151148368.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1151148370.zip)
<!--- section:artifacts:end -->