### PR TITLE
Fix swim softlock

### DIFF
--- a/soh/soh/Enhancements/mods.cpp
+++ b/soh/soh/Enhancements/mods.cpp
@@ -1464,40 +1464,44 @@ typedef struct {
 //special respawns used when voided out without swim to prevent infinite loops
 std::map<s32, SpecialRespawnInfo> swimSpecialRespawnInfo = {
     {
-        0x1D9,//hf to zr in water
+        ENTR_ZORAS_RIVER_3,//hf to zr in water
         { { -1455.443, -20, 1384.826 }, 28761 }
     },
     {
-        0x311,//zr to hf in water
+        ENTR_HYRULE_FIELD_14,//zr to hf in water
         { { 5830.209, -92.16, 3925.911 }, -20025 }
     },
     {
-        0x4DA,//zr to lw
+        ENTR_LOST_WOODS_7,//zr to lw
         { { 1978.718, -36.908, -855 }, -16384 }
     },
     {
-        0x1DD,//lw to zr
+        ENTR_ZORAS_RIVER_4,//lw to zr
         { { 4082.366, 860.442, -1018.949 }, -32768 }
     },
     {
-        0x219,//gv to lh
+        ENTR_LAKE_HYLIA_1,//gv to lh
         { { -3276.416, -1033, 2908.421 }, 11228 }
     },
     {
-        0x10,//lh to water temple
+        ENTR_WATER_TEMPLE_0,//lh to water temple
         { { -182, 780, 759.5 }, -32768 }
     },
     {
-        0x21D,//water temple to lh
+        ENTR_LAKE_HYLIA_2,//water temple to lh
         { { -955.028, -1306.9, 6768.954 }, -32768 }
     },
     {
-        0x328,//lh to zd
+        ENTR_ZORAS_DOMAIN_4,//lh to zd
         { { -109.86, 11.396, -9.933 }, -29131 }
     },
     {
-        0x560,//zd to lh
+        ENTR_LAKE_HYLIA_7,//zd to lh
         { { -912, -1326.967, 3391 }, 0 }
+    },
+    {
+        ENTR_GERUDO_VALLEY_1,//caught by gerudos as child
+        { { -74.5, -70, -116.5 }, -16384 }
     }
 };
 

--- a/soh/soh/Enhancements/mods.cpp
+++ b/soh/soh/Enhancements/mods.cpp
@@ -1501,7 +1501,7 @@ std::map<s32, SpecialRespawnInfo> swimSpecialRespawnInfo = {
     },
     {
         ENTR_GERUDO_VALLEY_1,//caught by gerudos as child
-        { { -74.5, -70, -116.5 }, -16384 }
+        { { -424, -2051, -74 }, 16384 }
     }
 };
 


### PR DESCRIPTION
Fixes the softlock when getting caught by the gerudos as child without swim.
Also changed the entrances to use the enum rather than raw values.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1330668313.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1330705806.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1330706440.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1330708494.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1330712298.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1330713904.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1330720887.zip)
<!--- section:artifacts:end -->