### PR TITLE
Fix hud position reset

### DIFF
--- a/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
+++ b/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
@@ -2413,8 +2413,7 @@ void CosmeticsEditorWindow::DrawElement() {
     }
     ImGui::SameLine();
     if (UIWidgets::Button("Reset All", UIWidgets::ButtonOptions().Size(ImVec2(250.0f, 0.0f)).Color(THEME_COLOR))) {
-        CVarClearBlock("gCosmetics");
-        ApplyOrResetCustomGfxPatches();
+        CosmeticsEditor_ResetAll();
     }
     if (UIWidgets::Button("Lock All", UIWidgets::ButtonOptions().Size(ImVec2(250.0f, 0.0f)).Color(THEME_COLOR))) {
         for (auto& [id, cosmeticOption] : cosmeticOptions) {


### PR DESCRIPTION
Changes the Reset All callback back to `CosmeticsEditor_ResetAll`, because it's already set up to not reset HUD position stuff. I tried replacing stuff in that function with CVarClearBlock calls, but it reloads the CVars after each one because of how that flow works, and it's extremely unperformant.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2924297736.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2924300163.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2924301161.zip)
<!--- section:artifacts:end -->