### PR TITLE
Fix Names On Custom Message

### DIFF
--- a/soh/src/code/z_message_PAL.c
+++ b/soh/src/code/z_message_PAL.c
@@ -1685,7 +1685,7 @@ bool Message_DecodeName(PlayState* play, s16* decodedBufPosPtr, s32* charTexIdxP
         }
     }
 
-    if (ResourceMgr_GetGameRegion(0) == GAME_REGION_PAL && gSaveContext.language != LANGUAGE_JPN) {
+    if (ResourceMgr_GetGameRegion(0) == GAME_REGION_PAL && (gSaveContext.language != LANGUAGE_JPN || sDisplayNextMessageAsEnglish)) {
         if (gSaveContext.ship.filenameLanguage == NAME_LANGUAGE_PAL) {
             for (i = 0; i < playerNameLen; i++) {
                 curChar2 = gSaveContext.playerName[i];
@@ -1740,7 +1740,7 @@ bool Message_DecodeName(PlayState* play, s16* decodedBufPosPtr, s32* charTexIdxP
                 msgCtx->msgBufDecoded[(*decodedBufPosPtr)] = curChar2;
                 (*decodedBufPosPtr)++;
             }
-        } else {
+        } else { // NAME_LANGUAGE_NTSC_JPN
             for (i = 0; i < playerNameLen; i++) {
                 curChar2 = gSaveContext.playerName[i];
 

--- a/soh/src/code/z_message_PAL.c
+++ b/soh/src/code/z_message_PAL.c
@@ -1780,7 +1780,7 @@ bool Message_DecodeName(PlayState* play, s16* decodedBufPosPtr, s32* charTexIdxP
     } else { // GAME_REGION_NTSC
 
         if (gSaveContext.ship.filenameLanguage == NAME_LANGUAGE_NTSC_JPN) {
-            if (gSaveContext.language == LANGUAGE_JPN) {
+            if (gSaveContext.language == LANGUAGE_JPN && !sDisplayNextMessageAsEnglish) {
                 for (i = 0; i < playerNameLen; i++) {
                     curChar2 = gSaveContext.playerName[i];
                     u8* fontBuf = &font->fontBuf[(curChar2 * 32) << 2];
@@ -1808,7 +1808,7 @@ bool Message_DecodeName(PlayState* play, s16* decodedBufPosPtr, s32* charTexIdxP
                 }
             }
         } else if (gSaveContext.ship.filenameLanguage == NAME_LANGUAGE_NTSC_ENG) {
-            if (gSaveContext.language == LANGUAGE_JPN) {
+            if (gSaveContext.language == LANGUAGE_JPN && !sDisplayNextMessageAsEnglish) {
                 for (i = 0; i < playerNameLen; i++) {
                     curChar2 = gSaveContext.playerName[i];
                     u8* fontBuf = &font->fontBuf[(curChar2 * 32) << 2];
@@ -1850,7 +1850,7 @@ bool Message_DecodeName(PlayState* play, s16* decodedBufPosPtr, s32* charTexIdxP
                 }
             }
         } else if (gSaveContext.ship.filenameLanguage == NAME_LANGUAGE_PAL) {
-            if (gSaveContext.language == LANGUAGE_JPN) {
+            if (gSaveContext.language == LANGUAGE_JPN && !sDisplayNextMessageAsEnglish) {
                 for (i = 0; i < playerNameLen; i++) {
                     curChar2 = gSaveContext.playerName[i];
 

--- a/soh/src/code/z_message_PAL.c
+++ b/soh/src/code/z_message_PAL.c
@@ -1685,7 +1685,8 @@ bool Message_DecodeName(PlayState* play, s16* decodedBufPosPtr, s32* charTexIdxP
         }
     }
 
-    if (ResourceMgr_GetGameRegion(0) == GAME_REGION_PAL && (gSaveContext.language != LANGUAGE_JPN || sDisplayNextMessageAsEnglish)) {
+    if (ResourceMgr_GetGameRegion(0) == GAME_REGION_PAL &&
+        (gSaveContext.language != LANGUAGE_JPN || sDisplayNextMessageAsEnglish)) {
         if (gSaveContext.ship.filenameLanguage == NAME_LANGUAGE_PAL) {
             for (i = 0; i < playerNameLen; i++) {
                 curChar2 = gSaveContext.playerName[i];


### PR DESCRIPTION
The decoding for JP and Eng/Ger/Fre has a shared function I made here, which means that when the 'force display as english' flag is set (used by custom messages), messages would decode using the japanese method, filling the message buffer with extra characters which were not `MESSAGE_NAME`, allowing for weird control codes to be hit and characters to overlap due to indexing the latin font char width table (with potential OOB access here)

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2867231460.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2867240422.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2867274011.zip)
<!--- section:artifacts:end -->