### PR TITLE
Allow non-ASCII characters on Windows

### DIFF
--- a/soh/src/code/main.c
+++ b/soh/src/code/main.c
@@ -1,5 +1,6 @@
 #ifdef _WIN32
 #include <Windows.h>
+#include <locale.h>
 #endif
 
 #include "global.h"
@@ -52,6 +53,8 @@ int SDL_main(int argc, char** argv) {
 #ifndef _DEBUG
     ShowWindow(GetConsoleWindow(), SW_HIDE);
 #endif
+    // Allow non-ascii characters for Windows
+    setlocale(LC_ALL, ".UTF8");
 
 #else //_WIN32
 int main(int argc, char** argv) {


### PR DESCRIPTION
Based on https://github.com/HarbourMasters/2ship2harkinian/pull/743

Test by putting SoH in a Windows folder containing a special character, such as é. As long as the O2R exists, it should not display the "Main OTR not found" error and hang. However, recent LUS changes cause special characters to fail at startup with no fanfare. [I submitted a PR to LUS for that](https://github.com/Kenix3/libultraship/pull/912). With I run both locally, SoH runs in paths with special characters.

For reference, 2ship already had this fix in place and worked on earlier versions of LUS. If I run 2ship locally with the LUS changes I linked, it works as well.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3734926484.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3734975670.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3748412744.zip)
<!--- section:artifacts:end -->