### PR TITLE
Hookify sequence name overlay and convert it to new Notification System

### DIFF
--- a/soh/soh/Enhancements/audio/AudioEditor.cpp
+++ b/soh/soh/Enhancements/audio/AudioEditor.cpp
@@ -524,19 +524,11 @@ void AudioEditor::DrawElement() {
                                  "the volume changing provides. If toggling this while in the Lost Woods, reload "
                                  "the area for the effect to kick in."));
                 UIWidgets::CVarCheckbox(
-                    "Display Sequence Name on Overlay", CVAR_AUDIO("SeqNameOverlay"),
+                    "Display Sequence Name in Notifications", CVAR_AUDIO("SeqNameNotification"),
                     UIWidgets::CheckboxOptions()
                         .Color(THEME_COLOR)
-                        .Tooltip("Displays the name of the current sequence in the corner of the screen whenever a new "
-                                 "sequence "
-                                 "is loaded to the main sequence player (does not apply to fanfares or enemy BGM)."));
-                UIWidgets::CVarSliderInt("Overlay Duration: %d seconds", CVAR_AUDIO("SeqNameOverlayDuration"),
-                                         UIWidgets::IntSliderOptions()
-                                             .Min(1)
-                                             .Max(10)
-                                             .DefaultValue(5)
-                                             .Size(ImVec2(300.0f, 0.0f))
-                                             .Color(THEME_COLOR));
+                        .Tooltip("Emits a notification with the current song name whenever it changes. "
+                                 "(does not apply to fanfares or enemy BGM)."));
                 UIWidgets::CVarSliderFloat("Link's voice pitch multiplier", CVAR_AUDIO("LinkVoiceFreqMultiplier"),
                                            UIWidgets::FloatSliderOptions()
                                                .IsPercentage()

--- a/soh/soh/Enhancements/audio/AudioHooks.cpp
+++ b/soh/soh/Enhancements/audio/AudioHooks.cpp
@@ -28,8 +28,7 @@ void NotifySequenceName(int32_t playerIdx, int32_t seqId) {
         const char* sequenceName = AudioCollection::Instance->GetSequenceName(seqId);
         if (sequenceName != NULL) {
             Notification::Emit({
-                .itemIcon = GetTextureForItemId(ITEM_SONG_LULLABY),
-                .message = sequenceName,
+                .message = ICON_FA_MUSIC " " + std::string(sequenceName),
                 .mute = true,
             });
         }

--- a/soh/soh/Enhancements/audio/AudioHooks.cpp
+++ b/soh/soh/Enhancements/audio/AudioHooks.cpp
@@ -36,8 +36,8 @@ void NotifySequenceName(int32_t playerIdx, int32_t seqId) {
     }
 }
 
-void RegisterAudioHooks() {
+void RegisterAudioNotificationHooks() {
     COND_HOOK(OnSeqPlayerInit, CVAR_SEQOVERLAY_VALUE, NotifySequenceName);
 }
 
-static RegisterShipInitFunc initFunc(RegisterAudioHooks, { CVAR_SEQOVERLAY_NAME });
+static RegisterShipInitFunc notifInitFunc(RegisterAudioNotificationHooks, { CVAR_SEQOVERLAY_NAME });

--- a/soh/soh/Enhancements/audio/AudioHooks.cpp
+++ b/soh/soh/Enhancements/audio/AudioHooks.cpp
@@ -1,0 +1,43 @@
+#include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
+#include "soh/ShipInit.hpp"
+#include "AudioCollection.h"
+#include <soh/Notification/Notification.h>
+#include <soh/SohGui/ImGuiUtils.h>
+
+extern "C" {
+#include "variables.h"
+
+extern PlayState* gPlayState;
+}
+
+#define CVAR_SEQOVERLAY_NAME CVAR_AUDIO("SeqNameOverlay")
+#define CVAR_SEQOVERLAY_DEFAULT 0
+#define CVAR_SEQOVERLAY_VALUE CVarGetInteger(CVAR_SEQOVERLAY_NAME, CVAR_SEQOVERLAY_DEFAULT)
+
+void NotifySequenceName(int32_t playerIdx, int32_t seqId) {
+    // Keep track of the previous sequence/scene so we don't repeat notifications
+    static uint16_t previousSeqId = UINT16_MAX;
+    static int16_t previousSceneNum = INT16_MAX;
+    if (playerIdx == SEQ_PLAYER_BGM_MAIN &&
+        (seqId != previousSeqId || (gPlayState != NULL && gPlayState->sceneNum != previousSceneNum))) {
+        
+        previousSeqId = seqId;
+        if (gPlayState != NULL) {
+            previousSceneNum = gPlayState->sceneNum;
+        }
+        const char* sequenceName = AudioCollection::Instance->GetSequenceName(seqId);
+        if (sequenceName != NULL) {
+            Notification::Emit({
+                .itemIcon = GetTextureForItemId(ITEM_SONG_LULLABY),
+                .message = sequenceName,
+                .mute = true,
+            });
+        }
+    }
+}
+
+void RegisterAudioHooks() {
+    COND_HOOK(OnSeqPlayerInit, CVAR_SEQOVERLAY_VALUE, NotifySequenceName);
+}
+
+static RegisterShipInitFunc initFunc(RegisterAudioHooks, { CVAR_SEQOVERLAY_NAME });

--- a/soh/soh/Enhancements/audio/AudioHooks.cpp
+++ b/soh/soh/Enhancements/audio/AudioHooks.cpp
@@ -10,7 +10,7 @@ extern "C" {
 extern PlayState* gPlayState;
 }
 
-#define CVAR_SEQOVERLAY_NAME CVAR_AUDIO("SeqNameOverlay")
+#define CVAR_SEQOVERLAY_NAME CVAR_AUDIO("SeqNameNotification")
 #define CVAR_SEQOVERLAY_DEFAULT 0
 #define CVAR_SEQOVERLAY_VALUE CVarGetInteger(CVAR_SEQOVERLAY_NAME, CVAR_SEQOVERLAY_DEFAULT)
 

--- a/soh/soh/Enhancements/game-interactor/GameInteractor_HookTable.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor_HookTable.h
@@ -67,3 +67,6 @@ DEFINE_HOOK(OnSetGameLanguage, ());
 DEFINE_HOOK(OnFileDropped, (std::string filePath));
 DEFINE_HOOK(OnAssetAltChange, ());
 DEFINE_HOOK(OnKaleidoUpdate, ());
+
+// Audio
+DEFINE_HOOK(OnSeqPlayerInit, (int32_t playerIdx, int32_t seqId));

--- a/soh/soh/Enhancements/game-interactor/GameInteractor_Hooks.cpp
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor_Hooks.cpp
@@ -290,3 +290,8 @@ void GameInteractor_RegisterOnAssetAltChange(void (*fn)(void)) {
 void GameInteractor_ExecuteOnKaleidoUpdate() {
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnKaleidoUpdate>();
 }
+
+// Mark: Audio
+void GameInteractor_ExecuteOnSeqPlayerInit(int32_t playerIdx, int32_t seqId) {
+    GameInteractor::Instance->ExecuteHooks<GameInteractor::OnSeqPlayerInit>(playerIdx, seqId);
+}

--- a/soh/soh/Enhancements/game-interactor/GameInteractor_Hooks.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor_Hooks.h
@@ -79,6 +79,9 @@ void GameInteractor_RegisterOnAssetAltChange(void (*fn)(void));
 //Mark: - Pause Menu
 void GameInteractor_ExecuteOnKaleidoUpdate();
 
+//Mark: - Audio
+void GameInteractor_ExecuteOnSeqPlayerInit(int32_t playerIdx, int32_t seqId);
+
 #ifdef __cplusplus
 }
 #endif

--- a/soh/soh/Notification/Notification.cpp
+++ b/soh/soh/Notification/Notification.cpp
@@ -133,7 +133,9 @@ void Emit(Options notification) {
         notification.remainingTime = CVarGetFloat(CVAR_SETTING("Notifications.Duration"), 10.0f);
     }
     notifications.push_back(notification);
-    Audio_PlaySoundGeneral(NA_SE_SY_METRONOME, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
+    if (!notification.mute) {
+        Audio_PlaySoundGeneral(NA_SE_SY_METRONOME, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
+    }
 }
 
 } // namespace Notification

--- a/soh/soh/Notification/Notification.h
+++ b/soh/soh/Notification/Notification.h
@@ -17,6 +17,7 @@ struct Options {
     std::string suffix = "";
     ImVec4 suffixColor = ImVec4(1.0f, 0.5f, 0.5f, 1.0f);
     float remainingTime = 0.0f; // Seconds
+    bool mute = false; // whether notification should make a noise
 };
 
 class Window : public Ship::GuiWindow {

--- a/soh/soh/config/ConfigMigrators.h
+++ b/soh/soh/config/ConfigMigrators.h
@@ -373,8 +373,7 @@ namespace SOH {
         { MigrationAction::Rename, "gGfxPrintCharSpacing", "gDeveloperTools.GfxPrintChar.Spacing" },
         { MigrationAction::Rename, "gEnemyBGMDisable", "gAudioEditor.EnemyBGMDisable" },
         { MigrationAction::Rename, "gLostWoodsConsistentVolume", "gAudioEditor.LostWoodsConsistentVolume" },
-        { MigrationAction::Rename, "gSeqNameOverlay", "gAudioEditor.SeqNameOverlay" },
-        { MigrationAction::Rename, "gSeqNameOverlayDuration", "gAudioEditor.SeqNameOverlayDuration" },
+        { MigrationAction::Rename, "gSeqNameOverlay", "gAudioEditor.SeqNameNotification" },
         { MigrationAction::Rename, "gLinkVoiceFreqMultiplier", "gAudioEditor.LinkVoiceFreqMultiplier" },
         { MigrationAction::Rename, "gExperimentalOctaveDrop", "gAudioEditor.ExperimentalOctaveDrop" },
         { MigrationAction::Rename, "gCosmetics.Hud_AButton", "gCosmetics.HUD.AButton" },
@@ -1434,5 +1433,6 @@ namespace SOH {
         { MigrationAction::Remove, "gGameControlEditorEnabled" },
         { MigrationAction::Remove, "gPreset0" },
         { MigrationAction::Remove, "gPreset1" },
+        { MigrationAction::Remove, "gSeqNameOverlayDuration" },
     };
 }

--- a/soh/src/code/audio_load.c
+++ b/soh/src/code/audio_load.c
@@ -8,6 +8,7 @@
 #include "soh/Enhancements/audio/AudioCollection.h"
 #include "soh/Enhancements/audio/AudioEditor.h"
 #include "soh/ResourceManagerHelpers.h"
+#include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
 #define MK_ASYNC_MSG(retData, tableType, id, status) (((retData) << 24) | ((tableType) << 16) | ((id) << 8) | (status))
 #define ASYNC_TBLTYPE(v) ((u8)(v >> 16))
@@ -629,23 +630,8 @@ s32 AudioLoad_SyncInitSeqPlayerInternal(s32 playerIdx, s32 seqId, s32 arg2) {
     
     AudioSeq_SkipForwardSequence(seqPlayer);
     //! @bug missing return (but the return value is not used so it's not UB)
-    
-    // Keep track of the previous sequence/scene so we don't repeat notifications
-    static uint16_t previousSeqId = UINT16_MAX;
-    static int16_t previousSceneNum = INT16_MAX;
-    if (CVarGetInteger(CVAR_AUDIO("SeqNameOverlay"), 0) &&
-        playerIdx == SEQ_PLAYER_BGM_MAIN &&
-        (seqId != previousSeqId || (gPlayState != NULL && gPlayState->sceneNum != previousSceneNum))) {
-        
-        previousSeqId = seqId;
-        if (gPlayState != NULL) {
-            previousSceneNum = gPlayState->sceneNum;
-        }
-        const char* sequenceName = AudioCollection_GetSequenceName(seqId);
-        if (sequenceName != NULL) {
-            Overlay_DisplayText_Seconds(CVarGetInteger(CVAR_AUDIO("SeqNameOverlayDuration"), 5), sequenceName);
-        }
-    }
+
+    GameInteractor_ExecuteOnSeqPlayerInit(playerIdx, seqId);
 }
 
 u8* AudioLoad_SyncLoadSeq(s32 seqId) {


### PR DESCRIPTION
I also implemented a way to make Notifications silent instead of the little noise they emit on a per notification basis. This might be the only thing that uses it (maybe Autosave?), I just figured having that noise on every scene change would get a bit distracting.

Here's what it looks like now:
![A Notification with musical eighth notes followed by a song name](https://github.com/user-attachments/assets/d94c6700-a88f-4a7b-8987-ed456b35e12c)


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2852738266.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2852751468.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2852755052.zip)
<!--- section:artifacts:end -->