### PR TITLE
Remove taking settings from a loaded spoiler instead of the imGUI settings

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -1873,10 +1873,12 @@ void GenerateRandomizerImgui(std::string seed = "") {
     CVarSetInteger(CVAR_GENERAL("RandoGenerating"), 1);
     CVarSave();
     auto ctx = Rando::Context::GetInstance();
+    /*RANDOTODO proper UI for selecting if a spoiler loaded should be used for settings
     if (!ctx->IsSpoilerLoaded()) {
         // We use the settings from the spoiler rather than CVars.
         ctx->GetSettings()->SetAllFromCVar();
-    }
+    }*/
+    
     // todo: this efficently when we build out cvar array support
     std::set<RandomizerCheck> excludedLocations;
     std::stringstream excludedLocationStringStream(CVarGetString(CVAR_RANDOMIZER_SETTING("ExcludedLocations"), ""));


### PR DESCRIPTION
There seems to have been an intended check to make settings from a loaded spoiler log take priority over the settings in imGUI. this was terrible UX and caused more confusing behaviors than useful ones, especially when a spoiler is loaded on game start. This comments it until a proper UI can be implemented for it.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2387664662.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2387665907.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2387667081.zip)
<!--- section:artifacts:end -->