### PR TITLE
Available Checks Small Key Fix

### DIFF
--- a/soh/soh/Enhancements/randomizer/logic.cpp
+++ b/soh/soh/Enhancements/randomizer/logic.cpp
@@ -2228,7 +2228,7 @@ const std::vector<uint8_t>& GetDungeonSmallKeyDoors(SceneID sceneId) {
             }
         } else if (transitionActor.id == ACTOR_DOOR_SHUTTER) {
             uint8_t doorType = (transitionActor.params >> 7) & 15;
-            if (doorType == SHUTTER_BACK_LOCKED || doorType == SHUTTER_BOSS || doorType == SHUTTER_KEY_LOCKED) {
+            if (doorType == SHUTTER_KEY_LOCKED) {
                 dungeonSmallKeyDoors[key].emplace_back(transitionActor.params & 0x3F);
             }
         }


### PR DESCRIPTION
Removed SHUTTER_BACK_LOCKED and SHUTTER_BOSS from GetDungeonSmallKeyDoors.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3724623139.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3724672732.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3724681185.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3724687656.zip)
<!--- section:artifacts:end -->