### PR TITLE
Added functionality to ocarina HUDs to reflect custom controls

### DIFF
--- a/soh/src/code/z_message_PAL.c
+++ b/soh/src/code/z_message_PAL.c
@@ -80,6 +80,10 @@ Color_RGB8 sOcarinaNoteCBtnEnv;
 Color_RGB8 sOcarinaNoteABtnPrim;
 Color_RGB8 sOcarinaNoteCBtnPrim;
 
+Color_RGB8 sOcarinaNoteCUpBtnEnv;
+Color_RGB8 sOcarinaNoteCLeftBtnEnv;
+Color_RGB8 sOcarinaNoteCRightBtnEnv;
+Color_RGB8 sOcarinaNoteCDownBtnEnv;
 Color_RGB8 sOcarinaNoteCUpBtnPrim;
 Color_RGB8 sOcarinaNoteCLeftBtnPrim;
 Color_RGB8 sOcarinaNoteCRightBtnPrim;
@@ -2005,9 +2009,37 @@ void Message_DrawMain(PlayState* play, Gfx** p) {
         ACTOR_OCEFF_WIPE,  ACTOR_OCEFF_STORM, ACTOR_OCEFF_WIPE4,
     };
     static s16 sOcarinaEffectActorParams[] = { 0x0000, 0x0000, 0x0000, 0x0000, 0x0001, 0x0000, 0x0000 };
