### PR TITLE
Fix: Actor init flow with object loading

### DIFF
--- a/soh/src/code/z_actor.c
+++ b/soh/src/code/z_actor.c
@@ -1220,7 +1220,7 @@ void Actor_Init(Actor* actor, PlayState* play) {
     actor->floorBgId = BGCHECK_SCENE;
     ActorShape_Init(&actor->shape, 0.0f, NULL, 0.0f);
     if (Object_IsLoaded(&play->objectCtx, actor->objBankIndex)) {
-        //Actor_SetObjectDependency(play, actor);
+        Actor_SetObjectDependency(play, actor);
         actor->init(actor, play);
         actor->init = NULL;
 
@@ -2548,6 +2548,13 @@ void Actor_UpdateAll(PlayState* play, ActorContext* actorCtx) {
                     Actor_SetObjectDependency(play, actor);
                     actor->init(actor, play);
                     actor->init = NULL;
+
+                    GameInteractor_ExecuteOnActorInit(actor);
+
+                    // For enemy health bar we need to know the max health during init
+                    if (actor->category == ACTORCAT_ENEMY) {
+                        actor->maximumHealth = actor->colChkInfo.health;
+                    }
                 }
                 actor = actor->next;
             } else if (!Object_IsLoaded(&play->objectCtx, actor->objBankIndex)) {


### PR DESCRIPTION
After adding back the object loaded detection for actors, there is now a second actor init path when the actor's object hasn't loaded during the first init check. This second init location was missing our custom logic for hooks and the enemy health bar handling.

Targeting develop, but if we think we may push out a new macready in the future, we'd probably just want to cherry pick this.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1392389118.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1392401949.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1392402426.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1392402782.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1392405196.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1392406000.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1392410804.zip)
<!--- section:artifacts:end -->