### PR TITLE
[Bug Fix] Fixes the shaking of Beehives when they are randomized

### DIFF
--- a/soh/soh/Enhancements/randomizer/ShuffleBeehives.cpp
+++ b/soh/soh/Enhancements/randomizer/ShuffleBeehives.cpp
@@ -43,7 +43,7 @@ void ObjComb_RandomizerWait(ObjComb* objComb, PlayState* play) {
     objComb->unk_1B0 -= 50;
 
     const auto beehiveIdentity = ObjectExtension::GetInstance().Get<BeehiveIdentity>(&objComb->actor);
-    if (RAND_GET_OPTION(RSK_SHUFFLE_BEEHIVES) && beehiveIdentity == nullptr &&
+    if (RAND_GET_OPTION(RSK_SHUFFLE_BEEHIVES) && beehiveIdentity != nullptr &&
         !Flags_GetRandomizerInf(beehiveIdentity->randomizerInf)) {
         if (objComb->unk_1B0 <= -5000) {
             objComb->unk_1B0 = 1500;
@@ -82,9 +82,11 @@ void ObjComb_RandomizerInit(void* actor) {
 
 void ObjComb_RandomizerUpdate(void* actor) {
     ObjComb* combActor = reinterpret_cast<ObjComb*>(actor);
+    PlayState* play = gPlayState;
+    combActor->unk_1B2 += 0x2EE0;
+    combActor->actionFunc(combActor, play);
     combActor->actor.shape.rot.x =
-        static_cast<int16_t>(Math_SinS(combActor->unk_1B2)) * CLAMP_MIN(combActor->unk_1B0, 0) +
-        combActor->actor.home.rot.x;
+        Math_SinS(combActor->unk_1B2) * CLAMP_MIN(combActor->unk_1B0, 0) + combActor->actor.home.rot.x;
 }
 
 void RegisterShuffleBeehives() {


### PR DESCRIPTION
During the move from hook_handlers to ShuffleBeehives.cpp, the shaking functionality whenever a check was not collect yet, or when shot with a weapon that could not break the beehive was broken and the beehive would always remain static. This fixes that by changing a nullptr check to != instead of == and by adding back some missing parts of the update function from the vanilla beehive update function, so that it reacts like it does normally and by removing the static_cast, which was making the whole thing read as 0, erroneously. 

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4019894000.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4019904727.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4019915448.zip)
<!--- section:artifacts:end -->