### PR TITLE
Fix doorType calculation for shutter doors

### DIFF
--- a/soh/soh/Enhancements/randomizer/logic.cpp
+++ b/soh/soh/Enhancements/randomizer/logic.cpp
@@ -2172,7 +2172,7 @@ const std::vector<uint8_t>& GetDungeonSmallKeyDoors(SceneID sceneId) {
                 dungeonSmallKeyDoors[key].emplace_back(transitionActor.params & 0x3F);
             }
         } else if (transitionActor.id == ACTOR_DOOR_SHUTTER) {
-            uint8_t doorType = (transitionActor.params >> 7) & 15;
+            uint8_t doorType = (transitionActor.params >> 6) & 15;
             if (doorType == SHUTTER_KEY_LOCKED) {
                 dungeonSmallKeyDoors[key].emplace_back(transitionActor.params & 0x3F);
             }


### PR DESCRIPTION
Discovered that the door-shutter bitmask was incorrect. `ACTOR_DOOR_SHUTTER` stores the type starting at bit position 6 and not 7 like `ACTOR_EN_DOOR`.
https://github.com/HarbourMasters/Shipwright/blob/dc5e9686c0a5c1b4f1cdf285ad8bf581be6233e1/soh/src/overlays/actors/ovl_Door_Shutter/z_door_shutter.h#L7-L40
https://github.com/HarbourMasters/Shipwright/blob/dc5e9686c0a5c1b4f1cdf285ad8bf581be6233e1/soh/src/overlays/actors/ovl_En_Door/z_en_door.h#L7-L40

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4323321238.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4323331002.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4323352058.zip)
<!--- section:artifacts:end -->