### PR TITLE
Add freeze timer hook for Gold Skulltula collection

### DIFF
--- a/soh/soh/Enhancements/game-interactor/GameInteractor.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor.h
@@ -353,6 +353,7 @@ typedef enum {
     VB_GIVE_ITEM_FROM_ITEM_00,
     // Opt: *EnSi
     VB_GIVE_ITEM_SKULL_TOKEN,
+    VB_FREEZE_ON_SKULL_TOKEN,
     // Opt: *EnCow
     VB_GIVE_ITEM_FROM_COW,
     // Opt: *EnDns

--- a/soh/soh/Enhancements/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.cpp
@@ -522,10 +522,9 @@ void TimeSaverOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_li
                 *should = false;
             }
             break;
-        case VB_GIVE_ITEM_SKULL_TOKEN:
-            if (!CVarGetInteger(CVAR_ENHANCEMENT("SkulltulaFreeze"), 0)) {
-                Player* player = GET_PLAYER(gPlayState);
-                player->actor.freezeTimer = 10;
+        case VB_FREEZE_ON_SKULL_TOKEN:
+            if (CVarGetInteger(CVAR_ENHANCEMENT("SkulltulaFreeze"), 0)) {
+                *should = false;
             }
             break;
         case VB_DAMPE_IN_GRAVEYARD_DESPAWN:

--- a/soh/soh/Enhancements/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.cpp
@@ -522,6 +522,12 @@ void TimeSaverOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_li
                 *should = false;
             }
             break;
