### PR TITLE
Support for new ucode loading patterns

### DIFF
--- a/soh/include/functions.h
+++ b/soh/include/functions.h
@@ -1828,8 +1828,8 @@ MtxF* Matrix_CheckFloats(MtxF* mf, char* file, s32 line);
 void Matrix_SetTranslateScaleMtx2(Mtx* mtx, f32 scaleX, f32 scaleY, f32 scaleZ, f32 translateX, f32 translateY,
                                   f32 translateZ);
 uintptr_t SysUcode_GetUCodeBoot(void);
-uintptr_t SysUcode_GetUCodeBootSize(void);
-uintptr_t SysUcode_GetUCode(void);
+size_t SysUcode_GetUCodeBootSize(void);
+uint32_t SysUcode_GetUCode(void);
 uintptr_t SysUcode_GetUCodeData(void);
 void func_800D2E30(UnkRumbleStruct* arg0);
 void func_800D3140(UnkRumbleStruct* arg0);

--- a/soh/include/functions.h
+++ b/soh/include/functions.h
@@ -1230,8 +1230,8 @@ Gfx* Gfx_EnvColor(GraphicsContext* gfxCtx, s32 r, s32 g, s32 b, s32 a);
 void Gfx_SetupFrame(GraphicsContext* gfxCtx, u8 r, u8 g, u8 b);
 void func_80095974(GraphicsContext* gfxCtx);
 void func_80095AA0(PlayState* play, Room* room, Input* arg2, UNK_TYPE arg3);
-void func_8009638C(Gfx** displayList, void* source, void* tlut, u16 width, u16 height, u8 fmt, u8 siz, u16 mode0,
-                   u16 tlutCount, f32 frameX, f32 frameY);
+void Room_DrawBackground2D(Gfx** gfxP, void* tex, void* tlut, u16 width, u16 height, u8 fmt, u8 siz, u16 tlutMode,
+                           u16 tlutCount, f32 offsetX, f32 offsetY);
 void func_80096FD4(PlayState* play, Room* room);
 u32 func_80096FE8(PlayState* play, RoomContext* roomCtx);
 s32 func_8009728C(PlayState* play, RoomContext* roomCtx, s32 roomNum);

--- a/soh/src/code/sys_ucode.c
+++ b/soh/src/code/sys_ucode.c
@@ -1,20 +1,25 @@
 #include "global.h"
 
-//uintptr_t D_8012DBA0 = (uintptr_t)&D_80155F50;
-//uintptr_t D_8012DBA4 = (uintptr_t)&D_80157580;
+#include "public/bridge/gfxbridge.h"
+
+UcodeHandlers sDefaultGSPUCodeText = ucode_f3dex2;
+// u64* sDefaultGSPUCodeData = gspF3DZEX2_NoN_PosLight_fifoDataStart;
 
 uintptr_t SysUcode_GetUCodeBoot(void) {
-    //return &D_80009320;
+    // return rspbootTextStart;
+    return (uintptr_t)NULL;
 }
 
