### PR TITLE
simply all loaches logic

### DIFF
--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -956,7 +956,7 @@ void DrawEnhancementsMenu() {
                     UIWidgets::PaddedEnhancementSliderInt("Adult Minimum Weight: %d", "##aMinimumWeight", CVAR_ENHANCEMENT("MinimumFishWeightAdult"), 6, 13, "", 13, true, true, false, disabled, disabledTooltip);
                     UIWidgets::Tooltip("The minimum weight for the unique fishing reward as an adult");
                     UIWidgets::PaddedEnhancementCheckbox("All fish are Hyrule Loaches", CVAR_ENHANCEMENT("AllHyruleLoaches"), true, false, disabled, disabledTooltip);
-                    UIWidgets::Tooltip("Every fish in the fishing pond will always be a Hyrule Loach");
+                    UIWidgets::Tooltip("Every fish in the fishing pond will always be a Hyrule Loach\n\nNote: This requires reloading the area");
                     ImGui::EndMenu();
                 }
                 UIWidgets::Spacer(0);

--- a/soh/src/overlays/actors/ovl_Fishing/z_fishing.c
+++ b/soh/src/overlays/actors/ovl_Fishing/z_fishing.c
@@ -1024,7 +1024,7 @@ void Fishing_Init(Actor* thisx, PlayState* play2) {
             this->fishState = 10;
             this->fishStateNext = 10;
 
-            this->isLoach = sFishInits[thisx->params - EN_FISH_PARAM].isLoach;
+            this->isLoach = sFishInits[thisx->params - EN_FISH_PARAM].isLoach || AllHyruleLoaches();
             this->perception = sFishInits[thisx->params - EN_FISH_PARAM].perception;
             this->fishLength = sFishInits[thisx->params - EN_FISH_PARAM].baseLength;
 
@@ -2850,7 +2850,7 @@ void Fishing_FishLeapSfx(Fishing* this, u8 outOfWater) {
     s16 sfxId;
     u8 length;
 
-    if (this->isLoach == 0 && !AllHyruleLoaches()) {
+    if (this->isLoach == 0) {
         length = this->fishLength;
     } else {
         length = 2.0f * this->fishLength;
@@ -2995,7 +2995,7 @@ void Fishing_UpdateFish(Actor* thisx, PlayState* play2) {
     this->actor.uncullZoneForward = 700.0f;
     this->actor.uncullZoneScale = 50.0f;
 
-    if (this->isLoach == 0 && !AllHyruleLoaches()) {
+    if (this->isLoach == 0) {
         playerSpeedMod = (player->actor.speedXZ * 0.15f) + 0.25f;
     } else {
         playerSpeedMod = (player->actor.speedXZ * 0.3f) + 0.25f;
@@ -3057,7 +3057,7 @@ void Fishing_UpdateFish(Actor* thisx, PlayState* play2) {
 
     Math_ApproachS(&this->fishLimbDRotZDelta, 0, 5, 0x1F4);
 
-    if (this->isLoach == 0 && !AllHyruleLoaches()) {
+    if (this->isLoach == 0) {
         Actor_SetScale(&this->actor, this->fishLength * 15.0f * 0.00001f);
 
         this->fishLimbRotPhase += this->fishLimbRotPhaseStep;
@@ -3226,7 +3226,7 @@ void Fishing_UpdateFish(Actor* thisx, PlayState* play2) {
             break;
 
         case 1:
-            if (this->isLoach == 1 || AllHyruleLoaches()) {
+            if (this->isLoach == 1) {
                 this->fishState = -1;
                 this->unk_1A4 = 20000;
                 this->unk_1A2 = 20000;
@@ -3379,7 +3379,7 @@ void Fishing_UpdateFish(Actor* thisx, PlayState* play2) {
 
             if (sLureEquipped == FS_LURE_SINKING) {
                 this->fishTargetPos.y = sLurePos.y;
-            } else if (this->isLoach == 0 && !AllHyruleLoaches()) {
+            } else if (this->isLoach == 0) {
                 this->fishTargetPos.y = sLurePos.y - 15.0f;
             } else {
                 this->fishTargetPos.y = sLurePos.y - 5.0f;
@@ -3454,8 +3454,8 @@ void Fishing_UpdateFish(Actor* thisx, PlayState* play2) {
             }
             if (getGuaranteeBite() == 1 ||
                 ((this->timerArray[0] == 1) || (Rand_ZeroOne() < chance)) &&
-                ((Rand_ZeroOne() < (this->perception * multiplier)) || (((this->isLoach || AllHyruleLoaches()) + 1) == KREG(69)))) {
-                if (this->isLoach == 0 && !AllHyruleLoaches()) {
+                ((Rand_ZeroOne() < (this->perception * multiplier)) || ((this->isLoach + 1) == KREG(69)))) {
+                if (this->isLoach == 0) {
                     this->fishState = 3;
                     this->unk_190 = 1.2f;
                     this->unk_194 = 5000.0f;
@@ -3676,7 +3676,7 @@ void Fishing_UpdateFish(Actor* thisx, PlayState* play2) {
                     Audio_QueueSeqCmd(SEQ_PLAYER_BGM_MAIN << 24 | NA_BGM_ENEMY | 0x800);
                     sFishingMusicDelay = 0;
 
-                    if (this->isLoach == 1 || AllHyruleLoaches()) {
+                    if (this->isLoach == 1) {
                         rumbleStrength = (this->fishLength * 3.0f) + 120.0f;
                     } else {
                         rumbleStrength = (2.0f * this->fishLength) + 120.0f;
@@ -3779,7 +3779,7 @@ void Fishing_UpdateFish(Actor* thisx, PlayState* play2) {
                             Math_ApproachF(&this->actor.speedXZ, 5.0f, 1.0f, 0.5f);
                         }
 
-                        if (this->isLoach == 0 && !AllHyruleLoaches()) {
+                        if (this->isLoach == 0) {
                             sRodReelingSpeed = 1.0f - (this->fishLength * 0.00899f);
                         } else {
                             sRodReelingSpeed = 1.0f - (this->fishLength * 0.00899f * 1.4f);
@@ -3795,7 +3795,7 @@ void Fishing_UpdateFish(Actor* thisx, PlayState* play2) {
                     this->unk_190 = 1.0f;
                     this->unk_194 = 4500.0f;
 
-                    if (this->isLoach == 0 && !AllHyruleLoaches()) {
+                    if (this->isLoach == 0) {
                         sRodReelingSpeed = 1.3f - (this->fishLength * 0.00899f);
                     } else {
                         sRodReelingSpeed = 1.3f - (this->fishLength * 0.00899f * 1.4f);
@@ -3949,7 +3949,7 @@ void Fishing_UpdateFish(Actor* thisx, PlayState* play2) {
                 Audio_QueueSeqCmd(SEQ_PLAYER_BGM_MAIN << 24 | NA_BGM_HEART_GET | 0x900);
                 sFishingCaughtTextDelay = 40;
 
-                if (this->isLoach == 0 && !AllHyruleLoaches()) {
+                if (this->isLoach == 0) {
                     sFishLengthToWeigh = this->fishLength;
 
                     if (sFishLengthToWeigh >= 75) {
@@ -3996,13 +3996,13 @@ void Fishing_UpdateFish(Actor* thisx, PlayState* play2) {
                                 if (play->msgCtx.choiceIndex == 0) {
                                     if (sFishOnHandLength == 0.0f) {
                                         sFishOnHandLength = this->fishLength;
-                                        sFishOnHandIsLoach = (this->isLoach || AllHyruleLoaches());
+                                        sFishOnHandIsLoach = this->isLoach;
                                         sLureCaughtWith = sLureEquipped;
                                         if (IS_FISHSANITY) {
                                             sFishOnHandParams = this->fishsanityParams;
                                         }
                                         Actor_Kill(&this->actor);
-                                    } else if (getShouldConfirmKeep() && (this->isLoach == 0 && !AllHyruleLoaches()) && (sFishOnHandIsLoach == 0) &&
+                                    } else if (getShouldConfirmKeep() && (this->isLoach == 0) && (sFishOnHandIsLoach == 0) &&
                                                ((s16)this->fishLength < (s16)sFishOnHandLength)) {
                                         this->keepState = 1;
                                         this->timerArray[0] = 0x3C;
@@ -4064,7 +4064,7 @@ void Fishing_UpdateFish(Actor* thisx, PlayState* play2) {
                     this->unk_194 = 2000.0f;
                     SkelAnime_Free(&this->skelAnime, play);
 
-                    if (this->isLoach == 0 && !AllHyruleLoaches()) {
+                    if (this->isLoach == 0) {
                         SkelAnime_InitFlex(play, &this->skelAnime, &gFishingFishSkel, &gFishingFishAnim, 0, 0, 0);
                         Animation_MorphToLoop(&this->skelAnime, &gFishingFishAnim, 0.0f);
                     } else {
@@ -4400,7 +4400,7 @@ void Fishing_DrawFish(Actor* thisx, PlayState* play) {
     Matrix_RotateZ(((this->unk_164 + this->actor.shape.rot.z) / 32768.0f) * M_PI, MTXMODE_APPLY);
     Matrix_Scale(this->actor.scale.x, this->actor.scale.y, this->actor.scale.z, MTXMODE_APPLY);
 
-    if (this->isLoach == 0 && !AllHyruleLoaches()) {
+    if (this->isLoach == 0) {
         Matrix_RotateY((this->fishLimb23RotYDelta * (M_PI / 32768)) - (M_PI / 2), MTXMODE_APPLY);
         Matrix_Translate(0.0f, 0.0f, this->fishLimb23RotYDelta * 10.0f * 0.01f, MTXMODE_APPLY);
 


### PR DESCRIPTION
the previous all loaches logic required modifying every `isLoach` check throughout the file. this had the benefit of allowing live-toggling all fish to be loaches or not, but added a lot of complexity.

this changes the logic to just set `isLoach` on each fish instead, and updates the tooltip to note an area reload is required

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1899579494.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1899618573.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1899622586.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1899624118.zip)
<!--- section:artifacts:end -->