### PR TITLE
Set Savewarp in Ganondorf to Ganon's Tower in Entrance Rando

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer_entrance.c
+++ b/soh/soh/Enhancements/randomizer/randomizer_entrance.c
@@ -404,9 +404,9 @@ void Entrance_SetSavewarpEntrance(void) {
         gSaveContext.entranceIndex = ENTR_ICE_CAVERN_ENTRANCE;
     } else if (scene == SCENE_INSIDE_GANONS_CASTLE) {
         gSaveContext.entranceIndex = ENTR_INSIDE_GANONS_CASTLE_ENTRANCE;
-    } else if (scene == SCENE_GANONS_TOWER || scene == SCENE_INSIDE_GANONS_CASTLE_COLLAPSE ||
-               scene == SCENE_GANONS_TOWER_COLLAPSE_INTERIOR || scene == SCENE_GANON_BOSS ||
-               scene == SCENE_GANONS_TOWER_COLLAPSE_EXTERIOR) {
+    } else if (scene == SCENE_GANONS_TOWER || scene == SCENE_GANONDORF_BOSS ||
+               scene == SCENE_INSIDE_GANONS_CASTLE_COLLAPSE || scene == SCENE_GANONS_TOWER_COLLAPSE_INTERIOR ||
+               scene == SCENE_GANON_BOSS || scene == SCENE_GANONS_TOWER_COLLAPSE_EXTERIOR) {
         gSaveContext.entranceIndex = ENTR_GANONS_TOWER_0;    // Inside Ganon's Castle -> Ganon's Tower Climb
     } else if (scene == SCENE_THIEVES_HIDEOUT) {             // Theives hideout
         gSaveContext.entranceIndex = ENTR_THIEVES_HIDEOUT_0; // Gerudo Fortress -> Thieve's Hideout spawn 0


### PR DESCRIPTION
Fixes #5337 

Adds ganondorf's scene to the list of ganon scenes accounted for in entrance rando savewarping.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2890252362.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2890258547.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2890277215.zip)
<!--- section:artifacts:end -->