### PR TITLE
[Enhancement] Toggle grave hole geometry

### DIFF
--- a/soh/soh/Enhancements/Restorations/GraveHoleJumps.cpp
+++ b/soh/soh/Enhancements/Restorations/GraveHoleJumps.cpp
@@ -46,7 +46,7 @@ CollisionHeader* getGraveyardCollisionHeader() {
      * into graves. NTSC 1.0's graveyard has 31 surface types, while later versions have 32. The contents of the lists
      * are shifted somewhat between versions, so to be safe we just create an extra slot that is not in any version.
      */
-    SurfaceType newSurfaceTypes[33];
+    static SurfaceType newSurfaceTypes[33];
     memcpy(newSurfaceTypes, graveyardColHeader->surfaceTypeList, sizeof(SurfaceType) * 33);
     newSurfaceTypes[CUSTOM_SURFACE_TYPE].data[0] = 0x24000004;
     newSurfaceTypes[CUSTOM_SURFACE_TYPE].data[1] = 0xFC8;

--- a/soh/soh/Enhancements/Restorations/GraveHoleJumps.cpp
+++ b/soh/soh/Enhancements/Restorations/GraveHoleJumps.cpp
@@ -1,0 +1,73 @@
+#include "public/bridge/consolevariablebridge.h"
+#include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
+#include "soh/ShipInit.hpp"
+#include "functions.h"
+#include "soh/Enhancements/enhancementTypes.h"
+#include "soh/resource/type/Scene.h"
+#include "soh/resource/type/scenecommand/SceneCommand.h"
+#include "soh/resource/type/scenecommand/SetCollisionHeader.h"
+
+#define CVAR_GRAVE_HOLE_NAME CVAR_ENHANCEMENT("GraveHoles")
+#define GRAVE_HOLES_DEFAULT 0
+#define CVAR_GRAVE_HOLE_VALUE CVarGetInteger(CVAR_GRAVE_HOLE_NAME, GRAVE_HOLES_DEFAULT)
+#define GRAVEYARD_SCENE_FILEPATH "scenes/shared/spot02_scene/spot02_scene"
+#define CUSTOM_SURFACE_TYPE 32
+
+const static std::vector<std::pair<std::pair<u16, u16>, std::pair<u16, u16>>> graveyardGeometryPatches = {
+    // { { startPolygon, endPolygon }, { originalSurfaceType, patchedSurfaceType } }
+    { { 487, 509 }, { 20, CUSTOM_SURFACE_TYPE } }, // Floor around graves
+    { { 651, 658 }, { 20, CUSTOM_SURFACE_TYPE } }, // Floor around Royal Family Tomb
+    { { 613, 620 }, { 0, 15 } },                   // Grave ledges (Hylian Shield)
+    { { 623, 630 }, { 0, 15 } },                   // Grave ledges (Redead)
+    { { 633, 640 }, { 0, 15 } },                   // Grave ledges (Dampe)
+    { { 643, 650 }, { 0, 15 } },                   // Grave ledges (Royal Family)
+};
+
+CollisionHeader* getGraveyardCollisionHeader() {
+    /*
+     * Load the graveyard collision header manually. Since its position varies between versions, we cannot directly use
+     * dspot02_sceneCollisionHeader_003C54. We have to scroll through the scene cmds to get the header the same way the
+     * game does.
+     */
+    SOH::Scene* scene =
+        (SOH::Scene*)Ship::Context::GetInstance()->GetResourceManager()->LoadResource(GRAVEYARD_SCENE_FILEPATH).get();
+    SOH::ISceneCommand* sceneCmd = nullptr;
+    for (int i = 0; i < scene->commands.size(); i++) {
+        auto cmd = scene->commands[i];
+        if (cmd->cmdId == SOH::SceneCommandID::SetCollisionHeader) {
+            sceneCmd = cmd.get();
+            break;
+        }
+    }
+    CollisionHeader* graveyardColHeader = (CollisionHeader*)((SOH::SetCollisionHeader*)sceneCmd)->GetRawPointer();
+
+    /*
+     * Copy the surface type list and give ourselves some extra space to create another surface type for Link to fall
+     * into graves. NTSC 1.0's graveyard has 31 surface types, while later versions have 32. The contents of the lists
+     * are shifted somewhat between versions, so to be safe we just create an extra slot that is not in any version.
+     */
+    size_t surfaceTypeListSize = sizeof(SurfaceType) * 33;
+    SurfaceType* newSurfaceTypes = (SurfaceType*)malloc(surfaceTypeListSize);
+    memcpy(newSurfaceTypes, graveyardColHeader->surfaceTypeList, surfaceTypeListSize);
+    newSurfaceTypes[CUSTOM_SURFACE_TYPE].data[0] = 0x24000004;
+    newSurfaceTypes[CUSTOM_SURFACE_TYPE].data[1] = 0xFC8;
+    graveyardColHeader->surfaceTypeList = newSurfaceTypes;
+
+    return graveyardColHeader;
+}
+
+void ApplyGraveyardGeometryPatches() {
+    static CollisionHeader* graveyardColHeader = getGraveyardCollisionHeader();
+    for (auto& mappingPatch : graveyardGeometryPatches) {
+        for (int i = mappingPatch.first.first; i <= mappingPatch.first.second; i++) {
+            CollisionPoly* poly = &graveyardColHeader->polyList[i];
+            poly->type = CVAR_GRAVE_HOLE_VALUE ? mappingPatch.second.first : mappingPatch.second.second;
+        }
+    }
+}
+
+void RegisterGraveHoleJumps() {
+    ApplyGraveyardGeometryPatches();
+}
+
+static RegisterShipInitFunc initFunc_GraveHoleJumps(RegisterGraveHoleJumps, { CVAR_GRAVE_HOLE_NAME });

--- a/soh/soh/Enhancements/Restorations/GraveHoleJumps.cpp
+++ b/soh/soh/Enhancements/Restorations/GraveHoleJumps.cpp
@@ -13,7 +13,7 @@
 #define GRAVEYARD_SCENE_FILEPATH "scenes/shared/spot02_scene/spot02_scene"
 #define CUSTOM_SURFACE_TYPE 32
 
-const static std::vector<std::pair<std::pair<u16, u16>, std::pair<u16, u16>>> graveyardGeometryPatches = {
+const static std::array<std::pair<std::pair<u16, u16>, std::pair<u16, u16>>, 6> graveyardGeometryPatches = { {
     // { { startPolygon, endPolygon }, { originalSurfaceType, patchedSurfaceType } }
     { { 487, 509 }, { 20, CUSTOM_SURFACE_TYPE } }, // Floor around graves
     { { 651, 658 }, { 20, CUSTOM_SURFACE_TYPE } }, // Floor around Royal Family Tomb
@@ -21,7 +21,7 @@ const static std::vector<std::pair<std::pair<u16, u16>, std::pair<u16, u16>>> gr
     { { 623, 630 }, { 0, 15 } },                   // Grave ledges (Redead)
     { { 633, 640 }, { 0, 15 } },                   // Grave ledges (Dampe)
     { { 643, 650 }, { 0, 15 } },                   // Grave ledges (Royal Family)
-};
+} };
 
 CollisionHeader* getGraveyardCollisionHeader() {
     /*
@@ -46,9 +46,8 @@ CollisionHeader* getGraveyardCollisionHeader() {
      * into graves. NTSC 1.0's graveyard has 31 surface types, while later versions have 32. The contents of the lists
      * are shifted somewhat between versions, so to be safe we just create an extra slot that is not in any version.
      */
-    size_t surfaceTypeListSize = sizeof(SurfaceType) * 33;
-    SurfaceType* newSurfaceTypes = (SurfaceType*)malloc(surfaceTypeListSize);
-    memcpy(newSurfaceTypes, graveyardColHeader->surfaceTypeList, surfaceTypeListSize);
+    SurfaceType newSurfaceTypes[33];
+    memcpy(newSurfaceTypes, graveyardColHeader->surfaceTypeList, sizeof(SurfaceType) * 33);
     newSurfaceTypes[CUSTOM_SURFACE_TYPE].data[0] = 0x24000004;
     newSurfaceTypes[CUSTOM_SURFACE_TYPE].data[1] = 0xFC8;
     graveyardColHeader->surfaceTypeList = newSurfaceTypes;

--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -1161,6 +1161,10 @@ void SohMenu::AddMenuEnhancements() {
         .CVar(CVAR_ENHANCEMENT("NGCKaleidoSwitcher"))
         .Options(CheckboxOptions().Tooltip(
             "Makes L and R switch pages like on the GameCube. Z opens the Debug Menu instead."));
+    AddWidget(path, "Grave Hole Jumps", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_ENHANCEMENT("GraveHoles"))
+        .Options(CheckboxOptions().Tooltip(
+            "Restores NTSC 1.0 behavior where Link jumps over grave holes and grabs the ledges."));
 
     // Difficulty Options
     path.sidebarName = "Difficulty";


### PR DESCRIPTION
In NTSC 1.0, the grave holes in the Kakariko graveyard work like regular ledges, meaning Link will jump over them and grab the edges. Later versions made Link fall right into the holes to lessen the annoyance.

This PR will automatically patch the map's data so that Link always falls into the holes by default, regardless of the game version. Enabling the toggle patches the data to reflect the original behavior of grave hopping. I waffled a bit on this, but I think it leads to better UX. While it is a data change rather than a code change, to the end user it should "feel" more consistent with the code-based restoration settings.

NTSC 1.0 with the patched geometry:

https://github.com/user-attachments/assets/3275ff42-afd7-4b0c-8d37-a503df59d097

PAL MQ with the original geometry:

https://github.com/user-attachments/assets/95a9c9b4-62b2-4998-8e59-367555d6f390

Tested on:
- NTSC-U 1.0
- NTSC-U 1.2
- NTSC-U GC
- PAL GC
- PAL MQ

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3798187924.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3798200917.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3798380072.zip)
<!--- section:artifacts:end -->