### PR TITLE
Additions for the German translation in two files

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/hint_list/hint_list_exclude_dungeon.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/hint_list/hint_list_exclude_dungeon.cpp
@@ -124,11 +124,11 @@ void StaticData::HintTable_Init_Exclude_Dungeon() {
                                                      /*french*/ "Selon moi, un #coeur dans l'Arbre Mojo# cache #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_DEKU_TREE_GRASS] = HintText(CustomMessage("They say that some #grass in the Deku Tree# hides #[[1]]#.",
-                                                     /*german*/ TODO_TRANSLATE,
+                                                     /*german*/ "Man erzählt sich, daß etwas #Gras im Deku-Baum# #[[1]]# verstecke.",
                                                      /*french*/ "Selon moi, de l'#herbe dans l'Arbre Mojo# cache #[[1]]#.", {QM_RED, QM_GREEN}));
 													 
     hintTextTable[RHT_CRATE_DEKU_TREE] = HintText(CustomMessage("They say that a #crate in the Deku Tree# contains #[[1]]#.",
-                                                     /*german*/ TODO_TRANSLATE,
+                                                     /*german*/ "Man erzählt sich, daß eine #Kiste im Deku-Baum# #[[1]]# enthielte.",
                                                      /*french*/ "Selon moi, une #caisse dans l'Arbre Mojo# contient #[[1]]#.", {QM_RED, QM_GREEN}));
 
   /*--------------------------
@@ -306,11 +306,11 @@ void StaticData::HintTable_Init_Exclude_Dungeon() {
                                                                             /*french*/ "Selon moi, #jouer un air orageux pour une pierre étrange dans la Caverne Dodongo# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_DODONGOS_CAVERN_GRASS] = HintText(CustomMessage("They say that some #grass in Dodongo's Cavern# hides #[[1]]#.",
-                                                                            /*german*/ TODO_TRANSLATE,
+                                                                            /*german*/ "Man erzählt sich, daß etwas #Gras in Dodongos Höhle# #[[1]]# verstecke.",
                                                                             /*french*/ "Selon moi, de l'#herbe dans la Caverne Dodongo# cache #[[1]]#.", {QM_RED, QM_GREEN}));
 											
     hintTextTable[RHT_CRATE_DODONGOS_CAVERN] = HintText(CustomMessage("They say that a #crate in Dodongo's Cavern# contains #[[1]]#.",
-                                                     /*german*/ TODO_TRANSLATE,
+                                                     /*german*/ "Man erzählt sich, daß eine #Kiste in Dodongos Höhle# #[[1]]# enthielte.",
                                                      /*french*/ "Selon moi, une #caisse dans la Caverne Dodongo# contient #[[1]]#.", {QM_RED, QM_GREEN}));
 
   /*--------------------------
@@ -473,11 +473,11 @@ void StaticData::HintTable_Init_Exclude_Dungeon() {
                                                      /*french*/ "Selon moi, près d'un #ascenceur central dans le Ventre de Jabu-Jabu# se trouve #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_JABU_JABUS_BELLY_GRASS] = HintText(CustomMessage("They say that some #grass in Jabu Jabu's Belly# hides #[[1]]#.",
-                                                     /*german*/ TODO_TRANSLATE,
+                                                     /*german*/ "Man erzählt sich, daß etwas #Gras in Jabu-Jabus Bauch# #[[1]]# verstecke.",
                                                      /*french*/ "Selon moi, de l'#herbe dans le Ventre de Jabu-Jabu# cache #[[1]]#.", {QM_RED, QM_GREEN}));
 													 
     hintTextTable[RHT_CRATE_JABU_JABU] = HintText(CustomMessage("They say that a #crate in Jabu Jabu's Belly# contains #[[1]]#.",
-                                                     /*german*/ TODO_TRANSLATE,
+                                                     /*german*/ "Man erzählt sich, daß eine #Kiste in Jabu-Jabus Bauch# #[[1]]# enthielte.",
                                                      /*french*/ "Selon moi, une #caisse dans le Ventre de Jabu-Jabu# contient #[[1]]#.", {QM_RED, QM_GREEN}));
 
   /*--------------------------
@@ -706,12 +706,12 @@ void StaticData::HintTable_Init_Exclude_Dungeon() {
                                                        /*german*/ "Man erzählt sich, daß eine #Vase im Waldtempel# #[[1]]# enthielte.",
                                                        /*french*/ "Selon moi, une #jarre dans le Temple de la Fôret# contient #[[1]]#.", {QM_RED, QM_GREEN}));
 
-  hintTextTable[RHT_FOREST_TEMPLE_HEART] = HintText(CustomMessage("They say that a #heart in the Forest Temple# hides #[[1]]#.",
-                                                       /*german*/ "Man erzählt sich, daß ein #Herz im Waldtempel# #[[1]]# verstecke.",
-                                                       /*french*/ "Selon moi, un #coeur dans le Temple de la Fôret# cache #[[1]]#.", {QM_RED, QM_GREEN}));
+    hintTextTable[RHT_FOREST_TEMPLE_HEART] = HintText(CustomMessage("They say that a #heart in the Forest Temple# hides #[[1]]#.",
+                                                         /*german*/ "Man erzählt sich, daß ein #Herz im Waldtempel# #[[1]]# verstecke.",
+                                                         /*french*/ "Selon moi, un #coeur dans le Temple de la Fôret# cache #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_CRATE_FOREST_TEMPLE] = HintText(CustomMessage("They say that a #crate in Forest Temple# contains #[[1]]#.",
-                                                     /*german*/ TODO_TRANSLATE,
+                                                     /*german*/ "Man erzählt sich, daß eine #Kiste im Waldtempel# #[[1]]# enthielte.",
                                                      /*french*/ "Selon moi, une #caisse dans le Temple de la Fôret# contient #[[1]]#.", {QM_RED, QM_GREEN}));
 
   /*--------------------------
@@ -911,15 +911,15 @@ void StaticData::HintTable_Init_Exclude_Dungeon() {
                                                        /*french*/ "Selon moi, un #coeur dans le Temple du Feu# cache #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_FIRE_TEMPLE_MQ_LOOP_STALFOS_SUN_FAIRY] = HintText(CustomMessage("They say that #calling the sun in a hot arena# reveals #[[1]]#.",
-                                                                                /*german*/ TODO_TRANSLATE,
+                                                                                /*german*/ "Man erzählt sich, daß das #Anrufen der Sonne in einer heißen Arena# #[[1]]# enthülle.",
                                                                                 /*french*/ "Selon moi, #appeler le soleil dans une arène chaude# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_FIRE_TEMPLE_MQ_LOOP_KNUCKLE_SUN_FAIRY] = HintText(CustomMessage("They say that #calling the sun behind a knight's throne in a volcano# reveals #[[1]]#.",
-                                                                                /*german*/ TODO_TRANSLATE,
+                                                                                /*german*/ "Man erzählt sich, daß das #Anrufen der Sonne hinter dem Thron eines Ritters in einem Vulkan# #[[1]]# enthülle.",
                                                                                 /*french*/ "Selon moi, #appeler le soleil derrière le trône d’un chevalier dans un volcan# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_CRATE_FIRE_TEMPLE] = HintText(CustomMessage("They say that a #crate in Fire Temple# contains #[[1]]#.",
-                                                     /*german*/ TODO_TRANSLATE,
+                                                     /*german*/ "Man erzählt sich, daß eine #Kiste im Feuertempel# #[[1]]# enthielte.",
                                                      /*french*/ "Selon moi, une #caisse dans le Temple du Feu# contient #[[1]]#.", {QM_RED, QM_GREEN}));
 
   /*--------------------------
@@ -1058,25 +1058,25 @@ void StaticData::HintTable_Init_Exclude_Dungeon() {
                                                         /*french*/ "Selon moi, une #rivière dans le Temple de l'Eau# cache #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_WATER_TEMPLE_MQ_DARK_LINK_PILAR_SUN_FAIRY] = HintText(CustomMessage("They say that #calling the sun atop a small pillar before a duel with one's shadow# reveals #[[1]]#.",
-                                                                               /*german*/ TODO_TRANSLATE,
+                                                                               /*german*/ "Man erzählt sich, daß das #Anrufen der Sonne auf einer kleinen Säule vor einem Duell mit seinem Schatten# #[[1]]# enthülle.",
                                                                                /*french*/ "Selon moi, #appeler le soleil au sommet d’un petit pilier avant un duel avec son ombre# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_WATER_TEMPLE_MQ_DARK_LINK_LEFT_STORM_FAIRY] = HintText(CustomMessage("They say that #calling the rain before a duel with one's shadow# reveals #[[1]]#.",
-                                                                                /*german*/ TODO_TRANSLATE,
+                                                                                /*german*/ "Man erzählt sich, daß das #Anrufen des Regens vor einem Duell mit seinem Schatten# #[[1]]# enthülle.",
                                                                                 /*french*/ "Selon moi, #appeler la pluie avant un duel avec son ombre# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_WATER_TEMPLE_MQ_DARK_LINK_RIGHT_SUN_FAIRY] = HintText(CustomMessage("They say that #calling the sun before a duel with one's shadow# reveals #[[1]]#.",
-                                                                               /*german*/ TODO_TRANSLATE,
+                                                                               /*german*/ "Man erzählt sich, daß das #Anrufen der Sonne vor einem Duell mit seinem Schatten# #[[1]]# enthülle.",
                                                                                /*french*/ "Selon moi, #appeler le soleil avant un duel avec son ombre# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_CRATE_WATER_TEMPLE] = HintText(CustomMessage("They say that a #crate in Water Temple# contains #[[1]]#.",
