### PR TITLE
[Enhancement] Preserve minimap toggle state between areas

### DIFF
--- a/soh/soh/Enhancements/presets.h
+++ b/soh/soh/Enhancements/presets.h
@@ -331,6 +331,7 @@ const std::vector<const char*> cheatCvars = {
     "gCosmetics.Link_HeadScale.Value",
     "gCosmetics.Link_SwordScale.Changed",
     "gCosmetics.Link_SwordScale.Value",
+    "gEnhancements.RememberMapToggleState",
 };
 
 const std::vector<const char*> randomizerCvars = {

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -967,6 +967,8 @@ void DrawEnhancementsMenu() {
                 UIWidgets::Tooltip("Disables the voice audio when Navi calls you");
                 UIWidgets::PaddedEnhancementCheckbox("Disable Hot/Underwater Warning Text", "gDisableTunicWarningText", true, false);
                 UIWidgets::Tooltip("Disables warning text when you don't have on the Goron/Zora Tunic in Hot/Underwater conditions.");
+                UIWidgets::PaddedEnhancementCheckbox("Remember Minimap State Between Areas", "gEnhancements.RememberMapToggleState");
+                UIWidgets::Tooltip("Preserves the minimap visibility state when going between areas rather than defaulting it to \"on\" when going through loading zones.");
 
                 ImGui::EndMenu();
             }

--- a/soh/src/code/z_construct.c
+++ b/soh/src/code/z_construct.c
@@ -430,7 +430,9 @@ void Regs_InitDataImpl(void) {
     WREG(28) = 0;
     R_OW_MINIMAP_X = 238;
     R_OW_MINIMAP_Y = 164;
-    R_MINIMAP_DISABLED = CVarGetInteger("gMinimalUI", 0);
+    if (!CVarGetInteger("gEnhancements.RememberMapToggleState", 0)) {
+        R_MINIMAP_DISABLED = CVarGetInteger("gMinimalUI", 0);
+    }
     WREG(32) = 122;
     WREG(33) = 60;
     WREG(35) = 0;


### PR DESCRIPTION
Currently going through loading zones resets the minimap toggle state to "on" (or "off" if Minimal UI is enabled) every time. This adds an enhancement checkbox to the Reduced Clutter menu to instead preserve the value when going through loading zones. 

This feature is very nice for streamers or other people who want to have something else in that spot, and the map makes things cluttered and hard to see if it keeps showing up behind other things. For example some people put the check tracker there and it makes the list hard to read when the map is visible.

![image](https://github.com/HarbourMasters/Shipwright/assets/7520947/e465973f-eaf4-4756-ab52-a4e525cf006f)


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1238858317.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1238906472.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1238907213.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1238909785.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1238919065.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1238922008.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1238998878.zip)
<!--- section:artifacts:end -->