### PR TITLE
Fix Entrance Rando weather override behavior

### DIFF
--- a/soh/soh/Enhancements/game-interactor/GameInteractor_HookTable.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor_HookTable.h
@@ -15,6 +15,7 @@ DEFINE_HOOK(OnItemReceive, (GetItemEntry itemEntry));
 DEFINE_HOOK(OnSaleEnd, (GetItemEntry itemEntry));
 DEFINE_HOOK(OnTransitionEnd, (int16_t sceneNum));
 DEFINE_HOOK(OnSceneInit, (int16_t sceneNum));
+DEFINE_HOOK(AfterSceneCommands, (int16_t sceneNum));
 DEFINE_HOOK(OnSceneFlagSet, (int16_t sceneNum, int16_t flagType, int16_t flag));
 DEFINE_HOOK(OnSceneFlagUnset, (int16_t sceneNum, int16_t flagType, int16_t flag));
 DEFINE_HOOK(OnFlagSet, (int16_t flagType, int16_t flag));

--- a/soh/soh/Enhancements/game-interactor/GameInteractor_Hooks.cpp
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor_Hooks.cpp
@@ -45,10 +45,16 @@ void GameInteractor_ExecuteOnTransitionEndHooks(int16_t sceneNum) {
     GameInteractor::Instance->ExecuteHooksForFilter<GameInteractor::OnTransitionEnd>(sceneNum);
 }
 
-void GameInteractor_ExecuteOnSceneInitHooks(int16_t sceneNum) {
+void GameInteractor_ExecuteOnSceneInit(int16_t sceneNum) {
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnSceneInit>(sceneNum);
     GameInteractor::Instance->ExecuteHooksForID<GameInteractor::OnSceneInit>(sceneNum, sceneNum);
     GameInteractor::Instance->ExecuteHooksForFilter<GameInteractor::OnSceneInit>(sceneNum);
+}
+
+void GameInteractor_ExecuteAfterSceneCommands(int16_t sceneNum) {
+    GameInteractor::Instance->ExecuteHooks<GameInteractor::AfterSceneCommands>(sceneNum);
+    GameInteractor::Instance->ExecuteHooksForID<GameInteractor::AfterSceneCommands>(sceneNum, sceneNum);
+    GameInteractor::Instance->ExecuteHooksForFilter<GameInteractor::AfterSceneCommands>(sceneNum);
 }
 
 void GameInteractor_ExecuteOnSceneFlagSet(int16_t sceneNum, int16_t flagType, int16_t flag) {

--- a/soh/soh/Enhancements/game-interactor/GameInteractor_Hooks.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor_Hooks.h
@@ -18,6 +18,7 @@ void GameInteractor_ExecuteOnItemReceiveHooks(GetItemEntry itemEntry);
 void GameInteractor_ExecuteOnSaleEndHooks(GetItemEntry itemEntry);
 void GameInteractor_ExecuteOnTransitionEndHooks(int16_t sceneNum);
 void GameInteractor_ExecuteOnSceneInit(int16_t sceneNum);
+void GameInteractor_ExecuteAfterSceneCommands(int16_t sceneNum);
 void GameInteractor_ExecuteOnSceneFlagSet(int16_t sceneNum, int16_t flagType, int16_t flag);
 void GameInteractor_ExecuteOnSceneFlagUnset(int16_t sceneNum, int16_t flagType, int16_t flag);
 void GameInteractor_ExecuteOnFlagSet(int16_t flagType, int16_t flag);

--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -1761,10 +1761,6 @@ void RandomizerOnSceneInitHandler(int16_t sceneNum) {
 
         // Handle updated link spawn positions
         Entrance_OverrideSpawnScene(sceneNum, gPlayState->curSpawn);
-
-        Entrance_OverrideWeatherState();
-        // Need to reinitialize the environment after replacing the weather mode
-        Play_InitEnvironment(gPlayState, gPlayState->skyboxId);
     }
 
     // LACs & Prelude checks
@@ -1801,6 +1797,13 @@ void RandomizerOnSceneInitHandler(int16_t sceneNum) {
             updateHook = 0;
         }
     });
