### PR TITLE
Prevent Big Octo one point cutscene from playing twice.

### DIFF
--- a/soh/soh/Enhancements/TimeSavers/SkipMiscInteractions/SkipChildRutoInteractions.cpp
+++ b/soh/soh/Enhancements/TimeSavers/SkipMiscInteractions/SkipChildRutoInteractions.cpp
@@ -65,7 +65,12 @@ void SkipChildRutoInteractions_Register() {
             enRu1->action = 42;
             Animation_Change(&enRu1->skelAnime, (AnimationHeader*)&gRutoChildWait2Anim, 1.0f, 0, 
                         Animation_GetLastFrame((void*)&gRutoChildWait2Anim), ANIMMODE_LOOP, -8.0f);
-            enRu1->unk_28C->cameraSetting = 1;
+            // If we aren't skipping one point cutscenes and BgBdan objects has set the camera setting
+            // to CAM_SET_NORMAL1 (2), don't reset the camera setting to 1. This prevents the One Point
+            // Cutscene of Ruto getting lifted up from getting queued up twice.
+            if (CVarGetInteger(CVAR_ENHANCEMENT("TimeSavers.SkipCutscene.OnePoint"), IS_RANDO) || enRu1->unk_28C->cameraSetting != 2) {
+                enRu1->unk_28C->cameraSetting = 1;
+            }
             Actor* sapphire = func_80AEB124(gPlayState);
             if (sapphire != NULL) {
                 Actor_Kill(sapphire);


### PR DESCRIPTION
Fixes #4940 

If One Point Cutscenes aren't skipped, but Miscellaneous Interactions _are_ skipped, The one point cutscene of Ruto getting lifted up and replaced with Big Octo is queued up twice, so the camera movements happen twice one after the other. This fixes it so that the Camera Setting meant to signal that the cutscene has been queued doesn't get reset by VB_RUTO_RUN_TO_SAPPHIRE.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2749897940.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2749908338.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2749973354.zip)
<!--- section:artifacts:end -->