### PR TITLE
More Sword Toggle Options

### DIFF
--- a/soh/soh/Enhancements/enhancementTypes.h
+++ b/soh/soh/Enhancements/enhancementTypes.h
@@ -78,4 +78,10 @@ typedef enum {
     DEKU_STICK_UNBREAKABLE_AND_ALWAYS_ON_FIRE,
 } DekuStickType;
 
+typedef enum {
+    SWORD_TOGGLE_NONE,
+    SWORD_TOGGLE_CHILD,
+    SWORD_TOGGLE_BOTH_AGES,
+} SwordToggleMode;
+
 #endif

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -104,6 +104,7 @@ static const char* imguiScaleOptions[4] = { "Small", "Normal", "Large", "X-Large
         "OHKO"
     };
     static const char* timeTravelOptions[3] = { "Disabled", "Ocarina of Time", "Any Ocarina" };
+    static const char* swordToggleModes[3] = { "Disabled", "Child Toggle", "Both Ages (May lead to unintended behaviour)"};
 
 extern "C" SaveContext gSaveContext;
 
@@ -920,6 +921,17 @@ void DrawEnhancementsMenu() {
             UIWidgets::Tooltip("Allows equipping the tunic and boots to c-buttons");
             UIWidgets::PaddedEnhancementCheckbox("Equipment Toggle", "gEquipmentCanBeRemoved", true, false);
             UIWidgets::Tooltip("Allows equipment to be removed by toggling it off on\nthe equipment subscreen.");
+            if (CVarGetInteger("gEquipmentCanBeRemoved", 0)) {
+                UIWidgets::PaddedText("Sword Toggle Options", true, false);
+                UIWidgets::EnhancementCombobox("gSwordToggle", swordToggleModes, SWORD_TOGGLE_NONE);
+                UIWidgets::Tooltip(
+                    "Introduces Options for unequipping Link's sword\n\n"
+                    "None: Only Biggoron's Sword/Giant's Knife can be toggled. Doing so will equip the Master Sword.\n\n"
+                    "Child Toggle: This will allow for completely unequipping any sword as child link.\n\n"
+                    "Both Ages: Any sword can be unequipped as either age. This may lead to swordless glitches as Adult.\n"
+                );
+            }
+
             UIWidgets::PaddedEnhancementCheckbox("Link's Cow in Both Time Periods", "gCowOfTime", true, false);
             UIWidgets::Tooltip("Allows the Lon Lon Ranch obstacle course reward to be shared across time periods");
             UIWidgets::PaddedEnhancementCheckbox("Enable visible guard vision", "gGuardVision", true, false);

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -923,7 +923,7 @@ void DrawEnhancementsMenu() {
             UIWidgets::Tooltip("Allows equipment to be removed by toggling it off on\nthe equipment subscreen.");
             if (CVarGetInteger("gEquipmentCanBeRemoved", 0)) {
                 UIWidgets::PaddedText("Sword Toggle Options", true, false);
-                UIWidgets::EnhancementCombobox("gSwordToggle", swordToggleModes, SWORD_TOGGLE_NONE);
+                UIWidgets::EnhancementCombobox("gEnhancements.SwordToggle", swordToggleModes, SWORD_TOGGLE_NONE);
                 UIWidgets::Tooltip(
                     "Introduces Options for unequipping Link's sword\n\n"
                     "None: Only Biggoron's Sword/Giant's Knife can be toggled. Doing so will equip the Master Sword.\n\n"

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_equipment.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_equipment.c
@@ -571,8 +571,8 @@ void KaleidoScope_DrawEquipment(PlayState* play) {
                     // If we have the feature toggled on
                     if (CVarGetInteger("gEquipmentCanBeRemoved", 0)) {
 
-                        if (CVarGetInteger("gSwordToggle", SWORD_TOGGLE_NONE) == SWORD_TOGGLE_BOTH_AGES ||
-                            (CVarGetInteger("gSwordToggle", SWORD_TOGGLE_NONE) == SWORD_TOGGLE_CHILD) && LINK_IS_CHILD) {
+                        if (CVarGetInteger("gEnhancements.SwordToggle", SWORD_TOGGLE_NONE) == SWORD_TOGGLE_BOTH_AGES ||
+                            (CVarGetInteger("gEnhancements.SwordToggle", SWORD_TOGGLE_NONE) == SWORD_TOGGLE_CHILD) && LINK_IS_CHILD) {
                             // If we're on the "swords" section of the equipment screen AND we're on a currently-equipped sword  
                             if (pauseCtx->cursorY[PAUSE_EQUIP] == 0 && pauseCtx->cursorX[PAUSE_EQUIP] == CUR_EQUIP_VALUE(EQUIP_TYPE_SWORD)) {
                                 Inventory_ChangeEquipment(EQUIP_TYPE_SWORD, EQUIP_VALUE_SWORD_NONE);

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_equipment.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_equipment.c
@@ -586,7 +586,7 @@ void KaleidoScope_DrawEquipment(PlayState* play) {
                                 && CUR_EQUIP_VALUE(EQUIP_TYPE_SWORD) == EQUIP_VALUE_SWORD_BIGGORON && CHECK_OWNED_EQUIP(EQUIP_TYPE_SWORD, EQUIP_INV_SWORD_MASTER)){ // And we have the Master Sword
                                 Inventory_ChangeEquipment(EQUIP_TYPE_SWORD, EQUIP_VALUE_SWORD_MASTER); // "Unequip" it by equipping Master Sword
                                 gSaveContext.equips.buttonItems[0] = ITEM_SWORD_MASTER;
-                                gSaveContext.infTable[29] = 0;
+                                Flags_UnsetInfTable(INFTABLE_SWORDLESS);
                                 goto RESUME_EQUIPMENT_SWORD;               // Skip to here so we don't re-equip it
                             }
                         }

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_equipment.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_equipment.c
@@ -577,7 +577,7 @@ void KaleidoScope_DrawEquipment(PlayState* play) {
                             if (pauseCtx->cursorY[PAUSE_EQUIP] == 0 && pauseCtx->cursorX[PAUSE_EQUIP] == CUR_EQUIP_VALUE(EQUIP_TYPE_SWORD)) {
                                 Inventory_ChangeEquipment(EQUIP_TYPE_SWORD, EQUIP_VALUE_SWORD_NONE);
                                 gSaveContext.equips.buttonItems[0] = ITEM_NONE;
-                                gSaveContext.infTable[29] = 1;              // Set the swordless flag
+                                Flags_SetInfTable(INFTABLE_SWORDLESS);
                                 goto RESUME_EQUIPMENT_SWORD;               // Skip to here so we don't re-equip it
                             }
                         } else {

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_equipment.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_equipment.c
@@ -572,8 +572,7 @@ void KaleidoScope_DrawEquipment(PlayState* play) {
                     if (CVarGetInteger("gEquipmentCanBeRemoved", 0)) {
 
                         if (CVarGetInteger("gSwordToggle", SWORD_TOGGLE_NONE) == SWORD_TOGGLE_BOTH_AGES ||
-                            ((CVarGetInteger("gSwordToggle", SWORD_TOGGLE_NONE) == SWORD_TOGGLE_CHILD) && 
-                             LINK_IS_CHILD)) {
+                            (CVarGetInteger("gSwordToggle", SWORD_TOGGLE_NONE) == SWORD_TOGGLE_CHILD) && LINK_IS_CHILD) {
                             // If we're on the "swords" section of the equipment screen AND we're on a currently-equipped sword  
                             if (pauseCtx->cursorY[PAUSE_EQUIP] == 0 && pauseCtx->cursorX[PAUSE_EQUIP] == CUR_EQUIP_VALUE(EQUIP_TYPE_SWORD)) {
                                 Inventory_ChangeEquipment(EQUIP_TYPE_SWORD, EQUIP_VALUE_SWORD_NONE);

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_equipment.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_equipment.c
@@ -2,6 +2,7 @@
 #include "textures/icon_item_static/icon_item_static.h"
 #include "textures/parameter_static/parameter_static.h"
 #include "soh/Enhancements/cosmetics/cosmeticsTypes.h"
+#include "soh/Enhancements/enhancementTypes.h"
 
 static u8 sChildUpgrades[] = { UPG_BULLET_BAG, UPG_BOMB_BAG, UPG_STRENGTH, UPG_SCALE };
 static u8 sAdultUpgrades[] = { UPG_QUIVER, UPG_BOMB_BAG, UPG_STRENGTH, UPG_SCALE };
@@ -562,20 +563,33 @@ void KaleidoScope_DrawEquipment(PlayState* play) {
             if (CHECK_AGE_REQ_EQUIP(pauseCtx->cursorY[PAUSE_EQUIP], pauseCtx->cursorX[PAUSE_EQUIP])) {
                 if (CHECK_BTN_ALL(input->press.button, BTN_A)) {
 
+                    // #Region SoH [Enhancements]
                     // Allow Link to remove his equipment from the equipment subscreen by toggling on/off
                     // Shields will be un-equipped entirely, and tunics/boots will revert to Kokiri Tunic/Kokiri Boots
                     // Only BGS/Giant's Knife is affected, and it will revert to Master Sword.
 
                     // If we have the feature toggled on
                     if (CVarGetInteger("gEquipmentCanBeRemoved", 0)) {
-                        
-                        // If we're on the "swords" section of the equipment screen AND we're on a currently-equipped BGS/Giant's Knife
-                        if (pauseCtx->cursorY[PAUSE_EQUIP] == 0 && pauseCtx->cursorX[PAUSE_EQUIP] == 3 
-                            && CUR_EQUIP_VALUE(EQUIP_TYPE_SWORD) == EQUIP_VALUE_SWORD_BIGGORON && CHECK_OWNED_EQUIP(EQUIP_TYPE_SWORD, EQUIP_INV_SWORD_MASTER)){ // And we have the Master Sword
-                            Inventory_ChangeEquipment(EQUIP_TYPE_SWORD, EQUIP_VALUE_SWORD_MASTER); // "Unequip" it by equipping Master Sword
-                            gSaveContext.equips.buttonItems[0] = ITEM_SWORD_MASTER;
-                            gSaveContext.infTable[29] = 0;
-                            goto RESUME_EQUIPMENT_SWORD;               // Skip to here so we don't re-equip it
+
+                        if (CVarGetInteger("gSwordToggle", SWORD_TOGGLE_NONE) == SWORD_TOGGLE_BOTH_AGES ||
+                            ((CVarGetInteger("gSwordToggle", SWORD_TOGGLE_NONE) == SWORD_TOGGLE_CHILD) && 
+                             (gSaveContext.linkAge == LINK_AGE_CHILD))) {
+                            // If we're on the "swords" section of the equipment screen AND we're on a currently-equipped sword  
+                            if (pauseCtx->cursorY[PAUSE_EQUIP] == 0 && pauseCtx->cursorX[PAUSE_EQUIP] == CUR_EQUIP_VALUE(EQUIP_TYPE_SWORD)) {
+                                Inventory_ChangeEquipment(EQUIP_TYPE_SWORD, EQUIP_VALUE_SWORD_NONE);
+                                gSaveContext.equips.buttonItems[0] = ITEM_NONE;
+                                gSaveContext.infTable[29] = 1;              // Set the swordless flag
+                                goto RESUME_EQUIPMENT_SWORD;               // Skip to here so we don't re-equip it
+                            }
+                        } else {
+                            // If we're on the "swords" section of the equipment screen AND we're on a currently-equipped BGS/Giant's Knife
+                            if (pauseCtx->cursorY[PAUSE_EQUIP] == 0 && pauseCtx->cursorX[PAUSE_EQUIP] == 3 
+                                && CUR_EQUIP_VALUE(EQUIP_TYPE_SWORD) == EQUIP_VALUE_SWORD_BIGGORON && CHECK_OWNED_EQUIP(EQUIP_TYPE_SWORD, EQUIP_INV_SWORD_MASTER)){ // And we have the Master Sword
+                                Inventory_ChangeEquipment(EQUIP_TYPE_SWORD, EQUIP_VALUE_SWORD_MASTER); // "Unequip" it by equipping Master Sword
+                                gSaveContext.equips.buttonItems[0] = ITEM_SWORD_MASTER;
+                                gSaveContext.infTable[29] = 0;
+                                goto RESUME_EQUIPMENT_SWORD;               // Skip to here so we don't re-equip it
+                            }
                         }
 
                         // If we're on the "shields" section of the equipment screen AND we're on a currently-equipped shield

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_equipment.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_equipment.c
@@ -573,7 +573,7 @@ void KaleidoScope_DrawEquipment(PlayState* play) {
 
                         if (CVarGetInteger("gSwordToggle", SWORD_TOGGLE_NONE) == SWORD_TOGGLE_BOTH_AGES ||
                             ((CVarGetInteger("gSwordToggle", SWORD_TOGGLE_NONE) == SWORD_TOGGLE_CHILD) && 
-                             (gSaveContext.linkAge == LINK_AGE_CHILD))) {
+                             LINK_IS_CHILD)) {
                             // If we're on the "swords" section of the equipment screen AND we're on a currently-equipped sword  
                             if (pauseCtx->cursorY[PAUSE_EQUIP] == 0 && pauseCtx->cursorX[PAUSE_EQUIP] == CUR_EQUIP_VALUE(EQUIP_TYPE_SWORD)) {
                                 Inventory_ChangeEquipment(EQUIP_TYPE_SWORD, EQUIP_VALUE_SWORD_NONE);


### PR DESCRIPTION
This will allow for options on how toggling the sword equips will work, with an added disclaimer that using this on adult may run into issues. Not sure if I should keep this behind the other equipment toggle or not, but will for now

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1208535352.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1208535355.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1208535357.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1208535359.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1208535361.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1208535363.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1208535365.zip)
<!--- section:artifacts:end -->