### PR TITLE
Skip Biggoron's waking up cutscene

### DIFF
--- a/soh/soh/Enhancements/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.cpp
@@ -288,8 +288,13 @@ void TimeSaverOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_li
                         RateLimitedSuccessChime();
                         break;
                     }
+                    case ACTOR_EN_GO2: {
+                        EnGo2* biggoron = (EnGo2*)actor;
+                        biggoron->isAwake = true;
+                        *should = false;
+                        break;
+                    }
                     case ACTOR_BG_HIDAN_FWBIG:
-                    case ACTOR_EN_GO2:
                     case ACTOR_EN_EX_ITEM:
                     case ACTOR_EN_DNT_NOMAL:
                     case ACTOR_EN_DNT_DEMO:

--- a/soh/soh/Enhancements/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.cpp
@@ -289,6 +289,7 @@ void TimeSaverOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_li
                         break;
                     }
                     case ACTOR_BG_HIDAN_FWBIG:
+                    case ACTOR_EN_GO2:
                     case ACTOR_EN_EX_ITEM:
                     case ACTOR_EN_DNT_NOMAL:
                     case ACTOR_EN_DNT_DEMO:


### PR DESCRIPTION
Fixes #4664

Added the cutscene skip and set the flag to allow Biggoron to be spoken to and traded with instantly.

Interesting side effect: the eyedrops cutscene is now skippable as a misc interation _and_ as a one-point cutscene.
Yeah...we really need to recategorize these.

https://github.com/user-attachments/assets/5c538c5f-8b5a-44b1-acd9-efd21d3b0cd7
https://github.com/user-attachments/assets/bbbc81f1-78ee-4c4d-9e67-eb657d88542e

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2323335030.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2323336289.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2323340506.zip)
<!--- section:artifacts:end -->