### PR TITLE
update macports

### DIFF
--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -113,8 +113,8 @@ jobs:
           echo "MacPorts already installed"
         else
           echo "Installing MacPorts"
-          wget https://github.com/macports/macports-base/releases/download/v2.9.3/MacPorts-2.9.3-14-Sonoma.pkg
-          sudo installer -pkg ./MacPorts-2.9.3-14-Sonoma.pkg -target /
+          wget https://github.com/macports/macports-base/releases/download/v2.11.5/MacPorts-2.11.5-14-Sonoma.pkg
+          sudo installer -pkg ./MacPorts-2.11.5-14-Sonoma.pkg -target /
         fi
         echo "/opt/local/bin:/opt/local/sbin" >> "$GITHUB_PATH"
     - name: Install dependencies


### PR DESCRIPTION
i was running into some macports flakiness when working on other things that involved dependency changes. it looks like there have been some reliability improvements between the version we had and this one, so i figure updating it makes sense

in order to actually *use* the new version we'll need to wipe the macports cache from actions, but that not urgent and can happen whenever someone feels like it

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4124544275.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4124548146.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4124565245.zip)
<!--- section:artifacts:end -->