### PR TITLE
fix: readme typos

### DIFF
--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -3,7 +3,7 @@
 ## Windows
 
 Requires:
-  * At least 8GB of RAM (machines with 4GB have seen complier failures)
+  * At least 8GB of RAM (machines with 4GB have seen compiler failures)
   * Visual Studio 2022 Community Edition with the C++ feature set
   * One of the Windows SDKs that comes with Visual Studio, for example the current Windows 10 version 10.0.19041.0
   * The `MSVC v143 - VS 2022 C++ build tools` component of Visual Studio

--- a/docs/MODDING.md
+++ b/docs/MODDING.md
@@ -59,7 +59,7 @@ if (IS_DAY || gTimeIncrement >= 0x190) {
 }
 ```
 
-We can make a quick change to this code to verify this is indeed what we are looking for, lets multiply the the gTimeIncrement by 10:
+We can make a quick change to this code to verify this is indeed what we are looking for, lets multiply the gTimeIncrement by 10:
 
 ```diff
 if (IS_DAY || gTimeIncrement >= 0x190) {


### PR DESCRIPTION
In https://github.com/HarbourMasters/Shipwright/blob/develop/docs/BUILDING.md
- "compiler" is spelt as "complier"

In https://github.com/HarbourMasters/Shipwright/blob/develop/docs/MODDING.md
- "the" is repeated twice