### PR TITLE
don't use magic numbers in `EnItem00_CustomItemsParticles`

### DIFF
--- a/soh/src/code/z_en_item00.c
+++ b/soh/src/code/z_en_item00.c
@@ -1183,19 +1183,22 @@ void EnItem00_Draw(Actor* thisx, PlayState* play) {
     }
 }
 
-#define MINUET_GREEN 0
-#define BOLERO_RED 1
-#define SERENADE_AQUA 2 
-#define REQUIEM_AMBER 3
-#define NOCTURNE_VIOLET 4
-#define PRELUDE_YELLOW 5
-#define STICK_FOREST_GREEN 6 
-#define NUT_GOLD 7
-#define DOUBLE_WHITE 8 
-#define BOMBCHU_BLUE 9
-#define FAIRY_PINK 10
-#define RED_POTION_RED 11
-#define BLUE_FIRE_BLUE 12
+
+typedef enum {
+    PARTICLE_BRIGHT_GREEN,
+    PARTICLE_RED,
+    PARTICLE_CYAN,
+    PARTICLE_ORANGE,
+    PARTICLE_VIOLET,
+    PARTICLE_YELLOW,
+    PARTICLE_GREEN,
+    PARTICLE_GOLD,
+    PARTICLE_WHITE,
+    PARTICLE_DARK_BLUE,
+    PARTICLE_PINK,
+    PARTICLE_BRIGHT_RED,
+    PARTICLE_BLUE,
+} Item00ParticleColors;
 
 void EnItem00_CustomItemsParticles(Actor* Parent, PlayState* play, GetItemEntry giEntry) {
     s16 colorIndex;
@@ -1203,35 +1206,35 @@ void EnItem00_CustomItemsParticles(Actor* Parent, PlayState* play, GetItemEntry 
         case MOD_NONE:
             switch (giEntry.drawItemId) {
                 case ITEM_SONG_MINUET:
-                    colorIndex = MINUET_GREEN;
+                    colorIndex = PARTICLE_BRIGHT_GREEN;
                     break;
                 case ITEM_SONG_BOLERO:
-                    colorIndex = BOLERO_RED;
+                    colorIndex = PARTICLE_RED;
                     break;
                 case ITEM_SONG_SERENADE:
-                    colorIndex = SERENADE_AQUA;
+                    colorIndex = PARTICLE_CYAN;
                     break;
                 case ITEM_SONG_REQUIEM:
-                    colorIndex = REQUIEM_AMBER;
+                    colorIndex = PARTICLE_ORANGE;
                     break;
                 case ITEM_SONG_NOCTURNE:
-                    colorIndex = NOCTURNE_VIOLET;
+                    colorIndex = PARTICLE_VIOLET;
                     break;
                 case ITEM_SONG_PRELUDE:
-                    colorIndex = PRELUDE_YELLOW;
+                    colorIndex = PARTICLE_YELLOW;
                     break;
                 case ITEM_STICK_UPGRADE_20:
                 case ITEM_STICK_UPGRADE_30:
-                    colorIndex = STICK_FOREST_GREEN;
+                    colorIndex = PARTICLE_GREEN;
                     break;
                 case ITEM_NUT_UPGRADE_30:
                 case ITEM_NUT_UPGRADE_40:
-                    colorIndex = NUT_GOLD;
+                    colorIndex = PARTICLE_GOLD;
                     break;
                 case ITEM_BOTTLE:
                 case ITEM_MILK_BOTTLE:
                 case ITEM_LETTER_RUTO:
-                    colorIndex = DOUBLE_WHITE;
+                    colorIndex = PARTICLE_WHITE;
                     break;
                 default:
                     return;
@@ -1245,32 +1248,38 @@ void EnItem00_CustomItemsParticles(Actor* Parent, PlayState* play, GetItemEntry 
                 case RG_BOTTLE_WITH_GREEN_POTION:
                 case RG_BOTTLE_WITH_BUGS:
                 case RG_GREG_RUPEE:
-                    colorIndex = MINUET_GREEN;
+                    colorIndex = PARTICLE_BRIGHT_GREEN;
                     break;
                 case RG_BOTTLE_WITH_FISH:
-                    colorIndex = SERENADE_AQUA;
+                    colorIndex = PARTICLE_CYAN;
                     break;
                 case RG_BOTTLE_WITH_POE:
-                    colorIndex = NOCTURNE_VIOLET;
+                    colorIndex = PARTICLE_VIOLET;
                     break;
                 case RG_BOTTLE_WITH_BIG_POE:
-                    colorIndex = PRELUDE_YELLOW;
+                    colorIndex = PARTICLE_YELLOW;
+                    break;
+                case RG_DEKU_STICK_BAG:
+                    colorIndex = PARTICLE_GREEN;
+                    break;
+                case RG_DEKU_NUT_BAG:
+                    colorIndex = PARTICLE_GOLD;
                     break;
                 case RG_DOUBLE_DEFENSE:
-                    colorIndex = DOUBLE_WHITE;
+                    colorIndex = PARTICLE_WHITE;
                     break;
                 case RG_PROGRESSIVE_BOMBCHUS:
-                    colorIndex = BOMBCHU_BLUE;
+                    colorIndex = PARTICLE_DARK_BLUE;
                     break;
                 case RG_BOTTLE_WITH_FAIRY:
-                    colorIndex = FAIRY_PINK;
+                    colorIndex = PARTICLE_PINK;
                     break;
                 case RG_BOTTLE_WITH_RED_POTION:
-                    colorIndex = RED_POTION_RED;
+                    colorIndex = PARTICLE_BRIGHT_RED;
                     break;
                 case RG_BOTTLE_WITH_BLUE_FIRE:
                 case RG_BOTTLE_WITH_BLUE_POTION:
-                    colorIndex = BLUE_FIRE_BLUE;
+                    colorIndex = PARTICLE_BLUE;
                     break;
                 default:
                     return;
@@ -1282,7 +1291,7 @@ void EnItem00_CustomItemsParticles(Actor* Parent, PlayState* play, GetItemEntry 
 
     // Color of the circle for the particles
     static Color_RGBA8 mainColors[13][3] = {
-        { 34, 255, 76 },   // Minuet, Bean Pack, and Magic Upgrades, Bottle with Green Potion, Bottle with Bugs, and Greg
+        { 34, 255, 76 },   // Minuet, Bean Pack, Magic Upgrades, Bottle with Green Potion, Bottle with Bugs, and Greg
         { 177, 35, 35 },   // Bolero
         { 115, 251, 253 }, // Serenade and Bottle with Fish
         { 177, 122, 35 },  // Requiem

--- a/soh/src/code/z_en_item00.c
+++ b/soh/src/code/z_en_item00.c
@@ -1183,41 +1183,55 @@ void EnItem00_Draw(Actor* thisx, PlayState* play) {
     }
 }
 
+#define MINUET_GREEN 0
+#define BOLERO_RED 1
+#define SERENADE_AQUA 2 
+#define REQUIEM_AMBER 3
+#define NOCTURNE_VIOLET 4
+#define PRELUDE_YELLOW 5
+#define STICK_FOREST_GREEN 6 
+#define NUT_GOLD 7
+#define DOUBLE_WHITE 8 
+#define BOMBCHU_BLUE 9
+#define FAIRY_PINK 10
+#define RED_POTION_RED 11
+#define BLUE_FIRE_BLUE 12
+
 void EnItem00_CustomItemsParticles(Actor* Parent, PlayState* play, GetItemEntry giEntry) {
-    s16 color_slot;
+    s16 colorIndex;
     switch (giEntry.drawModIndex) {
         case MOD_NONE:
             switch (giEntry.drawItemId) {
                 case ITEM_SONG_MINUET:
-                    color_slot = 0;
+                    colorIndex = MINUET_GREEN;
                     break;
                 case ITEM_SONG_BOLERO:
-                    color_slot = 1;
+                    colorIndex = BOLERO_RED;
                     break;
                 case ITEM_SONG_SERENADE:
-                    color_slot = 2;
+                    colorIndex = SERENADE_AQUA;
                     break;
                 case ITEM_SONG_REQUIEM:
-                    color_slot = 3;
+                    colorIndex = REQUIEM_AMBER;
                     break;
                 case ITEM_SONG_NOCTURNE:
-                    color_slot = 4;
+                    colorIndex = NOCTURNE_VIOLET;
                     break;
                 case ITEM_SONG_PRELUDE:
-                    color_slot = 5;
+                    colorIndex = PRELUDE_YELLOW;
                     break;
                 case ITEM_STICK_UPGRADE_20:
                 case ITEM_STICK_UPGRADE_30:
-                    color_slot = 6;
+                    colorIndex = STICK_FOREST_GREEN;
                     break;
                 case ITEM_NUT_UPGRADE_30:
                 case ITEM_NUT_UPGRADE_40:
-                    color_slot = 7;
+                    colorIndex = NUT_GOLD;
                     break;
                 case ITEM_BOTTLE:
                 case ITEM_MILK_BOTTLE:
                 case ITEM_LETTER_RUTO:
-                    color_slot = 8;
+                    colorIndex = DOUBLE_WHITE;
                     break;
                 default:
                     return;
@@ -1231,32 +1245,32 @@ void EnItem00_CustomItemsParticles(Actor* Parent, PlayState* play, GetItemEntry 
                 case RG_BOTTLE_WITH_GREEN_POTION:
                 case RG_BOTTLE_WITH_BUGS:
                 case RG_GREG_RUPEE:
-                    color_slot = 0;
+                    colorIndex = MINUET_GREEN;
                     break;
                 case RG_BOTTLE_WITH_FISH:
-                    color_slot = 2;
+                    colorIndex = SERENADE_AQUA;
                     break;
                 case RG_BOTTLE_WITH_POE:
-                    color_slot = 4;
+                    colorIndex = NOCTURNE_VIOLET;
                     break;
                 case RG_BOTTLE_WITH_BIG_POE:
-                    color_slot = 5;
+                    colorIndex = PRELUDE_YELLOW;
                     break;
                 case RG_DOUBLE_DEFENSE:
-                    color_slot = 8;
+                    colorIndex = DOUBLE_WHITE;
                     break;
                 case RG_PROGRESSIVE_BOMBCHUS:
-                    color_slot = 9;
+                    colorIndex = BOMBCHU_BLUE;
                     break;
                 case RG_BOTTLE_WITH_FAIRY:
-                    color_slot = 10;
+                    colorIndex = FAIRY_PINK;
                     break;
                 case RG_BOTTLE_WITH_RED_POTION:
-                    color_slot = 11;
+                    colorIndex = RED_POTION_RED;
                     break;
                 case RG_BOTTLE_WITH_BLUE_FIRE:
                 case RG_BOTTLE_WITH_BLUE_POTION:
-                    color_slot = 12;
+                    colorIndex = BLUE_FIRE_BLUE;
                     break;
                 default:
                     return;
@@ -1304,8 +1318,8 @@ void EnItem00_CustomItemsParticles(Actor* Parent, PlayState* play, GetItemEntry 
     static Vec3f accel = { 0.0f, 0.0f, 0.0f };
     Color_RGBA8 primColor;
     Color_RGBA8 envColor;
-    Color_RGBA8_Copy(&primColor, &mainColors[color_slot]);
-    Color_RGBA8_Copy(&envColor, &flareColors[color_slot]);
+    Color_RGBA8_Copy(&primColor, &mainColors[colorIndex]);
+    Color_RGBA8_Copy(&envColor, &flareColors[colorIndex]);
     Vec3f pos;
 
     // Make particles more compact for shop items and use a different height offset for them.


### PR DESCRIPTION
resolves https://github.com/HarbourMasters/Shipwright/issues/1156

i know just throwing some `#define`s in there isn't a perfect solution but it gets us away from magic numbers

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2357127920.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2357131032.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2357140284.zip)
<!--- section:artifacts:end -->