### PR TITLE
Re-sync deku stick cheat CVar name.

### DIFF
--- a/soh/soh/Enhancements/cheat_hook_handlers.cpp
+++ b/soh/soh/Enhancements/cheat_hook_handlers.cpp
@@ -15,13 +15,13 @@ extern PlayState* gPlayState;
 void CheatsOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_list originalArgs) {
     switch (id) {
         case VB_DEKU_STICK_BREAK: {
-            if (CVarGetInteger(CVAR_CHEAT("DekuStickCheat"), DEKU_STICK_NORMAL) != DEKU_STICK_NORMAL) {
+            if (CVarGetInteger(CVAR_CHEAT("DekuStick"), DEKU_STICK_NORMAL) != DEKU_STICK_NORMAL) {
                 *should = false;
             }
             break;
         }
         case VB_DEKU_STICK_BE_ON_FIRE: {
-            if (CVarGetInteger(CVAR_CHEAT("DekuStickCheat"), DEKU_STICK_NORMAL) == DEKU_STICK_UNBREAKABLE_AND_ALWAYS_ON_FIRE) {
+            if (CVarGetInteger(CVAR_CHEAT("DekuStick"), DEKU_STICK_NORMAL) == DEKU_STICK_UNBREAKABLE_AND_ALWAYS_ON_FIRE) {
                 Player* player = GET_PLAYER(gPlayState);
                 player->unk_860 = 200;    // Keeps the stick's flame lit
                 player->unk_85C = 1.0f;   // Ensures the stick is the proper length
@@ -30,13 +30,13 @@ void CheatsOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_list 
             break;
         }
         case VB_DEKU_STICK_BURN_OUT: {
-            if (CVarGetInteger(CVAR_CHEAT("DekuStickCheat"), DEKU_STICK_NORMAL) != DEKU_STICK_NORMAL) {
+            if (CVarGetInteger(CVAR_CHEAT("DekuStick"), DEKU_STICK_NORMAL) != DEKU_STICK_NORMAL) {
                 *should = false;
             }
             break;
         }
         case VB_DEKU_STICK_BURN_DOWN: {
-            if (CVarGetInteger(CVAR_CHEAT("DekuStickCheat"), DEKU_STICK_NORMAL) != DEKU_STICK_NORMAL) {
+            if (CVarGetInteger(CVAR_CHEAT("DekuStick"), DEKU_STICK_NORMAL) != DEKU_STICK_NORMAL) {
                 *should = false;
             }
             break;


### PR DESCRIPTION
The CVar name for the deku stick cheat option got desynced in v3 between the menubar and the cheat handler. This resyncs them.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2066096707.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2066143114.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2066147158.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2066148727.zip)
<!--- section:artifacts:end -->