### PR TITLE
Fix actor inits happening too early

### DIFF
--- a/soh/src/overlays/actors/ovl_En_Dnt_Jiji/z_en_dnt_jiji.c
+++ b/soh/src/overlays/actors/ovl_En_Dnt_Jiji/z_en_dnt_jiji.c
@@ -102,9 +102,6 @@ void EnDntJiji_Destroy(Actor* thisx, PlayState* play) {
 }
 
 void EnDntJiji_SetFlower(EnDntJiji* this, PlayState* play) {
-    // SOH: Due to removed object dependencies, parent was still NULL when Init was called. In order to properly set
-    // stage, redo it here now that we are a frame later.
-    this->stage = (EnDntDemo*)this->actor.parent;
     if (this->actor.bgCheckFlags & 1) {
         this->flowerPos = this->actor.world.pos;
         this->actionFunc = EnDntJiji_SetupWait;

--- a/soh/src/overlays/actors/ovl_En_Sw/z_en_sw.c
+++ b/soh/src/overlays/actors/ovl_En_Sw/z_en_sw.c
@@ -215,16 +215,6 @@ s32 func_80B0C0CC(EnSw* this, PlayState* play, s32 arg2) {
     return sp64;
 }
 
-// Presumably, due to the removal of object dependency, there is a race condition where
-// the GS on the Kak construction site spawns to early and fails to detect the
-// construction site dyna poly. This custom action func rechecks moving the GS
-// to the nearest poly one frame after init. Further explanation available:
-// https://github.com/HarbourMasters/Shipwright/issues/2310#issuecomment-1492829517
-void EnSw_MoveGoldLater(EnSw* this, PlayState* play) {
-    func_80B0C0CC(this, play, 1);
-    this->actionFunc = func_80B0D590;
-}
-
 void EnSw_Init(Actor* thisx, PlayState* play) {
     EnSw* this = (EnSw*)thisx;
     s32 phi_v0;
@@ -315,14 +305,6 @@ void EnSw_Init(Actor* thisx, PlayState* play) {
         this->actionFunc = func_80B0E5E0;
     } else {
         this->actionFunc = func_80B0D590;
-    }
-
-    // If a normal GS failed to get attached to a poly during init
-    // try once more on the next frame via a custom action func
-    if ((((thisx->params & 0xE000) >> 0xD) == 1 ||
-         ((thisx->params & 0xE000) >> 0xD) == 2) &&
-        this->actor.floorPoly == NULL) {
-        this->actionFunc = EnSw_MoveGoldLater;
     }
 }
 


### PR DESCRIPTION
fixes https://github.com/HarbourMasters/Shipwright/issues/1231
resolves https://github.com/HarbourMasters/Shipwright/issues/4743

based on https://github.com/HarbourMasters/2ship2harkinian/pull/248

edit: switched to draft to clean up individual actor fixes https://github.com/HarbourMasters/Shipwright/issues/4743
edit2: done

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2350077444.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2350083235.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2350090885.zip)
<!--- section:artifacts:end -->