### PR TITLE
Rando: Fix checking gSaveContext for used small keys

### DIFF
--- a/soh/soh/Enhancements/randomizer/logic.cpp
+++ b/soh/soh/Enhancements/randomizer/logic.cpp
@@ -2244,7 +2244,7 @@ const std::vector<uint8_t>& GetDungeonSmallKeyDoors(SceneID sceneId) {
     return dungeonSmallKeyDoors[key];
 }
 
-int8_t GetUsedSmallKeyCount(SceneID sceneId) {
+int8_t Logic::GetUsedSmallKeyCount(SceneID sceneId) {
     const auto& smallKeyDoors = GetDungeonSmallKeyDoors(sceneId);
 
     // Get the swch value for the scene
@@ -2252,7 +2252,7 @@ int8_t GetUsedSmallKeyCount(SceneID sceneId) {
     if (gPlayState != nullptr && gPlayState->sceneNum == sceneId) {
         swch = gPlayState->actorCtx.flags.swch;
     } else {
-        swch = gSaveContext.sceneFlags[sceneId].swch;
+        swch = mSaveContext->sceneFlags[sceneId].swch;
     }
 
     // Count the number of small keys doors unlocked

--- a/soh/soh/Enhancements/randomizer/logic.h
+++ b/soh/soh/Enhancements/randomizer/logic.h
@@ -267,6 +267,7 @@ class Logic {
     bool CheckEquipment(uint32_t item);
     bool CheckQuestItem(uint32_t item);
     void SetQuestItem(uint32_t item, bool state);
+    int8_t GetUsedSmallKeyCount(SceneID sceneId);
     uint8_t GetSmallKeyCount(uint32_t dungeonIndex);
     void SetSmallKeyCount(uint32_t dungeonIndex, uint8_t count);
     bool CheckDungeonItem(uint32_t item, uint32_t dungeonIndex);


### PR DESCRIPTION
The issue here was that `GetUsedSmallKeys` was checking `gSaveContext` for switch flags, even during seed generation. It was causing issues with seeds generated when save files already existed or were loaded. Apparently this was added for the in-game accessibility tracking, so the impact during seed gen apparently wasn't checked.

Fixed by making `GetUsedSmallKeys` a member of the `Logic` class so it can access `mSaveContext` (which points to `gSaveContext` during gameplay).

This should fix several issues reported during the Glitchless weekly seeds that started after 9.0.0 came out (this bug had no affect on No Logic seeds).

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2898007957.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2898031307.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2898083010.zip)
<!--- section:artifacts:end -->