### PR TITLE
Add barebones support for the GameCube controller adapter.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ set(CMAKE_C_STANDARD 23 CACHE STRING "The C standard to use")
 set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "Minimum OS X deployment version")
 
 project(Ship VERSION 9.0.5 LANGUAGES C CXX)
+link_directories(/opt/homebrew/lib)
 include(CMake/soh-cvars.cmake)
 include(CMake/lus-cvars.cmake)
 

--- a/soh/soh/GCAdapterBridge.cpp
+++ b/soh/soh/GCAdapterBridge.cpp
@@ -1,0 +1,4 @@
+#include "soh/ShipInit.hpp"
+#include "public/bridge/controllerbridge.h"
+
+static RegisterShipInitFunc gInitGCAdapter([]() { InitGCAdapter(); });


### PR DESCRIPTION
This PR has the minimal code required to set up a GameCube controller as input using the official USB adapter. It is fully functional but does not update any UI elements and does not support configuring the mappings however, it uses the asme default input configuration as vc and scales the stick inputs similarly to electromodder's adapter.

Depends on: Kenix3/libultraship#911