### PR TITLE
Dynamic Shadow option (Auto-spawn ACTOR_EN_SDA on scene load; Experimental)

### DIFF
--- a/soh/soh/Enhancements/cosmetics/DynamicShadow.cpp
+++ b/soh/soh/Enhancements/cosmetics/DynamicShadow.cpp
@@ -1,5 +1,4 @@
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
-#include "soh/Enhancements/mods.h"
 #include "soh/ShipInit.hpp"
 #include "soh/OTRGlobals.h"
 
@@ -38,20 +37,7 @@ static void SpawnDynamicShadow() {
     }
 }
 
-static void RegisterDynamicShadow() {
-    COND_VB_SHOULD(VB_EXECUTE_PLAYER_STARTMODE_FUNC, CVAR_DYNAMICSHADOW_VALUE, {
-        int32_t startMode = va_arg(args, int32_t);
-        Player* player = GET_PLAYER(gPlayState);
-        Actor* shadowActor;
-
-        if ((player != nullptr) && (startMode != PLAYER_START_MODE_NOTHING)) {
-            SPDLOG_DEBUG("Spawning Dynamic Shadow. sceneNum: {0:#x}", gPlayState->sceneNum);
-            SpawnDynamicShadow();
-        }
-    });
-}
-
-void UpdateDynamicShadow() {
+static void UpdateDynamicShadow() {
     if (gPlayState != nullptr) {
         Player* player = GET_PLAYER(gPlayState);
         Actor* shadowActor;
@@ -92,6 +78,20 @@ void UpdateDynamicShadow() {
             }
         }
     }
+}
+
+static void RegisterDynamicShadow() {
+    UpdateDynamicShadow();  // Handle Dynamic Shadow toggle
+
+    COND_VB_SHOULD(VB_EXECUTE_PLAYER_STARTMODE_FUNC, CVAR_DYNAMICSHADOW_VALUE, {
+        int32_t startMode = va_arg(args, int32_t);
+        Player* player = GET_PLAYER(gPlayState);
+
+        if ((player != nullptr) && (startMode != PLAYER_START_MODE_NOTHING)) {
+            SPDLOG_DEBUG("Spawning Dynamic Shadow. sceneNum: {0:#x}", gPlayState->sceneNum);
+            SpawnDynamicShadow();
+        }
+    });
 }
 
 static RegisterShipInitFunc initFunc(RegisterDynamicShadow, { CVAR_DYNAMICSHADOW_NAME });

