### PR TITLE
Clean `__osMalloc.c`

### DIFF
--- a/soh/include/functions.h
+++ b/soh/include/functions.h
@@ -2294,7 +2294,7 @@ void* __osReallocDebug(Arena* arena, void* ptr, size_t newSize, const char* file
 void ArenaImpl_GetSizes(Arena* arena, u32* outMaxFree, u32* outFree, u32* outAlloc);
 void __osDisplayArena(Arena* arena);
 void ArenaImpl_FaultClient(Arena* arena);
-u32 __osCheckArena(Arena* arena);
+s32 __osCheckArena(Arena* arena);
 u8 func_800FF334(Arena* arena);
 s32 PrintUtils_VPrintf(PrintCallback* pfn, const char* fmt, va_list args);
 s32 PrintUtils_Printf(PrintCallback* pfn, const char* fmt, ...);

--- a/soh/include/functions.h
+++ b/soh/include/functions.h
@@ -2277,7 +2277,7 @@ void __osMallocInit(Arena* arena, void* start, size_t size);
 void __osMallocAddBlock(Arena* arena, void* start, ptrdiff_t size);
 void ArenaImpl_RemoveAllBlocks(Arena* arena);
 void __osMallocCleanup(Arena* arena);
-u8 __osMallocIsInitalized(Arena* arena);
+s32 __osMallocIsInitialized(Arena* arena);
 void __osMalloc_FreeBlockTest(Arena* arena, ArenaNode* node);
 void* __osMalloc_NoLockDebug(Arena* arena, size_t size, const char* file, s32 line);
 void* __osMallocDebug(Arena* arena, size_t size, const char* file, s32 line);
@@ -2418,7 +2418,10 @@ OSThread* __osGetCurrFaultedThread(void);
 u32* osViGetCurrentFramebuffer(void);
 s32 __osSpSetPc(void* pc);
 f32 absf(f32);
-void* func_801068B0(void* dst, void* src, size_t size);
+#ifndef __cplusplus
+void* oot_memmove(void* dest, const void* src, size_t len);
+#define memmove oot_memmove
+#endif
 void Message_UpdateOcarinaGame(PlayState* play);
 u8 Message_ShouldAdvance(PlayState* play);
 u8 Message_ShouldAdvanceSilent(PlayState* play);

--- a/soh/include/functions.h
+++ b/soh/include/functions.h
@@ -2418,10 +2418,7 @@ OSThread* __osGetCurrFaultedThread(void);
 u32* osViGetCurrentFramebuffer(void);
 s32 __osSpSetPc(void* pc);
 f32 absf(f32);
-#ifndef __cplusplus
 void* oot_memmove(void* dest, const void* src, size_t len);
-#define memmove oot_memmove
-#endif
 void Message_UpdateOcarinaGame(PlayState* play);
 u8 Message_ShouldAdvance(PlayState* play);
 u8 Message_ShouldAdvanceSilent(PlayState* play);

--- a/soh/include/z64.h
+++ b/soh/include/z64.h
@@ -2035,13 +2035,13 @@ typedef struct ArenaNode {
     /* 0x04 */ size_t size;
     /* 0x08 */ struct ArenaNode* next;
     /* 0x0C */ struct ArenaNode* prev;
-    ///* 0x10 */ const char* filename;
-    ///* 0x14 */ s32 line;
-    ///* 0x18 */ OSId threadId;
-    ///* 0x1C */ Arena* arena;
-    ///* 0x20 */ OSTime time;
-    ///* 0x28 */ u8 unk_28[0x30-0x28]; // probably padding
-} ArenaNode; // size = 0x10
+    //* 0x10 */ const char* filename;
+    //* 0x14 */ s32 line;
+    //* 0x18 */ OSId threadId;
+    //* 0x1C */ Arena* arena;
+    //* 0x20 */ OSTime time;
+    //* 0x28 */ u8 unk_28[0x30-0x28]; // probably padding
+} ArenaNode; // size = 0x30
 
 typedef struct OverlayRelocationSection {
     /* 0x00 */ u32 textSize;

--- a/soh/include/z64.h
+++ b/soh/include/z64.h
@@ -2035,12 +2035,12 @@ typedef struct ArenaNode {
     /* 0x04 */ size_t size;
     /* 0x08 */ struct ArenaNode* next;
     /* 0x0C */ struct ArenaNode* prev;
-    //* 0x10 */ const char* filename;
-    //* 0x14 */ s32 line;
-    //* 0x18 */ OSId threadId;
-    //* 0x1C */ Arena* arena;
-    //* 0x20 */ OSTime time;
-    //* 0x28 */ u8 unk_28[0x30-0x28]; // probably padding
+    // /* 0x10 */ const char* filename;
+    // /* 0x14 */ s32 line;
+    // /* 0x18 */ OSId threadId;
+    // /* 0x1C */ Arena* arena;
+    // /* 0x20 */ OSTime time;
+    // /* 0x28 */ u8 unk_28[0x30-0x28]; // probably padding
 } ArenaNode; // size = 0x30
 
 typedef struct OverlayRelocationSection {

--- a/soh/src/code/__osMalloc.c
+++ b/soh/src/code/__osMalloc.c
@@ -3,18 +3,18 @@
 
 #include <string.h>
 
-#define FILL_ALLOCBLOCK (1 << 0)
-#define FILL_FREEBLOCK (1 << 1)
-#define CHECK_FREE_BLOCK (1 << 2)
+#define FILL_ALLOC_BLOCK_FLAG (1 << 0)
+#define FILL_FREE_BLOCK_FLAG (1 << 1)
+#define CHECK_FREE_BLOCK_FLAG (1 << 2)
 
-#define NODE_MAGIC (0x7373)
+#define NODE_MAGIC 0x7373
 
-#define BLOCK_UNINIT_MAGIC (0xAB)
-#define BLOCK_UNINIT_MAGIC_32 (0xABABABAB)
-#define BLOCK_ALLOC_MAGIC (0xCD)
-#define BLOCK_ALLOC_MAGIC_32 (0xCDCDCDCD)
-#define BLOCK_FREE_MAGIC (0xEF)
-#define BLOCK_FREE_MAGIC_32 (0xEFEFEFEF)
+#define BLOCK_UNINIT_MAGIC 0xAB
+#define BLOCK_UNINIT_MAGIC_32 0xABABABAB
+#define BLOCK_ALLOC_MAGIC 0xCD
+#define BLOCK_ALLOC_MAGIC_32 0xCDCDCDCD
+#define BLOCK_FREE_MAGIC 0xEF
+#define BLOCK_FREE_MAGIC_32 0xEFEFEFEF
 
 #define NODE_IS_VALID(node) (((node) != NULL) && ((node)->magic == NODE_MAGIC))
 
@@ -22,33 +22,33 @@ OSMesg sArenaLockMsg;
 u32 __osMalloc_FreeBlockTest_Enable;
 
 u32 ArenaImpl_GetFillAllocBlock(Arena* arena) {
-    return (arena->flag & FILL_ALLOCBLOCK) != 0;
+    return (arena->flag & FILL_ALLOC_BLOCK_FLAG) != 0;
 }
 u32 ArenaImpl_GetFillFreeBlock(Arena* arena) {
-    return (arena->flag & FILL_FREEBLOCK) != 0;
+    return (arena->flag & FILL_FREE_BLOCK_FLAG) != 0;
 }
 u32 ArenaImpl_GetCheckFreeBlock(Arena* arena) {
-    return (arena->flag & CHECK_FREE_BLOCK) != 0;
+    return (arena->flag & CHECK_FREE_BLOCK_FLAG) != 0;
 }
 
 void ArenaImpl_SetFillAllocBlock(Arena* arena) {
-    arena->flag |= FILL_ALLOCBLOCK;
+    arena->flag |= FILL_ALLOC_BLOCK_FLAG;
 }
 void ArenaImpl_SetFillFreeBlock(Arena* arena) {
-    arena->flag |= FILL_FREEBLOCK;
+    arena->flag |= FILL_FREE_BLOCK_FLAG;
 }
 void ArenaImpl_SetCheckFreeBlock(Arena* arena) {
-    arena->flag |= CHECK_FREE_BLOCK;
+    arena->flag |= CHECK_FREE_BLOCK_FLAG;
 }
 
 void ArenaImpl_UnsetFillAllocBlock(Arena* arena) {
-    arena->flag &= ~FILL_ALLOCBLOCK;
+    arena->flag &= ~FILL_ALLOC_BLOCK_FLAG;
 }
 void ArenaImpl_UnsetFillFreeBlock(Arena* arena) {
-    arena->flag &= ~FILL_FREEBLOCK;
+    arena->flag &= ~FILL_FREE_BLOCK_FLAG;
 }
 void ArenaImpl_UnsetCheckFreeBlock(Arena* arena) {
-    arena->flag &= ~CHECK_FREE_BLOCK;
+    arena->flag &= ~CHECK_FREE_BLOCK_FLAG;
 }
 
 void ArenaImpl_SetDebugInfo(ArenaNode* node, const char* file, s32 line, Arena* arena) {
@@ -210,7 +210,7 @@ void* __osMalloc_NoLockDebug(Arena* arena, size_t size, const char* file, s32 li
 
     while (iter != NULL) {
         if (iter->isFree && iter->size >= size) {
-            if (arena->flag & CHECK_FREE_BLOCK) {
+            if (arena->flag & CHECK_FREE_BLOCK_FLAG) {
                 __osMalloc_FreeBlockTest(arena, iter);
             }
 
@@ -233,7 +233,7 @@ void* __osMalloc_NoLockDebug(Arena* arena, size_t size, const char* file, s32 li
             iter->isFree = false;
             ArenaImpl_SetDebugInfo(iter, file, line, arena);
             alloc = (void*)((uintptr_t)iter + sizeof(ArenaNode));
-            if (arena->flag & FILL_ALLOCBLOCK) {
+            if (arena->flag & FILL_ALLOC_BLOCK_FLAG) {
                 memset(alloc, BLOCK_ALLOC_MAGIC, size);
             }
 
@@ -269,7 +269,7 @@ void* __osMallocRDebug(Arena* arena, size_t size, const char* file, s32 line) {
 
     while (iter != NULL) {
         if (iter->isFree && iter->size >= size) {
-            if (arena->flag & CHECK_FREE_BLOCK) {
+            if (arena->flag & CHECK_FREE_BLOCK_FLAG) {
                 __osMalloc_FreeBlockTest(arena, iter);
             }
 
@@ -293,7 +293,7 @@ void* __osMallocRDebug(Arena* arena, size_t size, const char* file, s32 line) {
             iter->isFree = false;
             ArenaImpl_SetDebugInfo(iter, file, line, arena);
             allocR = (void*)((uintptr_t)iter + sizeof(ArenaNode));
-            if (arena->flag & FILL_ALLOCBLOCK) {
+            if (arena->flag & FILL_ALLOC_BLOCK_FLAG) {
                 memset(allocR, BLOCK_ALLOC_MAGIC, size);
             }
 
@@ -321,7 +321,7 @@ void* __osMalloc_NoLock(Arena* arena, size_t size) {
     while (iter != NULL) {
 
         if (iter->isFree && iter->size >= size) {
-            if (arena->flag & CHECK_FREE_BLOCK) {
+            if (arena->flag & CHECK_FREE_BLOCK_FLAG) {
                 __osMalloc_FreeBlockTest(arena, iter);
             }
 
@@ -344,7 +344,7 @@ void* __osMalloc_NoLock(Arena* arena, size_t size) {
             iter->isFree = false;
             ArenaImpl_SetDebugInfo(iter, NULL, 0, arena);
             alloc = (void*)((uintptr_t)iter + sizeof(ArenaNode));
-            if (arena->flag & FILL_ALLOCBLOCK) {
+            if (arena->flag & FILL_ALLOC_BLOCK_FLAG) {
                 memset(alloc, BLOCK_ALLOC_MAGIC, size);
             }
             break;
@@ -379,7 +379,7 @@ void* __osMallocR(Arena* arena, size_t size) {
 
     while (iter != NULL) {
         if (iter->isFree && iter->size >= size) {
-            if (arena->flag & CHECK_FREE_BLOCK) {
+            if (arena->flag & CHECK_FREE_BLOCK_FLAG) {
                 __osMalloc_FreeBlockTest(arena, iter);
             }
 
@@ -403,7 +403,7 @@ void* __osMallocR(Arena* arena, size_t size) {
             iter->isFree = false;
             ArenaImpl_SetDebugInfo(iter, NULL, 0, arena);
             alloc = (void*)((uintptr_t)iter + sizeof(ArenaNode));
-            if (arena->flag & FILL_ALLOCBLOCK) {
+            if (arena->flag & FILL_ALLOC_BLOCK_FLAG) {
                 memset(alloc, BLOCK_ALLOC_MAGIC, size);
             }
             break;
@@ -450,7 +450,7 @@ void __osFree_NoLock(Arena* arena, void* ptr) {
     node->isFree = true;
     ArenaImpl_SetDebugInfo(node, NULL, 0, arena);
 
-    if (arena->flag & FILL_FREEBLOCK) {
+    if (arena->flag & FILL_FREE_BLOCK_FLAG) {
         memset((uintptr_t)node + sizeof(ArenaNode), BLOCK_FREE_MAGIC, node->size);
     }
 
@@ -462,7 +462,7 @@ void __osFree_NoLock(Arena* arena, void* ptr) {
         }
 
         node->size += next->size + sizeof(ArenaNode);
-        if (arena->flag & FILL_FREEBLOCK) {
+        if (arena->flag & FILL_FREE_BLOCK_FLAG) {
             memset(next, BLOCK_FREE_MAGIC, sizeof(ArenaNode));
         }
         node->next = newNext;
@@ -475,7 +475,7 @@ void __osFree_NoLock(Arena* arena, void* ptr) {
         }
         prev->next = next;
         prev->size += node->size + sizeof(ArenaNode);
-        if (arena->flag & FILL_FREEBLOCK) {
+        if (arena->flag & FILL_FREE_BLOCK_FLAG) {
             memset(node, BLOCK_FREE_MAGIC, sizeof(ArenaNode));
         }
     }
@@ -523,7 +523,7 @@ void __osFree_NoLockDebug(Arena* arena, void* ptr, const char* file, s32 line) {
     node->isFree = true;
     ArenaImpl_SetDebugInfo(node, file, line, arena);
 
-    if (arena->flag & FILL_FREEBLOCK) {
+    if (arena->flag & FILL_FREE_BLOCK_FLAG) {
         memset((uintptr_t)node + sizeof(ArenaNode), BLOCK_FREE_MAGIC, node->size);
     }
 
@@ -535,7 +535,7 @@ void __osFree_NoLockDebug(Arena* arena, void* ptr, const char* file, s32 line) {
         }
 
         node->size += next->size + sizeof(ArenaNode);
-        if (arena->flag & FILL_FREEBLOCK) {
+        if (arena->flag & FILL_FREE_BLOCK_FLAG) {
             memset(next, BLOCK_FREE_MAGIC, sizeof(ArenaNode));
         }
         node->next = newNext;
@@ -548,7 +548,7 @@ void __osFree_NoLockDebug(Arena* arena, void* ptr, const char* file, s32 line) {
         }
         prev->next = next;
         prev->size += node->size + sizeof(ArenaNode);
-        if (arena->flag & FILL_FREEBLOCK) {
+        if (arena->flag & FILL_FREE_BLOCK_FLAG) {
             memset(node, BLOCK_FREE_MAGIC, sizeof(ArenaNode));
         }
     }

--- a/soh/src/code/__osMalloc.c
+++ b/soh/src/code/__osMalloc.c
@@ -21,6 +21,28 @@
 #define NODE_GET_NEXT(node) ArenaImpl_GetNextBlock(node)
 #define NODE_GET_PREV(node) ArenaImpl_GetPrevBlock(node)
 
+#define SET_DEBUG_INFO(node, file, line, arena) ArenaImpl_SetDebugInfo(node, file, line, arena)
+
+#define FILL_UNINIT_BLOCK(arena, node, size) memset(node, BLOCK_UNINIT_MAGIC, size)
+
+#define FILL_ALLOC_BLOCK(arena, alloc, size)   \
+    if ((arena)->flag & FILL_ALLOC_BLOCK_FLAG) \
+    memset(alloc, BLOCK_ALLOC_MAGIC, size)
+
+#define FILL_FREE_BLOCK_HEADER(arena, node)   \
+    if ((arena)->flag & FILL_FREE_BLOCK_FLAG) \
+    memset(node, BLOCK_FREE_MAGIC, sizeof(ArenaNode))
+
+#define FILL_FREE_BLOCK_CONTENTS(arena, node) \
+    if ((arena)->flag & FILL_FREE_BLOCK_FLAG) \
+    memset((void*)((u32)(node) + sizeof(ArenaNode)), BLOCK_FREE_MAGIC, (node)->size)
+
+#define CHECK_FREE_BLOCK(arena, node)          \
+    if ((arena)->flag & CHECK_FREE_BLOCK_FLAG) \
+    __osMalloc_FreeBlockTest(arena, node)
+
+#define CHECK_ALLOC_FAILURE(arena, ptr) (void)0
+
 OSMesg sArenaLockMsg;
 u32 __osMalloc_FreeBlockTest_Enable;
 

--- a/soh/src/code/__osMalloc.c
+++ b/soh/src/code/__osMalloc.c
@@ -49,15 +49,16 @@ void ArenaImpl_UnsetCheckFreeBlock(Arena* arena) {
     arena->flag &= ~CHECK_FREE_BLOCK;
 }
 
-#if 0
 void ArenaImpl_SetDebugInfo(ArenaNode* node, const char* file, s32 line, Arena* arena) {
+    /*
     node->filename = file;
     node->line = line;
     node->threadId = osGetThreadId(NULL);
     node->arena = arena;
     node->time = osGetTime();
+    */
 }
-#endif
+
 void ArenaImpl_LockInit(Arena* arena) {
     osCreateMesgQueue(&arena->lock, &sArenaLockMsg, 1);
 }
@@ -228,7 +229,7 @@ void* __osMalloc_NoLockDebug(Arena* arena, size_t size, const char* file, s32 li
             }
 
             iter->isFree = false;
-            //ArenaImpl_SetDebugInfo(iter, file, line, arena);
+            ArenaImpl_SetDebugInfo(iter, file, line, arena);
             alloc = (void*)((uintptr_t)iter + sizeof(ArenaNode));
             if (arena->flag & FILL_ALLOCBLOCK) {
                 memset(alloc, BLOCK_ALLOC_MAGIC, size);
@@ -288,7 +289,7 @@ void* __osMallocRDebug(Arena* arena, size_t size, const char* file, s32 line) {
             }
 
             iter->isFree = false;
-            //ArenaImpl_SetDebugInfo(iter, file, line, arena);
+            ArenaImpl_SetDebugInfo(iter, file, line, arena);
             allocR = (void*)((uintptr_t)iter + sizeof(ArenaNode));
             if (arena->flag & FILL_ALLOCBLOCK) {
                 memset(allocR, BLOCK_ALLOC_MAGIC, size);
@@ -339,7 +340,7 @@ void* __osMalloc_NoLock(Arena* arena, size_t size) {
             }
 
             iter->isFree = false;
-            //ArenaImpl_SetDebugInfo(iter, NULL, 0, arena);
+            ArenaImpl_SetDebugInfo(iter, NULL, 0, arena);
             alloc = (void*)((uintptr_t)iter + sizeof(ArenaNode));
             if (arena->flag & FILL_ALLOCBLOCK) {
                 memset(alloc, BLOCK_ALLOC_MAGIC, size);
@@ -398,7 +399,7 @@ void* __osMallocR(Arena* arena, size_t size) {
             }
 
             iter->isFree = false;
-            //ArenaImpl_SetDebugInfo(iter, NULL, 0, arena);
+            ArenaImpl_SetDebugInfo(iter, NULL, 0, arena);
             alloc = (void*)((uintptr_t)iter + sizeof(ArenaNode));
             if (arena->flag & FILL_ALLOCBLOCK) {
                 memset(alloc, BLOCK_ALLOC_MAGIC, size);
@@ -432,18 +433,20 @@ void __osFree_NoLock(Arena* arena, void* ptr) {
         osSyncPrintf(VT_COL(RED, WHITE) "__osFree:二重解放(%08x)\n" VT_RST, ptr); // "__osFree: Double release (%08x)"
         return;
     }
-    #if 0
+
+    /*
     if (arena != node->arena && arena != NULL) {
         // "__osFree:Tried to release in a different way than when it was secured (%08x:%08x)"
         osSyncPrintf(VT_COL(RED, WHITE) "__osFree:確保時と違う方法で解放しようとした (%08x:%08x)\n" VT_RST, arena,
                      node->arena);
         return;
     }
-#endif
+    */
+
     next = ArenaImpl_GetNextBlock(node);
     prev = ArenaImpl_GetPrevBlock(node);
     node->isFree = true;
-    //ArenaImpl_SetDebugInfo(node, NULL, 0, arena);
+    ArenaImpl_SetDebugInfo(node, NULL, 0, arena);
 
     if (arena->flag & FILL_FREEBLOCK) {
         memset((uintptr_t)node + sizeof(ArenaNode), BLOCK_FREE_MAGIC, node->size);
@@ -503,18 +506,20 @@ void __osFree_NoLockDebug(Arena* arena, void* ptr, const char* file, s32 line) {
         osSyncPrintf(VT_COL(RED, WHITE) "__osFree:二重解放(%08x) [%s:%d ]\n" VT_RST, ptr, file, line);
         return;
     }
-    #if 0
+
+    /*
     if (arena != node->arena && arena != NULL) {
         // "__osFree:Tried to release in a different way than when it was secured (%08x:%08x)"
         osSyncPrintf(VT_COL(RED, WHITE) "__osFree:確保時と違う方法で解放しようとした (%08x:%08x)\n" VT_RST, arena,
                      node->arena);
         return;
     }
-    #endif
+    */
+
     next = ArenaImpl_GetNextBlock(node);
     prev = ArenaImpl_GetPrevBlock(node);
     node->isFree = true;
-    //ArenaImpl_SetDebugInfo(node, file, line, arena);
+    ArenaImpl_SetDebugInfo(node, file, line, arena);
 
     if (arena->flag & FILL_FREEBLOCK) {
         memset((uintptr_t)node + sizeof(ArenaNode), BLOCK_FREE_MAGIC, node->size);
@@ -710,12 +715,14 @@ void __osDisplayArena(Arena* arena) {
                          (next == NULL) ? '$' : (iter != next->prev ? '!' : ' '),
                          iter->isFree ? "空き" : "確保", //? "Free" : "Secure"
                          iter->size);
-            #if 0
+
+            /*
             if (!iter->isFree) {
                 osSyncPrintf(" [%016llu:%2d:%s:%d]", OS_CYCLES_TO_NSEC(iter->time), iter->threadId,
                              iter->filename != NULL ? iter->filename : "**NULL**", iter->line);
             }
-            #endif
+            */
+
             osSyncPrintf("\n");
 
             if (iter->isFree) {

--- a/soh/src/code/__osMalloc.c
+++ b/soh/src/code/__osMalloc.c
@@ -9,6 +9,10 @@
 #define OOT_DEBUG 1
 // #endregion
 
+// #region SOH [General] We renamed OoT's memmove to prevent conflicts with the libc version
+#define memmove oot_memmove
+// #endregion
+
 #define FILL_ALLOC_BLOCK_FLAG (1 << 0)
 #define FILL_FREE_BLOCK_FLAG (1 << 1)
 #define CHECK_FREE_BLOCK_FLAG (1 << 2)
@@ -43,7 +47,7 @@
 
 #define FILL_FREE_BLOCK_CONTENTS(arena, node) \
     if ((arena)->flag & FILL_FREE_BLOCK_FLAG) \
-    memset((void*)((u32)(node) + sizeof(ArenaNode)), BLOCK_FREE_MAGIC, (node)->size)
+    memset((void*)((uintptr_t)(node) + sizeof(ArenaNode)), BLOCK_FREE_MAGIC, (node)->size)
 
 #define CHECK_FREE_BLOCK(arena, node)          \
     if ((arena)->flag & CHECK_FREE_BLOCK_FLAG) \
@@ -114,6 +118,7 @@ void ArenaImpl_UnsetCheckFreeBlock(Arena* arena) {
 }
 
 void ArenaImpl_SetDebugInfo(ArenaNode* node, const char* file, int line, Arena* arena) {
+    // Upstream TODO: Figure out why uncommenting this crashes
     /*
     node->filename = file;
     node->line = line;

--- a/soh/src/code/code_801068B0.c
+++ b/soh/src/code/code_801068B0.c
@@ -1,24 +1,33 @@
 #include "global.h"
 
-// memmove used in __osMalloc.c
-void* func_801068B0(void* dst, void* src, size_t size) {
-    u8* spC = dst;
-    u8* sp8 = src;
-    register s32 a3;
+/**
+ * memmove: copies `len` bytes from memory starting at `src` to memory starting at `dest`.
+ *
+ * Unlike memcpy(), the regions of memory may overlap.
+ *
+ * @param dest address of start of buffer to write to
+ * @param src address of start of buffer to read from
+ * @param len number of bytes to copy.
+ *
+ * @return dest
+ */
+void* oot_memmove(void* dest, const void* src, size_t len) {
+    char* d = dest;
+    const char* s = src;
 
-    if (spC == sp8) {
-        return dst;
+    if (d == s) {
+        return dest;
     }
-    if (spC < sp8) {
-        for (a3 = size--; a3 != 0; a3 = size--) {
-            *spC++ = *sp8++;
+    if (d < s) {
+        while (len--) {
+            *d++ = *s++;
         }
     } else {
-        spC += size - 1;
-        sp8 += size - 1;
-        for (a3 = size--; a3 != 0; a3 = size--) {
-            *spC-- = *sp8--;
+        d += len - 1;
+        s += len - 1;
+        while (len--) {
+            *d-- = *s--;
         }
     }
-    return dst;
+    return dest;
 }

--- a/soh/src/code/debug_malloc.c
+++ b/soh/src/code/debug_malloc.c
@@ -109,5 +109,5 @@ void DebugArena_Cleanup(void) {
 }
 
 u8 DebugArena_IsInitalized(void) {
-    return __osMallocIsInitalized(&sDebugArena);
+    return __osMallocIsInitialized(&sDebugArena);
 }

--- a/soh/src/code/system_malloc.c
+++ b/soh/src/code/system_malloc.c
@@ -107,5 +107,5 @@ void SystemArena_Cleanup(void) {
 }
 
 u8 SystemArena_IsInitalized(void) {
-    return __osMallocIsInitalized(&gSystemArena);
+    return __osMallocIsInitialized(&gSystemArena);
 }

--- a/soh/src/code/z_malloc.c
+++ b/soh/src/code/z_malloc.c
@@ -106,5 +106,5 @@ void ZeldaArena_Cleanup() {
 }
 
 u8 ZeldaArena_IsInitalized() {
-    return __osMallocIsInitalized(&sZeldaArena);
+    return __osMallocIsInitialized(&sZeldaArena);
 }


### PR DESCRIPTION
Cleans `__osMalloc.c` bringing it closer to decomp's `__osMalloc_gc.c`.
For some reason I can't add back the commented out debug data in `ArenaNode` or the game crashes; and, also don't really like what I had to do for `memmove` either.
Also didn't do any of the `T` macro stuff as that probably will need a PR to add it to the whole codebase.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2168694434.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2168715812.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2168716730.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2168719085.zip)
<!--- section:artifacts:end -->