### PR TITLE
Invisible Navi option

### DIFF
--- a/soh/soh/Enhancements/audio/DisableNaviCallAudio.cpp
+++ b/soh/soh/Enhancements/audio/DisableNaviCallAudio.cpp
@@ -1,0 +1,13 @@
+#include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
+#include "soh/ShipInit.hpp"
+
+static constexpr int32_t CVAR_DISABLENAVICALLAUDIO_DEFAULT = 0;
+#define CVAR_DISABLENAVICALLAUDIO_NAME CVAR_AUDIO("DisableNaviCallAudio")
+#define CVAR_DISABLENAVICALLAUDIO_VALUE \
+    CVarGetInteger(CVAR_DISABLENAVICALLAUDIO_NAME, CVAR_DISABLENAVICALLAUDIO_DEFAULT)
+
+void RegisterDisableNaviCallAudio() {
+    COND_VB_SHOULD(VB_PLAY_NAVI_CALL_SOUND, CVAR_DISABLENAVICALLAUDIO_VALUE, { *should = false; });
+}
+
+static RegisterShipInitFunc initFunc(RegisterDisableNaviCallAudio, { CVAR_DISABLENAVICALLAUDIO_NAME });

--- a/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
+++ b/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
@@ -1874,6 +1874,10 @@ void DrawSillyTab() {
 
     UIWidgets::Separator(true, true, 2.0f, 2.0f);
 
+    UIWidgets::CVarCheckbox(
+        "Invisible Navi", CVAR_COSMETIC("InvisibleNavi"),
+        UIWidgets::CheckboxOptions().Color(THEME_COLOR).Tooltip("Makes Navi invisible and disables her sounds."));
+
     UIWidgets::CVarCheckbox("Let It Snow", CVAR_GENERAL("LetItSnow"),
                             UIWidgets::CheckboxOptions()
                                 .Color(THEME_COLOR)

--- a/soh/soh/Enhancements/cosmetics/InvisibleNavi.cpp
+++ b/soh/soh/Enhancements/cosmetics/InvisibleNavi.cpp
@@ -56,6 +56,8 @@ void RegisterInvisibleNavi() {
     });
 
     COND_VB_SHOULD(VB_PLAY_NAVI_CALL_SOUND, CVAR_INVISIBLENAVI_VALUE, { *should = false; });
+
+    COND_VB_SHOULD(VB_PLAY_INTRO_NAVI_SOUNDS, CVAR_INVISIBLENAVI_VALUE, { *should = false; });
 }
 
 static RegisterShipInitFunc initFunc(RegisterInvisibleNavi, { CVAR_INVISIBLENAVI_NAME });

