### PR TITLE
Better verbose output for clang-format

### DIFF
--- a/run-clang-format.ps1
+++ b/run-clang-format.ps1
@@ -41,8 +41,9 @@ $files = Get-ChildItem -Path $basePath\soh -Recurse -File `
                        (-not ($_.FullName -like "*\soh\src\*" -or $_.FullName -like "*\soh\include\*")))) -and `
                      (-not ($_.FullName -like "*\soh\assets\*")) }
 
-foreach ($file in $files) {
+for ($i = 0; $i -lt $files.Length; $i++) {
+    $file = $files[$i]
     $relativePath = $file.FullName.Substring($basePath.Length + 1)
-    Write-Host "Formatting $relativePath"
+    Write-Host "Formatting [$($i+1)/$($files.Length)] $relativePath"
     .\clang-format.exe -i $file.FullName
 }

--- a/run-clang-format.sh
+++ b/run-clang-format.sh
@@ -21,8 +21,9 @@
 # -print0
 # separate paths with NUL bytes, avoiding issues with spaces in paths
 #
-# | xargs -0 clang-format-14 -i
+# | xargs -0 clang-format-14 -i -verbose
 # use xargs to take each path we've found
 # and pass it as an argument to clang-format
+# verbose to print files being formatted and X out of Y status
 
-find soh -type f \( -name "*.c" -o -name "*.cpp" -o \( -name "*.h" ! -path "soh/src/**.h" ! -path "soh/include/**.h" \) \) ! -path "soh/assets/*" -print0 | xargs -0 clang-format-14 -i
+find soh -type f \( -name "*.c" -o -name "*.cpp" -o \( -name "*.h" ! -path "soh/src/**.h" ! -path "soh/include/**.h" \) \) ! -path "soh/assets/*" -print0 | xargs -0 clang-format-14 -i --verbose


### PR DESCRIPTION
This updates the format scripts to output the file its working on and how many X out of Y the status is on.

Setting `--verbose` on the linux/mac script was sufficient for this behavior.

In the windows powershell script, we were already looping and printing the file name, the loop is updated to now have the current index out of length printed as well. (Couldn't use `--verbose` since we execute `clang-format` multiple times. Trying to pass all files direct to `clang-format` led to a "command too long" issue in powershell's `CreateProcess`)

Example:

```
Formatting [1/1296] soh/platform/pathconf.c
Formatting [2/1296] soh/resource.h
Formatting [3/1296] soh/soh/util.cpp
Formatting [4/1296] soh/soh/mixer.c
Formatting [5/1296] soh/soh/CrashHandlerExp.h
Formatting [6/1296] soh/soh/stubs.c
Formatting [7/1296] soh/soh/config/ConfigMigrators.h
Formatting [8/1296] soh/soh/config/ConfigUpdaters.h
```

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2877876561.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2877887030.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2877920716.zip)
<!--- section:artifacts:end -->