### PR TITLE
Rebottle Blue Fire

### DIFF
--- a/soh/soh/Enhancements/RebottleBlueFire.cpp
+++ b/soh/soh/Enhancements/RebottleBlueFire.cpp
@@ -1,0 +1,25 @@
+#include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
+#include "soh/ShipInit.hpp"
+
+extern "C" {
+#include "src/overlays/actors/ovl_En_Ice_Hono/z_en_ice_hono.h"
+void EnIceHono_CapturableFlame(EnIceHono* thisx, PlayState* play);
+u32 EnIceHono_InBottleRange(EnIceHono* thisx, PlayState* play);
+}
+
+extern PlayState* gPlayState;
+
+void OnEnIceHonoUpdate(void* actor) {
+    EnIceHono* thisx = (EnIceHono*)actor;
+    if (thisx->actionFunc != EnIceHono_CapturableFlame && EnIceHono_InBottleRange(thisx, gPlayState)) {
+        // GI_MAX in this case allows the player to catch the actor in a bottle
+        Actor_OfferGetItem(&thisx->actor, gPlayState, GI_MAX, 60.0f, 100.0f);
+    }
+}
+
+void RegisterRebottleBlueFire() {
+    COND_ID_HOOK(OnActorUpdate, ACTOR_EN_ICE_HONO, CVarGetInteger(CVAR_ENHANCEMENT("RebottleBlueFire"), 0),
+                 OnEnIceHonoUpdate);
+}
+
+static RegisterShipInitFunc initFunc(RegisterRebottleBlueFire, { CVAR_ENHANCEMENT("RebottleBlueFire") });

--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -830,6 +830,11 @@ void SohMenu::AddMenuEnhancements() {
         .CVar(CVAR_ENHANCEMENT("FastFarores"))
         .Options(CheckboxOptions().Tooltip("Greatly decreases cast time of Farore's Wind magic spell."));
 
+    AddWidget(path, "Bottles", WIDGET_SEPARATOR_TEXT);
+    AddWidget(path, "Rebottle Blue Fire", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_ENHANCEMENT("RebottleBlueFire"))
+        .Options(CheckboxOptions().Tooltip("Blue Fire dropped from bottle can be bottled."));
+
     // Fixes
     path.sidebarName = "Fixes";
     AddSidebarEntry("Enhancements", path.sidebarName, 3);

--- a/soh/src/overlays/actors/ovl_En_Ice_Hono/z_en_ice_hono.c
+++ b/soh/src/overlays/actors/ovl_En_Ice_Hono/z_en_ice_hono.c
@@ -7,6 +7,8 @@
 #include "z_en_ice_hono.h"
 #include "objects/gameplay_keep/gameplay_keep.h"
 
+#include <libultraship/libultra.h>
+
 #define FLAGS 0
 
 void EnIceHono_Init(Actor* thisx, PlayState* play);
@@ -296,6 +298,10 @@ void EnIceHono_SpreadFlames(EnIceHono* this, PlayState* play) {
         }
     }
 
+    if (CVarGetInteger(CVAR_ENHANCEMENT("RebottleBlueFire"), 0)) {
+        EnIceHono_CapturableFlame(this, play);
+    }
+
     if (this->timer <= 0) {
         Actor_Kill(&this->actor);
     }
@@ -331,6 +337,11 @@ void EnIceHono_SmallFlameMove(EnIceHono* this, PlayState* play) {
         this->alpha -= 10;
         this->alpha = CLAMP(this->alpha, 0, 255);
     }
+
+    if (CVarGetInteger(CVAR_ENHANCEMENT("RebottleBlueFire"), 0)) {
+        EnIceHono_CapturableFlame(this, play);
+    }
+
     if (this->timer <= 0) {
         Actor_Kill(&this->actor);
     }

--- a/soh/src/overlays/actors/ovl_En_Ice_Hono/z_en_ice_hono.c
+++ b/soh/src/overlays/actors/ovl_En_Ice_Hono/z_en_ice_hono.c
@@ -7,8 +7,6 @@
 #include "z_en_ice_hono.h"
 #include "objects/gameplay_keep/gameplay_keep.h"
 
-#include <libultraship/libultra.h>
-
 #define FLAGS 0
 
 void EnIceHono_Init(Actor* thisx, PlayState* play);
@@ -298,10 +296,6 @@ void EnIceHono_SpreadFlames(EnIceHono* this, PlayState* play) {
         }
     }
 
-    if (CVarGetInteger(CVAR_ENHANCEMENT("RebottleBlueFire"), 0)) {
-        EnIceHono_CapturableFlame(this, play);
-    }
-
     if (this->timer <= 0) {
         Actor_Kill(&this->actor);
     }
@@ -337,11 +331,6 @@ void EnIceHono_SmallFlameMove(EnIceHono* this, PlayState* play) {
         this->alpha -= 10;
         this->alpha = CLAMP(this->alpha, 0, 255);
     }
-
-    if (CVarGetInteger(CVAR_ENHANCEMENT("RebottleBlueFire"), 0)) {
-        EnIceHono_CapturableFlame(this, play);
-    }
-
     if (this->timer <= 0) {
         Actor_Kill(&this->actor);
     }


### PR DESCRIPTION
Makes Ice Cavern less annoying, & is particularly useful to avoid excessive laps between Ice Cavern & Mud Walls (Medigoron..) when Blue Fire tricks enabled

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3101864860.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3101866939.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3101874142.zip)
<!--- section:artifacts:end -->