### PR TITLE
Fix unexpected quantization of float sliders

### DIFF
--- a/soh/soh/UIWidgets.cpp
+++ b/soh/soh/UIWidgets.cpp
@@ -449,7 +449,7 @@ namespace UIWidgets {
 
         if (changed && !(abs(oldVal - val) < 0.000001f)) {
             std::stringstream ss;
-            ss << std::setprecision(ticks + 1) << val;
+            ss << std::setprecision(ticks + 1) << std::setiosflags(std::ios_base::fixed) << val;
             val = std::stof(ss.str());
             CVarSetFloat(cvarName, val);
             LUS::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();


### PR DESCRIPTION
Closes #3898.  The stringstream used in the EnhancementSliderFloat UIWidget was unexpectedly using scientific notation instead of fixed for float values larger than 10.  This was resulting in, for example, the goron neck slider going from values 80 > 90 > 100 > 200 when dragged, and not being able to use the +/- buttons at all when the value was greater than 10.  Making sure fixed notation is used fixes this.  

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1216887086.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1216898603.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1216898990.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1216899193.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1216902225.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1216902930.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1216908378.zip)
<!--- section:artifacts:end -->