### PR TITLE
Add playing icon to improve Audio Editor indicator

### DIFF
--- a/soh/soh/Enhancements/audio/AudioEditor.cpp
+++ b/soh/soh/Enhancements/audio/AudioEditor.cpp
@@ -298,9 +298,12 @@ void Draw_SfxTab(const std::string& tabId, SeqType type, const std::string& tabN
 
         ImGui::TableNextRow();
         ImGui::TableNextColumn();
-        ImGui::TextColored(
-            UIWidgets::ColorValues.at(isCurrentlyPlaying ? UIWidgets::Colors::Yellow : UIWidgets::Colors::White), "%s",
-            seqData.label.c_str());
+        if (isCurrentlyPlaying) {
+            ImGui::TextColored(UIWidgets::ColorValues.at(UIWidgets::Colors::Yellow), "%s %s", ICON_FA_PLAY,
+                               seqData.label.c_str());
+        } else {
+            ImGui::Text("%s", seqData.label.c_str());
+        }
         ImGui::TableNextColumn();
         ImGui::PushItemWidth(-FLT_MIN);
         const int initialValue = map.contains(currentValue) ? currentValue : defaultValue;


### PR DESCRIPTION
I've been wanting to add an icon to improve the currently playing indicator for a while, for the benefit of the colorblind.

<img width="778" height="108" alt="2025-07-21" src="https://github.com/user-attachments/assets/55facb65-606f-4ad1-80eb-0487388a8840" />