### PR TITLE
Fix/modern menu/secret flag

### DIFF
--- a/soh/soh/SohGui/UIWidgets.cpp
+++ b/soh/soh/SohGui/UIWidgets.cpp
@@ -777,6 +777,10 @@ bool InputString(const char* label, std::string* value, const InputOptions& opti
         }
     }
     ImGui::SetNextItemWidth(width);
+    ImGuiInputTextFlags flags = ImGuiInputTextFlags_CallbackResize;
+    if (options.secret) {
+        flags |= ImGuiInputTextFlags_Password;
+    }
     if (ImGui::InputText(label, (char*)value->c_str(), value->capacity() + 1, ImGuiInputTextFlags_CallbackResize, InputTextResizeCallback, value)) {
         dirty = true;
     }

--- a/soh/soh/SohGui/UIWidgets.cpp
+++ b/soh/soh/SohGui/UIWidgets.cpp
@@ -781,7 +781,8 @@ bool InputString(const char* label, std::string* value, const InputOptions& opti
     if (options.secret) {
         flags |= ImGuiInputTextFlags_Password;
     }
-    if (ImGui::InputText(label, (char*)value->c_str(), value->capacity() + 1, ImGuiInputTextFlags_CallbackResize, InputTextResizeCallback, value)) {
+    flags |= options.addedFlags;
+    if (ImGui::InputText(label, (char*)value->c_str(), value->capacity() + 1, flags, InputTextResizeCallback, value)) {
         dirty = true;
     }
     if (value->empty() && !options.placeholder.empty()) {
@@ -832,7 +833,7 @@ bool InputInt(const char* label, int32_t* value, const InputOptions& options) {
         }
     }
     ImGui::SetNextItemWidth(width);
-    if (ImGui::InputScalar(label, ImGuiDataType_S32, value)) {
+    if (ImGui::InputScalar(label, ImGuiDataType_S32, value, nullptr, nullptr, nullptr, options.addedFlags)) {
         dirty = true;
     }
     if ((ImGui::GetItemStatusFlags() & ImGuiItemStatusFlags_Edited) && !options.placeholder.empty()) {

--- a/soh/soh/SohGui/UIWidgets.hpp
+++ b/soh/soh/SohGui/UIWidgets.hpp
@@ -425,6 +425,7 @@ namespace UIWidgets {
         std::string placeholder = "";
         InputTypes type = InputTypes::String;
         std::string defaultValue = "";
+        bool secret = false;
 
         InputOptions& Tooltip(const char* tooltip_) {
             WidgetOptions::tooltip = tooltip_;
@@ -461,6 +462,11 @@ namespace UIWidgets {
 
         InputOptions& DefaultValue(std::string defaultValue_) {
             defaultValue = defaultValue_;
+            return *this;
+        }
+        
+        InputOptions& IsSecret(bool secret_ = false) {
+            secret = secret_;
             return *this;
         }
     };

--- a/soh/soh/SohGui/UIWidgets.hpp
+++ b/soh/soh/SohGui/UIWidgets.hpp
@@ -426,6 +426,7 @@ namespace UIWidgets {
         InputTypes type = InputTypes::String;
         std::string defaultValue = "";
         bool secret = false;
+        ImGuiInputFlags addedFlags = 0;
 
         InputOptions& Tooltip(const char* tooltip_) {
             WidgetOptions::tooltip = tooltip_;


### PR DESCRIPTION
Adds the ability to pass arbitrary flags to `InputString` and `InputInt` through the flags member of `InputOptions`. I didn't add a method for it because I envisioned this one as a last resort for some niche scenarios. I also added an `IsSecret()` method to `InputOptions` to allow specifically setting `ImGuiInputTextFlags_Password`. Nothing currently uses it but Anchor probably will, and there could be others in the future.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2768479824.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2768482074.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2768486458.zip)
<!--- section:artifacts:end -->