### PR TITLE
Windows Build Assets Tweak

### DIFF
--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -33,7 +33,7 @@ cd Shipwright
 # Add `-DCMAKE_BUILD_TYPE:STRING=Release` if you're packaging
 & 'C:\Program Files\CMake\bin\cmake' -S . -B "build/x64" -G "Visual Studio 17 2022" -T v143 -A x64
 
-# To generate soh.otr
+# Generate soh.otr
 & 'C:\Program Files\CMake\bin\cmake.exe' --build .\build\x64 --target GenerateSohOtr
 
 # Compile project
@@ -76,6 +76,12 @@ cd "build/x64"
 ```powershell
 # If you need to clean the project you can run
 C:\Program Files\CMake\bin\cmake.exe --build build-cmake --target clean
+```
+
+#### Regenerate Asset Headers
+```powershell
+# If you need to regenerate the asset headers to check them into source
+C:\Program Files\CMake\bin\cmake.exe --build build-cmake --target ExtractAssetHeaders
 ```
 
 ## Linux
@@ -158,6 +164,11 @@ cpack -G External (creates appimage)
 # If you need to clean the project you can run
 cmake --build build-cmake --target clean
 ```
+#### Regenerate Asset Headers
+```bash
+# If you need to regenerate the asset headers to check them into source
+cmake --build build-cmake --target ExtractAssetHeaders
+```
 
 ## macOS
 Requires Xcode (or xcode-tools) && `sdl2, libpng, glew, ninja, cmake` (can be installed via homebrew, macports, etc)
@@ -178,15 +189,12 @@ git submodule update --init
 # Add `-DCMAKE_BUILD_TYPE:STRING=Release` if you're packaging
 cmake -H. -Bbuild-cmake -GNinja
 
-# If you need a newer soh.otr only
+# Generate soh.otr
 cmake --build build-cmake --target GenerateSohOtr
 
 # Compile the project
 # Add `--config Release` if you're packaging
 cmake --build build-cmake
-
-# Copy oot.otr into the Application Support directory
-cp build-cmake/soh/oot.otr ~/Library/Application\ Support/com.shipofharkinian.soh/
 
 # Now you can run the executable file:
 ./build-cmake/soh/soh-macos

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -22,27 +22,25 @@ It is recommended that you install Python and Git standalone, the install proces
 
 _Note: Be sure to either clone with the ``--recursive`` flag or do ``git submodule update --init`` after cloning to pull in the libultraship submodule!_
 
+2. After setup and initial build, use the built-in OTR extraction to make your oot.otr/oot-mq.otr files.
+
 _Note: Instructions assume using powershell_
 ```powershell
 # Navigate to the Shipwright repo within powershell. ie: cd "C:\yourpath\Shipwright"
 cd Shipwright
 
 # Setup cmake project
-& 'C:\Program Files\CMake\bin\cmake' -S . -B "build/x64" -G "Visual Studio 17 2022" -T v143 -A x64 # -DCMAKE_BUILD_TYPE:STRING=Release (if you're packaging)
+# Add `-DCMAKE_BUILD_TYPE:STRING=Release` if you're packaging
+& 'C:\Program Files\CMake\bin\cmake' -S . -B "build/x64" -G "Visual Studio 17 2022" -T v143 -A x64
 
 # To generate soh.otr
 & 'C:\Program Files\CMake\bin\cmake.exe' --build .\build\x64 --target GenerateSohOtr
 
 # Compile project
-& 'C:\Program Files\CMake\bin\cmake.exe' --build .\build\x64 # --config Release (if you're packaging)
+# Add `--config Release` if you're packaging
+& 'C:\Program Files\CMake\bin\cmake.exe' --build .\build\x64
 
