### PR TITLE
SwitchTimerMultiplier: fix crash due to missing actor param

### DIFF
--- a/soh/src/overlays/actors/ovl_Bg_Gnd_Darkmeiro/z_bg_gnd_darkmeiro.c
+++ b/soh/src/overlays/actors/ovl_Bg_Gnd_Darkmeiro/z_bg_gnd_darkmeiro.c
@@ -134,7 +134,7 @@ void BgGndDarkmeiro_UpdateBlockTimer(BgGndDarkmeiro* this, PlayState* play) {
     if (Flags_GetSwitch(play, ((this->dyna.actor.params >> 8) & 0x3F) + 2)) {
         if (this->actionFlags & 8) {
             if (this->timer2 > 0) {
-                if (GameInteractor_Should(VB_SWITCH_TIMER_TICK, true, &this->timer2)) {
+                if (GameInteractor_Should(VB_SWITCH_TIMER_TICK, true, this, &this->timer2)) {
                     this->timer2--;
                 }
             } else {

--- a/soh/src/overlays/actors/ovl_Bg_Relay_Objects/z_bg_relay_objects.c
+++ b/soh/src/overlays/actors/ovl_Bg_Relay_Objects/z_bg_relay_objects.c
@@ -169,7 +169,7 @@ void BgRelayObjects_DoNothing(BgRelayObjects* this, PlayState* play) {
 }
 
 void func_808A932C(BgRelayObjects* this, PlayState* play) {
-    if (GameInteractor_Should(VB_SWITCH_TIMER_TICK, this->timer != 0, &this->timer)) {
+    if (GameInteractor_Should(VB_SWITCH_TIMER_TICK, this->timer != 0, this, &this->timer)) {
         this->timer--;
     }
     if (this->timer == 0) {


### PR DESCRIPTION
null

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3341518230.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3341529232.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3341551718.zip)
<!--- section:artifacts:end -->