-    static void* sOcarinaNoteTextures[] = {
-        gOcarinaBtnIconATex, gOcarinaBtnIconCDownTex, gOcarinaBtnIconCRightTex, gOcarinaBtnIconCLeftTex, gOcarinaBtnIconCUpTex,
+
+    int32_t sOcarinaBtnMaps[5] = {
+        CVarGetInteger("gOcarinaD4BtnMap", BTN_A),
+        CVarGetInteger("gOcarinaF4BtnMap", BTN_CDOWN),
+        CVarGetInteger("gOcarinaA4BtnMap", BTN_CRIGHT),
+        CVarGetInteger("gOcarinaB4BtnMap", BTN_CLEFT),
+        CVarGetInteger("gOcarinaD5BtnMap", BTN_CUP)
     };
+
+    static void* sOcarinaNoteTextures[5];
+
+    for (int i = 0; i < 5; i++) {
+        switch (sOcarinaBtnMaps[i]) {
+            default:
+            case BTN_A:
+                sOcarinaNoteTextures[i] = gOcarinaBtnIconATex;
+                break;
+            case BTN_CDOWN:
+                sOcarinaNoteTextures[i] = gOcarinaBtnIconCDownTex;
+                break;
+            case BTN_CRIGHT:
+                sOcarinaNoteTextures[i] = gOcarinaBtnIconCRightTex;
+                break;
+            case BTN_CLEFT:
+                sOcarinaNoteTextures[i] = gOcarinaBtnIconCLeftTex;
+                break;
+            case BTN_CUP:
+                sOcarinaNoteTextures[i] = gOcarinaBtnIconCUpTex;
+                break;
+        }
+    }
 
     // SoH [Cosmetics] The following Color_RGB8 were originally static
     Color_RGB8 sOcarinaNoteAPrimColors[2] = {
@@ -2325,13 +2357,13 @@ void Message_DrawMain(PlayState* play, Gfx** p) {
                 FLASH_NOTE_COLORS(sOcarinaNoteCBtnPrim, sOcarinaNoteCPrimColors)
                 FLASH_NOTE_COLORS(sOcarinaNoteCBtnEnv, sOcarinaNoteCEnvColors)
                 FLASH_NOTE_COLORS(sOcarinaNoteCUpBtnPrim, sOcarinaNoteCUpPrimColors)
-                FLASH_NOTE_COLORS(sOcarinaNoteCBtnEnv, sOcarinaNoteCUpEnvColors)
+                FLASH_NOTE_COLORS(sOcarinaNoteCUpBtnEnv, sOcarinaNoteCUpEnvColors)
                 FLASH_NOTE_COLORS(sOcarinaNoteCDownBtnPrim, sOcarinaNoteCDownPrimColors)
-                FLASH_NOTE_COLORS(sOcarinaNoteCBtnEnv, sOcarinaNoteCDownEnvColors)
+                FLASH_NOTE_COLORS(sOcarinaNoteCDownBtnEnv, sOcarinaNoteCDownEnvColors)
                 FLASH_NOTE_COLORS(sOcarinaNoteCLeftBtnPrim, sOcarinaNoteCLeftPrimColors)
-                FLASH_NOTE_COLORS(sOcarinaNoteCBtnEnv, sOcarinaNoteCLeftEnvColors)
+                FLASH_NOTE_COLORS(sOcarinaNoteCLeftBtnEnv, sOcarinaNoteCLeftEnvColors)
                 FLASH_NOTE_COLORS(sOcarinaNoteCRightBtnPrim, sOcarinaNoteCRightPrimColors)
-                FLASH_NOTE_COLORS(sOcarinaNoteCBtnEnv, sOcarinaNoteCRightEnvColors)
+                FLASH_NOTE_COLORS(sOcarinaNoteCRightBtnEnv, sOcarinaNoteCRightEnvColors)
 
                 sOcarinaNoteFlashTimer--;
                 if (sOcarinaNoteFlashTimer == 0) {
@@ -2968,23 +3000,39 @@ void Message_DrawMain(PlayState* play, Gfx** p) {
 
                     gDPPipeSync(gfx++);
 
-                    // Since I don't know what exactly these Env vars are used for, I elected keep their usage
-                    // consistent with the note played, rather than having AEnv be used for whatever note A happens to
-                    // play at the moment and CEnv for everything else, even with custom controls enabled.
-                    if (sOcarinaNoteBuf[i] == OCARINA_NOTE_D4) {
-                        gDPSetPrimColor(gfx++, 0, 0, sOcarinaNoteABtnPrim.r, sOcarinaNoteABtnPrim.g, sOcarinaNoteABtnPrim.b, sOcarinaNotesAlphaValues[i]);
-                        gDPSetEnvColor(gfx++, sOcarinaNoteABtnEnv.r, sOcarinaNoteABtnEnv.g, sOcarinaNoteABtnEnv.b, 0);
-                    } else {
-                        if (sOcarinaNoteBuf[i] == OCARINA_NOTE_D5) {
-                            gDPSetPrimColor(gfx++, 0, 0, sOcarinaNoteCUpBtnPrim.r, sOcarinaNoteCUpBtnPrim.g, sOcarinaNoteCUpBtnPrim.b, sOcarinaNotesAlphaValues[i]);
-                        } else if (sOcarinaNoteBuf[i] == OCARINA_NOTE_B4) {
-                            gDPSetPrimColor(gfx++, 0, 0, sOcarinaNoteCLeftBtnPrim.r, sOcarinaNoteCLeftBtnPrim.g, sOcarinaNoteCLeftBtnPrim.b, sOcarinaNotesAlphaValues[i]);
-                        } else if (sOcarinaNoteBuf[i] == OCARINA_NOTE_A4) {
-                            gDPSetPrimColor(gfx++, 0, 0, sOcarinaNoteCRightBtnPrim.r, sOcarinaNoteCRightBtnPrim.g, sOcarinaNoteCRightBtnPrim.b, sOcarinaNotesAlphaValues[i]);
-                        } else if (sOcarinaNoteBuf[i] == OCARINA_NOTE_F4) {
-                            gDPSetPrimColor(gfx++, 0, 0, sOcarinaNoteCDownBtnPrim.r, sOcarinaNoteCDownBtnPrim.g, sOcarinaNoteCDownBtnPrim.b, sOcarinaNotesAlphaValues[i]);
-                        }
-                        gDPSetEnvColor(gfx++, sOcarinaNoteCBtnEnv.r, sOcarinaNoteCBtnEnv.g, sOcarinaNoteCBtnEnv.b, 0);
+                    // Quick hack for getting custom colors to work with custom ocarina controls
+                    switch (sOcarinaBtnMaps[sOcarinaNoteBuf[i]]) {
+                        default:
+                        case BTN_A:
+                            gDPSetPrimColor(gfx++, 0, 0, sOcarinaNoteABtnPrim.r, sOcarinaNoteABtnPrim.g,
+                                            sOcarinaNoteABtnPrim.b, sOcarinaNotesAlphaValues[i]);
+                            gDPSetEnvColor(gfx++, sOcarinaNoteABtnEnv.r, sOcarinaNoteABtnEnv.g, sOcarinaNoteABtnEnv.b,
+                                           0);
+                            break;
+                        case BTN_CDOWN:
+                            gDPSetPrimColor(gfx++, 0, 0, sOcarinaNoteCDownBtnPrim.r, sOcarinaNoteCDownBtnPrim.g,
+                                            sOcarinaNoteCDownBtnPrim.b, sOcarinaNotesAlphaValues[i]);
+                            gDPSetEnvColor(gfx++, sOcarinaNoteCDownBtnEnv.r, sOcarinaNoteCDownBtnEnv.g, sOcarinaNoteCDownBtnEnv.b,
+                                           0);
+                            break;
+                        case BTN_CRIGHT:
+                            gDPSetPrimColor(gfx++, 0, 0, sOcarinaNoteCRightBtnPrim.r, sOcarinaNoteCRightBtnPrim.g,
+                                            sOcarinaNoteCRightBtnPrim.b, sOcarinaNotesAlphaValues[i]);
+                            gDPSetEnvColor(gfx++, sOcarinaNoteCRightBtnEnv.r, sOcarinaNoteCRightBtnEnv.g,
+                                           sOcarinaNoteCRightBtnEnv.b, 0);
+                            break;
+                        case BTN_CLEFT:
+                            gDPSetPrimColor(gfx++, 0, 0, sOcarinaNoteCLeftBtnPrim.r, sOcarinaNoteCLeftBtnPrim.g,
+                                            sOcarinaNoteCLeftBtnPrim.b, sOcarinaNotesAlphaValues[i]);
+                            gDPSetEnvColor(gfx++, sOcarinaNoteCLeftBtnEnv.r, sOcarinaNoteCLeftBtnEnv.g,
+                                           sOcarinaNoteCLeftBtnEnv.b, 0);
+                            break;
+                        case BTN_CUP:
+                            gDPSetPrimColor(gfx++, 0, 0, sOcarinaNoteCUpBtnPrim.r, sOcarinaNoteCUpBtnPrim.g,
+                                            sOcarinaNoteCUpBtnPrim.b, sOcarinaNotesAlphaValues[i]);
+                            gDPSetEnvColor(gfx++, sOcarinaNoteCUpBtnEnv.r, sOcarinaNoteCUpBtnEnv.g,
+                                           sOcarinaNoteCUpBtnEnv.b, 0);
+                            break;
                     }
 
                     gDPLoadTextureBlock(gfx++, sOcarinaNoteTextures[sOcarinaNoteBuf[i]], G_IM_FMT_IA, G_IM_SIZ_8b, 16,

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_collect.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_collect.c
@@ -60,9 +60,38 @@ void KaleidoScope_DrawQuestStatus(PlayState* play, GraphicsContext* gfxCtx) {
     static u8 D_8082A124[] = {
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     };
-    static void* D_8082A130[] = {
-        gOcarinaBtnIconATex, gOcarinaBtnIconCDownTex, gOcarinaBtnIconCRightTex, gOcarinaBtnIconCLeftTex, gOcarinaBtnIconCUpTex,
+
+    int32_t sOcarinaBtnMaps[5] = { CVarGetInteger("gOcarinaD4BtnMap", BTN_A),
+                                   CVarGetInteger("gOcarinaF4BtnMap", BTN_CDOWN),
+                                   CVarGetInteger("gOcarinaA4BtnMap", BTN_CRIGHT),
+                                   CVarGetInteger("gOcarinaB4BtnMap", BTN_CLEFT),
+                                   CVarGetInteger("gOcarinaD5BtnMap", BTN_CUP)
     };
+
+    // Hack to get custom ocarina controls to override default
+    static void* sOcarinaNoteTextures[5];
+
+    for (int i = 0; i < 5; i++) {
+        switch (sOcarinaBtnMaps[i]) {
+            default:
+            case BTN_A:
+                sOcarinaNoteTextures[i] = gOcarinaBtnIconATex;
+                break;
+            case BTN_CDOWN:
+                sOcarinaNoteTextures[i] = gOcarinaBtnIconCDownTex;
+                break;
+            case BTN_CRIGHT:
+                sOcarinaNoteTextures[i] = gOcarinaBtnIconCRightTex;
+                break;
+            case BTN_CLEFT:
+                sOcarinaNoteTextures[i] = gOcarinaBtnIconCLeftTex;
+                break;
+            case BTN_CUP:
+                sOcarinaNoteTextures[i] = gOcarinaBtnIconCUpTex;
+                break;
+        }
+    }
+
     static u16 D_8082A144[] = {
         0xFFCC, 0xFFCC, 0xFFCC, 0xFFCC, 0xFFCC,
     };
@@ -523,26 +552,60 @@ void KaleidoScope_DrawQuestStatus(PlayState* play, GraphicsContext* gfxCtx) {
                     gDPPipeSync(POLY_KAL_DISP++);
 
                     s16 Notes_alpha = D_8082A150[sp218];
-                    if (D_8082A124[sp218] == 0) {
-                        gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, aButtonColor.r, aButtonColor.g, aButtonColor.b, Notes_alpha);
+                    // Quick hack for getting custom colors to work with custom ocarina controls
+                    switch (sOcarinaBtnMaps [D_8082A124[sp218]]) {
+                        case BTN_A:
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, aButtonColor.r, aButtonColor.g, aButtonColor.b,
+                                            Notes_alpha);
+                            break;
+                        case BTN_CDOWN:
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, cDownButtonColor.r, cDownButtonColor.g,
+                                            cDownButtonColor.b, Notes_alpha);
+                            break;
+                        case BTN_CRIGHT:
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, cRightButtonColor.r, cRightButtonColor.g,
+                                            cRightButtonColor.b, Notes_alpha);
+                            break;
+                        case BTN_CLEFT:
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, cLeftButtonColor.r, cLeftButtonColor.g,
+                                            cLeftButtonColor.b, Notes_alpha);
+                            break;
+                        case BTN_CUP:
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, cUpButtonColor.r, cUpButtonColor.g, cUpButtonColor.b,
+                                            Notes_alpha);
+                            break;
+                        default:
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, cButtonsColor.r, cButtonsColor.g, cButtonsColor.b,
+                                            Notes_alpha);
+                            break;
+                    }
+                    /// OLD FUNCTIONALITY
+                    /*if (D_8082A124[sp218] == 0) {
+                        gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, aButtonColor.r, aButtonColor.g, aButtonColor.b,
+                                        Notes_alpha);
                     } else {
                         if (D_8082A124[sp218] == OCARINA_NOTE_D5) {
-                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, cUpButtonColor.r, cUpButtonColor.g, cUpButtonColor.b, Notes_alpha);
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, cUpButtonColor.r, cUpButtonColor.g, cUpButtonColor.b,
+                                            Notes_alpha);
                         } else if (D_8082A124[sp218] == OCARINA_NOTE_B4) {
-                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, cLeftButtonColor.r, cLeftButtonColor.g, cLeftButtonColor.b, Notes_alpha);
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, cLeftButtonColor.r, cLeftButtonColor.g,
+                                            cLeftButtonColor.b, Notes_alpha);
                         } else if (D_8082A124[sp218] == OCARINA_NOTE_A4) {
-                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, cRightButtonColor.r, cRightButtonColor.g, cRightButtonColor.b, Notes_alpha);
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, cRightButtonColor.r, cRightButtonColor.g,
+                                            cRightButtonColor.b, Notes_alpha);
                         } else if (D_8082A124[sp218] == OCARINA_NOTE_F4) {
-                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, cDownButtonColor.r, cDownButtonColor.g, cDownButtonColor.b, Notes_alpha);
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, cDownButtonColor.r, cDownButtonColor.g,
+                                            cDownButtonColor.b, Notes_alpha);
                         } else {
-                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, cButtonsColor.r, cButtonsColor.g, cButtonsColor.b, Notes_alpha);
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, cButtonsColor.r, cButtonsColor.g, cButtonsColor.b,
+                                            Notes_alpha);
                         }
-                    }
+                    }*/
 
                     gDPSetEnvColor(POLY_KAL_DISP++, 10, 10, 10, 0);
                     gSPVertex(POLY_KAL_DISP++, &pauseCtx->questVtx[sp21A], 4, 0);
 
-                    gDPLoadTextureBlock(POLY_KAL_DISP++, D_8082A130[D_8082A124[sp218]], G_IM_FMT_IA, G_IM_SIZ_8b, 16,
+                    gDPLoadTextureBlock(POLY_KAL_DISP++, sOcarinaNoteTextures[D_8082A124[sp218]], G_IM_FMT_IA, G_IM_SIZ_8b, 16,
                                         16, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK,
                                         G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
 
@@ -564,21 +627,55 @@ void KaleidoScope_DrawQuestStatus(PlayState* play, GraphicsContext* gfxCtx) {
 
                 if (pauseCtx->unk_1E4 == 8) {
                     s16 Notes_alpha = 200;
-                    if (gOcarinaSongNotes[sp224].notesIdx[phi_s3] == 0) {
-                        gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, aButtonColor.r, aButtonColor.g, aButtonColor.b, Notes_alpha);
+                    // Quick hack for getting custom colors to work with custom ocarina controls
+                    switch (sOcarinaBtnMaps[gOcarinaSongNotes[sp224].notesIdx[phi_s3]]) {
+                        case BTN_A:
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, aButtonColor.r, aButtonColor.g, aButtonColor.b,
+                                            Notes_alpha);
+                            break;
+                        case BTN_CDOWN:
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, cDownButtonColor.r, cDownButtonColor.g,
+                                            cDownButtonColor.b, Notes_alpha);
+                            break;
+                        case BTN_CRIGHT:
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, cRightButtonColor.r, cRightButtonColor.g,
+                                            cRightButtonColor.b, Notes_alpha);
+                            break;
+                        case BTN_CLEFT:
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, cLeftButtonColor.r, cLeftButtonColor.g,
+                                            cLeftButtonColor.b, Notes_alpha);
+                            break;
+                        case BTN_CUP:
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, cUpButtonColor.r, cUpButtonColor.g, cUpButtonColor.b,
+                                            Notes_alpha);
+                            break;
+                        default:
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, cButtonsColor.r, cButtonsColor.g, cButtonsColor.b,
+                                            Notes_alpha);
+                            break;
+                    }
+                    /// OLD FUNCTIONALITY
+                    /*if (gOcarinaSongNotes[sp224].notesIdx[phi_s3] == 0) {
+                        gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, aButtonColor.r, aButtonColor.g, aButtonColor.b,
+                                        Notes_alpha);
                     } else {
                         if (gOcarinaSongNotes[sp224].notesIdx[phi_s3] == OCARINA_NOTE_D5) {
-                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, cUpButtonColor.r, cUpButtonColor.g, cUpButtonColor.b, Notes_alpha);
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, cUpButtonColor.r, cUpButtonColor.g, cUpButtonColor.b,
+                                            Notes_alpha);
                         } else if (gOcarinaSongNotes[sp224].notesIdx[phi_s3] == OCARINA_NOTE_B4) {
-                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, cLeftButtonColor.r, cLeftButtonColor.g, cLeftButtonColor.b, Notes_alpha);
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, cLeftButtonColor.r, cLeftButtonColor.g,
+                                            cLeftButtonColor.b, Notes_alpha);
                         } else if (gOcarinaSongNotes[sp224].notesIdx[phi_s3] == OCARINA_NOTE_A4) {
-                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, cRightButtonColor.r, cRightButtonColor.g, cRightButtonColor.b, Notes_alpha);
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, cRightButtonColor.r, cRightButtonColor.g,
+                                            cRightButtonColor.b, Notes_alpha);
                         } else if (gOcarinaSongNotes[sp224].notesIdx[phi_s3] == OCARINA_NOTE_F4) {
-                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, cDownButtonColor.r, cDownButtonColor.g, cDownButtonColor.b, Notes_alpha);
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, cDownButtonColor.r, cDownButtonColor.g,
+                                            cDownButtonColor.b, Notes_alpha);
                         } else {
-                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, cButtonsColor.r, cButtonsColor.g, cButtonsColor.b, Notes_alpha);
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, cButtonsColor.r, cButtonsColor.g, cButtonsColor.b,
+                                            Notes_alpha);
                         }
-                    }
+                    }*/
                 } else {
                     gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 150, 150, 150, 150);
                 }