-# Now you can run the executable in .\build\x64
-
-# If you need to clean the project you can run
-& 'C:\Program Files\CMake\bin\cmake.exe' --build .\build\x64 --target clean
-
-# If you need to regenerate the asset headers to check them into source
-& 'C:\Program Files\CMake\bin\cmake.exe' --build .\build\x64 --target ExtractAssetHeaders
+# Now you can run the executable in .\build\x64 or run in Visual Studio
 ```
 
 ### Developing SoH
@@ -71,6 +69,13 @@ After compiling the project you can generate the distributable by running:
 cd "build/x64"
 # Generate
 & 'C:\Program Files\CMake\bin\cpack.exe' -G ZIP
+```
+
+### Additional CMake Targets
+#### Clean
+```powershell
+# If you need to clean the project you can run
+C:\Program Files\CMake\bin\cmake.exe --build build-cmake --target clean
 ```
 
 ## Linux
@@ -121,13 +126,16 @@ cd Shipwright
 git submodule update --init
 
 # Generate Ninja project
-cmake -H. -Bbuild-cmake -GNinja # -DCMAKE_BUILD_TYPE:STRING=Release (if you're packaging) -DPython3_EXECUTABLE=$(which python3) (if you are using non-standard Python installations such as PyEnv)
+# Add `-DCMAKE_BUILD_TYPE:STRING=Release` if you're packaging
+# Add `-DPython3_EXECUTABLE=$(which python3)` if you are using non-standard Python installations such as PyEnv
+cmake -H. -Bbuild-cmake -GNinja
 
 # Generate soh.otr
 cmake --build build-cmake --target GenerateSohOtr
 
 # Compile the project
-cmake --build build-cmake # --config Release (if you're packaging)
+# Add `--config Release` if you're packaging
+cmake --build build-cmake
 
 # Now you can run the executable in ./build-cmake/soh/soh.elf
 # To develop the project open the repository in VSCode (or your preferred editor)
@@ -151,13 +159,6 @@ cpack -G External (creates appimage)
 cmake --build build-cmake --target clean
 ```
 
-#### Regenerate Asset Headers
-```bash
-# If you need to regenerate the asset headers to check them into source
-cp <path to your ROM> OTRExporter
-cmake --build build-cmake --target ExtractAssetHeaders
-```
-
 ## macOS
 Requires Xcode (or xcode-tools) && `sdl2, libpng, glew, ninja, cmake` (can be installed via homebrew, macports, etc)
 
@@ -169,16 +170,20 @@ _Note: If you're using Visual Studio Code, the [cpack plugin](https://marketplac
 # Clone the repo
 git clone https://github.com/HarbourMasters/Shipwright.git
 cd ShipWright
+
 # Clone the submodule libultraship
 git submodule update --init
-# Copy the baserom to the OTRExporter folder
-cp <path to your ROM> OTRExporter
+
 # Generate Ninja project
-cmake -H. -Bbuild-cmake -GNinja # -DCMAKE_BUILD_TYPE:STRING=Release (if you're packaging)
-# Extract assets & generate OTR (run this anytime you need to regenerate OTR)
-cmake --build build-cmake --target ExtractAssets
+# Add `-DCMAKE_BUILD_TYPE:STRING=Release` if you're packaging
+cmake -H. -Bbuild-cmake -GNinja
+
+# If you need a newer soh.otr only
+cmake --build build-cmake --target GenerateSohOtr
+
 # Compile the project
-cmake --build build-cmake # --config Release (if you're packaging)
+# Add `--config Release` if you're packaging
+cmake --build build-cmake
 
 # Copy oot.otr into the Application Support directory
 cp build-cmake/soh/oot.otr ~/Library/Application\ Support/com.shipofharkinian.soh/
@@ -186,15 +191,6 @@ cp build-cmake/soh/oot.otr ~/Library/Application\ Support/com.shipofharkinian.so
 # Now you can run the executable file:
 ./build-cmake/soh/soh-macos
 # To develop the project open the repository in VSCode (or your preferred editor)
-
-# If you need to clean the project you can run
-cmake --build build-cmake --target clean
-
-# If you need to regenerate the asset headers to check them into source
-cmake --build build-cmake --target ExtractAssetHeaders
-
-# If you need a newer soh.otr only
-cmake --build build-cmake --target GenerateSohOtr
 ```
 
 ### Generating a distributable
