### PR TITLE
Standardize InitFunc

### DIFF
--- a/soh/soh/Enhancements/BonkDamage.cpp
+++ b/soh/soh/Enhancements/BonkDamage.cpp
@@ -48,4 +48,4 @@ void RegisterBonkDamage() {
               });
 }
 
-static RegisterShipInitFunc registerBonkDamage(RegisterBonkDamage, { CVAR_ENHANCEMENT("BonkDamageMult") });
+static RegisterShipInitFunc initFunc(RegisterBonkDamage, { CVAR_ENHANCEMENT("BonkDamageMult") });

--- a/soh/soh/Enhancements/BootToDebugWarpScreen.cpp
+++ b/soh/soh/Enhancements/BootToDebugWarpScreen.cpp
@@ -42,6 +42,5 @@ void RegisterBootToDebugWarpScreen() {
               OnZTitleUpdateBootToDebugWarpScreen);
 }
 
-static RegisterShipInitFunc initFunc_BootToDebugWarpScreen(RegisterBootToDebugWarpScreen,
-                                                           { CVAR_DEBUG_ENABLED_NAME,
-                                                             CVAR_BOOT_TO_DEBUG_WARP_SCREEN_NAME });
+static RegisterShipInitFunc initFunc(RegisterBootToDebugWarpScreen,
+                                     { CVAR_DEBUG_ENABLED_NAME, CVAR_BOOT_TO_DEBUG_WARP_SCREEN_NAME });

--- a/soh/soh/Enhancements/Cheats/NoKeeseGuayTarget.cpp
+++ b/soh/soh/Enhancements/Cheats/NoKeeseGuayTarget.cpp
@@ -20,4 +20,4 @@ void RegisterNoKeeseGuayTarget() {
     COND_VB_SHOULD(VB_GUAY_FORCE_FLY_AWAY, CVAR_NOKEESEGUAYTARGET_VALUE, { *should = true; });
 }
 
-static RegisterShipInitFunc initFunc_NoKeeseGuayTarget(RegisterNoKeeseGuayTarget, { CVAR_NOKEESEGUAYTARGET_NAME });
+static RegisterShipInitFunc initFunc(RegisterNoKeeseGuayTarget, { CVAR_NOKEESEGUAYTARGET_NAME });

--- a/soh/soh/Enhancements/Cheats/NoRedeadFreeze.cpp
+++ b/soh/soh/Enhancements/Cheats/NoRedeadFreeze.cpp
@@ -14,4 +14,4 @@ void RegisterNoRedeadFreeze() {
     COND_VB_SHOULD(VB_REDEAD_GIBDO_FREEZE_LINK, CVAR_NOREDEADFREEZE_VALUE, { *should = false; });
 }
 
-static RegisterShipInitFunc initFunc_NoRedeadFreeze(RegisterNoRedeadFreeze, { CVAR_NOREDEADFREEZE_NAME });
+static RegisterShipInitFunc initFunc(RegisterNoRedeadFreeze, { CVAR_NOREDEADFREEZE_NAME });

--- a/soh/soh/Enhancements/ExtraModes/RupeeDash.cpp
+++ b/soh/soh/Enhancements/ExtraModes/RupeeDash.cpp
@@ -40,4 +40,4 @@ void RegisterRupeeDash() {
     COND_HOOK(OnPlayerUpdate, CVAR_RUPEE_DASH_VALUE, UpdateRupeeDash);
 }
 
-static RegisterShipInitFunc initFunc_RupeeDash(RegisterRupeeDash, { CVAR_RUPEE_DASH_NAME });
+static RegisterShipInitFunc initFunc(RegisterRupeeDash, { CVAR_RUPEE_DASH_NAME });

--- a/soh/soh/Enhancements/ExtraModes/ShadowTag.cpp
+++ b/soh/soh/Enhancements/ExtraModes/ShadowTag.cpp
@@ -47,4 +47,4 @@ void RegisterShadowTag() {
     COND_HOOK(OnSceneInit, true, [](int16_t) { ResetShadowTagSpawnTimer(); });
 }
 
-static RegisterShipInitFunc initFunc_ShadowTag(RegisterShadowTag, { CVAR_SHADOW_TAG_NAME });
+static RegisterShipInitFunc initFunc(RegisterShadowTag, { CVAR_SHADOW_TAG_NAME });

