### PR TITLE
Split Skip Pickup Messages

### DIFF
--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -353,9 +353,12 @@ void SohMenu::AddMenuEnhancements() {
             "Door Switch CS, Water Temple Dragon Switch CS, and the Box Skip One Point in Jabu."));
 
     AddWidget(path, "Text", WIDGET_SEPARATOR_TEXT);
-    AddWidget(path, "Skip Pickup Messages", WIDGET_CVAR_CHECKBOX)
+    AddWidget(path, "Skip Bottle Pickup Messages", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("FastDrops"))
-        .Options(CheckboxOptions().Tooltip("Skip Pickup Messages for new Consumable Items and Bottle Swipes."));
+        .Options(CheckboxOptions().Tooltip("Skip Pickup Messages for Bottle Swipes."));
+    AddWidget(path, "Skip Consumable Item Pickup Messages", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_ENHANCEMENT("FastConsumables"))
+        .Options(CheckboxOptions().Tooltip("Skip Pickup Messages for new Consumable Items."));
     AddWidget(path, "Skip Forced Dialog", WIDGET_CVAR_COMBOBOX)
         .CVar(CVAR_ENHANCEMENT("TimeSavers.SkipForcedDialog"))
         .Options(ComboboxOptions()

--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -354,10 +354,10 @@ void SohMenu::AddMenuEnhancements() {
 
     AddWidget(path, "Text", WIDGET_SEPARATOR_TEXT);
     AddWidget(path, "Skip Bottle Pickup Messages", WIDGET_CVAR_CHECKBOX)
-        .CVar(CVAR_ENHANCEMENT("FastDrops"))
+        .CVar(CVAR_ENHANCEMENT("FastBottles"))
         .Options(CheckboxOptions().Tooltip("Skip Pickup Messages for Bottle Swipes."));
     AddWidget(path, "Skip Consumable Item Pickup Messages", WIDGET_CVAR_CHECKBOX)
-        .CVar(CVAR_ENHANCEMENT("FastConsumables"))
+        .CVar(CVAR_ENHANCEMENT("FastDrops"))
         .Options(CheckboxOptions().Tooltip("Skip Pickup Messages for new Consumable Items."));
     AddWidget(path, "Skip Forced Dialog", WIDGET_CVAR_COMBOBOX)
         .CVar(CVAR_ENHANCEMENT("TimeSavers.SkipForcedDialog"))

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -14697,7 +14697,7 @@ void Player_Action_SwingBottle(Player* this, PlayState* play) {
     if (LinkAnimation_Update(play, &this->skelAnime)) {
         if (this->av1.bottleCatchType != BOTTLE_CATCH_NONE) {
             if (!this->av2.startedTextbox) {
-                if (CVarGetInteger(CVAR_ENHANCEMENT("FastDrops"), 0)) {
+                if (CVarGetInteger(CVAR_ENHANCEMENT("FastBottles"), 0)) {
                     this->av1.bottleCatchType = BOTTLE_CATCH_NONE;
                 } else {
                     // 1 is subtracted because `sBottleCatchInfo` does not have an entry for `BOTTLE_CATCH_NONE`
@@ -14740,13 +14740,13 @@ void Player_Action_SwingBottle(Player* this, PlayState* play) {
                     this->av1.bottleCatchType = i + 1;
 
                     this->av2.startedTextbox = false;
-                    if (!CVarGetInteger(CVAR_ENHANCEMENT("FastDrops"), 0)) {
+                    if (!CVarGetInteger(CVAR_ENHANCEMENT("FastBottles"), 0)) {
                         this->stateFlags1 |= PLAYER_STATE1_IN_ITEM_CS | PLAYER_STATE1_IN_CUTSCENE;
                     }
                     this->interactRangeActor->parent = &this->actor;
 
                     Player_UpdateBottleHeld(play, this, catchInfo->itemId, ABS(catchInfo->itemAction));
-                    if (!CVarGetInteger(CVAR_ENHANCEMENT("FastDrops"), 0)) {
+                    if (!CVarGetInteger(CVAR_ENHANCEMENT("FastBottles"), 0)) {
                         Player_AnimPlayOnceAdjusted(play, this, swingEntry->catchAnimation);
                         func_80835EA4(play, 4);
                     }

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -7353,7 +7353,7 @@ s32 Player_ActionHandler_2(Player* this, PlayState* play) {
                 // Skip cutscenes from picking up consumables with "Fast Pickup Text" enabled, even when the player
                 // never picked it up before. But only for bushes/rocks/enemies because otherwise it can lead to
                 // softlocks in deku mask theatre and potentially other places.
-                uint8_t skipItemCutscene = CVarGetInteger(CVAR_ENHANCEMENT("FastDrops"), 0) && isDropToSkip;
+                uint8_t skipItemCutscene = CVarGetInteger(CVAR_ENHANCEMENT("FastConsumables"), 0) && isDropToSkip;
 
                 // Same as above but for rando. Rando is different because we want to enable cutscenes for items that
                 // the player already has because those items could be a randomized item coming from scrubs,

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -7353,7 +7353,7 @@ s32 Player_ActionHandler_2(Player* this, PlayState* play) {
                 // Skip cutscenes from picking up consumables with "Fast Pickup Text" enabled, even when the player
                 // never picked it up before. But only for bushes/rocks/enemies because otherwise it can lead to
                 // softlocks in deku mask theatre and potentially other places.
-                uint8_t skipItemCutscene = CVarGetInteger(CVAR_ENHANCEMENT("FastConsumables"), 0) && isDropToSkip;
+                uint8_t skipItemCutscene = CVarGetInteger(CVAR_ENHANCEMENT("FastDrops"), 0) && isDropToSkip;
 
                 // Same as above but for rando. Rando is different because we want to enable cutscenes for items that
                 // the player already has because those items could be a randomized item coming from scrubs,


### PR DESCRIPTION
following ZFG's comment in one of his recent randos https://youtube.com/clip/UgkxF-LDaR-zyTkqSkqtP3dkLrCca_KGScIw?si=RJY9SIG8QKSiWgVl

splits the Skip Pickup Messages time saver into 2 for consumables and bottle pickups

Decided to do this since it was probably gonna be quick (building took more time than making the changes) cus I thought it'd be useful

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3454320673.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3454399620.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3454403637.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3454407818.zip)
<!--- section:artifacts:end -->