### PR TITLE
Exclude skip get item animations outside of rando

### DIFF
--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -297,6 +297,8 @@ void RandomizerOnPlayerUpdateForRCQueueHandler() {
             rc != RC_MARKET_BOMBCHU_BOWLING_SECOND_PRIZE &&
             // Always show ItemGet animation for ice traps
             !(getItemEntry.modIndex == MOD_RANDOMIZER && getItemEntry.getItemId == RG_ICE_TRAP) &&
+            // Always show ItemGet animation outside of randomizer to keep behaviour consistent in vanilla
+            IS_RANDO &&
             (
                 CVarGetInteger(CVAR_RANDOMIZER_ENHANCEMENT("TimeSavers.SkipGetItemAnimation"), SGIA_DISABLED) == SGIA_ALL ||
                 (


### PR DESCRIPTION
Fixes https://github.com/HarbourMasters/Shipwright/issues/5126

For more context on the why, see the above issue.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2779701682.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2779712195.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2779892715.zip)
<!--- section:artifacts:end -->