### PR TITLE
Fix Seed generation when adult trade is off and some shield logic

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/item_pool.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/item_pool.cpp
@@ -905,16 +905,6 @@ void GenerateItemPool() {
     AddItemToMainPool(RG_PRESCRIPTION);
     AddItemToMainPool(RG_EYEBALL_FROG);
     AddItemToMainPool(RG_EYEDROPS);
-  } else {
-    ctx->PlaceItemInLocation(RC_KAK_TRADE_POCKET_CUCCO, RG_COJIRO, false, true);
-    ctx->PlaceItemInLocation(RC_LW_TRADE_COJIRO, RG_ODD_MUSHROOM, false, true);
-    ctx->PlaceItemInLocation(RC_KAK_TRADE_ODD_MUSHROOM, RG_ODD_POTION, false, true);
-    ctx->PlaceItemInLocation(RC_LW_TRADE_ODD_POTION, RG_POACHERS_SAW, false, true);
-    ctx->PlaceItemInLocation(RC_GV_TRADE_SAW, RG_BROKEN_SWORD, false, true);
-    ctx->PlaceItemInLocation(RC_DMT_TRADE_BROKEN_SWORD, RG_PRESCRIPTION, false, true);
-    ctx->PlaceItemInLocation(RC_ZD_TRADE_PRESCRIPTION, RG_EYEBALL_FROG, false, true);
-    ctx->PlaceItemInLocation(RC_LH_TRADE_FROG, RG_EYEDROPS, false, true);
-    ctx->PlaceItemInLocation(RC_DMT_TRADE_EYEDROPS, RG_CLAIM_CHECK, false, true);
   }
   AddItemToMainPool(RG_CLAIM_CHECK);
 

