### PR TITLE
Fix temp flags transferring in dungeon chains and voidouts in mixed entrances

### DIFF
--- a/soh/soh/Enhancements/game-interactor/GameInteractor.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor.h
@@ -281,6 +281,9 @@ typedef enum {
     VB_SPAWN_BLUE_WARP,
     // Vanilla condition: this->warpTimer > sWarpTimerTarget && gSaveContext.nextCutsceneIndex == 0xFFEF
     VB_BLUE_WARP_APPLY_ENTRANCE_AND_CUTSCENE,
+    // Vanilla condition: SurfaceType_GetSlope(&play->colCtx, poly, bgId) == 2
+    // Opt: int (original next entrance index)
+    VB_SET_VOIDOUT_FROM_SURFACE,
     // Vanilla condition: this->collider.base.acFlags & 2
     VB_BG_BREAKWALL_BREAK,
     // Vanilla condition: true

--- a/soh/soh/Enhancements/randomizer/randomizer_entrance.c
+++ b/soh/soh/Enhancements/randomizer/randomizer_entrance.c
@@ -267,13 +267,6 @@ s16 Entrance_PeekNextIndexOverride(int16_t nextEntranceIndex) {
 }
 
 s16 Entrance_OverrideNextIndex(s16 nextEntranceIndex) {
-    // When entering Spirit Temple, clear temp flags so they don't carry over to the randomized dungeon
-    if (nextEntranceIndex == ENTR_SPIRIT_TEMPLE_ENTRANCE && Entrance_GetOverride(nextEntranceIndex) != nextEntranceIndex &&
-        gPlayState != NULL) {
-        gPlayState->actorCtx.flags.tempSwch = 0;
-        gPlayState->actorCtx.flags.tempCollect = 0;
-    }
-
     // Exiting through the crawl space from Hyrule Castle courtyard is the same exit as leaving Ganon's castle
     // Don't override the entrance if we came from the Castle courtyard (day and night scenes)
     if (gPlayState != NULL && (gPlayState->sceneNum == SCENE_CASTLE_COURTYARD_GUARDS_DAY || gPlayState->sceneNum == SCENE_CASTLE_COURTYARD_GUARDS_NIGHT) &&

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -5145,9 +5145,9 @@ s32 Player_HandleExitsAndVoids(PlayState* play, Player* this, CollisionPoly* pol
 
                     Scene_SetTransitionForNextEntrance(play);
                 } else {
-                    // In Entrance rando, if our respawnFlag is set for a grotto return, we don't want the void out to happen
-                    if (SurfaceType_GetSlope(&play->colCtx, poly, bgId) == 2 &&
-                        (!IS_RANDO || (Randomizer_GetSettingValue(RSK_SHUFFLE_ENTRANCES) && gSaveContext.respawnFlag != 2))) {
+                    if (GameInteractor_Should(VB_SET_VOIDOUT_FROM_SURFACE,
+                                              SurfaceType_GetSlope(&play->colCtx, poly, bgId) == 2,
+                                              play->setupExitList[exitIndex - 1])) {
                         gSaveContext.respawn[RESPAWN_MODE_DOWN].entranceIndex = play->nextEntranceIndex;
                         Play_TriggerVoidOut(play);
                         gSaveContext.respawnFlag = -2;


### PR DESCRIPTION
Dungeons have special surfaces on entrance transitions to aid in transferring temp flags from one scene to another.

This is used between dungeons and their boss rooms, and additionally with Spirit Temple hands entrances and main entrance.

We previously had logic to wipe out the temp flags when the spirit temple entrance was randomized, but boss doors wasn't handled, and now with dungeon chains exposes issues where dungeons behind another dungeon would have things impacted by it.

This PR adds a VB should around the special voidout from the surface type. Here we wipe the temp flags if the original entrance does not match the overridden entrance.

Additionally there is a check for if the overridden entrance is a grotto return, so that we can skip the voidout and apply a data flag to prevent dungeon door actors from writing over the grotto return values.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2287178104.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2287180709.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2287182297.zip)
<!--- section:artifacts:end -->