### PR TITLE
Reduce Minimum Internal Resolution Scalar to 0.1f

### DIFF
--- a/soh/soh/Enhancements/resolution-editor/ResolutionEditor.cpp
+++ b/soh/soh/Enhancements/resolution-editor/ResolutionEditor.cpp
@@ -115,7 +115,7 @@ void AdvancedResolutionSettingsWindow::DrawElement() {
             const bool disabled_resolutionSlider = (CVarGetInteger("gAdvancedResolution.VerticalResolutionToggle", 0) &&
                                                     CVarGetInteger("gAdvancedResolution.Enabled", 0)) ||
                                                    CVarGetInteger("gLowResMode", 0);
-            if (UIWidgets::EnhancementSliderFloat("Internal Resolution: %.1f%%", "##IMul", "gInternalResolution", 0.5f,
+            if (UIWidgets::EnhancementSliderFloat("Internal Resolution: %.1f%%", "##IMul", "gInternalResolution", 0.1f,
                                                   2.0f, "", 1.0f, true, true, disabled_resolutionSlider)) {
                 LUS::Context::GetInstance()->GetWindow()->SetResolutionMultiplier(
                     CVarGetFloat("gInternalResolution", 1));

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -272,7 +272,7 @@ void DrawSettingsMenu() {
         #ifndef __APPLE__
             const bool disabled_resolutionSlider = CVarGetInteger("gAdvancedResolution.VerticalResolutionToggle", 0) &&
                                                    CVarGetInteger("gAdvancedResolution.Enabled", 0);
-            if (UIWidgets::EnhancementSliderFloat("Internal Resolution: %.1f %%", "##IMul", "gInternalResolution", 0.5f,
+            if (UIWidgets::EnhancementSliderFloat("Internal Resolution: %.1f %%", "##IMul", "gInternalResolution", 0.1f,
                                                   2.0f, "", 1.0f, true, true, disabled_resolutionSlider)) {
                 LUS::Context::GetInstance()->GetWindow()->SetResolutionMultiplier(CVarGetFloat("gInternalResolution", 1));
             }


### PR DESCRIPTION
This setting dates back to https://github.com/HarbourMasters/Shipwright/pull/3130 , which also adds an Advanced Resolution Editor (that doesn't appear to be available on the Switch).   This value appears to be arbitrarily set.

Reducing this minimum value appears to be the easiest way to enable N64-like resolutions with widescreen enabled on the Switch platform.   When forced via the config.json, it snaps back to 0.5f whenever that menu is navigated to.

I've noticed this complaint in some Reddit comments as well.   This should also help on non-switch, High-DPI screens as well.