### PR TITLE
Fix boss title card extraction for NTSC; Fix Morpha water

### DIFF
--- a/soh/assets/xml/GC_MQ_NTSC_J/objects/object_bv.xml
+++ b/soh/assets/xml/GC_MQ_NTSC_J/objects/object_bv.xml
@@ -38,7 +38,7 @@
         <Texture Name="object_bvTLUT_01DBB0" OutName="object_bvTLUT_01DBB0" Format="rgba16" Width="16" Height="16" Offset="0x1C7B0" AddedByScript="true"/>
         <Texture Name="object_bvTLUT_01E6B0" OutName="object_bvTLUT_01E6B0" Format="rgba16" Width="16" Height="16" Offset="0x1D2B0" AddedByScript="true"/>
         <!-- Boss title card -->
-        <Texture Name="gBarinadeTitleCardTex" OutName="barinade_title_card" Format="i8" Width="128" Height="120" Offset="0x1230"/>
+        <Texture Name="gBarinadeTitleCardTex" OutName="barinade_title_card" Format="i8" Width="128" Height="80" Offset="0x1230"/>
 
         <Skeleton Name="gBarinadeBodySkel" Type="Normal" LimbType="Standard" Offset="0x14718"/>
         <Skeleton Name="gBarinadeSupportSkel" Type="Flex" LimbType="Standard" Offset="0x16098"/>

--- a/soh/assets/xml/GC_MQ_NTSC_J/objects/object_fd.xml
+++ b/soh/assets/xml/GC_MQ_NTSC_J/objects/object_fd.xml
@@ -28,7 +28,7 @@
         <Texture Name="object_fdTLUT_000A58" OutName="object_fdTLUT_000A58" Format="rgba16" Width="4" Height="4" Offset="0xA58" AddedByScript="true"/>
         <Texture Name="object_fdTLUT_0032A8" OutName="object_fdTLUT_0032A8" Format="rgba16" Width="16" Height="16" Offset="0x32A8" AddedByScript="true"/>
         <!-- Boss title card -->
-        <!-- <Texture Name="gVolvagiaTitleCardTex" OutName="volvagia_boss_title_card" Format="i8" Width="128" Height="120" Offset="0xD700"/> -->
+        <!-- <Texture Name="gVolvagiaTitleCardTex" OutName="volvagia_boss_title_card" Format="i8" Width="128" Height="80" Offset="0xD700"/> -->
 
         <!-- Skeletons -->
         <Skeleton Name="gVolvagiaLeftArmSkel" Type="Normal" LimbType="Standard" Offset="0x100E0"/>

--- a/soh/assets/xml/GC_MQ_NTSC_J/objects/object_fhg.xml
+++ b/soh/assets/xml/GC_MQ_NTSC_J/objects/object_fhg.xml
@@ -38,7 +38,7 @@
         <Animation Name="gPhantomHorseFenceJumpAnim" Offset="0xAD80"/>
         
         <!-- Boss title card -->
-        <Texture Name="gPhantomGanonTitleCardTex" OutName="phantom_ganon_title_card" Format="i8" Width="128" Height="120" Offset="0x59A0"/>
+        <Texture Name="gPhantomGanonTitleCardTex" OutName="phantom_ganon_title_card" Format="i8" Width="128" Height="80" Offset="0x59A0"/>
     
         <!-- Energy attack DLists -->
         <DList Name="gPhantomWarpDL" Offset="0xE6A0"/>

--- a/soh/assets/xml/GC_MQ_NTSC_J/objects/object_ganon.xml
+++ b/soh/assets/xml/GC_MQ_NTSC_J/objects/object_ganon.xml
@@ -68,7 +68,7 @@
         <DList Name="gGanondorfRightHandOpenDL" Offset="0xC9E8"/>
 
         <!-- Ganondorf Title Card Texture -->
-        <!-- <Texture Name="gGanondorfTitleCardTex" OutName="ganondorf_title_card" Format="i8" Width="128" Height="120" Offset="0xCF00"/> -->
+        <!-- <Texture Name="gGanondorfTitleCardTex" OutName="ganondorf_title_card" Format="i8" Width="128" Height="80" Offset="0xCF00"/> -->
 
         <!-- Ganondorf Animation -->
         <Animation Name="gGanondorfEndingFloatAnim" Offset="0xFF48"/> <!-- Original name is "ONOLEE" (lit. "Curse you!" from his in-game dialogue) -->

--- a/soh/assets/xml/GC_MQ_NTSC_J/objects/object_goma.xml
+++ b/soh/assets/xml/GC_MQ_NTSC_J/objects/object_goma.xml
@@ -159,7 +159,7 @@
         <Texture Name="gGohmaIrisTex" OutName="gohma_iris" Format="rgba16" Width="32" Height="32" Offset="0x193A8"/>
 
         <!-- Boss title card -->
-        <Texture Name="gGohmaTitleCardTex" OutName="gohma_title_card" Format="i8" Width="128" Height="120" Offset="0x19BA8"/>
+        <Texture Name="gGohmaTitleCardTex" OutName="gohma_title_card" Format="i8" Width="128" Height="80" Offset="0x19BA8"/>
 
         <!-- Door -->
         <DList Name="gGohmaDoorDL" Offset="0x1D820"/>

--- a/soh/assets/xml/GC_MQ_NTSC_J/objects/object_kingdodongo.xml
+++ b/soh/assets/xml/GC_MQ_NTSC_J/objects/object_kingdodongo.xml
@@ -48,7 +48,7 @@
         <Texture Name="object_kingdodongo_Tex_016D90" OutName="tex_00016D90" Format="rgba16" Width="8" Height="8" Offset="0x16D90"/>
         <Texture Name="object_kingdodongo_Tex_016E10" OutName="tex_00016E10" Format="rgba16" Width="32" Height="16" Offset="0x16E10"/>
         <Texture Name="object_kingdodongo_Tex_017210" OutName="tex_00017210" Format="rgba16" Width="8" Height="32" Offset="0x17210"/>
-        <Texture Name="gKingDodongoTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="120" Offset="0x17410"/>
+        <Texture Name="gKingDodongoTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="80" Offset="0x17410"/>
         <Limb Name="object_kingdodongo_Limb_01B010" LimbType="Standard" Offset="0x19C10"/>
         <Limb Name="object_kingdodongo_Limb_01B01C" LimbType="Standard" Offset="0x19C1C"/>
         <Limb Name="object_kingdodongo_Limb_01B028" LimbType="Standard" Offset="0x19C28"/>

--- a/soh/assets/xml/GC_MQ_NTSC_J/objects/object_mo.xml
+++ b/soh/assets/xml/GC_MQ_NTSC_J/objects/object_mo.xml
@@ -6,7 +6,7 @@
         <Texture Name="object_moTex_005520" OutName="object_moTex_005520" Format="ia16" Width="32" Height="32" Offset="0x4120" AddedByScript="true"/>
         <Texture Name="object_moTex_005D20" OutName="object_moTex_005D20" Format="ia16" Width="32" Height="32" Offset="0x4920" AddedByScript="true"/>
         <!-- Morpha's Title Card -->
-        <Texture Name="gMorphaTitleCardTex" Format="i8" Width="128" Height="120" Offset="0x1010"/>
+        <Texture Name="gMorphaTitleCardTex" Format="i8" Width="128" Height="80" Offset="0x1010"/>
         <Texture Name="gMorphaWaterTex" Format="rgba16" Width="32" Height="32" Offset="0x7470"/>
 
         <!-- DLists for Morpha's Core -->

--- a/soh/assets/xml/GC_MQ_NTSC_J/objects/object_sst.xml
+++ b/soh/assets/xml/GC_MQ_NTSC_J/objects/object_sst.xml
@@ -17,7 +17,7 @@
         <Texture Name="object_sstTex_01A730" OutName="object_sstTex_01A730" Format="rgba16" Width="4" Height="16" Offset="0x19330" AddedByScript="true"/>
         <Texture Name="object_sstTex_01A7B0" OutName="object_sstTex_01A7B0" Format="rgba16" Width="16" Height="16" Offset="0x193B0" AddedByScript="true"/>
         <!-- Boss Title Card -->
-        <Texture Name="gBongoTitleCardTex" OutName="bongo_title_card" Format="i8" Width="128" Height="120" Offset="0x13D80"/>
+        <Texture Name="gBongoTitleCardTex" OutName="bongo_title_card" Format="i8" Width="128" Height="80" Offset="0x13D80"/>
         
         <!-- Skeletons -->
         <Skeleton Name="gBongoLeftHandSkel" Type="Flex" LimbType="Standard" Offset="0x04DE0"/>

--- a/soh/assets/xml/GC_MQ_NTSC_J/objects/object_tw.xml
+++ b/soh/assets/xml/GC_MQ_NTSC_J/objects/object_tw.xml
@@ -273,7 +273,7 @@
         <DList Name="gTwinrovaBroomIceTrailDL" Offset="0x2DEB0"/>
         <DList Name="gTwinrovaBroomFireJetDL" Offset="0x2DFB0"/>
         <DList Name="gTwinrovaBroomFireTrailDL" Offset="0x2E098"/>
