### PR TITLE
Fix performance of DList viewer

### DIFF
--- a/soh/soh/Enhancements/debugger/dlViewer.cpp
+++ b/soh/soh/Enhancements/debugger/dlViewer.cpp
@@ -9,7 +9,6 @@
 #include <bit>
 #include <map>
 #include <string>
-#include <regex>
 #include <libultraship/libultraship.h>
 #include "dlViewer.h"
 
@@ -68,14 +67,12 @@ std::map<int, std::string> cmdMap = {
 void PerformDisplayListSearch() {
     auto result = LUS::Context::GetInstance()->GetResourceManager()->GetArchiveManager()->ListFiles("*" + std::string(searchString) + "*DL*");
 
-    std::regex dlSearch(".*((DL)|(DL_.*))$");
-
     displayListSearchResults.clear();
 
     // Filter the file results even further as StormLib can only use wildcard searching
     for (size_t i = 0; i < result->size(); i++) {
         std::string val = result->at(i);
-        if (std::regex_search(val.c_str(), dlSearch)) {
+        if (val.ends_with("DL") || val.find("DL_") != std::string::npos) {
             displayListSearchResults.push_back(val);
         }
     }
@@ -98,8 +95,6 @@ void DLViewerWindow::DrawElement() {
         ImGui::End();
         return;
     }
-
-    ImGui::Text("%d", searchDebounceFrames);
 
     // Debounce the search field as listing otr files is expensive
     if (ImGui::InputText("Search Display Lists", searchString, ARRAY_COUNT(searchString))) {


### PR DESCRIPTION
Per findings from @Rozelette, the DList viewer was using an expensive regex that caused slowdowns of 9+ seconds in MSVC debug mode.

Since the search itself is simple, we can ditch the regex from normal string methods that are much more performant.

Before:
![image](https://github.com/HarbourMasters/Shipwright/assets/13861068/ff4003cd-9a4f-4827-9f51-4209630cc481)

After:
![image](https://github.com/HarbourMasters/Shipwright/assets/13861068/3cb649e2-acc0-423f-ab1d-b30fbd43241c)

---
Also removed a left over visualization of the debounced frame timer.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1260843327.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1260880552.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1260882969.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1260883810.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1260892467.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1260895428.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1260911272.zip)
<!--- section:artifacts:end -->