@@ -204,6 +200,19 @@ After compiling the project you can generate a distributable by running of the f
 cd build-cmake
 # Generate
 cpack
+```
+
+### Additional CMake Targets
+#### Clean
+```bash
+# If you need to clean the project you can run
+cmake --build build-cmake --target clean
+```
+
+#### Regenerate Asset Headers
+```bash
+# If you need to regenerate the asset headers to check them into source
+cmake --build build-cmake --target ExtractAssetHeaders
 ```
 
 ## Switch

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -22,8 +22,6 @@ It is recommended that you install Python and Git standalone, the install proces
 
 _Note: Be sure to either clone with the ``--recursive`` flag or do ``git submodule update --init`` after cloning to pull in the libultraship submodule!_
 
-2. Place one or more [compatible](#compatible-roms) roms in the `OTRExporter` directory with namings of your choice
-
 _Note: Instructions assume using powershell_
 ```powershell
 # Navigate to the Shipwright repo within powershell. ie: cd "C:\yourpath\Shipwright"
@@ -31,8 +29,10 @@ cd Shipwright
 
 # Setup cmake project
 & 'C:\Program Files\CMake\bin\cmake' -S . -B "build/x64" -G "Visual Studio 17 2022" -T v143 -A x64 # -DCMAKE_BUILD_TYPE:STRING=Release (if you're packaging)
-# Extract assets & generate OTR (run this anytime you need to regenerate OTR)
-& 'C:\Program Files\CMake\bin\cmake.exe' --build .\build\x64 --target ExtractAssets # --config Release (if you're packaging)
+
+# To generate soh.otr
+& 'C:\Program Files\CMake\bin\cmake.exe' --build .\build\x64 --target GenerateSohOtr
+
 # Compile project
 & 'C:\Program Files\CMake\bin\cmake.exe' --build .\build\x64 # --config Release (if you're packaging)
 
@@ -43,9 +43,6 @@ cd Shipwright
 
 # If you need to regenerate the asset headers to check them into source
 & 'C:\Program Files\CMake\bin\cmake.exe' --build .\build\x64 --target ExtractAssetHeaders
-
-# If you need a newer soh.otr only
-& 'C:\Program Files\CMake\bin\cmake.exe' --build .\build\x64 --target GenerateSohOtr
 ```
 
 ### Developing SoH

--- a/soh/CMakeLists.txt
+++ b/soh/CMakeLists.txt
@@ -606,6 +606,9 @@ endif()
 ################################################################################
 # Pre build events
 ################################################################################
+if (MSVC)
+	set(MSVC_CMD ${CMAKE_COMMAND} -E copy_directory $<TARGET_FILE_DIR:soh>/assets ${CMAKE_BINARY_DIR}/soh/assets)
+endif()
 if(NOT CMAKE_SYSTEM_NAME MATCHES "NintendoSwitch|CafeOS")
     add_custom_command(
 		TARGET ${PROJECT_NAME}
@@ -618,6 +621,7 @@ if(NOT CMAKE_SYSTEM_NAME MATCHES "NintendoSwitch|CafeOS")
         COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/OTRExporter/CFG/ActorList_OoTMqDbg.txt $<TARGET_FILE_DIR:soh>/assets/extractor/symbols
         COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/OTRExporter/CFG/ObjectList_OoTMqDbg.txt $<TARGET_FILE_DIR:soh>/assets/extractor/symbols
 	    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/OTRExporter/CFG/SymbolMap_OoTMqDbg.txt $<TARGET_FILE_DIR:soh>/assets/extractor/symbols
+		COMMAND ${MSVC_CMD}
     )
 endif()
 ################################################################################


### PR DESCRIPTION
Changes the CMake process to copy the assets necessary for OTR creation to the Visual Studio run directory.
Also removes the reference to ExtractAssets target from Windows build instructions, since the built-in process will now be the recommended method.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2110509385.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2110543236.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2110543683.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2110547269.zip)
<!--- section:artifacts:end -->