### PR TITLE
Fix Rando Give for Adult Fishing as Child Glitch

### DIFF
--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -948,6 +948,14 @@ typedef enum {
 
     // #### `result`
     // ```c
+    // false
+    // ```
+    // #### `args`
+    // - '*Fishing' (&this)
+    VB_GIVE_RANDO_GLITCH_FISHING_PRIZE,
+
+    // #### `result`
+    // ```c
     // true
     // ```
     // #### `args`

--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -1593,7 +1593,7 @@ void RandomizerOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_l
         }
         case VB_GIVE_RANDO_GLITCH_FISHING_PRIZE: {
             if (IS_RANDO) {
-                VBFishingData* fishData = va_arg(args, VBFishingData*);
+                Fishing* fishing = va_arg(args, Fishing*);
                 if (!Flags_GetRandomizerInf(RAND_INF_ADULT_FISHING)) {
                     Flags_SetRandomizerInf(RAND_INF_ADULT_FISHING);
                 }

--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -1591,6 +1591,17 @@ void RandomizerOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_l
             }
             break;
         }
+        case VB_GIVE_RANDO_GLITCH_FISHING_PRIZE: {
+            if (IS_RANDO) {
+                VBFishingData* fishData = va_arg(args, VBFishingData*);
+                if (!Flags_GetRandomizerInf(RAND_INF_ADULT_FISHING)) {
+                    Flags_SetRandomizerInf(RAND_INF_ADULT_FISHING);
+                }
+                *should = true;
+                fishData->actor->stateAndTimer = 0;
+            }
+            break;
+        }
         case VB_TRADE_TIMER_EYEDROPS: {
             EnMk* enMk = va_arg(args, EnMk*);
             Flags_SetRandomizerInf(RAND_INF_ADULT_TRADES_LH_TRADE_FROG);

--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -1598,7 +1598,7 @@ void RandomizerOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_l
                     Flags_SetRandomizerInf(RAND_INF_ADULT_FISHING);
                 }
                 *should = true;
-                fishData->actor->stateAndTimer = 0;
+                fishing->actor->stateAndTimer = 0;
             }
             break;
         }

--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -1598,7 +1598,7 @@ void RandomizerOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_l
                     Flags_SetRandomizerInf(RAND_INF_ADULT_FISHING);
                 }
                 *should = true;
-                fishing->actor->stateAndTimer = 0;
+                fishing->stateAndTimer = 0;
             }
             break;
         }

--- a/soh/src/overlays/actors/ovl_Fishing/z_fishing.c
+++ b/soh/src/overlays/actors/ovl_Fishing/z_fishing.c
@@ -5170,7 +5170,9 @@ void Fishing_HandleOwnerDialog(Fishing* this, PlayState* play) {
             if (Actor_HasParent(&this->actor, play)) {
                 this->stateAndTimer = 24;
             } else {
-                Actor_OfferGetItem(&this->actor, play, GI_SCALE_GOLDEN, 2000.0f, 1000.0f);
+                if (!GameInteractor_Should(VB_GIVE_RANDO_GLITCH_FISHING_PRIZE, false, &this)) {
+                    Actor_OfferGetItem(&this->actor, play, GI_SCALE_GOLDEN, 2000.0f, 1000.0f);
+                }
             }
             break;
 


### PR DESCRIPTION
Fixes #5345 

Adds a VB block to handle the gold scale as child glitch in rando. Note that thanks to the way the VBs are currently setup, the child fishing reward can't be locked out - it will always be given first.

Long version because this file is huge:
Current flow:
-After child reward complete, catching a larger fish and performing the glitch hits the VB_GIVE_RANDO_FISHING_PRIZE block in Case 11, and gets sent to Case 23, as Link is child and has already received the child reward
-If performed correctly, it hits the else block in Case 23, giving the Gold Scale - new VB interrupts this flow


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2904168997.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2904178595.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2904192785.zip)
<!--- section:artifacts:end -->