### PR TITLE
Show Time of Day on-screen

### DIFF
--- a/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
+++ b/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
@@ -407,6 +407,8 @@ void DrawInfoTab() {
     ImGui::SetNextItemWidth(ImGui::GetFontSize() * 15);
     ImGui::SliderScalar("Time", ImGuiDataType_U16, &gSaveContext.dayTime, &dayTimeMin, &dayTimeMax);
     UIWidgets::InsertHelpHoverText("Time of day");
+    ImGui::SameLine();
+    UIWidgets::PaddedEnhancementCheckbox("Display On-screen", CVAR_ENHANCEMENT("TimeDisplay"), true, false);
     if (ImGui::Button("Dawn")) {
         gSaveContext.dayTime = 0x4000;
     }
@@ -1746,7 +1748,24 @@ void DrawPlayerTab() {
     }
 }
 
+std::string convertTime(uint32_t dayTime) {
+    uint32_t totalSeconds = 24 * 60 * 60;
+    uint32_t seconds = static_cast<uint32_t>(static_cast<double>(dayTime) * (totalSeconds - 1) / 65535);
+    uint32_t hh = seconds / 3600;
+    uint32_t mm = (seconds % 3600) / 60;
+    uint32_t ss = seconds % 60;
+    return fmt::format("{:0>2}:{:0>2}:{:0>2}", hh, mm, ss);
+}
+
 void SaveEditorWindow::DrawElement() {
+    if (CVarGetInteger(CVAR_ENHANCEMENT("TimeDisplay"), 0) == 1) {
+        ImGui::SetNextWindowSize(ImVec2(100, 100));
+        ImGui::Begin("##TimeofDay", nullptr, ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoDecoration);
+        std::string timeOfDay = convertTime(gSaveContext.dayTime);
+        ImGui::Text(timeOfDay.c_str());
+        ImGui::End();
+    }
+
     ImGui::SetNextWindowSize(ImVec2(520, 600), ImGuiCond_FirstUseEver);
     if (!ImGui::Begin("Save Editor", &mIsVisible, ImGuiWindowFlags_NoFocusOnAppearing)) {
         ImGui::End();

--- a/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
+++ b/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
@@ -407,8 +407,6 @@ void DrawInfoTab() {
     ImGui::SetNextItemWidth(ImGui::GetFontSize() * 15);
     ImGui::SliderScalar("Time", ImGuiDataType_U16, &gSaveContext.dayTime, &dayTimeMin, &dayTimeMax);
     UIWidgets::InsertHelpHoverText("Time of day");
-    ImGui::SameLine();
-    UIWidgets::PaddedEnhancementCheckbox("Display On-screen", CVAR_ENHANCEMENT("TimeDisplay"), true, false);
     if (ImGui::Button("Dawn")) {
         gSaveContext.dayTime = 0x4000;
     }
@@ -1748,24 +1746,7 @@ void DrawPlayerTab() {
     }
 }
 
-std::string convertTime(uint32_t dayTime) {
-    uint32_t totalSeconds = 24 * 60 * 60;
-    uint32_t seconds = static_cast<uint32_t>(static_cast<double>(dayTime) * (totalSeconds - 1) / 65535);
-    uint32_t hh = seconds / 3600;
-    uint32_t mm = (seconds % 3600) / 60;
-    uint32_t ss = seconds % 60;
-    return fmt::format("{:0>2}:{:0>2}:{:0>2}", hh, mm, ss);
-}
-
 void SaveEditorWindow::DrawElement() {
-    if (CVarGetInteger(CVAR_ENHANCEMENT("TimeDisplay"), 0) == 1) {
-        ImGui::SetNextWindowSize(ImVec2(100, 100));
-        ImGui::Begin("##TimeofDay", nullptr, ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoDecoration);
-        std::string timeOfDay = convertTime(gSaveContext.dayTime);
-        ImGui::Text(timeOfDay.c_str());
-        ImGui::End();
-    }
-
     ImGui::SetNextWindowSize(ImVec2(520, 600), ImGuiCond_FirstUseEver);
     if (!ImGui::Begin("Save Editor", &mIsVisible, ImGuiWindowFlags_NoFocusOnAppearing)) {
         ImGui::End();

--- a/soh/soh/Enhancements/gameplaystats.cpp
+++ b/soh/soh/Enhancements/gameplaystats.cpp
@@ -267,6 +267,14 @@ std::string formatTimestampGameplayStat(uint32_t value) {
     return fmt::format("{}:{:0>2}:{:0>2}.{}", hh, mm, ss, ds);
 }
 
+std::string convertTime(uint32_t dayTime) {
+    uint32_t totalSeconds = 24 * 60 * 60;
+    uint32_t seconds = static_cast<uint32_t>(static_cast<double>(dayTime) * (totalSeconds - 1) / 65535);
+    uint32_t hh = seconds / 3600;
+    uint32_t mm = (seconds % 3600) / 60;
+    return fmt::format("{:0>2}:{:0>2}", hh, mm);
+}
+
 std::string formatIntGameplayStat(uint32_t value) {
     return fmt::format("{}", value);
 }
@@ -280,7 +288,12 @@ std::string formatHexOnlyGameplayStat(uint32_t value) {
 }
 
 extern "C" char* GameplayStats_GetCurrentTime() {
-    std::string timeString = formatTimestampGameplayStat(GAMEPLAYSTAT_TOTAL_TIME).c_str();
+    std::string timeString;
+    if (CVarGetInteger(CVAR_ENHANCEMENT("TimeDisplay"), 0) == 1) {
+        timeString = convertTime(gSaveContext.dayTime).c_str();
+    } else {
+        timeString = formatTimestampGameplayStat(GAMEPLAYSTAT_TOTAL_TIME).c_str();
+    }
     const size_t stringLength = timeString.length();
     char* timeChar = (char*)malloc(stringLength + 1); // We need to use malloc so we can free this from a C file.
     strcpy(timeChar, timeString.c_str());
@@ -602,6 +615,9 @@ void DrawGameplayStatsBreakdownTab() {
 
 void DrawGameplayStatsOptionsTab() {
     UIWidgets::PaddedEnhancementCheckbox("Show in-game total timer", CVAR_ENHANCEMENT("GameplayStats.ShowIngameTimer"), true, false);
+    if (CVarGetInteger(CVAR_ENHANCEMENT("GameplayStats.ShowIngameTimer"), 0)) {
+        UIWidgets::PaddedEnhancementCheckbox("Show Day/Night Instead", CVAR_ENHANCEMENT("TimeDisplay"), true, false);
+    }
     UIWidgets::InsertHelpHoverText("Keep track of the timer as an in-game HUD element. The position of the timer can be changed in the Cosmetics Editor.");
     UIWidgets::PaddedEnhancementCheckbox("Show latest timestamps on top", CVAR_ENHANCEMENT("GameplayStats.ReverseTimestamps"), true, false);
     UIWidgets::PaddedEnhancementCheckbox("Room Breakdown", CVAR_ENHANCEMENT("GameplayStats.RoomBreakdown"), true, false);


### PR DESCRIPTION
Someone requested this recently and I've seen it asked for previously.

Allows toggling the In-Game RTA Timer to the Current Time of Day.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1712885668.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1712918529.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1712924949.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1713001674.zip)
<!--- section:artifacts:end -->