### PR TITLE
Fix weird egg logic

### DIFF
--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -245,10 +245,6 @@ void RandomizerOnFlagSetHandler(int16_t flagType, int16_t flag) {
         Flags_SetRandomizerInf(RAND_INF_ZELDAS_LETTER);
     }
 
-    if (flagType == FLAG_EVENT_CHECK_INF && flag == EVENTCHKINF_OBTAINED_POCKET_EGG) {
-        Flags_SetRandomizerInf(RAND_INF_WEIRD_EGG);
-    }
-
     RandomizerCheck rc = GetRandomizerCheckFromFlag(flagType, flag);
     if (rc == RC_UNKNOWN_CHECK)
         return;

--- a/soh/soh/Enhancements/randomizer/location_access/overworld/castle_grounds.cpp
+++ b/soh/soh/Enhancements/randomizer/location_access/overworld/castle_grounds.cpp
@@ -34,7 +34,7 @@ void RegionTable_Init_CastleGrounds() {
     }, {
         //Exits
         Entrance(RR_CASTLE_GROUNDS,          []{return true;}),
-        Entrance(RR_HC_GARDEN,               []{return logic->CanUse(RG_WEIRD_EGG) || !ctx->GetOption(RSK_SHUFFLE_WEIRD_EGG) || (ctx->GetTrickOption(RT_DAMAGE_BOOST_SIMPLE) && logic->HasExplosives() && logic->CanJumpslash());}),
+        Entrance(RR_HC_GARDEN,               []{return logic->CanUse(RG_WEIRD_EGG) || (ctx->GetTrickOption(RT_DAMAGE_BOOST_SIMPLE) && logic->HasExplosives() && logic->CanJumpslash());}),
         Entrance(RR_HC_GREAT_FAIRY_FOUNTAIN, []{return logic->BlastOrSmash();}),
         Entrance(RR_HC_STORMS_GROTTO,        []{return logic->CanOpenStormsGrotto();}),
     });

--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -2434,6 +2434,9 @@ u8 Item_Give(PlayState* play, u8 item) {
                 }
             } else {
                 Flags_SetRandomizerInf(item - ITEM_WEIRD_EGG + RAND_INF_CHILD_TRADES_HAS_WEIRD_EGG);
+                if (item == ITEM_WEIRD_EGG) {
+                    Flags_SetRandomizerInf(RAND_INF_WEIRD_EGG);
+                }
             }
         }
 


### PR DESCRIPTION
There were three problems with weird egg logic. First, `RAND_INF_WEIRD_EGG` was getting set when talking to Malon, even if weird egg was shuffled (availability change). This would falsely show things past Talon as accessible after talking to Malon but without the egg. Second was that `RAND_INF_WEIRD_EGG` wasn't getting set if the egg was collected elsewhere due to shuffling it. These were both solved by removing the eventchkinf trigger for it from `RandomizerOnFlagSetHandler()` and moving it to the trade item give processing in `z_parameter` instead.

The third was that logic was showing "Song from Impa" as accessible before getting the egg when it wasn't shuffled because the entrance access was checking for the RSK not being set, which was redundant because of `ApplyItemEffect()` still being triggered when the egg was vanilla, so `CanUse(RG_WEIRD_EGG)` there covers both cases, so this removes that RSK check.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2922158424.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2922158835.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2922161210.zip)
<!--- section:artifacts:end -->