### PR TITLE
Fix Boss Rush blue warps

### DIFF
--- a/soh/soh/Enhancements/TimeSavers/SkipCutscene/Story/SkipBlueWarp.cpp
+++ b/soh/soh/Enhancements/TimeSavers/SkipCutscene/Story/SkipBlueWarp.cpp
@@ -20,6 +20,11 @@ static bool sEnteredBlueWarp = false;
  * should also account for the difference between your first and following visits to the blue warp.
  */
 void SkipBlueWarp_ShouldPlayTransitionCS(GIVanillaBehavior _, bool* should, va_list originalArgs) {
+    // Do nothing when in a boss rush
+    if (IS_BOSS_RUSH) {
+        return;
+    }
+    
     bool overrideBlueWarpDestinations =
         IS_RANDO && (RAND_GET_OPTION(RSK_SHUFFLE_DUNGEON_ENTRANCES) != RO_DUNGEON_ENTRANCE_SHUFFLE_OFF ||
                      RAND_GET_OPTION(RSK_SHUFFLE_BOSS_ENTRANCES) != RO_BOSS_ROOM_ENTRANCE_SHUFFLE_OFF);

--- a/soh/soh/Enhancements/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.cpp
@@ -1060,6 +1060,11 @@ void TimeSaverOnSceneInitHandler(int16_t sceneNum) {
 static GetItemEntry vanillaQueuedItemEntry = GET_ITEM_NONE;
 
 void TimeSaverOnFlagSetHandler(int16_t flagType, int16_t flag) {
+    // Do nothing when in a boss rush
+    if (IS_BOSS_RUSH) {
+        return;
+    }
+
     if (CVarGetInteger(CVAR_ENHANCEMENT("TimeSavers.SkipCutscene.Story"), IS_RANDO)) {
         switch (flagType) {
             case FLAG_EVENT_CHECK_INF:


### PR DESCRIPTION
This addresses an issue when using blue warps in Boss Rush mode that was caused by certain timesavers. To address this I abort these timesavers when in boss rush. These were the main ones that I saw causing issues, but we might want to consider if all the other "skip" timesavers should have similar checks.

Fixes #5006 

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2789490035.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2789498172.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2789510448.zip)
<!--- section:artifacts:end -->