### PR TITLE
Exclude debug file and cutscene map from auto save

### DIFF
--- a/soh/soh/Enhancements/Autosave.cpp
+++ b/soh/soh/Enhancements/Autosave.cpp
@@ -26,11 +26,9 @@ bool Autosave_CanSave() {
 
     // Don't save when in title screen or debug file
     // Don't save the first 60 frames to not save the magic meter when it's still in the animation of filling it.
-    // Don't save in Ganon's fight because of master sword.
     // Don't save in Chamber of Sages and the Cutscene map because of remember save location and cutscene item gives.
     if (!GameInteractor::IsSaveLoaded(false) || gPlayState->gameplayFrames < 60 ||
-        gPlayState->sceneNum == SCENE_GANON_BOSS || gPlayState->sceneNum == SCENE_CHAMBER_OF_THE_SAGES ||
-        gPlayState->sceneNum == SCENE_CUTSCENE_MAP) {
+        gPlayState->sceneNum == SCENE_CHAMBER_OF_THE_SAGES || gPlayState->sceneNum == SCENE_CUTSCENE_MAP) {
         return false;
     }
 

--- a/soh/soh/Enhancements/Autosave.cpp
+++ b/soh/soh/Enhancements/Autosave.cpp
@@ -24,11 +24,13 @@ typedef enum {
 
 bool Autosave_CanSave() {
 
-    // Don't save when in title screen
+    // Don't save when in title screen or debug file
     // Don't save the first 60 frames to not save the magic meter when it's still in the animation of filling it.
-    // Don't save in Ganon's fight and chamber of sages because of master sword and remember save location issues.
-    if (!GameInteractor::IsSaveLoaded(true) || gPlayState->gameplayFrames < 60 ||
-        gPlayState->sceneNum == SCENE_GANON_BOSS || gPlayState->sceneNum == SCENE_CHAMBER_OF_THE_SAGES) {
+    // Don't save in Ganon's fight because of master sword.
+    // Don't save in Chamber of Sages and the Cutscene map because of remember save location and cutscene item gives.
+    if (!GameInteractor::IsSaveLoaded(false) || gPlayState->gameplayFrames < 60 ||
+        gPlayState->sceneNum == SCENE_GANON_BOSS || gPlayState->sceneNum == SCENE_CHAMBER_OF_THE_SAGES ||
+        gPlayState->sceneNum == SCENE_CUTSCENE_MAP) {
         return false;
     }
 


### PR DESCRIPTION
Excludes the debug save file from auto saving. Nothing ever actually saved, but the notification was still emitting with "Game Saved". Changed `GameInteractor::IsSaveLoaded` to pass in false to exclude the debug save file.

Remove's Ganon's Lair from the auto save exclusion as now that we don't save upon collecting an item, the original issue requiring the exclusion is no long there (#2156)

Also adds `CUTSCENE_MAP` to the scene exclusion, which is the scene for the triforce godess, ganondorf, etc cutscenes. This addresses an issue where autosave would trigger after killing ganon during the end credits. The rest of the credits are handled by the `GAMEMODE_NORMAL` check.

Fixes #5087

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2620329384.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2620331040.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2620336160.zip)
<!--- section:artifacts:end -->