### PR TITLE
Fix return of Item_Give for stricter compilers

### DIFF
--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -1933,7 +1933,7 @@ u8 Item_Give(PlayState* play, u8 item) {
         Randomizer_GetSettingValue(RSK_SHUFFLE_DEKU_STICK_BAG) &&
         CUR_UPG_VALUE(UPG_STICKS) == 0
     ) {
-        Return_Item(item, MOD_NONE, ITEM_NONE);
+        return item;
     }
 
     //prevents getting nuts without the bag in case something got missed
@@ -1943,7 +1943,7 @@ u8 Item_Give(PlayState* play, u8 item) {
         Randomizer_GetSettingValue(RSK_SHUFFLE_DEKU_NUT_BAG) &&
         CUR_UPG_VALUE(UPG_NUTS) == 0
     ) {
-        Return_Item(item, MOD_NONE, ITEM_NONE);
+        return item;
     }
 
     lusprintf(__FILE__, __LINE__, 2, "Item Give - item: %#x", item);

--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -1933,7 +1933,7 @@ u8 Item_Give(PlayState* play, u8 item) {
         Randomizer_GetSettingValue(RSK_SHUFFLE_DEKU_STICK_BAG) &&
         CUR_UPG_VALUE(UPG_STICKS) == 0
     ) {
-        return;
+        Return_Item(item, MOD_NONE, ITEM_NONE);
     }
 
     //prevents getting nuts without the bag in case something got missed
@@ -1943,7 +1943,7 @@ u8 Item_Give(PlayState* play, u8 item) {
         Randomizer_GetSettingValue(RSK_SHUFFLE_DEKU_NUT_BAG) &&
         CUR_UPG_VALUE(UPG_NUTS) == 0
     ) {
-        return;
+        Return_Item(item, MOD_NONE, ITEM_NONE);
     }
 
     lusprintf(__FILE__, __LINE__, 2, "Item Give - item: %#x", item);


### PR DESCRIPTION
Tiny fix as my compiler didn't like the lack of return type here

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1716256377.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1716285326.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1716288210.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1716296275.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1716376208.zip)
<!--- section:artifacts:end -->