### PR TITLE
Port over ShipInit from 2Ship

### DIFF
--- a/soh/soh/Enhancements/Cheats/MoonJump.cpp
+++ b/soh/soh/Enhancements/Cheats/MoonJump.cpp
@@ -12,7 +12,6 @@ extern PlayState* gPlayState;
 
 void RegisterMoonJump() {
     COND_ID_HOOK(OnActorUpdate, ACTOR_PLAYER, CVAR, [](void* actorRef) {
-        Actor* actor = (Actor*)actorRef;
         Player* player = GET_PLAYER(gPlayState);
 
         if (player != nullptr && CHECK_BTN_ANY(gPlayState->state.input[0].cur.button, BTN_L)) {

--- a/soh/soh/Enhancements/Cheats/MoonJump.cpp
+++ b/soh/soh/Enhancements/Cheats/MoonJump.cpp
@@ -1,0 +1,24 @@
+#include <libultraship/bridge.h>
+#include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
+#include "soh/ShipInit.hpp"
+
+extern "C" {
+#include "macros.h"
+extern PlayState* gPlayState;
+}
+
+#define CVAR_NAME "gCheats.MoonJumpOnL"
+#define CVAR CVarGetInteger(CVAR_NAME, 0)
+
+void RegisterMoonJump() {
+    COND_ID_HOOK(OnActorUpdate, ACTOR_PLAYER, CVAR, [](void* actorRef) {
+        Actor* actor = (Actor*)actorRef;
+        Player* player = GET_PLAYER(gPlayState);
+
+        if (player != nullptr && CHECK_BTN_ANY(gPlayState->state.input[0].cur.button, BTN_L)) {
+            player->actor.velocity.y = 6.34375f;
+        }
+    });
+}
+
+static RegisterShipInitFunc initFunc(RegisterMoonJump, { CVAR_NAME });

--- a/soh/soh/Enhancements/Cheats/MoonJump.cpp
+++ b/soh/soh/Enhancements/Cheats/MoonJump.cpp
@@ -7,17 +7,20 @@ extern "C" {
 extern PlayState* gPlayState;
 }
 
-#define CVAR_NAME "gCheats.MoonJumpOnL"
-#define CVAR CVarGetInteger(CVAR_NAME, 0)
+#define CVAR_MOON_JUMP_NAME "gCheats.MoonJumpOnL"
+#define CVAR_MOON_JUMP_DEFAULT 0
+#define CVAR_MOON_JUMP_VALUE CVarGetInteger(CVAR_MOON_JUMP_NAME, CVAR_MOON_JUMP_DEFAULT)
 
-void RegisterMoonJump() {
-    COND_ID_HOOK(OnActorUpdate, ACTOR_PLAYER, CVAR, [](void* actorRef) {
-        Player* player = GET_PLAYER(gPlayState);
+void OnPlayerUpdateMoonJump() {
+    Player* player = GET_PLAYER(gPlayState);
 
-        if (player != nullptr && CHECK_BTN_ANY(gPlayState->state.input[0].cur.button, BTN_L)) {
-            player->actor.velocity.y = 6.34375f;
-        }
-    });
+    if (player != nullptr && CHECK_BTN_ANY(gPlayState->state.input[0].cur.button, BTN_L)) {
+        player->actor.velocity.y = 6.34375f;
+    }
 }
 
-static RegisterShipInitFunc initFunc(RegisterMoonJump, { CVAR_NAME });
+void RegisterMoonJump() {
+    COND_HOOK(OnPlayerUpdate, CVAR_MOON_JUMP_VALUE, OnPlayerUpdateMoonJump);
+}
+
+static RegisterShipInitFunc initFunc(RegisterMoonJump, { CVAR_MOON_JUMP_NAME });

--- a/soh/soh/Enhancements/game-interactor/GameInteractor.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor.h
@@ -592,14 +592,42 @@ struct HookInfo {
 #define GET_CURRENT_REGISTERING_INFO(type) HookRegisteringInfo{}
 #endif
 
-#define REGISTER_VB_SHOULD(flag, body)                                                      \
+#define REGISTER_VB_SHOULD(flag, body)                                                  \
     GameInteractor::Instance->RegisterGameHookForID<GameInteractor::OnVanillaBehavior>( \
-        flag, [](GIVanillaBehavior _, bool* should, va_list _originalArgs) {                 \
-            va_list args;                                                                   \
-            va_copy(args, _originalArgs);                                                    \
-            body;                                                                           \
-            va_end(args);                                                                   \
+        flag, [](GIVanillaBehavior _, bool* should, va_list _originalArgs) {            \
+            va_list args;                                                               \
+            va_copy(args, _originalArgs);                                               \
+            body;                                                                       \
+            va_end(args);                                                               \
         })
+
+#define COND_HOOK(hookType, condition, body)                                                     \
+    {                                                                                            \
+        static HOOK_ID hookId = 0;                                                               \
+        GameInteractor::Instance->UnregisterGameHook<GameInteractor::hookType>(hookId);          \
+        hookId = 0;                                                                              \
+        if (condition) {                                                                         \
+            hookId = GameInteractor::Instance->RegisterGameHook<GameInteractor::hookType>(body); \
+        }                                                                                        \
+    }
+#define COND_ID_HOOK(hookType, id, condition, body)                                                       \
+    {                                                                                                     \
+        static HOOK_ID hookId = 0;                                                                        \
+        GameInteractor::Instance->UnregisterGameHookForID<GameInteractor::hookType>(hookId);              \
+        hookId = 0;                                                                                       \
+        if (condition) {                                                                                  \
+            hookId = GameInteractor::Instance->RegisterGameHookForID<GameInteractor::hookType>(id, body); \
+        }                                                                                                 \
+    }
+#define COND_VB_SHOULD(id, condition, body)                                                               \
+    {                                                                                                     \
+        static HOOK_ID hookId = 0;                                                                        \
+        GameInteractor::Instance->UnregisterGameHookForID<GameInteractor::ShouldVanillaBehavior>(hookId); \
+        hookId = 0;                                                                                       \
+        if (condition) {                                                                                  \
+            hookId = REGISTER_VB_SHOULD(id, body);                                                        \
+        }                                                                                                 \
+    }
 
 class GameInteractor {
 public:

--- a/soh/soh/Enhancements/mods.cpp
+++ b/soh/soh/Enhancements/mods.cpp
@@ -144,21 +144,6 @@ void RegisterInfiniteNayrusLove() {
     });
 }
 
-void RegisterMoonJumpOnL() {
-    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnGameFrameUpdate>([]() {
-        if (!GameInteractor::IsSaveLoaded(true)) return;
-        
-        if (CVarGetInteger(CVAR_CHEAT("MoonJumpOnL"), 0) != 0) {
-            Player* player = GET_PLAYER(gPlayState);
-
-            if (CHECK_BTN_ANY(gPlayState->state.input[0].cur.button, BTN_L)) {
-                player->actor.velocity.y = 6.34375f;
-            }
-        }
-    });
-}
-
-
 void RegisterInfiniteISG() {
     GameInteractor::Instance->RegisterGameHook<GameInteractor::OnGameFrameUpdate>([]() {
         if (!GameInteractor::IsSaveLoaded(true)) return;
@@ -1411,7 +1396,6 @@ void InitMods() {
     RegisterInfiniteAmmo();
     RegisterInfiniteMagic();
     RegisterInfiniteNayrusLove();
-    RegisterMoonJumpOnL();
     RegisterInfiniteISG();
     RegisterEzQPA();
     RegisterUnrestrictedItems();

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -127,6 +127,7 @@ Sail* Sail::Instance;
 #include "soh/resource/importer/BackgroundFactory.h"
 
 #include "soh/config/ConfigUpdaters.h"
+#include "soh/ShipInit.hpp"
 
 extern "C" {
 #include "src/overlays/actors/ovl_En_Dns/z_en_dns.h"
@@ -1150,6 +1151,7 @@ extern "C" void InitOTR() {
     conf->RunVersionUpdates();
 
     SohGui::SetupGuiElements();
+    ShipInit::InitAll();
     AudioCollection::Instance = new AudioCollection();
     ActorDB::Instance = new ActorDB();
 #ifdef __APPLE__

--- a/soh/soh/ShipInit.hpp
+++ b/soh/soh/ShipInit.hpp
@@ -1,0 +1,43 @@
+#ifndef SHIP_INIT_HPP
+#define SHIP_INIT_HPP
+
+#ifdef __cplusplus
+
+#include <vector>
+#include <set>
+#include <unordered_map>
+#include <functional>
+
+struct ShipInit {
+    static std::unordered_map<std::string, std::vector<std::function<void()>>>& GetAll() {
+        static std::unordered_map<std::string, std::vector<std::function<void()>>> shipInitFuncs;
+        return shipInitFuncs;
+    }
+
+    static void InitAll() {
+        ShipInit::Init("*");
+    }
+
+    static void Init(const std::string& path) {
+        auto& shipInitFuncs = ShipInit::GetAll();
+        for (const auto& initFunc : shipInitFuncs[path]) {
+            initFunc();
+        }
+    }
+};
+
+struct RegisterShipInitFunc {
+    RegisterShipInitFunc(std::function<void()> initFunc, const std::set<std::string>& updatePaths = {}) {
+        auto& shipInitFuncs = ShipInit::GetAll();
+
+        shipInitFuncs["*"].push_back(initFunc);
+
+        for (const auto& path : updatePaths) {
+            shipInitFuncs[path].push_back(initFunc);
+        }
+    }
+};
+
+#endif // __cplusplus
+
+#endif // SHIP_INIT_HPP

--- a/soh/soh/UIWidgets.cpp
+++ b/soh/soh/UIWidgets.cpp
@@ -239,6 +239,7 @@ namespace UIWidgets {
         if (CustomCheckbox(text, &val, disabled, disabledGraphic)) {
             CVarSetInteger(cvarName, val);
             Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
+            ShipInit::Init(cvarName);
             changed = true;
         }
 
@@ -298,6 +299,7 @@ namespace UIWidgets {
                         selected = i;
                         changed = true;
                         Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
+                        ShipInit::Init(cvarName);
                     }
                 }
             }

--- a/soh/soh/UIWidgets.hpp
+++ b/soh/soh/UIWidgets.hpp
@@ -1,10 +1,3 @@
-//
-//  UIWidgets.hpp
-//  soh
-//
-//  Created by David Chavez on 25.08.22.
-//
-
 #ifndef UIWidgets_hpp
 #define UIWidgets_hpp
 
@@ -17,6 +10,7 @@
 #define IMGUI_DEFINE_MATH_OPERATORS
 #endif
 #include <imgui.h>
+#include "soh/ShipInit.hpp"
 
 namespace UIWidgets {
 


### PR DESCRIPTION
As title says, ports over the ShipInit changes from Proxy over from 2Ship to SoH. Only includes a converted Moon Jump for now to confirm it works. Eventually we'd want to transfer everything from hook_handlers.cpp etc to separate files like this and use this new pattern, but that'll be a while.

I want this in now because I want to start creating a couple of example PRs how enhancements etc should look using hooks, and I really want to start doing that with the new macros. That way we can direct people with existing PRs to the new examples as well instead of having to say "please use hooks instead" with no or little direction.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2368213346.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2368214314.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2368216068.zip)
<!--- section:artifacts:end -->