### PR TITLE
Item Tracker Hookshot/Longshot Identifiers

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
@@ -417,6 +417,16 @@ void DrawItemCount(ItemTrackerItem item) {
     int32_t trackerNumberDisplayMode = CVarGetInteger("gItemTrackerCapacityTrack", ITEM_TRACKER_NUMBER_CURRENT_CAPACITY_ONLY);
     int32_t trackerKeyNumberDisplayMode = CVarGetInteger("gItemTrackerKeyTrack", KEYS_COLLECTED_MAX);
 
+    if (item.id == ITEM_HOOKSHOT) {
+        ImGui::SetCursorScreenPos(ImVec2(p.x + (iconSize / 2) - (ImGui::CalcTextSize("H").x / 2) + 9, p.y - 22));
+        ImGui::Text("H");
+        return;
+    }
+    if (item.id == ITEM_LONGSHOT) {
+        ImGui::SetCursorScreenPos(ImVec2(p.x + (iconSize / 2) - (ImGui::CalcTextSize("L").x / 2) + 9, p.y - 22));
+        ImGui::Text("L");
+        return;
+    }
     if (item.id == ITEM_KEY_SMALL && IsValidSaveFile()) {
         std::string currentString = "";
         std::string maxString = std::to_string(currentAndMax.maxCapacity);

--- a/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
@@ -423,14 +423,12 @@ void DrawItemCount(ItemTrackerItem item) {
     if (CVarGetInteger("gHookshotIdentifier", 0)) {
         if ((actualItemId == ITEM_HOOKSHOT || actualItemId == ITEM_LONGSHOT) && hasItem) {
 
-            // Calculate the scaled position for the text centered on the icon, moved slightly more to the left
+            // Calculate the scaled position for the text
             ImVec2 textPos = ImVec2(p.x + (iconSize / 2) - (ImGui::CalcTextSize(item.id == ITEM_HOOKSHOT ? "H" : "L").x * 
             textScalingFactor / 2) + 8 * textScalingFactor, p.y - 22 * textScalingFactor);
 
-            // Set the cursor position for the text
             ImGui::SetCursorScreenPos(textPos);
 
-            // Draw the scaled text
             ImGui::SetWindowFontScale(textScalingFactor);
 
             ImGui::Text(item.id == ITEM_HOOKSHOT ? "H" : "L");

--- a/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
@@ -420,7 +420,7 @@ void DrawItemCount(ItemTrackerItem item) {
     uint32_t actualItemId = INV_CONTENT(item.id);
     bool hasItem = actualItemId != ITEM_NONE;
 
-    if (CVarGetInteger("gHookshotIdentifier", 0)) {
+    if (CVarGetInteger("gTrackers.ItemTracker.HookshotIdentifier", 0)) {
         if ((actualItemId == ITEM_HOOKSHOT || actualItemId == ITEM_LONGSHOT) && hasItem) {
 
             // Calculate the scaled position for the text
@@ -1218,7 +1218,7 @@ void ItemTrackerSettingsWindow::DrawElement() {
             shouldUpdateVectors = true;
         }
     }
-    UIWidgets::EnhancementCheckbox("Show Hookshot Identifiers", "gHookshotIdentifier");
+    UIWidgets::EnhancementCheckbox("Show Hookshot Identifiers", "gTrackers.ItemTracker.HookshotIdentifier");
     UIWidgets::InsertHelpHoverText("Shows an 'H' or an 'L' to more easiely distinguish between Hookshot and Longshot.");
 
     UIWidgets::Spacer(0);

--- a/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
@@ -416,16 +416,26 @@ void DrawItemCount(ItemTrackerItem item) {
     ImVec2 p = ImGui::GetCursorScreenPos();
     int32_t trackerNumberDisplayMode = CVarGetInteger("gItemTrackerCapacityTrack", ITEM_TRACKER_NUMBER_CURRENT_CAPACITY_ONLY);
     int32_t trackerKeyNumberDisplayMode = CVarGetInteger("gItemTrackerKeyTrack", KEYS_COLLECTED_MAX);
+    float textScalingFactor = static_cast<float>(iconSize) / 36.0f;
+    uint32_t actualItemId = INV_CONTENT(item.id);
+    bool hasItem = actualItemId != ITEM_NONE;
 
-    if (item.id == ITEM_HOOKSHOT) {
-        ImGui::SetCursorScreenPos(ImVec2(p.x + (iconSize / 2) - (ImGui::CalcTextSize("H").x / 2) + 9, p.y - 22));
-        ImGui::Text("H");
-        return;
-    }
-    if (item.id == ITEM_LONGSHOT) {
-        ImGui::SetCursorScreenPos(ImVec2(p.x + (iconSize / 2) - (ImGui::CalcTextSize("L").x / 2) + 9, p.y - 22));
-        ImGui::Text("L");
-        return;
+    if (CVarGetInteger("gHookshotIdentifier", 0)) {
+        if ((actualItemId == ITEM_HOOKSHOT || actualItemId == ITEM_LONGSHOT) && hasItem) {
+
+            // Calculate the scaled position for the text centered on the icon, moved slightly more to the left
+            ImVec2 textPos = ImVec2(p.x + (iconSize / 2) - (ImGui::CalcTextSize(item.id == ITEM_HOOKSHOT ? "H" : "L").x * 
+            textScalingFactor / 2) + 8 * textScalingFactor, p.y - 22 * textScalingFactor);
+
+            // Set the cursor position for the text
+            ImGui::SetCursorScreenPos(textPos);
+
+            // Draw the scaled text
+            ImGui::SetWindowFontScale(textScalingFactor);
+
+            ImGui::Text(item.id == ITEM_HOOKSHOT ? "H" : "L");
+            ImGui::SetWindowFontScale(1.0f); // Reset font scale to the original state
+        }
     }
     if (item.id == ITEM_KEY_SMALL && IsValidSaveFile()) {
         std::string currentString = "";
@@ -1210,6 +1220,10 @@ void ItemTrackerSettingsWindow::DrawElement() {
             shouldUpdateVectors = true;
         }
     }
+    UIWidgets::EnhancementCheckbox("Show Hookshot Identifiers", "gHookshotIdentifier");
+    UIWidgets::InsertHelpHoverText("Shows an 'H' or an 'L' to more easiely distinguish between Hookshot and Longshot.");
+
+    UIWidgets::Spacer(0);
 
     ImGui::PopStyleVar(1);
     ImGui::EndTable();


### PR DESCRIPTION
Adds an H and L for Hookshot and Longshot to be able to tell more clearly which one you have, since the icons are very similar.

![image](https://github.com/HarbourMasters/Shipwright/assets/115201185/c2c1876c-5e19-4df0-8db8-6371bfe3cbee)
![image](https://github.com/HarbourMasters/Shipwright/assets/115201185/7547999e-bf4e-499c-bda7-e49c9d7a9fc4)

https://github.com/HarbourMasters/Shipwright/assets/115201185/2f9e99a0-42ed-49fb-a7e8-2b4c3e5cb5c9



<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1207807622.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1207807623.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1207807624.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1207807625.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1207807626.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1207807627.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1207807628.zip)
<!--- section:artifacts:end -->