### PR TITLE
SDL_GameControllerDB repo owner gabomdq -> mdqinc

### DIFF
--- a/docs/GAME_CONTROLLER_DB.md
+++ b/docs/GAME_CONTROLLER_DB.md
@@ -1,38 +1,38 @@
 # SDL GameControllerDB
 
 The Ship of Harkinian utilizes a text file with SDL controller mappings for extended controller hardware support.
-This file is pulled from https://github.com/gabomdq/SDL_GameControllerDB during the build process as [a part of CMakeLists.txt](https://github.com/HarbourMasters/Shipwright/blob/bb643661f62865dfc757c185d0daaebb32f2d53d/soh/CMakeLists.txt#L760).
+This file is pulled from https://github.com/mdqinc/SDL_GameControllerDB during the build process as [a part of CMakeLists.txt](https://github.com/HarbourMasters/Shipwright/blob/bb643661f62865dfc757c185d0daaebb32f2d53d/soh/CMakeLists.txt#L760).
 
 ## Released versions
 
 | Release | sha | diff |
 | - | - | - |
-| Zhora Alfa 4.0.0 | [967daa8](https://github.com/gabomdq/SDL_GameControllerDB/tree/967daa8f89c48b01ed0f9c6a86ac849930442fc6) | |
-| Zhora Bravo 4.0.1 | [ccac7cd](https://github.com/gabomdq/SDL_GameControllerDB/tree/ccac7cd97f445955d4437e21c5f82123d9b4349b) | [+1](https://github.com/gabomdq/SDL_GameControllerDB/compare/967daa8...ccac7cd) |
-| Zhora Charlie 4.0.2 | [ff26eb0](https://github.com/gabomdq/SDL_GameControllerDB/tree/ff26eb04d0fe18356985d968119429d6012e7d75) | [+8/-3](https://github.com/gabomdq/SDL_GameControllerDB/compare/ccac7cd...ff26eb0) |
-| Zhora Delta 4.0.3 | [ad02da5](https://github.com/gabomdq/SDL_GameControllerDB/tree/ad02da5a95ca8005f2c1facc11a5a52f8522f0ee) | [+4/-5](https://github.com/gabomdq/SDL_GameControllerDB/compare/ff26eb0...ad02da5) |
-| Zohra Echo 4.0.4 | [c203690](https://github.com/gabomdq/SDL_GameControllerDB/tree/c203690b1e13980699802918d362cd9dadf89bd0) | [+8/-4](https://github.com/gabomdq/SDL_GameControllerDB/compare/ad02da5...c203690) |
-| Zhora Foxtrot 4.0.5 | [9db8101](https://github.com/gabomdq/SDL_GameControllerDB/tree/9db8101a5780d1b0721bf6de385e6ffe0d07dfc7) | [+6](https://github.com/gabomdq/SDL_GameControllerDB/compare/c203690...9db8101) |
-| Flynn Alfa 5.0.0 | [163cc5d](https://github.com/gabomdq/SDL_GameControllerDB/tree/163cc5d45e9fc2f1bb2b95ea7eee4bbc9a57955c) | [+29/-8](https://github.com/gabomdq/SDL_GameControllerDB/compare/9db8101...163cc5d) |
-| Flynn Bravo 5.0.1 | [7efce7d](https://github.com/gabomdq/SDL_GameControllerDB/tree/7efce7d3f309ec1fa409b1af09153f9eb77fbedf) | [-1](https://github.com/gabomdq/SDL_GameControllerDB/compare/163cc5d...7efce7d) |
-| Flynn Charlie 5.0.2 | [e607703](https://github.com/gabomdq/SDL_GameControllerDB/tree/e607703392145343e8aca42be052121c0b7bd1c9) | [+40/-17](https://github.com/gabomdq/SDL_GameControllerDB/compare/7efce7d...e607703) |
-| Bradley Alfa 5.1.0 | [2ba9676](https://github.com/gabomdq/SDL_GameControllerDB/tree/2ba96761af795c15e916cc97790b51e09dc0cd54) | [+1/-1](https://github.com/gabomdq/SDL_GameControllerDB/compare/e607703...2ba9676) |
-| Bradley Charlie 5.1.2 | [4f5d1d4](https://github.com/gabomdq/SDL_GameControllerDB/tree/4f5d1d497985b75f4a83a5de46f596dc4d7f002e) | [+5/-1](https://github.com/gabomdq/SDL_GameControllerDB/compare/2ba9676...4f5d1d4) |
-| Bradley Delta 5.1.3 | [9b73049](https://github.com/gabomdq/SDL_GameControllerDB/tree/9b73049ee62a2cc862d6ad94c2c777f2e8363a48) | [+4/-1](https://github.com/gabomdq/SDL_GameControllerDB/compare/4f5d1d4...9b73049) |
-| Bradley Echo 5.1.4 | [6d3801f](https://github.com/gabomdq/SDL_GameControllerDB/tree/6d3801fcfe74b1989de96403b7b560eba72a175c) | [+56/-21](https://github.com/gabomdq/SDL_GameControllerDB/compare/9b73049...6d3801f) |
-| Gibbs Alfa 6.0.0 | [0562b00](https://github.com/gabomdq/SDL_GameControllerDB/tree/0562b00eaf5c0308c49d329b79263d2dae1c3a85) | [+8/-2](https://github.com/gabomdq/SDL_GameControllerDB/compare/6d3801f...0562b00) |
-| Khan Alfa 6.1.0 | [436c7e3](https://github.com/gabomdq/SDL_GameControllerDB/tree/436c7e3d54a57189ea0ab44d05f36b7cc7ea496c) | [+31/-16](https://github.com/gabomdq/SDL_GameControllerDB/compare/0562b00...436c7e3) |
-| Khan Bravo 6.1.1 | [01cca2e](https://github.com/gabomdq/SDL_GameControllerDB/tree/01cca2e77f9bf9f1432be04f876f287eb78297fe) | [+23/-6](https://github.com/gabomdq/SDL_GameControllerDB/compare/436c7e3...01cca2e) |
-| Khan Charlie 6.1.2 | [6852946](https://github.com/gabomdq/SDL_GameControllerDB/tree/6852946487534c69b7d228fd4eb8c87cf6966475) | [+25/-15](https://github.com/gabomdq/SDL_GameControllerDB/compare/01cca2e...6852946) |
-| Spock Alfa 7.0.0 | [38bda81](https://github.com/gabomdq/SDL_GameControllerDB/tree/38bda816dc786f18493876f7bc30bc12dfd2636a) | [+15/-1](https://github.com/gabomdq/SDL_GameControllerDB/compare/6852946...38bda81) |
-| Spock Bravo 7.0.1 | [228d980](https://github.com/gabomdq/SDL_GameControllerDB/tree/228d980d3d791e9df3b096472f6b97459f8709fe) | [+7/-3](https://github.com/gabomdq/SDL_GameControllerDB/compare/38bda81...228d980) |
-| Spock Charlie 7.0.2 | [c5b4df0](https://github.com/gabomdq/SDL_GameControllerDB/tree/c5b4df0e1061175cb11e3ebbf8045178339864a5) | [+3](https://github.com/gabomdq/SDL_GameControllerDB/compare/228d980...c5b4df0) |
-| Sulu Alfa 7.1.0 | [a2cf171](https://github.com/gabomdq/SDL_GameControllerDB/tree/a2cf1711b4ebc646a3814705d2fb6aac5707bcae) | [+4/-1](https://github.com/gabomdq/SDL_GameControllerDB/compare/c5b4df0...a2cf171) |
-| Sulu Bravo 7.1.1 | [cc9f777](https://github.com/gabomdq/SDL_GameControllerDB/tree/cc9f777721f0cb30058d9eef52a295130b734a4a) | [+29/-9](https://github.com/gabomdq/SDL_GameControllerDB/compare/a2cf171...cc9f777) |
-| MacReady Alfa 8.0.0 | [c56329f](https://github.com/gabomdq/SDL_GameControllerDB/tree/c56329f4df93fc7a780bdbeae47a9c91447b629c) | [+67/-23](https://github.com/gabomdq/SDL_GameControllerDB/compare/cc9f777...c56329f) |
-| MacReady Bravo 8.0.1 | [721b575](https://github.com/gabomdq/SDL_GameControllerDB/tree/721b575d3053b21d6d30419bf74afb5b1d0fa7a4) | [+5/-5](https://github.com/gabomdq/SDL_GameControllerDB/compare/c56329f...721b575) |
-| MacReady Charlie 8.0.2 | [721b575](https://github.com/gabomdq/SDL_GameControllerDB/tree/721b575d3053b21d6d30419bf74afb5b1d0fa7a4) | [+0/-0](https://github.com/gabomdq/SDL_GameControllerDB/compare/721b575...721b575) |
-| MacReady Delta 8.0.3 | [d4ab609](https://github.com/gabomdq/SDL_GameControllerDB/tree/d4ab609121ee6e687bc3d3a7e80244b3b26d1164) | [+5/-3](https://github.com/gabomdq/SDL_GameControllerDB/compare/721b575...d4ab609) |
-| MacReady Echo 8.0.4 | [6555d47](https://github.com/gabomdq/SDL_GameControllerDB/tree/6555d47ecb5d9eebac0e3d8cd19a545e9d946c40) | [+2/-0](https://github.com/gabomdq/SDL_GameControllerDB/compare/d4ab609...6555d47) |
-| MacReady Foxtrot 8.0.5 | [037d6a1](https://github.com/gabomdq/SDL_GameControllerDB/tree/037d6a1533ed94fbc6a8c71e6f1f9aff1e46208a) | [+47/-14](https://github.com/gabomdq/SDL_GameControllerDB/compare/6555d47...037d6a1) |
-| MacReady Golf 8.0.6 | [075c154](https://github.com/gabomdq/SDL_GameControllerDB/tree/075c1549075ef89a397fd7e0663d21e53a2485fd) | [+340/-301](https://github.com/gabomdq/SDL_GameControllerDB/compare/037d6a1...075c154) |
+| Zhora Alfa 4.0.0 | [967daa8](https://github.com/mdqinc/SDL_GameControllerDB/tree/967daa8f89c48b01ed0f9c6a86ac849930442fc6) | |
+| Zhora Bravo 4.0.1 | [ccac7cd](https://github.com/mdqinc/SDL_GameControllerDB/tree/ccac7cd97f445955d4437e21c5f82123d9b4349b) | [+1](https://github.com/mdqinc/SDL_GameControllerDB/compare/967daa8...ccac7cd) |
+| Zhora Charlie 4.0.2 | [ff26eb0](https://github.com/mdqinc/SDL_GameControllerDB/tree/ff26eb04d0fe18356985d968119429d6012e7d75) | [+8/-3](https://github.com/mdqinc/SDL_GameControllerDB/compare/ccac7cd...ff26eb0) |
+| Zhora Delta 4.0.3 | [ad02da5](https://github.com/mdqinc/SDL_GameControllerDB/tree/ad02da5a95ca8005f2c1facc11a5a52f8522f0ee) | [+4/-5](https://github.com/mdqinc/SDL_GameControllerDB/compare/ff26eb0...ad02da5) |
+| Zohra Echo 4.0.4 | [c203690](https://github.com/mdqinc/SDL_GameControllerDB/tree/c203690b1e13980699802918d362cd9dadf89bd0) | [+8/-4](https://github.com/mdqinc/SDL_GameControllerDB/compare/ad02da5...c203690) |
+| Zhora Foxtrot 4.0.5 | [9db8101](https://github.com/mdqinc/SDL_GameControllerDB/tree/9db8101a5780d1b0721bf6de385e6ffe0d07dfc7) | [+6](https://github.com/mdqinc/SDL_GameControllerDB/compare/c203690...9db8101) |
+| Flynn Alfa 5.0.0 | [163cc5d](https://github.com/mdqinc/SDL_GameControllerDB/tree/163cc5d45e9fc2f1bb2b95ea7eee4bbc9a57955c) | [+29/-8](https://github.com/mdqinc/SDL_GameControllerDB/compare/9db8101...163cc5d) |
+| Flynn Bravo 5.0.1 | [7efce7d](https://github.com/mdqinc/SDL_GameControllerDB/tree/7efce7d3f309ec1fa409b1af09153f9eb77fbedf) | [-1](https://github.com/mdqinc/SDL_GameControllerDB/compare/163cc5d...7efce7d) |
+| Flynn Charlie 5.0.2 | [e607703](https://github.com/mdqinc/SDL_GameControllerDB/tree/e607703392145343e8aca42be052121c0b7bd1c9) | [+40/-17](https://github.com/mdqinc/SDL_GameControllerDB/compare/7efce7d...e607703) |
+| Bradley Alfa 5.1.0 | [2ba9676](https://github.com/mdqinc/SDL_GameControllerDB/tree/2ba96761af795c15e916cc97790b51e09dc0cd54) | [+1/-1](https://github.com/mdqinc/SDL_GameControllerDB/compare/e607703...2ba9676) |
+| Bradley Charlie 5.1.2 | [4f5d1d4](https://github.com/mdqinc/SDL_GameControllerDB/tree/4f5d1d497985b75f4a83a5de46f596dc4d7f002e) | [+5/-1](https://github.com/mdqinc/SDL_GameControllerDB/compare/2ba9676...4f5d1d4) |
+| Bradley Delta 5.1.3 | [9b73049](https://github.com/mdqinc/SDL_GameControllerDB/tree/9b73049ee62a2cc862d6ad94c2c777f2e8363a48) | [+4/-1](https://github.com/mdqinc/SDL_GameControllerDB/compare/4f5d1d4...9b73049) |
+| Bradley Echo 5.1.4 | [6d3801f](https://github.com/mdqinc/SDL_GameControllerDB/tree/6d3801fcfe74b1989de96403b7b560eba72a175c) | [+56/-21](https://github.com/mdqinc/SDL_GameControllerDB/compare/9b73049...6d3801f) |
+| Gibbs Alfa 6.0.0 | [0562b00](https://github.com/mdqinc/SDL_GameControllerDB/tree/0562b00eaf5c0308c49d329b79263d2dae1c3a85) | [+8/-2](https://github.com/mdqinc/SDL_GameControllerDB/compare/6d3801f...0562b00) |
+| Khan Alfa 6.1.0 | [436c7e3](https://github.com/mdqinc/SDL_GameControllerDB/tree/436c7e3d54a57189ea0ab44d05f36b7cc7ea496c) | [+31/-16](https://github.com/mdqinc/SDL_GameControllerDB/compare/0562b00...436c7e3) |
+| Khan Bravo 6.1.1 | [01cca2e](https://github.com/mdqinc/SDL_GameControllerDB/tree/01cca2e77f9bf9f1432be04f876f287eb78297fe) | [+23/-6](https://github.com/mdqinc/SDL_GameControllerDB/compare/436c7e3...01cca2e) |
+| Khan Charlie 6.1.2 | [6852946](https://github.com/mdqinc/SDL_GameControllerDB/tree/6852946487534c69b7d228fd4eb8c87cf6966475) | [+25/-15](https://github.com/mdqinc/SDL_GameControllerDB/compare/01cca2e...6852946) |
+| Spock Alfa 7.0.0 | [38bda81](https://github.com/mdqinc/SDL_GameControllerDB/tree/38bda816dc786f18493876f7bc30bc12dfd2636a) | [+15/-1](https://github.com/mdqinc/SDL_GameControllerDB/compare/6852946...38bda81) |
+| Spock Bravo 7.0.1 | [228d980](https://github.com/mdqinc/SDL_GameControllerDB/tree/228d980d3d791e9df3b096472f6b97459f8709fe) | [+7/-3](https://github.com/mdqinc/SDL_GameControllerDB/compare/38bda81...228d980) |
+| Spock Charlie 7.0.2 | [c5b4df0](https://github.com/mdqinc/SDL_GameControllerDB/tree/c5b4df0e1061175cb11e3ebbf8045178339864a5) | [+3](https://github.com/mdqinc/SDL_GameControllerDB/compare/228d980...c5b4df0) |
+| Sulu Alfa 7.1.0 | [a2cf171](https://github.com/mdqinc/SDL_GameControllerDB/tree/a2cf1711b4ebc646a3814705d2fb6aac5707bcae) | [+4/-1](https://github.com/mdqinc/SDL_GameControllerDB/compare/c5b4df0...a2cf171) |
+| Sulu Bravo 7.1.1 | [cc9f777](https://github.com/mdqinc/SDL_GameControllerDB/tree/cc9f777721f0cb30058d9eef52a295130b734a4a) | [+29/-9](https://github.com/mdqinc/SDL_GameControllerDB/compare/a2cf171...cc9f777) |
+| MacReady Alfa 8.0.0 | [c56329f](https://github.com/mdqinc/SDL_GameControllerDB/tree/c56329f4df93fc7a780bdbeae47a9c91447b629c) | [+67/-23](https://github.com/mdqinc/SDL_GameControllerDB/compare/cc9f777...c56329f) |
+| MacReady Bravo 8.0.1 | [721b575](https://github.com/mdqinc/SDL_GameControllerDB/tree/721b575d3053b21d6d30419bf74afb5b1d0fa7a4) | [+5/-5](https://github.com/mdqinc/SDL_GameControllerDB/compare/c56329f...721b575) |
+| MacReady Charlie 8.0.2 | [721b575](https://github.com/mdqinc/SDL_GameControllerDB/tree/721b575d3053b21d6d30419bf74afb5b1d0fa7a4) | [+0/-0](https://github.com/mdqinc/SDL_GameControllerDB/compare/721b575...721b575) |
+| MacReady Delta 8.0.3 | [d4ab609](https://github.com/mdqinc/SDL_GameControllerDB/tree/d4ab609121ee6e687bc3d3a7e80244b3b26d1164) | [+5/-3](https://github.com/mdqinc/SDL_GameControllerDB/compare/721b575...d4ab609) |
+| MacReady Echo 8.0.4 | [6555d47](https://github.com/mdqinc/SDL_GameControllerDB/tree/6555d47ecb5d9eebac0e3d8cd19a545e9d946c40) | [+2/-0](https://github.com/mdqinc/SDL_GameControllerDB/compare/d4ab609...6555d47) |
+| MacReady Foxtrot 8.0.5 | [037d6a1](https://github.com/mdqinc/SDL_GameControllerDB/tree/037d6a1533ed94fbc6a8c71e6f1f9aff1e46208a) | [+47/-14](https://github.com/mdqinc/SDL_GameControllerDB/compare/6555d47...037d6a1) |
+| MacReady Golf 8.0.6 | [075c154](https://github.com/mdqinc/SDL_GameControllerDB/tree/075c1549075ef89a397fd7e0663d21e53a2485fd) | [+340/-301](https://github.com/mdqinc/SDL_GameControllerDB/compare/037d6a1...075c154) |

--- a/soh/CMakeLists.txt
+++ b/soh/CMakeLists.txt
@@ -740,7 +740,7 @@ INSTALL(FILES ${CMAKE_BINARY_DIR}/soh/soh.o2r DESTINATION . COMPONENT ship)
 endif()
 
 find_program(CURL NAMES curl DOC "Path to the curl program.  Used to download files.")
-execute_process(COMMAND ${CURL} -sSfL https://raw.githubusercontent.com/gabomdq/SDL_GameControllerDB/master/gamecontrollerdb.txt -o ${CMAKE_BINARY_DIR}/gamecontrollerdb.txt OUTPUT_VARIABLE RESULT)
+execute_process(COMMAND ${CURL} -sSfL https://raw.githubusercontent.com/mdqinc/SDL_GameControllerDB/master/gamecontrollerdb.txt -o ${CMAKE_BINARY_DIR}/gamecontrollerdb.txt OUTPUT_VARIABLE RESULT)
 
 if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
 configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/macosx/Info.plist.in ${CMAKE_BINARY_DIR}/macosx/Info.plist @ONLY)


### PR DESCRIPTION
Seems at some point the owner of the SDL_GameControllerDB repo change from gabomdq to mdqinc. The previous URL redirected so functionally there is no change. This updates avoids breakage should that redirect ever disappear (and avoids an HTTP hop).

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3845177363.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3845207271.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3845389153.zip)
<!--- section:artifacts:end -->