### PR TITLE
rando: fix regression when freestanding off

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/item_pool.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/item_pool.cpp
@@ -1265,9 +1265,7 @@ void GenerateItemPool() {
                              ctx->GetOption(RSK_SHUFFLE_FREESTANDING).Is(RO_FREESTANDING_ALL);
   bool dungeonFreeStandingActive = ctx->GetOption(RSK_SHUFFLE_FREESTANDING).Is(RO_FREESTANDING_DUNGEONS) ||
                            ctx->GetOption(RSK_SHUFFLE_FREESTANDING).Is(RO_FREESTANDING_ALL);
-  if (overworldFreeStandingActive || dungeonFreeStandingActive) {
-    PlaceItemsForType(RCTYPE_FREESTANDING, overworldFreeStandingActive, dungeonFreeStandingActive, true);
-  }
+  PlaceItemsForType(RCTYPE_FREESTANDING, overworldFreeStandingActive, dungeonFreeStandingActive, true);
 
   AddItemsToPool(ItemPool, alwaysItems);
   AddItemsToPool(ItemPool, dungeonRewards);


### PR DESCRIPTION
regression introduced in #4773 when not shuffling freestanding,
`PlaceItemsForType` still needs to run to fill checks with vanilla items

There's still an issue: collecting the freestanding item will also give the shuffled item,
with this PR at least that'll just double dip the item, but I'm still digging into why this is happening. Somewhere freestanding_mode check needs to be added

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2381777556.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2381779005.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2381781536.zip)
<!--- section:artifacts:end -->