### PR TITLE
Handle ignoring 0x3F for navi talk skips

### DIFF
--- a/soh/soh/Enhancements/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.cpp
@@ -317,9 +317,11 @@ void TimeSaverOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, void*
         case VB_NAVI_TALK: {
             if (CVarGetInteger(CVAR_ENHANCEMENT("TimeSavers.NoForcedDialog"), IS_RANDO)) {
                 ElfMsg* naviTalk = static_cast<ElfMsg*>(opt);
-                Flags_SetSwitch(gPlayState, (naviTalk->actor.params >> 8) & 0x3F);
-                Actor_Kill(&naviTalk->actor);
-                *should = false;
+                if (((naviTalk->actor.params >> 8) & 0x3F) != 0x3F) {
+                    Flags_SetSwitch(gPlayState, (naviTalk->actor.params >> 8) & 0x3F);
+                    Actor_Kill(&naviTalk->actor);
+                    *should = false;
+                }
             }
             break;
         }


### PR DESCRIPTION
Might fix some odd side effects, but notably fixes a case in dodongo's cavern in which a navi talk flag made some platforms raise that shouldn't have.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1969238519.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1969278777.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1969279350.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1969280150.zip)
<!--- section:artifacts:end -->