### PR TITLE
Decouple Audio Thread from Main Thread Signaling

### DIFF
--- a/soh/soh/OTRAudio.h
+++ b/soh/soh/OTRAudio.h
@@ -5,4 +5,5 @@ static struct {
     std::thread thread;
     std::mutex mutex;
     bool running;
+    bool paused;
 } audio;

--- a/soh/soh/OTRAudio.h
+++ b/soh/soh/OTRAudio.h
@@ -1,11 +1,8 @@
 #pragma once
 #include <thread>
-#include <condition_variable>
 
 static struct {
     std::thread thread;
-    std::condition_variable cv_to_thread, cv_from_thread;
     std::mutex mutex;
     bool running;
-    bool processing;
 } audio;

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -47,6 +47,7 @@
 #include "Enhancements/presets.h"
 #include "util.h"
 #include <boost_custom/container_hash/hash_32.hpp>
+#include <chrono>
 
 #if not defined (__SWITCH__) && not defined(__WIIU__)
 #include "Extractor/Extract.h"
@@ -496,48 +497,38 @@ extern "C" void ResourceMgr_LoadDirectory(const char* resName);
 extern "C" SequenceData ResourceMgr_LoadSeqByName(const char* path);
 std::unordered_map<std::string, ExtensionEntry> ExtensionCache;
 
