### PR TITLE
Clean up autosave header

### DIFF
--- a/soh/soh/Enhancements/Autosave.h
+++ b/soh/soh/Enhancements/Autosave.h
@@ -1,4 +1,0 @@
-typedef enum {
-    AUTOSAVE_OFF,
-    AUTOSAVE_ON,
-} AutosaveOptions;

--- a/soh/soh/SohGui/SohMenuBar.cpp
+++ b/soh/soh/SohGui/SohMenuBar.cpp
@@ -45,7 +45,6 @@
 #include "soh/Enhancements/randomizer/Plandomizer.h"
 #include "soh/Enhancements/TimeDisplay/TimeDisplay.h"
 #include "soh/AboutWindow.h"
-#include "soh/Enhancements/Autosave.h"
 
 // FA icons are kind of wonky, if they worked how I expected them to the "+ 2.0f" wouldn't be needed, but
 // they don't work how I expect them to so I added that because it looked good when I eyeballed it


### PR DESCRIPTION
I moved the enum in the header into the .cpp file but apparently failed to remove the header and an include to it.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2599757215.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2599758538.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2599761442.zip)
<!--- section:artifacts:end -->