### PR TITLE
Add enhancement to have Zora's River waterfall always open

### DIFF
--- a/soh/soh/Enhancements/enhancementTypes.h
+++ b/soh/soh/Enhancements/enhancementTypes.h
@@ -35,6 +35,12 @@ typedef enum {
 } BunnyHoodMode;
 
 typedef enum {
+    ZORA_WATERFALL_CLOSED,
+    ZORA_WATERFALL_OPEN_ADULT,
+    ZORA_WATERFALL_OPEN_ALWAYS
+} ZoraWaterfallMode;
+
+typedef enum {
     MIRRORED_WORLD_OFF,
     MIRRORED_WORLD_ALWAYS,
     MIRRORED_WORLD_RANDOM,

--- a/soh/soh/Enhancements/game-interactor/GameInteractor.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor.h
@@ -291,6 +291,8 @@ typedef enum {
     VB_GANON_HEAL_BEFORE_FIGHT,
     VB_FREEZE_LINK_FOR_BLOCK_THROW,
     VB_MOVE_THROWN_ACTOR,
+    // Vanilla condition: false
+    VB_KEEP_ZORA_WATERFALL_OPEN,
 
     /*** Play Cutscenes ***/
 

--- a/soh/soh/Enhancements/presets.h
+++ b/soh/soh/Enhancements/presets.h
@@ -303,6 +303,7 @@ const std::vector<const char*> enhancementsCvars = {
     CVAR_ENHANCEMENT("TimeSavers.SkipChildStealth"),
     CVAR_ENHANCEMENT("TimeSavers.SkipTowerEscape"),
     CVAR_ENHANCEMENT("TimeSavers.SkipForcedDialog"),
+    CVAR_ENHANCEMENT("TimeSavers.ZoraWaterfall"),
     CVAR_ENHANCEMENT("SlowTextSpeed"),
 };
 

--- a/soh/soh/Enhancements/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.cpp
@@ -665,6 +665,20 @@ void TimeSaverOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_li
             }
             break;
         }