-        <Texture Name="gTwinrovaTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="120" Offset="0x2E170"/>
+        <Texture Name="gTwinrovaTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="80" Offset="0x2E170"/>
         <Limb Name="gTwinrovaPelvisLimb" LimbType="Standard" Offset="0x30970"/>
         <Limb Name="gTwinrovaSash1Limb" LimbType="Standard" Offset="0x3097C"/>
         <Limb Name="gTwinrovaSash2Limb" LimbType="Standard" Offset="0x30988"/>

--- a/soh/assets/xml/GC_MQ_NTSC_U/objects/object_bv.xml
+++ b/soh/assets/xml/GC_MQ_NTSC_U/objects/object_bv.xml
@@ -38,7 +38,7 @@
         <Texture Name="object_bvTLUT_01DBB0" OutName="object_bvTLUT_01DBB0" Format="rgba16" Width="16" Height="16" Offset="0x1C7B0" AddedByScript="true"/>
         <Texture Name="object_bvTLUT_01E6B0" OutName="object_bvTLUT_01E6B0" Format="rgba16" Width="16" Height="16" Offset="0x1D2B0" AddedByScript="true"/>
         <!-- Boss title card -->
-        <Texture Name="gBarinadeTitleCardTex" OutName="barinade_title_card" Format="i8" Width="128" Height="120" Offset="0x1230"/>
+        <Texture Name="gBarinadeTitleCardTex" OutName="barinade_title_card" Format="i8" Width="128" Height="80" Offset="0x1230"/>
 
         <Skeleton Name="gBarinadeBodySkel" Type="Normal" LimbType="Standard" Offset="0x14718"/>
         <Skeleton Name="gBarinadeSupportSkel" Type="Flex" LimbType="Standard" Offset="0x16098"/>

--- a/soh/assets/xml/GC_MQ_NTSC_U/objects/object_fd.xml
+++ b/soh/assets/xml/GC_MQ_NTSC_U/objects/object_fd.xml
@@ -28,7 +28,7 @@
         <Texture Name="object_fdTLUT_000A58" OutName="object_fdTLUT_000A58" Format="rgba16" Width="4" Height="4" Offset="0xA58" AddedByScript="true"/>
         <Texture Name="object_fdTLUT_0032A8" OutName="object_fdTLUT_0032A8" Format="rgba16" Width="16" Height="16" Offset="0x32A8" AddedByScript="true"/>
         <!-- Boss title card -->
-        <!-- <Texture Name="gVolvagiaTitleCardTex" OutName="volvagia_boss_title_card" Format="i8" Width="128" Height="120" Offset="0xD700"/> -->
+        <!-- <Texture Name="gVolvagiaTitleCardTex" OutName="volvagia_boss_title_card" Format="i8" Width="128" Height="80" Offset="0xD700"/> -->
 
         <!-- Skeletons -->
         <Skeleton Name="gVolvagiaLeftArmSkel" Type="Normal" LimbType="Standard" Offset="0x100E0"/>

--- a/soh/assets/xml/GC_MQ_NTSC_U/objects/object_fhg.xml
+++ b/soh/assets/xml/GC_MQ_NTSC_U/objects/object_fhg.xml
@@ -38,7 +38,7 @@
         <Animation Name="gPhantomHorseFenceJumpAnim" Offset="0xAD80"/>
         
         <!-- Boss title card -->
-        <Texture Name="gPhantomGanonTitleCardTex" OutName="phantom_ganon_title_card" Format="i8" Width="128" Height="120" Offset="0x59A0"/>
+        <Texture Name="gPhantomGanonTitleCardTex" OutName="phantom_ganon_title_card" Format="i8" Width="128" Height="80" Offset="0x59A0"/>
     
         <!-- Energy attack DLists -->
         <DList Name="gPhantomWarpDL" Offset="0xE6A0"/>

--- a/soh/assets/xml/GC_MQ_NTSC_U/objects/object_ganon.xml
+++ b/soh/assets/xml/GC_MQ_NTSC_U/objects/object_ganon.xml
@@ -68,7 +68,7 @@
         <DList Name="gGanondorfRightHandOpenDL" Offset="0xC9E8"/>
 
         <!-- Ganondorf Title Card Texture -->
-        <!-- <Texture Name="gGanondorfTitleCardTex" OutName="ganondorf_title_card" Format="i8" Width="128" Height="120" Offset="0xCF00"/> -->
+        <!-- <Texture Name="gGanondorfTitleCardTex" OutName="ganondorf_title_card" Format="i8" Width="128" Height="80" Offset="0xCF00"/> -->
 
         <!-- Ganondorf Animation -->
         <Animation Name="gGanondorfEndingFloatAnim" Offset="0xFF48"/> <!-- Original name is "ONOLEE" (lit. "Curse you!" from his in-game dialogue) -->

--- a/soh/assets/xml/GC_MQ_NTSC_U/objects/object_goma.xml
+++ b/soh/assets/xml/GC_MQ_NTSC_U/objects/object_goma.xml
@@ -159,7 +159,7 @@
         <Texture Name="gGohmaIrisTex" OutName="gohma_iris" Format="rgba16" Width="32" Height="32" Offset="0x193A8"/>
 
         <!-- Boss title card -->
-        <Texture Name="gGohmaTitleCardTex" OutName="gohma_title_card" Format="i8" Width="128" Height="120" Offset="0x19BA8"/>
+        <Texture Name="gGohmaTitleCardTex" OutName="gohma_title_card" Format="i8" Width="128" Height="80" Offset="0x19BA8"/>
 
         <!-- Door -->
         <DList Name="gGohmaDoorDL" Offset="0x1D820"/>

--- a/soh/assets/xml/GC_MQ_NTSC_U/objects/object_kingdodongo.xml
+++ b/soh/assets/xml/GC_MQ_NTSC_U/objects/object_kingdodongo.xml
@@ -48,7 +48,7 @@
         <Texture Name="object_kingdodongo_Tex_016D90" OutName="tex_00016D90" Format="rgba16" Width="8" Height="8" Offset="0x16D90"/>
         <Texture Name="object_kingdodongo_Tex_016E10" OutName="tex_00016E10" Format="rgba16" Width="32" Height="16" Offset="0x16E10"/>
         <Texture Name="object_kingdodongo_Tex_017210" OutName="tex_00017210" Format="rgba16" Width="8" Height="32" Offset="0x17210"/>
-        <Texture Name="gKingDodongoTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="120" Offset="0x17410"/>
+        <Texture Name="gKingDodongoTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="80" Offset="0x17410"/>
         <Limb Name="object_kingdodongo_Limb_01B010" LimbType="Standard" Offset="0x19C10"/>
         <Limb Name="object_kingdodongo_Limb_01B01C" LimbType="Standard" Offset="0x19C1C"/>
         <Limb Name="object_kingdodongo_Limb_01B028" LimbType="Standard" Offset="0x19C28"/>

--- a/soh/assets/xml/GC_MQ_NTSC_U/objects/object_mo.xml
+++ b/soh/assets/xml/GC_MQ_NTSC_U/objects/object_mo.xml
@@ -6,7 +6,7 @@
         <Texture Name="object_moTex_005520" OutName="object_moTex_005520" Format="ia16" Width="32" Height="32" Offset="0x4120" AddedByScript="true"/>
         <Texture Name="object_moTex_005D20" OutName="object_moTex_005D20" Format="ia16" Width="32" Height="32" Offset="0x4920" AddedByScript="true"/>
         <!-- Morpha's Title Card -->
-        <Texture Name="gMorphaTitleCardTex" Format="i8" Width="128" Height="120" Offset="0x1010"/>
+        <Texture Name="gMorphaTitleCardTex" Format="i8" Width="128" Height="80" Offset="0x1010"/>
         <Texture Name="gMorphaWaterTex" Format="rgba16" Width="32" Height="32" Offset="0x7470"/>
 
         <!-- DLists for Morpha's Core -->

--- a/soh/assets/xml/GC_MQ_NTSC_U/objects/object_sst.xml
+++ b/soh/assets/xml/GC_MQ_NTSC_U/objects/object_sst.xml
@@ -17,7 +17,7 @@
         <Texture Name="object_sstTex_01A730" OutName="object_sstTex_01A730" Format="rgba16" Width="4" Height="16" Offset="0x19330" AddedByScript="true"/>
         <Texture Name="object_sstTex_01A7B0" OutName="object_sstTex_01A7B0" Format="rgba16" Width="16" Height="16" Offset="0x193B0" AddedByScript="true"/>
         <!-- Boss Title Card -->
-        <Texture Name="gBongoTitleCardTex" OutName="bongo_title_card" Format="i8" Width="128" Height="120" Offset="0x13D80"/>
+        <Texture Name="gBongoTitleCardTex" OutName="bongo_title_card" Format="i8" Width="128" Height="80" Offset="0x13D80"/>
         
         <!-- Skeletons -->
         <Skeleton Name="gBongoLeftHandSkel" Type="Flex" LimbType="Standard" Offset="0x04DE0"/>

--- a/soh/assets/xml/GC_MQ_NTSC_U/objects/object_tw.xml
+++ b/soh/assets/xml/GC_MQ_NTSC_U/objects/object_tw.xml
@@ -273,7 +273,7 @@
         <DList Name="gTwinrovaBroomIceTrailDL" Offset="0x2DEB0"/>
         <DList Name="gTwinrovaBroomFireJetDL" Offset="0x2DFB0"/>
         <DList Name="gTwinrovaBroomFireTrailDL" Offset="0x2E098"/>
