### PR TITLE
fix dark link not getting hit when stunned

### DIFF
--- a/soh/src/overlays/actors/ovl_En_Torch2/z_en_torch2.c
+++ b/soh/src/overlays/actors/ovl_En_Torch2/z_en_torch2.c
@@ -608,7 +608,7 @@ void EnTorch2_Update(Actor* thisx, PlayState* play2) {
         sDeathFlag = false;
     }
     if ((this->invincibilityTimer == 0) && (this->actor.colChkInfo.health != 0) &&
-        (this->cylinder.base.acFlags & AC_HIT) && !(this->stateFlags1 & PLAYER_STATE1_SHIELDING) &&
+        (this->cylinder.base.acFlags & AC_HIT) && !(this->stateFlags1 & PLAYER_STATE1_DAMAGED) &&
         !(this->meleeWeaponQuads[0].base.atFlags & AT_HIT) && !(this->meleeWeaponQuads[1].base.atFlags & AT_HIT)) {
 
         if (!Actor_ApplyDamage(&this->actor)) {
@@ -660,7 +660,7 @@ void EnTorch2_Update(Actor* thisx, PlayState* play2) {
         this->stateFlags3 &= ~PLAYER_STATE3_PAUSE_ACTION_FUNC;
     } else {
         this->stateFlags3 |= PLAYER_STATE3_PAUSE_ACTION_FUNC;
-        this->stateFlags1 &= ~PLAYER_STATE1_SHIELDING;
+        this->stateFlags1 &= ~PLAYER_STATE1_DAMAGED;
         this->invincibilityTimer = 0;
         input->press.stick_x = input->press.stick_y = 0;
         /*! @bug


### PR DESCRIPTION
in https://github.com/HarbourMasters/Shipwright/pull/3280 both `0x00400000` and `0x04000000` were replaced with `PLAYER_STATE1_SHIELDING`.

`0x00400000` is `PLAYER_STATE1_SHIELDING`, but  `0x04000000` is `PLAYER_STATE1_DAMAGED`

this fixes the spots in `z_en_torch2` where we had `PLAYER_STATE1_SHIELDING` where it should have been `PLAYER_STATE1_DAMAGED`

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2560636543.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2560637211.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2560638727.zip)
<!--- section:artifacts:end -->