### PR TITLE
Unlock locked interior doors with overworld keys enabled

### DIFF
--- a/soh/soh/Enhancements/randomizer/LockOverworldDoors.cpp
+++ b/soh/soh/Enhancements/randomizer/LockOverworldDoors.cpp
@@ -16,7 +16,6 @@ std::map<SceneDoorParamsPair, RandomizerInf> lookupTable = {
     {{ SCENE_MARKET_ENTRANCE_DAY, 447 },         RAND_INF_GUARD_HOUSE_UNLOCKED },
     {{ SCENE_MARKET_ENTRANCE_NIGHT, 447 },       RAND_INF_GUARD_HOUSE_UNLOCKED },
     {{ SCENE_MARKET_ENTRANCE_RUINS, 447 },       RAND_INF_GUARD_HOUSE_UNLOCKED },
-    {{ SCENE_MARKET_GUARD_HOUSE, 447 },          RAND_INF_GUARD_HOUSE_UNLOCKED },
     {{ SCENE_MARKET_DAY, 4543 },                 RAND_INF_MARKET_BAZAAR_UNLOCKED },
     {{ SCENE_MARKET_NIGHT, 4753 },               RAND_INF_MARKET_BAZAAR_UNLOCKED },
     {{ SCENE_MARKET_DAY, 1471 },                 RAND_INF_MARKET_POTION_SHOP_UNLOCKED },
@@ -25,22 +24,16 @@ std::map<SceneDoorParamsPair, RandomizerInf> lookupTable = {
     {{ SCENE_MARKET_NIGHT, 3728 },               RAND_INF_MASK_SHOP_UNLOCKED },
     {{ SCENE_MARKET_DAY, 2495 },                 RAND_INF_MARKET_SHOOTING_GALLERY_UNLOCKED },
     {{ SCENE_MARKET_NIGHT, 2703 },               RAND_INF_MARKET_SHOOTING_GALLERY_UNLOCKED },
-    {{ SCENE_SHOOTING_GALLERY, 447 },            RAND_INF_MARKET_SHOOTING_GALLERY_UNLOCKED },
     {{ SCENE_MARKET_DAY, 5567 },                 RAND_INF_BOMBCHU_BOWLING_UNLOCKED },
     {{ SCENE_MARKET_NIGHT, 5567 },               RAND_INF_BOMBCHU_BOWLING_UNLOCKED },
-    {{ SCENE_BOMBCHU_BOWLING_ALLEY, 447 },       RAND_INF_BOMBCHU_BOWLING_UNLOCKED },
     {{ SCENE_MARKET_DAY, 653 },                  RAND_INF_TREASURE_CHEST_GAME_BUILDING_UNLOCKED },
     {{ SCENE_MARKET_NIGHT, 447 },                RAND_INF_TREASURE_CHEST_GAME_BUILDING_UNLOCKED },
-    {{ SCENE_TREASURE_BOX_SHOP, 6591 },          RAND_INF_TREASURE_CHEST_GAME_BUILDING_UNLOCKED },
     {{ SCENE_BACK_ALLEY_DAY, 2689 },             RAND_INF_BOMBCHU_SHOP_UNLOCKED },
     {{ SCENE_BACK_ALLEY_NIGHT, 2495 },           RAND_INF_BOMBCHU_SHOP_UNLOCKED },
     {{ SCENE_BACK_ALLEY_DAY, 447 },              RAND_INF_RICHARDS_HOUSE_UNLOCKED },
     {{ SCENE_BACK_ALLEY_NIGHT, 447 },            RAND_INF_RICHARDS_HOUSE_UNLOCKED },
-    {{ SCENE_DOG_LADY_HOUSE, 447 },              RAND_INF_RICHARDS_HOUSE_UNLOCKED },
-    {{ SCENE_DOG_LADY_HOUSE, 447 },              RAND_INF_RICHARDS_HOUSE_UNLOCKED },
     {{ SCENE_BACK_ALLEY_HOUSE, 447 },            RAND_INF_ALLEY_HOUSE_UNLOCKED },
     {{ SCENE_BACK_ALLEY_DAY, 1665 },             RAND_INF_ALLEY_HOUSE_UNLOCKED },
-    {{ SCENE_BACK_ALLEY_NIGHT, 1471 },           RAND_INF_ALLEY_HOUSE_UNLOCKED },
     {{ SCENE_KAKARIKO_VILLAGE, 6801 },           RAND_INF_KAK_BAZAAR_UNLOCKED }, // Adult Night
     {{ SCENE_KAKARIKO_VILLAGE, 6591 },           RAND_INF_KAK_BAZAAR_UNLOCKED }, // Adult Day
     {{ SCENE_KAKARIKO_VILLAGE, 6813 },           RAND_INF_KAK_BAZAAR_UNLOCKED }, // Child Day
@@ -51,35 +44,47 @@ std::map<SceneDoorParamsPair, RandomizerInf> lookupTable = {
     {{ SCENE_KAKARIKO_VILLAGE, 7822 },           RAND_INF_KAK_POTION_SHOP_UNLOCKED }, // Adult Night
     {{ SCENE_KAKARIKO_VILLAGE, 7615 },           RAND_INF_KAK_POTION_SHOP_UNLOCKED }, // Child Day/Night and Adult Day
     {{ SCENE_KAKARIKO_VILLAGE, 2495 },           RAND_INF_BOSS_HOUSE_UNLOCKED },
-    {{ SCENE_KAKARIKO_CENTER_GUEST_HOUSE, 447 }, RAND_INF_BOSS_HOUSE_UNLOCKED },
     {{ SCENE_KAKARIKO_VILLAGE, 3750 },           RAND_INF_GRANNYS_POTION_SHOP_UNLOCKED }, // Child
     {{ SCENE_KAKARIKO_VILLAGE, 3519 },           RAND_INF_GRANNYS_POTION_SHOP_UNLOCKED }, // Adult
-    {{ SCENE_POTION_SHOP_GRANNY, 447 },          RAND_INF_GRANNYS_POTION_SHOP_UNLOCKED },
     {{ SCENE_KAKARIKO_VILLAGE, 5567 },           RAND_INF_SKULLTULA_HOUSE_UNLOCKED },
-    {{ SCENE_HOUSE_OF_SKULLTULA, 447 },          RAND_INF_SKULLTULA_HOUSE_UNLOCKED },
     {{ SCENE_KAKARIKO_VILLAGE, 1471 },           RAND_INF_IMPAS_HOUSE_UNLOCKED },
-    {{ SCENE_IMPAS_HOUSE, 447 },                 RAND_INF_IMPAS_HOUSE_UNLOCKED },
     {{ SCENE_KAKARIKO_VILLAGE, 447 },            RAND_INF_WINDMILL_UNLOCKED },
-    {{ SCENE_WINDMILL_AND_DAMPES_GRAVE, 2495 },  RAND_INF_WINDMILL_UNLOCKED },
     {{ SCENE_KAKARIKO_VILLAGE, 4543 },           RAND_INF_KAK_SHOOTING_GALLERY_UNLOCKED }, // Day
     {{ SCENE_KAKARIKO_VILLAGE, 4751 },           RAND_INF_KAK_SHOOTING_GALLERY_UNLOCKED }, // Night
-    {{ SCENE_SHOOTING_GALLERY, 447 },            RAND_INF_KAK_SHOOTING_GALLERY_UNLOCKED },
     {{ SCENE_GRAVEYARD, 645 },                   RAND_INF_DAMPES_HUT_UNLOCKED }, // Child Day
     {{ SCENE_GRAVEYARD, 447 },                   RAND_INF_DAMPES_HUT_UNLOCKED }, // Child Evening & Adult
     {{ SCENE_GRAVEYARD, 774 },                   RAND_INF_DAMPES_HUT_UNLOCKED }, // Child Night (After Dampes Tour)
-    {{ SCENE_GRAVEKEEPERS_HUT, 447 },            RAND_INF_DAMPES_HUT_UNLOCKED },
     {{ SCENE_LON_LON_RANCH, 2495 },              RAND_INF_TALONS_HOUSE_UNLOCKED },
     {{ SCENE_LON_LON_RANCH, 2473 },              RAND_INF_TALONS_HOUSE_UNLOCKED },
     {{ SCENE_LON_LON_RANCH, 2729 },              RAND_INF_TALONS_HOUSE_UNLOCKED },
-    {{ SCENE_LON_LON_BUILDINGS, 1471 },          RAND_INF_TALONS_HOUSE_UNLOCKED },
     {{ SCENE_LON_LON_RANCH, 1471 },              RAND_INF_STABLES_UNLOCKED },
-    {{ SCENE_STABLE, 447 },                      RAND_INF_STABLES_UNLOCKED },
     {{ SCENE_LON_LON_RANCH, 447 },               RAND_INF_BACK_TOWER_UNLOCKED },
-    {{ SCENE_LON_LON_BUILDINGS, 447 },           RAND_INF_BACK_TOWER_UNLOCKED },
     {{ SCENE_LAKE_HYLIA, 447 },                  RAND_INF_HYLIA_LAB_UNLOCKED },
-    {{ SCENE_LAKESIDE_LABORATORY, 447 },         RAND_INF_HYLIA_LAB_UNLOCKED },
     {{ SCENE_LAKE_HYLIA, 1471 },                 RAND_INF_FISHING_HOLE_UNLOCKED },
+    // Doors below this are the insides of the interior areas. In entrance rando, this meant you could
+    // very easily get stuck inside these areas. Outside of entrance rando, you wouldn't be able
+    // to enter these areas without unlocking the outside door anyway, so for now they're
+    // commented out just in case someone else wants to use them for something in the future.
+    /*
+    {{ SCENE_MARKET_GUARD_HOUSE, 447 },          RAND_INF_GUARD_HOUSE_UNLOCKED },
+    {{ SCENE_SHOOTING_GALLERY, 447 },            RAND_INF_MARKET_SHOOTING_GALLERY_UNLOCKED },
+    {{ SCENE_BOMBCHU_BOWLING_ALLEY, 447 },       RAND_INF_BOMBCHU_BOWLING_UNLOCKED },
+    {{ SCENE_TREASURE_BOX_SHOP, 6591 },          RAND_INF_TREASURE_CHEST_GAME_BUILDING_UNLOCKED },
+    {{ SCENE_DOG_LADY_HOUSE, 447 },              RAND_INF_RICHARDS_HOUSE_UNLOCKED },
+    {{ SCENE_BACK_ALLEY_NIGHT, 1471 },           RAND_INF_ALLEY_HOUSE_UNLOCKED },
+    {{ SCENE_KAKARIKO_CENTER_GUEST_HOUSE, 447 }, RAND_INF_BOSS_HOUSE_UNLOCKED },
+    {{ SCENE_POTION_SHOP_GRANNY, 447 },          RAND_INF_GRANNYS_POTION_SHOP_UNLOCKED },
+    {{ SCENE_HOUSE_OF_SKULLTULA, 447 },          RAND_INF_SKULLTULA_HOUSE_UNLOCKED },
+    {{ SCENE_IMPAS_HOUSE, 447 },                 RAND_INF_IMPAS_HOUSE_UNLOCKED },
+    {{ SCENE_WINDMILL_AND_DAMPES_GRAVE, 2495 },  RAND_INF_WINDMILL_UNLOCKED },
+    {{ SCENE_SHOOTING_GALLERY, 447 },            RAND_INF_KAK_SHOOTING_GALLERY_UNLOCKED },
+    {{ SCENE_GRAVEKEEPERS_HUT, 447 },            RAND_INF_DAMPES_HUT_UNLOCKED },
+    {{ SCENE_LON_LON_BUILDINGS, 1471 },          RAND_INF_TALONS_HOUSE_UNLOCKED },
+    {{ SCENE_STABLE, 447 },                      RAND_INF_STABLES_UNLOCKED },
+    {{ SCENE_LON_LON_BUILDINGS, 447 },           RAND_INF_BACK_TOWER_UNLOCKED },
+    {{ SCENE_LAKESIDE_LABORATORY, 447 },         RAND_INF_HYLIA_LAB_UNLOCKED },
     {{ SCENE_FISHING_POND, 447 },                RAND_INF_FISHING_HOLE_UNLOCKED },
+    */
 };
 
 static void OnDoorInit(void* actorRef) {
@@ -88,12 +93,7 @@ static void OnDoorInit(void* actorRef) {
 
     auto it = lookupTable.find({gPlayState->sceneNum, enDoor->actor.params});
     if (it != lookupTable.end()) {
-        if (it->second == RAND_INF_MARKET_SHOOTING_GALLERY_UNLOCKED && gSaveContext.entranceIndex == 0x3B) {
-            // Adult shooting gallery uses same scene and door params as child, so we manually handle it
-            enDoor->randomizerInf = RAND_INF_KAK_SHOOTING_GALLERY_UNLOCKED;
-        } else {
-            enDoor->randomizerInf = it->second;
-        }
+        enDoor->randomizerInf = it->second;
         if (!Flags_GetRandomizerInf(enDoor->randomizerInf)) {
             // We don't want to override checkable doors, we still want those to not be openable even if they have a key
             if (((enDoor->actor.params >> 7) & 7) != DOOR_CHECKABLE) {

--- a/soh/soh/Enhancements/randomizer/LockOverworldDoors.cpp
+++ b/soh/soh/Enhancements/randomizer/LockOverworldDoors.cpp
@@ -61,30 +61,6 @@ std::map<SceneDoorParamsPair, RandomizerInf> lookupTable = {
     {{ SCENE_LON_LON_RANCH, 447 },               RAND_INF_BACK_TOWER_UNLOCKED },
     {{ SCENE_LAKE_HYLIA, 447 },                  RAND_INF_HYLIA_LAB_UNLOCKED },
     {{ SCENE_LAKE_HYLIA, 1471 },                 RAND_INF_FISHING_HOLE_UNLOCKED },
-    // Doors below this are the insides of the interior areas. In entrance rando, this meant you could
-    // very easily get stuck inside these areas. Outside of entrance rando, you wouldn't be able
-    // to enter these areas without unlocking the outside door anyway, so for now they're
-    // commented out just in case someone else wants to use them for something in the future.
-    /*
-    {{ SCENE_MARKET_GUARD_HOUSE, 447 },          RAND_INF_GUARD_HOUSE_UNLOCKED },
-    {{ SCENE_SHOOTING_GALLERY, 447 },            RAND_INF_MARKET_SHOOTING_GALLERY_UNLOCKED },
-    {{ SCENE_BOMBCHU_BOWLING_ALLEY, 447 },       RAND_INF_BOMBCHU_BOWLING_UNLOCKED },
-    {{ SCENE_TREASURE_BOX_SHOP, 6591 },          RAND_INF_TREASURE_CHEST_GAME_BUILDING_UNLOCKED },
-    {{ SCENE_DOG_LADY_HOUSE, 447 },              RAND_INF_RICHARDS_HOUSE_UNLOCKED },
-    {{ SCENE_BACK_ALLEY_NIGHT, 1471 },           RAND_INF_ALLEY_HOUSE_UNLOCKED },
-    {{ SCENE_KAKARIKO_CENTER_GUEST_HOUSE, 447 }, RAND_INF_BOSS_HOUSE_UNLOCKED },
-    {{ SCENE_POTION_SHOP_GRANNY, 447 },          RAND_INF_GRANNYS_POTION_SHOP_UNLOCKED },
-    {{ SCENE_HOUSE_OF_SKULLTULA, 447 },          RAND_INF_SKULLTULA_HOUSE_UNLOCKED },
-    {{ SCENE_IMPAS_HOUSE, 447 },                 RAND_INF_IMPAS_HOUSE_UNLOCKED },
-    {{ SCENE_WINDMILL_AND_DAMPES_GRAVE, 2495 },  RAND_INF_WINDMILL_UNLOCKED },
-    {{ SCENE_SHOOTING_GALLERY, 447 },            RAND_INF_KAK_SHOOTING_GALLERY_UNLOCKED },
-    {{ SCENE_GRAVEKEEPERS_HUT, 447 },            RAND_INF_DAMPES_HUT_UNLOCKED },
-    {{ SCENE_LON_LON_BUILDINGS, 1471 },          RAND_INF_TALONS_HOUSE_UNLOCKED },
-    {{ SCENE_STABLE, 447 },                      RAND_INF_STABLES_UNLOCKED },
-    {{ SCENE_LON_LON_BUILDINGS, 447 },           RAND_INF_BACK_TOWER_UNLOCKED },
-    {{ SCENE_LAKESIDE_LABORATORY, 447 },         RAND_INF_HYLIA_LAB_UNLOCKED },
-    {{ SCENE_FISHING_POND, 447 },                RAND_INF_FISHING_HOLE_UNLOCKED },
-    */
 };
 
 static void OnDoorInit(void* actorRef) {

--- a/soh/soh/Enhancements/randomizer/location_access/overworld/graveyard.cpp
+++ b/soh/soh/Enhancements/randomizer/location_access/overworld/graveyard.cpp
@@ -101,10 +101,7 @@ void RegionTable_Init_Graveyard() {
     areaTable[RR_GRAVEYARD_DAMPES_HOUSE] = Region("Graveyard Dampes House", "Graveyard Dampes House", {}, NO_DAY_NIGHT_CYCLE, {}, {
         //Locations
         LOCATION(RC_DAMPE_HINT, logic->IsAdult),
-    }, {
-        //Exits
-        Entrance(RR_THE_GRAVEYARD, []{return logic->CanOpenOverworldDoor(RG_DAMPES_HUT_KEY);}),
-    });
+    }, {});
 
     areaTable[RR_GRAVEYARD_WARP_PAD_REGION] = Region("Graveyard Warp Pad Region", "Graveyard", {RA_THE_GRAVEYARD}, NO_DAY_NIGHT_CYCLE, {
         //Events

--- a/soh/soh/Enhancements/randomizer/location_access/overworld/graveyard.cpp
+++ b/soh/soh/Enhancements/randomizer/location_access/overworld/graveyard.cpp
@@ -101,7 +101,10 @@ void RegionTable_Init_Graveyard() {
     areaTable[RR_GRAVEYARD_DAMPES_HOUSE] = Region("Graveyard Dampes House", "Graveyard Dampes House", {}, NO_DAY_NIGHT_CYCLE, {}, {
         //Locations
         LOCATION(RC_DAMPE_HINT, logic->IsAdult),
-    }, {});
+    }, {
+        //Exits
+        Entrance(RR_THE_GRAVEYARD, []{return true;}),
+    });
 
     areaTable[RR_GRAVEYARD_WARP_PAD_REGION] = Region("Graveyard Warp Pad Region", "Graveyard", {RA_THE_GRAVEYARD}, NO_DAY_NIGHT_CYCLE, {
         //Events

--- a/soh/soh/Enhancements/randomizer/location_access/overworld/kakariko.cpp
+++ b/soh/soh/Enhancements/randomizer/location_access/overworld/kakariko.cpp
@@ -102,10 +102,7 @@ void RegionTable_Init_Kakariko() {
     areaTable[RR_KAK_CARPENTER_BOSS_HOUSE] = Region("Kak Carpenter Boss House", "Kak Carpenter Boss House", {}, NO_DAY_NIGHT_CYCLE, {
         //Events
         EventAccess(&logic->WakeUpAdultTalon, []{return logic->IsAdult && logic->CanUse(RG_POCKET_EGG);}),
-    }, {}, {
-        //Exits
-        Entrance(RR_KAKARIKO_VILLAGE, []{return logic->CanOpenOverworldDoor(RG_BOSS_HOUSE_KEY);}),
-    });
+    }, {}, {});
 
     areaTable[RR_KAK_HOUSE_OF_SKULLTULA] = Region("Kak House of Skulltula", "Kak House of Skulltula", {}, NO_DAY_NIGHT_CYCLE, {}, {
         //Locations
@@ -115,18 +112,12 @@ void RegionTable_Init_Kakariko() {
         LOCATION(RC_KAK_40_GOLD_SKULLTULA_REWARD,  logic->GetGSCount() >= 40),
         LOCATION(RC_KAK_50_GOLD_SKULLTULA_REWARD,  logic->GetGSCount() >= 50),
         LOCATION(RC_KAK_100_GOLD_SKULLTULA_REWARD, logic->GetGSCount() >= 100),
-    }, {
-        //Exits
-        Entrance(RR_KAKARIKO_VILLAGE, []{return logic->CanOpenOverworldDoor(RG_SKULLTULA_HOUSE_KEY);}),
-    });
+    }, {});
 
     areaTable[RR_KAK_IMPAS_HOUSE] = Region("Kak Impas House", "Kak Impas House", {}, NO_DAY_NIGHT_CYCLE, {}, {
         //Locations
         LOCATION(RC_KAK_IMPAS_HOUSE_COW, logic->CanUse(RG_EPONAS_SONG)),
-    }, {
-        //Exits
-        Entrance(RR_KAKARIKO_VILLAGE, []{return logic->CanOpenOverworldDoor(RG_IMPAS_HOUSE_KEY);}),
-    });
+    }, {});
 
     areaTable[RR_KAK_IMPAS_HOUSE_BACK] = Region("Kak Impas House Back", "Kak Impas House", {}, NO_DAY_NIGHT_CYCLE, {}, {
         //Locations
@@ -144,10 +135,7 @@ void RegionTable_Init_Kakariko() {
         //Locations
         LOCATION(RC_KAK_WINDMILL_FREESTANDING_POH, logic->CanUse(RG_BOOMERANG) || logic->DampesWindmillAccess || (logic->IsAdult && ctx->GetTrickOption(RT_KAK_ADULT_WINDMILL_POH)) || (logic->IsChild && logic->CanJumpslashExceptHammer() && ctx->GetTrickOption(RT_KAK_CHILD_WINDMILL_POH))),
         LOCATION(RC_SONG_FROM_WINDMILL,            logic->IsAdult && logic->HasItem(RG_FAIRY_OCARINA)),
-    }, {
-        //Exits
-        Entrance(RR_KAKARIKO_VILLAGE, []{return logic->CanOpenOverworldDoor(RG_WINDMILL_KEY);}),
-    });
+    }, {});
 
     areaTable[RR_KAK_BAZAAR] = Region("Kak Bazaar", "Kak Bazaar", {}, NO_DAY_NIGHT_CYCLE, {}, {
         //Locations
@@ -167,10 +155,7 @@ void RegionTable_Init_Kakariko() {
     areaTable[RR_KAK_SHOOTING_GALLERY] = Region("Kak Shooting Gallery", "Kak Shooting Gallery", {}, NO_DAY_NIGHT_CYCLE, {}, {
         //Locations
         LOCATION(RC_KAK_SHOOTING_GALLERY_REWARD, logic->HasItem(RG_CHILD_WALLET) && logic->IsAdult && logic->CanUse(RG_FAIRY_BOW)),
-    }, {
-        //Exits
-        Entrance(RR_KAKARIKO_VILLAGE, []{return logic->CanOpenOverworldDoor(RG_KAK_SHOOTING_GALLERY_KEY);}),
-    });
+    }, {});
 
     areaTable[RR_KAK_POTION_SHOP_FRONT] = Region("Kak Potion Shop Front", "Kak Potion Shop", {}, NO_DAY_NIGHT_CYCLE, {}, {
         //Locations
@@ -201,10 +186,7 @@ void RegionTable_Init_Kakariko() {
         //Locations
         LOCATION(RC_KAK_TRADE_ODD_MUSHROOM, logic->IsAdult && logic->CanUse(RG_ODD_MUSHROOM)),
         LOCATION(RC_KAK_GRANNYS_SHOP,       logic->IsAdult && (logic->CanUse(RG_ODD_MUSHROOM) || logic->TradeQuestStep(RG_ODD_MUSHROOM))),
-    }, {
-        // Exits
-        Entrance(RR_KAK_BACKYARD, []{return logic->CanOpenOverworldDoor(RG_GRANNYS_POTION_SHOP_KEY);}),
-    });
+    }, {});
 
     areaTable[RR_KAK_REDEAD_GROTTO] = Region("Kak Redead Grotto", "Kak Redead Grotto", {}, NO_DAY_NIGHT_CYCLE, {}, {
         //Locations

--- a/soh/soh/Enhancements/randomizer/location_access/overworld/kakariko.cpp
+++ b/soh/soh/Enhancements/randomizer/location_access/overworld/kakariko.cpp
@@ -102,7 +102,10 @@ void RegionTable_Init_Kakariko() {
     areaTable[RR_KAK_CARPENTER_BOSS_HOUSE] = Region("Kak Carpenter Boss House", "Kak Carpenter Boss House", {}, NO_DAY_NIGHT_CYCLE, {
         //Events
         EventAccess(&logic->WakeUpAdultTalon, []{return logic->IsAdult && logic->CanUse(RG_POCKET_EGG);}),
-    }, {}, {});
+    }, {}, {
+        //Exits
+        Entrance(RR_KAKARIKO_VILLAGE, []{return true;}),
+    });
 
     areaTable[RR_KAK_HOUSE_OF_SKULLTULA] = Region("Kak House of Skulltula", "Kak House of Skulltula", {}, NO_DAY_NIGHT_CYCLE, {}, {
         //Locations
@@ -112,12 +115,18 @@ void RegionTable_Init_Kakariko() {
         LOCATION(RC_KAK_40_GOLD_SKULLTULA_REWARD,  logic->GetGSCount() >= 40),
         LOCATION(RC_KAK_50_GOLD_SKULLTULA_REWARD,  logic->GetGSCount() >= 50),
         LOCATION(RC_KAK_100_GOLD_SKULLTULA_REWARD, logic->GetGSCount() >= 100),
-    }, {});
+    }, {
+        //Exits
+        Entrance(RR_KAKARIKO_VILLAGE, []{return true;}),
+    });
 
     areaTable[RR_KAK_IMPAS_HOUSE] = Region("Kak Impas House", "Kak Impas House", {}, NO_DAY_NIGHT_CYCLE, {}, {
         //Locations
         LOCATION(RC_KAK_IMPAS_HOUSE_COW, logic->CanUse(RG_EPONAS_SONG)),
-    }, {});
+    }, {
+        //Exits
+        Entrance(RR_KAKARIKO_VILLAGE, []{return true;}),
+    });
 
     areaTable[RR_KAK_IMPAS_HOUSE_BACK] = Region("Kak Impas House Back", "Kak Impas House", {}, NO_DAY_NIGHT_CYCLE, {}, {
         //Locations
@@ -135,7 +144,10 @@ void RegionTable_Init_Kakariko() {
         //Locations
         LOCATION(RC_KAK_WINDMILL_FREESTANDING_POH, logic->CanUse(RG_BOOMERANG) || logic->DampesWindmillAccess || (logic->IsAdult && ctx->GetTrickOption(RT_KAK_ADULT_WINDMILL_POH)) || (logic->IsChild && logic->CanJumpslashExceptHammer() && ctx->GetTrickOption(RT_KAK_CHILD_WINDMILL_POH))),
         LOCATION(RC_SONG_FROM_WINDMILL,            logic->IsAdult && logic->HasItem(RG_FAIRY_OCARINA)),
-    }, {});
+    }, {
+        //Exits
+        Entrance(RR_KAKARIKO_VILLAGE, []{return true;}),
+    });
 
     areaTable[RR_KAK_BAZAAR] = Region("Kak Bazaar", "Kak Bazaar", {}, NO_DAY_NIGHT_CYCLE, {}, {
         //Locations
@@ -155,7 +167,10 @@ void RegionTable_Init_Kakariko() {
     areaTable[RR_KAK_SHOOTING_GALLERY] = Region("Kak Shooting Gallery", "Kak Shooting Gallery", {}, NO_DAY_NIGHT_CYCLE, {}, {
         //Locations
         LOCATION(RC_KAK_SHOOTING_GALLERY_REWARD, logic->HasItem(RG_CHILD_WALLET) && logic->IsAdult && logic->CanUse(RG_FAIRY_BOW)),
-    }, {});
+    }, {
+        //Exits
+        Entrance(RR_KAKARIKO_VILLAGE, []{return true;}),
+    });
 
     areaTable[RR_KAK_POTION_SHOP_FRONT] = Region("Kak Potion Shop Front", "Kak Potion Shop", {}, NO_DAY_NIGHT_CYCLE, {}, {
         //Locations
@@ -186,7 +201,10 @@ void RegionTable_Init_Kakariko() {
         //Locations
         LOCATION(RC_KAK_TRADE_ODD_MUSHROOM, logic->IsAdult && logic->CanUse(RG_ODD_MUSHROOM)),
         LOCATION(RC_KAK_GRANNYS_SHOP,       logic->IsAdult && (logic->CanUse(RG_ODD_MUSHROOM) || logic->TradeQuestStep(RG_ODD_MUSHROOM))),
-    }, {});
+    }, {
+        // Exits
+        Entrance(RR_KAK_BACKYARD, []{return true;}),
+    });
 
     areaTable[RR_KAK_REDEAD_GROTTO] = Region("Kak Redead Grotto", "Kak Redead Grotto", {}, NO_DAY_NIGHT_CYCLE, {}, {
         //Locations

--- a/soh/soh/Enhancements/randomizer/location_access/overworld/lake_hylia.cpp
+++ b/soh/soh/Enhancements/randomizer/location_access/overworld/lake_hylia.cpp
@@ -68,10 +68,7 @@ void RegionTable_Init_LakeHylia() {
         LOCATION(RC_LH_LAB_FRONT_RUPEE, logic->CanUse(RG_IRON_BOOTS) || logic->HasItem(RG_GOLDEN_SCALE)),
         LOCATION(RC_LH_LAB_LEFT_RUPEE,  logic->CanUse(RG_IRON_BOOTS) || logic->HasItem(RG_GOLDEN_SCALE)),
         LOCATION(RC_LH_LAB_RIGHT_RUPEE, logic->CanUse(RG_IRON_BOOTS) || logic->HasItem(RG_GOLDEN_SCALE)),
-    }, {
-        //Exits
-        Entrance(RR_LAKE_HYLIA, []{return logic->CanOpenOverworldDoor(RG_HYLIA_LAB_KEY);}),
-    });
+    }, {});
 
     // TODO: should some of these helpers be done via events instead?
     areaTable[RR_LH_FISHING_POND] = Region("LH Fishing Hole", "LH Fishing Hole", {}, DAY_NIGHT_CYCLE, {}, {
@@ -113,10 +110,7 @@ void RegionTable_Init_LakeHylia() {
         LOCATION(RC_LH_ADULT_LOACH,    logic->CanUse(RG_FISHING_POLE) && logic->IsAdult && ctx->GetOption(RSK_FISHSANITY_AGE_SPLIT)),
         LOCATION(RC_LH_HYRULE_LOACH,   logic->CanUse(RG_FISHING_POLE)),
         LOCATION(RC_FISHING_POLE_HINT, true),
-    }, {
-        //Exits
-        Entrance(RR_LH_FISHING_ISLAND, []{return logic->CanOpenOverworldDoor(RG_FISHING_HOLE_KEY);}),
-    });
+    }, {});
 
     areaTable[RR_LH_GROTTO] = Region("LH Grotto", "LH Grotto", {}, NO_DAY_NIGHT_CYCLE, {}, {
         //Locations

--- a/soh/soh/Enhancements/randomizer/location_access/overworld/lake_hylia.cpp
+++ b/soh/soh/Enhancements/randomizer/location_access/overworld/lake_hylia.cpp
@@ -68,7 +68,10 @@ void RegionTable_Init_LakeHylia() {
         LOCATION(RC_LH_LAB_FRONT_RUPEE, logic->CanUse(RG_IRON_BOOTS) || logic->HasItem(RG_GOLDEN_SCALE)),
         LOCATION(RC_LH_LAB_LEFT_RUPEE,  logic->CanUse(RG_IRON_BOOTS) || logic->HasItem(RG_GOLDEN_SCALE)),
         LOCATION(RC_LH_LAB_RIGHT_RUPEE, logic->CanUse(RG_IRON_BOOTS) || logic->HasItem(RG_GOLDEN_SCALE)),
-    }, {});
+    }, {
+        //Exits
+        Entrance(RR_LAKE_HYLIA, []{return true;}),
+    });
 
     // TODO: should some of these helpers be done via events instead?
     areaTable[RR_LH_FISHING_POND] = Region("LH Fishing Hole", "LH Fishing Hole", {}, DAY_NIGHT_CYCLE, {}, {
@@ -110,7 +113,10 @@ void RegionTable_Init_LakeHylia() {
         LOCATION(RC_LH_ADULT_LOACH,    logic->CanUse(RG_FISHING_POLE) && logic->IsAdult && ctx->GetOption(RSK_FISHSANITY_AGE_SPLIT)),
         LOCATION(RC_LH_HYRULE_LOACH,   logic->CanUse(RG_FISHING_POLE)),
         LOCATION(RC_FISHING_POLE_HINT, true),
-    }, {});
+    }, {
+        //Exits
+        Entrance(RR_LH_FISHING_ISLAND, []{return true;}),
+    });
 
     areaTable[RR_LH_GROTTO] = Region("LH Grotto", "LH Grotto", {}, NO_DAY_NIGHT_CYCLE, {}, {
         //Locations

--- a/soh/soh/Enhancements/randomizer/location_access/overworld/lon_lon_ranch.cpp
+++ b/soh/soh/Enhancements/randomizer/location_access/overworld/lon_lon_ranch.cpp
@@ -37,20 +37,29 @@ void RegionTable_Init_LonLonRanch() {
         LOCATION(RC_LLR_TALONS_HOUSE_POT_1, logic->CanBreakPots()),
         LOCATION(RC_LLR_TALONS_HOUSE_POT_2, logic->CanBreakPots()),
         LOCATION(RC_LLR_TALONS_HOUSE_POT_3, logic->CanBreakPots()),
-    }, {});
+    }, {
+        //Exits
+        Entrance(RR_LON_LON_RANCH, []{return true;}),
+    });
 
     areaTable[RR_LLR_STABLES] = Region("LLR Stables", "LLR Stables", {}, NO_DAY_NIGHT_CYCLE, {}, {
         //Locations
         LOCATION(RC_LLR_STABLES_LEFT_COW,  logic->CanUse(RG_EPONAS_SONG)),
         LOCATION(RC_LLR_STABLES_RIGHT_COW, logic->CanUse(RG_EPONAS_SONG)),
-    }, {});
+    }, {
+        //Exits
+        Entrance(RR_LON_LON_RANCH, []{return true;}),
+    });
 
     areaTable[RR_LLR_TOWER] = Region("LLR Tower", "LLR Tower", {}, NO_DAY_NIGHT_CYCLE, {}, {
         //Locations
         LOCATION(RC_LLR_FREESTANDING_POH, logic->IsChild),
         LOCATION(RC_LLR_TOWER_LEFT_COW,   logic->CanUse(RG_EPONAS_SONG)),
         LOCATION(RC_LLR_TOWER_RIGHT_COW,  logic->CanUse(RG_EPONAS_SONG)),
-    }, {});
+    }, {
+        //Exits
+        Entrance(RR_LON_LON_RANCH, []{return true;}),
+    });
 
     areaTable[RR_LLR_GROTTO] = Region("LLR Grotto", "LLR Grotto", {}, NO_DAY_NIGHT_CYCLE, {}, {
         //Locations

--- a/soh/soh/Enhancements/randomizer/location_access/overworld/lon_lon_ranch.cpp
+++ b/soh/soh/Enhancements/randomizer/location_access/overworld/lon_lon_ranch.cpp
@@ -37,29 +37,20 @@ void RegionTable_Init_LonLonRanch() {
         LOCATION(RC_LLR_TALONS_HOUSE_POT_1, logic->CanBreakPots()),
         LOCATION(RC_LLR_TALONS_HOUSE_POT_2, logic->CanBreakPots()),
         LOCATION(RC_LLR_TALONS_HOUSE_POT_3, logic->CanBreakPots()),
-    }, {
-        //Exits
-        Entrance(RR_LON_LON_RANCH, []{return logic->CanOpenOverworldDoor(RG_TALONS_HOUSE_KEY);}),
-    });
+    }, {});
 
     areaTable[RR_LLR_STABLES] = Region("LLR Stables", "LLR Stables", {}, NO_DAY_NIGHT_CYCLE, {}, {
         //Locations
         LOCATION(RC_LLR_STABLES_LEFT_COW,  logic->CanUse(RG_EPONAS_SONG)),
         LOCATION(RC_LLR_STABLES_RIGHT_COW, logic->CanUse(RG_EPONAS_SONG)),
-    }, {
-        //Exits
-        Entrance(RR_LON_LON_RANCH, []{return logic->CanOpenOverworldDoor(RG_STABLES_KEY);}),
-    });
+    }, {});
 
     areaTable[RR_LLR_TOWER] = Region("LLR Tower", "LLR Tower", {}, NO_DAY_NIGHT_CYCLE, {}, {
         //Locations
         LOCATION(RC_LLR_FREESTANDING_POH, logic->IsChild),
         LOCATION(RC_LLR_TOWER_LEFT_COW,   logic->CanUse(RG_EPONAS_SONG)),
         LOCATION(RC_LLR_TOWER_RIGHT_COW,  logic->CanUse(RG_EPONAS_SONG)),
-    }, {
-        //Exits
-        Entrance(RR_LON_LON_RANCH, []{return logic->CanOpenOverworldDoor(RG_BACK_TOWER_KEY);}),
-    });
+    }, {});
 
     areaTable[RR_LLR_GROTTO] = Region("LLR Grotto", "LLR Grotto", {}, NO_DAY_NIGHT_CYCLE, {}, {
         //Locations

--- a/soh/soh/Enhancements/randomizer/location_access/overworld/market.cpp
+++ b/soh/soh/Enhancements/randomizer/location_access/overworld/market.cpp
@@ -96,10 +96,7 @@ void RegionTable_Init_Market() {
         LOCATION(RC_MK_GUARD_HOUSE_ADULT_POT_9,  logic->IsAdult && logic->CanBreakPots()),
         LOCATION(RC_MK_GUARD_HOUSE_ADULT_POT_10, logic->IsAdult && logic->CanBreakPots()),
         LOCATION(RC_MK_GUARD_HOUSE_ADULT_POT_11, logic->IsAdult && logic->CanBreakPots()),
-    }, {
-        //Exits
-        Entrance(RR_MARKET_ENTRANCE, []{return logic->CanOpenOverworldDoor(RG_GUARD_HOUSE_KEY);}),
-    });
+    }, {});
 
     areaTable[RR_MARKET_BAZAAR] = Region("Market Bazaar", "Market Bazaar", {}, NO_DAY_NIGHT_CYCLE, {}, {
         //Locations
@@ -131,10 +128,7 @@ void RegionTable_Init_Market() {
     areaTable[RR_MARKET_SHOOTING_GALLERY] = Region("Market Shooting Gallery", "Market Shooting Gallery", {}, NO_DAY_NIGHT_CYCLE, {}, {
         //Locations
         LOCATION(RC_MARKET_SHOOTING_GALLERY_REWARD, logic->IsChild && logic->HasItem(RG_CHILD_WALLET)),
-    }, {
-        //Exits
-        Entrance(RR_THE_MARKET, []{return logic->CanOpenOverworldDoor(RG_MARKET_SHOOTING_GALLERY_KEY);}),
-    });
+    }, {});
 
     areaTable[RR_MARKET_BOMBCHU_BOWLING] = Region("Market Bombchu Bowling", "Market Bombchu Bowling", {}, NO_DAY_NIGHT_CYCLE, {
         //Events
@@ -143,10 +137,7 @@ void RegionTable_Init_Market() {
         //Locations
         LOCATION(RC_MARKET_BOMBCHU_BOWLING_FIRST_PRIZE,  logic->CouldPlayBowling && logic->BombchusEnabled()),
         LOCATION(RC_MARKET_BOMBCHU_BOWLING_SECOND_PRIZE, logic->CouldPlayBowling && logic->BombchusEnabled()),
-    }, {
-        //Exits
-        Entrance(RR_THE_MARKET, []{return logic->CanOpenOverworldDoor(RG_BOMBCHU_BOWLING_KEY);}),
-    });
+    }, {});
 
     areaTable[RR_MARKET_POTION_SHOP] = Region("Market Potion Shop", "Market Potion Shop", {}, NO_DAY_NIGHT_CYCLE, {}, {
         //Locations
@@ -177,10 +168,7 @@ void RegionTable_Init_Market() {
         LOCATION(RC_MARKET_TREASURE_CHEST_GAME_ITEM_4, logic->HasItem(RG_CHILD_WALLET) && ((ctx->GetOption(RSK_SHUFFLE_CHEST_MINIGAME).Is(RO_CHEST_GAME_SINGLE_KEYS) && logic->SmallKeys(RR_MARKET_TREASURE_CHEST_GAME, 4)) || (ctx->GetOption(RSK_SHUFFLE_CHEST_MINIGAME).Is(RO_CHEST_GAME_PACK) && logic->SmallKeys(RR_MARKET_TREASURE_CHEST_GAME, 1)) || (logic->CanUse(RG_LENS_OF_TRUTH) && !ctx->GetOption(RSK_SHUFFLE_CHEST_MINIGAME)))),
         LOCATION(RC_MARKET_TREASURE_CHEST_GAME_KEY_5,  logic->HasItem(RG_CHILD_WALLET) && ((ctx->GetOption(RSK_SHUFFLE_CHEST_MINIGAME).Is(RO_CHEST_GAME_SINGLE_KEYS) && logic->SmallKeys(RR_MARKET_TREASURE_CHEST_GAME, 5)) || (ctx->GetOption(RSK_SHUFFLE_CHEST_MINIGAME).Is(RO_CHEST_GAME_PACK) && logic->SmallKeys(RR_MARKET_TREASURE_CHEST_GAME, 1)) || (logic->CanUse(RG_LENS_OF_TRUTH) && !ctx->GetOption(RSK_SHUFFLE_CHEST_MINIGAME)))),
         LOCATION(RC_MARKET_TREASURE_CHEST_GAME_ITEM_5, logic->HasItem(RG_CHILD_WALLET) && ((ctx->GetOption(RSK_SHUFFLE_CHEST_MINIGAME).Is(RO_CHEST_GAME_SINGLE_KEYS) && logic->SmallKeys(RR_MARKET_TREASURE_CHEST_GAME, 5)) || (ctx->GetOption(RSK_SHUFFLE_CHEST_MINIGAME).Is(RO_CHEST_GAME_PACK) && logic->SmallKeys(RR_MARKET_TREASURE_CHEST_GAME, 1)) || (logic->CanUse(RG_LENS_OF_TRUTH) && !ctx->GetOption(RSK_SHUFFLE_CHEST_MINIGAME)))),
-    }, {
-        //Exits
-        Entrance(RR_THE_MARKET, []{return logic->CanOpenOverworldDoor(RG_TREASURE_CHEST_GAME_BUILDING_KEY);}),
-    });
+    }, {});
 
     areaTable[RR_MARKET_BOMBCHU_SHOP] = Region("Market Bombchu Shop", "Market Bombchu Shop", {}, NO_DAY_NIGHT_CYCLE, {}, {
         //Locations
@@ -200,18 +188,12 @@ void RegionTable_Init_Market() {
     areaTable[RR_MARKET_DOG_LADY_HOUSE] = Region("Market Dog Lady House", "Market Dog Lady House", {}, NO_DAY_NIGHT_CYCLE, {}, {
         //Locations
         LOCATION(RC_MARKET_LOST_DOG, logic->IsChild && logic->AtNight),
-    }, {
-        //Exits
-        Entrance(RR_MARKET_BACK_ALLEY, []{return logic->CanOpenOverworldDoor(RG_RICHARDS_HOUSE_KEY);}),
-    });
+    }, {});
 
     areaTable[RR_MARKET_MAN_IN_GREEN_HOUSE] = Region("Market Man in Green House", "Market Man in Green House", {}, NO_DAY_NIGHT_CYCLE, {}, {
         // Locations
         LOCATION(RC_MK_BACK_ALLEY_HOUSE_POT_1, logic->CanBreakPots()),
         LOCATION(RC_MK_BACK_ALLEY_HOUSE_POT_2, logic->CanBreakPots()),
         LOCATION(RC_MK_BACK_ALLEY_HOUSE_POT_3, logic->CanBreakPots()),
-    }, {
-        //Exits
-        Entrance(RR_MARKET_BACK_ALLEY, []{return logic->CanOpenOverworldDoor(RG_ALLEY_HOUSE_KEY);}),
-    });
+    }, {});
 }

