### PR TITLE
Remove EnFr_RandomizerCheckFromSongIndex

### DIFF
--- a/soh/soh/Enhancements/enemyrandomizer.cpp
+++ b/soh/soh/Enhancements/enemyrandomizer.cpp
@@ -186,7 +186,7 @@ extern "C" uint8_t GetRandomizedEnemy(PlayState* play, int16_t *actorId, f32 *po
     // Lengthen timer in non-MQ Jabu Jabu bubble room.
     if (!isMQ && *actorId == ACTOR_OBJ_ROOMTIMER && *params == 30760 && play->sceneNum == SCENE_JABU_JABU &&
         play->roomCtx.curRoom.num == 12) {
-        *params = 26744;
+        *params = (*params & ~0x3FF) | 120;
     }
 
     if (IsEnemyFoundToRandomize(play->sceneNum, play->roomCtx.curRoom.num, *actorId, *params, *posX)) {

--- a/soh/soh/Enhancements/enemyrandomizer.cpp
+++ b/soh/soh/Enhancements/enemyrandomizer.cpp
@@ -186,7 +186,7 @@ extern "C" uint8_t GetRandomizedEnemy(PlayState* play, int16_t *actorId, f32 *po
     // Lengthen timer in non-MQ Jabu Jabu bubble room.
     if (!isMQ && *actorId == ACTOR_OBJ_ROOMTIMER && *params == 30760 && play->sceneNum == SCENE_JABU_JABU &&
         play->roomCtx.curRoom.num == 12) {
-        *params = 92280;
+        *params = 26744;
     }
 
     if (IsEnemyFoundToRandomize(play->sceneNum, play->roomCtx.curRoom.num, *actorId, *params, *posX)) {

--- a/soh/soh/Enhancements/game-interactor/GameInteractor_RawAction.cpp
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor_RawAction.cpp
@@ -220,6 +220,9 @@ bool GameInteractor::RawAction::CheckFlag(int16_t flagType, int16_t flag) {
             return Flags_GetRandomizerInf(static_cast<RandomizerInf>(flag));
         case FlagType::FLAG_GS_TOKEN:
             return GET_GS_FLAGS((flag & 0x1F00) >> 8);
+        default:
+            assert(false);
+            return false;
     }
 }
 

--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -547,27 +547,6 @@ u8 EnGm_RandoCanGetMedigoronItem() {
             !Flags_GetRandomizerInf(RAND_INF_MERCHANTS_MEDIGORON);
 }
 
-RandomizerCheck EnFr_RandomizerCheckFromSongIndex(u16 songIndex) {
-    switch (songIndex) {
-        case FROG_ZL:
-            return RC_ZR_FROGS_ZELDAS_LULLABY;
-        case FROG_EPONA:
-            return RC_ZR_FROGS_EPONAS_SONG;
-        case FROG_SARIA:
-            return RC_ZR_FROGS_SARIAS_SONG;
-        case FROG_SUNS:
-            return RC_ZR_FROGS_SUNS_SONG;
-        case FROG_SOT:
-            return RC_ZR_FROGS_SONG_OF_TIME;
-        case FROG_STORMS:
-            return RC_ZR_FROGS_IN_THE_RAIN;
-        case FROG_CHOIR_SONG:
-            return RC_ZR_FROGS_OCARINA_GAME;
-        default:
-            return RC_UNKNOWN_CHECK;
-    }
-}
-
 void RandomizerSetChestGameRandomizerInf(RandomizerCheck rc) {
     switch (rc) {
         case RC_MARKET_TREASURE_CHEST_GAME_ITEM_1:

--- a/soh/src/overlays/actors/ovl_Obj_Roomtimer/z_obj_roomtimer.c
+++ b/soh/src/overlays/actors/ovl_Obj_Roomtimer/z_obj_roomtimer.c
@@ -32,13 +32,7 @@ void ObjRoomtimer_Init(Actor* thisx, PlayState* play) {
     ObjRoomtimer* this = (ObjRoomtimer*)thisx;
     s16 params = this->actor.params;
 
-    // Shabom room in Jabu Jabu has a lengthened timer in Enemy Randomizer. Flag doesn't match what the game
-    // expects. Instead set it back to the same flag as what it would be in vanilla.
-    if (CVarGetInteger(CVAR_ENHANCEMENT("RandomizedEnemies"), 0) && play->sceneNum == SCENE_JABU_JABU && play->roomCtx.curRoom.num == 12) {
-        this->switchFlag = 30;
-    } else {
-        this->switchFlag = (params >> 10) & 0x3F;
-    }
+    this->switchFlag = (params >> 10) & 0x3F;
     this->actor.params = params & 0x3FF;
     params = this->actor.params;
 


### PR DESCRIPTION
Also handle missing return in RawAction::CheckFlag
Also adjust jabu jabu shabom timer override to be non-overflowing constant (but same constant)

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2793355235.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2793361777.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2793373585.zip)
<!--- section:artifacts:end -->