### PR TITLE
Fix memory leak in WrappedText

### DIFF
--- a/soh/soh/UIWidgets.cpp
+++ b/soh/soh/UIWidgets.cpp
@@ -28,7 +28,7 @@ namespace UIWidgets {
         std::string newText(text);
         const size_t tipLength = newText.length();
         int lastSpace = -1;
-        int currentLineLength = 0;
+        unsigned int currentLineLength = 0;
         for (unsigned int currentCharacter = 0; currentCharacter < tipLength; currentCharacter++) {
             if (newText[currentCharacter] == '\n') {
                 currentLineLength = 0;
@@ -46,7 +46,7 @@ namespace UIWidgets {
             currentLineLength++;
         }
 
-        return strdup(newText.c_str());
+        return _strdup(newText.c_str());
     }
 
     char* WrappedText(const std::string& text, unsigned int charactersPerLine) {
@@ -56,7 +56,9 @@ namespace UIWidgets {
     void SetLastItemHoverText(const std::string& text) {
         if (ImGui::IsItemHovered()) {
             ImGui::BeginTooltip();
-            ImGui::Text("%s", WrappedText(text, 60));
+            char* hoverTextWrapped = WrappedText(text, 60);
+            ImGui::Text("%s", hoverTextWrapped);
+            free(hoverTextWrapped);
             ImGui::EndTooltip();
         }
     }
@@ -64,7 +66,9 @@ namespace UIWidgets {
     void SetLastItemHoverText(const char* text) {
         if (ImGui::IsItemHovered()) {
             ImGui::BeginTooltip();
-            ImGui::Text("%s", WrappedText(text, 60));
+            char* hoverTextWrapped = WrappedText(text, 60);
+            ImGui::Text("%s", hoverTextWrapped);
+            free(hoverTextWrapped);
             ImGui::EndTooltip();
         }
     }
@@ -75,7 +79,9 @@ namespace UIWidgets {
         ImGui::TextColored(ImVec4(0.7f, 0.7f, 0.7f, 1.0f), "?");
         if (ImGui::IsItemHovered()) {
             ImGui::BeginTooltip();
-            ImGui::Text("%s", WrappedText(text, 60));
+            char* hoverTextWrapped = WrappedText(text, 60);
+            ImGui::Text("%s", hoverTextWrapped);
+            free(hoverTextWrapped);
             ImGui::EndTooltip();
         }
     }
@@ -85,7 +91,9 @@ namespace UIWidgets {
         ImGui::TextColored(ImVec4(0.7f, 0.7f, 0.7f, 1.0f), "?");
         if (ImGui::IsItemHovered()) {
             ImGui::BeginTooltip();
-            ImGui::Text("%s", WrappedText(text, 60));
+            char* hoverTextWrapped = WrappedText(text, 60);
+            ImGui::Text("%s", hoverTextWrapped);
+            free(hoverTextWrapped);
             ImGui::EndTooltip();
         }
     }
@@ -95,7 +103,9 @@ namespace UIWidgets {
 
     void Tooltip(const char* text) {
         if (ImGui::IsItemHovered()) {
-            ImGui::SetTooltip("%s", WrappedText(text));
+            char* tooltipWrapped = WrappedText(text);
+            ImGui::SetTooltip("%s", tooltipWrapped);
+            free(tooltipWrapped);
         }
     }
 

--- a/soh/soh/UIWidgets.cpp
+++ b/soh/soh/UIWidgets.cpp
@@ -17,6 +17,10 @@
 #include <libultraship/libultra/types.h>
 #include "soh/Enhancements/cosmetics/CosmeticsEditor.h"
 
+#ifdef _MSC_VER
+#define strdup _strdup
+#endif
+
 namespace UIWidgets {
 
     // MARK: - Layout Helper
@@ -46,7 +50,7 @@ namespace UIWidgets {
             currentLineLength++;
         }
 
-        return _strdup(newText.c_str());
+        return strdup(newText.c_str());
     }
 
     char* WrappedText(const std::string& text, unsigned int charactersPerLine) {


### PR DESCRIPTION
This function allocated memory with `_strdup` and was never freed.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1392241006.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1392246052.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1392249230.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1392250103.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1392251520.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1392252275.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1392270181.zip)
<!--- section:artifacts:end -->