### PR TITLE
[Bug Fix] Fix Equipment LOD not being disabled

### DIFF
--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -11892,6 +11892,10 @@ void Player_Draw(Actor* thisx, PlayState* play2) {
             lod = 1;
         }
 
+        if (CVarGetInteger(CVAR_ENHANCEMENT("DisableLOD"), 0)) {
+            lod = 0;
+        }
+
         func_80093C80(play);
         Gfx_SetupDL_25Xlu(play->state.gfxCtx);
 


### PR DESCRIPTION
Re-adds the code needed to be able to disable LOD for Links Equipment

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1950695856.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1950741282.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1950747543.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1950752081.zip)
<!--- section:artifacts:end -->