### PR TITLE
Warnings Round 2 (mostly Rando)

### DIFF
--- a/soh/soh/Enhancements/TimeSavers/FasterHeavyBlockLift.cpp
+++ b/soh/soh/Enhancements/TimeSavers/FasterHeavyBlockLift.cpp
@@ -41,7 +41,7 @@ void FasterHeavyBlockLift_Register() {
         LinkAnimationHeader* anim = va_arg(args, LinkAnimationHeader*);
 
         // Same actor is used for small and large silver rocks, use actor params to identify large ones
-        bool isLargeSilverRock = interactActorId == ACTOR_EN_ISHI && interactRangeActor->params & 1 == 1;
+        bool isLargeSilverRock = (interactActorId == ACTOR_EN_ISHI) && ((interactRangeActor->params & 1) == 1);
         if (CVarGetInteger(CVAR_ENHANCEMENT("FasterHeavyBlockLift"), 0) &&
             (isLargeSilverRock || interactActorId == ACTOR_BG_HEAVY_BLOCK)) {
             *should = false;

--- a/soh/soh/Enhancements/randomizer/3drando/fill.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/fill.cpp
@@ -710,11 +710,11 @@ static void PareDownPlaythrough() {
     auto ctx = Rando::Context::GetInstance();
     std::vector<RandomizerCheck> toAddBackItem;
     // Start at sphere before Ganon's and count down
-    for (int i = ctx->playthroughLocations.size() - 2; i >= 0; i--) {
+    for (size_t i = ctx->playthroughLocations.size() - 2; i >= 0; i--) {
         // Check each item location in sphere
         std::vector<int> erasableIndices;
         std::vector<RandomizerCheck> sphere = ctx->playthroughLocations.at(i);
-        for (int j = sphere.size() - 1; j >= 0; j--) {
+        for (size_t j = sphere.size() - 1; j >= 0; j--) {
             RandomizerCheck loc = sphere.at(j);
             RandomizerGet locGet = ctx->GetItemLocation(loc)->GetPlacedRandomizerGet(); // Copy out item
 

--- a/soh/soh/Enhancements/randomizer/3drando/hints.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/hints.cpp
@@ -63,11 +63,11 @@ const CustomMessage& HintText::GetAmbiguous(uint8_t selection) const {
 }
 
 uint8_t HintText::GetAmbiguousSize() const {
-    return ambiguousText.size();
+    return static_cast<uint8_t>(ambiguousText.size());
 }
 
 uint8_t HintText::GetObscureSize() const {
-    return obscureText.size();
+    return static_cast<uint8_t>(obscureText.size());
 }
 
 const CustomMessage& HintText::GetHintMessage(uint8_t selection) const {
@@ -598,7 +598,7 @@ static void DistributeHints(std::vector<uint8_t>& selected, size_t stoneCount,
     }
     // if stones are left, assign junk to every remaining stone as a fallback.
     if (stoneCount > 0) {
-        selected[selected.size() - 1] += stoneCount;
+        selected[static_cast<uint8_t>(selected.size()) - 1] += stoneCount;
     }
 }
 

--- a/soh/soh/Enhancements/randomizer/3drando/hints.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/hints.cpp
@@ -598,7 +598,7 @@ static void DistributeHints(std::vector<uint8_t>& selected, size_t stoneCount,
     }
     // if stones are left, assign junk to every remaining stone as a fallback.
     if (stoneCount > 0) {
-        selected[static_cast<uint8_t>(selected.size()) - 1] += stoneCount;
+        selected[static_cast<uint8_t>(selected.size()) - 1] += static_cast<uint8_t>(stoneCount);
     }
 }
 

--- a/soh/soh/Enhancements/randomizer/3drando/item_pool.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/item_pool.cpp
@@ -325,7 +325,7 @@ RandomizerGet GetJunkItem() {
         return RandomElement(JunkPoolItems);
     }
     // Ice Trap is the last item in JunkPoolItems, so subtract 1 to never hit that index
-    uint8_t idx = Random(0, JunkPoolItems.size() - 1);
+    uint8_t idx = Random(0, static_cast<uint32_t>(JunkPoolItems.size()) - 1);
     return JunkPoolItems[idx];
 }
 

--- a/soh/soh/Enhancements/randomizer/3drando/menu.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/menu.cpp
@@ -27,7 +27,7 @@ bool GenerateRandomizer(std::set<RandomizerCheck> excludedLocations, std::set<Ra
     ResetPerformanceTimers();
     StartPerformanceTimer(PT_WHOLE_SEED);
 
-    srand(time(NULL));
+    srand(static_cast<uint32_t>(time(NULL)));
     // if a blank seed was entered, make a random one
     if (seedInput.empty()) {
         seedInput = std::to_string(rand() % 0xFFFFFFFF);
@@ -35,7 +35,7 @@ bool GenerateRandomizer(std::set<RandomizerCheck> excludedLocations, std::set<Ra
         int count;
         try {
             count = std::stoi(seedInput.substr(18), nullptr);
-        } catch (std::invalid_argument& e) { count = 1; } catch (std::out_of_range& e) {
+        } catch (std::invalid_argument&) { count = 1; } catch (std::out_of_range&) {
             count = 1;
         }
         Playthrough::Playthrough_Repeat(excludedLocations, enabledTricks, count);

--- a/soh/soh/Enhancements/randomizer/3drando/random.hpp
+++ b/soh/soh/Enhancements/randomizer/3drando/random.hpp
@@ -13,7 +13,7 @@ double RandomDouble();
 
 // Get a random element from a vector or array
 template <typename T> T RandomElement(std::vector<T>& vector, bool erase) {
-    const auto idx = Random(0, vector.size());
+    const auto idx = Random(0, static_cast<uint32_t>(vector.size()));
     const T selected = vector[idx];
     if (erase) {
         vector.erase(vector.begin() + idx);

--- a/soh/soh/Enhancements/randomizer/3drando/shops.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/shops.cpp
@@ -115,7 +115,7 @@ uint16_t GetPriceFromSettings(Rando::Location* loc, PriceSettingsStruct priceSet
                 if (random < ShopPriceProbability[i]) {
                     // The randomly generated value has surpassed the total probability up to this point, so this is the
                     // generated price i in range [0, 59], output in range [0, 295] in increments of 5
-                    return i * 5;
+                    return static_cast<uint16_t>(i) * 5;
                 }
             }
             return 150;
@@ -196,7 +196,8 @@ uint16_t GetCheapBalancedPrice() {
     double random = RandomDouble();
     for (size_t i = 0; i < CheapPriceProbability.size(); i++) {
         if (random < CheapPriceProbability[i]) {
-            return i * 5; // i in range [0, 19], output in range [0, 95] in increments of 5
+            // i in range [0, 19], output in range [0, 95] in increments of 5
+            return static_cast<uint16_t>(i) * 5;
         }
     }
     return -1;

--- a/soh/soh/Enhancements/randomizer/Plandomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/Plandomizer.cpp
@@ -632,7 +632,7 @@ void PlandomizerLoadSpoilerLog(std::string logFile) {
                     PlandomizerAddToItemList(plandomizerRandoRetrieveItem(RG_SOLD_OUT));
                 }
             }
-        } catch (nlohmann::json::parse_error& e) {
+        } catch (nlohmann::json::parse_error&) {
             Notification::Emit({ .message = "Invalid Spoiler Log Format", .remainingTime = 10.0f });
         }
     }
@@ -967,7 +967,7 @@ void PlandomizerDrawOptions() {
                 }
                 ImGui::TableNextColumn();
 
-                size_t index = 0;
+                int32_t index = 0;
                 PlandoPushImageButtonStyle();
                 for (auto& hash : plandoHash) {
                     ImGui::PushID(index);
@@ -995,7 +995,7 @@ void PlandomizerDrawOptions() {
                     ImGui::PopStyleVar();
                     if (downRet) {
                         if (hash == 0) {
-                            hash = gSeedTextures.size() - 1;
+                            hash = static_cast<int32_t>(gSeedTextures.size()) - 1;
                         } else {
                             hash--;
                         }

--- a/soh/soh/Enhancements/randomizer/ShuffleCows.cpp
+++ b/soh/soh/Enhancements/randomizer/ShuffleCows.cpp
@@ -19,7 +19,7 @@ void EnCow_MoveForRandomizer(EnCow* enCow, PlayState* play) {
         // Move left cow in lon lon tower
         enCow->actor.world.pos.x = -229.0f;
         enCow->actor.world.pos.z = 157.0f;
-        enCow->actor.shape.rot.y = 15783.0f;
+        enCow->actor.shape.rot.y = 15783;
         moved = true;
     } else if (play->sceneNum == SCENE_STABLE && enCow->actor.world.pos.x == -3 && enCow->actor.world.pos.z == -254) {
         // Move right cow in lon lon stable
@@ -39,7 +39,8 @@ void RegisterShuffleCows() {
     COND_VB_SHOULD(VB_GIVE_ITEM_FROM_COW, shouldRegister, {
         EnCow* enCow = va_arg(args, EnCow*);
         CowIdentity cowIdentity = OTRGlobals::Instance->gRandomizer->IdentifyCow(
-            gPlayState->sceneNum, enCow->actor.world.pos.x, enCow->actor.world.pos.z);
+            gPlayState->sceneNum, static_cast<int32_t>(enCow->actor.world.pos.x),
+            static_cast<int32_t>(enCow->actor.world.pos.z));
         // Has this cow already rewarded an item?
         if (!Flags_GetRandomizerInf(cowIdentity.randomizerInf)) {
             Flags_SetRandomizerInf(cowIdentity.randomizerInf);

--- a/soh/soh/Enhancements/randomizer/ShuffleCrates.cpp
+++ b/soh/soh/Enhancements/randomizer/ShuffleCrates.cpp
@@ -3,6 +3,7 @@
 #include "static_data.h"
 #include <libultraship/libultra.h>
 #include "global.h"
+#include "soh/ResourceManagerHelpers.h"
 
 extern "C" {
 #include "variables.h"
@@ -11,7 +12,6 @@ extern "C" {
 #include "overlays/actors/ovl_Obj_Kibako/z_obj_kibako.h"
 #include "objects/gameplay_dangeon_keep/gameplay_dangeon_keep.h"
 #include "soh/Enhancements/enhancementTypes.h"
-#include "soh/ResourceManagerHelpers.h"
 extern PlayState* gPlayState;
 }
 
@@ -195,7 +195,7 @@ void ObjKibako2_RandomizerSpawnCollectible(ObjKibako2* crateActor, PlayState* pl
     item00->actor.draw = (ActorFunc)EnItem00_DrawRandomizedItem;
     item00->actor.velocity.y = 8.0f;
     item00->actor.speedXZ = 2.0f;
-    item00->actor.world.rot.y = Rand_CenteredFloat(65536.0f);
+    item00->actor.world.rot.y = static_cast<int16_t>(Rand_CenteredFloat(65536.0f));
 }
 
 void ObjKibako_RandomizerSpawnCollectible(ObjKibako* smallCrateActor, PlayState* play) {
@@ -206,7 +206,7 @@ void ObjKibako_RandomizerSpawnCollectible(ObjKibako* smallCrateActor, PlayState*
     item00->actor.draw = (ActorFunc)EnItem00_DrawRandomizedItem;
     item00->actor.velocity.y = 8.0f;
     item00->actor.speedXZ = 2.0f;
-    item00->actor.world.rot.y = Rand_CenteredFloat(65536.0f);
+    item00->actor.world.rot.y = static_cast<int16_t>(Rand_CenteredFloat(65536.0f));
 }
 
 void ObjKibako2_RandomizerInit(void* actorRef) {

--- a/soh/soh/Enhancements/randomizer/ShuffleGrass.cpp
+++ b/soh/soh/Enhancements/randomizer/ShuffleGrass.cpp
@@ -117,7 +117,7 @@ void EnKusa_RandomizerSpawnCollectible(EnKusa* grassActor, PlayState* play) {
     item00->actor.draw = (ActorFunc)EnItem00_DrawRandomizedItem;
     item00->actor.velocity.y = 8.0f;
     item00->actor.speedXZ = 2.0f;
-    item00->actor.world.rot.y = Rand_CenteredFloat(65536.0f);
+    item00->actor.world.rot.y = static_cast<int16_t>(Rand_CenteredFloat(65536.0f));
 }
 
 void EnKusa_RandomizerInit(void* actorRef) {

--- a/soh/soh/Enhancements/randomizer/ShufflePots.cpp
+++ b/soh/soh/Enhancements/randomizer/ShufflePots.cpp
@@ -48,7 +48,7 @@ void ObjTsubo_RandomizerSpawnCollectible(ObjTsubo* potActor, PlayState* play) {
     item00->actor.draw = (ActorFunc)EnItem00_DrawRandomizedItem;
     item00->actor.velocity.y = 8.0f;
     item00->actor.speedXZ = 2.0f;
-    item00->actor.world.rot.y = Rand_CenteredFloat(65536.0f);
+    item00->actor.world.rot.y = static_cast<int16_t>(Rand_CenteredFloat(65536.0f));
 }
 
 void ObjTsubo_RandomizerInit(void* actorRef) {

--- a/soh/soh/Enhancements/randomizer/draw.cpp
+++ b/soh/soh/Enhancements/randomizer/draw.cpp
@@ -597,7 +597,7 @@ extern "C" s32 OverrideLimbDrawBarinade(PlayState* play, s32 limbIndex, Gfx** dL
                    (uintptr_t)Gfx_TwoTexScroll(play->state.gfxCtx, 0, 0, 0, 8, 16, 1, 0,
                                                (play->gameplayFrames * -2) % 64, 16, 16));
         gDPSetEnvColor(POLY_OPA_DISP++, 0, 0, 0, 200);
-        Matrix_RotateX(static_cast<float>(-M_PI / 2), MTXMODE_APPLY);
+        Matrix_RotateX(-M_PIf / 2.0f, MTXMODE_APPLY);
     } else if ((limbIndex >= 10) && (limbIndex < 20)) {
         rot->x -= 0x4000;
         *dList = NULL;
@@ -1126,8 +1126,8 @@ extern "C" void Randomizer_DrawFishingPoleGI(PlayState* play, GetItemEntry* getI
     Matrix_Scale(5.0f, 5.0f, 5.0f, MTXMODE_APPLY);
     pos = { 0.0f, -25.5f, -4.0f };
     Matrix_Translate(pos.x, pos.y, pos.z, MTXMODE_APPLY);
-    Matrix_RotateZ(static_cast<float>(-M_PI_2), MTXMODE_APPLY);
-    Matrix_RotateY(static_cast<float>(-M_PI_2) - 0.2f, MTXMODE_APPLY);
+    Matrix_RotateZ(-M_PI_2f, MTXMODE_APPLY);
+    Matrix_RotateY(-M_PI_2f - 0.2f, MTXMODE_APPLY);
     Matrix_Scale(0.006f, 0.006f, 0.006f, MTXMODE_APPLY);
     Gfx_SetupDL_25Opa(play->state.gfxCtx);
     gSPMatrix(POLY_OPA_DISP++, Matrix_NewMtx(play->state.gfxCtx, (char*)__FILE__, __LINE__),
@@ -1140,7 +1140,7 @@ extern "C" void Randomizer_DrawFishingPoleGI(PlayState* play, GetItemEntry* getI
     gSPMatrix(POLY_OPA_DISP++, Matrix_NewMtx(play->state.gfxCtx, (char*)__FILE__, __LINE__),
               G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
     gSPDisplayList(POLY_OPA_DISP++, (Gfx*)gFishingLureHookDL);
-    Matrix_RotateZ(static_cast<float>(M_PI_2), MTXMODE_APPLY);
+    Matrix_RotateZ(M_PI_2f, MTXMODE_APPLY);
     gSPMatrix(POLY_OPA_DISP++, Matrix_NewMtx(play->state.gfxCtx, (char*)__FILE__, __LINE__),
               G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
     gSPDisplayList(POLY_OPA_DISP++, (Gfx*)gFishingLureHookDL);
@@ -1149,7 +1149,7 @@ extern "C" void Randomizer_DrawFishingPoleGI(PlayState* play, GetItemEntry* getI
     gSPMatrix(POLY_OPA_DISP++, Matrix_NewMtx(play->state.gfxCtx, (char*)__FILE__, __LINE__),
               G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
     gSPDisplayList(POLY_OPA_DISP++, (Gfx*)gFishingLureHookDL);
-    Matrix_RotateZ(static_cast<float>(M_PI / 2), MTXMODE_APPLY);
+    Matrix_RotateZ(M_PIf / 2.0f, MTXMODE_APPLY);
     gSPMatrix(POLY_OPA_DISP++, Matrix_NewMtx(play->state.gfxCtx, (char*)__FILE__, __LINE__),
               G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
     gSPDisplayList(POLY_OPA_DISP++, (Gfx*)gFishingLureHookDL);

--- a/soh/soh/Enhancements/randomizer/draw.cpp
+++ b/soh/soh/Enhancements/randomizer/draw.cpp
@@ -597,7 +597,7 @@ extern "C" s32 OverrideLimbDrawBarinade(PlayState* play, s32 limbIndex, Gfx** dL
                    (uintptr_t)Gfx_TwoTexScroll(play->state.gfxCtx, 0, 0, 0, 8, 16, 1, 0,
                                                (play->gameplayFrames * -2) % 64, 16, 16));
         gDPSetEnvColor(POLY_OPA_DISP++, 0, 0, 0, 200);
-        Matrix_RotateX(-M_PI / 2, MTXMODE_APPLY);
+        Matrix_RotateX(static_cast<float>(-M_PI / 2), MTXMODE_APPLY);
     } else if ((limbIndex >= 10) && (limbIndex < 20)) {
         rot->x -= 0x4000;
         *dList = NULL;
@@ -1097,7 +1097,7 @@ extern "C" void Randomizer_DrawBronzeScale(PlayState* play, GetItemEntry* getIte
     gSPSegment(POLY_XLU_DISP++, 0x08,
                (uintptr_t)Gfx_TwoTexScroll(play->state.gfxCtx, 0, 1 * (play->state.frames * 2),
                                            -1 * (play->state.frames * 2), 64, 64, 1, 1 * (play->state.frames * 4),
-                                           1 * -(play->state.frames * 4), 32, 32));
+                                           -1 * (play->state.frames * 4), 32, 32));
 
     gSPMatrix(POLY_XLU_DISP++, Matrix_NewMtx(play->state.gfxCtx, (char*)__FILE__, __LINE__),
               G_MTX_MODELVIEW | G_MTX_LOAD);
@@ -1116,7 +1116,7 @@ extern "C" void Randomizer_DrawFishingPoleGI(PlayState* play, GetItemEntry* getI
 
     // Draw rod
     Gfx_SetupDL_25Opa(play->state.gfxCtx);
-    Matrix_Scale(0.2, 0.2, 0.2, MTXMODE_APPLY);
+    Matrix_Scale(0.2f, 0.2f, 0.2f, MTXMODE_APPLY);
     gSPMatrix(POLY_OPA_DISP++, Matrix_NewMtx(play->state.gfxCtx, (char*)__FILE__, __LINE__),
               G_MTX_MODELVIEW | G_MTX_LOAD);
     gSPDisplayList(POLY_OPA_DISP++, (Gfx*)gFishingPoleGiDL);
@@ -1126,8 +1126,8 @@ extern "C" void Randomizer_DrawFishingPoleGI(PlayState* play, GetItemEntry* getI
     Matrix_Scale(5.0f, 5.0f, 5.0f, MTXMODE_APPLY);
     pos = { 0.0f, -25.5f, -4.0f };
     Matrix_Translate(pos.x, pos.y, pos.z, MTXMODE_APPLY);
-    Matrix_RotateZ(-M_PI_2, MTXMODE_APPLY);
-    Matrix_RotateY(-M_PI_2 - 0.2f, MTXMODE_APPLY);
+    Matrix_RotateZ(static_cast<float>(-M_PI_2), MTXMODE_APPLY);
+    Matrix_RotateY(static_cast<float>(-M_PI_2) - 0.2f, MTXMODE_APPLY);
     Matrix_Scale(0.006f, 0.006f, 0.006f, MTXMODE_APPLY);
     Gfx_SetupDL_25Opa(play->state.gfxCtx);
     gSPMatrix(POLY_OPA_DISP++, Matrix_NewMtx(play->state.gfxCtx, (char*)__FILE__, __LINE__),
@@ -1140,7 +1140,7 @@ extern "C" void Randomizer_DrawFishingPoleGI(PlayState* play, GetItemEntry* getI
     gSPMatrix(POLY_OPA_DISP++, Matrix_NewMtx(play->state.gfxCtx, (char*)__FILE__, __LINE__),
               G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
     gSPDisplayList(POLY_OPA_DISP++, (Gfx*)gFishingLureHookDL);
-    Matrix_RotateZ(M_PI_2, MTXMODE_APPLY);
+    Matrix_RotateZ(static_cast<float>(M_PI_2), MTXMODE_APPLY);
     gSPMatrix(POLY_OPA_DISP++, Matrix_NewMtx(play->state.gfxCtx, (char*)__FILE__, __LINE__),
               G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
     gSPDisplayList(POLY_OPA_DISP++, (Gfx*)gFishingLureHookDL);
@@ -1149,7 +1149,7 @@ extern "C" void Randomizer_DrawFishingPoleGI(PlayState* play, GetItemEntry* getI
     gSPMatrix(POLY_OPA_DISP++, Matrix_NewMtx(play->state.gfxCtx, (char*)__FILE__, __LINE__),
               G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
     gSPDisplayList(POLY_OPA_DISP++, (Gfx*)gFishingLureHookDL);
-    Matrix_RotateZ(M_PI / 2, MTXMODE_APPLY);
+    Matrix_RotateZ(static_cast<float>(M_PI / 2), MTXMODE_APPLY);
     gSPMatrix(POLY_OPA_DISP++, Matrix_NewMtx(play->state.gfxCtx, (char*)__FILE__, __LINE__),
               G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
     gSPDisplayList(POLY_OPA_DISP++, (Gfx*)gFishingLureHookDL);

--- a/soh/soh/Enhancements/randomizer/hint.cpp
+++ b/soh/soh/Enhancements/randomizer/hint.cpp
@@ -226,7 +226,8 @@ uint8_t Hint::GetNumberOfMessages() const {
     if (numMessages == 0) {
         numMessages = 1; // RANDOTODO make std::max actually fucking work for 3 arguments
     }
-    return numMessages;
+    // RANDOTODO will number of messages always be u8?
+    return static_cast<uint8_t>(numMessages);
 }
 
 const std::vector<std::string> Hint::GetAllMessageStrings(MessageFormat format) const {

--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -1013,7 +1013,7 @@ void RandomizerOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_l
                     if (item00->itemEntry.getItemId == GI_SWORD_BGS) {
                         gSaveContext.bgsFlag = true;
                     }
-                    Item_Give(gPlayState, item00->itemEntry.itemId);
+                    Item_Give(gPlayState, static_cast<uint8_t>(item00->itemEntry.itemId));
                 } else if (item00->itemEntry.modIndex == MOD_RANDOMIZER) {
                     if (item00->itemEntry.getItemId == RG_ICE_TRAP) {
                         gSaveContext.ship.pendingIceTrapCount++;
@@ -2137,23 +2137,23 @@ void RandomizerOnActorInitHandler(void* actorRef) {
 
 void RandomizerOnGameFrameUpdateHandler() {
     if (Flags_GetRandomizerInf(RAND_INF_HAS_INFINITE_QUIVER)) {
-        AMMO(ITEM_BOW) = CUR_CAPACITY(UPG_QUIVER);
+        AMMO(ITEM_BOW) = static_cast<int8_t>(CUR_CAPACITY(UPG_QUIVER));
     }
 
     if (Flags_GetRandomizerInf(RAND_INF_HAS_INFINITE_BOMB_BAG)) {
-        AMMO(ITEM_BOMB) = CUR_CAPACITY(UPG_BOMB_BAG);
+        AMMO(ITEM_BOMB) = static_cast<int8_t>(CUR_CAPACITY(UPG_BOMB_BAG));
     }
 
     if (Flags_GetRandomizerInf(RAND_INF_HAS_INFINITE_BULLET_BAG)) {
-        AMMO(ITEM_SLINGSHOT) = CUR_CAPACITY(UPG_BULLET_BAG);
+        AMMO(ITEM_SLINGSHOT) = static_cast<int8_t>(CUR_CAPACITY(UPG_BULLET_BAG));
     }
 
     if (Flags_GetRandomizerInf(RAND_INF_HAS_INFINITE_STICK_UPGRADE)) {
-        AMMO(ITEM_STICK) = CUR_CAPACITY(UPG_STICKS);
+        AMMO(ITEM_STICK) = static_cast<int8_t>(CUR_CAPACITY(UPG_STICKS));
     }
 
     if (Flags_GetRandomizerInf(RAND_INF_HAS_INFINITE_NUT_UPGRADE)) {
-        AMMO(ITEM_NUT) = CUR_CAPACITY(UPG_NUTS);
+        AMMO(ITEM_NUT) = static_cast<int8_t>(CUR_CAPACITY(UPG_NUTS));
     }
 
     if (Flags_GetRandomizerInf(RAND_INF_HAS_INFINITE_MAGIC_METER)) {
@@ -2165,7 +2165,7 @@ void RandomizerOnGameFrameUpdateHandler() {
     }
 
     if (Flags_GetRandomizerInf(RAND_INF_HAS_INFINITE_MONEY)) {
-        gSaveContext.rupees = CUR_CAPACITY(UPG_WALLET);
+        gSaveContext.rupees = static_cast<int8_t>(CUR_CAPACITY(UPG_WALLET));
     }
 
     if (!Flags_GetRandomizerInf(RAND_INF_HAS_WALLET)) {

--- a/soh/soh/Enhancements/randomizer/logic.cpp
+++ b/soh/soh/Enhancements/randomizer/logic.cpp
@@ -1814,7 +1814,7 @@ void Logic::ApplyItemEffect(Item& item, bool state) {
                     if (randoGet == RG_BOTTLE_WITH_BIG_POE) {
                         BigPoes++;
                     }
-                    mSaveContext->inventory.items[slot] = itemId;
+                    mSaveContext->inventory.items[slot] = static_cast<uint8_t>(itemId);
                 } break;
                 case RG_RUTOS_LETTER:
                     SetRandoInf(RAND_INF_OBTAINED_RUTOS_LETTER, state);
@@ -2306,7 +2306,7 @@ void Logic::SetEventChkInf(int32_t flag, bool state) {
 }
 
 uint8_t Logic::GetGSCount() {
-    return mSaveContext->inventory.gsTokens;
+    return static_cast<uint8_t>(mSaveContext->inventory.gsTokens);
 }
 
 uint8_t Logic::GetAmmo(uint32_t item) {

--- a/soh/soh/Enhancements/randomizer/option.cpp
+++ b/soh/soh/Enhancements/randomizer/option.cpp
@@ -83,11 +83,11 @@ void Option::RestoreDelayedOption() {
     contextSelection = delayedSelection;
 }
 
-void Option::SetContextIndex(size_t idx) {
+void Option::SetContextIndex(uint8_t idx) {
     // TODO: Set to Context's OptionValue array.
     contextSelection = idx;
-    if (contextSelection > options.size() - 1) {
-        contextSelection = options.size() - 1;
+    if (contextSelection > static_cast<uint8_t>(options.size() - 1)) {
+        contextSelection = static_cast<uint8_t>(options.size() - 1);
     }
 }
 
@@ -105,7 +105,7 @@ bool Option::IsHidden() const {
 
 void Option::ChangeOptions(std::vector<std::string> opts) {
     if (GetOptionIndex() >= opts.size()) {
-        CVarSetInteger(cvarName.c_str(), opts.size() - 1);
+        CVarSetInteger(cvarName.c_str(), static_cast<uint8_t>(opts.size() - 1));
     }
     options = std::move(opts);
 }
@@ -206,8 +206,8 @@ bool Option::RenderCheckbox() {
 bool Option::RenderCombobox() {
     bool changed = false;
     uint8_t selected = CVarGetInteger(cvarName.c_str(), defaultOption);
-    if (selected >= options.size()) {
-        selected = options.size();
+    if (selected >= static_cast<uint8_t>(options.size())) {
+        selected = static_cast<uint8_t>(options.size());
         CVarSetInteger(cvarName.c_str(), selected);
         changed = true;
         Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
@@ -231,13 +231,13 @@ bool Option::RenderSlider() {
     bool changed = false;
     int val = CVarGetInteger(cvarName.c_str(), defaultOption);
     if (val > options.size() - 1) {
-        val = options.size() - 1;
+        val = static_cast<int>(options.size()) - 1;
         changed = true;
     }
     UIWidgets::IntSliderOptions widgetOptions = UIWidgets::IntSliderOptions()
                                                     .Color(THEME_COLOR)
                                                     .Min(0)
-                                                    .Max(options.size() - 1)
+                                                    .Max(static_cast<uint8_t>(options.size() - 1))
                                                     .Tooltip(description.c_str())
                                                     .Format(options[val].c_str())
                                                     .DefaultValue(defaultOption);

--- a/soh/soh/Enhancements/randomizer/option.h
+++ b/soh/soh/Enhancements/randomizer/option.h
@@ -241,11 +241,11 @@ class Option {
     void RestoreDelayedOption();
 
     /**
-     * @brief Set the rando context index for this Option. Also calls `SetVariable()`.
+     * @brief Set the rando context index for this Option.
      *
      * @param idx the index to set as the selected index.
      */
-    void SetContextIndex(size_t idx);
+    void SetContextIndex(uint8_t idx);
 
     /**
      * @brief Hides this Option in the menu. (Not currently being used afaik, we prefer to

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -357,9 +357,12 @@ std::unordered_map<s16, s16> getItemIdToItemId = {
     { GI_CLAIM_CHECK, ITEM_CLAIM_CHECK },
 };
 
+#ifdef _MSC_VER
 #pragma optimize("", off)
+#else
 #pragma GCC push_options
 #pragma GCC optimize("O0")
+#endif
 bool Randomizer::SpoilerFileExists(const char* spoilerFileName) {
     if (strcmp(spoilerFileName, "") != 0) {
         std::ifstream spoilerFileStream(SohUtils::Sanitize(spoilerFileName));
@@ -372,8 +375,11 @@ bool Randomizer::SpoilerFileExists(const char* spoilerFileName) {
 
     return false;
 }
-#pragma GCC pop_options
+#ifdef _MSC_VER
 #pragma optimize("", on)
+#else
+#pragma GCC pop_options
+#endif
 
 void Randomizer::LoadHintMessages() {
     auto ctx = Rando::Context::GetInstance();
@@ -3506,9 +3512,9 @@ CrateIdentity Randomizer::IdentifyCrate(s32 sceneNum, s32 posX, s32 posZ) {
         crateSceneNum = SCENE_MARKET_DAY;
     } else if (sceneNum == SCENE_GERUDOS_FORTRESS && gPlayState->linkAgeOnLoad == 1 && posX == 310) {
         if (posZ == -1830) {
-            posZ = -1842.0f;
+            posZ = -1842;
         } else if (posZ == -1770) {
-            posZ = -1782.0f;
+            posZ = -1782;
         }
     }
 
@@ -4100,7 +4106,7 @@ void RandomizerSettingsWindow::DrawElement() {
                     Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
                 }
             }
-            if (ImGui::BeginTable("trickTags", showTag.size(),
+            if (ImGui::BeginTable("trickTags", static_cast<int>(showTag.size()),
                                   ImGuiTableFlags_Resizable | ImGuiTableFlags_NoSavedSettings |
                                       ImGuiTableFlags_Borders)) {
                 for (auto [rtTag, isShown] : showTag) {
@@ -5572,7 +5578,7 @@ void RandomizerSettingsWindow::InitElement() {
 // (special cases for rando items)
 void Randomizer_GameplayStats_SetTimestamp(uint16_t item) {
 
-    u32 time = GAMEPLAYSTAT_TOTAL_TIME;
+    u32 time = static_cast<u32>(GAMEPLAYSTAT_TOTAL_TIME);
 
     // Have items in Link's pocket shown as being obtained at 0.1 seconds
     if (time == 0) {
@@ -5868,7 +5874,7 @@ extern "C" u16 Randomizer_Item_Give(PlayState* play, GetItemEntry giEntry) {
         case RG_GREG_RUPEE:
             Rupees_ChangeBy(1);
             Flags_SetRandomizerInf(RAND_INF_GREG_FOUND);
-            gSaveContext.ship.stats.itemTimestamp[TIMESTAMP_FOUND_GREG] = GAMEPLAYSTAT_TOTAL_TIME;
+            gSaveContext.ship.stats.itemTimestamp[TIMESTAMP_FOUND_GREG] = static_cast<u32>(GAMEPLAYSTAT_TOTAL_TIME);
             break;
         case RG_TRIFORCE_PIECE:
             gSaveContext.ship.quest.data.randomizer.triforcePiecesCollected++;
@@ -5877,7 +5883,8 @@ extern "C" u16 Randomizer_Item_Give(PlayState* play, GetItemEntry giEntry) {
             // Teleport to credits when goal is reached.
             if (gSaveContext.ship.quest.data.randomizer.triforcePiecesCollected ==
                 (OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_TRIFORCE_HUNT_PIECES_REQUIRED) + 1)) {
-                gSaveContext.ship.stats.itemTimestamp[TIMESTAMP_TRIFORCE_COMPLETED] = GAMEPLAYSTAT_TOTAL_TIME;
+                gSaveContext.ship.stats.itemTimestamp[TIMESTAMP_TRIFORCE_COMPLETED] =
+                    static_cast<u32>(GAMEPLAYSTAT_TOTAL_TIME);
                 gSaveContext.ship.stats.gameComplete = 1;
                 Flags_SetRandomizerInf(RAND_INF_GRANT_GANONS_BOSSKEY);
                 Play_PerformSave(play);
@@ -5910,12 +5917,12 @@ extern "C" u16 Randomizer_Item_Give(PlayState* play, GetItemEntry giEntry) {
         case RG_DEKU_STICK_BAG:
             Inventory_ChangeUpgrade(UPG_STICKS, 1);
             INV_CONTENT(ITEM_STICK) = ITEM_STICK;
-            AMMO(ITEM_STICK) = CUR_CAPACITY(UPG_STICKS);
+            AMMO(ITEM_STICK) = static_cast<int8_t>(CUR_CAPACITY(UPG_STICKS));
             break;
         case RG_DEKU_NUT_BAG:
             Inventory_ChangeUpgrade(UPG_NUTS, 1);
             INV_CONTENT(ITEM_NUT) = ITEM_NUT;
-            AMMO(ITEM_NUT) = CUR_CAPACITY(UPG_NUTS);
+            AMMO(ITEM_NUT) = static_cast<int8_t>(CUR_CAPACITY(UPG_NUTS));
             break;
         default:
             LUSLOG_WARN("Randomizer_Item_Give didn't have behaviour specified for getItemId=%d", item);

--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -1892,16 +1892,16 @@ static std::set<std::string> rainbowCVars = {
 
 int hue = 0;
 void RainbowTick() {
-    float freqHue = hue * 2 * M_PI / (360 * CVarGetFloat(CVAR_COSMETIC("RainbowSpeed"), 0.6f));
+    float freqHue = hue * 2 * static_cast<float>(M_PI) / (360 * CVarGetFloat(CVAR_COSMETIC("RainbowSpeed"), 0.6f));
     for (auto& cvar : rainbowCVars) {
         if (CVarGetInteger((cvar + ".Rainbow").c_str(), 0) == 0) {
             continue;
         }
 
         Color_RGBA8 newColor;
-        newColor.r = sin(freqHue + 0) * 127 + 128;
-        newColor.g = sin(freqHue + (2 * M_PI / 3)) * 127 + 128;
-        newColor.b = sin(freqHue + (4 * M_PI / 3)) * 127 + 128;
+        newColor.r = static_cast<uint8_t>(sin(freqHue + 0) * 127) + 128;
+        newColor.g = static_cast<uint8_t>(sin(freqHue + (2 * M_PI / 3)) * 127) + 128;
+        newColor.b = static_cast<uint8_t>(sin(freqHue + (4 * M_PI / 3)) * 127) + 128;
         newColor.a = 255;
 
         CVarSetColor((cvar + ".Value").c_str(), newColor);

--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -1892,7 +1892,7 @@ static std::set<std::string> rainbowCVars = {
 
 int hue = 0;
 void RainbowTick() {
-    float freqHue = hue * 2 * static_cast<float>(M_PI) / (360 * CVarGetFloat(CVAR_COSMETIC("RainbowSpeed"), 0.6f));
+    float freqHue = hue * 2 * M_PIf / (360 * CVarGetFloat(CVAR_COSMETIC("RainbowSpeed"), 0.6f));
     for (auto& cvar : rainbowCVars) {
         if (CVarGetInteger((cvar + ".Rainbow").c_str(), 0) == 0) {
             continue;

--- a/soh/soh/Enhancements/randomizer/randomizer_entrance_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_entrance_tracker.cpp
@@ -382,7 +382,7 @@ const EntranceData entranceData[] = {
 };
 
 // Check if Link is in the area and return that scene/entrance for tracking
-s8 LinkIsInArea(const EntranceData* entrance) {
+int16_t LinkIsInArea(const EntranceData* entrance) {
     bool result = false;
 
     if (gPlayState == nullptr) {

--- a/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
@@ -670,17 +670,17 @@ void DrawItemCount(ItemTrackerItem item, bool hideMax) {
 
 void DrawEquip(ItemTrackerItem item) {
     bool hasEquip = HasEquipment(item);
-    int iconSize = CVarGetInteger(CVAR_TRACKER_ITEM("IconSize"), 36);
+    float iconSize = static_cast<float>(CVarGetInteger(CVAR_TRACKER_ITEM("IconSize"), 36));
     ImGui::Image(Ship::Context::GetInstance()->GetWindow()->GetGui()->GetTextureByName(
                      hasEquip && IsValidSaveFile() ? item.name : item.nameFaded),
-                 ImVec2(iconSize, iconSize), ImVec2(0, 0), ImVec2(1, 1));
+                 ImVec2(iconSize, iconSize), ImVec2(0.0f, 0.0f), ImVec2(1, 1));
 
     Tooltip(SohUtils::GetItemName(item.id).c_str());
 }
 
 void DrawQuest(ItemTrackerItem item) {
     bool hasQuestItem = HasQuestItem(item);
-    int iconSize = CVarGetInteger(CVAR_TRACKER_ITEM("IconSize"), 36);
+    float iconSize = static_cast<float>(CVarGetInteger(CVAR_TRACKER_ITEM("IconSize"), 36));
     ImGui::BeginGroup();
     ImGui::Image(Ship::Context::GetInstance()->GetWindow()->GetGui()->GetTextureByName(
                      hasQuestItem && IsValidSaveFile() ? item.name : item.nameFaded),
@@ -698,7 +698,7 @@ void DrawQuest(ItemTrackerItem item) {
 void DrawItem(ItemTrackerItem item) {
 
     uint32_t actualItemId = GameInteractor::IsSaveLoaded() ? INV_CONTENT(item.id) : ITEM_NONE;
-    int iconSize = CVarGetInteger(CVAR_TRACKER_ITEM("IconSize"), 36);
+    float iconSize = static_cast<float>(CVarGetInteger(CVAR_TRACKER_ITEM("IconSize"), 36));
     bool hasItem = actualItemId != ITEM_NONE;
     std::string itemName = "";
 
@@ -1015,7 +1015,7 @@ void DrawBottle(ItemTrackerItem item) {
         item = actualItemTrackerItemMap[actualItemId];
     }
 
-    int iconSize = CVarGetInteger(CVAR_TRACKER_ITEM("IconSize"), 36);
+    float iconSize = static_cast<float>(CVarGetInteger(CVAR_TRACKER_ITEM("IconSize"), 36));
     ImGui::Image(Ship::Context::GetInstance()->GetWindow()->GetGui()->GetTextureByName(
                      hasItem && IsValidSaveFile() ? item.name : item.nameFaded),
                  ImVec2(iconSize, iconSize), ImVec2(0, 0), ImVec2(1, 1));
@@ -1027,7 +1027,7 @@ void DrawDungeonItem(ItemTrackerItem item) {
     uint32_t itemId = item.id;
     ImU32 dungeonColor = IM_COL_WHITE;
     uint32_t bitMask = 1 << (item.id - ITEM_KEY_BOSS); // Bitset starts at ITEM_KEY_BOSS == 0. the rest are sequential
-    int iconSize = CVarGetInteger(CVAR_TRACKER_ITEM("IconSize"), 36);
+    float iconSize = static_cast<float>(CVarGetInteger(CVAR_TRACKER_ITEM("IconSize"), 36));
     bool hasItem = GameInteractor::IsSaveLoaded() ? (bitMask & gSaveContext.inventory.dungeonItems[item.data]) : false;
     bool hasSmallKey = GameInteractor::IsSaveLoaded() ? ((gSaveContext.inventory.dungeonKeys[item.data]) >= 0) : false;
     ImGui::BeginGroup();
@@ -1078,19 +1078,19 @@ void DrawDungeonItem(ItemTrackerItem item) {
 }
 
 void DrawSong(ItemTrackerItem item) {
-    int iconSize = CVarGetInteger(CVAR_TRACKER_ITEM("IconSize"), 36);
+    float iconSize = static_cast<float>(CVarGetInteger(CVAR_TRACKER_ITEM("IconSize"), 36));
     ImVec2 p = ImGui::GetCursorScreenPos();
     bool hasSong = HasSong(item);
     ImGui::SetCursorScreenPos(ImVec2(p.x + 6, p.y));
     ImGui::Image(Ship::Context::GetInstance()->GetWindow()->GetGui()->GetTextureByName(
                      hasSong && IsValidSaveFile() ? item.name : item.nameFaded),
-                 ImVec2(iconSize / 1.5, iconSize), ImVec2(0, 0), ImVec2(1, 1));
+                 ImVec2(iconSize / 1.5f, iconSize), ImVec2(0, 0), ImVec2(1, 1));
     Tooltip(SohUtils::GetQuestItemName(item.id).c_str());
 }
 
 void DrawNotes(bool resizeable = false) {
     ImGui::BeginGroup();
-    int iconSize = CVarGetInteger(CVAR_TRACKER_ITEM("IconSize"), 36);
+    float iconSize = static_cast<float>(CVarGetInteger(CVAR_TRACKER_ITEM("IconSize"), 36));
     int iconSpacing = CVarGetInteger(CVAR_TRACKER_ITEM("IconSpacing"), 12);
 
     struct ItemTrackerNotes {
@@ -1113,7 +1113,7 @@ void DrawNotes(bool resizeable = false) {
         }
     };
     ImVec2 size = resizeable ? ImVec2(-FLT_MIN, ImGui::GetContentRegionAvail().y)
-                             : ImVec2(((iconSize + iconSpacing) * 6) - 8, 200);
+                             : ImVec2(((iconSize + iconSpacing) * 6) - 8.0f, 200.0f);
     if (GameInteractor::IsSaveLoaded()) {
         if (ItemTrackerNotes::TrackerNotesInputTextMultiline("##ItemTrackerNotes", &itemTrackerNotes, size,
                                                              ImGuiInputTextFlags_AllowTabInput)) {
@@ -1185,7 +1185,7 @@ void EndFloatingWindows() {
  * Takes in a vector of ItemTrackerItem and draws them in rows of N items
  */
 void DrawItemsInRows(std::vector<ItemTrackerItem> items, int columns = 6) {
-    int iconSize = CVarGetInteger(CVAR_TRACKER_ITEM("IconSize"), 36);
+    float iconSize = static_cast<float>(CVarGetInteger(CVAR_TRACKER_ITEM("IconSize"), 36));
     int iconSpacing = CVarGetInteger(CVAR_TRACKER_ITEM("IconSpacing"), 12);
     int topPadding =
         (CVarGetInteger(CVAR_TRACKER_ITEM("WindowType"), TRACKER_WINDOW_FLOATING) == TRACKER_WINDOW_WINDOW) ? 20 : 0;
@@ -1194,7 +1194,7 @@ void DrawItemsInRows(std::vector<ItemTrackerItem> items, int columns = 6) {
         int row = i / columns;
         int column = i % columns;
         ImGui::SetCursorPos(
-            ImVec2((column * (iconSize + iconSpacing) + 8), (row * (iconSize + iconSpacing)) + 8 + topPadding));
+            ImVec2((column * (iconSize + iconSpacing) + 8.0f), (row * (iconSize + iconSpacing)) + 8.0f + topPadding));
         items[i].drawFunc(items[i]);
     }
 }
@@ -1208,10 +1208,10 @@ void DrawItemsInACircle(std::vector<ItemTrackerItem> items) {
     int iconSpacing = CVarGetInteger(CVAR_TRACKER_ITEM("IconSpacing"), 12);
 
     ImVec2 max = ImGui::GetWindowContentRegionMax();
-    float radius = (iconSize + iconSpacing) * 2;
+    float radius = (iconSize + iconSpacing) * 2.0f;
 
     for (int i = 0; i < items.size(); i++) {
-        float angle = (float)i / items.size() * 2.0f * M_PI;
+        float angle = static_cast<float>(i / items.size() * 2.0f * M_PI);
         float x = (radius / 2.0f) * cos(angle) + max.x / 2.0f;
         float y = (radius / 2.0f) * sin(angle) + max.y / 2.0f;
         ImGui::SetCursorPos(ImVec2(x - (CVarGetInteger(CVAR_TRACKER_ITEM("IconSize"), 36) - 8) / 2.0f, y + 4));
@@ -1225,14 +1225,12 @@ void DrawItemsInACircle(std::vector<ItemTrackerItem> items) {
  * to then call DrawItemsInRows
  */
 std::vector<ItemTrackerItem> GetDungeonItemsVector(std::vector<ItemTrackerDungeon> dungeons, int columns = 6) {
-    int iconSize = CVarGetInteger(CVAR_TRACKER_ITEM("IconSize"), 36);
-    int iconSpacing = CVarGetInteger(CVAR_TRACKER_ITEM("IconSpacing"), 12);
     std::vector<ItemTrackerItem> dungeonItems = {};
 
     int rowCount = 0;
     for (int i = 0; i < dungeons.size(); i++) {
         if (dungeons[i].items.size() > rowCount)
-            rowCount = dungeons[i].items.size();
+            rowCount = static_cast<int32_t>(dungeons[i].items.size());
     }
 
     for (int i = 0; i < rowCount; i++) {
@@ -1469,7 +1467,7 @@ void ItemTrackerSaveFile(SaveContext* saveContext, int sectionID, bool fullSave)
 void ItemTrackerLoadFile() {
     std::string initialTrackerNotes = "";
     SaveManager::Instance->LoadData("personalNotes", initialTrackerNotes);
-    itemTrackerNotes.resize(initialTrackerNotes.length() + 1);
+    itemTrackerNotes.resize(static_cast<int>(initialTrackerNotes.length() + 1));
     if (initialTrackerNotes != "") {
         SohUtils::CopyStringToCharArray(itemTrackerNotes.Data, initialTrackerNotes.c_str(), itemTrackerNotes.size());
     } else {

--- a/soh/soh/Enhancements/randomizer/savefile.cpp
+++ b/soh/soh/Enhancements/randomizer/savefile.cpp
@@ -22,7 +22,7 @@ void StartingItemGive(GetItemEntry getItemEntry, RandomizerCheck randomizerCheck
         if (getItemEntry.getItemId == GI_SWORD_BGS) {
             gSaveContext.bgsFlag = true;
         }
-        Item_Give(NULL, getItemEntry.itemId);
+        Item_Give(NULL, static_cast<uint8_t>(getItemEntry.itemId));
     } else if (getItemEntry.modIndex == MOD_RANDOMIZER) {
         if (getItemEntry.getItemId == RG_ICE_TRAP) {
             gSaveContext.ship.pendingIceTrapCount++;

--- a/soh/soh/Enhancements/randomizer/settings.cpp
+++ b/soh/soh/Enhancements/randomizer/settings.cpp
@@ -24,7 +24,7 @@ std::vector<std::string> NumOpts(const int min, const int max, const int step = 
 }
 
 std::vector<std::string> MultiVecOpts(const std::vector<std::vector<std::string>>& optionsVector) {
-    uint32_t totalSize = 0;
+    size_t totalSize = 0;
     for (const auto& vector : optionsVector) {
         totalSize += vector.size();
     }
@@ -2638,7 +2638,7 @@ void Context::FinalizeSettings(const std::set<RandomizerCheck>& excludedLocation
                         mqSet += 1;
                         break;
                     case RO_MQ_SET_RANDOM:
-                        randMQOption.push_back(i);
+                        randMQOption.push_back(static_cast<uint8_t>(i));
                         dungeons[i]->SetDungeonKnown(false);
                         break;
                     default:
@@ -2659,7 +2659,7 @@ void Context::FinalizeSettings(const std::set<RandomizerCheck>& excludedLocation
                 // otherwise, make everything a possibility and unknown
             } else {
                 for (size_t i = 0; i < dungeons.size(); i++) {
-                    randMQOption.push_back(i);
+                    randMQOption.push_back(static_cast<uint8_t>(i));
                     dungeons[i]->SetDungeonKnown(false);
                     mOptions[dungeons[i]->GetMQSetting()].Set(RO_MQ_SET_RANDOM);
                 }

--- a/soh/soh/OTRGlobals.h
+++ b/soh/soh/OTRGlobals.h
@@ -15,6 +15,11 @@
 #define BTN_CUSTOM_OCARINA_PITCH_UP ((CONTROLLERBUTTONS_T)0x00400000)
 #define BTN_CUSTOM_OCARINA_PITCH_DOWN ((CONTROLLERBUTTONS_T)0x00800000)
 
+#define M_PIf 3.14159265358979323846f
+#define M_PI_2f 1.57079632679489661923f // pi/2
+#define M_SQRT2f 1.41421356237309504880f
+#define M_SQRT1_2f 0.70710678118654752440f /* 1/sqrt(2) */
+
 #ifdef __cplusplus
 #include <Context.h>
 #include "Enhancements/savestates.h"


### PR DESCRIPTION
Handles virtually all warnings in `soh/Enhancements/randomizer/*`. The only exception is when `boost::hash32` is used, where a warning of conversion from `size_t` to `uint32_t` is raised from within `hash_32.hpp`. Considering my initial attempts to fix didn't work, and we're working towards removing boost anyway, I figured I'd just leave those for now.

Also handles order of operations warning in `FasterHeavyBlockLift`.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3127223618.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3127231262.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3127232157.zip)
<!--- section:artifacts:end -->