### PR TITLE
Fix some memory leaks with WrappedText and LoadArrayByNameAsVec3s

### DIFF
--- a/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
+++ b/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
@@ -782,7 +782,7 @@ void DrawFlagTableArray16(const FlagTable& flagTable, uint16_t row, uint16_t& fl
         ImGui::PopStyleColor();
         if (ImGui::IsItemHovered() && hasDescription) {
             ImGui::BeginTooltip();
-            ImGui::Text("%s", UIWidgets::WrappedText(flagTable.flagDescriptions.at(row * 16 + flagIndex), 60));
+            ImGui::Text("%s", UIWidgets::WrappedText(flagTable.flagDescriptions.at(row * 16 + flagIndex), 60).c_str());
             ImGui::EndTooltip();
         }
         ImGui::PopID();

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -1735,6 +1735,7 @@ extern "C" char* ResourceMgr_LoadArrayByName(const char* path)
     return (char*)res->Scalars.data();
 }
 
+// Return of LoadArrayByNameAsVec3s must be freed by the caller
 extern "C" char* ResourceMgr_LoadArrayByNameAsVec3s(const char* path) {
     auto res = std::static_pointer_cast<LUS::Array>(GetResourceByNameHandlingMQ(path));
 

--- a/soh/soh/UIWidgets.cpp
+++ b/soh/soh/UIWidgets.cpp
@@ -21,7 +21,7 @@ namespace UIWidgets {
     // Automatically adds newlines to break up text longer than a specified number of characters
     // Manually included newlines will still be respected and reset the line length
     // If line is midword when it hits the limit, text should break at the last encountered space
-    char* WrappedText(const char* text, unsigned int charactersPerLine) {
+    std::string WrappedText(const char* text, unsigned int charactersPerLine) {
         std::string newText(text);
         const size_t tipLength = newText.length();
         int lastSpace = -1;
@@ -43,17 +43,17 @@ namespace UIWidgets {
             currentLineLength++;
         }
 
-        return strdup(newText.c_str());
+        return newText;
     }
 
-    char* WrappedText(const std::string& text, unsigned int charactersPerLine) {
+    std::string WrappedText(const std::string& text, unsigned int charactersPerLine) {
         return WrappedText(text.c_str(), charactersPerLine);
     }
 
     void SetLastItemHoverText(const std::string& text) {
         if (ImGui::IsItemHovered()) {
             ImGui::BeginTooltip();
-            ImGui::Text("%s", WrappedText(text, 60));
+            ImGui::Text("%s", WrappedText(text, 60).c_str());
             ImGui::EndTooltip();
         }
     }
@@ -61,7 +61,7 @@ namespace UIWidgets {
     void SetLastItemHoverText(const char* text) {
         if (ImGui::IsItemHovered()) {
             ImGui::BeginTooltip();
-            ImGui::Text("%s", WrappedText(text, 60));
+            ImGui::Text("%s", WrappedText(text, 60).c_str());
             ImGui::EndTooltip();
         }
     }
@@ -72,7 +72,7 @@ namespace UIWidgets {
         ImGui::TextColored(ImVec4(0.7f, 0.7f, 0.7f, 1.0f), "?");
         if (ImGui::IsItemHovered()) {
             ImGui::BeginTooltip();
-            ImGui::Text("%s", WrappedText(text, 60));
+            ImGui::Text("%s", WrappedText(text, 60).c_str());
             ImGui::EndTooltip();
         }
     }
@@ -82,7 +82,7 @@ namespace UIWidgets {
         ImGui::TextColored(ImVec4(0.7f, 0.7f, 0.7f, 1.0f), "?");
         if (ImGui::IsItemHovered()) {
             ImGui::BeginTooltip();
-            ImGui::Text("%s", WrappedText(text, 60));
+            ImGui::Text("%s", WrappedText(text, 60).c_str());
             ImGui::EndTooltip();
         }
     }
@@ -92,7 +92,7 @@ namespace UIWidgets {
 
     void Tooltip(const char* text) {
         if (ImGui::IsItemHovered()) {
-            ImGui::SetTooltip("%s", WrappedText(text));
+            ImGui::SetTooltip("%s", WrappedText(text).c_str());
         }
     }
 

--- a/soh/soh/UIWidgets.hpp
+++ b/soh/soh/UIWidgets.hpp
@@ -50,8 +50,8 @@ namespace UIWidgets {
     constexpr float sliderButtonWidth = 30.0f;
 #endif
 
-    char* WrappedText(const char* text, unsigned int charactersPerLine = 60);
-    char* WrappedText(const std::string& text, unsigned int charactersPerLine);
+    std::string WrappedText(const char* text, unsigned int charactersPerLine = 60);
+    std::string WrappedText(const std::string& text, unsigned int charactersPerLine);
 
     void SetLastItemHoverText(const std::string& text);
     void SetLastItemHoverText(const char* text);

--- a/soh/src/code/z_player_lib.c
+++ b/soh/src/code/z_player_lib.c
@@ -2307,10 +2307,12 @@ void Player_DrawPause(PlayState* play, u8* segment, SkelAnime* skelAnime, Vec3f*
         }
 
         srcTable = ResourceMgr_LoadArrayByNameAsVec3s(srcTable);
+        Vec3s* ogSrcTable = srcTable;
         destTable = skelAnime->jointTable;
         for (i = 0; i < skelAnime->limbCount; i++) {
             *destTable++ = *srcTable++;
         }
+        free(ogSrcTable);
     }
 
 


### PR DESCRIPTION
WrappedText for UIWidgets was using strdup with having the return string freed up later. Rather than using strdup, we can just return std::string and have the caller execute `.c_str()` on the result and avoid malloc/free issues all together. (see #4043)

Also address a memory leak from LoadArrayByNameAsVec3s which mallocs a new array every call to it on the static pause link drawing. The Vec3s resource copies by value to the skelanime joint table, but the original Vec3s resource was not being freed after.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1486773961.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1486773963.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1486773964.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1486773965.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1486773966.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1486773968.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1486773969.zip)
<!--- section:artifacts:end -->