### PR TITLE
[Fixes] Fix for Zora hint dialogue condition with an inverted flag check

### DIFF
--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -1211,6 +1211,8 @@ void DrawEnhancementsMenu() {
             UIWidgets::PaddedEnhancementCheckbox("Fix Darunia dancing too fast", "gEnhancements.FixDaruniaDanceSpeed",
                                                  true, false, false, "", UIWidgets::CheckboxGraphics::Cross, true);
             UIWidgets::Tooltip("Fixes Darunia's dancing speed so he dances to the beat of Saria's Song, like in vanilla.");
+            UIWidgets::PaddedEnhancementCheckbox("Fix Zora hint dialogue", "gFixZoraHintDialogue", true, false);
+            UIWidgets::Tooltip("Fixes one Zora's dialogue giving a hint about bringing Ruto's Letter to King Zora to properly occur before moving King Zora rather than after");
 
             ImGui::EndMenu();
         }

--- a/soh/src/overlays/actors/ovl_En_Zo/z_en_zo.c
+++ b/soh/src/overlays/actors/ovl_En_Zo/z_en_zo.c
@@ -427,8 +427,8 @@ u16 EnZo_GetTextId(PlayState* play, Actor* thisx) {
                 return 0x402D;
             }
 
-            if (CVarGetInteger("gFixZoraHintDialogue", 0) && !Flags_GetEventChkInf(EVENTCHKINF_KING_ZORA_MOVED) ||
-                !CVarGetInteger("gFixZoraHintDialogue", 0) && Flags_GetEventChkInf(EVENTCHKINF_KING_ZORA_MOVED)) {
+            if (!CVarGetInteger("gFixZoraHintDialogue", 0) && Flags_GetEventChkInf(EVENTCHKINF_KING_ZORA_MOVED) ||
+                CVarGetInteger("gFixZoraHintDialogue", 0) && Flags_GetEventChkInf(EVENTCHKINF_OBTAINED_RUTOS_LETTER)) {
                 return 0x4010;
             }
             if (Flags_GetEventChkInf(EVENTCHKINF_SPOKE_TO_A_ZORA)) {

--- a/soh/src/overlays/actors/ovl_En_Zo/z_en_zo.c
+++ b/soh/src/overlays/actors/ovl_En_Zo/z_en_zo.c
@@ -427,8 +427,9 @@ u16 EnZo_GetTextId(PlayState* play, Actor* thisx) {
                 return 0x402D;
             }
 
-            if (!CVarGetInteger("gFixZoraHintDialogue", 0) && Flags_GetEventChkInf(EVENTCHKINF_KING_ZORA_MOVED) ||
-                CVarGetInteger("gFixZoraHintDialogue", 0) && Flags_GetEventChkInf(EVENTCHKINF_OBTAINED_RUTOS_LETTER)) {
+            if (Flags_GetEventChkInf(EVENTCHKINF_KING_ZORA_MOVED) ||
+                (CVarGetInteger("gFixZoraHintDialogue", 0) &&
+                 Flags_GetEventChkInf(EVENTCHKINF_OBTAINED_RUTOS_LETTER))) {
                 return 0x4010;
             }
             if (Flags_GetEventChkInf(EVENTCHKINF_SPOKE_TO_A_ZORA)) {

--- a/soh/src/overlays/actors/ovl_En_Zo/z_en_zo.c
+++ b/soh/src/overlays/actors/ovl_En_Zo/z_en_zo.c
@@ -361,7 +361,7 @@ void EnZo_SpawnSplashes(EnZo* this) {
     }
 }
 
-u16 func_80B61024(PlayState* play, Actor* thisx) {
+u16 EnZo_GetTextId(PlayState* play, Actor* thisx) {
     u16 textId;
 
     textId = Text_GetFaceReaction(play, 29);
@@ -427,7 +427,8 @@ u16 func_80B61024(PlayState* play, Actor* thisx) {
                 return 0x402D;
             }
 
-            if (Flags_GetEventChkInf(EVENTCHKINF_KING_ZORA_MOVED)) {
+            if (CVarGetInteger("gFixZoraHintDialogue", 0) && !Flags_GetEventChkInf(EVENTCHKINF_KING_ZORA_MOVED) ||
+                !CVarGetInteger("gFixZoraHintDialogue", 0) && Flags_GetEventChkInf(EVENTCHKINF_KING_ZORA_MOVED)) {
                 return 0x4010;
             }
             if (Flags_GetEventChkInf(EVENTCHKINF_SPOKE_TO_A_ZORA)) {
@@ -520,7 +521,7 @@ void EnZo_Dialog(EnZo* this, PlayState* play) {
     }
     Npc_TrackPoint(&this->actor, &this->interactInfo, 11, this->trackingMode);
     if (this->canSpeak == true) {
-        Npc_UpdateTalking(play, &this->actor, &this->interactInfo.talkState, this->dialogRadius, func_80B61024,
+        Npc_UpdateTalking(play, &this->actor, &this->interactInfo.talkState, this->dialogRadius, EnZo_GetTextId,
                           func_80B61298);
     }
 }


### PR DESCRIPTION
One Zora is supposed to give a hint about bringing Ruto's Letter to King Zora, but due to the condition to check a flag being inverted, it only shows the dialogue *after* you've already shown the letter. This adds an optional fix to show this dialogue properly after finding the letter rather than after showing the letter.

First time speaking to a zora:
![image](https://github.com/HarbourMasters/Shipwright/assets/7520947/7c7530e0-2db4-4d49-b61f-bd74eba7d9d1)

Before finding letter:
![image](https://github.com/HarbourMasters/Shipwright/assets/7520947/4639bcc9-1441-442a-8497-6e5822d9992e)

After finding letter:
![image](https://github.com/HarbourMasters/Shipwright/assets/7520947/bd79224c-281c-416b-ba82-1288ecfb23d6)

After obtaining Sapphire:
![image](https://github.com/HarbourMasters/Shipwright/assets/7520947/81a93feb-ca91-44af-83b0-a1459b9b9c64)

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1239297993.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1239333744.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1239335434.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1239336834.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1239344487.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1239347362.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1239414228.zip)
<!--- section:artifacts:end -->