### PR TITLE
Fix Docked Tracker Ghosting

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
@@ -1161,11 +1161,16 @@ void BeginFloatingWindows(std::string UniqueName, ImGuiWindowFlags flags = 0) {
             windowFlags |= ImGuiWindowFlags_NoInputs | ImGuiWindowFlags_NoMove;
         }
     }
-    ImGui::PushStyleColor(ImGuiCol_WindowBg,
-                          VecFromRGBA8(CVarGetColor(CVAR_TRACKER_ITEM("BgColor.Value"), { 0, 0, 0, 0 })));
+    auto color = VecFromRGBA8(CVarGetColor(CVAR_TRACKER_ITEM("BgColor.Value"), { 0, 0, 0, 0 }));
+    ImGuiWindow* window = ImGui::FindWindowByName(UniqueName.c_str());
+    if (window != NULL && window->DockTabIsVisible) {
+        color.w = 1.0f;
+    }
+    ImGui::PushStyleColor(ImGuiCol_WindowBg, color);
     ImGui::PushStyleColor(ImGuiCol_Border, ImVec4(0, 0, 0, 0));
     ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 4.0f);
     ImGui::Begin(UniqueName.c_str(), nullptr, windowFlags);
+    ImGui::GetCurrentWindow()->Name;
 }
 void EndFloatingWindows() {
     ImGui::PopStyleVar();

--- a/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
@@ -1170,7 +1170,6 @@ void BeginFloatingWindows(std::string UniqueName, ImGuiWindowFlags flags = 0) {
     ImGui::PushStyleColor(ImGuiCol_Border, ImVec4(0, 0, 0, 0));
     ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 4.0f);
     ImGui::Begin(UniqueName.c_str(), nullptr, windowFlags);
-    ImGui::GetCurrentWindow()->Name;
 }
 void EndFloatingWindows() {
     ImGui::PopStyleVar();


### PR DESCRIPTION
The issue was caused by a transparent color being applied to the window even while it was docked. This sets it up to dynamically change a tracker's chosen color's opacity to full when it registers as docked to fix it.

Underlying cause: it *seems* like ImGui itself is supposed to do that automatically when a window is docked (could make the ghosting go away without this by docking another window in the same tab group, like the check tracker, which would then make the ImGuiWindow::DockIsActive be true when it was false on its own), but no need waiting on the process of repro and investigation and subsequent release over there.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2904631206.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2904649268.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2904649341.zip)
<!--- section:artifacts:end -->