### PR TITLE
Fix club moblins moving out of bounds and remove them from the no-clear-room list

### DIFF
--- a/soh/soh/Enhancements/enemyrandomizer.cpp
+++ b/soh/soh/Enhancements/enemyrandomizer.cpp
@@ -433,11 +433,9 @@ bool IsEnemyAllowedToSpawn(int16_t sceneNum, int8_t roomNum, EnemyEntry enemy) {
     // Shell Blade & Spike - Child Link can't kill these with sword or Deku Stick.
     // Arwing & Dark Link - Both go out of bounds way too easily, softlocking the player.
     // Wallmaster - Not easily visible, often makes players think they're softlocked and that there's no enemies left.
-    // Club Moblin - Many issues with them falling or placing out of bounds. Maybe fixable in the future?
     bool enemiesToExcludeClearRooms = enemy.id == ACTOR_EN_FZ || enemy.id == ACTOR_EN_VM || enemy.id == ACTOR_EN_SB ||
                                       enemy.id == ACTOR_EN_NY || enemy.id == ACTOR_EN_CLEAR_TAG ||
-                                      enemy.id == ACTOR_EN_WALLMAS || enemy.id == ACTOR_EN_TORCH2 ||
-                                      enemy.id == ACTOR_EN_MB;
+                                      enemy.id == ACTOR_EN_WALLMAS || enemy.id == ACTOR_EN_TORCH2;
 
     // Bari - Spawns 3 more enemies, potentially extremely difficult in timed rooms.
     bool enemiesToExcludeTimedRooms = enemiesToExcludeClearRooms || enemy.id == ACTOR_EN_VALI;

--- a/soh/src/overlays/actors/ovl_En_Mb/z_en_mb.c
+++ b/soh/src/overlays/actors/ovl_En_Mb/z_en_mb.c
@@ -303,7 +303,7 @@ void EnMb_Init(Actor* thisx, PlayState* play) {
 
             relYawFromPlayer =
                 this->actor.world.rot.y - Math_Vec3f_Yaw(&this->actor.world.pos, &player->actor.world.pos);
-            if (ABS(relYawFromPlayer) > 0x4000) {
+            if (ABS(relYawFromPlayer) > 0x4000 && !CVarGetInteger(CVAR_ENHANCEMENT("RandomizedEnemies"), 0)) {
                 this->actor.world.rot.y = thisx->world.rot.y + 0x8000;
                 this->actor.shape.rot.y = thisx->world.rot.y;
                 this->actor.world.pos.z = thisx->world.pos.z + 600.0f;


### PR DESCRIPTION
Club Moblins have a line of code that tells them to move and turn around if the player enters their room from a certain angle, to facilitate them appearing on the other side of the SFM corridor when you enter from the minuet pad or forest temple. This would still trigger when they were randomly spawned, often causing them to move out of bounds. This is a quick fix to this behavior, and as a consequence they no longer need to be on the no-clear list. 

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3298679793.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3298736799.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3306692266.zip)
<!--- section:artifacts:end -->