### PR TITLE
Add OOB texture fix entry for Arrow heads

### DIFF
--- a/soh/assets/objects/gameplay_keep/gameplay_keep.h
+++ b/soh/assets/objects/gameplay_keep/gameplay_keep.h
@@ -21,6 +21,9 @@ static const ALIGN_ASSET(2) char gHilite1Tex[] = dgHilite1Tex;
 #define dgHilite2Tex "__OTR__objects/gameplay_keep/gHilite2Tex"
 static const ALIGN_ASSET(2) char gHilite2Tex[] = dgHilite2Tex;
 
+#define dgHilite2Tex_Overflow "__OTR__objects/gameplay_keep/gHilite2Tex_Overflow"
+static const ALIGN_ASSET(2) char gHilite2Tex_Overflow[] = dgHilite2Tex_Overflow;
+
 #define dgHylianShieldDesignTex "__OTR__objects/gameplay_keep/gHylianShieldDesignTex"
 static const ALIGN_ASSET(2) char gHylianShieldDesignTex[] = dgHylianShieldDesignTex;
 

--- a/soh/assets/xml/GC_MQ_D/objects/gameplay_keep.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/gameplay_keep.xml
@@ -7,6 +7,8 @@
         <Texture Name="gameplay_keepTex_04CF40" OutName="gameplay_keepTex_04CF40" Format="i8" Width="64" Height="17" Offset="0x4CF40" AddedByScript="true"/>
         <Texture Name="gHilite1Tex" OutName="hilite_1" Format="rgba16" Width="16" Height="16" Offset="0x0"/>
         <Texture Name="gHilite2Tex" OutName="hilite_2" Format="rgba16" Width="16" Height="16" Offset="0x200"/>
+        <!-- SOH [Port] Additional entry for authentic overflowed texture usage. This entry has its offset off by "one pixel" due to ZAPD not allowing duplicates -->
+        <Texture Name="gHilite2Tex_Overflow" OutName="hilite_2_overflow" Format="rgba16" Width="32" Height="32" Offset="0x1FE" />
         <Texture Name="gHylianShieldDesignTex" OutName="hylian_shield_design" Format="rgba16" Width="32" Height="64" Offset="0x400"/>
         <Texture Name="gOcarinaofTimeDesignTex" OutName="ocarina_of_time_design" Format="rgba16" Width="32" Height="16" Offset="0x1400"/>
         <Texture Name="gBottleGlassTex" OutName="bottle_glass" Format="rgba16" Width="16" Height="16" Offset="0x1800"/>

--- a/soh/assets/xml/GC_MQ_PAL_F/objects/gameplay_keep.xml
+++ b/soh/assets/xml/GC_MQ_PAL_F/objects/gameplay_keep.xml
@@ -7,6 +7,8 @@
         <Texture Name="gameplay_keepTex_04CF40" OutName="gameplay_keepTex_04CF40" Format="i8" Width="64" Height="17" Offset="0x4CF40" AddedByScript="true"/>
         <Texture Name="gHilite1Tex" OutName="hilite_1" Format="rgba16" Width="16" Height="16" Offset="0x0"/>
         <Texture Name="gHilite2Tex" OutName="hilite_2" Format="rgba16" Width="16" Height="16" Offset="0x200"/>
+        <!-- SOH [Port] Additional entry for authentic overflowed texture usage. This entry has its offset off by "one pixel" due to ZAPD not allowing duplicates -->
+        <Texture Name="gHilite2Tex_Overflow" OutName="hilite_2_overflow" Format="rgba16" Width="32" Height="32" Offset="0x1FE" />
         <Texture Name="gHylianShieldDesignTex" OutName="hylian_shield_design" Format="rgba16" Width="32" Height="64" Offset="0x400"/>
         <Texture Name="gOcarinaofTimeDesignTex" OutName="ocarina_of_time_design" Format="rgba16" Width="32" Height="16" Offset="0x1400"/>
         <Texture Name="gBottleGlassTex" OutName="bottle_glass" Format="rgba16" Width="16" Height="16" Offset="0x1800"/>

--- a/soh/assets/xml/GC_NMQ_D/objects/gameplay_keep.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/gameplay_keep.xml
@@ -7,6 +7,8 @@
         <Texture Name="gameplay_keepTex_04CF40" OutName="gameplay_keepTex_04CF40" Format="i8" Width="64" Height="17" Offset="0x4CF40" AddedByScript="true"/>
         <Texture Name="gHilite1Tex" OutName="hilite_1" Format="rgba16" Width="16" Height="16" Offset="0x0"/>
         <Texture Name="gHilite2Tex" OutName="hilite_2" Format="rgba16" Width="16" Height="16" Offset="0x200"/>
+         <!-- SOH [Port] Additional entry for authentic overflowed texture usage. This entry has its offset off by "one pixel" due to ZAPD not allowing duplicates -->
+        <Texture Name="gHilite2Tex_Overflow" OutName="hilite_2_overflow" Format="rgba16" Width="32" Height="32" Offset="0x1FE" />
         <Texture Name="gHylianShieldDesignTex" OutName="hylian_shield_design" Format="rgba16" Width="32" Height="64" Offset="0x400"/>
         <Texture Name="gOcarinaofTimeDesignTex" OutName="ocarina_of_time_design" Format="rgba16" Width="32" Height="16" Offset="0x1400"/>
         <Texture Name="gBottleGlassTex" OutName="bottle_glass" Format="rgba16" Width="16" Height="16" Offset="0x1800"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/gameplay_keep.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/gameplay_keep.xml
