### PR TITLE
Fix Windows warning for euro symbol in CustomMessageManager.h

### DIFF
--- a/soh/CMakeLists.txt
+++ b/soh/CMakeLists.txt
@@ -138,6 +138,8 @@ endforeach()
 if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     set_source_files_properties(soh/OTRGlobals.cpp PROPERTIES COMPILE_FLAGS "/utf-8")
     set_source_files_properties(soh/Enhancements/tts/tts.cpp PROPERTIES COMPILE_FLAGS "/utf-8")
+    set_source_files_properties(soh/Enhancements/custom-message/CustomMessageManager.cpp PROPERTIES COMPILE_FLAGS "/utf-8")
+    set_source_files_properties(soh/Enhancements/custom-message/CustomMessageManager.h PROPERTIES COMPILE_FLAGS "/utf-8")
 endif()
 
 # handle Network removals

--- a/soh/soh/Enhancements/custom-message/CustomMessageManager.h
+++ b/soh/soh/Enhancements/custom-message/CustomMessageManager.h
@@ -154,9 +154,9 @@ class CustomMessage {
     void InsertNumber(uint8_t num);
 
     /**
-     * @brief A € sign at the end of an item name signals that it is plural.
+     * @brief A â‚¬ sign at the end of an item name signals that it is plural.
      * If a hint text has |singular|plural| forms specified, the unused one get's deleted.
-     * If no € sign is present, the singular form is used.
+     * If no â‚¬ sign is present, the singular form is used.
      */
     void SetSingularPlural();
 


### PR DESCRIPTION
null

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3375865593.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3375870608.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3375905836.zip)
<!--- section:artifacts:end -->