### PR TITLE
Add "Like Like don't Steal Items" Cheat

### DIFF
--- a/soh/soh/Enhancements/Cheats/NoLikeLikeItemSteal.cpp
+++ b/soh/soh/Enhancements/Cheats/NoLikeLikeItemSteal.cpp
@@ -1,0 +1,17 @@
+#include <libultraship/bridge.h>
+#include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
+#include "soh/ShipInit.hpp"
+
+extern "C" {
+#include "macros.h"
+}
+
+static constexpr int32_t CVAR_NOLIKELIKEITEMSTEAL_DEFAULT = 0;
+#define CVAR_NOLIKELIKEITEMSTEAL_NAME CVAR_CHEAT("NoLikeLikeItemSteal")
+#define CVAR_NOLIKELIKEITEMSTEAL_VALUE CVarGetInteger(CVAR_NOLIKELIKEITEMSTEAL_NAME, CVAR_NOLIKELIKEITEMSTEAL_DEFAULT)
+
+void RegisterNoLikeLikeItemSteal() {
+    COND_VB_SHOULD(VB_LIKE_LIKE_STEAL_EQUIPMENT, CVAR_NOLIKELIKEITEMSTEAL_VALUE, { *should = false; });
+}
+
+static RegisterShipInitFunc initFunc(RegisterNoLikeLikeItemSteal, { CVAR_NOLIKELIKEITEMSTEAL_NAME });

