### PR TITLE
Bump LUS for 2cyc color combiner fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,7 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 # Set GBI version
 ################################################################################
 
-add_compile_definitions(F3DEX_GBI_2)
+set(GBI_UCODE F3DEX_GBI_2)
 
 ################################################################################
 # Sub-projects

--- a/soh/soh/Enhancements/cosmetics/authenticGfxPatches.cpp
+++ b/soh/soh/Enhancements/cosmetics/authenticGfxPatches.cpp
@@ -9,7 +9,6 @@ extern "C" {
 #include "objects/object_gi_soldout/object_gi_soldout.h"
 #include "objects/object_ik/object_ik.h"
 #include "objects/object_link_child/object_link_child.h"
-#include "objects/object_ru2/object_ru2.h"
 
 uint32_t ResourceMgr_GameHasMasterQuest();
 uint32_t ResourceMgr_GameHasOriginal();
@@ -189,25 +188,10 @@ void PatchIronKnuckleTextureOverflow() {
     }
 }
 
-void PatchPrincessRutoEaring() {
-    // FAST3D: This is a hack for the issue of both TEXEL0 and TEXEL1 using the same texture with different settings.
-    // Ruto's earring uses both TEXEL0 and TEXEL1 to render. The issue is that it never loads anything into TEXEL1, so
-    // it reuses whatever happens to be there, which is the water temple brick texture. It just so happens that the
-    // earring texture loads into the same place in TMEM as the brick texture, so when it comes to rendering, TEXEL1
-    // uses the earring texture with different clamp settings, and it displays without noticeable error. However, both
-    // texel samplers are not intended to be used for the same texture with different settings, so this misuse confuses
-    // our texture cache, and we load the wrong settings for the earrings texture. This patch is a hack that replaces
-    // TEXEL1 with TEXEL0, which is most likely the original intention, and all is well.
-    ResourceMgr_PatchGfxByName(gAdultRutoHeadDL, "RutoEaringTileFix", 162,
-                               gsDPSetCombineLERP(TEXEL0, 0, PRIMITIVE, 0, TEXEL0, 0, ENVIRONMENT, 0, 0, 0, 0, COMBINED,
-                                                  TEXEL0, 0, PRIM_LOD_FRAC, COMBINED));
-}
-
 void ApplyAuthenticGfxPatches() {
     PatchDekuStickTextureOverflow();
     PatchFreezardTextureOverflow();
     PatchIronKnuckleTextureOverflow();
-    PatchPrincessRutoEaring();
 }
 
 // Patches the Sold Out GI DL to render the texture in the mirror boundary

--- a/soh/soh/SohGui.cpp
+++ b/soh/soh/SohGui.cpp
@@ -206,6 +206,9 @@ namespace SohGui {
     }
 
     void Destroy() {
+        auto gui = Ship::Context::GetInstance()->GetWindow()->GetGui();
+        gui->RemoveAllGuiWindows();
+        
         mModalWindow = nullptr;
         mAdvancedResolutionSettingsWindow = nullptr;
         mRandomizerSettingsWindow = nullptr;


### PR DESCRIPTION
Bumps LUS to bring in a fix for textures duplicating from the color combiner logic overusing texel1.

The recent changes around the color combiner enable us to drop the gfx path for adult Ruto's earrings texture rendering duplicated.

Also adds a call to remove all window instances vars from the gui context so that the SohGui::Destroy truly destructs our gui windows before the LUS context is destructed.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1630110475.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1630132625.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1630132852.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1630133158.zip)
<!--- section:artifacts:end -->