### PR TITLE
Fix copyright tex for GC JP

### DIFF
--- a/soh/assets/objects/object_mag/object_mag.h
+++ b/soh/assets/objects/object_mag/object_mag.h
@@ -18,6 +18,12 @@ static const ALIGN_ASSET(2) char gTitleCopyright19982002Tex[] = dgTitleCopyright
 #define dgTitleCopyright19982003Tex "__OTR__objects/object_mag/gTitleCopyright19982003Tex"
 static const ALIGN_ASSET(2) char gTitleCopyright19982003Tex[] = dgTitleCopyright19982003Tex;
 
+#define dgTitleCopyright19982004EngTex "__OTR__objects/object_mag/gTitleCopyright19982004EngTex"
+static const ALIGN_ASSET(2) char gTitleCopyright19982004EngTex[] = dgTitleCopyright19982004EngTex;
+
+#define dgTitleCopyright19982004JpnTex "__OTR__objects/object_mag/gTitleCopyright19982004JpnTex"
+static const ALIGN_ASSET(2) char gTitleCopyright19982004JpnTex[] = dgTitleCopyright19982004JpnTex;
+
 #define dgTitleMasterQuestSubtitleTex "__OTR__objects/object_mag/gTitleMasterQuestSubtitleTex"
 static const ALIGN_ASSET(2) char gTitleMasterQuestSubtitleTex[] = dgTitleMasterQuestSubtitleTex;
 

--- a/soh/assets/xml/GC_MQ_NTSC_J/objects/object_mag.xml
+++ b/soh/assets/xml/GC_MQ_NTSC_J/objects/object_mag.xml
@@ -1,7 +1,7 @@
 <Root>
     <File Name="object_mag" Segment="6">
         <Texture Name="gTitleZeldaShieldLogoMQTex" OutName="title_zelda_shield_logo_mq" Format="rgba32" Width="160" Height="160" Offset="0x0"/>
-        <Texture Name="gTitleCopyright19982003Tex" OutName="title_copyright_19982003" Format="ia8" Width="160" Height="16" Offset="0x19000"/>
+        <Texture Name="gTitleCopyright19982002Tex" OutName="title_copyright_19982002" Format="ia8" Width="160" Height="16" Offset="0x19000"/>
         <Texture Name="gTitleEffectMask00Tex" OutName="title_effect_mask_0_0" Format="i4" Width="64" Height="64" Offset="0x1B600"/>
         <Texture Name="gTitleEffectMask01Tex" OutName="title_effect_mask_0_1" Format="i4" Width="64" Height="64" Offset="0x1BE00"/>
         <Texture Name="gTitleEffectMask02Tex" OutName="title_effect_mask_0_2" Format="i4" Width="64" Height="64" Offset="0x1C600"/>

--- a/soh/assets/xml/GC_NMQ_NTSC_J/objects/object_mag.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_J/objects/object_mag.xml
@@ -1,7 +1,7 @@
 <Root>
     <File Name="object_mag" Segment="6">
         <Texture Name="gTitleZeldaShieldLogoMQTex" OutName="title_zelda_shield_logo_mq" Format="rgba32" Width="160" Height="160" Offset="0x0"/>
-        <Texture Name="gTitleCopyright19982003Tex" OutName="title_copyright_19982003" Format="ia8" Width="160" Height="16" Offset="0x19000"/>
+        <Texture Name="gTitleCopyright19982002Tex" OutName="title_copyright_19982002" Format="ia8" Width="160" Height="16" Offset="0x19000"/>
         <Texture Name="gTitleDiskTex" OutName="title_disk" Format="ia8" Width="48" Height="16" Offset="0x19A00"/>
         <Texture Name="gTitleEffectMask00Tex" OutName="title_effect_mask_0_0" Format="i4" Width="64" Height="64" Offset="0x19D00"/>
         <Texture Name="gTitleEffectMask01Tex" OutName="title_effect_mask_0_1" Format="i4" Width="64" Height="64" Offset="0x1A500"/>

--- a/soh/assets/xml/GC_NMQ_NTSC_J_CE/objects/object_mag.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_J_CE/objects/object_mag.xml
@@ -1,8 +1,8 @@
 <Root>
     <File Name="object_mag" Segment="6">
         <Texture Name="gTitleZeldaShieldLogoMQTex" OutName="title_zelda_shield_logo_mq" Format="rgba32" Width="160" Height="160" Offset="0x0"/>
-        <Texture Name="gTitleCopyright19982002Tex" OutName="title_copyright_19982002" Format="ia8" Width="160" Height="16" Offset="0x19000"/>
-        <Texture Name="gTitleCopyright19982003Tex" OutName="title_copyright_19982003" Format="ia8" Width="160" Height="16" Offset="0x19A00"/>
+        <Texture Name="gTitleCopyright19982004JpnTex" OutName="title_copyright_19982004_jpn" Format="ia8" Width="160" Height="16" Offset="0x19000"/>
+        <Texture Name="gTitleCopyright19982004EngTex" OutName="title_copyright_19982004_eng" Format="ia8" Width="160" Height="16" Offset="0x19A00"/>
         <Texture Name="gTitleDiskTex" OutName="title_disk" Format="ia8" Width="48" Height="16" Offset="0x1A400"/>
         <Texture Name="gTitleEffectMask00Tex" OutName="title_effect_mask_0_0" Format="i4" Width="64" Height="64" Offset="0x1A700"/>
         <Texture Name="gTitleEffectMask01Tex" OutName="title_effect_mask_0_1" Format="i4" Width="64" Height="64" Offset="0x1AF00"/>

