### PR TITLE
Shuffle Fairy - Gossip stone fairy improvement

### DIFF
--- a/soh/soh/Enhancements/randomizer/ShuffleFairies.cpp
+++ b/soh/soh/Enhancements/randomizer/ShuffleFairies.cpp
@@ -180,8 +180,9 @@ void RegisterShuffleFairies() {
             // collected, the vanilla code will handle that part automatically.
             FairyIdentity fairyIdentity = ShuffleFairies_GetFairyIdentity(params);
             if (!ShuffleFairies_FairyExists(fairyIdentity)) {
-                if (SpawnFairy(gossipStone->actor.world.pos.x, gossipStone->actor.world.pos.y,
-                               gossipStone->actor.world.pos.z, params, fairyType)) {
+                Player* player = GET_PLAYER(gPlayState);
+                if (SpawnFairy(player->actor.world.pos.x, (player->actor.world.pos.y + 20), player->actor.world.pos.z,
+                               params, fairyType)) {
                     Audio_PlayActorSound2(&gossipStone->actor, NA_SE_EV_BUTTERFRY_TO_FAIRY);
                     // Set vanilla check for fairy spawned so it doesn't spawn the vanilla fairy afterwards as well.
                     gossipStone->unk_19D = 0;


### PR DESCRIPTION
Very simple but quite effective change in practice. Fairies spawning from gossip stones that are randomized will spawn on link's position instead, so you don't have to go chase them constantly. Very common annoyance with them.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4374017051.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4374019524.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4374033033.zip)
<!--- section:artifacts:end -->