-        <Texture Name="gTwinrovaTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="120" Offset="0x2E170"/>
+        <Texture Name="gTwinrovaTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="80" Offset="0x2E170"/>
         <Limb Name="gTwinrovaPelvisLimb" LimbType="Standard" Offset="0x30970"/>
         <Limb Name="gTwinrovaSash1Limb" LimbType="Standard" Offset="0x3097C"/>
         <Limb Name="gTwinrovaSash2Limb" LimbType="Standard" Offset="0x30988"/>

--- a/soh/assets/xml/GC_NMQ_NTSC_J/objects/object_bv.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_J/objects/object_bv.xml
@@ -38,7 +38,7 @@
         <Texture Name="object_bvTLUT_01DBB0" OutName="object_bvTLUT_01DBB0" Format="rgba16" Width="16" Height="16" Offset="0x1C7B0" AddedByScript="true"/>
         <Texture Name="object_bvTLUT_01E6B0" OutName="object_bvTLUT_01E6B0" Format="rgba16" Width="16" Height="16" Offset="0x1D2B0" AddedByScript="true"/>
         <!-- Boss title card -->
-        <Texture Name="gBarinadeTitleCardTex" OutName="barinade_title_card" Format="i8" Width="128" Height="120" Offset="0x1230"/>
+        <Texture Name="gBarinadeTitleCardTex" OutName="barinade_title_card" Format="i8" Width="128" Height="80" Offset="0x1230"/>
 
         <Skeleton Name="gBarinadeBodySkel" Type="Normal" LimbType="Standard" Offset="0x14718"/>
         <Skeleton Name="gBarinadeSupportSkel" Type="Flex" LimbType="Standard" Offset="0x16098"/>

--- a/soh/assets/xml/GC_NMQ_NTSC_J/objects/object_fd.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_J/objects/object_fd.xml
@@ -28,7 +28,7 @@
         <Texture Name="object_fdTLUT_000A58" OutName="object_fdTLUT_000A58" Format="rgba16" Width="4" Height="4" Offset="0xA58" AddedByScript="true"/>
         <Texture Name="object_fdTLUT_0032A8" OutName="object_fdTLUT_0032A8" Format="rgba16" Width="16" Height="16" Offset="0x32A8" AddedByScript="true"/>
         <!-- Boss title card -->
-        <!-- <Texture Name="gVolvagiaTitleCardTex" OutName="volvagia_boss_title_card" Format="i8" Width="128" Height="120" Offset="0xD700"/> -->
+        <!-- <Texture Name="gVolvagiaTitleCardTex" OutName="volvagia_boss_title_card" Format="i8" Width="128" Height="80" Offset="0xD700"/> -->
 
         <!-- Skeletons -->
         <Skeleton Name="gVolvagiaLeftArmSkel" Type="Normal" LimbType="Standard" Offset="0x100E0"/>

--- a/soh/assets/xml/GC_NMQ_NTSC_J/objects/object_fhg.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_J/objects/object_fhg.xml
@@ -38,7 +38,7 @@
         <Animation Name="gPhantomHorseFenceJumpAnim" Offset="0xAD80"/>
         
         <!-- Boss title card -->
-        <Texture Name="gPhantomGanonTitleCardTex" OutName="phantom_ganon_title_card" Format="i8" Width="128" Height="120" Offset="0x59A0"/>
+        <Texture Name="gPhantomGanonTitleCardTex" OutName="phantom_ganon_title_card" Format="i8" Width="128" Height="80" Offset="0x59A0"/>
     
         <!-- Energy attack DLists -->
         <DList Name="gPhantomWarpDL" Offset="0xE6A0"/>

--- a/soh/assets/xml/GC_NMQ_NTSC_J/objects/object_ganon.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_J/objects/object_ganon.xml
@@ -68,7 +68,7 @@
         <DList Name="gGanondorfRightHandOpenDL" Offset="0xC9E8"/>
 
         <!-- Ganondorf Title Card Texture -->
-        <!-- <Texture Name="gGanondorfTitleCardTex" OutName="ganondorf_title_card" Format="i8" Width="128" Height="120" Offset="0xCF00"/> -->
+        <!-- <Texture Name="gGanondorfTitleCardTex" OutName="ganondorf_title_card" Format="i8" Width="128" Height="80" Offset="0xCF00"/> -->
 
         <!-- Ganondorf Animation -->
         <Animation Name="gGanondorfEndingFloatAnim" Offset="0xFF48"/> <!-- Original name is "ONOLEE" (lit. "Curse you!" from his in-game dialogue) -->

--- a/soh/assets/xml/GC_NMQ_NTSC_J/objects/object_goma.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_J/objects/object_goma.xml
@@ -159,7 +159,7 @@
         <Texture Name="gGohmaIrisTex" OutName="gohma_iris" Format="rgba16" Width="32" Height="32" Offset="0x193A8"/>
 
         <!-- Boss title card -->
-        <Texture Name="gGohmaTitleCardTex" OutName="gohma_title_card" Format="i8" Width="128" Height="120" Offset="0x19BA8"/>
+        <Texture Name="gGohmaTitleCardTex" OutName="gohma_title_card" Format="i8" Width="128" Height="80" Offset="0x19BA8"/>
 
         <!-- Door -->
         <DList Name="gGohmaDoorDL" Offset="0x1D820"/>

--- a/soh/assets/xml/GC_NMQ_NTSC_J/objects/object_kingdodongo.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_J/objects/object_kingdodongo.xml
@@ -48,7 +48,7 @@
         <Texture Name="object_kingdodongo_Tex_016D90" OutName="tex_00016D90" Format="rgba16" Width="8" Height="8" Offset="0x16D90"/>
         <Texture Name="object_kingdodongo_Tex_016E10" OutName="tex_00016E10" Format="rgba16" Width="32" Height="16" Offset="0x16E10"/>
         <Texture Name="object_kingdodongo_Tex_017210" OutName="tex_00017210" Format="rgba16" Width="8" Height="32" Offset="0x17210"/>
-        <Texture Name="gKingDodongoTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="120" Offset="0x17410"/>
+        <Texture Name="gKingDodongoTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="80" Offset="0x17410"/>
         <Limb Name="object_kingdodongo_Limb_01B010" LimbType="Standard" Offset="0x19C10"/>
         <Limb Name="object_kingdodongo_Limb_01B01C" LimbType="Standard" Offset="0x19C1C"/>
         <Limb Name="object_kingdodongo_Limb_01B028" LimbType="Standard" Offset="0x19C28"/>

--- a/soh/assets/xml/GC_NMQ_NTSC_J/objects/object_mo.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_J/objects/object_mo.xml
@@ -6,7 +6,7 @@
         <Texture Name="object_moTex_005520" OutName="object_moTex_005520" Format="ia16" Width="32" Height="32" Offset="0x4120" AddedByScript="true"/>
         <Texture Name="object_moTex_005D20" OutName="object_moTex_005D20" Format="ia16" Width="32" Height="32" Offset="0x4920" AddedByScript="true"/>
         <!-- Morpha's Title Card -->
-        <Texture Name="gMorphaTitleCardTex" Format="i8" Width="128" Height="120" Offset="0x1010"/>
+        <Texture Name="gMorphaTitleCardTex" Format="i8" Width="128" Height="80" Offset="0x1010"/>
         <Texture Name="gMorphaWaterTex" Format="rgba16" Width="32" Height="32" Offset="0x7470"/>
 
         <!-- DLists for Morpha's Core -->

--- a/soh/assets/xml/GC_NMQ_NTSC_J/objects/object_sst.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_J/objects/object_sst.xml
@@ -17,7 +17,7 @@
         <Texture Name="object_sstTex_01A730" OutName="object_sstTex_01A730" Format="rgba16" Width="4" Height="16" Offset="0x19330" AddedByScript="true"/>
         <Texture Name="object_sstTex_01A7B0" OutName="object_sstTex_01A7B0" Format="rgba16" Width="16" Height="16" Offset="0x193B0" AddedByScript="true"/>
         <!-- Boss Title Card -->
-        <Texture Name="gBongoTitleCardTex" OutName="bongo_title_card" Format="i8" Width="128" Height="120" Offset="0x13D80"/>
+        <Texture Name="gBongoTitleCardTex" OutName="bongo_title_card" Format="i8" Width="128" Height="80" Offset="0x13D80"/>
         
         <!-- Skeletons -->
         <Skeleton Name="gBongoLeftHandSkel" Type="Flex" LimbType="Standard" Offset="0x04DE0"/>

--- a/soh/assets/xml/GC_NMQ_NTSC_J/objects/object_tw.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_J/objects/object_tw.xml
@@ -273,7 +273,7 @@
         <DList Name="gTwinrovaBroomIceTrailDL" Offset="0x2DEB0"/>
         <DList Name="gTwinrovaBroomFireJetDL" Offset="0x2DFB0"/>
         <DList Name="gTwinrovaBroomFireTrailDL" Offset="0x2E098"/>
-        <Texture Name="gTwinrovaTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="120" Offset="0x2E170"/>
+        <Texture Name="gTwinrovaTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="80" Offset="0x2E170"/>
         <Limb Name="gTwinrovaPelvisLimb" LimbType="Standard" Offset="0x30970"/>
         <Limb Name="gTwinrovaSash1Limb" LimbType="Standard" Offset="0x3097C"/>
         <Limb Name="gTwinrovaSash2Limb" LimbType="Standard" Offset="0x30988"/>

