### PR TITLE
ShipInit and move ValueViewer rendering out of src

### DIFF
--- a/soh/soh/Enhancements/debugger/colViewer.h
+++ b/soh/soh/Enhancements/debugger/colViewer.h
@@ -2,11 +2,6 @@
 
 #include <libultraship/libultraship.h>
 
-#ifdef __cplusplus
-extern "C"
-#endif
-void DrawColViewer();
-
 typedef enum {
   COLVIEW_DISABLED,
   COLVIEW_SOLID,

--- a/soh/soh/Enhancements/debugger/valueViewer.h
+++ b/soh/soh/Enhancements/debugger/valueViewer.h
@@ -42,12 +42,4 @@ class ValueViewerWindow : public Ship::GuiWindow {
     void UpdateElement() override {};
 };
 
-extern "C" {
-#include <z64.h>
-#endif
-
-void ValueViewer_Draw(GfxPrint* printer);
-
-#ifdef __cplusplus
-}
 #endif

--- a/soh/src/code/graph.c
+++ b/soh/src/code/graph.c
@@ -6,8 +6,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include "soh/Enhancements/debugger/colViewer.h"
-#include "soh/Enhancements/debugger/valueViewer.h"
 #include "soh/Enhancements/gameconsole.h"
 #include "soh/OTRGlobals.h"
 #include "libultraship/bridge.h"
@@ -301,28 +299,6 @@ void Graph_Update(GraphicsContext* gfxCtx, GameState* gameState) {
     GameState_Update(gameState);
 
     OPEN_DISPS(gfxCtx);
-
-    if (CVarGetInteger(CVAR_DEVELOPER_TOOLS("ValueViewerEnablePrinting"), 0)) {
-        Gfx* gfx;
-        Gfx* polyOpa;
-        GfxPrint printer;
-
-        polyOpa = POLY_OPA_DISP;
-        gfx = Graph_GfxPlusOne(polyOpa);
-        gSPDisplayList(OVERLAY_DISP++, gfx);
-
-        GfxPrint_Init(&printer);
-        GfxPrint_Open(&printer, gfx);
-
-        ValueViewer_Draw(&printer);
-
-        gfx = GfxPrint_Close(&printer);
-        GfxPrint_Destroy(&printer);
-
-        gSPEndDisplayList(gfx++);
-        Graph_BranchDlist(polyOpa, gfx);
-        POLY_OPA_DISP = gfx;
-    }
 
     gDPNoOpString(WORK_DISP++, "WORK_DISP 終了", 0);
     gDPNoOpString(POLY_OPA_DISP++, "POLY_OPA_DISP 終了", 0);


### PR DESCRIPTION
Uses ShipInit to register and move the ValueViewer rendering to the game state update hook (which places the value viewer draw at the end of the display buffers).

Also cleaned up some left over references for the collision viewer draw method.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2574142140.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2574148746.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2574309281.zip)
<!--- section:artifacts:end -->