### PR TITLE
Fixes Save Bleed issues

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/menu.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/menu.cpp
@@ -46,6 +46,7 @@ bool GenerateRandomizer(std::set<RandomizerCheck> excludedLocations, std::set<Ra
     uint32_t seedHash = boost::hash_32<std::string>{}(ctx->GetSettings()->GetSeedString());
     ctx->GetSettings()->SetSeed(seedHash & 0xFFFFFFFF);
 
+    ctx->ClearItemLocations();
     int ret = Playthrough::Playthrough_Init(ctx->GetSettings()->GetSeed(), excludedLocations, enabledTricks);
     if (ret < 0) {
         if (ret == -1) { // Failed to generate after 5 tries

--- a/soh/soh/Enhancements/randomizer/context.cpp
+++ b/soh/soh/Enhancements/randomizer/context.cpp
@@ -226,6 +226,12 @@ std::vector<RandomizerCheck> Context::GetLocations(const std::vector<RandomizerC
     return locationsInCategory;
 }
 
+void Context::ClearItemLocations() {
+    for (int i = 0; i < itemLocationTable.size(); i++) {
+        GetItemLocation(static_cast<RandomizerCheck>(i))->ResetVariables();
+    }
+}
+
 void Context::ItemReset() {
     for (const RandomizerCheck il : allLocations) {
         GetItemLocation(il)->ResetVariables();

--- a/soh/soh/Enhancements/randomizer/context.h
+++ b/soh/soh/Enhancements/randomizer/context.h
@@ -50,6 +50,7 @@ class Context {
                                               Category categoryInclude, Category categoryExclude = Category::cNull);
     void AddExcludedOptions();
     void LocationReset();
+    void ClearItemLocations();
     void ItemReset();
     void HintReset();
     void CreateItemOverrides();


### PR DESCRIPTION
This should fix some issues related to item location data being brought over from a save file instead of starting from scratch on a new seed generation. I haven't actually been able to replicate these save bleed issues yet so I'll need some other people to test this.

The crux of the issue, ultimately, is that not every single RC value ends up in `allLocations` to get reset during the `ItemReset` function. `allLocations` is supposed to end up with all the RCs relevant to that seed, so for instance if you don't have MQ dungeons, it doesn't have MQ dungeon RC's in it. Also, if people are adding new RC's and not putting them in either overworld locations or in the list of locations for the correct dungeon, they wouldn't be getting cleared.

To fix this, I added a new function that will run at the start of any seed generation and call `ResetVariables` for every RC. The existing `ItemReset` and `LocationReset` functions I believe get called in some other situations where the current behaviour is expected and desired, so I didn't want to completely remove them. Some renaming may be due to happen in this arena at some point to clear things up.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1153108209.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1153108210.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1153108211.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1153108212.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1153108213.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1153108214.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1153108215.zip)
<!--- section:artifacts:end -->