### PR TITLE
give early returns values

### DIFF
--- a/soh/src/code/z_camera.c
+++ b/soh/src/code/z_camera.c
@@ -1679,7 +1679,9 @@ s32 Camera_Normal1(Camera* camera) {
 
     if (anim->startSwingTimer <= 0) {
         // idle camera re-center
-        if (CVarGetInteger("gA11yDisableIdleCam", 0)) return;
+        if (CVarGetInteger("gA11yDisableIdleCam", 0)) {
+            return 1;
+        }
         eyeAdjustment.pitch = atEyeNextGeo.pitch;
         eyeAdjustment.yaw =
             Camera_LERPCeilS(anim->swingYawTarget, atEyeNextGeo.yaw, 1.0f / camera->yawUpdateRateInv, 0xA);

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -6611,7 +6611,9 @@ s32 func_8083E5A8(Player* this, PlayState* play) {
     if(gSaveContext.pendingIceTrapCount) {
         gSaveContext.pendingIceTrapCount--;
         GameInteractor_ExecuteOnItemReceiveHooks(ItemTable_RetrieveEntry(MOD_RANDOMIZER, RG_ICE_TRAP));
-        if (CVarGetInteger("gAddTraps.enabled", 0)) return;
+        if (CVarGetInteger("gAddTraps.enabled", 0)) {
+            return 1;
+        }
         this->stateFlags1 &= ~(PLAYER_STATE1_GETTING_ITEM | PLAYER_STATE1_ITEM_OVER_HEAD);
         this->actor.colChkInfo.damage = 0;
         func_80837C0C(play, this, 3, 0.0f, 0.0f, 0, 20);


### PR DESCRIPTION
quoting https://github.com/HarbourMasters/Shipwright/pull/3383#issuecomment-1937556245

> the tl;dr on why linux clang isn't happy  is `‘return’ with no value, in function returning non-void` errors
>
> if we turn on ` -Werror=return-type` we'll catch all of those, but also all the `control reaches end of non-void function` ones
>
> i do think turning on ` -Werror=return-type` and addressing all of those is something worth doing, but it's quite a big change

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1236449255.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1236458355.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1236459034.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1236459355.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1236461309.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1236461982.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1236465748.zip)
<!--- section:artifacts:end -->