### PR TITLE
Fix some Dark Link issues

### DIFF
--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -2011,6 +2011,38 @@ typedef enum {
     // #### `args`
     // - `*EnWonderTalk2`
     VB_WONDER_TALK,
+
+    // #### `result`
+    // ```c
+    // true
+    // ```
+    // #### `args`
+    // - `*Actor`
+    VB_TRIGGER_VOIDOUT,
+
+    // #### `result`
+    // ```c
+    // true
+    // ```
+    // #### `args`
+    // - `*Actor`
+    VB_TORCH2_HANDLE_CLANKING,
+
+    // #### `result`
+    // ```c
+    // true
+    // ```
+    // #### `args`
+    // - `*Actor`
+    VB_RECIEVE_FALL_DAMAGE,
+
+    // #### `result`
+    // ```c
+    // true
+    // ```
+    // #### `args`
+    // - `*EnRr`
+    VB_LIKE_LIKE_GRAB_PLAYER,
 } GIVanillaBehavior;
 
 #endif

--- a/soh/src/overlays/actors/ovl_En_Rr/z_en_rr.c
+++ b/soh/src/overlays/actors/ovl_En_Rr/z_en_rr.c
@@ -507,7 +507,7 @@ void EnRr_CollisionCheck(EnRr* this, PlayState* play) {
             this->collider2.base.ocFlags1 &= ~OC1_HIT;
             // "catch"
             osSyncPrintf(VT_FGCOL(GREEN) "キャッチ(%d)！！" VT_RST "\n", this->frameCount);
-            if (play->grabPlayer(play, player)) {
+            if (GameInteractor_Should(VB_LIKE_LIKE_GRAB_PLAYER, true, this) && play->grabPlayer(play, player)) {
                 player->actor.parent = &this->actor;
                 this->stopScroll = false;
                 EnRr_SetupGrabPlayer(this, player);

--- a/soh/src/overlays/actors/ovl_En_Torch2/z_en_torch2.c
+++ b/soh/src/overlays/actors/ovl_En_Torch2/z_en_torch2.c
@@ -706,7 +706,7 @@ void EnTorch2_Update(Actor* thisx, PlayState* play2) {
             sStaggerCount = 0;
         }
     }
-    if (player->linearVelocity == -18.0f) {
+    if (GameInteractor_Should(VB_TORCH2_HANDLE_CLANKING, player->linearVelocity == -18.0f, this)) {
         if (this->actor.xzDistToPlayer > 80.0f) {
             player->linearVelocity = 1.2f;
         } else if (this->actor.xzDistToPlayer < 70.0f) {

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -4764,7 +4764,9 @@ s32 func_808382DC(Player* this, PlayState* play) {
                     gSaveContext.respawn[RESPAWN_MODE_DOWN].yaw = respawnInfo->yaw;
                 }
 
-                Play_TriggerVoidOut(play);
+                if (GameInteractor_Should(VB_TRIGGER_VOIDOUT, true, this)) {
+                    Play_TriggerVoidOut(play);
+                }
             }
 
             Player_PlayVoiceSfx(this, NA_SE_VO_LI_TAKEN_AWAY);
@@ -5129,7 +5131,9 @@ s32 Player_HandleExitsAndVoids(PlayState* play, Player* this, CollisionPoly* pol
             }
 
             if (exitIndex == 0) {
-                Play_TriggerVoidOut(play);
+                if (GameInteractor_Should(VB_TRIGGER_VOIDOUT, true, this)) {
+                    Play_TriggerVoidOut(play);
+                }
                 Scene_SetTransitionForNextEntrance(play);
             } else {
                 play->nextEntranceIndex = play->setupExitList[exitIndex - 1];
@@ -5163,7 +5167,9 @@ s32 Player_HandleExitsAndVoids(PlayState* play, Player* this, CollisionPoly* pol
                                               SurfaceType_GetSlope(&play->colCtx, poly, bgId) == 2,
                                               play->setupExitList[exitIndex - 1])) {
                         gSaveContext.respawn[RESPAWN_MODE_DOWN].entranceIndex = play->nextEntranceIndex;
-                        Play_TriggerVoidOut(play);
+                        if (GameInteractor_Should(VB_TRIGGER_VOIDOUT, true, this)) {
+                            Play_TriggerVoidOut(play);
+                        }
                         gSaveContext.respawnFlag = -2;
                     }
                     gSaveContext.retainWeatherMode = 1;
@@ -5226,7 +5232,7 @@ s32 Player_HandleExitsAndVoids(PlayState* play, Player* this, CollisionPoly* pol
                     if (this->actor.bgCheckFlags & 1) {
                         if (this->floorProperty == 5) {
                             Play_TriggerRespawn(play);
-                        } else {
+                        } else if (GameInteractor_Should(VB_TRIGGER_VOIDOUT, true, this)) {
                             Play_TriggerVoidOut(play);
                         }
                         play->transitionType = TRANS_TYPE_FADE_BLACK_FAST;
@@ -9612,6 +9618,10 @@ static FallImpactInfo D_80854600[] = {
 
 s32 func_80843E64(PlayState* play, Player* this) {
     s32 sp34;
+
+    if (!GameInteractor_Should(VB_RECIEVE_FALL_DAMAGE, true, this)) {
+        return 0;
+    }
 
     if ((sFloorType == 6) || (sFloorType == 9)) {
         sp34 = 0;
@@ -15009,7 +15019,7 @@ void Player_Action_8084F88C(Player* this, PlayState* play) {
                 if (IS_RANDO && Randomizer_GetSettingValue(RSK_SHUFFLE_ENTRANCES)) {
                     Grotto_ForceRegularVoidOut();
                 }
-            } else {
+            } else if (GameInteractor_Should(VB_TRIGGER_VOIDOUT, true, this)) {
                 Play_TriggerVoidOut(play);
             }
 


### PR DESCRIPTION
Fixes the following dark link issues in enemy randomizer:
- Dark Link voiding out also voids out the player
- Dark Link receiving fall damage also deals it to the player
- Dark Link interferes with HESS/recoil/etc (only fixed when at more than 100 units away from him)
- Dark Link can be grabbed by like likes which also grabs the player

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3188719316.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3188729965.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3188748054.zip)
<!--- section:artifacts:end -->