### PR TITLE
Fix Gift from Sages not showing in tracker

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/hints.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/hints.cpp
@@ -757,7 +757,7 @@ void CreateStaticHintFromData(RandomizerHint hint, StaticHintInfo staticData){
           //If we get to here then it means a location got through with no area assignment, which means something went wrong elsewhere.
           SPDLOG_DEBUG("Attempted to hint location with no areas: ");
           SPDLOG_DEBUG(Rando::StaticData::GetLocation(loc)->GetName());
-          assert(false);
+          //assert(false);
           areas.push_back(RA_NONE);
         } else {
           areas.push_back(ctx->GetItemLocation(loc)->GetRandomArea());

--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -32,8 +32,6 @@ extern std::vector<ItemTrackerItem> dungeonRewardMedallions;
 extern std::vector<ItemTrackerItem> songItems;
 extern std::vector<ItemTrackerItem> equipmentItems;
 
-#define RCO_RAORU { RC_GIFT_FROM_SAGES, RCVORMQ_BOTH, RCTYPE_DUNGEON_REWARD, RCAREA_MARKET, ACTOR_ID_MAX, SCENE_ID_MAX, 0x00, GI_NONE, false, "Gift from Raoru", "Gift from Raoru", true };
-
 using json = nlohmann::json;
 
 namespace CheckTracker {
@@ -215,34 +213,6 @@ std::vector<uint32_t> buttons = { BTN_A, BTN_B, BTN_CUP,   BTN_CDOWN, BTN_CLEFT,
 static ImGuiTextFilter checkSearch;
 std::array<bool, RCAREA_INVALID> filterAreasHidden = { 0 };
 std::array<bool, RC_MAX> filterChecksHidden = { 0 };
-
-void SongFromImpa() {
-    if (IS_RANDO) {
-        if (OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_SKIP_CHILD_ZELDA) == RO_GENERIC_ON && IS_RANDO) {
-            //if (gSaveContext.checkTrackerData[RC_SONG_FROM_IMPA].status != RCSHOW_SAVED) {
-            //    gSaveContext.checkTrackerData[RC_SONG_FROM_IMPA].status = RCSHOW_SAVED;
-            //}
-        }
-    }
-}
-
-void GiftFromSages() {
-    if (!IS_RANDO) {
-        //DefaultCheckData(RC_GIFT_FROM_SAGES);
-    }
-}
-
-std::vector<RandomizerCheck> checks;
-// Function for adding Link's Pocket check
-void LinksPocket() {
-    /*if (IS_RANDO) {
-        if (OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_LINKS_POCKET) != RO_LINKS_POCKET_NOTHING ||
-            OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_SHUFFLE_DUNGEON_REWARDS) == RO_DUNGEON_REWARDS_END_OF_DUNGEON) {
-            DefaultCheckData(RC_LINKS_POCKET);
-            gSaveContext.checkTrackerData[RC_LINKS_POCKET].status = RCSHOW_SAVED;
-        }
-    }*/
-}
 
 void TrySetAreas() {
     if (checksByArea.empty()) {
@@ -507,9 +477,6 @@ void CheckTrackerLoadGame(int32_t fileNum) {
     showVOrMQ = (OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_MQ_DUNGEON_RANDOM) == RO_MQ_DUNGEONS_RANDOM_NUMBER ||
                 (OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_MQ_DUNGEON_RANDOM) == RO_MQ_DUNGEONS_SET_NUMBER &&
                 OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_MQ_DUNGEON_COUNT) < 12));
-    LinksPocket();
-    SongFromImpa();
-    GiftFromSages();
     initialized = true;
     UpdateAllOrdering();
     UpdateInventoryChecks();
@@ -1254,7 +1221,6 @@ bool IsCheckShuffled(RandomizerCheck rc) {
             (loc->GetRCType() != RCTYPE_SHOP ||
                 (showShops && OTRGlobals::Instance->gRandomizer->IdentifyShopItem(loc->GetScene(), loc->GetActorParams() + 1).enGirlAShopItem == 50)) &&
             (rc != RC_TRIFORCE_COMPLETED || !hideTriforceCompleted) &&
-            (rc != RC_GIFT_FROM_SAGES || !IS_RANDO) &&
             (loc->GetRCType() != RCTYPE_SCRUB ||
                 showScrubs ||
                 (showMajorScrubs && (rc == RC_LW_DEKU_SCRUB_NEAR_BRIDGE || // The 3 scrubs that are always randomized


### PR DESCRIPTION
Apparently it's a valid shuffle now! Bit of tracker code cleanup, too.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2208320064.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2208419100.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2208425809.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2208431446.zip)
<!--- section:artifacts:end -->