### PR TITLE
Save timesplits colour to cvar and reload it on init.

### DIFF
--- a/soh/assets/objects/object_link_child/object_link_child.h
+++ b/soh/assets/objects/object_link_child/object_link_child.h
@@ -220,7 +220,7 @@ static const ALIGN_ASSET(2) char gLinkChildDL_18580[] = dgLinkChildDL_18580;
 static const ALIGN_ASSET(2) char gLinkChildBottle2DL[] = dgLinkChildBottle2DL;
 
 #define dgLinkChildSlinghotStringDL "__OTR__objects/object_link_child/gLinkChildSlinghotStringDL"
-static const ALIGN_ASSET(2) char gLinkChildSlinghotStringDL[] = dgLinkChildSlinghotStringDL;
+static const ALIGN_ASSET(2) char gLinkChildSlingshotStringDL[] = dgLinkChildSlinghotStringDL;
 
 #define dgLinkChildDekuShieldDL "__OTR__objects/object_link_child/gLinkChildDekuShieldDL"
 static const ALIGN_ASSET(2) char gLinkChildDekuShieldDL[] = dgLinkChildDekuShieldDL;

--- a/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
+++ b/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
@@ -851,7 +851,7 @@ void ApplyOrResetCustomGfxPatches(bool manualChange) {
         Color_RGBA8 color = CVarGetColor(equipmentSlingshotString.cvar, defaultColor);
         PATCH_GFX(gGiSlingshotDL,                                 "Equipment_SlingshotString1",equipmentSlingshotString.changedCvar, 75, gsDPSetPrimColor(0, 0, color.r, color.g, color.b, 255));
         PATCH_GFX(gGiSlingshotDL,                                 "Equipment_SlingshotString2",equipmentSlingshotString.changedCvar, 76, gsDPSetEnvColor(color.r / 2, color.g / 2, color.b / 2, 255));
-        PATCH_GFX(gLinkChildSlinghotStringDL,                     "Equipment_SlingshotString3",equipmentSlingshotString.changedCvar,  9, gsDPSetPrimColor(0, 0, color.r, color.g, color.b, 255));
+        PATCH_GFX(gLinkChildSlingshotStringDL,                    "Equipment_SlingshotString3",equipmentSlingshotString.changedCvar,  9, gsDPSetPrimColor(0, 0, color.r, color.g, color.b, 255));
     }
 
     static CosmeticOption& equipmentBowTips = cosmeticOptions.at("Equipment.BowTips");

