### PR TITLE
TWEAK: SoT Time Travel - Allow Swordless

### DIFF
--- a/soh/soh/Enhancements/enhancementTypes.h
+++ b/soh/soh/Enhancements/enhancementTypes.h
@@ -112,7 +112,9 @@ typedef enum {
 typedef enum {
     TIME_TRAVEL_DISABLED,
     TIME_TRAVEL_OOT,
+    TIME_TRAVEL_OOT_MS,
     TIME_TRAVEL_ANY,
+    TIME_TRAVEL_ANY_MS
 } TimeTravelType;
 
 typedef enum {

--- a/soh/soh/Enhancements/mods.cpp
+++ b/soh/soh/Enhancements/mods.cpp
@@ -131,13 +131,29 @@ void RegisterOcarinaTimeTravel() {
         bool notNearAnySource = !nearbyTimeBlockEmpty && !nearbyTimeBlock && !nearbyOcarinaSpot && !nearbyDoorOfTime &&
                                 !nearbyFrogs && !nearbyGossipStone;
         bool hasOcarinaOfTime = (INV_CONTENT(ITEM_OCARINA_TIME) == ITEM_OCARINA_TIME);
+        bool hasMasterSword = CHECK_OWNED_EQUIP(EQUIP_TYPE_SWORD, EQUIP_INV_SWORD_MASTER);
         int timeTravelSetting = CVarGetInteger(CVAR_ENHANCEMENT("TimeTravel"), 0);
-        bool doesntNeedOcarinaOfTime = timeTravelSetting == TIME_TRAVEL_ANY || timeTravelSetting == TIME_TRAVEL_ANY_MS;
-        bool needMasterSwordAndOcarina = timeTravelSetting == TIME_TRAVEL_ANY_MS || timeTravelSetting == TIME_TRAVEL_OOT_MS;
+        bool meetsTimeTravelRequirements = false;
 
-        if (justPlayedSoT && notNearAnySource && (hasOcarinaOfTime || doesntNeedOcarinaOfTime || needMasterSwordAndOcarina)) {
+        switch (timeTravelSetting) {
+            case TIME_TRAVEL_ANY:
+                meetsTimeTravelRequirements = true;
+                break;
+            case TIME_TRAVEL_ANY_MS:
+                meetsTimeTravelRequirements = hasMasterSword;
+                break;
+            case TIME_TRAVEL_OOT_MS:
+                meetsTimeTravelRequirements = hasMasterSword && hasOcarinaOfTime;
+                break;
+            default:
+                meetsTimeTravelRequirements = hasOcarinaOfTime;
+                break;
+        }
+
+        if (justPlayedSoT && notNearAnySource && meetsTimeTravelRequirements) {
             SwitchAge();
         }
+
     });
 }
 

--- a/soh/soh/Enhancements/mods.cpp
+++ b/soh/soh/Enhancements/mods.cpp
@@ -149,7 +149,7 @@ void RegisterOcarinaTimeTravel() {
             default:
                 meetsTimeTravelRequirements = hasOcarinaOfTime;
                 break;
-        }        
+        }
 
         if (justPlayedSoT && notNearAnySource && meetsTimeTravelRequirements) {
             SwitchAge();

--- a/soh/soh/Enhancements/mods.cpp
+++ b/soh/soh/Enhancements/mods.cpp
@@ -154,7 +154,6 @@ void RegisterOcarinaTimeTravel() {
         if (justPlayedSoT && notNearAnySource && meetsTimeTravelRequirements) {
             SwitchAge();
         }
-
     });
 }
 

--- a/soh/soh/Enhancements/mods.cpp
+++ b/soh/soh/Enhancements/mods.cpp
@@ -145,10 +145,11 @@ void RegisterOcarinaTimeTravel() {
             case TIME_TRAVEL_OOT_MS:
                 meetsTimeTravelRequirements = hasMasterSword && hasOcarinaOfTime;
                 break;
+            case TIME_TRAVEL_OOT:
             default:
                 meetsTimeTravelRequirements = hasOcarinaOfTime;
                 break;
-        }
+        }        
 
         if (justPlayedSoT && notNearAnySource && meetsTimeTravelRequirements) {
             SwitchAge();

--- a/soh/soh/Enhancements/mods.cpp
+++ b/soh/soh/Enhancements/mods.cpp
@@ -131,10 +131,11 @@ void RegisterOcarinaTimeTravel() {
         bool notNearAnySource = !nearbyTimeBlockEmpty && !nearbyTimeBlock && !nearbyOcarinaSpot && !nearbyDoorOfTime &&
                                 !nearbyFrogs && !nearbyGossipStone;
         bool hasOcarinaOfTime = (INV_CONTENT(ITEM_OCARINA_TIME) == ITEM_OCARINA_TIME);
-        bool doesntNeedOcarinaOfTime = CVarGetInteger(CVAR_ENHANCEMENT("TimeTravel"), 0) == 2;
-        bool hasMasterSword = CHECK_OWNED_EQUIP(EQUIP_TYPE_SWORD, EQUIP_INV_SWORD_MASTER);
-        // TODO: Once Swordless Adult is fixed: Remove the Master Sword check
-        if (justPlayedSoT && notNearAnySource && (hasOcarinaOfTime || doesntNeedOcarinaOfTime) && hasMasterSword) {
+        int timeTravelSetting = CVarGetInteger(CVAR_ENHANCEMENT("TimeTravel"), 0);
+        bool doesntNeedOcarinaOfTime = timeTravelSetting == TIME_TRAVEL_ANY || timeTravelSetting == TIME_TRAVEL_ANY_MS;
+        bool needMasterSwordAndOcarina = timeTravelSetting == TIME_TRAVEL_ANY_MS || timeTravelSetting == TIME_TRAVEL_OOT_MS;
+
+        if (justPlayedSoT && notNearAnySource && (hasOcarinaOfTime || doesntNeedOcarinaOfTime || needMasterSwordAndOcarina)) {
             SwitchAge();
         }
     });

--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -56,7 +56,9 @@ static const std::unordered_map<int32_t, const char*> chestStyleMatchesContentsO
 static const std::unordered_map<int32_t, const char*> timeTravelOptions = {
     { TIME_TRAVEL_DISABLED, "Disabled" },
     { TIME_TRAVEL_OOT, "Ocarina of Time" },
+    { TIME_TRAVEL_OOT_MS, "Ocarina of Time + Master Sword" },
     { TIME_TRAVEL_ANY, "Any Ocarina" },
+    { TIME_TRAVEL_ANY_MS, "Any Ocarina + Master Sword" },
 };
 
 static const std::unordered_map<int32_t, const char*> sleepingWaterfallOptions = {
@@ -783,9 +785,9 @@ void SohMenu::AddMenuEnhancements() {
                      .Tooltip("Allows Link to freely change age by playing the Song of Time.\n"
                               "Time Blocks can still be used properly.\n\n"
                               "Requirements:\n"
-                              " - Obtained the Ocarina of Time (depends on selection)\n"
                               " - Obtained the Song of Time\n"
-                              " - Obtained the Master Sword\n"
+                              " - Obtained the Ocarina of Time (depends on selection)\n"
+                              " - Obtained the Master Sword (depends on selection)\n"
                               " - Not within range of a Time Block\n"
                               " - Not within range of Ocarina Playing spots"));
 


### PR DESCRIPTION
This was on my to-do list until Adult Swordless was fixed, and I forgot about it

- Added an option to choose whether the Master Sword is required
- Removed magic numbers

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3673838679.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3673840520.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3673847141.zip)
<!--- section:artifacts:end -->