--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -2250,7 +2250,23 @@ typedef enum {
     // ```
     // #### `args`
     // - `*EnRr`
+    VB_LIKE_LIKE_DROP_COLLECTIBLE,
+
+    // #### `result`
+    // ```c
+    // true
+    // ```
+    // #### `args`
+    // - `*EnRr`
     VB_LIKE_LIKE_GRAB_PLAYER,
+
+    // #### `result`
+    // ```c
+    // true
+    // ```
+    // #### `args`
+    // - `*EnRr`
+    VB_LIKE_LIKE_STEAL_EQUIPMENT,
 
     // #### `result`
     // ```c

--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -2250,6 +2250,16 @@ typedef enum {
     // ```
     // #### `args`
     // - `*EnRr`
+    // - `*u8` (shield)
+    // - `*u8` (tunic)
+    VB_LIKE_LIKE_DISPLAY_EQUIPMENT_STOLEN_MESSAGE,
+
+    // #### `result`
+    // ```c
+    // true
+    // ```
+    // #### `args`
+    // - `*EnRr`
     VB_LIKE_LIKE_DROP_COLLECTIBLE,
 
     // #### `result`
@@ -2266,6 +2276,8 @@ typedef enum {
     // ```
     // #### `args`
     // - `*EnRr`
+    // - `*u8` (shield)
+    // - `*u8` (tunic)
     VB_LIKE_LIKE_STEAL_EQUIPMENT,
 
     // #### `result`

--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -1722,6 +1722,9 @@ void SohMenu::AddMenuEnhancements() {
         .Options(CheckboxOptions().Tooltip(
             "Keese and Guay no longer target you and simply ignore you as if you were wearing the "
             "Skull Mask."));
+    AddWidget(path, "Like Like don't Steal Items", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_CHEAT("NoLikeLikeItemSteal"))
+        .Options(CheckboxOptions().Tooltip("Prevents Like Likes from being able to steal your equipments."));
     AddWidget(path, "Disable Haunted Wasteland Sandstorm", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_CHEAT("DisableSandstorm"))
         .Options(CheckboxOptions().Tooltip("Disables sandstorm effect in Haunted Wasteland."));

--- a/soh/src/overlays/actors/ovl_En_Rr/z_en_rr.c
+++ b/soh/src/overlays/actors/ovl_En_Rr/z_en_rr.c
@@ -300,32 +300,35 @@ void EnRr_SetupReleasePlayer(EnRr* this, PlayState* play) {
     this->wobbleSizeTarget = 2048.0f;
     tunic = 0;
     shield = 0;
-    if (CUR_EQUIP_VALUE(EQUIP_TYPE_SHIELD) != EQUIP_VALUE_SHIELD_MIRROR) {
-        shield = Inventory_DeleteEquipment(play, EQUIP_TYPE_SHIELD);
-        if (shield != 0) {
-            this->eatenShield = shield;
-            this->retreat = true;
+    if (GameInteractor_Should(VB_LIKE_LIKE_STEAL_EQUIPMENT, true, this)) {
+        if (CUR_EQUIP_VALUE(EQUIP_TYPE_SHIELD) != EQUIP_VALUE_SHIELD_MIRROR) {
+            shield = Inventory_DeleteEquipment(play, EQUIP_TYPE_SHIELD);
+            if (shield != 0) {
+                this->eatenShield = shield;
+                this->retreat = true;
+            }
         }
-    }
-    if (CUR_EQUIP_VALUE(EQUIP_TYPE_TUNIC) != EQUIP_VALUE_TUNIC_KOKIRI && !IS_RANDO /* Randomizer Save File */) {
-        tunic = Inventory_DeleteEquipment(play, EQUIP_TYPE_TUNIC);
-        if (tunic != 0) {
-            this->eatenTunic = tunic;
-            this->retreat = true;
+        if (CUR_EQUIP_VALUE(EQUIP_TYPE_TUNIC) != EQUIP_VALUE_TUNIC_KOKIRI && !IS_RANDO /* Randomizer Save File */) {
+            tunic = Inventory_DeleteEquipment(play, EQUIP_TYPE_TUNIC);
+            if (tunic != 0) {
+                this->eatenTunic = tunic;
+                this->retreat = true;
+            }
+        }
+
+        switch (EnRr_GetMessage(shield, tunic)) {
+            case RR_MESSAGE_SHIELD:
+                Message_StartTextbox(play, 0x305F, NULL);
+                break;
+            case RR_MESSAGE_TUNIC:
+                Message_StartTextbox(play, 0x3060, NULL);
+                break;
+            case RR_MESSAGE_TUNIC | RR_MESSAGE_SHIELD:
+                Message_StartTextbox(play, 0x3061, NULL);
+                break;
         }
     }
     player->actor.parent = NULL;
-    switch (EnRr_GetMessage(shield, tunic)) {
-        case RR_MESSAGE_SHIELD:
-            Message_StartTextbox(play, 0x305F, NULL);
-            break;
-        case RR_MESSAGE_TUNIC:
-            Message_StartTextbox(play, 0x3060, NULL);
-            break;
-        case RR_MESSAGE_TUNIC | RR_MESSAGE_SHIELD:
-            Message_StartTextbox(play, 0x3061, NULL);
-            break;
-    }
     osSyncPrintf(VT_FGCOL(YELLOW) "%s[%d] : Rr_Catch_Cancel" VT_RST "\n", __FILE__, __LINE__);
     func_8002F6D4(play, &this->actor, 4.0f, this->actor.shape.rot.y, 12.0f, 8);
     if (this->actor.colorFilterTimer == 0) {
@@ -666,50 +669,53 @@ void EnRr_Death(EnRr* this, PlayState* play) {
                 (SQ(4 - i) * (f32)this->frameCount * 0.003f) + 1.0f;
         }
     } else if (this->frameCount >= 95) {
-        Vec3f dropPos;
+        if (GameInteractor_Should(VB_LIKE_LIKE_DROP_COLLECTIBLE, true, this)) {
+            Vec3f dropPos;
 
-        dropPos.x = this->actor.world.pos.x;
-        dropPos.y = this->actor.world.pos.y;
-        dropPos.z = this->actor.world.pos.z;
-        switch (this->eatenShield) {
-            case 1:
-                Item_DropCollectible(play, &dropPos, ITEM00_SHIELD_DEKU);
-                break;
-            case 2:
-                Item_DropCollectible(play, &dropPos, ITEM00_SHIELD_HYLIAN);
-                break;
+            dropPos.x = this->actor.world.pos.x;
+            dropPos.y = this->actor.world.pos.y;
+            dropPos.z = this->actor.world.pos.z;
+            switch (this->eatenShield) {
+                case 1:
+                    Item_DropCollectible(play, &dropPos, ITEM00_SHIELD_DEKU);
+                    break;
+                case 2:
+                    Item_DropCollectible(play, &dropPos, ITEM00_SHIELD_HYLIAN);
+                    break;
+            }
+            switch (this->eatenTunic) {
+                case 2:
+                    Item_DropCollectible(play, &dropPos, ITEM00_TUNIC_GORON);
+                    break;
+                case 3:
+                    Item_DropCollectible(play, &dropPos, ITEM00_TUNIC_ZORA);
+                    break;
+            }
+            // "dropped"
+            osSyncPrintf(VT_FGCOL(GREEN) "「%s」が出た！！" VT_RST "\n", sDropNames[this->dropType]);
+            switch (this->dropType) {
+                case RR_DROP_MAGIC:
+                    Item_DropCollectible(play, &dropPos, ITEM00_MAGIC_SMALL);
+                    break;
+                case RR_DROP_ARROW:
+                    Item_DropCollectible(play, &dropPos, ITEM00_ARROWS_SINGLE);
+                    break;
+                case RR_DROP_FLEXIBLE:
+                    Item_DropCollectible(play, &dropPos, ITEM00_FLEXIBLE);
+                    break;
+                case RR_DROP_RUPEE_PURPLE:
+                    Item_DropCollectible(play, &dropPos, ITEM00_RUPEE_PURPLE);
+                    break;
+                case RR_DROP_RUPEE_RED:
+                    Item_DropCollectible(play, &dropPos, ITEM00_RUPEE_RED);
+                    break;
+                case RR_DROP_RANDOM_RUPEE:
+                default:
+                    Item_DropCollectibleRandom(play, &this->actor, &dropPos, 12 << 4);
+                    break;
+            }
         }
-        switch (this->eatenTunic) {
-            case 2:
-                Item_DropCollectible(play, &dropPos, ITEM00_TUNIC_GORON);
-                break;
-            case 3:
-                Item_DropCollectible(play, &dropPos, ITEM00_TUNIC_ZORA);
-                break;
-        }
-        // "dropped"
-        osSyncPrintf(VT_FGCOL(GREEN) "「%s」が出た！！" VT_RST "\n", sDropNames[this->dropType]);
-        switch (this->dropType) {
-            case RR_DROP_MAGIC:
-                Item_DropCollectible(play, &dropPos, ITEM00_MAGIC_SMALL);
-                break;
-            case RR_DROP_ARROW:
-                Item_DropCollectible(play, &dropPos, ITEM00_ARROWS_SINGLE);
-                break;
-            case RR_DROP_FLEXIBLE:
-                Item_DropCollectible(play, &dropPos, ITEM00_FLEXIBLE);
-                break;
-            case RR_DROP_RUPEE_PURPLE:
-                Item_DropCollectible(play, &dropPos, ITEM00_RUPEE_PURPLE);
-                break;
-            case RR_DROP_RUPEE_RED:
-                Item_DropCollectible(play, &dropPos, ITEM00_RUPEE_RED);
-                break;
-            case RR_DROP_RANDOM_RUPEE:
-            default:
-                Item_DropCollectibleRandom(play, &this->actor, &dropPos, 12 << 4);
-                break;
-        }
+
         Actor_Kill(&this->actor);
     } else if (this->frameCount == 88) {
         Vec3f pos;

--- a/soh/src/overlays/actors/ovl_En_Rr/z_en_rr.c
+++ b/soh/src/overlays/actors/ovl_En_Rr/z_en_rr.c
@@ -300,7 +300,7 @@ void EnRr_SetupReleasePlayer(EnRr* this, PlayState* play) {
     this->wobbleSizeTarget = 2048.0f;
     tunic = 0;
     shield = 0;
-    if (GameInteractor_Should(VB_LIKE_LIKE_STEAL_EQUIPMENT, true, this)) {
+    if (GameInteractor_Should(VB_LIKE_LIKE_STEAL_EQUIPMENT, true, this, &shield, &tunic)) {
         if (CUR_EQUIP_VALUE(EQUIP_TYPE_SHIELD) != EQUIP_VALUE_SHIELD_MIRROR) {
             shield = Inventory_DeleteEquipment(play, EQUIP_TYPE_SHIELD);
             if (shield != 0) {
@@ -315,7 +315,9 @@ void EnRr_SetupReleasePlayer(EnRr* this, PlayState* play) {
                 this->retreat = true;
             }
         }
-
+    }
+    player->actor.parent = NULL;
+    if (GameInteractor_Should(VB_LIKE_LIKE_DISPLAY_EQUIPMENT_STOLEN_MESSAGE, true, this, &shield, &tunic)) {
         switch (EnRr_GetMessage(shield, tunic)) {
             case RR_MESSAGE_SHIELD:
                 Message_StartTextbox(play, 0x305F, NULL);
@@ -328,7 +330,6 @@ void EnRr_SetupReleasePlayer(EnRr* this, PlayState* play) {
                 break;
         }
     }
-    player->actor.parent = NULL;
     osSyncPrintf(VT_FGCOL(YELLOW) "%s[%d] : Rr_Catch_Cancel" VT_RST "\n", __FILE__, __LINE__);
     func_8002F6D4(play, &this->actor, 4.0f, this->actor.shape.rot.y, 12.0f, 8);
     if (this->actor.colorFilterTimer == 0) {


### PR DESCRIPTION
Sometimes it's annoying to get your equipment stolen.

This PR also adds new VanillaBehavior hooks (VB_LIKE_LIKE_STEAL_EQUIPMENT and VB_LIKE_LIKE_DROP_COLLECTIBLE) that runs when a Like Like tries to steal equipment and the Like Like is killed, respectively. The latter is not used by the cheat itself, but I've added it so someone else can make a randomizer option that allow Like Like to steal even more items. (I don't have much knowledge of Rando so I can't do it myself yet)

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4707880944.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4707902446.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4707920751.zip)
<!--- section:artifacts:end -->