### PR TITLE
Apply Faster Block Push to Forest Basement Pillars

### DIFF
--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -579,8 +579,16 @@ void DrawEnhancementsMenu() {
                 UIWidgets::Tooltip("Holding down B skips text");
                 UIWidgets::PaddedEnhancementSliderInt("King Zora Speed: %dx", "##MWEEPSPEED", CVAR_ENHANCEMENT("MweepSpeed"), 1, 5, "", 1, true, false, true);
                 UIWidgets::PaddedEnhancementSliderInt("Vine/Ladder Climb speed +%d", "##CLIMBSPEED", CVAR_ENHANCEMENT("ClimbSpeed"), 0, 12, "", 0, true, false, true);
-                UIWidgets::PaddedEnhancementSliderInt("Block pushing speed +%d", "##BLOCKSPEED", CVAR_ENHANCEMENT("FasterBlockPush"), 0, 5, "", 0, true, false, true);
+                if (UIWidgets::PaddedEnhancementSliderInt("Block pushing speed +%d", "##BLOCKSPEED", CVAR_ENHANCEMENT("FasterBlockPush"), 0, 5, "", 0, true, false, true)) {
+                    if (!CVarGetInteger(CVAR_ENHANCEMENT("FasterBlockPush"), 0)) {
+                        CVarSetInteger(CVAR_ENHANCEMENT("FasterForestPillars"), 0);
+                    }
+                }
                 UIWidgets::PaddedEnhancementSliderInt("Crawl speed %dx", "##CRAWLSPEED", CVAR_ENHANCEMENT("CrawlSpeed"), 1, 4, "", 1, true, false, true);
+                if (CVarGetInteger(CVAR_ENHANCEMENT("FasterBlockPush"), 0)) {
+                    UIWidgets::PaddedEnhancementCheckbox("Faster Forest Basement Pillars", CVAR_ENHANCEMENT("FasterForestPillars"), false, false);
+                    UIWidgets::Tooltip("Applies the block push speed to the Forest Temple basement pillars and allows Link to move during the cutscene");
+                }
                 UIWidgets::PaddedEnhancementCheckbox("Faster Heavy Block Lift", CVAR_ENHANCEMENT("FasterHeavyBlockLift"), false, false);
                 UIWidgets::Tooltip("Speeds up lifting silver rocks and obelisks");
                 UIWidgets::PaddedEnhancementCheckbox("Skip Pickup Messages", CVAR_ENHANCEMENT("FastDrops"), true, false);

--- a/soh/src/overlays/actors/ovl_Bg_Mori_Kaitenkabe/z_bg_mori_kaitenkabe.c
+++ b/soh/src/overlays/actors/ovl_Bg_Mori_Kaitenkabe/z_bg_mori_kaitenkabe.c
@@ -99,6 +99,9 @@ void BgMoriKaitenkabe_Wait(BgMoriKaitenkabe* this, PlayState* play) {
             if ((this->timer > (28 - CVarGetInteger(CVAR_ENHANCEMENT("FasterBlockPush"), 0) * 4)) &&
                 !Player_InCsMode(play)) {
                 BgMoriKaitenkabe_SetupRotate(this);
+                if (!CVarGetInteger(CVAR_ENHANCEMENT("FasterForestPillars"), 0)) {
+                    func_8002DF54(play, &this->dyna.actor, 8);
+                }
                 Math_Vec3f_Copy(&this->lockedPlayerPos, &player->actor.world.pos);
                 push.x = Math_SinS(this->dyna.unk_158);
                 push.y = 0.0f;
@@ -147,7 +150,7 @@ void BgMoriKaitenkabe_Rotate(BgMoriKaitenkabe* this, PlayState* play) {
     s16 rotY;
 
     // #region SOH [Enhancement]
-    if (CVarGetInteger(CVAR_ENHANCEMENT("FasterBlockPush"), 0)) {
+    if (CVarGetInteger(CVAR_ENHANCEMENT("FasterForestPillars"), 0)) {
         Math_StepToF(&this->rotSpeed, 0.6f * CVarGetInteger(CVAR_ENHANCEMENT("FasterBlockPush"), 0),
                      0.02f * CVarGetInteger(CVAR_ENHANCEMENT("FasterBlockPush"), 0) * 10);
         if (Math_StepToF(&this->rotYdeg, this->rotDirection * 45.0f, this->rotSpeed)) {
@@ -167,6 +170,9 @@ void BgMoriKaitenkabe_Rotate(BgMoriKaitenkabe* this, PlayState* play) {
         if (fabsf(this->dyna.unk_150) > 0.001f) {
             this->dyna.unk_150 = 0.0f;
             player->stateFlags2 &= ~PLAYER_STATE2_MOVING_DYNAPOLY;
+        }
+        if (Player_InCsMode(play)) {
+            func_8002DF54(play, thisx, 7);
         }
         // #endregion
     } else {

--- a/soh/src/overlays/actors/ovl_Bg_Mori_Kaitenkabe/z_bg_mori_kaitenkabe.c
+++ b/soh/src/overlays/actors/ovl_Bg_Mori_Kaitenkabe/z_bg_mori_kaitenkabe.c
@@ -148,8 +148,8 @@ void BgMoriKaitenkabe_Rotate(BgMoriKaitenkabe* this, PlayState* play) {
 
     // #region SOH [Enhancement]
     if (CVarGetInteger(CVAR_ENHANCEMENT("FasterBlockPush"), 0)) {
-        Math_StepToF(&this->rotSpeed, 0.6f * (CVarGetInteger(CVAR_ENHANCEMENT("FasterBlockPush"), 0) + 1),
-                     0.02f * (CVarGetInteger(CVAR_ENHANCEMENT("FasterBlockPush"), 0) + 1) * 10);
+        Math_StepToF(&this->rotSpeed, 0.6f * CVarGetInteger(CVAR_ENHANCEMENT("FasterBlockPush"), 0),
+                     0.02f * CVarGetInteger(CVAR_ENHANCEMENT("FasterBlockPush"), 0) * 10);
         if (Math_StepToF(&this->rotYdeg, this->rotDirection * 45.0f, this->rotSpeed)) {
             BgMoriKaitenkabe_SetupWait(this);
             if (this->rotDirection > 0.0f) {


### PR DESCRIPTION
Aiming for parity with OOTR:
1) Changes the pillar top speed to 3.0 (from 0.6) and acceleration to 1.0 (from 0.02) at Block Push Speed of +5. 
2) Removes the cutscene stops that prevent Link from moving while the pillars move.

Lots of duplication here to keep the blocks together; can probably be cut down but will be less readable.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1972339458.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1972429457.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1972435206.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1972444494.zip)
<!--- section:artifacts:end -->