### PR TITLE
Fix Trick List Duplication

### DIFF
--- a/soh/soh/SaveManager.cpp
+++ b/soh/soh/SaveManager.cpp
@@ -2842,6 +2842,7 @@ extern "C" void Save_SaveGlobal(void) {
 
 extern "C" void Save_LoadFile(void) {
     // Handle vanilla context reset
+    OTRGlobals::Instance->gRandoContext->GetLogic()->SetContext(nullptr);
     OTRGlobals::Instance->gRandoContext.reset();
     OTRGlobals::Instance->gRandoContext = Rando::Context::CreateInstance();
     OTRGlobals::Instance->gRandoContext->GetLogic()->SetSaveContext(&gSaveContext);


### PR DESCRIPTION
`Logic` was preventing `Context` from being reset on file load because it was holding onto its reference of its parent `Context` instance, thus causing `Settings::CreateOptions()` to continually add to the `tricksByArea` structure. This fixes that by forcing the global rando context's `Logic` child to release its parent `Context` reference by setting its `shared_ptr` to `nullptr` before calling `reset()` on `gRandoContext`.

Fixes #4393 

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2066738352.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2066776491.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2066778103.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2066778141.zip)
<!--- section:artifacts:end -->