### PR TITLE
Fix items being placed on hint locations

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/fill.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/fill.cpp
@@ -1023,7 +1023,7 @@ static void RandomizeDungeonItems() {
   auto ctx = Rando::Context::GetInstance();
 
   //Get Any Dungeon and Overworld group locations
-  std::vector<RandomizerCheck> anyDungeonLocations = FilterFromPool(ctx->allLocations, [](const auto loc){return Rando::StaticData::GetLocation(loc)->IsDungeon();});
+  std::vector<RandomizerCheck> anyDungeonLocations = Rando::StaticData::GetDungeonLocations();
   //Rando::StaticData::GetOverworldLocations() defined in item_location.cpp
 
   //Create Any Dungeon and Overworld item pools

--- a/soh/soh/Enhancements/randomizer/location_list.cpp
+++ b/soh/soh/Enhancements/randomizer/location_list.cpp
@@ -82,7 +82,23 @@ std::vector<RandomizerCheck> Rando::StaticData::GetOverworldLocations() {
             location.GetRandomizerCheck() != RC_UNKNOWN_CHECK &&
             location.GetRandomizerCheck() != RC_TRIFORCE_COMPLETED && //not really an overworld check
             location.GetRCType() != RCTYPE_FISH && //temp fix while locations are properly sorted out
-            location.GetRCType() != RCTYPE_CHEST_GAME //this is supposed to be excluded
+            location.GetRCType() != RCTYPE_CHEST_GAME && //this is supposed to be excluded
+            location.GetRCType() != RCTYPE_STATIC_HINT && 
+            location.GetRCType() != RCTYPE_GOSSIP_STONE  //don't put items on hints
+        ) {
+            overworldLocations.push_back(location.GetRandomizerCheck());
+        }
+    }
+    return overworldLocations;
+}
+
+std::vector<RandomizerCheck> Rando::StaticData::GetDungeonLocations() {
+    std::vector<RandomizerCheck> overworldLocations = {};
+    for (Location& location : locationTable) {
+        if (
+            location.IsDungeon() &&
+            location.GetRCType() != RCTYPE_STATIC_HINT && 
+            location.GetRCType() != RCTYPE_GOSSIP_STONE  //don't put items on hints
         ) {
             overworldLocations.push_back(location.GetRandomizerCheck());
         }

--- a/soh/soh/Enhancements/randomizer/static_data.h
+++ b/soh/soh/Enhancements/randomizer/static_data.h
@@ -36,6 +36,7 @@ class StaticData {
       static std::unordered_map<std::string, uint32_t> PopulateTranslationMap(std::unordered_map<uint32_t, RandomizerHintTextKey> input);
       static std::multimap<std::tuple<s16, s16, s32>, RandomizerCheck> CheckFromActorMultimap;
       static std::vector<RandomizerCheck> GetOverworldLocations();
+      static std::vector<RandomizerCheck> GetDungeonLocations();
       static std::vector<RandomizerCheck> dungeonRewardLocations;
       static std::vector<RandomizerCheck> GetShopLocations();
       static std::vector<RandomizerCheck> GetScrubLocations();


### PR DESCRIPTION
Fixes the issue of hints getting checks, and in turn the issue where they don't get hints.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2008555727.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2008595098.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2008596260.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2008597263.zip)
<!--- section:artifacts:end -->