### PR TITLE
Fix Default Sidebar Index

### DIFF
--- a/soh/soh/SohGui/Menu.cpp
+++ b/soh/soh/SohGui/Menu.cpp
@@ -727,7 +727,7 @@ void Menu::DrawElement() {
 
     std::string sectionIndex = CVarGetString(sidebarCvar, "");
     if (!sidebar->contains(sectionIndex)) {
-        sectionIndex = sidebar->begin()->first;
+        sectionIndex = menuEntries.at(headerIndex).sidebarOrder.at(0);
     }
     float sectionCenterX = pos.x + (sidebarWidth / 2);
     float topY = pos.y;


### PR DESCRIPTION
by changing default index retrieval to `sidebarOrder` vectors.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2801988480.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2801990772.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2802001586.zip)
<!--- section:artifacts:end -->