### PR TITLE
Nightmare Traps

### DIFF
--- a/soh/soh/Enhancements/ExtraTraps.cpp
+++ b/soh/soh/Enhancements/ExtraTraps.cpp
@@ -191,8 +191,8 @@ static void RollRandomTrap(uint32_t seed) {
     uint32_t finalSeed = seed + (IS_RANDO ? Rando::Context::GetInstance()->GetSeed()
                                           : static_cast<uint32_t>(gSaveContext.ship.stats.fileCreatedAt));
     Random_Init(finalSeed);
-    roll = ADD_POCKET_TRAP;
-    // roll = RandomElement(getEnabledAddTraps());
+    //roll = ADD_POCKET_TRAP;
+    roll = RandomElement(getEnabledAddTraps());
     switch (roll) {
         case ADD_ICE_TRAP:
             GameInteractor::RawAction::FreezePlayer();

--- a/soh/soh/Enhancements/ExtraTraps.cpp
+++ b/soh/soh/Enhancements/ExtraTraps.cpp
@@ -4,6 +4,7 @@
 #include "soh/Enhancements/randomizer/3drando/random.hpp"
 #include "soh/Notification/Notification.h"
 #include "soh/OTRGlobals.h"
+#include "soh/SohGui/ImGuiUtils.h"
 
 extern "C" {
 #include "variables.h"
@@ -11,6 +12,7 @@ extern "C" {
 #include "macros.h"
 extern PlayState* gPlayState;
 GetItemEntry ItemTable_RetrieveEntry(s16 modIndex, s16 getItemID);
+GetItemID RetrieveGetItemIDFromItemID(ItemID itemID);
 }
 
 #define CVAR_EXTRA_TRAPS_NAME CVAR_ENHANCEMENT("ExtraTraps.Enabled")
@@ -28,6 +30,7 @@ typedef enum {
     ADD_AMMO_TRAP,
     ADD_KILL_TRAP,
     ADD_TELEPORT_TRAP,
+    ADD_POCKET_TRAP,
     ADD_TRAP_MAX
 } AltTrapType;
 
@@ -36,11 +39,12 @@ static int statusTimer = -1;
 static int eventTimer = -1;
 
 const char* altTrapTypeCvars[] = {
-    CVAR_ENHANCEMENT("ExtraTraps.Ice"),   CVAR_ENHANCEMENT("ExtraTraps.Burn"),
-    CVAR_ENHANCEMENT("ExtraTraps.Shock"), CVAR_ENHANCEMENT("ExtraTraps.Knockback"),
-    CVAR_ENHANCEMENT("ExtraTraps.Speed"), CVAR_ENHANCEMENT("ExtraTraps.Bomb"),
-    CVAR_ENHANCEMENT("ExtraTraps.Void"),  CVAR_ENHANCEMENT("ExtraTraps.Ammo"),
-    CVAR_ENHANCEMENT("ExtraTraps.Kill"),  CVAR_ENHANCEMENT("ExtraTraps.Teleport"),
+    CVAR_ENHANCEMENT("ExtraTraps.Ice"),    CVAR_ENHANCEMENT("ExtraTraps.Burn"),
+    CVAR_ENHANCEMENT("ExtraTraps.Shock"),  CVAR_ENHANCEMENT("ExtraTraps.Knockback"),
+    CVAR_ENHANCEMENT("ExtraTraps.Speed"),  CVAR_ENHANCEMENT("ExtraTraps.Bomb"),
+    CVAR_ENHANCEMENT("ExtraTraps.Void"),   CVAR_ENHANCEMENT("ExtraTraps.Ammo"),
+    CVAR_ENHANCEMENT("ExtraTraps.Kill"),   CVAR_ENHANCEMENT("ExtraTraps.Teleport"),
+    CVAR_ENHANCEMENT("ExtraTraps.Pocket"),
 };
 
 std::vector<AltTrapType> getEnabledAddTraps() {
@@ -60,12 +64,135 @@ std::vector<AltTrapType> getEnabledAddTraps() {
     return enabledAddTraps;
 };
 
+void TriggerVoidOut() {
+    Player* player = GET_PLAYER(gPlayState);
+
+    Audio_PlaySoundGeneral(NA_SE_EN_BUBLE_LAUGH, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale,
+                           &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
+
+    // Hyrule Castle: Very likely to fall through floor, so we force a specific entrance
+    if (gPlayState->sceneNum == SCENE_HYRULE_CASTLE || gPlayState->sceneNum == SCENE_OUTSIDE_GANONS_CASTLE) {
+        gPlayState->nextEntranceIndex = ENTR_CASTLE_GROUNDS_SOUTH_EXIT;
+    } else {
+        gSaveContext.respawnFlag = 1;
+        gPlayState->nextEntranceIndex = gSaveContext.entranceIndex;
+
+        // Preserve the player's position and orientation
+        gSaveContext.respawn[RESPAWN_MODE_DOWN].entranceIndex = gPlayState->nextEntranceIndex;
+        gSaveContext.respawn[RESPAWN_MODE_DOWN].roomIndex = gPlayState->roomCtx.curRoom.num;
+        gSaveContext.respawn[RESPAWN_MODE_DOWN].pos = player->actor.world.pos;
+        gSaveContext.respawn[RESPAWN_MODE_DOWN].yaw = player->actor.shape.rot.y;
+
+        if (gPlayState->roomCtx.curRoom.behaviorType2 < 4) {
+            gSaveContext.respawn[RESPAWN_MODE_DOWN].playerParams = 0x0DFF;
+        } else {
+            // Scenes with static backgrounds use a special camera we need to preserve
+            Camera* camera = GET_ACTIVE_CAM(gPlayState);
+            s16 camId = camera->camDataIdx;
+            gSaveContext.respawn[RESPAWN_MODE_DOWN].playerParams = 0x0D00 | camId;
+        }
+    }
+
+    gPlayState->transitionTrigger = TRANS_TRIGGER_START;
+    gPlayState->transitionType = TRANS_TYPE_INSTANT;
+    gSaveContext.nextTransitionType = TRANS_TYPE_FADE_BLACK_FAST;
+}
+
+void ExecutePocketTrap() {
+    std::vector<uint32_t> currentLoadout;
+
+    for (auto& items : itemMapping) {
+        if (INV_CONTENT(items.second.id) == items.second.id) {
+            currentLoadout.push_back(items.second.id);
+        }
+    }
+
+    if (currentLoadout.size() == 0) {
+        GameInteractor::RawAction::FreezePlayer();
+        return;
+    }
+
+    uint32_t roll = Random(0, currentLoadout.size() - 1);
+    GetItemID getItemId = RetrieveGetItemIDFromItemID((ItemID)currentLoadout[roll]);
+    RandomizerGet rgItem = RG_NONE;
+
+    for (auto& randoGet : Rando::StaticData::GetItemTable()) {
+        if (randoGet.GetItemID() == getItemId) {
+            rgItem = randoGet.GetRandomizerGet();
+            break;
+        }
+    }
+
+    if (rgItem == RG_NONE) {
+        return;
+    }
+
+    for (auto& check : Rando::StaticData::GetLocationTable()) {
+        if (Rando::Context::GetInstance()->GetItemLocation(check.GetRandomizerCheck())->GetPlacedRandomizerGet() ==
+            rgItem) {
+            if (check.GetRandomizerCheck() == RC_UNKNOWN_CHECK || check.GetRandomizerCheck() == RC_LINKS_POCKET) {
+                GameInteractor::RawAction::FreezePlayer();
+                return;
+            }
+            switch (check.GetActorID()) {
+                case ACTOR_EN_BOX:
+                    GameInteractor::RawAction::UnsetSceneFlag(check.GetScene(), FLAG_SCENE_TREASURE,
+                                                              check.GetActorParams() & 0x1F);
+                    break;
+                default:
+                    if (check.GetCollectionCheck().type != SPOILER_CHK_NONE) {
+                        switch (check.GetCollectionCheck().type) {
+                            case SPOILER_CHK_ITEM_GET_INF:
+                                Flags_UnsetItemGetInf(check.GetCollectionCheck().flag);
+                                break;
+                            case SPOILER_CHK_RANDOMIZER_INF:
+                                Flags_UnsetRandomizerInf((RandomizerInf)check.GetCollectionCheck().flag);
+                                break;
+                            case SPOILER_CHK_EVENT_CHK_INF:
+                                Flags_UnsetEventInf(check.GetCollectionCheck().flag);
+                                break;
+                            case SPOILER_CHK_CHEST:
+                                GameInteractor::RawAction::UnsetSceneFlag(check.GetScene(), FLAG_SCENE_TREASURE,
+                                                                          check.GetCollectionCheck().flag);
+                                break;
+                            case SPOILER_CHK_COLLECTABLE:
+                                GameInteractor::RawAction::UnsetSceneFlag(check.GetScene(), FLAG_SCENE_COLLECTIBLE,
+                                                                          check.GetCollectionCheck().flag);
+                                break;
+                            case SPOILER_CHK_INF_TABLE:
+                                Flags_UnsetInfTable(check.GetCollectionCheck().flag);
+                                break;
+                            default:
+                                GameInteractor::RawAction::FreezePlayer();
+                                return;
+                        }
+                    }
+                    break;
+            }
+
+            Rando::Context::GetInstance()->GetItemLocation(check.GetRandomizerCheck())->SetCheckStatus(RCSHOW_SEEN);
+            INV_CONTENT(currentLoadout[roll]) = ITEM_NONE;
+            break;
+        }
+    }
+
+    Notification::Emit({ .itemIcon = (const char*)gItemIcons[currentLoadout[roll]],
+                         .prefix = "You've lost your",
+                         .prefixColor = UIWidgets::ColorValues.at(UIWidgets::Colors::White),
+                         .message = Rando::StaticData::RetrieveItem(rgItem).GetName().english.c_str(),
+                         .messageColor = UIWidgets::ColorValues.at(UIWidgets::Colors::Green),
+                         .suffix = ". I remember seeing it somewhere...",
+                         .suffixColor = UIWidgets::ColorValues.at(UIWidgets::Colors::White) });
+
+    TriggerVoidOut();
+}
+
 static void RollRandomTrap(uint32_t seed) {
     uint32_t finalSeed = seed + (IS_RANDO ? Rando::Context::GetInstance()->GetSeed()
                                           : static_cast<uint32_t>(gSaveContext.ship.stats.fileCreatedAt));
     Random_Init(finalSeed);
-
-    roll = RandomElement(getEnabledAddTraps());
+    roll = ADD_POCKET_TRAP;
+    // roll = RandomElement(getEnabledAddTraps());
     switch (roll) {
         case ADD_ICE_TRAP:
             GameInteractor::RawAction::FreezePlayer();
@@ -103,6 +230,9 @@ static void RollRandomTrap(uint32_t seed) {
             break;
         case ADD_TELEPORT_TRAP:
             eventTimer = 3;
+            break;
+        case ADD_POCKET_TRAP:
+            ExecutePocketTrap();
             break;
         default:
             break;

--- a/soh/soh/Enhancements/ExtraTraps.cpp
+++ b/soh/soh/Enhancements/ExtraTraps.cpp
@@ -5,6 +5,7 @@
 #include "soh/Notification/Notification.h"
 #include "soh/OTRGlobals.h"
 #include "soh/SohGui/ImGuiUtils.h"
+#include "soh/SaveManager.h"
 
 extern "C" {
 #include "variables.h"
@@ -13,6 +14,7 @@ extern "C" {
 extern PlayState* gPlayState;
 GetItemEntry ItemTable_RetrieveEntry(s16 modIndex, s16 getItemID);
 GetItemID RetrieveGetItemIDFromItemID(ItemID itemID);
+RandomizerGet RetrieveRandomizerGetFromItemID(ItemID itemID);
 }
 
 #define CVAR_EXTRA_TRAPS_NAME CVAR_ENHANCEMENT("ExtraTraps.Enabled")
@@ -31,12 +33,15 @@ typedef enum {
     ADD_KILL_TRAP,
     ADD_TELEPORT_TRAP,
     ADD_POCKET_TRAP,
+    ADD_PERMADEATH_TRAP,
     ADD_TRAP_MAX
 } AltTrapType;
 
 static AltTrapType roll = ADD_TRAP_MAX;
 static int statusTimer = -1;
 static int eventTimer = -1;
+static int permaDeathTimer = -1;
+bool shouldFileDelete = false;
 
 const char* altTrapTypeCvars[] = {
     CVAR_ENHANCEMENT("ExtraTraps.Ice"),    CVAR_ENHANCEMENT("ExtraTraps.Burn"),
@@ -44,7 +49,32 @@ const char* altTrapTypeCvars[] = {
     CVAR_ENHANCEMENT("ExtraTraps.Speed"),  CVAR_ENHANCEMENT("ExtraTraps.Bomb"),
     CVAR_ENHANCEMENT("ExtraTraps.Void"),   CVAR_ENHANCEMENT("ExtraTraps.Ammo"),
     CVAR_ENHANCEMENT("ExtraTraps.Kill"),   CVAR_ENHANCEMENT("ExtraTraps.Teleport"),
-    CVAR_ENHANCEMENT("ExtraTraps.Pocket"),
+    CVAR_ENHANCEMENT("ExtraTraps.Pocket"), CVAR_ENHANCEMENT("ExtraTraps.Permadeath"),
+};
+
+static std::unordered_map<ItemID, QuestItem> itemToQuestMap = {
+    { ITEM_MEDALLION_FOREST, QUEST_MEDALLION_FOREST },
+    { ITEM_MEDALLION_FIRE, QUEST_MEDALLION_FIRE },
+    { ITEM_MEDALLION_WATER, QUEST_MEDALLION_WATER },
+    { ITEM_MEDALLION_SPIRIT, QUEST_MEDALLION_SPIRIT },
+    { ITEM_MEDALLION_SHADOW, QUEST_MEDALLION_SHADOW },
+    { ITEM_MEDALLION_LIGHT, QUEST_MEDALLION_LIGHT },
+    { ITEM_SONG_MINUET, QUEST_SONG_MINUET },
+    { ITEM_SONG_BOLERO, QUEST_SONG_BOLERO },
+    { ITEM_SONG_SERENADE, QUEST_SONG_SERENADE },
+    { ITEM_SONG_REQUIEM, QUEST_SONG_REQUIEM },
+    { ITEM_SONG_NOCTURNE, QUEST_SONG_NOCTURNE },
+    { ITEM_SONG_PRELUDE, QUEST_SONG_PRELUDE },
+    { ITEM_SONG_LULLABY, QUEST_SONG_LULLABY },
+    { ITEM_SONG_EPONA, QUEST_SONG_EPONA },
+    { ITEM_SONG_SARIA, QUEST_SONG_SARIA },
+    { ITEM_SONG_SUN, QUEST_SONG_SUN },
+    { ITEM_SONG_TIME, QUEST_SONG_TIME },
+    { ITEM_SONG_STORMS, QUEST_SONG_STORMS },
+    { ITEM_KOKIRI_EMERALD, QUEST_KOKIRI_EMERALD },
+    { ITEM_GORON_RUBY, QUEST_GORON_RUBY },
+    { ITEM_ZORA_SAPPHIRE, QUEST_ZORA_SAPPHIRE },
+    { ITEM_GERUDO_CARD, QUEST_GERUDO_CARD },
 };
 
 std::vector<AltTrapType> getEnabledAddTraps() {
@@ -104,6 +134,16 @@ void ExecutePocketTrap() {
     for (auto& items : itemMapping) {
         if (INV_CONTENT(items.second.id) == items.second.id) {
             currentLoadout.push_back(items.second.id);
+            continue;
+        }
+        auto questItem = itemToQuestMap.find(
+            (ItemID)items.second.id); // std::find(itemToQuestMap.begin(), itemToQuestMap.end(), items.second.id);
+        if (questItem == itemToQuestMap.end()) {
+            continue;
+        }
+        if (CHECK_QUEST_ITEM(questItem->second)) {
+            currentLoadout.push_back(items.second.id);
+            continue;
         }
     }
 
@@ -112,18 +152,23 @@ void ExecutePocketTrap() {
         return;
     }
 
-    uint32_t roll = Random(0, currentLoadout.size() - 1);
-    GetItemID getItemId = RetrieveGetItemIDFromItemID((ItemID)currentLoadout[roll]);
     RandomizerGet rgItem = RG_NONE;
 
-    for (auto& randoGet : Rando::StaticData::GetItemTable()) {
-        if (randoGet.GetItemID() == getItemId) {
-            rgItem = randoGet.GetRandomizerGet();
-            break;
+    uint32_t roll = Random(0, currentLoadout.size() - 1);
+    if (currentLoadout[roll] >= ITEM_SONG_MINUET) {
+        rgItem = RetrieveRandomizerGetFromItemID((ItemID)currentLoadout[roll]);
+    } else {
+        GetItemID getItemId = RetrieveGetItemIDFromItemID((ItemID)currentLoadout[roll]);
+        for (auto& randoGet : Rando::StaticData::GetItemTable()) {
+            if (randoGet.GetItemID() == getItemId) {
+                rgItem = randoGet.GetRandomizerGet();
+                break;
+            }
         }
     }
 
     if (rgItem == RG_NONE) {
+        GameInteractor::RawAction::FreezePlayer();
         return;
     }
 
@@ -191,7 +236,7 @@ static void RollRandomTrap(uint32_t seed) {
     uint32_t finalSeed = seed + (IS_RANDO ? Rando::Context::GetInstance()->GetSeed()
                                           : static_cast<uint32_t>(gSaveContext.ship.stats.fileCreatedAt));
     Random_Init(finalSeed);
-    //roll = ADD_POCKET_TRAP;
+    // roll = ADD_PERMADEATH_TRAP;
     roll = RandomElement(getEnabledAddTraps());
     switch (roll) {
         case ADD_ICE_TRAP:
@@ -233,6 +278,15 @@ static void RollRandomTrap(uint32_t seed) {
             break;
         case ADD_POCKET_TRAP:
             ExecutePocketTrap();
+            break;
+        case ADD_PERMADEATH_TRAP:
+            permaDeathTimer = 180;
+            shouldFileDelete = true;
+            Notification::Emit({ .itemIcon = (const char*)gItemIcons[ITEM_BOMB],
+                                 .message = "Collect a Check or Perma Death executes in ",
+                                 .messageColor = UIWidgets::ColorValues.at(UIWidgets::Colors::White),
+                                 .suffix = "60 seconds.",
+                                 .suffixColor = UIWidgets::ColorValues.at(UIWidgets::Colors::Red) });
             break;
         default:
             break;
@@ -298,6 +352,17 @@ static void OnPlayerUpdate() {
                 break;
         }
     }
+    if (permaDeathTimer == 0) {
+        if (shouldFileDelete) {
+            SaveManager::Instance->DeleteZeldaFile(gSaveContext.fileNum);
+            std::reinterpret_pointer_cast<Ship::ConsoleWindow>(
+                Ship::Context::GetInstance()->GetWindow()->GetGui()->GetGuiWindow("Console"))
+                ->Dispatch("reset");
+        }
+    }
+    if (permaDeathTimer >= 0) {
+        permaDeathTimer--;
+    }
     if (statusTimer >= 0) {
         statusTimer--;
     }
@@ -324,6 +389,20 @@ void RegisterExtraTraps() {
             RollRandomTrap(gPlayState->sceneNum + player->getItemEntry.drawItemId);
         } else {
             GameInteractor::RawAction::FreezePlayer();
+        }
+    });
+
+    COND_HOOK(OnFlagSet, CVAR_EXTRA_TRAPS_NAME, [](int16_t flagType, int16_t flag) {
+        SPDLOG_INFO("Flag Set Here {}", std::to_string(flagType).c_str());
+        if (flagType != FLAG_SCENE_CLEAR) {
+            shouldFileDelete = false;
+        }
+    });
+
+    COND_HOOK(OnSceneFlagSet, CVAR_EXTRA_TRAPS_NAME, [](int16_t sceneNum, int16_t flagType, int16_t flag) {
+        SPDLOG_INFO("Scene Flag Set Here {}", std::to_string(flagType).c_str());
+        if (flagType != FLAG_SCENE_CLEAR) {
+            shouldFileDelete = false;
         }
     });
 }

--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -1631,6 +1631,13 @@ void SohMenu::AddMenuEnhancements() {
         .CVar(CVAR_ENHANCEMENT("ExtraTraps.Teleport"))
         .PreFunc(
             [](WidgetInfo& info) { info.isHidden = CVarGetInteger(CVAR_ENHANCEMENT("ExtraTraps.Enabled"), 0) == 0; });
+    AddWidget(path, "Nightmare Traps:", WIDGET_TEXT).PreFunc([](WidgetInfo& info) {
+        info.isHidden = CVarGetInteger(CVAR_ENHANCEMENT("ExtraTraps.Enabled"), 0) == 0;
+    });
+    AddWidget(path, "Pocket Traps", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_ENHANCEMENT("ExtraTraps.Pocket"))
+        .PreFunc(
+            [](WidgetInfo& info) { info.isHidden = CVarGetInteger(CVAR_ENHANCEMENT("ExtraTraps.Enabled"), 0) == 0; });
 
     path.column = SECTION_COLUMN_2;
     AddWidget(path, "Enemy Randomizer", WIDGET_CVAR_COMBOBOX)

--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -1638,6 +1638,10 @@ void SohMenu::AddMenuEnhancements() {
         .CVar(CVAR_ENHANCEMENT("ExtraTraps.Pocket"))
         .PreFunc(
             [](WidgetInfo& info) { info.isHidden = CVarGetInteger(CVAR_ENHANCEMENT("ExtraTraps.Enabled"), 0) == 0; });
+    AddWidget(path, "Perma Death Traps", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_ENHANCEMENT("ExtraTraps.Permadeath"))
+        .PreFunc(
+            [](WidgetInfo& info) { info.isHidden = CVarGetInteger(CVAR_ENHANCEMENT("ExtraTraps.Enabled"), 0) == 0; });
 
     path.column = SECTION_COLUMN_2;
     AddWidget(path, "Enemy Randomizer", WIDGET_CVAR_COMBOBOX)


### PR DESCRIPTION
THIS IS A HEAVY WIP MEANT FOR NO LOGIC RANDO IN ITS CURRENT STATE, NO SUPPORT WILL BE GIVEN AT THIS TIME


Adds new Additional Trap Options and a new Tier of traps called **Nightmare Traps**.
- **Pocket Trap:** Removes an Item from your Inventory and places it back in the Check you found it.
- **Perma Death Trap:** Starts a 60 Second timer, if you do not collect another Check within that time, the game resets and your Save File is **Permanently Deleted**.


More will be added to the PR as I create them. Obviously this is a draft but figured people can test it out.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4104763010.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4104784103.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4105037876.zip)
<!--- section:artifacts:end -->