### PR TITLE
Add safety measure to Scene_CommandObjectList to prevent crash

### DIFF
--- a/soh/soh/z_scene_otr.cpp
+++ b/soh/soh/z_scene_otr.cpp
@@ -177,7 +177,7 @@ bool Scene_CommandObjectList(PlayState* play, LUS::ISceneCommand* cmd) {
 
     // Loop until a mismatch in the object lists
     // Then clear all object ids past that in the context object list and kill actors for those objects
-    for (i = play->objectCtx.unk_09, k = 0; i < play->objectCtx.num; i++, k++) {
+    for (i = play->objectCtx.unk_09, k = 0; i < play->objectCtx.num, k < cmdObj->objects.size(); i++, k++) {
         if (play->objectCtx.status[i].id != cmdObj->objects[k]) {
             for (j = i; j < play->objectCtx.num; j++) {
                 play->objectCtx.status[j].id = OBJECT_INVALID;

--- a/soh/soh/z_scene_otr.cpp
+++ b/soh/soh/z_scene_otr.cpp
@@ -177,8 +177,8 @@ bool Scene_CommandObjectList(PlayState* play, LUS::ISceneCommand* cmd) {
 
     // Loop until a mismatch in the object lists
     // Then clear all object ids past that in the context object list and kill actors for those objects
-    for (i = play->objectCtx.unk_09, k = 0; i < play->objectCtx.num, k < cmdObj->objects.size(); i++, k++) {
-        if (play->objectCtx.status[i].id != cmdObj->objects[k]) {
+    for (i = play->objectCtx.unk_09, k = 0; i < play->objectCtx.num; i++, k++) {
+        if (i >= cmdObj->objects.size() || play->objectCtx.status[i].id != cmdObj->objects[k]) {
             for (j = i; j < play->objectCtx.num; j++) {
                 play->objectCtx.status[j].id = OBJECT_INVALID;
             }


### PR DESCRIPTION
On debug versions it was reported that going between certain rooms in a scene would cause a crash. I gave this branch for someone to test and it seems to fix the issue. I believe what was happening was just that cmdObj->objects[k] was indexing past the size of objects, however, I was never able to replicate the original crash on my machine

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1236297018.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1236297019.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1236297021.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1236297022.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1236297023.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1236297024.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1236297025.zip)
<!--- section:artifacts:end -->