### PR TITLE
Track Golden Skulltula death

### DIFF
--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -2076,14 +2076,12 @@ void RandomizerOnPlayDestroyHandler() {
     }
 }
 
-void RandomizerOnEnemyDefeatHandler(void *refActor) {
+void RandomizerOnGoldenSkulltulaDefeatHandler(void *refActor) {
     Actor* actor = static_cast<Actor*>(refActor);
-    if (actor->id == ACTOR_EN_SW) {
-        auto rc = GetRandomizerCheckFromFlag(FlagType::FLAG_GS_TOKEN, actor->params);
-        auto itemLoc = Rando::Context::GetInstance()->GetItemLocation(rc);
-        if (itemLoc->GetCheckStatus() == RCSHOW_UNCHECKED) {
-            itemLoc->SetCheckStatus(RCSHOW_SEEN);
-        }
+    auto rc = GetRandomizerCheckFromFlag(FlagType::FLAG_GS_TOKEN, actor->params);
+    auto itemLoc = Rando::Context::GetInstance()->GetItemLocation(rc);
+    if (itemLoc->GetCheckStatus() == RCSHOW_UNCHECKED) {
+        itemLoc->SetCheckStatus(RCSHOW_SEEN);
     }
 }
 
@@ -2125,7 +2123,7 @@ void RandomizerRegisterHooks() {
     static uint32_t onGameFrameUpdateHook = 0;
     static uint32_t onSceneSpawnActorsHook = 0;
     static uint32_t onPlayDestroyHook = 0;
-    static uint32_t onEnemyDefeatHook = 0;
+    static uint32_t onGoldenSkulltulaDefeatHook = 0;
     static uint32_t onExitGameHook = 0;
     static uint32_t onKaleidoUpdateHook = 0;
 
@@ -2153,7 +2151,7 @@ void RandomizerRegisterHooks() {
         GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnGameFrameUpdate>(onGameFrameUpdateHook);
         GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnSceneSpawnActors>(onSceneSpawnActorsHook);
         GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnPlayDestroy>(onPlayDestroyHook);
-        GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnEnemyDefeat>(onEnemyDefeatHook);
+        GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnEnemyDefeat>(onGoldenSkulltulaDefeatHook);
         GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnExitGame>(onExitGameHook);
         GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnKaleidoscopeUpdate>(onKaleidoUpdateHook);
 
@@ -2176,7 +2174,7 @@ void RandomizerRegisterHooks() {
         onGameFrameUpdateHook = 0;
         onSceneSpawnActorsHook = 0;
         onPlayDestroyHook = 0;
-        onEnemyDefeatHook = 0;
+        onGoldenSkulltulaDefeatHook = 0;
         onExitGameHook = 0;
         onKaleidoUpdateHook = 0;
 
@@ -2209,7 +2207,7 @@ void RandomizerRegisterHooks() {
         onGameFrameUpdateHook = GameInteractor::Instance->RegisterGameHook<GameInteractor::OnGameFrameUpdate>(RandomizerOnGameFrameUpdateHandler);
         onSceneSpawnActorsHook = GameInteractor::Instance->RegisterGameHook<GameInteractor::OnSceneSpawnActors>(RandomizerOnSceneSpawnActorsHandler);
         onPlayDestroyHook = GameInteractor::Instance->RegisterGameHook<GameInteractor::OnPlayDestroy>(RandomizerOnPlayDestroyHandler);
-        onEnemyDefeatHook = GameInteractor::Instance->RegisterGameHook<GameInteractor::OnEnemyDefeat>(RandomizerOnEnemyDefeatHandler);
+        onGoldenSkulltulaDefeatHook = GameInteractor::Instance->RegisterGameHookForID<GameInteractor::OnEnemyDefeat>(ACTOR_EN_SW, RandomizerOnGoldenSkulltulaDefeatHandler);
         onPlayDestroyHook = GameInteractor::Instance->RegisterGameHook<GameInteractor::OnExitGame>(RandomizerOnExitGameHandler);
         onKaleidoUpdateHook = GameInteractor::Instance->RegisterGameHook<GameInteractor::OnKaleidoscopeUpdate>(RandomizerOnKaleidoscopeUpdateHandler);
 

--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -2076,6 +2076,17 @@ void RandomizerOnPlayDestroyHandler() {
     }
 }
 
+void RandomizerOnEnemyDefeatHandler(void *refActor) {
+    Actor* actor = static_cast<Actor*>(refActor);
+    if (actor->id == ACTOR_EN_SW) {
+        auto rc = GetRandomizerCheckFromFlag(FlagType::FLAG_GS_TOKEN, actor->params);
+        auto itemLoc = Rando::Context::GetInstance()->GetItemLocation(rc);
+        if (itemLoc->GetCheckStatus() == RCSHOW_UNCHECKED) {
+            itemLoc->SetCheckStatus(RCSHOW_SEEN);
+        }
+    }
+}
+
 void RandomizerOnExitGameHandler(int32_t fileNum) {
     // When going from a rando save to a vanilla save within the same game instance
     // we need to reset the entrance table back to its vanilla state
@@ -2114,6 +2125,7 @@ void RandomizerRegisterHooks() {
     static uint32_t onGameFrameUpdateHook = 0;
     static uint32_t onSceneSpawnActorsHook = 0;
     static uint32_t onPlayDestroyHook = 0;
+    static uint32_t onEnemyDefeatHook = 0;
     static uint32_t onExitGameHook = 0;
     static uint32_t onKaleidoUpdateHook = 0;
 
@@ -2141,6 +2153,7 @@ void RandomizerRegisterHooks() {
         GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnGameFrameUpdate>(onGameFrameUpdateHook);
         GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnSceneSpawnActors>(onSceneSpawnActorsHook);
         GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnPlayDestroy>(onPlayDestroyHook);
+        GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnEnemyDefeat>(onEnemyDefeatHook);
         GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnExitGame>(onExitGameHook);
         GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnKaleidoscopeUpdate>(onKaleidoUpdateHook);
 
@@ -2163,6 +2176,7 @@ void RandomizerRegisterHooks() {
         onGameFrameUpdateHook = 0;
         onSceneSpawnActorsHook = 0;
         onPlayDestroyHook = 0;
+        onEnemyDefeatHook = 0;
         onExitGameHook = 0;
         onKaleidoUpdateHook = 0;
 
@@ -2195,6 +2209,7 @@ void RandomizerRegisterHooks() {
         onGameFrameUpdateHook = GameInteractor::Instance->RegisterGameHook<GameInteractor::OnGameFrameUpdate>(RandomizerOnGameFrameUpdateHandler);
         onSceneSpawnActorsHook = GameInteractor::Instance->RegisterGameHook<GameInteractor::OnSceneSpawnActors>(RandomizerOnSceneSpawnActorsHandler);
         onPlayDestroyHook = GameInteractor::Instance->RegisterGameHook<GameInteractor::OnPlayDestroy>(RandomizerOnPlayDestroyHandler);
+        onEnemyDefeatHook = GameInteractor::Instance->RegisterGameHook<GameInteractor::OnEnemyDefeat>(RandomizerOnEnemyDefeatHandler);
         onPlayDestroyHook = GameInteractor::Instance->RegisterGameHook<GameInteractor::OnExitGame>(RandomizerOnExitGameHandler);
         onKaleidoUpdateHook = GameInteractor::Instance->RegisterGameHook<GameInteractor::OnKaleidoscopeUpdate>(RandomizerOnKaleidoscopeUpdateHandler);
 


### PR DESCRIPTION
Hi, trying to dip my toes into contributing with a simple idea: mark item as seen after golden skulltula dies, similar to items seen in shop. This can be useful for cases where one can kill GS with projectiles but can't yet reach

I realize this could be argued on, some skulltulas like ones behind rocks need tricks to see even tho you can kill them with clips. Could always have a list of GS which this ignores

It works enough that after GS dies tracker is updated, but oddly game soft locks when Link goes to collect reward (still able to pause, just can't move)

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2210562823.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2210563498.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2210564471.zip)
<!--- section:artifacts:end -->