### PR TITLE
TimelessEquipment - Preserve Link's last equipped sword for each age

### DIFF
--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -1440,17 +1440,16 @@ void Inventory_SwapAgeEquipment(void) {
     s16 i;
     u16 shieldEquipValue;
 
-    static u8 lastEquippedSwordChild = ITEM_NONE;
-    static u8 lastEquippedSwordAdult = ITEM_NONE;
-
-    //If TimlessEquipment is enable, preserve the last equipped sword for both Child and Adult Link across age transitions
+    // If TimlessEquipment is enabled, preserve the last equpped sword by age
     if (CVarGetInteger("gTimelessEquipment", 0)) {
         if (LINK_AGE_IN_YEARS == YEARS_CHILD) {
-            lastEquippedSwordAdult = gSaveContext.equips.buttonItems[0];
-            gSaveContext.equips.buttonItems[0] = lastEquippedSwordChild != ITEM_NONE ? lastEquippedSwordChild : gSaveContext.equips.buttonItems[0];
+            // Save the currently equipped sword for Child Link
+            gSaveContext.childEquips.buttonItems[0] = gSaveContext.equips.buttonItems[0];
         } else {
-            lastEquippedSwordChild = gSaveContext.equips.buttonItems[0];
-            gSaveContext.equips.buttonItems[0] = lastEquippedSwordAdult != ITEM_NONE ? lastEquippedSwordAdult : gSaveContext.equips.buttonItems[0];
+            // When transitioning from Adult to Child, re-equip Child Link's last equipped sword, if any was previously equipped
+            gSaveContext.equips.buttonItems[0] = (gSaveContext.childEquips.buttonItems[0] != ITEM_NONE) ? 
+                                                gSaveContext.childEquips.buttonItems[0] : 
+                                                gSaveContext.equips.buttonItems[0];
         }
     } else {
         if (LINK_AGE_IN_YEARS == YEARS_CHILD) {

--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -1957,8 +1957,10 @@ u8 Item_Give(PlayState* play, u8 item) {
             
         } else if (item == ITEM_SWORD_MASTER) {
             if (CVarGetInteger("gTimelessEquipment", 0)) {
-                // Do not equip the Master Sword if gTimelessEquipment is enabled
-                // This prevents child's last equipped sword from always being MS
+                // If gTimelessEquipment is enabled, only update the interface.
+                if (play != NULL) {
+                    Interface_LoadItemIcon1(play, 0);
+                }
             } else {
                 gSaveContext.equips.buttonItems[0] = ITEM_SWORD_MASTER;
                 gSaveContext.equips.equipment &= (u16) ~(0xF << (EQUIP_TYPE_SWORD * 4));


### PR DESCRIPTION
If TimelessEquipment is enabled,  it'll save the last sword equipped by Link before switching ages and restore it upon returning to that age.

For issue #3853 

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1238670691.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1238674871.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1238674964.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1238676132.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1238677078.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1238686208.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1238689459.zip)
<!--- section:artifacts:end -->