### PR TITLE
Exclude locations fix

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/spoiler_log.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/spoiler_log.cpp
@@ -159,7 +159,7 @@ static void WriteExcludedLocations() {
 
   for (size_t i = 1; i < Rando::Settings::GetInstance()->GetExcludeLocationsOptions().size(); i++) {
     for (const auto& location : Rando::Settings::GetInstance()->GetExcludeLocationsOptions()[i]) {
-      if (ctx->GetOption(location->GetKey()).Get() == RO_LOCATION_INCLUDE) {
+      if (ctx->GetLocationOption(static_cast<RandomizerCheck>(location->GetKey())).Get() == RO_LOCATION_INCLUDE) {
         continue;
       }
 

--- a/soh/soh/Enhancements/randomizer/context.cpp
+++ b/soh/soh/Enhancements/randomizer/context.cpp
@@ -438,14 +438,6 @@ OptionValue& Context::GetOption(const RandomizerSettingKey key) {
     return mOptions[key];
 }
 
-OptionValue& Context::GetOption(const RandomizerTrick key) {
-    return mTrickOptions[key];
-}
-
-OptionValue& Context::GetOption(const RandomizerCheck key) {
-    return itemLocationTable[key].GetExcludedOption();
-}
-
 OptionValue& Context::GetTrickOption(const RandomizerTrick key) {
     return mTrickOptions[key];
 }

--- a/soh/soh/Enhancements/randomizer/context.h
+++ b/soh/soh/Enhancements/randomizer/context.h
@@ -91,8 +91,6 @@ class Context {
     TrialInfo* GetTrial(TrialKey key) const;
     static Sprite* GetSeedTexture(uint8_t index);
     OptionValue& GetOption(RandomizerSettingKey key);
-    OptionValue& GetOption(RandomizerTrick key);
-    OptionValue& GetOption(RandomizerCheck key);
     OptionValue& GetTrickOption(RandomizerTrick key);
     OptionValue& GetLocationOption(RandomizerCheck key);
 


### PR DESCRIPTION
Fix WriteExcludedLocations from reading the regular options instead of the excluded location options. Also deleted function overrides for GetOption, as they weren't working the way I intended them to when I wrote them and we no longer need them.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2504520078.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2504563082.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2504566253.zip)
<!--- section:artifacts:end -->