### PR TITLE
Fix Save Prompt Cursor on Quest/Misc Item Tracker Windows

### DIFF
--- a/soh/soh/Enhancements/kaleido.cpp
+++ b/soh/soh/Enhancements/kaleido.cpp
@@ -191,37 +191,46 @@ namespace Rando {
         // it would be a much larger Kaleido change.
         bool shouldScroll = false;
         bool dpad = CVarGetInteger(CVAR_SETTING("DPadOnPause"), 0);
-        if ((!pauseCtx->unk_1E4 || (pauseCtx->unk_1E4 == 5) || (pauseCtx->unk_1E4 == 8)) &&
+        if (((pauseCtx->unk_1E4 == 0) || (pauseCtx->unk_1E4 == 5) || (pauseCtx->unk_1E4 == 8)) &&
             (pauseCtx->pageIndex == PAUSE_QUEST)) {
-            if (pauseCtx->cursorSpecialPos == 0) {
-                if ((pauseCtx->stickRelY > 30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DUP))) {
-                    if (mTopIndex > 0) {
-                        mTopIndex--;
-                        shouldScroll = true;
+            if (!((pauseCtx->state != 6) || ((pauseCtx->stickRelX == 0) && (pauseCtx->stickRelY == 0)))) {
+                if (pauseCtx->cursorSpecialPos == 0) {
+                    if ((pauseCtx->stickRelY > 30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DUP))) {
+                        if (mTopIndex > 0) {
+                            mTopIndex--;
+                            shouldScroll = true;
+                        }
                     }
-                } else if ((pauseCtx->stickRelY < -30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DDOWN))) {
-                    if (mTopIndex + mNumVisible < mEntries.size()) {
-                        mTopIndex++;
-                        shouldScroll = true;
+                    else if ((pauseCtx->stickRelY < -30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DDOWN))) {
+                        if (mTopIndex + mNumVisible < mEntries.size()) {
+                            mTopIndex++;
+                            shouldScroll = true;
+                        }
+                    }
+                    if ((pauseCtx->stickRelX < -30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DLEFT))) {
+                        KaleidoScope_MoveCursorToSpecialPos(play, PAUSE_CURSOR_PAGE_LEFT);
+                        pauseCtx->unk_1E4 = 0;
+                    }
+                    else if ((pauseCtx->stickRelX > 30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DRIGHT))) {
+                        KaleidoScope_MoveCursorToSpecialPos(play, PAUSE_CURSOR_PAGE_RIGHT);
+                        pauseCtx->unk_1E4 = 0;
                     }
                 }
-                if ((pauseCtx->stickRelX < -30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DLEFT))) {
-                    KaleidoScope_MoveCursorToSpecialPos(play, PAUSE_CURSOR_PAGE_LEFT);
-                    pauseCtx->unk_1E4 = 0;
-                } else if ((pauseCtx->stickRelX > 30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DRIGHT))) {
-                    KaleidoScope_MoveCursorToSpecialPos(play, PAUSE_CURSOR_PAGE_RIGHT);
-                    pauseCtx->unk_1E4 = 0;
+                else if (pauseCtx->cursorSpecialPos == PAUSE_CURSOR_PAGE_LEFT) {
+                    if ((pauseCtx->stickRelX > 30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DRIGHT))) {
+                        pauseCtx->cursorSpecialPos = 0;
+                        Audio_PlaySoundGeneral(NA_SE_SY_CURSOR, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
+                    }
                 }
-            } else if (pauseCtx->cursorSpecialPos == PAUSE_CURSOR_PAGE_LEFT) {
-                if ((pauseCtx->stickRelX > 30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DRIGHT))) {
-                    pauseCtx->cursorSpecialPos = 0;
-                    Audio_PlaySoundGeneral(NA_SE_SY_CURSOR, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
+                else if (pauseCtx->cursorSpecialPos == PAUSE_CURSOR_PAGE_RIGHT) {
+                    if ((pauseCtx->stickRelX < -30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DLEFT))) {
+                        pauseCtx->cursorSpecialPos = 0;
+                        Audio_PlaySoundGeneral(NA_SE_SY_CURSOR, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
+                    }
                 }
-            } else if (pauseCtx->cursorSpecialPos == PAUSE_CURSOR_PAGE_RIGHT) {
-                if ((pauseCtx->stickRelX < -30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DLEFT))) {
-                    pauseCtx->cursorSpecialPos = 0;
-                    Audio_PlaySoundGeneral(NA_SE_SY_CURSOR, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
-                }
+            }
+            else if (pauseCtx->cursorSpecialPos != 0 && pauseCtx->state == 7) {
+                pauseCtx->cursorSpecialPos = 0;
             }
         }
         int yOffset = 2;

