### PR TITLE
Fix the start with Master Sword option

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/hints.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/hints.cpp
@@ -835,7 +835,7 @@ void CreateGanondorfJoke() {
 void CreateGanondorfHint() {
     auto ctx = Rando::Context::GetInstance();
     if (ctx->GetOption(RSK_GANONDORF_HINT) && !ctx->GetHint(RH_GANONDORF_HINT)->IsEnabled()) {
-        if (ctx->GetOption(RSK_SHUFFLE_MASTER_SWORD)) {
+        if (ctx->GetOption(RSK_SHUFFLE_MASTER_SWORD) && ctx->GetOption(RSK_STARTING_MASTER_SWORD).Is(RO_GENERIC_OFF)) {
             CreateStaticItemHint(
                 RH_GANONDORF_HINT,
                 { RHT_GANONDORF_HINT_LA_ONLY, RHT_GANONDORF_HINT_MS_ONLY, RHT_GANONDORF_HINT_LA_AND_MS },

--- a/soh/soh/Enhancements/randomizer/savefile.cpp
+++ b/soh/soh/Enhancements/randomizer/savefile.cpp
@@ -107,6 +107,7 @@ void GiveLinksPocketItem() {
 }
 
 void SetStartingItems() {
+    int startingAge = OTRGlobals::Instance->gRandoContext->GetOption(RSK_SELECTED_STARTING_AGE).Get();
     if (Randomizer_GetSettingValue(RSK_STARTING_KOKIRI_SWORD))
         Item_Give(NULL, ITEM_SWORD_KOKIRI);
     if (Randomizer_GetSettingValue(RSK_STARTING_DEKU_SHIELD))
@@ -157,6 +158,13 @@ void SetStartingItems() {
     }
     if (Randomizer_GetSettingValue(RSK_STARTING_NUTS) && !Randomizer_GetSettingValue(RSK_SHUFFLE_DEKU_NUT_BAG)) {
         GiveLinkDekuNuts(20);
+    }
+    if (Randomizer_GetSettingValue(RSK_STARTING_MASTER_SWORD)) {
+        if (startingAge == RO_AGE_ADULT) {
+            Item_Give(NULL, ITEM_SWORD_MASTER);
+        } else {
+            gSaveContext.inventory.equipment |= 1 << 1;
+        }
     }
 
     if (Randomizer_GetSettingValue(RSK_FULL_WALLETS)) {


### PR DESCRIPTION
Before, starting with Master Sword would logically assume you had Master Sword, but not actually put it in your Inventory. This fixes that, automatically equipping it if Starting as Adult Link (but not as Child Link). I don't *think* auto-equipping would break any glitches, but even if it did we do have options to allow unequipping it now.

Fixes #5300 

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2876772798.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2876781117.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2876823546.zip)
<!--- section:artifacts:end -->