### PR TITLE
Allow Enemy Randomizer in Debug Save

### DIFF
--- a/soh/src/code/z_actor.c
+++ b/soh/src/code/z_actor.c
@@ -3321,10 +3321,9 @@ int gMapLoading = 0;
 Actor* Actor_Spawn(ActorContext* actorCtx, PlayState* play, s16 actorId, f32 posX, f32 posY, f32 posZ, s16 rotX,
                    s16 rotY, s16 rotZ, s16 params, s16 canRandomize) {
 
-    uint8_t tryRandomizeEnemy = CVarGetInteger(CVAR_ENHANCEMENT("RandomizedEnemies"), 0) &&
+    uint8_t tryRandomizeEnemy = canRandomize && CVarGetInteger(CVAR_ENHANCEMENT("RandomizedEnemies"), 0) &&
                                 ((gSaveContext.fileNum >= 0 && gSaveContext.fileNum <= 2) ||
-                                 (gSaveContext.fileNum == 0xFF && gSaveContext.gameMode == GAMEMODE_NORMAL)) &&
-                                canRandomize;
+                                 (gSaveContext.fileNum == 0xFF && gSaveContext.gameMode == GAMEMODE_NORMAL));
 
     if (tryRandomizeEnemy) {
         if (!GetRandomizedEnemy(play, &actorId, &posX, &posY, &posZ, &rotX, &rotY, &rotZ, &params)) {

--- a/soh/src/code/z_actor.c
+++ b/soh/src/code/z_actor.c
@@ -3321,8 +3321,11 @@ int gMapLoading = 0;
 Actor* Actor_Spawn(ActorContext* actorCtx, PlayState* play, s16 actorId, f32 posX, f32 posY, f32 posZ, s16 rotX,
                    s16 rotY, s16 rotZ, s16 params, s16 canRandomize) {
 
-    uint8_t tryRandomizeEnemy = CVarGetInteger(CVAR_ENHANCEMENT("RandomizedEnemies"), 0) && gSaveContext.fileNum >= 0 &&
-                                gSaveContext.fileNum <= 2 && canRandomize;
+    uint8_t tryRandomizeEnemy =
+        CVarGetInteger(CVAR_ENHANCEMENT("RandomizedEnemies"), 0) &&
+        ((gSaveContext.fileNum >= 0 && gSaveContext.fileNum <= 2) ||
+         (gSaveContext.fileNum == 0xFF && CVarGetInteger(CVAR_DEVELOPER_TOOLS("DebugEnabled"), 0))) &&
+        canRandomize;
 
     if (tryRandomizeEnemy) {
         if (!GetRandomizedEnemy(play, &actorId, &posX, &posY, &posZ, &rotX, &rotY, &rotZ, &params)) {

--- a/soh/src/code/z_actor.c
+++ b/soh/src/code/z_actor.c
@@ -3321,11 +3321,10 @@ int gMapLoading = 0;
 Actor* Actor_Spawn(ActorContext* actorCtx, PlayState* play, s16 actorId, f32 posX, f32 posY, f32 posZ, s16 rotX,
                    s16 rotY, s16 rotZ, s16 params, s16 canRandomize) {
 
-    uint8_t tryRandomizeEnemy =
-        CVarGetInteger(CVAR_ENHANCEMENT("RandomizedEnemies"), 0) &&
-        ((gSaveContext.fileNum >= 0 && gSaveContext.fileNum <= 2) ||
-         (gSaveContext.fileNum == 0xFF && CVarGetInteger(CVAR_DEVELOPER_TOOLS("DebugEnabled"), 0))) &&
-        canRandomize;
+    uint8_t tryRandomizeEnemy = CVarGetInteger(CVAR_ENHANCEMENT("RandomizedEnemies"), 0) &&
+                                ((gSaveContext.fileNum >= 0 && gSaveContext.fileNum <= 2) ||
+                                 (gSaveContext.fileNum == 0xFF && gSaveContext.gameMode == GAMEMODE_NORMAL)) &&
+                                canRandomize;
 
     if (tryRandomizeEnemy) {
         if (!GetRandomizedEnemy(play, &actorId, &posX, &posY, &posZ, &rotX, &rotY, &rotZ, &params)) {


### PR DESCRIPTION
This PR allows Enemy Randomizer to be used in Debug Save (e.g. when using "Boot To Debug Warp Screen" option) which IMO is a valid game mode.

I think this is useful when quickly testing enemy randomizers.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4637825001.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4637836482.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4637882401.zip)
<!--- section:artifacts:end -->