### PR TITLE
Gui window rework

### DIFF
--- a/soh/soh/Enhancements/audio/AudioEditor.cpp
+++ b/soh/soh/Enhancements/audio/AudioEditor.cpp
@@ -424,12 +424,6 @@ void AudioEditor::InitElement() {
 void AudioEditor::DrawElement() {
     AudioCollection::Instance->InitializeShufflePool();
 
-    ImGui::SetNextWindowSize(ImVec2(820, 630), ImGuiCond_FirstUseEver);
-    if (!ImGui::Begin("Audio Editor", &mIsVisible)) {
-        ImGui::End();
-        return;
-    }
-
     float buttonSegments = ImGui::GetContentRegionAvail().x / 4;
     if (ImGui::Button("Randomize All Groups", ImVec2(buttonSegments, 30.0f))) {
         AudioEditor_RandomizeAll();
@@ -700,7 +694,6 @@ void AudioEditor::DrawElement() {
 
         ImGui::EndTabBar();
     }
-    ImGui::End();
 }
 
 std::vector<SeqType> allTypes = { SEQ_BGM_WORLD, SEQ_BGM_EVENT, SEQ_BGM_BATTLE, SEQ_OCARINA, SEQ_FANFARE, SEQ_INSTRUMENT, SEQ_SFX, SEQ_VOICE };

--- a/soh/soh/Enhancements/controls/InputViewer.cpp
+++ b/soh/soh/Enhancements/controls/InputViewer.cpp
@@ -425,257 +425,250 @@ InputViewerSettingsWindow::~InputViewerSettingsWindow() {
 }
 
 void InputViewerSettingsWindow::DrawElement() {
-    ImGui::SetNextWindowSize(ImVec2(500, 525), ImGuiCond_FirstUseEver);
+   // gInputViewer.Scale
+    UIWidgets::EnhancementSliderFloat("Input Viewer Scale: %.2f", "##Input", CVAR_INPUT_VIEWER("Scale"), 0.1f, 5.0f, "",
+                                        1.0f, false, true);
+    UIWidgets::Tooltip("Sets the on screen size of the input viewer");
 
-    if (ImGui::Begin("Input Viewer Settings", &mIsVisible, ImGuiWindowFlags_HorizontalScrollbar)) {
+    // gInputViewer.EnableDragging
+    UIWidgets::EnhancementCheckbox("Enable Dragging", CVAR_INPUT_VIEWER("EnableDragging"), false, "",
+                                    UIWidgets::CheckboxGraphics::Checkmark, true);
 
-        // gInputViewer.Scale
-        UIWidgets::EnhancementSliderFloat("Input Viewer Scale: %.2f", "##Input", CVAR_INPUT_VIEWER("Scale"), 0.1f, 5.0f, "",
-                                          1.0f, false, true);
-        UIWidgets::Tooltip("Sets the on screen size of the input viewer");
+    UIWidgets::PaddedSeparator(true, true);
 
-        // gInputViewer.EnableDragging
-        UIWidgets::EnhancementCheckbox("Enable Dragging", CVAR_INPUT_VIEWER("EnableDragging"), false, "",
-                                       UIWidgets::CheckboxGraphics::Checkmark, true);
+    // gInputViewer.ShowBackground
+    UIWidgets::EnhancementCheckbox("Show Background Layer", CVAR_INPUT_VIEWER("ShowBackground"), false, "",
+                                    UIWidgets::CheckboxGraphics::Checkmark, true);
+
+    UIWidgets::PaddedSeparator(true, true);
+
+    if (ImGui::CollapsingHeader("Buttons")) {
+
+        // gInputViewer.ButtonOutlineMode
+        UIWidgets::PaddedText("Button Outlines/Backgrounds", true, false);
+        UIWidgets::EnhancementCombobox(
+            CVAR_INPUT_VIEWER("ButtonOutlineMode"), buttonOutlineOptions, BUTTON_OUTLINE_NOT_PRESSED,
+            !CVarGetInteger(CVAR_INPUT_VIEWER("UseGlobalButtonOutlineMode"), 1), "",
+            CVarGetInteger(CVAR_INPUT_VIEWER("ButtonOutlineMode"), BUTTON_OUTLINE_NOT_PRESSED));
+        UIWidgets::Tooltip(
+            "Sets the desired visibility behavior for the button outline/background layers. Useful for "
+            "custom input viewers.");
+
+        // gInputViewer.UseGlobalButtonOutlineMode
+        UIWidgets::EnhancementCheckbox("Use for all buttons", CVAR_INPUT_VIEWER("UseGlobalButtonOutlineMode"), false, "",
+                                        UIWidgets::CheckboxGraphics::Checkmark, true);
+
+        UIWidgets::PaddedSeparator();
+
+        bool useIndividualOutlines = !CVarGetInteger(CVAR_INPUT_VIEWER("UseGlobalButtonOutlineMode"), 1);
+
+        // gInputViewer.ABtn
+        UIWidgets::EnhancementCheckbox("Show A-Button Layers", CVAR_INPUT_VIEWER("ABtn"), false, "",
+                                        UIWidgets::CheckboxGraphics::Checkmark, true);
+        if (useIndividualOutlines && CVarGetInteger(CVAR_INPUT_VIEWER("ABtn"), 1)) {
+            ImGui::Indent();
+            UIWidgets::EnhancementCombobox(CVAR_INPUT_VIEWER("ABtnOutlineMode"), buttonOutlineOptionsVerbose,
+                                            BUTTON_OUTLINE_NOT_PRESSED);
+            ImGui::Unindent();
+        }
+        // gInputViewer.BBtn
+        UIWidgets::EnhancementCheckbox("Show B-Button Layers", CVAR_INPUT_VIEWER("BBtn"), false, "",
+                                        UIWidgets::CheckboxGraphics::Checkmark, true);
+        if (useIndividualOutlines && CVarGetInteger(CVAR_INPUT_VIEWER("BBtn"), 1)) {
+            ImGui::Indent();
+            UIWidgets::EnhancementCombobox(CVAR_INPUT_VIEWER("BBtnOutlineMode"), buttonOutlineOptionsVerbose,
+                                            BUTTON_OUTLINE_NOT_PRESSED);
+            ImGui::Unindent();
+        }
+        // gInputViewer.CUp
+        UIWidgets::EnhancementCheckbox("Show C-Up Layers", CVAR_INPUT_VIEWER("CUp"), false, "",
+                                        UIWidgets::CheckboxGraphics::Checkmark, true);
+        if (useIndividualOutlines && CVarGetInteger(CVAR_INPUT_VIEWER("CUp"), 1)) {
+            ImGui::Indent();
+            UIWidgets::EnhancementCombobox(CVAR_INPUT_VIEWER("CUpOutlineMode"), buttonOutlineOptionsVerbose,
+                                            BUTTON_OUTLINE_NOT_PRESSED);
+            ImGui::Unindent();
+        }
+        // gInputViewer.CRight
+        UIWidgets::EnhancementCheckbox("Show C-Right Layers", CVAR_INPUT_VIEWER("CRight"), false, "",
+                                        UIWidgets::CheckboxGraphics::Checkmark, true);
+        if (useIndividualOutlines && CVarGetInteger(CVAR_INPUT_VIEWER("CRight"), 1)) {
+            ImGui::Indent();
+            UIWidgets::EnhancementCombobox(CVAR_INPUT_VIEWER("CRightOutlineMode"), buttonOutlineOptionsVerbose,
+                                            BUTTON_OUTLINE_NOT_PRESSED);
+            ImGui::Unindent();
+        }
+        // gInputViewer.CDown
+        UIWidgets::EnhancementCheckbox("Show C-Down Layers", CVAR_INPUT_VIEWER("CDown"), false, "",
+                                        UIWidgets::CheckboxGraphics::Checkmark, true);
+        if (useIndividualOutlines && CVarGetInteger(CVAR_INPUT_VIEWER("CDown"), 1)) {
+            ImGui::Indent();
+            UIWidgets::EnhancementCombobox(CVAR_INPUT_VIEWER("CDownOutlineMode"), buttonOutlineOptionsVerbose,
+                                            BUTTON_OUTLINE_NOT_PRESSED);
+            ImGui::Unindent();
+        }
+        // gInputViewer.CLeft
+        UIWidgets::EnhancementCheckbox("Show C-Left Layers", CVAR_INPUT_VIEWER("CLeft"), false, "",
+                                        UIWidgets::CheckboxGraphics::Checkmark, true);
+        if (useIndividualOutlines && CVarGetInteger(CVAR_INPUT_VIEWER("CLeft"), 1)) {
+            ImGui::Indent();
+            UIWidgets::EnhancementCombobox(CVAR_INPUT_VIEWER("CLeftOutlineMode"), buttonOutlineOptionsVerbose,
+                                            BUTTON_OUTLINE_NOT_PRESSED);
+            ImGui::Unindent();
+        }
+        // gInputViewer.LBtn
+        UIWidgets::EnhancementCheckbox("Show L-Button Layers", CVAR_INPUT_VIEWER("LBtn"), false, "",
+                                        UIWidgets::CheckboxGraphics::Checkmark, true);
+        if (useIndividualOutlines && CVarGetInteger(CVAR_INPUT_VIEWER("LBtn"), 1)) {
+            ImGui::Indent();
+            UIWidgets::EnhancementCombobox(CVAR_INPUT_VIEWER("LBtnOutlineMode"), buttonOutlineOptionsVerbose,
+                                            BUTTON_OUTLINE_NOT_PRESSED);
+            ImGui::Unindent();
+        }
+        // gInputViewer.RBtn
+        UIWidgets::EnhancementCheckbox("Show R-Button Layers", CVAR_INPUT_VIEWER("RBtn"), false, "",
+                                        UIWidgets::CheckboxGraphics::Checkmark, true);
+        if (useIndividualOutlines && CVarGetInteger(CVAR_INPUT_VIEWER("RBtn"), 1)) {
+            ImGui::Indent();
+            UIWidgets::EnhancementCombobox(CVAR_INPUT_VIEWER("RBtnOutlineMode"), buttonOutlineOptionsVerbose,
+                                            BUTTON_OUTLINE_NOT_PRESSED);
+            ImGui::Unindent();
+        }
+        // gInputViewer.ZBtn
+        UIWidgets::EnhancementCheckbox("Show Z-Button Layers", CVAR_INPUT_VIEWER("ZBtn"), false, "",
+                                        UIWidgets::CheckboxGraphics::Checkmark, true);
+        if (useIndividualOutlines && CVarGetInteger(CVAR_INPUT_VIEWER("ZBtn"), 1)) {
+            ImGui::Indent();
+            UIWidgets::EnhancementCombobox(CVAR_INPUT_VIEWER("ZBtnOutlineMode"), buttonOutlineOptionsVerbose,
+                                            BUTTON_OUTLINE_NOT_PRESSED);
+            ImGui::Unindent();
+        }
+        // gInputViewer.StartBtn
+        UIWidgets::EnhancementCheckbox("Show Start Button Layers", CVAR_INPUT_VIEWER("StartBtn"), false, "",
+                                        UIWidgets::CheckboxGraphics::Checkmark, true);
+        if (useIndividualOutlines && CVarGetInteger(CVAR_INPUT_VIEWER("StartBtn"), 1)) {
+            ImGui::Indent();
+            UIWidgets::EnhancementCombobox(CVAR_INPUT_VIEWER("StartBtnOutlineMode"), buttonOutlineOptionsVerbose,
+                                            BUTTON_OUTLINE_NOT_PRESSED);
+            ImGui::Unindent();
+        }
+        // gInputViewer.Dpad
+        UIWidgets::EnhancementCheckbox("Show D-Pad Layers", CVAR_INPUT_VIEWER("Dpad"), false, "",
+                                        UIWidgets::CheckboxGraphics::Checkmark, false);
+        if (useIndividualOutlines && CVarGetInteger(CVAR_INPUT_VIEWER("Dpad"), 0)) {
+            ImGui::Indent();
+            UIWidgets::EnhancementCombobox(CVAR_INPUT_VIEWER("DpadOutlineMode"), buttonOutlineOptionsVerbose,
+                                            BUTTON_OUTLINE_NOT_PRESSED);
+            ImGui::Unindent();
+        }
+        // gInputViewer.Mod1
+        UIWidgets::EnhancementCheckbox("Show Modifier Button 1 Layers", CVAR_INPUT_VIEWER("Mod1"), false, "",
+                                        UIWidgets::CheckboxGraphics::Checkmark, false);
+        if (useIndividualOutlines && CVarGetInteger(CVAR_INPUT_VIEWER("Mod1"), 0)) {
+            ImGui::Indent();
+            UIWidgets::EnhancementCombobox(CVAR_INPUT_VIEWER("Mod1OutlineMode"), buttonOutlineOptionsVerbose,
+                                            BUTTON_OUTLINE_NOT_PRESSED);
+            ImGui::Unindent();
+        }
+        // gInputViewer.Mod2
+        UIWidgets::EnhancementCheckbox("Show Modifier Button 2 Layers", CVAR_INPUT_VIEWER("Mod2"), false, "",
+                                        UIWidgets::CheckboxGraphics::Checkmark, false);
+        if (useIndividualOutlines && CVarGetInteger(CVAR_INPUT_VIEWER("Mod2"), 0)) {
+            ImGui::Indent();
+            UIWidgets::EnhancementCombobox(CVAR_INPUT_VIEWER("Mod2OutlineMode"), buttonOutlineOptionsVerbose,
+                                            BUTTON_OUTLINE_NOT_PRESSED);
+            ImGui::Unindent();
+        }
 
         UIWidgets::PaddedSeparator(true, true);
+    }
 
-        // gInputViewer.ShowBackground
-        UIWidgets::EnhancementCheckbox("Show Background Layer", CVAR_INPUT_VIEWER("ShowBackground"), false, "",
-                                       UIWidgets::CheckboxGraphics::Checkmark, true);
+    if (ImGui::CollapsingHeader("Analog Stick")) {
+        // gInputViewer.AnalogStick.VisibilityMode
+        UIWidgets::PaddedText("Analog Stick Visibility", true, false);
+        UIWidgets::EnhancementCombobox(CVAR_INPUT_VIEWER("AnalogStick.VisibilityMode"), stickModeOptions,
+                                        STICK_MODE_ALWAYS_SHOWN);
+        UIWidgets::Tooltip(
+            "Determines the conditions under which the moving layer of the analog stick texture is visible.");
 
+        // gInputViewer.AnalogStick.OutlineMode
+        UIWidgets::PaddedText("Analog Stick Outline/Background Visibility", true, false);
+        UIWidgets::EnhancementCombobox(CVAR_INPUT_VIEWER("AnalogStick.OutlineMode"), stickModeOptions,
+                                        STICK_MODE_ALWAYS_SHOWN);
+        UIWidgets::Tooltip(
+            "Determines the conditions under which the analog stick outline/background texture is visible.");
+
+        // gInputViewer.AnalogStick.Movement
+        UIWidgets::EnhancementSliderInt("Analog Stick Movement: %dpx", "##AnalogMovement",
+                                        CVAR_INPUT_VIEWER("AnalogStick.Movement"), 0, 200, "", 12, true);
+        UIWidgets::Tooltip(
+            "Sets the distance to move the analog stick in the input viewer. Useful for custom input viewers.");
         UIWidgets::PaddedSeparator(true, true);
+    }
 
-        if (ImGui::CollapsingHeader("Buttons")) {
+    if (ImGui::CollapsingHeader("Additional (\"Right\") Stick")) {
+        // gInputViewer.RightStick.VisibilityMode
+        UIWidgets::PaddedText("Right Stick Visibility", true, false);
+        UIWidgets::EnhancementCombobox(CVAR_INPUT_VIEWER("RightStick.VisibilityMode"), stickModeOptions,
+                                        STICK_MODE_HIDDEN_IN_DEADZONE);
+        UIWidgets::Tooltip(
+            "Determines the conditions under which the moving layer of the right stick texture is visible.");
 
-            // gInputViewer.ButtonOutlineMode
-            UIWidgets::PaddedText("Button Outlines/Backgrounds", true, false);
-            UIWidgets::EnhancementCombobox(
-                CVAR_INPUT_VIEWER("ButtonOutlineMode"), buttonOutlineOptions, BUTTON_OUTLINE_NOT_PRESSED,
-                !CVarGetInteger(CVAR_INPUT_VIEWER("UseGlobalButtonOutlineMode"), 1), "",
-                CVarGetInteger(CVAR_INPUT_VIEWER("ButtonOutlineMode"), BUTTON_OUTLINE_NOT_PRESSED));
+        // gInputViewer.RightStick.OutlineMode
+        UIWidgets::PaddedText("Right Stick Outline/Background Visibility", true, false);
+        UIWidgets::EnhancementCombobox(CVAR_INPUT_VIEWER("RightStick.OutlineMode"), stickModeOptions,
+                                        STICK_MODE_HIDDEN_IN_DEADZONE);
+        UIWidgets::Tooltip(
+            "Determines the conditions under which the right stick outline/background texture is visible.");
+
+        // gInputViewer.RightStick.Movement
+        UIWidgets::EnhancementSliderInt("Right Stick Movement: %dpx", "##RightMovement",
+                                        CVAR_INPUT_VIEWER("RightStick.Movement"), 0, 200, "", 7, true);
+        UIWidgets::Tooltip(
+            "Sets the distance to move the right stick in the input viewer. Useful for custom input viewers.");
+        UIWidgets::PaddedSeparator(true, true);
+    }
+
+    if (ImGui::CollapsingHeader("Analog Angle Values")) {
+        // gAnalogAngles
+        UIWidgets::EnhancementCheckbox("Show Analog Stick Angle Values", CVAR_INPUT_VIEWER("AnalogAngles.Enabled"));
+        UIWidgets::Tooltip("Displays analog stick angle values in the input viewer");
+        if (CVarGetInteger(CVAR_INPUT_VIEWER("AnalogAngles.Enabled"), 0)) {
+            // gInputViewer.AnalogAngles.TextColor
+            if (ImGui::ColorEdit4("Text Color", (float*)&textColor)) {
+                CVarSetColor(CVAR_INPUT_VIEWER("AnalogAngles.TextColor"), vec2Color(textColor));
+            }
+            // gAnalogAngleScale
+            UIWidgets::EnhancementSliderFloat("Angle Text Scale: %.2f%%", "##AnalogAngleScale",
+                                                CVAR_INPUT_VIEWER("AnalogAngles.Scale"), 0.1f, 5.0f, "", 1.0f, true, true);
+            // gInputViewer.AnalogAngles.Offset
+            UIWidgets::EnhancementSliderInt("Angle Text Offset: %dpx", "##AnalogAngleOffset",
+                                            CVAR_INPUT_VIEWER("AnalogAngles.Offset"), 0, 400, "", 0, true);
+            UIWidgets::PaddedSeparator(true, true);
+            // gInputViewer.AnalogAngles.Range1.Enabled
+            UIWidgets::EnhancementCheckbox("Highlight ESS Position", CVAR_INPUT_VIEWER("AnalogAngles.Range1.Enabled"));
             UIWidgets::Tooltip(
-                "Sets the desired visibility behavior for the button outline/background layers. Useful for "
-                "custom input viewers.");
-
-            // gInputViewer.UseGlobalButtonOutlineMode
-            UIWidgets::EnhancementCheckbox("Use for all buttons", CVAR_INPUT_VIEWER("UseGlobalButtonOutlineMode"), false, "",
-                                           UIWidgets::CheckboxGraphics::Checkmark, true);
-
-            UIWidgets::PaddedSeparator();
-
-            bool useIndividualOutlines = !CVarGetInteger(CVAR_INPUT_VIEWER("UseGlobalButtonOutlineMode"), 1);
-
-            // gInputViewer.ABtn
-            UIWidgets::EnhancementCheckbox("Show A-Button Layers", CVAR_INPUT_VIEWER("ABtn"), false, "",
-                                           UIWidgets::CheckboxGraphics::Checkmark, true);
-            if (useIndividualOutlines && CVarGetInteger(CVAR_INPUT_VIEWER("ABtn"), 1)) {
-                ImGui::Indent();
-                UIWidgets::EnhancementCombobox(CVAR_INPUT_VIEWER("ABtnOutlineMode"), buttonOutlineOptionsVerbose,
-                                               BUTTON_OUTLINE_NOT_PRESSED);
-                ImGui::Unindent();
-            }
-            // gInputViewer.BBtn
-            UIWidgets::EnhancementCheckbox("Show B-Button Layers", CVAR_INPUT_VIEWER("BBtn"), false, "",
-                                           UIWidgets::CheckboxGraphics::Checkmark, true);
-            if (useIndividualOutlines && CVarGetInteger(CVAR_INPUT_VIEWER("BBtn"), 1)) {
-                ImGui::Indent();
-                UIWidgets::EnhancementCombobox(CVAR_INPUT_VIEWER("BBtnOutlineMode"), buttonOutlineOptionsVerbose,
-                                               BUTTON_OUTLINE_NOT_PRESSED);
-                ImGui::Unindent();
-            }
-            // gInputViewer.CUp
-            UIWidgets::EnhancementCheckbox("Show C-Up Layers", CVAR_INPUT_VIEWER("CUp"), false, "",
-                                           UIWidgets::CheckboxGraphics::Checkmark, true);
-            if (useIndividualOutlines && CVarGetInteger(CVAR_INPUT_VIEWER("CUp"), 1)) {
-                ImGui::Indent();
-                UIWidgets::EnhancementCombobox(CVAR_INPUT_VIEWER("CUpOutlineMode"), buttonOutlineOptionsVerbose,
-                                               BUTTON_OUTLINE_NOT_PRESSED);
-                ImGui::Unindent();
-            }
-            // gInputViewer.CRight
-            UIWidgets::EnhancementCheckbox("Show C-Right Layers", CVAR_INPUT_VIEWER("CRight"), false, "",
-                                           UIWidgets::CheckboxGraphics::Checkmark, true);
-            if (useIndividualOutlines && CVarGetInteger(CVAR_INPUT_VIEWER("CRight"), 1)) {
-                ImGui::Indent();
-                UIWidgets::EnhancementCombobox(CVAR_INPUT_VIEWER("CRightOutlineMode"), buttonOutlineOptionsVerbose,
-                                               BUTTON_OUTLINE_NOT_PRESSED);
-                ImGui::Unindent();
-            }
-            // gInputViewer.CDown
-            UIWidgets::EnhancementCheckbox("Show C-Down Layers", CVAR_INPUT_VIEWER("CDown"), false, "",
-                                           UIWidgets::CheckboxGraphics::Checkmark, true);
-            if (useIndividualOutlines && CVarGetInteger(CVAR_INPUT_VIEWER("CDown"), 1)) {
-                ImGui::Indent();
-                UIWidgets::EnhancementCombobox(CVAR_INPUT_VIEWER("CDownOutlineMode"), buttonOutlineOptionsVerbose,
-                                               BUTTON_OUTLINE_NOT_PRESSED);
-                ImGui::Unindent();
-            }
-            // gInputViewer.CLeft
-            UIWidgets::EnhancementCheckbox("Show C-Left Layers", CVAR_INPUT_VIEWER("CLeft"), false, "",
-                                           UIWidgets::CheckboxGraphics::Checkmark, true);
-            if (useIndividualOutlines && CVarGetInteger(CVAR_INPUT_VIEWER("CLeft"), 1)) {
-                ImGui::Indent();
-                UIWidgets::EnhancementCombobox(CVAR_INPUT_VIEWER("CLeftOutlineMode"), buttonOutlineOptionsVerbose,
-                                               BUTTON_OUTLINE_NOT_PRESSED);
-                ImGui::Unindent();
-            }
-            // gInputViewer.LBtn
-            UIWidgets::EnhancementCheckbox("Show L-Button Layers", CVAR_INPUT_VIEWER("LBtn"), false, "",
-                                           UIWidgets::CheckboxGraphics::Checkmark, true);
-            if (useIndividualOutlines && CVarGetInteger(CVAR_INPUT_VIEWER("LBtn"), 1)) {
-                ImGui::Indent();
-                UIWidgets::EnhancementCombobox(CVAR_INPUT_VIEWER("LBtnOutlineMode"), buttonOutlineOptionsVerbose,
-                                               BUTTON_OUTLINE_NOT_PRESSED);
-                ImGui::Unindent();
-            }
-            // gInputViewer.RBtn
-            UIWidgets::EnhancementCheckbox("Show R-Button Layers", CVAR_INPUT_VIEWER("RBtn"), false, "",
-                                           UIWidgets::CheckboxGraphics::Checkmark, true);
-            if (useIndividualOutlines && CVarGetInteger(CVAR_INPUT_VIEWER("RBtn"), 1)) {
-                ImGui::Indent();
-                UIWidgets::EnhancementCombobox(CVAR_INPUT_VIEWER("RBtnOutlineMode"), buttonOutlineOptionsVerbose,
-                                               BUTTON_OUTLINE_NOT_PRESSED);
-                ImGui::Unindent();
-            }
-            // gInputViewer.ZBtn
-            UIWidgets::EnhancementCheckbox("Show Z-Button Layers", CVAR_INPUT_VIEWER("ZBtn"), false, "",
-                                           UIWidgets::CheckboxGraphics::Checkmark, true);
-            if (useIndividualOutlines && CVarGetInteger(CVAR_INPUT_VIEWER("ZBtn"), 1)) {
-                ImGui::Indent();
-                UIWidgets::EnhancementCombobox(CVAR_INPUT_VIEWER("ZBtnOutlineMode"), buttonOutlineOptionsVerbose,
-                                               BUTTON_OUTLINE_NOT_PRESSED);
-                ImGui::Unindent();
-            }
-            // gInputViewer.StartBtn
-            UIWidgets::EnhancementCheckbox("Show Start Button Layers", CVAR_INPUT_VIEWER("StartBtn"), false, "",
-                                           UIWidgets::CheckboxGraphics::Checkmark, true);
-            if (useIndividualOutlines && CVarGetInteger(CVAR_INPUT_VIEWER("StartBtn"), 1)) {
-                ImGui::Indent();
-                UIWidgets::EnhancementCombobox(CVAR_INPUT_VIEWER("StartBtnOutlineMode"), buttonOutlineOptionsVerbose,
-                                               BUTTON_OUTLINE_NOT_PRESSED);
-                ImGui::Unindent();
-            }
-            // gInputViewer.Dpad
-            UIWidgets::EnhancementCheckbox("Show D-Pad Layers", CVAR_INPUT_VIEWER("Dpad"), false, "",
-                                           UIWidgets::CheckboxGraphics::Checkmark, false);
-            if (useIndividualOutlines && CVarGetInteger(CVAR_INPUT_VIEWER("Dpad"), 0)) {
-                ImGui::Indent();
-                UIWidgets::EnhancementCombobox(CVAR_INPUT_VIEWER("DpadOutlineMode"), buttonOutlineOptionsVerbose,
-                                               BUTTON_OUTLINE_NOT_PRESSED);
-                ImGui::Unindent();
-            }
-            // gInputViewer.Mod1
-            UIWidgets::EnhancementCheckbox("Show Modifier Button 1 Layers", CVAR_INPUT_VIEWER("Mod1"), false, "",
-                                           UIWidgets::CheckboxGraphics::Checkmark, false);
-            if (useIndividualOutlines && CVarGetInteger(CVAR_INPUT_VIEWER("Mod1"), 0)) {
-                ImGui::Indent();
-                UIWidgets::EnhancementCombobox(CVAR_INPUT_VIEWER("Mod1OutlineMode"), buttonOutlineOptionsVerbose,
-                                               BUTTON_OUTLINE_NOT_PRESSED);
-                ImGui::Unindent();
-            }
-            // gInputViewer.Mod2
-            UIWidgets::EnhancementCheckbox("Show Modifier Button 2 Layers", CVAR_INPUT_VIEWER("Mod2"), false, "",
-                                           UIWidgets::CheckboxGraphics::Checkmark, false);
-            if (useIndividualOutlines && CVarGetInteger(CVAR_INPUT_VIEWER("Mod2"), 0)) {
-                ImGui::Indent();
-                UIWidgets::EnhancementCombobox(CVAR_INPUT_VIEWER("Mod2OutlineMode"), buttonOutlineOptionsVerbose,
-                                               BUTTON_OUTLINE_NOT_PRESSED);
-                ImGui::Unindent();
+                "Highlights the angle value text when the analog stick is in ESS position (on flat ground)");
+            if (CVarGetInteger(CVAR_INPUT_VIEWER("AnalogAngles.Range1.Enabled"), 0)) {
+                // gInputViewer.AnalogAngles.Range1.Color
+                if (ImGui::ColorEdit4("ESS Color", (float*)&range1Color)) {
+                    CVarSetColor(CVAR_INPUT_VIEWER("AnalogAngles.Range1.Color"), vec2Color(range1Color));
+                }
             }
 
             UIWidgets::PaddedSeparator(true, true);
-        }
-
-        if (ImGui::CollapsingHeader("Analog Stick")) {
-            // gInputViewer.AnalogStick.VisibilityMode
-            UIWidgets::PaddedText("Analog Stick Visibility", true, false);
-            UIWidgets::EnhancementCombobox(CVAR_INPUT_VIEWER("AnalogStick.VisibilityMode"), stickModeOptions,
-                                           STICK_MODE_ALWAYS_SHOWN);
-            UIWidgets::Tooltip(
-                "Determines the conditions under which the moving layer of the analog stick texture is visible.");
-
-            // gInputViewer.AnalogStick.OutlineMode
-            UIWidgets::PaddedText("Analog Stick Outline/Background Visibility", true, false);
-            UIWidgets::EnhancementCombobox(CVAR_INPUT_VIEWER("AnalogStick.OutlineMode"), stickModeOptions,
-                                           STICK_MODE_ALWAYS_SHOWN);
-            UIWidgets::Tooltip(
-                "Determines the conditions under which the analog stick outline/background texture is visible.");
-
-            // gInputViewer.AnalogStick.Movement
-            UIWidgets::EnhancementSliderInt("Analog Stick Movement: %dpx", "##AnalogMovement",
-                                            CVAR_INPUT_VIEWER("AnalogStick.Movement"), 0, 200, "", 12, true);
-            UIWidgets::Tooltip(
-                "Sets the distance to move the analog stick in the input viewer. Useful for custom input viewers.");
-            UIWidgets::PaddedSeparator(true, true);
-        }
-
-        if (ImGui::CollapsingHeader("Additional (\"Right\") Stick")) {
-            // gInputViewer.RightStick.VisibilityMode
-            UIWidgets::PaddedText("Right Stick Visibility", true, false);
-            UIWidgets::EnhancementCombobox(CVAR_INPUT_VIEWER("RightStick.VisibilityMode"), stickModeOptions,
-                                           STICK_MODE_HIDDEN_IN_DEADZONE);
-            UIWidgets::Tooltip(
-                "Determines the conditions under which the moving layer of the right stick texture is visible.");
-
-            // gInputViewer.RightStick.OutlineMode
-            UIWidgets::PaddedText("Right Stick Outline/Background Visibility", true, false);
-            UIWidgets::EnhancementCombobox(CVAR_INPUT_VIEWER("RightStick.OutlineMode"), stickModeOptions,
-                                           STICK_MODE_HIDDEN_IN_DEADZONE);
-            UIWidgets::Tooltip(
-                "Determines the conditions under which the right stick outline/background texture is visible.");
-
-            // gInputViewer.RightStick.Movement
-            UIWidgets::EnhancementSliderInt("Right Stick Movement: %dpx", "##RightMovement",
-                                            CVAR_INPUT_VIEWER("RightStick.Movement"), 0, 200, "", 7, true);
-            UIWidgets::Tooltip(
-                "Sets the distance to move the right stick in the input viewer. Useful for custom input viewers.");
-            UIWidgets::PaddedSeparator(true, true);
-        }
-
-        if (ImGui::CollapsingHeader("Analog Angle Values")) {
-            // gAnalogAngles
-            UIWidgets::EnhancementCheckbox("Show Analog Stick Angle Values", CVAR_INPUT_VIEWER("AnalogAngles.Enabled"));
-            UIWidgets::Tooltip("Displays analog stick angle values in the input viewer");
-            if (CVarGetInteger(CVAR_INPUT_VIEWER("AnalogAngles.Enabled"), 0)) {
-                // gInputViewer.AnalogAngles.TextColor
-                if (ImGui::ColorEdit4("Text Color", (float*)&textColor)) {
-                    CVarSetColor(CVAR_INPUT_VIEWER("AnalogAngles.TextColor"), vec2Color(textColor));
-                }
-                // gAnalogAngleScale
-                UIWidgets::EnhancementSliderFloat("Angle Text Scale: %.2f%%", "##AnalogAngleScale",
-                                                  CVAR_INPUT_VIEWER("AnalogAngles.Scale"), 0.1f, 5.0f, "", 1.0f, true, true);
-                // gInputViewer.AnalogAngles.Offset
-                UIWidgets::EnhancementSliderInt("Angle Text Offset: %dpx", "##AnalogAngleOffset",
-                                                CVAR_INPUT_VIEWER("AnalogAngles.Offset"), 0, 400, "", 0, true);
-                UIWidgets::PaddedSeparator(true, true);
-                // gInputViewer.AnalogAngles.Range1.Enabled
-                UIWidgets::EnhancementCheckbox("Highlight ESS Position", CVAR_INPUT_VIEWER("AnalogAngles.Range1.Enabled"));
-                UIWidgets::Tooltip(
-                    "Highlights the angle value text when the analog stick is in ESS position (on flat ground)");
-                if (CVarGetInteger(CVAR_INPUT_VIEWER("AnalogAngles.Range1.Enabled"), 0)) {
-                    // gInputViewer.AnalogAngles.Range1.Color
-                    if (ImGui::ColorEdit4("ESS Color", (float*)&range1Color)) {
-                        CVarSetColor(CVAR_INPUT_VIEWER("AnalogAngles.Range1.Color"), vec2Color(range1Color));
-                    }
-                }
-
-                UIWidgets::PaddedSeparator(true, true);
-                // gInputViewer.AnalogAngles.Range2.Enabled
-                UIWidgets::EnhancementCheckbox("Highlight Walking Speed Angles",
-                                               CVAR_INPUT_VIEWER("AnalogAngles.Range2.Enabled"));
-                UIWidgets::Tooltip("Highlights the angle value text when the analog stick is at an angle that would "
-                                   "produce a walking speed (on flat ground)\n\n"
-                                   "Useful for 1.0 Empty Jumpslash Quick Put Away");
-                if (CVarGetInteger(CVAR_INPUT_VIEWER("AnalogAngles.Range2.Enabled"), 0)) {
-                    // gInputViewer.AnalogAngles.Range2.Color
-                    if (ImGui::ColorEdit4("Walking Speed Color", (float*)&range2Color)) {
-                        CVarSetColor(CVAR_INPUT_VIEWER("AnalogAngles.Range2.Color"), vec2Color(range2Color));
-                    }
+            // gInputViewer.AnalogAngles.Range2.Enabled
+            UIWidgets::EnhancementCheckbox("Highlight Walking Speed Angles",
+                                            CVAR_INPUT_VIEWER("AnalogAngles.Range2.Enabled"));
+            UIWidgets::Tooltip("Highlights the angle value text when the analog stick is at an angle that would "
+                                "produce a walking speed (on flat ground)\n\n"
+                                "Useful for 1.0 Empty Jumpslash Quick Put Away");
+            if (CVarGetInteger(CVAR_INPUT_VIEWER("AnalogAngles.Range2.Enabled"), 0)) {
+                // gInputViewer.AnalogAngles.Range2.Color
+                if (ImGui::ColorEdit4("Walking Speed Color", (float*)&range2Color)) {
+                    CVarSetColor(CVAR_INPUT_VIEWER("AnalogAngles.Range2.Color"), vec2Color(range2Color));
                 }
             }
         }
-
-        ImGui::End();
     }
 }

--- a/soh/soh/Enhancements/controls/InputViewer.cpp
+++ b/soh/soh/Enhancements/controls/InputViewer.cpp
@@ -61,6 +61,15 @@ void InputViewer::RenderButton(std::string btnTexture, std::string btnOutlineTex
     }
 }
 
+void InputViewer::Draw() {
+    if (!IsVisible()) {
+        return;
+    }
+    DrawElement();
+    // Sync up the IsVisible flag if it was changed by ImGui
+    SyncVisibilityConsoleVariable();
+}
+
 void InputViewer::DrawElement() {
     if (CVarGetInteger(CVAR_WINDOW("InputViewer"), 0)) {
         static bool sButtonTexturesLoaded = false;
@@ -73,60 +82,60 @@ void InputViewer::DrawElement() {
             Ship::Context::GetInstance()->GetWindow()->GetGui()->LoadTextureFromRawImage("R-Btn", "textures/buttons/RBtn.png");
             Ship::Context::GetInstance()->GetWindow()->GetGui()->LoadTextureFromRawImage("Z-Btn", "textures/buttons/ZBtn.png");
             Ship::Context::GetInstance()->GetWindow()->GetGui()->LoadTextureFromRawImage("Start-Btn",
-                                                                            "textures/buttons/StartBtn.png");
+                "textures/buttons/StartBtn.png");
             Ship::Context::GetInstance()->GetWindow()->GetGui()->LoadTextureFromRawImage("C-Left", "textures/buttons/CLeft.png");
             Ship::Context::GetInstance()->GetWindow()->GetGui()->LoadTextureFromRawImage("C-Right", "textures/buttons/CRight.png");
             Ship::Context::GetInstance()->GetWindow()->GetGui()->LoadTextureFromRawImage("C-Up", "textures/buttons/CUp.png");
             Ship::Context::GetInstance()->GetWindow()->GetGui()->LoadTextureFromRawImage("C-Down", "textures/buttons/CDown.png");
             Ship::Context::GetInstance()->GetWindow()->GetGui()->LoadTextureFromRawImage("Analog-Stick",
-                                                                            "textures/buttons/AnalogStick.png");
+                "textures/buttons/AnalogStick.png");
             Ship::Context::GetInstance()->GetWindow()->GetGui()->LoadTextureFromRawImage("Dpad-Left",
-                                                                            "textures/buttons/DPadLeft.png");
+                "textures/buttons/DPadLeft.png");
             Ship::Context::GetInstance()->GetWindow()->GetGui()->LoadTextureFromRawImage("Dpad-Right",
-                                                                            "textures/buttons/DPadRight.png");
+                "textures/buttons/DPadRight.png");
             Ship::Context::GetInstance()->GetWindow()->GetGui()->LoadTextureFromRawImage("Dpad-Up", "textures/buttons/DPadUp.png");
             Ship::Context::GetInstance()->GetWindow()->GetGui()->LoadTextureFromRawImage("Dpad-Down",
-                                                                            "textures/buttons/DPadDown.png");
+                "textures/buttons/DPadDown.png");
             Ship::Context::GetInstance()->GetWindow()->GetGui()->LoadTextureFromRawImage("Modifier-1", "textures/buttons/Mod1.png");
             Ship::Context::GetInstance()->GetWindow()->GetGui()->LoadTextureFromRawImage("Modifier-2", "textures/buttons/Mod2.png");
             Ship::Context::GetInstance()->GetWindow()->GetGui()->LoadTextureFromRawImage("Right-Stick",
-                                                                            "textures/buttons/RightStick.png");
+                "textures/buttons/RightStick.png");
             Ship::Context::GetInstance()->GetWindow()->GetGui()->LoadTextureFromRawImage("A-Btn Outline",
-                                                                            "textures/buttons/ABtnOutline.png");
+                "textures/buttons/ABtnOutline.png");
             Ship::Context::GetInstance()->GetWindow()->GetGui()->LoadTextureFromRawImage("B-Btn Outline",
-                                                                            "textures/buttons/BBtnOutline.png");
+                "textures/buttons/BBtnOutline.png");
             Ship::Context::GetInstance()->GetWindow()->GetGui()->LoadTextureFromRawImage("L-Btn Outline",
-                                                                            "textures/buttons/LBtnOutline.png");
+                "textures/buttons/LBtnOutline.png");
             Ship::Context::GetInstance()->GetWindow()->GetGui()->LoadTextureFromRawImage("R-Btn Outline",
-                                                                            "textures/buttons/RBtnOutline.png");
+                "textures/buttons/RBtnOutline.png");
             Ship::Context::GetInstance()->GetWindow()->GetGui()->LoadTextureFromRawImage("Z-Btn Outline",
-                                                                            "textures/buttons/ZBtnOutline.png");
+                "textures/buttons/ZBtnOutline.png");
             Ship::Context::GetInstance()->GetWindow()->GetGui()->LoadTextureFromRawImage("Start-Btn Outline",
-                                                                            "textures/buttons/StartBtnOutline.png");
+                "textures/buttons/StartBtnOutline.png");
             Ship::Context::GetInstance()->GetWindow()->GetGui()->LoadTextureFromRawImage("C-Left Outline",
-                                                                            "textures/buttons/CLeftOutline.png");
+                "textures/buttons/CLeftOutline.png");
             Ship::Context::GetInstance()->GetWindow()->GetGui()->LoadTextureFromRawImage("C-Right Outline",
-                                                                            "textures/buttons/CRightOutline.png");
+                "textures/buttons/CRightOutline.png");
             Ship::Context::GetInstance()->GetWindow()->GetGui()->LoadTextureFromRawImage("C-Up Outline",
-                                                                            "textures/buttons/CUpOutline.png");
+                "textures/buttons/CUpOutline.png");
             Ship::Context::GetInstance()->GetWindow()->GetGui()->LoadTextureFromRawImage("C-Down Outline",
-                                                                            "textures/buttons/CDownOutline.png");
+                "textures/buttons/CDownOutline.png");
             Ship::Context::GetInstance()->GetWindow()->GetGui()->LoadTextureFromRawImage("Analog-Stick Outline",
-                                                                            "textures/buttons/AnalogStickOutline.png");
+                "textures/buttons/AnalogStickOutline.png");
             Ship::Context::GetInstance()->GetWindow()->GetGui()->LoadTextureFromRawImage("Dpad-Left Outline",
-                                                                            "textures/buttons/DPadLeftOutline.png");
+                "textures/buttons/DPadLeftOutline.png");
             Ship::Context::GetInstance()->GetWindow()->GetGui()->LoadTextureFromRawImage("Dpad-Right Outline",
-                                                                            "textures/buttons/DPadRightOutline.png");
+                "textures/buttons/DPadRightOutline.png");
             Ship::Context::GetInstance()->GetWindow()->GetGui()->LoadTextureFromRawImage("Dpad-Up Outline",
-                                                                            "textures/buttons/DPadUpOutline.png");
+                "textures/buttons/DPadUpOutline.png");
             Ship::Context::GetInstance()->GetWindow()->GetGui()->LoadTextureFromRawImage("Dpad-Down Outline",
-                                                                            "textures/buttons/DPadDownOutline.png");
+                "textures/buttons/DPadDownOutline.png");
             Ship::Context::GetInstance()->GetWindow()->GetGui()->LoadTextureFromRawImage("Modifier-1 Outline",
-                                                                            "textures/buttons/Mod1Outline.png");
+                "textures/buttons/Mod1Outline.png");
             Ship::Context::GetInstance()->GetWindow()->GetGui()->LoadTextureFromRawImage("Modifier-2 Outline",
-                                                                            "textures/buttons/Mod2Outline.png");
+                "textures/buttons/Mod2Outline.png");
             Ship::Context::GetInstance()->GetWindow()->GetGui()->LoadTextureFromRawImage("Right-Stick Outline",
-                                                                            "textures/buttons/RightStickOutline.png");
+                "textures/buttons/RightStickOutline.png");
             sButtonTexturesLoaded = true;
         }
 
