### PR TITLE
fix tooltip wonkyness

### DIFF
--- a/soh/soh/UIWidgets.cpp
+++ b/soh/soh/UIWidgets.cpp
@@ -213,11 +213,11 @@ namespace UIWidgets {
     }
 
     void ReEnableComponent(const char* disabledTooltipText) {
-        // End of disable region of previous component
-        ImGui::PopStyleVar(1);
         if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && strcmp(disabledTooltipText, "") != 0) {
             ImGui::SetTooltip("%s", disabledTooltipText);
         }
+        // End of disable region of previous component
+        ImGui::PopStyleVar(1);
         ImGui::PopItemFlag();
     }
 


### PR DESCRIPTION
@Spodi mentioned
> oh what, my game just blacked out. no image at all
hovering over some option in Graphic enhancement menu causes that
let me check which one
seems like cull glitch actors, when it is actually disabled (as in: greyed out) (edited)
hovering ANY grayed out menu checkbox results in a blackout, lol
nothing i tried makes it go away, other than completely closing the game (edited)

i did some digging and wasn't able to repro that exact behavior but following the repro steps led to

https://github.com/user-attachments/assets/7714a65f-3010-4151-8509-45dbdeb037b1

i then found/mentioned
> so it seems to be tooltip related, i can't repro the issue if i comment out https://github.com/HarbourMasters/Shipwright/blob/0ae7f626a1dccc17a9d98ea0fc701616f955ac7f/soh/soh/UIWidgets.cpp#L218-L220  (which is interesting because it's not something i touched in https://github.com/HarbourMasters/Shipwright/pull/4838)

after more digging i found

> so the tooltip stuff has something to do with <https://github.com/ocornut/imgui/commit/f953ebf9ca15bbe1477d4cef499009faa8110814>
> 
> i tried commenting out `BeginDisabledOverrideReenable` and `EndDisabledOverrideReenable` and it doesn't bug out, but i see the standard tooltip instead of the disabled tooltip
> 
> i can also get to that point without changing imgui source by changing `ReEnableComponent` to have the tooltip stuff before `PopStyleVar` and `PopItemFlag` instead of in between them (and i know we're making it into the if block because i put logging in there and it's logging when i'm hovering
> 
> orig
> ```cpp
>     void ReEnableComponent(const char* disabledTooltipText) {
>         // End of disable region of previous component
>         ImGui::PopStyleVar(1);
>         if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && strcmp(disabledTooltipText, "") != 0) {
>             ImGui::SetTooltip("%s", disabledTooltipText);
>         }
>         ImGui::PopItemFlag();
>     }
> ```
> 
> shows non-disabled tooltip
> ```cpp
>     void ReEnableComponent(const char* disabledTooltipText) {
>         // End of disable region of previous component
>         if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && strcmp(disabledTooltipText, "") != 0) {
>             SPDLOG_INFO("blarg");
>             ImGui::SetTooltip("%s", disabledTooltipText);
>         }
>         ImGui::PopStyleVar(1);
>         ImGui::PopItemFlag();
>     }
> 
> ```
> 
> so i did a bit more digging and grabbed a build from before the imgui bump <https://github.com/HarbourMasters/Shipwright/actions/runs/12721871572> and tested out the tooltip - it seems we're seeing the standard (non-disabled) tooltip every time (even when the checkbox is disabled) there too

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2417043021.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2417044740.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2417045381.zip)
<!--- section:artifacts:end -->