### PR TITLE
Force Warp Song Hints off when Warp Songs are not shuffled

### DIFF
--- a/soh/soh/Enhancements/randomizer/settings.cpp
+++ b/soh/soh/Enhancements/randomizer/settings.cpp
@@ -1739,6 +1739,12 @@ void Settings::UpdateOptionProperties() {
         mOptions[RSK_HINT_DISTRIBUTION].Unhide();
     }
 
+    if (CVarGetInteger(CVAR_RANDOMIZER_SETTING("ShuffleWarpSongs"), RO_GENERIC_ON)) {
+        mOptions[RSK_WARP_SONG_HINTS].Enable();
+    } else {
+        mOptions[RSK_WARP_SONG_HINTS].Disable("This option is disabled since warp song locations not shuffled.");
+    }
+
     if (CVarGetInteger(CVAR_RANDOMIZER_SETTING("ShuffleCows"), RO_GENERIC_OFF)) {
         mOptions[RSK_MALON_HINT].Enable();
         } else {
@@ -2037,6 +2043,10 @@ void Settings::FinalizeSettings(const std::set<RandomizerCheck>& excludedLocatio
         }
         mOptions[RSK_KEYSANITY].SetDelayedOption();
         mOptions[RSK_KEYSANITY].SetSelectedIndex(3);
+    }
+
+    if (!mOptions[RSK_SHUFFLE_WARP_SONGS]) {
+        mOptions[RSK_WARP_SONG_HINTS].SetSelectedIndex(RO_GENERIC_OFF);
     }
 
     if (!mOptions[RSK_SHUFFLE_COWS]) {


### PR DESCRIPTION
Small fix for the issues maple was having in discord. If warp songs are not shuffled the hint setting for them is disabled in both the UI and as the seed is generated.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1691081175.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1691153909.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1691155885.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1691171621.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1691222043.zip)
<!--- section:artifacts:end -->