### PR TITLE
Fix accidental assignment expression

### DIFF
--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -1446,7 +1446,7 @@ void RandomizerOnActorInitHandler(void* actorRef) {
 
     //consumable bags
     if (
-        actor->id = ACTOR_EN_ITEM00 &&
+        actor->id == ACTOR_EN_ITEM00 &&
         (
             (
                 RAND_GET_OPTION(RSK_SHUFFLE_DEKU_STICK_BAG) &&


### PR DESCRIPTION
A typo from https://github.com/HarbourMasters/Shipwright/commit/a5c0cede12d3a53cb0f1069a5d4a5c4febe991fa resulted in various bugs due to giving every actor the same id.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1721243247.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1721266010.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1721266544.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1721268975.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1721276984.zip)
<!--- section:artifacts:end -->