### PR TITLE
CheckBeatable: move clearing ctx->playthroughBeatable into function

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/fill.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/fill.cpp
@@ -327,13 +327,12 @@ bool IsBeatableWithout(RandomizerCheck excludedCheck, bool replaceItem,
     auto ctx = Rando::Context::GetInstance();
     RandomizerGet copy = ctx->GetItemLocation(excludedCheck)->GetPlacedRandomizerGet(); // Copy out item
     ctx->GetItemLocation(excludedCheck)->SetPlacedItem(RG_NONE);                        // Write in empty item
-    ctx->playthroughBeatable = false;
     logic->Reset();
-    CheckBeatable(ignore);
+    bool result = CheckBeatable(ignore);
     if (replaceItem) {
         ctx->GetItemLocation(excludedCheck)->SetPlacedItem(copy); // Immediately put item back
     }
-    return ctx->playthroughBeatable;
+    return result;
 }
 
 // Reset non-Logic-class logic, and optionally apply the initial inventory
@@ -581,6 +580,7 @@ void GeneratePlaythrough() {
 // return if the seed is currently beatable or not
 bool CheckBeatable(RandomizerGet ignore /* = RG_NONE*/) {
     auto ctx = Rando::Context::GetInstance();
+    ctx->playthroughBeatable = false;
     GetAccessibleLocationsStruct gals(0);
     ResetLogic(ctx, gals, true);
     do {
@@ -929,10 +929,8 @@ static void AssumedFill(const std::vector<RandomizerGet>& items, const std::vect
             // If ALR is off, then we check beatability after placing the item.
             // If the game is beatable, then we can stop placing items with logic.
             if (!ctx->GetOption(RSK_ALL_LOCATIONS_REACHABLE)) {
-                ctx->playthroughBeatable = false;
                 logic->Reset();
-                CheckBeatable();
-                if (ctx->playthroughBeatable) {
+                if (CheckBeatable()) {
                     SPDLOG_DEBUG("Game beatable, now placing items randomly. " + std::to_string(itemsToPlace.size()) +
                                  " major items remaining.\n\n");
                     FastFill(itemsToPlace, GetEmptyLocations(allowedLocations), true);


### PR DESCRIPTION
small cleanup I made while working on NNL, seems clearer

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2952854823.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2952855256.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2952879678.zip)
<!--- section:artifacts:end -->