### PR TITLE
Fix Multiple Foolish hints from an area being generated.

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/hints.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/hints.cpp
@@ -129,9 +129,9 @@ bool FilterWotHLocations(RandomizerCheck loc){
   return ctx->GetItemLocation(loc)->IsWothCandidate();
 }
 
-bool FilterBarrenLocations(RandomizerCheck loc){
+bool FilterFoolishLocations(RandomizerCheck loc){
   auto ctx = Rando::Context::GetInstance();
-  return ctx->GetItemLocation(loc)->IsBarrenCandidate();
+  return ctx->GetItemLocation(loc)->IsFoolishCandidate();
 }
 
 bool FilterSongLocations(RandomizerCheck loc){
@@ -176,7 +176,7 @@ const std::array<HintSetting, 4> hintSettingTable{{
     .junkWeight = 6,
     .distTable = {
       {"WotH",       HINT_TYPE_WOTH,      7,   0, 1, FilterWotHLocations,      2},
-      {"Barren",     HINT_TYPE_FOOLISH,   4,   0, 1, FilterBarrenLocations,    1},
+      {"Foolish",    HINT_TYPE_FOOLISH,   4,   0, 1, FilterFoolishLocations,   1},
       //("Entrance",   HINT_TYPE_ENTRANCE,      6,  0, 1), //not yet implemented
       {"Song",       HINT_TYPE_ITEM,      2,   0, 1, FilterSongLocations},
       {"Overworld",  HINT_TYPE_ITEM,      4,   0, 1, FilterOverworldLocations},
@@ -192,7 +192,7 @@ const std::array<HintSetting, 4> hintSettingTable{{
     .junkWeight = 0,
     .distTable = {
       {"WotH",       HINT_TYPE_WOTH,      12, 0, 2, FilterWotHLocations,      2},
-      {"Barren",     HINT_TYPE_FOOLISH,   12, 0, 1, FilterBarrenLocations,    1},
+      {"Foolish",    HINT_TYPE_FOOLISH,   12, 0, 1, FilterFoolishLocations,   1},
       //{"Entrance",   HINT_TYPE_ENTRANCE,      4, 0, 1}, //not yet implemented
       {"Song",       HINT_TYPE_ITEM,      4,  0, 1, FilterSongLocations},
       {"Overworld",  HINT_TYPE_ITEM,      6,  0, 1, FilterOverworldLocations},
@@ -208,7 +208,7 @@ const std::array<HintSetting, 4> hintSettingTable{{
     .junkWeight = 0,
     .distTable = {
       {"WotH",       HINT_TYPE_WOTH,      15, 0, 2, FilterWotHLocations},
-      {"Barren",     HINT_TYPE_FOOLISH,   15, 0, 1, FilterBarrenLocations},
+      {"Foolish",    HINT_TYPE_FOOLISH,   15, 0, 1, FilterFoolishLocations},
       //{"Entrance",   HINT_TYPE_ENTRANCE,     10, 0, 1}, //not yet implemented
       {"Song",       HINT_TYPE_ITEM,      2,  0, 1, FilterSongLocations},
       {"Overworld",  HINT_TYPE_ITEM,      7,  0, 1, FilterOverworldLocations},
@@ -448,9 +448,6 @@ static RandomizerCheck CreateRandomHint(std::vector<RandomizerCheck>& possibleHi
 
     placed = CreateHint(hintedLocation, copies, type, distributionName);
   }
-  if (type == HINT_TYPE_FOOLISH){
-     SetAllInRegionAsHinted(ctx->GetItemLocation(hintedLocation)->GetArea(), possibleHintLocations);
-  }
   return hintedLocation;
 }
 
@@ -582,6 +579,10 @@ uint8_t PlaceHints(std::vector<uint8_t>& selectedHints,
       RandomizerCheck hintedLocation = RC_UNKNOWN_CHECK;
 
       hintedLocation = CreateRandomHint(hintTypePool, distribution.copies, distribution.type, distribution.name);
+      if (distribution.type == HINT_TYPE_FOOLISH){
+        SetAllInRegionAsHinted(ctx->GetItemLocation(hintedLocation)->GetArea(), hintTypePool);
+        hintTypePool = FilterHintability(hintTypePool);
+      }
       if (hintedLocation == RC_UNKNOWN_CHECK){ //if hint failed to place, remove all wieght and copies then return the number of stones to redistribute
         uint8_t hintsToRemove = (selectedHints[curSlot] - numHint) * distribution.copies;
         selectedHints[curSlot] = 0;   //as distTable is passed by refernce here, these changes stick for the rest of this seed generation

--- a/soh/soh/Enhancements/randomizer/hint.cpp
+++ b/soh/soh/Enhancements/randomizer/hint.cpp
@@ -400,7 +400,7 @@ oJson Hint::toJSON() {
       log["distribution"] = distribution;
     }
     
-    if (hintType != HINT_TYPE_FOOLISH){
+    //if (hintType != HINT_TYPE_FOOLISH){
       if (!(StaticData::staticHintInfoMap.contains(ownKey) && 
           StaticData::staticHintInfoMap[ownKey].targetChecks.size() > 0)){
         if (locations.size() == 1){
@@ -413,7 +413,7 @@ oJson Hint::toJSON() {
           }
           log["locations"] = locStrings;
         }
-      }
+      //}
       
       if (!(StaticData::staticHintInfoMap.contains(ownKey) &&
           StaticData::staticHintInfoMap[ownKey].targetItems.size() > 0)){

--- a/soh/soh/Enhancements/randomizer/hint.cpp
+++ b/soh/soh/Enhancements/randomizer/hint.cpp
@@ -400,7 +400,7 @@ oJson Hint::toJSON() {
       log["distribution"] = distribution;
     }
     
-    //if (hintType != HINT_TYPE_FOOLISH){
+    if (hintType != HINT_TYPE_FOOLISH){
       if (!(StaticData::staticHintInfoMap.contains(ownKey) && 
           StaticData::staticHintInfoMap[ownKey].targetChecks.size() > 0)){
         if (locations.size() == 1){
@@ -413,7 +413,7 @@ oJson Hint::toJSON() {
           }
           log["locations"] = locStrings;
         }
-      //}
+      }
       
       if (!(StaticData::staticHintInfoMap.contains(ownKey) &&
           StaticData::staticHintInfoMap[ownKey].targetItems.size() > 0)){

--- a/soh/soh/Enhancements/randomizer/item_location.cpp
+++ b/soh/soh/Enhancements/randomizer/item_location.cpp
@@ -192,7 +192,7 @@ void ItemLocation::SetWothCandidate() {
     wothCandidate = true;
 }
 
-bool ItemLocation::IsBarrenCandidate() const {
+bool ItemLocation::IsFoolishCandidate() const {
     return barrenCandidate;
 }
 

--- a/soh/soh/Enhancements/randomizer/item_location.h
+++ b/soh/soh/Enhancements/randomizer/item_location.h
@@ -49,7 +49,7 @@ class ItemLocation {
     void SetVisible(bool visibleInImGui_);
     bool IsWothCandidate() const;
     void SetWothCandidate();
-    bool IsBarrenCandidate() const;
+    bool IsFoolishCandidate() const;
     void SetBarrenCandidate();
     void ResetVariables();
 


### PR DESCRIPTION
Quick hotfix for a regression caused by previous hint generation fixes. I also changed some more "Barren" names to "Foolish"

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1543947603.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1543995102.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1544009552.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1544011495.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1544248360.zip)
<!--- section:artifacts:end -->