### PR TITLE
Fix Plando Resize Crash

### DIFF
--- a/soh/soh/Enhancements/randomizer/Plandomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/Plandomizer.cpp
@@ -884,84 +884,90 @@ void PlandomizerDrawIceTrapSetup(uint32_t index) {
 }
 
 void PlandomizerDrawOptions() {
-    ImGui::BeginTable("LoadSpoiler", 2);
-    ImGui::TableNextColumn();
-    ImGui::SeparatorText("Load/Save Spoiler Log");
-    PlandomizerPopulateSeedList();
-    static size_t selectedList = 0;
-    if (existingSeedList.size() != 0) {
-        if (ImGui::BeginCombo("##JsonFiles", existingSeedList[selectedList].c_str())) {
-            for (size_t i = 0; i < existingSeedList.size(); i++) {
-                bool isSelected = (selectedList == i);
-                if (ImGui::Selectable(existingSeedList[i].c_str(), isSelected)) {
-                    selectedList = i;
-                }
-                if (isSelected) {
-                    ImGui::SetItemDefaultFocus();
-                }
-            }
-            ImGui::EndCombo();
-        }
-    } else {
-        ImGui::Text("No Spoiler Logs found.");
-    }
-    ImGui::BeginDisabled(existingSeedList.empty());
-    if (ImGui::Button("Load")) {
-        logTemp = existingSeedList[selectedList].c_str();
-        PlandomizerLoadSpoilerLog(logTemp.c_str());
-    }
-    ImGui::EndDisabled();
-    ImGui::BeginDisabled(spoilerLogData.empty());
-    ImGui::SameLine();
-    if (ImGui::Button("Save")) {
-        PlandomizerSaveSpoilerLog();
-    }
-    ImGui::EndDisabled();
-
-    ImGui::TableNextColumn();
-    ImGui::SeparatorText("Current Seed Hash");
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + (ImGui::GetContentRegionAvail().x * 0.5f) - (34.0f * 5.0f));
-    if (spoilerLogData.size() > 0) {
-        ImGui::BeginTable("HashIcons", 5);
-        for (int i = 0; i < 5; i++) {
-            ImGui::TableSetupColumn("Icon", ImGuiTableColumnFlags_WidthFixed, 34.0f);
-        }
+    if (ImGui::BeginTable("LoadSpoiler", 2)) {
         ImGui::TableNextColumn();
-    
-        size_t index = 0;
-        PlandoPushImageButtonStyle();
-        for (auto& hash : plandoHash) {
-            ImGui::PushID(index);
-            textureID = Ship::Context::GetInstance()->GetWindow()->GetGui()->GetTextureByName(gSeedTextures[hash].tex);
-            if (ImGui::ImageButton(Ship::Context::GetInstance()->GetWindow()->GetGui()->GetTextureByName("HASH_ARROW_UP"), 
-                ImVec2(35.0f, 18.0f), ImVec2(1, 1), ImVec2(0, 0), 2.0f, ImVec4(0, 0, 0, 0), ImVec4(1, 1, 1, 1))) {
-                if (hash + 1 >= gSeedTextures.size()) {
-                    hash = 0;
-                } else {
-                    hash++;
+        ImGui::SeparatorText("Load/Save Spoiler Log");
+        PlandomizerPopulateSeedList();
+        static size_t selectedList = 0;
+        if (existingSeedList.size() != 0) {
+            if (ImGui::BeginCombo("##JsonFiles", existingSeedList[selectedList].c_str())) {
+                for (size_t i = 0; i < existingSeedList.size(); i++) {
+                    bool isSelected = (selectedList == i);
+                    if (ImGui::Selectable(existingSeedList[i].c_str(), isSelected)) {
+                        selectedList = i;
+                    }
+                    if (isSelected) {
+                        ImGui::SetItemDefaultFocus();
+                    }
                 }
+                ImGui::EndCombo();
             }
-            ImGui::Image(textureID, ImVec2(35.0f, 35.0f));
-            if (ImGui::ImageButton(Ship::Context::GetInstance()->GetWindow()->GetGui()->GetTextureByName("HASH_ARROW_DWN"), 
-                ImVec2(35.0f, 18.0f), ImVec2(0, 0), ImVec2(1, 1), 2.0f, ImVec4(0, 0, 0, 0), ImVec4(1, 1, 1, 1))) {
-                if (hash == 0) {
-                    hash = gSeedTextures.size() - 1;
-                } else {
-                    hash--;
-                }
-            }
-            if (index != spoilerHash.size() - 1) {
-                ImGui::TableNextColumn();
-            }
-            ImGui::PopID();
-            index++;
         }
-        PlandoPopImageButtonStyle();
+        else {
+            ImGui::Text("No Spoiler Logs found.");
+        }
+        ImGui::BeginDisabled(existingSeedList.empty());
+        if (ImGui::Button("Load")) {
+            logTemp = existingSeedList[selectedList].c_str();
+            PlandomizerLoadSpoilerLog(logTemp.c_str());
+        }
+        ImGui::EndDisabled();
+        ImGui::BeginDisabled(spoilerLogData.empty());
+        ImGui::SameLine();
+        if (ImGui::Button("Save")) {
+            PlandomizerSaveSpoilerLog();
+        }
+        ImGui::EndDisabled();
+
+        ImGui::TableNextColumn();
+        ImGui::SeparatorText("Current Seed Hash");
+        ImGui::SetCursorPosX(ImGui::GetCursorPosX() + (ImGui::GetContentRegionAvail().x * 0.5f) - (34.0f * 5.0f));
+        if (spoilerLogData.size() > 0) {
+            if (ImGui::BeginTable("HashIcons", 5)) {
+                for (int i = 0; i < 5; i++) {
+                    ImGui::TableSetupColumn("Icon", ImGuiTableColumnFlags_WidthFixed, 34.0f);
+                }
+                ImGui::TableNextColumn();
+
+                size_t index = 0;
+                PlandoPushImageButtonStyle();
+                for (auto& hash : plandoHash) {
+                    ImGui::PushID(index);
+                    textureID = Ship::Context::GetInstance()->GetWindow()->GetGui()->GetTextureByName(gSeedTextures[hash].tex);
+                    if (ImGui::ImageButton(Ship::Context::GetInstance()->GetWindow()->GetGui()->GetTextureByName("HASH_ARROW_UP"),
+                        ImVec2(35.0f, 18.0f), ImVec2(1, 1), ImVec2(0, 0), 2.0f, ImVec4(0, 0, 0, 0), ImVec4(1, 1, 1, 1))) {
+                        if (hash + 1 >= gSeedTextures.size()) {
+                            hash = 0;
+                        }
+                        else {
+                            hash++;
+                        }
+                    }
+                    ImGui::Image(textureID, ImVec2(35.0f, 35.0f));
+                    if (ImGui::ImageButton(Ship::Context::GetInstance()->GetWindow()->GetGui()->GetTextureByName("HASH_ARROW_DWN"),
+                        ImVec2(35.0f, 18.0f), ImVec2(0, 0), ImVec2(1, 1), 2.0f, ImVec4(0, 0, 0, 0), ImVec4(1, 1, 1, 1))) {
+                        if (hash == 0) {
+                            hash = gSeedTextures.size() - 1;
+                        }
+                        else {
+                            hash--;
+                        }
+                    }
+                    if (index != spoilerHash.size() - 1) {
+                        ImGui::TableNextColumn();
+                    }
+                    ImGui::PopID();
+                    index++;
+                }
+                PlandoPopImageButtonStyle();
+                ImGui::EndTable();
+            }
+        }
+        else {
+            ImGui::Text("No Spoiler Log Loaded");
+        }
         ImGui::EndTable();
-    } else {
-        ImGui::Text("No Spoiler Log Loaded");
     }
-    ImGui::EndTable();
     
     ImGui::SeparatorText("Options");
     if (plandoLogData.size() == 0) {
@@ -1019,81 +1025,85 @@ void PlandomizerDrawHintsWindow() {
     std::string hintInputText;
 
     ImGui::BeginChild("Hints");
-    ImGui::BeginTable("Hints Window", 1, ImGuiTableFlags_BordersInnerV | ImGuiTableFlags_ScrollY);
-    ImGui::TableSetupColumn("Hint Entries");
-    ImGui::TableSetupScrollFreeze(0, 1);
-    ImGui::TableHeadersRow();
-    
-    for (auto& hintData : spoilerHintData) {
-        ImGui::PushID(index);
-        ImGui::TableNextColumn();
-        ImGui::SeparatorText(hintData.hintName.c_str());
-        ImGui::Text("Current Hint: ");
-        ImGui::SameLine();
-        ImGui::TextWrapped(hintData.hintText.c_str());
+    if (ImGui::BeginTable("Hints Window", 1, ImGuiTableFlags_BordersInnerV | ImGuiTableFlags_ScrollY)) {
+        ImGui::TableSetupColumn("Hint Entries");
+        ImGui::TableSetupScrollFreeze(0, 1);
+        ImGui::TableHeadersRow();
 
-        if (spoilerHintData.size() > 0) {
-            hintInputText = plandoHintData[index].hintText.c_str();
+        for (auto& hintData : spoilerHintData) {
+            ImGui::PushID(index);
+            ImGui::TableNextColumn();
+            ImGui::SeparatorText(hintData.hintName.c_str());
+            ImGui::Text("Current Hint: ");
+            ImGui::SameLine();
+            ImGui::TextWrapped(hintData.hintText.c_str());
+
+            if (spoilerHintData.size() > 0) {
+                hintInputText = plandoHintData[index].hintText.c_str();
+            }
+            ImGui::Text("New Hint:     ");
+            ImGui::SameLine();
+            if (ImGui::Button(randomizeButton.c_str())) {
+                PlandomizerRandomizeHint(HINT_SINGLE, index);
+            }
+            UIWidgets::Tooltip("Randomize Hint");
+            ImGui::SameLine();
+            ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - 10);
+            if (UIWidgets::InputString("##HintMessage", &hintInputText)) {
+                plandoHintData[index].hintText = hintInputText.c_str();
+            }
+            UIWidgets::Tooltip(plandomizerHintsTooltip().c_str());
+            index++;
+            ImGui::PopID();
         }
-        ImGui::Text("New Hint:     ");
-        ImGui::SameLine();
-        if (ImGui::Button(randomizeButton.c_str())) {
-            PlandomizerRandomizeHint(HINT_SINGLE, index);
-        }
-        UIWidgets::Tooltip("Randomize Hint");
-        ImGui::SameLine();
-        ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - 10);
-        if (UIWidgets::InputString("##HintMessage", &hintInputText)) {
-            plandoHintData[index].hintText = hintInputText.c_str();
-        }
-        UIWidgets::Tooltip(plandomizerHintsTooltip().c_str());
-        index++;
-        ImGui::PopID();
+
+        ImGui::EndTable();
     }
-
-    ImGui::EndTable();
     ImGui::EndChild();
 }
 
 void PlandomizerDrawLocationsWindow(RandomizerCheckArea rcArea) {
     uint32_t index = 0;
     ImGui::BeginChild("Locations");
-    ImGui::BeginTable("Locations Window", 4, ImGuiTableFlags_BordersInnerV | ImGuiTableFlags_ScrollY);
-    ImGui::TableSetupColumn("Spoiler Log Check Name", ImGuiTableColumnFlags_WidthFixed, 250.0f);
-    ImGui::TableSetupColumn("Spoiler Log Reward", ImGuiTableColumnFlags_WidthFixed, 190.0f);
-    ImGui::TableSetupColumn("New Reward", ImGuiTableColumnFlags_WidthFixed | ImGuiTableColumnFlags_NoHeaderLabel, 34.0f);
-    ImGui::TableSetupColumn("Additional Options");
-    ImGui::TableSetupScrollFreeze(0, 1);
-    ImGui::TableHeadersRow();
+    if (ImGui::BeginTable("Locations Window", 4, ImGuiTableFlags_BordersInnerV | ImGuiTableFlags_ScrollY)) {
+        ImGui::TableSetupColumn("Spoiler Log Check Name", ImGuiTableColumnFlags_WidthFixed, 250.0f);
+        ImGui::TableSetupColumn("Spoiler Log Reward", ImGuiTableColumnFlags_WidthFixed, 190.0f);
+        ImGui::TableSetupColumn("New Reward", ImGuiTableColumnFlags_WidthFixed | ImGuiTableColumnFlags_NoHeaderLabel, 34.0f);
+        ImGui::TableSetupColumn("Additional Options");
+        ImGui::TableSetupScrollFreeze(0, 1);
+        ImGui::TableHeadersRow();
 
-    for (auto& spoilerData : spoilerLogData) {
-        auto checkID = Rando::StaticData::locationNameToEnum[spoilerData.checkName];
-        auto randoArea = Rando::StaticData::GetLocation(checkID)->GetArea();
-        if (rcArea == RCAREA_INVALID || rcArea == randoArea) {
-            ImGui::TableNextColumn();
-            ImGui::TextWrapped(spoilerData.checkName.c_str());
-            ImGui::TableNextColumn();
-            ImGui::TextWrapped(spoilerData.checkRewardItem.GetName().english.c_str());
-            ImGui::TableNextColumn();
-            PlandomizerDrawItemSlots(index);
-            if (plandoLogData[index].checkRewardItem.GetRandomizerGet() == RG_ICE_TRAP) {
+        for (auto& spoilerData : spoilerLogData) {
+            auto checkID = Rando::StaticData::locationNameToEnum[spoilerData.checkName];
+            auto randoArea = Rando::StaticData::GetLocation(checkID)->GetArea();
+            if (rcArea == RCAREA_INVALID || rcArea == randoArea) {
                 ImGui::TableNextColumn();
-                PlandomizerDrawIceTrapSetup(index);
-            } else if (spoilerData.shopPrice != -1) {
+                ImGui::TextWrapped(spoilerData.checkName.c_str());
                 ImGui::TableNextColumn();
-                ImGui::BeginTable("Shops", 1, ImGuiTableFlags_BordersOuter | ImGuiTableFlags_BordersInner);
-                ImGui::TableSetupColumn("Shop Price");
-                ImGui::TableHeadersRow();
+                ImGui::TextWrapped(spoilerData.checkRewardItem.GetName().english.c_str());
                 ImGui::TableNextColumn();
-                PlandomizerDrawShopSlider(index);
-                ImGui::EndTable();
-            } else {
-                ImGui::TableNextColumn();
+                PlandomizerDrawItemSlots(index);
+                if (plandoLogData[index].checkRewardItem.GetRandomizerGet() == RG_ICE_TRAP) {
+                    ImGui::TableNextColumn();
+                    PlandomizerDrawIceTrapSetup(index);
+                }
+                else if (spoilerData.shopPrice != -1) {
+                    ImGui::TableNextColumn();
+                    ImGui::BeginTable("Shops", 1, ImGuiTableFlags_BordersOuter | ImGuiTableFlags_BordersInner);
+                    ImGui::TableSetupColumn("Shop Price");
+                    ImGui::TableHeadersRow();
+                    ImGui::TableNextColumn();
+                    PlandomizerDrawShopSlider(index);
+                    ImGui::EndTable();
+                }
+                else {
+                    ImGui::TableNextColumn();
+                }
             }
+            index++;
         }
-        index++;
+        ImGui::EndTable();
     }
-    ImGui::EndTable();
     ImGui::EndChild();
 }
 


### PR DESCRIPTION
The issue happened because the tables weren't setup properly. If they're not visible, they're not drawn, but the code after the BeginTable calls was still trying to reference those nonexistent tables when not drawn, and that's what was causing the crash: the transition between visible and not visible and/or vice versa. Just needs `if(ImGui::BeginTable()){}` blocks around them.
Fixes #4699

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2327582196.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2327593739.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2327622626.zip)
<!--- section:artifacts:end -->