@@ -147,12 +156,12 @@ void InputViewer::DrawElement() {
 
         ImGui::SetNextWindowSize(
             ImVec2(scaledBGSize.x + 20, scaledBGSize.y +
-                                            (showAnalogAngles ? ImGui::CalcTextSize("X").y : 0) * scale *
-                                                CVarGetFloat(CVAR_INPUT_VIEWER("AnalogAngles.Scale"), 1.0f) +
-                                            20));
+                (showAnalogAngles ? ImGui::CalcTextSize("X").y : 0) * scale *
+                CVarGetFloat(CVAR_INPUT_VIEWER("AnalogAngles.Scale"), 1.0f) +
+                20));
         ImGui::SetNextWindowContentSize(
             ImVec2(scaledBGSize.x, scaledBGSize.y + (showAnalogAngles ? 15 : 0) * scale *
-                                                        CVarGetFloat(CVAR_INPUT_VIEWER("AnalogAngles.Scale"), 1.0f)));
+                CVarGetFloat(CVAR_INPUT_VIEWER("AnalogAngles.Scale"), 1.0f)));
         ImGui::SetNextWindowPos(
             ImVec2(mainPos.x + size.x - scaledBGSize.x - 30, mainPos.y + size.y - scaledBGSize.y - 30),
             ImGuiCond_FirstUseEver);
