### PR TITLE
Fix display list offset values and unhandled opcodes

### DIFF
--- a/soh/src/overlays/actors/ovl_Bg_Toki_Hikari/z_bg_toki_hikari.c
+++ b/soh/src/overlays/actors/ovl_Bg_Toki_Hikari/z_bg_toki_hikari.c
@@ -179,7 +179,8 @@ void func_808BA2CC(BgTokiHikari* this, PlayState* play) {
     gSPMatrix(POLY_XLU_DISP++, MATRIX_NEWMTX(play->state.gfxCtx),
               G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
 
-    gSPDisplayListOffset(POLY_XLU_DISP++, object_toki_objects_DL_0009C0, 10);
+    // SOH [Port] Index adjust 11 -> 14 (for LUS marker and gsSPVertex) to account for our extraction size changes
+    gSPDisplayListOffset(POLY_XLU_DISP++, object_toki_objects_DL_0009C0, 10 + 2 + 1);
     Matrix_Pop();
     CLOSE_DISPS(play->state.gfxCtx);
 }

--- a/soh/src/overlays/actors/ovl_En_Box/z_en_box.c
+++ b/soh/src/overlays/actors/ovl_En_Box/z_en_box.c
@@ -737,6 +737,8 @@ void EnBox_CreateExtraChestTextures() {
         gsDPSetTextureImage(G_IM_FMT_RGBA, G_IM_SIZ_16b, 1, gChristmasGreenTreasureChestSideAndTopTex),
     };
 
+    Gfx gNoOp[] = { gsDPNoOp() };
+
     Gfx* frontCmd = ResourceMgr_LoadGfxByName(gTreasureChestChestFrontDL);
     int frontIndex = 0;
     while (frontCmd->words.w0 >> 24 != G_ENDDL) {
@@ -745,6 +747,20 @@ void EnBox_CreateExtraChestTextures() {
         gKeyTreasureChestChestFrontDL[frontIndex] = *frontCmd;
         gChristmasRedTreasureChestChestFrontDL[frontIndex] = *frontCmd;
         gChristmasGreenTreasureChestChestFrontDL[frontIndex] = *frontCmd;
+
+        // Set the second instruction of img OTR hash opcode to noop, since we will replace it with the
+        // OTR filepath opcode below
+        if (frontCmd->words.w0 >> 24 == G_SETTIMG_OTR_HASH) {
+            frontIndex++;
+            ++frontCmd;
+
+            gSkullTreasureChestChestFrontDL[frontIndex] = gNoOp[0];
+            gGoldTreasureChestChestFrontDL[frontIndex] = gNoOp[0];
+            gKeyTreasureChestChestFrontDL[frontIndex] = gNoOp[0];
+            gChristmasRedTreasureChestChestFrontDL[frontIndex] = gNoOp[0];
+            gChristmasGreenTreasureChestChestFrontDL[frontIndex] = gNoOp[0];
+        }
+
         frontIndex++;
         ++frontCmd;
     }
@@ -783,6 +799,20 @@ void EnBox_CreateExtraChestTextures() {
         gKeyTreasureChestChestSideAndLidDL[sideIndex] = *sideCmd;
         gChristmasRedTreasureChestChestSideAndLidDL[sideIndex] = *sideCmd;
         gChristmasGreenTreasureChestChestSideAndLidDL[sideIndex] = *sideCmd;
+
+        // Set the second instruction of img OTR hash opcode to noop, since we will replace it with the
+        // OTR filepath opcode below
+        if (sideCmd->words.w0 >> 24 == G_SETTIMG_OTR_HASH) {
+            sideIndex++;
+            ++sideCmd;
+
+            gSkullTreasureChestChestSideAndLidDL[sideIndex] = gNoOp[0];
+            gGoldTreasureChestChestSideAndLidDL[sideIndex] = gNoOp[0];
+            gKeyTreasureChestChestSideAndLidDL[sideIndex] = gNoOp[0];
+            gChristmasRedTreasureChestChestSideAndLidDL[sideIndex] = gNoOp[0];
+            gChristmasGreenTreasureChestChestSideAndLidDL[sideIndex] = gNoOp[0];
+        }
+
         sideIndex++;
         ++sideCmd;
     }

--- a/soh/src/overlays/actors/ovl_Oceff_Wipe4/z_oceff_wipe4.c
+++ b/soh/src/overlays/actors/ovl_Oceff_Wipe4/z_oceff_wipe4.c
@@ -108,7 +108,8 @@ void OceffWipe4_Draw(Actor* thisx, PlayState* play) {
     gSPDisplayList(POLY_XLU_DISP++, sMaterial2DL);
     gSPDisplayList(POLY_XLU_DISP++, Gfx_TwoTexScroll(play->state.gfxCtx, 0, scroll * 2, scroll * (-2), 32, 64, 1,
                                                      scroll * (-1), scroll, 32, 32));
-    gSPDisplayListOffset(POLY_XLU_DISP++, sMaterial2DL, 11);
+    // SOH [Port] Index adjust 11 -> 14 (for LUS marker and load texture) to account for our extraction size changes
+    gSPDisplayListOffset(POLY_XLU_DISP++, sMaterial2DL, 11 + 2 + 1);
 
     CLOSE_DISPS(play->state.gfxCtx);
 }


### PR DESCRIPTION
There was `Unhandled OP Code: 0x86, for loaded ucode: 2` showing up in the logs when in the Temple of Time. This was due to an instance where the game offsets into a display list. The issue arises because the extracted display lists have additional instructions, causing the original offset to not be accurate anymore.

This updates the two places in the code base to account for additional op code instructions (LUS markers and instructions with OTR hash values).

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2280092825.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2280142946.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2280168309.zip)
<!--- section:artifacts:end -->