### PR TITLE
Better blank hint issue fix

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/hints.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/hints.cpp
@@ -964,7 +964,12 @@ static void DistributeHints(std::vector<uint8_t>& selected, size_t stoneCount, s
     for (uint8_t distribution = 0; distribution < distTable.size(); distribution++){
       currentWeight -= distTable[distribution].weight;
       if (currentWeight <= 0){
-        if (stoneCount >= distTable[distribution].copies || distTable[distribution].copies == 0){
+        if (distTable[distribution].copies == 0) {
+          // This should only happen if we ran out of locations to place hints of a certain distribution earlier. Skip
+          // to the next distribution.
+          break;
+        }
+        if (stoneCount >= distTable[distribution].copies){
           selected[distribution] += 1;
           stoneCount -= distTable[distribution].copies;
           break;


### PR DESCRIPTION
The previous blank hint fix PR still had some issues.  Not every seed genned with issues but a handful did. After this fix I wasn't able to gen any more seeds with blank hints. Note this does change the seed gen algorithm slightly so I wasn't able to reattempt any specific seeds that were an issue before. If you gen any blank hint seeds with this PR, please let me know.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1444619568.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1444677416.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1444678438.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1444678622.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1444689388.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1444693047.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1444939042.zip)
<!--- section:artifacts:end -->