### PR TITLE
Move collision viewer draw to hook and fix empty nametags

### DIFF
--- a/soh/soh/Enhancements/debugger/colViewer.cpp
+++ b/soh/soh/Enhancements/debugger/colViewer.cpp
@@ -8,6 +8,7 @@
 #include <libultraship/bridge.h>
 #include <libultraship/libultraship.h>
 #include "soh/OTRGlobals.h"
+#include "soh/Enhancements/game-interactor/GameInteractor.h"
 
 extern "C" {
 #include <z64.h>
@@ -274,11 +275,6 @@ void CreateSphereData() {
     }
 
     sphereGfx.push_back(gsSPEndDisplayList());
-}
-
-void ColViewerWindow::InitElement() {
-    CreateCylinderData();
-    CreateSphereData();
 }
 
 // Initializes the display list for a ColRenderSetting
@@ -688,4 +684,11 @@ extern "C" void DrawColViewer() {
     }
 
     CLOSE_DISPS(gPlayState->state.gfxCtx);
+}
+
+void ColViewerWindow::InitElement() {
+    CreateCylinderData();
+    CreateSphereData();
+
+    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnPlayDrawEnd>(DrawColViewer);
 }

--- a/soh/soh/Enhancements/nametag.cpp
+++ b/soh/soh/Enhancements/nametag.cpp
@@ -201,7 +201,7 @@ extern "C" void NameTag_RegisterForActorWithOptions(Actor* actor, const char* te
     processedText.erase(std::remove_if(processedText.begin(), processedText.end(), [](const char& c) {
         // 172 is max supported texture for the in-game font system,
         // and filter anything less than a space but not the newline or nul characters
-        return c > (s8)172 || (c < ' ' && c != '\n' && c != '\0');
+        return (unsigned char)c > 172 || (c < ' ' && c != '\n' && c != '\0');
     }), processedText.end());
 
     int16_t numChar = processedText.length();

--- a/soh/src/code/graph.c
+++ b/soh/src/code/graph.c
@@ -300,7 +300,6 @@ void Graph_Update(GraphicsContext* gfxCtx, GameState* gameState) {
 
     GameState_ReqPadData(gameState);
     GameState_Update(gameState);
-    DrawColViewer();
 
     OPEN_DISPS(gfxCtx);
 


### PR DESCRIPTION
Moves the collision viewer draw execution to be within the play draw end hook, which when combined with #4522 will prevent collision viewer from drawing when kaleido menu is open.

Fixes #4433

Also noticed I incorrectly handled casting in the name tag char filter which lead to all name tags being empty. Fixed now.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2149229831.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2149289609.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2149292978.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2149294451.zip)
<!--- section:artifacts:end -->