### PR TITLE
Skip Shadow Statue Cutscene

### DIFF
--- a/soh/soh/Enhancements/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.cpp
@@ -112,6 +112,8 @@ void RateLimitedSuccessChime() {
 }
 
 bool ForcedDialogIsDisabled(ForcedDialogMode type) {
+    auto test = CVarGetInteger(CVAR_ENHANCEMENT("TimeSavers.SkipForcedDialog"),0);
+    auto test2 = test & type;
     return (CVarGetInteger(CVAR_ENHANCEMENT("TimeSavers.SkipForcedDialog"),
                            IS_RANDO ? FORCED_DIALOG_SKIP_ALL : FORCED_DIALOG_SKIP_NONE) &
             type) != 0;
@@ -289,7 +291,8 @@ void TimeSaverOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_li
                     case ACTOR_BG_HIDAN_FWBIG:
                     case ACTOR_EN_EX_ITEM:
                     case ACTOR_EN_DNT_NOMAL:
-                    case ACTOR_EN_DNT_DEMO: {
+                    case ACTOR_EN_DNT_DEMO:
+                    case ACTOR_BG_HAKA_ZOU: {
                         *should = false;
                         break;
                     }

--- a/soh/soh/Enhancements/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.cpp
@@ -112,8 +112,6 @@ void RateLimitedSuccessChime() {
 }
 
 bool ForcedDialogIsDisabled(ForcedDialogMode type) {
-    auto test = CVarGetInteger(CVAR_ENHANCEMENT("TimeSavers.SkipForcedDialog"),0);
-    auto test2 = test & type;
     return (CVarGetInteger(CVAR_ENHANCEMENT("TimeSavers.SkipForcedDialog"),
                            IS_RANDO ? FORCED_DIALOG_SKIP_ALL : FORCED_DIALOG_SKIP_NONE) &
             type) != 0;


### PR DESCRIPTION
fixes #4594 

This is specifically the statue with bomb flowers after the boat and is considered a OnePoint cut-scene.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2269066176.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2269074827.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2269084798.zip)
<!--- section:artifacts:end -->