### PR TITLE
Fix the trick options loop

### DIFF
--- a/soh/soh/Enhancements/randomizer/settings.cpp
+++ b/soh/soh/Enhancements/randomizer/settings.cpp
@@ -533,7 +533,8 @@ void Settings::CreateOptions() {
     });
     // TODO: Exclude Locations Menus
     mTricksByArea.clear();
-    std::vector<Option*> tricksOption(mTrickOptions.size());
+    std::vector<Option*> tricksOption;
+    tricksOption.reserve(mTrickOptions.size());
     for (int i = 0; i < RT_MAX; i++) {
         auto trick = &mTrickOptions[i];
         if (!trick->GetName().empty()) {


### PR DESCRIPTION
It initialized an array with a size, which pre-filled it all with nullptrs, and then used push_back on top of that. So it was a bunch of nullptrs followed by the actual option pointers. Fixed by calling reserve instead of constructing with a size, so it reserves the memory it needs without actually filling the vector with nullptrs, so push_back properly starts from the beginning.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2453799718.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2453801731.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2453803972.zip)
<!--- section:artifacts:end -->