### PR TITLE
Fix Switch Puzzles Not Setting as Solved

### DIFF
--- a/soh/src/code/z_bgcheck.c
+++ b/soh/src/code/z_bgcheck.c
@@ -398,7 +398,7 @@ s32 CollisionPoly_LineVsPoly(CollisionPoly* poly, Vec3s* vtxList, Vec3f* posA, V
         (poly->normal.x * posB->x + poly->normal.y * posB->y + poly->normal.z * posB->z) * COLPOLY_NORMAL_FRAC +
         plane.originDist;
 
-#ifdef __WIIU__
+#if defined(__SWITCH__) || defined(__WIIU__)
     // on some platforms this ends up as very small numbers due to rounding issues
     if (IS_ZERO(planeDistA)) {
         planeDistA = 0.0f;


### PR DESCRIPTION
Based on https://github.com/HarbourMasters/Shipwright/pull/28#issuecomment-1120377443 I have added switch to the ifdef checks here. I do not have any means of testing this out right now unfortunately.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1292867326.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1292878768.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1292879922.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1292881870.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1292882545.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1292883137.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1292891865.zip)
<!--- section:artifacts:end -->