### PR TITLE
Add Big Skulltula logic to adult kokiri forest and fix a small bug in forest temple logic

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_forest_temple.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_forest_temple.cpp
@@ -170,7 +170,7 @@ void AreaTable_Init_ForestTemple() {
                   Entrance(RR_FOREST_TEMPLE_WEST_CORRIDOR,            {[]{return true;}}),
                   Entrance(RR_FOREST_TEMPLE_NW_OUTDOORS_UPPER,        {[]{return logic->CanUse(RG_HOVER_BOOTS) || (randoCtx->GetTrickOption(RT_FOREST_OUTSIDE_BACKDOOR) && logic->CanJumpslash && logic->GoronBracelet);}}),
                   Entrance(RR_FOREST_TEMPLE_NW_CORRIDOR_TWISTED,      {[]{return logic->IsAdult && logic->GoronBracelet && logic->SmallKeys(RR_FOREST_TEMPLE, 2);}}),
-                  Entrance(RR_FOREST_TEMPLE_NW_CORRIDOR_STRAIGHTENED, {[]{return (logic->CanUse(RG_FAIRY_BOW) || logic->CanUse(RG_FAIRY_SLINGSHOT)) && logic->GoronBracelet && logic->SmallKeys(RR_FOREST_TEMPLE, 2);}}),
+                  Entrance(RR_FOREST_TEMPLE_NW_CORRIDOR_STRAIGHTENED, {[]{return logic->IsAdult && (logic->CanUse(RG_FAIRY_BOW) || logic->CanUse(RG_FAIRY_SLINGSHOT)) && logic->GoronBracelet && logic->SmallKeys(RR_FOREST_TEMPLE, 2);}}),
   });
 
   areaTable[RR_FOREST_TEMPLE_NW_CORRIDOR_TWISTED] = Area("Forest Temple NW Corridor Twisted", "Forest Temple", RA_FOREST_TEMPLE, NO_DAY_NIGHT_CYCLE, {}, {}, {

--- a/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_lost_woods.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_lost_woods.cpp
@@ -24,7 +24,7 @@ void AreaTable_Init_LostWoods() {
                   Entrance(RR_KF_HOUSE_OF_TWINS,     {[]{return true;}}),
                   Entrance(RR_KF_KNOW_IT_ALL_HOUSE,  {[]{return true;}}),
                   Entrance(RR_KF_KOKIRI_SHOP,        {[]{return true;}}),
-                  Entrance(RR_KF_OUTSIDE_DEKU_TREE,  {[]{return logic->IsAdult || randoCtx->GetOption(RSK_FOREST).Is(RO_FOREST_OPEN) || logic->ShowedMidoSwordAndShield;}}),
+                  Entrance(RR_KF_OUTSIDE_DEKU_TREE,  {[]{return (logic->IsAdult && (logic->CanPassEnemy("Big Skulltula") || logic->ForestTempleClear)) || randoCtx->GetOption(RSK_FOREST).Is(RO_FOREST_OPEN) || logic->ShowedMidoSwordAndShield;}}),
                   Entrance(RR_THE_LOST_WOODS,        {[]{return true;}}),
                   Entrance(RR_LW_BRIDGE_FROM_FOREST, {[]{return logic->IsAdult || randoCtx->GetOption(RSK_FOREST).IsNot(RO_FOREST_CLOSED) || logic->DekuTreeClear;}}),
                   Entrance(RR_KF_STORMS_GROTTO,      {[]{return logic->CanOpenStormGrotto;}}),
@@ -42,7 +42,7 @@ void AreaTable_Init_LostWoods() {
                 }, {
                   //Exits
                   Entrance(RR_DEKU_TREE_ENTRYWAY, {[]{return logic->IsChild || (randoCtx->GetOption(RSK_SHUFFLE_DUNGEON_ENTRANCES).IsNot(RO_DUNGEON_ENTRANCE_SHUFFLE_OFF) && (randoCtx->GetOption(RSK_FOREST).Is(RO_FOREST_OPEN) || logic->ShowedMidoSwordAndShield));}}),
-                  Entrance(RR_KOKIRI_FOREST,      {[]{return logic->IsAdult || randoCtx->GetOption(RSK_FOREST).Is(RO_FOREST_OPEN) || logic->ShowedMidoSwordAndShield;}}),
+                  Entrance(RR_KOKIRI_FOREST,      {[]{return (logic->IsAdult && (logic->CanPassEnemy("Big Skulltula") || logic->ForestTempleClear)) || randoCtx->GetOption(RSK_FOREST).Is(RO_FOREST_OPEN) || logic->ShowedMidoSwordAndShield;}}),
   });
 
   areaTable[RR_KF_LINKS_HOUSE] = Area("KF Link's House", "KF Link's House", RA_NONE, NO_DAY_NIGHT_CYCLE, {}, {

--- a/soh/soh/Enhancements/randomizer/logic.cpp
+++ b/soh/soh/Enhancements/randomizer/logic.cpp
@@ -230,6 +230,26 @@ namespace Rando {
         return false;
     }
 
+    bool Logic::CanKillEnemy(std::string enemy) {
+        //switch(enemy) {} RANDOTODO implement enemies enum
+        if (enemy == "Big Skulltulla"){
+            return CanUse(RG_FAIRY_BOW) || CanUse(RG_FAIRY_SLINGSHOT) || CanJumpslash || CanUse(RG_MEGATON_HAMMER) || CanUse(RG_HOOKSHOT) || CanUse(RG_DINS_FIRE) || HasExplosives;
+        }
+        //Shouldn't be reached
+        return false;
+    }
+
+    bool Logic::CanPassEnemy(std::string enemy) {
+        //switch(enemy) {} RANDOTODO implement enemies enum
+        if (CanKillEnemy(enemy)){
+            return true;
+        }
+        if (enemy == "Big Skulltulla"){
+            return Nuts || CanUse(RG_BOOMERANG);
+        }
+        return false;
+    }
+
     Logic::Logic() {
         
     }

--- a/soh/soh/Enhancements/randomizer/logic.cpp
+++ b/soh/soh/Enhancements/randomizer/logic.cpp
@@ -232,7 +232,7 @@ namespace Rando {
 
     bool Logic::CanKillEnemy(std::string enemy) {
         //switch(enemy) {} RANDOTODO implement enemies enum
-        if (enemy == "Big Skulltulla"){
+        if (enemy == "Big Skulltula"){
             return CanUse(RG_FAIRY_BOW) || CanUse(RG_FAIRY_SLINGSHOT) || CanJumpslash || CanUse(RG_MEGATON_HAMMER) || CanUse(RG_HOOKSHOT) || CanUse(RG_DINS_FIRE) || HasExplosives;
         }
         //Shouldn't be reached
@@ -244,7 +244,7 @@ namespace Rando {
         if (CanKillEnemy(enemy)){
             return true;
         }
-        if (enemy == "Big Skulltulla"){
+        if (enemy == "Big Skulltula"){
             return Nuts || CanUse(RG_BOOMERANG);
         }
         return false;

--- a/soh/soh/Enhancements/randomizer/logic.h
+++ b/soh/soh/Enhancements/randomizer/logic.h
@@ -422,6 +422,8 @@ class Logic {
     bool SmallKeys(RandomizerRegion dungeon, uint8_t requiredAmountGlitchless, uint8_t requiredAmountGlitched);
     bool CanDoGlitch(GlitchType glitch);
     bool CanEquipSwap(RandomizerGet itemName);
+    bool CanKillEnemy(std::string enemy);
+    bool CanPassEnemy(std::string enemy);
     bool EventsUpdated();
     void Reset();
 


### PR DESCRIPTION
Specifically this is #3934 for V3, and also a fix for a logic bug where logic incorrectly thinks you need nothing to pass the big skulltula between kokiri and deku tree as adult. 

In order to make enemy kill logic clearer, and be a precursor for enemy rando in logic, I made 2 helper functions "CanPassEnemy" and "CanKillEnemy" which are similar to CanUse in that they ask for an enemy name and return if you can pass by or kill it. in the interests of keeping this PR small only this check uses it so far.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1246571690.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1246595045.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1246596523.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1246597833.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1246602950.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1246603527.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1246628961.zip)
<!--- section:artifacts:end -->