### PR TITLE
ci(linux): fix mkdir not working with cached entries

### DIFF
--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -33,6 +33,7 @@ jobs:
         path: |
           build-cmake
           SDL2-2.30.3
+          tinyxml2-10.0.0
     - name: Install latest SDL
       run: |
         export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
@@ -54,7 +55,7 @@ jobs:
           tar -xzf 10.0.0.tar.gz
         fi
         cd tinyxml2-10.0.0
-        mkdir build
+        mkdir -p build
         cd build
         cmake ..
         make
@@ -194,7 +195,7 @@ jobs:
           tar -xzf 10.0.0.tar.gz
         fi
         cd tinyxml2-10.0.0
-        mkdir build
+        mkdir -p build
         cd build
         cmake ..
         make


### PR DESCRIPTION
Need the `-p` flag for mkdir to gracefully handle cached build folders

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2334976134.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2334984334.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2334993956.zip)
<!--- section:artifacts:end -->