### PR TITLE
Segregate count-injected item get messages by type

### DIFF
--- a/soh/soh/Enhancements/presets.h
+++ b/soh/soh/Enhancements/presets.h
@@ -1037,7 +1037,7 @@ const std::vector<PresetEntry> spockRaceNoLogicPresetEntries = {
     PRESET_ENTRY_S32(CVAR_ENHANCEMENT("FishNeverEscape"), 1),
     PRESET_ENTRY_S32(CVAR_ENHANCEMENT("ForgeTime"), 0),
     PRESET_ENTRY_S32(CVAR_ENHANCEMENT("GoronPot"), 1),
-    PRESET_ENTRY_S32(CVAR_ENHANCEMENT("GuaranteeFishingBite"), 1)
+    PRESET_ENTRY_S32(CVAR_ENHANCEMENT("GuaranteeFishingBite"), 1),
     PRESET_ENTRY_S32(CVAR_ENHANCEMENT("InjectItemCounts.GoldSkulltula"), 1),
     PRESET_ENTRY_S32(CVAR_ENHANCEMENT("InjectItemCounts.HeartPiece"), 1),
     PRESET_ENTRY_S32(CVAR_ENHANCEMENT("InjectItemCounts.HeartContainer"), 1),

--- a/soh/soh/Enhancements/presets.h
+++ b/soh/soh/Enhancements/presets.h
@@ -142,7 +142,9 @@ const std::vector<const char*> enhancementsCvars = {
     CVAR_ENHANCEMENT("CowOfTime"),
     CVAR_ENHANCEMENT("GuardVision"),
     CVAR_ENHANCEMENT("TimeFlowFileSelect"),
-    CVAR_ENHANCEMENT("InjectItemCounts"),
+    CVAR_ENHANCEMENT("InjectItemCounts.GoldSkulltula"),
+    CVAR_ENHANCEMENT("InjectItemCounts.HeartPiece"),
+    CVAR_ENHANCEMENT("InjectItemCounts.HeartContainer"),
     CVAR_ENHANCEMENT("DayGravePull"),
     CVAR_ENHANCEMENT("DampeAllNight"),
     CVAR_ENHANCEMENT("QuitFishingAtDoor"),
@@ -573,7 +575,9 @@ const std::vector<PresetEntry> vanillaPlusPresetEntries = {
     // Enable passage of time on file select
     PRESET_ENTRY_S32(CVAR_ENHANCEMENT("TimeFlowFileSelect"), 1),
     // Inject Item Counts in messages
-    PRESET_ENTRY_S32(CVAR_ENHANCEMENT("InjectItemCounts"), 1),
+    PRESET_ENTRY_S32(CVAR_ENHANCEMENT("InjectItemCounts.GoldSkulltula"), 1),
+    PRESET_ENTRY_S32(CVAR_ENHANCEMENT("InjectItemCounts.HeartPiece"), 1),
+    PRESET_ENTRY_S32(CVAR_ENHANCEMENT("InjectItemCounts.HeartContainer"), 1),
 
     // Pause link animation (0 to 16)
     PRESET_ENTRY_S32(CVAR_ENHANCEMENT("PauseLiveLink"), 1),
@@ -644,7 +648,9 @@ const std::vector<PresetEntry> enhancedPresetEntries = {
     // Enable passage of time on file select
     PRESET_ENTRY_S32(CVAR_ENHANCEMENT("TimeFlowFileSelect"), 1),
     // Inject Item Counts in messages
-    PRESET_ENTRY_S32(CVAR_ENHANCEMENT("InjectItemCounts"), 1),
+    PRESET_ENTRY_S32(CVAR_ENHANCEMENT("InjectItemCounts.GoldSkulltula"), 1),
+    PRESET_ENTRY_S32(CVAR_ENHANCEMENT("InjectItemCounts.HeartPiece"), 1),
+    PRESET_ENTRY_S32(CVAR_ENHANCEMENT("InjectItemCounts.HeartContainer"), 1),
 
     // Pause link animation (0 to 16)
     PRESET_ENTRY_S32(CVAR_ENHANCEMENT("PauseLiveLink"), 1),
@@ -776,7 +782,9 @@ const std::vector<PresetEntry> randomizerPresetEntries = {
     // Enable passage of time on file select
     PRESET_ENTRY_S32(CVAR_ENHANCEMENT("TimeFlowFileSelect"), 1),
     // Inject Item Counts in messages
-    PRESET_ENTRY_S32(CVAR_ENHANCEMENT("InjectItemCounts"), 1),
+    PRESET_ENTRY_S32(CVAR_ENHANCEMENT("InjectItemCounts.GoldSkulltula"), 1),
+    PRESET_ENTRY_S32(CVAR_ENHANCEMENT("InjectItemCounts.HeartPiece"), 1),
+    PRESET_ENTRY_S32(CVAR_ENHANCEMENT("InjectItemCounts.HeartContainer"), 1),
 
     // Dynamic Wallet Icon
     PRESET_ENTRY_S32(CVAR_ENHANCEMENT("DynamicWalletIcon"), 1),
@@ -945,7 +953,9 @@ const std::vector<PresetEntry> spockRacePresetEntries = {
     PRESET_ENTRY_S32(CVAR_ENHANCEMENT("FastFarores"), 1),
     PRESET_ENTRY_S32(CVAR_ENHANCEMENT("NoInputForCredits"), 1),
     PRESET_ENTRY_S32(CVAR_ENHANCEMENT("MaskSelect"), 1),
-    PRESET_ENTRY_S32(CVAR_ENHANCEMENT("InjectItemCounts"), 1),
+    PRESET_ENTRY_S32(CVAR_ENHANCEMENT("InjectItemCounts.GoldSkulltula"), 1),
+    PRESET_ENTRY_S32(CVAR_ENHANCEMENT("InjectItemCounts.HeartPiece"), 1),
+    PRESET_ENTRY_S32(CVAR_ENHANCEMENT("InjectItemCounts.HeartContainer"), 1),
     PRESET_ENTRY_S32(CVAR_ENHANCEMENT("CustomizeFishing"), 1),
     PRESET_ENTRY_S32(CVAR_ENHANCEMENT("FishNeverEscape"), 1),
     PRESET_ENTRY_S32(CVAR_ENHANCEMENT("InstantFishing"), 1),
@@ -1027,8 +1037,10 @@ const std::vector<PresetEntry> spockRaceNoLogicPresetEntries = {
     PRESET_ENTRY_S32(CVAR_ENHANCEMENT("FishNeverEscape"), 1),
     PRESET_ENTRY_S32(CVAR_ENHANCEMENT("ForgeTime"), 0),
     PRESET_ENTRY_S32(CVAR_ENHANCEMENT("GoronPot"), 1),
-    PRESET_ENTRY_S32(CVAR_ENHANCEMENT("GuaranteeFishingBite"), 1),
-    PRESET_ENTRY_S32(CVAR_ENHANCEMENT("InjectItemCounts"), 1),
+    PRESET_ENTRY_S32(CVAR_ENHANCEMENT("GuaranteeFishingBite"), 1)
+    PRESET_ENTRY_S32(CVAR_ENHANCEMENT("InjectItemCounts.GoldSkulltula"), 1),
+    PRESET_ENTRY_S32(CVAR_ENHANCEMENT("InjectItemCounts.HeartPiece"), 1),
+    PRESET_ENTRY_S32(CVAR_ENHANCEMENT("InjectItemCounts.HeartContainer"), 1),
     PRESET_ENTRY_S32(CVAR_ENHANCEMENT("InstantFishing"), 1),
     PRESET_ENTRY_S32(CVAR_ENHANCEMENT("InstantPutaway"), 1),
     PRESET_ENTRY_S32(CVAR_ENHANCEMENT("MMBunnyHood"), BUNNY_HOOD_FAST),

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -2800,7 +2800,7 @@ extern "C" int CustomMessage_RetrieveIfExists(PlayState* play) {
         }
     }
     if (textId == TEXT_GS_NO_FREEZE || textId == TEXT_GS_FREEZE) {
-        if (CVarGetInteger(CVAR_ENHANCEMENT("InjectItemCounts"), 0) != 0) {
+        if (CVarGetInteger(CVAR_ENHANCEMENT("InjectItemCounts.GoldSkulltula"), 0) != 0) {
             // The freeze text cannot be manually dismissed and must be auto-dismissed.
             // This is fine and even wanted when skull tokens are not shuffled, but when
             // when they are shuffled we don't want to be able to manually dismiss the box.
@@ -2823,10 +2823,10 @@ extern "C" int CustomMessage_RetrieveIfExists(PlayState* play) {
     } else if ((IS_RANDO || CVarGetInteger(CVAR_ENHANCEMENT("BetterBombchuShopping"), 0)) &&
                 (textId == TEXT_BUY_BOMBCHUS_10_DESC || textId == TEXT_BUY_BOMBCHUS_10_PROMPT)) {
             messageEntry = CustomMessageManager::Instance->RetrieveMessage(customMessageTableID, textId, MF_FORMATTED);
-    } else if (textId == TEXT_HEART_CONTAINER && CVarGetInteger(CVAR_ENHANCEMENT("InjectItemCounts"), 0)) {
+    } else if (textId == TEXT_HEART_CONTAINER && CVarGetInteger(CVAR_ENHANCEMENT("InjectItemCounts.HeartContainer"), 0)) {
         messageEntry = CustomMessageManager::Instance->RetrieveMessage(customMessageTableID, TEXT_HEART_CONTAINER, MF_FORMATTED);
         messageEntry.Replace("[[heartContainerCount]]", std::to_string(gSaveContext.sohStats.heartContainers + 1));
-    } else if (textId >= TEXT_HEART_PIECE && textId < TEXT_HEART_CONTAINER && CVarGetInteger(CVAR_ENHANCEMENT("InjectItemCounts"), 0)) {
+    } else if (textId >= TEXT_HEART_PIECE && textId < TEXT_HEART_CONTAINER && CVarGetInteger(CVAR_ENHANCEMENT("InjectItemCounts.HeartPiece"), 0)) {
         messageEntry = CustomMessageManager::Instance->RetrieveMessage(customMessageTableID, TEXT_HEART_PIECE, MF_FORMATTED);
         messageEntry.Replace("[[heartPieceCount]]", std::to_string(gSaveContext.sohStats.heartPieces + 1));
     } else if (textId == TEXT_MARKET_GUARD_NIGHT && CVarGetInteger(CVAR_ENHANCEMENT("MarketSneak"), 0) && play->sceneNum == SCENE_MARKET_ENTRANCE_NIGHT) {

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -826,6 +826,16 @@ void DrawEnhancementsMenu() {
 
             UIWidgets::Spacer(0);
 
+            if (ImGui::BeginMenu("Item Count Messages")) {
+                UIWidgets::EnhancementCheckbox("Gold Skulltula Tokens", CVAR_ENHANCEMENT("InjectItemCounts.GoldSkulltula"));
+                UIWidgets::PaddedEnhancementCheckbox("Pieces of Heart", CVAR_ENHANCEMENT("InjectItemCounts.HeartPiece"), true, false);
+                UIWidgets::PaddedEnhancementCheckbox("Heart Containers", CVAR_ENHANCEMENT("InjectItemCounts.HeartContainer"), true, false);
+
+                ImGui::EndMenu();
+            }
+
+            UIWidgets::Spacer(0);
+
             if (ImGui::BeginMenu("Difficulty Options"))
             {
                 if (ImGui::BeginMenu("Potion Values"))
@@ -1135,16 +1145,6 @@ void DrawEnhancementsMenu() {
                 UIWidgets::PaddedEnhancementCheckbox("Remember Minimap State Between Areas", CVAR_ENHANCEMENT("RememberMapToggleState"));
                 UIWidgets::Tooltip("Preserves the minimap visibility state when going between areas rather than defaulting it to \"on\" when going through loading zones.");
 
-                ImGui::EndMenu();
-            }
-
-            UIWidgets::Spacer(0);
-
-            if (ImGui::BeginMenu("Item Count Messages")) {
-                UIWidgets::EnhancementCheckbox("Gold Skulltula Tokens", CVAR_ENHANCEMENT("InjectItemCounts.GoldSkulltula"));
-                UIWidgets::PaddedEnhancementCheckbox("Pieces of Heart", CVAR_ENHANCEMENT("InjectItemCounts.HeartPiece"), true, false);
-                UIWidgets::PaddedEnhancementCheckbox("Heart Containers", CVAR_ENHANCEMENT("InjectItemCounts.HeartContainer"), true, false);
-                
                 ImGui::EndMenu();
             }
 

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -1140,6 +1140,16 @@ void DrawEnhancementsMenu() {
 
             UIWidgets::Spacer(0);
 
+            if (ImGui::BeginMenu("Item Count Messages")) {
+                UIWidgets::EnhancementCheckbox("Gold Skulltula Tokens", CVAR_ENHANCEMENT("InjectItemCounts.GoldSkulltula"));
+                UIWidgets::PaddedEnhancementCheckbox("Pieces of Heart", CVAR_ENHANCEMENT("InjectItemCounts.HeartPiece"), true, false);
+                UIWidgets::PaddedEnhancementCheckbox("Heart Containers", CVAR_ENHANCEMENT("InjectItemCounts.HeartContainer"), true, false);
+                
+                ImGui::EndMenu();
+            }
+
+            UIWidgets::Spacer(0);
+
             UIWidgets::EnhancementCheckbox("Visual Stone of Agony", CVAR_ENHANCEMENT("VisualAgony"));
             UIWidgets::Tooltip("Displays an icon and plays a sound when Stone of Agony should be activated, for those without rumble");
             static const char* cursorOnAnySlot[3] = { "Only in Rando", "Always", "Never" };
@@ -1165,8 +1175,6 @@ void DrawEnhancementsMenu() {
             UIWidgets::Tooltip("Allows the Lon Lon Ranch obstacle course reward to be shared across time periods");
             UIWidgets::PaddedEnhancementCheckbox("Enable visible guard vision", CVAR_ENHANCEMENT("GuardVision"), true, false);
             UIWidgets::PaddedEnhancementCheckbox("Enable passage of time on file select", CVAR_ENHANCEMENT("TimeFlowFileSelect"), true, false);
-            UIWidgets::PaddedEnhancementCheckbox("Item counts in messages", CVAR_ENHANCEMENT("InjectItemCounts"), true, false);
-            UIWidgets::Tooltip("Injects item counts in pickup messages, like golden skulltula tokens and heart pieces");
             UIWidgets::PaddedEnhancementCheckbox("Pull grave during the day", CVAR_ENHANCEMENT("DayGravePull"), true, false);
             UIWidgets::Tooltip("Allows graves to be pulled when child during the day");
             UIWidgets::PaddedEnhancementCheckbox("Dogs follow you everywhere", CVAR_ENHANCEMENT("DogFollowsEverywhere"), true, false);


### PR DESCRIPTION
Instead of one setting for all item get messages with counts injected, I've separated the settings by type. Now players can selectively inject item counts by item type (e.g. inject for Heart Pieces, but not for Heart Containers).

![2024-10-16](https://github.com/user-attachments/assets/126ea733-4b0b-4a4a-8dd7-4aef1dacfe2c)

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2063943984.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2063988927.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2063999023.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2064001603.zip)
<!--- section:artifacts:end -->