-                                                     /*german*/ TODO_TRANSLATE,
+                                                     /*german*/ "Man erzählt sich, daß eine #Kiste im Wassertempel# #[[1]]# enthielte.",
                                                      /*french*/ "Selon moi, une #caisse dans le Temple de l'Eau# contient #[[1]]#.", {QM_RED, QM_GREEN}));
 
   /*--------------------------
   |      SPIRIT TEMPLE       |
   ---------------------------*/
- hintTextTable[RHT_SPIRIT_TEMPLE_CHILD_BRIDGE_CHEST] = HintText(CustomMessage("They say that a child conquers a #skull in green fire# in the Spirit Temple to reach #[[1]]#.",
+    hintTextTable[RHT_SPIRIT_TEMPLE_CHILD_BRIDGE_CHEST] = HintText(CustomMessage("They say that a child conquers a #skull in green fire# in the Spirit Temple to reach #[[1]]#.",
                                                                       /*german*/ "Man erzählt sich, daß ein Kind einen #Schädel in grünem Feuer# im Geistertempel erobere, um #[[1]]# zu erreichen.",
                                                                       /*french*/ "Selon moi, le #crâne au halo vert dans le colosse# cache #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                    // /*spanish*/ Según dicen, el joven que #baje el puente# del Templo del Espíritu encontrará #[[1]]#.
@@ -1311,15 +1311,15 @@ void StaticData::HintTable_Init_Exclude_Dungeon() {
                                                        /*french*/ "Selon moi, une #jarre dans le Temple de l'Esprit# contient #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_SPIRIT_TEMPLE_HEART] = HintText(CustomMessage("They say that on a #small platform# in the Spirit Temple lies #[[1]]#.",
-                                                         /*german*/ TODO_TRANSLATE,
+                                                         /*german*/ "Man erzählt sich, daß auf einer #kleinen Plattform# im Geistertempel #[[1]]# läge.",
                                                          /*french*/ "Selon moi, sur une #petite plateforme# dans le Temple de l'Esprit repose #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_SPIRIT_TEMPLE_MQ_HEART] = HintText(CustomMessage("They say that guarded by a #ring of flame# in the Spirit Temple is #[[1]]#.",
-                                                         /*german*/ TODO_TRANSLATE,
+                                                         /*german*/ "Man erzählt sich, daß sich bewacht von einem #Ring der Flammen# im Geistertempel #[[1]]# befände.",
                                                          /*french*/ "Selon moi, protégé par un #cercle de flammes# dans le Temple de l'Esprit se trouve #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_CRATE_SPIRIT_TEMPLE] = HintText(CustomMessage("They say that a #crate in Spirit Temple# contains #[[1]]#.",
-                                                     /*german*/ TODO_TRANSLATE,
+                                                     /*german*/ "Man erzählt sich, daß eine #Kiste im Geistertempel# #[[1]]# enthielte.",
                                                      /*french*/ "Selon moi, une #caisse dans le Temple de l'Esprit# contient #[[1]]#.", {QM_RED, QM_GREEN}));
 
   /*--------------------------
@@ -1574,19 +1574,19 @@ void StaticData::HintTable_Init_Exclude_Dungeon() {
                                                          /*french*/ "Selon moi, un #coeur dans le Temple de l'Ombre# cache #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_SHADOW_TEMPLE_BEAMOS_STORM_FAIRY] = HintText(CustomMessage("They say that an #calling the rain for a sentry guarding a house of the dead# reveals #[[1]]#.",
-                                                                      /*german*/ TODO_TRANSLATE,
+                                                                      /*german*/ "Man erzählt sich, daß das #Anrufen des Regens für einen über ein Haus der Toten wachenden Posten# #[[1]]# enthülle.",
                                                                       /*french*/ "Selon moi, #appeler la pluie pour une sentinelle gardant une maison des morts# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_SHADOW_TEMPLE_PIT_STORM_FAIRY] = HintText(CustomMessage("They say that an #calling the rain on a platform suspended above a bottomless pit# reveals #[[1]]#.",
-                                                                   /*german*/ TODO_TRANSLATE,
+                                                                   /*german*/ "Man erzählt sich, daß das #Anrufen des Regens auf einer über einer bodenlosen Grube hängenden Plattform# #[[1]]# enthülle.",
                                                                    /*french*/ "Selon moi, #appeler la pluie sur une plateforme suspendue au-dessus d’un gouffre sans fond# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_SHADOW_TEMPLE_WIND_HINT_SUN_FAIRY] = HintText(CustomMessage("They say that an #calling the sun near an invisible chest guarded by the dead# reveals #[[1]]#.",
-                                                                       /*german*/ TODO_TRANSLATE,
+                                                                       /*german*/ "Man erzählt sich, daß das #Anrufen der Sonne nahe einer von Toten bewachten unsichtbaren Truhe# #[[1]]# enthülle.",
                                                                        /*french*/ "Selon moi, #appeler le soleil près d’un coffre invisible gardé par les morts# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_CRATE_SHADOW_TEMPLE] = HintText(CustomMessage("They say that a #crate in Shadow Temple# contains #[[1]]#.",
-                                                     /*german*/ TODO_TRANSLATE,
+                                                     /*german*/ "Man erzählt sich, daß eine #Kiste im Schattentempel# #[[1]]# enthielte.",
                                                      /*french*/ "Selon moi, une #caisse dans le Temple de l'Ombre# contient #[[1]]#.", {QM_RED, QM_GREEN}));
 
   /*--------------------------
@@ -1716,7 +1716,7 @@ void StaticData::HintTable_Init_Exclude_Dungeon() {
                                                               /*french*/ "Selon moi, un #coeur dans le Puits# cache #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_BOTTOM_OF_THE_WELL_RUPEE] = HintText(CustomMessage("They say that a #hidden path through the floor# in the well leads to #[[1]]#.",
-                                                              /*german*/ "Man erzählt sich, daß ein #versteckter Pfad durch den Grund# im Brunnen zu #[[1]]# führe.",
+                                                              /*german*/ "Man erzählt sich, daß ein #versteckter Pfad durch den Boden# im Brunnen zu #[[1]]# führe.",
                                                               /*french*/ "Selon moi, un #passage caché sous le sol# dans le puits mène à #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_BOTTOM_OF_THE_WELL_BASEMENT_SUN_FAIRY] = HintText(CustomMessage("They say that an #calling the sun a dead end# within the well reveals #[[1]]#.",
@@ -1732,7 +1732,7 @@ void StaticData::HintTable_Init_Exclude_Dungeon() {
                                                                        /*french*/ "Selon moi, #appeler le soleil dans une impasse# à l’intérieur du puits révèle #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_BOTTOM_OF_THE_WELL_GRASS] = HintText(CustomMessage("They say that some #grass in the Bottom of the Well# hides #[[1]]#.",
-                                                     /*german*/ TODO_TRANSLATE,
+                                                     /*german*/ "Man erzählt sich, daß etwas #Gras auf dem Grund des Brunnens# #[[1]]# verstecke.",
                                                      /*french*/ "Selon moi, de l'#herbe dans le Puits# cache #[[1]]#.", {QM_RED, QM_GREEN}));
 
 
@@ -2013,7 +2013,7 @@ void StaticData::HintTable_Init_Exclude_Dungeon() {
                                                                    /*french*/ "Selon moi, dans #une épreuve avec un Dinolfos# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_CRATE_GERUDO_TRAINING_GROUND] = HintText(CustomMessage("They say that a #crate in Gerudo Training Ground# contains #[[1]]#.",
-                                                     /*german*/ TODO_TRANSLATE,
+                                                     /*german*/ "Man erzählt sich, daß eine #Kiste auf dem Gerudo-Trainingsgelände# #[[1]]# enthielte.",
                                                      /*french*/ "Selon moi, une #caisse dans le Gymnase Gerudo# contient #[[1]]#.", {QM_RED, QM_GREEN}));
 
   /*--------------------------

--- a/soh/soh/Enhancements/randomizer/3drando/hint_list/hint_list_exclude_overworld.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/hint_list/hint_list_exclude_overworld.cpp
@@ -1674,346 +1674,384 @@ void StaticData::HintTable_Init_Exclude_Overworld() {
                                             /*french*/ "Selon moi, #arroser une jeune pousse sur le flanc d'une montagne# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_TOT_GOSSIP_STONE_FAIRY] = HintText(CustomMessage("They say that #playing a tune for an odd stone in the outskirts of the market# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer Melodie für einen seltsamen Stein am Rand des Marktes# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, #jouer une mélodie pour une pierre étrange en périphérie du marché# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_TOT_GOSSIP_STONE_FAIRY_BIG] = HintText(CustomMessage("They say that #playing a stormy tune for an odd stone in the outskirts of the market# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer stürmischen Melodie für einen seltsamen Stein am Rand des Marktes# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, #jouer une mélodie orageuse pour une pierre étrange en périphérie du marché# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_DMC_GOSSIP_STONE_FAIRY] = HintText(CustomMessage("They say that #playing a tune for an odd stone within a volcano# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer Melodie für einen seltsamen Stein innerhalb eines Vulkans# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, #jouer une mélodie pour une pierre étrange dans un volcan# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_DMC_GOSSIP_STONE_FAIRY_BIG] = HintText(CustomMessage("They say that #playing a stormy tune for an odd stone within a volcano# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer stürmischen Melodie für einen seltsamen Stein innerhalb eines Vulkans# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, #jouer une mélodie orageuse pour une pierre étrange dans un volcan# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_DMT_GOSSIP_STONE_FAIRY] = HintText(CustomMessage("They say that #playing a tune for an odd stone on a mountain cliff face# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer Melodie für einen seltsamen Stein an einer Bergklippe# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, #jouer une mélodie pour une pierre étrange sur une falaise de montagne# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_DMT_GOSSIP_STONE_FAIRY_BIG] = HintText(CustomMessage("They say that #playing a stormy tune for an odd stone on a mountain cliff face# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer stürmischen Melodie für einen seltsamen Stein an einer Bergklippe# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, #jouer une mélodie orageuse pour une pierre étrange sur une falaise de montagne# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
 
