### PR TITLE
File Select: Reload Font on Language Change

### DIFF
--- a/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -1806,6 +1806,18 @@ void FileChoose_PulsateCursor(GameState* thisx) {
 void FileChoose_ConfigModeUpdate(GameState* thisx) {
     FileChooseContext* this = (FileChooseContext*)thisx;
 
+    // #region SOH [NTSC] Reload Fonts If Language Has Changed
+    static s32 previousLanguage = LANGUAGE_ENG;
+    if (previousLanguage != gSaveContext.language) {
+        if (ResourceMgr_GetGameRegion(0) == GAME_REGION_PAL && gSaveContext.language != LANGUAGE_JPN) {
+            Font_LoadOrderedFont(&this->font);
+        } else { // GAME_REGION_NTSC
+            Font_LoadOrderedFontNTSC(&this->font);
+        }
+        previousLanguage = gSaveContext.language;
+    }
+    // #endregion
+
     if (ResourceMgr_GetGameRegion(0) == GAME_REGION_PAL && gSaveContext.language != LANGUAGE_JPN) {
         gConfigModeUpdateFuncs[this->configMode](&this->state);
     } else { // GAME_REGION_NTSC


### PR DESCRIPTION
This fixes some issues where when you change language with PAL and NTSC loaded with the file select menu already open, the font for certain filename characters would load wrong.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2868008506.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2868026936.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2868064480.zip)
<!--- section:artifacts:end -->