### PR TITLE
Fix Adult Fishing as Child Softlock

### DIFF
--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -951,7 +951,7 @@ typedef enum {
     // false
     // ```
     // #### `args`
-    // - '*Fishing' (this)
+    // - '*Fishing'
     VB_GIVE_RANDO_GLITCH_FISHING_PRIZE,
 
     // #### `result`

--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -951,7 +951,7 @@ typedef enum {
     // false
     // ```
     // #### `args`
-    // - '*Fishing' (&this)
+    // - '*Fishing' (this)
     VB_GIVE_RANDO_GLITCH_FISHING_PRIZE,
 
     // #### `result`

--- a/soh/src/overlays/actors/ovl_Fishing/z_fishing.c
+++ b/soh/src/overlays/actors/ovl_Fishing/z_fishing.c
@@ -5170,7 +5170,7 @@ void Fishing_HandleOwnerDialog(Fishing* this, PlayState* play) {
             if (Actor_HasParent(&this->actor, play)) {
                 this->stateAndTimer = 24;
             } else {
-                if (!GameInteractor_Should(VB_GIVE_RANDO_GLITCH_FISHING_PRIZE, false, &this)) {
+                if (!GameInteractor_Should(VB_GIVE_RANDO_GLITCH_FISHING_PRIZE, false, this)) {
                     Actor_OfferGetItem(&this->actor, play, GI_SCALE_GOLDEN, 2000.0f, 1000.0f);
                 }
             }


### PR DESCRIPTION
Changing the hook code to correctly use Fishing* instead of VBFishingData* resulted in passing a pointer to the pointer (&this - Fishing**), causing a softlock when the switch variable was only updated on this copy instead of live. Passing the pointer itself resolves this.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2921045664.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2921046207.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2921112061.zip)
<!--- section:artifacts:end -->