### PR TITLE
Fix skipping twisted hallway cutscenes

### DIFF
--- a/soh/soh/Enhancements/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.cpp
@@ -310,6 +310,7 @@ void TimeSaverOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_li
                     case ACTOR_BG_SPOT05_SOKO:
                     case ACTOR_BG_SPOT18_BASKET:
                     case ACTOR_BG_HIDAN_CURTAIN:
+                    case ACTOR_BG_MORI_HINERI:
                         *should = false;
                         RateLimitedSuccessChime();
                         break;


### PR DESCRIPTION
Addresses #4472, at least for vanilla. I don't play MQ, so I'd appreciate someone else testing that.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2169533890.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2169570862.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2169574413.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2169578349.zip)
<!--- section:artifacts:end -->