### PR TITLE
Frame Advance Alternative Control Scheme

### DIFF
--- a/soh/soh/Enhancements/FrameAdvanceAltScheme.cpp
+++ b/soh/soh/Enhancements/FrameAdvanceAltScheme.cpp
@@ -54,5 +54,4 @@ void RegisterFrameAdvanceAltScheme() {
     });
 }
 
-static RegisterShipInitFunc initFunc_FrameAdvanceAltScheme(RegisterFrameAdvanceAltScheme,
-                                                           { CVAR_FRAMEADVANCEALTSCHEME_NAME });
+static RegisterShipInitFunc initFunc(RegisterFrameAdvanceAltScheme, { CVAR_FRAMEADVANCEALTSCHEME_NAME });

--- a/soh/soh/Enhancements/FrameAdvanceAltScheme.cpp
+++ b/soh/soh/Enhancements/FrameAdvanceAltScheme.cpp
@@ -1,0 +1,58 @@
+#include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
+#include "soh/ShipInit.hpp"
+#include "soh/OTRGlobals.h"
+
+#include <spdlog/spdlog.h>
+
+extern "C" {
+#include "functions.h"
+#include "macros.h"
+#include "variables.h"
+
+extern PlayState* gPlayState;
+}
+
+#define CVAR_FRAMEADVANCEALTSCHEME_NAME CVAR_DEVELOPER_TOOLS("FrameAdvanceAltScheme")
+#define CVAR_FRAMEADVANCEALTSCHEME_DEFAULT 0
+#define CVAR_FRAMEADVANCEALTSCHEME_VALUE \
+    CVarGetInteger(CVAR_FRAMEADVANCEALTSCHEME_NAME, CVAR_FRAMEADVANCEALTSCHEME_DEFAULT)
+
+void RegisterFrameAdvanceAltScheme() {
+    COND_VB_SHOULD(VB_FRAME_ADVANCE_BE_VANILLA, CVAR_FRAMEADVANCEALTSCHEME_VALUE, {
+        // Do not run vanilla Frame Advance codes.
+        *should = false;
+    });
+
+    COND_VB_SHOULD(VB_FRAME_ADVANCE_FREEZE_FRAME, CVAR_FRAMEADVANCEALTSCHEME_VALUE, {
+        FrameAdvanceContext* frameAdvCtx = va_arg(args, FrameAdvanceContext*);
+        Input* input = gPlayState->state.input;
+        bool runFrame = false;
+
+        // Push START to toggle the frame advance mode.
+        if (CHECK_BTN_ALL(input[3].press.button, BTN_START)) {
+            frameAdvCtx->enabled = !frameAdvCtx->enabled;
+            if (frameAdvCtx->enabled) {
+                SPDLOG_DEBUG("Frame Advance is now enabled");
+            } else {
+                SPDLOG_DEBUG("Frame Advance is now disabled");
+            }
+        }
+
+        // Push A to advance one frame.
+        // Hold L to run normally until L is released.
+        // Hold R to advance a frame every half second.
+        if (!frameAdvCtx->enabled || CVarGetInteger(CVAR_DEVELOPER_TOOLS("FrameAdvanceTick"), 0) ||
+            CHECK_BTN_ALL(input[3].press.button, BTN_A) || CHECK_BTN_ALL(input[3].cur.button, BTN_L) ||
+            CHECK_BTN_ALL(input[3].press.button, BTN_R) ||
+            (CHECK_BTN_ALL(input[3].cur.button, BTN_R) && (++frameAdvCtx->timer >= 9))) {
+            CVarClear(CVAR_DEVELOPER_TOOLS("FrameAdvanceTick"));
+            frameAdvCtx->timer = 0;
+            runFrame = true;
+        }
+
+        *should = !runFrame;
+    });
+}
+
+static RegisterShipInitFunc initFunc_FrameAdvanceAltScheme(RegisterFrameAdvanceAltScheme,
+                                                           { CVAR_FRAMEADVANCEALTSCHEME_NAME });