--- a/soh/soh/Enhancements/Graphics/Disable2DBackgrounds.cpp
+++ b/soh/soh/Enhancements/Graphics/Disable2DBackgrounds.cpp
@@ -158,4 +158,4 @@ void Register3DPreRenderedScenes() {
     });
 }
 
-static RegisterShipInitFunc PreRender3DInitFunc(Register3DPreRenderedScenes, { CVAR_NAME });
+static RegisterShipInitFunc initFunc(Register3DPreRenderedScenes, { CVAR_NAME });

--- a/soh/soh/Enhancements/Presets/Presets.cpp
+++ b/soh/soh/Enhancements/Presets/Presets.cpp
@@ -445,4 +445,4 @@ void RegisterPresetsWidgets() {
     LoadPresets();
 }
 
-static RegisterMenuInitFunc initFunc(RegisterPresetsWidgets);
+static RegisterMenuInitFunc menuInitFunc(RegisterPresetsWidgets);

--- a/soh/soh/Enhancements/QoL/DaytimeGS.cpp
+++ b/soh/soh/Enhancements/QoL/DaytimeGS.cpp
@@ -66,4 +66,4 @@ void RegisterDaytimeGoldSkultullas() {
     COND_HOOK(OnSceneSpawnActors, CVAR_DAYTIME_GS_VALUE, OnSpawnNighttimeGoldSkulltula);
 }
 
-static RegisterShipInitFunc initFunc_DaytimeGoldSkulltulas(RegisterDaytimeGoldSkultullas, { CVAR_DAYTIME_GS_NAME });
+static RegisterShipInitFunc initFunc(RegisterDaytimeGoldSkultullas, { CVAR_DAYTIME_GS_NAME });

--- a/soh/soh/Enhancements/Restorations/GraveHoleJumps.cpp
+++ b/soh/soh/Enhancements/Restorations/GraveHoleJumps.cpp
@@ -69,4 +69,4 @@ void RegisterGraveHoleJumps() {
     ApplyGraveyardGeometryPatches();
 }
 
-static RegisterShipInitFunc initFunc_GraveHoleJumps(RegisterGraveHoleJumps, { CVAR_GRAVE_HOLE_NAME });
+static RegisterShipInitFunc initFunc(RegisterGraveHoleJumps, { CVAR_GRAVE_HOLE_NAME });

--- a/soh/soh/Enhancements/Restorations/WideShutterDoorRanges.cpp
+++ b/soh/soh/Enhancements/Restorations/WideShutterDoorRanges.cpp
@@ -27,5 +27,4 @@ void RegisterWideShutterDoorRange() {
     });
 }
 
-static RegisterShipInitFunc initFunc_WideShutterDoorRange(RegisterWideShutterDoorRange,
-                                                          { CVAR_WIDE_SHUTTER_DOOR_RANGE });
+static RegisterShipInitFunc initFunc(RegisterWideShutterDoorRange, { CVAR_WIDE_SHUTTER_DOOR_RANGE });

--- a/soh/soh/Enhancements/TimeSavers/CrawlSpeed.cpp
+++ b/soh/soh/Enhancements/TimeSavers/CrawlSpeed.cpp
@@ -117,4 +117,4 @@ void CrawlSpeed_Register() {
     });
 }
 
-static RegisterShipInitFunc initSpeed(CrawlSpeed_Register, { CVAR_CRAWL_SPEED_NAME });
+static RegisterShipInitFunc initFunc(CrawlSpeed_Register, { CVAR_CRAWL_SPEED_NAME });

--- a/soh/soh/Enhancements/audio/AudioEditor.cpp
+++ b/soh/soh/Enhancements/audio/AudioEditor.cpp
@@ -894,4 +894,4 @@ void RegisterAudioWidgets() {
     SohGui::mSohMenu->AddSearchWidget({ lowerOctaves, "Enhancements", "Audio Editor", "Audio Options" });
 }
 
-static RegisterMenuInitFunc initAudioWidgets(RegisterAudioWidgets);
+static RegisterMenuInitFunc menuInitFunc(RegisterAudioWidgets);

