### PR TITLE
Enhancement to double pause menu animation speed

### DIFF
--- a/soh/soh/Enhancements/TimeSavers/FasterKaleido.cpp
+++ b/soh/soh/Enhancements/TimeSavers/FasterKaleido.cpp
@@ -7,7 +7,7 @@ extern PlayState* gPlayState;
 extern void func_808237B4(PlayState* play, Input* input);
 }
 
-#define CVAR_FASTER_KALEIDO_NAME CVAR_ENHANCEMENT("FasterKaleido")
+#define CVAR_FASTER_KALEIDO_NAME CVAR_ENHANCEMENT("FasterPauseMenu")
 #define CVAR_FASTER_KALEIDO_VALUE CVarGetInteger(CVAR_FASTER_KALEIDO_NAME, 0)
 
 void OnKaleidoUpdateFaster() {

--- a/soh/soh/Enhancements/TimeSavers/FasterKaleido.cpp
+++ b/soh/soh/Enhancements/TimeSavers/FasterKaleido.cpp
@@ -1,0 +1,35 @@
+#include "soh/Enhancements/game-interactor/GameInteractor.h"
+#include "soh/ShipInit.hpp"
+
+extern "C" {
+#include "variables.h"
+extern PlayState* gPlayState;
+extern void func_808237B4(PlayState* play, Input* input);
+}
+
+#define CVAR_FASTER_KALEIDO_NAME CVAR_ENHANCEMENT("FasterKaleido")
+#define CVAR_FASTER_KALEIDO_VALUE CVarGetInteger(CVAR_FASTER_KALEIDO_NAME, 0)
+
+void OnKaleidoUpdateFaster() {
+    ZREG(46) = 2; // pauseCtx->eye and pauseCtx->unk_1EA multiply by this for animation. Double the default value.
+    WREG(6) = 4;  // Numerous kaleido animations divide by this for movement and alpha. Half the default value.
+
+    // Page turn animation is governed by func_808237B4. Those values don't use registers to modify the speed, so we
+    // just directly call it twice to effectively double the speed.
+    if (gPlayState->pauseCtx.state == 6 && gPlayState->pauseCtx.unk_1E4 == 1) { // In page turning mode
+        func_808237B4(gPlayState, gPlayState->state.input);
+    }
+}
+
+void RegisterFasterKaleido() {
+    COND_HOOK(GameInteractor::OnKaleidoUpdate, CVAR_FASTER_KALEIDO_VALUE, OnKaleidoUpdateFaster);
+
+    // Reset register values on close. These values are only used by z_kaleido_scope_PAL.c
+    COND_VB_SHOULD(VB_KALEIDO_UNPAUSE_CLOSE, CVAR_FASTER_KALEIDO_VALUE, {
+        // Default values, as defined in Regs_InitDataImpl
+        ZREG(46) = 1;
+        WREG(6) = 8;
+    });
+}
+
+static RegisterShipInitFunc initFunc(RegisterFasterKaleido, { CVAR_FASTER_KALEIDO_NAME });

--- a/soh/soh/Enhancements/TimeSavers/FasterPauseMenu.cpp
+++ b/soh/soh/Enhancements/TimeSavers/FasterPauseMenu.cpp
@@ -21,7 +21,7 @@ void OnKaleidoUpdateFaster() {
     }
 }
 
-void RegisterFasterPauseMenu() {
+void InitFasterPauseMenu() {
     COND_HOOK(GameInteractor::OnKaleidoUpdate, CVAR_FASTER_PAUSE_MENU_VALUE, OnKaleidoUpdateFaster);
 
     // Reset register values on close. These values are only used by z_kaleido_scope_PAL.c
@@ -32,4 +32,4 @@ void RegisterFasterPauseMenu() {
     });
 }
 
-static RegisterShipInitFunc initFunc(RegisterFasterPauseMenu, { CVAR_FASTER_PAUSE_MENU_NAME });
+static RegisterShipInitFunc initFunc(InitFasterPauseMenu, { CVAR_FASTER_PAUSE_MENU_NAME });

--- a/soh/soh/Enhancements/TimeSavers/FasterPauseMenu.cpp
+++ b/soh/soh/Enhancements/TimeSavers/FasterPauseMenu.cpp
@@ -7,8 +7,8 @@ extern PlayState* gPlayState;
 extern void func_808237B4(PlayState* play, Input* input);
 }
 
