### PR TITLE
Fix freezard graphics crash with enemy health scaling

### DIFF
--- a/soh/src/overlays/actors/ovl_En_Fz/z_en_fz.c
+++ b/soh/src/overlays/actors/ovl_En_Fz/z_en_fz.c
@@ -720,6 +720,15 @@ void EnFz_Draw(Actor* thisx, PlayState* play) {
 
     index = (6 - this->actor.colChkInfo.health) >> 1;
 
+    // SOH [Enhancement] - With enemy health scaling, the Freezards health could cause an index out of bounds for the
+    // displayLists, so we need to recompute the index based on the scaled health (using the maximum health value) and
+    // clamp the final result for safety.
+    if (CVarGetInteger(CVAR_ENHANCEMENT("EnemySizeScalesHealth"), 0)) {
+        u8 scaledHealth = (u8)(((f32)this->actor.colChkInfo.health / this->actor.maximumHealth) * 6);
+        index = (6 - scaledHealth) >> 1;
+        index = CLAMP(index, 0, 2);
+    }
+
     OPEN_DISPS(play->state.gfxCtx);
 
     if (this->actor.colChkInfo.health == 0) {


### PR DESCRIPTION
Freezards use a calculation of their health as an index for which display list to use for their body. If the health value is too large, then the index would go out of bounds and place garbage into the graphics instructions.

To fix this, a check for enemy health scaling is used and the index recalculated by scaling the health from a ratio of the "new" maximum health, back down to the original max of 6, and then a final safety clamp to get the index into range.

This should make it so that Freezards broken state will linearly match the scaled health.

Fixes #5225

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2834081283.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2834087747.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2834125962.zip)
<!--- section:artifacts:end -->