### PR TITLE
[Fix] GS Token giveItemId bleed between rando and vanilla saves

### DIFF
--- a/soh/src/overlays/actors/ovl_En_Si/z_en_si.c
+++ b/soh/src/overlays/actors/ovl_En_Si/z_en_si.c
@@ -16,6 +16,7 @@ void EnSi_Init(Actor* thisx, PlayState* play);
 void EnSi_Destroy(Actor* thisx, PlayState* play);
 void EnSi_Update(Actor* thisx, PlayState* play);
 void EnSi_Draw(Actor* thisx, PlayState* play);
+void EnSi_Reset();
 
 s32 func_80AFB748(EnSi* this, PlayState* play);
 void func_80AFB768(EnSi* this, PlayState* play);
@@ -61,7 +62,7 @@ const ActorInit En_Si_InitVars = {
     (ActorFunc)EnSi_Destroy,
     (ActorFunc)EnSi_Update,
     (ActorFunc)EnSi_Draw,
-    NULL,
+    (ActorResetFunc)EnSi_Reset,
 };
 
 void EnSi_Init(Actor* thisx, PlayState* play) {
@@ -222,6 +223,11 @@ void EnSi_Draw(Actor* thisx, PlayState* play) {
             GetItemEntry_Draw(play, getItem);
         }
     }
+}
+
+void EnSi_Reset() {
+    textId = 0xB4;
+    giveItemId = ITEM_SKULL_TOKEN;
 }
 
 void Randomizer_UpdateSkullReward(EnSi* this, PlayState* play) {


### PR DESCRIPTION
Currently, if you have rando and vanilla saves at the same time, collect a non-token item from a gold skulltula in the rando save, and just reset to select the vanilla save, all GS tokens will then give you the rando item, even though the token is rendered appropriately. This adds a reset function to z_en_si (GS Token) to set getItemId to vanilla after resetting SoH to prevent this. The reset function also resets the textId, just in case.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1235779571.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1235779572.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1235779573.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1235779576.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1235779577.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1235779578.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1235779579.zip)
<!--- section:artifacts:end -->