### PR TITLE
Remove erroneous Entrance_OverrideBlueWarp

### DIFF
--- a/soh/soh/Enhancements/TimeSavers/SkipCutscene/Story/SkipBlueWarp.cpp
+++ b/soh/soh/Enhancements/TimeSavers/SkipCutscene/Story/SkipBlueWarp.cpp
@@ -19,19 +19,19 @@ extern "C" {
  */
 void SkipBlueWarp_ShouldPlayTransitionCS(GIVanillaBehavior _, bool* should, void* opt) {
     if (CVarGetInteger(CVAR_ENHANCEMENT("TimeSavers.SkipCutscene.Story"), IS_RANDO)) {
-        uint8_t isBlueWarp = 0;
+        uint8_t isBlueWarpCutscene = 0;
         // Deku Tree Blue warp
         if (gSaveContext.entranceIndex == ENTR_KOKIRI_FOREST_0 && gSaveContext.cutsceneIndex == 0xFFF1) {
             gSaveContext.entranceIndex = ENTR_KOKIRI_FOREST_11;
-            isBlueWarp = 1;
+            isBlueWarpCutscene = 1;
         // Dodongo's Cavern Blue warp
         } else if (gSaveContext.entranceIndex == ENTR_DEATH_MOUNTAIN_TRAIL_0 && gSaveContext.cutsceneIndex == 0xFFF1) {
             gSaveContext.entranceIndex = ENTR_DEATH_MOUNTAIN_TRAIL_5;
-            isBlueWarp = 1;
+            isBlueWarpCutscene = 1;
         // Jabu Jabu's Blue warp
         } else if (gSaveContext.entranceIndex == ENTR_ZORAS_FOUNTAIN_0 && gSaveContext.cutsceneIndex == 0xFFF0) {
             gSaveContext.entranceIndex = ENTR_ZORAS_FOUNTAIN_0;
-            isBlueWarp = 1;
+            isBlueWarpCutscene = 1;
         // Forest Temple Blue warp
         } else if (gSaveContext.entranceIndex == ENTR_CHAMBER_OF_THE_SAGES_0 && gSaveContext.cutsceneIndex == 0x0 && gSaveContext.chamberCutsceneNum == CHAMBER_CS_FOREST) {
             // Normally set in the blue warp cutscene
@@ -43,14 +43,14 @@ void SkipBlueWarp_ShouldPlayTransitionCS(GIVanillaBehavior _, bool* should, void
                 gSaveContext.entranceIndex = ENTR_KOKIRI_FOREST_12;
             }
 
-            isBlueWarp = 1;
+            isBlueWarpCutscene = 1;
         // Fire Temple Blue warp
         } else if (gSaveContext.entranceIndex == ENTR_KAKARIKO_VILLAGE_0 && gSaveContext.cutsceneIndex == 0xFFF3) {
             // Normally set in the blue warp cutscene
             Flags_SetEventChkInf(EVENTCHKINF_DEATH_MOUNTAIN_ERUPTED);
 
             gSaveContext.entranceIndex = ENTR_DEATH_MOUNTAIN_CRATER_5;
-            isBlueWarp = 1;
+            isBlueWarpCutscene = 1;
         // Water Temple Blue warp
         } else if (gSaveContext.entranceIndex == ENTR_CHAMBER_OF_THE_SAGES_0 && gSaveContext.cutsceneIndex == 0x0 && gSaveContext.chamberCutsceneNum == CHAMBER_CS_WATER) {
             // Normally set in the blue warp cutscene
@@ -58,18 +58,18 @@ void SkipBlueWarp_ShouldPlayTransitionCS(GIVanillaBehavior _, bool* should, void
             Flags_SetEventChkInf(EVENTCHKINF_RAISED_LAKE_HYLIA_WATER);
 
             gSaveContext.entranceIndex = ENTR_LAKE_HYLIA_9;
-            isBlueWarp = 1;
+            isBlueWarpCutscene = 1;
         // Spirit Temple Blue warp
         } else if (gSaveContext.entranceIndex == ENTR_CHAMBER_OF_THE_SAGES_0 && gSaveContext.cutsceneIndex == 0x0 && gSaveContext.chamberCutsceneNum == CHAMBER_CS_SPIRIT) {
             gSaveContext.entranceIndex = ENTR_DESERT_COLOSSUS_8;
-            isBlueWarp = 1;
+            isBlueWarpCutscene = 1;
         // Shadow Temple Blue warp
         } else if (gSaveContext.entranceIndex == ENTR_CHAMBER_OF_THE_SAGES_0 && gSaveContext.cutsceneIndex == 0x0 && gSaveContext.chamberCutsceneNum == CHAMBER_CS_SHADOW) {
             gSaveContext.entranceIndex = ENTR_GRAVEYARD_8;
-            isBlueWarp = 1;
+            isBlueWarpCutscene = 1;
         }
 
-        if (isBlueWarp) {
+        if (isBlueWarpCutscene) {
             if (gSaveContext.entranceIndex != ENTR_LAKE_HYLIA_9) {
                 // Normally set in the blue warp cutscene
                 gSaveContext.dayTime = gSaveContext.skyboxTime = 0x8000;
@@ -77,10 +77,11 @@ void SkipBlueWarp_ShouldPlayTransitionCS(GIVanillaBehavior _, bool* should, void
 
             *should = false;
             gSaveContext.cutsceneIndex = 0;
+        }
 
-            if (IS_RANDO && (RAND_GET_OPTION(RSK_SHUFFLE_DUNGEON_ENTRANCES) != RO_DUNGEON_ENTRANCE_SHUFFLE_OFF || RAND_GET_OPTION(RSK_SHUFFLE_BOSS_ENTRANCES) != RO_BOSS_ROOM_ENTRANCE_SHUFFLE_OFF)) {
-                Entrance_OverrideBlueWarp();
-            }
+        // This is outside the above condition because we want to handle both first and following visits to the blue warp
+        if (IS_RANDO && (RAND_GET_OPTION(RSK_SHUFFLE_DUNGEON_ENTRANCES) != RO_DUNGEON_ENTRANCE_SHUFFLE_OFF || RAND_GET_OPTION(RSK_SHUFFLE_BOSS_ENTRANCES) != RO_BOSS_ROOM_ENTRANCE_SHUFFLE_OFF)) {
+            Entrance_OverrideBlueWarp();
         }
     }
 }

--- a/soh/src/overlays/actors/ovl_Door_Warp1/z_door_warp1.c
+++ b/soh/src/overlays/actors/ovl_Door_Warp1/z_door_warp1.c
@@ -557,11 +557,6 @@ void DoorWarp1_ChildWarpOut(DoorWarp1* this, PlayState* play) {
             gSaveContext.nextCutsceneIndex = 0;
         }
 
-        if (IS_RANDO && (Randomizer_GetSettingValue(RSK_SHUFFLE_DUNGEON_ENTRANCES) != RO_DUNGEON_ENTRANCE_SHUFFLE_OFF ||
-            Randomizer_GetSettingValue(RSK_SHUFFLE_BOSS_ENTRANCES) != RO_BOSS_ROOM_ENTRANCE_SHUFFLE_OFF)) {
-            Entrance_OverrideBlueWarp();
-        }
-
         osSyncPrintf("\n\n\nおわりおわり");
         play->transitionTrigger = TRANS_TRIGGER_START;
         play->transitionType = TRANS_TYPE_FADE_WHITE_SLOW;
@@ -653,11 +648,6 @@ void DoorWarp1_RutoWarpOut(DoorWarp1* this, PlayState* play) {
             gSaveContext.nextCutsceneIndex = 0xFFF0;
         }
         play->nextEntranceIndex = ENTR_ZORAS_FOUNTAIN_0;
-
-        if (IS_RANDO && (Randomizer_GetSettingValue(RSK_SHUFFLE_DUNGEON_ENTRANCES) != RO_DUNGEON_ENTRANCE_SHUFFLE_OFF ||
-            Randomizer_GetSettingValue(RSK_SHUFFLE_BOSS_ENTRANCES) != RO_BOSS_ROOM_ENTRANCE_SHUFFLE_OFF)) {
-            Entrance_OverrideBlueWarp();
-        }
 
         play->transitionTrigger = TRANS_TRIGGER_START;
         play->transitionType = TRANS_TYPE_FADE_WHITE_SLOW;
@@ -845,11 +835,6 @@ void DoorWarp1_AdultWarpOut(DoorWarp1* this, PlayState* play) {
                 }
                 gSaveContext.nextCutsceneIndex = 0;
             }
-        }
-
-        if (IS_RANDO && (Randomizer_GetSettingValue(RSK_SHUFFLE_DUNGEON_ENTRANCES) != RO_DUNGEON_ENTRANCE_SHUFFLE_OFF ||
-            Randomizer_GetSettingValue(RSK_SHUFFLE_BOSS_ENTRANCES) != RO_BOSS_ROOM_ENTRANCE_SHUFFLE_OFF)) {
-            Entrance_OverrideBlueWarp();
         }
 
         play->transitionTrigger = TRANS_TRIGGER_START;


### PR DESCRIPTION
These should have been removed in the original VB branch, as the override was moved to `TimeSavers/SkipCutscene/Story/SkipBlueWarp.cpp`

This seems to resolve invalid blue warps happening in entrance rando

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1943373498.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1943463435.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1943472292.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1943480151.zip)
<!--- section:artifacts:end -->