### PR TITLE
dev-tools: add bit label on flags table

### DIFF
--- a/soh/CMakeLists.txt
+++ b/soh/CMakeLists.txt
@@ -502,6 +502,7 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
     if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
         target_compile_options(${PROJECT_NAME} PRIVATE
             -Wall -Wextra -Wno-error
+            -Wformat-security
             -Wno-return-type
             -Wno-unused-parameter
             -Wno-unused-function
@@ -529,6 +530,7 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
     elseif (CMAKE_SYSTEM_NAME STREQUAL "NintendoSwitch")
         target_compile_options(${PROJECT_NAME} PRIVATE
             -Wall -Wextra -Wno-error
+            -Wformat-security
             -Wno-return-type
             -Wno-unused-parameter
             -Wno-unused-function
@@ -579,6 +581,7 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
 
         target_compile_options(${PROJECT_NAME} PRIVATE
             -Wall -Wextra -Wno-error
+            -Wformat-security
             -Wno-unused-parameter
             -Wno-unused-function
             -Wno-unused-variable

--- a/soh/soh/Enhancements/Presets/Presets.cpp
+++ b/soh/soh/Enhancements/Presets/Presets.cpp
@@ -395,7 +395,7 @@ void PresetsCustomWidget(WidgetInfo& info) {
             ImGui::TableNextRow();
             ImGui::TableNextColumn();
             ImGui::AlignTextToFramePadding();
-            ImGui::Text(name.c_str());
+            ImGui::Text("%s", name.c_str());
             for (int i = PRESET_SECTION_SETTINGS; i < PRESET_SECTION_MAX; i++) {
                 ImGui::TableNextColumn();
                 DrawSectionCheck(name, !info.presetValues["blocks"].contains(blockInfo[i].names[1]), &info.apply[i],

--- a/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
+++ b/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
@@ -572,7 +572,9 @@ void DrawFlagTableArray16(const FlagTable& flagTable, uint16_t row, uint16_t& fl
         PopStyleCheckbox();
         if (ImGui::IsItemHovered() && hasDescription) {
             ImGui::BeginTooltip();
-            ImGui::Text("%s", UIWidgets::WrappedText(flagTable.flagDescriptions.at(row * 16 + flagIndex), 60).c_str());
+            uint16_t index = row * 16 + flagIndex;
+            const char* desc = flagTable.flagDescriptions.at(index);
+            ImGui::Text("0x%02X: %s", index, UIWidgets::WrappedText(desc, 60).c_str());
             ImGui::EndTooltip();
         }
         ImGui::PopID();
@@ -930,7 +932,15 @@ void DrawFlagsTab() {
             for (int j = 0; j < flagTable.size + 1; j++) {
                 DrawGroupWithBorder(
                     [&]() {
-                        ImGui::Text("%s", fmt::format("{:<2x}", j).c_str());
+                        if (j == 0) {
+                            for (int k = 0xF; k >= 0; k--) {
+                                ImGui::SameLine(37.5 + ((0xF - k) * 33.8));
+                                ImGui::Text("%X", k);
+                            }
+                        }
+
+                        ImGui::Text("%s", fmt::format("{:<2X}", j).c_str());
+
                         switch (flagTable.flagTableType) {
                             case EVENT_CHECK_INF:
                                 DrawFlagTableArray16(flagTable, j, gSaveContext.eventChkInf[j]);

--- a/soh/soh/Enhancements/randomizer/Plandomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/Plandomizer.cpp
@@ -647,7 +647,7 @@ void PlandomizerOverlayText(std::pair<Rando::Item, uint32_t> drawObject) {
                             imageMax.y - ImGui::CalcTextSize(std::to_string(drawObject.second).c_str()).y - 2);
 
     ImGui::SetCursorScreenPos(textPos);
-    ImGui::Text(std::to_string(drawObject.second).c_str());
+    ImGui::Text("%s", std::to_string(drawObject.second).c_str());
 
     // Overlay item info
     if (drawObject.first.GetRandomizerGet() >= RG_PROGRESSIVE_HOOKSHOT &&
@@ -665,7 +665,7 @@ void PlandomizerOverlayText(std::pair<Rando::Item, uint32_t> drawObject) {
         ImGui::SetCursorScreenPos(textPos);
         std::string overlayText = "+";
         overlayText += extractNumberInParentheses(drawObject.first.GetName().english.c_str());
-        ImGui::Text(overlayText.c_str());
+        ImGui::Text("%s", overlayText.c_str());
     }
     if (drawObject.first.GetRandomizerGet() >= RG_FOREST_TEMPLE_BOSS_KEY &&
         drawObject.first.GetRandomizerGet() <= RG_GANONS_CASTLE_BOSS_KEY) {
@@ -678,7 +678,7 @@ void PlandomizerOverlayText(std::pair<Rando::Item, uint32_t> drawObject) {
                 break;
             }
         }
-        ImGui::Text(shortName.c_str());
+        ImGui::Text("%s", shortName.c_str());
     }
     if (drawObject.first.GetRandomizerGet() >= RG_OCARINA_A_BUTTON &&
         drawObject.first.GetRandomizerGet() <= RG_OCARINA_C_RIGHT_BUTTON) {
@@ -691,7 +691,7 @@ void PlandomizerOverlayText(std::pair<Rando::Item, uint32_t> drawObject) {
                 break;
             }
         }
-        ImGui::Text(shortName.c_str());
+        ImGui::Text("%s", shortName.c_str());
     }
 }
 
@@ -1066,7 +1066,7 @@ void PlandomizerDrawHintsWindow() {
             ImGui::SeparatorText(hintData.hintName.c_str());
             ImGui::Text("Current Hint: ");
             ImGui::SameLine();
-            ImGui::TextWrapped(hintData.hintText.c_str());
+            ImGui::TextWrapped("%s", hintData.hintText.c_str());
 
             if (spoilerHintData.size() > 0) {
                 hintInputText = plandoHintData[index].hintText.c_str();
@@ -1115,9 +1115,9 @@ void PlandomizerDrawLocationsWindow(RandomizerCheckArea rcArea) {
             auto randoArea = Rando::StaticData::GetLocation(checkID)->GetArea();
             if (rcArea == RCAREA_INVALID || rcArea == randoArea) {
                 ImGui::TableNextColumn();
-                ImGui::TextWrapped(spoilerData.checkName.c_str());
+                ImGui::TextWrapped("%s", spoilerData.checkName.c_str());
                 ImGui::TableNextColumn();
-                ImGui::TextWrapped(spoilerData.checkRewardItem.GetName().english.c_str());
+                ImGui::TextWrapped("%s", spoilerData.checkRewardItem.GetName().english.c_str());
                 ImGui::TableNextColumn();
                 PlandomizerDrawItemSlots(index);
                 if (plandoLogData[index].checkRewardItem.GetRandomizerGet() == RG_ICE_TRAP) {

--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -1085,7 +1085,7 @@ void CheckTrackerWindow::DrawElement() {
         totalChecksSS << totalChecksAvailable << " Available / ";
     }
     totalChecksSS << totalChecksGotten << " Checked / " << totalChecks << " Total";
-    ImGui::Text(totalChecksSS.str().c_str());
+    ImGui::Text("%s", totalChecksSS.str().c_str());
 
     UIWidgets::PaddedSeparator();
 
@@ -1194,7 +1194,7 @@ void CheckTrackerWindow::DrawElement() {
                     }
                 }
 
-                ImGui::Text(areaTotalsSS.str().c_str());
+                ImGui::Text("%s", areaTotalsSS.str().c_str());
                 UIWidgets::Tooltip(areaTotalsTooltipSS.str().c_str());
             } else {
                 ImGui::Text("???");


### PR DESCRIPTION
This adds a bit flag label on horizontal axis of the flags table, and also prints the flag coordinate on the tooltip.

I was investigating various flags and found that this was useful when referencing the corresponding INFTABLE values

![](https://cdn.jb55.com/s/6361626cd17f1198.png)

This builds on top of:

- #5646 

since I need that to compile the project

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3589587861.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3589598967.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3589625284.zip)
<!--- section:artifacts:end -->