### PR TITLE
Fix an issue with a stray Rando::Context shared_ptr hanging around.

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/location_access.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/location_access.cpp
@@ -240,12 +240,12 @@ bool HasAccessTo(const RandomizerRegion area) {
   return areaTable[area].HasAccess();
 }
 
-std::shared_ptr<Rando::Context> randoCtx;
+Rando::Context* randoCtx;
 std::shared_ptr<Rando::Logic> logic;
 
 void AreaTable_Init() {
   using namespace Rando;
-  randoCtx = Context::GetInstance();
+  randoCtx = Context::GetInstance().get();
   logic = randoCtx->GetLogic();
   grottoEvents = {
       EventAccess(&logic->GossipStoneFairy, { [] { return logic->GossipStoneFairy || logic->CanSummonGossipFairy; } }),

--- a/soh/soh/Enhancements/randomizer/3drando/location_access.hpp
+++ b/soh/soh/Enhancements/randomizer/3drando/location_access.hpp
@@ -12,7 +12,7 @@
 typedef bool (*ConditionFn)();
 
 // I hate this but every alternative I can think of right now is worse
-extern std::shared_ptr<Rando::Context> randoCtx;
+extern Rando::Context* randoCtx;
 extern std::shared_ptr<Rando::Logic> logic;
 
 class EventAccess {

--- a/soh/soh/Enhancements/randomizer/context.cpp
+++ b/soh/soh/Enhancements/randomizer/context.cpp
@@ -30,6 +30,7 @@ Context::Context() {
     mTrials = std::make_shared<Trials>();
     mSettings = std::make_shared<Settings>();
     mFishsanity = std::make_shared<Fishsanity>();
+    mKaleido = nullptr;
 }
 
 RandomizerArea Context::GetAreaFromString(std::string str) {

--- a/soh/soh/Enhancements/randomizer/context.cpp
+++ b/soh/soh/Enhancements/randomizer/context.cpp
@@ -30,7 +30,6 @@ Context::Context() {
     mTrials = std::make_shared<Trials>();
     mSettings = std::make_shared<Settings>();
     mFishsanity = std::make_shared<Fishsanity>();
-    mKaleido = nullptr;
 }
 
 RandomizerArea Context::GetAreaFromString(std::string str) {

--- a/soh/soh/Enhancements/randomizer/entrance.cpp
+++ b/soh/soh/Enhancements/randomizer/entrance.cpp
@@ -235,6 +235,11 @@ Entrance* Entrance::AssumeReachable() {
     return assumed;
 }
 
+EntranceShuffler::EntranceShuffler() {
+  playthroughEntrances = {};
+  entranceOverrides = {};
+}
+
 bool EntranceShuffler::HasNoRandomEntrances() {
     return mNoRandomEntrances;
 }

--- a/soh/soh/Enhancements/randomizer/entrance.h
+++ b/soh/soh/Enhancements/randomizer/entrance.h
@@ -115,6 +115,7 @@ using EntrancePools = std::map<EntranceType, std::vector<Entrance*>>;
 
 class EntranceShuffler {
   public:
+    EntranceShuffler();
     std::array<EntranceOverride, ENTRANCE_OVERRIDES_MAX_COUNT> entranceOverrides;
     std::vector<std::list<Entrance*>> playthroughEntrances;
     bool HasNoRandomEntrances();

--- a/soh/soh/SaveManager.cpp
+++ b/soh/soh/SaveManager.cpp
@@ -2841,7 +2841,7 @@ extern "C" void Save_SaveGlobal(void) {
 }
 
 extern "C" void Save_LoadFile(void) {
-    if (gSaveContext.questId == QUEST_RANDOMIZER) {
+    if (SaveManager::Instance->fileMetaInfo[gSaveContext.fileNum].randoSave) {
         // Reset rando context for rando saves.
           OTRGlobals::Instance->gRandoContext.reset();
         OTRGlobals::Instance->gRandoContext = Rando::Context::CreateInstance();


### PR DESCRIPTION
`location_access.cpp` was keeping a shared_ptr to Rando::Context instance around, which meant that when we called `.reset()` on the main one (`OTRGlobals::Instance->gRandoContext`), it would clear that pointer but then Rando::Context::CreateInstance() would still return the old one, since the `mContext` weak pointer was not expired yet.

This also uncovered some more stuff that wasn't getting properly initialized within EntranceShuffler (something must have been initializing it outside of that). I already fixed that one, but this very well may uncover some other bugs as well that I haven't found yet.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1755981556.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1756004168.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1756005016.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1756022970.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1756043311.zip)
<!--- section:artifacts:end -->