### PR TITLE
Remove Shuffle Pots assert

### DIFF
--- a/soh/soh/Enhancements/randomizer/ShufflePots.cpp
+++ b/soh/soh/Enhancements/randomizer/ShufflePots.cpp
@@ -54,9 +54,6 @@ void ObjTsubo_RandomizerSpawnCollectible(ObjTsubo* potActor, PlayState* play) {
 void ObjTsubo_RandomizerInit(void* actorRef) {
     Actor* actor = static_cast<Actor*>(actorRef);
 
-    // Check for Lake Hylia specifically because the game spawns 2 pots out of bounds there for some reason.
-    if (actor->id != ACTOR_OBJ_TSUBO || gPlayState->sceneNum == SCENE_LAKE_HYLIA || gPlayState->sceneNum == SCENE_HYRULE_CASTLE) return;
-
     ObjTsubo* potActor = static_cast<ObjTsubo*>(actorRef);
 
     potActor->potIdentity = OTRGlobals::Instance->gRandomizer->IdentifyPot(gPlayState->sceneNum, (s16)actor->world.pos.x, (s16)actor->world.pos.z);

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -1807,7 +1807,6 @@ PotIdentity Randomizer::IdentifyPot(s32 sceneNum, s32 posX, s32 posZ) {
 
     if (location->GetRandomizerCheck() == RC_UNKNOWN_CHECK) {
         LUSLOG_WARN("IdentifyPot did not receive a valid RC value (%d).", location->GetRandomizerCheck());
-        assert(false);
     } else {
         potIdentity.randomizerInf = rcToRandomizerInf[location->GetRandomizerCheck()];
         potIdentity.randomizerCheck = location->GetRandomizerCheck();


### PR DESCRIPTION
Originally in place to make sure we didn't miss any pots which could lead to problems, but ultimately after adding the assert, it's been tripped by out of bounds, unused pots 4 different times. So I'm just removing the assert. I feel like after this long if we missed a pot, it probably would've been discovered by now too.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2779551333.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2779558322.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2779695974.zip)
<!--- section:artifacts:end -->