### PR TITLE
Play success sound on dropping in spoiler log

### DIFF
--- a/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -1035,6 +1035,7 @@ void FileChoose_UpdateRandomizer() {
         SpoilerFileExists(CVarGetString(CVAR_GENERAL("SpoilerLog"), "")) && !fileSelectSpoilerFileLoaded) {
             if (CVarGetInteger(CVAR_GENERAL("RandomizerNewFileDropped"), 0) != 0) {
                 CVarSetString(CVAR_GENERAL("SpoilerLog"), CVarGetString(CVAR_GENERAL("RandomizerDroppedFile"), ""));
+                Audio_PlayFanfare(NA_BGM_HORSE_GOAL);
             }
             const char* fileLoc = CVarGetString(CVAR_GENERAL("SpoilerLog"), "");
             CVarSetInteger(CVAR_GENERAL("RandomizerNewFileDropped"), 0);


### PR DESCRIPTION
Fixes https://github.com/HarbourMasters/Shipwright/issues/4846

No clue when this broke, but added back the success sound for dropping in a spoiler log. It's specifically inside that if statement because the rest of this code also runs when you load up the game with a spoiler log loaded previously. This makes sure it only plays when someone actively drops a spoiler log onto the game.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2448866656.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2448868329.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2448878009.zip)
<!--- section:artifacts:end -->