### PR TITLE
Various menu fixes

### DIFF
--- a/soh/soh/Enhancements/controls/InputViewer.cpp
+++ b/soh/soh/Enhancements/controls/InputViewer.cpp
@@ -584,7 +584,7 @@ void InputViewerSettingsWindow::DrawElement() {
         }
         // gInputViewer.Dpad
         CVarCheckbox("Show D-Pad Layers", CVAR_INPUT_VIEWER("Dpad"),
-                     CheckboxOptions().Color(THEME_COLOR).DefaultValue(true));
+                     CheckboxOptions().Color(THEME_COLOR).DefaultValue(false));
         if (useIndividualOutlines && CVarGetInteger(CVAR_INPUT_VIEWER("Dpad"), 0)) {
             ImGui::Indent();
             CVarCombobox("##DpadOutline", CVAR_INPUT_VIEWER("DpadOutlineMode"), buttonOutlineOptionsVerbose,
@@ -593,7 +593,7 @@ void InputViewerSettingsWindow::DrawElement() {
         }
         // gInputViewer.Mod1
         CVarCheckbox("Show Modifier Button 1 Layers", CVAR_INPUT_VIEWER("Mod1"),
-                     CheckboxOptions().Color(THEME_COLOR).DefaultValue(true));
+                     CheckboxOptions().Color(THEME_COLOR).DefaultValue(false));
         if (useIndividualOutlines && CVarGetInteger(CVAR_INPUT_VIEWER("Mod1"), 0)) {
             ImGui::Indent();
             CVarCombobox("##Mmod1Outline", CVAR_INPUT_VIEWER("Mod1OutlineMode"), buttonOutlineOptionsVerbose,
@@ -602,7 +602,7 @@ void InputViewerSettingsWindow::DrawElement() {
         }
         // gInputViewer.Mod2
         CVarCheckbox("Show Modifier Button 2 Layers", CVAR_INPUT_VIEWER("Mod2"),
-                     CheckboxOptions().Color(THEME_COLOR).DefaultValue(true));
+                     CheckboxOptions().Color(THEME_COLOR).DefaultValue(false));
         if (useIndividualOutlines && CVarGetInteger(CVAR_INPUT_VIEWER("Mod2"), 0)) {
             ImGui::Indent();
             CVarCombobox("##Mod2Outline", CVAR_INPUT_VIEWER("Mod2OutlineMode"), buttonOutlineOptionsVerbose,
@@ -652,7 +652,7 @@ void InputViewerSettingsWindow::DrawElement() {
             "Right Stick Visibility", CVAR_INPUT_VIEWER("RightStick.VisibilityMode"), stickModeOptions,
             ComboboxOptions()
                 .Color(THEME_COLOR)
-                .DefaultIndex(STICK_MODE_ALWAYS_SHOWN)
+                .DefaultIndex(STICK_MODE_ALWAYS_HIDDEN)
                 .Tooltip(
                     "Determines the conditions under which the moving layer of the right stick texture is visible."));
 
@@ -661,7 +661,7 @@ void InputViewerSettingsWindow::DrawElement() {
             "Right Stick Outline/Background Visibility", CVAR_INPUT_VIEWER("RightStick.OutlineMode"), stickModeOptions,
             ComboboxOptions()
                 .Color(THEME_COLOR)
-                .DefaultIndex(STICK_MODE_ALWAYS_SHOWN)
+                .DefaultIndex(STICK_MODE_ALWAYS_HIDDEN)
                 .Tooltip(
                     "Determines the conditions under which the right stick outline/background texture is visible."));
 

--- a/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
@@ -1839,7 +1839,8 @@ void ItemTrackerSettingsWindow::DrawElement() {
     }
     if (CVarGetInteger(CVAR_TRACKER_ITEM("DisplayType.DungeonRewards"), SECTION_DISPLAY_MAIN_WINDOW) ==
         SECTION_DISPLAY_SEPARATE) {
-        if (CVarCheckbox("Circle display", CVAR_TRACKER_ITEM("DungeonRewardsLayout"))) {
+        if (CVarCheckbox("Circle display", CVAR_TRACKER_ITEM("DungeonRewardsLayout"),
+                         CheckboxOptions().DefaultValue(false).Color(THEME_COLOR))) {
             shouldUpdateVectors = true;
         }
     }

--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -778,8 +778,7 @@ void SohMenu::AddMenuEnhancements() {
             "Change aiming for the Boomerang from Third-Person to First-Person to see past Link's head."));
     AddWidget(path, "Aiming Reticle for Boomerang", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("BoomerangReticle"))
-        .PreFunc(
-            [](WidgetInfo& info) { info.isHidden = !CVarGetInteger(CVAR_ENHANCEMENT("BoomerangFirstPerson"), 0); })
+        .PreFunc([](WidgetInfo& info) { info.isHidden = !CVarGetInteger(CVAR_ENHANCEMENT("BoomerangFirstPerson"), 0); })
         .Options(CheckboxOptions().Tooltip("Aiming with the Boomerang will display a reticle as with the Hookshot."));
 
     AddWidget(path, "Magic Spells", WIDGET_SEPARATOR_TEXT);

--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -562,7 +562,7 @@ void SohMenu::AddMenuEnhancements() {
     AddWidget(path, "Kokiri Draw Distance", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("DisableKokiriDrawDistance"))
         .PreFunc(
-            [](WidgetInfo& info) { info.isHidden = CVarGetInteger(CVAR_ENHANCEMENT("DisableDrawDistance"), 1) > 1; })
+            [](WidgetInfo& info) { info.isHidden = CVarGetInteger(CVAR_ENHANCEMENT("DisableDrawDistance"), 1) <= 1; })
         .Options(CheckboxOptions().Tooltip(
             "The Kokiri are mystical beings that fade into view when approached. Enabling this will remove their "
             "draw distance."));
@@ -777,9 +777,9 @@ void SohMenu::AddMenuEnhancements() {
         .Options(CheckboxOptions().Tooltip(
             "Change aiming for the Boomerang from Third-Person to First-Person to see past Link's head."));
     AddWidget(path, "Aiming Reticle for Boomerang", WIDGET_CVAR_CHECKBOX)
-        .CVar(CVAR_ENHANCEMENT("BoomerangFirstPerson"))
+        .CVar(CVAR_ENHANCEMENT("BoomerangReticle"))
         .PreFunc(
-            [](WidgetInfo& info) { info.isHidden = CVarGetInteger(CVAR_ENHANCEMENT("BoomerangFirstPerson"), 0) != 0; })
+            [](WidgetInfo& info) { info.isHidden = !CVarGetInteger(CVAR_ENHANCEMENT("BoomerangFirstPerson"), 0); })
         .Options(CheckboxOptions().Tooltip("Aiming with the Boomerang will display a reticle as with the Hookshot."));
 
     AddWidget(path, "Magic Spells", WIDGET_SEPARATOR_TEXT);


### PR DESCRIPTION
Fixes #5289 

Also fixes a few incorrect defaults in the Input Viewer and applies the theme color to the Dungeon Rewards Circle Display option in the Item Tracker


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2884419723.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2884429169.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2884489037.zip)
<!--- section:artifacts:end -->