### PR TITLE
Use VB hook to fix Deku Nut upgrade bug

### DIFF
--- a/soh/soh/Enhancements/Fixes/DekuNutUpgradeFix.cpp
+++ b/soh/soh/Enhancements/Fixes/DekuNutUpgradeFix.cpp
@@ -6,11 +6,18 @@
 #include "variables.h"
 #include "z64save.h"
 
+extern "C" PlayState* gPlayState;
+
 static constexpr int32_t CVAR_NUT_UPGRADE_FIX_DEFAULT = 0;
 #define CVAR_NUT_UPGRADE_FIX_NAME CVAR_ENHANCEMENT("DekuNutUpgradeFix")
 #define CVAR_NUT_UPGRADE_FIX_VALUE CVarGetInteger(CVAR_NUT_UPGRADE_FIX_NAME, CVAR_NUT_UPGRADE_FIX_DEFAULT)
 
 void DekuNutUpgradeFixAtForestStage(bool* should) {
+    // This check is needed because of an intentional fallthrough at the source
+    if (Player_GetMask(gPlayState) == PLAYER_MASK_SKULL) {
+        return;
+    }
+
     s32 expectedNutUpgrades = (INV_CONTENT(ITEM_NUT) == ITEM_NUT ? 1 : 0) +
                               (Flags_GetInfTable(INFTABLE_BOUGHT_NUT_UPGRADE) ? 1 : 0) +
                               (Flags_GetItemGetInf(ITEMGETINF_OBTAINED_NUT_UPGRADE_FROM_STAGE) ? 1 : 0);

--- a/soh/soh/Enhancements/Fixes/DekuNutUpgradeFix.cpp
+++ b/soh/soh/Enhancements/Fixes/DekuNutUpgradeFix.cpp
@@ -1,0 +1,39 @@
+#include <libultraship/bridge.h>
+#include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
+#include "soh/ShipInit.hpp"
+#include "functions.h"
+#include "macros.h"
+#include "variables.h"
+#include "z64save.h"
+
+extern "C" SaveContext gSaveContext;
+
+#define CVAR_DEKU_NUT_UPGRADE_FIX_NAME CVAR_ENHANCEMENT("DekuNutUpgradeFix")
+#define CVAR_DEKU_NUT_UPGRADE_FIX_DEFAULT 0
+#define CVAR_DEKU_NUT_UPGRADE_FIX_VALUE \
+    IS_RANDO || CVarGetInteger(CVAR_DEKU_NUT_UPGRADE_FIX_NAME, CVAR_DEKU_NUT_UPGRADE_FIX_DEFAULT)
+
+void DekuNutUpgradeFixAtForestStage(bool* should) {
+    s32 expectedNutUpgrades = (INV_CONTENT(ITEM_NUT) == ITEM_NUT ? 1 : 0) +
+                              (Flags_GetInfTable(INFTABLE_BOUGHT_NUT_UPGRADE) ? 1 : 0) +
+                              (Flags_GetItemGetInf(ITEMGETINF_OBTAINED_NUT_UPGRADE_FROM_STAGE) ? 1 : 0);
+    s32 actualNutUpgrades = CUR_UPG_VALUE(UPG_NUTS);
+
+    if (expectedNutUpgrades != actualNutUpgrades) {
+        Flags_UnsetItemGetInf(ITEMGETINF_OBTAINED_NUT_UPGRADE_FROM_STAGE);
+        *should = true;
+    }
+}
+
+void DekuNutUpgradeSetByPoachersSaw(bool* should) {
+    *should = false;
+}
+
+void RegisterDekuNutUpgradeFix() {
+    COND_VB_SHOULD(VB_POACHERS_SAW_SET_DEKU_NUT_UPGRADE_FLAG, CVAR_DEKU_NUT_UPGRADE_FIX_VALUE,
+                   { DekuNutUpgradeSetByPoachersSaw(should); });
+    COND_VB_SHOULD(VB_DEKU_SCRUBS_REACT_TO_MASK_OF_TRUTH, CVAR_DEKU_NUT_UPGRADE_FIX_VALUE,
+                   { DekuNutUpgradeFixAtForestStage(should); });
+}
+
+static RegisterShipInitFunc initFunc(RegisterDekuNutUpgradeFix, { CVAR_DEKU_NUT_UPGRADE_FIX_NAME, "IS_RANDO" });

--- a/soh/soh/Enhancements/Fixes/DekuNutUpgradeFix.cpp
+++ b/soh/soh/Enhancements/Fixes/DekuNutUpgradeFix.cpp
@@ -36,7 +36,7 @@ void DekuNutUpgradeSetByPoachersSaw(bool* should) {
 void RegisterDekuNutUpgradeFix() {
     COND_VB_SHOULD(VB_POACHERS_SAW_SET_DEKU_NUT_UPGRADE_FLAG, CVAR_NUT_UPGRADE_FIX_VALUE || IS_RANDO,
                    { DekuNutUpgradeSetByPoachersSaw(should); });
-    COND_VB_SHOULD(VB_DEKU_SCRUBS_REACT_TO_MASK_OF_TRUTH, CVAR_NUT_UPGRADE_FIX_VALUE || IS_RANDO,
+    COND_VB_SHOULD(VB_DEKU_SCRUBS_REACT_TO_MASK_OF_TRUTH, CVAR_NUT_UPGRADE_FIX_VALUE && !IS_RANDO,
                    { DekuNutUpgradeFixAtForestStage(should); });
 }
 

--- a/soh/soh/Enhancements/Fixes/DekuNutUpgradeFix.cpp
+++ b/soh/soh/Enhancements/Fixes/DekuNutUpgradeFix.cpp
@@ -6,10 +6,9 @@
 #include "variables.h"
 #include "z64save.h"
 
-static constexpr int32_t CVAR_DEKU_NUT_UPGRADE_FIX_DEFAULT = 0;
-#define CVAR_DEKU_NUT_UPGRADE_FIX_NAME CVAR_ENHANCEMENT("DekuNutUpgradeFix")
-#define CVAR_DEKU_NUT_UPGRADE_FIX_VALUE \
-    IS_RANDO || CVarGetInteger(CVAR_DEKU_NUT_UPGRADE_FIX_NAME, CVAR_DEKU_NUT_UPGRADE_FIX_DEFAULT)
+static constexpr int32_t CVAR_NUT_UPGRADE_FIX_DEFAULT = 0;
+#define CVAR_NUT_UPGRADE_FIX_NAME CVAR_ENHANCEMENT("DekuNutUpgradeFix")
+#define CVAR_NUT_UPGRADE_FIX_VALUE CVarGetInteger(CVAR_NUT_UPGRADE_FIX_NAME, CVAR_NUT_UPGRADE_FIX_DEFAULT)
 
 void DekuNutUpgradeFixAtForestStage(bool* should) {
     s32 expectedNutUpgrades = (INV_CONTENT(ITEM_NUT) == ITEM_NUT ? 1 : 0) +
@@ -28,10 +27,10 @@ void DekuNutUpgradeSetByPoachersSaw(bool* should) {
 }
 
 void RegisterDekuNutUpgradeFix() {
-    COND_VB_SHOULD(VB_POACHERS_SAW_SET_DEKU_NUT_UPGRADE_FLAG, CVAR_DEKU_NUT_UPGRADE_FIX_VALUE,
+    COND_VB_SHOULD(VB_POACHERS_SAW_SET_DEKU_NUT_UPGRADE_FLAG, CVAR_NUT_UPGRADE_FIX_VALUE || IS_RANDO,
                    { DekuNutUpgradeSetByPoachersSaw(should); });
-    COND_VB_SHOULD(VB_DEKU_SCRUBS_REACT_TO_MASK_OF_TRUTH, CVAR_DEKU_NUT_UPGRADE_FIX_VALUE,
+    COND_VB_SHOULD(VB_DEKU_SCRUBS_REACT_TO_MASK_OF_TRUTH, CVAR_NUT_UPGRADE_FIX_VALUE || IS_RANDO,
                    { DekuNutUpgradeFixAtForestStage(should); });
 }
 
-static RegisterShipInitFunc initFunc(RegisterDekuNutUpgradeFix, { CVAR_DEKU_NUT_UPGRADE_FIX_NAME, "IS_RANDO" });
+static RegisterShipInitFunc initFunc(RegisterDekuNutUpgradeFix, { CVAR_NUT_UPGRADE_FIX_NAME, "IS_RANDO" });

--- a/soh/soh/Enhancements/Fixes/DekuNutUpgradeFix.cpp
+++ b/soh/soh/Enhancements/Fixes/DekuNutUpgradeFix.cpp
@@ -6,10 +6,8 @@
 #include "variables.h"
 #include "z64save.h"
 
-extern "C" SaveContext gSaveContext;
-
+static constexpr int32_t CVAR_DEKU_NUT_UPGRADE_FIX_DEFAULT = 0;
 #define CVAR_DEKU_NUT_UPGRADE_FIX_NAME CVAR_ENHANCEMENT("DekuNutUpgradeFix")
-#define CVAR_DEKU_NUT_UPGRADE_FIX_DEFAULT 0
 #define CVAR_DEKU_NUT_UPGRADE_FIX_VALUE \
     IS_RANDO || CVarGetInteger(CVAR_DEKU_NUT_UPGRADE_FIX_NAME, CVAR_DEKU_NUT_UPGRADE_FIX_DEFAULT)
 

--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -292,6 +292,14 @@ typedef enum {
 
     // #### `result`
     // ```c
+    // !Flags_GetItemGetInf(ITEMGETINF_OBTAINED_NUT_UPGRADE_FROM_STAGE) && (Player_GetMask(play) != PLAYER_MASK_SKULL)
+    // ```
+    // #### `args`
+    // - None
+    VB_DEKU_SCRUBS_REACT_TO_MASK_OF_TRUTH,
+
+    // #### `result`
+    // ```c
     // CHECK_QUEST_ITEM(QUEST_MEDALLION_FOREST)
     // ```
     // #### `args`
@@ -1509,6 +1517,14 @@ typedef enum {
     // #### `args`
     // - `*DemoIm`
     VB_PLAY_ZELDAS_LULLABY_CS,
+
+    // #### `result`
+    // ```c
+    // item == ITEM_SAW
+    // ```
+    // #### `args`
+    // - None
+    VB_POACHERS_SAW_SET_DEKU_NUT_UPGRADE_FLAG,
 
     // #### `result`
     // ```c

--- a/soh/soh/Enhancements/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.cpp
@@ -92,7 +92,9 @@ void EnDntDemo_JudgeSkipToReward(EnDntDemo* enDntDemo, PlayState* play) {
             return;
         }
         case PLAYER_MASK_TRUTH: {
-            Flags_SetItemGetInf(ITEMGETINF_OBTAINED_NUT_UPGRADE_FROM_STAGE);
+            if (GameInteractor_Should(VB_DEKU_SCRUBS_REACT_TO_MASK_OF_TRUTH, true)) {
+                Flags_SetItemGetInf(ITEMGETINF_OBTAINED_NUT_UPGRADE_FROM_STAGE);
+            }
             return;
         }
         default: {

--- a/soh/soh/SohGui/SohMenuBar.cpp
+++ b/soh/soh/SohGui/SohMenuBar.cpp
@@ -1336,7 +1336,10 @@ void DrawEnhancementsMenu() {
             UIWidgets::PaddedEnhancementCheckbox("Fix the Gravedigging Tour Glitch", CVAR_ENHANCEMENT("GravediggingTourFix"), true, false, SaveManager::Instance->IsRandoFile(),
                                                         "This setting is always enabled in randomizer files", UIWidgets::CheckboxGraphics::Checkmark);
             UIWidgets::Tooltip("Fixes a bug where the Gravedigging Tour Heart Piece disappears if the area reloads");
-            UIWidgets::PaddedEnhancementCheckbox("Fix Deku Nut upgrade", CVAR_ENHANCEMENT("DekuNutUpgradeFix"), true, false);
+            UIWidgets::PaddedEnhancementCheckbox(
+                "Fix Deku Nut upgrade", CVAR_ENHANCEMENT("DekuNutUpgradeFix"), true, false, IS_RANDO,
+                "This setting is forcefully enabled when you are playing a randomizer.",
+                UIWidgets::CheckboxGraphics::Checkmark);
             UIWidgets::Tooltip("Prevents the Forest Stage Deku Nut upgrade from becoming unobtainable after receiving the Poacher's Saw");
             UIWidgets::PaddedEnhancementCheckbox("Fix Navi text HUD position", CVAR_ENHANCEMENT("NaviTextFix"), true, false);
             UIWidgets::Tooltip("Correctly centers the Navi text prompt on the HUD's C-Up button");

--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -2442,7 +2442,7 @@ u8 Item_Give(PlayState* play, u8 item) {
         }
         return Return_Item(item, MOD_NONE, ITEM_NONE);
     } else if ((item >= ITEM_WEIRD_EGG) && (item <= ITEM_CLAIM_CHECK)) {
-        if ((item == ITEM_SAW) && CVarGetInteger(CVAR_ENHANCEMENT("DekuNutUpgradeFix"), 0) == 0) {
+        if (GameInteractor_Should(VB_POACHERS_SAW_SET_DEKU_NUT_UPGRADE_FLAG, item == ITEM_SAW)) {
             Flags_SetItemGetInf(ITEMGETINF_OBTAINED_NUT_UPGRADE_FROM_STAGE);
         }
 

--- a/soh/src/overlays/actors/ovl_En_Dnt_Demo/z_en_dnt_demo.c
+++ b/soh/src/overlays/actors/ovl_En_Dnt_Demo/z_en_dnt_demo.c
@@ -10,6 +10,7 @@
 #include "overlays/actors/ovl_En_Dnt_Nomal/z_en_dnt_nomal.h"
 #include "vt.h"
 #include "soh/OTRGlobals.h"
+#include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
 #define FLAGS 0
 
@@ -165,7 +166,9 @@ void EnDntDemo_Judge(EnDntDemo* this, PlayState* play) {
                         break;
                     }
                 case PLAYER_MASK_TRUTH:
-                    if (!Flags_GetItemGetInf(ITEMGETINF_OBTAINED_NUT_UPGRADE_FROM_STAGE) && (Player_GetMask(play) != PLAYER_MASK_SKULL)) {
+                    if (GameInteractor_Should(VB_DEKU_SCRUBS_REACT_TO_MASK_OF_TRUTH,
+                                              !Flags_GetItemGetInf(ITEMGETINF_OBTAINED_NUT_UPGRADE_FROM_STAGE) &&
+                                                  (Player_GetMask(play) != PLAYER_MASK_SKULL))) {
                         Audio_PlaySoundGeneral(NA_SE_SY_TRE_BOX_APPEAR, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale,
                                                &gSfxDefaultReverb);
                         this->prize = DNT_PRIZE_NUTS;


### PR DESCRIPTION
Alternative to #4777. Changes the retroactive flag fix from a wasteful frame update hook to a lazy VB hook.

I'd like some feedback on whether there's a difference between this and #4777 in terms of how they affect rando. Just in case, I've kept the `IS_RANDO` part of the hook.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2582457277.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2582464663.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2582618929.zip)
<!--- section:artifacts:end -->