### PR TITLE
Fix crash when randomizer preset amount is too high

### DIFF
--- a/soh/soh/Enhancements/presets.cpp
+++ b/soh/soh/Enhancements/presets.cpp
@@ -42,7 +42,10 @@ void applyPreset(std::vector<PresetEntry> entries) {
 void DrawPresetSelector(PresetType presetTypeId) {
     const std::string presetTypeCvar = CVAR_GENERAL("SelectedPresets.") + std::to_string(presetTypeId);
     const PresetTypeDefinition presetTypeDef = presetTypes.at(presetTypeId);
-    const uint16_t selectedPresetId = CVarGetInteger(presetTypeCvar.c_str(), 0);
+    uint16_t selectedPresetId = CVarGetInteger(presetTypeCvar.c_str(), 0);
+    if(selectedPresetId >= presetTypeDef.presets.size()){
+        selectedPresetId = 0;
+    }
     const PresetDefinition selectedPresetDef = presetTypeDef.presets.at(selectedPresetId);
     std::string comboboxTooltip = "";
     for ( auto iter = presetTypeDef.presets.begin(); iter != presetTypeDef.presets.end(); ++iter ) {


### PR DESCRIPTION
Addresses #4357

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1960432457.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1960474793.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1960475193.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1960475679.zip)
<!--- section:artifacts:end -->