--- a/soh/soh/Enhancements/randomizer/location_access/overworld/market.cpp
+++ b/soh/soh/Enhancements/randomizer/location_access/overworld/market.cpp
@@ -96,7 +96,10 @@ void RegionTable_Init_Market() {
         LOCATION(RC_MK_GUARD_HOUSE_ADULT_POT_9,  logic->IsAdult && logic->CanBreakPots()),
         LOCATION(RC_MK_GUARD_HOUSE_ADULT_POT_10, logic->IsAdult && logic->CanBreakPots()),
         LOCATION(RC_MK_GUARD_HOUSE_ADULT_POT_11, logic->IsAdult && logic->CanBreakPots()),
-    }, {});
+    }, {
+        //Exits
+        Entrance(RR_MARKET_ENTRANCE, []{return true;}),
+    });
 
     areaTable[RR_MARKET_BAZAAR] = Region("Market Bazaar", "Market Bazaar", {}, NO_DAY_NIGHT_CYCLE, {}, {
         //Locations
@@ -128,7 +131,10 @@ void RegionTable_Init_Market() {
     areaTable[RR_MARKET_SHOOTING_GALLERY] = Region("Market Shooting Gallery", "Market Shooting Gallery", {}, NO_DAY_NIGHT_CYCLE, {}, {
         //Locations
         LOCATION(RC_MARKET_SHOOTING_GALLERY_REWARD, logic->IsChild && logic->HasItem(RG_CHILD_WALLET)),
-    }, {});
+    }, {
+        //Exits
+        Entrance(RR_THE_MARKET, []{return true;}),
+    });
 
     areaTable[RR_MARKET_BOMBCHU_BOWLING] = Region("Market Bombchu Bowling", "Market Bombchu Bowling", {}, NO_DAY_NIGHT_CYCLE, {
         //Events
@@ -137,7 +143,10 @@ void RegionTable_Init_Market() {
         //Locations
         LOCATION(RC_MARKET_BOMBCHU_BOWLING_FIRST_PRIZE,  logic->CouldPlayBowling && logic->BombchusEnabled()),
         LOCATION(RC_MARKET_BOMBCHU_BOWLING_SECOND_PRIZE, logic->CouldPlayBowling && logic->BombchusEnabled()),
-    }, {});
+    }, {
+        //Exits
+        Entrance(RR_THE_MARKET, []{return true;}),
+    });
 
     areaTable[RR_MARKET_POTION_SHOP] = Region("Market Potion Shop", "Market Potion Shop", {}, NO_DAY_NIGHT_CYCLE, {}, {
         //Locations
@@ -168,7 +177,10 @@ void RegionTable_Init_Market() {
         LOCATION(RC_MARKET_TREASURE_CHEST_GAME_ITEM_4, logic->HasItem(RG_CHILD_WALLET) && ((ctx->GetOption(RSK_SHUFFLE_CHEST_MINIGAME).Is(RO_CHEST_GAME_SINGLE_KEYS) && logic->SmallKeys(RR_MARKET_TREASURE_CHEST_GAME, 4)) || (ctx->GetOption(RSK_SHUFFLE_CHEST_MINIGAME).Is(RO_CHEST_GAME_PACK) && logic->SmallKeys(RR_MARKET_TREASURE_CHEST_GAME, 1)) || (logic->CanUse(RG_LENS_OF_TRUTH) && !ctx->GetOption(RSK_SHUFFLE_CHEST_MINIGAME)))),
         LOCATION(RC_MARKET_TREASURE_CHEST_GAME_KEY_5,  logic->HasItem(RG_CHILD_WALLET) && ((ctx->GetOption(RSK_SHUFFLE_CHEST_MINIGAME).Is(RO_CHEST_GAME_SINGLE_KEYS) && logic->SmallKeys(RR_MARKET_TREASURE_CHEST_GAME, 5)) || (ctx->GetOption(RSK_SHUFFLE_CHEST_MINIGAME).Is(RO_CHEST_GAME_PACK) && logic->SmallKeys(RR_MARKET_TREASURE_CHEST_GAME, 1)) || (logic->CanUse(RG_LENS_OF_TRUTH) && !ctx->GetOption(RSK_SHUFFLE_CHEST_MINIGAME)))),
         LOCATION(RC_MARKET_TREASURE_CHEST_GAME_ITEM_5, logic->HasItem(RG_CHILD_WALLET) && ((ctx->GetOption(RSK_SHUFFLE_CHEST_MINIGAME).Is(RO_CHEST_GAME_SINGLE_KEYS) && logic->SmallKeys(RR_MARKET_TREASURE_CHEST_GAME, 5)) || (ctx->GetOption(RSK_SHUFFLE_CHEST_MINIGAME).Is(RO_CHEST_GAME_PACK) && logic->SmallKeys(RR_MARKET_TREASURE_CHEST_GAME, 1)) || (logic->CanUse(RG_LENS_OF_TRUTH) && !ctx->GetOption(RSK_SHUFFLE_CHEST_MINIGAME)))),
-    }, {});
+    }, {
+        //Exits
+        Entrance(RR_THE_MARKET, []{return true;}),
+    });
 
     areaTable[RR_MARKET_BOMBCHU_SHOP] = Region("Market Bombchu Shop", "Market Bombchu Shop", {}, NO_DAY_NIGHT_CYCLE, {}, {
         //Locations
@@ -188,12 +200,18 @@ void RegionTable_Init_Market() {
     areaTable[RR_MARKET_DOG_LADY_HOUSE] = Region("Market Dog Lady House", "Market Dog Lady House", {}, NO_DAY_NIGHT_CYCLE, {}, {
         //Locations
         LOCATION(RC_MARKET_LOST_DOG, logic->IsChild && logic->AtNight),
-    }, {});
+    }, {
+        //Exits
+        Entrance(RR_MARKET_BACK_ALLEY, []{return true;}),
+    });
 
     areaTable[RR_MARKET_MAN_IN_GREEN_HOUSE] = Region("Market Man in Green House", "Market Man in Green House", {}, NO_DAY_NIGHT_CYCLE, {}, {
         // Locations
         LOCATION(RC_MK_BACK_ALLEY_HOUSE_POT_1, logic->CanBreakPots()),
         LOCATION(RC_MK_BACK_ALLEY_HOUSE_POT_2, logic->CanBreakPots()),
         LOCATION(RC_MK_BACK_ALLEY_HOUSE_POT_3, logic->CanBreakPots()),
-    }, {});
+    }, {
+        //Exits
+        Entrance(RR_MARKET_BACK_ALLEY, []{return true;}),
+    });
 }


### PR DESCRIPTION
Yeah that's a mouthful. After feedback from people playing with the overworld keys and entrance rando, we decided to not lock the doors from the inside. I commented them out if this decision needs revisiting in the future, maybe if there turns out to be a demand to turn this on anyway etc.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2525746564.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2525754409.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2525774249.zip)
<!--- section:artifacts:end -->