--- a/soh/soh/Enhancements/timesplits/TimeSplits.cpp
+++ b/soh/soh/Enhancements/timesplits/TimeSplits.cpp
@@ -745,10 +745,10 @@ void TimeSplitsDrawOptionsMenu() {
     ImGui::SeparatorText("Window Options");
     if (ImGui::ColorEdit4("Background Color", (float*)&windowColor, ImGuiColorEditFlags_NoInputs | ImGuiColorEditFlags_NoLabel)) {
         Color_RGBA8 color;
-        color.r = windowColor.x * 255;
-        color.g = windowColor.y * 255;
-        color.b = windowColor.z * 255;
-        color.a = windowColor.w * 255;
+        color.r = windowColor.x * 255.0;
+        color.g = windowColor.y * 255.0;
+        color.b = windowColor.z * 255.0;
+        color.a = windowColor.w * 255.0;
         CVarSetColor("TimeSplits.WindowColor", color);
         Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
     }
@@ -918,8 +918,8 @@ static bool initialized = false;
 void TimeSplitWindow::DrawElement() {
     ImGui::SetWindowFontScale(timeSplitsWindowSize);
     if (!initialized) {
-        Color_RGBA8 color = CVarGetColor("TimeSplits.WindowColor", Color_RGBA8(0.0f, 0.0f, 0.0f, 1.0f));
-        windowColor = {(float)color.r / 255, (float)color.g / 255, (float)color.b / 255, (float)color.a / 255};
+        Color_RGBA8 color = CVarGetColor("TimeSplits.WindowColor", Color_RGBA8(0, 0, 0, 1));
+        windowColor = {(float)color.r / 255.0, (float)color.g / 255.0, (float)color.b / 255.0, (float)color.a / 255.0};
         InitializeSplitDataFile();
         initialized = true;
     }

--- a/soh/soh/Enhancements/timesplits/TimeSplits.cpp
+++ b/soh/soh/Enhancements/timesplits/TimeSplits.cpp
@@ -745,14 +745,18 @@ void TimeSplitsDrawOptionsMenu() {
     ImGui::SeparatorText("Window Options");
     if (ImGui::ColorEdit4("Background Color", (float*)&windowColor, ImGuiColorEditFlags_NoInputs | ImGuiColorEditFlags_NoLabel)) {
         Color_RGBA8 color;
-        color.r = windowColor.x;
-        color.g = windowColor.y;
-        color.b = windowColor.z;
-        color.a = windowColor.w;
+        color.r = windowColor.x * 255;
+        color.g = windowColor.y * 255;
+        color.b = windowColor.z * 255;
+        color.a = windowColor.w * 255;
+        CVarSetColor("TimeSplits.WindowColor", color);
+        Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
     }
     ImGui::SameLine();
     if (ImGui::Button("Reset")) {
         windowColor = { 0.0f, 0.0f, 0.0f, 1.0f };
+        CVarSetColor("TimeSplits.WindowColor", {0, 0, 0, 1});
+        Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
     }
 
     if (UIWidgets::PaddedEnhancementSliderFloat("Window Size: %.1fx", "##windowSize",
@@ -914,6 +918,8 @@ static bool initialized = false;
 void TimeSplitWindow::DrawElement() {
     ImGui::SetWindowFontScale(timeSplitsWindowSize);
     if (!initialized) {
+        Color_RGBA8 color = CVarGetColor("TimeSplits.WindowColor", Color_RGBA8(0.0f, 0.0f, 0.0f, 1.0f));
+        windowColor = {(float)color.r / 255, (float)color.g / 255, (float)color.b / 255, (float)color.a / 255};
         InitializeSplitDataFile();
         initialized = true;
     }

--- a/soh/soh/Enhancements/timesplits/TimeSplits.cpp
+++ b/soh/soh/Enhancements/timesplits/TimeSplits.cpp
@@ -918,8 +918,9 @@ static bool initialized = false;
 void TimeSplitWindow::DrawElement() {
     ImGui::SetWindowFontScale(timeSplitsWindowSize);
     if (!initialized) {
-        Color_RGBA8 color = CVarGetColor("TimeSplits.WindowColor", Color_RGBA8(0, 0, 0, 1));
-        windowColor = {(float)color.r / 255.0, (float)color.g / 255.0, (float)color.b / 255.0, (float)color.a / 255.0};
+        Color_RGBA8 defaultColour = {0, 0, 0, 255};
+        Color_RGBA8 color = CVarGetColor("TimeSplits.WindowColor", defaultColour);
+        windowColor = {(float)color.r / 255.0f, (float)color.g / 255.0f, (float)color.b / 255.0f, (float)color.a / 255.0f};
         InitializeSplitDataFile();
         initialized = true;
     }

--- a/soh/src/code/z_player_lib.c
+++ b/soh/src/code/z_player_lib.c
@@ -1753,7 +1753,7 @@ Vec3f sLeftHandArrowVec3 = { 398.0f, 1419.0f, 244.0f };
 
 BowStringData sBowStringData[] = {
     { gLinkAdultBowStringDL, { 0.0f, -360.4f, 0.0f } },       // bow
-    { gLinkChildSlinghotStringDL, { 606.0f, 236.0f, 0.0f } }, // slingshot
+    { gLinkChildSlingshotStringDL, { 606.0f, 236.0f, 0.0f } }, // slingshot
 };
 
 Vec3f sRightHandLimbModelShieldQuadVertices[] = {


### PR DESCRIPTION
Resolves #4549.

Not sure if I'm doing the conversion from 8 bit CVar colour to float based colour in the best way, but it works.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2225453728.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2225469460.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2225478919.zip)
<!--- section:artifacts:end -->