### PR TITLE
Follow app directory for  `timesplitdata.json`

### DIFF
--- a/soh/soh/Enhancements/timesplits/TimeSplits.cpp
+++ b/soh/soh/Enhancements/timesplits/TimeSplits.cpp
@@ -4,6 +4,7 @@
 #include "soh/util.h"
 #include <vector>
 #include "include/z64item.h"
+#include "Context.h"
 
 #include <fstream>
 #include <filesystem>
@@ -363,7 +364,7 @@ void TimeSplitsSkipSplit(uint32_t index) {
 }
 
 void TimeSplitsFileManagement(uint32_t action, const char* listEntry, std::vector<SplitObject> listData) {
-    std::string filename = "timesplitdata.json";
+    std::string filename = Ship::Context::GetPathRelativeToAppDirectory("timesplitdata.json");
     json saveFile;
     json listArray = nlohmann::json::array();
 
@@ -948,9 +949,10 @@ void TimeSplitsDrawManageList() {
 }
 
 void InitializeSplitDataFile() {
-    if (!std::filesystem::exists("timesplitdata.json")) {
+    std::string filename = Ship::Context::GetPathRelativeToAppDirectory("timesplitdata.json");
+    if (!std::filesystem::exists(filename)) {
         json j;
-        std::ofstream file("timesplitdata.json");
+        std::ofstream file(filename);
         file << j.dump(4);
         file.close();
     }


### PR DESCRIPTION
Caught this one easily while testing aur build. `timesplitdata.json` somehow always creates on current directory instead of putting on app directory.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3602184129.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3602279770.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3602290945.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3602322466.zip)
<!--- section:artifacts:end -->