### PR TITLE
fix incorrect `__VA_ARGS__` use in `lusprintf` version of `osSyncPrintf`

### DIFF
--- a/soh/include/functions.h
+++ b/soh/include/functions.h
@@ -15,7 +15,7 @@ extern "C"
 #include <soh/Enhancements/randomizer/randomizer_inf.h>
 
 // #if defined(INCLUDE_GAME_PRINTF) && defined(_DEBUG)
-#define osSyncPrintf(fmt, ...) lusprintf(__FILE__, __LINE__, 0, fmt, __VA_ARGS__)
+#define osSyncPrintf(fmt, ...) lusprintf(__FILE__, __LINE__, 0, fmt, ##__VA_ARGS__)
 // #else
 // #define osSyncPrintf(fmt, ...) osSyncPrintfUnused(fmt, ##__VA_ARGS__)
 // #endif

--- a/soh/include/functions.h
+++ b/soh/include/functions.h
@@ -14,11 +14,11 @@ extern "C"
 #include <soh/Enhancements/item-tables/ItemTableTypes.h>
 #include <soh/Enhancements/randomizer/randomizer_inf.h>
 
-// #if defined(INCLUDE_GAME_PRINTF) && defined(_DEBUG)
+#if defined(INCLUDE_GAME_PRINTF) && defined(_DEBUG)
 #define osSyncPrintf(fmt, ...) lusprintf(__FILE__, __LINE__, 0, fmt, ##__VA_ARGS__)
-// #else
-// #define osSyncPrintf(fmt, ...) osSyncPrintfUnused(fmt, ##__VA_ARGS__)
-// #endif
+#else
+#define osSyncPrintf(fmt, ...) osSyncPrintfUnused(fmt, ##__VA_ARGS__)
+#endif
 
 void gSPSegment(void* value, int segNum, uintptr_t target);
 void gSPSegmentLoadRes(void* value, int segNum, uintptr_t target);

--- a/soh/include/functions.h
+++ b/soh/include/functions.h
@@ -14,11 +14,11 @@ extern "C"
 #include <soh/Enhancements/item-tables/ItemTableTypes.h>
 #include <soh/Enhancements/randomizer/randomizer_inf.h>
 
-#if defined(INCLUDE_GAME_PRINTF) && defined(_DEBUG)
+// #if defined(INCLUDE_GAME_PRINTF) && defined(_DEBUG)
 #define osSyncPrintf(fmt, ...) lusprintf(__FILE__, __LINE__, 0, fmt, __VA_ARGS__)
-#else
-#define osSyncPrintf(fmt, ...) osSyncPrintfUnused(fmt, ##__VA_ARGS__)
-#endif
+// #else
+// #define osSyncPrintf(fmt, ...) osSyncPrintfUnused(fmt, ##__VA_ARGS__)
+// #endif
 
 void gSPSegment(void* value, int segNum, uintptr_t target);
 void gSPSegmentLoadRes(void* value, int segNum, uintptr_t target);


### PR DESCRIPTION
what this PR does:

* https://github.com/HarbourMasters/Shipwright/pull/5510/commits/188121c2e4509323a39f7286a80d8f19f05a5a65
  * commented out conditionals around the `lusprintf` definition of `osSyncPrintf` to get CI to fail
* https://github.com/HarbourMasters/Shipwright/pull/5510/commits/d580a6e138ab82f310edb2905f9903c06e0c7cc2
  * applied fix (used `##__VA_ARGS__` instead of just `__VA_ARGS__` - see https://gcc.gnu.org/onlinedocs/cpp/Variadic-Macros.html for details) to see CI pass with conditionals removed
* https://github.com/HarbourMasters/Shipwright/pull/5510/commits/541b0c38d3ce9182c3a9b03e2756896b2b85d7e9
  * restore conditionals so this is ready to merge

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3146095390.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3146101450.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3146103954.zip)
<!--- section:artifacts:end -->