### PR TITLE
Fix the player state flag that Tailparasan checks for for Damage Effect

### DIFF
--- a/soh/src/overlays/actors/ovl_En_Tp/z_en_tp.c
+++ b/soh/src/overlays/actors/ovl_En_Tp/z_en_tp.c
@@ -657,7 +657,7 @@ void EnTp_Update(Actor* thisx, PlayState* play) {
     Player* player = GET_PLAYER(play);
     s16 yawToWall;
 
-    if (player->stateFlags1 & PLAYER_STATE1_DAMAGED) { // Shielding
+    if (player->stateFlags1 & PLAYER_STATE1_DAMAGED) { // Damaged
         this->damageEffect = TAILPASARAN_DMGEFF_NONE;
     }
 

--- a/soh/src/overlays/actors/ovl_En_Tp/z_en_tp.c
+++ b/soh/src/overlays/actors/ovl_En_Tp/z_en_tp.c
@@ -657,7 +657,7 @@ void EnTp_Update(Actor* thisx, PlayState* play) {
     Player* player = GET_PLAYER(play);
     s16 yawToWall;
 
-    if (player->stateFlags1 & PLAYER_STATE1_SHIELDING) { // Shielding
+    if (player->stateFlags1 & PLAYER_STATE1_DAMAGED) { // Shielding
         this->damageEffect = TAILPASARAN_DMGEFF_NONE;
     }
 


### PR DESCRIPTION
Tailparasan (the electric eels in Jabu) were checking for the player state flag `PLAYER_STATE1_DAMAGED`(`(1 << 26)`), but during a documentation PR it got changed to `PLAYER_STATE1_SHIELDING` (`(1 << 22)`) by mistake, most likely because of the comment next to it that I believe is incorrect. This resulted in the player being unable to crouch stab Tailparasans, among other potential innacuracies. This PR sets it back to `PLAYER_STATE1_DAMAGED` and changes the corresponding comment to match.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2817492994.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2817500774.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2817544645.zip)
<!--- section:artifacts:end -->