### PR TITLE
rework assignable tunic/boots to use shipinit and hooks

### DIFF
--- a/soh/soh/Enhancements/AssignableTunicsAndBoots.cpp
+++ b/soh/soh/Enhancements/AssignableTunicsAndBoots.cpp
@@ -9,6 +9,7 @@ extern s32 Player_GetItemOnButton(PlayState*, s32);
 extern void Inventory_ChangeEquipment(s16, u16);
 extern void Player_SetEquipmentData(PlayState*, Player*);
 extern void func_808328EC(Player*, u16);
+extern PlayState* gPlayState;
 }
 
 static u16 sItemButtons[] = { BTN_B, BTN_CLEFT, BTN_CDOWN, BTN_CRIGHT, BTN_DUP, BTN_DDOWN, BTN_DLEFT, BTN_DRIGHT };
@@ -87,13 +88,17 @@ void RegisterAssignableTunicsBoots() {
 
     // do something when the player presses a button to use the tunics/boots
     COND_VB_SHOULD(VB_EXECUTE_PLAYER_ACTION_FUNC, CVAR_TUNICBOOTS_VALUE != CVAR_TUNICBOOTS_DEFAULT, {
-        Player* player = va_arg(args, Player*);
-        PlayState* play = va_arg(args, PlayState*);
+        // if the vanilla condition doesn't want us to run the actionFunc, don't do any of this
+        if (!*should) {
+            return;
+        }
+
         Input* input = va_arg(args, Input*);
+        Player* player = GET_PLAYER(gPlayState);
 
         *should = false;
-        player->actionFunc(player, play);
-        UseTunicBoots(player, play, input);
+        player->actionFunc(player, gPlayState);
+        UseTunicBoots(player, gPlayState, input);
     });
 
     // clear out assigned tunics/boots when the enhancement is toggled off

--- a/soh/soh/Enhancements/AssignableTunicsAndBoots.cpp
+++ b/soh/soh/Enhancements/AssignableTunicsAndBoots.cpp
@@ -16,7 +16,6 @@ void RegisterTunicBootsChangeUseHeldItem() {
 
         if (item >= ITEM_TUNIC_KOKIRI && item <= ITEM_BOOTS_HOVER) {
             *should = false;
-            return;
         }
     });
 }

--- a/soh/soh/Enhancements/AssignableTunicsAndBoots.cpp
+++ b/soh/soh/Enhancements/AssignableTunicsAndBoots.cpp
@@ -23,13 +23,14 @@ void UseTunicBoots(Player* player, PlayState* play, Input* input) {
         return;
     }
 
