### PR TITLE
filter randomizer checks in tracker

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -116,6 +116,7 @@ RandomizerCheckArea previousArea = RCAREA_INVALID;
 RandomizerCheckArea currentArea = RCAREA_INVALID;
 OSContPad* trackerButtonsPressed;
 
+bool passesTextFilter(ImGuiTextFilter& checkSearch, const RandomizerCheckObject rcObject);
 void BeginFloatWindows(std::string UniqueName, bool& open, ImGuiWindowFlags flags = 0);
 bool CompareChecks(RandomizerCheckObject, RandomizerCheckObject);
 bool CheckByArea(RandomizerCheckArea);
@@ -892,6 +893,14 @@ void CheckTrackerWindow::DrawElement() {
         optExpandAll = false;
         optCollapseAll = true;
     }
+    ImGui::SameLine();
+    static ImGuiTextFilter checkSearch;
+    if (ImGui::Button("Clear")) {
+        checkSearch.Clear();
+    }
+    UIWidgets::Tooltip("Clear the search field");
+    checkSearch.Draw();
+
     UIWidgets::PaddedSeparator();
 
     //Checks Section Lead-in
@@ -1005,11 +1014,14 @@ void CheckTrackerWindow::DrawElement() {
                 ImGui::SetScrollHereY(0.0f);
                 doAreaScroll = false;
             }
