### PR TITLE
Account for removed object dependency in Deku Scrub Leader

### DIFF
--- a/soh/src/overlays/actors/ovl_En_Dnt_Jiji/z_en_dnt_jiji.c
+++ b/soh/src/overlays/actors/ovl_En_Dnt_Jiji/z_en_dnt_jiji.c
@@ -101,7 +101,7 @@ void EnDntJiji_Destroy(Actor* thisx, PlayState* play) {
 }
 
 void EnDntJiji_SetFlower(EnDntJiji* this, PlayState* play) {
-    // SOH: Due to removed object dependencies, parent was still NULL when Init was called. In order to proper set
+    // SOH: Due to removed object dependencies, parent was still NULL when Init was called. In order to properly set
     // stage, redo it here now that we are a frame later.
     this->stage = (EnDntDemo*)this->actor.parent;
     if (this->actor.bgCheckFlags & 1) {

--- a/soh/src/overlays/actors/ovl_En_Dnt_Jiji/z_en_dnt_jiji.c
+++ b/soh/src/overlays/actors/ovl_En_Dnt_Jiji/z_en_dnt_jiji.c
@@ -101,6 +101,9 @@ void EnDntJiji_Destroy(Actor* thisx, PlayState* play) {
 }
 
 void EnDntJiji_SetFlower(EnDntJiji* this, PlayState* play) {
+    // SOH: Due to removed object dependencies, parent was still NULL when Init was called. In order to proper set
+    // stage, redo it here now that we are a frame later.
+    this->stage = (EnDntDemo*)this->actor.parent;
     if (this->actor.bgCheckFlags & 1) {
         this->flowerPos = this->actor.world.pos;
         this->actionFunc = EnDntJiji_SetupWait;


### PR DESCRIPTION
Fixes #161 
When an actor is spawned as a child, it is spawned, and then the parent and child pointers are set. In the Deku Scrub Leader's `Init`, it stores its parent to a new pointer and uses that pointer to signal to other actors. If the parent is set _after_ `Init`, how does this work?

Well, that is because `Init` is not called until the actor's object dependency is loaded. Because we completely ignore that (all object are treated as loaded all the time), `Init` is always ran right as an actor is spawned.

To account for this behavior, I have added a second attempt to store the parent in leader's action function immediately following load.

 Note that in the vanilla game, the original behavior is actually a bug. Theoretically, the object could be loaded on frame 1. This is almost certainly never going to happen in practice, however.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1193350798.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1193350799.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1193350800.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1193350804.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1193350806.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1193350807.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1193350808.zip)
<!--- section:artifacts:end -->