### PR TITLE
Convert "Passage of Time on File Select" to ShipInit Hook

### DIFF
--- a/soh/soh/Enhancements/cosmetics/TimeFlowFileSelect.cpp
+++ b/soh/soh/Enhancements/cosmetics/TimeFlowFileSelect.cpp
@@ -1,0 +1,20 @@
+#include <libultraship/bridge.h>
+#include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
+#include "soh/ShipInit.hpp"
+#include "z64save.h"
+
+extern "C" SaveContext gSaveContext;
+
+static constexpr int32_t CVAR_TIMEFLOWFILESELECT_DEFAULT = 0;
+#define CVAR_TIMEFLOWFILESELECT_NAME CVAR_ENHANCEMENT("TimeFlowFileSelect")
+#define CVAR_TIMEFLOWFILESELECT_VALUE CVarGetInteger(CVAR_TIMEFLOWFILESELECT_NAME, CVAR_TIMEFLOWFILESELECT_DEFAULT)
+
+void OnFileChooseMainTimeFlowFileSelect(void* gameState) {
+    gSaveContext.skyboxTime += 0x10;
+}
+
+void RegisterTimeFlowFileSelect() {
+    COND_HOOK(OnFileChooseMain, CVAR_TIMEFLOWFILESELECT_VALUE, OnFileChooseMainTimeFlowFileSelect);
+}
+
+static RegisterShipInitFunc initFunc_TimeFlowFileSelect(RegisterTimeFlowFileSelect, { CVAR_TIMEFLOWFILESELECT_NAME });

--- a/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -3597,10 +3597,6 @@ void FileChoose_Main(GameState* thisx) {
         sWindowContentColors[0][2] = 255;
     }
 
-    if (CVarGetInteger(CVAR_ENHANCEMENT("TimeFlowFileSelect"), 0) != 0) {
-        gSaveContext.skyboxTime += 0x10;
-    }
-
     OPEN_DISPS(this->state.gfxCtx);
 
     this->n64ddFlag = 0;


### PR DESCRIPTION
This PR adds a new hook on `FileChoose_Main` at z_file_choose.c (same hook as #5485), and moves "Passage of Time on File Select" code to a separate cpp file that uses ShipInit hook.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3366716365.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3366723321.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3366734124.zip)
<!--- section:artifacts:end -->