### PR TITLE
More minor menu/cvar fixes

### DIFF
--- a/soh/soh/Enhancements/cosmetics/CustomLogoTitle.cpp
+++ b/soh/soh/Enhancements/cosmetics/CustomLogoTitle.cpp
@@ -117,7 +117,7 @@ extern "C" void CustomLogoTitle_Draw(TitleContext* titleContext, uint8_t logoToD
     CLOSE_DISPS(titleContext->state.gfxCtx);
 }
 
-#define CVAR_BOOTSEQUENCE_NAME CVAR_ENHANCEMENT("BootSequence")
+#define CVAR_BOOTSEQUENCE_NAME CVAR_SETTING("BootSequence")
 #define CVAR_BOOTSEQUENCE_DEFAULT BOOTSEQUENCE_DEFAULT
 #define CVAR_BOOTSEQUENCE_VALUE CVarGetInteger(CVAR_BOOTSEQUENCE_NAME, CVAR_BOOTSEQUENCE_DEFAULT)
 

--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -879,7 +879,7 @@ void CheckTrackerWindow::DrawElement() {
     mystery                     = CVarGetInteger(CVAR_RANDOMIZER_ENHANCEMENT("MysteriousShuffle"), 0);
     showLogicTooltip            = CVarGetInteger(CVAR_TRACKER_CHECK("ShowLogic"), 0);
 
-    hideShopUnshuffledChecks = CVarGetInteger(CVAR_TRACKER_CHECK("HideUnshuffledShopChecks"), 1);
+    hideShopUnshuffledChecks = CVarGetInteger(CVAR_TRACKER_CHECK("HideUnshuffledShopChecks"), 0);
     alwaysShowGS = CVarGetInteger(CVAR_TRACKER_CHECK("AlwaysShowGSLocs"), 0);
     if (CVarGetInteger(CVAR_TRACKER_CHECK("WindowType"), TRACKER_WINDOW_WINDOW) == TRACKER_WINDOW_FLOATING) {
         if (CVarGetInteger(CVAR_TRACKER_CHECK("ShowOnlyPaused"), 0) && (gPlayState == nullptr || gPlayState->pauseCtx.state == 0)) {

--- a/soh/soh/SohGui/SohMenuSettings.cpp
+++ b/soh/soh/SohGui/SohMenuSettings.cpp
@@ -354,7 +354,7 @@ void SohMenu::AddMenuSettings() {
                      .Tooltip("Which corner of the screen notifications appear in.")
                      .ComboMap(notificationPosition)
                      .DefaultIndex(3));
-    AddWidget(path, "Duration: %.0f seconds", WIDGET_CVAR_SLIDER_FLOAT)
+    AddWidget(path, "Duration (seconds):", WIDGET_CVAR_SLIDER_FLOAT)
         .CVar(CVAR_SETTING("Notifications.Duration"))
         .Options(FloatSliderOptions()
                      .Tooltip("How long notifications are displayed for.")
@@ -363,13 +363,13 @@ void SohMenu::AddMenuSettings() {
                      .Min(3.0f)
                      .Max(30.0f)
                      .DefaultValue(10.0f));
-    AddWidget(path, "Background Opacity: %.0f%%", WIDGET_CVAR_SLIDER_FLOAT)
+    AddWidget(path, "Background Opacity", WIDGET_CVAR_SLIDER_FLOAT)
         .CVar(CVAR_SETTING("Notifications.BgOpacity"))
         .Options(FloatSliderOptions()
                      .Tooltip("How opaque the background of notifications is.")
                      .DefaultValue(0.5f)
                      .IsPercentage());
-    AddWidget(path, "Size %.1f", WIDGET_CVAR_SLIDER_FLOAT)
+    AddWidget(path, "Size:", WIDGET_CVAR_SLIDER_FLOAT)
         .CVar(CVAR_SETTING("Notifications.Size"))
         .Options(FloatSliderOptions()
                      .Tooltip("How large notifications are.")


### PR DESCRIPTION
- Fix boot sequence cvar
- Remove units in labels in Notifications submenu as they're already shown in the sliders.
- Fix default for `Hide Unshuffled Shop Checks` (was changed a while ago)

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2818698152.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2818707400.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2818739743.zip)
<!--- section:artifacts:end -->