### PR TITLE
fix rainbow all

### DIFF
--- a/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
+++ b/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
@@ -1969,6 +1969,7 @@ void CosmeticsEditorWindow::DrawElement() {
                 )
             ) {
                 CVarSetInteger(cosmeticOption.rainbowCvar, 1);
+                CVarSetInteger(cosmeticOption.changedCvar, 1);
             }
         }
         Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();


### PR DESCRIPTION
pressing rainbow all wasn't doing anything if it was the first thing you did in the cosmetics editor. i found hitting randomize all and then rainbow all worked. also manually clicking rainbow on any given thing from default worked.

noticed rainbow all was missing
https://github.com/HarbourMasters/Shipwright/blob/8ae8770db8f1c3548e1b2da26c5da72a40c32d33/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp#L1746

so i added it

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2531515755.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2531517581.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2531528658.zip)
<!--- section:artifacts:end -->