### PR TITLE
Update PR artifacts actions and exclude soh.otr

### DIFF
--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -244,7 +244,6 @@ jobs:
     - name: Cache build folder
       uses: actions/cache@v4
       with:
-        save-always: true
         key: ${{ runner.os }}-build-${{ github.ref }}-${{ github.sha }}
         restore-keys: |
           ${{ runner.os }}-build-${{ github.ref }}

--- a/.github/workflows/pr-artifacts.yml
+++ b/.github/workflows/pr-artifacts.yml
@@ -12,7 +12,7 @@ jobs:
     if: ${{ github.event.workflow_run.event == 'pull_request' }}
     steps:
       - id: 'pr-number'
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           result-encoding: string
           script: |
@@ -20,8 +20,9 @@ jobs:
             const pullHeadSHA = '${{github.event.workflow_run.head_sha}}';
             const pullUserId = ${{github.event.sender.id}};
             const prNumber = await (async () => {
-              const pulls = await github.rest.pulls.list({owner, repo});
-              for await (const {data} of github.paginate.iterator(pulls)) {
+              for await (const { data } of github.paginate.iterator(
+                github.rest.pulls.list, { owner, repo }
+              )) {
                 for (const pull of data) {
                   if (pull.head.sha === pullHeadSHA && pull.user.id === pullUserId) {
                     return pull.number;
@@ -36,7 +37,7 @@ jobs:
 
             return prNumber;
       - id: 'artifacts-text'
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           result-encoding: string
           script: |
@@ -47,13 +48,13 @@ jobs:
             });
 
             return allArtifacts.data.artifacts.reduce((acc, item) => {
-              if (item.name === "assets") return acc;
+              if (item.name === "soh.otr") return acc;
               acc += `
               - [${item.name}.zip](https://nightly.link/${context.repo.owner}/${context.repo.repo}/actions/artifacts/${item.id}.zip)`;
               return acc;
             }, '### Build Artifacts');
       - id: 'add-to-pr'
-        uses: garrettjoecox/pr-section@3.1.0
+        uses: garrettjoecox/pr-section@4.0.0
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
           pr-number: ${{ steps.pr-number.outputs.result }}


### PR DESCRIPTION
This updates the pr artifacts job to use the latest action versions to make sure its still compliant with GH deprecating node 16.

Additionally added soh.otr to the exclude filter as it doesn't really make sense for that to be added to PR descriptions as its available through the platform downloads.

Also removes a deprecated `save-always` flag for windows cache, we don't really need this for our needs.

This will have to be merged first for the changes to take affect.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2209266949.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2209280797.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2209283104.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2209371189.zip)
<!--- section:artifacts:end -->