### PR TITLE
a11y: read out changes in action button

### DIFF
--- a/soh/soh/Enhancements/game-interactor/GameInteractor_HookTable.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor_HookTable.h
@@ -22,6 +22,7 @@ DEFINE_HOOK(OnFlagSet, (int16_t flagType, int16_t flag));
 DEFINE_HOOK(OnFlagUnset, (int16_t flagType, int16_t flag));
 DEFINE_HOOK(OnSceneSpawnActors, ());
 DEFINE_HOOK(OnPlayerUpdate, ());
+DEFINE_HOOK(OnSetDoAction, (uint16_t action));
 DEFINE_HOOK(OnOcarinaSongAction, ());
 DEFINE_HOOK(OnCuccoOrChickenHatch, ());
 DEFINE_HOOK(OnShopSlotChange, (uint8_t cursorIndex, int16_t price));

--- a/soh/soh/Enhancements/game-interactor/GameInteractor_Hooks.cpp
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor_Hooks.cpp
@@ -85,6 +85,10 @@ void GameInteractor_ExecuteOnPlayerUpdate() {
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnPlayerUpdate>();
 }
 
+void GameInteractor_ExecuteOnSetDoAction(uint16_t action) {
+    GameInteractor::Instance->ExecuteHooks<GameInteractor::OnSetDoAction>(action);
+}
+
 void GameInteractor_ExecuteOnOcarinaSongAction() {
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnOcarinaSongAction>();
 }

--- a/soh/soh/Enhancements/game-interactor/GameInteractor_Hooks.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor_Hooks.h
@@ -25,6 +25,7 @@ void GameInteractor_ExecuteOnFlagSet(int16_t flagType, int16_t flag);
 void GameInteractor_ExecuteOnFlagUnset(int16_t flagType, int16_t flag);
 void GameInteractor_ExecuteOnSceneSpawnActors();
 void GameInteractor_ExecuteOnPlayerUpdate();
+void GameInteractor_ExecuteOnSetDoAction(uint16_t action);
 void GameInteractor_ExecuteOnOcarinaSongAction();
 void GameInteractor_ExecuteOnCuccoOrChickenHatch();
 void GameInteractor_ExecuteOnActorInit(void* actor);