@@ -587,7 +684,7 @@ void KaleidoScope_DrawQuestStatus(PlayState* play, GraphicsContext* gfxCtx) {
 
                 gSPVertex(POLY_KAL_DISP++, &pauseCtx->questVtx[sp21A], 4, 0);
 
-                gDPLoadTextureBlock(POLY_KAL_DISP++, D_8082A130[gOcarinaSongNotes[sp224].notesIdx[phi_s3]], G_IM_FMT_IA,
+                gDPLoadTextureBlock(POLY_KAL_DISP++, sOcarinaNoteTextures[gOcarinaSongNotes[sp224].notesIdx[phi_s3]], G_IM_FMT_IA,
                                     G_IM_SIZ_8b, 16, 16, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP,
                                     G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
 
@@ -630,27 +727,61 @@ void KaleidoScope_DrawQuestStatus(PlayState* play, GraphicsContext* gfxCtx) {
                     gDPPipeSync(POLY_KAL_DISP++);
 
                     s16 Notes_alpha = D_8082A150[phi_s3];
-                    if (D_8082A124[phi_s3] == 0) {
-                        gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, aButtonColor.r, aButtonColor.g, aButtonColor.b, Notes_alpha);
+                    // Quick hack for getting custom colors to work with custom ocarina controls
+                    switch (sOcarinaBtnMaps [gOcarinaSongNotes[sp224].notesIdx[phi_s3]]) {
+                        case BTN_A:
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, aButtonColor.r, aButtonColor.g, aButtonColor.b,
+                                            Notes_alpha);
+                            break;
+                        case BTN_CDOWN:
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, cDownButtonColor.r, cDownButtonColor.g,
+                                            cDownButtonColor.b, Notes_alpha);
+                            break;
+                        case BTN_CRIGHT:
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, cRightButtonColor.r, cRightButtonColor.g,
+                                            cRightButtonColor.b, Notes_alpha);
+                            break;
+                        case BTN_CLEFT:
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, cLeftButtonColor.r, cLeftButtonColor.g,
+                                            cLeftButtonColor.b, Notes_alpha);
+                            break;
+                        case BTN_CUP:
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, cUpButtonColor.r, cUpButtonColor.g, cUpButtonColor.b,
+                                            Notes_alpha);
+                            break;
+                        default:
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, cButtonsColor.r, cButtonsColor.g, cButtonsColor.b,
+                                            Notes_alpha);
+                            break;
+                    }
+                    /// OLD FUNCTIONALITY
+                    /*if (D_8082A124[phi_s3] == 0) {
+                        gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, aButtonColor.r, aButtonColor.g, aButtonColor.b,
+                                        Notes_alpha);
                     } else {
                         if (gOcarinaSongNotes[sp224].notesIdx[phi_s3] == OCARINA_NOTE_D5) {
-                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, cUpButtonColor.r, cUpButtonColor.g, cUpButtonColor.b, Notes_alpha);
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, cUpButtonColor.r, cUpButtonColor.g, cUpButtonColor.b,
+                                            Notes_alpha);
                         } else if (gOcarinaSongNotes[sp224].notesIdx[phi_s3] == OCARINA_NOTE_B4) {
-                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, cLeftButtonColor.r, cLeftButtonColor.g, cLeftButtonColor.b, Notes_alpha);
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, cLeftButtonColor.r, cLeftButtonColor.g,
+                                            cLeftButtonColor.b, Notes_alpha);
                         } else if (gOcarinaSongNotes[sp224].notesIdx[phi_s3] == OCARINA_NOTE_A4) {
-                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, cRightButtonColor.r, cRightButtonColor.g, cRightButtonColor.b, Notes_alpha);
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, cRightButtonColor.r, cRightButtonColor.g,
+                                            cRightButtonColor.b, Notes_alpha);
                         } else if (gOcarinaSongNotes[sp224].notesIdx[phi_s3] == OCARINA_NOTE_F4) {
-                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, cDownButtonColor.r, cDownButtonColor.g, cDownButtonColor.b, Notes_alpha);
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, cDownButtonColor.r, cDownButtonColor.g,
+                                            cDownButtonColor.b, Notes_alpha);
                         } else {
-                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, cButtonsColor.r, cButtonsColor.g, cButtonsColor.b, Notes_alpha);
+                            gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, cButtonsColor.r, cButtonsColor.g, cButtonsColor.b,
+                                            Notes_alpha);
                         }
-                    }
+                    }*/
 
                     gDPSetEnvColor(POLY_KAL_DISP++, 10, 10, 10, 0);
 
                     gSPVertex(POLY_KAL_DISP++, &pauseCtx->questVtx[sp21A], 4, 0);
 
