### PR TITLE
Tweak: Implement better extended culling options

### DIFF
--- a/soh/include/functions.h
+++ b/soh/include/functions.h
@@ -2460,6 +2460,8 @@ void Message_DrawText(PlayState* play, Gfx** gfxP);
 
 void Interface_CreateQuadVertexGroup(Vtx* vtxList, s32 xStart, s32 yStart, s32 width, s32 height, u8 flippedH);
 void Interface_RandoRestoreSwordless(void);
+s32 Ship_CalcShouldDrawAndUpdate(PlayState* play, Actor* actor, Vec3f* projectedPos, f32 projectedW, bool* shouldDraw,
+                                 bool* shouldUpdate);
 
 // #endregion
 

--- a/soh/soh/Enhancements/debugger/actorViewer.cpp
+++ b/soh/soh/Enhancements/debugger/actorViewer.cpp
@@ -26,6 +26,23 @@ extern PlayState* gPlayState;
 
 #define DEBUG_ACTOR_NAMETAG_TAG "debug_actor_viewer"
 
+
+#include <vector>
+std::vector<int16_t> unculledActors;
+std::vector<int16_t> culledActors;
+
+extern "C" void AV_ClearLists() {
+    unculledActors.clear();
+    culledActors.clear();
+}
+
+extern "C" void AV_AddUnculledActor(Actor* actor) {
+    unculledActors.push_back(actor->id);
+}
+extern "C" void AV_AddCulledActor(Actor* actor) {
+    culledActors.push_back(actor->id);
+}
+
 typedef struct {
     u16 id;
     u16 params;
@@ -402,6 +419,17 @@ void ActorViewerWindow::DrawElement() {
             list.clear();
             needs_reset = false;
         }
+    }
+
+    ImGui::Text("Unculled Actors");
+    for (auto id : unculledActors) {
+        ImGui::Text(GetActorDescription(id).c_str());
+    }
+    ImGui::NewLine();
+    ImGui::NewLine();
+    ImGui::Text("Culled Actors");
+    for (auto id : culledActors) {
+        ImGui::Text(GetActorDescription(id).c_str());
     }
 
     ImGui::End();

--- a/soh/soh/Enhancements/debugger/actorViewer.cpp
+++ b/soh/soh/Enhancements/debugger/actorViewer.cpp
@@ -26,23 +26,6 @@ extern PlayState* gPlayState;
 
 #define DEBUG_ACTOR_NAMETAG_TAG "debug_actor_viewer"
 
-
-#include <vector>
-std::vector<int16_t> unculledActors;
-std::vector<int16_t> culledActors;
-
-extern "C" void AV_ClearLists() {
-    unculledActors.clear();
-    culledActors.clear();
-}
-
-extern "C" void AV_AddUnculledActor(Actor* actor) {
-    unculledActors.push_back(actor->id);
-}
-extern "C" void AV_AddCulledActor(Actor* actor) {
-    culledActors.push_back(actor->id);
-}
-
 typedef struct {
     u16 id;
     u16 params;
@@ -419,17 +402,6 @@ void ActorViewerWindow::DrawElement() {
             list.clear();
             needs_reset = false;
         }
-    }
-
-    ImGui::Text("Unculled Actors");
-    for (auto id : unculledActors) {
-        ImGui::Text(GetActorDescription(id).c_str());
-    }
-    ImGui::NewLine();
-    ImGui::NewLine();
-    ImGui::Text("Culled Actors");
-    for (auto id : culledActors) {
-        ImGui::Text(GetActorDescription(id).c_str());
     }
 
     ImGui::End();

