### PR TITLE
Make ConfigUpdaterV2 use CVarClearBlock instead of manually scanning

### DIFF
--- a/soh/soh/config/ConfigUpdaters.cpp
+++ b/soh/soh/config/ConfigUpdaters.cpp
@@ -66,9 +66,7 @@ namespace SOH {
     }
 
     void ConfigVersion2Updater::Update(Ship::Config* conf) {
-        for (auto seq : AudioCollection::Instance->GetAllSequences()) {
-            CVarClear(std::string("gAudioEditor.ReplacedSequences." + seq.second.sfxKey).c_str());
-        }
+        CVarClearBlock("gAudioEditor.ReplacedSequences");
     }
 
     void ConfigVersion3Updater::Update(Ship::Config* conf) {


### PR DESCRIPTION
Previous iteration was made before the updaters were changed to run sooner in the flow, meaning the audio manager hadn't been initialized before the updaters anymore, causing a crash on fresh installs on first boot. This changes that to use the new CVarClearBlock function in LUS made for updater v3 so it can delete the block directly instead of relying on the sequenceMap being loaded.

Related to LUS PR fixing CVarClearBlock, but while this won't clear bad audioManager blocks now, that shouldn't be an issue for people testing dev builds, and it'll fix the crash now and will be fully functional automatically once the LUS PR gets merged.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2071975439.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2072007109.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2072008258.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2072026745.zip)
<!--- section:artifacts:end -->