### PR TITLE
Fix crash in Message Viewer when playing with an NTSC OTR.

### DIFF
--- a/soh/soh/Enhancements/debugger/MessageViewer.cpp
+++ b/soh/soh/Enhancements/debugger/MessageViewer.cpp
@@ -2,6 +2,7 @@
 
 #include "soh/SohGui/UIWidgets.hpp"
 #include "soh/SohGui/SohGui.hpp"
+#include "soh/SohGui/SohMenu.h"
 #include "soh/OTRGlobals.h"
 
 #include <textures/message_static/message_static.h>
@@ -56,22 +57,12 @@ void MessageViewer::DrawElement() {
         memset(mTextIdBuf, 0, sizeof(char) * MAX_STRING_SIZE);
     }
     PopStyleCheckbox();
-    ImGui::Text("Language");
-    ImGui::SameLine();
-    PushStyleCombobox(THEME_COLOR);
-    if (ImGui::BeginCombo("##Language", mLanguages[mLanguage])) {
-        // ReSharper disable CppDFAUnreachableCode
-        for (size_t i = 0; i < mLanguages.size(); i++) {
-            if (strlen(mLanguages[i]) > 0) {
-                if (ImGui::Selectable(mLanguages[i], i == mLanguage)) {
-                    mLanguage = i;
-                }
-            }
-        }
-        ImGui::EndCombo();
-    }
-    PopStyleCombobox();
-    UIWidgets::InsertHelpHoverText("Which language to load from the selected text ID");
+    SohGui::SohMenu::UpdateLanguageMap(SohGui::languages);
+    UIWidgets::Combobox("Language", &mLanguage, SohGui::languages,
+                        UIWidgets::ComboboxOptions()
+                            .Color(THEME_COLOR)
+                            .DefaultIndex(0)
+                            .Tooltip("Which language to load from the selected text ID"));
     PushStyleButton(THEME_COLOR);
     if (ImGui::Button("Display Message##ExistingMessage")) {
         mDisplayExistingMessageClicked = true;
@@ -196,6 +187,11 @@ void MessageDebug_StartTextBox(const char* tableId, uint16_t textId, uint8_t lan
     R_TEXT_CHAR_SCALE = 75;
     R_TEXT_LINE_SPACING = 12;
     R_TEXT_INIT_XPOS = 65;
+    if (language == LANGUAGE_JPN) {
+        R_TEXT_CHAR_SCALE = 88;
+        R_TEXT_LINE_SPACING = 18;
+        R_TEXT_INIT_XPOS = 65;
+    }
     char* buffer = font->msgBuf;
     msgCtx->textId = textId;
     if (strlen(tableId) == 0) {
@@ -207,10 +203,8 @@ void MessageDebug_StartTextBox(const char* tableId, uint16_t textId, uint8_t lan
         constexpr int maxBufferSize = sizeof(font->msgBuf);
         const CustomMessage messageEntry = CustomMessageManager::Instance->RetrieveMessage(tableId, textId);
         font->charTexBuf[0] = (messageEntry.GetTextBoxType() << 4) | messageEntry.GetTextBoxPosition();
-        switch (language) {
-            font->msgLength =
-                SohUtils::CopyStringToCharBuffer(buffer, messageEntry.GetForLanguage(language), maxBufferSize);
-        }
+        font->msgLength =
+            SohUtils::CopyStringToCharBuffer(buffer, messageEntry.GetForLanguage(language), maxBufferSize);
         msgCtx->msgLength = static_cast<int32_t>(font->msgLength);
     }
     msgCtx->textBoxProperties = font->charTexBuf[0];

--- a/soh/soh/Enhancements/debugger/MessageViewer.h
+++ b/soh/soh/Enhancements/debugger/MessageViewer.h
@@ -4,7 +4,7 @@
 
 #ifdef __cplusplus
 #include "GuiWindow.h"
-#include <array>
+#include <unordered_map>
 extern "C" {
 #endif
 /**
@@ -41,7 +41,6 @@ class MessageViewer : public Ship::GuiWindow {
     void DisplayCustomMessage() const;
 
     static constexpr uint16_t MAX_STRING_SIZE = 1024;
-    static constexpr std::array<const char*, LANGUAGE_MAX> mLanguages = { "English", "German", "French" };
     static constexpr int HEXADECIMAL = 0;
     static constexpr int DECIMAL = 1;
     char* mTableIdBuf;
@@ -49,7 +48,7 @@ class MessageViewer : public Ship::GuiWindow {
     char* mTextIdBuf;
     uint16_t mTextId;
     int mTextIdBase = HEXADECIMAL;
-    size_t mLanguage = LANGUAGE_ENG;
+    int32_t mLanguage = LANGUAGE_ENG;
     char* mCustomMessageBuf;
     std::string mCustomMessageString;
     bool mDisplayExistingMessageClicked = false;

--- a/soh/soh/SohGui/SohMenu.h
+++ b/soh/soh/SohGui/SohMenu.h
@@ -28,6 +28,13 @@ void disableBetaQuest();
 
 namespace SohGui {
 
+static std::unordered_map<int32_t, const char*> languages = {
+    { LANGUAGE_ENG, "English" },
+    { LANGUAGE_GER, "German" },
+    { LANGUAGE_FRA, "French" },
+    { LANGUAGE_JPN, "Japanese" },
+};
+
 static const std::unordered_map<int32_t, const char*> menuThemeOptions = {
     { UIWidgets::Colors::Red, "Red" },
     { UIWidgets::Colors::DarkRed, "Dark Red" },

--- a/soh/soh/SohGui/SohMenuSettings.cpp
+++ b/soh/soh/SohGui/SohMenuSettings.cpp
@@ -14,12 +14,7 @@ namespace SohGui {
 
 extern std::shared_ptr<SohMenu> mSohMenu;
 using namespace UIWidgets;
-static const std::unordered_map<int32_t, const char*> languages = {
-    { LANGUAGE_ENG, "English" },
-    { LANGUAGE_GER, "German" },
-    { LANGUAGE_FRA, "French" },
-    { LANGUAGE_JPN, "Japanese" },
-};
+
 static std::unordered_map<int32_t, const char*> imguiScaleOptions = {
     { 0, "Small" },
     { 1, "Normal" },


### PR DESCRIPTION
fixes #5299

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2913076182.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2913080289.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2913096356.zip)
<!--- section:artifacts:end -->