@@ -163,8 +172,8 @@ void InputViewer::DrawElement() {
         OSContPad* pads = Ship::Context::GetInstance()->GetControlDeck()->GetPads();
 
         ImGuiWindowFlags windowFlags = ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoScrollbar |
-                                       ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoBackground |
-                                       ImGuiWindowFlags_NoFocusOnAppearing;
+            ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoBackground |
+            ImGuiWindowFlags_NoFocusOnAppearing;
 
         if (!CVarGetInteger(CVAR_INPUT_VIEWER("EnableDragging"), 1)) {
             windowFlags |= ImGuiWindowFlags_NoInputs | ImGuiWindowFlags_NoMove;
@@ -187,17 +196,17 @@ void InputViewer::DrawElement() {
                 ImGui::SetNextItemAllowOverlap();
                 ImGui::SetCursorPos(aPos);
                 RenderButton("B-Btn", "B-Btn Outline", pads[0].button & BTN_B, scaledBGSize,
-                             useGlobalOutlineMode
-                                 ? buttonOutlineMode
-                                 : CVarGetInteger(CVAR_INPUT_VIEWER("BBtnOutlineMode"), BUTTON_OUTLINE_NOT_PRESSED));
+                    useGlobalOutlineMode
+                    ? buttonOutlineMode
+                    : CVarGetInteger(CVAR_INPUT_VIEWER("BBtnOutlineMode"), BUTTON_OUTLINE_NOT_PRESSED));
             }
             if (CVarGetInteger(CVAR_INPUT_VIEWER("ABtn"), 1)) {
                 ImGui::SetNextItemAllowOverlap();
                 ImGui::SetCursorPos(aPos);
                 RenderButton("A-Btn", "A-Btn Outline", pads[0].button & BTN_A, scaledBGSize,
-                             useGlobalOutlineMode
-                                 ? buttonOutlineMode
-                                 : CVarGetInteger(CVAR_INPUT_VIEWER("ABtnOutlineMode"), BUTTON_OUTLINE_NOT_PRESSED));
+                    useGlobalOutlineMode
+                    ? buttonOutlineMode
+                    : CVarGetInteger(CVAR_INPUT_VIEWER("ABtnOutlineMode"), BUTTON_OUTLINE_NOT_PRESSED));
             }
 
             // C buttons
@@ -205,33 +214,33 @@ void InputViewer::DrawElement() {
                 ImGui::SetNextItemAllowOverlap();
                 ImGui::SetCursorPos(aPos);
                 RenderButton("C-Up", "C-Up Outline", pads[0].button & BTN_CUP, scaledBGSize,
-                             useGlobalOutlineMode
-                                 ? buttonOutlineMode
-                                 : CVarGetInteger(CVAR_INPUT_VIEWER("CUpOutlineMode"), BUTTON_OUTLINE_NOT_PRESSED));
+                    useGlobalOutlineMode
+                    ? buttonOutlineMode
+                    : CVarGetInteger(CVAR_INPUT_VIEWER("CUpOutlineMode"), BUTTON_OUTLINE_NOT_PRESSED));
             }
             if (CVarGetInteger(CVAR_INPUT_VIEWER("CLeft"), 1)) {
                 ImGui::SetNextItemAllowOverlap();
                 ImGui::SetCursorPos(aPos);
                 RenderButton("C-Left", "C-Left Outline", pads[0].button & BTN_CLEFT, scaledBGSize,
-                             useGlobalOutlineMode
-                                 ? buttonOutlineMode
-                                 : CVarGetInteger(CVAR_INPUT_VIEWER("CLeftOutlineMode"), BUTTON_OUTLINE_NOT_PRESSED));
+                    useGlobalOutlineMode
+                    ? buttonOutlineMode
+                    : CVarGetInteger(CVAR_INPUT_VIEWER("CLeftOutlineMode"), BUTTON_OUTLINE_NOT_PRESSED));
             }
             if (CVarGetInteger(CVAR_INPUT_VIEWER("CRight"), 1)) {
                 ImGui::SetNextItemAllowOverlap();
                 ImGui::SetCursorPos(aPos);
                 RenderButton("C-Right", "C-Right Outline", pads[0].button & BTN_CRIGHT, scaledBGSize,
-                             useGlobalOutlineMode
-                                 ? buttonOutlineMode
-                                 : CVarGetInteger(CVAR_INPUT_VIEWER("CRightOutlineMode"), BUTTON_OUTLINE_NOT_PRESSED));
+                    useGlobalOutlineMode
+                    ? buttonOutlineMode
+                    : CVarGetInteger(CVAR_INPUT_VIEWER("CRightOutlineMode"), BUTTON_OUTLINE_NOT_PRESSED));
             }
             if (CVarGetInteger(CVAR_INPUT_VIEWER("CDown"), 1)) {
                 ImGui::SetNextItemAllowOverlap();
                 ImGui::SetCursorPos(aPos);
                 RenderButton("C-Down", "C-Down Outline", pads[0].button & BTN_CDOWN, scaledBGSize,
-                             useGlobalOutlineMode
-                                 ? buttonOutlineMode
-                                 : CVarGetInteger(CVAR_INPUT_VIEWER("CDownOutlineMode"), BUTTON_OUTLINE_NOT_PRESSED));
+                    useGlobalOutlineMode
+                    ? buttonOutlineMode
+                    : CVarGetInteger(CVAR_INPUT_VIEWER("CDownOutlineMode"), BUTTON_OUTLINE_NOT_PRESSED));
             }
 
             // L/R/Z
@@ -239,25 +248,25 @@ void InputViewer::DrawElement() {
                 ImGui::SetNextItemAllowOverlap();
                 ImGui::SetCursorPos(aPos);
                 RenderButton("L-Btn", "L-Btn Outline", pads[0].button & BTN_L, scaledBGSize,
-                             useGlobalOutlineMode
-                                 ? buttonOutlineMode
-                                 : CVarGetInteger(CVAR_INPUT_VIEWER("LBtnOutlineMode"), BUTTON_OUTLINE_NOT_PRESSED));
+                    useGlobalOutlineMode
+                    ? buttonOutlineMode
+                    : CVarGetInteger(CVAR_INPUT_VIEWER("LBtnOutlineMode"), BUTTON_OUTLINE_NOT_PRESSED));
             }
             if (CVarGetInteger(CVAR_INPUT_VIEWER("RBtn"), 1)) {
                 ImGui::SetNextItemAllowOverlap();
                 ImGui::SetCursorPos(aPos);
                 RenderButton("R-Btn", "R-Btn Outline", pads[0].button & BTN_R, scaledBGSize,
-                             useGlobalOutlineMode
-                                 ? buttonOutlineMode
-                                 : CVarGetInteger(CVAR_INPUT_VIEWER("RBtnOutlineMode"), BUTTON_OUTLINE_NOT_PRESSED));
+                    useGlobalOutlineMode
+                    ? buttonOutlineMode
+                    : CVarGetInteger(CVAR_INPUT_VIEWER("RBtnOutlineMode"), BUTTON_OUTLINE_NOT_PRESSED));
             }
             if (CVarGetInteger(CVAR_INPUT_VIEWER("ZBtn"), 1)) {
                 ImGui::SetNextItemAllowOverlap();
                 ImGui::SetCursorPos(aPos);
                 RenderButton("Z-Btn", "Z-Btn Outline", pads[0].button & BTN_Z, scaledBGSize,
-                             useGlobalOutlineMode
-                                 ? buttonOutlineMode
-                                 : CVarGetInteger(CVAR_INPUT_VIEWER("ZBtnOutlineMode"), BUTTON_OUTLINE_NOT_PRESSED));
+                    useGlobalOutlineMode
+                    ? buttonOutlineMode
+                    : CVarGetInteger(CVAR_INPUT_VIEWER("ZBtnOutlineMode"), BUTTON_OUTLINE_NOT_PRESSED));
             }
 
             // Start
@@ -265,9 +274,9 @@ void InputViewer::DrawElement() {
                 ImGui::SetNextItemAllowOverlap();
                 ImGui::SetCursorPos(aPos);
                 RenderButton("Start-Btn", "Start-Btn Outline", pads[0].button & BTN_START, scaledBGSize,
-                             useGlobalOutlineMode
-                                 ? buttonOutlineMode
-                                 : CVarGetInteger(CVAR_INPUT_VIEWER("StartBtnOutlineMode"), BUTTON_OUTLINE_NOT_PRESSED));
+                    useGlobalOutlineMode
+                    ? buttonOutlineMode
+                    : CVarGetInteger(CVAR_INPUT_VIEWER("StartBtnOutlineMode"), BUTTON_OUTLINE_NOT_PRESSED));
             }
 
             // Dpad
