### PR TITLE
Rando Versioning Fixes

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -406,6 +406,8 @@ bool Randomizer::SpoilerFileExists(const char* spoilerFileName) {
                     "The spoiler file located at\n" + std::string(spoilerFileName) +
                         "\nwas made by a version that doesn't match the currently running version.\n" +
                         "Loading for this file has been cancelled.");
+                CVarClear(CVAR_GENERAL("SpoilerLog"));
+                Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
             }
 
             // Update cache

--- a/soh/soh/SaveManager.cpp
+++ b/soh/soh/SaveManager.cpp
@@ -1111,6 +1111,7 @@ void SaveManager::LoadFile(int fileNum) {
     std::ifstream input(fileName);
 
     try {
+        bool deleteRando = false;
         saveBlock = nlohmann::json::object();
         input >> saveBlock;
         if (!saveBlock.contains("version")) {
@@ -1122,6 +1123,10 @@ void SaveManager::LoadFile(int fileNum) {
                 for (auto& block : saveBlock["sections"].items()) {
                     std::string sectionName = block.key();
                     if (sectionName == "randomizer") {
+                        if (block.value()["data"].empty()) {
+                            deleteRando = true;
+                            continue;
+                        }
                         bool hasStats = saveBlock["sections"].contains("sohStats");
                         if (block.value()["data"].contains("aat0") || !hasStats) { // Rachael rando data
                             SohGui::RegisterPopup(
@@ -1200,6 +1205,11 @@ void SaveManager::LoadFile(int fileNum) {
                              GetFileName(fileNum).string());
                 assert(false);
                 break;
+        }
+        if (deleteRando) {
+            saveBlock["sections"].erase(saveBlock["sections"].find("randomizer"));
+            SaveFile(fileNum);
+            deleteRando = false;
         }
         InitMeta(fileNum);
         GameInteractor::Instance->ExecuteHooks<GameInteractor::OnLoadFile>(fileNum);


### PR DESCRIPTION
Prevent empty randomizer blocks from triggering the rando version flow.
Clear `SpoilerLog` CVar when unsupported spoiler log is discovered on load.