### PR TITLE
Restore Original Scene Command Object List Behaviour

### DIFF
--- a/soh/soh/z_scene_otr.cpp
+++ b/soh/soh/z_scene_otr.cpp
@@ -152,7 +152,6 @@ extern "C" void* func_800982FC(ObjectContext* objectCtx, s32 bankIndex, s16 obje
 bool OTRfunc_800982FC(ObjectContext* objectCtx, s32 bankIndex, s16 objectId) {
 
     objectCtx->status[bankIndex].id = -objectId;
-    objectCtx->status[bankIndex].dmaRequest.vromAddr = 0;
 
     return false;
 }

--- a/soh/soh/z_scene_otr.cpp
+++ b/soh/soh/z_scene_otr.cpp
@@ -175,6 +175,8 @@ bool Scene_CommandObjectList(PlayState* play, LUS::ISceneCommand* cmd) {
     firstStatus = &play->objectCtx.status[0];
     status = &play->objectCtx.status[i];
 
+    // Loop until a mismatch in the object lists
+    // Then clear all object ids past that in the context object list and kill actors for those objects
     for (i = play->objectCtx.unk_09, k = 0; i < play->objectCtx.num; i++, k++) {
         if (play->objectCtx.status[i].id != cmdObj->objects[k]) {
             for (j = i; j < play->objectCtx.num; j++) {
@@ -185,7 +187,7 @@ bool Scene_CommandObjectList(PlayState* play, LUS::ISceneCommand* cmd) {
         }
     }
 
-
+    // Continuing from the last index, add the remaining object ids from the command object list
     for (; k < cmdObj->objects.size(); k++, i++) {
         if (i < OBJECT_EXCHANGE_BANK_MAX - 1) {
             OTRfunc_800982FC(&play->objectCtx, i, cmdObj->objects[k]);

--- a/soh/soh/z_scene_otr.cpp
+++ b/soh/soh/z_scene_otr.cpp
@@ -149,6 +149,14 @@ bool Scene_CommandMeshHeader(PlayState* play, LUS::ISceneCommand* cmd) {
 
 extern "C" void* func_800982FC(ObjectContext* objectCtx, s32 bankIndex, s16 objectId);
 
+bool OTRfunc_800982FC(ObjectContext* objectCtx, s32 bankIndex, s16 objectId) {
+
+    objectCtx->status[bankIndex].id = -objectId;
+    objectCtx->status[bankIndex].dmaRequest.vromAddr = 0;
+
+    return false;
+}
+
 bool Scene_CommandObjectList(PlayState* play, LUS::ISceneCommand* cmd) {
     // LUS::SetObjectList* cmdObj = static_pointer_cast<LUS::SetObjectList>(cmd);
     LUS::SetObjectList* cmdObj = (LUS::SetObjectList*)cmd;
@@ -164,49 +172,28 @@ bool Scene_CommandObjectList(PlayState* play, LUS::ISceneCommand* cmd) {
     void* nextPtr;
 
     k = 0;
-    // i = play->objectCtx.unk_09;
-    i = 0;
+    i = play->objectCtx.unk_09;
     firstStatus = &play->objectCtx.status[0];
     status = &play->objectCtx.status[i];
 
-    for (int i = 0; i < cmdObj->objects.size(); i++) {
-        bool alreadyIncluded = false;
-
-        for (int j = 0; j < play->objectCtx.num; j++) {
-            if (play->objectCtx.status[j].id == cmdObj->objects[i]) {
-                alreadyIncluded = true;
-                break;
+    for (i = play->objectCtx.unk_09, k = 0; i < play->objectCtx.num; i++, k++) {
+        if (play->objectCtx.status[i].id != cmdObj->objects[k]) {
+            for (j = i; j < play->objectCtx.num; j++) {
+                play->objectCtx.status[j].id = OBJECT_INVALID;
             }
-        }
-
-        if (!alreadyIncluded) {
-            play->objectCtx.status[play->objectCtx.num++].id = cmdObj->objects[i];
             func_80031A28(play, &play->actorCtx);
+            break;
         }
     }
 
-    /*
-    while (i < play->objectCtx.num) {
-        if (status->id != *objectEntry) {
-            status2 = &play->objectCtx.status[i];
-            for (j = i; j < play->objectCtx.num; j++) {
-                status2->id = OBJECT_INVALID;
-                status2++;
-            }
-            play->objectCtx.num = i;
-            func_80031A28(play, &play->actorCtx);
 
-            continue;
+    for (; k < cmdObj->objects.size(); k++, i++) {
+        if (i < OBJECT_EXCHANGE_BANK_MAX - 1) {
+            OTRfunc_800982FC(&play->objectCtx, i, cmdObj->objects[k]);
         }
-
-        i++;
-        k++;
-        objectEntry++;
-        status++;
     }
 
     play->objectCtx.num = i;
-    */
 
     return false;
 }

--- a/soh/src/code/z_actor.c
+++ b/soh/src/code/z_actor.c
@@ -1239,8 +1239,7 @@ void Actor_Init(Actor* actor, PlayState* play) {
     CollisionCheck_InitInfo(&actor->colChkInfo);
     actor->floorBgId = BGCHECK_SCENE;
     ActorShape_Init(&actor->shape, 0.0f, NULL, 0.0f);
-    //if (Object_IsLoaded(&play->objectCtx, actor->objBankIndex))
-    {
+    if (Object_IsLoaded(&play->objectCtx, actor->objBankIndex)) {
         //Actor_SetObjectDependency(play, actor);
         actor->init(actor, play);
         actor->init = NULL;
@@ -3149,6 +3148,9 @@ void Actor_FreeOverlay(ActorDBEntry* dbEntry) {
     osSyncPrintf(VT_RST);
 }
 
+// SoH: Flag to check if actors are being spawned from the actor entry list
+//      This flag is checked against to allow actors which dont have an objectBankIndex in the objectCtx slot/status array to spawn
+//      An example of what this fixes, is that it allows hookshot to be used as child
 int gMapLoading = 0;
 
 Actor* Actor_Spawn(ActorContext* actorCtx, PlayState* play, s16 actorId, f32 posX, f32 posY, f32 posZ,

--- a/soh/src/code/z_scene.c
+++ b/soh/src/code/z_scene.c
@@ -93,7 +93,7 @@ void Object_UpdateBank(ObjectContext* objectCtx) {
                 size = objectFile->vromEnd - objectFile->vromStart;
                 osSyncPrintf("OBJECT EXCHANGE BANK-%2d SIZE %8.3fK SEG=%08x\n", i, size / 1024.0f, status->segment);
                 DmaMgr_SendRequest2(&status->dmaRequest, status->segment, objectFile->vromStart, size, 0,
-                                    &status->loadQueue, OS_MESG_PTR(NULL), __FILE__, __LINE__);
+                                    &status->loadQueue, NULL, __FILE__, __LINE__);
             } else if (!osRecvMesg(&status->loadQueue, NULL, OS_MESG_NOBLOCK)) {
                 status->id = -status->id;
             }

--- a/soh/src/code/z_scene.c
+++ b/soh/src/code/z_scene.c
@@ -83,23 +83,26 @@ void Object_UpdateBank(ObjectContext* objectCtx) {
     RomFile* objectFile;
     size_t size;
 
-    /*
+
     for (i = 0; i < objectCtx->num; i++) {
         if (status->id < 0) {
+            /*
             if (status->dmaRequest.vromAddr == 0) {
                 osCreateMesgQueue(&status->loadQueue, &status->loadMsg, 1);
                 objectFile = &gObjectTable[-status->id];
                 size = objectFile->vromEnd - objectFile->vromStart;
                 osSyncPrintf("OBJECT EXCHANGE BANK-%2d SIZE %8.3fK SEG=%08x\n", i, size / 1024.0f, status->segment);
                 DmaMgr_SendRequest2(&status->dmaRequest, status->segment, objectFile->vromStart, size, 0,
-                                    &status->loadQueue, NULL, __FILE__, __LINE__);
+                                    &status->loadQueue, OS_MESG_PTR(NULL), __FILE__, __LINE__);
             } else if (!osRecvMesg(&status->loadQueue, NULL, OS_MESG_NOBLOCK)) {
                 status->id = -status->id;
             }
+            */
+           status->id = -status->id;
         }
         status++;
     }
-    */
+
 }
 
 s32 Object_GetIndex(ObjectContext* objectCtx, s16 objectId) {


### PR DESCRIPTION
This restores the original behaviour of the scene command object list. What this achieves is restoring the behaviour of the Actor Glitch, which previously would not work on SoH.

I have included some extra comments explaining some things I learnt about when coming up with this.

See here for the relevant original behaviour from decomp https://github.com/zeldaret/oot/blob/c1a499c3ae7b0b6b54c66a651784d65c93a613e8/src/code/z_scene.c#L263C17-L263C17 

I have tidied up the loops a bit since they are messy on decomp, and probably could be matched with for loops

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1154982298.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1154982300.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1154982303.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1154982305.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1154982307.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1154982309.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1154982310.zip)
<!--- section:artifacts:end -->