--- a/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_death_mountain.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_death_mountain.cpp
@@ -25,7 +25,6 @@ void RegionTable_Init_DeathMountain() {
 
   areaTable[RR_DEATH_MOUNTAIN_SUMMIT] = Region("Death Mountain Summit", "Death Mountain", RA_DEATH_MOUNTAIN_TRAIL, DAY_NIGHT_CYCLE, {
                   //Events
-                  EventAccess(&logic->PrescriptionAccess, {[]{return logic->PrescriptionAccess || (logic->IsAdult && (logic->BrokenSwordAccess || logic->CanUse(RG_BROKEN_SWORD)));}}),
                   EventAccess(&logic->GossipStoneFairy,   {[]{return logic->CallGossipFairy();}}),
                   EventAccess(&logic->BugRock,            {[]{return logic->BugRock            || logic->IsChild;}}),
                 }, {

--- a/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_dodongos_cavern.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_dodongos_cavern.cpp
@@ -56,7 +56,7 @@ void RegionTable_Init_DodongosCavern() {
                 }, {
                   //Exits
                   Entrance(RR_DODONGOS_CAVERN_LOBBY,               {[]{return true;}}),
-                  //Shield in logic to block baby dodongos to make them blow up the wall?
+                  //Shield seems to be in logic to drop a pot on thier head as they hit you to blow up the wall
                   Entrance(RR_DODONGOS_CAVERN_SE_ROOM,             {[]{return Here(RR_DODONGOS_CAVERN_SE_CORRIDOR, []{return logic->BlastOrSmash() || logic->CanAttack() || (logic->TakeDamage() && logic->CanShield());});}}),
                   Entrance(RR_DODONGOS_CAVERN_NEAR_LOWER_LIZALFOS, {[]{return true;}}),
   });

--- a/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_forest_temple.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_forest_temple.cpp
@@ -127,11 +127,11 @@ void RegionTable_Init_ForestTemple() {
 
   areaTable[RR_FOREST_TEMPLE_MAP_ROOM] = Region("Forest Temple Map Room", "Forest Temple", RA_FOREST_TEMPLE, NO_DAY_NIGHT_CYCLE, {}, {
                   //Locations
-                  LOCATION(RC_FOREST_TEMPLE_MAP_CHEST, Here(RR_FOREST_TEMPLE_MAP_ROOM, []{return logic->HasExplosives() || logic->CanUse(RG_MEGATON_HAMMER) || logic->CanUse(RG_FAIRY_BOW) || ((logic->CanJumpslash() || logic->CanUse(RG_FAIRY_SLINGSHOT)) && (logic->CanUse(RG_NUTS) || logic->HookshotOrBoomerang() || logic->CanShield()));})),
+                  LOCATION(RC_FOREST_TEMPLE_MAP_CHEST, logic->CanKillEnemy(RE_BLUE_BUBBLE)),
                 }, {
                   //Exits
-                  Entrance(RR_FOREST_TEMPLE_NW_OUTDOORS_LOWER, {[]{return Here(RR_FOREST_TEMPLE_MAP_ROOM, []{return logic->HasExplosives() || logic->CanUse(RG_MEGATON_HAMMER) || logic->CanUse(RG_FAIRY_BOW) || ((logic->CanJumpslash() || logic->CanUse(RG_FAIRY_SLINGSHOT)) && (logic->CanUse(RG_NUTS) || logic->HookshotOrBoomerang() || logic->CanShield()));});}}),
-                  Entrance(RR_FOREST_TEMPLE_NE_OUTDOORS_UPPER, {[]{return Here(RR_FOREST_TEMPLE_MAP_ROOM, []{return logic->HasExplosives() || logic->CanUse(RG_MEGATON_HAMMER) || logic->CanUse(RG_FAIRY_BOW) || ((logic->CanJumpslash() || logic->CanUse(RG_FAIRY_SLINGSHOT)) && (logic->CanUse(RG_NUTS) || logic->HookshotOrBoomerang() || logic->CanShield()));});}}),
+                  Entrance(RR_FOREST_TEMPLE_NW_OUTDOORS_LOWER, {[]{return Here(RR_FOREST_TEMPLE_MAP_ROOM, []{return logic->CanKillEnemy(RE_BLUE_BUBBLE);});}}),
+                  Entrance(RR_FOREST_TEMPLE_NE_OUTDOORS_UPPER, {[]{return Here(RR_FOREST_TEMPLE_MAP_ROOM, []{return logic->CanKillEnemy(RE_BLUE_BUBBLE);});}}),
   });
 
   areaTable[RR_FOREST_TEMPLE_SEWER] = Region("Forest Temple Sewer", "Forest Temple", RA_FOREST_TEMPLE, NO_DAY_NIGHT_CYCLE, {}, {
@@ -145,7 +145,7 @@ void RegionTable_Init_ForestTemple() {
 
   areaTable[RR_FOREST_TEMPLE_BELOW_BOSS_KEY_CHEST] = Region("Forest Temple Below Boss Key Chest", "Forest Temple", RA_FOREST_TEMPLE, NO_DAY_NIGHT_CYCLE, {}, {}, {
                   //Exits
-                  Entrance(RR_FOREST_TEMPLE_NW_OUTDOORS_UPPER, {[]{return Here(RR_FOREST_TEMPLE_BELOW_BOSS_KEY_CHEST, []{return logic->HasExplosives() || logic->CanUse(RG_MEGATON_HAMMER) || logic->CanUse(RG_FAIRY_BOW) || ((logic->CanJumpslash() || logic->CanUse(RG_FAIRY_SLINGSHOT)) && (logic->CanUse(RG_NUTS) || logic->HookshotOrBoomerang() || logic->CanShield()));});}}),
+                  Entrance(RR_FOREST_TEMPLE_NW_OUTDOORS_UPPER, {[]{return Here(RR_FOREST_TEMPLE_BELOW_BOSS_KEY_CHEST, []{return logic->CanKillEnemy(RE_BLUE_BUBBLE);});}}),
   });
 
   areaTable[RR_FOREST_TEMPLE_FLOORMASTER_ROOM] = Region("Forest Temple Floormaster Room", "Forest Temple", RA_FOREST_TEMPLE, NO_DAY_NIGHT_CYCLE, {}, {

--- a/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_gerudo_valley.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_gerudo_valley.cpp
@@ -54,10 +54,7 @@ void RegionTable_Init_GerudoValley() {
                   Entrance(RR_GV_LOWER_STREAM, {[]{return true;}}),
   });
 
-  areaTable[RR_GV_FORTRESS_SIDE] = Region("GV Fortress Side", "Gerudo Valley", RA_GERUDO_VALLEY, DAY_NIGHT_CYCLE, {
-                  //Events
-                  EventAccess(&logic->BrokenSwordAccess, {[]{return logic->IsAdult && (logic->PoachersSawAccess || logic->CanUse(RG_POACHERS_SAW));}}),
-                }, {
+  areaTable[RR_GV_FORTRESS_SIDE] = Region("GV Fortress Side", "Gerudo Valley", RA_GERUDO_VALLEY, DAY_NIGHT_CYCLE, {}, {
                   //Locations                                       
                   LOCATION(RC_GV_CHEST,          logic->IsAdult && logic->CanUse(RG_MEGATON_HAMMER)),
                   LOCATION(RC_GV_TRADE_SAW,      logic->IsAdult && logic->CanUse(RG_POACHERS_SAW)),

--- a/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_hyrule_field.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_hyrule_field.cpp
@@ -151,10 +151,7 @@ void RegionTable_Init_HyruleField() {
                   Entrance(RR_HYRULE_FIELD, {[]{return true;}}),
   });
 
-  areaTable[RR_LH_LAB] = Region("LH Lab", "LH Lab", RA_NONE, NO_DAY_NIGHT_CYCLE, {
-                  //Events
-                  EventAccess(&logic->EyedropsAccess, {[]{return logic->EyedropsAccess || (logic->IsAdult && (logic->EyeballFrogAccess || (logic->CanUse(RG_EYEBALL_FROG) && logic->DisableTradeRevert)));}}),
-                }, {
+  areaTable[RR_LH_LAB] = Region("LH Lab", "LH Lab", RA_NONE, NO_DAY_NIGHT_CYCLE, {}, {
                   //Locations
                   LOCATION(RC_LH_LAB_DIVE,     logic->HasItem(RG_GOLDEN_SCALE) || (ctx->GetTrickOption(RT_LH_LAB_DIVING) && logic->CanUse(RG_IRON_BOOTS) && logic->CanUse(RG_HOOKSHOT))),
                   LOCATION(RC_LH_TRADE_FROG,   logic->IsAdult && logic->CanUse(RG_EYEBALL_FROG)),

--- a/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_kakariko.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_kakariko.cpp
@@ -6,7 +6,6 @@ using namespace Rando;
 void RegionTable_Init_Kakariko() {
   areaTable[RR_KAKARIKO_VILLAGE] = Region("Kakariko Village", "Kakariko Village", RA_KAKARIKO_VILLAGE, NO_DAY_NIGHT_CYCLE, {
                   //Events
-                  EventAccess(&logic->CojiroAccess,            {[]{return logic->CojiroAccess || (logic->IsAdult && logic->WakeUpAdultTalon);}}),
                   EventAccess(&logic->BugRock,                 {[]{return true;}}),
                   EventAccess(&logic->KakarikoVillageGateOpen, {[]{return logic->KakarikoVillageGateOpen || (logic->IsChild && (logic->HasItem(RG_ZELDAS_LETTER) || ctx->GetOption(RSK_KAK_GATE).Is(RO_KAK_GATE_OPEN)));}}),
                 }, {
@@ -14,7 +13,7 @@ void RegionTable_Init_Kakariko() {
                   LOCATION(RC_SHEIK_IN_KAKARIKO,               logic->IsAdult && logic->HasItem(RG_FOREST_MEDALLION) && logic->HasItem(RG_FIRE_MEDALLION) && logic->HasItem(RG_WATER_MEDALLION)),
                   LOCATION(RC_KAK_ANJU_AS_CHILD,               logic->IsChild && logic->AtDay),
                   LOCATION(RC_KAK_ANJU_AS_ADULT,               logic->IsAdult && logic->AtDay),
-                  LOCATION(RC_KAK_TRADE_POCKET_CUCCO,          logic->IsAdult && logic->AtDay && logic->CanUse(RG_POCKET_EGG) && logic->WakeUpAdultTalon),
+                  LOCATION(RC_KAK_TRADE_POCKET_CUCCO,          logic->IsAdult && logic->AtDay && (logic->CanUse(RG_POCKET_EGG) && logic->WakeUpAdultTalon)),
                   LOCATION(RC_KAK_GS_HOUSE_UNDER_CONSTRUCTION, logic->IsChild && logic->AtNight && logic->CanGetNightTimeGS()),
                   LOCATION(RC_KAK_GS_SKULLTULA_HOUSE,          logic->IsChild && logic->AtNight && logic->CanGetNightTimeGS()),
                   LOCATION(RC_KAK_GS_GUARDS_HOUSE,             logic->IsChild && logic->AtNight && logic->CanGetNightTimeGS()),
@@ -72,7 +71,7 @@ void RegionTable_Init_Kakariko() {
 
   areaTable[RR_KAK_CARPENTER_BOSS_HOUSE] = Region("Kak Carpenter Boss House", "Kak Carpenter Boss House", RA_NONE, NO_DAY_NIGHT_CYCLE, {
                   //Events
-                  EventAccess(&logic->WakeUpAdultTalon, {[]{return logic->WakeUpAdultTalon || (logic->IsAdult && logic->CanUse(RG_POCKET_EGG));}}),
+                  EventAccess(&logic->WakeUpAdultTalon, {[]{return logic->IsAdult && logic->CanUse(RG_POCKET_EGG);}}),
                 }, {}, {
                   //Exits
                   Entrance(RR_KAKARIKO_VILLAGE, {[]{return true;}}),
@@ -170,16 +169,10 @@ void RegionTable_Init_Kakariko() {
   });
 
   areaTable[RR_KAK_ODD_POTION_BUILDING] =
-      Region("Kak Granny's Potion Shop", "Kak Granny's Potion Shop", RA_NONE, NO_DAY_NIGHT_CYCLE, {
-          
-               // Events
-               EventAccess(&logic->OddPoulticeAccess, { [] {
-                   return logic->OddPoulticeAccess || (logic->IsAdult && (logic->OddMushroomAccess || (logic->CanUse(RG_ODD_MUSHROOM) && logic->DisableTradeRevert)));
-               } }),
-           },
+      Region("Kak Granny's Potion Shop", "Kak Granny's Potion Shop", RA_NONE, NO_DAY_NIGHT_CYCLE, {},
            {
                LOCATION(RC_KAK_TRADE_ODD_MUSHROOM, logic->IsAdult && logic->CanUse(RG_ODD_MUSHROOM)),
-               LOCATION(RC_KAK_GRANNYS_SHOP, logic->IsAdult && logic->CanUse(RG_ODD_MUSHROOM) && logic->HasItem(RG_ADULT_WALLET)),
+               LOCATION(RC_KAK_GRANNYS_SHOP, logic->IsAdult && (logic->CanUse(RG_ODD_MUSHROOM) || logic->TradeQuestStep(RG_ODD_MUSHROOM)) && logic->HasItem(RG_ADULT_WALLET)),
            },
            {
                // Exits

--- a/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_lost_woods.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_lost_woods.cpp
@@ -113,8 +113,6 @@ void RegionTable_Init_LostWoods() {
 
   areaTable[RR_THE_LOST_WOODS] = Region("Lost Woods", "Lost Woods", RA_THE_LOST_WOODS, NO_DAY_NIGHT_CYCLE, {
                   //Events
-                  EventAccess(&logic->OddMushroomAccess, {[]{return logic->OddMushroomAccess || (logic->IsAdult && (logic->CojiroAccess || logic->CanUse(RG_COJIRO)));}}),
-                  EventAccess(&logic->PoachersSawAccess, {[]{return logic->PoachersSawAccess || (logic->IsAdult && logic->OddPoulticeAccess);}}),
                   EventAccess(&logic->GossipStoneFairy,  {[]{return logic->CallGossipFairyExceptSuns();}}),
                   EventAccess(&logic->BeanPlantFairy,    {[]{return logic->BeanPlantFairy    || logic->CanUse(RG_SONG_OF_STORMS);}}),
                   EventAccess(&logic->BugShrub,          {[]{return logic->IsChild && logic->CanCutShrubs();}}),
@@ -122,7 +120,8 @@ void RegionTable_Init_LostWoods() {
                   //Locations
                   LOCATION(RC_LW_SKULL_KID,                 logic->IsChild && logic->CanUse(RG_SARIAS_SONG)),
                   LOCATION(RC_LW_TRADE_COJIRO,              logic->IsAdult && logic->CanUse(RG_COJIRO)),
-                  LOCATION(RC_LW_TRADE_ODD_POTION,          logic->IsAdult && logic->CanUse(RG_ODD_POTION) && logic->CanUse(RG_COJIRO)),
+                  //I cannot think of a case where you can use Odd pot but not Cojiro to reset the quadrant should you have both. If one exists, add it to logic
+                  LOCATION(RC_LW_TRADE_ODD_POTION,          logic->IsAdult && logic->CanUse(RG_ODD_POTION)),
                                                                                                 //all 5 buttons are logically required for memory game
                                                                                                 //because the chances of being able to beat it
                                                                                                 //every time you attempt it are as follows:

--- a/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_zoras_domain.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/location_access/locacc_zoras_domain.cpp
@@ -84,7 +84,6 @@ void RegionTable_Init_ZorasDomain() {
 
   areaTable[RR_ZORAS_DOMAIN] = Region("Zoras Domain", "Zoras Domain", RA_ZORAS_DOMAIN, NO_DAY_NIGHT_CYCLE, {
                   //Events
-                  EventAccess(&logic->EyeballFrogAccess, {[]{return logic->EyeballFrogAccess || (logic->IsAdult && logic->KingZoraThawed && (logic->CanUse(RG_EYEDROPS) || logic->CanUse(RG_EYEBALL_FROG) || logic->CanUse(RG_PRESCRIPTION) || logic->PrescriptionAccess));}}),
                   EventAccess(&logic->GossipStoneFairy,  {[]{return logic->CallGossipFairyExceptSuns();}}),
                   EventAccess(&logic->NutPot,            {[]{return true;}}),
                   EventAccess(&logic->StickPot,          {[]{return logic->StickPot          || logic->IsChild;}}),

--- a/soh/soh/Enhancements/randomizer/location_list.cpp
+++ b/soh/soh/Enhancements/randomizer/location_list.cpp
@@ -1,5 +1,6 @@
 #include "static_data.h"
 #include "z64save.h"
+#include "context.h"
 
 #define TWO_ACTOR_PARAMS(a, b) (abs(a) << 16) | abs(b)
 
@@ -54,6 +55,16 @@ std::vector<RandomizerCheck> Rando::StaticData::GetScrubLocations() {
     return scrubLocations;
 }
 
+std::vector<RandomizerCheck> Rando::StaticData::GetAdultTradeLocations() {
+    std::vector<RandomizerCheck> tradeLocations = {};
+    for (Location& location : locationTable) {
+        if (location.GetRCType() == RCTYPE_ADULT_TRADE && location.GetRandomizerCheck() != RC_UNKNOWN_CHECK) {
+            tradeLocations.push_back(location.GetRandomizerCheck());
+        }
+    }
+    return tradeLocations;
+}
+
 std::vector<RandomizerCheck> Rando::StaticData::GetGossipStoneLocations() {
     std::vector<RandomizerCheck> gossipStoneLocations = {};
     for (Location& location : locationTable) {
@@ -74,8 +85,11 @@ std::vector<RandomizerCheck> Rando::StaticData::GetShopLocations() {
     return shopLocations;
 }
 
+
 std::vector<RandomizerCheck> Rando::StaticData::GetOverworldLocations() {
+    //RANDOTODO better way of filling the initial location pool, among other things. 
     std::vector<RandomizerCheck> overworldLocations = {};
+    auto ctx = Rando::Context::GetInstance();
     for (Location& location : locationTable) {
         if (
             location.IsOverworld() &&
@@ -83,6 +97,7 @@ std::vector<RandomizerCheck> Rando::StaticData::GetOverworldLocations() {
             location.GetRandomizerCheck() != RC_TRIFORCE_COMPLETED && //not really an overworld check
             location.GetRCType() != RCTYPE_FISH && //temp fix while locations are properly sorted out
             location.GetRCType() != RCTYPE_CHEST_GAME && //this is supposed to be excluded
+            (ctx->GetOption(RSK_SHUFFLE_ADULT_TRADE) || location.GetRCType() != RCTYPE_ADULT_TRADE) && //trade is handled elsewhere in location pool
             location.GetRCType() != RCTYPE_STATIC_HINT && 
             location.GetRCType() != RCTYPE_GOSSIP_STONE  //don't put items on hints
         ) {

--- a/soh/soh/Enhancements/randomizer/logic.h
+++ b/soh/soh/Enhancements/randomizer/logic.h
@@ -40,15 +40,6 @@ class Logic {
 
     // Trade Quest Events
     bool WakeUpAdultTalon = false;
-    bool CojiroAccess = false;
-    bool OddMushroomAccess = false;
-    bool OddPoulticeAccess = false;
-    bool PoachersSawAccess = false;
-    bool BrokenSwordAccess = false;
-    bool PrescriptionAccess = false;
-    bool EyeballFrogAccess = false;
-    bool EyedropsAccess = false;
-    bool DisableTradeRevert = false;
 
     // Dungeon Clears
     bool DekuTreeClear = false;
@@ -199,7 +190,9 @@ class Logic {
     bool CanBreakLowerBeehives();
     bool HasFireSource();
     bool HasFireSourceWithTorch();
+    bool TradeQuestStep(RandomizerGet rg);
     bool CanFinishGerudoFortress();
+    bool CanStandingShield();
     bool CanShield();
     bool CanUseProjectile();
     bool CanBuildRainbowBridge();

--- a/soh/soh/Enhancements/randomizer/randomizerTypes.h
+++ b/soh/soh/Enhancements/randomizer/randomizerTypes.h
@@ -4369,6 +4369,7 @@ typedef enum {
     RE_KEESE,
     RE_FIRE_KEESE,
     RE_MAD_SCRUB,
+    RE_BLUE_BUBBLE,
 } RandomizerEnemy;
 
 typedef enum {

--- a/soh/soh/Enhancements/randomizer/static_data.h
+++ b/soh/soh/Enhancements/randomizer/static_data.h
@@ -40,6 +40,7 @@ class StaticData {
       static std::vector<RandomizerCheck> dungeonRewardLocations;
       static std::vector<RandomizerCheck> GetShopLocations();
       static std::vector<RandomizerCheck> GetScrubLocations();
+      static std::vector<RandomizerCheck> GetAdultTradeLocations();
       static std::vector<RandomizerCheck> GetGossipStoneLocations();
       static std::vector<RandomizerCheck> GetStaticHintLocations();
       static std::vector<RandomizerCheck> GetPondFishLocations();


### PR DESCRIPTION
As title, this fixes recently discovered seed generations issues, as well as cases where child can use turtle hylian shield to achieve something.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2021241350.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2021261724.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2021263348.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2021264190.zip)
<!--- section:artifacts:end -->