--- a/soh/soh/Enhancements/kaleido.cpp
+++ b/soh/soh/Enhancements/kaleido.cpp
@@ -200,8 +200,7 @@ namespace Rando {
                             mTopIndex--;
                             shouldScroll = true;
                         }
-                    }
-                    else if ((pauseCtx->stickRelY < -30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DDOWN))) {
+                    } else if ((pauseCtx->stickRelY < -30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DDOWN))) {
                         if (mTopIndex + mNumVisible < mEntries.size()) {
                             mTopIndex++;
                             shouldScroll = true;
@@ -210,26 +209,22 @@ namespace Rando {
                     if ((pauseCtx->stickRelX < -30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DLEFT))) {
                         KaleidoScope_MoveCursorToSpecialPos(play, PAUSE_CURSOR_PAGE_LEFT);
                         pauseCtx->unk_1E4 = 0;
-                    }
-                    else if ((pauseCtx->stickRelX > 30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DRIGHT))) {
+                    } else if ((pauseCtx->stickRelX > 30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DRIGHT))) {
                         KaleidoScope_MoveCursorToSpecialPos(play, PAUSE_CURSOR_PAGE_RIGHT);
                         pauseCtx->unk_1E4 = 0;
                     }
-                }
-                else if (pauseCtx->cursorSpecialPos == PAUSE_CURSOR_PAGE_LEFT) {
+                } else if (pauseCtx->cursorSpecialPos == PAUSE_CURSOR_PAGE_LEFT) {
                     if ((pauseCtx->stickRelX > 30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DRIGHT))) {
                         pauseCtx->cursorSpecialPos = 0;
                         Audio_PlaySoundGeneral(NA_SE_SY_CURSOR, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
                     }
-                }
-                else if (pauseCtx->cursorSpecialPos == PAUSE_CURSOR_PAGE_RIGHT) {
+                } else if (pauseCtx->cursorSpecialPos == PAUSE_CURSOR_PAGE_RIGHT) {
                     if ((pauseCtx->stickRelX < -30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DLEFT))) {
                         pauseCtx->cursorSpecialPos = 0;
                         Audio_PlaySoundGeneral(NA_SE_SY_CURSOR, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
                     }
                 }
-            }
-            else if (pauseCtx->cursorSpecialPos != 0 && pauseCtx->state == 7) {
+            } else if (pauseCtx->cursorSpecialPos != 0 && pauseCtx->state == 7) {
                 pauseCtx->cursorSpecialPos = 0;
             }
         }

