### PR TITLE
rando: remove vanilla

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/fill.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/fill.cpp
@@ -973,8 +973,7 @@ static void RandomizeDungeonRewards() {
             return Rando::StaticData::RetrieveItem(i).GetItemType() == ITEMTYPE_DUNGEONREWARD;
         });
 
-        if (ctx->GetOption(RSK_LOGIC_RULES).Is(RO_LOGIC_VANILLA) ||
-            ctx->GetOption(RSK_SHUFFLE_DUNGEON_REWARDS)
+        if (ctx->GetOption(RSK_SHUFFLE_DUNGEON_REWARDS)
                 .Is(RO_DUNGEON_REWARDS_VANILLA)) { // Place dungeon rewards in vanilla locations
             for (RandomizerCheck loc : Rando::StaticData::dungeonRewardLocations) {
                 ctx->GetItemLocation(loc)->PlaceVanillaItem();

--- a/soh/soh/Enhancements/randomizer/3drando/playthrough.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/playthrough.cpp
@@ -65,13 +65,9 @@ int Playthrough_Init(uint32_t seed, std::set<RandomizerCheck> excludedLocations,
     Random_Init(finalHash);
     ctx->SetHash(std::to_string(finalHash));
 
-    if (ctx->GetOption(RSK_LOGIC_RULES).Is(RO_LOGIC_VANILLA)) {
-        VanillaFill(); // Just place items in their vanilla locations
-    } else {           // Fill locations with logic
-        int ret = Fill();
-        if (ret < 0) {
-            return ret;
-        }
+    int ret = Fill();
+    if (ret < 0) {
+        return ret;
     }
 
     GenerateHash();

--- a/soh/soh/Enhancements/randomizer/context.cpp
+++ b/soh/soh/Enhancements/randomizer/context.cpp
@@ -124,8 +124,7 @@ void Context::PlaceItemInLocation(const RandomizerCheck locKey, const Randomizer
     SPDLOG_DEBUG(StaticData::RetrieveItem(item).GetName().GetEnglish() + " placed at " +
                  StaticData::GetLocation(locKey)->GetName() + "\n");
 
-    if (applyEffectImmediately || mOptions[RSK_LOGIC_RULES].Is(RO_LOGIC_GLITCHLESS) ||
-        mOptions[RSK_LOGIC_RULES].Is(RO_LOGIC_VANILLA)) {
+    if (applyEffectImmediately || mOptions[RSK_LOGIC_RULES].Is(RO_LOGIC_GLITCHLESS)) {
         StaticData::RetrieveItem(item).ApplyEffect();
     }
 

--- a/soh/soh/Enhancements/randomizer/option_descriptions.cpp
+++ b/soh/soh/Enhancements/randomizer/option_descriptions.cpp
@@ -747,11 +747,7 @@ void Settings::CreateOptionDescriptions() {
         "Glitchless - No glitches are required, but may require some minor tricks. Additional tricks may be enabled "
         "and disabled below.\n"
         "\n"
-        //"Glitched - Glitches may be required to beat the game. You can disable and enable glitches below.\n"
-        //"\n"
-        "No logic - Item placement is completely random. MAY BE IMPOSSIBLE TO BEAT.\n"
-        "\n"
-        "Vanilla - Places all items and dungeon rewards in their vanilla locations.";
+        "No logic - Item placement is completely random. MAY BE IMPOSSIBLE TO BEAT.";
     mOptionDescriptions[RSK_ALL_LOCATIONS_REACHABLE] = "When this options is enabled, the randomizer will "
                                                        "guarantee that every item is obtainable and every "
                                                        "location is reachable. When disabled, only "

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -3899,32 +3899,24 @@ void RandomizerSettingsWindow::DrawElement() {
 
         if (ImGui::BeginTabItem("Items")) {
             ImGui::PushStyleVar(ImGuiStyleVar_CellPadding, cellPadding);
-            ImGui::BeginDisabled(CVarGetInteger(CVAR_RANDOMIZER_SETTING("LogicRules"), RO_LOGIC_GLITCHLESS) ==
-                                 RO_LOGIC_VANILLA);
             if (mSettings->GetOptionGroup(RSG_ITEMS_IMGUI_TABLE).RenderImGui()) {
                 mNeedsUpdate = true;
             }
-            ImGui::EndDisabled();
             ImGui::PopStyleVar(1);
             ImGui::EndTabItem();
         }
 
         if (ImGui::BeginTabItem("Gameplay")) {
-            ImGui::BeginDisabled(CVarGetInteger(CVAR_RANDOMIZER_SETTING("LogicRules"), RO_LOGIC_GLITCHLESS) ==
-                                 RO_LOGIC_VANILLA);
             ImGui::PushStyleVar(ImGuiStyleVar_CellPadding, cellPadding);
             if (mSettings->GetOptionGroup(RSG_GAMEPLAY_IMGUI_TABLE).RenderImGui()) {
                 mNeedsUpdate = true;
             }
-            ImGui::EndDisabled();
             ImGui::PopStyleVar(1);
             ImGui::EndTabItem();
         }
 
         if (ImGui::BeginTabItem("Locations")) {
-            ImGui::BeginDisabled(CVarGetInteger(CVAR_SETTING("DisableChanges"), 0) || disableEditingRandoSettings ||
-                                 CVarGetInteger(CVAR_RANDOMIZER_SETTING("LogicRules"), RO_LOGIC_GLITCHLESS) ==
-                                     RO_LOGIC_VANILLA);
+            ImGui::BeginDisabled(CVarGetInteger(CVAR_SETTING("DisableChanges"), 0) || disableEditingRandoSettings);
             ImGui::PushStyleVar(ImGuiStyleVar_CellPadding, cellPadding);
             if (!locationsTabOpen) {
                 locationsTabOpen = true;
@@ -4098,19 +4090,11 @@ void RandomizerSettingsWindow::DrawElement() {
                         mNeedsUpdate = true;
                     }
                 }
-                if (CVarGetInteger(CVAR_RANDOMIZER_SETTING("LogicRules"), RO_LOGIC_GLITCHLESS) == RO_LOGIC_VANILLA) {
-                    ImGui::SameLine();
-                    ImGui::TextColored(
-                        ImVec4(1.0f, 0.0f, 0.0f, 1.0f),
-                        "Heads up! This will disable all rando settings except for entrance shuffle and starter items");
-                }
                 ImGui::PopItemWidth();
                 ImGui::EndTable();
             }
 
-            ImGui::BeginDisabled(CVarGetInteger(CVAR_SETTING("DisableChanges"), 0) || disableEditingRandoSettings ||
-                                 CVarGetInteger(CVAR_RANDOMIZER_SETTING("LogicRules"), RO_LOGIC_GLITCHLESS) ==
-                                     RO_LOGIC_VANILLA);
+            ImGui::BeginDisabled(CVarGetInteger(CVAR_SETTING("DisableChanges"), 0) || disableEditingRandoSettings);
 
             // Tricks
             static std::unordered_map<RandomizerArea, bool> areaTreeDisabled{

--- a/soh/soh/Enhancements/randomizer/randomizerTypes.h
+++ b/soh/soh/Enhancements/randomizer/randomizerTypes.h
@@ -6324,7 +6324,6 @@ typedef enum {
 typedef enum {
     RO_LOGIC_GLITCHLESS,
     RO_LOGIC_NO_LOGIC,
-    RO_LOGIC_VANILLA,
 } RandoOptionLogic;
 
 // Damage Multiplier

--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -1513,7 +1513,7 @@ bool IsCheckShuffled(RandomizerCheck rc) {
     if (loc->GetRCType() == RCTYPE_SHOP) {
         auto identity = OTRGlobals::Instance->gRandomizer->IdentifyShopItem(loc->GetScene(), loc->GetActorParams() + 1);
     }
-    if (IS_RANDO && OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_LOGIC_RULES) != RO_LOGIC_VANILLA) {
+    if (IS_RANDO) {
         return (loc->GetArea() != RCAREA_INVALID) &&        // don't show Invalid locations
                (loc->GetRCType() != RCTYPE_GOSSIP_STONE) && // TODO: Don't show hints until tracker supports them
                (loc->GetRCType() != RCTYPE_STATIC_HINT) &&  // TODO: Don't show hints until tracker supports them

--- a/soh/soh/Enhancements/randomizer/settings.cpp
+++ b/soh/soh/Enhancements/randomizer/settings.cpp
@@ -330,7 +330,7 @@ void Settings::CreateOptions() {
     OPT_U8(RSK_STARTING_SKULLTULA_TOKEN, "Gold Skulltula Tokens", {NumOpts(0, 100)}, OptionCategory::Setting, CVAR_RANDOMIZER_SETTING("StartingSkulltulaToken"), "", WidgetType::Slider);
     OPT_U8(RSK_STARTING_HEARTS, "Starting Hearts", {NumOpts(1, 20)}, OptionCategory::Setting, CVAR_RANDOMIZER_SETTING("StartingHearts"), "", WidgetType::Slider, 2);
     // TODO: Remainder of Starting Items
-    OPT_U8(RSK_LOGIC_RULES, "Logic", {"Glitchless", "No Logic", "Vanilla"}, OptionCategory::Setting, CVAR_RANDOMIZER_SETTING("LogicRules"), mOptionDescriptions[RSK_LOGIC_RULES], WidgetType::Combobox, RO_LOGIC_GLITCHLESS);
+    OPT_U8(RSK_LOGIC_RULES, "Logic", {"Glitchless", "No Logic"}, OptionCategory::Setting, CVAR_RANDOMIZER_SETTING("LogicRules"), mOptionDescriptions[RSK_LOGIC_RULES], WidgetType::Combobox, RO_LOGIC_GLITCHLESS);
     OPT_BOOL(RSK_ALL_LOCATIONS_REACHABLE, "All Locations Reachable", {"Off", "On"}, OptionCategory::Setting, CVAR_RANDOMIZER_SETTING("AllLocationsReachable"), mOptionDescriptions[RSK_ALL_LOCATIONS_REACHABLE], WidgetType::Checkbox, RO_GENERIC_ON);
     OPT_BOOL(RSK_SKULLS_SUNS_SONG, "Night Skulltula's Expect Sun's Song", CVAR_RANDOMIZER_SETTING("GsExpectSunsSong"), mOptionDescriptions[RSK_SKULLS_SUNS_SONG]);
     OPT_U8(RSK_DAMAGE_MULTIPLIER, "Damage Multiplier", {"x1/2", "x1", "x2", "x4", "x8", "x16", "OHKO"}, OptionCategory::Setting, "", "", WidgetType::Slider, RO_DAMAGE_MULTIPLIER_DEFAULT);
@@ -1828,158 +1828,134 @@ void Settings::UpdateOptionProperties() {
     mOptions[RSK_RAINBOW_BRIDGE_REWARD_COUNT].Hide();
     mOptions[RSK_RAINBOW_BRIDGE_DUNGEON_COUNT].Hide();
     mOptions[RSK_RAINBOW_BRIDGE_TOKEN_COUNT].Hide();
-    if (CVarGetInteger(CVAR_RANDOMIZER_SETTING("LogicRules"), RO_LOGIC_GLITCHLESS) == RO_LOGIC_VANILLA) {
-        mOptionGroups[RSG_AREA_ACCESS_IMGUI].Disable();
-        mOptions[RSK_STARTING_AGE].Disable("");
-        mOptions[RSK_GERUDO_FORTRESS].Disable("");
-        mOptions[RSK_RAINBOW_BRIDGE].Disable("");
-        mOptions[RSK_BRIDGE_OPTIONS].Disable("");
-        mOptions[RSK_RAINBOW_BRIDGE_STONE_COUNT].Disable("");
-        mOptions[RSK_RAINBOW_BRIDGE_MEDALLION_COUNT].Disable("");
-        mOptions[RSK_RAINBOW_BRIDGE_REWARD_COUNT].Disable("");
-        mOptions[RSK_RAINBOW_BRIDGE_DUNGEON_COUNT].Disable("");
-        mOptions[RSK_RAINBOW_BRIDGE_TOKEN_COUNT].Disable("");
-        mOptions[RSK_GANONS_TRIALS].Disable("");
-        mOptions[RSK_TRIAL_COUNT].Disable("");
-        mOptions[RSK_TRIFORCE_HUNT].Disable("");
-        mOptions[RSK_TRIFORCE_HUNT_PIECES_TOTAL].Disable("");
-        mOptions[RSK_TRIFORCE_HUNT_PIECES_REQUIRED].Disable("");
-        mOptionGroups[RSG_ITEMS_IMGUI_TABLE].Disable();
-        mOptionGroups[RSG_GAMEPLAY_IMGUI_TABLE].Disable();
-        mOptions[RSK_LINKS_POCKET].Disable("");
-        mOptions[RSK_STARTING_OCARINA].Disable("");
+    mOptionGroups[RSG_AREA_ACCESS_IMGUI].Enable();
+    // Starting Age - Disabled when Forest is set to Closed or under very specific conditions
+    if (CVarGetInteger(CVAR_RANDOMIZER_SETTING("DoorOfTime"), RO_DOOROFTIME_CLOSED) == RO_DOOROFTIME_CLOSED &&
+        CVarGetInteger(CVAR_RANDOMIZER_SETTING("ShuffleOcarinas"), RO_GENERIC_OFF) ==
+            RO_GENERIC_OFF) /* closed door of time with ocarina shuffle off */ {
+        mOptions[RSK_STARTING_AGE].Disable("This option is disabled due to other options making the game unbeatable.");
     } else {
-        mOptionGroups[RSG_AREA_ACCESS_IMGUI].Enable();
-        // Starting Age - Disabled when Forest is set to Closed or under very specific conditions
-        if (CVarGetInteger(CVAR_RANDOMIZER_SETTING("DoorOfTime"), RO_DOOROFTIME_CLOSED) == RO_DOOROFTIME_CLOSED &&
-            CVarGetInteger(CVAR_RANDOMIZER_SETTING("ShuffleOcarinas"), RO_GENERIC_OFF) ==
-                RO_GENERIC_OFF) /* closed door of time with ocarina shuffle off */ {
-            mOptions[RSK_STARTING_AGE].Disable(
-                "This option is disabled due to other options making the game unbeatable.");
-        } else {
-            mOptions[RSK_STARTING_AGE].Enable();
-        }
-        mOptions[RSK_GERUDO_FORTRESS].Enable();
-        mOptions[RSK_RAINBOW_BRIDGE].Enable();
-        mOptions[RSK_BRIDGE_OPTIONS].Enable();
-        mOptions[RSK_RAINBOW_BRIDGE_STONE_COUNT].Enable();
-        mOptions[RSK_RAINBOW_BRIDGE_MEDALLION_COUNT].Enable();
-        mOptions[RSK_RAINBOW_BRIDGE_REWARD_COUNT].Enable();
-        mOptions[RSK_RAINBOW_BRIDGE_DUNGEON_COUNT].Enable();
-        mOptions[RSK_RAINBOW_BRIDGE_TOKEN_COUNT].Enable();
-        const uint8_t bridgeOpt =
-            CVarGetInteger(CVAR_RANDOMIZER_SETTING("BridgeRewardOptions"), RO_BRIDGE_STANDARD_REWARD);
-        switch (CVarGetInteger(CVAR_RANDOMIZER_SETTING("RainbowBridge"), RO_BRIDGE_VANILLA)) {
-            case RO_BRIDGE_STONES:
-                // Show Bridge Options and Stone Count slider
-                mOptions[RSK_RAINBOW_BRIDGE].RemoveFlag(IMFLAG_SEPARATOR_BOTTOM);
-                mOptions[RSK_BRIDGE_OPTIONS].Unhide();
-                mOptions[RSK_RAINBOW_BRIDGE_STONE_COUNT].Unhide();
-                if (bridgeOpt == RO_BRIDGE_GREG_REWARD) {
-                    if (mOptions[RSK_RAINBOW_BRIDGE_STONE_COUNT].GetOptionCount() == 4) {
-                        mOptions[RSK_RAINBOW_BRIDGE_STONE_COUNT].ChangeOptions(NumOpts(0, 4));
-                    }
-                } else {
-                    if (mOptions[RSK_RAINBOW_BRIDGE_STONE_COUNT].GetOptionCount() == 5) {
-                        mOptions[RSK_RAINBOW_BRIDGE_STONE_COUNT].ChangeOptions(NumOpts(0, 3));
-                    }
-                }
-                break;
-            case RO_BRIDGE_MEDALLIONS:
-                // Show Bridge Options and Medallion Count Slider
-                mOptions[RSK_RAINBOW_BRIDGE].RemoveFlag(IMFLAG_SEPARATOR_BOTTOM);
-                mOptions[RSK_BRIDGE_OPTIONS].Unhide();
-                mOptions[RSK_RAINBOW_BRIDGE_MEDALLION_COUNT].Unhide();
-                if (bridgeOpt == RO_BRIDGE_GREG_REWARD) {
-                    if (mOptions[RSK_RAINBOW_BRIDGE_MEDALLION_COUNT].GetOptionCount() == 7) {
-                        mOptions[RSK_RAINBOW_BRIDGE_MEDALLION_COUNT].ChangeOptions(NumOpts(0, 7));
-                    }
-                } else {
-                    if (mOptions[RSK_RAINBOW_BRIDGE_MEDALLION_COUNT].GetOptionCount() == 8) {
-                        mOptions[RSK_RAINBOW_BRIDGE_MEDALLION_COUNT].ChangeOptions(NumOpts(0, 6));
-                    }
-                }
-                break;
-            case RO_BRIDGE_DUNGEON_REWARDS:
-                // Show Bridge Options and Dungeon Reward Count Slider
-                mOptions[RSK_RAINBOW_BRIDGE].RemoveFlag(IMFLAG_SEPARATOR_BOTTOM);
-                mOptions[RSK_BRIDGE_OPTIONS].Unhide();
-                mOptions[RSK_RAINBOW_BRIDGE_REWARD_COUNT].Unhide();
-                if (bridgeOpt == RO_BRIDGE_GREG_REWARD) {
-                    if (mOptions[RSK_RAINBOW_BRIDGE_REWARD_COUNT].GetOptionCount() == 10) {
-                        mOptions[RSK_RAINBOW_BRIDGE_REWARD_COUNT].ChangeOptions(NumOpts(0, 10));
-                    }
-                } else {
-                    if (mOptions[RSK_RAINBOW_BRIDGE_REWARD_COUNT].GetOptionCount() == 11) {
-                        mOptions[RSK_RAINBOW_BRIDGE_REWARD_COUNT].ChangeOptions(NumOpts(0, 9));
-                    }
-                }
-                break;
-            case RO_BRIDGE_DUNGEONS:
-                // Show Bridge Options and Dungeon Count Slider
-                mOptions[RSK_RAINBOW_BRIDGE].RemoveFlag(IMFLAG_SEPARATOR_BOTTOM);
-                mOptions[RSK_BRIDGE_OPTIONS].Unhide();
-                mOptions[RSK_RAINBOW_BRIDGE_DUNGEON_COUNT].Unhide();
-                if (bridgeOpt == RO_BRIDGE_GREG_REWARD) {
-                    if (mOptions[RSK_RAINBOW_BRIDGE_DUNGEON_COUNT].GetOptionCount() == 9) {
-                        mOptions[RSK_RAINBOW_BRIDGE_DUNGEON_COUNT].ChangeOptions(NumOpts(0, 9));
-                    }
-                } else {
-                    if (mOptions[RSK_RAINBOW_BRIDGE_DUNGEON_COUNT].GetOptionCount() == 10) {
-                        mOptions[RSK_RAINBOW_BRIDGE_DUNGEON_COUNT].ChangeOptions(NumOpts(0, 8));
-                    }
-                }
-                break;
-            case RO_BRIDGE_TOKENS:
-                // Show token count slider (not bridge options)
-                mOptions[RSK_RAINBOW_BRIDGE].RemoveFlag(IMFLAG_SEPARATOR_BOTTOM);
-                mOptions[RSK_BRIDGE_OPTIONS].Hide();
-                mOptions[RSK_RAINBOW_BRIDGE_TOKEN_COUNT].Unhide();
-                break;
-            default:
-                break;
-        }
-        mOptions[RSK_GANONS_TRIALS].Enable();
-        mOptions[RSK_TRIAL_COUNT].Enable();
-        // Only show the trial count slider if Trials is set to Set Number
-        if (CVarGetInteger(CVAR_RANDOMIZER_SETTING("GanonTrial"), RO_GANONS_TRIALS_SET_NUMBER) ==
-            RO_GANONS_TRIALS_SET_NUMBER) {
-            mOptions[RSK_GANONS_TRIALS].RemoveFlag(IMFLAG_SEPARATOR_BOTTOM);
-            mOptions[RSK_TRIAL_COUNT].Unhide();
-        } else {
-            mOptions[RSK_GANONS_TRIALS].AddFlag(IMFLAG_SEPARATOR_BOTTOM);
-            mOptions[RSK_TRIAL_COUNT].Hide();
-        }
-        mOptions[RSK_TRIFORCE_HUNT].Enable();
-        mOptions[RSK_TRIFORCE_HUNT_PIECES_TOTAL].Enable();
-        mOptions[RSK_TRIFORCE_HUNT_PIECES_REQUIRED].Enable();
-        // Remove the pieces required/total sliders and add a separator after Tirforce Hunt if Triforce Hunt is off
-        if (CVarGetInteger(CVAR_RANDOMIZER_SETTING("TriforceHunt"), RO_GENERIC_OFF) == RO_GENERIC_OFF) {
-            mOptions[RSK_TRIFORCE_HUNT_PIECES_REQUIRED].Hide();
-            mOptions[RSK_TRIFORCE_HUNT_PIECES_TOTAL].Hide();
-            mOptions[RSK_TRIFORCE_HUNT].AddFlag(IMFLAG_SEPARATOR_BOTTOM);
-        } else {
-            mOptions[RSK_TRIFORCE_HUNT_PIECES_REQUIRED].Unhide();
-            mOptions[RSK_TRIFORCE_HUNT_PIECES_TOTAL].Unhide();
-            mOptions[RSK_TRIFORCE_HUNT].RemoveFlag(IMFLAG_SEPARATOR_BOTTOM);
-        }
-        // Update triforce pieces required to be capped at the current value for pieces total.
-        const uint8_t triforceTotal = CVarGetInteger(CVAR_RANDOMIZER_SETTING("TriforceHuntTotalPieces"), 30);
-        if (mOptions[RSK_TRIFORCE_HUNT_PIECES_REQUIRED].GetOptionCount() != triforceTotal + 1) {
-            mOptions[RSK_TRIFORCE_HUNT_PIECES_REQUIRED].ChangeOptions(NumOpts(1, triforceTotal + 1));
-        }
-        mOptionGroups[RSG_ITEMS_IMGUI_TABLE].Enable();
-        mOptionGroups[RSG_GAMEPLAY_IMGUI_TABLE].Enable();
-        // Link's Pocket - Disabled when Dungeon Rewards are shuffled to End of Dungeon
-        if (CVarGetInteger(CVAR_RANDOMIZER_SETTING("ShuffleDungeonReward"), RO_DUNGEON_REWARDS_END_OF_DUNGEON) ==
-            RO_DUNGEON_REWARDS_END_OF_DUNGEON) {
-            mOptions[RSK_LINKS_POCKET].Disable(
-                "This option is disabled because \"Dungeon Rewards\" are shuffled to \"End of Dungeons\".");
-        } else {
-            mOptions[RSK_LINKS_POCKET].Enable();
-        }
-        mOptions[RSK_STARTING_OCARINA].Enable();
+        mOptions[RSK_STARTING_AGE].Enable();
     }
+    mOptions[RSK_GERUDO_FORTRESS].Enable();
+    mOptions[RSK_RAINBOW_BRIDGE].Enable();
+    mOptions[RSK_BRIDGE_OPTIONS].Enable();
+    mOptions[RSK_RAINBOW_BRIDGE_STONE_COUNT].Enable();
+    mOptions[RSK_RAINBOW_BRIDGE_MEDALLION_COUNT].Enable();
+    mOptions[RSK_RAINBOW_BRIDGE_REWARD_COUNT].Enable();
+    mOptions[RSK_RAINBOW_BRIDGE_DUNGEON_COUNT].Enable();
+    mOptions[RSK_RAINBOW_BRIDGE_TOKEN_COUNT].Enable();
+    const uint8_t bridgeOpt = CVarGetInteger(CVAR_RANDOMIZER_SETTING("BridgeRewardOptions"), RO_BRIDGE_STANDARD_REWARD);
+    switch (CVarGetInteger(CVAR_RANDOMIZER_SETTING("RainbowBridge"), RO_BRIDGE_VANILLA)) {
+        case RO_BRIDGE_STONES:
+            // Show Bridge Options and Stone Count slider
+            mOptions[RSK_RAINBOW_BRIDGE].RemoveFlag(IMFLAG_SEPARATOR_BOTTOM);
+            mOptions[RSK_BRIDGE_OPTIONS].Unhide();
+            mOptions[RSK_RAINBOW_BRIDGE_STONE_COUNT].Unhide();
+            if (bridgeOpt == RO_BRIDGE_GREG_REWARD) {
+                if (mOptions[RSK_RAINBOW_BRIDGE_STONE_COUNT].GetOptionCount() == 4) {
+                    mOptions[RSK_RAINBOW_BRIDGE_STONE_COUNT].ChangeOptions(NumOpts(0, 4));
+                }
+            } else {
+                if (mOptions[RSK_RAINBOW_BRIDGE_STONE_COUNT].GetOptionCount() == 5) {
+                    mOptions[RSK_RAINBOW_BRIDGE_STONE_COUNT].ChangeOptions(NumOpts(0, 3));
+                }
+            }
+            break;
+        case RO_BRIDGE_MEDALLIONS:
+            // Show Bridge Options and Medallion Count Slider
+            mOptions[RSK_RAINBOW_BRIDGE].RemoveFlag(IMFLAG_SEPARATOR_BOTTOM);
+            mOptions[RSK_BRIDGE_OPTIONS].Unhide();
+            mOptions[RSK_RAINBOW_BRIDGE_MEDALLION_COUNT].Unhide();
+            if (bridgeOpt == RO_BRIDGE_GREG_REWARD) {
+                if (mOptions[RSK_RAINBOW_BRIDGE_MEDALLION_COUNT].GetOptionCount() == 7) {
+                    mOptions[RSK_RAINBOW_BRIDGE_MEDALLION_COUNT].ChangeOptions(NumOpts(0, 7));
+                }
+            } else {
+                if (mOptions[RSK_RAINBOW_BRIDGE_MEDALLION_COUNT].GetOptionCount() == 8) {
+                    mOptions[RSK_RAINBOW_BRIDGE_MEDALLION_COUNT].ChangeOptions(NumOpts(0, 6));
+                }
+            }
+            break;
+        case RO_BRIDGE_DUNGEON_REWARDS:
+            // Show Bridge Options and Dungeon Reward Count Slider
+            mOptions[RSK_RAINBOW_BRIDGE].RemoveFlag(IMFLAG_SEPARATOR_BOTTOM);
+            mOptions[RSK_BRIDGE_OPTIONS].Unhide();
+            mOptions[RSK_RAINBOW_BRIDGE_REWARD_COUNT].Unhide();
+            if (bridgeOpt == RO_BRIDGE_GREG_REWARD) {
+                if (mOptions[RSK_RAINBOW_BRIDGE_REWARD_COUNT].GetOptionCount() == 10) {
+                    mOptions[RSK_RAINBOW_BRIDGE_REWARD_COUNT].ChangeOptions(NumOpts(0, 10));
+                }
+            } else {
+                if (mOptions[RSK_RAINBOW_BRIDGE_REWARD_COUNT].GetOptionCount() == 11) {
+                    mOptions[RSK_RAINBOW_BRIDGE_REWARD_COUNT].ChangeOptions(NumOpts(0, 9));
+                }
+            }
+            break;
+        case RO_BRIDGE_DUNGEONS:
+            // Show Bridge Options and Dungeon Count Slider
+            mOptions[RSK_RAINBOW_BRIDGE].RemoveFlag(IMFLAG_SEPARATOR_BOTTOM);
+            mOptions[RSK_BRIDGE_OPTIONS].Unhide();
+            mOptions[RSK_RAINBOW_BRIDGE_DUNGEON_COUNT].Unhide();
+            if (bridgeOpt == RO_BRIDGE_GREG_REWARD) {
+                if (mOptions[RSK_RAINBOW_BRIDGE_DUNGEON_COUNT].GetOptionCount() == 9) {
+                    mOptions[RSK_RAINBOW_BRIDGE_DUNGEON_COUNT].ChangeOptions(NumOpts(0, 9));
+                }
+            } else {
+                if (mOptions[RSK_RAINBOW_BRIDGE_DUNGEON_COUNT].GetOptionCount() == 10) {
+                    mOptions[RSK_RAINBOW_BRIDGE_DUNGEON_COUNT].ChangeOptions(NumOpts(0, 8));
+                }
+            }
+            break;
+        case RO_BRIDGE_TOKENS:
+            // Show token count slider (not bridge options)
+            mOptions[RSK_RAINBOW_BRIDGE].RemoveFlag(IMFLAG_SEPARATOR_BOTTOM);
+            mOptions[RSK_BRIDGE_OPTIONS].Hide();
+            mOptions[RSK_RAINBOW_BRIDGE_TOKEN_COUNT].Unhide();
+            break;
+        default:
+            break;
+    }
+    mOptions[RSK_GANONS_TRIALS].Enable();
+    mOptions[RSK_TRIAL_COUNT].Enable();
+    // Only show the trial count slider if Trials is set to Set Number
+    if (CVarGetInteger(CVAR_RANDOMIZER_SETTING("GanonTrial"), RO_GANONS_TRIALS_SET_NUMBER) ==
+        RO_GANONS_TRIALS_SET_NUMBER) {
+        mOptions[RSK_GANONS_TRIALS].RemoveFlag(IMFLAG_SEPARATOR_BOTTOM);
+        mOptions[RSK_TRIAL_COUNT].Unhide();
+    } else {
+        mOptions[RSK_GANONS_TRIALS].AddFlag(IMFLAG_SEPARATOR_BOTTOM);
+        mOptions[RSK_TRIAL_COUNT].Hide();
+    }
+    mOptions[RSK_TRIFORCE_HUNT].Enable();
+    mOptions[RSK_TRIFORCE_HUNT_PIECES_TOTAL].Enable();
+    mOptions[RSK_TRIFORCE_HUNT_PIECES_REQUIRED].Enable();
+    // Remove the pieces required/total sliders and add a separator after Tirforce Hunt if Triforce Hunt is off
+    if (CVarGetInteger(CVAR_RANDOMIZER_SETTING("TriforceHunt"), RO_GENERIC_OFF) == RO_GENERIC_OFF) {
+        mOptions[RSK_TRIFORCE_HUNT_PIECES_REQUIRED].Hide();
+        mOptions[RSK_TRIFORCE_HUNT_PIECES_TOTAL].Hide();
+        mOptions[RSK_TRIFORCE_HUNT].AddFlag(IMFLAG_SEPARATOR_BOTTOM);
+    } else {
+        mOptions[RSK_TRIFORCE_HUNT_PIECES_REQUIRED].Unhide();
+        mOptions[RSK_TRIFORCE_HUNT_PIECES_TOTAL].Unhide();
+        mOptions[RSK_TRIFORCE_HUNT].RemoveFlag(IMFLAG_SEPARATOR_BOTTOM);
+    }
+    // Update triforce pieces required to be capped at the current value for pieces total.
+    const uint8_t triforceTotal = CVarGetInteger(CVAR_RANDOMIZER_SETTING("TriforceHuntTotalPieces"), 30);
+    if (mOptions[RSK_TRIFORCE_HUNT_PIECES_REQUIRED].GetOptionCount() != triforceTotal + 1) {
+        mOptions[RSK_TRIFORCE_HUNT_PIECES_REQUIRED].ChangeOptions(NumOpts(1, triforceTotal + 1));
+    }
+    mOptionGroups[RSG_ITEMS_IMGUI_TABLE].Enable();
+    mOptionGroups[RSG_GAMEPLAY_IMGUI_TABLE].Enable();
+    // Link's Pocket - Disabled when Dungeon Rewards are shuffled to End of Dungeon
+    if (CVarGetInteger(CVAR_RANDOMIZER_SETTING("ShuffleDungeonReward"), RO_DUNGEON_REWARDS_END_OF_DUNGEON) ==
+        RO_DUNGEON_REWARDS_END_OF_DUNGEON) {
+        mOptions[RSK_LINKS_POCKET].Disable(
+            "This option is disabled because \"Dungeon Rewards\" are shuffled to \"End of Dungeons\".");
+    } else {
+        mOptions[RSK_LINKS_POCKET].Enable();
+    }
+    mOptions[RSK_STARTING_OCARINA].Enable();
 
     // Don't show any MQ options if both quests aren't available
     if (!(OTRGlobals::Instance->HasMasterQuest() && OTRGlobals::Instance->HasOriginal())) {
@@ -2888,15 +2864,6 @@ void Context::FinalizeSettings(const std::set<RandomizerCheck>& excludedLocation
         mLACSCondition = RO_LACS_TOKENS;
     } else {
         mLACSCondition = RO_LACS_VANILLA;
-    }
-
-    if (mOptions[RSK_LOGIC_RULES].Is(RO_LOGIC_VANILLA)) {
-        for (OptionValue* setting : VanillaLogicDefaults) {
-            // setting->SetDelayedOption();
-            setting->Set(0);
-        }
-        // mOptions[RSK_KEYSANITY].SetDelayedOption();
-        mOptions[RSK_KEYSANITY].Set(3);
     }
 
     if (!mOptions[RSK_SHUFFLE_WARP_SONGS]) {


### PR DESCRIPTION
issues with Vanilla shuffle raised in #5796

I think this was leftover from 3ds. Vanilla shuffle makes sense for romhack randomizers, where players may want the QoL for a Faster Quest experience, but in Ship players can turn on these enhancements without rando. So this feature lacks value / usage, & has therefore decayed

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4064284307.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4064286214.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4064286376.zip)
<!--- section:artifacts:end -->