### PR TITLE
Fixes crashes on asan related to audio.

### DIFF
--- a/soh/soh/mixer.c
+++ b/soh/soh/mixer.c
@@ -99,8 +99,14 @@ void aClearBufferImpl(uint16_t addr, int nbytes) {
     memset(BUF_U8(addr), 0, nbytes);
 }
 
-void aLoadBufferImpl(const void *source_addr, uint16_t dest_addr, uint16_t nbytes) {
+void aLoadBufferImpl(const void* source_addr, uint16_t dest_addr, uint16_t nbytes) {
+#if __SANITIZE_ADDRESS__
+    for (size_t i = 0; i < ROUND_DOWN_16(nbytes); i++) {
+        BUF_U8(dest_addr)[i] = ((const unsigned char*)source_addr)[i];
+    }
+#else
     memcpy(BUF_U8(dest_addr), source_addr, ROUND_DOWN_16(nbytes));
+#endif
 }
 
 void aSaveBufferImpl(uint16_t source_addr, int16_t *dest_addr, uint16_t nbytes) {


### PR DESCRIPTION
Found in MM

The issue is actually in the caller function, and it's believed to exist on the original game. Basically the caller doesn't correctly stop loading the sample using `aLoadBuffer` correctly. It tries to copy a set number of frames, but the issue is that the samples don't always have that much data.
The mixer func shouldn't be modified imo
The exporter should generate padded samples that have enough data to account for alignment.
Modifying just the mixer is more brittle because there may be other code affected by alignment issues. 
The calling func is just not calculating sample positions correctly, and the samples aren't aligned.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1403533293.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1403557707.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1403558817.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1403559796.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1403564790.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1403565320.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1403609389.zip)
<!--- section:artifacts:end -->