### PR TITLE
RecalculateAvailableChecks Fix - IsSaveLoaded Guard

### DIFF
--- a/soh/soh/Enhancements/debugconsole.cpp
+++ b/soh/soh/Enhancements/debugconsole.cpp
@@ -1471,10 +1471,7 @@ static bool AvailableChecksProcessUndiscoveredExitsHandler(std::shared_ptr<Ship:
     INFO_MESSAGE("[SOH] Available Checks - Process Undiscovered Exits %s",
                  logic->ACProcessUndiscoveredExits ? "enabled" : "disabled");
 
-    if (GameInteractor::IsSaveLoaded(true)) {
-        CheckTracker::RecalculateAvailableChecks();
-    }
-
+    CheckTracker::RecalculateAvailableChecks();
     return 0;
 }
 

--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -1985,10 +1985,7 @@ void ImGuiDrawTwoColorPickerSection(const char* text, const char* cvarMainName, 
 }
 
 void RecalculateAvailableChecks(RandomizerRegion startingRegion /* = RR_ROOT */) {
-    if (!enableAvailableChecks) {
-        return;
-    }
-    if (!GameInteractor::IsSaveLoaded(true)) {
+    if (!enableAvailableChecks || !GameInteractor::IsSaveLoaded(true)) {
         return;
     }
 

--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -1988,6 +1988,9 @@ void RecalculateAvailableChecks(RandomizerRegion startingRegion /* = RR_ROOT */)
     if (!enableAvailableChecks) {
         return;
     }
+    if (!GameInteractor::IsSaveLoaded(true)) {
+        return;
+    }
 
     ResetPerformanceTimer(PT_RECALCULATE_AVAILABLE_CHECKS);
     StartPerformanceTimer(PT_RECALCULATE_AVAILABLE_CHECKS);
@@ -2135,10 +2138,7 @@ void CheckTrackerSettingsWindow::DrawElement() {
                                                  "with your current progress.")
                                         .Color(THEME_COLOR))) {
             enableAvailableChecks = CVarGetInteger(CVAR_TRACKER_CHECK("EnableAvailableChecks"), 0);
-
-            if (GameInteractor::IsSaveLoaded(true)) {
-                RecalculateAvailableChecks();
-            }
+            RecalculateAvailableChecks();
         }
         ImGui::EndDisabled();
 


### PR DESCRIPTION
Added `IsSaveLoaded` guard clause to `RecalculateAvailableChecks`.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3329503099.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3329504071.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3329506652.zip)
<!--- section:artifacts:end -->