### PR TITLE
Fix Freed Carpenters

### DIFF
--- a/soh/soh/Enhancements/randomizer/logic.cpp
+++ b/soh/soh/Enhancements/randomizer/logic.cpp
@@ -2471,6 +2471,7 @@ void Logic::Reset(bool resetSaveContext /*= true*/) {
     THCouldFreeDoubleCellCarpenter = false;
     TH_CouldFreeDeadEndCarpenter = false;
     THCouldRescueSlopeCarpenter = false;
+    THRescuedAllCarpenters = false;
     GF_GateOpen = false;
     GtG_GateOpen = false;
     DampesWindmillAccess = false;


### PR DESCRIPTION
Add `THRescuedAllCarpenters` to reset list to prevent seed bleed of bridge.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3696534026.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3696539108.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3696557014.zip)
<!--- section:artifacts:end -->