### PR TITLE
Fix Gerudo Valley entrance logic

### DIFF
--- a/soh/soh/Enhancements/randomizer/location_access/overworld/gerudo_valley.cpp
+++ b/soh/soh/Enhancements/randomizer/location_access/overworld/gerudo_valley.cpp
@@ -42,7 +42,7 @@ void RegionTable_Init_GerudoValley() {
 
     areaTable[RR_GV_LOWER_STREAM] = Region("GV Lower Stream", "Gerudo Valley", {RA_GERUDO_VALLEY}, DAY_NIGHT_CYCLE, {}, {}, {
         //Exits
-        Entrance(RR_LAKE_HYLIA, []{return logic->HasItem(RG_BRONZE_SCALE);}),
+        Entrance(RR_LAKE_HYLIA, []{return logic->HasItem(RG_BRONZE_SCALE) || logic->CanUse(RG_IRON_BOOTS);}),
     });
 
     areaTable[RR_GV_GROTTO_LEDGE] = Region("GV Grotto Ledge", "Gerudo Valley", {RA_GERUDO_VALLEY}, DAY_NIGHT_CYCLE, {}, {}, {

--- a/soh/soh/Enhancements/randomizer/location_access/overworld/gerudo_valley.cpp
+++ b/soh/soh/Enhancements/randomizer/location_access/overworld/gerudo_valley.cpp
@@ -47,7 +47,8 @@ void RegionTable_Init_GerudoValley() {
 
     areaTable[RR_GV_GROTTO_LEDGE] = Region("GV Grotto Ledge", "Gerudo Valley", {RA_GERUDO_VALLEY}, DAY_NIGHT_CYCLE, {}, {}, {
         //Exits
-        Entrance(RR_GV_LOWER_STREAM,   []{return logic->HasItem(RG_BRONZE_SCALE);}), // possible with precise sidehop, but stuck without bronze scale, not useful enough for trick
+        Entrance(RR_GV_UPPER_STREAM,   []{return ctx->GetTrickOption(RT_DAMAGE_BOOST_SIMPLE) && logic->HasExplosives();}),
+        Entrance(RR_GV_LOWER_STREAM,   []{return true;}),
         Entrance(RR_GV_OCTOROK_GROTTO, []{return logic->CanUse(RG_SILVER_GAUNTLETS);}),
         Entrance(RR_GV_CRATE_LEDGE,    []{return logic->CanUse(RG_LONGSHOT);}),
     });

--- a/soh/soh/Enhancements/randomizer/location_access/overworld/gerudo_valley.cpp
+++ b/soh/soh/Enhancements/randomizer/location_access/overworld/gerudo_valley.cpp
@@ -13,10 +13,11 @@ void RegionTable_Init_GerudoValley() {
     }, {
         //Exits
         Entrance(RR_HYRULE_FIELD,     []{return true;}),
-        Entrance(RR_GV_UPPER_STREAM,  []{return true;}),
+        Entrance(RR_GV_UPPER_STREAM,  []{return logic->IsChild || logic->HasItem(RG_BRONZE_SCALE);}),
         Entrance(RR_GV_CRATE_LEDGE,   []{return logic->IsChild || logic->CanUse(RG_LONGSHOT);}),
         Entrance(RR_GV_GROTTO_LEDGE,  []{return true;}),
         Entrance(RR_GV_FORTRESS_SIDE, []{return (logic->IsAdult && (logic->CanUse(RG_EPONA) || logic->CanUse(RG_LONGSHOT) || ctx->GetOption(RSK_GERUDO_FORTRESS).Is(RO_GF_CARPENTERS_FREE) || logic->CarpenterRescue)) || (logic->IsChild && logic->CanUse(RG_HOOKSHOT));}),
+        Entrance(RR_LAKE_HYLIA,       []{return logic->IsChild;}), //can use cucco as child
     });
 
     areaTable[RR_GV_UPPER_STREAM] = Region("GV Upper Stream", "Gerudo Valley", {RA_GERUDO_VALLEY}, DAY_NIGHT_CYCLE, {
@@ -41,12 +42,12 @@ void RegionTable_Init_GerudoValley() {
 
     areaTable[RR_GV_LOWER_STREAM] = Region("GV Lower Stream", "Gerudo Valley", {RA_GERUDO_VALLEY}, DAY_NIGHT_CYCLE, {}, {}, {
         //Exits
-        Entrance(RR_LAKE_HYLIA, []{return logic->IsChild || logic->HasItem(RG_BRONZE_SCALE);}),//can use cucco as child
+        Entrance(RR_LAKE_HYLIA, []{return logic->HasItem(RG_BRONZE_SCALE);}),
     });
 
     areaTable[RR_GV_GROTTO_LEDGE] = Region("GV Grotto Ledge", "Gerudo Valley", {RA_GERUDO_VALLEY}, DAY_NIGHT_CYCLE, {}, {}, {
         //Exits
-        Entrance(RR_GV_LOWER_STREAM,   []{return true;}),
+        Entrance(RR_GV_LOWER_STREAM,   []{return logic->HasItem(RG_BRONZE_SCALE);}), // possible with precise sidehop, but stuck without bronze scale, not useful enough for trick
         Entrance(RR_GV_OCTOROK_GROTTO, []{return logic->CanUse(RG_SILVER_GAUNTLETS);}),
         Entrance(RR_GV_CRATE_LEDGE,    []{return logic->CanUse(RG_LONGSHOT);}),
     });

--- a/soh/soh/Enhancements/randomizer/location_access/overworld/gerudo_valley.cpp
+++ b/soh/soh/Enhancements/randomizer/location_access/overworld/gerudo_valley.cpp
@@ -13,7 +13,7 @@ void RegionTable_Init_GerudoValley() {
     }, {
         //Exits
         Entrance(RR_HYRULE_FIELD,     []{return true;}),
-        Entrance(RR_GV_UPPER_STREAM,  []{return logic->IsChild || logic->HasItem(RG_BRONZE_SCALE);}),
+        Entrance(RR_GV_UPPER_STREAM,  []{return logic->IsChild || logic->HasItem(RG_BRONZE_SCALE) || logic->TakeDamage();}),
         Entrance(RR_GV_CRATE_LEDGE,   []{return logic->IsChild || logic->CanUse(RG_LONGSHOT);}),
         Entrance(RR_GV_GROTTO_LEDGE,  []{return true;}),
         Entrance(RR_GV_FORTRESS_SIDE, []{return (logic->IsAdult && (logic->CanUse(RG_EPONA) || logic->CanUse(RG_LONGSHOT) || ctx->GetOption(RSK_GERUDO_FORTRESS).Is(RO_GF_CARPENTERS_FREE) || logic->CarpenterRescue)) || (logic->IsChild && logic->CanUse(RG_HOOKSHOT));}),


### PR DESCRIPTION
Logic assumed cucco could be used as child to get around lacking bronze scale,
but this assumption fails if you enter grotto ledge from grotto or initial spawn

This updates logic with following:

1. Adult can only get across to upper stream by either taking damage or having bronze scale
2. Child reaches Lake Hylia with cucco from top of cliff, never any other location
3. Adult can walk to Lake Hylia from lower stream with iron boots
4. It is possible to get from grotto ledge to upper stream, put behind trick logic *(note explosive not really needed, an accurate sidehop will do)*

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2667503187.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2667533374.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2667627767.zip)
<!--- section:artifacts:end -->