### PR TITLE
SAIL: "SpawnActor::CanBeApplied" no longer also spawns an actor

### DIFF
--- a/soh/soh/Enhancements/game-interactor/GameInteractionEffect.cpp
+++ b/soh/soh/Enhancements/game-interactor/GameInteractionEffect.cpp
@@ -632,10 +632,10 @@ void SlipperyFloor::_Remove() {
 
 // MARK: - SpawnEnemyWithOffset
 GameInteractionEffectQueryResult SpawnEnemyWithOffset::CanBeApplied() {
-    if (!GameInteractor::IsSaveLoaded(true)) {
+    if (!GameInteractor::CanSpawnActor()) {
         return GameInteractionEffectQueryResult::TemporarilyNotPossible;
     }
-    return GameInteractor::RawAction::SpawnEnemyWithOffset(parameters[0], parameters[1]);
+    return GameInteractionEffectQueryResult::Possible;
 }
 
 void SpawnEnemyWithOffset::_Apply() {
@@ -644,10 +644,10 @@ void SpawnEnemyWithOffset::_Apply() {
 
 // MARK: - SpawnActor
 GameInteractionEffectQueryResult SpawnActor::CanBeApplied() {
-    if (!GameInteractor::IsSaveLoaded(true)) {
+    if (!GameInteractor::CanSpawnActor()) {
         return GameInteractionEffectQueryResult::TemporarilyNotPossible;
     }
-    return GameInteractor::RawAction::SpawnActor(parameters[0], parameters[1]);
+    return GameInteractionEffectQueryResult::Possible;
 }
 
 void SpawnActor::_Apply() {


### PR DESCRIPTION
The "SpawnActor::CanBeApplied()" function was calling the "SpawnEnemy" function, which would also actually spawn the actor, causing two actors two be spawned when Apply() is called afterwards. (also fixes for SpawnEnemyWithOffset)

There's a deeper confusion where SpawnActor reports whether it succeeded, whereas most actions don't, which is addressed in the second commit. However, this change makes the GameInteractionEffectBase::Apply() function virtual, which may not be "worth it", in which case I can drop that commit.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4168313944.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4168319062.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4168361951.zip)
<!--- section:artifacts:end -->