-            for (auto rco : objs) {
-                if (IsVisibleInCheckTracker(rco) && doDraw && isThisAreaSpoiled) {
-                    DrawLocation(rco);
+
+            for (auto rcObject : objs) {
+                if (IsVisibleInCheckTracker(rcObject) && passesTextFilter(checkSearch, rcObject) && doDraw &&
+                    isThisAreaSpoiled) {
+                    DrawLocation(rcObject);
                 }
             }
+
             if (doDraw) {
                 ImGui::TreePop();
             }
@@ -1024,6 +1036,13 @@ void CheckTrackerWindow::DrawElement() {
         optCollapseAll = false;
         optExpandAll = false;
     }
+}
+
+bool passesTextFilter(ImGuiTextFilter& checkSearch, RandomizerCheckObject rcObject) {
+    return (
+        checkSearch.PassFilter(RandomizerCheckObjects::GetRCAreaName(rcObject.rcArea).c_str()) ||
+        checkSearch.PassFilter(rcObject.rcShortName.c_str())
+    );
 }
 
 // Windowing stuff

--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -1039,13 +1039,12 @@ void CheckTrackerWindow::DrawElement() {
 }
 
 bool shouldHideArea(ImGuiTextFilter& checkSearch, std::map<RandomizerCheckArea, std::vector<RandomizerCheckObject>> checksByArea, RandomizerCheckArea rcArea) {
-    bool shouldHideFilteredAreas = CVarGetInteger("gCheckTrackerHideFilteredAreas", 0);
+    bool shouldHideFilteredAreas = CVarGetInteger("gCheckTrackerHideFilteredAreas", 1);
     if (!shouldHideFilteredAreas) {
         return false;
     }
-    std::vector<RandomizerCheckObject> checksForArea = checksByArea[rcArea];
-    for (unsigned long i = 0; i < checksForArea.size(); i++) {
-        if (passesTextFilter(checkSearch, checksForArea[i])) {
+    for (auto check : checksByArea[rcArea]) {
+        if (passesTextFilter(checkSearch, check)) {
             return false;
         }
     }
@@ -1613,7 +1612,7 @@ void CheckTrackerSettingsWindow::DrawElement() {
 
     // Filtering settings
     UIWidgets::PaddedSeparator();
-    UIWidgets::EnhancementCheckbox("Filter Empty Areas", "gCheckTrackerHideFilteredAreas");
+    UIWidgets::EnhancementCheckbox("Filter Empty Areas", "gCheckTrackerHideFilteredAreas", false, "", UIWidgets::CheckboxGraphics::Checkmark, true);
     UIWidgets::Tooltip("If enabled, will hide area headers that have no locations matching filter");
 
     ImGui::TableNextColumn();

--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -33,9 +33,9 @@ using json = nlohmann::json;
 
 void to_json(json& j, const RandomizerCheckTrackerData& rctd) {
     j = json {
-        { "status", rctd.status == RCSHOW_COLLECTED ? RCSHOW_SAVED : rctd.status }, 
-        { "skipped", rctd.skipped }, 
-        { "price", rctd.price }, 
+        { "status", rctd.status == RCSHOW_COLLECTED ? RCSHOW_SAVED : rctd.status },
+        { "skipped", rctd.skipped },
+        { "price", rctd.price },
         { "hintItem", rctd.hintItem }};
     }
 
@@ -489,7 +489,7 @@ void CheckTrackerLoadGame(int32_t fileNum) {
                 break;
         }
         RandomizerCheckObject linksPocket = { RC_LINKS_POCKET, RCVORMQ_BOTH, RCTYPE_LINKS_POCKET, startingArea, ACTOR_ID_MAX, SCENE_ID_MAX, 0x00, GI_NONE, false, "Link's Pocket", "Link's Pocket" };
-        
+
         checksByArea.find(startingArea)->second.push_back(linksPocket);
         areaChecksGotten[startingArea]++;
         areaCheckTotals[startingArea]++;
@@ -665,7 +665,7 @@ void CheckTrackerFlagSet(int16_t flagType, int32_t flag) {
             break;
         case FLAG_EVENT_CHECK_INF:
             if ((flag == EVENTCHKINF_CARPENTERS_FREE(0) || flag == EVENTCHKINF_CARPENTERS_FREE(1) ||
-                 flag == EVENTCHKINF_CARPENTERS_FREE(2) || flag == EVENTCHKINF_CARPENTERS_FREE(3)) 
+                 flag == EVENTCHKINF_CARPENTERS_FREE(2) || flag == EVENTCHKINF_CARPENTERS_FREE(3))
                 && GET_EVENTCHKINF_CARPENTERS_FREE_ALL()) {
                 SetCheckCollected(RC_GF_GERUDO_MEMBERSHIP_CARD);
                 return;
@@ -812,12 +812,12 @@ void Teardown() {
 
 void UpdateCheck(uint32_t check, RandomizerCheckTrackerData data) {
     auto area = RandomizerCheckObjects::GetAllRCObjects().find(static_cast<RandomizerCheck>(check))->second.rcArea;
-    if ((!gSaveContext.checkTrackerData[check].skipped && data.skipped) || 
-        ((gSaveContext.checkTrackerData[check].status != RCSHOW_COLLECTED && gSaveContext.checkTrackerData[check].status != RCSHOW_SAVED) && 
+    if ((!gSaveContext.checkTrackerData[check].skipped && data.skipped) ||
+        ((gSaveContext.checkTrackerData[check].status != RCSHOW_COLLECTED && gSaveContext.checkTrackerData[check].status != RCSHOW_SAVED) &&
             (data.status == RCSHOW_COLLECTED || data.status == RCSHOW_SAVED))) {
         areaChecksGotten[area]++;
-    } else if ((gSaveContext.checkTrackerData[check].skipped && !data.skipped) || 
-        ((gSaveContext.checkTrackerData[check].status == RCSHOW_COLLECTED || gSaveContext.checkTrackerData[check].status == RCSHOW_SAVED) && 
+    } else if ((gSaveContext.checkTrackerData[check].skipped && !data.skipped) ||
+        ((gSaveContext.checkTrackerData[check].status == RCSHOW_COLLECTED || gSaveContext.checkTrackerData[check].status == RCSHOW_SAVED) &&
             (data.status != RCSHOW_COLLECTED && data.status != RCSHOW_SAVED))) {
         areaChecksGotten[area]--;
     }
@@ -949,7 +949,7 @@ void CheckTrackerWindow::DrawElement() {
             previousShowHidden = showHidden;
             doAreaScroll = true;
         }
-        if (shouldHideArea(checkSearch, checksByArea, rcArea) || 
+        if (shouldHideArea(checkSearch, checksByArea, rcArea) ||
             (!showHidden && ( hideComplete && thisAreaFullyChecked || hideIncomplete && !thisAreaFullyChecked))
         ) {
             doDraw = false;
@@ -1333,7 +1333,7 @@ bool IsHeartPiece(GetItemID giid) {
 }
 
 void DrawLocation(RandomizerCheckObject rcObj) {
-    Color_RGBA8 mainColor; 
+    Color_RGBA8 mainColor;
     Color_RGBA8 extraColor;
     std::string txt;
     bool showHidden = CVarGetInteger("gCheckTrackerOptionShowHidden", 0);
@@ -1383,13 +1383,13 @@ void DrawLocation(RandomizerCheckObject rcObj) {
                     CVarGetColor("gCheckTrackerUncheckedMainColor", Color_Main_Default);
         extraColor = CVarGetColor("gCheckTrackerUncheckedExtraColor",  Color_Unchecked_Extra_Default);
     }
- 
+
     //Main Text
     txt = rcObj.rcShortName;
     if (lastLocationChecked == rcObj.rc) {
         txt = "* " + txt;
     }
- 
+
     // Draw button - for Skipped/Seen/Scummed/Unchecked only
     if (status == RCSHOW_UNCHECKED || status == RCSHOW_SEEN || status == RCSHOW_IDENTIFIED || status == RCSHOW_SCUMMED || skipped) {
         if (UIWidgets::StateButton(std::to_string(rcObj.rc).c_str(), skipped ? ICON_FA_PLUS : ICON_FA_TIMES)) {
@@ -1494,13 +1494,13 @@ void RainbowTick() {
         if (CVarGetInteger((cvar + "RBM").c_str(), 0) == 0) {
             continue;
         }
-     
+
         Color_RGBA8 newColor;
         newColor.r = sin(freqHue +              0) * 127 + 128;
         newColor.g = sin(freqHue + (2 * M_PI / 3)) * 127 + 128;
         newColor.b = sin(freqHue + (4 * M_PI / 3)) * 127 + 128;
         newColor.a = 255;
-         
+
         CVarSetColor(cvar.c_str(), newColor);
     }
 
@@ -1537,7 +1537,7 @@ void ImGuiDrawTwoColorPickerSection(const char* text, const char* cvarMainName, 
                 main_color = CVarGetColor(cvarMainName, main_default_color);
             };
             ImGui::PopItemWidth();
-         
+
             ImGui::TableNextColumn();
             ImGui::AlignTextToFramePadding();
             ImGui::PushItemWidth(ImGui::GetContentRegionAvail().x);

--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -950,7 +950,7 @@ void CheckTrackerWindow::DrawElement() {
             doAreaScroll = true;
         }
         if (shouldHideArea(checkSearch, checksByArea, rcArea) ||
-            (!showHidden && ( hideComplete && thisAreaFullyChecked || hideIncomplete && !thisAreaFullyChecked))
+            (!showHidden && ((hideComplete && thisAreaFullyChecked) || (hideIncomplete && !thisAreaFullyChecked)))
         ) {
             doDraw = false;
         } else {
@@ -1039,7 +1039,7 @@ void CheckTrackerWindow::DrawElement() {
 }
 
 bool shouldHideArea(ImGuiTextFilter& checkSearch, std::map<RandomizerCheckArea, std::vector<RandomizerCheckObject>> checksByArea, RandomizerCheckArea rcArea) {
-    bool shouldHideFilteredAreas = CVarGetInteger("gCheckTrackerHideFilteredAreas", 1);
+    bool shouldHideFilteredAreas = CVarGetInteger("g.CheckTracker.HideFilteredAreas", 1);
     if (!shouldHideFilteredAreas) {
         return false;
     }
@@ -1612,7 +1612,7 @@ void CheckTrackerSettingsWindow::DrawElement() {
 
     // Filtering settings
     UIWidgets::PaddedSeparator();
-    UIWidgets::EnhancementCheckbox("Filter Empty Areas", "gCheckTrackerHideFilteredAreas", false, "", UIWidgets::CheckboxGraphics::Checkmark, true);
+    UIWidgets::EnhancementCheckbox("Filter Empty Areas", "g.CheckTracker.HideFilteredAreas", false, "", UIWidgets::CheckboxGraphics::Checkmark, true);
     UIWidgets::Tooltip("If enabled, will hide area headers that have no locations matching filter");
 
     ImGui::TableNextColumn();

--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -1043,18 +1043,20 @@ bool shouldHideArea(ImGuiTextFilter& checkSearch, std::map<RandomizerCheckArea, 
     if (!shouldHideFilteredAreas) {
         return false;
     }
+
     for (auto check : checksByArea[rcArea]) {
-        if (passesTextFilter(checkSearch, check)) {
+        if (IsVisibleInCheckTracker(check) && passesTextFilter(checkSearch, check)) {
             return false;
         }
     }
+
     return true;
 }
 
-bool passesTextFilter(ImGuiTextFilter& checkSearch, RandomizerCheckObject rcObject) {
+bool passesTextFilter(ImGuiTextFilter& checkSearch, RandomizerCheckObject check) {
     return (
-        checkSearch.PassFilter(RandomizerCheckObjects::GetRCAreaName(rcObject.rcArea).c_str()) ||
-        checkSearch.PassFilter(rcObject.rcShortName.c_str())
+        checkSearch.PassFilter(RandomizerCheckObjects::GetRCAreaName(check.rcArea).c_str()) ||
+        checkSearch.PassFilter(check.rcShortName.c_str())
     );
 }
 

--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -1039,7 +1039,7 @@ void CheckTrackerWindow::DrawElement() {
 }
 
 bool shouldHideArea(ImGuiTextFilter& checkSearch, std::map<RandomizerCheckArea, std::vector<RandomizerCheckObject>> checksByArea, RandomizerCheckArea rcArea) {
-    bool shouldHideFilteredAreas = CVarGetInteger("g.CheckTracker.HideFilteredAreas", 1);
+    bool shouldHideFilteredAreas = CVarGetInteger("gTrackers.CheckTracker.HideFilteredAreas", 1);
     if (!shouldHideFilteredAreas) {
         return false;
     }
@@ -1612,7 +1612,7 @@ void CheckTrackerSettingsWindow::DrawElement() {
 
     // Filtering settings
     UIWidgets::PaddedSeparator();
-    UIWidgets::EnhancementCheckbox("Filter Empty Areas", "g.CheckTracker.HideFilteredAreas", false, "", UIWidgets::CheckboxGraphics::Checkmark, true);
+    UIWidgets::EnhancementCheckbox("Filter Empty Areas", "gTrackers.CheckTracker.HideFilteredAreas", false, "", UIWidgets::CheckboxGraphics::Checkmark, true);
     UIWidgets::Tooltip("If enabled, will hide area headers that have no locations matching filter");
 
     ImGui::TableNextColumn();


### PR DESCRIPTION
Followed the example set by the entrance tracker.

We elected not to filter out the area names when an area becomes empty, but would be open to doing this based on feedback, or bringing it in a later PR. **EDIT**: we ended putting in optional hiding of headers for areas which have no locations matching filter

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1356733576.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1356739384.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1356739596.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1356739800.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1356742186.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1356764866.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1356892884.zip)
<!--- section:artifacts:end -->