### PR TITLE
[Time Saver] Reset Navi Timer

### DIFF
--- a/soh/soh/Enhancements/mods.cpp
+++ b/soh/soh/Enhancements/mods.cpp
@@ -689,7 +689,7 @@ void RegisterMirrorModeHandler() {
 
 void RegisterResetNaviTimer() {
     GameInteractor::Instance->RegisterGameHook<GameInteractor::OnSceneInit>([](int32_t sceneNum) {
-		if (CVarGetInteger("gResetNaviTimer", 0) == 1) {
+		if (CVarGetInteger("gEnhancements.ResetNaviTimer", 0)) {
 			gSaveContext.naviTimer = 0;
 		}
 	});

--- a/soh/soh/Enhancements/mods.cpp
+++ b/soh/soh/Enhancements/mods.cpp
@@ -687,6 +687,14 @@ void RegisterMirrorModeHandler() {
     });
 }
 
+void RegisterResetNaviTimer() {
+    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnSceneInit>([](int32_t sceneNum) {
+		if (CVarGetInteger("gResetNaviTimer", 0) == 1) {
+			gSaveContext.naviTimer = 0;
+		}
+	});
+}
+
 f32 triforcePieceScale;
 
 void RegisterTriforceHunt() {
@@ -1248,6 +1256,7 @@ void InitMods() {
     RegisterBonkDamage();
     RegisterMenuPathFix();
     RegisterMirrorModeHandler();
+    RegisterResetNaviTimer();
     RegisterTriforceHunt();
     RegisterGrantGanonsBossKey();
     RegisterEnemyDefeatCounts();

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -541,7 +541,7 @@ void DrawEnhancementsMenu() {
                 UIWidgets::Tooltip("Allows you to have \"Link\" as a premade file name");
                 UIWidgets::PaddedEnhancementCheckbox("No Forced Navi", "gNoForcedNavi", true, false);
                 UIWidgets::Tooltip("Prevent forced Navi conversations");
-                UIWidgets::PaddedEnhancementCheckbox("Navi Timer Resets", "gResetNaviTimer", true, false);
+                UIWidgets::PaddedEnhancementCheckbox("Navi Timer Resets", "gEnhancements.ResetNaviTimer", true, false);
                 UIWidgets::Tooltip("Resets the Navi timer on scene change. If you have already talked to her, she will try and talk to you again, instead of needing a save warp or death. ");
                 UIWidgets::PaddedEnhancementCheckbox("No Skulltula Freeze", "gSkulltulaFreeze", true, false);
                 UIWidgets::Tooltip("Stops the game from freezing the player when picking up Gold Skulltulas");

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -541,6 +541,8 @@ void DrawEnhancementsMenu() {
                 UIWidgets::Tooltip("Allows you to have \"Link\" as a premade file name");
                 UIWidgets::PaddedEnhancementCheckbox("No Forced Navi", "gNoForcedNavi", true, false);
                 UIWidgets::Tooltip("Prevent forced Navi conversations");
+                UIWidgets::PaddedEnhancementCheckbox("Navi Timer Resets", "gResetNaviTimer", true, false);
+                UIWidgets::Tooltip("Resets the Navi timer on scene change. If you have already talked to her, she will try and talk to you again, instead of needing a save warp or death.");
                 UIWidgets::PaddedEnhancementCheckbox("No Skulltula Freeze", "gSkulltulaFreeze", true, false);
                 UIWidgets::Tooltip("Stops the game from freezing the player when picking up Gold Skulltulas");
                 UIWidgets::PaddedEnhancementCheckbox("Fast Chests", "gFastChests", true, false);

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -542,7 +542,7 @@ void DrawEnhancementsMenu() {
                 UIWidgets::PaddedEnhancementCheckbox("No Forced Navi", "gNoForcedNavi", true, false);
                 UIWidgets::Tooltip("Prevent forced Navi conversations");
                 UIWidgets::PaddedEnhancementCheckbox("Navi Timer Resets", "gResetNaviTimer", true, false);
-                UIWidgets::Tooltip("Resets the Navi timer on scene change. If you have already talked to her, she will try and talk to you again, instead of needing a save warp or death.");
+                UIWidgets::Tooltip("Resets the Navi timer on scene change. If you have already talked to her, she will try and talk to you again, instead of needing a save warp or death. ");
                 UIWidgets::PaddedEnhancementCheckbox("No Skulltula Freeze", "gSkulltulaFreeze", true, false);
                 UIWidgets::Tooltip("Stops the game from freezing the player when picking up Gold Skulltulas");
                 UIWidgets::PaddedEnhancementCheckbox("Fast Chests", "gFastChests", true, false);


### PR DESCRIPTION
This enhancement resets the Navi Timer to 0 each time you change scenes. Normally once you talk to Navi once, it will set the timer to 3000, preventing Navi from talking to you again until you save and reset or die and reset. But each scene Navi's prompt to talk to her will pop up after her timer gets to 600. This is useful for Navi Dives, ISG, or just the general hints that Navi gives.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1207830648.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1207830649.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1207830650.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1207830652.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1207830653.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1207830654.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1207830655.zip)
<!--- section:artifacts:end -->