### PR TITLE
Disable Lens Effect On Unequip

### DIFF
--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -3692,7 +3692,7 @@ void Interface_UpdateMagicBar(PlayState* play) {
                 (msgCtx->msgMode == MSGMODE_NONE) && (play->gameOverCtx.state == GAMEOVER_INACTIVE) &&
                 (play->transitionTrigger == TRANS_TRIGGER_OFF) && (play->transitionMode == TRANS_MODE_OFF) && !Play_InCsMode(play)) {
                 bool hasLens = false;
-                for (int buttonIndex = 1; buttonIndex < (CVarGetInteger(CVAR_ENHANCEMENT("DpadEquips"), 0) != 0) ? ARRAY_COUNT(gSaveContext.equips.buttonItems) : 4;
+                for (int buttonIndex = 1; buttonIndex < ((CVarGetInteger(CVAR_ENHANCEMENT("DpadEquips"), 0) != 0) ? ARRAY_COUNT(gSaveContext.equips.buttonItems) : 4);
                      buttonIndex++) {
                     if (gSaveContext.equips.buttonItems[buttonIndex] == ITEM_LENS) {
                         hasLens = true;

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_item.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_item.c
@@ -1138,7 +1138,6 @@ void KaleidoScope_UpdateItemEquip(PlayState* play) {
             
             // If the item is on another button already, swap the two
             uint16_t targetButtonIndex = pauseCtx->equipTargetCBtn + 1;
-            bool swap = false;
             for (uint16_t otherSlotIndex = 0; otherSlotIndex < ARRAY_COUNT(gSaveContext.equips.cButtonSlots);
                  otherSlotIndex++) {
                 uint16_t otherButtonIndex = otherSlotIndex + 1;
@@ -1147,7 +1146,6 @@ void KaleidoScope_UpdateItemEquip(PlayState* play) {
                 }
 
                 if (pauseCtx->equipTargetSlot == gSaveContext.equips.cButtonSlots[otherSlotIndex]) {
-                    swap = true;
                     // Assign the other button to the target's current item
                     if (gSaveContext.equips.buttonItems[targetButtonIndex] != ITEM_NONE) {
                         gSaveContext.equips.buttonItems[otherButtonIndex] =
@@ -1171,12 +1169,6 @@ void KaleidoScope_UpdateItemEquip(PlayState* play) {
                             gSaveContext.equips.cButtonSlots[otherSlotIndex] = gSaveContext.equips.cButtonSlots[pauseCtx->equipTargetCBtn];
                             Interface_LoadItemIcon2(play, otherButtonIndex);
                         }
-                }
-            }
-
-            if (!swap && gSaveContext.equips.buttonItems[targetButtonIndex] == ITEM_LENS) {
-                if (play->actorCtx.lensActive) {
-                    Actor_DisableLens(play);
                 }
             }
 

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_item.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_item.c
@@ -1138,6 +1138,7 @@ void KaleidoScope_UpdateItemEquip(PlayState* play) {
             
             // If the item is on another button already, swap the two
             uint16_t targetButtonIndex = pauseCtx->equipTargetCBtn + 1;
+            bool swap = false;
             for (uint16_t otherSlotIndex = 0; otherSlotIndex < ARRAY_COUNT(gSaveContext.equips.cButtonSlots);
                  otherSlotIndex++) {
                 uint16_t otherButtonIndex = otherSlotIndex + 1;
@@ -1146,6 +1147,7 @@ void KaleidoScope_UpdateItemEquip(PlayState* play) {
                 }
 
                 if (pauseCtx->equipTargetSlot == gSaveContext.equips.cButtonSlots[otherSlotIndex]) {
+                    swap = true;
                     // Assign the other button to the target's current item
                     if (gSaveContext.equips.buttonItems[targetButtonIndex] != ITEM_NONE) {
                         gSaveContext.equips.buttonItems[otherButtonIndex] =
@@ -1169,6 +1171,12 @@ void KaleidoScope_UpdateItemEquip(PlayState* play) {
                             gSaveContext.equips.cButtonSlots[otherSlotIndex] = gSaveContext.equips.cButtonSlots[pauseCtx->equipTargetCBtn];
                             Interface_LoadItemIcon2(play, otherButtonIndex);
                         }
+                }
+            }
+
+            if (!swap && gSaveContext.equips.buttonItems[targetButtonIndex] == ITEM_LENS) {
+                if (play->actorCtx.lensActive) {
+                    Actor_DisableLens(play);
                 }
             }
 


### PR DESCRIPTION
Restores vanilla functionality by fixing a bug introduced by DPad equips. Fixes #967 

Credit to @Rozelette for finding the issue.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2071299466.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2071307177.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2071312771.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2071321689.zip)
<!--- section:artifacts:end -->