### PR TITLE
Better account for punctuation in auto-format

### DIFF
--- a/soh/soh/Enhancements/custom-message/CustomMessageManager.cpp
+++ b/soh/soh/Enhancements/custom-message/CustomMessageManager.cpp
@@ -536,11 +536,16 @@ void CustomMessage::AutoFormatString(std::string& str) const {
                     // or move the lastNewline cursor to the next line if a '^' is encountered.
                 } else if (carrot < lastNewline + lineLength) {
                     lastNewline = carrot + 1;
-                    // some lines need to be split but don't have spaces, look for periods instead
+                    // some lines need to be split but don't have spaces, look for punctuation instead
                 } else if (lastSpace == std::string::npos) {
-                    const size_t lastPeriod = str.rfind('.', lastNewline + lineLength);
-                    str.replace(lastPeriod, 1, ".^" + colorText);
-                    lastNewline = lastPeriod + 2;
+                    const size_t lastPunc = str.find_last_of('.,!', lastNewline + lineLength);
+                    //if none exist, we just have to throw it down somewhere....
+                    if (lastPunc != std::string::npos){
+
+                    } else {
+                        str.insert(lastPunc+1, "^" + colorText);
+                        lastNewline = lastPunc + 2;
+                    } 
                 } else {
                     str.replace(lastSpace, 1, "^" + colorText);
                     lastNewline = lastSpace + 1;

--- a/soh/soh/Enhancements/custom-message/CustomMessageManager.cpp
+++ b/soh/soh/Enhancements/custom-message/CustomMessageManager.cpp
@@ -470,11 +470,11 @@ size_t CustomMessage::FindNEWLINE(std::string& str, size_t lastNewline) const {
 }
 
 bool CustomMessage::AddBreakString(std::string& str, size_t pos, std::string breakString) const {
-    if (str[pos] == (char)" " || str[pos] == (char)"&"){
+    if (str[pos] == (char)" " || str[pos] == (char)"&") {
         str.replace(pos, 1, breakString);
         return false;
     } else {
-        str.insert(pos+1, breakString);
+        str.insert(pos + 1, breakString);
         return true;
     }
 }
@@ -523,23 +523,23 @@ void CustomMessage::AutoFormatString(std::string& str) const {
                     lineCount = 0;
                     // some lines need to be split but don't have spaces, look for periods instead
                 } else {
-                    const size_t lastBreak = str.find_last_of((std::string)".,!- ", lastNewline + lineLength);
-                    //if none exist or we go backwards, we look forward for a something and allow the overflow
-                    if (lastBreak == std::string::npos || lastBreak < lastNewline){
-                        const size_t nextBreak = str.find_first_of((std::string)".,!- &^", lastNewline);
-                        if (str[nextBreak] == (char)"^"){
+                    const size_t lastBreak = str.find_last_of((std::string) ".,!- ", lastNewline + lineLength);
+                    // if none exist or we go backwards, we look forward for a something and allow the overflow
+                    if (lastBreak == std::string::npos || lastBreak < lastNewline) {
+                        const size_t nextBreak = str.find_first_of((std::string) ".,!- &^", lastNewline);
+                        if (str[nextBreak] == (char)"^") {
                             lastNewline = nextBreak + 1;
-                            lineCount = 0; //increments to 1 at the end
-                        } else if (str[nextBreak] == (char)"&"){
+                            lineCount = 0; // increments to 1 at the end
+                        } else if (str[nextBreak] == (char)"&") {
                             lastNewline = nextBreak + 1;
                         } else {
                             bool isAdded = AddBreakString(str, nextBreak, "&");
                             lastNewline = nextBreak + 1 + isAdded;
-                        } 
+                        }
                     } else {
                         bool isAdded = AddBreakString(str, lastBreak, "&");
                         lastNewline = lastBreak + 1 + isAdded;
-                    } 
+                    }
                 }
                 lineCount += 1;
             } else {
@@ -558,20 +558,20 @@ void CustomMessage::AutoFormatString(std::string& str) const {
                     lastNewline = carrot + 1;
                     // some lines need to be split but don't have spaces, look for punctuation instead
                 } else {
-                    const size_t lastBreak = str.find_last_of((std::string)".,!- &", lastNewline + lineLength);
-                    //if none exist or we go backwards, we look forward for a something and allow the overflow
-                    if (lastBreak == std::string::npos || lastBreak < lastNewline){
-                        const size_t nextBreak = str.find_first_of((std::string)".,!- &^", lastNewline);
-                        if (str[nextBreak] == (char)"^"){
+                    const size_t lastBreak = str.find_last_of((std::string) ".,!- &", lastNewline + lineLength);
+                    // if none exist or we go backwards, we look forward for a something and allow the overflow
+                    if (lastBreak == std::string::npos || lastBreak < lastNewline) {
+                        const size_t nextBreak = str.find_first_of((std::string) ".,!- &^", lastNewline);
+                        if (str[nextBreak] == (char)"^") {
                             lastNewline = nextBreak + 1;
                         } else {
                             bool isAdded = AddBreakString(str, nextBreak, "^" + colorText);
                             lastNewline = nextBreak + 1 + isAdded;
-                        } 
+                        }
                     } else {
                         bool isAdded = AddBreakString(str, lastBreak, "^" + colorText);
                         lastNewline = lastBreak + 1 + isAdded;
-                    } 
+                    }
                 }
                 lineCount = 1;
             }

--- a/soh/soh/Enhancements/custom-message/CustomMessageManager.cpp
+++ b/soh/soh/Enhancements/custom-message/CustomMessageManager.cpp
@@ -469,6 +469,16 @@ size_t CustomMessage::FindNEWLINE(std::string& str, size_t lastNewline) const {
     return newLine;
 }
 
+bool CustomMessage::AddBreakString(std::string& str, size_t pos, std::string breakString) const {
+    if (str[pos] == (char)" " || str[pos] == (char)"&"){
+        str.replace(pos, 1, breakString);
+        return false;
+    } else {
+        str.insert(pos+1, breakString);
+        return true;
+    }
+}
+
 void CustomMessage::AutoFormatString(std::string& str) const {
     ReplaceAltarIcons(str);
     ReplaceColors(str);
@@ -481,7 +491,6 @@ void CustomMessage::AutoFormatString(std::string& str) const {
     while (lastNewline + lineLength < str.length() || yesNo != std::string::npos) {
         const size_t carrot = str.find('^', lastNewline);
         const size_t ampersand = str.find('&', lastNewline);
-        const size_t lastSpace = str.rfind(' ', lastNewline + lineLength);
         size_t waitForInput = str.find(WAIT_FOR_INPUT()[0], lastNewline);
         size_t newLine = FindNEWLINE(str, lastNewline);
         if (carrot < waitForInput) {
@@ -513,13 +522,24 @@ void CustomMessage::AutoFormatString(std::string& str) const {
                     lastNewline = waitForInput + 1;
                     lineCount = 0;
                     // some lines need to be split but don't have spaces, look for periods instead
-                } else if (lastSpace == std::string::npos) {
-                    const size_t lastPeriod = str.rfind('.', lastNewline + lineLength);
-                    str.replace(lastPeriod, 1, ".&");
-                    lastNewline = lastPeriod + 2;
                 } else {
-                    str.replace(lastSpace, 1, "&");
-                    lastNewline = lastSpace + 1;
+                    const size_t lastBreak = str.find_last_of((std::string)".,!- ", lastNewline + lineLength);
+                    //if none exist or we go backwards, we look forward for a something and allow the overflow
+                    if (lastBreak == std::string::npos || lastBreak < lastNewline){
+                        const size_t nextBreak = str.find_first_of((std::string)".,!- &^", lastNewline);
+                        if (str[nextBreak] == (char)"^"){
+                            lastNewline = nextBreak + 1;
+                            lineCount = 0; //increments to 1 at the end
+                        } else if (str[nextBreak] == (char)"&"){
+                            lastNewline = nextBreak + 1;
+                        } else {
+                            bool isAdded = AddBreakString(str, nextBreak, "&");
+                            lastNewline = nextBreak + 1 + isAdded;
+                        } 
+                    } else {
+                        bool isAdded = AddBreakString(str, lastBreak, "&");
+                        lastNewline = lastBreak + 1 + isAdded;
+                    } 
                 }
                 lineCount += 1;
             } else {
@@ -537,18 +557,21 @@ void CustomMessage::AutoFormatString(std::string& str) const {
                 } else if (carrot < lastNewline + lineLength) {
                     lastNewline = carrot + 1;
                     // some lines need to be split but don't have spaces, look for punctuation instead
-                } else if (lastSpace == std::string::npos) {
-                    const size_t lastPunc = str.find_last_of('.,!', lastNewline + lineLength);
-                    //if none exist, we just have to throw it down somewhere....
-                    if (lastPunc != std::string::npos){
-
-                    } else {
-                        str.insert(lastPunc+1, "^" + colorText);
-                        lastNewline = lastPunc + 2;
-                    } 
                 } else {
-                    str.replace(lastSpace, 1, "^" + colorText);
-                    lastNewline = lastSpace + 1;
+                    const size_t lastBreak = str.find_last_of((std::string)".,!- &", lastNewline + lineLength);
+                    //if none exist or we go backwards, we look forward for a something and allow the overflow
+                    if (lastBreak == std::string::npos || lastBreak < lastNewline){
+                        const size_t nextBreak = str.find_first_of((std::string)".,!- &^", lastNewline);
+                        if (str[nextBreak] == (char)"^"){
+                            lastNewline = nextBreak + 1;
+                        } else {
+                            bool isAdded = AddBreakString(str, nextBreak, "^" + colorText);
+                            lastNewline = nextBreak + 1 + isAdded;
+                        } 
+                    } else {
+                        bool isAdded = AddBreakString(str, lastBreak, "^" + colorText);
+                        lastNewline = lastBreak + 1 + isAdded;
+                    } 
                 }
                 lineCount = 1;
             }

--- a/soh/soh/Enhancements/custom-message/CustomMessageManager.h
+++ b/soh/soh/Enhancements/custom-message/CustomMessageManager.h
@@ -190,6 +190,8 @@ class CustomMessage {
      */
     size_t FindNEWLINE(std::string& str, size_t lastNewline) const;
 
+    bool AddBreakString(std::string& str, size_t pos, std::string breakString) const;
+
     /**
      * @brief formats the string specifically to fit in OoT's
      * textboxes, and use it's formatting.

--- a/soh/soh/Enhancements/randomizer/3drando/hint_list.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/hint_list.cpp
@@ -2280,8 +2280,12 @@ void StaticData::HintTable_Init() {
     hintTextTable[RHT_HBA_HINT_SIGN] = HintText(CustomMessage("#Horseback Archery# Range Prizes:&1000: #[[1]]#&1500: #[[2]]#^@'s Record: #" + CustomMessage::POINTS(HS_HORSE_ARCHERY) + "#",
                                                               {QM_RED, QM_GREEN, QM_GREEN, QM_GREEN}, {}, TEXTBOX_TYPE_WOODEN));
 
-    hintTextTable[RHT_HBA_HINT_NOT_ON_HORSE] = HintText(CustomMessage("Hey, rookie!&Come back on your #horse# and take on then #Horseback Archery# challenge!^"
+    hintTextTable[RHT_HBA_HINT_NOT_ON_HORSE] = HintText(CustomMessage("Hey, rookie!&Come back on your #horse# and take on the #Horseback Archery# challenge!^"
                                                                       "Impress me with a high score of 1000 to win a #[[1]]# or score 1500 for #[[2]]#!",
+														   /*german*/ "Hey, Neuling!&Komm mit deinem #Pferd# zurück und stell dich der #Pferdebogenschießen#-Herausforderung!^"
+																	  "Beeindruck mich mit 1000 Punkten und gewinne #[[1]]#! Oder hol dir 1500 Punkte für #[[2]]#!",
+												   		   /*french*/ "Hé, l'nouveau!&Reviens avec ton #cheval# et essaie notre #Terrain d'Archerie Montée#^"
+                                                                      "Impressionne-moi avec un score de 1000 pour gagner #[[1]]# ou atteins 1500 pour #[[2]]#!",
                                                                       {QM_RED, QM_RED, QM_GREEN, QM_GREEN}));
 
     hintTextTable[RHT_HBA_HINT_INITIAL] = HintText(CustomMessage("Hey, rookie!&Want to take on the #Horseback Archery# challenge?^"


### PR DESCRIPTION
This PR edits auto-format to see all punctuation as valid targets for breaks even if there is a space on the line. This also adds a fallback to more gracefully handle any excessively long words, and fixes a small type in one of the HBA hints.

A Translation of the HBA hint without epona is supplied to test the new system, as the current version crashed when processing "#Pferdebogenschießen#-Herausforderung!"

A few test runs on this (or ideally #5422 with this added) are recommended before merging to check for any regressions in auto-format.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2971282479.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2971288976.zip)
<!--- section:artifacts:end -->