### PR TITLE
Potion Shop back door open at night

### DIFF
--- a/soh/soh/Enhancements/QoL/OpenAllHours.cpp
+++ b/soh/soh/Enhancements/QoL/OpenAllHours.cpp
@@ -57,4 +57,4 @@ static void RegisterOpenAllHours() {
     COND_HOOK(OnActorInit, CVAR_OPEN_ALL_HOURS_VALUE && overworldDoorsOpen, OpenAllHours);
 }
 
-static RegisterShipInitFunc initFunc_OpenAllHours(RegisterOpenAllHours, { CVAR_OPEN_ALL_HOURS_NAME, "IS_RANDO" });
+static RegisterShipInitFunc initFunc(RegisterOpenAllHours, { CVAR_OPEN_ALL_HOURS_NAME, "IS_RANDO" });

--- a/soh/soh/Enhancements/QoL/OpenAllHours.cpp
+++ b/soh/soh/Enhancements/QoL/OpenAllHours.cpp
@@ -39,8 +39,7 @@ static void OpenAllHours(void* refActor) {
         case DOOR_NIGHT_KAK_ARCHERY_GAME:
         case DOOR_NIGHT_KAK_BAZAAR:
         case DOOR_NIGHT_KAK_POTION_SHOP:
-        case DOOR_NIGHT_KAK_POTION_SHOP_BACK:
-        {
+        case DOOR_NIGHT_KAK_POTION_SHOP_BACK: {
             actor->params = (actor->params & 0xFC00) | (DOOR_SCENEEXIT << 7) | 0x3F;
             EnDoor* enDoor = static_cast<EnDoor*>(refActor);
             EnDoor_SetupType(enDoor, gPlayState);

--- a/soh/soh/Enhancements/QoL/OpenAllHours.cpp
+++ b/soh/soh/Enhancements/QoL/OpenAllHours.cpp
@@ -1,0 +1,61 @@
+#include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
+#include "soh/OTRGlobals.h"
+#include "soh/ShipInit.hpp"
+
+extern "C" {
+#include "src/overlays/actors/ovl_En_Door/z_en_door.h"
+extern PlayState* gPlayState;
+}
+
+static constexpr int32_t CVAR_OPEN_ALL_HOURS_DEFAULT = 0;
+#define CVAR_OPEN_ALL_HOURS_NAME CVAR_ENHANCEMENT("OpenAllHours")
+#define CVAR_OPEN_ALL_HOURS_VALUE CVarGetInteger(CVAR_OPEN_ALL_HOURS_NAME, CVAR_OPEN_ALL_HOURS_DEFAULT)
+
+static constexpr int32_t DOOR_DAY_CHEST_GAME = 653;
+static constexpr int32_t DOOR_DAY_BOMBCHU_SHOP = 2689;
+
+static constexpr int32_t DOOR_NIGHT_POTION_SHOP = 1678;
+static constexpr int32_t DOOR_NIGHT_SLINGSHOT_GAME = 2703;
+static constexpr int32_t DOOR_NIGHT_MASK_SHOP = 3728;
+static constexpr int32_t DOOR_NIGHT_MARKET_BAZAAR = 4753;
+static constexpr int32_t DOOR_NIGHT_KAK_ARCHERY_GAME = 4751;
+static constexpr int32_t DOOR_NIGHT_KAK_BAZAAR = 6801;
+static constexpr int32_t DOOR_NIGHT_KAK_POTION_SHOP = 7822;
+static constexpr int32_t DOOR_NIGHT_KAK_POTION_SHOP_BACK = 8846;
+
+static void OpenAllHours(void* refActor) {
+    Actor* actor = static_cast<Actor*>(refActor);
+    if (actor->id != ACTOR_EN_DOOR) {
+        return;
+    }
+
+    switch (actor->params) {
+        case DOOR_DAY_CHEST_GAME:
+        case DOOR_DAY_BOMBCHU_SHOP:
+        case DOOR_NIGHT_POTION_SHOP:
+        case DOOR_NIGHT_SLINGSHOT_GAME:
+        case DOOR_NIGHT_MASK_SHOP:
+        case DOOR_NIGHT_MARKET_BAZAAR:
+        case DOOR_NIGHT_KAK_ARCHERY_GAME:
+        case DOOR_NIGHT_KAK_BAZAAR:
+        case DOOR_NIGHT_KAK_POTION_SHOP:
+        case DOOR_NIGHT_KAK_POTION_SHOP_BACK:
+        {
+            actor->params = (actor->params & 0xFC00) | (DOOR_SCENEEXIT << 7) | 0x3F;
+            EnDoor* enDoor = static_cast<EnDoor*>(refActor);
+            EnDoor_SetupType(enDoor, gPlayState);
+            break;
+        }
+        default:
+            break;
+    }
+}
+
+static void RegisterOpenAllHours() {
+    bool overworldDoorsOpen =
+        !IS_RANDO || !OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_LOCK_OVERWORLD_DOORS);
+
+    COND_HOOK(OnActorInit, CVAR_OPEN_ALL_HOURS_VALUE && overworldDoorsOpen, OpenAllHours);
+}
+
+static RegisterShipInitFunc initFunc_OpenAllHours(RegisterOpenAllHours, { CVAR_OPEN_ALL_HOURS_NAME, "IS_RANDO" });

--- a/soh/soh/Enhancements/mods.cpp
+++ b/soh/soh/Enhancements/mods.cpp
@@ -44,7 +44,6 @@ extern "C" {
 #include "soh/cvar_prefixes.h"
 #include "variables.h"
 #include "functions.h"
-#include "src/overlays/actors/ovl_En_Door/z_en_door.h"
 
 extern SaveContext gSaveContext;
 extern PlayState* gPlayState;
@@ -742,35 +741,6 @@ void RegisterRandomizedEnemySizes() {
     });
 }
 
-void RegisterOpenAllHours() {
-    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnActorInit>([](void* refActor) {
-        Actor* actor = static_cast<Actor*>(refActor);
-
-        if (CVarGetInteger(CVAR_ENHANCEMENT("OpenAllHours"), 0) && (actor->id == ACTOR_EN_DOOR) &&
-            (!IS_RANDO || !OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_LOCK_OVERWORLD_DOORS))) {
-            switch (actor->params) {
-                case 4753: // Night Market Bazaar
-                case 1678: // Night Potion Shop
-                case 2689: // Day Bombchu Shop
-                case 2703: // Night Slingshot Game
-                case 653:  // Day Chest Game
-                case 6801: // Night Kak Bazaar
-                case 7822: // Night Kak Potion Shop
-                case 4751: // Night Kak Archery Game
-                case 3728: // Night Mask Shop
-                {
-                    actor->params = (actor->params & 0xFC00) | (DOOR_SCENEEXIT << 7) | 0x3F;
-                    EnDoor* enDoor = static_cast<EnDoor*>(refActor);
-                    EnDoor_SetupType(enDoor, gPlayState);
-                    break;
-                }
-                default:
-                    break;
-            }
-        }
-    });
-}
-
 void PatchToTMedallions() {
     // TODO: Refactor the DemoEffect_UpdateJewelAdult and DemoEffect_UpdateJewelChild from z_demo_effect
     // effects to take effect in there
@@ -943,7 +913,6 @@ void InitMods() {
     RegisterEnemyDefeatCounts();
     RegisterBossDefeatTimestamps();
     RegisterRandomizedEnemySizes();
-    RegisterOpenAllHours();
     RegisterToTMedallions();
     RegisterFloorSwitchesHook();
     RegisterPatchHandHandler();


### PR DESCRIPTION
Fixes #5816

The back door of the Potion Shop is now open at night when the "Shops and Games Always Open" setting is turned on.

I could've just added the constant to the list, but why settle for that when I can modularize the hook as well?

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4287750745.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4287759510.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4287809795.zip)
<!--- section:artifacts:end -->