### PR TITLE
Fix other hint locations not getting reset

### DIFF
--- a/soh/soh/Enhancements/randomizer/context.cpp
+++ b/soh/soh/Enhancements/randomizer/context.cpp
@@ -247,7 +247,9 @@ void Context::LocationReset() {
         GetItemLocation(il)->RemoveFromPool();
     }
 
-    GetItemLocation(RC_GANONDORF_HINT)->RemoveFromPool();
+    for (const RandomizerCheck il : StaticData::otherHintLocations) {
+        GetItemLocation(il)->RemoveFromPool();
+    }
 }
 
 void Context::HintReset() {


### PR DESCRIPTION
This fixes greg hints being forced when they shouldn't, among other things

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1151215818.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1151215821.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1151215824.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1151215825.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1151215827.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1151215831.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1151215834.zip)
<!--- section:artifacts:end -->