### PR TITLE
Fix Crash On Play Scene Inits

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -15,6 +15,7 @@
 #include "soh/Enhancements/debugger/performanceTimer.h"
 
 #include <string>
+#include <sstream>
 #include <vector>
 #include <set>
 #include <libultraship/libultraship.h>

--- a/soh/src/code/z_scene.c
+++ b/soh/src/code/z_scene.c
@@ -507,11 +507,13 @@ void (*gSceneCmdHandlers[SCENE_CMD_ID_MAX])(PlayState*, SceneCmd*) = {
     Scene_CommandMiscSettings,        // SCENE_CMD_ID_MISC_SETTINGS
 };
 
+// clang-format off
 RomFile sNaviMsgFiles[] = {
-    ROM_FILE(text / elf_message_field / elf_message_field),
-    ROM_FILE(text / elf_message_ydan / elf_message_ydan),
+    ROM_FILE(text/elf_message_field/elf_message_field),
+    ROM_FILE(text/elf_message_ydan/elf_message_ydan),
     ROM_FILE_UNSET,
 };
+// clang-format on
 
 s16 gLinkObjectIds[] = { OBJECT_LINK_BOY, OBJECT_LINK_CHILD };
 


### PR DESCRIPTION
Following clang format PR these file path strings had spaces added so this removes those spaces and gets it to pass the clang format test

I also needed to add sstream include to get it compiling on my mac

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2866737333.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2866756582.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2866774736.zip)
<!--- section:artifacts:end -->