-    hintTextTable[RHT_COLOSSUS_GOSSIP_STONE_FAIRY] = HintText(CustomMessage("They say that #playing a tune for an odd stone near the temple of the sane# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+    hintTextTable[RHT_COLOSSUS_GOSSIP_STONE_FAIRY] = HintText(CustomMessage("They say that #playing a tune for an odd stone near the temple of the sand# reveals #[[1]]#.",
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer Melodie für einen seltsamen Stein nahe des Tempels des Sandes# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, #jouer une mélodie pour une pierre étrange près du temple du sable# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
 
-    hintTextTable[RHT_COLOSSUS_GOSSIP_STONE_FAIRY_BIG] = HintText(CustomMessage("They say that #playing a stormy tune for an odd stone near the temple of the sane# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+    hintTextTable[RHT_COLOSSUS_GOSSIP_STONE_FAIRY_BIG] = HintText(CustomMessage("They say that #playing a stormy tune for an odd stone near the temple of the sand# reveals #[[1]]#.",
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer stürmischen Melodie für einen seltsamen Stein nahe des Tempels des Sandes# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, #jouer une mélodie orageuse pour une pierre étrange près du temple du sable# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_GV_GOSSIP_STONE_FAIRY] = HintText(CustomMessage("They say that #playing a tune for an odd stone near a canyon waterfall# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer Melodie für einen seltsamen Stein nahe eines Wasserfalls in einer Schlucht# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, #jouer une mélodie pour une pierre étrange près d'une cascade de canyon# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_GV_GOSSIP_STONE_FAIRY_BIG] = HintText(CustomMessage("They say that #playing a stormy tune for an odd stone near a canyon waterfall# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer stürmischen Melodie für einen seltsamen Stein nahe eines Wasserfalls in einer Schlucht# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, #jouer une mélodie orageuse pour une pierre étrange près d'une cascade de canyon# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_GC_MAZE_GOSSIP_STONE_FAIRY] = HintText(CustomMessage("They say that #playing a tune for an odd stone behind a maze of rock# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer Melodie für einen seltsamen Stein hinter einem Felslabyrinth# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, #jouer une mélodie pour une pierre étrange derrière un labyrinthe de roches# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_GC_MAZE_GOSSIP_STONE_FAIRY_BIG] = HintText(CustomMessage("They say that #playing a stormy tune for an odd stone behind a maze of rock# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer stürmischen Melodie für einen seltsamen Stein hinter einem Felslabyrinth# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, #jouer une mélodie orageuse pour une pierre étrange derrière un labyrinthe de roches# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_GC_MEDIGORON_GOSSIP_STONE_FAIRY] = HintText(CustomMessage("They say that #playing a tune for an odd stone near a blacksmith# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer Melodie für einen seltsamen Stein nahe eines Schmiedes# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, #jouer une mélodie pour une pierre étrange près d'un forgeron# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_GC_MEDIGORON_GOSSIP_STONE_FAIRY_BIG] = HintText(CustomMessage("They say that #playing a stormy tune for an odd stone near a blacksmith# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer stürmischen Melodie für einen seltsamen Stein nahe eines Schmiedes# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, #jouer une mélodie orageuse pour une pierre étrange près d'un forgeron# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_GRAVEYARD_GOSSIP_STONE_FAIRY] = HintText(CustomMessage("They say that #playing a tune for an odd stone overlooking the graveyard# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer Melodie für einen seltsamen Stein, welcher den Friedhof überblickt#, #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, #jouer une mélodie pour une pierre étrange surplombant le cimetière# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_GRAVEYARD_GOSSIP_STONE_FAIRY_BIG] = HintText(CustomMessage("They say that #playing a stormy tune for an odd stone overlooking the graveyard# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer stürmischen Melodie für einen seltsamen Stein, welcher den Friedhof überblickt#, #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, #jouer une mélodie orageuse pour une pierre étrange surplombant le cimetière# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_HC_MALON_GOSSIP_STONE_FAIRY] = HintText(CustomMessage("They say that #playing a tune for an odd stone overlooking the path to the castle# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer Melodie für einen seltsamen Stein, welcher den Pfad zum Schloß überblickt#, #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, #jouer une mélodie pour une pierre étrange surplombant le chemin du château# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_HC_MALON_GOSSIP_STONE_FAIRY_BIG] = HintText(CustomMessage("They say that #playing a stormy tune for an odd stone overlooking the path to the castle# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer stürmischen Melodie für einen seltsamen Stein, welcher den Pfad zum Schloß überblickt#, #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, #jouer une mélodie orageuse pour une pierre étrange surplombant le chemin du château# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_HC_ROCK_WALL_GOSSIP_STONE_FAIRY] = HintText(CustomMessage("They say that #playing a tune for an odd stone near a secret path to the castle# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer Melodie für einen seltsamen Stein nahe eines geheimen Pfades zum Schloß# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, #jouer une mélodie pour une pierre étrange près d'un chemin secret vers le château# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_HC_ROCK_WALL_GOSSIP_STONE_FAIRY_BIG] = HintText(CustomMessage("They say that #playing a stormy tune for an odd stone near a secret path to the castle# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer stürmischen Melodie für einen seltsamen Stein nahe eines geheimen Pfades zum Schloß# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, #jouer une mélodie orageuse pour une pierre étrange près d'un chemin secret vers le château# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_HC_STORMS_GROTTO_GOSSIP_STONE_FAIRY] = HintText(CustomMessage("They say that #playing a tune for an odd stone beneath the castle# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer Melodie für einen seltsamen Stein unterhalb des Schloßes# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, #jouer une mélodie pour une pierre étrange sous le château# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_HC_STORMS_GROTTO_GOSSIP_STONE_FAIRY_BIG] = HintText(CustomMessage("They say that #playing a stormy tune for an odd stone beneath the castle# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer stürmischen Melodie für einen seltsamen Stein unterhalb des Schloßes# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, jouer une mélodie orageuse pour une pierre étrange sous le château révèle [[1]].", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_KF_DEKU_TREE_GOSSIP_STONE_FAIRY] = HintText(CustomMessage("They say that #playing a tune for an odd stone near an ancient tree# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer Melodie für einen seltsamen Stein nahe eines antiken Baumes# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, jouer une mélodie pour une pierre étrange près d'un arbre ancien révèle [[1]].", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_KF_DEKU_TREE_GOSSIP_STONE_FAIRY_BIG] = HintText(CustomMessage("They say that #playing a stormy tune for an odd stone near an ancient tree# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer stürmischen Melodie für einen seltsamen Stein nahe eines antiken Baumes# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, jouer une mélodie orageuse pour une pierre étrange près d'un arbre ancien révèle [[1]].", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_KF_GOSSIP_STONE_FAIRY] = HintText(CustomMessage("They say that #playing a tune for an odd stone overlooking a forest village# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer Melodie für einen seltsamen Stein, welcher ein Dorf im Wald überblickt#, #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, jouer une mélodie pour une pierre étrange surplombant un village forestier révèle [[1]].", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_KF_GOSSIP_STONE_FAIRY_BIG] = HintText(CustomMessage("They say that #playing a stormy tune for an odd stone overlooking a forest village# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer stürmischen Melodie für einen seltsamen Stein, welcher ein Dorf im Wald überblickt#, #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, jouer une mélodie orageuse pour une pierre étrange surplombant un village forestier révèle [[1]].", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_KF_STORMS_GROTTO_GOSSIP_STONE_FAIRY] = HintText(CustomMessage("They say that #playing a tune for an odd stone beneath a forest village# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer Melodie für einen seltsamen Stein unterhalb eines Dorfes im Wald# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, jouer une mélodie pour une pierre étrange sous un village forestier révèle [[1]].", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_KF_STORMS_GROTTO_GOSSIP_STONE_FAIRY_BIG] = HintText(CustomMessage("They say that #playing a stormy tune for an odd stone beneath a forest village# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer stürmischen Melodie für einen seltsamen Stein unterhalb eines Dorfes im Wald# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, jouer une mélodie orageuse pour une pierre étrange sous un village forestier révèle [[1]].", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_LH_LAB_GOSSIP_STONE_FAIRY] = HintText(CustomMessage("They say that #playing a tune for an odd stone overlooking the river feeding a lake# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer Melodie für einen seltsamen Stein, welcher einen See nährenden Fluß überblickt#, #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, jouer une mélodie pour une pierre étrange surplombant la rivière qui alimente un lac révèle [[1]].", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_LH_LAB_GOSSIP_STONE_FAIRY_BIG] = HintText(CustomMessage("They say that #playing a stormy tune for an odd stone overlooking the river feeding a lake# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer stürmischen Melodie für einen seltsamen Stein, welcher einen See nährenden Fluß überblickt#, #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, jouer une mélodie orageuse pour une pierre étrange surplombant la rivière qui alimente un lac révèle [[1]].", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_LH_SOUTHEAST_GOSSIP_STONE_FAIRY] = HintText(CustomMessage("They say that #playing a tune for an odd stone at the back of a lake# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer Melodie für einen seltsamen Stein am Rücken eines Sees# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, jouer une mélodie pour une pierre étrange au fond d'un lac révèle [[1]].", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_LH_SOUTHEAST_GOSSIP_STONE_FAIRY_BIG] = HintText(CustomMessage("They say that #playing a stormy tune for an odd stone at the back of a lake# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer stürmischen Melodie für einen seltsamen Stein am Rücken eines Sees# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, jouer une mélodie orageuse pour une pierre étrange au fond d'un lac révèle [[1]].", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_LH_SOUTHWEST_GOSSIP_STONE_FAIRY] = HintText(CustomMessage("They say that #playing a tune for an odd stone at the back of a lake# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer Melodie für einen seltsamen Stein am Rücken eines Sees# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, jouer une mélodie pour une pierre étrange au fond d'un lac révèle [[1]].", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_LH_SOUTHWEST_GOSSIP_STONE_FAIRY_BIG] = HintText(CustomMessage("They say that #playing a stormy tune for an odd stone at the back of a lake# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer stürmischen Melodie für einen seltsamen Stein am Rücken eines Sees# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, jouer une mélodie orageuse pour une pierre étrange au fond d'un lac révèle [[1]].", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_LW_GOSSIP_STONE_FAIRY] = HintText(CustomMessage("They say that #playing a tune for an odd stone within a perplexing wood# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer Melodie für einen seltsamen Stein innerhalb eines verwirrenden Waldes# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, jouer une mélodie pour une pierre étrange dans un bois déroutant révèle [[1]].", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_LW_GOSSIP_STONE_FAIRY_BIG] = HintText(CustomMessage("They say that #playing a stormy tune for an odd stone within a perplexing wood# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer stürmischen Melodie für einen seltsamen Stein innerhalb eines verwirrenden Waldes# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, jouer une mélodie orageuse pour une pierre étrange dans un bois déroutant révèle [[1]].", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_SFM_MAZE_GOSSIP_STONE_FAIRY] = HintText(CustomMessage("They say that #playing a tune for an odd stone overlooking a forest maze# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer Melodie für einen seltsamen Stein, welcher ein Waldlabyrinth überblickt#, #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, jouer une mélodie pour une pierre étrange surplombant un labyrinthe forestier révèle [[1]].", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_SFM_MAZE_GOSSIP_STONE_FAIRY_BIG] = HintText(CustomMessage("They say that #playing a stormy tune for an odd stone overlooking a forest maze# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer stürmischen Melodie für einen seltsamen Stein, welcher ein Waldlabyrinth überblickt#, #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, jouer une mélodie orageuse pour une pierre étrange surplombant un labyrinthe forestier révèle [[1]].", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_SFM_SARIA_GOSSIP_STONE_FAIRY] = HintText(CustomMessage("They say that #playing a tune for an odd stone watching a hiding place in the woods# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer Melodie für einen seltsamen Stein, welcher ein Versteck im Wald überblickt#, #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, jouer une mélodie pour une pierre étrange surveillant une cachette dans les bois révèle [[1]].", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_SFM_SARIA_GOSSIP_STONE_FAIRY_BIG] = HintText(CustomMessage("They say that #playing a stormy tune for an odd stone watching a hiding place in the woods# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer stürmischen Melodie für einen seltsamen Stein, welcher ein Versteck im Wald überblickt#, #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, jouer une mélodie orageuse pour une pierre étrange surveillant une cachette dans les bois révèle [[1]].", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_ZD_GOSSIP_STONE_FAIRY] = HintText(CustomMessage("They say that #playing a tune for an odd stone listening to an aquatic king# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer Melodie für einen seltsamen Stein, welcher einem aquatischen König zuhört#, #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, jouer une mélodie pour une pierre étrange écoutant un roi aquatique révèle [[1]].", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_ZD_GOSSIP_STONE_FAIRY_BIG] = HintText(CustomMessage("They say that #playing a stormy tune for an odd stone listening to an aquatic king# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer stürmischen Melodie für einen seltsamen Stein, welcher einem aquatischen König zuhört#, #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, jouer une mélodie orageuse pour une pierre étrange écoutant un roi aquatique révèle [[1]].", {QM_RED, QM_GREEN}));
 
-    hintTextTable[RHT_ZF_FAIRY_GOSSIP_STONE_FAIRY] = HintText(CustomMessage("They say that #playing a tune for an odd stone in the ouskirts of a deap fountain# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+    hintTextTable[RHT_ZF_FAIRY_GOSSIP_STONE_FAIRY] = HintText(CustomMessage("They say that #playing a tune for an odd stone in the outskirts of a deep fountain# reveals #[[1]]#.",
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer Melodie für einen seltsamen Stein am Rand eines tiefen Brunnens# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, jouer une mélodie pour une pierre étrange en périphérie d'une profonde fontaine révèle [[1]].", {QM_RED, QM_GREEN}));
 
-    hintTextTable[RHT_ZF_FAIRY_GOSSIP_STONE_FAIRY_BIG] = HintText(CustomMessage("They say that #playing a stormy tune for an odd stone in the ouskirts of a deap fountain# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+    hintTextTable[RHT_ZF_FAIRY_GOSSIP_STONE_FAIRY_BIG] = HintText(CustomMessage("They say that #playing a stormy tune for an odd stone in the outskirts of a deep fountain# reveals #[[1]]#.",
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer stürmischen Melodie für einen seltsamen Stein am Rand eines tiefen Brunnens# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, jouer une mélodie orageuse pour une pierre étrange en périphérie d'une profonde fontaine révèle [[1]].", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_ZF_JABU_GOSSIP_STONE_FAIRY] = HintText(CustomMessage("They say that #playing a tune for an odd stone watching a guardian of the sea# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer Melodie für einen seltsamen Stein, welcher einen Wächter des Meeres beobachtet#, #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, jouer une mélodie pour une pierre étrange surveillant un gardien de la mer révèle [[1]].", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_ZF_JABU_GOSSIP_STONE_FAIRY_BIG] = HintText(CustomMessage("They say that #playing a stormy tune for an odd stone watching a guardian of the sea# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer stürmischen Melodie für einen seltsamen Stein, welcher einen Wächter des Meeres beobachtet#, #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, jouer une mélodie orageuse pour une pierre étrange surveillant un gardien de la mer révèle [[1]].", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_ZR_NEAR_GROTTOS_GOSSIP_STONE_FAIRY] = HintText(CustomMessage("They say that #playing a tune for an odd stone overwatching a river# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer Melodie für einen seltsamen Stein, welcher einen Fluß überblickt#, #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, jouer une mélodie pour une pierre étrange surplombant une rivière révèle [[1]].", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_ZR_NEAR_GROTTOS_GOSSIP_STONE_FAIRY_BIG] = HintText(CustomMessage("They say that #playing a stormy tune for an odd stone overwatching a river# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer stürmischen Melodie für einen seltsamen Stein, welcher einen Fluß überblickt#, #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, jouer une mélodie orageuse pour une pierre étrange surplombant une rivière révèle [[1]].", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_ZR_NEAR_DOMAIN_GOSSIP_STONE_FAIRY] = HintText(CustomMessage("They say that #playing a tune for an odd stone beneath a waterfall# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer Melodie für einen seltsamen Stein unterhalb eines Wasserfalls# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, jouer une mélodie pour une pierre étrange sous une cascade révèle [[1]].", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_ZR_NEAR_DOMAIN_GOSSIP_STONE_FAIRY_BIG] = HintText(CustomMessage("They say that #playing a stormy tune for an odd stone beneath a waterfall# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer stürmischen Melodie für einen seltsamen Stein unterhalb eines Wasserfalls# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, jouer une mélodie orageuse pour une pierre étrange sous une cascade révèle [[1]].", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_HF_COW_GROTTO_GOSSIP_STONE_FAIRY] = HintText(CustomMessage("They say that #playing a tune for an odd stone hiding near a cow# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer Melodie für einen seltsamen Stein, welcher sich nahe einer Kuh versteckt#, #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, jouer une mélodie pour une pierre étrange cachée près d'une vache révèle [[1]].", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_HF_COW_GROTTO_GOSSIP_STONE_FAIRY_BIG] = HintText(CustomMessage("They say that #playing a stormy tune for an odd stone hiding near a cow# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer stürmischen Melodie für einen seltsamen Stein, welcher sich nahe einer Kuh versteckt#, #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, jouer une mélodie orageuse pour une pierre étrange cachée près d'une vache révèle [[1]].", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_HF_NEAR_MARKET_GROTTO_GOSSIP_STONE_FAIRY] = HintText(CustomMessage("They say that #playing a tune for an odd stone beneath the entrance to the market# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer Melodie für einen seltsamen Stein unterhalb des Eingangs zum Markt# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, jouer une mélodie pour une pierre étrange sous l'entrée du marché révèle [[1]].", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_HF_NEAR_MARKET_GROTTO_GOSSIP_STONE_FAIRY_BIG] = HintText(CustomMessage("They say that #playing a stormy tune for an odd stone beneath the entrance to the market# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer stürmischen Melodie für einen seltsamen Stein unterhalb des Eingangs zum Markt# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, jouer une mélodie orageuse pour une pierre étrange sous l'entrée du marché révèle [[1]].", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_HF_SOUTHEAST_GROTTO_GOSSIP_STONE_FAIRY] = HintText(CustomMessage("They say that #playing a tune for an odd stone beneath trees guarded by a Peahat# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer Melodie für einen seltsamen Stein unterhalb von Killeranas bewachten Bäumen# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, jouer une mélodie pour une pierre étrange sous des arbres gardés par un Peahat révèle [[1]].", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_HF_SOUTHEAST_GROTTO_GOSSIP_STONE_FAIRY_BIG] = HintText(CustomMessage("They say that #playing a stormy tune for an odd stone beneath trees guarded by a Peahat# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer stürmischen Melodie für einen seltsamen Stein unterhalb von Killeranas bewachten Bäumen# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, jouer une mélodie orageuse pour une pierre étrange sous des arbres gardés par un Peahat révèle [[1]].", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_KAK_OPEN_GROTTO_GOSSIP_STONE_FAIRY] = HintText(CustomMessage("They say that #playing a tune for an odd stone beneath a village at the base of a mountain# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer Melodie für einen seltsamen Stein unterhalb eines Dorfes am Fuße eines Berges# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, jouer une mélodie pour une pierre étrange sous un village au pied d'une montagne révèle [[1]].", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_KAK_OPEN_GROTTO_GOSSIP_STONE_FAIRY_BIG] = HintText(CustomMessage("They say that #playing a stormy tune for an odd stone beneath a village at the base of a mountain# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer stürmischen Melodie für einen seltsamen Stein unterhalb eines Dorfes am Fuße eines Berges# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, jouer une mélodie orageuse pour une pierre étrange sous un village au pied d'une montagne révèle [[1]].", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_ZR_OPEN_GROTTO_GOSSIP_STONE_FAIRY] = HintText(CustomMessage("They say that #playing a tune for an odd stone within a plateau by a river# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer Melodie für einen seltsamen Stein auf einem Plateau von einem Fluß# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, jouer une mélodie pour une pierre étrange dans un plateau près d'une rivière révèle [[1]].", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_ZR_OPEN_GROTTO_GOSSIP_STONE_FAIRY_BIG] = HintText(CustomMessage("They say that #playing a stormy tune for an odd stone within a plateau by a river# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer stürmischen Melodie für einen seltsamen Stein auf einem Plateau bei einem Fluß# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, jouer une mélodie orageuse pour une pierre étrange dans un plateau près d'une rivière révèle [[1]].", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_LW_NEAR_SHORTCUTS_GROTTO_GOSSIP_STONE_FAIRY] = HintText(CustomMessage("They say that #playing a tune for an odd stone beneath an escape from the forest# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer Melodie für einen seltsamen Stein unterhalb eines Auswegs des Waldes# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, jouer une mélodie pour une pierre étrange sous une issue de la forêt révèle [[1]].", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_LW_NEAR_SHORTCUTS_GROTTO_GOSSIP_STONE_FAIRY_BIG] = HintText(CustomMessage("They say that #playing a stormy tune for an odd stone beneath an escape from the forest# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer stürmischen Melodie für einen seltsamen Stein unterhalb eines Auswegs des Waldes# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, jouer une mélodie orageuse pour une pierre étrange sous une issue de la forêt révèle [[1]].", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_DMT_STORMS_GROTTO_GOSSIP_STONE_FAIRY] = HintText(CustomMessage("They say that #playing a tune for an odd stone beneath the entrance to a village within a mountain# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer Melodie für einen seltsamen Stein unterhalb eines Eingangs zu einem Dorf innerhalb eines Berges# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, jouer une mélodie pour une pierre étrange sous l'entrée d'un village dans une montagne révèle [[1]].", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_DMT_STORMS_GROTTO_GOSSIP_STONE_FAIRY_BIG] = HintText(CustomMessage("They say that #playing a stormy tune for an odd stone beneath the entrance to a village within a mountain# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer stürmischen Melodie für einen seltsamen Stein unterhalb eines Eingangs zu einem Dorf innerhalb eines Berges# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, jouer une mélodie orageuse pour une pierre étrange sous l'entrée d'un village dans une montagne révèle [[1]].", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_DMC_UPPER_GROTTO_GOSSIP_STONE_FAIRY] = HintText(CustomMessage("They say that #playing a tune for an odd stone within the side of a crater# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer Melodie für einen seltsamen Stein innerhalb der Seite eines Kraters# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, jouer une mélodie pour une pierre étrange dans le côté d'un cratère révèle [[1]].", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_DMC_UPPER_GROTTO_GOSSIP_STONE_FAIRY_BIG] = HintText(CustomMessage("They say that #playing a stormy tune for an odd stone within the side of a crater# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Spielen einer stürmischen Melodie für einen seltsamen Stein innerhalb der Seite eines Kraters# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, jouer une mélodie orageuse pour une pierre étrange dans le côté d'un cratère révèle [[1]].", {QM_RED, QM_GREEN}));
     
-    hintTextTable[RHT_LH_ISLAND_SUN_FAIRY] = HintText(CustomMessage("They say that #summoning the sun on the lake's island# calls #[[1]]#.", {QM_RED, QM_GREEN}));
+    hintTextTable[RHT_LH_ISLAND_SUN_FAIRY] = HintText(CustomMessage("They say that #summoning the sun on the lake's island# calls #[[1]]#.",
+                                            /*german*/ "Man erzählt sich, daß das #Beschwören der Sonne auf der Insel eines Sees# #[[1]]# anrufe.",
+                                            /*french*/ TODO_TRANSLATE, {QM_RED, QM_GREEN}));
 
-    hintTextTable[RHT_HF_POND_STORMS_FAIRY] = HintText(CustomMessage("They say that #calling rain to the field's pond# summons #[[1]]#.", {QM_RED, QM_GREEN}));
+    hintTextTable[RHT_HF_POND_STORMS_FAIRY] = HintText(CustomMessage("They say that #calling rain to the field's pond# summons #[[1]]#.",
+                                            /*german*/ "Man erzählt sich, daß das #Anrufen des Regens für den Tümpel eines Feldes# #[[1]]# beschwöre.",
+                                            /*french*/ TODO_TRANSLATE, {QM_RED, QM_GREEN}));
 
-    hintTextTable[RHT_HF_FENCE_GROTTO_STORMS_FAIRY] = HintText(CustomMessage("They say that #making it rain in a scrub's cave# wakes #[[1]]#.", {QM_RED, QM_GREEN}));
+    hintTextTable[RHT_HF_FENCE_GROTTO_STORMS_FAIRY] = HintText(CustomMessage("They say that #making it rain in a scrub's cave# wakes #[[1]]#.",
+                                            /*german*/ "Man erzählt sich, daß das #Machen von Regen in der Höhle eines Dekus# #[[1]]# erwecke.",
+                                            /*french*/ TODO_TRANSLATE, {QM_RED, QM_GREEN}));
 
-    hintTextTable[RHT_DMT_FLAG_SUN_FAIRY] = HintText(CustomMessage("They say that #changing the time in front of the trail's flag# reveals #[[1]]#.", {QM_RED, QM_GREEN}));
+    hintTextTable[RHT_DMT_FLAG_SUN_FAIRY] = HintText(CustomMessage("They say that #changing the time in front of the trail's flag# reveals #[[1]]#.",
+                                            /*german*/ "Man erzählt sich, daß das #Verändern der Zeit im Angesicht der Flagge eines Pfades# #[[1]]# enthülle.",
+                                            /*french*/ TODO_TRANSLATE, {QM_RED, QM_GREEN}));
 
-    hintTextTable[RHT_DMT_COW_GROTTO_STORMS_FAIRY] = HintText(CustomMessage("They say that #calling a storm for a lonely cow# reveals #[[1]]#.", {QM_RED, QM_GREEN}));
+    hintTextTable[RHT_DMT_COW_GROTTO_STORMS_FAIRY] = HintText(CustomMessage("They say that #calling a storm for a lonely cow# reveals #[[1]]#.",
+                                            /*german*/ "Man erzählt sich, daß das #Anrufen eines Sturms für eine einsame Kuh# #[[1]]# enthülle.",
+                                            /*french*/ TODO_TRANSLATE, {QM_RED, QM_GREEN}));
 
-    hintTextTable[RHT_LW_SHORTCUT_STORMS_FAIRY] = HintText(CustomMessage("They say that #making it rain in the Lost Woods# reveals #[[1]]#.", {QM_RED, QM_GREEN}));
+    hintTextTable[RHT_LW_SHORTCUT_STORMS_FAIRY] = HintText(CustomMessage("They say that #making it rain in the Lost Woods# reveals #[[1]]#.",
+                                            /*german*/ "Man erzählt sich, daß das #Machen von Regen in den verlorenen Wäldern# #[[1]]# enthülle.",
+                                            /*french*/ TODO_TRANSLATE, {QM_RED, QM_GREEN}));
 
-    hintTextTable[RHT_GF_KITCHEN_SUN_FAIRY] = HintText(CustomMessage("They say that #calling the sun in a guarded kitchen# exposes #[[1]]#.", {QM_RED, QM_GREEN}));
+    hintTextTable[RHT_GF_KITCHEN_SUN_FAIRY] = HintText(CustomMessage("They say that #calling the sun in a guarded kitchen# exposes #[[1]]#.",
+                                            /*german*/ "Man erzählt sich, daß das #Anrufen der Sonne in einer bewachten Küche# #[[1]]# freilege.",
+                                            /*french*/ TODO_TRANSLATE, {QM_RED, QM_GREEN}));
 
-    hintTextTable[RHT_LW_DEKU_SCRUB_GROTTO_SUN_FAIRY] = HintText(CustomMessage("They say that #calling the sun for scrubs in the Lost Woods# reveals #[[1]]#.", { QM_RED, QM_GREEN }));
+    hintTextTable[RHT_LW_DEKU_SCRUB_GROTTO_SUN_FAIRY] = HintText(CustomMessage("They say that #calling the sun for scrubs in the Lost Woods# reveals #[[1]]#.",
+                                            /*german*/ "Man erzählt sich, daß das #Anrufen der Sonne für Dekus in den verlorenen Wäldern# #[[1]]# enthülle.",
+                                            /*french*/ TODO_TRANSLATE, {QM_RED, QM_GREEN}));
 
-    hintTextTable[RHT_GRAVEYARD_ROYAL_FAMILYS_TOMB_SUN_FAIRY] = HintText(CustomMessage("They say that #calling the sun in a royal tomb# reveals #[[1]]#.", { QM_RED, QM_GREEN }));
+    hintTextTable[RHT_GRAVEYARD_ROYAL_FAMILYS_TOMB_SUN_FAIRY] = HintText(CustomMessage("They say that #calling the sun in a royal tomb# reveals #[[1]]#.",
+                                            /*german*/ "Man erzählt sich, daß das #Anrufen der Sonne in einer königlichen Gruft# #[[1]]# enthülle.",
+                                            /*french*/ TODO_TRANSLATE, {QM_RED, QM_GREEN}));
 
-    hintTextTable[RHT_KF_GRASS] = HintText(CustomMessage("They say that #cutting some grass in a forest# reveals #[[1]]#.", { QM_RED, QM_GREEN }));
+    hintTextTable[RHT_KF_GRASS] = HintText(CustomMessage("They say that #cutting some grass in a forest# reveals #[[1]]#.",
+                                            /*german*/ "Man erzählt sich, daß das #Schneiden einiger Gräser in einem Wald# #[[1]]# enthülle.",
+                                            /*french*/ TODO_TRANSLATE, {QM_RED, QM_GREEN}));
 
-    hintTextTable[RHT_LW_GRASS] = HintText(CustomMessage("They say that #cutting some grass in the woods# reveals #[[1]]#.", { QM_RED, QM_GREEN }));
+    hintTextTable[RHT_LW_GRASS] = HintText(CustomMessage("They say that #cutting some grass in the woods# reveals #[[1]]#.",
+                                            /*german*/ "Man erzählt sich, daß das #Schneiden einiger Gräser in den Wäldern# #[[1]]# enthülle.",
+                                            /*french*/ TODO_TRANSLATE, {QM_RED, QM_GREEN}));
 
-    hintTextTable[RHT_MARKET_GRASS] = HintText(CustomMessage("They say that #cutting some grass in the market# reveals #[[1]]#.", { QM_RED, QM_GREEN }));
+    hintTextTable[RHT_MARKET_GRASS] = HintText(CustomMessage("They say that #cutting some grass in the market# reveals #[[1]]#.",
+                                            /*german*/ "Man erzählt sich, daß das #Schneiden einiger Gräser auf dem Markt# #[[1]]# enthülle.",
+                                            /*french*/ TODO_TRANSLATE, {QM_RED, QM_GREEN}));
 
-    hintTextTable[RHT_HC_GRASS] = HintText(CustomMessage("They say that #cutting some grass near the castle# reveals #[[1]]#.", { QM_RED, QM_GREEN }));
+    hintTextTable[RHT_HC_GRASS] = HintText(CustomMessage("They say that #cutting some grass near the castle# reveals #[[1]]#.",
+                                            /*german*/ "Man erzählt sich, daß das #Schneiden einiger Gräser in der Nähe vom Schloß# #[[1]]# enthülle.",
+                                            /*french*/ TODO_TRANSLATE, {QM_RED, QM_GREEN}));
 
-    hintTextTable[RHT_KAK_GRASS] = HintText(CustomMessage("They say that #cutting some grass in a village# reveals #[[1]]#.", { QM_RED, QM_GREEN }));
+    hintTextTable[RHT_KAK_GRASS] = HintText(CustomMessage("They say that #cutting some grass in a village# reveals #[[1]]#.",
+                                            /*german*/ "Man erzählt sich, daß das #Schneiden einiger Gräser in einem Dorf# #[[1]]# enthülle.",
+                                            /*french*/ TODO_TRANSLATE, {QM_RED, QM_GREEN}));
 
-    hintTextTable[RHT_GY_GRASS] = HintText(CustomMessage("They say that #cutting some grass in a graveyard# reveals #[[1]]#.", { QM_RED, QM_GREEN }));
+    hintTextTable[RHT_GY_GRASS] = HintText(CustomMessage("They say that #cutting some grass in a graveyard# reveals #[[1]]#.",
+                                            /*german*/ "Man erzählt sich, daß das #Schneiden einiger Gräser auf einem Friedhof# #[[1]]# enthülle.",
+                                            /*french*/ TODO_TRANSLATE, {QM_RED, QM_GREEN}));
 
-    hintTextTable[RHT_LH_GRASS] = HintText(CustomMessage("They say that #cutting some grass near a lake# reveals #[[1]]#.", { QM_RED, QM_GREEN }));
+    hintTextTable[RHT_LH_GRASS] = HintText(CustomMessage("They say that #cutting some grass near a lake# reveals #[[1]]#.",
+                                            /*german*/ "Man erzählt sich, daß das #Schneiden einiger Gräser nahe eines Sees# #[[1]]# enthülle.",
+                                            /*french*/ TODO_TRANSLATE, {QM_RED, QM_GREEN}));
 
-    hintTextTable[RHT_HF_GRASS] = HintText(CustomMessage("They say that #cutting some grass on a field# reveals #[[1]]#.", { QM_RED, QM_GREEN }));
+    hintTextTable[RHT_HF_GRASS] = HintText(CustomMessage("They say that #cutting some grass on a field# reveals #[[1]]#.",
+                                            /*german*/ "Man erzählt sich, daß das #Schneiden einiger Gräser auf einem Feld# #[[1]]# enthülle.",
+                                            /*french*/ TODO_TRANSLATE, {QM_RED, QM_GREEN}));
 
-    hintTextTable[RHT_ZR_GRASS] = HintText(CustomMessage("They say that #cutting some grass near a river# reveals #[[1]]#.", { QM_RED, QM_GREEN }));
+    hintTextTable[RHT_ZR_GRASS] = HintText(CustomMessage("They say that #cutting some grass near a river# reveals #[[1]]#.",
+                                            /*german*/ "Man erzählt sich, daß das #Schneiden einiger Gräser in der Nähe von einem Fluß# #[[1]]# enthülle.",
+                                            /*french*/ TODO_TRANSLATE, {QM_RED, QM_GREEN}));
 
-    hintTextTable[RHT_GROTTO_GRASS] = HintText(CustomMessage("They say that #cutting some grass in a grotto# reveals #[[1]]#.", { QM_RED, QM_GREEN }));
+    hintTextTable[RHT_GROTTO_GRASS] = HintText(CustomMessage("They say that #cutting some grass in a grotto# reveals #[[1]]#.",
+                                            /*german*/ "Man erzählt sich, daß das #Schneiden einiger Gräser in einer Grotte# #[[1]]# enthülle.",
+                                            /*french*/ TODO_TRANSLATE, {QM_RED, QM_GREEN}));
 	
     hintTextTable[RHT_CRATE_GERUDO_VALLEY] = HintText(CustomMessage("They say that a #crate in Gerudo Valley# contains #[[1]]#.",
-                            /*german*/ TODO_TRANSLATE,
-                            /*french*/ "Selon moi, une #caisse dans une vallée# a #[[1]]#.", { QM_RED, QM_GREEN }));
+                                            /*german*/ "Man erzählt sich, daß eine #Kiste im Gerudotal# #[[1]]# enthielte.",
+                                            /*french*/ "Selon moi, une #caisse dans une vallée# a #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_CRATE_GERUDOS_FORTRESS] = HintText(CustomMessage("They say that a #crate in Gerudo Fortress# contains #[[1]]#.",
-                            /*german*/ TODO_TRANSLATE,
-                            /*french*/ "Selon moi, une #caisse dans la Forteresse Gerudo# contient #[[1]]#.", { QM_RED, QM_GREEN }));
+                                            /*german*/ "Man erzählt sich, daß eine #Kiste in der Gerudofestung# #[[1]]# enthielte.",
+                                            /*french*/ "Selon moi, une #caisse dans la Forteresse Gerudo# contient #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_CRATE_WASTELAND] = HintText(CustomMessage("They say that a #crate in Haunted Wasteland# contains #[[1]]#.",
-                            /*german*/ TODO_TRANSLATE,
-                            /*french*/ "Selon moi, une #caisse dans le Désert Hanté# contient #[[1]]#.", { QM_RED, QM_GREEN }));
+                                            /*german*/ "Man erzählt sich, daß eine #Kiste im Gerudotal# #[[1]]# enthielte.",
+                                            /*french*/ "Selon moi, une #caisse dans le Désert Hanté# contient #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_CRATE_MARKET] = HintText(CustomMessage("They say that a #crate in the Market# contains #[[1]]#.",
-                            /*german*/ TODO_TRANSLATE,
-                            /*french*/ "Selon moi, une #caisse dans la Place du Marché# contient #[[1]]#.", { QM_RED, QM_GREEN }));
+                                            /*german*/ "Man erzählt sich, daß eine #Kiste in der Gespensterwüste# #[[1]]# enthielte.",
+                                            /*french*/ "Selon moi, une #caisse dans la Place du Marché# contient #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_CRATE_KAKARIKO_VILLAGE] = HintText(CustomMessage("They say that a #crate in Kakariko Village# contains #[[1]]#.",
-                            /*german*/ TODO_TRANSLATE,
-                            /*french*/ "Selon moi, une #caisse dans le Village de Cocorico# contient #[[1]]#.", { QM_RED, QM_GREEN }));
+                                            /*german*/ "Man erzählt sich, daß eine #Kiste im Dorf von Kakariko# #[[1]]# enthielte.",
+                                            /*french*/ "Selon moi, une #caisse dans le Village de Cocorico# contient #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_CRATE_GRAVEYARD] = HintText(CustomMessage("They say that a #crate in the Graveyard# contains #[[1]]#.",
-                            /*german*/ TODO_TRANSLATE,
-                            /*french*/ "Selon moi, une #caisse dans le Cimetière# contient #[[1]]#.", { QM_RED, QM_GREEN }));
+                                            /*german*/ "Man erzählt sich, daß eine #Kiste auf dem Friedhof# #[[1]]# enthielte.",
+                                            /*french*/ "Selon moi, une #caisse dans le Cimetière# contient #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_CRATE_GORON_CITY] = HintText(CustomMessage("They say that a #crate in Goron City# contains #[[1]]#.",
-                            /*german*/ TODO_TRANSLATE,
-                            /*french*/ "Selon moi, une #caisse dans le Village Goron# contient #[[1]]#.", { QM_RED, QM_GREEN }));
+                                            /*german*/ "Man erzählt sich, daß eine #Kiste in Goronia# #[[1]]# enthielte.",
+                                            /*french*/ "Selon moi, une #caisse dans le Village Goron# contient #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_CRATE_DEATH_MOUNTAIN_CRATER] = HintText(CustomMessage("They say that a #crate in Death Mountain Crater# contains #[[1]]#.",
-                            /*german*/ TODO_TRANSLATE,
-                            /*french*/ "Selon moi, une #caisse sur le Mont du Péril# contient #[[1]]#.", { QM_RED, QM_GREEN }));
+                                            /*german*/ "Man erzählt sich, daß eine #Kiste im Todeskrater# #[[1]]# enthielte.",
+                                            /*french*/ "Selon moi, une #caisse sur le Mont du Péril# contient #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_CRATE_LON_LON_RANCH] = HintText(CustomMessage("They say that a #crate in Lon Lon Ranch# contains #[[1]]#.",
-                            /*german*/ TODO_TRANSLATE,
-                            /*french*/ "Selon moi, une #caisse dans le Ranch Lon Lon# contient #[[1]]#.", { QM_RED, QM_GREEN }));
+                                            /*german*/ "Man erzählt sich, daß eine #Kiste auf der Lon Lon-Farm# #[[1]]# enthielte.",
+                                            /*french*/ "Selon moi, une #caisse dans le Ranch Lon Lon# contient #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_CRATE_LAKESIDE_LABORATORY] = HintText(CustomMessage("They say that a #crate in the Laboratory# contains #[[1]]#.",
-                            /*german*/ TODO_TRANSLATE,
-                            /*french*/ "Selon moi, une #caisse dans un laboratoire# contient #[[1]]#.", { QM_RED, QM_GREEN }));
+                                            /*german*/ "Man erzählt sich, daß eine #Kiste im Laboratorium# #[[1]]# enthielte.",
+                                            /*french*/ "Selon moi, une #caisse dans un laboratoire# contient #[[1]]#.", {QM_RED, QM_GREEN}));
 
     // clang-format on
 }

