### PR TITLE
Rando Versioning (Again)

### DIFF
--- a/soh/soh/SaveManager.cpp
+++ b/soh/soh/SaveManager.cpp
@@ -1122,7 +1122,8 @@ void SaveManager::LoadFile(int fileNum) {
             case 1:
                 for (auto& block : saveBlock["sections"].items()) {
                     bool oldVanilla = block.value()["data"].empty() || block.value()["data"].contains("aat0") ||
-                                      block.value()["data"]["entrances"].empty();
+                                      block.value()["data"]["entrances"].empty() || 
+                                      SohUtils::IsStringEmpty(saveBlock["sections"]["sohStats"]["data"]["buildVersion"]);
                     std::string sectionName = block.key();
                     if (sectionName == "randomizer") {
                         bool hasStats = saveBlock["sections"].contains("sohStats");

--- a/soh/soh/SaveManager.cpp
+++ b/soh/soh/SaveManager.cpp
@@ -1121,25 +1121,22 @@ void SaveManager::LoadFile(int fileNum) {
         switch (saveBlock["version"].get<int>()) {
             case 1:
                 for (auto& block : saveBlock["sections"].items()) {
+                    bool oldVanilla = block.value()["data"].empty() || block.value()["data"].contains("aat0") ||
+                                      block.value()["data"]["entrances"].empty();
                     std::string sectionName = block.key();
                     if (sectionName == "randomizer") {
-                        if (block.value()["data"].empty()) {
-                            deleteRando = true;
-                            continue;
-                        }
                         bool hasStats = saveBlock["sections"].contains("sohStats");
-                        if (block.value()["data"].contains("aat0") || !hasStats) { // Rachael rando data
+                        if (oldVanilla || !hasStats) { // Vanilla "rando" data
                             SohGui::RegisterPopup(
                                 "Loading old file",
                                 "The file in slot " + std::to_string(fileNum + 1) +
-                                    " appears to contain randomizer data, but is a very old format.\n" +
+                                    " appears to contain randomizer data, but is a very old format or is empty.\n" +
                                     "The randomizer data has been removed, and this file will be treated as a vanilla "
-                                    "file.\n" +
+                                    "file.\nIf this was a vanilla file, it still is, and you shouldn't see this "
+                                    "message again.\n" +
                                     "If this was a randomizer file, the file will not work, and should be deleted.");
-                            input.close();
-                            saveMtx.unlock();
-                            SaveFile(fileNum);
-                            return;
+                            deleteRando = true;
+                            continue;
                         }
                         s16 major = saveBlock["sections"]["sohStats"]["data"]["buildVersionMajor"];
                         s16 minor = saveBlock["sections"]["sohStats"]["data"]["buildVersionMinor"];
@@ -1206,6 +1203,7 @@ void SaveManager::LoadFile(int fileNum) {
                 assert(false);
                 break;
         }
+        input.close();
         if (deleteRando) {
             saveBlock["sections"].erase(saveBlock["sections"].find("randomizer"));
             SaveFile(fileNum);

--- a/soh/soh/SaveManager.cpp
+++ b/soh/soh/SaveManager.cpp
@@ -1121,9 +1121,10 @@ void SaveManager::LoadFile(int fileNum) {
         switch (saveBlock["version"].get<int>()) {
             case 1:
                 for (auto& block : saveBlock["sections"].items()) {
-                    bool oldVanilla = block.value()["data"].empty() || block.value()["data"].contains("aat0") ||
-                                      block.value()["data"]["entrances"].empty() || 
-                                      SohUtils::IsStringEmpty(saveBlock["sections"]["sohStats"]["data"]["buildVersion"]);
+                    bool oldVanilla =
+                        block.value()["data"].empty() || block.value()["data"].contains("aat0") ||
+                        block.value()["data"]["entrances"].empty() ||
+                        SohUtils::IsStringEmpty(saveBlock["sections"]["sohStats"]["data"]["buildVersion"]);
                     std::string sectionName = block.key();
                     if (sectionName == "randomizer") {
                         bool hasStats = saveBlock["sections"].contains("sohStats");


### PR DESCRIPTION
Adds Sulu/Spock rando block check (data not empty, but all sub-entries null), and added that and data being empty to the old file flow. Also added a line to the popup that mentions that the file could have been vanilla, and that it will work as is.

Moves the `SaveFile` call to after everything else is loaded to preserve sohStats block.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3600981892.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3601153745.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3601166201.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3601179350.zip)
<!--- section:artifacts:end -->