### PR TITLE
Add pulsate boss icon enhancement

### DIFF
--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -1555,6 +1555,8 @@ void DrawEnhancementsMenu() {
             UIWidgets::Tooltip("Restores the original outcomes when performing Reverse Bottle Adventure.");
             UIWidgets::PaddedEnhancementCheckbox("Early Eyeball Frog", CVAR_ENHANCEMENT("EarlyEyeballFrog"), true, false);
             UIWidgets::Tooltip("Restores a bug from NTSC 1.0/1.1 that allows you to obtain the eyeball frog from King Zora instead of the Zora Tunic by holding shield.");
+            UIWidgets::PaddedEnhancementCheckbox("Pulsate boss icon", CVAR_ENHANCEMENT("PulsateBossIcon"), true, false);
+            UIWidgets::Tooltip("Restores an unfinished feature to pulsate the boss room icon when you are in the boss room.");
 
             ImGui::EndMenu();
         }

--- a/soh/src/code/z_kaleido_scope_call.c
+++ b/soh/src/code/z_kaleido_scope_call.c
@@ -4,7 +4,7 @@
 
 void (*sKaleidoScopeUpdateFunc)(PlayState* play);
 void (*sKaleidoScopeDrawFunc)(PlayState* play);
-f32 gBossMarkScale;
+f32 gBossMarkScale = 1.0f;
 u32 D_8016139C;
 PauseMapMarksData* gLoadedPauseMarkDataTable;
 

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_lmap_mark.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_lmap_mark.c
@@ -37,8 +37,6 @@ extern PauseMapMarksData gPauseMapMarkDataTable[];
 extern PauseMapMarksData gPauseMapMarkDataTableMasterQuest[];
 
 void PauseMapMark_Init(PlayState* play) {
-    gBossMarkState = 0;
-    gBossMarkScale = 1.0f;
     if(ResourceMgr_IsGameMasterQuest()) {
         gLoadedPauseMarkDataTable = gPauseMapMarkDataTableMasterQuest;
     } else {
@@ -171,6 +169,20 @@ void PauseMapMark_Draw(PlayState* play) {
         case SCENE_BOTTOM_OF_THE_WELL:
         case SCENE_ICE_CAVERN:
             PauseMapMark_DrawForDungeon(play);
+            break;
+        case SCENE_DEKU_TREE_BOSS:
+        case SCENE_DODONGOS_CAVERN_BOSS:
+        case SCENE_JABU_JABU_BOSS:
+        case SCENE_FOREST_TEMPLE_BOSS:
+        case SCENE_FIRE_TEMPLE_BOSS:
+        case SCENE_WATER_TEMPLE_BOSS:
+        case SCENE_SPIRIT_TEMPLE_BOSS:
+        case SCENE_SHADOW_TEMPLE_BOSS:
+        case SCENE_GANONDORF_BOSS:
+        case SCENE_GANONS_TOWER_COLLAPSE_EXTERIOR:
+            if (CVarGetInteger(CVAR_ENHANCEMENT("PulsateBossIcon"), 0) != 0) {
+                PauseMapMark_DrawForDungeon(play);
+            }
             break;
     }
 


### PR DESCRIPTION
There is already all the code to pulsate the boss icons when you're in a boss room, except that it's never ran when you're in one. This adds a restoration enhancement to do so.

The only actual change is how the tracking variables are initialized since `PauseMapMark_Init` is called every frame and would constantly reset the state otherwise.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2289948045.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2289950375.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2289951710.zip)
<!--- section:artifacts:end -->