### PR TITLE
Tweak boss rush fix

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -495,7 +495,7 @@ void SetShopSeen(uint32_t sceneNum, bool prices) {
 }
 
 void CheckTrackerLoadGame(int32_t fileNum) {
-    if (!IS_RANDO) {
+    if (IS_BOSS_RUSH) {
         return;
     }
     LoadSettings();


### PR DESCRIPTION
#5623 fixed a crash in the tracker, but I forgot that tracking does still work, though only partially, in vanilla, so I changed it from `!IS_RANDO` to `IS_BOSS_RUSH`.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3428448514.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3428509101.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3428514472.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3428525090.zip)
<!--- section:artifacts:end -->