### PR TITLE
Mono dev tools

### DIFF
--- a/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
+++ b/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
@@ -1555,6 +1555,8 @@ void ResetBaseOptions() {
 
 void SaveEditorWindow::DrawElement() {
     PushStyleTabs(THEME_COLOR);
+    ImGui::PushFont(OTRGlobals::Instance->fontMonoLarger);
+
     if (ImGui::BeginTabBar("SaveContextTabBar", ImGuiTabBarFlags_NoCloseWithMiddleMouseButton)) {
         ResetBaseOptions();
         if (ImGui::BeginTabItem("Info")) {
@@ -1594,6 +1596,8 @@ void SaveEditorWindow::DrawElement() {
 
         ImGui::EndTabBar();
     }
+
+    ImGui::PopFont();
     PopStyleTabs();
 }
 

--- a/soh/soh/Enhancements/debugger/dlViewer.cpp
+++ b/soh/soh/Enhancements/debugger/dlViewer.cpp
@@ -93,6 +93,8 @@ void PerformDisplayListSearch() {
 void DLViewerWindow::DrawElement() {
     // Debounce the search field as listing otr files is expensive
     UIWidgets::PushStyleInput(THEME_COLOR);
+    ImGui::PushFont(OTRGlobals::Instance->fontMonoLarger);
+
     if (ImGui::InputText("Search Display Lists", searchString, ARRAY_COUNT(searchString))) {
         doSearch = true;
         searchDebounceFrames = 30;
@@ -121,6 +123,7 @@ void DLViewerWindow::DrawElement() {
     UIWidgets::PopStyleCombobox();
 
     if (activeDisplayList == "") {
+        ImGui::PopFont();
         return;
     }
 
@@ -326,8 +329,11 @@ void DLViewerWindow::DrawElement() {
         }
     } catch (const std::exception& e) {
         ImGui::Text("Error displaying DL instructions.");
+        ImGui::PopFont();
         return;
     }
+
+    ImGui::PopFont();
 }
 
 void DLViewerWindow::InitElement() {

--- a/soh/soh/Enhancements/debugger/hookDebugger.cpp
+++ b/soh/soh/Enhancements/debugger/hookDebugger.cpp
@@ -1,6 +1,7 @@
 #include "hookDebugger.h"
 #include "soh/Enhancements/game-interactor/GameInteractor.h"
 #include "soh/SohGui/UIWidgets.hpp"
+#include "soh/OTRGlobals.h"
 #include <string>
 #include <version>
 
@@ -82,12 +83,16 @@ void HookDebuggerWindow::DrawElement() {
                                "(\"__cpp_lib_source_location\" not defined in \"<version>\").");
 #endif
 
+    ImGui::PushFont(OTRGlobals::Instance->fontMonoLarger);
+
     for (auto& [hookName, _] : hookData) {
         if (ImGui::TreeNode(hookName)) {
             DrawHookRegisteringInfos(hookName);
             ImGui::TreePop();
         }
     }
+
+    ImGui::PopFont();
 }
 
 void HookDebuggerWindow::InitElement() {

--- a/soh/soh/Enhancements/debugger/sohConsole.cpp
+++ b/soh/soh/Enhancements/debugger/sohConsole.cpp
@@ -1,0 +1,30 @@
+#include "sohConsole.h"
+#include "soh/OTRGlobals.h"
+#include "soh/SohGui/UIWidgets.hpp"
+#include "soh/SohGui/SohGui.hpp"
+
+void SohConsoleWindow::InitElement() {
+    ConsoleWindow::InitElement();
+}
+
+void SohConsoleWindow::UpdateElement() {
+    ConsoleWindow::UpdateElement();
+}
+
+void SohConsoleWindow::DrawElement() {
+    UIWidgets::PushStyleInput(THEME_COLOR);
+    // Small font (13) to match hardcoded width values in the LUS window.. set large font after below TODO addressed
+    ImGui::PushFont(OTRGlobals::Instance->fontMonoSmall);
+
+    // TODO: This can be removed after the LUS console window is designed better without hardcoding widths
+    ImGui::BeginChild("##Console Wrapper", ImVec2(0, 0), ImGuiChildFlags_None,
+                      ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoScrollbar |
+                          ImGuiWindowFlags_NoScrollWithMouse);
+
+    ConsoleWindow::DrawElement();
+
+    ImGui::EndChild();
+
+    ImGui::PopFont();
+    UIWidgets::PopStyleInput();
+}

--- a/soh/soh/Enhancements/debugger/sohConsole.h
+++ b/soh/soh/Enhancements/debugger/sohConsole.h
@@ -1,0 +1,17 @@
+#ifndef SOH_CONSOLE_H
+#define SOH_CONSOLE_H
+
+#include "window/gui/GuiWindow.h"
+#include "window/gui/ConsoleWindow.h"
+
+class SohConsoleWindow : public Ship::ConsoleWindow {
+  public:
+    using ConsoleWindow::ConsoleWindow;
+
+  protected:
+    void InitElement() override;
+    void UpdateElement() override;
+    void DrawElement() override;
+};
+
+#endif // SOH_CONSOLE_H

--- a/soh/soh/Enhancements/debugger/sohGfxDebugger.cpp
+++ b/soh/soh/Enhancements/debugger/sohGfxDebugger.cpp
@@ -1,0 +1,16 @@
+#include "sohGfxDebugger.h"
+#include "soh/OTRGlobals.h"
+
+void SohGfxDebuggerWindow::InitElement() {
+    GfxDebuggerWindow::InitElement();
+}
+
+void SohGfxDebuggerWindow::UpdateElement() {
+    GfxDebuggerWindow::UpdateElement();
+}
+
+void SohGfxDebuggerWindow::DrawElement() {
+    ImGui::PushFont(OTRGlobals::Instance->fontMonoLarger);
+    GfxDebuggerWindow::DrawElement();
+    ImGui::PopFont();
+}

--- a/soh/soh/Enhancements/debugger/sohGfxDebugger.h
+++ b/soh/soh/Enhancements/debugger/sohGfxDebugger.h
@@ -1,0 +1,17 @@
+#ifndef SOH_GFX_DEBUGGER_H
+#define SOH_GFX_DEBUGGER_H
+
+#include "window/gui/GuiWindow.h"
+#include "window/gui/GfxDebuggerWindow.h"
+
+class SohGfxDebuggerWindow : public LUS::GfxDebuggerWindow {
+  public:
+    using GfxDebuggerWindow::GfxDebuggerWindow;
+
+  protected:
+    void InitElement() override;
+    void UpdateElement() override;
+    void DrawElement() override;
+};
+
+#endif // SOH_GFX_DEBUGGER_H

--- a/soh/soh/Enhancements/gameplaystats.cpp
+++ b/soh/soh/Enhancements/gameplaystats.cpp
@@ -635,9 +635,11 @@ void DrawGameplayStatsOptionsTab() {
 }
 
 void GameplayStatsWindow::DrawElement() {
+    ImGui::PushFont(OTRGlobals::Instance->fontMonoLarger);
     DrawGameplayStatsHeader();
 
     UIWidgets::PushStyleTabs(THEME_COLOR);
+
     if (ImGui::BeginTabBar("Stats", ImGuiTabBarFlags_NoCloseWithMiddleMouseButton)) {
         if (ImGui::BeginTabItem("Timestamps")) {
             DrawGameplayStatsTimestampsTab();
@@ -657,7 +659,9 @@ void GameplayStatsWindow::DrawElement() {
         }
         ImGui::EndTabBar();
     }
+
     UIWidgets::PopStyleTabs();
+    ImGui::PopFont();
 
     ImGui::Text("Note: Gameplay stats are saved to the current file and will be\nlost if you quit without saving.");
 }

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -401,7 +401,7 @@ OTRGlobals::OTRGlobals() {
 
     previousImGuiScale = defaultImGuiScale;
 
-    fontMonoSmall = CreateFontWithSize(13.0f, "fonts/Inconsolata-Regular.ttf");
+    fontMonoSmall = CreateFontWithSize(14.0f, "fonts/Inconsolata-Regular.ttf");
     fontMono = CreateFontWithSize(16.0f, "fonts/Inconsolata-Regular.ttf");
     fontMonoLarger = CreateFontWithSize(20.0f, "fonts/Inconsolata-Regular.ttf");
     fontMonoLargest = CreateFontWithSize(24.0f, "fonts/Inconsolata-Regular.ttf");

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -401,6 +401,7 @@ OTRGlobals::OTRGlobals() {
 
     previousImGuiScale = defaultImGuiScale;
 
+    fontMonoSmall = CreateFontWithSize(13.0f, "fonts/Inconsolata-Regular.ttf");
     fontMono = CreateFontWithSize(16.0f, "fonts/Inconsolata-Regular.ttf");
     fontMonoLarger = CreateFontWithSize(20.0f, "fonts/Inconsolata-Regular.ttf");
     fontMonoLargest = CreateFontWithSize(24.0f, "fonts/Inconsolata-Regular.ttf");

--- a/soh/soh/OTRGlobals.h
+++ b/soh/soh/OTRGlobals.h
@@ -54,6 +54,7 @@ class OTRGlobals {
         ImFont* defaultFontLarger;
         ImFont* defaultFontLargest;
 
+        ImFont* fontMonoSmall;
         ImFont* fontStandard;
         ImFont* fontStandardLarger;
         ImFont* fontStandardLargest;

--- a/soh/soh/SohGui/SohGui.cpp
+++ b/soh/soh/SohGui/SohGui.cpp
@@ -124,15 +124,11 @@ namespace SohGui {
             SPDLOG_ERROR("Could not find stats window");
         }
 
-        mConsoleWindow = gui->GetGuiWindow("Console");
-        if (mConsoleWindow == nullptr) {
-            SPDLOG_ERROR("Could not find console window");
-        }
+        mConsoleWindow = std::make_shared<SohConsoleWindow>(CVAR_WINDOW("Console"), "Console##SoH", ImVec2(820, 630));
+        gui->AddGuiWindow(mConsoleWindow);
 
-        mGfxDebuggerWindow = gui->GetGuiWindow("Gfx Debugger");
-        if (mGfxDebuggerWindow == nullptr) {
-            SPDLOG_ERROR("Could not find Gfx Debugger window");
-        }
+        mGfxDebuggerWindow = std::make_shared<SohGfxDebuggerWindow>(CVAR_WINDOW("GfxDebugger"), "GfxDebugger##SoH", ImVec2(820, 630));
+        gui->AddGuiWindow(mGfxDebuggerWindow);
 
         mInputEditorWindow = gui->GetGuiWindow("Controller Configuration");
         if (mInputEditorWindow == nullptr) {

--- a/soh/soh/SohGui/SohGui.hpp
+++ b/soh/soh/SohGui/SohGui.hpp
@@ -18,6 +18,8 @@
 #include "soh/Enhancements/debugger/debugSaveEditor.h"
 #include "soh/Enhancements/debugger/hookDebugger.h"
 #include "soh/Enhancements/debugger/dlViewer.h"
+#include "soh/Enhancements/debugger/sohConsole.h"
+#include "soh/Enhancements/debugger/sohGfxDebugger.h"
 #include "soh/Enhancements/debugger/valueViewer.h"
 #include "soh/Enhancements/gameplaystatswindow.h"
 #include "soh/Enhancements/randomizer/randomizer_check_tracker.h"

--- a/soh/soh/SohGui/SohMenuDevTools.cpp
+++ b/soh/soh/SohGui/SohMenuDevTools.cpp
@@ -99,7 +99,7 @@ void SohMenu::AddMenuDevTools() {
     AddSidebarEntry("Dev Tools", path.sidebarName, 1);
     AddWidget(path, "Popout Console", WIDGET_WINDOW_BUTTON)
         .CVar(CVAR_WINDOW("Console"))
-        .WindowName("Console")
+        .WindowName("Console##SoH")
         .Options(WindowButtonOptions().Tooltip("Enables the separate Console Window."));
 
     // Save Editor
@@ -163,7 +163,7 @@ void SohMenu::AddMenuDevTools() {
     AddSidebarEntry("Dev Tools", path.sidebarName, 1);
     AddWidget(path, "Popout Gfx Debugger", WIDGET_WINDOW_BUTTON)
         .CVar(CVAR_WINDOW("GfxDebugger"))
-        .WindowName("GfxDebuggerWindow")
+        .WindowName("GfxDebugger##SoH")
         .Options(WindowButtonOptions().Tooltip("Enables the separate Gfx Debugger Window."));
 }
 


### PR DESCRIPTION
This applies the mono font to a couple windows that originally had mono spacing in mind for alignments:
* Save editor
* Hook Debugger
* Gameplay Stats
* DL Viewer

I've also applied a hack-ish to apply the mono font to some of the LUS provided windows by creating GUI window wrappers that extend the LUS ones and push/pop the font around the original draw element. This requires us to ignore the original registered LUS windows and register our own (with a different unique ID to avoid collisions).

This was done for the GFX Debugger and the Console. For the console I had to introduce a small mono font variant at 14pt size because the console window uses hardcoded widths assuming a 13pt size font was used. Using a larger font causes the console to scroll horizontally in a undesirable way. Locking the scroll would also force part of the submit button to get clipped. This can be removed in the future with a redesigned console.

![image](https://github.com/user-attachments/assets/0add80f8-e817-4400-818b-037894b59831)


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2793657707.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2793662644.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2793664642.zip)
<!--- section:artifacts:end -->