### PR TITLE
Add separate speed option for slower text

### DIFF
--- a/soh/soh/Enhancements/presets.h
+++ b/soh/soh/Enhancements/presets.h
@@ -300,6 +300,7 @@ const std::vector<const char*> enhancementsCvars = {
     CVAR_ENHANCEMENT("TimeSavers.SkipGetItemAnimation"),
     CVAR_ENHANCEMENT("TimeSavers.SkipChildStealth"),
     CVAR_ENHANCEMENT("TimeSavers.SkipTowerEscape"),
+    CVAR_ENHANCEMENT("SlowTextSpeed"),
 };
 
 const std::vector<const char*> cheatCvars = {
@@ -559,6 +560,8 @@ const std::vector<PresetEntry> vanillaPlusPresetEntries = {
 
     // Text Speed (1 to 5)
     PRESET_ENTRY_S32(CVAR_ENHANCEMENT("TextSpeed"), 5),
+    // Slow Text Speed (1 to 5)
+    PRESET_ENTRY_S32(CVAR_ENHANCEMENT("SlowTextSpeed"), 5),
     // Skip Text
     PRESET_ENTRY_S32(CVAR_ENHANCEMENT("SkipText"), 1),
     // King Zora Speed (1 to 5)
@@ -630,6 +633,8 @@ const std::vector<PresetEntry> enhancedPresetEntries = {
 
     // Text Speed (1 to 5)
     PRESET_ENTRY_S32(CVAR_ENHANCEMENT("TextSpeed"), 5),
+    // Slow Text Speed (1 to 5)
+    PRESET_ENTRY_S32(CVAR_ENHANCEMENT("SlowTextSpeed"), 5),
     // Skip Text
     PRESET_ENTRY_S32(CVAR_ENHANCEMENT("SkipText"), 1),
     // King Zora Speed (1 to 5)
@@ -762,6 +767,8 @@ const std::vector<PresetEntry> randomizerPresetEntries = {
 
     // Text Speed (1 to 5)
     PRESET_ENTRY_S32(CVAR_ENHANCEMENT("TextSpeed"), 5),
+    // Slow Text Speed (1 to 5)
+    PRESET_ENTRY_S32(CVAR_ENHANCEMENT("SlowTextSpeed"), 5),
     // Skip Text
     PRESET_ENTRY_S32(CVAR_ENHANCEMENT("SkipText"), 1),
     // King Zora Speed (1 to 5)
@@ -914,6 +921,7 @@ const std::vector<PresetEntry> randomizerPresetEntries = {
 const std::vector<PresetEntry> spockRacePresetEntries = {
     PRESET_ENTRY_S32(CVAR_RANDOMIZER_SETTING("LogicRules"), 0),
     PRESET_ENTRY_S32(CVAR_ENHANCEMENT("TextSpeed"), 5),
+    PRESET_ENTRY_S32(CVAR_ENHANCEMENT("SlowTextSpeed"), 5),
     PRESET_ENTRY_FLOAT(CVAR_ENHANCEMENT("MweepSpeed"), 5.0f),
     PRESET_ENTRY_S32(CVAR_ENHANCEMENT("ClimbSpeed"), 4),
     PRESET_ENTRY_S32(CVAR_ENHANCEMENT("FasterBlockPush"), 5),

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -666,6 +666,10 @@ void DrawEnhancementsMenu() {
 
                 UIWidgets::PaddedEnhancementSliderInt("Text Speed: %dx", "##TEXTSPEED", CVAR_ENHANCEMENT("TextSpeed"), 1, 5, "", 1, true, false, true);
                 UIWidgets::PaddedEnhancementCheckbox("Skip Text", CVAR_ENHANCEMENT("SkipText"), false, true);
+                UIWidgets::PaddedEnhancementSliderInt("Slow Text Speed: %dx", "##SLOWTEXTSPEED", CVAR_ENHANCEMENT("SlowTextSpeed"), 1, 5, "", 1, true, false, true);
+                if (ImGui::Button("Match Normal Text")) {
+                    CVarSetInteger(CVAR_ENHANCEMENT("SlowTextSpeed"), CVarGetInteger(CVAR_ENHANCEMENT("TextSpeed"), 1));
+                }
                 UIWidgets::Tooltip("Holding down B skips text");
                 UIWidgets::PaddedEnhancementSliderFloat("King Zora Speed: %.2fx", "##MWEEPSPEED", CVAR_ENHANCEMENT("MweepSpeed"), 0.1f, 5.0f, "", 1.0f, false, false, true);
                 UIWidgets::PaddedEnhancementSliderInt("Vine/Ladder Climb speed +%d", "##CLIMBSPEED", CVAR_ENHANCEMENT("ClimbSpeed"), 0, 12, "", 0, true, false, true);

--- a/soh/src/code/z_message_PAL.c
+++ b/soh/src/code/z_message_PAL.c
@@ -835,7 +835,7 @@ void Message_DrawText(PlayState* play, Gfx** gfxP) {
     u16 i;
     u16 sfxHi;
     u16 charTexIdx;
-    int gTextSpeed;
+    int gTextSpeed, gSlowTextSpeed;
     Font* font = &play->msgCtx.font;
     Gfx* gfx = *gfxP;
 
@@ -857,7 +857,8 @@ void Message_DrawText(PlayState* play, Gfx** gfxP) {
     charTexIdx = 0;
 
     gTextSpeed = CVarGetInteger(CVAR_ENHANCEMENT("TextSpeed"), 1);
-
+    gSlowTextSpeed = CVarGetInteger(CVAR_ENHANCEMENT("SlowTextSpeed"), gTextSpeed);
+    
     for (i = 0; i < msgCtx->textDrawPos; i++) {
         character = msgCtx->msgBufDecoded[i];
 
@@ -1125,10 +1126,10 @@ void Message_DrawText(PlayState* play, Gfx** gfxP) {
     } else if (msgCtx->textDelayTimer == 0) {
         msgCtx->textDrawPos = i + 1;
         msgCtx->textDelayTimer = msgCtx->textDelay;
-    } else if (msgCtx->textDelayTimer <= gTextSpeed) {
+    } else if (msgCtx->textDelayTimer <= gSlowTextSpeed) {
         msgCtx->textDelayTimer = 0;
     } else {
-        msgCtx->textDelayTimer -= gTextSpeed;
+        msgCtx->textDelayTimer -= gSlowTextSpeed;
     }
     *gfxP = gfx;
 }


### PR DESCRIPTION
Just in case people want to preserve the slower speed of delayed text, or tweak it to their preference. This eliminates the trade-off of the text speed setting between speeding it up for time savings and slowing it down for dramatic effect.

In the video, for instance, normal text speed is set to x5 while slow text is set to x1, which is why the "Heh heh heh..." appears at its normal, snail-slow pace while the rest is sped up.

https://github.com/user-attachments/assets/6d533888-09da-4c8f-9ed5-1166eafadf29

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2064115608.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2064207666.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2064212275.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2064233399.zip)
<!--- section:artifacts:end -->