### PR TITLE
Fix how the gMtxClear is extracted and used by the Jabu scene DLs

### DIFF
--- a/soh/assets/xml/GC_MQ_D/code/sys_matrix.xml
+++ b/soh/assets/xml/GC_MQ_D/code/sys_matrix.xml
@@ -1,5 +1,5 @@
 <Root>
-    <File Name="code" OutName="sys_matrix" RangeStart="0x110CC0" RangeEnd="0x110D00">
-        <Mtx Name="gMtxClear"  Offset="0x110CC0"/>
+    <File Name="code" OutName="sys_matrix" BaseAddress="0x1CE60" RangeStart="0x110CC0" RangeEnd="0x110D00">
+        <Mtx Name="gMtxClear" Offset="0x110CC0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_MQ_PAL_F/code/sys_matrix.xml
+++ b/soh/assets/xml/GC_MQ_PAL_F/code/sys_matrix.xml
@@ -1,5 +1,5 @@
 <Root>
-    <File Name="code" OutName="sys_matrix" RangeStart="0xEAD00" RangeEnd="0xEAD40">
-        <Mtx Name="gMtxClear"  Offset="0xEAD00"/>
+    <File Name="code" OutName="sys_matrix" BaseAddress="0x10F00" RangeStart="0xEAD00" RangeEnd="0xEAD40">
+        <Mtx Name="gMtxClear" Offset="0xEAD00"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/code/sys_matrix.xml
+++ b/soh/assets/xml/GC_NMQ_D/code/sys_matrix.xml
@@ -1,5 +1,5 @@
 <Root>
-    <File Name="code" OutName="sys_matrix" RangeStart="0x110CE0" RangeEnd="0x110D20">
-        <Mtx Name="gMtxClear"  Offset="0x110CE0"/>
+    <File Name="code" OutName="sys_matrix" BaseAddress="0x1CE60" RangeStart="0x110CE0" RangeEnd="0x110D20">
+        <Mtx Name="gMtxClear" Offset="0x110CE0"/>
     </File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_PAL_F/code/sys_matrix.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/code/sys_matrix.xml
@@ -1,5 +1,5 @@
 <Root>
-    <File Name="code" OutName="sys_matrix" RangeStart="0xEAD20" RangeEnd="0xEAD60">
-        <Mtx Name="gMtxClear"  Offset="0xEAD20"/>
+    <File Name="code" OutName="sys_matrix" BaseAddress="0x10F00" RangeStart="0xEAD20" RangeEnd="0xEAD60">
+        <Mtx Name="gMtxClear" Offset="0xEAD20"/>
     </File>
 </Root>

--- a/soh/assets/xml/N64_PAL_10/code/sys_matrix.xml
+++ b/soh/assets/xml/N64_PAL_10/code/sys_matrix.xml
@@ -1,5 +1,5 @@
 <Root>
-    <File Name="code" OutName="sys_matrix" RangeStart="0xEB620" RangeEnd="0xEB660">
-        <Mtx Name="gMtxClear"  Offset="0xEB620"/>
+    <File Name="code" OutName="sys_matrix" BaseAddress="0x116E0" RangeStart="0xEB620" RangeEnd="0xEB660">
+        <Mtx Name="gMtxClear" Offset="0xEB620"/>
     </File>
 </Root>

--- a/soh/assets/xml/N64_PAL_11/code/sys_matrix.xml
+++ b/soh/assets/xml/N64_PAL_11/code/sys_matrix.xml
@@ -1,5 +1,5 @@
 <Root>
-    <File Name="code" OutName="sys_matrix" RangeStart="0xEB660" RangeEnd="0xEB6A0">
-        <Mtx Name="gMtxClear"  Offset="0xEB660"/>
+    <File Name="code" OutName="sys_matrix" BaseAddress="0x116E0" RangeStart="0xEB660" RangeEnd="0xEB6A0">
+        <Mtx Name="gMtxClear" Offset="0xEB660"/>
     </File>
 </Root>


### PR DESCRIPTION
* Depends on https://github.com/HarbourMasters/OTRExporter/pull/27

After #4200, we've been extracting the `gMtxClear` to OTRs, but it's offset address does not match the segmented address that the Jabu scene DLs have which lead to the Jabu not loading the matrix at all. This lead to missing scene geometry in the room with the floor holes.

It looks like specifying a `BaseAddress` allows us to handle the segmented address difference, while still extracting the correct Matrix data. This is accompanied by https://github.com/HarbourMasters/OTRExporter/pull/27 so that segmented lookups also account for external files.

Verified by the Gfx debugger, we can now see that the Jabu DLs correctly reference the `gMtxClear` path and the scene geometry renders correctly.

![image](https://github.com/user-attachments/assets/8f3e2baa-6524-4bce-85c7-bb32efcd40fd)


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2043046248.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2043080942.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2043081197.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2043083264.zip)
<!--- section:artifacts:end -->