### PR TITLE
Fix rando menu sliders so they update on JSON drop

### DIFF
--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -2432,6 +2432,10 @@ void SoH_ProcessDroppedFiles(std::string filePath) {
             }
         }
 
+        auto randoCtx = Rando::Context::GetInstance();
+        randoCtx->GetSettings()->UpdateOptionProperties();
+        randoCtx->GetSettings()->SetAllFromCVar();
+
         auto gui = Ship::Context::GetInstance()->GetWindow()->GetGui();
         gui->GetGuiWindow("Console")->Hide();
         gui->GetGuiWindow("Actor Viewer")->Hide();


### PR DESCRIPTION
Sliders in the rando menu would not visually update when a shipofharkinian.json was dropped. The CVars would update, so the actual in-game effect of the json values would take effect, this is just ensuring the sliders stay visually updated. Other UI elements were checking the CVar directly, it was only the sliders that weren't at the moment. In theory this would have also fixed them if they were checking the Rando Settings instance instead.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2453450435.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2453453496.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2453456730.zip)
<!--- section:artifacts:end -->