### PR TITLE
Another round of fixes for skip intro and grotto rando

### DIFF
--- a/soh/soh/Enhancements/TimeSavers/SkipCutscene/SkipIntro.cpp
+++ b/soh/soh/Enhancements/TimeSavers/SkipCutscene/SkipIntro.cpp
@@ -18,7 +18,8 @@ void SkipIntro_Register() {
         bool shuffleOverworldSpawns =
             OTRGlobals::Instance->gRandoContext->GetOption(RSK_SHUFFLE_OVERWORLD_SPAWNS).Is(true);
         if ((CVarGetInteger(CVAR_ENHANCEMENT("TimeSavers.SkipCutscene.Intro"), IS_RANDO) ||
-             (IS_RANDO && (adultStart || shuffleOverworldSpawns)) && gSaveContext.cutsceneIndex == 0xFFF1)) {
+             (IS_RANDO && (adultStart || shuffleOverworldSpawns))) &&
+            gSaveContext.cutsceneIndex == 0xFFF1) {
             // Calculate spawn location. Start with vanilla, Link's house.
             int32_t spawnEntrance = ENTR_LINKS_HOUSE_0;
             // If we're not in rando, we can skip all of the below.

--- a/soh/soh/Enhancements/randomizer/randomizer_grotto.c
+++ b/soh/soh/Enhancements/randomizer/randomizer_grotto.c
@@ -142,12 +142,12 @@ s16 Grotto_GetEntranceValueHandlingGrottoRando(s16 nextEntranceIndex) {
         nextEntranceIndex = grottoExitList[grottoId];
     }
 
-    // Get the new grotto id from the next entrance
-    grottoId = nextEntranceIndex & 0x00FF;
+    // Get the new grotto id from the next entrance, temp value to override modifying the static one
+    s8 tempGrottoId = nextEntranceIndex & 0x00FF;
 
     // Grotto Returns
     if (nextEntranceIndex >= ENTRANCE_RANDO_GROTTO_EXIT_START && nextEntranceIndex < ENTRANCE_RANDO_GROTTO_EXIT_START + NUM_GROTTOS) {
-        GrottoReturnInfo grotto = grottoReturnTable[grottoId];
+        GrottoReturnInfo grotto = grottoReturnTable[tempGrottoId];
 
         // When the nextEntranceIndex is determined by a dynamic exit,
         // or set by Entrance_OverrideBlueWarp to mark a blue warp entrance,
@@ -162,7 +162,7 @@ s16 Grotto_GetEntranceValueHandlingGrottoRando(s16 nextEntranceIndex) {
         }
     // Grotto Loads
     } else if (nextEntranceIndex >= ENTRANCE_RANDO_GROTTO_LOAD_START && nextEntranceIndex < ENTRANCE_RANDO_GROTTO_EXIT_START) {
-        GrottoLoadInfo grotto = grottoLoadTable[grottoId];
+        GrottoLoadInfo grotto = grottoLoadTable[tempGrottoId];
         nextEntranceIndex = grotto.entranceIndex;
     }
 


### PR DESCRIPTION
Apply cutscene index check to the whole conditional (parenthesis placement)

Make `Grotto_GetEntranceValueHandlingGrottoRando` actually not modify grotto rando state info.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1737662549.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1737697327.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1737701698.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1737721863.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1742003634.zip)
<!--- section:artifacts:end -->