### PR TITLE
Fix the Show Horizontal Resolution Field option

### DIFF
--- a/soh/soh/SohGui/ResolutionEditor.cpp
+++ b/soh/soh/SohGui/ResolutionEditor.cpp
@@ -79,7 +79,7 @@ static float aspectRatioX;
 static float aspectRatioY;
 static int32_t verticalPixelCount;
 // Additional settings
-static bool showHorizontalResField = false;
+static bool showHorizontalResField;
 static int32_t horizontalPixelCount;
 // Disabling flags
 static bool disabled_everything;

--- a/soh/soh/SohGui/ResolutionEditor.cpp
+++ b/soh/soh/SohGui/ResolutionEditor.cpp
@@ -79,7 +79,7 @@ static float aspectRatioX;
 static float aspectRatioY;
 static int32_t verticalPixelCount;
 // Additional settings
-static bool showHorizontalResField;
+static bool showHorizontalResField = false;
 static int32_t horizontalPixelCount;
 // Disabling flags
 static bool disabled_everything;
@@ -582,7 +582,6 @@ void UpdateResolutionVars() {
     verticalPixelCount =
         CVarGetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".VerticalPixelCount", pixelCountPresets[item_pixelCount]);
     // Additional settings
-    showHorizontalResField = false;
     horizontalPixelCount = (verticalPixelCount / aspectRatioY) * aspectRatioX;
     // Disabling flags
     disabled_everything = !CVarGetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".Enabled", 0);


### PR DESCRIPTION
`showHorizontalResField` was being set to false on every update, so you could not access the Horiz. Pixel Count field. This fixes that allowing users to directly set the Horizontal Pixel counts if wanted. 

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3560347083.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3560352811.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3560444504.zip)
<!--- section:artifacts:end -->