### PR TITLE
Move Window calls to portside

### DIFF
--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -1356,12 +1356,18 @@ extern "C" void Graph_StartFrame() {
         CVarClear(CVAR_DROPPED_FILE);
     }
 
-    OTRGlobals::Instance->context->GetWindow()->StartFrame();
+    // OTRGlobals::Instance->context->GetWindow()->StartFrame();
 }
 
 void RunCommands(Gfx* Commands, const std::vector<std::unordered_map<Mtx*, MtxF>>& mtx_replacements) {
+    auto wnd = OTRGlobals::Instance->context->GetWindow();
+    auto gui = wnd->GetGui();
+
     for (const auto& m : mtx_replacements) {
+        gui->StartDraw();
+        wnd->StartFrame();
         gfx_run(Commands, m);
+        gui->EndDraw();
         gfx_end_frame();
     }
 }

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -1355,20 +1355,31 @@ extern "C" void Graph_StartFrame() {
         CVarClear(CVAR_NEW_FILE_DROPPED);
         CVarClear(CVAR_DROPPED_FILE);
     }
-
-    // OTRGlobals::Instance->context->GetWindow()->StartFrame();
 }
 
 void RunCommands(Gfx* Commands, const std::vector<std::unordered_map<Mtx*, MtxF>>& mtx_replacements) {
     auto wnd = OTRGlobals::Instance->context->GetWindow();
     auto gui = wnd->GetGui();
 
+    // Process window events for resize, mouse, keyboard events
+    wnd->HandleEvents();
+
     for (const auto& m : mtx_replacements) {
+        // Skip dropped frames
+        if (!wnd->IsFrameReady()) {
+            continue;
+        }
+
+        // Setup of the backend frames and draw initial Window and GUI menus
         gui->StartDraw();
+        // Setup game framebuffers to match available window space
         wnd->StartFrame();
+        // Execute the games gfx commands
         gfx_run(Commands, m);
+        // Renders the game frame buffer to the final window and finishes the GUI
         gui->EndDraw();
-        gfx_end_frame();
+        // Finialize swap buffers
+        wnd->EndFrame();
     }
 }
 

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -1358,28 +1358,17 @@ extern "C" void Graph_StartFrame() {
 }
 
 void RunCommands(Gfx* Commands, const std::vector<std::unordered_map<Mtx*, MtxF>>& mtx_replacements) {
-    auto wnd = OTRGlobals::Instance->context->GetWindow();
-    auto gui = wnd->GetGui();
+    auto wnd = std::dynamic_pointer_cast<Fast::Fast3dWindow>(OTRGlobals::Instance->context->GetWindow());
+
+    if (wnd == nullptr) {
+        return;
+    }
 
     // Process window events for resize, mouse, keyboard events
     wnd->HandleEvents();
 
     for (const auto& m : mtx_replacements) {
-        // Skip dropped frames
-        if (!wnd->IsFrameReady()) {
-            continue;
-        }
-
-        // Setup of the backend frames and draw initial Window and GUI menus
-        gui->StartDraw();
-        // Setup game framebuffers to match available window space
-        wnd->StartFrame();
-        // Execute the games gfx commands
-        gfx_run(Commands, m);
-        // Renders the game frame buffer to the final window and finishes the GUI
-        gui->EndDraw();
-        // Finialize swap buffers
-        wnd->EndFrame();
+        wnd->DrawAndRunGraphicsCommands(Commands, m);
     }
 }
 


### PR DESCRIPTION
This bumps LUS and updates the game render loop to call a new method exposed on the `Fast3dWindow` class itself which ensures proper order of rendering ImGui and the game.

Notably this is done to fix the issues with DirectX crashing on latest nightlies and framebuffer garbage rendering when resizing the window.

* LUS PR: https://github.com/Kenix3/libultraship/pull/787

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2416417327.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2416418728.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2416427455.zip)
<!--- section:artifacts:end -->