### PR TITLE
Fix issues leftover from PR #5023

### DIFF
--- a/soh/soh/Enhancements/randomizer/context.cpp
+++ b/soh/soh/Enhancements/randomizer/context.cpp
@@ -174,8 +174,17 @@ void Context::GenerateLocationPool() {
                 location.GetRandomizerCheck() == RC_LW_DEKU_SCRUB_NEAR_BRIDGE ||
                 location.GetRandomizerCheck() == RC_HF_DEKU_SCRUB_GROTTO
             )) ||
+            (location.GetRCType() == RCTYPE_ADULT_TRADE && mOptions[RSK_SHUFFLE_ADULT_TRADE].Is(RO_GENERIC_OFF)) ||
             (location.GetRCType() == RCTYPE_COW && mOptions[RSK_SHUFFLE_COWS].Is(RO_GENERIC_OFF)) ||
-            (location.GetRCType() == RCTYPE_FISH && mOptions[RSK_FISHSANITY].Is(RO_FISHSANITY_OFF)) ||
+            (location.GetRandomizerCheck() == RC_LH_HYRULE_LOACH && mOptions[RSK_FISHSANITY].IsNot(RO_FISHSANITY_HYRULE_LOACH)) ||
+            (location.GetRCType() == RCTYPE_FISH && (
+                mOptions[RSK_FISHSANITY].Is(RO_FISHSANITY_OFF) ||
+                (mOptions[RSK_FISHSANITY].Is(RO_FISHSANITY_OVERWORLD) && location.GetScene() == SCENE_FISHING_POND) ||
+                (mOptions[RSK_FISHSANITY].Is(RO_FISHSANITY_POND) && (location.GetScene() != SCENE_FISHING_POND ||
+                (mOptions[RSK_FISHSANITY_AGE_SPLIT].Is(RO_GENERIC_OFF) && (
+                    location.GetRandomizerCheck() >= RC_LH_ADULT_FISH_1 && location.GetRandomizerCheck() <= RC_LH_ADULT_LOACH))
+                ))
+            )) ||
             (location.GetRCType() == RCTYPE_POT && mOptions[RSK_SHUFFLE_POTS].Is(RO_SHUFFLE_POTS_OFF)) ||
             (location.GetRCType() == RCTYPE_FAIRY && !mOptions[RSK_SHUFFLE_FAIRIES]) ||
             (location.GetRCType() == RCTYPE_FREESTANDING &&


### PR DESCRIPTION
Some locations that normally didn't end up in the pool ended up in the pool after changes from PR #5023 which caused some problems generating seed with certain combinations of settings. This may not have solved all of them, but I definitely solved the two issues that I know of, which is Adult Trade Shuffle and Fishsanity.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2583368841.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2583372659.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2583450087.zip)
<!--- section:artifacts:end -->