### PR TITLE
Fix interpolation for Kaleido

### DIFF
--- a/soh/src/code/z_view.c
+++ b/soh/src/code/z_view.c
@@ -398,7 +398,8 @@ s32 func_800AAA9C(View* view) {
         }
     }
 
-    if (dont_interpolate) {
+    // Ignore camera heuristics when paused as the camera moves a lot in Kaleido, allowing it to be interpolate
+    if (dont_interpolate && R_PAUSE_MENU_MODE == 0) {
         FrameInterpolation_DontInterpolateCamera();
     }
 


### PR DESCRIPTION
When kaleido opens or pages are rotated, the game's camera is what moves, not the actual menu. This "erratic" movement of the camera trips our camera heuristics for dealing with camera "jump cuts" for interpolation. This had an effect of making kaleido not interpolate.

I've adjusted the logic to ignore camera heuristics if kaleido is open, which seems to work nicely as there aren't actual camera "jump cuts" when the game is paused.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2038222000.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2038252367.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2038255274.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2038255483.zip)
<!--- section:artifacts:end -->