### PR TITLE
Fix ITEM_00's giving twinrovas check.

### DIFF
--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -883,6 +883,7 @@ void RandomizerOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_l
                 RandomizerCheck rc = OTRGlobals::Instance->gRandomizer->GetCheckFromActor(
                     item00->actor.id, gPlayState->sceneNum, item00->ogParams);
                 if (rc != RC_UNKNOWN_CHECK) {
+                    item00->randoInf = RAND_INF_MAX;
                     item00->actor.params = ITEM00_SOH_DUMMY;
                     item00->itemEntry = Rando::Context::GetInstance()->GetFinalGIEntry(
                         rc, true, (GetItemID)Rando::StaticData::GetLocation(rc)->GetVanillaItem());


### PR DESCRIPTION
This fixes all the strange instances of freestanding PoH's giving medallions or nothing instead of their checks

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2392587592.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2392596056.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2392602448.zip)
<!--- section:artifacts:end -->