### PR TITLE
Fix clang-format ps1 script

### DIFF
--- a/run-clang-format.ps1
+++ b/run-clang-format.ps1
@@ -25,7 +25,7 @@ if (-not (Test-Path $clangFormatFilePath) -or ($currentVersion -ne $requiredVers
     }
 
     $wc = New-Object net.webclient
-    $wc.Downloadfile($url, $PSScriptRoot + "\LLVM-14.0.6-win64.exe")
+    $wc.Downloadfile($url, $PSScriptRoot + $llvmInstallerPath)
 
     $sevenZipPath = "C:\Program Files\7-Zip\7z.exe"
     $specificFileInArchive = "bin\clang-format.exe"

--- a/run-clang-format.ps1
+++ b/run-clang-format.ps1
@@ -25,7 +25,7 @@ if (-not (Test-Path $clangFormatFilePath) -or ($currentVersion -ne $requiredVers
     }
 
     $wc = New-Object net.webclient
-    $wc.Downloadfile($url, $llvmInstallerPath)
+    $wc.Downloadfile($url, $PSScriptRoot + "\LLVM-14.0.6-win64.exe")
 
     $sevenZipPath = "C:\Program Files\7-Zip\7z.exe"
     $specificFileInArchive = "bin\clang-format.exe"


### PR DESCRIPTION
Script wasn't working for me because for some reason, specifically within `Downloadfile` the relative path pointed to windows32 and not the current directory. So instead just for that, using the built-in `$PSScriptRoot` variable makes it point to the curent folder properly.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3435962913.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3435965282.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3435979161.zip)
<!--- section:artifacts:end -->