### PR TITLE
ci(linux): install libzip without crypto, bump sdl from 2.28.5 -> 2.30.3

### DIFF
--- a/.github/workflows/apt-deps.txt
+++ b/.github/workflows/apt-deps.txt
@@ -1,1 +1,1 @@
-libusb-dev libusb-1.0-0-dev libsdl2-dev libsdl2-net-dev libpng-dev libglew-dev libzip-dev zipcmp zipmerge ziptool nlohmann-json3-dev libtinyxml2-dev libspdlog-dev ninja-build 
+libusb-dev libusb-1.0-0-dev libsdl2-dev libsdl2-net-dev libpng-dev libglew-dev nlohmann-json3-dev libtinyxml2-dev libspdlog-dev ninja-build 

--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y $(cat .github/workflows/apt-deps.txt)
+        sudo apt-get install -y $(cat .github/workflows/apt-deps.txt) libzip-dev zipcmp zipmerge ziptool
     - name: Cache build folders
       uses: actions/cache@v4
       with:
@@ -32,15 +32,15 @@ jobs:
           ${{ runner.os }}-otr-build-
         path: |
           build-cmake
-          SDL2-2.28.5
+          SDL2-2.30.3
     - name: Install latest SDL
       run: |
         export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
-        if [ ! -d "SDL2-2.28.5" ]; then
-          wget https://www.libsdl.org/release/SDL2-2.28.5.tar.gz
-          tar -xzf SDL2-2.28.5.tar.gz
+        if [ ! -d "SDL2-2.30.3" ]; then
+          wget https://www.libsdl.org/release/SDL2-2.30.3.tar.gz
+          tar -xzf SDL2-2.30.3.tar.gz
         fi
-        cd SDL2-2.28.5
+        cd SDL2-2.30.3
         ./configure --enable-hidapi-libusb
         make -j 10
         sudo make install
@@ -157,17 +157,31 @@ jobs:
           linux-build-${{ github.ref }}
           linux-build-
         path: |
-          SDL2-2.28.5
+          SDL2-2.30.3
           SDL2_net-2.2.0
+          tinyxml2-10.0.0
+          libzip-1.10.1
     - name: Install latest SDL
       run: |
         export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
-        if [ ! -d "SDL2-2.28.5" ]; then
-          wget https://www.libsdl.org/release/SDL2-2.28.5.tar.gz
-          tar -xzf SDL2-2.28.5.tar.gz
+        if [ ! -d "SDL2-2.30.3" ]; then
+          wget https://www.libsdl.org/release/SDL2-2.30.3.tar.gz
+          tar -xzf SDL2-2.30.3.tar.gz
         fi
-        cd SDL2-2.28.5
+        cd SDL2-2.30.3
         ./configure --enable-hidapi-libusb
+        make -j 10
+        sudo make install
+        sudo cp -av /usr/local/lib/libSDL* /lib/x86_64-linux-gnu/
+    - name: Install latest SDL_net
+      run: |
+        export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+        if [ ! -d "SDL2_net-2.2.0" ]; then
+          wget https://www.libsdl.org/projects/SDL_net/release/SDL2_net-2.2.0.tar.gz
+          tar -xzf SDL2_net-2.2.0.tar.gz
+        fi
+        cd SDL2_net-2.2.0
+        ./configure
         make -j 10
         sudo make install
         sudo cp -av /usr/local/lib/libSDL* /lib/x86_64-linux-gnu/
@@ -185,18 +199,20 @@ jobs:
         cmake ..
         make
         sudo make install
-    - name: Install latest SDL_net
+    - name: Install libzip without crypto
       run: |
         export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
-        if [ ! -d "SDL2_net-2.2.0" ]; then
-          wget https://www.libsdl.org/projects/SDL_net/release/SDL2_net-2.2.0.tar.gz
-          tar -xzf SDL2_net-2.2.0.tar.gz
+        if [ ! -d "libzip-1.10.1" ]; then
+          wget https://github.com/nih-at/libzip/releases/download/v1.10.1/libzip-1.10.1.tar.gz
+          tar -xzf libzip-1.10.1.tar.gz
         fi
-        cd SDL2_net-2.2.0
-        ./configure
-        make -j 10
+        cd libzip-1.10.1
+        mkdir -p build
+        cd build
+        cmake .. -DENABLE_COMMONCRYPTO=OFF -DENABLE_GNUTLS=OFF -DENABLE_MBEDTLS=OFF -DENABLE_OPENSSL=OFF
+        make
         sudo make install
-        sudo cp -av /usr/local/lib/libSDL* /lib/x86_64-linux-gnu/
+        sudo cp -av /usr/local/lib/libzip* /lib/x86_64-linux-gnu/
     - name: Download soh.otr
       uses: actions/download-artifact@v4
       with:


### PR DESCRIPTION
Ports over the changes from https://github.com/HarbourMasters/2ship2harkinian/pull/588 which make it so our linux runner manually compiles libzip without crypto support to avoid issues with ssl incompatibility.

Also bumps SDL to 2.30.3 which has been used on 2ship for awhile now.

I reorganized the runner install steps so that SDL and SDL-Net are side by side.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2333328464.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2333342013.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2333346953.zip)
<!--- section:artifacts:end -->