### PR TITLE
Fix More File Info

### DIFF
--- a/soh/soh/SaveManager.h
+++ b/soh/soh/SaveManager.h
@@ -28,8 +28,8 @@ typedef struct {
     s16 rupees;
     s16 gsTokens;
     u8 isDoubleDefenseAcquired;
-    u8 gregFound;
-    u8 hasWallet;
+    s32 gregFound;
+    s32 hasWallet;
 } SaveFileMetaInfo;
 
 #ifdef __cplusplus

--- a/soh/src/code/code_8006C3A0.c
+++ b/soh/src/code/code_8006C3A0.c
@@ -29,5 +29,5 @@ s32 Flags_GetEnv(PlayState* play, s16 flag) {
     s16 bit = flag % 16;
     s16 mask = 1 << bit;
 
-    return play->envFlags[index] & mask;
+    return (play->envFlags[index] & mask) != 0;
 }

--- a/soh/src/code/z_actor.c
+++ b/soh/src/code/z_actor.c
@@ -4971,7 +4971,7 @@ s32 Flags_GetRandomizerInf(RandomizerInf flag) {
  * Sets "randomizerInf" flag.
  */
 void Flags_SetRandomizerInf(RandomizerInf flag) {
-    u8 previouslyOff = !Flags_GetRandomizerInf(flag);
+    s32 previouslyOff = !Flags_GetRandomizerInf(flag);
     gSaveContext.randomizerInf[flag >> 4] |= (1 << (flag & 0xF));
     if (previouslyOff) {
         LUSLOG_INFO("RandomizerInf Flag Set - %#x", flag);
@@ -4983,7 +4983,7 @@ void Flags_SetRandomizerInf(RandomizerInf flag) {
  * Unsets "randomizerInf" flag.
  */
 void Flags_UnsetRandomizerInf(RandomizerInf flag) {
-    u8 previouslyOn = Flags_GetRandomizerInf(flag);
+    s32 previouslyOn = Flags_GetRandomizerInf(flag);
     gSaveContext.randomizerInf[flag >> 4] &= ~(1 << (flag & 0xF));
     if (previouslyOn) {
         LUSLOG_INFO("RandomizerInf Flag Unset - %#x", flag);


### PR DESCRIPTION
Modify all (4) instances of `Flags_GetRandomizerInf()` returns that were stored as u8 to s32 to avoid value overflow (anything bigger than 255 would store as 0, even though it was non-zero, registering as not set when compared later).

Fixes #4462.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2084497890.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2084569154.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2084579222.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2084580021.zip)
<!--- section:artifacts:end -->