### PR TITLE
[Fix] Disable Lod Applies To Everything

### DIFF
--- a/soh/src/code/z_fcurve_data_skelanime.c
+++ b/soh/src/code/z_fcurve_data_skelanime.c
@@ -131,6 +131,10 @@ void SkelCurve_DrawLimb(PlayState* play, s32 limbIndex, SkelAnimeCurve* skelCurv
         Matrix_TranslateRotateZYX(&pos, &rot);
         Matrix_Scale(scale.x, scale.y, scale.z, MTXMODE_APPLY);
 
+        if (CVarGetInteger("gDisableLOD", 0)) {
+            lod = 0;
+        }
+
         if (lod == 0) {
             s32 pad1;
 

--- a/soh/src/code/z_skelanime.c
+++ b/soh/src/code/z_skelanime.c
@@ -28,6 +28,10 @@ void SkelAnime_DrawLimbLod(PlayState* play, s32 limbIndex, void** skeleton, Vec3
     Vec3f pos;
     Vec3s rot;
 
+    if (CVarGetInteger("gDisableLOD", 0)) {
+        lod = 0;
+    }
+
     OPEN_DISPS(play->state.gfxCtx);
 
     Matrix_Push();
@@ -135,6 +139,10 @@ void SkelAnime_DrawFlexLimbLod(PlayState* play, s32 limbIndex, void** skeleton, 
     Vec3f pos;
     Vec3s rot;
 
+    if (CVarGetInteger("gDisableLOD", 0)) {
+        lod = 0;
+    }
+
     Matrix_Push();
 
     limb = (LodLimb*)SEGMENTED_TO_VIRTUAL(skeleton[limbIndex]);
@@ -194,6 +202,10 @@ void SkelAnime_DrawFlexLod(PlayState* play, void** skeleton, Vec3s* jointTable, 
     Vec3f pos;
     Vec3s rot;
     Mtx* mtx = Graph_Alloc(play->state.gfxCtx, dListCount * sizeof(Mtx));
+
+    if (CVarGetInteger("gDisableLOD", 0)) {
+        lod = 0;
+    }
 
     if (skeleton == NULL) {
         osSyncPrintf(VT_FGCOL(RED));

--- a/soh/src/code/z_skelanime.c
+++ b/soh/src/code/z_skelanime.c
@@ -28,10 +28,6 @@ void SkelAnime_DrawLimbLod(PlayState* play, s32 limbIndex, void** skeleton, Vec3
     Vec3f pos;
     Vec3s rot;
 
-    if (CVarGetInteger("gDisableLOD", 0)) {
-        lod = 0;
-    }
-
     OPEN_DISPS(play->state.gfxCtx);
 
     Matrix_Push();
@@ -138,10 +134,6 @@ void SkelAnime_DrawFlexLimbLod(PlayState* play, s32 limbIndex, void** skeleton, 
     Gfx* limbDList;
     Vec3f pos;
     Vec3s rot;
-
-    if (CVarGetInteger("gDisableLOD", 0)) {
-        lod = 0;
-    }
 
     Matrix_Push();
 

--- a/soh/src/code/z_skelanime.c
+++ b/soh/src/code/z_skelanime.c
@@ -78,6 +78,10 @@ void SkelAnime_DrawLod(PlayState* play, void** skeleton, Vec3s* jointTable,
     Vec3f pos;
     Vec3s rot;
 
+    if (CVarGetInteger("gDisableLOD", 0)) {
+        lod = 0;
+    }
+
     if (skeleton == NULL) {
         osSyncPrintf(VT_FGCOL(RED));
         osSyncPrintf("Si2_Lod_draw():skelがNULLです。\n"); // "skel is NULL."

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -11892,10 +11892,6 @@ void Player_Draw(Actor* thisx, PlayState* play2) {
             lod = 1;
         }
 
-        if (CVarGetInteger("gDisableLOD", 0) != 0) {
-            lod = 0;
-        }
-
         func_80093C80(play);
         Gfx_SetupDL_25Xlu(play->state.gfxCtx);
 

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -11892,6 +11892,10 @@ void Player_Draw(Actor* thisx, PlayState* play2) {
             lod = 1;
         }
 
+        if (CVarGetInteger("gDisableLOD", 0)) {
+            lod = 0;
+        }
+
         func_80093C80(play);
         Gfx_SetupDL_25Xlu(play->state.gfxCtx);
 


### PR DESCRIPTION
Addresses #3978 

It looks as though gDisableLod only applies to player limbs and not others. This adds a cvar check to inside the respsective functions they are handled, although the player check is still required due to additional checks against the lod within the player draw flow.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1287566054.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1287600228.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1287603440.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1287603656.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1287609538.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1287610150.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1287619440.zip)
<!--- section:artifacts:end -->