### PR TITLE
Fix rutos letter access

### DIFF
--- a/soh/soh/Enhancements/randomizer/logic.cpp
+++ b/soh/soh/Enhancements/randomizer/logic.cpp
@@ -121,8 +121,6 @@ bool Logic::HasItem(RandomizerGet itemName) {
         case RG_STONE_OF_AGONY:
         case RG_GERUDO_MEMBERSHIP_CARD:
             return CheckQuestItem(RandoGetToQuestItem.at(itemName));
-        case RG_RUTOS_LETTER:
-            return CheckEventChkInf(EVENTCHKINF_OBTAINED_RUTOS_LETTER);
         case RG_DOUBLE_DEFENSE:
             return GetSaveContext()->isDoubleDefenseAcquired;
         case RG_FISHING_POLE:
@@ -171,6 +169,7 @@ bool Logic::HasItem(RandomizerGet itemName) {
         case RG_BACK_TOWER_KEY:
         case RG_HYLIA_LAB_KEY:
         case RG_FISHING_HOLE_KEY:
+        case RG_RUTOS_LETTER:
             return CheckRandoInf(RandoGetToRandInf.at(itemName));
             // Boss Keys
         case RG_EPONA:
@@ -1455,6 +1454,7 @@ std::map<RandomizerGet, uint32_t> Logic::RandoGetToEquipFlag = {
 std::map<RandomizerGet, uint32_t> Logic::RandoGetToRandInf = {
     { RG_ZELDAS_LETTER, RAND_INF_ZELDAS_LETTER },
     { RG_WEIRD_EGG, RAND_INF_WEIRD_EGG },
+    { RG_RUTOS_LETTER, RAND_INF_OBTAINED_RUTOS_LETTER },
     { RG_GOHMA_SOUL, RAND_INF_GOHMA_SOUL },
     { RG_KING_DODONGO_SOUL, RAND_INF_KING_DODONGO_SOUL },
     { RG_BARINADE_SOUL, RAND_INF_BARINADE_SOUL },
@@ -1819,7 +1819,7 @@ void Logic::ApplyItemEffect(Item& item, bool state) {
                     mSaveContext->inventory.items[slot] = itemId;
                 } break;
                 case RG_RUTOS_LETTER:
-                    SetEventChkInf(EVENTCHKINF_OBTAINED_RUTOS_LETTER, state);
+                    SetRandoInf(RAND_INF_OBTAINED_RUTOS_LETTER, state);
                     break;
                 case RG_GOHMA_SOUL:
                 case RG_KING_DODONGO_SOUL:

--- a/soh/soh/Enhancements/randomizer/randomizer_inf.h
+++ b/soh/soh/Enhancements/randomizer/randomizer_inf.h
@@ -1952,6 +1952,7 @@ typedef enum {
     RAND_INF_DEKU_TREE_QUEEN_GOHMA_GRASS_7,
     RAND_INF_DEKU_TREE_QUEEN_GOHMA_GRASS_8,
     // End Grass
+    RAND_INF_OBTAINED_RUTOS_LETTER,
     // If you add anything to this list, you need to update the size of randomizerInf in z64save.h to be
     // ceil(RAND_INF_MAX / 16)
 

--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -2411,6 +2411,9 @@ u8 Item_Give(PlayState* play, u8 item) {
                 }
             }
         } else {
+            if (item == ITEM_LETTER_RUTO) {
+                Flags_SetRandomizerInf(RAND_INF_OBTAINED_RUTOS_LETTER);
+            }
             for (i = 0; i < 4; i++) {
                 if (gSaveContext.inventory.items[temp + i] == ITEM_NONE) {
                     gSaveContext.inventory.items[temp + i] = item;


### PR DESCRIPTION
Logic was still checking the EventChkInf for Ruto's letter to determine whether the player had the letter, despite that being tied to the underwater item check. This implements a RandomizerInf for Ruto's letter to apply to logic to track it separately from the underwater item check.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2949231993.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2949245035.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2949245899.zip)
<!--- section:artifacts:end -->