### PR TITLE
Fix Bean Access Availability Logic

### DIFF
--- a/soh/soh/Enhancements/randomizer/logic.cpp
+++ b/soh/soh/Enhancements/randomizer/logic.cpp
@@ -71,7 +71,7 @@ bool Logic::HasItem(RandomizerGet itemName) {
         case RG_DISTANT_SCARECROW:
             return ScarecrowsSong() && CanUse(RG_LONGSHOT);
         case RG_MAGIC_BEAN:
-            return GetAmmo(ITEM_BEAN) > 0;
+            return GetAmmo(ITEM_BEAN) > 0 || CheckInventory(ITEM_BEAN, true);
         case RG_KOKIRI_SWORD:
         case RG_DEKU_SHIELD:
         case RG_GORON_TUNIC:


### PR DESCRIPTION
Logic for being able to use a bean was relying on ammo count being higher than 0, but this could be problematic for things like bean stalk fairies that weren't accessible at the time it was planted and running out of beans, thus showing the fairies as inaccessible even after getting Storms. This adds a check for bean inventory slot having bean on it to allow availability to succeed with ammo count 0.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2914532998.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2914536926.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2914540170.zip)
<!--- section:artifacts:end -->