### PR TITLE
Add check for GAMEMODE_END_CREDITS in Audio Editor's OnSceneInit hook

### DIFF
--- a/soh/soh/Enhancements/audio/AudioEditor.cpp
+++ b/soh/soh/Enhancements/audio/AudioEditor.cpp
@@ -16,14 +16,14 @@
 #include "AudioCollection.h"
 #include "soh/Enhancements/game-interactor/GameInteractor.h"
 
-Vec3f pos = { 0.0f, 0.0f, 0.0f };
-f32 freqScale = 1.0f;
-s8 reverbAdd = 0;
-
 extern "C" {
     #include "z64save.h"
     extern SaveContext gSaveContext;
 }
+
+Vec3f pos = { 0.0f, 0.0f, 0.0f };
+f32 freqScale = 1.0f;
+s8 reverbAdd = 0;
 
 // Authentic sequence counts
 // used to ensure we have enough to shuffle

--- a/soh/soh/Enhancements/audio/AudioEditor.cpp
+++ b/soh/soh/Enhancements/audio/AudioEditor.cpp
@@ -20,6 +20,11 @@ Vec3f pos = { 0.0f, 0.0f, 0.0f };
 f32 freqScale = 1.0f;
 s8 reverbAdd = 0;
 
+extern "C" {
+    #include "z64save.h"
+    extern SaveContext gSaveContext;
+}
+
 // Authentic sequence counts
 // used to ensure we have enough to shuffle
 #define SEQ_COUNT_BGM_WORLD 30
@@ -440,7 +445,7 @@ void DrawTypeChip(SeqType type, std::string sequenceName) {
 
 void AudioEditorRegisterOnSceneInitHook() {
     GameInteractor::Instance->RegisterGameHook<GameInteractor::OnSceneInit>([](int16_t sceneNum) {
-        if (CVarGetInteger(CVAR_AUDIO("RandomizeAllOnNewScene"), 0)) {
+        if (gSaveContext.gameMode != GAMEMODE_END_CREDITS && CVarGetInteger(CVAR_AUDIO("RandomizeAllOnNewScene"), 0)) {
             AudioEditor_RandomizeAll();
         }
     });


### PR DESCRIPTION
To prevent sequence shuffles mid-credits, which would restart the end credits music.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2793374090.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2793377508.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2793388043.zip)
<!--- section:artifacts:end -->