### PR TITLE
rando: fix reentry of jabu blue warp

### DIFF
--- a/soh/soh/Enhancements/TimeSavers/SkipCutscene/Story/SkipBlueWarp.cpp
+++ b/soh/soh/Enhancements/TimeSavers/SkipCutscene/Story/SkipBlueWarp.cpp
@@ -168,8 +168,9 @@ void RegisterShouldPlayBlueWarp() {
             }
 
             // This is outside the above condition because we want to handle both first and following visits to the blue
-            // warp
-            if (sEnteredBlueWarp && overrideBlueWarpDestinations) {
+            // warp. Jabu's blue warp doesn't call VB_PLAY_BLUE_WARP_CS without Ruto
+            if ((sEnteredBlueWarp || gSaveContext.entranceIndex == ENTR_ZORAS_FOUNTAIN_JABU_JABU_BLUE_WARP) &&
+                overrideBlueWarpDestinations) {
                 Entrance_OverrideBlueWarp();
             }
         }

--- a/soh/src/overlays/actors/ovl_Door_Warp1/z_door_warp1.c
+++ b/soh/src/overlays/actors/ovl_Door_Warp1/z_door_warp1.c
@@ -557,6 +557,7 @@ void DoorWarp1_ChildWarpOut(DoorWarp1* this, PlayState* play) {
                 gSaveContext.nextCutsceneIndex = 0;
             }
         } else if (play->sceneNum == SCENE_JABU_JABU_BOSS) {
+            GameInteractor_Should(VB_PLAY_BLUE_WARP_CS, false, EVENTCHKINF_USED_JABU_JABUS_BELLY_BLUE_WARP);
             play->nextEntranceIndex = ENTR_ZORAS_FOUNTAIN_JABU_JABU_BLUE_WARP;
             gSaveContext.nextCutsceneIndex = 0;
         }

--- a/soh/src/overlays/actors/ovl_Door_Warp1/z_door_warp1.c
+++ b/soh/src/overlays/actors/ovl_Door_Warp1/z_door_warp1.c
@@ -557,7 +557,6 @@ void DoorWarp1_ChildWarpOut(DoorWarp1* this, PlayState* play) {
                 gSaveContext.nextCutsceneIndex = 0;
             }
         } else if (play->sceneNum == SCENE_JABU_JABU_BOSS) {
-            GameInteractor_Should(VB_PLAY_BLUE_WARP_CS, false, EVENTCHKINF_USED_JABU_JABUS_BELLY_BLUE_WARP);
             play->nextEntranceIndex = ENTR_ZORAS_FOUNTAIN_JABU_JABU_BLUE_WARP;
             gSaveContext.nextCutsceneIndex = 0;
         }


### PR DESCRIPTION
entrance randomizer uses VB_PLAY_BLUE_WARP_CS to set a flag,
which was not called when entering jabu blue warp without ruto

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4183914058.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4183919021.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4183939517.zip)
<!--- section:artifacts:end -->