### PR TITLE
[Draft] Keep Shadow Temple entrance door open through time

### DIFF
--- a/soh/soh/Enhancements/enhancementTypes.h
+++ b/soh/soh/Enhancements/enhancementTypes.h
@@ -29,6 +29,12 @@ typedef enum {
 } ForcedDialogMode;
 
 typedef enum {
+    PERSIST_SHADOW_DOOR_DISABLED,
+    PERSIST_SHADOW_DOOR_CHILD,
+    PERSIST_SHADOW_DOOR_BOTH
+} PersistShadowDoorMode;
+
+typedef enum {
     BUNNY_HOOD_VANILLA,
     BUNNY_HOOD_FAST_AND_JUMP,
     BUNNY_HOOD_FAST

--- a/soh/soh/Enhancements/mods.cpp
+++ b/soh/soh/Enhancements/mods.cpp
@@ -1395,6 +1395,27 @@ void RegisterRandomizerCompasses() {
     });
 }
 
+void RegisterPersistShadowDoor() {
+    //Change both age flags when opening Shadow Temple Door
+    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnSceneFlagSet>(
+        [](int16_t sceneNum, int16_t flagType, int16_t flag) 
+        {
+            int32_t pShdwDoor = CVarGetInteger(CVAR_ENHANCEMENT("PersistShadowDoor"), PERSIST_SHADOW_DOOR_DISABLED);
+            int16_t childDoor = 0x1F; //child flag
+            int16_t adultDoor = 0x1E; //adult flag
+
+            if (pShdwDoor != PERSIST_SHADOW_DOOR_DISABLED && 
+                sceneNum == SCENE_GRAVEYARD && 
+                flagType == FLAG_SCENE_SWITCH)
+            {
+                if ((pShdwDoor == PERSIST_SHADOW_DOOR_CHILD || pShdwDoor == PERSIST_SHADOW_DOOR_BOTH) && flag == childDoor)
+                    GameInteractor::RawAction::SetSceneFlag(SCENE_GRAVEYARD, FLAG_SCENE_SWITCH, adultDoor);
+                else if (pShdwDoor == PERSIST_SHADOW_DOOR_BOTH && flag == adultDoor)
+                    GameInteractor::RawAction::SetSceneFlag(SCENE_GRAVEYARD, FLAG_SCENE_SWITCH, childDoor);
+            }
+        });
+}
+
 void InitMods() {
     BossRush_RegisterHooks();
     RandomizerRegisterHooks();
@@ -1438,4 +1459,5 @@ void InitMods() {
     RegisterHurtContainerModeHandler();
     RegisterPauseMenuHooks();
     RandoKaleido_RegisterHooks();
+    RegisterPersistShadowDoor();
 }

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -80,6 +80,7 @@ static const char* imguiScaleOptions[4] = { "Small", "Normal", "Large", "X-Large
     static const char* chestStyleMatchesContentsOptions[4] = { "Disabled", "Both", "Texture Only", "Size Only" };
     static const char* skipGetItemAnimationOptions[3] = { "Disabled", "Junk Items", "All Items" };
     static const char* skipForcedDialogOptions[4] = { "None", "Navi Only", "NPCs Only", "All" };
+    static const char* persistShadowDoorOptions[3] = { "Disabled", "Child to Adult", "Both Ways"};
     static const char* bunnyHoodOptions[3] = { "Disabled", "Faster Run & Longer Jump", "Faster Run" };
     static const char* mirroredWorldModes[9] = {
         "Disabled",           "Always",        "Random",          "Random (Seeded)",          "Dungeons",
@@ -794,6 +795,12 @@ void DrawEnhancementsMenu() {
                     "- Not within range of Ocarina playing spots");
                 UIWidgets::PaddedEnhancementCheckbox("Pause Warp", CVAR_ENHANCEMENT("PauseWarp"), true, false);
                 UIWidgets::Tooltip("Selection of warp song in pause menu initiates warp. Disables song playback.");
+                UIWidgets::PaddedText("Persist Shadow Temple Door through time", true, false);
+                UIWidgets::EnhancementCombobox(CVAR_ENHANCEMENT("PersistShadowDoor"), persistShadowDoorOptions, PERSIST_SHADOW_DOOR_DISABLED);
+                UIWidgets::Tooltip(
+                    "The Shadow Temple Door in Graveyard opens for both ages.\n"
+                    " - Child to Adult: If you open the door as Child, it will be open as Adult\n"
+                    " - Both Ways: If you open the door in any age, it will be open as the other too");
                 
                 ImGui::EndTable();
                 ImGui::EndMenu();


### PR DESCRIPTION
More on the series of small things that slightly annoy me that I'm using as practice. 
Those torches will stand the test of time and stay lit for over 7 years, so that you don't need to light them up again to open the Shadow Temple door as adult.

2 options:
- Child to Adult: The Adult flag will be set when you open the door as Child
- Both ways: Send your fire to the past and set both flags no matter what age you originally set them on.

Enhancements>Gameplay>Time Savers>Changes>Persist Shadow Temple Door through time

Video of the "Child to Adult" option:

https://github.com/user-attachments/assets/b4bfb518-61e3-432e-9e11-28d5f3ebc4f5

I don't expect this to be merged because it might be too small of an issue solved in exchange of more clutter to that menu. I did it mostly for fun.