### PR TITLE
Fix shuffled fairies despawning

### DIFF
--- a/soh/soh/Enhancements/randomizer/ShuffleFairies.cpp
+++ b/soh/soh/Enhancements/randomizer/ShuffleFairies.cpp
@@ -68,7 +68,6 @@ bool ShuffleFairies_SpawnFairy(f32 posX, f32 posY, f32 posZ, int32_t params) {
                                            0, 0, FAIRY_HEAL, true);
         fairy->sohFairyIdentity = fairyIdentity;
         fairy->actor.draw = (ActorFunc)ShuffleFairies_DrawRandomizedItem;
-        fairy->fairyFlags |= FAIRY_FLAG_TIMED;
         return true;
     }
     return false;


### PR DESCRIPTION
Pretty sure this was originally meant to *remove* the timed flag before my rewrite of this code. So uhh, woops.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2393926083.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2393931491.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2393934105.zip)
<!--- section:artifacts:end -->