### PR TITLE
Fix oversight in dragon room of MQ water

### DIFF
--- a/soh/soh/Enhancements/randomizer/location_access/dungeons/water_temple.cpp
+++ b/soh/soh/Enhancements/randomizer/location_access/dungeons/water_temple.cpp
@@ -658,7 +658,7 @@ void RegionTable_Init_WaterTemple() {
 
     areaTable[RR_WATER_TEMPLE_MQ_DRAGON_ROOM_ALCOVE] = Region("Water Temple MQ Dragon Room Alcove", "Water Temple", {RA_WATER_TEMPLE}, NO_DAY_NIGHT_CYCLE, {
         //Events
-        EventAccess(&logic->MQWaterDragonTorches, []{return true;}),
+        EventAccess(&logic->MQWaterDragonTorches, []{return logic->HasFireSource();}),
     }, 
     {
         //Locations


### PR DESCRIPTION
The logic forgets to check if you had a fire source to light the torches in the MQ version of the square whirlpool room of water, potentially causing an impossible seed, this fixes it.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3108867463.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3108881902.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3108906578.zip)
<!--- section:artifacts:end -->