### PR TITLE
Fix menu path reassignment

### DIFF
--- a/soh/soh/SohGui/SohMenuNetwork.cpp
+++ b/soh/soh/SohGui/SohMenuNetwork.cpp
@@ -14,9 +14,10 @@ using namespace UIWidgets;
 void SohMenu::AddMenuNetwork() {
     // Add Network Menu
     AddMenuEntry("Network", CVAR_SETTING("Menu.NetworkSidebarSection"));
+    WidgetPath path;
 
 #ifndef ENABLE_REMOTE_CONTROL
-    WidgetPath path = { "Network", "Info", SECTION_COLUMN_1 };
+    path = { "Network", "Info", SECTION_COLUMN_1 };
     AddSidebarEntry("Network", path.sidebarName, 2);
 
     AddWidget(path,
@@ -28,7 +29,7 @@ void SohMenu::AddMenuNetwork() {
 #endif
 
     // Sail
-    WidgetPath path = { "Network", "Sail", SECTION_COLUMN_1 };
+    path = { "Network", "Sail", SECTION_COLUMN_1 };
     AddSidebarEntry("Network", path.sidebarName, 3);
 
     AddWidget(path,


### PR DESCRIPTION
Didn't realize the compiler would catch this

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4523191007.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4523203650.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4523274929.zip)
<!--- section:artifacts:end -->