### PR TITLE
Fix Bottle RGs being assigned to slots in logic

### DIFF
--- a/soh/soh/Enhancements/randomizer/logic.cpp
+++ b/soh/soh/Enhancements/randomizer/logic.cpp
@@ -1431,6 +1431,18 @@ namespace Rando {
         { RG_GERUDO_MEMBERSHIP_CARD, QUEST_GERUDO_CARD },
     };
 
+    std::map<uint32_t, uint32_t> BottleRandomizerGetToItemID = {
+        { RG_BOTTLE_WITH_RED_POTION, ITEM_POTION_RED },
+        { RG_BOTTLE_WITH_GREEN_POTION, ITEM_POTION_GREEN },
+        { RG_BOTTLE_WITH_BLUE_POTION, ITEM_POTION_BLUE },
+        { RG_BOTTLE_WITH_FAIRY, ITEM_FAIRY },
+        { RG_BOTTLE_WITH_FISH, ITEM_FISH },
+        { RG_BOTTLE_WITH_BLUE_FIRE, ITEM_BLUE_FIRE },
+        { RG_BOTTLE_WITH_BUGS, ITEM_BUG },
+        { RG_BOTTLE_WITH_POE, ITEM_POE },
+        { RG_BOTTLE_WITH_BIG_POE, ITEM_BIG_POE },
+    };
+
     uint32_t HookshotLookup[3] = { ITEM_NONE, ITEM_HOOKSHOT, ITEM_LONGSHOT };
     uint32_t OcarinaLookup[3] = { ITEM_NONE, ITEM_OCARINA_FAIRY, ITEM_OCARINA_TIME };
 
@@ -1675,7 +1687,11 @@ namespace Rando {
                     }
                     slot++;
                 }
-                mSaveContext->inventory.items[slot] = item.GetGIEntry()->itemId;
+                uint16_t itemId = item.GetGIEntry()->itemId;
+                if (BottleRandomizerGetToItemID.contains(randoGet)) {
+                    itemId = BottleRandomizerGetToItemID[randoGet];
+                }
+                mSaveContext->inventory.items[slot] = itemId;
             }   break;
             case RG_RUTOS_LETTER:
                 SetEventChkInf(EVENTCHKINF_OBTAINED_RUTOS_LETTER, state);
@@ -2201,7 +2217,7 @@ namespace Rando {
         //Bottle Count
         Bottles    = 0;
         NumBottles = 0;
-        CanEmptyBigPoes = true;
+        CanEmptyBigPoes = false;
 
         //Drops and Bottle Contents Access
         NutPot           = false;


### PR DESCRIPTION
`ItemTable` has RGs assigned to `GetItemEntry::itemId` for all bottle items except empty, milk, and Ruto's letter. Because of this, the way `BottleCount()` was checking them was always incrementing them because they never matched the ITEM_ prefixes in the `BottleCount()` for big poe and Ruto's letter, causing logic errors. However, the entries in `itemTable` couldn't be changed because these are referenced for `GetItemEntry::drawItemId`, so this adds a translation for bottle item RGs to itemIDs for assigning to slots in seed gen.

Also, with no interior or overworld shuffle, `CouldEmptyBigPoes` was always true, so `CanEmptyPigPoes` resetting to true in `Logic::Reset()` would mean that you could always count the big poe bottle in the bottle count, even if you don't have access to adult because of SoT or Closed Door of Time setting, so this also changes `CanEmptyBigPoes` to reset to false in logic reset.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2488080001.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2488081176.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2488096654.zip)
<!--- section:artifacts:end -->