### PR TITLE
Attempt to fix improperly set areas

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/fill.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/fill.cpp
@@ -613,14 +613,14 @@ void ValidateEntrances(bool checkPoeCollectorAccess, bool checkOtherEntranceAcce
 
 void LookForExternalArea(Region* currentRegion, std::set<Region*> &alreadyChecked, std::set<RandomizerArea> &areas, bool LowPriorityMode=false){
   for (const auto& entrance : currentRegion->entrances) {
+    //if the region is arealess and hasn't already been checked, recursivly check what connects to it
     //if this entrance does not pass areas, only process it if we are in low priority mode
-    if (LowPriorityMode || entrance->DoesSpreadAreas()){
+    if ((LowPriorityMode || entrance->DoesSpreadAreas()) && !alreadyChecked.contains(entrance->GetParentRegion())){
       std::set<RandomizerArea> otherAreas = entrance->GetParentRegion()->GetAllAreas();
-      //if the region is arealess and hasn't already been checked, recursivly check what connects to it
-      if (otherAreas.size() == 0 && !alreadyChecked.contains(currentRegion)) {
-        alreadyChecked.insert(entrance->GetParentRegion());
+      alreadyChecked.insert(entrance->GetParentRegion());
+      if (otherAreas.size() == 0) {
         LookForExternalArea(entrance->GetParentRegion(), alreadyChecked, areas, LowPriorityMode);
-      //if we find an area and it's not links pocket, we should try and add it.
+      //If we find a valid area we should add it.
       //If it's Links Pocket or RA_NONE, do not propagate those, they are not real areas.
       //This check is likely to fail if a region somehow is both in Link's Pocket and elsewhere, but this should never happen
       } else if (*otherAreas.begin() > RA_LINKS_POCKET){

--- a/soh/soh/Enhancements/randomizer/3drando/fill.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/fill.cpp
@@ -635,14 +635,14 @@ void SetAreas(){
 //RANDOTODO give entrances an enum like RandomizerCheck, the give them all areas here,
 //then use those areas to not need to recursivly find ItemLocation areas when an identifying entrance's area
   for (int regionType = 0; regionType < RR_MARKER_AREAS_END; regionType++) {
-    Region region = areaTable[regionType];
-    std::set<RandomizerArea> areas = region.GetAllAreas();
-    std::set<Region*> regionsToSet = {&region};
+    Region* region = &areaTable[regionType];
+    std::set<RandomizerArea> areas = region->GetAllAreas();
+    std::set<Region*> regionsToSet = {region};
     if (areas.empty()) {
-      LookForExternalArea(&region, regionsToSet, areas);
+      LookForExternalArea(region, regionsToSet, areas);
       //If we found nothing, try again in low priority mode to try every entrance
       if (areas.empty()) {
-        LookForExternalArea(&region, regionsToSet, areas, true);
+        LookForExternalArea(region, regionsToSet, areas, true);
         //If we still found nothing, we're disconnected, use RA_NONE to represent that
         if (areas.empty()){
           areas.insert(RA_NONE);

--- a/soh/soh/Enhancements/randomizer/3drando/hints.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/hints.cpp
@@ -501,25 +501,33 @@ void CreateWarpSongTexts() {
     auto warpSongEntrances = GetShuffleableEntrances(EntranceType::WarpSong, false);
     for (auto entrance : warpSongEntrances) {
       //RANDOTODO make random
-      const auto destination = entrance->GetConnectedRegion()->GetAllAreas().begin();
+      RandomizerArea destination = RA_NONE;
+      if (!entrance->GetConnectedRegion()->GetAllAreas().empty()){
+        destination = *entrance->GetConnectedRegion()->GetAllAreas().begin();
+      } else {
+        auto test = *entrance->GetConnectedRegion()->GetAllAreas().begin();
+        auto testtwo = entrance->GetConnectedRegion()->GetAllAreas().empty();
+        auto testthree = entrance->GetConnectedRegion()->GetAllAreas().size();
+        destination = RA_NONE;
+      }
       switch (entrance->GetIndex()) {
         case 0x0600: // minuet RANDOTODO make into entrance hints when they are added
-          ctx->AddHint(RH_MINUET_WARP_LOC, Hint(RH_MINUET_WARP_LOC, HINT_TYPE_AREA, "", {RHT_WARP_SONG}, {}, {*destination}));
+          ctx->AddHint(RH_MINUET_WARP_LOC, Hint(RH_MINUET_WARP_LOC, HINT_TYPE_AREA, "", {RHT_WARP_SONG}, {}, {destination}));
           break;
         case 0x04F6: // bolero
-          ctx->AddHint(RH_BOLERO_WARP_LOC, Hint(RH_BOLERO_WARP_LOC, HINT_TYPE_AREA, "", {RHT_WARP_SONG}, {}, {*destination}));
+          ctx->AddHint(RH_BOLERO_WARP_LOC, Hint(RH_BOLERO_WARP_LOC, HINT_TYPE_AREA, "", {RHT_WARP_SONG}, {}, {destination}));
           break;
         case 0x0604: // serenade
-          ctx->AddHint(RH_SERENADE_WARP_LOC, Hint(RH_SERENADE_WARP_LOC, HINT_TYPE_AREA, "", {RHT_WARP_SONG}, {}, {*destination}));
+          ctx->AddHint(RH_SERENADE_WARP_LOC, Hint(RH_SERENADE_WARP_LOC, HINT_TYPE_AREA, "", {RHT_WARP_SONG}, {}, {destination}));
           break;
         case 0x01F1: // requiem
-          ctx->AddHint(RH_REQUIEM_WARP_LOC, Hint(RH_REQUIEM_WARP_LOC, HINT_TYPE_AREA, "", {RHT_WARP_SONG}, {}, {*destination}));
+          ctx->AddHint(RH_REQUIEM_WARP_LOC, Hint(RH_REQUIEM_WARP_LOC, HINT_TYPE_AREA, "", {RHT_WARP_SONG}, {}, {destination}));
           break;
         case 0x0568: // nocturne
-          ctx->AddHint(RH_NOCTURNE_WARP_LOC, Hint(RH_NOCTURNE_WARP_LOC, HINT_TYPE_AREA, "", {RHT_WARP_SONG}, {}, {*destination}));
+          ctx->AddHint(RH_NOCTURNE_WARP_LOC, Hint(RH_NOCTURNE_WARP_LOC, HINT_TYPE_AREA, "", {RHT_WARP_SONG}, {}, {destination}));
           break;
         case 0x05F4: // prelude
-          ctx->AddHint(RH_PRELUDE_WARP_LOC, Hint(RH_PRELUDE_WARP_LOC, HINT_TYPE_AREA, "", {RHT_WARP_SONG}, {}, {*destination}));
+          ctx->AddHint(RH_PRELUDE_WARP_LOC, Hint(RH_PRELUDE_WARP_LOC, HINT_TYPE_AREA, "", {RHT_WARP_SONG}, {}, {destination}));
           break;
         default:
           break;

--- a/soh/soh/Enhancements/randomizer/3drando/hints.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/hints.cpp
@@ -504,11 +504,6 @@ void CreateWarpSongTexts() {
       RandomizerArea destination = RA_NONE;
       if (!entrance->GetConnectedRegion()->GetAllAreas().empty()){
         destination = *entrance->GetConnectedRegion()->GetAllAreas().begin();
-      } else {
-        auto test = *entrance->GetConnectedRegion()->GetAllAreas().begin();
-        auto testtwo = entrance->GetConnectedRegion()->GetAllAreas().empty();
-        auto testthree = entrance->GetConnectedRegion()->GetAllAreas().size();
-        destination = RA_NONE;
       }
       switch (entrance->GetIndex()) {
         case 0x0600: // minuet RANDOTODO make into entrance hints when they are added


### PR DESCRIPTION
This fixes a few oversights I found in SetAreas that were causing crashes on debugs and likely bad hints elsewhere

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2045630231.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2045641134.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2045647388.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2045706364.zip)
<!--- section:artifacts:end -->