### PR TITLE
Fix early eyeball frog source adaption in King Zora

### DIFF
--- a/soh/src/overlays/actors/ovl_En_Kz/z_en_kz.c
+++ b/soh/src/overlays/actors/ovl_En_Kz/z_en_kz.c
@@ -125,43 +125,42 @@ u16 EnKz_GetText(PlayState* play, Actor* thisx) {
 
 s16 func_80A9C6C0(PlayState* play, Actor* thisx) {
     EnKz* this = (EnKz*)thisx;
-    s16 ret = NPC_TALK_STATE_TALKING;
+    s16 talkState = NPC_TALK_STATE_TALKING;
 
     switch (Message_GetState(&play->msgCtx)) {
         case TEXT_STATE_DONE:
             if (CVarGetInteger(CVAR_ENHANCEMENT("EarlyEyeballFrog"), 0)) {
                 if (Message_ShouldAdvance(play)) {
-                    ret = NPC_TALK_STATE_ITEM_GIVEN;
+                    talkState = NPC_TALK_STATE_ITEM_GIVEN;
                 }
             } else {
-                ret = NPC_TALK_STATE_IDLE;
+                talkState = NPC_TALK_STATE_IDLE;
                 switch (this->actor.textId) {
                     case 0x4012:
-                        Flags_SetInfTable(INFTABLE_139);
-                        ret = NPC_TALK_STATE_ACTION;
+                        SET_INFTABLE(INFTABLE_139);
+                        talkState = NPC_TALK_STATE_ACTION;
                         break;
                     case 0x401B:
-                        ret = !Message_ShouldAdvance(play) ? NPC_TALK_STATE_TALKING : NPC_TALK_STATE_ACTION;
+                        talkState = !Message_ShouldAdvance(play) ? NPC_TALK_STATE_TALKING : NPC_TALK_STATE_ACTION;
                         break;
                     case 0x401F:
-                        Flags_SetInfTable(INFTABLE_139);
+                        SET_INFTABLE(INFTABLE_139);
                         break;
                 }
             }
             break;
         case TEXT_STATE_CLOSING:
             if (CVarGetInteger(CVAR_ENHANCEMENT("EarlyEyeballFrog"), 0)) {
-                ret = NPC_TALK_STATE_IDLE;
+                talkState = NPC_TALK_STATE_IDLE;
                 switch (this->actor.textId) {
                     case 0x4012:
-                        Flags_SetInfTable(INFTABLE_139);
-                        ret = NPC_TALK_STATE_ACTION;
-                        break;
+                        SET_INFTABLE(INFTABLE_139);
+                        FALLTHROUGH;
                     case 0x401B:
-                        ret = !Message_ShouldAdvance(play) ? NPC_TALK_STATE_TALKING : NPC_TALK_STATE_ACTION;
+                        talkState = NPC_TALK_STATE_ACTION;
                         break;
                     case 0x401F:
-                        Flags_SetInfTable(INFTABLE_139);
+                        SET_INFTABLE(INFTABLE_139);
                         break;
                 }
             }
@@ -187,7 +186,7 @@ s16 func_80A9C6C0(PlayState* play, Actor* thisx) {
                     if (!CVarGetInteger(CVAR_ENHANCEMENT("EarlyEyeballFrog"), 0)) {
                         EnKz_SetupGetItem(this, play);
                     }
-                    ret = NPC_TALK_STATE_ACTION;
+                    talkState = NPC_TALK_STATE_ACTION;
                 } else {
                     this->actor.textId = 0x4016;
                     Message_ContinueTextbox(play, this->actor.textId);
@@ -196,7 +195,7 @@ s16 func_80A9C6C0(PlayState* play, Actor* thisx) {
             break;
         case TEXT_STATE_EVENT:
             if (Message_ShouldAdvance(play)) {
-                ret = NPC_TALK_STATE_ACTION;
+                talkState = NPC_TALK_STATE_ACTION;
             }
             break;
         case TEXT_STATE_NONE:
@@ -206,7 +205,7 @@ s16 func_80A9C6C0(PlayState* play, Actor* thisx) {
         case TEXT_STATE_9:
             break;
     }
-    return ret;
+    return talkState;
 }
 
 void EnKz_UpdateEyes(EnKz* this) {

--- a/soh/src/overlays/actors/ovl_En_Kz/z_en_kz.c
+++ b/soh/src/overlays/actors/ovl_En_Kz/z_en_kz.c
@@ -137,14 +137,14 @@ s16 func_80A9C6C0(PlayState* play, Actor* thisx) {
                 talkState = NPC_TALK_STATE_IDLE;
                 switch (this->actor.textId) {
                     case 0x4012:
-                        SET_INFTABLE(INFTABLE_139);
+                        Flags_SetInfTable(INFTABLE_139);
                         talkState = NPC_TALK_STATE_ACTION;
                         break;
                     case 0x401B:
                         talkState = !Message_ShouldAdvance(play) ? NPC_TALK_STATE_TALKING : NPC_TALK_STATE_ACTION;
                         break;
                     case 0x401F:
-                        SET_INFTABLE(INFTABLE_139);
+                        Flags_SetInfTable(INFTABLE_139);
                         break;
                 }
             }
@@ -154,13 +154,13 @@ s16 func_80A9C6C0(PlayState* play, Actor* thisx) {
                 talkState = NPC_TALK_STATE_IDLE;
                 switch (this->actor.textId) {
                     case 0x4012:
-                        SET_INFTABLE(INFTABLE_139);
+                        Flags_SetInfTable(INFTABLE_139);
                         FALLTHROUGH;
                     case 0x401B:
                         talkState = NPC_TALK_STATE_ACTION;
                         break;
                     case 0x401F:
-                        SET_INFTABLE(INFTABLE_139);
+                        Flags_SetInfTable(INFTABLE_139);
                         break;
                 }
             }


### PR DESCRIPTION
fixes #5249

A case statement in early eyeball frog was improperly copied, causing issues for Ruto's letter which broke the actor unless skip text was used.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2847160391.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2847163174.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2847172375.zip)
<!--- section:artifacts:end -->