### PR TITLE
Add a link to ship.equipment to the CRC error message box during extraction

### DIFF
--- a/soh/soh/Extractor/Extract.cpp
+++ b/soh/soh/Extractor/Extract.cpp
@@ -107,7 +107,8 @@ void Extractor::ShowSizeErrorBox() const {
 }
 
 void Extractor::ShowCrcErrorBox() const {
-    ShowErrorBox("Rom CRC invalid", "Rom CRC did not match the list of known good roms. Please find another.");
+    ShowErrorBox("Rom CRC invalid", "Rom CRC did not match the list of known good roms. Please find another.\n\n"
+                                    "Visit https://ship.equipment/ to validate your ROM and see a list of compatible versions");
 }
 
 void Extractor::ShowCompressedErrorBox() const {
@@ -480,7 +481,7 @@ bool Extractor::Run(std::string searchPath, RomSearchMode searchMode) {
                 } else {
                     ShowErrorBox("Rom CRC invalid",
                                  "Rom CRC did not match the list of known good roms. Trying the next one...\n\n"
-                                 "Check if your ROM is valid at https://ship.equipment/");
+                                 "Visit https://ship.equipment/ to validate your ROM and see a list of compatible versions");
                 }
                 continue;
             }

--- a/soh/soh/Extractor/Extract.cpp
+++ b/soh/soh/Extractor/Extract.cpp
@@ -479,7 +479,8 @@ bool Extractor::Run(std::string searchPath, RomSearchMode searchMode) {
                     ShowCrcErrorBox();
                 } else {
                     ShowErrorBox("Rom CRC invalid",
-                                 "Rom CRC did not match the list of known good roms. Trying the next one...");
+                                 "Rom CRC did not match the list of known good roms. Trying the next one...\n\n"
+                                 "Check if your ROM is valid at https://ship.equipment/");
                 }
                 continue;
             }

--- a/soh/soh/Extractor/Extract.cpp
+++ b/soh/soh/Extractor/Extract.cpp
@@ -107,7 +107,7 @@ void Extractor::ShowSizeErrorBox() const {
 }
 
 void Extractor::ShowCrcErrorBox() const {
-    ShowErrorBox("Rom CRC invalid", "Rom CRC did not match the list of known good roms. Please find another.\n\n"
+    ShowErrorBox("Rom CRC invalid", "Rom CRC did not match the list of known compatible roms. Please find another.\n\n"
                                     "Visit https://ship.equipment/ to validate your ROM and see a list of compatible versions");
 }
 
@@ -480,7 +480,7 @@ bool Extractor::Run(std::string searchPath, RomSearchMode searchMode) {
                     ShowCrcErrorBox();
                 } else {
                     ShowErrorBox("Rom CRC invalid",
-                                 "Rom CRC did not match the list of known good roms. Trying the next one...\n\n"
+                                 "Rom CRC did not match the list of known compatible roms. Trying the next one...\n\n"
                                  "Visit https://ship.equipment/ to validate your ROM and see a list of compatible versions");
                 }
                 continue;


### PR DESCRIPTION
Currently the extraction process gives no helpful information when a CRC fails. This is likely the most impactful minimal change to help our support team deal with fewer issues here just by directing people to the https://ship.equipment/ page to check their ROM and see a list of compatible versions.

![image](https://github.com/HarbourMasters/Shipwright/assets/7520947/9f5936f7-1a88-43df-9437-6ba804652dd5)

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1249649331.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1249651555.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1249651763.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1249651799.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1249652427.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1249658541.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1249659348.zip)
<!--- section:artifacts:end -->