### PR TITLE
No Saved Settings for Notification windows

### DIFF
--- a/soh/soh/Notification/Notification.cpp
+++ b/soh/soh/Notification/Notification.cpp
@@ -61,7 +61,7 @@ void Window::Draw() {
                      ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoNav | ImGuiWindowFlags_NoFocusOnAppearing |
                          ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoDocking | ImGuiWindowFlags_NoTitleBar |
                          ImGuiWindowFlags_NoScrollWithMouse | ImGuiWindowFlags_NoInputs | ImGuiWindowFlags_NoMove |
-                         ImGuiWindowFlags_NoScrollbar);
+                         ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoSavedSettings);
 
         ImGui::SetWindowFontScale(CVarGetFloat(CVAR_SETTING("Notifications.Size"), 1.8f)); // Make this adjustable
 


### PR DESCRIPTION
Was saving settings for notification ids well into the 500s in one I saw, and seemed to be causing migration issues (for someone having those issues, when I sent back an ini with the notification entries removed, the migration was no longer an issue). This adds the flag to prevent saving that info in the ini. Unfortunately, users will have to do that themselves or wipe their ini for this to take effect for them.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2917397464.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2917398289.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2917404214.zip)
<!--- section:artifacts:end -->