### PR TITLE
Upgrade GitHub checkout action to v4

### DIFF
--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -9,7 +9,7 @@ jobs:
   generate-soh-otr:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - name: ccache
@@ -73,7 +73,7 @@ jobs:
     needs: generate-soh-otr
     runs-on: macos-14
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - name: ccache
@@ -135,7 +135,7 @@ jobs:
     needs: generate-soh-otr
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - name: Install dependencies
@@ -229,7 +229,7 @@ jobs:
       run: |
         choco install ninja
         Remove-Item -Path "C:\ProgramData\Chocolatey\bin\ccache.exe" -Force -ErrorAction SilentlyContinue
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - name: ccache

--- a/.github/workflows/test-builds-on-distros.yml
+++ b/.github/workflows/test-builds-on-distros.yml
@@ -59,7 +59,7 @@ jobs:
         cmake ..
         make
         sudo make install
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - name: Build SoH


### PR DESCRIPTION
The old version of the checkout action uses a deprecated version of Node. The newer version uses Node 20.