### PR TITLE
Remove redundent entrance logic check when adding a region to the pool.

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/fill.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/fill.cpp
@@ -219,17 +219,18 @@ void ProcessExits(Region* region, GetAccessibleLocationsStruct& gals, Randomizer
                 }
                 ValidateSphereZero(gals);
             }
+            // If the exit is accessible and hasn't been added yet, add it to the pool
+            // RANDOTODO do we want to add the region after the loop now, considering we
+            // are processing the new region immediately. Maybe a reverse for loop in ProcessRegion?
+            if (!exitRegion->addedToPool) {
+                exitRegion->addedToPool = true;
+                gals.regionPool.push_back(exit.GetConnectedRegionKey());
+            }
+
             // process the region we just expanded to, to reduce looping
             ProcessRegion(exitRegion, gals, ignore, stopOnBeatable, addToPlaythrough);
         }
 
-        // If the exit is accessible and hasn't been added yet, add it to the pool
-        // RANDOTODO do we want to add the region after the loop now, considering we
-        // are processing the new region immediately. Maybe a reverse for loop in ProcessRegion?
-        if (!exitRegion->addedToPool && exit.ConditionsMet()) {
-            exitRegion->addedToPool = true;
-            gals.regionPool.push_back(exit.GetConnectedRegionKey());
-        }
 
         if (addToPlaythrough) {
             // RANDOTODO Should this match the regular spheres?

--- a/soh/soh/Enhancements/randomizer/3drando/fill.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/fill.cpp
@@ -231,7 +231,6 @@ void ProcessExits(Region* region, GetAccessibleLocationsStruct& gals, Randomizer
             ProcessRegion(exitRegion, gals, ignore, stopOnBeatable, addToPlaythrough);
         }
 
-
         if (addToPlaythrough) {
             // RANDOTODO Should this match the regular spheres?
             // Add shuffled entrances to the entrance playthrough


### PR DESCRIPTION
Entrance conditions were getting run twice when first adding a region to the region pool as the ToDAccess check and the Region Pool addition were both running effectively the same check. This merges them for a minor optimization (seems to be around 2% shorter seed generation on beginner seeds on debug)

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2955716214.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2955733944.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2955756744.zip)
<!--- section:artifacts:end -->