### PR TITLE
CanUse instead of HasItem for Hover Boots to reach jabu switch ledge

### DIFF
--- a/soh/soh/Enhancements/randomizer/location_access/dungeons/jabujabus_belly.cpp
+++ b/soh/soh/Enhancements/randomizer/location_access/dungeons/jabujabus_belly.cpp
@@ -64,7 +64,7 @@ void RegionTable_Init_JabuJabusBelly() {
         //Exits
         Entrance(RR_JABU_JABUS_BELLY_MAIN,                    []{return true;}),
         //there's tricks for getting here with bunny-jumps or just side-hops
-        Entrance(RR_JABU_JABUS_BELLY_WATER_SWITCH_ROOM_LEDGE, []{return logic->HasItem(RG_BRONZE_SCALE) || logic->HasItem(RG_HOVER_BOOTS);}),
+        Entrance(RR_JABU_JABUS_BELLY_WATER_SWITCH_ROOM_LEDGE, []{return logic->HasItem(RG_BRONZE_SCALE) || logic->CanUse(RG_HOVER_BOOTS);}),
         Entrance(RR_JABU_JABUS_BELLY_WATER_SWITCH_ROOM_SOUTH, []{return logic->IsAdult || logic->HasItem(RG_BRONZE_SCALE);}),
     });
 
@@ -90,7 +90,7 @@ void RegionTable_Init_JabuJabusBelly() {
     }, {
         //Exits
         Entrance(RR_JABU_JABUS_BELLY_B1_NORTH,                []{return logic->IsAdult || logic->HasItem(RG_BRONZE_SCALE);}),
-        Entrance(RR_JABU_JABUS_BELLY_WATER_SWITCH_ROOM_LEDGE, []{return logic->HasItem(RG_BRONZE_SCALE) || logic->HasItem(RG_HOVER_BOOTS);}),
+        Entrance(RR_JABU_JABUS_BELLY_WATER_SWITCH_ROOM_LEDGE, []{return logic->HasItem(RG_BRONZE_SCALE) || logic->CanUse(RG_HOVER_BOOTS);}),
         Entrance(RR_JABU_JABUS_BELLY_MAIN,                    []{return logic->CanUseProjectile();}),
     });
 

--- a/soh/soh/Enhancements/randomizer/location_access/overworld/zoras_fountain.cpp
+++ b/soh/soh/Enhancements/randomizer/location_access/overworld/zoras_fountain.cpp
@@ -41,7 +41,7 @@ void RegionTable_Init_ZorasFountain() {
     }, {
         //Exits
         //This hover is pretty tight, come at it with momentum and aim for the small corner polygon of the big iceburg while spamming roll
-        Entrance(RR_ZORAS_FOUNTAIN, []{return logic->HasItem(RG_BRONZE_SCALE) || logic->HasItem(RG_HOVER_BOOTS);}),
+        Entrance(RR_ZORAS_FOUNTAIN, []{return logic->HasItem(RG_BRONZE_SCALE) || logic->CanUse(RG_HOVER_BOOTS);}),
         Entrance(RR_ZF_LAKEBED,     []{return logic->CanUse(RG_IRON_BOOTS);}),
         Entrance(RR_ZF_LEDGE,       []{return true;}),
     });


### PR DESCRIPTION
The real issue behind the bug #5580 found. 

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3328233996.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3328236021.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3328240397.zip)
<!--- section:artifacts:end -->