### PR TITLE
Fix: particle effect back for progressive bombchus

### DIFF
--- a/soh/src/code/z_en_item00.c
+++ b/soh/src/code/z_en_item00.c
@@ -1210,6 +1210,9 @@ void EnItem00_CustomItemsParticles(Actor* Parent, PlayState* play, GetItemEntry 
                 case ITEM_LETTER_RUTO:
                     colorIndex = PARTICLE_WHITE;
                     break;
+                case ITEM_BOMBCHU:
+                    colorIndex = PARTICLE_DARK_BLUE;
+                    break;
                 default:
                     return;
             }
@@ -1253,9 +1256,6 @@ void EnItem00_CustomItemsParticles(Actor* Parent, PlayState* play, GetItemEntry 
                     break;
                 case RG_DOUBLE_DEFENSE:
                     colorIndex = PARTICLE_WHITE;
-                    break;
-                case RG_PROGRESSIVE_BOMBCHUS:
-                    colorIndex = PARTICLE_DARK_BLUE;
                     break;
                 case RG_BOTTLE_WITH_FAIRY:
                     colorIndex = PARTICLE_PINK;


### PR DESCRIPTION
Only useful in shops to differentiate pricing from refills.
![image](https://github.com/user-attachments/assets/aefca53a-019f-4222-9473-1c6bf44e2d4d)


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2458694919.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2458697809.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2458699264.zip)
<!--- section:artifacts:end -->