### PR TITLE
Fix scarce and minimal item pools removing shuffled sticks and nuts.

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/item_pool.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/item_pool.cpp
@@ -665,8 +665,8 @@ static void SetScarceItemPool() {
   ReplaceMaxItem(RG_BOMBCHU_20, 0);
   ReplaceMaxItem(RG_PROGRESSIVE_MAGIC_METER, 1);
   ReplaceMaxItem(RG_DOUBLE_DEFENSE, 0);
-  ReplaceMaxItem(RG_PROGRESSIVE_STICK_UPGRADE, (ctx->GetOption(RSK_SHUFFLE_DEKU_STICK_BAG).GetContextOptionIndex() == 1)? 2 : 1);
-  ReplaceMaxItem(RG_PROGRESSIVE_NUT_UPGRADE, (ctx->GetOption(RSK_SHUFFLE_DEKU_NUT_BAG).GetContextOptionIndex() == 1)? 2 : 1);
+  ReplaceMaxItem(RG_PROGRESSIVE_STICK_UPGRADE, ctx->GetOption(RSK_SHUFFLE_DEKU_STICK_BAG) ? 2 : 1);
+  ReplaceMaxItem(RG_PROGRESSIVE_NUT_UPGRADE, ctx->GetOption(RSK_SHUFFLE_DEKU_NUT_BAG) ? 2 : 1);
   ReplaceMaxItem(RG_PROGRESSIVE_BOW, 2);
   ReplaceMaxItem(RG_PROGRESSIVE_SLINGSHOT, 2);
   ReplaceMaxItem(RG_PROGRESSIVE_BOMB_BAG, 2);
@@ -682,8 +682,8 @@ static void SetMinimalItemPool() {
   ReplaceMaxItem(RG_NAYRUS_LOVE, 0);
   ReplaceMaxItem(RG_PROGRESSIVE_MAGIC_METER, 1);
   ReplaceMaxItem(RG_DOUBLE_DEFENSE, 0);
-  ReplaceMaxItem(RG_PROGRESSIVE_STICK_UPGRADE, (ctx->GetOption(RSK_SHUFFLE_DEKU_STICK_BAG).GetContextOptionIndex() == 1)? 1 : 0);
-  ReplaceMaxItem(RG_PROGRESSIVE_NUT_UPGRADE, (ctx->GetOption(RSK_SHUFFLE_DEKU_NUT_BAG).GetContextOptionIndex() == 1)? 1 : 0);
+  ReplaceMaxItem(RG_PROGRESSIVE_STICK_UPGRADE, ctx->GetOption(RSK_SHUFFLE_DEKU_STICK_BAG) ? 1 : 0);
+  ReplaceMaxItem(RG_PROGRESSIVE_NUT_UPGRADE, ctx->GetOption(RSK_SHUFFLE_DEKU_NUT_BAG) ? 1 : 0);
   ReplaceMaxItem(RG_PROGRESSIVE_BOW, 1);
   ReplaceMaxItem(RG_PROGRESSIVE_SLINGSHOT, 1);
   ReplaceMaxItem(RG_PROGRESSIVE_BOMB_BAG, 1);

--- a/soh/soh/Enhancements/randomizer/3drando/item_pool.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/item_pool.cpp
@@ -665,8 +665,8 @@ static void SetScarceItemPool() {
   ReplaceMaxItem(RG_BOMBCHU_20, 0);
   ReplaceMaxItem(RG_PROGRESSIVE_MAGIC_METER, 1);
   ReplaceMaxItem(RG_DOUBLE_DEFENSE, 0);
-  ReplaceMaxItem(RG_PROGRESSIVE_STICK_UPGRADE, 1);
-  ReplaceMaxItem(RG_PROGRESSIVE_NUT_UPGRADE, 1);
+  ReplaceMaxItem(RG_PROGRESSIVE_STICK_UPGRADE, (ctx->GetOption(RSK_SHUFFLE_DEKU_STICK_BAG).GetContextOptionIndex() == 1)? 2 : 1);
+  ReplaceMaxItem(RG_PROGRESSIVE_NUT_UPGRADE, (ctx->GetOption(RSK_SHUFFLE_DEKU_NUT_BAG).GetContextOptionIndex() == 1)? 2 : 1);
   ReplaceMaxItem(RG_PROGRESSIVE_BOW, 2);
   ReplaceMaxItem(RG_PROGRESSIVE_SLINGSHOT, 2);
   ReplaceMaxItem(RG_PROGRESSIVE_BOMB_BAG, 2);
@@ -682,8 +682,8 @@ static void SetMinimalItemPool() {
   ReplaceMaxItem(RG_NAYRUS_LOVE, 0);
   ReplaceMaxItem(RG_PROGRESSIVE_MAGIC_METER, 1);
   ReplaceMaxItem(RG_DOUBLE_DEFENSE, 0);
-  ReplaceMaxItem(RG_PROGRESSIVE_STICK_UPGRADE, 0);
-  ReplaceMaxItem(RG_PROGRESSIVE_NUT_UPGRADE, 0);
+  ReplaceMaxItem(RG_PROGRESSIVE_STICK_UPGRADE, (ctx->GetOption(RSK_SHUFFLE_DEKU_STICK_BAG).GetContextOptionIndex() == 1)? 1 : 0);
+  ReplaceMaxItem(RG_PROGRESSIVE_NUT_UPGRADE, (ctx->GetOption(RSK_SHUFFLE_DEKU_NUT_BAG).GetContextOptionIndex() == 1)? 1 : 0);
   ReplaceMaxItem(RG_PROGRESSIVE_BOW, 1);
   ReplaceMaxItem(RG_PROGRESSIVE_SLINGSHOT, 1);
   ReplaceMaxItem(RG_PROGRESSIVE_BOMB_BAG, 1);


### PR DESCRIPTION
This fixes a generation failure with sticks shuffle + minimal pool + any entrance rando.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2380123880.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2380125657.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2380127113.zip)
<!--- section:artifacts:end -->