### PR TITLE
Fix (Some of) Actor uncullZone Range Issues (MacReady)

### DIFF
--- a/soh/src/code/z_actor.c
+++ b/soh/src/code/z_actor.c
@@ -2861,9 +2861,9 @@ s32 func_800314D4(PlayState* play, Actor* actor, Vec3f* arg2, f32 arg3) {
     if ((arg2->z > -actor->uncullZoneScale) && (arg2->z < (actor->uncullZoneForward + actor->uncullZoneScale))) {
         var = (arg3 < 1.0f) ? 1.0f : 1.0f / arg3;
 
-        if ((((fabsf(arg2->x) - actor->uncullZoneScale) * var) < 2.0f) &&
-            (((arg2->y + actor->uncullZoneDownward) * var) > -2.0f) &&
-            (((arg2->y - actor->uncullZoneScale) * var) < 2.0f)) {
+        if ((((fabsf(arg2->x) - actor->uncullZoneScale) * var) < 1.0f) &&
+            (((arg2->y + actor->uncullZoneDownward) * var) > -1.0f) &&
+            (((arg2->y - actor->uncullZoneScale) * var) < 1.0f)) {
             return true;
         }
     }


### PR DESCRIPTION
I still sense that there are some issues with actor cull zones even with this, but this definitely fixes passing the gerudo guard. I'd know about these floats being wrong for a while but had always tested with blue warp zones which are harder to test with and more inconsistent in general so was glad to see it at least fixed the guard.

Edit: King Zora Unfreeze After Moving with Sign works with n64 setups now too

I still need to test that this will look good with widescreen, but I also figure we have disable draw distance for that reason

Edit: Haven't noticed any issues!

[soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1155284153.zip)
    [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1155284154.zip)
    [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1155284156.zip)
    [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1155284157.zip)
    [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1155284159.zip)
    [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1155284162.zip)
    [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1155284163.zip)