--- a/soh/assets/xml/GC_NMQ_NTSC_J_CE/objects/object_bv.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_J_CE/objects/object_bv.xml
@@ -38,7 +38,7 @@
         <Texture Name="object_bvTLUT_01DBB0" OutName="object_bvTLUT_01DBB0" Format="rgba16" Width="16" Height="16" Offset="0x1C7B0" AddedByScript="true"/>
         <Texture Name="object_bvTLUT_01E6B0" OutName="object_bvTLUT_01E6B0" Format="rgba16" Width="16" Height="16" Offset="0x1D2B0" AddedByScript="true"/>
         <!-- Boss title card -->
-        <Texture Name="gBarinadeTitleCardTex" OutName="barinade_title_card" Format="i8" Width="128" Height="120" Offset="0x1230"/>
+        <Texture Name="gBarinadeTitleCardTex" OutName="barinade_title_card" Format="i8" Width="128" Height="80" Offset="0x1230"/>
 
         <Skeleton Name="gBarinadeBodySkel" Type="Normal" LimbType="Standard" Offset="0x14718"/>
         <Skeleton Name="gBarinadeSupportSkel" Type="Flex" LimbType="Standard" Offset="0x16098"/>

--- a/soh/assets/xml/GC_NMQ_NTSC_J_CE/objects/object_fd.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_J_CE/objects/object_fd.xml
@@ -28,7 +28,7 @@
         <Texture Name="object_fdTLUT_000A58" OutName="object_fdTLUT_000A58" Format="rgba16" Width="4" Height="4" Offset="0xA58" AddedByScript="true"/>
         <Texture Name="object_fdTLUT_0032A8" OutName="object_fdTLUT_0032A8" Format="rgba16" Width="16" Height="16" Offset="0x32A8" AddedByScript="true"/>
         <!-- Boss title card -->
-        <!-- <Texture Name="gVolvagiaTitleCardTex" OutName="volvagia_boss_title_card" Format="i8" Width="128" Height="120" Offset="0xD700"/> -->
+        <!-- <Texture Name="gVolvagiaTitleCardTex" OutName="volvagia_boss_title_card" Format="i8" Width="128" Height="80" Offset="0xD700"/> -->
 
         <!-- Skeletons -->
         <Skeleton Name="gVolvagiaLeftArmSkel" Type="Normal" LimbType="Standard" Offset="0x100E0"/>

--- a/soh/assets/xml/GC_NMQ_NTSC_J_CE/objects/object_fhg.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_J_CE/objects/object_fhg.xml
@@ -38,7 +38,7 @@
         <Animation Name="gPhantomHorseFenceJumpAnim" Offset="0xAD80"/>
         
         <!-- Boss title card -->
-        <Texture Name="gPhantomGanonTitleCardTex" OutName="phantom_ganon_title_card" Format="i8" Width="128" Height="120" Offset="0x59A0"/>
+        <Texture Name="gPhantomGanonTitleCardTex" OutName="phantom_ganon_title_card" Format="i8" Width="128" Height="80" Offset="0x59A0"/>
     
         <!-- Energy attack DLists -->
         <DList Name="gPhantomWarpDL" Offset="0xE6A0"/>

--- a/soh/assets/xml/GC_NMQ_NTSC_J_CE/objects/object_ganon.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_J_CE/objects/object_ganon.xml
@@ -68,7 +68,7 @@
         <DList Name="gGanondorfRightHandOpenDL" Offset="0xC9E8"/>
 
         <!-- Ganondorf Title Card Texture -->
-        <!-- <Texture Name="gGanondorfTitleCardTex" OutName="ganondorf_title_card" Format="i8" Width="128" Height="120" Offset="0xCF00"/> -->
+        <!-- <Texture Name="gGanondorfTitleCardTex" OutName="ganondorf_title_card" Format="i8" Width="128" Height="80" Offset="0xCF00"/> -->
 
         <!-- Ganondorf Animation -->
         <Animation Name="gGanondorfEndingFloatAnim" Offset="0xFF48"/> <!-- Original name is "ONOLEE" (lit. "Curse you!" from his in-game dialogue) -->

--- a/soh/assets/xml/GC_NMQ_NTSC_J_CE/objects/object_goma.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_J_CE/objects/object_goma.xml
@@ -159,7 +159,7 @@
         <Texture Name="gGohmaIrisTex" OutName="gohma_iris" Format="rgba16" Width="32" Height="32" Offset="0x193A8"/>
 
         <!-- Boss title card -->
-        <Texture Name="gGohmaTitleCardTex" OutName="gohma_title_card" Format="i8" Width="128" Height="120" Offset="0x19BA8"/>
+        <Texture Name="gGohmaTitleCardTex" OutName="gohma_title_card" Format="i8" Width="128" Height="80" Offset="0x19BA8"/>
 
         <!-- Door -->
         <DList Name="gGohmaDoorDL" Offset="0x1D820"/>

--- a/soh/assets/xml/GC_NMQ_NTSC_J_CE/objects/object_kingdodongo.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_J_CE/objects/object_kingdodongo.xml
@@ -48,7 +48,7 @@
         <Texture Name="object_kingdodongo_Tex_016D90" OutName="tex_00016D90" Format="rgba16" Width="8" Height="8" Offset="0x16D90"/>
         <Texture Name="object_kingdodongo_Tex_016E10" OutName="tex_00016E10" Format="rgba16" Width="32" Height="16" Offset="0x16E10"/>
         <Texture Name="object_kingdodongo_Tex_017210" OutName="tex_00017210" Format="rgba16" Width="8" Height="32" Offset="0x17210"/>
-        <Texture Name="gKingDodongoTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="120" Offset="0x17410"/>
+        <Texture Name="gKingDodongoTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="80" Offset="0x17410"/>
         <Limb Name="object_kingdodongo_Limb_01B010" LimbType="Standard" Offset="0x19C10"/>
         <Limb Name="object_kingdodongo_Limb_01B01C" LimbType="Standard" Offset="0x19C1C"/>
         <Limb Name="object_kingdodongo_Limb_01B028" LimbType="Standard" Offset="0x19C28"/>

--- a/soh/assets/xml/GC_NMQ_NTSC_J_CE/objects/object_mo.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_J_CE/objects/object_mo.xml
@@ -6,7 +6,7 @@
         <Texture Name="object_moTex_005520" OutName="object_moTex_005520" Format="ia16" Width="32" Height="32" Offset="0x4120" AddedByScript="true"/>
         <Texture Name="object_moTex_005D20" OutName="object_moTex_005D20" Format="ia16" Width="32" Height="32" Offset="0x4920" AddedByScript="true"/>
         <!-- Morpha's Title Card -->
-        <Texture Name="gMorphaTitleCardTex" Format="i8" Width="128" Height="120" Offset="0x1010"/>
+        <Texture Name="gMorphaTitleCardTex" Format="i8" Width="128" Height="80" Offset="0x1010"/>
         <Texture Name="gMorphaWaterTex" Format="rgba16" Width="32" Height="32" Offset="0x7470"/>
 
         <!-- DLists for Morpha's Core -->

--- a/soh/assets/xml/GC_NMQ_NTSC_J_CE/objects/object_sst.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_J_CE/objects/object_sst.xml
@@ -17,7 +17,7 @@
         <Texture Name="object_sstTex_01A730" OutName="object_sstTex_01A730" Format="rgba16" Width="4" Height="16" Offset="0x19330" AddedByScript="true"/>
         <Texture Name="object_sstTex_01A7B0" OutName="object_sstTex_01A7B0" Format="rgba16" Width="16" Height="16" Offset="0x193B0" AddedByScript="true"/>
         <!-- Boss Title Card -->
-        <Texture Name="gBongoTitleCardTex" OutName="bongo_title_card" Format="i8" Width="128" Height="120" Offset="0x13D80"/>
+        <Texture Name="gBongoTitleCardTex" OutName="bongo_title_card" Format="i8" Width="128" Height="80" Offset="0x13D80"/>
         
         <!-- Skeletons -->
         <Skeleton Name="gBongoLeftHandSkel" Type="Flex" LimbType="Standard" Offset="0x04DE0"/>

--- a/soh/assets/xml/GC_NMQ_NTSC_J_CE/objects/object_tw.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_J_CE/objects/object_tw.xml
@@ -273,7 +273,7 @@
         <DList Name="gTwinrovaBroomIceTrailDL" Offset="0x2DEB0"/>
         <DList Name="gTwinrovaBroomFireJetDL" Offset="0x2DFB0"/>
         <DList Name="gTwinrovaBroomFireTrailDL" Offset="0x2E098"/>
-        <Texture Name="gTwinrovaTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="120" Offset="0x2E170"/>
+        <Texture Name="gTwinrovaTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="80" Offset="0x2E170"/>
         <Limb Name="gTwinrovaPelvisLimb" LimbType="Standard" Offset="0x30970"/>
         <Limb Name="gTwinrovaSash1Limb" LimbType="Standard" Offset="0x3097C"/>
         <Limb Name="gTwinrovaSash2Limb" LimbType="Standard" Offset="0x30988"/>

