### PR TITLE
Fix Infinite Wallet Upgrade

### DIFF
--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -2122,7 +2122,7 @@ void RandomizerOnGameFrameUpdateHandler() {
     }
 
     if (Flags_GetRandomizerInf(RAND_INF_HAS_INFINITE_MONEY)) {
-        gSaveContext.rupees = static_cast<int8_t>(CUR_CAPACITY(UPG_WALLET));
+        gSaveContext.rupees = static_cast<s16>(CUR_CAPACITY(UPG_WALLET));
     }
 
     if (!Flags_GetRandomizerInf(RAND_INF_HAS_WALLET)) {


### PR DESCRIPTION
Fixes #5614 

gSaveContext.rupees is an s16, so the rupee value was being truncated, resulting in a negative value being assigned each frame

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3406286603.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3406294116.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3406317533.zip)
<!--- section:artifacts:end -->