### PR TITLE
Early Ship::Context Initialization

### DIFF
--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -261,6 +261,10 @@ const char* constCameraStrings[] = {
 };
 
 OTRGlobals::OTRGlobals() {
+    context = Ship::Context::CreateUninitializedInstance("Ship of Harkinian", appShortName, "shipofharkinian.json");
+}
+
+void OTRGlobals::Initialize() {
     std::vector<std::string> OTRFiles;
     std::string mqPath = Ship::Context::LocateFileAcrossAppDirs("oot-mq.otr", appShortName);
     if (std::filesystem::exists(mqPath)) {
@@ -299,8 +303,6 @@ OTRGlobals::OTRGlobals() {
         OOT_NTSC_US_11, OOT_NTSC_US_12, OOT_PAL_10,     OOT_PAL_11,        OOT_NTSC_JP_GC_CE,
         OOT_NTSC_JP_GC, OOT_NTSC_US_GC, OOT_PAL_GC,     OOT_PAL_GC_DBG1,   OOT_PAL_GC_DBG2,
     };
-
-    context = Ship::Context::CreateUninitializedInstance("Ship of Harkinian", appShortName, "shipofharkinian.json");
 
     context->InitLogging();
     context->InitGfxDebugger();
@@ -1100,7 +1102,7 @@ void CheckAndCreateModFolder() {
 }
 
 extern "C" void InitOTR() {
-
+    OTRGlobals::Instance = new OTRGlobals();
 #ifdef __SWITCH__
     Ship::Switch::Init(Ship::PreInitPhase);
 #elif defined(__WIIU__)
@@ -1207,7 +1209,7 @@ extern "C" void InitOTR() {
     DetectOTRVersion("oot.otr", false);
     DetectOTRVersion("oot-mq.otr", true);
 
-    OTRGlobals::Instance = new OTRGlobals();
+    OTRGlobals::Instance->Initialize();
     CustomMessageManager::Instance = new CustomMessageManager();
     ItemTableManager::Instance = new ItemTableManager();
     GameInteractor::Instance = new GameInteractor();

--- a/soh/soh/OTRGlobals.h
+++ b/soh/soh/OTRGlobals.h
@@ -71,7 +71,7 @@ class OTRGlobals {
     ~OTRGlobals();
 
     void ScaleImGui();
-
+    void Initialize();
     bool HasMasterQuest();
     bool HasOriginal();
     uint32_t GetInterpolationFPS();


### PR DESCRIPTION
Initialize OTRGlobals' Context early to prevent non-portable crash during asset archive lookup.

The only thing that is needed for that lookup is the app shortName, which is passed in the initialization function. I'm working on half-initialization separately to allow for ImGui to be used before ROM archives exist.

Fixes #5602

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3375903272.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3375905468.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3375927416.zip)
<!--- section:artifacts:end -->