### PR TITLE
Adds saving and loading for location exclusion, and hooks the check t…

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -1588,10 +1588,11 @@ bool IsCheckShuffled(RandomizerCheck rc) {
 bool IsVisibleInCheckTracker(RandomizerCheck rc) {
     auto loc = Rando::StaticData::GetLocation(rc);
     if (IS_RANDO) {
-        return IsCheckShuffled(rc) ||
-               (alwaysShowGS && loc->GetRCType() == RCTYPE_SKULL_TOKEN &&
-                OTRGlobals::Instance->gRandoContext->IsQuestOfLocationActive(rc)) ||
-               (loc->GetRCType() == RCTYPE_SHOP && showShops && !hideShopUnshuffledChecks);
+        return !Rando::Context::GetInstance()->GetItemLocation(rc)->IsExcluded() &&
+               (IsCheckShuffled(rc) ||
+                (alwaysShowGS && loc->GetRCType() == RCTYPE_SKULL_TOKEN &&
+                 OTRGlobals::Instance->gRandoContext->IsQuestOfLocationActive(rc)) ||
+                (loc->GetRCType() == RCTYPE_SHOP && showShops && !hideShopUnshuffledChecks));
     } else {
         return loc->IsVanillaCompletion() &&
                (!loc->IsDungeon() || (loc->IsDungeon() && loc->GetQuest() == gSaveContext.ship.quest.id));

--- a/soh/soh/SaveManager.cpp
+++ b/soh/soh/SaveManager.cpp
@@ -179,6 +179,9 @@ void SaveManager::LoadRandomizer() {
                 // all ItemLocations is 0 anyway.
                 randoContext->GetItemLocation(i)->SetCustomPrice(price);
             }
+            bool excluded = false;
+            SaveManager::Instance->LoadData("excluded", excluded, false);
+            randoContext->GetItemLocation(i)->SetExcludedOption(excluded);
         });
     });
 
@@ -268,6 +271,9 @@ void SaveManager::SaveRandomizer(SaveContext* saveContext, int sectionID, bool f
                                                     randoContext->GetItemOverride(i).GetTrickName().GetFrench());
                     // TODO: German (trick names don't have german translations yet)
                 });
+            }
+            if (randoContext->GetItemLocation(i)->IsExcluded()) {
+                SaveManager::Instance->SaveData("excluded", true);
             }
             if (randoContext->GetItemLocation(i)->HasCustomPrice()) {
                 SaveManager::Instance->SaveData("price", randoContext->GetItemLocation(i)->GetPrice());


### PR DESCRIPTION
Adds saving and loading for location exclusion status in the save file, and hooks the check tracker into it to return false from `IsVisibleInCheckTracker()` if a location was excluded.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3341625180.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3341630451.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3341664018.zip)
<!--- section:artifacts:end -->