### PR TITLE
Fix getting heart containers on pocket and skipped impas song

### DIFF
--- a/soh/soh/Enhancements/randomizer/savefile.cpp
+++ b/soh/soh/Enhancements/randomizer/savefile.cpp
@@ -231,6 +231,8 @@ extern "C" void Randomizer_InitSaveFile() {
 
     // Reset triforce pieces collected.
     gSaveContext.ship.quest.data.randomizer.triforcePiecesCollected = 0;
+    
+    SetStartingItems();
 
     // Set Cutscene flags and texts to skip them.
     Flags_SetEventChkInf(EVENTCHKINF_FIRST_SPOKE_TO_MIDO);
@@ -431,5 +433,4 @@ extern "C" void Randomizer_InitSaveFile() {
         gSaveContext.itemGetInf[3] |= 0x8000; // Obtained Mask of Truth
     }
 
-    SetStartingItems();
 }

--- a/soh/soh/Enhancements/randomizer/savefile.cpp
+++ b/soh/soh/Enhancements/randomizer/savefile.cpp
@@ -231,7 +231,7 @@ extern "C" void Randomizer_InitSaveFile() {
 
     // Reset triforce pieces collected.
     gSaveContext.ship.quest.data.randomizer.triforcePiecesCollected = 0;
-    
+
     SetStartingItems();
 
     // Set Cutscene flags and texts to skip them.
@@ -432,5 +432,4 @@ extern "C" void Randomizer_InitSaveFile() {
         gSaveContext.itemGetInf[3] |= 0x800;  // Bunny Hood related
         gSaveContext.itemGetInf[3] |= 0x8000; // Obtained Mask of Truth
     }
-
 }


### PR DESCRIPTION
This was caused by starting hearts being set after the Link's Pocket and skipped Impa's Song checks were given, deleting any health previously gained.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3152466406.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3152509664.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3152517054.zip)
<!--- section:artifacts:end -->