### PR TITLE
Tweak: Prevent remember save location in dungeons/boss rooms

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer_entrance.c
+++ b/soh/soh/Enhancements/randomizer/randomizer_entrance.c
@@ -398,6 +398,11 @@ void Entrance_SetSavewarpEntrance(void) {
         gSaveContext.entranceIndex = 0x0486; // Gerudo Fortress -> Thieve's Hideout spawn 0
     } else if (scene == SCENE_LINKS_HOUSE) {
         gSaveContext.entranceIndex = Entrance_OverrideNextIndex(LINK_HOUSE_SAVEWARP_ENTRANCE);
+    } else if (CVarGetInteger("gRememberSaveLocation", 0) && scene != SCENE_FAIRYS_FOUNTAIN && scene != SCENE_GROTTOS &&
+               // Use the saved entrance value with remember save location, except when in grottos/fairy fountains or if
+               // the entrance index is -1 (new save)
+               gSaveContext.entranceIndex != -1) {
+        return;
     } else if (LINK_IS_CHILD) {
         gSaveContext.entranceIndex = Entrance_OverrideNextIndex(LINK_HOUSE_SAVEWARP_ENTRANCE); // Child Overworld Spawn
     } else {

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -558,7 +558,7 @@ void DrawEnhancementsMenu() {
                 UIWidgets::Tooltip("Pierre appears when Ocarina is pulled out. Requires learning scarecrow song.");
                 UIWidgets::PaddedEnhancementCheckbox("Remember Save Location", "gRememberSaveLocation", true, false);
                 UIWidgets::Tooltip("When loading a save, places Link at the last entrance he went through.\n"
-                        "This doesn't work if the save was made in a grotto.");
+                        "This doesn't work if the save was made in grottos/fairy fountains or dungeons.");
                 UIWidgets::PaddedEnhancementCheckbox("Skip Magic Arrow Equip Animation", "gSkipArrowAnimation", true, false);
                 UIWidgets::PaddedEnhancementCheckbox("Skip save confirmation", "gSkipSaveConfirmation", true, false);
                 UIWidgets::Tooltip("Skip the \"Game saved.\" confirmation screen");

--- a/soh/src/code/z_sram.c
+++ b/soh/src/code/z_sram.c
@@ -59,65 +59,68 @@ void Sram_OpenSave() {
 
     Save_LoadFile();
 
-    if (!CVarGetInteger("gRememberSaveLocation", 0) || gSaveContext.savedSceneNum == SCENE_FAIRYS_FOUNTAIN ||
-        gSaveContext.savedSceneNum == SCENE_GROTTOS) {
-        switch (gSaveContext.savedSceneNum) {
-            case SCENE_DEKU_TREE:
-            case SCENE_DODONGOS_CAVERN:
-            case SCENE_JABU_JABU:
-            case SCENE_FOREST_TEMPLE:
-            case SCENE_FIRE_TEMPLE:
-            case SCENE_WATER_TEMPLE:
-            case SCENE_SPIRIT_TEMPLE:
-            case SCENE_SHADOW_TEMPLE:
-            case SCENE_BOTTOM_OF_THE_WELL:
-            case SCENE_ICE_CAVERN:
-            case SCENE_GANONS_TOWER:
-            case SCENE_GERUDO_TRAINING_GROUND:
-            case SCENE_THIEVES_HIDEOUT:
-            case SCENE_INSIDE_GANONS_CASTLE:
-                gSaveContext.entranceIndex = dungeonEntrances[gSaveContext.savedSceneNum];
-                break;
-            case SCENE_DEKU_TREE_BOSS:
-                gSaveContext.entranceIndex = 0;
-                break;
-            case SCENE_DODONGOS_CAVERN_BOSS:
-                gSaveContext.entranceIndex = 4;
-                break;
-            case SCENE_JABU_JABU_BOSS:
-                gSaveContext.entranceIndex = 0x28;
-                break;
-            case SCENE_FOREST_TEMPLE_BOSS:
-                gSaveContext.entranceIndex = 0x169;
-                break;
-            case SCENE_FIRE_TEMPLE_BOSS:
-                gSaveContext.entranceIndex = 0x165;
-                break;
-            case SCENE_WATER_TEMPLE_BOSS:
-                gSaveContext.entranceIndex = 0x10;
-                break;
-            case SCENE_SPIRIT_TEMPLE_BOSS:
-                gSaveContext.entranceIndex = 0x82;
-                break;
-            case SCENE_SHADOW_TEMPLE_BOSS:
-                gSaveContext.entranceIndex = 0x37;
-                break;
-            case SCENE_GANONS_TOWER_COLLAPSE_INTERIOR:
-            case SCENE_INSIDE_GANONS_CASTLE_COLLAPSE:
-            case SCENE_GANONDORF_BOSS:
-            case SCENE_GANONS_TOWER_COLLAPSE_EXTERIOR:
-            case SCENE_GANON_BOSS:
-                gSaveContext.entranceIndex = 0x41B;
-                break;
+    switch (gSaveContext.savedSceneNum) {
+        case SCENE_DEKU_TREE:
+        case SCENE_DODONGOS_CAVERN:
+        case SCENE_JABU_JABU:
+        case SCENE_FOREST_TEMPLE:
+        case SCENE_FIRE_TEMPLE:
+        case SCENE_WATER_TEMPLE:
+        case SCENE_SPIRIT_TEMPLE:
+        case SCENE_SHADOW_TEMPLE:
+        case SCENE_BOTTOM_OF_THE_WELL:
+        case SCENE_ICE_CAVERN:
+        case SCENE_GANONS_TOWER:
+        case SCENE_GERUDO_TRAINING_GROUND:
+        case SCENE_THIEVES_HIDEOUT:
+        case SCENE_INSIDE_GANONS_CASTLE:
+            gSaveContext.entranceIndex = dungeonEntrances[gSaveContext.savedSceneNum];
+            break;
+        case SCENE_DEKU_TREE_BOSS:
+            gSaveContext.entranceIndex = 0;
+            break;
+        case SCENE_DODONGOS_CAVERN_BOSS:
+            gSaveContext.entranceIndex = 4;
+            break;
+        case SCENE_JABU_JABU_BOSS:
+            gSaveContext.entranceIndex = 0x28;
+            break;
+        case SCENE_FOREST_TEMPLE_BOSS:
+            gSaveContext.entranceIndex = 0x169;
+            break;
+        case SCENE_FIRE_TEMPLE_BOSS:
+            gSaveContext.entranceIndex = 0x165;
+            break;
+        case SCENE_WATER_TEMPLE_BOSS:
+            gSaveContext.entranceIndex = 0x10;
+            break;
+        case SCENE_SPIRIT_TEMPLE_BOSS:
+            gSaveContext.entranceIndex = 0x82;
+            break;
+        case SCENE_SHADOW_TEMPLE_BOSS:
+            gSaveContext.entranceIndex = 0x37;
+            break;
+        case SCENE_GANONS_TOWER_COLLAPSE_INTERIOR:
+        case SCENE_INSIDE_GANONS_CASTLE_COLLAPSE:
+        case SCENE_GANONDORF_BOSS:
+        case SCENE_GANONS_TOWER_COLLAPSE_EXTERIOR:
+        case SCENE_GANON_BOSS:
+            gSaveContext.entranceIndex = 0x41B;
+            break;
 
-            default:
-                if (gSaveContext.savedSceneNum != SCENE_LINKS_HOUSE) {
-                    gSaveContext.entranceIndex = (LINK_AGE_IN_YEARS == YEARS_CHILD) ? 0xBB : 0x5F4;
-                } else {
-                    gSaveContext.entranceIndex = 0xBB;
-                }
+        default:
+            // Use the saved entrance value with remember save location, except when in grottos/fairy fountains
+            if (CVarGetInteger("gRememberSaveLocation", 0) && gSaveContext.savedSceneNum != SCENE_FAIRYS_FOUNTAIN &&
+                gSaveContext.savedSceneNum != SCENE_GROTTOS) {
                 break;
-        }
+            }
+
+            if (gSaveContext.savedSceneNum != SCENE_LINKS_HOUSE) {
+                gSaveContext.entranceIndex = (LINK_AGE_IN_YEARS == YEARS_CHILD) ? 0xBB : 0x5F4;
+            } else {
+                gSaveContext.entranceIndex = 0xBB;
+            }
+            break;
     }
 
     osSyncPrintf("scene_no = %d\n", gSaveContext.entranceIndex);

--- a/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -3036,11 +3036,7 @@ void FileChoose_LoadGame(GameState* thisx) {
         Entrance_Init();
 
         // Handle randomized spawn positions after the save context has been setup from load
-        // When remeber save location is on, set save warp if the save was in an a grotto, or
-        // the entrance index is -1 from shuffle overwarld spawn
-        if (Randomizer_GetSettingValue(RSK_SHUFFLE_ENTRANCES) && ((!CVarGetInteger("gRememberSaveLocation", 0) ||
-            gSaveContext.savedSceneNum == SCENE_FAIRYS_FOUNTAIN || gSaveContext.savedSceneNum == SCENE_GROTTOS) ||
-            (CVarGetInteger("gRememberSaveLocation", 0) && Randomizer_GetSettingValue(RSK_SHUFFLE_OVERWORLD_SPAWNS) && gSaveContext.entranceIndex == -1))) {
+        if (Randomizer_GetSettingValue(RSK_SHUFFLE_ENTRANCES)) {
             Entrance_SetSavewarpEntrance();
         }
     }


### PR DESCRIPTION
The remember save location often just leaves users stuck in a boss room or ganons fight with no way out unless you disable the enhancement.

This tweaks it so that dungeons and boss rooms will still return you to their vanilla location, but interiors/overworld are still remembered.