### PR TITLE
Clarify descriptions of Graphics Settings

### DIFF
--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -385,27 +385,27 @@ void DrawSettingsMenu() {
                 bool matchingRefreshRate =
                     CVarGetInteger("gMatchRefreshRate", 0) && LUS::Context::GetInstance()->GetWindow()->GetWindowBackend() != LUS::WindowBackend::DX11;
                 UIWidgets::PaddedEnhancementSliderInt(
-                    (currentFps == 20) ? "Framerate: Original (20 fps)" : "Framerate: %d fps",
+                    (currentFps == 20) ? "Frame Rate: Original (20 fps)" : "Frame Rate: %d fps",
                     "##FPSInterpolation", "gInterpolationFPS", minFps, maxFps, "", 20, true, true, false, matchingRefreshRate);
             #endif
                 if (LUS::Context::GetInstance()->GetWindow()->GetWindowBackend() == LUS::WindowBackend::DX11) {
                     UIWidgets::Tooltip(
                         "Uses Matrix Interpolation to create extra frames, resulting in smoother graphics.\n"
                         "This is purely visual and does not impact game logic, execution of glitches etc.\n"
-                        "Higher FPS settings may impact CPU performance."
+                        "Higher frame rate settings may impact CPU performance."
                         "\n\n " ICON_FA_INFO_CIRCLE 
                         " There is no need to set this above your monitor's refresh rate. Doing so will waste resources and may give a worse result.");
                 } else {
                     UIWidgets::Tooltip(
                         "Uses Matrix Interpolation to create extra frames, resulting in smoother graphics.\n"
                         "This is purely visual and does not impact game logic, execution of glitches etc.\n"
-                        "Higher FPS settings may impact CPU performance.");
+                        "Higher frame rate settings may impact CPU performance.");
                 }
             } // END FPS Slider
 
             if (LUS::Context::GetInstance()->GetWindow()->GetWindowBackend() == LUS::WindowBackend::DX11) {
                 UIWidgets::Spacer(0);
-                if (ImGui::Button("Match Framerate to Refresh Rate")) {
+                if (ImGui::Button("Match Frame Rate to Refresh Rate")) {
                     int hz = LUS::Context::GetInstance()->GetWindow()->GetCurrentRefreshRate();
                     if (hz >= 20 && hz <= 360) {
                         CVarSetInteger("gInterpolationFPS", hz);
@@ -413,7 +413,7 @@ void DrawSettingsMenu() {
                     }
                 }
             } else {
-                UIWidgets::PaddedEnhancementCheckbox("Match FPS to Refresh Rate", "gMatchRefreshRate", true, false);
+                UIWidgets::PaddedEnhancementCheckbox("Match Frame Rate to Refresh Rate", "gMatchRefreshRate", true, false);
             }
             UIWidgets::Tooltip("Matches interpolation value to the game window's current refresh rate.");
 
@@ -422,7 +422,7 @@ void DrawSettingsMenu() {
                     "##ExtraLatencyThreshold", "gExtraLatencyThreshold", 0, 360, "", 80, true, true, false);
                 UIWidgets::Tooltip(
                     "(For DirectX backend only)\n\n"
-                    "When Interpolation FPS setting is at least this threshold, add one frame of delay (e.g. 16.6 ms for 60 FPS) in order to avoid jitter."
+                    "When Interpolation FPS (Frame Rate) setting is at least this threshold, add one frame of delay (e.g. 16.6 ms for 60 FPS) in order to avoid jitter."
                     "This setting allows the CPU to work on one frame while GPU works on the previous frame.\n"
                     "This setting should be used when your computer is too slow to do CPU + GPU work in time.");
             }

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -294,7 +294,9 @@ void DrawSettingsMenu() {
             }
 
         #ifndef __WIIU__
-            if (UIWidgets::PaddedEnhancementSliderInt("Anti-Aliasing (MSAA): %d", "##IMSAA", "gMSAAValue", 1, 8, "", 1, true, true, false)) {
+            if (UIWidgets::PaddedEnhancementSliderInt(
+                    (CVarGetInteger("gMSAAValue", 1) == 1) ? "Anti-Aliasing (MSAA): Off" : "Anti-Aliasing (MSAA): %d",
+                    "##IMSAA", "gMSAAValue", 1, 8, "", 1, true, true, false)) {
                 LUS::Context::GetInstance()->GetWindow()->SetMsaaLevel(CVarGetInteger("gMSAAValue", 1));
             };
             //UIWidgets::Tooltip("Activates multi-sample anti-aliasing when above 1x up to 8x for 8 samples for every pixel");

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -405,7 +405,7 @@ void DrawSettingsMenu() {
 
             if (LUS::Context::GetInstance()->GetWindow()->GetWindowBackend() == LUS::WindowBackend::DX11) {
                 UIWidgets::Spacer(0);
-                if (ImGui::Button("Match FPS to Refresh Rate")) {
+                if (ImGui::Button("Match Framerate to Refresh Rate")) {
                     int hz = LUS::Context::GetInstance()->GetWindow()->GetCurrentRefreshRate();
                     if (hz >= 20 && hz <= 360) {
                         CVarSetInteger("gInterpolationFPS", hz);

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -302,7 +302,7 @@ void DrawSettingsMenu() {
 
         #ifndef __WIIU__
             if (UIWidgets::PaddedEnhancementSliderInt(
-                    (CVarGetInteger("gMSAAValue", 1) == 1) ? "Anti-Aliasing (MSAA): Off" : "Anti-Aliasing (MSAA): %d",
+                    (CVarGetInteger("gMSAAValue", 1) == 1) ? "Anti-aliasing (MSAA): Off" : "Anti-aliasing (MSAA): %d",
                     "##IMSAA", "gMSAAValue", 1, 8, "", 1, true, true, false)) {
                 LUS::Context::GetInstance()->GetWindow()->SetMsaaLevel(CVarGetInteger("gMSAAValue", 1));
             }
@@ -418,7 +418,7 @@ void DrawSettingsMenu() {
             UIWidgets::Tooltip("Matches interpolation value to the game window's current refresh rate.");
 
             if (LUS::Context::GetInstance()->GetWindow()->GetWindowBackend() == LUS::WindowBackend::DX11) {
-                UIWidgets::PaddedEnhancementSliderInt(CVarGetInteger("gExtraLatencyThreshold", 80) == 0 ? "Jitter fix threshold: Off" : "Jitter fix: >= %d FPS",
+                UIWidgets::PaddedEnhancementSliderInt(CVarGetInteger("gExtraLatencyThreshold", 80) == 0 ? "Jitter fix: Off" : "Jitter fix: >= %d FPS",
                     "##ExtraLatencyThreshold", "gExtraLatencyThreshold", 0, 360, "", 80, true, true, false);
                 UIWidgets::Tooltip(
                     "(For DirectX backend only)\n\n"
@@ -494,7 +494,7 @@ void DrawSettingsMenu() {
             UIWidgets::EnhancementCombobox("gTextureFilter", filters, FILTER_THREE_POINT);
             UIWidgets::Tooltip("Texture filtering, aka texture smoothing. Requires a reload to take effect.\n\n"
                                "Three-Point: Replicates real N64 texture filtering.\n"
-                               "Bilinear: If Three-Point causes performance issues, try this.\n"
+                               "Bilinear: If Three-Point causes poor performance, try this.\n"
                                "Nearest: Disables texture smoothing. (Not recommended)");
 
             UIWidgets::PaddedSeparator(true, true, 3.0f, 3.0f);

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -277,7 +277,6 @@ void DrawSettingsMenu() {
                                "Lower values may improve performance.\n"
                                "Values above 100% can be used for super-sampling, as an intensive but highly effective form of anti-aliasing.\n\n"
                                "Default: 100%");
-        #endif
             
             if (mAdvancedResolutionSettingsWindow) {
                 ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(12.0f, 6.0f));
@@ -291,6 +290,15 @@ void DrawSettingsMenu() {
                 ImGui::PopStyleColor(1);
                 ImGui::PopStyleVar(3);
             }
+        #else
+            // macOS: Internal resolution is currently disabled in libultraship.
+            ImGui::BeginGroup();
+            ImGui::Text("Internal Resolution: 100.0%%");
+            UIWidgets::Spacer(0);
+            ImGui::Text(" " ICON_FA_INFO_CIRCLE " Not available on this system.");
+            UIWidgets::Spacer(0);
+            ImGui::EndGroup();
+        #endif
 
         #ifndef __WIIU__
             if (UIWidgets::PaddedEnhancementSliderInt(

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -273,7 +273,11 @@ void DrawSettingsMenu() {
                                                   2.0f, "", 1.0f, true, true, disabled_resolutionSlider)) {
                 LUS::Context::GetInstance()->GetWindow()->SetResolutionMultiplier(CVarGetFloat("gInternalResolution", 1));
             }
-            UIWidgets::Tooltip("Multiplies your output resolution by the value inputted, as a more intensive but effective form of anti-aliasing");
+            //UIWidgets::Tooltip("Multiplies your output resolution by the value inputted, as a more intensive but effective form of anti-aliasing");
+            UIWidgets::Tooltip("Resolution scale. Multiplies output resolution by this value, on each axis relative to window size.\n"
+                               "Lower values may improve performance.\n"
+                               "Values above 100% can be used for super-sampling, as an intensive but highly effective form of anti-aliasing.\n"
+                               "Default: 100%");
         #endif
             
             if (mAdvancedResolutionSettingsWindow) {
@@ -290,10 +294,13 @@ void DrawSettingsMenu() {
             }
 
         #ifndef __WIIU__
-            if (UIWidgets::PaddedEnhancementSliderInt("MSAA: %d", "##IMSAA", "gMSAAValue", 1, 8, "", 1, true, true, false)) {
+            if (UIWidgets::PaddedEnhancementSliderInt("Anti-Aliasing (MSAA): %d", "##IMSAA", "gMSAAValue", 1, 8, "", 1, true, true, false)) {
                 LUS::Context::GetInstance()->GetWindow()->SetMsaaLevel(CVarGetInteger("gMSAAValue", 1));
             };
-            UIWidgets::Tooltip("Activates multi-sample anti-aliasing when above 1x up to 8x for 8 samples for every pixel");
+            //UIWidgets::Tooltip("Activates multi-sample anti-aliasing when above 1x up to 8x for 8 samples for every pixel");
+            UIWidgets::Tooltip("Activates MSAA (multi-sample anti-aliasing) from 2x up to 8x, to smooth the edges of rendered geometry.\n"
+                               "Higher sample count will result in smoother edges on models, but may reduce performance.\n"
+                               "Recommended: 2x or 4x");
         #endif
 
             { // FPS Slider
@@ -455,6 +462,7 @@ void DrawSettingsMenu() {
 
             if (LUS::Context::GetInstance()->GetWindow()->CanDisableVerticalSync()) {
                 UIWidgets::PaddedEnhancementCheckbox("Enable Vsync", "gVsyncEnabled", true, false);
+                UIWidgets::Tooltip("Activate vertical sync, to prevent screen tearing.");
             }
 
             if (LUS::Context::GetInstance()->GetWindow()->SupportsWindowedFullscreen()) {
@@ -462,12 +470,12 @@ void DrawSettingsMenu() {
             }
 
             if (LUS::Context::GetInstance()->GetWindow()->GetGui()->SupportsViewports()) {
-                UIWidgets::PaddedEnhancementCheckbox("Allow multi-windows", "gEnableMultiViewports", true, false, false, "", UIWidgets::CheckboxGraphics::Cross, true);
+                UIWidgets::PaddedEnhancementCheckbox("Allow multi-windows (Needs reload)", "gEnableMultiViewports", true, false, false, "", UIWidgets::CheckboxGraphics::Cross, true);
                 UIWidgets::Tooltip("Allows windows to be able to be dragged off of the main game window. Requires a reload to take effect.");
             }
 
             // If more filters are added to LUS, make sure to add them to the filters list here
-            ImGui::Text("Texture Filter (Needs reload)");
+            ImGui::Text("Texture Filtering (Needs reload)");
 
             UIWidgets::EnhancementCombobox("gTextureFilter", filters, FILTER_THREE_POINT);
 

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -305,6 +305,7 @@ void DrawSettingsMenu() {
                                "Recommended: 2x or 4x");
         #endif
 
+            UIWidgets::PaddedSeparator(true, true, 3.0f, 3.0f);
             { // FPS Slider
                 const int minFps = 20;
                 static int maxFps;
@@ -378,26 +379,27 @@ void DrawSettingsMenu() {
                 bool matchingRefreshRate =
                     CVarGetInteger("gMatchRefreshRate", 0) && LUS::Context::GetInstance()->GetWindow()->GetWindowBackend() != LUS::WindowBackend::DX11;
                 UIWidgets::PaddedEnhancementSliderInt(
-                    (currentFps == 20) ? "FPS: Original (20)" : "FPS: %d",
+                    (currentFps == 20) ? "Framerate: Original (20 fps)" : "Framerate: %d fps",
                     "##FPSInterpolation", "gInterpolationFPS", minFps, maxFps, "", 20, true, true, false, matchingRefreshRate);
             #endif
                 if (LUS::Context::GetInstance()->GetWindow()->GetWindowBackend() == LUS::WindowBackend::DX11) {
                     UIWidgets::Tooltip(
-                        "Uses Matrix Interpolation to create extra frames, resulting in smoother graphics. This is purely "
-                        "visual and does not impact game logic, execution of glitches etc.\n\n"
-                        "A higher target FPS than your monitor's refresh rate will waste resources, and might give a worse result."
-                    );
+                        "Uses Matrix Interpolation to create extra frames, resulting in smoother graphics.\n"
+                        "This is purely visual and does not impact game logic, execution of glitches etc.\n"
+                        "Higher FPS settings may impact CPU performance."
+                        "\n\n " ICON_FA_INFO_CIRCLE 
+                        " There is no need to set this above your monitor's refresh rate. Doing so will waste resources and may give a worse result.");
                 } else {
                     UIWidgets::Tooltip(
-                        "Uses Matrix Interpolation to create extra frames, resulting in smoother graphics. This is purely "
-                        "visual and does not impact game logic, execution of glitches etc."
-                    );
+                        "Uses Matrix Interpolation to create extra frames, resulting in smoother graphics.\n"
+                        "This is purely visual and does not impact game logic, execution of glitches etc.\n"
+                        "Higher FPS settings may impact CPU performance.");
                 }
             } // END FPS Slider
 
             if (LUS::Context::GetInstance()->GetWindow()->GetWindowBackend() == LUS::WindowBackend::DX11) {
                 UIWidgets::Spacer(0);
-                if (ImGui::Button("Match Refresh Rate")) {
+                if (ImGui::Button("Match FPS to Refresh Rate")) {
                     int hz = LUS::Context::GetInstance()->GetWindow()->GetCurrentRefreshRate();
                     if (hz >= 20 && hz <= 360) {
                         CVarSetInteger("gInterpolationFPS", hz);
@@ -405,14 +407,18 @@ void DrawSettingsMenu() {
                     }
                 }
             } else {
-                UIWidgets::PaddedEnhancementCheckbox("Match Refresh Rate", "gMatchRefreshRate", true, false);
+                UIWidgets::PaddedEnhancementCheckbox("Match FPS to Refresh Rate", "gMatchRefreshRate", true, false);
             }
-            UIWidgets::Tooltip("Matches interpolation value to the current game's window refresh rate");
+            UIWidgets::Tooltip("Matches interpolation value to the game window's current refresh rate.");
 
             if (LUS::Context::GetInstance()->GetWindow()->GetWindowBackend() == LUS::WindowBackend::DX11) {
                 UIWidgets::PaddedEnhancementSliderInt(CVarGetInteger("gExtraLatencyThreshold", 80) == 0 ? "Jitter fix: Off" : "Jitter fix: >= %d FPS",
                     "##ExtraLatencyThreshold", "gExtraLatencyThreshold", 0, 360, "", 80, true, true, false);
-                UIWidgets::Tooltip("When Interpolation FPS setting is at least this threshold, add one frame of input lag (e.g. 16.6 ms for 60 FPS) in order to avoid jitter. This setting allows the CPU to work on one frame while GPU works on the previous frame.\nThis setting should be used when your computer is too slow to do CPU + GPU work in time.");
+                UIWidgets::Tooltip(
+                    "(For DX11 backend only)\n"
+                    "When Interpolation FPS setting is at least this threshold, add one frame of delay (e.g. 16.6 ms for 60 FPS) in order to avoid jitter."
+                    "This setting allows the CPU to work on one frame while GPU works on the previous frame.\n"
+                    "This setting should be used when your computer is too slow to do CPU + GPU work in time.");
             }
 
             UIWidgets::PaddedSeparator(true, true, 3.0f, 3.0f);

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -273,10 +273,9 @@ void DrawSettingsMenu() {
                                                   2.0f, "", 1.0f, true, true, disabled_resolutionSlider)) {
                 LUS::Context::GetInstance()->GetWindow()->SetResolutionMultiplier(CVarGetFloat("gInternalResolution", 1));
             }
-            //UIWidgets::Tooltip("Multiplies your output resolution by the value inputted, as a more intensive but effective form of anti-aliasing");
             UIWidgets::Tooltip("Resolution scale. Multiplies output resolution by this value, on each axis relative to window size.\n"
                                "Lower values may improve performance.\n"
-                               "Values above 100% can be used for super-sampling, as an intensive but highly effective form of anti-aliasing.\n"
+                               "Values above 100% can be used for super-sampling, as an intensive but highly effective form of anti-aliasing.\n\n"
                                "Default: 100%");
         #endif
             
@@ -298,10 +297,9 @@ void DrawSettingsMenu() {
                     (CVarGetInteger("gMSAAValue", 1) == 1) ? "Anti-Aliasing (MSAA): Off" : "Anti-Aliasing (MSAA): %d",
                     "##IMSAA", "gMSAAValue", 1, 8, "", 1, true, true, false)) {
                 LUS::Context::GetInstance()->GetWindow()->SetMsaaLevel(CVarGetInteger("gMSAAValue", 1));
-            };
-            //UIWidgets::Tooltip("Activates multi-sample anti-aliasing when above 1x up to 8x for 8 samples for every pixel");
+            }
             UIWidgets::Tooltip("Activates MSAA (multi-sample anti-aliasing) from 2x up to 8x, to smooth the edges of rendered geometry.\n"
-                               "Higher sample count will result in smoother edges on models, but may reduce performance.\n"
+                               "Higher sample count will result in smoother edges on models, but may reduce performance.\n\n"
                                "Recommended: 2x or 4x");
         #endif
 
@@ -412,16 +410,17 @@ void DrawSettingsMenu() {
             UIWidgets::Tooltip("Matches interpolation value to the game window's current refresh rate.");
 
             if (LUS::Context::GetInstance()->GetWindow()->GetWindowBackend() == LUS::WindowBackend::DX11) {
-                UIWidgets::PaddedEnhancementSliderInt(CVarGetInteger("gExtraLatencyThreshold", 80) == 0 ? "Jitter fix: Off" : "Jitter fix: >= %d FPS",
+                UIWidgets::PaddedEnhancementSliderInt(CVarGetInteger("gExtraLatencyThreshold", 80) == 0 ? "Jitter fix threshold: Off" : "Jitter fix: >= %d FPS",
                     "##ExtraLatencyThreshold", "gExtraLatencyThreshold", 0, 360, "", 80, true, true, false);
                 UIWidgets::Tooltip(
-                    "(For DX11 backend only)\n"
+                    "(For DirectX backend only)\n\n"
                     "When Interpolation FPS setting is at least this threshold, add one frame of delay (e.g. 16.6 ms for 60 FPS) in order to avoid jitter."
                     "This setting allows the CPU to work on one frame while GPU works on the previous frame.\n"
                     "This setting should be used when your computer is too slow to do CPU + GPU work in time.");
             }
 
             UIWidgets::PaddedSeparator(true, true, 3.0f, 3.0f);
+
             ImGui::Text("ImGui Menu Scale");
             ImGui::SameLine();
             ImGui::TextColored({ 0.85f, 0.35f, 0.0f, 1.0f }, "(Experimental)");
@@ -484,11 +483,15 @@ void DrawSettingsMenu() {
 
             // If more filters are added to LUS, make sure to add them to the filters list here
             ImGui::Text("Texture Filtering (Needs reload)");
-
             UIWidgets::EnhancementCombobox("gTextureFilter", filters, FILTER_THREE_POINT);
+            UIWidgets::Tooltip("Texture filtering, aka texture smoothing. Requires a reload to take effect.\n\n"
+                               "Three-Point: Replicates real N64 texture filtering.\n"
+                               "Bilinear: If Three-Point causes performance issues, try this.\n"
+                               "Nearest: Disables texture smoothing. (Not recommended)");
 
-            UIWidgets::Spacer(0);
+            UIWidgets::PaddedSeparator(true, true, 3.0f, 3.0f);
 
+            // Draw LUS settings menu (such as Overlays Text Font)
             LUS::Context::GetInstance()->GetWindow()->GetGui()->GetGameOverlay()->DrawSettings();
 
             ImGui::EndMenu();


### PR DESCRIPTION
Rewrite tooltips and rename certain settings.

- `Internal Resolution`: Clearer language in tooltip. 
- Add "Internal Resolution not available on this system." advisory for macOS, as this was causing some support headaches.
- `MSAA`: Renamed to `Anti-aliasing (MSAA)`. A setting of 1 now more helpfully displays as "Off". Clearer language in tooltip.
- `FPS`: Renamed to `Frame Rate` and displayed in units of `fps`.
- `Match Refresh Rate`: Renamed to `Match Frame Rate to Refresh Rate`. 
- `Enable Vsync`: Added tooltip.
- `Allow multi-windows`: Added "(Needs reload)"
- `Texture Filter`: Renamed to `Texture Filtering`. Added tooltip.
- Other small tweaks to tooltips, layout, and code style were made.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1208389995.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1208389997.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1208389998.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1208390003.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1208390007.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1208390009.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1208390011.zip)
<!--- section:artifacts:end -->