### PR TITLE
Glitch Tick Change

### DIFF
--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -3583,7 +3583,7 @@ void Interface_DrawLineupTick(PlayState* play) {
     s16 width = 32;
     s16 height = 32;
     s16 x = -8 + (SCREEN_WIDTH / 2);
-    s16 y = CVarGetInteger("gOpenMenuBar", 0) ? -4 : -6;
+    s16 y = -6;
 
     OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, gEmptyCDownArrowTex, width, height, x, y, width, height, 2 << 10, 2 << 10);
 


### PR DESCRIPTION
Having it set to just -6 makes the Glitch Tick stay in the same spot in game. when the F1 menu bar is open. At least on Windows

**With F1 Bar closed**
![image](https://github.com/HarbourMasters/Shipwright/assets/115201185/c4fa53aa-9ab4-442e-a8ac-ea5c6d4ef0a7)

**With F1 Bar open BEFORE**
![image](https://github.com/HarbourMasters/Shipwright/assets/115201185/a44d8e26-96cb-4d51-8c45-75df1b8ec34d)

**With F1 Bar open AFTER**
![image](https://github.com/HarbourMasters/Shipwright/assets/115201185/97dce864-bb89-44f0-a04c-baafcd04fb1b)


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1152143960.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1152143962.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1152143963.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1152143964.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1152143965.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1152143966.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1152143967.zip)
<!--- section:artifacts:end -->