### PR TITLE
Fix Skeleton Key Hint

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/hint_list/hint_list_item.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/hint_list/hint_list_item.cpp
@@ -2057,7 +2057,7 @@ void StaticData::HintTable_Init_Item() {
                                                }, {
                                                CustomMessage("a fish-puller", /*german*/"ein Fischzieher", /*french*/"(canne à pêche)")});
                                                 // /*spanish*/(caña de pescar)
-    hintTextTable[RHT_SKELETON_KEY] = HintText(CustomMessage("a Skeleton Key", /*german*/ "ein Universalschlüssel", /*french*/ "une Clé Squelette),
+    hintTextTable[RHT_SKELETON_KEY] = HintText(CustomMessage("a Skeleton Key", /*german*/ "ein Universalschlüssel", /*french*/ "une Clé Squelette"),
                                                // /*spanish*/una Llave Maestra
                                                {
                                                CustomMessage("a key", /*german*/ "ein Schlüssel", /*french*/ "une clé")

--- a/soh/soh/Enhancements/randomizer/3drando/hint_list/hint_list_item.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/hint_list/hint_list_item.cpp
@@ -2063,7 +2063,7 @@ void StaticData::HintTable_Init_Item() {
                                                CustomMessage("a key", /*german*/ "ein Schlüssel", /*french*/ "une clé")
                                                 // /*spanish*/una llave
                                                },
-                                               { CustomMessage("a master unlocker", /*german*/ "ein Meisterentsperrer", /*french*/ "un déverrouilleur maître") });
+                                               { CustomMessage("a master unlocker", /*german*/ "ein Meisterentsperrer", /*french*/ "un Kit de Déverrouillage") });
                                                 // /*spanish*/un desbloqueador maestro
     hintTextTable[RHT_QUIVER_INF] = HintText(CustomMessage("", /*german*/"!!!", /*french*/"!!!"),
                                              {

--- a/soh/soh/Enhancements/randomizer/3drando/hint_list/hint_list_item.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/hint_list/hint_list_item.cpp
@@ -2057,7 +2057,7 @@ void StaticData::HintTable_Init_Item() {
                                                }, {
                                                CustomMessage("a fish-puller", /*german*/"ein Fischzieher", /*french*/"(canne à pêche)")});
                                                 // /*spanish*/(caña de pescar)
-    hintTextTable[RHT_SKELETON_KEY] = HintText(CustomMessage("a Skeleton Key", /*german*/ "ein Universalschlüssel", /*french*/ "un Passe-Partout"),
+    hintTextTable[RHT_SKELETON_KEY] = HintText(CustomMessage("a Skeleton Key", /*german*/ "ein Universalschlüssel", /*french*/ "une Clé Squelette),
                                                // /*spanish*/una Llave Maestra
                                                {
                                                CustomMessage("a key", /*german*/ "ein Schlüssel", /*french*/ "une clé")

--- a/soh/soh/Enhancements/randomizer/3drando/hint_list/hint_list_item.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/hint_list/hint_list_item.cpp
@@ -2057,7 +2057,14 @@ void StaticData::HintTable_Init_Item() {
                                                }, {
                                                CustomMessage("a fish-puller", /*german*/"ein Fischzieher", /*french*/"(canne à pêche)")});
                                                 // /*spanish*/(caña de pescar)
-  
+    hintTextTable[RHT_SKELETON_KEY] = HintText(CustomMessage("a Skeleton Key", /*german*/ "ein Universalschlüssel", /*french*/ "un Passe-Partout"),
+                                               // /*spanish*/una Llave Maestra
+                                               {
+                                               CustomMessage("a key", /*german*/ "ein Schlüssel", /*french*/ "une clé")
+                                                // /*spanish*/una llave
+                                               },
+                                               { CustomMessage("a master unlocker", /*german*/ "ein Meisterentsperrer", /*french*/ "un déverrouilleur maître") });
+                                                // /*spanish*/un desbloqueador maestro
     hintTextTable[RHT_QUIVER_INF] = HintText(CustomMessage("", /*german*/"!!!", /*french*/"!!!"),
                                              {
                                              CustomMessage("", /*german*/"!!!", /*french*/"!!!"),


### PR DESCRIPTION
Fixes #4854 
Adds text to skeleton key hint. Will need translation review.

Successful hint generation attached for Clear, Ambiguous, Obscure types

[05-23-56-08-20.json](https://github.com/user-attachments/files/18386748/05-23-56-08-20.json)
[11-49-39-86-79.json](https://github.com/user-attachments/files/18386749/11-49-39-86-79.json)
[24-21-66-99-72.json](https://github.com/user-attachments/files/18386750/24-21-66-99-72.json)


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2417340646.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2417343904.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2417357113.zip)
<!--- section:artifacts:end -->