### PR TITLE
fix seed gen underflow

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/fill.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/fill.cpp
@@ -712,11 +712,11 @@ static void PareDownPlaythrough() {
     auto ctx = Rando::Context::GetInstance();
     std::vector<RandomizerCheck> toAddBackItem;
     // Start at sphere before Ganon's and count down
-    for (size_t i = ctx->playthroughLocations.size() - 2; i >= 0; i--) {
+    for (int32_t i = static_cast<int32_t>(ctx->playthroughLocations.size()) - 2; i >= 0; i--) {
         // Check each item location in sphere
         std::vector<int> erasableIndices;
         std::vector<RandomizerCheck> sphere = ctx->playthroughLocations.at(i);
-        for (size_t j = sphere.size() - 1; j >= 0; j--) {
+        for (int32_t j = static_cast<int32_t>(sphere.size()) - 1; j >= 0; j--) {
             RandomizerCheck loc = sphere.at(j);
             RandomizerGet locGet = ctx->GetItemLocation(loc)->GetPlacedRandomizerGet(); // Copy out item
 


### PR DESCRIPTION
https://github.com/HarbourMasters/Shipwright/pull/5486 changed a couple for loops in `PareDownPlaythrough` to use an unsigned `size_t` instead of a signed `int`. these loops iterate backwards (using `i--` and `j--`), and rely on checking `i >= 0`/`j >= 0`. switching to signed caused these to underflow.

those loops have been around unchanged forever (followed the blame back to https://github.com/HarbourMasters/Shipwright/pull/416) - and i'm not sure why exactly they rely on iterating backwards but i didn't want to touch it when making this fix.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3143884688.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3143888867.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3143895360.zip)
<!--- section:artifacts:end -->