### PR TITLE
Fix fast speed skipping quick text markers

### DIFF
--- a/soh/src/code/z_message_PAL.c
+++ b/soh/src/code/z_message_PAL.c
@@ -856,6 +856,8 @@ void Message_DrawText(PlayState* play, Gfx** gfxP) {
     msgCtx->unk_E3D0 = 0;
     charTexIdx = 0;
 
+    gTextSpeed = CVarGetInteger(CVAR_ENHANCEMENT("TextSpeed"), 1);
+
     for (i = 0; i < msgCtx->textDrawPos; i++) {
         character = msgCtx->msgBufDecoded[i];
 
@@ -903,9 +905,9 @@ void Message_DrawText(PlayState* play, Gfx** gfxP) {
                 *gfxP = gfx;
                 return;
             case MESSAGE_QUICKTEXT_ENABLE:
-                if (i + 1 == msgCtx->textDrawPos && (msgCtx->msgMode == MSGMODE_TEXT_DISPLAYING ||
-                                                     (msgCtx->msgMode >= MSGMODE_OCARINA_STARTING &&
-                                                      msgCtx->msgMode < MSGMODE_SCARECROW_LONG_RECORDING_START))) {
+                if (i < msgCtx->textDrawPos && i + gTextSpeed >= msgCtx->textDrawPos && (msgCtx->msgMode == MSGMODE_TEXT_DISPLAYING ||
+                                                                                         (msgCtx->msgMode >= MSGMODE_OCARINA_STARTING &&
+                                                                                          msgCtx->msgMode < MSGMODE_SCARECROW_LONG_RECORDING_START))) {
                     j = i;
                     while (true) {
                         lookAheadCharacter = msgCtx->msgBufDecoded[j];
@@ -922,8 +924,10 @@ void Message_DrawText(PlayState* play, Gfx** gfxP) {
                             break;
                         }
                     }
-                    i = j - 1;
-                    msgCtx->textDrawPos = i + 1;
+                    if (j > msgCtx->textDrawPos) {
+                        i = j - 1;
+                        msgCtx->textDrawPos = j;
+                    }
 
                     if (character) {}
                 }
@@ -1116,8 +1120,6 @@ void Message_DrawText(PlayState* play, Gfx** gfxP) {
                 break;
         }
     }
-
-    gTextSpeed = CVarGetInteger(CVAR_ENHANCEMENT("TextSpeed"), 1);
     if (msgCtx->textDelay == 0) {
         msgCtx->textDrawPos = i + gTextSpeed;
     } else if (msgCtx->textDelayTimer == 0) {


### PR DESCRIPTION
Fixes #4083 (part 1; part 2 already fixed)

The text renderer was capable of skipping over quick text symbols designed to control when an entire string should be added to the display all at once. Now it'll recognize them no matter what.

https://github.com/user-attachments/assets/f120385e-4a47-4dcd-98be-56ebcf9bcf6c

https://github.com/user-attachments/assets/00288d14-8411-4ce1-b31c-08b54c50231c

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2059514570.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2059577308.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2059585018.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2059587456.zip)
<!--- section:artifacts:end -->