### PR TITLE
Remove "Jitter Fix" option

### DIFF
--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -1438,9 +1438,6 @@ extern "C" void Graph_ProcessGfxCommands(Gfx* commands) {
         wnd->SetTargetFps(fps);
     }
 
-    int threshold = CVarGetInteger(CVAR_SETTING("ExtraLatencyThreshold"), 80);
-    wnd->SetMaximumFrameLatency(threshold > 0 && target_fps >= threshold ? 2 : 1);
-
     // When the gfx debugger is active, only run with the final mtx
     if (GfxDebuggerIsDebugging()) {
         mtx_replacements.clear();

--- a/soh/soh/SohGui/SohMenuBar.cpp
+++ b/soh/soh/SohGui/SohMenuBar.cpp
@@ -478,16 +478,6 @@ void DrawSettingsMenu() {
             }
             UIWidgets::Tooltip("Matches interpolation value to the game window's current refresh rate.");
 
-            if (Ship::Context::GetInstance()->GetWindow()->GetWindowBackend() == Ship::WindowBackend::FAST3D_DXGI_DX11) {
-                UIWidgets::PaddedEnhancementSliderInt(CVarGetInteger(CVAR_SETTING("ExtraLatencyThreshold"), 80) == 0 ? "Jitter fix: Off" : "Jitter fix: >= %d FPS",
-                    "##ExtraLatencyThreshold", CVAR_SETTING("ExtraLatencyThreshold"), 0, 360, "", 80, true, true, false);
-                UIWidgets::Tooltip(
-                    "(For DirectX backend only)\n\n"
-                    "When Interpolation FPS (Frame Rate) setting is at least this threshold, add one frame of delay (e.g. 16.6 ms for 60 FPS) in order to avoid jitter."
-                    "This setting allows the CPU to work on one frame while GPU works on the previous frame.\n"
-                    "This setting should be used when your computer is too slow to do CPU + GPU work in time.");
-            }
-
             UIWidgets::PaddedSeparator(true, true, 3.0f, 3.0f);
 
             ImGui::Text("ImGui Menu Scale");


### PR DESCRIPTION
Removes the "Jitter Fix" slider completely. This was just confusing for users.

On its own defaults to Jitter fix always off. https://github.com/Kenix3/libultraship/pull/812 however sets it to always on by default, so this LUS change should also be pulled.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2559117642.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2559118442.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2559118999.zip)
<!--- section:artifacts:end -->