### PR TITLE
RSK_MQ_DUNGEON_COUNT Value defined using #define in header file

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -2967,11 +2967,11 @@ void GenerateRandomizerImgui(std::string seed = "") {
     if (OTRGlobals::Instance->HasMasterQuest() && OTRGlobals::Instance->HasOriginal()) {
         // If both OTRs are loaded.
         cvarSettings[RSK_RANDOM_MQ_DUNGEONS] = CVarGetInteger(CVAR_RANDOMIZER_SETTING("MQDungeons"), RO_MQ_DUNGEONS_NONE);
-        cvarSettings[RSK_MQ_DUNGEON_COUNT] = CVarGetInteger(CVAR_RANDOMIZER_SETTING("MQDungeonCount"), 12);
+        cvarSettings[RSK_MQ_DUNGEON_COUNT] = CVarGetInteger(CVAR_RANDOMIZER_SETTING("MQDungeonCount"), RSK_MQ_DUNGEON_COUNT_VALUE);
     } else if (OTRGlobals::Instance->HasMasterQuest()) {
         // If only Master Quest is loaded.
         cvarSettings[RSK_RANDOM_MQ_DUNGEONS] = RO_MQ_DUNGEONS_SET_NUMBER;
-        cvarSettings[RSK_MQ_DUNGEON_COUNT] = 12;
+        cvarSettings[RSK_MQ_DUNGEON_COUNT] = RSK_MQ_DUNGEON_COUNT_VALUE;
     } else {
         // If only Original Quest is loaded.
         cvarSettings[RSK_RANDOM_MQ_DUNGEONS] = RO_MQ_DUNGEONS_NONE;
@@ -5518,7 +5518,7 @@ CustomMessage Randomizer::GetMapGetItemMessageWithHint(GetItemEntry itemEntry) {
 
     if (this->randoSettings[RSK_RANDOM_MQ_DUNGEONS] == RO_MQ_DUNGEONS_NONE ||
         (this->randoSettings[RSK_RANDOM_MQ_DUNGEONS] == RO_MQ_DUNGEONS_SET_NUMBER &&
-         this->randoSettings[RSK_MQ_DUNGEON_COUNT] == 12)
+         this->randoSettings[RSK_MQ_DUNGEON_COUNT] == RSK_MQ_DUNGEON_COUNT_VALUE)
        ) {
         messageEntry.Replace("{{typeHint}}", "");
     } else if (ResourceMgr_IsSceneMasterQuest(sceneNum)) {

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -2967,11 +2967,11 @@ void GenerateRandomizerImgui(std::string seed = "") {
     if (OTRGlobals::Instance->HasMasterQuest() && OTRGlobals::Instance->HasOriginal()) {
         // If both OTRs are loaded.
         cvarSettings[RSK_RANDOM_MQ_DUNGEONS] = CVarGetInteger(CVAR_RANDOMIZER_SETTING("MQDungeons"), RO_MQ_DUNGEONS_NONE);
-        cvarSettings[RSK_MQ_DUNGEON_COUNT] = CVarGetInteger(CVAR_RANDOMIZER_SETTING("MQDungeonCount"), RSK_MQ_DUNGEON_COUNT_VALUE);
+        cvarSettings[RSK_MQ_DUNGEON_COUNT] = CVarGetInteger(CVAR_RANDOMIZER_SETTING("MQDungeonCount"), MAX_MQ_DUNGEON_COUNT);
     } else if (OTRGlobals::Instance->HasMasterQuest()) {
         // If only Master Quest is loaded.
         cvarSettings[RSK_RANDOM_MQ_DUNGEONS] = RO_MQ_DUNGEONS_SET_NUMBER;
-        cvarSettings[RSK_MQ_DUNGEON_COUNT] = RSK_MQ_DUNGEON_COUNT_VALUE;
+        cvarSettings[RSK_MQ_DUNGEON_COUNT] = MAX_MQ_DUNGEON_COUNT;
     } else {
         // If only Original Quest is loaded.
         cvarSettings[RSK_RANDOM_MQ_DUNGEONS] = RO_MQ_DUNGEONS_NONE;
@@ -5518,7 +5518,7 @@ CustomMessage Randomizer::GetMapGetItemMessageWithHint(GetItemEntry itemEntry) {
 
     if (this->randoSettings[RSK_RANDOM_MQ_DUNGEONS] == RO_MQ_DUNGEONS_NONE ||
         (this->randoSettings[RSK_RANDOM_MQ_DUNGEONS] == RO_MQ_DUNGEONS_SET_NUMBER &&
-         this->randoSettings[RSK_MQ_DUNGEON_COUNT] == RSK_MQ_DUNGEON_COUNT_VALUE)
+         this->randoSettings[RSK_MQ_DUNGEON_COUNT] == MAX_MQ_DUNGEON_COUNT)
        ) {
         messageEntry.Replace("{{typeHint}}", "");
     } else if (ResourceMgr_IsSceneMasterQuest(sceneNum)) {

--- a/soh/soh/Enhancements/randomizer/randomizerTypes.h
+++ b/soh/soh/Enhancements/randomizer/randomizerTypes.h
@@ -5,6 +5,7 @@
 #include "randomizer_inf.h"
 
 #define MAX_TRICK_NAME_SIZE 50
+#define RSK_MQ_DUNGEON_COUNT 12
 
 // This should probably go in a less rando-specific location
 // but the best location will probably be in the modding engine

--- a/soh/soh/Enhancements/randomizer/randomizerTypes.h
+++ b/soh/soh/Enhancements/randomizer/randomizerTypes.h
@@ -5,7 +5,7 @@
 #include "randomizer_inf.h"
 
 #define MAX_TRICK_NAME_SIZE 50
-#define RSK_MQ_DUNGEON_COUNT 12
+#define MAX_MQ_DUNGEON_COUNT 12
 
 // This should probably go in a less rando-specific location
 // but the best location will probably be in the modding engine

--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -497,7 +497,7 @@ void CheckTrackerLoadGame(int32_t fileNum) {
             OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_RANDOM_MQ_DUNGEONS) == RO_MQ_DUNGEONS_NONE ||
             OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_RANDOM_MQ_DUNGEONS) == RO_MQ_DUNGEONS_SELECTION ||
             (OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_RANDOM_MQ_DUNGEONS) == RO_MQ_DUNGEONS_SET_NUMBER &&
-            OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_MQ_DUNGEON_COUNT) == 12))) {
+            OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_MQ_DUNGEON_COUNT) == RSK_MQ_DUNGEON_COUNT_VALUE))) {
             SetAreaSpoiled(static_cast<RandomizerCheckArea>(i));
         }
     }
