### PR TITLE
Dampe's Hut open all night when Dampe is out

### DIFF
--- a/soh/soh/Enhancements/TimeSavers/DampeAllNight.cpp
+++ b/soh/soh/Enhancements/TimeSavers/DampeAllNight.cpp
@@ -1,0 +1,37 @@
+#include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
+#include "soh/OTRGlobals.h"
+#include "soh/ShipInit.hpp"
+
+extern "C" {
+#include "src/overlays/actors/ovl_En_Door/z_en_door.h"
+extern SaveContext gSaveContext;
+extern PlayState* gPlayState;
+}
+
+static constexpr int32_t CVAR_DAMPE_ALL_NIGHT_DEFAULT = 0;
+#define CVAR_DAMPE_ALL_NIGHT_NAME CVAR_ENHANCEMENT("DampeAllNight")
+#define CVAR_DAMPE_ALL_NIGHT_VALUE CVarGetInteger(CVAR_DAMPE_ALL_NIGHT_NAME, CVAR_DAMPE_ALL_NIGHT_DEFAULT)
+
+static constexpr s16 DAMPE_HUT_DOOR_OPEN = 447;
+static constexpr s16 DAMPE_HUT_DOOR_CLOSED = 774;
+
+static bool DampeIsResting() {
+    return LINK_IS_ADULT || gPlayState->sceneNum != SCENE_GRAVEYARD;
+}
+
+static void OpenDampeHutDoor(void* refActor) {
+    EnDoor* enDoor = static_cast<EnDoor*>(refActor);
+    s16* params = &enDoor->actor.params;
+
+    if (*params == DAMPE_HUT_DOOR_CLOSED && !DampeIsResting()) {
+        *params = DAMPE_HUT_DOOR_OPEN;
+        EnDoor_SetupType(enDoor, gPlayState);
+    }
+}
+
+static void RegisterDampeAllNight() {
+    COND_VB_SHOULD(VB_DAMPE_IN_GRAVEYARD_DESPAWN, CVAR_DAMPE_ALL_NIGHT_VALUE, { *should = DampeIsResting(); });
+    COND_ID_HOOK(OnActorInit, ACTOR_EN_DOOR, CVAR_DAMPE_ALL_NIGHT_VALUE, OpenDampeHutDoor);
+}
+
+static RegisterShipInitFunc initFunc(RegisterDampeAllNight, { CVAR_DAMPE_ALL_NIGHT_NAME });

--- a/soh/soh/Enhancements/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.cpp
@@ -709,11 +709,6 @@ void TimeSaverOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_li
                 *should = false;
             }
             break;
-        case VB_DAMPE_IN_GRAVEYARD_DESPAWN:
-            if (CVarGetInteger(CVAR_ENHANCEMENT("DampeAllNight"), 0)) {
-                *should = LINK_IS_ADULT || gPlayState->sceneNum != SCENE_GRAVEYARD;
-            }
-            break;
         case VB_BE_VALID_GRAVEDIGGING_SPOT:
             if (CVarGetInteger(CVAR_ENHANCEMENT("DampeWin"), IS_RANDO)) {
                 EnTk* enTk = va_arg(args, EnTk*);


### PR DESCRIPTION
Fixes #4892

Added a timesaver hook file for the "Dampe All Night" setting that includes two hooks: the VB hook for his despawning and the actor hook for the door.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4508778839.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4508784740.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4508822071.zip)
<!--- section:artifacts:end -->