### PR TITLE
Fix failure to assign areas to regions on initial spoiler load

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/fill.hpp
+++ b/soh/soh/Enhancements/randomizer/3drando/fill.hpp
@@ -56,6 +56,7 @@ struct GetAccessibleLocationsStruct {
 void ClearProgress();
 void VanillaFill();
 int Fill();
+void SetAreas();
 
 std::vector<RandomizerCheck> GetEmptyLocations(std::vector<RandomizerCheck> allowedLocations);
 

--- a/soh/soh/Enhancements/randomizer/context.cpp
+++ b/soh/soh/Enhancements/randomizer/context.cpp
@@ -400,9 +400,9 @@ void Context::ParseSpoiler(const char* spoilerFileName) {
         ParseHashIconIndexesJson(spoilerFileJson);
         Rando::Settings::GetInstance()->ParseJson(spoilerFileJson);
         ParseItemLocationsJson(spoilerFileJson);
-        ParseHintJson(spoilerFileJson);
         ParseTricksJson(spoilerFileJson);
         mEntranceShuffler->ParseJson(spoilerFileJson);
+        ParseHintJson(spoilerFileJson);
         mDungeons->ParseJson(spoilerFileJson);
         mTrials->ParseJson(spoilerFileJson);
         mSpoilerLoaded = true;

--- a/soh/soh/Enhancements/randomizer/entrance.cpp
+++ b/soh/soh/Enhancements/randomizer/entrance.cpp
@@ -1666,6 +1666,10 @@ void EntranceShuffler::ParseJson(nlohmann::json spoilerFileJson) {
             }
         }
     } catch (const std::exception& e) { throw e; }
+    // We may need to reset more things here or elsewhere in spoiler loading
+    RegionTable_Init();
+    ApplyEntranceOverrides();
+    SetAreas();
 }
 
 void EntranceShuffler::ApplyEntranceOverrides() {


### PR DESCRIPTION
This fixes an assert if a spoiler with static item hints is loaded.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3193926636.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3193931449.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3193933483.zip)
<!--- section:artifacts:end -->