### PR TITLE
Fix Preset List with no customs available

### DIFF
--- a/soh/soh/Enhancements/Presets/Presets.cpp
+++ b/soh/soh/Enhancements/Presets/Presets.cpp
@@ -193,23 +193,22 @@ void ParsePreset(nlohmann::json& json, std::string name) {
 }
 
 void LoadPresets() {
-    if (!fs::exists(presetFolder)) {
-        return;
-    }
     if (!presets.empty()) {
         presets.clear();
     }
-    for (auto const& preset : fs::directory_iterator(presetFolder)) {
-        std::ifstream ifs(preset.path());
+    if (fs::exists(presetFolder)) {
+        for (auto const& preset : fs::directory_iterator(presetFolder)) {
+            std::ifstream ifs(preset.path());
 
-        auto json = nlohmann::json::parse(ifs);
-        if (!json.contains("presetName")) {
-            spdlog::error(fmt::format("Attempted to load file {} as a preset, but was not a preset file.",
-                                      preset.path().filename().string()));
-        } else {
-            ParsePreset(json, preset.path().filename().stem().string());
+            auto json = nlohmann::json::parse(ifs);
+            if (!json.contains("presetName")) {
+                spdlog::error(fmt::format("Attempted to load file {} as a preset, but was not a preset file.",
+                    preset.path().filename().string()));
+            } else {
+                ParsePreset(json, preset.path().filename().stem().string());
+            }
+            ifs.close();
         }
-        ifs.close();
     }
     auto initData = std::make_shared<Ship::ResourceInitData>();
     initData->Format = RESOURCE_FORMAT_BINARY;

--- a/soh/soh/Enhancements/Presets/Presets.cpp
+++ b/soh/soh/Enhancements/Presets/Presets.cpp
@@ -203,7 +203,7 @@ void LoadPresets() {
             auto json = nlohmann::json::parse(ifs);
             if (!json.contains("presetName")) {
                 spdlog::error(fmt::format("Attempted to load file {} as a preset, but was not a preset file.",
-                    preset.path().filename().string()));
+                                          preset.path().filename().string()));
             } else {
                 ParsePreset(json, preset.path().filename().stem().string());
             }


### PR DESCRIPTION
Surrounds the preset file processing with the `fs::exists` check rather than returning early if the folder doesn't exist (signifying no custom presets have ever been made).

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3191687219.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3191690855.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3191695847.zip)
<!--- section:artifacts:end -->