@@ -275,27 +284,27 @@ void InputViewer::DrawElement() {
                 ImGui::SetNextItemAllowOverlap();
                 ImGui::SetCursorPos(aPos);
                 RenderButton("Dpad-Left", "Dpad-Left Outline", pads[0].button & BTN_DLEFT, scaledBGSize,
-                             useGlobalOutlineMode
-                                 ? buttonOutlineMode
-                                 : CVarGetInteger(CVAR_INPUT_VIEWER("DpadOutlineMode"), BUTTON_OUTLINE_NOT_PRESSED));
+                    useGlobalOutlineMode
+                    ? buttonOutlineMode
+                    : CVarGetInteger(CVAR_INPUT_VIEWER("DpadOutlineMode"), BUTTON_OUTLINE_NOT_PRESSED));
                 ImGui::SetNextItemAllowOverlap();
                 ImGui::SetCursorPos(aPos);
                 RenderButton("Dpad-Right", "Dpad-Right Outline", pads[0].button & BTN_DRIGHT, scaledBGSize,
-                             useGlobalOutlineMode
-                                 ? buttonOutlineMode
-                                 : CVarGetInteger(CVAR_INPUT_VIEWER("DpadOutlineMode"), BUTTON_OUTLINE_NOT_PRESSED));
+                    useGlobalOutlineMode
+                    ? buttonOutlineMode
+                    : CVarGetInteger(CVAR_INPUT_VIEWER("DpadOutlineMode"), BUTTON_OUTLINE_NOT_PRESSED));
                 ImGui::SetNextItemAllowOverlap();
                 ImGui::SetCursorPos(aPos);
                 RenderButton("Dpad-Up", "Dpad-Up Outline", pads[0].button & BTN_DUP, scaledBGSize,
-                             useGlobalOutlineMode
-                                 ? buttonOutlineMode
-                                 : CVarGetInteger(CVAR_INPUT_VIEWER("DpadOutlineMode"), BUTTON_OUTLINE_NOT_PRESSED));
+                    useGlobalOutlineMode
+                    ? buttonOutlineMode
+                    : CVarGetInteger(CVAR_INPUT_VIEWER("DpadOutlineMode"), BUTTON_OUTLINE_NOT_PRESSED));
                 ImGui::SetNextItemAllowOverlap();
                 ImGui::SetCursorPos(aPos);
                 RenderButton("Dpad-Down", "Dpad-Down Outline", pads[0].button & BTN_DDOWN, scaledBGSize,
-                             useGlobalOutlineMode
-                                 ? buttonOutlineMode
-                                 : CVarGetInteger(CVAR_INPUT_VIEWER("DpadOutlineMode"), BUTTON_OUTLINE_NOT_PRESSED));
+                    useGlobalOutlineMode
+                    ? buttonOutlineMode
+                    : CVarGetInteger(CVAR_INPUT_VIEWER("DpadOutlineMode"), BUTTON_OUTLINE_NOT_PRESSED));
             }
 
             // Modifier 1
@@ -303,18 +312,18 @@ void InputViewer::DrawElement() {
                 ImGui::SetNextItemAllowOverlap();
                 ImGui::SetCursorPos(aPos);
                 RenderButton("Modifier-1", "Modifier-1 Outline", pads[0].button & BTN_MODIFIER1, scaledBGSize,
-                             useGlobalOutlineMode
-                                 ? buttonOutlineMode
-                                 : CVarGetInteger(CVAR_INPUT_VIEWER("Mod1OutlineMode"), BUTTON_OUTLINE_NOT_PRESSED));
+                    useGlobalOutlineMode
+                    ? buttonOutlineMode
+                    : CVarGetInteger(CVAR_INPUT_VIEWER("Mod1OutlineMode"), BUTTON_OUTLINE_NOT_PRESSED));
             }
             // Modifier 2
             if (CVarGetInteger(CVAR_INPUT_VIEWER("Mod2"), 0)) {
                 ImGui::SetNextItemAllowOverlap();
                 ImGui::SetCursorPos(aPos);
                 RenderButton("Modifier-2", "Modifier-2 Outline", pads[0].button & BTN_MODIFIER2, scaledBGSize,
-                             useGlobalOutlineMode
-                                 ? buttonOutlineMode
-                                 : CVarGetInteger(CVAR_INPUT_VIEWER("Mod2OutlineMode"), BUTTON_OUTLINE_NOT_PRESSED));
+                    useGlobalOutlineMode
+                    ? buttonOutlineMode
+                    : CVarGetInteger(CVAR_INPUT_VIEWER("Mod2OutlineMode"), BUTTON_OUTLINE_NOT_PRESSED));
             }
 
             const bool analogStickIsInDeadzone = !pads[0].stick_x && !pads[0].stick_y;
@@ -339,9 +348,9 @@ void InputViewer::DrawElement() {
                 ImGui::SetNextItemAllowOverlap();
                 ImGui::SetCursorPos(
                     ImVec2(aPos.x + maxStickDistance * ((float)(pads[0].stick_x) / MAX_AXIS_RANGE) * scale,
-                           aPos.y - maxStickDistance * ((float)(pads[0].stick_y) / MAX_AXIS_RANGE) * scale));
+                        aPos.y - maxStickDistance * ((float)(pads[0].stick_y) / MAX_AXIS_RANGE) * scale));
                 ImGui::Image(Ship::Context::GetInstance()->GetWindow()->GetGui()->GetTextureByName("Analog-Stick"),
-                             scaledBGSize, ImVec2(0, 0), ImVec2(1.0f, 1.0f), ImVec4(255, 255, 255, 255));
+                    scaledBGSize, ImVec2(0, 0), ImVec2(1.0f, 1.0f), ImVec4(255, 255, 255, 255));
             }
 
             // Right Stick
@@ -363,15 +372,15 @@ void InputViewer::DrawElement() {
                 ImGui::SetNextItemAllowOverlap();
                 ImGui::SetCursorPos(
                     ImVec2(aPos.x + maxRightStickDistance * ((float)(pads[0].right_stick_x) / MAX_AXIS_RANGE) * scale,
-                           aPos.y - maxRightStickDistance * ((float)(pads[0].right_stick_y) / MAX_AXIS_RANGE) * scale));
+                        aPos.y - maxRightStickDistance * ((float)(pads[0].right_stick_y) / MAX_AXIS_RANGE) * scale));
                 ImGui::Image(Ship::Context::GetInstance()->GetWindow()->GetGui()->GetTextureByName("Right-Stick"),
-                             scaledBGSize, ImVec2(0, 0), ImVec2(1.0f, 1.0f), ImVec4(255, 255, 255, 255));
+                    scaledBGSize, ImVec2(0, 0), ImVec2(1.0f, 1.0f), ImVec4(255, 255, 255, 255));
             }
 
             // Analog stick angle text
             if (showAnalogAngles) {
                 ImGui::SetCursorPos(ImVec2(aPos.x + 10 + CVarGetInteger(CVAR_INPUT_VIEWER("AnalogAngles.Offset"), 0) * scale,
-                                           scaledBGSize.y + aPos.y + 10));
+                    scaledBGSize.y + aPos.y + 10));
                 // Scale font with input viewer scale
                 float oldFontScale = ImGui::GetFont()->Scale;
                 ImGui::GetFont()->Scale *= scale * CVarGetFloat(CVAR_INPUT_VIEWER("AnalogAngles.Scale"), 1.0f);
@@ -393,14 +402,16 @@ void InputViewer::DrawElement() {
                     ImGui::PushStyleColor(
                         ImGuiCol_Text,
                         color2Vec(CVarGetColor(CVAR_INPUT_VIEWER("AnalogAngles.Range1.Color"), vec2Color(range1Color))));
-                } else if (CVarGetInteger(CVAR_INPUT_VIEWER("AnalogAngles.Range2.Enabled"), 0) &&
-                           (rSquared >= (range2Min * range2Min)) && (rSquared < (range2Max * range2Max))) {
+                }
+                else if (CVarGetInteger(CVAR_INPUT_VIEWER("AnalogAngles.Range2.Enabled"), 0) &&
+                    (rSquared >= (range2Min * range2Min)) && (rSquared < (range2Max * range2Max))) {
                     ImGui::PushStyleColor(
                         ImGuiCol_Text,
                         color2Vec(CVarGetColor(CVAR_INPUT_VIEWER("AnalogAngles.Range2.Color"), vec2Color(range2Color))));
-                } else {
+                }
+                else {
                     ImGui::PushStyleColor(ImGuiCol_Text, color2Vec(CVarGetColor(CVAR_INPUT_VIEWER("AnalogAngles.TextColor"),
-                                                                                vec2Color(textColor))));
+                        vec2Color(textColor))));
                 }
 
                 // Render text

