### PR TITLE
Encapsulate `BeginTable` for item and check tracker settings windows.

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -2199,8 +2199,8 @@ void CheckTrackerSettingsWindow::DrawElement() {
             "Checks that you saved the game while having collected.", THEME_COLOR);
 
         ImGui::PopStyleVar(1);
+        ImGui::EndTable();
     }
-    ImGui::EndTable();
 }
 
 void CheckTrackerWindow::InitElement() {

--- a/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
@@ -1713,245 +1713,156 @@ static std::unordered_map<int32_t, const char*> minimalDisplayTypes = {
 
 void ItemTrackerSettingsWindow::DrawElement() {
     ImGui::PushStyleVar(ImGuiStyleVar_CellPadding, { 8.0f, 8.0f });
-    ImGui::BeginTable("itemTrackerSettingsTable", 2, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV);
-    ImGui::TableSetupColumn("General settings", ImGuiTableColumnFlags_WidthStretch, 200.0f);
-    ImGui::TableSetupColumn("Section settings", ImGuiTableColumnFlags_WidthStretch, 200.0f);
-    ImGui::TableHeadersRow();
-    ImGui::TableNextRow();
-    ImGui::TableNextColumn();
-    ImGui::PushItemWidth(ImGui::GetContentRegionAvail().x);
-    CVarColorPicker("Background Color##gItemTrackerBgColor", CVAR_TRACKER_ITEM("BgColor"), { 0, 0, 0, 0 }, true,
-                    ColorPickerRandomButton | ColorPickerResetButton, THEME_COLOR);
+    if (ImGui::BeginTable("itemTrackerSettingsTable", 2, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV)) {
+        ImGui::TableSetupColumn("General settings", ImGuiTableColumnFlags_WidthStretch, 200.0f);
+        ImGui::TableSetupColumn("Section settings", ImGuiTableColumnFlags_WidthStretch, 200.0f);
+        ImGui::TableHeadersRow();
+        ImGui::TableNextRow();
+        ImGui::TableNextColumn();
+        ImGui::PushItemWidth(ImGui::GetContentRegionAvail().x);
+        CVarColorPicker("Background Color##gItemTrackerBgColor", CVAR_TRACKER_ITEM("BgColor"), { 0, 0, 0, 0 }, true,
+                        ColorPickerRandomButton | ColorPickerResetButton, THEME_COLOR);
 
-    ImGui::PopItemWidth();
-    if (CVarCombobox("Window Type", CVAR_TRACKER_ITEM("WindowType"), windowTypes,
-                     ComboboxOptions()
-                         .DefaultIndex(TRACKER_WINDOW_FLOATING)
-                         .ComponentAlignment(ComponentAlignments::Right)
-                         .LabelPosition(LabelPositions::Far)
-                         .Color(THEME_COLOR))) {
-        shouldUpdateVectors = true;
-    }
-
-    if (CVarGetInteger(CVAR_TRACKER_ITEM("WindowType"), TRACKER_WINDOW_FLOATING) == TRACKER_WINDOW_FLOATING) {
-        if (CVarCheckbox("Enable Dragging", CVAR_TRACKER_ITEM("Draggable"), CheckboxOptions().Color(THEME_COLOR))) {
-            shouldUpdateVectors = true;
-        }
-        if (CVarCheckbox("Only enable while paused", CVAR_TRACKER_ITEM("ShowOnlyPaused"),
-                         CheckboxOptions().Color(THEME_COLOR))) {
-            shouldUpdateVectors = true;
-        }
-        if (CVarCombobox("Display Mode", CVAR_TRACKER_ITEM("DisplayType.Main"), displayModes,
+        ImGui::PopItemWidth();
+        if (CVarCombobox("Window Type", CVAR_TRACKER_ITEM("WindowType"), windowTypes,
                          ComboboxOptions()
-                             .DefaultIndex(TRACKER_DISPLAY_ALWAYS)
+                             .DefaultIndex(TRACKER_WINDOW_FLOATING)
                              .ComponentAlignment(ComponentAlignments::Right)
                              .LabelPosition(LabelPositions::Far)
                              .Color(THEME_COLOR))) {
             shouldUpdateVectors = true;
         }
-        if (CVarGetInteger(CVAR_TRACKER_ITEM("DisplayType.Main"), TRACKER_DISPLAY_ALWAYS) ==
-            TRACKER_DISPLAY_COMBO_BUTTON) {
-            if (CVarCombobox("Combo Button 1", CVAR_TRACKER_ITEM("ComboButton1"), buttons,
+
+        if (CVarGetInteger(CVAR_TRACKER_ITEM("WindowType"), TRACKER_WINDOW_FLOATING) == TRACKER_WINDOW_FLOATING) {
+            if (CVarCheckbox("Enable Dragging", CVAR_TRACKER_ITEM("Draggable"), CheckboxOptions().Color(THEME_COLOR))) {
+                shouldUpdateVectors = true;
+            }
+            if (CVarCheckbox("Only enable while paused", CVAR_TRACKER_ITEM("ShowOnlyPaused"),
+                             CheckboxOptions().Color(THEME_COLOR))) {
+                shouldUpdateVectors = true;
+            }
+            if (CVarCombobox("Display Mode", CVAR_TRACKER_ITEM("DisplayType.Main"), displayModes,
                              ComboboxOptions()
-                                 .DefaultIndex(TRACKER_COMBO_BUTTON_L)
+                                 .DefaultIndex(TRACKER_DISPLAY_ALWAYS)
                                  .ComponentAlignment(ComponentAlignments::Right)
                                  .LabelPosition(LabelPositions::Far)
                                  .Color(THEME_COLOR))) {
                 shouldUpdateVectors = true;
             }
-            if (CVarCombobox("Combo Button 2", CVAR_TRACKER_ITEM("ComboButton2"), buttons,
-                             ComboboxOptions()
-                                 .DefaultIndex(TRACKER_COMBO_BUTTON_R)
-                                 .ComponentAlignment(ComponentAlignments::Right)
-                                 .LabelPosition(LabelPositions::Far)
-                                 .Color(THEME_COLOR))) {
+            if (CVarGetInteger(CVAR_TRACKER_ITEM("DisplayType.Main"), TRACKER_DISPLAY_ALWAYS) ==
+                TRACKER_DISPLAY_COMBO_BUTTON) {
+                if (CVarCombobox("Combo Button 1", CVAR_TRACKER_ITEM("ComboButton1"), buttons,
+                                 ComboboxOptions()
+                                     .DefaultIndex(TRACKER_COMBO_BUTTON_L)
+                                     .ComponentAlignment(ComponentAlignments::Right)
+                                     .LabelPosition(LabelPositions::Far)
+                                     .Color(THEME_COLOR))) {
+                    shouldUpdateVectors = true;
+                }
+                if (CVarCombobox("Combo Button 2", CVAR_TRACKER_ITEM("ComboButton2"), buttons,
+                                 ComboboxOptions()
+                                     .DefaultIndex(TRACKER_COMBO_BUTTON_R)
+                                     .ComponentAlignment(ComponentAlignments::Right)
+                                     .LabelPosition(LabelPositions::Far)
+                                     .Color(THEME_COLOR))) {
+                    shouldUpdateVectors = true;
+                }
+            }
+        }
+        ImGui::Separator();
+        CVarSliderInt("Icon size : %dpx", CVAR_TRACKER_ITEM("IconSize"),
+                      IntSliderOptions().Min(25).Max(128).DefaultValue(36).Color(THEME_COLOR));
+        CVarSliderInt("Icon margins : %dpx", CVAR_TRACKER_ITEM("IconSpacing"),
+                      IntSliderOptions().Min(-5).Max(50).DefaultValue(12).Color(THEME_COLOR));
+        CVarSliderInt("Text size : %dpx", CVAR_TRACKER_ITEM("TextSize"),
+                      IntSliderOptions().Min(1).Max(30).DefaultValue(13).Color(THEME_COLOR));
+
+        ImGui::NewLine();
+        CVarCombobox("Ammo/Capacity Tracking", CVAR_TRACKER_ITEM("ItemCountType"), itemTrackerCapacityTrackOptions,
+                     ComboboxOptions()
+                         .DefaultIndex(ITEM_TRACKER_NUMBER_CURRENT_CAPACITY_ONLY)
+                         .ComponentAlignment(ComponentAlignments::Left)
+                         .LabelPosition(LabelPositions::Above)
+                         .Color(THEME_COLOR)
+                         .Tooltip("Customize what the numbers under each item are tracking."
+                                  "\n\nNote: items without capacity upgrades will track ammo even in capacity mode"));
+        if (CVarGetInteger(CVAR_TRACKER_ITEM("ItemCountType"), ITEM_TRACKER_NUMBER_CURRENT_CAPACITY_ONLY) ==
+                ITEM_TRACKER_NUMBER_CURRENT_CAPACITY_ONLY ||
+            CVarGetInteger(CVAR_TRACKER_ITEM("ItemCountType"), ITEM_TRACKER_NUMBER_CURRENT_CAPACITY_ONLY) ==
+                ITEM_TRACKER_NUMBER_CURRENT_AMMO_ONLY) {
+            if (CVarCheckbox("Align count to left side", CVAR_TRACKER_ITEM("ItemCountAlignLeft"),
+                             CheckboxOptions().Color(THEME_COLOR))) {
                 shouldUpdateVectors = true;
             }
         }
-    }
-    ImGui::Separator();
-    CVarSliderInt("Icon size : %dpx", CVAR_TRACKER_ITEM("IconSize"),
-                  IntSliderOptions().Min(25).Max(128).DefaultValue(36).Color(THEME_COLOR));
-    CVarSliderInt("Icon margins : %dpx", CVAR_TRACKER_ITEM("IconSpacing"),
-                  IntSliderOptions().Min(-5).Max(50).DefaultValue(12).Color(THEME_COLOR));
-    CVarSliderInt("Text size : %dpx", CVAR_TRACKER_ITEM("TextSize"),
-                  IntSliderOptions().Min(1).Max(30).DefaultValue(13).Color(THEME_COLOR));
 
-    ImGui::NewLine();
-    CVarCombobox("Ammo/Capacity Tracking", CVAR_TRACKER_ITEM("ItemCountType"), itemTrackerCapacityTrackOptions,
-                 ComboboxOptions()
-                     .DefaultIndex(ITEM_TRACKER_NUMBER_CURRENT_CAPACITY_ONLY)
-                     .ComponentAlignment(ComponentAlignments::Left)
-                     .LabelPosition(LabelPositions::Above)
-                     .Color(THEME_COLOR)
-                     .Tooltip("Customize what the numbers under each item are tracking."
-                              "\n\nNote: items without capacity upgrades will track ammo even in capacity mode"));
-    if (CVarGetInteger(CVAR_TRACKER_ITEM("ItemCountType"), ITEM_TRACKER_NUMBER_CURRENT_CAPACITY_ONLY) ==
-            ITEM_TRACKER_NUMBER_CURRENT_CAPACITY_ONLY ||
-        CVarGetInteger(CVAR_TRACKER_ITEM("ItemCountType"), ITEM_TRACKER_NUMBER_CURRENT_CAPACITY_ONLY) ==
-            ITEM_TRACKER_NUMBER_CURRENT_AMMO_ONLY) {
-        if (CVarCheckbox("Align count to left side", CVAR_TRACKER_ITEM("ItemCountAlignLeft"),
-                         CheckboxOptions().Color(THEME_COLOR))) {
+        CVarCombobox("Key Count Tracking", CVAR_TRACKER_ITEM("KeyCounts"), itemTrackerKeyTrackOptions,
+                     ComboboxOptions()
+                         .DefaultIndex(KEYS_COLLECTED_MAX)
+                         .ComponentAlignment(ComponentAlignments::Left)
+                         .LabelPosition(LabelPositions::Above)
+                         .Color(THEME_COLOR)
+                         .Tooltip("Customize what numbers are shown for key tracking."));
+
+        CVarCombobox("Triforce Piece Count Tracking", CVAR_TRACKER_ITEM("TriforcePieceCounts"),
+                     itemTrackerTriforcePieceTrackOptions,
+                     ComboboxOptions()
+                         .DefaultIndex(TRIFORCE_PIECE_COLLECTED_REQUIRED_MAX)
+                         .ComponentAlignment(ComponentAlignments::Left)
+                         .LabelPosition(LabelPositions::Above)
+                         .Color(THEME_COLOR)
+                         .Tooltip("Customize what numbers are shown for triforce piece tracking."));
+
+        ImGui::TableNextColumn();
+
+        if (CVarCombobox("Inventory", CVAR_TRACKER_ITEM("DisplayType.Inventory"), displayTypes,
+                         ComboboxOptions()
+                             .DefaultIndex(SECTION_DISPLAY_MAIN_WINDOW)
+                             .ComponentAlignment(ComponentAlignments::Right)
+                             .LabelPosition(LabelPositions::Far)
+                             .Color(THEME_COLOR))) {
             shouldUpdateVectors = true;
         }
-    }
-
-    CVarCombobox("Key Count Tracking", CVAR_TRACKER_ITEM("KeyCounts"), itemTrackerKeyTrackOptions,
-                 ComboboxOptions()
-                     .DefaultIndex(KEYS_COLLECTED_MAX)
-                     .ComponentAlignment(ComponentAlignments::Left)
-                     .LabelPosition(LabelPositions::Above)
-                     .Color(THEME_COLOR)
-                     .Tooltip("Customize what numbers are shown for key tracking."));
-
-    CVarCombobox("Triforce Piece Count Tracking", CVAR_TRACKER_ITEM("TriforcePieceCounts"),
-                 itemTrackerTriforcePieceTrackOptions,
-                 ComboboxOptions()
-                     .DefaultIndex(TRIFORCE_PIECE_COLLECTED_REQUIRED_MAX)
-                     .ComponentAlignment(ComponentAlignments::Left)
-                     .LabelPosition(LabelPositions::Above)
-                     .Color(THEME_COLOR)
-                     .Tooltip("Customize what numbers are shown for triforce piece tracking."));
-
-    ImGui::TableNextColumn();
-
-    if (CVarCombobox("Inventory", CVAR_TRACKER_ITEM("DisplayType.Inventory"), displayTypes,
-                     ComboboxOptions()
-                         .DefaultIndex(SECTION_DISPLAY_MAIN_WINDOW)
-                         .ComponentAlignment(ComponentAlignments::Right)
-                         .LabelPosition(LabelPositions::Far)
-                         .Color(THEME_COLOR))) {
-        shouldUpdateVectors = true;
-    }
-    if (CVarCombobox("Equipment", CVAR_TRACKER_ITEM("DisplayType.Equipment"), displayTypes,
-                     ComboboxOptions()
-                         .DefaultIndex(SECTION_DISPLAY_MAIN_WINDOW)
-                         .ComponentAlignment(ComponentAlignments::Right)
-                         .LabelPosition(LabelPositions::Far)
-                         .Color(THEME_COLOR))) {
-        shouldUpdateVectors = true;
-    }
-    if (CVarCombobox("Misc", CVAR_TRACKER_ITEM("DisplayType.Misc"), displayTypes,
-                     ComboboxOptions()
-                         .DefaultIndex(SECTION_DISPLAY_MAIN_WINDOW)
-                         .ComponentAlignment(ComponentAlignments::Right)
-                         .LabelPosition(LabelPositions::Far)
-                         .Color(THEME_COLOR))) {
-        shouldUpdateVectors = true;
-    }
-    if (CVarCombobox("Dungeon Rewards", CVAR_TRACKER_ITEM("DisplayType.DungeonRewards"), displayTypes,
-                     ComboboxOptions()
-                         .DefaultIndex(SECTION_DISPLAY_MAIN_WINDOW)
-                         .ComponentAlignment(ComponentAlignments::Right)
-                         .LabelPosition(LabelPositions::Far)
-                         .Color(THEME_COLOR))) {
-        shouldUpdateVectors = true;
-    }
-    if (CVarGetInteger(CVAR_TRACKER_ITEM("DisplayType.DungeonRewards"), SECTION_DISPLAY_MAIN_WINDOW) ==
-        SECTION_DISPLAY_SEPARATE) {
-        if (CVarCheckbox("Circle display", CVAR_TRACKER_ITEM("DungeonRewardsLayout"),
-                         CheckboxOptions().DefaultValue(false).Color(THEME_COLOR))) {
+        if (CVarCombobox("Equipment", CVAR_TRACKER_ITEM("DisplayType.Equipment"), displayTypes,
+                         ComboboxOptions()
+                             .DefaultIndex(SECTION_DISPLAY_MAIN_WINDOW)
+                             .ComponentAlignment(ComponentAlignments::Right)
+                             .LabelPosition(LabelPositions::Far)
+                             .Color(THEME_COLOR))) {
             shouldUpdateVectors = true;
         }
-    }
-    if (CVarCombobox("Songs", CVAR_TRACKER_ITEM("DisplayType.Songs"), displayTypes,
-                     ComboboxOptions()
-                         .DefaultIndex(SECTION_DISPLAY_MAIN_WINDOW)
-                         .ComponentAlignment(ComponentAlignments::Right)
-                         .LabelPosition(LabelPositions::Far)
-                         .Color(THEME_COLOR))) {
-        shouldUpdateVectors = true;
-    }
-    if (CVarCombobox("Dungeon Items", CVAR_TRACKER_ITEM("DisplayType.DungeonItems"), displayTypes,
-                     ComboboxOptions()
-                         .DefaultIndex(SECTION_DISPLAY_HIDDEN)
-                         .ComponentAlignment(ComponentAlignments::Right)
-                         .LabelPosition(LabelPositions::Far)
-                         .Color(THEME_COLOR))) {
-        shouldUpdateVectors = true;
-    }
-    if (CVarGetInteger(CVAR_TRACKER_ITEM("DisplayType.DungeonItems"), SECTION_DISPLAY_HIDDEN) !=
-        SECTION_DISPLAY_HIDDEN) {
-        if (CVarGetInteger(CVAR_TRACKER_ITEM("DisplayType.DungeonItems"), SECTION_DISPLAY_HIDDEN) ==
+        if (CVarCombobox("Misc", CVAR_TRACKER_ITEM("DisplayType.Misc"), displayTypes,
+                         ComboboxOptions()
+                             .DefaultIndex(SECTION_DISPLAY_MAIN_WINDOW)
+                             .ComponentAlignment(ComponentAlignments::Right)
+                             .LabelPosition(LabelPositions::Far)
+                             .Color(THEME_COLOR))) {
+            shouldUpdateVectors = true;
+        }
+        if (CVarCombobox("Dungeon Rewards", CVAR_TRACKER_ITEM("DisplayType.DungeonRewards"), displayTypes,
+                         ComboboxOptions()
+                             .DefaultIndex(SECTION_DISPLAY_MAIN_WINDOW)
+                             .ComponentAlignment(ComponentAlignments::Right)
+                             .LabelPosition(LabelPositions::Far)
+                             .Color(THEME_COLOR))) {
+            shouldUpdateVectors = true;
+        }
+        if (CVarGetInteger(CVAR_TRACKER_ITEM("DisplayType.DungeonRewards"), SECTION_DISPLAY_MAIN_WINDOW) ==
             SECTION_DISPLAY_SEPARATE) {
-            if (CVarCheckbox("Horizontal display", CVAR_TRACKER_ITEM("DungeonItems.Layout"),
-                             CheckboxOptions().DefaultValue(true).Color(THEME_COLOR))) {
+            if (CVarCheckbox("Circle display", CVAR_TRACKER_ITEM("DungeonRewardsLayout"),
+                             CheckboxOptions().DefaultValue(false).Color(THEME_COLOR))) {
                 shouldUpdateVectors = true;
             }
         }
-        if (CVarCheckbox("Maps and compasses", CVAR_TRACKER_ITEM("DungeonItems.DisplayMaps"),
-                         CheckboxOptions().DefaultValue(true).Color(THEME_COLOR))) {
+        if (CVarCombobox("Songs", CVAR_TRACKER_ITEM("DisplayType.Songs"), displayTypes,
+                         ComboboxOptions()
+                             .DefaultIndex(SECTION_DISPLAY_MAIN_WINDOW)
+                             .ComponentAlignment(ComponentAlignments::Right)
+                             .LabelPosition(LabelPositions::Far)
+                             .Color(THEME_COLOR))) {
             shouldUpdateVectors = true;
         }
-    }
-    if (CVarCombobox("Greg", CVAR_TRACKER_ITEM("DisplayType.Greg"), extendedDisplayTypes,
-                     ComboboxOptions()
-                         .DefaultIndex(SECTION_DISPLAY_EXTENDED_HIDDEN)
-                         .ComponentAlignment(ComponentAlignments::Right)
-                         .LabelPosition(LabelPositions::Far)
-                         .Color(THEME_COLOR))) {
-        shouldUpdateVectors = true;
-    }
-
-    if (CVarCombobox("Triforce Pieces", CVAR_TRACKER_ITEM("DisplayType.TriforcePieces"), displayTypes,
-                     ComboboxOptions()
-                         .DefaultIndex(SECTION_DISPLAY_HIDDEN)
-                         .ComponentAlignment(ComponentAlignments::Right)
-                         .LabelPosition(LabelPositions::Far)
-                         .Color(THEME_COLOR))) {
-        shouldUpdateVectors = true;
-    }
-
-    if (CVarCombobox("Boss Souls", CVAR_TRACKER_ITEM("DisplayType.BossSouls"), displayTypes,
-                     ComboboxOptions()
-                         .DefaultIndex(SECTION_DISPLAY_HIDDEN)
-                         .ComponentAlignment(ComponentAlignments::Right)
-                         .LabelPosition(LabelPositions::Far)
-                         .Color(THEME_COLOR))) {
-        shouldUpdateVectors = true;
-    }
-
-    if (CVarCombobox("Ocarina Buttons", CVAR_TRACKER_ITEM("DisplayType.OcarinaButtons"), displayTypes,
-                     ComboboxOptions()
-                         .DefaultIndex(SECTION_DISPLAY_HIDDEN)
-                         .ComponentAlignment(ComponentAlignments::Right)
-                         .LabelPosition(LabelPositions::Far)
-                         .Color(THEME_COLOR))) {
-        shouldUpdateVectors = true;
-    }
-
-    if (CVarCombobox("Overworld Keys", CVAR_TRACKER_ITEM("DisplayType.OverworldKeys"), displayTypes,
-                     ComboboxOptions()
-                         .DefaultIndex(SECTION_DISPLAY_HIDDEN)
-                         .ComponentAlignment(ComponentAlignments::Right)
-                         .LabelPosition(LabelPositions::Far)
-                         .Color(THEME_COLOR))) {
-        shouldUpdateVectors = true;
-    }
-
-    if (CVarCombobox("Fishing Pole", CVAR_TRACKER_ITEM("DisplayType.FishingPole"), extendedDisplayTypes,
-                     ComboboxOptions()
-                         .DefaultIndex(SECTION_DISPLAY_EXTENDED_HIDDEN)
-                         .ComponentAlignment(ComponentAlignments::Right)
-                         .LabelPosition(LabelPositions::Far)
-                         .Color(THEME_COLOR))) {
-        shouldUpdateVectors = true;
-    }
-
-    if (CVarCombobox("Total Checks", "gTrackers.ItemTracker.TotalChecks.DisplayType", minimalDisplayTypes,
-                     ComboboxOptions()
-                         .DefaultIndex(SECTION_DISPLAY_MINIMAL_HIDDEN)
-                         .ComponentAlignment(ComponentAlignments::Right)
-                         .LabelPosition(LabelPositions::Far)
-                         .Color(THEME_COLOR))) {
-        shouldUpdateVectors = true;
-    }
-
-    if (CVarGetInteger(CVAR_TRACKER_ITEM("WindowType"), TRACKER_WINDOW_FLOATING) == TRACKER_WINDOW_WINDOW ||
-        (CVarGetInteger(CVAR_TRACKER_ITEM("WindowType"), TRACKER_WINDOW_FLOATING) == TRACKER_WINDOW_FLOATING &&
-         CVarGetInteger(CVAR_TRACKER_ITEM("DisplayType.Main"), TRACKER_DISPLAY_ALWAYS) !=
-             TRACKER_DISPLAY_COMBO_BUTTON)) {
-        if (CVarCombobox("Personal notes", CVAR_TRACKER_ITEM("DisplayType.Notes"), displayTypes,
+        if (CVarCombobox("Dungeon Items", CVAR_TRACKER_ITEM("DisplayType.DungeonItems"), displayTypes,
                          ComboboxOptions()
                              .DefaultIndex(SECTION_DISPLAY_HIDDEN)
                              .ComponentAlignment(ComponentAlignments::Right)
@@ -1959,14 +1870,104 @@ void ItemTrackerSettingsWindow::DrawElement() {
                              .Color(THEME_COLOR))) {
             shouldUpdateVectors = true;
         }
-    }
-    CVarCheckbox("Show Hookshot Identifiers", CVAR_TRACKER_ITEM("HookshotIdentifier"),
-                 CheckboxOptions()
-                     .Tooltip("Shows an 'H' or an 'L' to more easiely distinguish between Hookshot and Longshot.")
-                     .Color(THEME_COLOR));
+        if (CVarGetInteger(CVAR_TRACKER_ITEM("DisplayType.DungeonItems"), SECTION_DISPLAY_HIDDEN) !=
+            SECTION_DISPLAY_HIDDEN) {
+            if (CVarGetInteger(CVAR_TRACKER_ITEM("DisplayType.DungeonItems"), SECTION_DISPLAY_HIDDEN) ==
+                SECTION_DISPLAY_SEPARATE) {
+                if (CVarCheckbox("Horizontal display", CVAR_TRACKER_ITEM("DungeonItems.Layout"),
+                                 CheckboxOptions().DefaultValue(true).Color(THEME_COLOR))) {
+                    shouldUpdateVectors = true;
+                }
+            }
+            if (CVarCheckbox("Maps and compasses", CVAR_TRACKER_ITEM("DungeonItems.DisplayMaps"),
+                             CheckboxOptions().DefaultValue(true).Color(THEME_COLOR))) {
+                shouldUpdateVectors = true;
+            }
+        }
+        if (CVarCombobox("Greg", CVAR_TRACKER_ITEM("DisplayType.Greg"), extendedDisplayTypes,
+                         ComboboxOptions()
+                             .DefaultIndex(SECTION_DISPLAY_EXTENDED_HIDDEN)
+                             .ComponentAlignment(ComponentAlignments::Right)
+                             .LabelPosition(LabelPositions::Far)
+                             .Color(THEME_COLOR))) {
+            shouldUpdateVectors = true;
+        }
 
-    ImGui::PopStyleVar(1);
-    ImGui::EndTable();
+        if (CVarCombobox("Triforce Pieces", CVAR_TRACKER_ITEM("DisplayType.TriforcePieces"), displayTypes,
+                         ComboboxOptions()
+                             .DefaultIndex(SECTION_DISPLAY_HIDDEN)
+                             .ComponentAlignment(ComponentAlignments::Right)
+                             .LabelPosition(LabelPositions::Far)
+                             .Color(THEME_COLOR))) {
+            shouldUpdateVectors = true;
+        }
+
+        if (CVarCombobox("Boss Souls", CVAR_TRACKER_ITEM("DisplayType.BossSouls"), displayTypes,
+                         ComboboxOptions()
+                             .DefaultIndex(SECTION_DISPLAY_HIDDEN)
+                             .ComponentAlignment(ComponentAlignments::Right)
+                             .LabelPosition(LabelPositions::Far)
+                             .Color(THEME_COLOR))) {
+            shouldUpdateVectors = true;
+        }
+
+        if (CVarCombobox("Ocarina Buttons", CVAR_TRACKER_ITEM("DisplayType.OcarinaButtons"), displayTypes,
+                         ComboboxOptions()
+                             .DefaultIndex(SECTION_DISPLAY_HIDDEN)
+                             .ComponentAlignment(ComponentAlignments::Right)
+                             .LabelPosition(LabelPositions::Far)
+                             .Color(THEME_COLOR))) {
+            shouldUpdateVectors = true;
+        }
+
+        if (CVarCombobox("Overworld Keys", CVAR_TRACKER_ITEM("DisplayType.OverworldKeys"), displayTypes,
+                         ComboboxOptions()
+                             .DefaultIndex(SECTION_DISPLAY_HIDDEN)
+                             .ComponentAlignment(ComponentAlignments::Right)
+                             .LabelPosition(LabelPositions::Far)
+                             .Color(THEME_COLOR))) {
+            shouldUpdateVectors = true;
+        }
+
+        if (CVarCombobox("Fishing Pole", CVAR_TRACKER_ITEM("DisplayType.FishingPole"), extendedDisplayTypes,
+                         ComboboxOptions()
+                             .DefaultIndex(SECTION_DISPLAY_EXTENDED_HIDDEN)
+                             .ComponentAlignment(ComponentAlignments::Right)
+                             .LabelPosition(LabelPositions::Far)
+                             .Color(THEME_COLOR))) {
+            shouldUpdateVectors = true;
+        }
+
+        if (CVarCombobox("Total Checks", "gTrackers.ItemTracker.TotalChecks.DisplayType", minimalDisplayTypes,
+                         ComboboxOptions()
+                             .DefaultIndex(SECTION_DISPLAY_MINIMAL_HIDDEN)
+                             .ComponentAlignment(ComponentAlignments::Right)
+                             .LabelPosition(LabelPositions::Far)
+                             .Color(THEME_COLOR))) {
+            shouldUpdateVectors = true;
+        }
+
+        if (CVarGetInteger(CVAR_TRACKER_ITEM("WindowType"), TRACKER_WINDOW_FLOATING) == TRACKER_WINDOW_WINDOW ||
+            (CVarGetInteger(CVAR_TRACKER_ITEM("WindowType"), TRACKER_WINDOW_FLOATING) == TRACKER_WINDOW_FLOATING &&
+             CVarGetInteger(CVAR_TRACKER_ITEM("DisplayType.Main"), TRACKER_DISPLAY_ALWAYS) !=
+                 TRACKER_DISPLAY_COMBO_BUTTON)) {
+            if (CVarCombobox("Personal notes", CVAR_TRACKER_ITEM("DisplayType.Notes"), displayTypes,
+                             ComboboxOptions()
+                                 .DefaultIndex(SECTION_DISPLAY_HIDDEN)
+                                 .ComponentAlignment(ComponentAlignments::Right)
+                                 .LabelPosition(LabelPositions::Far)
+                                 .Color(THEME_COLOR))) {
+                shouldUpdateVectors = true;
+            }
+        }
+        CVarCheckbox("Show Hookshot Identifiers", CVAR_TRACKER_ITEM("HookshotIdentifier"),
+                     CheckboxOptions()
+                         .Tooltip("Shows an 'H' or an 'L' to more easiely distinguish between Hookshot and Longshot.")
+                         .Color(THEME_COLOR));
+
+        ImGui::PopStyleVar(1);
+        ImGui::EndTable();
+    }
 }
 
 void ItemTrackerWindow::InitElement() {


### PR DESCRIPTION
Fixes a crash when item or check tracker sections were open in the menu when the window was too small for the tables in them to be displayed.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3931115355.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3931317452.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3931322157.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/3931336242.zip)
<!--- section:artifacts:end -->