### PR TITLE
cleanup indentation around trees drop sticks

### DIFF
--- a/soh/src/overlays/actors/ovl_En_Wood02/z_en_wood02.c
+++ b/soh/src/overlays/actors/ovl_En_Wood02/z_en_wood02.c
@@ -358,13 +358,15 @@ void EnWood02_Update(Actor* thisx, PlayState* play2) {
             dropsSpawnPt = this->actor.world.pos;
             dropsSpawnPt.y += 200.0f;
 
-            if ((this->unk_14C >= 0) && (this->unk_14C < 0x64) && (CVarGetInteger(CVAR_ENHANCEMENT("TreesDropSticks"), 0)) && !(INV_CONTENT(ITEM_STICK) == ITEM_NONE)) {
-                (numDrops = (Rand_ZeroOne() * 4));
-                for (i = 0; i < numDrops; ++i) {
-                    Item_DropCollectible(play, &dropsSpawnPt, ITEM00_STICK);
+            if ((this->unk_14C >= 0) && (this->unk_14C < 0x64)) { 
+                if (CVarGetInteger(CVAR_ENHANCEMENT("TreesDropSticks"), 0) && INV_CONTENT(ITEM_STICK) != ITEM_NONE) {
+                    numDrops = Rand_ZeroOne() * 4;
+                    for (i = 0; i < numDrops; ++i) {
+                        Item_DropCollectible(play, &dropsSpawnPt, ITEM00_STICK);
+                    }
+                } else {
+                    Item_DropCollectibleRandom(play, &this->actor, &dropsSpawnPt, this->unk_14C << 4);
                 }
-            } else if ((this->unk_14C >= 0) && (this->unk_14C < 0x64)) {
-                Item_DropCollectibleRandom(play, &this->actor, &dropsSpawnPt, this->unk_14C << 4);
             } else if (this->actor.home.rot.z != 0) {
                 this->actor.home.rot.z &= 0x1FFF;
                 this->actor.home.rot.z |= 0xE000;

--- a/soh/src/overlays/actors/ovl_En_Wood02/z_en_wood02.c
+++ b/soh/src/overlays/actors/ovl_En_Wood02/z_en_wood02.c
@@ -363,18 +363,14 @@ void EnWood02_Update(Actor* thisx, PlayState* play2) {
                 for (i = 0; i < numDrops; ++i) {
                     Item_DropCollectible(play, &dropsSpawnPt, ITEM00_STICK);
                 }
-            } else {
-                if ((this->unk_14C >= 0) && (this->unk_14C < 0x64)) {
+            } else if ((this->unk_14C >= 0) && (this->unk_14C < 0x64)) {
                 Item_DropCollectibleRandom(play, &this->actor, &dropsSpawnPt, this->unk_14C << 4);
-            } else {
-                if (this->actor.home.rot.z != 0) {
-                    this->actor.home.rot.z &= 0x1FFF;
-                    this->actor.home.rot.z |= 0xE000;
-                    Actor_Spawn(&play->actorCtx, play, ACTOR_EN_SW, dropsSpawnPt.x, dropsSpawnPt.y,
-                                dropsSpawnPt.z, 0, this->actor.world.rot.y, 0, this->actor.home.rot.z, true);
-                    this->actor.home.rot.z = 0;
-                    }
-                }
+            } else if (this->actor.home.rot.z != 0) {
+                this->actor.home.rot.z &= 0x1FFF;
+                this->actor.home.rot.z |= 0xE000;
+                Actor_Spawn(&play->actorCtx, play, ACTOR_EN_SW, dropsSpawnPt.x, dropsSpawnPt.y,
+                            dropsSpawnPt.z, 0, this->actor.world.rot.y, 0, this->actor.home.rot.z, true);
+                this->actor.home.rot.z = 0;
             }
 
             // Spawn falling leaves


### PR DESCRIPTION
pointed out in #4769

does not change behavior, so doesn't fix issue

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2373286935.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2373288970.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2373300310.zip)
<!--- section:artifacts:end -->