-    s32 i;
-    for (i = 0; i < ARRAY_COUNT(sItemButtons); i++) {
+    s32 item = ITEM_NONE;
+    for (s32 i = 0; i < ARRAY_COUNT(sItemButtons); i++) {
         if (CHECK_BTN_ALL(input->press.button, sItemButtons[i])) {
+            item = Player_GetItemOnButton(play, i);
             break;
         }
     }
-    s32 item = Player_GetItemOnButton(play, i);
+
     if (item >= ITEM_TUNIC_KOKIRI && item <= ITEM_BOOTS_HOVER) {
         if (item >= ITEM_BOOTS_KOKIRI) {
             u16 bootsValue = item - ITEM_BOOTS_KOKIRI + 1;

--- a/soh/soh/Enhancements/AssignableTunicsAndBoots.cpp
+++ b/soh/soh/Enhancements/AssignableTunicsAndBoots.cpp
@@ -6,6 +6,57 @@
 // in Player_UseTunicBoots (where the actual logic lives), which is
 // called by Player_UpdateCommon
 
+extern "C" {
+#include "macros.h"
+#include "variables.h"
+
+extern s32 Player_GetItemOnButton(PlayState*, s32);
+extern void Inventory_ChangeEquipment(s16, u16);
+extern void Player_SetEquipmentData(PlayState*, Player*);
+extern void func_808328EC(Player*, u16);
+}
+
+static u16 sItemButtons[] = { BTN_B, BTN_CLEFT, BTN_CDOWN, BTN_CRIGHT, BTN_DUP, BTN_DDOWN, BTN_DLEFT, BTN_DRIGHT };
+
+void UseTunicBoots(Player* player, PlayState* play, Input* input) {
+    // Boots and tunics equip despite state
+    if (
+        player->stateFlags1 & (PLAYER_STATE1_INPUT_DISABLED | PLAYER_STATE1_IN_ITEM_CS | PLAYER_STATE1_IN_CUTSCENE | PLAYER_STATE1_TALKING | PLAYER_STATE1_DEAD) ||
+        player->stateFlags2 & PLAYER_STATE2_OCARINA_PLAYING
+    ) {
+        return;
+    }
+
+    s32 i;
+    for (i = 0; i < ARRAY_COUNT(sItemButtons); i++) {
+        if (CHECK_BTN_ALL(input->press.button, sItemButtons[i])) {
+            break;
+        }
+    }
+    s32 item = Player_GetItemOnButton(play, i);
+    if (item >= ITEM_TUNIC_KOKIRI && item <= ITEM_BOOTS_HOVER) {
+        if (item >= ITEM_BOOTS_KOKIRI) {
+            u16 bootsValue = item - ITEM_BOOTS_KOKIRI + 1;
+            if (CUR_EQUIP_VALUE(EQUIP_TYPE_BOOTS) == bootsValue) {
+                Inventory_ChangeEquipment(EQUIP_TYPE_BOOTS, EQUIP_VALUE_BOOTS_KOKIRI);
+            } else {
+                Inventory_ChangeEquipment(EQUIP_TYPE_BOOTS, bootsValue);
+            }
+            Player_SetEquipmentData(play, player);
+            func_808328EC(player, CUR_EQUIP_VALUE(EQUIP_TYPE_BOOTS) == EQUIP_VALUE_BOOTS_IRON ? NA_SE_PL_WALK_HEAVYBOOTS : NA_SE_PL_CHANGE_ARMS);
+        } else {
+            u16 tunicValue = item - ITEM_TUNIC_KOKIRI + 1;
+            if (CUR_EQUIP_VALUE(EQUIP_TYPE_TUNIC) == tunicValue) {
+                Inventory_ChangeEquipment(EQUIP_TYPE_TUNIC, EQUIP_VALUE_TUNIC_KOKIRI);
+            } else {
+                Inventory_ChangeEquipment(EQUIP_TYPE_TUNIC, tunicValue);
+            }
+            Player_SetEquipmentData(play, player);
+            func_808328EC(player, NA_SE_PL_CHANGE_ARMS);
+        }
+    }
+}
+
 #define CVAR_TUNICBOOTS_NAME CVAR_ENHANCEMENT("AssignableTunicsAndBoots")
 #define CVAR_TUNICBOOTS_DEFAULT 0
 #define CVAR_TUNICBOOTS_VALUE CVarGetInteger(CVAR_TUNICBOOTS_NAME, CVAR_TUNICBOOTS_DEFAULT)
@@ -25,6 +76,16 @@ void RegisterAssignableTunicsBoots() {
         if (item >= ITEM_TUNIC_KOKIRI && item <= ITEM_BOOTS_HOVER) {
             *should = true;
         }
+    });
+
+    COND_VB_SHOULD(VB_EXECUTE_PLAYER_ACTION_FUNC, CVAR_TUNICBOOTS_VALUE != CVAR_TUNICBOOTS_DEFAULT, {
+        Player* player = va_arg(args, Player*);
+        PlayState* play = va_arg(args, PlayState*);
+        Input* input = va_arg(args, Input*);
+
+        *should = false;
+        player->actionFunc(player, play);
+        UseTunicBoots(player, play, input);
     });
 }
 

--- a/soh/soh/Enhancements/AssignableTunicsAndBoots.cpp
+++ b/soh/soh/Enhancements/AssignableTunicsAndBoots.cpp
@@ -1,0 +1,24 @@
+#include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
+#include "soh/ShipInit.hpp"
+
+// Most of the assignable tunics and boots logic has not been moved
+// over to use hooks yet. It currently lives directly in z_player.c
+// in Player_UseTunicBoots (where the actual logic lives), which is
+// called by Player_UpdateCommon
+
+#define CVAR_TUNICBOOTS_NAME CVAR_ENHANCEMENT("AssignableTunicsAndBoots")
+#define CVAR_TUNICBOOTS_DEFAULT 0
+#define CVAR_TUNICBOOTS_VALUE CVarGetInteger(CVAR_TUNICBOOTS_NAME, CVAR_TUNICBOOTS_DEFAULT)
+
+void RegisterTunicBootsChangeUseHeldItem() {
+    COND_VB_SHOULD(VB_CHANGE_HELD_ITEM_AND_USE_ITEM, CVAR_TUNICBOOTS_VALUE != CVAR_TUNICBOOTS_DEFAULT, {
+        int32_t item = va_arg(args, int32_t);
+
+        if (item >= ITEM_TUNIC_KOKIRI && item <= ITEM_BOOTS_HOVER) {
+            *should = false;
+            return;
+        }
+    });
+}
+
+static RegisterShipInitFunc initFunc(RegisterTunicBootsChangeUseHeldItem, { CVAR_TUNICBOOTS_NAME });

--- a/soh/soh/Enhancements/AssignableTunicsAndBoots.cpp
+++ b/soh/soh/Enhancements/AssignableTunicsAndBoots.cpp
@@ -1,11 +1,6 @@
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 #include "soh/ShipInit.hpp"
 
-// Most of the assignable tunics and boots logic has not been moved
-// over to use hooks yet. It currently lives directly in z_player.c
-// in Player_UseTunicBoots (where the actual logic lives), which is
-// called by Player_UpdateCommon
-
 extern "C" {
 #include "macros.h"
 #include "variables.h"
@@ -57,11 +52,22 @@ void UseTunicBoots(Player* player, PlayState* play, Input* input) {
     }
 }
 
+void ClearAssignedTunicsBoots(int32_t unused = 0) {
+    for (int32_t buttonIndex = 0; buttonIndex < 8; buttonIndex++) {
+        int32_t item = gSaveContext.equips.buttonItems[buttonIndex];
+
+        if (item >= ITEM_TUNIC_KOKIRI && item <= ITEM_BOOTS_HOVER) {
+            gSaveContext.equips.buttonItems[buttonIndex] = ITEM_NONE;
+        }
+    }
+}
+
 #define CVAR_TUNICBOOTS_NAME CVAR_ENHANCEMENT("AssignableTunicsAndBoots")
 #define CVAR_TUNICBOOTS_DEFAULT 0
 #define CVAR_TUNICBOOTS_VALUE CVarGetInteger(CVAR_TUNICBOOTS_NAME, CVAR_TUNICBOOTS_DEFAULT)
 
 void RegisterAssignableTunicsBoots() {
+    // make sure we don't change our held/equipped item when changing tunics/boots
     COND_VB_SHOULD(VB_CHANGE_HELD_ITEM_AND_USE_ITEM, CVAR_TUNICBOOTS_VALUE != CVAR_TUNICBOOTS_DEFAULT, {
         int32_t item = va_arg(args, int32_t);
 
@@ -70,6 +76,7 @@ void RegisterAssignableTunicsBoots() {
         }
     });
 
+    // make sure we don't crash because tunics/boots don't have assoicated item actions
     COND_VB_SHOULD(VB_ITEM_ACTION_BE_NONE, CVAR_TUNICBOOTS_VALUE != CVAR_TUNICBOOTS_DEFAULT, {
         int32_t item = va_arg(args, int32_t);
 
@@ -78,6 +85,7 @@ void RegisterAssignableTunicsBoots() {
         }
     });
 
+    // do something when the player presses a button to use the tunics/boots
     COND_VB_SHOULD(VB_EXECUTE_PLAYER_ACTION_FUNC, CVAR_TUNICBOOTS_VALUE != CVAR_TUNICBOOTS_DEFAULT, {
         Player* player = va_arg(args, Player*);
         PlayState* play = va_arg(args, PlayState*);
@@ -87,6 +95,14 @@ void RegisterAssignableTunicsBoots() {
         player->actionFunc(player, play);
         UseTunicBoots(player, play, input);
     });
+
+    // clear out assigned tunics/boots when the enhancement is toggled off
+    if (GameInteractor::IsSaveLoaded(true) && CVAR_TUNICBOOTS_VALUE == CVAR_TUNICBOOTS_DEFAULT) {
+        ClearAssignedTunicsBoots();
+    }
+
+    // clear out assigned tunics/boots when loading a save with enhancement turned off
+    COND_HOOK(OnLoadGame, CVAR_TUNICBOOTS_VALUE == CVAR_TUNICBOOTS_DEFAULT, ClearAssignedTunicsBoots);
 }
 
 static RegisterShipInitFunc initFunc(RegisterAssignableTunicsBoots, { CVAR_TUNICBOOTS_NAME });

--- a/soh/soh/Enhancements/AssignableTunicsAndBoots.cpp
+++ b/soh/soh/Enhancements/AssignableTunicsAndBoots.cpp
@@ -10,7 +10,7 @@
 #define CVAR_TUNICBOOTS_DEFAULT 0
 #define CVAR_TUNICBOOTS_VALUE CVarGetInteger(CVAR_TUNICBOOTS_NAME, CVAR_TUNICBOOTS_DEFAULT)
 
-void RegisterTunicBootsChangeUseHeldItem() {
+void RegisterAssignableTunicsBoots() {
     COND_VB_SHOULD(VB_CHANGE_HELD_ITEM_AND_USE_ITEM, CVAR_TUNICBOOTS_VALUE != CVAR_TUNICBOOTS_DEFAULT, {
         int32_t item = va_arg(args, int32_t);
 
@@ -18,6 +18,14 @@ void RegisterTunicBootsChangeUseHeldItem() {
             *should = false;
         }
     });
+
+    COND_VB_SHOULD(VB_ITEM_ACTION_BE_NONE, CVAR_TUNICBOOTS_VALUE != CVAR_TUNICBOOTS_DEFAULT, {
+        int32_t item = va_arg(args, int32_t);
+
+        if (item >= ITEM_TUNIC_KOKIRI && item <= ITEM_BOOTS_HOVER) {
+            *should = true;
+        }
+    });
 }
 
-static RegisterShipInitFunc initFunc(RegisterTunicBootsChangeUseHeldItem, { CVAR_TUNICBOOTS_NAME });
+static RegisterShipInitFunc initFunc(RegisterAssignableTunicsBoots, { CVAR_TUNICBOOTS_NAME });

--- a/soh/soh/Enhancements/game-interactor/GameInteractor.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor.h
@@ -532,6 +532,9 @@ typedef enum {
     VB_SPAWN_SONG_FAIRY,
     // Opt: *EnGs
     VB_SPAWN_GOSSIP_STONE_FAIRY,
+
+    /*** Equippable tunics and boots ***/
+    VB_CHANGE_HELD_ITEM_AND_USE_ITEM,
 } GIVanillaBehavior;
 
 #ifdef __cplusplus

--- a/soh/soh/Enhancements/game-interactor/GameInteractor.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor.h
@@ -536,6 +536,7 @@ typedef enum {
     /*** Equippable tunics and boots ***/
     VB_CHANGE_HELD_ITEM_AND_USE_ITEM,
     VB_ITEM_ACTION_BE_NONE,
+    VB_EXECUTE_PLAYER_ACTION_FUNC,
 } GIVanillaBehavior;
 
 #ifdef __cplusplus

--- a/soh/soh/Enhancements/game-interactor/GameInteractor.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor.h
@@ -535,6 +535,7 @@ typedef enum {
 
     /*** Equippable tunics and boots ***/
     VB_CHANGE_HELD_ITEM_AND_USE_ITEM,
+    VB_ITEM_ACTION_BE_NONE,
 } GIVanillaBehavior;
 
 #ifdef __cplusplus

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -2572,7 +2572,7 @@ void Player_ProcessItemButtons(Player* this, PlayState* play) {
             if ((item < ITEM_NONE_FE) && (Player_ItemToItemAction(item) == this->heldItemAction)) {
                 sHeldItemButtonIsHeldDown = true;
             }
-        } else {
+        } else if (item < ITEM_TUNIC_KOKIRI || item > ITEM_BOOTS_HOVER) {
             this->heldItemButton = i;
             Player_UseItem(play, this, item);
         }

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -12174,7 +12174,7 @@ void Player_UpdateCommon(Player* this, PlayState* play, Input* input) {
         sUseHeldItem = sHeldItemButtonIsHeldDown = 0;
         sSavedCurrentMask = this->currentMask;
 
-        if (GameInteractor_Should(VB_EXECUTE_PLAYER_ACTION_FUNC, !(this->stateFlags3 & PLAYER_STATE3_PAUSE_ACTION_FUNC), this, play, input)) {
+        if (GameInteractor_Should(VB_EXECUTE_PLAYER_ACTION_FUNC, !(this->stateFlags3 & PLAYER_STATE3_PAUSE_ACTION_FUNC), input)) {
             this->actionFunc(this, play);
         }
 

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -2244,16 +2244,12 @@ void Player_InitItemActionWithAnim(PlayState* play, Player* this, s8 itemAction)
 }
 
 s8 Player_ItemToItemAction(s32 item) {
-    if (item >= ITEM_NONE_FE) {
+    if (GameInteractor_Should(VB_ITEM_ACTION_BE_NONE, item >= ITEM_NONE_FE, item)) {
         return PLAYER_IA_NONE;
     } else if (item == ITEM_LAST_USED) {
         return PLAYER_IA_SWORD_CS;
     } else if (item == ITEM_FISHING_POLE) {
         return PLAYER_IA_FISHING_POLE;
-    // #region SOH [Enhancement] Added to prevent crashes with assignable equipment
-    } else if (item >= ITEM_TUNIC_KOKIRI && item <= ITEM_BOOTS_HOVER) {
-        return PLAYER_IA_NONE;
-    // #endregion
     } else {
         return sItemActions[item];
     }

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -2572,7 +2572,7 @@ void Player_ProcessItemButtons(Player* this, PlayState* play) {
             if ((item < ITEM_NONE_FE) && (Player_ItemToItemAction(item) == this->heldItemAction)) {
                 sHeldItemButtonIsHeldDown = true;
             }
-        } else if (item < ITEM_TUNIC_KOKIRI || item > ITEM_BOOTS_HOVER) {
+        } else if (GameInteractor_Should(VB_CHANGE_HELD_ITEM_AND_USE_ITEM, true, item)) {
             this->heldItemButton = i;
             Player_UseItem(play, this, item);
         }

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -12213,10 +12213,14 @@ void Player_UpdateCommon(Player* this, PlayState* play, Input* input) {
         sUseHeldItem = sHeldItemButtonIsHeldDown = 0;
         sSavedCurrentMask = this->currentMask;
 
-        if (!(this->stateFlags3 & PLAYER_STATE3_PAUSE_ACTION_FUNC)) {
+        if (GameInteractor_Should(VB_EXECUTE_PLAYER_ACTION_FUNC, !(this->stateFlags3 & PLAYER_STATE3_PAUSE_ACTION_FUNC), this, play, input)) {
             this->actionFunc(this, play);
-            Player_UseTunicBoots(this, play);
         }
+
+        // if (!(this->stateFlags3 & PLAYER_STATE3_PAUSE_ACTION_FUNC)) {
+        //     this->actionFunc(this, play);
+        //     Player_UseTunicBoots(this, play);
+        // }
 
         Player_UpdateCamAndSeqModes(play, this);
 

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -11878,45 +11878,6 @@ static Vec3f D_80854814 = { 0.0f, 0.0f, 200.0f };
 static f32 sWaterConveyorSpeeds[] = { 2.0f, 4.0f, 7.0f };
 static f32 sFloorConveyorSpeeds[] = { 0.5f, 1.0f, 3.0f };
 
-void Player_UseTunicBoots(Player* this, PlayState* play) {
-    // Boots and tunics equip despite state
-    if (
-        this->stateFlags1 & (PLAYER_STATE1_INPUT_DISABLED | PLAYER_STATE1_IN_ITEM_CS | PLAYER_STATE1_IN_CUTSCENE | PLAYER_STATE1_TALKING | PLAYER_STATE1_DEAD) ||
-        this->stateFlags2 & PLAYER_STATE2_OCARINA_PLAYING
-    ) {
-        return;
-    }
-
-    s32 i;
-    for (i = 0; i < ARRAY_COUNT(sItemButtons); i++) {
-        if (CHECK_BTN_ALL(sControlInput->press.button, sItemButtons[i])) {
-            break;
-        }
-    }
-    s32 item = Player_GetItemOnButton(play, i);
-    if (item >= ITEM_TUNIC_KOKIRI && item <= ITEM_BOOTS_HOVER) {
-        if (item >= ITEM_BOOTS_KOKIRI) {
-            u16 bootsValue = item - ITEM_BOOTS_KOKIRI + 1;
-            if (CUR_EQUIP_VALUE(EQUIP_TYPE_BOOTS) == bootsValue) {
-                Inventory_ChangeEquipment(EQUIP_TYPE_BOOTS, EQUIP_VALUE_BOOTS_KOKIRI);
-            } else {
-                Inventory_ChangeEquipment(EQUIP_TYPE_BOOTS, bootsValue);
-            }
-            Player_SetEquipmentData(play, this);
-            func_808328EC(this, CUR_EQUIP_VALUE(EQUIP_TYPE_BOOTS) == EQUIP_VALUE_BOOTS_IRON ? NA_SE_PL_WALK_HEAVYBOOTS : NA_SE_PL_CHANGE_ARMS);
-        } else {
-            u16 tunicValue = item - ITEM_TUNIC_KOKIRI + 1;
-            if (CUR_EQUIP_VALUE(EQUIP_TYPE_TUNIC) == tunicValue) {
-                Inventory_ChangeEquipment(EQUIP_TYPE_TUNIC, EQUIP_VALUE_TUNIC_KOKIRI);
-            } else {
-                Inventory_ChangeEquipment(EQUIP_TYPE_TUNIC, tunicValue);
-            }
-            Player_SetEquipmentData(play, this);
-            func_808328EC(this, NA_SE_PL_CHANGE_ARMS);
-        }
-    }
-}
-
 void Player_UpdateCommon(Player* this, PlayState* play, Input* input) {
     s32 pad;
 
@@ -12216,11 +12177,6 @@ void Player_UpdateCommon(Player* this, PlayState* play, Input* input) {
         if (GameInteractor_Should(VB_EXECUTE_PLAYER_ACTION_FUNC, !(this->stateFlags3 & PLAYER_STATE3_PAUSE_ACTION_FUNC), this, play, input)) {
             this->actionFunc(this, play);
         }
-
-        // if (!(this->stateFlags3 & PLAYER_STATE3_PAUSE_ACTION_FUNC)) {
-        //     this->actionFunc(this, play);
-        //     Player_UseTunicBoots(this, play);
-        // }
 
         Player_UpdateCamAndSeqModes(play, this);
 


### PR DESCRIPTION
moved the rabbit hole diving i was doing in https://github.com/HarbourMasters/Shipwright/pull/4977 over here

main issue is that having `VB_ITEM_ACTION_BE_NONE` do the tunic/boots safeguarding conditionally on assignable tunic/boots makes it so unchecking that while still having tunic/boots equipped then trying to use them by pressing the button causes a crash

- [x] i think the real fix is to unassign them from the buttons when the enhancement is toggled off ~, i haven't started digging into how to handle that with hooks yet~ (done in https://github.com/HarbourMasters/Shipwright/pull/4978/commits/bfc3679cde49d2a2a1bc3b2da8e52818187a5ceb)

there's also the kaleido part of the rabbit hole which i don't plan on getting to in this PR

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2529362590.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2529385799.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2529389749.zip)
<!--- section:artifacts:end -->