--- a/soh/assets/xml/GC_NMQ_NTSC_U/objects/object_bv.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_U/objects/object_bv.xml
@@ -38,7 +38,7 @@
         <Texture Name="object_bvTLUT_01DBB0" OutName="object_bvTLUT_01DBB0" Format="rgba16" Width="16" Height="16" Offset="0x1C7B0" AddedByScript="true"/>
         <Texture Name="object_bvTLUT_01E6B0" OutName="object_bvTLUT_01E6B0" Format="rgba16" Width="16" Height="16" Offset="0x1D2B0" AddedByScript="true"/>
         <!-- Boss title card -->
-        <Texture Name="gBarinadeTitleCardTex" OutName="barinade_title_card" Format="i8" Width="128" Height="120" Offset="0x1230"/>
+        <Texture Name="gBarinadeTitleCardTex" OutName="barinade_title_card" Format="i8" Width="128" Height="80" Offset="0x1230"/>
 
         <Skeleton Name="gBarinadeBodySkel" Type="Normal" LimbType="Standard" Offset="0x14718"/>
         <Skeleton Name="gBarinadeSupportSkel" Type="Flex" LimbType="Standard" Offset="0x16098"/>

--- a/soh/assets/xml/GC_NMQ_NTSC_U/objects/object_fd.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_U/objects/object_fd.xml
@@ -28,7 +28,7 @@
         <Texture Name="object_fdTLUT_000A58" OutName="object_fdTLUT_000A58" Format="rgba16" Width="4" Height="4" Offset="0xA58" AddedByScript="true"/>
         <Texture Name="object_fdTLUT_0032A8" OutName="object_fdTLUT_0032A8" Format="rgba16" Width="16" Height="16" Offset="0x32A8" AddedByScript="true"/>
         <!-- Boss title card -->
-        <!-- <Texture Name="gVolvagiaTitleCardTex" OutName="volvagia_boss_title_card" Format="i8" Width="128" Height="120" Offset="0xD700"/> -->
+        <!-- <Texture Name="gVolvagiaTitleCardTex" OutName="volvagia_boss_title_card" Format="i8" Width="128" Height="80" Offset="0xD700"/> -->
 
         <!-- Skeletons -->
         <Skeleton Name="gVolvagiaLeftArmSkel" Type="Normal" LimbType="Standard" Offset="0x100E0"/>

--- a/soh/assets/xml/GC_NMQ_NTSC_U/objects/object_fhg.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_U/objects/object_fhg.xml
@@ -38,7 +38,7 @@
         <Animation Name="gPhantomHorseFenceJumpAnim" Offset="0xAD80"/>
         
         <!-- Boss title card -->
-        <Texture Name="gPhantomGanonTitleCardTex" OutName="phantom_ganon_title_card" Format="i8" Width="128" Height="120" Offset="0x59A0"/>
+        <Texture Name="gPhantomGanonTitleCardTex" OutName="phantom_ganon_title_card" Format="i8" Width="128" Height="80" Offset="0x59A0"/>
     
         <!-- Energy attack DLists -->
         <DList Name="gPhantomWarpDL" Offset="0xE6A0"/>

--- a/soh/assets/xml/GC_NMQ_NTSC_U/objects/object_ganon.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_U/objects/object_ganon.xml
@@ -68,7 +68,7 @@
         <DList Name="gGanondorfRightHandOpenDL" Offset="0xC9E8"/>
 
         <!-- Ganondorf Title Card Texture -->
-        <!-- <Texture Name="gGanondorfTitleCardTex" OutName="ganondorf_title_card" Format="i8" Width="128" Height="120" Offset="0xCF00"/> -->
+        <!-- <Texture Name="gGanondorfTitleCardTex" OutName="ganondorf_title_card" Format="i8" Width="128" Height="80" Offset="0xCF00"/> -->
 
         <!-- Ganondorf Animation -->
         <Animation Name="gGanondorfEndingFloatAnim" Offset="0xFF48"/> <!-- Original name is "ONOLEE" (lit. "Curse you!" from his in-game dialogue) -->

--- a/soh/assets/xml/GC_NMQ_NTSC_U/objects/object_goma.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_U/objects/object_goma.xml
@@ -159,7 +159,7 @@
         <Texture Name="gGohmaIrisTex" OutName="gohma_iris" Format="rgba16" Width="32" Height="32" Offset="0x193A8"/>
 
         <!-- Boss title card -->
-        <Texture Name="gGohmaTitleCardTex" OutName="gohma_title_card" Format="i8" Width="128" Height="120" Offset="0x19BA8"/>
+        <Texture Name="gGohmaTitleCardTex" OutName="gohma_title_card" Format="i8" Width="128" Height="80" Offset="0x19BA8"/>
 
         <!-- Door -->
         <DList Name="gGohmaDoorDL" Offset="0x1D820"/>

--- a/soh/assets/xml/GC_NMQ_NTSC_U/objects/object_kingdodongo.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_U/objects/object_kingdodongo.xml
@@ -48,7 +48,7 @@
         <Texture Name="object_kingdodongo_Tex_016D90" OutName="tex_00016D90" Format="rgba16" Width="8" Height="8" Offset="0x16D90"/>
         <Texture Name="object_kingdodongo_Tex_016E10" OutName="tex_00016E10" Format="rgba16" Width="32" Height="16" Offset="0x16E10"/>
         <Texture Name="object_kingdodongo_Tex_017210" OutName="tex_00017210" Format="rgba16" Width="8" Height="32" Offset="0x17210"/>
-        <Texture Name="gKingDodongoTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="120" Offset="0x17410"/>
+        <Texture Name="gKingDodongoTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="80" Offset="0x17410"/>
         <Limb Name="object_kingdodongo_Limb_01B010" LimbType="Standard" Offset="0x19C10"/>
         <Limb Name="object_kingdodongo_Limb_01B01C" LimbType="Standard" Offset="0x19C1C"/>
         <Limb Name="object_kingdodongo_Limb_01B028" LimbType="Standard" Offset="0x19C28"/>

--- a/soh/assets/xml/GC_NMQ_NTSC_U/objects/object_mo.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_U/objects/object_mo.xml
@@ -6,7 +6,7 @@
         <Texture Name="object_moTex_005520" OutName="object_moTex_005520" Format="ia16" Width="32" Height="32" Offset="0x4120" AddedByScript="true"/>
         <Texture Name="object_moTex_005D20" OutName="object_moTex_005D20" Format="ia16" Width="32" Height="32" Offset="0x4920" AddedByScript="true"/>
         <!-- Morpha's Title Card -->
-        <Texture Name="gMorphaTitleCardTex" Format="i8" Width="128" Height="120" Offset="0x1010"/>
+        <Texture Name="gMorphaTitleCardTex" Format="i8" Width="128" Height="80" Offset="0x1010"/>
         <Texture Name="gMorphaWaterTex" Format="rgba16" Width="32" Height="32" Offset="0x7470"/>
 
         <!-- DLists for Morpha's Core -->

--- a/soh/assets/xml/GC_NMQ_NTSC_U/objects/object_sst.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_U/objects/object_sst.xml
@@ -17,7 +17,7 @@
         <Texture Name="object_sstTex_01A730" OutName="object_sstTex_01A730" Format="rgba16" Width="4" Height="16" Offset="0x19330" AddedByScript="true"/>
         <Texture Name="object_sstTex_01A7B0" OutName="object_sstTex_01A7B0" Format="rgba16" Width="16" Height="16" Offset="0x193B0" AddedByScript="true"/>
         <!-- Boss Title Card -->
-        <Texture Name="gBongoTitleCardTex" OutName="bongo_title_card" Format="i8" Width="128" Height="120" Offset="0x13D80"/>
+        <Texture Name="gBongoTitleCardTex" OutName="bongo_title_card" Format="i8" Width="128" Height="80" Offset="0x13D80"/>
         
         <!-- Skeletons -->
         <Skeleton Name="gBongoLeftHandSkel" Type="Flex" LimbType="Standard" Offset="0x04DE0"/>

--- a/soh/assets/xml/GC_NMQ_NTSC_U/objects/object_tw.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_U/objects/object_tw.xml
@@ -273,7 +273,7 @@
         <DList Name="gTwinrovaBroomIceTrailDL" Offset="0x2DEB0"/>
         <DList Name="gTwinrovaBroomFireJetDL" Offset="0x2DFB0"/>
         <DList Name="gTwinrovaBroomFireTrailDL" Offset="0x2E098"/>
-        <Texture Name="gTwinrovaTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="120" Offset="0x2E170"/>
+        <Texture Name="gTwinrovaTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="80" Offset="0x2E170"/>
         <Limb Name="gTwinrovaPelvisLimb" LimbType="Standard" Offset="0x30970"/>
         <Limb Name="gTwinrovaSash1Limb" LimbType="Standard" Offset="0x3097C"/>
         <Limb Name="gTwinrovaSash2Limb" LimbType="Standard" Offset="0x30988"/>

--- a/soh/assets/xml/N64_NTSC_10/objects/object_bv.xml
+++ b/soh/assets/xml/N64_NTSC_10/objects/object_bv.xml
@@ -38,7 +38,7 @@
         <Texture Name="object_bvTLUT_01DBB0" OutName="object_bvTLUT_01DBB0" Format="rgba16" Width="16" Height="16" Offset="0x1C7B0" AddedByScript="true"/>
         <Texture Name="object_bvTLUT_01E6B0" OutName="object_bvTLUT_01E6B0" Format="rgba16" Width="16" Height="16" Offset="0x1D2B0" AddedByScript="true"/>
         <!-- Boss title card -->
