### PR TITLE
Zora's River waterfall opens instantly

### DIFF
--- a/soh/soh/Enhancements/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.cpp
@@ -209,7 +209,9 @@ void TimeSaverOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_li
                         RateLimitedSuccessChime();
                         taki = (BgSpot03Taki*)Actor_FindNearby(gPlayState, &GET_PLAYER(gPlayState)->actor,
                                                                ACTOR_BG_SPOT03_TAKI, ACTORCAT_BG, 999.0f);
-                        func_8003EBF8(gPlayState, &gPlayState->colCtx.dyna, taki->dyna.bgId);
+                        if (taki != NULL) {
+                            func_8003EBF8(gPlayState, &gPlayState->colCtx.dyna, taki->dyna.bgId);
+                        }
                         break;
                     default:
                         SPDLOG_INFO("VB_PLAY_ONEPOINT_CS {}", *csId);

--- a/soh/soh/Enhancements/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.cpp
@@ -205,6 +205,9 @@ void TimeSaverOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_li
                     case 4100:
                         *should = false;
                         RateLimitedSuccessChime();
+                        BgSpot03Taki* taki = (BgSpot03Taki*)Actor_FindNearby(gPlayState, &GET_PLAYER(gPlayState)->actor,
+                                                                             ACTOR_BG_SPOT03_TAKI, ACTORCAT_BG, 999.0f);
+                        func_8003EBF8(gPlayState, &gPlayState->colCtx.dyna, taki->dyna.bgId);
                         break;
                     default:
                         SPDLOG_INFO("VB_PLAY_ONEPOINT_CS {}", *csId);

--- a/soh/soh/Enhancements/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.cpp
@@ -22,6 +22,7 @@ extern "C" {
 #include "src/overlays/actors/ovl_En_Tk/z_en_tk.h"
 #include "src/overlays/actors/ovl_En_Fu/z_en_fu.h"
 #include "src/overlays/actors/ovl_Bg_Spot02_Objects/z_bg_spot02_objects.h"
+#include "src/overlays/actors/ovl_Bg_Spot03_Taki/z_bg_spot03_taki.h"
 #include "src/overlays/actors/ovl_Bg_Hidan_Kousi/z_bg_hidan_kousi.h"
 #include "src/overlays/actors/ovl_Bg_Dy_Yoseizo/z_bg_dy_yoseizo.h"
 #include "src/overlays/actors/ovl_En_Dnt_Demo/z_en_dnt_demo.h"
@@ -200,13 +201,14 @@ void TimeSaverOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_li
         case VB_PLAY_ONEPOINT_CS: {
             if (CVarGetInteger(CVAR_ENHANCEMENT("TimeSavers.SkipCutscene.OnePoint"), IS_RANDO)) {
                 s16* csId = va_arg(args, s16*);
+                BgSpot03Taki* taki = NULL;
                 switch (*csId) {
                     case 4180:
                     case 4100:
                         *should = false;
                         RateLimitedSuccessChime();
-                        BgSpot03Taki* taki = (BgSpot03Taki*)Actor_FindNearby(gPlayState, &GET_PLAYER(gPlayState)->actor,
-                                                                             ACTOR_BG_SPOT03_TAKI, ACTORCAT_BG, 999.0f);
+                        taki = (BgSpot03Taki*)Actor_FindNearby(gPlayState, &GET_PLAYER(gPlayState)->actor,
+                                                               ACTOR_BG_SPOT03_TAKI, ACTORCAT_BG, 999.0f);
                         func_8003EBF8(gPlayState, &gPlayState->colCtx.dyna, taki->dyna.bgId);
                         break;
                     default:

--- a/soh/src/overlays/actors/ovl_Bg_Spot03_Taki/z_bg_spot03_taki.c
+++ b/soh/src/overlays/actors/ovl_Bg_Spot03_Taki/z_bg_spot03_taki.c
@@ -73,9 +73,7 @@ void func_808ADEF0(BgSpot03Taki* this, PlayState* play) {
         if (Flags_GetSwitch(play, this->switchFlag)) {
             this->state = WATERFALL_OPENING_ANIMATED;
             this->timer = 40;
-            if (OnePointCutscene_Init(play, 4100, -99, NULL, MAIN_CAM) == SUBCAM_NONE) {
-                func_8003EBF8(play, &play->colCtx.dyna, this->dyna.bgId);
-            }
+            OnePointCutscene_Init(play, 4100, -99, NULL, MAIN_CAM);
         }
     } else if (this->state == WATERFALL_OPENING_IDLE) {
         this->timer--;

--- a/soh/src/overlays/actors/ovl_Bg_Spot03_Taki/z_bg_spot03_taki.c
+++ b/soh/src/overlays/actors/ovl_Bg_Spot03_Taki/z_bg_spot03_taki.c
@@ -73,8 +73,9 @@ void func_808ADEF0(BgSpot03Taki* this, PlayState* play) {
         if (Flags_GetSwitch(play, this->switchFlag)) {
             this->state = WATERFALL_OPENING_ANIMATED;
             this->timer = 40;
-            OnePointCutscene_Init(play, 4100, -99, NULL, MAIN_CAM);
-            func_8003EBF8(play, &play->colCtx.dyna, this->dyna.bgId);
+            if (OnePointCutscene_Init(play, 4100, -99, NULL, MAIN_CAM) == SUBCAM_NONE) {
+                func_8003EBF8(play, &play->colCtx.dyna, this->dyna.bgId);
+            }
         }
     } else if (this->state == WATERFALL_OPENING_IDLE) {
         this->timer--;
@@ -85,6 +86,7 @@ void func_808ADEF0(BgSpot03Taki* this, PlayState* play) {
         if (this->openingAlpha > 0) {
             this->openingAlpha -= 5;
             if (this->openingAlpha <= 0.0f) {
+                func_8003EBF8(play, &play->colCtx.dyna, this->dyna.bgId);
                 this->timer = 400;
                 this->state = WATERFALL_OPENED;
                 this->openingAlpha = 0;

--- a/soh/src/overlays/actors/ovl_Bg_Spot03_Taki/z_bg_spot03_taki.c
+++ b/soh/src/overlays/actors/ovl_Bg_Spot03_Taki/z_bg_spot03_taki.c
@@ -74,6 +74,7 @@ void func_808ADEF0(BgSpot03Taki* this, PlayState* play) {
             this->state = WATERFALL_OPENING_ANIMATED;
             this->timer = 40;
             OnePointCutscene_Init(play, 4100, -99, NULL, MAIN_CAM);
+            func_8003EBF8(play, &play->colCtx.dyna, this->dyna.bgId);
         }
     } else if (this->state == WATERFALL_OPENING_IDLE) {
         this->timer--;
@@ -84,7 +85,6 @@ void func_808ADEF0(BgSpot03Taki* this, PlayState* play) {
         if (this->openingAlpha > 0) {
             this->openingAlpha -= 5;
             if (this->openingAlpha <= 0.0f) {
-                func_8003EBF8(play, &play->colCtx.dyna, this->dyna.bgId);
                 this->timer = 400;
                 this->state = WATERFALL_OPENED;
                 this->openingAlpha = 0;


### PR DESCRIPTION
Fixes #4453

After playing Zelda's Lullaby, if the one-point cutscene is skipped, the waterfall can be passed through instantly without having to wait for the animation. Again, the animation itself is left alone, just the collision is disabled.

https://github.com/user-attachments/assets/a9c5cbb8-3056-4e2b-8d57-4db48fb91a31



<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2080368164.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2080372535.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2080377986.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2080380643.zip)
<!--- section:artifacts:end -->