### PR TITLE
Fix Link's Pocket Appearing in Hints.

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/fill.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/fill.cpp
@@ -18,7 +18,6 @@
 #include <vector>
 #include <list>
 #include <spdlog/spdlog.h>
-#include <ranges>
 
 using namespace CustomMessages;
 using namespace Rando;
@@ -489,7 +488,7 @@ static void GeneratePlaythrough() {
 RandomizerArea LookForExternalArea(const Area* const currentRegion, std::vector<RandomizerRegion> &alreadyChecked){
   for (const auto& entrance : currentRegion->entrances) {
     RandomizerArea otherArea = entrance->GetParentRegion()->GetArea();
-    const bool isAreaUnchecked = std::ranges::find(alreadyChecked, entrance->GetParentRegionKey()) == alreadyChecked.end();
+    const bool isAreaUnchecked = std::find(alreadyChecked.begin(), alreadyChecked.end(), entrance->GetParentRegionKey()) == alreadyChecked.end();
     if (otherArea == RA_NONE && isAreaUnchecked) {
       //if the region is in RA_NONE and hasn't already been checked, check it
       alreadyChecked.push_back(entrance->GetParentRegionKey());

--- a/soh/soh/Enhancements/randomizer/3drando/fill.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/fill.cpp
@@ -488,14 +488,16 @@ static void GeneratePlaythrough() {
 RandomizerArea LookForExternalArea(Area* curRegion, std::vector<RandomizerRegion> alreadyChecked){//RANDOTODO curREGION
   for (auto& entrance : curRegion->entrances) {
     RandomizerArea otherArea = entrance->GetParentRegion()->GetArea();
-    if(otherArea != RA_NONE){
-      return otherArea;
-      //if the area hasn't already been checked, check it
-    } else if (std::find(alreadyChecked.begin(), alreadyChecked.end(), entrance->GetParentRegionKey()) == alreadyChecked.end()) {
-      alreadyChecked.push_back(entrance->GetParentRegionKey());
-      RandomizerArea passdown = LookForExternalArea(entrance->GetParentRegion(), alreadyChecked);
-      if(passdown != RA_NONE){
-        return passdown;
+    if (otherArea != RA_LINKS_POCKET){ //if it's links pocket, do not propogate this, link's pocket is not a real Area
+      if(otherArea != RA_NONE){
+        return otherArea;
+        //if the area hasn't already been checked, check it
+      } else if (std::find(alreadyChecked.begin(), alreadyChecked.end(), entrance->GetParentRegionKey()) == alreadyChecked.end()) {
+        alreadyChecked.push_back(entrance->GetParentRegionKey());
+        RandomizerArea passdown = LookForExternalArea(entrance->GetParentRegion(), alreadyChecked);
+        if(passdown != RA_NONE){
+          return passdown;
+        }
       }
     }
   }
@@ -515,6 +517,7 @@ void SetAreas(){
     for (auto& loc : region.locations){
       ctx->GetItemLocation(loc.GetLocation())->SetArea(area);
     }
+    areaTable[c].SetArea(area);
   }
 }
 

--- a/soh/soh/Enhancements/randomizer/3drando/fill.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/fill.cpp
@@ -18,6 +18,7 @@
 #include <vector>
 #include <list>
 #include <spdlog/spdlog.h>
+#include <ranges>
 
 using namespace CustomMessages;
 using namespace Rando;
@@ -488,13 +489,14 @@ static void GeneratePlaythrough() {
 RandomizerArea LookForExternalArea(const Area* const currentRegion, std::vector<RandomizerRegion> &alreadyChecked){
   for (const auto& entrance : currentRegion->entrances) {
     RandomizerArea otherArea = entrance->GetParentRegion()->GetArea();
-    if(otherArea == RA_NONE && std::find(alreadyChecked.begin(), alreadyChecked.end(), entrance->GetParentRegionKey()) == alreadyChecked.end()){
-        //if the region is in RA_NONE and hasn't already been checked, check it
-        alreadyChecked.push_back(entrance->GetParentRegionKey());
-        const RandomizerArea passdown = LookForExternalArea(entrance->GetParentRegion(), alreadyChecked);
-        if(passdown != RA_NONE){
-          return passdown;
-        }
+    const bool isAreaUnchecked = std::ranges::find(alreadyChecked, entrance->GetParentRegionKey()) == alreadyChecked.end();
+    if (otherArea == RA_NONE && isAreaUnchecked) {
+      //if the region is in RA_NONE and hasn't already been checked, check it
+      alreadyChecked.push_back(entrance->GetParentRegionKey());
+      const RandomizerArea passdown = LookForExternalArea(entrance->GetParentRegion(), alreadyChecked);
+      if(passdown != RA_NONE){
+        return passdown;
+      }
     } else if (otherArea != RA_LINKS_POCKET){ //if it's links pocket, do not propogate this, Link's Pocket is not a real Area
       return otherArea;
     }

--- a/soh/soh/Enhancements/randomizer/3drando/hints.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/hints.cpp
@@ -496,7 +496,7 @@ void CreateWarpSongTexts() {
   if (ctx->GetOption(RSK_WARP_SONG_HINTS)){
     auto warpSongEntrances = GetShuffleableEntrances(EntranceType::WarpSong, false);
     for (auto entrance : warpSongEntrances) {
-      auto destination = entrance->GetConnectedRegion()->GetArea();//KNOWN ISSUE: says links pocket sometimes, putting off as this will need rewriting when entrance hits are added anyway
+      auto destination = entrance->GetConnectedRegion()->GetArea();
       switch (entrance->GetIndex()) {
         case 0x0600: // minuet RANDOTODO make into entrance hints when they are added
           ctx->AddHint(RH_MINUET_WARP_LOC, Hint(RH_MINUET_WARP_LOC, HINT_TYPE_AREA, "", {RHT_WARP_SONG}, {}, {destination}));

--- a/soh/soh/Enhancements/randomizer/3drando/hints.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/hints.cpp
@@ -496,7 +496,7 @@ void CreateWarpSongTexts() {
   if (ctx->GetOption(RSK_WARP_SONG_HINTS)){
     auto warpSongEntrances = GetShuffleableEntrances(EntranceType::WarpSong, false);
     for (auto entrance : warpSongEntrances) {
-      auto destination = entrance->GetConnectedRegion()->GetArea();
+      const auto destination = entrance->GetConnectedRegion()->GetArea();
       switch (entrance->GetIndex()) {
         case 0x0600: // minuet RANDOTODO make into entrance hints when they are added
           ctx->AddHint(RH_MINUET_WARP_LOC, Hint(RH_MINUET_WARP_LOC, HINT_TYPE_AREA, "", {RHT_WARP_SONG}, {}, {destination}));

--- a/soh/soh/Enhancements/randomizer/3drando/location_access.hpp
+++ b/soh/soh/Enhancements/randomizer/3drando/location_access.hpp
@@ -186,6 +186,10 @@ public:
         return area;
     }
 
+    void SetArea(RandomizerArea newArea) {
+        area = newArea;
+    }
+
     //Here checks conditional access based on whether or not both ages have
     //access to this area. For example: if there are rocks that block a path
     //which both child and adult can access, adult having hammer can give
@@ -222,7 +226,6 @@ public:
                      "Child Night: " + std::to_string(childNight) + "\t"
                      "Adult Day:   " + std::to_string(adultDay)   + "\t"
                      "Adult Night: " + std::to_string(adultNight);
-      //CitraPrint(message);
     }
 };
 


### PR DESCRIPTION
Due to some errors in how areas were propagated into interiors, some locations were being designated as Link's Pocket when Random Warp Songs and Spawns were enabled. Additionally an Oversight meant that the interior region itself was not having it's area changed.

An entrance refactor would ideally prevent certain entrances from passing their area down explicitly, (owl drops may still be a problem, for example) but this fixes the obvious issues.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1672112482.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1672153034.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1672156316.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1672163583.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1672360014.zip)
<!--- section:artifacts:end -->