### PR TITLE
remove color from UIWidgets::WidgetOptions

### DIFF
--- a/soh/soh/SohGui/Menu.cpp
+++ b/soh/soh/SohGui/Menu.cpp
@@ -303,21 +303,23 @@ void Menu::MenuDrawItem(WidgetInfo& widget, uint32_t width, UIWidgets::Colors me
                 ImGui::Separator();
             } break;
             case WIDGET_SEPARATOR_TEXT: {
-                if (widget.options->color != UIWidgets::Colors::NoColor) {
-                    ImGui::PushStyleColor(ImGuiCol_Text, UIWidgets::ColorValues.at(widget.options->color));
+                auto options = std::static_pointer_cast<UIWidgets::TextOptions>(widget.options);
+                if (options->color != UIWidgets::Colors::NoColor) {
+                    ImGui::PushStyleColor(ImGuiCol_Text, UIWidgets::ColorValues.at(options->color));
                 }
                 ImGui::SeparatorText(widget.name.c_str());
-                if (widget.options->color != UIWidgets::Colors::NoColor) {
+                if (options->color != UIWidgets::Colors::NoColor) {
                     ImGui::PopStyleColor();
                 }
             } break;
             case WIDGET_TEXT: {
-                if (widget.options->color != UIWidgets::Colors::NoColor) {
-                    ImGui::PushStyleColor(ImGuiCol_Text, UIWidgets::ColorValues.at(widget.options->color));
+                auto options = std::static_pointer_cast<UIWidgets::TextOptions>(widget.options);
+                if (options->color != UIWidgets::Colors::NoColor) {
+                    ImGui::PushStyleColor(ImGuiCol_Text, UIWidgets::ColorValues.at(options->color));
                 }
                 ImGui::AlignTextToFramePadding();
                 ImGui::TextWrapped("%s", widget.name.c_str());
-                if (widget.options->color != UIWidgets::Colors::NoColor) {
+                if (options->color != UIWidgets::Colors::NoColor) {
                     ImGui::PopStyleColor();
                 }
             } break;

--- a/soh/soh/SohGui/MenuTypes.h
+++ b/soh/soh/SohGui/MenuTypes.h
@@ -73,7 +73,7 @@ typedef enum {
 using CVarVariant = std::variant<int32_t, const char*, float, Color_RGBA8, Color_RGB8>;
 using OptionsVariant =
     std::variant<UIWidgets::ButtonOptions, UIWidgets::CheckboxOptions, UIWidgets::ComboboxOptions,
-                 UIWidgets::FloatSliderOptions, UIWidgets::IntSliderOptions, UIWidgets::WidgetOptions,
+                 UIWidgets::FloatSliderOptions, UIWidgets::IntSliderOptions, UIWidgets::TextOptions, UIWidgets::WidgetOptions,
                  UIWidgets::WindowButtonOptions>;
 
 // All the info needed for display and search of all widgets in the menu.
@@ -145,6 +145,8 @@ struct WidgetInfo {
                 break;
             case WIDGET_TEXT:
             case WIDGET_SEPARATOR_TEXT:
+                options = std::make_shared<UIWidgets::TextOptions>(std::get<UIWidgets::TextOptions>(options_));
+                break;
             case WIDGET_SEPARATOR:
             default:
                 options = std::make_shared<UIWidgets::WidgetOptions>(std::get<UIWidgets::WidgetOptions>(options_));

--- a/soh/soh/SohGui/ResolutionEditor.cpp
+++ b/soh/soh/SohGui/ResolutionEditor.cpp
@@ -360,10 +360,10 @@ void RegisterResolutionWidgets() {
                     WIDGET_TEXT)
         .PreFunc(
             [](WidgetInfo& info) { info.isHidden = !(!CVarGetInteger(CVAR_LOW_RES_MODE, 0) && IsDroppingFrames()); })
-        .Options(WidgetOptions().Color(Colors::Orange));
+        .Options(TextOptions().Color(Colors::Orange));
     mSohMenu->AddWidget(path, ICON_FA_QUESTION_CIRCLE " \"N64 Mode\" is overriding these settings.", WIDGET_TEXT)
         .PreFunc([](WidgetInfo& info) { info.isHidden = !CVarGetInteger(CVAR_LOW_RES_MODE, 0); })
-        .Options(WidgetOptions().Color(Colors::LightBlue));
+        .Options(TextOptions().Color(Colors::LightBlue));
     mSohMenu->AddWidget(path, "Click to disable N64 mode", WIDGET_BUTTON)
         .PreFunc([](WidgetInfo& info) { info.isHidden = !CVarGetInteger(CVAR_LOW_RES_MODE, 0); })
         .Callback([](WidgetInfo& info) {
@@ -391,7 +391,7 @@ void RegisterResolutionWidgets() {
             }
         })
         .SameLine(true)
-        .Options(WidgetOptions().Color(Colors::Gray));
+        .Options(TextOptions().Color(Colors::Gray));
     // Presets
     mSohMenu->AddWidget(path, "Aspect Ratio", WIDGET_COMBOBOX)
         .ValuePointer(&item_aspectRatio)

--- a/soh/soh/SohGui/SohMenu.cpp
+++ b/soh/soh/SohGui/SohMenu.cpp
@@ -64,10 +64,12 @@ WidgetInfo& SohMenu::AddWidget(WidgetPath& pathInfo, std::string widgetName, Wid
         case WIDGET_COLOR_24:
         case WIDGET_COLOR_32:
             break;
-        case WIDGET_SEARCH:
-        case WIDGET_SEPARATOR:
         case WIDGET_SEPARATOR_TEXT:
         case WIDGET_TEXT:
+            widget.options = std::make_shared<TextOptions>();
+            break;
+        case WIDGET_SEARCH:
+        case WIDGET_SEPARATOR:
         default:
             widget.options = std::make_shared<WidgetOptions>();
     }

--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -1992,7 +1992,7 @@ void SohMenu::AddMenuEnhancements() {
     path.column = SECTION_COLUMN_3;
     AddWidget(path, "Save States", WIDGET_SEPARATOR_TEXT);
     AddWidget(path, ICON_FA_EXCLAMATION_TRIANGLE " WARNING!!!! " ICON_FA_EXCLAMATION_TRIANGLE, WIDGET_TEXT)
-        .Options(WidgetOptions().Color(Colors::Orange));
+        .Options(TextOptions().Color(Colors::Orange));
     AddWidget(path,
               "These are NOT like emulator states. They do not save your game progress "
               "and they WILL break across transitions and load zones (like doors). "

--- a/soh/soh/SohGui/SohMenuSettings.cpp
+++ b/soh/soh/SohGui/SohMenuSettings.cpp
@@ -118,7 +118,7 @@ void SohMenu::AddMenuSettings() {
         .CVar(CVAR_SETTING("A11yDisableIdleCam"))
         .Options(CheckboxOptions().Tooltip("Disables the automatic re-centering of the camera when idle."));
     AddWidget(path, "EXPERIMENTAL", WIDGET_SEPARATOR_TEXT)
-        .Options(WidgetOptions().Color(Colors::Orange));
+        .Options(TextOptions().Color(Colors::Orange));
     AddWidget(path, "ImGui Menu Scaling", WIDGET_CVAR_COMBOBOX)
         .CVar(CVAR_SETTING("ImGuiScale"))
         .Options(ComboboxOptions().ComboMap(imguiScaleOptions).Tooltip("Changes the scaling of the ImGui menu elements.").DefaultIndex(1)

--- a/soh/soh/SohGui/UIWidgets.cpp
+++ b/soh/soh/SohGui/UIWidgets.cpp
@@ -193,8 +193,8 @@ bool WindowButton(const char* label, const char* cvarName, std::shared_ptr<Ship:
     } else {
         buttonText = ICON_FA_EXTERNAL_LINK_SQUARE " " + buttonText;
     }
-    if (Button(buttonText.c_str(), {{ options.tooltip, options.disabled, options.disabledTooltip, options.color },
-                                      options.size, options.padding })) {
+    if (Button(buttonText.c_str(), {{ options.tooltip, options.disabled, options.disabledTooltip },
+                                      options.size, options.padding, options.color })) {
         windowPtr->ToggleVisibility();
         dirty = true;
     }

--- a/soh/soh/SohGui/UIWidgets.hpp
+++ b/soh/soh/SohGui/UIWidgets.hpp
@@ -122,12 +122,7 @@ namespace UIWidgets {
         const char* tooltip = "";
         bool disabled = false;
         const char* disabledTooltip = "";
-        Colors color = Colors::NoColor;
 
-        WidgetOptions& Color(Colors color_) {
-            color = color = color_;
-            return *this;
-        }
         WidgetOptions& Tooltip(const char* tooltip_) {
             tooltip = tooltip_;
             return *this;
@@ -138,6 +133,15 @@ namespace UIWidgets {
         }
         WidgetOptions& DisabledTooltip(const char* disabledTooltip_) {
             disabledTooltip = disabledTooltip_;
+            return *this;
+        }
+    };
+
+    struct TextOptions : WidgetOptions {
+        Colors color = Colors::NoColor;
+
+        TextOptions& Color(Colors color_) {
+            color = color_;
             return *this;
         }
     };
@@ -160,7 +164,7 @@ namespace UIWidgets {
             return *this;
         }
         ButtonOptions& Color(Colors color_) {
-            WidgetOptions::color = color = color_;
+            color = color_;
             return *this;
         }
     };
@@ -185,7 +189,7 @@ namespace UIWidgets {
             return *this;
         }
         WindowButtonOptions& Color(Colors color_) {
-            WidgetOptions::color = color = color_;
+            color = color_;
             return *this;
         }
         WindowButtonOptions& ShowButton(bool showButton_) {
@@ -202,7 +206,7 @@ namespace UIWidgets {
         bool defaultValue = false; // Only applicable to CVarCheckbox
         ComponentAlignment alignment = ComponentAlignment::Left;
         LabelPosition labelPosition = LabelPosition::Near;
-        Colors color = WidgetOptions::color = Colors::LightBlue;
+        Colors color = Colors::LightBlue;
 
         CheckboxOptions& DefaultValue(bool defaultValue_) {
             defaultValue = defaultValue_;
@@ -221,7 +225,7 @@ namespace UIWidgets {
             return *this;
         }
         CheckboxOptions& Color(Colors color_) {
-            WidgetOptions::color = color = color_;
+            color = color_;
             return *this;
         }
         CheckboxOptions& DisabledTooltip(const char* disabledTooltip_) {
@@ -259,7 +263,7 @@ namespace UIWidgets {
             return *this;
         }
         ComboboxOptions& Color(Colors color_) {
-            WidgetOptions::color = color = color_;
+            color = color_;
             return *this;
         }
     };
@@ -315,7 +319,7 @@ namespace UIWidgets {
             return *this;
         }
         IntSliderOptions& Color(Colors color_) {
-            WidgetOptions::color = color = color_;
+            color = color_;
             return *this;
         }
         IntSliderOptions& Size(ImVec2 size_) {
@@ -387,7 +391,7 @@ namespace UIWidgets {
             return *this;
         }
         FloatSliderOptions& Color(Colors color_) {
-            WidgetOptions::color = color = color_;
+            color = color_;
             return *this;
         }
         FloatSliderOptions& Size(ImVec2 size_) {
@@ -402,6 +406,7 @@ namespace UIWidgets {
 
     struct RadioButtonsOptions : WidgetOptions {
         std::unordered_map<int32_t, const char*> buttonMap;
+        Colors color = Colors::LightBlue;
         
         RadioButtonsOptions& ButtonMap(std::unordered_map<int32_t, const char*> buttonMap_) {
             buttonMap = buttonMap_;
@@ -412,7 +417,7 @@ namespace UIWidgets {
             return *this;
         }
         RadioButtonsOptions& Color(Colors color_) {
-            WidgetOptions::color = color = color_;
+            color = color_;
             return *this;
         }
     };
@@ -433,7 +438,7 @@ namespace UIWidgets {
             return *this;
         }
         InputOptions& Color(Colors color_) {
-            WidgetOptions::color = color = color_;
+            color = color_;
             return *this;
         }
         InputOptions& Size(ImVec2 size_) {


### PR DESCRIPTION
split out from #5135

On gcc this was raising a sequence point warning, which could be resolved by making assignment two lines,
but it seems cleanest to not have everything besides text have two color fields,
one of which will cause incorrect behavior if using the inherited method

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2775554742.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2775563354.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2775571218.zip)
<!--- section:artifacts:end -->