### PR TITLE
Add temporary patch for invisible boulder fragments

### DIFF
--- a/soh/soh/Enhancements/cosmetics/authenticGfxPatches.cpp
+++ b/soh/soh/Enhancements/cosmetics/authenticGfxPatches.cpp
@@ -281,11 +281,24 @@ void PatchIronKnuckleTextureOverflow() {
     }
 }
 
+void PatchBoulderFragment() {
+    // The boulder fragment renders invisible due to the change made by https://github.com/Kenix3/libultraship/pull/721
+    // Until it is known wether this change is approriate or something else should be done to it, the following patches
+    // adjust the render mode for the DL to not become invisible
+    ResourceMgr_PatchGfxByName(gBoulderFragmentsDL, "boulderFragmentRenderFix3", 3,
+                               gsDPSetRenderMode(G_RM_FOG_SHADE_A, G_RM_AA_ZB_OPA_SURF2));
+    ResourceMgr_PatchGfxByName(gBoulderFragmentsDL, "boulderFragmentRenderFix6", 6,
+                               gsDPSetCombineMode(G_CC_MODULATEIDECALA, G_CC_MODULATEIA_PRIM2));
+}
+
 void ApplyAuthenticGfxPatches() {
+    // Overflow textures
     PatchArrowTipTexture();
     PatchDekuStickTextureOverflow();
     PatchFreezardTextureOverflow();
     PatchIronKnuckleTextureOverflow();
+
+    PatchBoulderFragment();
 }
 
 // Patches the Sold Out GI DL to render the texture in the mirror boundary


### PR DESCRIPTION
For reasons not understood, the change made in LUS by https://github.com/Kenix3/libultraship/pull/721 was causing boulder fragments to display invisible.

As a temporary solution, this adds a gfx patch to replace the render mode and color combiner with the values used by the effect spawner/manager in `EffectSsKakera_Draw`. This works enough to get the fragments to display like they did before from what I can tell.

Ideally it would be great to investigate the LUS change itself and see if what it was trying to solve for is correctly accounted for.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2903801895.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2903802255.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2903811644.zip)
<!--- section:artifacts:end -->