### PR TITLE
Fix King Dodongo entrance crash in grotto mixed pool entrance rando

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer_entrance.c
+++ b/soh/soh/Enhancements/randomizer/randomizer_entrance.c
@@ -253,7 +253,9 @@ void Entrance_Init(void) {
             for (s16 i = 0; i < 4; i++) {
                 // Zero out the bit in the field which tells the game to keep playing
                 // background music for all four scene setups at each index
-                gEntranceTable[override + i].field &= ~ENTRANCE_INFO_CONTINUE_BGM_FLAG;
+                if (override + i < ENTRANCE_TABLE_SIZE) {
+                    gEntranceTable[override + i].field &= ~ENTRANCE_INFO_CONTINUE_BGM_FLAG;
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes #5562 

The crash is stemming from an OOB write in randomizer_entrance.c, which was overwriting memory corresponding to the King Dodongo scene table entry. 

With the introduction of mixed pools, entrances can be shuffled to grottos, which fall outside the range of the vanilla entrance table that is used in clearing the continuing background music flag to account for the GC Lost Woods shortcut and Hyrule Castle -> Market entrances.

This fix simply stops this procedure from happening if the write would be OOB (aka any grotto entrance/exit). Tested and couldn't find any grotto entrances/exits that continued background music, but it's still likely there's a better/more explicit solution than this.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3308767748.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3308777616.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3308820691.zip)
<!--- section:artifacts:end -->