### PR TITLE
Add jabu box skip door  and frog hint exceptions to cutscene skipping

### DIFF
--- a/soh/soh/Enhancements/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.cpp
@@ -237,11 +237,16 @@ void TimeSaverOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, void*
                         break;
                     }
                     case ACTOR_BG_BDAN_SWITCH: {
-                        BgBdanSwitch* switchActor = static_cast<BgBdanSwitch*>(opt);
-                        switchActor->unk_1D8 = 0;
-                        switchActor->unk_1DA = 0;
-                        *should = false;
-                        RateLimitedSuccessChime();
+                        // The switch in jabu that you are intended to press with a box to reach barrinade
+                        // can be skipped by either a frame perfect roll open or with OI
+                        // The One Point for that switch is used in common setups for the former and is required for the latter to work
+                        if (!(actor->params == 14848 && gPlayState->sceneNum == SCENE_JABU_JABU) || CVarGetInteger(CVAR_ENHANCEMENT("TimeSavers.SkipCutscene.GlitchAiding"), 0)){
+                            BgBdanSwitch* switchActor = static_cast<BgBdanSwitch*>(opt);
+                            switchActor->unk_1D8 = 0;
+                            switchActor->unk_1DA = 0;
+                            *should = false;
+                            RateLimitedSuccessChime();
+                        }
                         break;
                     }
                     case ACTOR_BG_HIDAN_KOUSI: {
@@ -297,7 +302,9 @@ void TimeSaverOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, void*
             }
             break;
         case VB_WONDER_TALK: {
-            if (CVarGetInteger(CVAR_ENHANCEMENT("TimeSavers.NoForcedDialog"), IS_RANDO)) {
+            //We want to show the frog hint if it is on, regardless of cutscene settings
+            if (CVarGetInteger(CVAR_ENHANCEMENT("TimeSavers.NoForcedDialog"), IS_RANDO) && 
+                !(gPlayState->sceneNum == SCENE_ZORAS_RIVER && IS_RANDO && RAND_GET_OPTION(RSK_FROGS_HINT))) {
                 *should = false;
             }
             break;

--- a/soh/soh/Enhancements/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.cpp
@@ -240,13 +240,14 @@ void TimeSaverOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, void*
                         // The switch in jabu that you are intended to press with a box to reach barrinade
                         // can be skipped by either a frame perfect roll open or with OI
                         // The One Point for that switch is used in common setups for the former and is required for the latter to work
-                        if (!(actor->params == 14848 && gPlayState->sceneNum == SCENE_JABU_JABU) || CVarGetInteger(CVAR_ENHANCEMENT("TimeSavers.SkipCutscene.GlitchAiding"), 0)){
-                            BgBdanSwitch* switchActor = static_cast<BgBdanSwitch*>(opt);
-                            switchActor->unk_1D8 = 0;
-                            switchActor->unk_1DA = 0;
-                            *should = false;
-                            RateLimitedSuccessChime();
+                        if (actor->params == 14848 && gPlayState->sceneNum == SCENE_JABU_JABU && !CVarGetInteger(CVAR_ENHANCEMENT("TimeSavers.SkipCutscene.GlitchAiding"), 0)){
+                            break;
                         }
+                        BgBdanSwitch* switchActor = static_cast<BgBdanSwitch*>(opt);
+                        switchActor->unk_1D8 = 0;
+                        switchActor->unk_1DA = 0;
+                        *should = false;
+                        RateLimitedSuccessChime();
                         break;
                     }
                     case ACTOR_BG_HIDAN_KOUSI: {


### PR DESCRIPTION
- The Jabu Box skip door is now seen as a Glitch Aiding Cutscene as it is needed to OI past the door and for 1 frame opening setups.
- The frogs dialogue is no longer skipped if the frogs hint is enabled, as it contains the hint.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1825189751.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1825194979.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1825197140.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1825199029.zip)
<!--- section:artifacts:end -->