### PR TITLE
Bugfix: Pause Warp sets subtimer to last second

### DIFF
--- a/soh/soh/Enhancements/pausewarp.c
+++ b/soh/soh/Enhancements/pausewarp.c
@@ -48,6 +48,7 @@ void PauseWarp_Execute() {
     for (int i = 0; i < ARRAY_COUNT(ocarinaSongMap); i++) {
         if (gPlayState->msgCtx.lastPlayedSong == ocarinaSongMap[i]) {
             gPlayState->nextEntranceIndex = entranceIndexMap[i];
+            func_80088AF0(gPlayState);
             return;
         }
     }


### PR DESCRIPTION
The Warp Songs are supposed to set the subtimer, which is used for both the Running Man race and the spoiling items in the Biggoron Sword sidequest, to its final second to prevent cheating. However, Pause Warp overlooks this, making it essentially a cheat. With this bugfix, Pause Warp can no longer be used to circumvent vanilla's anti-cheating measure.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4388629300.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4388640217.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4388657296.zip)
<!--- section:artifacts:end -->