### PR TITLE
[Tweak] Add Particle Effect to Shop Bottles

### DIFF
--- a/soh/src/code/z_en_item00.c
+++ b/soh/src/code/z_en_item00.c
@@ -1215,6 +1215,11 @@ void EnItem00_CustomItemsParticles(Actor* Parent, PlayState* play, GetItemEntry 
                 case ITEM_NUT_UPGRADE_40:
                     color_slot = 7;
                     break;
+                case ITEM_BOTTLE:
+                case ITEM_MILK_BOTTLE:
+                case ITEM_LETTER_RUTO:
+                    color_slot = 8;
+                    break;
                 default:
                     return;
             }
@@ -1224,13 +1229,34 @@ void EnItem00_CustomItemsParticles(Actor* Parent, PlayState* play, GetItemEntry 
                 case RG_MAGIC_SINGLE:
                 case RG_MAGIC_DOUBLE:
                 case RG_MAGIC_BEAN_PACK:
+                case RG_BOTTLE_WITH_GREEN_POTION:
+                case RG_BOTTLE_WITH_BUGS:
                     color_slot = 0;
+                    break;
+                case RG_BOTTLE_WITH_FISH:
+                    color_slot = 2;
+                    break;
+                case RG_BOTTLE_WITH_POE:
+                    color_slot = 4;
+                    break;
+                case RG_BOTTLE_WITH_BIG_POE:
+                    color_slot = 5;
                     break;
                 case RG_DOUBLE_DEFENSE:
                     color_slot = 8;
                     break;
                 case RG_PROGRESSIVE_BOMBCHUS:
                     color_slot = 9;
+                    break;
+                case RG_BOTTLE_WITH_FAIRY:
+                    color_slot = 10;
+                    break;
+                case RG_BOTTLE_WITH_RED_POTION:
+                    color_slot = 11;
+                    break;
+                case RG_BOTTLE_WITH_BLUE_FIRE:
+                case RG_BOTTLE_WITH_BLUE_POTION:
+                    color_slot = 12;
                     break;
                 default:
                     return;
@@ -1241,21 +1267,24 @@ void EnItem00_CustomItemsParticles(Actor* Parent, PlayState* play, GetItemEntry 
     }
 
     // Color of the circle for the particles
-    static Color_RGBA8 mainColors[10][3] = {
-        { 34, 255, 76 },   // Minuet, Bean Pack, and Magic Upgrades
+    static Color_RGBA8 mainColors[13][3] = {
+        { 34, 255, 76 },   // Minuet, Bean Pack, Magic Upgrades, Bottle with Green Potion, and Bottle with Bugs
         { 177, 35, 35 },   // Bolero
-        { 115, 251, 253 }, // Serenade
+        { 115, 251, 253 }, // Serenade and Bottle with Fish
         { 177, 122, 35 },  // Requiem
-        { 177, 28, 212 },  // Nocturne
-        { 255, 255, 92 },  // Prelude
+        { 177, 28, 212 },  // Nocturne and Bottle with Poe
+        { 255, 255, 92 },  // Prelude and Bottle with Big Poe
         { 31, 152, 49 },   // Stick Upgrade
         { 222, 182, 20 },  // Nut Upgrade
-        { 255, 255, 255 }, // Double Defense
-        { 19, 120, 182 }   // Progressive Bombchu
+        { 255, 255, 254 }, // Double Defense, Empty Bottle, Bottle with Milk, and Bottle with Ruto's Letter
+        { 19, 120, 182 },  // Progressive Bombchu
+        { 255, 205, 255 }, // Bottle with Fairy
+        { 255, 118, 118 }, // Bottle with Red Potion
+        { 154, 204, 255 }  // Bottle with Blue Fire and Bottle with Blue Potion
     };
 
     // Color of the faded flares stretching off the particles
-    static Color_RGBA8 flareColors[10][3] = {
+    static Color_RGBA8 flareColors[13][3] = {
         { 30, 110, 30 },   // Minuet, Bean Pack, and Magic Upgrades
         { 90, 10, 10 },    // Bolero
         { 35, 35, 177 },   // Serenade
@@ -1265,7 +1294,10 @@ void EnItem00_CustomItemsParticles(Actor* Parent, PlayState* play, GetItemEntry 
         { 5, 50, 10 },     // Stick Upgrade
         { 150, 100, 5 },   // Nut Upgrade
         { 154, 154, 154 }, // Double Defense
-        { 204, 102, 0 }    // Progressive Bombchu
+        { 204, 102, 0 },   // Progressive Bombchu
+        { 216, 70, 216 },  // Bottle with Fairy
+        { 90, 10, 10 },    // Bottle with Red Potion
+        { 35, 35, 177 }    // Bottle with Blue Fire
     };
 
     static Vec3f velocity = { 0.0f, 0.0f, 0.0f };


### PR DESCRIPTION
Bottles in shops currently use the same model as their "Buy Bottle" counterparts, making them difficult to differentiate. This adds the particle effect to real bottles to make the difference obvious. 

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1997169011.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1997217442.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1997221866.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/1997233624.zip)
<!--- section:artifacts:end -->