### PR TITLE
Fix disable lod breaking certain effects

### DIFF
--- a/soh/src/code/z_fcurve_data_skelanime.c
+++ b/soh/src/code/z_fcurve_data_skelanime.c
@@ -131,10 +131,6 @@ void SkelCurve_DrawLimb(PlayState* play, s32 limbIndex, SkelAnimeCurve* skelCurv
         Matrix_TranslateRotateZYX(&pos, &rot);
         Matrix_Scale(scale.x, scale.y, scale.z, MTXMODE_APPLY);
 
-        if (CVarGetInteger("gDisableLOD", 0)) {
-            lod = 0;
-        }
-
         if (lod == 0) {
             s32 pad1;
 

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -11339,10 +11339,6 @@ void Player_Draw(Actor* thisx, PlayState* play2) {
             lod = 1;
         }
 
-        if (CVarGetInteger("gDisableLOD", 0)) {
-            lod = 0;
-        }
-
         func_80093C80(play);
         Gfx_SetupDL_25Xlu(play->state.gfxCtx);
 


### PR DESCRIPTION
The disable lod enhancement was overwriting the lod value in `SkelCurve_DrawLimb` which uses lod to mean something else. In here, a lod value of `0` means render one DL as OPA, and a lod value of `1` means render a DL as OPA and another DL as XLU.

There are only 3 instances of `SkelCurve_DrawLimb`, all of which explicitly use a lod value of `1` to render transparent effects.

I've removed this override as it is not correct for this method.

I also removed a separate override for lod value in z_player that was redundant, as eventually the player code just calls `SkelAnime_DrawFlexLod` which already has the disable lod override within it.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1719604952.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1719604954.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1719604956.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1719604958.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1719604962.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1719604965.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1719604967.zip)
<!--- section:artifacts:end -->