### PR TITLE
Apply final specifier to classes inheriting from Ship::GuiWindow

### DIFF
--- a/soh/soh/Enhancements/TimeDisplay/TimeDisplay.h
+++ b/soh/soh/Enhancements/TimeDisplay/TimeDisplay.h
@@ -1,6 +1,6 @@
 #include <libultraship/libultraship.h>
 
-class TimeDisplayWindow : public Ship::GuiWindow {
+class TimeDisplayWindow final : public Ship::GuiWindow {
   public:
     using GuiWindow::GuiWindow;
 

--- a/soh/soh/Enhancements/audio/AudioEditor.h
+++ b/soh/soh/Enhancements/audio/AudioEditor.h
@@ -7,7 +7,7 @@
 #include <imgui.h>
 #include "AudioCollection.h"
 
-class AudioEditor : public Ship::GuiWindow {
+class AudioEditor final : public Ship::GuiWindow {
   public:
     using GuiWindow::GuiWindow;
 

--- a/soh/soh/Enhancements/controls/InputViewer.h
+++ b/soh/soh/Enhancements/controls/InputViewer.h
@@ -17,7 +17,7 @@ typedef enum {
     STICK_MODE_ALWAYS_HIDDEN,
 } StickMode;
 
-class InputViewer : public Ship::GuiWindow {
+class InputViewer final : public Ship::GuiWindow {
   public:
     using GuiWindow::GuiWindow;
 
@@ -33,7 +33,7 @@ class InputViewer : public Ship::GuiWindow {
     void RenderButton(std::string btn, std::string btnOutline, int state, ImVec2 size, int outlineMode);
 };
 
-class InputViewerSettingsWindow : public Ship::GuiWindow {
+class InputViewerSettingsWindow final : public Ship::GuiWindow {
   public:
     using GuiWindow::GuiWindow;
 

--- a/soh/soh/Enhancements/controls/SohInputEditorWindow.h
+++ b/soh/soh/Enhancements/controls/SohInputEditorWindow.h
@@ -17,7 +17,7 @@ typedef struct {
     N64ButtonMask defaultBtn;
 } CustomButtonMap;
 
-class SohInputEditorWindow : public Ship::GuiWindow {
+class SohInputEditorWindow final : public Ship::GuiWindow {
   public:
     using GuiWindow::GuiWindow;
     ~SohInputEditorWindow();

--- a/soh/soh/Enhancements/cosmetics/CosmeticsEditor.h
+++ b/soh/soh/Enhancements/cosmetics/CosmeticsEditor.h
@@ -60,7 +60,7 @@ void CosmeticsEditor_ResetAll();
 void CosmeticsEditor_ResetGroup(CosmeticGroup group);
 void ApplyOrResetCustomGfxPatches(bool manualChange = true);
 
-class CosmeticsEditorWindow : public Ship::GuiWindow {
+class CosmeticsEditorWindow final : public Ship::GuiWindow {
   public:
     using GuiWindow::GuiWindow;
 

--- a/soh/soh/Enhancements/debugger/MessageViewer.h
+++ b/soh/soh/Enhancements/debugger/MessageViewer.h
@@ -25,7 +25,7 @@ void MessageDebug_DisplayCustomMessage(const char* customMessage);
 #ifdef __cplusplus
 }
 
-class MessageViewer : public Ship::GuiWindow {
+class MessageViewer final : public Ship::GuiWindow {
   public:
     static inline const char* TABLE_ID = "MessageViewer";
     using GuiWindow::GuiWindow;

--- a/soh/soh/Enhancements/debugger/SohStatsWindow.h
+++ b/soh/soh/Enhancements/debugger/SohStatsWindow.h
@@ -3,7 +3,7 @@
 
 #include <libultraship/libultraship.h>
 
-class SohStatsWindow : public Ship::GuiWindow {
+class SohStatsWindow final : public Ship::GuiWindow {
   public:
     using GuiWindow::GuiWindow;
     ~SohStatsWindow(){};

--- a/soh/soh/Enhancements/debugger/actorViewer.h
+++ b/soh/soh/Enhancements/debugger/actorViewer.h
@@ -2,7 +2,7 @@
 
 #include <libultraship/libultraship.h>
 
-class ActorViewerWindow : public Ship::GuiWindow {
+class ActorViewerWindow final : public Ship::GuiWindow {
   public:
     using GuiWindow::GuiWindow;
 

--- a/soh/soh/Enhancements/debugger/colViewer.cpp
+++ b/soh/soh/Enhancements/debugger/colViewer.cpp
@@ -20,7 +20,7 @@ extern "C" {
 extern PlayState* gPlayState;
 }
 
-typedef enum ColRenderSetting { ColRenderDisabled, ColRenderSolid, ColRenderTransparent } ColRenderSetting;
+enum ColRenderSetting { ColRenderDisabled, ColRenderSolid, ColRenderTransparent };
 
 static std::unordered_map<int32_t, const char*> ColRenderSettingNames = {
     { ColRenderDisabled, "Disabled" },

--- a/soh/soh/Enhancements/debugger/colViewer.h
+++ b/soh/soh/Enhancements/debugger/colViewer.h
@@ -5,7 +5,7 @@
 typedef enum { COLVIEW_DISABLED, COLVIEW_SOLID, COLVIEW_TRANSPARENT } ColViewerRenderSetting;
 
 #ifdef __cplusplus
-class ColViewerWindow : public Ship::GuiWindow {
+class ColViewerWindow final : public Ship::GuiWindow {
   public:
     using GuiWindow::GuiWindow;
 

--- a/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
+++ b/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
@@ -106,7 +106,7 @@ char z2ASCII(int code) {
     return char(ret);
 }
 
-typedef enum MagicLevel { MAGIC_LEVEL_NONE, MAGIC_LEVEL_SINGLE, MAGIC_LEVEL_DOUBLE };
+enum MagicLevel { MAGIC_LEVEL_NONE, MAGIC_LEVEL_SINGLE, MAGIC_LEVEL_DOUBLE };
 
 std::unordered_map<int8_t, const char*> magicLevelMap = {
     { MAGIC_LEVEL_NONE, "None" },
@@ -114,7 +114,7 @@ std::unordered_map<int8_t, const char*> magicLevelMap = {
     { MAGIC_LEVEL_DOUBLE, "Double" },
 };
 
-typedef enum AudioOutput {
+enum AudioOutput {
     AUDIO_STEREO,
     AUDIO_MONO,
     AUDIO_HEADSET,
@@ -128,7 +128,7 @@ std::unordered_map<uint8_t, const char*> audioMap = {
     { AUDIO_SURROUND, "Surround" },
 };
 
-typedef enum ZTarget {
+enum ZTarget {
     Z_TARGET_SWITCH,
     Z_TARGET_HOLD,
 };

--- a/soh/soh/Enhancements/debugger/debugSaveEditor.h
+++ b/soh/soh/Enhancements/debugger/debugSaveEditor.h
@@ -1770,7 +1770,7 @@ const std::vector<std::string> state3 = {
     "Travelling to Hook Target",
 };
 
-class SaveEditorWindow : public Ship::GuiWindow {
+class SaveEditorWindow final : public Ship::GuiWindow {
   public:
     using GuiWindow::GuiWindow;
 

--- a/soh/soh/Enhancements/debugger/dlViewer.h
+++ b/soh/soh/Enhancements/debugger/dlViewer.h
@@ -2,7 +2,7 @@
 
 #include <libultraship/libultraship.h>
 
-class DLViewerWindow : public Ship::GuiWindow {
+class DLViewerWindow final : public Ship::GuiWindow {
   public:
     using GuiWindow::GuiWindow;
 

--- a/soh/soh/Enhancements/debugger/hookDebugger.h
+++ b/soh/soh/Enhancements/debugger/hookDebugger.h
@@ -1,6 +1,6 @@
 #include <libultraship/libultraship.h>
 
-class HookDebuggerWindow : public Ship::GuiWindow {
+class HookDebuggerWindow final : public Ship::GuiWindow {
   public:
     using GuiWindow::GuiWindow;
 

--- a/soh/soh/Enhancements/debugger/valueViewer.h
+++ b/soh/soh/Enhancements/debugger/valueViewer.h
@@ -33,7 +33,7 @@ typedef struct {
     uint32_t y;
 } ValueTableElement;
 
-class ValueViewerWindow : public Ship::GuiWindow {
+class ValueViewerWindow final : public Ship::GuiWindow {
   public:
     using GuiWindow::GuiWindow;
 

--- a/soh/soh/Enhancements/gameplaystatswindow.h
+++ b/soh/soh/Enhancements/gameplaystatswindow.h
@@ -1,6 +1,6 @@
 #include <libultraship/libultraship.h>
 
-class GameplayStatsWindow : public Ship::GuiWindow {
+class GameplayStatsWindow final : public Ship::GuiWindow {
   public:
     using GuiWindow::GuiWindow;
 

--- a/soh/soh/Enhancements/randomizer/Plandomizer.h
+++ b/soh/soh/Enhancements/randomizer/Plandomizer.h
@@ -16,7 +16,7 @@ extern "C" {
 #include "soh/Enhancements/randomizer/item.h"
 
 #ifdef __cplusplus
-class PlandomizerWindow : public Ship::GuiWindow {
+class PlandomizerWindow final : public Ship::GuiWindow {
   public:
     using GuiWindow::GuiWindow;
 

--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.h
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.h
@@ -8,7 +8,7 @@
 
 namespace CheckTracker {
 
-class CheckTrackerSettingsWindow : public Ship::GuiWindow {
+class CheckTrackerSettingsWindow final : public Ship::GuiWindow {
   public:
     using GuiWindow::GuiWindow;
     ~CheckTrackerSettingsWindow(){};
@@ -19,7 +19,7 @@ class CheckTrackerSettingsWindow : public Ship::GuiWindow {
     void UpdateElement() override{};
 };
 
-class CheckTrackerWindow : public Ship::GuiWindow {
+class CheckTrackerWindow final : public Ship::GuiWindow {
   public:
     using GuiWindow::GuiWindow;
     void Draw() override;

--- a/soh/soh/Enhancements/randomizer/randomizer_entrance_tracker.h
+++ b/soh/soh/Enhancements/randomizer/randomizer_entrance_tracker.h
@@ -91,7 +91,7 @@ s16 GetLastEntranceOverride();
 s16 GetCurrentGrottoId();
 const EntranceData* GetEntranceData(s16);
 
-class EntranceTrackerSettingsWindow : public Ship::GuiWindow {
+class EntranceTrackerSettingsWindow final : public Ship::GuiWindow {
   public:
     using GuiWindow::GuiWindow;
 
@@ -101,7 +101,7 @@ class EntranceTrackerSettingsWindow : public Ship::GuiWindow {
     void UpdateElement() override{};
 };
 
-class EntranceTrackerWindow : public Ship::GuiWindow {
+class EntranceTrackerWindow final : public Ship::GuiWindow {
   public:
     using GuiWindow::GuiWindow;
     void Draw() override;

--- a/soh/soh/Enhancements/randomizer/randomizer_item_tracker.h
+++ b/soh/soh/Enhancements/randomizer/randomizer_item_tracker.h
@@ -30,7 +30,7 @@ typedef struct ItemTrackerDungeon {
     std::vector<uint32_t> items;
 } ItemTrackerDungeon;
 
-class ItemTrackerSettingsWindow : public Ship::GuiWindow {
+class ItemTrackerSettingsWindow final : public Ship::GuiWindow {
   public:
     using GuiWindow::GuiWindow;
 
@@ -40,7 +40,7 @@ class ItemTrackerSettingsWindow : public Ship::GuiWindow {
     void UpdateElement() override{};
 };
 
-class ItemTrackerWindow : public Ship::GuiWindow {
+class ItemTrackerWindow final : public Ship::GuiWindow {
   public:
     using GuiWindow::GuiWindow;
     void Draw() override;

--- a/soh/soh/Enhancements/randomizer/randomizer_settings_window.h
+++ b/soh/soh/Enhancements/randomizer/randomizer_settings_window.h
@@ -6,7 +6,7 @@ namespace Rando {
 class Settings;
 }
 
-class RandomizerSettingsWindow : public Ship::GuiWindow {
+class RandomizerSettingsWindow final : public Ship::GuiWindow {
   public:
     using GuiWindow::GuiWindow;
 

--- a/soh/soh/Enhancements/timesplits/TimeSplits.h
+++ b/soh/soh/Enhancements/timesplits/TimeSplits.h
@@ -17,7 +17,7 @@ extern "C" {
 #include <libultraship/libultraship.h>
 
 #ifdef __cplusplus
-class TimeSplitWindow : public Ship::GuiWindow {
+class TimeSplitWindow final : public Ship::GuiWindow {
   public:
     using GuiWindow::GuiWindow;
 
@@ -39,7 +39,7 @@ typedef enum SplitStatus {
     SPLIT_STATUS_ACTIVE,
     SPLIT_STATUS_INACTIVE,
     SPLIT_STATUS_COLLECTED,
-    SPLIT_STATUS_SKIPPED
+    SPLIT_STATUS_SKIPPED,
 } SplitStatus;
 
 typedef enum SplitType {

--- a/soh/soh/Notification/Notification.h
+++ b/soh/soh/Notification/Notification.h
@@ -19,7 +19,7 @@ struct Options {
     float remainingTime = 0.0f; // Seconds
 };
 
-class Window : public Ship::GuiWindow {
+class Window final : public Ship::GuiWindow {
   public:
     using GuiWindow::GuiWindow;
 

--- a/soh/soh/SohGui/SohModals.h
+++ b/soh/soh/SohGui/SohModals.h
@@ -4,7 +4,7 @@
 #include "window/gui/GuiMenuBar.h"
 #include "window/gui/GuiElement.h"
 
-class SohModalWindow : public Ship::GuiWindow {
+class SohModalWindow final : public Ship::GuiWindow {
   public:
     using GuiWindow::GuiWindow;
     void Draw() override;


### PR DESCRIPTION
Was getting infamous c++ style warnings:

*(also address `typedef requires a name` warnings)*

```
In file included from /home/erpre/s/ShipWright/soh/soh/SohGui/SohGui.cpp:8:
In file included from /home/erpre/s/ShipWright/soh/soh/SohGui/SohGui.hpp:12:
In file included from /home/erpre/s/ShipWright/soh/soh/SohGui/SohMenuBar.h:3:
In file included from /home/erpre/s/ShipWright/soh/../libultraship/include/libultraship/libultraship.h:5:
In file included from /home/erpre/s/ShipWright/soh/../libultraship/include/libultraship/bridge.h:4:
In file included from /home/erpre/s/ShipWright/soh/../libultraship/src/public/bridge/resourcebridge.h:9:
In file included from /home/erpre/s/ShipWright/soh/../libultraship/src/resource/type/Texture.h:3:
In file included from /home/erpre/s/ShipWright/soh/../libultraship/src/resource/Resource.h:3:
In file included from /home/erpre/s/ShipWright/soh/../libultraship/src/resource/File.h:3:
In file included from /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/string:42:
In file included from /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/char_traits.h:57:
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/stl_construct.h:88:2: warning: destructor called on non-final 'SohGui::SohMenu' that has virtual functions but non-virtual destructor [-Wdelete-non-abstract-non-virtual-dtor]
   88 |         __location->~_Tp();
      |         ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/stl_construct.h:149:12: note: in instantiation of function template specialization 'std::destroy_at<SohGui::SohMenu>' requested here
  149 |       std::destroy_at(__pointer);
      |            ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/alloc_traits.h:720:9: note: in instantiation of function template specialization 'std::_Destroy<SohGui::SohMenu>' requested here
  720 |         { std::_Destroy(__p); }
      |                ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr_base.h:616:28: note: in instantiation of function template specialization 'std::allocator_traits<std::allocator<void>>::destroy<SohGui::SohMenu>' requested here
  616 |         allocator_traits<_Alloc>::destroy(_M_impl._M_alloc(), _M_ptr());
      |                                   ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr_base.h:602:2: note: in instantiation of member function 'std::_Sp_counted_ptr_inplace<SohGui::SohMenu, std::allocator<void>, __gnu_cxx::_S_atomic>::_M_dispose' requested here
  602 |         _Sp_counted_ptr_inplace(_Alloc __a, _Args&&... __args)
      |         ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr_base.h:970:6: note: in instantiation of function template specialization 'std::_Sp_counted_ptr_inplace<SohGui::SohMenu, std::allocator<void>, __gnu_cxx::_S_atomic>::_Sp_counted_ptr_inplace<const char (&)[18], const char (&)[10]>' requested here
  970 |             _Sp_cp_type(__a._M_a, std::forward<_Args>(__args)...);
      |             ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr_base.h:1713:14: note: in instantiation of function template specialization 'std::__shared_count<>::__shared_count<SohGui::SohMenu, std::allocator<void>, const char (&)[18], const char (&)[10]>' requested here
 1713 |         : _M_ptr(), _M_refcount(_M_ptr, __tag, std::forward<_Args>(__args)...)
      |                     ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr.h:463:4: note: in instantiation of function template specialization 'std::__shared_ptr<SohGui::SohMenu>::__shared_ptr<std::allocator<void>, const char (&)[18], const char (&)[10]>' requested here
  463 |         : __shared_ptr<_Tp>(__tag, std::forward<_Args>(__args)...)
      |           ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr.h:1007:14: note: in instantiation of function template specialization 'std::shared_ptr<SohGui::SohMenu>::shared_ptr<std::allocator<void>, const char (&)[18], const char (&)[10]>' requested here
 1007 |       return shared_ptr<_Tp>(_Sp_alloc_shared_tag<_Alloc>{__a},
      |              ^
/home/erpre/s/ShipWright/soh/soh/SohGui/SohGui.cpp:121:21: note: in instantiation of function template specialization 'std::make_shared<SohGui::SohMenu, const char (&)[18], const char (&)[10]>' requested here
  121 |     mSohMenu = std::make_shared<SohMenu>(CVAR_WINDOW("Menu"), "Port Menu");
      |                     ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/stl_construct.h:88:15: note: qualify call to silence this warning
   88 |         __location->~_Tp();
      |                      ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/stl_construct.h:88:2: warning: destructor called on non-final 'SohConsoleWindow' that has virtual functions but non-virtual destructor [-Wdelete-non-abstract-non-virtual-dtor]
   88 |         __location->~_Tp();
      |         ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/stl_construct.h:149:12: note: in instantiation of function template specialization 'std::destroy_at<SohConsoleWindow>' requested here
  149 |       std::destroy_at(__pointer);
      |            ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/alloc_traits.h:720:9: note: in instantiation of function template specialization 'std::_Destroy<SohConsoleWindow>' requested here
  720 |         { std::_Destroy(__p); }
      |                ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr_base.h:616:28: note: in instantiation of function template specialization 'std::allocator_traits<std::allocator<void>>::destroy<SohConsoleWindow>' requested here
  616 |         allocator_traits<_Alloc>::destroy(_M_impl._M_alloc(), _M_ptr());
      |                                   ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr_base.h:602:2: note: in instantiation of member function 'std::_Sp_counted_ptr_inplace<SohConsoleWindow, std::allocator<void>, __gnu_cxx::_S_atomic>::_M_dispose' requested here
  602 |         _Sp_counted_ptr_inplace(_Alloc __a, _Args&&... __args)
      |         ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr_base.h:970:6: note: in instantiation of function template specialization 'std::_Sp_counted_ptr_inplace<SohConsoleWindow, std::allocator<void>, __gnu_cxx::_S_atomic>::_Sp_counted_ptr_inplace<const char (&)[24], const char (&)[13], ImVec2>' requested here
  970 |             _Sp_cp_type(__a._M_a, std::forward<_Args>(__args)...);
      |             ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr_base.h:1713:14: note: in instantiation of function template specialization 'std::__shared_count<>::__shared_count<SohConsoleWindow, std::allocator<void>, const char (&)[24], const char (&)[13], ImVec2>' requested here
 1713 |         : _M_ptr(), _M_refcount(_M_ptr, __tag, std::forward<_Args>(__args)...)
      |                     ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr.h:463:4: note: in instantiation of function template specialization 'std::__shared_ptr<SohConsoleWindow>::__shared_ptr<std::allocator<void>, const char (&)[24], const char (&)[13], ImVec2>' requested here
  463 |         : __shared_ptr<_Tp>(__tag, std::forward<_Args>(__args)...)
      |           ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr.h:1007:14: note: in instantiation of function template specialization 'std::shared_ptr<SohConsoleWindow>::shared_ptr<std::allocator<void>, const char (&)[24], const char (&)[13], ImVec2>' requested here
 1007 |       return shared_ptr<_Tp>(_Sp_alloc_shared_tag<_Alloc>{__a},
      |              ^
/home/erpre/s/ShipWright/soh/soh/SohGui/SohGui.cpp:124:27: note: in instantiation of function template specialization 'std::make_shared<SohConsoleWindow, const char (&)[24], const char (&)[13], ImVec2>' requested here
  124 |     mConsoleWindow = std::make_shared<SohConsoleWindow>(CVAR_WINDOW("SohConsole"), "Console##SoH", ImVec2(820, 630));
      |                           ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/stl_construct.h:88:15: note: qualify call to silence this warning
   88 |         __location->~_Tp();
      |                      ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/stl_construct.h:88:2: warning: destructor called on non-final 'SohGfxDebuggerWindow' that has virtual functions but non-virtual destructor [-Wdelete-non-abstract-non-virtual-dtor]
   88 |         __location->~_Tp();
      |         ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/stl_construct.h:149:12: note: in instantiation of function template specialization 'std::destroy_at<SohGfxDebuggerWindow>' requested here
  149 |       std::destroy_at(__pointer);
      |            ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/alloc_traits.h:720:9: note: in instantiation of function template specialization 'std::_Destroy<SohGfxDebuggerWindow>' requested here
  720 |         { std::_Destroy(__p); }
      |                ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr_base.h:616:28: note: in instantiation of function template specialization 'std::allocator_traits<std::allocator<void>>::destroy<SohGfxDebuggerWindow>' requested here
  616 |         allocator_traits<_Alloc>::destroy(_M_impl._M_alloc(), _M_ptr());
      |                                   ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr_base.h:602:2: note: in instantiation of member function 'std::_Sp_counted_ptr_inplace<SohGfxDebuggerWindow, std::allocator<void>, __gnu_cxx::_S_atomic>::_M_dispose' requested here
  602 |         _Sp_counted_ptr_inplace(_Alloc __a, _Args&&... __args)
      |         ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr_base.h:970:6: note: in instantiation of function template specialization 'std::_Sp_counted_ptr_inplace<SohGfxDebuggerWindow, std::allocator<void>, __gnu_cxx::_S_atomic>::_Sp_counted_ptr_inplace<const char (&)[28], const char (&)[17], ImVec2>' requested here
  970 |             _Sp_cp_type(__a._M_a, std::forward<_Args>(__args)...);
      |             ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr_base.h:1713:14: note: in instantiation of function template specialization 'std::__shared_count<>::__shared_count<SohGfxDebuggerWindow, std::allocator<void>, const char (&)[28], const char (&)[17], ImVec2>' requested here
 1713 |         : _M_ptr(), _M_refcount(_M_ptr, __tag, std::forward<_Args>(__args)...)
      |                     ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr.h:463:4: note: in instantiation of function template specialization 'std::__shared_ptr<SohGfxDebuggerWindow>::__shared_ptr<std::allocator<void>, const char (&)[28], const char (&)[17], ImVec2>' requested here
  463 |         : __shared_ptr<_Tp>(__tag, std::forward<_Args>(__args)...)
      |           ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr.h:1007:14: note: in instantiation of function template specialization 'std::shared_ptr<SohGfxDebuggerWindow>::shared_ptr<std::allocator<void>, const char (&)[28], const char (&)[17], ImVec2>' requested here
 1007 |       return shared_ptr<_Tp>(_Sp_alloc_shared_tag<_Alloc>{__a},
      |              ^
/home/erpre/s/ShipWright/soh/soh/SohGui/SohGui.cpp:128:14: note: in instantiation of function template specialization 'std::make_shared<SohGfxDebuggerWindow, const char (&)[28], const char (&)[17], ImVec2>' requested here
  128 |         std::make_shared<SohGfxDebuggerWindow>(CVAR_WINDOW("SohGfxDebugger"), "GfxDebugger##SoH", ImVec2(820, 630));
      |              ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/stl_construct.h:88:15: note: qualify call to silence this warning
   88 |         __location->~_Tp();
      |                      ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/stl_construct.h:88:2: warning: destructor called on non-final 'SohStatsWindow' that has virtual functions but non-virtual destructor [-Wdelete-non-abstract-non-virtual-dtor]
   88 |         __location->~_Tp();
      |         ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/stl_construct.h:149:12: note: in instantiation of function template specialization 'std::destroy_at<SohStatsWindow>' requested here
  149 |       std::destroy_at(__pointer);
      |            ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/alloc_traits.h:720:9: note: in instantiation of function template specialization 'std::_Destroy<SohStatsWindow>' requested here
  720 |         { std::_Destroy(__p); }
      |                ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr_base.h:616:28: note: in instantiation of function template specialization 'std::allocator_traits<std::allocator<void>>::destroy<SohStatsWindow>' requested here
  616 |         allocator_traits<_Alloc>::destroy(_M_impl._M_alloc(), _M_ptr());
      |                                   ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr_base.h:602:2: note: in instantiation of member function 'std::_Sp_counted_ptr_inplace<SohStatsWindow, std::allocator<void>, __gnu_cxx::_S_atomic>::_M_dispose' requested here
  602 |         _Sp_counted_ptr_inplace(_Alloc __a, _Args&&... __args)
      |         ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr_base.h:970:6: note: in instantiation of function template specialization 'std::_Sp_counted_ptr_inplace<SohStatsWindow, std::allocator<void>, __gnu_cxx::_S_atomic>::_Sp_counted_ptr_inplace<const char (&)[22], const char (&)[11], ImVec2>' requested here
  970 |             _Sp_cp_type(__a._M_a, std::forward<_Args>(__args)...);
      |             ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr_base.h:1713:14: note: in instantiation of function template specialization 'std::__shared_count<>::__shared_count<SohStatsWindow, std::allocator<void>, const char (&)[22], const char (&)[11], ImVec2>' requested here
 1713 |         : _M_ptr(), _M_refcount(_M_ptr, __tag, std::forward<_Args>(__args)...)
      |                     ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr.h:463:4: note: in instantiation of function template specialization 'std::__shared_ptr<SohStatsWindow>::__shared_ptr<std::allocator<void>, const char (&)[22], const char (&)[11], ImVec2>' requested here
  463 |         : __shared_ptr<_Tp>(__tag, std::forward<_Args>(__args)...)
      |           ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr.h:1007:14: note: in instantiation of function template specialization 'std::shared_ptr<SohStatsWindow>::shared_ptr<std::allocator<void>, const char (&)[22], const char (&)[11], ImVec2>' requested here
 1007 |       return shared_ptr<_Tp>(_Sp_alloc_shared_tag<_Alloc>{__a},
      |              ^
/home/erpre/s/ShipWright/soh/soh/SohGui/SohGui.cpp:131:25: note: in instantiation of function template specialization 'std::make_shared<SohStatsWindow, const char (&)[22], const char (&)[11], ImVec2>' requested here
  131 |     mStatsWindow = std::make_shared<SohStatsWindow>(CVAR_WINDOW("SohStats"), "Stats##Soh", ImVec2(400, 100));
      |                         ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/stl_construct.h:88:15: note: qualify call to silence this warning
   88 |         __location->~_Tp();
      |                      ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/stl_construct.h:88:2: warning: destructor called on non-final 'AudioEditor' that has virtual functions but non-virtual destructor [-Wdelete-non-abstract-non-virtual-dtor]
   88 |         __location->~_Tp();
      |         ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/stl_construct.h:149:12: note: in instantiation of function template specialization 'std::destroy_at<AudioEditor>' requested here
  149 |       std::destroy_at(__pointer);
      |            ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/alloc_traits.h:720:9: note: in instantiation of function template specialization 'std::_Destroy<AudioEditor>' requested here
  720 |         { std::_Destroy(__p); }
      |                ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr_base.h:616:28: note: in instantiation of function template specialization 'std::allocator_traits<std::allocator<void>>::destroy<AudioEditor>' requested here
  616 |         allocator_traits<_Alloc>::destroy(_M_impl._M_alloc(), _M_ptr());
      |                                   ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr_base.h:602:2: note: in instantiation of member function 'std::_Sp_counted_ptr_inplace<AudioEditor, std::allocator<void>, __gnu_cxx::_S_atomic>::_M_dispose' requested here
  602 |         _Sp_counted_ptr_inplace(_Alloc __a, _Args&&... __args)
      |         ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr_base.h:970:6: note: in instantiation of function template specialization 'std::_Sp_counted_ptr_inplace<AudioEditor, std::allocator<void>, __gnu_cxx::_S_atomic>::_Sp_counted_ptr_inplace<const char (&)[25], const char (&)[13], ImVec2>' requested here
  970 |             _Sp_cp_type(__a._M_a, std::forward<_Args>(__args)...);
      |             ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr_base.h:1713:14: note: in instantiation of function template specialization 'std::__shared_count<>::__shared_count<AudioEditor, std::allocator<void>, const char (&)[25], const char (&)[13], ImVec2>' requested here
 1713 |         : _M_ptr(), _M_refcount(_M_ptr, __tag, std::forward<_Args>(__args)...)
      |                     ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr.h:463:4: note: in instantiation of function template specialization 'std::__shared_ptr<AudioEditor>::__shared_ptr<std::allocator<void>, const char (&)[25], const char (&)[13], ImVec2>' requested here
  463 |         : __shared_ptr<_Tp>(__tag, std::forward<_Args>(__args)...)
      |           ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr.h:1007:14: note: in instantiation of function template specialization 'std::shared_ptr<AudioEditor>::shared_ptr<std::allocator<void>, const char (&)[25], const char (&)[13], ImVec2>' requested here
 1007 |       return shared_ptr<_Tp>(_Sp_alloc_shared_tag<_Alloc>{__a},
      |              ^
/home/erpre/s/ShipWright/soh/soh/SohGui/SohGui.cpp:139:31: note: in instantiation of function template specialization 'std::make_shared<AudioEditor, const char (&)[25], const char (&)[13], ImVec2>' requested here
  139 |     mAudioEditorWindow = std::make_shared<AudioEditor>(CVAR_WINDOW("AudioEditor"), "Audio Editor", ImVec2(820, 630));
      |                               ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/stl_construct.h:88:15: note: qualify call to silence this warning
   88 |         __location->~_Tp();
      |                      ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/stl_construct.h:88:2: warning: destructor called on non-final 'InputViewer' that has virtual functions but non-virtual destructor [-Wdelete-non-abstract-non-virtual-dtor]
   88 |         __location->~_Tp();
      |         ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/stl_construct.h:149:12: note: in instantiation of function template specialization 'std::destroy_at<InputViewer>' requested here
  149 |       std::destroy_at(__pointer);
      |            ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/alloc_traits.h:720:9: note: in instantiation of function template specialization 'std::_Destroy<InputViewer>' requested here
  720 |         { std::_Destroy(__p); }
      |                ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr_base.h:616:28: note: in instantiation of function template specialization 'std::allocator_traits<std::allocator<void>>::destroy<InputViewer>' requested here
  616 |         allocator_traits<_Alloc>::destroy(_M_impl._M_alloc(), _M_ptr());
      |                                   ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr_base.h:602:2: note: in instantiation of member function 'std::_Sp_counted_ptr_inplace<InputViewer, std::allocator<void>, __gnu_cxx::_S_atomic>::_M_dispose' requested here
  602 |         _Sp_counted_ptr_inplace(_Alloc __a, _Args&&... __args)
      |         ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr_base.h:970:6: note: in instantiation of function template specialization 'std::_Sp_counted_ptr_inplace<InputViewer, std::allocator<void>, __gnu_cxx::_S_atomic>::_Sp_counted_ptr_inplace<const char (&)[25], const char (&)[13]>' requested here
  970 |             _Sp_cp_type(__a._M_a, std::forward<_Args>(__args)...);
      |             ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr_base.h:1713:14: note: in instantiation of function template specialization 'std::__shared_count<>::__shared_count<InputViewer, std::allocator<void>, const char (&)[25], const char (&)[13]>' requested here
 1713 |         : _M_ptr(), _M_refcount(_M_ptr, __tag, std::forward<_Args>(__args)...)
      |                     ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr.h:463:4: note: in instantiation of function template specialization 'std::__shared_ptr<InputViewer>::__shared_ptr<std::allocator<void>, const char (&)[25], const char (&)[13]>' requested here
  463 |         : __shared_ptr<_Tp>(__tag, std::forward<_Args>(__args)...)
      |           ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr.h:1007:14: note: in instantiation of function template specialization 'std::shared_ptr<InputViewer>::shared_ptr<std::allocator<void>, const char (&)[25], const char (&)[13]>' requested here
 1007 |       return shared_ptr<_Tp>(_Sp_alloc_shared_tag<_Alloc>{__a},
      |              ^
/home/erpre/s/ShipWright/soh/soh/SohGui/SohGui.cpp:141:25: note: in instantiation of function template specialization 'std::make_shared<InputViewer, const char (&)[25], const char (&)[13]>' requested here
  141 |     mInputViewer = std::make_shared<InputViewer>(CVAR_WINDOW("InputViewer"), "Input Viewer");
      |                         ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/stl_construct.h:88:15: note: qualify call to silence this warning
   88 |         __location->~_Tp();
      |                      ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/stl_construct.h:88:2: warning: destructor called on non-final 'InputViewerSettingsWindow' that has virtual functions but non-virtual destructor [-Wdelete-non-abstract-non-virtual-dtor]
   88 |         __location->~_Tp();
      |         ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/stl_construct.h:149:12: note: in instantiation of function template specialization 'std::destroy_at<InputViewerSettingsWindow>' requested here
  149 |       std::destroy_at(__pointer);
      |            ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/alloc_traits.h:720:9: note: in instantiation of function template specialization 'std::_Destroy<InputViewerSettingsWindow>' requested here
  720 |         { std::_Destroy(__p); }
      |                ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr_base.h:616:28: note: in instantiation of function template specialization 'std::allocator_traits<std::allocator<void>>::destroy<InputViewerSettingsWindow>' requested here
  616 |         allocator_traits<_Alloc>::destroy(_M_impl._M_alloc(), _M_ptr());
      |                                   ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr_base.h:602:2: note: in instantiation of member function 'std::_Sp_counted_ptr_inplace<InputViewerSettingsWindow, std::allocator<void>, __gnu_cxx::_S_atomic>::_M_dispose' requested here
  602 |         _Sp_counted_ptr_inplace(_Alloc __a, _Args&&... __args)
      |         ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr_base.h:970:6: note: in instantiation of function template specialization 'std::_Sp_counted_ptr_inplace<InputViewerSettingsWindow, std::allocator<void>, __gnu_cxx::_S_atomic>::_Sp_counted_ptr_inplace<const char (&)[33], const char (&)[22], ImVec2>' requested here
  970 |             _Sp_cp_type(__a._M_a, std::forward<_Args>(__args)...);
      |             ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr_base.h:1713:14: note: in instantiation of function template specialization 'std::__shared_count<>::__shared_count<InputViewerSettingsWindow, std::allocator<void>, const char (&)[33], const char (&)[22], ImVec2>' requested here
 1713 |         : _M_ptr(), _M_refcount(_M_ptr, __tag, std::forward<_Args>(__args)...)
      |                     ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr.h:463:4: note: in instantiation of function template specialization 'std::__shared_ptr<InputViewerSettingsWindow>::__shared_ptr<std::allocator<void>, const char (&)[33], const char (&)[22], ImVec2>' requested here
  463 |         : __shared_ptr<_Tp>(__tag, std::forward<_Args>(__args)...)
      |           ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr.h:1007:14: note: in instantiation of function template specialization 'std::shared_ptr<InputViewerSettingsWindow>::shared_ptr<std::allocator<void>, const char (&)[33], const char (&)[22], ImVec2>' requested here
 1007 |       return shared_ptr<_Tp>(_Sp_alloc_shared_tag<_Alloc>{__a},
      |              ^
/home/erpre/s/ShipWright/soh/soh/SohGui/SohGui.cpp:143:33: note: in instantiation of function template specialization 'std::make_shared<InputViewerSettingsWindow, const char (&)[33], const char (&)[22], ImVec2>' requested here
  143 |     mInputViewerSettings = std::make_shared<InputViewerSettingsWindow>(CVAR_WINDOW("InputViewerSettings"),
      |                                 ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/stl_construct.h:88:15: note: qualify call to silence this warning
   88 |         __location->~_Tp();
      |                      ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/stl_construct.h:88:2: warning: destructor called on non-final 'CosmeticsEditorWindow' that has virtual functions but non-virtual destructor [-Wdelete-non-abstract-non-virtual-dtor]
   88 |         __location->~_Tp();
      |         ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/stl_construct.h:149:12: note: in instantiation of function template specialization 'std::destroy_at<CosmeticsEditorWindow>' requested here
  149 |       std::destroy_at(__pointer);
      |            ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/alloc_traits.h:720:9: note: in instantiation of function template specialization 'std::_Destroy<CosmeticsEditorWindow>' requested here
  720 |         { std::_Destroy(__p); }
      |                ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr_base.h:616:28: note: in instantiation of function template specialization 'std::allocator_traits<std::allocator<void>>::destroy<CosmeticsEditorWindow>' requested here
  616 |         allocator_traits<_Alloc>::destroy(_M_impl._M_alloc(), _M_ptr());
      |                                   ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr_base.h:602:2: note: in instantiation of member function 'std::_Sp_counted_ptr_inplace<CosmeticsEditorWindow, std::allocator<void>, __gnu_cxx::_S_atomic>::_M_dispose' requested here
  602 |         _Sp_counted_ptr_inplace(_Alloc __a, _Args&&... __args)
      |         ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr_base.h:970:6: note: in instantiation of function template specialization 'std::_Sp_counted_ptr_inplace<CosmeticsEditorWindow, std::allocator<void>, __gnu_cxx::_S_atomic>::_Sp_counted_ptr_inplace<const char (&)[29], const char (&)[17], ImVec2>' requested here
  970 |             _Sp_cp_type(__a._M_a, std::forward<_Args>(__args)...);
      |             ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr_base.h:1713:14: note: in instantiation of function template specialization 'std::__shared_count<>::__shared_count<CosmeticsEditorWindow, std::allocator<void>, const char (&)[29], const char (&)[17], ImVec2>' requested here
 1713 |         : _M_ptr(), _M_refcount(_M_ptr, __tag, std::forward<_Args>(__args)...)
      |                     ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr.h:463:4: note: in instantiation of function template specialization 'std::__shared_ptr<CosmeticsEditorWindow>::__shared_ptr<std::allocator<void>, const char (&)[29], const char (&)[17], ImVec2>' requested here
  463 |         : __shared_ptr<_Tp>(__tag, std::forward<_Args>(__args)...)
      |           ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr.h:1007:14: note: in instantiation of function template specialization 'std::shared_ptr<CosmeticsEditorWindow>::shared_ptr<std::allocator<void>, const char (&)[29], const char (&)[17], ImVec2>' requested here
 1007 |       return shared_ptr<_Tp>(_Sp_alloc_shared_tag<_Alloc>{__a},
      |              ^
/home/erpre/s/ShipWright/soh/soh/SohGui/SohGui.cpp:147:14: note: in instantiation of function template specialization 'std::make_shared<CosmeticsEditorWindow, const char (&)[29], const char (&)[17], ImVec2>' requested here
  147 |         std::make_shared<CosmeticsEditorWindow>(CVAR_WINDOW("CosmeticsEditor"), "Cosmetics Editor", ImVec2(550, 520));
      |              ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/stl_construct.h:88:15: note: qualify call to silence this warning
   88 |         __location->~_Tp();
      |                      ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/stl_construct.h:88:2: warning: destructor called on non-final 'ActorViewerWindow' that has virtual functions but non-virtual destructor [-Wdelete-non-abstract-non-virtual-dtor]
   88 |         __location->~_Tp();
      |         ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/stl_construct.h:149:12: note: in instantiation of function template specialization 'std::destroy_at<ActorViewerWindow>' requested here
  149 |       std::destroy_at(__pointer);
      |            ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/alloc_traits.h:720:9: note: in instantiation of function template specialization 'std::_Destroy<ActorViewerWindow>' requested here
  720 |         { std::_Destroy(__p); }
      |                ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr_base.h:616:28: note: in instantiation of function template specialization 'std::allocator_traits<std::allocator<void>>::destroy<ActorViewerWindow>' requested here
  616 |         allocator_traits<_Alloc>::destroy(_M_impl._M_alloc(), _M_ptr());
      |                                   ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr_base.h:602:2: note: in instantiation of member function 'std::_Sp_counted_ptr_inplace<ActorViewerWindow, std::allocator<void>, __gnu_cxx::_S_atomic>::_M_dispose' requested here
  602 |         _Sp_counted_ptr_inplace(_Alloc __a, _Args&&... __args)
      |         ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr_base.h:970:6: note: in instantiation of function template specialization 'std::_Sp_counted_ptr_inplace<ActorViewerWindow, std::allocator<void>, __gnu_cxx::_S_atomic>::_Sp_counted_ptr_inplace<const char (&)[25], const char (&)[13], ImVec2>' requested here
  970 |             _Sp_cp_type(__a._M_a, std::forward<_Args>(__args)...);
      |             ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr_base.h:1713:14: note: in instantiation of function template specialization 'std::__shared_count<>::__shared_count<ActorViewerWindow, std::allocator<void>, const char (&)[25], const char (&)[13], ImVec2>' requested here
 1713 |         : _M_ptr(), _M_refcount(_M_ptr, __tag, std::forward<_Args>(__args)...)
      |                     ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr.h:463:4: note: in instantiation of function template specialization 'std::__shared_ptr<ActorViewerWindow>::__shared_ptr<std::allocator<void>, const char (&)[25], const char (&)[13], ImVec2>' requested here
  463 |         : __shared_ptr<_Tp>(__tag, std::forward<_Args>(__args)...)
      |           ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr.h:1007:14: note: in instantiation of function template specialization 'std::shared_ptr<ActorViewerWindow>::shared_ptr<std::allocator<void>, const char (&)[25], const char (&)[13], ImVec2>' requested here
 1007 |       return shared_ptr<_Tp>(_Sp_alloc_shared_tag<_Alloc>{__a},
      |              ^
/home/erpre/s/ShipWright/soh/soh/SohGui/SohGui.cpp:150:14: note: in instantiation of function template specialization 'std::make_shared<ActorViewerWindow, const char (&)[25], const char (&)[13], ImVec2>' requested here
  150 |         std::make_shared<ActorViewerWindow>(CVAR_WINDOW("ActorViewer"), "Actor Viewer", ImVec2(520, 600));
      |              ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/stl_construct.h:88:15: note: qualify call to silence this warning
   88 |         __location->~_Tp();
      |                      ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/stl_construct.h:88:2: warning: destructor called on non-final 'ColViewerWindow' that has virtual functions but non-virtual destructor [-Wdelete-non-abstract-non-virtual-dtor]
   88 |         __location->~_Tp();
      |         ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/stl_construct.h:149:12: note: in instantiation of function template specialization 'std::destroy_at<ColViewerWindow>' requested here
  149 |       std::destroy_at(__pointer);
      |            ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/alloc_traits.h:720:9: note: in instantiation of function template specialization 'std::_Destroy<ColViewerWindow>' requested here
  720 |         { std::_Destroy(__p); }
      |                ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr_base.h:616:28: note: in instantiation of function template specialization 'std::allocator_traits<std::allocator<void>>::destroy<ColViewerWindow>' requested here
  616 |         allocator_traits<_Alloc>::destroy(_M_impl._M_alloc(), _M_ptr());
      |                                   ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr_base.h:602:2: note: in instantiation of member function 'std::_Sp_counted_ptr_inplace<ColViewerWindow, std::allocator<void>, __gnu_cxx::_S_atomic>::_M_dispose' requested here
  602 |         _Sp_counted_ptr_inplace(_Alloc __a, _Args&&... __args)
      |         ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr_base.h:970:6: note: in instantiation of function template specialization 'std::_Sp_counted_ptr_inplace<ColViewerWindow, std::allocator<void>, __gnu_cxx::_S_atomic>::_Sp_counted_ptr_inplace<const char (&)[29], const char (&)[17], ImVec2>' requested here
  970 |             _Sp_cp_type(__a._M_a, std::forward<_Args>(__args)...);
      |             ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr_base.h:1713:14: note: in instantiation of function template specialization 'std::__shared_count<>::__shared_count<ColViewerWindow, std::allocator<void>, const char (&)[29], const char (&)[17], ImVec2>' requested here
 1713 |         : _M_ptr(), _M_refcount(_M_ptr, __tag, std::forward<_Args>(__args)...)
      |                     ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr.h:463:4: note: in instantiation of function template specialization 'std::__shared_ptr<ColViewerWindow>::__shared_ptr<std::allocator<void>, const char (&)[29], const char (&)[17], ImVec2>' requested here
  463 |         : __shared_ptr<_Tp>(__tag, std::forward<_Args>(__args)...)
      |           ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr.h:1007:14: note: in instantiation of function template specialization 'std::shared_ptr<ColViewerWindow>::shared_ptr<std::allocator<void>, const char (&)[29], const char (&)[17], ImVec2>' requested here
 1007 |       return shared_ptr<_Tp>(_Sp_alloc_shared_tag<_Alloc>{__a},
      |              ^
/home/erpre/s/ShipWright/soh/soh/SohGui/SohGui.cpp:153:14: note: in instantiation of function template specialization 'std::make_shared<ColViewerWindow, const char (&)[29], const char (&)[17], ImVec2>' requested here
  153 |         std::make_shared<ColViewerWindow>(CVAR_WINDOW("CollisionViewer"), "Collision Viewer", ImVec2(520, 600));
      |              ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/stl_construct.h:88:15: note: qualify call to silence this warning
   88 |         __location->~_Tp();
      |                      ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/stl_construct.h:88:2: warning: destructor called on non-final 'SaveEditorWindow' that has virtual functions but non-virtual destructor [-Wdelete-non-abstract-non-virtual-dtor]
   88 |         __location->~_Tp();
      |         ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/stl_construct.h:149:12: note: in instantiation of function template specialization 'std::destroy_at<SaveEditorWindow>' requested here
  149 |       std::destroy_at(__pointer);
      |            ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/alloc_traits.h:720:9: note: in instantiation of function template specialization 'std::_Destroy<SaveEditorWindow>' requested here
  720 |         { std::_Destroy(__p); }
      |                ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/shared_ptr_base.h:616:28: note: in instantiation of function template specialization 'std::allocator_traits<std::allocator<void>>::destroy<SaveEditorWindow>' requested here
  616 |         allocator_traits<_Alloc>::destroy(_M_impl._M_alloc(), _M_ptr());
      |                                   ^

...
```

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2987354320.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2987360757.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/2987388529.zip)
<!--- section:artifacts:end -->