### PR TITLE
Fixes bugs with spoiler file parsing

### DIFF
--- a/soh/soh/Enhancements/randomizer/context.cpp
+++ b/soh/soh/Enhancements/randomizer/context.cpp
@@ -20,19 +20,6 @@ namespace Rando {
 std::weak_ptr<Context> Context::mContext;
 
 Context::Context() {
-    mSpoilerfileCheckNameToEnum["Invalid Location"] = RC_UNKNOWN_CHECK;
-    mSpoilerfileCheckNameToEnum["Link's Pocket"] = RC_LINKS_POCKET;
-
-    for (auto& item : StaticData::GetItemTable()) {
-        // Easiest way to filter out all the empty values from the array, since we still technically want the 0/RG_NONE
-        // entry
-        if (item.GetName().english.empty()) {
-            continue;
-        }
-        mSpoilerfileGetNameToEnum[item.GetName().english] = item.GetRandomizerGet();
-        mSpoilerfileGetNameToEnum[item.GetName().french] = item.GetRandomizerGet();
-    }
-
     mSpoilerfileHintTypeNameToEnum = {
         { "Static", HINT_TYPE_STATIC },
         { "Trial", HINT_TYPE_TRIAL },
@@ -93,9 +80,6 @@ Context::Context() {
     mTrials = std::make_shared<Trials>();
     mSettings = std::make_shared<Settings>();
     mFishsanity = std::make_shared<Fishsanity>();
-    for (auto& location : StaticData::GetLocationTable()) {
-        mSpoilerfileCheckNameToEnum[location.GetName()] = location.GetRandomizerCheck();
-    }
 }
 
 RandomizerArea Context::GetAreaFromString(std::string str) {
@@ -409,22 +393,22 @@ void Context::ParseHashIconIndexesJson(nlohmann::json spoilerFileJson) {
 void Context::ParseItemLocationsJson(nlohmann::json spoilerFileJson) {
     nlohmann::json locationsJson = spoilerFileJson["locations"];
     for (auto it = locationsJson.begin(); it != locationsJson.end(); ++it) {
-        RandomizerCheck rc = mSpoilerfileCheckNameToEnum[it.key()];
+        RandomizerCheck rc = StaticData::SpoilerfileCheckNameToEnum[it.key()];
         if (it->is_structured()) {
             nlohmann::json itemJson = *it;
             for (auto itemit = itemJson.begin(); itemit != itemJson.end(); ++itemit) {
                 if (itemit.key() == "item") {
-                    itemLocationTable[rc].SetPlacedItem(mSpoilerfileGetNameToEnum[itemit.value().get<std::string>()]);
+                    itemLocationTable[rc].SetPlacedItem(StaticData::SpoilerfileItemNameToEnum[itemit.value().get<std::string>()]);
                 } else if (itemit.key() == "price") {
                     itemLocationTable[rc].SetCustomPrice(itemit.value().get<uint16_t>());
                 } else if (itemit.key() == "model") {
-                    overrides[rc] = ItemOverride(rc, mSpoilerfileGetNameToEnum[itemit.value().get<std::string>()]);
+                    overrides[rc] = ItemOverride(rc, StaticData::SpoilerfileItemNameToEnum[itemit.value().get<std::string>()]);
                 } else if (itemit.key() == "trickName") {
                     overrides[rc].SetTrickName(Text(itemit.value().get<std::string>()));
                 }
             }
         } else {
-            itemLocationTable[rc].SetPlacedItem(mSpoilerfileGetNameToEnum[it.value().get<std::string>()]);
+            itemLocationTable[rc].SetPlacedItem(StaticData::SpoilerfileItemNameToEnum[it.value().get<std::string>()]);
         }
     }
 }
@@ -433,23 +417,23 @@ void Context::ParseHintJson(nlohmann::json spoilerFileJson) {
     // Child Altar
     std::string childAltarText = spoilerFileJson["childAltar"]["hintText"].get<std::string>();
     AddHint(RH_ALTAR_CHILD, Text(childAltarText), RC_UNKNOWN_CHECK, HINT_TYPE_STATIC, "Static", RA_NONE);
-    mEmeraldLoc = mSpoilerfileCheckNameToEnum[spoilerFileJson["childAltar"]["rewards"]["emeraldLoc"]];
-    mRubyLoc = mSpoilerfileCheckNameToEnum[spoilerFileJson["childAltar"]["rewards"]["rubyLoc"]];
-    mSapphireLoc = mSpoilerfileCheckNameToEnum[spoilerFileJson["childAltar"]["rewards"]["sapphireLoc"]];
+    mEmeraldLoc = StaticData::SpoilerfileCheckNameToEnum[spoilerFileJson["childAltar"]["rewards"]["emeraldLoc"]];
+    mRubyLoc = StaticData::SpoilerfileCheckNameToEnum[spoilerFileJson["childAltar"]["rewards"]["rubyLoc"]];
+    mSapphireLoc = StaticData::SpoilerfileCheckNameToEnum[spoilerFileJson["childAltar"]["rewards"]["sapphireLoc"]];
 
     // Adult Altar
     std::string adultAltarText = spoilerFileJson["adultAltar"]["hintText"].get<std::string>();
     AddHint(RH_ALTAR_ADULT, Text(adultAltarText), RC_UNKNOWN_CHECK, HINT_TYPE_STATIC, "Static", RA_NONE);
-    mForestMedallionLoc = mSpoilerfileCheckNameToEnum[spoilerFileJson["adultAltar"]["rewards"]["forestMedallionLoc"].get<std::string>()];
-    mFireMedallionLoc = mSpoilerfileCheckNameToEnum[spoilerFileJson["adultAltar"]["rewards"]["fireMedallionLoc"].get<std::string>()];
-    mWaterMedallionLoc = mSpoilerfileCheckNameToEnum[spoilerFileJson["adultAltar"]["rewards"]["waterMedallionLoc"].get<std::string>()];
-    mShadowMedallionLoc = mSpoilerfileCheckNameToEnum[spoilerFileJson["adultAltar"]["rewards"]["shadowMedallionLoc"].get<std::string>()];
-    mSpiritMedallionLoc = mSpoilerfileCheckNameToEnum[spoilerFileJson["adultAltar"]["rewards"]["spiritMedallionLoc"].get<std::string>()];
-    mLightMedallionLoc = mSpoilerfileCheckNameToEnum[spoilerFileJson["adultAltar"]["rewards"]["lightMedallionLoc"].get<std::string>()];
+    mForestMedallionLoc = StaticData::SpoilerfileCheckNameToEnum[spoilerFileJson["adultAltar"]["rewards"]["forestMedallionLoc"].get<std::string>()];
+    mFireMedallionLoc = StaticData::SpoilerfileCheckNameToEnum[spoilerFileJson["adultAltar"]["rewards"]["fireMedallionLoc"].get<std::string>()];
+    mWaterMedallionLoc = StaticData::SpoilerfileCheckNameToEnum[spoilerFileJson["adultAltar"]["rewards"]["waterMedallionLoc"].get<std::string>()];
+    mShadowMedallionLoc = StaticData::SpoilerfileCheckNameToEnum[spoilerFileJson["adultAltar"]["rewards"]["shadowMedallionLoc"].get<std::string>()];
+    mSpiritMedallionLoc = StaticData::SpoilerfileCheckNameToEnum[spoilerFileJson["adultAltar"]["rewards"]["spiritMedallionLoc"].get<std::string>()];
+    mLightMedallionLoc = StaticData::SpoilerfileCheckNameToEnum[spoilerFileJson["adultAltar"]["rewards"]["lightMedallionLoc"].get<std::string>()];
 
     // Ganondorf and Sheik Light Arrow Hints
     std::string ganonHintText = spoilerFileJson["ganonHintText"].get<std::string>();
-    RandomizerCheck lightArrowLoc = mSpoilerfileCheckNameToEnum[spoilerFileJson["lightArrowHintLoc"].get<std::string>()];
+    RandomizerCheck lightArrowLoc = StaticData::SpoilerfileCheckNameToEnum[spoilerFileJson["lightArrowHintLoc"].get<std::string>()];
     std::string lightArrowRegion = spoilerFileJson["lightArrowArea"].get<std::string>();
     AddHint(RH_GANONDORF_HINT, Text(ganonHintText), lightArrowLoc, HINT_TYPE_STATIC, "Static", mSpoilerfileAreaNameToEnum[lightArrowRegion]);
     if (spoilerFileJson.contains("sheikText")) {
@@ -463,7 +447,7 @@ void Context::ParseHintJson(nlohmann::json spoilerFileJson) {
     if (spoilerFileJson.contains("dampeText")) {
         std::string dampeText = spoilerFileJson["dampeText"].get<std::string>();
         std::string dampeRegion = spoilerFileJson["dampeRegion"].get<std::string>();
-        RandomizerCheck dampeHintLoc = mSpoilerfileCheckNameToEnum[spoilerFileJson["dampeHintLoc"].get<std::string>()];
+        RandomizerCheck dampeHintLoc = StaticData::SpoilerfileCheckNameToEnum[spoilerFileJson["dampeHintLoc"].get<std::string>()];
         AddHint(RH_DAMPES_DIARY, Text(dampeText), dampeHintLoc, HINT_TYPE_STATIC, "Static", mSpoilerfileAreaNameToEnum[dampeRegion]);
     }
 
@@ -471,7 +455,7 @@ void Context::ParseHintJson(nlohmann::json spoilerFileJson) {
     if (spoilerFileJson.contains("gregText")) {
         std::string gregText = spoilerFileJson["gregText"].get<std::string>();
         std::string gregRegion = spoilerFileJson["gregRegion"].get<std::string>();
-        RandomizerCheck gregLoc = mSpoilerfileCheckNameToEnum[spoilerFileJson["gregLoc"].get<std::string>()];
+        RandomizerCheck gregLoc = StaticData::SpoilerfileCheckNameToEnum[spoilerFileJson["gregLoc"].get<std::string>()];
         AddHint(RH_GREG_RUPEE, Text(gregText), gregLoc, HINT_TYPE_STATIC, "Static", mSpoilerfileAreaNameToEnum[gregRegion]);
     }
 
@@ -479,7 +463,7 @@ void Context::ParseHintJson(nlohmann::json spoilerFileJson) {
     if (spoilerFileJson.contains("sariaText")) {
         std::string sariaText = spoilerFileJson["sariaText"].get<std::string>();
         std::string sariaRegion = spoilerFileJson["sariaRegion"].get<std::string>();
-        RandomizerCheck sariaHintLoc = mSpoilerfileCheckNameToEnum[spoilerFileJson["sariaHintLoc"].get<std::string>()];
+        RandomizerCheck sariaHintLoc = StaticData::SpoilerfileCheckNameToEnum[spoilerFileJson["sariaHintLoc"].get<std::string>()];
         AddHint(RH_SARIA, Text(sariaText), sariaHintLoc, HINT_TYPE_STATIC, "Static", mSpoilerfileAreaNameToEnum[sariaRegion]);
     }
 
@@ -487,7 +471,7 @@ void Context::ParseHintJson(nlohmann::json spoilerFileJson) {
     if(spoilerFileJson.contains("fishingPoleText")) {
         std::string fishingPoleText = spoilerFileJson["fishingPoleText"].get<std::string>();
         std::string fishingPoleRegion = spoilerFileJson["fishingPoleRegion"].get<std::string>();
-        RandomizerCheck fishingPoleHintLoc = mSpoilerfileCheckNameToEnum[spoilerFileJson["fishingPoleHintLoc"].get<std::string>()];
+        RandomizerCheck fishingPoleHintLoc = StaticData::SpoilerfileCheckNameToEnum[spoilerFileJson["fishingPoleHintLoc"].get<std::string>()];
         AddHint(RH_FISHING_POLE, Text(fishingPoleText), fishingPoleHintLoc, HINT_TYPE_STATIC, "Static", mSpoilerfileAreaNameToEnum[fishingPoleRegion]);
     }
 
@@ -520,11 +504,11 @@ void Context::ParseHintJson(nlohmann::json spoilerFileJson) {
     // Gossip Stones
     nlohmann::json hintsJson = spoilerFileJson["hints"];
     for (auto it = hintsJson.begin(); it != hintsJson.end(); ++it) {
-        RandomizerCheck gossipStoneLoc = mSpoilerfileCheckNameToEnum[it.key()];
+        RandomizerCheck gossipStoneLoc = StaticData::SpoilerfileCheckNameToEnum[it.key()];
         nlohmann::json hintInfo = it.value();
         std::string hintText = hintInfo["hint"].get<std::string>();
         HintType hintType = mSpoilerfileHintTypeNameToEnum[hintInfo["type"].get<std::string>()];
-        RandomizerCheck hintedLocation = hintInfo.contains("location") ? mSpoilerfileCheckNameToEnum[hintInfo["location"]] : RC_UNKNOWN_CHECK;
+        RandomizerCheck hintedLocation = hintInfo.contains("location") ? StaticData::SpoilerfileCheckNameToEnum[hintInfo["location"]] : RC_UNKNOWN_CHECK;
         RandomizerArea hintedArea = hintInfo.contains("area") ? mSpoilerfileAreaNameToEnum[hintInfo["area"].get<std::string>()] : RA_NONE;
         std::string distribution = hintInfo["distribution"].get<std::string>();
         AddHint(static_cast<RandomizerHintKey>(gossipStoneLoc - RC_COLOSSUS_GOSSIP_STONE + 1), Text(hintText), hintedLocation, hintType, distribution, hintedArea);

--- a/soh/soh/Enhancements/randomizer/context.h
+++ b/soh/soh/Enhancements/randomizer/context.h
@@ -87,14 +87,12 @@ class Context {
     std::vector<RandomizerGet> possibleIceTrapModels = {};
     std::unordered_map<RandomizerCheck, RandomizerGet> iceTrapModels = {};
     std::array<uint8_t, 5> hashIconIndexes = {};
-    std::unordered_map<std::string, RandomizerCheck> mSpoilerfileCheckNameToEnum;
     bool playthroughBeatable = false;
     bool allLocationsReachable = false;
     RandomizerArea GetAreaFromString(std::string str);
 
   private:
     static std::weak_ptr<Context> mContext;
-    std::unordered_map<std::string, RandomizerGet> mSpoilerfileGetNameToEnum;
     std::unordered_map<std::string, HintType> mSpoilerfileHintTypeNameToEnum;
     std::unordered_map<std::string, RandomizerArea> mSpoilerfileAreaNameToEnum;
     std::array<Hint, RH_MAX> hintTable = {};

--- a/soh/soh/Enhancements/randomizer/item_list.cpp
+++ b/soh/soh/Enhancements/randomizer/item_list.cpp
@@ -8,6 +8,7 @@
 using namespace Rando;
 
 std::array<Item, RG_MAX> Rando::StaticData::itemTable;
+std::unordered_map<std::string, RandomizerGet> Rando::StaticData::SpoilerfileItemNameToEnum;
 
 void Rando::StaticData::InitItemTable() {
     auto logic = Context::GetInstance()->GetLogic();
@@ -320,6 +321,17 @@ void Rando::StaticData::InitItemTable() {
     itemTable[RG_MAGIC_SINGLE] =                        Item(RG_MAGIC_SINGLE,                     Text{ "Magic Meter", "Jauge de Magie", "Magisches Messgerät" },                                                   ITEMTYPE_ITEM,              0x8A,               true,  &logic->ProgressiveMagic,    RHT_MAGIC_SINGLE,           RG_MAGIC_SINGLE,                OBJECT_GI_MAGICPOT,     GID_MAGIC_SMALL,    0xE4,                        0x80, CHEST_ANIM_LONG,  ITEM_CATEGORY_MAJOR,  MOD_RANDOMIZER);
     itemTable[RG_MAGIC_DOUBLE] =                        Item(RG_MAGIC_DOUBLE,                     Text{ "Enhanced Magic Meter", "Jauge de Magie améliorée", "Verbesserte Magieanzeige" },                           ITEMTYPE_ITEM,              0x8A,               true,  &logic->ProgressiveMagic,    RHT_MAGIC_DOUBLE,           RG_MAGIC_DOUBLE,                OBJECT_GI_MAGICPOT,     GID_MAGIC_LARGE,    0xE8,                        0x80, CHEST_ANIM_LONG,  ITEM_CATEGORY_LESSER, MOD_RANDOMIZER);
     itemTable[RG_TRIFORCE_PIECE] =                      Item(RG_TRIFORCE_PIECE,                   Text{ "Triforce Piece", "Triforce Piece", "Triforce Piece" },                                                     ITEMTYPE_ITEM,              0xDF,               true,  &logic->TriforcePieces,      RHT_TRIFORCE_PIECE,         RG_TRIFORCE_PIECE,              OBJECT_GI_BOMB_2,       GID_TRIFORCE_PIECE, TEXT_RANDOMIZER_CUSTOM_ITEM, 0x80, CHEST_ANIM_LONG,  ITEM_CATEGORY_MAJOR,  MOD_RANDOMIZER);
+
+    // Init SpoilerfileItemNameToEnum
+    for (auto& item : itemTable) {
+        // Easiest way to filter out all the empty values from the array, since we still technically want the 0/RG_NONE
+        // entry
+        if (item.GetName().english.empty()) {
+            continue;
+        }
+        SpoilerfileItemNameToEnum[item.GetName().english] = item.GetRandomizerGet();
+        SpoilerfileItemNameToEnum[item.GetName().french] = item.GetRandomizerGet();
+    }
 }
 
 Item& Rando::StaticData::RetrieveItem(const RandomizerGet rgid) {

--- a/soh/soh/Enhancements/randomizer/location_list.cpp
+++ b/soh/soh/Enhancements/randomizer/location_list.cpp
@@ -3,6 +3,8 @@
 #define TWO_ACTOR_PARAMS(a, b) (abs(a) << 16) | abs(b)
 
 std::array<Rando::Location, RC_MAX> Rando::StaticData::locationTable;
+std::unordered_map<std::string, RandomizerCheck> Rando::StaticData::SpoilerfileCheckNameToEnum;
+std::multimap<std::tuple<s16, s16, s32>, RandomizerCheck> Rando::StaticData::CheckFromActorMultimap;
 
 std::vector<RandomizerCheck> KF_ShopLocations = {
     RC_KF_SHOP_ITEM_1, RC_KF_SHOP_ITEM_2, RC_KF_SHOP_ITEM_3, RC_KF_SHOP_ITEM_4,
@@ -1569,6 +1571,15 @@ void Rando::StaticData::InitLocationTable() {
     
     locationTable[RC_TRIFORCE_COMPLETED] = Location::Reward(RC_TRIFORCE_COMPLETED, RCQUEST_BOTH, RCTYPE_STANDARD, RCAREA_MARKET, ACTOR_ID_MAX, SCENE_ID_MAX, 0x00, 0x00, "Completed Triforce", "Completed Triforce", RHT_NONE, RG_NONE, {}, SpoilerCollectionCheck::None(), SpoilerCollectionCheckGroup::GROUP_NO_GROUP);
     // clang-format on
+
+    // Init SpoilerfileCheckNameToEnum
+    SpoilerfileCheckNameToEnum["Invalid Location"] = RC_UNKNOWN_CHECK;
+    SpoilerfileCheckNameToEnum["Link's Pocket"] = RC_LINKS_POCKET;
+
+    for (auto& location : locationTable) {
+        SpoilerfileCheckNameToEnum[location.GetName()] = location.GetRandomizerCheck();
+        CheckFromActorMultimap.emplace(std::make_tuple((int16_t)location.GetActorID(), (int16_t)location.GetScene(), location.GetActorParams()), location.GetRandomizerCheck());
+    }
 }
 
 Location* Rando::StaticData::GetLocation(RandomizerCheck locKey) {

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -47,11 +47,8 @@ extern std::array<std::string, HINT_TYPE_MAX> hintTypeNames;
 using json = nlohmann::json;
 using namespace std::literals::string_literals;
 
-std::unordered_map<std::string, RandomizerCheck> SpoilerfileCheckNameToEnum;
-std::unordered_map<std::string, RandomizerGet> SpoilerfileGetNameToEnum;
 std::unordered_map<std::string, RandomizerCheckArea> SpoilerfileAreaNameToEnum;
 std::unordered_map<std::string, HintType> SpoilerfileHintTypeNameToEnum;
-std::multimap<std::tuple<s16, s16, s32>, RandomizerCheck> checkFromActorMultimap;
 std::set<RandomizerCheck> excludedLocations;
 std::set<RandomizerCheck> spoilerExcludedLocations;
 std::set<RandomizerTrick> enabledTricks;
@@ -129,24 +126,7 @@ static const char* frenchRupeeNames[36] = {
 Randomizer::Randomizer() {
     Rando::StaticData::InitItemTable();
     Rando::StaticData::InitLocationTable();
-    for (auto& location : Rando::StaticData::GetLocationTable()) {
-        SpoilerfileCheckNameToEnum[location.GetName()] = location.GetRandomizerCheck();
-        checkFromActorMultimap.emplace(std::make_tuple((s16)location.GetActorID(), (s16)location.GetScene(), location.GetActorParams()), location.GetRandomizerCheck());
-    }
-    SpoilerfileCheckNameToEnum["Invalid Location"] = RC_UNKNOWN_CHECK;
-    SpoilerfileCheckNameToEnum["Link's Pocket"] = RC_LINKS_POCKET;
 
-    for (auto& item: Rando::StaticData::GetItemTable()) {
-        // Easiest way to filter out all the empty values from the array, since we still technically want the 0/RG_NONE entry
-        if (item.GetName().english.empty()) continue;
-        SpoilerfileGetNameToEnum[item.GetName().english] = item.GetRandomizerGet();
-        SpoilerfileGetNameToEnum[item.GetName().french] = item.GetRandomizerGet();
-        EnumToSpoilerfileGetName[item.GetRandomizerGet()] = {
-            item.GetName().english,
-            item.GetName().english,
-            item.GetName().french,
-        };
-    }
     for (auto area : rcAreaNames) {
         SpoilerfileAreaNameToEnum[area.second] = area.first;
     }
@@ -1758,7 +1738,7 @@ Rando::Location* Randomizer::GetCheckObjectFromActor(s16 actorId, s16 sceneNum, 
         return Rando::StaticData::GetLocation(specialRc);
     }
 
-    auto range = checkFromActorMultimap.equal_range(std::make_tuple(actorId, sceneNum, actorParams));
+    auto range = Rando::StaticData::CheckFromActorMultimap.equal_range(std::make_tuple(actorId, sceneNum, actorParams));
 
     for (auto it = range.first; it != range.second; ++it) {
         if (

--- a/soh/soh/Enhancements/randomizer/settings.cpp
+++ b/soh/soh/Enhancements/randomizer/settings.cpp
@@ -2644,7 +2644,7 @@ void Settings::ParseJson(nlohmann::json spoilerFileJson) {
 
     ctx->AddExcludedOptions();
     for (auto it = jsonExcludedLocations.begin(); it != jsonExcludedLocations.end(); ++it) {
-        const RandomizerCheck rc = ctx->mSpoilerfileCheckNameToEnum[it.value()];
+        const RandomizerCheck rc = StaticData::SpoilerfileCheckNameToEnum[it.value()];
         ctx->GetItemLocation(rc)->GetExcludedOption()->SetSelectedIndex(RO_GENERIC_ON);
     }
 

--- a/soh/soh/Enhancements/randomizer/static_data.h
+++ b/soh/soh/Enhancements/randomizer/static_data.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <array>
-#include <unordered_map>
+#include <map>
 #include "randomizerTypes.h"
 #include "item.h"
 #include "location.h"
@@ -27,6 +27,9 @@ class StaticData {
       static void InitLocationTable();
       static Location* GetLocation(RandomizerCheck locKey);
       static std::array<Rando::Location, RC_MAX>& GetLocationTable();
+      static std::unordered_map<std::string, RandomizerCheck> SpoilerfileCheckNameToEnum;
+      static std::unordered_map<std::string, RandomizerGet> SpoilerfileItemNameToEnum;
+      static std::multimap<std::tuple<s16, s16, s32>, RandomizerCheck> CheckFromActorMultimap;
       static std::vector<RandomizerCheck> overworldLocations;
       static std::vector<RandomizerCheck> dungeonRewardLocations;
       static std::vector<std::vector<RandomizerCheck>> shopLocationLists;

--- a/soh/soh/Enhancements/randomizer/static_data.h
+++ b/soh/soh/Enhancements/randomizer/static_data.h
@@ -2,7 +2,7 @@
 
 #include <array>
 #include <map>
-#include <unodered_map>
+#include <unordered_map>
 #include "randomizerTypes.h"
 #include "item.h"
 #include "location.h"

--- a/soh/soh/Enhancements/randomizer/static_data.h
+++ b/soh/soh/Enhancements/randomizer/static_data.h
@@ -2,6 +2,7 @@
 
 #include <array>
 #include <map>
+#include <unodered_map>
 #include "randomizerTypes.h"
 #include "item.h"
 #include "location.h"


### PR DESCRIPTION
Moves some of the reverse map data from strings to enums to StaticData namespace so they can't get cleared when the Context gets reset.

This fixes the same issue as #3468 in the proper way, so I believe that PR can be closed.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1437743447.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1437755225.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1437757839.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1437758389.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1437759901.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1437778824.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1437781677.zip)
<!--- section:artifacts:end -->