--- a/soh/soh/Enhancements/controls/InputViewer.h
+++ b/soh/soh/Enhancements/controls/InputViewer.h
@@ -21,6 +21,7 @@ class InputViewer : public Ship::GuiWindow {
 public:
     using GuiWindow::GuiWindow;
 
+    void Draw() override;
     void InitElement() override {};
     void DrawElement() override;
     void UpdateElement() override {};

--- a/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
+++ b/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
@@ -1687,12 +1687,6 @@ static const char* colorSchemes[2] = {
 };
 
 void CosmeticsEditorWindow::DrawElement() {
-    ImGui::SetNextWindowSize(ImVec2(550, 520), ImGuiCond_FirstUseEver);
-    if (!ImGui::Begin("Cosmetics Editor", &mIsVisible)) {
-        ImGui::End();
-        return;
-    }
-
     ImGui::Text("Color Scheme");
     ImGui::SameLine();
     UIWidgets::EnhancementCombobox(CVAR_COSMETIC("DefaultColorScheme"), colorSchemes, COLORSCHEME_N64);
@@ -1811,7 +1805,6 @@ void CosmeticsEditorWindow::DrawElement() {
         }
         ImGui::EndTabBar();
     }
-    ImGui::End();
 }
 
 void RegisterOnLoadGameHook() {

--- a/soh/soh/Enhancements/debugger/MessageViewer.cpp
+++ b/soh/soh/Enhancements/debugger/MessageViewer.cpp
@@ -20,11 +20,6 @@ void MessageViewer::InitElement() {
 }
 
 void MessageViewer::DrawElement() {
-    ImGui::SetNextWindowSize(ImVec2(520, 600), ImGuiCond_FirstUseEver);
-    if (!ImGui::Begin("Custom Message Debugger", &mIsVisible, ImGuiWindowFlags_NoFocusOnAppearing)) {
-        ImGui::End();
-        return;
-    }
     ImGui::Text("Table ID");
     ImGui::SameLine();
     ImGui::InputText("##TableID", mTableIdBuf, MAX_STRING_SIZE, ImGuiInputTextFlags_CallbackCharFilter, UIWidgets::TextFilters::FilterAlphaNum);
@@ -74,7 +69,6 @@ void MessageViewer::DrawElement() {
     if (ImGui::Button("Display Message##CustomMessage")) {
         mDisplayCustomMessageClicked = true;
     }
-    ImGui::End();
     // ReSharper restore CppDFAUnreachableCode
 }
 

--- a/soh/soh/Enhancements/debugger/actorViewer.cpp
+++ b/soh/soh/Enhancements/debugger/actorViewer.cpp
@@ -925,12 +925,6 @@ void ActorViewer_AddTagForAllActors() {
 }
 
 void ActorViewerWindow::DrawElement() {
-    ImGui::SetNextWindowSize(ImVec2(520, 600), ImGuiCond_FirstUseEver);
-    if (!ImGui::Begin("Actor Viewer", &mIsVisible, ImGuiWindowFlags_NoFocusOnAppearing)) {
-        ImGui::End();
-        return;
-    }
-
     static Actor* display;
     static Actor empty{};
     static Actor* fetch = NULL;
@@ -1235,8 +1229,6 @@ void ActorViewerWindow::DrawElement() {
             actors.clear();
         }
     }
-
-    ImGui::End();
 }
 
 void ActorViewerWindow::InitElement() {

--- a/soh/soh/Enhancements/debugger/colViewer.cpp
+++ b/soh/soh/Enhancements/debugger/colViewer.cpp
@@ -53,11 +53,6 @@ static std::vector<Vtx> sphereVtx;
 
 // Draws the ImGui window for the collision viewer
 void ColViewerWindow::DrawElement() {
-    ImGui::SetNextWindowSize(ImVec2(520, 600), ImGuiCond_FirstUseEver);
-    if (!ImGui::Begin("Collision Viewer", &mIsVisible, ImGuiWindowFlags_NoFocusOnAppearing)) {
-        ImGui::End();
-        return;
-    }
     UIWidgets::EnhancementCheckbox("Enabled", CVAR_DEVELOPER_TOOLS("ColViewer.Enabled"));
 
     UIWidgets::LabeledRightAlignedEnhancementCombobox("Scene", CVAR_DEVELOPER_TOOLS("ColViewer.Scene"), ColRenderSettingNames, COLVIEW_DISABLED);

--- a/soh/soh/Enhancements/debugger/colViewer.cpp
+++ b/soh/soh/Enhancements/debugger/colViewer.cpp
@@ -90,8 +90,6 @@ void ColViewerWindow::DrawElement() {
     } else {
         UIWidgets::InsertHelpHoverText(colorHelpText);
     }
-
-    ImGui::End();
 }
 
 // Calculates the normal for a triangle at the 3 specified points

--- a/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
+++ b/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
@@ -1747,12 +1747,6 @@ void DrawPlayerTab() {
 }
 
 void SaveEditorWindow::DrawElement() {
-    ImGui::SetNextWindowSize(ImVec2(520, 600), ImGuiCond_FirstUseEver);
-    if (!ImGui::Begin("Save Editor", &mIsVisible, ImGuiWindowFlags_NoFocusOnAppearing)) {
-        ImGui::End();
-        return;
-    }
-
     if (ImGui::BeginTabBar("SaveContextTabBar", ImGuiTabBarFlags_NoCloseWithMiddleMouseButton)) {
         if (ImGui::BeginTabItem("Info")) {
             DrawInfoTab();
@@ -1786,8 +1780,6 @@ void SaveEditorWindow::DrawElement() {
 
         ImGui::EndTabBar();
     }
-
-    ImGui::End();
 }
 
 void SaveEditorWindow::InitElement() {

--- a/soh/soh/Enhancements/debugger/dlViewer.cpp
+++ b/soh/soh/Enhancements/debugger/dlViewer.cpp
@@ -90,12 +90,6 @@ void PerformDisplayListSearch() {
 }
 
 void DLViewerWindow::DrawElement() {
-    ImGui::SetNextWindowSize(ImVec2(520, 600), ImGuiCond_FirstUseEver);
-    if (!ImGui::Begin("Display List Viewer", &mIsVisible, ImGuiWindowFlags_NoFocusOnAppearing)) {
-        ImGui::End();
-        return;
-    }
-
     // Debounce the search field as listing otr files is expensive
     if (ImGui::InputText("Search Display Lists", searchString, ARRAY_COUNT(searchString))) {
         doSearch = true;
@@ -328,8 +322,6 @@ void DLViewerWindow::DrawElement() {
         ImGui::End();
         return;
     }
-
-    ImGui::End();
 }
 
 void DLViewerWindow::InitElement() {

--- a/soh/soh/Enhancements/debugger/dlViewer.cpp
+++ b/soh/soh/Enhancements/debugger/dlViewer.cpp
@@ -116,7 +116,6 @@ void DLViewerWindow::DrawElement() {
     }
 
     if (activeDisplayList == "") {
-        ImGui::End();
         return;
     }
 
@@ -125,7 +124,6 @@ void DLViewerWindow::DrawElement() {
 
         if (res->GetInitData()->Type != static_cast<uint32_t>(LUS::ResourceType::DisplayList)) {
             ImGui::Text("Resource type is not a Display List. Please choose another.");
-            ImGui::End();
             return;
         }
 
@@ -319,7 +317,6 @@ void DLViewerWindow::DrawElement() {
         }
     } catch (const std::exception& e) {
         ImGui::Text("Error displaying DL instructions.");
-        ImGui::End();
         return;
     }
 }

--- a/soh/soh/Enhancements/debugger/valueViewer.cpp
+++ b/soh/soh/Enhancements/debugger/valueViewer.cpp
@@ -102,12 +102,6 @@ extern "C" void ValueViewer_Draw(GfxPrint* printer) {
 }
 
 void ValueViewerWindow::DrawElement() {
-    ImGui::SetNextWindowSize(ImVec2(520, 600), ImGuiCond_FirstUseEver);
-    if (!ImGui::Begin("Value Viewer", &mIsVisible, ImGuiWindowFlags_NoFocusOnAppearing)) {
-        ImGui::End();
-        return;
-    }
-
     UIWidgets::PaddedEnhancementCheckbox("Enable Printing", CVAR_DEVELOPER_TOOLS("ValueViewerEnablePrinting"));
 
     ImGui::BeginGroup();
@@ -212,8 +206,6 @@ void ValueViewerWindow::DrawElement() {
         }
         ImGui::EndGroup();
     }
-
-    ImGui::End();
 }
 
 void ValueViewerWindow::InitElement() {

--- a/soh/soh/Enhancements/gameplaystats.cpp
+++ b/soh/soh/Enhancements/gameplaystats.cpp
@@ -619,12 +619,6 @@ void DrawGameplayStatsOptionsTab() {
 }
 
 void GameplayStatsWindow::DrawElement() {
-    ImGui::SetNextWindowSize(ImVec2(480, 550), ImGuiCond_FirstUseEver);
-    if (!ImGui::Begin("Gameplay Stats", &mIsVisible, ImGuiWindowFlags_NoFocusOnAppearing)) {
-        ImGui::End();
-        return;
-    }
-
     DrawGameplayStatsHeader();
 
     if (ImGui::BeginTabBar("Stats", ImGuiTabBarFlags_NoCloseWithMiddleMouseButton)) {
@@ -648,8 +642,6 @@ void GameplayStatsWindow::DrawElement() {
     }
    
     ImGui::Text("Note: Gameplay stats are saved to the current file and will be\nlost if you quit without saving.");
-
-    ImGui::End();
 }
 void InitStats(bool isDebug) {
     gSaveContext.sohStats.heartPieces = isDebug ? 8 : 0;

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -3137,13 +3137,6 @@ void RandomizerSettingsWindow::DrawElement() {
 
     static int maxKeyringCount;
     static bool disableGFKeyring = false;
-
-    ImGui::SetNextWindowSize(ImVec2(920, 600), ImGuiCond_FirstUseEver);
-    if (!ImGui::Begin("Randomizer Editor", &mIsVisible, ImGuiWindowFlags_NoFocusOnAppearing)) {
-        ImGui::End();
-        return;
-    }
-
     bool disableEditingRandoSettings = CVarGetInteger(CVAR_GENERAL("RandoGenerating"), 0) || CVarGetInteger(CVAR_GENERAL("OnFileSelectNameEntry"), 0);
     if (disableEditingRandoSettings) {
         UIWidgets::DisableComponent(ImGui::GetStyle().Alpha * 0.5f);
@@ -5284,7 +5277,6 @@ void RandomizerSettingsWindow::DrawElement() {
     if (disableEditingRandoSettings) {
         UIWidgets::ReEnableComponent("");
     }
-    ImGui::End();
 }
 
 CustomMessage Randomizer::GetWarpSongMessage(u16 textId, bool mysterious) {

--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -877,8 +877,6 @@ void CheckTrackerWindow::Draw() {
 }
 
 void CheckTrackerWindow::DrawElement() {
-    ImGui::SetNextWindowSize(ImVec2(600, 375), ImGuiCond_FirstUseEver);
-
     if (CVarGetInteger(CVAR_TRACKER_CHECK("WindowType"), TRACKER_WINDOW_WINDOW) == TRACKER_WINDOW_FLOATING) {
         if (CVarGetInteger(CVAR_TRACKER_CHECK("ShowOnlyPaused"), 0) && (gPlayState == nullptr || gPlayState->pauseCtx.state == 0)) {
             return;
@@ -896,24 +894,8 @@ void CheckTrackerWindow::DrawElement() {
             }
         }
     }
-    
-    if (CVarGetInteger(CVAR_TRACKER_CHECK("WindowType"), TRACKER_WINDOW_WINDOW) == TRACKER_WINDOW_FLOATING) {
-        if (CVarGetInteger(CVAR_TRACKER_CHECK("ShowOnlyPaused"), 0) && (gPlayState == nullptr || gPlayState->pauseCtx.state == 0)) {
-            return;
-        }
 
-        if (CVarGetInteger(CVAR_TRACKER_CHECK("DisplayType"), TRACKER_DISPLAY_ALWAYS) == TRACKER_DISPLAY_COMBO_BUTTON) {
-            int comboButton1Mask = buttons[CVarGetInteger(CVAR_TRACKER_CHECK("ComboButton1"), TRACKER_COMBO_BUTTON_L)];
-            int comboButton2Mask = buttons[CVarGetInteger(CVAR_TRACKER_CHECK("ComboButton2"), TRACKER_COMBO_BUTTON_R)];
-            OSContPad* trackerButtonsPressed = Ship::Context::GetInstance()->GetControlDeck()->GetPads();
-            bool comboButtonsHeld = trackerButtonsPressed != nullptr &&
-                trackerButtonsPressed[0].button & comboButton1Mask &&
-                trackerButtonsPressed[0].button & comboButton2Mask;
-            if (!comboButtonsHeld) {
-                return;
-            }
-        }
-    }
+    ImGui::SetNextWindowSize(ImVec2(400, 540), ImGuiCond_FirstUseEver);
 
     BeginFloatWindows("Check Tracker", mIsVisible, ImGuiWindowFlags_NoScrollbar);
 

--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -867,12 +867,11 @@ void UpdateCheck(uint32_t check, RandomizerCheckTrackerData data) {
     UpdateOrdering(area);
 }
 
-void CheckTrackerWindow::DrawElement() {
-    ImGui::SetNextWindowSize(ImVec2(400, 540), ImGuiCond_FirstUseEver);
-
+void CheckTrackerWindow::UpdateElement() {
+    bool visible = IsVisible();
     if (CVarGetInteger(CVAR_TRACKER_CHECK("WindowType"), TRACKER_WINDOW_WINDOW) == TRACKER_WINDOW_FLOATING) {
         if (CVarGetInteger(CVAR_TRACKER_CHECK("ShowOnlyPaused"), 0) && (gPlayState == nullptr || gPlayState->pauseCtx.state == 0)) {
-            return;
+            visible = false;
         }
 
         if (CVarGetInteger(CVAR_TRACKER_CHECK("DisplayType"), TRACKER_DISPLAY_ALWAYS) == TRACKER_DISPLAY_COMBO_BUTTON) {
@@ -880,14 +879,19 @@ void CheckTrackerWindow::DrawElement() {
             int comboButton2Mask = buttons[CVarGetInteger(CVAR_TRACKER_CHECK("ComboButton2"), TRACKER_COMBO_BUTTON_R)];
             OSContPad* trackerButtonsPressed = Ship::Context::GetInstance()->GetControlDeck()->GetPads();
             bool comboButtonsHeld = trackerButtonsPressed != nullptr &&
-                                    trackerButtonsPressed[0].button & comboButton1Mask &&
-                                    trackerButtonsPressed[0].button & comboButton2Mask;
+                trackerButtonsPressed[0].button & comboButton1Mask &&
+                trackerButtonsPressed[0].button & comboButton2Mask;
             if (!comboButtonsHeld) {
-                return;
+                visible = false;
             }
         }
     }
+    if (visible != IsVisible()) {
+        SetVisiblity(visible);
+    }
+}
 
+void CheckTrackerWindow::DrawElement() {
     BeginFloatWindows("Check Tracker", mIsVisible, ImGuiWindowFlags_NoScrollbar);
 
     if (!GameInteractor::IsSaveLoaded() || !initialized) {
@@ -1064,7 +1068,7 @@ void CheckTrackerWindow::DrawElement() {
 
     ImGui::EndTable(); //Checks Lead-out
     ImGui::EndTable(); //Quick Options Lead-out
-    EndFloatWindows();
+    //EndFloatWindows();
     if (doingCollapseOrExpand) {
         optCollapseAll = false;
         optExpandAll = false;
@@ -1602,13 +1606,6 @@ static const char* displayType[] = { "Always", "Combo Button Hold" };
 static const char* buttonStrings[] = { "A Button", "B Button", "C-Up",  "C-Down", "C-Left", "C-Right", "L Button",
                                        "Z Button", "R Button", "Start", "D-Up",   "D-Down", "D-Left",  "D-Right" };
 void CheckTrackerSettingsWindow::DrawElement() {
-    ImGui::SetNextWindowSize(ImVec2(600, 375), ImGuiCond_FirstUseEver);
-
-    if (!ImGui::Begin("Check Tracker Settings", &mIsVisible, ImGuiWindowFlags_NoFocusOnAppearing)) {
-        ImGui::End();
-        return;
-    }
-
     ImGui::PushStyleVar(ImGuiStyleVar_CellPadding, { 8.0f, 8.0f });
     ImGui::BeginTable("CheckTrackerSettingsTable", 2, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV);
     ImGui::TableSetupColumn("General settings", ImGuiTableColumnFlags_WidthStretch, 200.0f);
@@ -1668,7 +1665,6 @@ void CheckTrackerSettingsWindow::DrawElement() {
 
     ImGui::PopStyleVar(1);
     ImGui::EndTable();
-    ImGui::End();
 }
 
 void CheckTrackerWindow::InitElement() {

--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.h
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.h
@@ -21,12 +21,13 @@ class CheckTrackerSettingsWindow : public Ship::GuiWindow {
 class CheckTrackerWindow : public Ship::GuiWindow {
   public:
     using GuiWindow::GuiWindow;
+    void Draw() override;
     ~CheckTrackerWindow() {};
 
   protected:
     void InitElement() override;
     void DrawElement() override;
-    void UpdateElement() override;
+    void UpdateElement() override {};
 };
 
 //Converts an index into a Little Endian bitmask, as follows:

--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.h
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.h
@@ -26,7 +26,7 @@ class CheckTrackerWindow : public Ship::GuiWindow {
   protected:
     void InitElement() override;
     void DrawElement() override;
-    void UpdateElement() override {};
+    void UpdateElement() override;
 };
 
 //Converts an index into a Little Endian bitmask, as follows:

--- a/soh/soh/Enhancements/randomizer/randomizer_entrance_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_entrance_tracker.cpp
@@ -637,13 +637,6 @@ void InitEntranceTrackingData() {
 }
 
 void EntranceTrackerWindow::DrawElement() {
-    ImGui::SetNextWindowSize(ImVec2(600, 375), ImGuiCond_FirstUseEver);
-
-    if (!ImGui::Begin("Entrance Tracker", &mIsVisible, ImGuiWindowFlags_NoFocusOnAppearing)) {
-        ImGui::End();
-        return;
-    }
-
     // Begin tracker settings
     ImGui::SetNextItemOpen(false, ImGuiCond_Once);
     if (ImGui::TreeNode("Tracker Settings")) {
@@ -929,8 +922,6 @@ void EntranceTrackerWindow::DrawElement() {
         }
     }
     ImGui::EndChild();
-
-    ImGui::End();
 }
 
 void EntranceTrackerWindow::InitElement() {

--- a/soh/soh/Enhancements/randomizer/randomizer_entrance_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_entrance_tracker.cpp
@@ -636,8 +636,24 @@ void InitEntranceTrackingData() {
     SortEntranceListByType(destListSortedByType, 1);
 }
 
+void EntranceTrackerWindow::Draw() {
+    if (!IsVisible()) {
+        return;
+    }
+    DrawElement();
+    // Sync up the IsVisible flag if it was changed by ImGui
+    SyncVisibilityConsoleVariable();
+}
+
 void EntranceTrackerWindow::DrawElement() {
     // Begin tracker settings
+    ImGui::SetNextWindowSize(ImVec2(600, 375), ImGuiCond_FirstUseEver);
+
+    if (!ImGui::Begin("Entrance Tracker", &mIsVisible, ImGuiWindowFlags_NoFocusOnAppearing)) {
+        ImGui::End();
+        return;
+    }
+
     ImGui::SetNextItemOpen(false, ImGuiCond_Once);
     if (ImGui::TreeNode("Tracker Settings")) {
         // Reduce indentation from the tree node for the table
@@ -922,6 +938,8 @@ void EntranceTrackerWindow::DrawElement() {
         }
     }
     ImGui::EndChild();
+
+    ImGui::End();
 }
 
 void EntranceTrackerWindow::InitElement() {

--- a/soh/soh/Enhancements/randomizer/randomizer_entrance_tracker.h
+++ b/soh/soh/Enhancements/randomizer/randomizer_entrance_tracker.h
@@ -89,6 +89,7 @@ class EntranceTrackerWindow : public Ship::GuiWindow {
   public:
     using GuiWindow::GuiWindow;
 
+    void Draw() override;
     void InitElement() override;
     void DrawElement() override;
     void UpdateElement() override {};

--- a/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
@@ -1122,13 +1122,6 @@ static const char* displayTypes[3] = { "Hidden", "Main Window", "Separate" };
 static const char* extendedDisplayTypes[4] = { "Hidden", "Main Window", "Misc Window", "Separate" };
 
 void ItemTrackerSettingsWindow::DrawElement() {
-    ImGui::SetNextWindowSize(ImVec2(733, 472), ImGuiCond_FirstUseEver);
-
-    if (!ImGui::Begin("Item Tracker Settings", &mIsVisible, ImGuiWindowFlags_NoFocusOnAppearing)) {
-        ImGui::End();
-        return;
-    }
-
     ImGui::PushStyleVar(ImGuiStyleVar_CellPadding, { 8.0f, 8.0f });
     ImGui::BeginTable("itemTrackerSettingsTable", 2, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV);
     ImGui::TableSetupColumn("General settings", ImGuiTableColumnFlags_WidthStretch, 200.0f);
@@ -1255,8 +1248,6 @@ void ItemTrackerSettingsWindow::DrawElement() {
 
     ImGui::PopStyleVar(1);
     ImGui::EndTable();
-
-    ImGui::End();
 }
 
 void ItemTrackerWindow::InitElement() {

--- a/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
@@ -1006,6 +1006,15 @@ void ItemTrackerLoadFile() {
     }
 }
 
+void ItemTrackerWindow::Draw() {
+    if (!IsVisible()) {
+        return;
+    }
+    DrawElement();
+    // Sync up the IsVisible flag if it was changed by ImGui
+    SyncVisibilityConsoleVariable();
+}
+
 void ItemTrackerWindow::DrawElement() {
     UpdateVectors();
 

--- a/soh/soh/Enhancements/randomizer/randomizer_item_tracker.h
+++ b/soh/soh/Enhancements/randomizer/randomizer_item_tracker.h
@@ -42,6 +42,7 @@ class ItemTrackerSettingsWindow : public Ship::GuiWindow {
 class ItemTrackerWindow : public Ship::GuiWindow {
   public:
     using GuiWindow::GuiWindow;
+    void Draw() override;
 
 protected:
     void InitElement() override;

--- a/soh/soh/Enhancements/resolution-editor/ResolutionEditor.cpp
+++ b/soh/soh/Enhancements/resolution-editor/ResolutionEditor.cpp
@@ -59,424 +59,420 @@ void AdvancedResolutionSettingsWindow::InitElement() {
 }
 
 void AdvancedResolutionSettingsWindow::DrawElement() {
-    ImGui::SetNextWindowSize(ImVec2(497, 599), ImGuiCond_FirstUseEver);
-    if (ImGui::Begin("Advanced Resolution Settings", &mIsVisible)) {
-        // Initialise update flags.
-        bool update[3];
-        for (uint8_t i = 0; i < sizeof(update); i++)
-            update[i] = false;
+    // Initialise update flags.
+    bool update[3];
+    for (uint8_t i = 0; i < sizeof(update); i++)
+        update[i] = false;
 
-        // Initialise integer scale bounds.
-        short max_integerScaleFactor = default_maxIntegerScaleFactor; // default value, which may or may not get
-                                                                      // overridden depending on viewport res
+    // Initialise integer scale bounds.
+    short max_integerScaleFactor = default_maxIntegerScaleFactor; // default value, which may or may not get
+                                                                    // overridden depending on viewport res
 
-        short integerScale_maximumBounds = 1; // can change when window is resized
-        // This is mostly just for UX purposes, as Fit Automatically logic is part of LUS.
-        if (((float)gfx_current_game_window_viewport.width / gfx_current_game_window_viewport.height) >
-            ((float)gfx_current_dimensions.width / gfx_current_dimensions.height)) {
-            // Scale to window height
-            integerScale_maximumBounds = gfx_current_game_window_viewport.height / gfx_current_dimensions.height;
-        } else {
-            // Scale to window width
-            integerScale_maximumBounds = gfx_current_game_window_viewport.width / gfx_current_dimensions.width;
-        }
-        // Lower-clamping maximum bounds value to 1 is no-longer necessary as that's accounted for in LUS.
-        // Letting it go below 1 in this Editor will even allow for checking if screen bounds are being exceeded.
-        if (default_maxIntegerScaleFactor < integerScale_maximumBounds) {
-            max_integerScaleFactor =
-                integerScale_maximumBounds + CVarGetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".IntegerScale.ExceedBoundsBy", 0);
-        }
+    short integerScale_maximumBounds = 1; // can change when window is resized
+    // This is mostly just for UX purposes, as Fit Automatically logic is part of LUS.
+    if (((float)gfx_current_game_window_viewport.width / gfx_current_game_window_viewport.height) >
+        ((float)gfx_current_dimensions.width / gfx_current_dimensions.height)) {
+        // Scale to window height
+        integerScale_maximumBounds = gfx_current_game_window_viewport.height / gfx_current_dimensions.height;
+    } else {
+        // Scale to window width
+        integerScale_maximumBounds = gfx_current_game_window_viewport.width / gfx_current_dimensions.width;
+    }
+    // Lower-clamping maximum bounds value to 1 is no-longer necessary as that's accounted for in LUS.
+    // Letting it go below 1 in this Editor will even allow for checking if screen bounds are being exceeded.
+    if (default_maxIntegerScaleFactor < integerScale_maximumBounds) {
+        max_integerScaleFactor =
+            integerScale_maximumBounds + CVarGetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".IntegerScale.ExceedBoundsBy", 0);
+    }
 
-        // Combo List defaults
-        static int item_aspectRatio = CVarGetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".UIComboItem.AspectRatio", 3);
-        static int item_pixelCount = CVarGetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".UIComboItem.PixelCount", default_pixelCount);
-        // Stored Values for non-UIWidgets elements
-        static float aspectRatioX =
-            CVarGetFloat(CVAR_PREFIX_ADVANCED_RESOLUTION ".AspectRatioX", aspectRatioPresetsX[item_aspectRatio]);
-        static float aspectRatioY =
-            CVarGetFloat(CVAR_PREFIX_ADVANCED_RESOLUTION ".AspectRatioY", aspectRatioPresetsY[item_aspectRatio]);
-        static int verticalPixelCount =
-            CVarGetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".VerticalPixelCount", pixelCountPresets[item_pixelCount]);
-        // Additional settings
-        static bool showHorizontalResField = false;
-        static int horizontalPixelCount = (verticalPixelCount / aspectRatioY) * aspectRatioX;
-        // Disabling flags
-        const bool disabled_everything = !CVarGetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".Enabled", 0);
-        const bool disabled_pixelCount = !CVarGetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".VerticalResolutionToggle", 0);
+    // Combo List defaults
+    static int item_aspectRatio = CVarGetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".UIComboItem.AspectRatio", 3);
+    static int item_pixelCount = CVarGetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".UIComboItem.PixelCount", default_pixelCount);
+    // Stored Values for non-UIWidgets elements
+    static float aspectRatioX =
+        CVarGetFloat(CVAR_PREFIX_ADVANCED_RESOLUTION ".AspectRatioX", aspectRatioPresetsX[item_aspectRatio]);
+    static float aspectRatioY =
+        CVarGetFloat(CVAR_PREFIX_ADVANCED_RESOLUTION ".AspectRatioY", aspectRatioPresetsY[item_aspectRatio]);
+    static int verticalPixelCount =
+        CVarGetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".VerticalPixelCount", pixelCountPresets[item_pixelCount]);
+    // Additional settings
+    static bool showHorizontalResField = false;
+    static int horizontalPixelCount = (verticalPixelCount / aspectRatioY) * aspectRatioX;
+    // Disabling flags
+    const bool disabled_everything = !CVarGetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".Enabled", 0);
+    const bool disabled_pixelCount = !CVarGetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".VerticalResolutionToggle", 0);
 
 #ifdef __APPLE__
-        // Display HiDPI warning. (Remove this once we can definitively say it's fixed.)
-        ImGui::TextColored(messageColor[MESSAGE_INFO],
-                           ICON_FA_INFO_CIRCLE " These settings may behave incorrectly on Retina displays.");
-        UIWidgets::PaddedSeparator(true, true, 3.0f, 3.0f);
+    // Display HiDPI warning. (Remove this once we can definitively say it's fixed.)
+    ImGui::TextColored(messageColor[MESSAGE_INFO],
+                        ICON_FA_INFO_CIRCLE " These settings may behave incorrectly on Retina displays.");
+    UIWidgets::PaddedSeparator(true, true, 3.0f, 3.0f);
 #endif
 
-        if (ImGui::CollapsingHeader("Original Settings", ImGuiTreeNodeFlags_DefaultOpen)) {
-            // The original resolution slider (for convenience)
-            const bool disabled_resolutionSlider = (CVarGetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".VerticalResolutionToggle", 0) &&
-                                                    CVarGetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".Enabled", 0)) ||
-                                                   CVarGetInteger(CVAR_LOW_RES_MODE, 0);
-            if (UIWidgets::EnhancementSliderFloat("Internal Resolution: %.1f%%", "##IMul", CVAR_INTERNAL_RESOLUTION, 0.5f,
-                                                  2.0f, "", 1.0f, true, true, disabled_resolutionSlider)) {
-                Ship::Context::GetInstance()->GetWindow()->SetResolutionMultiplier(
-                    CVarGetFloat(CVAR_INTERNAL_RESOLUTION, 1));
-            }
-            UIWidgets::Tooltip("Multiplies your output resolution by the value entered.");
+    if (ImGui::CollapsingHeader("Original Settings", ImGuiTreeNodeFlags_DefaultOpen)) {
+        // The original resolution slider (for convenience)
+        const bool disabled_resolutionSlider = (CVarGetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".VerticalResolutionToggle", 0) &&
+                                                CVarGetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".Enabled", 0)) ||
+                                                CVarGetInteger(CVAR_LOW_RES_MODE, 0);
+        if (UIWidgets::EnhancementSliderFloat("Internal Resolution: %.1f%%", "##IMul", CVAR_INTERNAL_RESOLUTION, 0.5f,
+                                                2.0f, "", 1.0f, true, true, disabled_resolutionSlider)) {
+            Ship::Context::GetInstance()->GetWindow()->SetResolutionMultiplier(
+                CVarGetFloat(CVAR_INTERNAL_RESOLUTION, 1));
+        }
+        UIWidgets::Tooltip("Multiplies your output resolution by the value entered.");
 
-            // The original MSAA slider (also for convenience)
+        // The original MSAA slider (also for convenience)
 #ifndef __WIIU__
-            if (UIWidgets::PaddedEnhancementSliderInt("MSAA: %d", "##IMSAA", CVAR_MSAA_VALUE, 1, 8, "", 1, true, true,
-                                                      false)) {
-                Ship::Context::GetInstance()->GetWindow()->SetMsaaLevel(CVarGetInteger(CVAR_MSAA_VALUE, 1));
-            };
-            UIWidgets::Tooltip(
-                "Activates multi-sample anti-aliasing when above 1x, up to 8x for 8 samples for every pixel.\n\n"
-                " " ICON_FA_INFO_CIRCLE
-                " (Higher MSAA with low resolution can approximate an authentic \"real N64\" look!)");
+        if (UIWidgets::PaddedEnhancementSliderInt("MSAA: %d", "##IMSAA", CVAR_MSAA_VALUE, 1, 8, "", 1, true, true,
+                                                    false)) {
+            Ship::Context::GetInstance()->GetWindow()->SetMsaaLevel(CVarGetInteger(CVAR_MSAA_VALUE, 1));
+        };
+        UIWidgets::Tooltip(
+            "Activates multi-sample anti-aliasing when above 1x, up to 8x for 8 samples for every pixel.\n\n"
+            " " ICON_FA_INFO_CIRCLE
+            " (Higher MSAA with low resolution can approximate an authentic \"real N64\" look!)");
 #endif
 
-            // N64 Mode toggle (again for convenience)
-            // UIWidgets::PaddedEnhancementCheckbox("(Enhancements>Graphics) N64 Mode", CVAR_LOW_RES_MODE, false, false, false, "", UIWidgets::CheckboxGraphics::Cross, false);
-        }
+        // N64 Mode toggle (again for convenience)
+        // UIWidgets::PaddedEnhancementCheckbox("(Enhancements>Graphics) N64 Mode", CVAR_LOW_RES_MODE, false, false, false, "", UIWidgets::CheckboxGraphics::Cross, false);
+    }
 
-        UIWidgets::PaddedSeparator(true, true, 3.0f, 3.0f);
-        // Activator
-        UIWidgets::PaddedEnhancementCheckbox("Enable advanced settings.", CVAR_PREFIX_ADVANCED_RESOLUTION ".Enabled", false, false,
-                                             false, "", UIWidgets::CheckboxGraphics::Cross, false);
-        // Error/Warning display
-        if (!CVarGetInteger(CVAR_LOW_RES_MODE, 0)) {
-            if (IsDroppingFrames()) { // Significant frame drop warning
-                ImGui::TextColored(messageColor[MESSAGE_WARNING],
-                                   ICON_FA_EXCLAMATION_TRIANGLE " Significant frame rate (FPS) drops may be occuring.");
-                UIWidgets::Spacer(2);
-            } else { // No warnings
-                UIWidgets::Spacer(enhancementSpacerHeight);
-            }
-        } else { // N64 Mode warning
-            ImGui::TextColored(messageColor[MESSAGE_QUESTION],
-                               ICON_FA_QUESTION_CIRCLE " \"N64 Mode\" is overriding these settings.");
-            ImGui::SameLine();
-            if (ImGui::Button("Click to disable")) {
-                CVarSetInteger(CVAR_LOW_RES_MODE, 0);
-                CVarSave();
-            }
+    UIWidgets::PaddedSeparator(true, true, 3.0f, 3.0f);
+    // Activator
+    UIWidgets::PaddedEnhancementCheckbox("Enable advanced settings.", CVAR_PREFIX_ADVANCED_RESOLUTION ".Enabled", false, false,
+                                            false, "", UIWidgets::CheckboxGraphics::Cross, false);
+    // Error/Warning display
+    if (!CVarGetInteger(CVAR_LOW_RES_MODE, 0)) {
+        if (IsDroppingFrames()) { // Significant frame drop warning
+            ImGui::TextColored(messageColor[MESSAGE_WARNING],
+                                ICON_FA_EXCLAMATION_TRIANGLE " Significant frame rate (FPS) drops may be occuring.");
+            UIWidgets::Spacer(2);
+        } else { // No warnings
+            UIWidgets::Spacer(enhancementSpacerHeight);
         }
-        // Resolution visualiser
-        ImGui::Text("Viewport dimensions: %d x %d", gfx_current_game_window_viewport.width,
-                    gfx_current_game_window_viewport.height);
-        ImGui::Text("Internal resolution: %d x %d", gfx_current_dimensions.width, gfx_current_dimensions.height);
-
-        UIWidgets::PaddedSeparator(true, true, 3.0f, 3.0f);
-        if (disabled_everything) { // Hide aspect ratio controls.
-            UIWidgets::DisableComponent(ImGui::GetStyle().Alpha * 0.5f);
-        }
-
-        // Aspect Ratio
-        ImGui::Text("Force aspect ratio:");
+    } else { // N64 Mode warning
+        ImGui::TextColored(messageColor[MESSAGE_QUESTION],
+                            ICON_FA_QUESTION_CIRCLE " \"N64 Mode\" is overriding these settings.");
         ImGui::SameLine();
-        ImGui::TextColored(messageColor[MESSAGE_GRAY_75], "(Select \"Off\" to disable.)");
-        // Presets
-        if (ImGui::Combo(" ", &item_aspectRatio, aspectRatioPresetLabels,
-                         IM_ARRAYSIZE(aspectRatioPresetLabels)) &&
-            item_aspectRatio != default_aspectRatio) { // don't change anything if "Custom" is selected.
-            aspectRatioX = aspectRatioPresetsX[item_aspectRatio];
-            aspectRatioY = aspectRatioPresetsY[item_aspectRatio];
-
-            if (showHorizontalResField) {
-                horizontalPixelCount = (verticalPixelCount / aspectRatioY) * aspectRatioX;
-            }
-
-            CVarSetFloat(CVAR_PREFIX_ADVANCED_RESOLUTION ".AspectRatioX", aspectRatioX);
-            CVarSetFloat(CVAR_PREFIX_ADVANCED_RESOLUTION ".AspectRatioY", aspectRatioY);
-            CVarSetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".UIComboItem.AspectRatio", item_aspectRatio);
+        if (ImGui::Button("Click to disable")) {
+            CVarSetInteger(CVAR_LOW_RES_MODE, 0);
             CVarSave();
         }
-        // Hide aspect ratio input fields if using one of the presets.
-        if (item_aspectRatio == default_aspectRatio && !showHorizontalResField) {
-            // Declare input interaction bools outside of IF statement to prevent Y field from disappearing.
-            const bool input_X = ImGui::InputFloat("X", &aspectRatioX, 0.1f, 1.0f, "%.3f");
-            const bool input_Y = ImGui::InputFloat("Y", &aspectRatioY, 0.1f, 1.0f, "%.3f");
-            if (input_X || input_Y) {
-                item_aspectRatio = default_aspectRatio;
-                update[UPDATE_aspectRatioX] = true;
-                update[UPDATE_aspectRatioY] = true;
-            }
-        } else if (showHorizontalResField) { // Show calculated aspect ratio
-            if (item_aspectRatio) {
-                UIWidgets::Spacer(2);
-                const float resolvedAspectRatio = (float)gfx_current_dimensions.width / gfx_current_dimensions.height;
-                ImGui::Text("Aspect ratio: %.2f:1", resolvedAspectRatio);
-            } else {
-                UIWidgets::Spacer(enhancementSpacerHeight);
-            }
-        }
+    }
+    // Resolution visualiser
+    ImGui::Text("Viewport dimensions: %d x %d", gfx_current_game_window_viewport.width,
+                gfx_current_game_window_viewport.height);
+    ImGui::Text("Internal resolution: %d x %d", gfx_current_dimensions.width, gfx_current_dimensions.height);
 
-        if (disabled_everything) { // Hide aspect ratio controls.
-            UIWidgets::ReEnableComponent("disabledTooltipText");
-        }
-        UIWidgets::Spacer(0);
+    UIWidgets::PaddedSeparator(true, true, 3.0f, 3.0f);
+    if (disabled_everything) { // Hide aspect ratio controls.
+        UIWidgets::DisableComponent(ImGui::GetStyle().Alpha * 0.5f);
+    }
 
-        // Vertical Resolution
-        UIWidgets::PaddedEnhancementCheckbox("Set fixed vertical resolution (disables Resolution slider)",
-                                             CVAR_PREFIX_ADVANCED_RESOLUTION ".VerticalResolutionToggle", true, false,
-                                             disabled_everything, "", UIWidgets::CheckboxGraphics::Cross, false);
-        UIWidgets::Tooltip(
-            "Override the resolution scale slider and use the settings below, irrespective of window size.");
-        if (disabled_pixelCount || disabled_everything) { // Hide pixel count controls.
-            UIWidgets::DisableComponent(ImGui::GetStyle().Alpha * 0.5f);
-        }
-        if (ImGui::Combo("Pixel Count Presets", &item_pixelCount, pixelCountPresetLabels,
-                         IM_ARRAYSIZE(pixelCountPresetLabels)) &&
-            item_pixelCount != default_pixelCount) { // don't change anything if "Custom" is selected.
-            verticalPixelCount = pixelCountPresets[item_pixelCount];
+    // Aspect Ratio
+    ImGui::Text("Force aspect ratio:");
+    ImGui::SameLine();
+    ImGui::TextColored(messageColor[MESSAGE_GRAY_75], "(Select \"Off\" to disable.)");
+    // Presets
+    if (ImGui::Combo(" ", &item_aspectRatio, aspectRatioPresetLabels,
+                        IM_ARRAYSIZE(aspectRatioPresetLabels)) &&
+        item_aspectRatio != default_aspectRatio) { // don't change anything if "Custom" is selected.
+        aspectRatioX = aspectRatioPresetsX[item_aspectRatio];
+        aspectRatioY = aspectRatioPresetsY[item_aspectRatio];
 
-            if (showHorizontalResField) {
-                horizontalPixelCount = (verticalPixelCount / aspectRatioY) * aspectRatioX;
-            }
-
-            CVarSetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".VerticalPixelCount", verticalPixelCount);
-            CVarSetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".UIComboItem.PixelCount", item_pixelCount);
-            CVarSave();
-        }
-        // Horizontal Resolution, if visibility is enabled for it.
         if (showHorizontalResField) {
-            // Only show the field if Aspect Ratio is being enforced.
-            if ((aspectRatioX > 0.0f) && (aspectRatioY > 0.0f)) {
-                // So basically we're "faking" this one by setting aspectRatioX instead.
-                if (ImGui::InputInt("Horiz. Pixel Count", &horizontalPixelCount, 8, 320)) {
-                    item_aspectRatio = default_aspectRatio;
-                    if (horizontalPixelCount < SCREEN_WIDTH) {
-                        horizontalPixelCount = SCREEN_WIDTH;
-                    }
-                    aspectRatioX = horizontalPixelCount;
-                    aspectRatioY = verticalPixelCount;
-                    update[UPDATE_aspectRatioX] = true;
-                    update[UPDATE_aspectRatioY] = true;
-                }
-            } else { // Display a notice instead.
-                ImGui::TextColored(messageColor[MESSAGE_QUESTION],
-                                   ICON_FA_QUESTION_CIRCLE " \"Force aspect ratio\" required.");
-                // ImGui::Text(" ");
-                ImGui::SameLine();
-                if (ImGui::Button("Click to resolve")) {
-                    item_aspectRatio = default_aspectRatio; // Set it to Custom
-                    aspectRatioX = aspectRatioPresetsX[2];  // but use the 4:3 defaults
-                    aspectRatioY = aspectRatioPresetsY[2];
-                    update[UPDATE_aspectRatioX] = true;
-                    update[UPDATE_aspectRatioY] = true;
-                    horizontalPixelCount = (verticalPixelCount / aspectRatioY) * aspectRatioX;
-                }
-            }
+            horizontalPixelCount = (verticalPixelCount / aspectRatioY) * aspectRatioX;
         }
-        // Vertical Resolution part 2
-        if (ImGui::InputInt("Vertical Pixel Count", &verticalPixelCount, 8, 240)) {
-            item_pixelCount = default_pixelCount;
-            update[UPDATE_verticalPixelCount] = true;
 
-            // Account for the natural instinct to enter horizontal first.
-            // Ignore vertical resolutions that are below the lower clamp constant.
-            if (showHorizontalResField && !(verticalPixelCount < minVerticalPixelCount)) {
+        CVarSetFloat(CVAR_PREFIX_ADVANCED_RESOLUTION ".AspectRatioX", aspectRatioX);
+        CVarSetFloat(CVAR_PREFIX_ADVANCED_RESOLUTION ".AspectRatioY", aspectRatioY);
+        CVarSetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".UIComboItem.AspectRatio", item_aspectRatio);
+        CVarSave();
+    }
+    // Hide aspect ratio input fields if using one of the presets.
+    if (item_aspectRatio == default_aspectRatio && !showHorizontalResField) {
+        // Declare input interaction bools outside of IF statement to prevent Y field from disappearing.
+        const bool input_X = ImGui::InputFloat("X", &aspectRatioX, 0.1f, 1.0f, "%.3f");
+        const bool input_Y = ImGui::InputFloat("Y", &aspectRatioY, 0.1f, 1.0f, "%.3f");
+        if (input_X || input_Y) {
+            item_aspectRatio = default_aspectRatio;
+            update[UPDATE_aspectRatioX] = true;
+            update[UPDATE_aspectRatioY] = true;
+        }
+    } else if (showHorizontalResField) { // Show calculated aspect ratio
+        if (item_aspectRatio) {
+            UIWidgets::Spacer(2);
+            const float resolvedAspectRatio = (float)gfx_current_dimensions.width / gfx_current_dimensions.height;
+            ImGui::Text("Aspect ratio: %.2f:1", resolvedAspectRatio);
+        } else {
+            UIWidgets::Spacer(enhancementSpacerHeight);
+        }
+    }
+
+    if (disabled_everything) { // Hide aspect ratio controls.
+        UIWidgets::ReEnableComponent("disabledTooltipText");
+    }
+    UIWidgets::Spacer(0);
+
+    // Vertical Resolution
+    UIWidgets::PaddedEnhancementCheckbox("Set fixed vertical resolution (disables Resolution slider)",
+                                            CVAR_PREFIX_ADVANCED_RESOLUTION ".VerticalResolutionToggle", true, false,
+                                            disabled_everything, "", UIWidgets::CheckboxGraphics::Cross, false);
+    UIWidgets::Tooltip(
+        "Override the resolution scale slider and use the settings below, irrespective of window size.");
+    if (disabled_pixelCount || disabled_everything) { // Hide pixel count controls.
+        UIWidgets::DisableComponent(ImGui::GetStyle().Alpha * 0.5f);
+    }
+    if (ImGui::Combo("Pixel Count Presets", &item_pixelCount, pixelCountPresetLabels,
+                        IM_ARRAYSIZE(pixelCountPresetLabels)) &&
+        item_pixelCount != default_pixelCount) { // don't change anything if "Custom" is selected.
+        verticalPixelCount = pixelCountPresets[item_pixelCount];
+
+        if (showHorizontalResField) {
+            horizontalPixelCount = (verticalPixelCount / aspectRatioY) * aspectRatioX;
+        }
+
+        CVarSetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".VerticalPixelCount", verticalPixelCount);
+        CVarSetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".UIComboItem.PixelCount", item_pixelCount);
+        CVarSave();
+    }
+    // Horizontal Resolution, if visibility is enabled for it.
+    if (showHorizontalResField) {
+        // Only show the field if Aspect Ratio is being enforced.
+        if ((aspectRatioX > 0.0f) && (aspectRatioY > 0.0f)) {
+            // So basically we're "faking" this one by setting aspectRatioX instead.
+            if (ImGui::InputInt("Horiz. Pixel Count", &horizontalPixelCount, 8, 320)) {
                 item_aspectRatio = default_aspectRatio;
+                if (horizontalPixelCount < SCREEN_WIDTH) {
+                    horizontalPixelCount = SCREEN_WIDTH;
+                }
                 aspectRatioX = horizontalPixelCount;
                 aspectRatioY = verticalPixelCount;
                 update[UPDATE_aspectRatioX] = true;
                 update[UPDATE_aspectRatioY] = true;
             }
+        } else { // Display a notice instead.
+            ImGui::TextColored(messageColor[MESSAGE_QUESTION],
+                                ICON_FA_QUESTION_CIRCLE " \"Force aspect ratio\" required.");
+            // ImGui::Text(" ");
+            ImGui::SameLine();
+            if (ImGui::Button("Click to resolve")) {
+                item_aspectRatio = default_aspectRatio; // Set it to Custom
+                aspectRatioX = aspectRatioPresetsX[2];  // but use the 4:3 defaults
+                aspectRatioY = aspectRatioPresetsY[2];
+                update[UPDATE_aspectRatioX] = true;
+                update[UPDATE_aspectRatioY] = true;
+                horizontalPixelCount = (verticalPixelCount / aspectRatioY) * aspectRatioX;
+            }
         }
-        if (disabled_pixelCount || disabled_everything) { // Hide pixel count controls.
-            UIWidgets::ReEnableComponent("disabledTooltipText");
+    }
+    // Vertical Resolution part 2
+    if (ImGui::InputInt("Vertical Pixel Count", &verticalPixelCount, 8, 240)) {
+        item_pixelCount = default_pixelCount;
+        update[UPDATE_verticalPixelCount] = true;
+
+        // Account for the natural instinct to enter horizontal first.
+        // Ignore vertical resolutions that are below the lower clamp constant.
+        if (showHorizontalResField && !(verticalPixelCount < minVerticalPixelCount)) {
+            item_aspectRatio = default_aspectRatio;
+            aspectRatioX = horizontalPixelCount;
+            aspectRatioY = verticalPixelCount;
+            update[UPDATE_aspectRatioX] = true;
+            update[UPDATE_aspectRatioY] = true;
+        }
+    }
+    if (disabled_pixelCount || disabled_everything) { // Hide pixel count controls.
+        UIWidgets::ReEnableComponent("disabledTooltipText");
+    }
+
+    UIWidgets::Spacer(0);
+
+    // Integer scaling settings group (Pixel-perfect Mode)
+    static const ImGuiTreeNodeFlags IntegerScalingResolvedImGuiFlag =
+        CVarGetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".PixelPerfectMode", 0) ? ImGuiTreeNodeFlags_DefaultOpen
+                                                                    : ImGuiTreeNodeFlags_None;
+    if (ImGui::CollapsingHeader("Integer Scaling Settings", IntegerScalingResolvedImGuiFlag)) {
+        const bool disabled_pixelPerfectMode =
+            !CVarGetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".PixelPerfectMode", 0) || disabled_everything;
+        // Pixel-perfect Mode
+        UIWidgets::PaddedEnhancementCheckbox("Pixel-perfect Mode", CVAR_PREFIX_ADVANCED_RESOLUTION ".PixelPerfectMode", true,
+                                                true, disabled_pixelCount || disabled_everything, "",
+                                                UIWidgets::CheckboxGraphics::Cross, false);
+        UIWidgets::Tooltip("Don't scale image to fill window.");
+        if (disabled_pixelCount && CVarGetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".PixelPerfectMode", 0)) {
+            CVarSetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".PixelPerfectMode", 0);
+            CVarSave();
         }
 
+        // Integer Scaling
+        UIWidgets::EnhancementSliderInt(
+            "Integer scale factor: %d", "##ARSIntScale", CVAR_PREFIX_ADVANCED_RESOLUTION ".IntegerScale.Factor", 1,
+            max_integerScaleFactor, "%d", 1, true,
+            disabled_pixelPerfectMode || CVarGetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".IntegerScale.FitAutomatically", 0));
+        UIWidgets::Tooltip("Integer scales the image. Only available in pixel-perfect mode.");
+        // Display warning if size is being clamped or if framebuffer is larger than viewport.
+        if (!disabled_pixelPerfectMode &&
+            (CVarGetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".IntegerScale.NeverExceedBounds", 1) &&
+                CVarGetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".IntegerScale.Factor", 1) > integerScale_maximumBounds)) {
+            ImGui::SameLine();
+            ImGui::TextColored(messageColor[MESSAGE_WARNING], ICON_FA_EXCLAMATION_TRIANGLE " Window exceeded.");
+        }
+
+        UIWidgets::PaddedEnhancementCheckbox(
+            "Automatically scale image to fit viewport", CVAR_PREFIX_ADVANCED_RESOLUTION ".IntegerScale.FitAutomatically", true,
+            true, disabled_pixelPerfectMode, "", UIWidgets::CheckboxGraphics::Cross, false);
+        UIWidgets::Tooltip("Automatically sets scale factor to fit window. Only available in pixel-perfect mode.");
+        if (CVarGetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".IntegerScale.FitAutomatically", 0)) {
+            // This is just here to update the value shown on the slider.
+            // The function in LUS to handle this setting will ignore IntegerScaleFactor while active.
+            CVarSetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".IntegerScale.Factor", integerScale_maximumBounds);
+            // CVarSave();
+        }
+    } // End of integer scaling settings
+
+    UIWidgets::PaddedSeparator(true, true, 3.0f, 3.0f);
+
+    // Collapsible panel for additional settings
+    if (ImGui::CollapsingHeader("Additional Settings")) {
         UIWidgets::Spacer(0);
 
-        // Integer scaling settings group (Pixel-perfect Mode)
-        static const ImGuiTreeNodeFlags IntegerScalingResolvedImGuiFlag =
-            CVarGetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".PixelPerfectMode", 0) ? ImGuiTreeNodeFlags_DefaultOpen
-                                                                      : ImGuiTreeNodeFlags_None;
-        if (ImGui::CollapsingHeader("Integer Scaling Settings", IntegerScalingResolvedImGuiFlag)) {
-            const bool disabled_pixelPerfectMode =
-                !CVarGetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".PixelPerfectMode", 0) || disabled_everything;
-            // Pixel-perfect Mode
-            UIWidgets::PaddedEnhancementCheckbox("Pixel-perfect Mode", CVAR_PREFIX_ADVANCED_RESOLUTION ".PixelPerfectMode", true,
-                                                 true, disabled_pixelCount || disabled_everything, "",
-                                                 UIWidgets::CheckboxGraphics::Cross, false);
-            UIWidgets::Tooltip("Don't scale image to fill window.");
-            if (disabled_pixelCount && CVarGetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".PixelPerfectMode", 0)) {
-                CVarSetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".PixelPerfectMode", 0);
+#if defined(__SWITCH__) || defined(__WIIU__)
+        // Disable aspect correction, stretching the framebuffer to fill the viewport.
+        // This option is only really needed on systems limited to 16:9 TV resolutions, such as consoles.
+        // The associated cvar is still functional on PC platforms if you want to use it though.
+        UIWidgets::PaddedEnhancementCheckbox("Disable aspect correction and stretch the output image.\n"
+                                                "(Might be useful for 4:3 televisions!)\n"
+                                                "Not available in Pixel Perfect Mode.",
+                                                CVAR_PREFIX_ADVANCED_RESOLUTION ".IgnoreAspectCorrection", false, true,
+                                                CVarGetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".PixelPerfectMode", 0) ||
+                                                    disabled_everything,
+                                                "", UIWidgets::CheckboxGraphics::Cross, false);
+#else
+        if (CVarGetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".IgnoreAspectCorrection", 0)) {
+            // This setting is intentionally not exposed on PC platforms,
+            // but may be accidentally activated for varying reasons.
+            // Having this button should hopefully prevent support headaches.
+            ImGui::TextColored(messageColor[MESSAGE_QUESTION], ICON_FA_QUESTION_CIRCLE
+                                " If the image is stretched and you don't know why, click this.");
+            if (ImGui::Button("Click to reenable aspect correction.")) {
+                CVarSetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".IgnoreAspectCorrection", 0);
+                CVarSave();
+            }
+            UIWidgets::Spacer(2);
+        }
+#endif
+
+        // A requested addition; an alternative way of displaying the resolution field.
+        if (ImGui::Checkbox("Show a horizontal resolution field, instead of aspect ratio.", &showHorizontalResField)) {
+            if (!showHorizontalResField && (aspectRatioX > 0.0f)) { // when turning this setting off
+                // Refresh relevant values
+                aspectRatioX = aspectRatioY * horizontalPixelCount / verticalPixelCount;
+                horizontalPixelCount = (verticalPixelCount / aspectRatioY) * aspectRatioX;
+            } else { // when turning this setting on
+                item_aspectRatio = default_aspectRatio;
+                if (aspectRatioX > 0.0f) {
+                    // Refresh relevant values in the opposite order
+                    horizontalPixelCount = (verticalPixelCount / aspectRatioY) * aspectRatioX;
+                    aspectRatioX = aspectRatioY * horizontalPixelCount / verticalPixelCount;
+                }
+            }
+            update[UPDATE_aspectRatioX] = true;
+        }
+                        
+        // Beginning of Integer Scaling additional settings.
+        {
+            // UIWidgets::PaddedSeparator(true, true, 3.0f, 3.0f);
+                
+            // Integer Scaling - Never Exceed Bounds.
+            const bool disabled_neverExceedBounds =
+                !CVarGetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".PixelPerfectMode", 0) ||
+                CVarGetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".IntegerScale.FitAutomatically", 0) || disabled_everything;
+            const bool checkbox_neverExceedBounds = 
+                UIWidgets::PaddedEnhancementCheckbox("Prevent integer scaling from exceeding screen bounds.\n"
+                                                        "(Makes screen bounds take priority over specified factor.)",
+                                                        CVAR_PREFIX_ADVANCED_RESOLUTION ".IntegerScale.NeverExceedBounds", 
+                                                        true, false, disabled_neverExceedBounds, "",
+                                                        UIWidgets::CheckboxGraphics::Cross, true);
+            UIWidgets::Tooltip(
+                "Prevents integer scaling factor from exceeding screen bounds.\n\n"
+                "Enabled: Will clamp the scaling factor and display a gentle warning in the resolution editor.\n"
+                "Disabled: Will allow scaling to exceed screen bounds, for users who want to crop overscan.\n\n"
+                " " ICON_FA_INFO_CIRCLE
+                " Please note that exceeding screen bounds may show a scroll bar on-screen.");
+
+            // Initialise the (currently unused) "Exceed Bounds By" cvar if it's been changed.
+            if (checkbox_neverExceedBounds &&
+                CVarGetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".IntegerScale.ExceedBoundsBy", 0)) {
+                CVarSetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".IntegerScale.ExceedBoundsBy", 0);
                 CVarSave();
             }
 
