### PR TITLE
Fix excluded locations getting bombchus when bombchu bag is off

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/fill.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/fill.cpp
@@ -1018,7 +1018,7 @@ static void FillExcludedLocations() {
         FilterFromPool(ctx->allLocations, [ctx](const auto loc) { return ctx->GetItemLocation(loc)->IsExcluded(); });
 
     for (RandomizerCheck loc : excludedLocations) {
-        PlaceJunkInExcludedLocation(loc);
+        ctx->PlaceItemInLocation(loc, GetJunkItem());
     }
 }
 

--- a/soh/soh/Enhancements/randomizer/3drando/item_pool.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/item_pool.cpp
@@ -350,12 +350,6 @@ static void ReplaceMaxItem(const RandomizerGet itemToReplace, int max) {
     }
 }
 
-void PlaceJunkInExcludedLocation(const RandomizerCheck il) {
-    // place a Bluee Rupee in this location
-    auto ctx = Rando::Context::GetInstance();
-    ctx->PlaceItemInLocation(il, RG_BLUE_RUPEE);
-}
-
 static void PlaceVanillaMapsAndCompasses() {
     auto ctx = Rando::Context::GetInstance();
     for (auto dungeon : ctx->GetDungeons()->GetDungeonList()) {

--- a/soh/soh/Enhancements/randomizer/3drando/item_pool.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/item_pool.cpp
@@ -351,16 +351,9 @@ static void ReplaceMaxItem(const RandomizerGet itemToReplace, int max) {
 }
 
 void PlaceJunkInExcludedLocation(const RandomizerCheck il) {
-    // place a non-advancement item in this location
+    // place a Bluee Rupee in this location
     auto ctx = Rando::Context::GetInstance();
-    for (size_t i = 0; i < ItemPool.size(); i++) {
-        if (Rando::StaticData::RetrieveItem(ItemPool[i]).GetCategory() == ITEM_CATEGORY_JUNK) {
-            ctx->PlaceItemInLocation(il, ItemPool[i]);
-            ItemPool.erase(ItemPool.begin() + i);
-            return;
-        }
-    }
-    SPDLOG_ERROR("ERROR: No Junk to Place!!!");
+    ctx->PlaceItemInLocation(il, RG_BLUE_RUPEE);
 }
 
 static void PlaceVanillaMapsAndCompasses() {

--- a/soh/soh/Enhancements/randomizer/3drando/item_pool.hpp
+++ b/soh/soh/Enhancements/randomizer/3drando/item_pool.hpp
@@ -9,7 +9,6 @@ class ItemLocation;
 
 void AddItemToPool(std::vector<RandomizerGet>& pool, const RandomizerGet item, size_t count = 1);
 RandomizerGet GetJunkItem();
-void PlaceJunkInExcludedLocation(const RandomizerCheck il);
 void GenerateItemPool();
 
 extern std::vector<RandomizerGet> ItemPool;


### PR DESCRIPTION
Instead, excluded locations will now always get a random non-pool junk item.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4511439041.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4511454167.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4511482801.zip)
<!--- section:artifacts:end -->