### PR TITLE
Fix array out of bounds in entrance rando init

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer_entrance.c
+++ b/soh/soh/Enhancements/randomizer/randomizer_entrance.c
@@ -161,7 +161,7 @@ void Entrance_Init(void) {
     }
 
     // Initialize all boss room save/death warps with their vanilla dungeon entryway
-    for (s16 i = 1; i < SHUFFLEABLE_BOSS_COUNT; i++) {
+    for (s16 i = 0; i < SHUFFLEABLE_BOSS_COUNT; i++) {
         bossSceneSaveDeathWarps[i] = dungeons[i].entryway;
     }
 
@@ -185,7 +185,7 @@ void Entrance_Init(void) {
         // Search for boss room overrides and look for the matching save/death warp value to use
         // If the boss room is in a dungeon, use the dungeons entryway as the save warp
         // Otherwise use the "exit" value for the entrance that lead to the boss room
-        for (int j = 0; j <= SHUFFLEABLE_BOSS_COUNT; j++) {
+        for (int j = 0; j < SHUFFLEABLE_BOSS_COUNT; j++) {
             if (overrideIndex == dungeons[j].bossDoor) {
                 bossScene = dungeons[j].bossScene;
             }

--- a/soh/soh/Enhancements/randomizer/randomizer_grotto.c
+++ b/soh/soh/Enhancements/randomizer/randomizer_grotto.c
@@ -273,7 +273,7 @@ void Grotto_OverrideActorEntrance(Actor* thisx) {
 void Grotto_ForceGrottoReturnOnSpecialEntrance(void) {
     if (lastEntranceType == GROTTO_RETURN && (Randomizer_GetSettingValue(RSK_SHUFFLE_GROTTO_ENTRANCES) || Randomizer_GetSettingValue(RSK_SHUFFLE_OVERWORLD_SPAWNS) || Randomizer_GetSettingValue(RSK_SHUFFLE_WARP_SONGS))) {
         gSaveContext.respawnFlag = 2;
-        gSaveContext.respawn[RESPAWN_MODE_RETURN].playerParams = 0x4FF;
+        gSaveContext.respawn[RESPAWN_MODE_RETURN].playerParams = 0x04FF;
         gSaveContext.respawn[RESPAWN_MODE_RETURN].pos = grottoReturnTable[grottoId].pos;
         // Clear current temp flags
         gSaveContext.respawn[RESPAWN_MODE_RETURN].tempSwchFlags = 0;
@@ -308,7 +308,7 @@ void Grotto_ForceRegularVoidOut(void) {
 // so that Sun's Song and Game Over will behave correctly
 void Grotto_SetupReturnInfoOnFWReturn(void) {
     if (Randomizer_GetSettingValue(RSK_SHUFFLE_GROTTO_ENTRANCES) || Randomizer_GetSettingValue(RSK_SHUFFLE_OVERWORLD_SPAWNS) || Randomizer_GetSettingValue(RSK_SHUFFLE_WARP_SONGS) &&
-        gSaveContext.fw.playerParams == 0x4FF) {
+        gSaveContext.fw.playerParams == 0x04FF) {
         gSaveContext.respawn[RESPAWN_MODE_RETURN] = gSaveContext.respawn[RESPAWN_MODE_TOP];
         gSaveContext.respawn[RESPAWN_MODE_RETURN].playerParams = 0x0DFF;
         lastEntranceType = GROTTO_RETURN;


### PR DESCRIPTION
There was an array out of bounds causing undefined behavior that seemed to break entrance rando on Mac when compiled in release mode.

This fixes that, and another similar for loop with incorrect values.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2216324336.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2216350767.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2216954997.zip)
<!--- section:artifacts:end -->