### PR TITLE
Lock mask select behind zelda's letter in rando

### DIFF
--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_item.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_item.c
@@ -317,7 +317,8 @@ void KaleidoScope_HandleItemCycleExtras(PlayState* play, u8 slot, bool canCycle,
 
 bool CanMaskSelect() {
     if (IS_RANDO) {
-        return CVarGetInteger(CVAR_ENHANCEMENT("MaskSelect"), 0) /* || Randomizer_GetSettingValue(RSK_SHUFFLE_CHILD_TRADE) */;
+        return CVarGetInteger(CVAR_ENHANCEMENT("MaskSelect"), 0) 
+               && Flags_GetEventChkInf(EVENTCHKINF_OBTAINED_ZELDAS_LETTER);/* || Randomizer_GetSettingValue(RSK_SHUFFLE_CHILD_TRADE) */
     }
 
     // only allow mask select when:

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_item.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_item.c
@@ -318,7 +318,7 @@ void KaleidoScope_HandleItemCycleExtras(PlayState* play, u8 slot, bool canCycle,
 bool CanMaskSelect() {
     if (IS_RANDO) {
         return CVarGetInteger(CVAR_ENHANCEMENT("MaskSelect"), 0) 
-               && Flags_GetEventChkInf(EVENTCHKINF_OBTAINED_ZELDAS_LETTER);/* || Randomizer_GetSettingValue(RSK_SHUFFLE_CHILD_TRADE) */
+               && Flags_GetRandomizerInf(RAND_INF_ZELDAS_LETTER);/* || Randomizer_GetSettingValue(RSK_SHUFFLE_CHILD_TRADE) */
     }
 
     // only allow mask select when:


### PR DESCRIPTION
fixes #5224 for the most part.

This forces you to have done the zelda's letter pickup before unlocking mask select in rando.

Does not check the kakariko gate guard or mask shop access due to softlock concerns with weird egg.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2853161056.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2853197181.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2853232400.zip)
<!--- section:artifacts:end -->