### PR TITLE
Menu - Randomizer enhancements menu improvements

### DIFF
--- a/soh/soh/SohGui/SohMenuRandomizer.cpp
+++ b/soh/soh/SohGui/SohMenuRandomizer.cpp
@@ -17,8 +17,11 @@ void SohMenu::AddMenuRandomizer() {
         .CVar(CVAR_WINDOW("RandomizerSettings"))
         .WindowName("Randomizer Settings")
         .Options(WindowButtonOptions().Tooltip("Enables the separate Randomizer Settings Window."));
+
+    // Enhancements
     path.sidebarName = "Enhancements";
-    AddSidebarEntry("Randomizer", path.sidebarName, 1);
+    AddSidebarEntry("Randomizer", path.sidebarName, 3);
+    AddWidget(path, "Randomizer Enhancements", WIDGET_SEPARATOR_TEXT);
     AddWidget(path, "Rando-Relevant Navi Hints", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_RANDOMIZER_ENHANCEMENT("RandoRelevantNavi"))
         .Options(CheckboxOptions().Tooltip(
@@ -75,7 +78,9 @@ void SohMenu::AddMenuRandomizer() {
     AddWidget(path, "Item Scale: %.2f", WIDGET_CVAR_SLIDER_FLOAT)
         .CVar(CVAR_RANDOMIZER_ENHANCEMENT("TimeSavers.SkipGetItemAnimationScale"))
         .PreFunc([](WidgetInfo& info) {
-        info.isHidden = CVarGetInteger(CVAR_RANDOMIZER_ENHANCEMENT("TimeSavers.SkipGetItemAnimation"), SGIA_DISABLED) == SGIA_DISABLED;
+            info.options->disabled =
+                !CVarGetInteger(CVAR_RANDOMIZER_ENHANCEMENT("TimeSavers.SkipGetItemAnimation"), SGIA_DISABLED);
+            info.options->disabledTooltip = "This slider only applies when using the \"Skip Get Item Animations\" option.";
             })
         .Options(FloatSliderOptions()
             .Min(5.0f)


### PR DESCRIPTION
Added the title "Randomizer Enhancements" to make it clearer these only apply to randomizer (even though the submenu lives under "Randomizer"). 

Set columns to 3 to not make the item scale slider go super wide.

Set item scale slider to not hide but disable when not applicable.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2779797857.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2779812267.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2779985478.zip)
<!--- section:artifacts:end -->