### PR TITLE
Change GetSelectedOptionText to contextSelection and clean up some junk

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/fill.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/fill.cpp
@@ -856,11 +856,6 @@ static void AssumedFill(const std::vector<RandomizerGet>& items, const std::vect
                 SPDLOG_DEBUG(Rando::StaticData::RetrieveItem(item).GetName().GetEnglish());
                 SPDLOG_DEBUG(". TRYING AGAIN...\n");
 
-#ifdef ENABLE_DEBUG
-                Regions::DumpWorldGraph(Rando::StaticData::RetrieveItem(item).GetName().GetEnglish());
-                PlacementLog_Write();
-#endif
-
                 // reset any locations that got an item
                 for (RandomizerCheck loc : attemptedLocations) {
                     ctx->GetItemLocation(loc)->SetPlacedItem(RG_NONE);

--- a/soh/soh/Enhancements/randomizer/3drando/playthrough.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/playthrough.cpp
@@ -80,14 +80,6 @@ int Playthrough_Init(uint32_t seed, std::set<RandomizerCheck> excludedLocations,
             SPDLOG_ERROR("Writing Spoiler Log Failed");
         }
         StopPerformanceTimer(PT_SPOILER_LOG);
-#ifdef ENABLE_DEBUG
-        SPDLOG_INFO("Writing Placement Log...");
-        if (PlacementLog_Write()) {
-            SPDLOG_INFO("Writing Placement Log Done");
-        } else {
-            SPDLOG_ERROR("Writing Placement Log Failed");
-        }
-#endif
     }
 
     ctx->playthroughLocations.clear();

--- a/soh/soh/Enhancements/randomizer/3drando/spoiler_log.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/spoiler_log.cpp
@@ -221,56 +221,20 @@ static void WriteStartingInventory() {
     }
 }
 
