### PR TITLE
Skip Hyrule Castle gate opening cutscene

### DIFF
--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -1427,6 +1427,14 @@ typedef enum {
     // true
     // ```
     // #### `args`
+    // - `*EnHeishi2`
+    VB_PLAY_HYRULE_CASTLE_GATE_CS,
+
+    // #### `result`
+    // ```c
+    // true
+    // ```
+    // #### `args`
     // - None
     VB_PLAY_MINUET_OF_FOREST_CS,
 

--- a/soh/soh/Enhancements/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.cpp
@@ -13,6 +13,7 @@ extern "C" {
 #include "src/overlays/actors/ovl_Bg_Treemouth/z_bg_treemouth.h"
 #include "src/overlays/actors/ovl_En_Owl/z_en_owl.h"
 #include "src/overlays/actors/ovl_En_Go2/z_en_go2.h"
+#include "src/overlays/actors/ovl_En_Heishi2/z_en_heishi2.h"
 #include "src/overlays/actors/ovl_En_Ko/z_en_ko.h"
 #include "src/overlays/actors/ovl_En_Ma1/z_en_ma1.h"
 #include "src/overlays/actors/ovl_En_Ru2/z_en_ru2.h"
@@ -718,6 +719,20 @@ void TimeSaverOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_li
                 *should = false;
             }
 
+            break;
+        }
+        case VB_PLAY_HYRULE_CASTLE_GATE_CS: {
+            if (CVarGetInteger(CVAR_ENHANCEMENT("TimeSavers.SkipMiscInteractions"), IS_RANDO)) {
+                EnHeishi2* enHeishi2 = va_arg(args, EnHeishi2*);
+                enHeishi2->unk_2F2[0] = 0;
+
+                if (enHeishi2->cameraId != MAIN_CAM) {
+                    Play_ClearCamera(gPlayState, enHeishi2->cameraId);
+                    Play_ChangeCameraStatus(gPlayState, MAIN_CAM, CAM_STAT_ACTIVE);
+                }
+
+                *should = false;
+            }
             break;
         }
         case VB_PLAY_RAINBOW_BRIDGE_CS: {

--- a/soh/src/overlays/actors/ovl_En_Heishi2/z_en_heishi2.c
+++ b/soh/src/overlays/actors/ovl_En_Heishi2/z_en_heishi2.c
@@ -314,19 +314,21 @@ void func_80A5372C(EnHeishi2* this, PlayState* play) {
     f32 frameCount = Animation_GetLastFrame(&gEnHeishiIdleAnim);
 
     Animation_Change(&this->skelAnime, &gEnHeishiIdleAnim, 1.0f, 0.0f, (s16)frameCount, ANIMMODE_LOOP, -10.0f);
-    this->unk_2F2[0] = 200;
-    this->cameraId = Play_CreateSubCamera(play);
-    Play_ChangeCameraStatus(play, MAIN_CAM, CAM_STAT_WAIT);
-    Play_ChangeCameraStatus(play, this->cameraId, CAM_STAT_ACTIVE);
-    this->unk_280.x = 947.0f;
-    this->unk_280.y = 1195.0f;
-    this->unk_280.z = 2682.0f;
+    if (GameInteractor_Should(VB_PLAY_HYRULE_CASTLE_GATE_CS, true, this)) {
+        this->unk_2F2[0] = 200;
+        this->cameraId = Play_CreateSubCamera(play);
+        Play_ChangeCameraStatus(play, MAIN_CAM, CAM_STAT_WAIT);
+        Play_ChangeCameraStatus(play, this->cameraId, CAM_STAT_ACTIVE);
+        this->unk_280.x = 947.0f;
+        this->unk_280.y = 1195.0f;
+        this->unk_280.z = 2682.0f;
 
-    this->unk_28C.x = 1164.0f;
-    this->unk_28C.y = 1145.0f;
-    this->unk_28C.z = 3014.0f;
+        this->unk_28C.x = 1164.0f;
+        this->unk_28C.y = 1145.0f;
+        this->unk_28C.z = 3014.0f;
 
-    Play_CameraSetAtEye(play, this->cameraId, &this->unk_280, &this->unk_28C);
+        Play_CameraSetAtEye(play, this->cameraId, &this->unk_280, &this->unk_28C);
+    }
     this->actionFunc = func_80A53850;
 }
 
@@ -334,11 +336,15 @@ void func_80A53850(EnHeishi2* this, PlayState* play) {
     BgSpot15Saku* gate;
 
     SkelAnime_Update(&this->skelAnime);
-    Play_CameraSetAtEye(play, this->cameraId, &this->unk_280, &this->unk_28C);
+    if (GameInteractor_Should(VB_PLAY_HYRULE_CASTLE_GATE_CS, true, this)) {
+        Play_CameraSetAtEye(play, this->cameraId, &this->unk_280, &this->unk_28C);
+    }
     gate = (BgSpot15Saku*)this->gate;
     if ((this->unk_2F2[0] == 0) || (gate->unk_168 == 0)) {
-        Play_ClearCamera(play, this->cameraId);
-        Play_ChangeCameraStatus(play, MAIN_CAM, CAM_STAT_ACTIVE);
+        if (GameInteractor_Should(VB_PLAY_HYRULE_CASTLE_GATE_CS, true, this)) {
+            Play_ClearCamera(play, this->cameraId);
+            Play_ChangeCameraStatus(play, MAIN_CAM, CAM_STAT_ACTIVE);
+        }
         Message_CloseTextbox(play);
         this->unk_30C = 1;
         Player_SetCsActionWithHaltedActors(play, NULL, 7);


### PR DESCRIPTION
Inspired by #5264

#5314 fixes the Kakariko gate cutscenes, but the Hyrule Castle gate has the same problem. Fixed here.

https://github.com/user-attachments/assets/885bda9c-a936-46ab-afc1-2961a98ff8ea

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2880241026.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2880242351.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2880254401.zip)
<!--- section:artifacts:end -->