### PR TITLE
Fishing Pond Traps

### DIFF
--- a/soh/soh/Enhancements/mods.cpp
+++ b/soh/soh/Enhancements/mods.cpp
@@ -1036,6 +1036,9 @@ std::vector<AltTrapType> getEnabledAddTraps () {
     std::vector<AltTrapType> enabledAddTraps;
     for (int i = 0; i < ADD_TRAP_MAX; i++) {
         if (CVarGetInteger(altTrapTypeCvars[i], 0)) {
+            if (gSaveContext.equips.buttonItems[0] == ITEM_FISHING_POLE && (i == ADD_VOID_TRAP || i == ADD_TELEPORT_TRAP)) {
+                continue; // don't add void or teleport if you're holding the fishing pole, as this causes issues
+            }
             enabledAddTraps.push_back(static_cast<AltTrapType>(i));
         }
     }


### PR DESCRIPTION
Prevent void and teleport traps from being added to the shuffle pool while fishing in the pond (checks for holding fishing pole).

Resolves #4525

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2241776756.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2241779049.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2241784300.zip)
<!--- section:artifacts:end -->