### PR TITLE
Fix oversight in HC storms grotto

### DIFF
--- a/soh/soh/Enhancements/randomizer/location_access/overworld/castle_grounds.cpp
+++ b/soh/soh/Enhancements/randomizer/location_access/overworld/castle_grounds.cpp
@@ -79,7 +79,7 @@ void RegionTable_Init_CastleGrounds() {
         LOCATION(RC_HC_STORMS_GROTTO_POT_4,                  logic->CanBreakPots()),
     }, {
         //Exits
-        Entrance(RR_CASTLE_GROUNDS, []{return true;}),
+        Entrance(RR_HC_STORMS_GROTTO, []{return true;}),
     });
 
     areaTable[RR_GANONS_CASTLE_GROUNDS] = Region("Ganon's Castle Grounds", "Castle Grounds", {RA_OUTSIDE_GANONS_CASTLE}, NO_DAY_NIGHT_CYCLE, {


### PR DESCRIPTION
This oversight would cause impossible seeds with grotto shuffle as it would always send logic to the actual Castle grounds, not the randomized exit. 

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2760275854.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2760276979.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2760279292.zip)
<!--- section:artifacts:end -->