### PR TITLE
Restore pause link drawing behavior to use the work buffer

### DIFF
--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_equipment.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_equipment.c
@@ -148,7 +148,10 @@ void KaleidoScope_DrawPlayerWork(PlayState* play) {
         scale = 0.047f;
     }
 
-    gsSPSetFB(play->state.gfxCtx->polyOpa.p++, gPauseLinkFrameBuffer);
+    // SOH [Port] Draw the pause Link on a separate framebuffer starting in the work buffer
+    OPEN_DISPS(play->state.gfxCtx);
+    gsSPSetFB(WORK_DISP++, gPauseLinkFrameBuffer);
+
     rot.y = 32300;
     rot.x = rot.z = 0;
     Player_DrawPause(play, pauseCtx->playerSegment, &pauseCtx->playerSkelAnime, &pos, &rot, scale,
@@ -156,7 +159,9 @@ void KaleidoScope_DrawPlayerWork(PlayState* play) {
                      TUNIC_EQUIP_TO_PLAYER(CUR_EQUIP_VALUE(EQUIP_TYPE_TUNIC)),
                      SHIELD_EQUIP_TO_PLAYER(CUR_EQUIP_VALUE(EQUIP_TYPE_SHIELD)),
                      BOOTS_EQUIP_TO_PLAYER(CUR_EQUIP_VALUE(EQUIP_TYPE_BOOTS)));
-    gsSPResetFB(play->state.gfxCtx->polyOpa.p++);
+
+    gsSPResetFB(WORK_DISP++);
+    CLOSE_DISPS(play->state.gfxCtx);
 }
 
 void KaleidoScope_DrawEquipment(PlayState* play) {


### PR DESCRIPTION
This restores some of the pause link draw code back to decomp src, where it creates two DLs (for OPA and XLU draws of Link) and then executes those as part of the work buffer which is the very first draw calls (work -> opa -> xlu -> overlay)

This is preemptive work to get us to rip out the custom added `polyKal` buffer which is no longer needed with the newer frame buffer handling for kaleido's background.

There was some extra hacks to force the triforce draw (which uses XLU internally) that made a temp and overwrote XLU to be the end of OPA. This is no longer necessary with these changes and can be simplified.

Here is how it looks in the Gfx Debugger, where OPA DL and XLU DL are the set-aside allocated buffers for the Link draws.

![image](https://github.com/user-attachments/assets/087324af-e8bd-474d-a3b4-0e98d1fbb9f5)


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2573620975.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2573629338.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2573838719.zip)
<!--- section:artifacts:end -->