--- a/soh/soh/Enhancements/audio/AudioHooks.cpp
+++ b/soh/soh/Enhancements/audio/AudioHooks.cpp
@@ -40,4 +40,4 @@ void RegisterAudioNotificationHooks() {
     COND_HOOK(OnSeqPlayerInit, CVAR_SEQOVERLAY_VALUE, NotifySequenceName);
 }
 
-static RegisterShipInitFunc notifInitFunc(RegisterAudioNotificationHooks, { CVAR_SEQOVERLAY_NAME });
+static RegisterShipInitFunc initFunc(RegisterAudioNotificationHooks, { CVAR_SEQOVERLAY_NAME });

--- a/soh/soh/Enhancements/controls/Mouse.cpp
+++ b/soh/soh/Enhancements/controls/Mouse.cpp
@@ -148,9 +148,9 @@ void Mouse_RegisterHandleQuickspin() {
     REGISTER_VB_SHOULD(VB_SHOULD_QUICKSPIN, { Mouse_HandleQuickspin(should, va_arg(args, s8*), va_arg(args, s8*)); });
 }
 
-static RegisterShipInitFunc initFunc_shieldRecenter(Mouse_RegisterRecenterCursorOnShield, { CVAR_ENABLE_MOUSE_NAME });
-static RegisterShipInitFunc initFunc_firstPerson(Mouse_RegisterHandleFirstPerson, { CVAR_ENABLE_MOUSE_NAME });
-static RegisterShipInitFunc initFunc_quickspinCount(Mouse_RegisterUpdateQuickspinCount, { CVAR_ENABLE_MOUSE_NAME });
-static RegisterShipInitFunc initFunc_quickspin(Mouse_RegisterHandleQuickspin, { CVAR_ENABLE_MOUSE_NAME });
-static RegisterShipInitFunc initFunc_shieldMove(Mouse_RegisterHandleShield, { CVAR_ENABLE_MOUSE_NAME });
+static RegisterShipInitFunc registerShieldRecenter(Mouse_RegisterRecenterCursorOnShield, { CVAR_ENABLE_MOUSE_NAME });
+static RegisterShipInitFunc registerFirstPerson(Mouse_RegisterHandleFirstPerson, { CVAR_ENABLE_MOUSE_NAME });
+static RegisterShipInitFunc registerQuickspinCount(Mouse_RegisterUpdateQuickspinCount, { CVAR_ENABLE_MOUSE_NAME });
+static RegisterShipInitFunc registerQuickspin(Mouse_RegisterHandleQuickspin, { CVAR_ENABLE_MOUSE_NAME });
+static RegisterShipInitFunc registerShieldMove(Mouse_RegisterHandleShield, { CVAR_ENABLE_MOUSE_NAME });
 } // extern "C"

--- a/soh/soh/Enhancements/controls/SohInputEditorWindow.cpp
+++ b/soh/soh/Enhancements/controls/SohInputEditorWindow.cpp
@@ -1969,4 +1969,4 @@ void RegisterInputEditorWidgets() {
     SohGui::mSohMenu->AddSearchWidget({ dpadText, "Settings", "Controls", "Dpad Controls" });
 }
 
-static RegisterMenuInitFunc initInputWidgets(RegisterInputEditorWidgets);
+static RegisterMenuInitFunc menuInitFunc(RegisterInputEditorWidgets);

--- a/soh/soh/Enhancements/cosmetics/CustomLogoTitle.cpp
+++ b/soh/soh/Enhancements/cosmetics/CustomLogoTitle.cpp
@@ -195,7 +195,7 @@ void RegisterCustomLogoTitle() {
     COND_HOOK(OnZTitleUpdate, true, OnZTitleUpdatePressButtonToSkip);
 }
 
-static RegisterShipInitFunc initFuncAlways(RegisterCustomLogoTitle);
+static RegisterShipInitFunc registerCustomLogo(RegisterCustomLogoTitle);
 
 // // // // // //
 // Bootsequence
@@ -216,7 +216,7 @@ void RegisterCustomLogoTitleBootsequence() {
     COND_HOOK(OnZTitleUpdate, CVAR_BOOTSEQUENCE_VALUE == BOOTSEQUENCE_FILESELECT, OnZTitleUpdateSkipToFileSelect);
 }
 
