### PR TITLE
Rando V3 - Small UI Cleanup

### DIFF
--- a/soh/soh/Enhancements/randomizer/option.cpp
+++ b/soh/soh/Enhancements/randomizer/option.cpp
@@ -240,7 +240,7 @@ bool Option::RenderCombobox() const {
     ImGui::Text("%s", name.c_str());
     uint8_t selected = CVarGetInteger(cvarName.c_str(), defaultOption);
     if (selected >= options.size()) {
-        selected--;
+        selected = options.size();
         CVarSetInteger(cvarName.c_str(), selected);
         changed = true;
         Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
@@ -272,7 +272,8 @@ bool Option::RenderSlider() const {
     bool changed = false;
     int val = CVarGetInteger(cvarName.c_str(), defaultOption);
     if (val >= options.size()) {
-        val--;
+        val = options.size();
+        CVarSetInteger(cvarName.c_str(), val);
         changed = true;
     }
     if (disabled) {

--- a/soh/soh/UIWidgets.cpp
+++ b/soh/soh/UIWidgets.cpp
@@ -170,7 +170,6 @@ namespace UIWidgets {
             ImGui::RenderCheckMark(window->DrawList, check_bb.Min + ImVec2(pad, pad), check_col, square_sz - pad * 2.0f);
         } else if ((!disabled && !*v && renderCrossWhenOff) || (disabled && disabledGraphic == CheckboxGraphics::Cross)) {
             const float pad = ImMax(1.0f, IM_FLOOR(square_sz / 6.0f));
-            RenderCross(window->DrawList, check_bb.Min + ImVec2(pad, pad), disabled ? cross_col : check_col, square_sz - pad * 2.0f);
         }
 
         ImVec2 label_pos = ImVec2(check_bb.Max.x + style.ItemInnerSpacing.x, check_bb.Min.y + style.FramePadding.y);

--- a/soh/soh/UIWidgets.cpp
+++ b/soh/soh/UIWidgets.cpp
@@ -170,6 +170,7 @@ namespace UIWidgets {
             ImGui::RenderCheckMark(window->DrawList, check_bb.Min + ImVec2(pad, pad), check_col, square_sz - pad * 2.0f);
         } else if ((!disabled && !*v && renderCrossWhenOff) || (disabled && disabledGraphic == CheckboxGraphics::Cross)) {
             const float pad = ImMax(1.0f, IM_FLOOR(square_sz / 6.0f));
+            //RenderCross(window->DrawList, check_bb.Min + ImVec2(pad, pad), disabled ? cross_col : check_col, square_sz - pad * 2.0f); // Caused confusion as to status
         }
 
         ImVec2 label_pos = ImVec2(check_bb.Max.x + style.ItemInnerSpacing.x, check_bb.Min.y + style.FramePadding.y);


### PR DESCRIPTION
Rando's Combobox and Slider Options were set to decrement when the saved value was bigger than the available options, but if the difference was more than 1, it would still be trying to reference an option out of bounds, thus displaying garbage data in the label, also causing a crash. This changes those two to just set it to the max directly to avoid this.

Also changes the tristate "Off" graphic to be nothing instead of the cross, to avoid confusion thinking that was enabled.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1988870241.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1988887001.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1988890018.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1988899792.zip)
<!--- section:artifacts:end -->