### PR TITLE
Fix Deku Mouth for Entrance Rando and Mido Rando Functionality

### DIFF
--- a/soh/soh/Enhancements/game-interactor/GameInteractor.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor.h
@@ -78,6 +78,8 @@ typedef enum {
     // Vanilla condition: INFTABLE_GREETED_BY_SARIA
     VB_NOT_BE_GREETED_BY_SARIA,
     // Opt: *EnMd
+    VB_MIDO_SPAWN,
+    // Opt: *EnMd
     // Vanilla condition: EnMd->interactInfo.talkState == NPC_TALK_STATE_ACTION
     VB_MOVE_MIDO_IN_KOKIRI_FOREST,
     // Opt: *EnMd

--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -615,6 +615,11 @@ void RandomizerOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, void
         case VB_BE_ELIGIBLE_FOR_PRELUDE_OF_LIGHT:
             *should = !Flags_GetEventChkInf(EVENTCHKINF_LEARNED_PRELUDE_OF_LIGHT) && CHECK_QUEST_ITEM(QUEST_MEDALLION_FOREST);
             break;
+        case VB_MIDO_SPAWN:
+            if (RAND_GET_OPTION(RSK_FOREST) != RO_FOREST_OPEN && !Flags_GetEventChkInf(EVENTCHKINF_SHOWED_MIDO_SWORD_SHIELD)) {
+                *should = true;
+            }
+            break;
         case VB_MOVE_MIDO_IN_KOKIRI_FOREST:
             if (RAND_GET_OPTION(RSK_FOREST) == RO_FOREST_OPEN) {
                 *should = true;

--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -12,6 +12,7 @@ extern "C" {
 #include "functions.h"
 #include "variables.h"
 #include "soh/Enhancements/randomizer/adult_trade_shuffle.h"
+#include "src/overlays/actors/ovl_Bg_Treemouth/z_bg_treemouth.h"
 #include "src/overlays/actors/ovl_En_Si/z_en_si.h"
 #include "src/overlays/actors/ovl_En_Cow/z_en_cow.h"
 #include "src/overlays/actors/ovl_En_Shopnuts/z_en_shopnuts.h"
@@ -1463,6 +1464,14 @@ void RandomizerOnActorInitHandler(void* actorRef) {
         if (CompletedAllTrials()) {
             Actor_Kill(actor);
         }
+    }
+
+    if (actor->id == ACTOR_BG_TREEMOUTH && LINK_IS_ADULT && IS_RANDO &&
+        OTRGlobals::Instance->gRandoContext->GetOption(RSK_SHUFFLE_DUNGEON_ENTRANCES).GetSelectedOptionIndex() != RO_DUNGEON_ENTRANCE_SHUFFLE_OFF &&
+        (OTRGlobals::Instance->gRandoContext->GetOption(RSK_FOREST).GetSelectedOptionIndex() == RO_FOREST_OPEN || 
+            Flags_GetEventChkInf(EVENTCHKINF_SHOWED_MIDO_SWORD_SHIELD))) {
+        BgTreemouth* bgTreemouth = static_cast<BgTreemouth*>(actorRef);
+        bgTreemouth->unk_168 = 1.0f;
     }
 
     //consumable bags

--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -1471,9 +1471,9 @@ void RandomizerOnActorInitHandler(void* actorRef) {
         }
     }
 
-    if (actor->id == ACTOR_BG_TREEMOUTH && LINK_IS_ADULT && IS_RANDO &&
-        OTRGlobals::Instance->gRandoContext->GetOption(RSK_SHUFFLE_DUNGEON_ENTRANCES).GetSelectedOptionIndex() != RO_DUNGEON_ENTRANCE_SHUFFLE_OFF &&
-        (OTRGlobals::Instance->gRandoContext->GetOption(RSK_FOREST).GetSelectedOptionIndex() == RO_FOREST_OPEN || 
+    if (actor->id == ACTOR_BG_TREEMOUTH && LINK_IS_ADULT &&
+        RAND_GET_OPTION(RSK_SHUFFLE_DUNGEON_ENTRANCES) != RO_DUNGEON_ENTRANCE_SHUFFLE_OFF &&
+        (RAND_GET_OPTION(RSK_FOREST) == RO_FOREST_OPEN ||
             Flags_GetEventChkInf(EVENTCHKINF_SHOWED_MIDO_SWORD_SHIELD))) {
         BgTreemouth* bgTreemouth = static_cast<BgTreemouth*>(actorRef);
         bgTreemouth->unk_168 = 1.0f;

--- a/soh/src/overlays/actors/ovl_En_Md/z_en_md.c
+++ b/soh/src/overlays/actors/ovl_En_Md/z_en_md.c
@@ -646,7 +646,7 @@ void EnMd_Init(Actor* thisx, PlayState* play) {
     Collider_InitCylinder(play, &this->collider);
     Collider_SetCylinder(play, &this->collider, &this->actor, &sCylinderInit);
     CollisionCheck_SetInfo2(&this->actor.colChkInfo, NULL, &sColChkInfoInit);
-    if (!EnMd_ShouldSpawn(this, play)) {
+    if (!GameInteractor_Should(VB_MIDO_SPAWN, EnMd_ShouldSpawn(this, play), this)) {
         Actor_Kill(&this->actor);
         return;
     }


### PR DESCRIPTION
Restores open Deku mouth for adult in dungeon entrance shuffle. Based on either forest being open or the flag for having shown Mido the sword and shield.

Also restores Rando Mido functionality (if starting with closed Deku or Forest and Skip Child Zelda, Mido would be in his house and you couldn't flip the flag for showing him the sword and sheild. Would have messed with Deku mouth as adult).

Vanilla and VB functionality appear to be untouched.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1934108778.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1934128266.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1934129201.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1934129496.zip)
<!--- section:artifacts:end -->