### PR TITLE
Skip Ganondorf boss battle intro

### DIFF
--- a/soh/soh/Enhancements/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.cpp
@@ -996,6 +996,13 @@ void TimeSaverOnSceneInitHandler(int16_t sceneNum) {
                 }
             }
             break;
+        case SCENE_GANONDORF_BOSS:
+            if (CVarGetInteger(CVAR_ENHANCEMENT("TimeSavers.SkipCutscene.BossIntro"), IS_RANDO)) {
+                if (!Flags_GetEventChkInf(EVENTCHKINF_BEGAN_GANONDORF_BATTLE)) {
+                    Flags_SetEventChkInf(EVENTCHKINF_BEGAN_GANONDORF_BATTLE);
+                }
+            }
+            break;
     }
 }
 


### PR DESCRIPTION
Right now it just "skips" the intro in the same manner as the other boss intro skips, i.e. pre-emptively setting the flag. In future I'd like to see it skip right to Ganondorf hovering.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2323555876.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2323555984.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2323556535.zip)
<!--- section:artifacts:end -->