### PR TITLE
Fix crash when no valid enemies are selected

### DIFF
--- a/soh/soh/Enhancements/enemyrandomizer.cpp
+++ b/soh/soh/Enhancements/enemyrandomizer.cpp
@@ -270,15 +270,7 @@ extern "C" uint8_t GetRandomizedEnemy(PlayState* play, int16_t* actorId, f32* po
         // Get randomized enemy ID and parameter.
         uint32_t seed =
             play->sceneNum + *actorId + (int)*posX + (int)*posY + (int)*posZ + *rotX + *rotY + *rotZ + *params;
-        EnemyEntry randomEnemy = GetRandomizedEnemyEntry(seed);
-
-        int8_t timesRandomized = 1;
-
-        // While randomized enemy isn't allowed in certain situations, randomize again.
-        while (!IsEnemyAllowedToSpawn(play->sceneNum, play->roomCtx.curRoom.num, randomEnemy)) {
-            randomEnemy = GetRandomizedEnemyEntry(seed + timesRandomized);
-            timesRandomized++;
-        }
+        EnemyEntry randomEnemy = GetRandomizedEnemyEntry(seed, play);
 
         *actorId = randomEnemy.id;
         *params = randomEnemy.params;
@@ -334,19 +326,28 @@ void GetSelectedEnemies() {
     }
 }
 
-EnemyEntry GetRandomizedEnemyEntry(uint32_t seed) {
+EnemyEntry GetRandomizedEnemyEntry(uint32_t seed, PlayState* play) {
+    std::vector<EnemyEntry> filteredEnemyList = {};
     if (selectedEnemyList.size() == 0) {
         GetSelectedEnemies();
+    }
+    for (EnemyEntry enemy: selectedEnemyList){
+        if(IsEnemyAllowedToSpawn(play->sceneNum, play->roomCtx.curRoom.num, enemy)){
+            filteredEnemyList.push_back(enemy);
+        }
+    }
+    if (filteredEnemyList.size() == 0) {
+        filteredEnemyList = selectedEnemyList;
     }
     if (CVarGetInteger(CVAR_ENHANCEMENT("RandomizedEnemies"), ENEMY_RANDOMIZER_OFF) == ENEMY_RANDOMIZER_RANDOM_SEEDED) {
         uint32_t finalSeed =
             seed + (IS_RANDO ? Rando::Context::GetInstance()->GetSeed() : gSaveContext.ship.stats.fileCreatedAt);
         Random_Init(finalSeed);
-        uint32_t randomNumber = Random(0, selectedEnemyList.size());
-        return selectedEnemyList[randomNumber];
+        uint32_t randomNumber = Random(0, filteredEnemyList.size());
+        return filteredEnemyList[randomNumber];
     } else {
-        uint32_t randomSelectedEnemy = Random(0, selectedEnemyList.size());
-        return selectedEnemyList[randomSelectedEnemy];
+        uint32_t randomSelectedEnemy = Random(0, filteredEnemyList.size());
+        return filteredEnemyList[randomSelectedEnemy];
     }
 }
 

--- a/soh/soh/Enhancements/enemyrandomizer.cpp
+++ b/soh/soh/Enhancements/enemyrandomizer.cpp
@@ -331,8 +331,8 @@ EnemyEntry GetRandomizedEnemyEntry(uint32_t seed, PlayState* play) {
     if (selectedEnemyList.size() == 0) {
         GetSelectedEnemies();
     }
-    for (EnemyEntry enemy: selectedEnemyList){
-        if(IsEnemyAllowedToSpawn(play->sceneNum, play->roomCtx.curRoom.num, enemy)){
+    for (EnemyEntry enemy : selectedEnemyList) {
+        if (IsEnemyAllowedToSpawn(play->sceneNum, play->roomCtx.curRoom.num, enemy)) {
             filteredEnemyList.push_back(enemy);
         }
     }

--- a/soh/soh/Enhancements/enemyrandomizer.h
+++ b/soh/soh/Enhancements/enemyrandomizer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <libultraship/bridge.h>
+#include "item-tables/ItemTableTypes.h"
 
 typedef struct EnemyEntry {
     int16_t id;
@@ -11,7 +12,7 @@ typedef struct EnemyEntry {
 
 bool IsEnemyFoundToRandomize(int16_t sceneNum, int8_t roomNum, int16_t actorId, int16_t params, float posX);
 bool IsEnemyAllowedToSpawn(int16_t sceneNum, int8_t roomNum, EnemyEntry enemy);
-EnemyEntry GetRandomizedEnemyEntry(uint32_t seed);
+EnemyEntry GetRandomizedEnemyEntry(uint32_t seed, PlayState* play);
 
 extern const char* enemyCVarList[];
 extern const char* enemyNameList[];


### PR DESCRIPTION
Some enemies cannot appear in clear rooms or timed rooms. If only these enemies were selected, it would cause a lock when the player tried to enter those rooms as there would be an infinite loop of trying and failing to select an enemy. This PR changes the way enemies are selected to remove any looping and also adds a fallback where if nothing valid is available, it allows invalid enemies to spawn.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3153555065.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3153583219.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3153620318.zip)
<!--- section:artifacts:end -->