### PR TITLE
"Skip forced dialog" no longer skips optional Navi hints

### DIFF
--- a/soh/soh/Enhancements/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.cpp
@@ -326,8 +326,9 @@ void TimeSaverOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_li
         case VB_NAVI_TALK: {
             if (ForcedDialogIsDisabled(FORCED_DIALOG_SKIP_NAVI)) {
                 ElfMsg* naviTalk = va_arg(args, ElfMsg*);
-                if (((naviTalk->actor.params >> 8) & 0x3F) != 0x3F) {
-                    Flags_SetSwitch(gPlayState, (naviTalk->actor.params >> 8) & 0x3F);
+                int32_t paramsHighByte = naviTalk->actor.params >> 8;
+                if ((paramsHighByte & 0x80) == 0 && (paramsHighByte & 0x3F) != 0x3F) {
+                    Flags_SetSwitch(gPlayState, paramsHighByte & 0x3F);
                     Actor_Kill(&naviTalk->actor);
                     *should = false;
                 }


### PR DESCRIPTION
Fixes #4426

Optional Navi hints remain optional, and can be listened to with C-Up. They are no longer canceled out by the enhancement that is only supposed to skip *forced* Navi hints.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2078402554.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2078419935.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2078420580.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2078422491.zip)
<!--- section:artifacts:end -->