### PR TITLE
Fix some misc. Rando menu issues

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -2710,12 +2710,7 @@ void RandomizerSettingsWindow::DrawElement() {
             "Characters from a-z, A-Z, and 0-9 are supported.\n"
             "Character limit is 1023, after which the seed will be truncated.\n"
         );
-        if (strnlen(seedString, MAX_SEED_STRING_SIZE) == 0) {
-            ImGui::SameLine(17.0f);
-            ImGui::TextColored(ImVec4(1.0f, 1.0f, 1.0f, 0.4f), "Leave blank for random seed");
-        }
-        UIWidgets::PopStyleInput();
-        ImGui::SameLine(0.f, 50.f);
+        ImGui::SameLine();
         if (UIWidgets::Button(ICON_FA_RANDOM, UIWidgets::ButtonOptions().Size(UIWidgets::Sizes::Inline).Color(THEME_COLOR).Padding(ImVec2(10.f, 6.f)).Tooltip(
             "Creates a new random seed value to be used when generating a randomizer"
         ))) {
@@ -2725,6 +2720,11 @@ void RandomizerSettingsWindow::DrawElement() {
         if (UIWidgets::Button(ICON_FA_ERASER, UIWidgets::ButtonOptions().Size(UIWidgets::Sizes::Inline).Color(THEME_COLOR).Padding(ImVec2(10.f, 6.f)))) {
             memset(seedString, 0, MAX_SEED_STRING_SIZE);
         }
+        if (strnlen(seedString, MAX_SEED_STRING_SIZE) == 0) {
+            ImGui::SameLine(17.0f);
+            ImGui::TextColored(ImVec4(1.0f, 1.0f, 1.0f, 0.4f), "Leave blank for random seed");
+        }
+        UIWidgets::PopStyleInput();
     }
 
     UIWidgets::Spacer(0);

--- a/soh/soh/SohGui/SohMenuRandomizer.cpp
+++ b/soh/soh/SohGui/SohMenuRandomizer.cpp
@@ -79,7 +79,7 @@ void SohMenu::AddMenuRandomizer() {
         .CVar(CVAR_RANDOMIZER_ENHANCEMENT("TimeSavers.SkipGetItemAnimationScale"))
         .PreFunc([](WidgetInfo& info) {
             info.options->disabled =
-                !CVarGetInteger(CVAR_RANDOMIZER_ENHANCEMENT("TimeSavers.SkipGetItemAnimation"), SGIA_DISABLED);
+                !CVarGetInteger(CVAR_RANDOMIZER_ENHANCEMENT("TimeSavers.SkipGetItemAnimation"), SGIA_JUNK);
             info.options->disabledTooltip = "This slider only applies when using the \"Skip Get Item Animations\" option.";
             })
         .Options(FloatSliderOptions()


### PR DESCRIPTION
Fixes an issue where the Manual Seed Entry textbox was overlapping the Random and Clear buttons next to it, especially when you pop out the seed settings window.

Fixes an issue where on a fresh json, the item scale is grayed out when the Skip Get Item Animations combobox is set to Junk Only. Caused by a mismatch of defaults (SGIA_JUNK in the combobox and SGIA_DISABLED in the scale slider's PreFunc to check if it should be disabled.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2855749790.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2855757210.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2855771829.zip)
<!--- section:artifacts:end -->