### PR TITLE
Additions for the German translation in two files

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/hint_list/hint_list_exclude_dungeon.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/hint_list/hint_list_exclude_dungeon.cpp
@@ -33,7 +33,7 @@ void StaticData::HintTable_Init_Exclude_Dungeon() {
                                                                     // /*spanish*/ Según dicen, los #salientes del Gran Árbol Deku# conducen a #[[1]]#.
 
     hintTextTable[RHT_DEKU_TREE_BASEMENT_CHEST] = HintText(CustomMessage("They say that #webs in the Deku Tree# hide #[[1]]#.",
-                                                              /*german*/ "Man erzählt sich, daß #Spinnweben im Deku-Baum# #[[1]]# verstecken würden.",
+                                                              /*german*/ "Man erzählt sich, daß #Spinnweben im Deku-Baum# #[[1]]# verbergen würden.",
                                                               /*french*/ "Selon moi, les #toiles dans l'Arbre Mojo# cachent #[[1]]#.", {QM_RED, QM_GREEN}));
                                                            // /*spanish*/ Según dicen, entre #telarañas del Gran Árbol Deku# yace #[[1]]#.
 
@@ -58,7 +58,7 @@ void StaticData::HintTable_Init_Exclude_Dungeon() {
                                                                          // /*spanish*/ Según dicen, los #salientes del Gran Árbol Deku# conducen a #[[1]]#.
 
     hintTextTable[RHT_DEKU_TREE_MQ_BASEMENT_CHEST] = HintText(CustomMessage("They say that #webs in the Deku Tree# hide #[[1]]#.",
-                                                                 /*german*/ "Man erzählt sich, daß #Spinnweben im Deku-Baum# #[[1]]# verstecken würden.",
+                                                                 /*german*/ "Man erzählt sich, daß #Spinnweben im Deku-Baum# #[[1]]# verbergen würden.",
                                                                  /*french*/ "Selon moi, les #toiles dans l'Arbre Mojo# cachent #[[1]]#.", {QM_RED, QM_GREEN}));
                                                               // /*spanish*/ Según dicen, entre #telarañas del Gran Árbol Deku# yace #[[1]]#.
 
@@ -309,7 +309,7 @@ hintTextTable[RHT_DODONGOS_CAVERN_BOSS_ROOM_CHEST] = HintText(CustomMessage("The
                                                                 // /*spanish*/ Según dicen, cierta #roca rodeada de vacas# esconde #[[1]]#.
                                                                 {}, {
                                                                 CustomMessage("They say that #pop rocks# hide #[[1]]#.",
-                                                                    /*german*/ "Man erzählt sich, daß #Knallfelsen# #[[1]]# verstecken würden.",
+                                                                    /*german*/ "Man erzählt sich, daß #Knallfelsen# #[[1]]# verbergen würden.",
                                                                     /*french*/ "Selon moi, des #pierres aux reins# cachent #[[1]]#.", {QM_RED, QM_GREEN}),
                                                                  // /*spanish*/ Según dicen, #cepillarse los dientes con explosivos# revela #[[1]]#.
                                                                 CustomMessage("They say that an #explosive palate# holds #[[1]]#.",
@@ -358,7 +358,7 @@ hintTextTable[RHT_DODONGOS_CAVERN_BOSS_ROOM_CHEST] = HintText(CustomMessage("The
                                                                                  // /*spanish*/ Según dicen, unos #stingers engullidos por Jabu-Jabu# guardan #[[1]]#.
                                                                                  {}, {
                                                                                  CustomMessage("They say that a school of #stingers swallowed by a deity# guard #[[1]]#.",
-                                                                                     /*german*/ "Man erzählt sich, daß von #Jabu-Jabu verschluckte Rochen# #[[1]]# bewachen würden.",
+                                                                                     /*german*/ "Man erzählt sich, daß von #einer Gottheit verschluckte Rochen# #[[1]]# bewachen würden.",
                                                                                      /*french*/ "Selon moi, les #raies avallées par le gardien# protègent #[[1]]#.", {QM_RED, QM_GREEN})});
                                                                                   // /*spanish*/ Según dicen, unos #stingers engullidos por cierta deidad# guardan #[[1]]#.
 
@@ -585,61 +585,61 @@ hintTextTable[RHT_DODONGOS_CAVERN_BOSS_ROOM_CHEST] = HintText(CustomMessage("The
                                                                   // /*spanish*/ Según dicen, en una #sala con otro punto de vista# se esconde #[[1]]#.
 
     hintTextTable[RHT_FOREST_TEMPLE_PHANTOM_GANON_HEART] = HintText(CustomMessage("They say that #Phantom Ganon# holds #[[1]]#.",
-                                                                       /*german*/ "",
+                                                                       /*german*/ "Man erzählt sich, daß #Phantom-Ganon# #[[1]]# besäße.",
                                                                        /*french*/ "Selon moi, #Ganon Spectral# possède #[[1]]#.", {QM_RED, QM_GREEN}),
                                                                     // /*spanish*/ Según dicen, #Ganon Fantasma# porta #[[1]]#.
                                                                     {}, {
                                                                     CustomMessage("They say that the #Evil Spirit from Beyond# holds #[[1]]#.",
-                                                                        /*german*/ "",
+                                                                        /*german*/ "Man erzählt sich, daß #böse Geist aus dem Jenseits# #[[1]]# besäße.",
                                                                         /*french*/ "Selon moi, l'#esprit maléfique de l'au-delà# possède #[[1]]#.", {QM_RED, QM_GREEN})});
                                                                      // /*spanish*/ Según dicen, el #espíritu maligno de ultratumba# porta #[[1]]#.
 
     hintTextTable[RHT_FOREST_TEMPLE_GS_RAISED_ISLAND_COURTYARD] = HintText(CustomMessage("They say that a #spider on a small island# in the Forest Temple holds #[[1]]#.",
-                                                                              /*german*/ "",
+                                                                              /*german*/ "Man erzählt sich, daß eine #Spinne auf einer kleinen Insel# im Waldtempel #[[1]]# besäße.",
                                                                               /*french*/ "Selon moi, une #Skulltula sur l'îlot du Temple de la Forêt# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                            // /*spanish*/ Según dicen, una #Skulltula sobre una pequeña isla# del Templo del Bosque otorga #[[1]]#.
 
     hintTextTable[RHT_FOREST_TEMPLE_GS_FIRST_ROOM] = HintText(CustomMessage("They say that a #spider high on a wall of vines# in the Forest Temple holds #[[1]]#.",
-                                                                 /*german*/ "",
+                                                                 /*german*/ "Man erzählt sich, daß eine #Spinne hoch auf einer Wand aus Reben# im Waldtempel #[[1]]# besäße.",
                                                                  /*french*/ "Selon moi, une #Skulltula sur un mur de vignes du Temple de la Forêt# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                               // /*spanish*/ Según dicen, una #Skulltula en lo alto de una pared de cepas# del Templo del Bosque otorga #[[1]]#.
 
     hintTextTable[RHT_FOREST_TEMPLE_GS_LEVEL_ISLAND_COURTYARD] = HintText(CustomMessage("They say that #stone columns# lead to a spider in the Forest Temple hiding #[[1]]#.",
-                                                                             /*german*/ "",
+                                                                             /*german*/ "Man erzählt sich, daß #Säulen aus Stein# zu einer Spinne im Waldtempel führen, welche #[[1]]# verstecke.",
                                                                              /*french*/ "Selon moi, une #Skulltula haut perchée dans le jardin du Temple de la Forêt# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                           // /*spanish*/ Según dicen, unas #columnas del Templo del Bosque# conducen a una Skulltula que otorga #[[1]]#.
 
     hintTextTable[RHT_FOREST_TEMPLE_GS_LOBBY] = HintText(CustomMessage("They say that a #spider among ghosts# in the Forest Temple guards #[[1]]#.",
-                                                            /*german*/ "",
+                                                            /*german*/ "Man erzählt sich, daß eine #Spinne inmitten von Geistern# im Waldtempel #[[1]]# bewache.",
                                                             /*french*/ "Selon moi, une #Skulltula dans la grande salle du Temple de la Forêt# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                          // /*spanish*/ Según dicen, una #Skulltula rodeada de fantasmas# del Templo del Bosque otorga #[[1]]#.
 
     hintTextTable[RHT_FOREST_TEMPLE_GS_BASEMENT] = HintText(CustomMessage("They say that a #spider within revolving walls# in the Forest Temple holds #[[1]]#.",
-                                                               /*german*/ "",
+                                                               /*german*/ "Man erzählt sich, daß eine #Spinne inmitten drehender Wände# im Waldtempel #[[1]]# besäße.",
                                                                /*french*/ "Selon moi, une #Skulltula derrière les murs pivotants du Temple de la Forêt# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                             // /*spanish*/ Según dicen, una #Skulltula entre paredes giratorias# del Templo del Bosque otorga #[[1]]#.
 
     hintTextTable[RHT_FOREST_TEMPLE_MQ_GS_FIRST_HALLWAY] = HintText(CustomMessage("They say that an #ivy-hidden spider# in the Forest Temple hoards #[[1]]#.",
-                                                                       /*german*/ "",
+                                                                       /*german*/ "Man erzählt sich, daß eine #unter Efeu versteckte Spinne# im Waldtempel #[[1]]# horte.",
                                                                        /*french*/ "Selon moi, une #Skulltula près de l'entrée du Temple de la Forêt# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                     // /*spanish*/ Según dicen, una #Skulltula escondida entre cepas# del Templo del Bosque otorga #[[1]]#.
 
     hintTextTable[RHT_FOREST_TEMPLE_MQ_GS_BLOCK_PUSH_ROOM] = HintText(CustomMessage("They say that a #spider in a hidden nook# within the Forest Temple holds #[[1]]#.",
-                                                                         /*german*/ "",
+                                                                         /*german*/ "Man erzählt sich, daß eine #Spinne in einem versteckten Winkel# im Waldtempel #[[1]]# besäße.",
                                                                          /*french*/ "Selon moi, une #Skulltula dans un recoin caché du Temple de la Forêt# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                       // /*spanish*/ Según dicen, una #Skulltula en una esquina oculta# del Templo del Bosque otorga #[[1]]#.
 
     hintTextTable[RHT_FOREST_TEMPLE_MQ_GS_RAISED_ISLAND_COURTYARD] = HintText(CustomMessage("They say that a #spider on an arch# in the Forest Temple holds #[[1]]#.",
-                                                                                 /*german*/ "",
+                                                                                 /*german*/ "Man erzählt sich, daß eine #Spinne auf einem Bogen# im Waldtempel #[[1]]# besäße.",
                                                                                  /*french*/ "Selon moi, une #Skulltula sur une arche du Temple de la Forêt# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                               // /*spanish*/ Según dicen, una #Skulltula sobre un arco# del Templo del Bosque otorga #[[1]]#.
 
     hintTextTable[RHT_FOREST_TEMPLE_MQ_GS_LEVEL_ISLAND_COURTYARD] = HintText(CustomMessage("They say that a #spider on a ledge# in the Forest Temple holds #[[1]]#.",
-                                                                                /*german*/ "",
+                                                                                /*german*/ "Man erzählt sich, daß eine #Spinne auf einem Vorsprung# im Waldtempel #[[1]]# besäße.",
                                                                                 /*french*/ "Selon moi, une #Skulltula dans le jardin du Temple de la Forêt# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                              // /*spanish*/ Según dicen, una #Skulltula en un borde# del Templo del Bosque otorga #[[1]]#.
   hintTextTable[RHT_FOREST_TEMPLE_MQ_GS_WELL] = HintText(CustomMessage("They say that #draining a well# in Forest Temple uncovers a spider with #[[1]]#.",
-                                                              /*german*/ "",
+                                                              /*german*/ "Man erzählt sich, daß das #Entleeren eines Brunnens# im Waldtempel eine Spinne mit #[[1]]# enthülle.",
                                                               /*french*/ "Selon moi, une #Skulltula au fond du Puits du Temple de la Forêt# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                            // /*spanish*/ Según dicen, #vaciar el pozo# del Templo del Bosque desvela una Skulltula que otorga #[[1]]#.
   
@@ -647,187 +647,187 @@ hintTextTable[RHT_DODONGOS_CAVERN_BOSS_ROOM_CHEST] = HintText(CustomMessage("The
   |       FIRE TEMPLE        |
   ---------------------------*/
 hintTextTable[RHT_FIRE_TEMPLE_NEAR_BOSS_CHEST] = HintText(CustomMessage("They say that #near a dragon# is #[[1]]#.",
-                                                                 /*german*/ "",
+                                                                 /*german*/ "Man erzählt sich, daß #nahe eines Drachens# #[[1]]# sei.",
                                                                  /*french*/ "Selon moi, #près d'un dragon# gît #[[1]]#.", {QM_RED, QM_GREEN}));
                                                               // /*spanish*/ Según dicen, #cerca de un dragón# yace #[[1]]#.
 
     hintTextTable[RHT_FIRE_TEMPLE_FLARE_DANCER_CHEST] = HintText(CustomMessage("They say that the #Flare Dancer behind a totem# guards #[[1]]#.",
-                                                                    /*german*/ "",
+                                                                    /*german*/ "Man erzählt sich, daß die #Flammenderwische hinter einem Totem# #[[1]]# bewachen würden.",
                                                                     /*french*/ "Selon moi, le #Danse-Flamme derrière un totem# protège #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                  // /*spanish*/ Según dicen, el #Bailafuego tras unos tótems# esconde #[[1]]#.
 
     hintTextTable[RHT_FIRE_TEMPLE_BOSS_KEY_CHEST] = HintText(CustomMessage("They say that a #prison beyond a totem# holds #[[1]]#.",
-                                                                /*german*/ "",
+                                                                /*german*/ "Man erzählt sich, daß ein #Gefängnis jenseits eines Totems# #[[1]]# enthielte.",
                                                                 /*french*/ "Selon moi, la #prison derrière un totem# contient #[[1]]#.", {QM_RED, QM_GREEN}));
                                                              // /*spanish*/ Según dicen, en una #prisión tras unos tótems# yace #[[1]]#.
 
     hintTextTable[RHT_FIRE_TEMPLE_BIG_LAVA_ROOM_BLOCKED_DOOR_CHEST] = HintText(CustomMessage("They say that #explosives over a lava pit# unveil #[[1]]#.",
-                                                                                  /*german*/ "",
+                                                                                  /*german*/ "Man erzählt sich, daß #Explosives über einem Lavastrom# #[[1]]# enthüllen würde.",
                                                                                   /*french*/ "Selon moi, des #explosifs dans un lac de lave# révèlent #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                                // /*spanish*/ Según dicen, los #explosivos en un mar de llamas# revelan #[[1]]#.
 
     hintTextTable[RHT_FIRE_TEMPLE_BIG_LAVA_ROOM_LOWER_OPEN_DOOR_CHEST] = HintText(CustomMessage("They say that a #Goron trapped near lava# holds #[[1]]#.",
-                                                                                     /*german*/ "",
+                                                                                     /*german*/ "Man erzählt sich, daß ein #nahe der Lava gefangene Gorone# #[[1]]# besäße.",
                                                                                      /*french*/ "Selon moi, le #Goron emprisonné près de la lave# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                                   // /*spanish*/ Según dicen, un #goron atrapado cerca de un mar de llamas# guarda #[[1]]#.
 
     hintTextTable[RHT_FIRE_TEMPLE_BOULDER_MAZE_LOWER_CHEST] = HintText(CustomMessage("They say that a #Goron at the end of a maze# holds #[[1]]#.",
-                                                                          /*german*/ "",
+                                                                          /*german*/ "Man erzählt sich, daß ein #Gorone am Ende eines Labyrinths# #[[1]]# besäße.",
                                                                           /*french*/ "Selon moi, le #Goron dans le labyrinthe# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                        // /*spanish*/ Según dicen, un #goron al final de un laberinto# guarda #[[1]]#.
 
     hintTextTable[RHT_FIRE_TEMPLE_BOULDER_MAZE_UPPER_CHEST] = HintText(CustomMessage("They say that a #Goron above a maze# holds #[[1]]#.",
-                                                                          /*german*/ "",
+                                                                          /*german*/ "Man erzählt sich, daß ein #Gorone oberhalb eines Labyrinths# #[[1]]# besäße.",
                                                                           /*french*/ "Selon moi, le #Goron au dessus du labyrinthe# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                        // /*spanish*/ Según dicen, un #goron sobre un laberinto# guarda #[[1]]#.
 
     hintTextTable[RHT_FIRE_TEMPLE_BOULDER_MAZE_SIDE_ROOM_CHEST] = HintText(CustomMessage("They say that a #Goron hidden near a maze# holds #[[1]]#.",
-                                                                              /*german*/ "",
+                                                                              /*german*/ "Man erzählt sich, daß ein #nahe eines Labyrinths versteckter Gorone# #[[1]]# besäße.",
                                                                               /*french*/ "Selon moi, le #Goron caché près du labyrinthe# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                            // /*spanish*/ Según dicen, un #goron escondido tras un laberinto# guarda #[[1]]#.
 
     hintTextTable[RHT_FIRE_TEMPLE_BOULDER_MAZE_SHORTCUT_CHEST] = HintText(CustomMessage("They say that a #blocked path# in Fire Temple holds #[[1]]#.",
-                                                                             /*german*/ "",
+                                                                             /*german*/ "Man erzählt sich, daß ein #blockierter Pfad# im Feuertempel #[[1]]# enthielte.",
                                                                              /*french*/ "Selon moi, un #sol fragile dans le Temple du Feu# contient #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                           // /*spanish*/ Según dicen, en un #camino bloqueado# del Templo del Fuego yace #[[1]]#.
 
     hintTextTable[RHT_FIRE_TEMPLE_MAP_CHEST] = HintText(CustomMessage("They say that a #caged chest# in the Fire Temple hoards #[[1]]#.",
-                                                           /*german*/ "",
+                                                           /*german*/ "Man erzählt sich, daß eine #eingesperrte Truhe# im Feuertempel #[[1]]# enthielte.",
                                                            /*french*/ "Selon moi, un #coffre emprisonné# dans le Temple du Feu contient #[[1]]#.", {QM_RED, QM_GREEN}));
                                                         // /*spanish*/ Según dicen, un #cofre entre rejas# del Templo del Fuego contiene #[[1]]#.
 
     hintTextTable[RHT_FIRE_TEMPLE_COMPASS_CHEST] = HintText(CustomMessage("They say that a #chest in a fiery maze# contains #[[1]]#.",
-                                                               /*german*/ "",
+                                                               /*german*/ "Man erzählt sich, daß eine #Truhe in einem feurigen Labyrinth# #[[1]]# enthielte.",
                                                                /*french*/ "Selon moi, un #coffre dans un labyrinthe enflammé# contient #[[1]]#.", {QM_RED, QM_GREEN}));
                                                             // /*spanish*/ Según dicen, un #cofre de un ardiente laberinto# contiene #[[1]]#.
 
     hintTextTable[RHT_FIRE_TEMPLE_HIGHEST_GORON_CHEST] = HintText(CustomMessage("They say that a #Goron atop the Fire Temple# holds #[[1]]#.",
-                                                                     /*german*/ "",
+                                                                     /*german*/ "Man erzählt sich, daß ein #Gorone auf der Spitze des Feuertempels# #[[1]]# besäße.",
                                                                      /*french*/ "Selon moi, le #Goron au sommet du Temple du Feu# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                   // /*spanish*/ Según dicen, un #goron en lo alto del Templo del Fuego# guarda #[[1]]#.
 
     hintTextTable[RHT_FIRE_TEMPLE_MQ_NEAR_BOSS_CHEST] = HintText(CustomMessage("They say that #near a dragon# is #[[1]]#.",
-                                                                    /*german*/ "",
+                                                                    /*german*/ "Man erzählt sich, daß #nahe eines Drachens# #[[1]]# sei.",
                                                                     /*french*/ "Selon moi, #près d'un dragon# gît #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                  // /*spanish*/ Según dicen, #cerca de un dragón# yace #[[1]]#.
 
     hintTextTable[RHT_FIRE_TEMPLE_MQ_MEGATON_HAMMER_CHEST] = HintText(CustomMessage("They say that the #Flare Dancer in the depths of the Fire Temple# guards #[[1]]#.",
-                                                                         /*german*/ "",
+                                                                         /*german*/ "Man erzählt sich, daß die #Flammenderwische in den Tiefen des Feuertempels# #[[1]]# bewachen würden.",
                                                                          /*french*/ "Selon moi, le #Danse-Flamme au coeur du volcan# a #[[1]]#.", {QM_RED, QM_GREEN}),
                                                                       // /*spanish*/ Según dicen, el #Bailafuego en lo profundo del Templo del Fuego# esconde #[[1]]#.
                                                                       {}, {
                                                                       CustomMessage("They say that the #Flare Dancer in the depths of a volcano# guards #[[1]]#.",
-                                                                          /*german*/ "",
+                                                                          /*german*/ "Man erzählt sich, daß die #Flammenderwische in den Tiefen eines Vulkans# #[[1]]# bewachen würden.",
                                                                           /*french*/ "Selon moi, le #Danse-Flamme au coeur du volcan# a #[[1]]#.", {QM_RED, QM_GREEN})});
                                                                        // /*spanish*/ Según dicen, el #Bailafuego en lo profundo del volcán# esconde #[[1]]#.
 
     hintTextTable[RHT_FIRE_TEMPLE_MQ_COMPASS_CHEST] = HintText(CustomMessage("They say that a #blocked path# in Fire Temple holds #[[1]]#.",
-                                                                  /*german*/ "",
+                                                                  /*german*/ "Man erzählt sich, daß ein #blockierter Pfad# im Feuertempel #[[1]]# enthielte.",
                                                                   /*french*/ "Selon moi, le #chemin scellé# dans le Temple du Feu contient #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                // /*spanish*/ Según dicen, en un #camino bloqueado# del Templo del Fuego yace #[[1]]#.
 
     hintTextTable[RHT_FIRE_TEMPLE_MQ_LIZALFOS_MAZE_LOWER_CHEST] = HintText(CustomMessage("They say that #crates in a maze# contain #[[1]]#.",
-                                                                              /*german*/ "",
+                                                                              /*german*/ "Man erzählt sich, daß #Kisten in einem Labyrinth# #[[1]]# enthielten.",
                                                                               /*french*/ "Selon moi, des #boîtes dans le labyrinthe# contiennent #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                            // /*spanish*/ Según dicen, las #cajas de un laberinto# contienen #[[1]]#.
 
     hintTextTable[RHT_FIRE_TEMPLE_MQ_LIZALFOS_MAZE_UPPER_CHEST] = HintText(CustomMessage("They say that #crates in a maze# contain #[[1]]#.",
-                                                                              /*german*/ "",
+                                                                              /*german*/ "Man erzählt sich, daß #Kisten in einem Labyrinth #[[1]]# enthielten.",
                                                                               /*french*/ "Selon moi, des #boîtes dans le labyrinthe# contiennent #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                            // /*spanish*/ Según dicen, las #cajas de un laberinto# contienen #[[1]]#.
 
     hintTextTable[RHT_FIRE_TEMPLE_MQ_MAP_ROOM_SIDE_CHEST] = HintText(CustomMessage("They say that a #falling slug# in the Fire Temple guards #[[1]]#.",
-                                                                        /*german*/ "",
+                                                                        /*german*/ "Man erzählt sich, daß eine #fallende Schnecke# im Feuertempel #[[1]]# bewache.",
                                                                         /*french*/ "Selon moi, la #limace tombante# dans le Temple du Feu protège #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                      // /*spanish*/ Según dicen, una #babosa del techo# del Templo del Fuego guarda #[[1]]#.
 
     hintTextTable[RHT_FIRE_TEMPLE_MQ_MAP_CHEST] = HintText(CustomMessage("They say that using a #hammer in the depths of the Fire Temple# reveals #[[1]]#.",
-                                                              /*german*/ "",
+                                                              /*german*/ "Man erzählt sich, daß die Benutzung eines #Hammers in den Tiefen des Feuertempels# #[[1]]# enthüllen würde.",
                                                               /*french*/ "Selon moi, frapper du #marteau au coeur du volcan# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
                                                            // /*spanish*/ Según dicen, usar el #martillo en lo profundo del Templo del Fuego# revela #[[1]]#.
 
     hintTextTable[RHT_FIRE_TEMPLE_MQ_BOSS_KEY_CHEST] = HintText(CustomMessage("They say that #illuminating a lava pit# reveals the path to #[[1]]#.",
-                                                                   /*german*/ "",
+                                                                   /*german*/ "Man erzählt sich, daß die #Illumination einer Lavagrube# den Pfad zu #[[1]]# enthülle.",
                                                                    /*french*/ "Selon moi, #éclairer le lac de lave# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                 // /*spanish*/ Según dicen, #iluminar un mar de llamas# revela #[[1]]#.
 
     hintTextTable[RHT_FIRE_TEMPLE_MQ_BIG_LAVA_ROOM_BLOCKED_DOOR_CHEST] = HintText(CustomMessage("They say that #explosives over a lava pit# unveil #[[1]]#.",
-                                                                                     /*german*/ "",
+                                                                                     /*german*/ "Man erzählt sich, daß #Explosives oberhalb einer Lavagrube# #[[1]]# enthüllen würde.",
                                                                                      /*french*/ "Selon moi, des #explosifs dans un lac de lave# révèlent #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                                   // /*spanish*/ Según dicen, los #explosivos en un mar de llamas# revelan #[[1]]#.
 
     hintTextTable[RHT_FIRE_TEMPLE_MQ_LIZALFOS_MAZE_SIDE_ROOM_CHEST] = HintText(CustomMessage("They say that a #Goron hidden near a maze# holds #[[1]]#.",
-                                                                                  /*german*/ "",
+                                                                                  /*german*/ "Man erzählt sich, daß ein #nahe eines Labyrinths versteckter Gorone# #[[1]]# besäße.",
                                                                                   /*french*/ "Selon moi, le #Goron caché près du labyrinthe# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                                // /*spanish*/ Según dicen, un #goron cerca de un laberinto# guarda #[[1]]#.
 
     hintTextTable[RHT_FIRE_TEMPLE_MQ_FREESTANDING_KEY] = HintText(CustomMessage("They say that hidden #beneath a block of stone# lies #[[1]]#.",
-                                                                     /*german*/ "",
+                                                                     /*german*/ "Man erzählt sich, daß versteckt #unter einem Steinblock# #[[1]]# läge.",
                                                                      /*french*/ "Selon moi, caché #derrière un bloc de pierre# gît #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                   // /*spanish*/ Según dicen, #bajo unos bloques de piedra# yace #[[1]]#.
 
     hintTextTable[RHT_FIRE_TEMPLE_VOLVAGIA_HEART] = HintText(CustomMessage("They say that #Volvagia# holds #[[1]]#.",
-                                                                /*german*/ "",
-                                                                /*french*/ "Selon moi, #Volvagia# possède #[[1]]#.", {QM_RED, QM_GREEN}),
+                                                                /*german*/ "Man erzählt sich, daß #Volvagia# #[[1]]# besäße.",
+                                                                /*french*/ "Selon moi, #Volcania# possède #[[1]]#.", {QM_RED, QM_GREEN}),
                                                              // /*spanish*/ Según dicen, #Volvagia# porta #[[1]]#.
                                                              {}, {
                                                              CustomMessage("They say that the #Subterranean Lava Dragon# holds #[[1]]#.",
-                                                                 /*german*/ "",
+                                                                 /*german*/ "Man erzählt sich, daß der #subterrane Lavadrache# #[[1]]# besäße.",
                                                                  /*french*/ "Selon moi, le #dragon des profondeurs# possède #[[1]]#.", {QM_RED, QM_GREEN})});
                                                               // /*spanish*/ Según dicen, el #dragón de lava subterráneo# porta #[[1]]#.
 
     hintTextTable[RHT_FIRE_TEMPLE_GS_SONG_OF_TIME_ROOM] = HintText(CustomMessage("They say that #eight tiles of malice# guard a spider holding #[[1]]#.",
-                                                                      /*german*/ "",
+                                                                      /*german*/ "Man erzählt sich, daß #acht Kacheln der Arglist# eine Spinne bewachen würden, welche #[[1]]# besäße.",
                                                                       /*french*/ "Selon moi, une #Skulltula protégée par huit tuiles dans le Temple du Feu# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                    // /*spanish*/ Según dicen, #ocho baldosas de maldad# custodian una Skulltula que otorga #[[1]]#.
 
     hintTextTable[RHT_FIRE_TEMPLE_GS_BOSS_KEY_LOOP] = HintText(CustomMessage("They say that #five tiles of malice# guard a spider holding #[[1]]#.",
-                                                                  /*german*/ "",
+                                                                  /*german*/ "Man erzählt sich, daß #fünf Kacheln der Arglist# eine Spinne bewachen würden, welche #[[1]]# besäße.",
                                                                   /*french*/ "Selon moi, une #Skulltula protégée par cinq tuiles dans le Temple du Feu# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                // /*spanish*/ Según dicen, #cinco baldosas de maldad# custodian una Skulltula que otorga #[[1]]#.
 
     hintTextTable[RHT_FIRE_TEMPLE_GS_BOULDER_MAZE] = HintText(CustomMessage("They say that #explosives in a maze# unveil a spider hiding #[[1]]#.",
-                                                                 /*german*/ "",
+                                                                 /*german*/ "Man erzählt sich, daß #Explosives in einem Labyrinth# eine Spinne enthüllen würde, welche #[[1]]# verstecke.",
                                                                  /*french*/ "Selon moi, une #Skulltula derrière un mur fragile du Temple du Feu# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                               // /*spanish*/ Según dicen, los #explosivos en un laberinto# desvelan una Skulltula que otorga #[[1]]#.
 
     hintTextTable[RHT_FIRE_TEMPLE_GS_SCARECROW_TOP] = HintText(CustomMessage("They say that a #spider-friendly scarecrow# atop the Fire Temple hides #[[1]]#.",
-                                                                  /*german*/ "",
+                                                                  /*german*/ "Man erzählt sich, daß eine #spinnenfreundliche Vogelscheuche# auf der Spitze des Feuertempels #[[1]]# verstecke.",
                                                                   /*french*/ "Selon moi, une #Skulltula repérée par l'épouvantail du Temple du Feu# a #[[1]]#.", {QM_RED, QM_GREEN}),
                                                                // /*spanish*/ Según dicen, un #espantapájaros del Templo del Fuego# custodia una Skulltula que otorga #[[1]]#.
                                                                {}, {
                                                                CustomMessage("They say that a #spider-friendly scarecrow# atop a volcano hides #[[1]]#.",
-                                                                   /*german*/ "",
+                                                                   /*german*/ "Man erzählt sich, daß eine #spinnenfreundliche Vogelscheuche# auf der Spitze eines Vulkans #[[1]]# verstecke.",
                                                                    /*french*/ "Selon moi, une #Skulltula repérée par l'épouvantail du volcan# a #[[1]]#.", {QM_RED, QM_GREEN})});
                                                                 // /*spanish*/ Según dicen, un #espantapájaros en lo alto de un volcán# custodia una Skulltula que otorga #[[1]]#.
 
     hintTextTable[RHT_FIRE_TEMPLE_GS_SCARECROW_CLIMB] = HintText(CustomMessage("They say that a #spider-friendly scarecrow# atop the Fire Temple hides #[[1]]#.",
-                                                                    /*german*/ "",
+                                                                    /*german*/ "Man erzählt sich, daß eine #spinnenfreundliche Vogelscheuche# auf der der Spitze des Feuertempels #[[1]]# verstecke.",
                                                                     /*french*/ "Selon moi, une #Skulltula repérée par l'épouvantail du Temple du Feu# a #[[1]]#.", {QM_RED, QM_GREEN}),
                                                                  // /*spanish*/ Según dicen, un #espantapájaros del Templo del Fuego# custodia una Skulltula que otorga #[[1]]#.
                                                                  {}, {
                                                                  CustomMessage("They say that a #spider-friendly scarecrow# atop a volcano hides #[[1]]#.",
-                                                                     /*german*/ "",
+                                                                     /*german*/ "Man erzählt sich, daß eine #spinnenfreundliche Vogelscheuche# auf der Spitze eines Vulkans #[[1]]# verstecke.",
                                                                      /*french*/ "Selon moi, une #Skulltula repérée par l'épouvantail du volcan# a #[[1]]#.", {QM_RED, QM_GREEN})});
                                                                   // /*spanish*/ Según dicen, un #espantapájaros en lo alto de un volcán# custodia una Skulltula que otorga #[[1]]#.
 
     hintTextTable[RHT_FIRE_TEMPLE_MQ_GS_ABOVE_FIRE_WALL_MAZE] = HintText(CustomMessage("They say that a #spider above a fiery maze# holds #[[1]]#.",
-                                                                            /*german*/ "",
+                                                                            /*german*/ "Man erzählt sich, daß eine #Spinne oberhalb eines feurigen Labyrinths #[[1]]# besäße.",
                                                                             /*french*/ "Selon moi, une #Skulltula au dessus du labyrinthe enflammé du Temple du Feu# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                          // /*spanish*/ Según dicen, una #Skulltula sobre un ardiente laberinto# otorga #[[1]]#.
 
     hintTextTable[RHT_FIRE_TEMPLE_MQ_GS_FIRE_WALL_MAZE_CENTER] = HintText(CustomMessage("They say that a #spider within a fiery maze# holds #[[1]]#.",
-                                                                             /*german*/ "",
+                                                                             /*german*/ "Man erzählt sich, daß eine #Spinne innerhalb eines feurigen Labyrinths# #[[1]]# besäße.",
                                                                              /*french*/ "Selon moi, une #Skulltula dans le labyrinthe enflammé du Temple du Feu# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                           // /*spanish*/ Según dicen, una #Skulltula en el interior de un ardiente laberinto# otorga #[[1]]#.
 
     hintTextTable[RHT_FIRE_TEMPLE_MQ_GS_BIG_LAVA_ROOM_OPEN_DOOR] = HintText(CustomMessage("They say that a #Goron trapped near lava# befriended a spider with #[[1]]#.",
-                                                                               /*german*/ "",
+                                                                               /*german*/ "Man erzählt sich, daß ein #nahe der Lava gefangener Gorone# sich mit einer Spinne angefreundet hat, welche #[[1]]# besäße.",
                                                                                /*french*/ "Selon moi, une #Skulltula emprisonnée près du lac de lave du Temple du Feu# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                             // /*spanish*/ Según dicen, una #Skulltula amiga de un Goron atrapado junto a la lava# otorga #[[1]]#.
 
     hintTextTable[RHT_FIRE_TEMPLE_MQ_GS_FIRE_WALL_MAZE_SIDE_ROOM] = HintText(CustomMessage("They say that a #spider beside a fiery maze# holds #[[1]]#.",
-                                                                                /*german*/ "",
+                                                                                /*german*/ "Man erzählt sich, daß eine #Spinne neben einem feurigen Labyrinth# #[[1]]# besäße.",
                                                                                 /*french*/ "Selon moi, une #Skulltula près du labyrinthe enflammé du Temple du Feu# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                              // /*spanish*/ Según dicen, una #Skulltula junto a un ardiente laberinto# otorga #[[1]]#.
 
@@ -835,126 +835,126 @@ hintTextTable[RHT_FIRE_TEMPLE_NEAR_BOSS_CHEST] = HintText(CustomMessage("They sa
   |       WATER TEMPLE       |
   ---------------------------*/
     hintTextTable[RHT_WATER_TEMPLE_MAP_CHEST] = HintText(CustomMessage("They say that #rolling spikes# in the Water Temple surround #[[1]]#.",
-                                                            /*german*/ "",
+                                                            /*german*/ "Man erzählt sich, daß #rollende Stacheln# im Wassertempel #[[1]]# umgeben würden.",
                                                             /*french*/ "Selon moi, des #Spikes# dans le Temple de l'Eau entourent #[[1]]#.", {QM_RED, QM_GREEN}));
                                                          // /*spanish*/ Según dicen, unas #rodantes púas# del Templo del Agua guardan #[[1]]#.
 
     hintTextTable[RHT_WATER_TEMPLE_COMPASS_CHEST] = HintText(CustomMessage("They say that #roaming stingers in the Water Temple# guard #[[1]]#.",
-                                                                /*german*/ "",
+                                                                /*german*/ "Man erzählt sich, daß #umherstreifende Rochen im Wassertempel# #[[1]]# bewachen würden.",
                                                                 /*french*/ "Selon moi, des #raies dans le Temple de l'Eau# protègent #[[1]]#.", {QM_RED, QM_GREEN}));
                                                              // /*spanish*/ Según dicen, unos #errantes stingers# del Templo del Agua guardan #[[1]]#.
 
     hintTextTable[RHT_WATER_TEMPLE_TORCHES_CHEST] = HintText(CustomMessage("They say that #fire in the Water Temple# reveals #[[1]]#.",
-                                                                /*german*/ "",
+                                                                /*german*/ "Man erzählt sich, daß #Feuer im Wassertempel# #[[1]]# enthüllen würde.",
                                                                 /*french*/ "Selon moi, des #flammes dans le Temple de l'Eau# révèlent #[[1]]#.", {QM_RED, QM_GREEN}));
                                                              // /*spanish*/ Según dicen, el #fuego en el Templo del Agua# revela #[[1]]#.
 
     hintTextTable[RHT_WATER_TEMPLE_DRAGON_CHEST] = HintText(CustomMessage("They say that a #serpent's prize# in the Water Temple is #[[1]]#.",
-                                                               /*german*/ "",
+                                                               /*german*/ "Man erzählt sich, daß der #Preis einer Schlange# im Wassertempel #[[1]]# sei.",
                                                                /*french*/ "Selon moi, la #récompense du dragon submergé# est #[[1]]#.", {QM_RED, QM_GREEN}));
                                                             // /*spanish*/ Según dicen, el #escamado premio# del Templo del Agua se trata de #[[1]]#.
 
     hintTextTable[RHT_WATER_TEMPLE_CENTRAL_BOW_TARGET_CHEST] = HintText(CustomMessage("They say that #blinding an eye# in the Water Temple leads to #[[1]]#.",
-                                                                           /*german*/ "",
+                                                                           /*german*/ "Man erzählt sich, daß das #Erblinden eines Auges# im Wassertempel zu #[[1]]# führe.",
                                                                            /*french*/ "Selon moi, #l'oeil# du Temple de l'Eau voit #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                         // /*spanish*/ Según dicen, #cegar un ojo# del Templo del Agua conduce a #[[1]]#.
 
     hintTextTable[RHT_WATER_TEMPLE_CENTRAL_PILLAR_CHEST] = HintText(CustomMessage("They say that in the #depths of the Water Temple# lies #[[1]]#.",
-                                                                       /*german*/ "",
+                                                                       /*german*/ "Man erzählt sich, daß in den #Tiefen des Wassertempels# #[[1]]# läge.",
                                                                        /*french*/ "Selon moi, le #coeur du Temple de l'Eau# cache #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                     // /*spanish*/ Según dicen, en las #profundidades del Templo del Agua# yace #[[1]]#.
 
     hintTextTable[RHT_WATER_TEMPLE_CRACKED_WALL_CHEST] = HintText(CustomMessage("They say that #through a crack# in the Water Temple is #[[1]]#.",
-                                                                     /*german*/ "",
+                                                                     /*german*/ "Man erzählt sich, daß #in einem Spalt# im Wassertempel #[[1]]# sei.",
                                                                      /*french*/ "Selon moi, le #mur fragile# du Temple de l'Eau cache #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                   // /*spanish*/ Según dicen, tras una #agrietada pared# del Templo del Agua yace #[[1]]#.
 
     hintTextTable[RHT_WATER_TEMPLE_LONGSHOT_CHEST] = HintText(CustomMessage("They say that #Dark Link# guards #[[1]]#.",
-                                                                 /*german*/ "",
+                                                                 /*german*/ "Man erzählt sich, daß der #schwarze Link# #[[1]]# bewache.",
                                                                  /*french*/ "Selon moi, l'#Ombre de @# protège #[[1]]#.", {QM_RED, QM_GREEN}),
                                                               // /*spanish*/ Según dicen, #@ Oscuro# guarda #[[1]]#.
                                                               {}, {
                                                               CustomMessage("They say that #facing yourself# reveals #[[1]]#.",
-                                                                  /*german*/ "",
+                                                                  /*german*/ "Man erzählt sich, daß die #Konfrontation mit einem Selbst# #[[1]]# offenbare.",
                                                                   /*french*/ "Selon moi, se #vaincre soi-même# révèle #[[1]]#.", {QM_RED, QM_GREEN}),
                                                                // /*spanish*/ Según dicen, #luchar contra ti mismo# revela #[[1]]#.
                                                               CustomMessage("They say that a #dark reflection# of yourself guards #[[1]]#.",
-                                                                  /*german*/ "",
+                                                                  /*german*/ "Man erzählt sich, daß eine #dunkle Reflektion# von einem Selbst #[[1]]# bewache.",
                                                                   /*french*/ "Selon moi, son #propre reflet# cache #[[1]]#.", {QM_RED, QM_GREEN})});
                                                                // /*spanish*/ Según dicen, el #oscuro reflejo de ti mismo# guarda #[[1]]#.
 
     hintTextTable[RHT_WATER_TEMPLE_MQ_CENTRAL_PILLAR_CHEST] = HintText(CustomMessage("They say that in the #depths of the Water Temple# lies #[[1]]#.",
-                                                                          /*german*/ "",
+                                                                          /*german*/ "Man erzählt sich, daß in den #Tiefen des Wassertempels# #[[1]]# läge.",
                                                                           /*french*/ "Selon moi, le #coeur du Temple de l'Eau# cache #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                        // /*spanish*/ Según dicen, en las #profundidades del Templo del Agua# yace #[[1]]#.
 
     hintTextTable[RHT_WATER_TEMPLE_MQ_BOSS_KEY_CHEST] = HintText(CustomMessage("They say that fire in the Water Temple unlocks a #vast gate# revealing a chest with #[[1]]#.",
-                                                                    /*german*/ "",
+                                                                    /*german*/ "Man erzählt sich, daß Feuer im Wassertempel ein #großes Tor# entschlüssele, welches eine Truhe mit #[[1]]# offenbare.",
                                                                     /*french*/ "Selon moi, des #flammes au coeur du Temple de l'Eau# révèlent #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                  // /*spanish*/ Según dicen, el fuego en el Templo del Agua alza una #gran valla# con #[[1]]#.
 
     hintTextTable[RHT_WATER_TEMPLE_MQ_LONGSHOT_CHEST] = HintText(CustomMessage("They say that #through a crack# in the Water Temple is #[[1]]#.",
-                                                                    /*german*/ "",
+                                                                    /*german*/ "Man erzählt sich, daß #in einem Spalt# im Wassertempel #[[1]]# sei.",
                                                                     /*french*/ "Selon moi, le #mur fragile# du Temple de l'Eau cache #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                  // /*spanish*/ Según dicen, tras una #agrietada pared# del Templo del Agua yace #[[1]]#.
 
     hintTextTable[RHT_WATER_TEMPLE_MQ_COMPASS_CHEST] = HintText(CustomMessage("They say that #fire in the Water Temple# reveals #[[1]]#.",
-                                                                   /*german*/ "",
+                                                                   /*german*/ "Man erzählt sich, daß #Feuer im Wassertempel# #[[1]]# offenbare.",
                                                                    /*french*/ "Selon moi, des #flammes dans le Temple de l'Eau# révèlent #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                 // /*spanish*/ Según dicen, el #fuego en el Templo del Agua# revela #[[1]]#.
 
     hintTextTable[RHT_WATER_TEMPLE_MQ_MAP_CHEST] = HintText(CustomMessage("They say that #sparring soldiers# in the Water Temple guard #[[1]]#.",
-                                                               /*german*/ "",
+                                                               /*german*/ "Man erzählt sich, daß #sich duellierende Soldaten# im Wassertempel #[[1]]# bewachen würden.",
                                                                /*french*/ "Selon moi, les #soldats du Temple de l'Eau# protègent #[[1]]#.", {QM_RED, QM_GREEN}));
                                                             // /*spanish*/ Según dicen, #acabar con unos soldados# del Templo del Agua revela #[[1]]#.
 
     hintTextTable[RHT_WATER_TEMPLE_MORPHA_HEART] = HintText(CustomMessage("They say that #Morpha# holds #[[1]]#.",
-                                                               /*german*/ "",
+                                                               /*german*/ "Man erzählt sich, daß #Morpha# #[[1]]# besäße.",
                                                                /*french*/ "Selon moi, #Morpha# possède #[[1]]#.", {QM_RED, QM_GREEN}),
                                                             // /*spanish*/ Según dicen, #Morpha# porta #[[1]]#.
                                                             {}, {
                                                             CustomMessage("They say that the #Giant Aquatic Amoeba# holds #[[1]]#.",
-                                                                /*german*/ "",
+                                                                /*german*/ "Man erzählt sich, daß die #gigantische aquatische Amöbe# #[[1]]# besäße.",
                                                                 /*french*/ "Selon moi, l'#amibe aquatique géante# possède #[[1]]#.", {QM_RED, QM_GREEN})});
                                                              // /*spanish*/ Según dicen, la #ameba acuática gigante# porta #[[1]]#.
 
     hintTextTable[RHT_WATER_TEMPLE_GS_FALLING_PLATFORM_ROOM] = HintText(CustomMessage("They say that a #spider over a waterfall# in the Water Temple holds #[[1]]#.",
-                                                                           /*german*/ "",
+                                                                           /*german*/ "Man erzählt sich, daß eine #Spinne über einem Wasserfall# im Wassertempel #[[1]]# besäße.",
                                                                            /*french*/ "Selon moi, une #Skulltula au dessus d'une cascade du Temple de l'Eau# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                         // /*spanish*/ Según dicen, una #Skulltula tras una cascada# del Templo del Agua otorga #[[1]]#.
 
     hintTextTable[RHT_WATER_TEMPLE_GS_CENTRAL_PILLAR] = HintText(CustomMessage("They say that a #spider in the center of the Water Temple# holds #[[1]]#.",
-                                                                    /*german*/ "",
+                                                                    /*german*/ "Man erzählt sich, daß eine #Spinne im Zentrum des Wassertempels# #[[1]]# besäße.",
                                                                     /*french*/ "Selon moi, une #Skulltula au centre du Temple de l'Eau# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                  // /*spanish*/ Según dicen, una #Skulltula en el centro del Templo del Agua# otorga #[[1]]#.
 
     hintTextTable[RHT_WATER_TEMPLE_GS_NEAR_BOSS_KEY_CHEST] = HintText(CustomMessage("They say that a spider protected by #rolling boulders in the Water Temple# hides #[[1]]#.",
-                                                                         /*german*/ "",
+                                                                         /*german*/ "Man erzählt sich, daß eine Spinne, welche von #rollenden Felsbrocken im Wassertempel# geschützt werde, #[[1]]# verstecke.",
                                                                          /*french*/ "Selon moi, une #Skulltula derrière les rochers roulants du Temple de l'Eau# a #[[1]]#.", {QM_RED, QM_GREEN}),
                                                                       // /*spanish*/ Según dicen, una #Skulltula protegida por rocas rodantes# del Templo del Agua otorga #[[1]]#.
                                                                       {}, {
                                                                       CustomMessage("They say that a spider protected by #rolling boulders under the lake# hides #[[1]]#.",
-                                                                          /*german*/ "",
+                                                                          /*german*/ "Man erzählt sich, daß eine Spinne, welche von #rollenden Felsbrocken unterhalb eines Flusses# geschützt werde, #[[1]]# verstecke.",
                                                                           /*french*/ "Selon moi, une #Skulltula derrière les rochers roulants sous le lac# a #[[1]]#.", {QM_RED, QM_GREEN})});
                                                                        // /*spanish*/ Según dicen, una #Skulltula protegida por rocas rodantes# bajo el lago otorga #[[1]]#.
 
     hintTextTable[RHT_WATER_TEMPLE_GS_RIVER] = HintText(CustomMessage("They say that a #spider over a river# in the Water Temple holds #[[1]]#.",
-                                                           /*german*/ "",
+                                                           /*german*/ "Man erzählt sich, daß eine #Spinne über einem Fluß# im Wassertempel #[[1]]# besäße.",
                                                            /*french*/ "Selon moi, une #Skulltula au dessus de la rivière du Temple de l'Eau# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                         // /*spanish*/ Según dicen, una #Skulltula sobre un río# del Templo del Agua otorga #[[1]]#.
 
     hintTextTable[RHT_WATER_TEMPLE_MQ_GS_BEFORE_UPPER_WATER_SWITCH] = HintText(CustomMessage("They say that #beyond a pit of lizards# is a spider holding #[[1]]#.",
-                                                                                  /*german*/ "",
+                                                                                  /*german*/ "Man erzählt sich, daß #jenseits einer Reptiliengrube# eine Spinne sei, welche #[[1]]# besäße.",
                                                                                   /*french*/ "Selon moi, une #Skulltula près des lézards du Temple de l'Eau# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                                // /*spanish*/ Según dicen, #más allá de un pozo de reptiles# una Skulltula otorga #[[1]]#.
 
     hintTextTable[RHT_WATER_TEMPLE_MQ_GS_LIZALFOS_HALLWAY] = HintText(CustomMessage("They say that #lizards guard a spider# in the Water Temple with #[[1]]#.",
-                                                                         /*german*/ "",
+                                                                         /*german*/ "Man erzählt sich, daß #eine von Reptilien bewachte Spinne# im Wassertempel #[[1]]# besäße.",
                                                                          /*french*/ "Selon moi, une #Skulltula dans les couloirs croisés du Temple de l'Eau# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                       // /*spanish*/ Según dicen, unos #reptiles custodian una Skulltula# del Templo del Agua que otorga #[[1]]#.
 
     hintTextTable[RHT_WATER_TEMPLE_MQ_GS_RIVER] = HintText(CustomMessage("They say that a #spider over a river# in the Water Temple holds #[[1]]#.",
-                                                              /*german*/ "",
+                                                              /*german*/ "Man erzählt sich, daß eine #Spinne oberhalb eines Flusses# im Wassertempel #[[1]]# besäße.",
                                                               /*french*/ "Selon moi, une #Skulltula au dessus de la rivière du Temple de l'Eau# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                            // /*spanish*/ Según dicen, una #Skulltula sobre un río# del Templo del Agua otorga #[[1]]#.
 
@@ -962,232 +962,232 @@ hintTextTable[RHT_FIRE_TEMPLE_NEAR_BOSS_CHEST] = HintText(CustomMessage("They sa
   |      SPIRIT TEMPLE       |
   ---------------------------*/
  hintTextTable[RHT_SPIRIT_TEMPLE_CHILD_BRIDGE_CHEST] = HintText(CustomMessage("They say that a child conquers a #skull in green fire# in the Spirit Temple to reach #[[1]]#.",
-                                                                      /*german*/ "",
+                                                                      /*german*/ "Man erzählt sich, daß ein Kind einen #Schädel in grünem Feuer# im Geistertempel erobere, um #[[1]]# zu erreichen.",
                                                                       /*french*/ "Selon moi, le #crâne au halo vert dans le colosse# cache #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                    // /*spanish*/ Según dicen, el joven que #baje el puente# del Templo del Espíritu encontrará #[[1]]#.
 
     hintTextTable[RHT_SPIRIT_TEMPLE_CHILD_EARLY_TORCHES_CHEST] = HintText(CustomMessage("They say that a child can find a #caged chest# in the Spirit Temple with #[[1]]#.",
-                                                                             /*german*/ "",
+                                                                             /*german*/ "Man erzählt sich, daß ein Kind eine #gefangene Truhe# im Geistertempel finden könne, welche #[[1]]# enthielte.",
                                                                              /*french*/ "Selon moi, le #coffre embarré dans le colosse# contient #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                           // /*spanish*/ Según dicen, un joven puede encontrar un #cofre entre rejas# del Templo del Espíritu con #[[1]]#.
 
     hintTextTable[RHT_SPIRIT_TEMPLE_COMPASS_CHEST] = HintText(CustomMessage("They say that #across a pit of sand# in the Spirit Temple lies #[[1]]#.",
-                                                                 /*german*/ "",
+                                                                 /*german*/ "Man erzählt sich, daß #jenseits einer Sandgrube# im Geistertempel #[[1]]# läge.",
                                                                  /*french*/ "Selon moi, le #trou sableux dans le colosse# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                               // /*spanish*/ Según dicen, tras un #pozo de arena# del Templo del Espíritu yace #[[1]]#.
 
     hintTextTable[RHT_SPIRIT_TEMPLE_EARLY_ADULT_RIGHT_CHEST] = HintText(CustomMessage("They say that #dodging boulders to collect silver rupees# in the Spirit Temple yields #[[1]]#.",
-                                                                           /*german*/ "",
+                                                                           /*german*/ "Man erzählt sich, daß das #Ausweichen von Felsbrocken um silberne Rubine zu sammeln# im Geistertempel #[[1]]# einbrächte.",
                                                                            /*french*/ "Selon moi, les #pièces argentées entourées de rochers dans le colosse# révèlent #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                         // /*spanish*/ Según dicen, #esquivar rocas y conseguir plateadas rupias# en el Templo del Espíritu conduce a #[[1]]#.
 
     hintTextTable[RHT_SPIRIT_TEMPLE_FIRST_MIRROR_LEFT_CHEST] = HintText(CustomMessage("They say that a #shadow circling reflected light# in the Spirit Temple guards #[[1]]#.",
-                                                                           /*german*/ "",
+                                                                           /*german*/ "Man erzählt sich, daß ein #reflektierendes Licht umzirkelnder Schatten# im Geistertempel #[[1]]# bewachen würde.",
                                                                            /*french*/ "Selon moi, l'#ombre près d'un miroir# protège #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                         // /*spanish*/ Según dicen, un #círculo de reflectante luz# del Templo del Espíritu guarda #[[1]]#.
 
     hintTextTable[RHT_SPIRIT_TEMPLE_FIRST_MIRROR_RIGHT_CHEST] = HintText(CustomMessage("They say that a #shadow circling reflected light# in the Spirit Temple guards #[[1]]#.",
-                                                                            /*german*/ "",
+                                                                            /*german*/ "Man erzählt sich, daß ein #reflektierendes Licht umzirkelnder Schatten# im Geistertempel #[[1]]# bewachen würde.",
                                                                             /*french*/ "Selon moi, l'#ombre près d'un miroir# protège #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                          // /*spanish*/ Según dicen, un #círculo de reflectante luz# del Templo del Espíritu guarda #[[1]]#.
 
     hintTextTable[RHT_SPIRIT_TEMPLE_MAP_CHEST] = HintText(CustomMessage("They say that #before a giant statue# in the Spirit Temple lies #[[1]]#.",
-                                                             /*german*/ "",
+                                                             /*german*/ "Man erzählt sich, daß #vor einer riesigen Statue# im Geistertempel #[[1]]# läge.",
                                                              /*french*/ "Selon moi, #devant la statue# dans le colosse gît #[[1]]#.", {QM_RED, QM_GREEN}));
                                                           // /*spanish*/ Según dicen, #ante una gran estatua# del Templo del Espíritu aguarda #[[1]]#.
 
     hintTextTable[RHT_SPIRIT_TEMPLE_CHILD_CLIMB_NORTH_CHEST] = HintText(CustomMessage("They say that #lizards in the Spirit Temple# guard #[[1]]#.",
-                                                                           /*german*/ "",
+                                                                           /*german*/ "Man erzählt sich, daß #Reptilien im Geistertempel# #[[1]]# bewachen würden.",
                                                                            /*french*/ "Selon moi, les #lézards dans le colosse# protègent #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                         // /*spanish*/ Según dicen, los #reptiles del Templo del Espíritu# guardan #[[1]]#.
 
     hintTextTable[RHT_SPIRIT_TEMPLE_CHILD_CLIMB_EAST_CHEST] = HintText(CustomMessage("They say that #lizards in the Spirit Temple# guard #[[1]]#.",
-                                                                          /*german*/ "",
+                                                                          /*german*/ "Man erzählt sich, daß #Reptilien im Geistertempel# #[[1]]# bewachen würden.",
                                                                           /*french*/ "Selon moi, les #lézards dans le colosse# protègent #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                        // /*spanish*/ Según dicen, los #reptiles del Templo del Espíritu# guardan #[[1]]#.
 
     hintTextTable[RHT_SPIRIT_TEMPLE_SUN_BLOCK_ROOM_CHEST] = HintText(CustomMessage("They say that #torchlight among Beamos# in the Spirit Temple reveals #[[1]]#.",
-                                                                        /*german*/ "",
+                                                                        /*german*/ "Man erzählt sich, daß #Fackellicht inmitten von Strahlzyklopen# #[[1]]# enthüllen würde.",
                                                                         /*french*/ "Selon moi, les #torches autour des Sentinelles# éclairent #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                      // /*spanish*/ Según dicen, las #antorchas junto a Beamos# del Templo del Espíritu revelan #[[1]]#.
 
     hintTextTable[RHT_SPIRIT_TEMPLE_STATUE_ROOM_HAND_CHEST] = HintText(CustomMessage("They say that a #statue in the Spirit Temple# holds #[[1]]#.",
-                                                                          /*german*/ "",
+                                                                          /*german*/ "Man erzählt sich, daß eine #Statue im Geistertempel# #[[1]]# hielte.",
                                                                           /*french*/ "Selon moi, la #statue dans le colosse# tient #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                        // /*spanish*/ Según dicen, una #estatua del Templo del Espíritu# esconde #[[1]]#.
 
     hintTextTable[RHT_SPIRIT_TEMPLE_STATUE_ROOM_NORTHEAST_CHEST] = HintText(CustomMessage("They say that on a #ledge by a statue# in the Spirit Temple rests #[[1]]#.",
-                                                                               /*german*/ "",
+                                                                               /*german*/ "Man erzählt sich, daß auf einem #Vorsprung einer Statue# im Geistertempel #[[1]]# ruhe.",
                                                                                /*french*/ "Selon moi, #haut perché près de la statue# dans le colosse gît #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                             // /*spanish*/ Según dicen, al #borde de una estatua# del Templo del Espíritu yace #[[1]]#.
 
     hintTextTable[RHT_SPIRIT_TEMPLE_NEAR_FOUR_ARMOS_CHEST] = HintText(CustomMessage("They say that those who #show the light among statues# in the Spirit Temple find #[[1]]#.",
-                                                                         /*german*/ "",
+                                                                         /*german*/ "Man erzählt sich, daß jene, welche #das Licht inmitten von Statuen# im Geistertempel zeigen würden, #[[1]]# fänden.",
                                                                          /*french*/ "Selon moi, le #soleil près des statues# cache #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                       // /*spanish*/ Según dicen, aquellos que #iluminen ante las estatuas# del Templo del Espíritu encontrarán #[[1]]#.
 
     hintTextTable[RHT_SPIRIT_TEMPLE_HALLWAY_RIGHT_INVISIBLE_CHEST] = HintText(CustomMessage("They say that the #Eye of Truth in the Spirit Temple# reveals #[[1]]#.",
-                                                                                 /*german*/ "",
+                                                                                 /*german*/ "Man erzählt sich, daß das #Auge der Wahrheit im Geistertempel# #[[1]]# enthüllen würde.",
                                                                                  /*french*/ "Selon moi, le #trésor invisible près du Hache-Viande# contient #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                               // /*spanish*/ Según dicen, el #Ojo de la Verdad# en el Templo del Espíritu revela #[[1]]#.
 
     hintTextTable[RHT_SPIRIT_TEMPLE_HALLWAY_LEFT_INVISIBLE_CHEST] = HintText(CustomMessage("They say that the #Eye of Truth in the Spirit Temple# reveals #[[1]]#.",
-                                                                                /*german*/ "",
+                                                                                /*german*/ "Man erzählt sich, daß das #Auge der Wahrheit im Geistertempel# #[[1]]# enthüllen würde.",
                                                                                 /*french*/ "Selon moi, le #trésor invisible près du Hache-Viande# contient #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                              // /*spanish*/ Según dicen, el #Ojo de la Verdad# en el Templo del Espíritu revela #[[1]]#.
 
     hintTextTable[RHT_SPIRIT_TEMPLE_BOSS_KEY_CHEST] = HintText(CustomMessage("They say that a #chest engulfed in flame# in the Spirit Temple holds #[[1]]#.",
-                                                                  /*german*/ "",
+                                                                  /*german*/ "Man erzählt sich, daß eine #von Flammen eingehüllte Truhe# im Geistertempel #[[1]]# enthielte.",
                                                                   /*french*/ "Selon moi, le #coffre enflammé dans le colosse# contient #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                // /*spanish*/ Según dicen, un #cofre rodeado de llamas# del Templo del Espíritu contiene #[[1]]#.
 
     hintTextTable[RHT_SPIRIT_TEMPLE_TOPMOST_CHEST] = HintText(CustomMessage("They say that those who #show the light above the Colossus# find #[[1]]#.",
-                                                                 /*german*/ "",
+                                                                 /*german*/ "Man erzählt sich, daß jene, welche #das Licht auf dem Koloss# zeigen würden, #[[1]]# fänden.",
                                                                  /*french*/ "Selon moi, le #soleil au sommet du colosse# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
                                                               // /*spanish*/ Según dicen, aquellos que #iluminen en lo alto del Coloso# encontrarán #[[1]]#.
 
     hintTextTable[RHT_SPIRIT_TEMPLE_MQ_ENTRANCE_FRONT_LEFT_CHEST] = HintText(CustomMessage("They say that #lying unguarded# in the Spirit Temple is #[[1]]#.",
-                                                                                /*german*/ "",
+                                                                                /*german*/ "Man erzählt sich, daß #unbewacht liegend# im Geistertempel #[[1]]# sei.",
                                                                                 /*french*/ "Selon moi, dans #l'entrée du colosse# se trouve #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                              // /*spanish*/ Según dicen, en la #entrada del Templo del Espíritu# yace #[[1]]#.
 
     hintTextTable[RHT_SPIRIT_TEMPLE_MQ_ENTRANCE_BACK_RIGHT_CHEST] = HintText(CustomMessage("They say that a #switch in a pillar# within the Spirit Temple drops #[[1]]#.",
-                                                                                /*german*/ "",
+                                                                                /*german*/ "Man erzählt sich, daß ein #Schalter in einer Säule# innerhalb des Geistertempels #[[1]]# erbringe.",
                                                                                 /*french*/ "Selon moi, l'#interrupteur dans un pilier# du colosse cache #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                              // /*spanish*/ Según dicen, el #interruptor de un pilar# del Templo del Espíritu revela #[[1]]#.
 
     hintTextTable[RHT_SPIRIT_TEMPLE_MQ_ENTRANCE_FRONT_RIGHT_CHEST] = HintText(CustomMessage("They say that #collecting rupees through a water jet# reveals #[[1]]#.",
-                                                                                 /*german*/ "",
+                                                                                 /*german*/ "Man erzählt sich, daß das #Sammeln von Rubin durch einen Wasserstrom# #[[1]]# enthüllen würde.",
                                                                                  /*french*/ "Selon moi, les #pièces argentées dans le jet d'eau# du colosse révèlent #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                               // /*spanish*/ Según dicen, #hacerte con rupias tras un géiser# revela #[[1]]#.
 
     hintTextTable[RHT_SPIRIT_TEMPLE_MQ_ENTRANCE_BACK_LEFT_CHEST] = HintText(CustomMessage("They say that an #eye blinded by stone# within the Spirit Temple conceals #[[1]]#.",
-                                                                               /*german*/ "",
+                                                                               /*german*/ "Man erzählt sich, daß ein #durch einen Stein erblindetes Auge# im Geistertempel #[[1]]# verberge.",
                                                                                /*french*/ "Selon moi, #l'oeil derrière le rocher# dans le colosse voit #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                             // /*spanish*/ Según dicen, #cegar a un ojo# del Templo del Espíritu revela #[[1]]#.
 
     hintTextTable[RHT_SPIRIT_TEMPLE_MQ_MAP_CHEST] = HintText(CustomMessage("They say that surrounded by #fire and wrappings# lies #[[1]]#.",
-                                                                /*german*/ "",
+                                                                /*german*/ "Man erzählt sich, daß umgeben von #Feuer umhüllt# #[[1]]# läge.",
                                                                 /*french*/ "Selon moi, près des #pierres tombales dans le colosse# gît #[[1]]#.", {QM_RED, QM_GREEN}));
                                                              // /*spanish*/ Según dicen, rodeado de #fuego y vendas# yace #[[1]]#.
 
     hintTextTable[RHT_SPIRIT_TEMPLE_MQ_MAP_ROOM_ENEMY_CHEST] = HintText(CustomMessage("They say that a child defeats a #gauntlet of monsters# within the Spirit Temple to find #[[1]]#.",
-                                                                           /*german*/ "",
+                                                                           /*german*/ "Man erzählt sich, daß ein Kind eine #Herausforderung von Monstern# innerhalb des Geistertempels bewältige und #[[1]]# fände.",
                                                                            /*french*/ "Selon moi, l'enfant qui vainc #plusieurs monstres# dans le colosse trouvera #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                         // /*spanish*/ Según dicen, el joven que derrote #unos monstruos# del Templo del Espíritu encontrará #[[1]]#.
 
     hintTextTable[RHT_SPIRIT_TEMPLE_MQ_CHILD_CLIMB_NORTH_CHEST] = HintText(CustomMessage("They say that #explosive sunlight# within the Spirit Temple uncovers #[[1]]#.",
-                                                                              /*german*/ "",
+                                                                              /*german*/ "Man erzählt sich, daß #explosives Sonnenlicht# innerhalb des Geistertempels #[[1]]# enthüllen würde.",
                                                                               /*french*/ "Selon moi, le #rayon de lumière explosif dans le colosse# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                            // /*spanish*/ Según dicen, una #explosiva luz solar# del Templo del Espíritu revela #[[1]]#.
 
     hintTextTable[RHT_SPIRIT_TEMPLE_MQ_CHILD_CLIMB_SOUTH_CHEST] = HintText(CustomMessage("They say that #trapped by falling enemies# within the Spirit Temple is #[[1]]#.",
-                                                                              /*german*/ "",
+                                                                              /*german*/ "Man erzählt sich, daß sich #gefangen von fallenden Feinden# im Geistertempel #[[1]]# befände.",
                                                                               /*french*/ "Selon moi, des #ennemis tombants# dans le colosse protègent #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                            // /*spanish*/ Según dicen, #rodeado de enemigos del cielo# del Templo del Espíritu yace #[[1]]#.
 
     hintTextTable[RHT_SPIRIT_TEMPLE_MQ_COMPASS_CHEST] = HintText(CustomMessage("They say that #blinding the colossus# unveils #[[1]]#.",
-                                                                    /*german*/ "",
+                                                                    /*german*/ "Man erzählt sich, daß das #Erblinden des Kolosses# #[[1]]# offenbare.",
                                                                     /*french*/ "Selon moi, #l'oeil dans le colosse# voit #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                  // /*spanish*/ Según dicen, #cegar al coloso# revela #[[1]]#.
 
     hintTextTable[RHT_SPIRIT_TEMPLE_MQ_STATUE_ROOM_LULLABY_CHEST] = HintText(CustomMessage("They say that a #royal melody awakens the colossus# to reveal #[[1]]#.",
-                                                                                /*german*/ "",
+                                                                                /*german*/ "Man erzählt sich, daß eine #königliche Melodie den Koloss erwecke# und #[[1]]# enthüllen würde.",
                                                                                 /*french*/ "Selon moi, la #mélodie royale éveille le colosse# et révèle #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                              // /*spanish*/ Según dicen, la #melodía real que despierte al coloso# revelará #[[1]]#.
 
     hintTextTable[RHT_SPIRIT_TEMPLE_MQ_STATUE_ROOM_INVISIBLE_CHEST] = HintText(CustomMessage("They say that the #Eye of Truth# finds the colossus's hidden #[[1]]#.",
-                                                                                  /*german*/ "",
+                                                                                  /*german*/ "Man erzählt sich, daß das #Auge der Wahrheit# des Kolosses verborgene #[[1]]# fände.",
                                                                                   /*french*/ "Selon moi, #l'oeil de vérité# verra dans le colosse #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                                // /*spanish*/ Según dicen, el #Ojo de la Verdad# en el Templo del Espíritu encontrará #[[1]]#.
 
     hintTextTable[RHT_SPIRIT_TEMPLE_MQ_SILVER_BLOCK_HALLWAY_CHEST] = HintText(CustomMessage("They say that #the old hide what the young find# to reveal #[[1]]#.",
-                                                                                 /*german*/ "",
+                                                                                 /*german*/ "Man erzählt sich, daß #der Alte verstecke, was der Junge finde# und #[[1]]# enthüllt würde.",
                                                                                  /*french*/ "Selon moi, l'#oeil dans le trou du bloc argent# dans le colosse voit #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                               // /*spanish*/ Según dicen, el #adulto esconde lo que el joven anhela#, revelando #[[1]]#.
 
     hintTextTable[RHT_SPIRIT_TEMPLE_MQ_SUN_BLOCK_ROOM_CHEST] = HintText(CustomMessage("They say that #sunlight in a maze of fire# hides #[[1]]#.",
-                                                                           /*german*/ "",
+                                                                           /*german*/ "Man erzählt sich, daß #Sonnenlicht in einem Labyrinth aus Feuer# #[[1]]# verstecke.",
                                                                            /*french*/ "Selon moi, #la lumière dans le labyrinthe de feu# du colosse révèle #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                         // /*spanish*/ Según dicen, la #luz solar de un ígneo laberinto# esconde #[[1]]#.
 
     hintTextTable[RHT_SPIRIT_TEMPLE_MQ_LEEVER_ROOM_CHEST] = HintText(CustomMessage("They say that #across a pit of sand# in the Spirit Temple lies #[[1]]#.",
-                                                                        /*german*/ "",
+                                                                        /*german*/ "Man erzählt sich, daß #jenseits einer Sandgrube# im Geistertempel #[[1]]# läge.",
                                                                         /*french*/ "Selon moi, le #trou sableux# dans le colosse a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                      // /*spanish*/ Según dicen, #a través del pozo de arena# del Templo del Espíritu yace #[[1]]#.
 
     hintTextTable[RHT_SPIRIT_TEMPLE_MQ_BEAMOS_ROOM_CHEST] = HintText(CustomMessage("They say that where #temporal stone blocks the path# within the Spirit Temple lies #[[1]]#.",
-                                                                        /*german*/ "",
+                                                                        /*german*/ "Man erzählt sich, daß wo #zeitlicher Stein den Pfad blockiere# im Geistertempel #[[1]]# läge.",
                                                                         /*french*/ "Selon moi, les #pierres temporelles# dans le colosse cachent #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                      // /*spanish*/ Según dicen, donde los #bloques temporales bloquean# en el Templo del Espíritu yace #[[1]]#.
 
     hintTextTable[RHT_SPIRIT_TEMPLE_MQ_CHEST_SWITCH_CHEST] = HintText(CustomMessage("They say that a #chest of double purpose# holds #[[1]]#.",
-                                                                         /*german*/ "",
+                                                                         /*german*/ "Man erzählt sich, daß eine #Truhe mit doppeltem Zweck# #[[1]]# enthielte.",
                                                                          /*french*/ "Selon moi, le #coffre à usage double# du colosse contient #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                       // /*spanish*/ Según dicen, un #cofre de doble uso# contiene #[[1]]#.
 
     hintTextTable[RHT_SPIRIT_TEMPLE_MQ_BOSS_KEY_CHEST] = HintText(CustomMessage("They say that a #temporal stone blocks the light# leading to #[[1]]#.",
-                                                                     /*german*/ "",
+                                                                     /*german*/ "Man erzählt sich, daß ein #zeitlicher Stein das Licht blockiere#, was zu #[[1]]# führe.",
                                                                      /*french*/ "Selon moi, la #pierre temporelle# le colosse fait ombre sur #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                   // /*spanish*/ Según dicen, un #bloque temporal bloquea la luz# que conduce a #[[1]]#.
 
     hintTextTable[RHT_SPIRIT_TEMPLE_MQ_MIRROR_PUZZLE_INVISIBLE_CHEST] = HintText(CustomMessage("They say that those who #show the light above the Colossus# find #[[1]]#.",
-                                                                                    /*german*/ "",
+                                                                                    /*german*/ "Man erzählt sich, daß jene, welche #das Licht auf dem Koloss# zeigen würden, #[[1]]# fänden.",
                                                                                     /*french*/ "Selon moi, le trésor invisible #au sommet du colosse# contient #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                                  // /*spanish*/ Según dicen, aquellos que #revelen la luz sobre el Coloso# encontrarán #[[1]]#.
 
     hintTextTable[RHT_SPIRIT_TEMPLE_TWINROVA_HEART] = HintText(CustomMessage("They say that #Twinrova# holds #[[1]]#.",
-                                                                  /*german*/ "",
+                                                                  /*german*/ "Man erzählt sich, daß #Twinrova# #[[1]]# besäße.",
                                                                   /*french*/ "Selon moi, #Twinrova# possède #[[1]]#.", {QM_RED, QM_GREEN}),
                                                                // /*spanish*/ Según dicen, #Birova# porta #[[1]]#.
                                                                {}, {
                                                                CustomMessage("They say that the #Sorceress Sisters# hold #[[1]]#.",
-                                                                   /*german*/ "",
+                                                                   /*german*/ "Man erzählt sich, daß die #Hexenschwestern# #[[1]]# besäßen.",
                                                                    /*french*/ "Selon moi, #les sorcières jumelles# possède #[[1]]#.", {QM_RED, QM_GREEN})});
                                                                 // /*spanish*/ Según dicen, las #hermanas hechiceras# portan #[[1]]#.
 
     hintTextTable[RHT_SPIRIT_TEMPLE_GS_HALL_AFTER_SUN_BLOCK_ROOM] = HintText(CustomMessage("They say that a spider in the #hall of a knight# guards #[[1]]#.",
-                                                                                /*german*/ "",
+                                                                                /*german*/ "Man erzählt sich, daß eine Spinne in der #Halle eines Ritters# #[[1]]# bewache.",
                                                                                 /*french*/ "Selon moi, une #Skulltula au dessus d'un escalier du Temple de l'Esprit# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                              // /*spanish*/ Según dicen, una #Skulltula en el salón de un guerrero# otorga #[[1]]#.
 
     hintTextTable[RHT_SPIRIT_TEMPLE_GS_BOULDER_ROOM] = HintText(CustomMessage("They say that a #spider behind a temporal stone# in the Spirit Temple yields #[[1]]#.",
-                                                                   /*german*/ "",
+                                                                   /*german*/ "Man erzählt sich, daß eine #Spinne hinter einem zeitlichen Stein# im Geistertempel #[[1]]# einbrächte.",
                                                                    /*french*/ "Selon moi, une #Skulltula derrière une pierre temporelle du Temple de l'Esprit# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                 // /*spanish*/ Según dicen, una #Skulltula tras un bloque temporal# del Templo del Espíritu otorga #[[1]]#.
 
     hintTextTable[RHT_SPIRIT_TEMPLE_GS_LOBBY] = HintText(CustomMessage("They say that a #spider beside a statue# holds #[[1]]#.",
-                                                            /*german*/ "",
+                                                            /*german*/ "Man erzählt sich, daß eine #Spinne neben einer Statue# #[[1]]# besäße.",
                                                             /*french*/ "Selon moi, une #Skulltula dans la grande salle du Temple de l'Esprit# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                          // /*spanish*/ Según dicen, una #Skulltula junto a una estatua# del Templo del Espíritu otorga #[[1]]#.
 
     hintTextTable[RHT_SPIRIT_TEMPLE_GS_SUN_ON_FLOOR_ROOM] = HintText(CustomMessage("They say that a #spider at the top of a deep shaft# in the Spirit Temple holds #[[1]]#.",
-                                                                        /*german*/ "",
+                                                                        /*german*/ "Man erzählt sich, daß eine #Spinne auf der Spitze eines tiefen Stiels# im Geistertempel #[[1]]# besäße.",
                                                                         /*french*/ "Selon moi, une #Skulltula près d'un mur d'escalade du Temple de l'Esprit# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                      // /*spanish*/ Según dicen, una #Skulltula en lo alto de un gran hueco# del Templo del Espíritu otorga #[[1]]#.
 
     hintTextTable[RHT_SPIRIT_TEMPLE_GS_METAL_FENCE] = HintText(CustomMessage("They say that a child defeats a #spider among bats# in the Spirit Temple to gain #[[1]]#.",
-                                                                  /*german*/ "",
+                                                                  /*german*/ "Man erzählt sich, daß ein Kind #eine Spinne inmitten von Fledermäusen# im Geistertempel besiege und #[[1]]# erhielte.",
                                                                   /*french*/ "Selon moi, une #Skulltula sur le grillage du Temple de l'Esprit# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                // /*spanish*/ Según dicen, el joven que derrote la #Skulltula entre murciélagos# del Templo del Espíritu hallará #[[1]]#.
 
     hintTextTable[RHT_SPIRIT_TEMPLE_MQ_GS_LEEVER_ROOM] = HintText(CustomMessage("They say that #above a pit of sand# in the Spirit Temple hides #[[1]]#.",
-                                                                     /*german*/ "",
+                                                                     /*german*/ "Man erzählt sich, daß sich #oberhalb einer Sandgrube# im Geistertempel #[[1]]# verstecke.",
                                                                      /*french*/ "Selon moi, une #Skulltula au dessus du trou sableux du Temple de l'Esprit# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                   // /*spanish*/ Según dicen, una #Skulltula sobre un pozo de arena# del Templo del Espíritu otorga #[[1]]#.
 
     hintTextTable[RHT_SPIRIT_TEMPLE_MQ_GS_NINE_THRONES_ROOM_WEST] = HintText(CustomMessage("They say that a spider in the #hall of a knight# guards #[[1]]#.",
-                                                                                /*german*/ "",
+                                                                                /*german*/ "Man erzählt sich, daß eine Spinne in der #Halle eines Ritters# #[[1]]# bewache.",
                                                                                 /*french*/ "Selon moi, une #Skulltula dans la salle aux neuf trônes du Temple de l'Esprit# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                              // /*spanish*/ Según dicen, una #Skulltula en el salón de un guerrero# otorga #[[1]]#.
 
     hintTextTable[RHT_SPIRIT_TEMPLE_MQ_GS_NINE_THRONES_ROOM_NORTH] = HintText(CustomMessage("They say that a spider in the #hall of a knight# guards #[[1]]#.",
-                                                                                 /*german*/ "",
+                                                                                 /*german*/ "Man erzählt sich, daß eine Spinne in der #Halle eines Ritters# #[[1]]# bewache.",
                                                                                  /*french*/ "Selon moi, une #Skulltula dans la salle aux neuf trônes du Temple de l'Esprit# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                               // /*spanish*/ Según dicen, una #Skulltula en el salón de un guerrero# otorga #[[1]]#.
 
     hintTextTable[RHT_SPIRIT_TEMPLE_MQ_GS_SUN_BLOCK_ROOM] = HintText(CustomMessage("They say that #upon a web of glass# in the Spirit Temple sits a spider holding #[[1]]#.",
-                                                                        /*german*/ "",
+                                                                        /*german*/ "Man erzählt sich, daß #auf einer Webe aus Glas# im Geistertempel eine Spinne säße, welche #[[1]]# besäße.",
                                                                         /*french*/ "Selon moi, une #Skulltula sur une paroi de verre du Temple de l'Esprit# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                      // /*spanish*/ Según dicen, #sobre una plataforma de cristal# yace una Skulltula que otorga #[[1]]#.
 
@@ -1195,242 +1195,242 @@ hintTextTable[RHT_FIRE_TEMPLE_NEAR_BOSS_CHEST] = HintText(CustomMessage("They sa
   |      SHADOW TEMPLE       |
   ---------------------------*/
 hintTextTable[RHT_SHADOW_TEMPLE_MAP_CHEST] = HintText(CustomMessage("They say that the #Eye of Truth# pierces a hall of faces to reveal #[[1]]#.",
-                                                             /*german*/ "",
+                                                             /*german*/ "Man erzählt sich, daß das #Auge der Wahrheit# eine Halle der Gesichter durchdränge und #[[1]]# offenbaren würde.",
                                                              /*french*/ "Selon moi, l'#oeil de vérité# voit dans les couloirs du Temple de l'Ombre #[[1]]#.", {QM_RED, QM_GREEN}));
                                                           // /*spanish*/ Según dicen, el #Ojo de la Verdad# descubrirá un pasillo de facetas con #[[1]]#.
 
     hintTextTable[RHT_SHADOW_TEMPLE_HOVER_BOOTS_CHEST] = HintText(CustomMessage("They say that #Dead Hand in the Shadow Temple# holds #[[1]]#.",
-                                                                     /*german*/ "",
+                                                                     /*german*/ "Man erzählt sich, daß eine #tote Hand im Schattentempel# #[[1]]# hielte.",
                                                                      /*french*/ "Selon moi, le #Poigneur dans le Temple de l'Ombre# cache #[[1]]#.", {QM_RED, QM_GREEN}),
                                                                   // /*spanish*/ Según dicen, la #Mano Muerta del Templo de las Sombras# guarda #[[1]]#.
                                                                   {}, {
                                                                   CustomMessage("They say that a #nether dweller in the Shadow Temple# holds #[[1]]#.",
-                                                                      /*german*/ "",
+                                                                      /*german*/ "Man erzählt sich, daß ein #Bewohner der Unterwelt im Schattentempel# #[[1]]# besäße.",
                                                                       /*french*/ "Selon moi, le #spectre du Temple de l'Ombre# a #[[1]]#.", {QM_RED, QM_GREEN})});
                                                                    // /*spanish*/ Según dicen, un #temido morador del Templo de las Sombras# guarda #[[1]]#.
 
     hintTextTable[RHT_SHADOW_TEMPLE_COMPASS_CHEST] = HintText(CustomMessage("They say that #mummies revealed by the Eye of Truth# guard #[[1]]#.",
-                                                                 /*german*/ "",
+                                                                 /*german*/ "Man erzählt sich, daß #durch das Auge der Wahrheit offenbarte Mumien# #[[1]]# bewachen würden.",
                                                                  /*french*/ "Selon moi, les #Gibdos dans les couloirs# du Temple de l'Ombre protègent #[[1]]#.", {QM_RED, QM_GREEN}));
                                                               // /*spanish*/ Según dicen, las #momias reveladas por el Ojo de la Verdad# guardan #[[1]]#.
 
     hintTextTable[RHT_SHADOW_TEMPLE_EARLY_SILVER_RUPEE_CHEST] = HintText(CustomMessage("They say that #spinning scythes# protect #[[1]]#.",
-                                                                            /*german*/ "",
+                                                                            /*german*/ "Man erzählt sich, daß #rotierende Sensen# #[[1]]# schützen würden.",
                                                                             /*french*/ "Selon moi, les #faucheurs danseurs# du Temple de l'Ombre protègent #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                          // /*spanish*/ Según dicen, las #giratorias guadañas# protegen #[[1]]#.
 
     hintTextTable[RHT_SHADOW_TEMPLE_INVISIBLE_BLADES_VISIBLE_CHEST] = HintText(CustomMessage("They say that #invisible blades# guard #[[1]]#.",
-                                                                                  /*german*/ "",
+                                                                                  /*german*/ "Man erzählt sich, daß #unsichtbare Klingen# #[[1]]# bewachen würden.",
                                                                                   /*french*/ "Selon moi, les #faucheurs invisibles# du Temple de l'Ombre protègent #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                                // /*spanish*/ Según dicen, las #hojas invisibles# guardan #[[1]]#.
 
     hintTextTable[RHT_SHADOW_TEMPLE_INVISIBLE_BLADES_INVISIBLE_CHEST] = HintText(CustomMessage("They say that #invisible blades# guard #[[1]]#.",
-                                                                                    /*german*/ "",
+                                                                                    /*german*/ "Man erzählt sich, daß #unsichtbare Klingen# #[[1]]# bewachen würden.",
                                                                                     /*french*/ "Selon moi, les #faucheurs invisibles# du Temple de l'Ombre protègent #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                                  // /*spanish*/ Según dicen, las #hojas invisibles# guardan #[[1]]#.
 
     hintTextTable[RHT_SHADOW_TEMPLE_FALLING_SPIKES_LOWER_CHEST] = HintText(CustomMessage("They say that #falling spikes# block the path to #[[1]]#.",
-                                                                              /*german*/ "",
+                                                                              /*german*/ "Man erzählt sich, daß #fallende Stacheln# den Pfad zu #[[1]]# blockieren würden.",
                                                                               /*french*/ "Selon moi, la #pluie de clous# surplombe #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                            // /*spanish*/ Según dicen, los #pinchos de un techo# conducen a #[[1]]#.
 
     hintTextTable[RHT_SHADOW_TEMPLE_FALLING_SPIKES_UPPER_CHEST] = HintText(CustomMessage("They say that #falling spikes# block the path to #[[1]]#.",
-                                                                              /*german*/ "",
+                                                                              /*german*/ "Man erzählt sich, daß #fallende Stacheln# den Pfad zu #[[1]]# blockieren würden.",
                                                                               /*french*/ "Selon moi, la #pluie de clous# surplombe #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                            // /*spanish*/ Según dicen, los #pinchos de un techo# conducen a #[[1]]#.
 
     hintTextTable[RHT_SHADOW_TEMPLE_FALLING_SPIKES_SWITCH_CHEST] = HintText(CustomMessage("They say that #falling spikes# block the path to #[[1]]#.",
-                                                                               /*german*/ "",
+                                                                               /*german*/ "Man erzählt sich, daß #fallende Stacheln# den Pfad zu #[[1]]# blockieren würden.",
                                                                                /*french*/ "Selon moi, la #pluie de clous# surplombe #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                             // /*spanish*/ Según dicen, los #pinchos de un techo# conducen a #[[1]]#.
 
     hintTextTable[RHT_SHADOW_TEMPLE_INVISIBLE_SPIKES_CHEST] = HintText(CustomMessage("They say that the #dead roam among invisible spikes# guarding #[[1]]#.",
-                                                                          /*german*/ "",
+                                                                          /*german*/ "Man erzählt sich, daß #herumschweifende Tote inmitten von unsichtbaren Stacheln# #[[1]]# bewachen würden.",
                                                                           /*french*/ "Selon moi, #parmi les clous invisibles# du Temple de l'Ombre se cache #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                        // /*spanish*/ Según dicen, los #muertos que vagan por pinchos invisibles# protegen #[[1]]#.
 
     hintTextTable[RHT_SHADOW_TEMPLE_WIND_HINT_CHEST] = HintText(CustomMessage("They say that an #invisible chest guarded by the dead# holds #[[1]]#.",
-                                                                   /*german*/ "",
+                                                                   /*german*/ "Man erzählt sich, daß eine #von Toten bewachte unsichtbare Truhe# #[[1]]# enthielte.",
                                                                    /*french*/ "Selon moi, le #trésor invisible du cul-de-sac# du Temple de l'Ombre contient #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                 // /*spanish*/ Según dicen, un #cofre invisible custodiado por los del más allá# contiene #[[1]]#.
 
     hintTextTable[RHT_SHADOW_TEMPLE_AFTER_WIND_ENEMY_CHEST] = HintText(CustomMessage("They say that #mummies guarding a ferry# hide #[[1]]#.",
-                                                                          /*german*/ "",
+                                                                          /*german*/ "Man erzählt sich, daß #eine Fähre bewachende Mumien# #[[1]]# verstecken würden.",
                                                                           /*french*/ "Selon moi, les #Gibdos qui bloquent le traversier# cachent #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                        // /*spanish*/ Según dicen, las #momias que protegen un navío# esconden #[[1]]#.
 
     hintTextTable[RHT_SHADOW_TEMPLE_AFTER_WIND_HIDDEN_CHEST] = HintText(CustomMessage("They say that #mummies guarding a ferry# hide #[[1]]#.",
-                                                                           /*german*/ "",
+                                                                           /*german*/ "Man erzählt sich, daß #eine Fähre bewachende Mumien# #[[1]]# verstecken würden.",
                                                                            /*french*/ "Selon moi, les #Gibdos qui bloquent le traversier# cachent #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                         // /*spanish*/ Según dicen, las #momias que protegen un navío# esconden #[[1]]#.
 
     hintTextTable[RHT_SHADOW_TEMPLE_SPIKE_WALLS_LEFT_CHEST] = HintText(CustomMessage("They say that #walls consumed by a ball of fire# reveal #[[1]]#.",
-                                                                          /*german*/ "",
+                                                                          /*german*/ "Man erzählt sich, daß #von einem Feuerball verschlungende Wände# #[[1]]# offenbaren würden.",
                                                                           /*french*/ "Selon moi, le #piège de bois# du Temple de l'Ombre cache #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                        // /*spanish*/ Según dicen, las #paredes consumidas por una esfera ígnea# revelan #[[1]]#.
 
     hintTextTable[RHT_SHADOW_TEMPLE_BOSS_KEY_CHEST] = HintText(CustomMessage("They say that #walls consumed by a ball of fire# reveal #[[1]]#.",
-                                                                  /*german*/ "",
+                                                                  /*german*/ "Man erzählt sich, daß #von einem Feuerball verschlungende Wände# #[[1]]# offenbaren würden.",
                                                                   /*french*/ "Selon moi, le #piège de bois# du Temple de l'Ombre cache #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                // /*spanish*/ Según dicen, las #paredes consumidas por una esfera ígnea# revelan #[[1]]#.
 
     hintTextTable[RHT_SHADOW_TEMPLE_FREESTANDING_KEY] = HintText(CustomMessage("They say that #inside a burning skull# lies #[[1]]#.",
-                                                                    /*german*/ "",
+                                                                    /*german*/ "Man erzählt sich, daß #innerhalb eines brennenden Schädels# #[[1]]# läge.",
                                                                     /*french*/ "Selon moi, #dans un crâne enflammé# gît #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                  // /*spanish*/ Según dicen, en el #interior de una calavera en llamas# aguarda #[[1]]#.
 
     hintTextTable[RHT_SHADOW_TEMPLE_MQ_COMPASS_CHEST] = HintText(CustomMessage("They say that the #Eye of Truth# pierces a hall of faces to reveal #[[1]]#.",
-                                                                    /*german*/ "",
+                                                                    /*german*/ "Man erzählt sich, daß das #Auge der Wahrheit# eine Halle der Gesichter durchdränge und #[[1]]# offenbaren würde.",
                                                                     /*french*/ "Selon moi, l'#oeil de vérité# voit dans les couloirs du Temple de l'Ombre #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                  // /*spanish*/ Según dicen, el #Ojo de la Verdad# descubre un pasillo de facetas con #[[1]]#.
 
     hintTextTable[RHT_SHADOW_TEMPLE_MQ_HOVER_BOOTS_CHEST] = HintText(CustomMessage("They say that #Dead Hand in the Shadow Temple# holds #[[1]]#.",
-                                                                        /*german*/ "",
+                                                                        /*german*/ "Man erzählt sich, daß eine #tote Hand im Schattentempel# #[[1]]# hielte.",
                                                                         /*french*/ "Selon moi, le #Poigneur dans le Temple de l'Ombre# cache #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                      // /*spanish*/ Según dicen, la #Mano Muerta del Templo de las Sombras# guarda #[[1]]#.
 
     hintTextTable[RHT_SHADOW_TEMPLE_MQ_EARLY_GIBDOS_CHEST] = HintText(CustomMessage("They say that #mummies revealed by the Eye of Truth# guard #[[1]]#.",
-                                                                         /*german*/ "",
+                                                                         /*german*/ "Man erzählt sich, daß #durch das Auge der Wahrheit offenbarte Mumien# #[[1]]# bewachen würden.",
                                                                          /*french*/ "Selon moi, les #Gibdos dans les couloirs# du Temple de l'Ombre protègent #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                       // /*spanish*/ Según dicen, las #momias reveladas por el Ojo de la Verdad# guardan #[[1]]#.
 
     hintTextTable[RHT_SHADOW_TEMPLE_MQ_MAP_CHEST] = HintText(CustomMessage("They say that #spinning scythes# protect #[[1]]#.",
-                                                                /*german*/ "",
+                                                                /*german*/ "Man erzählt sich, daß #rotierende Sensen# #[[1]]# bewachen würden.",
                                                                 /*french*/ "Selon moi, les #faucheurs danseurs# du Temple de l'Ombre protègent #[[1]]#.", {QM_RED, QM_GREEN}));
                                                              // /*spanish*/ Según dicen, las #giratorias guadañas# protegen #[[1]]#.
 
     hintTextTable[RHT_SHADOW_TEMPLE_MQ_BEAMOS_SILVER_RUPEES_CHEST] = HintText(CustomMessage("They say that #collecting rupees in a vast cavern# with the Shadow Temple unveils #[[1]]#.",
-                                                                                 /*german*/ "",
+                                                                                 /*german*/ "Man erzählt sich, daß das #Sammeln von Rubinen in einer riesigen Kaverne# im Schattentempel #[[1]]# offenbaren würde.",
                                                                                  /*french*/ "Selon moi, les #pièces argentées dans le Temple de l'Ombre# révèlent #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                               // /*spanish*/ Según dicen, hacerte con las #rupias en una gran caverna# del Templo de las Sombras revela #[[1]]#.
 
     hintTextTable[RHT_SHADOW_TEMPLE_MQ_FALLING_SPIKES_SWITCH_CHEST] = HintText(CustomMessage("They say that #falling spikes# block the path to #[[1]]#.",
-                                                                                  /*german*/ "",
+                                                                                  /*german*/ "Man erzählt sich, daß #fallende Stachel# den Pfad zu #[[1]]# blockieren würden.",
                                                                                   /*french*/ "Selon moi, la #pluie de clous# surplombe #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                                // /*spanish*/ Según dicen, los #pinchos de un techo# conducen a #[[1]]#.
 
     hintTextTable[RHT_SHADOW_TEMPLE_MQ_FALLING_SPIKES_LOWER_CHEST] = HintText(CustomMessage("They say that #falling spikes# block the path to #[[1]]#.",
-                                                                                 /*german*/ "",
+                                                                                 /*german*/ "Man erzählt sich, daß #fallende Stachel# den Pfad zu #[[1]]# blockieren würden.",
                                                                                  /*french*/ "Selon moi, la #pluie de clous# surplombe #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                               // /*spanish*/ Según dicen, los #pinchos de un techo# conducen a #[[1]]#.
 
     hintTextTable[RHT_SHADOW_TEMPLE_MQ_FALLING_SPIKES_UPPER_CHEST] = HintText(CustomMessage("They say that #falling spikes# block the path to #[[1]]#.",
-                                                                                 /*german*/ "",
+                                                                                 /*german*/ "Man erzählt sich, daß #fallende Stachel# den Pfad zu #[[1]]# blockieren würden.",
                                                                                  /*french*/ "Selon moi, la #pluie de clous# surplombe #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                               // /*spanish*/ Según dicen, los #pinchos de un techo# conducen a #[[1]]#.
 
     hintTextTable[RHT_SHADOW_TEMPLE_MQ_INVISIBLE_SPIKES_CHEST] = HintText(CustomMessage("They say that the #dead roam among invisible spikes# guarding #[[1]]#.",
-                                                                             /*german*/ "",
+                                                                             /*german*/ "Man erzählt sich, daß #herumschweifende Tote inmitten von unsichtbaren Stacheln# #[[1]]# bewachen würden.",
                                                                              /*french*/ "Selon moi, #parmi les clous invisibles# du Temple de l'Ombre se cache #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                           // /*spanish*/ Según dicen, los #muertos que vagan por pinchos invisibles# protegen #[[1]]#.
 
     hintTextTable[RHT_SHADOW_TEMPLE_MQ_BOSS_KEY_CHEST] = HintText(CustomMessage("They say that #walls consumed by a ball of fire# reveal #[[1]]#.",
-                                                                     /*german*/ "",
+                                                                     /*german*/ "Man erzählt sich, daß #von einem Feuerball verschlungende Wände# #[[1]]# offenbaren würden.",
                                                                      /*french*/ "Selon moi, le #piège de bois# du Temple de l'Ombre cache #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                   // /*spanish*/ Según dicen, las #paredes consumidas por una esfera ígnea# revelan #[[1]]#.
 
     hintTextTable[RHT_SHADOW_TEMPLE_MQ_SPIKE_WALLS_LEFT_CHEST] = HintText(CustomMessage("They say that #walls consumed by a ball of fire# reveal #[[1]]#.",
-                                                                             /*german*/ "",
+                                                                             /*german*/ "Man erzählt sich, daß #von einem Feuerball verschlungende Wände# #[[1]]# offenbaren würden.",
                                                                              /*french*/ "Selon moi, le #piège de bois# du Temple de l'Ombre cache #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                           // /*spanish*/ Según dicen, las #paredes consumidas por una esfera ígnea# revelan #[[1]]#.
 
     hintTextTable[RHT_SHADOW_TEMPLE_MQ_STALFOS_ROOM_CHEST] = HintText(CustomMessage("They say that near an #empty pedestal# within the Shadow Temple lies #[[1]]#.",
-                                                                         /*german*/ "",
+                                                                         /*german*/ "Man erzählt sich, daß nahe einem #leeren Sockel# im Schattentempel #[[1]]# läge.",
                                                                          /*french*/ "Selon moi, #près d'un pédestal vide du Temple de l'Ombre# gît #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                       // /*spanish*/ Según dicen, cerca de un #vacío pedestal# del Templo de las Sombras yace #[[1]]#.
 
     hintTextTable[RHT_SHADOW_TEMPLE_MQ_INVISIBLE_BLADES_INVISIBLE_CHEST] = HintText(CustomMessage("They say that #invisible blades# guard #[[1]]#.",
-                                                                                       /*german*/ "",
+                                                                                       /*german*/ "Man erzählt sich, daß #unsichtbare Klingen# #[[1]]# bewachen würden.",
                                                                                        /*french*/ "Selon moi, les #faucheurs invisibles# du Temple de l'Ombre protègent #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                                     // /*spanish*/ Según dicen, unas #hojas invisibles# guardan #[[1]]#.
 
     hintTextTable[RHT_SHADOW_TEMPLE_MQ_INVISIBLE_BLADES_VISIBLE_CHEST] = HintText(CustomMessage("They say that #invisible blades# guard #[[1]]#.",
-                                                                                     /*german*/ "",
+                                                                                     /*german*/ "Man erzählt sich, daß #unsichtbare Klingen# #[[1]]# bewachen würden.",
                                                                                      /*french*/ "Selon moi, les #faucheurs invisibles# du Temple de l'Ombre protègent #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                                   // /*spanish*/ Según dicen, unas #hojas invisibles# guardan #[[1]]#.
 
     hintTextTable[RHT_SHADOW_TEMPLE_MQ_WIND_HINT_CHEST] = HintText(CustomMessage("They say that an #invisible chest guarded by the dead# holds #[[1]]#.",
-                                                                      /*german*/ "",
+                                                                      /*german*/ "Man erzählt sich, daß eine #von Toten bewachte unsichtbare Truhe# #[[1]]# enthielte.",
                                                                       /*french*/ "Selon moi, le #trésor invisible du cul-de-sac# du Temple de l'Ombre contient #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                    // /*spanish*/ Según dicen, un #cofre invisible custodiado por los del más allá# contiene #[[1]]#.
 
     hintTextTable[RHT_SHADOW_TEMPLE_MQ_AFTER_WIND_HIDDEN_CHEST] = HintText(CustomMessage("They say that #mummies guarding a ferry# hide #[[1]]#.",
-                                                                              /*german*/ "",
+                                                                              /*german*/ "Man erzählt sich, daß #eine Fähre bewachende Mumien# #[[1]]# verstecken würden.",
                                                                               /*french*/ "Selon moi, les #Gibdos qui bloquent le traversier# cachent #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                            // /*spanish*/ Según dicen, las #momias que protegen un navío# esconden #[[1]]#.
 
     hintTextTable[RHT_SHADOW_TEMPLE_MQ_AFTER_WIND_ENEMY_CHEST] = HintText(CustomMessage("They say that #mummies guarding a ferry# hide #[[1]]#.",
-                                                                             /*german*/ "",
+                                                                             /*german*/ "Man erzählt sich, daß #eine Fähre bewachende Mumien# #[[1]]# verstecken würden.",
                                                                              /*french*/ "Selon moi, les #Gibdos qui bloquent le traversier# cachent #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                           // /*spanish*/ Según dicen, las #momias que protegen un navío# esconden #[[1]]#.
 
     hintTextTable[RHT_SHADOW_TEMPLE_MQ_NEAR_SHIP_INVISIBLE_CHEST] = HintText(CustomMessage("They say that #caged near a ship# lies #[[1]]#.",
-                                                                                /*german*/ "",
+                                                                                /*german*/ "Man erzählt sich, daß #in der Nähe eines Schiffes eingesperrt# #[[1]]# läge.",
                                                                                 /*french*/ "Selon moi, #dans une cage près du traversier# gît #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                              // /*spanish*/ Según dicen, #entre rejas al lado de un navío# yace #[[1]]#.
 
     hintTextTable[RHT_SHADOW_TEMPLE_MQ_FREESTANDING_KEY] = HintText(CustomMessage("They say that #behind three burning skulls# lies #[[1]]#.",
-                                                                       /*german*/ "",
+                                                                       /*german*/ "Man erzählt sich, daß #hinter drei brennenden Schädeln# #[[1]]# läge.",
                                                                        /*french*/ "Selon moi, #derrière trois crânes enflammés# gît #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                     // /*spanish*/ Según dicen, tras #tres ardientes calaveras# yace #[[1]]#.
 
     hintTextTable[RHT_SHADOW_TEMPLE_BONGO_BONGO_HEART] = HintText(CustomMessage("They say that #Bongo Bongo# holds #[[1]]#.",
-                                                                     /*german*/ "",
+                                                                     /*german*/ "Man erzählt sich, daß #Bongo Bongo# #[[1]]# besäße.",
                                                                      /*french*/ "Selon moi, #Bongo Bongo# possède #[[1]]#.", {QM_RED, QM_GREEN}),
                                                                   // /*spanish*/ Según dicen, #Bongo Bongo# porta #[[1]]#.
                                                                   {}, {
                                                                   CustomMessage("They say that the #Phantom Shadow Beast# holds #[[1]]#.",
-                                                                      /*german*/ "",
+                                                                      /*german*/ "Man erzählt sich, daß das #Phantomschattenbiest# #[[1]]# besäße.",
                                                                       /*french*/ "Selon moi, le #monstre de l'ombre# possède #[[1]]#.", {QM_RED, QM_GREEN})});
                                                                    // /*spanish*/ Según dicen, la #alimaña oscura espectral# porta #[[1]]#.
 
     hintTextTable[RHT_SHADOW_TEMPLE_GS_SINGLE_GIANT_POT] = HintText(CustomMessage("They say that #beyond a burning skull# lies a spider with #[[1]]#.",
-                                                                       /*german*/ "",
+                                                                       /*german*/ "Man erzählt sich, daß #jenseits eines brennenden Schädels# eine Spinne läge, welche #[[1]]# besäße.",
                                                                        /*french*/ "Selon moi, une #Skulltula derrière un crâne enflammé du Temple de l'Ombre# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                     // /*spanish*/ Según dicen, #tras una ardiente calavera# yace una Skulltula que otorga #[[1]]#.
 
     hintTextTable[RHT_SHADOW_TEMPLE_GS_FALLING_SPIKES_ROOM] = HintText(CustomMessage("They say that a #spider beyond falling spikes# holds #[[1]]#.",
-                                                                          /*german*/ "",
+                                                                          /*german*/ "Man erzählt sich, daß eine #Spinne jenseits fallender Stacheln# #[[1]]# besäße.",
                                                                           /*french*/ "Selon moi, une #Skulltula au delà de la pluie de clous du Temple de l'Ombre# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                        // /*spanish*/ Según dicen, una #Skulltula tras los pinchos del techo# otorga #[[1]]#.
 
     hintTextTable[RHT_SHADOW_TEMPLE_GS_TRIPLE_GIANT_POT] = HintText(CustomMessage("They say that #beyond three burning skulls# lies a spider with #[[1]]#.",
-                                                                       /*german*/ "",
+                                                                       /*german*/ "Man erzählt sich, daß #jenseits drei brennender Schädel# eine Spinne läge, welche #[[1]]# besäße.",
                                                                        /*french*/ "Selon moi, une #Skulltula derrière trois crânes enflammés du Temple de l'Ombre# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                     // /*spanish*/ Según dicen, #tras tres ardientes calaveras# yace una Skulltula que otorga #[[1]]#.
 
     hintTextTable[RHT_SHADOW_TEMPLE_GS_LIKE_LIKE_ROOM] = HintText(CustomMessage("They say that a spider guarded by #invisible blades# holds #[[1]]#.",
-                                                                     /*german*/ "",
+                                                                     /*german*/ "Man erzählt sich, daß eine Spinne von #unsichtbaren Klingen# bewacht werde und #[[1]]# besäße.",
                                                                      /*french*/ "Selon moi, une #Skulltula protégée par les faucheurs invisibles du Temple de l'Ombre# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                   // /*spanish*/ Según dicen, una #Skulltula custodiada por hojas invisibles# otorga #[[1]]#.
 
     hintTextTable[RHT_SHADOW_TEMPLE_GS_NEAR_SHIP] = HintText(CustomMessage("They say that a spider near a #docked ship# hoards #[[1]]#.",
-                                                                /*german*/ "",
+                                                                /*german*/ "Man erzählt sich, daß eine Spinne nahe eines #geankerten Schiffs# #[[1]]# horte.",
                                                                 /*french*/ "Selon moi, une #Skulltula près du traversier du Temple de l'Ombre# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                              // /*spanish*/ Según dicen, una #Skulltula cercana a un navío# otorga #[[1]]#.
 
     hintTextTable[RHT_SHADOW_TEMPLE_MQ_GS_FALLING_SPIKES_ROOM] = HintText(CustomMessage("They say that a #spider beyond falling spikes# holds #[[1]]#.",
-                                                                             /*german*/ "",
+                                                                             /*german*/ "Man erzählt sich, daß eine #Spinne jenseits fallender Stacheln# #[[1]]# besäße.",
                                                                              /*french*/ "Selon moi, une #Skulltula au delà de la pluie de clous du Temple de l'Ombre# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                           // /*spanish*/ Según dicen, una #Skulltula tras los pinchos del techo# otorga #[[1]]#.
 
     hintTextTable[RHT_SHADOW_TEMPLE_MQ_GS_WIND_HINT_ROOM] = HintText(CustomMessage("They say that a #spider amidst roaring winds# in the Shadow Temple holds #[[1]]#.",
-                                                                        /*german*/ "",
+                                                                        /*german*/ "Man erzählt sich, daß eine #Spinne inmitten stürmischer Winde# im Schattentempel #[[1]]# besäße.",
                                                                         /*french*/ "Selon moi, une #Skulltula près des vents du Temple de l'Ombre# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                      // /*spanish*/ Según dicen, una #Skulltula entre ventarrones# del Templo de las Sombras otorga #[[1]]#.
 
     hintTextTable[RHT_SHADOW_TEMPLE_MQ_GS_AFTER_WIND] = HintText(CustomMessage("They say that a #spider beneath gruesome debris# in the Shadow Temple hides #[[1]]#.",
-                                                                    /*german*/ "",
+                                                                    /*german*/ "Man erzählt sich, daß eine #Spinne unterhalb grauenvoller Trümmer# im Schattentempel #[[1]]# verstecke.",
                                                                     /*french*/ "Selon moi, une #Skulltula sous des débris du Temple de l'Ombre# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                  // /*spanish*/ Según dicen, una #Skulltula bajo unos horripilantes escombros# del Templo de las Sombras otorga #[[1]]#.
 
     hintTextTable[RHT_SHADOW_TEMPLE_MQ_GS_AFTER_SHIP] = HintText(CustomMessage("They say that a #fallen statue# reveals a spider with #[[1]]#.",
-                                                                    /*german*/ "",
+                                                                    /*german*/ "Man erzählt sich, daß eine #fallende Statue# eine Spinne enthülle, welche #[[1]]# besäße.",
                                                                     /*french*/ "Selon moi, une #Skulltula près de la statue écroulée du Temple de l'Ombre# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                  // /*spanish*/ Según dicen, una #estatua caída# revelará una Skulltula que otorgue #[[1]]#.
 
     hintTextTable[RHT_SHADOW_TEMPLE_MQ_GS_NEAR_BOSS] = HintText(CustomMessage("They say that a #suspended spider# guards #[[1]]#.",
-                                                                   /*german*/ "",
+                                                                   /*german*/ "Man erzählt sich, daß eine #hängende Spinne# #[[1]]# bewache.",
                                                                    /*french*/ "Selon moi, une #Skulltula près du repère du Temple de l'Ombre# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                 // /*spanish*/ Según dicen, una #Skulltula flotante# del Templo de las Sombras otorga #[[1]]#.
 
@@ -1438,117 +1438,117 @@ hintTextTable[RHT_SHADOW_TEMPLE_MAP_CHEST] = HintText(CustomMessage("They say th
   |    BOTTOM OF THE WELL    |
   ---------------------------*/
     hintTextTable[RHT_BOTTOM_OF_THE_WELL_FRONT_LEFT_FAKE_WALL_CHEST] = HintText(CustomMessage("They say that the #Eye of Truth in the well# reveals #[[1]]#.",
-                                                                                   /*german*/ "",
+                                                                                   /*german*/ "Man erzählt sich, daß das #Auge der Wahrheit im Brunnen# #[[1]]# offenbare.",
                                                                                    /*french*/ "Selon moi, l'#oeil de vérité dans le Puits# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                                 // /*spanish*/ Según dicen, el #Ojo de la Verdad en el pozo# revela #[[1]]#.
 
     hintTextTable[RHT_BOTTOM_OF_THE_WELL_FRONT_CENTER_BOMBABLE_CHEST] = HintText(CustomMessage("They say that #gruesome debris# in the well hides #[[1]]#.",
-                                                                                    /*german*/ "",
+                                                                                    /*german*/ "Man erzählt sich, daß #grauenvolle Trümmer# im Brunnen #[[1]]# verbergen würden.",
                                                                                     /*french*/ "Selon moi, des #débris dans le Puits# cachent #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                                  // /*spanish*/ Según dicen, unos #horripilantes escombros# del pozo esconden #[[1]]#.
 
     hintTextTable[RHT_BOTTOM_OF_THE_WELL_RIGHT_BOTTOM_FAKE_WALL_CHEST] = HintText(CustomMessage("They say that the #Eye of Truth in the well# reveals #[[1]]#.",
-                                                                                     /*german*/ "",
+                                                                                     /*german*/ "Man erzählt sich, daß das #Auge der Wahrheit im Brunnen# #[[1]]# offenbare.",
                                                                                      /*french*/ "Selon moi, l'#oeil de vérité dans le Puits# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                                   // /*spanish*/ Según dicen, el #Ojo de la Verdad en el pozo# revela #[[1]]#.
 
     hintTextTable[RHT_BOTTOM_OF_THE_WELL_COMPASS_CHEST] = HintText(CustomMessage("They say that a #hidden entrance to a cage# in the well leads to #[[1]]#.",
-                                                                      /*german*/ "",
+                                                                      /*german*/ "Man erzählt sich, daß ein #verborgener Eingang zu einem Käfig# im Brunnen zu #[[1]]# führe.",
                                                                       /*french*/ "Selon moi, dans un #chemin caché dans le Puits# gît #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                    // /*spanish*/ Según dicen, la #entrada oculta de una celda# del pozo conduce a #[[1]]#.
 
     hintTextTable[RHT_BOTTOM_OF_THE_WELL_CENTER_SKULLTULA_CHEST] = HintText(CustomMessage("They say that a #spider guarding a cage# in the well protects #[[1]]#.",
-                                                                               /*german*/ "",
+                                                                               /*german*/ "Man erzählt sich, daß eine #einen Käfig schützende Spinne# im Brunnen #[[1]]# schütze.",
                                                                                /*french*/ "Selon moi, l'#araignée dans la cage du Puits# protège #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                             // /*spanish*/ Según dicen, una #araña protegiendo una celda# del pozo guarda #[[1]]#.
 
     hintTextTable[RHT_BOTTOM_OF_THE_WELL_BACK_LEFT_BOMBABLE_CHEST] = HintText(CustomMessage("They say that #gruesome debris# in the well hides #[[1]]#.",
-                                                                                 /*german*/ "",
+                                                                                 /*german*/ "Man erzählt sich, daß #grauenvolle Trümmer# im Brunnen #[[1]]# verbergen würde.",
                                                                                  /*french*/ "Selon moi, des #débris dans le Puits# cachent #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                               // /*spanish*/ Según dicen, unos #horripilantes escombros# del pozo esconden #[[1]]#.
 
     hintTextTable[RHT_BOTTOM_OF_THE_WELL_INVISIBLE_CHEST] = HintText(CustomMessage("They say that #Dead Hand's invisible secret# is #[[1]]#.",
-                                                                        /*german*/ "",
+                                                                        /*german*/ "Man erzählt sich, daß das #unsichtbare Geheimnis der toten Hand# #[[1]]# sei.",
                                                                         /*french*/ "Selon moi, le #trésor invisible du Poigneur# est #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                      // /*spanish*/ Según dicen, el #secreto invisible de la Mano Muerta# esconde #[[1]]#.
 
     hintTextTable[RHT_BOTTOM_OF_THE_WELL_UNDERWATER_FRONT_CHEST] = HintText(CustomMessage("They say that a #royal melody in the well# uncovers #[[1]]#.",
-                                                                               /*german*/ "",
+                                                                               /*german*/ "Man erzählt sich, daß eine #königliche Melodie im Brunnen# #[[1]]# enthüllen würde.",
                                                                                /*french*/ "Selon moi, la #mélodie royale révèle dans le Puits# #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                             // /*spanish*/ Según dicen, una #melodía real en el pozo# revela #[[1]]#.
 
     hintTextTable[RHT_BOTTOM_OF_THE_WELL_UNDERWATER_LEFT_CHEST] = HintText(CustomMessage("They say that a #royal melody in the well# uncovers #[[1]]#.",
-                                                                              /*german*/ "",
+                                                                              /*german*/ "Man erzählt sich, daß eine #königliche Melodie im Brunnen# #[[1]]# enthüllen würde.",
                                                                               /*french*/ "Selon moi, la #mélodie royale révèle dans le Puits# #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                            // /*spanish*/ Según dicen, una #melodía real en el pozo# revela #[[1]]#.
 
     hintTextTable[RHT_BOTTOM_OF_THE_WELL_MAP_CHEST] = HintText(CustomMessage("They say that in the #depths of the well# lies #[[1]]#.",
-                                                                  /*german*/ "",
+                                                                  /*german*/ "Man erzählt sich, daß in den #Tiefen des Brunnens# #[[1]]# läge.",
                                                                   /*french*/ "Selon moi, #dans le coeur du Puits# gît #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                // /*spanish*/ Según dicen, en las #profundidades del pozo# yace #[[1]]#.
 
     hintTextTable[RHT_BOTTOM_OF_THE_WELL_FIRE_KEESE_CHEST] = HintText(CustomMessage("They say that #perilous pits# in the well guard the path to #[[1]]#.",
-                                                                         /*german*/ "",
+                                                                         /*german*/ "Man erzählt sich, daß #gefährliche Gruben# im Brunnen den Pfad zu #[[1]]# bewachen würden.",
                                                                          /*french*/ "Selon moi, #trois trous# dans le Puits protègent #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                       // /*spanish*/ Según dicen, #peligrosos fosos# del pozo conducen a #[[1]]#.
 
     hintTextTable[RHT_BOTTOM_OF_THE_WELL_LIKE_LIKE_CHEST] = HintText(CustomMessage("They say that #locked in a cage# in the well lies #[[1]]#.",
-                                                                        /*german*/ "",
+                                                                        /*german*/ "Man erzählt sich, daß #in einem Käfig eingeschlossen# im Brunnen #[[1]]# läge.",
                                                                         /*french*/ "Selon moi, #dans une cage# du Puits gît #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                      // /*spanish*/ Según dicen, #entre rejas# en el pozo yace #[[1]]#.
 
     hintTextTable[RHT_BOTTOM_OF_THE_WELL_FREESTANDING_KEY] = HintText(CustomMessage("They say that #inside a coffin# hides #[[1]]#.",
-                                                                         /*german*/ "",
+                                                                         /*german*/ "Man erzählt sich, daß #in einem Sarg# #[[1]]# verborgen läge.",
                                                                          /*french*/ "Selon moi, dans #un cercueil# gît #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                       // /*spanish*/ Según dicen, en el #interior de un ataúd# yace #[[1]]#.
 
     hintTextTable[RHT_BOTTOM_OF_THE_WELL_MQ_MAP_CHEST] = HintText(CustomMessage("They say that a #royal melody in the well# uncovers #[[1]]#.",
-                                                                     /*german*/ "",
+                                                                     /*german*/ "Man erzählt sich, daß eine #königliche Melodie im Brunnen# #[[1]]# enthüllen würde.",
                                                                      /*french*/ "Selon moi, la #mélodie royale révèle dans le Puits# #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                   // /*spanish*/ Según dicen, una #melodía real en el pozo# revela #[[1]]#.
 
     hintTextTable[RHT_BOTTOM_OF_THE_WELL_MQ_LENS_OF_TRUTH_CHEST] = HintText(CustomMessage("They say that an #army of the dead# in the well guards #[[1]]#.",
-                                                                               /*german*/ "",
+                                                                               /*german*/ "Man erzählt sich, daß eine #Armee der Toten# im Brunnen #[[1]]# bewachen würde.",
                                                                                /*french*/ "Selon moi, l'#armée des morts# dans le Puits protège #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                             // /*spanish*/ Según dicen, un #ejército del más allá# del pozo guarda #[[1]]#.
 
     hintTextTable[RHT_BOTTOM_OF_THE_WELL_MQ_DEAD_HAND_FREESTANDING_KEY] = HintText(CustomMessage("They say that #Dead Hand's explosive secret# is #[[1]]#.",
-                                                                                      /*german*/ "",
+                                                                                      /*german*/ "Man erzählt sich, daß das #explosive Geheimnis der toten Hand# #[[1]]# sei.",
                                                                                       /*french*/ "Selon moi, le #secret explosif du Poigneur# est #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                                    // /*spanish*/ Según dicen, el #explosivo secreto de la Mano Muerta# esconde #[[1]]#.
 
     hintTextTable[RHT_BOTTOM_OF_THE_WELL_MQ_EAST_INNER_ROOM_FREESTANDING_KEY] = HintText(CustomMessage("They say that an #invisible path in the well# leads to #[[1]]#.",
-                                                                                            /*german*/ "",
+                                                                                            /*german*/ "Man erzählt sich, daß ein #unsichtbarer Pfad im Brunnen# zu #[[1]]# führe.",
                                                                                             /*french*/ "Selon moi, dans un #chemin caché dans le Puits# gît #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                                          // /*spanish*/ Según dicen, un #camino invisible del pozo# conduce a #[[1]]#.
 
     hintTextTable[RHT_BOTTOM_OF_THE_WELL_GS_LIKE_LIKE_CAGE] = HintText(CustomMessage("They say that a #spider locked in a cage# in the well holds #[[1]]#.",
-                                                                          /*german*/ "",
+                                                                          /*german*/ "Man erzählt sich, daß eine #in einem Käfig eingeschlossene Spinne# im Brunnen #[[1]]# besäße.",
                                                                           /*french*/ "Selon moi, une #Skulltula dans une cage au fonds du Puits# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                        // /*spanish*/ Según dicen, una #Skulltula enjaulada# del pozo otorga #[[1]]#.
 
     hintTextTable[RHT_BOTTOM_OF_THE_WELL_GS_EAST_INNER_ROOM] = HintText(CustomMessage("They say that an #invisible path in the well# leads to #[[1]]#.",
-                                                                           /*german*/ "",
+                                                                           /*german*/ "Man erzählt sich, daß ein #unsichtbarer Pfad im Brunnen# zu #[[1]]# führe.",
                                                                            /*french*/ "Selon moi, une #Skulltula dans le chemin invisible au fonds du Puits# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                         // /*spanish*/ Según dicen, un #camino invisible del pozo# conduce a una Skulltula que otorga #[[1]]#.
 
     hintTextTable[RHT_BOTTOM_OF_THE_WELL_GS_WEST_INNER_ROOM] = HintText(CustomMessage("They say that a #spider locked in a crypt# within the well guards #[[1]]#.",
-                                                                           /*german*/ "",
+                                                                           /*german*/ "Man erzählt sich, daß eine #in einer Krypta eingeschlossene Spinne# im Brunnen #[[1]]# bewache.",
                                                                            /*french*/ "Selon moi, une #Skulltula embarrée dans la crypte au fonds du Puits# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                         // /*spanish*/ Según dicen, una #Skulltula encerrada en una cripta# del pozo otorga #[[1]]#.
 
     hintTextTable[RHT_BOTTOM_OF_THE_WELL_MQ_GS_BASEMENT] = HintText(CustomMessage("They say that a #gauntlet of invisible spiders# protects #[[1]]#.",
-                                                                       /*german*/ "",
+                                                                       /*german*/ "Man erzählt sich, daß eine #Herausforderung unsichtbarer Spinnen# #[[1]]# bewache.",
                                                                        /*french*/ "Selon moi, une #Skulltula protégée par les araignées invisibles au fonds du Puits# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                     // /*spanish*/ Según dicen, unas #arañas invisibles# custodian una Skulltula que otorga #[[1]]#.
 
     hintTextTable[RHT_BOTTOM_OF_THE_WELL_MQ_GS_COFFIN_ROOM] = HintText(CustomMessage("They say that a #spider crawling near the dead# in the well holds #[[1]]#.",
-                                                                          /*german*/ "",
+                                                                          /*german*/ "Man erzählt sich, daß eine #nahe der Toten kriechende Spinne# im Brunnen #[[1]]# besäße.",
                                                                           /*french*/ "Selon moi, une #Skulltula près des cercueils au fonds du Puits# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                        // /*spanish*/ Según dicen, una #Skulltula junto a los muertos# del pozo otorga #[[1]]#.
 
     hintTextTable[RHT_BOTTOM_OF_THE_WELL_MQ_GS_WEST_INNER_ROOM] = HintText(CustomMessage("They say that a #spider locked in a crypt# within the well guards #[[1]]#.",
-                                                                              /*german*/ "",
+                                                                              /*german*/ "Man erzählt sich, daß eine #in einer Krypta eingeschlossene Spinne# im Brunnen #[[1]]# bewache.",
                                                                               /*french*/ "Selon moi, une #Skulltula embarrée dans la crypte au fonds du Puits# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                            // /*spanish*/ Según dicen, una #Skulltula encerrada en una cripta# del pozo otorga #[[1]]#.
 
@@ -1556,72 +1556,72 @@ hintTextTable[RHT_SHADOW_TEMPLE_MAP_CHEST] = HintText(CustomMessage("They say th
   |        ICE CAVERN        |
   ---------------------------*/
     hintTextTable[RHT_ICE_CAVERN_MAP_CHEST] = HintText(CustomMessage("They say that #winds of ice# surround #[[1]]#.",
-                                                          /*german*/ "",
+                                                          /*german*/ "Man erzählt sich, daß #Eiswinde# #[[1]]# umgeben würden.",
                                                           /*french*/ "Selon moi, #figé dans la glace rouge# gît #[[1]]#.", {QM_RED, QM_GREEN}));
                                                        // /*spanish*/ Según dicen, #heladas borrascas# rodean #[[1]]#.
 
     hintTextTable[RHT_ICE_CAVERN_COMPASS_CHEST] = HintText(CustomMessage("They say that a #wall of ice# protects #[[1]]#.",
-                                                              /*german*/ "",
+                                                              /*german*/ "Man erzählt sich, daß eine #Eiswand# #[[1]]# schütze.",
                                                               /*french*/ "Selon moi, #un mur de glace rouge# cache #[[1]]#.", {QM_RED, QM_GREEN}));
                                                            // /*spanish*/ Según dicen, una #gélida pared# protege #[[1]]#.
 
     hintTextTable[RHT_ICE_CAVERN_IRON_BOOTS_CHEST] = HintText(CustomMessage("They say that a #monster in a frozen cavern# guards #[[1]]#.",
-                                                                 /*german*/ "",
+                                                                 /*german*/ "Man erzählt sich, daß ein #Monster in einer gefrorenen Kaverne# #[[1]]# bewache.",
                                                                  /*french*/ "Selon moi, le #monstre de la caverne de glace# protège #[[1]]#.", {QM_RED, QM_GREEN}));
                                                               // /*spanish*/ Según dicen, un #monstruo de una helada caverna# guarda #[[1]]#.
 
     hintTextTable[RHT_ICE_CAVERN_FREESTANDING_POH] = HintText(CustomMessage("They say that a #wall of ice# protects #[[1]]#.",
-                                                                 /*german*/ "",
+                                                                 /*german*/ "Man erzählt sich, daß eine #Eiswand# #[[1]]# schütze.",
                                                                  /*french*/ "Selon moi, un #mur de glace rouge# cache #[[1]]#.", {QM_RED, QM_GREEN}));
                                                               // /*spanish*/ Según dicen, una #gélida pared# protege #[[1]]#.
 
     hintTextTable[RHT_ICE_CAVERN_MQ_IRON_BOOTS_CHEST] = HintText(CustomMessage("They say that a #monster in a frozen cavern# guards #[[1]]#.",
-                                                                    /*german*/ "",
+                                                                    /*german*/ "Man erzählt sich, daß ein #Monster in einer gefrorenen Kaverne# #[[1]]# bewache.",
                                                                     /*french*/ "Selon moi, le #monstre de la caverne de glace# protège #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                  // /*spanish*/ Según dicen, un #monstruo de una helada caverna# guarda #[[1]]#.
 
     hintTextTable[RHT_ICE_CAVERN_MQ_COMPASS_CHEST] = HintText(CustomMessage("They say that #winds of ice# surround #[[1]]#.",
-                                                                 /*german*/ "",
+                                                                 /*german*/ "Man erzählt sich, daß #Eiswinde# #[[1]]# umgeben würden.",
                                                                  /*french*/ "Selon moi, #entouré de vent glacial# gît #[[1]]#.", {QM_RED, QM_GREEN}));
                                                               // /*spanish*/ Según dicen, #heladas borrascas# rodean #[[1]]#.
 
     hintTextTable[RHT_ICE_CAVERN_MQ_MAP_CHEST] = HintText(CustomMessage("They say that a #wall of ice# protects #[[1]]#.",
-                                                             /*german*/ "",
+                                                             /*german*/ "Man erzählt sich, daß eine #Eiswand# #[[1]]# schütze.",
                                                              /*french*/ "Selon moi, #un mur de glace rouge# cache #[[1]]#.", {QM_RED, QM_GREEN}));
                                                           // /*spanish*/ Según dicen, una #gélida pared# protege #[[1]]#.
 
     hintTextTable[RHT_ICE_CAVERN_MQ_FREESTANDING_POH] = HintText(CustomMessage("They say that #winds of ice# surround #[[1]]#.",
-                                                                    /*german*/ "",
+                                                                    /*german*/ "Man erzählt sich, daß #Eiswinde# #[[1]]# umgeben würden.",
                                                                     /*french*/ "Selon moi, #entouré de vent glacial# gît #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                  // /*spanish*/ Según dicen, #heladas borrascas# rodean #[[1]]#.
 
     hintTextTable[RHT_ICE_CAVERN_GS_PUSH_BLOCK_ROOM] = HintText(CustomMessage("They say that a #spider above icy pits# holds #[[1]]#.",
-                                                                   /*german*/ "",
+                                                                   /*german*/ "Man erzählt sich, daß eine #Spinne oberhalb eisiger Gruben# #[[1]]# besäße.",
                                                                    /*french*/ "Selon moi, une #Skulltula au dessus d'un goufre glacial# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                 // /*spanish*/ Según dicen, una #Skulltula sobre gélidos vacíos# otorga #[[1]]#.
 
     hintTextTable[RHT_ICE_CAVERN_GS_SPINNING_SCYTHE_ROOM] = HintText(CustomMessage("They say that #spinning ice# guards a spider holding #[[1]]#.",
-                                                                        /*german*/ "",
+                                                                        /*german*/ "Man erzählt sich, daß #rotierendes Eis# eine Spinne beschütze, welche #[[1]]# besäße.",
                                                                         /*french*/ "Selon moi, une #Skulltula près de deux lames de glace# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                      // /*spanish*/ Según dicen, unos #témpanos giratorios# custodian una Skulltula que otorga #[[1]]#.
 
     hintTextTable[RHT_ICE_CAVERN_GS_HEART_PIECE_ROOM] = HintText(CustomMessage("They say that a #spider behind a wall of ice# hides #[[1]]#.",
-                                                                    /*german*/ "",
+                                                                    /*german*/ "Man erzählt sich, daß eine #Spinne hinter einer Eiswand# #[[1]]# verstecke.",
                                                                     /*french*/ "Selon moi, une #Skulltula derrière un mur de glace# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                  // /*spanish*/ Según dicen, una #Skulltula tras una gélida pared# otorga #[[1]]#.
 
     hintTextTable[RHT_ICE_CAVERN_MQ_GS_SCARECROW] = HintText(CustomMessage("They say that a #spider above icy pits# holds #[[1]]#.",
-                                                                /*german*/ "",
+                                                                /*german*/ "Man erzählt sich, daß eine #Spinne oberhalb eisiger Gruben# #[[1]]# besäße.",
                                                                 /*french*/ "Selon moi, une #Skulltula au dessus d'un goufre glacial# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                              // /*spanish*/ Según dicen, una #Skulltula sobre gélidos vacíos# otorga #[[1]]#.
 
     hintTextTable[RHT_ICE_CAVERN_MQ_GS_ICE_BLOCK] = HintText(CustomMessage("They say that a #web of ice# surrounds a spider with #[[1]]#.",
-                                                                /*german*/ "",
+                                                                /*german*/ "Man erzählt sich, daß eine #Webe aus Eis# eine Spinne umgebe, welche #[[1]]# besäße.",
                                                                 /*french*/ "Selon moi, une #Skulltula protégée d'une toile glacée# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                              // /*spanish*/ Según dicen, una #gélida red# rodea a una Skulltula que otorga #[[1]]#.
 
     hintTextTable[RHT_ICE_CAVERN_MQ_GS_RED_ICE] = HintText(CustomMessage("They say that a #spider in fiery ice# hoards #[[1]]#.",
-                                                              /*german*/ "",
+                                                              /*german*/ "Man erzählt sich, daß eine #Spinne in feurigem Eis# #[[1]]# horte.",
                                                               /*french*/ "Selon moi, une #Skulltula figée dans la glace rouge# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                            // /*spanish*/ Según dicen, una #Skulltula tras un ardiente hielo# otorga #[[1]]#.
 
@@ -1629,177 +1629,177 @@ hintTextTable[RHT_SHADOW_TEMPLE_MAP_CHEST] = HintText(CustomMessage("They say th
   | GERUDO TRAINING GROUNDS  |
   ---------------------------*/
     hintTextTable[RHT_GERUDO_TRAINING_GROUND_LOBBY_LEFT_CHEST] = HintText(CustomMessage("They say that a #blinded eye in the Gerudo Training Grounds# drops #[[1]]#.",
-                                                                             /*german*/ "",
+                                                                             /*german*/ "Man erzählt sich, daß ein #erblindetes Auge in der Gerudo-Trainingsarena# #[[1]]# fallen ließe.",
                                                                              /*french*/ "Selon moi, l'#Oeil dans le Gymnase Gerudo# voit #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                           // /*spanish*/ Según dicen, #cegar un ojo en el Centro de Instrucción Gerudo# revela #[[1]]#.
 
     hintTextTable[RHT_GERUDO_TRAINING_GROUND_LOBBY_RIGHT_CHEST] = HintText(CustomMessage("They say that a #blinded eye in the Gerudo Training Grounds# drops #[[1]]#.",
-                                                                              /*german*/ "",
+                                                                              /*german*/ "Man erzählt sich, daß ein #erblindetes Auge in der Gerudo-Trainingsarena# #[[1]]# fallen ließe.",
                                                                               /*french*/ "Selon moi, l'#Oeil dans le Gymnase Gerudo# voit #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                            // /*spanish*/ Según dicen, #cegar un ojo en el Centro de Instrucción Gerudo# revela #[[1]]#.
 
     hintTextTable[RHT_GERUDO_TRAINING_GROUND_STALFOS_CHEST] = HintText(CustomMessage("They say that #soldiers walking on shifting sands# in the Gerudo Training Grounds guard #[[1]]#.",
-                                                                          /*german*/ "",
+                                                                          /*german*/ "Man erzählt sich, daß #auf veränderlichen Sanden laufende Soldaten# in der Gerudo-Trainingsarena #[[1]]# bewachen würden.",
                                                                           /*french*/ "Selon moi, les #squelettes# du Gymnase Gerudo protègent #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                        // /*spanish*/ Según dicen, #soldados en resbaladizas arenas# del Centro de Instrucción Gerudo protegen #[[1]]#.
 
     hintTextTable[RHT_GERUDO_TRAINING_GROUND_BEAMOS_CHEST] = HintText(CustomMessage("They say that #reptilian warriors# in the Gerudo Training Grounds protect #[[1]]#.",
-                                                                         /*german*/ "",
+                                                                         /*german*/ "Man erzählt sich, daß #reptilienartige Krieger# in der Gerudo-Trainingsarena #[[1]]# schützen würden.",
                                                                          /*french*/ "Selon moi, les #lézards# dans le Gymnase Gerudo protègent #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                       // /*spanish*/ Según dicen, #unos escamosos guerreros# del Centro de Instrucción Gerudo protegen #[[1]]#.
 
     hintTextTable[RHT_GERUDO_TRAINING_GROUND_HIDDEN_CEILING_CHEST] = HintText(CustomMessage("They say that the #Eye of Truth# in the Gerudo Training Grounds reveals #[[1]]#.",
-                                                                                 /*german*/ "",
+                                                                                 /*german*/ "Man erzählt sich, daß das #Auge der Wahrheit# in der Gerudo-Trainingsarena #[[1]]# enthülle.",
                                                                                  /*french*/ "Selon moi, #bien caché# dans le Gymnase Gerudo gît #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                               // /*spanish*/ Según dicen, el #Ojo de la Verdad# en el Centro de Instrucción Gerudo revela #[[1]]#.
 
     hintTextTable[RHT_GERUDO_TRAINING_GROUND_MAZE_PATH_FIRST_CHEST] = HintText(CustomMessage("They say that the first prize of #the thieves' training# is #[[1]]#.",
-                                                                                  /*german*/ "",
+                                                                                  /*german*/ "Man erzählt sich, daß der erste Preis des #Diebestrainings# #[[1]]# sei.",
                                                                                   /*french*/ "Selon moi, le #premier trésor du Gymnase Gerudo# est #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                                // /*spanish*/ Según dicen, el primer premio de la #instrucción bandida# se trata de #[[1]]#.
 
     hintTextTable[RHT_GERUDO_TRAINING_GROUND_MAZE_PATH_SECOND_CHEST] = HintText(CustomMessage("They say that the second prize of #the thieves' training# is #[[1]]#.",
-                                                                                   /*german*/ "",
+                                                                                   /*german*/ "Man erzählt sich, daß der zweite Preis des #Diebestrainings# #[[1]]# sei.",
                                                                                    /*french*/ "Selon moi, le #deuxième trésor du Gymnase Gerudo# est #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                                 // /*spanish*/ Según dicen, el segundo premio de la #instrucción bandida# se trata de #[[1]]#.
 
     hintTextTable[RHT_GERUDO_TRAINING_GROUND_MAZE_PATH_THIRD_CHEST] = HintText(CustomMessage("They say that the third prize of #the thieves' training# is #[[1]]#.",
-                                                                                  /*german*/ "",
+                                                                                  /*german*/ "Man erzählt sich, daß der dritte Preis des #Diebestrainings# #[[1]]# sei.",
                                                                                   /*french*/ "Selon moi, le #troisième trésor du Gymnase Gerudo# est #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                                // /*spanish*/ Según dicen, el tercer premio de la #instrucción bandida# se trata de #[[1]]#.
 
     hintTextTable[RHT_GERUDO_TRAINING_GROUND_MAZE_RIGHT_CENTRAL_CHEST] = HintText(CustomMessage("They say that the #Song of Time# in the Gerudo Training Grounds leads to #[[1]]#.",
-                                                                                     /*german*/ "",
+                                                                                     /*german*/ "Man erzählt sich, daß die #Hymne der Zeit# in der Gerudo-Trainingsarena zu #[[1]]# führe.",
                                                                                      /*french*/ "Selon moi, le #chant du temps# révèle dans le Gymnase Gerudo #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                                   // /*spanish*/ Según dicen, la #Canción del Tiempo# en el Centro de Instrucción Gerudo conduce a #[[1]]#.
 
     hintTextTable[RHT_GERUDO_TRAINING_GROUND_MAZE_RIGHT_SIDE_CHEST] = HintText(CustomMessage("They say that the #Song of Time# in the Gerudo Training Grounds leads to #[[1]]#.",
-                                                                                  /*german*/ "",
+                                                                                  /*german*/ "Man erzählt sich, daß die #Hymne der Zeit# in der Gerudo-Trainingsarena zu #[[1]]# führe.",
                                                                                   /*french*/ "Selon moi, le #chant du temps# révèle dans le Gymnase Gerudo #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                                // /*spanish*/ Según dicen, la #Canción del Tiempo# en el Centro de Instrucción Gerudo conduce a #[[1]]#.
 
     hintTextTable[RHT_GERUDO_TRAINING_GROUND_HAMMER_ROOM_CLEAR_CHEST] = HintText(CustomMessage("They say that #fiery foes# in the Gerudo Training Grounds guard #[[1]]#.",
-                                                                                    /*german*/ "",
+                                                                                    /*german*/ "Man erzählt sich, daß #feurige Feinde# in der Gerudo-Trainingsarena #[[1]]# bewachen würden.",
                                                                                     /*french*/ "Selon moi, les #limaces de feu# du Gymnase Gerudo protègent #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                                  // /*spanish*/ Según dicen, unos #flamígeros enemigos# del Centro de Instrucción Gerudo guardan #[[1]]#.
 
     hintTextTable[RHT_GERUDO_TRAINING_GROUND_HAMMER_ROOM_SWITCH_CHEST] = HintText(CustomMessage("They say that #engulfed in flame# where thieves train lies #[[1]]#.",
-                                                                                     /*german*/ "",
+                                                                                     /*german*/ "Man erzählt sich, daß #von Flammen umschlungen# wo Diebe trainieren #[[1]]# läge.",
                                                                                      /*french*/ "Selon moi, le #trésor enflammé# du Gymnase Gerudo est #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                                   // /*spanish*/ Según dicen, donde entrenan las bandidas #entre llamas# yace #[[1]]#.
 
     hintTextTable[RHT_GERUDO_TRAINING_GROUND_EYE_STATUE_CHEST] = HintText(CustomMessage("They say that thieves #blind four faces# to find #[[1]]#.",
-                                                                             /*german*/ "",
+                                                                             /*german*/ "Man erzählt sich, daß Diebe #vier Gesichter erblinden# würden und #[[1]]# fänden.",
                                                                              /*french*/ "Selon moi, l'#épreuve d'archerie# du Gymnase Gerudo donne #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                           // /*spanish*/ Según dicen, las bandidas #ciegan cuatro bustos# para hallar #[[1]]#.
 
     hintTextTable[RHT_GERUDO_TRAINING_GROUND_NEAR_SCARECROW_CHEST] = HintText(CustomMessage("They say that thieves #blind four faces# to find #[[1]]#.",
-                                                                                 /*german*/ "",
+                                                                                 /*german*/ "Man erzählt sich, daß Diebe #vier Gesichter erblinden# würden und #[[1]]# fänden.",
                                                                                  /*french*/ "Selon moi, l'#épreuve d'archerie# du Gymnase Gerudo donne #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                               // /*spanish*/ Según dicen, las bandidas #ciegan cuatro bustos# para hallar #[[1]]#.
 
     hintTextTable[RHT_GERUDO_TRAINING_GROUND_BEFORE_HEAVY_BLOCK_CHEST] = HintText(CustomMessage("They say that #before a block of silver# thieves can find #[[1]]#.",
-                                                                                     /*german*/ "",
+                                                                                     /*german*/ "Man erzählt sich, daß #vor einem Block aus Silber# Diebe #[[1]]# finden könnten.",
                                                                                      /*french*/ "Selon moi, #près d'un bloc argent# dans le Gymnase Gerudo gît #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                                   // /*spanish*/ Según dicen, #ante un plateado bloque# las bandidas hallan #[[1]]#.
 
     hintTextTable[RHT_GERUDO_TRAINING_GROUND_HEAVY_BLOCK_FIRST_CHEST] = HintText(CustomMessage("They say that a #feat of strength# rewards thieves with #[[1]]#.",
-                                                                                    /*german*/ "",
+                                                                                    /*german*/ "Man erzählt sich, daß ein #Meisterstück der Stärke# Diebe mit #[[1]]# belohnen würde.",
                                                                                     /*french*/ "Selon moi, #derrière un bloc argent# dans le Gymnase Gerudo gît #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                                  // /*spanish*/ Según dicen, una #hazaña de fuerza# premia a las bandidas con #[[1]]#.
 
     hintTextTable[RHT_GERUDO_TRAINING_GROUND_HEAVY_BLOCK_SECOND_CHEST] = HintText(CustomMessage("They say that a #feat of strength# rewards thieves with #[[1]]#.",
-                                                                                     /*german*/ "",
+                                                                                     /*german*/ "Man erzählt sich, daß ein #Meisterstück der Stärke# Diebe mit #[[1]]# belohnen würde.",
                                                                                      /*french*/ "Selon moi, #derrière un bloc argent# dans le Gymnase Gerudo gît #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                                   // /*spanish*/ Según dicen, una #hazaña de fuerza# premia a las bandidas con #[[1]]#.
 
     hintTextTable[RHT_GERUDO_TRAINING_GROUND_HEAVY_BLOCK_THIRD_CHEST] = HintText(CustomMessage("They say that a #feat of strength# rewards thieves with #[[1]]#.",
-                                                                                    /*german*/ "",
+                                                                                    /*german*/ "Man erzählt sich, daß ein #Meisterstück der Stärke# Diebe mit #[[1]]# belohnen würde.",
                                                                                     /*french*/ "Selon moi, #derrière un bloc argent# dans le Gymnase Gerudo gît #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                                  // /*spanish*/ Según dicen, una #hazaña de fuerza# premia a las bandidas con #[[1]]#.
 
     hintTextTable[RHT_GERUDO_TRAINING_GROUND_HEAVY_BLOCK_FOURTH_CHEST] = HintText(CustomMessage("They say that a #feat of strength# rewards thieves with #[[1]]#.",
-                                                                                     /*german*/ "",
+                                                                                     /*german*/ "Man erzählt sich, daß ein #Meisterstück der Stärke# Diebe mit #[[1]]# belohnen würde.",
                                                                                      /*french*/ "Selon moi, #derrière un bloc argent# dans le Gymnase Gerudo gît #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                                   // /*spanish*/ Según dicen, una #hazaña de fuerza# premia a las bandidas con #[[1]]#.
 
     hintTextTable[RHT_GERUDO_TRAINING_GROUND_FREESTANDING_KEY] = HintText(CustomMessage("They say that the #Song of Time# in the Gerudo Training Grounds leads to #[[1]]#.",
-                                                                             /*german*/ "",
+                                                                             /*german*/ "Man erzählt sich, daß die #Hymne der Zeit# in der Gerudo-Trainingsarena zu #[[1]]# führe.",
                                                                              /*french*/ "Selon moi, le #chant du temps# révèle dans le Gymnase Gerudo #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                           // /*spanish*/ Según dicen, la #Canción del Tiempo# en el Centro de Instrucción Gerudo conduce a #[[1]]#.
 
     hintTextTable[RHT_GERUDO_TRAINING_GROUND_MQ_LOBBY_RIGHT_CHEST] = HintText(CustomMessage("They say that #thieves prepare for training# with #[[1]]#.",
-                                                                                 /*german*/ "",
+                                                                                 /*german*/ "Man erzählt sich, daß sich #Diebe auf das Training vorbereiteten# mit #[[1]]#.",
                                                                                  /*french*/ "Selon moi, dans #l'entrée du Gymnase Gerudo# gît #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                               // /*spanish*/ Según dicen, las #bandidas se instruyen# con #[[1]]#.
 
     hintTextTable[RHT_GERUDO_TRAINING_GROUND_MQ_LOBBY_LEFT_CHEST] = HintText(CustomMessage("They say that #thieves prepare for training# with #[[1]]#.",
-                                                                                /*german*/ "",
+                                                                                /*german*/ "Man erzählt sich, daß sich #Diebe auf das Training vorbereiteten# mit #[[1]]#.",
                                                                                 /*french*/ "Selon moi, dans #l'entrée du Gymnase Gerudo# gît #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                              // /*spanish*/ Según dicen, las #bandidas se instruyen# con #[[1]]#.
 
     hintTextTable[RHT_GERUDO_TRAINING_GROUND_MQ_FIRST_IRON_KNUCKLE_CHEST] = HintText(CustomMessage("They say that #soldiers walking on shifting sands# in the Gerudo Training Grounds guard #[[1]]#.",
-                                                                                        /*german*/ "",
+                                                                                        /*german*/ "Man erzählt sich, daß #auf veränderlichen Sanden laufende Soldaten# in der Gerudo-Trainingsarena #[[1]]# bewachen würden.",
                                                                                         /*french*/ "Selon moi, les #squelettes# du Gymnase Gerudo protègent #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                                      // /*spanish*/ Según dicen, #soldados en resbaladizas arenas# del Centro de Instrucción Gerudo protegen #[[1]]#.
 
     hintTextTable[RHT_GERUDO_TRAINING_GROUND_MQ_BEFORE_HEAVY_BLOCK_CHEST] = HintText(CustomMessage("They say that #before a block of silver# thieves can find #[[1]]#.",
-                                                                                        /*german*/ "",
+                                                                                        /*german*/ "Man erzählt sich, daß #vor einem Block aus Silber# Diebe #[[1]]# finden könnten.",
                                                                                         /*french*/ "Selon moi, #près d'un bloc argent# dans le Gymnase Gerudo gît #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                                      // /*spanish*/ Según dicen, #ante un plateado bloque# las bandidas hallan #[[1]]#.
 
     hintTextTable[RHT_GERUDO_TRAINING_GROUND_MQ_EYE_STATUE_CHEST] = HintText(CustomMessage("They say that thieves #blind four faces# to find #[[1]]#.",
-                                                                                /*german*/ "",
+                                                                                /*german*/ "Man erzählt sich, daß Diebe #vier Gesichter erblinden# würden und #[[1]]# fänden.",
                                                                                 /*french*/ "Selon moi, l'#épreuve d'archerie# du Gymnase Gerudo donne #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                              // /*spanish*/ Según dicen, las bandidas #ciegan cuatro bustos# para hallar #[[1]]#.
 
     hintTextTable[RHT_GERUDO_TRAINING_GROUND_MQ_FLAME_CIRCLE_CHEST] = HintText(CustomMessage("They say that #engulfed in flame# where thieves train lies #[[1]]#.",
-                                                                                  /*german*/ "",
+                                                                                  /*german*/ "Man erzählt sich, daß #von Flammen umschlungen# wo Diebe trainieren #[[1]]# läge.",
                                                                                   /*french*/ "Selon moi, le #trésor enflammé# du Gymnase Gerudo est #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                                // /*spanish*/ Según dicen, donde entrenan las bandidas #entre llamas# yace #[[1]]#.
 
     hintTextTable[RHT_GERUDO_TRAINING_GROUND_MQ_SECOND_IRON_KNUCKLE_CHEST] = HintText(CustomMessage("They say that #fiery foes# in the Gerudo Training Grounds guard #[[1]]#.",
-                                                                                         /*german*/ "",
+                                                                                         /*german*/ "Man erzählt sich, daß #feurige Feinde# in der Gerudo-Trainingsarena #[[1]]# bewachen würden.",
                                                                                          /*french*/ "Selon moi, les #ennemis de feu# du Gymnase Gerudo protègent #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                                       // /*spanish*/ Según dicen, unos #flamígeros enemigos# del Centro de Instrucción Gerudo guardan #[[1]]#.
 
     hintTextTable[RHT_GERUDO_TRAINING_GROUND_MQ_DINOLFOS_CHEST] = HintText(CustomMessage("They say that #reptilian warriors# in the Gerudo Training Grounds protect #[[1]]#.",
-                                                                              /*german*/ "",
+                                                                              /*german*/ "Man erzählt sich, daß #reptilienartige Krieger# in der Gerudo-Trainingsarena #[[1]]# schützen würden.",
                                                                               /*french*/ "Selon moi, les #lézards# dans le Gymnase Gerudo protègent #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                            // /*spanish*/ Según dicen, #unos escamosos guerreros# del Centro de Instrucción Gerudo protegen #[[1]]#.
 
     hintTextTable[RHT_GERUDO_TRAINING_GROUND_MQ_MAZE_RIGHT_CENTRAL_CHEST] = HintText(CustomMessage("They say that a #path of fire# leads thieves to #[[1]]#.",
-                                                                                        /*german*/ "",
+                                                                                        /*german*/ "Man erzählt sich, daß der #Pfad des Feuers# Diebe zu #[[1]]# führe.",
                                                                                         /*french*/ "Selon moi, dans le #chemin enflammé# dans le Gymnase Gerudo gît #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                                      // /*spanish*/ Según dicen, un #camino de fuego# conduce a las bandidas a #[[1]]#.
 
     hintTextTable[RHT_GERUDO_TRAINING_GROUND_MQ_MAZE_PATH_FIRST_CHEST] = HintText(CustomMessage("They say that the first prize of #the thieves' training# is #[[1]]#.",
-                                                                                     /*german*/ "",
+                                                                                     /*german*/ "Man erzählt sich, daß der erste Preis des #Diebestrainings# #[[1]]# sei.",
                                                                                      /*french*/ "Selon moi, le #premier trésor du Gymnase Gerudo# est #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                                   // /*spanish*/ Según dicen, el primer premio de la #instrucción bandida# se trata de #[[1]]#.
 
     hintTextTable[RHT_GERUDO_TRAINING_GROUND_MQ_MAZE_RIGHT_SIDE_CHEST] = HintText(CustomMessage("They say that a #path of fire# leads thieves to #[[1]]#.",
-                                                                                     /*german*/ "",
+                                                                                     /*german*/ "Man erzählt sich, daß der #Pfad des Feuers# Diebe zu #[[1]]# führe.",
                                                                                      /*french*/ "Selon moi, dans le #chemin enflammé# dans le Gymnase Gerudo gît #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                                   // /*spanish*/ Según dicen, un #camino de fuego# conduce a las bandidas a #[[1]]#.
 
     hintTextTable[RHT_GERUDO_TRAINING_GROUND_MQ_MAZE_PATH_THIRD_CHEST] = HintText(CustomMessage("They say that the third prize of #the thieves' training# is #[[1]]#.",
-                                                                                     /*german*/ "",
+                                                                                     /*german*/ "Man erzählt sich, daß der dritte Preis des #Diebestrainings# #[[1]]# sei.",
                                                                                      /*french*/ "Selon moi, le #troisième trésor du Gymnase Gerudo# est #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                                   // /*spanish*/ Según dicen, el tercer premio de la #instrucción bandida# se trata de #[[1]]#.
 
     hintTextTable[RHT_GERUDO_TRAINING_GROUND_MQ_MAZE_PATH_SECOND_CHEST] = HintText(CustomMessage("They say that the second prize of #the thieves' training# is #[[1]]#.",
-                                                                                      /*german*/ "",
+                                                                                      /*german*/ "Man erzählt sich, daß der zweite Preis des #Diebestrainings# #[[1]]# sei.",
                                                                                       /*french*/ "Selon moi, le #deuxième trésor du Gymnase Gerudo# est #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                                    // /*spanish*/ Según dicen, el segundo premio de la #instrucción bandida# se trata de #[[1]]#.
 
     hintTextTable[RHT_GERUDO_TRAINING_GROUND_MQ_HIDDEN_CEILING_CHEST] = HintText(CustomMessage("They say that the #Eye of Truth# in the Gerudo Training Grounds reveals #[[1]]#.",
-                                                                                    /*german*/ "",
+                                                                                    /*german*/ "Man erzählt sich, daß das #Auge der Wahrheit# in der Gerudo-Trainingsarena #[[1]]# enthülle.",
                                                                                     /*french*/ "Selon moi, #bien caché# dans le Gymnase Gerudo gît #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                                  // /*spanish*/ Según dicen, el #Ojo de la Verdad# en el Centro de Instrucción Gerudo revela #[[1]]#.
 
     hintTextTable[RHT_GERUDO_TRAINING_GROUND_MQ_HEAVY_BLOCK_CHEST] = HintText(CustomMessage("They say that a #feat of strength# rewards thieves with #[[1]]#.",
-                                                                                 /*german*/ "",
+                                                                                 /*german*/ "Man erzählt sich, daß ein #Meisterstück der Stärke# Diebe mit #[[1]]# belohnen würde.",
                                                                                  /*french*/ "Selon moi, #derrière un bloc argent# dans le Gymnase Gerudo gît #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                               // /*spanish*/ Según dicen, una #hazaña de fuerza# premia a las bandidas con #[[1]]#.
 
@@ -1807,192 +1807,192 @@ hintTextTable[RHT_SHADOW_TEMPLE_MAP_CHEST] = HintText(CustomMessage("They say th
   |      GANONS CASTLE       |
   ---------------------------*/
     hintTextTable[RHT_GANONS_TOWER_BOSS_KEY_CHEST] = HintText(CustomMessage("They say that the #Evil King# hoards #[[1]]#.",
-                                                                 /*german*/ "",
+                                                                 /*german*/ "Man erzählt sich, daß der #böse König# #[[1]]# horte.",
                                                                  /*french*/ "Selon moi, le #Roi du Mal# possède #[[1]]#.", {QM_RED, QM_GREEN}));
                                                               // /*spanish*/ Según dicen, el #Rey del Mal# acapara #[[1]]#.
 
     hintTextTable[RHT_GANONS_CASTLE_FOREST_TRIAL_CHEST] = HintText(CustomMessage("They say that the #test of the wilds# holds #[[1]]#.",
-                                                                      /*german*/ "",
+                                                                      /*german*/ "Man erzählt sich, daß die #Prüfung der Wildnis# #[[1]]# enthielte.",
                                                                       /*french*/ "Selon moi, l'#épreuve des bois# contient #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                    // /*spanish*/ Según dicen, la #prueba de la naturaleza# brinda #[[1]]#.
 
     hintTextTable[RHT_GANONS_CASTLE_WATER_TRIAL_LEFT_CHEST] = HintText(CustomMessage("They say that the #test of the seas# holds #[[1]]#.",
-                                                                          /*german*/ "",
+                                                                          /*german*/ "Man erzählt sich, daß die #Prüfung der Meere# #[[1]]# enthielte.",
                                                                           /*french*/ "Selon moi, l'#épreuve des mers# contient #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                        // /*spanish*/ Según dicen, la #prueba del mar# brinda #[[1]]#.
 
     hintTextTable[RHT_GANONS_CASTLE_WATER_TRIAL_RIGHT_CHEST] = HintText(CustomMessage("They say that the #test of the seas# holds #[[1]]#.",
-                                                                           /*german*/ "",
+                                                                           /*german*/ "Man erzählt sich, daß die #Prüfung der Meere# #[[1]]# enthielte.",
                                                                            /*french*/ "Selon moi, l'#épreuve des mers# contient #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                         // /*spanish*/ Según dicen, la #prueba del mar# brinda #[[1]]#.
 
     hintTextTable[RHT_GANONS_CASTLE_SHADOW_TRIAL_FRONT_CHEST] = HintText(CustomMessage("They say that #music in the test of darkness# unveils #[[1]]#.",
-                                                                            /*german*/ "",
+                                                                            /*german*/ "Man erzählt sich, daß #Musik in der Prüfung des Dunkelheit# #[[1]]# enthüllen würde.",
                                                                             /*french*/ "Selon moi, la #musique dans l'épreuve des ténèbres# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                          // /*spanish*/ Según dicen, la #música en la prueba de la oscuridad# revela #[[1]]#.
 
     hintTextTable[RHT_GANONS_CASTLE_SHADOW_TRIAL_GOLDEN_GAUNTLETS_CHEST] = HintText(CustomMessage("They say that #light in the test of darkness# unveils #[[1]]#.",
-                                                                                       /*german*/ "",
+                                                                                       /*german*/ "Man erzählt sich, daß #Licht in der Prüfung der Dunkelheit# #[[1]]# enthüllen würde.",
                                                                                        /*french*/ "Selon moi, la #lumière dans l'épreuve des ténèbres# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                                     // /*spanish*/ Según dicen, la #luz en la prueba de la oscuridad# revela #[[1]]#.
 
     hintTextTable[RHT_GANONS_CASTLE_SPIRIT_TRIAL_CRYSTAL_SWITCH_CHEST] = HintText(CustomMessage("They say that the #test of the sands# holds #[[1]]#.",
-                                                                                     /*german*/ "",
+                                                                                     /*german*/ "Man erzählt sich, daß die #Prüfung der Sande# #[[1]]# enthielte.",
                                                                                      /*french*/ "Selon moi, l'#épreuve des sables# contient #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                                   // /*spanish*/ Según dicen, la #prueba de las arenas# brinda #[[1]]#.
 
     hintTextTable[RHT_GANONS_CASTLE_SPIRIT_TRIAL_INVISIBLE_CHEST] = HintText(CustomMessage("They say that the #test of the sands# holds #[[1]]#.",
-                                                                                /*german*/ "",
+                                                                                /*german*/ "Man erzählt sich, daß die #Prüfung der Sande# #[[1]]# enthielte.",
                                                                                 /*french*/ "Selon moi, l'#épreuve des sables# contient #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                              // /*spanish*/ Según dicen, la #prueba de las arenas# brinda #[[1]]#.
 
     hintTextTable[RHT_GANONS_CASTLE_LIGHT_TRIAL_FIRST_LEFT_CHEST] = HintText(CustomMessage("They say that the #test of radiance# holds #[[1]]#.",
-                                                                                /*german*/ "",
+                                                                                /*german*/ "Man erzählt sich, daß die #Prüfung des Glanzes# #[[1]]# enthielte.",
                                                                                 /*french*/ "Selon moi, l'#épreuve du ciel# contient #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                              // /*spanish*/ Según dicen, la #prueba del resplandor# brinda #[[1]]#.
 
     hintTextTable[RHT_GANONS_CASTLE_LIGHT_TRIAL_SECOND_LEFT_CHEST] = HintText(CustomMessage("They say that the #test of radiance# holds #[[1]]#.",
-                                                                                 /*german*/ "",
+                                                                                 /*german*/ "Man erzählt sich, daß die #Prüfung des Glanzes# #[[1]]# enthielte.",
                                                                                  /*french*/ "Selon moi, l'#épreuve du ciel# contient #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                               // /*spanish*/ Según dicen, la #prueba del resplandor# brinda #[[1]]#.
 
     hintTextTable[RHT_GANONS_CASTLE_LIGHT_TRIAL_THIRD_LEFT_CHEST] = HintText(CustomMessage("They say that the #test of radiance# holds #[[1]]#.",
-                                                                                /*german*/ "",
+                                                                                /*german*/ "Man erzählt sich, daß die #Prüfung des Glanzes# #[[1]]# enthielte.",
                                                                                 /*french*/ "Selon moi, l'#épreuve du ciel# contient #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                              // /*spanish*/ Según dicen, la #prueba del resplandor# brinda #[[1]]#.
 
     hintTextTable[RHT_GANONS_CASTLE_LIGHT_TRIAL_FIRST_RIGHT_CHEST] = HintText(CustomMessage("They say that the #test of radiance# holds #[[1]]#.",
-                                                                                 /*german*/ "",
+                                                                                 /*german*/ "Man erzählt sich, daß die #Prüfung des Glanzes# #[[1]]# enthielte.",
                                                                                  /*french*/ "Selon moi, l'#épreuve du ciel# contient #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                               // /*spanish*/ Según dicen, la #prueba del resplandor# brinda #[[1]]#.
 
     hintTextTable[RHT_GANONS_CASTLE_LIGHT_TRIAL_SECOND_RIGHT_CHEST] = HintText(CustomMessage("They say that the #test of radiance# holds #[[1]]#.",
-                                                                                  /*german*/ "",
+                                                                                  /*german*/ "Man erzählt sich, daß die #Prüfung des Glanzes# #[[1]]# enthielte.",
                                                                                   /*french*/ "Selon moi, l'#épreuve du ciel# contient #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                                // /*spanish*/ Según dicen, la #prueba del resplandor# brinda #[[1]]#.
 
     hintTextTable[RHT_GANONS_CASTLE_LIGHT_TRIAL_THIRD_RIGHT_CHEST] = HintText(CustomMessage("They say that the #test of radiance# holds #[[1]]#.",
-                                                                                 /*german*/ "",
+                                                                                 /*german*/ "Man erzählt sich, daß die #Prüfung des Glanzes# #[[1]]# enthielte.",
                                                                                  /*french*/ "Selon moi, l'#épreuve du ciel# contient #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                               // /*spanish*/ Según dicen, la #prueba del resplandor# brinda #[[1]]#.
 
     hintTextTable[RHT_GANONS_CASTLE_LIGHT_TRIAL_INVISIBLE_ENEMIES_CHEST] = HintText(CustomMessage("They say that the #test of radiance# holds #[[1]]#.",
-                                                                                       /*german*/ "",
+                                                                                       /*german*/ "Man erzählt sich, daß die #Prüfung des Glanzes# #[[1]]# enthielte.",
                                                                                        /*french*/ "Selon moi, l'#épreuve du ciel# contient #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                                     // /*spanish*/ Según dicen, la #prueba del resplandor# brinda #[[1]]#.
 
     hintTextTable[RHT_GANONS_CASTLE_LIGHT_TRIAL_LULLABY_CHEST] = HintText(CustomMessage("They say that #music in the test of radiance# reveals #[[1]]#.",
-                                                                             /*german*/ "",
+                                                                             /*german*/ "Man erzählt sich, daß #Musik in der Prüfung des Glanzes# #[[1]]# enthüllen würde.",
                                                                              /*french*/ "Selon moi, la #musique dans l'épreuve du ciel# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                           // /*spanish*/ Según dicen, la #música en la prueba del resplandor# revela #[[1]]#.
 
     hintTextTable[RHT_GANONS_CASTLE_MQ_WATER_TRIAL_CHEST] = HintText(CustomMessage("They say that the #test of the seas# holds #[[1]]#.",
-                                                                        /*german*/ "",
+                                                                        /*german*/ "Man erzählt sich, daß die #Prüfung der Meere# #[[1]]# enthielte.",
                                                                         /*french*/ "Selon moi, l'#épreuve des mers# contient #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                      // /*spanish*/ Según dicen, la #prueba del mar# brinda #[[1]]#.
 
     hintTextTable[RHT_GANONS_CASTLE_MQ_FOREST_TRIAL_EYE_SWITCH_CHEST] = HintText(CustomMessage("They say that the #test of the wilds# holds #[[1]]#.",
-                                                                                    /*german*/ "",
+                                                                                    /*german*/ "Man erzählt sich, daß die #Prüfung der Wildnis# #[[1]]# enthielte.",
                                                                                     /*french*/ "Selon moi, l'#épreuve des bois# contient #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                                  // /*spanish*/ Según dicen, la #prueba de la naturaleza# brinda #[[1]]#.
 
     hintTextTable[RHT_GANONS_CASTLE_MQ_FOREST_TRIAL_FROZEN_EYE_SWITCH_CHEST] = HintText(CustomMessage("They say that the #test of the wilds# holds #[[1]]#.",
-                                                                                           /*german*/ "",
+                                                                                           /*german*/ "Man erzählt sich, daß die #Prüfung der Wildnis# #[[1]]# enthielte.",
                                                                                            /*french*/ "Selon moi, l'#épreuve des bois# contient #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                                         // /*spanish*/ Según dicen, la #prueba de la naturaleza# brinda #[[1]]#.
 
     hintTextTable[RHT_GANONS_CASTLE_MQ_LIGHT_TRIAL_LULLABY_CHEST] = HintText(CustomMessage("They say that #music in the test of radiance# reveals #[[1]]#.",
-                                                                                /*german*/ "",
+                                                                                /*german*/ "Man erzählt sich, daß #Musik in der Prüfung des Glanzes# #[[1]]# enthüllen würde.",
                                                                                 /*french*/ "Selon moi, la #musique dans l'épreuve du ciel# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                              // /*spanish*/ Según dicen, la #música en la prueba del resplandor# revela #[[1]]#.
 
     hintTextTable[RHT_GANONS_CASTLE_MQ_SHADOW_TRIAL_BOMB_FLOWER_CHEST] = HintText(CustomMessage("They say that the #test of darkness# holds #[[1]]#.",
-                                                                                     /*german*/ "",
+                                                                                     /*german*/ "Man erzählt sich, daß die #Prüfung der Dunkelheit# #[[1]]# enthielte.",
                                                                                      /*french*/ "Selon moi, l'#épreuve des ténèbres# contient #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                                   // /*spanish*/ Según dicen, la #prueba de la oscuridad# brinda #[[1]]#.
 
     hintTextTable[RHT_GANONS_CASTLE_MQ_SHADOW_TRIAL_EYE_SWITCH_CHEST] = HintText(CustomMessage("They say that the #test of darkness# holds #[[1]]#.",
-                                                                                    /*german*/ "",
+                                                                                    /*german*/ "Man erzählt sich, daß die #Prüfung der Dunkelheit# #[[1]]# enthielte.",
                                                                                     /*french*/ "Selon moi, l'#épreuve des ténèbres# contient #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                                  // /*spanish*/ Según dicen, la #prueba de la oscuridad# brinda #[[1]]#.
 
     hintTextTable[RHT_GANONS_CASTLE_MQ_SPIRIT_TRIAL_GOLDEN_GAUNTLETS_CHEST] = HintText(CustomMessage("They say that #reflected light in the test of the sands# reveals #[[1]]#.",
-                                                                                          /*german*/ "",
+                                                                                          /*german*/ "Man erzählt sich, daß #reflektiertes Licht in der Prüfung der Sande# #[[1]]# enthüllen würde.",
                                                                                           /*french*/ "Selon moi, le #soleil dans l'épreuve des sables# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                                        // /*spanish*/ Según dicen, #reflejar la luz en la prueba de las arenas# revela #[[1]]#.
 
     hintTextTable[RHT_GANONS_CASTLE_MQ_SPIRIT_TRIAL_SUN_BACK_RIGHT_CHEST] = HintText(CustomMessage("They say that #reflected light in the test of the sands# reveals #[[1]]#.",
-                                                                                        /*german*/ "",
+                                                                                        /*german*/ "Man erzählt sich, daß #reflektiertes Licht in der Prüfung der Sande# #[[1]]# enthüllen würde.",
                                                                                         /*french*/ "Selon moi, le #soleil dans l'épreuve des sables# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                                      // /*spanish*/ Según dicen, #reflejar la luz en la prueba de las arenas# revela #[[1]]#.
 
     hintTextTable[RHT_GANONS_CASTLE_MQ_SPIRIT_TRIAL_SUN_BACK_LEFT_CHEST] = HintText(CustomMessage("They say that #reflected light in the test of the sands# reveals #[[1]]#.",
-                                                                                       /*german*/ "",
+                                                                                       /*german*/ "Man erzählt sich, daß #reflektiertes Licht in der Prüfung der Sande# #[[1]]# enthüllen würde.",
                                                                                        /*french*/ "Selon moi, le #soleil dans l'épreuve des sables# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                                     // /*spanish*/ Según dicen, #reflejar la luz en la prueba de las arenas# revela #[[1]]#.
 
     hintTextTable[RHT_GANONS_CASTLE_MQ_SPIRIT_TRIAL_SUN_FRONT_LEFT_CHEST] = HintText(CustomMessage("They say that #reflected light in the test of the sands# reveals #[[1]]#.",
-                                                                                        /*german*/ "",
+                                                                                        /*german*/ "Man erzählt sich, daß #reflektiertes Licht in der Prüfung der Sande# #[[1]]# enthüllen würde.",
                                                                                         /*french*/ "Selon moi, le #soleil dans l'épreuve des sables# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                                      // /*spanish*/ Según dicen, #reflejar la luz en la prueba de las arenas# revela #[[1]]#.
 
     hintTextTable[RHT_GANONS_CASTLE_MQ_SPIRIT_TRIAL_FIRST_CHEST] = HintText(CustomMessage("They say that #reflected light in the test of the sands# reveals #[[1]]#.",
-                                                                               /*german*/ "",
+                                                                               /*german*/ "Man erzählt sich, daß #reflektiertes Licht in der Prüfung der Sande# #[[1]]# enthüllen würde.",
                                                                                /*french*/ "Selon moi, le #soleil dans l'épreuve des sables# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                             // /*spanish*/ Según dicen, #reflejar la luz en la prueba de las arenas# revela #[[1]]#.
 
     hintTextTable[RHT_GANONS_CASTLE_MQ_SPIRIT_TRIAL_INVISIBLE_CHEST] = HintText(CustomMessage("They say that #reflected light in the test of the sands# reveals #[[1]]#.",
-                                                                                   /*german*/ "",
+                                                                                   /*german*/ "Man erzählt sich, daß #reflektiertes Licht in der Prüfung der Sande# #[[1]]# enthüllen würde.",
                                                                                    /*french*/ "Selon moi, le #soleil dans l'épreuve des sables# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                                 // /*spanish*/ Según dicen, #reflejar la luz en la prueba de las arenas# revela #[[1]]#.
 
     hintTextTable[RHT_GANONS_CASTLE_MQ_FOREST_TRIAL_FREESTANDING_KEY] = HintText(CustomMessage("They say that the #test of the wilds# holds #[[1]]#.",
-                                                                                    /*german*/ "",
+                                                                                    /*german*/ "Man erzählt sich, daß die #Prüfung der Wildnis# #[[1]]# enthielte.",
                                                                                     /*french*/ "Selon moi, l'#épreuve des bois# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                                  // /*spanish*/ Según dicen, la #prueba de la naturaleza# brinda #[[1]]#.
 
     hintTextTable[RHT_GANONS_CASTLE_DEKU_SCRUB_CENTER_LEFT] = HintText(CustomMessage("They say that #scrubs in Ganon's Castle# sell #[[1]]#.",
-                                                                          /*german*/ "",
+                                                                          /*german*/ "Man erzählt sich, daß #Dekus in Ganons Schloß# #[[1]]# verkaufen würden.",
                                                                           /*french*/ "Selon moi, les #pestes Mojo dans le Château de Ganon# vendent #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                        // /*spanish*/ Según dicen, los #dekus del Castillo de Ganon# venden #[[1]]#.
 
     hintTextTable[RHT_GANONS_CASTLE_DEKU_SCRUB_CENTER_RIGHT] = HintText(CustomMessage("They say that #scrubs in Ganon's Castle# sell #[[1]]#.",
-                                                                           /*german*/ "",
+                                                                           /*german*/ "Man erzählt sich, daß #Dekus in Ganons Schloß# #[[1]]# verkaufen würden.",
                                                                            /*french*/ "Selon moi, les #pestes Mojo dans le Château de Ganon# vendent #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                         // /*spanish*/ Según dicen, los #dekus del Castillo de Ganon# venden #[[1]]#.
 
     hintTextTable[RHT_GANONS_CASTLE_DEKU_SCRUB_RIGHT] = HintText(CustomMessage("They say that #scrubs in Ganon's Castle# sell #[[1]]#.",
-                                                                    /*german*/ "",
+                                                                    /*german*/ "Man erzählt sich, daß #Dekus in Ganons Schloß# #[[1]]# verkaufen würden.",
                                                                     /*french*/ "Selon moi, les #pestes Mojo dans le Château de Ganon# vendent #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                  // /*spanish*/ Según dicen, los #dekus del Castillo de Ganon# venden #[[1]]#.
 
     hintTextTable[RHT_GANONS_CASTLE_DEKU_SCRUB_LEFT] = HintText(CustomMessage("They say that #scrubs in Ganon's Castle# sell #[[1]]#.",
-                                                                   /*german*/ "",
+                                                                   /*german*/ "Man erzählt sich, daß #Dekus in Ganons Schloß# #[[1]]# verkaufen würden.",
                                                                    /*french*/ "Selon moi, les #pestes Mojo dans le Château de Ganon# vendent #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                 // /*spanish*/ Según dicen, los #dekus del Castillo de Ganon# venden #[[1]]#.
 
     hintTextTable[RHT_GANONS_CASTLE_MQ_DEKU_SCRUB_RIGHT] = HintText(CustomMessage("They say that #scrubs in Ganon's Castle# sell #[[1]]#.",
-                                                                       /*german*/ "",
+                                                                       /*german*/ "Man erzählt sich, daß #Dekus in Ganons Schloß# #[[1]]# verkaufen würden.",
                                                                        /*french*/ "Selon moi, les #pestes Mojo dans le Château de Ganon# vendent #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                     // /*spanish*/ Según dicen, los #dekus del Castillo de Ganon# venden #[[1]]#.
 
     hintTextTable[RHT_GANONS_CASTLE_MQ_DEKU_SCRUB_CENTER_LEFT] = HintText(CustomMessage("They say that #scrubs in Ganon's Castle# sell #[[1]]#.",
-                                                                             /*german*/ "",
+                                                                             /*german*/ "Man erzählt sich, daß #Dekus in Ganons Schloß# #[[1]]# verkaufen würden.",
                                                                              /*french*/ "Selon moi, les #pestes Mojo dans le Château de Ganon# vendent #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                           // /*spanish*/ Según dicen, los #dekus del Castillo de Ganon# venden #[[1]]#.
 
     hintTextTable[RHT_GANONS_CASTLE_MQ_DEKU_SCRUB_CENTER] = HintText(CustomMessage("They say that #scrubs in Ganon's Castle# sell #[[1]]#.",
-                                                                        /*german*/ "",
+                                                                        /*german*/ "Man erzählt sich, daß #Dekus in Ganons Schloß# #[[1]]# verkaufen würden.",
                                                                         /*french*/ "Selon moi, les #pestes Mojo dans le Château de Ganon# vendent #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                      // /*spanish*/ Según dicen, los #dekus del Castillo de Ganon# venden #[[1]]#.
 
     hintTextTable[RHT_GANONS_CASTLE_MQ_DEKU_SCRUB_CENTER_RIGHT] = HintText(CustomMessage("They say that #scrubs in Ganon's Castle# sell #[[1]]#.",
-                                                                              /*german*/ "",
+                                                                              /*german*/ "Man erzählt sich, daß #Dekus in Ganons Schloß# #[[1]]# verkaufen würden.",
                                                                               /*french*/ "Selon moi, les #pestes Mojo dans le Château de Ganon# vendent #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                            // /*spanish*/ Según dicen, los #dekus del Castillo de Ganon# venden #[[1]]#.
 
     hintTextTable[RHT_GANONS_CASTLE_MQ_DEKU_SCRUB_LEFT] = HintText(CustomMessage("They say that #scrubs in Ganon's Castle# sell #[[1]]#.",
-                                                                      /*german*/ "",
+                                                                      /*german*/ "Man erzählt sich, daß #Dekus in Ganons Schloß# #[[1]]# verkaufen würden.",
                                                                       /*french*/ "Selon moi, les #pestes Mojo dans le Château de Ganon# vendent #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                    // /*spanish*/ Según dicen, los #dekus del Castillo de Ganon# venden #[[1]]#.
 }

--- a/soh/soh/Enhancements/randomizer/3drando/hint_list/hint_list_exclude_overworld.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/hint_list/hint_list_exclude_overworld.cpp
@@ -171,1320 +171,1323 @@ void StaticData::HintTable_Init_Exclude_Overworld() {
                                                                 // /*spanish*/ Según dicen, bajo un #hoyo de un laberinto forestal# yace #[[1]]#.
 
     hintTextTable[RHT_DMT_STORMS_GROTTO_CHEST] = HintText(CustomMessage("They say that #hole flooded with rain on a mountain# holds #[[1]]#.",
-                                                             /*german*/ "",
+                                                             /*german*/ "Man erzählt sich, daß ein #durch Regen geflutetes Loch auf einem Berg# #[[1]]# enthielte.",
                                                              /*french*/ "Selon moi, la #grotte inondée de pluie sur la montagne# contient #[[1]]#.", {QM_RED, QM_GREEN}));
                                                           // /*spanish*/ Según dicen, bajo un #hoyo de una montaña inundado de lluvia# yace #[[1]]#.
 
     hintTextTable[RHT_DMT_STORMS_GROTTO_FISH] = HintText(CustomMessage("They say that #fish in a hole flooded with rain on a mountain# holds #[[1]]#.",
-                                                            /*german*/ "",
+                                                            /*german*/ "Man erzählt sich, daß ein #Fisch in einem durch Regen geflutetes Loch auf einem Berg# #[[1]]# enthielte.",
                                                             /*french*/ "Selon moi, la #grotte inondée de pluie sur la montagne# contient #[[1]]#.", {QM_RED, QM_GREEN}));
                                                          // /*spanish*/ Según dicen, bajo un #hoyo de una montaña inundado de lluvia# yace #[[1]]#.
 
     hintTextTable[RHT_DMC_UPPER_GROTTO_CHEST] = HintText(CustomMessage("They say that a #hole in a volcano# holds #[[1]]#.",
-                                                            /*german*/ "",
+                                                            /*german*/ "Man erzählt sich, daß ein #Loch in einem Vulkan# #[[1]]# enthielte.",
                                                             /*french*/ "Selon moi, la #grotte dans le volcan# contient #[[1]]#.", {QM_RED, QM_GREEN}));
                                                          // /*spanish*/ Según dicen, bajo el #hoyo de un volcán# yace #[[1]]#.
 
     hintTextTable[RHT_DMC_UPPER_GROTTO_FISH] = HintText(CustomMessage("They say that a #fish in a hole in a volcano# holds #[[1]]#.",
-                                                           /*german*/ "",
+                                                           /*german*/ "Man erzählt sich, daß ein #Fisch in einem Loch in einem Vulkan# #[[1]]# enthielte.",
                                                            /*french*/ "Selon moi, la #grotte dans le volcan# contient #[[1]]#.", {QM_RED, QM_GREEN}));
                                                         // /*spanish*/ Según dicen, bajo el #hoyo de un volcán# yace #[[1]]#.
 
     hintTextTable[RHT_TOT_MASTER_SWORD] = HintText(CustomMessage("They say that a #pedestal in a temple# holds #[[1]]#.",
-                                                      /*german*/ "",
+                                                      /*german*/ "Man erzählt sich, daß sich auf einem #Podest in einem Tempel# #[[1]]# befände.",
                                                       /*french*/ "Selon moi, un #piédestal dans un temple# contient #[[1]]#.", {QM_RED, QM_GREEN}));
                                                    // /*spanish*/ Según dicen, un #pedestal en un templo# sostiene #[[1]]#.
 
     hintTextTable[RHT_TOT_LIGHT_ARROWS_CUTSCENE] = HintText(CustomMessage("They say that the #final gift of a princess# is #[[1]]#.",
-                                                               /*german*/ "",
+                                                               /*german*/ "Man erzählt sich, daß das #letzte Geschenk einer Prinzessin# #[[1]]# sei.",
                                                                /*french*/ "Selon moi, le #cadeau d'adieu de la princesse# est #[[1]]#.", {QM_RED, QM_GREEN}));
                                                             // /*spanish*/ Según dicen, el #obsequio final de la princesa# se trata de #[[1]]#.
 
     hintTextTable[RHT_LW_GIFT_FROM_SARIA] = HintText(CustomMessage("They say that #Saria's Gift# is #[[1]]#.",
-                                                        /*german*/ "",
+                                                        /*german*/ "Man erzählt sich, daß #Salias Geschenk# #[[1]]# sei.",
                                                         /*french*/ "Selon moi, le #cadeau de Saria# est #[[1]]#.", {QM_RED, QM_GREEN}),
                                                      // /*spanish*/ Según dicen, el #regalo de Saria# se trata de #[[1]]#.
                                                      {}, {
                                                      CustomMessage("They say that a #potato hoarder# holds #[[1]]#.",
-                                                         /*german*/ "",
+                                                         /*german*/ "Man erzählt sich, daß ein #Kartoffelhortender# #[[1]]# besäße.",
                                                          /*french*/ "Selon moi, le #panini mélodieux# est en fait #[[1]]#.", {QM_RED, QM_GREEN}),
                                                       // /*spanish*/ Según dicen, cierta #jovencita verde# concede #[[1]]#.
                                                      CustomMessage("They say that a rooty tooty #flutey cutey# gifts #[[1]]#.",
-                                                         /*german*/ "",
+                                                         /*german*/ "Man erzählt sich, daß die #musikalische Kartoffel# #[[1]]# schenke.",
                                                          /*french*/ "Selon moi, la #patate musicale# est en fait #[[1]]#.", {QM_RED, QM_GREEN})});
                                                       // /*spanish*/ Según dicen, una #gran amiga# concede #[[1]]#.
 
     hintTextTable[RHT_ZF_GREAT_FAIRY_REWARD] = HintText(CustomMessage("They say that the #fairy of winds# holds #[[1]]#.",
-                                                           /*german*/ "",
+                                                           /*german*/ "Man erzählt sich, daß die #Fee der Winde# #[[1]]# besäße.",
                                                            /*french*/ "Selon moi, la #fée du vent# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                         // /*spanish*/ Según dicen, el #hada del viento# brinda #[[1]]#.
 
     hintTextTable[RHT_HC_GREAT_FAIRY_REWARD] = HintText(CustomMessage("They say that the #fairy of fire# holds #[[1]]#.",
-                                                           /*german*/ "",
+                                                           /*german*/ "Man erzählt sich, daß die #Fee des Feuers# #[[1]]# besäße.",
                                                            /*french*/ "Selon moi, la #fée du feu# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                         // /*spanish*/ Según dicen, el #hada del fuego# brinda #[[1]]#.
 
     hintTextTable[RHT_COLOSSUS_GREAT_FAIRY_REWARD] = HintText(CustomMessage("They say that the #fairy of love# holds #[[1]]#.",
-                                                                 /*german*/ "",
+                                                                 /*german*/ "Man erzählt sich, daß die #Fee der Liebe# #[[1]]# besäße.",
                                                                  /*french*/ "Selon moi, la #fée de l'amour# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                               // /*spanish*/ Según dicen, el #hada del amor# brinda #[[1]]#.
 
     hintTextTable[RHT_DMT_GREAT_FAIRY_REWARD] = HintText(CustomMessage("They say that a #magical fairy# gifts #[[1]]#.",
-                                                            /*german*/ "",
+                                                            /*german*/ "Man erzählt sich, daß eine #magische Fee# #[[1]]# schenke.",
                                                             /*french*/ "Selon moi, la #fée de la magie# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                          // /*spanish*/ Según dicen, un #hada mágica# brinda #[[1]]#.
 
     hintTextTable[RHT_DMC_GREAT_FAIRY_REWARD] = HintText(CustomMessage("They say that a #magical fairy# gifts #[[1]]#.",
-                                                            /*german*/ "",
+                                                            /*german*/ "Man erzählt sich, daß eine #magische Fee# #[[1]]# schenke.",
                                                             /*french*/ "Selon moi, la #fée de la magie# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                          // /*spanish*/ Según dicen, un #hada mágica# brinda #[[1]]#.
 
     hintTextTable[RHT_OGC_GREAT_FAIRY_REWARD] = HintText(CustomMessage("They say that the #fairy of strength# holds #[[1]]#.",
-                                                            /*german*/ "",
+                                                            /*german*/ "Man erzählt sich, daß die #Fee der Stärke# #[[1]]# besäße.",
                                                             /*french*/ "Selon moi, la #fée de la force# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                          // /*spanish*/ Según dicen, el #hada de la fuerza# brinda #[[1]]#.
 
     hintTextTable[RHT_SONG_FROM_IMPA] = HintText(CustomMessage("They say that #deep in a castle#, Impa teaches #[[1]]#.",
-                                                    /*german*/ "",
+                                                    /*german*/ "Man erzählt sich, daß #tief in einem Schloß#, Impa #[[1]]# lehre.",
                                                     /*french*/ "Selon moi, #la gardienne de la princesse# donne #[[1]]#.", {QM_RED, QM_GREEN}));
                                                  // /*spanish*/ Según dicen, en el #jardín del castillo Impa enseña# #[[1]]#.
 
     hintTextTable[RHT_SONG_FROM_MALON] = HintText(CustomMessage("They say that #a farm girl# sings #[[1]]#.",
-                                                     /*german*/ "",
+                                                     /*german*/ "Man erzählt sich, daß ein #Mädchen des Landes# #[[1]]# singe.",
                                                      /*french*/ "Selon moi, la #fillette de la ferme# donne #[[1]]#.", {QM_RED, QM_GREEN}));
                                                   // /*spanish*/ Según dicen, una #chica rupestre# canta #[[1]]#.
 
     hintTextTable[RHT_SONG_FROM_SARIA] = HintText(CustomMessage("They say that #deep in the forest#, Saria teaches #[[1]]#.",
-                                                     /*german*/ "",
+                                                     /*german*/ "Man erzählt sich, daß #tief im Wald#, Salia #[[1]]# lehre.",
                                                      /*french*/ "Selon moi, la #fille de la forêt# donne #[[1]]#.", {QM_RED, QM_GREEN}));
                                                   // /*spanish*/ Según dicen, al #fondo del bosque# Saria enseña #[[1]]#.
 
     hintTextTable[RHT_SONG_FROM_WINDMILL] = HintText(CustomMessage("They say that a man #in a windmill# is obsessed with #[[1]]#.",
-                                                        /*german*/ "",
+                                                        /*german*/ "Man erzählt sich, daß ein Mann #in einer Windmühle# von #[[1]]# besessen sei.",
                                                         /*french*/ "Selon moi, l'#homme du moulin# donne #[[1]]#.", {QM_RED, QM_GREEN}));
                                                      // /*spanish*/ Según dicen, el #hombre del molino# está obsesionado con #[[1]]#.
 
     hintTextTable[RHT_HC_MALON_EGG] = HintText(CustomMessage("They say that a #girl looking for her father# gives #[[1]]#.",
-                                                  /*german*/ "",
+                                                  /*german*/ "Man erzählt sich, daß ein #nach ihrem Vater suchenden Mädchen# #[[1]]# gäbe.",
                                                   /*french*/ "Selon moi, la #fillette qui cherche son père# donne #[[1]]#.", {QM_RED, QM_GREEN}));
                                                // /*spanish*/ Según dicen, una #chica en busca de su padre# otorga #[[1]]#.
 
     hintTextTable[RHT_HC_ZELDAS_LETTER] = HintText(CustomMessage("They say that a #princess in a castle# gifts #[[1]]#.",
-                                                      /*german*/ "",
+                                                      /*german*/ "Man erzählt sich, daß eine #Prinzessin in einem Schloß# #[[1]]# schenke.",
                                                       /*french*/ "Selon moi, la #princesse dans le château# donne #[[1]]#.", {QM_RED, QM_GREEN}));
                                                    // /*spanish*/ Según dicen, la #princesa de un castillo# otorga #[[1]]#.
 
     hintTextTable[RHT_ZD_DIVING_MINIGAME] = HintText(CustomMessage("They say that those who #dive for Zora rupees# will find #[[1]]#.",
-                                                        /*german*/ "",
+                                                        /*german*/ "Man erzählt sich, daß jene, welche nach den #Rubinen der Zora tauchen# #[[1]]# fänden.",
                                                         /*french*/ "Selon moi, ceux qui #plongent pour des rubis Zora# trouveront #[[1]]#.", {QM_RED, QM_GREEN}),
                                                      // /*spanish*/ Según dicen, aquellos que se #sumergan por las rupias zora# encontrarán #[[1]]#.
                                                      {}, {
                                                      CustomMessage("They say that an #unsustainable business model# gifts #[[1]]#.",
-                                                         /*german*/ "",
+                                                         /*german*/ "Man erzählt sich, daß ein #unwirtschaftliches Geschäftsmodell# #[[1]]# schenke.",
                                                          /*french*/ "Selon moi, le #mauvais modèle d'affaires# donne #[[1]]#.", {QM_RED, QM_GREEN})});
                                                       // /*spanish*/ Según dicen, un #mal modelo de negocio# premia con #[[1]]#.
 
     hintTextTable[RHT_LH_CHILD_FISHING] = HintText(CustomMessage("They say that #fishing in youth# bestows #[[1]]#.",
-                                                      /*german*/ "",
+                                                      /*german*/ "Man erzählt sich, daß das #Fischen in der Jugend# #[[1]]# verleihe.",
                                                       /*french*/ "Selon moi, #pêcher dans sa jeunesse# promet #[[1]]#.", {QM_RED, QM_GREEN}));
                                                    // /*spanish*/ Según dicen, #pescar en la juventud# conduce a #[[1]]#.
 
     hintTextTable[RHT_LH_POND_FISH] = HintText(CustomMessage("They say that #hitting the pond# reveals #[[1]]#.",
-                                                  /*german*/ "",
+                                                  /*german*/ "Man erzählt sich, daß das #Fischen im Teich# #[[1]]# enthülle.",
                                                   /*french*/ "Selon moi,  #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_LH_HYRULE_LOACH] = HintText(CustomMessage("They say that #fishing the hyrule loach# will give you #[[1]]#.",
-                                                     /*german*/ "",
+                                                     /*german*/ "Man erzählt sich, daß das #Fischen der hylianischen Schmerle# #[[1]]# einbrächte.",
                                                      /*french*/ "Selon moi, !!! #[[1]]#.", {QM_RED, QM_GREEN}),
                                                   // /*spanish*/ Según dicen, si #pescas a la Locha de Hyrule# encontrarás #[[1]]#.
                                                   {}, {
                                                   CustomMessage("They say that #fishing the legend# bestows #[[1]]#.",
-                                                      /*german*/ "",
+                                                      /*german*/ "Man erzählt sich, daß das #Fischen der Legende# #[[1]]# verleihe.",
                                                       /*french*/ "Selon moi, !!! #[[1]]#.", {QM_RED, QM_GREEN})});
                                                    // /*spanish*/ Según dicen, #pescar a la leyenda# conduce a #[[1]]#.
 
     hintTextTable[RHT_LH_ADULT_FISHING] = HintText(CustomMessage("They say that #fishing in maturity# bestows #[[1]]#.",
-                                                      /*german*/ "",
+                                                      /*german*/ "Man erzählt sich, daß das #Fischen im Alter# #[[1]]# verleihe.",
                                                       /*french*/ "Selon moi, #pêcher dans sa maturité# promet #[[1]]#.", {QM_RED, QM_GREEN}));
                                                    // /*spanish*/ Según dicen, #pescar en la madurez# conduce a #[[1]]#.
 
     hintTextTable[RHT_LH_LAB_DIVE] = HintText(CustomMessage("They say that a #diving experiment# is rewarded with #[[1]]#.",
-                                                 /*german*/ "",
+                                                 /*german*/ "Man erzählt sich, daß ein #Tauchexperiment# mit #[[1]]# belohnt würde.",
                                                  /*french*/ "Selon moi, l'#expérience de plongée# donne #[[1]]#.", {QM_RED, QM_GREEN}));
                                               // /*spanish*/ Según dicen, #bucear para un experimento# se premia con #[[1]]#.
     // RANDOTODO: needs translation
-    hintTextTable[RHT_ZD_FISH] = HintText(CustomMessage("They say that a #fish by a waterfall# hoards #[[1]]#.", {QM_RED, QM_GREEN}));
+    hintTextTable[RHT_ZD_FISH] = HintText(CustomMessage("They say that a #fish by a waterfall# hoards #[[1]]#.",
+                                             /*german*/ "Man erzählt sich, daß ein #Fisch nahe eines Wasserfalls# #[[1]]# horte.",
+                                             /*french*/ "Selon moi, #[[1]]#.", {QM_RED, QM_GREEN}));
+                                          // /*spanish*/ Según dicen, #[[1]]#.
 
  
     hintTextTable[RHT_GC_ROLLING_GORON_AS_ADULT] = HintText(CustomMessage("They say that #reassuring a young Goron# is rewarded with #[[1]]#.",
-                                                               /*german*/ "",
+                                                               /*german*/ "Man erzählt sich, daß das #Beruhigen eines jungen Goronen# mit #[[1]]# belohnt würde.",
                                                                /*french*/ "Selon moi, #rassurer un jeune Goron# donne #[[1]]#.", {QM_RED, QM_GREEN}),
                                                             // /*spanish*/ Según dicen, #calmar a un joven Goron# otorga #[[1]]#.
                                                             {}, {
                                                             CustomMessage("They say that #comforting yourself# provides #[[1]]#.",
-                                                                /*german*/ "",
+                                                                /*german*/ "Man erzählt sich, daß die #Ermutigung von einem Selbst# #[[1]]# einbrächte.",
                                                                 /*french*/ "Selon moi, se #réconforter soi-même# donne #[[1]]#.", {QM_RED, QM_GREEN})});
                                                              // /*spanish*/ Según dicen, #confrontarte a ti mismo# otorga #[[1]]#.
 
     hintTextTable[RHT_MARKET_BOMBCHU_BOWLING_FIRST_PRIZE] = HintText(CustomMessage("They say that the #first explosive prize# is #[[1]]#.",
-                                                                        /*german*/ "",
+                                                                        /*german*/ "Man erzählt sich, daß der #erste explosive Preis# #[[1]]# sei.",
                                                                         /*french*/ "Selon moi, le #premier prix explosif# est #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                      // /*spanish*/ Según dicen, el #primer premio explosivo# se trata de #[[1]]#.
 
     hintTextTable[RHT_MARKET_BOMBCHU_BOWLING_SECOND_PRIZE] = HintText(CustomMessage("They say that the #second explosive prize# is #[[1]]#.",
-                                                                         /*german*/ "",
+                                                                         /*german*/ "Man erzählt sich, daß der #zweite explosive Preis# #[[1]]# sei.",
                                                                          /*french*/ "Selon moi, le #deuxième prix explosif# est #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                       // /*spanish*/ Según dicen, el #segundo premio explosivo# se trata de #[[1]]#.
 
     hintTextTable[RHT_MARKET_LOST_DOG] = HintText(CustomMessage("They say that #rescuing Richard the Dog# is rewarded with #[[1]]#.",
-                                                     /*german*/ "",
+                                                     /*german*/ "Man erzählt sich, daß die #Rettung des Hundes Richard# mit #[[1]]# belohnt würde.",
                                                      /*french*/ "Selon moi, #retrouver Kiki le chien# promet #[[1]]#.", {QM_RED, QM_GREEN}),
                                                   // /*spanish*/ Según dicen, #rescatar al perrito Ricardo# conduce a #[[1]]#.
                                                   {}, {
                                                   CustomMessage("They say that #puppy lovers# will find #[[1]]#.",
-                                                      /*german*/ "",
+                                                      /*german*/ "Man erzählt sich, daß #Welpenliebhaber# #[[1]]# fänden.",
                                                       /*french*/ "Selon moi, les #amoureux canins# trouveront #[[1]]#.", {QM_RED, QM_GREEN})});
                                                    // /*spanish*/ Según dicen, los #amantes caninos# encontrarán #[[1]]#.
 
     hintTextTable[RHT_LW_OCARINA_MEMORY_GAME] = HintText(CustomMessage("They say that #playing an Ocarina in Lost Woods# is rewarded with #[[1]]#.",
-                                                            /*german*/ "",
+                                                            /*german*/ "Man erzählt sich, daß das #Spielen der Okarina in den verlorenen Wäldern# mit #[[1]]# belohnt würde.",
                                                             /*french*/ "Selon moi, #jouer l'ocarina dans les Bois Perdus# donne #[[1]]#.", {QM_RED, QM_GREEN}),
                                                          // /*spanish*/ Según dicen, #tocar la ocarina en el Bosque Perdido# otorga #[[1]]#.
                                                          {}, {
                                                          CustomMessage("They say that the prize for a #game of Simon Says# is #[[1]]#.",
-                                                             /*german*/ "",
+                                                             /*german*/ "Man erzählt sich, daß der Preis für eine Partie #Simon sagt# #[[1]]# sei.",
                                                              /*french*/ "Selon moi, la #récompense de Jean Dit# est #[[1]]#.", {QM_RED, QM_GREEN}),
                                                           // /*spanish*/ Según dicen, #repetir ciertas melodías# otorga #[[1]]#.
                                                          CustomMessage("They say that a #child sing-a-long# holds #[[1]]#.",
-                                                             /*german*/ "",
+                                                             /*german*/ "Man erzählt sich, daß die #jungen Flötisten# #[[1]]# besäßen.",
                                                              /*french*/ "Selon moi, les #jeunes flûtistes# donnent #[[1]]#.", {QM_RED, QM_GREEN})});
                                                           // /*spanish*/ Según dicen, #tocar junto a otros# otorga #[[1]]#.
 
     hintTextTable[RHT_KAK_10_GOLD_SKULLTULA_REWARD] = HintText(CustomMessage("They say that slaying #10 Gold Skulltulas# reveals #[[1]]#.",
-                                                                  /*german*/ "",
+                                                                  /*german*/ "Man erzählt sich, daß das Besiegen von #10 Goldenen Skulltulas# #[[1]]# enthüllen würde.",
                                                                   /*french*/ "Selon moi, détruire #10 Skulltulas d'or# donne #[[1]]#.", {QM_RED, QM_GREEN}),
                                                                // /*spanish*/ Según dicen, #exterminar 10 skulltulas doradas# revela #[[1]]#.
                                                                {}, {
                                                                CustomMessage("They say that #10 bug badges# rewards #[[1]]#.",
-                                                                   /*german*/ "",
+                                                                   /*german*/ "Man erzählt sich, daß #10 Käferabzeichen# mit #[[1]]# belohnt würde.",
                                                                    /*french*/ "Selon moi, #10 écussons# donnent #[[1]]#.", {QM_RED, QM_GREEN}),
                                                                 // /*spanish*/ Según dicen, #10 medallas de insectos# otorgan #[[1]]#.
                                                                CustomMessage("They say that #10 spider souls# yields #[[1]]#.",
-                                                                   /*german*/ "",
+                                                                   /*german*/ "Man erzählt sich, daß #10 Spinnenseelen# #[[1]]# einbrächten.",
                                                                    /*french*/ "Selon moi, #10 âmes# donnent #[[1]]#.", {QM_RED, QM_GREEN}),
                                                                 // /*spanish*/ Según dicen, #10 almas de araña# otorgan #[[1]]#.
                                                                CustomMessage("They say that #10 auriferous arachnids# lead to #[[1]]#.",
-                                                                   /*german*/ "",
+                                                                   /*german*/ "Man erzählt sich, daß #10 goldhaltige Arachniden# zu #[[1]]# führen würden.",
                                                                    /*french*/ "Selon moi, #10 arachnides aurifères# donnent #[[1]]#.", {QM_RED, QM_GREEN})});
                                                                 // /*spanish*/ Según dicen, #10 arácnidos auríferos# otorgan #[[1]]#.
 
     hintTextTable[RHT_KAK_MAN_ON_ROOF] = HintText(CustomMessage("They say that a #rooftop wanderer# holds #[[1]]#.",
-                                                     /*german*/ "",
+                                                     /*german*/ "Man erzählt sich, daß ein #Dachwanderer# #[[1]]# besäße.",
                                                      /*french*/ "Selon moi, une #rencontre sur un toit# donne #[[1]]#.", {QM_RED, QM_GREEN}));
                                                   // /*spanish*/ Según dicen, #alguien sobre un tejado# otorga #[[1]]#.
 
     hintTextTable[RHT_ZR_MAGIC_BEAN_SALESMAN] = HintText(CustomMessage("They say that a #bean seller# offers #[[1]]#.",
-                                                            /*german*/ "",
+                                                            /*german*/ "Man erzählt sich, daß ein #Bohnenverkäufer# #[[1]]# offeriere.",
                                                             /*french*/ "Selon moi, le #marchand de haricots magiques# vend en fait #[[1]]#.", {QM_RED, QM_GREEN}),
                                                          // /*spanish*/ Según dicen, el #vendedor de judías# ofrece #[[1]]#.
                                                          {}, {
                                                          CustomMessage("They say that a seller of #colorful crops# has #[[1]]#.",
-                                                             /*german*/ "",
+                                                             /*german*/ "Man erzählt sich, daß ein Verkäufer #bunter Ernte# #[[1]]# besäße.",
                                                              /*french*/ "Selon moi, le #marchand de légumes# vend #[[1]]#.", {QM_RED, QM_GREEN})});
                                                           // /*spanish*/ Según dicen, el vendedor de un #colorido cultivo# ofrece #[[1]]#.
 
     hintTextTable[RHT_ZR_FROGS_IN_THE_RAIN] = HintText(CustomMessage("They say that #frogs in a storm# gift #[[1]]#.",
-                                                          /*german*/ "",
+                                                          /*german*/ "Man erzählt sich, daß #Frösche im Sturm# #[[1]]# schenken würden.",
                                                           /*french*/ "Selon moi, #des grenouilles mouillées# donnent #[[1]]#.", {QM_RED, QM_GREEN}));
                                                        // /*spanish*/ Según dicen, las #ancas bajo la tormenta# otorgan #[[1]]#.
 
     hintTextTable[RHT_ZR_FROGS_ZELDAS_LULLABY] = HintText(CustomMessage("They say that after hearing #Zelda's Lullaby, the frogs# gift #[[1]]#.",
-                                                             /*german*/ "",
+                                                             /*german*/ "Man erzählt sich, daß die #Frösche nach dem Hören von Zeldas Wiegenlied# #[[1]]# schenken würden.",
                                                              /*french*/ "Selon moi, à l'écoute de #la berceuse de Zelda, les grenouilles# donnent #[[1]]#.", {QM_RED, QM_GREEN}),
                                                           // /*spanish*/ Según dicen, después de escuchar #la Nana de Zelda, las ranas# regalan #[[1]]#.
                                                           {}, {
                                                           CustomMessage("They say that #sleepy frogs# gift #[[1]]#.",
-                                                              /*german*/ "",
+                                                              /*german*/ "Man erzählt sich, daß #schläfrige Frösche# #[[1]]# schenken würden.",
                                                               /*french*/ "Selon moi, #les grenouilles somnolentes# donnent #[[1]]#.", {QM_RED, QM_GREEN}),
                                                            // /*spanish*/ Según dicen, las #ranas somnolientas# regalan #[[1]]#.
                                                           CustomMessage("They say that #the Froggish Tenor in the back-left# gifts #[[1]]#.",
-                                                              /*german*/ "",
+                                                              /*german*/ "Man erzählt sich, daß #der froschige Tenor hinten links# #[[1]]# schenke.",
                                                               /*french*/ "Selon moi, #le ténor grenouillesque au fond à gauche# donne #[[1]]#.", {QM_RED, QM_GREEN})});
                                                            // /*spanish*/ Según dicen, el #Sapo Tenore al fondo, a la izquierda#, regala #[[1]]#.
 
     hintTextTable[RHT_ZR_FROGS_EPONAS_SONG] = HintText(CustomMessage("They say that after hearing #Epona's Song, the frogs# gift #[[1]]#.",
-                                                          /*german*/ "",
+                                                          /*german*/ "Man erzählt sich, daß die #Frösche nach dem Hören von Eponas Lied# #[[1]]# schenken würden.",
                                                           /*french*/ "Selon moi, à l'écoute du #chant d'Epona, les grenouilles# donnent #[[1]]#.", {QM_RED, QM_GREEN}),
                                                        // /*spanish*/ Según dicen, después de escuchar #la Canción de Epona, las ranas# regalan #[[1]]#.
                                                        {}, {
                                                        CustomMessage("They say that #equine frogs# gift #[[1]]#.",
-                                                           /*german*/ "",
+                                                           /*german*/ "Man erzählt sich, daß #pferdeartige Frösche# #[[1]]# schenken würden.",
                                                            /*french*/ "Selon moi, #les grenouilles équestres# donnent #[[1]]#.", {QM_RED, QM_GREEN}),
                                                         // /*spanish*/ Según dicen, las #ranas equinas# regalan #[[1]]#.
                                                        CustomMessage("They say that #the Froggish Tenor in the back-right# gifts #[[1]]#.",
-                                                           /*german*/ "",
+                                                           /*german*/ "Man erzählt sich, daß #der froschige Tenor hinten rechts# #[[1]]# schenke.",
                                                            /*french*/ "Selon moi, #le ténor grenouillesque au fond à droite# donne #[[1]]#.", {QM_RED, QM_GREEN})});
                                                         // /*spanish*/ Según dicen, el #Sapo Tenore al fondo, a la derecha#, regala #[[1]]#.
 
     hintTextTable[RHT_ZR_FROGS_SARIAS_SONG] = HintText(CustomMessage("They say that after hearing #Saria's Song, the frogs# gift #[[1]]#.",
-                                                          /*german*/ "",
+                                                          /*german*/ "Man erzählt sich, daß die #Frösche nach dem Hören von Salias Lied# #[[1]]# schenken würden.",
                                                           /*french*/ "Selon moi, à l'écoute du #chant de Saria, les grenouilles# donnent #[[1]]#.", {QM_RED, QM_GREEN}),
                                                        // /*spanish*/ Según dicen, después de escuchar #la Canción de Saria, las ranas# regalan #[[1]]#.
                                                        {}, {
                                                        CustomMessage("They say that #sylvan frogs# gift #[[1]]#.",
-                                                           /*german*/ "",
+                                                           /*german*/ "Man erzählt sich, daß #waldige Frösche# #[[1]]# schenken würden.",
                                                            /*french*/ "Selon moi, #les grenouilles sylvestres# donnent #[[1]]#.", {QM_RED, QM_GREEN}),
                                                         // /*spanish*/ Según dicen, las #ranas silvestres# regalan #[[1]]#.
                                                        CustomMessage("They say that #the Froggish Tenor in the center# gifts #[[1]]#.",
-                                                           /*german*/ "",
+                                                           /*german*/ "Man erzählt sich, daß #der froschige Tenor im Zentrum# #[[1]]# schenke.",
                                                            /*french*/ "Selon moi, #le ténor grenouillesque dans le centre# donne #[[1]]#.", {QM_RED, QM_GREEN})});
                                                         // /*spanish*/ Según dicen, el #Sapo Tenore en el centro# regala #[[1]]#.
 
     hintTextTable[RHT_ZR_FROGS_SUNS_SONG] = HintText(CustomMessage("They say that after hearing #the Sun's Song, the frogs# gift #[[1]]#.",
-                                                        /*german*/ "",
+                                                        /*german*/ "Man erzählt sich, daß die #Frösche nach dem Hören der Hymne der Sonne# #[[1]]# schenken würden.",
                                                         /*french*/ "Selon moi, à l'écoute du #chant du soleil, les grenouilles# donnent #[[1]]#.", {QM_RED, QM_GREEN}),
                                                      // /*spanish*/ Según dicen, después de escuchar #la Canción del Sol, las ranas# regalan #[[1]]#.
                                                      {}, {
                                                      CustomMessage("They say that #enlightened frogs# gift #[[1]]#.",
-                                                         /*german*/ "",
+                                                         /*german*/ "Man erzählt sich, daß #erleuchtete Frösche# #[[1]]# schenken würden.",
                                                          /*french*/ "Selon moi, #les grenouilles éclairées# donnent #[[1]]#.", {QM_RED, QM_GREEN}),
                                                       // /*spanish*/ Según dicen, las #ranas alumbradas# regalan #[[1]]#.
                                                      CustomMessage("They say that #the Froggish Tenor in the front-left# gifts #[[1]]#.",
-                                                         /*german*/ "",
+                                                         /*german*/ "Man erzählt sich, daß #der froschige Tenor vorne links# #[[1]]# schenke.",
                                                          /*french*/ "Selon moi, #le ténor grenouillesque à l'avant gauche# donne #[[1]]#.", {QM_RED, QM_GREEN})});
                                                       // /*spanish*/ Según dicen, el #Sapo Tenore al frente, a la izquierda#, regala #[[1]]#.
 
     hintTextTable[RHT_ZR_FROGS_SONG_OF_TIME] = HintText(CustomMessage("They say that after hearing #the Song of Time, the frogs# gift #[[1]]#.",
-                                                           /*german*/ "",
+                                                           /*german*/ "Man erzählt sich, daß die #Frösche nach dem Hören der Hymne der Zeit# #[[1]]# schenken würden.",
                                                            /*french*/ "Selon moi, à l'écoute du #chant du temps, les grenouilles# donnent #[[1]]#.", {QM_RED, QM_GREEN}),
                                                         // /*spanish*/ Según dicen, después de escuchar #la Canción del tiempo, las ranas# regalan #[[1]]#.
                                                         {}, {
                                                         CustomMessage("They say that #time-traveling frogs# gift #[[1]]#.",
-                                                            /*german*/ "",
+                                                            /*german*/ "Man erzählt sich, daß #zeitreisende Frösche# #[[1]]# schenken würden.",
                                                             /*french*/ "Selon moi, #les grenouilles voyageuses dans le temps# donnent #[[1]]#.", {QM_RED, QM_GREEN}),
                                                          // /*spanish*/ Según dicen, las #ranas viajeras del tiempo# regalan #[[1]]#.
                                                         CustomMessage("They say that #the Froggish Tenor in the front-right# gifts #[[1]]#.",
-                                                            /*german*/ "",
+                                                            /*german*/ "Man erzählt sich, daß #der froschige Tenor vorne rechts# #[[1]]# schenke.",
                                                             /*french*/ "Selon moi, #le ténor grenouillesque à l'avant droite# donne #[[1]]#.", {QM_RED, QM_GREEN})});
                                                          // /*spanish*/ Según dicen, el #Sapo Tenore al frente, a la derecha#, regala #[[1]]#.
 
     hintTextTable[RHT_GF_HBA_1000_POINTS] = HintText(CustomMessage("They say that scoring 1000 in #horseback archery# grants #[[1]]#.",
-                                                        /*german*/ "",
+                                                        /*german*/ "Man erzählt sich, daß das Erzielen von 1000 Punkten beim #Pferdebogenschießen# #[[1]]# einbrächte.",
                                                         /*french*/ "Selon moi, obtenir 1000 points dans l'#archerie équestre# donne #[[1]]#.", {QM_RED, QM_GREEN}));
                                                      // /*spanish*/ Según dicen, conseguir 1000 puntos en el #tiro con arco a caballo# premia #[[1]]#.
 
     hintTextTable[RHT_MARKET_SHOOTING_GALLERY_REWARD] = HintText(CustomMessage("They say that #shooting in youth# grants #[[1]]#.",
-                                                                    /*german*/ "",
+                                                                    /*german*/ "Man erzählt sich, daß das #Schießen in der Jugend# #[[1]]# einbrächte.",
                                                                     /*french*/ "Selon moi, #faire du tir dans sa jeunesse# donne #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                  // /*spanish*/ Según dicen, #disparar en la juventud# otorga #[[1]]#.
 
     hintTextTable[RHT_KAK_SHOOTING_GALLERY_REWARD] = HintText(CustomMessage("They say that #shooting in maturity# grants #[[1]]#.",
-                                                                 /*german*/ "",
+                                                                 /*german*/ "Man erzählt sich, daß das #Schießen im Alter# #[[1]]# einbrächte.",
                                                                  /*french*/ "Selon moi, #faire du tir dans sa maturité# donne #[[1]]#.", {QM_RED, QM_GREEN}));
                                                               // /*spanish*/ Según dicen, #disparar en la madurez# otorga #[[1]]#.
 
     hintTextTable[RHT_LW_TARGET_IN_WOODS] = HintText(CustomMessage("They say that shooting a #target in the woods# grants #[[1]]#.",
-                                                        /*german*/ "",
+                                                        /*german*/ "Man erzählt sich, daß das Abschießen eines #Zieles in den Wäldern# #[[1]]# einbrächte.",
                                                         /*french*/ "Selon moi, #tirer une cible dans les bois# donne #[[1]]#.", {QM_RED, QM_GREEN}));
                                                      // /*spanish*/ Según dicen, disparar a un #blanco forestal# brinda #[[1]]#.
 
     hintTextTable[RHT_KAK_ANJU_AS_ADULT] = HintText(CustomMessage("They say that a #chicken caretaker# offers adults #[[1]]#.",
-                                                       /*german*/ "",
+                                                       /*german*/ "Man erzählt sich, daß ein #Hühnchenpfleger# Erwachsenen #[[1]]# anböte.",
                                                        /*french*/ "Selon moi, devenir un #éleveur de Cocottes# donne #[[1]]#.", {QM_RED, QM_GREEN}));
                                                     // /*spanish*/ Según dicen, una #cuidadora de emplumados# le ofrece a los mayores #[[1]]#.
 
     hintTextTable[RHT_LLR_TALONS_CHICKENS] = HintText(CustomMessage("They say that #finding Super Cuccos# is rewarded with #[[1]]#.",
-                                                         /*german*/ "",
+                                                         /*german*/ "Man erzählt sich, daß das #Finden von Superhühnchen# mit #[[1]]# belohnt würde.",
                                                          /*french*/ "Selon moi, #trouver des Super Cocottes# donne #[[1]]#.", {QM_RED, QM_GREEN}));
                                                       // /*spanish*/ Según dicen, #hallar los supercucos# conduce a #[[1]]#.
 
     hintTextTable[RHT_GC_ROLLING_GORON_AS_CHILD] = HintText(CustomMessage("They say that the prize offered by a #large rolling Goron# is #[[1]]#.",
-                                                               /*german*/ "",
+                                                               /*german*/ "Man erzählt sich, daß der angebotene Preis eines #großen rollenden Goronen# #[[1]]# sei.",
                                                                /*french*/ "Selon moi, la récompense d'un #gros Goron roulant# est #[[1]]#.", {QM_RED, QM_GREEN}));
                                                             // /*spanish*/ Según dicen, un #gran Goron rodante# otorga #[[1]]#.
 
     hintTextTable[RHT_LH_UNDERWATER_ITEM] = HintText(CustomMessage("They say that the #sunken treasure in a lake# is #[[1]]#.",
-                                                        /*german*/ "",
+                                                        /*german*/ "Man erzählt sich, daß der #versunkene Schatz in einem See# #[[1]]# sei.",
                                                         /*french*/ "Selon moi, le #trésor au fond du lac# est #[[1]]#.", {QM_RED, QM_GREEN}));
                                                      // /*spanish*/ Según dicen, el #tesoro hundido del lago# se trata de #[[1]]#.
 
     hintTextTable[RHT_GF_GERUDO_MEMBERSHIP_CARD] = HintText(CustomMessage("They say that #rescuing captured carpenters# is rewarded with #[[1]]#.",
-                                                               /*german*/ "",
+                                                               /*german*/ "Man erzählt sich, daß das #Retten gefangener Zimmerleute# mit #[[1]]# belohnt würde.",
                                                                /*french*/ "Selon moi, #secourir les charpentiers capturés# assure #[[1]]#.", {QM_RED, QM_GREEN}));
                                                             // /*spanish*/ Según dicen, #rescatar los apresados carpinteros# se premia con #[[1]]#.
 
     hintTextTable[RHT_WASTELAND_BOMBCHU_SALESMAN] = HintText(CustomMessage("They say that a #carpet guru# sells #[[1]]#.",
-                                                                /*german*/ "",
+                                                                /*german*/ "Man erzählt sich, daß ein #Teppichguru# #[[1]]# verkaufe.",
                                                                 /*french*/ "Selon moi, #un marchand du désert# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                              // /*spanish*/ Según dicen, el #genio de una alfombra# vende #[[1]]#.
 
     hintTextTable[RHT_GC_MEDIGORON] = HintText(CustomMessage("They say that #Medigoron# sells #[[1]]#.",
-                                                  /*german*/ "",
+                                                  /*german*/ "Man erzählt sich, daß #Medigoron# #[[1]]# verkaufe.",
                                                   /*french*/ "Selon moi, #Medigoron# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                // /*spanish*/ Según dicen, #Medigoron# vende #[[1]]#.
 
     hintTextTable[RHT_KAK_GRANNYS_SHOP] = HintText(CustomMessage("They say that the #potion shop lady# sells #[[1]]#.",
-                                                      /*german*/ "",
+                                                      /*german*/ "Man erzählt sich, daß die #Dame des Hexenladens# #[[1]]# verkaufe.",
                                                       /*french*/ "Selon moi, la #dame du magasin de potion# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                    // /*spanish*/ Según dicen, la #señora de la tienda de pociones# vende #[[1]]#.
 
     hintTextTable[RHT_KAK_IMPAS_HOUSE_FREESTANDING_POH] = HintText(CustomMessage("They say that #imprisoned in a house# lies #[[1]]#.",
-                                                                      /*german*/ "",
+                                                                      /*german*/ "Man erzählt sich, daß #eingesperrt in einem Haus# #[[1]]# läge.",
                                                                       /*french*/ "Selon moi, #encagé dans une maison# gît #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                    // /*spanish*/ Según dicen, #en una casa entre rejas# yace #[[1]]#.
 
     hintTextTable[RHT_HF_TEKTITE_GROTTO_FREESTANDING_POH] = HintText(CustomMessage("They say that #deep underwater in a hole# is #[[1]]#.",
-                                                                        /*german*/ "",
+                                                                        /*german*/ "Man erzählt sich, daß #tief unter Wasser in einem Loch# #[[1]]# sei.",
                                                                         /*french*/ "Selon moi, #dans les profondeurs d'une grotte# gît #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                      // /*spanish*/ Según dicen, #en lo hondo bajo un hoyo# yace #[[1]]#.
 
     hintTextTable[RHT_KAK_WINDMILL_FREESTANDING_POH] = HintText(CustomMessage("They say that on a #windmill ledge# lies #[[1]]#.",
-                                                                   /*german*/ "",
+                                                                   /*german*/ "Man erzählt sich, daß auf einem #Vorsprung in einer Windmühle# #[[1]]# läge.",
                                                                    /*french*/ "Selon moi, #haut perché dans le moulin# gît #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                 // /*spanish*/ Según dicen, al #borde de un molino# yace #[[1]]#.
 
     hintTextTable[RHT_GRAVEYARD_DAMPE_RACE_FREESTANDING_POH] = HintText(CustomMessage("They say that #dead Dampe's second# prize is #[[1]]#.",
-                                                                           /*german*/ "",
+                                                                           /*german*/ "Man erzählt sich, daß der #zweite Preis des toten Boris# #[[1]]# sei.",
                                                                            /*french*/ "Selon moi, la #deuxième course d'Igor# donne #[[1]]#.", {QM_RED, QM_GREEN}),
                                                                         // /*spanish*/ Según dicen, el segundo premio de #la carrera de Dampé# se trata de #[[1]]#.
                                                                         {}, {
                                                                         CustomMessage("They say that #racing a ghost# leads to #[[1]]#.",
-                                                                            /*german*/ "",
+                                                                            /*german*/ "Man erzählt sich, daß das #Rennen gegen einen Geist# zu #[[1]]# führen würde.",
                                                                             /*french*/ "Selon moi, le défi du #revenant rapide# donne #[[1]]#.", {QM_RED, QM_GREEN})});
                                                                          // /*spanish*/ Según dicen, #perseguir a un fantasma# conduce a #[[1]]#.
 
     hintTextTable[RHT_LLR_FREESTANDING_POH] = HintText(CustomMessage("They say that in a #ranch silo# lies #[[1]]#.",
-                                                          /*german*/ "",
+                                                          /*german*/ "Man erzählt sich, daß in einem #ländlichen Silo# #[[1]]# läge.",
                                                           /*french*/ "Selon moi, #dans l'entrepôt de la ferme# gît #[[1]]#.", {QM_RED, QM_GREEN}));
                                                        // /*spanish*/ Según dicen, en un #granero rupestre# yace #[[1]]#.
 
     hintTextTable[RHT_GRAVEYARD_FREESTANDING_POH] = HintText(CustomMessage("They say that a #crate in a graveyard# hides #[[1]]#.",
-                                                                /*german*/ "",
+                                                                /*german*/ "Man erzählt sich, daß eine #Kiste auf einem Friedhof# #[[1]]# verberge.",
                                                                 /*french*/ "Selon moi, #la boîte dans le Cimetière# contient #[[1]]#.", {QM_RED, QM_GREEN}));
                                                              // /*spanish*/ Según dicen, bajo la #caja de un cementerio# yace #[[1]]#.
 
     hintTextTable[RHT_GRAVEYARD_DAMPE_GRAVEDIGGING_TOUR] = HintText(CustomMessage("They say that a #gravekeeper digs up# #[[1]]#.",
-                                                                       /*german*/ "",
+                                                                       /*german*/ "Man erzählt sich, daß ein #Grabpfleger# #[[1]]# ausgrabe.",
                                                                        /*french*/ "Selon moi, #le jeu du fossoyeur# cache #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                     // /*spanish*/ Según dicen, cierto #sepultero desentierra# #[[1]]#.
 
     hintTextTable[RHT_ZR_NEAR_OPEN_GROTTO_FREESTANDING_POH] = HintText(CustomMessage("They say that on top of a #pillar in a river# lies #[[1]]#.",
-                                                                          /*german*/ "",
+                                                                          /*german*/ "Man erzählt sich, daß auf der Spitze einer #Säule in einem Fluß# #[[1]]# läge.",
                                                                           /*french*/ "Selon moi, #sur un pilier au dessus du fleuve# gît #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                        // /*spanish*/ Según dicen, en lo alto del #pilar de un río# yace #[[1]]#.
 
     hintTextTable[RHT_ZR_NEAR_DOMAIN_FREESTANDING_POH] = HintText(CustomMessage("They say that on a #river ledge by a waterfall# lies #[[1]]#.",
-                                                                     /*german*/ "",
+                                                                     /*german*/ "Man erzählt sich, daß auf einem #Vorsprung von einem Fluß nahe eines Wasserfalls# #[[1]]# läge.",
                                                                      /*french*/ "Selon moi, #sur la falaise au dessus du fleuve# gît #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                   // /*spanish*/ Según dicen, al borde de #la entrada a una cascada# yace #[[1]]#.
 
     hintTextTable[RHT_LH_FREESTANDING_POH] = HintText(CustomMessage("They say that high on a #lab rooftop# one can find #[[1]]#.",
-                                                         /*german*/ "",
+                                                         /*german*/ "Man erzählt sich, daß man auf dem #Dach eines Laboratoriums# #[[1]]# finden könne.",
                                                          /*french*/ "Selon moi, #la tour d'observation du lac# cache #[[1]]#.", {QM_RED, QM_GREEN}));
                                                       // /*spanish*/ Según dicen, en lo #alto de un laboratorio# yace #[[1]]#.
 
     hintTextTable[RHT_ZF_ICEBERG_FREESTANDING_POH] = HintText(CustomMessage("They say that #floating on ice# is #[[1]]#.",
-                                                                 /*german*/ "",
+                                                                 /*german*/ "Man erzählt sich, daß sich schwebend auf Eis #[[1]]# befände.",
                                                                  /*french*/ "Selon moi, #gisant sur la glace# gît #[[1]]#.", {QM_RED, QM_GREEN}));
                                                               // /*spanish*/ Según dicen, #flotando sobre hielo# yace #[[1]]#.
 
     hintTextTable[RHT_GV_WATERFALL_FREESTANDING_POH] = HintText(CustomMessage("They say that behind a #valley waterfall# is #[[1]]#.",
-                                                                   /*german*/ "",
+                                                                   /*german*/ "Man erzählt sich, daß hinter einem #Wasserfall in einem Tal# #[[1]]# sei.",
                                                                    /*french*/ "Selon moi, #derrière la cascade du désert# se cache #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                 // /*spanish*/ Según dicen, tras una #desierta cascada# yace #[[1]]#.
 
     hintTextTable[RHT_GV_CRATE_FREESTANDING_POH] = HintText(CustomMessage("They say that a #crate in a valley# hides #[[1]]#.",
-                                                               /*german*/ "",
+                                                               /*german*/ "Man erzählt sich, daß eine #Kiste in einem Tal# #[[1]]# verberge.",
                                                                /*french*/ "Selon moi, la #boîte dans la vallée# contient #[[1]]#.", {QM_RED, QM_GREEN}));
                                                             // /*spanish*/ Según dicen, bajo la #caja de un valle# yace #[[1]]#.
 
     hintTextTable[RHT_COLOSSUS_FREESTANDING_POH] = HintText(CustomMessage("They say that on top of an #arch of stone# lies #[[1]]#.",
-                                                               /*german*/ "",
+                                                               /*german*/ "Man erzählt sich, daß auf der Spitze eines #Steinbogens# #[[1]]# läge.",
                                                                /*french*/ "Selon moi, #gisant sur une arche de pierre# gît #[[1]]#.", {QM_RED, QM_GREEN}));
                                                             // /*spanish*/ Según dicen, en lo alto de un #arco de piedra# yace #[[1]]#.
 
     hintTextTable[RHT_DMT_FREESTANDING_POH] = HintText(CustomMessage("They say that above a #mountain cavern entrance# is #[[1]]#.",
-                                                          /*german*/ "",
+                                                          /*german*/ "Man erzählt sich, daß oberhalb eines #Berghöhleneingangs# #[[1]]# sei.",
                                                           /*french*/ "Selon moi, gisant #au dessus de la caverne montagneuse# gît #[[1]]#.", {QM_RED, QM_GREEN}));
                                                        // /*spanish*/ Según dicen, en lo alto de la #entrada de una cueva en la montaña# yace #[[1]]#.
 
     hintTextTable[RHT_DMC_WALL_FREESTANDING_POH] = HintText(CustomMessage("They say that nestled in a #volcanic wall# is #[[1]]#.",
-                                                               /*german*/ "",
+                                                               /*german*/ "Man erzählt sich, daß in einem #vulkanischen Alkoven# #[[1]]# sei.",
                                                                /*french*/ "Selon moi, dans une #alcove volcanique# gît #[[1]]#.", {QM_RED, QM_GREEN}));
                                                             // /*spanish*/ Según dicen, entre unas #murallas volcánicas# yace #[[1]]#.
 
     hintTextTable[RHT_DMC_VOLCANO_FREESTANDING_POH] = HintText(CustomMessage("They say that obscured by #volcanic ash# is #[[1]]#.",
-                                                                  /*german*/ "",
+                                                                  /*german*/ "Man erzählt sich, daß #[[1]]# von #Vulkanasche# verdeckt sei.",
                                                                   /*french*/ "Selon moi, #recouvert de cendres volcaniques# gît #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                // /*spanish*/ Según dicen, bajo la #ceniza volcánica# yace #[[1]]#.
 
     hintTextTable[RHT_GF_NORTH_F1_CARPENTER] = HintText(CustomMessage("They say that #defeating Gerudo guards# reveals #[[1]]#.",
-                                                           /*german*/ "",
+                                                           /*german*/ "Man erzählt sich, daß das #Besiegen der Gerudo-Wachen# #[[1]]# enthüllen würde.",
                                                            /*french*/ "Selon moi, les #geôliers Gerudo# détiennent #[[1]]#.", {QM_RED, QM_GREEN}));
                                                         // /*spanish*/ Según dicen, #derrotar a las guardas Gerudo# revela #[[1]]#.
 
     hintTextTable[RHT_GF_NORTH_F2_CARPENTER] = HintText(CustomMessage("They say that #defeating Gerudo guards# reveals #[[1]]#.",
-                                                           /*german*/ "",
+                                                           /*german*/ "Man erzählt sich, daß das #Besiegen der Gerudo-Wachen# #[[1]]# enthüllen würde.",
                                                            /*french*/ "Selon moi, les #geôliers Gerudo# détiennent #[[1]]#.", {QM_RED, QM_GREEN}));
                                                         // /*spanish*/ Según dicen, #derrotar a las guardas Gerudo# revela #[[1]]#.
 
     hintTextTable[RHT_GF_SOUTH_F1_CARPENTER] = HintText(CustomMessage("They say that #defeating Gerudo guards# reveals #[[1]]#.",
-                                                           /*german*/ "",
+                                                           /*german*/ "Man erzählt sich, daß das #Besiegen der Gerudo-Wachen# #[[1]]# enthüllen würde.",
                                                            /*french*/ "Selon moi, les #geôliers Gerudo# détiennent #[[1]]#.", {QM_RED, QM_GREEN}));
                                                         // /*spanish*/ Según dicen, #derrotar a las guardas Gerudo# revela #[[1]]#.
 
     hintTextTable[RHT_GF_SOUTH_F2_CARPENTER] = HintText(CustomMessage("They say that #defeating Gerudo guards# reveals #[[1]]#.",
-                                                           /*german*/ "",
+                                                           /*german*/ "Man erzählt sich, daß das #Besiegen der Gerudo-Wachen# #[[1]]# enthüllen würde.",
                                                            /*french*/ "Selon moi, les #geôliers Gerudo# détiennent #[[1]]#.", {QM_RED, QM_GREEN}));
                                                         // /*spanish*/ Según dicen, #derrotar a las guardas Gerudo# revela #[[1]]#.
 
     hintTextTable[RHT_HF_GS_NEAR_KAK_GROTTO] = HintText(CustomMessage("They say that a #spider-guarded spider in a hole# hoards #[[1]]#.",
-                                                           /*german*/ "",
+                                                           /*german*/ "Man erzählt sich, daß eine #spinnenbewachte Spinne in einem Loch #[[1]]# horte.",
                                                            /*french*/ "Selon moi, une #Skulltula dans un trou d'arachnides# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                         // /*spanish*/ Según dicen, una #Skulltula custodiada por otra# de un hoyo otorga #[[1]]#.
 
     hintTextTable[RHT_LLR_GS_BACK_WALL] = HintText(CustomMessage("They say that night reveals a #spider in a ranch# holding #[[1]]#.",
-                                                      /*german*/ "",
+                                                      /*german*/ "Man erzählt sich, daß die Nacht eine #Spinne auf einer Farm# enthülle, welche #[[1]]# besäße.",
                                                       /*french*/ "Selon moi, une #Skulltula sur la façade de la ferme# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                    // /*spanish*/ Según dicen, la noche revela una #Skulltula del rancho# que otorga #[[1]]#.
 
     hintTextTable[RHT_LLR_GS_RAIN_SHED] = HintText(CustomMessage("They say that night reveals a #spider in a ranch# holding #[[1]]#.",
-                                                      /*german*/ "",
+                                                      /*german*/ "Man erzählt sich, daß die Nacht eine #Spinne auf einer Farm# enthülle, welche #[[1]]# besäße.",
                                                       /*french*/ "Selon moi, une #Skulltula sur le mur de l'enclos# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                    // /*spanish*/ Según dicen, la noche revela una #Skulltula del rancho# que otorga #[[1]]#.
 
     hintTextTable[RHT_LLR_GS_HOUSE_WINDOW] = HintText(CustomMessage("They say that night reveals a #spider in a ranch# holding #[[1]]#.",
-                                                         /*german*/ "",
+                                                         /*german*/ "Man erzählt sich, daß die Nacht eine #Spinne auf einer Farm# enthülle, welche #[[1]]# besäße.",
                                                          /*french*/ "Selon moi, une #Skulltula sur la maison de ferme# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                       // /*spanish*/ Según dicen, la noche revela una #Skulltula del rancho# que otorga #[[1]]#.
 
     hintTextTable[RHT_LLR_GS_TREE] = HintText(CustomMessage("They say that a spider hiding in a #ranch tree# holds #[[1]]#.",
-                                                 /*german*/ "",
+                                                 /*german*/ "Man erzählt sich, daß eine in einem #Baum auf einer Farm# versteckte Spinne #[[1]]# besäße.",
                                                  /*french*/ "Selon moi, une #Skulltula dans l'arbre de la ferme# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                               // /*spanish*/ Según dicen, una Skulltula escondida en el #árbol de un rancho# otorga #[[1]]#.
 
     hintTextTable[RHT_KF_GS_BEAN_PATCH] = HintText(CustomMessage("They say that a #spider buried in a forest# holds #[[1]]#.",
-                                                      /*german*/ "",
+                                                      /*german*/ "Man erzählt sich, daß eine #in einem Wald vergrabene Spinne# #[[1]]# besäße.",
                                                       /*french*/ "Selon moi, une #Skulltula enterrée dans la forêt# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                    // /*spanish*/ Según dicen, una #Skulltula enterrada en un bosque# otorga #[[1]]#.
 
     hintTextTable[RHT_KF_GS_KNOW_IT_ALL_HOUSE] = HintText(CustomMessage("They say that night in the past reveals a #spider in a forest# holding #[[1]]#.",
-                                                             /*german*/ "",
+                                                             /*german*/ "Man erzählt sich, daß die Nacht in der Vergangenheit eine #Spinne in einem Wald# enthülle, welche #[[1]]# besäße.",
                                                              /*french*/ "Selon moi, une #Skulltula derrière une cabane de la forêt# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                           // /*spanish*/ Según dicen, la noche revela en el pasado una #Skulltula del bosque# que otorga #[[1]]#.
 
     hintTextTable[RHT_KF_GS_HOUSE_OF_TWINS] = HintText(CustomMessage("They say that night in the future reveals a #spider in a forest# holding #[[1]]#.",
-                                                          /*german*/ "",
+                                                          /*german*/ "Man erzählt sich, daß die Nacht in der Zukunft eine #Spinne in einem Wald# enthülle, welche #[[1]]# besäße.",
                                                           /*french*/ "Selon moi, une #Skulltula sur une cabane de la forêt# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                        // /*spanish*/ Según dicen, la noche revela en el futuro una #Skulltula del rancho# que otorga #[[1]]#.
 
     hintTextTable[RHT_LW_GS_BEAN_PATCH_NEAR_BRIDGE] = HintText(CustomMessage("They say that a #spider buried deep in a forest maze# holds #[[1]]#.",
-                                                                  /*german*/ "",
+                                                                  /*german*/ "Man erzählt sich, daß eine #tief in einem Waldlabyrinth vergrabene Spinne# #[[1]]# besäße.",
                                                                   /*french*/ "Selon moi, une #Skulltula enterrée dans les bois# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                // /*spanish*/ Según dicen, una #Skulltula enterrada en un laberinto forestal# otorga #[[1]]#.
 
     hintTextTable[RHT_LW_GS_BEAN_PATCH_NEAR_THEATER] = HintText(CustomMessage("They say that a #spider buried deep in a forest maze# holds #[[1]]#.",
-                                                                   /*german*/ "",
+                                                                   /*german*/ "Man erzählt sich, daß eine #tief in einem Waldlabyrinth vergrabene Spinne# #[[1]]# besäße.",
                                                                    /*french*/ "Selon moi, une #Skulltula enterrée dans les bois# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                 // /*spanish*/ Según dicen, una #Skulltula enterrada en un laberinto forestal# otorga #[[1]]#.
 
     hintTextTable[RHT_LW_GS_ABOVE_THEATER] = HintText(CustomMessage("They say that night reveals a #spider deep in a forest maze# holding #[[1]]#.",
-                                                         /*german*/ "",
+                                                         /*german*/ "Man erzählt sich, daß die Nacht eine #Spinne tief in einem Waldlabyrinth# enthülle, welche #[[1]]# besäße.",
                                                          /*french*/ "Selon moi, une #Skulltula haut perchée dans les bois# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                       // /*spanish*/ Según dicen, la noche revela una #Skulltula del laberinto forestal# que otorga #[[1]]#.
 
     hintTextTable[RHT_SFM_GS] = HintText(CustomMessage("They say that night reveals a #spider in a forest meadow# holding #[[1]]#.",
-                                            /*german*/ "",
+                                            /*german*/ "Man erzählt sich, daß die Nacht eine #Spinne auf einer Waldwiese# enthülle, welche #[[1]]# besäße.",
                                             /*french*/ "Selon moi, une #Skulltula dans le sanctuaire des bois# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                          // /*spanish*/ Según dicen, la noche revela una #Skulltula de la pradera del bosque# que otorga #[[1]]#.
 
     hintTextTable[RHT_OGC_GS] = HintText(CustomMessage("They say that a #spider outside a tyrant's tower# holds #[[1]]#.",
-                                            /*german*/ "",
+                                            /*german*/ "Man erzählt sich, daß eine #Spinne außerhalb eines Turms eines Tyrannen# #[[1]]# besäße.",
                                             /*french*/ "Selon moi, une #Skulltula parmi les ruines du château# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                          // /*spanish*/ Según dicen, una #Skulltula a las afueras de la torre de un tirano# otorga #[[1]]#.
 
     hintTextTable[RHT_HC_GS_TREE] = HintText(CustomMessage("They say that a spider hiding in a #tree outside of a castle# holds #[[1]]#.",
-                                                /*german*/ "",
+                                                /*german*/ "Man erzählt sich, daß eine in einem #Baum außerhalb von einem Schloß befindliche Spinne# #[[1]]# besäße.",
                                                 /*french*/ "Selon moi, une #Skulltula dans l'arbre près du château# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                              // /*spanish*/ Según dicen, una Skulltula escondida en el #árbol de las afueras de un castillo# otorga #[[1]]#.
 
     hintTextTable[RHT_MARKET_GS_GUARD_HOUSE] = HintText(CustomMessage("They say that a #spider in a guarded crate# holds #[[1]]#.",
-                                                           /*german*/ "",
+                                                           /*german*/ "Man erzählt sich, daß eine #Spinne in einer bewachten Kiste# #[[1]]# besäße.",
                                                            /*french*/ "Selon moi, une #Skulltula dans une boîte en ville# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                         // /*spanish*/ Según dicen, una #Skulltula bajo una custodiada caja# otorga #[[1]]#.
 
     hintTextTable[RHT_DMC_GS_BEAN_PATCH] = HintText(CustomMessage("They say that a #spider buried in a volcano# holds #[[1]]#.",
-                                                       /*german*/ "",
+                                                       /*german*/ "Man erzählt sich, daß eine #in einem Vulkan begrabene Spinne# #[[1]]# besäße.",
                                                        /*french*/ "Selon moi, une #Skulltula enterrée dans un volcan# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                     // /*spanish*/ Según dicen, una #Skulltula enterrada en un volcán# otorga #[[1]]#.
 
     hintTextTable[RHT_DMT_GS_BEAN_PATCH] = HintText(CustomMessage("They say that a #spider buried outside a cavern# holds #[[1]]#.",
-                                                       /*german*/ "",
+                                                       /*german*/ "Man erzählt sich, daß eine #außerhalb einer Höhle begrabene Spinne# #[[1]]# besäße.",
                                                        /*french*/ "Selon moi, une #Skulltula enterrée près d'une caverne# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                     // /*spanish*/ Según dicen, una #Skulltula enterrada a la entrada de una cueva# otorga #[[1]]#.
 
     hintTextTable[RHT_DMT_GS_NEAR_KAK] = HintText(CustomMessage("They say that a #spider hidden in a mountain nook# holds #[[1]]#.",
-                                                     /*german*/ "",
+                                                     /*german*/ "Man erzählt sich, daß eine #in einem Bergwinkel versteckte Spinne# #[[1]]# besäße.",
                                                      /*french*/ "Selon moi, une #Skulltula cachée dans le flanc d'une montagne# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                   // /*spanish*/ Según dicen, una #Skulltula oculta en el rincón de la montaña# otorga #[[1]]#.
 
     hintTextTable[RHT_DMT_GS_ABOVE_DODONGOS_CAVERN] = HintText(CustomMessage("They say that the hammer reveals a #spider on a mountain# holding #[[1]]#.",
-                                                                  /*german*/ "",
+                                                                  /*german*/ "Man erzählt sich, daß der Hammer eine #Spinne auf einem Berg# enthülle, welche #[[1]]# besäße.",
                                                                   /*french*/ "Selon moi, une #Skulltula derrière un rocher massif près d'une caverne# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                // /*spanish*/ Según dicen, el martillo revela #una Skulltula de la montaña# que otorga #[[1]]#.
 
     hintTextTable[RHT_DMT_GS_FALLING_ROCKS_PATH] = HintText(CustomMessage("They say that the hammer reveals a #spider on a mountain# holding #[[1]]#.",
-                                                               /*german*/ "",
+                                                               /*german*/ "Man erzählt sich, daß der Hammer eine #Spinne auf einem Berg# enthülle, welche #[[1]]# besäße.",
                                                                /*french*/ "Selon moi, une #Skulltula derrière un rocher massif près du sommet d'un volcan# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                             // /*spanish*/ Según dicen, el martillo revela #una Skulltula de la montaña# que otorga #[[1]]#.
 
     hintTextTable[RHT_GC_GS_CENTER_PLATFORM] = HintText(CustomMessage("They say that a #suspended spider# in Goron City holds #[[1]]#.",
-                                                           /*german*/ "",
+                                                           /*german*/ "Man erzählt sich, daß eine #hängende Spinne# in Goronia #[[1]]# besäße.",
                                                            /*french*/ "Selon moi, une #Skulltula perchée dans le village Goron# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                         // /*spanish*/ Según dicen, una #Skulltula suspendida# en la Ciudad Goron otorga #[[1]]#.
 
     hintTextTable[RHT_GC_GS_BOULDER_MAZE] = HintText(CustomMessage("They say that a spider in a #Goron City crate# holds #[[1]]#.",
-                                                        /*german*/ "",
+                                                        /*german*/ "Man erzählt sich, daß eine Spinne in einer #Kiste in Goronia# #[[1]]# besäße.",
                                                         /*french*/ "Selon moi, une #Skulltula dans une boîte du village Goron# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                      // /*spanish*/ Según dicen, una #Skulltula bajo una caja# de la Ciudad Goron otorga #[[1]]#.
 
     hintTextTable[RHT_KAK_GS_HOUSE_UNDER_CONSTRUCTION] = HintText(CustomMessage("They say that night in the past reveals a #spider in a town# holding #[[1]]#.",
-                                                                     /*german*/ "",
+                                                                     /*german*/ "Man erzählt sich, daß die Nacht in der Vergangenheit eine #Spinne in einer Stadt# enthülle, welche #[[1]]# besäße.",
                                                                      /*french*/ "Selon moi, une #Skulltula dans le chantier de construction# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                   // /*spanish*/ Según dicen, la noche del pasado revela una #Skulltula del pueblo# que otorga #[[1]]#.
 
     hintTextTable[RHT_KAK_GS_SKULLTULA_HOUSE] = HintText(CustomMessage("They say that night in the past reveals a #spider in a town# holding #[[1]]#.",
-                                                            /*german*/ "",
+                                                            /*german*/ "Man erzählt sich, daß die Nacht in der Vergangenheit eine #Spinne in einer Stadt# enthülle, welche #[[1]]# besäße.",
                                                             /*french*/ "Selon moi, une #Skulltula sur une maison maudite# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                          // /*spanish*/ Según dicen, la noche del pasado revela una #Skulltula del pueblo# que otorga #[[1]]#.
 
     hintTextTable[RHT_KAK_GS_GUARDS_HOUSE] = HintText(CustomMessage("They say that night in the past reveals a #spider in a town# holding #[[1]]#.",
-                                                         /*german*/ "",
+                                                         /*german*/ "Man erzählt sich, daß die Nacht in der Vergangenheit eine #Spinne in einer Stadt# enthülle, welche #[[1]]# besäße.",
                                                          /*french*/ "Selon moi, une #Skulltula sur une maison de village# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                       // /*spanish*/ Según dicen, la noche del pasado revela una #Skulltula del pueblo# que otorga #[[1]]#.
 
     hintTextTable[RHT_KAK_GS_TREE] = HintText(CustomMessage("They say that night in the past reveals a #spider in a town# holding #[[1]]#.",
-                                                 /*german*/ "",
+                                                 /*german*/ "Man erzählt sich, daß die Nacht in der Vergangenheit eine #Spinne in einer Stadt# enthülle, welche #[[1]]# besäße.",
                                                  /*french*/ "Selon moi, une #Skulltula dans un arbre de village# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                               // /*spanish*/ Según dicen, la noche del pasado revela una #Skulltula del pueblo# que otorga #[[1]]#.
 
     hintTextTable[RHT_KAK_GS_WATCHTOWER] = HintText(CustomMessage("They say that night in the past reveals a #spider in a town# holding #[[1]]#.",
-                                                       /*german*/ "",
+                                                       /*german*/ "Man erzählt sich, daß die Nacht in der Vergangenheit eine #Spinne in einer Stadt# enthülle, welche #[[1]]# besäße.",
                                                        /*french*/ "Selon moi, une #Skulltula sur une échelle dans un village# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                     // /*spanish*/ Según dicen, la noche del pasado revela una #Skulltula del pueblo# que otorga #[[1]]#.
 
     hintTextTable[RHT_KAK_GS_ABOVE_IMPAS_HOUSE] = HintText(CustomMessage("They say that night in the future reveals a #spider in a town# holding #[[1]]#.",
-                                                              /*german*/ "",
+                                                              /*german*/ "Man erzählt sich, daß die Nacht in der Zukunft eine #Spinne in einer Stadt# enthülle, welche #[[1]]# besäße.",
                                                               /*french*/ "Selon moi, une #Skulltula au dessus d'une grande maison# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                            // /*spanish*/ Según dicen, la noche del futuro revela una #Skulltula del pueblo# que otorga #[[1]]#.
 
     hintTextTable[RHT_GRAVEYARD_GS_WALL] = HintText(CustomMessage("They say that night reveals a #spider in a graveyard# holding #[[1]]#.",
-                                                       /*german*/ "",
+                                                       /*german*/ "Man erzählt sich, daß die Nacht eine #Spinne auf einem Friedhof# enthülle, welche #[[1]]# besäße.",
                                                        /*french*/ "Selon moi, une #Skulltula sur une façade du Cimetière# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                     // /*spanish*/ Según dicen, la noche revela una #Skulltula del cementerio# que otorga #[[1]]#.
 
     hintTextTable[RHT_GRAVEYARD_GS_BEAN_PATCH] = HintText(CustomMessage("They say that a #spider buried in a graveyard# holds #[[1]]#.",
-                                                             /*german*/ "",
+                                                             /*german*/ "Man erzählt sich, daß eine #auf einem Friedhof begrabene Spinne# #[[1]]# besäße.",
                                                              /*french*/ "Selon moi, une #Skulltula enterrée dans le Cimetière# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                           // /*spanish*/ Según dicen, una #Skulltula enterrada en el cementerio# otorga #[[1]]#.
 
     hintTextTable[RHT_ZR_GS_LADDER] = HintText(CustomMessage("They say that night in the past reveals a #spider in a river# holding #[[1]]#.",
-                                                  /*german*/ "",
+                                                  /*german*/ "Man erzählt sich, daß die Nacht in der Vergangenheit eine #Spinne in einem Fluß# enthülle, welche #[[1]]# besäße.",
                                                   /*french*/ "Selon moi, une #Skulltula sur une échelle près d'une cascade# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                // /*spanish*/ Según dicen, la noche del pasado revela una #Skulltula del río# que otorga #[[1]]#.
 
     hintTextTable[RHT_ZR_GS_TREE] = HintText(CustomMessage("They say that a spider hiding in a #tree by a river# holds #[[1]]#.",
-                                                /*german*/ "",
+                                                /*german*/ "Man erzählt sich, daß eine in einem #Baum bei einem Fluß# versteckte Spinne #[[1]]# besäße.",
                                                 /*french*/ "Selon moi, une #Skulltula dans un arbre près du fleuve# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                              // /*spanish*/ Según dicen, una Skulltula escondida en el #árbol de un río# otorga #[[1]]#.
 
     hintTextTable[RHT_ZR_GS_ABOVE_BRIDGE] = HintText(CustomMessage("They say that night in the future reveals a #spider in a river# holding #[[1]]#.",
-                                                        /*german*/ "",
+                                                        /*german*/ "Man erzählt sich, daß die Nacht in der Zukunft eine #Spinne in einem Fluß# enthülle, welche #[[1]]# besäße.",
                                                         /*french*/ "Selon moi, une #Skulltula sur une façade près d'une cascade# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                      // /*spanish*/ Según dicen, la noche del futuro revela una #Skulltula del río# que otorga #[[1]]#.
 
     hintTextTable[RHT_ZR_GS_NEAR_RAISED_GROTTOS] = HintText(CustomMessage("They say that night in the future reveals a #spider in a river# holding #[[1]]#.",
-                                                               /*german*/ "",
+                                                               /*german*/ "Man erzählt sich, daß die Nacht in der Zukunft eine #Spinne in einem Fluß# enthülle, welche #[[1]]# besäße.",
                                                                /*french*/ "Selon moi, une #Skulltula sur une façade près d'une grotte du fleuve# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                             // /*spanish*/ Según dicen, la noche del futuro revela una #Skulltula del río# que otorga #[[1]]#.
 
     hintTextTable[RHT_ZD_GS_FROZEN_WATERFALL] = HintText(CustomMessage("They say that night reveals a #spider by a frozen waterfall# holding #[[1]]#.",
-                                                            /*german*/ "",
+                                                            /*german*/ "Man erzählt sich, daß die Nacht eine #Spinne bei einem gefrorenen Wasserfall# enthülle, welche #[[1]]# besäße.",
                                                             /*french*/ "Selon moi, une #Skulltula près d'une cascade gelée# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                          // /*spanish*/ Según dicen, la noche revela una #Skulltula junto a una congelada cascada# que otorga #[[1]]#.
 
     hintTextTable[RHT_ZF_GS_ABOVE_THE_LOG] = HintText(CustomMessage("They say that night reveals a #spider near a deity# holding #[[1]]#.",
-                                                         /*german*/ "",
+                                                         /*german*/ "Man erzählt sich, daß die Nacht eine #Spinne in der Nähe einer Gottheit# enthülle, welche #[[1]]# besäße.",
                                                          /*french*/ "Selon moi, une #Skulltula près du gardien aquatique# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                       // /*spanish*/ Según dicen, la noche revela una #Skulltula junto a cierta deidad# que otorga #[[1]]#.
 
     hintTextTable[RHT_ZF_GS_TREE] = HintText(CustomMessage("They say that a spider hiding in a #tree near a deity# holds #[[1]]#.",
-                                                /*german*/ "",
+                                                /*german*/ "Man erzählt sich, daß eine in einem #Baum in der Nähe einer Gottheit# versteckte Spinne #[[1]]# besäße.",
                                                 /*french*/ "Selon moi, une #Skulltula dans un arbre dans un réservoir# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                              // /*spanish*/ Según dicen, una Skulltula escondida en el #árbol junto a cierta deidad# otorga #[[1]]#.
 
     hintTextTable[RHT_LH_GS_BEAN_PATCH] = HintText(CustomMessage("They say that a #spider buried by a lake# holds #[[1]]#.",
-                                                      /*german*/ "",
+                                                      /*german*/ "Man erzählt sich, daß eine #bei einem Fluß begrabene Spinne# #[[1]]# besäße.",
                                                       /*french*/ "Selon moi, une #Skulltula enterrée près d'un lac# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                    // /*spanish*/ Según dicen, una #Skulltula enterrada junto a un lago# otorga #[[1]]#.
 
     hintTextTable[RHT_LH_GS_SMALL_ISLAND] = HintText(CustomMessage("They say that night reveals a #spider by a lake# holding #[[1]]#.",
-                                                        /*german*/ "",
+                                                        /*german*/ "Man erzählt sich, daß die Nacht eine #Spinne bei einem Fluß# enthülle, welche #[[1]]# besäße.",
                                                         /*french*/ "Selon moi, une #Skulltula sur un îlot du lac# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                      // /*spanish*/ Según dicen, la noche revela una #Skulltula junto a un lago# que otorga #[[1]]#.
 
     hintTextTable[RHT_LH_GS_LAB_WALL] = HintText(CustomMessage("They say that night reveals a #spider by a lake# holding #[[1]]#.",
-                                                    /*german*/ "",
+                                                    /*german*/ "Man erzählt sich, daß die Nacht eine #Spinne bei einem Fluß# enthülle, welche #[[1]]# besäße.",
                                                     /*french*/ "Selon moi, une #Skulltula sur le mur d'un centre de recherche# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                  // /*spanish*/ Según dicen, la noche revela una #Skulltula junto a un lago# que otorga #[[1]]#.
 
     hintTextTable[RHT_LH_GS_LAB_CRATE] = HintText(CustomMessage("They say that a spider deed underwater in a #lab crate# holds #[[1]]#.",
-                                                     /*german*/ "",
+                                                     /*german*/ "Man erzählt sich, daß einer Spinne in einer #Laborkiste# unter Wasser #[[1]]# besäße.",
                                                      /*french*/ "Selon moi, une #Skulltula dans une boîte au fond d'une cuve d'eau# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                   // /*spanish*/ Según dicen, una #Skulltula bajo la sumergida caja de un laboratorio# otorga #[[1]]#.
 
     hintTextTable[RHT_LH_GS_TREE] = HintText(CustomMessage("They say that night reveals a #spider by a lake high in a tree# holding #[[1]]#.",
-                                                /*german*/ "",
+                                                /*german*/ "Man erzählt sich, daß die Nacht eine #Spinne in einem Baum bei einem Fluß# enthülle, welche #[[1]]# besäße.",
                                                 /*french*/ "Selon moi, une #Skulltula dans un grand arbre du lac# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                              // /*spanish*/ Según dicen, la noche revela #una Skulltula del lago sobre un árbol# que otorga #[[1]]#.
 
     hintTextTable[RHT_GV_GS_BEAN_PATCH] = HintText(CustomMessage("They say that a #spider buried in a valley# holds #[[1]]#.",
-                                                      /*german*/ "",
+                                                      /*german*/ "Man erzählt sich, daß eine #in einem Tal begrabene Spinne# #[[1]]# besäße.",
                                                       /*french*/ "Selon moi, une #Skulltula enterré dans une vallée# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                    // /*spanish*/ Según dicen, una #Skulltula enterrada en un valle# otorga #[[1]]#.
 
     hintTextTable[RHT_GV_GS_SMALL_BRIDGE] = HintText(CustomMessage("They say that night in the past reveals a #spider in a valley# holding #[[1]]#.",
-                                                        /*german*/ "",
+                                                        /*german*/ "Man erzählt sich, daß die Nacht in der Vergangenheit eine #Spinne in einem Tal# enthülle, welche #[[1]]# besäße.",
                                                         /*french*/ "Selon moi, une #Skulltula au dessus d'une petite cascade# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                      // /*spanish*/ Según dicen, la noche del pasado revela una #Skulltula del valle# que otorga #[[1]]#.
 
     hintTextTable[RHT_GV_GS_PILLAR] = HintText(CustomMessage("They say that night in the future reveals a #spider in a valley# holding #[[1]]#.",
-                                                  /*german*/ "",
+                                                  /*german*/ "Man erzählt sich, daß die Nacht in der Zukunft eine #Spinne in einem Tal# enthülle, welche #[[1]]# besäße.",
                                                   /*french*/ "Selon moi, une #Skulltula sur une arche de pierre dans une vallée# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                // /*spanish*/ Según dicen, la noche del futuro revela una #Skulltula del valle# que otorga #[[1]]#.
 
     hintTextTable[RHT_GV_GS_BEHIND_TENT] = HintText(CustomMessage("They say that night in the future reveals a #spider in a valley# holding #[[1]]#.",
-                                                       /*german*/ "",
+                                                       /*german*/ "Man erzählt sich, daß die Nacht in der Zukunft eine #Spinne in einem Tal# enthülle, welche #[[1]]# besäße.",
                                                        /*french*/ "Selon moi, une #Skulltula derrière une tente# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                     // /*spanish*/ Según dicen, la noche del futuro revela una #Skulltula del valle# que otorga #[[1]]#.
 
     hintTextTable[RHT_GF_GS_ARCHERY_RANGE] = HintText(CustomMessage("They say that night reveals a #spider in a fortress# holding #[[1]]#.",
-                                                         /*german*/ "",
+                                                         /*german*/ "Man erzählt sich, daß die Nacht eine #Spinne in einer Festung# enthülle, welche #[[1]]# besäße.",
                                                          /*french*/ "Selon moi, une #Skulltula sur une cible de tir# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                       // /*spanish*/ Según dicen, la noche revela una #Skulltula de una fortaleza# que otorga #[[1]]#.
 
     hintTextTable[RHT_GF_GS_TOP_FLOOR] = HintText(CustomMessage("They say that night reveals a #spider in a fortress# holding #[[1]]#.",
-                                                     /*german*/ "",
+                                                     /*german*/ "Man erzählt sich, daß die Nacht eine #Spinne in einer Festung# enthülle, welche #[[1]]# besäße.",
                                                      /*french*/ "Selon moi, une #Skulltula au sommet d'une forteresse# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                   // /*spanish*/ Según dicen, la noche revela una #Skulltula de una fortaleza# que otorga #[[1]]#.
 
     hintTextTable[RHT_COLOSSUS_GS_BEAN_PATCH] = HintText(CustomMessage("They say that a #spider buried in the desert# holds #[[1]]#.",
-                                                            /*german*/ "",
+                                                            /*german*/ "Man erzählt sich, daß eine #in der Wüste begrabene Spinne# #[[1]]# besäße.",
                                                             /*french*/ "Selon moi, une #Skulltula enterrée au pied du colosse# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                          // /*spanish*/ Según dicen, una #Skulltula enterrada en el desierto# otorga #[[1]]#.
 
     hintTextTable[RHT_COLOSSUS_GS_HILL] = HintText(CustomMessage("They say that night reveals a #spider deep in the desert# holding #[[1]]#.",
-                                                      /*german*/ "",
+                                                      /*german*/ "Man erzählt sich, daß die Nacht eine #Spinne tief in der Wüste# enthülle, welche #[[1]]# besäße.",
                                                       /*french*/ "Selon moi, une #Skulltula sur une colline dans le désert# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                    // /*spanish*/ Según dicen, la noche revela una #Skulltula en las profundidades del desierto# que otorga #[[1]]#.
 
     hintTextTable[RHT_COLOSSUS_GS_TREE] = HintText(CustomMessage("They say that night reveals a #spider deep in the desert# holding #[[1]]#.",
-                                                      /*german*/ "",
+                                                      /*german*/ "Man erzählt sich, daß die Nacht eine #Spinne tief in der Wüste# enthülle, welche #[[1]]# besäße.",
                                                       /*french*/ "Selon moi, une #Skulltula dans un arbre du désert# a #[[1]]#.", {QM_RED, QM_GREEN}));
                                                    // /*spanish*/ Según dicen, la noche revela una #Skulltula en las profundidades del desierto# que otorga #[[1]]#.
 
     hintTextTable[RHT_KF_SHOP_ITEM_1] = HintText(CustomMessage("They say that a #child shopkeeper# sells #[[1]]#.",
-                                                    /*german*/ "",
+                                                    /*german*/ "Man erzählt sich, daß der #Inhaber des Kokiri-Ladens# #[[1]]# verkaufe.",
                                                     /*french*/ "Selon moi, la #boutique Kokiri# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                  // /*spanish*/ Según dicen, un #joven dependiente# vende #[[1]]#.
 
     hintTextTable[RHT_KF_SHOP_ITEM_2] = HintText(CustomMessage("They say that a #child shopkeeper# sells #[[1]]#.",
-                                                    /*german*/ "",
+                                                    /*german*/ "Man erzählt sich, daß der #Inhaber des Kokiri-Ladens# #[[1]]# verkaufe.",
                                                     /*french*/ "Selon moi, la #boutique Kokiri# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                  // /*spanish*/ Según dicen, un #joven dependiente# vende #[[1]]#.
 
     hintTextTable[RHT_KF_SHOP_ITEM_3] = HintText(CustomMessage("They say that a #child shopkeeper# sells #[[1]]#.",
-                                                    /*german*/ "",
+                                                    /*german*/ "Man erzählt sich, daß der #Inhaber des Kokiri-Ladens# #[[1]]# verkaufe.",
                                                     /*french*/ "Selon moi, la #boutique Kokiri# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                  // /*spanish*/ Según dicen, un #joven dependiente# vende #[[1]]#.
 
     hintTextTable[RHT_KF_SHOP_ITEM_4] = HintText(CustomMessage("They say that a #child shopkeeper# sells #[[1]]#.",
-                                                    /*german*/ "",
+                                                    /*german*/ "Man erzählt sich, daß der #Inhaber des Kokiri-Ladens# #[[1]]# verkaufe.",
                                                     /*french*/ "Selon moi, la #boutique Kokiri# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                  // /*spanish*/ Según dicen, un #joven dependiente# vende #[[1]]#.
 
     hintTextTable[RHT_KF_SHOP_ITEM_5] = HintText(CustomMessage("They say that a #child shopkeeper# sells #[[1]]#.",
-                                                    /*german*/ "",
+                                                    /*german*/ "Man erzählt sich, daß der #Inhaber des Kokiri-Ladens# #[[1]]# verkaufe.",
                                                     /*french*/ "Selon moi, la #boutique Kokiri# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                  // /*spanish*/ Según dicen, un #joven dependiente# vende #[[1]]#.
 
     hintTextTable[RHT_KF_SHOP_ITEM_6] = HintText(CustomMessage("They say that a #child shopkeeper# sells #[[1]]#.",
-                                                    /*german*/ "",
+                                                    /*german*/ "Man erzählt sich, daß der #Inhaber des Kokiri-Ladens# #[[1]]# verkaufe.",
                                                     /*french*/ "Selon moi, la #boutique Kokiri# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                  // /*spanish*/ Según dicen, un #joven dependiente# vende #[[1]]#.
 
     hintTextTable[RHT_KF_SHOP_ITEM_7] = HintText(CustomMessage("They say that a #child shopkeeper# sells #[[1]]#.",
-                                                    /*german*/ "",
+                                                    /*german*/ "Man erzählt sich, daß der #Inhaber des Kokiri-Ladens# #[[1]]# verkaufe.",
                                                     /*french*/ "Selon moi, la #boutique Kokiri# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                  // /*spanish*/ Según dicen, un #joven dependiente# vende #[[1]]#.
 
     hintTextTable[RHT_KF_SHOP_ITEM_8] = HintText(CustomMessage("They say that a #child shopkeeper# sells #[[1]]#.",
-                                                    /*german*/ "",
+                                                    /*german*/ "Man erzählt sich, daß der #Inhaber des Kokiri-Ladens# #[[1]]# verkaufe.",
                                                     /*french*/ "Selon moi, la #boutique Kokiri# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                  // /*spanish*/ Según dicen, un #joven dependiente# vende #[[1]]#.
 
     hintTextTable[RHT_KAK_POTION_SHOP_ITEM_1] = HintText(CustomMessage("They say that the #Kakariko Potion Shop# offers #[[1]]#.",
-                                                            /*german*/ "",
+                                                            /*german*/ "Man erzählt sich, daß der #Magie-Laden in Kakariko# #[[1]]# offeriere.",
                                                             /*french*/ "Selon moi, l'#apothicaire de Kakariko# vend #[[1]]#.", {QM_RED, QM_GREEN}),
                                                          // /*spanish*/ Según dicen, la #tienda de pociones de Kakariko# ofrece #[[1]]#.
                                                          {}, {
                                                          CustomMessage("They say that a #potion seller# offers #[[1]]#.",
-                                                             /*german*/ "",
+                                                             /*german*/ "Man erzählt sich, daß ein #Trankhändler# #[[1]]# anböte.",
                                                              /*french*/ "Selon moi, l'#apothicaire# vend #[[1]]#.", {QM_RED, QM_GREEN})});
                                                           // /*spanish*/ Según dicen, un #vendedor de pociones# ofrece #[[1]]#.
 
     hintTextTable[RHT_KAK_POTION_SHOP_ITEM_2] = HintText(CustomMessage("They say that the #Kakariko Potion Shop# offers #[[1]]#.",
-                                                            /*german*/ "",
+                                                            /*german*/ "Man erzählt sich, daß der #Magie-Laden in Kakariko# #[[1]]# offeriere.",
                                                             /*french*/ "Selon moi, l'#apothicaire de Kakariko# vend #[[1]]#.", {QM_RED, QM_GREEN}),
                                                          // /*spanish*/ Según dicen, la #tienda de pociones de Kakariko# ofrece #[[1]]#.
                                                          {}, {
                                                          CustomMessage("They say that a #potion seller# offers #[[1]]#.",
-                                                             /*german*/ "",
+                                                             /*german*/ "Man erzählt sich, daß ein #Trankhändler# #[[1]]# anböte.",
                                                              /*french*/ "Selon moi, l'#apothicaire# vend #[[1]]#.", {QM_RED, QM_GREEN})});
                                                           // /*spanish*/ Según dicen, un #vendedor de pociones# ofrece #[[1]]#.
 
     hintTextTable[RHT_KAK_POTION_SHOP_ITEM_3] = HintText(CustomMessage("They say that the #Kakariko Potion Shop# offers #[[1]]#.",
-                                                            /*german*/ "",
+                                                            /*german*/ "Man erzählt sich, daß der #Magie-Laden in Kakariko# #[[1]]# offeriere.",
                                                             /*french*/ "Selon moi, l'#apothicaire de Kakariko# vend #[[1]]#.", {QM_RED, QM_GREEN}),
                                                          // /*spanish*/ Según dicen, la #tienda de pociones de Kakariko# ofrece #[[1]]#.
                                                          {}, {
                                                          CustomMessage("They say that a #potion seller# offers #[[1]]#.",
-                                                             /*german*/ "",
+                                                             /*german*/ "Man erzählt sich, daß ein #Trankhändler# #[[1]]# anböte.",
                                                              /*french*/ "Selon moi, l'#apothicaire# vend #[[1]]#.", {QM_RED, QM_GREEN})});
                                                           // /*spanish*/ Según dicen, un #vendedor de pociones# ofrece #[[1]]#.
 
     hintTextTable[RHT_KAK_POTION_SHOP_ITEM_4] = HintText(CustomMessage("They say that the #Kakariko Potion Shop# offers #[[1]]#.",
-                                                            /*german*/ "",
+                                                            /*german*/ "Man erzählt sich, daß der #Magie-Laden in Kakariko# #[[1]]# offeriere.",
                                                             /*french*/ "Selon moi, l'#apothicaire de Kakariko# vend #[[1]]#.", {QM_RED, QM_GREEN}),
                                                          // /*spanish*/ Según dicen, la #tienda de pociones de Kakariko# ofrece #[[1]]#.
                                                          {}, {
                                                          CustomMessage("They say that a #potion seller# offers #[[1]]#.",
-                                                             /*german*/ "",
+                                                             /*german*/ "Man erzählt sich, daß ein #Trankhändler# #[[1]]# anböte.",
                                                              /*french*/ "Selon moi, l'#apothicaire# vend #[[1]]#.", {QM_RED, QM_GREEN})});
                                                           // /*spanish*/ Según dicen, un #vendedor de pociones# ofrece #[[1]]#.
 
     hintTextTable[RHT_KAK_POTION_SHOP_ITEM_5] = HintText(CustomMessage("They say that the #Kakariko Potion Shop# offers #[[1]]#.",
-                                                            /*german*/ "",
+                                                            /*german*/ "Man erzählt sich, daß der #Magie-Laden in Kakariko# #[[1]]# offeriere.",
                                                             /*french*/ "Selon moi, l'#apothicaire de Kakariko# vend #[[1]]#.", {QM_RED, QM_GREEN}),
                                                          // /*spanish*/ Según dicen, la #tienda de pociones de Kakariko# ofrece #[[1]]#.
                                                          {}, {
                                                          CustomMessage("They say that a #potion seller# offers #[[1]]#.",
-                                                             /*german*/ "",
+                                                             /*german*/ "Man erzählt sich, daß ein #Trankhändler# #[[1]]# anböte.",
                                                              /*french*/ "Selon moi, l'#apothicaire# vend #[[1]]#.", {QM_RED, QM_GREEN})});
                                                           // /*spanish*/ Según dicen, un #vendedor de pociones# ofrece #[[1]]#.
 
     hintTextTable[RHT_KAK_POTION_SHOP_ITEM_6] = HintText(CustomMessage("They say that the #Kakariko Potion Shop# offers #[[1]]#.",
-                                                            /*german*/ "",
+                                                            /*german*/ "Man erzählt sich, daß der #Magie-Laden in Kakariko# #[[1]]# offeriere.",
                                                             /*french*/ "Selon moi, l'#apothicaire de Kakariko# vend #[[1]]#.", {QM_RED, QM_GREEN}),
                                                          // /*spanish*/ Según dicen, la #tienda de pociones de Kakariko# ofrece #[[1]]#.
                                                          {}, {
                                                          CustomMessage("They say that a #potion seller# offers #[[1]]#.",
-                                                             /*german*/ "",
+                                                             /*german*/ "Man erzählt sich, daß ein #Trankhändler# #[[1]]# anböte.",
                                                              /*french*/ "Selon moi, l'#apothicaire# vend #[[1]]#.", {QM_RED, QM_GREEN})});
                                                           // /*spanish*/ Según dicen, un #vendedor de pociones# ofrece #[[1]]#.
 
     hintTextTable[RHT_KAK_POTION_SHOP_ITEM_7] = HintText(CustomMessage("They say that the #Kakariko Potion Shop# offers #[[1]]#.",
-                                                            /*german*/ "",
+                                                            /*german*/ "Man erzählt sich, daß der #Magie-Laden in Kakariko# #[[1]]# offeriere.",
                                                             /*french*/ "Selon moi, l'#apothicaire de Kakariko# vend #[[1]]#.", {QM_RED, QM_GREEN}),
                                                          // /*spanish*/ Según dicen, la #tienda de pociones de Kakariko# ofrece #[[1]]#.
                                                          {}, {
                                                          CustomMessage("They say that a #potion seller# offers #[[1]]#.",
-                                                             /*german*/ "",
+                                                             /*german*/ "Man erzählt sich, daß ein #Trankhändler# #[[1]]# anböte.",
                                                              /*french*/ "Selon moi, l'#apothicaire# vend #[[1]]#.", {QM_RED, QM_GREEN})});
                                                           // /*spanish*/ Según dicen, un #vendedor de pociones# ofrece #[[1]]#.
 
     hintTextTable[RHT_KAK_POTION_SHOP_ITEM_8] = HintText(CustomMessage("They say that the #Kakariko Potion Shop# offers #[[1]]#.",
-                                                            /*german*/ "",
+                                                            /*german*/ "Man erzählt sich, daß der #Magie-Laden in Kakariko# #[[1]]# offeriere.",
                                                             /*french*/ "Selon moi, l'#apothicaire de Kakariko# vend #[[1]]#.", {QM_RED, QM_GREEN}),
                                                          // /*spanish*/ Según dicen, la #tienda de pociones de Kakariko# ofrece #[[1]]#.
                                                          {}, {
                                                          CustomMessage("They say that a #potion seller# offers #[[1]]#.",
-                                                             /*german*/ "",
+                                                             /*german*/ "Man erzählt sich, daß ein #Trankhändler# #[[1]]# anböte.",
                                                              /*french*/ "Selon moi, l'#apothicaire# vend #[[1]]#.", {QM_RED, QM_GREEN})});
                                                           // /*spanish*/ Según dicen, un #vendedor de pociones# ofrece #[[1]]#.
 
     hintTextTable[RHT_MARKET_BOMBCHU_SHOP_ITEM_1] = HintText(CustomMessage("They say that a #Bombchu merchant# sells #[[1]]#.",
-                                                                /*german*/ "",
+                                                                /*german*/ "Man erzählt sich, daß ein #Krabbelminenhändler# #[[1]]# verkaufe.",
                                                                 /*french*/ "Selon moi, le #marchand de Missiles# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                              // /*spanish*/ Según dicen, un #mercader de bombchus# vende #[[1]]#.
 
     hintTextTable[RHT_MARKET_BOMBCHU_SHOP_ITEM_2] = HintText(CustomMessage("They say that a #Bombchu merchant# sells #[[1]]#.",
-                                                                /*german*/ "",
+                                                                /*german*/ "Man erzählt sich, daß ein #Krabbelminenhändler# #[[1]]# verkaufe.",
                                                                 /*french*/ "Selon moi, le #marchand de Missiles# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                              // /*spanish*/ Según dicen, un #mercader de bombchus# vende #[[1]]#.
 
     hintTextTable[RHT_MARKET_BOMBCHU_SHOP_ITEM_3] = HintText(CustomMessage("They say that a #Bombchu merchant# sells #[[1]]#.",
-                                                                /*german*/ "",
+                                                                /*german*/ "Man erzählt sich, daß ein #Krabbelminenhändler# #[[1]]# verkaufe.",
                                                                 /*french*/ "Selon moi, le #marchand de Missiles# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                              // /*spanish*/ Según dicen, un #mercader de bombchus# vende #[[1]]#.
 
     hintTextTable[RHT_MARKET_BOMBCHU_SHOP_ITEM_4] = HintText(CustomMessage("They say that a #Bombchu merchant# sells #[[1]]#.",
-                                                                /*german*/ "",
+                                                                /*german*/ "Man erzählt sich, daß ein #Krabbelminenhändler# #[[1]]# verkaufe.",
                                                                 /*french*/ "Selon moi, le #marchand de Missiles# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                              // /*spanish*/ Según dicen, un #mercader de bombchus# vende #[[1]]#.
 
     hintTextTable[RHT_MARKET_BOMBCHU_SHOP_ITEM_5] = HintText(CustomMessage("They say that a #Bombchu merchant# sells #[[1]]#.",
-                                                                /*german*/ "",
+                                                                /*german*/ "Man erzählt sich, daß ein #Krabbelminenhändler# #[[1]]# verkaufe.",
                                                                 /*french*/ "Selon moi, le #marchand de Missiles# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                              // /*spanish*/ Según dicen, un #mercader de bombchus# vende #[[1]]#.
 
     hintTextTable[RHT_MARKET_BOMBCHU_SHOP_ITEM_6] = HintText(CustomMessage("They say that a #Bombchu merchant# sells #[[1]]#.",
-                                                                /*german*/ "",
+                                                                /*german*/ "Man erzählt sich, daß ein #Krabbelminenhändler# #[[1]]# verkaufe.",
                                                                 /*french*/ "Selon moi, le #marchand de Missiles# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                              // /*spanish*/ Según dicen, un #mercader de bombchus# vende #[[1]]#.
 
     hintTextTable[RHT_MARKET_BOMBCHU_SHOP_ITEM_7] = HintText(CustomMessage("They say that a #Bombchu merchant# sells #[[1]]#.",
-                                                                /*german*/ "",
+                                                                /*german*/ "Man erzählt sich, daß ein #Krabbelminenhändler# #[[1]]# verkaufe.",
                                                                 /*french*/ "Selon moi, le #marchand de Missiles# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                              // /*spanish*/ Según dicen, un #mercader de bombchus# vende #[[1]]#.
 
     hintTextTable[RHT_MARKET_BOMBCHU_SHOP_ITEM_8] = HintText(CustomMessage("They say that a #Bombchu merchant# sells #[[1]]#.",
-                                                                /*german*/ "",
+                                                                /*german*/ "Man erzählt sich, daß ein #Krabbelminenhändler# #[[1]]# verkaufe.",
                                                                 /*french*/ "Selon moi, le #marchand de Missiles# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                              // /*spanish*/ Según dicen, un #mercader de bombchus# vende #[[1]]#.
 
     hintTextTable[RHT_MARKET_POTION_SHOP_ITEM_1] = HintText(CustomMessage("They say that the #Market Potion Shop# offers #[[1]]#.",
-                                                               /*german*/ "",
+                                                               /*german*/ "Man erzählt sich, daß der #Magie-Laden auf dem Markt# #[[1]]# offeriere.",
                                                                /*french*/ "Selon moi, l'#apothicaire dans la Place du Marché# vend #[[1]]#.", {QM_RED, QM_GREEN}),
                                                             // /*spanish*/ Según dicen, la #tienda de pociones del mercado# ofrece #[[1]]#.
                                                             {}, {
                                                             CustomMessage("They say that a #potion seller# offers #[[1]]#.",
-                                                                /*german*/ "",
+                                                                /*german*/ "Man erzählt sich, daß ein #Trankhändler# #[[1]]# anböte.",
                                                                 /*french*/ "Selon moi, l'#apothicaire# vend #[[1]]#.", {QM_RED, QM_GREEN})});
                                                              // /*spanish*/ Según dicen, un #vendedor de pociones# ofrece #[[1]]#.
 
     hintTextTable[RHT_MARKET_POTION_SHOP_ITEM_2] = HintText(CustomMessage("They say that the #Market Potion Shop# offers #[[1]]#.",
-                                                               /*german*/ "",
+                                                               /*german*/ "Man erzählt sich, daß der #Magie-Laden auf dem Markt# #[[1]]# offeriere.",
                                                                /*french*/ "Selon moi, l'#apothicaire dans la Place du Marché# vend #[[1]]#.", {QM_RED, QM_GREEN}),
                                                             // /*spanish*/ Según dicen, la #tienda de pociones del mercado# ofrece #[[1]]#.
                                                             {}, {
                                                             CustomMessage("They say that a #potion seller# offers #[[1]]#.",
-                                                                /*german*/ "",
+                                                                /*german*/ "Man erzählt sich, daß ein #Trankhändler# #[[1]]# anböte.",
                                                                 /*french*/ "Selon moi, l'#apothicaire# vend #[[1]]#.", {QM_RED, QM_GREEN})});
                                                              // /*spanish*/ Según dicen, un #vendedor de pociones# ofrece #[[1]]#.
 
     hintTextTable[RHT_MARKET_POTION_SHOP_ITEM_3] = HintText(CustomMessage("They say that the #Market Potion Shop# offers #[[1]]#.",
-                                                               /*german*/ "",
+                                                               /*german*/ "Man erzählt sich, daß der #Magie-Laden auf dem Markt# #[[1]]# offeriere.",
                                                                /*french*/ "Selon moi, l'#apothicaire dans la Place du Marché# vend #[[1]]#.", {QM_RED, QM_GREEN}),
                                                             // /*spanish*/ Según dicen, la #tienda de pociones del mercado# ofrece #[[1]]#.
                                                             {}, {
                                                             CustomMessage("They say that a #potion seller# offers #[[1]]#.",
-                                                                /*german*/ "",
+                                                                /*german*/ "Man erzählt sich, daß ein #Trankhändler# #[[1]]# anböte.",
                                                                 /*french*/ "Selon moi, l'#apothicaire# vend #[[1]]#.", {QM_RED, QM_GREEN})});
                                                              // /*spanish*/ Según dicen, un #vendedor de pociones# ofrece #[[1]]#.
 
     hintTextTable[RHT_MARKET_POTION_SHOP_ITEM_4] = HintText(CustomMessage("They say that the #Market Potion Shop# offers #[[1]]#.",
-                                                               /*german*/ "",
+                                                               /*german*/ "Man erzählt sich, daß der #Magie-Laden auf dem Markt# #[[1]]# offeriere.",
                                                                /*french*/ "Selon moi, l'#apothicaire dans la Place du Marché# vend #[[1]]#.", {QM_RED, QM_GREEN}),
                                                             // /*spanish*/ Según dicen, la #tienda de pociones del mercado# ofrece #[[1]]#.
                                                             {}, {
                                                             CustomMessage("They say that a #potion seller# offers #[[1]]#.",
-                                                                /*german*/ "",
+                                                                /*german*/ "Man erzählt sich, daß ein #Trankhändler# #[[1]]# anböte.",
                                                                 /*french*/ "Selon moi, l'#apothicaire# vend #[[1]]#.", {QM_RED, QM_GREEN})});
                                                              // /*spanish*/ Según dicen, un #vendedor de pociones# ofrece #[[1]]#.
 
     hintTextTable[RHT_MARKET_POTION_SHOP_ITEM_5] = HintText(CustomMessage("They say that the #Market Potion Shop# offers #[[1]]#.",
-                                                               /*german*/ "",
+                                                               /*german*/ "Man erzählt sich, daß der #Magie-Laden auf dem Markt# #[[1]]# offeriere.",
                                                                /*french*/ "Selon moi, l'#apothicaire dans la Place du Marché# vend #[[1]]#.", {QM_RED, QM_GREEN}),
                                                             // /*spanish*/ Según dicen, la #tienda de pociones del mercado# ofrece #[[1]]#.
                                                             {}, {
                                                             CustomMessage("They say that a #potion seller# offers #[[1]]#.",
-                                                                /*german*/ "",
+                                                                /*german*/ "Man erzählt sich, daß ein #Trankhändler# #[[1]]# anböte.",
                                                                 /*french*/ "Selon moi, l'#apothicaire# vend #[[1]]#.", {QM_RED, QM_GREEN})});
                                                              // /*spanish*/ Según dicen, un #vendedor de pociones# ofrece #[[1]]#.
 
     hintTextTable[RHT_MARKET_POTION_SHOP_ITEM_6] = HintText(CustomMessage("They say that the #Market Potion Shop# offers #[[1]]#.",
-                                                               /*german*/ "",
+                                                               /*german*/ "Man erzählt sich, daß der #Magie-Laden auf dem Markt# #[[1]]# offeriere.",
                                                                /*french*/ "Selon moi, l'#apothicaire dans la Place du Marché# vend #[[1]]#.", {QM_RED, QM_GREEN}),
                                                             // /*spanish*/ Según dicen, la #tienda de pociones del mercado# ofrece #[[1]]#.
                                                             {}, {
                                                             CustomMessage("They say that a #potion seller# offers #[[1]]#.",
-                                                                /*german*/ "",
+                                                                /*german*/ "Man erzählt sich, daß ein #Trankhändler# #[[1]]# anböte.",
                                                                 /*french*/ "Selon moi, l'#apothicaire# vend #[[1]]#.", {QM_RED, QM_GREEN})});
                                                              // /*spanish*/ Según dicen, un #vendedor de pociones# ofrece #[[1]]#.
 
     hintTextTable[RHT_MARKET_POTION_SHOP_ITEM_7] = HintText(CustomMessage("They say that the #Market Potion Shop# offers #[[1]]#.",
-                                                               /*german*/ "",
+                                                               /*german*/ "Man erzählt sich, daß der #Magie-Laden auf dem Markt# #[[1]]# offeriere.",
                                                                /*french*/ "Selon moi, l'#apothicaire dans la Place du Marché# vend #[[1]]#.", {QM_RED, QM_GREEN}),
                                                             // /*spanish*/ Según dicen, la #tienda de pociones del mercado# ofrece #[[1]]#.
                                                             {}, {
                                                             CustomMessage("They say that a #potion seller# offers #[[1]]#.",
-                                                                /*german*/ "",
+                                                                /*german*/ "Man erzählt sich, daß ein #Trankhändler# #[[1]]# anböte.",
                                                                 /*french*/ "Selon moi, l'#apothicaire# vend #[[1]]#.", {QM_RED, QM_GREEN})});
                                                              // /*spanish*/ Según dicen, un #vendedor de pociones# ofrece #[[1]]#.
 
     hintTextTable[RHT_MARKET_POTION_SHOP_ITEM_8] = HintText(CustomMessage("They say that the #Market Potion Shop# offers #[[1]]#.",
-                                                               /*german*/ "",
+                                                               /*german*/ "Man erzählt sich, daß der #Magie-Laden auf dem Markt# #[[1]]# offeriere.",
                                                                /*french*/ "Selon moi, l'#apothicaire dans la Place du Marché# vend #[[1]]#.", {QM_RED, QM_GREEN}),
                                                             // /*spanish*/ Según dicen, la #tienda de pociones del mercado# ofrece #[[1]]#.
                                                             {}, {
                                                             CustomMessage("They say that a #potion seller# offers #[[1]]#.",
-                                                                /*german*/ "",
+                                                                /*german*/ "Man erzählt sich, daß ein #Trankhändler# #[[1]]# anböte.",
                                                                 /*french*/ "Selon moi, l'#apothicaire# vend #[[1]]#.", {QM_RED, QM_GREEN})});
                                                              // /*spanish*/ Según dicen, un #vendedor de pociones# ofrece #[[1]]#.
 
     hintTextTable[RHT_MARKET_BAZAAR_ITEM_1] = HintText(CustomMessage("They say that the #Market Bazaar# offers #[[1]]#.",
-                                                          /*german*/ "",
+                                                          /*german*/ "Man erzählt sich, daß auf dem #Marktbasar# #[[1]]# angeboten würde.",
                                                           /*french*/ "Selon moi, le #bazar de la Place du Marché# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                        // /*spanish*/ Según dicen, el #bazar del mercado# ofrece #[[1]]#.
 
     hintTextTable[RHT_MARKET_BAZAAR_ITEM_2] = HintText(CustomMessage("They say that the #Market Bazaar# offers #[[1]]#.",
-                                                          /*german*/ "",
+                                                          /*german*/ "Man erzählt sich, daß auf dem #Marktbasar# #[[1]]# angeboten würde.",
                                                           /*french*/ "Selon moi, le #bazar de la Place du Marché# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                        // /*spanish*/ Según dicen, el #bazar del mercado# ofrece #[[1]]#.
 
     hintTextTable[RHT_MARKET_BAZAAR_ITEM_3] = HintText(CustomMessage("They say that the #Market Bazaar# offers #[[1]]#.",
-                                                          /*german*/ "",
+                                                          /*german*/ "Man erzählt sich, daß auf dem #Marktbasar# #[[1]]# angeboten würde.",
                                                           /*french*/ "Selon moi, le #bazar de la Place du Marché# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                        // /*spanish*/ Según dicen, el #bazar del mercado# ofrece #[[1]]#.
 
     hintTextTable[RHT_MARKET_BAZAAR_ITEM_4] = HintText(CustomMessage("They say that the #Market Bazaar# offers #[[1]]#.",
-                                                          /*german*/ "",
+                                                          /*german*/ "Man erzählt sich, daß auf dem #Marktbasar# #[[1]]# angeboten würde.",
                                                           /*french*/ "Selon moi, le #bazar de la Place du Marché# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                        // /*spanish*/ Según dicen, el #bazar del mercado# ofrece #[[1]]#.
 
     hintTextTable[RHT_MARKET_BAZAAR_ITEM_5] = HintText(CustomMessage("They say that the #Market Bazaar# offers #[[1]]#.",
-                                                          /*german*/ "",
+                                                          /*german*/ "Man erzählt sich, daß auf dem #Marktbasar# #[[1]]# angeboten würde.",
                                                           /*french*/ "Selon moi, le #bazar de la Place du Marché# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                        // /*spanish*/ Según dicen, el #bazar del mercado# ofrece #[[1]]#.
 
     hintTextTable[RHT_MARKET_BAZAAR_ITEM_6] = HintText(CustomMessage("They say that the #Market Bazaar# offers #[[1]]#.",
-                                                          /*german*/ "",
+                                                          /*german*/ "Man erzählt sich, daß auf dem #Marktbasar# #[[1]]# angeboten würde.",
                                                           /*french*/ "Selon moi, le #bazar de la Place du Marché# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                        // /*spanish*/ Según dicen, el #bazar del mercado# ofrece #[[1]]#.
 
     hintTextTable[RHT_MARKET_BAZAAR_ITEM_7] = HintText(CustomMessage("They say that the #Market Bazaar# offers #[[1]]#.",
-                                                          /*german*/ "",
+                                                          /*german*/ "Man erzählt sich, daß auf dem #Marktbasar# #[[1]]# angeboten würde.",
                                                           /*french*/ "Selon moi, le #bazar de la Place du Marché# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                        // /*spanish*/ Según dicen, el #bazar del mercado# ofrece #[[1]]#.
 
     hintTextTable[RHT_MARKET_BAZAAR_ITEM_8] = HintText(CustomMessage("They say that the #Market Bazaar# offers #[[1]]#.",
-                                                          /*german*/ "",
+                                                          /*german*/ "Man erzählt sich, daß auf dem #Marktbasar# #[[1]]# angeboten würde.",
                                                           /*french*/ "Selon moi, le #bazar de la Place du Marché# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                        // /*spanish*/ Según dicen, el #bazar del mercado# ofrece #[[1]]#.
 
     hintTextTable[RHT_KAK_BAZAAR_ITEM_1] = HintText(CustomMessage("They say that the #Kakariko Bazaar# offers #[[1]]#.",
-                                                       /*german*/ "",
+                                                       /*german*/ "Man erzählt sich, daß auf dem #Basar in Kakariko# #[[1]]# angeboten würde.",
                                                        /*french*/ "Selon moi, le #bazar de Kakariko# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                     // /*spanish*/ Según dicen, el #bazar de Kakariko# ofrece #[[1]]#.
 
     hintTextTable[RHT_KAK_BAZAAR_ITEM_2] = HintText(CustomMessage("They say that the #Kakariko Bazaar# offers #[[1]]#.",
-                                                       /*german*/ "",
+                                                       /*german*/ "Man erzählt sich, daß auf dem #Basar in Kakariko# #[[1]]# angeboten würde.",
                                                        /*french*/ "Selon moi, le #bazar de Kakariko# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                     // /*spanish*/ Según dicen, el #bazar de Kakariko# ofrece #[[1]]#.
 
     hintTextTable[RHT_KAK_BAZAAR_ITEM_3] = HintText(CustomMessage("They say that the #Kakariko Bazaar# offers #[[1]]#.",
-                                                       /*german*/ "",
+                                                       /*german*/ "Man erzählt sich, daß auf dem #Basar in Kakariko# #[[1]]# angeboten würde.",
                                                        /*french*/ "Selon moi, le #bazar de Kakariko# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                     // /*spanish*/ Según dicen, el #bazar de Kakariko# ofrece #[[1]]#.
 
     hintTextTable[RHT_KAK_BAZAAR_ITEM_4] = HintText(CustomMessage("They say that the #Kakariko Bazaar# offers #[[1]]#.",
-                                                       /*german*/ "",
+                                                       /*german*/ "Man erzählt sich, daß auf dem #Basar in Kakariko# #[[1]]# angeboten würde.",
                                                        /*french*/ "Selon moi, le #bazar de Kakariko# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                     // /*spanish*/ Según dicen, el #bazar de Kakariko# ofrece #[[1]]#.
 
     hintTextTable[RHT_KAK_BAZAAR_ITEM_5] = HintText(CustomMessage("They say that the #Kakariko Bazaar# offers #[[1]]#.",
-                                                       /*german*/ "",
+                                                       /*german*/ "Man erzählt sich, daß auf dem #Basar in Kakariko# #[[1]]# angeboten würde.",
                                                        /*french*/ "Selon moi, le #bazar de Kakariko# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                     // /*spanish*/ Según dicen, el #bazar de Kakariko# ofrece #[[1]]#.
 
     hintTextTable[RHT_KAK_BAZAAR_ITEM_6] = HintText(CustomMessage("They say that the #Kakariko Bazaar# offers #[[1]]#.",
-                                                       /*german*/ "",
+                                                       /*german*/ "Man erzählt sich, daß auf dem #Basar in Kakariko# #[[1]]# angeboten würde.",
                                                        /*french*/ "Selon moi, le #bazar de Kakariko# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                     // /*spanish*/ Según dicen, el #bazar de Kakariko# ofrece #[[1]]#.
 
     hintTextTable[RHT_KAK_BAZAAR_ITEM_7] = HintText(CustomMessage("They say that the #Kakariko Bazaar# offers #[[1]]#.",
-                                                       /*german*/ "",
+                                                       /*german*/ "Man erzählt sich, daß auf dem #Basar in Kakariko# #[[1]]# angeboten würde.",
                                                        /*french*/ "Selon moi, le #bazar de Kakariko# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                     // /*spanish*/ Según dicen, el #bazar de Kakariko# ofrece #[[1]]#.
 
     hintTextTable[RHT_KAK_BAZAAR_ITEM_8] = HintText(CustomMessage("They say that the #Kakariko Bazaar# offers #[[1]]#.",
-                                                       /*german*/ "",
+                                                       /*german*/ "Man erzählt sich, daß auf dem #Basar in Kakariko# #[[1]]# angeboten würde.",
                                                        /*french*/ "Selon moi, le #bazar de Kakariko# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                     // /*spanish*/ Según dicen, el #bazar de Kakariko# ofrece #[[1]]#.
 
     hintTextTable[RHT_ZD_SHOP_ITEM_1] = HintText(CustomMessage("They say that a #Zora shopkeeper# sells #[[1]]#.",
-                                                    /*german*/ "",
+                                                    /*german*/ "Man erzählt sich, daß ein #Händler der Zora# #[[1]]# verkaufen würde.",
                                                     /*french*/ "Selon moi, la #boutique Zora# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                  // /*spanish*/ Según dicen, el #dependiente Zora# vende #[[1]]#.
 
     hintTextTable[RHT_ZD_SHOP_ITEM_2] = HintText(CustomMessage("They say that a #Zora shopkeeper# sells #[[1]]#.",
-                                                    /*german*/ "",
+                                                    /*german*/ "Man erzählt sich, daß ein #Händler der Zora# #[[1]]# verkaufen würde.",
                                                     /*french*/ "Selon moi, la #boutique Zora# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                  // /*spanish*/ Según dicen, el #dependiente Zora# vende #[[1]]#.
 
     hintTextTable[RHT_ZD_SHOP_ITEM_3] = HintText(CustomMessage("They say that a #Zora shopkeeper# sells #[[1]]#.",
-                                                    /*german*/ "",
+                                                    /*german*/ "Man erzählt sich, daß ein #Händler der Zora# #[[1]]# verkaufen würde.",
                                                     /*french*/ "Selon moi, la #boutique Zora# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                  // /*spanish*/ Según dicen, el #dependiente Zora# vende #[[1]]#.
 
     hintTextTable[RHT_ZD_SHOP_ITEM_4] = HintText(CustomMessage("They say that a #Zora shopkeeper# sells #[[1]]#.",
-                                                    /*german*/ "",
+                                                    /*german*/ "Man erzählt sich, daß ein #Händler der Zora# #[[1]]# verkaufen würde.",
                                                     /*french*/ "Selon moi, la #boutique Zora# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                  // /*spanish*/ Según dicen, el #dependiente Zora# vende #[[1]]#.
 
     hintTextTable[RHT_ZD_SHOP_ITEM_5] = HintText(CustomMessage("They say that a #Zora shopkeeper# sells #[[1]]#.",
-                                                    /*german*/ "",
+                                                    /*german*/ "Man erzählt sich, daß ein #Händler der Zora# #[[1]]# verkaufen würde.",
                                                     /*french*/ "Selon moi, la #boutique Zora# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                  // /*spanish*/ Según dicen, el #dependiente Zora# vende #[[1]]#.
 
     hintTextTable[RHT_ZD_SHOP_ITEM_6] = HintText(CustomMessage("They say that a #Zora shopkeeper# sells #[[1]]#.",
-                                                    /*german*/ "",
+                                                    /*german*/ "Man erzählt sich, daß ein #Händler der Zora# #[[1]]# verkaufen würde.",
                                                     /*french*/ "Selon moi, la #boutique Zora# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                  // /*spanish*/ Según dicen, el #dependiente Zora# vende #[[1]]#.
 
     hintTextTable[RHT_ZD_SHOP_ITEM_7] = HintText(CustomMessage("They say that a #Zora shopkeeper# sells #[[1]]#.",
-                                                    /*german*/ "",
+                                                    /*german*/ "Man erzählt sich, daß ein #Händler der Zora# #[[1]]# verkaufen würde.",
                                                     /*french*/ "Selon moi, la #boutique Zora# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                  // /*spanish*/ Según dicen, el #dependiente Zora# vende #[[1]]#.
 
     hintTextTable[RHT_ZD_SHOP_ITEM_8] = HintText(CustomMessage("They say that a #Zora shopkeeper# sells #[[1]]#.",
-                                                    /*german*/ "",
+                                                    /*german*/ "Man erzählt sich, daß ein #Händler der Zora# #[[1]]# verkaufen würde.",
                                                     /*french*/ "Selon moi, la #boutique Zora# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                  // /*spanish*/ Según dicen, el #dependiente Zora# vende #[[1]]#.
 
     hintTextTable[RHT_GC_SHOP_ITEM_1] = HintText(CustomMessage("They say that a #Goron shopkeeper# sells #[[1]]#.",
-                                                    /*german*/ "",
+                                                    /*german*/ "Man erzählt sich, daß ein #Händler der Goronen# #[[1]]# verkaufen würde.",
                                                     /*french*/ "Selon moi, la #boutique Goron# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                  // /*spanish*/ Según dicen, el #dependiente Goron# vende #[[1]]#.
 
     hintTextTable[RHT_GC_SHOP_ITEM_2] = HintText(CustomMessage("They say that a #Goron shopkeeper# sells #[[1]]#.",
-                                                    /*german*/ "",
+                                                    /*german*/ "Man erzählt sich, daß ein #Händler der Goronen# #[[1]]# verkaufen würde.",
                                                     /*french*/ "Selon moi, la #boutique Goron# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                  // /*spanish*/ Según dicen, el #dependiente Goron# vende #[[1]]#.
 
     hintTextTable[RHT_GC_SHOP_ITEM_3] = HintText(CustomMessage("They say that a #Goron shopkeeper# sells #[[1]]#.",
-                                                    /*german*/ "",
+                                                    /*german*/ "Man erzählt sich, daß ein #Händler der Goronen# #[[1]]# verkaufen würde.",
                                                     /*french*/ "Selon moi, la #boutique Goron# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                  // /*spanish*/ Según dicen, el #dependiente Goron# vende #[[1]]#.
 
     hintTextTable[RHT_GC_SHOP_ITEM_4] = HintText(CustomMessage("They say that a #Goron shopkeeper# sells #[[1]]#.",
-                                                    /*german*/ "",
+                                                    /*german*/ "Man erzählt sich, daß ein #Händler der Goronen# #[[1]]# verkaufen würde.",
                                                     /*french*/ "Selon moi, la #boutique Goron# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                  // /*spanish*/ Según dicen, el #dependiente Goron# vende #[[1]]#.
 
     hintTextTable[RHT_GC_SHOP_ITEM_5] = HintText(CustomMessage("They say that a #Goron shopkeeper# sells #[[1]]#.",
-                                                    /*german*/ "",
+                                                    /*german*/ "Man erzählt sich, daß ein #Händler der Goronen# #[[1]]# verkaufen würde.",
                                                     /*french*/ "Selon moi, la #boutique Goron# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                  // /*spanish*/ Según dicen, el #dependiente Goron# vende #[[1]]#.
 
     hintTextTable[RHT_GC_SHOP_ITEM_6] = HintText(CustomMessage("They say that a #Goron shopkeeper# sells #[[1]]#.",
-                                                    /*german*/ "",
+                                                    /*german*/ "Man erzählt sich, daß ein #Händler der Goronen# #[[1]]# verkaufen würde.",
                                                     /*french*/ "Selon moi, la #boutique Goron# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                  // /*spanish*/ Según dicen, el #dependiente Goron# vende #[[1]]#.
 
     hintTextTable[RHT_GC_SHOP_ITEM_7] = HintText(CustomMessage("They say that a #Goron shopkeeper# sells #[[1]]#.",
-                                                    /*german*/ "",
+                                                    /*german*/ "Man erzählt sich, daß ein #Händler der Goronen# #[[1]]# verkaufen würde.",
                                                     /*french*/ "Selon moi, la #boutique Goron# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                  // /*spanish*/ Según dicen, el #dependiente Goron# vende #[[1]]#.
 
     hintTextTable[RHT_GC_SHOP_ITEM_8] = HintText(CustomMessage("They say that a #Goron shopkeeper# sells #[[1]]#.",
-                                                    /*german*/ "",
+                                                    /*german*/ "Man erzählt sich, daß ein #Händler der Goronen# #[[1]]# verkaufen würde.",
                                                     /*french*/ "Selon moi, la #boutique Goron# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                  // /*spanish*/ Según dicen, el #dependiente Goron# vende #[[1]]#.
 
     hintTextTable[RHT_HF_DEKU_SCRUB_GROTTO] = HintText(CustomMessage("They say that a lonely #scrub in a hole# sells #[[1]]#.",
-                                                          /*german*/ "",
+                                                          /*german*/ "Man erzählt sich, daß ein #einsamer Deku in einem Loch# #[[1]]# verkaufe.",
                                                           /*french*/ "Selon moi, la #peste Mojo dans une grotte de la plaine# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                        // /*spanish*/ Según dicen, un #singular deku bajo un hoyo# de la llanura vende #[[1]]#.
 
     hintTextTable[RHT_LLR_DEKU_SCRUB_GROTTO_LEFT] = HintText(CustomMessage("They say that a #trio of scrubs# sells #[[1]]#.",
-                                                                /*german*/ "",
+                                                                /*german*/ "Man erzählt sich, daß ein #Deku-Trio# #[[1]]# verkaufe.",
                                                                 /*french*/ "Selon moi, le #trio de peste Mojo à la ferme# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                              // /*spanish*/ Según dicen, un #trío de dekus# de una granja venden #[[1]]#.
 
     hintTextTable[RHT_LLR_DEKU_SCRUB_GROTTO_RIGHT] = HintText(CustomMessage("They say that a #trio of scrubs# sells #[[1]]#.",
-                                                                 /*german*/ "",
+                                                                 /*german*/ "Man erzählt sich, daß ein #Deku-Trio# #[[1]]# verkaufe.",
                                                                  /*french*/ "Selon moi, le #trio de peste Mojo à la ferme# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                               // /*spanish*/ Según dicen, un #trío de dekus# de una granja venden #[[1]]#.
 
     hintTextTable[RHT_LLR_DEKU_SCRUB_GROTTO_CENTER] = HintText(CustomMessage("They say that a #trio of scrubs# sells #[[1]]#.",
-                                                                  /*german*/ "",
+                                                                  /*german*/ "Man erzählt sich, daß ein #Deku-Trio# #[[1]]# verkaufe.",
                                                                   /*french*/ "Selon moi, le #trio de peste Mojo à la ferme# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                // /*spanish*/ Según dicen, un #trío de dekus# de una granja venden #[[1]]#.
 
     hintTextTable[RHT_LW_DEKU_SCRUB_NEAR_DEKU_THEATER_RIGHT] = HintText(CustomMessage("They say that a pair of #scrubs in the woods# sells #[[1]]#.",
-                                                                           /*german*/ "",
+                                                                           /*german*/ "Man erzählt sich, daß ein #Deku-Paar in den Wäldern# #[[1]]# verkaufe.",
                                                                            /*french*/ "Selon moi, le #duo de peste Mojo près du théâtre# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                         // /*spanish*/ Según dicen, un par de #dekus del bosque# venden #[[1]]#.
 
     hintTextTable[RHT_LW_DEKU_SCRUB_NEAR_DEKU_THEATER_LEFT] = HintText(CustomMessage("They say that a pair of #scrubs in the woods# sells #[[1]]#.",
-                                                                          /*german*/ "",
+                                                                          /*german*/ "Man erzählt sich, daß ein #Deku-Paar in den Wäldern# #[[1]]# verkaufe.",
                                                                           /*french*/ "Selon moi, le #duo de peste Mojo près du théâtre# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                        // /*spanish*/ Según dicen, un par de #dekus del bosque# venden #[[1]]#.
 
     hintTextTable[RHT_LW_DEKU_SCRUB_NEAR_BRIDGE] = HintText(CustomMessage("They say that a #scrub by a bridge# sells #[[1]]#.",
-                                                               /*german*/ "",
+                                                               /*german*/ "Man erzählt sich, daß ein #Deku bei einer Brücke# #[[1]]# verkaufe.",
                                                                /*french*/ "Selon moi, la #peste Mojo près du pont dans les bois# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                             // /*spanish*/ Según dicen, un #deku bajo un puente# del bosque venden #[[1]]#.
 
     hintTextTable[RHT_LW_DEKU_SCRUB_GROTTO_REAR] = HintText(CustomMessage("They say that a #scrub underground duo# sells #[[1]]#.",
-                                                               /*german*/ "",
+                                                               /*german*/ "Man erzählt sich, daß ein #Deku-Paar im Untergrund# #[[1]]# verkaufe.",
                                                                /*french*/ "Selon moi, le #duo de peste Mojo dans les sous-bois# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                             // /*spanish*/ Según dicen, un #par de dekus subterráneos# del bosque venden #[[1]]#.
 
     hintTextTable[RHT_LW_DEKU_SCRUB_GROTTO_FRONT] = HintText(CustomMessage("They say that a #scrub underground duo# sells #[[1]]#.",
-                                                                /*german*/ "",
+                                                                /*german*/ "Man erzählt sich, daß ein #Deku-Paar im Untergrund# #[[1]]# verkaufe.",
                                                                 /*french*/ "Selon moi, le #duo de peste Mojo dans les sous-bois# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                              // /*spanish*/ Según dicen, un #par de dekus subterráneos# del bosque venden #[[1]]#.
 
     hintTextTable[RHT_SFM_DEKU_SCRUB_GROTTO_REAR] = HintText(CustomMessage("They say that a #scrub underground duo# sells #[[1]]#.",
-                                                                /*german*/ "",
+                                                                /*german*/ "Man erzählt sich, daß ein #Deku-Paar im Untergrund# #[[1]]# verkaufe.",
                                                                 /*french*/ "Selon moi, le #duo de peste Mojo au cur du sanctuaire sylvestre# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                              // /*spanish*/ Según dicen, un #par de dekus subterráneos# de la pradera sagrada venden #[[1]]#.
 
     hintTextTable[RHT_SFM_DEKU_SCRUB_GROTTO_FRONT] = HintText(CustomMessage("They say that a #scrub underground duo# sells #[[1]]#.",
-                                                                 /*german*/ "",
+                                                                 /*german*/ "Man erzählt sich, daß ein #Deku-Paar im Untergrund# #[[1]]# verkaufe.",
                                                                  /*french*/ "Selon moi, le #duo de peste Mojo au cur du sanctuaire sylvestre# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                               // /*spanish*/ Según dicen, un #par de dekus subterráneos# de la pradera sagrada venden #[[1]]#.
 
     hintTextTable[RHT_GC_DEKU_SCRUB_GROTTO_LEFT] = HintText(CustomMessage("They say that a #trio of scrubs# sells #[[1]]#.",
-                                                               /*german*/ "",
+                                                               /*german*/ "Man erzählt sich, daß ein #Deku-Trio# #[[1]]# verkaufe.",
                                                                /*french*/ "Selon moi, le #trio de peste Mojo dans le village Goron# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                             // /*spanish*/ Según dicen, un #trío de dekus# de la Ciudad Goron venden #[[1]]#.
 
     hintTextTable[RHT_GC_DEKU_SCRUB_GROTTO_RIGHT] = HintText(CustomMessage("They say that a #trio of scrubs# sells #[[1]]#.",
-                                                                /*german*/ "",
+                                                                /*german*/ "Man erzählt sich, daß ein #Deku-Trio# #[[1]]# verkaufe.",
                                                                 /*french*/ "Selon moi, le #trio de peste Mojo dans le village Goron# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                              // /*spanish*/ Según dicen, un #trío de dekus# de la Ciudad Goron venden #[[1]]#.
 
     hintTextTable[RHT_GC_DEKU_SCRUB_GROTTO_CENTER] = HintText(CustomMessage("They say that a #trio of scrubs# sells #[[1]]#.",
-                                                                 /*german*/ "",
+                                                                 /*german*/ "Man erzählt sich, daß ein #Deku-Trio# #[[1]]# verkaufe.",
                                                                  /*french*/ "Selon moi, le #trio de peste Mojo dans le village Goron# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                               // /*spanish*/ Según dicen, un #trío de dekus# de la Ciudad Goron venden #[[1]]#.
 
     hintTextTable[RHT_DMC_DEKU_SCRUB_GROTTO_LEFT] = HintText(CustomMessage("They say that a #trio of scrubs# sells #[[1]]#.",
-                                                                /*german*/ "",
+                                                                /*german*/ "Man erzählt sich, daß ein #Deku-Trio# #[[1]]# verkaufe.",
                                                                 /*french*/ "Selon moi, le #trio de peste Mojo dans le volcan# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                              // /*spanish*/ Según dicen, un #trío de dekus# del volcán venden #[[1]]#.
 
     hintTextTable[RHT_DMC_DEKU_SCRUB_GROTTO_RIGHT] = HintText(CustomMessage("They say that a #trio of scrubs# sells #[[1]]#.",
-                                                                 /*german*/ "",
+                                                                 /*german*/ "Man erzählt sich, daß ein #Deku-Trio# #[[1]]# verkaufe.",
                                                                  /*french*/ "Selon moi, le #trio de peste Mojo dans le volcan# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                               // /*spanish*/ Según dicen, un #trío de dekus# del volcán venden #[[1]]#.
 
     hintTextTable[RHT_DMC_DEKU_SCRUB_GROTTO_CENTER] = HintText(CustomMessage("They say that a #trio of scrubs# sells #[[1]]#.",
-                                                                  /*german*/ "",
+                                                                  /*german*/ "Man erzählt sich, daß ein #Deku-Trio# #[[1]]# verkaufe.",
                                                                   /*french*/ "Selon moi, le #trio de peste Mojo dans le volcan# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                // /*spanish*/ Según dicen, un #trío de dekus# del volcán venden #[[1]]#.
 
     hintTextTable[RHT_ZR_DEKU_SCRUB_GROTTO_REAR] = HintText(CustomMessage("They say that a #scrub underground duo# sells #[[1]]#.",
-                                                               /*german*/ "",
+                                                               /*german*/ "Man erzählt sich, daß ein #Deku-Paar im Untergrund# #[[1]]# verkaufe.",
                                                                /*french*/ "Selon moi, le #duo de peste Mojo près du fleuve# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                             // /*spanish*/ Según dicen, un #par de dekus subterráneos# del río venden #[[1]]#.
 
     hintTextTable[RHT_ZR_DEKU_SCRUB_GROTTO_FRONT] = HintText(CustomMessage("They say that a #scrub underground duo# sells #[[1]]#.",
-                                                                /*german*/ "",
+                                                                /*german*/ "Man erzählt sich, daß ein #Deku-Paar im Untergrund# #[[1]]# verkaufe.",
                                                                 /*french*/ "Selon moi, le #duo de peste Mojo près du fleuve# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                              // /*spanish*/ Según dicen, un #par de dekus subterráneos# del río venden #[[1]]#.
 
     hintTextTable[RHT_LH_DEKU_SCRUB_GROTTO_LEFT] = HintText(CustomMessage("They say that a #trio of scrubs# sells #[[1]]#.",
-                                                               /*german*/ "",
+                                                               /*german*/ "Man erzählt sich, daß ein #Deku-Trio# #[[1]]# verkaufe.",
                                                                /*french*/ "Selon moi, le #trio de peste Mojo près du lac# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                             // /*spanish*/ Según dicen, un #trío de dekus# del lago venden #[[1]]#.
 
     hintTextTable[RHT_LH_DEKU_SCRUB_GROTTO_RIGHT] = HintText(CustomMessage("They say that a #trio of scrubs# sells #[[1]]#.",
-                                                                /*german*/ "",
+                                                                /*german*/ "Man erzählt sich, daß ein #Deku-Trio# #[[1]]# verkaufe.",
                                                                 /*french*/ "Selon moi, le #trio de peste Mojo près du lac# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                              // /*spanish*/ Según dicen, un #trío de dekus# del lago venden #[[1]]#.
 
     hintTextTable[RHT_LH_DEKU_SCRUB_GROTTO_CENTER] = HintText(CustomMessage("They say that a #trio of scrubs# sells #[[1]]#.",
-                                                                 /*german*/ "",
+                                                                 /*german*/ "Man erzählt sich, daß ein #Deku-Trio# #[[1]]# verkaufe.",
                                                                  /*french*/ "Selon moi, le #trio de peste Mojo près du lac# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                               // /*spanish*/ Según dicen, un #trío de dekus# del lago venden #[[1]]#.
 
     hintTextTable[RHT_GV_DEKU_SCRUB_GROTTO_REAR] = HintText(CustomMessage("They say that a #scrub underground duo# sells #[[1]]#.",
-                                                               /*german*/ "",
+                                                               /*german*/ "Man erzählt sich, daß ein #Deku-Paar im Untergrund# #[[1]]# verkaufe.",
                                                                /*french*/ "Selon moi, le #duo de peste Mojo près de la vallée# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                             // /*spanish*/ Según dicen, un #par de dekus subterráneos# del valle venden #[[1]]#.
 
     hintTextTable[RHT_GV_DEKU_SCRUB_GROTTO_FRONT] = HintText(CustomMessage("They say that a #scrub underground duo# sells #[[1]]#.",
-                                                                /*german*/ "",
+                                                                /*german*/ "Man erzählt sich, daß ein #Deku-Paar im Untergrund# #[[1]]# verkaufe.",
                                                                 /*french*/ "Selon moi, le #duo de peste Mojo près de la vallée# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                              // /*spanish*/ Según dicen, un #par de dekus subterráneos# del valle venden #[[1]]#.
 
     hintTextTable[RHT_COLOSSUS_DEKU_SCRUB_GROTTO_FRONT] = HintText(CustomMessage("They say that a #scrub underground duo# sells #[[1]]#.",
-                                                                      /*german*/ "",
+                                                                      /*german*/ "Man erzählt sich, daß ein #Deku-Paar im Untergrund# #[[1]]# verkaufe.",
                                                                       /*french*/ "Selon moi, le #duo de peste Mojo dans le désert# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                    // /*spanish*/ Según dicen, un #par de dekus subterráneos# del desierto venden #[[1]]#.
 
     hintTextTable[RHT_COLOSSUS_DEKU_SCRUB_GROTTO_REAR] = HintText(CustomMessage("They say that a #scrub underground duo# sells #[[1]]#.",
-                                                                     /*german*/ "",
+                                                                     /*german*/ "Man erzählt sich, daß ein #Deku-Paar im Untergrund# #[[1]]# verkaufe.",
                                                                      /*french*/ "Selon moi, le #duo de peste Mojo dans le désert# vend #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                   // /*spanish*/ Según dicen, un #par de dekus subterráneos# del desierto venden #[[1]]#.
 
     hintTextTable[RHT_LLR_STABLES_LEFT_COW] = HintText(CustomMessage("They say that a #cow in a stable# gifts #[[1]]#.",
-                                                          /*german*/ "",
+                                                          /*german*/ "Man erzählt sich, daß eine #Kuh in einem Stall# #[[1]]# schenke.",
                                                           /*french*/ "Selon moi, la #vache dans l'étable# donne #[[1]]#.", {QM_RED, QM_GREEN}));
                                                        // /*spanish*/ Según dicen, una #vaca del establo# brinda #[[1]]#.
 
     hintTextTable[RHT_LLR_STABLES_RIGHT_COW] = HintText(CustomMessage("They say that a #cow in a stable# gifts #[[1]]#.",
-                                                           /*german*/ "",
+                                                           /*german*/ "Man erzählt sich, daß eine #Kuh in einem Stall# #[[1]]# schenke.",
                                                            /*french*/ "Selon moi, la #vache dans l'étable# donne #[[1]]#.", {QM_RED, QM_GREEN}));
                                                         // /*spanish*/ Según dicen, una #vaca del establo# brinda #[[1]]#.
 
     hintTextTable[RHT_LLR_TOWER_RIGHT_COW] = HintText(CustomMessage("They say that a #cow in a ranch silo# gifts #[[1]]#.",
-                                                         /*german*/ "",
+                                                         /*german*/ "Man erzählt sich, daß eine #Kuh in einem Silo# #[[1]]# schenke.",
                                                          /*french*/ "Selon moi, la #vache dans le silo de la ferme# donne #[[1]]#.", {QM_RED, QM_GREEN}));
                                                       // /*spanish*/ Según dicen, una #vaca del granero# brinda #[[1]]#.
 
     hintTextTable[RHT_LLR_TOWER_LEFT_COW] = HintText(CustomMessage("They say that a #cow in a ranch silo# gifts #[[1]]#.",
-                                                        /*german*/ "",
+                                                        /*german*/ "Man erzählt sich, daß eine #Kuh in einem Silo# #[[1]]# schenke.",
                                                         /*french*/ "Selon moi, la #vache dans le silo de la ferme# donne #[[1]]#.", {QM_RED, QM_GREEN}));
                                                      // /*spanish*/ Según dicen, una #vaca del granero# brinda #[[1]]#.
 
     hintTextTable[RHT_KAK_IMPAS_HOUSE_COW] = HintText(CustomMessage("They say that a #cow imprisoned in a house# protects #[[1]]#.",
-                                                         /*german*/ "",
+                                                         /*german*/ "Man erzählt sich, daß eine #in einem Haus gefangene Kuh# #[[1]]# schütze.",
                                                          /*french*/ "Selon moi, la #vache en cage# donne #[[1]]#.", {QM_RED, QM_GREEN}));
                                                       // /*spanish*/ Según dicen, una #vaca enjaulada de una casa# brinda #[[1]]#.
 
     hintTextTable[RHT_DMT_COW_GROTTO_COW] = HintText(CustomMessage("They say that a #cow in a luxurious hole# offers #[[1]]#.",
-                                                        /*german*/ "",
+                                                        /*german*/ "Man erzählt sich, daß eine #Kuh in einem luxuriösen Loch# #[[1]]# offeriere.",
                                                         /*french*/ "Selon moi, la #vache dans une grotte luxueuse# donne #[[1]]#.", {QM_RED, QM_GREEN}));
                                                      // /*spanish*/ Según dicen, una #vaca de un lujoso hoyo# brinda #[[1]]#.
 
     hintTextTable[RHT_BEEHIVE_CHEST_GROTTO] = HintText(CustomMessage("They say that a #beehive above a chest# hides #[[1]]#.",
-                                                          /*german*/ "",
+                                                          /*german*/ "Man erzählt sich, daß ein #Bienenstock oberhalb einer Truhe# #[[1]]# verberge.",
                                                           /*french*/ "Selon moi,  #[[1]]#.", {QM_RED, QM_GREEN}));
                                                        // /*spanish*/ Según dicen, una #colmena sobre un cofre# esconde #[[1]]#.
 
     hintTextTable[RHT_BEEHIVE_LONELY_SCRUB_GROTTO] = HintText(CustomMessage("They say that a #beehive above a lonely scrub# hides #[[1]]#.",
-                                                                 /*german*/ "",
+                                                                 /*german*/ "Man erzählt sich, daß ein #Bienenstock oberhalb eines einsamen Deku# #[[1]]# verberge.",
                                                                  /*french*/ "Selon moi,  #[[1]]#.", {QM_RED, QM_GREEN}));
                                                               // /*spanish*/ Según dicen, una #colmena sobre un deku solitario# esconde #[[1]]#.
 
     hintTextTable[RHT_BEEHIVE_SCRUB_PAIR_GROTTO] = HintText(CustomMessage("They say that a #beehive above a pair of scrubs# hides #[[1]]#.",
-                                                               /*german*/ "",
+                                                               /*german*/ "Man erzählt sich, daß ein #Bienenstock oberhalb eines Deku-Paars# #[[1]]# verberge.",
                                                                /*french*/ "Selon moi,  #[[1]]#.", {QM_RED, QM_GREEN}));
                                                             // /*spanish*/ Según dicen, una #colmena sobre un par de dekus# esconde #[[1]]#.
 
     hintTextTable[RHT_BEEHIVE_SCRUB_TRIO_GROTTO] = HintText(CustomMessage("They say that a #beehive above a trio of scrubs# hides #[[1]]#.",
-                                                               /*german*/ "",
+                                                               /*german*/ "Man erzählt sich, daß ein #Bienenstock oberhalb eines Deku-Trios# #[[1]]# verberge.",
                                                                /*french*/ "Selon moi,  #[[1]]#.", {QM_RED, QM_GREEN}));
                                                             // /*spanish*/ Según dicen, una #colmena sobre un trío de dekus# esconde #[[1]]#.
 
     hintTextTable[RHT_BEEHIVE_COW_GROTTO] = HintText(CustomMessage("They say that a #beehive above a cow# hides #[[1]]#.",
-                                                        /*german*/ "",
+                                                        /*german*/ "Man erzählt sich, daß ein #Bienenstock oberhalb einer Kuh# #[[1]]# verberge.",
                                                         /*french*/ "Selon moi,  #[[1]]#.", {QM_RED, QM_GREEN}));
                                                      // /*spanish*/ Según dicen, una #colmena sobre una vaca# esconde #[[1]]#.
 
     hintTextTable[RHT_BEEHIVE_IN_FRONT_OF_KING_ZORA] = HintText(CustomMessage("They say that a #beehive in front of the king of the zoras# hides #[[1]]#.",
-                                                                   /*german*/ "",
+                                                                   /*german*/ "Man erzählt sich, daß ein #Bienenstock vor dem Zora-König# #[[1]]# verberge.",
                                                                    /*french*/ "Selon moi,  #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                 // /*spanish*/ Según dicen, una #colmena delante del rey de los zoras# esconde #[[1]]#.
 
     hintTextTable[RHT_BEEHIVE_BEHIND_KING_ZORA] = HintText(CustomMessage("They say that a #beehive behind the king of the zoras# hides #[[1]]#.",
-                                                              /*german*/ "",
+                                                              /*german*/ "Man erzählt sich, daß ein #Bienenstock hinter dem Zora-König# #[[1]]# verberge.",
                                                               /*french*/ "Selon moi,  #[[1]]#.", {QM_RED, QM_GREEN}));
                                                            // /*spanish*/ Según dicen, una #colmena detrás del rey de los zoras# esconde #[[1]]#.
 }


### PR DESCRIPTION
This PR contains the full German translation of hint_list_exclude_dungeon.cpp and hint_list_exclude_overworld.cpp combined with a small fix for the French translation.

I put emphasis on the usage of the old German orthography and the preservation of the original expressions.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1844964162.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1845012945.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1845013292.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1845101008.zip)
<!--- section:artifacts:end -->