### PR TITLE
Fix transition wipe not rendering properly

### DIFF
--- a/soh/src/code/z_fbdemo_circle.c
+++ b/soh/src/code/z_fbdemo_circle.c
@@ -11,31 +11,35 @@ Gfx sCircleNullDList[] = {
 //#include "code/fbdemo_circle/z_fbdemo_circle.c"
 #include "code/fbdemo_circle/z_fbdemo_circle.h"
 
-Gfx __sCircleDList[] = {
-    gsDPPipeSync(),                                                                                                 // 0
-    gsSPClearGeometryMode(G_ZBUFFER | G_SHADE | G_CULL_BOTH | G_FOG | G_LIGHTING | G_TEXTURE_GEN |                  // 1
+Gfx sTransCircleDL[] = {
+    gsDPPipeSync(),
+    gsSPClearGeometryMode(G_ZBUFFER | G_SHADE | G_CULL_BOTH | G_FOG | G_LIGHTING | G_TEXTURE_GEN |
                           G_TEXTURE_GEN_LINEAR | G_LOD | G_SHADING_SMOOTH),
-    gsSPSetGeometryMode(G_SHADE | G_SHADING_SMOOTH),                                                                // 2
-    gsDPSetOtherMode(G_AD_DISABLE | G_CD_MAGICSQ | G_CK_NONE | G_TC_FILT | G_TF_BILERP | G_TT_NONE | G_TL_TILE |    // 3
+    gsSPSetGeometryMode(G_SHADE | G_SHADING_SMOOTH),
+    gsDPSetOtherMode(G_AD_DISABLE | G_CD_MAGICSQ | G_CK_NONE | G_TC_FILT | G_TF_BILERP | G_TT_NONE | G_TL_TILE |
                          G_TD_CLAMP | G_TP_PERSP | G_CYC_1CYCLE | G_PM_NPRIMITIVE,
-                     G_AC_NONE | G_ZS_PIXEL | G_RM_XLU_SURF | G_RM_XLU_SURF2),                                      // 4
-    gsDPSetCombineMode(G_CC_BLENDPEDECALA, G_CC_BLENDPEDECALA),                                                     // 5
-    gsSPTexture(0xFFFF, 0xFFFF, 0, G_TX_RENDERTILE, G_ON),                                                          // 6
-    gsDPLoadTextureBlock(SEG_ADDR(8, 0), G_IM_FMT_I, G_IM_SIZ_8b, 16, 64, 0, G_TX_NOMIRROR | G_TX_WRAP,                 // 7
+                     G_AC_NONE | G_ZS_PIXEL | G_RM_XLU_SURF | G_RM_XLU_SURF2),
+    gsDPSetCombineMode(G_CC_BLENDPEDECALA, G_CC_BLENDPEDECALA),
+    gsSPTexture(0xFFFF, 0xFFFF, 0, G_TX_RENDERTILE, G_ON),
+    gsDPLoadTextureBlock(SEG_ADDR(8, 0), G_IM_FMT_I, G_IM_SIZ_8b, 16, 64, 0, G_TX_NOMIRROR | G_TX_WRAP,
                          G_TX_NOMIRROR | G_TX_CLAMP, 4, 6, G_TX_NOLOD, G_TX_NOLOD),
-    gsSPDisplayList(SEG_ADDR(9, 0)),                                                                                    // 8
-    gsSPVertex(sTransCircleVtx, 32, 0),                                                                              // 9
-    gsSP2Triangles(0, 1, 2, 0, 1, 3, 4, 0),                                                                         // 10
-    gsSP2Triangles(3, 5, 6, 0, 5, 7, 8, 0),                                                                         // 11
-    gsSP2Triangles(7, 9, 10, 0, 9, 11, 12, 0),                                                                      // 12
-    gsSP2Triangles(11, 13, 14, 0, 13, 15, 16, 0),                                                                   // 13
-    gsSP2Triangles(15, 17, 18, 0, 17, 19, 20, 0),                                                                   // 14
-    gsSP2Triangles(19, 21, 22, 0, 21, 23, 24, 0),                                                                   // 15
-    gsSP2Triangles(23, 25, 26, 0, 25, 27, 28, 0),                                                                   // 16
-    gsSP1Triangle(27, 29, 30, 0),                                                                                   // 17
-    gsSPVertex(&sTransCircleVtx[31], 3, 0),                                                                          // 18
-    gsSP1Triangle(0, 1, 2, 0),                                                                                      // 19
-    gsSPEndDisplayList(),                                                                                           // 20
+    gsSPDisplayList(SEG_ADDR(9, 0)),
+    // OTRTODO: Add proper gsSPVertexOTRFilepath macro
+    { G_VTX_OTR_FILEPATH << 24, (uintptr_t)sTransCircleVtx },
+    { 32, 0 << 16 | 0 },
+    gsSP2Triangles(0, 1, 2, 0, 1, 3, 4, 0),
+    gsSP2Triangles(3, 5, 6, 0, 5, 7, 8, 0),
+    gsSP2Triangles(7, 9, 10, 0, 9, 11, 12, 0),
+    gsSP2Triangles(11, 13, 14, 0, 13, 15, 16, 0),
+    gsSP2Triangles(15, 17, 18, 0, 17, 19, 20, 0),
+    gsSP2Triangles(19, 21, 22, 0, 21, 23, 24, 0),
+    gsSP2Triangles(23, 25, 26, 0, 25, 27, 28, 0),
+    gsSP1Triangle(27, 29, 30, 0),
+    // OTRTODO: Add proper gsSPVertexOTRFilepath macro
+    { G_VTX_OTR_FILEPATH << 24, (uintptr_t)sTransCircleVtx },
+    { 3, 0 << 16 | 31 },
+    gsSP1Triangle(0, 1, 2, 0),
+    gsSPEndDisplayList(),
 };
 
 void TransitionCircle_Start(void* thisx) {
@@ -149,7 +153,7 @@ void TransitionCircle_Draw(void* thisx, Gfx** gfxP) {
 
     this->frame ^= 1;
     gDPPipeSync(gfx++);
-    texScroll = Gfx_BranchTexScroll(&gfx, this->texX, this->texY, 0x10, 0x40);
+    texScroll = Gfx_BranchTexScroll(&gfx, this->texX, this->texY, 16, 64);
     gSPSegment(gfx++, 9, texScroll);
     gSPSegment(gfx++, 8, this->texture);
     gDPSetColor(gfx++, G_SETPRIMCOLOR, this->color.rgba);
@@ -174,15 +178,7 @@ void TransitionCircle_Draw(void* thisx, Gfx** gfxP) {
         guTranslate(&modelView[2], tPos, tPos, 0.0f);
         gSPMatrix(gfx++, &modelView[2], G_MTX_NOPUSH | G_MTX_MUL | G_MTX_MODELVIEW);
     }
-
-    // OTRTODO: This is an ugly hack but it will do for now...
-    Vtx* vtx = ResourceMgr_LoadVtxByName(sTransCircleVtx);
-    Gfx var1 = gsSPVertex(vtx, 32, 0);
-    Gfx var2 = gsSPVertex(&vtx[31], 3, 0);
-    __sCircleDList[0xe] = var1;
-    __sCircleDList[0x17] = var2;
-
-    gSPDisplayList(gfx++, __sCircleDList);
+    gSPDisplayList(gfx++, sTransCircleDL);
     gDPPipeSync(gfx++);
     *gfxP = gfx;
 }

--- a/soh/src/code/z_fbdemo_wipe1.c
+++ b/soh/src/code/z_fbdemo_wipe1.c
@@ -3,25 +3,30 @@
 
 #include "code/fbdemo_wipe1/z_fbdemo_wipe1.h"
 
-Gfx sWipeDList[] = {
+Gfx sTransWipeDL[] = {
     gsDPPipeSync(),
     gsSPClearGeometryMode(G_ZBUFFER | G_SHADE | G_CULL_BOTH | G_FOG | G_LIGHTING | G_TEXTURE_GEN |
                           G_TEXTURE_GEN_LINEAR | G_LOD | G_SHADING_SMOOTH),
-    gsSPSetGeometryMode(G_ZBUFFER | G_SHADE | G_SHADING_SMOOTH),
+    // SOH [Port] Removed G_ZBUFFER as gsDPSetPrimDepth is unimplemented in LUS.
+    // This should have the same effect of ignoring previous depth values
+    // LUSTODO: Add back once gsDPSetPrimDepth is implemented
+    gsSPSetGeometryMode(/* G_ZBUFFER | */ G_SHADE | G_SHADING_SMOOTH),
     gsDPSetOtherMode(G_AD_DISABLE | G_CD_MAGICSQ | G_CK_NONE | G_TC_FILT | G_TF_BILERP | G_TT_NONE | G_TL_TILE |
                          G_TD_CLAMP | G_TP_PERSP | G_CYC_2CYCLE | G_PM_1PRIMITIVE,
                      G_AC_NONE | G_ZS_PRIM | G_RM_PASS | G_RM_AA_ZB_TEX_EDGE2),
     gsDPSetCombineLERP(TEXEL1, TEXEL0, PRIM_LOD_FRAC, TEXEL0, TEXEL1, TEXEL0, PRIM_LOD_FRAC, TEXEL0, COMBINED, 0,
                        PRIMITIVE, 0, COMBINED, 0, PRIMITIVE, 0),
     gsDPSetPrimDepth(0, 0),
-    gsDPLoadTextureBlock_4b(sTransWipeTex, G_IM_FMT_I, 64, 64, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_MIRROR | G_TX_WRAP, 6, 6,
-                            11, G_TX_NOLOD),
+    gsDPLoadTextureBlock_4b(sTransWipeTex, G_IM_FMT_I, 64, 64, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_MIRROR | G_TX_WRAP, 6,
+                            6, 11, G_TX_NOLOD),
     gsDPLoadMultiBlock_4b(sTransWipeTex, 0x0100, 1, G_IM_FMT_I, 64, 64, 0, G_TX_NOMIRROR | G_TX_WRAP,
                           G_TX_MIRROR | G_TX_WRAP, 6, 6, 11, 1),
     gsDPSetTextureLUT(G_TT_NONE),
     gsSPTexture(0xFFFF, 0xFFFF, 0, G_TX_RENDERTILE, G_ON),
     gsSPDisplayList(SEG_ADDR(8, 0)),
-    gsSPVertex(sTransWipeVtx, 25, 0),
+    // OTRTODO: Add proper gsSPVertexOTRFilepath macro
+    { G_VTX_OTR_FILEPATH << 24, (uintptr_t)sTransWipeVtx },
+    { 25, 0 << 16 | 0 },
     gsSP2Triangles(0, 1, 2, 0, 1, 3, 4, 0),
     gsSP2Triangles(5, 6, 7, 0, 6, 8, 9, 0),
     gsSP2Triangles(8, 10, 11, 0, 10, 12, 13, 0),
@@ -32,7 +37,7 @@ Gfx sWipeDList[] = {
 };
 
 // unused.
-Gfx sWipeSyncDList[] = {
+Gfx sTransWipeSyncDL[] = {
     gsDPPipeSync(),
     gsSPEndDisplayList(),
 };
@@ -88,18 +93,17 @@ void TransitionWipe_Draw(void* thisx, Gfx** gfxP) {
     Mtx* modelView;
     TransitionWipe* this = (TransitionWipe*)thisx;
     s32 pad[4];
-    Gfx* tex;
-    Gfx* wipeDl = sWipeDList;
+    Gfx* texScroll;
 
     modelView = this->modelView[this->frame];
-
     this->frame ^= 1;
+
     guScale(&modelView[0], 0.56f, 0.56f, 1.0f);
     guRotate(&modelView[1], 0.0f, 0.0f, 0.0f, 1.0f);
     guTranslate(&modelView[2], 0.0f, 0.0f, 0.0f);
     gDPPipeSync(gfx++);
-    tex = Gfx_BranchTexScroll(&gfx, this->texX, this->texY, 0, 0);
-    gSPSegment(gfx++, 8, tex);
+    texScroll = Gfx_BranchTexScroll(&gfx, this->texX, this->texY, 0, 0);
+    gSPSegment(gfx++, 8, texScroll);
     gDPSetPrimColor(gfx++, 0, 0x80, this->color.r, this->color.g, this->color.b, 255);
     gSPMatrix(gfx++, &this->projection, G_MTX_LOAD | G_MTX_PROJECTION);
     gSPPerspNormalize(gfx++, this->normal);
@@ -107,7 +111,7 @@ void TransitionWipe_Draw(void* thisx, Gfx** gfxP) {
     gSPMatrix(gfx++, &modelView[0], G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
     gSPMatrix(gfx++, &modelView[1], G_MTX_NOPUSH | G_MTX_MUL | G_MTX_MODELVIEW);
     gSPMatrix(gfx++, &modelView[2], G_MTX_NOPUSH | G_MTX_MUL | G_MTX_MODELVIEW);
-    gSPDisplayList(gfx++, sWipeDList);
+    gSPDisplayList(gfx++, sTransWipeDL);
     gDPPipeSync(gfx++);
     *gfxP = gfx;
 }


### PR DESCRIPTION
This fixes graphical issues with the transition wipe effect. Specifically two problems were happening:

* The vertex data was not sent to the renderer, instead the string pointer to the resource name was used, leading to garbage memory being read instead.
  * This is addressed by using the `VTX_OTR_FILEPATH` opcode instead. Unfortunately LUS does not provide a convenience macro for us to use, so I bit-packed the opcode manually.
* The transition DL turned on `G_ZBUFFER` and `G_ZS_PRIM` and uses `gsDPSetPrimDepth` to set the depth test value as 0. `gsDPSetPrimDepth` is unimplemented in LUS, which meant that the DL was just using the normal depth buffer as a test, leading to the effect being obscured behind the scene geometry.
  * In lieu of a proper prim depth implementation, we can temporarily remove `G_ZBUFFER` since the prim depth was being set to 0 anyways.

I've also updated the transition circle effect to set the vertex data using the otr macro instead of loading the vertex manually and overwriting the DL. And some minor decomp name/value updates in the areas being touched.

Fixes #649

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2359827449.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2359827646.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2359834948.zip)
<!--- section:artifacts:end -->