### PR TITLE
Adds item names to filtered check parameters.

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -1064,12 +1064,22 @@ bool UpdateFilters() {
 }
 
 bool ShouldShowCheck(RandomizerCheck check) {
+    auto itemLoc = Rando::Context::GetInstance()->GetItemLocation(check);
+    std::string search = (Rando::StaticData::GetLocation(check)->GetShortName() + " " +
+        Rando::StaticData::GetLocation(check)->GetName() + " " +
+        RandomizerCheckObjects::GetRCAreaName(Rando::StaticData::GetLocation(check)->GetArea()));
+    if (itemLoc->HasObtained() || itemLoc->GetCheckStatus() == RCSHOW_SCUMMED || 
+        (!mystery && (itemLoc->GetCheckStatus() == RCSHOW_IDENTIFIED || itemLoc->GetCheckStatus() == RCSHOW_SEEN) && itemLoc->GetPlacedRandomizerGet() != RG_ICE_TRAP)) {
+        search += " " + itemLoc->GetPlacedItemName().GetForLanguage(gSaveContext.language);
+    } else if (itemLoc->GetCheckStatus() == RCSHOW_IDENTIFIED && !mystery) {
+        search += OTRGlobals::Instance->gRandoContext->overrides[check].GetTrickName().GetForLanguage(gSaveContext.language);
+    } else if (itemLoc->GetCheckStatus() == RCSHOW_SEEN && !mystery) {
+        search += Rando::StaticData::RetrieveItem(OTRGlobals::Instance->gRandoContext->overrides[check].LooksLike()).GetName().GetForLanguage(gSaveContext.language);
+    }
     return (
-        IsVisibleInCheckTracker(check) && 
+        IsVisibleInCheckTracker(check) &&
         (checkSearch.Filters.Size == 0 ||
-        checkSearch.PassFilter((Rando::StaticData::GetLocation(check)->GetShortName() + " " +
-            Rando::StaticData::GetLocation(check)->GetName() + " " +
-            RandomizerCheckObjects::GetRCAreaName(Rando::StaticData::GetLocation(check)->GetArea())).c_str()))
+            checkSearch.PassFilter(search.c_str()))
     );
 }
 


### PR DESCRIPTION
Includes saved/collected/scummed and seen/identified shop names. Should even work with ice trap names for shops.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2108543730.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2108562152.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2108564277.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2108572065.zip)
<!--- section:artifacts:end -->