### PR TITLE
Skip Kakariko and Hyrule Castle gate cutscenes

### DIFF
--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -1428,6 +1428,7 @@ typedef enum {
     // ```
     // #### `args`
     // - `*EnHeishi2`
+    // - `bool` (clearCamera - true if the code clears a sub-camera, false otherwise)
     VB_PLAY_GATE_OPENING_OR_CLOSING_CS,
 
     // #### `result`

--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -1435,6 +1435,14 @@ typedef enum {
     // true
     // ```
     // #### `args`
+    // - `*EnHeishi2
+    VB_PLAY_KAKARIKO_GATE_CS,
+
+    // #### `result`
+    // ```c
+    // true
+    // ```
+    // #### `args`
     // - None
     VB_PLAY_MINUET_OF_FOREST_CS,
 

--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -1427,7 +1427,7 @@ typedef enum {
     // true
     // ```
     // #### `args`
-    // - `*EnHeishi2
+    // - `*EnHeishi2`
     VB_PLAY_GATE_OPENING_OR_CLOSING_CS,
 
     // #### `result`

--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -1427,16 +1427,16 @@ typedef enum {
     // true
     // ```
     // #### `args`
-    // - None
-    VB_PLAY_GORON_FREE_CS,
+    // - `*EnHeishi2
+    VB_PLAY_GATE_OPENING_OR_CLOSING_CS,
 
     // #### `result`
     // ```c
     // true
     // ```
     // #### `args`
-    // - `*EnHeishi2
-    VB_PLAY_KAKARIKO_GATE_CS,
+    // - None
+    VB_PLAY_GORON_FREE_CS,
 
     // #### `result`
     // ```c

--- a/soh/soh/Enhancements/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.cpp
@@ -728,7 +728,7 @@ void TimeSaverOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_li
 
                 // The second argument determines whether the vanilla code should be run anyway. It
                 // should be set to `true` ONLY IF said code calls `Play_ClearCamera`, false otherwise.
-                bool clearCamera = va_arg(args, bool);
+                bool clearCamera = (bool)va_arg(args, int);
                 *should = clearCamera && enHeishi2->cameraId != MAIN_CAM;
             }
             break;

--- a/soh/soh/Enhancements/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.cpp
@@ -13,6 +13,7 @@ extern "C" {
 #include "src/overlays/actors/ovl_Bg_Treemouth/z_bg_treemouth.h"
 #include "src/overlays/actors/ovl_En_Owl/z_en_owl.h"
 #include "src/overlays/actors/ovl_En_Go2/z_en_go2.h"
+#include "src/overlays/actors/ovl_En_Heishi2/z_en_heishi2.h"
 #include "src/overlays/actors/ovl_En_Ko/z_en_ko.h"
 #include "src/overlays/actors/ovl_En_Ma1/z_en_ma1.h"
 #include "src/overlays/actors/ovl_En_Ru2/z_en_ru2.h"
@@ -718,6 +719,20 @@ void TimeSaverOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_li
                 *should = false;
             }
 
+            break;
+        }
+        case VB_PLAY_KAKARIKO_GATE_CS: {
+            if (CVarGetInteger(CVAR_ENHANCEMENT("TimeSavers.SkipMiscInteractions"), IS_RANDO)) {
+                EnHeishi2* enHeishi2 = va_arg(args, EnHeishi2*);
+                enHeishi2->unk_2F2[0] = 0;
+
+                if (enHeishi2->cameraId != MAIN_CAM) {
+                    Play_ClearCamera(gPlayState, enHeishi2->cameraId);
+                    Play_ChangeCameraStatus(gPlayState, MAIN_CAM, CAM_STAT_ACTIVE);
+                }
+
+                *should = false;
+            }
             break;
         }
         case VB_PLAY_RAINBOW_BRIDGE_CS: {

--- a/soh/soh/Enhancements/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.cpp
@@ -725,7 +725,7 @@ void TimeSaverOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_li
             if (CVarGetInteger(CVAR_ENHANCEMENT("TimeSavers.SkipMiscInteractions"), IS_RANDO)) {
                 EnHeishi2* enHeishi2 = va_arg(args, EnHeishi2*);
                 enHeishi2->unk_2F2[0] = 0;
-                
+
                 // The second argument determines whether the vanilla code should be run anyway. It
                 // should be set to `true` ONLY IF said code calls `Play_ClearCamera`, false otherwise.
                 bool clearCamera = va_arg(args, bool);

--- a/soh/soh/Enhancements/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.cpp
@@ -721,7 +721,7 @@ void TimeSaverOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_li
 
             break;
         }
-        case VB_PLAY_KAKARIKO_GATE_CS: {
+        case VB_PLAY_GATE_OPENING_OR_CLOSING_CS: {
             if (CVarGetInteger(CVAR_ENHANCEMENT("TimeSavers.SkipMiscInteractions"), IS_RANDO)) {
                 EnHeishi2* enHeishi2 = va_arg(args, EnHeishi2*);
                 enHeishi2->unk_2F2[0] = 0;

--- a/soh/soh/Enhancements/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.cpp
@@ -725,6 +725,12 @@ void TimeSaverOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_li
             if (CVarGetInteger(CVAR_ENHANCEMENT("TimeSavers.SkipMiscInteractions"), IS_RANDO)) {
                 EnHeishi2* enHeishi2 = va_arg(args, EnHeishi2*);
                 enHeishi2->unk_2F2[0] = 0;
+
+                if (enHeishi2->cameraId != MAIN_CAM) {
+                    Play_ClearCamera(gPlayState, enHeishi2->cameraId);
+                    Play_ChangeCameraStatus(gPlayState, MAIN_CAM, CAM_STAT_ACTIVE);
+                }
+
                 *should = false;
             }
             break;

--- a/soh/soh/Enhancements/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.cpp
@@ -725,13 +725,11 @@ void TimeSaverOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_li
             if (CVarGetInteger(CVAR_ENHANCEMENT("TimeSavers.SkipMiscInteractions"), IS_RANDO)) {
                 EnHeishi2* enHeishi2 = va_arg(args, EnHeishi2*);
                 enHeishi2->unk_2F2[0] = 0;
-
-                if (enHeishi2->cameraId != MAIN_CAM) {
-                    Play_ClearCamera(gPlayState, enHeishi2->cameraId);
-                    Play_ChangeCameraStatus(gPlayState, MAIN_CAM, CAM_STAT_ACTIVE);
-                }
-
-                *should = false;
+                
+                // The second argument determines whether the vanilla code should be run anyway. It
+                // should be set to `true` ONLY IF said code calls `Play_ClearCamera`, false otherwise.
+                bool clearCamera = va_arg(args, bool);
+                *should = clearCamera && enHeishi2->cameraId != MAIN_CAM;
             }
             break;
         }

--- a/soh/soh/Enhancements/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.cpp
@@ -725,12 +725,6 @@ void TimeSaverOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_li
             if (CVarGetInteger(CVAR_ENHANCEMENT("TimeSavers.SkipMiscInteractions"), IS_RANDO)) {
                 EnHeishi2* enHeishi2 = va_arg(args, EnHeishi2*);
                 enHeishi2->unk_2F2[0] = 0;
-
-                if (enHeishi2->cameraId != MAIN_CAM) {
-                    Play_ClearCamera(gPlayState, enHeishi2->cameraId);
-                    Play_ChangeCameraStatus(gPlayState, MAIN_CAM, CAM_STAT_ACTIVE);
-                }
-
                 *should = false;
             }
             break;

--- a/soh/src/overlays/actors/ovl_En_Heishi2/z_en_heishi2.c
+++ b/soh/src/overlays/actors/ovl_En_Heishi2/z_en_heishi2.c
@@ -510,10 +510,8 @@ void func_80A53F30(EnHeishi2* this, PlayState* play) {
     }
     gate = (BgGateShutter*)this->gate;
     if ((this->unk_2F2[0] == 0) || (gate->openingState == 0)) {
-        if (GameInteractor_Should(VB_PLAY_KAKARIKO_GATE_CS, true, this)) {
-            Play_ClearCamera(play, this->cameraId);
-            Play_ChangeCameraStatus(play, MAIN_CAM, CAM_STAT_ACTIVE);
-        }
+        Play_ClearCamera(play, this->cameraId);
+        Play_ChangeCameraStatus(play, MAIN_CAM, CAM_STAT_ACTIVE);
         if ((this->unk_30A != 2)) {
             if (this->unk_30A == 0) {
                 this->actor.textId = 0x2015;

--- a/soh/src/overlays/actors/ovl_En_Heishi2/z_en_heishi2.c
+++ b/soh/src/overlays/actors/ovl_En_Heishi2/z_en_heishi2.c
@@ -314,19 +314,21 @@ void func_80A5372C(EnHeishi2* this, PlayState* play) {
     f32 frameCount = Animation_GetLastFrame(&gEnHeishiIdleAnim);
 
     Animation_Change(&this->skelAnime, &gEnHeishiIdleAnim, 1.0f, 0.0f, (s16)frameCount, ANIMMODE_LOOP, -10.0f);
-    this->unk_2F2[0] = 200;
-    this->cameraId = Play_CreateSubCamera(play);
-    Play_ChangeCameraStatus(play, MAIN_CAM, CAM_STAT_WAIT);
-    Play_ChangeCameraStatus(play, this->cameraId, CAM_STAT_ACTIVE);
-    this->unk_280.x = 947.0f;
-    this->unk_280.y = 1195.0f;
-    this->unk_280.z = 2682.0f;
+    if (GameInteractor_Should(VB_PLAY_GATE_OPENING_OR_CLOSING_CS, true, this)) {
+        this->unk_2F2[0] = 200;
+        this->cameraId = Play_CreateSubCamera(play);
+        Play_ChangeCameraStatus(play, MAIN_CAM, CAM_STAT_WAIT);
+        Play_ChangeCameraStatus(play, this->cameraId, CAM_STAT_ACTIVE);
+        this->unk_280.x = 947.0f;
+        this->unk_280.y = 1195.0f;
+        this->unk_280.z = 2682.0f;
 
-    this->unk_28C.x = 1164.0f;
-    this->unk_28C.y = 1145.0f;
-    this->unk_28C.z = 3014.0f;
+        this->unk_28C.x = 1164.0f;
+        this->unk_28C.y = 1145.0f;
+        this->unk_28C.z = 3014.0f;
 
-    Play_CameraSetAtEye(play, this->cameraId, &this->unk_280, &this->unk_28C);
+        Play_CameraSetAtEye(play, this->cameraId, &this->unk_280, &this->unk_28C);
+    }
     this->actionFunc = func_80A53850;
 }
 
@@ -334,11 +336,15 @@ void func_80A53850(EnHeishi2* this, PlayState* play) {
     BgSpot15Saku* gate;
 
     SkelAnime_Update(&this->skelAnime);
-    Play_CameraSetAtEye(play, this->cameraId, &this->unk_280, &this->unk_28C);
+    if (GameInteractor_Should(VB_PLAY_GATE_OPENING_OR_CLOSING_CS, true, this)) {
+        Play_CameraSetAtEye(play, this->cameraId, &this->unk_280, &this->unk_28C);
+    }
     gate = (BgSpot15Saku*)this->gate;
     if ((this->unk_2F2[0] == 0) || (gate->unk_168 == 0)) {
-        Play_ClearCamera(play, this->cameraId);
-        Play_ChangeCameraStatus(play, MAIN_CAM, CAM_STAT_ACTIVE);
+        if (GameInteractor_Should(VB_PLAY_GATE_OPENING_OR_CLOSING_CS, true, this)) {
+            Play_ClearCamera(play, this->cameraId);
+            Play_ChangeCameraStatus(play, MAIN_CAM, CAM_STAT_ACTIVE);
+        }
         Message_CloseTextbox(play);
         this->unk_30C = 1;
         Player_SetCsActionWithHaltedActors(play, NULL, 7);
@@ -479,7 +485,7 @@ void func_80A53DF8(EnHeishi2* this, PlayState* play) {
     f32 frameCount = Animation_GetLastFrame(&gEnHeishiIdleAnim);
 
     Animation_Change(&this->skelAnime, &gEnHeishiIdleAnim, 1.0f, 0.0f, (s16)frameCount, ANIMMODE_LOOP, -10.0f);
-    if (GameInteractor_Should(VB_PLAY_KAKARIKO_GATE_CS, true, this)) {
+    if (GameInteractor_Should(VB_PLAY_GATE_OPENING_OR_CLOSING_CS, true, this)) {
         this->unk_2F2[0] = 200;
         this->cameraId = Play_CreateSubCamera(play);
         Play_ChangeCameraStatus(play, MAIN_CAM, CAM_STAT_WAIT);
@@ -505,12 +511,12 @@ void func_80A53F30(EnHeishi2* this, PlayState* play) {
     BgGateShutter* gate;
 
     SkelAnime_Update(&this->skelAnime);
-    if (GameInteractor_Should(VB_PLAY_KAKARIKO_GATE_CS, true, this)) {
+    if (GameInteractor_Should(VB_PLAY_GATE_OPENING_OR_CLOSING_CS, true, this)) {
         Play_CameraSetAtEye(play, this->cameraId, &this->unk_280, &this->unk_28C);
     }
     gate = (BgGateShutter*)this->gate;
     if ((this->unk_2F2[0] == 0) || (gate->openingState == 0)) {
-        if (GameInteractor_Should(VB_PLAY_KAKARIKO_GATE_CS, true, this)) {
+        if (GameInteractor_Should(VB_PLAY_GATE_OPENING_OR_CLOSING_CS, true, this)) {
             Play_ClearCamera(play, this->cameraId);
             Play_ChangeCameraStatus(play, MAIN_CAM, CAM_STAT_ACTIVE);
         }

--- a/soh/src/overlays/actors/ovl_En_Heishi2/z_en_heishi2.c
+++ b/soh/src/overlays/actors/ovl_En_Heishi2/z_en_heishi2.c
@@ -510,8 +510,10 @@ void func_80A53F30(EnHeishi2* this, PlayState* play) {
     }
     gate = (BgGateShutter*)this->gate;
     if ((this->unk_2F2[0] == 0) || (gate->openingState == 0)) {
-        Play_ClearCamera(play, this->cameraId);
-        Play_ChangeCameraStatus(play, MAIN_CAM, CAM_STAT_ACTIVE);
+        if (GameInteractor_Should(VB_PLAY_KAKARIKO_GATE_CS, true, this)) {
+            Play_ClearCamera(play, this->cameraId);
+            Play_ChangeCameraStatus(play, MAIN_CAM, CAM_STAT_ACTIVE);
+        }
         if ((this->unk_30A != 2)) {
             if (this->unk_30A == 0) {
                 this->actor.textId = 0x2015;

--- a/soh/src/overlays/actors/ovl_En_Heishi2/z_en_heishi2.c
+++ b/soh/src/overlays/actors/ovl_En_Heishi2/z_en_heishi2.c
@@ -479,23 +479,25 @@ void func_80A53DF8(EnHeishi2* this, PlayState* play) {
     f32 frameCount = Animation_GetLastFrame(&gEnHeishiIdleAnim);
 
     Animation_Change(&this->skelAnime, &gEnHeishiIdleAnim, 1.0f, 0.0f, (s16)frameCount, ANIMMODE_LOOP, -10.0f);
-    this->unk_2F2[0] = 200;
-    this->cameraId = Play_CreateSubCamera(play);
-    Play_ChangeCameraStatus(play, MAIN_CAM, CAM_STAT_WAIT);
-    Play_ChangeCameraStatus(play, this->cameraId, CAM_STAT_ACTIVE);
-    this->unk_2BC.x = -71.0f;
-    this->unk_280.x = -71.0f;
-    this->unk_2BC.y = 571.0f;
-    this->unk_280.y = 571.0f;
-    this->unk_2BC.z = -1487.0f;
-    this->unk_280.z = -1487.0f;
-    this->unk_298.x = 181.0f;
-    this->unk_28C.x = 181.0f;
-    this->unk_298.y = 417.0f;
-    this->unk_28C.y = 417.0f;
-    this->unk_298.z = -1079.0f;
-    this->unk_28C.z = -1079.0f;
-    Play_CameraSetAtEye(play, this->cameraId, &this->unk_280, &this->unk_28C);
+    if (GameInteractor_Should(VB_PLAY_KAKARIKO_GATE_CS, true, this)) {
+        this->unk_2F2[0] = 200;
+        this->cameraId = Play_CreateSubCamera(play);
+        Play_ChangeCameraStatus(play, MAIN_CAM, CAM_STAT_WAIT);
+        Play_ChangeCameraStatus(play, this->cameraId, CAM_STAT_ACTIVE);
+        this->unk_2BC.x = -71.0f;
+        this->unk_280.x = -71.0f;
+        this->unk_2BC.y = 571.0f;
+        this->unk_280.y = 571.0f;
+        this->unk_2BC.z = -1487.0f;
+        this->unk_280.z = -1487.0f;
+        this->unk_298.x = 181.0f;
+        this->unk_28C.x = 181.0f;
+        this->unk_298.y = 417.0f;
+        this->unk_28C.y = 417.0f;
+        this->unk_298.z = -1079.0f;
+        this->unk_28C.z = -1079.0f;
+        Play_CameraSetAtEye(play, this->cameraId, &this->unk_280, &this->unk_28C);
+    }
     this->actionFunc = func_80A53F30;
 }
 
@@ -503,11 +505,15 @@ void func_80A53F30(EnHeishi2* this, PlayState* play) {
     BgGateShutter* gate;
 
     SkelAnime_Update(&this->skelAnime);
-    Play_CameraSetAtEye(play, this->cameraId, &this->unk_280, &this->unk_28C);
+    if (GameInteractor_Should(VB_PLAY_KAKARIKO_GATE_CS, true, this)) {
+        Play_CameraSetAtEye(play, this->cameraId, &this->unk_280, &this->unk_28C);
+    }
     gate = (BgGateShutter*)this->gate;
     if ((this->unk_2F2[0] == 0) || (gate->openingState == 0)) {
-        Play_ClearCamera(play, this->cameraId);
-        Play_ChangeCameraStatus(play, MAIN_CAM, CAM_STAT_ACTIVE);
+        if (GameInteractor_Should(VB_PLAY_KAKARIKO_GATE_CS, true, this)) {
+            Play_ClearCamera(play, this->cameraId);
+            Play_ChangeCameraStatus(play, MAIN_CAM, CAM_STAT_ACTIVE);
+        }
         if ((this->unk_30A != 2)) {
             if (this->unk_30A == 0) {
                 this->actor.textId = 0x2015;

--- a/soh/src/overlays/actors/ovl_En_Heishi2/z_en_heishi2.c
+++ b/soh/src/overlays/actors/ovl_En_Heishi2/z_en_heishi2.c
@@ -314,7 +314,7 @@ void func_80A5372C(EnHeishi2* this, PlayState* play) {
     f32 frameCount = Animation_GetLastFrame(&gEnHeishiIdleAnim);
 
     Animation_Change(&this->skelAnime, &gEnHeishiIdleAnim, 1.0f, 0.0f, (s16)frameCount, ANIMMODE_LOOP, -10.0f);
-    if (GameInteractor_Should(VB_PLAY_GATE_OPENING_OR_CLOSING_CS, true, this)) {
+    if (GameInteractor_Should(VB_PLAY_GATE_OPENING_OR_CLOSING_CS, true, this, false)) {
         this->unk_2F2[0] = 200;
         this->cameraId = Play_CreateSubCamera(play);
         Play_ChangeCameraStatus(play, MAIN_CAM, CAM_STAT_WAIT);
@@ -336,12 +336,12 @@ void func_80A53850(EnHeishi2* this, PlayState* play) {
     BgSpot15Saku* gate;
 
     SkelAnime_Update(&this->skelAnime);
-    if (GameInteractor_Should(VB_PLAY_GATE_OPENING_OR_CLOSING_CS, true, this)) {
+    if (GameInteractor_Should(VB_PLAY_GATE_OPENING_OR_CLOSING_CS, true, this, false)) {
         Play_CameraSetAtEye(play, this->cameraId, &this->unk_280, &this->unk_28C);
     }
     gate = (BgSpot15Saku*)this->gate;
     if ((this->unk_2F2[0] == 0) || (gate->unk_168 == 0)) {
-        if (GameInteractor_Should(VB_PLAY_GATE_OPENING_OR_CLOSING_CS, true, this)) {
+        if (GameInteractor_Should(VB_PLAY_GATE_OPENING_OR_CLOSING_CS, true, this, true)) {
             Play_ClearCamera(play, this->cameraId);
             Play_ChangeCameraStatus(play, MAIN_CAM, CAM_STAT_ACTIVE);
         }
@@ -485,7 +485,7 @@ void func_80A53DF8(EnHeishi2* this, PlayState* play) {
     f32 frameCount = Animation_GetLastFrame(&gEnHeishiIdleAnim);
 
     Animation_Change(&this->skelAnime, &gEnHeishiIdleAnim, 1.0f, 0.0f, (s16)frameCount, ANIMMODE_LOOP, -10.0f);
-    if (GameInteractor_Should(VB_PLAY_GATE_OPENING_OR_CLOSING_CS, true, this)) {
+    if (GameInteractor_Should(VB_PLAY_GATE_OPENING_OR_CLOSING_CS, true, this, false)) {
         this->unk_2F2[0] = 200;
         this->cameraId = Play_CreateSubCamera(play);
         Play_ChangeCameraStatus(play, MAIN_CAM, CAM_STAT_WAIT);
@@ -511,12 +511,12 @@ void func_80A53F30(EnHeishi2* this, PlayState* play) {
     BgGateShutter* gate;
 
     SkelAnime_Update(&this->skelAnime);
-    if (GameInteractor_Should(VB_PLAY_GATE_OPENING_OR_CLOSING_CS, true, this)) {
+    if (GameInteractor_Should(VB_PLAY_GATE_OPENING_OR_CLOSING_CS, true, this, false)) {
         Play_CameraSetAtEye(play, this->cameraId, &this->unk_280, &this->unk_28C);
     }
     gate = (BgGateShutter*)this->gate;
     if ((this->unk_2F2[0] == 0) || (gate->openingState == 0)) {
-        if (GameInteractor_Should(VB_PLAY_GATE_OPENING_OR_CLOSING_CS, true, this)) {
+        if (GameInteractor_Should(VB_PLAY_GATE_OPENING_OR_CLOSING_CS, true, this, true)) {
             Play_ClearCamera(play, this->cameraId);
             Play_ChangeCameraStatus(play, MAIN_CAM, CAM_STAT_ACTIVE);
         }


### PR DESCRIPTION
Fixes #5264

There are three cutscenes to skip. First, if you show the guard Zelda's Letter, he'll open the gate:

https://github.com/user-attachments/assets/a0921a3e-0670-44fa-bfbd-1d24b84ba2b1

Second, if you refuse to sell him Keaton's Mask, he'll close it:

https://github.com/user-attachments/assets/8a9ac7d8-418a-4045-b523-deb97dbeb8e1

Third, if you then do sell it to him, he'll open it again:

https://github.com/user-attachments/assets/7b2e1ca5-480c-47d6-8460-29b35dd30d2c

As an extra, I'm also adding a skip to the Hyrule Castle gate, which can be opened by paying the guard 10 Rupees:

https://github.com/user-attachments/assets/885bda9c-a936-46ab-afc1-2961a98ff8ea

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3023473679.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3023482319.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3023497117.zip)
<!--- section:artifacts:end -->