### PR TITLE
Skip fire arrow spawn cutscene after shooting sun

### DIFF
--- a/soh/soh/Enhancements/game-interactor/GameInteractor.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor.h
@@ -344,6 +344,8 @@ typedef enum {
     VB_PLAY_RAINBOW_BRIDGE_CS,
     // Opt: *EnBox
     VB_PLAY_SLOW_CHEST_CS,
+    // Opt: *ShotSun
+    VB_PLAY_FIRE_ARROW_CS,
     //*Opt f32 sFishOnHandLength
     // Vanilla condition: (s16)sFishingRecordLength < (s16)sFishOnHandLength
     VB_SHOULD_CHECK_FOR_FISHING_RECORD,

--- a/soh/soh/Enhancements/game-interactor/GameInteractor.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor.h
@@ -302,6 +302,7 @@ typedef enum {
     /*** Play Cutscenes ***/
 
     VB_PLAY_TRANSITION_CS,
+    VB_PLAY_GORON_FREE_CS,
     VB_PLAY_FIRE_ARROW_CS,
     // Vanilla condition: INV_CONTENT(ITEM_ARROW_FIRE) == ITEM_NONE
     VB_SPAWN_FIRE_ARROW,
@@ -332,8 +333,6 @@ typedef enum {
     VB_PLAY_BOLERO_OF_FIRE_CS,
     VB_PLAY_SERENADE_OF_WATER_CS,
     VB_PLAY_EYEDROPS_CS,
-    // Opt: *EnGo2
-    VB_PLAY_GORON_FREE_CS,
     // Opt: *EnOkarinaTag
     VB_PLAY_DRAIN_WELL_CS,
     // Opt: *EnOkarinaTag
@@ -374,6 +373,7 @@ typedef enum {
 
     /*** Give Items ***/
 
+    VB_FREEZE_ON_SKULL_TOKEN,
     // Opt: *EnBox
     VB_GIVE_ITEM_FROM_CHEST,
     // Opt: ItemID
@@ -382,7 +382,6 @@ typedef enum {
     VB_GIVE_ITEM_FROM_ITEM_00,
     // Opt: *EnSi
     VB_GIVE_ITEM_SKULL_TOKEN,
-    VB_FREEZE_ON_SKULL_TOKEN,
     // Opt: *EnCow
     VB_GIVE_ITEM_FROM_COW,
     // Opt: *EnDns

--- a/soh/soh/Enhancements/game-interactor/GameInteractor.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor.h
@@ -346,6 +346,7 @@ typedef enum {
     VB_PLAY_SLOW_CHEST_CS,
     // Opt: *ShotSun
     VB_PLAY_FIRE_ARROW_CS,
+    VB_SPAWN_FIRE_ARROW,
     //*Opt f32 sFishOnHandLength
     // Vanilla condition: (s16)sFishingRecordLength < (s16)sFishOnHandLength
     VB_SHOULD_CHECK_FOR_FISHING_RECORD,

--- a/soh/soh/Enhancements/game-interactor/GameInteractor.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor.h
@@ -302,6 +302,9 @@ typedef enum {
     /*** Play Cutscenes ***/
 
     VB_PLAY_TRANSITION_CS,
+    VB_PLAY_FIRE_ARROW_CS,
+    // Vanilla condition: INV_CONTENT(ITEM_ARROW_FIRE) == ITEM_NONE
+    VB_SPAWN_FIRE_ARROW,
     // Opt: *EventChkInf flag
     VB_PLAY_ENTRANCE_CS,
     // Opt: *cutsceneId
@@ -344,9 +347,6 @@ typedef enum {
     VB_PLAY_RAINBOW_BRIDGE_CS,
     // Opt: *EnBox
     VB_PLAY_SLOW_CHEST_CS,
-    // Opt: *ShotSun
-    VB_PLAY_FIRE_ARROW_CS,
-    VB_SPAWN_FIRE_ARROW,
     //*Opt f32 sFishOnHandLength
     // Vanilla condition: (s16)sFishingRecordLength < (s16)sFishOnHandLength
     VB_SHOULD_CHECK_FOR_FISHING_RECORD,

--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -800,6 +800,9 @@ void RandomizerOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_l
             *should = false;
             break;
         }
+        case VB_SPAWN_FIRE_ARROW:
+            *should = !Flags_GetTreasure(gPlayState, 0x1F);
+            break;
         case VB_PLAY_NABOORU_CAPTURED_CS:
             // This behavior is replicated for randomizer in RandomizerOnItemReceiveHandler
             *should = false;

--- a/soh/soh/Enhancements/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.cpp
@@ -538,8 +538,6 @@ void TimeSaverOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_li
         case VB_PLAY_FIRE_ARROW_CS: {
             if (CVarGetInteger(CVAR_ENHANCEMENT("TimeSavers.SkipMiscInteractions"), 0)) {
                 *should = false;
-            } else if (IS_RANDO) {
-                *should = !Flags_GetTreasure(gPlayState, 0x1F);
             }
             break;
         }

--- a/soh/soh/Enhancements/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.cpp
@@ -535,6 +535,14 @@ void TimeSaverOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_li
             }
             break;
         }
+        case VB_PLAY_FIRE_ARROW_CS: {
+            if (CVarGetInteger(CVAR_ENHANCEMENT("TimeSavers.SkipMiscInteractions"), 0)) {
+                *should = false;
+            } else if (IS_RANDO) {
+                *should = !Flags_GetTreasure(gPlayState, 0x1F);
+            }
+            break;
+        }
         case VB_GIVE_ITEM_MINUET_OF_FOREST:
         case VB_GIVE_ITEM_BOLERO_OF_FIRE:
         case VB_GIVE_ITEM_SERENADE_OF_WATER:

--- a/soh/src/overlays/actors/ovl_En_Si/z_en_si.c
+++ b/soh/src/overlays/actors/ovl_En_Si/z_en_si.c
@@ -98,7 +98,7 @@ void func_80AFB768(EnSi* this, PlayState* play) {
                 this->collider.base.ocFlags2 &= ~OC2_HIT_PLAYER;
                 if (GameInteractor_Should(VB_GIVE_ITEM_SKULL_TOKEN, true, this)) {
                     Item_Give(play, ITEM_SKULL_TOKEN);
-                    if (GameInteractor_Should(VB_FREEZE_ON_SKULL_TOKEN, true, this)) {
+                    if (GameInteractor_Should(VB_FREEZE_ON_SKULL_TOKEN, true)) {
                         player->actor.freezeTimer = 10;
                     }
                     Message_StartTextbox(play, TEXT_GS_NO_FREEZE, NULL);
@@ -124,7 +124,7 @@ void func_80AFB89C(EnSi* this, PlayState* play) {
     if (!CHECK_FLAG_ALL(this->actor.flags, ACTOR_FLAG_HOOKSHOT_ATTACHED)) {
         if (GameInteractor_Should(VB_GIVE_ITEM_SKULL_TOKEN, true, this)) {
             Item_Give(play, ITEM_SKULL_TOKEN);
-            if (GameInteractor_Should(VB_FREEZE_ON_SKULL_TOKEN, true, this)) {
+            if (GameInteractor_Should(VB_FREEZE_ON_SKULL_TOKEN, true)) {
                 player->actor.freezeTimer = 10;
             }
             Message_StartTextbox(play, TEXT_GS_NO_FREEZE, NULL);
@@ -137,7 +137,7 @@ void func_80AFB89C(EnSi* this, PlayState* play) {
 void func_80AFB950(EnSi* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
 
-    if (Message_GetState(&play->msgCtx) != TEXT_STATE_CLOSING && GameInteractor_Should(VB_FREEZE_ON_SKULL_TOKEN, true, this)) {
+    if (Message_GetState(&play->msgCtx) != TEXT_STATE_CLOSING && GameInteractor_Should(VB_FREEZE_ON_SKULL_TOKEN, true)) {
         player->actor.freezeTimer = 10;
     } else {
         SET_GS_FLAGS((this->actor.params & 0x1F00) >> 8, this->actor.params & 0xFF);

--- a/soh/src/overlays/actors/ovl_Shot_Sun/z_shot_sun.c
+++ b/soh/src/overlays/actors/ovl_Shot_Sun/z_shot_sun.c
@@ -7,6 +7,7 @@
 #include "z_shot_sun.h"
 #include "overlays/actors/ovl_En_Elf/z_en_elf.h"
 #include "scenes/overworld/spot06/spot06_scene.h"
+#include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 #include "vt.h"
 
 #define FLAGS (ACTOR_FLAG_TARGETABLE | ACTOR_FLAG_FRIENDLY)
@@ -162,8 +163,7 @@ void ShotSun_UpdateHyliaSun(ShotSun* this, PlayState* play) {
     if (this->collider.base.acFlags & AC_HIT) {
         Sfx_PlaySfxCentered(NA_SE_SY_CORRECT_CHIME);
         osSyncPrintf(VT_FGCOL(CYAN) "SHOT_SUN HIT!!!!!!!\n" VT_RST);
-        if ((INV_CONTENT(ITEM_ARROW_FIRE) == ITEM_NONE && !IS_RANDO) ||
-            (!Flags_GetTreasure(play, 0x1F) && IS_RANDO)) {
+        if (GameInteractor_Should(VB_PLAY_FIRE_ARROW_CS, INV_CONTENT(ITEM_ARROW_FIRE) == ITEM_NONE, this)) {
             Actor_Spawn(&play->actorCtx, play, ACTOR_ITEM_ETCETERA, 700.0f, -800.0f, 7261.0f, 0, 0, 0, 7, true);
             play->csCtx.segment = SEGMENTED_TO_VIRTUAL(gLakeHyliaFireArrowsCS);
             gSaveContext.cutsceneTrigger = 1;

--- a/soh/src/overlays/actors/ovl_Shot_Sun/z_shot_sun.c
+++ b/soh/src/overlays/actors/ovl_Shot_Sun/z_shot_sun.c
@@ -163,10 +163,12 @@ void ShotSun_UpdateHyliaSun(ShotSun* this, PlayState* play) {
     if (this->collider.base.acFlags & AC_HIT) {
         Sfx_PlaySfxCentered(NA_SE_SY_CORRECT_CHIME);
         osSyncPrintf(VT_FGCOL(CYAN) "SHOT_SUN HIT!!!!!!!\n" VT_RST);
-        if (GameInteractor_Should(VB_PLAY_FIRE_ARROW_CS, INV_CONTENT(ITEM_ARROW_FIRE) == ITEM_NONE, this)) {
+        if (GameInteractor_Should(VB_SPAWN_FIRE_ARROW, INV_CONTENT(ITEM_ARROW_FIRE) == ITEM_NONE)) {
             Actor_Spawn(&play->actorCtx, play, ACTOR_ITEM_ETCETERA, 700.0f, -800.0f, 7261.0f, 0, 0, 0, 7, true);
-            play->csCtx.segment = SEGMENTED_TO_VIRTUAL(gLakeHyliaFireArrowsCS);
-            gSaveContext.cutsceneTrigger = 1;
+            if (GameInteractor_Should(VB_PLAY_FIRE_ARROW_CS, true)) {
+                play->csCtx.segment = SEGMENTED_TO_VIRTUAL(gLakeHyliaFireArrowsCS);
+                gSaveContext.cutsceneTrigger = 1;
+            }
         } else {
             spawnPos.x = 700.0f;
             spawnPos.y = -800.0f;


### PR DESCRIPTION
Fixes #4629

The game doesn't seem to treat it as a one-point cutscene, so I filed it under misc interactions instead. Counter arguments welcome.

As a tangent, I moved the rando check to its own hook.

As another tangent, now that I know the proper system of organization for the VB enum flags, I've reorganized my own flags to follow it.

https://github.com/user-attachments/assets/f5d5f4f6-6591-446a-8d69-291093d9655a

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2319556178.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2319563324.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2319564056.zip)
<!--- section:artifacts:end -->