### PR TITLE
Fix excluded locations on subsequent seed generations

### DIFF
--- a/soh/soh/SaveManager.cpp
+++ b/soh/soh/SaveManager.cpp
@@ -2908,6 +2908,7 @@ extern "C" void Save_LoadFile(void) {
     OTRGlobals::Instance->gRandoContext = Rando::Context::CreateInstance();
     OTRGlobals::Instance->gRandoContext->GetLogic()->SetSaveContext(&gSaveContext);
     Rando::Settings::GetInstance()->AssignContext(OTRGlobals::Instance->gRandoContext);
+    OTRGlobals::Instance->gRandoContext->AddExcludedOptions();
     SaveManager::Instance->LoadFile(gSaveContext.fileNum);
 }
 


### PR DESCRIPTION
Excluded Locations were being missed on subsequent seed generations. This is due to Rando::Context::everyPossibleLocation not being refilled when the context is reset when a save is loaded. For now I just call the function to repopulate it, but by the next major release there will likely be a more complete solution that removes the need for this call.

Fixes #5301 

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2876268078.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2876289208.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2876322782.zip)
<!--- section:artifacts:end -->