--- a/soh/soh/Enhancements/cosmetics/DynamicShadow.cpp
+++ b/soh/soh/Enhancements/cosmetics/DynamicShadow.cpp
@@ -81,7 +81,7 @@ static void UpdateDynamicShadow() {
 }
 
 static void RegisterDynamicShadow() {
-    UpdateDynamicShadow();  // Handle Dynamic Shadow toggle
+    UpdateDynamicShadow(); // Handle Dynamic Shadow toggle
 
     COND_VB_SHOULD(VB_EXECUTE_PLAYER_STARTMODE_FUNC, CVAR_DYNAMICSHADOW_VALUE, {
         int32_t startMode = va_arg(args, int32_t);

--- a/soh/soh/Enhancements/cosmetics/DynamicShadow.cpp
+++ b/soh/soh/Enhancements/cosmetics/DynamicShadow.cpp
@@ -1,4 +1,5 @@
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
+#include "soh/Enhancements/mods.h"
 #include "soh/ShipInit.hpp"
 #include "soh/OTRGlobals.h"
 
@@ -12,11 +13,32 @@ extern "C" {
 extern PlayState* gPlayState;
 }
 
+static constexpr int32_t CVAR_DYNAMICSHADOW_DEFAULT = 0;
 #define CVAR_DYNAMICSHADOW_NAME CVAR_ENHANCEMENT("DynamicShadow")
-#define CVAR_DYNAMICSHADOW_DEFAULT 0
 #define CVAR_DYNAMICSHADOW_VALUE CVarGetInteger(CVAR_DYNAMICSHADOW_NAME, CVAR_DYNAMICSHADOW_DEFAULT)
 
-void RegisterDynamicShadow() {
+static void SpawnDynamicShadow() {
+    if (gPlayState != nullptr) {
+        Player* player = GET_PLAYER(gPlayState);
+
+        if (player != nullptr) {
+            Actor* shadowActor;
+
+            // Spawn as Link's child so the shadow doesn't get unloaded on room change.
+            shadowActor = Actor_SpawnAsChild(&gPlayState->actorCtx, &player->actor, gPlayState, ACTOR_EN_SDA,
+                                             player->actor.world.pos.x, player->actor.world.pos.y,
+                                             player->actor.world.pos.z, 0, 0, 0, 0);
+
+            // For whatever reason the dynamic shadow's category is ACTORCAT_BOSS.
+            // We're changing it to ACTORCAT_ITEMACTION, the same category as Navi.
+            if (shadowActor != nullptr) {
+                Actor_ChangeCategory(gPlayState, &gPlayState->actorCtx, shadowActor, ACTORCAT_ITEMACTION);
+            }
+        }
+    }
+}
+
+static void RegisterDynamicShadow() {
     COND_VB_SHOULD(VB_EXECUTE_PLAYER_STARTMODE_FUNC, CVAR_DYNAMICSHADOW_VALUE, {
         int32_t startMode = va_arg(args, int32_t);
         Player* player = GET_PLAYER(gPlayState);
@@ -24,16 +46,49 @@ void RegisterDynamicShadow() {
 
         if ((player != nullptr) && (startMode != PLAYER_START_MODE_NOTHING)) {
             SPDLOG_DEBUG("Spawning Dynamic Shadow. sceneNum: {0:#x}", gPlayState->sceneNum);
-
-            // Spawn as Link's child so the shadow doesn't get unloaded on room change.
-            shadowActor = Actor_SpawnAsChild(&gPlayState->actorCtx, &player->actor, gPlayState, ACTOR_EN_SDA, 0, 0, 0,
-                                             0, 0, 0, 0);
-
-            // For whatever reason the dynamic shadow's category is ACTORCAT_BOSS.
-            // We're changing it to ACTORCAT_ITEMACTION, the same category as Navi.
-            Actor_ChangeCategory(gPlayState, &gPlayState->actorCtx, shadowActor, ACTORCAT_ITEMACTION);
+            SpawnDynamicShadow();
         }
     });
+}
+
+void UpdateDynamicShadow() {
+    if (gPlayState != nullptr) {
+        Player* player = GET_PLAYER(gPlayState);
+        Actor* shadowActor;
+
+        if (player != nullptr) {
+            if (CVAR_DYNAMICSHADOW_VALUE) {
+                SPDLOG_DEBUG("Dynamic Shadow has been toggled on. sceneNum: {0:#x}", gPlayState->sceneNum);
+
+                shadowActor = Actor_Find(&gPlayState->actorCtx, ACTOR_EN_SDA, ACTORCAT_BOSS);
+                if (shadowActor != nullptr) {
+                    SPDLOG_DEBUG("Dynamic Shadow already exists in ACTORCAT_BOSS");
+                } else {
+                    shadowActor = Actor_Find(&gPlayState->actorCtx, ACTOR_EN_SDA, ACTORCAT_ITEMACTION);
+
+                    if (shadowActor != nullptr) {
+                        SPDLOG_DEBUG("Dynamic Shadow already exists in ACTORCAT_ITEMACTION");
+                    } else {
+                        SpawnDynamicShadow();
+                    }
+                }
+            } else {
+                SPDLOG_DEBUG("Dynamic Shadow has been toggled off. sceneNum: {0:#x}", gPlayState->sceneNum);
+
+                shadowActor = Actor_Find(&gPlayState->actorCtx, ACTOR_EN_SDA, ACTORCAT_BOSS);
+                if (shadowActor != nullptr) {
+                    SPDLOG_DEBUG("Killing Dynamic Shadow in ACTORCAT_BOSS");
+                    Actor_Kill(shadowActor);
+                }
+
+                shadowActor = Actor_Find(&gPlayState->actorCtx, ACTOR_EN_SDA, ACTORCAT_ITEMACTION);
+                if (shadowActor != nullptr) {
+                    SPDLOG_DEBUG("Killing Dynamic Shadow in ACTORCAT_ITEMACTION");
+                    Actor_Kill(shadowActor);
+                }
+            }
+        }
+    }
 }
 
 static RegisterShipInitFunc initFunc(RegisterDynamicShadow, { CVAR_DYNAMICSHADOW_NAME });

--- a/soh/soh/Enhancements/cosmetics/DynamicShadow.cpp
+++ b/soh/soh/Enhancements/cosmetics/DynamicShadow.cpp
@@ -1,0 +1,39 @@
+#include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
+#include "soh/ShipInit.hpp"
+#include "soh/OTRGlobals.h"
+
+#include <spdlog/spdlog.h>
+
+extern "C" {
+#include "functions.h"
+#include "macros.h"
+#include "variables.h"
+
+extern PlayState* gPlayState;
+}
+
+#define CVAR_DYNAMICSHADOW_NAME CVAR_ENHANCEMENT("DynamicShadow")
+#define CVAR_DYNAMICSHADOW_DEFAULT 0
+#define CVAR_DYNAMICSHADOW_VALUE CVarGetInteger(CVAR_DYNAMICSHADOW_NAME, CVAR_DYNAMICSHADOW_DEFAULT)
+
+void RegisterDynamicShadow() {
+    COND_VB_SHOULD(VB_EXECUTE_PLAYER_STARTMODE_FUNC, CVAR_DYNAMICSHADOW_VALUE, {
+        int32_t startMode = va_arg(args, int32_t);
+        Player* player = GET_PLAYER(gPlayState);
+        Actor* shadowActor;
+
+        if ((player != nullptr) && (startMode != PLAYER_START_MODE_NOTHING)) {
+            SPDLOG_DEBUG("Spawning Dynamic Shadow");
+
+            // Spawn as Link's child so the shadow doesn't get unloaded on room change.
+            shadowActor = Actor_SpawnAsChild(&gPlayState->actorCtx, &player->actor, gPlayState, ACTOR_EN_SDA, 0, 0, 0,
+                                             0, 0, 0, 0);
+
+            // For whatever reason the dynamic shadow's category is ACTORCAT_BOSS.
+            // We're changing it to ACTORCAT_ITEMACTION, the same category as Navi.
+            Actor_ChangeCategory(gPlayState, &gPlayState->actorCtx, shadowActor, ACTORCAT_ITEMACTION);
+        }
+    });
+}
+
+static RegisterShipInitFunc initFunc(RegisterDynamicShadow, { CVAR_DYNAMICSHADOW_NAME });

--- a/soh/soh/Enhancements/cosmetics/DynamicShadow.cpp
+++ b/soh/soh/Enhancements/cosmetics/DynamicShadow.cpp
@@ -36,4 +36,4 @@ void RegisterDynamicShadow() {
     });
 }
 
-static RegisterShipInitFunc initFunc_DynamicShadow(RegisterDynamicShadow, { CVAR_DYNAMICSHADOW_NAME });
+static RegisterShipInitFunc initFunc(RegisterDynamicShadow, { CVAR_DYNAMICSHADOW_NAME });

--- a/soh/soh/Enhancements/cosmetics/DynamicShadow.cpp
+++ b/soh/soh/Enhancements/cosmetics/DynamicShadow.cpp
@@ -23,7 +23,7 @@ void RegisterDynamicShadow() {
         Actor* shadowActor;
 
         if ((player != nullptr) && (startMode != PLAYER_START_MODE_NOTHING)) {
-            SPDLOG_DEBUG("Spawning Dynamic Shadow");
+            SPDLOG_DEBUG("Spawning Dynamic Shadow. sceneNum: {0:#x}", gPlayState->sceneNum);
 
             // Spawn as Link's child so the shadow doesn't get unloaded on room change.
             shadowActor = Actor_SpawnAsChild(&gPlayState->actorCtx, &player->actor, gPlayState, ACTOR_EN_SDA, 0, 0, 0,
@@ -36,4 +36,4 @@ void RegisterDynamicShadow() {
     });
 }
 
-static RegisterShipInitFunc initFunc(RegisterDynamicShadow, { CVAR_DYNAMICSHADOW_NAME });
+static RegisterShipInitFunc initFunc_DynamicShadow(RegisterDynamicShadow, { CVAR_DYNAMICSHADOW_NAME });

--- a/soh/soh/Enhancements/cosmetics/DynamicShadow.cpp
+++ b/soh/soh/Enhancements/cosmetics/DynamicShadow.cpp
@@ -86,6 +86,9 @@ void UpdateDynamicShadow() {
                     SPDLOG_DEBUG("Killing Dynamic Shadow in ACTORCAT_ITEMACTION");
                     Actor_Kill(shadowActor);
                 }
+
+                // Restore player's normal shadow
+                player->actor.shape.shadowAlpha = 255;
             }
         }
     }

--- a/soh/soh/Enhancements/mods.h
+++ b/soh/soh/Enhancements/mods.h
@@ -11,7 +11,6 @@ void UpdateHyperEnemiesState();
 void UpdateHyperBossesState();
 void InitMods();
 void SwitchAge();
-void UpdateDynamicShadow();
 
 #ifdef __cplusplus
 }

