### PR TITLE
Fix Adult Spawn crashes with non-spawn entrance shuffle

### DIFF
--- a/soh/soh/Enhancements/TimeSavers/SkipCutscene/SkipIntro.cpp
+++ b/soh/soh/Enhancements/TimeSavers/SkipCutscene/SkipIntro.cpp
@@ -15,10 +15,9 @@ void SkipIntro_Register() {
         // If we're playing rando and if starting age is adult and/or overworld spawns are shuffled we need to skip
         // the cutscene regardless of the enhancement being on.
         bool adultStart = gSaveContext.linkAge == LINK_AGE_ADULT;
-        bool shuffleOverworldSpawns =
-            OTRGlobals::Instance->gRandoContext->GetOption(RSK_SHUFFLE_OVERWORLD_SPAWNS).Is(true);
+        bool shuffleEntrances = OTRGlobals::Instance->gRandoContext->GetOption(RSK_SHUFFLE_ENTRANCES).Is(true);
         if ((CVarGetInteger(CVAR_ENHANCEMENT("TimeSavers.SkipCutscene.Intro"), IS_RANDO) ||
-             (IS_RANDO && (adultStart || shuffleOverworldSpawns))) &&
+             (IS_RANDO && (adultStart || shuffleEntrances))) &&
             gSaveContext.cutsceneIndex == 0xFFF1) {
             // Calculate spawn location. Start with vanilla, Link's house.
             int32_t spawnEntrance = ENTR_LINKS_HOUSE_0;
@@ -28,9 +27,9 @@ void SkipIntro_Register() {
                 if (adultStart) {
                     spawnEntrance = ENTR_TEMPLE_OF_TIME_7;
                 }
-                // If we're shuffling overworld spawns we'll need to get the Entrance Override
-                if (shuffleOverworldSpawns) {
-                    // If we're shuffling overworld spawns the adult spawn is ENTR_HYRULE_FIELD_10 instead of
+                // If we're shuffling any entrances we'll need to get the Entrance Override
+                if (shuffleEntrances) {
+                    // If we're shuffling any entrances, the adult spawn is ENTR_HYRULE_FIELD_10 instead of
                     // ENTR_TEMPLE_OF_TIME_7, so that spawn and Prelude don't share an entrance.
                     if (adultStart) {
                         spawnEntrance = ENTR_HYRULE_FIELD_10;


### PR DESCRIPTION
Looks like checking just spawn shuffle wasn't enough for skip intro checking. This changes the check to all entrance shuffle, preventing the crash with non-spawn entrance shuffle settings. Fixes #4331 

Thanks to @garrettjoecox for the necessary changes.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2066247343.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2066284797.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2066288862.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2066289007.zip)
<!--- section:artifacts:end -->