### PR TITLE
Fix crash on selling big poe when poe requirement is set to zero

### DIFF
--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -1820,7 +1820,15 @@ typedef enum {
     // ```
     // #### `args`
     // - `*EnGb`
-    VB_SELL_POES_TO_POE_COLLECTOR,
+    VB_TALK_TO_POE_COLLECTOR,
+
+    // #### `result`
+    // ```c
+    // true
+    // ```
+    // #### `args`
+    // - `*EnGb`
+    VB_CALCULATE_POE_COLLECTOR_SCORE,
 
     // #### `result`
     // ```c

--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -1101,17 +1101,16 @@ void RandomizerOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_l
             break;
         }
         case VB_CALCULATE_POE_COLLECTOR_SCORE: {
-            if(HIGH_SCORE(HS_POE_POINTS) >= 1000) {
+            if (HIGH_SCORE(HS_POE_POINTS) >= 1000) {
                 if (HIGH_SCORE(HS_POE_POINTS) > 1100) {
                     HIGH_SCORE(HS_POE_POINTS) = 1100;
                 }
                 EnGb* enGb = va_arg(args, EnGb*);
                 Player* player = GET_PLAYER(gPlayState);
-                if(Flags_GetRandomizerInf(RAND_INF_10_BIG_POES)){
+                if (Flags_GetRandomizerInf(RAND_INF_10_BIG_POES)) {
                     Actor_ProcessTalkRequest(&enGb->dyna.actor, gPlayState);
                     enGb->actionFunc = func_80A2F83C;
-                }
-                else {
+                } else {
                     player->exchangeItemId = EXCH_ITEM_NONE;
                     enGb->textId = 0x70F8;
                     Message_ContinueTextbox(gPlayState, enGb->textId);

--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -1090,12 +1090,33 @@ void RandomizerOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_l
             *should = false;
             break;
         }
-        case VB_SELL_POES_TO_POE_COLLECTOR: {
+        case VB_TALK_TO_POE_COLLECTOR: {
             if (!Flags_GetRandomizerInf(RAND_INF_10_BIG_POES) && HIGH_SCORE(HS_POE_POINTS) >= 1000) {
                 EnGb* enGb = va_arg(args, EnGb*);
                 enGb->textId = 0x70F8;
                 Message_ContinueTextbox(gPlayState, enGb->textId);
                 enGb->actionFunc = func_80A2FB40;
+                *should = false;
+            }
+            break;
+        }
+        case VB_CALCULATE_POE_COLLECTOR_SCORE: {
+            if(HIGH_SCORE(HS_POE_POINTS) >= 1000) {
+                if (HIGH_SCORE(HS_POE_POINTS) > 1100) {
+                    HIGH_SCORE(HS_POE_POINTS) = 1100;
+                }
+                EnGb* enGb = va_arg(args, EnGb*);
+                Player* player = GET_PLAYER(gPlayState);
+                if(Flags_GetRandomizerInf(RAND_INF_10_BIG_POES)){
+                    Actor_ProcessTalkRequest(&enGb->dyna.actor, gPlayState);
+                    enGb->actionFunc = func_80A2F83C;
+                }
+                else {
+                    player->exchangeItemId = EXCH_ITEM_NONE;
+                    enGb->textId = 0x70F8;
+                    Message_ContinueTextbox(gPlayState, enGb->textId);
+                    enGb->actionFunc = func_80A2FB40;
+                }
                 *should = false;
             }
             break;

--- a/soh/src/overlays/actors/ovl_En_Gb/z_en_gb.c
+++ b/soh/src/overlays/actors/ovl_En_Gb/z_en_gb.c
@@ -288,9 +288,9 @@ void func_80A2F83C(EnGb* this, PlayState* play) {
         }
     }
     if (Actor_ProcessTalkRequest(&this->dyna.actor, play)) {
-        if (GameInteractor_Should(VB_SELL_POES_TO_POE_COLLECTOR, true, this)) {
-            switch (func_8002F368(play)) {
-                case EXCH_ITEM_NONE:
+        switch (func_8002F368(play)) {
+            case EXCH_ITEM_NONE:
+                if (GameInteractor_Should(VB_TALK_TO_POE_COLLECTOR, true, this)) {
                     func_80A2F180(this);
                     this->actionFunc = func_80A2F94C;
                     break;
@@ -342,18 +342,19 @@ void func_80A2FA50(EnGb* this, PlayState* play) {
         Player_UpdateBottleHeld(play, GET_PLAYER(play), ITEM_BOTTLE, PLAYER_IA_BOTTLE);
         Rupees_ChangeBy(50);
         HIGH_SCORE(HS_POE_POINTS) += 100;
-        if (HIGH_SCORE(HS_POE_POINTS) != 1000) {
-            if (HIGH_SCORE(HS_POE_POINTS) > 1100) {
-                HIGH_SCORE(HS_POE_POINTS) = 1100;
+        if(GameInteractor_Should(VB_CALCULATE_POE_COLLECTOR_SCORE, true, this)) {
+            if (HIGH_SCORE(HS_POE_POINTS) != 1000) {
+                if (HIGH_SCORE(HS_POE_POINTS) > 1100) {
+                    HIGH_SCORE(HS_POE_POINTS) = 1100;
+                }
+                this->actionFunc = func_80A2F83C;
+            } else {
+                Player* player = GET_PLAYER(play);
+                player->exchangeItemId = EXCH_ITEM_NONE;
+                this->textId = 0x70F8;
+                Message_ContinueTextbox(play, this->textId);
+                this->actionFunc = func_80A2FB40;
             }
-            this->actionFunc = func_80A2F83C;
-        } else {
-            Player* player = GET_PLAYER(play);
-
-            player->exchangeItemId = EXCH_ITEM_NONE;
-            this->textId = 0x70F8;
-            Message_ContinueTextbox(play, this->textId);
-            this->actionFunc = func_80A2FB40;
         }
     }
 }

--- a/soh/src/overlays/actors/ovl_En_Gb/z_en_gb.c
+++ b/soh/src/overlays/actors/ovl_En_Gb/z_en_gb.c
@@ -303,9 +303,9 @@ void func_80A2F83C(EnGb* this, PlayState* play) {
                 player->actor.textId = 0x70F7;
                 this->actionFunc = func_80A2FA50;
                 break;
-            }
         }
-    
+    }
+
     if (this->dyna.actor.xzDistToPlayer < 100.0f) {
         func_8002F298(&this->dyna.actor, play, 100.0f, EXCH_ITEM_POE);
     }
@@ -343,7 +343,7 @@ void func_80A2FA50(EnGb* this, PlayState* play) {
         Player_UpdateBottleHeld(play, GET_PLAYER(play), ITEM_BOTTLE, PLAYER_IA_BOTTLE);
         Rupees_ChangeBy(50);
         HIGH_SCORE(HS_POE_POINTS) += 100;
-        if(GameInteractor_Should(VB_CALCULATE_POE_COLLECTOR_SCORE, true, this)) {
+        if (GameInteractor_Should(VB_CALCULATE_POE_COLLECTOR_SCORE, true, this)) {
             if (HIGH_SCORE(HS_POE_POINTS) != 1000) {
                 if (HIGH_SCORE(HS_POE_POINTS) > 1100) {
                     HIGH_SCORE(HS_POE_POINTS) = 1100;

--- a/soh/src/overlays/actors/ovl_En_Gb/z_en_gb.c
+++ b/soh/src/overlays/actors/ovl_En_Gb/z_en_gb.c
@@ -304,12 +304,12 @@ void func_80A2F83C(EnGb* this, PlayState* play) {
                 this->actionFunc = func_80A2FA50;
                 break;
         }
+        return;
     }
 
     if (this->dyna.actor.xzDistToPlayer < 100.0f) {
         func_8002F298(&this->dyna.actor, play, 100.0f, EXCH_ITEM_POE);
     }
-    return;
 }
 
 void func_80A2F94C(EnGb* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_Gb/z_en_gb.c
+++ b/soh/src/overlays/actors/ovl_En_Gb/z_en_gb.c
@@ -305,11 +305,11 @@ void func_80A2F83C(EnGb* this, PlayState* play) {
                 break;
             }
         }
-        return;
-    }
+    
     if (this->dyna.actor.xzDistToPlayer < 100.0f) {
         func_8002F298(&this->dyna.actor, play, 100.0f, EXCH_ITEM_POE);
     }
+    return;
 }
 
 void func_80A2F94C(EnGb* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_Gb/z_en_gb.c
+++ b/soh/src/overlays/actors/ovl_En_Gb/z_en_gb.c
@@ -293,15 +293,16 @@ void func_80A2F83C(EnGb* this, PlayState* play) {
                 if (GameInteractor_Should(VB_TALK_TO_POE_COLLECTOR, true, this)) {
                     func_80A2F180(this);
                     this->actionFunc = func_80A2F94C;
-                    break;
-                case EXCH_ITEM_POE:
-                    player->actor.textId = 0x70F6;
-                    this->actionFunc = func_80A2F9C0;
-                    break;
-                case EXCH_ITEM_BIG_POE:
-                    player->actor.textId = 0x70F7;
-                    this->actionFunc = func_80A2FA50;
-                    break;
+                }
+                break;
+            case EXCH_ITEM_POE:
+                player->actor.textId = 0x70F6;
+                this->actionFunc = func_80A2F9C0;
+                break;
+            case EXCH_ITEM_BIG_POE:
+                player->actor.textId = 0x70F7;
+                this->actionFunc = func_80A2FA50;
+                break;
             }
         }
         return;


### PR DESCRIPTION
In rando when you have the required big poe count set to zero, you can get the item by talking to the poe seller.
However if you try to sell a bottled big poe the game crashes.
This fix allows you to sell the big poe and get the item afterwards.


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3720190824.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3720206015.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3720284728.zip)
<!--- section:artifacts:end -->