### PR TITLE
Add destination highlighting, context hiding, and a single-line toggle to Entrance Tracker

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer_entrance_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_entrance_tracker.cpp
@@ -21,9 +21,9 @@ extern PlayState* gPlayState;
 #include "soh/Enhancements/game-interactor/GameInteractor.h"
 
 #define COLOR_ORANGE IM_COL32(230, 159, 0, 255)
-#define COLOR_GREEN IM_COL32(0, 158, 115, 255)
+#define COLOR_GREEN IM_COL32(0, 190, 105, 255)
 #define COLOR_GRAY IM_COL32(155, 155, 155, 255)
-#define COLOR_PINK IM_COL32(232, 0, 125, 255)
+#define COLOR_PINK IM_COL32(219, 143, 255, 255)
 
 EntranceOverride srcListSortedByArea[ENTRANCE_OVERRIDES_MAX_COUNT] = {0};
 EntranceOverride destListSortedByArea[ENTRANCE_OVERRIDES_MAX_COUNT] = {0};

--- a/soh/soh/Enhancements/randomizer/randomizer_entrance_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_entrance_tracker.cpp
@@ -672,7 +672,7 @@ void EntranceTrackerWindow::DrawElement() {
                 UIWidgets::Tooltip("Highlight the previous entrance that Link came from");
                 UIWidgets::PaddedEnhancementCheckbox("Highlight available", "gEntranceTrackerHighlightAvailable", true, false);
                 UIWidgets::Tooltip("Highlight available entrances in the current scene");
-                UIWidgets::PaddedEnhancementCheckbox("Highlight destinations", "gEntranceTrackerHighlightDestinations", true, false);
+                UIWidgets::PaddedEnhancementCheckbox("Highlight destinations", "gTrackers.EntranceTracker.HighlightDestinations", true, false);
                 UIWidgets::Tooltip("Highlight destinations with a separate color");
                 UIWidgets::PaddedEnhancementCheckbox("Hide undiscovered", "gEntranceTrackerCollapseUndiscovered", true, false);
                 UIWidgets::Tooltip("Collapse undiscovered entrances towards the bottom of each group");
@@ -681,13 +681,13 @@ void EntranceTrackerWindow::DrawElement() {
                 UIWidgets::PaddedEnhancementCheckbox("Hide reverse", "gEntranceTrackerHideReverseEntrances", true, false,
                                               disableHideReverseEntrances, disableHideReverseEntrancesText, UIWidgets::CheckboxGraphics::Cross, true);
                 UIWidgets::Tooltip("Hide reverse entrance transitions when Decouple Entrances is off");
-                UIWidgets::PaddedEnhancementCheckbox("Hide \"to\" context", "gEntranceTrackerSimplifyTo", true, false);
+                UIWidgets::PaddedEnhancementCheckbox("Hide \"to\" context", "gTrackers.EntranceTracker.SimplifyTo", true, false);
                 UIWidgets::Tooltip("Simplify entrance list by removing the context from the beginning of entrance names (ex: \"KF to Mido's House\" becomes \"Mido's House\")\n\n"
                                    "If the \"Sort By\" setting is set to \"From\", the example would instead be: \"KF to Mido's House\" becomes \"KF\"");
-                UIWidgets::PaddedEnhancementCheckbox("Hide \"from\" context", "gEntranceTrackerSimplifyFrom", true, false);
+                UIWidgets::PaddedEnhancementCheckbox("Hide \"from\" context", "gTrackers.EntranceTracker.SimplifyFrom", true, false);
                 UIWidgets::Tooltip("Simplify entrance list by removing the context from the end of entrance names (ex: \"Market Entrance from Hyrule Field\" becomes \"Market Entrance\")\n\n"
                                    "If the \"Sort By\" setting is set to \"From\", the example would instead be: \"Market Entrance from Hyrule Field\" becomes \"from Hyrule Field\"");
-                UIWidgets::PaddedEnhancementCheckbox("One line", "gEntranceTrackerOneLine", true, false);
+                UIWidgets::PaddedEnhancementCheckbox("One line", "gTrackers.EntranceTracker.OneLine", true, false);
                 UIWidgets::Tooltip("Keep entrances and destinations on one line");
                 UIWidgets::Spacer(0);
 
@@ -806,7 +806,7 @@ void EntranceTrackerWindow::DrawElement() {
             if ((original->type == ENTRANCE_TYPE_DUNGEON || original->type == ENTRANCE_TYPE_GROTTO || original->type == ENTRANCE_TYPE_INTERIOR) &&
                 (original->oneExit != 1 && OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_DECOUPLED_ENTRANCES) == RO_GENERIC_OFF) &&
                 CVarGetInteger("gEntranceTrackerHideReverseEntrances", 1) == 1) {
-                    continue;
+                    continue;`
             }
 
             bool isDiscovered = IsEntranceDiscovered(entrance.index);
@@ -865,7 +865,7 @@ void EntranceTrackerWindow::DrawElement() {
 
                     bool showOriginal = (!destToggle ? CVarGetInteger("gEntranceTrackerShowTo", 0) : CVarGetInteger("gEntranceTrackerShowFrom", 0)) || isDiscovered;
                     bool showOverride = (!destToggle ? CVarGetInteger("gEntranceTrackerShowFrom", 0) : CVarGetInteger("gEntranceTrackerShowTo", 0)) || isDiscovered;
-                    bool highlightDestinations = CVarGetInteger("gEntranceTrackerHighlightDestinations", 0);
+                    bool highlightDestinations = CVarGetInteger("gTrackers.EntranceTracker.HighlightDestinations", 0);
 
                     const char* unknown = "???";
 
@@ -902,15 +902,15 @@ void EntranceTrackerWindow::DrawElement() {
                     auto nbsp = u8"\u00A0";
                     if (original->srcGroup != ENTRANCE_GROUP_ONE_WAY) {
                         if (!destToggle) ImGui::PushStyleColor(ImGuiCol_Text, COLOR_GRAY);  
-                        if (locationSearch.IsActive() || destToggle || !CVarGetInteger("gEntranceTrackerSimplifyTo", 0)) {
+                        if (locationSearch.IsActive() || destToggle || !CVarGetInteger("gTrackers.EntranceTracker.SimplifyTo", 0)) {
                             ImGui::Text("%s", origSrcName);
                             ImGui::SameLine();
                         }
                         if (!destToggle) ImGui::PopStyleColor();
                         
                         if (destToggle) ImGui::PushStyleColor(ImGuiCol_Text, COLOR_GRAY);
-                        if (locationSearch.IsActive() || !destToggle || !CVarGetInteger("gEntranceTrackerSimplifyTo", 0))
-                            ImGui::Text("%s%s%s->", CVarGetInteger("gEntranceTrackerSimplifyTo", 0) && !locationSearch.IsActive() ? "" : "to ", origDstName, nbsp);
+                        if (locationSearch.IsActive() || !destToggle || !CVarGetInteger("gTrackers.EntranceTracker.SimplifyTo", 0))
+                            ImGui::Text("%s%s%s->", CVarGetInteger("gTrackers.EntranceTracker.SimplifyTo", 0) && !locationSearch.IsActive() ? "" : "to ", origDstName, nbsp);
                         else
                             ImGui::Text("->");
                         if (destToggle) ImGui::PopStyleColor();
@@ -918,7 +918,7 @@ void EntranceTrackerWindow::DrawElement() {
                         ImGui::Text("%s%s->", origSrcName, nbsp);
                     }
 
-                    if (CVarGetInteger("gEntranceTrackerOneLine", 0)) {
+                    if (CVarGetInteger("gTrackers.EntranceTracker.OneLine", 0)) {
                         ImGui::SameLine();
                     } else {
                         // Indent the destination
@@ -928,15 +928,15 @@ void EntranceTrackerWindow::DrawElement() {
                         if (destToggle || !isDiscovered) ImGui::PushStyleColor(ImGuiCol_Text,  COLOR_GRAY);
                         else if (highlightDestinations) ImGui::PushStyleColor(ImGuiCol_Text, COLOR_PINK);
                         
-                        if (!destToggle || !CVarGetInteger("gEntranceTrackerSimplifyFrom", 0))
+                        if (!destToggle || !CVarGetInteger("gTrackers.EntranceTracker.SimplifyFrom", 0))
                             ImGui::Text("%s", rplcDstName);
                         if (destToggle || !isDiscovered || highlightDestinations) ImGui::PopStyleColor();
 
                         if (destToggle && highlightDestinations && isDiscovered) ImGui::PushStyleColor(ImGuiCol_Text, COLOR_PINK);
                         else ImGui::PushStyleColor(ImGuiCol_Text, COLOR_GRAY);
 
-                        if (locationSearch.IsActive() || destToggle || !CVarGetInteger("gEntranceTrackerSimplifyFrom", 0)) {
-                            if (!destToggle || !CVarGetInteger("gEntranceTrackerSimplifyFrom", 0))
+                        if (locationSearch.IsActive() || destToggle || !CVarGetInteger("gTrackers.EntranceTracker.SimplifyFrom", 0)) {
+                            if (!destToggle || !CVarGetInteger("gTrackers.EntranceTracker.SimplifyFrom", 0))
                                  ImGui::SameLine();
                             ImGui::Text("%s %s", "from", rplcSrcName);
                         }

--- a/soh/soh/Enhancements/randomizer/randomizer_entrance_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_entrance_tracker.cpp
@@ -806,7 +806,7 @@ void EntranceTrackerWindow::DrawElement() {
             if ((original->type == ENTRANCE_TYPE_DUNGEON || original->type == ENTRANCE_TYPE_GROTTO || original->type == ENTRANCE_TYPE_INTERIOR) &&
                 (original->oneExit != 1 && OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_DECOUPLED_ENTRANCES) == RO_GENERIC_OFF) &&
                 CVarGetInteger("gEntranceTrackerHideReverseEntrances", 1) == 1) {
-                    continue;`
+                    continue;
             }
 
             bool isDiscovered = IsEntranceDiscovered(entrance.index);

--- a/soh/soh/Enhancements/randomizer/randomizer_entrance_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_entrance_tracker.cpp
@@ -910,7 +910,7 @@ void EntranceTrackerWindow::DrawElement() {
                         
                         if (destToggle) ImGui::PushStyleColor(ImGuiCol_Text, COLOR_GRAY);
                         if (locationSearch.IsActive() || !destToggle || !CVarGetInteger("gEntranceTrackerSimplifyTo", 0))
-                            ImGui::Text("%s%s%s->", CVarGetInteger("gEntranceTrackerSimplifyTo", 0) ? "" : "to ", origDstName, nbsp);
+                            ImGui::Text("%s%s%s->", CVarGetInteger("gEntranceTrackerSimplifyTo", 0) && !locationSearch.IsActive() ? "" : "to ", origDstName, nbsp);
                         else
                             ImGui::Text("->");
                         if (destToggle) ImGui::PopStyleColor();


### PR DESCRIPTION
The Entrance Tracker is currently quite difficult to use. The Anchor branch made some tweaks that make some aspects easier but others harder. This takes some of those changes and expands on them to provide options to make things easier to read and use.

- The "context" information of an entrance ( _**KF to**_ Mido's House / Market Entrance _**from Hyrule Field**_ ) is grayed out, while the main entrance information is colored normally.
  - This is reversed if the "Sort By" setting is switched to "From"
- An option is added to toggle highlighting destinations as a separate color, making it easier to search for specific locations
- An option is added to fully hide the "to" contexts (the part grayed out in "KF to Mido's House")
- An option is added to fully hide the "from" contexts (the part grayed out in "Market Entrance from Hyrule Field")
- An option is added to toggle between having everything on one line and having the destination be on a separate line
- The list now has horizontal scrolling instead of wordwrap due to issues with the way ImGui handles wrapping.



Examples:

UPDATED COLORS:
![image](https://github.com/HarbourMasters/Shipwright/assets/7520947/0193de8d-a592-4431-a1f0-d963bd462f1c)

Old colors:

Video can be found here: https://discord.com/channels/808039310850130000/1019824570938699798/1204221952328339496

![image](https://github.com/HarbourMasters/Shipwright/assets/7520947/24612c1a-ac7f-4c54-bf82-b5c29f11810e)
![image](https://github.com/HarbourMasters/Shipwright/assets/7520947/fe607228-c8f8-4676-8d01-281657672288)
![image](https://github.com/HarbourMasters/Shipwright/assets/7520947/9adad9bd-25b2-4c6c-b583-0a089b9f073d)
![image](https://github.com/HarbourMasters/Shipwright/assets/7520947/b2bf6c90-3d39-4f48-8c9b-d49b81f41798)
![image](https://github.com/HarbourMasters/Shipwright/assets/7520947/1a1269f9-ca76-46d3-89ed-4f64333bbac8)
![image](https://github.com/HarbourMasters/Shipwright/assets/7520947/2dbbafbf-b611-4781-a70c-0e202cf35e36)



<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1228216098.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1228220466.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1228222160.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1228230789.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1228256455.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1228258439.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1228265944.zip)
<!--- section:artifacts:end -->