### PR TITLE
Fix finite shields getting thier effect applied in SCL

### DIFF
--- a/soh/soh/Enhancements/randomizer/logic.cpp
+++ b/soh/soh/Enhancements/randomizer/logic.cpp
@@ -1785,7 +1785,7 @@ namespace Rando {
         case ITEMTYPE_EQUIP:
         {
             RandomizerGet itemRG = item.GetRandomizerGet();
-            if (itemRG == RG_GIANTS_KNIFE) {
+            if (itemRG == RG_GIANTS_KNIFE || itemRG == RG_DEKU_SHIELD || itemRG == RG_HYLIAN_SHIELD) {
                 return;
             }
             uint32_t equipId = RandoGetToEquipFlag.find(itemRG)->second;


### PR DESCRIPTION
This caused shields to be added in logic that were invisible to the playthrough and would not be replaceable if eaten or burnt, potentially causing a logically impossible seed.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2767678513.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2767684356.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2767756205.zip)
<!--- section:artifacts:end -->