### PR TITLE
Fix infinite freeze in rando on GS pickup.

### DIFF
--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -1397,6 +1397,7 @@ void RandomizerOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_l
             }
             break;
         }
+        case VB_FREEZE_ON_SKULL_TOKEN:
         case VB_TRADE_TIMER_ODD_MUSHROOM:
         case VB_TRADE_TIMER_EYEDROPS:
         case VB_TRADE_TIMER_FROG:


### PR DESCRIPTION
In a rando file, with Gold Skulltulas shuffled, if you didn't have "No Skulltula Freeze" enabled, you would end up frozen indefinitely because no messagebox was popping up. Since rando always returns false for `VB_GIVE_ITEM_SKULL_TOKEN`, this always bypasses the vanilla codepath, so this adds `VB_FREEZE_ON_SKULL_TOKEN` to the list that always return false to prevent the freeze lock.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2205319652.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2205359668.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2205362295.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2205536806.zip)
<!--- section:artifacts:end -->