--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -540,6 +540,22 @@ typedef enum {
     // true
     // ```
     // #### `args`
+    // - `*FrameAdvanceContext`
+    VB_FRAME_ADVANCE_BE_VANILLA,
+
+    // #### `result`
+    // ```c
+    // false
+    // ```
+    // #### `args`
+    // - `*FrameAdvanceContext`
+    VB_FRAME_ADVANCE_FREEZE_FRAME,
+
+    // #### `result`
+    // ```c
+    // true
+    // ```
+    // #### `args`
     // - `*BgHeavyBlock`
     VB_FREEZE_LINK_FOR_BLOCK_THROW,
 

--- a/soh/soh/SohGui/SohMenuDevTools.cpp
+++ b/soh/soh/SohGui/SohMenuDevTools.cpp
@@ -105,6 +105,13 @@ void SohMenu::AddMenuDevTools() {
             }
         })
         .SameLine(true);
+    AddWidget(path, "Frame Advance Alternative Control Scheme", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_DEVELOPER_TOOLS("FrameAdvanceAltScheme"))
+        .Options(CheckboxOptions().Tooltip("Remaps Frame Advance controls. Uses Controller Port 4.\n"
+                                           "Push START button to toggle Frame Advance.\n"
+                                           "Push A button to advance a frame.\n"
+                                           "Hold L button to run the game normally until L button is released.\n"
+                                           "Hold R button to advance a frame every half second."));
     AddWidget(path, "Log Level", WIDGET_CVAR_COMBOBOX)
         .CVar(CVAR_DEVELOPER_TOOLS("LogLevel"))
         .Options(ComboboxOptions()

--- a/soh/src/code/z_frame_advance.c
+++ b/soh/src/code/z_frame_advance.c
@@ -14,18 +14,43 @@ void FrameAdvance_Init(FrameAdvanceContext* frameAdvCtx) {
  * This function returns true when frame advance is not active (game will run normally)
  */
 s32 FrameAdvance_Update(FrameAdvanceContext* frameAdvCtx, Input* input) {
-    if (CHECK_BTN_ALL(input->cur.button, BTN_R) && CHECK_BTN_ALL(input->press.button, BTN_DDOWN)) {
-        frameAdvCtx->enabled = !frameAdvCtx->enabled;
-    }
+    if (CVarGetInteger(CVAR_DEVELOPER_TOOLS("FrameAdvanceAltScheme"), 0) != 0) {
+        // Frame Advance Alternative Control Scheme
 
-    if (!frameAdvCtx->enabled || CVarGetInteger(CVAR_DEVELOPER_TOOLS("FrameAdvanceTick"), 0) ||
-        (CHECK_BTN_ALL(input->cur.button, BTN_Z) &&
-         (CHECK_BTN_ALL(input->press.button, BTN_R) ||
-          (CHECK_BTN_ALL(input->cur.button, BTN_R) && (++frameAdvCtx->timer >= 9))))) {
-        CVarClear(CVAR_DEVELOPER_TOOLS("FrameAdvanceTick"));
-        frameAdvCtx->timer = 0;
-        return true;
-    }
+        // Push START to toggle the frame advance mode.
+        if (CHECK_BTN_ALL(input->press.button, BTN_START)) {
+            frameAdvCtx->enabled = !frameAdvCtx->enabled;
+        }
 
-    return false;
+        // Push A to advance one frame.
+        // Hold L to run normally until L is released.
+        // Hold R to advance a frame every half second.
+        if (!frameAdvCtx->enabled || CVarGetInteger(CVAR_DEVELOPER_TOOLS("FrameAdvanceTick"), 0) ||
+            CHECK_BTN_ALL(input->press.button, BTN_A) || CHECK_BTN_ALL(input->cur.button, BTN_L) ||
+            CHECK_BTN_ALL(input->press.button, BTN_R) ||
+            (CHECK_BTN_ALL(input->cur.button, BTN_R) && (++frameAdvCtx->timer >= 9))) {
+            CVarClear(CVAR_DEVELOPER_TOOLS("FrameAdvanceTick"));
+            frameAdvCtx->timer = 0;
+            return true;
+        }
+
+        return false;
+    } else {
+        // Frame Advance Original Control Scheme
+
+        if (CHECK_BTN_ALL(input->cur.button, BTN_R) && CHECK_BTN_ALL(input->press.button, BTN_DDOWN)) {
+            frameAdvCtx->enabled = !frameAdvCtx->enabled;
+        }
+
+        if (!frameAdvCtx->enabled || CVarGetInteger(CVAR_DEVELOPER_TOOLS("FrameAdvanceTick"), 0) ||
+            (CHECK_BTN_ALL(input->cur.button, BTN_Z) &&
+             (CHECK_BTN_ALL(input->press.button, BTN_R) ||
+              (CHECK_BTN_ALL(input->cur.button, BTN_R) && (++frameAdvCtx->timer >= 9))))) {
+            CVarClear(CVAR_DEVELOPER_TOOLS("FrameAdvanceTick"));
+            frameAdvCtx->timer = 0;
+            return true;
+        }
+
+        return false;
+    }
 }

--- a/soh/src/code/z_frame_advance.c
+++ b/soh/src/code/z_frame_advance.c
@@ -1,4 +1,6 @@
 #include "global.h"
+#include "soh/Enhancements/game-interactor/GameInteractor.h"
+#include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
 void FrameAdvance_Init(FrameAdvanceContext* frameAdvCtx) {
     frameAdvCtx->timer = 0;
@@ -14,30 +16,8 @@ void FrameAdvance_Init(FrameAdvanceContext* frameAdvCtx) {
  * This function returns true when frame advance is not active (game will run normally)
  */
 s32 FrameAdvance_Update(FrameAdvanceContext* frameAdvCtx, Input* input) {
-    if (CVarGetInteger(CVAR_DEVELOPER_TOOLS("FrameAdvanceAltScheme"), 0) != 0) {
-        // Frame Advance Alternative Control Scheme
-
-        // Push START to toggle the frame advance mode.
-        if (CHECK_BTN_ALL(input->press.button, BTN_START)) {
-            frameAdvCtx->enabled = !frameAdvCtx->enabled;
-        }
-
-        // Push A to advance one frame.
-        // Hold L to run normally until L is released.
-        // Hold R to advance a frame every half second.
-        if (!frameAdvCtx->enabled || CVarGetInteger(CVAR_DEVELOPER_TOOLS("FrameAdvanceTick"), 0) ||
-            CHECK_BTN_ALL(input->press.button, BTN_A) || CHECK_BTN_ALL(input->cur.button, BTN_L) ||
-            CHECK_BTN_ALL(input->press.button, BTN_R) ||
-            (CHECK_BTN_ALL(input->cur.button, BTN_R) && (++frameAdvCtx->timer >= 9))) {
-            CVarClear(CVAR_DEVELOPER_TOOLS("FrameAdvanceTick"));
-            frameAdvCtx->timer = 0;
-            return true;
-        }
-
-        return false;
-    } else {
-        // Frame Advance Original Control Scheme
-
+    if (GameInteractor_Should(VB_FRAME_ADVANCE_BE_VANILLA, true, frameAdvCtx)) {
+        // Vanilla Frame Advance
         if (CHECK_BTN_ALL(input->cur.button, BTN_R) && CHECK_BTN_ALL(input->press.button, BTN_DDOWN)) {
             frameAdvCtx->enabled = !frameAdvCtx->enabled;
         }
@@ -53,4 +33,11 @@ s32 FrameAdvance_Update(FrameAdvanceContext* frameAdvCtx, Input* input) {
 
         return false;
     }
+
+    // Call hooks and ask if we should freeze the frame
+    if (GameInteractor_Should(VB_FRAME_ADVANCE_FREEZE_FRAME, false, frameAdvCtx)) {
+        return false;
+    }
+    // No hooks said we should freeze the frame, so run the game normally
+    return true;
 }

--- a/soh/src/code/z_play.c
+++ b/soh/src/code/z_play.c
@@ -693,7 +693,6 @@ void Play_Update(PlayState* play) {
     Input* input = play->state.input;
     s32 isPaused;
     s32 pad1;
-    s32 frameAdvanceInputPort;
 
     if ((SREG(1) < 0) || (DREG(0) != 0)) {
         SREG(1) = 0;
@@ -731,13 +730,7 @@ void Play_Update(PlayState* play) {
     gSegments[5] = VIRTUAL_TO_PHYSICAL(play->objectCtx.status[play->objectCtx.subKeepIndex].segment);
     gSegments[2] = VIRTUAL_TO_PHYSICAL(play->sceneSegment);
 
-    if (CVarGetInteger(CVAR_DEVELOPER_TOOLS("FrameAdvanceAltScheme"), 0) != 0) {
-        frameAdvanceInputPort = 3; // Frame Advance Alternative Control Scheme. Uses P4 port.
-    } else {
-        frameAdvanceInputPort = 1; // Frame Advance Original Control Scheme. Uses P2 port.
-    }
-
-    if (FrameAdvance_Update(&play->frameAdvCtx, &input[frameAdvanceInputPort])) {
+    if (FrameAdvance_Update(&play->frameAdvCtx, &input[1])) {
         if ((play->transitionMode == TRANS_MODE_OFF) && (play->transitionTrigger != TRANS_TRIGGER_OFF)) {
             play->transitionMode = TRANS_MODE_SETUP;
         }

--- a/soh/src/code/z_play.c
+++ b/soh/src/code/z_play.c
@@ -693,6 +693,7 @@ void Play_Update(PlayState* play) {
     Input* input = play->state.input;
     s32 isPaused;
     s32 pad1;
+    s32 frameAdvanceInputPort;
 
     if ((SREG(1) < 0) || (DREG(0) != 0)) {
         SREG(1) = 0;
@@ -730,7 +731,13 @@ void Play_Update(PlayState* play) {
     gSegments[5] = VIRTUAL_TO_PHYSICAL(play->objectCtx.status[play->objectCtx.subKeepIndex].segment);
     gSegments[2] = VIRTUAL_TO_PHYSICAL(play->sceneSegment);
 
-    if (FrameAdvance_Update(&play->frameAdvCtx, &input[1])) {
+    if (CVarGetInteger(CVAR_DEVELOPER_TOOLS("FrameAdvanceAltScheme"), 0) != 0) {
+        frameAdvanceInputPort = 3; // Frame Advance Alternative Control Scheme. Uses P4 port.
+    } else {
+        frameAdvanceInputPort = 1; // Frame Advance Original Control Scheme. Uses P2 port.
+    }
+
+    if (FrameAdvance_Update(&play->frameAdvCtx, &input[frameAdvanceInputPort])) {
         if ((play->transitionMode == TRANS_MODE_OFF) && (play->transitionTrigger != TRANS_TRIGGER_OFF)) {
             play->transitionMode = TRANS_MODE_SETUP;
         }


### PR DESCRIPTION
This PR adds an alternative Frame Advance control scheme option that uses Controller Port 4.
I wanted a dedicated frame advance keyboard shortcut that don't require holding multiple buttons at once. I'm not sure if dedicating entire controller port 4 for this purpose is a right choice, hence the "draft" status.

Controls (all uses port 4):
* Push START button to toggle Frame Advance.
* Push A button to advance a frame.
* Hold L button to run the game normally until L button is released.
* Hold R button to advance a frame every half second.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4261597418.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4261616258.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4261666189.zip)
<!--- section:artifacts:end -->