### PR TITLE
Fix +/- buttons on float sliders not working at certain values

### DIFF
--- a/soh/soh/UIWidgets.cpp
+++ b/soh/soh/UIWidgets.cpp
@@ -449,7 +449,7 @@ namespace UIWidgets {
 
         if (changed && !(abs(oldVal - val) < 0.000001f)) {
             std::stringstream ss;
-            ss << std::setprecision(ticks) << val;
+            ss << std::setprecision(ticks + 1) << val;
             val = std::stof(ss.str());
             CVarSetFloat(cvarName, val);
             LUS::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();


### PR DESCRIPTION
When the value stored internally was slightly greater than the intended value, the +/- buttons were working fine.  Like, 0.99 was stored internally as something like 0.99000081, so truncating it to 2 decimal places would work as intended.  However, when the value stored internally was slightly less than the intended value, the stringstream truncation was being too aggressive.  For example, when going from 1.00 to 1.01, 1.01 is stored internally as something like 1.009999999902.  Thus, when trying to truncate to only two decimal places, the stringstream would see "1.00" and happily just store it as one, making it appear as though the button click did absolutely nothing (because it ended up in fact doing absolutely nothing!)  Adding an extra order of magnitude of precision fixes this case.  How I managed to only test with values that were stored slightly higher internally is 🥖 on me.  

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1171201898.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1171201900.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1171201901.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1171201903.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1171201904.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1171201905.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1171201906.zip)
<!--- section:artifacts:end -->