-            // Integer Scaling
-            UIWidgets::EnhancementSliderInt(
-                "Integer scale factor: %d", "##ARSIntScale", CVAR_PREFIX_ADVANCED_RESOLUTION ".IntegerScale.Factor", 1,
-                max_integerScaleFactor, "%d", 1, true,
-                disabled_pixelPerfectMode || CVarGetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".IntegerScale.FitAutomatically", 0));
-            UIWidgets::Tooltip("Integer scales the image. Only available in pixel-perfect mode.");
-            // Display warning if size is being clamped or if framebuffer is larger than viewport.
-            if (!disabled_pixelPerfectMode &&
-                (CVarGetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".IntegerScale.NeverExceedBounds", 1) &&
-                 CVarGetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".IntegerScale.Factor", 1) > integerScale_maximumBounds)) {
-                ImGui::SameLine();
-                ImGui::TextColored(messageColor[MESSAGE_WARNING], ICON_FA_EXCLAMATION_TRIANGLE " Window exceeded.");
-            }
+            // Integer Scaling - Exceed Bounds By 1x/Offset.
+            // A popular feature in some retro frontends/upscalers, sometimes called "crop overscan" or "1080p 5x". 
+            /*
+            UIWidgets::PaddedEnhancementCheckbox("Allow integer scale factor to go +1 above maximum screen bounds.", CVAR_PREFIX_ADVANCED_RESOLUTION ".IntegerScale.ExceedBoundsBy", false, false, !CVarGetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".PixelPerfectMode", 0) || disabled_everything, "", UIWidgets::CheckboxGraphics::Cross, false);
+            */
+            // It does actually function as expected, but exceeding the bottom of the screen shows a scroll bar.
+            // I've ended up commenting this one out because of the scroll bar, and for simplicity.
 
