### PR TITLE
Separate option values into context and menu indexes.

### DIFF
--- a/soh/soh/Enhancements/TimeSavers/SkipCutscene/Story/SkipBlueWarp.cpp
+++ b/soh/soh/Enhancements/TimeSavers/SkipCutscene/Story/SkipBlueWarp.cpp
@@ -10,7 +10,7 @@ extern "C" {
 #include "variables.h"
 }
 
-#define RAND_GET_OPTION(option) Rando::Context::GetInstance()->GetOption(option).GetSelectedOptionIndex()
+#define RAND_GET_OPTION(option) Rando::Context::GetInstance()->GetOption(option).GetContextOptionIndex()
 
 static bool sEnteredBlueWarp = false;
 

--- a/soh/soh/Enhancements/kaleido.cpp
+++ b/soh/soh/Enhancements/kaleido.cpp
@@ -125,8 +125,8 @@ namespace Rando {
                     std::make_shared<KaleidoEntryIconCountRequired>(
                             gTriforcePieceTex, G_IM_FMT_RGBA, G_IM_SIZ_32b, 32, 32, Color_RGBA8{ 255,255,255,255 }, 0,
                             yOffset, reinterpret_cast<int*>(&gSaveContext.triforcePiecesCollected),
-                            ctx->GetOption(RSK_TRIFORCE_HUNT_PIECES_REQUIRED).GetSelectedOptionIndex() + 1,
-                            ctx->GetOption(RSK_TRIFORCE_HUNT_PIECES_TOTAL).GetSelectedOptionIndex() + 1));
+                            ctx->GetOption(RSK_TRIFORCE_HUNT_PIECES_REQUIRED).GetContextOptionIndex() + 1,
+                            ctx->GetOption(RSK_TRIFORCE_HUNT_PIECES_TOTAL).GetContextOptionIndex() + 1));
             yOffset += 18;
         }
         if (ctx->GetOption(RSK_SHUFFLE_OCARINA_BUTTONS)) {

--- a/soh/soh/Enhancements/randomizer/3drando/fill.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/fill.cpp
@@ -238,10 +238,10 @@ static int GetMaxGSCount() {
   int maxBridge = 0;
   int maxLACS = 0;
   if (ctx->GetOption(RSK_RAINBOW_BRIDGE).Is(RO_BRIDGE_TOKENS)) {
-    maxBridge = ctx->GetOption(RSK_RAINBOW_BRIDGE_TOKEN_COUNT).Value<uint8_t>();
+    maxBridge = ctx->GetOption(RSK_RAINBOW_BRIDGE_TOKEN_COUNT).GetContextOptionIndex();
   }
   if (ctx->GetOption(RSK_GANONS_BOSS_KEY).Is(RO_GANON_BOSS_KEY_LACS_TOKENS)) {
-    maxLACS = ctx->GetOption(RSK_LACS_TOKEN_COUNT).Value<uint8_t>();
+    maxLACS = ctx->GetOption(RSK_LACS_TOKEN_COUNT).GetContextOptionIndex();
   }
   maxBridge = std::max(maxBridge, maxLACS);
   //Get the max amount of GS which could be useful from token reward locations
@@ -266,7 +266,7 @@ static int GetMaxGSCount() {
       maxUseful = 10;
   }
   //Return max of the two possible reasons tokens could be important, minus the tokens in the starting inventory
-  return std::max(maxUseful, maxBridge) - ctx->GetOption(RSK_STARTING_SKULLTULA_TOKEN).Value<uint8_t>();
+  return std::max(maxUseful, maxBridge) - ctx->GetOption(RSK_STARTING_SKULLTULA_TOKEN).GetContextOptionIndex();
 }
 
 std::string GetShopItemBaseName(std::string itemName) {

--- a/soh/soh/Enhancements/randomizer/3drando/hints.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/hints.cpp
@@ -222,18 +222,18 @@ uint8_t StonesRequiredBySettings() {
     auto ctx = Rando::Context::GetInstance();
     uint8_t stones = 0;
     if (ctx->GetOption(RSK_RAINBOW_BRIDGE).Is(RO_BRIDGE_STONES)) {
-        stones = ctx->GetOption(RSK_RAINBOW_BRIDGE_STONE_COUNT).Value<uint8_t>();
+        stones = ctx->GetOption(RSK_RAINBOW_BRIDGE_STONE_COUNT).GetContextOptionIndex();
     } else if (ctx->GetOption(RSK_RAINBOW_BRIDGE).Is(RO_BRIDGE_DUNGEON_REWARDS)) {
-        stones = ctx->GetOption(RSK_RAINBOW_BRIDGE_REWARD_COUNT).Value<uint8_t>() - 6;
+        stones = ctx->GetOption(RSK_RAINBOW_BRIDGE_REWARD_COUNT).GetContextOptionIndex() - 6;
     } else if ((ctx->GetOption(RSK_RAINBOW_BRIDGE).Is(RO_BRIDGE_DUNGEONS)) && (ctx->GetOption(RSK_SHUFFLE_DUNGEON_REWARDS).Is(RO_DUNGEON_REWARDS_END_OF_DUNGEON))) {
-        stones = ctx->GetOption(RSK_RAINBOW_BRIDGE_DUNGEON_COUNT).Value<uint8_t>() - 6;
+        stones = ctx->GetOption(RSK_RAINBOW_BRIDGE_DUNGEON_COUNT).GetContextOptionIndex() - 6;
     }
     if (ctx->GetOption(RSK_GANONS_BOSS_KEY).Is(RO_GANON_BOSS_KEY_LACS_STONES)) {
-        stones = std::max<uint8_t>({ stones, ctx->GetOption(RSK_LACS_STONE_COUNT).Value<uint8_t>() });
+        stones = std::max<uint8_t>({ stones, ctx->GetOption(RSK_LACS_STONE_COUNT).GetContextOptionIndex() });
     } else if (ctx->GetOption(RSK_GANONS_BOSS_KEY).Is(RO_GANON_BOSS_KEY_LACS_STONES)) {
-        stones = std::max<uint8_t>({ stones, (uint8_t)(ctx->GetOption(RSK_LACS_REWARD_COUNT).Value<uint8_t>() - 6 )});
+        stones = std::max<uint8_t>({ stones, (uint8_t)(ctx->GetOption(RSK_LACS_REWARD_COUNT).GetContextOptionIndex() - 6 )});
     } else if (ctx->GetOption(RSK_GANONS_BOSS_KEY).Is(RO_GANON_BOSS_KEY_LACS_DUNGEONS)) {
-        stones = std::max<uint8_t>({ stones, (uint8_t)(ctx->GetOption(RSK_LACS_DUNGEON_COUNT).Value<uint8_t>() - 6 )});
+        stones = std::max<uint8_t>({ stones, (uint8_t)(ctx->GetOption(RSK_LACS_DUNGEON_COUNT).GetContextOptionIndex() - 6 )});
     }
     return stones;
 }
@@ -242,18 +242,18 @@ uint8_t MedallionsRequiredBySettings() {
     auto ctx = Rando::Context::GetInstance();
     uint8_t medallions = 0;
     if (ctx->GetOption(RSK_RAINBOW_BRIDGE).Is(RO_BRIDGE_MEDALLIONS)) {
-        medallions = ctx->GetOption(RSK_RAINBOW_BRIDGE_MEDALLION_COUNT).Value<uint8_t>();
+        medallions = ctx->GetOption(RSK_RAINBOW_BRIDGE_MEDALLION_COUNT).GetContextOptionIndex();
     } else if (ctx->GetOption(RSK_RAINBOW_BRIDGE).Is(RO_BRIDGE_DUNGEON_REWARDS)) {
-        medallions = ctx->GetOption(RSK_RAINBOW_BRIDGE_REWARD_COUNT).Value<uint8_t>() - 3;
+        medallions = ctx->GetOption(RSK_RAINBOW_BRIDGE_REWARD_COUNT).GetContextOptionIndex() - 3;
     } else if (ctx->GetOption(RSK_RAINBOW_BRIDGE).Is(RO_BRIDGE_DUNGEONS) && ctx->GetOption(RSK_SHUFFLE_DUNGEON_REWARDS).Is(RO_DUNGEON_REWARDS_END_OF_DUNGEON)) {
-        medallions = ctx->GetOption(RSK_RAINBOW_BRIDGE_DUNGEON_COUNT).Value<uint8_t>() - 3;
+        medallions = ctx->GetOption(RSK_RAINBOW_BRIDGE_DUNGEON_COUNT).GetContextOptionIndex() - 3;
     }
     if (ctx->GetOption(RSK_GANONS_BOSS_KEY).Is(RO_GANON_BOSS_KEY_LACS_MEDALLIONS)) {
-        medallions = std::max({ medallions, ctx->GetOption(RSK_LACS_MEDALLION_COUNT).Value<uint8_t>() });
+        medallions = std::max({ medallions, ctx->GetOption(RSK_LACS_MEDALLION_COUNT).GetContextOptionIndex() });
     } else if (ctx->GetOption(RSK_GANONS_BOSS_KEY).Is(RO_GANON_BOSS_KEY_LACS_REWARDS)) {
-        medallions = std::max({ medallions, (uint8_t)(ctx->GetOption(RSK_LACS_REWARD_COUNT).Value<uint8_t>() - 3 )});
+        medallions = std::max({ medallions, (uint8_t)(ctx->GetOption(RSK_LACS_REWARD_COUNT).GetContextOptionIndex() - 3 )});
     } else if (ctx->GetOption(RSK_GANONS_BOSS_KEY).Is(RO_GANON_BOSS_KEY_LACS_DUNGEONS) && ctx->GetOption(RSK_SHUFFLE_DUNGEON_REWARDS).Is(RO_DUNGEON_REWARDS_END_OF_DUNGEON)) {
-        medallions = std::max({ medallions, (uint8_t)(ctx->GetOption(RSK_LACS_DUNGEON_COUNT).Value<uint8_t>() - 3 )});
+        medallions = std::max({ medallions, (uint8_t)(ctx->GetOption(RSK_LACS_DUNGEON_COUNT).GetContextOptionIndex() - 3 )});
     }
     return medallions;
 }
@@ -262,10 +262,10 @@ uint8_t TokensRequiredBySettings() {
     auto ctx = Rando::Context::GetInstance();
     uint8_t tokens = 0;
     if (ctx->GetOption(RSK_RAINBOW_BRIDGE).Is(RO_BRIDGE_TOKENS)) {
-        tokens = ctx->GetOption(RSK_RAINBOW_BRIDGE_TOKEN_COUNT).Value<uint8_t>();
+        tokens = ctx->GetOption(RSK_RAINBOW_BRIDGE_TOKEN_COUNT).GetContextOptionIndex();
     }
     if (ctx->GetOption(RSK_GANONS_BOSS_KEY).Is(RO_GANON_BOSS_KEY_LACS_TOKENS)) {
-        tokens = std::max<uint8_t>({ tokens, ctx->GetOption(RSK_LACS_TOKEN_COUNT).Value<uint8_t>() });
+        tokens = std::max<uint8_t>({ tokens, ctx->GetOption(RSK_LACS_TOKEN_COUNT).GetContextOptionIndex() });
     }
     return tokens;
 }
@@ -273,7 +273,7 @@ uint8_t TokensRequiredBySettings() {
 std::vector<std::pair<RandomizerCheck, std::function<bool()>>> conditionalAlwaysHints = {
     std::make_pair(RC_MARKET_10_BIG_POES, []() {
                        auto ctx = Rando::Context::GetInstance();
-                       return ctx->GetOption(RSK_BIG_POE_COUNT).Value<uint8_t>() >= 3 && !ctx->GetOption(RSK_BIG_POES_HINT);
+                       return ctx->GetOption(RSK_BIG_POE_COUNT).GetContextOptionIndex() >= 3 && !ctx->GetOption(RSK_BIG_POES_HINT);
                    }), // Remember, the option's value being 3 means 4 are required
     std::make_pair(RC_DEKU_THEATER_MASK_OF_TRUTH, []() {
                        auto ctx = Rando::Context::GetInstance();
@@ -483,7 +483,7 @@ static void CreateTrialHints(uint8_t copies) {
       AddGossipStoneHintCopies(copies, HINT_TYPE_HINT_KEY, "Trial", {RHT_ZERO_TRIALS});
     } else {
       std::vector<TrialInfo*> trials = ctx->GetTrials()->GetTrialList(); //there's probably a way to remove this assignment
-      if (ctx->GetOption(RSK_TRIAL_COUNT).Value<uint8_t>() >= 4) {//4 or 5 required trials, get skipped trials
+      if (ctx->GetOption(RSK_TRIAL_COUNT).GetContextOptionIndex() >= 4) {//4 or 5 required trials, get skipped trials
         trials = FilterFromPool(trials, [](TrialInfo* trial){return trial->IsSkipped();});
       } else {//1 to 3 trials, get requried trials
         auto requiredTrials = FilterFromPool(trials, [](TrialInfo* trial){return trial->IsRequired();});
@@ -611,7 +611,7 @@ uint8_t PlaceHints(std::vector<uint8_t>& selectedHints, std::vector<HintDistribu
 void CreateStoneHints() {
   auto ctx = Rando::Context::GetInstance();
   SPDLOG_DEBUG("\nNOW CREATING HINTS\n");
-  const HintSetting& hintSetting = hintSettingTable[ctx->GetOption(RSK_HINT_DISTRIBUTION).Value<uint8_t>()];
+  const HintSetting& hintSetting = hintSettingTable[ctx->GetOption(RSK_HINT_DISTRIBUTION).GetContextOptionIndex()];
   std::vector<HintDistributionSetting> distTable = hintSetting.distTable;
 
   // Apply impa's song exclusions when zelda is skipped

--- a/soh/soh/Enhancements/randomizer/3drando/item_pool.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/item_pool.cpp
@@ -655,7 +655,7 @@ static void SetMinimalItemPool() {
   ReplaceMaxItem(RG_PROGRESSIVE_BOMB_BAG, 1);
   ReplaceMaxItem(RG_PIECE_OF_HEART, 0);
   // Need an extra heart container when starting with 1 heart to be able to reach 3 hearts
-  ReplaceMaxItem(RG_HEART_CONTAINER, (ctx->GetOption(RSK_STARTING_HEARTS).Value<uint8_t>() == 18)? 1 : 0);
+  ReplaceMaxItem(RG_HEART_CONTAINER, (ctx->GetOption(RSK_STARTING_HEARTS).GetContextOptionIndex() == 18)? 1 : 0);
 }
 
 void GenerateItemPool() {
@@ -721,7 +721,7 @@ void GenerateItemPool() {
 
   if (ctx->GetOption(RSK_TRIFORCE_HUNT)) {
     ctx->possibleIceTrapModels.push_back(RG_TRIFORCE_PIECE);
-    AddItemToMainPool(RG_TRIFORCE_PIECE, (ctx->GetOption(RSK_TRIFORCE_HUNT_PIECES_TOTAL).Value<uint8_t>() + 1));
+    AddItemToMainPool(RG_TRIFORCE_PIECE, (ctx->GetOption(RSK_TRIFORCE_HUNT_PIECES_TOTAL).GetContextOptionIndex() + 1));
     ctx->PlaceItemInLocation(RC_TRIFORCE_COMPLETED, RG_TRIFORCE); // Win condition
     ctx->PlaceItemInLocation(RC_GANON, GetJunkItem(), false, true);
   } else {
@@ -821,7 +821,7 @@ void GenerateItemPool() {
   if (fsMode.IsNot(RO_FISHSANITY_OFF)) {
     if (fsMode.Is(RO_FISHSANITY_POND) || fsMode.Is(RO_FISHSANITY_BOTH)) {
       // 17 max child pond fish
-      uint8_t pondCt = ctx->GetOption(RSK_FISHSANITY_POND_COUNT).GetSelectedOptionIndex();
+      uint8_t pondCt = ctx->GetOption(RSK_FISHSANITY_POND_COUNT).GetContextOptionIndex();
       for (uint8_t i = 0; i < pondCt; i++) {
         AddItemToMainPool(GetJunkItem());
       }
@@ -1348,7 +1348,7 @@ void GenerateItemPool() {
 
   if (ctx->GetOption(RSK_GANONS_BOSS_KEY).Is(RO_GANON_BOSS_KEY_KAK_TOKENS)) {
     ctx->PlaceItemInLocation(RC_KAK_100_GOLD_SKULLTULA_REWARD, RG_GANONS_CASTLE_BOSS_KEY);
-  } else if (ctx->GetOption(RSK_GANONS_BOSS_KEY).Value<uint8_t>() >= RO_GANON_BOSS_KEY_LACS_VANILLA && ctx->GetOption(RSK_GANONS_BOSS_KEY).IsNot(RO_GANON_BOSS_KEY_TRIFORCE_HUNT)) {
+  } else if (ctx->GetOption(RSK_GANONS_BOSS_KEY).GetContextOptionIndex() >= RO_GANON_BOSS_KEY_LACS_VANILLA && ctx->GetOption(RSK_GANONS_BOSS_KEY).IsNot(RO_GANON_BOSS_KEY_TRIFORCE_HUNT)) {
     ctx->PlaceItemInLocation(RC_TOT_LIGHT_ARROWS_CUTSCENE, RG_GANONS_CASTLE_BOSS_KEY);
   } else if (ctx->GetOption(RSK_GANONS_BOSS_KEY).Is(RO_GANON_BOSS_KEY_VANILLA)) {
     ctx->PlaceItemInLocation(RC_GANONS_TOWER_BOSS_KEY_CHEST, RG_GANONS_CASTLE_BOSS_KEY);

--- a/soh/soh/Enhancements/randomizer/3drando/location_access.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/location_access.cpp
@@ -260,7 +260,7 @@ void RegionTable_Init() {
   areaTable[RR_ROOT] = Region("Root", "", {RA_LINKS_POCKET}, NO_DAY_NIGHT_CYCLE, {}, {
                   //Locations
                   LOCATION(RC_LINKS_POCKET,       true),
-                  LOCATION(RC_TRIFORCE_COMPLETED, logic->GetSaveContext()->triforcePiecesCollected >= ctx->GetOption(RSK_TRIFORCE_HUNT_PIECES_REQUIRED).Value<uint8_t>();),
+                  LOCATION(RC_TRIFORCE_COMPLETED, logic->GetSaveContext()->triforcePiecesCollected >= ctx->GetOption(RSK_TRIFORCE_HUNT_PIECES_REQUIRED).GetContextOptionIndex();),
                   LOCATION(RC_SARIA_SONG_HINT,    logic->CanUse(RG_SARIAS_SONG)),
                 }, {
                   //Exits

--- a/soh/soh/Enhancements/randomizer/3drando/location_access.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/location_access.cpp
@@ -395,7 +395,7 @@ void ReplaceAllInString(std::string& s, std::string const& toReplace, std::strin
 std::string CleanCheckConditionString(std::string condition) {
     ReplaceAllInString(condition, "logic->", "");
     ReplaceAllInString(condition, "ctx->", "");
-    ReplaceAllInString(condition, ".Value<uint8_t>()", "");
+    ReplaceAllInString(condition, "GetContextOptionIndex()", "");
     ReplaceAllInString(condition, "GetSaveContext()->", "");
     return condition;
 }

--- a/soh/soh/Enhancements/randomizer/3drando/location_access.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/location_access.cpp
@@ -395,7 +395,7 @@ void ReplaceAllInString(std::string& s, std::string const& toReplace, std::strin
 std::string CleanCheckConditionString(std::string condition) {
     ReplaceAllInString(condition, "logic->", "");
     ReplaceAllInString(condition, "ctx->", "");
-    ReplaceAllInString(condition, "GetContextOptionIndex()", "");
+    ReplaceAllInString(condition, ".GetContextOptionIndex()", "");
     ReplaceAllInString(condition, "GetSaveContext()->", "");
     return condition;
 }

--- a/soh/soh/Enhancements/randomizer/3drando/shops.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/shops.cpp
@@ -156,7 +156,7 @@ int GetPriceFromMax(int max) {
 
 uint16_t GetPriceFromSettings(Rando::Location *loc, PriceSettingsStruct priceSettings) {
    auto ctx = Rando::Context::GetInstance();
-   switch (ctx->GetOption(priceSettings.main).Value<uint8_t>()){
+   switch (ctx->GetOption(priceSettings.main).GetContextOptionIndex()){
       case RO_PRICE_VANILLA: 
          return loc->GetVanillaPrice();
       case RO_PRICE_CHEAP_BALANCED:
@@ -172,19 +172,19 @@ uint16_t GetPriceFromSettings(Rando::Location *loc, PriceSettingsStruct priceSet
          return 150;
       }
       case RO_PRICE_FIXED:
-         return (uint16_t)ctx->GetOption(priceSettings.fixedPrice).Value<uint8_t>() * 5;
+         return (uint16_t)ctx->GetOption(priceSettings.fixedPrice).GetContextOptionIndex() * 5;
       case RO_PRICE_RANGE:{
-         uint16_t range1 = (uint16_t)ctx->GetOption(priceSettings.range1).Value<uint8_t>() * 5;
-         uint16_t range2 = (uint16_t)ctx->GetOption(priceSettings.range2).Value<uint8_t>() * 5;
+         uint16_t range1 = (uint16_t)ctx->GetOption(priceSettings.range1).GetContextOptionIndex() * 5;
+         uint16_t range2 = (uint16_t)ctx->GetOption(priceSettings.range2).GetContextOptionIndex() * 5;
          return range1 < range2 ? Random(range1, range2+1) : Random(range2, range1+1);
       }
       case RO_PRICE_SET_BY_WALLET:{
-         bool isTycoon = ctx->GetOption(RSK_INCLUDE_TYCOON_WALLET).Value<bool>();
-         uint16_t noWeight = ctx->GetOption(priceSettings.noWallet).Value<uint8_t>();
-         uint16_t childWeight = ctx->GetOption(priceSettings.childWallet).Value<uint8_t>();
-         uint16_t adultWeight = ctx->GetOption(priceSettings.adultWallet).Value<uint8_t>();
-         uint16_t giantWeight = ctx->GetOption(priceSettings.giantWallet).Value<uint8_t>();
-         uint16_t tycoonWeight = isTycoon ? ctx->GetOption(priceSettings.tycoonWallet).Value<uint8_t>() : 0;
+         bool isTycoon = ctx->GetOption(RSK_INCLUDE_TYCOON_WALLET).GetContextOptionIndex();
+         uint16_t noWeight = ctx->GetOption(priceSettings.noWallet).GetContextOptionIndex();
+         uint16_t childWeight = ctx->GetOption(priceSettings.childWallet).GetContextOptionIndex();
+         uint16_t adultWeight = ctx->GetOption(priceSettings.adultWallet).GetContextOptionIndex();
+         uint16_t giantWeight = ctx->GetOption(priceSettings.giantWallet).GetContextOptionIndex();
+         uint16_t tycoonWeight = isTycoon ? ctx->GetOption(priceSettings.tycoonWallet).GetContextOptionIndex() : 0;
          uint16_t totalWeight = noWeight + childWeight + adultWeight + giantWeight + tycoonWeight;
          if (totalWeight == 0){ //if no weight, return from sane range
             return Random(0, 501);

--- a/soh/soh/Enhancements/randomizer/3drando/spoiler_log.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/spoiler_log.cpp
@@ -176,7 +176,7 @@ static void WriteSettings() {
     auto allOptionGroups = ctx->GetSettings()->GetOptionGroups();
     for (const Rando::OptionGroup& optionGroup : allOptionGroups) {
         if (optionGroup.GetContainsType() == Rando::OptionGroupType::DEFAULT && optionGroup.PrintInSpoiler()) {
-            for (const Rando::Option* option : optionGroup.GetOptions()) {
+            for (Rando::Option* option : optionGroup.GetOptions()) {
                 std::string settingName = optionGroup.GetName() + ":" + option->GetName();
                 jsonData["settings"][settingName] = option->GetSelectedOptionText();
             }
@@ -191,7 +191,7 @@ static void WriteExcludedLocations() {
 
   for (size_t i = 1; i < ctx->GetSettings()->GetExcludeLocationsOptions().size(); i++) {
     for (const auto& location : ctx->GetSettings()->GetExcludeLocationsOptions()[i]) {
-      if (location->GetSelectedOptionIndex() == RO_LOCATION_INCLUDE) {
+      if (location->GetContextOptionIndex() == RO_LOCATION_INCLUDE) {
         continue;
       }
 
@@ -214,7 +214,7 @@ static void WriteStartingInventory() {
     const Rando::OptionGroup& optionGroup = ctx->GetSettings()->GetOptionGroup(RSG_STARTING_INVENTORY);
     for (const Rando::OptionGroup* subGroup : optionGroup.GetSubGroups()) {
         if (subGroup->GetContainsType() == Rando::OptionGroupType::DEFAULT) {
-            for (const Rando::Option* option : subGroup->GetOptions()) {
+            for (Rando::Option* option : subGroup->GetOptions()) {
                 jsonData["settings"][option->GetName()] = option->GetSelectedOptionText();
             }
         }
@@ -227,7 +227,7 @@ static void WriteEnabledTricks(tinyxml2::XMLDocument& spoilerLog) {
   auto ctx = Rando::Context::GetInstance();
 
   for (const auto& setting : ctx->GetSettings()->GetOptionGroup(RSG_TRICKS).GetOptions()) {
-    if (setting->GetSelectedOptionIndex() != RO_GENERIC_ON/* || !setting->IsCategory(OptionCategory::Setting)*/) {
+    if (setting->GetContextOptionIndex() != RO_GENERIC_ON/* || !setting->IsCategory(OptionCategory::Setting)*/) {
       continue;
     }
     jsonData["enabledTricks"].push_back(RemoveLineBreaks(setting->GetName()).c_str());

--- a/soh/soh/Enhancements/randomizer/3drando/starting_inventory.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/starting_inventory.cpp
@@ -112,7 +112,7 @@ void GenerateStartingInventory() {
   //   AddItemToInventory(RG_EMPTY_BOTTLE, 1);
   // }
   // AddItemToInventory(RG_RUTOS_LETTER,              StartingRutoBottle.Value<uint8_t>());
-  AddItemToInventory(RG_PROGRESSIVE_OCARINA,       ctx->GetOption(RSK_STARTING_OCARINA).Value<uint8_t>());
+  AddItemToInventory(RG_PROGRESSIVE_OCARINA,       ctx->GetOption(RSK_STARTING_OCARINA).GetContextOptionIndex());
   AddItemToInventory(RG_ZELDAS_LULLABY,            ctx->GetOption(RSK_STARTING_ZELDAS_LULLABY) ? 1 : 0);
   AddItemToInventory(RG_EPONAS_SONG,               ctx->GetOption(RSK_STARTING_EPONAS_SONG) ? 1 : 0);
   AddItemToInventory(RG_SARIAS_SONG,               ctx->GetOption(RSK_STARTING_SARIAS_SONG) ? 1 : 0);
@@ -153,21 +153,21 @@ void GenerateStartingInventory() {
   // AddItemToInventory(RG_SPIRIT_MEDALLION,          StartingSpiritMedallion.Value<uint8_t>());
   // AddItemToInventory(RG_SHADOW_MEDALLION,          StartingShadowMedallion.Value<uint8_t>());
   // AddItemToInventory(RG_LIGHT_MEDALLION,           StartingLightMedallion.Value<uint8_t>());
-  AddItemToInventory(RG_GOLD_SKULLTULA_TOKEN,      ctx->GetOption(RSK_STARTING_SKULLTULA_TOKEN).Value<uint8_t>());
+  AddItemToInventory(RG_GOLD_SKULLTULA_TOKEN,      ctx->GetOption(RSK_STARTING_SKULLTULA_TOKEN).GetContextOptionIndex());
 
-  int8_t hearts = ctx->GetOption(RSK_STARTING_HEARTS).Value<uint8_t>() - 2;
+  int8_t hearts = ctx->GetOption(RSK_STARTING_HEARTS).GetContextOptionIndex() - 2;
   AdditionalHeartContainers = 0;
   if (hearts < 0) {
     AddItemToInventory(RG_PIECE_OF_HEART, 4);
     // Plentiful and minimal have less than 4 standard pieces of heart so also replace the winner heart
-    if (ctx->GetOption(RSK_ITEM_POOL).Value<uint8_t>() == 0 || ctx->GetOption(RSK_ITEM_POOL).Value<uint8_t>() == 3) {
+    if (ctx->GetOption(RSK_ITEM_POOL).GetContextOptionIndex() == 0 || ctx->GetOption(RSK_ITEM_POOL).GetContextOptionIndex() == 3) {
       AddItemToInventory(RG_TREASURE_GAME_HEART);
     }
 
     AdditionalHeartContainers = 1 - hearts;
   } else if (hearts > 0) {
     // 16 containers in plentiful, 8 in balanced and 0 in the others
-    uint8_t maxContainers = 8 * std::max(0, 2 - ctx->GetOption(RSK_ITEM_POOL).Value<uint8_t>());
+    uint8_t maxContainers = 8 * std::max(0, 2 - ctx->GetOption(RSK_ITEM_POOL).GetContextOptionIndex());
 
     if (hearts <= maxContainers) {
       AddItemToInventory(RG_HEART_CONTAINER, hearts);

--- a/soh/soh/Enhancements/randomizer/entrance.cpp
+++ b/soh/soh/Enhancements/randomizer/entrance.cpp
@@ -1333,12 +1333,12 @@ int EntranceShuffler::ShuffleAllEntrances() {
         (ctx->GetOption(RSK_MIX_OVERWORLD_ENTRANCES) ? 1 : 0) + (ctx->GetOption(RSK_MIX_INTERIOR_ENTRANCES) ? 1 : 0) +
         (ctx->GetOption(RSK_MIX_GROTTO_ENTRANCES) ? 1 : 0);
     if (totalMixedPools < 2) {
-        ctx->GetOption(RSK_MIXED_ENTRANCE_POOLS).SetSelectedIndex(RO_GENERIC_OFF);
-        ctx->GetOption(RSK_MIX_DUNGEON_ENTRANCES).SetSelectedIndex(RO_GENERIC_OFF);
-        ctx->GetOption(RSK_MIX_BOSS_ENTRANCES).SetSelectedIndex(RO_GENERIC_OFF);
-        ctx->GetOption(RSK_MIX_OVERWORLD_ENTRANCES).SetSelectedIndex(RO_GENERIC_OFF);
-        ctx->GetOption(RSK_MIX_INTERIOR_ENTRANCES).SetSelectedIndex(RO_GENERIC_OFF);
-        ctx->GetOption(RSK_MIX_GROTTO_ENTRANCES).SetSelectedIndex(RO_GENERIC_OFF);
+        ctx->GetOption(RSK_MIXED_ENTRANCE_POOLS).SetContextIndex(RO_GENERIC_OFF);
+        ctx->GetOption(RSK_MIX_DUNGEON_ENTRANCES).SetContextIndex(RO_GENERIC_OFF);
+        ctx->GetOption(RSK_MIX_BOSS_ENTRANCES).SetContextIndex(RO_GENERIC_OFF);
+        ctx->GetOption(RSK_MIX_OVERWORLD_ENTRANCES).SetContextIndex(RO_GENERIC_OFF);
+        ctx->GetOption(RSK_MIX_INTERIOR_ENTRANCES).SetContextIndex(RO_GENERIC_OFF);
+        ctx->GetOption(RSK_MIX_GROTTO_ENTRANCES).SetContextIndex(RO_GENERIC_OFF);
     }
     if (ctx->GetOption(RSK_MIXED_ENTRANCE_POOLS)) {
         std::set<EntranceType> poolsToMix = {};

--- a/soh/soh/Enhancements/randomizer/fishsanity.cpp
+++ b/soh/soh/Enhancements/randomizer/fishsanity.cpp
@@ -17,7 +17,7 @@ extern PlayState* gPlayState;
 
 #define FSi OTRGlobals::Instance->gRandoContext->GetFishsanity()
 
-#define RAND_GET_OPTION(option) Rando::Context::GetInstance()->GetOption(option).GetSelectedOptionIndex()
+#define RAND_GET_OPTION(option) Rando::Context::GetInstance()->GetOption(option).GetContextOptionIndex()
 
 /**
  * @brief Parallel list of pond fish checks for both ages

--- a/soh/soh/Enhancements/randomizer/hint.cpp
+++ b/soh/soh/Enhancements/randomizer/hint.cpp
@@ -559,23 +559,23 @@ CustomMessage Hint::GetBridgeReqsText() {
   } 
   else if (ctx->GetOption(RSK_RAINBOW_BRIDGE).Is(RO_BRIDGE_STONES)) {
     bridgeMessage = StaticData::hintTextTable[RHT_BRIDGE_STONES_HINT].GetHintMessage();
-    bridgeMessage.InsertNumber(ctx->GetOption(RSK_RAINBOW_BRIDGE_STONE_COUNT).Value<uint8_t>());
+    bridgeMessage.InsertNumber(ctx->GetOption(RSK_RAINBOW_BRIDGE_STONE_COUNT).GetContextOptionIndex());
   } 
   else if (ctx->GetOption(RSK_RAINBOW_BRIDGE).Is(RO_BRIDGE_MEDALLIONS)) {
     bridgeMessage = StaticData::hintTextTable[RHT_BRIDGE_MEDALLIONS_HINT].GetHintMessage();
-    bridgeMessage.InsertNumber(ctx->GetOption(RSK_RAINBOW_BRIDGE_MEDALLION_COUNT).Value<uint8_t>());
+    bridgeMessage.InsertNumber(ctx->GetOption(RSK_RAINBOW_BRIDGE_MEDALLION_COUNT).GetContextOptionIndex());
   } 
   else if (ctx->GetOption(RSK_RAINBOW_BRIDGE).Is(RO_BRIDGE_DUNGEON_REWARDS)) {
     bridgeMessage = StaticData::hintTextTable[RHT_BRIDGE_REWARDS_HINT].GetHintMessage();
-    bridgeMessage.InsertNumber(ctx->GetOption(RSK_RAINBOW_BRIDGE_REWARD_COUNT).Value<uint8_t>());
+    bridgeMessage.InsertNumber(ctx->GetOption(RSK_RAINBOW_BRIDGE_REWARD_COUNT).GetContextOptionIndex());
   } 
   else if (ctx->GetOption(RSK_RAINBOW_BRIDGE).Is(RO_BRIDGE_DUNGEONS)) {
     bridgeMessage = StaticData::hintTextTable[RHT_BRIDGE_DUNGEONS_HINT].GetHintMessage();
-    bridgeMessage.InsertNumber(ctx->GetOption(RSK_RAINBOW_BRIDGE_DUNGEON_COUNT).Value<uint8_t>());
+    bridgeMessage.InsertNumber(ctx->GetOption(RSK_RAINBOW_BRIDGE_DUNGEON_COUNT).GetContextOptionIndex());
   } 
   else if (ctx->GetOption(RSK_RAINBOW_BRIDGE).Is(RO_BRIDGE_TOKENS)) {
     bridgeMessage = StaticData::hintTextTable[RHT_BRIDGE_TOKENS_HINT].GetHintMessage();
-    bridgeMessage.InsertNumber(ctx->GetOption(RSK_RAINBOW_BRIDGE_TOKEN_COUNT).Value<uint8_t>());
+    bridgeMessage.InsertNumber(ctx->GetOption(RSK_RAINBOW_BRIDGE_TOKEN_COUNT).GetContextOptionIndex());
   } 
   else if (ctx->GetOption(RSK_RAINBOW_BRIDGE).Is(RO_BRIDGE_GREG)) {
     return  StaticData::hintTextTable[RHT_BRIDGE_GREG_HINT].GetHintMessage();
@@ -613,23 +613,23 @@ CustomMessage Hint::GetGanonBossKeyText() {
   } 
   else if (ctx->GetOption(RSK_GANONS_BOSS_KEY).Is(RO_GANON_BOSS_KEY_LACS_STONES)) {
     ganonBossKeyMessage = StaticData::hintTextTable[RHT_LACS_STONES_HINT].GetHintMessage();
-    ganonBossKeyMessage.InsertNumber(ctx->GetOption(RSK_LACS_STONE_COUNT).Value<uint8_t>());
+    ganonBossKeyMessage.InsertNumber(ctx->GetOption(RSK_LACS_STONE_COUNT).GetContextOptionIndex());
   } 
   else if (ctx->GetOption(RSK_GANONS_BOSS_KEY).Is(RO_GANON_BOSS_KEY_LACS_MEDALLIONS)) {
     ganonBossKeyMessage = StaticData::hintTextTable[RHT_LACS_MEDALLIONS_HINT].GetHintMessage();
-    ganonBossKeyMessage.InsertNumber(ctx->GetOption(RSK_LACS_MEDALLION_COUNT).Value<uint8_t>());
+    ganonBossKeyMessage.InsertNumber(ctx->GetOption(RSK_LACS_MEDALLION_COUNT).GetContextOptionIndex());
   }
   else if (ctx->GetOption(RSK_GANONS_BOSS_KEY).Is(RO_GANON_BOSS_KEY_LACS_REWARDS)) {
     ganonBossKeyMessage = StaticData::hintTextTable[RHT_LACS_REWARDS_HINT].GetHintMessage();
-    ganonBossKeyMessage.InsertNumber(ctx->GetOption(RSK_LACS_REWARD_COUNT).Value<uint8_t>());
+    ganonBossKeyMessage.InsertNumber(ctx->GetOption(RSK_LACS_REWARD_COUNT).GetContextOptionIndex());
   } 
   else if (ctx->GetOption(RSK_GANONS_BOSS_KEY).Is(RO_GANON_BOSS_KEY_LACS_DUNGEONS)) {
     ganonBossKeyMessage = StaticData::hintTextTable[RHT_LACS_DUNGEONS_HINT].GetHintMessage();
-    ganonBossKeyMessage.InsertNumber(ctx->GetOption(RSK_LACS_DUNGEON_COUNT).Value<uint8_t>());
+    ganonBossKeyMessage.InsertNumber(ctx->GetOption(RSK_LACS_DUNGEON_COUNT).GetContextOptionIndex());
   } 
   else if (ctx->GetOption(RSK_GANONS_BOSS_KEY).Is(RO_GANON_BOSS_KEY_LACS_TOKENS)) {
     ganonBossKeyMessage = StaticData::hintTextTable[RHT_LACS_TOKENS_HINT].GetHintMessage();
-    ganonBossKeyMessage.InsertNumber(ctx->GetOption(RSK_LACS_TOKEN_COUNT).Value<uint8_t>());
+    ganonBossKeyMessage.InsertNumber(ctx->GetOption(RSK_LACS_TOKEN_COUNT).GetContextOptionIndex());
   }
   else if (ctx->GetOption(RSK_GANONS_BOSS_KEY).Is(RO_GANON_BOSS_KEY_TRIFORCE_HUNT)) {
     return StaticData::hintTextTable[RHT_GANON_BK_TRIFORCE_HINT].GetHintMessage();

--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -62,7 +62,7 @@ extern s32 Player_SetupWaitForPutAway(PlayState* play, Player* player, AfterPutA
 extern void Play_InitEnvironment(PlayState * play, s16 skyboxId);
 }
 
-#define RAND_GET_OPTION(option) Rando::Context::GetInstance()->GetOption(option).GetSelectedOptionIndex()
+#define RAND_GET_OPTION(option) Rando::Context::GetInstance()->GetOption(option).GetContextOptionIndex()
 
 bool LocMatchesQuest(Rando::Location loc) {
     if (loc.GetQuest() == RCQUEST_BOTH) {

--- a/soh/soh/Enhancements/randomizer/item_location.cpp
+++ b/soh/soh/Enhancements/randomizer/item_location.cpp
@@ -176,8 +176,8 @@ void ItemLocation::SetHidden(const bool hidden_) {
     hidden = hidden_;
 }
 
-bool ItemLocation::IsExcluded() const {
-    return excludedOption.Value<bool>();
+bool ItemLocation::IsExcluded() {
+    return excludedOption.GetContextOptionIndex();
 }
 
 Option* ItemLocation::GetExcludedOption() {
@@ -197,7 +197,7 @@ void ItemLocation::AddExcludeOption() {
     // RANDOTODO: this without string compares and loops
     bool alreadyAdded = false;
     const Location* loc = StaticData::GetLocation(rc);
-    for (const Option* location : Context::GetInstance()->GetSettings()->GetExcludeOptionsForArea(loc->GetArea())) {
+    for (Option* location : Context::GetInstance()->GetSettings()->GetExcludeOptionsForArea(loc->GetArea())) {
         if (location->GetName() == excludedOption.GetName()) {
             alreadyAdded = true;
         }

--- a/soh/soh/Enhancements/randomizer/item_location.h
+++ b/soh/soh/Enhancements/randomizer/item_location.h
@@ -45,7 +45,7 @@ class ItemLocation {
     const std::vector<RandomizerHint>& GetHintedBy() const;
     void AddHintedBy(RandomizerHint hintKey);
     bool IsHidden() const;
-    bool IsExcluded() const;
+    bool IsExcluded();
     void AddExcludeOption();
     Option* GetExcludedOption();
     void SetHidden(bool hidden_);

--- a/soh/soh/Enhancements/randomizer/logic.cpp
+++ b/soh/soh/Enhancements/randomizer/logic.cpp
@@ -974,7 +974,7 @@ namespace Rando {
         10 for OHKO.
         This is the number of shifts to apply, not a real multiplier
         */
-        uint8_t Multiplier = (ctx->GetOption(RSK_DAMAGE_MULTIPLIER).Value<uint8_t>() < 6) ? ctx->GetOption(RSK_DAMAGE_MULTIPLIER).Value<uint8_t>() : 10;
+        uint8_t Multiplier = (ctx->GetOption(RSK_DAMAGE_MULTIPLIER).GetContextOptionIndex() < 6) ? ctx->GetOption(RSK_DAMAGE_MULTIPLIER).GetContextOptionIndex() : 10;
         //(Hearts() << (2 + HasItem(RG_DOUBLE_DEFENSE))) is quarter hearts after DD
         //>> Multiplier halves on normal and does nothing on half, meaning we're working with half hearts on normal damage 
         return ((Hearts() << (2 + HasItem(RG_DOUBLE_DEFENSE))) >> Multiplier) + 
@@ -1103,21 +1103,21 @@ namespace Rando {
     bool Logic::CanBuildRainbowBridge(){
         return ctx->GetOption(RSK_RAINBOW_BRIDGE).Is(RO_BRIDGE_ALWAYS_OPEN)      ||
                (ctx->GetOption(RSK_RAINBOW_BRIDGE).Is(RO_BRIDGE_VANILLA)         && HasItem(RG_SHADOW_MEDALLION) && HasItem(RG_SPIRIT_MEDALLION) && CanUse(RG_LIGHT_ARROWS)) ||
-               (ctx->GetOption(RSK_RAINBOW_BRIDGE).Is(RO_BRIDGE_STONES)          && StoneCount() + (HasItem(RG_GREG_RUPEE) && ctx->GetOption(RSK_BRIDGE_OPTIONS).Is(RO_BRIDGE_GREG_REWARD)) >= ctx->GetOption(RSK_RAINBOW_BRIDGE_STONE_COUNT).Value<uint8_t>()) ||
-               (ctx->GetOption(RSK_RAINBOW_BRIDGE).Is(RO_BRIDGE_MEDALLIONS)      && MedallionCount() + (HasItem(RG_GREG_RUPEE) && ctx->GetOption(RSK_BRIDGE_OPTIONS).Is(RO_BRIDGE_GREG_REWARD)) >= ctx->GetOption(RSK_RAINBOW_BRIDGE_MEDALLION_COUNT).Value<uint8_t>()) ||
-               (ctx->GetOption(RSK_RAINBOW_BRIDGE).Is(RO_BRIDGE_DUNGEON_REWARDS) && StoneCount() + MedallionCount() + (HasItem(RG_GREG_RUPEE) && ctx->GetOption(RSK_BRIDGE_OPTIONS).Is(RO_BRIDGE_GREG_REWARD)) >= ctx->GetOption(RSK_RAINBOW_BRIDGE_REWARD_COUNT).Value<uint8_t>()) ||
-               (ctx->GetOption(RSK_RAINBOW_BRIDGE).Is(RO_BRIDGE_DUNGEONS)        && DungeonCount() + (HasItem(RG_GREG_RUPEE) && ctx->GetOption(RSK_BRIDGE_OPTIONS).Is(RO_BRIDGE_GREG_REWARD)) >= ctx->GetOption(RSK_RAINBOW_BRIDGE_DUNGEON_COUNT).Value<uint8_t>()) ||
-               (ctx->GetOption(RSK_RAINBOW_BRIDGE).Is(RO_BRIDGE_TOKENS)          && GetGSCount() >= ctx->GetOption(RSK_RAINBOW_BRIDGE_TOKEN_COUNT).Value<uint8_t>()) ||
+               (ctx->GetOption(RSK_RAINBOW_BRIDGE).Is(RO_BRIDGE_STONES)          && StoneCount() + (HasItem(RG_GREG_RUPEE) && ctx->GetOption(RSK_BRIDGE_OPTIONS).Is(RO_BRIDGE_GREG_REWARD)) >= ctx->GetOption(RSK_RAINBOW_BRIDGE_STONE_COUNT).GetContextOptionIndex()) ||
+               (ctx->GetOption(RSK_RAINBOW_BRIDGE).Is(RO_BRIDGE_MEDALLIONS)      && MedallionCount() + (HasItem(RG_GREG_RUPEE) && ctx->GetOption(RSK_BRIDGE_OPTIONS).Is(RO_BRIDGE_GREG_REWARD)) >= ctx->GetOption(RSK_RAINBOW_BRIDGE_MEDALLION_COUNT).GetContextOptionIndex()) ||
+               (ctx->GetOption(RSK_RAINBOW_BRIDGE).Is(RO_BRIDGE_DUNGEON_REWARDS) && StoneCount() + MedallionCount() + (HasItem(RG_GREG_RUPEE) && ctx->GetOption(RSK_BRIDGE_OPTIONS).Is(RO_BRIDGE_GREG_REWARD)) >= ctx->GetOption(RSK_RAINBOW_BRIDGE_REWARD_COUNT).GetContextOptionIndex()) ||
+               (ctx->GetOption(RSK_RAINBOW_BRIDGE).Is(RO_BRIDGE_DUNGEONS)        && DungeonCount() + (HasItem(RG_GREG_RUPEE) && ctx->GetOption(RSK_BRIDGE_OPTIONS).Is(RO_BRIDGE_GREG_REWARD)) >= ctx->GetOption(RSK_RAINBOW_BRIDGE_DUNGEON_COUNT).GetContextOptionIndex()) ||
+               (ctx->GetOption(RSK_RAINBOW_BRIDGE).Is(RO_BRIDGE_TOKENS)          && GetGSCount() >= ctx->GetOption(RSK_RAINBOW_BRIDGE_TOKEN_COUNT).GetContextOptionIndex()) ||
                (ctx->GetOption(RSK_RAINBOW_BRIDGE).Is(RO_BRIDGE_GREG)            && HasItem(RG_GREG_RUPEE));
     }
 
     bool Logic::CanTriggerLACS(){
         return (ctx->GetSettings()->LACSCondition() == RO_LACS_VANILLA    && HasItem(RG_SHADOW_MEDALLION) && HasItem(RG_SPIRIT_MEDALLION)) ||
-               (ctx->GetSettings()->LACSCondition() == RO_LACS_STONES     && StoneCount() + (HasItem(RG_GREG_RUPEE) && ctx->GetOption(RSK_LACS_OPTIONS).Is(RO_LACS_GREG_REWARD)) >= ctx->GetOption(RSK_LACS_STONE_COUNT).Value<uint8_t>()) ||
-               (ctx->GetSettings()->LACSCondition() == RO_LACS_MEDALLIONS && MedallionCount() + (HasItem(RG_GREG_RUPEE) && ctx->GetOption(RSK_LACS_OPTIONS).Is(RO_LACS_GREG_REWARD)) >= ctx->GetOption(RSK_LACS_MEDALLION_COUNT).Value<uint8_t>()) ||
-               (ctx->GetSettings()->LACSCondition() == RO_LACS_REWARDS    && StoneCount() + MedallionCount() + (HasItem(RG_GREG_RUPEE) && ctx->GetOption(RSK_LACS_OPTIONS).Is(RO_LACS_GREG_REWARD)) >= ctx->GetOption(RSK_LACS_REWARD_COUNT).Value<uint8_t>()) ||
-               (ctx->GetSettings()->LACSCondition() == RO_LACS_DUNGEONS   && DungeonCount() + (HasItem(RG_GREG_RUPEE) && ctx->GetOption(RSK_LACS_OPTIONS).Is(RO_LACS_GREG_REWARD)) >= ctx->GetOption(RSK_LACS_DUNGEON_COUNT).Value<uint8_t>()) ||
-               (ctx->GetSettings()->LACSCondition() == RO_LACS_TOKENS     && GetGSCount() >= ctx->GetOption(RSK_LACS_TOKEN_COUNT).Value<uint8_t>());
+               (ctx->GetSettings()->LACSCondition() == RO_LACS_STONES     && StoneCount() + (HasItem(RG_GREG_RUPEE) && ctx->GetOption(RSK_LACS_OPTIONS).Is(RO_LACS_GREG_REWARD)) >= ctx->GetOption(RSK_LACS_STONE_COUNT).GetContextOptionIndex()) ||
+               (ctx->GetSettings()->LACSCondition() == RO_LACS_MEDALLIONS && MedallionCount() + (HasItem(RG_GREG_RUPEE) && ctx->GetOption(RSK_LACS_OPTIONS).Is(RO_LACS_GREG_REWARD)) >= ctx->GetOption(RSK_LACS_MEDALLION_COUNT).GetContextOptionIndex()) ||
+               (ctx->GetSettings()->LACSCondition() == RO_LACS_REWARDS    && StoneCount() + MedallionCount() + (HasItem(RG_GREG_RUPEE) && ctx->GetOption(RSK_LACS_OPTIONS).Is(RO_LACS_GREG_REWARD)) >= ctx->GetOption(RSK_LACS_REWARD_COUNT).GetContextOptionIndex()) ||
+               (ctx->GetSettings()->LACSCondition() == RO_LACS_DUNGEONS   && DungeonCount() + (HasItem(RG_GREG_RUPEE) && ctx->GetOption(RSK_LACS_OPTIONS).Is(RO_LACS_GREG_REWARD)) >= ctx->GetOption(RSK_LACS_DUNGEON_COUNT).GetContextOptionIndex()) ||
+               (ctx->GetSettings()->LACSCondition() == RO_LACS_TOKENS     && GetGSCount() >= ctx->GetOption(RSK_LACS_TOKEN_COUNT).GetContextOptionIndex());
     }
 
     bool Logic::SmallKeys(RandomizerRegion dungeon, uint8_t requiredAmount) {
@@ -2089,7 +2089,7 @@ namespace Rando {
         //CanPlantBean        = false;
         BigPoeKill            = false;
 
-        BaseHearts      = ctx->GetOption(RSK_STARTING_HEARTS).Value<uint8_t>() + 1;
+        BaseHearts      = ctx->GetOption(RSK_STARTING_HEARTS).GetContextOptionIndex() + 1;
         
 
         //Bridge Requirements

--- a/soh/soh/Enhancements/randomizer/option.cpp
+++ b/soh/soh/Enhancements/randomizer/option.cpp
@@ -30,72 +30,79 @@ Option Option::LogicTrick(std::string name_) {
                   "", WidgetType::Checkbox, 0, false, IMFLAG_NONE);
 }
 
-Option::operator bool() const {
-    if (std::holds_alternative<bool>(var)) {
-        return Value<bool>();
-    }
-    return Value<uint8_t>() != 0;
+Option::operator bool() {
+    return contextSelection != 0;
 }
 
-size_t Option::GetOptionCount() const {
+size_t Option::GetOptionCount() {
     return options.size();
 }
 
-const std::string& Option::GetName() const {
+std::string& Option::GetName() {
     return name;
 }
 
-const std::string& Option::GetDescription() const {
+std::string& Option::GetDescription() {
     return description;
 }
 
-uint8_t Option::GetSelectedOptionIndex() const {
-    return selectedOption;
+uint8_t Option::GetMenuOptionIndex() {
+    return menuSelection;
 }
 
-const std::string& Option::GetSelectedOptionText() const {
-    return options[selectedOption];
+uint8_t Option::GetContextOptionIndex() {
+    return contextSelection;
 }
 
-const std::string& Option::GetCVarName() const {
+std::string& Option::GetSelectedOptionText() {
+    return options[menuSelection];
+}
+
+std::string& Option::GetCVarName() {
     return cvarName;
 }
 
 void Option::SetVariable() {
     if (std::holds_alternative<bool>(var)) {
-        var.emplace<bool>(selectedOption != 0);
+        var.emplace<bool>(menuSelection != 0);
     } else {
-        var.emplace<uint8_t>(selectedOption);
+        var.emplace<uint8_t>(menuSelection);
     }
 }
 
-void Option::SetCVar() const {
+void Option::SetCVar() {
     if (!cvarName.empty()) {
-        CVarSetInteger(cvarName.c_str(), GetSelectedOptionIndex());
+        CVarSetInteger(cvarName.c_str(), GetMenuOptionIndex());
     }
 }
 
 void Option::SetFromCVar() {
     if (!cvarName.empty()) {
-        SetSelectedIndex(CVarGetInteger(cvarName.c_str(), defaultOption));
+        SetMenuIndex(CVarGetInteger(cvarName.c_str(), defaultOption));
     }
 }
 
 void Option::SetDelayedOption() {
-    delayedOption = selectedOption;
+    delayedSelection = contextSelection;
 }
 
 void Option::RestoreDelayedOption() {
-    selectedOption = delayedOption;
+    contextSelection = delayedSelection;
+}
+
+void Option::SetMenuIndex(size_t idx) {
+    menuSelection = idx;
+    if (menuSelection > options.size() - 1) {
+        menuSelection = options.size() - 1;
+    }
     SetVariable();
 }
 
-void Option::SetSelectedIndex(size_t idx) {
-    selectedOption = idx;
-    if (selectedOption > options.size() - 1) {
-        selectedOption = options.size() - 1;
+void Option::SetContextIndex(size_t idx) {
+    contextSelection = idx;
+    if (contextSelection > options.size() - 1) {
+        contextSelection = options.size() - 1;
     }
-    SetVariable();
 }
 
 void Option::Hide() {
@@ -106,13 +113,13 @@ void Option::Unhide() {
     hidden = false;
 }
 
-bool Option::IsHidden() const {
+bool Option::IsHidden() {
     return hidden;
 }
 
 void Option::ChangeOptions(std::vector<std::string> opts) {
-    if (selectedOption >= opts.size()) {
-        selectedOption = opts.size() - 1;
+    if (menuSelection >= opts.size()) {
+        menuSelection = opts.size() - 1;
     }
     options = std::move(opts);
 }
@@ -155,7 +162,7 @@ bool Option::RenderImGui() {
     return changed;
 }
 
-bool Option::HasFlag(const int imFlag_) const {
+bool Option::HasFlag(const int imFlag_) {
     return imFlag_ & imFlags;
 }
 
@@ -177,7 +184,7 @@ Option::Option(uint8_t var_, std::string name_, std::vector<std::string> options
     : var(var_), name(std::move(name_)), options(std::move(options_)), category(category_),
       cvarName(std::move(cvarName_)), description(std::move(description_)), widgetType(widgetType_),
       defaultOption(defaultOption_), defaultHidden(defaultHidden_), imFlags(imFlags_) {
-    selectedOption = defaultOption;
+    menuSelection = contextSelection =  defaultOption;
     hidden = defaultHidden;
     SetFromCVar();
 }
@@ -187,7 +194,7 @@ Option::Option(bool var_, std::string name_, std::vector<std::string> options_, 
     : var(var_), name(std::move(name_)), options(std::move(options_)), category(category_),
       cvarName(std::move(cvarName_)), description(std::move(description_)), widgetType(widgetType_),
       defaultOption(defaultOption_), defaultHidden(defaultHidden_), imFlags(imFlags_) {
-    selectedOption = defaultOption;
+    menuSelection = contextSelection = defaultOption;
     hidden = defaultHidden;
     SetFromCVar();
 }
@@ -270,7 +277,7 @@ bool Option::RenderCombobox() {
 
 bool Option::RenderSlider() {
     bool changed = false;
-    int val = GetSelectedOptionIndex();
+    int val = GetMenuOptionIndex();
     if (val > options.size() - 1) {
         val = options.size() - 1;
         CVarSetInteger(cvarName.c_str(), val);

--- a/soh/soh/Enhancements/randomizer/option.cpp
+++ b/soh/soh/Enhancements/randomizer/option.cpp
@@ -70,7 +70,7 @@ void Option::SetVariable() {
     }
 }
 
-void Option::SetCVar() const {
+void Option::SaveCVar() const {
     if (!cvarName.empty()) {
         CVarSetInteger(cvarName.c_str(), GetMenuOptionIndex());
     }
@@ -113,7 +113,7 @@ void Option::Unhide() {
     hidden = false;
 }
 
-bool Option::IsHidden() {
+bool Option::IsHidden() const {
     return hidden;
 }
 

--- a/soh/soh/Enhancements/randomizer/option.cpp
+++ b/soh/soh/Enhancements/randomizer/option.cpp
@@ -34,31 +34,31 @@ Option::operator bool() {
     return contextSelection != 0;
 }
 
-size_t Option::GetOptionCount() {
+size_t Option::GetOptionCount() const {
     return options.size();
 }
 
-const std::string& Option::GetName() {
+const std::string& Option::GetName() const {
     return name;
 }
 
-const std::string& Option::GetDescription() {
+const std::string& Option::GetDescription() const {
     return description;
 }
 
-uint8_t Option::GetMenuOptionIndex() {
+uint8_t Option::GetMenuOptionIndex() const {
     return menuSelection;
 }
 
-uint8_t Option::GetContextOptionIndex() {
+uint8_t Option::GetContextOptionIndex() const {
     return contextSelection;
 }
 
-const std::string& Option::GetSelectedOptionText() {
+const std::string& Option::GetSelectedOptionText() const {
     return options[menuSelection];
 }
 
-const std::string& Option::GetCVarName() {
+const std::string& Option::GetCVarName() const {
     return cvarName;
 }
 
@@ -162,7 +162,7 @@ bool Option::RenderImGui() {
     return changed;
 }
 
-bool Option::HasFlag(const int imFlag_) {
+bool Option::HasFlag(const int imFlag_) const {
     return imFlag_ & imFlags;
 }
 

--- a/soh/soh/Enhancements/randomizer/option.cpp
+++ b/soh/soh/Enhancements/randomizer/option.cpp
@@ -38,11 +38,11 @@ size_t Option::GetOptionCount() {
     return options.size();
 }
 
-std::string& Option::GetName() {
+const std::string& Option::GetName() {
     return name;
 }
 
-std::string& Option::GetDescription() {
+const std::string& Option::GetDescription() {
     return description;
 }
 
@@ -54,11 +54,11 @@ uint8_t Option::GetContextOptionIndex() {
     return contextSelection;
 }
 
-std::string& Option::GetSelectedOptionText() {
+const std::string& Option::GetSelectedOptionText() {
     return options[menuSelection];
 }
 
-std::string& Option::GetCVarName() {
+const std::string& Option::GetCVarName() {
     return cvarName;
 }
 

--- a/soh/soh/Enhancements/randomizer/option.cpp
+++ b/soh/soh/Enhancements/randomizer/option.cpp
@@ -30,7 +30,7 @@ Option Option::LogicTrick(std::string name_) {
                   "", WidgetType::Checkbox, 0, false, IMFLAG_NONE);
 }
 
-Option::operator bool() {
+Option::operator bool() const {
     return contextSelection != 0;
 }
 
@@ -70,7 +70,7 @@ void Option::SetVariable() {
     }
 }
 
-void Option::SetCVar() {
+void Option::SetCVar() const {
     if (!cvarName.empty()) {
         CVarSetInteger(cvarName.c_str(), GetMenuOptionIndex());
     }

--- a/soh/soh/Enhancements/randomizer/option.h
+++ b/soh/soh/Enhancements/randomizer/option.h
@@ -127,19 +127,8 @@ class Option {
     static Option LogicTrick(std::string name_);
 
     /**
-     * @brief Gets the selected index or boolean value of the Option.
-     *
-     * @tparam T uint8_t or bool, depending on how the option was constructed.
-     * @return T
-     */
-    //template <typename T> T Value() {
-    //    return std::get<T>(var);
-    //}
-
-    /**
      * @brief Determines if the value/selected index of this Option matches the provided value.
      *
-     * @tparam T uint8_t, bool, or an enum (which will be cast to uint8_t).
      * @param other The value to compare.
      * @return true
      * @return false
@@ -151,7 +140,6 @@ class Option {
     /**
      * @brief Determines if the value/selected index of this Option does not match the provided value.
      *
-     * @tparam T uint8_t, book, or an enum (which will be cast to uint8_t).
      * @param other The value to compare.
      * @return true
      * @return false
@@ -166,7 +154,7 @@ class Option {
      * @return true
      * @return false
      */
-    explicit operator bool();
+    explicit operator bool() const;
 
     /**
      * @brief Get the size of the options array.
@@ -220,7 +208,7 @@ class Option {
      * @brief Sets the CVar corresponding to the property `cvarName` equal to the value
      * of the property `selectedValue`.
     */
-    void SetCVar();
+    void SetCVar() const;
 
     /**
      * @brief Sets the value of property `selectedValue` equal to the CVar corresponding

--- a/soh/soh/Enhancements/randomizer/option.h
+++ b/soh/soh/Enhancements/randomizer/option.h
@@ -180,22 +180,22 @@ class Option {
      *
      * @return const std::string&
      */
-    std::string& GetName();
-    std::string& GetDescription();
+    const std::string& GetName();
+    const std::string& GetDescription();
 
     /**
      * @brief Get the value name corresponding to the selected index.
      *
      * @return const std::string&
      */
-    std::string& GetSelectedOptionText();
+    const std::string& GetSelectedOptionText();
 
     /**
      * @brief Get the CVar name for this Option.
      *
      * @return const std::string&
      */
-    std::string& GetCVarName();
+    const std::string& GetCVarName();
 
     /**
      * @brief Get the menu index for this Option.

--- a/soh/soh/Enhancements/randomizer/option.h
+++ b/soh/soh/Enhancements/randomizer/option.h
@@ -133,7 +133,7 @@ class Option {
      * @return true
      * @return false
      */
-    bool Is(uint32_t other) {
+    bool Is(uint32_t other) const {
         return contextSelection == other;
     }
 
@@ -144,7 +144,7 @@ class Option {
      * @return true
      * @return false
      */
-    bool IsNot(uint32_t other) {
+    bool IsNot(uint32_t other) const {
         return !Is(other);
     }
 
@@ -208,7 +208,7 @@ class Option {
      * @brief Sets the CVar corresponding to the property `cvarName` equal to the value
      * of the property `selectedValue`.
     */
-    void SetCVar() const;
+    void SaveCVar() const;
 
     /**
      * @brief Sets the value of property `selectedValue` equal to the CVar corresponding
@@ -258,7 +258,7 @@ class Option {
      * @return false
      */
 
-    bool IsHidden();
+    bool IsHidden() const;
     /**
      * @brief Replaces the `options` vector for this Option with a new one.
      * If the new vector is smaller than the old one and the current selected

--- a/soh/soh/Enhancements/randomizer/option.h
+++ b/soh/soh/Enhancements/randomizer/option.h
@@ -132,9 +132,9 @@ class Option {
      * @tparam T uint8_t or bool, depending on how the option was constructed.
      * @return T
      */
-    template <typename T> T Value() const {
-        return std::get<T>(var);
-    }
+    //template <typename T> T Value() {
+    //    return std::get<T>(var);
+    //}
 
     /**
      * @brief Determines if the value/selected index of this Option matches the provided value.
@@ -144,13 +144,8 @@ class Option {
      * @return true
      * @return false
      */
-    template <typename T> bool Is(T other) const {
-        static_assert(std::is_integral_v<T> || std::is_enum_v<T>, "T must be an integral type or an enum.");
-        if constexpr ((std::is_integral_v<T> && !std::is_same_v<bool, T>) || std::is_enum_v<T>) {
-            return Value<uint8_t>() == static_cast<uint8_t>(other);
-        } else {
-            return Value<bool>() == static_cast<bool>(other);
-        }
+    bool Is(uint32_t other) {
+        return contextSelection == other;
     }
 
     /**
@@ -161,7 +156,7 @@ class Option {
      * @return true
      * @return false
      */
-    template <typename T> bool IsNot(T other) const {
+    bool IsNot(uint32_t other) {
         return !Is(other);
     }
 
@@ -171,43 +166,50 @@ class Option {
      * @return true
      * @return false
      */
-    explicit operator bool() const;
+    explicit operator bool();
 
     /**
      * @brief Get the size of the options array.
      *
      * @return size_t
      */
-    size_t GetOptionCount() const;
+    size_t GetOptionCount();
 
     /**
      * @brief Get the name of the Option.
      *
      * @return const std::string&
      */
-    const std::string& GetName() const;
-    const std::string& GetDescription() const;
+    std::string& GetName();
+    std::string& GetDescription();
 
     /**
      * @brief Get the value name corresponding to the selected index.
      *
      * @return const std::string&
      */
-    const std::string& GetSelectedOptionText() const;
+    std::string& GetSelectedOptionText();
 
     /**
      * @brief Get the CVar name for this Option.
      *
      * @return const std::string&
      */
-    const std::string& GetCVarName() const;
+    std::string& GetCVarName();
 
     /**
-     * @brief Get the selected index for this Option.
+     * @brief Get the menu index for this Option.
      *
      * @return uint8_t
      */
-    uint8_t GetSelectedOptionIndex() const;
+    uint8_t GetMenuOptionIndex();
+
+    /**
+     * @brief Get the rando context index for this Option.
+     *
+     * @return uint8_t
+     */
+    uint8_t GetContextOptionIndex();
 
     /**
      * @brief Sets the variable to the currently selected index for this Option.
@@ -218,7 +220,7 @@ class Option {
      * @brief Sets the CVar corresponding to the property `cvarName` equal to the value
      * of the property `selectedValue`.
     */
-    void SetCVar() const;
+    void SetCVar();
 
     /**
      * @brief Sets the value of property `selectedValue` equal to the CVar corresponding
@@ -237,11 +239,18 @@ class Option {
     void RestoreDelayedOption();
 
     /**
-     * @brief Set the selected index for this Option. Also calls `SetVariable()`.
+     * @brief Set the menu index for this Option. Also calls `SetVariable()`.
      *
      * @param idx the index to set as the selected index.
      */
-    void SetSelectedIndex(size_t idx);
+    void SetMenuIndex(size_t idx);
+
+    /**
+     * @brief Set the rando context index for this Option. Also calls `SetVariable()`.
+     *
+     * @param idx the index to set as the selected index.
+     */
+    void SetContextIndex(size_t idx);
 
     /**
      * @brief Hides this Option in the menu. (Not currently being used afaik, we prefer to
@@ -261,7 +270,7 @@ class Option {
      * @return false
      */
 
-    bool IsHidden() const;
+    bool IsHidden();
     /**
      * @brief Replaces the `options` vector for this Option with a new one.
      * If the new vector is smaller than the old one and the current selected
@@ -303,7 +312,7 @@ class Option {
      */
     bool RenderImGui();
 
-    bool HasFlag(int imFlag_) const;
+    bool HasFlag(int imFlag_);
     void AddFlag(int imFlag_);
     void SetFlag(int imFlag_);
     void RemoveFlag(int imFlag_);
@@ -324,8 +333,9 @@ protected:
     std::variant<bool, uint8_t> var;
     std::string name;
     std::vector<std::string> options;
-    uint8_t selectedOption = 0;
-    uint8_t delayedOption = 0;
+    uint8_t menuSelection = 0;
+    uint8_t contextSelection = 0;
+    uint8_t delayedSelection = 0;
     bool hidden = false;
     OptionCategory category = OptionCategory::Setting;
     std::string cvarName;

--- a/soh/soh/Enhancements/randomizer/option.h
+++ b/soh/soh/Enhancements/randomizer/option.h
@@ -173,43 +173,43 @@ class Option {
      *
      * @return size_t
      */
-    size_t GetOptionCount();
+    size_t GetOptionCount() const;
 
     /**
      * @brief Get the name of the Option.
      *
      * @return const std::string&
      */
-    const std::string& GetName();
-    const std::string& GetDescription();
+    const std::string& GetName() const;
+    const std::string& GetDescription() const;
 
     /**
      * @brief Get the value name corresponding to the selected index.
      *
      * @return const std::string&
      */
-    const std::string& GetSelectedOptionText();
+    const std::string& GetSelectedOptionText() const;
 
     /**
      * @brief Get the CVar name for this Option.
      *
      * @return const std::string&
      */
-    const std::string& GetCVarName();
+    const std::string& GetCVarName() const;
 
     /**
      * @brief Get the menu index for this Option.
      *
      * @return uint8_t
      */
-    uint8_t GetMenuOptionIndex();
+    uint8_t GetMenuOptionIndex() const;
 
     /**
      * @brief Get the rando context index for this Option.
      *
      * @return uint8_t
      */
-    uint8_t GetContextOptionIndex();
+    uint8_t GetContextOptionIndex() const;
 
     /**
      * @brief Sets the variable to the currently selected index for this Option.
@@ -312,7 +312,7 @@ class Option {
      */
     bool RenderImGui();
 
-    bool HasFlag(int imFlag_);
+    bool HasFlag(int imFlag_) const;
     void AddFlag(int imFlag_);
     void SetFlag(int imFlag_);
     void RemoveFlag(int imFlag_);

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -1270,7 +1270,7 @@ FishIdentity Randomizer::IdentifyFish(s32 sceneNum, s32 actorParams) {
 }
 
 u8 Randomizer::GetRandoSettingValue(RandomizerSettingKey randoSettingKey) {
-    return Rando::Context::GetInstance()->GetOption(randoSettingKey).GetSelectedOptionIndex();
+    return Rando::Context::GetInstance()->GetOption(randoSettingKey).GetContextOptionIndex();
 }
 
 GetItemEntry Randomizer::GetItemFromKnownCheck(RandomizerCheck randomizerCheck, GetItemID ogItemId, bool checkObtainability) {

--- a/soh/soh/Enhancements/randomizer/settings.cpp
+++ b/soh/soh/Enhancements/randomizer/settings.cpp
@@ -1468,7 +1468,7 @@ TrickOption& Settings::GetTrickOption(const RandomizerTrick key) {
 
 void Settings::ResetTrickOptions() {
     for (int count = 0; count < RT_MAX; count++){
-        mTrickOptions[count].SetSelectedIndex(0); //RANDOTODO this can probably be done better
+        mTrickOptions[count].SetContextIndex(0); //RANDOTODO this can probably be done better
     };
 }
 
@@ -2212,6 +2212,9 @@ void Settings::UpdateOptionProperties() {
 void Settings::FinalizeSettings(const std::set<RandomizerCheck>& excludedLocations, const std::set<RandomizerTrick>& enabledTricks) {
     const auto ctx = Rando::Context::GetInstance();
     if (!ctx->IsSpoilerLoaded()) {
+        for (Option& option : mOptions) {
+            option.SetContextIndex(option.GetMenuOptionIndex());
+        }
         // If we've loaded a spoiler file, the settings have already been populated, so we
         // only need to do things like resolve the starting age or determine MQ dungeons.
         // Any logic dependent on cvarSettings should go in this if statement
@@ -2219,39 +2222,39 @@ void Settings::FinalizeSettings(const std::set<RandomizerCheck>& excludedLocatio
         // if we skip child zelda, we start with zelda's letter, and malon starts
         // at the ranch, so we should *not* shuffle the weird egg
         if (mOptions[RSK_SKIP_CHILD_ZELDA]) {
-            mOptions[RSK_SHUFFLE_WEIRD_EGG].SetSelectedIndex(RO_GENERIC_OFF);
+            mOptions[RSK_SHUFFLE_WEIRD_EGG].SetContextIndex(RO_GENERIC_OFF);
         }
 
         // With certain access settings, the seed is only beatable if Starting Age is set to Child.
         if (mOptions[RSK_FOREST].Is(RO_FOREST_CLOSED) || (mOptions[RSK_DOOR_OF_TIME].Is(RO_DOOROFTIME_CLOSED) &&
             !mOptions[RSK_SHUFFLE_OCARINA])) {
-            mOptions[RSK_STARTING_AGE].SetSelectedIndex(RO_AGE_CHILD);
+            mOptions[RSK_STARTING_AGE].SetContextIndex(RO_AGE_CHILD);
         }
 
         if (mOptions[RSK_TRIFORCE_HUNT]) {
-            mOptions[RSK_GANONS_BOSS_KEY].SetSelectedIndex(RO_GANON_BOSS_KEY_TRIFORCE_HUNT);
+            mOptions[RSK_GANONS_BOSS_KEY].SetContextIndex(RO_GANON_BOSS_KEY_TRIFORCE_HUNT);
         }
 
         // Force 100 GS Shuffle if that's where Ganon's Boss Key is
         if (mOptions[RSK_GANONS_BOSS_KEY].Is(RO_GANON_BOSS_KEY_KAK_TOKENS)) {
-            mOptions[RSK_SHUFFLE_100_GS_REWARD].SetSelectedIndex(1);
+            mOptions[RSK_SHUFFLE_100_GS_REWARD].SetContextIndex(1);
         }
 
         // If we only have MQ, set all dungeons to MQ
         if (OTRGlobals::Instance->HasMasterQuest() && !OTRGlobals::Instance->HasOriginal()) {
-            mOptions[RSK_MQ_DUNGEON_RANDOM].SetSelectedIndex(RO_MQ_DUNGEONS_SET_NUMBER);
-            mOptions[RSK_MQ_DUNGEON_COUNT].SetSelectedIndex(12);
-            mOptions[RSK_MQ_DUNGEON_SET].SetSelectedIndex(RO_GENERIC_OFF);
+            mOptions[RSK_MQ_DUNGEON_RANDOM].SetContextIndex(RO_MQ_DUNGEONS_SET_NUMBER);
+            mOptions[RSK_MQ_DUNGEON_COUNT].SetContextIndex(12);
+            mOptions[RSK_MQ_DUNGEON_SET].SetContextIndex(RO_GENERIC_OFF);
         }
 
         // If we don't have MQ, set all dungeons to Vanilla
         if (OTRGlobals::Instance->HasOriginal() && !OTRGlobals::Instance->HasMasterQuest()) {
-            mOptions[RSK_MQ_DUNGEON_RANDOM].SetSelectedIndex(RO_MQ_DUNGEONS_NONE);
+            mOptions[RSK_MQ_DUNGEON_RANDOM].SetContextIndex(RO_MQ_DUNGEONS_NONE);
         }
 
         if (mOptions[RSK_MQ_DUNGEON_RANDOM].Is(RO_MQ_DUNGEONS_NONE)) {
-            mOptions[RSK_MQ_DUNGEON_COUNT].SetSelectedIndex(0);
-            mOptions[RSK_MQ_DUNGEON_SET].SetSelectedIndex(RO_GENERIC_OFF);
+            mOptions[RSK_MQ_DUNGEON_COUNT].SetContextIndex(0);
+            mOptions[RSK_MQ_DUNGEON_SET].SetContextIndex(RO_GENERIC_OFF);
         }
 
         // If any of the individual shuffle settings are on, turn on the main Shuffle Entrances option
@@ -2261,53 +2264,53 @@ void Settings::FinalizeSettings(const std::set<RandomizerCheck>& excludedLocatio
             || mOptions[RSK_SHUFFLE_INTERIOR_ENTRANCES].IsNot(RO_INTERIOR_ENTRANCE_SHUFFLE_OFF)
             || mOptions[RSK_SHUFFLE_GROTTO_ENTRANCES] || mOptions[RSK_SHUFFLE_OWL_DROPS]
             || mOptions[RSK_SHUFFLE_WARP_SONGS] || mOptions[RSK_SHUFFLE_OVERWORLD_SPAWNS]) {
-            mOptions[RSK_SHUFFLE_ENTRANCES].SetSelectedIndex(RO_GENERIC_ON);
+            mOptions[RSK_SHUFFLE_ENTRANCES].SetContextIndex(RO_GENERIC_ON);
         } else {
-            mOptions[RSK_SHUFFLE_ENTRANCES].SetSelectedIndex(RO_GENERIC_OFF);
+            mOptions[RSK_SHUFFLE_ENTRANCES].SetContextIndex(RO_GENERIC_OFF);
         }
 
         if (mOptions[RSK_SHUFFLE_DUNGEON_REWARDS].Is(RO_DUNGEON_REWARDS_END_OF_DUNGEON)) {
-            mOptions[RSK_LINKS_POCKET].SetSelectedIndex(RO_LINKS_POCKET_DUNGEON_REWARD);
+            mOptions[RSK_LINKS_POCKET].SetContextIndex(RO_LINKS_POCKET_DUNGEON_REWARD);
         }
 
         if (!ctx->IsSpoilerLoaded()) {
             ctx->AddExcludedOptions();
             for (const auto locationKey : ctx->everyPossibleLocation) {
                 if (const auto location = ctx->GetItemLocation(locationKey); excludedLocations.contains(location->GetRandomizerCheck())) {
-                    location->GetExcludedOption()->SetSelectedIndex(1);
+                    location->GetExcludedOption()->SetContextIndex(1);
                 } else {
-                    location->GetExcludedOption()->SetSelectedIndex(0);
+                    location->GetExcludedOption()->SetContextIndex(0);
                 }
             }
             // Tricks
             ResetTrickOptions();
             for (const auto randomizerTrick : enabledTricks) {
-                mTrickOptions[randomizerTrick].SetSelectedIndex(1);
+                mTrickOptions[randomizerTrick].SetContextIndex(1);
             }
         }
         if (!mOptions[RSK_SHUFFLE_KOKIRI_SWORD]) {
             if (mOptions[RSK_STARTING_KOKIRI_SWORD]) {
-                ctx->GetItemLocation(RC_KF_KOKIRI_SWORD_CHEST)->GetExcludedOption()->SetSelectedIndex(1);
+                ctx->GetItemLocation(RC_KF_KOKIRI_SWORD_CHEST)->GetExcludedOption()->SetContextIndex(1);
             }
         }
         if (!mOptions[RSK_SHUFFLE_MASTER_SWORD]) {
             if (mOptions[RSK_STARTING_MASTER_SWORD]) {
-                ctx->GetItemLocation(RC_MASTER_SWORD_PEDESTAL)->GetExcludedOption()->SetSelectedIndex(1);
+                ctx->GetItemLocation(RC_MASTER_SWORD_PEDESTAL)->GetExcludedOption()->SetContextIndex(1);
             }
         }
         if (!mOptions[RSK_SHUFFLE_OCARINA]) {
             if (mOptions[RSK_STARTING_OCARINA].IsNot(RO_STARTING_OCARINA_OFF)) {
-                ctx->GetItemLocation(RC_LW_GIFT_FROM_SARIA)->GetExcludedOption()->SetSelectedIndex(1);
+                ctx->GetItemLocation(RC_LW_GIFT_FROM_SARIA)->GetExcludedOption()->SetContextIndex(1);
                 if (mOptions[RSK_STARTING_OCARINA].Is(RO_STARTING_OCARINA_TIME)) {
-                    ctx->GetItemLocation(RC_HF_OCARINA_OF_TIME_ITEM)->GetExcludedOption()->SetSelectedIndex(1);
+                    ctx->GetItemLocation(RC_HF_OCARINA_OF_TIME_ITEM)->GetExcludedOption()->SetContextIndex(1);
                 }
             }
         }
     }
 
     // RANDOTODO implement chest shuffle with keysanity
-    // ShuffleChestMinigame.SetSelectedIndex(cvarSettings[RSK_SHUFFLE_CHEST_MINIGAME]);
-    mOptions[RSK_SHUFFLE_CHEST_MINIGAME].SetSelectedIndex(RO_CHEST_GAME_OFF);
+    // ShuffleChestMinigame.SetContextIndex(cvarSettings[RSK_SHUFFLE_CHEST_MINIGAME]);
+    mOptions[RSK_SHUFFLE_CHEST_MINIGAME].SetContextIndex(RO_CHEST_GAME_OFF);
     
     //TODO: RandomizeAllSettings(true) when implementing the ability to randomize the options themselves.
     std::array<DungeonInfo*, 12> dungeons = ctx->GetDungeons()->GetDungeonList();
@@ -2318,12 +2321,12 @@ void Settings::FinalizeSettings(const std::set<RandomizerCheck>& excludedLocatio
         dungeon->SetDungeonKnown(true);
     }
     //if it's selection mode, process the selection directly
-    if (mOptions[RSK_MQ_DUNGEON_RANDOM].Value<uint8_t>() == RO_MQ_DUNGEONS_SELECTION){
-        mOptions[RSK_MQ_DUNGEON_SET].SetSelectedIndex(RO_GENERIC_ON);
+    if (mOptions[RSK_MQ_DUNGEON_RANDOM].GetContextOptionIndex() == RO_MQ_DUNGEONS_SELECTION){
+        mOptions[RSK_MQ_DUNGEON_SET].SetContextIndex(RO_GENERIC_ON);
         //How many dungeons are set to MQ in selection
         uint8_t mqSet = 0;
         for (auto dungeon: dungeons) {
-            switch (mOptions[dungeon->GetMQSetting()].Value<uint8_t>()) {
+            switch (mOptions[dungeon->GetMQSetting()].GetContextOptionIndex()) {
                 case RO_MQ_SET_MQ:
                     dungeon->SetMQ();
                     mqSet += 1;
@@ -2342,11 +2345,11 @@ void Settings::FinalizeSettings(const std::set<RandomizerCheck>& excludedLocatio
             }
         }
         //override the dungeons set with the ones set by selection, so it's accurate for anything that wants to know MQ dungeon count
-        mOptions[RSK_MQ_DUNGEON_COUNT].SetSelectedIndex(mqSet);
+        mOptions[RSK_MQ_DUNGEON_COUNT].SetContextIndex(mqSet);
     //handling set number and random number together
-    } else if (mOptions[RSK_MQ_DUNGEON_RANDOM].Value<uint8_t>() != RO_MQ_DUNGEONS_NONE){
+    } else if (mOptions[RSK_MQ_DUNGEON_RANDOM].GetContextOptionIndex() != RO_MQ_DUNGEONS_NONE){
         // so we don't have to call this repeatedly
-        uint8_t mqCount = mOptions[RSK_MQ_DUNGEON_COUNT].Value<uint8_t>();
+        uint8_t mqCount = mOptions[RSK_MQ_DUNGEON_COUNT].GetContextOptionIndex();
         //How many dungeons are set to MQ in selection
         uint8_t mqSet = 0;
         //the number of random 
@@ -2356,7 +2359,7 @@ void Settings::FinalizeSettings(const std::set<RandomizerCheck>& excludedLocatio
         //if dungeons have been preset, process them
         if (mOptions[RSK_MQ_DUNGEON_SET]){
             for (size_t i = 0; i < dungeons.size(); i++) {
-                switch (mOptions[dungeons[i]->GetMQSetting()].Value<uint8_t>()) {
+                switch (mOptions[dungeons[i]->GetMQSetting()].GetContextOptionIndex()) {
                 case RO_MQ_SET_MQ:
                     dungeons[i]->SetMQ();
                     mqSet += 1;
@@ -2372,22 +2375,22 @@ void Settings::FinalizeSettings(const std::set<RandomizerCheck>& excludedLocatio
         //otherwise, every dungeon is possible
         } else {
             //if the count is fixed to 12, we know everything is MQ, so can skip some setps and do not set Known
-            if (mOptions[RSK_MQ_DUNGEON_RANDOM].Value<uint8_t>() == RO_MQ_DUNGEONS_SET_NUMBER &&
+            if (mOptions[RSK_MQ_DUNGEON_RANDOM].GetContextOptionIndex() == RO_MQ_DUNGEONS_SET_NUMBER &&
                 mqCount == 12) {
                 randMQOption = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
                 for (auto dungeon: dungeons) {
-                    mOptions[dungeon->GetMQSetting()].SetSelectedIndex(RO_MQ_SET_MQ);
+                    mOptions[dungeon->GetMQSetting()].SetContextIndex(RO_MQ_SET_MQ);
                 }
             //if it's fixed to zero, set it to None instead. the rest is processed after
-            } else if (mOptions[RSK_MQ_DUNGEON_RANDOM].Value<uint8_t>() == RO_MQ_DUNGEONS_SET_NUMBER &&
+            } else if (mOptions[RSK_MQ_DUNGEON_RANDOM].GetContextOptionIndex() == RO_MQ_DUNGEONS_SET_NUMBER &&
                        mqCount == 0){
-                mOptions[RSK_MQ_DUNGEON_RANDOM].SetSelectedIndex(RO_MQ_DUNGEONS_NONE);
+                mOptions[RSK_MQ_DUNGEON_RANDOM].SetContextIndex(RO_MQ_DUNGEONS_NONE);
             //otherwise, make everything a possibility and unknown
             } else {
                 for (size_t i = 0; i < dungeons.size(); i++) {
                     randMQOption.push_back(i);
                     dungeons[i]->SetDungeonKnown(false);
-                    mOptions[dungeons[i]->GetMQSetting()].SetSelectedIndex(RO_MQ_SET_RANDOM);
+                    mOptions[dungeons[i]->GetMQSetting()].SetContextIndex(RO_MQ_SET_RANDOM);
                 }
             }
         }
@@ -2409,20 +2412,20 @@ void Settings::FinalizeSettings(const std::set<RandomizerCheck>& excludedLocatio
         } else {
             //if there's no random options, check if we can collapse the setting into None or Selection
             if (mqSet == 0){   
-                mOptions[RSK_MQ_DUNGEON_RANDOM].SetSelectedIndex(RO_MQ_DUNGEONS_NONE);
+                mOptions[RSK_MQ_DUNGEON_RANDOM].SetContextIndex(RO_MQ_DUNGEONS_NONE);
             } else {
-                mOptions[RSK_MQ_DUNGEON_RANDOM].SetSelectedIndex(RO_MQ_DUNGEONS_SELECTION);
+                mOptions[RSK_MQ_DUNGEON_RANDOM].SetContextIndex(RO_MQ_DUNGEONS_SELECTION);
             }
         }
         //reset the value set based on what was actually set
-        mOptions[RSK_MQ_DUNGEON_COUNT].SetSelectedIndex(mqToSet + mqSet);
+        mOptions[RSK_MQ_DUNGEON_COUNT].SetContextIndex(mqToSet + mqSet);
     } 
     //Not an if else as other settings can become None in processing
-    if (mOptions[RSK_MQ_DUNGEON_RANDOM].Value<uint8_t>() == RO_MQ_DUNGEONS_NONE) {
-        mOptions[RSK_MQ_DUNGEON_SET].SetSelectedIndex(RO_GENERIC_OFF);
-        mOptions[RSK_MQ_DUNGEON_COUNT].SetSelectedIndex(0);
+    if (mOptions[RSK_MQ_DUNGEON_RANDOM].GetContextOptionIndex() == RO_MQ_DUNGEONS_NONE) {
+        mOptions[RSK_MQ_DUNGEON_SET].SetContextIndex(RO_GENERIC_OFF);
+        mOptions[RSK_MQ_DUNGEON_COUNT].SetContextIndex(0);
         for (auto dungeon: dungeons) {
-            mOptions[dungeon->GetMQSetting()].SetSelectedIndex(RO_MQ_SET_VANILLA);
+            mOptions[dungeon->GetMQSetting()].SetContextIndex(RO_MQ_SET_VANILLA);
         }
     }
 
@@ -2448,16 +2451,16 @@ void Settings::FinalizeSettings(const std::set<RandomizerCheck>& excludedLocatio
         if (mOptions[RSK_GERUDO_FORTRESS].Is(RO_GF_NORMAL) && mOptions[RSK_GERUDO_KEYS].IsNot(RO_GERUDO_KEYS_VANILLA)) {
             keyrings.push_back(&mOptions[RSK_KEYRINGS_GERUDO_FORTRESS]);
         } else {
-            mOptions[RSK_KEYRINGS_GERUDO_FORTRESS].SetSelectedIndex(RO_KEYRING_FOR_DUNGEON_OFF);
+            mOptions[RSK_KEYRINGS_GERUDO_FORTRESS].SetContextIndex(RO_KEYRING_FOR_DUNGEON_OFF);
         }
         if (mOptions[RSK_KEYRINGS].Is(RO_KEYRINGS_RANDOM) || mOptions[RSK_KEYRINGS].Is(RO_KEYRINGS_COUNT)) {
-            const uint32_t keyRingCount = mOptions[RSK_KEYRINGS].Is(RO_KEYRINGS_COUNT) ? mOptions[RSK_KEYRINGS_RANDOM_COUNT].Value<uint8_t>() : Random(0, static_cast<int>(keyrings.size()));
+            const uint32_t keyRingCount = mOptions[RSK_KEYRINGS].Is(RO_KEYRINGS_COUNT) ? mOptions[RSK_KEYRINGS_RANDOM_COUNT].GetContextOptionIndex() : Random(0, static_cast<int>(keyrings.size()));
             Shuffle(keyrings);
             for (size_t i = 0; i < keyRingCount; i++) {
-                keyrings[i]->SetSelectedIndex(RO_KEYRING_FOR_DUNGEON_ON);
+                keyrings[i]->SetContextIndex(RO_KEYRING_FOR_DUNGEON_ON);
             }
             for (size_t i = keyRingCount; i < keyrings.size(); i++) {
-                keyrings[i]->SetSelectedIndex(RO_KEYRING_FOR_DUNGEON_OFF);
+                keyrings[i]->SetContextIndex(RO_KEYRING_FOR_DUNGEON_OFF);
             }
         }
         if (mOptions[RSK_KEYRINGS_BOTTOM_OF_THE_WELL].Is(RO_KEYRING_FOR_DUNGEON_ON) || (mOptions[RSK_KEYRINGS_BOTTOM_OF_THE_WELL].Is(RO_KEYRING_FOR_DUNGEON_RANDOM) && Random(0, 2) == 1)) {
@@ -2492,11 +2495,11 @@ void Settings::FinalizeSettings(const std::set<RandomizerCheck>& excludedLocatio
         trial->SetAsSkipped();
     }
     if(mOptions[RSK_GANONS_TRIALS].Is(RO_GANONS_TRIALS_SKIP)){
-        mOptions[RSK_TRIAL_COUNT].SetSelectedIndex(0);
+        mOptions[RSK_TRIAL_COUNT].SetContextIndex(0);
     } else if(mOptions[RSK_GANONS_TRIALS].Is(RO_GANONS_TRIALS_RANDOM_NUMBER)) {
-        mOptions[RSK_TRIAL_COUNT].SetSelectedIndex(Random(0, static_cast<int>(mOptions[RSK_TRIAL_COUNT].GetOptionCount())));
+        mOptions[RSK_TRIAL_COUNT].SetContextIndex(Random(0, static_cast<int>(mOptions[RSK_TRIAL_COUNT].GetOptionCount())));
     }
-    for (uint8_t i = 0; i < mOptions[RSK_TRIAL_COUNT].Value<uint8_t>(); i++) {
+    for (uint8_t i = 0; i < mOptions[RSK_TRIAL_COUNT].GetContextOptionIndex(); i++) {
         trials[i]->SetAsRequired();
     }
 
@@ -2504,7 +2507,7 @@ void Settings::FinalizeSettings(const std::set<RandomizerCheck>& excludedLocatio
         (mOptions[RSK_SHUFFLE_INTERIOR_ENTRANCES].Is(RO_INTERIOR_ENTRANCE_SHUFFLE_ALL) ||
          mOptions[RSK_SHUFFLE_OVERWORLD_ENTRANCES] || mOptions[RSK_SHUFFLE_OVERWORLD_SPAWNS] ||
          mOptions[RSK_DECOUPLED_ENTRANCES] || mOptions[RSK_MIXED_ENTRANCE_POOLS])) {
-        mOptions[RSK_FOREST].SetSelectedIndex(RO_FOREST_CLOSED_DEKU);
+        mOptions[RSK_FOREST].SetContextIndex(RO_FOREST_CLOSED_DEKU);
     }
 
     if (mOptions[RSK_STARTING_AGE].Is(RO_AGE_RANDOM)) {
@@ -2514,7 +2517,7 @@ void Settings::FinalizeSettings(const std::set<RandomizerCheck>& excludedLocatio
             mResolvedStartingAge = RO_AGE_ADULT;
         }
     } else {
-        mResolvedStartingAge = static_cast<RandoOptionStartingAge>(mOptions[RSK_STARTING_AGE].Value<uint8_t>());
+        mResolvedStartingAge = static_cast<RandoOptionStartingAge>(mOptions[RSK_STARTING_AGE].GetContextOptionIndex());
     }
 
     // TODO: Random Starting Time
@@ -2535,35 +2538,35 @@ void Settings::FinalizeSettings(const std::set<RandomizerCheck>& excludedLocatio
 
     if (mOptions[RSK_LOGIC_RULES].Is(RO_LOGIC_VANILLA)) {
         for (Option* setting : VanillaLogicDefaults) {
-            setting->SetDelayedOption();
-            setting->SetSelectedIndex(0);
+            //setting->SetDelayedOption();
+            setting->SetContextIndex(0);
         }
-        mOptions[RSK_KEYSANITY].SetDelayedOption();
-        mOptions[RSK_KEYSANITY].SetSelectedIndex(3);
+        //mOptions[RSK_KEYSANITY].SetDelayedOption();
+        mOptions[RSK_KEYSANITY].SetContextIndex(3);
     }
 
     if (!mOptions[RSK_SHUFFLE_WARP_SONGS]) {
-        mOptions[RSK_WARP_SONG_HINTS].SetSelectedIndex(RO_GENERIC_OFF);
+        mOptions[RSK_WARP_SONG_HINTS].SetContextIndex(RO_GENERIC_OFF);
     }
 
     if (!mOptions[RSK_SHUFFLE_COWS]) {
-        mOptions[RSK_MALON_HINT].SetSelectedIndex(RO_GENERIC_OFF);
+        mOptions[RSK_MALON_HINT].SetContextIndex(RO_GENERIC_OFF);
     }
 
     if (!mOptions[RSK_SHUFFLE_100_GS_REWARD]) {
-        mOptions[RSK_KAK_100_SKULLS_HINT].SetSelectedIndex(RO_GENERIC_OFF);
+        mOptions[RSK_KAK_100_SKULLS_HINT].SetContextIndex(RO_GENERIC_OFF);
     }
 
     if (!mOptions[RSK_SHUFFLE_FISHING_POLE]) {
-        mOptions[RSK_FISHING_POLE_HINT].SetSelectedIndex(RO_GENERIC_OFF);
+        mOptions[RSK_FISHING_POLE_HINT].SetContextIndex(RO_GENERIC_OFF);
     }
 
     if (mOptions[RSK_FISHSANITY].IsNot(RO_FISHSANITY_HYRULE_LOACH)) {
-        mOptions[RSK_LOACH_HINT].SetSelectedIndex(RO_GENERIC_OFF);
+        mOptions[RSK_LOACH_HINT].SetContextIndex(RO_GENERIC_OFF);
     }
 
     if (mOptions[RSK_CUCCO_COUNT].Is(0)) {
-        mOptions[RSK_CHICKENS_HINT].SetSelectedIndex(RO_GENERIC_OFF);
+        mOptions[RSK_CHICKENS_HINT].SetContextIndex(RO_GENERIC_OFF);
     }
 }
 void Settings::ParseJson(nlohmann::json spoilerFileJson) {
@@ -2581,115 +2584,115 @@ void Settings::ParseJson(nlohmann::json spoilerFileJson) {
             switch (const RandomizerSettingKey index = mSpoilerfileSettingNameToEnum[it.key()]) {
                 case RSK_LOGIC_RULES:
                     if (it.value() == "Glitchless") {
-                        mOptions[index].SetSelectedIndex(RO_LOGIC_GLITCHLESS);
+                        mOptions[index].SetContextIndex(RO_LOGIC_GLITCHLESS);
                     } else if (it.value() == "No Logic") {
-                        mOptions[index].SetSelectedIndex(RO_LOGIC_NO_LOGIC);
+                        mOptions[index].SetContextIndex(RO_LOGIC_NO_LOGIC);
                     } else if (it.value() == "Vanilla") {
-                        mOptions[index].SetSelectedIndex(RO_LOGIC_VANILLA);
+                        mOptions[index].SetContextIndex(RO_LOGIC_VANILLA);
                     }
                     break;
                 case RSK_FOREST:
                     if (it.value() == "Closed") {
-                        mOptions[index].SetSelectedIndex(RO_FOREST_CLOSED);
+                        mOptions[index].SetContextIndex(RO_FOREST_CLOSED);
                     } else if (it.value() == "Open") {
-                        mOptions[index].SetSelectedIndex(RO_FOREST_OPEN);
+                        mOptions[index].SetContextIndex(RO_FOREST_OPEN);
                     } else if (it.value() == "Closed Deku") {
-                        mOptions[index].SetSelectedIndex(RO_FOREST_CLOSED_DEKU);
+                        mOptions[index].SetContextIndex(RO_FOREST_CLOSED_DEKU);
                     }
                     break;
                 case RSK_KAK_GATE:
                     if (it.value() == "Closed") {
-                        mOptions[index].SetSelectedIndex(RO_KAK_GATE_CLOSED);
+                        mOptions[index].SetContextIndex(RO_KAK_GATE_CLOSED);
                     } else if (it.value() == "Open") {
-                        mOptions[index].SetSelectedIndex(RO_KAK_GATE_OPEN);
+                        mOptions[index].SetContextIndex(RO_KAK_GATE_OPEN);
                     }
                     break;
                 case RSK_DOOR_OF_TIME:
                     if (it.value() == "Open") {
-                        mOptions[index].SetSelectedIndex(RO_DOOROFTIME_OPEN);
+                        mOptions[index].SetContextIndex(RO_DOOROFTIME_OPEN);
                     } else if (it.value() == "Song only") {
-                        mOptions[index].SetSelectedIndex(RO_DOOROFTIME_SONGONLY);
+                        mOptions[index].SetContextIndex(RO_DOOROFTIME_SONGONLY);
                     } else if (it.value() == "Closed") {
-                        mOptions[index].SetSelectedIndex(RO_DOOROFTIME_CLOSED);
+                        mOptions[index].SetContextIndex(RO_DOOROFTIME_CLOSED);
                     }
                     break;
                 case RSK_ZORAS_FOUNTAIN:
                     if (it.value() == "Closed") {
-                        mOptions[index].SetSelectedIndex(RO_ZF_CLOSED);
+                        mOptions[index].SetContextIndex(RO_ZF_CLOSED);
                     } else if (it.value() == "Closed as child") {
-                        mOptions[index].SetSelectedIndex(RO_ZF_CLOSED_CHILD);
+                        mOptions[index].SetContextIndex(RO_ZF_CLOSED_CHILD);
                     } else if (it.value() == "Open") {
-                        mOptions[index].SetSelectedIndex(RO_ZF_OPEN);
+                        mOptions[index].SetContextIndex(RO_ZF_OPEN);
                     }
                     break;
                 case RSK_STARTING_AGE:
                     if (it.value() == "Child") {
-                        mOptions[index].SetSelectedIndex(RO_AGE_CHILD);
+                        mOptions[index].SetContextIndex(RO_AGE_CHILD);
                     } else if (it.value() == "Adult") {
-                        mOptions[index].SetSelectedIndex(RO_AGE_ADULT);
+                        mOptions[index].SetContextIndex(RO_AGE_ADULT);
                     }
                     break;
                 case RSK_GERUDO_FORTRESS:
                     if (it.value() == "Normal") {
-                        mOptions[index].SetSelectedIndex(RO_GF_NORMAL);
+                        mOptions[index].SetContextIndex(RO_GF_NORMAL);
                     } else if (it.value() == "Fast") {
-                        mOptions[index].SetSelectedIndex(RO_GF_FAST);
+                        mOptions[index].SetContextIndex(RO_GF_FAST);
                     } else if (it.value() == "Open") {
-                        mOptions[index].SetSelectedIndex(RO_GF_OPEN);
+                        mOptions[index].SetContextIndex(RO_GF_OPEN);
                     }
                     break;
                 case RSK_RAINBOW_BRIDGE:
                     if (it.value() == "Vanilla") {
-                        mOptions[index].SetSelectedIndex(RO_BRIDGE_VANILLA);
+                        mOptions[index].SetContextIndex(RO_BRIDGE_VANILLA);
                     } else if (it.value() == "Always open") {
-                        mOptions[index].SetSelectedIndex(RO_BRIDGE_ALWAYS_OPEN);
+                        mOptions[index].SetContextIndex(RO_BRIDGE_ALWAYS_OPEN);
                     } else if (it.value() == "Stones") {
-                        mOptions[index].SetSelectedIndex(RO_BRIDGE_STONES);
+                        mOptions[index].SetContextIndex(RO_BRIDGE_STONES);
                     } else if (it.value() == "Medallions") {
-                        mOptions[index].SetSelectedIndex(RO_BRIDGE_MEDALLIONS);
+                        mOptions[index].SetContextIndex(RO_BRIDGE_MEDALLIONS);
                     } else if (it.value() == "Dungeon rewards") {
-                        mOptions[index].SetSelectedIndex(RO_BRIDGE_DUNGEON_REWARDS);
+                        mOptions[index].SetContextIndex(RO_BRIDGE_DUNGEON_REWARDS);
                     } else if (it.value() == "Dungeons") {
-                        mOptions[index].SetSelectedIndex(RO_BRIDGE_DUNGEONS);
+                        mOptions[index].SetContextIndex(RO_BRIDGE_DUNGEONS);
                     } else if (it.value() == "Tokens") {
-                        mOptions[index].SetSelectedIndex(RO_BRIDGE_TOKENS);
+                        mOptions[index].SetContextIndex(RO_BRIDGE_TOKENS);
                     } else if (it.value() == "Greg") {
-                        mOptions[index].SetSelectedIndex(RO_BRIDGE_GREG);
+                        mOptions[index].SetContextIndex(RO_BRIDGE_GREG);
                     }
                     break;
                 case RSK_BRIDGE_OPTIONS:
                     if (it.value() == "Standard Rewards") {
-                        mOptions[index].SetSelectedIndex(RO_BRIDGE_STANDARD_REWARD);
+                        mOptions[index].SetContextIndex(RO_BRIDGE_STANDARD_REWARD);
                     } else if (it.value() == "Greg as Reward") {
-                        mOptions[index].SetSelectedIndex(RO_BRIDGE_GREG_REWARD);
+                        mOptions[index].SetContextIndex(RO_BRIDGE_GREG_REWARD);
                     } else if (it.value() == "Greg as Wildcard") {
-                        mOptions[index].SetSelectedIndex(RO_BRIDGE_WILDCARD_REWARD);
+                        mOptions[index].SetContextIndex(RO_BRIDGE_WILDCARD_REWARD);
                     }
                     break;
                 case RSK_LACS_OPTIONS:
                     if (it.value() == "Standard Reward") {
-                        mOptions[index].SetSelectedIndex(RO_LACS_STANDARD_REWARD);
+                        mOptions[index].SetContextIndex(RO_LACS_STANDARD_REWARD);
                     } else if (it.value() == "Greg as Reward") {
-                        mOptions[index].SetSelectedIndex(RO_LACS_GREG_REWARD);
+                        mOptions[index].SetContextIndex(RO_LACS_GREG_REWARD);
                     } else if (it.value() == "Greg as Wildcard") {
-                        mOptions[index].SetSelectedIndex(RO_LACS_WILDCARD_REWARD);
+                        mOptions[index].SetContextIndex(RO_LACS_WILDCARD_REWARD);
                     }
                     break;
                 case RSK_DAMAGE_MULTIPLIER:
                     if (it.value() == "x1/2") {
-                        mOptions[index].SetSelectedIndex(RO_DAMAGE_MULTIPLIER_HALF);
+                        mOptions[index].SetContextIndex(RO_DAMAGE_MULTIPLIER_HALF);
                     } else if (it.value() == "x1") {
-                        mOptions[index].SetSelectedIndex(RO_DAMAGE_MULTIPLIER_DEFAULT);
+                        mOptions[index].SetContextIndex(RO_DAMAGE_MULTIPLIER_DEFAULT);
                     } else if (it.value() == "x2") {
-                        mOptions[index].SetSelectedIndex(RO_DAMAGE_MULTIPLIER_DOUBLE);
+                        mOptions[index].SetContextIndex(RO_DAMAGE_MULTIPLIER_DOUBLE);
                     } else if (it.value() == "x4") {
-                        mOptions[index].SetSelectedIndex(RO_DAMAGE_MULTIPLIER_QUADRUPLE);
+                        mOptions[index].SetContextIndex(RO_DAMAGE_MULTIPLIER_QUADRUPLE);
                     } else if (it.value() == "x8") {
-                        mOptions[index].SetSelectedIndex(RO_DAMAGE_MULTIPLIER_OCTUPLE);
+                        mOptions[index].SetContextIndex(RO_DAMAGE_MULTIPLIER_OCTUPLE);
                     } else if (it.value() == "x16") {
-                        mOptions[index].SetSelectedIndex(RO_DAMAGE_MULTIPLIER_SEXDECUPLE);
+                        mOptions[index].SetContextIndex(RO_DAMAGE_MULTIPLIER_SEXDECUPLE);
                     } else if (it.value() == "OHKO") {
-                        mOptions[index].SetSelectedIndex(RO_DAMAGE_MULTIPLIER_OHKO);
+                        mOptions[index].SetContextIndex(RO_DAMAGE_MULTIPLIER_OHKO);
                     }
                     break;
                 case RSK_RAINBOW_BRIDGE_STONE_COUNT:
@@ -2709,7 +2712,7 @@ void Settings::ParseJson(nlohmann::json spoilerFileJson) {
                 case RSK_STARTING_SKULLTULA_TOKEN:
                 case RSK_SHOPSANITY_COUNT:
                     numericValueString = it.value();
-                    mOptions[index].SetSelectedIndex(std::stoi(numericValueString));
+                    mOptions[index].SetContextIndex(std::stoi(numericValueString));
                     break;
                 // Same as the above section, but the indexes are off by one from the text
                 // (i.e. 10 Big Poes is index 9).
@@ -2718,49 +2721,49 @@ void Settings::ParseJson(nlohmann::json spoilerFileJson) {
                 case RSK_TRIFORCE_HUNT_PIECES_REQUIRED:
                 case RSK_STARTING_HEARTS:
                     numericValueString = it.value();
-                    mOptions[index].SetSelectedIndex(std::stoi(numericValueString) - 1);
+                    mOptions[index].SetContextIndex(std::stoi(numericValueString) - 1);
                     break;
                 case RSK_GANONS_TRIALS:
                     if (it.value() == "Skip") {
-                        mOptions[index].SetSelectedIndex(RO_GANONS_TRIALS_SKIP);
+                        mOptions[index].SetContextIndex(RO_GANONS_TRIALS_SKIP);
                     } else if (it.value() == "Set Number") {
-                        mOptions[index].SetSelectedIndex(RO_GANONS_TRIALS_SET_NUMBER);
+                        mOptions[index].SetContextIndex(RO_GANONS_TRIALS_SET_NUMBER);
                     } else if (it.value() == "Random Number") {
-                        mOptions[index].SetSelectedIndex(RO_GANONS_TRIALS_RANDOM_NUMBER);
+                        mOptions[index].SetContextIndex(RO_GANONS_TRIALS_RANDOM_NUMBER);
                     }
                 case RSK_SHOPSANITY:
                     if (it.value() == "Off") {
-                        mOptions[index].SetSelectedIndex(RO_SHOPSANITY_OFF);
+                        mOptions[index].SetContextIndex(RO_SHOPSANITY_OFF);
                     } else if (it.value() == "Specific Count") {
-                        mOptions[index].SetSelectedIndex(RO_SHOPSANITY_SPECIFIC_COUNT);
+                        mOptions[index].SetContextIndex(RO_SHOPSANITY_SPECIFIC_COUNT);
                     } else if (it.value() == "Random") {
-                        mOptions[index].SetSelectedIndex(RO_SHOPSANITY_RANDOM);
+                        mOptions[index].SetContextIndex(RO_SHOPSANITY_RANDOM);
                     }
                     break;
                 case RSK_SHOPSANITY_PRICES:
                 case RSK_SCRUBS_PRICES:
                 case RSK_MERCHANT_PRICES:
                     if (it.value() == "Vanilla") {
-                        mOptions[index].SetSelectedIndex(RO_PRICE_VANILLA);
+                        mOptions[index].SetContextIndex(RO_PRICE_VANILLA);
                     } else if (it.value() == "Cheap Balanced") {
-                        mOptions[index].SetSelectedIndex(RO_PRICE_CHEAP_BALANCED);
+                        mOptions[index].SetContextIndex(RO_PRICE_CHEAP_BALANCED);
                     } else if (it.value() == "Balanced") {
-                        mOptions[index].SetSelectedIndex(RO_PRICE_BALANCED);
+                        mOptions[index].SetContextIndex(RO_PRICE_BALANCED);
                     } else if (it.value() == "Fixed") {
-                        mOptions[index].SetSelectedIndex(RO_PRICE_FIXED);
+                        mOptions[index].SetContextIndex(RO_PRICE_FIXED);
                     } else if (it.value() == "Range") {
-                        mOptions[index].SetSelectedIndex(RO_PRICE_RANGE);
+                        mOptions[index].SetContextIndex(RO_PRICE_RANGE);
                     } else if (it.value() == "Set By Wallet") {
-                        mOptions[index].SetSelectedIndex(RO_PRICE_SET_BY_WALLET);
+                        mOptions[index].SetContextIndex(RO_PRICE_SET_BY_WALLET);
                     }
                     break;
                 case RSK_SHUFFLE_SCRUBS:
                     if (it.value() == "Off") {
-                        mOptions[index].SetSelectedIndex(RO_SCRUBS_OFF);
+                        mOptions[index].SetContextIndex(RO_SCRUBS_OFF);
                     } else if (it.value() == "Major Items Only") {
-                        mOptions[index].SetSelectedIndex(RO_SCRUBS_MAJOR_ONLY);
+                        mOptions[index].SetContextIndex(RO_SCRUBS_MAJOR_ONLY);
                     } else if (it.value() == "All") {
-                        mOptions[index].SetSelectedIndex(RO_SCRUBS_ALL);
+                        mOptions[index].SetContextIndex(RO_SCRUBS_ALL);
                     }
                     break;
                 case RSK_SHUFFLE_FISHING_POLE:
@@ -2848,20 +2851,20 @@ void Settings::ParseJson(nlohmann::json spoilerFileJson) {
                 case RSK_SHUFFLE_DEKU_NUT_BAG:
                 case RSK_SHUFFLE_DEKU_STICK_BAG:
                     if (it.value() == "Off") {
-                        mOptions[index].SetSelectedIndex(RO_GENERIC_OFF);
+                        mOptions[index].SetContextIndex(RO_GENERIC_OFF);
                     } else if (it.value() == "On") {
-                        mOptions[index].SetSelectedIndex(RO_GENERIC_ON);
+                        mOptions[index].SetContextIndex(RO_GENERIC_ON);
                     }
                     break;
                 case RSK_KEYRINGS:
                     if (it.value() == "Off") {
-                        mOptions[index].SetSelectedIndex(RO_KEYRINGS_OFF);
+                        mOptions[index].SetContextIndex(RO_KEYRINGS_OFF);
                     } else if (it.value() == "Random") {
-                        mOptions[index].SetSelectedIndex(RO_KEYRINGS_RANDOM);
+                        mOptions[index].SetContextIndex(RO_KEYRINGS_RANDOM);
                     } else if (it.value() == "Count") {
-                        mOptions[index].SetSelectedIndex(RO_KEYRINGS_COUNT);
+                        mOptions[index].SetContextIndex(RO_KEYRINGS_COUNT);
                     } else if (it.value() == "Selection") {
-                        mOptions[index].SetSelectedIndex(RO_KEYRINGS_SELECTION);
+                        mOptions[index].SetContextIndex(RO_KEYRINGS_SELECTION);
                     }
                     break;
                 case RSK_KEYRINGS_GERUDO_FORTRESS:
@@ -2874,283 +2877,283 @@ void Settings::ParseJson(nlohmann::json spoilerFileJson) {
                 case RSK_KEYRINGS_GTG:
                 case RSK_KEYRINGS_GANONS_CASTLE:
                     if (it.value() == "No") {
-                        mOptions[index].SetSelectedIndex(RO_KEYRING_FOR_DUNGEON_OFF);
+                        mOptions[index].SetContextIndex(RO_KEYRING_FOR_DUNGEON_OFF);
                     } else if (it.value() == "Random") {
-                        mOptions[index].SetSelectedIndex(RO_KEYRING_FOR_DUNGEON_RANDOM);
+                        mOptions[index].SetContextIndex(RO_KEYRING_FOR_DUNGEON_RANDOM);
                     } else if (it.value() == "Yes") {
-                        mOptions[index].SetSelectedIndex(RO_KEYRING_FOR_DUNGEON_ON);
+                        mOptions[index].SetContextIndex(RO_KEYRING_FOR_DUNGEON_ON);
                     }
                     break;
                 case RSK_SHUFFLE_MERCHANTS:
                     if (it.value() == "Off") {
-                        mOptions[index].SetSelectedIndex(RO_SHUFFLE_MERCHANTS_OFF);
+                        mOptions[index].SetContextIndex(RO_SHUFFLE_MERCHANTS_OFF);
                     } else if (it.value() == "Beans Only") {
-                        mOptions[index].SetSelectedIndex(RO_SHUFFLE_MERCHANTS_BEANS_ONLY);
+                        mOptions[index].SetContextIndex(RO_SHUFFLE_MERCHANTS_BEANS_ONLY);
                     } else if (it.value() == "All but Beans") {
-                        mOptions[index].SetSelectedIndex(RO_SHUFFLE_MERCHANTS_ALL_BUT_BEANS);
+                        mOptions[index].SetContextIndex(RO_SHUFFLE_MERCHANTS_ALL_BUT_BEANS);
                     } else if (it.value() == "All") {
-                        mOptions[index].SetSelectedIndex(RO_SHUFFLE_MERCHANTS_ALL);
+                        mOptions[index].SetContextIndex(RO_SHUFFLE_MERCHANTS_ALL);
                     }
                     break;
                 // Uses Ammo Drops option for now. "Off" not yet implemented
                 // TODO: Change to Ammo Drops
                 case RSK_ENABLE_BOMBCHU_DROPS:
                     if (it.value() == "Yes") {
-                        mOptions[index].SetSelectedIndex(RO_AMMO_DROPS_ON);
+                        mOptions[index].SetContextIndex(RO_AMMO_DROPS_ON);
                     // } else if (it.value() == "On + Bombchu") {
-                    //     mOptions[index].SetSelectedIndex(RO_AMMO_DROPS_ON_PLUS_BOMBCHU);
+                    //     mOptions[index].SetContextIndex(RO_AMMO_DROPS_ON_PLUS_BOMBCHU);
                     } else if (it.value() == "No") {
-                        mOptions[index].SetSelectedIndex(RO_AMMO_DROPS_OFF);
+                        mOptions[index].SetContextIndex(RO_AMMO_DROPS_OFF);
                     }
                     break;
                 case RSK_FISHSANITY:
                     if (it.value() == "Off") {
-                        mOptions[index].SetSelectedIndex(RO_FISHSANITY_OFF);
+                        mOptions[index].SetContextIndex(RO_FISHSANITY_OFF);
                     } else if (it.value() == "Shuffle Fishing Pond") {
-                        mOptions[index].SetSelectedIndex(RO_FISHSANITY_POND);
+                        mOptions[index].SetContextIndex(RO_FISHSANITY_POND);
                     } else if (it.value() == "Shuffle Overworld Fish") {
-                        mOptions[index].SetSelectedIndex(RO_FISHSANITY_OVERWORLD);
+                        mOptions[index].SetContextIndex(RO_FISHSANITY_OVERWORLD);
                     } else if (it.value() == "Shuffle Both") {
-                        mOptions[index].SetSelectedIndex(RO_FISHSANITY_BOTH);
+                        mOptions[index].SetContextIndex(RO_FISHSANITY_BOTH);
                     }
                     break;
                 case RSK_SHUFFLE_BOSS_SOULS:
                     if (it.value() == "Off") {
-                        mOptions[index].SetSelectedIndex(RO_BOSS_SOULS_OFF);
+                        mOptions[index].SetContextIndex(RO_BOSS_SOULS_OFF);
                     } else if (it.value() == "On") {
-                        mOptions[index].SetSelectedIndex(RO_BOSS_SOULS_ON);
+                        mOptions[index].SetContextIndex(RO_BOSS_SOULS_ON);
                     } else if (it.value() == "On + Ganon") {
-                        mOptions[index].SetSelectedIndex(RO_BOSS_SOULS_ON_PLUS_GANON);
+                        mOptions[index].SetContextIndex(RO_BOSS_SOULS_ON_PLUS_GANON);
                     }
                 case RSK_STARTING_OCARINA:
                     if (it.value() == "Off") {
-                        mOptions[index].SetSelectedIndex(RO_STARTING_OCARINA_OFF);
+                        mOptions[index].SetContextIndex(RO_STARTING_OCARINA_OFF);
                     } else if (it.value() == "Fairy Ocarina") {
-                        mOptions[index].SetSelectedIndex(RO_STARTING_OCARINA_FAIRY);
+                        mOptions[index].SetContextIndex(RO_STARTING_OCARINA_FAIRY);
                     }
                     break;
                 case RSK_ITEM_POOL:
                     if (it.value() == "Plentiful") {
-                        mOptions[index].SetSelectedIndex(RO_ITEM_POOL_PLENTIFUL);
+                        mOptions[index].SetContextIndex(RO_ITEM_POOL_PLENTIFUL);
                     } else if (it.value() == "Balanced") {
-                        mOptions[index].SetSelectedIndex(RO_ITEM_POOL_BALANCED);
+                        mOptions[index].SetContextIndex(RO_ITEM_POOL_BALANCED);
                     } else if (it.value() == "Scarce") {
-                        mOptions[index].SetSelectedIndex(RO_ITEM_POOL_SCARCE);
+                        mOptions[index].SetContextIndex(RO_ITEM_POOL_SCARCE);
                     } else if (it.value() == "Minimal") {
-                        mOptions[index].SetSelectedIndex(RO_ITEM_POOL_MINIMAL);
+                        mOptions[index].SetContextIndex(RO_ITEM_POOL_MINIMAL);
                     }
                     break;
                 case RSK_ICE_TRAPS:
                     if (it.value() == "Off") {
-                        mOptions[index].SetSelectedIndex(RO_ICE_TRAPS_OFF);
+                        mOptions[index].SetContextIndex(RO_ICE_TRAPS_OFF);
                     } else if (it.value() == "Normal") {
-                        mOptions[index].SetSelectedIndex(RO_ICE_TRAPS_NORMAL);
+                        mOptions[index].SetContextIndex(RO_ICE_TRAPS_NORMAL);
                     } else if (it.value() == "Extra") {
-                        mOptions[index].SetSelectedIndex(RO_ICE_TRAPS_EXTRA);
+                        mOptions[index].SetContextIndex(RO_ICE_TRAPS_EXTRA);
                     } else if (it.value() == "Mayhem") {
-                        mOptions[index].SetSelectedIndex(RO_ICE_TRAPS_MAYHEM);
+                        mOptions[index].SetContextIndex(RO_ICE_TRAPS_MAYHEM);
                     } else if (it.value() == "Onslaught") {
-                        mOptions[index].SetSelectedIndex(RO_ICE_TRAPS_ONSLAUGHT);
+                        mOptions[index].SetContextIndex(RO_ICE_TRAPS_ONSLAUGHT);
                     }
                     break;
                 case RSK_GOSSIP_STONE_HINTS:
                     if (it.value() == "No Hints") {
-                        mOptions[index].SetSelectedIndex(RO_GOSSIP_STONES_NONE);
+                        mOptions[index].SetContextIndex(RO_GOSSIP_STONES_NONE);
                     } else if (it.value() == "Need Nothing") {
-                        mOptions[index].SetSelectedIndex(RO_GOSSIP_STONES_NEED_NOTHING);
+                        mOptions[index].SetContextIndex(RO_GOSSIP_STONES_NEED_NOTHING);
                     } else if (it.value() == "Mask of Truth") {
-                        mOptions[index].SetSelectedIndex(RO_GOSSIP_STONES_NEED_TRUTH);
+                        mOptions[index].SetContextIndex(RO_GOSSIP_STONES_NEED_TRUTH);
                     } else if (it.value() == "Stone of Agony") {
-                        mOptions[index].SetSelectedIndex(RO_GOSSIP_STONES_NEED_STONE);
+                        mOptions[index].SetContextIndex(RO_GOSSIP_STONES_NEED_STONE);
                     }
                     break;
                 case RSK_HINT_CLARITY:
                     if (it.value() == "Obscure") {
-                        mOptions[index].SetSelectedIndex(RO_HINT_CLARITY_OBSCURE);
+                        mOptions[index].SetContextIndex(RO_HINT_CLARITY_OBSCURE);
                     } else if (it.value() == "Ambiguous") {
-                        mOptions[index].SetSelectedIndex(RO_HINT_CLARITY_AMBIGUOUS);
+                        mOptions[index].SetContextIndex(RO_HINT_CLARITY_AMBIGUOUS);
                     } else if (it.value() == "Clear") {
-                        mOptions[index].SetSelectedIndex(RO_HINT_CLARITY_CLEAR);
+                        mOptions[index].SetContextIndex(RO_HINT_CLARITY_CLEAR);
                     }
                     break;
                 case RSK_HINT_DISTRIBUTION:
                     if (it.value() == "Useless") {
-                        mOptions[index].SetSelectedIndex(RO_HINT_DIST_USELESS);
+                        mOptions[index].SetContextIndex(RO_HINT_DIST_USELESS);
                     } else if (it.value() == "Balanced") {
-                        mOptions[index].SetSelectedIndex(RO_HINT_DIST_BALANCED);
+                        mOptions[index].SetContextIndex(RO_HINT_DIST_BALANCED);
                     } else if (it.value() == "Strong") {
-                        mOptions[index].SetSelectedIndex(RO_HINT_DIST_STRONG);
+                        mOptions[index].SetContextIndex(RO_HINT_DIST_STRONG);
                     } else if (it.value() == "Very Strong") {
-                        mOptions[index].SetSelectedIndex(RO_HINT_DIST_VERY_STRONG);
+                        mOptions[index].SetContextIndex(RO_HINT_DIST_VERY_STRONG);
                     }
                     break;
                 case RSK_GERUDO_KEYS:
                     if (it.value() == "Vanilla") {
-                        mOptions[index].SetSelectedIndex(RO_GERUDO_KEYS_VANILLA);
+                        mOptions[index].SetContextIndex(RO_GERUDO_KEYS_VANILLA);
                     } else if (it.value() == "Any Dungeon") {
-                        mOptions[index].SetSelectedIndex(RO_GERUDO_KEYS_ANY_DUNGEON);
+                        mOptions[index].SetContextIndex(RO_GERUDO_KEYS_ANY_DUNGEON);
                     } else if (it.value() == "Overworld") {
-                        mOptions[index].SetSelectedIndex(RO_GERUDO_KEYS_OVERWORLD);
+                        mOptions[index].SetContextIndex(RO_GERUDO_KEYS_OVERWORLD);
                     } else if (it.value() == "Anywhere") {
-                        mOptions[index].SetSelectedIndex(RO_GERUDO_KEYS_ANYWHERE);
+                        mOptions[index].SetContextIndex(RO_GERUDO_KEYS_ANYWHERE);
                     }
                     break;
                 case RSK_KEYSANITY:
                 case RSK_BOSS_KEYSANITY:
                 case RSK_SHUFFLE_MAPANDCOMPASS:
                     if (it.value() == "Start With") {
-                        mOptions[index].SetSelectedIndex(RO_DUNGEON_ITEM_LOC_STARTWITH);
+                        mOptions[index].SetContextIndex(RO_DUNGEON_ITEM_LOC_STARTWITH);
                     } else if (it.value() == "Vanilla") {
-                        mOptions[index].SetSelectedIndex(RO_DUNGEON_ITEM_LOC_VANILLA);
+                        mOptions[index].SetContextIndex(RO_DUNGEON_ITEM_LOC_VANILLA);
                     } else if (it.value() == "Own Dungeon") {
-                        mOptions[index].SetSelectedIndex(RO_DUNGEON_ITEM_LOC_OWN_DUNGEON);
+                        mOptions[index].SetContextIndex(RO_DUNGEON_ITEM_LOC_OWN_DUNGEON);
                     } else if (it.value() == "Any Dungeon") {
-                        mOptions[index].SetSelectedIndex(RO_DUNGEON_ITEM_LOC_ANY_DUNGEON);
+                        mOptions[index].SetContextIndex(RO_DUNGEON_ITEM_LOC_ANY_DUNGEON);
                     } else if (it.value() == "Overworld") {
-                        mOptions[index].SetSelectedIndex(RO_DUNGEON_ITEM_LOC_OVERWORLD);
+                        mOptions[index].SetContextIndex(RO_DUNGEON_ITEM_LOC_OVERWORLD);
                     } else if (it.value() == "Anywhere") {
-                        mOptions[index].SetSelectedIndex(RO_DUNGEON_ITEM_LOC_ANYWHERE);
+                        mOptions[index].SetContextIndex(RO_DUNGEON_ITEM_LOC_ANYWHERE);
                     }
                     break;
                 case RSK_GANONS_BOSS_KEY:
                     if (it.value() == "Vanilla") {
-                        mOptions[index].SetSelectedIndex(RO_GANON_BOSS_KEY_VANILLA);
+                        mOptions[index].SetContextIndex(RO_GANON_BOSS_KEY_VANILLA);
                     } else if (it.value() == "Own dungeon") {
-                        mOptions[index].SetSelectedIndex(RO_GANON_BOSS_KEY_OWN_DUNGEON);
+                        mOptions[index].SetContextIndex(RO_GANON_BOSS_KEY_OWN_DUNGEON);
                     } else if (it.value() == "Start with") {
-                        mOptions[index].SetSelectedIndex(RO_GANON_BOSS_KEY_STARTWITH);
+                        mOptions[index].SetContextIndex(RO_GANON_BOSS_KEY_STARTWITH);
                     } else if (it.value() == "Any Dungeon") {
-                        mOptions[index].SetSelectedIndex(RO_GANON_BOSS_KEY_ANY_DUNGEON);
+                        mOptions[index].SetContextIndex(RO_GANON_BOSS_KEY_ANY_DUNGEON);
                     } else if (it.value() == "Overworld") {
-                        mOptions[index].SetSelectedIndex(RO_GANON_BOSS_KEY_OVERWORLD);
+                        mOptions[index].SetContextIndex(RO_GANON_BOSS_KEY_OVERWORLD);
                     } else if (it.value() == "Anywhere") {
-                        mOptions[index].SetSelectedIndex(RO_GANON_BOSS_KEY_ANYWHERE);
+                        mOptions[index].SetContextIndex(RO_GANON_BOSS_KEY_ANYWHERE);
                     } else if (it.value() == "LACS-Vanilla") {
-                        mOptions[index].SetSelectedIndex(RO_GANON_BOSS_KEY_LACS_VANILLA);
+                        mOptions[index].SetContextIndex(RO_GANON_BOSS_KEY_LACS_VANILLA);
                     } else if (it.value() == "LACS-Stones") {
-                        mOptions[index].SetSelectedIndex(RO_GANON_BOSS_KEY_LACS_STONES);
+                        mOptions[index].SetContextIndex(RO_GANON_BOSS_KEY_LACS_STONES);
                     } else if (it.value() == "LACS-Medallions") {
-                        mOptions[index].SetSelectedIndex(RO_GANON_BOSS_KEY_LACS_MEDALLIONS);
+                        mOptions[index].SetContextIndex(RO_GANON_BOSS_KEY_LACS_MEDALLIONS);
                     } else if (it.value() == "LACS-Rewards") {
-                        mOptions[index].SetSelectedIndex(RO_GANON_BOSS_KEY_LACS_REWARDS);
+                        mOptions[index].SetContextIndex(RO_GANON_BOSS_KEY_LACS_REWARDS);
                     } else if (it.value() == "LACS-Dungeons") {
-                        mOptions[index].SetSelectedIndex(RO_GANON_BOSS_KEY_LACS_DUNGEONS);
+                        mOptions[index].SetContextIndex(RO_GANON_BOSS_KEY_LACS_DUNGEONS);
                     } else if (it.value() == "LACS-Tokens") {
-                        mOptions[index].SetSelectedIndex(RO_GANON_BOSS_KEY_LACS_TOKENS);
+                        mOptions[index].SetContextIndex(RO_GANON_BOSS_KEY_LACS_TOKENS);
                     } else if (it.value() == "100 GS Reward") {
-                        mOptions[index].SetSelectedIndex(RO_GANON_BOSS_KEY_KAK_TOKENS);
+                        mOptions[index].SetContextIndex(RO_GANON_BOSS_KEY_KAK_TOKENS);
                     } else if (it.value() == "Triforce Hunt") {
-                        mOptions[index].SetSelectedIndex(RO_GANON_BOSS_KEY_TRIFORCE_HUNT);
+                        mOptions[index].SetContextIndex(RO_GANON_BOSS_KEY_TRIFORCE_HUNT);
                     }
                     break;
                 case RSK_MQ_DUNGEON_RANDOM:
                     if (it.value() == "None") {
-                        mOptions[index].SetSelectedIndex(RO_MQ_DUNGEONS_NONE);
+                        mOptions[index].SetContextIndex(RO_MQ_DUNGEONS_NONE);
                     } else if (it.value() == "Random Number") {
-                        mOptions[index].SetSelectedIndex(RO_MQ_DUNGEONS_RANDOM_NUMBER);
+                        mOptions[index].SetContextIndex(RO_MQ_DUNGEONS_RANDOM_NUMBER);
                     } else if (it.value() == "Set Number") {
-                        mOptions[index].SetSelectedIndex(RO_MQ_DUNGEONS_SET_NUMBER);
+                        mOptions[index].SetContextIndex(RO_MQ_DUNGEONS_SET_NUMBER);
                     } else if (it.value() == "Selection Only") {
-                        mOptions[index].SetSelectedIndex(RO_MQ_DUNGEONS_SELECTION);
+                        mOptions[index].SetContextIndex(RO_MQ_DUNGEONS_SELECTION);
                     }
                     break;
                 case RSK_STARTING_CONSUMABLES:
                 case RSK_FULL_WALLETS:
                     if (it.value() == "No") {
-                        mOptions[index].SetSelectedIndex(RO_GENERIC_NO);
+                        mOptions[index].SetContextIndex(RO_GENERIC_NO);
                     } else if (it.value() == "Yes") {
-                        mOptions[index].SetSelectedIndex(RO_GENERIC_YES);
+                        mOptions[index].SetContextIndex(RO_GENERIC_YES);
                     }
                     break;
                 case RSK_SKIP_CHILD_ZELDA:
                 case RSK_SKIP_CHILD_STEALTH:
                 case RSK_SKIP_EPONA_RACE:
                     if (it.value() == "Don't Skip") {
-                        mOptions[index].SetSelectedIndex(RO_GENERIC_DONT_SKIP);
+                        mOptions[index].SetContextIndex(RO_GENERIC_DONT_SKIP);
                     } else if (it.value() == "Skip") {
-                        mOptions[index].SetSelectedIndex(RO_GENERIC_SKIP);
+                        mOptions[index].SetContextIndex(RO_GENERIC_SKIP);
                     }
                     break;
                 case RSK_SHUFFLE_DUNGEON_REWARDS:
                     if (it.value() == "End of dungeons") {
-                        mOptions[index].SetSelectedIndex(RO_DUNGEON_REWARDS_END_OF_DUNGEON);
+                        mOptions[index].SetContextIndex(RO_DUNGEON_REWARDS_END_OF_DUNGEON);
                     } else if (it.value() == "Any dungeon") {
-                        mOptions[index].SetSelectedIndex(RO_DUNGEON_REWARDS_ANY_DUNGEON);
+                        mOptions[index].SetContextIndex(RO_DUNGEON_REWARDS_ANY_DUNGEON);
                     } else if (it.value() == "Overworld") {
-                        mOptions[index].SetSelectedIndex(RO_DUNGEON_REWARDS_OVERWORLD);
+                        mOptions[index].SetContextIndex(RO_DUNGEON_REWARDS_OVERWORLD);
                     } else if (it.value() == "Anywhere") {
-                        mOptions[index].SetSelectedIndex(RO_DUNGEON_REWARDS_ANYWHERE);
+                        mOptions[index].SetContextIndex(RO_DUNGEON_REWARDS_ANYWHERE);
                     }
                     break;
                 case RSK_SHUFFLE_SONGS:
                     if (it.value() == "Song locations") {
-                        mOptions[index].SetSelectedIndex(RO_SONG_SHUFFLE_SONG_LOCATIONS);
+                        mOptions[index].SetContextIndex(RO_SONG_SHUFFLE_SONG_LOCATIONS);
                     } else if (it.value() == "Dungeon rewards") {
-                        mOptions[index].SetSelectedIndex(RO_SONG_SHUFFLE_DUNGEON_REWARDS);
+                        mOptions[index].SetContextIndex(RO_SONG_SHUFFLE_DUNGEON_REWARDS);
                     } else if (it.value() == "Anywhere") {
-                        mOptions[index].SetSelectedIndex(RO_SONG_SHUFFLE_ANYWHERE);
+                        mOptions[index].SetContextIndex(RO_SONG_SHUFFLE_ANYWHERE);
                     }
                     break;
                 case RSK_SHUFFLE_TOKENS:
                     if (it.value() == "Off") {
-                        mOptions[index].SetSelectedIndex(RO_TOKENSANITY_OFF);
+                        mOptions[index].SetContextIndex(RO_TOKENSANITY_OFF);
                     } else if (it.value() == "Dungeons") {
-                        mOptions[index].SetSelectedIndex(RO_TOKENSANITY_DUNGEONS);
+                        mOptions[index].SetContextIndex(RO_TOKENSANITY_DUNGEONS);
                     } else if (it.value() == "Overworld") {
-                        mOptions[index].SetSelectedIndex(RO_TOKENSANITY_OVERWORLD);
+                        mOptions[index].SetContextIndex(RO_TOKENSANITY_OVERWORLD);
                     } else if (it.value() == "All Tokens") {
-                        mOptions[index].SetSelectedIndex(RO_TOKENSANITY_ALL);
+                        mOptions[index].SetContextIndex(RO_TOKENSANITY_ALL);
                     }
                     break;
                 case RSK_LINKS_POCKET:
                     if (it.value() == "Dungeon Reward") {
-                        mOptions[index].SetSelectedIndex(RO_LINKS_POCKET_DUNGEON_REWARD);
+                        mOptions[index].SetContextIndex(RO_LINKS_POCKET_DUNGEON_REWARD);
                     } else if (it.value() == "Advancement") {
-                        mOptions[index].SetSelectedIndex(RO_LINKS_POCKET_ADVANCEMENT);
+                        mOptions[index].SetContextIndex(RO_LINKS_POCKET_ADVANCEMENT);
                     } else if (it.value() == "Anything") {
-                        mOptions[index].SetSelectedIndex(RO_LINKS_POCKET_ANYTHING);
+                        mOptions[index].SetContextIndex(RO_LINKS_POCKET_ANYTHING);
                     } else if (it.value() == "Nothing") {
-                        mOptions[index].SetSelectedIndex(RO_LINKS_POCKET_NOTHING);
+                        mOptions[index].SetContextIndex(RO_LINKS_POCKET_NOTHING);
                     }
                     break;
                 case RSK_MQ_DUNGEON_COUNT:
                     numericValueString = it.value();
-                    mOptions[index].SetSelectedIndex(std::stoi(numericValueString));
+                    mOptions[index].SetContextIndex(std::stoi(numericValueString));
                     break;
                 case RSK_SHUFFLE_DUNGEON_ENTRANCES:
                     if (it.value() == "Off") {
-                        mOptions[index].SetSelectedIndex(RO_DUNGEON_ENTRANCE_SHUFFLE_OFF);
+                        mOptions[index].SetContextIndex(RO_DUNGEON_ENTRANCE_SHUFFLE_OFF);
                     } else if (it.value() == "On") {
-                        mOptions[index].SetSelectedIndex(RO_DUNGEON_ENTRANCE_SHUFFLE_ON);
+                        mOptions[index].SetContextIndex(RO_DUNGEON_ENTRANCE_SHUFFLE_ON);
                     } else if (it.value() == "On + Ganon") {
-                        mOptions[index].SetSelectedIndex(RO_DUNGEON_ENTRANCE_SHUFFLE_ON_PLUS_GANON);
+                        mOptions[index].SetContextIndex(RO_DUNGEON_ENTRANCE_SHUFFLE_ON_PLUS_GANON);
                     }
                     break;
                 case RSK_SHUFFLE_BOSS_ENTRANCES:
                     if (it.value() == "Off") {
-                        mOptions[index].SetSelectedIndex(RO_BOSS_ROOM_ENTRANCE_SHUFFLE_OFF);
+                        mOptions[index].SetContextIndex(RO_BOSS_ROOM_ENTRANCE_SHUFFLE_OFF);
                     } else if (it.value() == "Age Restricted") {
-                        mOptions[index].SetSelectedIndex(RO_BOSS_ROOM_ENTRANCE_SHUFFLE_AGE_RESTRICTED);
+                        mOptions[index].SetContextIndex(RO_BOSS_ROOM_ENTRANCE_SHUFFLE_AGE_RESTRICTED);
                     } else if (it.value() == "Full") {
-                        mOptions[index].SetSelectedIndex(RO_BOSS_ROOM_ENTRANCE_SHUFFLE_FULL);
+                        mOptions[index].SetContextIndex(RO_BOSS_ROOM_ENTRANCE_SHUFFLE_FULL);
                     }
                     break;
                 case RSK_SHUFFLE_INTERIOR_ENTRANCES:
                     if (it.value() == "Off") {
-                        mOptions[index].SetSelectedIndex(RO_INTERIOR_ENTRANCE_SHUFFLE_OFF);
+                        mOptions[index].SetContextIndex(RO_INTERIOR_ENTRANCE_SHUFFLE_OFF);
                     } else if (it.value() == "Simple") {
-                        mOptions[index].SetSelectedIndex(RO_INTERIOR_ENTRANCE_SHUFFLE_SIMPLE);
+                        mOptions[index].SetContextIndex(RO_INTERIOR_ENTRANCE_SHUFFLE_SIMPLE);
                     } else if (it.value() == "All") {
-                        mOptions[index].SetSelectedIndex(RO_INTERIOR_ENTRANCE_SHUFFLE_ALL);
+                        mOptions[index].SetContextIndex(RO_INTERIOR_ENTRANCE_SHUFFLE_ALL);
                     }
                     break;
                 case RSK_SHUFFLE_CHEST_MINIGAME:
                     if (it.value() == "Off") {
-                        mOptions[index].SetSelectedIndex(RO_CHEST_GAME_OFF);
+                        mOptions[index].SetContextIndex(RO_CHEST_GAME_OFF);
                     } else if (it.value() == "On (Separate)") {
-                        mOptions[index].SetSelectedIndex(RO_CHEST_GAME_SINGLE_KEYS);
+                        mOptions[index].SetContextIndex(RO_CHEST_GAME_SINGLE_KEYS);
                     } else if (it.value() == "On (Pack)") {
-                        mOptions[index].SetSelectedIndex(RO_CHEST_GAME_PACK);
+                        mOptions[index].SetContextIndex(RO_CHEST_GAME_PACK);
                     }
                     break;
                 case RSK_MQ_DEKU_TREE:
@@ -3166,11 +3169,11 @@ void Settings::ParseJson(nlohmann::json spoilerFileJson) {
                 case RSK_MQ_GTG:
                 case RSK_MQ_GANONS_CASTLE:
                     if (it.value() == "Vanilla") {
-                        mOptions[index].SetSelectedIndex(RO_MQ_SET_VANILLA);
+                        mOptions[index].SetContextIndex(RO_MQ_SET_VANILLA);
                     } else if (it.value() == "Master Quest") {
-                        mOptions[index].SetSelectedIndex(RO_MQ_SET_MQ);
+                        mOptions[index].SetContextIndex(RO_MQ_SET_MQ);
                     } else if (it.value() == "Random") {
-                        mOptions[index].SetSelectedIndex(RO_MQ_SET_RANDOM);
+                        mOptions[index].SetContextIndex(RO_MQ_SET_RANDOM);
                     }
                     break;
                 default:
@@ -3186,13 +3189,13 @@ void Settings::ParseJson(nlohmann::json spoilerFileJson) {
     ctx->AddExcludedOptions();
     for (auto it = jsonExcludedLocations.begin(); it != jsonExcludedLocations.end(); ++it) {
         const RandomizerCheck rc = Rando::StaticData::locationNameToEnum[it.value()];
-        ctx->GetItemLocation(rc)->GetExcludedOption()->SetSelectedIndex(RO_GENERIC_ON);
+        ctx->GetItemLocation(rc)->GetExcludedOption()->SetContextIndex(RO_GENERIC_ON);
     }
 
     nlohmann::json enabledTricksJson = spoilerFileJson["enabledTricks"];
     for (auto it = enabledTricksJson.begin(); it != enabledTricksJson.end(); ++it) {
         const RandomizerTrick rt = mTrickNameToEnum[it.value()];
-        GetTrickOption(rt).SetSelectedIndex(RO_GENERIC_ON);
+        GetTrickOption(rt).SetContextIndex(RO_GENERIC_ON);
     }
 }
 

--- a/soh/soh/Enhancements/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.cpp
@@ -38,7 +38,7 @@ extern int32_t D_8011D3AC;
 extern void func_80AF36EC(EnRu2* enRu2, PlayState* play);
 }
 
-#define RAND_GET_OPTION(option) Rando::Context::GetInstance()->GetOption(option).GetSelectedOptionIndex()
+#define RAND_GET_OPTION(option) Rando::Context::GetInstance()->GetOption(option).GetContextOptionIndex()
 
 void EnMa1_EndTeachSong(EnMa1* enMa1, PlayState* play) {
     if (Message_GetState(&gPlayState->msgCtx) == TEXT_STATE_CLOSING) {

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -1919,7 +1919,7 @@ extern "C" u32 SpoilerFileExists(const char* spoilerFileName) {
 }
 
 extern "C" u8 Randomizer_GetSettingValue(RandomizerSettingKey randoSettingKey) {
-    return OTRGlobals::Instance->gRandoContext->GetOption(randoSettingKey).GetSelectedOptionIndex();
+    return OTRGlobals::Instance->gRandoContext->GetOption(randoSettingKey).GetContextOptionIndex();
 }
 
 extern "C" RandomizerCheck Randomizer_GetCheckFromActor(s16 actorId, s16 sceneNum, s16 actorParams) {

--- a/soh/soh/SaveManager.cpp
+++ b/soh/soh/SaveManager.cpp
@@ -180,7 +180,7 @@ void SaveManager::LoadRandomizerVersion1() {
         int key, value;
         SaveManager::Instance->LoadData("sk" + std::to_string(i), key);
         SaveManager::Instance->LoadData("sv" + std::to_string(i), value);
-        randoContext->GetOption(RandomizerSettingKey(key)).SetSelectedIndex(value);
+        randoContext->GetOption(RandomizerSettingKey(key)).SetContextIndex(value);
     }
 
     for (int i = 0; i < 50; i++) {
@@ -286,7 +286,7 @@ void SaveManager::LoadRandomizerVersion2() {
     SaveManager::Instance->LoadArray("randoSettings", RSK_MAX, [&](size_t i) {
         int value = 0;
         SaveManager::Instance->LoadData("", value);
-        randoContext->GetOption(RandomizerSettingKey(i)).SetSelectedIndex(value);
+        randoContext->GetOption(RandomizerSettingKey(i)).SetContextIndex(value);
     });
 
     SaveManager::Instance->LoadArray("hintLocations", RH_ZR_OPEN_GROTTO_GOSSIP_STONE + 1, [&](size_t i) {
@@ -435,7 +435,7 @@ void SaveManager::LoadRandomizerVersion3() {
     SaveManager::Instance->LoadArray("randoSettings", RSK_MAX, [&](size_t i) {
         int value = 0;
         SaveManager::Instance->LoadData("", value);
-        randoContext->GetOption(RandomizerSettingKey(i)).SetSelectedIndex(value);
+        randoContext->GetOption(RandomizerSettingKey(i)).SetContextIndex(value);
     });
 
     SaveManager::Instance->LoadArray("hintLocations", RH_MAX, [&](size_t i) {
@@ -464,7 +464,7 @@ void SaveManager::LoadRandomizerVersion3() {
     });
 
     randoContext->GetTrials()->SkipAll();
-    SaveManager::Instance->LoadArray("requiredTrials", randoContext->GetOption(RSK_TRIAL_COUNT).GetSelectedOptionIndex()+1, [&](size_t i) {
+    SaveManager::Instance->LoadArray("requiredTrials", randoContext->GetOption(RSK_TRIAL_COUNT).GetContextOptionIndex() + 1, [&](size_t i) {
         size_t trialId;
         SaveManager::Instance->LoadData("", trialId);
         randoContext->GetTrial(trialId)->SetAsRequired();
@@ -513,7 +513,7 @@ void SaveManager::SaveRandomizer(SaveContext* saveContext, int sectionID, bool f
     SaveManager::Instance->SaveData("finalSeed", randoContext->GetSettings()->GetSeed());
 
     SaveManager::Instance->SaveArray("randoSettings", RSK_MAX, [&](size_t i) {
-        SaveManager::Instance->SaveData("", randoContext->GetOption((RandomizerSettingKey(i))).GetSelectedOptionIndex());
+        SaveManager::Instance->SaveData("", randoContext->GetOption((RandomizerSettingKey(i))).GetContextOptionIndex());
     });
 
     SaveManager::Instance->SaveArray("hintLocations", RH_MAX, [&](size_t i) {


### PR DESCRIPTION
Somewhere along the way, things started crossing scope in the Settings and Options where changes in the rando settings window mid-save would affect how things were operating, and changes from loading spoilers and the like were reflected in the menu. This PR decouples the Settings into two values, `contextSelection` and `menuSelection`. Presets and the settings window now operate on `menuSelection`, and generation, spoiler loading and in-game settings are handled with `contextSelection`. Since generation was already disabled mid-save, and spoiler parsing doesn't happen outside of File Select, this was all that was needed to finish the process of preventing context setting modification.

There was talk of having arrays of values separate (and also separating out static data of Options) so that multiple instances of Settings could be held, but the way things work was too integrated with name, cvar, etc, being part of Option, and those would have been part of a static structure that would have been difficult to rework those references, so I decided on this way instead.

I believe this fixes #4541 and #4542, as well as the problem exemplified by loading a save without warp song hints, then applying a preset which had them enabled.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2255606823.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2255612678.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2255651896.zip)
<!--- section:artifacts:end -->