### PR TITLE
Limit retries when generating seeds from the Randomiser Quest Menu.

### DIFF
--- a/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -1008,6 +1008,7 @@ void DrawSeedHashSprites(FileChooseContext* this) {
 }
 
 u8 generating;
+int retries = 0;
 bool fileSelectSpoilerFileLoaded = false;
 
 void FileChoose_UpdateRandomizer() {
@@ -1018,6 +1019,7 @@ void FileChoose_UpdateRandomizer() {
     } else if (CVarGetInteger(CVAR_GENERAL("RandoGenerating"), 0) == 0 && generating) {
             if (Randomizer_IsSeedGenerated()) {
                 Audio_PlayFanfare(NA_BGM_HORSE_GOAL);
+                retries = 0;
             } else {
                 Sfx_PlaySfxCentered(NA_SE_SY_OCARINA_ERROR);
             }
@@ -1340,6 +1342,7 @@ void FileChoose_GenerateRandoSeed(GameState* thisx) {
         Audio_PlayFanfare(NA_BGM_HORSE_GOAL);
         func_800F5E18(SEQ_PLAYER_BGM_MAIN, NA_BGM_FILE_SELECT, 0, 7, 1);
         generating = 0;
+        retries = 0;
         Randomizer_SetSpoilerLoaded(true);
         static u8 emptyName[] = { 0x3E, 0x3E, 0x3E, 0x3E, 0x3E, 0x3E, 0x3E, 0x3E };
         static u8 linkName[] = { 0x15, 0x2C, 0x31, 0x2E, 0x3E, 0x3E, 0x3E, 0x3E };
@@ -1361,7 +1364,13 @@ void FileChoose_GenerateRandoSeed(GameState* thisx) {
         return;
     }
     if (!generating) {
-        Randomizer_GenerateSeed();
+        if (retries >= 5 || (retries >= 1 && Randomizer_IsSpoilerLoaded())){
+            this->configMode = CM_QUEST_MENU;
+            retries = 0;
+        } else {
+            Randomizer_GenerateSeed();
+            retries++;
+        }
     }
 }
 


### PR DESCRIPTION
This makes it so that, when a seed is loaded, it only attempts to generate that seed once, and when a seed is not loaded, it only tries to generate  a seed 5 times. This change is done to avoid infinite loops of DONG noises when the player feeds an invalid seed in from a spoiler log, or tries to make a seed is incompatible settings.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2216229134.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2216230510.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2216237416.zip)
<!--- section:artifacts:end -->