-static RegisterShipInitFunc initFuncBootsequence(RegisterCustomLogoTitleBootsequence, { CVAR_BOOTSEQUENCE_NAME });
+static RegisterShipInitFunc registerTitleBootSequence(RegisterCustomLogoTitleBootsequence, { CVAR_BOOTSEQUENCE_NAME });
 
 // // // // // //
 // Let it Snow
@@ -230,4 +230,4 @@ void RegisterCustomLogoTitleLetItSnow() {
     shouldDrawIceOnSpinningLogo = CVAR_LETITSNOW_VALUE != CVAR_LETITSNOW_DEFAULT;
 }
 
-static RegisterShipInitFunc initFuncLetItSnow(RegisterCustomLogoTitleLetItSnow, { CVAR_LETITSNOW_NAME });
+static RegisterShipInitFunc registerLetItSnow(RegisterCustomLogoTitleLetItSnow, { CVAR_LETITSNOW_NAME });

--- a/soh/soh/Enhancements/cosmetics/TimeFlowFileSelect.cpp
+++ b/soh/soh/Enhancements/cosmetics/TimeFlowFileSelect.cpp
@@ -17,4 +17,4 @@ void RegisterTimeFlowFileSelect() {
     COND_HOOK(OnFileChooseMain, CVAR_TIMEFLOWFILESELECT_VALUE, OnFileChooseMainTimeFlowFileSelect);
 }
 
-static RegisterShipInitFunc initFunc_TimeFlowFileSelect(RegisterTimeFlowFileSelect, { CVAR_TIMEFLOWFILESELECT_NAME });
+static RegisterShipInitFunc initFunc(RegisterTimeFlowFileSelect, { CVAR_TIMEFLOWFILESELECT_NAME });

--- a/soh/soh/Enhancements/debugger/actorViewer.cpp
+++ b/soh/soh/Enhancements/debugger/actorViewer.cpp
@@ -1228,4 +1228,4 @@ void ActorViewer_RegisterNameTagHooks() {
               [](void* actor) { ActorViewer_AddTagForActor(static_cast<Actor*>(actor)); });
 }
 
-RegisterShipInitFunc nametagInit(ActorViewer_RegisterNameTagHooks, { CVAR_ACTOR_NAME_TAGS_ENABLED_NAME });
+static RegisterShipInitFunc initFunc(ActorViewer_RegisterNameTagHooks, { CVAR_ACTOR_NAME_TAGS_ENABLED_NAME });

--- a/soh/soh/Enhancements/debugger/valueViewer.cpp
+++ b/soh/soh/Enhancements/debugger/valueViewer.cpp
@@ -151,7 +151,7 @@ void RegisterValueViewerHooks() {
     COND_HOOK(OnGameFrameUpdate, CVAR_VALUE, []() { ValueViewer_SetupDraw(); });
 }
 
-RegisterShipInitFunc initFunc(RegisterValueViewerHooks, { CVAR_NAME });
+static RegisterShipInitFunc initFunc(RegisterValueViewerHooks, { CVAR_NAME });
 
 void ValueViewerWindow::DrawElement() {
     ImGui::BeginDisabled(CVarGetInteger(CVAR_SETTING("DisableChanges"), 0));

--- a/soh/soh/Enhancements/randomizer/ShuffleBeehives.cpp
+++ b/soh/soh/Enhancements/randomizer/ShuffleBeehives.cpp
@@ -99,7 +99,7 @@ void RegisterShuffleBeehives() {
     COND_ID_HOOK(OnActorUpdate, ACTOR_OBJ_COMB, shouldRegister, ObjComb_RandomizerUpdate);
 }
 
-static RegisterShipInitFunc initFunc(RegisterShuffleBeehives, { "IS_RANDO" });
+static RegisterShipInitFunc registerShuffleBeehives(RegisterShuffleBeehives, { "IS_RANDO" });
 
 void Rando::StaticData::RegisterBeehiveLocations() {
     static bool registered = false;
@@ -143,4 +143,4 @@ void Rando::StaticData::RegisterBeehiveLocations() {
 }
 
 static ObjectExtension::Register<BeehiveIdentity> RegisterBeehiveIdentity;
-static RegisterShipInitFunc registerFunc(Rando::StaticData::RegisterBeehiveLocations);
+static RegisterShipInitFunc registerBeehiveLocations(Rando::StaticData::RegisterBeehiveLocations);

--- a/soh/soh/Enhancements/randomizer/ShuffleCows.cpp
+++ b/soh/soh/Enhancements/randomizer/ShuffleCows.cpp
@@ -58,7 +58,7 @@ void RegisterShuffleCows() {
     });
 }
 
