### PR TITLE
Fix hint crash on windows

### DIFF
--- a/soh/soh/Enhancements/custom-message/CustomMessageManager.cpp
+++ b/soh/soh/Enhancements/custom-message/CustomMessageManager.cpp
@@ -184,7 +184,7 @@ CustomMessage CustomMessage::operator+(const CustomMessage& right) const {
         newColors.push_back(color);
     }
     std::vector<bool> newCapital = capital;
-    newCapital.insert(capital.end(), right.GetCapital().begin(), right.GetCapital().end());
+    newCapital.insert(newCapital.end(), right.GetCapital().begin(), right.GetCapital().end());
     return CustomMessage(messages[LANGUAGE_ENG] + right.GetEnglish(MF_RAW),
                          messages[LANGUAGE_GER] + right.GetGerman(MF_RAW),
                          messages[LANGUAGE_FRA] + right.GetFrench(MF_RAW),


### PR DESCRIPTION
Fixes a stupid crash in hint generation. Please merge quickly.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1684177232.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1684217015.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1684219512.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1684225520.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1684239836.zip)
<!--- section:artifacts:end -->