### PR TITLE
fix blank names in spoiler

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/spoiler_log.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/spoiler_log.cpp
@@ -267,10 +267,10 @@ static void WriteAllLocations() {
         switch (gSaveContext.language) {
             case 0:
             default:
-                placedItemName = location->GetPlacedItemName().english;
+                placedItemName = location->GetPlacedItemName().GetEnglish();
                 break;
             case 2:
-                placedItemName = location->GetPlacedItemName().french;
+                placedItemName = location->GetPlacedItemName().GetFrench();
                 break;
         }
 

--- a/soh/soh/Enhancements/randomizer/3drando/spoiler_log.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/spoiler_log.cpp
@@ -303,18 +303,18 @@ static void WriteAllLocations() {
                             ["model"] = Rando::StaticData::RetrieveItem(
                                             ctx->overrides[location->GetRandomizerCheck()].LooksLike())
                                             .GetName()
-                                            .english;
+                                            .GetEnglish();
                     jsonData["locations"][Rando::StaticData::GetLocation(location->GetRandomizerCheck())->GetName()]
-                            ["trickName"] = ctx->overrides[location->GetRandomizerCheck()].GetTrickName().english;
+                            ["trickName"] = ctx->overrides[location->GetRandomizerCheck()].GetTrickName().GetEnglish();
                     break;
                 case 2:
                     jsonData["locations"][Rando::StaticData::GetLocation(location->GetRandomizerCheck())->GetName()]
                             ["model"] = Rando::StaticData::RetrieveItem(
                                             ctx->overrides[location->GetRandomizerCheck()].LooksLike())
                                             .GetName()
-                                            .french;
+                                            .GetFrench();
                     jsonData["locations"][Rando::StaticData::GetLocation(location->GetRandomizerCheck())->GetName()]
-                            ["trickName"] = ctx->overrides[location->GetRandomizerCheck()].GetTrickName().french;
+                            ["trickName"] = ctx->overrides[location->GetRandomizerCheck()].GetTrickName().GetFrench();
                     break;
             }
         }


### PR DESCRIPTION
fixes the item names getting into spoiler as blank part of https://github.com/HarbourMasters/Shipwright/issues/5309

![Screenshot From 2025-04-05 12-54-11](https://github.com/user-attachments/assets/734d95a8-d018-48a0-9ba5-ffdbb8a5e638)

![Screenshot From 2025-04-05 12-59-03](https://github.com/user-attachments/assets/94c1cd10-cd2e-4a80-a687-f9dda7ad1eb3)

> [!NOTE]
> i know the screenshot is of the alley house key not the guard house key, it was just the quickest one to get to when testing

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2896743497.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2896752371.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2896823486.zip)
<!--- section:artifacts:end -->