### PR TITLE
Small scrub and shop sanity fixes

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -1181,10 +1181,10 @@ ScrubIdentity Randomizer::IdentifyScrub(s32 sceneNum, s32 actorParams, s32 respa
         scrubIdentity.randomizerInf = rcToRandomizerInf[location->GetRandomizerCheck()];
         scrubIdentity.randomizerCheck = location->GetRandomizerCheck();
         scrubIdentity.getItemId = (GetItemID)Rando::StaticData::RetrieveItem(location->GetVanillaItem()).GetItemID();
-        scrubIdentity.isShuffled = GetRandoSettingValue(RSK_SHUFFLE_SCRUBS) != RO_SCRUBS_OFF;
+        scrubIdentity.isShuffled = GetRandoSettingValue(RSK_SHUFFLE_SCRUBS) == RO_SCRUBS_ALL;
 
         if (location->GetRandomizerCheck() == RC_HF_DEKU_SCRUB_GROTTO || location->GetRandomizerCheck() == RC_LW_DEKU_SCRUB_GROTTO_FRONT || location->GetRandomizerCheck() == RC_LW_DEKU_SCRUB_NEAR_BRIDGE) {
-            scrubIdentity.isShuffled = true;
+            scrubIdentity.isShuffled = GetRandoSettingValue(RSK_SHUFFLE_SCRUBS) != RO_SCRUBS_OFF;;
         }
 
         scrubIdentity.itemPrice = OTRGlobals::Instance->gRandoContext->GetItemLocation(scrubIdentity.randomizerCheck)->GetPrice();

--- a/soh/soh/config/ConfigMigrators.h
+++ b/soh/soh/config/ConfigMigrators.h
@@ -1292,7 +1292,7 @@ namespace SOH {
         { MigrationAction::Rename, "gCheckTrackerHudEditMode", "gTrackers.CheckTracker.Draggable" },
         { MigrationAction::Rename, "gCheckTrackerKnownHide", "gTrackers.CheckTracker.Scummed.Hide" },
         { MigrationAction::Rename, "gCheckTrackerOptionAlwaysShowGSLocs", "gTrackers.CheckTracker.AlwaysShowGSLocs" },
-        { MigrationAction::Rename, "gCheckTrackerOptionHideRightShopChecks", "gTrackers.CheckTracker.HideRightShopChecks" },
+        { MigrationAction::Rename, "gCheckTrackerOptionHideRightShopChecks", "gTrackers.CheckTracker.HideUnshuffledShopChecks" },
         { MigrationAction::Rename, "gCheckTrackerOptionMQSpoilers", "gTrackers.CheckTracker.MQSpoilers" },
         { MigrationAction::Rename, "gCheckTrackerOptionShowHidden", "gTrackers.CheckTracker.ShowHidden" },
         { MigrationAction::Rename, "gCheckTrackerSavedExtraColor", "gTrackers.CheckTracker.Saved.ExtraColor" },


### PR DESCRIPTION
Rando used to automatically shuffle the three upgrade scrubs regardless of scrubsanity, and scrubsanity was only a binary on/off. This changes the assumptions made in custom message and check tracking code that were not updated when the ability to chooose not to shuffle any scrubs was added.

This also changes the shop tracking to be able to determine if a shop slot was shuffled or not, and hide or not hide based on that rather than by slot number.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2091255825.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2091293937.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2091294269.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2091296511.zip)
<!--- section:artifacts:end -->