### PR TITLE
Change `RSK_SHUFFLE` instance in mixed pool code to `RSK_MIX`.

### DIFF
--- a/soh/soh/Enhancements/randomizer/entrance.cpp
+++ b/soh/soh/Enhancements/randomizer/entrance.cpp
@@ -1392,16 +1392,16 @@ int EntranceShuffler::ShuffleAllEntrances() {
                 poolsToMix.insert(EntranceType::BossReverse);
             }
         }
-        if (ctx->GetOption(RSK_SHUFFLE_OVERWORLD_ENTRANCES)) {
+        if (ctx->GetOption(RSK_MIX_OVERWORLD_ENTRANCES)) {
             poolsToMix.insert(EntranceType::Overworld);
         }
-        if (ctx->GetOption(RSK_SHUFFLE_INTERIOR_ENTRANCES)) {
+        if (ctx->GetOption(RSK_MIX_INTERIOR_ENTRANCES)) {
             poolsToMix.insert(EntranceType::Interior);
             if (ctx->GetOption(RSK_DECOUPLED_ENTRANCES)) {
                 poolsToMix.insert(EntranceType::InteriorReverse);
             }
         }
-        if (ctx->GetOption(RSK_SHUFFLE_GROTTO_ENTRANCES)) {
+        if (ctx->GetOption(RSK_MIX_GROTTO_ENTRANCES)) {
             poolsToMix.insert(EntranceType::GrottoGrave);
             if (ctx->GetOption(RSK_DECOUPLED_ENTRANCES)) {
                 poolsToMix.insert(EntranceType::GrottoGraveReverse);


### PR DESCRIPTION
In the evaluations for mixed entrances, the `RSK_SHUFFLE` keys were used for overworld, interior, and grotto, thus causing them to be mixed every time they were shuffled, even if they weren't added to the pools. This changes those back to `RSK_MIX` keys to fix that.

Fixes #4274.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1774182040.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1774195404.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1774195653.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1774198374.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1774203954.zip)
<!--- section:artifacts:end -->