### PR TITLE
simplify ci

### DIFF
--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -83,11 +83,11 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-ccache-${{ github.ref }}
           ${{ runner.os }}-ccache-
-    - name: Install gtar wrapper
-      run: |
-        sudo mv /usr/local/bin/gtar /usr/local/bin/gtar.orig
-        sudo cp .github/workflows//gtar /usr/local/bin/gtar
-        sudo chmod +x /usr/local/bin/gtar
+    # - name: Install gtar wrapper
+    #   run: |
+    #     sudo mv /usr/local/bin/gtar /usr/local/bin/gtar.orig
+    #     sudo cp .github/workflows//gtar /usr/local/bin/gtar
+    #     sudo chmod +x /usr/local/bin/gtar
     - name: Cache MacPorts
       id: cache-macports
       uses: actions/cache@v2

--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -89,22 +89,22 @@ jobs:
         sudo mv /opt/homebrew/bin/gtar /opt/homebrew/bin/gtar.orig
         sudo cp .github/workflows//gtar /opt/homebrew/bin/gtar
         sudo chmod +x /opt/homebrew/bin/gtar
-    - name: Cache MacPorts
-      id: cache-macports
-      uses: actions/cache@v2
-      with:
-        path: /opt/local/
-        key: ${{ runner.os }}-macports-${{ hashFiles('.github/workflows/macports-deps.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-macports-
+    # - name: Cache MacPorts
+    #   id: cache-macports
+    #   uses: actions/cache@v2
+    #   with:
+    #     path: /opt/local/
+    #     key: ${{ runner.os }}-macports-${{ hashFiles('.github/workflows/macports-deps.txt') }}
+    #     restore-keys: |
+    #       ${{ runner.os }}-macports-
     - name: Install MacPorts (if necessary)
       run: |
-        if [ -d /opt/local/ ]; then
-          echo "MacPorts already installed"
-        else
-          wget https://github.com/macports/macports-base/releases/download/v2.9.3/MacPorts-2.9.3-14-Sonoma.pkg
-          sudo installer -pkg ./MacPorts-2.9.3-14-Sonoma.pkg -target /
-        fi
+        # if [ -d /opt/local/ ]; then
+        #   echo "MacPorts already installed"
+        # else
+        wget https://github.com/macports/macports-base/releases/download/v2.9.3/MacPorts-2.9.3-14-Sonoma.pkg
+        sudo installer -pkg ./MacPorts-2.9.3-14-Sonoma.pkg -target /
+        # fi
         echo "/opt/local/bin:/opt/local/sbin" >> $GITHUB_PATH
     - name: Install dependencies
       run: |

--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -7,7 +7,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   generate-soh-otr:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -85,7 +85,7 @@ jobs:
           ${{ runner.os }}-ccache-
     - name: Install gtar wrapper
       run: |
-        brew install gnu-tar
+        which gtar
         sudo mv /usr/local/bin/gtar /usr/local/bin/gtar.orig
         sudo cp .github/workflows//gtar /usr/local/bin/gtar
         sudo chmod +x /usr/local/bin/gtar

--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -102,8 +102,8 @@ jobs:
         if [ -d /opt/local/ ]; then
           echo "MacPorts already installed"
         else
-          wget https://github.com/macports/macports-base/releases/download/v2.9.3/MacPorts-2.9.3-12-Monterey.pkg
-          sudo installer -pkg ./MacPorts-2.9.3-12-Monterey.pkg -target /
+          wget https://github.com/macports/macports-base/releases/download/v2.9.3/MacPorts-2.9.3-14-Sonoma.pkg
+          sudo installer -pkg ./MacPorts-2.9.3-14-Sonoma.pkg -target /
         fi
         echo "/opt/local/bin:/opt/local/sbin" >> $GITHUB_PATH
     - name: Install dependencies

--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -89,22 +89,22 @@ jobs:
         sudo mv /opt/homebrew/bin/gtar /opt/homebrew/bin/gtar.orig
         sudo cp .github/workflows//gtar /opt/homebrew/bin/gtar
         sudo chmod +x /opt/homebrew/bin/gtar
-    # - name: Cache MacPorts
-    #   id: cache-macports
-    #   uses: actions/cache@v2
-    #   with:
-    #     path: /opt/local/
-    #     key: ${{ runner.os }}-macports-${{ hashFiles('.github/workflows/macports-deps.txt') }}
-    #     restore-keys: |
-    #       ${{ runner.os }}-macports-
+    - name: Cache MacPorts
+      id: cache-macports
+      uses: actions/cache@v2
+      with:
+        path: /opt/local/
+        key: ${{ runner.os }}-macports-${{ hashFiles('.github/workflows/macports-deps.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-macports-
     - name: Install MacPorts (if necessary)
       run: |
-        # if [ -d /opt/local/ ]; then
-        #   echo "MacPorts already installed"
-        # else
-        wget https://github.com/macports/macports-base/releases/download/v2.9.3/MacPorts-2.9.3-14-Sonoma.pkg
-        sudo installer -pkg ./MacPorts-2.9.3-14-Sonoma.pkg -target /
-        # fi
+        if [ -d /opt/local/ ]; then
+          echo "MacPorts already installed"
+        else
+          wget https://github.com/macports/macports-base/releases/download/v2.9.3/MacPorts-2.9.3-14-Sonoma.pkg
+          sudo installer -pkg ./MacPorts-2.9.3-14-Sonoma.pkg -target /
+        fi
         echo "/opt/local/bin:/opt/local/sbin" >> $GITHUB_PATH
     - name: Install dependencies
       run: |

--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -79,10 +79,10 @@ jobs:
     - name: ccache
       uses: hendrikmuhs/ccache-action@v1.2.11
       with:
-        key: ${{ runner.os }}-ccache-${{ github.ref }}-${{ github.sha }}
+        key: ${{ runner.os }}-14-ccache-${{ github.ref }}-${{ github.sha }}
         restore-keys: |
-          ${{ runner.os }}-ccache-${{ github.ref }}
-          ${{ runner.os }}-ccache-
+          ${{ runner.os }}-14-ccache-${{ github.ref }}
+          ${{ runner.os }}-14-ccache-
     - name: Install gtar wrapper
       run: |
         which gtar

--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -108,7 +108,7 @@ jobs:
         echo "/opt/local/bin:/opt/local/sbin" >> $GITHUB_PATH
     - name: Install dependencies
       run: |
-        brew uninstall --ignore-dependencies libpng libzip
+        brew uninstall --ignore-dependencies libpng
         sudo port install $(cat .github/workflows/macports-deps.txt)
         brew install ninja
     - name: Download soh.otr

--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -80,9 +80,9 @@ jobs:
       uses: hendrikmuhs/ccache-action@v1.2.11
       with:
         key: ${{ runner.os }}-ccache-${{ github.ref }}-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-ccache-${{ github.ref }}
-          ${{ runner.os }}-ccache-
+        # restore-keys: |
+        #   ${{ runner.os }}-ccache-${{ github.ref }}
+        #   ${{ runner.os }}-ccache-
     - name: Install gtar wrapper
       run: |
         which gtar

--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -83,11 +83,12 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-ccache-${{ github.ref }}
           ${{ runner.os }}-ccache-
-    # - name: Install gtar wrapper
-    #   run: |
-    #     sudo mv /usr/local/bin/gtar /usr/local/bin/gtar.orig
-    #     sudo cp .github/workflows//gtar /usr/local/bin/gtar
-    #     sudo chmod +x /usr/local/bin/gtar
+    - name: Install gtar wrapper
+      run: |
+        brew install gnu-tar
+        sudo mv /usr/local/bin/gtar /usr/local/bin/gtar.orig
+        sudo cp .github/workflows//gtar /usr/local/bin/gtar
+        sudo chmod +x /usr/local/bin/gtar
     - name: Cache MacPorts
       id: cache-macports
       uses: actions/cache@v2

--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -86,9 +86,9 @@ jobs:
     - name: Install gtar wrapper
       run: |
         which gtar
-        sudo mv /usr/local/bin/gtar /usr/local/bin/gtar.orig
-        sudo cp .github/workflows//gtar /usr/local/bin/gtar
-        sudo chmod +x /usr/local/bin/gtar
+        sudo mv /opt/homebrew/bin/gtar /opt/homebrew/bin/gtar.orig
+        sudo cp .github/workflows//gtar /opt/homebrew/bin/gtar
+        sudo chmod +x /opt/homebrew/bin/gtar
     - name: Cache MacPorts
       id: cache-macports
       uses: actions/cache@v2

--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -80,9 +80,9 @@ jobs:
       uses: hendrikmuhs/ccache-action@v1.2.11
       with:
         key: ${{ runner.os }}-ccache-${{ github.ref }}-${{ github.sha }}
-        # restore-keys: |
-        #   ${{ runner.os }}-ccache-${{ github.ref }}
-        #   ${{ runner.os }}-ccache-
+        restore-keys: |
+          ${{ runner.os }}-ccache-${{ github.ref }}
+          ${{ runner.os }}-ccache-
     - name: Install gtar wrapper
       run: |
         which gtar
@@ -95,8 +95,8 @@ jobs:
       with:
         path: /opt/local/
         key: ${{ runner.os }}-macports-${{ hashFiles('.github/workflows/macports-deps.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-macports-
+        # restore-keys: |
+        #   ${{ runner.os }}-macports-
     - name: Install MacPorts (if necessary)
       run: |
         if [ -d /opt/local/ ]; then

--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -94,9 +94,9 @@ jobs:
       uses: actions/cache@v2
       with:
         path: /opt/local/
-        key: ${{ runner.os }}-macports-${{ hashFiles('.github/workflows/macports-deps.txt') }}
-        # restore-keys: |
-        #   ${{ runner.os }}-macports-
+        key: ${{ runner.os }}-14-macports-${{ hashFiles('.github/workflows/macports-deps.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-14-macports-
     - name: Install MacPorts (if necessary)
       run: |
         if [ -d /opt/local/ ]; then

--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -77,8 +77,9 @@ jobs:
       with:
         submodules: true
     - name: ccache
-      uses: hendrikmuhs/ccache-action@v1.2.11
+      uses: hendrikmuhs/ccache-action@v1.2.13
       with:
+        create-symlink: true
         key: ${{ runner.os }}-14-ccache-${{ github.ref }}-${{ github.sha }}
         restore-keys: |
           ${{ runner.os }}-14-ccache-${{ github.ref }}
@@ -117,8 +118,6 @@ jobs:
         name: soh.otr
     - name: Build SoH
       run: |
-        which ccache
-        export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
         cmake --no-warn-unused-cli -H. -Bbuild-cmake -GNinja -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" -DBUILD_REMOTE_CONTROL=1
         cmake --build build-cmake --config Release --parallel 10
         mv soh.otr build-cmake/soh

--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -86,7 +86,6 @@ jobs:
           ${{ runner.os }}-14-ccache-
     - name: Install gtar wrapper
       run: |
-        which gtar
         sudo mv /opt/homebrew/bin/gtar /opt/homebrew/bin/gtar.orig
         sudo cp .github/workflows//gtar /opt/homebrew/bin/gtar
         sudo chmod +x /opt/homebrew/bin/gtar

--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -117,6 +117,7 @@ jobs:
         name: soh.otr
     - name: Build SoH
       run: |
+        which ccache
         export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
         cmake --no-warn-unused-cli -H. -Bbuild-cmake -GNinja -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" -DBUILD_REMOTE_CONTROL=1
         cmake --build build-cmake --config Release --parallel 10

--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -7,7 +7,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   generate-soh-otr:
-    runs-on: ${{ (vars.LINUX_RUNNER && fromJSON(vars.LINUX_RUNNER)) || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
       with:
@@ -20,7 +20,6 @@ jobs:
           ${{ runner.os }}-otr-ccache-${{ github.ref }}
           ${{ runner.os }}-otr-ccache-
     - name: Install dependencies
-      if: ${{ !vars.LINUX_RUNNER }}
       run: |
         sudo apt-get update
         sudo apt-get install -y $(cat .github/workflows/apt-deps.txt)
@@ -35,7 +34,6 @@ jobs:
           build-cmake
           SDL2-2.28.5
     - name: Install latest SDL
-      if: ${{ !vars.LINUX_RUNNER }}
       run: |
         export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
         if [ ! -d "SDL2-2.28.5" ]; then
@@ -73,7 +71,7 @@ jobs:
         retention-days: 1
   build-macos:
     needs: generate-soh-otr
-    runs-on: ${{ (vars.MAC_RUNNER && fromJSON(vars.MAC_RUNNER)) || 'macos-12' }}
+    runs-on: macos-14
     steps:
     - uses: actions/checkout@v3
       with:
@@ -86,14 +84,12 @@ jobs:
           ${{ runner.os }}-ccache-${{ github.ref }}
           ${{ runner.os }}-ccache-
     - name: Install gtar wrapper
-      if: ${{ !vars.MAC_RUNNER }}
       run: |
         sudo mv /usr/local/bin/gtar /usr/local/bin/gtar.orig
         sudo cp .github/workflows//gtar /usr/local/bin/gtar
         sudo chmod +x /usr/local/bin/gtar
     - name: Cache MacPorts
       id: cache-macports
-      if: ${{ !vars.MAC_RUNNER }}
       uses: actions/cache@v2
       with:
         path: /opt/local/
@@ -101,7 +97,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-macports-
     - name: Install MacPorts (if necessary)
-      if: ${{ !vars.MAC_RUNNER }}
       run: |
         if [ -d /opt/local/ ]; then
           echo "MacPorts already installed"
@@ -111,7 +106,6 @@ jobs:
         fi
         echo "/opt/local/bin:/opt/local/sbin" >> $GITHUB_PATH
     - name: Install dependencies
-      if: ${{ !vars.MAC_RUNNER }}
       run: |
         brew uninstall --ignore-dependencies libpng libzip
         sudo port install $(cat .github/workflows/macports-deps.txt)
@@ -139,45 +133,33 @@ jobs:
           readme.txt
   build-linux:
     needs: generate-soh-otr
-    strategy:
-      fail-fast: true
-      matrix:
-        include:
-        - os: ubuntu-20.04
-          gcc: 10
-          archive-suffix: compatibility
-        - os: ubuntu-22.04
-          gcc: 12
-          archive-suffix: performance
-    runs-on: ${{ (matrix.os == 'ubuntu-20.04' && ((vars.LINUX_COMPATIBILITY_RUNNER && fromJSON(vars.LINUX_COMPATIBILITY_RUNNER)) || matrix.os)) || (matrix.os == 'ubuntu-22.04' && ((vars.LINUX_PERFORMANCE_RUNNER && fromJSON(vars.LINUX_PERFORMANCE_RUNNER)) || matrix.os)) }}
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
       with:
         submodules: true
     - name: Install dependencies
-      if: ${{ (matrix.os == 'ubuntu-20.04' && !vars.LINUX_COMPATIBILITY_RUNNER) || (matrix.os == 'ubuntu-22.04' && !vars.LINUX_PERFORMANCE_RUNNER) }}
       run: |
         sudo apt-get update
         sudo apt-get install -y $(cat .github/workflows/apt-deps.txt)
     - name: ccache
       uses: hendrikmuhs/ccache-action@v1.2.11
       with:
-        key: ${{ matrix.os }}-ccache-${{ github.ref }}-${{ github.sha }}
+        key: linux-ccache-${{ github.ref }}-${{ github.sha }}
         restore-keys: |
-          ${{ matrix.os }}-ccache-${{ github.ref }}
-          ${{ matrix.os }}-ccache-
+          linux-ccache-${{ github.ref }}
+          linux-ccache-
     - name: Cache build folders
       uses: actions/cache@v4
       with:
-        key: ${{ matrix.os }}-build-${{ github.ref }}-${{ github.sha }}
+        key: linux-build-${{ github.ref }}-${{ github.sha }}
         restore-keys: |
-          ${{ matrix.os }}-build-${{ github.ref }}
-          ${{ matrix.os }}-build-
+          linux-build-${{ github.ref }}
+          linux-build-
         path: |
           SDL2-2.28.5
           SDL2_net-2.2.0
     - name: Install latest SDL
-      if: ${{ (matrix.os == 'ubuntu-20.04' && !vars.LINUX_COMPATIBILITY_RUNNER) || (matrix.os == 'ubuntu-22.04' && !vars.LINUX_PERFORMANCE_RUNNER) }}
       run: |
         export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
         if [ ! -d "SDL2-2.28.5" ]; then
@@ -189,38 +171,7 @@ jobs:
         make -j 10
         sudo make install
         sudo cp -av /usr/local/lib/libSDL* /lib/x86_64-linux-gnu/
-    - name: Install latest libzip
-      if: ${{ (matrix.os == 'ubuntu-20.04' && !vars.LINUX_COMPATIBILITY_RUNNER) }}
-      run: |
-        sudo apt-get remove libzip-dev zipcmp zipmerge ziptool
-        export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
-        if [ ! -d "libzip-1.10.1" ]; then
-          wget https://libzip.org/download/libzip-1.10.1.tar.gz
-          tar -xzvf libzip-1.10.1.tar.gz
-        fi
-        cd libzip-1.10.1
-        mkdir build
-        cd build
-        cmake ..
-        make
-        sudo make install
-    - name: Install latest nlohmann
-      if: ${{ (matrix.os == 'ubuntu-20.04' && !vars.LINUX_COMPATIBILITY_RUNNER) }}
-      run: |
-        sudo apt-get remove nlohmann-json3-dev
-        export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
-        if [ ! -d "json-3.11.3" ]; then
-          wget https://github.com/nlohmann/json/archive/refs/tags/v3.11.3.tar.gz
-          tar -xzvf v3.11.3.tar.gz
-        fi
-        cd json-3.11.3
-        mkdir build
-        cd build
-        cmake ..
-        make
-        sudo make install
     - name: Install latest tinyxml2
-      if: ${{ (matrix.os == 'ubuntu-20.04' && !vars.LINUX_COMPATIBILITY_RUNNER) || (matrix.os == 'ubuntu-22.04' && !vars.LINUX_PERFORMANCE_RUNNER) }}
       run: |
         sudo apt-get remove libtinyxml2-dev
         export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
@@ -235,7 +186,6 @@ jobs:
         make
         sudo make install
     - name: Install latest SDL_net
-      if: ${{ (matrix.os == 'ubuntu-20.04' && !vars.LINUX_COMPATIBILITY_RUNNER) || (matrix.os == 'ubuntu-22.04' && !vars.LINUX_PERFORMANCE_RUNNER) }}
       run: |
         export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
         if [ ! -d "SDL2_net-2.2.0" ]; then
@@ -261,12 +211,12 @@ jobs:
         mv README.md readme.txt
         mv build-cmake/*.appimage soh.appimage
       env:
-        CC: gcc-${{ matrix.gcc }}
-        CXX: g++-${{ matrix.gcc }}
+        CC: gcc-12
+        CXX: g++-12
     - name: Upload build
       uses: actions/upload-artifact@v4
       with:
-        name: soh-linux-${{ matrix.archive-suffix }}
+        name: soh-linux
         path: |
           soh.appimage
           readme.txt

--- a/.github/workflows/gtar
+++ b/.github/workflows/gtar
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec sudo /usr/local/bin/gtar.orig "$@"
+exec sudo /opt/homebrew/bin/gtar.orig "$@"


### PR DESCRIPTION
### what changed
* drops linux compat builds
* drops selfhosted conditional logic
* moved to macOS 14, 12 doesn't use M1 gh runners ([source](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories))

### todo (maybe?)
- ~switch the mac cache keys back to `${{ runner.os }}-ccache-*` from `${{ runner.os }}-14-ccache-*`~

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1479192043.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1479198419.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1479206512.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1479220592.zip)
<!--- section:artifacts:end -->