### PR TITLE
Added skip of Forest Stage leader cutscene

### DIFF
--- a/soh/soh/Enhancements/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.cpp
@@ -326,6 +326,7 @@ void TimeSaverOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_li
                     case ACTOR_SHOT_SUN:
                     case ACTOR_BG_HAKA_GATE:
                     case ACTOR_EN_KAKASI2:
+                    case ACTOR_EN_DNT_JIJI:
                         *should = false;
                         RateLimitedSuccessChime();
                         break;


### PR DESCRIPTION
This is the cutscene that plays when you're wearing the Mask of Truth in the Forest Stage to obtain the Deku Nut upgrade.

### Before
https://github.com/user-attachments/assets/f9c69893-fbc0-40e9-a313-979d69c3253f

### After
https://github.com/user-attachments/assets/9e81cf0a-8b16-4159-ad98-e5fa99e8df4f

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2391851588.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2391858879.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2391859046.zip)
<!--- section:artifacts:end -->