### PR TITLE
Fix CVar evaluation for scummed checks being hidden

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -1337,7 +1337,7 @@ void DrawLocation(RandomizerCheckObject rcObj) {
                     CVarGetColor("gCheckTrackerSeenMainColor", Color_Main_Default);
         extraColor = CVarGetColor("gCheckTrackerSeenExtraColor", Color_Seen_Extra_Default);
     } else if (status == RCSHOW_SCUMMED) {
-        if (!showHidden && CVarGetInteger("gCheckTrackerKnownHide", 0)) {
+        if (!showHidden && CVarGetInteger("gCheckTrackerScummedHide", 0)) {
             return;
         }
         mainColor = !IsHeartPiece(rcObj.ogItemId) && !IS_RANDO ? CVarGetColor("gCheckTrackerScummedExtraColor", Color_Scummed_Extra_Default) :


### PR DESCRIPTION
The check for whether it *should* be hidden was using `gCheckTrackerKnownHide` instead of `ScummedHide`, so they weren't properly hiding when specified to.