--- a/soh/soh/Enhancements/randomizer/3drando/hint_list/hint_list_exclude_overworld.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/hint_list/hint_list_exclude_overworld.cpp
@@ -6,7 +6,7 @@ namespace Rando {
 void StaticData::HintTable_Init_Exclude_Overworld() {
     // clang-format off
 
-   hintTextTable[RHT_KF_KOKIRI_SWORD_CHEST] = HintText(CustomMessage("They say that the #hidden treasure of the Kokiri# is #[[1]]#.",
+    hintTextTable[RHT_KF_KOKIRI_SWORD_CHEST] = HintText(CustomMessage("They say that the #hidden treasure of the Kokiri# is #[[1]]#.",
                                                            /*german*/ "Man erzählt sich, daß der #versteckte Schatz der Kokiri# #[[1]]# sei.",
                                                            /*french*/ "Selon moi, le #trésor des Kokiri# est #[[1]]#.", {QM_RED, QM_GREEN}));
                                                         // /*spanish*/ Según dicen, el #tesoro oculto de los Kokiri# esconde #[[1]]#.
@@ -1557,127 +1557,127 @@ void StaticData::HintTable_Init_Exclude_Overworld() {
                                                         /*french*/ "Selon moi, un cœur dans la #maison d'une amie chère# cache #[[1]]#.", {QM_RED, QM_GREEN}));
                                                      // /*spanish*/
     hintTextTable[RHT_LOST_WOODS_RUPEE] = HintText(CustomMessage("They say that under a #boulder in the woods# lies #[[1]]#.",
-                                                      /*german*/ TODO_TRANSLATE,
+                                                      /*german*/ "Man erzählt sich, daß unter einem #Felsen in den Wäldern# #[[1]]# läge.",
                                                       /*french*/ "Selon moi, sous un #rocher dans les bois# se trouve #[[1]]#.", {QM_RED, QM_GREEN}));
                                                    // /*spanish*/
     hintTextTable[RHT_LOST_WOODS_SHORTCUT_RUPEE] = HintText(CustomMessage("They say that in a #pool of water in the woods# lies #[[1]]#.",
-                                                               /*german*/ TODO_TRANSLATE,
+                                                               /*german*/ "Man erzählt sich, daß in einem #Wasserbecken in den Wäldern# #[[1]]# läge.",
                                                                /*french*/ "Selon moi, dans une #mare d'eau dans les bois# se trouve #[[1]]#.", {QM_RED, QM_GREEN}));
                                                             // /*spanish*/
     hintTextTable[RHT_LAKE_HYLIA_RUPEE] = HintText(CustomMessage("They say that just off the #coast of a lake# lies #[[1]]#.",
-                                                      /*german*/ TODO_TRANSLATE,
+                                                      /*german*/ "Man erzählt sich, daß an der #Küste eines Sees# #[[1]]# läge.",
                                                       /*french*/ "Selon moi, juste au large de la #côte d'un lac# se trouve #[[1]]#.", {QM_RED, QM_GREEN}));
                                                    // /*spanish*/
     hintTextTable[RHT_LABORATORY_RUPEE] = HintText(CustomMessage("They say that at the #bottom of a tank# lies #[[1]]#.",
-                                                      /*german*/ TODO_TRANSLATE,
+                                                      /*german*/ "Man erzählt sich, daß auf dem #Grund eines Reservoirs# #[[1]]# läge.",
                                                       /*french*/ "Selon moi, au #fond d'un réservoir# se trouve #[[1]]#.", {QM_RED, QM_GREEN}));
                                                    // /*spanish*/
     hintTextTable[RHT_DAMPES_GRAVE_RUPEE] = HintText(CustomMessage("They say that within a #quick-footed spirit's grave# lies #[[1]]#.",
-                                                        /*german*/ TODO_TRANSLATE,
+                                                        /*german*/ "Man erzählt sich, daß innerhalb eines #Grabes eines leichtfüßigen Geistes# #[[1]]# läge.",
                                                         /*french*/ "Selon moi, dans la #tombe d'un esprit à pieds rapides# se trouve #[[1]]#.", {QM_RED, QM_GREEN}));
                                                      // /*spanish*/
     hintTextTable[RHT_GERUDO_VALLEY_GROTTO_RUPEE] = HintText(CustomMessage("They say that an Octarok in an #underground spring# guards #[[1]]#.",
-                                                                /*german*/ TODO_TRANSLATE,
+                                                                /*german*/ "Man erzählt sich, daß ein Oktorok in einer #untergründigen Quelle# #[[1]]# bewache.",
                                                                 /*french*/ "Selon moi, un Octrocher dans une #source souterraine# garde #[[1]]#.", {QM_RED, QM_GREEN}));
                                                              // /*spanish*/
     hintTextTable[RHT_DEATH_MOUNTAIN_TRAIL_RUPEE] = HintText(CustomMessage("They say that beneath a boulder on a #mountain's cliffside# lies #[[1]]#.",
-                                                                /*german*/ TODO_TRANSLATE,
+                                                                /*german*/ "Man erzählt sich, daß unterhalb eines Felsens an einem #abfallenden Felswand eines Berges# #[[1]]# läge.",
                                                                 /*french*/ "Selon moi, sous un rocher sur la #falaise d'une montagne# se trouve #[[1]]#.", {QM_RED, QM_GREEN}));
                                                              // /*spanish*/
     hintTextTable[RHT_DEATH_MOUNTAIN_TRAIL_GROTTO_HEART] = HintText(CustomMessage("They say that accompanying a #cow in a small cave# is #[[1]]#.",
-                                                                       /*german*/ TODO_TRANSLATE,
+                                                                       /*german*/ "Man erzählt sich, daß unterhalb eines Felsens an einem #abfallenden Felswand eines Berges# #[[1]]# läge.",
                                                                        /*french*/ "Selon moi, accompagner une #vache dans une petite grotte# est #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                     // /*spanish*/
     hintTextTable[RHT_DEATH_MOUNTAIN_TRAIL_GROTTO_RUPEE] = HintText(CustomMessage("They say that accompanying a #cow in a small cave# is #[[1]]#.",
-                                                                       /*german*/ TODO_TRANSLATE,
+                                                                       /*german*/ "Man erzählt sich, daß das Begleiten einer #Kuh in einer kleinen Höhle# #[[1]]# sei.",
                                                                        /*french*/ "Selon moi, accompagner une #vache dans une petite grotte# est #[[1]]#.", {QM_RED, QM_GREEN}));
                                                                     // /*spanish*/
     hintTextTable[RHT_DEATH_MOUNTAIN_CRATER_RUPEE] = HintText(CustomMessage("They say that on a #small platform suspended above lava# lies #[[1]]#.",
-                                                                 /*german*/ TODO_TRANSLATE,
+                                                                 /*german*/ "Man erzählt sich, daß auf einer #oberhalb von Lava hängenden kleinen Plattform# #[[1]]# läge.",
                                                                  /*french*/ "Selon moi, sur une #petite plateforme suspendue au-dessus de la lave# se trouve #[[1]]#.", {QM_RED, QM_GREEN}));
                                                               // /*spanish*/
     hintTextTable[RHT_ZORAS_RIVER_WATERFALL_RUPEE] = HintText(CustomMessage("They say that beneath a #waterfall feeding a narrow river# lies #[[1]]#.",
-                                                                 /*german*/ TODO_TRANSLATE,
+                                                                 /*german*/ "Man erzählt sich, daß unterhalb eines #einen schmalen Fluss nährenden Wasserfall# #[[1]]# läge.",
                                                                  /*french*/ "Selon moi, sous une #cascade alimentant une rivière étroite# se trouve #[[1]]#.", {QM_RED, QM_GREEN}));
                                                               // /*spanish*/
     hintTextTable[RHT_ZORAS_FOUNTAIN_RUPEE] = HintText(CustomMessage("They say that at the bottom of a #partially-frozen spring# lies #[[1]]#.",
-                                                          /*german*/ TODO_TRANSLATE,
+                                                          /*german*/ "Man erzählt sich, daß auf dem Grund einer #teilweise gefrorenen Quelle# #[[1]]# läge.",
                                                           /*french*/ "Selon moi, au fond d'une #source partiellement gelée# se trouve #[[1]]#.", {QM_RED, QM_GREEN}));
                                                        // /*spanish*/
 
     hintTextTable[RHT_SFM_FAIRY_GROTTO_FAIRY] = HintText(CustomMessage("They say that within #a fountain beneath a forest meadow# rests #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß innerhalb #eines Brunnens unter einer Waldwiese# #[[1]]# ruhe.",
                                             /*french*/ "Selon moi, dans #une fontaine sous un bosquet forestier# repose #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_ZR_FAIRY_GROTTO_FAIRY] = HintText(CustomMessage("They say that within #a fountain beneath a river# rests #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß innerhalb #eines Brunnens unter einem Fluß# #[[1]]# ruhe.",
                                             /*french*/ "Selon moi, dans #une fontaine sous une rivière# repose #[[1]]#.", {QM_RED, QM_GREEN}));
 
-    hintTextTable[RHT_HF_FAIRY_GROTTO_FAIRY] = HintText(CustomMessage("They say that within #a fountain beneath a a few trees bordering a wide field# rests #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+    hintTextTable[RHT_HF_FAIRY_GROTTO_FAIRY] = HintText(CustomMessage("They say that within #a fountain beneath a few trees bordering a wide field# rests #[[1]]#.",
+                                            /*german*/ "Man erzählt sich, daß innerhalb #eines Brunnens unter ein weites Feld angrenzenden Bäumen# #[[1]]# ruhe.",
                                             /*french*/ "Selon moi, dans #une fontaine sous quelques arbres bordant un vaste champ# repose #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_ZD_FAIRY_GROTTO_FAIRY] = HintText(CustomMessage("They say that within #a fountain beneath the home of the Zoras# rests #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß innerhalb #eines Brunnens unter der Heimat der Zoras# #[[1]]# ruhe.",
                                             /*french*/ "Selon moi, dans #une fontaine sous la maison des Zora# repose #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_GF_FAIRY_GROTTO_FAIRY] = HintText(CustomMessage("They say that within #a fountain beneath the home of thieves# rests #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß innerhalb #eines Brunnens unter der Heimat von Dieben# #[[1]]# ruhe.",
                                             /*french*/ "Selon moi, dans #une fontaine sous la maison des voleurs# repose #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_GRAVEYARD_SHIELD_GRAVE_FAIRY] = HintText(CustomMessage("They say that within #a fountain behind a wall within a grave# rests #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß innerhalb #eines Brunnens unter einer Mauer innerhalb eines Grabes# #[[1]]# ruhe.",
                                             /*french*/ "Selon moi, dans #une fontaine derrière un mur dans une tombe# repose #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_COLOSSUS_OASIS_FAIRY] = HintText(CustomMessage("They say that #restoring water to a dried oasis# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Wiederbringen von Wasser zu einer ausgetrockneten Oase# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, #restaurer l'eau dans un oasis asséché# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_ZR_BEAN_SPROUT_FAIRY] = HintText(CustomMessage("They say that #watering a young sprout on the riverside# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Wässern eines jungen Sprosses am Flußufer# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, #arroser une jeune pousse au bord de la rivière# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_KF_BEAN_SPROUT_FAIRY] = HintText(CustomMessage("They say that #watering a young sprout near a forest shop# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Wässern eines jungen Sprosses nahe des Waldladens# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, #arroser une jeune pousse près d'un magasin forestier# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_LW_BEAN_SPROUT_NEAR_BRIDGE_FAIRY] = HintText(CustomMessage("They say that #watering a young sprout near the entrance to the forest# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Wässern eines jungen Sprosses nahe des Eingangs zum Wald# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, #arroser une jeune pousse près de l'entrée de la forêt# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_LW_BEAN_SPROUT_NEAR_THEATER_FAIRY] = HintText(CustomMessage("They say that #watering a young sprout above a sylvan theatre# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Wässern eines jungen Sprosses oberhalb eines waldigen Theaters# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, #arroser une jeune pousse au-dessus d'un théâtre sylvestre# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_LH_BEAN_SPROUT_FAIRY] = HintText(CustomMessage("They say that #watering a young sprout on the lakeside# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Wässern eines jungen Sprosses am Seeufer# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, #arroser une jeune pousse au bord du lac# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_GV_BEAN_SPROUT_FAIRY] = HintText(CustomMessage("They say that #watering a young sprout on the side of a canyon# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Wässern eines jungen Sprosses an der Seite einer Schlucht# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, #arroser une jeune pousse sur le côté d'un canyon# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_COLOSSUS_BEAN_SPROUT_FAIRY] = HintText(CustomMessage("They say that #watering a young sprout near a temple of the sand# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Wässern eines jungen Sprosses nahe eines Tempels des Sandes# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, #arroser une jeune pousse près d'un temple du sable# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_GRAVEYARD_BEAN_SPROUT_FAIRY] = HintText(CustomMessage("They say that #watering a young sprout within a graveyard# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Wässern eines jungen Sprosses auf einem Friedhof# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, #arroser une jeune pousse dans un cimetière# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
 
     hintTextTable[RHT_DMC_BEAN_SPROUT_FAIRY] = HintText(CustomMessage("They say that #watering a young sprout within a volcano# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+                                            /*german*/ "Man erzählt sich, daß das #Wässern eines jungen Sprosses innerhalb eines Vulkans# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, #arroser une jeune pousse dans un volcan# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
 
-    hintTextTable[RHT_DMT_BEAN_SPROUT_FAIRY] = HintText(CustomMessage("They say that #watering a young sprout on the moutainside# reveals #[[1]]#.",
-                                            /*german*/ TODO_TRANSLATE,
+    hintTextTable[RHT_DMT_BEAN_SPROUT_FAIRY] = HintText(CustomMessage("They say that #watering a young sprout on the mountainside# reveals #[[1]]#.",
+                                            /*german*/ "Man erzählt sich, daß das #Wässern eines jungen Sprosses an einem Berghang# #[[1]]# enthülle.",
                                             /*french*/ "Selon moi, #arroser une jeune pousse sur le flanc d'une montagne# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
 
-    hintTextTable[RHT_TOT_GOSSIP_STONE_FAIRY] = HintText(CustomMessage("They say that #playing a tune for an odd stone in the ouskirts of the market# reveals #[[1]]#.",
+    hintTextTable[RHT_TOT_GOSSIP_STONE_FAIRY] = HintText(CustomMessage("They say that #playing a tune for an odd stone in the outskirts of the market# reveals #[[1]]#.",
                                             /*german*/ TODO_TRANSLATE,
                                             /*french*/ "Selon moi, #jouer une mélodie pour une pierre étrange en périphérie du marché# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
 
-    hintTextTable[RHT_TOT_GOSSIP_STONE_FAIRY_BIG] = HintText(CustomMessage("They say that #playing a stormy tune for an odd stone in the ouskirts of the market# reveals #[[1]]#.",
+    hintTextTable[RHT_TOT_GOSSIP_STONE_FAIRY_BIG] = HintText(CustomMessage("They say that #playing a stormy tune for an odd stone in the outskirts of the market# reveals #[[1]]#.",
                                             /*german*/ TODO_TRANSLATE,
                                             /*french*/ "Selon moi, #jouer une mélodie orageuse pour une pierre étrange en périphérie du marché# révèle #[[1]]#.", {QM_RED, QM_GREEN}));
 


### PR DESCRIPTION
This PR contains additions for the German translation of hint_list_exclude_dungeon.cpp and hint_list_exclude_overworld.cpp combined with small fixes for the English translation.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2904599866.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2904601529.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2904648083.zip)
<!--- section:artifacts:end -->