### PR TITLE
Fix Fishsanity Pond Fish Multigive

### DIFF
--- a/soh/soh/Enhancements/randomizer/fishsanity.h
+++ b/soh/soh/Enhancements/randomizer/fishsanity.h
@@ -134,11 +134,6 @@ class Fishsanity {
     static void OnActorInitHandler(void* refActor);
 
     /**
-     * @brief FlagSet hook handler for fishsanity
-    */
-    static void OnFlagSetHandler(int16_t flagType, int16_t flag);
-
-    /**
      * @brief PlayerUpdate hook handler for fishsanity
     */
     static void OnPlayerUpdateHandler();
@@ -157,6 +152,8 @@ class Fishsanity {
      * @brief VB hook handler for fishsanity
     */
     static void OnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_list originalArgs);
+
+    static void OnItemReceiveHandler(GetItemEntry itemEntry);
 
   private:
     /**
@@ -184,6 +181,7 @@ class Fishsanity {
     static bool fishsanityHelpersInit;
 
     static s16 fishGroupCounter;
+    static bool enableAdvance;
 
     /////////////////////////////////////////////////////////
     //// Helper data structures derived from static data ////

--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -2119,10 +2119,10 @@ void RandomizerRegisterHooks() {
     static uint32_t onKaleidoUpdateHook = 0;
 
     static uint32_t fishsanityOnActorInitHook = 0;
-    static uint32_t fishsanityOnFlagSetHook = 0;
     static uint32_t fishsanityOnActorUpdateHook = 0;
     static uint32_t fishsanityOnSceneInitHook = 0;
     static uint32_t fishsanityOnVanillaBehaviorHook = 0;
+    static uint32_t fishsanityOnItemReceiveHook = 0;
 
     GameInteractor::Instance->RegisterGameHook<GameInteractor::OnLoadGame>([](int32_t fileNum) {
         randomizerQueuedChecks = std::queue<RandomizerCheck>();
@@ -2146,10 +2146,10 @@ void RandomizerRegisterHooks() {
         GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnKaleidoscopeUpdate>(onKaleidoUpdateHook);
 
         GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnActorInit>(fishsanityOnActorInitHook);
-        GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnFlagSet>(fishsanityOnFlagSetHook);
         GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnActorUpdate>(fishsanityOnActorUpdateHook);
         GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnSceneInit>(fishsanityOnSceneInitHook);
         GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnVanillaBehavior>(fishsanityOnVanillaBehaviorHook);
+        GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnItemReceive>(fishsanityOnItemReceiveHook);
 
         onFlagSetHook = 0;
         onSceneFlagSetHook = 0;
@@ -2168,10 +2168,10 @@ void RandomizerRegisterHooks() {
         onKaleidoUpdateHook = 0;
 
         fishsanityOnActorInitHook = 0;
-        fishsanityOnFlagSetHook = 0;
         fishsanityOnActorUpdateHook = 0;
         fishsanityOnSceneInitHook = 0;
         fishsanityOnVanillaBehaviorHook = 0;
+        fishsanityOnItemReceiveHook = 0;
 
         if (!IS_RANDO) return;
 
@@ -2203,10 +2203,10 @@ void RandomizerRegisterHooks() {
             OTRGlobals::Instance->gRandoContext->GetFishsanity()->InitializeFromSave();
 
             fishsanityOnActorInitHook = GameInteractor::Instance->RegisterGameHook<GameInteractor::OnActorInit>(Rando::Fishsanity::OnActorInitHandler);
-            fishsanityOnFlagSetHook = GameInteractor::Instance->RegisterGameHook<GameInteractor::OnFlagSet>(Rando::Fishsanity::OnFlagSetHandler);
             fishsanityOnActorUpdateHook = GameInteractor::Instance->RegisterGameHook<GameInteractor::OnActorUpdate>(Rando::Fishsanity::OnActorUpdateHandler);
             fishsanityOnSceneInitHook = GameInteractor::Instance->RegisterGameHook<GameInteractor::OnSceneInit>(Rando::Fishsanity::OnSceneInitHandler);
             fishsanityOnVanillaBehaviorHook = GameInteractor::Instance->RegisterGameHook<GameInteractor::OnVanillaBehavior>(Rando::Fishsanity::OnVanillaBehaviorHandler);
+            fishsanityOnItemReceiveHook = GameInteractor::Instance->RegisterGameHook<GameInteractor::OnItemReceive>(Rando::Fishsanity::OnItemReceiveHandler);
         }
     });
 }


### PR DESCRIPTION
With the way it was setup, catching a fish would trigger a flag set, which would advance the pond in the same frame, and the actor update was only checking for fish state, so it would set a flag and advance the pond every frame. This removed the flag set handler and replaced it with an OnItemReceive hook. A variable to advance the pond gets set when the pond fish flag gets set, and when that flag's item is received, the advance actually happens. This makes each catch only give one item again.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2237049235.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2237049879.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2237051358.zip)
<!--- section:artifacts:end -->