### PR TITLE
exclude `libcrypto` from appimage (instead rely on system version of openssl)

### DIFF
--- a/CMake/Packaging.cmake
+++ b/CMake/Packaging.cmake
@@ -79,6 +79,7 @@ execute_process(
     --executable=$<TARGET_FILE:soh>
     $<$<BOOL:$<TARGET_PROPERTY:soh,APPIMAGE_DESKTOP_FILE>>:--desktop-file=$<TARGET_PROPERTY:soh,APPIMAGE_DESKTOP_FILE>>
     $<$<BOOL:$<TARGET_PROPERTY:soh,APPIMAGE_ICON_FILE>>:--icon-file=$<TARGET_PROPERTY:soh,APPIMAGE_ICON_FILE>>
+    --exclude-library "*libcrypto*"
     --output=appimage
     # --verbosity=2
 )


### PR DESCRIPTION
null

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1538970807.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1538983157.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1538984652.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1538987199.zip)
<!--- section:artifacts:end -->