### PR TITLE
Fix oversight causing big poes check not to run

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/fill.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/fill.cpp
@@ -161,7 +161,7 @@ static void ValidateOtherEntrance(GetAccessibleLocationsStruct& gals) {
     }
     // If we are not shuffling the guard house, add the key so we can properly check for poe merchant access
     if (gals.validatedStartingRegion && gals.foundTempleOfTime &&
-        !ctx->GetOption(RSK_SHUFFLE_INTERIOR_ENTRANCES).Is(RO_INTERIOR_ENTRANCE_SHUFFLE_ALL)) {
+        ctx->GetOption(RSK_SHUFFLE_INTERIOR_ENTRANCES).Is(RO_INTERIOR_ENTRANCE_SHUFFLE_OFF)) {
         Rando::StaticData::RetrieveItem(RG_GUARD_HOUSE_KEY).ApplyEffect();
     }
 }
@@ -213,7 +213,7 @@ void ProcessExits(Region* region, GetAccessibleLocationsStruct& gals, Randomizer
         // Update Time of Day Access for the exit
         if (UpdateToDAccess(&exit, exitRegion)) {
             gals.logicUpdated = true;
-            if (!gals.sphereZeroComplete) {
+            if (!gals.sphereZeroComplete || logic->AreCheckingBigPoes) {
                 if (!gals.foundTempleOfTime || !gals.validatedStartingRegion) {
                     ValidateOtherEntrance(gals);
                 }
@@ -622,7 +622,7 @@ void ValidateEntrances(bool checkPoeCollectorAccess, bool checkOtherEntranceAcce
         RegionTable(RR_ROOT)->adultDay = true;
     } else if (checkPoeCollectorAccess) {
         // If we are not shuffling the guard house, add the key so we can properly check for poe merchant access
-        if (!ctx->GetOption(RSK_SHUFFLE_INTERIOR_ENTRANCES).Is(RO_INTERIOR_ENTRANCE_SHUFFLE_ALL)) {
+        if (ctx->GetOption(RSK_SHUFFLE_INTERIOR_ENTRANCES).Is(RO_INTERIOR_ENTRANCE_SHUFFLE_OFF)) {
             Rando::StaticData::RetrieveItem(RG_GUARD_HOUSE_KEY).ApplyEffect();
         }
     } else {

--- a/soh/soh/Enhancements/randomizer/location_access.cpp
+++ b/soh/soh/Enhancements/randomizer/location_access.cpp
@@ -326,7 +326,7 @@ void RegionTable_Init() {
         EventAccess(&logic->KakarikoVillageGateOpen, []{return ctx->GetOption(RSK_KAK_GATE).Is(RO_KAK_GATE_OPEN);}),
         //The big poes bottle softlock safety check does not account for the guard house lock if the guard house is not shuffled, so the key is needed before we can safely allow bottle use in logic
         //RANDOTODO a setting that lets you drink/dump big poes so we don't need this logic
-        EventAccess(&logic->CouldEmptyBigPoes,       []{return ctx->GetOption(RSK_SHUFFLE_INTERIOR_ENTRANCES).Is(RO_INTERIOR_ENTRANCE_SHUFFLE_ALL) || logic->CanOpenOverworldDoor(RG_GUARD_HOUSE_KEY);}),
+        EventAccess(&logic->CouldEmptyBigPoes,       []{return !ctx->GetOption(RSK_SHUFFLE_INTERIOR_ENTRANCES).Is(RO_INTERIOR_ENTRANCE_SHUFFLE_OFF) || logic->CanOpenOverworldDoor(RG_GUARD_HOUSE_KEY);}),
     }, {
         //Locations
         LOCATION(RC_LINKS_POCKET,       true),


### PR DESCRIPTION
Fixes an oversight with where the new big poes check was placed, causing it to not run when other entrance randos were not on.

This also fixes an oversight where the overworld key was not being added when interior shuffle was set to simple. 

should fix #5297 

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2876601393.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2876612210.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2876653328.zip)
<!--- section:artifacts:end -->