### PR TITLE
Fix free Epona

### DIFF
--- a/soh/src/code/z_horse.c
+++ b/soh/src/code/z_horse.c
@@ -75,6 +75,9 @@ void func_8006D0EC(PlayState* play, Player* player) {
     } else if ((play->sceneNum == gSaveContext.horseData.scene) &&
                (((Flags_GetEventChkInf(EVENTCHKINF_EPONA_OBTAINED) != 0) && (!IS_RANDO ||
                (IS_RANDO && CHECK_QUEST_ITEM(QUEST_SONG_EPONA) &&
+                    Flags_GetRandomizerInf(RAND_INF_HAS_OCARINA_C_UP) &&
+                    Flags_GetRandomizerInf(RAND_INF_HAS_OCARINA_C_LEFT) &&
+                    Flags_GetRandomizerInf(RAND_INF_HAS_OCARINA_C_RIGHT) &&
                (INV_CONTENT(ITEM_OCARINA_FAIRY) != ITEM_NONE)))) || DREG(1) != 0)) {
         // "Set by existence of horse %d %d %d"
         osSyncPrintf("馬存在によるセット %d %d %d\n", gSaveContext.horseData.scene, Flags_GetEventChkInf(EVENTCHKINF_EPONA_OBTAINED),


### PR DESCRIPTION
Fixes Epona being outside Lon Lon if you have an ocarina and Epona's song but not the ocarina buttons required to play Epona's song, allowing you to ride her without being able to play Epona's song.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1330438325.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1330484279.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1330487025.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1330488313.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1330495429.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1330497455.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1330522247.zip)
<!--- section:artifacts:end -->