### PR TITLE
Fix: Timestamp truncation

### DIFF
--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -1144,8 +1144,7 @@ extern "C" uint64_t GetUnixTimestamp() {
     auto time = std::chrono::system_clock::now();
     auto since_epoch = time.time_since_epoch();
     auto millis = std::chrono::duration_cast<std::chrono::milliseconds>(since_epoch);
-    long now = millis.count();
-    return now;
+    return (uint64_t)millis.count();
 }
 
 // C->C++ Bridge


### PR DESCRIPTION
Our timestamp function using chrono was downcasting a `long long` to a `long` before finally casting it up to `uint64_t` (which is `unsigned long long`). This was causing the timestamp values to be truncated to 32 bits. Visually the in-game timers still displayed "ok" since it was comparing truncated value against truncated.

This change removes the down cast to prevent the truncation. After this merge, any save created before that was using RTA timing will display a large difference, but that in my opinion is not a big deal because most people aren't playing RTA timing across updates/many days apart from creation.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1190518024.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1190518026.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1190518028.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1190518029.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1190518030.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1190518031.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1190518033.zip)
<!--- section:artifacts:end -->