### PR TITLE
Default to Hiragana keyboard when playing in Japanese

### DIFF
--- a/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -1374,6 +1374,7 @@ void FileChoose_UpdateQuestMenu(GameState* thisx) {
                 } else {
                     defaultName = &emptyNameNES;
                 }
+                this->charPage = FS_CHAR_PAGE_HIRA; // Default to Hiragana Keyboard
             } else { // GAME_REGION_NTSC
                 defaultName = CVarGetInteger(CVAR_ENHANCEMENT("LinkDefaultName"), 0) ? &linkNameNES : &emptyNameNES;
             }
@@ -1575,6 +1576,7 @@ void FileChoose_UpdateRandomizerMenu(GameState* thisx) {
                     } else {
                         defaultName = &emptyNameNES;
                     }
+                    this->charPage = FS_CHAR_PAGE_HIRA; // Default to Hiragana Keyboard
                 } else { // GAME_REGION_NTSC
                     defaultName = CVarGetInteger(CVAR_ENHANCEMENT("LinkDefaultName"), 0) ? &linkNameNES : &emptyNameNES;
                 }

--- a/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -1375,7 +1375,7 @@ void FileChoose_UpdateQuestMenu(GameState* thisx) {
                     defaultName = &emptyNameNES;
                 }
                 this->charPage = FS_CHAR_PAGE_HIRA; // Default to Hiragana Keyboard
-            } else { // GAME_REGION_NTSC
+            } else {                                // GAME_REGION_NTSC
                 defaultName = CVarGetInteger(CVAR_ENHANCEMENT("LinkDefaultName"), 0) ? &linkNameNES : &emptyNameNES;
             }
             memcpy(Save_GetSaveMetaInfo(this->buttonIndex)->playerName, defaultName, 8);
@@ -1577,7 +1577,7 @@ void FileChoose_UpdateRandomizerMenu(GameState* thisx) {
                         defaultName = &emptyNameNES;
                     }
                     this->charPage = FS_CHAR_PAGE_HIRA; // Default to Hiragana Keyboard
-                } else { // GAME_REGION_NTSC
+                } else {                                // GAME_REGION_NTSC
                     defaultName = CVarGetInteger(CVAR_ENHANCEMENT("LinkDefaultName"), 0) ? &linkNameNES : &emptyNameNES;
                 }
                 memcpy(Save_GetSaveMetaInfo(this->buttonIndex)->playerName, defaultName, 8);


### PR DESCRIPTION
This PR changes the default Name Entry keyboard to Hiragana when playing in Japanese. This matches NTSC Japanese ROM behavior.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3195751702.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3195759490.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3195765697.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3195766639.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3195770703.zip)
<!--- section:artifacts:end -->