### PR TITLE
Fix grass graphic in Shuffle Grass

### DIFF
--- a/soh/soh/Enhancements/randomizer/ShuffleGrass.cpp
+++ b/soh/soh/Enhancements/randomizer/ShuffleGrass.cpp
@@ -15,11 +15,10 @@ extern PlayState* gPlayState;
 extern void EnItem00_DrawRandomizedItem(EnItem00* enItem00, PlayState* play);
 
 void DrawTypeOfGrass(EnKusa* grassActor, Gfx* bushDList, Gfx* grassDList, PlayState* play) {
-    // Actor params is -255 for regrowable grass.
-    if (grassActor->actor.params == -255) {
-        Gfx_DrawDListOpa(play, grassDList);
-    } else {
+    if ((grassActor->actor.params & 3) == 0) {
         Gfx_DrawDListOpa(play, bushDList);
+    } else {
+        Gfx_DrawDListOpa(play, grassDList);
     }
 }
 


### PR DESCRIPTION
Previously rendering grass as wrong kind in MQ Dodongo room above stairs

Updated code to match decomp logic

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4187815916.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4187819857.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4187854032.zip)
<!--- section:artifacts:end -->