### PR TITLE
Flags Tab GS Map Combobox Fix

### DIFF
--- a/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
+++ b/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
@@ -849,9 +849,19 @@ void DrawFlagsTab() {
 
     DrawGroupWithBorder(
         [&]() {
-            size_t selectedGsMap = 0;
+            PushStyleCombobox(THEME_COLOR);
+            static size_t selectedGsMap = 0;
             ImGui::Text("Gold Skulltulas");
-            Combobox("Map##Gold Skulltulas", &selectedGsMap, gsMapping, comboboxOptionsBase.Tooltip(""));
+            if (ImGui::BeginCombo("##GSMap", gsMapping[selectedGsMap])) {
+                for (size_t index = 0; index < gsMapping.size(); index++) {
+                    if (ImGui::Selectable(gsMapping[index])) {
+                        selectedGsMap = index;
+                    }
+                }
+
+                ImGui::EndCombo();
+            }
+            PopStyleCombobox();
 
             // TODO We should write out descriptions for each one... ugh
             ImGui::AlignTextToFramePadding();


### PR DESCRIPTION
Fix the GS Map combobox in the Flags tab of the save editor not remembering the selected index, and also rework it to remove the label.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2880252603.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2880256123.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2880273097.zip)
<!--- section:artifacts:end -->