### PR TITLE
Add Water Temple Dragon Switch CS to Glitch Useful Cutscenes

### DIFF
--- a/soh/soh/Enhancements/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.cpp
@@ -275,8 +275,9 @@ void TimeSaverOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_li
                 }
                 switch (actor->id) {
                     case ACTOR_OBJ_SWITCH: {
-                        if (actor->params == 8224 && gPlayState->sceneNum == SCENE_DODONGOS_CAVERN &&
-                            CVarGetInteger(CVAR_ENHANCEMENT("TimeSavers.SkipCutscene.GlitchAiding"), 0)) {
+                        if ((actor->params == 8224 && gPlayState->sceneNum == SCENE_DODONGOS_CAVERN) ||
+                            (actor->params == 6979 && gPlayState->sceneNum == SCENE_WATER_TEMPLE) &&
+                                CVarGetInteger(CVAR_ENHANCEMENT("TimeSavers.SkipCutscene.GlitchAiding"), 0)) {
                             break;
                         }
                         ObjSwitch* switchActor = (ObjSwitch*)actor;

--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -334,10 +334,10 @@ void SohMenu::AddMenuEnhancements() {
         .Options(CheckboxOptions().DefaultValue(IS_RANDO));
     AddWidget(path, "Exclude Glitch-Aiding Cutscenes", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("TimeSavers.SkipCutscene.GlitchAiding"))
-        .Options(
-            CheckboxOptions().Tooltip("Don't skip cutscenes that are associated with useful glitches. Currently, it is "
-                                      "only the Fire Temple Darunia CS, Forest Temple Poe Sisters CS, Dodongo Boss "
-                                      "Door Switch, and the Box Skip One Point in Jabu."));
+        .Options(CheckboxOptions().Tooltip(
+            "Don't skip cutscenes that are associated with useful glitches. Currently, it is "
+            "only the Fire Temple Darunia CS, Forest Temple Poe Sisters CS, Dodongo Boss "
+            "Door Switch CS, Water Temple Dragon Switch CS, and the Box Skip One Point in Jabu."));
 
     AddWidget(path, "Text", WIDGET_SEPARATOR_TEXT);
     AddWidget(path, "Skip Pickup Messages", WIDGET_CVAR_CHECKBOX)


### PR DESCRIPTION
Adds the Water Temple dragon room switch to the Exclude Glitch-Aiding Cutscenes option, allowing the player to drop to the bottom of the room during the cutscene to clear the gate without scale or iron boots.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3033791262.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3033792386.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3033796693.zip)
<!--- section:artifacts:end -->