### PR TITLE
Fix crash when toggling alt assets while paused

### DIFF
--- a/soh/src/code/z_play.c
+++ b/soh/src/code/z_play.c
@@ -12,6 +12,7 @@
 #include "soh/Enhancements/enhancementTypes.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 #include "soh/OTRGlobals.h"
+#include "soh/ResourceManagerHelpers.h"
 #include "soh/SaveManager.h"
 #include "soh/framebuffer_effects.h"
 
@@ -1327,15 +1328,16 @@ void Play_Draw(PlayState* play) {
     // Track render size when paused and that a copy was performed
     static u32 lastPauseWidth;
     static u32 lastPauseHeight;
-    static u8 hasCapturedPauseBuffer;
-    u8 recapturePauseBuffer = false;
+    static bool lastAltAssets;
+    static bool hasCapturedPauseBuffer;
+    bool recapturePauseBuffer = false;
 
-    // If the size has changed or dropped frames leading to the buffer not being copied,
+    // If the size has changed, alt assets toggled, or dropped frames leading to the buffer not being copied,
     // set the prerender state back to setup to copy a new frame.
-    // This requires not rendering kaleido during this copy to avoid kaleido being copied
+    // This requires not rendering kaleido during this copy to avoid kaleido itself being copied too.
     if ((R_PAUSE_MENU_MODE == 2 || R_PAUSE_MENU_MODE == 3) &&
         (lastPauseWidth != OTRGetGameRenderWidth() || lastPauseHeight != OTRGetGameRenderHeight() ||
-         !hasCapturedPauseBuffer)) {
+         lastAltAssets != ResourceMgr_IsAltAssetsEnabled() || !hasCapturedPauseBuffer)) {
         R_PAUSE_MENU_MODE = 1;
         recapturePauseBuffer = true;
     }
@@ -1594,6 +1596,7 @@ void Play_Draw(PlayState* play) {
                 // #region SOH [Port] Custom handling for pause prerender background capture
                 lastPauseWidth = OTRGetGameRenderWidth();
                 lastPauseHeight = OTRGetGameRenderHeight();
+                lastAltAssets = ResourceMgr_IsAltAssetsEnabled();
                 hasCapturedPauseBuffer = false;
 
                 FB_CopyToFramebuffer(&gfxP, 0, gPauseFrameBuffer, false, &hasCapturedPauseBuffer);


### PR DESCRIPTION
This fixes a crash identified in 2ship https://github.com/HarbourMasters/2ship2harkinian/pull/839 when toggling alt assets while the pause menu is up.

The fix checks when alt assets get toggled, and when it does, force a new pause menu background to be captured. By doing this we render the game world for one frame, which will leave the render state in a "good" state for the framebuffer draw to rely on. This has the added benefit of having the pause menu background "update" for any new textures applied by alt toggling.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2281350066.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2281351437.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2281352767.zip)
<!--- section:artifacts:end -->