### PR TITLE
Fix fortress pots being considered dungeon in pot replacment

### DIFF
--- a/soh/soh/Enhancements/randomizer/ShufflePots.cpp
+++ b/soh/soh/Enhancements/randomizer/ShufflePots.cpp
@@ -1,5 +1,6 @@
 #include "ShufflePots.h"
 #include "soh_assets.h"
+#include "static_data.h"
 
 extern "C" {
 #include "variables.h"
@@ -25,9 +26,8 @@ extern "C" void ObjTsubo_RandomizerDraw(Actor* thisx, PlayState* play) {
 }
 
 uint8_t ObjTsubo_RandomizerHoldsItem(ObjTsubo* potActor, PlayState* play) {
-    uint8_t isDungeon =
-        (play->sceneNum < SCENE_THIEVES_HIDEOUT || play->sceneNum == SCENE_INSIDE_GANONS_CASTLE ||
-             (play->sceneNum > SCENE_TREASURE_BOX_SHOP && play->sceneNum < SCENE_GANONS_TOWER_COLLAPSE_EXTERIOR));
+    RandomizerCheck rc = potActor->potIdentity.randomizerCheck;
+    uint8_t isDungeon = Rando::StaticData::GetLocation(rc)->IsDungeon();
     uint8_t potSetting = Rando::Context::GetInstance()->GetOption(RSK_SHUFFLE_POTS).GetContextOptionIndex();
 
     // Don't pull randomized item if pot isn't randomized or is already checked

--- a/soh/soh/Enhancements/randomizer/ShufflePots.cpp
+++ b/soh/soh/Enhancements/randomizer/ShufflePots.cpp
@@ -26,8 +26,8 @@ extern "C" void ObjTsubo_RandomizerDraw(Actor* thisx, PlayState* play) {
 
 uint8_t ObjTsubo_RandomizerHoldsItem(ObjTsubo* potActor, PlayState* play) {
     uint8_t isDungeon =
-        play->sceneNum < SCENE_GANONS_TOWER_COLLAPSE_INTERIOR ||
-        (play->sceneNum > SCENE_TREASURE_BOX_SHOP && play->sceneNum < SCENE_GANONS_TOWER_COLLAPSE_EXTERIOR);
+        (play->sceneNum < SCENE_THIEVES_HIDEOUT || play->sceneNum == SCENE_INSIDE_GANONS_CASTLE ||
+             (play->sceneNum > SCENE_TREASURE_BOX_SHOP && play->sceneNum < SCENE_GANONS_TOWER_COLLAPSE_EXTERIOR));
     uint8_t potSetting = Rando::Context::GetInstance()->GetOption(RSK_SHUFFLE_POTS).GetContextOptionIndex();
 
     // Don't pull randomized item if pot isn't randomized or is already checked

--- a/soh/soh/Enhancements/randomizer/location.cpp
+++ b/soh/soh/Enhancements/randomizer/location.cpp
@@ -53,9 +53,9 @@ const std::string& Rando::Location::GetShortName() const {
 
 bool Rando::Location::IsDungeon() const {
     return (checkType != RCTYPE_SKULL_TOKEN &&
-            (scene < SCENE_THIEVES_HIDEOUT || scene == SCENE_INSIDE_GANONS_CASTLE ||
-             (scene > SCENE_TREASURE_BOX_SHOP && scene < SCENE_GANONS_TOWER_COLLAPSE_EXTERIOR))) ||
-           (checkType == RCTYPE_SKULL_TOKEN && scene < SCENE_GANONS_TOWER);
+            (scene <= SCENE_GERUDO_TRAINING_GROUND || scene == SCENE_INSIDE_GANONS_CASTLE ||
+             (scene >= SCENE_DEKU_TREE_BOSS && scene <= SCENE_GANONDORF_BOSS))) ||
+           (checkType == RCTYPE_SKULL_TOKEN && scene <= SCENE_ICE_CAVERN);
 }
 
 bool Rando::Location::IsOverworld() const {


### PR DESCRIPTION
Fixes #4729

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2356310770.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2356316344.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2356317644.zip)
<!--- section:artifacts:end -->