### PR TITLE
Fix Tektite texture body break parts for custom skeletons

### DIFF
--- a/soh/src/overlays/actors/ovl_En_Part/z_en_part.c
+++ b/soh/src/overlays/actors/ovl_En_Part/z_en_part.c
@@ -299,11 +299,17 @@ void EnPart_Draw(Actor* thisx, PlayState* play) {
         gSPSegment(POLY_OPA_DISP++, 0x08, func_80ACEAC0(play->state.gfxCtx, 255, 255, 255, 180, 180, 180));
         gSPSegment(POLY_OPA_DISP++, 0x09, func_80ACEAC0(play->state.gfxCtx, 225, 205, 115, 25, 20, 0));
         gSPSegment(POLY_OPA_DISP++, 0x0A, func_80ACEAC0(play->state.gfxCtx, 225, 205, 115, 25, 20, 0));
-    } else if ((thisx->params == 9) && (strcmp((const char*)this->displayList, object_tite_DL_002FF0) == 0)) {
+        // #region SOH [Port] DL references are stored as resource paths so we need to use string comparison to check
+        // for equality. Additionally, we added a fallback for checking the parent actor ID to account for mods the
+        // override the Tektite skelton
+    } else if ((thisx->params == 9) && ((strcmp((const char*)this->displayList, object_tite_DL_002FF0) == 0) ||
+                                        (thisx->parent && thisx->parent->id == ACTOR_EN_TITE))) {
         gSPSegment(POLY_OPA_DISP++, 0x08, object_tite_Tex_001300);
         gSPSegment(POLY_OPA_DISP++, 0x09, object_tite_Tex_001700);
         gSPSegment(POLY_OPA_DISP++, 0x0A, object_tite_Tex_001900);
-    } else if ((thisx->params == 10) && (strcmp((const char*)this->displayList, object_tite_DL_002FF0) == 0)) {
+    } else if ((thisx->params == 10) && ((strcmp((const char*)this->displayList, object_tite_DL_002FF0) == 0) ||
+                                         (thisx->parent && thisx->parent->id == ACTOR_EN_TITE))) {
+        // #endregion
         gSPSegment(POLY_OPA_DISP++, 0x08, object_tite_Tex_001B00);
         gSPSegment(POLY_OPA_DISP++, 0x09, object_tite_Tex_001F00);
         gSPSegment(POLY_OPA_DISP++, 0x0A, object_tite_Tex_002100);

--- a/soh/src/overlays/actors/ovl_En_Part/z_en_part.c
+++ b/soh/src/overlays/actors/ovl_En_Part/z_en_part.c
@@ -303,12 +303,12 @@ void EnPart_Draw(Actor* thisx, PlayState* play) {
         // for equality. Additionally, we added a fallback for checking the parent actor ID to account for mods the
         // override the Tektite skelton
     } else if ((thisx->params == 9) && ((strcmp((const char*)this->displayList, object_tite_DL_002FF0) == 0) ||
-                                        (thisx->parent && thisx->parent->id == ACTOR_EN_TITE))) {
+                                        (thisx->parent != NULL && thisx->parent->id == ACTOR_EN_TITE))) {
         gSPSegment(POLY_OPA_DISP++, 0x08, object_tite_Tex_001300);
         gSPSegment(POLY_OPA_DISP++, 0x09, object_tite_Tex_001700);
         gSPSegment(POLY_OPA_DISP++, 0x0A, object_tite_Tex_001900);
     } else if ((thisx->params == 10) && ((strcmp((const char*)this->displayList, object_tite_DL_002FF0) == 0) ||
-                                         (thisx->parent && thisx->parent->id == ACTOR_EN_TITE))) {
+                                         (thisx->parent != NULL && thisx->parent->id == ACTOR_EN_TITE))) {
         // #endregion
         gSPSegment(POLY_OPA_DISP++, 0x08, object_tite_Tex_001B00);
         gSPSegment(POLY_OPA_DISP++, 0x09, object_tite_Tex_001F00);


### PR DESCRIPTION
For Tektites, the body breakpart system looks for a specific tektite DL by name to decide if the blue or red body textures should be loaded into segment positions. We've already changed this in the past to do a string comparison because of how our resources work, but this check fails whenever a custom skeleton is used for Tektites that does not use the exact same DL names.

To help with mod support, I've added a fallback to just check that the parent actor has the Tektite ID. Also add region comments to clarify the port change.

I believe this should be safe as even I don't think any other breakpart should trigger this (considering the param and parent relationship), and even if it did, all that would happen is the segment values would be unused.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2819779946.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2819784425.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2819808346.zip)
<!--- section:artifacts:end -->