### PR TITLE
Defer scene DList resource loading to in-game and support alt pathing

### DIFF
--- a/soh/soh/resource/importer/scenecommand/SetMeshFactory.cpp
+++ b/soh/soh/resource/importer/scenecommand/SetMeshFactory.cpp
@@ -65,9 +65,9 @@ SetMeshFactory::ReadResource(std::shared_ptr<Ship::ResourceInitData> initData, s
             setMesh->meshHeader.polygon1.format = reader->ReadUByte();
 
             // These strings are the same that are read and used below. Not sure why they get exported twice from the exporter.
-            // We ignore these in favor of using the ones below.
-            std::string imgOpa = reader->ReadString();
-            std::string imgXlu = reader->ReadString();
+            // We read and ignore these to advance the reader.
+            reader->ReadString();
+            reader->ReadString();
 
             int32_t bgImageCount = reader->ReadUInt32();
             setMesh->images.reserve(bgImageCount);
@@ -241,11 +241,6 @@ std::shared_ptr<Ship::IResource> SetMeshFactoryXML::ReadResource(std::shared_ptr
             pType.xlu = nullptr;
 
             setMesh->meshHeader.polygon1.format = child->IntAttribute("Format");
-
-            // These strings are the same that are read and used below. Not sure why they get exported twice from the exporter.
-            // We ignore these in favor of using the ones below.
-            std::string imgOpa = child->Attribute("ImgOpa");
-            std::string imgXlu = child->Attribute("ImgXlu");
 
             int32_t bgImageCount = child->IntAttribute("BgImageCount");
             setMesh->images.reserve(bgImageCount);

--- a/soh/soh/resource/importer/scenecommand/SetMeshFactory.cpp
+++ b/soh/soh/resource/importer/scenecommand/SetMeshFactory.cpp
@@ -36,30 +36,38 @@ SetMeshFactory::ReadResource(std::shared_ptr<Ship::ResourceInitData> initData, s
     for (int32_t i = 0; i < polyNum; i++) {
         if (setMesh->meshHeader.base.type == 0) {
             PolygonDlist dlist;
+            dlist.opa = nullptr;
+            dlist.xlu = nullptr;
 
             int32_t polyType = reader->ReadInt8(); // Unused
             std::string meshOpa = reader->ReadString();
             std::string meshXlu = reader->ReadString();
 
-            auto opaRes = Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(meshOpa.c_str());
-            auto xluRes = Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(meshXlu.c_str());
-            dlist.opa = meshOpa != "" ? (Gfx*)(opaRes ? opaRes->GetRawPointer() : nullptr) : 0;
-            dlist.xlu = meshXlu != "" ? (Gfx*)(xluRes ? xluRes->GetRawPointer() : nullptr) : 0;
+            // Enables alt-toggling support by setting maintained c_str references to DList resource after pushing to vector the first
+            // Defers resource loading later in game when the scene is drawn
+            if (meshOpa != "") {
+                meshOpa = "__OTR__" + meshOpa;
+                setMesh->opaPaths.push_back(meshOpa);
+                dlist.opa = (Gfx*)setMesh->opaPaths.back().c_str();
+            }
+            if (meshXlu != "") {
+                meshXlu = "__OTR__" + meshXlu;
+                setMesh->xluPaths.push_back(meshXlu);
+                dlist.xlu = (Gfx*)setMesh->xluPaths.back().c_str();
+            }
 
-            setMesh->opaPaths.push_back(meshOpa);
-            setMesh->xluPaths.push_back(meshXlu);
             setMesh->dlists.push_back(dlist);
         } else if (setMesh->meshHeader.base.type == 1) {
             PolygonDlist pType;
+            pType.opa = nullptr;
+            pType.xlu = nullptr;
 
             setMesh->meshHeader.polygon1.format = reader->ReadUByte();
+
+            // These strings are the same that are read and used below. Not sure why they get exported twice from the exporter.
+            // We ignore these in favor of using the ones below.
             std::string imgOpa = reader->ReadString();
             std::string imgXlu = reader->ReadString();
-
-            auto opaRes = Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(imgOpa.c_str());
-            auto xluRes = Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(imgXlu.c_str());
-            pType.opa = imgOpa != "" ? (Gfx*)(opaRes ? opaRes->GetRawPointer() : nullptr) : 0;
-            pType.xlu = imgXlu != "" ? (Gfx*)(xluRes ? xluRes->GetRawPointer() : nullptr) : 0;
 
             int32_t bgImageCount = reader->ReadUInt32();
             setMesh->images.reserve(bgImageCount);
@@ -104,17 +112,24 @@ SetMeshFactory::ReadResource(std::shared_ptr<Ship::ResourceInitData> initData, s
             std::string meshOpa = reader->ReadString();
             std::string meshXlu = reader->ReadString();
 
-            opaRes = Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(meshOpa.c_str());
-            xluRes = Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(meshXlu.c_str());
-            pType.opa = meshOpa != "" ? (Gfx*)(opaRes ? opaRes->GetRawPointer() : nullptr) : 0;
-            pType.xlu = meshXlu != "" ? (Gfx*)(xluRes ? xluRes->GetRawPointer() : nullptr) : 0;
+            // Use long-lived maintained c_str references
+            if (meshOpa != "") {
+                meshOpa = "__OTR__" + meshOpa;
+                setMesh->opaPaths.push_back(meshOpa);
+                pType.opa = (Gfx*)setMesh->opaPaths.back().c_str();
+            }
+            if (meshXlu != "") {
+                meshXlu = "__OTR__" + meshXlu;
+                setMesh->xluPaths.push_back(meshXlu);
+                pType.xlu = (Gfx*)setMesh->xluPaths.back().c_str();
+            }
 
-            setMesh->opaPaths.push_back(meshOpa);
-            setMesh->xluPaths.push_back(meshXlu);
             setMesh->dlists.push_back(pType);
         } else if (setMesh->meshHeader.base.type == 2) {
             PolygonDlist2 dlist;
-            
+            dlist.opa = nullptr;
+            dlist.xlu = nullptr;
+
             int32_t polyType = reader->ReadInt8(); // Unused
             dlist.pos.x = reader->ReadInt16();
             dlist.pos.y = reader->ReadInt16();
@@ -124,13 +139,18 @@ SetMeshFactory::ReadResource(std::shared_ptr<Ship::ResourceInitData> initData, s
             std::string meshOpa = reader->ReadString();
             std::string meshXlu = reader->ReadString();
 
-            auto opaRes = meshOpa != "" ? Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(meshOpa.c_str()) : nullptr;
-            auto xluRes = meshXlu != "" ? Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(meshXlu.c_str()) : nullptr;
-            dlist.opa = (Gfx*)(opaRes ? opaRes->GetRawPointer() : nullptr);
-            dlist.xlu = (Gfx*)(xluRes ? xluRes->GetRawPointer() : nullptr);
+            // Use long-lived maintained c_str references
+            if (meshOpa != "") {
+                meshOpa = "__OTR__" + meshOpa;
+                setMesh->opaPaths.push_back(meshOpa);
+                dlist.opa = (Gfx*)setMesh->opaPaths.back().c_str();
+            }
+            if (meshXlu != "") {
+                meshXlu = "__OTR__" + meshXlu;
+                setMesh->xluPaths.push_back(meshXlu);
+                dlist.xlu = (Gfx*)setMesh->xluPaths.back().c_str();
+            }
 
-            setMesh->opaPaths.push_back(meshOpa);
-            setMesh->xluPaths.push_back(meshXlu);
             setMesh->dlists2.push_back(dlist);
         } else {
             SPDLOG_ERROR("Tried to load mesh in SetMesh scene header with type that doesn't exist: {}", setMesh->meshHeader.base.type);
@@ -194,38 +214,38 @@ std::shared_ptr<Ship::IResource> SetMeshFactoryXML::ReadResource(std::shared_ptr
 
         if (setMesh->meshHeader.base.type == 0) {
             PolygonDlist dlist;
+            dlist.opa = nullptr;
+            dlist.xlu = nullptr;
 
             int32_t polyType = child->IntAttribute("PolyType"); // Unused
             std::string meshOpa = child->Attribute("MeshOpa");
             std::string meshXlu = child->Attribute("MeshXlu");
+
+            // Enables alt-toggling support by setting maintained c_str references to DList resource after pushing to vector the first
+            // Defers resource loading later in game when the scene is drawn
             if (meshOpa != "") {
-                auto opaRes = Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(meshOpa.c_str());
-                dlist.opa = (Gfx*)(opaRes ? opaRes->GetRawPointer() : nullptr);
-            } else {
-                dlist.opa = 0;
+                meshOpa = "__OTR__" + meshOpa;
+                setMesh->opaPaths.push_back(meshOpa);
+                dlist.opa = (Gfx*)setMesh->opaPaths.back().c_str();
             }
-
             if (meshXlu != "") {
-                auto xluRes = Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(meshXlu.c_str());
-                dlist.xlu = (Gfx*)(xluRes ? xluRes->GetRawPointer() : nullptr);
-            } else {
-                dlist.xlu = 0;
+                meshXlu = "__OTR__" + meshXlu;
+                setMesh->xluPaths.push_back(meshXlu);
+                dlist.xlu = (Gfx*)setMesh->xluPaths.back().c_str();
             }
 
-            setMesh->opaPaths.push_back(meshOpa);
-            setMesh->xluPaths.push_back(meshXlu);
             setMesh->dlists.push_back(dlist);
         } else if (setMesh->meshHeader.base.type == 1) {
             PolygonDlist pType;
+            pType.opa = nullptr;
+            pType.xlu = nullptr;
 
             setMesh->meshHeader.polygon1.format = child->IntAttribute("Format");
+
+            // These strings are the same that are read and used below. Not sure why they get exported twice from the exporter.
+            // We ignore these in favor of using the ones below.
             std::string imgOpa = child->Attribute("ImgOpa");
             std::string imgXlu = child->Attribute("ImgXlu");
-
-            auto opaRes = Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(imgOpa.c_str());
-            auto xluRes = Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(imgXlu.c_str());
-            pType.opa = imgOpa != "" ? (Gfx*)(opaRes ? opaRes->GetRawPointer() : nullptr) : 0;
-            pType.xlu = imgXlu != "" ? (Gfx*)(xluRes ? xluRes->GetRawPointer() : nullptr) : 0;
 
             int32_t bgImageCount = child->IntAttribute("BgImageCount");
             setMesh->images.reserve(bgImageCount);
@@ -279,16 +299,23 @@ std::shared_ptr<Ship::IResource> SetMeshFactoryXML::ReadResource(std::shared_ptr
             std::string meshOpa = child->Attribute("MeshOpa");
             std::string meshXlu = child->Attribute("MeshXlu");
 
-            opaRes = Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(meshOpa.c_str());
-            xluRes = Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(meshXlu.c_str());
-            pType.opa = meshOpa != "" ? (Gfx*)(opaRes ? opaRes->GetRawPointer() : nullptr) : 0;
-            pType.xlu = meshXlu != "" ? (Gfx*)(xluRes ? xluRes->GetRawPointer() : nullptr) : 0;
+            // Use long-lived maintained c_str references
+            if (meshOpa != "") {
+                meshOpa = "__OTR__" + meshOpa;
+                setMesh->opaPaths.push_back(meshOpa);
+                pType.opa = (Gfx*)setMesh->opaPaths.back().c_str();
+            }
+            if (meshXlu != "") {
+                meshXlu = "__OTR__" + meshXlu;
+                setMesh->xluPaths.push_back(meshXlu);
+                pType.xlu = (Gfx*)setMesh->xluPaths.back().c_str();
+            }
 
-            setMesh->opaPaths.push_back(meshOpa);
-            setMesh->xluPaths.push_back(meshXlu);
             setMesh->dlists.push_back(pType);
         } else if (setMesh->meshHeader.base.type == 2) {
             PolygonDlist2 dlist;
+            dlist.opa = nullptr;
+            dlist.xlu = nullptr;
 
             int32_t polyType = child->IntAttribute("PolyType"); // Unused
             dlist.pos.x = child->IntAttribute("PosX");
@@ -299,13 +326,18 @@ std::shared_ptr<Ship::IResource> SetMeshFactoryXML::ReadResource(std::shared_ptr
             std::string meshOpa = child->Attribute("MeshOpa");
             std::string meshXlu = child->Attribute("MeshXlu");
 
-            auto opaRes = Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(meshOpa.c_str());
-            auto xluRes = Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(meshXlu.c_str());
-            dlist.opa = meshOpa != "" ? (Gfx*)(opaRes ? opaRes->GetRawPointer() : nullptr) : 0;
-            dlist.xlu = meshXlu != "" ? (Gfx*)(xluRes ? xluRes->GetRawPointer() : nullptr) : 0;
+            // Use long-lived maintained c_str references
+            if (meshOpa != "") {
+                meshOpa = "__OTR__" + meshOpa;
+                setMesh->opaPaths.push_back(meshOpa);
+                dlist.opa = (Gfx*)setMesh->opaPaths.back().c_str();
+            }
+            if (meshXlu != "") {
+                meshXlu = "__OTR__" + meshXlu;
+                setMesh->xluPaths.push_back(meshXlu);
+                dlist.xlu = (Gfx*)setMesh->xluPaths.back().c_str();
+            }
 
-            setMesh->opaPaths.push_back(meshOpa);
-            setMesh->xluPaths.push_back(meshXlu);
             setMesh->dlists2.push_back(dlist);
         } else {
             SPDLOG_ERROR("Tried to load mesh in SetMesh scene header with type that doesn't exist: {}", setMesh->meshHeader.base.type);


### PR DESCRIPTION
This reworks the scene mesh importer to assign the polygon DList's as resource strings, instead of loading the resource in that moment.

This achieves two main things:
* Supports re-loading individual DList resources in-game if they were previous unloaded (such as alt asset unloading)
* Supports alt-toggling on the fly. Before once a scene was loaded, the dlist was set in stone regardless if you toggled alt.

Using resource strings aligns with how we implemented alt-toggling for skeletons.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2531698727.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2531708906.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2531719136.zip)
<!--- section:artifacts:end -->