### PR TITLE
Add some +/- buttons and clean up timesavers menu

### DIFF
--- a/soh/soh/Enhancements/randomizer/Plandomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/Plandomizer.cpp
@@ -805,13 +805,28 @@ void PlandomizerDrawItemSlots(uint32_t index) {
 }
 
 void PlandomizerDrawShopSlider(uint32_t index) {
+    //Going back 3 pops in order to get the original button colours for the non-image buttons
+    ImGui::PopStyleColor(3);
     ImGui::PushID(index);
     ImGui::Text("Price:");
     ImGui::SameLine();
-    ImGui::PushItemWidth(ImGui::GetContentRegionAvail().x - 20.0f);
+    std::string MinusBTNName = " - ##Price";
+    if (ImGui::Button(MinusBTNName.c_str()) && plandoLogData[index].shopPrice > 0) {
+        plandoLogData[index].shopPrice--;
+    }
+    ImGui::SameLine();
+    ImGui::PushItemWidth(ImGui::GetContentRegionAvail().x - 40.0f);
     ImGui::SliderInt("", &plandoLogData[index].shopPrice, 0, 999, "%d Rupees");
     ImGui::PopItemWidth();
+    ImGui::SameLine();
+    std::string PlusBTNName = " + ##Price";
+    if (ImGui::Button(PlusBTNName.c_str()) && plandoLogData[index].shopPrice < 999) {
+        plandoLogData[index].shopPrice++;
+    }
     ImGui::PopID();
+    ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(1.0f, 1.0f, 1.0f, 0.0f));
+    ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(1.0f, 1.0f, 1.0f, 0.2f));
+    ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(1.0f, 1.0f, 1.0f, 0.1f));
 }
 
 void PlandomizerDrawIceTrapSetup(uint32_t index) {

--- a/soh/soh/Enhancements/randomizer/Plandomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/Plandomizer.cpp
@@ -270,6 +270,16 @@ Rando::Item plandomizerRandoRetrieveItem(RandomizerGet randoGetItem) {
     return randoGetItemEntry;
 }
 
+void PlandoPushImageButtonStyle(){
+    ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(1.0f, 1.0f, 1.0f, 0.0f));
+    ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(1.0f, 1.0f, 1.0f, 0.2f));
+    ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(1.0f, 1.0f, 1.0f, 0.1f));
+}
+
+void PlandoPopImageButtonStyle(){
+    ImGui::PopStyleColor(3);
+}
+
 ImVec4 plandomizerGetItemColor(Rando::Item randoItem) {
     itemColor = ImVec4( 1.0f, 1.0f, 1.0f, 1.0f );
     if (randoItem.GetItemType() == ITEMTYPE_SMALLKEY || randoItem.GetItemType() == ITEMTYPE_FORTRESS_SMALLKEY
@@ -698,6 +708,7 @@ void PlandomizerOverlayText(std::pair<Rando::Item, uint32_t> drawObject ) {
 
 void PlandomizerDrawItemPopup(uint32_t index) {
     if (shouldPopup && ImGui::BeginPopup("ItemList")) {
+        PlandoPushImageButtonStyle();
         ImGui::SeparatorText("Resources");
         ImGui::BeginTable("Infinite Item Table", 7);
         for (auto& item : infiniteItemList) {
@@ -759,6 +770,7 @@ void PlandomizerDrawItemPopup(uint32_t index) {
             PlandomizerRemoveFromItemList(drawnItemsList[temporaryItemIndex].first);
             PlandomizerAddToItemList(temporaryItem);
         }
+        PlandoPopImageButtonStyle();
         ImGui::EndTable();
         ImGui::EndPopup();
     }
@@ -767,6 +779,7 @@ void PlandomizerDrawItemPopup(uint32_t index) {
 void PlandomizerDrawIceTrapPopUp(uint32_t index) {
     if (shouldTrapPopup && ImGui::BeginPopup("TrapList")) {
         ImGui::BeginTable("Ice Trap Table", 8);
+        PlandoPushImageButtonStyle();
         for (auto& items : itemImageMap) {
             if (items.first == RG_ICE_TRAP) {
                 continue;
@@ -785,6 +798,7 @@ void PlandomizerDrawIceTrapPopUp(uint32_t index) {
 
             ImGui::PopID();
         }
+        PlandoPopImageButtonStyle();
         ImGui::EndTable();
         ImGui::EndPopup();
     }
@@ -792,12 +806,14 @@ void PlandomizerDrawIceTrapPopUp(uint32_t index) {
 
 void PlandomizerDrawItemSlots(uint32_t index) {
     ImGui::PushID(index);
+    PlandoPushImageButtonStyle();
     PlandomizerItemImageCorrection(plandoLogData[index].checkRewardItem);
     if (ImGui::ImageButton(textureID, imageSize, textureUV0, textureUV1, imagePadding, ImVec4(0, 0, 0, 0), itemColor)) {
         shouldPopup = true;
         temporaryItem = plandoLogData[index].checkRewardItem;
         ImGui::OpenPopup("ItemList");
     };
+    PlandoPopImageButtonStyle();
     UIWidgets::Tooltip(plandoLogData[index].checkRewardItem.GetName().english.c_str());
     PlandomizerOverlayText(std::make_pair(plandoLogData[index].checkRewardItem, 1));
     PlandomizerDrawItemPopup(index);
@@ -805,8 +821,6 @@ void PlandomizerDrawItemSlots(uint32_t index) {
 }
 
 void PlandomizerDrawShopSlider(uint32_t index) {
-    //Going back 3 pops in order to get the original button colours for the non-image buttons
-    ImGui::PopStyleColor(3);
     ImGui::PushID(index);
     ImGui::Text("Price:");
     ImGui::SameLine();
@@ -824,9 +838,6 @@ void PlandomizerDrawShopSlider(uint32_t index) {
         plandoLogData[index].shopPrice++;
     }
     ImGui::PopID();
-    ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(1.0f, 1.0f, 1.0f, 0.0f));
-    ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(1.0f, 1.0f, 1.0f, 0.2f));
-    ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(1.0f, 1.0f, 1.0f, 0.1f));
 }
 
 void PlandomizerDrawIceTrapSetup(uint32_t index) {
@@ -840,10 +851,12 @@ void PlandomizerDrawIceTrapSetup(uint32_t index) {
 
     ImGui::TableNextColumn();
     PlandomizerItemImageCorrection(plandoLogData[index].iceTrapModel);
+    PlandoPushImageButtonStyle();
     if (ImGui::ImageButton(textureID, imageSize, textureUV0, textureUV1, imagePadding, ImVec4(0, 0, 0, 0), itemColor)) {
         shouldTrapPopup = true;
         ImGui::OpenPopup("TrapList");
     };
+    PlandoPopImageButtonStyle();
     UIWidgets::Tooltip(plandoLogData[index].iceTrapModel.GetName().english.c_str());
     PlandomizerDrawIceTrapPopUp(index);
     ImGui::SameLine();
@@ -862,7 +875,7 @@ void PlandomizerDrawIceTrapSetup(uint32_t index) {
             plandoLogData[index].iceTrapName = trapTextInput.c_str();
         }
     
-    if (plandoLogData[index].shopPrice > -1) {
+    if (plandoLogData[index].shopPrice >= 0) {
         PlandomizerDrawShopSlider(index);
     }
     ImGui::EndTable();
@@ -875,7 +888,7 @@ void PlandomizerDrawOptions() {
     ImGui::TableNextColumn();
     ImGui::SeparatorText("Load/Save Spoiler Log");
     PlandomizerPopulateSeedList();
-    static int32_t selectedList = 0;
+    static size_t selectedList = 0;
     if (existingSeedList.size() != 0) {
         if (ImGui::BeginCombo("##JsonFiles", existingSeedList[selectedList].c_str())) {
             for (size_t i = 0; i < existingSeedList.size(); i++) {
@@ -910,15 +923,13 @@ void PlandomizerDrawOptions() {
     ImGui::SetCursorPosX(ImGui::GetCursorPosX() + (ImGui::GetContentRegionAvail().x * 0.5f) - (34.0f * 5.0f));
     if (spoilerLogData.size() > 0) {
         ImGui::BeginTable("HashIcons", 5);
-        ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(1.0f, 1.0f, 1.0f, 0.0f));
-        ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(1.0f, 1.0f, 1.0f, 0.2f));
-        ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(1.0f, 1.0f, 1.0f, 0.1f));
         for (int i = 0; i < 5; i++) {
             ImGui::TableSetupColumn("Icon", ImGuiTableColumnFlags_WidthFixed, 34.0f);
         }
         ImGui::TableNextColumn();
     
-        int32_t index = 0;
+        size_t index = 0;
+        PlandoPushImageButtonStyle();
         for (auto& hash : plandoHash) {
             ImGui::PushID(index);
             textureID = Ship::Context::GetInstance()->GetWindow()->GetGui()->GetTextureByName(gSeedTextures[hash].tex);
@@ -945,7 +956,7 @@ void PlandomizerDrawOptions() {
             ImGui::PopID();
             index++;
         }
-        ImGui::PopStyleColor(3);
+        PlandoPopImageButtonStyle();
         ImGui::EndTable();
     } else {
         ImGui::Text("No Spoiler Log Loaded");
@@ -1054,9 +1065,6 @@ void PlandomizerDrawLocationsWindow(RandomizerCheckArea rcArea) {
     ImGui::TableSetupColumn("Additional Options");
     ImGui::TableSetupScrollFreeze(0, 1);
     ImGui::TableHeadersRow();
-    ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(1.0f, 1.0f, 1.0f, 0.0f));
-    ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(1.0f, 1.0f, 1.0f, 0.2f));
-    ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(1.0f, 1.0f, 1.0f, 0.1f));
 
     for (auto& spoilerData : spoilerLogData) {
         auto checkID = Rando::StaticData::locationNameToEnum[spoilerData.checkName];
@@ -1085,7 +1093,6 @@ void PlandomizerDrawLocationsWindow(RandomizerCheckArea rcArea) {
         }
         index++;
     }
-    ImGui::PopStyleColor(3);
     ImGui::EndTable();
     ImGui::EndChild();
 }

--- a/soh/soh/Enhancements/timesplits/TimeSplits.cpp
+++ b/soh/soh/Enhancements/timesplits/TimeSplits.cpp
@@ -425,7 +425,24 @@ void TimeSplitsPopUpContext() {
                     ImVec2(32.0f, 32.0f), ImVec2(0, 0), ImVec2(1, 1), 2.0f, ImVec4(0, 0, 0, 0));
             ImGui::TableNextColumn();
             ImGui::PushItemWidth(150.0f);
+
+            //Going back 3 pops in order to get the original button colours for the non-image buttons
+            ImGui::PopStyleColor(3);
+            ImGui::BeginGroup();
+            std::string MinusBTNName = " - ##Set Tokens";
+            ImGui::SameLine();
+            if (ImGui::Button(MinusBTNName.c_str()) && skullTokenCount > 0) {
+                skullTokenCount--;
+            }
+            ImGui::SameLine();
             ImGui::SliderInt("##count", &skullTokenCount, 0, 100, "%d Tokens");
+            std::string PlusBTNName = " + ##Set Tokens";
+            ImGui::SameLine();
+            if (ImGui::Button(PlusBTNName.c_str()) && skullTokenCount < 100) {
+                skullTokenCount++;
+            }
+            ImGui::EndGroup();
+
             ImGui::PopItemWidth();
             if (ImGui::Button("Set Tokens")) {
                 auto findID = std::find_if(splitObjectList.begin(), splitObjectList.end(), [&](const SplitObject& obj) { return obj.splitID == ITEM_SKULL_TOKEN; });
@@ -439,6 +456,9 @@ void TimeSplitsPopUpContext() {
                 ImGui::CloseCurrentPopup();
                 popupID = -1;
             }
+            ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(1.0f, 1.0f, 1.0f, 0.0f));
+            ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(1.0f, 1.0f, 1.0f, 0.2f));
+            ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(1.0f, 1.0f, 1.0f, 0.1f));
             ImGui::EndTable();
         }  else {
             int rowIndex = 0;

--- a/soh/soh/Enhancements/timesplits/TimeSplits.cpp
+++ b/soh/soh/Enhancements/timesplits/TimeSplits.cpp
@@ -301,6 +301,16 @@ void TimeSplitsGetImageSize(uint32_t item) {
     }
 }
 
+void SplitsPushImageButtonStyle(){
+    ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(1.0f, 1.0f, 1.0f, 0.0f));
+    ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(1.0f, 1.0f, 1.0f, 0.2f));
+    ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(1.0f, 1.0f, 1.0f, 0.1f));
+}
+
+void SplitsPopImageButtonStyle(){
+    ImGui::PopStyleColor(3);
+}
+
 void TimeSplitsUpdateSplitStatus() {
     uint32_t index = 0;
     for (auto& data : splitList) {
@@ -310,7 +320,7 @@ void TimeSplitsUpdateSplitStatus() {
         }
         index++;
     }
-    for (int i = index; i < splitList.size(); i++) {
+    for (size_t i = index; i < splitList.size(); i++) {
         if (splitList[i].splitTimeStatus != SPLIT_STATUS_ACTIVE && splitList[i].splitTimeStatus != SPLIT_STATUS_COLLECTED) {
             splitList[i].splitTimeStatus = SPLIT_STATUS_INACTIVE;
         }
@@ -421,13 +431,13 @@ void TimeSplitsPopUpContext() {
         if (popupID == ITEM_SKULL_TOKEN) {
             ImGui::BeginTable("Token Table", 2);
             ImGui::TableNextColumn();
+            SplitsPushImageButtonStyle();
             ImGui::ImageButton(Ship::Context::GetInstance()->GetWindow()->GetGui()->GetTextureByName("QUEST_SKULL_TOKEN"),
                     ImVec2(32.0f, 32.0f), ImVec2(0, 0), ImVec2(1, 1), 2.0f, ImVec4(0, 0, 0, 0));
             ImGui::TableNextColumn();
+            SplitsPopImageButtonStyle();
             ImGui::PushItemWidth(150.0f);
 
-            //Going back 3 pops in order to get the original button colours for the non-image buttons
-            ImGui::PopStyleColor(3);
             ImGui::BeginGroup();
             std::string MinusBTNName = " - ##Set Tokens";
             ImGui::SameLine();
@@ -456,12 +466,10 @@ void TimeSplitsPopUpContext() {
                 ImGui::CloseCurrentPopup();
                 popupID = -1;
             }
-            ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(1.0f, 1.0f, 1.0f, 0.0f));
-            ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(1.0f, 1.0f, 1.0f, 0.2f));
-            ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(1.0f, 1.0f, 1.0f, 0.1f));
             ImGui::EndTable();
         }  else {
             int rowIndex = 0;
+            SplitsPushImageButtonStyle();
             for (auto item : popupList[popupID]) {
                 auto findID = std::find_if(splitObjectList.begin(), splitObjectList.end(), [&](const SplitObject& obj) { return obj.splitID == item; });
                 if (findID == splitObjectList.end()) {
@@ -488,7 +496,7 @@ void TimeSplitsPopUpContext() {
                     if (popupID <= ITEM_SLINGSHOT && popupID != -1) {
                         ImVec2 imageMin = ImGui::GetItemRectMin();
                         ImVec2 imageMax = ImGui::GetItemRectMax();
-                        ImVec2 imageSize = ImVec2(imageMax.x - imageMin.x, imageMax.y - imageMin.y);
+                        //ImVec2 imageSize = ImVec2(imageMax.x - imageMin.x, imageMax.y - imageMin.y); UNUSED
                         ImVec2 textPos = ImVec2(imageMax.x - ImGui::CalcTextSize("00").x - 5,
                                                 imageMax.y - ImGui::CalcTextSize("00").y - 5);
 
@@ -504,6 +512,7 @@ void TimeSplitsPopUpContext() {
                 }
                 rowIndex++;
             }
+            SplitsPopImageButtonStyle();
         }
         ImGui::EndPopup();
     }
@@ -630,10 +639,8 @@ void TimeSplitsDrawSplitsList() {
     ImGui::TableSetupColumn("Prev. Best");
     ImGui::TableHeadersRow();
 
-    ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(1.0f, 1.0f, 1.0f, 0.0f));
-    ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(1.0f, 1.0f, 1.0f, 0.2f));
-    ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(1.0f, 1.0f, 1.0f, 0.1f));
 
+    SplitsPushImageButtonStyle();
     for (auto& split : splitList) {
         ImGui::TableNextColumn();
         TimeSplitsSplitBestTimeDisplay(split);
@@ -668,10 +675,10 @@ void TimeSplitsDrawSplitsList() {
 
         dragIndex++;
     }
+    SplitsPopImageButtonStyle();
 
     TimeSplitsPostDragAndDrop();
 
-    ImGui::PopStyleColor(3);
     ImGui::PopStyleVar(1);
     ImGui::EndTable();
     ImGui::EndChild();
@@ -697,7 +704,7 @@ void TimeSplitsDrawItemList(uint32_t type) {
 
     ImGui::BeginChild("Item Child");
     ImGui::BeginTable("Item List", tableSize);
-    for (int i = 0; i < tableSize; i++) {
+    for (size_t i = 0; i < tableSize; i++) {
         if (i == 0) {
             ImGui::TableSetupColumn("Item Image", ImGuiTableColumnFlags_WidthFixed | ImGuiTableColumnFlags_NoHeaderLabel, 39.0f);
         } else {
@@ -709,15 +716,12 @@ void TimeSplitsDrawItemList(uint32_t type) {
         }
     }
 
-    ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(1.0f, 1.0f, 1.0f, 0.0f));
-    ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(1.0f, 1.0f, 1.0f, 0.2f));
-    ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(1.0f, 1.0f, 1.0f, 0.1f));
-
     for (auto& split : splitObjectList) {
         if (split.splitType == type) {
             ImGui::TableNextColumn();
             ImGui::PushID(split.splitID);
             TimeSplitsGetImageSize(split.splitID);
+            SplitsPushImageButtonStyle();
             if (ImGui::ImageButton(Ship::Context::GetInstance()->GetWindow()->GetGui()->GetTextureByName(split.splitImage),
                                imageSize, ImVec2(0, 0), ImVec2(1, 1), imagePadding, ImVec4(0, 0, 0, 0), split.splitTint)) {
                 
@@ -735,6 +739,7 @@ void TimeSplitsDrawItemList(uint32_t type) {
                     }
                 }
             }
+            SplitsPopImageButtonStyle();
 
             TimeSplitsPopUpContext();
             ImGui::PopID();
@@ -749,7 +754,6 @@ void TimeSplitsDrawItemList(uint32_t type) {
             
         }
     }
-    ImGui::PopStyleColor(3);
     ImGui::EndTable();
     ImGui::EndChild();
 }

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -583,9 +583,9 @@ void DrawSettingsMenu() {
 
             ImGui::Text("Position");
             UIWidgets::EnhancementCombobox(CVAR_SETTING("Notifications.Position"), notificationPosition, 0);
-            UIWidgets::EnhancementSliderFloat("Duration: %.0f seconds", "##NotificationDuration", CVAR_SETTING("Notifications.Duration"), 3.0f, 30.0f, "", 10.0f, false, false, false);
-            UIWidgets::EnhancementSliderFloat("BG Opacity: %.1f %%", "##NotificaitonBgOpacity", CVAR_SETTING("Notifications.BgOpacity"), 0.0f, 1.0f, "", 0.5f, true, false, false);
-            UIWidgets::EnhancementSliderFloat("Size: %.1f", "##NotificaitonSize", CVAR_SETTING("Notifications.Size"), 1.0f, 5.0f, "", 1.8f, false, false, false);
+            UIWidgets::EnhancementSliderFloat("Duration: %.1f seconds", "##NotificationDuration", CVAR_SETTING("Notifications.Duration"), 3.0f, 30.0f, "", 10.0f, false, true, false);
+            UIWidgets::EnhancementSliderFloat("BG Opacity: %.1f %%", "##NotificaitonBgOpacity", CVAR_SETTING("Notifications.BgOpacity"), 0.0f, 1.0f, "", 0.5f, true, true, false);
+            UIWidgets::EnhancementSliderFloat("Size: %.1f", "##NotificaitonSize", CVAR_SETTING("Notifications.Size"), 1.0f, 20.0f, "", 1.8f, false, true, false);
 
             UIWidgets::Spacer(0);
 
@@ -714,23 +714,15 @@ void DrawEnhancementsMenu() {
                 UIWidgets::PaddedEnhancementSliderInt("Crawl speed %dx", "##CRAWLSPEED", CVAR_ENHANCEMENT("CrawlSpeed"), 1, 4, "", 1, true, false, true);
                 UIWidgets::PaddedEnhancementCheckbox("Faster Heavy Block Lift", CVAR_ENHANCEMENT("FasterHeavyBlockLift"), false, false);
                 UIWidgets::Tooltip("Speeds up lifting silver rocks and obelisks");
-                UIWidgets::PaddedEnhancementCheckbox("Faster Rupee Accumulator", CVAR_ENHANCEMENT("TimeSavers.FasterRupeeAccumulator"), false, false);
                 UIWidgets::PaddedEnhancementCheckbox("Skip Pickup Messages", CVAR_ENHANCEMENT("FastDrops"), true, false);
                 UIWidgets::Tooltip("Skip pickup messages for new consumable items and bottle swipes");
                 UIWidgets::PaddedEnhancementCheckbox("Fast Ocarina Playback", CVAR_ENHANCEMENT("FastOcarinaPlayback"), true, false);
                 UIWidgets::Tooltip("Skip the part where the Ocarina playback is called when you play a song");
-                bool forceSkipScarecrow = IS_RANDO && OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_SKIP_SCARECROWS_SONG);
-                static const char* forceSkipScarecrowText = "This setting is forcefully enabled because a savefile\nwith \"Skip Scarecrow Song\" is loaded";
-                UIWidgets::PaddedEnhancementCheckbox("Skip Scarecrow Song", CVAR_ENHANCEMENT("InstantScarecrow"), true, false,
-                                                        forceSkipScarecrow, forceSkipScarecrowText, UIWidgets::CheckboxGraphics::Checkmark);
-                UIWidgets::Tooltip("Pierre appears when Ocarina is pulled out. Requires learning scarecrow song.");
                 UIWidgets::PaddedEnhancementCheckbox("Skip Magic Arrow Equip Animation", CVAR_ENHANCEMENT("SkipArrowAnimation"), true, false);
                 UIWidgets::PaddedEnhancementCheckbox("Skip save confirmation", CVAR_ENHANCEMENT("SkipSaveConfirmation"), true, false);
                 UIWidgets::Tooltip("Skip the \"Game saved.\" confirmation screen");
                 UIWidgets::PaddedEnhancementCheckbox("Faster Farore's Wind", CVAR_ENHANCEMENT("FastFarores"), true, false);
                 UIWidgets::Tooltip("Greatly decreases cast time of Farore's Wind magic spell.");
-                UIWidgets::PaddedEnhancementCheckbox("Skip water take breath animation", CVAR_ENHANCEMENT("SkipSwimDeepEndAnim"), true, false);
-                UIWidgets::Tooltip("Skips Link's taking breath animation after coming up from water. This setting does not interfere with getting items from underwater.");
 
                 ImGui::TableNextColumn();
                 UIWidgets::Spacer(0);
@@ -797,6 +789,14 @@ void DrawEnhancementsMenu() {
                     "- Not within range of Ocarina playing spots");
                 UIWidgets::PaddedEnhancementCheckbox("Pause Warp", CVAR_ENHANCEMENT("PauseWarp"), true, false);
                 UIWidgets::Tooltip("Selection of warp song in pause menu initiates warp. Disables song playback.");
+                UIWidgets::PaddedEnhancementCheckbox("Skip water take breath animation", CVAR_ENHANCEMENT("SkipSwimDeepEndAnim"), true, false);
+                UIWidgets::Tooltip("Skips Link's taking breath animation after coming up from water. This setting does not interfere with getting items from underwater.");
+                bool forceSkipScarecrow = IS_RANDO && OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_SKIP_SCARECROWS_SONG);
+                static const char* forceSkipScarecrowText = "This setting is forcefully enabled because a savefile\nwith \"Skip Scarecrow Song\" is loaded";
+                UIWidgets::PaddedEnhancementCheckbox("Skip Scarecrow Song", CVAR_ENHANCEMENT("InstantScarecrow"), true, false,
+                                                        forceSkipScarecrow, forceSkipScarecrowText, UIWidgets::CheckboxGraphics::Checkmark);
+                UIWidgets::Tooltip("Pierre appears when Ocarina is pulled out. Requires learning scarecrow song.");
+
                 
                 ImGui::EndTable();
                 ImGui::EndMenu();
@@ -1268,6 +1268,9 @@ void DrawEnhancementsMenu() {
 
             UIWidgets::PaddedEnhancementCheckbox("Targetable Hookshot Reticle", CVAR_ENHANCEMENT("HookshotableReticle"), true, false);
             UIWidgets::Tooltip("Use a different color when aiming at hookshotable collision");
+
+            UIWidgets::PaddedEnhancementCheckbox("Faster Rupee Accumulator", CVAR_ENHANCEMENT("TimeSavers.FasterRupeeAccumulator"), true, false);
+            UIWidgets::Tooltip("Causes your wallet to fill and empty faster when you gain or lose money.");
 
             ImGui::EndMenu();
         }


### PR DESCRIPTION
Fixes #4548 and moves some options to reduce the size of the speed-up column in time-savers so it won't overflow the screen at 1080P windowed. I also added padding and a tooltip to the faster rupee accumulations tickbox.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2241296752.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2241301172.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2241309476.zip)
<!--- section:artifacts:end -->