### PR TITLE
Port Over Nametag improvements

### DIFF
--- a/soh/soh/Enhancements/debugger/actorViewer.cpp
+++ b/soh/soh/Enhancements/debugger/actorViewer.cpp
@@ -5,6 +5,7 @@
 #include "soh/ActorDB.h"
 #include "soh/Enhancements/game-interactor/GameInteractor.h"
 #include "soh/Enhancements/nametag.h"
+#include "soh/ShipInit.hpp"
 
 #include <array>
 #include <bit>
@@ -13,6 +14,7 @@
 #include <string>
 #include <libultraship/bridge.h>
 #include <libultraship/libultraship.h>
+#include <spdlog/fmt/fmt.h>
 #include "soh/OTRGlobals.h"
 #include "soh/cvar_prefixes.h"
 
@@ -30,6 +32,10 @@ extern PlayState* gPlayState;
 
 #define DEKUNUTS_FLOWER 10
 #define DEBUG_ACTOR_NAMETAG_TAG "debug_actor_viewer"
+
+#define CVAR_ACTOR_NAME_TAGS(val) CVAR_DEVELOPER_TOOLS("ActorViewer.NameTags." val)
+#define CVAR_ACTOR_NAME_TAGS_ENABLED_NAME CVAR_ACTOR_NAME_TAGS("Enabled")
+#define CVAR_ACTOR_NAME_TAGS_ENABLED CVarGetInteger(CVAR_ACTOR_NAME_TAGS("Enabled"), 0)
 
 typedef struct {
     u16 id;
@@ -65,6 +71,10 @@ typedef enum {
 
 const std::string GetActorDescription(u16 id) {
     return ActorDB::Instance->RetrieveEntry(id).entry.valid ? ActorDB::Instance->RetrieveEntry(id).entry.desc : "???";
+}
+
+const std::string GetActorDebugName(u16 id) {
+    return ActorDB::Instance->RetrieveEntry(id).entry.valid ? ActorDB::Instance->RetrieveEntry(id).entry.name : "???";
 }
 
 template <typename T> void DrawGroupWithBorder(T&& drawFunc, std::string section) {
@@ -812,25 +822,37 @@ std::vector<u16> GetActorsWithDescriptionContainingString(std::string s) {
 }
 
 void ActorViewer_AddTagForActor(Actor* actor) {
-    int val = CVarGetInteger(CVAR_DEVELOPER_TOOLS("ActorViewer.NameTags"), ACTORVIEWER_NAMETAGS_NONE);
-    auto entry = ActorDB::Instance->RetrieveEntry(actor->id);
-    std::string tag;
-
-    if (val > 0 && entry.entry.valid) {
-        switch (val) {
-            case ACTORVIEWER_NAMETAGS_DESC:
-                tag = entry.desc;
-                break;
-            case ACTORVIEWER_NAMETAGS_NAME:
-                tag = entry.name;
-                break;
-            case ACTORVIEWER_NAMETAGS_BOTH:
-                tag = entry.name + '\n' + entry.desc;
-                break;
-        }
-
-        NameTag_RegisterForActorWithOptions(actor, tag.c_str(), { .tag = DEBUG_ACTOR_NAMETAG_TAG });
+    if (!CVarGetInteger(CVAR_ACTOR_NAME_TAGS("Enabled"), 0)) {
+        return;
     }
+
+    std::vector<std::string> parts;
+
+    if (CVarGetInteger(CVAR_ACTOR_NAME_TAGS("DisplayID"), 0)) {
+        parts.push_back(GetActorDebugName(actor->id));
+    }
+    if (CVarGetInteger(CVAR_ACTOR_NAME_TAGS("DisplayDescription"), 0)) {
+        parts.push_back(GetActorDescription(actor->id));
+    }
+    if (CVarGetInteger(CVAR_ACTOR_NAME_TAGS("DisplayCategory"), 0)) {
+        parts.push_back(acMapping[actor->category]);
+    }
+    if (CVarGetInteger(CVAR_ACTOR_NAME_TAGS("DisplayParams"), 0)) {
+        parts.push_back(fmt::format("0x{:04X} ({})", (u16)actor->params, actor->params));
+    }
+
+    std::string tag = "";
+    for (size_t i = 0; i < parts.size(); i++) {
+        if (i != 0) {
+            tag += "\n";
+        }
+        tag += parts.at(i);
+    }
+
+    bool withZBuffer = CVarGetInteger(CVAR_ACTOR_NAME_TAGS("WithZBuffer"), 0);
+
+    NameTag_RegisterForActorWithOptions(actor, tag.c_str(),
+                                        { .tag = DEBUG_ACTOR_NAMETAG_TAG, .noZBuffer = !withZBuffer });
 }
 
 void ActorViewer_AddTagForAllActors() {
@@ -879,6 +901,57 @@ void ActorViewerWindow::DrawElement() {
             actors.clear();
         }
         lastSceneId = gPlayState->sceneNum;
+
+        if (ImGui::BeginChild("options", ImVec2(0, 0), ImGuiChildFlags_Border | ImGuiChildFlags_AutoResizeY)) {
+            bool toggled = false;
+            bool optionChange = false;
+
+            ImGui::SeparatorText("Options");
+
+            toggled = UIWidgets::CVarCheckbox("Actor Name Tags", CVAR_ACTOR_NAME_TAGS("Enabled"),
+                                              { { .tooltip = "Adds \"name tags\" above actors for identification" } });
+
+            ImGui::SameLine();
+
+            UIWidgets::Button("Display Items", { { .tooltip = "Click to add display items on the name tags" } });
+
+            if (ImGui::BeginPopupContextItem(nullptr, ImGuiPopupFlags_MouseButtonLeft | ImGuiPopupFlags_NoReopen)) {
+                optionChange |= UIWidgets::CVarCheckbox("ID", CVAR_ACTOR_NAME_TAGS("DisplayID"));
+                optionChange |= UIWidgets::CVarCheckbox("Description", CVAR_ACTOR_NAME_TAGS("DisplayDescription"));
+                optionChange |= UIWidgets::CVarCheckbox("Category", CVAR_ACTOR_NAME_TAGS("DisplayCategory"));
+                optionChange |= UIWidgets::CVarCheckbox("Params", CVAR_ACTOR_NAME_TAGS("DisplayParams"));
+
+                ImGui::EndPopup();
+            }
+
+            optionChange |= UIWidgets::CVarCheckbox(
+                "Name tags with Z-Buffer", CVAR_ACTOR_NAME_TAGS("WithZBuffer"),
+                { { .tooltip = "Allow name tags to be obstructed when behind geometry and actors" } });
+
+            if (toggled || optionChange) {
+                bool tagsEnabled = CVarGetInteger(CVAR_ACTOR_NAME_TAGS("Enabled"), 0);
+                bool noOptionsEnabled = !CVarGetInteger(CVAR_ACTOR_NAME_TAGS("DisplayID"), 0) &&
+                                        !CVarGetInteger(CVAR_ACTOR_NAME_TAGS("DisplayDescription"), 0) &&
+                                        !CVarGetInteger(CVAR_ACTOR_NAME_TAGS("DisplayCategory"), 0) &&
+                                        !CVarGetInteger(CVAR_ACTOR_NAME_TAGS("DisplayParams"), 0);
+
+                // Save the user an extra click and prevent adding "empty" tags by enabling,
+                // disabling, or setting an option based on what changed
+                if (tagsEnabled && noOptionsEnabled) {
+                    if (toggled) {
+                        CVarSetInteger(CVAR_ACTOR_NAME_TAGS("DisplayID"), 1);
+                    } else {
+                        CVarSetInteger(CVAR_ACTOR_NAME_TAGS("Enabled"), 0);
+                    }
+                } else if (optionChange && !tagsEnabled && !noOptionsEnabled) {
+                    CVarSetInteger(CVAR_ACTOR_NAME_TAGS("Enabled"), 1);
+                }
+
+                NameTag_RemoveAllByTag(DEBUG_ACTOR_NAMETAG_TAG);
+                ActorViewer_AddTagForAllActors();
+            }
+        }
+        ImGui::EndChild();
 
         PushStyleCombobox(THEME_COLOR);
         if (ImGui::BeginCombo("Actor Type", acMapping[category])) {
@@ -1159,20 +1232,6 @@ void ActorViewerWindow::DrawElement() {
             ImGui::TreePop();
         }
         PopStyleHeader();
-
-        static std::unordered_map<int32_t, const char*> nameTagOptions = {
-            { 0, "None" },
-            { 1, "Short Description" },
-            { 2, "Actor ID" },
-            { 3, "Both" },
-        };
-
-        if (CVarCombobox(
-                "Actor Name Tags", CVAR_DEVELOPER_TOOLS("ActorViewer.NameTags"), nameTagOptions,
-                ComboboxOptions().Color(THEME_COLOR).Tooltip("Adds \"name tags\" above actors for identification"))) {
-            NameTag_RemoveAllByTag(DEBUG_ACTOR_NAMETAG_TAG);
-            ActorViewer_AddTagForAllActors();
-        }
     } else {
         ImGui::Text("Global Context needed for actor info!");
         if (needs_reset) {
@@ -1188,9 +1247,9 @@ void ActorViewerWindow::DrawElement() {
     }
 }
 
-void ActorViewerWindow::InitElement() {
-    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnActorInit>([](void* refActor) {
-        Actor* actor = static_cast<Actor*>(refActor);
-        ActorViewer_AddTagForActor(actor);
-    });
+void ActorViewer_RegisterNameTagHooks() {
+    COND_HOOK(OnActorInit, CVAR_ACTOR_NAME_TAGS_ENABLED,
+              [](void* actor) { ActorViewer_AddTagForActor(static_cast<Actor*>(actor)); });
 }
+
+RegisterShipInitFunc nametagInit(ActorViewer_RegisterNameTagHooks, { CVAR_ACTOR_NAME_TAGS_ENABLED_NAME });

--- a/soh/soh/Enhancements/debugger/actorViewer.h
+++ b/soh/soh/Enhancements/debugger/actorViewer.h
@@ -7,6 +7,6 @@ class ActorViewerWindow : public Ship::GuiWindow {
     using GuiWindow::GuiWindow;
 
     void DrawElement() override;
-    void InitElement() override;
+    void InitElement() override{};
     void UpdateElement() override{};
 };

--- a/soh/soh/Enhancements/game-interactor/GameInteractor_HookTable.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor_HookTable.h
@@ -27,6 +27,7 @@ DEFINE_HOOK(OnShopSlotChange, (uint8_t cursorIndex, int16_t price));
 DEFINE_HOOK(OnActorInit, (void* actor));
 DEFINE_HOOK(OnActorUpdate, (void* actor));
 DEFINE_HOOK(OnActorKill, (void* actor));
+DEFINE_HOOK(OnActorDestroy, (void* actor));
 DEFINE_HOOK(OnEnemyDefeat, (void* actor));
 DEFINE_HOOK(OnBossDefeat, (void* actor));
 DEFINE_HOOK(OnTimestamp, (u8 item));

--- a/soh/soh/Enhancements/game-interactor/GameInteractor_Hooks.cpp
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor_Hooks.cpp
@@ -112,6 +112,13 @@ void GameInteractor_ExecuteOnActorKill(void* actor) {
     GameInteractor::Instance->ExecuteHooksForFilter<GameInteractor::OnActorKill>(actor);
 }
 
+void GameInteractor_ExecuteOnActorDestroy(void* actor) {
+    GameInteractor::Instance->ExecuteHooks<GameInteractor::OnActorDestroy>(actor);
+    GameInteractor::Instance->ExecuteHooksForID<GameInteractor::OnActorDestroy>(((Actor*)actor)->id, actor);
+    GameInteractor::Instance->ExecuteHooksForPtr<GameInteractor::OnActorDestroy>((uintptr_t)actor, actor);
+    GameInteractor::Instance->ExecuteHooksForFilter<GameInteractor::OnActorDestroy>(actor);
+}
+
 void GameInteractor_ExecuteOnEnemyDefeat(void* actor) {
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnEnemyDefeat>(actor);
     GameInteractor::Instance->ExecuteHooksForID<GameInteractor::OnEnemyDefeat>(((Actor*)actor)->id, actor);

--- a/soh/soh/Enhancements/game-interactor/GameInteractor_Hooks.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor_Hooks.h
@@ -29,6 +29,7 @@ void GameInteractor_ExecuteOnCuccoOrChickenHatch();
 void GameInteractor_ExecuteOnActorInit(void* actor);
 void GameInteractor_ExecuteOnActorUpdate(void* actor);
 void GameInteractor_ExecuteOnActorKill(void* actor);
+void GameInteractor_ExecuteOnActorDestroy(void* actor);
 void GameInteractor_ExecuteOnEnemyDefeat(void* actor);
 void GameInteractor_ExecuteOnBossDefeat(void* actor);
 void GameInteractor_ExecuteOnTimestamp(u8 item);

--- a/soh/soh/Enhancements/mods.cpp
+++ b/soh/soh/Enhancements/mods.cpp
@@ -12,7 +12,6 @@
 #include "soh/Enhancements/randomizer/3drando/random.hpp"
 #include "soh/Enhancements/cosmetics/authenticGfxPatches.h"
 #include <soh/Enhancements/item-tables/ItemTableManager.h>
-#include "soh/Enhancements/nametag.h"
 #include "soh/Enhancements/timesaver_hook_handlers.h"
 #include "soh/Enhancements/TimeSavers/TimeSavers.h"
 #include "soh/Enhancements/randomizer/hook_handlers.h"
@@ -1090,7 +1089,6 @@ void InitMods() {
     RegisterRandomizedEnemySizes();
     RegisterOpenAllHours();
     RegisterToTMedallions();
-    NameTag_RegisterHooks();
     RegisterFloorSwitchesHook();
     RegisterPatchHandHandler();
     RegisterHurtContainerModeHandler();

--- a/soh/soh/Enhancements/nametag.h
+++ b/soh/soh/Enhancements/nametag.h
@@ -1,11 +1,16 @@
-#ifndef _NAMETAG_H_
-#define _NAMETAG_H_
-#include <z64.h>
+#ifndef NAMETAG_H
+#define NAMETAG_H
+
+#include <libultraship/color.h>
+#include <libultraship/libultra.h>
+
+struct Actor;
 
 typedef struct {
     const char* tag;       // Tag identifier to filter/remove multiple tags
     int16_t yOffset;       // Additional Y offset to apply for the name tag
     Color_RGBA8 textColor; // Text color override. Global color is used if alpha is 0
+    uint8_t noZBuffer;     // Allow rendering over geometry
 } NameTagOptions;
 
 // Register required hooks for nametags on startup
@@ -28,4 +33,4 @@ void NameTag_RemoveAllByTag(const char* tag);
 }
 #endif
 
-#endif // _NAMETAG_H_
+#endif // NAMETAG_H

--- a/soh/src/code/z_actor.c
+++ b/soh/src/code/z_actor.c
@@ -3466,6 +3466,9 @@ Actor* Actor_Delete(ActorContext* actorCtx, Actor* actor, PlayState* play) {
 
     player = GET_PLAYER(play);
 
+    // Execute before actor memory is freed
+    GameInteractor_ExecuteOnActorDestroy(actor);
+
     dbEntry = ActorDB_Retrieve(actor->id);
 
     if (HREG(20) != 0) {


### PR DESCRIPTION
This ports over some of the improvements from the 2ship Nametags PR https://github.com/HarbourMasters/2ship2harkinian/pull/746

Copying the relevant details here:

* Nametags render roughly 2x farther (this could be changed to any value really, but if its too far away you cant really read it anyways)
* Actor Viewer name tags now can display any combination of ID, short description, actor category, and actor params
* Individual nametags can set whether ZBuffer should be used (obscured by geometry)
  * Debug nametags from the actor viewer by default do not set this, but an option to change that is available
* Hooks are optimized to (un)registered when there exists nametags
* New hook `OnActorDestroy` - Called right before an actor is freed from the arena. When actors are removed via room transitions, they will not always call `Actor_Kill`, but `Actor_Destroy` will always be called in both cases. `OnActorDestroy` is a better hook to use over `OnActorKill`

---

* Depends on #5151


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2864328174.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2864330457.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2864495496.zip)
<!--- section:artifacts:end -->