### PR TITLE
Format map GI text

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/hint_list.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/hint_list.cpp
@@ -2412,13 +2412,13 @@ void StaticData::HintTable_Init() {
 
     hintTextTable[RHT_ISOLATED_PLACE] = HintText(CustomMessage("an Isolated Place"));
 
-    hintTextTable[RHT_DUNGEON_ORDINARY] = HintText(CustomMessage(" It's ordinary.",
-                                                      /*german*/ "&Sieht aus wie immer.",
-                                                      /*french*/ "&Elle vous semble %rordinaire%w."));
+    hintTextTable[RHT_DUNGEON_ORDINARY] = HintText(CustomMessage("&It's %gordinary%w.",
+                                                      /*german*/ "&Sieht aus %gwie immer%w.",
+                                                      /*french*/ "&Elle vous semble %gordinaire%w."));
 
-    hintTextTable[RHT_DUNGEON_MASTERFUL] = HintText(CustomMessage(" It's masterful!",
-                                                       /*german*/ "&Man kann darauf die Worte&%r\"Master Quest\"%w entziffern...",
-                                                       /*french*/ "&Étrange... les mots %r\"Master&Quest\"%w sont gravés dessus."));
+    hintTextTable[RHT_DUNGEON_MASTERFUL] = HintText(CustomMessage("&It's %rmasterful%w!",
+                                                       /*german*/ "&Man kann darauf die Worte %r\"Master_Quest\"%w entziffern...",
+                                                       /*french*/ "&Étrange... les mots %r\"Master_Quest\"%w sont gravés dessus."));
 
     // clang-format on
 }

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -4515,7 +4515,7 @@ CustomMessage Randomizer::GetMapGetItemMessageWithHint(GetItemEntry itemEntry) {
         messageEntry.Replace("[[typeHint]]", Rando::StaticData::hintTextTable[RHT_DUNGEON_ORDINARY].GetHintMessage());
     }
 
-    //BUG: the icon is not in the message yet so are not accounted for, so overflows are possible
+    // BUG: the icon is not in the message yet so are not accounted for, so overflows are possible
     messageEntry.AutoFormat();
 
     return messageEntry;

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -4515,6 +4515,9 @@ CustomMessage Randomizer::GetMapGetItemMessageWithHint(GetItemEntry itemEntry) {
         messageEntry.Replace("[[typeHint]]", Rando::StaticData::hintTextTable[RHT_DUNGEON_ORDINARY].GetHintMessage());
     }
 
+    //BUG: the icon is not in the message yet so are not accounted for, so overflows are possible
+    messageEntry.AutoFormat();
+
     return messageEntry;
 }
 


### PR DESCRIPTION
Auto-format's the map GI text, fixing issues on french and german maps with hints.

This PR also makes "ordinary "consistently green and "master quest" consistently red, and tweaks the german ordinary text based on feedback.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2965224932.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2965225482.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2965228712.zip)
<!--- section:artifacts:end -->