### PR TITLE
Fix Naborru fight CS for child and with entrance skips

### DIFF
--- a/soh/soh/Enhancements/game-interactor/GameInteractor.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor.h
@@ -310,7 +310,9 @@ typedef enum {
     VB_PLAY_FIRE_ARROW_CS,
     // Vanilla condition: INV_CONTENT(ITEM_ARROW_FIRE) == ITEM_NONE
     VB_SPAWN_FIRE_ARROW,
-    // Opt: *EventChkInf flag
+    // Opt: s32 entranceIndex
+    VB_ALLOW_ENTRANCE_CS_FOR_EITHER_AGE,
+    // Opt: s32 flag/EventChkInf, s32 entranceIndex
     VB_PLAY_ENTRANCE_CS,
     // Opt: *cutsceneId
     VB_PLAY_ONEPOINT_CS,

--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -784,6 +784,15 @@ void RandomizerOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_l
     va_copy(args, originalArgs);
 
     switch (id) {
+        case VB_ALLOW_ENTRANCE_CS_FOR_EITHER_AGE: {
+            s32 entranceIndex = va_arg(args, s32);
+
+            // Allow Nabooru fight cutscene to play for child in rando
+            if (entranceIndex == ENTR_SPIRIT_TEMPLE_BOSS_ENTRANCE) {
+                *should = true;
+            }
+            break;
+        }
         case VB_PLAY_SLOW_CHEST_CS: {
             // We force fast chests if SkipGetItemAnimation is enabled because the camera in the CS looks pretty wonky otherwise
             if (CVarGetInteger(CVAR_ENHANCEMENT("TimeSavers.SkipGetItemAnimation"), SGIA_DISABLED)) {

--- a/soh/soh/Enhancements/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.cpp
@@ -204,8 +204,13 @@ void TimeSaverOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_li
             break;
         }
         case VB_PLAY_ENTRANCE_CS: {
-            s32* entranceFlag = va_arg(args, s32*);
-            if (CVarGetInteger(CVAR_ENHANCEMENT("TimeSavers.SkipCutscene.Entrances"), IS_RANDO) && (*entranceFlag != EVENTCHKINF_EPONA_OBTAINED)) {
+            s32 entranceFlag = va_arg(args, s32);
+            s32 entranceIndex = va_arg(args, s32);
+
+            // Epona LLR fence jump cutscenes not skipped to allow the player and epona to load in the world correctly
+            // Nabooru fight cutscene is handled by boss intro skip instead (which deals with other flags needing to be set)
+            if (CVarGetInteger(CVAR_ENHANCEMENT("TimeSavers.SkipCutscene.Entrances"), IS_RANDO) &&
+                (entranceFlag != EVENTCHKINF_EPONA_OBTAINED) && entranceIndex != ENTR_SPIRIT_TEMPLE_BOSS_ENTRANCE) {
                 *should = false;
             }
             break;

--- a/soh/src/code/z_demo.c
+++ b/soh/src/code/z_demo.c
@@ -2176,7 +2176,7 @@ void Cutscene_HandleEntranceTriggers(PlayState* play) {
     for (i = 0; i < ARRAY_COUNT(sEntranceCutsceneTable); i++) {
         entranceCutscene = &sEntranceCutsceneTable[i];
         requiredAge = entranceCutscene->ageRestriction;
-        if (requiredAge == 2) {
+        if (GameInteractor_Should(VB_ALLOW_ENTRANCE_CS_FOR_EITHER_AGE, requiredAge == 2, entranceCutscene->entrance)) {
             requiredAge = gSaveContext.linkAge;
         }
 
@@ -2185,7 +2185,7 @@ void Cutscene_HandleEntranceTriggers(PlayState* play) {
             (gSaveContext.cutsceneIndex < 0xFFF0) && ((u8)gSaveContext.linkAge == requiredAge) &&
             (gSaveContext.respawnFlag <= 0)) {
             Flags_SetEventChkInf(entranceCutscene->flag);
-            if (GameInteractor_Should(VB_PLAY_ENTRANCE_CS, true, &entranceCutscene->flag)) {
+            if (GameInteractor_Should(VB_PLAY_ENTRANCE_CS, true, entranceCutscene->flag, entranceCutscene->entrance)) {
                 Cutscene_SetSegment(play, entranceCutscene->segAddr);
                 gSaveContext.cutsceneTrigger = 2;
                 gSaveContext.showTitleCard = false;

--- a/soh/src/overlays/actors/ovl_Bg_Breakwall/z_bg_breakwall.c
+++ b/soh/src/overlays/actors/ovl_Bg_Breakwall/z_bg_breakwall.c
@@ -302,8 +302,8 @@ void BgBreakwall_Wait(BgBreakwall* this, PlayState* play) {
 
         if ((wallType == BWALL_DC_ENTRANCE) && (!Flags_GetEventChkInf(EVENTCHKINF_ENTERED_DODONGOS_CAVERN))) {
             Flags_SetEventChkInf(EVENTCHKINF_ENTERED_DODONGOS_CAVERN);
-            s32 flag = EVENTCHKINF_ENTERED_DODONGOS_CAVERN;
-            if (GameInteractor_Should(VB_PLAY_ENTRANCE_CS, true, &flag)) {
+            if (GameInteractor_Should(VB_PLAY_ENTRANCE_CS, true, EVENTCHKINF_ENTERED_DODONGOS_CAVERN,
+                                      gSaveContext.entranceIndex)) {
                 Cutscene_SetSegment(play, gDcOpeningCs);
                 gSaveContext.cutsceneTrigger = 1;
                 Player_SetCsActionWithHaltedActors(play, NULL, 0x31);

--- a/soh/src/overlays/actors/ovl_Bg_Toki_Swd/z_bg_toki_swd.c
+++ b/soh/src/overlays/actors/ovl_Bg_Toki_Swd/z_bg_toki_swd.c
@@ -117,8 +117,8 @@ void func_808BAF40(BgTokiSwd* this, PlayState* play) {
     if (((Flags_GetEventChkInf(EVENTCHKINF_ENTERED_MASTER_SWORD_CHAMBER)) == 0) && (gSaveContext.sceneSetupIndex < 4) &&
         Actor_IsFacingAndNearPlayer(&this->actor, 800.0f, 0x7530) && !Play_InCsMode(play)) {
         Flags_SetEventChkInf(EVENTCHKINF_ENTERED_MASTER_SWORD_CHAMBER);
-        s32 flag = EVENTCHKINF_ENTERED_MASTER_SWORD_CHAMBER;
-        if (GameInteractor_Should(VB_PLAY_ENTRANCE_CS, true, &flag)) {
+        if (GameInteractor_Should(VB_PLAY_ENTRANCE_CS, true, EVENTCHKINF_ENTERED_MASTER_SWORD_CHAMBER,
+                                  gSaveContext.entranceIndex)) {
             play->csCtx.segment = D_808BBD90;
             gSaveContext.cutsceneTrigger = 1;
         }


### PR DESCRIPTION
The spirit temple boss entrance cutscene is responsible for starting the Naborru fight (cutscene sets flags, etc).
The cutscene is restricted to Adult age, which means the cutscene wont play for Child. In Rando with boss entrance shuffle, it is possible that Child could enter the room. Without Skip Boss Intros, this meant that the Naborru fight would never start for Child.

I've added a new `VB_ALLOW_ENTRANCE_CS_FOR_EITHER_AGE` to make the spirit temple boss entrance cutscene apply to both ages fixing Rando for Child access.

Additionally I fixed an issue where Skip Entrance Cutscenes would skip the Naborru fight CS for Adult as well (causing same behavior), so now that entrance is ignored as Skip Boss Intro deals with it instead.

Fixes #4788

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2392951059.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2392954556.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2392976691.zip)
<!--- section:artifacts:end -->