### PR TITLE
Fix Fishing-related checks location pool (again)

### DIFF
--- a/soh/soh/Enhancements/randomizer/context.cpp
+++ b/soh/soh/Enhancements/randomizer/context.cpp
@@ -180,6 +180,8 @@ void Context::GenerateLocationPool() {
                location.GetRandomizerCheck() == RC_HF_DEKU_SCRUB_GROTTO)) ||
             (location.GetRCType() == RCTYPE_ADULT_TRADE && mOptions[RSK_SHUFFLE_ADULT_TRADE].Is(RO_GENERIC_OFF)) ||
             (location.GetRCType() == RCTYPE_COW && mOptions[RSK_SHUFFLE_COWS].Is(RO_GENERIC_OFF)) ||
+            (location.GetRandomizerCheck() == RC_LH_HYRULE_LOACH &&
+             mOptions[RSK_FISHSANITY].IsNot(RO_FISHSANITY_HYRULE_LOACH)) ||
             (location.GetRCType() == RCTYPE_FISH && !mFishsanity->GetFishLocationIncluded(&location)) ||
             (location.GetRCType() == RCTYPE_POT && mOptions[RSK_SHUFFLE_POTS].Is(RO_SHUFFLE_POTS_OFF)) ||
             (location.GetRCType() == RCTYPE_GRASS && mOptions[RSK_SHUFFLE_GRASS].Is(RO_SHUFFLE_GRASS_OFF)) ||

--- a/soh/soh/Enhancements/randomizer/fishsanity.cpp
+++ b/soh/soh/Enhancements/randomizer/fishsanity.cpp
@@ -74,13 +74,10 @@ Fishsanity::~Fishsanity() {
 bool Fishsanity::GetFishLocationIncluded(Rando::Location* loc, FishsanityOptionsSource optionsSource) {
     auto [mode, numFish, ageSplit] = GetOptions(optionsSource);
 
-    if (loc->GetRCType() != RCTYPE_FISH || mode == RO_FISHSANITY_OFF) {
+    if (loc->GetRCType() != RCTYPE_FISH || mode == RO_FISHSANITY_OFF || mode == RO_FISHSANITY_HYRULE_LOACH) {
         return false;
     }
     RandomizerCheck rc = loc->GetRandomizerCheck();
-    if (mode == RO_FISHSANITY_HYRULE_LOACH && rc != RC_LH_HYRULE_LOACH) {
-        return false;
-    }
     // Are pond fish enabled, and is this a pond fish location?
     if (mode != RO_FISHSANITY_OVERWORLD && numFish > 0 && loc->GetScene() == SCENE_FISHING_POND &&
         loc->GetActorID() == ACTOR_FISHING) {


### PR DESCRIPTION
I missed the fact that Hyrule Loach Check is, in fact, not of type `RC_FISH` but of type `RC_STANDARD`. Oops. I tested all the settings to confirm that nothing ended up in the spoiler log that shouldn't have been there. I would encourage someone else to do the same.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2916281130.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2916282519.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2916284615.zip)
<!--- section:artifacts:end -->