### PR TITLE
allow all connected controllers to be used for menu nav

### DIFF
--- a/soh/soh/SohGui/Menu.cpp
+++ b/soh/soh/SohGui/Menu.cpp
@@ -9,6 +9,7 @@
 #include <spdlog/fmt/fmt.h>
 #include "variables.h"
 #include <tuple>
+#include "imgui_impl_sdl2.h"
 
 extern "C" {
 #include "z64.h"
@@ -120,6 +121,7 @@ UIWidgets::Colors Menu::GetMenuThemeColor() {
 Menu::Menu(const std::string& cVar, const std::string& name, uint8_t searchSidebarIndex_,
            UIWidgets::Colors defaultThemeIndex_)
     : GuiWindow(cVar, name), searchSidebarIndex(searchSidebarIndex_), defaultThemeIndex(defaultThemeIndex_) {
+    ImGui_ImplSDL2_SetGamepadMode(ImGui_ImplSDL2_GamepadMode::ImGui_ImplSDL2_GamepadMode_AutoAll);
 }
 
 void Menu::InitElement() {


### PR DESCRIPTION
helps https://github.com/HarbourMasters/Shipwright/issues/5437 (edit: imgui still isn't picking controllers back up on reconnect, moved to draft, i'll keep digging) (edit2: more context on the disconnect/reconnect thing https://github.com/Kenix3/libultraship/issues/885#issuecomment-2888858374)



i'd like to address this on the LUS side of things, so i made https://github.com/Kenix3/libultraship/issues/885 to track that, but i'd also like to land this in blair without needing to bump LUS so this feels like a reasonable short-term solution. once an LUS side fix lands we can remove these changes and rely on that for dev

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3146341110.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3146344641.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3146352013.zip)
<!--- section:artifacts:end -->