-                    gDPLoadTextureBlock(POLY_KAL_DISP++, D_8082A130[D_8082A124[phi_s3]], G_IM_FMT_IA, G_IM_SIZ_8b, 16,
+                    gDPLoadTextureBlock(POLY_KAL_DISP++, sOcarinaNoteTextures[D_8082A124[phi_s3]], G_IM_FMT_IA, G_IM_SIZ_8b, 16,
                                         16, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK,
                                         G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
 

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_collect.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_collect.c
@@ -655,6 +655,7 @@ void KaleidoScope_DrawQuestStatus(PlayState* play, GraphicsContext* gfxCtx) {
                             break;
                     }
                     /// OLD FUNCTIONALITY
+                    // todo: remove if not needed
                     /*if (gOcarinaSongNotes[sp224].notesIdx[phi_s3] == 0) {
                         gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, aButtonColor.r, aButtonColor.g, aButtonColor.b,
                                         Notes_alpha);


### PR DESCRIPTION
Let's you see visually what burtons you're pressing when you've customized your ocarina controls
![Screenshot 2024-04-10 030501](https://github.com/HarbourMasters/Shipwright/assets/147758365/6049243a-6f9e-4511-9fd5-250b49de41e5)
![Screenshot 2024-04-10 030542](https://github.com/HarbourMasters/Shipwright/assets/147758365/4187b7d7-151b-4c13-b1a8-2c7afd817a96)