### PR TITLE
Fix camera mode not following boomerang with first person rang

### DIFF
--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -11496,13 +11496,7 @@ void Player_UpdateCamAndSeqModes(PlayState* play, Player* this) {
                     camMode = CAM_MODE_TALK;
                 } else if (this->stateFlags1 & PLAYER_STATE1_FRIENDLY_ACTOR_FOCUS) {
                     if (this->stateFlags1 & PLAYER_STATE1_BOOMERANG_THROWN) {
-                        // #region SOH [Enhancement]
-                        if (CVarGetInteger(CVAR_ENHANCEMENT("BoomerangFirstPerson"), 0)) {
-                            camMode = CAM_MODE_TARGET;
-                        // #endregion
-                        } else {
-                            camMode = CAM_MODE_FOLLOWBOOMERANG;
-                        }
+                        camMode = CAM_MODE_FOLLOWBOOMERANG;
                     } else {
                         camMode = CAM_MODE_FOLLOWTARGET;
                     }
@@ -11515,7 +11509,13 @@ void Player_UpdateCamAndSeqModes(PlayState* play, Player* this) {
             } else if (this->stateFlags1 & PLAYER_STATE1_BOOMERANG_THROWN) {
                 // #region SOH [Enhancement]
                 if (CVarGetInteger(CVAR_ENHANCEMENT("BoomerangFirstPerson"), 0)) {
-                    camMode = CAM_MODE_TARGET;
+                    // Avoid camera jumps by switching  to normal cam to exit the first person camera,
+                    // before following the boomerang
+                    if (Play_GetCamera(play, 0)->mode == CAM_MODE_FIRSTPERSON) {
+                        camMode = CAM_MODE_NORMAL;
+                    } else {
+                        camMode = CAM_MODE_FOLLOWBOOMERANG;
+                    }
                 // #endregion
                 } else {
                     camMode = CAM_MODE_FOLLOWBOOMERANG;


### PR DESCRIPTION
Fixes #4715 by preserving the behavior of the boomerang to be followed by the camera after thrown.
When not targeting, we need one frame of switching to the normal camera to avoid a bad camera jump from first person -> follow boomerang.
When targeting a friendly, the camera is no longer in first person mode, so there was no need for us to override the follow rang portion.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2337967913.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2337973853.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2337987050.zip)
<!--- section:artifacts:end -->