### PR TITLE
Add merge strategy for preset sections

### DIFF
--- a/soh/soh/Enhancements/Presets/Presets.cpp
+++ b/soh/soh/Enhancements/Presets/Presets.cpp
@@ -61,7 +61,9 @@ void PresetCheckboxStyle(const ImVec4& color) {
 }
 
 static BlockInfo blockInfo[PRESET_SECTION_MAX] = {
-    { { CVAR_PREFIX_SETTING, CVAR_PREFIX_WINDOW }, ICON_FA_COG, { "Settings", "settings" } },
+    { { CVAR_PREFIX_SETTING, CVAR_PREFIX_WINDOW, CVAR_PREFIX_GAMEPLAY_STATS },
+      ICON_FA_COG,
+      { "Settings", "settings" } },
     { { CVAR_PREFIX_ENHANCEMENT, CVAR_PREFIX_RANDOMIZER_ENHANCEMENT, CVAR_PREFIX_CHEAT },
       ICON_FA_PLUS_CIRCLE,
       { "Enhancements", "enhancements" } },
@@ -96,12 +98,28 @@ void applyPreset(std::string presetName, std::vector<PresetSection> includeSecti
                 }
             }
             auto section = info.presetValues["blocks"][blockInfo[i].names[1]];
+            std::string sectionStrategy = "overwrite";
+            if (info.presetValues.contains("blockStrategy") &&
+                info.presetValues["blockStrategy"].contains(blockInfo[i].names[1])) {
+                sectionStrategy = info.presetValues["blockStrategy"][blockInfo[i].names[1]];
+            }
+
             for (auto& item : section.items()) {
                 if (section[item.key()].is_null()) {
                     CVarClearBlock(item.key().c_str());
                 } else {
+                    auto block = item.value();
+                    if (sectionStrategy == "merge") {
+                        auto currentJson = Ship::Context::GetInstance()->GetConfig()->GetNestedJson();
+                        if (currentJson.contains("CVars") && currentJson["CVars"].contains(item.key())) {
+                            block = currentJson["CVars"][item.key()];
+                            // Recursively merge the two json objects
+                            block.update(item.value(), true);
+                        }
+                    }
+
                     Ship::Context::GetInstance()->GetConfig()->SetBlock(fmt::format("{}.{}", "CVars", item.key()),
-                                                                        item.value());
+                                                                        block);
                     Ship::Context::GetInstance()->GetConsoleVariables()->Load();
                 }
             }


### PR DESCRIPTION
This introduces a merge strategy option for preset sections, fixing a major drawback of the current implementation. Take the following preset for example. This will entirely wipe out many of the users settings including their controller bindings and all of cosmetics just so we can enable RTA timing & goron neck length (as Miyamoto intended)

Now we can define a `blockStrategy` object that will change this behavior to instead merge, overwriting only the values provided by the preset.

```json
{
    "blocks": {
        "settings": {
            "gSettings": {
                "DisableChanges": 1,
                "BootSequence": 2
            },
            "gGameplayStats": {
                "RTATiming": 1
            }
        },
        "cosmetics": {
            "gCosmetics": {
                "Goron": {
                    "NeckLength": 5000.0
                },
                "Kak": {
                    "Windmill_Speed": {
                        "Changed": 1,
                        "Value": 6000.0
                    }
                }
            }
        },
        "enhancements": {
            "gCheats": {
                "EasyFrameAdvance": 1
            },
            "gEnhancements": {
                "AdultMasks": 1
            }
        }
    },
    "blockStrategy": {
        "cosmetics": "merge",
        "settings": "merge"
    },
    "presetName": "9.1.0-Standard"
}
```

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4508165763.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4508173155.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4508190056.zip)
<!--- section:artifacts:end -->