--- a/soh/src/overlays/actors/ovl_En_Mag/z_en_mag.c
+++ b/soh/src/overlays/actors/ovl_En_Mag/z_en_mag.c
@@ -484,8 +484,11 @@ bool EnMag_ShouldDrawPressStart(Font* font, Gfx** gfxP, bool isActualText) {
 // Title logo is shifted to the left in Master Quest
 #define LOGO_X_SHIFT (isMQ ? 0 : -8)
 #define LOGO_TEX (isMQ ? gTitleZeldaShieldLogoMQTex : gTitleZeldaShieldLogoTex)
-// Copyright texture is larger on GC
-#define COPYRIGHT_TEX (isGC ? gTitleCopyright19982003Tex : gTitleCopyright1998Tex)
+// Copyright texture is larger on GC and different
+#define COPYRIGHT_TEX                                                                               \
+    (isGC ? ((isJpnGC_notCE || gSaveContext.language == LANGUAGE_JPN) ? gTitleCopyright19982002Tex  \
+                                                                      : gTitleCopyright19982003Tex) \
+          : gTitleCopyright1998Tex)
 #define COPYRIGHT_TEX_WIDTH (isGC ? 160 : 128)
 #define COPYRIGHT_TEX_LEFT (isGC ? 78 : 94)
 
@@ -515,6 +518,8 @@ void EnMag_DrawInner(Actor* thisx, PlayState* play, Gfx** gfxP) {
     u16 rectTop;
     bool isMQ = ResourceMgr_IsGameMasterQuest();
     bool isGC = ResourceMgr_GetGamePlatform(0) == GAME_PLATFORM_GC;
+    bool isJpnGC_notCE =
+        isGC && (ResourceMgr_GetGameVersion(0) == OOT_NTSC_JP_GC || ResourceMgr_GetGameVersion(0) == OOT_NTSC_JP_MQ);
 
     gSPSegment(gfx++, 0x06, play->objectCtx.status[this->actor.objBankIndex].segment);
 

--- a/soh/src/overlays/actors/ovl_En_Mag/z_en_mag.c
+++ b/soh/src/overlays/actors/ovl_En_Mag/z_en_mag.c
@@ -484,11 +484,17 @@ bool EnMag_ShouldDrawPressStart(Font* font, Gfx** gfxP, bool isActualText) {
 // Title logo is shifted to the left in Master Quest
 #define LOGO_X_SHIFT (isMQ ? 0 : -8)
 #define LOGO_TEX (isMQ ? gTitleZeldaShieldLogoMQTex : gTitleZeldaShieldLogoTex)
-// Copyright texture is larger on GC and different
-#define COPYRIGHT_TEX                                                                               \
-    (isGC ? ((isJpnGC_notCE || gSaveContext.language == LANGUAGE_JPN) ? gTitleCopyright19982002Tex  \
-                                                                      : gTitleCopyright19982003Tex) \
-          : gTitleCopyright1998Tex)
+// Copyright texture is different depending on the version
+// JPN CE displays two slightly different 2004 copyrights when lang is jpn or not
+// Otherwise the other GC JPN versions either display 2002 for JPN or 2003 for others
+// Else fallback to 2003 for GC or 1998 for N64
+#define COPYRIGHT_TEX                                                                                              \
+    (isJpnGC_CE                                                                                                    \
+         ? (gSaveContext.language == LANGUAGE_JPN ? gTitleCopyright19982004JpnTex : gTitleCopyright19982004EngTex) \
+         : (isGC ? ((isJpnGC_notCE || gSaveContext.language == LANGUAGE_JPN) ? gTitleCopyright19982002Tex          \
+                                                                             : gTitleCopyright19982003Tex)         \
+                 : gTitleCopyright1998Tex))
+// Copyright texture is larger on GC
 #define COPYRIGHT_TEX_WIDTH (isGC ? 160 : 128)
 #define COPYRIGHT_TEX_LEFT (isGC ? 78 : 94)
 
@@ -518,6 +524,7 @@ void EnMag_DrawInner(Actor* thisx, PlayState* play, Gfx** gfxP) {
     u16 rectTop;
     bool isMQ = ResourceMgr_IsGameMasterQuest();
     bool isGC = ResourceMgr_GetGamePlatform(0) == GAME_PLATFORM_GC;
+    bool isJpnGC_CE = isGC && ResourceMgr_GetGameVersion(0) == OOT_NTSC_JP_GC_CE;
     bool isJpnGC_notCE =
         isGC && (ResourceMgr_GetGameVersion(0) == OOT_NTSC_JP_GC || ResourceMgr_GetGameVersion(0) == OOT_NTSC_JP_MQ);
 


### PR DESCRIPTION
The GC JP versions (not CE), only have a texture for the copyright matching the year 2002.
This adjusts the name of the texture extracted and updates the title screen logo to display 2002 as appropriately and matching decomp (when only the GC JP version is loaded, or language is set to JPN with any GC version).

Will require regen for these specific versions, which we already are expecting for 9.0.1 from the boss title card fix.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2888469182.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2888471019.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2888487512.zip)
<!--- section:artifacts:end -->