### PR TITLE
Fix C-Down Position with Anchor Left

### DIFF
--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -4112,7 +4112,8 @@ void Interface_DrawItemButtons(PlayState* play) {
             if (CVarGetInteger(CVAR_COSMETIC("HUD.CDownButton.UseMargins"), 0) != 0) {
                 X_Margins_CD = Left_HUD_Margin;
             };
-            C_Down_BTN_Pos[0] = (CVarGetInteger(CVAR_COSMETIC("HUD.CDownButton.PosX"), 0) + X_Margins_CD);
+            C_Down_BTN_Pos[0] =
+                OTRGetDimensionFromLeftEdge(CVarGetInteger(CVAR_COSMETIC("HUD.CDownButton.PosX"), 0) + X_Margins_CD);
         } else if (CVarGetInteger(CVAR_COSMETIC("HUD.CDownButton.PosType"), 0) == ANCHOR_RIGHT) {
             if (CVarGetInteger(CVAR_COSMETIC("HUD.CDownButton.UseMargins"), 0) != 0) {
                 X_Margins_CD = Right_HUD_Margin;


### PR DESCRIPTION
This fixes the issue of the c-down button position getting desynced from the item position when using the Anchor Left option.

I couldn't find when this function was removed, but adding it back matches the previous behavior and the pattern for the other c-buttons - correctly adjusting for screen resolution.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2970910087.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2970931783.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2970932669.zip)
<!--- section:artifacts:end -->