### PR TITLE
tts: use `RawJson` resource + add `SpeechLogger`

### DIFF
--- a/soh/soh/Enhancements/speechsynthesizer/SpeechLogger.cpp
+++ b/soh/soh/Enhancements/speechsynthesizer/SpeechLogger.cpp
@@ -1,0 +1,16 @@
+#include "SpeechLogger.h"
+#include <libultraship/libultraship.h>
+
+SpeechLogger::SpeechLogger() {
+}
+
+void SpeechLogger::Speak(const char* text, const char* language) {
+    lusprintf(__FILE__, __LINE__, 2, "Spoken Text (%s): %s", language, text);
+}
+
+bool SpeechLogger::DoInit() {
+    return true;
+}
+
+void SpeechLogger::DoUninitialize() {
+}

--- a/soh/soh/Enhancements/speechsynthesizer/SpeechLogger.h
+++ b/soh/soh/Enhancements/speechsynthesizer/SpeechLogger.h
@@ -1,0 +1,17 @@
+#ifndef SOHSpeechLogger_h
+#define SOHSpeechLogger_h
+
+#include "SpeechSynthesizer.h"
+
+class SpeechLogger : public SpeechSynthesizer {
+  public:
+    SpeechLogger();
+
+    void Speak(const char* text, const char* language);
+
+  protected:
+    bool DoInit(void);
+    void DoUninitialize(void);
+};
+
+#endif

