### PR TITLE
Hardcode spirit hands to be dungeon checks

### DIFF
--- a/soh/soh/Enhancements/randomizer/location.cpp
+++ b/soh/soh/Enhancements/randomizer/location.cpp
@@ -55,7 +55,8 @@ const std::string& Rando::Location::GetShortName() const {
 bool Rando::Location::IsDungeon() const {
     return (checkType != RCTYPE_SKULL_TOKEN &&
             (scene <= SCENE_GERUDO_TRAINING_GROUND || scene == SCENE_INSIDE_GANONS_CASTLE ||
-             (scene >= SCENE_DEKU_TREE_BOSS && scene <= SCENE_GANONDORF_BOSS))) ||
+             (scene >= SCENE_DEKU_TREE_BOSS && scene <= SCENE_GANONDORF_BOSS)) ||
+             (rc == RC_SPIRIT_TEMPLE_SILVER_GAUNTLETS_CHEST || rc == RC_SPIRIT_TEMPLE_MIRROR_SHIELD_CHEST)) ||
            (checkType == RCTYPE_SKULL_TOKEN && scene <= SCENE_ICE_CAVERN);
 }
 

--- a/soh/soh/Enhancements/randomizer/location.cpp
+++ b/soh/soh/Enhancements/randomizer/location.cpp
@@ -54,9 +54,9 @@ const std::string& Rando::Location::GetShortName() const {
 
 bool Rando::Location::IsDungeon() const {
     return (checkType != RCTYPE_SKULL_TOKEN &&
-            (scene <= SCENE_GERUDO_TRAINING_GROUND || scene == SCENE_INSIDE_GANONS_CASTLE ||
-             (scene >= SCENE_DEKU_TREE_BOSS && scene <= SCENE_GANONDORF_BOSS)) ||
-             (rc == RC_SPIRIT_TEMPLE_SILVER_GAUNTLETS_CHEST || rc == RC_SPIRIT_TEMPLE_MIRROR_SHIELD_CHEST)) ||
+                (scene <= SCENE_GERUDO_TRAINING_GROUND || scene == SCENE_INSIDE_GANONS_CASTLE ||
+                 (scene >= SCENE_DEKU_TREE_BOSS && scene <= SCENE_GANONDORF_BOSS)) ||
+            (rc == RC_SPIRIT_TEMPLE_SILVER_GAUNTLETS_CHEST || rc == RC_SPIRIT_TEMPLE_MIRROR_SHIELD_CHEST)) ||
            (checkType == RCTYPE_SKULL_TOKEN && scene <= SCENE_ICE_CAVERN);
 }
 


### PR DESCRIPTION
overworld hints were pointing to spirit hands because their scene is desert colossus, however for all practical purposes the hands are dungeon checks (being part of spirit temple for hint area and keys and such). This change is a quick fix to that as properly moving them to spirit temple has consequences involving the vanilla vs MQ, among possible other side effects.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3335380497.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3335382503.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3335422292.zip)
<!--- section:artifacts:end -->