### PR TITLE
Fix Plando Window Crash on new installs

### DIFF
--- a/soh/soh/Enhancements/randomizer/Plandomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/Plandomizer.cpp
@@ -361,13 +361,11 @@ void PlandomizerPopulateSeedList() {
     existingSeedList.clear();
     auto spoilerPath = Ship::Context::GetPathRelativeToAppDirectory("Randomizer");
 
-    if (!std::filesystem::exists(spoilerPath)) {
-        std::filesystem::create_directory(spoilerPath);
-    }
-
-    for (const auto& entry : std::filesystem::directory_iterator(spoilerPath)) {
-        if (entry.is_regular_file() && entry.path().extension() == ".json") {
-            existingSeedList.push_back(entry.path().stem().string());
+    if (std::filesystem::exists(spoilerPath)) {
+        for (const auto& entry : std::filesystem::directory_iterator(spoilerPath)) {
+            if (entry.is_regular_file() && entry.path().extension() == ".json") {
+                existingSeedList.push_back(entry.path().stem().string());
+            }
         }
     }
 }
@@ -879,15 +877,18 @@ void PlandomizerDrawOptions() {
     } else {
         ImGui::Text("No Spoiler Logs found.");
     }
-
+    ImGui::BeginDisabled(existingSeedList.empty());
     if (ImGui::Button("Load")) {
         logTemp = existingSeedList[selectedList].c_str();
         PlandomizerLoadSpoilerLog(logTemp.c_str());
     }
+    ImGui::EndDisabled();
+    ImGui::BeginDisabled(spoilerLogData.empty());
     ImGui::SameLine();
     if (ImGui::Button("Save")) {
         PlandomizerSaveSpoilerLog();
     }
+    ImGui::EndDisabled();
 
     ImGui::TableNextColumn();
     ImGui::SeparatorText("Current Seed Hash");

--- a/soh/soh/Enhancements/randomizer/Plandomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/Plandomizer.cpp
@@ -361,6 +361,10 @@ void PlandomizerPopulateSeedList() {
     existingSeedList.clear();
     auto spoilerPath = Ship::Context::GetPathRelativeToAppDirectory("Randomizer");
 
+    if (!std::filesystem::exists(spoilerPath)) {
+        std::filesystem::create_directory(spoilerPath);
+    }
+
     for (const auto& entry : std::filesystem::directory_iterator(spoilerPath)) {
         if (entry.is_regular_file() && entry.path().extension() == ".json") {
             existingSeedList.push_back(entry.path().stem().string());


### PR DESCRIPTION
Adds a check for the Randomizer folder existing, and bailing if not, to the plando window before trying to iterate on files inside it, which was causing a crash on new installs.

Also implements button disabling to prevent crashes loading or saving empty/nonexistent structures.
Fixes #4559

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2209971481.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2210013967.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2210017990.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2210052657.zip)
<!--- section:artifacts:end -->