### PR TITLE
Allow console commands in debug save

### DIFF
--- a/soh/soh/Enhancements/game-interactor/GameInteractionEffect.cpp
+++ b/soh/soh/Enhancements/game-interactor/GameInteractionEffect.cpp
@@ -50,7 +50,7 @@ namespace GameInteractionEffect {
 
 // MARK: - Flags
 GameInteractionEffectQueryResult SetSceneFlag::CanBeApplied() {
-    if (!GameInteractor::IsSaveLoaded()) {
+    if (!GameInteractor::IsSaveLoaded(true)) {
         return GameInteractionEffectQueryResult::TemporarilyNotPossible;
     }
 
@@ -62,7 +62,7 @@ void SetSceneFlag::_Apply() {
 }
 
 GameInteractionEffectQueryResult UnsetSceneFlag::CanBeApplied() {
-    if (!GameInteractor::IsSaveLoaded()) {
+    if (!GameInteractor::IsSaveLoaded(true)) {
         return GameInteractionEffectQueryResult::TemporarilyNotPossible;
     }
 
@@ -74,7 +74,7 @@ void UnsetSceneFlag::_Apply() {
 }
 
 GameInteractionEffectQueryResult SetFlag::CanBeApplied() {
-    if (!GameInteractor::IsSaveLoaded()) {
+    if (!GameInteractor::IsSaveLoaded(true)) {
         return GameInteractionEffectQueryResult::TemporarilyNotPossible;
     }
 
@@ -86,7 +86,7 @@ void SetFlag::_Apply() {
 }
 
 GameInteractionEffectQueryResult UnsetFlag::CanBeApplied() {
-    if (!GameInteractor::IsSaveLoaded()) {
+    if (!GameInteractor::IsSaveLoaded(true)) {
         return GameInteractionEffectQueryResult::TemporarilyNotPossible;
     }
 
@@ -99,7 +99,7 @@ void UnsetFlag::_Apply() {
 
 // MARK: - ModifyHeartContainers
 GameInteractionEffectQueryResult ModifyHeartContainers::CanBeApplied() {
-    if (!GameInteractor::IsSaveLoaded()) {
+    if (!GameInteractor::IsSaveLoaded(true)) {
         return GameInteractionEffectQueryResult::TemporarilyNotPossible;
     } else if ((parameters[0] > 0 && (gSaveContext.healthCapacity + (parameters[0] * 0x10) > 0x140)) ||
                (parameters[0] < 0 && (gSaveContext.healthCapacity + (parameters[0] * 0x10) < 0x10))) {
@@ -115,7 +115,7 @@ void ModifyHeartContainers::_Apply() {
 
 // MARK: - FillMagic
 GameInteractionEffectQueryResult FillMagic::CanBeApplied() {
-    if (!GameInteractor::IsSaveLoaded()) {
+    if (!GameInteractor::IsSaveLoaded(true)) {
         return GameInteractionEffectQueryResult::TemporarilyNotPossible;
     } else if (!gSaveContext.isMagicAcquired || gSaveContext.magic >= ((gSaveContext.isDoubleMagicAcquired + 1) * 48)) {
         return GameInteractionEffectQueryResult::NotPossible;
@@ -129,7 +129,7 @@ void FillMagic::_Apply() {
 
 // MARK: - EmptyMagic
 GameInteractionEffectQueryResult EmptyMagic::CanBeApplied() {
-    if (!GameInteractor::IsSaveLoaded()) {
+    if (!GameInteractor::IsSaveLoaded(true)) {
         return GameInteractionEffectQueryResult::TemporarilyNotPossible;
     } else if (!gSaveContext.isMagicAcquired || gSaveContext.magic <= 0) {
         return GameInteractionEffectQueryResult::NotPossible;
@@ -143,7 +143,7 @@ void EmptyMagic::_Apply() {
 
 // MARK: - ModifyRupees
 GameInteractionEffectQueryResult ModifyRupees::CanBeApplied() {
-    if (!GameInteractor::IsSaveLoaded()) {
+    if (!GameInteractor::IsSaveLoaded(true)) {
         return GameInteractionEffectQueryResult::TemporarilyNotPossible;
     } else if ((parameters[0] < 0 && gSaveContext.rupees <= 0) ||
                (parameters[0] > 0 && gSaveContext.rupees >= CUR_CAPACITY(UPG_WALLET))) {
@@ -158,7 +158,7 @@ void ModifyRupees::_Apply() {
 
 // MARK: - NoUI
 GameInteractionEffectQueryResult NoUI::CanBeApplied() {
-    if (!GameInteractor::IsSaveLoaded() || GameInteractor::IsGameplayPaused()) {
+    if (!GameInteractor::IsSaveLoaded(true) || GameInteractor::IsGameplayPaused()) {
         return GameInteractionEffectQueryResult::TemporarilyNotPossible;
     } else {
         return GameInteractionEffectQueryResult::Possible;
@@ -173,7 +173,7 @@ void NoUI::_Remove() {
 
 // MARK: - ModifyGravity
 GameInteractionEffectQueryResult ModifyGravity::CanBeApplied() {
-    if (!GameInteractor::IsSaveLoaded() || GameInteractor::IsGameplayPaused()) {
+    if (!GameInteractor::IsSaveLoaded(true) || GameInteractor::IsGameplayPaused()) {
         return GameInteractionEffectQueryResult::TemporarilyNotPossible;
     } else {
         return GameInteractionEffectQueryResult::Possible;
@@ -188,7 +188,7 @@ void ModifyGravity::_Remove() {
 
 // MARK: - ModifyHealth
 GameInteractionEffectQueryResult ModifyHealth::CanBeApplied() {
-    if (!GameInteractor::IsSaveLoaded()) {
+    if (!GameInteractor::IsSaveLoaded(true)) {
         return GameInteractionEffectQueryResult::TemporarilyNotPossible;
     } else if ((parameters[0] > 0 && gSaveContext.health == gSaveContext.healthCapacity) ||
                (parameters[0] < 0 && (gSaveContext.health + (16 * parameters[0]) <= 0))) {
@@ -204,7 +204,7 @@ void ModifyHealth::_Apply() {
 // MARK: - SetPlayerHealth
 GameInteractionEffectQueryResult SetPlayerHealth::CanBeApplied() {
     Player* player = GET_PLAYER(gPlayState);
-    if (!GameInteractor::IsSaveLoaded() || GameInteractor::IsGameplayPaused()) {
+    if (!GameInteractor::IsSaveLoaded(true) || GameInteractor::IsGameplayPaused()) {
         return GameInteractionEffectQueryResult::TemporarilyNotPossible;
     } else {
         return GameInteractionEffectQueryResult::Possible;
@@ -217,7 +217,7 @@ void SetPlayerHealth::_Apply() {
 // MARK: - FreezePlayer
 GameInteractionEffectQueryResult FreezePlayer::CanBeApplied() {
     Player* player = GET_PLAYER(gPlayState);
-    if (!GameInteractor::IsSaveLoaded() || GameInteractor::IsGameplayPaused() || !PlayerGrounded(player)) {
+    if (!GameInteractor::IsSaveLoaded(true) || GameInteractor::IsGameplayPaused() || !PlayerGrounded(player)) {
         return GameInteractionEffectQueryResult::TemporarilyNotPossible;
     } else {
         return GameInteractionEffectQueryResult::Possible;
@@ -230,7 +230,7 @@ void FreezePlayer::_Apply() {
 // MARK: - BurnPlayer
 GameInteractionEffectQueryResult BurnPlayer::CanBeApplied() {
     Player* player = GET_PLAYER(gPlayState);
-    if (!GameInteractor::IsSaveLoaded() || GameInteractor::IsGameplayPaused() || !PlayerGrounded(player)) {
+    if (!GameInteractor::IsSaveLoaded(true) || GameInteractor::IsGameplayPaused() || !PlayerGrounded(player)) {
         return GameInteractionEffectQueryResult::TemporarilyNotPossible;
     } else {
         return GameInteractionEffectQueryResult::Possible;
@@ -243,7 +243,7 @@ void BurnPlayer::_Apply() {
 // MARK: - ElectrocutePlayer
 GameInteractionEffectQueryResult ElectrocutePlayer::CanBeApplied() {
     Player* player = GET_PLAYER(gPlayState);
-    if (!GameInteractor::IsSaveLoaded() || GameInteractor::IsGameplayPaused() || !PlayerGrounded(player)) {
+    if (!GameInteractor::IsSaveLoaded(true) || GameInteractor::IsGameplayPaused() || !PlayerGrounded(player)) {
         return GameInteractionEffectQueryResult::TemporarilyNotPossible;
     } else {
         return GameInteractionEffectQueryResult::Possible;
@@ -256,7 +256,7 @@ void ElectrocutePlayer::_Apply() {
 // MARK: - KnockbackPlayer
 GameInteractionEffectQueryResult KnockbackPlayer::CanBeApplied() {
     Player* player = GET_PLAYER(gPlayState);
-    if (!GameInteractor::IsSaveLoaded() || GameInteractor::IsGameplayPaused() ||
+    if (!GameInteractor::IsSaveLoaded(true) || GameInteractor::IsGameplayPaused() ||
         player->stateFlags2 & PLAYER_STATE2_CRAWLING) {
         return GameInteractionEffectQueryResult::TemporarilyNotPossible;
     } else {
@@ -269,7 +269,7 @@ void KnockbackPlayer::_Apply() {
 
 // MARK: - ModifyLinkSize
 GameInteractionEffectQueryResult ModifyLinkSize::CanBeApplied() {
-    if (!GameInteractor::IsSaveLoaded() || GameInteractor::IsGameplayPaused()) {
+    if (!GameInteractor::IsSaveLoaded(true) || GameInteractor::IsGameplayPaused()) {
         return GameInteractionEffectQueryResult::TemporarilyNotPossible;
     } else {
         return GameInteractionEffectQueryResult::Possible;
@@ -284,7 +284,7 @@ void ModifyLinkSize::_Remove() {
 
 // MARK: - InvisibleLink
 GameInteractionEffectQueryResult InvisibleLink::CanBeApplied() {
-    if (!GameInteractor::IsSaveLoaded() || GameInteractor::IsGameplayPaused()) {
+    if (!GameInteractor::IsSaveLoaded(true) || GameInteractor::IsGameplayPaused()) {
         return GameInteractionEffectQueryResult::TemporarilyNotPossible;
     } else {
         return GameInteractionEffectQueryResult::Possible;
@@ -299,7 +299,7 @@ void InvisibleLink::_Remove() {
 
 // MARK: - PacifistMode
 GameInteractionEffectQueryResult PacifistMode::CanBeApplied() {
-    if (!GameInteractor::IsSaveLoaded() || GameInteractor::IsGameplayPaused()) {
+    if (!GameInteractor::IsSaveLoaded(true) || GameInteractor::IsGameplayPaused()) {
         return GameInteractionEffectQueryResult::TemporarilyNotPossible;
     } else {
         return GameInteractionEffectQueryResult::Possible;
@@ -314,7 +314,7 @@ void PacifistMode::_Remove() {
 
 // MARK: - DisableZTargeting
 GameInteractionEffectQueryResult DisableZTargeting::CanBeApplied() {
-    if (!GameInteractor::IsSaveLoaded() || GameInteractor::IsGameplayPaused()) {
+    if (!GameInteractor::IsSaveLoaded(true) || GameInteractor::IsGameplayPaused()) {
         return GameInteractionEffectQueryResult::TemporarilyNotPossible;
     } else {
         return GameInteractionEffectQueryResult::Possible;
@@ -329,7 +329,7 @@ void DisableZTargeting::_Remove() {
 
 // MARK: - WeatherRainstorm
 GameInteractionEffectQueryResult WeatherRainstorm::CanBeApplied() {
-    if (!GameInteractor::IsSaveLoaded() || GameInteractor::IsGameplayPaused()) {
+    if (!GameInteractor::IsSaveLoaded(true) || GameInteractor::IsGameplayPaused()) {
         return GameInteractionEffectQueryResult::TemporarilyNotPossible;
     } else {
         return GameInteractionEffectQueryResult::Possible;
@@ -344,7 +344,7 @@ void WeatherRainstorm::_Remove() {
 
 // MARK: - ReverseControls
 GameInteractionEffectQueryResult ReverseControls::CanBeApplied() {
-    if (!GameInteractor::IsSaveLoaded()) {
+    if (!GameInteractor::IsSaveLoaded(true)) {
         return GameInteractionEffectQueryResult::TemporarilyNotPossible;
     } else {
         return GameInteractionEffectQueryResult::Possible;
@@ -359,7 +359,7 @@ void ReverseControls::_Remove() {
 
 // MARK: - ForceEquipBoots
 GameInteractionEffectQueryResult ForceEquipBoots::CanBeApplied() {
-    if (!GameInteractor::IsSaveLoaded() || GameInteractor::IsGameplayPaused()) {
+    if (!GameInteractor::IsSaveLoaded(true) || GameInteractor::IsGameplayPaused()) {
         return GameInteractionEffectQueryResult::TemporarilyNotPossible;
     } else {
         return GameInteractionEffectQueryResult::Possible;
@@ -374,7 +374,7 @@ void ForceEquipBoots::_Remove() {
 
 // MARK: - ModifyMovementSpeedMultiplier
 GameInteractionEffectQueryResult ModifyMovementSpeedMultiplier::CanBeApplied() {
-    if (!GameInteractor::IsSaveLoaded() || GameInteractor::IsGameplayPaused()) {
+    if (!GameInteractor::IsSaveLoaded(true) || GameInteractor::IsGameplayPaused()) {
         return GameInteractionEffectQueryResult::TemporarilyNotPossible;
     } else {
         return GameInteractionEffectQueryResult::Possible;
@@ -393,7 +393,7 @@ void ModifyMovementSpeedMultiplier::_Remove() {
 
 // MARK: - OneHitKO
 GameInteractionEffectQueryResult OneHitKO::CanBeApplied() {
-    if (!GameInteractor::IsSaveLoaded() || GameInteractor::IsGameplayPaused()) {
+    if (!GameInteractor::IsSaveLoaded(true) || GameInteractor::IsGameplayPaused()) {
         return GameInteractionEffectQueryResult::TemporarilyNotPossible;
     } else {
         return GameInteractionEffectQueryResult::Possible;
@@ -408,7 +408,7 @@ void OneHitKO::_Remove() {
 
 // MARK: - ModifyDefenseModifier
 GameInteractionEffectQueryResult ModifyDefenseModifier::CanBeApplied() {
-    if (!GameInteractor::IsSaveLoaded() || GameInteractor::IsGameplayPaused()) {
+    if (!GameInteractor::IsSaveLoaded(true) || GameInteractor::IsGameplayPaused()) {
         return GameInteractionEffectQueryResult::TemporarilyNotPossible;
     } else {
         return GameInteractionEffectQueryResult::Possible;
@@ -423,7 +423,7 @@ void ModifyDefenseModifier::_Remove() {
 
 // MARK: - GiveOrTakeShield
 GameInteractionEffectQueryResult GiveOrTakeShield::CanBeApplied() {
-    if (!GameInteractor::IsSaveLoaded() || GameInteractor::IsGameplayPaused()) {
+    if (!GameInteractor::IsSaveLoaded(true) || GameInteractor::IsGameplayPaused()) {
         return GameInteractionEffectQueryResult::TemporarilyNotPossible;
     } else if ((parameters[0] > 0 && ((gBitFlags[parameters[0] - ITEM_SHIELD_DEKU] << gEquipShifts[EQUIP_TYPE_SHIELD]) &
                                       gSaveContext.inventory.equipment)) ||
@@ -441,7 +441,7 @@ void GiveOrTakeShield::_Apply() {
 
 // MARK: - TeleportPlayer
 GameInteractionEffectQueryResult TeleportPlayer::CanBeApplied() {
-    if (!GameInteractor::IsSaveLoaded() || GameInteractor::IsGameplayPaused()) {
+    if (!GameInteractor::IsSaveLoaded(true) || GameInteractor::IsGameplayPaused()) {
         return GameInteractionEffectQueryResult::TemporarilyNotPossible;
     } else {
         return GameInteractionEffectQueryResult::Possible;
@@ -453,7 +453,7 @@ void TeleportPlayer::_Apply() {
 
 // MARK: - ClearAssignedButtons
 GameInteractionEffectQueryResult ClearAssignedButtons::CanBeApplied() {
-    if (!GameInteractor::IsSaveLoaded()) {
+    if (!GameInteractor::IsSaveLoaded(true)) {
         return GameInteractionEffectQueryResult::TemporarilyNotPossible;
     } else {
         return GameInteractionEffectQueryResult::Possible;
@@ -465,7 +465,7 @@ void ClearAssignedButtons::_Apply() {
 
 // MARK: - SetTimeOfDay
 GameInteractionEffectQueryResult SetTimeOfDay::CanBeApplied() {
-    if (!GameInteractor::IsSaveLoaded()) {
+    if (!GameInteractor::IsSaveLoaded(true)) {
         return GameInteractionEffectQueryResult::TemporarilyNotPossible;
     } else {
         return GameInteractionEffectQueryResult::Possible;
@@ -477,7 +477,7 @@ void SetTimeOfDay::_Apply() {
 
 // MARK: - SetCollisionViewer
 GameInteractionEffectQueryResult SetCollisionViewer::CanBeApplied() {
-    if (!GameInteractor::IsSaveLoaded() || GameInteractor::IsGameplayPaused()) {
+    if (!GameInteractor::IsSaveLoaded(true) || GameInteractor::IsGameplayPaused()) {
         return GameInteractionEffectQueryResult::TemporarilyNotPossible;
     } else {
         return GameInteractionEffectQueryResult::Possible;
@@ -492,7 +492,7 @@ void SetCollisionViewer::_Remove() {
 
 // MARK: - RandomizeCosmetics
 GameInteractionEffectQueryResult RandomizeCosmetics::CanBeApplied() {
-    if (!GameInteractor::IsSaveLoaded()) {
+    if (!GameInteractor::IsSaveLoaded(true)) {
         return GameInteractionEffectQueryResult::TemporarilyNotPossible;
     } else {
         return GameInteractionEffectQueryResult::Possible;
@@ -504,7 +504,7 @@ void RandomizeCosmetics::_Apply() {
 
 // MARK: - PressButton
 GameInteractionEffectQueryResult PressButton::CanBeApplied() {
-    if (!GameInteractor::IsSaveLoaded()) {
+    if (!GameInteractor::IsSaveLoaded(true)) {
         return GameInteractionEffectQueryResult::TemporarilyNotPossible;
     } else {
         return GameInteractionEffectQueryResult::Possible;
@@ -516,7 +516,7 @@ void PressButton::_Apply() {
 
 // MARK: - PressRandomButton
 GameInteractionEffectQueryResult PressRandomButton::CanBeApplied() {
-    if (!GameInteractor::IsSaveLoaded()) {
+    if (!GameInteractor::IsSaveLoaded(true)) {
         return GameInteractionEffectQueryResult::TemporarilyNotPossible;
     } else {
         return GameInteractionEffectQueryResult::Possible;
@@ -528,7 +528,7 @@ void PressRandomButton::_Apply() {
 
 // MARK: - AddOrTakeAmmo
 GameInteractionEffectQueryResult AddOrTakeAmmo::CanBeApplied() {
-    if (!GameInteractor::IsSaveLoaded()) {
+    if (!GameInteractor::IsSaveLoaded(true)) {
         return GameInteractionEffectQueryResult::TemporarilyNotPossible;
     } else if (!GameInteractor::CanAddOrTakeAmmo(parameters[0], parameters[1])) {
         return GameInteractionEffectQueryResult::NotPossible;
@@ -542,7 +542,7 @@ void AddOrTakeAmmo::_Apply() {
 
 // MARK: - RandomBombFuseTimer
 GameInteractionEffectQueryResult RandomBombFuseTimer::CanBeApplied() {
-    if (!GameInteractor::IsSaveLoaded() || GameInteractor::IsGameplayPaused()) {
+    if (!GameInteractor::IsSaveLoaded(true) || GameInteractor::IsGameplayPaused()) {
         return GameInteractionEffectQueryResult::TemporarilyNotPossible;
     } else {
         return GameInteractionEffectQueryResult::Possible;
@@ -557,7 +557,7 @@ void RandomBombFuseTimer::_Remove() {
 
 // MARK: - DisableLedgeGrabs
 GameInteractionEffectQueryResult DisableLedgeGrabs::CanBeApplied() {
-    if (!GameInteractor::IsSaveLoaded() || GameInteractor::IsGameplayPaused()) {
+    if (!GameInteractor::IsSaveLoaded(true) || GameInteractor::IsGameplayPaused()) {
         return GameInteractionEffectQueryResult::TemporarilyNotPossible;
     } else {
         return GameInteractionEffectQueryResult::Possible;
@@ -572,7 +572,7 @@ void DisableLedgeGrabs::_Remove() {
 
 // MARK: - RandomWind
 GameInteractionEffectQueryResult RandomWind::CanBeApplied() {
-    if (!GameInteractor::IsSaveLoaded() || GameInteractor::IsGameplayPaused()) {
+    if (!GameInteractor::IsSaveLoaded(true) || GameInteractor::IsGameplayPaused()) {
         return GameInteractionEffectQueryResult::TemporarilyNotPossible;
     } else {
         return GameInteractionEffectQueryResult::Possible;
@@ -587,7 +587,7 @@ void RandomWind::_Remove() {
 
 // MARK: - RandomBonks
 GameInteractionEffectQueryResult RandomBonks::CanBeApplied() {
-    if (!GameInteractor::IsSaveLoaded() || GameInteractor::IsGameplayPaused()) {
+    if (!GameInteractor::IsSaveLoaded(true) || GameInteractor::IsGameplayPaused()) {
         return GameInteractionEffectQueryResult::TemporarilyNotPossible;
     } else {
         return GameInteractionEffectQueryResult::Possible;
@@ -602,7 +602,7 @@ void RandomBonks::_Remove() {
 
 // MARK: - PlayerInvincibility
 GameInteractionEffectQueryResult PlayerInvincibility::CanBeApplied() {
-    if (!GameInteractor::IsSaveLoaded() || GameInteractor::IsGameplayPaused()) {
+    if (!GameInteractor::IsSaveLoaded(true) || GameInteractor::IsGameplayPaused()) {
         return GameInteractionEffectQueryResult::TemporarilyNotPossible;
     } else {
         return GameInteractionEffectQueryResult::Possible;
@@ -617,7 +617,7 @@ void PlayerInvincibility::_Remove() {
 
 // MARK: - SlipperyFloor
 GameInteractionEffectQueryResult SlipperyFloor::CanBeApplied() {
-    if (!GameInteractor::IsSaveLoaded() || GameInteractor::IsGameplayPaused()) {
+    if (!GameInteractor::IsSaveLoaded(true) || GameInteractor::IsGameplayPaused()) {
         return GameInteractionEffectQueryResult::TemporarilyNotPossible;
     } else {
         return GameInteractionEffectQueryResult::Possible;
@@ -632,7 +632,7 @@ void SlipperyFloor::_Remove() {
 
 // MARK: - SpawnEnemyWithOffset
 GameInteractionEffectQueryResult SpawnEnemyWithOffset::CanBeApplied() {
-    if (!GameInteractor::IsSaveLoaded()) {
+    if (!GameInteractor::IsSaveLoaded(true)) {
         return GameInteractionEffectQueryResult::TemporarilyNotPossible;
     }
     return GameInteractor::RawAction::SpawnEnemyWithOffset(parameters[0], parameters[1]);
@@ -644,7 +644,7 @@ void SpawnEnemyWithOffset::_Apply() {
 
 // MARK: - SpawnActor
 GameInteractionEffectQueryResult SpawnActor::CanBeApplied() {
-    if (!GameInteractor::IsSaveLoaded()) {
+    if (!GameInteractor::IsSaveLoaded(true)) {
         return GameInteractionEffectQueryResult::TemporarilyNotPossible;
     }
     return GameInteractor::RawAction::SpawnActor(parameters[0], parameters[1]);


### PR DESCRIPTION
This PR allows console commands to be used in Debug Save (e.g. when using "Boot To Debug Warp Screen" option) which IMO is a valid game mode.

I think this is useful when testing or creating more console commands.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3523626602.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3523636306.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3523714565.zip)
<!--- section:artifacts:end -->