### PR TITLE
Fix messages crashing when no ntsc game is loaded

### DIFF
--- a/soh/include/functions.h
+++ b/soh/include/functions.h
@@ -901,7 +901,7 @@ s32 Jpeg_Decode(void* data, void* zbuffer, void* workBuff, u32 workSize);
 void KaleidoSetup_Update(PlayState* play);
 void KaleidoSetup_Init(PlayState* play);
 void KaleidoSetup_Destroy(PlayState* play);
-void func_8006EE50(Font* font, u16 arg1, u16 arg2);
+void Font_LoadCharWide(Font* font, u16 arg1, u16 arg2);
 void Font_LoadChar(Font* font, u8 character, u16 codePointIndex);
 void Font_LoadMessageBoxIcon(Font* font, u16 icon);
 void Font_LoadOrderedFont(Font* font);

--- a/soh/src/code/z_kanfont.c
+++ b/soh/src/code/z_kanfont.c
@@ -4144,7 +4144,11 @@ const char* msgStaticTbl[] =
 };
 // #endregion
 
-void func_8006EE50(Font* font, u16 character, u16 codePointIndex) {
+/**
+ * Loads a texture from kanji for the requested `character` into the character texture buffer
+ * at `codePointIndex`. The value of `character` is the SHIFT-JIS encoding of the character.
+ */
+void Font_LoadCharWide(Font* font, u16 character, u16 codePointIndex) {
     // DmaMgr_RequestSync(&font->charTexBuf[codePointIndex], _kanjiSegmentStart + Kanji_OffsetFromShiftJIS(character), 0x80);
 
     // #region SOH [NTSC]

--- a/soh/src/code/z_kanfont.c
+++ b/soh/src/code/z_kanfont.c
@@ -7,6 +7,9 @@
 #include "textures/kanji/kanji.h"
 #include "textures/message_static/message_static.h"
 
+// SOH [NTSC]
+extern MessageTableEntry* sJpnMessageEntryTablePtr;
+
 // #region SOH [Port] Asset tables we can pull from instead of from ROM
 const char* fontTbl[140] =
 {
@@ -4142,8 +4145,15 @@ const char* msgStaticTbl[] =
 // #endregion
 
 void func_8006EE50(Font* font, u16 character, u16 codePointIndex) {
-    // #region SOH [NTSC]
     // DmaMgr_RequestSync(&font->charTexBuf[codePointIndex], _kanjiSegmentStart + Kanji_OffsetFromShiftJIS(character), 0x80);
+
+    // #region SOH [NTSC]
+    // This function is called even for non-nstc, but this function would be empty for non-ntsc.
+    // To simulate that, we check if the jpn message table is loaded and if not immediately return.
+    if (sJpnMessageEntryTablePtr == NULL) {
+        return;
+    }
+
     s32 charIndex = Kanji_OffsetFromShiftJIS(character);
     charIndex /= FONT_CHAR_TEX_SIZE;
     if (charIndex < ARRAY_COUNT(kanjiFontTbl))
@@ -4213,8 +4223,6 @@ void Font_LoadOrderedFont(Font* font) {
 }
 
 // #region SOH [NTSC]
-extern MessageTableEntry* sJpnMessageEntryTablePtr;
-
 void Font_LoadOrderedFontNTSC(Font* font) {
     s32 len;
     s32 size;

--- a/soh/src/code/z_message_PAL.c
+++ b/soh/src/code/z_message_PAL.c
@@ -1995,17 +1995,17 @@ void Message_DecodeJPN(PlayState* play) {
             }
 
             for (i = 0; i < 4; i++) {
-                func_8006EE50(font, digits[i] + 0x824F, charTexIdx);
+                Font_LoadCharWide(font, digits[i] + 0x824F, charTexIdx);
                 charTexIdx += FONT_CHAR_TEX_SIZE;
                 msgCtx->msgBufDecodedWide[decodedBufPos] = digits[i] + 0x824F;
                 decodedBufPos++;
                 if (i == 1) {
-                    func_8006EE50(font, 0x95AA, charTexIdx);
+                    Font_LoadCharWide(font, 0x95AA, charTexIdx);
                     charTexIdx += FONT_CHAR_TEX_SIZE;
                     msgCtx->msgBufDecodedWide[decodedBufPos] = 0x95AA;
                     decodedBufPos++;
                 } else if (i == 3) {
-                    func_8006EE50(font, 0x9562, charTexIdx);
+                    Font_LoadCharWide(font, 0x9562, charTexIdx);
                     charTexIdx += FONT_CHAR_TEX_SIZE;
                     msgCtx->msgBufDecodedWide[decodedBufPos] = 0x9562;
                 }
@@ -2032,7 +2032,7 @@ void Message_DecodeJPN(PlayState* play) {
                     loadChar = true;
                 }
                 if (loadChar) {
-                    func_8006EE50(font, digits[i] + 0x824F, charTexIdx);
+                    Font_LoadCharWide(font, digits[i] + 0x824F, charTexIdx);
                     charTexIdx += FONT_CHAR_TEX_SIZE;
                     msgCtx->msgBufDecodedWide[decodedBufPos] = digits[i] + 0x824F;
                     decodedBufPos++;
@@ -2058,7 +2058,7 @@ void Message_DecodeJPN(PlayState* play) {
                     loadChar = true;
                 }
                 if (loadChar) {
-                    func_8006EE50(font, digits[i] + 0x824F, charTexIdx);
+                    Font_LoadCharWide(font, digits[i] + 0x824F, charTexIdx);
                     charTexIdx += FONT_CHAR_TEX_SIZE;
                     msgCtx->msgBufDecodedWide[decodedBufPos] = digits[i] + 0x824F;
                     decodedBufPos++;
@@ -2076,7 +2076,7 @@ void Message_DecodeJPN(PlayState* play) {
 
             for (i = 0; i < 2; i++) {
                 if (i == 1 || digits[i] != 0) {
-                    func_8006EE50(font, digits[i] + 0x824F, charTexIdx);
+                    Font_LoadCharWide(font, digits[i] + 0x824F, charTexIdx);
                     charTexIdx += FONT_CHAR_TEX_SIZE;
                     msgCtx->msgBufDecodedWide[decodedBufPos] = digits[i] + 0x824F;
                     decodedBufPos++;
@@ -2118,7 +2118,7 @@ void Message_DecodeJPN(PlayState* play) {
                             loadChar = true;
                         }
                         if (loadChar) {
-                            func_8006EE50(font, digits[i] + 0x824F, charTexIdx);
+                            Font_LoadCharWide(font, digits[i] + 0x824F, charTexIdx);
                             charTexIdx += FONT_CHAR_TEX_SIZE;
                             msgCtx->msgBufDecodedWide[decodedBufPos] = digits[i] + 0x824F;
                             decodedBufPos++;
@@ -2148,17 +2148,17 @@ void Message_DecodeJPN(PlayState* play) {
                     }
 
                     for (i = 0; i < 4; i++) {
-                        func_8006EE50(font, digits[i] + 0x824F, charTexIdx);
+                        Font_LoadCharWide(font, digits[i] + 0x824F, charTexIdx);
                         charTexIdx += FONT_CHAR_TEX_SIZE;
                         msgCtx->msgBufDecodedWide[decodedBufPos] = digits[i] + 0x824F;
                         decodedBufPos++;
                         if (i == 1) {
-                            func_8006EE50(font, 0x95AA, charTexIdx);
+                            Font_LoadCharWide(font, 0x95AA, charTexIdx);
                             charTexIdx += FONT_CHAR_TEX_SIZE;
                             msgCtx->msgBufDecodedWide[decodedBufPos] = 0x95AA;
                             decodedBufPos++;
                         } else if (i == 3) {
-                            func_8006EE50(font, 0x9562, charTexIdx);
+                            Font_LoadCharWide(font, 0x9562, charTexIdx);
                             charTexIdx += FONT_CHAR_TEX_SIZE;
                             msgCtx->msgBufDecodedWide[decodedBufPos] = 0x9562;
                         }
@@ -2182,17 +2182,17 @@ void Message_DecodeJPN(PlayState* play) {
             }
 
             for (i = 0; i < 4; i++) {
-                func_8006EE50(font, digits[i] + 0x824F, charTexIdx);
+                Font_LoadCharWide(font, digits[i] + 0x824F, charTexIdx);
                 charTexIdx += FONT_CHAR_TEX_SIZE;
                 msgCtx->msgBufDecodedWide[decodedBufPos] = digits[i] + 0x824F;
                 decodedBufPos++;
                 if (i == 1) {
-                    func_8006EE50(font, 0x8E9E, charTexIdx);
+                    Font_LoadCharWide(font, 0x8E9E, charTexIdx);
                     charTexIdx += FONT_CHAR_TEX_SIZE;
                     msgCtx->msgBufDecodedWide[decodedBufPos] = 0x8E9E;
                     decodedBufPos++;
                 } else if (i == 3) {
-                    func_8006EE50(font, 0x95AA, charTexIdx);
+                    Font_LoadCharWide(font, 0x95AA, charTexIdx);
                     charTexIdx += FONT_CHAR_TEX_SIZE;
                     msgCtx->msgBufDecodedWide[decodedBufPos] = 0x95AA;
                 }
@@ -2231,7 +2231,7 @@ void Message_DecodeJPN(PlayState* play) {
                 msgCtx->choiceNum = 3;
                 R_TEXT_INIT_XPOS += 32;
             } else if (curChar != MESSAGE_SPACE_JPN) {
-                func_8006EE50(font, curChar, charTexIdx);
+                Font_LoadCharWide(font, curChar, charTexIdx);
                 charTexIdx += FONT_CHAR_TEX_SIZE;
             }
         }
@@ -3011,7 +3011,7 @@ void Message_StartOcarina(PlayState* play, u16 ocarinaActionId) {
         Interface_ChangeAlpha(1);
     }
     for (k = 0, j = 0; j < 48; j++) {
-        func_8006EE50(&play->msgCtx.font, 0x8140, k);
+        Font_LoadCharWide(&play->msgCtx.font, 0x8140, k);
         k += FONT_CHAR_TEX_SIZE;
     }
 }
@@ -3328,7 +3328,7 @@ void Message_DrawMain(PlayState* play, Gfx** p) {
             case MSGMODE_TEXT_CONTINUING:
                 if (msgCtx->stateTimer == 1) {
                     for (j = 0, i = 0; i < 48; i++) {
-                        func_8006EE50(&play->msgCtx.font, 0x8140, j);
+                        Font_LoadCharWide(&play->msgCtx.font, 0x8140, j);
                         j += FONT_CHAR_TEX_SIZE;
                     }
                     if (gSaveContext.language == LANGUAGE_JPN && !sTextIsCredits && !sDisplayNextMessageAsEnglish) {

--- a/soh/src/code/z_message_PAL.c
+++ b/soh/src/code/z_message_PAL.c
@@ -3010,8 +3010,9 @@ void Message_StartOcarina(PlayState* play, u16 ocarinaActionId) {
         gSaveContext.unk_13EA = 0;
         Interface_ChangeAlpha(1);
     }
-    for (k = 0, j = 0; j < 48; j++, k += 0x80) {
+    for (k = 0, j = 0; j < 48; j++) {
         func_8006EE50(&play->msgCtx.font, 0x8140, k);
+        k += FONT_CHAR_TEX_SIZE;
     }
 }
 
@@ -3326,8 +3327,9 @@ void Message_DrawMain(PlayState* play, Gfx** p) {
                 break;
             case MSGMODE_TEXT_CONTINUING:
                 if (msgCtx->stateTimer == 1) {
-                    for (j = 0, i = 0; i < 48; i++, j += 0x80) {
+                    for (j = 0, i = 0; i < 48; i++) {
                         func_8006EE50(&play->msgCtx.font, 0x8140, j);
+                        j += FONT_CHAR_TEX_SIZE;
                     }
                     if (gSaveContext.language == LANGUAGE_JPN && !sTextIsCredits && !sDisplayNextMessageAsEnglish) {
                         Message_DrawTextJPN(play, &gfx);


### PR DESCRIPTION
This func is used by NTSC messages to load the char texture, but it is also used in some spots for non-NTSC messages.
On decomp, this methods logic is ifdef'ed out for non-ntsc leaving it as an empty function.

To simulate that, I added an early return check for having the japan message table loaded.

Also matched the func name to decomp and the loops in the message code.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2847664048.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2847673186.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2847678812.zip)
<!--- section:artifacts:end -->