--- a/soh/soh/Enhancements/cosmetics/InvisibleNavi.cpp
+++ b/soh/soh/Enhancements/cosmetics/InvisibleNavi.cpp
@@ -1,0 +1,61 @@
+#include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
+#include "soh/ShipInit.hpp"
+
+extern "C" {
+#include "src/overlays/actors/ovl_En_Elf/z_en_elf.h"
+}
+
+static constexpr int32_t CVAR_INVISIBLENAVI_DEFAULT = 0;
+#define CVAR_INVISIBLENAVI_NAME CVAR_COSMETIC("InvisibleNavi")
+#define CVAR_INVISIBLENAVI_VALUE CVarGetInteger(CVAR_INVISIBLENAVI_NAME, CVAR_INVISIBLENAVI_DEFAULT)
+
+void RegisterInvisibleNavi() {
+    COND_VB_SHOULD(VB_FAIRY_DRAW, CVAR_INVISIBLENAVI_VALUE, {
+        EnElf* enElf = va_arg(args, EnElf*);
+        if (enElf->actor.params == FAIRY_NAVI) {
+            *should = false;
+        }
+    });
+
+    COND_VB_SHOULD(VB_FAIRY_SPAWN_SPARKLES, CVAR_INVISIBLENAVI_VALUE, {
+        EnElf* enElf = va_arg(args, EnElf*);
+        if (enElf->actor.params == FAIRY_NAVI) {
+            *should = false;
+        }
+    });
+
+    COND_VB_SHOULD(VB_FAIRY_PLAY_C_UP_TALK_SOUND, CVAR_INVISIBLENAVI_VALUE, {
+        EnElf* enElf = va_arg(args, EnElf*);
+        if (enElf->actor.params == FAIRY_NAVI) {
+            *should = false;
+        }
+    });
+
+    COND_VB_SHOULD(VB_FAIRY_PLAY_DASH_SOUND, CVAR_INVISIBLENAVI_VALUE, {
+        EnElf* enElf = va_arg(args, EnElf*);
+        if (enElf->actor.params == FAIRY_NAVI) {
+            *should = false;
+        }
+    });
+
+    COND_VB_SHOULD(VB_FAIRY_PLAY_VANISH_SOUND, CVAR_INVISIBLENAVI_VALUE, {
+        EnElf* enElf = va_arg(args, EnElf*);
+        if (enElf->actor.params == FAIRY_NAVI) {
+            *should = false;
+        }
+    });
+
+    COND_VB_SHOULD(VB_FAIRY_UPDATE_LIGHTS, CVAR_INVISIBLENAVI_VALUE, {
+        EnElf* enElf = va_arg(args, EnElf*);
+        if (enElf->actor.params == FAIRY_NAVI) {
+            // Force Navi's light radius to zero.
+            Lights_PointGlowSetInfo(&enElf->lightInfoGlow, enElf->actor.world.pos.x, enElf->actor.world.pos.y,
+                                    enElf->actor.world.pos.z, 255, 255, 255, 0);
+            *should = false;
+        }
+    });
+
+    COND_VB_SHOULD(VB_PLAY_NAVI_CALL_SOUND, CVAR_INVISIBLENAVI_VALUE, { *should = false; });
+}
+
+static RegisterShipInitFunc initFunc(RegisterInvisibleNavi, { CVAR_INVISIBLENAVI_NAME });

