### PR TITLE
Exclude maps from junk only GI skip

### DIFF
--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -302,9 +302,12 @@ void RandomizerOnPlayerUpdateForRCQueueHandler() {
                 (
                     CVarGetInteger(CVAR_RANDOMIZER_ENHANCEMENT("TimeSavers.SkipGetItemAnimation"), SGIA_DISABLED) == SGIA_JUNK &&
                     (
+                        //crude fix to ensure map hints are readable. Ideally replace with better hint tracking. 
+                        !(getItemEntry.getItemId >= RG_DEKU_TREE_MAP && getItemEntry.getItemId <= RG_ICE_CAVERN_MAP) && (
                         getItemEntry.getItemCategory == ITEM_CATEGORY_JUNK ||
                         getItemEntry.getItemCategory == ITEM_CATEGORY_SKULLTULA_TOKEN ||
-                        getItemEntry.getItemCategory == ITEM_CATEGORY_LESSER
+                        getItemEntry.getItemCategory == ITEM_CATEGORY_LESSER 
+                        )
                     )
                 )
             )


### PR DESCRIPTION
Fix #5040 

A blunt fix, eventually we would want something more sophisticated when we have better trackers and more options for hints.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2774952436.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2774954154.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2774956448.zip)
<!--- section:artifacts:end -->