-uintptr_t SysUcode_GetUCodeBootSize(void) {
-    //return (uintptr_t)&D_800093F0 - (uintptr_t)&D_80009320;
+size_t SysUcode_GetUCodeBootSize(void) {
+    // return (ptrdiff_t)((uintptr_t)rspbootTextEnd - (uintptr_t)rspbootTextStart);
+    return 0;
 }
 
-uintptr_t SysUcode_GetUCode(void) {
-    //return D_8012DBA0;
+uint32_t SysUcode_GetUCode(void) {
+    return sDefaultGSPUCodeText;
 }
 
 uintptr_t SysUcode_GetUCodeData(void) {
-    //return D_8012DBA4;
+    // return sDefaultGSPUCodeData;
+    return (uintptr_t)NULL;
 }

--- a/soh/src/code/z_room.c
+++ b/soh/src/code/z_room.c
@@ -256,23 +256,21 @@ s32 swapAndConvertJPEG(void* data) {
 }
 
 
-void func_8009638C(Gfx** displayList, void* source, void* tlut, u16 width, u16 height, u8 fmt, u8 siz, u16 mode0,
-                   u16 tlutCount, f32 frameX, f32 frameY) {
-    Gfx* displayListHead;
+void Room_DrawBackground2D(Gfx** gfxP, void* tex, void* tlut, u16 width, u16 height, u8 fmt, u8 siz, u16 tlutMode,
+                           u16 tlutCount, f32 offsetX, f32 offsetY) {
+    Gfx* gfx = *gfxP;
     uObjBg* bg;
-    s32 temp;
 
-    displayListHead = *displayList;
+    bg = (uObjBg*)(gfx + 1);
+    gSPBranchList(gfx, (Gfx*)(bg + 1));
 
-    bg = (uObjBg*)(displayListHead + 1);
-    gSPBranchList(displayListHead, (u8*)bg + sizeof(uObjBg));
     bg->b.imageX = 0;
-    bg->b.imageW = width * 4;
-    bg->b.frameX = frameX * 4;
+    bg->b.imageW = width * (1 << 2);
+    bg->b.frameX = offsetX * (1 << 2);
     bg->b.imageY = 0;
-    bg->b.imageH = height * 4;
-    bg->b.frameY = frameY * 4;
-    bg->b.imagePtr = source;
+    bg->b.imageH = height * (1 << 2);
+    bg->b.frameY = offsetY * (1 << 2);
+    bg->b.imagePtr = tex;
     bg->b.imageLoad = G_BGLT_LOADTILE;
     bg->b.imageFmt = fmt;
     bg->b.imageSiz = siz;
@@ -282,62 +280,67 @@ void func_8009638C(Gfx** displayList, void* source, void* tlut, u16 width, u16 h
     // When an alt resource exists for the background, we need to unload the original asset
     // to clear the cache so the alt asset will be loaded instead
     // OTRTODO: If Alt loading over original cache is fixed, this line can most likely be removed
-    ResourceMgr_UnloadOriginalWhenAltExists((char*) source);
+    ResourceMgr_UnloadOriginalWhenAltExists((char*)tex);
 
-    if (ResourceMgr_ResourceIsBackground((char*) source)) {
-        char* blob = (char*) ResourceGetDataByName((char *) source);
+    if (ResourceMgr_ResourceIsBackground((char*)tex)) {
+        char* blob = (char*)ResourceGetDataByName((char *)tex);
         swapAndConvertJPEG(blob);
-        bg->b.imagePtr = (uintptr_t) blob;
+        bg->b.imagePtr = (uintptr_t)blob;
     }
 
-    displayListHead = (void*)(bg + 1);
+    gfx = (Gfx*)(bg + 1);
+
     if (fmt == G_IM_FMT_CI) {
-        gDPLoadTLUT(displayListHead++, tlutCount, 256, tlut);
+        gDPLoadTLUT(gfx++, tlutCount, 256, tlut);
     } else {
-        gDPPipeSync(displayListHead++);
+        gDPPipeSync(gfx++);
     }
 
     if ((fmt == G_IM_FMT_RGBA) && (SREG(26) == 0)) {
-        bg->b.frameW = width * 4;
-        bg->b.frameH = height * 4;
+        bg->b.frameW = width * (1 << 2);
+        bg->b.frameH = height * (1 << 2);
         guS2DInitBg(bg);
 
-        gDPSetOtherMode(displayListHead++, mode0 | G_TL_TILE | G_TD_CLAMP | G_TP_NONE | G_CYC_FILL | G_PM_NPRIMITIVE,
+        // #region 2S2H [Widescreen] Account for different aspect ratios than 4:3
+        // When larger we want to render an additional black rectangle behind the 2d image
+        // to simulate black bars on the side that cover up the world
+        s16 newX = OTRGetRectDimensionFromLeftEdge(0);
+        if (newX < 0) {
+            gDPSetOtherMode(gfx++, tlutMode | G_TL_TILE | G_TD_CLAMP | G_TP_NONE | G_CYC_FILL | G_PM_NPRIMITIVE,
+                            G_AC_THRESHOLD | G_ZS_PIXEL | G_RM_NOOP | G_RM_NOOP2);
+            gDPSetFillColor(gfx++, GPACK_RGBA5551(0, 0, 0, 1) << 16 | GPACK_RGBA5551(0, 0, 0, 1));
+            gDPFillWideRectangle(gfx++, newX, 0, OTRGetRectDimensionFromRightEdge(SCREEN_WIDTH), SCREEN_HEIGHT);
+        }
+
+        gDPSetOtherMode(gfx++, tlutMode | G_TL_TILE | G_TD_CLAMP | G_TP_NONE | G_CYC_COPY | G_PM_NPRIMITIVE,
                         G_AC_THRESHOLD | G_ZS_PIXEL | G_RM_NOOP | G_RM_NOOP2);
 
-        gDPSetFillColor(displayListHead++, GPACK_RGBA5551(0, 0, 0, 1) << 16 | GPACK_RGBA5551(0, 0, 0, 1));
-        gDPFillWideRectangle(displayListHead++, OTRGetRectDimensionFromLeftEdge(0), 0,
-                         OTRGetRectDimensionFromRightEdge(SCREEN_WIDTH), SCREEN_HEIGHT);
-
-        gDPSetOtherMode(displayListHead++, mode0 | G_TL_TILE | G_TD_CLAMP | G_TP_NONE | G_CYC_COPY | G_PM_NPRIMITIVE,
-                        G_AC_THRESHOLD | G_ZS_PIXEL | G_RM_NOOP | G_RM_NOOP2);
-
-        gDPLoadMultiTile(displayListHead++, bg->b.imagePtr, 0,
+        gDPLoadMultiTile(gfx++, bg->b.imagePtr, 0,
             G_TX_RENDERTILE, G_IM_FMT_RGBA, G_IM_SIZ_16b, 320, 0, 0, 0, 0 + 31,
             0 + 31, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOLOD,
             G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOLOD);
 
-        gSPBgRectCopy(displayListHead++, bg);
-
+        gSPBgRectCopy(gfx++, bg);
     } else {
-        bg->s.frameW = width * 4;
-        bg->s.frameH = height * 4;
-        bg->s.scaleW = 1024;
-        bg->s.scaleH = 1024;
+        bg->s.frameW = width * (1 << 2);
+        bg->s.frameH = height * (1 << 2);
+        bg->s.scaleW = 1 << 10;
+        bg->s.scaleH = 1 << 10;
         bg->s.imageYorig = bg->b.imageY;
-        gDPSetOtherMode(displayListHead++,
-                        mode0 | G_AD_DISABLE | G_CD_DISABLE | G_CK_NONE | G_TC_FILT | G_TF_POINT | G_TT_NONE |
+        gDPSetOtherMode(gfx++,
+                        tlutMode | G_AD_DISABLE | G_CD_DISABLE | G_CK_NONE | G_TC_FILT | G_TF_POINT | G_TT_NONE |
                             G_TL_TILE | G_TD_CLAMP | G_TP_NONE | G_CYC_1CYCLE | G_PM_NPRIMITIVE,
                         G_AC_THRESHOLD | G_ZS_PIXEL | AA_EN | CVG_DST_CLAMP | ZMODE_OPA | CVG_X_ALPHA | ALPHA_CVG_SEL |
                             GBL_c1(G_BL_CLR_IN, G_BL_A_IN, G_BL_CLR_BL, G_BL_1MA) |
                             GBL_c2(G_BL_CLR_IN, G_BL_A_IN, G_BL_CLR_BL, G_BL_1MA));
-        gDPSetCombineLERP(displayListHead++, 0, 0, 0, TEXEL0, 0, 0, 0, 1, 0, 0, 0, TEXEL0, 0, 0, 0, 1);
-        gSPObjRenderMode(displayListHead++, G_OBJRM_ANTIALIAS | G_OBJRM_BILERP);
-        gSPBgRect1Cyc(displayListHead++, bg);
+        gDPSetCombineLERP(gfx++, 0, 0, 0, TEXEL0, 0, 0, 0, 1, 0, 0, 0, TEXEL0, 0, 0, 0, 1);
+        gSPObjRenderMode(gfx++, G_OBJRM_ANTIALIAS | G_OBJRM_BILERP);
+        gSPBgRect1Cyc(gfx++, bg);
     }
 
-    gDPPipeSync(displayListHead++);
-    *displayList = displayListHead;
+    gDPPipeSync(gfx++);
+
+    *gfxP = gfx;
 }
 
 // Room Draw Polygon Type 1 - Single Format
@@ -377,7 +380,7 @@ void func_80096680(PlayState* play, Room* room, u32 flags) {
                 Vec3f sp60;
                 spA8 = POLY_OPA_DISP;
                 Camera_GetSkyboxOffset(&sp60, camera);
-                func_8009638C(&spA8, polygon1->single.source, polygon1->single.tlut, polygon1->single.width,
+                Room_DrawBackground2D(&spA8, polygon1->single.source, polygon1->single.tlut, polygon1->single.width,
                               polygon1->single.height, polygon1->single.fmt, polygon1->single.siz,
                               polygon1->single.mode0, polygon1->single.tlutCount,
                               (sp60.x + sp60.z) * 1.2f + sp60.y * 0.6f, sp60.y * 2.4f + (sp60.x + sp60.z) * 0.3f);
@@ -478,7 +481,7 @@ void func_80096B6C(PlayState* play, Room* room, u32 flags) {
                 Vec3f sp5C;
                 spA8 = POLY_OPA_DISP;
                 Camera_GetSkyboxOffset(&sp5C, camera);
-                func_8009638C(&spA8, bgImage->source, bgImage->tlut, bgImage->width, bgImage->height, bgImage->fmt,
+                Room_DrawBackground2D(&spA8, bgImage->source, bgImage->tlut, bgImage->width, bgImage->height, bgImage->fmt,
                               bgImage->siz, bgImage->mode0, bgImage->tlutCount,
                               (sp5C.x + sp5C.z) * 1.2f + sp5C.y * 0.6f, sp5C.y * 2.4f + (sp5C.x + sp5C.z) * 0.3f);
                 POLY_OPA_DISP = spA8;

--- a/soh/src/code/z_room.c
+++ b/soh/src/code/z_room.c
@@ -8,6 +8,8 @@
 #include <string.h>
 #include <assert.h>
 
+#include "public/bridge/gfxbridge.h"
+
 void func_80095AB4(PlayState* play, Room* room, u32 flags);
 void func_80095D04(PlayState* play, Room* room, u32 flags);
 void func_80096F6C(PlayState* play, Room* room, u32 flags);
@@ -369,8 +371,7 @@ void func_80096680(PlayState* play, Room* room, u32 flags) {
         }
 
         if (sp98) {
-            // gSPLoadUcodeL(POLY_OPA_DISP++, rspS2DEX)?
-            //gSPLoadUcodeEx(POLY_OPA_DISP++, OS_K0_TO_PHYSICAL(D_80113070), OS_K0_TO_PHYSICAL(D_801579A0), 0x800);
+            gSPLoadUcodeL(POLY_OPA_DISP++, ucode_s2dex);
 
             {
                 Vec3f sp60;
@@ -383,8 +384,7 @@ void func_80096680(PlayState* play, Room* room, u32 flags) {
                 POLY_OPA_DISP = spA8;
             }
 
-            // gSPLoadUcode(POLY_OPA_DISP++, SysUcode_GetUCode(), SysUcode_GetUCodeData())?
-            gSPLoadUcodeEx(POLY_OPA_DISP++, SysUcode_GetUCode(), SysUcode_GetUCodeData(), 0x800);
+            gSPLoadUcode(POLY_OPA_DISP++, SysUcode_GetUCode());
         }
     }
 
@@ -472,8 +472,7 @@ void func_80096B6C(PlayState* play, Room* room, u32 flags) {
         }
 
         if (sp94) {
-            // gSPLoadUcodeL(POLY_OPA_DISP++, rspS2DEX)?
-            //gSPLoadUcodeEx(POLY_OPA_DISP++, OS_K0_TO_PHYSICAL(D_80113070), OS_K0_TO_PHYSICAL(D_801579A0), 0x800);
+            gSPLoadUcodeL(POLY_OPA_DISP++, ucode_s2dex);
 
             {
                 Vec3f sp5C;
@@ -485,8 +484,7 @@ void func_80096B6C(PlayState* play, Room* room, u32 flags) {
                 POLY_OPA_DISP = spA8;
             }
 
-            // gSPLoadUcode(POLY_OPA_DISP++, SysUcode_GetUCode(), SysUcode_GetUCodeData())?
-            gSPLoadUcodeEx(POLY_OPA_DISP++, SysUcode_GetUCode(), SysUcode_GetUCodeData(), 0x800);
+            gSPLoadUcode(POLY_OPA_DISP++, SysUcode_GetUCode());
         }
     }
 

--- a/soh/src/code/z_room.c
+++ b/soh/src/code/z_room.c
@@ -301,8 +301,8 @@ void Room_DrawBackground2D(Gfx** gfxP, void* tex, void* tlut, u16 width, u16 hei
         bg->b.frameH = height * (1 << 2);
         guS2DInitBg(bg);
 
-        // #region 2S2H [Widescreen] Account for different aspect ratios than 4:3
-        // When larger we want to render an additional black rectangle behind the 2d image
+        // #region SOH [Port][Widescreen]
+        // When larger than 4:3 we want to render an additional black rectangle behind the 2d image
         // to simulate black bars on the side that cover up the world
         s16 newX = OTRGetRectDimensionFromLeftEdge(0);
         if (newX < 0) {
@@ -311,6 +311,7 @@ void Room_DrawBackground2D(Gfx** gfxP, void* tex, void* tlut, u16 width, u16 hei
             gDPSetFillColor(gfx++, GPACK_RGBA5551(0, 0, 0, 1) << 16 | GPACK_RGBA5551(0, 0, 0, 1));
             gDPFillWideRectangle(gfx++, newX, 0, OTRGetRectDimensionFromRightEdge(SCREEN_WIDTH), SCREEN_HEIGHT);
         }
+        // #endregion
 
         gDPSetOtherMode(gfx++, tlutMode | G_TL_TILE | G_TD_CLAMP | G_TP_NONE | G_CYC_COPY | G_PM_NPRIMITIVE,
                         G_AC_THRESHOLD | G_ZS_PIXEL | G_RM_NOOP | G_RM_NOOP2);

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_map_PAL.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_map_PAL.c
@@ -7,6 +7,8 @@
 #include "textures/icon_item_dungeon_static/icon_item_dungeon_static.h"
 #include "textures/icon_item_nes_static/icon_item_nes_static.h"
 
+#include "public/bridge/gfxbridge.h"
+
 void KaleidoScope_DrawDungeonMap(PlayState* play, GraphicsContext* gfxCtx) {
     static void* dungeonItemTexs[] = {
         gQuestIconDungeonBossKeyTex,
@@ -595,14 +597,12 @@ void KaleidoScope_DrawWorldMap(PlayState* play, GraphicsContext* gfxCtx) {
         Gfx* sp1CC = POLY_KAL_DISP;
         void* mapImage = gWorldMapImageTex;
 
-        // gSPLoadUcodeL(sp1CC++, rspS2DEX)?
-        //gSPLoadUcodeEx(sp1CC++, OS_K0_TO_PHYSICAL(D_80113070), OS_K0_TO_PHYSICAL(D_801579A0), 0x800);
+        gSPLoadUcodeL(sp1CC++, ucode_s2dex);
 
         func_8009638C(&sp1CC, mapImage, gWorldMapImageTLUT, 216, 128, G_IM_FMT_CI, G_IM_SIZ_8b, 0x8000, 256,
                       HREG(13) / 100.0f, HREG(14) / 100.0f);
 
-        // gSPLoadUcode(sp1CC++, SysUcode_GetUCode(), SysUcode_GetUCodeData())?
-        gSPLoadUcodeEx(sp1CC++, SysUcode_GetUCode(), SysUcode_GetUCodeData(), 0x800);
+        gSPLoadUcode(sp1CC++, SysUcode_GetUCode());
 
         POLY_KAL_DISP = sp1CC;
     }

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_map_PAL.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_map_PAL.c
@@ -594,17 +594,16 @@ void KaleidoScope_DrawWorldMap(PlayState* play, GraphicsContext* gfxCtx) {
 
         gSP1Quadrangle(POLY_KAL_DISP++, j, j + 2, j + 3, j + 1, 0);
     } else if (HREG(15) == 1) {
-        Gfx* sp1CC = POLY_KAL_DISP;
-        void* mapImage = gWorldMapImageTex;
+        Gfx* gfx = POLY_KAL_DISP;
 
-        gSPLoadUcodeL(sp1CC++, ucode_s2dex);
+        gSPLoadUcodeL(gfx++, ucode_s2dex);
 
-        func_8009638C(&sp1CC, mapImage, gWorldMapImageTLUT, 216, 128, G_IM_FMT_CI, G_IM_SIZ_8b, 0x8000, 256,
-                      HREG(13) / 100.0f, HREG(14) / 100.0f);
+        Room_DrawBackground2D(&gfx, gWorldMapImageTex, gWorldMapImageTLUT, 216, 128, G_IM_FMT_CI, G_IM_SIZ_8b,
+                              G_TT_RGBA16, 256, HREG(13) / 100.0f, HREG(14) / 100.0f);
 
-        gSPLoadUcode(sp1CC++, SysUcode_GetUCode());
+        gSPLoadUcode(gfx++, SysUcode_GetUCode());
 
-        POLY_KAL_DISP = sp1CC;
+        POLY_KAL_DISP = gfx;
     }
 
     if (HREG(15) == 2) {


### PR DESCRIPTION
After https://github.com/Kenix3/libultraship/pull/461 we now need to explicitly mark the ucodes that we need to load using enums from LUS. This makes using s2dex operations work correctly for room backgrounds.

I also updated the background draw func to pull in latest docs, and conditionally render the black rectangle only for widescreens.

First commit is the real fix, second is the docs.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1385516277.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1385521315.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1385521885.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1385522466.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1385523857.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1385532401.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1385534266.zip)
<!--- section:artifacts:end -->