--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -521,11 +521,59 @@ typedef enum {
 
     // #### `result`
     // ```c
+    // ((this->unk_2A8 != 8) && !(this->fairyFlags & 8))
+    // ```
+    // #### `args`
+    // - `*EnElf`
+    VB_FAIRY_DRAW,
+
+    // #### `result`
+    // ```c
     // true
     // ```
     // #### `args`
     // - `*EnElf`
     VB_FAIRY_HEAL,
+
+    // #### `result`
+    // ```c
+    // true
+    // ```
+    // #### `args`
+    // - `*EnElf`
+    VB_FAIRY_SPAWN_SPARKLES,
+
+    // #### `result`
+    // ```c
+    // true
+    // ```
+    // #### `args`
+    // - `*EnElf`
+    VB_FAIRY_PLAY_C_UP_TALK_SOUND,
+
+    // #### `result`
+    // ```c
+    // true
+    // ```
+    // #### `args`
+    // - `*EnElf`
+    VB_FAIRY_PLAY_DASH_SOUND,
+
+    // #### `result`
+    // ```c
+    // true
+    // ```
+    // #### `args`
+    // - `*EnElf`
+    VB_FAIRY_PLAY_VANISH_SOUND,
+
+    // #### `result`
+    // ```c
+    // true
+    // ```
+    // #### `args`
+    // - `*EnElf`
+    VB_FAIRY_UPDATE_LIGHTS,
 
     // #### `result`
     // ```c
@@ -1603,6 +1651,14 @@ typedef enum {
     // #### `args`
     // - None
     VB_PLAY_NABOORU_CAPTURED_CS,
+
+    // #### `result`
+    // ```c
+    // true
+    // ```
+    // #### `args`
+    // - `int32_t` (naviCallState) (promoted from `uint16_t` by va_arg)
+    VB_PLAY_NAVI_CALL_SOUND,
 
     // #### `result`
     // ```c

--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -541,6 +541,7 @@ typedef enum {
     // ```
     // #### `args`
     // - `*EnElf`
+    // - `int32_t` (sparkleLife)
     VB_FAIRY_SPAWN_SPARKLES,
 
     // #### `result`
@@ -1627,6 +1628,14 @@ typedef enum {
     // #### `args`
     // - None
     VB_PLAY_GORON_FREE_CS,
+
+    // #### `result`
+    // ```c
+    // true
+    // ```
+    // #### `args`
+    // - `*ObjectKankyo`
+    VB_PLAY_INTRO_NAVI_SOUNDS,
 
     // #### `result`
     // ```c

--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -2807,7 +2807,7 @@ void Interface_SetNaviCall(PlayState* play, u16 naviCallState) {
 
     if (((naviCallState == 0x1D) || (naviCallState == 0x1E)) && !interfaceCtx->naviCalling &&
         (play->csCtx.state == CS_STATE_IDLE)) {
-        if (!CVarGetInteger(CVAR_AUDIO("DisableNaviCallAudio"), 0)) {
+        if (GameInteractor_Should(VB_PLAY_NAVI_CALL_SOUND, true, naviCallState)) {
             // clang-format off
             if (naviCallState == 0x1E) { Audio_PlaySoundGeneral(NA_SE_VO_NAVY_CALL, &gSfxDefaultPos, 4,
                                                                 &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb); }

--- a/soh/src/overlays/actors/ovl_En_Elf/z_en_elf.c
+++ b/soh/src/overlays/actors/ovl_En_Elf/z_en_elf.c
@@ -1206,7 +1206,7 @@ void EnElf_SpawnSparkles(EnElf* this, PlayState* play, s32 sparkleLife) {
     Color_RGBA8 primColor;
     Color_RGBA8 envColor;
 
-    if (GameInteractor_Should(VB_FAIRY_SPAWN_SPARKLES, true, this)) {
+    if (GameInteractor_Should(VB_FAIRY_SPAWN_SPARKLES, true, this, sparkleLife)) {
         sparklePos.x = Rand_CenteredFloat(6.0f) + this->actor.world.pos.x;
         sparklePos.y = (Rand_ZeroOne() * 6.0f) + this->actor.world.pos.y;
         sparklePos.z = Rand_CenteredFloat(6.0f) + this->actor.world.pos.z;

--- a/soh/src/overlays/actors/ovl_En_Elf/z_en_elf.c
+++ b/soh/src/overlays/actors/ovl_En_Elf/z_en_elf.c
@@ -817,28 +817,30 @@ void EnElf_UpdateLights(EnElf* this, PlayState* play) {
     s16 glowLightRadius;
     Player* player;
 
-    glowLightRadius = 100;
+    if (GameInteractor_Should(VB_FAIRY_UPDATE_LIGHTS, true, this)) {
+        glowLightRadius = 100;
 
-    if (this->unk_2A8 == 8) {
-        glowLightRadius = 0;
+        if (this->unk_2A8 == 8) {
+            glowLightRadius = 0;
+        }
+
+        if (this->fairyFlags & 0x20) {
+            player = GET_PLAYER(play);
+            Lights_PointNoGlowSetInfo(&this->lightInfoNoGlow, player->actor.world.pos.x,
+                                      (s16)(player->actor.world.pos.y) + 60.0f, player->actor.world.pos.z, 255, 255,
+                                      255, 200);
+        } else {
+            Lights_PointNoGlowSetInfo(&this->lightInfoNoGlow, this->actor.world.pos.x, this->actor.world.pos.y,
+                                      this->actor.world.pos.z, 255, 255, 255, -1);
+        }
+
+        Lights_PointGlowSetInfo(&this->lightInfoGlow, this->actor.world.pos.x, this->actor.world.pos.y,
+                                this->actor.world.pos.z, 255, 255, 255, glowLightRadius);
+
+        this->unk_2BC = Math_Atan2S(this->actor.velocity.z, this->actor.velocity.x);
+
+        Actor_SetScale(&this->actor, this->actor.scale.x);
     }
-
-    if (this->fairyFlags & 0x20) {
-        player = GET_PLAYER(play);
-        Lights_PointNoGlowSetInfo(&this->lightInfoNoGlow, player->actor.world.pos.x,
-                                  (s16)(player->actor.world.pos.y) + 60.0f, player->actor.world.pos.z, 255, 255, 255,
-                                  200);
-    } else {
-        Lights_PointNoGlowSetInfo(&this->lightInfoNoGlow, this->actor.world.pos.x, this->actor.world.pos.y,
-                                  this->actor.world.pos.z, 255, 255, 255, -1);
-    }
-
-    Lights_PointGlowSetInfo(&this->lightInfoGlow, this->actor.world.pos.x, this->actor.world.pos.y,
-                            this->actor.world.pos.z, 255, 255, 255, glowLightRadius);
-
-    this->unk_2BC = Math_Atan2S(this->actor.velocity.z, this->actor.velocity.x);
-
-    Actor_SetScale(&this->actor, this->actor.scale.x);
 }
 
 void func_80A03CF8(EnElf* this, PlayState* play) {
@@ -872,7 +874,9 @@ void func_80A03CF8(EnElf* this, PlayState* play) {
         if ((play->sceneNum == SCENE_LINKS_HOUSE) && (gSaveContext.sceneSetupIndex == 4)) {
             // play dash sound as Navi enters Links house in the intro
             if (play->csCtx.frames == 55) {
-                Audio_PlayActorSound2(&this->actor, NA_SE_EV_FAIRY_DASH);
+                if (GameInteractor_Should(VB_FAIRY_PLAY_DASH_SOUND, true, this)) {
+                    Audio_PlayActorSound2(&this->actor, NA_SE_EV_FAIRY_DASH);
+                }
             }
 
             // play dash sound in intervals as Navi is waking up Link in the intro
@@ -884,7 +888,9 @@ void func_80A03CF8(EnElf* this, PlayState* play) {
                 } else {
                     if (this->actor.world.pos.y < prevPos.y) {
                         this->fairyFlags |= 0x40;
-                        Audio_PlayActorSound2(&this->actor, NA_SE_EV_FAIRY_DASH);
+                        if (GameInteractor_Should(VB_FAIRY_PLAY_DASH_SOUND, true, this)) {
+                            Audio_PlayActorSound2(&this->actor, NA_SE_EV_FAIRY_DASH);
+                        }
                     }
                 }
             }
@@ -967,7 +973,9 @@ void func_80A03CF8(EnElf* this, PlayState* play) {
                             this->fairyFlags |= 2;
 
                             if (this->unk_2C7 == 0) {
-                                Audio_PlayActorSound2(&this->actor, NA_SE_EV_FAIRY_DASH);
+                                if (GameInteractor_Should(VB_FAIRY_PLAY_DASH_SOUND, true, this)) {
+                                    Audio_PlayActorSound2(&this->actor, NA_SE_EV_FAIRY_DASH);
+                                }
                             }
 
                             this->unk_2C0 = 0x64;
@@ -1015,7 +1023,9 @@ void func_80A04414(EnElf* this, PlayState* play) {
         this->unk_29C = 1.0f;
 
         if (this->unk_2C7 == 0) {
-            Audio_PlayActorSound2(&this->actor, NA_SE_EV_FAIRY_DASH);
+            if (GameInteractor_Should(VB_FAIRY_PLAY_DASH_SOUND, true, this)) {
+                Audio_PlayActorSound2(&this->actor, NA_SE_EV_FAIRY_DASH);
+            }
         }
 
     } else {
@@ -1105,7 +1115,9 @@ void func_80A0461C(EnElf* this, PlayState* play) {
                             temp = 0;
                         } else {
                             if (this->unk_2C7 == 0) {
-                                Audio_PlayActorSound2(&this->actor, NA_SE_EV_NAVY_VANISH);
+                                if (GameInteractor_Should(VB_FAIRY_PLAY_VANISH_SOUND, true, this)) {
+                                    Audio_PlayActorSound2(&this->actor, NA_SE_EV_NAVY_VANISH);
+                                }
                             }
                             temp = 7;
                         }
@@ -1149,7 +1161,9 @@ void func_80A0461C(EnElf* this, PlayState* play) {
                 if (!(player->stateFlags2 & PLAYER_STATE2_NAVI_ACTIVE)) {
                     temp = 7;
                     if (this->unk_2C7 == 0) {
-                        Audio_PlayActorSound2(&this->actor, NA_SE_EV_NAVY_VANISH);
+                        if (GameInteractor_Should(VB_FAIRY_PLAY_VANISH_SOUND, true, this)) {
+                            Audio_PlayActorSound2(&this->actor, NA_SE_EV_NAVY_VANISH);
+                        }
                     }
                 }
                 break;
@@ -1159,7 +1173,9 @@ void func_80A0461C(EnElf* this, PlayState* play) {
                     this->unk_2C0 = 42;
                     temp = 11;
                     if (this->unk_2C7 == 0) {
-                        Audio_PlayActorSound2(&this->actor, NA_SE_EV_FAIRY_DASH);
+                        if (GameInteractor_Should(VB_FAIRY_PLAY_DASH_SOUND, true, this)) {
+                            Audio_PlayActorSound2(&this->actor, NA_SE_EV_FAIRY_DASH);
+                        }
                     }
                 }
                 break;
@@ -1190,20 +1206,22 @@ void EnElf_SpawnSparkles(EnElf* this, PlayState* play, s32 sparkleLife) {
     Color_RGBA8 primColor;
     Color_RGBA8 envColor;
 
-    sparklePos.x = Rand_CenteredFloat(6.0f) + this->actor.world.pos.x;
-    sparklePos.y = (Rand_ZeroOne() * 6.0f) + this->actor.world.pos.y;
-    sparklePos.z = Rand_CenteredFloat(6.0f) + this->actor.world.pos.z;
+    if (GameInteractor_Should(VB_FAIRY_SPAWN_SPARKLES, true, this)) {
+        sparklePos.x = Rand_CenteredFloat(6.0f) + this->actor.world.pos.x;
+        sparklePos.y = (Rand_ZeroOne() * 6.0f) + this->actor.world.pos.y;
+        sparklePos.z = Rand_CenteredFloat(6.0f) + this->actor.world.pos.z;
 
-    primColor.r = this->innerColor.r;
-    primColor.g = this->innerColor.g;
-    primColor.b = this->innerColor.b;
+        primColor.r = this->innerColor.r;
+        primColor.g = this->innerColor.g;
+        primColor.b = this->innerColor.b;
 
-    envColor.r = this->outerColor.r;
-    envColor.g = this->outerColor.g;
-    envColor.b = this->outerColor.b;
+        envColor.r = this->outerColor.r;
+        envColor.g = this->outerColor.g;
+        envColor.b = this->outerColor.b;
 
-    EffectSsKiraKira_SpawnDispersed(play, &sparklePos, &sparkleVelocity, &sparkleAccel, &primColor, &envColor, 1000,
-                                    sparkleLife);
+        EffectSsKiraKira_SpawnDispersed(play, &sparklePos, &sparkleVelocity, &sparkleAccel, &primColor, &envColor, 1000,
+                                        sparkleLife);
+    }
 }
 
 void func_80A04D90(EnElf* this, PlayState* play) {
@@ -1392,7 +1410,9 @@ void func_80A053F0(Actor* thisx, PlayState* play) {
     }
 
     if (Actor_ProcessTalkRequest(thisx, play)) {
-        func_800F4524(&gSfxDefaultPos, NA_SE_VO_SK_LAUGH, 0x20);
+        if (GameInteractor_Should(VB_FAIRY_PLAY_C_UP_TALK_SOUND, true, this)) {
+            func_800F4524(&gSfxDefaultPos, NA_SE_VO_SK_LAUGH, 0x20);
+        }
         thisx->focus.pos = thisx->world.pos;
 
         if (thisx->textId == ElfMessage_GetCUpText(play)) {
@@ -1506,7 +1526,7 @@ void EnElf_Draw(Actor* thisx, PlayState* play) {
     Gfx* dListHead;
     Player* player = GET_PLAYER(play);
 
-    if ((this->unk_2A8 != 8) && !(this->fairyFlags & 8)) {
+    if (GameInteractor_Should(VB_FAIRY_DRAW, ((this->unk_2A8 != 8) && !(this->fairyFlags & 8)), this)) {
         if (!(player->stateFlags1 & PLAYER_STATE1_FIRST_PERSON) || (kREG(90) < this->actor.projectedPos.z)) {
             dListHead = Graph_Alloc(play->state.gfxCtx, sizeof(Gfx) * 4);
 

--- a/soh/src/overlays/actors/ovl_Object_Kankyo/z_object_kankyo.c
+++ b/soh/src/overlays/actors/ovl_Object_Kankyo/z_object_kankyo.c
@@ -8,6 +8,7 @@
 #include "objects/object_demo_kekkai/object_demo_kekkai.h"
 #include "objects/gameplay_keep/gameplay_keep.h"
 #include "objects/object_spot02_objects/object_spot02_objects.h"
+#include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
 #include "soh/frame_interpolation.h"
 #include <assert.h>
@@ -205,23 +206,25 @@ void ObjectKankyo_Fairies(ObjectKankyo* this, PlayState* play) {
             dist = 1.0f;
         }
 
-        func_800F436C(&sSoundPos, NA_SE_EV_NAVY_FLY - SFX_FLAG, (0.4f * dist) + 0.6f);
-        switch (play->csCtx.frames) {
-            case 473:
-                Sfx_PlaySfxCentered2(NA_SE_VO_NA_HELLO_3);
-                break;
+        if (GameInteractor_Should(VB_PLAY_INTRO_NAVI_SOUNDS, true, this)) {
+            func_800F436C(&sSoundPos, NA_SE_EV_NAVY_FLY - SFX_FLAG, (0.4f * dist) + 0.6f);
+            switch (play->csCtx.frames) {
+                case 473:
+                    Sfx_PlaySfxCentered2(NA_SE_VO_NA_HELLO_3);
+                    break;
 
-            case 583:
-                func_800F4524(&gSfxDefaultPos, NA_SE_VO_NA_HELLO_2, 32);
-                break;
+                case 583:
+                    func_800F4524(&gSfxDefaultPos, NA_SE_VO_NA_HELLO_2, 32);
+                    break;
 
-            case 763:
-                Sfx_PlaySfxCentered(NA_SE_EV_NAVY_CRASH - SFX_FLAG);
-                break;
+                case 763:
+                    Sfx_PlaySfxCentered(NA_SE_EV_NAVY_CRASH - SFX_FLAG);
+                    break;
 
-            case 771:
-                Sfx_PlaySfxCentered(NA_SE_VO_RT_THROW);
-                break;
+                case 771:
+                    Sfx_PlaySfxCentered(NA_SE_VO_RT_THROW);
+                    break;
+            }
         }
     }
 


### PR DESCRIPTION
This PR adds "Invisible Navi" option under "Silly" tab in Cosmetics. This is purely cosmetic; Navi still exists in the game world, can still be talked, and can be toggled easily.

This PR also converts "Disable Navi Call Audio" to a hook, reducing direct CVar usage.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4273947454.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4273971335.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4274038674.zip)
<!--- section:artifacts:end -->