+        case VB_KEEP_ZORA_WATERFALL_OPEN: {
+            switch (CVarGetInteger(CVAR_ENHANCEMENT("TimeSavers.ZoraWaterfall"), ZORA_WATERFALL_CLOSED)) {
+                case ZORA_WATERFALL_CLOSED:
+                    *should = false;
+                    break;
+                case ZORA_WATERFALL_OPEN_ADULT:
+                    *should = LINK_IS_ADULT;
+                    break;
+                case ZORA_WATERFALL_OPEN_ALWAYS:
+                    *should = true;
+                    break;
+            }
+            break;
+        }
     }
 
     va_end(args);

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -78,6 +78,7 @@ static const char* imguiScaleOptions[4] = { "Small", "Normal", "Large", "X-Large
     static const char* chestStyleMatchesContentsOptions[4] = { "Disabled", "Both", "Texture Only", "Size Only" };
     static const char* skipGetItemAnimationOptions[3] = { "Disabled", "Junk Items", "All Items" };
     static const char* skipForcedDialogOptions[4] = { "None", "Navi Only", "NPCs Only", "All" };
+    static const char* zoraWaterfallOptions[3] = { "Closed", "Open As Adult", "Always Open" };
     static const char* bunnyHoodOptions[3] = { "Disabled", "Faster Run & Longer Jump", "Faster Run" };
     static const char* mirroredWorldModes[9] = {
         "Disabled",           "Always",        "Random",          "Random (Seeded)",          "Dungeons",
@@ -761,6 +762,14 @@ void DrawEnhancementsMenu() {
                     "- Not within range of Ocarina playing spots");
                 UIWidgets::PaddedEnhancementCheckbox("Pause Warp", CVAR_ENHANCEMENT("PauseWarp"), true, false);
                 UIWidgets::Tooltip("Selection of warp song in pause menu initiates warp. Disables song playback.");
+
+                UIWidgets::PaddedText("Zora's River Waterfall", true, false);
+                UIWidgets::EnhancementCombobox(CVAR_ENHANCEMENT("TimeSavers.ZoraWaterfall"), zoraWaterfallOptions, ZORA_WATERFALL_CLOSED);
+                UIWidgets::Tooltip("Skips having to play Zelda's Lullaby to enter Zora's Domain.\n\n"
+                                   "Closed: Link must always play Zelda's Lullaby.\n"
+                                   "Open As Adult: Child Link must always play Zelda's Lullaby, but Adult Link may "
+                                   "enter without playing it.\n"
+                                   "Open Always: Link may always enter Zora's Domain.");
                 
                 ImGui::EndTable();
                 ImGui::EndMenu();

--- a/soh/src/overlays/actors/ovl_Bg_Spot03_Taki/z_bg_spot03_taki.c
+++ b/soh/src/overlays/actors/ovl_Bg_Spot03_Taki/z_bg_spot03_taki.c
@@ -6,7 +6,7 @@
 
 #include "z_bg_spot03_taki.h"
 #include "objects/object_spot03_object/object_spot03_object.h"
-#include "soh/Enhancements/enhancementTypes.h"
+#include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
 #define FLAGS (ACTOR_FLAG_UPDATE_WHILE_CULLED | ACTOR_FLAG_DRAW_WHILE_CULLED)
 
@@ -46,17 +46,6 @@ void BgSpot03Taki_ApplyOpeningAlpha(BgSpot03Taki* this, s32 bufferIndex) {
     }
 }
 
-static bool BgSpot03Taki_ShouldKeepOpen() {
-    switch (CVarGetInteger(CVAR_ENHANCEMENT("TimeSavers.ZoraWaterfall"), 0)) {
-        case ZORA_WATERFALL_OPEN_ALWAYS:
-            return true;
-        case ZORA_WATERFALL_OPEN_ADULT:
-            return LINK_IS_ADULT;
-        default:
-            return false;
-    }
-}
-
 void BgSpot03Taki_Init(Actor* thisx, PlayState* play) {
     BgSpot03Taki* this = (BgSpot03Taki*)thisx;
     s16 pad;
@@ -65,7 +54,7 @@ void BgSpot03Taki_Init(Actor* thisx, PlayState* play) {
     this->switchFlag = (this->dyna.actor.params & 0x3F);
     DynaPolyActor_Init(&this->dyna, DPM_UNK);
 
-    if (BgSpot03Taki_ShouldKeepOpen()) {
+    if (GameInteractor_Should(VB_KEEP_ZORA_WATERFALL_OPEN, false)) {
         this->state = WATERFALL_OPENED;
         Flags_SetSwitch(play, this->switchFlag);
         this->openingAlpha = 0.0f;
@@ -111,7 +100,7 @@ void func_808ADEF0(BgSpot03Taki* this, PlayState* play) {
                 this->openingAlpha = 0;
             }
         }
-    } else if (this->state == WATERFALL_OPENED && !BgSpot03Taki_ShouldKeepOpen()) {
+    } else if (this->state == WATERFALL_OPENED && !GameInteractor_Should(VB_KEEP_ZORA_WATERFALL_OPEN, false)) {
         this->timer--;
         if (this->timer < 0) {
             this->state = WATERFALL_CLOSING;

--- a/soh/src/overlays/actors/ovl_Bg_Spot03_Taki/z_bg_spot03_taki.c
+++ b/soh/src/overlays/actors/ovl_Bg_Spot03_Taki/z_bg_spot03_taki.c
@@ -6,6 +6,7 @@
 
 #include "z_bg_spot03_taki.h"
 #include "objects/object_spot03_object/object_spot03_object.h"
+#include "soh/Enhancements/enhancementTypes.h"
 
 #define FLAGS (ACTOR_FLAG_UPDATE_WHILE_CULLED | ACTOR_FLAG_DRAW_WHILE_CULLED)
 
@@ -45,6 +46,17 @@ void BgSpot03Taki_ApplyOpeningAlpha(BgSpot03Taki* this, s32 bufferIndex) {
     }
 }
 
+static bool BgSpot03Taki_ShouldKeepOpen() {
+    switch (CVarGetInteger(CVAR_ENHANCEMENT("TimeSavers.ZoraWaterfall"), 0)) {
+        case ZORA_WATERFALL_OPEN_ALWAYS:
+            return true;
+        case ZORA_WATERFALL_OPEN_ADULT:
+            return LINK_IS_ADULT;
+        default:
+            return false;
+    }
+}
+
 void BgSpot03Taki_Init(Actor* thisx, PlayState* play) {
     BgSpot03Taki* this = (BgSpot03Taki*)thisx;
     s16 pad;
@@ -52,11 +64,20 @@ void BgSpot03Taki_Init(Actor* thisx, PlayState* play) {
 
     this->switchFlag = (this->dyna.actor.params & 0x3F);
     DynaPolyActor_Init(&this->dyna, DPM_UNK);
-    CollisionHeader_GetVirtual(&object_spot03_object_Col_000C98, &colHeader);
-    this->dyna.bgId = DynaPoly_SetBgActor(play, &play->colCtx.dyna, &this->dyna.actor, colHeader);
+
+    if (BgSpot03Taki_ShouldKeepOpen()) {
+        this->state = WATERFALL_OPENED;
+        Flags_SetSwitch(play, this->switchFlag);
+        this->openingAlpha = 0.0f;
+    } else {
+        this->state = WATERFALL_CLOSED;
+        CollisionHeader_GetVirtual(&object_spot03_object_Col_000C98, &colHeader);
+        this->dyna.bgId = DynaPoly_SetBgActor(play, &play->colCtx.dyna, &this->dyna.actor, colHeader);
+        this->openingAlpha = 255.0f;
+    }
+
     Actor_ProcessInitChain(&this->dyna.actor, sInitChain);
     this->bufferIndex = 0;
-    this->openingAlpha = 255.0f;
     BgSpot03Taki_ApplyOpeningAlpha(this, 0);
     BgSpot03Taki_ApplyOpeningAlpha(this, 1);
     this->actionFunc = func_808ADEF0;
@@ -90,7 +111,7 @@ void func_808ADEF0(BgSpot03Taki* this, PlayState* play) {
                 this->openingAlpha = 0;
             }
         }
-    } else if (this->state == WATERFALL_OPENED) {
+    } else if (this->state == WATERFALL_OPENED && !BgSpot03Taki_ShouldKeepOpen()) {
         this->timer--;
         if (this->timer < 0) {
             this->state = WATERFALL_CLOSING;


### PR DESCRIPTION
The enhancement bypasses the requirement of playing Zelda's Lullaby to open the entrance to Zora's Domain. There's also an adult-only option.

![2024-10-20 (3)](https://github.com/user-attachments/assets/d1feee50-eb9c-4447-b556-2d6a66369680)
![2024-10-20](https://github.com/user-attachments/assets/ecef3e53-64e8-4d13-8901-4b6ba4d6a10b)


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2079940394.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2079952564.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2079952981.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2079954769.zip)
<!--- section:artifacts:end -->