### PR TITLE
Revert default imgui behavior of MacOS CMD and CTRL keys

### DIFF
--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -405,6 +405,9 @@ OTRGlobals::OTRGlobals() {
     defaultFontLargest = CreateDefaultFontWithSize(20.0f);
     ScaleImGui();
 
+    // Force OSX behavior off so that CMD is not swapped with CTRL (i.e. our CMD+R hotkey, CTRL+LeftClick on input fields)
+    ImGui::GetIO().ConfigMacOSXBehaviors = false;
+
     // Move the camera strings from read only memory onto the heap (writable memory)
     // This is in OTRGlobals right now because this is a place that will only ever be run once at the beginning of startup.
     // We should probably find some code in db_camera that does initialization and only run once, and then dealloc on deinitialization.


### PR DESCRIPTION
After the ImGui bump, default behavior of how the CMD and CTRL keys are handled in MacOS were swapped. This sets a flag to return back to the previous behavior where `ImGuiKey::Super` == CMD and `ImGuiKey::Ctrl` == CTRL

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2437922660.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2437925438.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2437929477.zip)
<!--- section:artifacts:end -->