### PR TITLE
Exclude build dependencies from clang format

### DIFF
--- a/run-clang-format.ps1
+++ b/run-clang-format.ps1
@@ -39,7 +39,7 @@ $files = Get-ChildItem -Path $basePath\soh -Recurse -File `
     | Where-Object { ($_.Extension -eq '.c' -or $_.Extension -eq '.cpp' -or `
                       (($_.Extension -eq '.h' -or $_.Extension -eq '.hpp') -and `
                        (-not ($_.FullName -like "*\soh\src\*" -or $_.FullName -like "*\soh\include\*")))) -and `
-                     (-not ($_.FullName -like "*\soh\assets\*")) }
+                     (-not ($_.FullName -like "*\soh\assets\*" -or $_.FullName -like "*\soh\build\*")) }
 
 for ($i = 0; $i -lt $files.Length; $i++) {
     $file = $files[$i]


### PR DESCRIPTION
I noticed this was happening, and it was an easy fix. This reduces the number of formatted files from 1720 to 1313.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3136693715.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3136699645.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3136716183.zip)
<!--- section:artifacts:end -->