### PR TITLE
Enhacment presets no longer reimport randomiser settings

### DIFF
--- a/soh/soh/Enhancements/presets.cpp
+++ b/soh/soh/Enhancements/presets.cpp
@@ -74,6 +74,9 @@ void DrawPresetSelector(PresetType presetTypeId) {
             applyPreset(selectedPresetDef.entries);
         }
         Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
+        if (presetTypeId == PRESET_TYPE_RANDOMIZER){
+            Rando::Context::GetInstance()->GetSettings()->ReloadOptions();
+        }
     }
     ImGui::PopStyleVar(1);
 }

--- a/soh/soh/Enhancements/presets.cpp
+++ b/soh/soh/Enhancements/presets.cpp
@@ -74,7 +74,6 @@ void DrawPresetSelector(PresetType presetTypeId) {
             applyPreset(selectedPresetDef.entries);
         }
         Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
-        Rando::Context::GetInstance()->GetSettings()->ReloadOptions();
     }
     ImGui::PopStyleVar(1);
 }


### PR DESCRIPTION
This fixes the No Hint issue found by Louist in the discord internal channels, which was caused by the Warp Song Hint setting reapplying when an enhancement preset was applied mid-game, causing the seed to try and look up hints that did not exist.

I do not know the purpose of this line, but do not see why enhancment presets would be applying randomiser settings anyway, so i moved forward with this PR, but I have no idea what to test for issues/regressions.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2210314178.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2210320664.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2210331364.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2210349225.zip)
<!--- section:artifacts:end -->