### PR TITLE
Program Execution Argument Extraction

### DIFF
--- a/soh/soh/Extractor/Extract.cpp
+++ b/soh/soh/Extractor/Extract.cpp
@@ -453,6 +453,35 @@ bool Extractor::ManuallySearchForRomMatchingType(RomSearchMode searchMode) {
     return true;
 }
 
+bool Extractor::RunFileStandalone(std::string rom) {
+    if (std::filesystem::is_directory(rom)) {
+        return false;
+    }
+    auto file = std::filesystem::path(rom);
+    if ((file.extension() != ".n64") && (file.extension() != ".z64") &&
+        (file.extension() != ".v64")) {
+        return false;
+    }
+    SetRomInfo(rom);
+
+    if (!ValidateRomSize()) {
+        return false;
+    }
+    std::ifstream inFile;
+
+    inFile.open(rom, std::ios::in | std::ios::binary);
+    inFile.read((char*)mRomData.get(), mCurRomSize);
+    inFile.clear();
+    inFile.close();
+    BitConverter::RomToBigEndian(mRomData.get(), mCurRomSize);
+
+    if (!ValidateRom(true)) {
+        return false;
+    }
+    
+    return true;
+}
+
 bool Extractor::Run(std::string searchPath, RomSearchMode searchMode) {
     std::vector<std::string> roms;
     std::ifstream inFile;

--- a/soh/soh/Extractor/Extract.cpp
+++ b/soh/soh/Extractor/Extract.cpp
@@ -458,8 +458,7 @@ bool Extractor::RunFileStandalone(std::string rom) {
         return false;
     }
     auto file = std::filesystem::path(rom);
-    if ((file.extension() != ".n64") && (file.extension() != ".z64") &&
-        (file.extension() != ".v64")) {
+    if ((file.extension() != ".n64") && (file.extension() != ".z64") && (file.extension() != ".v64")) {
         return false;
     }
     SetRomInfo(rom);
@@ -478,7 +477,7 @@ bool Extractor::RunFileStandalone(std::string rom) {
     if (!ValidateRom(true)) {
         return false;
     }
-    
+
     return true;
 }
 

--- a/soh/soh/Extractor/Extract.h
+++ b/soh/soh/Extractor/Extract.h
@@ -59,6 +59,7 @@ class Extractor {
     static void ShowErrorBox(const char* title, const char* text);
     bool IsMasterQuest() const;
 
+    bool RunFileStandalone(std::string file);
     bool Run(std::string searchPath, RomSearchMode searchMode = RomSearchMode::Both);
     bool CallZapd(std::string installPath, std::string exportdir);
     const char* GetZapdStr();

--- a/soh/soh/GbiWrap.cpp
+++ b/soh/soh/GbiWrap.cpp
@@ -3,7 +3,7 @@
 // OTRTODO - this is awful
 
 extern "C" {
-void InitOTR();
+void InitOTR(int argc, char* argv[]);
 void Graph_ProcessFrame(void (*run_one_game_iter)(void));
 void Graph_StartFrame();
 void Graph_ProcessGfxCommands(Gfx* commands);

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -1134,7 +1134,7 @@ void CheckAndCreateModFolder() {
 
 extern "C" void InitOTR(int argc, char* argv[]) {
 #if !defined(__SWITCH__) && !defined(__WIIU__)
-    if (argc > 0) {
+    if (argc > 1) {
         for (int i = 1; i < argc; i++) {
             std::string installPath = Ship::Context::GetAppBundlePath();
             Extractor extract;
@@ -1143,7 +1143,7 @@ extern "C" void InitOTR(int argc, char* argv[]) {
                 std::string archive = (extract.IsMasterQuest() ? "oot-mq.o2r" : "oot.o2r");
                 if (std::filesystem::exists(Ship::Context::GetAppBundlePath() + "/" + archive)) {
                     std::string msg = "Archive for current ROM, " + archive + ", already exists. Extract again?";
-                    doExtract = !extract.ShowYesNoBox("Confirm Re-extract", msg.c_str());
+                    doExtract = extract.ShowYesNoBox("Confirm Re-extract", msg.c_str()) == IDYES;
                 }
                 if (doExtract) {
                     extract.CallZapd(installPath, Ship::Context::GetAppDirectoryPath(appShortName));
@@ -1153,7 +1153,7 @@ extern "C" void InitOTR(int argc, char* argv[]) {
                 extract.ShowErrorBox("Incompatible File", msg.c_str());
             }
         }
-        if (!Extractor::ShowYesNoBox("Run Ship of Harkinian", "All files have been processed. Run SoH?")) {
+        if (Extractor::ShowYesNoBox("Run Ship of Harkinian", "All files have been processed. Run SoH?") != IDYES) {
             exit(0);
         }
     }

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -1132,7 +1132,30 @@ void CheckAndCreateModFolder() {
     }
 }
 
-extern "C" void InitOTR() {
+extern "C" void InitOTR(int argc, char* argv[]) {
+    if (argc > 0) {
+        for (int i = 1; i < argc; i++) {
+            std::string installPath = Ship::Context::GetAppBundlePath();
+            Extractor extract;
+            if (extract.RunFileStandalone(argv[i])) {
+                bool doExtract = true;
+                std::string archive = (extract.IsMasterQuest() ? "oot-mq.o2r" : "oot.o2r");
+                if (std::filesystem::exists(Ship::Context::GetAppBundlePath() + "/" + archive)) {
+                    std::string msg = "Archive for current ROM, " + archive + ", already exists. Extract again?";
+                    doExtract = !extract.ShowYesNoBox("Confirm Re-extract", msg.c_str());
+                }
+                if (doExtract) {
+                    extract.CallZapd(installPath, Ship::Context::GetAppDirectoryPath(appShortName));
+                }
+            } else {
+                std::string msg = "File " + std::string(argv[i]) + " is not a ROM or does not match supported ROMs.";
+                extract.ShowErrorBox("Incompatible File", msg.c_str());
+            }
+        }
+        if (!Extractor::ShowYesNoBox("Run Ship of Harkinian", "All files have been processed. Run SoH?")) {
+            exit(0);
+        }
+    }
     OTRGlobals::Instance = new OTRGlobals();
 #ifdef __SWITCH__
     Ship::Switch::Init(Ship::PreInitPhase);

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -1133,6 +1133,7 @@ void CheckAndCreateModFolder() {
 }
 
 extern "C" void InitOTR(int argc, char* argv[]) {
+#if !defined(__SWITCH__) && !defined(__WIIU__)
     if (argc > 0) {
         for (int i = 1; i < argc; i++) {
             std::string installPath = Ship::Context::GetAppBundlePath();
@@ -1156,6 +1157,7 @@ extern "C" void InitOTR(int argc, char* argv[]) {
             exit(0);
         }
     }
+#endif
     OTRGlobals::Instance = new OTRGlobals();
 #ifdef __SWITCH__
     Ship::Switch::Init(Ship::PreInitPhase);

--- a/soh/soh/OTRGlobals.h
+++ b/soh/soh/OTRGlobals.h
@@ -87,7 +87,7 @@ class OTRGlobals {
 #endif
 
 #ifndef __cplusplus
-void InitOTR(void);
+void InitOTR(int argc, char* argv[]);
 void DeinitOTR(void);
 void VanillaItemTable_Init();
 void OTRAudio_Init();

--- a/soh/src/code/main.c
+++ b/soh/src/code/main.c
@@ -44,7 +44,7 @@ void Main_LogSystemHeap(void) {
 }
 
 #ifdef _WIN32
-int SDL_main(int argc, char** argv) {
+int SDL_main(int argc, char* argv[]) {
     AllocConsole();
     (void)freopen("CONIN$", "r", stdin);
     (void)freopen("CONOUT$", "w", stdout);
@@ -54,11 +54,10 @@ int SDL_main(int argc, char** argv) {
 #endif
 
 #else //_WIN32
-int main(int argc, char** argv) {
+int main(int argc, char* argv[]) {
 #endif
-
     GameConsole_Init();
-    InitOTR();
+    InitOTR(argc, argv);
     // TODO: Was moved to below InitOTR because it requires window to be setup. But will be late to catch crashes.
     CrashHandlerRegisterCallback(CrashHandler_PrintSohData);
     BootCommands_Init();


### PR DESCRIPTION
Adds function to be able to feed specific path into `Extractor` to process programmatically, and sets up execution argument parsing (excluding Switch and Wii U because why not), with prompts for incompatible files, re-extraction confirmation, and an option to run SoH after all dropped files have been processed. This also allows for dragging and dropping ROMs onto the Windows .exe.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4198408936.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4198527209.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4198568529.zip)
<!--- section:artifacts:end -->