### PR TITLE
[V3] Fishsanity Cleanup

### DIFF
--- a/soh/soh/Enhancements/randomizer/fishsanity.cpp
+++ b/soh/soh/Enhancements/randomizer/fishsanity.cpp
@@ -75,19 +75,22 @@ namespace Rando {
                                              FishsanityOptionsSource optionsSource) {
         auto [mode, numFish, ageSplit] = GetOptions(optionsSource);
 
-        if (loc->GetRCType() != RCTYPE_FISH || mode == RO_FISHSANITY_OFF)
+        if (loc->GetRCType() != RCTYPE_FISH || mode == RO_FISHSANITY_OFF) {
             return false;
+        }
         RandomizerCheck rc = loc->GetRandomizerCheck();
         // Are pond fish enabled, and is this a pond fish location?
         if (mode != RO_FISHSANITY_OVERWORLD && numFish > 0 && loc->GetScene() == SCENE_FISHING_POND &&
             loc->GetActorID() == ACTOR_FISHING) {
             // Is this a child fish location? If so, is it within the defined number of pond fish checks?
-            if (rc >= RC_LH_CHILD_FISH_1 && rc <= RC_LH_CHILD_LOACH_2 && numFish > (loc->GetActorParams() - 100))
+            if (rc >= RC_LH_CHILD_FISH_1 && rc <= RC_LH_CHILD_LOACH_2 && numFish > (loc->GetActorParams() - 100)) {
                 return true;
+            }
             // Are adult fish available, and is this an adult fish location? If so, is it within the defined number of pond
             // fish checks?
-            if (ageSplit && rc >= RC_LH_ADULT_FISH_1 && rc <= RC_LH_ADULT_LOACH && numFish > (loc->GetActorParams() - 100))
+            if (ageSplit && rc >= RC_LH_ADULT_FISH_1 && rc <= RC_LH_ADULT_LOACH && numFish > (loc->GetActorParams() - 100)) {
                 return true;
+            }
         }
         // Are overworld fish enabled, and is this an overworld fish location?
         if (mode != RO_FISHSANITY_POND && (loc->GetScene() == SCENE_GROTTOS || loc->GetScene() == SCENE_ZORAS_DOMAIN)
@@ -238,7 +241,7 @@ namespace Rando {
     bool Fishsanity::GetPondFishShuffled() {
         u8 fsMode = OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_FISHSANITY);
         return OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_FISHSANITY_POND_COUNT) > 0 &&
-           (fsMode == RO_FISHSANITY_POND || fsMode == RO_FISHSANITY_BOTH);
+            (fsMode == RO_FISHSANITY_POND || fsMode == RO_FISHSANITY_BOTH);
     }
 
     bool Fishsanity::GetOverworldFishShuffled() {
@@ -253,8 +256,9 @@ namespace Rando {
     bool Fishsanity::GetPondCleared() {
         auto [mode, pondCount, ageSplit] = GetOptions();
         // no fish shuffled, so pond is always cleared :thumbsup:
-        if (pondCount == 0)
+        if (pondCount == 0) {
             return true;
+        }
 
         bool adultPond = LINK_IS_ADULT && ageSplit;
         // if we've collected the final shuffled fish, pond is complete
@@ -268,23 +272,26 @@ namespace Rando {
         for (auto tableEntry : Rando::StaticData::randomizerFishingPondFish) {
             RandomizerCheck rc = adultPond ? tableEntry.second : tableEntry.first;
             // if we haven't collected this fish, then we're not done yet! get back in there, soldier
-            if (rc != RC_UNKNOWN_CHECK && !Flags_GetRandomizerInf(OTRGlobals::Instance->gRandomizer->GetRandomizerInfFromCheck(rc)))
+            if (rc != RC_UNKNOWN_CHECK && !Flags_GetRandomizerInf(OTRGlobals::Instance->gRandomizer->GetRandomizerInfFromCheck(rc))) {
                 return false;
+            }
         }
         return true;
     }
 
     bool Fishsanity::GetDomainCleared() {
         for (RandomizerInf i = RAND_INF_ZD_FISH_1; i <= RAND_INF_ZD_FISH_5; i = (RandomizerInf)(i + 1)) {
-            if (!Flags_GetRandomizerInf(i))
+            if (!Flags_GetRandomizerInf(i)) {
                 return false;
+            }
         }
         return true;
     }
 
     void Fishsanity::InitializeHelpers() {
-        if (fishsanityHelpersInit)
+        if (fishsanityHelpersInit) {
             return;
+        }
 
         for (auto pair : Rando::StaticData::randomizerFishingPondFish) {
             pondFishAgeMap[pair.first] = LINK_AGE_CHILD;
@@ -315,15 +322,18 @@ namespace Rando {
 
     FishsanityCheckType Fishsanity::GetCheckType(RandomizerCheck rc) {
         // Is this a pond fish?
-        if (std::binary_search(Rando::StaticData::GetPondFishLocations().begin(), Rando::StaticData::GetPondFishLocations().end(), rc))
+        if (std::binary_search(Rando::StaticData::GetPondFishLocations().begin(), Rando::StaticData::GetPondFishLocations().end(), rc)) {
             return FSC_POND;
+        }
 
         // Is this an overworld fish?
         if (std::binary_search(Rando::StaticData::GetOverworldFishLocations().begin(), Rando::StaticData::GetOverworldFishLocations().end(), rc)) {
-            if (rc < RC_ZD_FISH_1)
+            if (rc < RC_ZD_FISH_1) {
                 return FSC_GROTTO;
-            else
+            }
+            else {
                 return FSC_ZD;
+            }
         }
         
         // Must not be a fishsanity check
@@ -331,8 +341,9 @@ namespace Rando {
     }
 
     bool Fishsanity::IsFish(FishIdentity* fish) {
-        if (fish->randomizerCheck == RC_UNKNOWN_CHECK || fish->randomizerInf == RAND_INF_MAX)
+        if (fish->randomizerCheck == RC_UNKNOWN_CHECK || fish->randomizerInf == RAND_INF_MAX) {
             return false;
+        }
 
         return GetCheckType(fish->randomizerCheck) != FSC_NONE;
     }
@@ -390,6 +401,9 @@ namespace Rando {
             return;
         }
         RandomizerCheck rc = OTRGlobals::Instance->gRandomizer->GetCheckFromRandomizerInf((RandomizerInf)flag);
+        if (Rando::StaticData::GetLocation(rc)->GetRCType() != RCTYPE_FISH) {
+            return;
+        }
         FishsanityCheckType fsType = Rando::Fishsanity::GetCheckType(rc);
         if (fsType == FSC_NONE) {
             return;

--- a/soh/soh/Enhancements/randomizer/fishsanity.cpp
+++ b/soh/soh/Enhancements/randomizer/fishsanity.cpp
@@ -322,22 +322,17 @@ namespace Rando {
 
     FishsanityCheckType Fishsanity::GetCheckType(RandomizerCheck rc) {
         // Is this a pond fish?
-        if (std::binary_search(Rando::StaticData::GetPondFishLocations().begin(), Rando::StaticData::GetPondFishLocations().end(), rc)) {
+        auto loc = Rando::StaticData::GetLocation(rc);
+        switch (loc->GetScene()) {
+        case SCENE_FISHING_POND:
             return FSC_POND;
+        case SCENE_ZORAS_DOMAIN:
+            return FSC_ZD;
+        case SCENE_GROTTOS:
+            return FSC_GROTTO;
+        default:
+            return FSC_NONE;
         }
-
-        // Is this an overworld fish?
-        if (std::binary_search(Rando::StaticData::GetOverworldFishLocations().begin(), Rando::StaticData::GetOverworldFishLocations().end(), rc)) {
-            if (rc < RC_ZD_FISH_1) {
-                return FSC_GROTTO;
-            }
-            else {
-                return FSC_ZD;
-            }
-        }
-        
-        // Must not be a fishsanity check
-        return FSC_NONE;
     }
 
     bool Fishsanity::IsFish(FishIdentity* fish) {

--- a/soh/soh/Enhancements/randomizer/fishsanity.cpp
+++ b/soh/soh/Enhancements/randomizer/fishsanity.cpp
@@ -321,7 +321,11 @@ namespace Rando {
     }
 
     FishsanityCheckType Fishsanity::GetCheckType(RandomizerCheck rc) {
-        // Is this a pond fish?
+        // if it's not RCTYPE_FISH, obviously it's not a fish
+        if (Rando::StaticData::GetLocation(rc)->GetRCType() != RCTYPE_FISH) {
+            return FSC_NONE;
+        }
+
         auto loc = Rando::StaticData::GetLocation(rc);
         switch (loc->GetScene()) {
         case SCENE_FISHING_POND:
@@ -396,9 +400,6 @@ namespace Rando {
             return;
         }
         RandomizerCheck rc = OTRGlobals::Instance->gRandomizer->GetCheckFromRandomizerInf((RandomizerInf)flag);
-        if (Rando::StaticData::GetLocation(rc)->GetRCType() != RCTYPE_FISH) {
-            return;
-        }
         FishsanityCheckType fsType = Rando::Fishsanity::GetCheckType(rc);
         if (fsType == FSC_NONE) {
             return;

--- a/soh/soh/Enhancements/randomizer/fishsanity.h
+++ b/soh/soh/Enhancements/randomizer/fishsanity.h
@@ -6,7 +6,7 @@
 #include "randomizerTypes.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
-typedef struct FishsanityPondOptions {
+typedef struct {
     u8 mode;
     u8 numFish;
     bool ageSplit;

--- a/soh/soh/Enhancements/randomizer/fishsanity.h
+++ b/soh/soh/Enhancements/randomizer/fishsanity.h
@@ -12,17 +12,17 @@ typedef struct FishsanityPondOptions {
     bool ageSplit;
 } FishsanityPondOptions;
 
-typedef enum FishsanityOptionsSource {
+typedef enum {
     FSO_SOURCE_RANDO,
     FSO_SOURCE_CVARS
-};
+} FishsanityOptionsSource;
 
-typedef enum FishsanityCheckType {
+typedef enum {
     FSC_NONE,
     FSC_POND,
     FSC_GROTTO,
     FSC_ZD,
-};
+} FishsanityCheckType;
 
 #ifdef __cplusplus
 namespace Rando {


### PR DESCRIPTION
Fishsanity's flag set handler was using `GetFishLocations()` functions, which return a new vector, as separate `begin()` and `end()` iterators, causing `binary_search` to search across two different vector objects, resulting in out of range errors and crashes. This fixes that by checking for `RCTYPE_FISH` at the beginning of `GetCheckType()` as well as changing `GetCheckType()` to a switch structure on `rc`'s `Location::GetScene()` and getting rid of `binary_search` altogether.

This also fixes some code formatting (one if block wasn't indented, several unbracketed single-line if blocks), and fixes typedef warnings in `fishsanity.h` where the enum name needs to be after the block of enum values instead of before.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2016808356.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2016825009.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2016831534.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2016839309.zip)
<!--- section:artifacts:end -->