### PR TITLE
Add faster rupee accumulator

### DIFF
--- a/soh/soh/Enhancements/TimeSavers/FasterRupeeAccumulator.cpp
+++ b/soh/soh/Enhancements/TimeSavers/FasterRupeeAccumulator.cpp
@@ -1,0 +1,47 @@
+#include "soh/Enhancements/game-interactor/GameInteractor.h"
+#include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
+#include "soh/OTRGlobals.h"
+#include "spdlog/spdlog.h"
+
+extern "C" {
+    #include "z64save.h"
+    #include "macros.h"
+    #include "variables.h"
+    #include "functions.h"
+    extern PlayState* gPlayState;
+    extern SaveContext gSaveContext;
+}
+
+void FasterRupeeAccumulator_Register() {
+    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnInterfaceUpdate>([]() {
+        if (!CVarGetInteger(CVAR_ENHANCEMENT("TimeSavers.FasterRupeeAccumulator"), 0)) return;
+
+        if (gSaveContext.rupeeAccumulator == 0) {
+            return;
+        }
+
+        // Gaining rupees
+        if (gSaveContext.rupeeAccumulator > 0) {
+            // Wallet is full
+            if (gSaveContext.rupees >= CUR_CAPACITY(UPG_WALLET)) {
+                return;
+            }
+
+            if (gSaveContext.rupeeAccumulator >= 10 && gSaveContext.rupees + 10 < CUR_CAPACITY(UPG_WALLET)) {
+                gSaveContext.rupeeAccumulator-= 10;
+                gSaveContext.rupees += 10;
+            }
+        // Losing rupees
+        } else if (gSaveContext.rupeeAccumulator < 0) {
+            // No rupees to lose
+            if (gSaveContext.rupees == 0) {
+                return;
+            }
+
+            if (gSaveContext.rupeeAccumulator <= -10 && gSaveContext.rupees > 10) {
+                gSaveContext.rupeeAccumulator += 10;
+                gSaveContext.rupees -= 10;
+            }
+        }
+    });
+}

--- a/soh/soh/Enhancements/TimeSavers/TimeSavers.cpp
+++ b/soh/soh/Enhancements/TimeSavers/TimeSavers.cpp
@@ -12,4 +12,5 @@ void TimeSavers_Register() {
     // SkipMiscInteractions
         MoveMidoInKokiriForest_Register();
     FasterHeavyBlockLift_Register();
+    FasterRupeeAccumulator_Register();
 }

--- a/soh/soh/Enhancements/TimeSavers/TimeSavers.h
+++ b/soh/soh/Enhancements/TimeSavers/TimeSavers.h
@@ -14,5 +14,6 @@ void TimeSavers_Register();
 // SkipMiscInteractions
     void MoveMidoInKokiriForest_Register();
 void FasterHeavyBlockLift_Register();
+void FasterRupeeAccumulator_Register();
 
 #endif // TIME_SAVERS_H

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -711,6 +711,7 @@ void DrawEnhancementsMenu() {
                 UIWidgets::PaddedEnhancementSliderInt("Crawl speed %dx", "##CRAWLSPEED", CVAR_ENHANCEMENT("CrawlSpeed"), 1, 4, "", 1, true, false, true);
                 UIWidgets::PaddedEnhancementCheckbox("Faster Heavy Block Lift", CVAR_ENHANCEMENT("FasterHeavyBlockLift"), false, false);
                 UIWidgets::Tooltip("Speeds up lifting silver rocks and obelisks");
+                UIWidgets::PaddedEnhancementCheckbox("Faster Rupee Accumulator", CVAR_ENHANCEMENT("TimeSavers.FasterRupeeAccumulator"), false, false);
                 UIWidgets::PaddedEnhancementCheckbox("Skip Pickup Messages", CVAR_ENHANCEMENT("FastDrops"), true, false);
                 UIWidgets::Tooltip("Skip pickup messages for new consumable items and bottle swipes");
                 UIWidgets::PaddedEnhancementCheckbox("Fast Ocarina Playback", CVAR_ENHANCEMENT("FastOcarinaPlayback"), true, false);


### PR DESCRIPTION
I experimented with +/- 100 and 50 but they were _way_ too fast

Also worth noting I'm doing < 10 and not <=, because I want there to be one left so the vanilla rupeeAccumulator can still pick up the last rupee and make the sound

https://github.com/user-attachments/assets/5a4d19bf-ba0c-499f-a9ce-eeba47007edc



<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2110214552.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2110249631.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2110250539.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2110251021.zip)
<!--- section:artifacts:end -->