### PR TITLE
Attempt to find area problems

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/fill.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/fill.cpp
@@ -636,7 +636,6 @@ void SetAreas(){
 //then use those areas to not need to recursivly find ItemLocation areas when an identifying entrance's area
   for (int regionType = 0; regionType < RR_MARKER_AREAS_END; regionType++) {
     Region* region = &areaTable[regionType];
-    //regionType == RR_FIRE_TEMPLE_BOSS_ROOM
     std::set<RandomizerArea> areas = region->GetAllAreas();
     std::set<Region*> regionsToSet = {region};
     if (areas.empty()) {

--- a/soh/soh/Enhancements/randomizer/3drando/fill.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/fill.cpp
@@ -617,8 +617,8 @@ void LookForExternalArea(Region* currentRegion, std::set<Region*> &alreadyChecke
     //if this entrance does not pass areas, only process it if we are in low priority mode
     if ((LowPriorityMode || entrance->DoesSpreadAreas()) && !alreadyChecked.contains(entrance->GetParentRegion())){
       std::set<RandomizerArea> otherAreas = entrance->GetParentRegion()->GetAllAreas();
-      alreadyChecked.insert(entrance->GetParentRegion());
       if (otherAreas.size() == 0) {
+        alreadyChecked.insert(entrance->GetParentRegion());
         LookForExternalArea(entrance->GetParentRegion(), alreadyChecked, areas, LowPriorityMode);
       //If we find a valid area we should add it.
       //If it's Links Pocket or RA_NONE, do not propagate those, they are not real areas.
@@ -636,6 +636,7 @@ void SetAreas(){
 //then use those areas to not need to recursivly find ItemLocation areas when an identifying entrance's area
   for (int regionType = 0; regionType < RR_MARKER_AREAS_END; regionType++) {
     Region* region = &areaTable[regionType];
+    //regionType == RR_FIRE_TEMPLE_BOSS_ROOM
     std::set<RandomizerArea> areas = region->GetAllAreas();
     std::set<Region*> regionsToSet = {region};
     if (areas.empty()) {

--- a/soh/soh/Enhancements/randomizer/3drando/hints.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/hints.cpp
@@ -411,7 +411,7 @@ static bool CreateHint(RandomizerCheck location, uint8_t copies, HintType type, 
       return false;
   }
   RandomizerCheck gossipStone = RandomElement(gossipStoneLocations);
-  RandomizerArea area = RandomElementFromSet(ctx->GetItemLocation(location)->GetAreas());
+  RandomizerArea area = ctx->GetItemLocation(location)->GetRandomArea();
 
   //Set that hints are accesible
   ctx->GetItemLocation(location)->SetHintAccesible();
@@ -707,7 +707,7 @@ void CreateChildAltarHint() {
     }
     std::vector<RandomizerArea> stoneAreas = {};
     for (auto loc : stoneLocs){
-      stoneAreas.push_back(RandomElementFromSet(ctx->GetItemLocation(loc)->GetAreas()));
+      stoneAreas.push_back(ctx->GetItemLocation(loc)->GetRandomArea());
     }
     ctx->AddHint(RH_ALTAR_CHILD, Hint(RH_ALTAR_CHILD, HINT_TYPE_ALTAR_CHILD, {}, stoneLocs, stoneAreas));
   }
@@ -729,7 +729,7 @@ void CreateAdultAltarHint() {
     }
     std::vector<RandomizerArea> medallionAreas = {};
     for (auto loc : medallionLocs){
-      medallionAreas.push_back(RandomElementFromSet(ctx->GetItemLocation(loc)->GetAreas()));
+      medallionAreas.push_back(ctx->GetItemLocation(loc)->GetRandomArea());
     }
     ctx->AddHint(RH_ALTAR_ADULT, Hint(RH_ALTAR_ADULT, HINT_TYPE_ALTAR_ADULT, {}, medallionLocs, medallionAreas));
   }
@@ -753,7 +753,15 @@ void CreateStaticHintFromData(RandomizerHint hint, StaticHintInfo staticData){
       std::vector<RandomizerArea> areas = {};
       for (auto loc : locations){
         ctx->GetItemLocation(loc)->SetHintAccesible();
-        areas.push_back(RandomElementFromSet(ctx->GetItemLocation(loc)->GetAreas()));
+        if (ctx->GetItemLocation(loc)->GetAreas().empty()){
+          //If we get to here then it means a location got through with no area assignment, which means something went wrong elsewhere.
+          SPDLOG_DEBUG("Attempted to hint location with no areas: ");
+          SPDLOG_DEBUG(Rando::StaticData::GetLocation(loc)->GetName());
+          assert(false);
+          areas.push_back(RA_NONE);
+        } else {
+          areas.push_back(ctx->GetItemLocation(loc)->GetRandomArea());
+        }
       }
       //hintKeys are defaulted to in the hint object and do not need to be specified
       ctx->AddHint(hint, Hint(hint, staticData.type, {}, locations, areas, {}, staticData.yourPocket, staticData.num));
@@ -768,7 +776,7 @@ void CreateStaticItemHint(RandomizerHint hintKey, std::vector<RandomizerHintText
   std::vector<RandomizerCheck> locations = FindItemsAndMarkHinted(items, hintChecks);
   std::vector<RandomizerArea> areas = {};
   for (auto loc : locations){
-    areas.push_back(RandomElementFromSet(ctx->GetItemLocation(loc)->GetAreas()));
+    areas.push_back(ctx->GetItemLocation(loc)->GetRandomArea());
   }
   ctx->AddHint(hintKey, Hint(hintKey, HINT_TYPE_AREA, hintTextKeys, locations, areas, {}, yourPocket));
 }

--- a/soh/soh/Enhancements/randomizer/3drando/random.hpp
+++ b/soh/soh/Enhancements/randomizer/3drando/random.hpp
@@ -40,6 +40,7 @@ const T RandomElementFromSet(const std::set<T>& set) {
     for (uint32_t i = 0; i < rand; i++) {
         it++;
     }
+    auto test = *it;
     return *it;
 }
 

--- a/soh/soh/Enhancements/randomizer/item_location.cpp
+++ b/soh/soh/Enhancements/randomizer/item_location.cpp
@@ -81,6 +81,17 @@ RandomizerArea ItemLocation::GetFirstArea() const {
     }
 }
 
+RandomizerArea ItemLocation::GetRandomArea() const {
+    if (areas.empty()){
+        SPDLOG_DEBUG("Attempted to get random area of location with no areas: ");
+        SPDLOG_DEBUG(Rando::StaticData::GetLocation(rc)->GetName());
+        assert(false);
+        return RA_NONE;
+    } else {
+        return RandomElementFromSet(areas);
+    }
+}
+
 void ItemLocation::PlaceVanillaItem() {
     placedItem = StaticData::GetLocation(rc)->GetVanillaItem();
 }

--- a/soh/soh/Enhancements/randomizer/item_location.h
+++ b/soh/soh/Enhancements/randomizer/item_location.h
@@ -24,6 +24,7 @@ class ItemLocation {
     void SetParentRegion (RandomizerRegion region);
     std::set<RandomizerArea> GetAreas() const;
     RandomizerArea GetFirstArea() const;
+    RandomizerArea GetRandomArea() const;
     void MergeAreas (std::set<RandomizerArea> newAreas);
     void PlaceVanillaItem();
     void ApplyPlacedItemEffect() const;


### PR DESCRIPTION
Adds a few asserts and logs to help look for area problems, and insulates the code better vs empty sets

I also fixed an issue I found in SetAreas causing areas with default areas to get assigned additional areas in some circumstances

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2115084364.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2115117828.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2115121855.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2115122608.zip)
<!--- section:artifacts:end -->