@@ -7,6 +7,8 @@
         <Texture Name="gameplay_keepTex_04CF40" OutName="gameplay_keepTex_04CF40" Format="i8" Width="64" Height="17" Offset="0x4CF40" AddedByScript="true"/>
         <Texture Name="gHilite1Tex" OutName="hilite_1" Format="rgba16" Width="16" Height="16" Offset="0x0"/>
         <Texture Name="gHilite2Tex" OutName="hilite_2" Format="rgba16" Width="16" Height="16" Offset="0x200"/>
+        <!-- SOH [Port] Additional entry for authentic overflowed texture usage. This entry has its offset off by "one pixel" due to ZAPD not allowing duplicates -->
+        <Texture Name="gHilite2Tex_Overflow" OutName="hilite_2_overflow" Format="rgba16" Width="32" Height="32" Offset="0x1FE" />
         <Texture Name="gHylianShieldDesignTex" OutName="hylian_shield_design" Format="rgba16" Width="32" Height="64" Offset="0x400"/>
         <Texture Name="gOcarinaofTimeDesignTex" OutName="ocarina_of_time_design" Format="rgba16" Width="32" Height="16" Offset="0x1400"/>
         <Texture Name="gBottleGlassTex" OutName="bottle_glass" Format="rgba16" Width="16" Height="16" Offset="0x1800"/>

--- a/soh/assets/xml/N64_PAL_10/objects/gameplay_keep.xml
+++ b/soh/assets/xml/N64_PAL_10/objects/gameplay_keep.xml
@@ -7,6 +7,8 @@
         <Texture Name="gameplay_keepTex_04CF40" OutName="gameplay_keepTex_04CF40" Format="i8" Width="64" Height="17" Offset="0x4CF40" AddedByScript="true"/>
         <Texture Name="gHilite1Tex" OutName="hilite_1" Format="rgba16" Width="16" Height="16" Offset="0x0"/>
         <Texture Name="gHilite2Tex" OutName="hilite_2" Format="rgba16" Width="16" Height="16" Offset="0x200"/>
+        <!-- SOH [Port] Additional entry for authentic overflowed texture usage. This entry has its offset off by "one pixel" due to ZAPD not allowing duplicates -->
+        <Texture Name="gHilite2Tex_Overflow" OutName="hilite_2_overflow" Format="rgba16" Width="32" Height="32" Offset="0x1FE" />
         <Texture Name="gHylianShieldDesignTex" OutName="hylian_shield_design" Format="rgba16" Width="32" Height="64" Offset="0x400"/>
         <Texture Name="gOcarinaofTimeDesignTex" OutName="ocarina_of_time_design" Format="rgba16" Width="32" Height="16" Offset="0x1400"/>
         <Texture Name="gBottleGlassTex" OutName="bottle_glass" Format="rgba16" Width="16" Height="16" Offset="0x1800"/>

--- a/soh/assets/xml/N64_PAL_11/objects/gameplay_keep.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/gameplay_keep.xml
@@ -7,6 +7,8 @@
         <Texture Name="gameplay_keepTex_04CF40" OutName="gameplay_keepTex_04CF40" Format="i8" Width="64" Height="17" Offset="0x4CF40" AddedByScript="true"/>
         <Texture Name="gHilite1Tex" OutName="hilite_1" Format="rgba16" Width="16" Height="16" Offset="0x0"/>
         <Texture Name="gHilite2Tex" OutName="hilite_2" Format="rgba16" Width="16" Height="16" Offset="0x200"/>
+        <!-- SOH [Port] Additional entry for authentic overflowed texture usage. This entry has its offset off by "one pixel" due to ZAPD not allowing duplicates -->
+        <Texture Name="gHilite2Tex_Overflow" OutName="hilite_2_overflow" Format="rgba16" Width="32" Height="32" Offset="0x1FE" />
         <Texture Name="gHylianShieldDesignTex" OutName="hylian_shield_design" Format="rgba16" Width="32" Height="64" Offset="0x400"/>
         <Texture Name="gOcarinaofTimeDesignTex" OutName="ocarina_of_time_design" Format="rgba16" Width="32" Height="16" Offset="0x1400"/>
         <Texture Name="gBottleGlassTex" OutName="bottle_glass" Format="rgba16" Width="16" Height="16" Offset="0x1800"/>


### PR DESCRIPTION
This adds another entry to the Authentic GFX patcher system and OOB texture toggle for arrow heads. Similar to Deku stick, Iron Knuckles and Freezards, arrow heads overflow their original texture.

When the OOB Textures fix is enabled, the arrow head DLs are patched to read the original texture at its correct size of 16x16.
When the OOB Textures fix is disabled, the arrow head DLs are patched to read a new texture entry that is the original arrow texture plus additional overflowed data to get a texture of 32x32. This overflowed texture contains pixel data from the hylian shield, matching console behavior.

Fixes #1740

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2812536234.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2812538788.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2812559275.zip)
<!--- section:artifacts:end -->