### PR TITLE
Dismiss Menubar Notification Popup with F1

### DIFF
--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -1295,7 +1295,11 @@ extern "C" void Graph_StartFrame() {
     switch (dwScancode) {
         case KbScancode::LUS_KB_F1: {
             std::shared_ptr<SohModalWindow> modal = static_pointer_cast<SohModalWindow>(Ship::Context::GetInstance()->GetWindow()->GetGui()->GetGuiWindow("Modal Window"));
-            modal->RegisterPopup("Menu Moved", "The menubar, accessed by hitting F1, no longer exists.\nThe new menu can be accessed by hitting the Esc button instead.", "OK");
+            if (modal->IsPopupOpen("Menu Moved")) {
+                modal->DismissPopup();
+            } else {
+                modal->RegisterPopup("Menu Moved", "The menubar, accessed by hitting F1, no longer exists.\nThe new menu can be accessed by hitting the Esc button instead.", "OK");
+            }
             break;
         }
         case KbScancode::LUS_KB_F5: {

--- a/soh/soh/SohGui/SohModals.cpp
+++ b/soh/soh/SohGui/SohModals.cpp
@@ -20,6 +20,8 @@ struct SohModal {
 };
 std::vector<SohModal> modals;
 
+bool closePopup = false;
+
 void SohModalWindow::Draw() {
     if (!IsVisible()) {
         return;
@@ -34,6 +36,11 @@ void SohModalWindow::DrawElement() {
         SohModal curModal = modals.at(0);
         if (!ImGui::IsPopupOpen(curModal.title_.c_str())) {
             ImGui::OpenPopup(curModal.title_.c_str());
+        }
+        if (closePopup) {
+            ImGui::CloseCurrentPopup();
+            modals.erase(modals.begin());
+            closePopup = false;
         }
         if (ImGui::BeginPopupModal(curModal.title_.c_str(), NULL, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoSavedSettings)) {
             ImGui::Text("%s", curModal.message_.c_str());
@@ -65,4 +72,12 @@ void SohModalWindow::DrawElement() {
 
 void SohModalWindow::RegisterPopup(std::string title, std::string message, std::string button1, std::string button2, std::function<void()> button1callback, std::function<void()> button2callback) {
     modals.push_back({ title, message, button1, button2, button1callback, button2callback });
+}
+
+bool SohModalWindow::IsPopupOpen(std::string title) {
+    return !modals.empty() && modals.at(0).title_ == title;
+}
+
+void SohModalWindow::DismissPopup() {
+    closePopup = true;
 }

--- a/soh/soh/SohGui/SohModals.h
+++ b/soh/soh/SohGui/SohModals.h
@@ -13,4 +13,6 @@ class SohModalWindow : public Ship::GuiWindow {
     void DrawElement() override;
     void UpdateElement() override {};
     void RegisterPopup(std::string title, std::string message, std::string button1 = "OK", std::string button2 = "", std::function<void()> button1callback = nullptr, std::function<void()> button2callback = nullptr);
+    bool IsPopupOpen(std::string title);
+    void DismissPopup();
 };


### PR DESCRIPTION
via new `IsPopupOpen()` and `DismissPopup` functions in `SohModalWindow`. Also inherently prevents multiple modals from being opened simultaneously for it.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2792001124.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2792008186.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2792016758.zip)
<!--- section:artifacts:end -->