### PR TITLE
Tweaks to coloridoscope

### DIFF
--- a/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
+++ b/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
@@ -269,35 +269,35 @@ static std::map<std::string, CosmeticOption> cosmeticOptions = {
     COSMETIC_OPTION("Hud_NameTagActorText",          "Nametag Text",         GROUP_HUD,          ImVec4(255, 255, 255, 255), true, true, false),
     COSMETIC_OPTION("Hud_NameTagActorBackground",    "Nametag Background",   GROUP_HUD,          ImVec4(0,     0,   0,  80), true, false, true),
 
-    COSMETIC_OPTION("Kal_ItemSelA",                  "Item Select Color A",  GROUP_KALEIDO,      ImVec4(10,   50,  80, 255), false, true, false),
-    COSMETIC_OPTION("Kal_ItemSelB",                  "Item Select Color B",  GROUP_KALEIDO,      ImVec4(70,  100, 130, 255), false, true, false),
-    COSMETIC_OPTION("Kal_ItemSelC",                  "Item Select Color C",  GROUP_KALEIDO,      ImVec4(70,  100, 130, 255), false, true, false),
-    COSMETIC_OPTION("Kal_ItemSelD",                  "Item Select Color D",  GROUP_KALEIDO,      ImVec4(10,   50,  80, 255), false, true, false),
+    COSMETIC_OPTION("Kal_ItemSelA",                  "Item Select Color",    GROUP_KALEIDO,      ImVec4(10,   50,  80, 255), false, true, false),
+    COSMETIC_OPTION("Kal_ItemSelB",                  "Item Select Color B",  GROUP_KALEIDO,      ImVec4(70,  100, 130, 255), false, true, true),
+    COSMETIC_OPTION("Kal_ItemSelC",                  "Item Select Color C",  GROUP_KALEIDO,      ImVec4(70,  100, 130, 255), false, true, true),
+    COSMETIC_OPTION("Kal_ItemSelD",                  "Item Select Color D",  GROUP_KALEIDO,      ImVec4(10,   50,  80, 255), false, true, true),
 
-    COSMETIC_OPTION("Kal_EquipSelA",                 "Equip Select Color A", GROUP_KALEIDO,      ImVec4(10,   50,  40, 255), false, true, false),
-    COSMETIC_OPTION("Kal_EquipSelB",                 "Equip Select Color B", GROUP_KALEIDO,      ImVec4(90,  100,  60, 255), false, true, false),
-    COSMETIC_OPTION("Kal_EquipSelC",                 "Equip Select Color C", GROUP_KALEIDO,      ImVec4(90,  100,  60, 255), false, true, false),
-    COSMETIC_OPTION("Kal_EquipSelD",                 "Equip Select Color D", GROUP_KALEIDO,      ImVec4(10,   50,  80, 255), false, true, false),
+    COSMETIC_OPTION("Kal_EquipSelA",                 "Equip Select Color",   GROUP_KALEIDO,      ImVec4(10,   50,  40, 255), false, true, false),
+    COSMETIC_OPTION("Kal_EquipSelB",                 "Equip Select Color B", GROUP_KALEIDO,      ImVec4(90,  100,  60, 255), false, true, true),
+    COSMETIC_OPTION("Kal_EquipSelC",                 "Equip Select Color C", GROUP_KALEIDO,      ImVec4(90,  100,  60, 255), false, true, true),
+    COSMETIC_OPTION("Kal_EquipSelD",                 "Equip Select Color D", GROUP_KALEIDO,      ImVec4(10,   50,  80, 255), false, true, true),
 
-    COSMETIC_OPTION("Kal_MapSelDunA",                "Map Dungeon Color A",  GROUP_KALEIDO,      ImVec4(80,   40,  30, 255), false, true, false),
-    COSMETIC_OPTION("Kal_MapSelDunB",                "Map Dungeon Color B",  GROUP_KALEIDO,      ImVec4(140,  60,  60, 255), false, true, false),
-    COSMETIC_OPTION("Kal_MapSelDunC",                "Map Dungeon Color C",  GROUP_KALEIDO,      ImVec4(140,  60,  60, 255), false, true, false),
-    COSMETIC_OPTION("Kal_MapSelDunD",                "Map Dungeon Color D",  GROUP_KALEIDO,      ImVec4(80,   40,  30, 255), false, true, false),
+    COSMETIC_OPTION("Kal_MapSelDunA",                "Map Dungeon Color",    GROUP_KALEIDO,      ImVec4(80,   40,  30, 255), false, true, true),
+    COSMETIC_OPTION("Kal_MapSelDunB",                "Map Dungeon Color B",  GROUP_KALEIDO,      ImVec4(140,  60,  60, 255), false, true, true),
+    COSMETIC_OPTION("Kal_MapSelDunC",                "Map Dungeon Color C",  GROUP_KALEIDO,      ImVec4(140,  60,  60, 255), false, true, true),
+    COSMETIC_OPTION("Kal_MapSelDunD",                "Map Dungeon Color D",  GROUP_KALEIDO,      ImVec4(80,   40,  30, 255), false, true, true),
 
-    COSMETIC_OPTION("Kal_QuestStatusA",              "Quest StatusColor A",  GROUP_KALEIDO,      ImVec4(80, 80, 50, 255),    false, true, false),
-    COSMETIC_OPTION("Kal_QuestStatusB",              "Quest StatusColor B",  GROUP_KALEIDO,      ImVec4(120, 120, 70, 255),  false, true, false),
-    COSMETIC_OPTION("Kal_QuestStatusC",              "Quest StatusColor C",  GROUP_KALEIDO,      ImVec4(120, 120, 70, 255),  false, true, false),
-    COSMETIC_OPTION("Kal_QuestStatusD",              "Quest StatusColor D",  GROUP_KALEIDO,      ImVec4(80, 80, 50, 255),    false, true, false),
+    COSMETIC_OPTION("Kal_QuestStatusA",              "Quest Status Color",   GROUP_KALEIDO,      ImVec4(80, 80, 50, 255),    false, true, false),
+    COSMETIC_OPTION("Kal_QuestStatusB",              "Quest Status Color B", GROUP_KALEIDO,      ImVec4(120, 120, 70, 255),  false, true, true),
+    COSMETIC_OPTION("Kal_QuestStatusC",              "Quest Status Color C", GROUP_KALEIDO,      ImVec4(120, 120, 70, 255),  false, true, true),
+    COSMETIC_OPTION("Kal_QuestStatusD",              "Quest Status Color D", GROUP_KALEIDO,      ImVec4(80, 80, 50, 255),    false, true, true),
 
-    COSMETIC_OPTION("Kal_MapSelectA",                "Map Color A",          GROUP_KALEIDO,      ImVec4(80, 40, 30, 255),    false, true, false),
-    COSMETIC_OPTION("Kal_MapSelectB",                "Map Color B",          GROUP_KALEIDO,      ImVec4(140, 60, 60, 255),   false, true, false),
-    COSMETIC_OPTION("Kal_MapSelectC",                "Map Color C",          GROUP_KALEIDO,      ImVec4(140, 60, 60, 255),   false, true, false),
-    COSMETIC_OPTION("Kal_MapSelectD",                "Map Color D",          GROUP_KALEIDO,      ImVec4(80, 40, 30, 255),    false, true, false),
+    COSMETIC_OPTION("Kal_MapSelectA",                "Map Color",            GROUP_KALEIDO,      ImVec4(80, 40, 30, 255),    false, true, false),
+    COSMETIC_OPTION("Kal_MapSelectB",                "Map Color B",          GROUP_KALEIDO,      ImVec4(140, 60, 60, 255),   false, true, true),
+    COSMETIC_OPTION("Kal_MapSelectC",                "Map Color C",          GROUP_KALEIDO,      ImVec4(140, 60, 60, 255),   false, true, true),
+    COSMETIC_OPTION("Kal_MapSelectD",                "Map Color D",          GROUP_KALEIDO,      ImVec4(80, 40, 30, 255),    false, true, true),
 
-    COSMETIC_OPTION("Kal_SaveA",                     "Save A",               GROUP_KALEIDO,      ImVec4(50, 50, 50, 255),    false, true, false),
-    COSMETIC_OPTION("Kal_SaveB",                     "Save B",               GROUP_KALEIDO,      ImVec4(110, 110, 110, 255), false, true, false),
-    COSMETIC_OPTION("Kal_SaveC",                     "Save C",               GROUP_KALEIDO,      ImVec4(110, 110, 110, 255), false, true, false),
-    COSMETIC_OPTION("Kal_SaveD",                     "Save D",               GROUP_KALEIDO,      ImVec4(50, 50, 50, 255),    false, true, false),
+    COSMETIC_OPTION("Kal_SaveA",                     "Save Color",           GROUP_KALEIDO,      ImVec4(50, 50, 50, 255),    false, true, false),
+    COSMETIC_OPTION("Kal_SaveB",                     "Save Color B",         GROUP_KALEIDO,      ImVec4(110, 110, 110, 255), false, true, true),
+    COSMETIC_OPTION("Kal_SaveC",                     "Save Color C",         GROUP_KALEIDO,      ImVec4(110, 110, 110, 255), false, true, true),
+    COSMETIC_OPTION("Kal_SaveD",                     "Save Color D",         GROUP_KALEIDO,      ImVec4(50, 50, 50, 255),    false, true, true),
 
     COSMETIC_OPTION("Kal_NamePanel",                 "Name Panel",           GROUP_KALEIDO,      ImVec4(90,100,130,255),     true, true, false),
 
@@ -1631,25 +1631,20 @@ void CopyMultipliedColor(CosmeticOption& cosmeticOptionSrc, CosmeticOption& cosm
     CVarSetInteger((cosmeticOptionTarget.changedCvar), 1);
 }
 
-void RandomizeColor(CosmeticOption& cosmeticOption) {
-    Color_RGBA8 newColor;
-    newColor.r = Random(0, 255);
-    newColor.g = Random(0, 255);
-    newColor.b = Random(0, 255);
-    newColor.a = 255;
-    // For alpha supported options, retain the last set alpha instead of overwriting
-    if (cosmeticOption.supportsAlpha) {
-        newColor.a = cosmeticOption.currentColor.w * 255;
+void ToggleRainbow(CosmeticOption& cosmeticOption, bool state) {
+    if (state) {
+        CVarSetInteger(cosmeticOption.rainbowCvar, 1);
+        CVarSetInteger(cosmeticOption.changedCvar, 1);
+    } else {
+        CVarClear(cosmeticOption.rainbowCvar);
+        CVarClear(cosmeticOption.changedCvar);
     }
+}
 
-    cosmeticOption.currentColor.x = newColor.r / 255.0;
-    cosmeticOption.currentColor.y = newColor.g / 255.0;
-    cosmeticOption.currentColor.z = newColor.b / 255.0;
-    cosmeticOption.currentColor.w = newColor.a / 255.0;
-
-    CVarSetColor(cosmeticOption.cvar, newColor);
-    CVarSetInteger((cosmeticOption.rainbowCvar), 0);
-    CVarSetInteger((cosmeticOption.changedCvar), 1);
+void ApplySideEffects(CosmeticOption& cosmeticOption) {
+    if (CVarGetInteger("gCosmetics.AdvancedMode", 0)) {
+        return;
+    }
 
     // This bit is kind of experimental, not sure how I feel about it yet, but it allows for
     // advanced cosmetic options to be changed based on a non-advanced option.
@@ -1671,7 +1666,89 @@ void RandomizeColor(CosmeticOption& cosmeticOption) {
         CopyMultipliedColor(cosmeticOption, cosmeticOptions.at("SpinAttack_Level1Primary"), 2.0f);
     } else if (cosmeticOption.label == "Level 2 Secondary") {
         CopyMultipliedColor(cosmeticOption, cosmeticOptions.at("SpinAttack_Level2Primary"), 2.0f);
+    } else if (cosmeticOption.label == "Item Select Color") {
+        if (CVarGetInteger(cosmeticOption.rainbowCvar, 0)) {
+            ToggleRainbow(cosmeticOptions.at("Kal_ItemSelB"), true);
+            ToggleRainbow(cosmeticOptions.at("Kal_ItemSelC"), true);
+            ToggleRainbow(cosmeticOptions.at("Kal_ItemSelD"), true);
+        } else {
+            CopyMultipliedColor(cosmeticOption, cosmeticOptions.at("Kal_ItemSelB"), 2.0f);
+            CopyMultipliedColor(cosmeticOption, cosmeticOptions.at("Kal_ItemSelC"), 2.0f);
+            CopyMultipliedColor(cosmeticOption, cosmeticOptions.at("Kal_ItemSelD"), 1.0f);
+        }
+    } else if (cosmeticOption.label == "Equip Select Color") {
+        if (CVarGetInteger(cosmeticOption.rainbowCvar, 0)) {
+            ToggleRainbow(cosmeticOptions.at("Kal_EquipSelB"), true);
+            ToggleRainbow(cosmeticOptions.at("Kal_EquipSelC"), true);
+            ToggleRainbow(cosmeticOptions.at("Kal_EquipSelD"), true);
+        } else {
+            CopyMultipliedColor(cosmeticOption, cosmeticOptions.at("Kal_EquipSelB"), 2.0f);
+            CopyMultipliedColor(cosmeticOption, cosmeticOptions.at("Kal_EquipSelC"), 2.0f);
+            CopyMultipliedColor(cosmeticOption, cosmeticOptions.at("Kal_EquipSelD"), 1.0f);
+        }
+    } else if (cosmeticOption.label == "Map Dungeon Color") {
+        if (CVarGetInteger(cosmeticOption.rainbowCvar, 0)) {
+            ToggleRainbow(cosmeticOptions.at("Kal_MapSelDunB"), true);
+            ToggleRainbow(cosmeticOptions.at("Kal_MapSelDunC"), true);
+            ToggleRainbow(cosmeticOptions.at("Kal_MapSelDunD"), true);
+        } else {
+            CopyMultipliedColor(cosmeticOption, cosmeticOptions.at("Kal_MapSelDunB"), 2.0f);
+            CopyMultipliedColor(cosmeticOption, cosmeticOptions.at("Kal_MapSelDunC"), 2.0f);
+            CopyMultipliedColor(cosmeticOption, cosmeticOptions.at("Kal_MapSelDunD"), 1.0f);
+        }
+    } else if (cosmeticOption.label == "Quest Status Color") {
+        if (CVarGetInteger(cosmeticOption.rainbowCvar, 0)) {
+            ToggleRainbow(cosmeticOptions.at("Kal_QuestStatusB"), true);
+            ToggleRainbow(cosmeticOptions.at("Kal_QuestStatusC"), true);
+            ToggleRainbow(cosmeticOptions.at("Kal_QuestStatusD"), true);
+        } else {
+            CopyMultipliedColor(cosmeticOption, cosmeticOptions.at("Kal_QuestStatusB"), 2.0f);
+            CopyMultipliedColor(cosmeticOption, cosmeticOptions.at("Kal_QuestStatusC"), 2.0f);
+            CopyMultipliedColor(cosmeticOption, cosmeticOptions.at("Kal_QuestStatusD"), 1.0f);
+        }
+    } else if (cosmeticOption.label == "Map Color") {
+        if (CVarGetInteger(cosmeticOption.rainbowCvar, 0)) {
+            ToggleRainbow(cosmeticOptions.at("Kal_MapSelectB"), true);
+            ToggleRainbow(cosmeticOptions.at("Kal_MapSelectC"), true);
+            ToggleRainbow(cosmeticOptions.at("Kal_MapSelectD"), true);
+        } else {
+            CopyMultipliedColor(cosmeticOption, cosmeticOptions.at("Kal_MapSelectB"), 2.0f);
+            CopyMultipliedColor(cosmeticOption, cosmeticOptions.at("Kal_MapSelectC"), 2.0f);
+            CopyMultipliedColor(cosmeticOption, cosmeticOptions.at("Kal_MapSelectD"), 1.0f);
+        }
+    } else if (cosmeticOption.label == "Save Color") {
+        if (CVarGetInteger(cosmeticOption.rainbowCvar, 0)) {
+            ToggleRainbow(cosmeticOptions.at("Kal_SaveB"), true);
+            ToggleRainbow(cosmeticOptions.at("Kal_SaveC"), true);
+            ToggleRainbow(cosmeticOptions.at("Kal_SaveD"), true);
+        } else {
+            CopyMultipliedColor(cosmeticOption, cosmeticOptions.at("Kal_SaveB"), 2.0f);
+            CopyMultipliedColor(cosmeticOption, cosmeticOptions.at("Kal_SaveC"), 2.0f);
+            CopyMultipliedColor(cosmeticOption, cosmeticOptions.at("Kal_SaveD"), 1.0f);
+        }
     }
+}
+
+void RandomizeColor(CosmeticOption& cosmeticOption) {
+    Color_RGBA8 newColor;
+    newColor.r = Random(0, 255);
+    newColor.g = Random(0, 255);
+    newColor.b = Random(0, 255);
+    newColor.a = 255;
+    // For alpha supported options, retain the last set alpha instead of overwriting
+    if (cosmeticOption.supportsAlpha) {
+        newColor.a = cosmeticOption.currentColor.w * 255;
+    }
+
+    cosmeticOption.currentColor.x = newColor.r / 255.0;
+    cosmeticOption.currentColor.y = newColor.g / 255.0;
+    cosmeticOption.currentColor.z = newColor.b / 255.0;
+    cosmeticOption.currentColor.w = newColor.a / 255.0;
+
+    CVarSetColor(cosmeticOption.cvar, newColor);
+    CVarSetInteger((cosmeticOption.rainbowCvar), 0);
+    CVarSetInteger((cosmeticOption.changedCvar), 1);
+    ApplySideEffects(cosmeticOption);
 }
 
 void ResetColor(CosmeticOption& cosmeticOption) {
@@ -1691,7 +1768,7 @@ void ResetColor(CosmeticOption& cosmeticOption) {
     CVarClear((std::string(cosmeticOption.cvar) + ".A").c_str());
     CVarClear((std::string(cosmeticOption.cvar) + ".Type").c_str());
 
-    // This portion should match 1:1 the multiplied colors in `RandomizeColor()`
+    // This portion should match 1:1 the multiplied colors in `ApplySideEffect()`
     if (cosmeticOption.label == "Bow Body") {
         ResetColor(cosmeticOptions.at("Equipment_BowTips"));
         ResetColor(cosmeticOptions.at("Equipment_BowHandle"));
@@ -1707,6 +1784,30 @@ void ResetColor(CosmeticOption& cosmeticOption) {
         ResetColor(cosmeticOptions.at("SpinAttack_Level1Primary"));
     } else if (cosmeticOption.label == "Level 2 Secondary") {
         ResetColor(cosmeticOptions.at("SpinAttack_Level2Primary"));
+    } else if (cosmeticOption.label == "Item Select Color") {
+        ResetColor(cosmeticOptions.at("Kal_ItemSelB"));
+        ResetColor(cosmeticOptions.at("Kal_ItemSelC"));
+        ResetColor(cosmeticOptions.at("Kal_ItemSelD"));
+    } else if (cosmeticOption.label == "Equip Select Color") {
+        ResetColor(cosmeticOptions.at("Kal_EquipSelB"));
+        ResetColor(cosmeticOptions.at("Kal_EquipSelC"));
+        ResetColor(cosmeticOptions.at("Kal_EquipSelD"));
+    } else if (cosmeticOption.label == "Map Dungeon Color") {
+        ResetColor(cosmeticOptions.at("Kal_MapSelDunB"));
+        ResetColor(cosmeticOptions.at("Kal_MapSelDunC"));
+        ResetColor(cosmeticOptions.at("Kal_MapSelDunD"));
+    } else if (cosmeticOption.label == "Quest Status Color") {
+        ResetColor(cosmeticOptions.at("Kal_QuestStatusB"));
+        ResetColor(cosmeticOptions.at("Kal_QuestStatusC"));
+        ResetColor(cosmeticOptions.at("Kal_QuestStatusD"));
+    } else if (cosmeticOption.label == "Map Color") {
+        ResetColor(cosmeticOptions.at("Kal_MapSelectB"));
+        ResetColor(cosmeticOptions.at("Kal_MapSelectC"));
+        ResetColor(cosmeticOptions.at("Kal_MapSelectD"));
+    } else if (cosmeticOption.label == "Save Color") {
+        ResetColor(cosmeticOptions.at("Kal_SaveB"));
+        ResetColor(cosmeticOptions.at("Kal_SaveC"));
+        ResetColor(cosmeticOptions.at("Kal_SaveD"));
     }
 }
 
@@ -1727,6 +1828,7 @@ void DrawCosmeticRow(CosmeticOption& cosmeticOption) {
         CVarSetColor(cosmeticOption.cvar, color);
         CVarSetInteger((cosmeticOption.rainbowCvar), 0);
         CVarSetInteger((cosmeticOption.changedCvar), 1);
+        ApplySideEffects(cosmeticOption);
         ApplyOrResetCustomGfxPatches();
         LUS::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
     }
@@ -1744,6 +1846,7 @@ void DrawCosmeticRow(CosmeticOption& cosmeticOption) {
         if (ImGui::Checkbox(("Rainbow##" + cosmeticOption.label).c_str(), &isRainbow)) {
             CVarSetInteger((cosmeticOption.rainbowCvar), isRainbow);
             CVarSetInteger((cosmeticOption.changedCvar), 1);
+            ApplySideEffects(cosmeticOption);
             ApplyOrResetCustomGfxPatches();
             LUS::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
         }
@@ -1800,7 +1903,7 @@ static const char* colorSchemes[2] = {
 };
 
 void CosmeticsEditorWindow::DrawElement() {
-    ImGui::SetNextWindowSize(ImVec2(480, 520), ImGuiCond_FirstUseEver);
+    ImGui::SetNextWindowSize(ImVec2(550, 520), ImGuiCond_FirstUseEver);
     if (!ImGui::Begin("Cosmetics Editor", &mIsVisible)) {
         ImGui::End();
         return;


### PR DESCRIPTION
- Combine each pane into a single option unless in advanced mode
- Make cosmetics editor a bit wider by default to prevent tab names from clipping
- Move "side effect" logic to it's own function, so that it can also be used with enabling rainbow mode on the "combined" options

Before outside of advanced mode:
<img width="526" alt="Screenshot 2024-02-02 at 4 09 02 PM" src="https://github.com/HarbourMasters/Shipwright/assets/7316699/1432e74c-b19d-41ed-b6cf-66205bdb2028">

After outside of advanced mode:
<img width="596" alt="Screenshot 2024-02-02 at 4 08 15 PM" src="https://github.com/HarbourMasters/Shipwright/assets/7316699/20018d4c-15a5-43a7-9376-6d8fbd3df251">


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1216542579.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1216569295.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1216570167.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1216573856.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1216576534.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1216576564.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1216591290.zip)
<!--- section:artifacts:end -->