### PR TITLE
allow setting device visibility in controller mapping window

### DIFF
--- a/soh/soh/Enhancements/controls/SohInputEditorWindow.h
+++ b/soh/soh/Enhancements/controls/SohInputEditorWindow.h
@@ -92,7 +92,6 @@ class SohInputEditorWindow : public Ship::GuiWindow {
     void DrawLinkTab();
     void DrawIvanTab();
     void DrawDebugPortTab(uint8_t portIndex, std::string customName = "");
-    void DrawDevicesTab();
     std::set<uint16_t> mButtonsBitmasks;
     std::set<uint16_t> mDpadBitmasks;
     std::set<uint16_t> mModifierButtonsBitmasks;
@@ -104,4 +103,7 @@ class SohInputEditorWindow : public Ship::GuiWindow {
     bool mInputEditorPopupOpen;
     void DrawSetDefaultsButton(uint8_t portIndex);
     void DrawClearAllButton(uint8_t portIndex);
+
+    std::map<Ship::ShipDeviceIndex, bool> mDeviceIndexVisiblity;
+    void DrawDeviceVisibilityButtons();
 };


### PR DESCRIPTION
i started looking into https://github.com/Kenix3/libultraship/issues/595 and the complexity piled up quickly

to "only auto-configure one controller device automatically" we'd want to ensure every connected controller still registers as connected, but doesn't have any mappings associated with it

on the surface that idea makes sense, but it quickly gets more complex when thinking about user flows other than "start up the game for the first time with multiple connected controllers and no existing mappings"

what should the menu look like if last time you played you had a different controller with mappings set up? those mappings still exist, should we hide them?

what should happen if you connect a controller mid game that you have previous mappings configured for? what about one where you don't have previous mappings configured?

all of these flows have been considered with the existing single player mode mapping method. all connected controllers get default mappings if there isn't already a mapping for that type of controller configured.

this aims to resolve the main issue of "when a player opens the controller config menu with a bunch of connected devices it's overwhelming" a simpler way. by default hide all but the first SDL controller and the keyboard, and provide a way to toggle visibility of any given device's mappings.

this way every controller will still work, you can pick up and play without touching the config menu, but you can go into the menu and toggle which devices you want to see mappings for.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1520853189.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1520883443.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1520883608.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1520890108.zip)
<!--- section:artifacts:end -->