### PR TITLE
Fix MQ Water Temple Check Totals

### DIFF
--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -1632,7 +1632,7 @@ void RandomizerOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_l
                     gPlayState->actorCtx.flags.tempCollect = 0;
 
                     // If the respawnFlag is set for a grotto return, we don't want the void out to happen.
-                    // Set the data flag to one to prevent the respawn point from being overriden by dungeon doors.
+                    // Set the data flag to one to prevent the respawn point from being overridden by dungeon doors.
                     if (gSaveContext.respawnFlag == 2) {
                         gSaveContext.respawn[RESPAWN_MODE_DOWN].data = 1;
                         *should = false;

--- a/soh/soh/Enhancements/randomizer/option.h
+++ b/soh/soh/Enhancements/randomizer/option.h
@@ -302,7 +302,7 @@ class Option {
     /**
      * @brief Automatically renders a widget for this option in ImGui, based on the various
      * properties of this Option. Typically, Bool options are rendered as Checkboxes and
-     * U8 options are rendered as Comboboxes, but this can be overriden during construction with
+     * U8 options are rendered as Comboboxes, but this can be overridden during construction with
      * the `widgetType` property.
      */
     bool RenderImGui();

--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -137,9 +137,9 @@ std::map<RandomizerCheckArea, std::vector<RandomizerCheck>> checksByArea;
 bool areasFullyChecked[RCAREA_INVALID];
 u32 areasSpoiled = 0;
 bool showVOrMQ;
-s8 areaChecksGotten[RCAREA_INVALID]; //|     "Kokiri Forest (4/9)"
-s8 areaChecksAvailable[RCAREA_INVALID];
-s8 areaCheckTotals[RCAREA_INVALID];
+s16 areaChecksGotten[RCAREA_INVALID]; //|     "Kokiri Forest (4/9)"
+s16 areaChecksAvailable[RCAREA_INVALID];
+s16 areaCheckTotals[RCAREA_INVALID];
 uint16_t totalChecks = 0;
 uint16_t totalChecksAvailable = 0;
 uint16_t totalChecksGotten = 0;
@@ -1932,7 +1932,7 @@ void ImGuiDrawTwoColorPickerSection(const char* text, const char* cvarMainName, 
                 "Hidden", cvarHideName,
                 UIWidgets::CheckboxOptions(
                     { { .tooltip = "When active, checks will hide by default when updated to this state. Can "
-                                   "be overriden with the \"Show Hidden Items\" option." } })
+                                   "be overridden with the \"Show Hidden Items\" option." } })
                     .Color(theme));
             ImGui::PopID();
         }

--- a/soh/soh/Enhancements/randomizer/randomizer_entrance_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_entrance_tracker.cpp
@@ -423,7 +423,7 @@ bool IsEntranceDiscovered(s16 index) {
     bool isDiscovered = Entrance_GetIsEntranceDiscovered(index);
     if (!isDiscovered) {
         // If the pair included one of the hyrule field <-> zora's river entrances,
-        // the randomizer will have also overriden the water-based entrances, so check those too
+        // the randomizer will have also overridden the water-based entrances, so check those too
         if ((index == ENTR_ZORAS_RIVER_WEST_EXIT && Entrance_GetIsEntranceDiscovered(ENTR_ZORAS_RIVER_3)) ||
             (index == ENTR_ZORAS_RIVER_3 && Entrance_GetIsEntranceDiscovered(ENTR_ZORAS_RIVER_WEST_EXIT))) {
             isDiscovered = true;

--- a/soh/src/overlays/gamestates/ovl_select/z_select.c
+++ b/soh/src/overlays/gamestates/ovl_select/z_select.c
@@ -40,7 +40,7 @@ void Select_LoadGame(SelectContext* this, s32 entranceIndex) {
     Audio_QueueSeqCmd(SEQ_PLAYER_BGM_MAIN << 24 | NA_BGM_STOP);
     gSaveContext.entranceIndex = entranceIndex;
 
-    // Check the entrance to see if the exit should be overriden to a grotto return point for entrance rando
+    // Check the entrance to see if the exit should be overridden to a grotto return point for entrance rando
     if (IS_RANDO && Randomizer_GetSettingValue(RSK_SHUFFLE_ENTRANCES)) {
         // Ignore return value as we want to load into the entrance specified by the debug menu
         Grotto_OverrideSpecialEntrance(Entrance_GetOverride(entranceIndex));
@@ -105,7 +105,7 @@ void Select_Grotto_LoadGame(SelectContext* this, s32 grottoIndex) {
     gSaveContext.respawn[RESPAWN_MODE_RETURN].playerParams = 0x4ff;
     gSaveContext.respawn[RESPAWN_MODE_RETURN].pos = this->betterGrottos[grottoIndex].pos;
 
-    // Check the entrance to see if the exit should be overriden to a grotto return point for entrance rando
+    // Check the entrance to see if the exit should be overridden to a grotto return point for entrance rando
     if (IS_RANDO && Randomizer_GetSettingValue(RSK_SHUFFLE_ENTRANCES)) {
         // Use grotto content and parent scene num to identify the right grotto
         s16 grottoEntrance = Grotto_GetRenamedGrottoIndexFromOriginal(this->betterGrottos[grottoIndex].data,


### PR DESCRIPTION
Changes check total array types to s16 to handle more check totals (thanks storage temple).

Also fixes typos regarding `overridden` in various parts of the codebase.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2899206918.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2899210464.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2899214990.zip)
<!--- section:artifacts:end -->