### PR TITLE
Properly replicate NaviTalk kill check

### DIFF
--- a/soh/soh/Enhancements/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.cpp
@@ -340,12 +340,14 @@ void TimeSaverOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_li
             if (ForcedDialogIsDisabled(FORCED_DIALOG_SKIP_NAVI)) {
                 ElfMsg* naviTalk = va_arg(args, ElfMsg*);
                 int32_t paramsHighByte = naviTalk->actor.params >> 8;
-                if ((paramsHighByte & 0x80) == 0 &&
-                    ((paramsHighByte & 0x3F) != 0x3F || gPlayState->sceneNum != SCENE_DODONGOS_CAVERN)) {
+                if ((paramsHighByte & 0x80) != 0) {
+                    break;
+                }
+                if ((paramsHighByte & 0x3F) != 0x3F) {
                     Flags_SetSwitch(gPlayState, paramsHighByte & 0x3F);
-                    Actor_Kill(&naviTalk->actor);
                     *should = false;
                 }
+                Actor_Kill(&naviTalk->actor);
             }
             break;
         }

--- a/soh/soh/Enhancements/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.cpp
@@ -345,9 +345,9 @@ void TimeSaverOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_li
                 }
                 if ((paramsHighByte & 0x3F) != 0x3F) {
                     Flags_SetSwitch(gPlayState, paramsHighByte & 0x3F);
-                    *should = false;
                 }
                 Actor_Kill(&naviTalk->actor);
+                *should = false;
             }
             break;
         }

--- a/soh/soh/Enhancements/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.cpp
@@ -338,7 +338,8 @@ void TimeSaverOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_li
             if (ForcedDialogIsDisabled(FORCED_DIALOG_SKIP_NAVI)) {
                 ElfMsg* naviTalk = va_arg(args, ElfMsg*);
                 int32_t paramsHighByte = naviTalk->actor.params >> 8;
-                if ((paramsHighByte & 0x80) == 0 && (paramsHighByte & 0x3F) != 0x3F) {
+                if ((paramsHighByte & 0x80) == 0 &&
+                    ((paramsHighByte & 0x3F) != 0x3F || gPlayState->sceneNum != SCENE_DODONGOS_CAVERN)) {
                     Flags_SetSwitch(gPlayState, paramsHighByte & 0x3F);
                     Actor_Kill(&naviTalk->actor);
                     *should = false;


### PR DESCRIPTION
Fixes #4611

It's admittedly a band-aid fix, but it does patch the side effect on the heavy switch in Jabu Jabu.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2295711681.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2295711884.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2295733381.zip)
<!--- section:artifacts:end -->