### PR TITLE
Fix the wrong codepath being used in CanBuy when generating seeds

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/fill.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/fill.cpp
@@ -421,7 +421,7 @@ bool AddCheckToLogic(LocationAccess& locPair, GetAccessibleLocationsStruct& gals
     Rando::ItemLocation* location = ctx->GetItemLocation(loc);
     RandomizerGet locItem = location->GetPlacedRandomizerGet();
 
-    if (!location->IsAddedToPool() && locPair.ConditionsMet(parentRegion)) {
+    if (!location->IsAddedToPool() && locPair.ConditionsMet(parentRegion, gals.calculatingAvailableChecks)) {
         if (gals.calculatingAvailableChecks) {
             gals.accessibleLocations.push_back(loc);
             StopPerformanceTimer(PT_LOCATION_LOGIC);

--- a/soh/soh/Enhancements/randomizer/location_access.cpp
+++ b/soh/soh/Enhancements/randomizer/location_access.cpp
@@ -33,7 +33,7 @@ bool LocationAccess::CheckConditionAtAgeTime(bool& age, bool& time) const {
     return GetConditionsMet();
 }
 
-bool LocationAccess::ConditionsMet(Region* parentRegion) const {
+bool LocationAccess::ConditionsMet(Region* parentRegion, bool calculatingAvailableChecks) const {
     // WARNING enterance validation can run this after resetting the access for sphere 0 validation
     // When refactoring ToD access, either fix the above or do not assume that we
     // have any access at all just because this is being run
@@ -46,7 +46,7 @@ bool LocationAccess::ConditionsMet(Region* parentRegion) const {
         conditionsMet = true;
     }
 
-    return conditionsMet && CanBuy();
+    return conditionsMet && CanBuy(calculatingAvailableChecks);
 }
 
 static uint16_t GetMinimumPrice(const Rando::Location* loc) {
@@ -90,13 +90,13 @@ static uint16_t GetMinimumPrice(const Rando::Location* loc) {
     }
 }
 
-bool LocationAccess::CanBuy() const {
+bool LocationAccess::CanBuy(bool calculatingAvailableChecks) const {
     const auto& loc = Rando::StaticData::GetLocation(location);
     const auto& itemLoc = OTRGlobals::Instance->gRandoContext->GetItemLocation(location);
 
     if (loc->GetRCType() == RCTYPE_SHOP || loc->GetRCType() == RCTYPE_SCRUB || loc->GetRCType() == RCTYPE_MERCHANT) {
         // Checks should only be identified while playing
-        if (itemLoc->GetCheckStatus() != RCSHOW_IDENTIFIED) {
+        if (calculatingAvailableChecks && itemLoc->GetCheckStatus() != RCSHOW_IDENTIFIED) {
             return CanBuyAnother(GetMinimumPrice(loc));
         } else {
             return CanBuyAnother(itemLoc->GetPrice());

--- a/soh/soh/Enhancements/randomizer/location_access.h
+++ b/soh/soh/Enhancements/randomizer/location_access.h
@@ -84,7 +84,7 @@ class LocationAccess {
 
     bool CheckConditionAtAgeTime(bool& age, bool& time) const;
 
-    bool ConditionsMet(Region* parentRegion) const;
+    bool ConditionsMet(Region* parentRegion, bool calculatingAvailableChecks) const;
 
     RandomizerCheck GetLocation() const {
         return location;
@@ -100,7 +100,7 @@ class LocationAccess {
     std::string condition_str;
 
     // Makes sure shop locations are buyable
-    bool CanBuy() const;
+    bool CanBuy(bool calculatingAvailableChecks) const;
 };
 
 bool CanBuyAnother(uint16_t price);


### PR DESCRIPTION
this was causing wallet to be ignored in seed generation on some settings

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3146807377.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3146810437.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3146815460.zip)
<!--- section:artifacts:end -->