### PR TITLE
Fix seed generation issues caused by Location Table changes

### DIFF
--- a/soh/soh/Enhancements/randomizer/context.cpp
+++ b/soh/soh/Enhancements/randomizer/context.cpp
@@ -188,20 +188,8 @@ void Context::ItemReset() {
 }
 
 void Context::LocationReset() {
-    for (const RandomizerCheck il : allLocations) {
-        GetItemLocation(il)->RemoveFromPool();
-    }
-
-    for (const RandomizerCheck il : StaticData::dungeonRewardLocations) {
-        GetItemLocation(il)->RemoveFromPool();
-    }
-
-    for (const RandomizerCheck il : StaticData::GetGossipStoneLocations()) {
-        GetItemLocation(il)->RemoveFromPool();
-    }
-
-    for (const RandomizerCheck il : StaticData::GetStaticHintLocations()) {
-        GetItemLocation(il)->RemoveFromPool();
+    for (auto& il : itemLocationTable) {
+        il.RemoveFromPool();
     }
 }
 


### PR DESCRIPTION
As title, the issue was caused by allLocation changes causing un-randomised to not have their addedToPool flag reset when logic was reset.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2006365894.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2006461417.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2006466650.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2006475331.zip)
<!--- section:artifacts:end -->