### PR TITLE
fix wii u ci

### DIFF
--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -235,8 +235,6 @@ jobs:
     - name: Install dependencies
       if: ${{ !vars.LINUX_RUNNER }}
       run: |
-        sudo cat /etc/apt/sources.list
-        sudo apt-get update
         sudo apt-get install -y ninja-build
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -235,6 +235,7 @@ jobs:
     - name: Install dependencies
       if: ${{ !vars.LINUX_RUNNER }}
       run: |
+        sudo cat /etc/apt/sources.list
         sudo apt-get update
         sudo apt-get install -y ninja-build
     - uses: actions/checkout@v3


### PR DESCRIPTION
both when running the image locally `docker run -it devkitpro/devkitppc:20230110 bash` [and on ci](https://github.com/briaguya-ai/Shipwright/actions/runs/8753065565/job/24022242976) i wasn't able to find any reference to backports in apt sources
![image](https://github.com/HarbourMasters/Shipwright/assets/70942617/7c1cdacf-fbb5-4051-b113-e8d20b73be56)

i opted to just remove the `sudo apt-get update` line which seems to resolve the issue

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1429454533.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1429460042.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1429460432.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1429460650.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1429461630.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1429484718.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1429579943.zip)
<!--- section:artifacts:end -->