### PR TITLE
Fix text Poeverflow on Poes hint

### DIFF
--- a/soh/soh/Enhancements/custom-message/CustomMessageManager.h
+++ b/soh/soh/Enhancements/custom-message/CustomMessageManager.h
@@ -179,6 +179,12 @@ class CustomMessage {
     void FormatString(std::string& str) const;
     
     /**
+     * @brief finds NEWLINEs in a string, while filtering
+     * /x01's that are used as opperands
+     */
+    size_t FindNEWLINE(std::string& str, size_t lastNewline) const;
+    
+    /**
      * @brief formats the string specifically to fit in OoT's 
      * textboxes, and use it's formatting.
      * RANDOTODO whoever knows exactly what this does check my adaption


### PR DESCRIPTION
fixes #4589 . This implements checks for the various control characters with operands to Auto-format to not consider /x01's there newlines.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2255637144.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2255639441.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2255678774.zip)
<!--- section:artifacts:end -->