### PR TITLE
Add hilite setup calls around all custom GI draws

### DIFF
--- a/soh/soh/Enhancements/randomizer/ShuffleFairies.cpp
+++ b/soh/soh/Enhancements/randomizer/ShuffleFairies.cpp
@@ -18,6 +18,8 @@ void ShuffleFairies_DrawRandomizedItem(EnElf* enElf, PlayState* play) {
     }
     Matrix_Push();
     Matrix_Scale(37.5, 37.5, 37.5, MTXMODE_APPLY);
+    func_8002EBCC(&enElf->actor, play, 0);
+    func_8002ED80(&enElf->actor, play, 0);
     EnItem00_CustomItemsParticles(&enElf->actor, play, randoGetItem);
     GetItemEntry_Draw(play, randoGetItem);
     Matrix_Pop();

--- a/soh/soh/Enhancements/randomizer/fishsanity.cpp
+++ b/soh/soh/Enhancements/randomizer/fishsanity.cpp
@@ -548,6 +548,8 @@ extern "C" {
         Matrix_Push();
         Matrix_Scale(30.0, 30.0, 30.0, MTXMODE_APPLY);
 
+        func_8002EBCC(actor, play, 0);
+        func_8002ED80(actor, play, 0);
         EnItem00_CustomItemsParticles(actor, play, randoItem);
         GetItemEntry_Draw(play, randoItem);
 

--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -381,6 +381,7 @@ void EnExItem_DrawRandomizedItem(EnExItem* enExItem, PlayState* play) {
     if (CVarGetInteger(CVAR_RANDOMIZER_ENHANCEMENT("MysteriousShuffle"), 0)) {
         randoGetItem = GET_ITEM_MYSTERY;
     }
+    func_8002EBCC(&enExItem->actor, play, 0);
     func_8002ED80(&enExItem->actor, play, 0);
     EnItem00_CustomItemsParticles(&enExItem->actor, play, randoGetItem);
     GetItemEntry_Draw(play, randoGetItem);
@@ -412,6 +413,8 @@ void EnItem00_DrawRandomizedItem(EnItem00* enItem00, PlayState* play) {
         enItem00->actor.params != ITEM00_SOH_GIVE_ITEM_ENTRY) {
         randoItem = GET_ITEM_MYSTERY;
     }
+    func_8002EBCC(&enItem00->actor, play, 0);
+    func_8002ED80(&enItem00->actor, play, 0);
     EnItem00_CustomItemsParticles(&enItem00->actor, play, randoItem);
     GetItemEntry_Draw(play, randoItem);
 }
@@ -421,6 +424,8 @@ void ItemBHeart_DrawRandomizedItem(ItemBHeart* itemBHeart, PlayState* play) {
     if (CVarGetInteger(CVAR_RANDOMIZER_ENHANCEMENT("MysteriousShuffle"), 0)) {
         randoItem = GET_ITEM_MYSTERY;
     }
+    func_8002EBCC(&itemBHeart->actor, play, 0);
+    func_8002ED80(&itemBHeart->actor, play, 0);
     EnItem00_CustomItemsParticles(&itemBHeart->actor, play, randoItem);
     GetItemEntry_Draw(play, randoItem);
 }

--- a/soh/src/code/z_en_item00.c
+++ b/soh/src/code/z_en_item00.c
@@ -997,6 +997,12 @@ void EnItem00_Draw(Actor* thisx, PlayState* play) {
     EnItem00* this = (EnItem00*)thisx;
     f32 mtxScale;
 
+    // Setup Hilites for 3D drops
+    if (CVarGetInteger(CVAR_ENHANCEMENT("NewDrops"), 0)) {
+        func_8002EBCC(&this->actor, play, 0);
+        func_8002ED80(&this->actor, play, 0);
+    }
+
     if (!(this->unk_156 & this->unk_158)) {
         switch (this->actor.params) {
             case ITEM00_RUPEE_GREEN:

--- a/soh/src/overlays/actors/ovl_En_Ex_Ruppy/z_en_ex_ruppy.c
+++ b/soh/src/overlays/actors/ovl_En_Ex_Ruppy/z_en_ex_ruppy.c
@@ -389,6 +389,9 @@ void EnExRuppy_Draw(Actor* thisx, PlayState* play) {
         OPEN_DISPS(play->state.gfxCtx);
 
         if (CVarGetInteger(CVAR_ENHANCEMENT("NewDrops"), 0)) {
+            func_8002EBCC(&this->actor, play, 0);
+            func_8002ED80(&this->actor, play, 0);
+
             // purple/gold rupees need less scaling
             f32 mtxScale = this->colorIdx >= 3 ? 17.5f : 25.0f;
             Matrix_Scale(mtxScale, mtxScale, mtxScale, MTXMODE_APPLY);

--- a/soh/src/overlays/actors/ovl_En_G_Switch/z_en_g_switch.c
+++ b/soh/src/overlays/actors/ovl_En_G_Switch/z_en_g_switch.c
@@ -481,6 +481,9 @@ void EnGSwitch_DrawRupee(Actor* thisx, PlayState* play) {
         OPEN_DISPS(play->state.gfxCtx);
 
         if (CVarGetInteger(CVAR_ENHANCEMENT("NewDrops"), 0)) {
+            func_8002EBCC(&this->actor, play, 0);
+            func_8002ED80(&this->actor, play, 0);
+
             // purple/gold/silver rupees need less scaling
             f32 mtxScale = this->colorIdx >= 3 ? 17.5f : 25.0f;
             Matrix_Scale(mtxScale, mtxScale, mtxScale, MTXMODE_APPLY);

--- a/soh/src/overlays/actors/ovl_En_GirlA/z_en_girla.c
+++ b/soh/src/overlays/actors/ovl_En_GirlA/z_en_girla.c
@@ -1428,6 +1428,9 @@ void EnGirlA_Draw(Actor* thisx, PlayState* play) {
     }
 
     if (this->actor.params == SI_RANDOMIZED_ITEM) {
+        // Set all hilites for randomized items
+        func_80A3C498(&this->actor, play, 0);
+
         ShopItemIdentity shopItemIdentity = Randomizer_IdentifyShopItem(play->sceneNum, this->randoSlotIndex);
         GetItemEntry getItemEntry = (CVarGetInteger(CVAR_RANDOMIZER_ENHANCEMENT("MysteriousShuffle"), 0) && this->actor.params == SI_RANDOMIZED_ITEM) ? GetItemMystery() : 
                                     Randomizer_GetItemFromKnownCheckWithoutObtainabilityCheck(shopItemIdentity.randomizerCheck, shopItemIdentity.ogItemId);


### PR DESCRIPTION
This adds hilite setup calls before all of our custom uses of GI draws.

The game normally does this before any GI draws that happen in vanilla (like in shops, heart containers, etc), but we weren't calling them in all other places that we added. The hilite calls are responsible for making the texture gen effects to not move strangely based on the player camera.

It is a little messy, and probably it would be worth having a new method that contains all the logic needed to draw GI models like this.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2575593208.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2575593868.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2575605963.zip)
<!--- section:artifacts:end -->