### PR TITLE
Remove macports upgrading

### DIFF
--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -77,15 +77,15 @@ jobs:
         sudo mv /usr/local/bin/gtar /usr/local/bin/gtar.orig
         sudo cp .github/workflows//gtar /usr/local/bin/gtar
         sudo chmod +x /usr/local/bin/gtar
-    # - name: Cache MacPorts
-    #   id: cache-macports
-    #   if: ${{ !vars.MAC_RUNNER }}
-    #   uses: actions/cache@v2
-    #   with:
-    #     path: /opt/local/
-    #     key: ${{ runner.os }}-macports-${{ hashFiles('.github/workflows/macports-deps.txt') }}
-    #     restore-keys: |
-    #       ${{ runner.os }}-macports-
+    - name: Cache MacPorts
+      id: cache-macports
+      if: ${{ !vars.MAC_RUNNER }}
+      uses: actions/cache@v2
+      with:
+        path: /opt/local/
+        key: ${{ runner.os }}-macports-${{ hashFiles('.github/workflows/macports-deps.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-macports-
     - name: Install MacPorts (if necessary)
       if: ${{ !vars.MAC_RUNNER }}
       run: |
@@ -96,10 +96,6 @@ jobs:
           sudo installer -pkg ./MacPorts-2.9.1-12-Monterey.pkg -target /
         fi
         echo "/opt/local/bin:/opt/local/sbin" >> $GITHUB_PATH
-    # - name: Update MacPorts
-    #   if: ${{ !vars.MAC_RUNNER }}
-    #   run: |
-    #     sudo port selfupdate
     - name: Install dependencies
       if: ${{ !vars.MAC_RUNNER }}
       run: |

--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -100,7 +100,6 @@ jobs:
       if: ${{ !vars.MAC_RUNNER }}
       run: |
         sudo port selfupdate
-        sudo port upgrade outdated
     - name: Install dependencies
       if: ${{ !vars.MAC_RUNNER }}
       run: |

--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -77,15 +77,15 @@ jobs:
         sudo mv /usr/local/bin/gtar /usr/local/bin/gtar.orig
         sudo cp .github/workflows//gtar /usr/local/bin/gtar
         sudo chmod +x /usr/local/bin/gtar
-    - name: Cache MacPorts
-      id: cache-macports
-      if: ${{ !vars.MAC_RUNNER }}
-      uses: actions/cache@v2
-      with:
-        path: /opt/local/
-        key: ${{ runner.os }}-macports-${{ hashFiles('.github/workflows/macports-deps.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-macports-
+    # - name: Cache MacPorts
+    #   id: cache-macports
+    #   if: ${{ !vars.MAC_RUNNER }}
+    #   uses: actions/cache@v2
+    #   with:
+    #     path: /opt/local/
+    #     key: ${{ runner.os }}-macports-${{ hashFiles('.github/workflows/macports-deps.txt') }}
+    #     restore-keys: |
+    #       ${{ runner.os }}-macports-
     - name: Install MacPorts (if necessary)
       if: ${{ !vars.MAC_RUNNER }}
       run: |
@@ -96,10 +96,10 @@ jobs:
           sudo installer -pkg ./MacPorts-2.9.1-12-Monterey.pkg -target /
         fi
         echo "/opt/local/bin:/opt/local/sbin" >> $GITHUB_PATH
-    - name: Update MacPorts
-      if: ${{ !vars.MAC_RUNNER }}
-      run: |
-        sudo port selfupdate
+    # - name: Update MacPorts
+    #   if: ${{ !vars.MAC_RUNNER }}
+    #   run: |
+    #     sudo port selfupdate
     - name: Install dependencies
       if: ${{ !vars.MAC_RUNNER }}
       run: |


### PR DESCRIPTION
This removes the macports upgrading in the github actions. It doesn't appear to be necessary and was increasing build times substantially.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1383735702.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1383738476.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1383738529.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1383738821.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1383739597.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1383747169.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1383778163.zip)
<!--- section:artifacts:end -->