--- a/soh/soh/config/ConfigMigrators.h
+++ b/soh/soh/config/ConfigMigrators.h
@@ -260,7 +260,6 @@ namespace SOH {
         { MigrationAction::Rename, "gHurtContainer", "gEnhancements.HurtContainer" },
         { MigrationAction::Rename, "gHyperBosses", "gEnhancements.HyperBosses" },
         { MigrationAction::Rename, "gHyperEnemies", "gEnhancements.HyperEnemies" },
-        { MigrationAction::Rename, "gInjectItemCounts", "gEnhancements.InjectItemCounts" },
         { MigrationAction::Rename, "gInstantFishing", "gEnhancements.InstantFishing" },
         { MigrationAction::Rename, "gInstantOcarinaGameWin", "gEnhancements.InstantOcarinaGameWin" },
         { MigrationAction::Rename, "gInstantPutaway", "gEnhancements.InstantPutaway" },

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_collect.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_collect.c
@@ -127,97 +127,102 @@ void KaleidoScope_DrawQuestStatus(PlayState* play, GraphicsContext* gfxCtx) {
 
     OPEN_DISPS(gfxCtx);
 
-    if ((!pauseCtx->unk_1E4 || (pauseCtx->unk_1E4 == 5) || (pauseCtx->unk_1E4 == 8)) &&
+    if (((pauseCtx->unk_1E4 == 0) || (pauseCtx->unk_1E4 == 5) || (pauseCtx->unk_1E4 == 8)) &&
         (pauseCtx->pageIndex == PAUSE_QUEST)) {
         pauseCtx->cursorColorSet = 0;
 
         if (pauseCtx->cursorSpecialPos == 0) {
             pauseCtx->nameColorSet = 0;
-            sp216 = pauseCtx->cursorSlot[PAUSE_QUEST];
-            phi_s3 = pauseCtx->cursorPoint[PAUSE_QUEST];
-
-            if ((pauseCtx->stickRelX < -30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DLEFT))) {
-                phi_s0 = D_8082A1AC[phi_s3][2];
-                if (phi_s0 == -3) {
-                    KaleidoScope_MoveCursorToSpecialPos(play, PAUSE_CURSOR_PAGE_LEFT);
-                    pauseCtx->unk_1E4 = 0;
-                } else {
-                    while (phi_s0 >= 0) {
-                        if ((s16)KaleidoScope_UpdateQuestStatusPoint(pauseCtx, phi_s0) != 0) {
-                            break;
-                        }
-                        phi_s0 = D_8082A1AC[phi_s0][2];
-                    }
-                }
-            } else if ((pauseCtx->stickRelX > 30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DRIGHT))) {
-                phi_s0 = D_8082A1AC[phi_s3][3];
-                if (phi_s0 == -2) {
-                    KaleidoScope_MoveCursorToSpecialPos(play, PAUSE_CURSOR_PAGE_RIGHT);
-                    pauseCtx->unk_1E4 = 0;
-                } else {
-                    while (phi_s0 >= 0) {
-                        if ((s16)KaleidoScope_UpdateQuestStatusPoint(pauseCtx, phi_s0) != 0) {
-                            break;
-                        }
-                        phi_s0 = D_8082A1AC[phi_s0][3];
-                    }
-                }
+            if ((pauseCtx->state != 6) || ((pauseCtx->stickRelX == 0) && (pauseCtx->stickRelY == 0))) {
+                // No cursor movement
+                sp216 = pauseCtx->cursorSlot[PAUSE_QUEST];
             }
+            else {
+                phi_s3 = pauseCtx->cursorPoint[PAUSE_QUEST];
 
-            if ((pauseCtx->stickRelY < -30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DDOWN))) {
-                phi_s0 = D_8082A1AC[phi_s3][1];
-                while (phi_s0 >= 0) {
-                    if ((s16)KaleidoScope_UpdateQuestStatusPoint(pauseCtx, phi_s0) != 0) {
-                        break;
-                    }
-                    phi_s0 = D_8082A1AC[phi_s0][1];
-                }
-            } else if ((pauseCtx->stickRelY > 30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DUP))) {
-                phi_s0 = D_8082A1AC[phi_s3][0];
-                while (phi_s0 >= 0) {
-                    if ((s16)KaleidoScope_UpdateQuestStatusPoint(pauseCtx, phi_s0) != 0) {
-                        break;
-                    }
-                    phi_s0 = D_8082A1AC[phi_s0][0];
-                }
-            }
-
-            if (phi_s3 != pauseCtx->cursorPoint[PAUSE_QUEST]) {
-                pauseCtx->unk_1E4 = 0;
-                Audio_PlaySoundGeneral(NA_SE_SY_CURSOR, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
-            }
-
-            if (pauseCtx->cursorPoint[PAUSE_QUEST] != 0x18) {
-                if (CHECK_QUEST_ITEM(pauseCtx->cursorPoint[PAUSE_QUEST])) {
-                    if (pauseCtx->cursorPoint[PAUSE_QUEST] < 6) {
-                        phi_s0_2 = pauseCtx->cursorPoint[PAUSE_QUEST] + 0x66;
-                        osSyncPrintf("000 ccc=%d\n", phi_s0_2);
-                    } else if (pauseCtx->cursorPoint[PAUSE_QUEST] < 0x12) {
-                        phi_s0_2 = pauseCtx->cursorPoint[PAUSE_QUEST] + 0x54;
-                        osSyncPrintf("111 ccc=%d\n", phi_s0_2);
+                if ((pauseCtx->stickRelX < -30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DLEFT))) {
+                    phi_s0 = D_8082A1AC[phi_s3][2];
+                    if (phi_s0 == -3) {
+                        KaleidoScope_MoveCursorToSpecialPos(play, PAUSE_CURSOR_PAGE_LEFT);
+                        pauseCtx->unk_1E4 = 0;
                     } else {
-                        phi_s0_2 = pauseCtx->cursorPoint[PAUSE_QUEST] + 0x5A;
-                        osSyncPrintf("222 ccc=%d (%d, %d, %d)\n", phi_s0_2, pauseCtx->cursorPoint[PAUSE_QUEST],
-                                        0x12, 0x6C);
+                        while (phi_s0 >= 0) {
+                            if ((s16)KaleidoScope_UpdateQuestStatusPoint(pauseCtx, phi_s0) != 0) {
+                                break;
+                            }
+                            phi_s0 = D_8082A1AC[phi_s0][2];
+                        }
+                    }
+                } else if ((pauseCtx->stickRelX > 30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DRIGHT))) {
+                    phi_s0 = D_8082A1AC[phi_s3][3];
+                    if (phi_s0 == -2) {
+                        KaleidoScope_MoveCursorToSpecialPos(play, PAUSE_CURSOR_PAGE_RIGHT);
+                        pauseCtx->unk_1E4 = 0;
+                    } else {
+                        while (phi_s0 >= 0) {
+                            if ((s16)KaleidoScope_UpdateQuestStatusPoint(pauseCtx, phi_s0) != 0) {
+                                break;
+                            }
+                            phi_s0 = D_8082A1AC[phi_s0][3];
+                        }
+                    }
+                }
+
+                if ((pauseCtx->stickRelY < -30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DDOWN))) {
+                    phi_s0 = D_8082A1AC[phi_s3][1];
+                    while (phi_s0 >= 0) {
+                        if ((s16)KaleidoScope_UpdateQuestStatusPoint(pauseCtx, phi_s0) != 0) {
+                            break;
+                        }
+                        phi_s0 = D_8082A1AC[phi_s0][1];
+                    }
+                } else if ((pauseCtx->stickRelY > 30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DUP))) {
+                    phi_s0 = D_8082A1AC[phi_s3][0];
+                    while (phi_s0 >= 0) {
+                        if ((s16)KaleidoScope_UpdateQuestStatusPoint(pauseCtx, phi_s0) != 0) {
+                            break;
+                        }
+                        phi_s0 = D_8082A1AC[phi_s0][0];
+                    }
+                }
+
+                if (phi_s3 != pauseCtx->cursorPoint[PAUSE_QUEST]) {
+                    pauseCtx->unk_1E4 = 0;
+                    Audio_PlaySoundGeneral(NA_SE_SY_CURSOR, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
+                }
+
+                if (pauseCtx->cursorPoint[PAUSE_QUEST] != 0x18) {
+                    if (CHECK_QUEST_ITEM(pauseCtx->cursorPoint[PAUSE_QUEST])) {
+                        if (pauseCtx->cursorPoint[PAUSE_QUEST] < 6) {
+                            phi_s0_2 = pauseCtx->cursorPoint[PAUSE_QUEST] + 0x66;
+                            osSyncPrintf("000 ccc=%d\n", phi_s0_2);
+                        } else if (pauseCtx->cursorPoint[PAUSE_QUEST] < 0x12) {
+                            phi_s0_2 = pauseCtx->cursorPoint[PAUSE_QUEST] + 0x54;
+                            osSyncPrintf("111 ccc=%d\n", phi_s0_2);
+                        } else {
+                            phi_s0_2 = pauseCtx->cursorPoint[PAUSE_QUEST] + 0x5A;
+                            osSyncPrintf("222 ccc=%d (%d, %d, %d)\n", phi_s0_2, pauseCtx->cursorPoint[PAUSE_QUEST],
+                                            0x12, 0x6C);
+                        }
+                    } else {
+                        phi_s0_2 = PAUSE_ITEM_NONE;
+                        osSyncPrintf("999 ccc=%d (%d,  %d)\n", PAUSE_ITEM_NONE, pauseCtx->cursorPoint[PAUSE_QUEST],
+                                        0x18);
                     }
                 } else {
-                    phi_s0_2 = PAUSE_ITEM_NONE;
-                    osSyncPrintf("999 ccc=%d (%d,  %d)\n", PAUSE_ITEM_NONE, pauseCtx->cursorPoint[PAUSE_QUEST],
-                                    0x18);
+                    if ((gSaveContext.inventory.questItems & 0xF0000000) != 0) {
+                        phi_s0_2 = 0x72;
+                    } else {
+                        phi_s0_2 = PAUSE_ITEM_NONE;
+                    }
+                    osSyncPrintf("888 ccc=%d (%d,  %d,  %x)\n", phi_s0_2, pauseCtx->cursorPoint[PAUSE_QUEST], 0x72,
+                                    gSaveContext.inventory.questItems & 0xF0000000);
                 }
-            } else {
-                if ((gSaveContext.inventory.questItems & 0xF0000000) != 0) {
-                    phi_s0_2 = 0x72;
-                } else {
-                    phi_s0_2 = PAUSE_ITEM_NONE;
-                }
-                osSyncPrintf("888 ccc=%d (%d,  %d,  %x)\n", phi_s0_2, pauseCtx->cursorPoint[PAUSE_QUEST], 0x72,
-                                gSaveContext.inventory.questItems & 0xF0000000);
-            }
 
-            sp216 = pauseCtx->cursorPoint[PAUSE_QUEST];
-            pauseCtx->cursorItem[pauseCtx->pageIndex] = phi_s0_2;
-            pauseCtx->cursorSlot[pauseCtx->pageIndex] = sp216;
+                sp216 = pauseCtx->cursorPoint[PAUSE_QUEST];
+                pauseCtx->cursorItem[pauseCtx->pageIndex] = phi_s0_2;
+                pauseCtx->cursorSlot[pauseCtx->pageIndex] = sp216;
+            }
 
             KaleidoScope_SetCursorVtx(pauseCtx, sp216 * 4, pauseCtx->questVtx);
 

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_collect.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_collect.c
@@ -136,8 +136,7 @@ void KaleidoScope_DrawQuestStatus(PlayState* play, GraphicsContext* gfxCtx) {
             if ((pauseCtx->state != 6) || ((pauseCtx->stickRelX == 0) && (pauseCtx->stickRelY == 0))) {
                 // No cursor movement
                 sp216 = pauseCtx->cursorSlot[PAUSE_QUEST];
-            }
-            else {
+            } else {
                 phi_s3 = pauseCtx->cursorPoint[PAUSE_QUEST];
 
                 if ((pauseCtx->stickRelX < -30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DLEFT))) {


### PR DESCRIPTION
`z_kaleido_collect.c` was missing some code that decomp has at the first public SoH commit that I *believe* was fine before dpad support was added to the menus. Certainly after that point, when bringing up the save prompt on the Quest subscreen, it would exhibit this behavior (sound on!):

https://github.com/user-attachments/assets/43c73dae-00cf-4288-95f7-da733b516642

As you can see, a similar thing was happening with the Misc Items Tracker screen, it just didn't have any subslots for the cursor to iterate over. This PR fixes this by pulling over enough of that code from decomp to isolate the behavior, and mirroring those changes in the Misc Items Tracker draw code.

https://github.com/user-attachments/assets/472554b9-cbff-4d66-80d3-a10504d8387f

The one thing I couldn't figure out was where it was failing to remove the cursor if you bring up the save prompt on the Quest subscreen while the cursor was on R or L/Z, but I can live with that until kaleido is updated to current decomp, as I believe that will be resolved at that point.

I also included the MigratorAction entry removal that I forgot in the Item Count Defaults PR.

Fixes #4447

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2329159773.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2329163705.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2329167585.zip)
<!--- section:artifacts:end -->