### PR TITLE
Rename stick and nut capacity settings in save editor

### DIFF
--- a/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
+++ b/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
@@ -1133,7 +1133,7 @@ void DrawEquipmentTab() {
         "20",
         "30",
     };
-    DrawUpgrade("Sticks", UPG_STICKS, stickNames);
+    DrawUpgrade("Deku Stick Capacity", UPG_STICKS, stickNames);
 
     const std::vector<std::string> nutNames = {
         "None",
@@ -1141,7 +1141,7 @@ void DrawEquipmentTab() {
         "30",
         "40",
     };
-    DrawUpgrade("Deku Nuts", UPG_NUTS, nutNames);
+    DrawUpgrade("Deku Nut Capacity", UPG_NUTS, nutNames);
 }
 
 // Draws a toggleable icon for a quest item that is faded when disabled


### PR DESCRIPTION
Fixes #4807

![capacity rename](https://github.com/user-attachments/assets/ff18640b-6edc-4b3d-9fe9-aeb943d66cd0)

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2396153841.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2396159930.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2396172689.zip)
<!--- section:artifacts:end -->