### PR TITLE
Warnings Squashing Round 1

### DIFF
--- a/soh/soh/Enhancements/ExtraTraps.cpp
+++ b/soh/soh/Enhancements/ExtraTraps.cpp
@@ -62,7 +62,7 @@ std::vector<AltTrapType> getEnabledAddTraps() {
 
 static void RollRandomTrap(uint32_t seed) {
     uint32_t finalSeed =
-        seed + (IS_RANDO ? Rando::Context::GetInstance()->GetSeed() : gSaveContext.ship.stats.fileCreatedAt);
+        seed + (IS_RANDO ? Rando::Context::GetInstance()->GetSeed() : (uint32_t)gSaveContext.ship.stats.fileCreatedAt);
     Random_Init(finalSeed);
 
     roll = RandomElement(getEnabledAddTraps());
@@ -126,12 +126,12 @@ static void OnPlayerUpdate() {
                 Play_TriggerRespawn(gPlayState);
                 break;
             case ADD_AMMO_TRAP:
-                AMMO(ITEM_STICK) = AMMO(ITEM_STICK) * 0.5;
-                AMMO(ITEM_NUT) = AMMO(ITEM_NUT) * 0.5;
-                AMMO(ITEM_SLINGSHOT) = AMMO(ITEM_SLINGSHOT) * 0.5;
-                AMMO(ITEM_BOW) = AMMO(ITEM_BOW) * 0.5;
-                AMMO(ITEM_BOMB) = AMMO(ITEM_BOMB) * 0.5;
-                AMMO(ITEM_BOMBCHU) = AMMO(ITEM_BOMBCHU) * 0.5;
+                AMMO(ITEM_STICK) = (int8_t)floor(AMMO(ITEM_STICK) * 0.5f);
+                AMMO(ITEM_NUT) = (int8_t)floor(AMMO(ITEM_NUT) * 0.5f);
+                AMMO(ITEM_SLINGSHOT) = (int8_t)floor(AMMO(ITEM_SLINGSHOT) * 0.5f);
+                AMMO(ITEM_BOW) = (int8_t)floor(AMMO(ITEM_BOW) * 0.5f);
+                AMMO(ITEM_BOMB) = (int8_t)floor(AMMO(ITEM_BOMB) * 0.5f);
+                AMMO(ITEM_BOMBCHU) = (int8_t)floor(AMMO(ITEM_BOMBCHU) * 0.5f);
                 Audio_PlaySoundGeneral(NA_SE_VO_FR_SMILE_0, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale,
                                        &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
                 break;

--- a/soh/soh/Enhancements/ExtraTraps.cpp
+++ b/soh/soh/Enhancements/ExtraTraps.cpp
@@ -61,8 +61,8 @@ std::vector<AltTrapType> getEnabledAddTraps() {
 };
 
 static void RollRandomTrap(uint32_t seed) {
-    uint32_t finalSeed =
-        seed + (IS_RANDO ? Rando::Context::GetInstance()->GetSeed() : (uint32_t)gSaveContext.ship.stats.fileCreatedAt);
+    uint32_t finalSeed = seed + (IS_RANDO ? Rando::Context::GetInstance()->GetSeed()
+                                          : static_cast<uint32_t>(gSaveContext.ship.stats.fileCreatedAt));
     Random_Init(finalSeed);
 
     roll = RandomElement(getEnabledAddTraps());
@@ -126,12 +126,12 @@ static void OnPlayerUpdate() {
                 Play_TriggerRespawn(gPlayState);
                 break;
             case ADD_AMMO_TRAP:
-                AMMO(ITEM_STICK) = (int8_t)floor(AMMO(ITEM_STICK) * 0.5f);
-                AMMO(ITEM_NUT) = (int8_t)floor(AMMO(ITEM_NUT) * 0.5f);
-                AMMO(ITEM_SLINGSHOT) = (int8_t)floor(AMMO(ITEM_SLINGSHOT) * 0.5f);
-                AMMO(ITEM_BOW) = (int8_t)floor(AMMO(ITEM_BOW) * 0.5f);
-                AMMO(ITEM_BOMB) = (int8_t)floor(AMMO(ITEM_BOMB) * 0.5f);
-                AMMO(ITEM_BOMBCHU) = (int8_t)floor(AMMO(ITEM_BOMBCHU) * 0.5f);
+                AMMO(ITEM_STICK) = static_cast<int8_t>(floor(AMMO(ITEM_STICK) * 0.5f));
+                AMMO(ITEM_NUT) = static_cast<int8_t>(floor(AMMO(ITEM_NUT) * 0.5f));
+                AMMO(ITEM_SLINGSHOT) = static_cast<int8_t>(floor(AMMO(ITEM_SLINGSHOT) * 0.5f));
+                AMMO(ITEM_BOW) = static_cast<int8_t>(floor(AMMO(ITEM_BOW) * 0.5f));
+                AMMO(ITEM_BOMB) = static_cast<int8_t>(floor(AMMO(ITEM_BOMB) * 0.5f));
+                AMMO(ITEM_BOMBCHU) = static_cast<int8_t>(floor(AMMO(ITEM_BOMBCHU) * 0.5f));
                 Audio_PlaySoundGeneral(NA_SE_VO_FR_SMILE_0, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale,
                                        &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
                 break;

--- a/soh/soh/Enhancements/boss-rush/BossRush.cpp
+++ b/soh/soh/Enhancements/boss-rush/BossRush.cpp
@@ -111,7 +111,7 @@ const char* BossRush_GetSettingChoiceName(u8 optionIndex, u8 choiceIndex, u8 lan
 }
 
 u8 BossRush_GetSettingOptionsAmount(u8 optionIndex) {
-    return (u8)BossRushOptions[optionIndex].choices.size();
+    return static_cast<u8>(BossRushOptions[optionIndex].choices.size());
 }
 
 void BossRush_SpawnBlueWarps(PlayState* play) {
@@ -311,7 +311,8 @@ void BossRush_HandleCompleteBoss(PlayState* play) {
         play->sceneNum == SCENE_GANON_BOSS) {
         gSaveContext.ship.stats.playTimer += 2;
         gSaveContext.ship.stats.gameComplete = 1;
-        gSaveContext.ship.stats.itemTimestamp[TIMESTAMP_BOSSRUSH_FINISH] = (uint32_t)GAMEPLAYSTAT_TOTAL_TIME;
+        gSaveContext.ship.stats.itemTimestamp[TIMESTAMP_BOSSRUSH_FINISH] =
+            static_cast<uint32_t>(GAMEPLAYSTAT_TOTAL_TIME);
     }
 }
 

--- a/soh/soh/Enhancements/boss-rush/BossRush.cpp
+++ b/soh/soh/Enhancements/boss-rush/BossRush.cpp
@@ -111,7 +111,7 @@ const char* BossRush_GetSettingChoiceName(u8 optionIndex, u8 choiceIndex, u8 lan
 }
 
 u8 BossRush_GetSettingOptionsAmount(u8 optionIndex) {
-    return BossRushOptions[optionIndex].choices.size();
+    return (u8)BossRushOptions[optionIndex].choices.size();
 }
 
 void BossRush_SpawnBlueWarps(PlayState* play) {
@@ -311,7 +311,7 @@ void BossRush_HandleCompleteBoss(PlayState* play) {
         play->sceneNum == SCENE_GANON_BOSS) {
         gSaveContext.ship.stats.playTimer += 2;
         gSaveContext.ship.stats.gameComplete = 1;
-        gSaveContext.ship.stats.itemTimestamp[TIMESTAMP_BOSSRUSH_FINISH] = GAMEPLAYSTAT_TOTAL_TIME;
+        gSaveContext.ship.stats.itemTimestamp[TIMESTAMP_BOSSRUSH_FINISH] = (uint32_t)GAMEPLAYSTAT_TOTAL_TIME;
     }
 }
 

--- a/soh/soh/Enhancements/controls/InputViewer.cpp
+++ b/soh/soh/Enhancements/controls/InputViewer.cpp
@@ -345,7 +345,7 @@ void InputViewer::DrawElement() {
             // Analog Stick
             const int analogOutlineMode =
                 CVarGetInteger(CVAR_INPUT_VIEWER("AnalogStick.OutlineMode"), STICK_MODE_ALWAYS_SHOWN);
-            const float maxStickDistance = CVarGetInteger(CVAR_INPUT_VIEWER("AnalogStick.Movement"), 12);
+            const int32_t maxStickDistance = CVarGetInteger(CVAR_INPUT_VIEWER("AnalogStick.Movement"), 12);
             if (analogOutlineMode == STICK_MODE_ALWAYS_SHOWN ||
                 (analogOutlineMode == STICK_MODE_HIDDEN_IN_DEADZONE && !analogStickIsInDeadzone)) {
                 ImGui::SetNextItemAllowOverlap();
@@ -367,7 +367,7 @@ void InputViewer::DrawElement() {
             }
 
             // Right Stick
-            const float maxRightStickDistance = CVarGetInteger(CVAR_INPUT_VIEWER("RightStick.Movement"), 7);
+            const int32_t maxRightStickDistance = CVarGetInteger(CVAR_INPUT_VIEWER("RightStick.Movement"), 7);
             const int rightOutlineMode =
                 CVarGetInteger(CVAR_INPUT_VIEWER("RightStick.OutlineMode"), STICK_MODE_ALWAYS_HIDDEN);
             if (rightOutlineMode == STICK_MODE_ALWAYS_SHOWN ||
@@ -401,7 +401,7 @@ void InputViewer::DrawElement() {
                 ImGui::PushFont(ImGui::GetFont());
 
                 // Calculate polar R coordinate from X and Y angles, squared to avoid sqrt
-                const float rSquared = pads[0].stick_x * pads[0].stick_x + pads[0].stick_y * pads[0].stick_y;
+                const int32_t rSquared = pads[0].stick_x * pads[0].stick_x + pads[0].stick_y * pads[0].stick_y;
 
                 // ESS range
                 const int range1Min = CVarGetInteger(CVAR_INPUT_VIEWER("AnalogAngles.Range1.Min"), 8);

--- a/soh/soh/Enhancements/controls/Mouse.cpp
+++ b/soh/soh/Enhancements/controls/Mouse.cpp
@@ -50,8 +50,8 @@ void Mouse_HandleFirstPerson(Player* player) {
                               : 1;
     s8 invertYAxisMulti = CVarGetInteger(CVAR_SETTING("Controls.InvertAimingYAxis"), 1) ? 1 : -1;
     if (MOUSE_ENABLED) {
-        player->actor.focus.rot.y -= mouseCoordRel.x * 6.0f * xAxisMulti * invertXAxisMulti;
-        player->actor.focus.rot.x += mouseCoordRel.y * 6.0f * yAxisMulti * invertYAxisMulti;
+        player->actor.focus.rot.y -= (int16_t)(mouseCoordRel.x * 6.0f * xAxisMulti * invertXAxisMulti);
+        player->actor.focus.rot.x += (int16_t)(mouseCoordRel.y * 6.0f * yAxisMulti * invertYAxisMulti);
     }
 }
 
@@ -78,8 +78,8 @@ void Mouse_HandleShield(f32* sp50, f32* sp54) {
 }
 
 static s8 iterMouse = 0;
-static f32 mouseQuickspinX[5] = {};
-static f32 mouseQuickspinY[5] = {};
+static s32 mouseQuickspinX[5] = {};
+static s32 mouseQuickspinY[5] = {};
 static u8 quickspinCount = 0;
 
 void Mouse_UpdateQuickspinCount() {
@@ -102,9 +102,9 @@ bool Mouse_HandleQuickspin(bool* should, s8* iter2, s8* sp3C) {
 
     for (i = 0; i < 4; i++, iter2++) {
         // Calculating angles as per z_lib.c:func_80077D10()
-        f32 relY = mouseQuickspinY[i + 1] - mouseQuickspinY[i];
-        f32 relX = mouseQuickspinX[i + 1] - mouseQuickspinX[i];
-        s16 aTan = Math_Atan2S(relY, -relX);
+        s32 relY = mouseQuickspinY[i + 1] - mouseQuickspinY[i];
+        s32 relX = mouseQuickspinX[i + 1] - mouseQuickspinX[i];
+        s16 aTan = Math_Atan2S((f32)relY, (f32)-relX);
         iterMouse = (u16)(aTan + 0x2000) >> 9; // See z_player.c:Player_ProcessControlStick()
         if ((*iter2 = iterMouse) < 0) {
             return *should = false;

--- a/soh/soh/Enhancements/controls/Mouse.cpp
+++ b/soh/soh/Enhancements/controls/Mouse.cpp
@@ -50,8 +50,8 @@ void Mouse_HandleFirstPerson(Player* player) {
                               : 1;
     s8 invertYAxisMulti = CVarGetInteger(CVAR_SETTING("Controls.InvertAimingYAxis"), 1) ? 1 : -1;
     if (MOUSE_ENABLED) {
-        player->actor.focus.rot.y -= (int16_t)(mouseCoordRel.x * 6.0f * xAxisMulti * invertXAxisMulti);
-        player->actor.focus.rot.x += (int16_t)(mouseCoordRel.y * 6.0f * yAxisMulti * invertYAxisMulti);
+        player->actor.focus.rot.y -= static_cast<int16_t>(mouseCoordRel.x * 6.0f * xAxisMulti * invertXAxisMulti);
+        player->actor.focus.rot.x += static_cast<int16_t>(mouseCoordRel.y * 6.0f * yAxisMulti * invertYAxisMulti);
     }
 }
 
@@ -59,7 +59,7 @@ void Mouse_RecenterCursor() {
     u32 width = GetWindow()->GetWidth();
     u32 height = GetWindow()->GetHeight();
     if (MOUSE_ENABLED) {
-        GetWindow()->SetMousePos({ (s32)(width / 2), (s32)(height / 2) });
+        GetWindow()->SetMousePos({ static_cast<s32>(width / 2), static_cast<s32>(height / 2) });
     }
 }
 
@@ -67,8 +67,8 @@ void Mouse_HandleShield(f32* sp50, f32* sp54) {
     if (MOUSE_ENABLED) {
         s32 width = GetWindow()->GetWidth();
         s32 height = GetWindow()->GetHeight();
-        f32 xBound = 7200 / ((f32)width / 2);
-        f32 yBound = 6000 / ((f32)height / 2);
+        f32 xBound = 7200 / (width / 2.0f);
+        f32 yBound = 6000 / (height / 2.0f);
         *sp50 +=
             (mouseCoord.x - (width / 2)) * xBound * (CVarGetInteger(CVAR_ENHANCEMENT("MirroredWorld"), 0) ? 1 : -1);
         *sp54 += (mouseCoord.y - (height / 2)) * yBound;

--- a/soh/soh/Enhancements/game-interactor/GameInteractor_RawAction.cpp
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor_RawAction.cpp
@@ -112,7 +112,7 @@ void GameInteractor::RawAction::FreezePlayer() {
 void GameInteractor::RawAction::BurnPlayer() {
     Player* player = GET_PLAYER(gPlayState);
     for (int i = 0; i < 18; i++) {
-        player->bodyFlameTimers[i] = (uint8_t)Rand_S16Offset(0, 200);
+        player->bodyFlameTimers[i] = static_cast<uint8_t>(Rand_S16Offset(0, 200));
     }
     player->bodyIsBurning = true;
     func_80837C0C(gPlayState, player, 0, 0, 0, 0, 0);
@@ -617,7 +617,7 @@ GameInteractionEffectQueryResult GameInteractor::RawAction::SpawnEnemyWithOffset
     }
 
     // Generate point in random angle with a radius.
-    float angle = (float)(RandomDouble() * 2 * M_PI);
+    float angle = static_cast<float>(RandomDouble() * 2 * M_PI);
     float radius = 150;
     float posXOffset = radius * cos(angle);
     float posZOffset = radius * sin(angle);

--- a/soh/soh/Enhancements/game-interactor/GameInteractor_RawAction.cpp
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor_RawAction.cpp
@@ -617,7 +617,7 @@ GameInteractionEffectQueryResult GameInteractor::RawAction::SpawnEnemyWithOffset
     }
 
     // Generate point in random angle with a radius.
-    float angle = Random(0, 2 * M_PI);
+    float angle = Random_Float(0, 2 * M_PI);
     float radius = 150;
     float posXOffset = radius * cos(angle);
     float posZOffset = radius * sin(angle);

--- a/soh/soh/Enhancements/game-interactor/GameInteractor_RawAction.cpp
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor_RawAction.cpp
@@ -112,7 +112,7 @@ void GameInteractor::RawAction::FreezePlayer() {
 void GameInteractor::RawAction::BurnPlayer() {
     Player* player = GET_PLAYER(gPlayState);
     for (int i = 0; i < 18; i++) {
-        player->bodyFlameTimers[i] = Rand_S16Offset(0, 200);
+        player->bodyFlameTimers[i] = (uint8_t)Rand_S16Offset(0, 200);
     }
     player->bodyIsBurning = true;
     func_80837C0C(gPlayState, player, 0, 0, 0, 0, 0);
@@ -559,7 +559,7 @@ void GameInteractor::RawAction::SetRandomWind(bool active) {
         GameInteractor::State::RandomWindActive = 0;
         GameInteractor::State::RandomWindSecondsSinceLastDirectionChange = 0;
         player->pushedSpeed = 0.0f;
-        player->pushedYaw = 0.0f;
+        player->pushedYaw = 0;
     }
 }
 
@@ -617,7 +617,7 @@ GameInteractionEffectQueryResult GameInteractor::RawAction::SpawnEnemyWithOffset
     }
 
     // Generate point in random angle with a radius.
-    float angle = Random_Float(0, 2 * M_PI);
+    float angle = (float)(RandomDouble() * 2 * M_PI);
     float radius = 150;
     float posXOffset = radius * cos(angle);
     float posZOffset = radius * sin(angle);

--- a/soh/soh/Enhancements/randomizer/3drando/random.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/random.cpp
@@ -14,8 +14,7 @@ void Random_Init(uint32_t seed) {
     generator = boost::random::mt19937{ seed };
 }
 
-// Returns a random integer in range [min, max-1]
-uint32_t Random(int min, int max) {
+void Random_InitSeed() {
     if (!init) {
         // No seed given, get a random number from device to seed
 #if !defined(__SWITCH__) && !defined(__WIIU__)
@@ -25,7 +24,19 @@ uint32_t Random(int min, int max) {
 #endif
         Random_Init(seed);
     }
+}
+
+// Returns a random unsigned integer in range [min, max-1]
+uint32_t Random(uint32_t min, uint32_t max) {
+    Random_InitSeed();
     boost::random::uniform_int_distribution<uint32_t> distribution(min, max - 1);
+    return distribution(generator);
+}
+
+// Returns a random float in range [min, max-1]
+float Random_Float(float min, float max) {
+    Random_InitSeed();
+    boost::random::uniform_real_distribution<float> distribution(min, max - 1);
     return distribution(generator);
 }
 

--- a/soh/soh/Enhancements/randomizer/3drando/random.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/random.cpp
@@ -33,14 +33,7 @@ uint32_t Random(uint32_t min, uint32_t max) {
     return distribution(generator);
 }
 
-// Returns a random float in range [min, max-1]
-float Random_Float(float min, float max) {
-    Random_InitSeed();
-    boost::random::uniform_real_distribution<float> distribution(min, max - 1);
-    return distribution(generator);
-}
-
-// Returns a random floating point number in [0.0, 1.0]
+// Returns a random floating point number in [0.0, 1.0)
 double RandomDouble() {
     boost::random::uniform_real_distribution<double> distribution(0.0, 1.0);
     return distribution(generator);

--- a/soh/soh/Enhancements/randomizer/3drando/random.hpp
+++ b/soh/soh/Enhancements/randomizer/3drando/random.hpp
@@ -8,7 +8,8 @@
 #include <set>
 
 void Random_Init(uint32_t seed);
-uint32_t Random(int min, int max);
+uint32_t Random(uint32_t min, uint32_t max);
+float Random_Float(float min, float max);
 double RandomDouble();
 
 // Get a random element from a vector or array
@@ -21,17 +22,17 @@ template <typename T> T RandomElement(std::vector<T>& vector, bool erase) {
     return selected;
 }
 template <typename Container> auto& RandomElement(Container& container) {
-    return container[Random(0, std::size(container))];
+    return container[Random(0, (uint32_t)std::size(container))];
 }
 template <typename Container> const auto& RandomElement(const Container& container) {
-    return container[Random(0, std::size(container))];
+    return container[Random(0, (uint32_t)std::size(container))];
 }
 
 template <typename T> const T RandomElementFromSet(const std::set<T>& set) {
     if (set.size() == 1) {
         return *set.begin();
     }
-    uint32_t rand = Random(0, set.size());
+    uint32_t rand = Random(0, (uint32_t)set.size());
     auto it = set.begin();
     for (uint32_t i = 0; i < rand; i++) {
         it++;
@@ -43,12 +44,12 @@ template <typename T> const T RandomElementFromSet(const std::set<T>& set) {
 // Shuffle items within a vector or array
 // RANDOTODO There's probably a more efficient way to do what this does.
 template <typename T> void Shuffle(std::vector<T>& vector) {
-    for (std::size_t i = 0; i + 1 < vector.size(); i++) {
-        std::swap(vector[i], vector[Random(i, vector.size())]);
+    for (size_t i = 0; i + 1 < vector.size(); i++) {
+        std::swap(vector[i], vector[Random((uint32_t)i, (uint32_t)vector.size())]);
     }
 }
-template <typename T, std::size_t size> void Shuffle(std::array<T, size>& arr) {
-    for (std::size_t i = 0; i + 1 < arr.size(); i++) {
-        std::swap(arr[i], arr[Random(i, arr.size())]);
+template <typename T, size_t size> void Shuffle(std::array<T, size>& arr) {
+    for (size_t i = 0; i + 1 < arr.size(); i++) {
+        std::swap(arr[i], arr[Random((uint32_t)i, (uint32_t)arr.size())]);
     }
 }

--- a/soh/soh/Enhancements/randomizer/3drando/random.hpp
+++ b/soh/soh/Enhancements/randomizer/3drando/random.hpp
@@ -9,7 +9,6 @@
 
 void Random_Init(uint32_t seed);
 uint32_t Random(uint32_t min, uint32_t max);
-float Random_Float(float min, float max);
 double RandomDouble();
 
 // Get a random element from a vector or array

--- a/soh/soh/Enhancements/randomizer/3drando/random.hpp
+++ b/soh/soh/Enhancements/randomizer/3drando/random.hpp
@@ -21,17 +21,17 @@ template <typename T> T RandomElement(std::vector<T>& vector, bool erase) {
     return selected;
 }
 template <typename Container> auto& RandomElement(Container& container) {
-    return container[Random(0, (uint32_t)std::size(container))];
+    return container[Random(0, static_cast<uint32_t>(std::size(container)))];
 }
 template <typename Container> const auto& RandomElement(const Container& container) {
-    return container[Random(0, (uint32_t)std::size(container))];
+    return container[Random(0, static_cast<uint32_t>(std::size(container)))];
 }
 
 template <typename T> const T RandomElementFromSet(const std::set<T>& set) {
     if (set.size() == 1) {
         return *set.begin();
     }
-    uint32_t rand = Random(0, (uint32_t)set.size());
+    uint32_t rand = Random(0, static_cast<uint32_t>(set.size()));
     auto it = set.begin();
     for (uint32_t i = 0; i < rand; i++) {
         it++;
@@ -44,11 +44,11 @@ template <typename T> const T RandomElementFromSet(const std::set<T>& set) {
 // RANDOTODO There's probably a more efficient way to do what this does.
 template <typename T> void Shuffle(std::vector<T>& vector) {
     for (size_t i = 0; i + 1 < vector.size(); i++) {
-        std::swap(vector[i], vector[Random((uint32_t)i, (uint32_t)vector.size())]);
+        std::swap(vector[i], vector[Random(static_cast<uint32_t>(i), static_cast<uint32_t>(vector.size()))]);
     }
 }
 template <typename T, size_t size> void Shuffle(std::array<T, size>& arr) {
     for (size_t i = 0; i + 1 < arr.size(); i++) {
-        std::swap(arr[i], arr[Random((uint32_t)i, (uint32_t)arr.size())]);
+        std::swap(arr[i], arr[Random(static_cast<uint32_t>(i), static_cast<uint32_t>(arr.size()))]);
     }
 }

--- a/soh/soh/Enhancements/randomizer/entrance.h
+++ b/soh/soh/Enhancements/randomizer/entrance.h
@@ -90,7 +90,7 @@ class Entrance {
     Entrance* reverse = nullptr;
     Entrance* assumed = nullptr;
     Entrance* replacement = nullptr;
-    int16_t index = 0xFFFF;
+    int16_t index = -1;
     bool shuffled = false;
     bool primary = false;
     bool addedToPool = false;

--- a/soh/soh/Enhancements/randomizer/fishsanity.cpp
+++ b/soh/soh/Enhancements/randomizer/fishsanity.cpp
@@ -136,8 +136,9 @@ Fishsanity::GetFishingPondLocations(FishsanityOptionsSource optionsSource) {
     }
     // NOTE: This only works because we can assume activeFish is already sorted; changes that break this assumption will
     // also break this
-    FilterAndEraseFromPool(remainingFish, 
-                           [&](RandomizerCheck loc) { return std::binary_search(activeFish.begin(), activeFish.end(), loc); });
+    FilterAndEraseFromPool(remainingFish, [&](RandomizerCheck loc) {
+        return std::binary_search(activeFish.begin(), activeFish.end(), loc);
+    });
 
     return std::make_pair(activeFish, remainingFish);
 }

--- a/soh/soh/Enhancements/randomizer/fishsanity.cpp
+++ b/soh/soh/Enhancements/randomizer/fishsanity.cpp
@@ -136,8 +136,8 @@ Fishsanity::GetFishingPondLocations(FishsanityOptionsSource optionsSource) {
     }
     // NOTE: This only works because we can assume activeFish is already sorted; changes that break this assumption will
     // also break this
-    FilterAndEraseFromPool(remainingFish,
-                           [&](uint32_t loc) { return std::binary_search(activeFish.begin(), activeFish.end(), loc); });
+    FilterAndEraseFromPool(remainingFish, 
+                           [&](RandomizerCheck loc) { return std::binary_search(activeFish.begin(), activeFish.end(), loc); });
 
     return std::make_pair(activeFish, remainingFish);
 }

--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -328,7 +328,7 @@ void RandomizerOnPlayerUpdateForRCQueueHandler() {
                   (getItemEntry.getItemCategory == ITEM_CATEGORY_JUNK ||
                    getItemEntry.getItemCategory == ITEM_CATEGORY_SKULLTULA_TOKEN ||
                    getItemEntry.getItemCategory == ITEM_CATEGORY_LESSER))))) {
-            Item_DropCollectible(gPlayState, &spawnPos, (int16_t)(ITEM00_SOH_GIVE_ITEM_ENTRY | 0x8000));
+            Item_DropCollectible(gPlayState, &spawnPos, static_cast<int16_t>(ITEM00_SOH_GIVE_ITEM_ENTRY | 0x8000));
         }
     }
 
@@ -2157,7 +2157,7 @@ void RandomizerOnGameFrameUpdateHandler() {
     }
 
     if (Flags_GetRandomizerInf(RAND_INF_HAS_INFINITE_MAGIC_METER)) {
-        gSaveContext.magic = (int8_t)gSaveContext.magicCapacity;
+        gSaveContext.magic = static_cast<int8_t>(gSaveContext.magicCapacity);
     }
 
     if (Flags_GetRandomizerInf(RAND_INF_HAS_INFINITE_BOMBCHUS)) {
@@ -2203,7 +2203,8 @@ void RandomizerOnActorUpdateHandler(void* refActor) {
     if (actor->id == ACTOR_OBJ_COMB) {
         ObjComb* combActor = reinterpret_cast<ObjComb*>(actor);
         combActor->actor.shape.rot.x =
-            (int16_t)Math_SinS(combActor->unk_1B2) * CLAMP_MIN(combActor->unk_1B0, 0) + combActor->actor.home.rot.x;
+            static_cast<int16_t>(Math_SinS(combActor->unk_1B2)) * CLAMP_MIN(combActor->unk_1B0, 0) +
+            combActor->actor.home.rot.x;
     }
 }
 
@@ -2298,8 +2299,8 @@ void RandomizerOnSceneSpawnActorsHandler() {
         switch (gPlayState->sceneNum) {
             case SCENE_TEMPLE_OF_TIME:
                 if (gPlayState->roomCtx.curRoom.num == 1) {
-                    Actor_Spawn(&gPlayState->actorCtx, gPlayState, ACTOR_EN_XC, -104, -40, 2382, 0, (int16_t)0x8000, 0,
-                                SHEIK_TYPE_RANDO, false);
+                    Actor_Spawn(&gPlayState->actorCtx, gPlayState, ACTOR_EN_XC, -104, -40, 2382, 0,
+                                static_cast<int16_t>(0x8000), 0, SHEIK_TYPE_RANDO, false);
                 }
                 break;
             case SCENE_INSIDE_GANONS_CASTLE:

--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -328,7 +328,7 @@ void RandomizerOnPlayerUpdateForRCQueueHandler() {
                   (getItemEntry.getItemCategory == ITEM_CATEGORY_JUNK ||
                    getItemEntry.getItemCategory == ITEM_CATEGORY_SKULLTULA_TOKEN ||
                    getItemEntry.getItemCategory == ITEM_CATEGORY_LESSER))))) {
-            Item_DropCollectible(gPlayState, &spawnPos, ITEM00_SOH_GIVE_ITEM_ENTRY | 0x8000);
+            Item_DropCollectible(gPlayState, &spawnPos, (int16_t)(ITEM00_SOH_GIVE_ITEM_ENTRY | 0x8000));
         }
     }
 
@@ -2157,7 +2157,7 @@ void RandomizerOnGameFrameUpdateHandler() {
     }
 
     if (Flags_GetRandomizerInf(RAND_INF_HAS_INFINITE_MAGIC_METER)) {
-        gSaveContext.magic = gSaveContext.magicCapacity;
+        gSaveContext.magic = (int8_t)gSaveContext.magicCapacity;
     }
 
     if (Flags_GetRandomizerInf(RAND_INF_HAS_INFINITE_BOMBCHUS)) {
@@ -2203,7 +2203,7 @@ void RandomizerOnActorUpdateHandler(void* refActor) {
     if (actor->id == ACTOR_OBJ_COMB) {
         ObjComb* combActor = reinterpret_cast<ObjComb*>(actor);
         combActor->actor.shape.rot.x =
-            Math_SinS(combActor->unk_1B2) * CLAMP_MIN(combActor->unk_1B0, 0) + combActor->actor.home.rot.x;
+            (int16_t)Math_SinS(combActor->unk_1B2) * CLAMP_MIN(combActor->unk_1B0, 0) + combActor->actor.home.rot.x;
     }
 }
 
@@ -2216,29 +2216,29 @@ typedef struct {
 // special respawns used when voided out without swim to prevent infinite loops
 std::map<s32, SpecialRespawnInfo> swimSpecialRespawnInfo = {
     { ENTR_ZORAS_RIVER_3, // hf to zr in water
-      { { -1455.443, -20, 1384.826 }, 28761 } },
+      { { -1455.443f, -20.0f, 1384.826f }, 28761 } },
     { ENTR_HYRULE_FIELD_14, // zr to hf in water
-      { { 5730.209, -20, 3725.911 }, -20025 } },
+      { { 5730.209f, -20.0f, 3725.911f }, -20025 } },
     { ENTR_LOST_WOODS_UNDERWATER_SHORTCUT, // zr to lw
-      { { 1978.718, -36.908, -855 }, -16384 } },
+      { { 1978.718f, -36.908f, -855.0f }, -16384 } },
     { ENTR_ZORAS_RIVER_UNDERWATER_SHORTCUT, // lw to zr
-      { { 4082.366, 860.442, -1018.949 }, -32768 } },
+      { { 4082.366f, 860.442f, -1018.949f }, -32768 } },
     { ENTR_LAKE_HYLIA_RIVER_EXIT, // gv to lh
-      { { -3276.416, -1033, 2908.421 }, 11228 } },
+      { { -3276.416f, -1033.0f, 2908.421f }, 11228 } },
     { ENTR_WATER_TEMPLE_ENTRANCE, // lh to water temple
-      { { -182, 780, 759.5 }, -32768 } },
+      { { -182.0f, 780.0f, 759.5f }, -32768 } },
     { ENTR_LAKE_HYLIA_OUTSIDE_TEMPLE, // water temple to lh
-      { { -955.028, -1306.9, 6768.954 }, -32768 } },
+      { { -955.028f, -1306.9f, 6768.954f }, -32768 } },
     { ENTR_ZORAS_DOMAIN_UNDERWATER_SHORTCUT, // lh to zd
-      { { -109.86, 11.396, -9.933 }, -29131 } },
+      { { -109.86f, 11.396f, -9.933f }, -29131 } },
     { ENTR_LAKE_HYLIA_UNDERWATER_SHORTCUT, // zd to lh
-      { { -912, -1326.967, 3391 }, 0 } },
+      { { -912.0f, -1326.967f, 3391.0f }, 0 } },
     { ENTR_GERUDO_VALLEY_1, // caught by gerudos as child
-      { { -424, -2051, -74 }, 16384 } },
+      { { -424.0f, -2051.0f, -74.0f }, 16384 } },
     { ENTR_HYRULE_FIELD_ON_BRIDGE_SPAWN, // mk to hf (can be a problem when it then turns night)
-      { { 0, 0, 1100 }, 0 } },
+      { { 0.0f, 0.0f, 1100.0f }, 0 } },
     { ENTR_ZORAS_FOUNTAIN_JABU_JABU_BLUE_WARP, // jabu blue warp to zf
-      { { -1580, 150, 1670 }, 8000 } },
+      { { -1580.0f, 150.0f, 1670.0f }, 8000 } },
 };
 
 f32 triforcePieceScale;
@@ -2298,7 +2298,7 @@ void RandomizerOnSceneSpawnActorsHandler() {
         switch (gPlayState->sceneNum) {
             case SCENE_TEMPLE_OF_TIME:
                 if (gPlayState->roomCtx.curRoom.num == 1) {
-                    Actor_Spawn(&gPlayState->actorCtx, gPlayState, ACTOR_EN_XC, -104, -40, 2382, 0, 0x8000, 0,
+                    Actor_Spawn(&gPlayState->actorCtx, gPlayState, ACTOR_EN_XC, -104, -40, 2382, 0, (int16_t)0x8000, 0,
                                 SHEIK_TYPE_RANDO, false);
                 }
                 break;

--- a/soh/soh/SohGui/UIWidgets.hpp
+++ b/soh/soh/SohGui/UIWidgets.hpp
@@ -606,9 +606,9 @@ bool Combobox(const char* label, T* value, const std::vector<const char*>& combo
     PushStyleCombobox(options.color);
 
     const char* longest;
-    int length = 0;
+    size_t length = 0;
     for (auto& string : comboVector) {
-        int len = strlen(string);
+        size_t len = strlen(string);
         if (len > length) {
             longest = string;
             length = len;
@@ -690,9 +690,9 @@ bool Combobox(const char* label, T* value, const std::vector<std::string>& combo
     PushStyleCombobox(options.color);
 
     const char* longest;
-    int length = 0;
+    size_t length = 0;
     for (auto& string : comboVector) {
-        int len = string.length();
+        size_t len = string.length();
         if (len > length) {
             longest = string.c_str();
             length = len;


### PR DESCRIPTION
Mostly fixing implicit conversion warnings, but also a few truncation warnings. 9 files this time. The `AMMO() = CUR_CAPACITY()` lines in `hook_handlers.cpp` still need addressing, but I wasn't sure how the `uint16_t` of `CUR_CAPACITY` was supposed to map to the `int8_t` of `AMMO`, and for some reason, `CUR_CAPACITY` also makes use of an `int16_t` cast internally, so if anyone has any suggestions on that, I'd appreciate it.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3118690631.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3118696973.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3118750841.zip)
<!--- section:artifacts:end -->