-        <Texture Name="gBarinadeTitleCardTex" OutName="barinade_title_card" Format="i8" Width="128" Height="120" Offset="0x1230"/>
+        <Texture Name="gBarinadeTitleCardTex" OutName="barinade_title_card" Format="i8" Width="128" Height="80" Offset="0x1230"/>
 
         <Skeleton Name="gBarinadeBodySkel" Type="Normal" LimbType="Standard" Offset="0x14718"/>
         <Skeleton Name="gBarinadeSupportSkel" Type="Flex" LimbType="Standard" Offset="0x16098"/>

--- a/soh/assets/xml/N64_NTSC_10/objects/object_fd.xml
+++ b/soh/assets/xml/N64_NTSC_10/objects/object_fd.xml
@@ -28,7 +28,7 @@
         <Texture Name="object_fdTLUT_000A58" OutName="object_fdTLUT_000A58" Format="rgba16" Width="4" Height="4" Offset="0xA58" AddedByScript="true"/>
         <Texture Name="object_fdTLUT_0032A8" OutName="object_fdTLUT_0032A8" Format="rgba16" Width="16" Height="16" Offset="0x32A8" AddedByScript="true"/>
         <!-- Boss title card -->
-        <!-- <Texture Name="gVolvagiaTitleCardTex" OutName="volvagia_boss_title_card" Format="i8" Width="128" Height="120" Offset="0xD700"/> -->
+        <!-- <Texture Name="gVolvagiaTitleCardTex" OutName="volvagia_boss_title_card" Format="i8" Width="128" Height="80" Offset="0xD700"/> -->
 
         <!-- Skeletons -->
         <Skeleton Name="gVolvagiaLeftArmSkel" Type="Normal" LimbType="Standard" Offset="0x100E0"/>

--- a/soh/assets/xml/N64_NTSC_10/objects/object_fhg.xml
+++ b/soh/assets/xml/N64_NTSC_10/objects/object_fhg.xml
@@ -38,7 +38,7 @@
         <Animation Name="gPhantomHorseFenceJumpAnim" Offset="0xAD80"/>
         
         <!-- Boss title card -->
-        <Texture Name="gPhantomGanonTitleCardTex" OutName="phantom_ganon_title_card" Format="i8" Width="128" Height="120" Offset="0x59A0"/>
+        <Texture Name="gPhantomGanonTitleCardTex" OutName="phantom_ganon_title_card" Format="i8" Width="128" Height="80" Offset="0x59A0"/>
     
         <!-- Energy attack DLists -->
         <DList Name="gPhantomWarpDL" Offset="0xE6A0"/>

--- a/soh/assets/xml/N64_NTSC_10/objects/object_ganon.xml
+++ b/soh/assets/xml/N64_NTSC_10/objects/object_ganon.xml
@@ -68,7 +68,7 @@
         <DList Name="gGanondorfRightHandOpenDL" Offset="0xC9E8"/>
 
         <!-- Ganondorf Title Card Texture -->
-        <!-- <Texture Name="gGanondorfTitleCardTex" OutName="ganondorf_title_card" Format="i8" Width="128" Height="120" Offset="0xCF00"/> -->
+        <!-- <Texture Name="gGanondorfTitleCardTex" OutName="ganondorf_title_card" Format="i8" Width="128" Height="80" Offset="0xCF00"/> -->
 
         <!-- Ganondorf Animation -->
         <Animation Name="gGanondorfEndingFloatAnim" Offset="0xFF48"/> <!-- Original name is "ONOLEE" (lit. "Curse you!" from his in-game dialogue) -->

--- a/soh/assets/xml/N64_NTSC_10/objects/object_goma.xml
+++ b/soh/assets/xml/N64_NTSC_10/objects/object_goma.xml
@@ -159,7 +159,7 @@
         <Texture Name="gGohmaIrisTex" OutName="gohma_iris" Format="rgba16" Width="32" Height="32" Offset="0x193A8"/>
 
         <!-- Boss title card -->
-        <Texture Name="gGohmaTitleCardTex" OutName="gohma_title_card" Format="i8" Width="128" Height="120" Offset="0x19BA8"/>
+        <Texture Name="gGohmaTitleCardTex" OutName="gohma_title_card" Format="i8" Width="128" Height="80" Offset="0x19BA8"/>
 
         <!-- Door -->
         <DList Name="gGohmaDoorDL" Offset="0x1D820"/>

--- a/soh/assets/xml/N64_NTSC_10/objects/object_kingdodongo.xml
+++ b/soh/assets/xml/N64_NTSC_10/objects/object_kingdodongo.xml
@@ -48,7 +48,7 @@
         <Texture Name="object_kingdodongo_Tex_016D90" OutName="tex_00016D90" Format="rgba16" Width="8" Height="8" Offset="0x16D90"/>
         <Texture Name="object_kingdodongo_Tex_016E10" OutName="tex_00016E10" Format="rgba16" Width="32" Height="16" Offset="0x16E10"/>
         <Texture Name="object_kingdodongo_Tex_017210" OutName="tex_00017210" Format="rgba16" Width="8" Height="32" Offset="0x17210"/>
-        <Texture Name="gKingDodongoTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="120" Offset="0x17410"/>
+        <Texture Name="gKingDodongoTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="80" Offset="0x17410"/>
         <Limb Name="object_kingdodongo_Limb_01B010" LimbType="Standard" Offset="0x19C10"/>
         <Limb Name="object_kingdodongo_Limb_01B01C" LimbType="Standard" Offset="0x19C1C"/>
         <Limb Name="object_kingdodongo_Limb_01B028" LimbType="Standard" Offset="0x19C28"/>

--- a/soh/assets/xml/N64_NTSC_10/objects/object_mo.xml
+++ b/soh/assets/xml/N64_NTSC_10/objects/object_mo.xml
@@ -6,7 +6,7 @@
         <Texture Name="object_moTex_005520" OutName="object_moTex_005520" Format="ia16" Width="32" Height="32" Offset="0x4120" AddedByScript="true"/>
         <Texture Name="object_moTex_005D20" OutName="object_moTex_005D20" Format="ia16" Width="32" Height="32" Offset="0x4920" AddedByScript="true"/>
         <!-- Morpha's Title Card -->
-        <Texture Name="gMorphaTitleCardTex" Format="i8" Width="128" Height="120" Offset="0x1010"/>
+        <Texture Name="gMorphaTitleCardTex" Format="i8" Width="128" Height="80" Offset="0x1010"/>
         <Texture Name="gMorphaWaterTex" Format="rgba16" Width="32" Height="32" Offset="0x7470"/>
 
         <!-- DLists for Morpha's Core -->

--- a/soh/assets/xml/N64_NTSC_10/objects/object_sst.xml
+++ b/soh/assets/xml/N64_NTSC_10/objects/object_sst.xml
@@ -17,7 +17,7 @@
         <Texture Name="object_sstTex_01A730" OutName="object_sstTex_01A730" Format="rgba16" Width="4" Height="16" Offset="0x19330" AddedByScript="true"/>
         <Texture Name="object_sstTex_01A7B0" OutName="object_sstTex_01A7B0" Format="rgba16" Width="16" Height="16" Offset="0x193B0" AddedByScript="true"/>
         <!-- Boss Title Card -->
-        <Texture Name="gBongoTitleCardTex" OutName="bongo_title_card" Format="i8" Width="128" Height="120" Offset="0x13D80"/>
+        <Texture Name="gBongoTitleCardTex" OutName="bongo_title_card" Format="i8" Width="128" Height="80" Offset="0x13D80"/>
         
         <!-- Skeletons -->
         <Skeleton Name="gBongoLeftHandSkel" Type="Flex" LimbType="Standard" Offset="0x04DE0"/>

--- a/soh/assets/xml/N64_NTSC_10/objects/object_tw.xml
+++ b/soh/assets/xml/N64_NTSC_10/objects/object_tw.xml
@@ -273,7 +273,7 @@
         <DList Name="gTwinrovaBroomIceTrailDL" Offset="0x2DEB0"/>
         <DList Name="gTwinrovaBroomFireJetDL" Offset="0x2DFB0"/>
         <DList Name="gTwinrovaBroomFireTrailDL" Offset="0x2E098"/>
-        <Texture Name="gTwinrovaTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="120" Offset="0x2E170"/>
+        <Texture Name="gTwinrovaTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="80" Offset="0x2E170"/>
         <Limb Name="gTwinrovaPelvisLimb" LimbType="Standard" Offset="0x30970"/>
         <Limb Name="gTwinrovaSash1Limb" LimbType="Standard" Offset="0x3097C"/>
         <Limb Name="gTwinrovaSash2Limb" LimbType="Standard" Offset="0x30988"/>

--- a/soh/assets/xml/N64_NTSC_11/objects/object_bv.xml
+++ b/soh/assets/xml/N64_NTSC_11/objects/object_bv.xml
@@ -38,7 +38,7 @@
         <Texture Name="object_bvTLUT_01DBB0" OutName="object_bvTLUT_01DBB0" Format="rgba16" Width="16" Height="16" Offset="0x1C7B0" AddedByScript="true"/>
         <Texture Name="object_bvTLUT_01E6B0" OutName="object_bvTLUT_01E6B0" Format="rgba16" Width="16" Height="16" Offset="0x1D2B0" AddedByScript="true"/>
         <!-- Boss title card -->
