### PR TITLE
Improve Nix support

### DIFF
--- a/CMake/FindOpusFile.cmake
+++ b/CMake/FindOpusFile.cmake
@@ -6,9 +6,16 @@
 #   OPUSFILE_LIBRARY     - Path to the opusfile library
 #   OPUSFILE_LIBRARIES   - Full list of libraries to link (opusfile, opus, ogg)
 
+# Use pkg-config to find opusfile if available
+find_package(PkgConf)
+if(PKG_CONFIG_FOUND)
+    pkg_check_modules(PC_OPUSFILE QUIET opusfile)
+endif()
+
 # Search for the OpusFile header
 find_path(OPUSFILE_INCLUDE_DIR
     NAMES opusfile.h
+    HINTS ${PC_OPUSFILE_INCLUDE_DIRS}
     PATHS /usr/include/opus /usr/local/include/opus /opt/local/include/opus /opt/homebrew/include/opus
     DOC "Directory where opusfile.h is located"
 )
@@ -16,6 +23,7 @@ find_path(OPUSFILE_INCLUDE_DIR
 # Search for the OpusFile library
 find_library(OPUSFILE_LIBRARY
     NAMES opusfile
+    HINTS ${PC_OPUSFILE_LIBRARY_DIRS}
     DOC "Path to the libopusfile library"
 )
 

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -119,6 +119,72 @@ zypper in gcc gcc-c++ git cmake ninja SDL2-devel libpng16-devel libzip-devel lib
 # or using clang
 zypper in clang libstdc++-devel git cmake ninja SDL2-devel libpng16-devel libzip-devel libzip-tools nlohmann_json-devel tinyxml2-devel spdlog-devel
 ```
+#### Nix
+You can use a `flake.nix` file to instantly setup a development environment using [Nix](https://nixos.org/). Write this `flake.nix` file in the root directory:
+
+```nix
+{
+  description = "Shipwright development environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            # Build tools
+            clang
+            git
+            cmake
+            ninja
+            lsb-release
+            pkg-config
+
+            # SDL2 libraries
+            SDL2
+            SDL2.dev
+            SDL2_net
+
+            # Other libraries
+            libpng
+            libzip
+            nlohmann_json
+            tinyxml-2
+            spdlog
+            libGL
+            libGL.dev
+            bzip2
+
+            # X11 libraries
+            xorg.libX11
+
+            # Audio libraries
+            libogg
+            libogg.dev
+            libvorbis
+            libvorbis.dev
+            libopus
+            libopus.dev
+            opusfile
+            opusfile.dev
+          ];
+          shellHook = ''
+            echo "Shipwright development environment loaded"
+            echo "Available tools: clang, git, cmake, ninja"
+          '';
+        };
+      });
+}
+```
+
+Now type `nix develop` and you will be dropped into a shell with all dependencies, ensuring that all build commands work.
 
 ### Build
 
@@ -231,7 +297,7 @@ cmake --build build-cmake --target ExtractAssetHeaders
 
 ## Switch
 1. Requires that your build machine is setup with the tools necessary for your platform above
-2. Requires that you have the switch build tools installed 
+2. Requires that you have the switch build tools installed
 3. Clone the Ship of Harkinian repository
 4. Place one or more [compatible](#compatible-roms) roms in the `OTRExporter` directory with namings of your choice
 
@@ -252,7 +318,7 @@ cmake --build build-switch --target soh_nro
 
 ## Wii U
 1. Requires that your build machine is setup with the tools necessary for your platform above
-2. Requires that you have the Wii U build tools installed 
+2. Requires that you have the Wii U build tools installed
 3. Clone the Ship of Harkinian repository
 4. Place one or more [compatible](#compatible-roms) roms in the `OTRExporter` directory with namings of your choice
 
@@ -265,7 +331,7 @@ cmake --build build-cmake --target ExtractAssets
 # Setup cmake project for building for Wii U
 cmake -H. -Bbuild-wiiu -GNinja -DCMAKE_TOOLCHAIN_FILE=/opt/devkitpro/cmake/WiiU.cmake # -DCMAKE_BUILD_TYPE:STRING=Release (if you're packaging)
 # Build project and generate rpx
-cmake --build build-wiiu --target soh # --target soh_wuhb (for building .wuhb) 
+cmake --build build-wiiu --target soh # --target soh_wuhb (for building .wuhb)
 
 # Now you can run the executable in ./build-wiiu/soh/soh.rpx or the Wii U Homebrew Bundle in ./build-wiiu/soh/soh.wuhb
 # To develop the project open the repository in VSCode (or your preferred editor)


### PR DESCRIPTION
I use NixOS, and additionally, I use a Nix flake in order to create a dev environment for Ship of Harkinian.

Unfortunately with even all the dependencies, the Ninja setup could not find OpusFile.

I added some hints to help it out, and updated the documentation accordingly.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3949197414.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3949274910.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3949278210.zip)
<!--- section:artifacts:end -->