### PR TITLE
Redo frog VB

### DIFF
--- a/soh/soh/Enhancements/game-interactor/GameInteractor.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor.h
@@ -286,6 +286,9 @@ typedef enum {
     VB_GANON_HEAL_BEFORE_FIGHT,
     VB_FREEZE_LINK_FOR_BLOCK_THROW,
     VB_MOVE_THROWN_ACTOR,
+    // Opt: *EnFr
+    // Vanilla condition: this->reward == GI_NONE
+    VB_FROGS_GO_TO_IDLE,
 
     /*** Play Cutscenes ***/
 
@@ -378,8 +381,6 @@ typedef enum {
     VB_GIVE_ITEM_FROM_MEDIGORON,
     // Opt: *EnMs
     VB_GIVE_ITEM_FROM_MAGIC_BEAN_SALESMAN,
-    // Opt: *EnFr
-    VB_GIVE_ITEM_FROM_FROGS,
     // Opt: *EnSkj
     VB_GIVE_ITEM_FROM_OCARINA_MEMORY_GAME,
     // Opt: *EnSkj

--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -994,19 +994,15 @@ void RandomizerOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_l
             }
             break;
         }
-        case VB_GIVE_ITEM_FROM_FROGS: {
+        case VB_FROGS_GO_TO_IDLE: {
             EnFr* enFr = va_arg(args, EnFr*);
 
-            // Skip GiveReward+SetIdle action func if the reward is an ice trap
-            if (enFr->actionFunc == (EnFrActionFunc)EnFr_GiveReward) {
-                RandomizerCheck rc = EnFr_RandomizerCheckFromSongIndex(enFr->songIndex);
-                GetItemEntry gi = Rando::Context::GetInstance()->GetFinalGIEntry(rc, true, (GetItemID)Rando::StaticData::GetLocation(rc)->GetVanillaItem());
-                if (gi.getItemId == RG_ICE_TRAP) {
-                    enFr->actionFunc = (EnFrActionFunc)EnFr_Idle;
-                }
+            if (
+                (enFr->songIndex >= FROG_STORMS && enFr->reward == GI_HEART_PIECE) || 
+                (enFr->songIndex < FROG_STORMS && enFr->reward == GI_RUPEE_PURPLE)
+            ) {
+                *should = true;
             }
-
-            *should = false;
             break;
         }
         case VB_TRADE_POCKET_CUCCO: {

--- a/soh/src/overlays/actors/ovl_En_Fr/z_en_fr.c
+++ b/soh/src/overlays/actors/ovl_En_Fr/z_en_fr.c
@@ -974,9 +974,7 @@ void EnFr_SetReward(EnFr* this, PlayState* play) {
         if (!(gSaveContext.eventChkInf[13] & sSongIndex[songIndex])) {
             gSaveContext.eventChkInf[13] |= sSongIndex[songIndex];
             GameInteractor_ExecuteOnFlagSet(FLAG_EVENT_CHECK_INF, (EVENTCHKINF_SONGS_FOR_FROGS_INDEX << 4) + sSongIndexShift[songIndex]);
-            if (GameInteractor_Should(VB_GIVE_ITEM_FROM_FROGS, true, this)) {
-                this->reward = GI_RUPEE_PURPLE;
-            }
+            this->reward = GI_RUPEE_PURPLE;
         } else {
             this->reward = GI_RUPEE_BLUE;
         }
@@ -984,9 +982,7 @@ void EnFr_SetReward(EnFr* this, PlayState* play) {
         if (!(gSaveContext.eventChkInf[13] & sSongIndex[songIndex])) {
             gSaveContext.eventChkInf[13] |= sSongIndex[songIndex];
             GameInteractor_ExecuteOnFlagSet(FLAG_EVENT_CHECK_INF, (EVENTCHKINF_SONGS_FOR_FROGS_INDEX << 4) + sSongIndexShift[songIndex]);
-            if (GameInteractor_Should(VB_GIVE_ITEM_FROM_FROGS, true, this)) {
-                this->reward = GI_HEART_PIECE;
-            }
+            this->reward = GI_HEART_PIECE;
         } else {
             this->reward = GI_RUPEE_BLUE;
         }
@@ -994,9 +990,7 @@ void EnFr_SetReward(EnFr* this, PlayState* play) {
         if (!(gSaveContext.eventChkInf[13] & sSongIndex[songIndex])) {
             gSaveContext.eventChkInf[13] |= sSongIndex[songIndex];
             GameInteractor_ExecuteOnFlagSet(FLAG_EVENT_CHECK_INF, (EVENTCHKINF_SONGS_FOR_FROGS_INDEX << 4) + sSongIndexShift[songIndex]);
-            if (GameInteractor_Should(VB_GIVE_ITEM_FROM_FROGS, true, this)) {
-                this->reward = GI_HEART_PIECE;
-            }
+            this->reward = GI_HEART_PIECE;
         } else {
             this->reward = GI_RUPEE_PURPLE;
         }
@@ -1042,18 +1036,16 @@ void EnFr_Deactivate(EnFr* this, PlayState* play) {
 
     play->msgCtx.ocarinaMode = OCARINA_MODE_04;
     Audio_PlayActorSound2(&this->actor, NA_SE_EV_FROG_CRY_0);
-    if (this->reward == GI_NONE) {
+    if (GameInteractor_Should(VB_FROGS_GO_TO_IDLE, this->reward == GI_NONE, this)) {
         this->actionFunc = EnFr_Idle;
     } else {
         this->actionFunc = EnFr_GiveReward;
-        if (GameInteractor_Should(VB_GIVE_ITEM_FROM_FROGS, true, this)) {
-            Actor_OfferGetItem(&this->actor, play, this->reward, 30.0f, 100.0f);
-        }
+        Actor_OfferGetItem(&this->actor, play, this->reward, 30.0f, 100.0f);
     }
 }
 
 void EnFr_GiveReward(EnFr* this, PlayState* play) {
-    if (Actor_HasParent(&this->actor, play) || !GameInteractor_Should(VB_GIVE_ITEM_FROM_FROGS, true, this)) {
+    if (Actor_HasParent(&this->actor, play)) {
         this->actor.parent = NULL;
         this->actionFunc = EnFr_SetIdle;
     } else {


### PR DESCRIPTION
Simplifies/reduces touch points. Fixes an issue where if you re-played a song the frogs would be left in a broken state. Replaying a song now hits the vanilla branch and gives you the rupees

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2106800555.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2106820261.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2106821425.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2106821681.zip)
<!--- section:artifacts:end -->