### PR TITLE
Skip playing cutscenes of Pierre spawning

### DIFF
--- a/soh/soh/Enhancements/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.cpp
@@ -323,6 +323,7 @@ void TimeSaverOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_li
                     case ACTOR_BG_MIZU_SHUTTER:
                     case ACTOR_SHOT_SUN:
                     case ACTOR_BG_HAKA_GATE:
+                    case ACTOR_EN_KAKASI2:
                         *should = false;
                         RateLimitedSuccessChime();
                         break;


### PR DESCRIPTION
Fixes #4704

At least, in theory. I figure that the check for the actor ID of Pierre's spawning points is enough to cover them all. @Pepper0ni, please test this in the Shadow Temple cases.

https://github.com/user-attachments/assets/e1a06226-afeb-4798-869f-ef28406fbd7a

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2345347495.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2345358684.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2345361955.zip)
<!--- section:artifacts:end -->