### PR TITLE
Fix Jabu Open Setting in Rando

### DIFF
--- a/soh/soh/Enhancements/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.cpp
@@ -941,7 +941,7 @@ void TimeSaverOnActorInitHandler(void* actorRef) {
             });
     }
 
-    if (actor->id == ACTOR_EN_JJ && !IS_RANDO) {
+    if (actor->id == ACTOR_EN_JJ) {
         enJjUpdateHook =
             GameInteractor::Instance->RegisterGameHook<GameInteractor::OnActorUpdate>([](void* innerActorRef) mutable {
                 Actor* innerActor = static_cast<Actor*>(innerActorRef);


### PR DESCRIPTION
Remove !IS_RANDO check preventing Jabu Open setting from running in Randomizer

The check for RANDO is a few lines further down - correctly checking for the setting if in Randomizer or the CVAR if not.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3704857936.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3705039201.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3705043241.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3705062100.zip)
<!--- section:artifacts:end -->