### PR TITLE
Fix endianess issue with camera setting data

### DIFF
--- a/soh/src/code/z_camera_data.inc
+++ b/soh/src/code/z_camera_data.inc
@@ -16,9 +16,11 @@ typedef struct {
     union {
         u32 unk_00;
         struct {
-            u32 unk_bit0 : 1;
-            u32 unk_bit1 : 1;
-            u32 validModes : 30;
+            // SoH [Port] These bitfield values are unused and led to shifting in validModes for little endian systems
+            // Removing those so that validModes can be a complete 32 bit value
+            // u32 unk_bit0 : 1;
+            // u32 unk_bit1 : 1;
+            u32 validModes;
         };
     };
     CameraMode* cameraModes;


### PR DESCRIPTION
The camera settings struct was using a union member and bitfield flags to pack a single 32bit int as multiple values. This assumes Big Endian (N64 hardware). On Little Endian systems, this led to `validModes` being shifted by 2 bits causing some validation functions to behave incorrectly (couldn't C-Up in the fishing pond or bombchu bowling lobby).

The other two single bit values are unused, so I've decided to just remove them and the bitfield flags so that `validModes` is just treated as the full 32bit value. This fixes #1253.

I've also confirmed this change works on Wii U (Big Endian).

Here is a print out of some of the values before and after, with the first person mode highlighted.
Before:
![cam-modes-before](https://github.com/HarbourMasters/Shipwright/assets/13861068/837f8976-22d1-4242-8336-2a3d28d8e0a2)

After:
![cam-mode-after](https://github.com/HarbourMasters/Shipwright/assets/13861068/2c380cf9-7a06-4706-b5a5-74b4bafc73fd)


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1255011393.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1255012477.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1255012494.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1255012952.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1255013538.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1255016057.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1255016137.zip)
<!--- section:artifacts:end -->