### PR TITLE
Fix Item Count Defaults

### DIFF
--- a/soh/soh/config/ConfigUpdaters.cpp
+++ b/soh/soh/config/ConfigUpdaters.cpp
@@ -71,17 +71,17 @@ namespace SOH {
 
     void ConfigVersion3Updater::Update(Ship::Config* conf) {
         conf->EraseBlock("Controllers");
+        if (conf->GetNestedJson().contains("CVars") && conf->GetNestedJson()["CVars"].contains("gInjectItemCounts")) {
+            CVarClear("gInjectItemCounts");
+            CVarSetInteger("gEnhancements.InjectItemCounts.GoldSkulltula", 1);
+            CVarSetInteger("gEnhancements.InjectItemCounts.HeartContainer", 1);
+            CVarSetInteger("gEnhancements.InjectItemCounts.HeartPiece", 1);
+        }
         for (Migration migration : version3Migrations) {
             if (migration.action == MigrationAction::Rename) {
                 CVarCopy(migration.from.c_str(), migration.to.value().c_str());
             }
             CVarClear(migration.from.c_str());
-        }
-        if (conf->Contains("CVars.gEnhancements.InjectItemCounts")) {
-            CVarClear("gEnhancements.InjectItemCounts");
-            CVarSetInteger("gEnhancements.InjectItemCounts.GoldSkulltula", 1);
-            CVarSetInteger("gEnhancements.InjectItemCounts.HeartContainer", 1);
-            CVarSetInteger("gEnhancements.InjectItemCounts.HeartPiece", 1);
         }
     }
 }


### PR DESCRIPTION
When I made the migrator for config v3, I didn't realize `Config::Contains` referenced the nested JSON instead of the flattened, so I was feeding it an incorrect string to check. This changes that process to look for the old one (to simplify nested contains checks) before the MigrationAction loop, and removes the MigrationAction entry for it, to prevent the CVarSets from running without the previous CVar being there.
Fixes #4640

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2323480504.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2323482353.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2323483919.zip)
<!--- section:artifacts:end -->