### PR TITLE
[Rando] Prevent alarm when at full HP

### DIFF
--- a/soh/soh/Enhancements/game-interactor/GameInteractor.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor.h
@@ -303,7 +303,7 @@ typedef enum {
     // Vanilla condition: this->reward == GI_NONE
     VB_FROGS_GO_TO_IDLE,
     // Vanilla condition: var >= gSaveContext.health) && (gSaveContext.health > 0
-    VB_PREVENT_ALARM_AT_FULL_HEALTH,
+    VB_HEALTH_METER_BE_CRITICAL,
 
     /*** Play Cutscenes ***/
 

--- a/soh/soh/Enhancements/game-interactor/GameInteractor.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor.h
@@ -302,6 +302,8 @@ typedef enum {
     // Opt: *EnFr
     // Vanilla condition: this->reward == GI_NONE
     VB_FROGS_GO_TO_IDLE,
+    // Vanilla condition: var >= gSaveContext.health) && (gSaveContext.health > 0
+    VB_PREVENT_ALARM_AT_FULL_HEALTH,
 
     /*** Play Cutscenes ***/
 

--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -1631,7 +1631,7 @@ void RandomizerOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_l
             }
             break;
         }
-        case VB_PREVENT_ALARM_AT_FULL_HEALTH: {
+        case VB_HEALTH_METER_BE_CRITICAL: {
             if (gSaveContext.health == gSaveContext.healthCapacity) {
                 *should = false;
             }

--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -1631,6 +1631,12 @@ void RandomizerOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_l
             }
             break;
         }
+        case VB_PREVENT_ALARM_AT_FULL_HEALTH: {
+            if (gSaveContext.health == gSaveContext.healthCapacity) {
+                *should = false;
+            }
+            break;
+        }
         case VB_FREEZE_ON_SKULL_TOKEN:
         case VB_TRADE_TIMER_ODD_MUSHROOM:
         case VB_TRADE_TIMER_FROG:

--- a/soh/src/code/z_lifemeter.c
+++ b/soh/src/code/z_lifemeter.c
@@ -675,7 +675,7 @@ u32 HealthMeter_IsCritical(void) {
         var = 0x2C;
     }
 
-    if (GameInteractor_Should(VB_PREVENT_ALARM_AT_FULL_HEALTH, var >= gSaveContext.health && gSaveContext.health > 0)) {
+    if (GameInteractor_Should(VB_HEALTH_METER_BE_CRITICAL, var >= gSaveContext.health && gSaveContext.health > 0)) {
         return true;
     } else {
         return false;

--- a/soh/src/code/z_lifemeter.c
+++ b/soh/src/code/z_lifemeter.c
@@ -2,6 +2,7 @@
 #include "textures/parameter_static/parameter_static.h"
 #include "soh/frame_interpolation.h"
 #include "soh/OTRGlobals.h"
+#include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
 s16 Top_LM_Margin = 0;
 s16 Left_LM_Margin = 0;
@@ -674,7 +675,7 @@ u32 HealthMeter_IsCritical(void) {
         var = 0x2C;
     }
 
-    if ((var >= gSaveContext.health) && (gSaveContext.health > 0)) {
+    if (GameInteractor_Should(VB_PREVENT_ALARM_AT_FULL_HEALTH, var >= gSaveContext.health && gSaveContext.health > 0)) {
         return true;
     } else {
         return false;


### PR DESCRIPTION
To stop the low health beeping noise and Link's idle animation from playing when you only have 1 heart capacity. #4620 

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2416507895.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2416511612.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2416531512.zip)
<!--- section:artifacts:end -->