### PR TITLE
tts: only announce timer at 10s intervals

### DIFF
--- a/soh/soh/Enhancements/tts/tts.cpp
+++ b/soh/soh/Enhancements/tts/tts.cpp
@@ -147,28 +147,25 @@ void RegisterOnInterfaceUpdateHook() {
             timer = gSaveContext.subTimerSeconds;
         }
 
-        if (timer > 0) {
-            if (timer > prevTimer || (timer % 30 == 0 && prevTimer != timer)) {
-                uint32_t minutes = timer / 60;
-                uint32_t seconds = timer % 60;
-                char* announceBuf = ttsAnnounceBuf;
-                char arg[8]; // at least big enough where no s8 string will overflow
-                if (minutes > 0) {
-                    snprintf(arg, sizeof(arg), "%d", minutes);
-                    auto translation = GetParameritizedText((minutes > 1) ? "minutes_plural" : "minutes_singular",
-                                                            TEXT_BANK_MISC, arg);
-                    announceBuf += snprintf(announceBuf, sizeof(ttsAnnounceBuf), "%s ", translation.c_str());
-                }
-                if (seconds > 0) {
-                    snprintf(arg, sizeof(arg), "%d", seconds);
-                    auto translation = GetParameritizedText((seconds > 1) ? "seconds_plural" : "seconds_singular",
-                                                            TEXT_BANK_MISC, arg);
-                    announceBuf += snprintf(announceBuf, sizeof(ttsAnnounceBuf), "%s", translation.c_str());
-                }
-                assert(announceBuf < ttsAnnounceBuf + sizeof(ttsAnnounceBuf));
-                SpeechSynthesizer::Instance->Speak(ttsAnnounceBuf, GetLanguageCode());
-                prevTimer = timer;
+        if (timer > 0 && timer % 30 == 0 && timer != prevTimer) {
+            uint32_t minutes = timer / 60;
+            uint32_t seconds = timer % 60;
+            char* announceBuf = ttsAnnounceBuf;
+            char arg[8]; // at least big enough where no s8 string will overflow
+            if (minutes > 0) {
+                snprintf(arg, sizeof(arg), "%d", minutes);
+                auto translation =
+                    GetParameritizedText((minutes > 1) ? "minutes_plural" : "minutes_singular", TEXT_BANK_MISC, arg);
+                announceBuf += snprintf(announceBuf, sizeof(ttsAnnounceBuf), "%s ", translation.c_str());
             }
+            if (seconds > 0) {
+                snprintf(arg, sizeof(arg), "%d", seconds);
+                auto translation =
+                    GetParameritizedText((seconds > 1) ? "seconds_plural" : "seconds_singular", TEXT_BANK_MISC, arg);
+                announceBuf += snprintf(announceBuf, sizeof(ttsAnnounceBuf), "%s", translation.c_str());
+            }
+            assert(announceBuf < ttsAnnounceBuf + sizeof(ttsAnnounceBuf));
+            SpeechSynthesizer::Instance->Speak(ttsAnnounceBuf, GetLanguageCode());
         }
 
         prevTimer = timer;

--- a/soh/soh/Enhancements/tts/tts.cpp
+++ b/soh/soh/Enhancements/tts/tts.cpp
@@ -147,7 +147,7 @@ void RegisterOnInterfaceUpdateHook() {
             timer = gSaveContext.subTimerSeconds;
         }
 
-        if (timer > 0 && timer % 30 == 0 && timer != prevTimer) {
+        if (timer > 0 && timer % (timer < 60 ? 10 : 30) == 0 && timer != prevTimer) {
             uint32_t minutes = timer / 60;
             uint32_t seconds = timer % 60;
             char* announceBuf = ttsAnnounceBuf;


### PR DESCRIPTION
1. reading out every second doesn't have enough time to even say more than a number
2. tts is hard to hear the rest of the game over while it's counting non stop

Counting up only occurs during Dampe Race & Horse Race

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3284183221.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3284186035.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3284194215.zip)
<!--- section:artifacts:end -->