--- a/soh/soh/Enhancements/mods.h
+++ b/soh/soh/Enhancements/mods.h
@@ -11,6 +11,7 @@ void UpdateHyperEnemiesState();
 void UpdateHyperBossesState();
 void InitMods();
 void SwitchAge();
+void UpdateDynamicShadow();
 
 #ifdef __cplusplus
 }

--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -723,7 +723,6 @@ void SohMenu::AddMenuEnhancements() {
         .Options(TextOptions().Color(Colors::Orange));
     AddWidget(path, "Dynamic Shadow", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("DynamicShadow"))
-        .Callback([](WidgetInfo& info) { UpdateDynamicShadow(); })
         .Options(CheckboxOptions().Tooltip("Enable Dynamic Shadow for the player. Uses unused functionality left in "
                                            "the game's code. May cause graphical glitches or "
                                            "gameplay issues."));

--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -722,9 +722,11 @@ void SohMenu::AddMenuEnhancements() {
     AddWidget(path, "EXPERIMENTAL", WIDGET_SEPARATOR_TEXT).Options(TextOptions().Color(Colors::Orange));
     AddWidget(path, "Dynamic Shadow", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("DynamicShadow"))
-        .Options(CheckboxOptions().Tooltip("Enable Dynamic Shadow for the player. Uses unused functionality left in "
-                                           "the game's code. May cause graphical glitches or "
-                                           "gameplay issues. Requires a scene reload to take effect."));
+        .Callback([](WidgetInfo& info) { UpdateDynamicShadow(); })
+        .Options(CheckboxOptions().Tooltip(
+            "Enable Dynamic Shadow for the player. Uses unused functionality left in "
+            "the game's code. May cause graphical glitches or "
+            "gameplay issues. If toggled off during the game, restoring the normal shadow requires a scene reload."));
 
     path.sidebarName = "Items";
     AddSidebarEntry("Enhancements", path.sidebarName, 3);

--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -719,14 +719,14 @@ void SohMenu::AddMenuEnhancements() {
             " - Blue Warps\n"
             " - Darunia\n"
             " - Gold Skulltulas\n"));
-    AddWidget(path, "EXPERIMENTAL", WIDGET_SEPARATOR_TEXT).Options(TextOptions().Color(Colors::Orange));
+    AddWidget(path, ICON_FA_EXCLAMATION_TRIANGLE " EXPERIMENTAL", WIDGET_SEPARATOR_TEXT)
+        .Options(TextOptions().Color(Colors::Orange));
     AddWidget(path, "Dynamic Shadow", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("DynamicShadow"))
         .Callback([](WidgetInfo& info) { UpdateDynamicShadow(); })
-        .Options(CheckboxOptions().Tooltip(
-            "Enable Dynamic Shadow for the player. Uses unused functionality left in "
-            "the game's code. May cause graphical glitches or "
-            "gameplay issues. If toggled off during the game, restoring the normal shadow requires a scene reload."));
+        .Options(CheckboxOptions().Tooltip("Enable Dynamic Shadow for the player. Uses unused functionality left in "
+                                           "the game's code. May cause graphical glitches or "
+                                           "gameplay issues."));
 
     path.sidebarName = "Items";
     AddSidebarEntry("Enhancements", path.sidebarName, 3);

--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -604,6 +604,11 @@ void SohMenu::AddMenuEnhancements() {
         .Options(CheckboxOptions().Tooltip(
             "When Medallions are collected, the Medallion imprints around the Master Sword Pedestal in the Temple "
             "of Time will become colored-in."));
+    AddWidget(path, "EXPERIMENTAL", WIDGET_SEPARATOR_TEXT).Options(TextOptions().Color(Colors::Orange));
+    AddWidget(path, "Dynamic Shadow", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_ENHANCEMENT("DynamicShadow"))
+        .Options(CheckboxOptions().Tooltip("Enable Dynamic Shadow for the player. May cause graphical glitches or "
+                                           "gameplay issues. Requires a scene reload to take effect."));
 
     path.column = SECTION_COLUMN_2;
     AddWidget(path, "UI", WIDGET_SEPARATOR_TEXT);

--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -604,11 +604,6 @@ void SohMenu::AddMenuEnhancements() {
         .Options(CheckboxOptions().Tooltip(
             "When Medallions are collected, the Medallion imprints around the Master Sword Pedestal in the Temple "
             "of Time will become colored-in."));
-    AddWidget(path, "EXPERIMENTAL", WIDGET_SEPARATOR_TEXT).Options(TextOptions().Color(Colors::Orange));
-    AddWidget(path, "Dynamic Shadow", WIDGET_CVAR_CHECKBOX)
-        .CVar(CVAR_ENHANCEMENT("DynamicShadow"))
-        .Options(CheckboxOptions().Tooltip("Enable Dynamic Shadow for the player. May cause graphical glitches or "
-                                           "gameplay issues. Requires a scene reload to take effect."));
 
     path.column = SECTION_COLUMN_2;
     AddWidget(path, "UI", WIDGET_SEPARATOR_TEXT);
@@ -724,6 +719,12 @@ void SohMenu::AddMenuEnhancements() {
             " - Blue Warps\n"
             " - Darunia\n"
             " - Gold Skulltulas\n"));
+    AddWidget(path, "EXPERIMENTAL", WIDGET_SEPARATOR_TEXT).Options(TextOptions().Color(Colors::Orange));
+    AddWidget(path, "Dynamic Shadow", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_ENHANCEMENT("DynamicShadow"))
+        .Options(CheckboxOptions().Tooltip("Enable Dynamic Shadow for the player. Uses unused functionality left in "
+                                           "the game's code. May cause graphical glitches or "
+                                           "gameplay issues. Requires a scene reload to take effect."));
 
     path.sidebarName = "Items";
     AddSidebarEntry("Enhancements", path.sidebarName, 3);


### PR DESCRIPTION
This PR adds an option to automatically spawn ACTOR_EN_SDA (Unused Dynamic Shadow for Link) on scene load. It is spawned at the same time with Navi.

As this is an actor, I suspect there can be places or situations where it will cause problems. There may also be places where the shadow just don't look right.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4693045327.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4693056112.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4693091060.zip)
<!--- section:artifacts:end -->