### PR TITLE
Remove MenuOptionIndex Middleman and fix rando presets

### DIFF
--- a/soh/soh/Enhancements/presets.cpp
+++ b/soh/soh/Enhancements/presets.cpp
@@ -75,9 +75,6 @@ void DrawPresetSelector(PresetType presetTypeId) {
         }
         CVarSetInteger(presetTypeCvar.c_str(), selectedPresetId);
         Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
-        if (presetTypeId == PRESET_TYPE_RANDOMIZER){
-            Rando::Settings::GetInstance()->ReloadOptions();
-        }
     }
     UIWidgets::PopStyleButton();
 }

--- a/soh/soh/Enhancements/randomizer/option.h
+++ b/soh/soh/Enhancements/randomizer/option.h
@@ -225,19 +225,7 @@ class Option {
      *
      * @return uint8_t
      */
-    uint8_t GetMenuOptionIndex() const;
-
-    /**
-     * @brief Sets the CVar corresponding to the property `cvarName` equal to the value
-     * of the property `selectedValue`.
-    */
-    void SaveCVar() const;
-
-    /**
-     * @brief Sets the value of property `selectedValue` equal to the CVar corresponding
-     * to the property `cvarName`.
-    */
-    void SetFromCVar();
+    uint8_t GetOptionIndex() const;
 
     /**
      * @brief Set the delayedOption to the currently selected index so it can be restored later.
@@ -248,13 +236,6 @@ class Option {
      * @brief Restores the delayedOption back to the selected index.
      */
     void RestoreDelayedOption();
-
-    /**
-     * @brief Set the menu index for this Option. Also calls `SetVariable()`.
-     *
-     * @param idx the index to set as the selected index.
-     */
-    void SetMenuIndex(size_t idx);
 
     /**
      * @brief Set the rando context index for this Option. Also calls `SetVariable()`.
@@ -344,7 +325,6 @@ protected:
     void PopulateTextToNum();
     std::string name;
     std::vector<std::string> options;
-    uint8_t menuSelection = 0;
     uint8_t contextSelection = 0;
     uint8_t delayedSelection = 0;
     bool hidden = false;

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -1871,7 +1871,6 @@ void GenerateRandomizerImgui(std::string seed = "") {
     CVarSave();
     auto ctx = Rando::Context::GetInstance();
     //RANDOTODO proper UI for selecting if a spoiler loaded should be used for settings
-    Rando::Settings::GetInstance()->SetAllFromCVar();
     Rando::Settings::GetInstance()->SetAllToContext();
     
     // todo: this efficently when we build out cvar array support
@@ -1972,6 +1971,7 @@ void RandomizerSettingsWindow::DrawElement() {
         }
         CVarSetInteger(presetTypeCvar.c_str(), randomizerPresetSelected);
         Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
+        mSettings->UpdateOptionProperties();
     }
 
     UIWidgets::Spacer(0);

--- a/soh/soh/Enhancements/randomizer/settings.cpp
+++ b/soh/soh/Enhancements/randomizer/settings.cpp
@@ -1147,12 +1147,6 @@ const OptionGroup& Settings::GetOptionGroup(const RandomizerSettingGroupKey key)
     return mOptionGroups[key];
 }
 
-void Settings::SetAllFromCVar() {
-    for (auto& option : mOptions) {
-        option.SetFromCVar();
-    }
-}
-
 void Settings::UpdateOptionProperties() {
     // Default to hiding bridge opts and the extra sliders.
     mOptions[RSK_RAINBOW_BRIDGE].AddFlag(IMFLAG_SEPARATOR_BOTTOM);
@@ -2222,11 +2216,6 @@ void Settings::ParseJson(nlohmann::json spoilerFileJson) {
     }
 }
 
-void Settings::ReloadOptions() {
-    for (int i = 0; i < RSK_MAX; i++) {
-        mOptions[i].SetFromCVar();
-    }
-}
 void Settings::AssignContext(std::shared_ptr<Context> ctx) {
     mContext = ctx;
 }
@@ -2237,13 +2226,13 @@ void Settings::ClearContext() {
 
 void Settings::SetAllToContext() {
     for (int i = 0; i < RSK_MAX; i++) {
-        mContext->GetOption(static_cast<RandomizerSettingKey>(i)).Set(mOptions[i].GetMenuOptionIndex());
+        mContext->GetOption(static_cast<RandomizerSettingKey>(i)).Set(mOptions[i].GetOptionIndex());
     }
     for (int i = 0; i < RT_MAX; i++) {
-        mContext->GetTrickOption(static_cast<RandomizerTrick>(i)).Set(mTrickOptions[i].GetMenuOptionIndex());
+        mContext->GetTrickOption(static_cast<RandomizerTrick>(i)).Set(mTrickOptions[i].GetOptionIndex());
     }
     for (int i = 0; i < RC_MAX; i++) {
-        mContext->GetItemLocation(i)->SetExcludedOption(StaticData::GetLocation(static_cast<RandomizerCheck>(i))->GetExcludedOption()->GetMenuOptionIndex());
+        mContext->GetItemLocation(i)->SetExcludedOption(StaticData::GetLocation(static_cast<RandomizerCheck>(i))->GetExcludedOption()->GetOptionIndex());
     }
 }
 

--- a/soh/soh/Enhancements/randomizer/settings.h
+++ b/soh/soh/Enhancements/randomizer/settings.h
@@ -89,12 +89,6 @@ class Settings {
     const OptionGroup& GetOptionGroup(RandomizerSettingGroupKey key);
 
     /**
-     * @brief sets the `selectedOption` of all Options to the value of the CVar
-     * corresponding to their `cvarName`s.
-    */
-    void SetAllFromCVar();
-
-    /**
      * @brief Updates various properties of options based on the value of other options.
      * Used to update visibility, whether or not interaction is disabled, and what the
      * actual option values are. Actually changing option values should be handled in
@@ -113,7 +107,6 @@ class Settings {
      */
     void ParseJson(nlohmann::json spoilerFileJson);
     std::map<RandomizerArea, std::vector<RandomizerTrick>> mTricksByArea = {};
-    void ReloadOptions();
 
     /**
      * @brief Assigns a Rando::Context instance to this settings instance

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -2514,7 +2514,6 @@ void SoH_ProcessDroppedFiles(std::string filePath) {
         }
 
         Rando::Settings::GetInstance()->UpdateOptionProperties();
-        Rando::Settings::GetInstance()->SetAllFromCVar();
 
         auto gui = Ship::Context::GetInstance()->GetWindow()->GetGui();
         gui->GetGuiWindow("Console")->Hide();

--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -921,7 +921,7 @@ void SohMenu::AddMenuEnhancements() {
         .Options(CheckboxOptions().Tooltip(
             "Removes the Dungeon Entrance icon on the top-left corner of the screen when no dungeon is present on the "
             "current map."));
-    AddWidget(path, "Fix Two-Handled Idle Animations", WIDGET_CVAR_CHECKBOX)
+    AddWidget(path, "Fix Two-Handed Idle Animations", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("TwoHandedIdle"))
         .Options(CheckboxOptions().Tooltip(
             "Re-Enables the two-handed idle animation, a seemingly finished animation that was disabled on accident "
@@ -992,7 +992,7 @@ void SohMenu::AddMenuEnhancements() {
         .Options(CheckboxOptions().Tooltip(
             "Restore pre-release behavior where defeating a Gold Skulltula will play a cutscene showing it die."));
     AddWidget(path, "Pulsate Boss Icon", WIDGET_CVAR_CHECKBOX)
-        .CVar(CVAR_ENHANCEMENT("Pulsate Boss Icon"))
+        .CVar(CVAR_ENHANCEMENT("PulsateBossIcon"))
         .Options(CheckboxOptions().Tooltip(
             "Restores an unfinished feature to pulsate the boss room icon when you are in the boss room."));
 


### PR DESCRIPTION
Removes the MenuOptionIndex and corresponding functions from Option class, it made sense at one point but now that Settings is outside of Context and the OptionValues read during gameplay are separated to an array in Context, it just adds an extra layer of complexity we no longer need. This means less steps to take when applying prefixes and dragging in ship.json files.

Also added the necessary steps to the rando preset selector to make it function correctly.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2801495556.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2801498713.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2801499971.zip)
<!--- section:artifacts:end -->