### PR TITLE
Fix Adult Spawn Crash

### DIFF
--- a/soh/soh/Enhancements/randomizer/savefile.cpp
+++ b/soh/soh/Enhancements/randomizer/savefile.cpp
@@ -282,15 +282,15 @@ extern "C" void Randomizer_InitSaveFile() {
     }
 
     int startingAge = OTRGlobals::Instance->gRandoContext->GetOption(RSK_SELECTED_STARTING_AGE).Get();
+    gSaveContext.savedSceneNum = -1;
     switch (startingAge) {
         case RO_AGE_ADULT: // Adult
             gSaveContext.linkAge = LINK_AGE_ADULT;
             gSaveContext.entranceIndex = ENTR_TEMPLE_OF_TIME_WARP_PAD;
-            gSaveContext.savedSceneNum = SCENE_LON_LON_RANCH; // Set scene num manually to ToT.
+            gSaveContext.cutsceneIndex = 0;
             break;
         case RO_AGE_CHILD: // Child
             gSaveContext.linkAge = LINK_AGE_CHILD;
-            gSaveContext.savedSceneNum = -1;
             break;
         default:
             break;


### PR DESCRIPTION
With entrance shuffle on, but overworld spawns off, Remember Save Location would cause a crash when starting as adult. This was because the saved scene was being set to Lon Lon Ranch. This unifies the -1 saved scene between ages. This also sets the cutsceneIndex to 0 to bypass end credits cutscene shenanigans that happened otherwise. Confirmed this works with or without Remember Save Location and with or without spawn shuffle or any entrance shuffle.

Fixes #5480

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4399163835.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4399170516.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4399222118.zip)
<!--- section:artifacts:end -->