### PR TITLE
[Draft] Keep ZR Waterfall open after playing once

### DIFF
--- a/soh/include/z64save.h
+++ b/soh/include/z64save.h
@@ -281,6 +281,7 @@ typedef struct {
     /*        */ SohStats sohStats;
     /*        */ FaroresWindData backupFW;
     /*        */ u8 maskMemory;
+    /*        */ u8 isWaterfallOpen;
     // #endregion
     // #region SOH [Randomizer]
     // Upstream TODO: Move these to their own struct or name to more obviously specific to Randomizer

--- a/soh/soh/Enhancements/mods.cpp
+++ b/soh/soh/Enhancements/mods.cpp
@@ -1401,6 +1401,7 @@ void RegisterKeepWaterfallOpen() {
     GameInteractor::Instance->RegisterGameHook<GameInteractor::OnActorInit>([](void* refActor) {
         //Set it to open on init if already played
         Actor* actor = static_cast<Actor*>(refActor);
+
         if (CVarGetInteger(CVAR_ENHANCEMENT("KeepWaterfallOpen"), 0) && actor->id == ACTOR_BG_SPOT03_TAKI && gSaveContext.isWaterfallOpen == 1) {
             
             BgSpot03Taki* waterfall = static_cast<BgSpot03Taki*>(refActor);
@@ -1414,10 +1415,12 @@ void RegisterKeepWaterfallOpen() {
     GameInteractor::Instance->RegisterGameHook<GameInteractor::OnActorUpdate>([](void* refActor) {
         
         Actor* actor = static_cast<Actor*>(refActor);
+
         if (CVarGetInteger(CVAR_ENHANCEMENT("KeepWaterfallOpen"), 0)  && actor->id == ACTOR_BG_SPOT03_TAKI) {
+            
             BgSpot03Taki* waterfall = static_cast<BgSpot03Taki*>(refActor);
 
-            //Keep timer from running out if open unless togglable and played song
+            //Keep timer from running out if open unless toggleable and played song
             if (gSaveContext.isWaterfallOpen == 1 && waterfall->timer > -1 &&
                 !(CVarGetInteger(CVAR_ENHANCEMENT("ToggleableWaterfall"), 0) && Flags_GetSwitch(gPlayState, waterfall->switchFlag))) {
                 waterfall->timer = 40;

--- a/soh/soh/Enhancements/mods.cpp
+++ b/soh/soh/Enhancements/mods.cpp
@@ -1186,7 +1186,6 @@ void RegisterRandomizedEnemySizes() {
         // Randomized Enemy Sizes
         Player* player = GET_PLAYER(gPlayState);
         Actor* actor = static_cast<Actor*>(refActor);
-       
         // Exclude wobbly platforms in Jabu because they need to act like platforms.
         // Exclude Dead Hand hands and Bongo Bongo main body because they make the fights (near) impossible.
         uint8_t excludedEnemy = actor->id == ACTOR_EN_BROB || actor->id == ACTOR_EN_DHA || (actor->id == ACTOR_BOSS_SST && actor->params == -1);
@@ -1398,7 +1397,7 @@ void RegisterRandomizerCompasses() {
 
 
 void RegisterKeepWaterfallOpen() {
-    // Keep Zora's River Waterfall open after plating the song
+    // Keep Zora's River Waterfall open after playing lullaby
     GameInteractor::Instance->RegisterGameHook<GameInteractor::OnActorInit>([](void* refActor) {
         //Set it to open on init if already played
         Actor* actor = static_cast<Actor*>(refActor);

--- a/soh/soh/Enhancements/mods.cpp
+++ b/soh/soh/Enhancements/mods.cpp
@@ -1398,27 +1398,22 @@ void RegisterRandomizerCompasses() {
 
 void RegisterKeepWaterfallOpen() {
     // Keep Zora's River Waterfall open after playing lullaby
-    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnActorInit>([](void* refActor) {
+    GameInteractor::Instance->RegisterGameHookForID<GameInteractor::OnActorInit>(ACTOR_BG_SPOT03_TAKI, [](void* refActor) {
         //Set it to open on init if already played
-        Actor* actor = static_cast<Actor*>(refActor);
+        BgSpot03Taki* waterfall = static_cast<BgSpot03Taki*>(refActor);
 
-        if (CVarGetInteger(CVAR_ENHANCEMENT("KeepWaterfallOpen"), 0) && actor->id == ACTOR_BG_SPOT03_TAKI && gSaveContext.isWaterfallOpen == 1) {
-            
-            BgSpot03Taki* waterfall = static_cast<BgSpot03Taki*>(refActor);
-
+        if (CVarGetInteger(CVAR_ENHANCEMENT("KeepWaterfallOpen"), 0) && gSaveContext.isWaterfallOpen == 1) {
             waterfall->state = WATERFALL_OPENED;
             func_8003EBF8(gPlayState, &gPlayState->colCtx.dyna, waterfall->dyna.bgId); //remove collision
             waterfall->openingAlpha = 0;
             waterfall->timer = 40;
         }
     });
-    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnActorUpdate>([](void* refActor) {
+    GameInteractor::Instance->RegisterGameHookForID<GameInteractor::OnActorUpdate>(ACTOR_BG_SPOT03_TAKI, [](void* refActor) {
         
-        Actor* actor = static_cast<Actor*>(refActor);
+        BgSpot03Taki* waterfall = static_cast<BgSpot03Taki*>(refActor);
 
-        if (CVarGetInteger(CVAR_ENHANCEMENT("KeepWaterfallOpen"), 0)  && actor->id == ACTOR_BG_SPOT03_TAKI) {
-            
-            BgSpot03Taki* waterfall = static_cast<BgSpot03Taki*>(refActor);
+        if (CVarGetInteger(CVAR_ENHANCEMENT("KeepWaterfallOpen"), 0)) {        
 
             //Keep timer from running out if open unless toggleable and played song
             if (gSaveContext.isWaterfallOpen == 1 && waterfall->timer > -1 &&

--- a/soh/soh/SaveManager.cpp
+++ b/soh/soh/SaveManager.cpp
@@ -1561,6 +1561,8 @@ void SaveManager::LoadBaseVersion1() {
     SaveManager::Instance->LoadArray("randomizerInf", ARRAY_COUNT(gSaveContext.randomizerInf), [](size_t i) {
         SaveManager::Instance->LoadData("", gSaveContext.randomizerInf[i]);
     });
+
+    SaveManager::Instance->LoadData("isWaterfallOpen", gSaveContext.isWaterfallOpen);
 }
 
 void SaveManager::LoadBaseVersion2() {
@@ -1750,6 +1752,8 @@ void SaveManager::LoadBaseVersion2() {
     if (isMQ) {
         gSaveContext.questId = QUEST_MASTER;
     }
+
+    SaveManager::Instance->LoadData("isWaterfallOpen", gSaveContext.isWaterfallOpen);
 
     // Workaround for breaking save compatibility from 5.0.2 -> 5.1.0 in commit d7c35221421bf712b5ead56a360f81f624aca4bc
     if (!gSaveContext.isMagicAcquired) {
@@ -1998,6 +2002,7 @@ void SaveManager::LoadBaseVersion3() {
         SaveManager::Instance->LoadData("tempCollectFlags", gSaveContext.backupFW.tempCollectFlags);
     });
     SaveManager::Instance->LoadData("dogParams", gSaveContext.dogParams);
+    SaveManager::Instance->LoadData("isWaterfallOpen", gSaveContext.isWaterfallOpen);
 }
 
 void SaveManager::LoadBaseVersion4() {
@@ -2180,6 +2185,7 @@ void SaveManager::LoadBaseVersion4() {
     });
     SaveManager::Instance->LoadData("dogParams", gSaveContext.dogParams);
     SaveManager::Instance->LoadData("maskMemory", gSaveContext.maskMemory);
+    SaveManager::Instance->LoadData("isWaterfallOpen", gSaveContext.isWaterfallOpen);
 }
 
 void SaveManager::SaveBase(SaveContext* saveContext, int sectionID, bool fullSave) {
@@ -2350,6 +2356,7 @@ void SaveManager::SaveBase(SaveContext* saveContext, int sectionID, bool fullSav
     });
     SaveManager::Instance->SaveData("dogParams", saveContext->dogParams);
     SaveManager::Instance->SaveData("maskMemory", saveContext->maskMemory);
+    SaveManager::Instance->SaveData("isWaterfallOpen", saveContext->isWaterfallOpen);
 }
 
 // Load a string into a char array based on size and ensuring it is null terminated when overflowed

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -794,6 +794,12 @@ void DrawEnhancementsMenu() {
                     "- Not within range of Ocarina playing spots");
                 UIWidgets::PaddedEnhancementCheckbox("Pause Warp", CVAR_ENHANCEMENT("PauseWarp"), true, false);
                 UIWidgets::Tooltip("Selection of warp song in pause menu initiates warp. Disables song playback.");
+                UIWidgets::PaddedEnhancementCheckbox("Keep Zora's River Waterfall Open", CVAR_ENHANCEMENT("KeepWaterfallOpen"), true, false);
+                UIWidgets::Tooltip("The entrance to Zora's Domain will remain open after playing Zelda's Lullaby for the first time.");
+                if (CVarGetInteger(CVAR_ENHANCEMENT("KeepWaterfallOpen"), 0)) {
+                    UIWidgets::PaddedEnhancementCheckbox("Toggleable Waterfall", CVAR_ENHANCEMENT("ToggleableWaterfall"), true, false);
+                    UIWidgets::Tooltip("Close the waterfall by playing Zelda's Lullaby again.");
+                }
                 
                 ImGui::EndTable();
                 ImGui::EndMenu();
@@ -1239,7 +1245,7 @@ void DrawEnhancementsMenu() {
             UIWidgets::Tooltip("Removes the input requirement on textboxes after defeating Ganon, allowing Credits sequence to continue to progress");
             UIWidgets::PaddedEnhancementCheckbox("Answer Navi Prompt with L Button", CVAR_ENHANCEMENT("NaviOnL"), true, false);
             UIWidgets::Tooltip("Speak to Navi with L but enter first-person camera with C-Up");
-
+            
             // Blue Fire Arrows
             bool forceEnableBlueFireArrows = IS_RANDO &&
                 OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_BLUE_FIRE_ARROWS);

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -1245,7 +1245,6 @@ void DrawEnhancementsMenu() {
             UIWidgets::Tooltip("Removes the input requirement on textboxes after defeating Ganon, allowing Credits sequence to continue to progress");
             UIWidgets::PaddedEnhancementCheckbox("Answer Navi Prompt with L Button", CVAR_ENHANCEMENT("NaviOnL"), true, false);
             UIWidgets::Tooltip("Speak to Navi with L but enter first-person camera with C-Up");
-            
             // Blue Fire Arrows
             bool forceEnableBlueFireArrows = IS_RANDO &&
                 OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_BLUE_FIRE_ARROWS);

--- a/soh/src/code/z_bgcheck.c
+++ b/soh/src/code/z_bgcheck.c
@@ -2694,6 +2694,7 @@ DynaPolyActor* DynaPoly_GetActor(CollisionContext* colCtx, s32 bgId) {
     return (DynaPolyActor*)colCtx->dyna.bgActors[bgId].actor;
 }
 
+//Remove collision
 void func_8003EBF8(PlayState* play, DynaCollisionContext* dyna, s32 bgId) {
     if (DynaPoly_IsBgIdBgActor(bgId)) {
         dyna->bgActorFlags[bgId] |= 4;
@@ -2701,6 +2702,7 @@ void func_8003EBF8(PlayState* play, DynaCollisionContext* dyna, s32 bgId) {
     }
 }
 
+//Restore collision
 void func_8003EC50(PlayState* play, DynaCollisionContext* dyna, s32 bgId) {
     if (DynaPoly_IsBgIdBgActor(bgId)) {
         dyna->bgActorFlags[bgId] &= ~4;


### PR DESCRIPTION
I was working on this before seeing there was already a PR for it, but I decided to make a PR anyway for feedback. It is my first time messing with the game hooks and trying to make something following the project practices.

There are two options: 
One makes it so that the waterfall keeps open after playing Zelda's Lullaby even after reloading the scene or the file.
The other appears if you selected the first and lets you close it up by playing the song again. It also persists through scenes and loading the file.
Enhancements>Gameplay>Timesavers
![image](https://github.com/user-attachments/assets/8f617c76-0788-4e79-a772-7c763c74b54f)


https://github.com/user-attachments/assets/6aa9a449-f0d7-44a8-8425-49db3e3bb861