-            UIWidgets::PaddedEnhancementCheckbox(
-                "Automatically scale image to fit viewport", CVAR_PREFIX_ADVANCED_RESOLUTION ".IntegerScale.FitAutomatically", true,
-                true, disabled_pixelPerfectMode, "", UIWidgets::CheckboxGraphics::Cross, false);
-            UIWidgets::Tooltip("Automatically sets scale factor to fit window. Only available in pixel-perfect mode.");
-            if (CVarGetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".IntegerScale.FitAutomatically", 0)) {
-                // This is just here to update the value shown on the slider.
-                // The function in LUS to handle this setting will ignore IntegerScaleFactor while active.
-                CVarSetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".IntegerScale.Factor", integerScale_maximumBounds);
-                // CVarSave();
-            }
-        } // End of integer scaling settings
-
-        UIWidgets::PaddedSeparator(true, true, 3.0f, 3.0f);
-
-        // Collapsible panel for additional settings
-        if (ImGui::CollapsingHeader("Additional Settings")) {
-            UIWidgets::Spacer(0);
-
-#if defined(__SWITCH__) || defined(__WIIU__)
-            // Disable aspect correction, stretching the framebuffer to fill the viewport.
-            // This option is only really needed on systems limited to 16:9 TV resolutions, such as consoles.
-            // The associated cvar is still functional on PC platforms if you want to use it though.
-            UIWidgets::PaddedEnhancementCheckbox("Disable aspect correction and stretch the output image.\n"
-                                                 "(Might be useful for 4:3 televisions!)\n"
-                                                 "Not available in Pixel Perfect Mode.",
-                                                 CVAR_PREFIX_ADVANCED_RESOLUTION ".IgnoreAspectCorrection", false, true,
-                                                 CVarGetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".PixelPerfectMode", 0) ||
-                                                     disabled_everything,
-                                                 "", UIWidgets::CheckboxGraphics::Cross, false);
-#else
-            if (CVarGetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".IgnoreAspectCorrection", 0)) {
-                // This setting is intentionally not exposed on PC platforms,
-                // but may be accidentally activated for varying reasons.
-                // Having this button should hopefully prevent support headaches.
-                ImGui::TextColored(messageColor[MESSAGE_QUESTION], ICON_FA_QUESTION_CIRCLE
-                                   " If the image is stretched and you don't know why, click this.");
-                if (ImGui::Button("Click to reenable aspect correction.")) {
-                    CVarSetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".IgnoreAspectCorrection", 0);
-                    CVarSave();
+            // Display an info message about the scroll bar.
+            if (!CVarGetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".IntegerScale.NeverExceedBounds", 1) ||
+                CVarGetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".IntegerScale.ExceedBoundsBy", 0)) {
+                if (disabled_neverExceedBounds) { // Dim this help text accordingly
+                    UIWidgets::DisableComponent(ImGui::GetStyle().Alpha * 0.5f);
                 }
-                UIWidgets::Spacer(2);
-            }
-#endif
-
-            // A requested addition; an alternative way of displaying the resolution field.
-            if (ImGui::Checkbox("Show a horizontal resolution field, instead of aspect ratio.", &showHorizontalResField)) {
-                if (!showHorizontalResField && (aspectRatioX > 0.0f)) { // when turning this setting off
-                    // Refresh relevant values
-                    aspectRatioX = aspectRatioY * horizontalPixelCount / verticalPixelCount;
-                    horizontalPixelCount = (verticalPixelCount / aspectRatioY) * aspectRatioX;
-                } else { // when turning this setting on
-                    item_aspectRatio = default_aspectRatio;
-                    if (aspectRatioX > 0.0f) {
-                        // Refresh relevant values in the opposite order
-                        horizontalPixelCount = (verticalPixelCount / aspectRatioY) * aspectRatioX;
-                        aspectRatioX = aspectRatioY * horizontalPixelCount / verticalPixelCount;
-                    }
+                ImGui::TextColored(messageColor[MESSAGE_INFO],
+                                    " " ICON_FA_INFO_CIRCLE
+                                    " A scroll bar may become visible if screen bounds are exceeded.");
+                if (disabled_neverExceedBounds) { // Dim this help text accordingly
+                    UIWidgets::ReEnableComponent("disabledTooltipText");
                 }
-                update[UPDATE_aspectRatioX] = true;
-            }
-                        
-            // Beginning of Integer Scaling additional settings.
-            {
-                // UIWidgets::PaddedSeparator(true, true, 3.0f, 3.0f);
-                
-                // Integer Scaling - Never Exceed Bounds.
-                const bool disabled_neverExceedBounds =
-                    !CVarGetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".PixelPerfectMode", 0) ||
-                    CVarGetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".IntegerScale.FitAutomatically", 0) || disabled_everything;
-                const bool checkbox_neverExceedBounds = 
-                    UIWidgets::PaddedEnhancementCheckbox("Prevent integer scaling from exceeding screen bounds.\n"
-                                                         "(Makes screen bounds take priority over specified factor.)",
-                                                         CVAR_PREFIX_ADVANCED_RESOLUTION ".IntegerScale.NeverExceedBounds", 
-                                                         true, false, disabled_neverExceedBounds, "",
-                                                         UIWidgets::CheckboxGraphics::Cross, true);
-                UIWidgets::Tooltip(
-                    "Prevents integer scaling factor from exceeding screen bounds.\n\n"
-                    "Enabled: Will clamp the scaling factor and display a gentle warning in the resolution editor.\n"
-                    "Disabled: Will allow scaling to exceed screen bounds, for users who want to crop overscan.\n\n"
-                    " " ICON_FA_INFO_CIRCLE
-                    " Please note that exceeding screen bounds may show a scroll bar on-screen.");
-
-                // Initialise the (currently unused) "Exceed Bounds By" cvar if it's been changed.
-                if (checkbox_neverExceedBounds &&
-                    CVarGetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".IntegerScale.ExceedBoundsBy", 0)) {
-                    CVarSetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".IntegerScale.ExceedBoundsBy", 0);
-                    CVarSave();
-                }
-
-                // Integer Scaling - Exceed Bounds By 1x/Offset.
-                // A popular feature in some retro frontends/upscalers, sometimes called "crop overscan" or "1080p 5x". 
-                /*
-                UIWidgets::PaddedEnhancementCheckbox("Allow integer scale factor to go +1 above maximum screen bounds.", CVAR_PREFIX_ADVANCED_RESOLUTION ".IntegerScale.ExceedBoundsBy", false, false, !CVarGetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".PixelPerfectMode", 0) || disabled_everything, "", UIWidgets::CheckboxGraphics::Cross, false);
-                */
-                // It does actually function as expected, but exceeding the bottom of the screen shows a scroll bar.
-                // I've ended up commenting this one out because of the scroll bar, and for simplicity.
-
-                // Display an info message about the scroll bar.
-                if (!CVarGetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".IntegerScale.NeverExceedBounds", 1) ||
-                    CVarGetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".IntegerScale.ExceedBoundsBy", 0)) {
-                    if (disabled_neverExceedBounds) { // Dim this help text accordingly
-                        UIWidgets::DisableComponent(ImGui::GetStyle().Alpha * 0.5f);
-                    }
-                    ImGui::TextColored(messageColor[MESSAGE_INFO],
-                                       " " ICON_FA_INFO_CIRCLE
-                                       " A scroll bar may become visible if screen bounds are exceeded.");
-                    if (disabled_neverExceedBounds) { // Dim this help text accordingly
-                        UIWidgets::ReEnableComponent("disabledTooltipText");
-                    }
                     
-                    // Another support helper button, to disable the unused "Exceed Bounds By" cvar.
-                    // (Remove this button if uncommenting the checkbox.)
-                    if (CVarGetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".IntegerScale.ExceedBoundsBy", 0)) {
-                        if (ImGui::Button("Click to reset a console variable that may be causing this.")) {
-                            CVarSetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".IntegerScale.ExceedBoundsBy", 0);
-                            CVarSave();
-                        }
+                // Another support helper button, to disable the unused "Exceed Bounds By" cvar.
+                // (Remove this button if uncommenting the checkbox.)
+                if (CVarGetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".IntegerScale.ExceedBoundsBy", 0)) {
+                    if (ImGui::Button("Click to reset a console variable that may be causing this.")) {
+                        CVarSetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".IntegerScale.ExceedBoundsBy", 0);
+                        CVarSave();
                     }
