### PR TITLE
Add RT_GF_JUMP case

### DIFF
--- a/soh/soh/Enhancements/randomizer/location_access/overworld/gerudo_fortress.cpp
+++ b/soh/soh/Enhancements/randomizer/location_access/overworld/gerudo_fortress.cpp
@@ -132,7 +132,7 @@ void RegionTable_Init_GerudoFortress() {
         //Exits
         Entrance(RR_GF_OUTSIDE_GTG,        []{return true;}),
         Entrance(RR_GF_TOP_OF_LOWER_VINES, []{return true;}),
-        Entrance(RR_GF_SLOPED_ROOF,        []{return logic->IsAdult && logic->CanUse(RG_HOVER_BOOTS);}),
+        Entrance(RR_GF_SLOPED_ROOF,        []{return logic->IsAdult && (logic->CanUse(RG_HOVER_BOOTS) || ctx->GetTrickOption(RT_GF_JUMP));}),
         Entrance(RR_GF_TOP_OF_UPPER_VINES, []{return true /* logic->CanClimb() */;}),
         Entrance(RR_GF_TO_GTG,             []{return logic->IsAdult && ctx->GetTrickOption(RT_GF_LEDGE_CLIP_INTO_GTG).Get();}),
     });


### PR DESCRIPTION
Adult can make jump without hover boots by jumping beside the wall (oddly, to the higher part of slope)

Only matters with Shuffle Climb

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4180409312.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4180414113.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4180433488.zip)
<!--- section:artifacts:end -->