### PR TITLE
Change soh override windows to use different cvar name

### DIFF
--- a/soh/soh/SohGui/SohGui.cpp
+++ b/soh/soh/SohGui/SohGui.cpp
@@ -125,10 +125,10 @@ namespace SohGui {
             SPDLOG_ERROR("Could not find stats window");
         }
 
-        mConsoleWindow = std::make_shared<SohConsoleWindow>(CVAR_WINDOW("Console"), "Console##SoH", ImVec2(820, 630));
+        mConsoleWindow = std::make_shared<SohConsoleWindow>(CVAR_WINDOW("SohConsole"), "Console##SoH", ImVec2(820, 630));
         gui->AddGuiWindow(mConsoleWindow);
 
-        mGfxDebuggerWindow = std::make_shared<SohGfxDebuggerWindow>(CVAR_WINDOW("GfxDebugger"), "GfxDebugger##SoH", ImVec2(820, 630));
+        mGfxDebuggerWindow = std::make_shared<SohGfxDebuggerWindow>(CVAR_WINDOW("SohGfxDebugger"), "GfxDebugger##SoH", ImVec2(820, 630));
         gui->AddGuiWindow(mGfxDebuggerWindow);
 
         mInputEditorWindow = gui->GetGuiWindow("Controller Configuration");

--- a/soh/soh/SohGui/SohMenuBar.cpp
+++ b/soh/soh/SohGui/SohMenuBar.cpp
@@ -84,8 +84,6 @@ namespace SohGui {
 std::unordered_map<Ship::WindowBackend, const char*> availableWindowBackendsMap;
 Ship::WindowBackend configWindowBackend;
 
-extern std::shared_ptr<Ship::GuiWindow> mGfxDebuggerWindow;
-
 void DrawSettingsMenu() {
 }
 

--- a/soh/soh/SohGui/SohMenuDevTools.cpp
+++ b/soh/soh/SohGui/SohMenuDevTools.cpp
@@ -98,7 +98,7 @@ void SohMenu::AddMenuDevTools() {
     path.sidebarName = "Console";
     AddSidebarEntry("Dev Tools", path.sidebarName, 1);
     AddWidget(path, "Popout Console", WIDGET_WINDOW_BUTTON)
-        .CVar(CVAR_WINDOW("Console"))
+        .CVar(CVAR_WINDOW("SohConsole"))
         .WindowName("Console##SoH")
         .Options(WindowButtonOptions().Tooltip("Enables the separate Console Window."));
 
@@ -162,7 +162,7 @@ void SohMenu::AddMenuDevTools() {
     path.sidebarName = "Gfx Debugger";
     AddSidebarEntry("Dev Tools", path.sidebarName, 1);
     AddWidget(path, "Popout Gfx Debugger", WIDGET_WINDOW_BUTTON)
-        .CVar(CVAR_WINDOW("GfxDebugger"))
+        .CVar(CVAR_WINDOW("SohGfxDebugger"))
         .WindowName("GfxDebugger##SoH")
         .Options(WindowButtonOptions().Tooltip("Enables the separate Gfx Debugger Window."));
 }


### PR DESCRIPTION
The two Soh override windows for the LUS console and gfx debugger need new CVar names to avoid collision with the LUS CVar names, as before reopening Soh would cause both windows to open on boot.

Also remove an unused extern declaration.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2812557560.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2812562482.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2812579031.zip)
<!--- section:artifacts:end -->