--- a/soh/soh/Enhancements/speechsynthesizer/SpeechSynthesizer.h
+++ b/soh/soh/Enhancements/speechsynthesizer/SpeechSynthesizer.h
@@ -36,3 +36,5 @@ class SpeechSynthesizer {
 #elif defined(__APPLE__)
 #include "DarwinSpeechSynthesizer.h"
 #endif
+
+#include "SpeechLogger.h"

--- a/soh/soh/Enhancements/tts/tts.cpp
+++ b/soh/soh/Enhancements/tts/tts.cpp
@@ -11,6 +11,8 @@
 #include "message_data_static.h"
 #include "overlays/gamestates/ovl_file_choose/file_choose.h"
 #include "soh/Enhancements/boss-rush/BossRush.h"
+#include "soh/resource/type/SohResourceType.h"
+#include "soh/resource/type/RawJson.h"
 
 extern "C" {
 extern MapData* gMapData;
@@ -1037,25 +1039,22 @@ void InitTTSBank() {
             break;
     }
 
-    auto sceneFile = LUS::Context::GetInstance()->GetResourceManager()->GetArchiveManager()->LoadFileRaw("accessibility/texts/scenes" + languageSuffix);
-    if (sceneFile != nullptr) {
-        sceneMap = nlohmann::json::parse(*sceneFile->Buffer.get(), nullptr, true, true);
-    }
+    auto initData = std::make_shared<LUS::ResourceInitData>();
+    initData->Format = RESOURCE_FORMAT_BINARY;
+    initData->Type = static_cast<uint32_t>(SOH::ResourceType::SOH_RawJson);
+    initData->ResourceVersion = 0;
     
-    auto miscFile = LUS::Context::GetInstance()->GetResourceManager()->GetArchiveManager()->LoadFileRaw("accessibility/texts/misc" + languageSuffix);
-    if (miscFile != nullptr) {
-        miscMap = nlohmann::json::parse(*miscFile->Buffer.get(), nullptr, true, true);
-    }
-    
-    auto kaleidoFile = LUS::Context::GetInstance()->GetResourceManager()->GetArchiveManager()->LoadFileRaw("accessibility/texts/kaleidoscope" + languageSuffix);
-    if (kaleidoFile != nullptr) {
-        kaleidoMap = nlohmann::json::parse(*kaleidoFile->Buffer.get(), nullptr, true, true);
-    }
-    
-    auto fileChooseFile = LUS::Context::GetInstance()->GetResourceManager()->GetArchiveManager()->LoadFileRaw("accessibility/texts/filechoose" + languageSuffix);
-    if (fileChooseFile != nullptr) {
-        fileChooseMap = nlohmann::json::parse(*fileChooseFile->Buffer.get(), nullptr, true, true);
-    }
+    sceneMap = std::static_pointer_cast<SOH::RawJson>(
+        LUS::Context::GetInstance()->GetResourceManager()->LoadResource("accessibility/texts/scenes" + languageSuffix, true, initData))->Data;
+
+    miscMap = std::static_pointer_cast<SOH::RawJson>(
+        LUS::Context::GetInstance()->GetResourceManager()->LoadResource("accessibility/texts/misc" + languageSuffix, true, initData))->Data;
+
+    kaleidoMap = std::static_pointer_cast<SOH::RawJson>(
+        LUS::Context::GetInstance()->GetResourceManager()->LoadResource("accessibility/texts/kaleidoscope" + languageSuffix, true, initData))->Data;
+
+    fileChooseMap = std::static_pointer_cast<SOH::RawJson>(
+        LUS::Context::GetInstance()->GetResourceManager()->LoadResource("accessibility/texts/filechoose" + languageSuffix, true, initData))->Data;
 }
 
 void RegisterOnSetGameLanguageHook() {

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -118,6 +118,7 @@ GameInteractorSail* GameInteractorSail::Instance;
 #include "soh/resource/importer/SkeletonLimbFactory.h"
 #include "soh/resource/importer/TextFactory.h"
 #include "soh/resource/importer/BackgroundFactory.h"
+#include "soh/resource/importer/RawJsonFactory.h"
 
 #include "soh/config/ConfigUpdaters.h"
 
@@ -341,6 +342,7 @@ OTRGlobals::OTRGlobals() {
     loader->RegisterResourceFactory(std::make_shared<SOH::ResourceFactoryBinaryAudioSoundFontV2>(), RESOURCE_FORMAT_BINARY, "AudioSoundFont", static_cast<uint32_t>(SOH::ResourceType::SOH_AudioSoundFont), 2);
     loader->RegisterResourceFactory(std::make_shared<SOH::ResourceFactoryBinaryAudioSequenceV2>(), RESOURCE_FORMAT_BINARY, "AudioSequence", static_cast<uint32_t>(SOH::ResourceType::SOH_AudioSequence), 2);
     loader->RegisterResourceFactory(std::make_shared<SOH::ResourceFactoryBinaryBackgroundV0>(), RESOURCE_FORMAT_BINARY, "Background", static_cast<uint32_t>(SOH::ResourceType::SOH_Background), 0);
+    loader->RegisterResourceFactory(std::make_shared<SOH::ResourceFactoryBinaryRawJsonV0>(), RESOURCE_FORMAT_BINARY, "RawJson", static_cast<uint32_t>(SOH::ResourceType::SOH_RawJson), 0);
 
     gSaveStateMgr = std::make_shared<SaveStateMgr>();
     gRandomizer = std::make_shared<Randomizer>();
@@ -1108,6 +1110,9 @@ extern "C" void InitOTR() {
     SpeechSynthesizer::Instance->Init();
 #elif defined(_WIN32)
     SpeechSynthesizer::Instance = new SAPISpeechSynthesizer();
+    SpeechSynthesizer::Instance->Init();
+#else
+    SpeechSynthesizer::Instance = new SpeechLogger();
     SpeechSynthesizer::Instance->Init();
 #endif
 

--- a/soh/soh/resource/importer/RawJsonFactory.cpp
+++ b/soh/soh/resource/importer/RawJsonFactory.cpp
@@ -1,0 +1,19 @@
+#include "soh/resource/importer/RawJsonFactory.h"
+#include "soh/resource/type/RawJson.h"
+#include "spdlog/spdlog.h"
+
+namespace SOH {
+std::shared_ptr<LUS::IResource> ResourceFactoryBinaryRawJsonV0::ReadResource(std::shared_ptr<LUS::File> file) {
+    if (!FileHasValidFormatAndReader(file)) {
+        return nullptr;
+    }
+
+    auto rawJson = std::make_shared<RawJson>(file->InitData);
+    auto reader = std::get<std::shared_ptr<LUS::BinaryReader>>(file->Reader);
+
+    rawJson->DataSize = file->Buffer->size();
+    rawJson->Data = nlohmann::json::parse(reader->ReadCString(), nullptr, true, true);
+
+    return rawJson;
+}
+} // namespace SOH

--- a/soh/soh/resource/importer/RawJsonFactory.h
+++ b/soh/soh/resource/importer/RawJsonFactory.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "resource/Resource.h"
+#include "resource/ResourceFactoryBinary.h"
+
+namespace SOH {
+class ResourceFactoryBinaryRawJsonV0 : public LUS::ResourceFactoryBinary {
+  public:
+    std::shared_ptr<LUS::IResource> ReadResource(std::shared_ptr<LUS::File> file) override;
+};
+}; // namespace SOH

--- a/soh/soh/resource/type/RawJson.cpp
+++ b/soh/soh/resource/type/RawJson.cpp
@@ -1,0 +1,14 @@
+#include "RawJson.h"
+
+namespace SOH {
+RawJson::RawJson() : Resource(std::shared_ptr<LUS::ResourceInitData>()) {
+}
+
+void* RawJson::GetPointer() {
+    return &Data;
+}
+
+size_t RawJson::GetPointerSize() {
+    return DataSize * sizeof(char);
+}
+} // namespace SOH

--- a/soh/soh/resource/type/RawJson.h
+++ b/soh/soh/resource/type/RawJson.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "resource/Resource.h"
+#include <nlohmann/json.hpp>
+
+namespace SOH {
+
+class RawJson : public LUS::Resource<void> {
+  public:
+    using Resource::Resource;
+
+    RawJson();
+
+    void* GetPointer() override;
+    size_t GetPointerSize() override;
+
+    nlohmann::json Data;
+    size_t DataSize;
+};
+}; // namespace SOH

--- a/soh/soh/resource/type/SohResourceType.h
+++ b/soh/soh/resource/type/SohResourceType.h
@@ -17,5 +17,6 @@ enum class ResourceType {
     SOH_AudioSequence = 0x4F534551,   // OSEQ
     SOH_Background = 0x4F424749,      // OBGI
     SOH_SceneCommand = 0x4F52434D,    // ORCM
+    SOH_RawJson = 0x4A534F4E,         // JSON
 };
 } // namespace SOH


### PR DESCRIPTION
## what i did
* moved `tts.cpp` away from using `LoadFileRaw` by creating a new `RawJson` resource type
* added `SpeechLogger` so i could verify everything was still working (we don't have a speech synth on linux)

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1299793291.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1299798484.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1299799014.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1299799236.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1299806970.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1299851401.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1299871641.zip)
<!--- section:artifacts:end -->