### PR TITLE
fix a V2 compatibility crash

### DIFF
--- a/soh/soh/Enhancements/randomizer/hint.h
+++ b/soh/soh/Enhancements/randomizer/hint.h
@@ -27,7 +27,7 @@ class Hint {
           std::vector<TrialKey> trials_ = {},
           bool yourPocket_ = false, 
           int num_ = 0);
-     explicit Hint(RandomizerHint ownKey_, std::vector<CustomMessage> messages_);
+     Hint(RandomizerHint ownKey_, std::vector<CustomMessage> messages_);
      Hint(RandomizerHint ownKey_, nlohmann::json json_);
      void FillGapsInData();
      void SetLocationsAsHinted() const;

--- a/soh/soh/Enhancements/randomizer/hint.h
+++ b/soh/soh/Enhancements/randomizer/hint.h
@@ -27,7 +27,7 @@ class Hint {
           std::vector<TrialKey> trials_ = {},
           bool yourPocket_ = false, 
           int num_ = 0);
-     Hint(RandomizerHint ownKey_, std::vector<CustomMessage> messages_);
+     explicit Hint(RandomizerHint ownKey_, std::vector<CustomMessage> messages_);
      Hint(RandomizerHint ownKey_, nlohmann::json json_);
      void FillGapsInData();
      void SetLocationsAsHinted() const;

--- a/soh/soh/SaveManager.cpp
+++ b/soh/soh/SaveManager.cpp
@@ -188,7 +188,7 @@ void SaveManager::LoadRandomizerVersion1() {
         for (int j = 0; j < ARRAY_COUNT(hintText); j++) {
             SaveManager::Instance->LoadData("ht" + std::to_string(i) + "-" + std::to_string(j), hintText[j]);
         }
-        RandomizerHint stoneHint = Rando::StaticData::oldVerHintOrder[rc - Rando::StaticData::oldVerGossipStoneStart];
+        RandomizerHint stoneHint = Rando::StaticData::oldVerHintOrder[i - Rando::StaticData::oldVerGossipStoneStart];
         randoContext->AddHint(stoneHint, Rando::Hint(stoneHint, {CustomMessage(hintText)}));
     }
 

--- a/soh/soh/SaveManager.cpp
+++ b/soh/soh/SaveManager.cpp
@@ -102,7 +102,7 @@ std::vector<RandomizerHint> Rando::StaticData::oldVerHintOrder {
     RH_ZR_OPEN_GROTTO_GOSSIP_STONE,
 };
 
-uint16_t Rando::StaticData::oldVerGossipStoneStart = 740;
+uint16_t Rando::StaticData::oldVerGossipStoneStart = 706;
 
 SaveManager::SaveManager() {
     coreSectionIDsByName["base"] = SECTION_ID_BASE;
@@ -188,7 +188,7 @@ void SaveManager::LoadRandomizerVersion1() {
         for (int j = 0; j < ARRAY_COUNT(hintText); j++) {
             SaveManager::Instance->LoadData("ht" + std::to_string(i) + "-" + std::to_string(j), hintText[j]);
         }
-        RandomizerHint stoneHint = Rando::StaticData::oldVerHintOrder[Rando::StaticData::oldVerGossipStoneStart];
+        RandomizerHint stoneHint = Rando::StaticData::oldVerHintOrder[rc - Rando::StaticData::oldVerGossipStoneStart];
         randoContext->AddHint(stoneHint, Rando::Hint(stoneHint, {CustomMessage(hintText)}));
     }
 
@@ -294,7 +294,7 @@ void SaveManager::LoadRandomizerVersion2() {
             if (rc != RC_UNKNOWN_CHECK) {
                 std::string hintText;
                 SaveManager::Instance->LoadData("hintText", hintText);
-                RandomizerHint stoneHint = Rando::StaticData::oldVerHintOrder[Rando::StaticData::oldVerGossipStoneStart];
+                RandomizerHint stoneHint = Rando::StaticData::oldVerHintOrder[rc - Rando::StaticData::oldVerGossipStoneStart];
                 randoContext->AddHint(stoneHint, Rando::Hint(stoneHint, {CustomMessage(hintText)}));
             }
         });


### PR DESCRIPTION
This is ~~an attempt to solve malk's issue where the json was ambiguous with a vector of CustomMessage by making the (seldom used) CustomMessage initializer explicit, while also~~ fixing a v2 save loading issue I stumbled across while testing it.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1477589081.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1477608957.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1477610924.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1477611368.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1477614928.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1477621179.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1477637172.zip)
<!--- section:artifacts:end -->