### PR TITLE
Increase Door Cull range

### DIFF
--- a/soh/src/code/z_actor.c
+++ b/soh/src/code/z_actor.c
@@ -2860,7 +2860,7 @@ s32 func_800314D4(PlayState* play, Actor* actor, Vec3f* arg2, f32 arg3) {
     if ((arg2->z > -actor->uncullZoneScale) && (arg2->z < (actor->uncullZoneForward + actor->uncullZoneScale))) {
         var = (arg3 < 1.0f) ? 1.0f : 1.0f / arg3;
 
-        // #Region SoH
+        // #region SoH [Widescreen support]
         // Doors will cull quite noticeably on wider screens. For these actors the zone is increased
         f32 limit = 1.0f;
         if (((actor->id == ACTOR_EN_DOOR) || (actor->id == ACTOR_DOOR_SHUTTER)) && CVarGetInteger("gIncreaseDoorUncullZones", 1)) {

--- a/soh/src/code/z_actor.c
+++ b/soh/src/code/z_actor.c
@@ -2863,7 +2863,7 @@ s32 func_800314D4(PlayState* play, Actor* actor, Vec3f* arg2, f32 arg3) {
         // #Region SoH
         // Doors will cull quite noticeably on wider screens. For these actors the zone is increased
         f32 limit = 1.0f;
-        if (((actor->id == ACTOR_EN_DOOR) || (actor->id == ACTOR_DOOR_SHUTTER)) && CVarGetInteger("gIncreaseDoorCullZones", 1)) {
+        if (((actor->id == ACTOR_EN_DOOR) || (actor->id == ACTOR_DOOR_SHUTTER)) && CVarGetInteger("gIncreaseDoorUncullZones", 1)) {
             limit = 2.0f;
         }
 

--- a/soh/src/code/z_actor.c
+++ b/soh/src/code/z_actor.c
@@ -2872,6 +2872,7 @@ s32 func_800314D4(PlayState* play, Actor* actor, Vec3f* arg2, f32 arg3) {
             (((arg2->y - actor->uncullZoneScale) * var) < limit)) {
             return true;
         }
+        // #endregion
     }
 
     return false;

--- a/soh/src/code/z_actor.c
+++ b/soh/src/code/z_actor.c
@@ -2860,9 +2860,16 @@ s32 func_800314D4(PlayState* play, Actor* actor, Vec3f* arg2, f32 arg3) {
     if ((arg2->z > -actor->uncullZoneScale) && (arg2->z < (actor->uncullZoneForward + actor->uncullZoneScale))) {
         var = (arg3 < 1.0f) ? 1.0f : 1.0f / arg3;
 
-        if ((((fabsf(arg2->x) - actor->uncullZoneScale) * var) < 1.0f) &&
-            (((arg2->y + actor->uncullZoneDownward) * var) > -1.0f) &&
-            (((arg2->y - actor->uncullZoneScale) * var) < 1.0f)) {
+        // #Region SoH
+        // Doors will cull quite noticeably on wider screens. For these actors the zone is increased
+        f32 limit = 1.0f;
+        if (((actor->id == ACTOR_EN_DOOR) || (actor->id == ACTOR_DOOR_SHUTTER)) && CVarGetInteger("gIncreaseDoorCullZones", 1)) {
+            limit = 2.0f;
+        }
+
+        if ((((fabsf(arg2->x) - actor->uncullZoneScale) * var) < limit) &&
+            (((arg2->y + actor->uncullZoneDownward) * var) > -limit) &&
+            (((arg2->y - actor->uncullZoneScale) * var) < limit)) {
             return true;
         }
     }


### PR DESCRIPTION
Following up on #3828 my suspicion is that the uncullzone scale check was changed due to issues with widescreen and doors. They are quite noticeably culled which ends up looking very off. I wasn't sure on the best approach, i.e. should this be default/ limited to doors/ what actors should be under this. So I am just putting this up with what I think makes sense, i.e. defaulting to increased uncull zones for doors, and using a hidden cvar

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1206710818.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1206710821.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1206710823.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1206710824.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1206710827.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1206710829.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1206710831.zip)
<!--- section:artifacts:end -->