### PR TITLE
clamp `addAlpha` when skipping spinning logos to prevent softlock

### DIFF
--- a/soh/soh/Enhancements/cosmetics/CustomLogoTitle.cpp
+++ b/soh/soh/Enhancements/cosmetics/CustomLogoTitle.cpp
@@ -187,6 +187,9 @@ void OnZTitleUpdatePressButtonToSkip(void* gameState) {
         // Force the title state to start fading to black and to last roughly 5 frames based on current fade in/out
         titleContext->visibleDuration = 0;
         titleContext->addAlpha = (255 - titleContext->coverAlpha) / 5;
+        if (titleContext->addAlpha == 0) {
+            titleContext->addAlpha = 1;
+        }
     }
 }
 

--- a/soh/soh/Enhancements/cosmetics/CustomLogoTitle.cpp
+++ b/soh/soh/Enhancements/cosmetics/CustomLogoTitle.cpp
@@ -185,7 +185,7 @@ void OnZTitleUpdatePressButtonToSkip(void* gameState) {
     if (CHECK_BTN_ANY(titleContext->state.input->press.button, BTN_A | BTN_B | BTN_START)) {
         // Force the title state to start fading to black and to last roughly 5 frames based on current fade in/out
         titleContext->visibleDuration = 0;
-        titleContext->addAlpha = std::clamp<int16_t>((255 - titleContext->coverAlpha) / 5, 1, INT16_MAX);
+        titleContext->addAlpha = std::max<int16_t>((255 - titleContext->coverAlpha) / 5, 1);
     }
 }
 

--- a/soh/soh/Enhancements/cosmetics/CustomLogoTitle.cpp
+++ b/soh/soh/Enhancements/cosmetics/CustomLogoTitle.cpp
@@ -123,7 +123,6 @@ extern "C" void CustomLogoTitle_Draw(TitleContext* titleContext, uint8_t logoToD
 
 extern "C" void CustomLogoTitle_Main(TitleContext* titleContext) {
     static uint8_t logosSeen = 0;
-    SPDLOG_DEBUG("Logos Seen: {}", logosSeen);
     uint8_t logoToDraw;
 
     if (CVAR_BOOTSEQUENCE_VALUE == BOOTSEQUENCE_DEFAULT) {
@@ -186,10 +185,7 @@ void OnZTitleUpdatePressButtonToSkip(void* gameState) {
     if (CHECK_BTN_ANY(titleContext->state.input->press.button, BTN_A | BTN_B | BTN_START)) {
         // Force the title state to start fading to black and to last roughly 5 frames based on current fade in/out
         titleContext->visibleDuration = 0;
-        titleContext->addAlpha = (255 - titleContext->coverAlpha) / 5;
-        if (titleContext->addAlpha == 0) {
-            titleContext->addAlpha = 1;
-        }
+        titleContext->addAlpha = std::clamp((255 - titleContext->coverAlpha) / 5, 1, INT16_MAX);
     }
 }
 

--- a/soh/soh/Enhancements/cosmetics/CustomLogoTitle.cpp
+++ b/soh/soh/Enhancements/cosmetics/CustomLogoTitle.cpp
@@ -4,7 +4,6 @@
 #include "textures/nintendo_rogo_static/nintendo_rogo_static.h"
 #include "assets/objects/gameplay_keep/gameplay_keep.h"
 #include "soh_assets.h"
-#include <algorithm>
 
 extern "C" {
 #include "macros.h"
@@ -186,7 +185,7 @@ void OnZTitleUpdatePressButtonToSkip(void* gameState) {
     if (CHECK_BTN_ANY(titleContext->state.input->press.button, BTN_A | BTN_B | BTN_START)) {
         // Force the title state to start fading to black and to last roughly 5 frames based on current fade in/out
         titleContext->visibleDuration = 0;
-        titleContext->addAlpha = std::clamp((255 - titleContext->coverAlpha) / 5, 1, INT16_MAX);
+        titleContext->addAlpha = std::clamp<int16_t>((255 - titleContext->coverAlpha) / 5, 1, INT16_MAX);
     }
 }
 

--- a/soh/soh/Enhancements/cosmetics/CustomLogoTitle.cpp
+++ b/soh/soh/Enhancements/cosmetics/CustomLogoTitle.cpp
@@ -123,6 +123,7 @@ extern "C" void CustomLogoTitle_Draw(TitleContext* titleContext, uint8_t logoToD
 
 extern "C" void CustomLogoTitle_Main(TitleContext* titleContext) {
     static uint8_t logosSeen = 0;
+    SPDLOG_DEBUG("Logos Seen: {}", logosSeen);
     uint8_t logoToDraw;
 
     if (CVAR_BOOTSEQUENCE_VALUE == BOOTSEQUENCE_DEFAULT) {

--- a/soh/soh/Enhancements/cosmetics/CustomLogoTitle.cpp
+++ b/soh/soh/Enhancements/cosmetics/CustomLogoTitle.cpp
@@ -4,6 +4,7 @@
 #include "textures/nintendo_rogo_static/nintendo_rogo_static.h"
 #include "assets/objects/gameplay_keep/gameplay_keep.h"
 #include "soh_assets.h"
+#include <algorithm>
 
 extern "C" {
 #include "macros.h"


### PR DESCRIPTION
### problem

when skipping the logos by pressing a button we calculate `addAlpha` based on the current state of fade in/out

on the very first frame of the logos it hasn't faded in at all yet, so the "cover" value is `255`

this means that when calculating it using
```cpp
titleContext->addAlpha = (255 - titleContext->coverAlpha) / 5;
```
we can get into a situation where `addAlpha` is `0` and the title screen is stuck

### solution

this PR just clamps (decided to use `std::max` instead of `std::clamp` because that feels cleaner) that calculation to have a minimum of  `1`

### alternatives considered

just using a static value (`255 / 5`) for `addAlpha` instead of calculating. i tested this and it didn't feel as smooth/nice as the 5 frame fadeout based on current fade in/out

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2494660325.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2494664483.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2494675013.zip)
<!--- section:artifacts:end -->