### PR TITLE
Fix Pause Warp Enhancement

### DIFF
--- a/soh/soh/Enhancements/pausewarp.c
+++ b/soh/soh/Enhancements/pausewarp.c
@@ -85,7 +85,8 @@ void PauseWarp_HandleSelection() {
     if (gSaveContext.inventory.items[SLOT_OCARINA] != ITEM_NONE) {
         int aButtonPressed = CHECK_BTN_ALL(gPlayState->state.input->press.button, BTN_A);
         int song = gPlayState->pauseCtx.cursorPoint[PAUSE_QUEST];
-        if (aButtonPressed && CHECK_QUEST_ITEM(song) && song >= QUEST_SONG_MINUET && song <= QUEST_SONG_PRELUDE) {
+        if (aButtonPressed && CHECK_QUEST_ITEM(song) && song >= QUEST_SONG_MINUET && song <= QUEST_SONG_PRELUDE &&
+            gPlayState->pauseCtx.pageIndex == PAUSE_QUEST && gPlayState->pauseCtx.state == 6) {
             ActivateWarp(&gPlayState->pauseCtx, song);
         }
     }


### PR DESCRIPTION
Addresses #4025 

This just adds the restriction to be on the correct pause page and in a pause state which is accepting inputs (rather than opening/closing/saving). I considered adding the mainstate restriction to be idle but im not sure if there would be issues with that state changing when pressing A on the song, and which path would occur first.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1384158381.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1384201408.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1384207486.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1384208887.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1384214870.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1384218474.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1384374655.zip)
<!--- section:artifacts:end -->