### PR TITLE
Fix Item Name Replacement

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -2613,7 +2613,11 @@ CustomMessage Randomizer::ReplaceWithItemName(CustomMessage message, std::string
                 ctx->overrides[hintedCheck].GetTrickName().english
             };
         } else {
-            itemName = EnumToSpoilerfileGetName[targetRG];
+            itemName = {
+                Rando::StaticData::RetrieveItem(targetRG).GetName().english,
+                Rando::StaticData::RetrieveItem(targetRG).GetName().french,
+                Rando::StaticData::RetrieveItem(targetRG).GetName().english,
+            };
         }
     message.Replace(std::move(toReplace), std::move(itemName[0]), std::move(itemName[1]), std::move(itemName[2]));
     return message;
@@ -2745,7 +2749,12 @@ CustomMessage Randomizer::GetMerchantMessage(RandomizerInf randomizerInf, u16 te
             std::string(ctx->overrides[rc].GetTrickName().english)
         };
     } else { 
-        shopItemName = EnumToSpoilerfileGetName[shopItemGet];
+        auto shopItem = Rando::StaticData::RetrieveItem(shopItemGet);
+        shopItemName = {
+            shopItem.GetName().english,
+            shopItem.GetName().french,
+            shopItem.GetName().english,
+        };
     }
     u16 shopItemPrice = ctx->GetItemLocation(rc)->GetPrice();
 

--- a/soh/soh/Enhancements/randomizer/randomizer.h
+++ b/soh/soh/Enhancements/randomizer/randomizer.h
@@ -39,9 +39,6 @@ class Randomizer {
     static const std::string IceTrapRandoMessageTableID;
     static const std::string randoMiscHintsTableID;
 
-    // Public for now to be accessed by SaveManager, will be made private again soon :tm:
-    std::unordered_map<RandomizerGet, std::array<std::string, 3>> EnumToSpoilerfileGetName;
-
     static Sprite* GetSeedTexture(uint8_t index);
     bool SpoilerFileExists(const char* spoilerFileName);
     void LoadMerchantMessages();


### PR DESCRIPTION
#4066 accidentally didn't replace one of the old maps with the new ones and caused item names to not be replaced in Scrub and Shop Messages at runtime. This fixes that.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1440089901.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1440147932.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1440152534.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1440154872.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1440163928.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1440170568.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1440181204.zip)
<!--- section:artifacts:end -->