-// Writes the enabled tricks to the spoiler log, if there are any.
-static void WriteEnabledTricks(tinyxml2::XMLDocument& spoilerLog) {
-  //auto parentNode = spoilerLog.NewElement("enabled-tricks");
+//Writes the enabled tricks to the spoiler log, if there are any.
+static void WriteEnabledTricks() {
   auto ctx = Rando::Context::GetInstance();
 
   for (const auto& setting : ctx->GetSettings()->GetOptionGroup(RSG_TRICKS).GetOptions()) {
-    if (setting->GetContextOptionIndex() != RO_GENERIC_ON/* || !setting->IsCategory(OptionCategory::Setting)*/) {
+    if (setting->GetContextOptionIndex() != RO_GENERIC_ON) {
       continue;
     }
     jsonData["enabledTricks"].push_back(RemoveLineBreaks(setting->GetName()).c_str());
-    //auto node = parentNode->InsertNewChildElement("trick");
-    //node->SetAttribute("name", RemoveLineBreaks(setting->GetName()).c_str());
   }
-
-  // if (!parentNode->NoChildren()) {
-  //  spoilerLog.RootElement()->InsertEndChild(parentNode);
-  //}
 }
 
-// Writes the enabled glitches to the spoiler log, if there are any.
-// TODO: Implement Glitches
-// static void WriteEnabledGlitches(tinyxml2::XMLDocument& spoilerLog) {
-//   auto parentNode = spoilerLog.NewElement("enabled-glitches");
-
-//   for (const auto& setting : Settings::glitchCategories) {
-//     if (setting->Value<uint8_t>() == 0) {
-//       continue;
-//     }
-
-//     auto node = parentNode->InsertNewChildElement("glitch-category");
-//     node->SetAttribute("name", setting->GetName().c_str());
-//     node->SetText(setting->GetSelectedOptionText().c_str());
-//   }
-
-//   for (const auto& setting : Settings::miscGlitches) {
-//     if (!setting->Value<bool>()) {
-//       continue;
-//     }
-
-//     auto node = parentNode->InsertNewChildElement("misc-glitch");
-//     node->SetAttribute("name", RemoveLineBreaks(setting->GetName()).c_str());
-//   }
-
-//   if (!parentNode->NoChildren()) {
-//     spoilerLog.RootElement()->InsertEndChild(parentNode);
-//   }
-// }
-
 // Writes the Master Quest dungeons to the spoiler log, if there are any.
-static void WriteMasterQuestDungeons(tinyxml2::XMLDocument& spoilerLog) {
+static void WriteMasterQuestDungeons() {
     auto ctx = Rando::Context::GetInstance();
     for (const auto* dungeon : ctx->GetDungeons()->GetDungeonList()) {
         std::string dungeonName;
@@ -389,11 +353,6 @@ static void WriteAllLocations() {
 
 const char* SpoilerLog_Write() {
     auto ctx = Rando::Context::GetInstance();
-    auto spoilerLog = tinyxml2::XMLDocument(false);
-    spoilerLog.InsertEndChild(spoilerLog.NewDeclaration());
-
-    auto rootNode = spoilerLog.NewElement("spoiler-log");
-    spoilerLog.InsertEndChild(rootNode);
 
     jsonData.clear();
 
@@ -413,11 +372,8 @@ const char* SpoilerLog_Write() {
     WriteSettings();
     WriteExcludedLocations();
     WriteStartingInventory();
-    WriteEnabledTricks(spoilerLog); //RANDOTODO clean up spoilerLog refernces
-    //if (Settings::Logic.Is(LOGIC_GLITCHED)) {
-    //    WriteEnabledGlitches(spoilerLog);
-    //}
-    WriteMasterQuestDungeons(spoilerLog);
+    WriteEnabledTricks(); 
+    WriteMasterQuestDungeons();
     WriteRequiredTrials();
     WritePlaythrough();
 
@@ -466,30 +422,3 @@ void PlacementLog_Clear() {
     placementtxt = "";
 }
 
-// RANDOTODO: Do we even use this?
-bool PlacementLog_Write() {
-    auto placementLog = tinyxml2::XMLDocument(false);
-    placementLog.InsertEndChild(placementLog.NewDeclaration());
-
-    auto rootNode = placementLog.NewElement("placement-log");
-    placementLog.InsertEndChild(rootNode);
-
-    // rootNode->SetAttribute("version", Settings::version.c_str());
-    // rootNode->SetAttribute("seed", Settings::seed);
-
-    // WriteSettings(placementLog, true); // Include hidden settings.
-    // WriteExcludedLocations(placementLog);
-    // WriteStartingInventory(placementLog);
-    WriteEnabledTricks(placementLog);
-    //WriteEnabledGlitches(placementLog);
-    WriteMasterQuestDungeons(placementLog);
-    //WriteRequiredTrials(placementLog);
-
-    placementtxt = "\n" + placementtxt;
-
-    auto node = rootNode->InsertNewChildElement("log");
-    auto contentNode = node->InsertNewText(placementtxt.c_str());
-    contentNode->SetCData(true);
-
-    return true;
-}

--- a/soh/soh/Enhancements/randomizer/3drando/spoiler_log.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/spoiler_log.cpp
@@ -6,7 +6,6 @@
 #include "../entrance.h"
 #include "random.hpp"
 #include "../trial.h"
-#include "tinyxml2.h"
 #include "utils.hpp"
 #include "hints.hpp"
 #include "pool_functions.hpp"
@@ -56,9 +55,6 @@ void GenerateHash() {
         int number = std::stoi(hash.substr(j, 2));
         ctx->hashIconIndexes[i] = number;
     }
-
-    // Clear out spoiler log data here, in case we aren't going to re-generate it
-    // spoilerData = { 0 };
 }
 
 static auto GetGeneralPath() {
@@ -79,7 +75,6 @@ static void WriteLocation(
   Rando::Location* location = Rando::StaticData::GetLocation(locationKey);
   Rando::ItemLocation* itemLocation = Rando::Context::GetInstance()->GetItemLocation(locationKey);
 
-  // auto node = parentNode->InsertNewChildElement("location");
   switch (gSaveContext.language) {
         case LANGUAGE_ENG:
         default:
@@ -89,35 +84,6 @@ static void WriteLocation(
             jsonData["playthrough"][sphere][location->GetName()] = itemLocation->GetPlacedItemName().GetFrench();
             break;
     }
-  // node->SetAttribute("name", location->GetName().c_str());
-  // node->SetText(location->GetPlacedItemName().GetEnglish().c_str());
-
-  // if (withPadding) {
-  //   constexpr int16_t LONGEST_NAME = 56; // The longest name of a location.
-  //   constexpr int16_t PRICE_ATTRIBUTE = 12; // Length of a 3-digit price attribute.
-
-  //   // Insert a padding so we get a kind of table in the XML document.
-  //   int16_t requiredPadding = LONGEST_NAME - location->GetName().length();
-  //   if (location->GetRCType() == RCTYPE_SHOP) {
-  //     // Shop items have short location names, but come with an additional price attribute.
-  //     requiredPadding -= PRICE_ATTRIBUTE;
-  //   }
-  //   if (requiredPadding >= 0) {
-  //     std::string padding(requiredPadding, ' ');
-  //     node->SetAttribute("_", padding.c_str());
-  //   }
-  // }
-
-  // if (location->GetRCType() == RCTYPE_SHOP) {
-  //   char price[6];
-  //   sprintf(price, "%03d", location->GetPrice());
-  //   node->SetAttribute("price", price);
-  // }
-  // if (!location->IsAddedToPool()) {
-  //   #ifdef ENABLE_DEBUG
-  //     node->SetAttribute("not-added", true);
-  //   #endif
-  // }
 }
 
 //Writes a shuffled entrance to the specified node
@@ -186,7 +152,6 @@ static void WriteSettings() {
 
 // Writes the excluded locations to the spoiler log, if there are any.
 static void WriteExcludedLocations() {
-  // auto parentNode = spoilerLog.NewElement("excluded-locations");
   auto ctx = Rando::Context::GetInstance();
 
   for (size_t i = 1; i < ctx->GetSettings()->GetExcludeLocationsOptions().size(); i++) {
@@ -197,15 +162,8 @@ static void WriteExcludedLocations() {
 
       jsonData["excludedLocations"].push_back(RemoveLineBreaks(location->GetName()));
 
-      // tinyxml2::XMLElement* node = spoilerLog.NewElement("location");
-      // node->SetAttribute("name", RemoveLineBreaks(location->GetName()).c_str());
-      // parentNode->InsertEndChild(node);
     }
   }
-
-  // if (!parentNode->NoChildren()) {
-  //   spoilerLog.RootElement()->InsertEndChild(parentNode);
-  // }
 }
 
 // Writes the starting inventory to the spoiler log, if there is any.
@@ -258,7 +216,6 @@ static void WriteRequiredTrials() {
 
 // Writes the intended playthrough to the spoiler log, separated into spheres.
 static void WritePlaythrough() {
-  // auto playthroughNode = spoilerLog.NewElement("playthrough");
   auto ctx = Rando::Context::GetInstance();
 
   for (uint32_t i = 0; i < ctx->playthroughLocations.size(); ++i) {
@@ -270,8 +227,6 @@ static void WritePlaythrough() {
       WriteLocation(sphereString, key, true);
     }
   }
-
-  // spoilerLog.RootElement()->InsertEndChild(playthroughNode);
 }
 
 //Write the randomized entrance playthrough to the spoiler log, if applicable

--- a/soh/soh/Enhancements/randomizer/entrance.cpp
+++ b/soh/soh/Enhancements/randomizer/entrance.cpp
@@ -672,11 +672,6 @@ bool EntranceShuffler::PlaceOneWayPriorityEntrance(
             }
         }
     }
-#ifdef ENABLE_DEBUG
-    auto message = "ERROR: Unable to place priority one-way entrance for " + priorityName + "\n";
-    SPDLOG_DEBUG(message);
-    PlacementLog_Write();
-#endif
     return false;
 }
 

--- a/soh/soh/Enhancements/randomizer/entrance.cpp
+++ b/soh/soh/Enhancements/randomizer/entrance.cpp
@@ -672,6 +672,8 @@ bool EntranceShuffler::PlaceOneWayPriorityEntrance(
             }
         }
     }
+    SPDLOG_DEBUG("ERROR: Unable to place priority one-way entrance for " + priorityName + "\n");
+    assert(false);
     return false;
 }
 

--- a/soh/soh/Enhancements/randomizer/option.cpp
+++ b/soh/soh/Enhancements/randomizer/option.cpp
@@ -55,7 +55,7 @@ uint8_t Option::GetContextOptionIndex() const {
 }
 
 const std::string& Option::GetSelectedOptionText() const {
-    return options[menuSelection];
+    return options[contextSelection];
 }
 
 const std::string& Option::GetCVarName() const {
@@ -184,7 +184,7 @@ Option::Option(uint8_t var_, std::string name_, std::vector<std::string> options
     : var(var_), name(std::move(name_)), options(std::move(options_)), category(category_),
       cvarName(std::move(cvarName_)), description(std::move(description_)), widgetType(widgetType_),
       defaultOption(defaultOption_), defaultHidden(defaultHidden_), imFlags(imFlags_) {
-    menuSelection = contextSelection =  defaultOption;
+    menuSelection = contextSelection = defaultOption;
     hidden = defaultHidden;
     SetFromCVar();
 }


### PR DESCRIPTION
When writing to the spoiler log, GetSelectedOptionText was used to write the text in. Because GetSelectedOptionText called the menuSelection it was not applying any changes made during FinalizeSettings, which writes to contextSelection, causing erroneous spoiler logs which may have caused mismatches on read or at the very least was confusing for readers. This PR corrects that issue

Additionally I cleaned up some old 3DS spoiler log code, removing references to unused xml objects.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2270268223.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2270282799.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2270303394.zip)
<!--- section:artifacts:end -->