### PR TITLE
Fix  ice trap animation not resetting

### DIFF
--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -278,6 +278,7 @@ void RandomizerOnPlayerUpdateForRCQueueHandler() {
     if (loc->HasObtained()) {
         SPDLOG_INFO("RC {} already obtained, skipping", static_cast<uint32_t>(rc));
     } else {
+        iceTrapScale = 0.0f;
         randomizerQueuedCheck = rc;
         randomizerQueuedItemEntry = getItemEntry;
         SPDLOG_INFO("Queueing Item mod {} item {} from RC {}", getItemEntry.modIndex, getItemEntry.itemId, static_cast<uint32_t>(rc));


### PR DESCRIPTION
Fixes https://github.com/HarbourMasters/Shipwright/issues/4842

IceTrapScale wasn't being reset properly after the item queue was introduced. It is still living in `GiveItemEntryFromActor` but I also added it when an item gets queued up with the new system. Now the ice trap properly grows over the item even after the initial first ice trap.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2448787521.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2448798233.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2448799936.zip)
<!--- section:artifacts:end -->