### PR TITLE
Add Total Checks to Check/Item Trackers

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -109,8 +109,8 @@ u32 areasSpoiled = 0;
 bool showVOrMQ;
 s8 areaChecksGotten[RCAREA_INVALID]; //|     "Kokiri Forest (4/9)"
 s8 areaCheckTotals[RCAREA_INVALID];
-s32 totalChecks;
-s32 totalChecksGotten;
+uint16_t totalChecks = 0;
+uint16_t totalChecksGotten = 0;
 bool optCollapseAll; // A bool that will collapse all checks once
 bool optExpandAll;       // A bool that will expand all checks once
 RandomizerCheck lastLocationChecked = RC_UNKNOWN_CHECK;
@@ -236,6 +236,14 @@ void CalculateTotals() {
         totalChecks += areaCheckTotals[i];
         totalChecksGotten += areaChecksGotten[i];
     }
+}
+
+uint16_t GetTotalChecks() {
+    return totalChecks;
+}
+
+uint16_t GetTotalChecksGotten() {
+    return totalChecksGotten;
 }
 
 void RecalculateAreaTotals() {

--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -109,6 +109,8 @@ u32 areasSpoiled = 0;
 bool showVOrMQ;
 s8 areaChecksGotten[RCAREA_INVALID]; //|     "Kokiri Forest (4/9)"
 s8 areaCheckTotals[RCAREA_INVALID];
+s32 totalChecks;
+s32 totalChecksGotten;
 bool optCollapseAll; // A bool that will collapse all checks once
 bool optExpandAll;       // A bool that will expand all checks once
 RandomizerCheck lastLocationChecked = RC_UNKNOWN_CHECK;
@@ -226,6 +228,16 @@ void TrySetAreas() {
     }
 }
 