-                } else {
-                    ImGui::Text(" ");
                 }
-                // UIWidgets::PaddedSeparator(true, true, 3.0f, 3.0f);
-            } // End of Integer Scaling additional settings.
+            } else {
+                ImGui::Text(" ");
+            }
+            // UIWidgets::PaddedSeparator(true, true, 3.0f, 3.0f);
+        } // End of Integer Scaling additional settings.
 
-        } // End of additional settings
+    } // End of additional settings
 
-        // Clamp and update the cvars that don't use UIWidgets
-        if (update[UPDATE_aspectRatioX] || update[UPDATE_aspectRatioY] || update[UPDATE_verticalPixelCount]) {
-            if (update[UPDATE_aspectRatioX]) {
-                if (aspectRatioX < 0.0f) {
-                    aspectRatioX = 0.0f;
-                }
-                CVarSetFloat(CVAR_PREFIX_ADVANCED_RESOLUTION ".AspectRatioX", aspectRatioX);
+    // Clamp and update the cvars that don't use UIWidgets
+    if (update[UPDATE_aspectRatioX] || update[UPDATE_aspectRatioY] || update[UPDATE_verticalPixelCount]) {
+        if (update[UPDATE_aspectRatioX]) {
+            if (aspectRatioX < 0.0f) {
+                aspectRatioX = 0.0f;
             }
-            if (update[UPDATE_aspectRatioY]) {
-                if (aspectRatioY < 0.0f) {
-                    aspectRatioY = 0.0f;
-                }
-                CVarSetFloat(CVAR_PREFIX_ADVANCED_RESOLUTION ".AspectRatioY", aspectRatioY);
-            }
-            if (update[UPDATE_verticalPixelCount]) {
-                // There's a upper and lower clamp on the Libultraship side too,
-                // so clamping it here is entirely visual, so the vertical resolution field reflects it.
-                if (verticalPixelCount < minVerticalPixelCount) {
-                    verticalPixelCount = minVerticalPixelCount;
-                }
-                if (verticalPixelCount > maxVerticalPixelCount) {
-                    verticalPixelCount = maxVerticalPixelCount;
-                }
-                CVarSetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".VerticalPixelCount", verticalPixelCount);
-            }
-            CVarSetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".UIComboItem.AspectRatio", item_aspectRatio);
-            CVarSetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".UIComboItem.PixelCount", item_pixelCount);
-            CVarSave();
+            CVarSetFloat(CVAR_PREFIX_ADVANCED_RESOLUTION ".AspectRatioX", aspectRatioX);
         }
+        if (update[UPDATE_aspectRatioY]) {
+            if (aspectRatioY < 0.0f) {
+                aspectRatioY = 0.0f;
+            }
+            CVarSetFloat(CVAR_PREFIX_ADVANCED_RESOLUTION ".AspectRatioY", aspectRatioY);
+        }
+        if (update[UPDATE_verticalPixelCount]) {
+            // There's a upper and lower clamp on the Libultraship side too,
+            // so clamping it here is entirely visual, so the vertical resolution field reflects it.
+            if (verticalPixelCount < minVerticalPixelCount) {
+                verticalPixelCount = minVerticalPixelCount;
+            }
+            if (verticalPixelCount > maxVerticalPixelCount) {
+                verticalPixelCount = maxVerticalPixelCount;
+            }
+            CVarSetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".VerticalPixelCount", verticalPixelCount);
+        }
+        CVarSetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".UIComboItem.AspectRatio", item_aspectRatio);
+        CVarSetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".UIComboItem.PixelCount", item_pixelCount);
+        CVarSave();
     }
-    ImGui::End();
 }
 
 void AdvancedResolutionSettingsWindow::UpdateElement() {

--- a/soh/soh/SohGui.cpp
+++ b/soh/soh/SohGui.cpp
@@ -164,45 +164,44 @@ namespace SohGui {
             SPDLOG_ERROR("Could not find input editor window");
         }
 
-        mAudioEditorWindow = std::make_shared<AudioEditor>(CVAR_WINDOW("AudioEditor"), "Audio Editor");
+        mAudioEditorWindow = std::make_shared<AudioEditor>(CVAR_WINDOW("AudioEditor"), "Audio Editor", ImVec2(820, 630));
         gui->AddGuiWindow(mAudioEditorWindow);
         mInputViewer = std::make_shared<InputViewer>(CVAR_WINDOW("InputViewer"), "Input Viewer");
         gui->AddGuiWindow(mInputViewer);
-        mInputViewerSettings = std::make_shared<InputViewerSettingsWindow>(CVAR_WINDOW("InputViewerSettings"), "Input Viewer Settings");
+        mInputViewerSettings = std::make_shared<InputViewerSettingsWindow>(CVAR_WINDOW("InputViewerSettings"), "Input Viewer Settings", ImVec2(500, 525));
         gui->AddGuiWindow(mInputViewerSettings);
-        mCosmeticsEditorWindow = std::make_shared<CosmeticsEditorWindow>(CVAR_WINDOW("CosmeticsEditor"), "Cosmetics Editor");
+        mCosmeticsEditorWindow = std::make_shared<CosmeticsEditorWindow>(CVAR_WINDOW("CosmeticsEditor"), "Cosmetics Editor", ImVec2(550, 520));
         gui->AddGuiWindow(mCosmeticsEditorWindow);
-        mActorViewerWindow = std::make_shared<ActorViewerWindow>(CVAR_WINDOW("ActorViewer"), "Actor Viewer");
+        mActorViewerWindow = std::make_shared<ActorViewerWindow>(CVAR_WINDOW("ActorViewer"), "Actor Viewer", ImVec2(520, 600));
         gui->AddGuiWindow(mActorViewerWindow);
-        mColViewerWindow = std::make_shared<ColViewerWindow>(CVAR_WINDOW("CollisionViewer"), "Collision Viewer");
+        mColViewerWindow = std::make_shared<ColViewerWindow>(CVAR_WINDOW("CollisionViewer"), "Collision Viewer", ImVec2(520, 600));
         gui->AddGuiWindow(mColViewerWindow);
-        mSaveEditorWindow = std::make_shared<SaveEditorWindow>(CVAR_WINDOW("SaveEditor"), "Save Editor");
+        mSaveEditorWindow = std::make_shared<SaveEditorWindow>(CVAR_WINDOW("SaveEditor"), "Save Editor", ImVec2(520, 600));
         gui->AddGuiWindow(mSaveEditorWindow);
-        mDLViewerWindow = std::make_shared<DLViewerWindow>(CVAR_WINDOW("DLViewer"), "Display List Viewer");
+        mDLViewerWindow = std::make_shared<DLViewerWindow>(CVAR_WINDOW("DLViewer"), "Display List Viewer", ImVec2(520, 600));
         gui->AddGuiWindow(mDLViewerWindow);
-        mValueViewerWindow = std::make_shared<ValueViewerWindow>(CVAR_WINDOW("ValueViewer"), "Value Viewer");
+        mValueViewerWindow = std::make_shared<ValueViewerWindow>(CVAR_WINDOW("ValueViewer"), "Value Viewer", ImVec2(520, 600));
         gui->AddGuiWindow(mValueViewerWindow);
-        mMessageViewerWindow = std::make_shared<MessageViewer>(CVAR_WINDOW("MessageViewer"), "Message Viewer");
+        mMessageViewerWindow = std::make_shared<MessageViewer>(CVAR_WINDOW("MessageViewer"), "Message Viewer", ImVec2(520, 600));
         gui->AddGuiWindow(mMessageViewerWindow);
-        mGameplayStatsWindow = std::make_shared<GameplayStatsWindow>(CVAR_WINDOW("GameplayStats"), "Gameplay Stats");
+        mGameplayStatsWindow = std::make_shared<GameplayStatsWindow>(CVAR_WINDOW("GameplayStats"), "Gameplay Stats", ImVec2(480, 550));
         gui->AddGuiWindow(mGameplayStatsWindow);
-        mCheckTrackerWindow = std::make_shared<CheckTracker::CheckTrackerWindow>(CVAR_WINDOW("CheckTracker"), "Check Tracker");
+        mCheckTrackerWindow = std::make_shared<CheckTracker::CheckTrackerWindow>(CVAR_WINDOW("CheckTracker"), "Check Tracker", ImVec2(400, 540));
         gui->AddGuiWindow(mCheckTrackerWindow);
-        mCheckTrackerSettingsWindow = std::make_shared<CheckTracker::CheckTrackerSettingsWindow>(CVAR_WINDOW("CheckTrackerSettings"), "Check Tracker Settings");
+        mCheckTrackerSettingsWindow = std::make_shared<CheckTracker::CheckTrackerSettingsWindow>(CVAR_WINDOW("CheckTrackerSettings"), "Check Tracker Settings", ImVec2(600, 375));
         gui->AddGuiWindow(mCheckTrackerSettingsWindow);
-        mEntranceTrackerWindow = std::make_shared<EntranceTrackerWindow>(CVAR_WINDOW("EntranceTracker"),"Entrance Tracker");
+        mEntranceTrackerWindow = std::make_shared<EntranceTrackerWindow>(CVAR_WINDOW("EntranceTracker"),"Entrance Tracker", ImVec2(600, 375));
         gui->AddGuiWindow(mEntranceTrackerWindow);
         mItemTrackerWindow = std::make_shared<ItemTrackerWindow>(CVAR_WINDOW("ItemTracker"), "Item Tracker");
         gui->AddGuiWindow(mItemTrackerWindow);
-        mItemTrackerSettingsWindow = std::make_shared<ItemTrackerSettingsWindow>(CVAR_WINDOW("ItemTrackerSettings"), "Item Tracker Settings");
+        mItemTrackerSettingsWindow = std::make_shared<ItemTrackerSettingsWindow>(CVAR_WINDOW("ItemTrackerSettings"), "Item Tracker Settings", ImVec2(733, 472));
         gui->AddGuiWindow(mItemTrackerSettingsWindow);
-        mRandomizerSettingsWindow = std::make_shared<RandomizerSettingsWindow>(CVAR_WINDOW("RandomizerSettings"), "Randomizer Settings");
+        mRandomizerSettingsWindow = std::make_shared<RandomizerSettingsWindow>(CVAR_WINDOW("RandomizerSettings"), "Randomizer Settings", ImVec2(920, 600));
         gui->AddGuiWindow(mRandomizerSettingsWindow);
-        mAdvancedResolutionSettingsWindow = std::make_shared<AdvancedResolutionSettings::AdvancedResolutionSettingsWindow>(CVAR_WINDOW("AdvancedResolutionEditor"), "Advanced Resolution Settings");
+        mAdvancedResolutionSettingsWindow = std::make_shared<AdvancedResolutionSettings::AdvancedResolutionSettingsWindow>(CVAR_WINDOW("AdvancedResolutionEditor"), "Advanced Resolution Settings", ImVec2(497, 599));
         gui->AddGuiWindow(mAdvancedResolutionSettingsWindow);
         mModalWindow = std::make_shared<SohModalWindow>(CVAR_WINDOW("ModalWindow"), "Modal Window");
         gui->AddGuiWindow(mModalWindow);
-        mModalWindow->Show();
     }
 
     void Destroy() {

--- a/soh/soh/SohGui.cpp
+++ b/soh/soh/SohGui.cpp
@@ -186,11 +186,11 @@ namespace SohGui {
         gui->AddGuiWindow(mMessageViewerWindow);
         mGameplayStatsWindow = std::make_shared<GameplayStatsWindow>(CVAR_WINDOW("GameplayStats"), "Gameplay Stats", ImVec2(480, 550));
         gui->AddGuiWindow(mGameplayStatsWindow);
-        mCheckTrackerWindow = std::make_shared<CheckTracker::CheckTrackerWindow>(CVAR_WINDOW("CheckTracker"), "Check Tracker", ImVec2(400, 540));
+        mCheckTrackerWindow = std::make_shared<CheckTracker::CheckTrackerWindow>(CVAR_WINDOW("CheckTracker"), "Check Tracker");
         gui->AddGuiWindow(mCheckTrackerWindow);
         mCheckTrackerSettingsWindow = std::make_shared<CheckTracker::CheckTrackerSettingsWindow>(CVAR_WINDOW("CheckTrackerSettings"), "Check Tracker Settings", ImVec2(600, 375));
         gui->AddGuiWindow(mCheckTrackerSettingsWindow);
-        mEntranceTrackerWindow = std::make_shared<EntranceTrackerWindow>(CVAR_WINDOW("EntranceTracker"),"Entrance Tracker", ImVec2(600, 375));
+        mEntranceTrackerWindow = std::make_shared<EntranceTrackerWindow>(CVAR_WINDOW("EntranceTracker"),"Entrance Tracker");
         gui->AddGuiWindow(mEntranceTrackerWindow);
         mItemTrackerWindow = std::make_shared<ItemTrackerWindow>(CVAR_WINDOW("ItemTracker"), "Item Tracker");
         gui->AddGuiWindow(mItemTrackerWindow);

--- a/soh/soh/SohGui.cpp
+++ b/soh/soh/SohGui.cpp
@@ -202,6 +202,7 @@ namespace SohGui {
         gui->AddGuiWindow(mAdvancedResolutionSettingsWindow);
         mModalWindow = std::make_shared<SohModalWindow>(CVAR_WINDOW("ModalWindow"), "Modal Window");
         gui->AddGuiWindow(mModalWindow);
+        mModalWindow->Show();
     }
 
     void Destroy() {

--- a/soh/soh/SohModals.cpp
+++ b/soh/soh/SohModals.cpp
@@ -46,9 +46,11 @@ void SohModalWindow::DrawElement() {
             }
         }
         ImGui::EndPopup();
+        SetVisiblity(false);
     }
 }
 
 void SohModalWindow::RegisterPopup(std::string title, std::string message, std::string button1, std::string button2, std::function<void()> button1callback, std::function<void()> button2callback) {
     modals.push_back({ title, message, button1, button2, button1callback, button2callback });
+    SetVisiblity(true);
 }

--- a/soh/soh/SohModals.cpp
+++ b/soh/soh/SohModals.cpp
@@ -19,6 +19,15 @@ struct SohModal {
 };
 std::vector<SohModal> modals;
 
+void SohModalWindow::Draw() {
+    if (!IsVisible()) {
+        return;
+    }
+    DrawElement();
+    // Sync up the IsVisible flag if it was changed by ImGui
+    SyncVisibilityConsoleVariable();
+}
+
 void SohModalWindow::DrawElement() {
     if (modals.size() > 0) {
         SohModal curModal = modals.at(0);
@@ -46,11 +55,9 @@ void SohModalWindow::DrawElement() {
             }
         }
         ImGui::EndPopup();
-        SetVisiblity(false);
     }
 }
 
 void SohModalWindow::RegisterPopup(std::string title, std::string message, std::string button1, std::string button2, std::function<void()> button1callback, std::function<void()> button2callback) {
     modals.push_back({ title, message, button1, button2, button1callback, button2callback });
-    SetVisiblity(true);
 }

--- a/soh/soh/SohModals.h
+++ b/soh/soh/SohModals.h
@@ -7,6 +7,7 @@
 class SohModalWindow : public Ship::GuiWindow {
   public:
     using GuiWindow::GuiWindow;
+    void Draw() override;
 
     void InitElement() override {};
     void DrawElement() override;


### PR DESCRIPTION
This adapts SoH's GuiWindows to the new modern menu system of drawing. Currently excludes Check, Entrance and Item trackers, as well as the Input Viewer, with Draw() overrides to bypass the built-in ImGui Begin and End calls in the normal flow.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1870342731.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1870426590.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1870432968.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1870444685.zip)
<!--- section:artifacts:end -->