### PR TITLE
Fix Zora's Sapphire crash

### DIFF
--- a/soh/src/overlays/actors/ovl_Demo_Effect/z_demo_effect.c
+++ b/soh/src/overlays/actors/ovl_Demo_Effect/z_demo_effect.c
@@ -2092,7 +2092,7 @@ void DemoEffect_DrawGetItem(Actor* thisx, PlayState* play) {
             RandomizerCheck rc = RC_MAX;
             RandomizerGet rg = RG_NONE;
 
-            switch (this->actor.params) {
+            switch (this->actor.params & 0x00FF) {
                 case DEMO_EFFECT_JEWEL_KOKIRI:
                     rc = RC_QUEEN_GOHMA;
                     rg = RG_KOKIRI_EMERALD;


### PR DESCRIPTION
Zora's Sapphire was crashing in the Big Octo room because the switch statement in `DemoEffect_DrawGetItem` wasn't matching any of the cases, since `this->actor.params` didn't match any of them. However, I noticed a similar switch statement in the Init function that matched the same enums with `this->actor.params & 0x00FF`. No segfault with this switch statement.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1741858661.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1741894188.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1741897856.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1741910796.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1742005046.zip)
<!--- section:artifacts:end -->