### PR TITLE
Prevent MQ Spirit softlock with increased crawl speed

### DIFF
--- a/soh/soh/Enhancements/TimeSavers/CrawlSpeed.cpp
+++ b/soh/soh/Enhancements/TimeSavers/CrawlSpeed.cpp
@@ -1,4 +1,5 @@
 #include <libultraship/bridge.h>
+#include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 #include "soh/ShipInit.hpp"
 #include "global.h"
@@ -102,8 +103,17 @@ void CrawlSpeed_Register() {
 
     COND_VB_SHOULD(VB_CRAWL_SPEED_INCREASE, shouldRegister, {
         Player* player = GET_PLAYER(gPlayState);
-        IncreaseCrawlSpeed(player, gPlayState);
-        *should = false;
+        bool isMQ = ResourceMgr_IsGameMasterQuest();
+        bool boulderExists = !Flags_GetSwitch(gPlayState, 5);
+        bool excludeSpiritMQBoulder =
+            (gPlayState->sceneNum == SCENE_SPIRIT_TEMPLE && player->actor.world.pos.z < -545.0f &&
+             player->actor.world.pos.z > -630.0f && isMQ && boulderExists);
+        if (excludeSpiritMQBoulder) {
+            *should = true;
+        } else {
+            IncreaseCrawlSpeed(player, gPlayState);
+            *should = false;
+        }
     });
 }
 

--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -463,7 +463,7 @@ void SohMenu::AddMenuEnhancements() {
         .Options(IntSliderOptions().Min(0).Max(5).DefaultValue(0).Format("+%d"));
     AddWidget(path, "Crawl Speed %dx", WIDGET_CVAR_SLIDER_INT)
         .CVar(CVAR_ENHANCEMENT("CrawlSpeed"))
-        .Options(IntSliderOptions().Min(1).Max(4).DefaultValue(1).Format("%dx"));
+        .Options(IntSliderOptions().Min(1).Max(5).DefaultValue(1).Format("%dx"));
     AddWidget(path, "Exclude Glitch-Aiding Crawlspaces", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("GlitchAidingCrawlspaces"))
         .PreFunc([](WidgetInfo& info) { info.isHidden = CVarGetInteger(CVAR_ENHANCEMENT("CrawlSpeed"), 0) == 1; })


### PR DESCRIPTION
Prevents the increase to crawl speed in the MQ Spirit crawl space with the boulder until the boulder is destroyed

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3582257202.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3582261448.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3582385828.zip)
<!--- section:artifacts:end -->