+}
+
+void RandomizerAfterSceneCommandsHandler(int16_t sceneNum) {
+    // ENTRTODO: Move all entrance rando handling to a dedicated file
+    if (RAND_GET_OPTION(RSK_SHUFFLE_ENTRANCES)) {
+        Entrance_OverrideWeatherState();
+    }
 }
 
 void EnSi_DrawRandomizedItem(EnSi* enSi, PlayState* play) {
@@ -2358,6 +2361,7 @@ void RandomizerRegisterHooks() {
     static uint32_t onDialogMessageHook = 0;
     static uint32_t onVanillaBehaviorHook = 0;
     static uint32_t onSceneInitHook = 0;
+    static uint32_t afterSceneCommandsHook = 0;
     static uint32_t onActorInitHook = 0;
     static uint32_t onActorUpdateHook = 0;
     static uint32_t onPlayerUpdateHook = 0;
@@ -2394,6 +2398,7 @@ void RandomizerRegisterHooks() {
         GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnItemReceive>(onDialogMessageHook);
         GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnVanillaBehavior>(onVanillaBehaviorHook);
         GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnSceneInit>(onSceneInitHook);
+        GameInteractor::Instance->UnregisterGameHook<GameInteractor::AfterSceneCommands>(afterSceneCommandsHook);
         GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnActorInit>(onActorInitHook);
         GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnActorUpdate>(onActorUpdateHook);
         GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnPlayerUpdate>(onPlayerUpdateHook);
@@ -2426,6 +2431,7 @@ void RandomizerRegisterHooks() {
         onDialogMessageHook = 0;
         onVanillaBehaviorHook = 0;
         onSceneInitHook = 0;
+        afterSceneCommandsHook = 0;
         onActorInitHook = 0;
         onActorUpdateHook = 0;
         onPlayerUpdateHook = 0;
@@ -2477,6 +2483,8 @@ void RandomizerRegisterHooks() {
             RandomizerOnVanillaBehaviorHandler);
         onSceneInitHook =
             GameInteractor::Instance->RegisterGameHook<GameInteractor::OnSceneInit>(RandomizerOnSceneInitHandler);
+        afterSceneCommandsHook = GameInteractor::Instance->RegisterGameHook<GameInteractor::AfterSceneCommands>(
+            RandomizerAfterSceneCommandsHandler);
         onActorInitHook =
             GameInteractor::Instance->RegisterGameHook<GameInteractor::OnActorInit>(RandomizerOnActorInitHandler);
         onActorUpdateHook =

--- a/soh/soh/z_play_otr.cpp
+++ b/soh/soh/z_play_otr.cpp
@@ -3,7 +3,7 @@
 #include <libultraship/libultraship.h>
 #include "soh/resource/type/Scene.h"
 #include <utils/StringHelper.h>
-#include "soh/Enhancements/game-interactor/GameInteractor.h"
+#include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 #include "global.h"
 #include "vt.h"
 #include <Vertex.h>
@@ -59,7 +59,7 @@ extern "C" void OTRPlay_SpawnScene(PlayState* play, s32 sceneId, s32 spawn) {
 
     osSyncPrintf("ROOM SIZE=%fK\n", roomSize / 1024.0f);
 
-    GameInteractor::Instance->ExecuteHooks<GameInteractor::OnSceneInit>(play->sceneNum);
+    GameInteractor_ExecuteOnSceneInit(play->sceneNum);
     SPDLOG_INFO("Scene Init - sceneNum: {0:#x}, entranceIndex: {1:#x}", play->sceneNum, gSaveContext.entranceIndex);
 }
 
@@ -79,6 +79,7 @@ void OTRPlay_InitScene(PlayState* play, s32 spawn) {
     YREG(15) = 0;
     gSaveContext.worldMapArea = 0;
     OTRScene_ExecuteCommands(play, (SOH::Scene*)play->sceneSegment);
+    GameInteractor_ExecuteAfterSceneCommands(play->sceneNum);
     Play_InitEnvironment(play, play->skyboxId);
     /* auto data = static_cast<LUS::Vertex*>(Ship::Context::GetInstance()
                                                ->GetResourceManager()


### PR DESCRIPTION
Fixes an issue with how entrance rando hooks where overriding the weather/skybox behavior. The problem was that `Play_InitEnvironment` was being executed twice (the second time with the updated weather/environment content applied), which resulted in `Environment_Init` inserting additional lights. This meant there was always double the lights added, potentially overriding/de-linking previous lights, which lead to strange behavior like characters having the wrong lighting.

This bug was introduced by moving the entrance rando methods out of the game src into hooks with 9.0.0. A new hook has been added for `AfterSceneCommands` which executes right after all the commands are processed, allowing any overrides to happen as soon as possible. In this case, it allows executing `Entrance_OverrideWeatherState` before `Play_InitEnvironment`, which is how 8.0.6 effectively was.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2942578623.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2942590836.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2942594364.zip)
<!--- section:artifacts:end -->