### PR TITLE
Fix RTA Triforce Hunt timer

### DIFF
--- a/soh/soh/Enhancements/gameplaystats.h
+++ b/soh/soh/Enhancements/gameplaystats.h
@@ -22,7 +22,10 @@ extern "C" {
 #define GAMEPLAYSTAT_TOTAL_TIME (gSaveContext.ship.stats.rtaTiming ?\
     (!gSaveContext.ship.stats.gameComplete ?\
         (!gSaveContext.ship.stats.fileCreatedAt ? 0 : ((GetUnixTimestamp() - gSaveContext.ship.stats.fileCreatedAt) / 100)) :\
-        (gSaveContext.ship.stats.itemTimestamp[TIMESTAMP_DEFEAT_GANON])) :\
+        (gSaveContext.ship.stats.itemTimestamp[TIMESTAMP_DEFEAT_GANON]                         \
+                       ? gSaveContext.ship.stats.itemTimestamp[TIMESTAMP_DEFEAT_GANON]         \
+                       : gSaveContext.ship.stats.itemTimestamp[TIMESTAMP_TRIFORCE_COMPLETED])) \
+         :\
     (gSaveContext.ship.stats.playTimer / 2 + gSaveContext.ship.stats.pauseTimer / 3))
 #define CURRENT_MODE_TIMER (CVarGetInteger(CVAR_ENHANCEMENT("GameplayStats.RoomBreakdown"), 0) ?\
     gSaveContext.ship.stats.roomTimer :\


### PR DESCRIPTION
Fixes https://github.com/HarbourMasters/Shipwright/issues/4845

RTA timer was relying on the "ganon defeated" timestamp, but if someone is playing triforce hunt, it was reading as 0 because that timestamp didn't exist. Now it's using the triforce completed timestamp if the ganon timestamp doesn't exist. This also gracefully handles the situation where someone first completes the triforce, then beats ganon. The completed time will then use the ganon time as I'd imagine is what the player would expect.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2448639586.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2448652384.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2448663107.zip)
<!--- section:artifacts:end -->