-static RegisterShipInitFunc initFunc(RegisterShuffleCows, { "IS_RANDO" });
+static RegisterShipInitFunc registerShuffleCows(RegisterShuffleCows, { "IS_RANDO" });
 
 void Rando::StaticData::RegisterCowLocations() {
     static bool registered = false;
@@ -79,4 +79,4 @@ void Rando::StaticData::RegisterCowLocations() {
     // clang-format-on
 }
 
-static RegisterShipInitFunc registerFunc(Rando::StaticData::RegisterCowLocations);
+static RegisterShipInitFunc registerCowLocations(Rando::StaticData::RegisterCowLocations);

--- a/soh/soh/Enhancements/randomizer/ShuffleCrates.cpp
+++ b/soh/soh/Enhancements/randomizer/ShuffleCrates.cpp
@@ -597,5 +597,5 @@ void Rando::StaticData::RegisterCrateLocations() {
 
 static ObjectExtension::Register<CrateIdentity> RegisterCrateIdentity;
 static ObjectExtension::Register<SmallCrateIdentity> RegisterSmallCrateIdentity;
-static RegisterShipInitFunc initFunc(RegisterShuffleCrates, { "IS_RANDO" });
-static RegisterShipInitFunc locFunc(Rando::StaticData::RegisterCrateLocations);
+static RegisterShipInitFunc registerShuffleCrates(RegisterShuffleCrates, { "IS_RANDO" });
+static RegisterShipInitFunc registerCrateLocations(Rando::StaticData::RegisterCrateLocations);

--- a/soh/soh/Enhancements/randomizer/ShuffleFairies.cpp
+++ b/soh/soh/Enhancements/randomizer/ShuffleFairies.cpp
@@ -421,4 +421,4 @@ void Rando::StaticData::RegisterFairyLocations() {
 
 static ObjectExtension::Register<FairyIdentity> RegisterFairyIdentity;
 static RegisterShipInitFunc registerShuffleFairies(RegisterShuffleFairies, { "IS_RANDO" });
-static RegisterShipInitFunc registerShuffleFairiesLocations(Rando::StaticData::RegisterFairyLocations);
+static RegisterShipInitFunc registerFairyLocations(Rando::StaticData::RegisterFairyLocations);

--- a/soh/soh/Enhancements/randomizer/ShuffleFreestanding.cpp
+++ b/soh/soh/Enhancements/randomizer/ShuffleFreestanding.cpp
@@ -287,4 +287,4 @@ void Rando::StaticData::RegisterFreestandingLocations() {
 }
 
 static RegisterShipInitFunc registerShuffleFreestanding(RegisterShuffleFreestanding, { "IS_RANDO" });
-static RegisterShipInitFunc registerShuffleFreestandingLocations(Rando::StaticData::RegisterFreestandingLocations);
+static RegisterShipInitFunc registerFreestandingLocations(Rando::StaticData::RegisterFreestandingLocations);

--- a/soh/soh/Enhancements/randomizer/ShuffleGrass.cpp
+++ b/soh/soh/Enhancements/randomizer/ShuffleGrass.cpp
@@ -530,4 +530,4 @@ void Rando::StaticData::RegisterGrassLocations() {
 
 static ObjectExtension::Register<GrassIdentity> RegisterGrassIdentity;
 static RegisterShipInitFunc registerShuffleGrass(RegisterShuffleGrass, { "IS_RANDO" });
-static RegisterShipInitFunc registerShuffleGrassLocations(Rando::StaticData::RegisterGrassLocations);
+static RegisterShipInitFunc registerGrassLocations(Rando::StaticData::RegisterGrassLocations);

--- a/soh/soh/Enhancements/randomizer/ShufflePots.cpp
+++ b/soh/soh/Enhancements/randomizer/ShufflePots.cpp
@@ -661,4 +661,4 @@ void Rando::StaticData::RegisterPotLocations() {
 
 static ObjectExtension::Register<PotIdentity> RegisterPotIdentity;
 static RegisterShipInitFunc registerShufflePots(RegisterShufflePots, { "IS_RANDO" });
-static RegisterShipInitFunc registerShufflePotLocations(Rando::StaticData::RegisterPotLocations);
+static RegisterShipInitFunc registerPotLocations(Rando::StaticData::RegisterPotLocations);

--- a/soh/soh/Enhancements/randomizer/ShuffleTrees.cpp
+++ b/soh/soh/Enhancements/randomizer/ShuffleTrees.cpp
@@ -262,4 +262,4 @@ void Rando::StaticData::RegisterTreeLocations() {
 
 static ObjectExtension::Register<TreeIdentity> RegisterPotIdentity;
 static RegisterShipInitFunc registerShuffleTrees(RegisterShuffleTrees, { "IS_RANDO" });
-static RegisterShipInitFunc registerShuffleTreeLocations(Rando::StaticData::RegisterTreeLocations);
+static RegisterShipInitFunc registerTreeLocations(Rando::StaticData::RegisterTreeLocations);

--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -2298,5 +2298,5 @@ void RegisterCheckTrackerWidgets() {
         });
 }
 
-static RegisterMenuInitFunc initCheckTrackerWidgets(RegisterCheckTrackerWidgets);
+static RegisterMenuInitFunc menuInitFunc(RegisterCheckTrackerWidgets);
 } // namespace CheckTracker

--- a/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
@@ -2125,4 +2125,4 @@ void RegisterItemTrackerWidgets() {
         { hookshotIdentWidget, "Settings", "Controls", "Camera Controls", "longshot icon" });
 }
 
-static RegisterMenuInitFunc initItemTrackerWidgets(RegisterItemTrackerWidgets);
+static RegisterMenuInitFunc menuInitFunc(RegisterItemTrackerWidgets);

--- a/soh/soh/Enhancements/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.cpp
@@ -1471,5 +1471,5 @@ void RegisterSkipTimerDelay() {
                  });
 }
 
