### PR TITLE
ignore out of bounds entrance overrides in json

### DIFF
--- a/soh/soh/Enhancements/randomizer/entrance.cpp
+++ b/soh/soh/Enhancements/randomizer/entrance.cpp
@@ -1643,7 +1643,7 @@ void EntranceShuffler::ParseJson(nlohmann::json spoilerFileJson) {
     try {
         nlohmann::json entrancesJson = spoilerFileJson["entrances"];
         size_t i = 0;
-        for (auto it = entrancesJson.begin(); it != entrancesJson.end(); ++it, i++) {
+        for (auto it = entrancesJson.begin(); it != entrancesJson.end() && i < entranceOverrides.size(); ++it, i++) {
             nlohmann::json entranceJson = *it;
             for (auto entranceIt = entranceJson.begin(); entranceIt != entranceJson.end(); ++entranceIt) {
                 if (entranceIt.key() == "type") {


### PR DESCRIPTION
was having segfault when using settings from door shuffle on develop

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2847081800.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2847085921.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2847090210.zip)
<!--- section:artifacts:end -->