### PR TITLE
Unify FPS and V-Sync controls and behavior between renderer

### DIFF
--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -495,8 +495,7 @@ bool OTRGlobals::HasOriginal() {
 uint32_t OTRGlobals::GetInterpolationFPS() {
     if (CVarGetInteger(CVAR_SETTING("MatchRefreshRate"), 0)) {
         return Ship::Context::GetInstance()->GetWindow()->GetCurrentRefreshRate();
-    }
-    else if (CVarGetInteger(CVAR_VSYNC_ENABLED, 1)) {
+    } else if (CVarGetInteger(CVAR_VSYNC_ENABLED, 1) || !Ship::Context::GetInstance()->GetWindow()->CanDisableVerticalSync()) {
         return std::min<uint32_t>(Ship::Context::GetInstance()->GetWindow()->GetCurrentRefreshRate(), CVarGetInteger(CVAR_SETTING("InterpolationFPS"), 20));
     }
     return CVarGetInteger(CVAR_SETTING("InterpolationFPS"), 20);

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -493,11 +493,13 @@ bool OTRGlobals::HasOriginal() {
 }
 
 uint32_t OTRGlobals::GetInterpolationFPS() {
-    if (CVarGetInteger(CVAR_SETTING("MatchRefreshRate"), 0) || Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(CVAR_VSYNC_ENABLED, 1)) {
+    if (CVarGetInteger(CVAR_SETTING("MatchRefreshRate"), 0)) {
         return Ship::Context::GetInstance()->GetWindow()->GetCurrentRefreshRate();
     }
-
-    return std::min<uint32_t>(Ship::Context::GetInstance()->GetWindow()->GetCurrentRefreshRate(), CVarGetInteger(CVAR_SETTING("InterpolationFPS"), 20));
+    else if (CVarGetInteger(CVAR_VSYNC_ENABLED, 1)) {
+        return std::min<uint32_t>(Ship::Context::GetInstance()->GetWindow()->GetCurrentRefreshRate(), CVarGetInteger(CVAR_SETTING("InterpolationFPS"), 20));
+    }
+    return CVarGetInteger(CVAR_SETTING("InterpolationFPS"), 20);
 }
 
 extern "C" void OTRMessage_Init();

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -493,11 +493,7 @@ bool OTRGlobals::HasOriginal() {
 }
 
 uint32_t OTRGlobals::GetInterpolationFPS() {
-    if (Ship::Context::GetInstance()->GetWindow()->GetWindowBackend() == Ship::WindowBackend::FAST3D_DXGI_DX11) {
-        return CVarGetInteger(CVAR_SETTING("InterpolationFPS"), 20);
-    }
-
-    if (CVarGetInteger(CVAR_SETTING("MatchRefreshRate"), 0)) {
+    if (CVarGetInteger(CVAR_SETTING("MatchRefreshRate"), 0) || Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(CVAR_VSYNC_ENABLED, 1)) {
         return Ship::Context::GetInstance()->GetWindow()->GetCurrentRefreshRate();
     }
 

--- a/soh/soh/SohGui/SohMenuBar.cpp
+++ b/soh/soh/SohGui/SohMenuBar.cpp
@@ -375,11 +375,12 @@ void DrawSettingsMenu() {
             { // FPS Slider
                 const int minFps = 20;
                 static int maxFps;
-                if (Ship::Context::GetInstance()->GetWindow()->GetWindowBackend() == Ship::WindowBackend::FAST3D_DXGI_DX11) {
+               // if (Ship::Context::GetInstance()->GetWindow()->GetWindowBackend() == Ship::WindowBackend::FAST3D_DXGI_DX11) {
                     maxFps = 360;
-                } else {
+               /* }
+                else {
                     maxFps = Ship::Context::GetInstance()->GetWindow()->GetCurrentRefreshRate();
-                }
+                } */
                 int currentFps = fmax(fmin(OTRGlobals::Instance->GetInterpolationFPS(), maxFps), minFps);
             #ifdef __WIIU__
                 UIWidgets::Spacer(0);

--- a/soh/soh/SohGui/SohMenuBar.cpp
+++ b/soh/soh/SohGui/SohMenuBar.cpp
@@ -374,13 +374,7 @@ void DrawSettingsMenu() {
             UIWidgets::PaddedSeparator(true, true, 3.0f, 3.0f);
             { // FPS Slider
                 const int minFps = 20;
-                static int maxFps;
-               // if (Ship::Context::GetInstance()->GetWindow()->GetWindowBackend() == Ship::WindowBackend::FAST3D_DXGI_DX11) {
-                    maxFps = 360;
-               /* }
-                else {
-                    maxFps = Ship::Context::GetInstance()->GetWindow()->GetCurrentRefreshRate();
-                } */
+                static int maxFps = 360;                  
                 int currentFps = fmax(fmin(OTRGlobals::Instance->GetInterpolationFPS(), maxFps), minFps);
             #ifdef __WIIU__
                 UIWidgets::Spacer(0);

--- a/soh/soh/SohGui/SohMenuBar.cpp
+++ b/soh/soh/SohGui/SohMenuBar.cpp
@@ -443,38 +443,20 @@ void DrawSettingsMenu() {
                 Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
             #else
                 bool matchingRefreshRate =
-                    CVarGetInteger(CVAR_SETTING("MatchRefreshRate"), 0) && Ship::Context::GetInstance()->GetWindow()->GetWindowBackend() != Ship::WindowBackend::FAST3D_DXGI_DX11;
+                    CVarGetInteger(CVAR_SETTING("MatchRefreshRate"), 0);
                 UIWidgets::PaddedEnhancementSliderInt(
                     (currentFps == 20) ? "Frame Rate: Original (20 fps)" : "Frame Rate: %d fps",
                     "##FPSInterpolation", CVAR_SETTING("InterpolationFPS"), minFps, maxFps, "", 20, true, true, false, matchingRefreshRate);
             #endif
-                if (Ship::Context::GetInstance()->GetWindow()->GetWindowBackend() == Ship::WindowBackend::FAST3D_DXGI_DX11) {
                     UIWidgets::Tooltip(
                         "Uses Matrix Interpolation to create extra frames, resulting in smoother graphics.\n"
                         "This is purely visual and does not impact game logic, execution of glitches etc.\n"
                         "Higher frame rate settings may impact CPU performance."
                         "\n\n " ICON_FA_INFO_CIRCLE 
                         " There is no need to set this above your monitor's refresh rate. Doing so will waste resources and may give a worse result.");
-                } else {
-                    UIWidgets::Tooltip(
-                        "Uses Matrix Interpolation to create extra frames, resulting in smoother graphics.\n"
-                        "This is purely visual and does not impact game logic, execution of glitches etc.\n"
-                        "Higher frame rate settings may impact CPU performance.");
-                }
             } // END FPS Slider
 
-            if (Ship::Context::GetInstance()->GetWindow()->GetWindowBackend() == Ship::WindowBackend::FAST3D_DXGI_DX11) {
-                UIWidgets::Spacer(0);
-                if (ImGui::Button("Match Frame Rate to Refresh Rate")) {
-                    int hz = Ship::Context::GetInstance()->GetWindow()->GetCurrentRefreshRate();
-                    if (hz >= 20 && hz <= 360) {
-                        CVarSetInteger(CVAR_SETTING("InterpolationFPS"), hz);
-                        Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
-                    }
-                }
-            } else {
-                UIWidgets::PaddedEnhancementCheckbox("Match Frame Rate to Refresh Rate", CVAR_SETTING("MatchRefreshRate"), true, false);
-            }
+            UIWidgets::PaddedEnhancementCheckbox("Match Frame Rate to Refresh Rate", CVAR_SETTING("MatchRefreshRate"), true, false);
             UIWidgets::Tooltip("Matches interpolation value to the game window's current refresh rate.");
 
             UIWidgets::PaddedSeparator(true, true, 3.0f, 3.0f);


### PR DESCRIPTION
- DirectX's "Match Refresh Rate" is now a checkbox like in OpenGL and Metal.
- Clamp max FPS to refresh rate when V-Sync is enabled or can't be disabled, regardles of the FPS sliders setting, to avoid slowdown in Metal / OpenGL and dropping frames in DirectX as much as possible.
- FPS slider allows up to 360 FPS in every renderer. This needs https://github.com/Kenix3/libultraship/pull/822, or it doesn't make much sense (currently included in this PR to allow testing).

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2631512439.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2631524030.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2631539877.zip)
<!--- section:artifacts:end -->