### PR TITLE
Fix Medallion Gives and Resolve Cutscene Skip Issues

### DIFF
--- a/soh/soh/Enhancements/TimeSavers/SkipCutscene/Story/SkipBlueWarp.cpp
+++ b/soh/soh/Enhancements/TimeSavers/SkipCutscene/Story/SkipBlueWarp.cpp
@@ -1,6 +1,7 @@
 #include "soh/Enhancements/game-interactor/GameInteractor.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 #include "soh/OTRGlobals.h"
+#include "soh/Enhancements/timesaver_hook_handlers.h"
 
 extern "C" {
 #include "macros.h"
@@ -12,6 +13,7 @@ extern "C" {
 
 #define RAND_GET_OPTION(option) Rando::Context::GetInstance()->GetOption(option).Get()
 
+extern "C" PlayState* gPlayState;
 static bool sEnteredBlueWarp = false;
 
 /**
@@ -124,6 +126,13 @@ void SkipBlueWarp_ShouldPlayBlueWarpCS(GIVanillaBehavior _, bool* should, va_lis
  */
 void SkipBlueWarp_ShouldGiveItem(GIVanillaBehavior _, bool* should, va_list originalArgs) {
     if (CVarGetInteger(CVAR_ENHANCEMENT("TimeSavers.SkipCutscene.Story"), IS_RANDO)) {
+        if (IS_VANILLA) {
+            if (gPlayState->sceneNum == SCENE_SHADOW_TEMPLE_BOSS) {
+                TimeSaverQueueItem(RG_SHADOW_MEDALLION);
+            } else if (gPlayState->sceneNum == SCENE_SPIRIT_TEMPLE_BOSS) {
+                TimeSaverQueueItem(RG_SPIRIT_MEDALLION);
+            }
+        }
         *should = false;
     }
 }

--- a/soh/soh/Enhancements/boss-rush/BossRush.cpp
+++ b/soh/soh/Enhancements/boss-rush/BossRush.cpp
@@ -501,6 +501,10 @@ void BossRush_OnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_li
             }
             break;
         }
+        case VB_PLAY_BLUE_WARP_CS: {
+            *should = false;
+            break;
+        }
         // Spawn clean blue warps (no ruto, adult animation, etc)
         case VB_SPAWN_BLUE_WARP: {
             switch (gPlayState->sceneNum) {

--- a/soh/soh/Enhancements/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.cpp
@@ -1,6 +1,5 @@
 #include <libultraship/bridge.h>
 #include "soh/OTRGlobals.h"
-#include "soh/Enhancements/randomizer/randomizerTypes.h"
 #include "soh/Enhancements/game-interactor/GameInteractor.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 #include "soh/Enhancements/enhancementTypes.h"
@@ -1198,6 +1197,10 @@ void TimeSaverOnSceneInitHandler(int16_t sceneNum) {
 }
 
 static GetItemEntry vanillaQueuedItemEntry = GET_ITEM_NONE;
+
+void TimeSaverQueueItem(RandomizerGet randoGet) {
+    vanillaQueuedItemEntry = Rando::StaticData::RetrieveItem(randoGet).GetGIEntry_Copy();
+}
 
 void TimeSaverOnFlagSetHandler(int16_t flagType, int16_t flag) {
     // Do nothing when in a boss rush

--- a/soh/soh/Enhancements/timesaver_hook_handlers.h
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.h
@@ -1,6 +1,9 @@
 #ifndef TIMESAVER_HOOK_HANDLERS_H
 #define TIMESAVER_HOOK_HANDLERS_H
 
+#include "soh/Enhancements/randomizer/randomizerTypes.h"
+
 void TimeSaverRegisterHooks();
+void TimeSaverQueueItem(RandomizerGet randoGet);
 
 #endif // TIMESAVER_HOOK_HANDLERS_H

--- a/soh/src/overlays/actors/ovl_Door_Warp1/z_door_warp1.c
+++ b/soh/src/overlays/actors/ovl_Door_Warp1/z_door_warp1.c
@@ -813,8 +813,7 @@ void DoorWarp1_AdultWarpOut(DoorWarp1* this, PlayState* play) {
                 gSaveContext.nextCutsceneIndex = 0;
             }
         } else if (play->sceneNum == SCENE_SPIRIT_TEMPLE_BOSS) {
-            if (GameInteractor_Should(VB_PLAY_BLUE_WARP_CS,
-                                      !Flags_GetRandomizerInf(RAND_INF_DUNGEONS_DONE_SPIRIT_TEMPLE),
+            if (GameInteractor_Should(VB_PLAY_BLUE_WARP_CS, !CHECK_QUEST_ITEM(QUEST_MEDALLION_SPIRIT),
                                       RAND_INF_DUNGEONS_DONE_SPIRIT_TEMPLE)) {
                 Flags_SetRandomizerInf(RAND_INF_DUNGEONS_DONE_SPIRIT_TEMPLE);
                 if (GameInteractor_Should(VB_GIVE_ITEM_FROM_BLUE_WARP, true, ITEM_MEDALLION_SPIRIT)) {
@@ -832,8 +831,7 @@ void DoorWarp1_AdultWarpOut(DoorWarp1* this, PlayState* play) {
                 gSaveContext.nextCutsceneIndex = 0;
             }
         } else if (play->sceneNum == SCENE_SHADOW_TEMPLE_BOSS) {
-            if (GameInteractor_Should(VB_PLAY_BLUE_WARP_CS,
-                                      !Flags_GetRandomizerInf(RAND_INF_DUNGEONS_DONE_SHADOW_TEMPLE),
+            if (GameInteractor_Should(VB_PLAY_BLUE_WARP_CS, !CHECK_QUEST_ITEM(QUEST_MEDALLION_SHADOW),
                                       RAND_INF_DUNGEONS_DONE_SHADOW_TEMPLE)) {
                 Flags_SetRandomizerInf(RAND_INF_DUNGEONS_DONE_SHADOW_TEMPLE);
                 if (GameInteractor_Should(VB_GIVE_ITEM_FROM_BLUE_WARP, true, ITEM_MEDALLION_SHADOW)) {


### PR DESCRIPTION
#5623 originally was fixing the issue where the Impa and Nabooru cutscenes were still playing while running Boss Rush, however, it ended up causing another issue in that those two medallions weren't being given in vanilla at all. This is because I'd forgotten that the randomizer section simply doesn't exist in vanilla saves anymore, and those two were relying on `RandomizerInf` flags. Reverting the changes in #5623 makes the two medallion gives work in vanilla with cutscene skips off, but re-introduced the boss rush issue, and the exposed cutscene skip issue was still there, so I had to add a handler to `SkipBlueWarp` to manually enqueue the medallions when appropriate, and add a case to `BossRush`'s handler to always make `should` on `VB_PLAY_BLUE_WARP_CS` always false for Boss Rush to let its own scene handling work properly.

Ideally, the real fix for the gives would have been creation and implementation of the SohInf structure, but that's far beyond the scope of a dev-blair PR.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3840004370.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3840104779.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3840108866.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3840126069.zip)
<!--- section:artifacts:end -->