### PR TITLE
Scale ship icon and match parent width of randomizer menu buttons

### DIFF
--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -126,7 +126,7 @@ void DrawMenuBarIcon() {
         ImVec2 iconSize = ImVec2(16.0f * 2, 16.0f * 2);
         float posScale = 2.0f;
 #else
-        float posScale = GImGui->CurrentDpiScale * imguiScaleOptionToValue[CVarGetInteger("gImGuiScale", defaultImGuiScale)];
+        float posScale = LUS::Context::GetInstance()->GetWindow()->GetGui()->GetCurrentDpiScale() * imguiScaleOptionToValue[CVarGetInteger("gImGuiScale", defaultImGuiScale)];
         ImVec2 iconSize = ImVec2(16.0f * posScale, 16.0f * posScale);
 #endif
         ImGui::SetCursorPos(ImVec2(5, 2.5f) * posScale);

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -126,8 +126,8 @@ void DrawMenuBarIcon() {
         ImVec2 iconSize = ImVec2(16.0f * 2, 16.0f * 2);
         float posScale = 2.0f;
 #else
-        ImVec2 iconSize = ImVec2(16.0f, 16.0f);
-        float posScale = 1.0f;
+        float posScale = GImGui->CurrentDpiScale * imguiScaleOptionToValue[CVarGetInteger("gImGuiScale", defaultImGuiScale)];
+        ImVec2 iconSize = ImVec2(16.0f * posScale, 16.0f * posScale);
 #endif
         ImGui::SetCursorPos(ImVec2(5, 2.5f) * posScale);
         ImGui::Image(LUS::Context::GetInstance()->GetWindow()->GetGui()->GetTextureByName("Game_Icon"), iconSize);
@@ -1889,7 +1889,7 @@ void DrawRandomizerMenu() {
     #ifdef __WIIU__
         static ImVec2 buttonSize(200.0f * 2.0f, 0.0f);
     #else
-        static ImVec2 buttonSize(200.0f, 0.0f);
+        static ImVec2 buttonSize(-1.0f, 0.0f);
     #endif
         if (mRandomizerSettingsWindow) {
             if (ImGui::Button(GetWindowButtonText("Randomizer Settings", CVarGetInteger("gRandomizerSettingsEnabled", 0)).c_str(), buttonSize)) {


### PR DESCRIPTION
This is complementary to my pull request in LUS: https://github.com/Kenix3/libultraship/pull/467
The ship icon isn't properly scaled if playing on a different UI scale.

![grafik](https://github.com/HarbourMasters/Shipwright/assets/25563010/5db15ef1-1302-4229-8760-18971740e222)

To match the new scaling in of my pull request in LUS i used the CurrentDpiScale of ImGUI and the value of the scale menu to adjust the size of the ship.

I also noticed the button width inside the randomizer menu is set to a fix value of 200 which looks like this if playing on a larger scale:

![grafik](https://github.com/HarbourMasters/Shipwright/assets/25563010/5a3a0fc5-07d4-40c5-bd3f-927ee5a49485)

This can be -1 instead to auto expand to the parent width like in the other menus.
The pictures are made in the current release version.