### PR TITLE
Fix gerudo card generation failures

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/item_pool.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/item_pool.cpp
@@ -861,7 +861,7 @@ void GenerateItemPool() {
         AddItemToMainPool(RG_GERUDO_MEMBERSHIP_CARD);
         ctx->possibleIceTrapModels.push_back(RG_GERUDO_MEMBERSHIP_CARD);
     } else if (ctx->GetOption(RSK_SHUFFLE_GERUDO_MEMBERSHIP_CARD)) {
-        AddItemToPool(PendingJunkPool, RG_GERUDO_MEMBERSHIP_CARD);
+        AddItemToPool(ItemPool, RG_GERUDO_MEMBERSHIP_CARD);
         ctx->PlaceItemInLocation(RC_GF_GERUDO_MEMBERSHIP_CARD, RG_ICE_TRAP, false, true);
     } else {
         ctx->PlaceItemInLocation(RC_GF_GERUDO_MEMBERSHIP_CARD, RG_GERUDO_MEMBERSHIP_CARD, false, true);


### PR DESCRIPTION
On some settings combinations the gerudo membership card was added to the junk pool instead of the item pool, causing generation failure. This fixes the problem on release.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3905232456.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3905416914.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3905424607.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3905434290.zip)
<!--- section:artifacts:end -->