### PR TITLE
rando: always spawn gerudo guard behind gate (also fix gaurd typos)

### DIFF
--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -982,7 +982,7 @@ void RandomizerOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_l
             break;
         }
         case VB_BIGGORON_CONSIDER_TRADE_COMPLETE: {
-            // This being true will prevent other biggoron trades, there are already safegaurds in place to prevent
+            // This being true will prevent other biggoron trades, there are already safeguards in place to prevent
             // claim check from being traded multiple times, so we don't really need the quest to ever be considered
             // "complete"
             *should = false;

--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -2027,6 +2027,10 @@ void RandomizerOnActorInitHandler(void* actorRef) {
         if (ge1Type == GE1_TYPE_TRAINING_GROUND_GUARD &&
             Flags_GetRandomizerInf(RAND_INF_GF_GTG_GATE_PERMANENTLY_OPEN)) {
             enGe1->actionFunc = (EnGe1ActionFunc)EnGe1_SetNormalText;
+        } else if (ge1Type == GE1_TYPE_GATE_OPERATOR && enGe1->actor.world.pos.x != -1358.0f) {
+            // When spawning the gate operator, also spawn an extra gate operator on the wasteland side
+            Actor_Spawn(&gPlayState->actorCtx, gPlayState, ACTOR_EN_GE1, -1358.0f, 88.0f, -3018.0f, 0, 0x95B0, 0,
+                        0x0300 | GE1_TYPE_GATE_OPERATOR, true);
         }
     }
 

--- a/soh/src/overlays/actors/ovl_En_Ge1/z_en_ge1.c
+++ b/soh/src/overlays/actors/ovl_En_Ge1/z_en_ge1.c
@@ -97,19 +97,6 @@ void EnGe1_Init(Actor* thisx, PlayState* play) {
     s32 pad;
     EnGe1* this = (EnGe1*)thisx;
 
-    // When spawning the gate operator, also spawn an extra gate operator on the wasteland side
-    if (IS_RANDO && (this->actor.params & 0xFF) == GE1_TYPE_GATE_OPERATOR) {
-        // Spawn the extra guard with params matching the custom type added (0x0300 + 0x02)
-        Actor_Spawn(&play->actorCtx, play, ACTOR_EN_GE1, -1358.0f, 88.0f, -3018.0f, 0, 0x95B0, 0,
-                    0x0300 | GE1_TYPE_EXTRA_GATE_OPERATOR, true);
-    }
-
-    // Convert the "extra" gate operator into a normal one so it matches the same params
-    if ((this->actor.params & 0xFF) == GE1_TYPE_EXTRA_GATE_OPERATOR) {
-        this->actor.params &= ~0xFF;
-        this->actor.params |= GE1_TYPE_GATE_OPERATOR;
-    }
-
     ActorShape_Init(&this->actor.shape, 0.0f, ActorShadow_DrawCircle, 30.0f);
     SkelAnime_InitFlex(play, &this->skelAnime, &gGerudoWhiteSkel, &gGerudoWhiteIdleAnim, this->jointTable,
                        this->morphTable, GE1_LIMB_MAX);

--- a/soh/src/overlays/actors/ovl_En_Ge1/z_en_ge1.c
+++ b/soh/src/overlays/actors/ovl_En_Ge1/z_en_ge1.c
@@ -98,11 +98,8 @@ void EnGe1_Init(Actor* thisx, PlayState* play) {
     EnGe1* this = (EnGe1*)thisx;
 
     // When spawning the gate operator, also spawn an extra gate operator on the wasteland side
-    if (IS_RANDO &&
-        (Randomizer_GetSettingValue(RSK_SHUFFLE_GERUDO_MEMBERSHIP_CARD) ||
-         Randomizer_GetSettingValue(RSK_SHUFFLE_OVERWORLD_ENTRANCES)) &&
-        (this->actor.params & 0xFF) == GE1_TYPE_GATE_OPERATOR) {
-        // Spawn the extra gaurd with params matching the custom type added (0x0300 + 0x02)
+    if (IS_RANDO && (this->actor.params & 0xFF) == GE1_TYPE_GATE_OPERATOR) {
+        // Spawn the extra guard with params matching the custom type added (0x0300 + 0x02)
         Actor_Spawn(&play->actorCtx, play, ACTOR_EN_GE1, -1358.0f, 88.0f, -3018.0f, 0, 0x95B0, 0,
                     0x0300 | GE1_TYPE_EXTRA_GATE_OPERATOR, true);
     }

--- a/soh/src/overlays/actors/ovl_En_Ge1/z_en_ge1.h
+++ b/soh/src/overlays/actors/ovl_En_Ge1/z_en_ge1.h
@@ -12,7 +12,6 @@ typedef void (*EnGe1ActionFunc)(struct EnGe1*, PlayState*);
 typedef enum {
     /* 0x00 */ GE1_TYPE_GATE_GUARD,
     /* 0x01 */ GE1_TYPE_GATE_OPERATOR,
-    /* 0x02 */ GE1_TYPE_EXTRA_GATE_OPERATOR, // Custom guard type for entrance randomizer to open the gate
     /* 0x04 */ GE1_TYPE_NORMAL = 4,
     /* 0x05 */ GE1_TYPE_VALLEY_FLOOR,
     /* 0x45 */ GE1_TYPE_HORSEBACK_ARCHERY = 0x45,


### PR DESCRIPTION
someone had seed where they had card so couldn't be caught to pass gate in reverse wasteland

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2936106767.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2936107296.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2936114061.zip)
<!--- section:artifacts:end -->