### PR TITLE
Extra Mode - Ice Trap Fever

### DIFF
--- a/soh/soh/Enhancements/gameplaystats.cpp
+++ b/soh/soh/Enhancements/gameplaystats.cpp
@@ -246,6 +246,8 @@ const char* const countMappings[] = {
 char itemTimestampDisplayName[TIMESTAMP_MAX][21] = { "" };
 ImVec4 itemTimestampDisplayColor[TIMESTAMP_MAX];
 
+bool stopFeverTimer = false;
+
 typedef struct {
     char name[40];
     u32 time;
@@ -281,8 +283,6 @@ std::string formatHexOnlyGameplayStat(uint32_t value) {
     return fmt::format("{:#x}", value, value);
 }
 
-bool stopTimer = false;
-
 extern "C" char* GameplayStats_GetCurrentTime() {
     std::string timeString;
     
@@ -290,10 +290,10 @@ extern "C" char* GameplayStats_GetCurrentTime() {
         uint32_t remainingFeverTime = 
             ((gSaveContext.sohStats.count[COUNT_ICE_TRAPS] * (CVarGetInteger(CVAR_ENHANCEMENT("ExtendTimer"), 0) * 600)) +
             (CVarGetInteger(CVAR_ENHANCEMENT("StartTimer"), 0) * 600) - GAMEPLAYSTAT_TOTAL_TIME);
-        if (remainingFeverTime > 0 && stopTimer == false) {
+        if (remainingFeverTime > 0 && stopFeverTimer == false) {
             timeString = formatTimestampGameplayStat(remainingFeverTime).c_str();
         } else if (remainingFeverTime == 0) {
-            stopTimer = true;
+            stopFeverTimer = true;
             IceTrapFever();
         } else {
             timeString = formatTimestampGameplayStat(0).c_str();

--- a/soh/soh/Enhancements/mods.cpp
+++ b/soh/soh/Enhancements/mods.cpp
@@ -1394,6 +1394,10 @@ void RegisterPauseMenuHooks() {
     });
 }
 
+void IceTrapFever() {
+    gSaveContext.health = 0;
+}
+
 void InitMods() {
     RegisterTTS();
     RegisterInfiniteMoney();

--- a/soh/soh/Enhancements/mods.h
+++ b/soh/soh/Enhancements/mods.h
@@ -15,7 +15,8 @@ void UpdatePermanentHeartLossState();
 void UpdateHyperEnemiesState();
 void UpdateHyperBossesState();
 void InitMods();
-void UpdatePatchHand(); 
+void UpdatePatchHand();
+void IceTrapFever();
 
 #ifdef __cplusplus
 }

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -1394,9 +1394,11 @@ void DrawEnhancementsMenu() {
                 "- Can be enabled retroactively after a File has already started.");
 
             UIWidgets::PaddedEnhancementCheckbox("Ice Trap Fever", CVAR_ENHANCEMENT("TrapFever"), true, false);
+            UIWidgets::Tooltip("Uses the In-Game Timer to determine how long you have to play.\n"
+                "Obtaining Ice Traps extends your timer.");
             if (CVarGetInteger(CVAR_ENHANCEMENT("TrapFever"), 0)) {
                 ImGui::Separator();
-                UIWidgets::PaddedEnhancementSliderInt("Starting Timer: %d minutes", "##StartTime", CVAR_ENHANCEMENT("StartTimer"), 1,
+                UIWidgets::PaddedEnhancementSliderInt("Starting Timer: %d minutes", "##StartTime", CVAR_ENHANCEMENT("StartTimer"), 5,
                                                       30, "", 15, true, true, false);
                 UIWidgets::PaddedEnhancementSliderInt("Time Extensions: %d minutes", "##ExtendTime", CVAR_ENHANCEMENT("ExtendTimer"),
                                                       1, 15, "", 5, true, true, false);

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -1386,7 +1386,6 @@ void DrawEnhancementsMenu() {
                 }
             }
 
-            UIWidgets::Spacer(0);
             if (UIWidgets::PaddedEnhancementCheckbox("Hurt Container Mode", CVAR_ENHANCEMENT("HurtContainer"), true, false)) {
                 UpdateHurtContainerModeState(CVarGetInteger(CVAR_ENHANCEMENT("HurtContainer"), 0));
             }
@@ -1394,6 +1393,15 @@ void DrawEnhancementsMenu() {
                 "- Each Heart Container or full Heart Piece reduces Links hearts by 1.\n"
                 "- Can be enabled retroactively after a File has already started.");
 
+            UIWidgets::PaddedEnhancementCheckbox("Ice Trap Fever", CVAR_ENHANCEMENT("TrapFever"), true, false);
+            if (CVarGetInteger(CVAR_ENHANCEMENT("TrapFever"), 0)) {
+                ImGui::Separator();
+                UIWidgets::PaddedEnhancementSliderInt("Starting Timer: %d minutes", "##StartTime", CVAR_ENHANCEMENT("StartTimer"), 1,
+                                                      30, "", 15, true, true, false);
+                UIWidgets::PaddedEnhancementSliderInt("Time Extensions: %d minutes", "##ExtendTime", CVAR_ENHANCEMENT("ExtendTimer"),
+                                                      1, 15, "", 5, true, true, false);
+                ImGui::Separator();
+            }
             ImGui::EndMenu();
         }
 


### PR DESCRIPTION
New Mode idea I saw Fredomato attempt on stream.

In-Game Timer ticks down rather than up, when it hits 0 Link dies, coupled with Permadeath makes for a nice challenge. Each Ice Trap you find adds additional time to your Timer.
- Set the Starting Timer (in minutes) for how long you want to start the Seed with.
- Set the Time Extensions (in minutes) for how much time you want added for each Trap.

Enable this in Enhancements > Extra Modes > Ice Trap Fever

- [ ] Need a way to reset the bool to False without closing SoH.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1715254989.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1715328802.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1715340943.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1715515910.zip)
<!--- section:artifacts:end -->