-        <Texture Name="gBarinadeTitleCardTex" OutName="barinade_title_card" Format="i8" Width="128" Height="120" Offset="0x1230"/>
+        <Texture Name="gBarinadeTitleCardTex" OutName="barinade_title_card" Format="i8" Width="128" Height="80" Offset="0x1230"/>
 
         <Skeleton Name="gBarinadeBodySkel" Type="Normal" LimbType="Standard" Offset="0x14718"/>
         <Skeleton Name="gBarinadeSupportSkel" Type="Flex" LimbType="Standard" Offset="0x16098"/>

--- a/soh/assets/xml/N64_NTSC_11/objects/object_fd.xml
+++ b/soh/assets/xml/N64_NTSC_11/objects/object_fd.xml
@@ -28,7 +28,7 @@
         <Texture Name="object_fdTLUT_000A58" OutName="object_fdTLUT_000A58" Format="rgba16" Width="4" Height="4" Offset="0xA58" AddedByScript="true"/>
         <Texture Name="object_fdTLUT_0032A8" OutName="object_fdTLUT_0032A8" Format="rgba16" Width="16" Height="16" Offset="0x32A8" AddedByScript="true"/>
         <!-- Boss title card -->
-        <!-- <Texture Name="gVolvagiaTitleCardTex" OutName="volvagia_boss_title_card" Format="i8" Width="128" Height="120" Offset="0xD700"/> -->
+        <!-- <Texture Name="gVolvagiaTitleCardTex" OutName="volvagia_boss_title_card" Format="i8" Width="128" Height="80" Offset="0xD700"/> -->
 
         <!-- Skeletons -->
         <Skeleton Name="gVolvagiaLeftArmSkel" Type="Normal" LimbType="Standard" Offset="0x100E0"/>

--- a/soh/assets/xml/N64_NTSC_11/objects/object_fhg.xml
+++ b/soh/assets/xml/N64_NTSC_11/objects/object_fhg.xml
@@ -38,7 +38,7 @@
         <Animation Name="gPhantomHorseFenceJumpAnim" Offset="0xAD80"/>
         
         <!-- Boss title card -->
-        <Texture Name="gPhantomGanonTitleCardTex" OutName="phantom_ganon_title_card" Format="i8" Width="128" Height="120" Offset="0x59A0"/>
+        <Texture Name="gPhantomGanonTitleCardTex" OutName="phantom_ganon_title_card" Format="i8" Width="128" Height="80" Offset="0x59A0"/>
     
         <!-- Energy attack DLists -->
         <DList Name="gPhantomWarpDL" Offset="0xE6A0"/>

--- a/soh/assets/xml/N64_NTSC_11/objects/object_ganon.xml
+++ b/soh/assets/xml/N64_NTSC_11/objects/object_ganon.xml
@@ -68,7 +68,7 @@
         <DList Name="gGanondorfRightHandOpenDL" Offset="0xC9E8"/>
 
         <!-- Ganondorf Title Card Texture -->
-        <!-- <Texture Name="gGanondorfTitleCardTex" OutName="ganondorf_title_card" Format="i8" Width="128" Height="120" Offset="0xCF00"/> -->
+        <!-- <Texture Name="gGanondorfTitleCardTex" OutName="ganondorf_title_card" Format="i8" Width="128" Height="80" Offset="0xCF00"/> -->
 
         <!-- Ganondorf Animation -->
         <Animation Name="gGanondorfEndingFloatAnim" Offset="0xFF48"/> <!-- Original name is "ONOLEE" (lit. "Curse you!" from his in-game dialogue) -->

--- a/soh/assets/xml/N64_NTSC_11/objects/object_goma.xml
+++ b/soh/assets/xml/N64_NTSC_11/objects/object_goma.xml
@@ -159,7 +159,7 @@
         <Texture Name="gGohmaIrisTex" OutName="gohma_iris" Format="rgba16" Width="32" Height="32" Offset="0x193A8"/>
 
         <!-- Boss title card -->
-        <Texture Name="gGohmaTitleCardTex" OutName="gohma_title_card" Format="i8" Width="128" Height="120" Offset="0x19BA8"/>
+        <Texture Name="gGohmaTitleCardTex" OutName="gohma_title_card" Format="i8" Width="128" Height="80" Offset="0x19BA8"/>
 
         <!-- Door -->
         <DList Name="gGohmaDoorDL" Offset="0x1D820"/>

--- a/soh/assets/xml/N64_NTSC_11/objects/object_kingdodongo.xml
+++ b/soh/assets/xml/N64_NTSC_11/objects/object_kingdodongo.xml
@@ -48,7 +48,7 @@
         <Texture Name="object_kingdodongo_Tex_016D90" OutName="tex_00016D90" Format="rgba16" Width="8" Height="8" Offset="0x16D90"/>
         <Texture Name="object_kingdodongo_Tex_016E10" OutName="tex_00016E10" Format="rgba16" Width="32" Height="16" Offset="0x16E10"/>
         <Texture Name="object_kingdodongo_Tex_017210" OutName="tex_00017210" Format="rgba16" Width="8" Height="32" Offset="0x17210"/>
-        <Texture Name="gKingDodongoTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="120" Offset="0x17410"/>
+        <Texture Name="gKingDodongoTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="80" Offset="0x17410"/>
         <Limb Name="object_kingdodongo_Limb_01B010" LimbType="Standard" Offset="0x19C10"/>
         <Limb Name="object_kingdodongo_Limb_01B01C" LimbType="Standard" Offset="0x19C1C"/>
         <Limb Name="object_kingdodongo_Limb_01B028" LimbType="Standard" Offset="0x19C28"/>

--- a/soh/assets/xml/N64_NTSC_11/objects/object_mo.xml
+++ b/soh/assets/xml/N64_NTSC_11/objects/object_mo.xml
@@ -6,7 +6,7 @@
         <Texture Name="object_moTex_005520" OutName="object_moTex_005520" Format="ia16" Width="32" Height="32" Offset="0x4120" AddedByScript="true"/>
         <Texture Name="object_moTex_005D20" OutName="object_moTex_005D20" Format="ia16" Width="32" Height="32" Offset="0x4920" AddedByScript="true"/>
         <!-- Morpha's Title Card -->
-        <Texture Name="gMorphaTitleCardTex" Format="i8" Width="128" Height="120" Offset="0x1010"/>
+        <Texture Name="gMorphaTitleCardTex" Format="i8" Width="128" Height="80" Offset="0x1010"/>
         <Texture Name="gMorphaWaterTex" Format="rgba16" Width="32" Height="32" Offset="0x7470"/>
 
         <!-- DLists for Morpha's Core -->

--- a/soh/assets/xml/N64_NTSC_11/objects/object_sst.xml
+++ b/soh/assets/xml/N64_NTSC_11/objects/object_sst.xml
@@ -17,7 +17,7 @@
         <Texture Name="object_sstTex_01A730" OutName="object_sstTex_01A730" Format="rgba16" Width="4" Height="16" Offset="0x19330" AddedByScript="true"/>
         <Texture Name="object_sstTex_01A7B0" OutName="object_sstTex_01A7B0" Format="rgba16" Width="16" Height="16" Offset="0x193B0" AddedByScript="true"/>
         <!-- Boss Title Card -->
-        <Texture Name="gBongoTitleCardTex" OutName="bongo_title_card" Format="i8" Width="128" Height="120" Offset="0x13D80"/>
+        <Texture Name="gBongoTitleCardTex" OutName="bongo_title_card" Format="i8" Width="128" Height="80" Offset="0x13D80"/>
         
         <!-- Skeletons -->
         <Skeleton Name="gBongoLeftHandSkel" Type="Flex" LimbType="Standard" Offset="0x04DE0"/>

--- a/soh/assets/xml/N64_NTSC_11/objects/object_tw.xml
+++ b/soh/assets/xml/N64_NTSC_11/objects/object_tw.xml
@@ -273,7 +273,7 @@
         <DList Name="gTwinrovaBroomIceTrailDL" Offset="0x2DEB0"/>
         <DList Name="gTwinrovaBroomFireJetDL" Offset="0x2DFB0"/>
         <DList Name="gTwinrovaBroomFireTrailDL" Offset="0x2E098"/>
-        <Texture Name="gTwinrovaTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="120" Offset="0x2E170"/>
+        <Texture Name="gTwinrovaTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="80" Offset="0x2E170"/>
         <Limb Name="gTwinrovaPelvisLimb" LimbType="Standard" Offset="0x30970"/>
         <Limb Name="gTwinrovaSash1Limb" LimbType="Standard" Offset="0x3097C"/>
         <Limb Name="gTwinrovaSash2Limb" LimbType="Standard" Offset="0x30988"/>

--- a/soh/assets/xml/N64_NTSC_12/objects/object_bv.xml
+++ b/soh/assets/xml/N64_NTSC_12/objects/object_bv.xml
@@ -38,7 +38,7 @@
         <Texture Name="object_bvTLUT_01DBB0" OutName="object_bvTLUT_01DBB0" Format="rgba16" Width="16" Height="16" Offset="0x1C7B0" AddedByScript="true"/>
         <Texture Name="object_bvTLUT_01E6B0" OutName="object_bvTLUT_01E6B0" Format="rgba16" Width="16" Height="16" Offset="0x1D2B0" AddedByScript="true"/>
         <!-- Boss title card -->
