### PR TITLE
Mod Menu Tweaks

### DIFF
--- a/soh/soh/Enhancements/mod_menu.cpp
+++ b/soh/soh/Enhancements/mod_menu.cpp
@@ -22,6 +22,9 @@ std::vector<std::string> enabledModFiles;
 std::vector<std::string> disabledModFiles;
 std::vector<std::string> unsupportedFiles;
 std::map<std::string, std::filesystem::path> filePaths;
+std::map<std::string, std::string> extChanges;
+static int dragSourceIndex = -1;
+static int dragTargetIndex = -1;
 
 namespace SohGui {
 extern std::shared_ptr<SohMenu> mSohMenu;
@@ -29,7 +32,7 @@ extern std::shared_ptr<SohMenu> mSohMenu;
 
 static WidgetInfo enableModsWidget;
 
-#define CVAR_ENABLED_MODS_NAME CVAR_GENERAL("EnabledMods")
+#define CVAR_ENABLED_MODS_NAME CVAR_SETTING("EnabledMods")
 #define CVAR_ENABLED_MODS_DEFAULT ""
 #define CVAR_ENABLED_MODS_VALUE CVarGetString(CVAR_ENABLED_MODS_NAME, CVAR_ENABLED_MODS_DEFAULT)
 
@@ -58,6 +61,42 @@ void SetEnabledModsCVarValue() {
     }
 
     CVarSetString(CVAR_ENABLED_MODS_NAME, s.c_str());
+}
+
+void AfterModChange() {
+    // disabled mods are always sorted
+    std::sort(disabledModFiles.begin(), disabledModFiles.end(), [](const std::string& a, const std::string& b) {
+        return std::lexicographical_compare(a.begin(), a.end(), b.begin(), b.end(),
+                                            [](char c1, char c2) { return std::tolower(c1) < std::tolower(c2); });
+    });
+}
+
+void ModsPostDragAndDrop() {
+    if (dragTargetIndex != -1) {
+        std::string file = enabledModFiles[dragSourceIndex];
+        enabledModFiles.erase(enabledModFiles.begin() + dragSourceIndex);
+        enabledModFiles.insert(enabledModFiles.begin() + dragTargetIndex, file);
+        dragTargetIndex = dragSourceIndex = -1;
+        AfterModChange();
+    }
+}
+
+void ModsHandleDragAndDrop(std::vector<std::string>& objectList, int targetIndex, const std::string& itemName,
+                           ImGuiDragDropFlags flags = ImGuiDragDropFlags_SourceAllowNullID) {
+    if (ImGui::BeginDragDropSource(flags)) {
+        ImGui::SetDragDropPayload("DragMove", &targetIndex, sizeof(uint32_t));
+        ImGui::Text("Move %s", itemName.c_str());
+        ImGui::EndDragDropSource();
+    }
+
+    if (ImGui::BeginDragDropTarget()) {
+        if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("DragMove")) {
+            IM_ASSERT(payload->DataSize == sizeof(uint32_t));
+            dragSourceIndex = *(const int*)payload->Data;
+            dragTargetIndex = targetIndex;
+        }
+        ImGui::EndDragDropTarget();
+    }
 }
 
 std::vector<std::string> GetEnabledModsFromCVar() {
@@ -111,7 +150,8 @@ void UpdateModFiles(bool init = false, bool reset = false) {
                 if (p.is_directory()) {
                     continue;
                 }
-                std::string filename = p.path().filename().generic_string();
+                std::string filename =
+                    p.path().filename().generic_string().substr(0, p.path().filename().generic_string().rfind("."));
                 std::string extension = p.path().extension().generic_string();
                 ExtensionType extType = GetExtensionType(extension);
                 bool enabled =
@@ -128,21 +168,26 @@ void UpdateModFiles(bool init = false, bool reset = false) {
                 }
                 filePaths.emplace(filename, p.path());
             }
-            std::vector<std::string> enabledTemp(enabledModFiles);
-            for (std::string mod : enabledTemp) {
-                auto archives = GetArchiveManager()->GetArchives();
-                // TODO ensure archives don't get added multiple times. breaks the renaming on close
-                if (filePaths.contains(mod)) {
-                    if (init/* && !GetArchiveManager()->HasFile(filePaths.at(mod).lexically_normal().generic_string())*/) {
+            if (init) {
+                std::vector<std::string> enabledTemp(enabledModFiles);
+                for (std::string mod : enabledTemp) {
+                    // auto archives = GetArchiveManager()->GetArchives();
+                    //  TODO ensure archives don't get added multiple times. breaks the renaming on close
+                    if (filePaths.contains(mod)) {
+                        // if (init/* &&
+                        // !GetArchiveManager()->HasFile(filePaths.at(mod).lexically_normal().generic_string())*/) {
                         GetArchiveManager()->AddArchive(filePaths.at(mod).generic_string());
+                        //}
+                    } else {
+                        enabledModFiles.erase(std::find(enabledModFiles.begin(), enabledModFiles.end(), mod));
+                        //    // if (!init /*&&
+                        //    // GetArchiveManager()->HasFile(filePaths.at(mod).lexically_normal().generic_string())*/)
+                        //    {
+                        //    //
+                        //    GetArchiveManager()->RemoveArchive(filePaths.at(mod).lexically_normal().generic_string());
+                        //    // }
+                        changed = true;
                     }
-                } else {
-                    enabledModFiles.erase(std::find(enabledModFiles.begin(), enabledModFiles.end(), mod));
-                    // if (!init /*&&
-                    // GetArchiveManager()->HasFile(filePaths.at(mod).lexically_normal().generic_string())*/) {
-                    //     GetArchiveManager()->RemoveArchive(filePaths.at(mod).lexically_normal().generic_string());
-                    // }
-                    changed = true;
                 }
             }
         }
@@ -153,16 +198,6 @@ void UpdateModFiles(bool init = false, bool reset = false) {
 }
 
 extern "C" void gfx_texture_cache_clear();
-
-std::map<std::string, std::string> extChanges;
-
-void AfterModChange() {
-    // disabled mods are always sorted
-    std::sort(disabledModFiles.begin(), disabledModFiles.end(), [](const std::string& a, const std::string& b) {
-        return std::lexicographical_compare(a.begin(), a.end(), b.begin(), b.end(),
-                                            [](char c1, char c2) { return std::tolower(c1) < std::tolower(c2); });
-    });
-}
 
 void EnableMod(std::string file) {
     disabledModFiles.erase(std::find(disabledModFiles.begin(), disabledModFiles.end(), file));
@@ -233,15 +268,19 @@ void DrawMods(bool enabled) {
     bool madeAnyChange = false;
     int switchFromIndex = -1;
     int switchToIndex = -1;
+    uint32_t index = 0;
 
     for (int i = 0; i < selectedModFiles.size(); i += 1) {
-        std::string file = selectedModFiles[i].substr(0, selectedModFiles[i].rfind("."));
-        if (UIWidgets::StateButton((file + "_left_right").c_str(), enabled ? ICON_FA_ARROW_LEFT : ICON_FA_ARROW_RIGHT,
+        std::string file = selectedModFiles[i];
+        if (enabled) {
+            ImGui::BeginGroup();
+        }
+        if (UIWidgets::StateButton((file + "_left_right").c_str(), enabled ? ICON_FA_ARROW_RIGHT : ICON_FA_ARROW_LEFT,
                                    ImVec2(25, 25), UIWidgets::ButtonOptions().Color(THEME_COLOR))) {
             if (enabled) {
-                DisableMod(selectedModFiles[i]);
+                DisableMod(file);
             } else {
-                EnableMod(selectedModFiles[i]);
+                EnableMod(file);
             }
         }
 
@@ -276,7 +315,15 @@ void DrawMods(bool enabled) {
             }
         }
 
-        DrawModInfo(file);
+        DrawModInfo(filePaths.at(file).filename().generic_string());
+        if (enabled) {
+            ImGui::EndGroup();
+            ModsHandleDragAndDrop(selectedModFiles, i, file);
+        }
+    }
+
+    if (enabled) {
+        ModsPostDragAndDrop();
     }
 
     if (madeAnyChange) {
@@ -292,8 +339,9 @@ void ModMenuWindow::DrawElement() {
 
     ImGui::TextColored(
         UIWidgets::ColorValues.at(UIWidgets::Colors::Yellow),
-        "Mods are currently not reloaded at runtime.\nClose and re-open Ship for the changes to take effect.\n"
-        "Mod load order is top to bottom. Mods at the top are loaded first.");
+        "Mods are currently not reloaded at runtime. Close and re-open Ship for the changes to take effect.\n"
+        "Drag ordering for the enabled list is available.\nMod load order is top to bottom. Mods at the top are loaded "
+        "first.");
 
     // if (UIWidgets::Button(
     //         "Update", UIWidgets::ButtonOptions({ { .disabled = editing, .disabledTooltip = "Currently editing..." }
@@ -342,8 +390,8 @@ void ModMenuWindow::DrawElement() {
     }
     ImGui::BeginDisabled(!editing);
     if (ImGui::BeginTable("tableMods", 2, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV)) {
-        ImGui::TableSetupColumn("Disabled Mods", ImGuiTableColumnFlags_WidthStretch, 200.0f);
         ImGui::TableSetupColumn("Enabled Mods", ImGuiTableColumnFlags_WidthStretch, 200.0f);
+        ImGui::TableSetupColumn("Disabled Mods", ImGuiTableColumnFlags_WidthStretch, 200.0f);
         ImGui::PushItemFlag(ImGuiItemFlags_Disabled, true);
         ImGui::TableHeadersRow();
         ImGui::PopItemFlag();
@@ -351,16 +399,16 @@ void ModMenuWindow::DrawElement() {
 
         ImGui::TableNextColumn();
 
-        if (ImGui::BeginChild("Disabled Mods", ImVec2(0, -8))) {
-            DrawMods(false);
+        if (ImGui::BeginChild("Enabled Mods", ImVec2(0, -8))) {
+            DrawMods(true);
 
             ImGui::EndChild();
         }
 
         ImGui::TableNextColumn();
 
-        if (ImGui::BeginChild("Enabled Mods", ImVec2(0, -8))) {
-            DrawMods(true);
+        if (ImGui::BeginChild("Disabled Mods", ImVec2(0, -8))) {
+            DrawMods(false);
 
             ImGui::EndChild();
         }

--- a/soh/soh/Enhancements/mod_menu.cpp
+++ b/soh/soh/Enhancements/mod_menu.cpp
@@ -8,8 +8,16 @@
 #include <ranges>
 #include <vector>
 
+typedef enum ExtensionType {
+    EXT_ENABLED,
+    EXT_DISABLED,
+    EXT_UNSUPPORTED,
+} ExtensionType;
+
 std::vector<std::string> enabledModFiles;
 std::vector<std::string> disabledModFiles;
+std::vector<std::string> unsupportedFiles;
+std::map<std::string, std::filesystem::path> filePaths;
 
 #define CVAR_ENABLED_MODS_NAME CVAR_GENERAL("EnabledMods")
 #define CVAR_ENABLED_MODS_DEFAULT ""
@@ -55,40 +63,67 @@ std::shared_ptr<Ship::ArchiveManager> GetArchiveManager() {
     return Ship::Context::GetInstance()->GetResourceManager()->GetArchiveManager();
 }
 
+ExtensionType GetExtensionType(std::string extension) {
+    if (
+#ifdef INCLUDE_MPQ_SUPPORT
+        // .mpq doesn't make sense to support because all tools to make such mods output OTR
+        StringHelper::IEquals(extension, ".otr") /*|| StringHelper::IEquals(extension, ".mpq")*/ ||
+#endif
+        // .zip needs to be excluded because mods are most often distributed in zip archives
+        // and thus could contain .otr/o2r files
+        StringHelper::IEquals(extension, ".o2r") /*|| StringHelper::IEquals(extension, ".zip")*/) {
+        return EXT_ENABLED;
+    } else if (
+#ifdef INCLUDE_MPQ_SUPPORT
+        StringHelper::IEquals(extension, ".disabled1") ||
+#endif
+        StringHelper::IEquals(extension, ".disabled2")) {
+        return EXT_DISABLED;
+    }
+    return EXT_UNSUPPORTED;
+}
+
 void UpdateModFiles(bool init = false) {
     if (init) {
         enabledModFiles.clear();
         enabledModFiles = GetEnabledModsFromCVar();
     }
     disabledModFiles.clear();
+    unsupportedFiles.clear();
     std::string modsPath = Ship::Context::LocateFileAcrossAppDirs("mods", appShortName);
     bool changed = false;
     if (modsPath.length() > 0 && std::filesystem::exists(modsPath)) {
+        std::vector<std::filesystem::path> enabledFiles;
         if (std::filesystem::is_directory(modsPath)) {
             for (const std::filesystem::directory_entry& p : std::filesystem::recursive_directory_iterator(
                      modsPath, std::filesystem::directory_options::follow_directory_symlink)) {
-                std::string extension = p.path().extension().string();
-                if (
-#ifdef INCLUDE_MPQ_SUPPORT
-                    StringHelper::IEquals(extension, ".otr") || StringHelper::IEquals(extension, ".mpq") ||
-#endif
-                    StringHelper::IEquals(extension, ".o2r") || StringHelper::IEquals(extension, ".zip")) {
-                    std::string path = p.path().generic_string();
-                    bool shouldBeEnabled =
-                        std::find(enabledModFiles.begin(), enabledModFiles.end(), path) != enabledModFiles.end();
-
-                    if (!shouldBeEnabled) {
-                        disabledModFiles.push_back(path);
-                    }
+                if (p.is_directory()) {
+                    continue;
                 }
-            }
-            for (std::string mod : enabledModFiles) {
-                std::string path = modsPath + "/" + mod;
-                if (std::filesystem::exists(path)) {
-                    GetArchiveManager()->AddArchive(path);
+                std::string filename = p.path().filename().generic_string();
+                std::string extension = p.path().extension().generic_string();
+                ExtensionType extType = GetExtensionType(extension);
+                bool enabled =
+                    std::find(enabledModFiles.begin(), enabledModFiles.end(), filename) != enabledModFiles.end();
+                if (extType == EXT_ENABLED) {
+                    if (!enabled) {
+                        enabledModFiles.push_back(filename);
+                        changed = true;
+                    }
+                } else if (extType == EXT_DISABLED) {
+                    disabledModFiles.push_back(filename);
                 } else {
-                    changed = true;
+                    unsupportedFiles.push_back(p.path().filename().generic_string());
+                }
+                filePaths.emplace(filename, p.path());
+            }
+            std::vector<std::string> enabledTemp(enabledModFiles);
+            for (std::string mod : enabledTemp) {
+                if (filePaths.contains(mod)) {
+                    GetArchiveManager()->AddArchive(filePaths.at(mod).generic_string());
+                } else {
                     enabledModFiles.erase(std::find(enabledModFiles.begin(), enabledModFiles.end(), mod));
+                    changed = true;
                 }
             }
         }

--- a/soh/soh/Enhancements/mod_menu.cpp
+++ b/soh/soh/Enhancements/mod_menu.cpp
@@ -218,7 +218,7 @@ void DrawMods(bool enabled) {
     int switchToIndex = -1;
     uint32_t index = 0;
 
-    for (int i = 0; i < selectedModFiles.size(); i += 1) {
+    for (int i = selectedModFiles.size() - 1; i >= 0; i--) {
         std::string file = selectedModFiles[i];
         if (enabled) {
             ImGui::BeginGroup();
@@ -236,30 +236,30 @@ void DrawMods(bool enabled) {
         // it's not relevant to reorder disabled mods
         if (enabled) {
             // ImGui::SameLine();
-            if (i == 0) {
+            if (i == selectedModFiles.size() - 1) {
                 ImGui::BeginDisabled();
             }
             if (UIWidgets::StateButton((file + "_up").c_str(), ICON_FA_ARROW_UP, ImVec2(25, 25),
                                        UIWidgets::ButtonOptions().Color(THEME_COLOR))) {
                 madeAnyChange = true;
                 switchFromIndex = i;
-                switchToIndex = i - 1;
+                switchToIndex = i + 1;
             }
-            if (i == 0) {
+            if (i == selectedModFiles.size() - 1) {
                 ImGui::EndDisabled();
             }
 
             ImGui::SameLine();
-            if (i == selectedModFiles.size() - 1) {
+            if (i == 0) {
                 ImGui::BeginDisabled();
             }
             if (UIWidgets::StateButton((file + "_down").c_str(), ICON_FA_ARROW_DOWN, ImVec2(25, 25),
                                        UIWidgets::ButtonOptions().Color(THEME_COLOR))) {
                 madeAnyChange = true;
                 switchFromIndex = i;
-                switchToIndex = i + 1;
+                switchToIndex = i - 1;
             }
-            if (i == selectedModFiles.size() - 1) {
+            if (i == 0) {
                 ImGui::EndDisabled();
             }
         }
@@ -291,8 +291,8 @@ void ModMenuWindow::DrawElement() {
     ImGui::TextColored(
         UIWidgets::ColorValues.at(UIWidgets::Colors::Yellow),
         "Mods are currently not reloaded at runtime. Close and re-open Ship for the changes to take effect.\n"
-        "Drag ordering for the enabled list is available.\nMod load order is top to bottom. Mods at the top are loaded "
-        "first.");
+        "Drag ordering for the enabled list is available.\nMod priority is top to bottom. They override mods listed "
+        "below them.");
 
     // if (UIWidgets::Button(
     //         "Update", UIWidgets::ButtonOptions({ { .disabled = editing, .disabledTooltip = "Currently editing..." }

--- a/soh/soh/Enhancements/mod_menu.cpp
+++ b/soh/soh/Enhancements/mod_menu.cpp
@@ -22,7 +22,6 @@ std::vector<std::string> enabledModFiles;
 std::vector<std::string> disabledModFiles;
 std::vector<std::string> unsupportedFiles;
 std::map<std::string, std::filesystem::path> filePaths;
-std::map<std::string, std::string> extChanges;
 static int dragSourceIndex = -1;
 static int dragTargetIndex = -1;
 
@@ -31,6 +30,7 @@ extern std::shared_ptr<SohMenu> mSohMenu;
 }
 
 static WidgetInfo enableModsWidget;
+static WidgetInfo tabHotkeyWidget;
 
 #define CVAR_ENABLED_MODS_NAME CVAR_SETTING("EnabledMods")
 #define CVAR_ENABLED_MODS_DEFAULT ""
@@ -154,39 +154,24 @@ void UpdateModFiles(bool init = false, bool reset = false) {
                     p.path().filename().generic_string().substr(0, p.path().filename().generic_string().rfind("."));
                 std::string extension = p.path().extension().generic_string();
                 ExtensionType extType = GetExtensionType(extension);
+                if (extType != EXT_ENABLED) {
+                    continue;
+                }
                 bool enabled =
                     std::find(enabledModFiles.begin(), enabledModFiles.end(), filename) != enabledModFiles.end();
-                if (extType == EXT_ENABLED) {
-                    if (!enabled) {
-                        enabledModFiles.push_back(filename);
-                        changed = true;
-                    }
-                } else if (extType == EXT_DISABLED) {
-                    disabledModFiles.push_back(filename);
-                } else {
-                    unsupportedFiles.push_back(p.path().filename().generic_string());
+                if (!enabled) {
+                    enabledModFiles.push_back(filename);
+                    changed = true;
                 }
                 filePaths.emplace(filename, p.path());
             }
             if (init) {
                 std::vector<std::string> enabledTemp(enabledModFiles);
                 for (std::string mod : enabledTemp) {
-                    // auto archives = GetArchiveManager()->GetArchives();
-                    //  TODO ensure archives don't get added multiple times. breaks the renaming on close
                     if (filePaths.contains(mod)) {
-                        // if (init/* &&
-                        // !GetArchiveManager()->HasFile(filePaths.at(mod).lexically_normal().generic_string())*/) {
                         GetArchiveManager()->AddArchive(filePaths.at(mod).generic_string());
-                        //}
                     } else {
                         enabledModFiles.erase(std::find(enabledModFiles.begin(), enabledModFiles.end(), mod));
-                        //    // if (!init /*&&
-                        //    // GetArchiveManager()->HasFile(filePaths.at(mod).lexically_normal().generic_string())*/)
-                        //    {
-                        //    //
-                        //    GetArchiveManager()->RemoveArchive(filePaths.at(mod).lexically_normal().generic_string());
-                        //    // }
-                        changed = true;
                     }
                 }
             }
@@ -202,23 +187,6 @@ extern "C" void gfx_texture_cache_clear();
 void EnableMod(std::string file) {
     disabledModFiles.erase(std::find(disabledModFiles.begin(), disabledModFiles.end(), file));
     enabledModFiles.insert(enabledModFiles.begin(), file);
-    std::string newExt;
-    auto& path = filePaths.at(file);
-    if (path.extension() == ".disabled1") {
-        newExt = ".otr";
-    } else {
-        newExt = ".o2r";
-    }
-    std::string oldPath = path.generic_string();
-    path.replace_extension(newExt);
-    std::string newPath = path.generic_string();
-    if (!extChanges.contains(oldPath)) {
-        if (extChanges.contains(newPath)) {
-            extChanges.erase(newPath);
-        } else {
-            extChanges.emplace(oldPath, newPath);
-        }
-    }
 
     // TODO: runtime changes
     // GetArchiveManager()->AddArchive(file);
@@ -228,23 +196,6 @@ void EnableMod(std::string file) {
 void DisableMod(std::string file) {
     enabledModFiles.erase(std::find(enabledModFiles.begin(), enabledModFiles.end(), file));
     disabledModFiles.insert(disabledModFiles.begin(), file);
-    std::string newExt;
-    auto& path = filePaths.at(file);
-    if (path.extension() == ".otr") {
-        newExt = ".disabled1";
-    } else {
-        newExt = ".disabled2";
-    }
-    std::string oldPath = path.generic_string();
-    path.replace_extension(newExt);
-    std::string newPath = path.generic_string();
-    if (!extChanges.contains(oldPath)) {
-        if (extChanges.contains(newPath)) {
-            extChanges.erase(newPath);
-        } else {
-            extChanges.emplace(oldPath, newPath);
-        }
-    }
 
     // TODO: runtime changes
     // GetArchiveManager()->RemoveArchive(file);
@@ -254,9 +205,6 @@ void DisableMod(std::string file) {
 void DrawModInfo(std::string file) {
     ImGui::SameLine();
     ImGui::Text("%s", file.c_str());
-}
-
-void RemoveExtension(std::string& file) {
 }
 
 void DrawMods(bool enabled) {
@@ -275,18 +223,19 @@ void DrawMods(bool enabled) {
         if (enabled) {
             ImGui::BeginGroup();
         }
-        if (UIWidgets::StateButton((file + "_left_right").c_str(), enabled ? ICON_FA_ARROW_RIGHT : ICON_FA_ARROW_LEFT,
-                                   ImVec2(25, 25), UIWidgets::ButtonOptions().Color(THEME_COLOR))) {
-            if (enabled) {
-                DisableMod(file);
-            } else {
-                EnableMod(file);
-            }
-        }
+        // if (UIWidgets::StateButton((file + "_left_right").c_str(), enabled ? ICON_FA_ARROW_RIGHT :
+        // ICON_FA_ARROW_LEFT,
+        //                            ImVec2(25, 25), UIWidgets::ButtonOptions().Color(THEME_COLOR))) {
+        //     if (enabled) {
+        //         DisableMod(file);
+        //     } else {
+        //         EnableMod(file);
+        //     }
+        // }
 
         // it's not relevant to reorder disabled mods
         if (enabled) {
-            ImGui::SameLine();
+            // ImGui::SameLine();
             if (i == 0) {
                 ImGui::BeginDisabled();
             }
@@ -336,6 +285,8 @@ bool editing = false;
 
 void ModMenuWindow::DrawElement() {
     SohGui::mSohMenu->MenuDrawItem(enableModsWidget, 200, THEME_COLOR);
+    ImGui::SameLine();
+    SohGui::mSohMenu->MenuDrawItem(tabHotkeyWidget, 200, THEME_COLOR);
 
     ImGui::TextColored(
         UIWidgets::ColorValues.at(UIWidgets::Colors::Yellow),
@@ -361,7 +312,6 @@ void ModMenuWindow::DrawElement() {
         ImGui::SameLine();
         if (UIWidgets::Button("Cancel", UIWidgets::ButtonOptions().Size(UIWidgets::Sizes::Inline))) {
             editing = false;
-            extChanges.clear();
             UpdateModFiles(false, true);
         }
         ImGui::SameLine();
@@ -371,12 +321,6 @@ void ModMenuWindow::DrawElement() {
                                   "Application currently requires a restart. Save the mod info and close SoH?", "Close",
                                   "Cancel", [&]() {
                                       // TODO: runtime changes
-                                      // GetArchiveManager()->RemoveArchive(file);
-                                      for (auto& [op, np] : extChanges) {
-                                          GetArchiveManager()->RemoveArchive(op);
-                                          std::filesystem::rename(op, np);
-                                      }
-                                      extChanges.clear();
                                       SetEnabledModsCVarValue();
                                       // TODO: runtime changes
                                       /*
@@ -391,7 +335,7 @@ void ModMenuWindow::DrawElement() {
     ImGui::BeginDisabled(!editing);
     if (ImGui::BeginTable("tableMods", 2, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV)) {
         ImGui::TableSetupColumn("Enabled Mods", ImGuiTableColumnFlags_WidthStretch, 200.0f);
-        ImGui::TableSetupColumn("Disabled Mods", ImGuiTableColumnFlags_WidthStretch, 200.0f);
+        // ImGui::TableSetupColumn("Disabled Mods", ImGuiTableColumnFlags_WidthStretch, 200.0f);
         ImGui::PushItemFlag(ImGuiItemFlags_Disabled, true);
         ImGui::TableHeadersRow();
         ImGui::PopItemFlag();
@@ -405,13 +349,13 @@ void ModMenuWindow::DrawElement() {
             ImGui::EndChild();
         }
 
-        ImGui::TableNextColumn();
+        /*ImGui::TableNextColumn();
 
         if (ImGui::BeginChild("Disabled Mods", ImVec2(0, -8))) {
             DrawMods(false);
 
             ImGui::EndChild();
-        }
+        }*/
 
         ImGui::EndTable();
     }
@@ -425,14 +369,26 @@ void ModMenuWindow::InitElement() {
 void RegisterModMenuWidgets() {
     enableModsWidget = { .name = "Enable Mods", .type = WidgetType::WIDGET_CVAR_CHECKBOX };
     enableModsWidget.CVar(CVAR_SETTING("AltAssets"))
+        .RaceDisable(false)
         .Options(UIWidgets::CheckboxOptions({ { .disabledTooltip = "Temporarily disabled while editing mods list." } })
                      .Color(THEME_COLOR)
-                     .Tooltip("Toggle mods. For graphics mods, this means toggling between default and mod graphics."))
+                     .Tooltip("Toggle mods. For graphics mods, this means toggling between default and mod graphics.")
+                     .DefaultValue(true))
         .PreFunc([&](WidgetInfo& info) {
             auto options = std::static_pointer_cast<UIWidgets::CheckboxOptions>(info.options);
             options->disabled = editing;
         });
-    SohGui::mSohMenu->AddSearchWidget({ enableModsWidget, "Enhancements", "Mod Menu", "Top", "alternat assets" });
+    SohGui::mSohMenu->AddSearchWidget({ enableModsWidget, "Settings", "Mod Menu", "Top", "alternat assets" });
+
+    tabHotkeyWidget = { .name = "Mods Tab Hotkey", .type = WidgetType::WIDGET_CVAR_CHECKBOX };
+    tabHotkeyWidget.CVar(CVAR_SETTING("Mods.AlternateAssetsHotkey"))
+        .RaceDisable(false)
+        .Options(UIWidgets::CheckboxOptions()
+                     .Color(THEME_COLOR)
+                     .Tooltip("Allows pressing the Tab key to toggle mods")
+                     .DefaultValue(true));
+    SohGui::mSohMenu->AddSearchWidget(
+        { enableModsWidget, "Settings", "Mod Menu", "Top", "alternat assets tab hotkey" });
 }
 
 static RegisterMenuInitFunc menuInitFunc(RegisterModMenuWidgets);

--- a/soh/soh/Enhancements/mod_menu.cpp
+++ b/soh/soh/Enhancements/mod_menu.cpp
@@ -12,12 +12,6 @@
 #include "soh/SohGui/SohMenu.h"
 #include "soh/SohGui/SohGui.hpp"
 
-typedef enum ExtensionType {
-    EXT_ENABLED,
-    EXT_DISABLED,
-    EXT_UNSUPPORTED,
-} ExtensionType;
-
 std::vector<std::string> enabledModFiles;
 std::vector<std::string> disabledModFiles;
 std::vector<std::string> unsupportedFiles;
@@ -112,7 +106,7 @@ std::shared_ptr<Ship::ArchiveManager> GetArchiveManager() {
     return Ship::Context::GetInstance()->GetResourceManager()->GetArchiveManager();
 }
 
-ExtensionType GetExtensionType(std::string extension) {
+bool IsValidExtension(std::string extension) {
     if (
 #ifdef INCLUDE_MPQ_SUPPORT
         // .mpq doesn't make sense to support because all tools to make such mods output OTR
@@ -121,15 +115,9 @@ ExtensionType GetExtensionType(std::string extension) {
         // .zip needs to be excluded because mods are most often distributed in zip archives
         // and thus could contain .otr/o2r files
         StringHelper::IEquals(extension, ".o2r") /*|| StringHelper::IEquals(extension, ".zip")*/) {
-        return EXT_ENABLED;
-    } else if (
-#ifdef INCLUDE_MPQ_SUPPORT
-        StringHelper::IEquals(extension, ".disabled1") ||
-#endif
-        StringHelper::IEquals(extension, ".disabled2")) {
-        return EXT_DISABLED;
+        return true;
     }
-    return EXT_UNSUPPORTED;
+    return false;
 }
 
 void UpdateModFiles(bool init = false, bool reset = false) {
@@ -153,8 +141,7 @@ void UpdateModFiles(bool init = false, bool reset = false) {
                 std::string filename =
                     p.path().filename().generic_string().substr(0, p.path().filename().generic_string().rfind("."));
                 std::string extension = p.path().extension().generic_string();
-                ExtensionType extType = GetExtensionType(extension);
-                if (extType != EXT_ENABLED) {
+                if (!IsValidExtension(extension)) {
                     continue;
                 }
                 bool enabled =

--- a/soh/soh/Enhancements/mod_menu.cpp
+++ b/soh/soh/Enhancements/mod_menu.cpp
@@ -1,12 +1,16 @@
-#include "mod_menu.h"
-#include <ship/utils/StringHelper.h>
-#include <libultraship/classes.h>
-#include "soh/SohGui/SohGui.hpp"
-#include "soh/OTRGlobals.h"
-#include "soh/resource/type/Skeleton.h"
 #include <map>
 #include <ranges>
 #include <vector>
+
+#include <libultraship/classes.h>
+#include <ship/utils/StringHelper.h>
+
+#include "mod_menu.h"
+#include "soh/OTRGlobals.h"
+#include "soh/resource/type/Skeleton.h"
+#include "soh/SohGui/MenuTypes.h"
+#include "soh/SohGui/SohMenu.h"
+#include "soh/SohGui/SohGui.hpp"
 
 typedef enum ExtensionType {
     EXT_ENABLED,
@@ -18,6 +22,13 @@ std::vector<std::string> enabledModFiles;
 std::vector<std::string> disabledModFiles;
 std::vector<std::string> unsupportedFiles;
 std::map<std::string, std::filesystem::path> filePaths;
+bool prevModsState;
+
+namespace SohGui {
+extern std::shared_ptr<SohMenu> mSohMenu;
+}
+
+static WidgetInfo enableModsWidget;
 
 #define CVAR_ENABLED_MODS_NAME CVAR_GENERAL("EnabledMods")
 #define CVAR_ENABLED_MODS_DEFAULT ""
@@ -90,6 +101,7 @@ void UpdateModFiles(bool init = false) {
     }
     disabledModFiles.clear();
     unsupportedFiles.clear();
+    filePaths.clear();
     std::string modsPath = Ship::Context::LocateFileAcrossAppDirs("mods", appShortName);
     bool changed = false;
     if (modsPath.length() > 0 && std::filesystem::exists(modsPath)) {
@@ -135,15 +147,9 @@ void UpdateModFiles(bool init = false) {
 
 extern "C" void gfx_texture_cache_clear();
 
-void AfterModChange() {
-    SetEnabledModsCVarValue();
-    // TODO: runtime changes
-    /*
-    gfx_texture_cache_clear();
-    SOH::SkeletonPatcher::ClearSkeletons();
-    */
-    Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
+std::map<std::string, std::string> extChanges;
 
+void AfterModChange() {
     // disabled mods are always sorted
     std::sort(disabledModFiles.begin(), disabledModFiles.end(), [](const std::string& a, const std::string& b) {
         return std::lexicographical_compare(a.begin(), a.end(), b.begin(), b.end(),
@@ -154,6 +160,23 @@ void AfterModChange() {
 void EnableMod(std::string file) {
     disabledModFiles.erase(std::find(disabledModFiles.begin(), disabledModFiles.end(), file));
     enabledModFiles.insert(enabledModFiles.begin(), file);
+    std::string newExt;
+    auto& path = filePaths.at(file);
+    if (path.extension() == ".disabled1") {
+        newExt = ".otr";
+    } else {
+        newExt = ".o2r";
+    }
+    std::string oldPath = path.generic_string();
+    path.replace_extension(newExt);
+    std::string newPath = path.generic_string();
+    if (!extChanges.contains(oldPath)) {
+        if (extChanges.contains(newPath)) {
+            extChanges.erase(newPath);
+        } else {
+            extChanges.emplace(oldPath, newPath);
+        }
+    }
 
     // TODO: runtime changes
     // GetArchiveManager()->AddArchive(file);
@@ -163,6 +186,23 @@ void EnableMod(std::string file) {
 void DisableMod(std::string file) {
     enabledModFiles.erase(std::find(enabledModFiles.begin(), enabledModFiles.end(), file));
     disabledModFiles.insert(disabledModFiles.begin(), file);
+    std::string newExt;
+    auto& path = filePaths.at(file);
+    if (path.extension() == ".otr") {
+        newExt = ".disabled1";
+    } else {
+        newExt = ".disabled2";
+    }
+    std::string oldPath = path.generic_string();
+    path.replace_extension(newExt);
+    std::string newPath = path.generic_string();
+    if (!extChanges.contains(oldPath)) {
+        if (extChanges.contains(newPath)) {
+            extChanges.erase(newPath);
+        } else {
+            extChanges.emplace(oldPath, newPath);
+        }
+    }
 
     // TODO: runtime changes
     // GetArchiveManager()->RemoveArchive(file);
@@ -172,6 +212,10 @@ void DisableMod(std::string file) {
 void DrawModInfo(std::string file) {
     ImGui::SameLine();
     ImGui::Text("%s", file.c_str());
+}
+
+void RemoveExtension(std::string& file) {
+    
 }
 
 void DrawMods(bool enabled) {
@@ -185,13 +229,13 @@ void DrawMods(bool enabled) {
     int switchToIndex = -1;
 
     for (int i = 0; i < selectedModFiles.size(); i += 1) {
-        std::string file = selectedModFiles[i];
+        std::string file = selectedModFiles[i].substr(0, selectedModFiles[i].rfind("."));
         if (UIWidgets::StateButton((file + "_left_right").c_str(), enabled ? ICON_FA_ARROW_LEFT : ICON_FA_ARROW_RIGHT,
                                    ImVec2(25, 25), UIWidgets::ButtonOptions().Color(THEME_COLOR))) {
             if (enabled) {
-                DisableMod(file);
+                DisableMod(selectedModFiles[i]);
             } else {
-                EnableMod(file);
+                EnableMod(selectedModFiles[i]);
             }
         }
 
@@ -235,19 +279,68 @@ void DrawMods(bool enabled) {
     }
 }
 
+bool editing = false;
+
 void ModMenuWindow::DrawElement() {
-    ImGui::BeginDisabled(CVarGetInteger(CVAR_SETTING("DisableChanges"), 0));
+    ImGui::BeginDisabled(editing);
+    SohGui::mSohMenu->MenuDrawItem(enableModsWidget, 200, THEME_COLOR);
+    if (editing) {
+        UIWidgets::Tooltip("Disabled while editing mods.");
+    } else {
+        UIWidgets::Tooltip("Toggle mods. For graphics mods, this means toggling between default and mod graphics.");
+    }
+    ImGui::EndDisabled();
 
-    const ImVec4 yellow = ImVec4(1, 1, 0, 1);
+    ImGui::TextColored(UIWidgets::ColorValues.at(UIWidgets::Colors::Yellow),
+        "Mods are currently not reloaded at runtime.\nClose and re-open Ship for the changes to take effect.");
 
-    ImGui::TextColored(
-        yellow, "Mods are currently not reloaded at runtime.\nClose and re-open Ship for the changes to take effect.");
-
-    if (UIWidgets::Button("Update", UIWidgets::ButtonOptions().Size(ImVec2(250.0f, 0.0f)).Color(THEME_COLOR))) {
+    if (UIWidgets::Button("Update",
+                          UIWidgets::ButtonOptions({ .disabled = editing, .disabledTooltip = "Currently editing..." })
+                              .Size(UIWidgets::Sizes::Inline)
+                              .Color(THEME_COLOR))) {
         UpdateModFiles();
     }
-    UIWidgets::Tooltip("Re-check the mods folder for new files");
-
+    ImGui::SameLine();
+    if (UIWidgets::Button("Edit",
+        UIWidgets::ButtonOptions({ .disabled = editing, .disabledTooltip = "Already editing..." })
+            .Size(UIWidgets::Sizes::Inline)
+            .Color(THEME_COLOR))) {
+        editing = true;
+    }
+    if (editing) {
+        ImGui::SameLine();
+        if (UIWidgets::Button("Cancel", UIWidgets::ButtonOptions()
+                                            .Size(UIWidgets::Sizes::Inline))) {
+            editing = false;
+            extChanges.clear();
+            UpdateModFiles(true);
+        }
+        ImGui::SameLine();
+        if (UIWidgets::Button("Apply & Close", UIWidgets::ButtonOptions()
+                .Size(UIWidgets::Sizes::Inline)
+                .Color(THEME_COLOR))) {
+            SohGui::RegisterPopup(
+                "Apply & Close", "Application currently requires a restart. Save the mod info and close SoH?", "Close", "Cancel",
+                [&]() {
+                    // TODO: runtime changes
+                    // GetArchiveManager()->RemoveArchive(file);
+                    for (auto& [op, np] : extChanges) {
+                        GetArchiveManager()->RemoveArchive(op);
+                        std::filesystem::rename(op, np);
+                    }
+                    extChanges.clear();
+                    SetEnabledModsCVarValue();
+                    // TODO: runtime changes
+                    /*
+                    gfx_texture_cache_clear();
+                    SOH::SkeletonPatcher::ClearSkeletons();
+                    */
+                    Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+                    Ship::Context::GetInstance()->GetWindow()->Close();
+                });
+        }
+    }
+    ImGui::BeginDisabled(!editing);
     if (ImGui::BeginTable("tableMods", 2, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV)) {
         ImGui::TableSetupColumn("Disabled Mods", ImGuiTableColumnFlags_WidthStretch, 200.0f);
         ImGui::TableSetupColumn("Enabled Mods", ImGuiTableColumnFlags_WidthStretch, 200.0f);
@@ -274,10 +367,19 @@ void ModMenuWindow::DrawElement() {
 
         ImGui::EndTable();
     }
-
     ImGui::EndDisabled();
 }
 
 void ModMenuWindow::InitElement() {
     UpdateModFiles(true);
 }
+
+void RegisterModMenuWidgets() {
+    enableModsWidget = { .name = "Enable Mods", .type = WidgetType::WIDGET_CVAR_CHECKBOX };
+    enableModsWidget.CVar(CVAR_SETTING("AltAssets"))
+        .Options(UIWidgets::CheckboxOptions()
+                     .Color(THEME_COLOR));
+    SohGui::mSohMenu->AddSearchWidget({ enableModsWidget, "Enhancements", "Mod Menu", "Top", "alternat assets" });
+}
+
+static RegisterMenuInitFunc menuInitFunc(RegisterModMenuWidgets);

--- a/soh/soh/Enhancements/mod_menu.cpp
+++ b/soh/soh/Enhancements/mod_menu.cpp
@@ -22,7 +22,6 @@ std::vector<std::string> enabledModFiles;
 std::vector<std::string> disabledModFiles;
 std::vector<std::string> unsupportedFiles;
 std::map<std::string, std::filesystem::path> filePaths;
-bool prevModsState;
 
 namespace SohGui {
 extern std::shared_ptr<SohMenu> mSohMenu;
@@ -94,8 +93,8 @@ ExtensionType GetExtensionType(std::string extension) {
     return EXT_UNSUPPORTED;
 }
 
-void UpdateModFiles(bool init = false) {
-    if (init) {
+void UpdateModFiles(bool init = false, bool reset = false) {
+    if (init || reset) {
         enabledModFiles.clear();
         enabledModFiles = GetEnabledModsFromCVar();
     }
@@ -131,10 +130,18 @@ void UpdateModFiles(bool init = false) {
             }
             std::vector<std::string> enabledTemp(enabledModFiles);
             for (std::string mod : enabledTemp) {
+                auto archives = GetArchiveManager()->GetArchives();
+                // TODO ensure archives don't get added multiple times. breaks the renaming on close
                 if (filePaths.contains(mod)) {
-                    GetArchiveManager()->AddArchive(filePaths.at(mod).generic_string());
+                    if (init/* && !GetArchiveManager()->HasFile(filePaths.at(mod).lexically_normal().generic_string())*/) {
+                        GetArchiveManager()->AddArchive(filePaths.at(mod).generic_string());
+                    }
                 } else {
                     enabledModFiles.erase(std::find(enabledModFiles.begin(), enabledModFiles.end(), mod));
+                    // if (!init /*&&
+                    // GetArchiveManager()->HasFile(filePaths.at(mod).lexically_normal().generic_string())*/) {
+                    //     GetArchiveManager()->RemoveArchive(filePaths.at(mod).lexically_normal().generic_string());
+                    // }
                     changed = true;
                 }
             }
@@ -288,13 +295,14 @@ void ModMenuWindow::DrawElement() {
         "Mods are currently not reloaded at runtime.\nClose and re-open Ship for the changes to take effect.\n"
         "Mod load order is top to bottom. Mods at the top are loaded first.");
 
-    if (UIWidgets::Button(
-            "Update", UIWidgets::ButtonOptions({ { .disabled = editing, .disabledTooltip = "Currently editing..." } })
-                          .Size(UIWidgets::Sizes::Inline)
-                          .Color(THEME_COLOR))) {
-        UpdateModFiles();
-    }
-    ImGui::SameLine();
+    // if (UIWidgets::Button(
+    //         "Update", UIWidgets::ButtonOptions({ { .disabled = editing, .disabledTooltip = "Currently editing..." }
+    //         })
+    //                       .Size(UIWidgets::Sizes::Inline)
+    //                       .Color(THEME_COLOR))) {
+    //     UpdateModFiles();
+    // }
+    // ImGui::SameLine();
     if (UIWidgets::Button("Edit",
                           UIWidgets::ButtonOptions({ { .disabled = editing, .disabledTooltip = "Already editing..." } })
                               .Size(UIWidgets::Sizes::Inline)
@@ -306,7 +314,7 @@ void ModMenuWindow::DrawElement() {
         if (UIWidgets::Button("Cancel", UIWidgets::ButtonOptions().Size(UIWidgets::Sizes::Inline))) {
             editing = false;
             extChanges.clear();
-            UpdateModFiles(true);
+            UpdateModFiles(false, true);
         }
         ImGui::SameLine();
         if (UIWidgets::Button("Apply & Close",
@@ -369,9 +377,13 @@ void ModMenuWindow::InitElement() {
 void RegisterModMenuWidgets() {
     enableModsWidget = { .name = "Enable Mods", .type = WidgetType::WIDGET_CVAR_CHECKBOX };
     enableModsWidget.CVar(CVAR_SETTING("AltAssets"))
-        .Options(UIWidgets::CheckboxOptions()
+        .Options(UIWidgets::CheckboxOptions({ { .disabledTooltip = "Temporarily disabled while editing mods list." } })
                      .Color(THEME_COLOR)
-                     .Tooltip("Toggle mods. For graphics mods, this means toggling between default and mod graphics."));
+                     .Tooltip("Toggle mods. For graphics mods, this means toggling between default and mod graphics."))
+        .PreFunc([&](WidgetInfo& info) {
+            auto options = std::static_pointer_cast<UIWidgets::CheckboxOptions>(info.options);
+            options->disabled = editing;
+        });
     SohGui::mSohMenu->AddSearchWidget({ enableModsWidget, "Enhancements", "Mod Menu", "Top", "alternat assets" });
 }
 

--- a/soh/soh/Enhancements/mod_menu.cpp
+++ b/soh/soh/Enhancements/mod_menu.cpp
@@ -58,34 +58,43 @@ std::shared_ptr<Ship::ArchiveManager> GetArchiveManager() {
 void UpdateModFiles(bool init = false) {
     if (init) {
         enabledModFiles.clear();
+        enabledModFiles = GetEnabledModsFromCVar();
     }
     disabledModFiles.clear();
-    std::vector<std::string> enabledMods = GetEnabledModsFromCVar();
     std::string modsPath = Ship::Context::LocateFileAcrossAppDirs("mods", appShortName);
+    bool changed = false;
     if (modsPath.length() > 0 && std::filesystem::exists(modsPath)) {
         if (std::filesystem::is_directory(modsPath)) {
             for (const std::filesystem::directory_entry& p : std::filesystem::recursive_directory_iterator(
                      modsPath, std::filesystem::directory_options::follow_directory_symlink)) {
                 std::string extension = p.path().extension().string();
                 if (
-#ifndef EXCLUDE_MPQ_SUPPORT
+#ifdef INCLUDE_MPQ_SUPPORT
                     StringHelper::IEquals(extension, ".otr") || StringHelper::IEquals(extension, ".mpq") ||
 #endif
                     StringHelper::IEquals(extension, ".o2r") || StringHelper::IEquals(extension, ".zip")) {
                     std::string path = p.path().generic_string();
-                    bool shouldBeEnabled = std::find(enabledMods.begin(), enabledMods.end(), path) != enabledMods.end();
+                    bool shouldBeEnabled =
+                        std::find(enabledModFiles.begin(), enabledModFiles.end(), path) != enabledModFiles.end();
 
-                    if (shouldBeEnabled) {
-                        if (init) {
-                            enabledModFiles.push_back(path);
-                            GetArchiveManager()->AddArchive(path);
-                        }
-                    } else {
+                    if (!shouldBeEnabled) {
                         disabledModFiles.push_back(path);
                     }
                 }
             }
+            for (std::string mod : enabledModFiles) {
+                std::string path = modsPath + "/" + mod;
+                if (std::filesystem::exists(path)) {
+                    GetArchiveManager()->AddArchive(path);
+                } else {
+                    changed = true;
+                    enabledModFiles.erase(std::find(enabledModFiles.begin(), enabledModFiles.end(), mod));
+                }
+            }
         }
+    }
+    if (changed) {
+        SetEnabledModsCVarValue();
     }
 }
 

--- a/soh/soh/Enhancements/mod_menu.cpp
+++ b/soh/soh/Enhancements/mod_menu.cpp
@@ -281,18 +281,12 @@ void DrawMods(bool enabled) {
 bool editing = false;
 
 void ModMenuWindow::DrawElement() {
-    ImGui::BeginDisabled(editing);
     SohGui::mSohMenu->MenuDrawItem(enableModsWidget, 200, THEME_COLOR);
-    if (editing) {
-        UIWidgets::Tooltip("Disabled while editing mods.");
-    } else {
-        UIWidgets::Tooltip("Toggle mods. For graphics mods, this means toggling between default and mod graphics.");
-    }
-    ImGui::EndDisabled();
 
     ImGui::TextColored(
         UIWidgets::ColorValues.at(UIWidgets::Colors::Yellow),
-        "Mods are currently not reloaded at runtime.\nClose and re-open Ship for the changes to take effect.");
+        "Mods are currently not reloaded at runtime.\nClose and re-open Ship for the changes to take effect.\n"
+        "Mod load order is top to bottom. Mods at the top are loaded first.");
 
     if (UIWidgets::Button(
             "Update", UIWidgets::ButtonOptions({ { .disabled = editing, .disabledTooltip = "Currently editing..." } })
@@ -374,7 +368,10 @@ void ModMenuWindow::InitElement() {
 
 void RegisterModMenuWidgets() {
     enableModsWidget = { .name = "Enable Mods", .type = WidgetType::WIDGET_CVAR_CHECKBOX };
-    enableModsWidget.CVar(CVAR_SETTING("AltAssets")).Options(UIWidgets::CheckboxOptions().Color(THEME_COLOR));
+    enableModsWidget.CVar(CVAR_SETTING("AltAssets"))
+        .Options(UIWidgets::CheckboxOptions()
+                     .Color(THEME_COLOR)
+                     .Tooltip("Toggle mods. For graphics mods, this means toggling between default and mod graphics."));
     SohGui::mSohMenu->AddSearchWidget({ enableModsWidget, "Enhancements", "Mod Menu", "Top", "alternat assets" });
 }
 

--- a/soh/soh/Enhancements/mod_menu.cpp
+++ b/soh/soh/Enhancements/mod_menu.cpp
@@ -215,7 +215,6 @@ void DrawModInfo(std::string file) {
 }
 
 void RemoveExtension(std::string& file) {
-    
 }
 
 void DrawMods(bool enabled) {
@@ -291,53 +290,52 @@ void ModMenuWindow::DrawElement() {
     }
     ImGui::EndDisabled();
 
-    ImGui::TextColored(UIWidgets::ColorValues.at(UIWidgets::Colors::Yellow),
+    ImGui::TextColored(
+        UIWidgets::ColorValues.at(UIWidgets::Colors::Yellow),
         "Mods are currently not reloaded at runtime.\nClose and re-open Ship for the changes to take effect.");
 
-    if (UIWidgets::Button("Update",
-                          UIWidgets::ButtonOptions({ .disabled = editing, .disabledTooltip = "Currently editing..." })
-                              .Size(UIWidgets::Sizes::Inline)
-                              .Color(THEME_COLOR))) {
+    if (UIWidgets::Button(
+            "Update", UIWidgets::ButtonOptions({ { .disabled = editing, .disabledTooltip = "Currently editing..." } })
+                          .Size(UIWidgets::Sizes::Inline)
+                          .Color(THEME_COLOR))) {
         UpdateModFiles();
     }
     ImGui::SameLine();
     if (UIWidgets::Button("Edit",
-        UIWidgets::ButtonOptions({ .disabled = editing, .disabledTooltip = "Already editing..." })
-            .Size(UIWidgets::Sizes::Inline)
-            .Color(THEME_COLOR))) {
+                          UIWidgets::ButtonOptions({ { .disabled = editing, .disabledTooltip = "Already editing..." } })
+                              .Size(UIWidgets::Sizes::Inline)
+                              .Color(THEME_COLOR))) {
         editing = true;
     }
     if (editing) {
         ImGui::SameLine();
-        if (UIWidgets::Button("Cancel", UIWidgets::ButtonOptions()
-                                            .Size(UIWidgets::Sizes::Inline))) {
+        if (UIWidgets::Button("Cancel", UIWidgets::ButtonOptions().Size(UIWidgets::Sizes::Inline))) {
             editing = false;
             extChanges.clear();
             UpdateModFiles(true);
         }
         ImGui::SameLine();
-        if (UIWidgets::Button("Apply & Close", UIWidgets::ButtonOptions()
-                .Size(UIWidgets::Sizes::Inline)
-                .Color(THEME_COLOR))) {
-            SohGui::RegisterPopup(
-                "Apply & Close", "Application currently requires a restart. Save the mod info and close SoH?", "Close", "Cancel",
-                [&]() {
-                    // TODO: runtime changes
-                    // GetArchiveManager()->RemoveArchive(file);
-                    for (auto& [op, np] : extChanges) {
-                        GetArchiveManager()->RemoveArchive(op);
-                        std::filesystem::rename(op, np);
-                    }
-                    extChanges.clear();
-                    SetEnabledModsCVarValue();
-                    // TODO: runtime changes
-                    /*
-                    gfx_texture_cache_clear();
-                    SOH::SkeletonPatcher::ClearSkeletons();
-                    */
-                    Ship::Context::GetInstance()->GetConsoleVariables()->Save();
-                    Ship::Context::GetInstance()->GetWindow()->Close();
-                });
+        if (UIWidgets::Button("Apply & Close",
+                              UIWidgets::ButtonOptions().Size(UIWidgets::Sizes::Inline).Color(THEME_COLOR))) {
+            SohGui::RegisterPopup("Apply & Close",
+                                  "Application currently requires a restart. Save the mod info and close SoH?", "Close",
+                                  "Cancel", [&]() {
+                                      // TODO: runtime changes
+                                      // GetArchiveManager()->RemoveArchive(file);
+                                      for (auto& [op, np] : extChanges) {
+                                          GetArchiveManager()->RemoveArchive(op);
+                                          std::filesystem::rename(op, np);
+                                      }
+                                      extChanges.clear();
+                                      SetEnabledModsCVarValue();
+                                      // TODO: runtime changes
+                                      /*
+                                      gfx_texture_cache_clear();
+                                      SOH::SkeletonPatcher::ClearSkeletons();
+                                      */
+                                      Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+                                      Ship::Context::GetInstance()->GetWindow()->Close();
+                                  });
         }
     }
     ImGui::BeginDisabled(!editing);
@@ -376,9 +374,7 @@ void ModMenuWindow::InitElement() {
 
 void RegisterModMenuWidgets() {
     enableModsWidget = { .name = "Enable Mods", .type = WidgetType::WIDGET_CVAR_CHECKBOX };
-    enableModsWidget.CVar(CVAR_SETTING("AltAssets"))
-        .Options(UIWidgets::CheckboxOptions()
-                     .Color(THEME_COLOR));
+    enableModsWidget.CVar(CVAR_SETTING("AltAssets")).Options(UIWidgets::CheckboxOptions().Color(THEME_COLOR));
     SohGui::mSohMenu->AddSearchWidget({ enableModsWidget, "Enhancements", "Mod Menu", "Top", "alternat assets" });
 }
 

--- a/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
@@ -2116,9 +2116,9 @@ void RegisterItemTrackerWidgets() {
     hookshotIdentWidget.CVar(CVAR_SETTING("FreeLook.Enabled"))
         .Options(CheckboxOptions()
                      .Color(THEME_COLOR)
-                     .Tooltip("Shows an 'H' or an 'L' to more easiely distinguish between Hookshot and Longshot."));
+                     .Tooltip("Shows an 'H' or an 'L' to more easily distinguish between Hookshot and Longshot."));
     SohGui::mSohMenu->AddSearchWidget(
-        { hookshotIdentWidget, "Settings", "Controls", "Camera Controls", "longshot icon" });
+        { hookshotIdentWidget, "Randomizer", "Item Tracker", "General Settings" });
 }
 
 static RegisterMenuInitFunc menuInitFunc(RegisterItemTrackerWidgets);

--- a/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
@@ -2117,8 +2117,7 @@ void RegisterItemTrackerWidgets() {
         .Options(CheckboxOptions()
                      .Color(THEME_COLOR)
                      .Tooltip("Shows an 'H' or an 'L' to more easily distinguish between Hookshot and Longshot."));
-    SohGui::mSohMenu->AddSearchWidget(
-        { hookshotIdentWidget, "Randomizer", "Item Tracker", "General Settings" });
+    SohGui::mSohMenu->AddSearchWidget({ hookshotIdentWidget, "Randomizer", "Item Tracker", "General Settings" });
 }
 
 static RegisterMenuInitFunc menuInitFunc(RegisterItemTrackerWidgets);

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -299,7 +299,7 @@ void OTRGlobals::Initialize() {
 
     // tell LUS to reserve 3 SoH specific threads (Game, Audio, Save)
     context->InitResourceManager(OTRFiles, {}, 3);
-    prevAltAssets = CVarGetInteger(CVAR_SETTING("AltAssets"), 0);
+    prevAltAssets = CVarGetInteger(CVAR_SETTING("AltAssets"), 1);
     context->GetResourceManager()->SetAltAssetsEnabled(prevAltAssets);
 
     auto controlDeck = std::make_shared<LUS::ControlDeck>(std::vector<CONTROLLERBUTTONS_T>({
@@ -1482,7 +1482,7 @@ extern "C" void Graph_StartFrame() {
 #endif
         case KbScancode::LUS_KB_TAB: {
             if (CVarGetInteger(CVAR_SETTING("Mods.AlternateAssetsHotkey"), 1)) {
-                CVarSetInteger(CVAR_SETTING("AltAssets"), !CVarGetInteger(CVAR_SETTING("AltAssets"), 0));
+                CVarSetInteger(CVAR_SETTING("AltAssets"), !CVarGetInteger(CVAR_SETTING("AltAssets"), 1));
             }
             break;
         }
@@ -1570,7 +1570,7 @@ extern "C" void Graph_ProcessGfxCommands(Gfx* commands) {
         }
     }
 
-    bool curAltAssets = CVarGetInteger(CVAR_SETTING("AltAssets"), 0);
+    bool curAltAssets = CVarGetInteger(CVAR_SETTING("AltAssets"), 1);
     if (prevAltAssets != curAltAssets) {
         prevAltAssets = curAltAssets;
         Ship::Context::GetInstance()->GetResourceManager()->SetAltAssetsEnabled(curAltAssets);

--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -537,12 +537,6 @@ void SohMenu::AddMenuEnhancements() {
     path.column = SECTION_COLUMN_1;
 
     AddWidget(path, "Mods", WIDGET_SEPARATOR_TEXT);
-    AddWidget(path, "Use Alternate Assets", WIDGET_CVAR_CHECKBOX)
-        .CVar(CVAR_SETTING("AltAssets"))
-        .RaceDisable(false)
-        .Options(CheckboxOptions().Tooltip(
-            "Toggle between standard assets and alternate assets. Usually mods will indicate if "
-            "this setting has to be used or not."));
     AddWidget(path, "Disable Bomb Billboarding", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("DisableBombBillboarding"))
         .RaceDisable(false)

--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -1902,15 +1902,6 @@ void SohMenu::AddMenuEnhancements() {
             .CVar(timer.timeEnable)
             .Callback([](WidgetInfo& info) { TimeDisplayUpdateDisplayOptions(); });
     }
-
-    // Mod Menu
-    path.sidebarName = "Mod Menu";
-    AddSidebarEntry("Enhancements", path.sidebarName, 1);
-    AddWidget(path, "Popout Mod Menu Window", WIDGET_WINDOW_BUTTON)
-        .CVar(CVAR_WINDOW("ModMenu"))
-        .WindowName("Mod Menu")
-        .HideInSearch(true)
-        .Options(WindowButtonOptions().Tooltip("Enables the separate Mod Menu Window."));
 }
 
 } // namespace SohGui

--- a/soh/soh/SohGui/SohMenuSettings.cpp
+++ b/soh/soh/SohGui/SohMenuSettings.cpp
@@ -178,11 +178,6 @@ void SohMenu::AddMenuSettings() {
         .RaceDisable(false)
         .Options(CheckboxOptions().Tooltip(
             "Search input box gets autofocus when visible. Does not affect using other widgets."));
-    AddWidget(path, "Alt Assets Tab hotkey", WIDGET_CVAR_CHECKBOX)
-        .CVar(CVAR_SETTING("Mods.AlternateAssetsHotkey"))
-        .RaceDisable(false)
-        .Options(
-            CheckboxOptions().Tooltip("Allows pressing the Tab key to toggle alternate assets").DefaultValue(true));
     AddWidget(path, "Open App Files Folder", WIDGET_BUTTON)
         .RaceDisable(false)
         .Callback([](WidgetInfo& info) {
@@ -505,6 +500,15 @@ void SohMenu::AddMenuSettings() {
             });
         })
         .Options(ButtonOptions().Tooltip("Displays a test notification."));
+
+    // Mod Menu
+    path.sidebarName = "Mod Menu";
+    AddSidebarEntry("Settings", path.sidebarName, 1);
+    AddWidget(path, "Popout Mod Menu Window", WIDGET_WINDOW_BUTTON)
+        .CVar(CVAR_WINDOW("ModMenu"))
+        .WindowName("Mod Menu")
+        .HideInSearch(true)
+        .Options(WindowButtonOptions().Tooltip("Enables the separate Mod Menu Window."));
 }
 
 } // namespace SohGui

--- a/soh/soh/config/ConfigMigrators.h
+++ b/soh/soh/config/ConfigMigrators.h
@@ -1503,7 +1503,7 @@ std::vector<Migration> version3Migrations = {
     { MigrationAction::Rename, "gOpenMenuBar", "gSettings.OpenMenuBar" },
     { MigrationAction::Rename, "gRandomizeSkipChildStealth", "gRandoSettings.SkipChildStealth" },
     { MigrationAction::Rename, "gRandomizeExcludedLocations", "gRandoSettings.ExcludedLocations" },
-    { MigrationAction::Rename, "gAltAssets", "gEnhancements.AltAssets" },
+    { MigrationAction::Rename, "gAltAssets", "gSettings.AltAssets" },
     { MigrationAction::Rename, "gMSAAValue", "gSettings.MSAAValue" },
     { MigrationAction::Rename, "gInternalResolution", "gSettings.InternalResolution" },
     { MigrationAction::Rename, "gTextureFilter", "gSettings.TextureFilter" },


### PR DESCRIPTION
This takes a look at what "enabled by default" would look like as far as mod menu is concerned. This is handled by:
* Maintaining the CVar for enabled mod order
* On load, available mod files are compared against mod order. If file exists but isn't in the order list, the file is added to the end of the list. If file is in the ordering, but doesn't exist in the file system anymore, file is removed from the list
* Disabled mods' extensions are changed (disabled1 for otr, disabled2 for o2r) to make them separable on load

This also:
* Moves the Use Alternate Assets checkbox to the mod menu and renames it to Enable Mods
* Adds information about what the list order means for load order
* Has the mod lists uninteractable by default, changed with the new Edit button
* Entering Edit mode brings up two more buttons, Cancel and "Apply & Close". Cancel restores the state of the lists before editing started. Apply & Close finalizes the reordering and saves it to the CVar, and executes the pending renames, before closing SoH

In my opinion, this makes the eventual change to live change application much simpler. It was absolutely more complex than the original attempt with disabled by default, but I think the change will be worth it on the user end.

Drag and drop ordering still planned in the future, as well as possibly grouping.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4312632739.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4312634540.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4312645335.zip)
<!--- section:artifacts:end -->