+        case VB_GIVE_ITEM_SKULL_TOKEN:
+            if (!CVarGetInteger(CVAR_ENHANCEMENT("SkulltulaFreeze"), 0)) {
+                Player* player = GET_PLAYER(gPlayState);
+                player->actor.freezeTimer = 10;
+            }
+            break;
         case VB_DAMPE_IN_GRAVEYARD_DESPAWN:
             if (CVarGetInteger(CVAR_ENHANCEMENT("DampeAllNight"), 0)) {
                 *should = LINK_IS_ADULT || gPlayState->sceneNum != SCENE_GRAVEYARD;

--- a/soh/src/overlays/actors/ovl_En_Si/z_en_si.c
+++ b/soh/src/overlays/actors/ovl_En_Si/z_en_si.c
@@ -96,7 +96,6 @@ void func_80AFB768(EnSi* this, PlayState* play) {
                 this->collider.base.ocFlags2 &= ~OC2_HIT_PLAYER;
                 if (GameInteractor_Should(VB_GIVE_ITEM_SKULL_TOKEN, true, this)) {
                     Item_Give(play, ITEM_SKULL_TOKEN);
-                    player->actor.freezeTimer = 10;
                     Message_StartTextbox(play, 0xB4, NULL);
                     Audio_PlayFanfare(NA_BGM_SMALL_ITEM_GET);
                 }
@@ -120,7 +119,6 @@ void func_80AFB89C(EnSi* this, PlayState* play) {
     if (!CHECK_FLAG_ALL(this->actor.flags, ACTOR_FLAG_HOOKSHOT_ATTACHED)) {
         if (GameInteractor_Should(VB_GIVE_ITEM_SKULL_TOKEN, true, this)) {
             Item_Give(play, ITEM_SKULL_TOKEN);
-            player->actor.freezeTimer = 10;
             Message_StartTextbox(play, 0xB4, NULL);
             Audio_PlayFanfare(NA_BGM_SMALL_ITEM_GET);
         }
@@ -131,9 +129,10 @@ void func_80AFB89C(EnSi* this, PlayState* play) {
 void func_80AFB950(EnSi* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
 
-    if (Message_GetState(&play->msgCtx) != TEXT_STATE_CLOSING && GameInteractor_Should(VB_GIVE_ITEM_SKULL_TOKEN, true, this)) {
-        player->actor.freezeTimer = 10;
-    } else {
+    if (
+        Message_GetState(&play->msgCtx) == TEXT_STATE_CLOSING ||
+        !GameInteractor_Should(VB_GIVE_ITEM_SKULL_TOKEN, !CVarGetInteger(CVAR_ENHANCEMENT("SkulltulaFreeze"), 0), this)
+    ) {
         SET_GS_FLAGS((this->actor.params & 0x1F00) >> 8, this->actor.params & 0xFF);
         GameInteractor_ExecuteOnFlagSet(FLAG_GS_TOKEN, this->actor.params);
         Actor_Kill(&this->actor);

--- a/soh/src/overlays/actors/ovl_En_Si/z_en_si.c
+++ b/soh/src/overlays/actors/ovl_En_Si/z_en_si.c
@@ -80,8 +80,6 @@ s32 func_80AFB748(EnSi* this, PlayState* play) {
 }
 
 void func_80AFB768(EnSi* this, PlayState* play) {
-    Player* player = GET_PLAYER(play);
-
     if (CHECK_FLAG_ALL(this->actor.flags, ACTOR_FLAG_HOOKSHOT_ATTACHED)) {
         this->actionFunc = func_80AFB89C;
     } else {
@@ -110,8 +108,6 @@ void func_80AFB768(EnSi* this, PlayState* play) {
 }
 
 void func_80AFB89C(EnSi* this, PlayState* play) {
-    Player* player = GET_PLAYER(play);
-
     Math_SmoothStepToF(&this->actor.scale.x, 0.25f, 0.4f, 1.0f, 0.0f);
     Actor_SetScale(&this->actor, this->actor.scale.x);
     this->actor.shape.rot.y += 0x400;
@@ -127,8 +123,6 @@ void func_80AFB89C(EnSi* this, PlayState* play) {
 }
 
 void func_80AFB950(EnSi* this, PlayState* play) {
-    Player* player = GET_PLAYER(play);
-
     if (
         Message_GetState(&play->msgCtx) == TEXT_STATE_CLOSING ||
         !GameInteractor_Should(VB_GIVE_ITEM_SKULL_TOKEN, !CVarGetInteger(CVAR_ENHANCEMENT("SkulltulaFreeze"), 0), this)

--- a/soh/src/overlays/actors/ovl_En_Si/z_en_si.c
+++ b/soh/src/overlays/actors/ovl_En_Si/z_en_si.c
@@ -126,9 +126,9 @@ void func_80AFB89C(EnSi* this, PlayState* play) {
             if (GameInteractor_Should(VB_FREEZE_ON_SKULL_TOKEN, true, this)) {
                 player->actor.freezeTimer = 10;
             }
+            Message_StartTextbox(play, TEXT_GS_NO_FREEZE, NULL);
+            Audio_PlayFanfare(NA_BGM_SMALL_ITEM_GET);
         }
-        Message_StartTextbox(play, TEXT_GS_NO_FREEZE, NULL);
-        Audio_PlayFanfare(NA_BGM_SMALL_ITEM_GET);
         this->actionFunc = func_80AFB950;
     }
 }

--- a/soh/src/overlays/actors/ovl_En_Si/z_en_si.c
+++ b/soh/src/overlays/actors/ovl_En_Si/z_en_si.c
@@ -5,6 +5,7 @@
  */
 
 #include "z_en_si.h"
+#include "soh/Enhancements/custom-message/CustomMessageTypes.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
 #define FLAGS (ACTOR_FLAG_TARGETABLE | ACTOR_FLAG_HOOKSHOT_DRAGS)
@@ -94,7 +95,7 @@ void func_80AFB768(EnSi* this, PlayState* play) {
                 this->collider.base.ocFlags2 &= ~OC2_HIT_PLAYER;
                 if (GameInteractor_Should(VB_GIVE_ITEM_SKULL_TOKEN, true, this)) {
                     Item_Give(play, ITEM_SKULL_TOKEN);
-                    Message_StartTextbox(play, 0xB4, NULL);
+                    Message_StartTextbox(play, TEXT_GS_NO_FREEZE, NULL);
                     Audio_PlayFanfare(NA_BGM_SMALL_ITEM_GET);
                 }
                 this->actionFunc = func_80AFB950;
@@ -115,7 +116,7 @@ void func_80AFB89C(EnSi* this, PlayState* play) {
     if (!CHECK_FLAG_ALL(this->actor.flags, ACTOR_FLAG_HOOKSHOT_ATTACHED)) {
         if (GameInteractor_Should(VB_GIVE_ITEM_SKULL_TOKEN, true, this)) {
             Item_Give(play, ITEM_SKULL_TOKEN);
-            Message_StartTextbox(play, 0xB4, NULL);
+            Message_StartTextbox(play, TEXT_GS_NO_FREEZE, NULL);
             Audio_PlayFanfare(NA_BGM_SMALL_ITEM_GET);
         }
         this->actionFunc = func_80AFB950;


### PR DESCRIPTION
Fixes #4409

Transferred the freeze timer handling for Gold Skulltula tokens to the VB hook, which now reads the "No Skulltula Freeze" enhancement option.

https://github.com/user-attachments/assets/b7fe942f-abfc-42cc-bd62-dc29a99c1f9e

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2080617813.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2080649592.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2080649988.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2080656698.zip)
<!--- section:artifacts:end -->