### PR TITLE
Fix Dungeon Type Spoiling

### DIFF
--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -328,6 +328,7 @@ void RandomizerOnItemReceiveHandler(GetItemEntry receivedItemEntry) {
     if (randomizerQueuedItemEntry.modIndex == receivedItemEntry.modIndex && randomizerQueuedItemEntry.itemId == receivedItemEntry.itemId) {
         SPDLOG_INFO("Item received mod {} item {} from RC {}", receivedItemEntry.modIndex, receivedItemEntry.itemId, static_cast<uint32_t>(randomizerQueuedCheck));
         loc->SetCheckStatus(RCSHOW_COLLECTED);
+        CheckTracker::SpoilAreaFromCheck(randomizerQueuedCheck);
         CheckTracker::RecalculateAllAreaTotals();
         SaveManager::Instance->SaveSection(gSaveContext.fileNum, SECTION_ID_TRACKER_DATA, true);
         randomizerQueuedCheck = RC_UNKNOWN_CHECK;

--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -464,7 +464,8 @@ void CheckTrackerLoadGame(int32_t fileNum) {
             }
         }
 
-        if (areaChecksGotten[entry2->GetArea()] != 0 || RandomizerCheckObjects::AreaIsOverworld(entry2->GetArea())) {
+        if (areaChecksGotten[entry2->GetArea()] != 0 || RandomizerCheckObjects::AreaIsOverworld(entry2->GetArea()) ||
+            loc->GetCheckStatus() == RCSHOW_SCUMMED) {
             areasSpoiled |= (1 << entry2->GetArea());
         }
 

--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -259,6 +259,33 @@ void RecalculateAreaTotals(RandomizerCheckArea rcArea) {
     CalculateTotals();
 }
 
+std::map<RandomizerGet, RandomizerCheckArea> MapRGtoRandomizerCheckArea = {
+    { RG_DEKU_TREE_MAP, RCAREA_DEKU_TREE},
+    { RG_DODONGOS_CAVERN_MAP, RCAREA_DODONGOS_CAVERN },
+    { RG_JABU_JABUS_BELLY_MAP, RCAREA_JABU_JABUS_BELLY },
+    { RG_FOREST_TEMPLE_MAP, RCAREA_FOREST_TEMPLE },
+    { RG_FIRE_TEMPLE_MAP, RCAREA_FIRE_TEMPLE },
+    { RG_WATER_TEMPLE_MAP, RCAREA_WATER_TEMPLE },
+    { RG_SPIRIT_TEMPLE_MAP, RCAREA_SPIRIT_TEMPLE },
+    { RG_SHADOW_TEMPLE_MAP, RCAREA_SHADOW_TEMPLE },
+    { RG_BOTTOM_OF_THE_WELL_MAP, RCAREA_BOTTOM_OF_THE_WELL },
+    { RG_ICE_CAVERN_MAP, RCAREA_ICE_CAVERN }
+};
+
+void SpoilAreaFromCheck(RandomizerCheck rc) {
+    Rando::Location* loc = Rando::StaticData::GetLocation(rc);
+    Rando::ItemLocation* itemLoc = Rando::Context::GetInstance()->GetItemLocation(rc);
+    if (itemLoc->GetPlacedItem().GetItemType() == ItemType::ITEMTYPE_MAP) {
+        RandomizerCheckArea area = MapRGtoRandomizerCheckArea[itemLoc->GetPlacedRandomizerGet()];
+        if (!IsAreaSpoiled(area)) {
+            SetAreaSpoiled(area);
+        }
+    }
+    if (!IsAreaSpoiled(loc->GetArea())) {
+        SetAreaSpoiled(loc->GetArea());
+    }
+}
+
 void RecalculateAllAreaTotals() {
     for (auto& [rcArea, checks] : checksByArea) {
         if (rcArea == RCAREA_INVALID) {

--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.h
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.h
@@ -59,4 +59,5 @@ void UpdateAreas(RandomizerCheckArea area);
 void UpdateAllOrdering();
 void UpdateAllAreas();
 void RecalculateAllAreaTotals();
+void SpoilAreaFromCheck(RandomizerCheck rc);
 } // namespace CheckTracker


### PR DESCRIPTION
Made a new `SpoilAreaFromCheck` function to spoil areas when getting maps or a first check in a dungeon that isn't spoiled by entrance with the new collection status flow. Also changed the check for spoiling on load to include any scummed checks in the dungeon.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2340246020.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2340251276.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2340262844.zip)
<!--- section:artifacts:end -->