### PR TITLE
Fix oversight in Static Hints, add some asserts

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/fill.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/fill.cpp
@@ -715,7 +715,7 @@ static void CalculateWotH() {
       //If removing this item and no other item caused the game to become unbeatable, then it is strictly necessary,
       //so add it unless it is in Links Pocket or an isolated place.
       auto itemLoc = ctx->GetItemLocation(ctx->playthroughLocations[i][j]);
-      if (itemLoc->IsHintable() && *itemLoc->GetAreas().begin() > RA_LINKS_POCKET &&
+      if (itemLoc->IsHintable() && itemLoc->GetFirstArea() > RA_LINKS_POCKET &&
           !(IsBeatableWithout(ctx->playthroughLocations[i][j], true))) {
         itemLoc->SetWothCandidate();
       }

--- a/soh/soh/Enhancements/randomizer/3drando/hints.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/hints.cpp
@@ -501,10 +501,7 @@ void CreateWarpSongTexts() {
     auto warpSongEntrances = GetShuffleableEntrances(EntranceType::WarpSong, false);
     for (auto entrance : warpSongEntrances) {
       //RANDOTODO make random
-      RandomizerArea destination = RA_NONE;
-      if (!entrance->GetConnectedRegion()->GetAllAreas().empty()){
-        destination = *entrance->GetConnectedRegion()->GetAllAreas().begin();
-      }
+      RandomizerArea destination = entrance->GetConnectedRegion()->GetFirstArea();
       switch (entrance->GetIndex()) {
         case 0x0600: // minuet RANDOTODO make into entrance hints when they are added
           ctx->AddHint(RH_MINUET_WARP_LOC, Hint(RH_MINUET_WARP_LOC, HINT_TYPE_AREA, "", {RHT_WARP_SONG}, {}, {destination}));
@@ -748,12 +745,14 @@ void CreateStaticHintFromData(RandomizerHint hint, StaticHintInfo staticData){
       std::vector<RandomizerCheck> locations = {};
       if (staticData.targetItems.size() > 0){
         locations = FindItemsAndMarkHinted(staticData.targetItems, staticData.hintChecks);
-      }
-      for(auto check: staticData.targetChecks){
-        ctx->GetItemLocation(check)->SetHintAccesible();
+      } else {
+        for(auto check: staticData.targetChecks){
+          locations.push_back(check);
+        }
       }
       std::vector<RandomizerArea> areas = {};
       for (auto loc : locations){
+        ctx->GetItemLocation(loc)->SetHintAccesible();
         areas.push_back(RandomElementFromSet(ctx->GetItemLocation(loc)->GetAreas()));
       }
       //hintKeys are defaulted to in the hint object and do not need to be specified

--- a/soh/soh/Enhancements/randomizer/3drando/location_access.hpp
+++ b/soh/soh/Enhancements/randomizer/3drando/location_access.hpp
@@ -205,6 +205,15 @@ public:
         return areas;
     }
 
+    RandomizerArea GetFirstArea() const{
+        if (areas.empty()){
+            assert(false);
+            return RA_NONE;
+        } else {
+            return *areas.begin();
+        }
+    }
+
     void ReplaceAreas(std::set<RandomizerArea> newAreas) {
         areas = newAreas;
     }

--- a/soh/soh/Enhancements/randomizer/hint.cpp
+++ b/soh/soh/Enhancements/randomizer/hint.cpp
@@ -148,7 +148,7 @@ void Hint::FillGapsInData(){
   for(uint8_t c = 0; c < locations.size(); c++){
     //if area matters for the hint, it should be specified and not left to this
     if (fillAreas){
-      areas.push_back(*ctx->GetItemLocation(locations[c])->GetAreas().begin());
+      areas.push_back(ctx->GetItemLocation(locations[c])->GetFirstArea());
     }
     if (fillItems){
       items.push_back(ctx->GetItemLocation(locations[c])->GetPlacedRandomizerGet());

--- a/soh/soh/Enhancements/randomizer/item_location.cpp
+++ b/soh/soh/Enhancements/randomizer/item_location.cpp
@@ -72,6 +72,15 @@ std::set<RandomizerArea> ItemLocation::GetAreas() const {
     return areas;
 }
 
+RandomizerArea ItemLocation::GetFirstArea() const {
+    if (areas.empty()){
+        assert(false);
+        return RA_NONE;
+    } else {
+        return *areas.begin();
+    }
+}
+
 void ItemLocation::PlaceVanillaItem() {
     placedItem = StaticData::GetLocation(rc)->GetVanillaItem();
 }

--- a/soh/soh/Enhancements/randomizer/item_location.h
+++ b/soh/soh/Enhancements/randomizer/item_location.h
@@ -23,6 +23,7 @@ class ItemLocation {
     RandomizerRegion GetParentRegionKey() const;
     void SetParentRegion (RandomizerRegion region);
     std::set<RandomizerArea> GetAreas() const;
+    RandomizerArea GetFirstArea() const;
     void MergeAreas (std::set<RandomizerArea> newAreas);
     void PlaceVanillaItem();
     void ApplyPlacedItemEffect() const;


### PR DESCRIPTION
This fixed the obvious cause of the issue Malk seemed to be having, and added some asserts to help catch other odd behavior. I can't make it hit the asserts on my end but there's some UB-like behavior going on which means I never find the issues. 

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2109904588.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2109924245.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2109930170.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2109930547.zip)
<!--- section:artifacts:end -->