### PR TITLE
No Saved Settings for Notification windows

### DIFF
--- a/soh/soh/Enhancements/enemyrandomizer.cpp
+++ b/soh/soh/Enhancements/enemyrandomizer.cpp
@@ -318,25 +318,19 @@ extern "C" uint8_t GetRandomizedEnemy(PlayState* play, int16_t* actorId, f32* po
     return 1;
 }
 
-std::vector<EnemyEntry> selectedEnemyList;
+static std::vector<EnemyEntry> selectedEnemyList;
 
 void GetSelectedEnemies() {
     selectedEnemyList.clear();
-    if (CVarGetInteger(CVAR_ENHANCEMENT("RandomizedEnemies"), ENEMY_RANDOMIZER_OFF) == ENEMY_RANDOMIZER_RANDOM) {
-        for (int i = 0; i < 49; i++) {
-            if (CVarGetInteger(CVAR_ENHANCEMENT("RandomizedEnemyList.All"), 0)) {
-                selectedEnemyList.push_back(randomizedEnemySpawnTable[i]);
-            } else if (CVarGetInteger(enemyCVarList[i], 1)) {
-                selectedEnemyList.push_back(randomizedEnemySpawnTable[i]);
-            }
-        }
-        if (selectedEnemyList.size() == 0) {
-            selectedEnemyList.push_back(randomizedEnemySpawnTable[0]);
-        }
-    } else {
-        for (int i = 0; i < 49; i++) {
+    for (int i = 0; i < 49; i++) {
+        if (CVarGetInteger(CVAR_ENHANCEMENT("RandomizedEnemyList.All"), 0)) {
+            selectedEnemyList.push_back(randomizedEnemySpawnTable[i]);
+        } else if (CVarGetInteger(enemyCVarList[i], 1)) {
             selectedEnemyList.push_back(randomizedEnemySpawnTable[i]);
         }
+    }
+    if (selectedEnemyList.size() == 0) {
+        selectedEnemyList.push_back(randomizedEnemySpawnTable[0]);
     }
 }
 
@@ -348,7 +342,7 @@ EnemyEntry GetRandomizedEnemyEntry(uint32_t seed) {
         uint32_t finalSeed =
             seed + (IS_RANDO ? Rando::Context::GetInstance()->GetSeed() : gSaveContext.ship.stats.fileCreatedAt);
         Random_Init(finalSeed);
-        uint32_t randomNumber = Random(0, RANDOMIZED_ENEMY_SPAWN_TABLE_SIZE);
+        uint32_t randomNumber = Random(0, selectedEnemyList.size());
         return selectedEnemyList[randomNumber];
     } else {
         uint32_t randomSelectedEnemy = Random(0, selectedEnemyList.size());


### PR DESCRIPTION
Was saving settings for notification ids well into the 500s in one I saw, and seemed to be causing migration issues (for someone having those issues, when I sent back an ini with the notification entries removed, the migration was no longer an issue). This adds the flag to prevent saving that info in the ini. Unfortunately, users will have to do that themselves or wipe their ini for this to take effect for them.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2917146702.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2917154929.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2917156214.zip)
<!--- section:artifacts:end -->