### PR TITLE
[Bugfix] Prevent Greg as Reward Crash

### DIFF
--- a/soh/soh/Enhancements/randomizer/settings.cpp
+++ b/soh/soh/Enhancements/randomizer/settings.cpp
@@ -1580,6 +1580,9 @@ void Settings::UpdateOptionProperties() {
                 } else {
                     if (mOptions[RSK_RAINBOW_BRIDGE_STONE_COUNT].GetOptionCount() == 5) {
                         mOptions[RSK_RAINBOW_BRIDGE_STONE_COUNT].ChangeOptions(NumOpts(0, 3));
+                        if (CVarGetInteger(CVAR_RANDOMIZER_SETTING("StoneCount"), 0) == 4) {
+                            CVarSetInteger(CVAR_RANDOMIZER_SETTING("StoneCount"), 3);
+                        }
                     }
                 }
                 break;
@@ -1595,6 +1598,9 @@ void Settings::UpdateOptionProperties() {
                 } else {
                     if (mOptions[RSK_RAINBOW_BRIDGE_MEDALLION_COUNT].GetOptionCount() == 8) {
                         mOptions[RSK_RAINBOW_BRIDGE_MEDALLION_COUNT].ChangeOptions(NumOpts(0, 6));
+                        if (CVarGetInteger(CVAR_RANDOMIZER_SETTING("MedallionCount"), 0) == 7) {
+                            CVarSetInteger(CVAR_RANDOMIZER_SETTING("MedallionCount"), 6);
+                        }
                     }
                 }
                 break;
@@ -1610,6 +1616,9 @@ void Settings::UpdateOptionProperties() {
                 } else {
                     if (mOptions[RSK_RAINBOW_BRIDGE_REWARD_COUNT].GetOptionCount() == 11) {
                         mOptions[RSK_RAINBOW_BRIDGE_REWARD_COUNT].ChangeOptions(NumOpts(0, 9));
+                        if (CVarGetInteger(CVAR_RANDOMIZER_SETTING("RewardCount"), 0) == 10) {
+                            CVarSetInteger(CVAR_RANDOMIZER_SETTING("RewardCount"), 9);
+                        }
                     }
                 }
                 break;
@@ -1625,6 +1634,9 @@ void Settings::UpdateOptionProperties() {
                 } else {
                     if (mOptions[RSK_RAINBOW_BRIDGE_DUNGEON_COUNT].GetOptionCount() == 10) {
                         mOptions[RSK_RAINBOW_BRIDGE_DUNGEON_COUNT].ChangeOptions(NumOpts(0, 8));
+                        if (CVarGetInteger(CVAR_RANDOMIZER_SETTING("DungeonCount"), 0) == 9) {
+                            CVarSetInteger(CVAR_RANDOMIZER_SETTING("DungeonCount"), 8);
+                        }
                     }
                 }
                 break;
@@ -2059,6 +2071,9 @@ void Settings::UpdateOptionProperties() {
             } else {
                 if (mOptions[RSK_LACS_STONE_COUNT].GetOptionCount() == 5) {
                     mOptions[RSK_LACS_STONE_COUNT].ChangeOptions(NumOpts(0, 3));
+                    if (CVarGetInteger(CVAR_RANDOMIZER_SETTING("LacsStoneCount"), 0) == 4) {
+                        CVarSetInteger(CVAR_RANDOMIZER_SETTING("LacsStoneCount"), 3);
+                    }
                 }
             }
             break;
@@ -2072,6 +2087,9 @@ void Settings::UpdateOptionProperties() {
             } else {
                 if (mOptions[RSK_LACS_MEDALLION_COUNT].GetOptionCount() == 8) {
                     mOptions[RSK_LACS_MEDALLION_COUNT].ChangeOptions(NumOpts(0, 6));
+                    if (CVarGetInteger(CVAR_RANDOMIZER_SETTING("LacsMedallionCount"), 0) == 7) {
+                        CVarSetInteger(CVAR_RANDOMIZER_SETTING("LacsMedallionCount"), 6);
+                    }
                 }
             }
             break;
@@ -2085,6 +2103,9 @@ void Settings::UpdateOptionProperties() {
             } else {
                 if (mOptions[RSK_LACS_REWARD_COUNT].GetOptionCount() == 11) {
                     mOptions[RSK_LACS_REWARD_COUNT].ChangeOptions(NumOpts(0, 9));
+                    if (CVarGetInteger(CVAR_RANDOMIZER_SETTING("LacsRewardCount"), 0) == 10) {
+                        CVarSetInteger(CVAR_RANDOMIZER_SETTING("LacsRewardCount"), 9);
+                    }
                 }
             }
             break;
@@ -2098,6 +2119,9 @@ void Settings::UpdateOptionProperties() {
             } else {
                 if (mOptions[RSK_LACS_DUNGEON_COUNT].GetOptionCount() == 10) {
                     mOptions[RSK_LACS_DUNGEON_COUNT].ChangeOptions(NumOpts(0, 8));
+                    if (CVarGetInteger(CVAR_RANDOMIZER_SETTING("LacsDungeonCount"), 0) == 9) {
+                        CVarSetInteger(CVAR_RANDOMIZER_SETTING("LacsDungeonCount"), 8);
+                    }
                 }
             }
             break;


### PR DESCRIPTION
Decrements the appropriate CVars to prevent a crash that occurs with the following conditions:

- Rainbow Bridge or LACS set to Stones, Medallions, Rewards, or Dungeons
- Set option to Greg as Reward
- Increase the slider to maximum
- Set option to Standard Reward or Greg as Wildcard

If there's a better way to do this, happy to change it - was planning to steal what this was doing and found the crash instead.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2058839855.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2058926702.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2058932828.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2058935133.zip)
<!--- section:artifacts:end -->