### PR TITLE
Backport Actor Extension and Actor List Index from 2ship.

### DIFF
--- a/soh/soh/ActorExtension/ActorExtension.cpp
+++ b/soh/soh/ActorExtension/ActorExtension.cpp
@@ -60,7 +60,7 @@ void ActorExtension_Free(Actor* actor) {
         return;
     }
 
-    for (auto& [ id, size ] : sGlobalSizes) {
+    for (auto& [id, size] : sGlobalSizes) {
         auto it = sData.find(std::make_pair(actor, id));
         if (it != sData.end()) {
             free(it->second);

--- a/soh/soh/ActorExtension/ActorExtension.cpp
+++ b/soh/soh/ActorExtension/ActorExtension.cpp
@@ -1,0 +1,78 @@
+#include "ActorExtension.h"
+
+static ActorExtensionId sNextId = 0;
+
+struct ActorExtensionKeyHash {
+    std::size_t operator()(const std::pair<Actor*, ActorExtensionId>& key) const {
+        return std::hash<Actor*>{}(key.first) ^ (std::hash<ActorExtensionId>{}(key.second) << 1);
+    }
+};
+
+static std::unordered_map<ActorExtensionId, size_t> sGlobalSizes;
+static std::unordered_map<s16, std::unordered_map<ActorExtensionId, size_t>> sSizes;
+static std::unordered_map<std::pair<Actor*, ActorExtensionId>, void*, ActorExtensionKeyHash> sData;
+
+void* ActorExtension_Get(Actor* actor, ActorExtensionId id) {
+    if (actor == nullptr) {
+        return nullptr;
+    }
+
+    auto it = sData.find(std::make_pair(actor, id));
+    if (it == sData.end()) {
+        return nullptr;
+    }
+
+    return it->second;
+}
+
+ActorExtensionId ActorExtension_CreateForId(int16_t actorId, size_t size) {
+    ActorExtensionId id = ++sNextId;
+    sSizes[actorId][id] = size;
+    return id;
+}
+
+ActorExtensionId ActorExtension_CreateForAll(size_t size) {
+    ActorExtensionId id = ++sNextId;
+    sGlobalSizes[id] = size;
+    return id;
+}
+
+void ActorExtension_Alloc(Actor* actor, int16_t actorId) {
+    if (actor == nullptr) {
+        return;
+    }
+
+    for (auto& [id, size] : sGlobalSizes) {
+        void* data = malloc(size);
+        memset(data, 0, size);
+        sData[std::make_pair(actor, id)] = data;
+    }
+
+    for (auto& [id, size] : sSizes[actorId]) {
+        void* data = malloc(size);
+        memset(data, 0, size);
+        sData[std::make_pair(actor, id)] = data;
+    }
+}
+
+void ActorExtension_Free(Actor* actor) {
+    if (actor == nullptr) {
+        return;
+    }
+
+    for (auto& [ id, size ] : sGlobalSizes) {
+        auto it = sData.find(std::make_pair(actor, id));
+        if (it != sData.end()) {
+            free(it->second);
+            sData.erase(it);
+        }
+    }
+
+    for (auto& [id, size] : sSizes[actor->id]) {
+        auto it = sData.find(std::make_pair(actor, id));
+        if (it != sData.end()) {
+            free(it->second);
+            sData.erase(it);
+        }
+    }
+}

--- a/soh/soh/ActorExtension/ActorExtension.h
+++ b/soh/soh/ActorExtension/ActorExtension.h
@@ -1,0 +1,27 @@
+#ifndef ACTOR_EXTENSION_H
+#define ACTOR_EXTENSION_H
+
+#include <libultraship/libultraship.h>
+
+#ifdef __cplusplus
+extern "C" {
+    #include <z64actor.h>
+#endif
+
+typedef uint32_t ActorExtensionId;
+
+void* ActorExtension_Get(Actor* actor, ActorExtensionId id);
+
+// These should only ever be called once, before any actors are spawned
+ActorExtensionId ActorExtension_CreateForId(int16_t actorId, size_t size);
+ActorExtensionId ActorExtension_CreateForAll(size_t size);
+
+// Internal, you shouldn't have to touch these
+void ActorExtension_Alloc(Actor* actor, int16_t actorId);
+void ActorExtension_Free(Actor* actor);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif //ACTOR_EXTENSION_H

--- a/soh/soh/ActorExtension/ActorExtension.h
+++ b/soh/soh/ActorExtension/ActorExtension.h
@@ -5,7 +5,7 @@
 
 #ifdef __cplusplus
 extern "C" {
-    #include <z64actor.h>
+#include <z64actor.h>
 #endif
 
 typedef uint32_t ActorExtensionId;
@@ -24,4 +24,4 @@ void ActorExtension_Free(Actor* actor);
 }
 #endif
 
-#endif //ACTOR_EXTENSION_H
+#endif // ACTOR_EXTENSION_H

--- a/soh/soh/ActorExtension/ActorListIndex.cpp
+++ b/soh/soh/ActorExtension/ActorListIndex.cpp
@@ -1,0 +1,32 @@
+#include "ActorListIndex.h"
+#include "soh/ShipInit.hpp"
+#include "soh/Enhancements/game-interactor/GameInteractor.h"
+
+ActorExtensionId actorListIndexActorExt = 0;
+int16_t currentActorListIndex = -1;
+
+static RegisterShipInitFunc initFunc(
+    []() {
+        if (actorListIndexActorExt == 0) {
+            actorListIndexActorExt = ActorExtension_CreateForAll(sizeof(int16_t));
+        }
+    },
+    {});
+
+int16_t GetActorListIndex(Actor* actor) {
+    int16_t* listIndex = (int16_t*)ActorExtension_Get(actor, actorListIndexActorExt);
+    if (listIndex == nullptr) {
+        return -1;
+    }
+    return *listIndex;
+}
+
+void SetActorListIndex(Actor* actor, int16_t index) {
+    int16_t* listIndex = (int16_t*)ActorExtension_Get(actor, actorListIndexActorExt);
+
+    if (listIndex == nullptr) {
+        assert(false);
+    } else {
+        *listIndex = index;
+    }
+}

--- a/soh/soh/ActorExtension/ActorListIndex.h
+++ b/soh/soh/ActorExtension/ActorListIndex.h
@@ -1,0 +1,22 @@
+#ifndef ACTOR_LIST_INDEX_H
+#define ACTOR_LIST_INDEX_H
+
+#include <libultraship/libultraship.h>
+#include <soh/ActorExtension/ActorExtension.h>
+
+#ifdef __cplusplus
+extern "C" {
+#include "z64actor.h"
+#endif
+
+extern ActorExtensionId actorListIndexActorExt;
+extern int16_t currentActorListIndex;
+
+int16_t GetActorListIndex(Actor* actor);
+void SetActorListIndex(Actor* actor, int16_t index);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // ACTOR_LIST_INDEX_H

--- a/soh/soh/Enhancements/debugger/actorViewer.cpp
+++ b/soh/soh/Enhancements/debugger/actorViewer.cpp
@@ -26,6 +26,7 @@ extern PlayState* gPlayState;
 
 #include "textures/icon_item_static/icon_item_static.h"
 #include "textures/icon_item_24_static/icon_item_24_static.h"
+#include <soh/ActorExtension/ActorListIndex.h>
 }
 
 #define DEKUNUTS_FLOWER 10
@@ -924,6 +925,7 @@ void ActorViewerWindow::DrawElement() {
                     ImGui::Text("Category: %s", acMapping[display->category]);
                     ImGui::Text("ID: %d", display->id);
                     ImGui::Text("Parameters: %d", display->params);
+                    ImGui::Text("Actor List Index: %d", GetActorListIndex(display));
                 },
                 "Selected Actor");
             ImGui::SameLine();

--- a/soh/src/code/z_actor.c
+++ b/soh/src/code/z_actor.c
@@ -81,6 +81,7 @@
 #include "textures/place_title_cards/g_pn_56.h"
 #include "textures/place_title_cards/g_pn_57.h"
 #endif
+#include <soh/ActorExtension/ActorListIndex.h>
 
 static CollisionPoly* sCurCeilingPoly;
 static s32 sCurCeilingBgId;
@@ -2575,8 +2576,14 @@ void Actor_UpdateAll(PlayState* play, ActorContext* actorCtx) {
     if (play->numSetupActors != 0) {
         actorEntry = &play->setupActorList[0];
         for (i = 0; i < play->numSetupActors; i++) {
+            // #region SOH [ActorExtension] ActorListIndex tracking
+            currentActorListIndex = i;
+            // #endregion
             Actor_SpawnEntry(&play->actorCtx, actorEntry++, play);
         }
+        // #region SOH [ActorExtension] ActorListIndex tracking
+        currentActorListIndex = -1;
+        // #endregion
         play->numSetupActors = 0;
         GameInteractor_ExecuteOnSceneSpawnActors();
     }
@@ -3355,6 +3362,8 @@ Actor* Actor_Spawn(ActorContext* actorCtx, PlayState* play, s16 actorId, f32 pos
 
     // #region SOH [ActorExtension]
     ActorExtension_Alloc(actor, dbEntry->id);
+    SetActorListIndex(actor, currentActorListIndex);
+    currentActorListIndex = -1;
     // #endregion
 
     assert(dbEntry->numLoaded < 255);

--- a/soh/src/code/z_actor.c
+++ b/soh/src/code/z_actor.c
@@ -1,4 +1,5 @@
 #include "global.h"
+#include "soh/ActorExtension/ActorExtension.h"
 #include "vt.h"
 
 #include "overlays/actors/ovl_Arms_Hook/z_arms_hook.h"
@@ -3352,6 +3353,10 @@ Actor* Actor_Spawn(ActorContext* actorCtx, PlayState* play, s16 actorId, f32 pos
         return NULL;
     }
 
+    // #region SOH [ActorExtension]
+    ActorExtension_Alloc(actor, dbEntry->id);
+    // #endregion
+
     assert(dbEntry->numLoaded < 255);
 
     dbEntry->numLoaded++;
@@ -3493,6 +3498,10 @@ Actor* Actor_Delete(ActorContext* actorCtx, Actor* actor, PlayState* play) {
     Actor_Destroy(actor, play);
 
     newHead = Actor_RemoveFromCategory(play, actorCtx, actor);
+
+    // #region SOH [ActorExtension]
+    ActorExtension_Free(actor);
+    // #endregion
 
     ZELDA_ARENA_FREE_DEBUG(actor);
 


### PR DESCRIPTION
Backports the Actor Extension system and Actor List Index from 2ship. Currently Actor List Index is the only thing using the Actor Extension system, and the only place the Actor List Index is actually used is in the Actor Viewer, where I added the Actor List Index there specifically to show it off. Actor List Index can be used later instead of coordinates for some of the rando actor identifications, and the Actor Extension system can be used for much more in the future. For instance, I plan to use it to track what RC we are currently collecting on the player actor so that the game do different things depending on where the item came from, such as making items that came from Skulltula locations behave more like vanilla Skull Tokens.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2868237814.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2868251060.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2868298059.zip)
<!--- section:artifacts:end -->