### PR TITLE
Cosmetics Editor fixes for icons in z_message_PAL.c

### DIFF
--- a/soh/src/code/z_message_PAL.c
+++ b/soh/src/code/z_message_PAL.c
@@ -453,11 +453,12 @@ void Message_SetTextColor(MessageContext* msgCtx, u16 colorParameter) {
 }
 
 void Message_DrawTextboxIcon(PlayState* play, Gfx** p, s16 x, s16 y) {
-    /* static */ Color_RGB8 sIconPrimColors[2] = {
+    // SoH [Cosmetics] The following Color_RGB8 were originally static
+    Color_RGB8 sIconPrimColors[2] = {
         { 0, 80, 200 },
         { 50, 130, 255 },
     };
-    /* static */ Color_RGB8 sIconEnvColors[2] = {
+    Color_RGB8 sIconEnvColors[2] = {
         { 0, 0, 0 },
         { 0, 130, 255 },
     };
@@ -2006,11 +2007,13 @@ void Message_DrawMain(PlayState* play, Gfx** p) {
     static void* sOcarinaNoteTextures[] = {
         gOcarinaBtnIconATex, gOcarinaBtnIconCDownTex, gOcarinaBtnIconCRightTex, gOcarinaBtnIconCLeftTex, gOcarinaBtnIconCUpTex,
     };
-    /* static */ Color_RGB8 sOcarinaNoteAPrimColors[2] = {
+
+    // SoH [Cosmetics] The following Color_RGB8 were originally static
+    Color_RGB8 sOcarinaNoteAPrimColors[2] = {
         { 80, 150, 255 },
         { 100, 200, 255 },
     };
-    /* static */ Color_RGB8 sOcarinaNoteAEnvColors[2] = {
+    Color_RGB8 sOcarinaNoteAEnvColors[2] = {
         { 10, 10, 10 },
         { 50, 50, 255 },
     };
@@ -2027,11 +2030,11 @@ void Message_DrawMain(PlayState* play, Gfx** p) {
         sOcarinaNoteAEnvColors[1] = (Color_RGB8){ 50, 255, 50 };
     }
 
-    /* static */ Color_RGB8 sOcarinaNoteCPrimColors[2] = {
+    Color_RGB8 sOcarinaNoteCPrimColors[2] = {
         { 255, 255, 50 },
         { 255, 255, 180 },
     };
-    /* static */ Color_RGB8 sOcarinaNoteCEnvColors[2] = {
+    Color_RGB8 sOcarinaNoteCEnvColors[2] = {
         { 10, 10, 10 },
         { 110, 110, 50 },
     };
@@ -2044,11 +2047,11 @@ void Message_DrawMain(PlayState* play, Gfx** p) {
         sOcarinaNoteCEnvColors[1].b = (color.b / 255.0f) * 95;
     }
 
-    /* static */ Color_RGB8 sOcarinaNoteCUpPrimColors[2] = {
+    Color_RGB8 sOcarinaNoteCUpPrimColors[2] = {
         { 255, 255, 50 },
         { 255, 255, 180 },
     };
-    /* static */ Color_RGB8 sOcarinaNoteCUpEnvColors[2] = {
+    Color_RGB8 sOcarinaNoteCUpEnvColors[2] = {
         { 10, 10, 10 },
         { 110, 110, 50 },
     };
@@ -2061,11 +2064,11 @@ void Message_DrawMain(PlayState* play, Gfx** p) {
         sOcarinaNoteCUpEnvColors[1].b = (color.b / 255.0f) * 95;
     }
 
-    /* static */ Color_RGB8 sOcarinaNoteCDownPrimColors[2] = {
+    Color_RGB8 sOcarinaNoteCDownPrimColors[2] = {
         { 255, 255, 50 },
         { 255, 255, 180 },
     };
-    /* static */ Color_RGB8 sOcarinaNoteCDownEnvColors[2] = {
+    Color_RGB8 sOcarinaNoteCDownEnvColors[2] = {
         { 10, 10, 10 },
         { 110, 110, 50 },
     };
@@ -2078,11 +2081,11 @@ void Message_DrawMain(PlayState* play, Gfx** p) {
         sOcarinaNoteCDownEnvColors[1].b = (color.b / 255.0f) * 95;
     }
 
-    /* static */ Color_RGB8 sOcarinaNoteCLeftPrimColors[2] = {
+    Color_RGB8 sOcarinaNoteCLeftPrimColors[2] = {
         { 255, 255, 50 },
         { 255, 255, 180 },
     };
-    /* static */ Color_RGB8 sOcarinaNoteCLeftEnvColors[2] = {
+    Color_RGB8 sOcarinaNoteCLeftEnvColors[2] = {
         { 10, 10, 10 },
         { 110, 110, 50 },
     };
@@ -2095,11 +2098,11 @@ void Message_DrawMain(PlayState* play, Gfx** p) {
         sOcarinaNoteCLeftEnvColors[1].b = (color.b / 255.0f) * 95;
     }
 
-    /* static */ Color_RGB8 sOcarinaNoteCRightPrimColors[2] = {
+    Color_RGB8 sOcarinaNoteCRightPrimColors[2] = {
         { 255, 255, 50 },
         { 255, 255, 180 },
     };
-    /* static */ Color_RGB8 sOcarinaNoteCRightEnvColors[2] = {
+    Color_RGB8 sOcarinaNoteCRightEnvColors[2] = {
         { 10, 10, 10 },
         { 110, 110, 50 },
     };

--- a/soh/src/code/z_message_PAL.c
+++ b/soh/src/code/z_message_PAL.c
@@ -453,11 +453,11 @@ void Message_SetTextColor(MessageContext* msgCtx, u16 colorParameter) {
 }
 
 void Message_DrawTextboxIcon(PlayState* play, Gfx** p, s16 x, s16 y) {
-    static Color_RGB8 sIconPrimColors[2] = {
+    /* static */ Color_RGB8 sIconPrimColors[2] = {
         { 0, 80, 200 },
         { 50, 130, 255 },
     };
-    static Color_RGB8 sIconEnvColors[2] = {
+    /* static */ Color_RGB8 sIconEnvColors[2] = {
         { 0, 0, 0 },
         { 0, 130, 255 },
     };
@@ -2006,11 +2006,11 @@ void Message_DrawMain(PlayState* play, Gfx** p) {
     static void* sOcarinaNoteTextures[] = {
         gOcarinaBtnIconATex, gOcarinaBtnIconCDownTex, gOcarinaBtnIconCRightTex, gOcarinaBtnIconCLeftTex, gOcarinaBtnIconCUpTex,
     };
-    static Color_RGB8 sOcarinaNoteAPrimColors[2] = {
+    /* static */ Color_RGB8 sOcarinaNoteAPrimColors[2] = {
         { 80, 150, 255 },
         { 100, 200, 255 },
     };
-    static Color_RGB8 sOcarinaNoteAEnvColors[2] = {
+    /* static */ Color_RGB8 sOcarinaNoteAEnvColors[2] = {
         { 10, 10, 10 },
         { 50, 50, 255 },
     };
@@ -2027,11 +2027,11 @@ void Message_DrawMain(PlayState* play, Gfx** p) {
         sOcarinaNoteAEnvColors[1] = (Color_RGB8){ 50, 255, 50 };
     }
 
-    static Color_RGB8 sOcarinaNoteCPrimColors[2] = {
+    /* static */ Color_RGB8 sOcarinaNoteCPrimColors[2] = {
         { 255, 255, 50 },
         { 255, 255, 180 },
     };
-    static Color_RGB8 sOcarinaNoteCEnvColors[2] = {
+    /* static */ Color_RGB8 sOcarinaNoteCEnvColors[2] = {
         { 10, 10, 10 },
         { 110, 110, 50 },
     };
@@ -2044,11 +2044,11 @@ void Message_DrawMain(PlayState* play, Gfx** p) {
         sOcarinaNoteCEnvColors[1].b = (color.b / 255) * 95;
     }
 
-    static Color_RGB8 sOcarinaNoteCUpPrimColors[2] = {
+    /* static */ Color_RGB8 sOcarinaNoteCUpPrimColors[2] = {
         { 255, 255, 50 },
         { 255, 255, 180 },
     };
-    static Color_RGB8 sOcarinaNoteCUpEnvColors[2] = {
+    /* static */ Color_RGB8 sOcarinaNoteCUpEnvColors[2] = {
         { 10, 10, 10 },
         { 110, 110, 50 },
     };
@@ -2061,11 +2061,11 @@ void Message_DrawMain(PlayState* play, Gfx** p) {
         sOcarinaNoteCUpEnvColors[1].b = (color.b / 255) * 95;
     }
 
-    static Color_RGB8 sOcarinaNoteCDownPrimColors[2] = {
+    /* static */ Color_RGB8 sOcarinaNoteCDownPrimColors[2] = {
         { 255, 255, 50 },
         { 255, 255, 180 },
     };
-    static Color_RGB8 sOcarinaNoteCDownEnvColors[2] = {
+    /* static */ Color_RGB8 sOcarinaNoteCDownEnvColors[2] = {
         { 10, 10, 10 },
         { 110, 110, 50 },
     };
@@ -2078,11 +2078,11 @@ void Message_DrawMain(PlayState* play, Gfx** p) {
         sOcarinaNoteCDownEnvColors[1].b = (color.b / 255) * 95;
     }
 
-    static Color_RGB8 sOcarinaNoteCLeftPrimColors[2] = {
+    /* static */ Color_RGB8 sOcarinaNoteCLeftPrimColors[2] = {
         { 255, 255, 50 },
         { 255, 255, 180 },
     };
-    static Color_RGB8 sOcarinaNoteCLeftEnvColors[2] = {
+    /* static */ Color_RGB8 sOcarinaNoteCLeftEnvColors[2] = {
         { 10, 10, 10 },
         { 110, 110, 50 },
     };
@@ -2095,11 +2095,11 @@ void Message_DrawMain(PlayState* play, Gfx** p) {
         sOcarinaNoteCLeftEnvColors[1].b = (color.b / 255) * 95;
     }
 
-    static Color_RGB8 sOcarinaNoteCRightPrimColors[2] = {
+    /* static */ Color_RGB8 sOcarinaNoteCRightPrimColors[2] = {
         { 255, 255, 50 },
         { 255, 255, 180 },
     };
-    static Color_RGB8 sOcarinaNoteCRightEnvColors[2] = {
+    /* static */ Color_RGB8 sOcarinaNoteCRightEnvColors[2] = {
         { 10, 10, 10 },
         { 110, 110, 50 },
     };

--- a/soh/src/code/z_message_PAL.c
+++ b/soh/src/code/z_message_PAL.c
@@ -463,9 +463,9 @@ void Message_DrawTextboxIcon(PlayState* play, Gfx** p, s16 x, s16 y) {
     };
     if (CVarGetInteger("gCosmetics.Hud_AButton.Changed", 0)) {
         Color_RGB8 color = CVarGetColor24("gCosmetics.Hud_AButton.Value", (Color_RGB8){ 50, 130, 255 });
-        sIconPrimColors[0].r = (color.r / 255) * 95;
-        sIconPrimColors[0].g = (color.g / 255) * 95;
-        sIconPrimColors[0].b = (color.b / 255) * 95;
+        sIconPrimColors[0].r = (color.r / 255.0f) * 200;
+        sIconPrimColors[0].g = (color.g / 255.0f) * 200;
+        sIconPrimColors[0].b = (color.b / 255.0f) * 200;
         sIconPrimColors[1] = color;
         sIconEnvColors[1] = color;
     } else if (CVarGetInteger("gCosmetics.DefaultColorScheme", COLORSCHEME_N64) == COLORSCHEME_GAMECUBE) {

--- a/soh/src/code/z_message_PAL.c
+++ b/soh/src/code/z_message_PAL.c
@@ -463,9 +463,9 @@ void Message_DrawTextboxIcon(PlayState* play, Gfx** p, s16 x, s16 y) {
     };
     if (CVarGetInteger("gCosmetics.Hud_AButton.Changed", 0)) {
         Color_RGB8 color = CVarGetColor24("gCosmetics.Hud_AButton.Value", (Color_RGB8){ 50, 130, 255 });
-        sIconPrimColors[0].r = (color.r / 255.0f) * 200;
-        sIconPrimColors[0].g = (color.g / 255.0f) * 200;
-        sIconPrimColors[0].b = (color.b / 255.0f) * 200;
+        sIconPrimColors[0].r = color.r - 50;
+        sIconPrimColors[0].g = color.g - 50;
+        sIconPrimColors[0].b = color.b - 50;
         sIconPrimColors[1] = color;
         sIconEnvColors[1] = color;
     } else if (CVarGetInteger("gCosmetics.DefaultColorScheme", COLORSCHEME_N64) == COLORSCHEME_GAMECUBE) {

--- a/soh/src/code/z_message_PAL.c
+++ b/soh/src/code/z_message_PAL.c
@@ -2016,9 +2016,9 @@ void Message_DrawMain(PlayState* play, Gfx** p) {
     };
     if (CVarGetInteger("gCosmetics.Hud_AButton.Changed", 0)) {
         Color_RGB8 color = CVarGetColor24("gCosmetics.Hud_AButton.Value", (Color_RGB8){ 100, 200, 255 });
-        sOcarinaNoteAPrimColors[0].r = (color.r / 255) * 95;
-        sOcarinaNoteAPrimColors[0].g = (color.g / 255) * 95;
-        sOcarinaNoteAPrimColors[0].b = (color.b / 255) * 95;
+        sOcarinaNoteAPrimColors[0].r = (color.r / 255.0f) * 95;
+        sOcarinaNoteAPrimColors[0].g = (color.g / 255.0f) * 95;
+        sOcarinaNoteAPrimColors[0].b = (color.b / 255.0f) * 95;
         sOcarinaNoteAPrimColors[1] = color;
         sOcarinaNoteAEnvColors[1] = color;
     } else if (CVarGetInteger("gCosmetics.DefaultColorScheme", COLORSCHEME_N64) == COLORSCHEME_GAMECUBE) {
@@ -2039,9 +2039,9 @@ void Message_DrawMain(PlayState* play, Gfx** p) {
         Color_RGB8 color = CVarGetColor24("gCosmetics.Hud_CButtons.Value", (Color_RGB8){ 100, 200, 255 });
         sOcarinaNoteCPrimColors[0] = color;
         sOcarinaNoteCPrimColors[1] = color;
-        sOcarinaNoteCEnvColors[1].r = (color.r / 255) * 95;
-        sOcarinaNoteCEnvColors[1].g = (color.g / 255) * 95;
-        sOcarinaNoteCEnvColors[1].b = (color.b / 255) * 95;
+        sOcarinaNoteCEnvColors[1].r = (color.r / 255.0f) * 95;
+        sOcarinaNoteCEnvColors[1].g = (color.g / 255.0f) * 95;
+        sOcarinaNoteCEnvColors[1].b = (color.b / 255.0f) * 95;
     }
 
     /* static */ Color_RGB8 sOcarinaNoteCUpPrimColors[2] = {
@@ -2056,9 +2056,9 @@ void Message_DrawMain(PlayState* play, Gfx** p) {
         Color_RGB8 color = CVarGetColor24("gCosmetics.Hud_CUpButton.Value", (Color_RGB8){ 100, 200, 255 });
         sOcarinaNoteCUpPrimColors[0] = color;
         sOcarinaNoteCUpPrimColors[1] = color;
-        sOcarinaNoteCUpEnvColors[1].r = (color.r / 255) * 95;
-        sOcarinaNoteCUpEnvColors[1].g = (color.g / 255) * 95;
-        sOcarinaNoteCUpEnvColors[1].b = (color.b / 255) * 95;
+        sOcarinaNoteCUpEnvColors[1].r = (color.r / 255.0f) * 95;
+        sOcarinaNoteCUpEnvColors[1].g = (color.g / 255.0f) * 95;
+        sOcarinaNoteCUpEnvColors[1].b = (color.b / 255.0f) * 95;
     }
 
     /* static */ Color_RGB8 sOcarinaNoteCDownPrimColors[2] = {
@@ -2073,9 +2073,9 @@ void Message_DrawMain(PlayState* play, Gfx** p) {
         Color_RGB8 color = CVarGetColor24("gCosmetics.Hud_CDownButton.Value", (Color_RGB8){ 100, 200, 255 });
         sOcarinaNoteCDownPrimColors[0] = color;
         sOcarinaNoteCDownPrimColors[1] = color;
-        sOcarinaNoteCDownEnvColors[1].r = (color.r / 255) * 95;
-        sOcarinaNoteCDownEnvColors[1].g = (color.g / 255) * 95;
-        sOcarinaNoteCDownEnvColors[1].b = (color.b / 255) * 95;
+        sOcarinaNoteCDownEnvColors[1].r = (color.r / 255.0f) * 95;
+        sOcarinaNoteCDownEnvColors[1].g = (color.g / 255.0f) * 95;
+        sOcarinaNoteCDownEnvColors[1].b = (color.b / 255.0f) * 95;
     }
 
     /* static */ Color_RGB8 sOcarinaNoteCLeftPrimColors[2] = {
@@ -2090,9 +2090,9 @@ void Message_DrawMain(PlayState* play, Gfx** p) {
         Color_RGB8 color = CVarGetColor24("gCosmetics.Hud_CLeftButton.Value", (Color_RGB8){ 100, 200, 255 });
         sOcarinaNoteCLeftPrimColors[0] = color;
         sOcarinaNoteCLeftPrimColors[1] = color;
-        sOcarinaNoteCLeftEnvColors[1].r = (color.r / 255) * 95;
-        sOcarinaNoteCLeftEnvColors[1].g = (color.g / 255) * 95;
-        sOcarinaNoteCLeftEnvColors[1].b = (color.b / 255) * 95;
+        sOcarinaNoteCLeftEnvColors[1].r = (color.r / 255.0f) * 95;
+        sOcarinaNoteCLeftEnvColors[1].g = (color.g / 255.0f) * 95;
+        sOcarinaNoteCLeftEnvColors[1].b = (color.b / 255.0f) * 95;
     }
 
     /* static */ Color_RGB8 sOcarinaNoteCRightPrimColors[2] = {
@@ -2107,9 +2107,9 @@ void Message_DrawMain(PlayState* play, Gfx** p) {
         Color_RGB8 color = CVarGetColor24("gCosmetics.Hud_CRightButton.Value", (Color_RGB8){ 100, 200, 255 });
         sOcarinaNoteCRightPrimColors[0] = color;
         sOcarinaNoteCRightPrimColors[1] = color;
-        sOcarinaNoteCRightEnvColors[1].r = (color.r / 255) * 95;
-        sOcarinaNoteCRightEnvColors[1].g = (color.g / 255) * 95;
-        sOcarinaNoteCRightEnvColors[1].b = (color.b / 255) * 95;
+        sOcarinaNoteCRightEnvColors[1].r = (color.r / 255.0f) * 95;
+        sOcarinaNoteCRightEnvColors[1].g = (color.g / 255.0f) * 95;
+        sOcarinaNoteCRightEnvColors[1].b = (color.b / 255.0f) * 95;
     }
 
     static s16 sOcarinaNoteFlashTimer = 12;


### PR DESCRIPTION
- Fix for text box icon colour not resetting after being edited, and fix pulsing effect when using custom colour (which was being truncated to black before). 
- Similar fixes for ocarina icon colours.
- Changes to vanilla code (removal of static declarations) are denoted as necessary.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1223953831.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1224006996.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1224009679.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1224022083.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1224023416.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1224026207.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1224069045.zip)
<!--- section:artifacts:end -->