+// 528 and 544 relate to 60 fps at 32 kHz 32000/60 = 533.333..
+// in an ideal world, one third of the calls should use num_samples=544 and two thirds num_samples=528
+//#define SAMPLES_HIGH 560
+//#define SAMPLES_LOW 528
+// PAL values
+//#define SAMPLES_HIGH 656
+//#define SAMPLES_LOW 624
+
+// 44KHZ values
+// Don't follow high and low anymore, but instead just the target sample rate as defined in the audio player properties.
+// Not sure how to adapt that to make other sample rates usable
+#define SAMPLES_TARGET 736
+#define NUM_AUDIO_CHANNELS 2
+
 void OTRAudio_Thread() {
     while (audio.running) {
-        {
-            std::unique_lock<std::mutex> Lock(audio.mutex);
-            while (!audio.processing && audio.running) {
-                audio.cv_to_thread.wait(Lock);
-            }
-
-            if (!audio.running) {
-                break;
-            }
+        if (gGameInfo == nullptr) {
+            continue;
         }
+        
+        if (!audio.running) {
+            break;
+        }
+
         std::unique_lock<std::mutex> Lock(audio.mutex);
         //AudioMgr_ThreadEntry(&gAudioMgr);
-        // 528 and 544 relate to 60 fps at 32 kHz 32000/60 = 533.333..
-        // in an ideal world, one third of the calls should use num_samples=544 and two thirds num_samples=528
-        //#define SAMPLES_HIGH 560
-        //#define SAMPLES_LOW 528
-        // PAL values
-        //#define SAMPLES_HIGH 656
-        //#define SAMPLES_LOW 624
-
-        // 44KHZ values
-        #define SAMPLES_HIGH 752
-        #define SAMPLES_LOW 720
-
-        #define AUDIO_FRAMES_PER_UPDATE (R_UPDATE_RATE > 0 ? R_UPDATE_RATE : 1 )
-        #define NUM_AUDIO_CHANNELS 2
 
         int samples_left = AudioPlayer_Buffered();
-        u32 num_audio_samples = samples_left < AudioPlayer_GetDesiredBuffered() ? SAMPLES_HIGH : SAMPLES_LOW;
-
-        // 3 is the maximum authentic frame divisor.
-        s16 audio_buffer[SAMPLES_HIGH * NUM_AUDIO_CHANNELS * 3];
-        for (int i = 0; i < AUDIO_FRAMES_PER_UPDATE; i++) {
-            AudioMgr_CreateNextAudioBuffer(audio_buffer + i * (num_audio_samples * NUM_AUDIO_CHANNELS), num_audio_samples);
-        }
-
-        AudioPlayer_Play((u8*)audio_buffer, num_audio_samples * (sizeof(int16_t) * NUM_AUDIO_CHANNELS * AUDIO_FRAMES_PER_UPDATE));
-
-        audio.processing = false;
-        audio.cv_from_thread.notify_one();
+        s16 audio_buffer[SAMPLES_TARGET * NUM_AUDIO_CHANNELS];
+        AudioMgr_CreateNextAudioBuffer(audio_buffer, SAMPLES_TARGET);
+        AudioPlayer_Play((u8*)audio_buffer, SAMPLES_TARGET * (sizeof(int16_t) * NUM_AUDIO_CHANNELS));
+        std::this_thread::sleep_for(std::chrono::milliseconds((1000 / 60) - (SAMPLES_TARGET - samples_left) / 60));
     }
 }
 
@@ -555,11 +546,7 @@ extern "C" void OTRAudio_Init()
 
 extern "C" void OTRAudio_Exit() {
     // Tell the audio thread to stop
-    {
-        std::unique_lock<std::mutex> Lock(audio.mutex);
-        audio.running = false;
-    }
-    audio.cv_to_thread.notify_all();
+    audio.running = false;
 
     // Wait until the audio thread quit
     audio.thread.join();
@@ -1361,12 +1348,6 @@ void RunCommands(Gfx* Commands, const std::vector<std::unordered_map<Mtx*, MtxF>
 
 // C->C++ Bridge
 extern "C" void Graph_ProcessGfxCommands(Gfx* commands) {
-    {
-        std::unique_lock<std::mutex> Lock(audio.mutex);
-        audio.processing = true;
-    }
-
-    audio.cv_to_thread.notify_one();
     std::vector<std::unordered_map<Mtx*, MtxF>> mtx_replacements;
     int target_fps = OTRGlobals::Instance->GetInterpolationFPS();
     static int last_fps;
@@ -1409,13 +1390,6 @@ extern "C" void Graph_ProcessGfxCommands(Gfx* commands) {
 
     last_fps = fps;
     last_update_rate = R_UPDATE_RATE;
-
-    {
-        std::unique_lock<std::mutex> Lock(audio.mutex);
-        while (audio.processing) {
-            audio.cv_from_thread.wait(Lock);
-        }
-    }
 
     bool curAltAssets = CVarGetInteger(CVAR_ENHANCEMENT("AltAssets"), 0);
     if (prevAltAssets != curAltAssets) {

--- a/soh/soh/OTRGlobals.h
+++ b/soh/soh/OTRGlobals.h
@@ -155,7 +155,7 @@ int16_t OTRGetRectDimensionFromRightEdge(float v);
 int AudioPlayer_Buffered(void);
 int AudioPlayer_GetDesiredBuffered(void);
 void AudioPlayer_Play(const uint8_t* buf, uint32_t len);
-void AudioMgr_CreateNextAudioBuffer(u8* samples, u32 num_samples);
+void AudioMgr_CreateNextAudioBuffer(s16* samples, u32 num_samples);
 int Controller_ShouldRumble(size_t slot);
 void Controller_BlockGameInput();
 void Controller_UnblockGameInput();

--- a/soh/soh/OTRGlobals.h
+++ b/soh/soh/OTRGlobals.h
@@ -155,7 +155,7 @@ int16_t OTRGetRectDimensionFromRightEdge(float v);
 int AudioPlayer_Buffered(void);
 int AudioPlayer_GetDesiredBuffered(void);
 void AudioPlayer_Play(const uint8_t* buf, uint32_t len);
-void AudioMgr_CreateNextAudioBuffer(s16* samples, u32 num_samples);
+void AudioMgr_CreateNextAudioBuffer(u8* samples, u32 num_samples);
 int Controller_ShouldRumble(size_t slot);
 void Controller_BlockGameInput();
 void Controller_UnblockGameInput();

--- a/soh/soh/OTRGlobals.h
+++ b/soh/soh/OTRGlobals.h
@@ -86,6 +86,8 @@ uint32_t IsGameMasterQuest();
 void DeinitOTR(void);
 void VanillaItemTable_Init();
 void OTRAudio_Init();
+bool OTRAudio_IsPaused();
+void OTRAudio_SetPaused(bool pause);
 void OTRMessage_Init();
 void InitAudio();
 void Graph_StartFrame();

--- a/soh/src/code/code_800F9280.c
+++ b/soh/src/code/code_800F9280.c
@@ -371,6 +371,9 @@ extern f32 D_80130F28;
 
 void Audio_QueueSeqCmd(u32 cmd) 
 {
+    if (OTRAudio_IsPaused()) {
+        OTRAudio_SetPaused(false);
+    }
     u8 op = cmd >> 28;
     if (op == 0 || op == 2 || op == 12) {
         u8 seqId = cmd & 0xFF;


### PR DESCRIPTION
There have been many issues now with the audio thread being blocked by main thread signaling, with no perceivable benefit (since cutscenes are already desynced anyway due to lack of lag), so this PR fully decouples the audio thread from the main thread and makes it run at a constant 60 FPS with 44.1kHz sample rate.

Save states music functionality still works. Didn't know if there was anything else to check.

I thought about making it so SoH could support more sample rates, but that seemed outside the scope of this PR, and isn't as important.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1950776851.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1950815801.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1950819789.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1950824438.zip)
<!--- section:artifacts:end -->