### PR TITLE
Skip Water Temple portcullis opening cutscene

### DIFF
--- a/soh/soh/Enhancements/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.cpp
@@ -306,6 +306,7 @@ void TimeSaverOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_li
                     case ACTOR_BG_YDAN_MARUTA:
                     case ACTOR_BG_SPOT18_SHUTTER:
                     case ACTOR_BG_SPOT05_SOKO:
+                    case ACTOR_BG_SPOT06_OBJECTS:
                     case ACTOR_BG_SPOT18_BASKET:
                     case ACTOR_BG_HIDAN_CURTAIN:
                     case ACTOR_BG_MORI_HINERI:


### PR DESCRIPTION
Fixes #4628

Had to do a cross-fade to make the video size small enough for GitHub. But it should be obvious what's fixed here.

https://github.com/user-attachments/assets/c4402f1d-6fae-43e2-a524-fd3c1d4d3146

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2288251678.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2288252099.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2288252587.zip)
<!--- section:artifacts:end -->