### PR TITLE
Convert actor health bars to use ObjectExtension

### DIFF
--- a/soh/include/z64actor.h
+++ b/soh/include/z64actor.h
@@ -266,9 +266,6 @@ typedef struct Actor {
     /* 0x134 */ ActorFunc draw; // Draw Routine. Called by `Actor_Draw`
     /* 0x138 */ ActorResetFunc reset;
     /* 0x13C */ char dbgPad[0x10]; // Padding that only exists in the debug rom
-    // #region SOH [General]
-    /*       */ u8 maximumHealth; // Max health value for use with health bars, set on actor init
-    // #endregion
 } Actor; // size = 0x14C
 
 typedef enum {

--- a/soh/soh/ObjectExtension/ActorMaximumHealth.cpp
+++ b/soh/soh/ObjectExtension/ActorMaximumHealth.cpp
@@ -1,0 +1,29 @@
+#include "ActorMaximumHealth.h"
+#include "soh/ObjectExtension/ObjectExtension.h"
+#include "soh/ShipInit.hpp"
+#include "soh/Enhancements/game-interactor/GameInteractor.h"
+
+struct ActorMaximumHealth {
+    u8 maximumHealth = 0;
+};
+static ObjectExtension::Register<ActorMaximumHealth> ActorMaximumHealthRegister;
+
+u8 GetActorMaximumHealth(const Actor* actor) {
+    const ActorMaximumHealth* maxHealth = ObjectExtension::GetInstance().Get<ActorMaximumHealth>(actor);
+    return maxHealth != nullptr ? maxHealth->maximumHealth : ActorMaximumHealth{}.maximumHealth;
+}
+
+void SetActorMaximumHealth(const Actor* actor, u8 maximumHealth) {
+    ObjectExtension::GetInstance().Set<ActorMaximumHealth>(actor, ActorMaximumHealth{ maximumHealth });
+}
+
+static void ActorMaximumHealth_Register() {
+    COND_HOOK(OnActorInit, true, [](void* ptr) {
+        Actor* actor = static_cast<Actor*>(ptr);
+        if (actor->category == ACTORCAT_ENEMY) {
+            SetActorMaximumHealth(actor, actor->colChkInfo.health);
+        }
+    });
+}
+
+RegisterShipInitFunc actorMaximumHealthInit(ActorMaximumHealth_Register);

--- a/soh/soh/ObjectExtension/ActorMaximumHealth.h
+++ b/soh/soh/ObjectExtension/ActorMaximumHealth.h
@@ -1,0 +1,17 @@
+#ifndef ACTOR_MAXIMUM_HEALTH_H
+#define ACTOR_MAXIMUM_HEALTH_H
+
+#ifdef __cplusplus
+extern "C" {
+#include "z64actor.h"
+#endif
+
+// Max health value for use with health bars, set on actor init
+u8 GetActorMaximumHealth(const Actor* actor);
+void SetActorMaximumHealth(const Actor* actor, u8 maximumHealth);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // ACTOR_MAXIMUM_HEALTH_H

--- a/soh/src/code/z_actor.c
+++ b/soh/src/code/z_actor.c
@@ -1260,11 +1260,6 @@ void Actor_Init(Actor* actor, PlayState* play) {
         actor->init = NULL;
 
         GameInteractor_ExecuteOnActorInit(actor);
-
-        // For enemy health bar we need to know the max health during init
-        if (actor->category == ACTORCAT_ENEMY) {
-            actor->maximumHealth = actor->colChkInfo.health;
-        }
     }
 }
 
@@ -2625,11 +2620,6 @@ void Actor_UpdateAll(PlayState* play, ActorContext* actorCtx) {
                     actor->init = NULL;
 
                     GameInteractor_ExecuteOnActorInit(actor);
-
-                    // For enemy health bar we need to know the max health during init
-                    if (actor->category == ACTORCAT_ENEMY) {
-                        actor->maximumHealth = actor->colChkInfo.health;
-                    }
                 }
                 actor = actor->next;
             } else if (!Object_IsLoaded(&play->objectCtx, actor->objBankIndex)) {

--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -24,6 +24,7 @@
 #include "soh/OTRGlobals.h"
 #include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/gameplaystats.h"
+#include "soh/ObjectExtension/ActorMaximumHealth.h"
 
 #include "message_data_static.h"
 extern MessageTableEntry* sNesMessageEntryTablePtr;
@@ -3643,7 +3644,7 @@ void Interface_DrawEnemyHealthBar(TargetContext* targetCtx, PlayState* play) {
         f32 scaleY = -0.75f;
         f32 scaledHeight = -texHeight * scaleY;
         f32 halfBarWidth = endTexWidth + ((f32)healthbar_fillWidth / 2);
-        s16 healthBarFill = ((f32)actor->colChkInfo.health / actor->maximumHealth) * healthbar_fillWidth;
+        s16 healthBarFill = ((f32)actor->colChkInfo.health / GetActorMaximumHealth(actor)) * healthbar_fillWidth;
 
         if (anchorType == ENEMYHEALTH_ANCHOR_ACTOR) {
             // Get actor projected position

--- a/soh/src/overlays/actors/ovl_En_Fz/z_en_fz.c
+++ b/soh/src/overlays/actors/ovl_En_Fz/z_en_fz.c
@@ -2,6 +2,7 @@
 #include "objects/object_fz/object_fz.h"
 #include "soh/frame_interpolation.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
+#include "soh/ObjectExtension/ActorMaximumHealth.h"
 
 #define FLAGS                                                                                 \
     (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_HOSTILE | ACTOR_FLAG_UPDATE_CULLING_DISABLED | \
@@ -725,7 +726,7 @@ void EnFz_Draw(Actor* thisx, PlayState* play) {
     // displayLists, so we need to recompute the index based on the scaled health (using the maximum health value) and
     // clamp the final result for safety.
     if (CVarGetInteger(CVAR_ENHANCEMENT("EnemySizeScalesHealth"), 0)) {
-        u8 scaledHealth = (u8)(((f32)this->actor.colChkInfo.health / this->actor.maximumHealth) * 6);
+        u8 scaledHealth = (u8)(((f32)this->actor.colChkInfo.health / GetActorMaximumHealth(this)) * 6);
         index = (6 - scaledHealth) >> 1;
         index = CLAMP(index, 0, 2);
     }


### PR DESCRIPTION
This gets us our Actor struct back to vanilla!

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3284876908.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3284877239.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3284877444.zip)
<!--- section:artifacts:end -->