-#define CVAR_FASTER_KALEIDO_NAME CVAR_ENHANCEMENT("FasterPauseMenu")
-#define CVAR_FASTER_KALEIDO_VALUE CVarGetInteger(CVAR_FASTER_KALEIDO_NAME, 0)
+#define CVAR_FASTER_PAUSE_MENU_NAME CVAR_ENHANCEMENT("FasterPauseMenu")
+#define CVAR_FASTER_PAUSE_MENU_VALUE CVarGetInteger(CVAR_FASTER_PAUSE_MENU_NAME, 0)
 
 void OnKaleidoUpdateFaster() {
     ZREG(46) = 2; // pauseCtx->eye and pauseCtx->unk_1EA multiply by this for animation. Double the default value.
@@ -21,15 +21,15 @@ void OnKaleidoUpdateFaster() {
     }
 }
 
-void RegisterFasterKaleido() {
-    COND_HOOK(GameInteractor::OnKaleidoUpdate, CVAR_FASTER_KALEIDO_VALUE, OnKaleidoUpdateFaster);
+void RegisterFasterPauseMenu() {
+    COND_HOOK(GameInteractor::OnKaleidoUpdate, CVAR_FASTER_PAUSE_MENU_VALUE, OnKaleidoUpdateFaster);
 
     // Reset register values on close. These values are only used by z_kaleido_scope_PAL.c
-    COND_VB_SHOULD(VB_KALEIDO_UNPAUSE_CLOSE, CVAR_FASTER_KALEIDO_VALUE, {
+    COND_VB_SHOULD(VB_KALEIDO_UNPAUSE_CLOSE, CVAR_FASTER_PAUSE_MENU_VALUE, {
         // Default values, as defined in Regs_InitDataImpl
         ZREG(46) = 1;
         WREG(6) = 8;
     });
 }
 
-static RegisterShipInitFunc initFunc(RegisterFasterKaleido, { CVAR_FASTER_KALEIDO_NAME });
+static RegisterShipInitFunc initFunc(RegisterFasterPauseMenu, { CVAR_FASTER_PAUSE_MENU_NAME });

--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -351,6 +351,9 @@ void SohMenu::AddMenuEnhancements() {
     AddWidget(path, "King Zora Speed: %.2fx", WIDGET_CVAR_SLIDER_FLOAT)
         .CVar(CVAR_ENHANCEMENT("MweepSpeed"))
         .Options(FloatSliderOptions().Min(0.1f).Max(5.0f).DefaultValue(1.0f).Format("%.2fx"));
+    AddWidget(path, "Faster Pause Menu", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_ENHANCEMENT("FasterKaleido"))
+        .Options(CheckboxOptions().Tooltip("Speeds up animation of the pause menu, similar to Majora's Mask"));
 
     path.column = SECTION_COLUMN_3;
     AddWidget(path, "Misc", WIDGET_SEPARATOR_TEXT);

--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -352,7 +352,7 @@ void SohMenu::AddMenuEnhancements() {
         .CVar(CVAR_ENHANCEMENT("MweepSpeed"))
         .Options(FloatSliderOptions().Min(0.1f).Max(5.0f).DefaultValue(1.0f).Format("%.2fx"));
     AddWidget(path, "Faster Pause Menu", WIDGET_CVAR_CHECKBOX)
-        .CVar(CVAR_ENHANCEMENT("FasterKaleido"))
+        .CVar(CVAR_ENHANCEMENT("FasterPauseMenu"))
         .Options(CheckboxOptions().Tooltip("Speeds up animation of the pause menu, similar to Majora's Mask"));
 
     path.column = SECTION_COLUMN_3;


### PR DESCRIPTION
https://github.com/user-attachments/assets/b1016ee9-5a6a-41de-89c6-73434832046c

OoT's pause menu can feel sluggish compared to MM's. It turns out that MM outright doubles the animation speed of the menu:

https://github.com/HarbourMasters/2ship2harkinian/blob/620859447c6bddcdf1dded50a7a4110f825536bf/mm/src/overlays/kaleido_scope/ovl_kaleido_scope/z_kaleido_scope_NES.c#L3234-L3236

There exist in the OoT kaleido code uses of `ZREG` and `WREG` values to govern the animation speed of the menu. This enhancement simply modifies those to achieve double speed. The page turn animation does not use multipliers (whereas it does in MM), so that part of this speedup is achieved by just calling the update method twice. We could just modify the source to use the same multipliers the other parts, but this approach keeps the changes isolated in one enhancement file.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3414506099.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3414516906.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3414544330.zip)
<!--- section:artifacts:end -->