### PR TITLE
Fix Cosmetics Editor getting stuck on weapon trails

### DIFF
--- a/soh/src/code/z_eff_blure.c
+++ b/soh/src/code/z_eff_blure.c
@@ -204,7 +204,7 @@ s32 EffectBlure_Update(void* thisx) {
     s32 i;
     Color_RGBA8 color;
     static u8 changed = 0;
-    static u8 reset = 0;
+    u8 reset = 0;
 
     switch (this->trailType) { //there HAS to be a better way to do this.
         case 2:
@@ -299,7 +299,6 @@ s32 EffectBlure_Update(void* thisx) {
     }
     if (reset) {
         changed = 0;
-        reset = 0;
     }
 
     // Don't override boomerang and bombchu trail durations

--- a/soh/src/code/z_eff_blure.c
+++ b/soh/src/code/z_eff_blure.c
@@ -231,6 +231,20 @@ s32 EffectBlure_Update(void* thisx) {
                 this->p2StartColor.b = color.b * 0.8f;
                 this->p1EndColor.b = color.b * 0.6f;
                 this->p2EndColor.b = color.b * 0.4f;
+            } else if (changed) {
+                color = (Color_RGBA8){ 250, 0, 0, 255 };
+                this->p1StartColor.r = color.r;
+                this->p2StartColor.r = color.r * 0.8f;
+                this->p1EndColor.r = color.r * 0.6f;
+                this->p2EndColor.r = color.r * 0.4f;
+                this->p1StartColor.g = color.g;
+                this->p2StartColor.g = color.g * 0.8f;
+                this->p1EndColor.g = color.g * 0.6f;
+                this->p2EndColor.g = color.g * 0.4f;
+                this->p1StartColor.b = color.b;
+                this->p2StartColor.b = color.b * 0.8f;
+                this->p1EndColor.b = color.b * 0.6f;
+                this->p2EndColor.b = color.b * 0.4f;
             }
             break;
         case 4:

--- a/soh/src/code/z_eff_blure.c
+++ b/soh/src/code/z_eff_blure.c
@@ -203,13 +203,17 @@ s32 EffectBlure_Update(void* thisx) {
     EffectBlure* this = (EffectBlure*)thisx;
     s32 i;
     Color_RGBA8 color;
-    u8 changed = 0;
+    static u8 changed = 0;
+    static u8 reset = 0;
 
     switch (this->trailType) { //there HAS to be a better way to do this.
         case 2:
             if (CVarGetInteger("gCosmetics.Trails_Boomerang.Changed", 0)) {
                 color = CVarGetColor("gCosmetics.Trails_Boomerang.Value", (Color_RGBA8){ 255, 255, 100, 255 });
                 changed = 1;
+            } else if (changed) {
+                color = (Color_RGBA8){ 255, 255, 100, 255 };
+                reset = 1;
             }
             break;
         case 3:
@@ -233,30 +237,45 @@ s32 EffectBlure_Update(void* thisx) {
             if (CVarGetInteger("gCosmetics.Trails_KokiriSword.Changed", 0)) {
                 color = CVarGetColor("gCosmetics.Trails_KokiriSword.Value", (Color_RGBA8){ 255, 255, 255, 255 });
                 changed = 1;
+            } else if (changed) {
+                color = (Color_RGBA8){ 255, 255, 255, 255 };
+                reset = 1;
             }
             break;
         case 5:
             if (CVarGetInteger("gCosmetics.Trails_MasterSword.Changed", 0)) {
                 color = CVarGetColor("gCosmetics.Trails_MasterSword.Value", (Color_RGBA8){ 255, 255, 255, 255 });
                 changed = 1;
+            } else if (changed) {
+                color = (Color_RGBA8){ 255, 255, 255, 255 };
+                reset = 1;
             }
             break;
         case 6:
             if (CVarGetInteger("gCosmetics.Trails_BiggoronSword.Changed", 0)) {
                 color = CVarGetColor("gCosmetics.Trails_BiggoronSword.Value", (Color_RGBA8){ 255, 255, 255, 255 });
                 changed = 1;
+            } else if (changed) {
+                color = (Color_RGBA8){ 255, 255, 255, 255 };
+                reset = 1;
             }
             break;
         case 7:
             if (CVarGetInteger("gCosmetics.Trails_Stick.Changed", 0)) {
                 color = CVarGetColor("gCosmetics.Trails_Stick.Value", (Color_RGBA8){ 255, 255, 255, 255 });
                 changed = 1;
+            } else if (changed) {
+                color = (Color_RGBA8){ 255, 255, 255, 255 };
+                reset = 1;
             }
             break;
         case 8:
             if (CVarGetInteger("gCosmetics.Trails_Hammer.Changed", 0)) {
                 color = CVarGetColor("gCosmetics.Trails_Hammer.Value", (Color_RGBA8){ 255, 255, 255, 255 });
                 changed = 1;
+            } else if (changed) {
+                color = (Color_RGBA8){ 255, 255, 255, 255 };
+                reset = 1;
             }
             break;
         default: // don't do anything
@@ -277,6 +296,10 @@ s32 EffectBlure_Update(void* thisx) {
         this->p2StartColor.b = color.b;
         this->p1EndColor.b = color.b;
         this->p2EndColor.b = color.b;
+    }
+    if (reset) {
+        changed = 0;
+        reset = 0;
     }
 
     // Don't override boomerang and bombchu trail durations


### PR DESCRIPTION
Fixes "reset button" behavior and other circumstances where the weapon trail colour would temporarily get stuck until a scene change.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1223440490.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1223443277.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1223443581.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1223444046.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1223444161.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1223464303.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1223515698.zip)
<!--- section:artifacts:end -->