-static RegisterShipInitFunc skipTimerDelay(RegisterSkipTimerDelay,
-                                           { CVAR_ENHANCEMENT("TimeSavers.SkipMiscInteractions"), "IS_RANDO" });
+static RegisterShipInitFunc initFunc(RegisterSkipTimerDelay,
+                                     { CVAR_ENHANCEMENT("TimeSavers.SkipMiscInteractions"), "IS_RANDO" });

--- a/soh/soh/ObjectExtension/ActorMaximumHealth.cpp
+++ b/soh/soh/ObjectExtension/ActorMaximumHealth.cpp
@@ -26,4 +26,4 @@ static void ActorMaximumHealth_Register() {
     });
 }
 
-static RegisterShipInitFunc actorMaximumHealthInit(ActorMaximumHealth_Register);
+static RegisterShipInitFunc initFunc(ActorMaximumHealth_Register);

--- a/soh/soh/SohGui/ResolutionEditor.cpp
+++ b/soh/soh/SohGui/ResolutionEditor.cpp
@@ -597,6 +597,6 @@ bool IsDroppingFrames() {
 }
 
 static RegisterMenuUpdateFunc updateFunc(UpdateResolutionVars, "Settings", "Graphics");
-static RegisterMenuInitFunc initFunc(RegisterResolutionWidgets);
+static RegisterMenuInitFunc menuInitFunc(RegisterResolutionWidgets);
 
 } // namespace SohGui


### PR DESCRIPTION
This standardizes naming conventions for `ShipInit` and `MenuInit` registrations.

This also fixes two instances of `ShipInit` registrations that were missing the `static` keyword, which was what was tripped me up with the menu init functions (which I was also calling "initFunc" at the time) that spurred the "unique initFunc naming" jag we were on, which now is no longer necessary.

The new rules are as follows:
* `ShipInit` registrations start with `initFunc` and `MenuInit` registrations start with `menuInitFunc`
* Must have `static` keyword
* When more than one init func of either type is registered in a single file, all names should then reflect the name of the function being passed into it in some way, or reflect the purpose of that function, starting with either "register" or "init" (e.g. `static RegisterShipInitFunc registerShuffleBeehives(RegisterShuffleBeehives, { "IS_RANDO" });`)



<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4240215601.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4240242015.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4240258454.zip)
<!--- section:artifacts:end -->