+void CalculateTotals() {
+    totalChecks = 0;
+    totalChecksGotten = 0;
+
+    for (uint8_t i = 0; i < RCAREA_INVALID; i++) {
+        totalChecks += areaCheckTotals[i];
+        totalChecksGotten += areaChecksGotten[i];
+    }
+}
+
 void RecalculateAreaTotals() {
     for (auto [rcArea, rcObjects] : checksByArea) {
         if (rcArea == RCAREA_INVALID) {
@@ -244,6 +256,8 @@ void RecalculateAreaTotals() {
             }
         }
     }
+
+    CalculateTotals();
 }
 
 void SetCheckCollected(RandomizerCheck rc) {
@@ -266,6 +280,7 @@ void SetCheckCollected(RandomizerCheck rc) {
     doAreaScroll = true;
     UpdateOrdering(rcObj.rcArea);
     UpdateInventoryChecks();
+    CalculateTotals();
 }
 
 bool IsAreaScene(SceneID sceneNum) {
@@ -371,6 +386,8 @@ void ClearAreaChecksAndTotals() {
         areaChecksGotten[rcArea] = 0;
         areaCheckTotals[rcArea] = 0;
     }
+    totalChecks = 0;
+    totalChecksGotten = 0;
 }
 
 void SetShopSeen(uint32_t sceneNum, bool prices) {
@@ -502,6 +519,7 @@ void CheckTrackerLoadGame(int32_t fileNum) {
     initialized = true;
     UpdateAllOrdering();
     UpdateInventoryChecks();
+    CalculateTotals();
 }
 
 void CheckTrackerShopSlotChange(uint8_t cursorSlot, int16_t basePrice) {
@@ -822,6 +840,7 @@ void UpdateCheck(uint32_t check, RandomizerCheckTrackerData data) {
     }
     gSaveContext.checkTrackerData[check] = data;
     UpdateOrdering(area);
+    CalculateTotals();
 }
 
 void CheckTrackerWindow::DrawElement() {
@@ -893,6 +912,10 @@ void CheckTrackerWindow::DrawElement() {
         optExpandAll = false;
         optCollapseAll = true;
     }
+    UIWidgets::PaddedSeparator();
+
+    ImGui::Text("Total Checks: %d / %d", totalChecksGotten, totalChecks);
+
     UIWidgets::PaddedSeparator();
 
     //Checks Section Lead-in

--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -264,8 +264,6 @@ void RecalculateAreaTotals() {
             }
         }
     }
-
-    CalculateTotals();
 }
 
 void SetCheckCollected(RandomizerCheck rc) {
@@ -288,7 +286,6 @@ void SetCheckCollected(RandomizerCheck rc) {
     doAreaScroll = true;
     UpdateOrdering(rcObj.rcArea);
     UpdateInventoryChecks();
-    CalculateTotals();
 }
 
 bool IsAreaScene(SceneID sceneNum) {
@@ -527,7 +524,6 @@ void CheckTrackerLoadGame(int32_t fileNum) {
     initialized = true;
     UpdateAllOrdering();
     UpdateInventoryChecks();
-    CalculateTotals();
 }
 
 void CheckTrackerShopSlotChange(uint8_t cursorSlot, int16_t basePrice) {
@@ -848,7 +844,6 @@ void UpdateCheck(uint32_t check, RandomizerCheckTrackerData data) {
     }
     gSaveContext.checkTrackerData[check] = data;
     UpdateOrdering(area);
-    CalculateTotals();
 }
 
 void CheckTrackerWindow::DrawElement() {
@@ -1280,6 +1275,8 @@ void UpdateOrdering(RandomizerCheckArea rcArea) {
     if(checksByArea.contains(rcArea)) {
         std::sort(checksByArea.find(rcArea)->second.begin(), checksByArea.find(rcArea)->second.end(), CompareChecks);
     }
+
+    CalculateTotals();
 }
 
 bool IsEoDCheck(RandomizerCheckType type) {

--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.h
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.h
@@ -50,6 +50,8 @@ bool IsVisibleInCheckTracker(RandomizerCheckObject rcObj);
 void InitTrackerData(bool isDebug);
 RandomizerCheckArea GetCheckArea();
 void UpdateCheck(uint32_t, RandomizerCheckTrackerData);
+uint16_t GetTotalChecks();
+uint16_t GetTotalChecksGotten();
 } // namespace CheckTracker
 
 

--- a/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
@@ -750,7 +750,7 @@ void DrawTotalChecks() {
     uint16_t totalChecksGotten = CheckTracker::GetTotalChecksGotten();
 
     ImGui::BeginGroup();
-    ImGui::SetWindowFontScale(2.0);
+    ImGui::SetWindowFontScale(2.5);
     ImGui::Text("Checks: %d/%d", totalChecksGotten, totalChecks);
     ImGui::EndGroup();
 }
@@ -1079,7 +1079,7 @@ void ItemTrackerWindow::DrawElement() {
             EndFloatingWindows();
         }
 
-        if (CVarGetInteger("gItemTrackerTotalChecksDisplayType", SECTION_DISPLAY_MINIMAL_HIDDEN) ==
+        if (CVarGetInteger("gTrackers.ItemTracker.TotalChecks.DisplayType", SECTION_DISPLAY_MINIMAL_HIDDEN) ==
             SECTION_DISPLAY_MINIMAL_SEPARATE) {
             ImGui::SetNextWindowSize(ImVec2(400, 300), ImGuiCond_FirstUseEver);
             BeginFloatingWindows("Total Checks");
@@ -1226,7 +1226,7 @@ void ItemTrackerSettingsWindow::DrawElement() {
         }
     }
 
-    if (UIWidgets::LabeledRightAlignedEnhancementCombobox("Total Checks", "gItemTrackerTotalChecksDisplayType", minimalDisplayTypes, SECTION_DISPLAY_MINIMAL_HIDDEN)) {
+    if (UIWidgets::LabeledRightAlignedEnhancementCombobox("Total Checks", "gTrackers.ItemTracker.TotalChecks.DisplayType", minimalDisplayTypes, SECTION_DISPLAY_MINIMAL_HIDDEN)) {
         shouldUpdateVectors = true;
     }
 

--- a/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
@@ -1,4 +1,5 @@
 #include "randomizer_item_tracker.h"
+#include "randomizer_check_tracker.h"
 #include "../../util.h"
 #include "../../OTRGlobals.h"
 #include "../../UIWidgets.hpp"
@@ -264,6 +265,11 @@ typedef enum {
     SECTION_DISPLAY_EXTENDED_MISC_WINDOW,
     SECTION_DISPLAY_EXTENDED_SEPARATE
 } ItemTrackerExtendedDisplayType;
+
+typedef enum {
+    SECTION_DISPLAY_MINIMAL_HIDDEN,
+    SECTION_DISPLAY_MINIMAL_SEPARATE
+} ItemTrackerMinimalDisplayType;
 
 struct ItemTrackerNumbers {
   int currentCapacity;
@@ -739,6 +745,16 @@ void DrawNotes(bool resizeable = false) {
     ImGui::EndGroup();
 }
 
+void DrawTotalChecks() {
+    uint16_t totalChecks = CheckTracker::GetTotalChecks();
+    uint16_t totalChecksGotten = CheckTracker::GetTotalChecksGotten();
+
+    ImGui::BeginGroup();
+    ImGui::SetWindowFontScale(2.0);
+    ImGui::Text("Checks: %d/%d", totalChecksGotten, totalChecks);
+    ImGui::EndGroup();
+}
+
 // Windowing stuff
 ImVec4 ChromaKeyBackground = { 0, 0, 0, 0 }; // Float value, 1 = 255 in rgb value.
 void BeginFloatingWindows(std::string UniqueName, ImGuiWindowFlags flags = 0) {
@@ -1062,6 +1078,14 @@ void ItemTrackerWindow::DrawElement() {
             DrawNotes(true);
             EndFloatingWindows();
         }
+
+        if (CVarGetInteger("gItemTrackerTotalChecksDisplayType", SECTION_DISPLAY_MINIMAL_HIDDEN) ==
+            SECTION_DISPLAY_MINIMAL_SEPARATE) {
+            ImGui::SetNextWindowSize(ImVec2(400, 300), ImGuiCond_FirstUseEver);
+            BeginFloatingWindows("Total Checks");
+            DrawTotalChecks();
+            EndFloatingWindows();
+        }
     }
 }
 
@@ -1073,6 +1097,7 @@ static const char* displayModes[2] = { "Always", "Combo Button Hold" };
 static const char* buttons[14] = { "A", "B", "C-Up", "C-Down", "C-Left", "C-Right", "L", "Z", "R", "Start", "D-Up", "D-Down", "D-Left", "D-Right" };
 static const char* displayTypes[3] = { "Hidden", "Main Window", "Separate" };
 static const char* extendedDisplayTypes[4] = { "Hidden", "Main Window", "Misc Window", "Separate" };
+static const char* minimalDisplayTypes[2] = { "Hidden", "Separate" };
 
 void ItemTrackerSettingsWindow::DrawElement() {
     ImGui::SetNextWindowSize(ImVec2(733, 472), ImGuiCond_FirstUseEver);
@@ -1199,6 +1224,10 @@ void ItemTrackerSettingsWindow::DrawElement() {
         if (UIWidgets::LabeledRightAlignedEnhancementCombobox("Personal notes", "gItemTrackerNotesDisplayType", displayTypes, SECTION_DISPLAY_HIDDEN)) {
             shouldUpdateVectors = true;
         }
+    }
+
+    if (UIWidgets::LabeledRightAlignedEnhancementCombobox("Total Checks", "gItemTrackerTotalChecksDisplayType", minimalDisplayTypes, SECTION_DISPLAY_MINIMAL_HIDDEN)) {
+        shouldUpdateVectors = true;
     }
 
     ImGui::PopStyleVar(1);


### PR DESCRIPTION
Adds a line to the top of the check tracker showing total checks gotten and total checks.

Adds new entry for the item tracker that shows the same information but in a similar matter to other item tracker entries.

Got the idea from all the recent races but probably a fun metric for regular randomizers too.

Preview: https://www.youtube.com/watch?v=GC1NDigEZdc

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1210549190.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1210549192.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1210549194.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1210549196.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1210549198.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1210549199.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1210549201.zip)
<!--- section:artifacts:end -->