### PR TITLE
Uncomment chime on one point cutscenes

### DIFF
--- a/soh/soh/Enhancements/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.cpp
@@ -108,8 +108,7 @@ void BgSpot03Taki_KeepOpen(BgSpot03Taki* bgSpot03Taki, PlayState* play) {
 static int successChimeCooldown = 0;
 void RateLimitedSuccessChime() {
     if (successChimeCooldown == 0) {
-        // Currently disabled, need to find a better way to do this, while being consistent with vanilla
-        // func_80078884(NA_SE_SY_CORRECT_CHIME);
+        Sfx_PlaySfxCentered(NA_SE_SY_CORRECT_CHIME);
         successChimeCooldown = 120;
     }
 }


### PR DESCRIPTION
Eventually meant to fix https://github.com/HarbourMasters/Shipwright/issues/4705

Uncomments the chime for playing cutscenes. According to @garrettjoecox this was commented out because it felt bad when they stayed in, but I've noticed the lack of feedback can confuse players sometimes (saw it on streams and myself). This PR, for now, just exists to easily share test builds so we can figure out where the pain points are and possibly find a better solution.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2450808088.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2450809091.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2450811111.zip)
<!--- section:artifacts:end -->