--- a/soh/soh/Enhancements/tts/tts.cpp
+++ b/soh/soh/Enhancements/tts/tts.cpp
@@ -1161,23 +1161,14 @@ void RegisterOnSetDoAction() {
                 case DO_ACTION_OPEN:
                     text = language == LANGUAGE_FRA ? "ouvrir" : language == LANGUAGE_GER ? "öffnen" : "open";
                     break;
-                case DO_ACTION_THROW:
-                    text = language == LANGUAGE_FRA ? "jeter" : language == LANGUAGE_GER ? "werfen" : "throw";
-                    break;
                 case DO_ACTION_CLIMB:
                     text = language == LANGUAGE_FRA ? "monter" : language == LANGUAGE_GER ? "hinauf" : "climb";
-                    break;
-                case DO_ACTION_DROP:
-                    text = language == LANGUAGE_FRA ? "poser" : language == LANGUAGE_GER ? "ablegen" : "drop";
                     break;
                 case DO_ACTION_SPEAK:
                     text = language == LANGUAGE_FRA ? "parler" : language == LANGUAGE_GER ? "reden" : "speak";
                     break;
                 case DO_ACTION_GRAB:
                     text = language == LANGUAGE_FRA ? "action" : language == LANGUAGE_GER ? "aktion" : "grab";
-                    break;
-                case DO_ACTION_PUTAWAY:
-                    text = language == LANGUAGE_FRA ? "ranger" : language == LANGUAGE_GER ? "zurück" : "putaway";
                     break;
                 default:
                     return;

--- a/soh/soh/Enhancements/tts/tts.cpp
+++ b/soh/soh/Enhancements/tts/tts.cpp
@@ -1170,6 +1170,12 @@ void RegisterOnSetDoAction() {
                 case DO_ACTION_GRAB:
                     text = language == LANGUAGE_FRA ? "action" : language == LANGUAGE_GER ? "aktion" : "grab";
                     break;
+                case DO_ACTION_DOWN: {
+                    Player* player = GET_PLAYER(gPlayState);
+                    if (player == NULL || !(player->stateFlags1 & PLAYER_STATE1_ON_HORSE))
+                        return;
+                    text = language == LANGUAGE_FRA ? "descendre" : language == LANGUAGE_GER ? "herab" : "down";
+                } break;
                 default:
                     return;
             }

--- a/soh/soh/Enhancements/tts/tts.cpp
+++ b/soh/soh/Enhancements/tts/tts.cpp
@@ -95,10 +95,8 @@ const char* GetLanguageCode() {
     switch (CVarGetInteger(CVAR_SETTING("Languages"), 0)) {
         case LANGUAGE_FRA:
             return "fr-FR";
-            break;
         case LANGUAGE_GER:
             return "de-DE";
-            break;
     }
 
     return "en-US";
@@ -1148,6 +1146,47 @@ void RegisterOnSetGameLanguageHook() {
     GameInteractor::Instance->RegisterGameHook<GameInteractor::OnSetGameLanguage>([]() { InitTTSBank(); });
 }
 
+void RegisterOnSetDoAction() {
+    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnSetDoAction>([](uint16_t action) {
+        if (CVarGetInteger(CVAR_SETTING("A11yTTS"), 0)) {
+            uint8_t language = CVarGetInteger(CVAR_SETTING("Languages"), 0);
+            const char* text;
+            switch (action) {
+                case DO_ACTION_CHECK:
+                    text = language == LANGUAGE_FRA ? "voir" : language == LANGUAGE_GER ? "lesen" : "check";
+                    break;
+                case DO_ACTION_ENTER:
+                    text = language == LANGUAGE_FRA ? "enter" : language == LANGUAGE_GER ? "kriechen" : "ranger";
+                    break;
+                case DO_ACTION_OPEN:
+                    text = language == LANGUAGE_FRA ? "ouvrir" : language == LANGUAGE_GER ? "öffnen" : "open";
+                    break;
+                case DO_ACTION_THROW:
+                    text = language == LANGUAGE_FRA ? "jeter" : language == LANGUAGE_GER ? "werfen" : "throw";
+                    break;
+                case DO_ACTION_CLIMB:
+                    text = language == LANGUAGE_FRA ? "monter" : language == LANGUAGE_GER ? "hinauf" : "climb";
+                    break;
+                case DO_ACTION_DROP:
+                    text = language == LANGUAGE_FRA ? "poser" : language == LANGUAGE_GER ? "ablegen" : "drop";
+                    break;
+                case DO_ACTION_SPEAK:
+                    text = language == LANGUAGE_FRA ? "parler" : language == LANGUAGE_GER ? "reden" : "speak";
+                    break;
+                case DO_ACTION_GRAB:
+                    text = language == LANGUAGE_FRA ? "action" : language == LANGUAGE_GER ? "aktion" : "grab";
+                    break;
+                case DO_ACTION_PUTAWAY:
+                    text = language == LANGUAGE_FRA ? "ranger" : language == LANGUAGE_GER ? "zurück" : "putaway";
+                    break;
+                default:
+                    return;
+            }
+            SpeechSynthesizer::Instance->Speak(text, GetLanguageCode());
+        }
+    });
+}
+
 void RegisterTTSModHooks() {
     RegisterOnSetGameLanguageHook();
     RegisterOnDialogMessageHook();
@@ -1156,6 +1195,7 @@ void RegisterTTSModHooks() {
     RegisterOnInterfaceUpdateHook();
     RegisterOnKaleidoscopeUpdateHook();
     RegisterOnUpdateMainMenuSelection();
+    RegisterOnSetDoAction();
 }
 
 void RegisterTTS() {

--- a/soh/soh/Enhancements/tts/tts.cpp
+++ b/soh/soh/Enhancements/tts/tts.cpp
@@ -1156,7 +1156,7 @@ void RegisterOnSetDoAction() {
                     text = language == LANGUAGE_FRA ? "voir" : language == LANGUAGE_GER ? "lesen" : "check";
                     break;
                 case DO_ACTION_ENTER:
-                    text = language == LANGUAGE_FRA ? "enter" : language == LANGUAGE_GER ? "kriechen" : "ranger";
+                    text = language == LANGUAGE_FRA ? "entrer" : language == LANGUAGE_GER ? "kriechen" : "enter";
                     break;
                 case DO_ACTION_OPEN:
                     text = language == LANGUAGE_FRA ? "ouvrir" : language == LANGUAGE_GER ? "öffnen" : "open";

--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -2791,6 +2791,7 @@ void Interface_SetDoAction(PlayState* play, u16 action) {
     PauseContext* pauseCtx = &play->pauseCtx;
 
     if (interfaceCtx->unk_1F0 != action) {
+        GameInteractor_ExecuteOnSetDoAction(action);
         interfaceCtx->unk_1F0 = action;
         interfaceCtx->unk_1EC = 1;
         interfaceCtx->unk_1F4 = 0.0f;


### PR DESCRIPTION
split out from #5410

this helps as early as entering crawl space in kokiri forest

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2987685012.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2987685487.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2987708554.zip)
<!--- section:artifacts:end -->