### PR TITLE
remove unused `VB_SHOULD`s

### DIFF
--- a/soh/soh/Enhancements/boss-rush/BossRush.cpp
+++ b/soh/soh/Enhancements/boss-rush/BossRush.cpp
@@ -522,13 +522,6 @@ void BossRush_OnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_li
             }
             break;
         }
-        // Replace the blue warp transitions with ones that lead back to the chamber of sages
-        case VB_BLUE_WARP_APPLY_ENTRANCE_AND_CUTSCENE: {
-            DoorWarp1* blueWarp = va_arg(args, DoorWarp1*);
-            BossRush_HandleBlueWarp(gPlayState, blueWarp->actor.world.pos.x, blueWarp->actor.world.pos.z);
-            *should = false;
-            break;
-        }
         // Spawn clean blue warps (no ruto, adult animation, etc)
         case VB_SPAWN_BLUE_WARP: {
             switch (gPlayState->sceneNum) {

--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -332,9 +332,6 @@ typedef enum {
     // - None
     VB_DEKU_STICK_BURN_OUT,
 
-    // # UNUSED
-    VB_DEKU_UPDATE_BURNING_DEKU_STICK,
-
     // #### `result`
     // ```c
     // Flags_GetItemGetInf(ITEMGETINF_30)

--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -727,12 +727,6 @@ typedef enum {
     // - None
     VB_GIVE_ITEM_GERUDO_MEMBERSHIP_CARD,
 
-    // # UNUSED
-    VB_GIVE_ITEM_GORON_RUBY,
-
-    // # UNUSED
-    VB_GIVE_ITEM_KOKIRI_EMERALD,
-
     // #### `result`
     // ```c
     // true
@@ -900,9 +894,6 @@ typedef enum {
     // #### `args`
     // - None
     VB_GIVE_ITEM_ZELDAS_LULLABY,
-
-    // # UNUSED
-    VB_GIVE_ITEM_ZORA_SAPPHIRE,
 
     // #### `result`
     // ```c

--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -1390,9 +1390,6 @@ typedef enum {
     // - None
     VB_PLAY_NABOORU_CAPTURED_CS,
 
-    // # UNUSED
-    VB_PLAY_ODD_POTION_ANIM,
-
     // #### `result`
     // ```c
     // true

--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -212,9 +212,6 @@ typedef enum {
     // - None
     VB_BIGGORON_CONSIDER_TRADE_COMPLETE,
 
-    // # UNUSED
-    VB_BLUE_WARP_APPLY_ENTRANCE_AND_CUTSCENE,
-
     // #### `result`
     // Actor is ACTOR_EN_ELF, ACTOR_EN_FISH, ACTOR_EN_ICE_HONO, or ACTOR_EN_INSECT
     // ```c

--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -1667,9 +1667,6 @@ void RandomizerOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_l
         case VB_GIVE_ITEM_STRENGTH_1:
         case VB_GIVE_ITEM_ZELDAS_LETTER:
         case VB_GIVE_ITEM_OCARINA_OF_TIME:
-        case VB_GIVE_ITEM_KOKIRI_EMERALD:
-        case VB_GIVE_ITEM_GORON_RUBY:
-        case VB_GIVE_ITEM_ZORA_SAPPHIRE:
         case VB_GIVE_ITEM_LIGHT_MEDALLION:
         case VB_GIVE_ITEM_FOREST_MEDALLION:
         case VB_GIVE_ITEM_FIRE_MEDALLION:


### PR DESCRIPTION
resolves https://github.com/HarbourMasters/Shipwright/issues/4997

after going through everything in https://github.com/HarbourMasters/Shipwright/issues/4997 i verified the docs had been updated for everything mentioned in that issue.

this PR just removes the leftover unused ones

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2585054511.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2585061750.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2585064127.zip)
<!--- section:artifacts:end -->