@@ -524,7 +524,7 @@ void CheckTrackerLoadGame(int32_t fileNum) {
 
     showVOrMQ = (OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_RANDOM_MQ_DUNGEONS) == RO_MQ_DUNGEONS_RANDOM_NUMBER ||
                 (OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_RANDOM_MQ_DUNGEONS) == RO_MQ_DUNGEONS_SET_NUMBER &&
-                OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_MQ_DUNGEON_COUNT) < 12));
+                OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_MQ_DUNGEON_COUNT) < RSK_MQ_DUNGEON_COUNT_VALUE));
     LinksPocket();
     SongFromImpa();
     GiftFromSages();

--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -497,7 +497,7 @@ void CheckTrackerLoadGame(int32_t fileNum) {
             OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_RANDOM_MQ_DUNGEONS) == RO_MQ_DUNGEONS_NONE ||
             OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_RANDOM_MQ_DUNGEONS) == RO_MQ_DUNGEONS_SELECTION ||
             (OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_RANDOM_MQ_DUNGEONS) == RO_MQ_DUNGEONS_SET_NUMBER &&
-            OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_MQ_DUNGEON_COUNT) == RSK_MQ_DUNGEON_COUNT_VALUE))) {
+            OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_MQ_DUNGEON_COUNT) == MAX_MQ_DUNGEON_COUNT))) {
             SetAreaSpoiled(static_cast<RandomizerCheckArea>(i));
         }
     }
@@ -524,7 +524,7 @@ void CheckTrackerLoadGame(int32_t fileNum) {
 
     showVOrMQ = (OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_RANDOM_MQ_DUNGEONS) == RO_MQ_DUNGEONS_RANDOM_NUMBER ||
                 (OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_RANDOM_MQ_DUNGEONS) == RO_MQ_DUNGEONS_SET_NUMBER &&
-                OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_MQ_DUNGEON_COUNT) < RSK_MQ_DUNGEON_COUNT_VALUE));
+                OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_MQ_DUNGEON_COUNT) < MAX_MQ_DUNGEON_COUNT));
     LinksPocket();
     SongFromImpa();
     GiftFromSages();


### PR DESCRIPTION
This PR tries to solve [#4196](https://github.com/HarbourMasters/Shipwright/issues/4196)
The hardcoded value of RSK_MQ_DUNGEON_COUNT is defined as a macro in the randomizerTypes.h file.