### PR TITLE
Remove a return 0 that stops me building.

### DIFF
--- a/soh/src/overlays/actors/ovl_En_Kz/z_en_kz.c
+++ b/soh/src/overlays/actors/ovl_En_Kz/z_en_kz.c
@@ -280,7 +280,7 @@ void func_80A9CB18(EnKz* this, PlayState* play) {
         yaw -= this->actor.shape.rot.y;
         if ((fabsf(yaw) > 1638.0f) || (this->actor.xzDistToPlayer < 265.0f)) {
             this->actor.flags &= ~ACTOR_FLAG_TARGETABLE;
-            return 0;
+            return;
         }
 
         this->actor.flags |= ACTOR_FLAG_TARGETABLE;


### PR DESCRIPTION
My compiler is sensitive like that. early eyeball still works.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1943159967.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1943253683.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1943256552.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1943294024.zip)
<!--- section:artifacts:end -->