### PR TITLE
Fix Seed Gen with Starting Master Sword

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/starting_inventory.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/starting_inventory.cpp
@@ -132,7 +132,8 @@ void GenerateStartingInventory() {
   //   AddItemToInventory(RG_GIANTS_KNIFE, (StartingBiggoronSword.Is(STARTINGBGS_GIANTS_KNIFE)) ? 1 : 0);
   //   AddItemToInventory(RG_BIGGORON_SWORD, (StartingBiggoronSword.Is(STARTINGBGS_BIGGORON_SWORD)) ? 1 : 0);
   // }
-  AddItemToInventory(RG_DEKU_SHIELD, ctx->GetOption(RSK_STARTING_DEKU_SHIELD) ? 1 : 0);
+  AddItemToInventory(RG_MASTER_SWORD,              ctx->GetOption(RSK_STARTING_MASTER_SWORD) ? 1 : 0);
+  AddItemToInventory(RG_DEKU_SHIELD,               ctx->GetOption(RSK_STARTING_DEKU_SHIELD) ? 1 : 0);
   // AddItemToInventory(RG_HYLIAN_SHIELD,             StartingHylianShield.Value<uint8_t>());
   // AddItemToInventory(RG_MIRROR_SHIELD,             StartingMirrorShield.Value<uint8_t>());
   // AddItemToInventory(RG_GORON_TUNIC,               StartingGoronTunic.Value<uint8_t>());


### PR DESCRIPTION
`starting_inventory.cpp` wasn't even checking `RSK_STARTING_MASTER_SWORD` to see if it was enabled, let alone applying it, even though the pedestal would be excluded in the settings, so the Master Sword just wouldn't be available in a seed where MS shuffle was off and starting MS was on. This makes it do that.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2066928626.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2066963918.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2066964224.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2066967388.zip)
<!--- section:artifacts:end -->