### PR TITLE
explicitly set c standard to 17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.26.0 FATAL_ERROR)
 
 set(CMAKE_SYSTEM_VERSION 10.0 CACHE STRING "" FORCE)
 set(CMAKE_CXX_STANDARD 20 CACHE STRING "The C++ standard to use")
+set(CMAKE_C_STANDARD 17 CACHE STRING "The C standard to use")
 
 set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "Minimum OS X deployment version")
 

--- a/soh/CMakeLists.txt
+++ b/soh/CMakeLists.txt
@@ -4,6 +4,7 @@ set(CMAKE_SYSTEM_VERSION 10.0 CACHE STRING "" FORCE)
 
 project(soh LANGUAGES C CXX)
 set(CMAKE_CXX_STANDARD 20 CACHE STRING "The C++ standard to use")
+set(CMAKE_C_STANDARD 17 CACHE STRING "The C standard to use")
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     enable_language(OBJCXX)


### PR DESCRIPTION
i was looking into https://github.com/HarbourMasters/Shipwright/pull/5467 and i did a bit of digging.

it seems the gcc15 issues are stemming from 15 [changing the default C version from `gnu17` to `gnu23`](https://gcc.gnu.org/gcc-15/porting_to.html#c23).

we didn't have the c standard explicitly set before, leading to compiler defaults being used.

our CI builds use gcc12 which defaults to c17. i think for consistency in blair it makes sense to fix the gcc15 issue by explicitly setting the c standard to c17.

i ran some test builds using a modified `test-builds-on-distros` workflow (i just removed everything but arch and gcc from it) and was able to get the project to successfully build with this change. 

i do think updating the code to work with the c23 standard is a reasonable thing to do, and i think https://github.com/HarbourMasters/Shipwright/pull/5467 does a great job of it, but  i would prefer we do that in `develop` instead.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3140837872.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3140849665.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3140867638.zip)
<!--- section:artifacts:end -->