--- a/soh/soh/Enhancements/presets.h
+++ b/soh/soh/Enhancements/presets.h
@@ -211,6 +211,8 @@ const std::vector<const char*> enhancementsCvars = {
     "gDisableLOD",
     "gDisableDrawDistance",
     "gDisableKokiriDrawDistance",
+    "gEnhancements.WidescreenActorCulling",
+    "gEnhancements.ExtendedCullingExcludeGlitchActors",
     "gLowResMode",
     "gDrawLineupTick",
     "gQuickBongoKill",

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -928,20 +928,26 @@ void DrawEnhancementsMenu() {
             }
             UIWidgets::PaddedEnhancementCheckbox("Disable LOD", "gDisableLOD", true, false);
             UIWidgets::Tooltip("Turns off the Level of Detail setting, making models use their higher-poly variants at any distance");
-            if (UIWidgets::PaddedEnhancementCheckbox("Increase Actor Draw Distance", "gDisableDrawDistance", true, false)) {
-                if (CVarGetInteger("gDisableDrawDistance", 0) == 0) {
+            if (UIWidgets::EnhancementSliderInt("Increase Actor Draw Distance: %dx", "##IncreaseActorDrawDistance",
+                                                "gDisableDrawDistance", 1, 5, "", 1, true, false)) {
+                if (CVarGetInteger("gDisableDrawDistance", 1) <= 1) {
                     CVarSetInteger("gDisableKokiriDrawDistance", 0);
                 }
             }
             UIWidgets::Tooltip("Increases the range in which actors/objects are drawn");
-            if (CVarGetInteger("gDisableDrawDistance", 0) == 1) {
+            if (CVarGetInteger("gDisableDrawDistance", 1) > 1) {
                 UIWidgets::PaddedEnhancementCheckbox("Kokiri Draw Distance", "gDisableKokiriDrawDistance", true, false);
-                UIWidgets::Tooltip("The Kokiri are mystical beings that fade into view when approached\nEnabling this will remove their draw distance");
+                UIWidgets::Tooltip("The Kokiri are mystical beings that fade into view when approached\nEnabling this "
+                                   "will remove their draw distance");
             }
-            UIWidgets::PaddedEnhancementCheckbox("Widescreen Actor Culling", "gEnhancements.WidescreenActorCulling", true, false);
+            UIWidgets::PaddedEnhancementCheckbox("Widescreen Actor Culling", "gEnhancements.WidescreenActorCulling",
+                                                 true, false);
             UIWidgets::Tooltip("Adjusts the horizontal culling plane to account for widescreen resolutions");
-            UIWidgets::PaddedEnhancementCheckbox("Exclude Glitch Useful Actors",
-                                                 "gEnhancements.ExtendedCullingExcludeGlitchActors", true, false);
+            UIWidgets::PaddedEnhancementCheckbox(
+                "Exclude Glitch Useful Actors", "gEnhancements.ExtendedCullingExcludeGlitchActors", true, false,
+                !CVarGetInteger("gEnhancements.WidescreenActorCulling", 0) &&
+                    CVarGetInteger("gDisableDrawDistance", 1) <= 1,
+                "Requires Actor Draw Distance to be increased or Widescreen Actor Culling enabled");
             UIWidgets::Tooltip(
                 "Exclude actors that are useful for glitches from the extended culling ranges.\n"
                 "Some actors may still draw in the extended ranges, but will not \"update\" so that certain "

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -944,7 +944,7 @@ void DrawEnhancementsMenu() {
                                                  true, false);
             UIWidgets::Tooltip("Adjusts the horizontal culling plane to account for widescreen resolutions");
             UIWidgets::PaddedEnhancementCheckbox(
-                "Exclude Glitch Useful Actors", "gEnhancements.ExtendedCullingExcludeGlitchActors", true, false,
+                "Cull Glitch Useful Actors", "gEnhancements.ExtendedCullingExcludeGlitchActors", true, false,
                 !CVarGetInteger("gEnhancements.WidescreenActorCulling", 0) &&
                     CVarGetInteger("gDisableDrawDistance", 1) <= 1,
                 "Requires Actor Draw Distance to be increased or Widescreen Actor Culling enabled");

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -928,16 +928,34 @@ void DrawEnhancementsMenu() {
             }
             UIWidgets::PaddedEnhancementCheckbox("Disable LOD", "gDisableLOD", true, false);
             UIWidgets::Tooltip("Turns off the Level of Detail setting, making models use their higher-poly variants at any distance");
-            if (UIWidgets::PaddedEnhancementCheckbox("Disable Draw Distance", "gDisableDrawDistance", true, false)) {
+            if (UIWidgets::PaddedEnhancementCheckbox("Increase Actor Draw Distance", "gDisableDrawDistance", true, false)) {
                 if (CVarGetInteger("gDisableDrawDistance", 0) == 0) {
                     CVarSetInteger("gDisableKokiriDrawDistance", 0);
                 }
             }
-            UIWidgets::Tooltip("Turns off the objects draw distance, making objects being visible from a longer range");
+            UIWidgets::Tooltip("Increases the range in which actors/objects are drawn");
             if (CVarGetInteger("gDisableDrawDistance", 0) == 1) {
                 UIWidgets::PaddedEnhancementCheckbox("Kokiri Draw Distance", "gDisableKokiriDrawDistance", true, false);
                 UIWidgets::Tooltip("The Kokiri are mystical beings that fade into view when approached\nEnabling this will remove their draw distance");
             }
+            UIWidgets::PaddedEnhancementCheckbox("Widescreen Actor Culling", "gEnhancements.WidescreenActorCulling", true, false);
+            UIWidgets::Tooltip("Adjusts the horizontal culling plane to account for widescreen resolutions");
+            UIWidgets::PaddedEnhancementCheckbox("Exclude Glitch Useful Actors",
+                                                 "gEnhancements.ExtendedCullingExcludeGlitchActors", true, false);
+            UIWidgets::Tooltip(
+                "Exclude actors that are useful for glitches from the extended culling ranges.\n"
+                "Some actors may still draw in the extended ranges, but will not \"update\" so that certain "
+                "glitches that leverage the original culling requirements will still work.\n"
+                "\n"
+                "The following actors are excluded:\n"
+                "- White clothed Gerudos\n"
+                "- King Zora\n"
+                "- Gossip Stones\n"
+                "- Boulders\n"
+                "- Blue Warps\n"
+                "- Darunia\n"
+                "- Gold Skulltulas");
+            UIWidgets::PaddedEnhancementCheckbox("old cull", "gMyInt1", true, false);
             UIWidgets::PaddedEnhancementCheckbox("N64 Mode", "gLowResMode", true, false);
             UIWidgets::Tooltip("Sets aspect ratio to 4:3 and lowers resolution to 240p, the N64's native resolution");
             UIWidgets::PaddedEnhancementCheckbox("Glitch line-up tick", "gDrawLineupTick", true, false);

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -961,7 +961,6 @@ void DrawEnhancementsMenu() {
                 "- Blue Warps\n"
                 "- Darunia\n"
                 "- Gold Skulltulas");
-            UIWidgets::PaddedEnhancementCheckbox("old cull", "gMyInt1", true, false);
             UIWidgets::PaddedEnhancementCheckbox("N64 Mode", "gLowResMode", true, false);
             UIWidgets::Tooltip("Sets aspect ratio to 4:3 and lowers resolution to 240p, the N64's native resolution");
             UIWidgets::PaddedEnhancementCheckbox("Glitch line-up tick", "gDrawLineupTick", true, false);

--- a/soh/src/code/z_actor.c
+++ b/soh/src/code/z_actor.c
@@ -78,6 +78,11 @@
 #include "textures/place_title_cards/g_pn_57.h"
 #endif
 
+extern void AV_ClearLists();
+
+extern void AV_AddUnculledActor(Actor* actor);
+extern void AV_AddCulledActor(Actor* actor);
+
 static CollisionPoly* sCurCeilingPoly;
 static s32 sCurCeilingBgId;
 
@@ -1208,14 +1213,6 @@ void Actor_Init(Actor* actor, PlayState* play) {
     actor->uncullZoneForward = 1000.0f;
     actor->uncullZoneScale = 350.0f;
     actor->uncullZoneDownward = 700.0f;
-    if (CVarGetInteger("gDisableDrawDistance", 0) != 0 && actor->id != ACTOR_EN_TORCH2 && actor->id != ACTOR_EN_BLKOBJ // Extra check for Dark Link and his room 
-        && actor->id != ACTOR_EN_HORSE // Check for Epona, else if we call her she will spawn at the other side of the  map + we can hear her during the title screen sequence
-        && actor->id != ACTOR_EN_HORSE_GANON && actor->id != ACTOR_EN_HORSE_ZELDA  // check for Zelda's and Ganondorf's horses that will always be scene during cinematic whith camera paning
-        && (play->sceneNum != SCENE_DODONGOS_CAVERN && actor->id != ACTOR_EN_ZF)) { // Check for DC and Lizalfos for the case where the miniboss music would still play under certains conditions and changing room
-        actor->uncullZoneForward = 32767.0f;
-        actor->uncullZoneScale = 32767.0f;
-        actor->uncullZoneDownward = 32767.0f;
-    }
     CollisionCheck_InitInfo(&actor->colChkInfo);
     actor->floorBgId = BGCHECK_SCENE;
     ActorShape_Init(&actor->shape, 0.0f, NULL, 0.0f);
@@ -2854,8 +2851,12 @@ s32 func_800314B0(PlayState* play, Actor* actor) {
     return func_800314D4(play, actor, &actor->projectedPos, actor->projectedW);
 }
 
-s32 func_800314D4(PlayState* play, Actor* actor, Vec3f* arg2, f32 arg3) {
+s32 func_800314D4_old(PlayState* play, Actor* actor, Vec3f* arg2, f32 arg3) {
     f32 var;
+
+    if (CVarGetInteger("gDisableDrawDistance", 0)) {
+        return true;
+    }
 
     if (CVarGetInteger("gDisableDrawDistance", 0) != 0 && actor->id != ACTOR_EN_TORCH2 && actor->id != ACTOR_EN_BLKOBJ // Extra check for Dark Link and his room 
         && actor->id != ACTOR_EN_HORSE // Check for Epona, else if we call her she will spawn at the other side of the  map + we can hear her during the title screen sequence
@@ -2870,9 +2871,9 @@ s32 func_800314D4(PlayState* play, Actor* actor, Vec3f* arg2, f32 arg3) {
         // #region SoH [Widescreen support]
         // Doors will cull quite noticeably on wider screens. For these actors the zone is increased
         f32 limit = 1.0f;
-        if (((actor->id == ACTOR_EN_DOOR) || (actor->id == ACTOR_DOOR_SHUTTER)) && CVarGetInteger("gIncreaseDoorUncullZones", 1)) {
+        // if (((actor->id == ACTOR_EN_DOOR) || (actor->id == ACTOR_DOOR_SHUTTER)) && CVarGetInteger("gIncreaseDoorUncullZones", 1)) {
             limit = 2.0f;
-        }
+        // }
 
         if ((((fabsf(arg2->x) - actor->uncullZoneScale) * var) < limit) &&
             (((arg2->y + actor->uncullZoneDownward) * var) > -limit) &&
@@ -2880,6 +2881,109 @@ s32 func_800314D4(PlayState* play, Actor* actor, Vec3f* arg2, f32 arg3) {
             return true;
         }
         // #endregion
+    }
+
+    return false;
+}
+
+
+s32 func_800314D4(PlayState* play, Actor* actor, Vec3f* arg2, f32 arg3) {
+    f32 var;
+
+    if (CVarGetInteger("gMyInt1", 0)) {
+        return func_800314D4_old(play, actor, arg2, arg3);
+    }
+
+    if ((arg2->z > -actor->uncullZoneScale) && (arg2->z < (actor->uncullZoneForward + actor->uncullZoneScale))) {
+        var = (arg3 < 1.0f) ? 1.0f : 1.0f / arg3;
+
+        if ((((fabsf(arg2->x) - actor->uncullZoneScale) * var) < 1.0f) &&
+            (((arg2->y + actor->uncullZoneDownward) * var) > -1.0f) &&
+            (((arg2->y - actor->uncullZoneScale) * var) < 1.0f)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+// #region SOH [Enhancements] Allows us to increase the draw and update distance independently, mostly a modified
+// version of the function above
+s32 Ship_CalcShouldDrawAndUpdate(PlayState* play, Actor* actor, Vec3f* projectedPos, f32 projectedW, bool* shouldDraw,
+                                 bool* shouldUpdate) {
+    f32 clampedProjectedW;
+
+    if (CVarGetInteger("gMyInt1", 0)) {
+        if (func_800314D4_old(play, actor, projectedPos, projectedW)) {
+            *shouldUpdate = true;
+            *shouldDraw = true;
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    // Check if the actor passes its original/vanilla culling requirements
+    if (func_800314D4(play, actor, projectedPos, projectedW)) {
+        *shouldUpdate = true;
+        *shouldDraw = true;
+        return true;
+    }
+
+    s32 multiplier =
+        CVarGetInteger("gDisableDrawDistance", 0) != 0
+                // && actor->id != ACTOR_EN_HORSE // Check for Epona, else if we call her she will spawn at the other side
+                //                                // of the map + we can hear her during the title screen sequence
+                // && actor->id != ACTOR_EN_HORSE_GANON &&
+                // actor->id != ACTOR_EN_HORSE_ZELDA // check for Zelda's and Ganondorf's horses that will always be scene
+                                                  // during cinematic whith camera paning
+                // && (play->sceneNum != SCENE_DODONGOS_CAVERN &&
+                //     actor->id != ACTOR_EN_ZF) // Check for DC and Lizalfos for the case where the miniboss music would
+                                              // still play under certains conditions and changing room
+            ? 5
+            : 1;
+
+    if ((projectedPos->z > -actor->uncullZoneScale) &&
+        (projectedPos->z < ((actor->uncullZoneForward * multiplier) + actor->uncullZoneScale))) {
+        clampedProjectedW = (projectedW < 1.0f) ? 1.0f : 1.0f / projectedW;
+
+        f32 ratioAdjusted = 1.0f;
+
+        if (CVarGetInteger("gEnhancements.WidescreenActorCulling", 0)) {
+            f32 originalAspectRatio = 4.0f / 3.0f;
+            f32 currentAspectRatio = OTRGetAspectRatio();
+            ratioAdjusted = MAX(currentAspectRatio / originalAspectRatio, 1.0f);
+        }
+
+        if ((((fabsf(projectedPos->x) - actor->uncullZoneScale) * (clampedProjectedW / ratioAdjusted)) < 1.0f) &&
+            (((projectedPos->y + actor->uncullZoneDownward) * clampedProjectedW) > -1.0f) &&
+            (((projectedPos->y - actor->uncullZoneScale) * clampedProjectedW) < 1.0f)) {
+
+            if (CVarGetInteger("gEnhancements.ExtendedCullingExcludeGlitchActors", 0)) {
+                if ((actor->id == ACTOR_OBJ_BOMBIWA || actor->id == ACTOR_OBJ_HAMISHI ||
+                     actor->id == ACTOR_EN_ISHI) || // Boulders (hookshot through collision)
+                    actor->id == ACTOR_EN_GS ||     // Gossip stones (text delay)
+                    actor->id == ACTOR_EN_GE1 ||    // White gerudos (gate clip/archery transition)
+                    actor->id == ACTOR_EN_KZ ||     // King Zora (unfreeze glitch)
+                    actor->id == ACTOR_EN_DU ||     // Darunia (Fire temple BK skip)
+                    actor->id == ACTOR_DOOR_WARP1   // Blue warps (wrong warps)
+                ) {
+                    *shouldDraw = true;
+                    return true;
+                }
+
+                if ((actor->id == ACTOR_EN_SW &&
+                     (((actor->params & 0xE000) >> 0xD) == 1 ||
+                      ((actor->params & 0xE000) >> 0xD) == 2)) // Gold Skulltulas (hitbox at 0,0))
+                ) {
+                    return false;
+                }
+            }
+
+            *shouldDraw = true;
+            *shouldUpdate = true;
+            return true;
+        }
     }
 
     return false;
@@ -2897,6 +3001,8 @@ void func_800315AC(PlayState* play, ActorContext* actorCtx) {
     OPEN_DISPS(play->state.gfxCtx);
 
     actorListEntry = &actorCtx->actorLists[0];
+
+    AV_ClearLists();
 
     for (i = 0; i < ARRAY_COUNT(actorCtx->actorLists); i++, actorListEntry++) {
         actor = actorListEntry->head;
@@ -2920,18 +3026,39 @@ void func_800315AC(PlayState* play, ActorContext* actorCtx) {
                 }
             }
 
+            // #region SOH 
+            bool shipShouldDraw = false;
+            bool shipShouldUpdate = false;
             if ((HREG(64) != 1) || ((HREG(65) != -1) && (HREG(65) != HREG(66))) || (HREG(70) == 0)) {
-                if (func_800314B0(play, actor)) {
-                    actor->flags |= ACTOR_FLAG_ACTIVE;
+                if (CVarGetInteger("gDisableDrawDistance", 0) ||
+                    CVarGetInteger("gEnhancements.WidescreenActorCulling", 0)) {
+                    Ship_CalcShouldDrawAndUpdate(play, actor, &actor->projectedPos, actor->projectedW, &shipShouldDraw,
+                                                 &shipShouldUpdate);
+
+                    if (shipShouldUpdate) {
+                        actor->flags |= ACTOR_FLAG_ACTIVE;
+                        AV_AddUnculledActor(actor);
+                    } else {
+                        actor->flags &= ~ACTOR_FLAG_ACTIVE;
+                        AV_AddCulledActor(actor);
+                    }
                 } else {
-                    actor->flags &= ~ACTOR_FLAG_ACTIVE;
+                    if (func_800314B0(play, actor)) {
+                        actor->flags |= ACTOR_FLAG_ACTIVE;
+                        AV_AddUnculledActor(actor);
+                    } else {
+                        actor->flags &= ~ACTOR_FLAG_ACTIVE;
+                        AV_AddCulledActor(actor);
+                    }
                 }
             }
 
             actor->isDrawn = false;
 
             if ((HREG(64) != 1) || ((HREG(65) != -1) && (HREG(65) != HREG(66))) || (HREG(71) == 0)) {
-                if ((actor->init == NULL) && (actor->draw != NULL) && (actor->flags & (ACTOR_FLAG_DRAW_WHILE_CULLED | ACTOR_FLAG_ACTIVE))) {
+                if ((actor->init == NULL) && (actor->draw != NULL) &&
+                    ((actor->flags & (ACTOR_FLAG_DRAW_WHILE_CULLED | ACTOR_FLAG_ACTIVE)) || shipShouldDraw)) {
+                    // #endregion
                     if ((actor->flags & ACTOR_FLAG_LENS) &&
                         ((play->roomCtx.curRoom.lensMode == LENS_MODE_HIDE_ACTORS) ||
                          play->actorCtx.lensActive || (actor->room != play->roomCtx.curRoom.num))) {

--- a/soh/src/code/z_actor.c
+++ b/soh/src/code/z_actor.c
@@ -2884,7 +2884,7 @@ s32 Ship_CalcShouldDrawAndUpdate(PlayState* play, Actor* actor, Vec3f* projected
     multiplier = MAX(multiplier, 1);
 
     // Some actors have a really short forward value, so we need to add to it before the multiplier to increase the
-    // strength of the forward culling
+    // final strength of the forward culling
     f32 adder = (actor->uncullZoneForward < 500) ? 1000.0f : 0.0f;
 
     if ((projectedPos->z > -actor->uncullZoneScale) &&

--- a/soh/src/overlays/actors/ovl_En_Wood02/z_en_wood02.c
+++ b/soh/src/overlays/actors/ovl_En_Wood02/z_en_wood02.c
@@ -101,12 +101,17 @@ static f32 sSpawnSin;
 s32 EnWood02_SpawnZoneCheck(EnWood02* this, PlayState* play, Vec3f* pos) {
     f32 phi_f12;
 
-    if (CVarGetInteger("gDisableDrawDistance", 0) != 0) {
-        return true;
-    }
-
     SkinMatrix_Vec3fMtxFMultXYZW(&play->viewProjectionMtxF, pos, &this->actor.projectedPos,
                                  &this->actor.projectedW);
+
+    // #region SOH [Enhancement] Use the extended culling calculation
+    if (CVarGetInteger("gDisableDrawDistance", 0) || CVarGetInteger("gEnhancements.WidescreenActorCulling", 0)) {
+        bool shipShouldDraw = false;
+        bool shipShouldUpdate = false;
+        return Ship_CalcShouldDrawAndUpdate(play, &this->actor, &this->actor.projectedPos, this->actor.projectedW,
+                                            &shipShouldDraw, &shipShouldUpdate);
+    }
+    // #endregion
 
     phi_f12 = ((this->actor.projectedW == 0.0f) ? 1000.0f : fabsf(1.0f / this->actor.projectedW));
 

--- a/soh/src/overlays/actors/ovl_Obj_Mure/z_obj_mure.c
+++ b/soh/src/overlays/actors/ovl_Obj_Mure/z_obj_mure.c
@@ -275,7 +275,12 @@ void ObjMure_InitialAction(ObjMure* this, PlayState* play) {
 }
 
 void ObjMure_CulledState(ObjMure* this, PlayState* play) {
-    if (fabsf(this->actor.projectedPos.z) < sZClip[this->type] || CVarGetInteger("gDisableDrawDistance", 0) == 3) {
+    // #region SOH [Enhancements] Extended draw distance
+    s32 distanceMultiplier = CVarGetInteger("gDisableDrawDistance", 1);
+    distanceMultiplier = MAX(distanceMultiplier, 1);
+
+    if (fabsf(this->actor.projectedPos.z) < sZClip[this->type] * distanceMultiplier) {
+        // #endregion
         this->actionFunc = ObjMure_ActiveState;
         this->actor.flags |= ACTOR_FLAG_UPDATE_WHILE_CULLED;
         ObjMure_SpawnActors(this, play);
@@ -399,11 +404,12 @@ static ObjMureActionFunc sTypeGroupBehaviorFunc[] = {
 void ObjMure_ActiveState(ObjMure* this, PlayState* play) {
     ObjMure_CheckChildren(this, play);
 
-    if (CVarGetInteger("gDisableDrawDistance", 0) != 0) {
-        // return;
-    }
+    // #region SOH [Enhancements] Extended draw distance
+    s32 distanceMultiplier = CVarGetInteger("gDisableDrawDistance", 1);
+    distanceMultiplier = MAX(distanceMultiplier, 1);
 
-    if (sZClip[this->type] + 40.0f <= fabsf(this->actor.projectedPos.z)) {
+    if ((sZClip[this->type] + 40.0f) * distanceMultiplier <= fabsf(this->actor.projectedPos.z)) {
+        // #endregion
         this->actionFunc = ObjMure_CulledState;
         this->actor.flags &= ~ACTOR_FLAG_UPDATE_WHILE_CULLED;
         ObjMure_KillActors(this, play);

--- a/soh/src/overlays/actors/ovl_Obj_Mure/z_obj_mure.c
+++ b/soh/src/overlays/actors/ovl_Obj_Mure/z_obj_mure.c
@@ -275,7 +275,7 @@ void ObjMure_InitialAction(ObjMure* this, PlayState* play) {
 }
 
 void ObjMure_CulledState(ObjMure* this, PlayState* play) {
-    if (fabsf(this->actor.projectedPos.z) < sZClip[this->type] || CVarGetInteger("gDisableDrawDistance", 0) != 0) {
+    if (fabsf(this->actor.projectedPos.z) < sZClip[this->type] || CVarGetInteger("gDisableDrawDistance", 0) == 3) {
         this->actionFunc = ObjMure_ActiveState;
         this->actor.flags |= ACTOR_FLAG_UPDATE_WHILE_CULLED;
         ObjMure_SpawnActors(this, play);
@@ -398,8 +398,12 @@ static ObjMureActionFunc sTypeGroupBehaviorFunc[] = {
 
 void ObjMure_ActiveState(ObjMure* this, PlayState* play) {
     ObjMure_CheckChildren(this, play);
-    if (sZClip[this->type] + 40.0f <= fabsf(this->actor.projectedPos.z) &&
-        CVarGetInteger("gDisableDrawDistance", 1) != 0) {
+
+    if (CVarGetInteger("gDisableDrawDistance", 0) != 0) {
+        // return;
+    }
+
+    if (sZClip[this->type] + 40.0f <= fabsf(this->actor.projectedPos.z)) {
         this->actionFunc = ObjMure_CulledState;
         this->actor.flags &= ~ACTOR_FLAG_UPDATE_WHILE_CULLED;
         ObjMure_KillActors(this, play);

--- a/soh/src/overlays/actors/ovl_Obj_Mure2/z_obj_mure2.c
+++ b/soh/src/overlays/actors/ovl_Obj_Mure2/z_obj_mure2.c
@@ -190,8 +190,7 @@ void func_80B9A658(ObjMure2* this) {
 
 void func_80B9A668(ObjMure2* this, PlayState* play) {
     if (Math3D_Dist1DSq(this->actor.projectedPos.x, this->actor.projectedPos.z) <
-            (sDistSquared1[this->actor.params & 3] * this->unk_184) ||
-        CVarGetInteger("gDisableDrawDistance", 0) != 0) {
+        (sDistSquared1[this->actor.params & 3] * this->unk_184)) {
         this->actor.flags |= ACTOR_FLAG_UPDATE_WHILE_CULLED;
         ObjMure2_SpawnActors(this, play);
         func_80B9A6E8(this);
@@ -205,12 +204,8 @@ void func_80B9A6E8(ObjMure2* this) {
 void func_80B9A6F8(ObjMure2* this, PlayState* play) {
     func_80B9A534(this);
 
-    if (CVarGetInteger("gDisableDrawDistance", 0) != 0) {
-        return;
-    }
-
     if ((sDistSquared2[this->actor.params & 3] * this->unk_184) <=
-            Math3D_Dist1DSq(this->actor.projectedPos.x, this->actor.projectedPos.z)) {
+        Math3D_Dist1DSq(this->actor.projectedPos.x, this->actor.projectedPos.z)) {
         this->actor.flags &= ~ACTOR_FLAG_UPDATE_WHILE_CULLED;
         ObjMure2_CleanupAndDie(this, play);
         func_80B9A658(this);
@@ -225,5 +220,11 @@ void ObjMure2_Update(Actor* thisx, PlayState* play) {
     } else {
         this->unk_184 = 4.0f;
     }
+
+    if (CVarGetInteger("gDisableDrawDistance", 0) || CVarGetInteger("gEnhancements.WidescreenActorCulling", 0)) {
+        this->unk_184 = 5.0f * 3.0f;
+        // this->unk_184 = SQ(5.0f);
+    }
+
     this->actionFunc(this, play);
 }

--- a/soh/src/overlays/actors/ovl_Obj_Mure2/z_obj_mure2.c
+++ b/soh/src/overlays/actors/ovl_Obj_Mure2/z_obj_mure2.c
@@ -221,9 +221,18 @@ void ObjMure2_Update(Actor* thisx, PlayState* play) {
         this->unk_184 = 4.0f;
     }
 
-    if (CVarGetInteger("gDisableDrawDistance", 0) || CVarGetInteger("gEnhancements.WidescreenActorCulling", 0)) {
-        this->unk_184 = 5.0f * 3.0f;
-        // this->unk_184 = SQ(5.0f);
+    // SOH [Enhancements] Extended draw distance
+    s32 distanceMultiplier = CVarGetInteger("gDisableDrawDistance", 1);
+    if (CVarGetInteger("gEnhancements.WidescreenActorCulling", 0) || distanceMultiplier > 1) {
+        f32 originalAspectRatio = 4.0f / 3.0f;
+        f32 currentAspectRatio = OTRGetAspectRatio();
+        // Adjust ratio difference based on field of view testing
+        f32 ratioAdjusted = 1.0f + (MAX(currentAspectRatio / originalAspectRatio, 1.0f) / 1.5f);
+        // Distance multiplier is squared due to the checks above for squared distances
+        distanceMultiplier = SQ(MAX(distanceMultiplier, 1));
+
+        // Prefer the largest of the three values
+        this->unk_184 = MAX(MAX((f32)distanceMultiplier, ratioAdjusted), this->unk_184);
     }
 
     this->actionFunc(this, play);


### PR DESCRIPTION
This PR achieves two main goals:
* Improve upon the existing "Disable Draw Distance" enhancement
* Re-implement widescreen actor culling as an optional toggle

### Draw Distance
Previously our Draw Distance enhancement was implemented rather poorly. The way it worked essentially bypassed culling checks entirely, meaning that all actors were drawn and updated, even if they where behind the camera/out of view. For lower end devices, this would cause significant lag in larger areas like Hyrule Field.

The changes in this PR attempt to address this in two ways:
First, a "draw distance" enhancement should really only increase the forward culling plane of the uncull frustum. So now things behind the camera will cull as expected following the actors rules.
Second, the "draw distance" enhancement is now a slider so that players can choose "how much" increased range they want. This works as a multiplier against each actors forward uncull zone value, so that the zones scale per actor (e.g. trees scale father than insects).

### Widescreen culling
Previously we hardcoded the side, top, and bottom uncull planes to be increased by a factor of 2. This change was arbitrary and got lost in git history, not to mention changing the top and bottom planes is not necessary for widescreens. It worked decently for 16:9 aspect ratios, but started to show actor pop-in on much larger ratios like 32:9. In 8.0.5, we reverted this change back to vanilla to restore certain uncull glitches (i.e. King Zora unfreeze), but now there is noticeable actor pop-in on regular widescreen ratios.

The changes in this PR bring back widescreen actor culling as a dedicated option, so that it can be turned on/off. Additionally, the horizontal planes are now increased proportionally to the games aspect ratio so that even 32:9 displays should have little-to-no actor pop-in.

### Exclude glitch useful actors
To deal with glitches, a new option is added that allows specific glitch-useful actors to be excluded from the extended culling options. This means things like King Zora unfreeze, Gerudo guard unculling, blue warp unculling, etc can all work as expected while extended culling is active. This works by allowing actors to "draw" without actually "updating", so there won't be pop-in, but update logic will not run (the logic that uncull glitches take advantage of).
Specific actors have been identified and included as of now, but we can add more as other use cases are identified.

### Other things to note
Previous actor exclusions like Dark Link's room or Dodongos Cavern Lizalfos are not longer necessary with these updates so they have been removed. Others were just incorrect (zelda/ganon horse), and have been replaced with the appropriate actor (`en_viewer`).

Some trees/bushes spawn and clean up "additional" actors in Hyrule field using the same extended logic now.
Bush/rock circles have additional logic to spawn/clean up their individual actors tweaked to match the extended culling options.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1796297306.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1796297309.zip)
  - [soh-linux-performance.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1796297312.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1796297315.zip)
  - [soh-switch.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1796297318.zip)
  - [soh-wiiu.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1796297319.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1796297321.zip)
<!--- section:artifacts:end -->