### PR TITLE
Cheat: Disable Sandstorm

### DIFF
--- a/soh/soh/Enhancements/DisableSandstorm.cpp
+++ b/soh/soh/Enhancements/DisableSandstorm.cpp
@@ -1,7 +1,7 @@
 #include "soh/Enhancements/game-interactor/GameInteractor.h"
 #include "soh/ShipInit.hpp"
 
-extern PlayState* gPlayState;
+extern "C" PlayState* gPlayState;
 
 void DisableSandstormAfterTransition(int16_t sceneNum) {
     if (sceneNum == SCENE_HAUNTED_WASTELAND) {

--- a/soh/soh/Enhancements/DisableSandstorm.cpp
+++ b/soh/soh/Enhancements/DisableSandstorm.cpp
@@ -1,0 +1,16 @@
+#include "soh/Enhancements/game-interactor/GameInteractor.h"
+#include "soh/ShipInit.hpp"
+
+extern PlayState* gPlayState;
+
+void DisableSandstormAfterTransition(int16_t sceneNum) {
+    if (sceneNum == SCENE_HAUNTED_WASTELAND) {
+        gPlayState->envCtx.sandstormState = SANDSTORM_OFF;
+    }
+}
+
+void RegisterDisableSandstorm() {
+    COND_HOOK(OnTransitionEnd, CVarGetInteger(CVAR_CHEAT("DisableSandstorm"), 0), DisableSandstormAfterTransition);
+}
+
+static RegisterShipInitFunc initFunc(RegisterDisableSandstorm, { CVAR_CHEAT("DisableSandstorm") });

--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -1741,6 +1741,9 @@ void SohMenu::AddMenuEnhancements() {
         .Options(CheckboxOptions().Tooltip(
             "Keese and Guay no longer target you and simply ignore you as if you were wearing the "
             "Skull Mask."));
+    AddWidget(path, "Disable Haunted Wasteland Sandstorm", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_CHEAT("DisableSandstorm"))
+        .Options(CheckboxOptions().Tooltip("Disables sandstorm effect in Haunted Wasteland."));
 
     AddWidget(path, "Glitch Aids", WIDGET_SEPARATOR_TEXT);
     AddWidget(path, "Easy Frame Advancing with Pause", WIDGET_CVAR_CHECKBOX)


### PR DESCRIPTION
Can also be considered an a11y feature,
tho it'll always be hard with the muted colors,
even if we added option to reduce fog

(surely I don't just want this while trying to see crate at night while doing Lensless Wasteland..)

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4037998590.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4038013486.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4038060260.zip)
<!--- section:artifacts:end -->