### PR TITLE
Stop creating timesplits file on init, and gitignore it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -417,6 +417,7 @@ tags
 shipofharkinian.ini
 shipofharkinian.json
 imgui.ini
+timesplitdata.json
 
 # Switch Stuff
 

--- a/soh/soh/Enhancements/timesplits/TimeSplits.cpp
+++ b/soh/soh/Enhancements/timesplits/TimeSplits.cpp
@@ -948,16 +948,6 @@ void TimeSplitsDrawManageList() {
     ImGui::EndChild();
 }
 
-void InitializeSplitDataFile() {
-    std::string filename = Ship::Context::GetPathRelativeToAppDirectory("timesplitdata.json");
-    if (!std::filesystem::exists(filename)) {
-        json j;
-        std::ofstream file(filename);
-        file << j.dump(4);
-        file.close();
-    }
-}
-
 void TimeSplitWindow::Draw() {
     ImGui::PushStyleColor(ImGuiCol_WindowBg, windowColor);
     GuiWindow::Draw();
@@ -997,7 +987,6 @@ void TimeSplitWindow::InitElement() {
                                                                         ImVec4(1, 1, 1, 1));
     Color_RGBA8 defaultColour = { 0, 0, 0, 255 };
     windowColor = VecFromRGBA8(CVarGetColor(CVAR_ENHANCEMENT("TimeSplits.WindowColor.Value"), defaultColour));
-    InitializeSplitDataFile();
 
     GameInteractor::Instance->RegisterGameHook<GameInteractor::OnTimestamp>([](u8 item) {
         if (item != ITEM_SKULL_TOKEN) {


### PR DESCRIPTION
From my testing, it's fine if this file doesn't exist, and it's created when you create your first timesplit list.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4505754617.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4505760553.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4505785906.zip)
<!--- section:artifacts:end -->