### PR TITLE
Fix Fast Phantom Ganon Death Time Saver Crash

### DIFF
--- a/soh/soh/Enhancements/game-interactor/GameInteractor.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor.h
@@ -343,6 +343,7 @@ typedef enum {
 
     // Opt: *EnBox
     VB_GIVE_ITEM_FROM_CHEST,
+    // Opt: ItemID
     VB_GIVE_ITEM_FROM_BLUE_WARP,
     // Opt: *EnItem00
     VB_GIVE_ITEM_FROM_ITEM_00,
@@ -469,8 +470,9 @@ typedef enum {
     VB_DEKU_UPDATE_BURNING_DEKU_STICK,
 
     /*** Quick Boss Deaths ***/
-    // Vanilla condition: true
+    // Vanilla condition: true; Opt: *BossGanondrof
     VB_PHANTOM_GANON_DEATH_SCENE,
+    // Opt: *EnIk
     VB_NABOORU_KNUCKLE_DEATH_SCENE,
 
     /*** Fishsanity ***/

--- a/soh/soh/Enhancements/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.cpp
@@ -619,7 +619,7 @@ void TimeSaverOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_li
                 *should = false;
                 BossGanondrof* pg = va_arg(args, BossGanondrof*);
                 Player* player = GET_PLAYER(gPlayState);
-                if (pg != nullptr && pg->work[GND_ACTION_STATE] == DEATH_SPASM) {
+                if (pg->work[GND_ACTION_STATE] == DEATH_SPASM) {
                     // Skip to death scream animation and move ganondrof to middle
                     pg->deathState = DEATH_SCREAM;
                     pg->timers[0] = 50;

--- a/soh/src/overlays/actors/ovl_Boss_Ganondrof/z_boss_ganondrof.c
+++ b/soh/src/overlays/actors/ovl_Boss_Ganondrof/z_boss_ganondrof.c
@@ -966,7 +966,7 @@ void BossGanondrof_Death(BossGanondrof* this, PlayState* play) {
                     bodyDecayLevel = 1;
                     break;
             }
-            if (GameInteractor_Should(VB_PHANTOM_GANON_DEATH_SCENE, true)) {
+            if (GameInteractor_Should(VB_PHANTOM_GANON_DEATH_SCENE, true, this)) {
                 Math_ApproachS(&this->actor.shape.rot.y, this->work[GND_VARIANCE_TIMER] * -100, 5, 0xBB8);
                 Math_ApproachF(&this->cameraNextEye.z, this->targetPos.z + 60.0f, 0.02f, 0.5f);
                 Math_ApproachF(&this->actor.world.pos.y, GND_BOSSROOM_CENTER_Y + 133.0f, 0.05f, 100.0f);


### PR DESCRIPTION
Also added a bit of documentation to the VB enum.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2102332630.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2102364599.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2102366133.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2102367368.zip)
<!--- section:artifacts:end -->