### PR TITLE
Clear Devices

### DIFF
--- a/soh/soh/SohGui/SohGui.cpp
+++ b/soh/soh/SohGui/SohGui.cpp
@@ -71,7 +71,6 @@ std::shared_ptr<SohMenuBar> mSohMenuBar;
 std::shared_ptr<Ship::GuiWindow> mConsoleWindow;
 std::shared_ptr<SohStatsWindow> mStatsWindow;
 std::shared_ptr<Ship::GuiWindow> mGfxDebuggerWindow;
-std::shared_ptr<Ship::GuiWindow> mInputEditorWindow;
 
 std::shared_ptr<SohMenu> mSohMenu;
 std::shared_ptr<AudioEditor> mAudioEditorWindow;
@@ -131,10 +130,10 @@ void SetupGuiElements() {
     mStatsWindow = std::make_shared<SohStatsWindow>(CVAR_WINDOW("SohStats"), "Stats##Soh", ImVec2(400, 100));
     gui->AddGuiWindow(mStatsWindow);
 
-    mInputEditorWindow = gui->GetGuiWindow("Controller Configuration");
+    /*mInputEditorWindow = gui->GetGuiWindow("Controller Configuration");
     if (mInputEditorWindow == nullptr) {
         SPDLOG_ERROR("Could not find input editor window");
-    }
+    }*/
 
     mAudioEditorWindow = std::make_shared<AudioEditor>(CVAR_WINDOW("AudioEditor"), "Audio Editor", ImVec2(820, 630));
     gui->AddGuiWindow(mAudioEditorWindow);
@@ -228,7 +227,6 @@ void Destroy() {
     mActorViewerWindow = nullptr;
     mCosmeticsEditorWindow = nullptr;
     mAudioEditorWindow = nullptr;
-    mInputEditorWindow = nullptr;
     mStatsWindow = nullptr;
     mConsoleWindow = nullptr;
     mGfxDebuggerWindow = nullptr;

--- a/soh/soh/SohGui/SohMenuSettings.cpp
+++ b/soh/soh/SohGui/SohMenuSettings.cpp
@@ -1,5 +1,7 @@
 #include "SohMenu.h"
 #include "soh/Notification/Notification.h"
+#include "soh/Enhancements/controls/SohInputEditorWindow.h"
+#include "SohModals.h"
 #include <soh/GameVersions.h>
 #include "soh/ResourceManagerHelpers.h"
 #include "UIWidgets.hpp"
@@ -13,6 +15,7 @@ extern "C" {
 namespace SohGui {
 
 extern std::shared_ptr<SohMenu> mSohMenu;
+extern std::shared_ptr<SohModalWindow> mModalWindow;
 using namespace UIWidgets;
 
 static std::unordered_map<int32_t, const char*> imguiScaleOptions = {
@@ -373,6 +376,20 @@ void SohMenu::AddMenuSettings() {
     path.sidebarName = "Controls";
     path.column = SECTION_COLUMN_1;
     AddSidebarEntry("Settings", "Controls", 2);
+    AddWidget(path, "Clear Devices", WIDGET_BUTTON)
+        .Callback([](WidgetInfo& info) {
+            SohGui::mModalWindow->RegisterPopup(
+                "Clear Config",
+                "This will completely erase the controls config, including registered devices.\nContinue?", "Clear",
+                "Cancel",
+                []() {
+                    Ship::Context::GetInstance()->GetConsoleVariables()->ClearBlock(CVAR_PREFIX_SETTING ".Controllers");
+                    uint8_t bits = 0;
+                    Ship::Context::GetInstance()->GetControlDeck()->Init(&bits);
+                },
+                nullptr);
+        })
+        .Options(ButtonOptions().Size(Sizes::Inline));
     AddWidget(path, "Controller Bindings", WIDGET_SEPARATOR_TEXT);
     AddWidget(path, "Popout Bindings Window", WIDGET_WINDOW_BUTTON)
         .CVar(CVAR_WINDOW("ControllerConfiguration"))


### PR DESCRIPTION
Adds a button at the top of Controls to clear the config entirely, which will allow for removing duplicate devices from the devices list.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3573284584.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3573335315.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3573337446.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3573340252.zip)
<!--- section:artifacts:end -->