-        <Texture Name="gBarinadeTitleCardTex" OutName="barinade_title_card" Format="i8" Width="128" Height="120" Offset="0x1230"/>
+        <Texture Name="gBarinadeTitleCardTex" OutName="barinade_title_card" Format="i8" Width="128" Height="80" Offset="0x1230"/>
 
         <Skeleton Name="gBarinadeBodySkel" Type="Normal" LimbType="Standard" Offset="0x14718"/>
         <Skeleton Name="gBarinadeSupportSkel" Type="Flex" LimbType="Standard" Offset="0x16098"/>

--- a/soh/assets/xml/N64_NTSC_12/objects/object_fd.xml
+++ b/soh/assets/xml/N64_NTSC_12/objects/object_fd.xml
@@ -28,7 +28,7 @@
         <Texture Name="object_fdTLUT_000A58" OutName="object_fdTLUT_000A58" Format="rgba16" Width="4" Height="4" Offset="0xA58" AddedByScript="true"/>
         <Texture Name="object_fdTLUT_0032A8" OutName="object_fdTLUT_0032A8" Format="rgba16" Width="16" Height="16" Offset="0x32A8" AddedByScript="true"/>
         <!-- Boss title card -->
-        <!-- <Texture Name="gVolvagiaTitleCardTex" OutName="volvagia_boss_title_card" Format="i8" Width="128" Height="120" Offset="0xD700"/> -->
+        <!-- <Texture Name="gVolvagiaTitleCardTex" OutName="volvagia_boss_title_card" Format="i8" Width="128" Height="80" Offset="0xD700"/> -->
 
         <!-- Skeletons -->
         <Skeleton Name="gVolvagiaLeftArmSkel" Type="Normal" LimbType="Standard" Offset="0x100E0"/>

--- a/soh/assets/xml/N64_NTSC_12/objects/object_fhg.xml
+++ b/soh/assets/xml/N64_NTSC_12/objects/object_fhg.xml
@@ -38,7 +38,7 @@
         <Animation Name="gPhantomHorseFenceJumpAnim" Offset="0xAD80"/>
         
         <!-- Boss title card -->
-        <Texture Name="gPhantomGanonTitleCardTex" OutName="phantom_ganon_title_card" Format="i8" Width="128" Height="120" Offset="0x59A0"/>
+        <Texture Name="gPhantomGanonTitleCardTex" OutName="phantom_ganon_title_card" Format="i8" Width="128" Height="80" Offset="0x59A0"/>
     
         <!-- Energy attack DLists -->
         <DList Name="gPhantomWarpDL" Offset="0xE6A0"/>

--- a/soh/assets/xml/N64_NTSC_12/objects/object_ganon.xml
+++ b/soh/assets/xml/N64_NTSC_12/objects/object_ganon.xml
@@ -68,7 +68,7 @@
         <DList Name="gGanondorfRightHandOpenDL" Offset="0xC9E8"/>
 
         <!-- Ganondorf Title Card Texture -->
-        <!-- <Texture Name="gGanondorfTitleCardTex" OutName="ganondorf_title_card" Format="i8" Width="128" Height="120" Offset="0xCF00"/> -->
+        <!-- <Texture Name="gGanondorfTitleCardTex" OutName="ganondorf_title_card" Format="i8" Width="128" Height="80" Offset="0xCF00"/> -->
 
         <!-- Ganondorf Animation -->
         <Animation Name="gGanondorfEndingFloatAnim" Offset="0xFF48"/> <!-- Original name is "ONOLEE" (lit. "Curse you!" from his in-game dialogue) -->

--- a/soh/assets/xml/N64_NTSC_12/objects/object_goma.xml
+++ b/soh/assets/xml/N64_NTSC_12/objects/object_goma.xml
@@ -159,7 +159,7 @@
         <Texture Name="gGohmaIrisTex" OutName="gohma_iris" Format="rgba16" Width="32" Height="32" Offset="0x193A8"/>
 
         <!-- Boss title card -->
-        <Texture Name="gGohmaTitleCardTex" OutName="gohma_title_card" Format="i8" Width="128" Height="120" Offset="0x19BA8"/>
+        <Texture Name="gGohmaTitleCardTex" OutName="gohma_title_card" Format="i8" Width="128" Height="80" Offset="0x19BA8"/>
 
         <!-- Door -->
         <DList Name="gGohmaDoorDL" Offset="0x1D820"/>

--- a/soh/assets/xml/N64_NTSC_12/objects/object_kingdodongo.xml
+++ b/soh/assets/xml/N64_NTSC_12/objects/object_kingdodongo.xml
@@ -48,7 +48,7 @@
         <Texture Name="object_kingdodongo_Tex_016D90" OutName="tex_00016D90" Format="rgba16" Width="8" Height="8" Offset="0x16D90"/>
         <Texture Name="object_kingdodongo_Tex_016E10" OutName="tex_00016E10" Format="rgba16" Width="32" Height="16" Offset="0x16E10"/>
         <Texture Name="object_kingdodongo_Tex_017210" OutName="tex_00017210" Format="rgba16" Width="8" Height="32" Offset="0x17210"/>
-        <Texture Name="gKingDodongoTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="120" Offset="0x17410"/>
+        <Texture Name="gKingDodongoTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="80" Offset="0x17410"/>
         <Limb Name="object_kingdodongo_Limb_01B010" LimbType="Standard" Offset="0x19C10"/>
         <Limb Name="object_kingdodongo_Limb_01B01C" LimbType="Standard" Offset="0x19C1C"/>
         <Limb Name="object_kingdodongo_Limb_01B028" LimbType="Standard" Offset="0x19C28"/>

--- a/soh/assets/xml/N64_NTSC_12/objects/object_mo.xml
+++ b/soh/assets/xml/N64_NTSC_12/objects/object_mo.xml
@@ -6,7 +6,7 @@
         <Texture Name="object_moTex_005520" OutName="object_moTex_005520" Format="ia16" Width="32" Height="32" Offset="0x4120" AddedByScript="true"/>
         <Texture Name="object_moTex_005D20" OutName="object_moTex_005D20" Format="ia16" Width="32" Height="32" Offset="0x4920" AddedByScript="true"/>
         <!-- Morpha's Title Card -->
-        <Texture Name="gMorphaTitleCardTex" Format="i8" Width="128" Height="120" Offset="0x1010"/>
+        <Texture Name="gMorphaTitleCardTex" Format="i8" Width="128" Height="80" Offset="0x1010"/>
         <Texture Name="gMorphaWaterTex" Format="rgba16" Width="32" Height="32" Offset="0x7470"/>
 
         <!-- DLists for Morpha's Core -->

--- a/soh/assets/xml/N64_NTSC_12/objects/object_sst.xml
+++ b/soh/assets/xml/N64_NTSC_12/objects/object_sst.xml
@@ -17,7 +17,7 @@
         <Texture Name="object_sstTex_01A730" OutName="object_sstTex_01A730" Format="rgba16" Width="4" Height="16" Offset="0x19330" AddedByScript="true"/>
         <Texture Name="object_sstTex_01A7B0" OutName="object_sstTex_01A7B0" Format="rgba16" Width="16" Height="16" Offset="0x193B0" AddedByScript="true"/>
         <!-- Boss Title Card -->
-        <Texture Name="gBongoTitleCardTex" OutName="bongo_title_card" Format="i8" Width="128" Height="120" Offset="0x13D80"/>
+        <Texture Name="gBongoTitleCardTex" OutName="bongo_title_card" Format="i8" Width="128" Height="80" Offset="0x13D80"/>
         
         <!-- Skeletons -->
         <Skeleton Name="gBongoLeftHandSkel" Type="Flex" LimbType="Standard" Offset="0x04DE0"/>

--- a/soh/assets/xml/N64_NTSC_12/objects/object_tw.xml
+++ b/soh/assets/xml/N64_NTSC_12/objects/object_tw.xml
@@ -273,7 +273,7 @@
         <DList Name="gTwinrovaBroomIceTrailDL" Offset="0x2DEB0"/>
         <DList Name="gTwinrovaBroomFireJetDL" Offset="0x2DFB0"/>
         <DList Name="gTwinrovaBroomFireTrailDL" Offset="0x2E098"/>
-        <Texture Name="gTwinrovaTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="120" Offset="0x2E170"/>
+        <Texture Name="gTwinrovaTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="80" Offset="0x2E170"/>
         <Limb Name="gTwinrovaPelvisLimb" LimbType="Standard" Offset="0x30970"/>
         <Limb Name="gTwinrovaSash1Limb" LimbType="Standard" Offset="0x3097C"/>
         <Limb Name="gTwinrovaSash2Limb" LimbType="Standard" Offset="0x30988"/>


### PR DESCRIPTION
This updates the size of the boss title cards being extracted for NTCS. They only have two languages so they should be smaller in height than PAL. In some cases, this over extraction caused issues with auto Vtx extraction, which broken the DL for the water in Morpha's room.

Fixes #5308 

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2883382854.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2883389441.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2883464256.zip)
<!--- section:artifacts:end -->