### PR TITLE
Skip one-point cutscene of Amy's blocks falling

### DIFF
--- a/soh/soh/Enhancements/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.cpp
@@ -212,6 +212,7 @@ void TimeSaverOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_li
                 s16* csId = va_arg(args, s16*);
                 BgSpot03Taki* taki = NULL;
                 switch (*csId) {
+                    case 3150:
                     case 4180:
                     case 4100:
                         *should = false;


### PR DESCRIPTION
Fixes #4630

https://github.com/user-attachments/assets/06dedf09-e92c-4311-bf9b-b77f77489314

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2288852997.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2288853744.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2288854524.zip)
<!--- section:artifacts:end -->